### PR TITLE
fix(init): emit forward-slash hook binary path for Git Bash on Windows

### DIFF
--- a/internal/agents/claudecode/hooks.go
+++ b/internal/agents/claudecode/hooks.go
@@ -86,7 +86,7 @@ func hookCommandWithMode(base, mode string) string {
 // environment differs between Claude Code and a terminal.
 func ResolveHookCommand(w io.Writer) string {
 	if path, err := exec.LookPath("gortex"); err == nil {
-		return path + " hook"
+		return shellSafeHookBinary(path) + " hook"
 	}
 	if w != nil {
 		_, _ = fmt.Fprintln(w,
@@ -94,6 +94,21 @@ func ResolveHookCommand(w io.Writer) string {
 				"writing bare \"gortex hook\" into settings — install gortex to PATH for a stable hook command")
 	}
 	return "gortex hook"
+}
+
+// shellSafeHookBinary normalizes a resolved binary path into a form
+// safe to embed in a shell-executed hook command. Claude Code runs
+// hooks through a shell; on Windows that shell is Git Bash, which
+// treats backslashes as escape characters — a native path like
+// C:\Users\me\gortex.exe is mangled to C:Usersmegortex.exe (\U, \m, …
+// swallowed) and the hook fails with "command not found". Forward
+// slashes survive: Git Bash maps C:/Users/... back to a native path
+// when it spawns the .exe. The replacement is unconditional rather
+// than Windows-guarded — any backslash in an unquoted shell command is
+// a bug regardless of OS, and a real Unix binary path never contains
+// one as a separator.
+func shellSafeHookBinary(path string) string {
+	return strings.ReplaceAll(path, "\\", "/")
 }
 
 // HookCommandPathIsEphemeral reports whether cmd's binary path lives

--- a/internal/agents/claudecode/hooks_test.go
+++ b/internal/agents/claudecode/hooks_test.go
@@ -148,6 +148,43 @@ func TestResolveHookCommand(t *testing.T) {
 		got := ResolveHookCommand(io.Discard)
 		assert.Equal(t, "gortex hook", got, "fallback to bare name keeps init working in sandboxes")
 	})
+
+	t.Run("commandNeverContainsBackslash", func(t *testing.T) {
+		dir := t.TempDir()
+		fake := filepath.Join(dir, "gortex")
+		require.NoError(t, os.WriteFile(fake, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+		t.Setenv("PATH", dir)
+
+		got := ResolveHookCommand(io.Discard)
+		assert.NotContains(t, got, "\\",
+			"baked hook command must use forward slashes — Git Bash on Windows mangles backslash paths")
+	})
+}
+
+// TestShellSafeHookBinary pins the Windows-path fix: a resolved binary
+// path with backslashes (as exec.LookPath returns on Windows) must be
+// rewritten to forward slashes so Claude Code's shell-run hook does not
+// swallow the separators. Runs on every platform because the helper is
+// a pure string transform.
+func TestShellSafeHookBinary(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"windowsAbsolute", `C:\Users\Borislav\AppData\Local\Programs\gortex\gortex.exe`, "C:/Users/Borislav/AppData/Local/Programs/gortex/gortex.exe"},
+		{"windowsMixed", `C:\Users\me/gortex.exe`, "C:/Users/me/gortex.exe"},
+		{"unixAbsolute", "/opt/homebrew/bin/gortex", "/opt/homebrew/bin/gortex"},
+		{"bareName", "gortex", "gortex"},
+		{"forwardSlashesUnchanged", "C:/Users/me/gortex.exe", "C:/Users/me/gortex.exe"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shellSafeHookBinary(tc.in)
+			assert.Equal(t, tc.want, got)
+			assert.NotContains(t, got, "\\", "result must be free of backslashes")
+		})
+	}
 }
 
 func makeHookEntry(matcher, command string) map[string]any {


### PR DESCRIPTION
Gortex init baked the `exec.LookPath` result verbatim into Claude Code's hook command. On Windows, that is a native backslash path (`C:\Users\...\gortex.exe`), and Claude Code runs hooks through Git Bash, which reads the backslashes as escape sequences and collapses the path to `C:Users...gortex.exe` — the hook then fails with command not found.

Normalize the resolved binary to forward slashes via a small pure helper (`shellSafeHookBinary`) before baking it in; Git Bash maps `C:/Users/...` back to a native path when spawning the `.exe`. Re-running gortex init self-heals an existing broken config because `rewriteGortexHookMode` already rewrites any Gortex hook command that differs from the freshly resolved one.

Fixes https://github.com/zzet/gortex/issues/36