### PR TITLE
fix: drop stale --web flag from generated .mcp.json

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -93,13 +93,13 @@ gortex mcp --index . --watch
 
 `--watch` re-indexes changed files live via fsnotify. `--cache-dir ~/.cache/gortex` (default) saves snapshots between restarts so subsequent starts are ~200ms instead of 3-5s.
 
-To also get the web UI + HTTP server API:
+To also get the HTTP server API (the UI is a separate Next.js app in `web/` that talks to it over HTTP):
 
 ```bash
-gortex server --index . --web --watch
+gortex server --index . --watch
 ```
 
-Open `http://localhost:4747` for the force-directed graph explorer.
+`gortex server` listens on `http://localhost:4747` and exposes `/v1/*` (including `/v1/graph` and `/v1/events` for force-directed rendering).
 
 **Option B — your IDE starts it automatically.** The `.mcp.json` that `gortex init` created tells the IDE how to spawn `gortex mcp`. You don't run anything yourself. Claude Code, Cursor, and VS Code all work this way. Downside: each tool gets its own server process (memory cost scales with number of tools).
 

--- a/internal/agents/claudecode/content.go
+++ b/internal/agents/claudecode/content.go
@@ -21,9 +21,7 @@ package claudecode
 import "github.com/zzet/gortex/internal/agents"
 
 // ProjectMCPJSON is the starter content for a project's .mcp.json
-// when no file exists yet. The --web flag is intentional: it turns
-// on the HTTP status page so users can peek at the index without
-// wiring anything else up.
+// when no file exists yet.
 const ProjectMCPJSON = `{
   "mcpServers": {
     "gortex": {
@@ -31,8 +29,7 @@ const ProjectMCPJSON = `{
       "args": [
         "mcp",
         "--index", ".",
-        "--watch",
-        "--web"
+        "--watch"
       ],
       "env": {
         "GORTEX_INDEX_WORKERS": "${GORTEX_WORKERS:-8}"


### PR DESCRIPTION
## Summary

Commit 7208e77 removed --web from `gortex mcp` and `gortex server`, but the Claude Code init template still hardcoded it, so freshly init'd projects produced an .mcp.json that crashed on launch with an unknown-flag error. Also fixes the matching example in docs/onboarding.md.

## Changes

- internal/agents/claudecode/content.go — the ProjectMCPJSON template still hardcoded --web, plus a stale comment claiming the flag was intentional.
- docs/onboarding.md — onboarding example still showed gortex server --index . --web --watch.
 

## Testing

- [ ] All tests pass (`go test -race ./...`)
- [ ] New tests added for new functionality
- [ ] Benchmarks run if performance-relevant

## Checklist

- [ ] Code follows existing patterns in the codebase
- [ ] No unnecessary abstractions added
- [ ] Language extractor includes `Meta["methods"]` for interfaces (if applicable)
- [ ] Methods have `EdgeMemberOf` edges to their containing type (if applicable)
