### PR TITLE
nudge full-body Gortex reads toward compress_bodies (#40)

### DIFF
--- a/bench/issue40_context_repro.py
+++ b/bench/issue40_context_repro.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+Reproduction for issue #40 — "Claude Code eats up context when using gortex".
+
+The report's core, *measurable* claim is:
+
+  - During plan implementation, files get read in FULL via gortex's read_file /
+    get_editing_context, which is token-expensive.
+  - compress_bodies:true and/or search_text are far cheaper, but nothing forces
+    (or even nudges toward) them — read_file defaults to compress_bodies:false.
+
+This script confirms/disproves the *measurable* part by driving the REAL tools
+through the running daemon (via `gortex mcp --proxy`) and comparing the wire
+cost of three access patterns on the same set of files:
+
+  1. read_file                      (full bodies — the "eats context" path)
+  2. read_file compress_bodies:true (signatures + structure only)
+  3. search_text                    (locate call sites, no body read at all)
+
+Token figures are estimated at ~bytes/4 (the standard rough heuristic; Claude's
+real tokenizer differs but the RATIO between patterns is what matters and is
+tokenizer-stable). The script reports raw bytes too, so nothing hinges on the
+estimate.
+
+Usage:
+  python3 bench/issue40_context_repro.py [GORTEX_BIN] [file ...]
+
+Defaults: ./gortex and a handful of ~14-24KB Go files (≈ the reporter's C++
+file sizes). Pass a repo-prefixed or absolute path per file (e.g.
+gortex/internal/resolver/external_calls.go).
+"""
+import json
+import subprocess
+import sys
+import threading
+
+GORTEX_BIN = sys.argv[1] if len(sys.argv) > 1 else "./gortex"
+FILES = sys.argv[2:] or [
+    "gortex/internal/resolver/external_calls.go",
+    "gortex/internal/mcp/tools_lsp.go",
+    "gortex/internal/agents/claudecode/plugin.go",
+    "gortex/internal/parser/languages/swift.go",
+]
+# A literal that recurs across the repo — the search_text "locate the call
+# sites" pattern the reporter says should have been used instead of reads.
+SEARCH_QUERY = "zap.Error"
+
+
+def approx_tokens(nbytes: int) -> int:
+    return round(nbytes / 4)
+
+
+class MCP:
+    """Minimal newline-delimited JSON-RPC client over `gortex mcp --proxy`."""
+
+    def __init__(self, binary):
+        self.p = subprocess.Popen(
+            [binary, "mcp", "--proxy", "--log-level", "error"],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            text=True, bufsize=1,
+        )
+        self._id = 0
+        # Drain stderr so a chatty daemon can't dead-lock the pipe.
+        self._err = []
+        threading.Thread(target=self._drain_err, daemon=True).start()
+
+    def _drain_err(self):
+        for line in self.p.stderr:
+            self._err.append(line)
+
+    def _send(self, method, params=None, notify=False):
+        msg = {"jsonrpc": "2.0", "method": method}
+        if params is not None:
+            msg["params"] = params
+        if not notify:
+            self._id += 1
+            msg["id"] = self._id
+        self.p.stdin.write(json.dumps(msg) + "\n")
+        self.p.stdin.flush()
+        if notify:
+            return None
+        return self._read_result(self._id)
+
+    def _read_result(self, want_id):
+        while True:
+            line = self.p.stdout.readline()
+            if not line:
+                raise RuntimeError(
+                    "daemon closed the connection.\nstderr:\n" + "".join(self._err[-20:]))
+            try:
+                msg = json.loads(line)
+            except json.JSONDecodeError:
+                continue  # skip log noise that leaked onto stdout
+            if msg.get("id") == want_id:
+                if "error" in msg:
+                    raise RuntimeError(f"RPC error: {msg['error']}")
+                return msg.get("result")
+
+    def initialize(self):
+        self._send("initialize", {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "issue40-repro", "version": "0"},
+        })
+        self._send("notifications/initialized", notify=True)
+
+    def call(self, name, args):
+        res = self._send("tools/call", {"name": name, "arguments": args})
+        # Concatenate all text content blocks — that is what lands in the model's
+        # context window.
+        parts = []
+        for block in (res or {}).get("content", []):
+            if block.get("type") == "text":
+                parts.append(block.get("text", ""))
+        return "".join(parts)
+
+    def close(self):
+        try:
+            self.p.stdin.close()
+        except Exception:
+            pass
+        self.p.terminate()
+
+
+def main():
+    mcp = MCP(GORTEX_BIN)
+    try:
+        mcp.initialize()
+        print(f"Driving real tools via `{GORTEX_BIN} mcp --proxy`\n")
+
+        rows = []
+        tot_full = tot_comp = 0
+        for path in FILES:
+            full = mcp.call("read_file", {"path": path})
+            comp = mcp.call("read_file", {"path": path, "compress_bodies": True})
+            bf, bc = len(full.encode()), len(comp.encode())
+            tot_full += bf
+            tot_comp += bc
+            save = 100 * (1 - bc / bf) if bf else 0
+            rows.append((path, bf, bc, save))
+
+        name_w = max(len(p) for p, *_ in rows)
+        print(f"{'file':<{name_w}}  {'full B':>9}  {'compress B':>11}  "
+              f"{'full ~tok':>10}  {'compress ~tok':>13}  {'saved':>6}")
+        print("-" * (name_w + 60))
+        for path, bf, bc, save in rows:
+            print(f"{path:<{name_w}}  {bf:>9,}  {bc:>11,}  "
+                  f"{approx_tokens(bf):>10,}  {approx_tokens(bc):>13,}  {save:>5.0f}%")
+        tot_save = 100 * (1 - tot_comp / tot_full) if tot_full else 0
+        print("-" * (name_w + 60))
+        print(f"{'TOTAL':<{name_w}}  {tot_full:>9,}  {tot_comp:>11,}  "
+              f"{approx_tokens(tot_full):>10,}  {approx_tokens(tot_comp):>13,}  {tot_save:>5.0f}%")
+
+        # Pattern 3: locate call sites instead of reading bodies at all.
+        # Cost scales with match count, so the honest figure is per-match.
+        st = mcp.call("search_text", {"query": SEARCH_QUERY, "limit": 100})
+        try:
+            n_matches = json.loads(st).get("count", 0)
+        except json.JSONDecodeError:
+            n_matches = st.count("path:")
+        bs = len(st.encode())
+        per = approx_tokens(bs) / n_matches if n_matches else 0
+        print(f"\nsearch_text(query={SEARCH_QUERY!r}): {n_matches} sites located in "
+              f"{bs:,} B (~{approx_tokens(bs):,} tok ≈ {per:.0f} tok/site) — "
+              f"line-precise file:line, zero bodies read")
+
+        print("\nVerdict inputs:")
+        print(f"  • Full reads cost ~{approx_tokens(tot_full):,} tok for {len(FILES)} files.")
+        print(f"  • compress_bodies:true would cost ~{approx_tokens(tot_comp):,} tok "
+              f"({tot_save:.0f}% less) — same signatures/structure.")
+        print(f"  • read_file's DEFAULT is compress_bodies:false → the expensive "
+              f"path is the default path.")
+    finally:
+        mcp.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/internal/agents/claudecode/hooks.go
+++ b/internal/agents/claudecode/hooks.go
@@ -16,12 +16,17 @@ import (
 
 // CurrentPreToolUseMatcher is the canonical matcher pattern we bake
 // into Claude Code's PreToolUse hook. Older versions used
-// "Read|Grep", "Read|Grep|Glob", "Read|Grep|Glob|Task", or
-// "Read|Grep|Glob|Task|Bash"; upgradeGortexMatcher rewrites those in
-// place. Edit and Write are included so the hook can redirect
-// whole-file rewrites of indexed source to the Gortex MCP edit
-// tools (gated by GORTEX_HOOK_BLOCK_EDIT in the hook itself).
-const CurrentPreToolUseMatcher = "Read|Grep|Glob|Task|Bash|Edit|Write"
+// "Read|Grep", "Read|Grep|Glob", "Read|Grep|Glob|Task",
+// "Read|Grep|Glob|Task|Bash", or "Read|Grep|Glob|Task|Bash|Edit|Write";
+// upgradeGortexMatcher rewrites those in place. Edit and Write are
+// included so the hook can redirect whole-file rewrites of indexed
+// source to the Gortex MCP edit tools (gated by GORTEX_HOOK_BLOCK_EDIT
+// in the hook itself). The two mcp__gortex__ read tools are included so
+// the hook can also nudge a full-body read_file / get_editing_context
+// toward compress_bodies / search_text — the one gap that fires once
+// the agent is already inside a Gortex tool (gated by
+// GORTEX_HOOK_FORCE_COMPRESS for the hard-deny posture).
+const CurrentPreToolUseMatcher = "Read|Grep|Glob|Task|Bash|Edit|Write|mcp__gortex__read_file|mcp__gortex__get_editing_context"
 
 // CurrentPostToolUseMatcher names the tools whose response the
 // PostToolUse hook augments. Only the read-shaped tools have an obvious
@@ -195,10 +200,11 @@ func upgradeGortexMatcher(hooks map[string]any) bool {
 		return false
 	}
 	legacyMatchers := map[string]bool{
-		"Read|Grep":                true,
-		"Read|Grep|Glob":           true,
-		"Read|Grep|Glob|Task":      true,
-		"Read|Grep|Glob|Task|Bash": true,
+		"Read|Grep":                           true,
+		"Read|Grep|Glob":                      true,
+		"Read|Grep|Glob|Task":                 true,
+		"Read|Grep|Glob|Task|Bash":            true,
+		"Read|Grep|Glob|Task|Bash|Edit|Write": true,
 	}
 	upgraded := false
 	for _, h := range pre {

--- a/internal/agents/claudecode/hooks_test.go
+++ b/internal/agents/claudecode/hooks_test.go
@@ -350,6 +350,35 @@ func TestRewriteGortexHookMode_IgnoresNonGortexEntries(t *testing.T) {
 		"non-Gortex entries must NOT be touched even when we're rewriting")
 }
 
+// TestUpgradeGortexMatcher_RewritesPreviousCurrent verifies the
+// migration path: an existing install pinned to the previous canonical
+// matcher (no MCP read tools) upgrades in place so the read-discipline
+// nudge starts firing without the user touching settings.json.
+func TestUpgradeGortexMatcher_RewritesPreviousCurrent(t *testing.T) {
+	hooks := map[string]any{
+		"PreToolUse": []any{makeHookEntry("Read|Grep|Glob|Task|Bash|Edit|Write", "/opt/gortex hook")},
+	}
+	assert.True(t, upgradeGortexMatcher(hooks), "previous-current matcher should upgrade")
+	got := hooks["PreToolUse"].([]any)[0].(map[string]any)["matcher"].(string)
+	assert.Equal(t, CurrentPreToolUseMatcher, got)
+	assert.Contains(t, got, "mcp__gortex__read_file",
+		"upgraded matcher must include the gortex read tools")
+}
+
+func TestUpgradeGortexMatcher_NoOpOnCurrent(t *testing.T) {
+	hooks := map[string]any{
+		"PreToolUse": []any{makeHookEntry(CurrentPreToolUseMatcher, "/opt/gortex hook")},
+	}
+	assert.False(t, upgradeGortexMatcher(hooks), "already-current matcher must not be rewritten")
+}
+
+func TestUpgradeGortexMatcher_IgnoresNonGortexEntries(t *testing.T) {
+	hooks := map[string]any{
+		"PreToolUse": []any{makeHookEntry("Read|Grep|Glob|Task|Bash|Edit|Write", "/usr/bin/other thing")},
+	}
+	assert.False(t, upgradeGortexMatcher(hooks), "a non-Gortex entry must not be upgraded")
+}
+
 // ---------------------------------------------------------------------------
 // InstallHookWithMode — end-to-end: deny → enrich → deny round-trip
 // ---------------------------------------------------------------------------

--- a/internal/agents/claudecode/plugin.go
+++ b/internal/agents/claudecode/plugin.go
@@ -80,12 +80,15 @@ const pluginMCPJSON = `{
 //   - Forward stdin / stderr / argv unchanged so all today's
 //     `gortex hook` event-dispatcher logic in internal/hooks/dispatch.go
 //     keeps working byte-for-byte.
+//
+// The %s is filled with CurrentPreToolUseMatcher at emit time so the
+// marketplace plugin and the `gortex init` settings.json never drift.
 const pluginHooksJSON = `{
   "description": "Gortex graph-aware hooks: PreToolUse routing, PreCompact orientation, post-task diagnostics, SessionStart cold briefing.",
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Read|Grep|Glob|Task|Bash|Edit|Write",
+        "matcher": "%s",
         "hooks": [
           {
             "type": "command",
@@ -322,7 +325,7 @@ func EmitPluginBundle(spec PluginBundleSpec) ([]string, error) {
 	}
 
 	// 8. hooks/hooks.json + hooks-handlers/gortex-hook.sh
-	if err := write("hooks/hooks.json", []byte(pluginHooksJSON), 0o644); err != nil {
+	if err := write("hooks/hooks.json", fmt.Appendf(nil, pluginHooksJSON, CurrentPreToolUseMatcher), 0o644); err != nil {
 		return nil, err
 	}
 	if err := write("hooks-handlers/gortex-hook.sh", []byte(pluginHookHandler), 0o755); err != nil {

--- a/internal/hooks/gortex_read.go
+++ b/internal/hooks/gortex_read.go
@@ -1,0 +1,125 @@
+package hooks
+
+import (
+	"fmt"
+	"strings"
+)
+
+// The Gortex MCP read tools that return whole-file source. A call to
+// either with default arguments hands the agent every function body —
+// the exact pattern that burns context in issue #40. They are the one
+// gap the native-tool (Read / Grep / Bash) redirects can't cover: once
+// the agent is already inside a Gortex tool, nothing else guards how it
+// is called.
+const (
+	gortexReadFileTool       = gortexMCPToolPrefix + "read_file"
+	gortexEditingContextTool = gortexMCPToolPrefix + "get_editing_context"
+)
+
+// gortexForceCompressEnvVar upgrades the compress-bodies advisory from a
+// soft nudge to a hard deny. It mirrors GORTEX_HOOK_BLOCK_EDIT: the
+// default posture is a non-blocking reminder — a full-body read is
+// sometimes genuinely needed — and a team can flip this on to enforce
+// the rule once they trust it.
+const gortexForceCompressEnvVar = "GORTEX_HOOK_FORCE_COMPRESS"
+
+// enrichGortexRead nudges (or, when GORTEX_HOOK_FORCE_COMPRESS is set,
+// denies) a whole-file read through read_file / get_editing_context
+// that omits compress_bodies on a source file. Returns an empty result
+// — i.e. silent pass-through — for any call that is already economical
+// (compressed, size-capped, or a non-code file where compression is a
+// no-op).
+func enrichGortexRead(toolName string, toolInput map[string]any) enrichResult {
+	msg := gortexReadNudge(toolName, toolInput)
+	if msg == "" {
+		return enrichResult{}
+	}
+	if gortexForceCompressEnabled() {
+		return enrichResult{deny: true, reason: msg}
+	}
+	return enrichResult{context: msg}
+}
+
+// gortexReadNudge returns the advisory message for a Gortex read-tool
+// call that should be nudged, or "" when the call needs no nudge. It is
+// pure (no env gate, no daemon round-trip — the decision is made
+// entirely from the tool input, so the hook stays sub-millisecond) so
+// callers can surface the message either as soft context or as a deny.
+func gortexReadNudge(toolName string, toolInput map[string]any) string {
+	// Already compressing — nothing to suggest.
+	if asBool(toolInput["compress_bodies"]) {
+		return ""
+	}
+	path, _ := toolInput["path"].(string)
+	if path == "" {
+		return ""
+	}
+	// compress_bodies only elides code bodies; on prose / config it is a
+	// no-op, so don't nag on non-source reads.
+	if !looksLikeSourceFile(path) {
+		return ""
+	}
+	// The agent already bounded the read (a slice or a token / byte cap)
+	// — it knows what it wants; don't second-guess a constrained call.
+	if hasReadSizeCap(toolInput) {
+		return ""
+	}
+	return gortexReadAdvisory(toolName, path)
+}
+
+// gortexReadAdvisory builds the reminder shown when a Gortex read tool
+// is about to pull full bodies. It names the cheaper paths the reporter
+// of issue #40 wished the agent had taken: search_text to locate sites
+// without reading bodies, and compress_bodies (+ keep) to read for an
+// edit at a fraction of the tokens.
+func gortexReadAdvisory(toolName, path string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "[Gortex] %s on %s without compress_bodies — a full-body read can dominate context.\n",
+		shortGortexToolName(toolName), path)
+	b.WriteString("  - Locating specific call sites? `search_text` returns line-precise hits and reads no bodies.\n")
+	b.WriteString("  - Reading to edit? Re-call with compress_bodies:true (~30-40% of the tokens; signatures, types, and comments kept).\n")
+	b.WriteString("  - Need certain bodies in full? Add keep:\"Name1,Name2\" alongside compress_bodies:true.\n")
+	return b.String()
+}
+
+// shortGortexToolName strips the mcp__gortex__ namespace so the advisory
+// reads "read_file" rather than the fully-qualified tool name.
+func shortGortexToolName(toolName string) string {
+	return strings.TrimPrefix(toolName, gortexMCPToolPrefix)
+}
+
+// hasReadSizeCap reports whether the read already bounds its output via a
+// line / byte / token cap. read_file uses max_lines / max_bytes;
+// get_editing_context uses max_bytes / max_tokens. A zero or non-numeric
+// value is treated as "no cap" so an explicit `max_tokens: 0` opt-out
+// still draws the nudge.
+func hasReadSizeCap(toolInput map[string]any) bool {
+	for _, k := range []string{"max_lines", "max_bytes", "max_tokens"} {
+		if n, ok := toFloat64(toolInput[k]); ok && n > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// asBool coerces a JSON-decoded tool-input value to bool. Claude Code
+// sends booleans as JSON true/false (decoded to Go bool); the string
+// fallback covers hosts that stringify tool inputs.
+func asBool(v any) bool {
+	switch b := v.(type) {
+	case bool:
+		return b
+	case string:
+		switch strings.ToLower(strings.TrimSpace(b)) {
+		case "true", "1", "yes", "on":
+			return true
+		}
+	}
+	return false
+}
+
+// gortexForceCompressEnabled reports whether the hard-deny gate is on.
+// Same truthiness rules as editBlockingEnabled (see envGateEnabled).
+func gortexForceCompressEnabled() bool {
+	return envGateEnabled(gortexForceCompressEnvVar)
+}

--- a/internal/hooks/gortex_read_test.go
+++ b/internal/hooks/gortex_read_test.go
@@ -1,0 +1,171 @@
+package hooks
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// withForceCompress flips GORTEX_HOOK_FORCE_COMPRESS for one test and
+// restores the previous value (including unset) on cleanup.
+func withForceCompress(t *testing.T, on bool) {
+	t.Helper()
+	t.Setenv(gortexForceCompressEnvVar, map[bool]string{true: "1", false: ""}[on])
+}
+
+func TestGortexReadNudge_NudgesFullSourceRead(t *testing.T) {
+	msg := gortexReadNudge(gortexReadFileTool, map[string]any{"path": "internal/resolver/resolver.go"})
+	if msg == "" {
+		t.Fatal("expected a nudge for a full-body source read")
+	}
+	for _, want := range []string{"compress_bodies", "search_text", "keep", "read_file"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("nudge missing %q:\n%s", want, msg)
+		}
+	}
+}
+
+func TestGortexReadNudge_SilentWhenAlreadyEconomical(t *testing.T) {
+	cases := []struct {
+		name  string
+		input map[string]any
+	}{
+		{"compress_bodies true", map[string]any{"path": "a.go", "compress_bodies": true}},
+		{"compress_bodies string true", map[string]any{"path": "a.go", "compress_bodies": "true"}},
+		{"non-source file", map[string]any{"path": "README.md"}},
+		{"config file", map[string]any{"path": "config.yaml"}},
+		{"capped by max_lines", map[string]any{"path": "a.go", "max_lines": float64(80)}},
+		{"capped by max_bytes", map[string]any{"path": "a.go", "max_bytes": float64(4000)}},
+		{"capped by max_tokens", map[string]any{"path": "a.go", "max_tokens": float64(2000)}},
+		{"no path", map[string]any{}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if msg := gortexReadNudge(gortexReadFileTool, c.input); msg != "" {
+				t.Errorf("expected silence, got nudge:\n%s", msg)
+			}
+		})
+	}
+}
+
+func TestGortexReadNudge_ZeroCapStillNudges(t *testing.T) {
+	// An explicit max_tokens:0 is an opt-out of the cap, not a cap — the
+	// read is still unbounded, so the nudge should fire.
+	if msg := gortexReadNudge(gortexReadFileTool, map[string]any{"path": "a.go", "max_tokens": float64(0)}); msg == "" {
+		t.Error("max_tokens:0 is not a cap; expected the nudge to fire")
+	}
+}
+
+func TestEnrichGortexRead_DefaultIsSoftContext(t *testing.T) {
+	withForceCompress(t, false)
+	result := enrichGortexRead(gortexReadFileTool, map[string]any{"path": "a.go"})
+	if result.deny {
+		t.Fatal("default posture must not deny")
+	}
+	if result.context == "" {
+		t.Error("expected soft advisory context")
+	}
+}
+
+func TestEnrichGortexRead_GateOnDenies(t *testing.T) {
+	withForceCompress(t, true)
+	result := enrichGortexRead(gortexEditingContextTool, map[string]any{"path": "a.go"})
+	if !result.deny {
+		t.Fatal("GORTEX_HOOK_FORCE_COMPRESS=1 must deny a full-body read")
+	}
+	if !strings.Contains(result.reason, "compress_bodies") {
+		t.Errorf("deny reason should name compress_bodies:\n%s", result.reason)
+	}
+}
+
+func TestEnrichGortexRead_EconomicalCallPassesThroughEvenWhenGated(t *testing.T) {
+	withForceCompress(t, true)
+	result := enrichGortexRead(gortexReadFileTool, map[string]any{"path": "a.go", "compress_bodies": true})
+	if result.deny || result.context != "" {
+		t.Errorf("already-compressed read must pass silently even with the gate on; got deny=%v ctx=%q", result.deny, result.context)
+	}
+}
+
+func TestEnrich_DispatchesGortexReadTools(t *testing.T) {
+	withForceCompress(t, false)
+	for _, tool := range []string{gortexReadFileTool, gortexEditingContextTool} {
+		input := HookInput{ToolName: tool, ToolInput: map[string]any{"path": "a.go"}}
+		if result := enrich(input, 0); result.context == "" {
+			t.Errorf("enrich must route %s to enrichGortexRead", tool)
+		}
+	}
+}
+
+func TestRunPreToolUse_GortexRead_EmitsAdditionalContext(t *testing.T) {
+	withForceCompress(t, false)
+	payload := []byte(`{"hook_event_name":"PreToolUse","tool_name":"mcp__gortex__read_file","tool_input":{"path":"internal/x.go"}}`)
+	out := captureStdout(t, func() { runPreToolUse(payload, 0, ModeDeny) })
+
+	var dec HookOutput
+	if err := json.Unmarshal([]byte(out), &dec); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+	if dec.HookSpecificOutput.PermissionDecision == "deny" {
+		t.Error("default posture must not hard-deny a Gortex read")
+	}
+	if !strings.Contains(dec.HookSpecificOutput.AdditionalContext, "compress_bodies") {
+		t.Errorf("expected compress_bodies advice in additionalContext:\n%s", out)
+	}
+}
+
+func TestRunPreToolUse_GortexRead_CompressedIsSilent(t *testing.T) {
+	withForceCompress(t, false)
+	payload := []byte(`{"hook_event_name":"PreToolUse","tool_name":"mcp__gortex__read_file","tool_input":{"path":"internal/x.go","compress_bodies":true}}`)
+	out := captureStdout(t, func() { runPreToolUse(payload, 0, ModeDeny) })
+	if strings.TrimSpace(out) != "" {
+		t.Errorf("a compressed read should emit nothing, got:\n%s", out)
+	}
+}
+
+func TestRunPreToolUse_GortexRead_PermissiveCarriesNudge(t *testing.T) {
+	withForceCompress(t, false)
+	// Under a permissive permission mode the call is auto-approved, but
+	// the read-discipline nudge must still ride along as soft context.
+	payload := []byte(`{"hook_event_name":"PreToolUse","tool_name":"mcp__gortex__read_file","tool_input":{"path":"internal/x.go"},"permission_mode":"acceptEdits"}`)
+	out := captureStdout(t, func() { runPreToolUse(payload, 0, ModeDeny) })
+
+	var dec HookOutput
+	if err := json.Unmarshal([]byte(out), &dec); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+	if dec.HookSpecificOutput.PermissionDecision != "allow" {
+		t.Errorf("permissive mode must keep the allow decision, got %q", dec.HookSpecificOutput.PermissionDecision)
+	}
+	if !strings.Contains(dec.HookSpecificOutput.AdditionalContext, "compress_bodies") {
+		t.Errorf("permissive auto-approve should still carry the nudge:\n%s", out)
+	}
+}
+
+func TestRunPreToolUse_GortexRead_PermissiveNeverDeniesEvenWhenGated(t *testing.T) {
+	withForceCompress(t, true)
+	payload := []byte(`{"hook_event_name":"PreToolUse","tool_name":"mcp__gortex__read_file","tool_input":{"path":"internal/x.go"},"permission_mode":"acceptEdits"}`)
+	out := captureStdout(t, func() { runPreToolUse(payload, 0, ModeDeny) })
+
+	var dec HookOutput
+	if err := json.Unmarshal([]byte(out), &dec); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+	if dec.HookSpecificOutput.PermissionDecision != "allow" {
+		t.Errorf("auto-approve must hold even with the gate on, got %q", dec.HookSpecificOutput.PermissionDecision)
+	}
+}
+
+func TestAsBool(t *testing.T) {
+	truthy := []any{true, "true", "TRUE", "1", "yes", "on"}
+	for _, v := range truthy {
+		if !asBool(v) {
+			t.Errorf("asBool(%#v) = false, want true", v)
+		}
+	}
+	falsy := []any{false, "false", "0", "no", "off", "", nil, 1, "maybe"}
+	for _, v := range falsy {
+		if asBool(v) {
+			t.Errorf("asBool(%#v) = true, want false", v)
+		}
+	}
+}

--- a/internal/hooks/pretooluse.go
+++ b/internal/hooks/pretooluse.go
@@ -93,13 +93,19 @@ func runPreToolUse(data []byte, gortexPort int, mode Mode) {
 	// switch and the other modes' logic so a gortex tool is never
 	// processed further.
 	if isGortexMCP && isPermissivePermissionMode(input.PermissionMode) {
-		emitPreToolUse(HookOutput{
-			HookSpecificOutput: &HookSpecificOutput{
-				HookEventName:            "PreToolUse",
-				PermissionDecision:       "allow",
-				PermissionDecisionReason: "[Gortex] auto-approved: Gortex MCP graph tool under a permissive permission mode.",
-			},
-		})
+		hso := &HookSpecificOutput{
+			HookEventName:            "PreToolUse",
+			PermissionDecision:       "allow",
+			PermissionDecisionReason: "[Gortex] auto-approved: Gortex MCP graph tool under a permissive permission mode.",
+		}
+		// The read-discipline nudge still rides along as soft context —
+		// a permissive permission mode means low friction, not "stop
+		// reminding me my full-body read is expensive". Never a hard
+		// deny here: auto-approve has already promised to allow the call.
+		if adv := gortexReadNudge(input.ToolName, input.ToolInput); adv != "" {
+			hso.AdditionalContext = adv
+		}
+		emitPreToolUse(HookOutput{HookSpecificOutput: hso})
 		return
 	}
 
@@ -294,6 +300,8 @@ func enrich(input HookInput, port int) enrichResult {
 		return enrichEdit(input.ToolInput, port)
 	case "Write":
 		return enrichWrite(input.ToolInput, port)
+	case gortexReadFileTool, gortexEditingContextTool:
+		return enrichGortexRead(input.ToolName, input.ToolInput)
 	default:
 		return enrichResult{}
 	}
@@ -679,8 +687,14 @@ const editBlockingEnvVar = "GORTEX_HOOK_BLOCK_EDIT"
 // redirect is on. Anything besides empty/"0"/"false"/"no"/"off"
 // enables.
 func editBlockingEnabled() bool {
-	v := strings.TrimSpace(strings.ToLower(os.Getenv(editBlockingEnvVar)))
-	switch v {
+	return envGateEnabled(editBlockingEnvVar)
+}
+
+// envGateEnabled reports whether a boolean env-var gate is on. Empty,
+// "0", "false", "no", and "off" are off; anything else is on. Shared by
+// the Edit/Write and force-compress gates so they read identically.
+func envGateEnabled(name string) bool {
+	switch strings.TrimSpace(strings.ToLower(os.Getenv(name))) {
 	case "", "0", "false", "no", "off":
 		return false
 	default:


### PR DESCRIPTION
Issue #40: Claude Code burns context reading whole files via Gortex's own read tools. 

The `PreToolUse` hook redirects native `Read`/`Grep`/`Glob` to graph tools, but its matcher (`Read`|`Grep`|`Glob`|`Task`|`Bash`|`Edit`|`Write`) never matched `mcp__gortex__read_file` — once the agent was inside a Gortex read tool, nothing guarded how it was called, and `read_file` defaults to `compress_bodies:false`. So the expensive path was the default path with no forcing function.

Close the gap:
- Add `mcp__gortex__read_file` and `mcp__gortex__get_editing_context` to the `PreToolUse` matcher; existing installs upgrade in place (the previous matcher joins the legacy set).
- `enrichGortexRead` nudges a full-body read on a source file toward `search_text` (locate sites, no bodies) or `compress_bodies:true` (+keep). Soft `additionalContext` by default; hard deny behind `GORTEX_HOOK_FORCE_COMPRESS`, mirroring `GORTEX_HOOK_BLOCK_EDIT`. The decision is made purely from the tool input — no daemon round-trip — so the hook stays sub-millisecond. Already-economical calls (compressed, size-capped, non-source) pass silently. The nudge also rides along with the permissive-mode auto-approve as soft context.
- Derive the marketplace plugin's hooks.json matcher from the constant so it can't drift from gortex init.

Adds `bench/issue40_context_repro.py`, which drives the live daemon to measure the full-vs-compressed read gap (~2x)

`bench/issue40_context_repro.py` — drives the real tools through the running daemon (`gortex mcp --proxy`) and measures actual wire bytes for the three access patterns. 

```bash
python3 bench/issue40_context_repro.py
```

  What it shows (4 mid-size Go files ≈ reporter's 16–20KB C++ files)

  ```
┌────────────────────────────────┬──────────────┬────────────────────────────────────────────────────────────────────┐
  │            Pattern             │     Cost     │                                Note                                │
  ├────────────────────────────────┼──────────────┼────────────────────────────────────────────────────────────────────┤
  │ read_file (full)               │ ~17.3k tok   │ the "eats context" path                                            │
  ├────────────────────────────────┼──────────────┼────────────────────────────────────────────────────────────────────┤
  │ read_file compress_bodies:true │ ~8.6k tok    │ 50% less aggregate, up to 75% per file — same signatures/structure │
  ├────────────────────────────────┼──────────────┼────────────────────────────────────────────────────────────────────┤
  │ search_text (locate sites)     │ ~41 tok/site │ line-precise file:line, zero bodies read                           │
  └────────────────────────────────┴──────────────┴────────────────────────────────────────────────────────────────────┘
```
