### PR TITLE
Resolution & cross-language edges: dispatch synthesizer engine, native bridges, and contract resolvers

### DIFF
--- a/cmd/gortex/wire_contract_test.go
+++ b/cmd/gortex/wire_contract_test.go
@@ -141,11 +141,12 @@ func wireContractGolden(name string) string {
 		// blank. Previously bumped when WorkspaceID / ProjectID were added.
 		return "b04bc4f58977e8220d31fdbf3fdab66867ab76790d6724bdabaf80b87958a7a4"
 	case "graph.Edge":
-		// Bumped when Tier was added — the coarse provenance label
-		// (ast / lsp / heuristic) derived from Origin and surfaced to
-		// agents. Additive: gob decodes older snapshots with Tier blank,
-		// and the enrich passes restamp it on next response.
-		return "954c994407f745b921ace19ab999d620f2e1aa071d177722a176f635ae7746dc"
+		// Bumped when Context was added — the per-reference role label
+		// (parameter_type / return_type / field / …) populated on demand by
+		// find_usages via RefContextOf. Additive: gob decodes older
+		// snapshots with Context blank, and it is recomputed at query time.
+		// (Previously bumped when Tier was added.)
+		return "ed897cce4720cd1482d8c217ba5ffb72d7f19d5d1c2d4015b9a98e9daa9d4b63"
 	case "snapshotHeader":
 		// Bumped when the VectorIndex / VectorDims / VectorCount fields
 		// were added (additive — gob decodes unknown fields as zero).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -503,16 +503,18 @@ type IndexConfig struct {
 	// identity node — `analyze kind=external_calls` then aggregates a
 	// service's whole external surface across repositories.
 	//
-	// Tri-state, default OFF: a nil pointer (the key absent) resolves to
-	// disabled via ExternalCallSynthesisEnabledOrDefault. Synthesis is a
-	// full-graph recompute that materialises a node per external package
-	// and re-targets every external call edge at each index settle point,
-	// so it stays opt-in to avoid a per-index cost on every repo. Enable
-	// with `.gortex.yaml::index::synthesize_external_calls: true` or
-	// GORTEX_SYNTH_EXTERNAL_CALLS=1 to get the stable cross-repo identity
-	// nodes. The qualification is per-language complete (Go/Rust/Java/
-	// Python/C#/TS); language / stdlib calls are filtered out regardless
-	// so the synthetic nodes only ever name genuine third-party packages.
+	// Tri-state, default ON: a nil pointer (the key absent) resolves to
+	// enabled via ExternalCallSynthesisEnabledOrDefault, so external-call
+	// qualification is automatic for every language whose extractor lands
+	// calls on a dep/stdlib/external terminal (Go/Rust/Java/Python/C#/TS).
+	// Affordable by default because synthesis is incremental on the hot
+	// reindex path (only the edited file's terminals are re-materialised)
+	// and the disk backend pushes candidate-edge selection down to a
+	// partial-indexed query. Opt out per-repo with
+	// `.gortex.yaml::index::synthesize_external_calls: false` or the
+	// GORTEX_SYNTH_EXTERNAL_CALLS=0 environment override; language /
+	// stdlib calls are filtered out regardless so the synthetic nodes
+	// only ever name genuine third-party packages.
 	SynthesizeExternalCalls *bool `mapstructure:"synthesize_external_calls" yaml:"synthesize_external_calls,omitempty"`
 	// Transforms are pluggable pre-ingestion content processors. Each
 	// rewrites a matching file's bytes before the parser sees them —
@@ -1067,17 +1069,18 @@ func (e EmbeddingConfig) EmbeddingEnabledOrDefault() bool {
 }
 
 // ExternalCallSynthesisEnabledOrDefault resolves the tri-state
-// SynthesizeExternalCalls flag. An unset flag (key absent) means OFF:
-// materialising a synthetic node per external package and re-targeting
-// every external call edge is a full-graph recompute that runs at each
-// index settle point, so leaving it on by default imposed a multi-x
-// indexing-cost regression. It stays opt-in — enable it (config key or
-// GORTEX_SYNTH_EXTERNAL_CALLS=1) to get the stable cross-repo identity
-// nodes. The qualification itself is per-language complete (Go / Rust /
-// Java / Python / C# / TS), so turning it on is a single switch.
+// SynthesizeExternalCalls flag against the default-on policy: an unset
+// flag (key absent) means external-package call qualification is ON, so
+// every external call gets a stable cross-repo identity node by default.
+// Default-on is affordable because the synthesis is incrementalised — a
+// single-file reindex re-materialises only that file's external terminals
+// (SynthesizeExternalCallsForFiles) instead of recomputing the whole
+// graph — and the disk backend selects candidate edges through a pushdown
+// (graph.ExternalCallCandidates) served by a partial index. Opt out
+// per-repo with the key set to false or GORTEX_SYNTH_EXTERNAL_CALLS=0.
 func (i IndexConfig) ExternalCallSynthesisEnabledOrDefault() bool {
 	if i.SynthesizeExternalCalls == nil {
-		return false
+		return true
 	}
 	return *i.SynthesizeExternalCalls
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -530,6 +530,21 @@ type IndexConfig struct {
 	// documented per-domain defaults" — cheap structural domains on,
 	// expensive ones off.
 	Coverage CoverageConfig `mapstructure:"coverage" yaml:"coverage,omitempty"`
+	// HTTPClientAliases names project-defined wrapped HTTP-client
+	// functions so calls to them are recognised as HTTP consumer
+	// contracts (RoleConsumer) — without relying on the type-driven
+	// fetch/axios heuristics. Each entry is a bare function name (or
+	// receiver.method) that forwards a string-literal path to an
+	// underlying client, e.g. `apiGet`, `apiPost`, `client.request`.
+	// The contracts HTTP extractor mints an `http::METHOD::/path`
+	// consumer contract for every call to one of these names. The
+	// method is taken from the name's verb suffix (`apiGet` → GET,
+	// `apiPost` → POST, ...) when present, falling back to the first
+	// string-literal argument when the call passes the method
+	// explicitly (`apiCall('GET', '/users')`); the path is the first
+	// path-shaped string literal. Empty by default. Configured under
+	// `index.http_client_aliases` in .gortex.yaml.
+	HTTPClientAliases []string `mapstructure:"http_client_aliases" yaml:"http_client_aliases,omitempty"`
 }
 
 // GrammarSpec declares a user-supplied tree-sitter grammar to load at

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -503,15 +503,16 @@ type IndexConfig struct {
 	// identity node — `analyze kind=external_calls` then aggregates a
 	// service's whole external surface across repositories.
 	//
-	// Tri-state, default ON: a nil pointer (the key absent from config)
-	// resolves to enabled via ExternalCallSynthesisEnabledOrDefault, so
-	// external qualification is automatic for every language whose
-	// extractor lands calls on a dep/stdlib/external terminal
-	// (Go/Rust/Java/Python/C#/TS). Opt out per-repo with
-	// `.gortex.yaml::index::synthesize_external_calls: false` or the
-	// GORTEX_SYNTH_EXTERNAL_CALLS=0 environment override; language /
-	// stdlib calls are filtered out regardless so the synthetic nodes
-	// only ever name genuine third-party packages.
+	// Tri-state, default OFF: a nil pointer (the key absent) resolves to
+	// disabled via ExternalCallSynthesisEnabledOrDefault. Synthesis is a
+	// full-graph recompute that materialises a node per external package
+	// and re-targets every external call edge at each index settle point,
+	// so it stays opt-in to avoid a per-index cost on every repo. Enable
+	// with `.gortex.yaml::index::synthesize_external_calls: true` or
+	// GORTEX_SYNTH_EXTERNAL_CALLS=1 to get the stable cross-repo identity
+	// nodes. The qualification is per-language complete (Go/Rust/Java/
+	// Python/C#/TS); language / stdlib calls are filtered out regardless
+	// so the synthetic nodes only ever name genuine third-party packages.
 	SynthesizeExternalCalls *bool `mapstructure:"synthesize_external_calls" yaml:"synthesize_external_calls,omitempty"`
 	// Transforms are pluggable pre-ingestion content processors. Each
 	// rewrites a matching file's bytes before the parser sees them —
@@ -1066,12 +1067,17 @@ func (e EmbeddingConfig) EmbeddingEnabledOrDefault() bool {
 }
 
 // ExternalCallSynthesisEnabledOrDefault resolves the tri-state
-// SynthesizeExternalCalls flag against the default-on policy: an unset
-// flag (key absent) means external-package call qualification is ON, so
-// every external call gets a stable cross-repo identity node by default.
+// SynthesizeExternalCalls flag. An unset flag (key absent) means OFF:
+// materialising a synthetic node per external package and re-targeting
+// every external call edge is a full-graph recompute that runs at each
+// index settle point, so leaving it on by default imposed a multi-x
+// indexing-cost regression. It stays opt-in — enable it (config key or
+// GORTEX_SYNTH_EXTERNAL_CALLS=1) to get the stable cross-repo identity
+// nodes. The qualification itself is per-language complete (Go / Rust /
+// Java / Python / C# / TS), so turning it on is a single switch.
 func (i IndexConfig) ExternalCallSynthesisEnabledOrDefault() bool {
 	if i.SynthesizeExternalCalls == nil {
-		return true
+		return false
 	}
 	return *i.SynthesizeExternalCalls
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -491,20 +491,28 @@ type IndexConfig struct {
 	// round-trip.
 	MaxExtractMillis int `mapstructure:"max_extract_millis" yaml:"max_extract_millis,omitempty"`
 	// SynthesizeExternalCalls turns a call into an un-indexed third
-	// party (an npm/pip/cargo package, or a sibling microservice) into
-	// an explicit graph terminal. Without it such a call edge stays an
-	// `unresolved::` placeholder with no destination node, and a
-	// call-chain walk silently stops there — losing the fact that the
-	// function reaches out to an external system at all. When on, the
-	// resolver synthesises a clearly-marked synthetic placeholder node
-	// for the external target and retargets the call edge to it, so
-	// `get_call_chain` / `get_callers` keep the external hop visible.
-	// Off by default — the synthesis is noise on a codebase that only
-	// wants intra-repo edges, so it is strictly opt-in and changes no
-	// behaviour unless enabled. Turn on via
-	// `.gortex.yaml::index::synthesize_external_calls: true` or the
-	// GORTEX_SYNTH_EXTERNAL_CALLS=1 environment override.
-	SynthesizeExternalCalls bool `mapstructure:"synthesize_external_calls" yaml:"synthesize_external_calls,omitempty"`
+	// party (an npm/pip/cargo/maven/nuget package, or a sibling
+	// microservice) into an explicit graph terminal. Without it such a
+	// call edge stays an `unresolved::` placeholder with no destination
+	// node, and a call-chain walk silently stops there — losing the fact
+	// that the function reaches out to an external system at all. When
+	// on, the resolver synthesises a clearly-marked synthetic node per
+	// (ecosystem, import path) and retargets the call edge to it, so
+	// `get_call_chain` / `get_callers` keep the external hop visible and
+	// every call into the same package shares one stable, cross-repo
+	// identity node — `analyze kind=external_calls` then aggregates a
+	// service's whole external surface across repositories.
+	//
+	// Tri-state, default ON: a nil pointer (the key absent from config)
+	// resolves to enabled via ExternalCallSynthesisEnabledOrDefault, so
+	// external qualification is automatic for every language whose
+	// extractor lands calls on a dep/stdlib/external terminal
+	// (Go/Rust/Java/Python/C#/TS). Opt out per-repo with
+	// `.gortex.yaml::index::synthesize_external_calls: false` or the
+	// GORTEX_SYNTH_EXTERNAL_CALLS=0 environment override; language /
+	// stdlib calls are filtered out regardless so the synthetic nodes
+	// only ever name genuine third-party packages.
+	SynthesizeExternalCalls *bool `mapstructure:"synthesize_external_calls" yaml:"synthesize_external_calls,omitempty"`
 	// Transforms are pluggable pre-ingestion content processors. Each
 	// rewrites a matching file's bytes before the parser sees them —
 	// expanding minified bundles, normalising SVG/TOON, converting a
@@ -1040,6 +1048,17 @@ func (e EmbeddingConfig) EmbeddingEnabledOrDefault() bool {
 		return true
 	}
 	return *e.Enabled
+}
+
+// ExternalCallSynthesisEnabledOrDefault resolves the tri-state
+// SynthesizeExternalCalls flag against the default-on policy: an unset
+// flag (key absent) means external-package call qualification is ON, so
+// every external call gets a stable cross-repo identity node by default.
+func (i IndexConfig) ExternalCallSynthesisEnabledOrDefault() bool {
+	if i.SynthesizeExternalCalls == nil {
+		return true
+	}
+	return *i.SynthesizeExternalCalls
 }
 
 // EmbeddingProviderOrDefault returns the configured provider name,

--- a/internal/config/external_calls_test.go
+++ b/internal/config/external_calls_test.go
@@ -7,18 +7,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestExternalCallSynthesis_AbsentIsDefaultOn asserts that a config with
+// TestExternalCallSynthesis_AbsentIsDefaultOff asserts that a config with
 // no `synthesize_external_calls` key leaves the pointer nil — which the
-// tri-state resolver reads as "external-call qualification ON" — so every
-// external call gets a stable cross-repo identity node by default.
-func TestExternalCallSynthesis_AbsentIsDefaultOn(t *testing.T) {
+// tri-state resolver reads as "external-call synthesis OFF" — so the
+// full-graph synthesis stays opt-in and imposes no per-index cost.
+func TestExternalCallSynthesis_AbsentIsDefaultOff(t *testing.T) {
 	cfg, err := Load(writeConfig(t, "index:\n  workers: 2\n"))
 	require.NoError(t, err)
 
 	assert.Nil(t, cfg.Index.SynthesizeExternalCalls,
-		"an absent key must leave the pointer nil (not false) so default-on applies")
-	assert.True(t, cfg.Index.ExternalCallSynthesisEnabledOrDefault(),
-		"a nil flag must resolve to ON")
+		"an absent key must leave the pointer nil (not false)")
+	assert.False(t, cfg.Index.ExternalCallSynthesisEnabledOrDefault(),
+		"a nil flag must resolve to OFF (opt-in)")
 }
 
 // TestExternalCallSynthesis_ExplicitlyDisabled asserts an explicit

--- a/internal/config/external_calls_test.go
+++ b/internal/config/external_calls_test.go
@@ -1,0 +1,43 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExternalCallSynthesis_AbsentIsDefaultOn asserts that a config with
+// no `synthesize_external_calls` key leaves the pointer nil — which the
+// tri-state resolver reads as "external-call qualification ON" — so every
+// external call gets a stable cross-repo identity node by default.
+func TestExternalCallSynthesis_AbsentIsDefaultOn(t *testing.T) {
+	cfg, err := Load(writeConfig(t, "index:\n  workers: 2\n"))
+	require.NoError(t, err)
+
+	assert.Nil(t, cfg.Index.SynthesizeExternalCalls,
+		"an absent key must leave the pointer nil (not false) so default-on applies")
+	assert.True(t, cfg.Index.ExternalCallSynthesisEnabledOrDefault(),
+		"a nil flag must resolve to ON")
+}
+
+// TestExternalCallSynthesis_ExplicitlyDisabled asserts an explicit
+// opt-out is distinguishable from "absent" and turns synthesis off.
+func TestExternalCallSynthesis_ExplicitlyDisabled(t *testing.T) {
+	cfg, err := Load(writeConfig(t, "index:\n  synthesize_external_calls: false\n"))
+	require.NoError(t, err)
+
+	require.NotNil(t, cfg.Index.SynthesizeExternalCalls, "an explicit value must round-trip as a non-nil pointer")
+	assert.False(t, *cfg.Index.SynthesizeExternalCalls)
+	assert.False(t, cfg.Index.ExternalCallSynthesisEnabledOrDefault())
+}
+
+// TestExternalCallSynthesis_ExplicitlyEnabled asserts `true` round-trips.
+func TestExternalCallSynthesis_ExplicitlyEnabled(t *testing.T) {
+	cfg, err := Load(writeConfig(t, "index:\n  synthesize_external_calls: true\n"))
+	require.NoError(t, err)
+
+	require.NotNil(t, cfg.Index.SynthesizeExternalCalls)
+	assert.True(t, *cfg.Index.SynthesizeExternalCalls)
+	assert.True(t, cfg.Index.ExternalCallSynthesisEnabledOrDefault())
+}

--- a/internal/config/external_calls_test.go
+++ b/internal/config/external_calls_test.go
@@ -7,18 +7,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestExternalCallSynthesis_AbsentIsDefaultOff asserts that a config with
+// TestExternalCallSynthesis_AbsentIsDefaultOn asserts that a config with
 // no `synthesize_external_calls` key leaves the pointer nil — which the
-// tri-state resolver reads as "external-call synthesis OFF" — so the
-// full-graph synthesis stays opt-in and imposes no per-index cost.
-func TestExternalCallSynthesis_AbsentIsDefaultOff(t *testing.T) {
+// tri-state resolver reads as "external-call qualification ON" — so every
+// external call gets a stable cross-repo identity node by default
+// (affordable because synthesis is incremental on the hot path).
+func TestExternalCallSynthesis_AbsentIsDefaultOn(t *testing.T) {
 	cfg, err := Load(writeConfig(t, "index:\n  workers: 2\n"))
 	require.NoError(t, err)
 
 	assert.Nil(t, cfg.Index.SynthesizeExternalCalls,
-		"an absent key must leave the pointer nil (not false)")
-	assert.False(t, cfg.Index.ExternalCallSynthesisEnabledOrDefault(),
-		"a nil flag must resolve to OFF (opt-in)")
+		"an absent key must leave the pointer nil (not false) so default-on applies")
+	assert.True(t, cfg.Index.ExternalCallSynthesisEnabledOrDefault(),
+		"a nil flag must resolve to ON")
 }
 
 // TestExternalCallSynthesis_ExplicitlyDisabled asserts an explicit

--- a/internal/contracts/http.go
+++ b/internal/contracts/http.go
@@ -13,7 +13,15 @@ import (
 
 // HTTPExtractor detects HTTP route provider and consumer patterns across
 // multiple languages using regex matching on source text.
-type HTTPExtractor struct{}
+type HTTPExtractor struct {
+	// ClientAliases are project-defined wrapped HTTP-client function
+	// names (e.g. "apiGet", "apiPost", "client.request"). Calls to any
+	// of these are treated as HTTP consumer contracts even though they
+	// don't match the built-in fetch/axios heuristics. Empty disables
+	// the alias pass. Sourced from index.http_client_aliases. See
+	// detectClientAliasConsumers for the supported call shapes.
+	ClientAliases []string
+}
 
 var _ Extractor = (*HTTPExtractor)(nil)
 
@@ -608,7 +616,14 @@ func (h *HTTPExtractor) extract(
 ) []Contract {
 	lang := detectLanguage(filePath)
 	if markers, ok := httpPrefilterMarkers[lang]; ok && !srcHasAnyMarker(src, markers) {
-		return nil
+		// A configured client-alias call (e.g. apiGet) carries none of
+		// the fetch/axios/app. markers, so the prefilter would skip the
+		// file and the alias pass would never run. Keep the file alive
+		// when it mentions an alias name; the alias pass below is the
+		// only work that will then fire.
+		if !srcMentionsAnyAlias(src, h.ClientAliases) {
+			return nil
+		}
 	}
 
 	text := string(src)
@@ -775,6 +790,15 @@ func (h *HTTPExtractor) extract(
 
 			out = append(out, c)
 		}
+	}
+
+	// Configurable HTTP-client wrapper aliases. Calls to a
+	// project-named wrapper (e.g. apiGet('/users')) become consumer
+	// contracts even though no built-in fetch/axios pattern matched.
+	// Scoped to the TS/JS family — the alias mechanism mirrors the
+	// fetch/axios consumer heuristics, which are TS/JS only.
+	if len(h.ClientAliases) > 0 && (lang == "typescript" || lang == "javascript") {
+		out = append(out, h.detectClientAliasConsumers(filePath, text, lines, fileNodes, lang, tree)...)
 	}
 
 	return out

--- a/internal/contracts/http_alias.go
+++ b/internal/contracts/http_alias.go
@@ -1,0 +1,224 @@
+package contracts
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/zzet/gortex/internal/parser"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// -----------------------------------------------------------------------------
+// Configurable HTTP-client wrapper aliases
+// -----------------------------------------------------------------------------
+//
+// Many TS/JS codebases route every network call through a project-local
+// helper — `apiGet('/users')`, `apiPost('/orders', body)`,
+// `httpClient.request('GET', '/users')`. The built-in fetch/axios
+// consumer patterns never see these because the call target is a
+// user-defined function, so the endpoints stay invisible to the
+// contract matcher. The `index.http_client_aliases` config lists those
+// wrapper names; this pass mints a consumer contract for each call to
+// one of them, using the SAME `http::METHOD::/path` ID scheme the
+// matcher pairs against providers.
+//
+// Supported call shapes (alias = a configured name like `apiGet` or
+// `client.request`):
+//
+//	apiGet('/users')                  → http::GET::/users
+//	apiPost('/orders', body)          → http::POST::/orders
+//	apiDelete(`/users/${id}`)         → http::DELETE::/users/{p1}
+//	  (method from the alias name's verb suffix: get/post/put/delete/
+//	   patch/head/options, case-insensitive)
+//
+//	apiCall('GET', '/users')          → http::GET::/users
+//	client.request('POST', '/orders') → http::POST::/orders
+//	  (alias name carries no verb suffix → the first string literal is
+//	   read as the method when it is a bare HTTP verb, and the next
+//	   string literal is the path)
+//
+// When the alias name has no verb suffix and the first literal isn't an
+// HTTP verb, the method defaults to GET and the first string literal is
+// the path — matching the lenient default the built-in `fetch(url)`
+// pattern uses.
+
+// srcMentionsAnyAlias reports whether src textually mentions any
+// configured alias name (the bare tail of a dotted alias counts, so
+// `client.request` is detected via `request`). A cheap substring gate
+// that lets the prefilter keep an alias-only file alive without
+// widening the regex scan for everyone else.
+func srcMentionsAnyAlias(src []byte, aliases []string) bool {
+	for _, a := range aliases {
+		a = strings.TrimSpace(a)
+		if a == "" {
+			continue
+		}
+		if i := strings.LastIndex(a, "."); i >= 0 {
+			a = a[i+1:]
+		}
+		if a != "" && bytes.Contains(src, []byte(a)) {
+			return true
+		}
+	}
+	return false
+}
+
+// aliasVerbSuffixRe pulls a trailing HTTP verb off an alias name so
+// `apiGet` → GET, `fetchUsersPost` → POST. Anchored to the end and
+// case-insensitive; the verb must be the literal tail of the name.
+var aliasVerbSuffixRe = regexp.MustCompile(`(?i)(get|post|put|delete|patch|head|options)$`)
+
+// aliasMethodLiteralRe matches a bare HTTP verb string literal used as
+// the first argument of a generic alias like apiCall('GET', '/x').
+var aliasMethodLiteralRe = regexp.MustCompile(`(?i)^(get|post|put|delete|patch|head|options)$`)
+
+// detectClientAliasConsumers scans src for calls to any configured
+// client-alias function and returns one consumer contract per call.
+// The path is the first path-shaped string literal in the argument
+// list; the method comes from the alias name's verb suffix or, for
+// suffix-less aliases, a leading bare-verb literal argument.
+func (h *HTTPExtractor) detectClientAliasConsumers(
+	filePath string,
+	text string,
+	lines []string,
+	fileNodes []*graph.Node,
+	lang string,
+	tree *parser.ParseTree,
+) []Contract {
+	var out []Contract
+	seen := make(map[string]bool) // de-dupe (contractID, line) within the file
+
+	for _, alias := range h.ClientAliases {
+		alias = strings.TrimSpace(alias)
+		if alias == "" {
+			continue
+		}
+		re := aliasCallRegex(alias)
+		if re == nil {
+			continue
+		}
+		// The verb suffix is derived from the LAST dotted segment of
+		// the alias so `client.get` → GET while `client.request` →
+		// (none, generic two-arg form).
+		nameForVerb := alias
+		if i := strings.LastIndex(alias, "."); i >= 0 {
+			nameForVerb = alias[i+1:]
+		}
+		method := ""
+		if m := aliasVerbSuffixRe.FindString(nameForVerb); m != "" {
+			method = strings.ToUpper(m)
+		}
+
+		for _, m := range re.FindAllStringSubmatchIndex(text, -1) {
+			// m[2]:m[3] is the captured argument-list head (everything
+			// from the opening paren to a reasonable bound).
+			if len(m) < 4 || m[2] < 0 {
+				continue
+			}
+			args := text[m[2]:m[3]]
+			method, path, ok := aliasMethodAndPath(method, args)
+			if !ok {
+				continue
+			}
+			normPath, origNames := NormalizeHTTPPathWithParams(path)
+			contractID := fmt.Sprintf("http::%s::%s", method, normPath)
+
+			lineNum := lineAtOffset(lines, m[0])
+			dedupeKey := fmt.Sprintf("%s@%d", contractID, lineNum)
+			if seen[dedupeKey] {
+				continue
+			}
+			seen[dedupeKey] = true
+
+			meta := map[string]any{
+				"method":    method,
+				"path":      normPath,
+				"framework": "client-alias",
+				"alias":     alias,
+			}
+			if len(origNames) > 0 {
+				meta["path_param_names"] = origNames
+			}
+
+			c := Contract{
+				ID:         contractID,
+				Type:       ContractHTTP,
+				Role:       RoleConsumer,
+				SymbolID:   findEnclosingSymbol(fileNodes, lineNum),
+				FilePath:   filePath,
+				Line:       lineNum,
+				Meta:       meta,
+				Confidence: 0.85,
+			}
+			// Enrich request/response types from the call-site window
+			// just like a regex-detected consumer would.
+			EnrichHTTPContractWithTree(&c, lines, fileNodes, lang, tree)
+
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// aliasCallRegex compiles a matcher for a single alias name. The
+// capture group is the argument-list head: from the char after the
+// opening paren up to (but not including) the matching close paren or
+// the end of the line, bounded so a missing close paren can't run
+// away. Dotted aliases (`client.get`) match the literal receiver.method
+// form; bare aliases match a free-standing call, optionally preceded by
+// a non-identifier char so `myApiGet(` doesn't match alias `apiGet`.
+func aliasCallRegex(alias string) *regexp.Regexp {
+	// Escape each dotted segment, join with an escaped dot.
+	segs := strings.Split(alias, ".")
+	for i, s := range segs {
+		segs[i] = regexp.QuoteMeta(s)
+	}
+	pat := strings.Join(segs, `\.`)
+	// `(?:^|[^\w$.])` ensures we match a whole identifier — not a
+	// suffix of a longer name (apiGet ≠ myApiGet) and not a property
+	// access chain we didn't ask for. The capture stops at the first
+	// `)` or newline; nested parens inside an argument (rare for a
+	// path literal) would truncate the capture, which only loses the
+	// trailing args we don't read anyway.
+	full := `(?:^|[^\w$.])` + pat + `\(([^)\n]*)`
+	re, err := regexp.Compile(full)
+	if err != nil {
+		return nil
+	}
+	return re
+}
+
+// aliasStringLitRe captures consecutive string literals (single, double,
+// or backtick) from an argument-list head, in source order.
+var aliasStringLitRe = regexp.MustCompile("[\"'`]([^\"'`]*)[\"'`]")
+
+// aliasMethodAndPath resolves the (method, path) pair for one alias
+// call. nameMethod is the verb derived from the alias name (empty when
+// the name has no verb suffix). args is the captured argument-list head.
+//
+//   - nameMethod set: the first string literal is the path.
+//   - nameMethod empty: if the first literal is a bare HTTP verb it is
+//     the method and the second literal is the path
+//     (apiCall('GET', '/x')); otherwise method defaults to GET and the
+//     first literal is the path.
+//
+// Returns ok=false when no usable path literal is present (e.g. the
+// argument is a runtime variable, not a string literal).
+func aliasMethodAndPath(nameMethod, args string) (method, path string, ok bool) {
+	lits := aliasStringLitRe.FindAllStringSubmatch(args, -1)
+	if len(lits) == 0 {
+		return "", "", false
+	}
+	if nameMethod != "" {
+		return nameMethod, lits[0][1], true
+	}
+	// Suffix-less alias: try the (method, path) two-arg form.
+	if len(lits) >= 2 && aliasMethodLiteralRe.MatchString(strings.TrimSpace(lits[0][1])) {
+		return strings.ToUpper(strings.TrimSpace(lits[0][1])), lits[1][1], true
+	}
+	// Lenient default — first literal is the path, method GET.
+	return "GET", lits[0][1], true
+}

--- a/internal/contracts/http_alias_test.go
+++ b/internal/contracts/http_alias_test.go
@@ -1,0 +1,259 @@
+package contracts
+
+import (
+	"testing"
+)
+
+// TestHTTPExtractor_ClientAlias_NameSuffixMethod covers the primary
+// shape: a configured wrapper whose name ends in an HTTP verb
+// (apiGet/apiPost). The verb comes from the name suffix and the path
+// from the first string-literal argument, producing the canonical
+// http::METHOD::/path consumer contract the matcher pairs against
+// providers.
+func TestHTTPExtractor_ClientAlias_NameSuffixMethod(t *testing.T) {
+	src := []byte(`
+async function loadUsers() {
+  const users = await apiGet('/users');
+  await apiPost('/users', { name: 'x' });
+}
+`)
+	nodes := makeNodes("api.ts", []struct {
+		name       string
+		start, end int
+	}{
+		{"loadUsers", 2, 5},
+	})
+
+	ext := &HTTPExtractor{ClientAliases: []string{"apiGet", "apiPost"}}
+	contracts := ext.Extract("api.ts", src, nodes, nil)
+
+	byID := map[string]Contract{}
+	for _, c := range contracts {
+		byID[c.ID] = c
+	}
+
+	get, ok := byID["http::GET::/users"]
+	if !ok {
+		t.Fatalf("missing http::GET::/users; have: %v", keysOf(byID))
+	}
+	if get.Role != RoleConsumer {
+		t.Errorf("GET role = %s, want consumer", get.Role)
+	}
+	if get.Type != ContractHTTP {
+		t.Errorf("GET type = %s, want http", get.Type)
+	}
+	if get.Meta["framework"] != "client-alias" {
+		t.Errorf("GET framework = %v, want client-alias", get.Meta["framework"])
+	}
+	if get.Meta["alias"] != "apiGet" {
+		t.Errorf("GET alias = %v, want apiGet", get.Meta["alias"])
+	}
+	if get.SymbolID != "api.ts::loadUsers" {
+		t.Errorf("GET symbol = %q, want api.ts::loadUsers", get.SymbolID)
+	}
+
+	post, ok := byID["http::POST::/users"]
+	if !ok {
+		t.Fatalf("missing http::POST::/users; have: %v", keysOf(byID))
+	}
+	if post.Role != RoleConsumer {
+		t.Errorf("POST role = %s, want consumer", post.Role)
+	}
+	if post.Meta["method"] != "POST" {
+		t.Errorf("POST method = %v, want POST", post.Meta["method"])
+	}
+}
+
+// TestHTTPExtractor_ClientAlias_TwoArgMethodForm covers the generic
+// (method, path) two-arg form for a suffix-less alias: apiCall('GET',
+// '/users') and client.request('POST', '/orders'). The first literal is
+// read as the method, the second as the path.
+func TestHTTPExtractor_ClientAlias_TwoArgMethodForm(t *testing.T) {
+	src := []byte(`
+async function go() {
+  await apiCall('GET', '/users');
+  await client.request('POST', '/orders', body);
+}
+`)
+	nodes := makeNodes("client.ts", []struct {
+		name       string
+		start, end int
+	}{
+		{"go", 2, 5},
+	})
+
+	ext := &HTTPExtractor{ClientAliases: []string{"apiCall", "client.request"}}
+	contracts := ext.Extract("client.ts", src, nodes, nil)
+
+	byID := map[string]Contract{}
+	for _, c := range contracts {
+		byID[c.ID] = c
+	}
+
+	if c, ok := byID["http::GET::/users"]; !ok {
+		t.Errorf("missing http::GET::/users; have: %v", keysOf(byID))
+	} else if c.Role != RoleConsumer {
+		t.Errorf("GET role = %s, want consumer", c.Role)
+	}
+
+	if c, ok := byID["http::POST::/orders"]; !ok {
+		t.Errorf("missing http::POST::/orders; have: %v", keysOf(byID))
+	} else {
+		if c.Role != RoleConsumer {
+			t.Errorf("POST role = %s, want consumer", c.Role)
+		}
+		if c.Meta["alias"] != "client.request" {
+			t.Errorf("POST alias = %v, want client.request", c.Meta["alias"])
+		}
+	}
+}
+
+// TestHTTPExtractor_ClientAlias_ParametricPath asserts a template-literal
+// path with an inline placeholder normalises to the positional {p1}
+// form so the alias-derived consumer pairs with a provider's parametric
+// route ID — the whole point of the canonical scheme.
+func TestHTTPExtractor_ClientAlias_ParametricPath(t *testing.T) {
+	src := []byte("async function del(id) {\n" +
+		"  await apiDelete(`/users/${id}`);\n" +
+		"}\n")
+	nodes := makeNodes("api.ts", []struct {
+		name       string
+		start, end int
+	}{
+		{"del", 1, 3},
+	})
+
+	ext := &HTTPExtractor{ClientAliases: []string{"apiDelete"}}
+	contracts := ext.Extract("api.ts", src, nodes, nil)
+
+	byID := map[string]Contract{}
+	for _, c := range contracts {
+		byID[c.ID] = c
+	}
+	c, ok := byID["http::DELETE::/users/{p1}"]
+	if !ok {
+		t.Fatalf("missing http::DELETE::/users/{p1}; have: %v", keysOf(byID))
+	}
+	if c.Meta["path"] != "/users/{p1}" {
+		t.Errorf("path = %v, want /users/{p1}", c.Meta["path"])
+	}
+}
+
+// TestHTTPExtractor_ClientAlias_WholeIdentifierOnly guards against an
+// alias matching a longer identifier it's a suffix of: alias "apiGet"
+// must not fire on a call to "myApiGet". Only the exact whole-name call
+// counts.
+func TestHTTPExtractor_ClientAlias_WholeIdentifierOnly(t *testing.T) {
+	src := []byte(`
+function f() {
+  myApiGet('/should-not-match');
+  apiGet('/should-match');
+}
+`)
+	nodes := makeNodes("api.ts", []struct {
+		name       string
+		start, end int
+	}{
+		{"f", 2, 5},
+	})
+
+	ext := &HTTPExtractor{ClientAliases: []string{"apiGet"}}
+	contracts := ext.Extract("api.ts", src, nodes, nil)
+
+	byID := map[string]Contract{}
+	for _, c := range contracts {
+		byID[c.ID] = c
+	}
+	if _, ok := byID["http::GET::/should-not-match"]; ok {
+		t.Errorf("alias apiGet wrongly matched myApiGet; have: %v", keysOf(byID))
+	}
+	if _, ok := byID["http::GET::/should-match"]; !ok {
+		t.Errorf("alias apiGet missed the exact call; have: %v", keysOf(byID))
+	}
+}
+
+// TestHTTPExtractor_ClientAlias_Disabled confirms the alias pass is a
+// no-op when no aliases are configured — existing detection behaviour is
+// unchanged for a plain non-fetch/non-axios wrapper call.
+func TestHTTPExtractor_ClientAlias_Disabled(t *testing.T) {
+	src := []byte(`
+function f() {
+  apiGet('/users');
+}
+`)
+	nodes := makeNodes("api.ts", []struct {
+		name       string
+		start, end int
+	}{
+		{"f", 2, 4},
+	})
+
+	ext := &HTTPExtractor{} // no ClientAliases
+	contracts := ext.Extract("api.ts", src, nodes, nil)
+	for _, c := range contracts {
+		if c.Meta["framework"] == "client-alias" {
+			t.Errorf("alias pass ran with no aliases configured: %+v", c)
+		}
+	}
+}
+
+// TestHTTPExtractor_ClientAlias_PairsWithProvider is the end-to-end pin:
+// an alias-derived consumer in one repo pairs with a real provider in a
+// sibling repo because both mint the same http::GET::/users ID.
+func TestHTTPExtractor_ClientAlias_PairsWithProvider(t *testing.T) {
+	providerSrc := []byte(`package main
+
+import "net/http"
+
+func wire(mux *http.ServeMux, h *Handler) {
+	mux.HandleFunc("GET /users", h.ListUsers)
+}
+`)
+	providerNodes := makeNodes("server.go", []struct {
+		name       string
+		start, end int
+	}{
+		{"wire", 5, 7},
+	})
+
+	consumerSrc := []byte(`
+async function loadUsers() {
+  return apiGet('/users');
+}
+`)
+	consumerNodes := makeNodes("api.ts", []struct {
+		name       string
+		start, end int
+	}{
+		{"loadUsers", 2, 4},
+	})
+
+	prov := (&HTTPExtractor{}).Extract("server.go", providerSrc, providerNodes, nil)
+	cons := (&HTTPExtractor{ClientAliases: []string{"apiGet"}}).Extract("api.ts", consumerSrc, consumerNodes, nil)
+
+	reg := NewRegistry()
+	for _, c := range prov {
+		c.RepoPrefix, c.WorkspaceID, c.ProjectID = "core", "ws", "ws"
+		reg.Add(c)
+	}
+	for _, c := range cons {
+		c.RepoPrefix, c.WorkspaceID, c.ProjectID = "web", "ws", "ws"
+		reg.Add(c)
+	}
+
+	result := Match(reg)
+	var paired *CrossLink
+	for i, m := range result.Matched {
+		if m.ContractID == "http::GET::/users" {
+			paired = &result.Matched[i]
+			break
+		}
+	}
+	if paired == nil {
+		t.Fatalf("expected http::GET::/users pair; matched=%d orphan_p=%d orphan_c=%d",
+			len(result.Matched), len(result.OrphanProviders), len(result.OrphanConsumers))
+	}
+	if !paired.CrossRepo {
+		t.Errorf("expected CrossRepo=true (provider core, consumer web)")
+	}
+}

--- a/internal/contracts/route_prefix.go
+++ b/internal/contracts/route_prefix.go
@@ -1,0 +1,564 @@
+package contracts
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Cross-file route-prefix joining for HTTP contract IDs.
+//
+// A sub-router is frequently declared in one file and *mounted* under a
+// path prefix in another. The route the sub-router declares should be
+// recorded with the joined path so a provider and a consumer agree on
+// the same canonical contract ID:
+//
+//	# users.py
+//	router = APIRouter(prefix="/users")
+//	@router.get("/{id}")            # declared path: /{id}
+//	def get_user(id): ...
+//
+//	# main.py
+//	app.include_router(router, prefix="/api")
+//
+// Without this pass the provider emits http::GET::/{p1}; the consumer
+// calling /api/users/42 emits http::GET::/api/users/{p1}; the two never
+// pair. JoinRouterPrefixes rewrites the provider to
+// http::GET::/api/users/{p1} so the matcher sees the same ID on both
+// sides.
+//
+// Coverage:
+//   - FastAPI (full): APIRouter(prefix=...) self-prefix + cross-file
+//     include_router(var, prefix=...) mounts, including nested includes
+//     (a router included into an already-included router → prefixes
+//     chain) and a missing prefix (no-op join).
+//   - Express (partial): app.use('/api', router) mounts joined onto
+//     routes declared on a receiver named app/router. Limited by the
+//     existing express regex, which only recognises those two receiver
+//     names.
+//   - NestJS (partial): @Controller('cats') class prefix joined onto
+//     the class's @Get('x') routes (single-file). Cross-module
+//     RouterModule.register prefixes are out of scope.
+//
+// The pass is idempotent: a contract already stamped joined is skipped,
+// so a re-run (incremental reindex) never double-joins.
+
+// routePrefixJoinedMeta marks a contract whose path/ID this pass has
+// already rewritten, so a second run is a no-op.
+const routePrefixJoinedMeta = "route_prefix_joined"
+
+// Frameworks whose routes participate in prefix joining. The HTTP
+// extractor stamps Meta["framework"] with these values.
+var routePrefixFrameworks = map[string]bool{
+	"fastapi/flask": true, // FastAPI APIRouter / include_router
+	"express":       true, // Express app.use mounts
+	"nestjs":        true, // NestJS @Controller class prefix
+}
+
+// --- FastAPI / Python -------------------------------------------------------
+
+// pyRouterDefRE matches a router variable bound to an APIRouter that
+// carries its own prefix, e.g. `router = APIRouter(prefix="/users")` or
+// `users_router = APIRouter(prefix='/users', tags=[...])`. Group 1 is
+// the variable name, group 2 the prefix.
+var pyRouterDefRE = regexp.MustCompile(`(\w+)\s*=\s*APIRouter\(([^)]*)\)`)
+
+// pyIncludeRouterRE matches a mount site, e.g.
+// `app.include_router(router, prefix="/api")` or
+// `parent.include_router(users.router, prefix='/api')`. Group 1 is the
+// mounted router reference (possibly attribute-qualified), group 2 the
+// argument list (scanned for prefix=).
+var pyIncludeRouterRE = regexp.MustCompile(`\binclude_router\(\s*([\w.]+)\s*((?:,[^)]*)?)\)`)
+
+// prefixKwargRE pulls prefix="..." out of a keyword-argument list.
+var prefixKwargRE = regexp.MustCompile(`prefix\s*=\s*["']([^"']*)["']`)
+
+// pyRouteReceiverRE recovers the decorator receiver variable from a
+// FastAPI route line, e.g. `@router.get("/{id}")` → "router". Anchored
+// to the start-of-line decorator form the Python provider pattern uses.
+var pyRouteReceiverRE = regexp.MustCompile(`@(\w+)\.(?:get|post|put|delete|patch|head|options)\(`)
+
+// --- Express / TS-JS --------------------------------------------------------
+
+// jsUseMountRE matches `app.use('/api', router)` /
+// `router.use("/v1", sub)`. Group 1 is the mount prefix, group 2 the
+// mounted router variable. A `.use('/api', fn1, fn2, router)` form
+// (middleware chain) is not handled — only the two-argument shape.
+var jsUseMountRE = regexp.MustCompile(`\b(\w+)\.use\(\s*["'` + "`" + `]([^"'` + "`" + `]+)["'` + "`" + `]\s*,\s*(\w+)\s*\)`)
+
+// jsRouteReceiverRE recovers the receiver from an express route line,
+// e.g. `router.get('/users', h)` → "router". Mirrors the express
+// provider pattern's (?:app|router) anchor.
+var jsRouteReceiverRE = regexp.MustCompile(`\b(app|router)\.(?:get|post|put|delete|patch|head|options|all)\(`)
+
+// --- NestJS -----------------------------------------------------------------
+
+// nestControllerRE matches a class-level `@Controller('cats')` /
+// `@Controller("/cats")` decorator. Group 1 is the class prefix. An
+// argument-less `@Controller()` carries no prefix (no-op).
+var nestControllerRE = regexp.MustCompile(`@Controller\(\s*["'` + "`" + `]([^"'` + "`" + `]*)["'` + "`" + `]\s*\)`)
+
+// JoinRouterPrefixes rewrites HTTP provider/consumer contract paths and
+// IDs to include the prefix at their router's mount site.
+//
+// scanFiles is the universe of source files to scan for router
+// definitions and mount sites (APIRouter(prefix=...), include_router,
+// app.use). This must include the *mount* files, which frequently carry
+// no route contracts of their own (a FastAPI main.py with only
+// include_router calls) — so the file set cannot be derived from the
+// contract registry alone. The route contracts being rewritten still
+// come from reg.
+//
+// srcFor returns the raw source bytes for a file path (as stored on the
+// contract / in scanFiles — i.e. repo-prefixed when the indexer uses a
+// repo prefix); returning nil for a path skips files that can't be read.
+// The pass mutates the registry in place via ReplaceByID.
+func JoinRouterPrefixes(reg *Registry, scanFiles []string, srcFor func(filePath string) []byte) {
+	if reg == nil || srcFor == nil {
+		return
+	}
+
+	// Per-file router facts, keyed by file path. Parsed once per file.
+	type fileFacts struct {
+		// selfPrefix: router var -> the prefix it declares on itself
+		// (APIRouter(prefix=...)). FastAPI only.
+		selfPrefix map[string]string
+		// mountPrefix: router var -> the prefix it is mounted under at
+		// an include_router / app.use site (may live in another file).
+		mountPrefix map[string]string
+		// mountChild: parent router var -> child router var it mounts,
+		// so nested includes can chain prefixes.
+		mountParent map[string]string
+	}
+
+	files := make(map[string]*fileFacts)
+	parseFile := func(filePath string) *fileFacts {
+		if f, ok := files[filePath]; ok {
+			return f
+		}
+		f := &fileFacts{
+			selfPrefix:  map[string]string{},
+			mountPrefix: map[string]string{},
+			mountParent: map[string]string{},
+		}
+		files[filePath] = f
+		src := srcFor(filePath)
+		if src == nil {
+			return f
+		}
+		text := string(src)
+
+		// FastAPI: router = APIRouter(prefix="/users")
+		for _, m := range pyRouterDefRE.FindAllStringSubmatch(text, -1) {
+			varName := m[1]
+			if pm := prefixKwargRE.FindStringSubmatch(m[2]); pm != nil {
+				f.selfPrefix[varName] = cleanPrefix(pm[1])
+			} else {
+				// APIRouter() with no prefix still registers the var so
+				// a later mount join knows it exists (no-op self-prefix).
+				if _, ok := f.selfPrefix[varName]; !ok {
+					f.selfPrefix[varName] = ""
+				}
+			}
+		}
+
+		// FastAPI: app.include_router(router, prefix="/api")
+		for _, m := range pyIncludeRouterRE.FindAllStringSubmatch(text, -1) {
+			child := lastAttr(m[1])
+			prefix := ""
+			if pm := prefixKwargRE.FindStringSubmatch(m[2]); pm != nil {
+				prefix = cleanPrefix(pm[1])
+			}
+			// A router can be mounted once; if seen twice keep the
+			// first (deterministic).
+			if _, ok := f.mountPrefix[child]; !ok {
+				f.mountPrefix[child] = prefix
+			}
+			// Record the mount receiver as the parent so nested
+			// includes chain (parent.include_router(child, ...)).
+			parent := receiverOfInclude(text, m[0])
+			if parent != "" && parent != child {
+				f.mountParent[child] = parent
+			}
+		}
+
+		// Express: app.use('/api', router)
+		for _, m := range jsUseMountRE.FindAllStringSubmatch(text, -1) {
+			parent, prefix, child := m[1], cleanPrefix(m[2]), m[3]
+			if _, ok := f.mountPrefix[child]; !ok {
+				f.mountPrefix[child] = prefix
+			}
+			if parent != "" && parent != child {
+				f.mountParent[child] = parent
+			}
+		}
+
+		return f
+	}
+
+	// Global maps merged across every contract file. Router var names
+	// commonly collide ("router"), so cross-file resolution is
+	// best-effort within a workspace: when exactly one file declares a
+	// self-prefix or mount for a var, use it. This favours the common
+	// monorepo / single-service layout the feature targets.
+	globalSelf := map[string]string{}    // var -> self prefix (FastAPI)
+	globalMount := map[string]string{}   // var -> mount prefix
+	globalParent := map[string]string{}  // var -> parent router var
+	selfConflict := map[string]bool{}    // var seen with >1 distinct self prefix
+	mountConflict := map[string]bool{}   // var seen with >1 distinct mount prefix
+
+	// First pass: parse every scan file plus every route-contract file
+	// (union) and merge router facts. Mount files (a FastAPI main.py
+	// that only calls include_router) carry no route contracts, so they
+	// must be reached via scanFiles; route-contract files supply the
+	// APIRouter(prefix=...) self-prefixes.
+	factFiles := make(map[string]bool, len(scanFiles))
+	for _, p := range scanFiles {
+		factFiles[p] = true
+	}
+	for _, c := range reg.All() {
+		if c.Type != ContractHTTP {
+			continue
+		}
+		fw, _ := c.Meta["framework"].(string)
+		if !routePrefixFrameworks[fw] {
+			continue
+		}
+		factFiles[c.FilePath] = true
+	}
+	for path := range factFiles {
+		f := parseFile(path)
+		for v, p := range f.selfPrefix {
+			if existing, ok := globalSelf[v]; ok {
+				if existing != p && existing != "" && p != "" {
+					selfConflict[v] = true
+				}
+				if existing == "" && p != "" {
+					globalSelf[v] = p
+				}
+			} else {
+				globalSelf[v] = p
+			}
+		}
+		for v, p := range f.mountPrefix {
+			if existing, ok := globalMount[v]; ok {
+				if existing != p {
+					mountConflict[v] = true
+				}
+			} else {
+				globalMount[v] = p
+			}
+		}
+		for child, parent := range f.mountParent {
+			if _, ok := globalParent[child]; !ok {
+				globalParent[child] = parent
+			}
+		}
+	}
+
+	// chainPrefix resolves the full mount prefix for a router var,
+	// walking parent includes so a router mounted into a router
+	// inherits both prefixes. Self-prefix is the router's own
+	// APIRouter(prefix=...); it is prepended by the per-route join, not
+	// here, because only the route's owning router contributes its self
+	// prefix.
+	var chainPrefix func(varName string, seen map[string]bool) string
+	chainPrefix = func(varName string, seen map[string]bool) string {
+		if seen[varName] {
+			return "" // cycle guard
+		}
+		seen[varName] = true
+		mount := ""
+		if mp, ok := globalMount[varName]; ok && !mountConflict[varName] {
+			mount = mp
+		}
+		// The parent router's own mount prefix prepends this one. The
+		// parent's *self* prefix also applies, since the parent is a
+		// real router whose routes sit under parentSelf+parentMount.
+		if parent, ok := globalParent[varName]; ok {
+			parentChain := chainPrefix(parent, seen)
+			parentSelf := ""
+			if ps, ok := globalSelf[parent]; ok && !selfConflict[parent] {
+				parentSelf = ps
+			}
+			return joinPaths(parentChain, parentSelf, mount)
+		}
+		return mount
+	}
+
+	// Second pass: rewrite each route contract.
+	type rewrite struct {
+		oldID string
+		list  []Contract
+	}
+	var rewrites []rewrite
+	processed := map[string]bool{} // contract ID -> already collected
+
+	for _, c := range reg.All() {
+		if c.Type != ContractHTTP || c.Meta == nil {
+			continue
+		}
+		fw, _ := c.Meta["framework"].(string)
+		if !routePrefixFrameworks[fw] {
+			continue
+		}
+		// Idempotency: skip contracts already joined.
+		if joined, _ := c.Meta[routePrefixJoinedMeta].(bool); joined {
+			continue
+		}
+		if processed[c.ID] {
+			continue
+		}
+
+		prefix := prefixForRoute(c, fw, srcFor, globalSelf, globalMount, selfConflict, mountConflict, chainPrefix)
+		if prefix == "" {
+			continue
+		}
+
+		// Rewrite every contract entry recorded for this ID (provider
+		// and any same-ID consumer) consistently.
+		items := reg.ByID(c.ID)
+		changed := false
+		for i := range items {
+			if items[i].Type != ContractHTTP || items[i].Meta == nil {
+				continue
+			}
+			ifw, _ := items[i].Meta["framework"].(string)
+			if !routePrefixFrameworks[ifw] {
+				continue
+			}
+			if joined, _ := items[i].Meta[routePrefixJoinedMeta].(bool); joined {
+				continue
+			}
+			rp := prefixForRoute(items[i], ifw, srcFor, globalSelf, globalMount, selfConflict, mountConflict, chainPrefix)
+			if rp == "" {
+				continue
+			}
+			rawPath, _ := items[i].Meta["path"].(string)
+			joinedRaw := joinPaths(rp, rawPath)
+			newPath, names := NormalizeHTTPPathWithParams(joinedRaw)
+			method, _ := items[i].Meta["method"].(string)
+			if method == "" {
+				method = "ANY"
+			}
+			newID := fmt.Sprintf("http::%s::%s", method, newPath)
+			// Clone the Meta map before mutating: ByID returns value
+			// copies whose Meta maps still alias the registry's other
+			// secondary indexes (maps are reference types). Mutating in
+			// place would leak the rewrite into stale index entries
+			// before ReplaceByID purges them.
+			items[i].Meta = cloneMeta(items[i].Meta)
+			if newID == items[i].ID {
+				// Already canonical (prefix was empty after norm).
+				items[i].Meta[routePrefixJoinedMeta] = true
+				changed = true
+				continue
+			}
+			items[i].ID = newID
+			items[i].Meta["path"] = newPath
+			if len(names) > 0 {
+				items[i].Meta["path_param_names"] = names
+			}
+			items[i].Meta[routePrefixJoinedMeta] = true
+			changed = true
+		}
+		if changed {
+			processed[c.ID] = true
+			rewrites = append(rewrites, rewrite{oldID: c.ID, list: items})
+		}
+	}
+
+	// Apply rewrites. ReplaceByID keys the byID bucket on the OLD id,
+	// so it can't be used directly when the rewrite *changes* the ID
+	// (it would file the new contract under the stale key and the
+	// matcher, which buckets on the byID key, would never pair it).
+	// Instead clear the old bucket (purging every secondary index) and
+	// re-Add each contract under its own — possibly rewritten — ID.
+	for _, rw := range rewrites {
+		reg.ReplaceByID(rw.oldID, nil)
+		for _, c := range rw.list {
+			reg.Add(c)
+		}
+	}
+}
+
+// prefixForRoute computes the full joined prefix (mount chain + the
+// route's own router self-prefix, or NestJS controller prefix) to
+// prepend to a single route contract's declared path. Returns "" when
+// no prefix applies (plain join no-op).
+func prefixForRoute(
+	c Contract,
+	framework string,
+	srcFor func(filePath string) []byte,
+	globalSelf, globalMount map[string]string,
+	selfConflict, mountConflict map[string]bool,
+	chainPrefix func(string, map[string]bool) string,
+) string {
+	switch framework {
+	case "fastapi/flask", "express":
+		varName := routeReceiver(c, framework, srcFor)
+		if varName == "" {
+			return ""
+		}
+		mount := chainPrefix(varName, map[string]bool{})
+		self := ""
+		if framework == "fastapi/flask" {
+			if ps, ok := globalSelf[varName]; ok && !selfConflict[varName] {
+				self = ps
+			}
+		}
+		return joinPaths(mount, self)
+	case "nestjs":
+		// Class-level @Controller('cats') prefix, found by scanning
+		// upward from the route line for the nearest preceding
+		// decorator in the same file.
+		return nestControllerPrefix(c, srcFor)
+	}
+	return ""
+}
+
+// routeReceiver recovers the router/app variable a route was declared
+// on, by re-reading the contract's source line. Returns "" when the
+// line can't be read or no receiver is found.
+func routeReceiver(c Contract, framework string, srcFor func(filePath string) []byte) string {
+	line := sourceLine(srcFor(c.FilePath), c.Line)
+	if line == "" {
+		return ""
+	}
+	switch framework {
+	case "fastapi/flask":
+		if m := pyRouteReceiverRE.FindStringSubmatch(line); m != nil {
+			return m[1]
+		}
+	case "express":
+		if m := jsRouteReceiverRE.FindStringSubmatch(line); m != nil {
+			return m[1]
+		}
+	}
+	return ""
+}
+
+// nestControllerPrefix scans upward from a NestJS route line for the
+// nearest @Controller('prefix') decorator (its enclosing class) and
+// returns that prefix, or "" when the controller carries none.
+func nestControllerPrefix(c Contract, srcFor func(filePath string) []byte) string {
+	src := srcFor(c.FilePath)
+	if src == nil {
+		return ""
+	}
+	lines := strings.Split(string(src), "\n")
+	idx := c.Line - 1 // contract lines are 1-based
+	if idx < 0 || idx >= len(lines) {
+		return ""
+	}
+	for i := idx; i >= 0; i-- {
+		if m := nestControllerRE.FindStringSubmatch(lines[i]); m != nil {
+			return cleanPrefix(m[1])
+		}
+	}
+	return ""
+}
+
+// sourceLine returns the 1-based line `n` from src, or "".
+func sourceLine(src []byte, n int) string {
+	if src == nil || n < 1 {
+		return ""
+	}
+	lines := strings.Split(string(src), "\n")
+	if n > len(lines) {
+		return ""
+	}
+	return lines[n-1]
+}
+
+// receiverOfInclude returns the receiver variable in front of an
+// `.include_router(` call given the matched fragment, e.g. for
+// `parent.include_router(child, ...)` returns "parent". Returns "" for
+// a bare `include_router(...)` (an imported function call with no
+// receiver) — those default to the implicit app and don't chain.
+func receiverOfInclude(text, fragment string) string {
+	i := strings.Index(text, fragment)
+	if i <= 0 {
+		return ""
+	}
+	// Walk backwards over the receiver expression: <recv>.include_router
+	j := i
+	// Skip a leading '.' if the fragment started at include_router.
+	if j > 0 && text[j-1] == '.' {
+		j--
+	}
+	end := j
+	for j > 0 {
+		ch := text[j-1]
+		if isIdentByte(ch) || ch == '.' {
+			j--
+			continue
+		}
+		break
+	}
+	recv := text[j:end]
+	return lastAttr(recv)
+}
+
+func isIdentByte(b byte) bool {
+	return b == '_' ||
+		(b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9')
+}
+
+// lastAttr returns the final attribute of a dotted reference, e.g.
+// "users.router" -> "router", "router" -> "router".
+func lastAttr(ref string) string {
+	if i := strings.LastIndex(ref, "."); i >= 0 {
+		return ref[i+1:]
+	}
+	return ref
+}
+
+// cloneMeta returns a shallow copy of a contract Meta map so a rewrite
+// doesn't mutate the map still aliased by the registry's other indexes.
+func cloneMeta(m map[string]any) map[string]any {
+	out := make(map[string]any, len(m)+1)
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+// cleanPrefix normalises a raw prefix string: trims surrounding
+// whitespace, drops a trailing slash, and ensures it is either empty or
+// starts with a slash. "/api/" -> "/api"; "api" -> "/api"; "" -> "".
+func cleanPrefix(p string) string {
+	p = strings.TrimSpace(p)
+	if p == "" || p == "/" {
+		return ""
+	}
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	p = strings.TrimRight(p, "/")
+	return p
+}
+
+// joinPaths concatenates path segments, skipping empties and collapsing
+// duplicate slashes. joinPaths("/api", "/users", "/{id}") ->
+// "/api/users/{id}"; joinPaths("", "/users") -> "/users".
+func joinPaths(parts ...string) string {
+	var b strings.Builder
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if !strings.HasPrefix(p, "/") {
+			p = "/" + p
+		}
+		p = strings.TrimRight(p, "/")
+		b.WriteString(p)
+	}
+	if b.Len() == 0 {
+		return ""
+	}
+	return b.String()
+}

--- a/internal/contracts/route_prefix_test.go
+++ b/internal/contracts/route_prefix_test.go
@@ -1,0 +1,320 @@
+package contracts
+
+import (
+	"testing"
+)
+
+// srcMap drives JoinRouterPrefixes directly: a file-path -> source map
+// standing in for the indexer's disk reader. The pass is exercised
+// without any graph / disk dependency.
+type srcMap map[string]string
+
+func (m srcMap) reader() func(string) []byte {
+	return func(p string) []byte {
+		s, ok := m[p]
+		if !ok {
+			return nil
+		}
+		return []byte(s)
+	}
+}
+
+// paths returns every file path in the map — the scan-file universe
+// JoinRouterPrefixes consumes (mount files included, which carry no
+// route contracts).
+func (m srcMap) paths() []string {
+	out := make([]string, 0, len(m))
+	for p := range m {
+		out = append(out, p)
+	}
+	return out
+}
+
+// extractInto runs the HTTP extractor over each file in the map and adds
+// every contract to reg with the given repo/workspace scope, so the
+// contracts carry real framework meta and normalised paths.
+func extractInto(t *testing.T, reg *Registry, files srcMap, repo, ws string) {
+	t.Helper()
+	ext := &HTTPExtractor{}
+	for path, src := range files {
+		for _, c := range ext.Extract(path, []byte(src), nil, nil) {
+			c.RepoPrefix = repo
+			c.WorkspaceID = ws
+			c.ProjectID = ws
+			reg.Add(c)
+		}
+	}
+}
+
+func idSet(reg *Registry) map[string]bool {
+	out := map[string]bool{}
+	for _, c := range reg.All() {
+		out[c.ID] = true
+	}
+	return out
+}
+
+// TestJoinRouterPrefixes_FastAPI_CrossFile is the primary target: a
+// router declared with its own prefix in users.py, mounted under a
+// second prefix in main.py. The route @router.get("/{id}") must land at
+// http::GET::/api/users/{p1}.
+func TestJoinRouterPrefixes_FastAPI_CrossFile(t *testing.T) {
+	files := srcMap{
+		"users.py": `
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/users")
+
+@router.get("/{id}")
+def get_user(id: int):
+    return id
+
+@router.get("/")
+def list_users():
+    return []
+`,
+		"main.py": `
+from fastapi import FastAPI
+from .users import router
+
+app = FastAPI()
+app.include_router(router, prefix="/api")
+`,
+	}
+
+	reg := NewRegistry()
+	extractInto(t, reg, files, "svc", "svc")
+
+	JoinRouterPrefixes(reg, files.paths(), files.reader())
+
+	ids := idSet(reg)
+	if !ids["http::GET::/api/users/{p1}"] {
+		t.Errorf("expected joined provider http::GET::/api/users/{p1}; got %v", keysOfBool(ids))
+	}
+	if !ids["http::GET::/api/users"] {
+		t.Errorf("expected joined provider http::GET::/api/users (from /); got %v", keysOfBool(ids))
+	}
+	// The un-joined originals must be gone.
+	if ids["http::GET::/{p1}"] {
+		t.Errorf("un-joined original http::GET::/{p1} still present: %v", keysOfBool(ids))
+	}
+}
+
+// TestJoinRouterPrefixes_FastAPI_Idempotent runs the pass twice; the
+// second run must be a no-op (no double-join to /api/api/users).
+func TestJoinRouterPrefixes_FastAPI_Idempotent(t *testing.T) {
+	files := srcMap{
+		"users.py": `router = APIRouter(prefix="/users")
+
+@router.get("/{id}")
+def get_user(id): return id
+`,
+		"main.py": `app.include_router(router, prefix="/api")`,
+	}
+	reg := NewRegistry()
+	extractInto(t, reg, files, "svc", "svc")
+
+	JoinRouterPrefixes(reg, files.paths(), files.reader())
+	JoinRouterPrefixes(reg, files.paths(), files.reader())
+
+	ids := idSet(reg)
+	if !ids["http::GET::/api/users/{p1}"] {
+		t.Errorf("expected http::GET::/api/users/{p1} after double run; got %v", keysOfBool(ids))
+	}
+	if ids["http::GET::/api/api/users/{p1}"] {
+		t.Errorf("double-join detected: %v", keysOfBool(ids))
+	}
+}
+
+// TestJoinRouterPrefixes_FastAPI_NestedIncludes chains prefixes: a
+// sub-router is included into a parent router, which is itself included
+// into the app. /v2 (app mount) + /admin (parent self) ... actually the
+// chain is app.include_router(parent, prefix="/api") and
+// parent.include_router(child, prefix="/admin"), child=APIRouter(prefix="/users").
+// Route @child.get("/{id}") -> /api/admin/users/{id}.
+func TestJoinRouterPrefixes_FastAPI_NestedIncludes(t *testing.T) {
+	files := srcMap{
+		"users.py": `child = APIRouter(prefix="/users")
+
+@child.get("/{id}")
+def get_user(id): return id
+`,
+		"admin.py": `parent = APIRouter()
+parent.include_router(child, prefix="/admin")
+`,
+		"main.py": `app.include_router(parent, prefix="/api")`,
+	}
+	reg := NewRegistry()
+	extractInto(t, reg, files, "svc", "svc")
+
+	JoinRouterPrefixes(reg, files.paths(), files.reader())
+
+	ids := idSet(reg)
+	if !ids["http::GET::/api/admin/users/{p1}"] {
+		t.Errorf("expected chained http::GET::/api/admin/users/{p1}; got %v", keysOfBool(ids))
+	}
+}
+
+// TestJoinRouterPrefixes_FastAPI_NoPrefix: a router with no self-prefix
+// mounted with no prefix is a no-op join — the ID stays as declared.
+func TestJoinRouterPrefixes_FastAPI_NoPrefix(t *testing.T) {
+	files := srcMap{
+		"users.py": `router = APIRouter()
+
+@router.get("/users/{id}")
+def get_user(id): return id
+`,
+		"main.py": `app.include_router(router)`,
+	}
+	reg := NewRegistry()
+	extractInto(t, reg, files, "svc", "svc")
+
+	JoinRouterPrefixes(reg, files.paths(), files.reader())
+
+	ids := idSet(reg)
+	if !ids["http::GET::/users/{p1}"] {
+		t.Errorf("no-prefix join should leave http::GET::/users/{p1}; got %v", keysOfBool(ids))
+	}
+}
+
+// TestJoinRouterPrefixes_FastAPI_SelfPrefixOnly: router carries a
+// prefix but is never mounted under another (or mounted with no
+// prefix). The self-prefix still applies.
+func TestJoinRouterPrefixes_FastAPI_SelfPrefixOnly(t *testing.T) {
+	files := srcMap{
+		"users.py": `router = APIRouter(prefix="/users")
+
+@router.get("/{id}")
+def get_user(id): return id
+`,
+		"main.py": `app.include_router(router)`,
+	}
+	reg := NewRegistry()
+	extractInto(t, reg, files, "svc", "svc")
+
+	JoinRouterPrefixes(reg, files.paths(), files.reader())
+
+	ids := idSet(reg)
+	if !ids["http::GET::/users/{p1}"] {
+		t.Errorf("self-prefix-only should yield http::GET::/users/{p1}; got %v", keysOfBool(ids))
+	}
+}
+
+// TestJoinRouterPrefixes_ConsumerPairsViaMatch is the end-to-end pin:
+// after the join, a consumer calling /api/users/42 (full path) pairs
+// with the rewritten provider via Match.
+func TestJoinRouterPrefixes_ConsumerPairsViaMatch(t *testing.T) {
+	providerFiles := srcMap{
+		"users.py": `router = APIRouter(prefix="/users")
+
+@router.get("/{id}")
+def get_user(id): return id
+`,
+		"main.py": `app.include_router(router, prefix="/api")`,
+	}
+	reg := NewRegistry()
+	extractInto(t, reg, providerFiles, "api", "shop")
+
+	// Consumer in a sibling repo of the same workspace calls the full
+	// joined path. Consumer paths are never prefix-joined (they already
+	// carry the mount prefix), so this is added as-is.
+	consumerSrc := `async function getUser(id) {
+  return fetch(` + "`/api/users/${id}`" + `);
+}
+`
+	ext := &HTTPExtractor{}
+	for _, c := range ext.Extract("api.ts", []byte(consumerSrc), nil, nil) {
+		c.RepoPrefix = "web"
+		c.WorkspaceID = "shop"
+		c.ProjectID = "shop"
+		reg.Add(c)
+	}
+
+	JoinRouterPrefixes(reg, providerFiles.paths(), providerFiles.reader())
+
+	result := Match(reg)
+	var paired *CrossLink
+	for i, m := range result.Matched {
+		if m.ContractID == "http::GET::/api/users/{p1}" {
+			paired = &result.Matched[i]
+			break
+		}
+	}
+	if paired == nil {
+		t.Fatalf("expected http::GET::/api/users/{p1} pair; matched=%d orphan_prov=%d orphan_cons=%d",
+			len(result.Matched), len(result.OrphanProviders), len(result.OrphanConsumers))
+	}
+	if !paired.CrossRepo {
+		t.Errorf("expected CrossRepo=true (provider api, consumer web)")
+	}
+	if paired.Provider.RepoPrefix != "api" || paired.Consumer.RepoPrefix != "web" {
+		t.Errorf("wrong wiring: provider=%s consumer=%s",
+			paired.Provider.RepoPrefix, paired.Consumer.RepoPrefix)
+	}
+}
+
+// TestJoinRouterPrefixes_Express joins an app.use('/api', router) mount
+// onto a route declared on that router in a sibling file.
+func TestJoinRouterPrefixes_Express(t *testing.T) {
+	files := srcMap{
+		"routes.ts": `
+const router = express.Router();
+router.get('/users/:id', getUser);
+`,
+		"app.ts": `
+const app = express();
+app.use('/api', router);
+`,
+	}
+	reg := NewRegistry()
+	extractInto(t, reg, files, "svc", "svc")
+
+	JoinRouterPrefixes(reg, files.paths(), files.reader())
+
+	ids := idSet(reg)
+	if !ids["http::GET::/api/users/{p1}"] {
+		t.Errorf("expected express-joined http::GET::/api/users/{p1}; got %v", keysOfBool(ids))
+	}
+}
+
+// TestJoinRouterPrefixes_NestJS joins a @Controller('cats') class
+// prefix onto the class's @Get(':id') method route (single file).
+func TestJoinRouterPrefixes_NestJS(t *testing.T) {
+	files := srcMap{
+		"cats.controller.ts": `
+@Controller('cats')
+export class CatsController {
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return id;
+  }
+
+  @Post('bulk')
+  createBulk() {
+    return 'created';
+  }
+}
+`,
+	}
+	reg := NewRegistry()
+	extractInto(t, reg, files, "svc", "svc")
+
+	JoinRouterPrefixes(reg, files.paths(), files.reader())
+
+	ids := idSet(reg)
+	if !ids["http::GET::/cats/{p1}"] {
+		t.Errorf("expected nestjs-joined http::GET::/cats/{p1}; got %v", keysOfBool(ids))
+	}
+	if !ids["http::POST::/cats/bulk"] {
+		t.Errorf("expected nestjs-joined http::POST::/cats/bulk; got %v", keysOfBool(ids))
+	}
+}
+
+// keysOfBool returns the keys of a string->bool set for diagnostics.
+func keysOfBool(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/graph/edge.go
+++ b/internal/graph/edge.go
@@ -520,6 +520,14 @@ type Edge struct {
 	// dataflow encoders; empty by default on the in-memory edge.
 	Tier      string `json:"tier,omitempty"`
 	CrossRepo bool   `json:"cross_repo,omitempty"`
+	// Context is the per-reference role a usage plays relative to the
+	// target symbol — parameter_type, return_type, field, value, type,
+	// attribute, generic_arg, or call. Empty on the stored edge; populated
+	// on demand by RefContextOf when find_usages classifies a usage, so
+	// agents can filter references by how they use the symbol
+	// (`find_usages context:"parameter_type"`). Not part of the edge
+	// identity / dedup key.
+	Context string `json:"context,omitempty"`
 	// Meta is intentionally excluded from JSON. It holds internal
 	// instrumentation (semantic_source, provider hints, etc.) that agents
 	// don't consume but that adds measurable bytes to every edge in
@@ -719,6 +727,71 @@ func ProvenanceWeight(e *Edge) float64 {
 		return ProvenanceWeightMin
 	}
 	return provWeightASTInferred
+}
+
+// Reference-context labels — the role a usage plays relative to the
+// symbol it references. Mirrors graphify's REFERENCE_CONTEXTS so
+// find_usages can filter "show me only the places this type is used as a
+// parameter / return type / field …".
+const (
+	RefContextParameterType = "parameter_type"
+	RefContextReturnType    = "return_type"
+	RefContextField         = "field"
+	RefContextValue         = "value"
+	RefContextType          = "type"
+	RefContextAttribute     = "attribute"
+	RefContextGenericArg    = "generic_arg"
+	RefContextCall          = "call"
+)
+
+// RefContextOf classifies the reference context of an edge given the kind
+// of its origin (usage-site) node. An extractor-stamped
+// Meta["ref_context"] always wins (it lets a language extractor mark a
+// context the structure alone can't reveal — e.g. generic_arg). Otherwise
+// the context is derived from the edge kind plus the origin node kind,
+// which Gortex's edge model already distinguishes:
+//
+//   - returns → return_type
+//   - typed_as → parameter_type (from a param), field (from a field),
+//     value (from a variable/constant/local), else type
+//   - annotated → attribute
+//   - reads / writes → value
+//   - references / implements / extends / composes / aliases / overrides → type
+//   - calls / instantiates → call
+//
+// Returns "" for edge kinds that carry no reference context.
+func RefContextOf(e *Edge, fromKind NodeKind) string {
+	if e == nil {
+		return ""
+	}
+	if e.Meta != nil {
+		if c, _ := e.Meta["ref_context"].(string); c != "" {
+			return c
+		}
+	}
+	switch e.Kind {
+	case EdgeReturns:
+		return RefContextReturnType
+	case EdgeTypedAs:
+		switch fromKind {
+		case KindParam:
+			return RefContextParameterType
+		case KindField:
+			return RefContextField
+		case KindVariable, KindConstant, KindLocal:
+			return RefContextValue
+		}
+		return RefContextType
+	case EdgeAnnotated:
+		return RefContextAttribute
+	case EdgeReads, EdgeWrites:
+		return RefContextValue
+	case EdgeReferences, EdgeImplements, EdgeExtends, EdgeComposes, EdgeAliases, EdgeOverrides:
+		return RefContextType
+	case EdgeCalls, EdgeInstantiates:
+		return RefContextCall
+	}
+	return ""
 }
 
 // ConfidenceLabelFor returns EXTRACTED, INFERRED, or AMBIGUOUS for an edge

--- a/internal/graph/ref_context_test.go
+++ b/internal/graph/ref_context_test.go
@@ -1,0 +1,39 @@
+package graph
+
+import "testing"
+
+func TestRefContextOf(t *testing.T) {
+	cases := []struct {
+		name string
+		kind EdgeKind
+		from NodeKind
+		meta map[string]any
+		want string
+	}{
+		{"return", EdgeReturns, KindFunction, nil, RefContextReturnType},
+		{"param", EdgeTypedAs, KindParam, nil, RefContextParameterType},
+		{"field", EdgeTypedAs, KindField, nil, RefContextField},
+		{"value_var", EdgeTypedAs, KindVariable, nil, RefContextValue},
+		{"value_local", EdgeTypedAs, KindLocal, nil, RefContextValue},
+		{"typed_other", EdgeTypedAs, KindType, nil, RefContextType},
+		{"attribute", EdgeAnnotated, KindFunction, nil, RefContextAttribute},
+		{"type_ref", EdgeReferences, KindFunction, nil, RefContextType},
+		{"implements", EdgeImplements, KindType, nil, RefContextType},
+		{"read", EdgeReads, KindFunction, nil, RefContextValue},
+		{"call", EdgeCalls, KindFunction, nil, RefContextCall},
+		{"instantiate", EdgeInstantiates, KindFunction, nil, RefContextCall},
+		{"meta_override", EdgeReferences, KindFunction, map[string]any{"ref_context": RefContextGenericArg}, RefContextGenericArg},
+		{"no_context", EdgeImports, KindFile, nil, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			e := &Edge{Kind: c.kind, Meta: c.meta}
+			if got := RefContextOf(e, c.from); got != c.want {
+				t.Errorf("RefContextOf(%s, from=%s) = %q, want %q", c.kind, c.from, got, c.want)
+			}
+		})
+	}
+	if RefContextOf(nil, KindFunction) != "" {
+		t.Error("nil edge must classify as empty context")
+	}
+}

--- a/internal/graph/store.go
+++ b/internal/graph/store.go
@@ -1159,6 +1159,25 @@ type EdgeAdjacencyForKinds interface {
 	EdgeAdjacencyForKinds(edgeKinds []EdgeKind, nodeKinds []NodeKind) iter.Seq[[2]string]
 }
 
+// ExternalCallCandidates is the optional pushdown for external-call
+// synthesis. ExternalCallCandidateEdges returns only the call / reference
+// edges whose target is an un-indexed external-package terminal
+// (dep:: / stdlib:: / external::, including the per-repo-prefixed stdlib
+// form) or an already-materialised external-call:: node — the exact set
+// the synthesizer might act on. The disk backend selects these rows with
+// a GLOB predicate (served by a partial index) instead of marshaling
+// every call edge in the graph and filtering Go-side; the marshaling /
+// allocation saving dominates on large graphs even when the planner
+// full-scans.
+//
+// Optional capability — resolver.externalCallCandidateEdges falls back to
+// the EdgesByKinds scan + prefix filter when the backend doesn't
+// implement it (the in-memory store, where there is no row marshaling to
+// save).
+type ExternalCallCandidates interface {
+	ExternalCallCandidateEdges() []*Edge
+}
+
 // CommunityCrossingsByKind is an optional capability backends MAY
 // implement to return per-source crossing counts for edges whose
 // Kind is in the supplied set, given a node→community membership

--- a/internal/graph/store_sqlite/external_call_candidates_test.go
+++ b/internal/graph/store_sqlite/external_call_candidates_test.go
@@ -1,0 +1,61 @@
+package store_sqlite_test
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// TestExternalCallCandidateEdges asserts the pushdown selects exactly the
+// external-package terminals (dep:: / stdlib:: / external::, the
+// per-repo-prefixed stdlib form, and already-materialised external-call::
+// nodes) and nothing else — no ordinary resolved call/reference edges,
+// no non-call edges.
+func TestExternalCallCandidateEdges(t *testing.T) {
+	s := openTestStore(t)
+
+	add := func(from, to string, kind graph.EdgeKind) {
+		s.AddEdge(&graph.Edge{From: from, To: to, Kind: kind, FilePath: "a.go", Line: 1})
+	}
+	// External terminals — should be selected.
+	add("a.go::f", "dep::github.com/x/y::Z", graph.EdgeCalls)
+	add("a.go::f", "stdlib::fmt::Sprintf", graph.EdgeCalls)
+	add("a.go::f", "myrepo::stdlib::net/http::Get", graph.EdgeCalls) // per-repo-prefixed stdlib form
+	add("a.go::f", "external::svc.internal/api", graph.EdgeReferences)
+	add("a.go::f", "external-call::dep::github.com/a/b", graph.EdgeCalls) // already synthesized
+	// Non-candidates — must NOT be selected.
+	add("a.go::f", "a.go::resolvedCallee", graph.EdgeCalls)   // ordinary resolved call
+	add("a.go::f", "unresolved::SomeName", graph.EdgeCalls)   // bare unresolved (no import evidence)
+	add("a.go::f", "a.go::SomeType", graph.EdgeImplements)    // not a call/ref edge
+	add("a.go::f", "dep::github.com/x/y::Z", graph.EdgeTests) // dep target but wrong kind
+
+	got := map[string]bool{}
+	for _, e := range s.ExternalCallCandidateEdges() {
+		got[e.To] = true
+	}
+
+	want := []string{
+		"dep::github.com/x/y::Z",
+		"stdlib::fmt::Sprintf",
+		"myrepo::stdlib::net/http::Get",
+		"external::svc.internal/api",
+		"external-call::dep::github.com/a/b",
+	}
+	for _, w := range want {
+		if !got[w] {
+			t.Errorf("ExternalCallCandidateEdges missing external terminal %q", w)
+		}
+	}
+	notWant := []string{"a.go::resolvedCallee", "unresolved::SomeName", "a.go::SomeType"}
+	for _, nw := range notWant {
+		if got[nw] {
+			t.Errorf("ExternalCallCandidateEdges wrongly selected non-candidate %q", nw)
+		}
+	}
+	// The EdgeImplements/EdgeTests rows share targets with selected ones
+	// but must not inflate the count via the wrong kind: exactly the 5
+	// distinct external targets above, all from calls/references kinds.
+	if len(got) != len(want) {
+		t.Errorf("selected %d distinct targets, want %d: %v", len(got), len(want), got)
+	}
+}

--- a/internal/graph/store_sqlite/store.go
+++ b/internal/graph/store_sqlite/store.go
@@ -148,6 +148,16 @@ func Open(path string) (*Store, error) {
 		_ = db.Close()
 		return nil, fmt.Errorf("sqlite schema: %w", err)
 	}
+	// edges_external is a partial index over exactly the external-call
+	// terminals, so ExternalCallCandidateEdges scans a tiny index instead
+	// of the full edges table. Built from the shared predicate const (not
+	// inlined in schemaSQL) so the index WHERE and the query WHERE stay
+	// byte-identical — SQLite only uses a partial index when the query's
+	// WHERE matches the index's.
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS edges_external ON edges(kind) WHERE ` + externalCallTargetPredicate); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("sqlite edges_external index: %w", err)
+	}
 
 	s := &Store{db: db}
 	// Initialise the bundle cache at construction so its pointer is

--- a/internal/graph/store_sqlite/store_aggregators.go
+++ b/internal/graph/store_sqlite/store_aggregators.go
@@ -391,6 +391,26 @@ func (s *Store) EdgesByKinds(kinds []graph.EdgeKind) iter.Seq[*graph.Edge] {
 	}
 }
 
+// externalCallTargetPredicate selects edges whose target is an
+// external-package terminal (dep:: / stdlib:: / external::, including the
+// per-repo-prefixed stdlib form) or an already-materialised
+// external-call:: node. Shared verbatim by ExternalCallCandidateEdges and
+// the edges_external partial index (schema.go) so SQLite matches the
+// partial index for the query — keep the two identical.
+const externalCallTargetPredicate = `(to_id GLOB 'dep::*' OR to_id GLOB 'external::*' OR to_id GLOB 'stdlib::*' OR to_id GLOB '*::stdlib::*' OR to_id GLOB 'external-call::*')`
+
+// ExternalCallCandidateEdges implements graph.ExternalCallCandidates: it
+// returns only the call / reference edges the external-call synthesizer
+// might act on, selected server-side so the whole call-edge table never
+// crosses into Go just to be prefix-filtered. The GLOB predicate is
+// served by the edges_external partial index.
+func (s *Store) ExternalCallCandidateEdges() []*graph.Edge {
+	q := `SELECT ` + lookupEdgeCols + ` FROM edges
+		WHERE kind IN ('calls','references') AND ` + externalCallTargetPredicate + `
+		ORDER BY id`
+	return s.queryEdgesSQL(q)
+}
+
 // NodesByKinds returns every node whose kind is in the supplied set.
 func (s *Store) NodesByKinds(kinds []graph.NodeKind) []*graph.Node {
 	_, args := aggDedupeNodeKinds(kinds)

--- a/internal/indexer/contract_import_resolve.go
+++ b/internal/indexer/contract_import_resolve.go
@@ -330,7 +330,7 @@ func resolveTSModulePath(modulePath, srcDir string, aliasMap *tsalias.Map, repoP
 	if strings.HasPrefix(modulePath, "./") || strings.HasPrefix(modulePath, "../") {
 		joined := path.Clean(path.Join(srcDir, modulePath))
 		switch path.Ext(joined) {
-		case ".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs":
+		case ".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs", ".svelte", ".vue":
 			return joined
 		}
 		return joined + ".ts"
@@ -352,7 +352,7 @@ func resolveTSModulePath(modulePath, srcDir string, aliasMap *tsalias.Map, repoP
 		full = repoPrefix + "/" + repoRel
 	}
 	switch path.Ext(full) {
-	case ".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs":
+	case ".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs", ".svelte", ".vue":
 		return full
 	}
 	return full + ".ts"
@@ -384,18 +384,27 @@ type tsReExport struct {
 // concrete files it might be on disk. resolveTSModulePath always
 // guesses `.ts`, but the real file is often `.tsx`, or the specifier
 // pointed at a directory whose entry point is `index.ts` (the barrel).
+// Single-file-component extensions (`.svelte`, `.vue`) are matched as
+// direct files only — they carry no `index.svelte` / `index.vue`
+// directory-barrel convention, so a bare directory import never
+// expands to one.
 func tsFileCandidates(resolved string) []string {
 	if resolved == "" {
 		return nil
 	}
 	stem := resolved
 	switch path.Ext(resolved) {
-	case ".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs":
+	case ".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs", ".svelte", ".vue":
 		stem = strings.TrimSuffix(resolved, path.Ext(resolved))
 	}
 	out := []string{resolved}
 	for _, ext := range []string{".ts", ".tsx", ".js", ".jsx", ".d.ts", ".mts", ".cts"} {
 		out = append(out, stem+ext, stem+"/index"+ext)
+	}
+	// Single-file components resolve to a direct file at the stem,
+	// never to a directory index.
+	for _, ext := range []string{".svelte", ".vue"} {
+		out = append(out, stem+ext)
 	}
 	seen := make(map[string]bool, len(out))
 	uniq := out[:0]
@@ -774,14 +783,16 @@ func (mi *MultiIndexer) followReExportChain(startFile, name string, srcCache map
 
 // isImportResolvableLang reports whether the contract source file
 // uses an import system this resolver can parse. TypeScript and
-// JavaScript files use ES-module imports we understand; Rust `use`
+// JavaScript files use ES-module imports we understand; Svelte / Vue
+// single-file components carry the same ES-module `import` /
+// `export ... from` syntax in their script block; Rust `use`
 // declarations are parsed for `pub use` re-export following. Go uses
 // package qualification which the in-file pass already handles
 // (and would have produced an unambiguous resolution at extraction
 // time).
 func isImportResolvableLang(filePath string) bool {
 	switch path.Ext(filePath) {
-	case ".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs", ".rs":
+	case ".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs", ".svelte", ".vue", ".rs":
 		return true
 	}
 	return false

--- a/internal/indexer/contract_import_resolve_test.go
+++ b/internal/indexer/contract_import_resolve_test.go
@@ -22,6 +22,57 @@ func TestTSFileCandidates(t *testing.T) {
 	require.Nil(t, tsFileCandidates(""))
 }
 
+// TestTSFileCandidates_SingleFileComponents confirms `.svelte` /
+// `.vue` module specifiers expand to a direct file candidate (the
+// stem with the SFC extension), and never to a directory `index`
+// barrel — single-file components have no `index.svelte` convention.
+func TestTSFileCandidates_SingleFileComponents(t *testing.T) {
+	got := tsFileCandidates("src/lib/Button.svelte")
+	require.Contains(t, got, "src/lib/Button.svelte")
+	require.NotContains(t, got, "src/lib/Button/index.svelte")
+
+	gotVue := tsFileCandidates("src/lib/Card.vue")
+	require.Contains(t, gotVue, "src/lib/Card.vue")
+	require.NotContains(t, gotVue, "src/lib/Card/index.vue")
+}
+
+// TestParseTSReExports_DefaultAsSvelte covers the Svelte component
+// barrel form `export { default as Button } from './Button.svelte'`:
+// the module specifier resolves to the `.svelte` file (no `.ts`
+// appended), and the local exported name `Button` maps to the
+// module's `default` export.
+func TestParseTSReExports_DefaultAsSvelte(t *testing.T) {
+	src := `
+export { default as Button } from './Button.svelte';
+export { default as Card } from './Card.vue';
+`
+	res := parseTSReExports(src, "src/lib/index.ts", nil, "")
+	require.Len(t, res, 2)
+
+	byFile := map[string]tsReExport{}
+	for _, re := range res {
+		byFile[re.fromFile] = re
+	}
+	// The `.svelte` / `.vue` specifier keeps its extension verbatim.
+	require.Equal(t, "default", byFile["src/lib/Button.svelte"].names["Button"])
+	require.Equal(t, "default", byFile["src/lib/Card.vue"].names["Card"])
+}
+
+// TestFollowReExportChain_DefaultAsSvelte drives the full follower over
+// a Svelte barrel: a consumer imports `Button`, the barrel re-exports
+// it as the default export of a `.svelte` component, and the chain must
+// reach that component file.
+func TestFollowReExportChain_DefaultAsSvelte(t *testing.T) {
+	mi := &MultiIndexer{}
+	srcCache := map[string][]byte{
+		"src/lib/index.ts":      []byte(`export { default as Button } from './Button.svelte';`),
+		"src/lib/Button.svelte": []byte(`<script lang="ts">export let label = "";</script>`),
+	}
+	reachable := mi.followReExportChain("src/lib/index.ts", "Button", srcCache)
+	require.True(t, reachable["src/lib/Button.svelte"],
+		"the `default as` re-export must reach the .svelte component file")
+}
+
 func TestParseTSReExports_StarNamedAndType(t *testing.T) {
 	src := `
 export * from './widgets';
@@ -361,11 +412,11 @@ func TestFollowReExportChain_RustPrivateUseNotForwarded(t *testing.T) {
 func TestResolveBareTypeViaImports_ThroughReExports(t *testing.T) {
 	cases := []struct {
 		name     string
-		consumer string                 // consumer file path
-		typeName string                 // bare type name being resolved
-		files    map[string][]byte      // re-export fixture sources
-		nodes    map[string]string      // candidate node ID -> FilePath
-		wantID   string                 // expected resolved node ID ("" = unresolved)
+		consumer string            // consumer file path
+		typeName string            // bare type name being resolved
+		files    map[string][]byte // re-export fixture sources
+		nodes    map[string]string // candidate node ID -> FilePath
+		wantID   string            // expected resolved node ID ("" = unresolved)
 	}{
 		{
 			name:     "ts wildcard multi-hop resolves to original definition",
@@ -378,7 +429,7 @@ func TestResolveBareTypeViaImports_ThroughReExports(t *testing.T) {
 				"web/src/ui/widget.ts": []byte(`export interface Widget { id: string }`),
 			},
 			nodes: map[string]string{
-				"web/src/ui/widget.ts::Widget": "web/src/ui/widget.ts",
+				"web/src/ui/widget.ts::Widget":  "web/src/ui/widget.ts",
 				"web/src/legacy/old.ts::Widget": "web/src/legacy/old.ts",
 			},
 			wantID: "web/src/ui/widget.ts::Widget",
@@ -388,12 +439,12 @@ func TestResolveBareTypeViaImports_ThroughReExports(t *testing.T) {
 			consumer: "app/src/main.js",
 			typeName: "Parser",
 			files: map[string][]byte{
-				"app/src/main.js":  []byte(`import { Parser } from './lib';`),
-				"app/src/lib.js":   []byte(`export * from './core';`),
-				"app/src/core.js":  []byte(`export class Parser {}`),
+				"app/src/main.js": []byte(`import { Parser } from './lib';`),
+				"app/src/lib.js":  []byte(`export * from './core';`),
+				"app/src/core.js": []byte(`export class Parser {}`),
 			},
 			nodes: map[string]string{
-				"app/src/core.js::Parser": "app/src/core.js",
+				"app/src/core.js::Parser":      "app/src/core.js",
 				"app/src/v1/legacy.js::Parser": "app/src/v1/legacy.js",
 			},
 			wantID: "app/src/core.js::Parser",
@@ -403,14 +454,14 @@ func TestResolveBareTypeViaImports_ThroughReExports(t *testing.T) {
 			consumer: "crate/src/main.rs",
 			typeName: "Account",
 			files: map[string][]byte{
-				"crate/src/main.rs":   []byte(`use crate::api::Account;`),
-				"crate/src/api.rs":    []byte(`pub use crate::model::Account;`),
-				"crate/src/model.rs":  []byte(`pub use crate::store::Account;`),
-				"crate/src/store.rs":  []byte(`pub struct Account { id: u64 }`),
+				"crate/src/main.rs":  []byte(`use crate::api::Account;`),
+				"crate/src/api.rs":   []byte(`pub use crate::model::Account;`),
+				"crate/src/model.rs": []byte(`pub use crate::store::Account;`),
+				"crate/src/store.rs": []byte(`pub struct Account { id: u64 }`),
 			},
 			nodes: map[string]string{
-				"crate/src/store.rs::Account":  "crate/src/store.rs",
-				"crate/src/other.rs::Account":  "crate/src/other.rs",
+				"crate/src/store.rs::Account": "crate/src/store.rs",
+				"crate/src/other.rs::Account": "crate/src/other.rs",
 			},
 			wantID: "crate/src/store.rs::Account",
 		},

--- a/internal/indexer/external_call_synthesis.go
+++ b/internal/indexer/external_call_synthesis.go
@@ -14,5 +14,5 @@ func (idx *Indexer) externalCallSynthesisEnabled() bool {
 	if v := os.Getenv("GORTEX_SYNTH_EXTERNAL_CALLS"); v != "" {
 		return v == "1" || strings.EqualFold(v, "true")
 	}
-	return idx.config.SynthesizeExternalCalls
+	return idx.config.ExternalCallSynthesisEnabledOrDefault()
 }

--- a/internal/indexer/external_call_synthesis_test.go
+++ b/internal/indexer/external_call_synthesis_test.go
@@ -11,16 +11,23 @@ import (
 func TestExternalCallSynthesisEnabled_EnvOverride(t *testing.T) {
 	g := graph.New()
 	idx := newTestIndexer(g)
-	// Default-off: neither config nor env set.
+	bptr := func(b bool) *bool { return &b }
+
+	// Default-on: key unset (nil) resolves to enabled.
+	require.True(t, idx.externalCallSynthesisEnabled())
+
+	// Explicit opt-out via config.
+	idx.config.SynthesizeExternalCalls = bptr(false)
 	require.False(t, idx.externalCallSynthesisEnabled())
 
-	idx.config.SynthesizeExternalCalls = true
+	// Explicit opt-in via config.
+	idx.config.SynthesizeExternalCalls = bptr(true)
 	require.True(t, idx.externalCallSynthesisEnabled())
 
 	t.Setenv("GORTEX_SYNTH_EXTERNAL_CALLS", "0")
 	require.False(t, idx.externalCallSynthesisEnabled()) // env overrides config-on
 
 	t.Setenv("GORTEX_SYNTH_EXTERNAL_CALLS", "1")
-	idx.config.SynthesizeExternalCalls = false
+	idx.config.SynthesizeExternalCalls = bptr(false)
 	require.True(t, idx.externalCallSynthesisEnabled()) // env overrides config-off
 }

--- a/internal/indexer/external_call_synthesis_test.go
+++ b/internal/indexer/external_call_synthesis_test.go
@@ -13,8 +13,8 @@ func TestExternalCallSynthesisEnabled_EnvOverride(t *testing.T) {
 	idx := newTestIndexer(g)
 	bptr := func(b bool) *bool { return &b }
 
-	// Default-off (opt-in): key unset (nil) resolves to disabled.
-	require.False(t, idx.externalCallSynthesisEnabled())
+	// Default-on: key unset (nil) resolves to enabled.
+	require.True(t, idx.externalCallSynthesisEnabled())
 
 	// Explicit opt-out via config.
 	idx.config.SynthesizeExternalCalls = bptr(false)

--- a/internal/indexer/external_call_synthesis_test.go
+++ b/internal/indexer/external_call_synthesis_test.go
@@ -13,8 +13,8 @@ func TestExternalCallSynthesisEnabled_EnvOverride(t *testing.T) {
 	idx := newTestIndexer(g)
 	bptr := func(b bool) *bool { return &b }
 
-	// Default-on: key unset (nil) resolves to enabled.
-	require.True(t, idx.externalCallSynthesisEnabled())
+	// Default-off (opt-in): key unset (nil) resolves to disabled.
+	require.False(t, idx.externalCallSynthesisEnabled())
 
 	// Explicit opt-out via config.
 	idx.config.SynthesizeExternalCalls = bptr(false)

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -712,24 +712,17 @@ func (idx *Indexer) RunGlobalGraphPasses(ctx context.Context) {
 	if idx.cloneIndex != nil {
 		idx.cloneIndex.Rebuild(idx.graph, idx.repoPrefix)
 	}
-	// gRPC stub-call resolution. Runs after InferImplements (the
-	// interface-satisfaction fallback signal depends on its
-	// EdgeImplements edges) and before DetectCrossRepoEdges so a
-	// cross-repo gRPC call gets its parallel cross_repo_calls edge.
-	reporter.Report("gRPC stub resolution (global)", 0, 0)
-	if grpcResolved := resolver.ResolveGRPCStubCalls(idx.graph); grpcResolved > 0 {
-		idx.logger.Info("gRPC stub calls resolved (global)",
-			zap.Int("edges", grpcResolved),
-		)
-	}
-	// Temporal workflow → activity stub-call resolution. Same ordering
-	// constraints as gRPC: needs InferImplements (Java interface chain)
-	// to have run; runs before DetectCrossRepoEdges so cross-repo
-	// Temporal dispatch gets its parallel cross_repo_calls edge.
-	reporter.Report("Temporal stub resolution (global)", 0, 0)
-	if temporalResolved := resolver.ResolveTemporalCalls(idx.graph); temporalResolved > 0 {
-		idx.logger.Info("Temporal stub calls resolved (global)",
-			zap.Int("edges", temporalResolved),
+	// Framework dynamic-dispatch synthesis (gRPC stubs, Temporal
+	// workflow→activity, in-process / native event channels, native
+	// bridges). Runs after InferImplements/InferOverrides (the
+	// interface-satisfaction signals several synthesizers depend on) and
+	// before DetectCrossRepoEdges so a cross-repo synthesized call gets
+	// its parallel cross_repo_calls edge.
+	reporter.Report("framework dispatch synthesis (global)", 0, 0)
+	if rep := resolver.RunFrameworkSynthesizers(idx.graph); rep.Total > 0 {
+		idx.logger.Info("framework dispatch calls synthesized (global)",
+			zap.Int("edges", rep.Total),
+			zap.Any("per_synthesizer", rep.Per),
 		)
 	}
 	// External-call placeholder synthesis (opt-in). Runs after the
@@ -2365,21 +2358,15 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 			if idx.cloneIndex != nil {
 				idx.cloneIndex.Rebuild(idx.graph, idx.repoPrefix)
 			}
-			// gRPC stub-call resolution — runs once the call graph and
-			// interface inference are final. Skipped under
+			// Framework dynamic-dispatch synthesis — runs once the call
+			// graph and interface inference are final. Skipped under
 			// deferGlobalPasses; the batch caller folds it into
 			// RunGlobalGraphPasses.
-			reporter.Report("gRPC stub resolution", 0, 0)
-			if grpcResolved := resolver.ResolveGRPCStubCalls(idx.graph); grpcResolved > 0 {
-				idx.logger.Info("gRPC stub calls resolved",
-					zap.Int("edges", grpcResolved),
-				)
-			}
-			// Temporal stub-call resolution — same staging as gRPC.
-			reporter.Report("Temporal stub resolution", 0, 0)
-			if temporalResolved := resolver.ResolveTemporalCalls(idx.graph); temporalResolved > 0 {
-				idx.logger.Info("Temporal stub calls resolved",
-					zap.Int("edges", temporalResolved),
+			reporter.Report("framework dispatch synthesis", 0, 0)
+			if rep := resolver.RunFrameworkSynthesizers(idx.graph); rep.Total > 0 {
+				idx.logger.Info("framework dispatch calls synthesized",
+					zap.Int("edges", rep.Total),
+					zap.Any("per_synthesizer", rep.Per),
 				)
 			}
 			// External-call placeholder synthesis (opt-in) — runs after
@@ -2806,12 +2793,10 @@ func (idx *Indexer) ResolveAll() {
 	idx.resolver.ResolveAll()
 	idx.resolver.InferImplements()
 	idx.resolver.InferOverrides()
-	// gRPC stub-call resolution depends on InferImplements (its
-	// interface-satisfaction fallback signal) having run first.
-	resolver.ResolveGRPCStubCalls(idx.graph)
-	// Temporal stub-call resolution piggybacks on the same staging —
-	// Java interface→impl propagation depends on EdgeImplements.
-	resolver.ResolveTemporalCalls(idx.graph)
+	// Framework dynamic-dispatch synthesis (gRPC / Temporal / event
+	// channels / native bridges) depends on InferImplements (the
+	// interface-satisfaction signals) having run first.
+	resolver.RunFrameworkSynthesizers(idx.graph)
 	// External-call placeholder synthesis (opt-in) — runs after the
 	// resolver and stub passes so only genuinely un-indexed external
 	// targets remain to materialise.
@@ -3814,8 +3799,7 @@ func (idx *Indexer) IncrementalReindexPaths(root string, paths []string) (*Index
 	if !idx.deferGlobalPasses && (len(staleFiles) > 0 || len(deletedFiles) > 0) {
 		idx.resolver.InferImplements()
 		idx.resolver.InferOverrides()
-		resolver.ResolveGRPCStubCalls(idx.graph)
-		resolver.ResolveTemporalCalls(idx.graph)
+		resolver.RunFrameworkSynthesizers(idx.graph)
 		resolver.SynthesizeExternalCalls(idx.graph, idx.externalCallSynthesisEnabled())
 	}
 
@@ -4022,12 +4006,11 @@ func (idx *Indexer) IncrementalReindex(root string) (*IndexResult, error) {
 	if !idx.deferGlobalPasses {
 		idx.resolver.InferImplements()
 		idx.resolver.InferOverrides()
-		// gRPC stub-call resolution — re-run because eviction may have
-		// dropped a handler or a registration edge, and the handler
-		// index must be rebuilt against the fresh graph.
-		resolver.ResolveGRPCStubCalls(idx.graph)
-		// Temporal stub-call resolution — same re-run rationale.
-		resolver.ResolveTemporalCalls(idx.graph)
+		// Framework dynamic-dispatch synthesis — re-run because eviction
+		// may have dropped a handler, a registration edge, or an emit /
+		// listen edge, and each synthesizer's index must be rebuilt
+		// against the fresh graph. Every pass is a full recompute.
+		resolver.RunFrameworkSynthesizers(idx.graph)
 		// External-call placeholder synthesis (opt-in) — re-run for the
 		// same reason: eviction can leave a previously-synthetic edge
 		// pointing at a stale terminal. The pass is a full recompute.

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -4186,6 +4186,34 @@ func (idx *Indexer) commitContracts(reg *contracts.Registry) {
 	// correct per-handler scope now that the graph is complete.
 	idx.resolveProviderHandlers(reg)
 
+	// Cross-file route-prefix joining. A FastAPI APIRouter declared in
+	// one file (`router = APIRouter(prefix="/users")`) is mounted under
+	// a second prefix elsewhere (`app.include_router(router,
+	// prefix="/api")`), so a route declared `@router.get("/{id}")`
+	// belongs at /api/users/{id}, not /{id}. Rewrite the affected
+	// provider contract IDs to the joined path before the matcher pairs
+	// them with consumers. Also handles Express app.use mounts and
+	// NestJS @Controller class prefixes. Reads source straight off disk
+	// (cached per file) — the same access pattern resolveProviderHandlers
+	// uses for cross-file handler bodies.
+	//
+	// Mount sites (a main.py that only calls include_router) often carry
+	// no route contracts, so the scan-file set comes from the graph's
+	// py/ts/js file nodes, not the registry — but only when at least one
+	// prefix-eligible route contract exists, so non-FastAPI/Express/Nest
+	// repos pay nothing.
+	if scanFiles := idx.routerPrefixScanFiles(reg); len(scanFiles) > 0 {
+		srcCache := make(map[string][]byte)
+		contracts.JoinRouterPrefixes(reg, scanFiles, func(filePath string) []byte {
+			if data, ok := srcCache[filePath]; ok {
+				return data
+			}
+			data := idx.contractFileSrc(filePath)
+			srcCache[filePath] = data
+			return data
+		})
+	}
+
 	// Trace response variables back to their call-site return types.
 	// Handles `source, err := h.svc.Get(...)` → response_type is
 	// whatever `h.svc.Get` returns. The enricher can't do this
@@ -4305,6 +4333,70 @@ func (idx *Indexer) bulkCommit(nodes []*graph.Node, edges []*graph.Edge) {
 		return
 	}
 	idx.graph.AddBatch(nodes, edges)
+}
+
+// routerPrefixScanFiles returns the set of source files
+// JoinRouterPrefixes must scan for router definitions and mount sites
+// (APIRouter / include_router / app.use). Returns nil when no HTTP
+// contract uses a prefix-joining framework (FastAPI / Express / NestJS),
+// so unrelated repos skip the file enumeration entirely. When eligible,
+// it enumerates py / ts / js / tsx / jsx file nodes from the graph — the
+// mount file (a FastAPI main.py) frequently has no route contract of its
+// own and so can't be discovered from the registry alone.
+func (idx *Indexer) routerPrefixScanFiles(reg *contracts.Registry) []string {
+	eligible := false
+	for _, c := range reg.All() {
+		if c.Type != contracts.ContractHTTP || c.Meta == nil {
+			continue
+		}
+		switch fw, _ := c.Meta["framework"].(string); fw {
+		case "fastapi/flask", "express", "nestjs":
+			eligible = true
+		}
+		if eligible {
+			break
+		}
+	}
+	if !eligible {
+		return nil
+	}
+
+	var out []string
+	for _, n := range idx.graph.AllNodes() {
+		if n.Kind != graph.KindFile {
+			continue
+		}
+		path := n.FilePath
+		if path == "" {
+			path = n.ID
+		}
+		switch {
+		case strings.HasSuffix(path, ".py"),
+			strings.HasSuffix(path, ".ts"),
+			strings.HasSuffix(path, ".tsx"),
+			strings.HasSuffix(path, ".js"),
+			strings.HasSuffix(path, ".jsx"):
+			out = append(out, path)
+		}
+	}
+	return out
+}
+
+// contractFileSrc reads the on-disk source for a contract FilePath
+// (which is repo-prefixed when the indexer uses a repo prefix). Returns
+// nil when the file can't be read. Mirrors the disk-resolution logic in
+// resolveProviderHandlers so cross-file passes share one access pattern.
+func (idx *Indexer) contractFileSrc(filePath string) []byte {
+	diskPath := filePath
+	if idx.repoPrefix != "" && strings.HasPrefix(diskPath, idx.repoPrefix+"/") {
+		diskPath = strings.TrimPrefix(diskPath, idx.repoPrefix+"/")
+	}
+	diskPath = filepath.Join(idx.rootPath, diskPath)
+	data, err := os.ReadFile(diskPath)
+	if err != nil {
+		return nil
+	}
+	return data
 }
 
 // isRouteContractType reports whether a ContractType corresponds to a

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -4076,7 +4076,7 @@ func (idx *Indexer) TotalDetected() int {
 // check per file.
 func (idx *Indexer) buildPerFileContractExtractors() ([]contracts.Extractor, map[string][]contracts.Extractor) {
 	extractors := []contracts.Extractor{
-		&contracts.HTTPExtractor{},
+		&contracts.HTTPExtractor{ClientAliases: idx.config.HTTPClientAliases},
 		&contracts.GRPCExtractor{},
 		&contracts.GraphQLExtractor{},
 		&contracts.OpenAPIExtractor{},

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -1040,6 +1040,22 @@ func (idx *Indexer) prefixPath(relPath string) string {
 	return idx.repoPrefix + "/" + relPath
 }
 
+// graphFilePaths maps reindex file paths (absolute or root-relative, as
+// passed to IndexFile) to the canonical graph file-path form
+// (prefixPath(relKey)) that GetFileNodes is keyed by — so file-scoped
+// passes can look up the just-reindexed files' nodes.
+func (idx *Indexer) graphFilePaths(files []string) []string {
+	out := make([]string, 0, len(files))
+	for _, f := range files {
+		abs := f
+		if !filepath.IsAbs(abs) && idx.rootPath != "" {
+			abs = filepath.Join(idx.rootPath, f)
+		}
+		out = append(out, idx.prefixPath(idx.relKey(abs)))
+	}
+	return out
+}
+
 // applyRepoPrefix transforms nodes and edges produced by an extractor to include
 // the repo prefix in IDs and file paths. Sets Node.RepoPrefix on all nodes.
 // This is a no-op when repoPrefix is empty (single-repo mode).
@@ -3800,7 +3816,9 @@ func (idx *Indexer) IncrementalReindexPaths(root string, paths []string) (*Index
 		idx.resolver.InferImplements()
 		idx.resolver.InferOverrides()
 		resolver.RunFrameworkSynthesizers(idx.graph)
-		resolver.SynthesizeExternalCalls(idx.graph, idx.externalCallSynthesisEnabled())
+		// Incremental: synthesize external calls only for the reindexed
+		// files (O(edited files)), not a full-graph recompute.
+		resolver.SynthesizeExternalCallsForFiles(idx.graph, idx.externalCallSynthesisEnabled(), idx.graphFilePaths(staleFiles))
 	}
 
 	// Skip the search-index rebuild on a zero-change reconcile when the
@@ -4011,10 +4029,11 @@ func (idx *Indexer) IncrementalReindex(root string) (*IndexResult, error) {
 		// listen edge, and each synthesizer's index must be rebuilt
 		// against the fresh graph. Every pass is a full recompute.
 		resolver.RunFrameworkSynthesizers(idx.graph)
-		// External-call placeholder synthesis (opt-in) — re-run for the
-		// same reason: eviction can leave a previously-synthetic edge
-		// pointing at a stale terminal. The pass is a full recompute.
-		resolver.SynthesizeExternalCalls(idx.graph, idx.externalCallSynthesisEnabled())
+		// External-call synthesis (opt-in) — file-scoped to the reindexed
+		// files (O(edited files)), not a full-graph recompute. Eviction
+		// already dropped a removed file's synthetic edges; a re-indexed
+		// file's fresh external terminals are re-materialised here.
+		resolver.SynthesizeExternalCallsForFiles(idx.graph, idx.externalCallSynthesisEnabled(), idx.graphFilePaths(staleFiles))
 		// Clone detection is not re-run here: each stale file was
 		// re-indexed through IndexFile above, whose resolve pass
 		// already recomputed EdgeSimilarTo against the fresh graph,

--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -468,24 +468,17 @@ func (mi *MultiIndexer) RunGlobalGraphPasses(ctx context.Context) {
 			idx.cloneIndex.Rebuild(mi.graph, idx.repoPrefix)
 		}
 	}
-	// gRPC stub-call resolution. After InferImplements (the
-	// interface-satisfaction fallback signal) and before
-	// DetectCrossRepoEdges so a cross-repo gRPC call gets its parallel
-	// cross_repo_calls edge.
-	reporter.Report("gRPC stub resolution (global)", 0, 0)
-	if grpcResolved := resolver.ResolveGRPCStubCalls(mi.graph); grpcResolved > 0 {
-		mi.logger.Info("gRPC stub calls resolved (global)",
-			zap.Int("edges", grpcResolved),
-		)
-	}
-	// Temporal stub-call resolution mirrors the gRPC staging — Java
-	// interface→impl propagation needs EdgeImplements already
-	// materialised; cross-repo workflow→activity dispatch then picks
-	// up its parallel cross_repo_calls edge below.
-	reporter.Report("Temporal stub resolution (global)", 0, 0)
-	if temporalResolved := resolver.ResolveTemporalCalls(mi.graph); temporalResolved > 0 {
-		mi.logger.Info("Temporal stub calls resolved (global)",
-			zap.Int("edges", temporalResolved),
+	// Framework dynamic-dispatch synthesis (gRPC stubs, Temporal
+	// workflow→activity, in-process / native event channels, native
+	// bridges). After InferImplements/InferOverrides (the
+	// interface-satisfaction signals) and before DetectCrossRepoEdges so
+	// a cross-repo synthesized call gets its parallel cross_repo_calls
+	// edge.
+	reporter.Report("framework dispatch synthesis (global)", 0, 0)
+	if rep := resolver.RunFrameworkSynthesizers(mi.graph); rep.Total > 0 {
+		mi.logger.Info("framework dispatch calls synthesized (global)",
+			zap.Int("edges", rep.Total),
+			zap.Any("per_synthesizer", rep.Per),
 		)
 	}
 	// External-call placeholder synthesis (opt-in). Runs after the

--- a/internal/indexer/npm_alias_resolve.go
+++ b/internal/indexer/npm_alias_resolve.go
@@ -1,6 +1,7 @@
 package indexer
 
 import (
+	"encoding/json"
 	"path"
 	"strings"
 	"sync"
@@ -37,6 +38,23 @@ type npmAliasIndex struct {
 	// A nil value records "read, but no npm-alias entries / missing
 	// file" so a miss is not re-read on every import edge.
 	aliasCache map[string]map[string]string
+	// exportsCache memoises the parsed `exports` subpath map of one
+	// package.json: disk path → packageExports. A nil value records
+	// "read, but no usable `exports` field / missing file" so a miss
+	// is not re-parsed on every import edge.
+	exportsCache map[string]*packageExports
+}
+
+// packageExports is one package.json's parsed `exports` field: the
+// declaring package's own `"name"` plus its subpath map flattened to
+// subpath-key → target file path. The name lets the resolver confirm
+// an import addresses this very package before consulting the map.
+type packageExports struct {
+	name string
+	// subpaths maps an `exports` key (`"."`, `"./feature"`, `"./*"`)
+	// to its resolved target file (`"./dist/feature.js"`), with the
+	// leading `./` kept so the matcher can splice wildcard tails.
+	subpaths map[string]string
 }
 
 // newNpmAliasIndex builds an index over the given repo roots. Returns
@@ -53,8 +71,9 @@ func newNpmAliasIndex(roots map[string]string) *npmAliasIndex {
 		return nil
 	}
 	return &npmAliasIndex{
-		roots:      usable,
-		aliasCache: map[string]map[string]string{},
+		roots:        usable,
+		aliasCache:   map[string]map[string]string{},
+		exportsCache: map[string]*packageExports{},
 	}
 }
 
@@ -87,17 +106,42 @@ func (x *npmAliasIndex) Resolve(callerFile, specifier string) string {
 	// stopping at the first package.json that declares the specifier
 	// — npm resolution honours the nearest manifest.
 	for dir := relDir; ; dir = path.Dir(dir) {
-		aliases := x.aliasesFor(joinPath(root, joinRel(dir, "package.json")))
-		if real, found := aliases[pkgName]; found {
+		manifest := joinPath(root, joinRel(dir, "package.json"))
+		if real, found := x.aliasesFor(manifest)[pkgName]; found {
 			if subPath == "" {
 				return real
 			}
 			return real + "/" + subPath
 		}
+		// `exports` subpath map: when this manifest IS the imported
+		// package (its `"name"` matches the specifier's package
+		// portion), resolve the sub-path through the package's declared
+		// `exports` entry points rather than treating it as a bare
+		// directory import. `pkg/feature` → `pkg/dist/feature.js`.
+		if mapped := x.exportTargetFor(manifest, pkgName, subPath); mapped != "" {
+			return pkgName + "/" + mapped
+		}
 		if dir == "." || dir == "" || dir == "/" {
 			return ""
 		}
 	}
+}
+
+// exportTargetFor resolves an import of `pkgName` (sub-path `subPath`,
+// "" for the package root) through the `exports` field of the
+// package.json at absPath, but only when that manifest declares
+// `pkgName` as its own `"name"`. It returns the mapped target file
+// relative to the package root with the leading `./` stripped (so the
+// caller can splice it after `pkgName`), or "" when the manifest is a
+// different package, declares no `exports`, or maps no matching
+// sub-path.
+func (x *npmAliasIndex) exportTargetFor(absPath, pkgName, subPath string) string {
+	exp := x.exportsFor(absPath)
+	if exp == nil || exp.name != pkgName {
+		return ""
+	}
+	target := resolveExportsSubpath(exp.subpaths, subPath)
+	return strings.TrimPrefix(target, "./")
 }
 
 // locate resolves callerFile to (repoRoot, repoRelativeDir). The
@@ -155,6 +199,181 @@ func (x *npmAliasIndex) aliasesFor(absPath string) map[string]string {
 	}
 	x.aliasCache[absPath] = aliases
 	return aliases
+}
+
+// exportsFor returns the parsed `exports` subpath map of the
+// package.json at absPath, reading and caching it on first request. A
+// nil result records "read, but no usable `exports` field / missing
+// file" so a miss is not re-parsed on every import edge.
+func (x *npmAliasIndex) exportsFor(absPath string) *packageExports {
+	x.mu.Lock()
+	defer x.mu.Unlock()
+	if cached, seen := x.exportsCache[absPath]; seen {
+		return cached
+	}
+	var exp *packageExports
+	if src, ok := readDiskFile(absPath); ok {
+		exp = parsePackageExports(src)
+	}
+	x.exportsCache[absPath] = exp
+	return exp
+}
+
+// parsePackageExports parses the `name` and `exports` fields of a
+// package.json. The `exports` field is the modern package entry-point
+// map; this flattens it to subpath-key → target file, handling the two
+// target shapes npm supports:
+//
+//	"./feature": "./dist/feature.js"                     (string)
+//	"./feature": { "import": "...", "default": "..." }   (conditional)
+//
+// For a conditional object the `import` condition is preferred, then
+// `default` — the order an ES-module consumer would resolve. A bare
+// string `exports` (`"exports": "./index.js"`) is treated as the `"."`
+// root entry. Returns nil when the manifest is unparseable or declares
+// no usable `exports` map.
+func parsePackageExports(source []byte) *packageExports {
+	if len(source) == 0 {
+		return nil
+	}
+	var manifest struct {
+		Name    string          `json:"name"`
+		Exports json.RawMessage `json:"exports"`
+	}
+	if err := json.Unmarshal(source, &manifest); err != nil {
+		return nil
+	}
+	if len(manifest.Exports) == 0 {
+		return nil
+	}
+	subpaths := map[string]string{}
+	// A string `exports` is the package root entry point; an object is
+	// the subpath map. Conditional objects keyed by condition (`import`
+	// / `default`) at the top level also collapse to the `"."` root.
+	var asString string
+	if err := json.Unmarshal(manifest.Exports, &asString); err == nil {
+		if t := strings.TrimSpace(asString); t != "" {
+			subpaths["."] = t
+		}
+	} else {
+		var asMap map[string]json.RawMessage
+		if err := json.Unmarshal(manifest.Exports, &asMap); err != nil {
+			return nil
+		}
+		// A top-level conditional object (no `"."` / `"./..."` keys, just
+		// `import` / `default`) is the root entry point in disguise.
+		if !hasSubpathKeys(asMap) {
+			if t := pickConditionalTarget(manifest.Exports); t != "" {
+				subpaths["."] = t
+			}
+		} else {
+			for key, raw := range asMap {
+				if t := pickConditionalTarget(raw); t != "" {
+					subpaths[key] = t
+				}
+			}
+		}
+	}
+	if len(subpaths) == 0 {
+		return nil
+	}
+	return &packageExports{name: manifest.Name, subpaths: subpaths}
+}
+
+// hasSubpathKeys reports whether an `exports` object is a subpath map
+// (keys begin with `.`) rather than a bare top-level conditional object
+// (keys like `import` / `default`). An empty map is treated as a
+// subpath map — there is nothing to collapse to the root.
+func hasSubpathKeys(m map[string]json.RawMessage) bool {
+	for key := range m {
+		if strings.HasPrefix(key, ".") {
+			return true
+		}
+	}
+	return len(m) == 0
+}
+
+// pickConditionalTarget resolves one `exports` value to a target file
+// string. A JSON string is returned verbatim; a conditional object
+// (`{ "import": "...", "require": "...", "default": "..." }`) is
+// resolved by preferring the `import` condition, then `default` — the
+// resolution an ES-module consumer performs. Returns "" for any other
+// shape (nested arrays, the `null` block-out sentinel, unknown
+// conditions only).
+func pickConditionalTarget(raw json.RawMessage) string {
+	var asString string
+	if err := json.Unmarshal(raw, &asString); err == nil {
+		return strings.TrimSpace(asString)
+	}
+	var conditions map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &conditions); err != nil {
+		return ""
+	}
+	for _, cond := range []string{"import", "default"} {
+		if sub, ok := conditions[cond]; ok {
+			if t := pickConditionalTarget(sub); t != "" {
+				return t
+			}
+		}
+	}
+	return ""
+}
+
+// resolveExportsSubpath matches an imported sub-path against a parsed
+// `exports` subpath map and returns the mapped target file (leading
+// `./` preserved), or "" for no match. The import key is the package
+// root (`"."`) when subPath is empty, else `"./" + subPath`. Matching
+// order mirrors Node: an exact key wins; otherwise the longest `./*`
+// wildcard whose static prefix matches splices the captured tail into
+// the target's own `*`. A sub-path containing a `..` segment escapes
+// the package and is rejected outright, as Node's resolver does.
+func resolveExportsSubpath(subpaths map[string]string, subPath string) string {
+	if len(subpaths) == 0 || hasDotDotSegment(subPath) {
+		return ""
+	}
+	key := "."
+	if subPath != "" {
+		key = "./" + subPath
+	}
+	if target, ok := subpaths[key]; ok {
+		return target
+	}
+	bestPrefixLen := -1
+	best := ""
+	for pat, target := range subpaths {
+		star := strings.IndexByte(pat, '*')
+		if star < 0 {
+			continue
+		}
+		prefix := pat[:star]
+		suffix := pat[star+1:]
+		if !strings.HasPrefix(key, prefix) || !strings.HasSuffix(key, suffix) {
+			continue
+		}
+		if len(key) < len(prefix)+len(suffix) {
+			continue
+		}
+		if len(prefix) <= bestPrefixLen {
+			continue
+		}
+		captured := key[len(prefix) : len(key)-len(suffix)]
+		best = strings.Replace(target, "*", captured, 1)
+		bestPrefixLen = len(prefix)
+	}
+	return best
+}
+
+// hasDotDotSegment reports whether a slash-separated sub-path contains
+// a `..` segment — a parent-directory escape an `exports` lookup must
+// reject so a wildcard like `./*` can never resolve outside the
+// package.
+func hasDotDotSegment(subPath string) bool {
+	for _, seg := range strings.Split(subPath, "/") {
+		if seg == ".." {
+			return true
+		}
+	}
+	return false
 }
 
 // splitPackageSpecifier splits an import specifier into its package

--- a/internal/indexer/npm_alias_resolve_test.go
+++ b/internal/indexer/npm_alias_resolve_test.go
@@ -113,6 +113,132 @@ func TestNpmAliasIndex_NilRootsYieldsNil(t *testing.T) {
 	assert.Nil(t, newNpmAliasIndex(map[string]string{"repo": ""}))
 }
 
+// TestParsePackageExports covers every `exports` shape the parser
+// recognises: string subpath targets, conditional-object targets
+// (`import` preferred over `default`), the `"."` root key, a bare
+// string `exports` collapsing to the root, a top-level conditional
+// object collapsing to the root, and a missing / non-`exports`
+// manifest yielding nil.
+func TestParsePackageExports(t *testing.T) {
+	t.Run("subpath string and conditional targets", func(t *testing.T) {
+		exp := parsePackageExports([]byte(`{
+  "name": "@acme/pkg",
+  "exports": {
+    ".": "./dist/index.js",
+    "./feature": "./dist/feature.js",
+    "./util": { "import": "./dist/util.mjs", "require": "./dist/util.cjs", "default": "./dist/util.js" },
+    "./only-default": { "default": "./dist/only.js" }
+  }
+}`))
+		require.NotNil(t, exp)
+		assert.Equal(t, "@acme/pkg", exp.name)
+		assert.Equal(t, "./dist/index.js", exp.subpaths["."])
+		assert.Equal(t, "./dist/feature.js", exp.subpaths["./feature"])
+		// `import` wins over `require` / `default`.
+		assert.Equal(t, "./dist/util.mjs", exp.subpaths["./util"])
+		// Falls back to `default` when `import` is absent.
+		assert.Equal(t, "./dist/only.js", exp.subpaths["./only-default"])
+	})
+
+	t.Run("bare string exports collapses to root", func(t *testing.T) {
+		exp := parsePackageExports([]byte(`{"name":"pkg","exports":"./index.js"}`))
+		require.NotNil(t, exp)
+		assert.Equal(t, "./index.js", exp.subpaths["."])
+	})
+
+	t.Run("top-level conditional object collapses to root", func(t *testing.T) {
+		exp := parsePackageExports([]byte(`{"name":"pkg","exports":{"import":"./esm.js","default":"./cjs.js"}}`))
+		require.NotNil(t, exp)
+		assert.Equal(t, "./esm.js", exp.subpaths["."])
+	})
+
+	t.Run("no exports field yields nil", func(t *testing.T) {
+		assert.Nil(t, parsePackageExports([]byte(`{"name":"pkg","main":"./index.js"}`)))
+		assert.Nil(t, parsePackageExports(nil))
+		assert.Nil(t, parsePackageExports([]byte(`not json`)))
+	})
+}
+
+// TestResolveExportsSubpath checks the subpath matcher: an exact key
+// wins, an empty sub-path resolves the `"."` root, and a `./*`
+// wildcard splices the captured tail into the target's own `*`. The
+// longest static prefix wins when several wildcards could match.
+func TestResolveExportsSubpath(t *testing.T) {
+	subpaths := map[string]string{
+		".":              "./dist/index.js",
+		"./feature":      "./dist/feature.js",
+		"./components/*": "./dist/components/*.js",
+		"./*":            "./dist/*.js",
+	}
+	cases := []struct {
+		name, subPath, want string
+	}{
+		{"root", "", "./dist/index.js"},
+		{"exact subpath", "feature", "./dist/feature.js"},
+		{"wildcard tail", "math", "./dist/math.js"},
+		{"longest-prefix wildcard wins", "components/Button", "./dist/components/Button.js"},
+		{"no match", "../escape", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, resolveExportsSubpath(subpaths, c.subPath))
+		})
+	}
+	assert.Equal(t, "", resolveExportsSubpath(nil, "feature"))
+}
+
+// TestNpmAliasIndex_ResolveExports drives the disk-backed resolver over
+// a package whose package.json declares an `exports` map: an import of
+// the package by name with a sub-path resolves through `exports` to the
+// mapped target file, the `"."` root resolves a bare package import,
+// and a `./*` wildcard splices the tail. A subpath the map does not
+// declare falls through (returns ""), and a package WITHOUT an
+// `exports` field is left untouched (no regression to bare-directory
+// resolution).
+func TestNpmAliasIndex_ResolveExports(t *testing.T) {
+	root := t.TempDir()
+	// The package itself lives at packages/ui; its files import it by
+	// its published name `@acme/ui`.
+	writePackageJSON(t, filepath.Join(root, "packages", "ui"), `{
+  "name": "@acme/ui",
+  "exports": {
+    ".": "./dist/index.js",
+    "./feature": "./dist/feature.js",
+    "./button": { "import": "./dist/button.mjs", "default": "./dist/button.js" },
+    "./components/*": "./dist/components/*.js"
+  }
+}`)
+	// A sibling package with no `exports` map — imports of it must not
+	// be rewritten through exports resolution.
+	writePackageJSON(t, filepath.Join(root, "packages", "plain"), `{
+  "name": "@acme/plain"
+}`)
+
+	idx := newNpmAliasIndex(map[string]string{"": root})
+	require.NotNil(t, idx)
+
+	caller := "packages/ui/src/widget.ts"
+	cases := []struct {
+		name      string
+		callerRel string
+		specifier string
+		want      string
+	}{
+		{"subpath maps to target file", caller, "@acme/ui/feature", "@acme/ui/dist/feature.js"},
+		{"conditional subpath prefers import", caller, "@acme/ui/button", "@acme/ui/dist/button.mjs"},
+		{"wildcard subpath splices the tail", caller, "@acme/ui/components/Card", "@acme/ui/dist/components/Card.js"},
+		{"root entry resolves a bare package import", caller, "@acme/ui", "@acme/ui/dist/index.js"},
+		{"undeclared subpath falls through", caller, "@acme/ui/missing", ""},
+		{"package without exports is untouched", "packages/plain/src/x.ts", "@acme/plain/sub", ""},
+		{"third-party package is untouched", caller, "react/jsx-runtime", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, idx.Resolve(c.callerRel, c.specifier))
+		})
+	}
+}
+
 // addPackageNode registers a KindPackage node with the given qualified
 // name — this is what CrossRepoResolver.resolveImport matches an
 // import path against (mirrors the existing cross-repo import tests).

--- a/internal/mcp/find_usages_context_test.go
+++ b/internal/mcp/find_usages_context_test.go
@@ -1,0 +1,79 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/query"
+	"github.com/zzet/gortex/internal/search"
+)
+
+// usagesContextServer builds a server whose graph references a type `Foo`
+// in three contexts: a parameter type, a return type, and a field type.
+func usagesContextServer(t *testing.T) (*Server, string) {
+	t.Helper()
+	g := graph.New()
+	foo := &graph.Node{ID: "pkg/foo.go::Foo", Kind: graph.KindType, Name: "Foo", FilePath: "pkg/foo.go"}
+	param := &graph.Node{ID: "pkg/a.go::handle#p", Kind: graph.KindParam, Name: "in", FilePath: "pkg/a.go", StartLine: 2}
+	fn := &graph.Node{ID: "pkg/a.go::make", Kind: graph.KindFunction, Name: "make", FilePath: "pkg/a.go", StartLine: 5}
+	field := &graph.Node{ID: "pkg/b.go::Box.item", Kind: graph.KindField, Name: "item", FilePath: "pkg/b.go", StartLine: 3}
+	for _, n := range []*graph.Node{foo, param, fn, field} {
+		g.AddNode(n)
+	}
+	g.AddEdge(&graph.Edge{From: param.ID, To: foo.ID, Kind: graph.EdgeTypedAs, FilePath: "pkg/a.go", Line: 2})
+	g.AddEdge(&graph.Edge{From: fn.ID, To: foo.ID, Kind: graph.EdgeReturns, FilePath: "pkg/a.go", Line: 5})
+	g.AddEdge(&graph.Edge{From: field.ID, To: foo.ID, Kind: graph.EdgeTypedAs, FilePath: "pkg/b.go", Line: 3})
+
+	eng := query.NewEngine(g)
+	eng.SetSearch(search.NewBM25())
+	return NewServer(eng, g, nil, nil, zap.NewNop(), nil), foo.ID
+}
+
+func findUsagesGroups(t *testing.T, srv *Server, args map[string]any) []any {
+	t.Helper()
+	args["group_by"] = "file"
+	req := mcplib.CallToolRequest{}
+	req.Params.Name = "find_usages"
+	req.Params.Arguments = args
+	res, err := srv.handleFindUsages(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal([]byte(res.Content[0].(mcplib.TextContent).Text), &resp))
+	groups, _ := resp["groups"].([]any)
+	return groups
+}
+
+func collectContexts(groups []any) map[string]int {
+	out := map[string]int{}
+	for _, g := range groups {
+		for _, u := range g.(map[string]any)["uses"].([]any) {
+			if ctx, ok := u.(map[string]any)["context"].(string); ok {
+				out[ctx]++
+			}
+		}
+	}
+	return out
+}
+
+func TestFindUsages_ContextLabels(t *testing.T) {
+	srv, id := usagesContextServer(t)
+	ctxs := collectContexts(findUsagesGroups(t, srv, map[string]any{"id": id}))
+	require.Equal(t, 1, ctxs["parameter_type"], "param-typed usage")
+	require.Equal(t, 1, ctxs["return_type"], "return-typed usage")
+	require.Equal(t, 1, ctxs["field"], "field-typed usage")
+}
+
+func TestFindUsages_ContextFilter(t *testing.T) {
+	srv, id := usagesContextServer(t)
+	ctxs := collectContexts(findUsagesGroups(t, srv, map[string]any{"id": id, "context": "parameter_type"}))
+	require.Equal(t, 1, ctxs["parameter_type"])
+	require.Zero(t, ctxs["return_type"], "return_type must be filtered out")
+	require.Zero(t, ctxs["field"], "field must be filtered out")
+}

--- a/internal/mcp/gcx.go
+++ b/internal/mcp/gcx.go
@@ -368,7 +368,7 @@ func encodeFindUsages(sg *query.SubGraph) ([]byte, error) {
 	meta := []string{"edges", fmt.Sprintf("%d", len(sg.Edges))}
 	meta = append(meta, zeroEdgeCaveatMeta(sg.Caveat)...)
 	enc := newGCX(&buf, "find_usages",
-		[]string{"from", "to", "edge_kind", "origin", "tier", "confidence", "from_name", "from_path", "from_line", "from_is_test", "from_test_role", "from_test_runner"},
+		[]string{"from", "to", "edge_kind", "context", "origin", "tier", "confidence", "from_name", "from_path", "from_line", "from_is_test", "from_test_role", "from_test_runner"},
 		meta...,
 	)
 	nodeIdx := indexNodes(sg.Nodes)
@@ -397,7 +397,7 @@ func encodeFindUsages(sg *query.SubGraph) ([]byte, error) {
 			tier = graph.ResolvedBy(e.Origin)
 		}
 		if err := enc.WriteRow(
-			e.From, e.To, string(e.Kind), e.Origin, tier, e.Confidence,
+			e.From, e.To, string(e.Kind), e.Context, e.Origin, tier, e.Confidence,
 			fname, fpath, fline, nodeIsTest(fn), nodeTestRole(fn), nodeTestRunner(fn),
 		); err != nil {
 			return nil, err

--- a/internal/mcp/tools_analyze_resolution_outcomes.go
+++ b/internal/mcp/tools_analyze_resolution_outcomes.go
@@ -91,18 +91,29 @@ func (s *Server) handleAnalyzeResolutionOutcomes(ctx context.Context, req mcp.Ca
 
 	byReason := map[string]int{}
 	var rows []row
-	// Cache name→candidate classification so repeated unresolved names
-	// (very common — every call to the same missing function) classify once.
-	type cand struct {
-		sameLangMin int // realSameLang count is recomputed per caller lang, so cache the raw split
+	// Memoise classification by (name, caller-language): the same
+	// unresolved name is referenced from many sites — every call to one
+	// missing function — and classifyUnresolved is pure given that pair,
+	// so this collapses a FindNodesByName-per-edge into one per distinct
+	// (name, lang).
+	type classKey struct{ name, lang string }
+	type classVal struct {
+		reason string
+		ncand  int
 	}
-	_ = cand{}
+	classCache := map[classKey]classVal{}
 	for _, p := range todo {
 		fromLang := ""
 		if n := fromNodes[p.edge.From]; n != nil {
 			fromLang = n.Language
 		}
-		reason, ncand := s.classifyUnresolved(p.name, fromLang)
+		key := classKey{name: p.name, lang: fromLang}
+		cv, ok := classCache[key]
+		if !ok {
+			cv.reason, cv.ncand = s.classifyUnresolved(p.name, fromLang)
+			classCache[key] = cv
+		}
+		reason, ncand := cv.reason, cv.ncand
 		byReason[reason]++
 		if reasonFilter != "" && reason != reasonFilter {
 			continue

--- a/internal/mcp/tools_analyze_resolution_outcomes.go
+++ b/internal/mcp/tools_analyze_resolution_outcomes.go
@@ -1,0 +1,209 @@
+package mcp
+
+import (
+	"context"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Structured resolver-suppression taxonomy. When the resolver leaves a
+// call / reference edge on an `unresolved::` placeholder it records no
+// reason — an agent only sees that the edge is unresolved, not *why*.
+// This analyzer reconstructs the why from the graph: for each unresolved
+// edge it looks up the name's definition candidates and classifies the
+// outcome. The reasons reflect Gortex's name-based resolver model (not a
+// C++ overload set), so the taxonomy is honest about how this resolver
+// actually gives up.
+const (
+	// outcomeAmbiguousMultiMatch: two or more same-name, same-language
+	// definitions exist — the resolver could not pick one and punted.
+	outcomeAmbiguousMultiMatch = "ambiguous_multi_match"
+	// outcomeCandidateOutOfScope: exactly one same-language definition
+	// exists but the edge stayed unresolved — it was outside the caller's
+	// resolution scope (cross-package guard, reachability prune, or a
+	// receiver-type mismatch).
+	outcomeCandidateOutOfScope = "candidate_out_of_scope"
+	// outcomeCrossLanguageOnly: the only definitions of this name are in a
+	// different language family, so the language gate suppressed the link.
+	outcomeCrossLanguageOnly = "cross_language_only"
+	// outcomeStubOnly: the name matches only stub / external-placeholder
+	// nodes — no real definition is indexed.
+	outcomeStubOnly = "stub_only"
+	// outcomeNoDefinition: no definition of this name exists in the graph
+	// at all — a genuinely external or un-indexed target.
+	outcomeNoDefinition = "no_definition"
+)
+
+// handleAnalyzeResolutionOutcomes classifies every unresolved call /
+// reference edge by the structured reason the resolver gave up, and
+// returns a per-reason rollup plus example rows. Optional `reason`
+// filters to one outcome; optional `limit` caps the example rows.
+func (s *Server) handleAnalyzeResolutionOutcomes(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := req.GetArguments()
+	reasonFilter := strings.TrimSpace(stringArg(args, "reason"))
+	limit := intArg(args, "limit", 50)
+
+	type row struct {
+		From       string `json:"from"`
+		To         string `json:"to"`
+		Kind       string `json:"edge_kind"`
+		Name       string `json:"name"`
+		Reason     string `json:"reason"`
+		Candidates int    `json:"candidates"`
+	}
+
+	// Collect unresolved edges + the From IDs (for language lookup).
+	type pending struct {
+		edge *graph.Edge
+		name string
+	}
+	var todo []pending
+	fromIDs := map[string]struct{}{}
+	for _, kind := range []graph.EdgeKind{graph.EdgeCalls, graph.EdgeReferences} {
+		for e := range s.graph.EdgesByKind(kind) {
+			if e == nil || !graph.IsUnresolvedTarget(e.To) {
+				continue
+			}
+			name := graph.UnresolvedName(e.To)
+			if name == "" {
+				continue
+			}
+			// A receiver-qualified placeholder (`unresolved::*.foo`) keeps
+			// its method name after the dot; normalise to the bare name.
+			if i := strings.LastIndexByte(name, '.'); i >= 0 && i+1 < len(name) {
+				name = name[i+1:]
+			}
+			todo = append(todo, pending{edge: e, name: name})
+			if e.From != "" {
+				fromIDs[e.From] = struct{}{}
+			}
+		}
+	}
+	fromList := make([]string, 0, len(fromIDs))
+	for id := range fromIDs {
+		fromList = append(fromList, id)
+	}
+	fromNodes := s.graph.GetNodesByIDs(fromList)
+
+	byReason := map[string]int{}
+	var rows []row
+	// Cache name→candidate classification so repeated unresolved names
+	// (very common — every call to the same missing function) classify once.
+	type cand struct {
+		sameLangMin int // realSameLang count is recomputed per caller lang, so cache the raw split
+	}
+	_ = cand{}
+	for _, p := range todo {
+		fromLang := ""
+		if n := fromNodes[p.edge.From]; n != nil {
+			fromLang = n.Language
+		}
+		reason, ncand := s.classifyUnresolved(p.name, fromLang)
+		byReason[reason]++
+		if reasonFilter != "" && reason != reasonFilter {
+			continue
+		}
+		if len(rows) < limit {
+			rows = append(rows, row{
+				From: p.edge.From, To: p.edge.To, Kind: string(p.edge.Kind),
+				Name: p.name, Reason: reason, Candidates: ncand,
+			})
+		}
+	}
+
+	if isCompact(req) {
+		var b strings.Builder
+		reasons := make([]string, 0, len(byReason))
+		for r := range byReason {
+			reasons = append(reasons, r)
+		}
+		sort.Slice(reasons, func(i, j int) bool { return byReason[reasons[i]] > byReason[reasons[j]] })
+		for _, r := range reasons {
+			b.WriteString(r)
+			b.WriteString(": ")
+			b.WriteString(strconv.Itoa(byReason[r]))
+			b.WriteByte('\n')
+		}
+		if len(byReason) == 0 {
+			b.WriteString("no unresolved edges\n")
+		}
+		return mcp.NewToolResultText(b.String()), nil
+	}
+
+	total := 0
+	for _, n := range byReason {
+		total += n
+	}
+	return s.respondJSONOrTOON(ctx, req, map[string]any{
+		"by_reason": byReason,
+		"total":     total,
+		"rows":      rows,
+	})
+}
+
+// classifyUnresolved returns the structured suppression reason for an
+// unresolved name relative to the caller's language, plus the number of
+// real (non-stub) definition candidates considered.
+func (s *Server) classifyUnresolved(name, fromLang string) (reason string, candidates int) {
+	var realSameLang, realOtherLang, stubs int
+	for _, n := range s.graph.FindNodesByName(name) {
+		if n == nil {
+			continue
+		}
+		if graph.IsStub(n.ID) {
+			stubs++
+			continue
+		}
+		if !nodeIsDefinitionKind(n.Kind) {
+			continue
+		}
+		if fromLang != "" && n.Language != "" && !sameLanguageFamily(fromLang, n.Language) {
+			realOtherLang++
+			continue
+		}
+		realSameLang++
+	}
+	switch {
+	case realSameLang >= 2:
+		return outcomeAmbiguousMultiMatch, realSameLang
+	case realSameLang == 1:
+		return outcomeCandidateOutOfScope, 1
+	case realOtherLang >= 1:
+		return outcomeCrossLanguageOnly, realOtherLang
+	case stubs >= 1:
+		return outcomeStubOnly, 0
+	default:
+		return outcomeNoDefinition, 0
+	}
+}
+
+// nodeIsDefinitionKind reports whether a node kind is a callable / type
+// definition an unresolved call or reference could legitimately bind to.
+func nodeIsDefinitionKind(k graph.NodeKind) bool {
+	switch k {
+	case graph.KindFunction, graph.KindMethod, graph.KindType,
+		graph.KindInterface, graph.KindVariable, graph.KindConstant, graph.KindField:
+		return true
+	}
+	return false
+}
+
+// sameLanguageFamily folds the TS/JS pair so a cross-file TS→JS reference
+// is not mis-reported as a cross-language suppression.
+func sameLanguageFamily(a, b string) bool {
+	if a == b {
+		return true
+	}
+	norm := func(l string) string {
+		switch l {
+		case "javascript", "typescript", "tsx", "jsx":
+			return "jsts"
+		}
+		return l
+	}
+	return norm(a) == norm(b)
+}

--- a/internal/mcp/tools_analyze_resolution_outcomes_test.go
+++ b/internal/mcp/tools_analyze_resolution_outcomes_test.go
@@ -1,0 +1,82 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func callAnalyzeResolutionOutcomes(t *testing.T, srv *Server, args map[string]any) map[string]any {
+	t.Helper()
+	args["kind"] = "resolution_outcomes"
+	req := mcplib.CallToolRequest{}
+	req.Params.Name = "analyze"
+	req.Params.Arguments = args
+	res, err := srv.handleAnalyze(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleAnalyze: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("error: %+v", res.Content)
+	}
+	textBlock := res.Content[0].(mcplib.TextContent)
+	var out map[string]any
+	if err := json.Unmarshal([]byte(textBlock.Text), &out); err != nil {
+		t.Fatalf("json: %v\n%s", err, textBlock.Text)
+	}
+	return out
+}
+
+func TestAnalyzeResolutionOutcomes_Taxonomy(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	g := srv.graph
+	// caller (go)
+	g.AddNode(&graph.Node{ID: "a.go::caller", Kind: graph.KindFunction, Name: "caller", FilePath: "a.go", Language: "go"})
+
+	// ambiguous_multi_match: two same-name go funcs named "doThing".
+	g.AddNode(&graph.Node{ID: "x.go::doThing", Kind: graph.KindFunction, Name: "doThing", FilePath: "x.go", Language: "go"})
+	g.AddNode(&graph.Node{ID: "y.go::doThing", Kind: graph.KindFunction, Name: "doThing", FilePath: "y.go", Language: "go"})
+	g.AddEdge(&graph.Edge{From: "a.go::caller", To: "unresolved::doThing", Kind: graph.EdgeCalls, FilePath: "a.go", Line: 2})
+
+	// candidate_out_of_scope: exactly one same-lang def named "single".
+	g.AddNode(&graph.Node{ID: "z.go::single", Kind: graph.KindFunction, Name: "single", FilePath: "z.go", Language: "go"})
+	g.AddEdge(&graph.Edge{From: "a.go::caller", To: "unresolved::single", Kind: graph.EdgeCalls, FilePath: "a.go", Line: 3})
+
+	// cross_language_only: only a python def named "pyOnly".
+	g.AddNode(&graph.Node{ID: "p.py::pyOnly", Kind: graph.KindFunction, Name: "pyOnly", FilePath: "p.py", Language: "python"})
+	g.AddEdge(&graph.Edge{From: "a.go::caller", To: "unresolved::pyOnly", Kind: graph.EdgeCalls, FilePath: "a.go", Line: 4})
+
+	// no_definition: nothing named "ghost".
+	g.AddEdge(&graph.Edge{From: "a.go::caller", To: "unresolved::ghost", Kind: graph.EdgeCalls, FilePath: "a.go", Line: 5})
+
+	out := callAnalyzeResolutionOutcomes(t, srv, map[string]any{})
+	byReason, _ := out["by_reason"].(map[string]any)
+	check := func(reason string, want int) {
+		if got, _ := byReason[reason].(float64); int(got) != want {
+			t.Errorf("by_reason[%q] = %v, want %d", reason, byReason[reason], want)
+		}
+	}
+	check(outcomeAmbiguousMultiMatch, 1)
+	check(outcomeCandidateOutOfScope, 1)
+	check(outcomeCrossLanguageOnly, 1)
+	check(outcomeNoDefinition, 1)
+}
+
+func TestAnalyzeResolutionOutcomes_ReasonFilter(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	g := srv.graph
+	g.AddNode(&graph.Node{ID: "a.go::caller", Kind: graph.KindFunction, Name: "caller", FilePath: "a.go", Language: "go"})
+	g.AddEdge(&graph.Edge{From: "a.go::caller", To: "unresolved::ghost", Kind: graph.EdgeCalls, FilePath: "a.go", Line: 5})
+
+	out := callAnalyzeResolutionOutcomes(t, srv, map[string]any{"reason": outcomeNoDefinition})
+	rows, _ := out["rows"].([]any)
+	if len(rows) != 1 {
+		t.Fatalf("reason filter: want 1 row, got %d", len(rows))
+	}
+	if rows[0].(map[string]any)["reason"] != outcomeNoDefinition {
+		t.Errorf("row reason = %v", rows[0])
+	}
+}

--- a/internal/mcp/tools_analyze_synthesizers.go
+++ b/internal/mcp/tools_analyze_synthesizers.go
@@ -1,0 +1,113 @@
+package mcp
+
+import (
+	"context"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// Edge.Meta keys the framework dynamic-dispatch synthesizer engine
+// stamps (mirrors resolver.MetaSynthesizedBy / MetaProvenance — kept as
+// literals here so the MCP layer doesn't depend on the resolver package
+// just for two string constants).
+const (
+	metaSynthesizedByKey = "synthesized_by"
+	metaProvenanceKey    = "provenance"
+)
+
+// handleAnalyzeSynthesizers rolls up the framework dynamic-dispatch
+// synthesizer engine's output: every edge carrying a `synthesized_by`
+// provenance marker, grouped by the synthesizer that produced it. This
+// is the queryable face of the engine — "which framework-dispatch passes
+// fired, and how many edges did each materialise?" — letting an agent
+// audit the heuristic, framework-wired call edges (gRPC stub → handler,
+// Temporal proxy → activity, event-channel emit → listener, native
+// bridge call → implementation) separately from compiler-verified ones.
+//
+// Optional `name` filters to a single synthesizer.
+func (s *Server) handleAnalyzeSynthesizers(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := req.GetArguments()
+	nameFilter := strings.TrimSpace(stringArg(args, "name"))
+
+	type sample struct {
+		From string `json:"from"`
+		To   string `json:"to"`
+		Kind string `json:"kind"`
+		Via  string `json:"via,omitempty"`
+	}
+	type synthRow struct {
+		Name       string         `json:"synthesizer"`
+		Provenance string         `json:"provenance"`
+		Edges      int            `json:"edges"`
+		ByKind     map[string]int `json:"by_kind"`
+		Samples    []sample       `json:"samples,omitempty"`
+	}
+	const maxSamples = 5
+	rows := map[string]*synthRow{}
+	for _, e := range s.graph.AllEdges() {
+		if e == nil || e.Meta == nil {
+			continue
+		}
+		by, _ := e.Meta[metaSynthesizedByKey].(string)
+		if by == "" {
+			continue
+		}
+		if nameFilter != "" && by != nameFilter {
+			continue
+		}
+		row, ok := rows[by]
+		if !ok {
+			prov, _ := e.Meta[metaProvenanceKey].(string)
+			row = &synthRow{Name: by, Provenance: prov, ByKind: map[string]int{}}
+			rows[by] = row
+		}
+		row.Edges++
+		row.ByKind[string(e.Kind)]++
+		if len(row.Samples) < maxSamples {
+			via, _ := e.Meta["via"].(string)
+			row.Samples = append(row.Samples, sample{
+				From: e.From,
+				To:   e.To,
+				Kind: string(e.Kind),
+				Via:  via,
+			})
+		}
+	}
+
+	out := make([]*synthRow, 0, len(rows))
+	total := 0
+	for _, r := range rows {
+		total += r.Edges
+		out = append(out, r)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Edges != out[j].Edges {
+			return out[i].Edges > out[j].Edges
+		}
+		return out[i].Name < out[j].Name
+	})
+
+	if isCompact(req) {
+		var b strings.Builder
+		for _, r := range out {
+			b.WriteString(r.Name)
+			b.WriteString(": ")
+			b.WriteString(strconv.Itoa(r.Edges))
+			b.WriteString(" edges (")
+			b.WriteString(r.Provenance)
+			b.WriteString(")\n")
+		}
+		if len(out) == 0 {
+			b.WriteString("no synthesized edges\n")
+		}
+		return mcp.NewToolResultText(b.String()), nil
+	}
+
+	return s.respondJSONOrTOON(ctx, req, map[string]any{
+		"synthesizers": out,
+		"total_edges":  total,
+	})
+}

--- a/internal/mcp/tools_analyze_synthesizers_test.go
+++ b/internal/mcp/tools_analyze_synthesizers_test.go
@@ -1,0 +1,85 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func callAnalyzeSynthesizers(t *testing.T, srv *Server, args map[string]any) map[string]any {
+	t.Helper()
+	args["kind"] = "synthesizers"
+	req := mcplib.CallToolRequest{}
+	req.Params.Name = "analyze"
+	req.Params.Arguments = args
+	res, err := srv.handleAnalyze(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleAnalyze: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("error: %+v", res.Content)
+	}
+	textBlock := res.Content[0].(mcplib.TextContent)
+	var out map[string]any
+	if err := json.Unmarshal([]byte(textBlock.Text), &out); err != nil {
+		t.Fatalf("json: %v\n%s", err, textBlock.Text)
+	}
+	return out
+}
+
+func addSynthEdge(g graph.Store, from, to, by, via string) {
+	g.AddEdge(&graph.Edge{
+		From: from, To: to, Kind: graph.EdgeCalls,
+		Meta: map[string]any{
+			"synthesized_by": by,
+			"provenance":     "heuristic",
+			"via":            via,
+		},
+	})
+}
+
+func TestAnalyzeSynthesizers_GroupsByName(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	addSynthEdge(srv.graph, "a.go::A", "b.go::B", "event-channel", "event.channel")
+	addSynthEdge(srv.graph, "a.go::A", "c.go::C", "event-channel", "event.channel")
+	addSynthEdge(srv.graph, "cli.go::run", "svc.go::Handle", "grpc-stub", "grpc.stub")
+	// A plain (non-synthesized) edge must be ignored.
+	srv.graph.AddEdge(&graph.Edge{From: "x.go::X", To: "y.go::Y", Kind: graph.EdgeCalls})
+
+	out := callAnalyzeSynthesizers(t, srv, map[string]any{})
+	if total, _ := out["total_edges"].(float64); int(total) != 3 {
+		t.Fatalf("expected 3 synthesized edges, got %v", out["total_edges"])
+	}
+	rows, _ := out["synthesizers"].([]any)
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 synthesizer groups, got %d", len(rows))
+	}
+	first := rows[0].(map[string]any)
+	if first["synthesizer"] != "event-channel" {
+		t.Errorf("expected event-channel first (most edges), got %v", first["synthesizer"])
+	}
+	if edges, _ := first["edges"].(float64); int(edges) != 2 {
+		t.Errorf("expected event-channel to have 2 edges, got %v", first["edges"])
+	}
+	if first["provenance"] != "heuristic" {
+		t.Errorf("expected heuristic provenance, got %v", first["provenance"])
+	}
+}
+
+func TestAnalyzeSynthesizers_NameFilter(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	addSynthEdge(srv.graph, "a.go::A", "b.go::B", "event-channel", "event.channel")
+	addSynthEdge(srv.graph, "cli.go::run", "svc.go::Handle", "grpc-stub", "grpc.stub")
+
+	out := callAnalyzeSynthesizers(t, srv, map[string]any{"name": "grpc-stub"})
+	rows, _ := out["synthesizers"].([]any)
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 group with name filter, got %d", len(rows))
+	}
+	if rows[0].(map[string]any)["synthesizer"] != "grpc-stub" {
+		t.Errorf("name filter failed: %v", rows[0])
+	}
+}

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -938,6 +938,7 @@ func (s *Server) registerCoreTools() {
 			mcp.WithString("min_tier", mcp.Description(minTierParamDescription)),
 			mcp.WithBoolean("exclude_tests", mcp.Description("Drop references originating in test functions (set true to see only production usages)")),
 			mcp.WithString("group_by", mcp.Description("Set to \"file\" to bucket the usages by the file each reference originates in -- each group carries the per-file use count and the enclosing symbol of every reference. Omit for the default flat result.")),
+			mcp.WithString("context", mcp.Description("Filter usages by their reference context — the role the symbol plays at each site: parameter_type, return_type, field, value, type, attribute, generic_arg, or call. Every returned usage also carries its classified context. Omit for all usages.")),
 		),
 		s.handleFindUsages,
 	)
@@ -2112,6 +2113,10 @@ func (s *Server) handleFindUsages(ctx context.Context, req mcp.CallToolRequest) 
 	sg = filterSubGraph(sg, allowed)
 	sg.FilterByMinTier(minTier)
 	enrichSubGraphEdges(sg)
+	// Classify each usage's reference context (parameter_type / return_type
+	// / field / value / type / attribute / call) and optionally filter to
+	// one context — `find_usages context:"parameter_type"`.
+	annotateAndFilterUsageContext(sg, strings.ToLower(strings.TrimSpace(req.GetString("context", ""))))
 	if len(sg.Edges) == 0 {
 		sg.Caveat = graph.CaveatForZeroEdge(s.graph, id)
 	}
@@ -2128,6 +2133,37 @@ func (s *Server) handleFindUsages(ctx context.Context, req mcp.CallToolRequest) 
 	return s.returnSubGraph(ctx, req, sg)
 }
 
+// annotateAndFilterUsageContext stamps each usage edge with its
+// reference context (RefContextOf, using the origin node's kind) and, when
+// contextFilter is non-empty, drops every usage whose context does not
+// match — the engine behind `find_usages context:"parameter_type"`.
+func annotateAndFilterUsageContext(sg *query.SubGraph, contextFilter string) {
+	if sg == nil {
+		return
+	}
+	nodeByID := make(map[string]*graph.Node, len(sg.Nodes))
+	for _, n := range sg.Nodes {
+		nodeByID[n.ID] = n
+	}
+	for _, e := range sg.Edges {
+		var fromKind graph.NodeKind
+		if fn := nodeByID[e.From]; fn != nil {
+			fromKind = fn.Kind
+		}
+		e.Context = graph.RefContextOf(e, fromKind)
+	}
+	if contextFilter == "" {
+		return
+	}
+	kept := sg.Edges[:0]
+	for _, e := range sg.Edges {
+		if e.Context == contextFilter {
+			kept = append(kept, e)
+		}
+	}
+	sg.Edges = kept
+}
+
 // usageFileGroup is one file's worth of references from a
 // group_by:"file" find_usages response.
 type usageFileGroup struct {
@@ -2141,6 +2177,7 @@ type usageFileGroup struct {
 type usageGroupItem struct {
 	Line       int    `json:"line"`
 	EdgeKind   string `json:"edge_kind"`
+	Context    string `json:"context,omitempty"`
 	SymbolID   string `json:"symbol_id,omitempty"`
 	SymbolName string `json:"symbol_name,omitempty"`
 }
@@ -2170,7 +2207,7 @@ func groupUsagesByFile(sg *query.SubGraph) map[string]any {
 			g = &usageFileGroup{File: file}
 			groups[file] = g
 		}
-		item := usageGroupItem{Line: e.Line, EdgeKind: string(e.Kind)}
+		item := usageGroupItem{Line: e.Line, EdgeKind: string(e.Kind), Context: e.Context}
 		if from != nil {
 			item.SymbolID = from.ID
 			item.SymbolName = from.Name

--- a/internal/mcp/tools_enhancements.go
+++ b/internal/mcp/tools_enhancements.go
@@ -695,7 +695,7 @@ func (s *Server) handlePrefetchContext(ctx context.Context, req mcp.CallToolRequ
 func (s *Server) handleAnalyze(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	kind, err := req.RequireString("kind")
 	if err != nil {
-		return mcp.NewToolResultError("kind is required (one of: dead_code, hotspots, cycles, would_create_cycle, todos, blame, coverage, stale_code, ownership, coverage_gaps, stale_flags, releases, cgo_users, wasm_users, orphan_tables, unreferenced_tables, coverage_summary, channel_ops, goroutine_spawns, field_writers, race_writes, unclosed_channels, unsafe_patterns, health_score, annotation_users, config_readers, event_emitters, pubsub, string_emitters, error_surface, log_events, sql_rebuild, external_calls, routes, models, components, k8s_resources, images, kustomize, cross_repo, impact, named, tests_as_edges, connectivity_health, pagerank, louvain, wcc, scc, kcore)"), nil
+		return mcp.NewToolResultError("kind is required (one of: dead_code, hotspots, cycles, would_create_cycle, todos, blame, coverage, stale_code, ownership, coverage_gaps, stale_flags, releases, cgo_users, wasm_users, orphan_tables, unreferenced_tables, coverage_summary, channel_ops, goroutine_spawns, field_writers, race_writes, unclosed_channels, unsafe_patterns, health_score, annotation_users, config_readers, event_emitters, pubsub, string_emitters, error_surface, log_events, sql_rebuild, external_calls, synthesizers, routes, models, components, k8s_resources, images, kustomize, cross_repo, impact, named, tests_as_edges, connectivity_health, pagerank, louvain, wcc, scc, kcore)"), nil
 	}
 	switch kind {
 	case "dead_code":
@@ -776,6 +776,8 @@ func (s *Server) handleAnalyze(ctx context.Context, req mcp.CallToolRequest) (*m
 		return s.handleAnalyzeSQLRebuild(ctx, req)
 	case "external_calls":
 		return s.handleAnalyzeExternalCalls(ctx, req)
+	case "synthesizers":
+		return s.handleAnalyzeSynthesizers(ctx, req)
 	case "routes":
 		return s.handleAnalyzeRoutes(ctx, req)
 	case "models":

--- a/internal/mcp/tools_enhancements.go
+++ b/internal/mcp/tools_enhancements.go
@@ -695,7 +695,7 @@ func (s *Server) handlePrefetchContext(ctx context.Context, req mcp.CallToolRequ
 func (s *Server) handleAnalyze(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	kind, err := req.RequireString("kind")
 	if err != nil {
-		return mcp.NewToolResultError("kind is required (one of: dead_code, hotspots, cycles, would_create_cycle, todos, blame, coverage, stale_code, ownership, coverage_gaps, stale_flags, releases, cgo_users, wasm_users, orphan_tables, unreferenced_tables, coverage_summary, channel_ops, goroutine_spawns, field_writers, race_writes, unclosed_channels, unsafe_patterns, health_score, annotation_users, config_readers, event_emitters, pubsub, string_emitters, error_surface, log_events, sql_rebuild, external_calls, synthesizers, routes, models, components, k8s_resources, images, kustomize, cross_repo, impact, named, tests_as_edges, connectivity_health, pagerank, louvain, wcc, scc, kcore)"), nil
+		return mcp.NewToolResultError("kind is required (one of: dead_code, hotspots, cycles, would_create_cycle, todos, blame, coverage, stale_code, ownership, coverage_gaps, stale_flags, releases, cgo_users, wasm_users, orphan_tables, unreferenced_tables, coverage_summary, channel_ops, goroutine_spawns, field_writers, race_writes, unclosed_channels, unsafe_patterns, health_score, annotation_users, config_readers, event_emitters, pubsub, string_emitters, error_surface, log_events, sql_rebuild, external_calls, synthesizers, resolution_outcomes, routes, models, components, k8s_resources, images, kustomize, cross_repo, impact, named, tests_as_edges, connectivity_health, pagerank, louvain, wcc, scc, kcore)"), nil
 	}
 	switch kind {
 	case "dead_code":
@@ -778,6 +778,8 @@ func (s *Server) handleAnalyze(ctx context.Context, req mcp.CallToolRequest) (*m
 		return s.handleAnalyzeExternalCalls(ctx, req)
 	case "synthesizers":
 		return s.handleAnalyzeSynthesizers(ctx, req)
+	case "resolution_outcomes":
+		return s.handleAnalyzeResolutionOutcomes(ctx, req)
 	case "routes":
 		return s.handleAnalyzeRoutes(ctx, req)
 	case "models":

--- a/internal/parser/detect_content.go
+++ b/internal/parser/detect_content.go
@@ -137,8 +137,22 @@ func sniffAmbiguous(ext string, content []byte) (string, bool) {
 		if hasMathematicaMarkers(probe) {
 			return "mathematica", true
 		}
+	case ".xml":
+		// A MyBatis mapper XML routes to the mybatis extractor; every
+		// other .xml keeps the generic "xml" default.
+		if hasMyBatisMapperMarkers(probe) {
+			return "mybatis", true
+		}
 	}
 	return "", false
+}
+
+// hasMyBatisMapperMarkers reports whether the content is a MyBatis mapper
+// XML document — a `<mapper` root element or the MyBatis mapper DTD. Kept
+// in package parser (inlined rather than calling languages.IsMyBatisMapper)
+// to avoid an import cycle.
+func hasMyBatisMapperMarkers(b []byte) bool {
+	return bytes.Contains(b, []byte("<mapper")) || bytes.Contains(b, []byte("mybatis.org//DTD Mapper"))
 }
 
 // hasObjCMarkers reports whether the content carries a syntax

--- a/internal/parser/detect_content.go
+++ b/internal/parser/detect_content.go
@@ -138,10 +138,13 @@ func sniffAmbiguous(ext string, content []byte) (string, bool) {
 			return "mathematica", true
 		}
 	case ".xml":
-		// A MyBatis mapper XML routes to the mybatis extractor; every
-		// other .xml keeps the generic "xml" default.
+		// A MyBatis mapper / Spring beans XML routes to its specific
+		// extractor; every other .xml keeps the generic "xml" default.
 		if hasMyBatisMapperMarkers(probe) {
 			return "mybatis", true
+		}
+		if hasSpringBeansMarkers(probe) {
+			return "spring", true
 		}
 	}
 	return "", false
@@ -153,6 +156,15 @@ func sniffAmbiguous(ext string, content []byte) (string, bool) {
 // to avoid an import cycle.
 func hasMyBatisMapperMarkers(b []byte) bool {
 	return bytes.Contains(b, []byte("<mapper")) || bytes.Contains(b, []byte("mybatis.org//DTD Mapper"))
+}
+
+// hasSpringBeansMarkers reports whether the content is a Spring beans XML
+// document — the Spring beans schema namespace, or a `<beans>`/`<bean>`
+// DTD-style document. Inlined in package parser to avoid an import cycle
+// with languages.IsSpringBeansXML.
+func hasSpringBeansMarkers(b []byte) bool {
+	return bytes.Contains(b, []byte("springframework.org/schema/beans")) ||
+		(bytes.Contains(b, []byte("<beans")) && bytes.Contains(b, []byte("<bean")))
 }
 
 // hasObjCMarkers reports whether the content carries a syntax

--- a/internal/parser/detect_content_test.go
+++ b/internal/parser/detect_content_test.go
@@ -19,6 +19,11 @@ func ambiguityRegistry() *Registry {
 	r.Register(&mockExtractor{lang: "perl", exts: []string{".pl"}})
 	r.Register(&mockExtractor{lang: "python", exts: []string{".py"}})
 	r.Register(&mockExtractor{lang: "bash", exts: []string{".sh"}})
+	// .xml defaults to the generic xml extractor; a MyBatis mapper is
+	// content-routed to "mybatis" (which claims no extension here, so it
+	// never overrides the .xml default).
+	r.Register(&mockExtractor{lang: "mybatis"})
+	r.Register(&mockExtractor{lang: "xml", exts: []string{".xml"}})
 	return r
 }
 
@@ -133,6 +138,24 @@ func TestDetectLanguageContent_AmbiguousDotM(t *testing.T) {
 	lang, ok = r.DetectLanguageContent("plain.m", []byte("int main() { return 0; }\n"))
 	assert.True(t, ok)
 	assert.Equal(t, "objc", lang)
+}
+
+func TestDetectLanguageContent_MyBatisMapper(t *testing.T) {
+	r := ambiguityRegistry()
+
+	mapper := []byte(`<?xml version="1.0"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "...">
+<mapper namespace="com.app.UserMapper">
+  <select id="findUser" resultType="User">SELECT * FROM users WHERE id = #{id}</select>
+</mapper>`)
+	lang, ok := r.DetectLanguageContent("UserMapper.xml", mapper)
+	assert.True(t, ok)
+	assert.Equal(t, "mybatis", lang, "a mapper document routes to the mybatis extractor")
+
+	// A generic XML document keeps the xml default.
+	lang, ok = r.DetectLanguageContent("config.xml", []byte(`<?xml version="1.0"?><config><name>x</name></config>`))
+	assert.True(t, ok)
+	assert.Equal(t, "xml", lang)
 }
 
 func TestDetectLanguageContent_NilContentMatchesNameOnly(t *testing.T) {

--- a/internal/parser/detect_content_test.go
+++ b/internal/parser/detect_content_test.go
@@ -23,6 +23,7 @@ func ambiguityRegistry() *Registry {
 	// content-routed to "mybatis" (which claims no extension here, so it
 	// never overrides the .xml default).
 	r.Register(&mockExtractor{lang: "mybatis"})
+	r.Register(&mockExtractor{lang: "spring"})
 	r.Register(&mockExtractor{lang: "xml", exts: []string{".xml"}})
 	return r
 }
@@ -151,6 +152,15 @@ func TestDetectLanguageContent_MyBatisMapper(t *testing.T) {
 	lang, ok := r.DetectLanguageContent("UserMapper.xml", mapper)
 	assert.True(t, ok)
 	assert.Equal(t, "mybatis", lang, "a mapper document routes to the mybatis extractor")
+
+	// A Spring beans XML routes to the spring extractor.
+	beans := []byte(`<?xml version="1.0"?>
+<beans xmlns="http://www.springframework.org/schema/beans">
+  <bean id="svc" class="com.app.Svc"/>
+</beans>`)
+	lang, ok = r.DetectLanguageContent("applicationContext.xml", beans)
+	assert.True(t, ok)
+	assert.Equal(t, "spring", lang)
 
 	// A generic XML document keeps the xml default.
 	lang, ok = r.DetectLanguageContent("config.xml", []byte(`<?xml version="1.0"?><config><name>x</name></config>`))

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -2,6 +2,7 @@ package languages
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/zzet/gortex/internal/graph"
@@ -9,6 +10,14 @@ import (
 	sitter "github.com/zzet/gortex/internal/parser/tsitter"
 	"github.com/zzet/gortex/internal/parser/tsitter/csharp"
 )
+
+// csharpInterfaceNamePattern encodes the C# `I`-prefix convention
+// (IService, IRepository, IList): an interface name conventionally
+// starts with a capital `I` followed by another uppercase letter. The
+// base-list heuristic falls back to this when a base type is defined in
+// another compilation unit and so cannot be matched against the file's
+// own interface declarations.
+var csharpInterfaceNamePattern = regexp.MustCompile(`^I[A-Z]`)
 
 // qCSharpAll is a single tree-sitter query alternating over every
 // pattern the C# extractor needs. One tree walk per file replaces the
@@ -34,6 +43,9 @@ const qCSharpAll = `
 
   (struct_declaration
     name: (identifier) @struct.name) @struct.def
+
+  (record_declaration
+    name: (identifier) @record.name) @record.def
 
   (enum_declaration
     name: (identifier) @enum.name) @enum.def
@@ -129,6 +141,13 @@ func (e *CSharpExtractor) Extract(filePath string, src []byte) (*parser.Extracti
 	annotationSeen := make(map[string]bool)
 	ifaceMethods := make(map[string][]string) // interface name → method names
 
+	// Pre-scan the file's own interface declarations. A base type that
+	// names one of these is definitively an interface, even when its name
+	// doesn't follow the `I`-prefix convention — the base-list heuristic
+	// (emitCSharpBaseList) checks this set before falling back to name
+	// shape so a locally-known interface always wins.
+	localInterfaces := collectCSharpInterfaceNames(root, src)
+
 	var calls []csharpDeferredCall
 	var locals []csharpDeferredLocal
 
@@ -139,16 +158,19 @@ func (e *CSharpExtractor) Extract(filePath string, src []byte) (*parser.Extracti
 			e.emitNamespace(m, filePath, fileID, result, seen)
 
 		case m.Captures["class.def"] != nil:
-			e.emitContainer(m, "class", graph.KindType, filePath, fileID, src, result, seen, annotationSeen)
+			e.emitContainer(m, "class", graph.KindType, filePath, fileID, src, result, seen, annotationSeen, localInterfaces)
 
 		case m.Captures["iface.def"] != nil:
-			e.emitContainer(m, "iface", graph.KindInterface, filePath, fileID, src, result, seen, annotationSeen)
+			e.emitContainer(m, "iface", graph.KindInterface, filePath, fileID, src, result, seen, annotationSeen, localInterfaces)
 
 		case m.Captures["struct.def"] != nil:
-			e.emitContainer(m, "struct", graph.KindType, filePath, fileID, src, result, seen, annotationSeen)
+			e.emitContainer(m, "struct", graph.KindType, filePath, fileID, src, result, seen, annotationSeen, localInterfaces)
+
+		case m.Captures["record.def"] != nil:
+			e.emitContainer(m, "record", graph.KindType, filePath, fileID, src, result, seen, annotationSeen, localInterfaces)
 
 		case m.Captures["enum.def"] != nil:
-			e.emitContainer(m, "enum", graph.KindType, filePath, fileID, src, result, seen, annotationSeen)
+			e.emitContainer(m, "enum", graph.KindType, filePath, fileID, src, result, seen, annotationSeen, localInterfaces)
 
 		case m.Captures["method.def"] != nil:
 			e.emitMethod(m, filePath, fileID, src, result, seen, annotationSeen, ifaceMethods)
@@ -291,7 +313,7 @@ func (e *CSharpExtractor) emitNamespace(m parser.QueryResult, filePath, fileID s
 // emitContainer collapses the per-kind class/interface/struct/enum
 // node emission. The capture-name prefix selects which capture set to
 // read from (the legacy code repeated this body four times).
-func (e *CSharpExtractor) emitContainer(m parser.QueryResult, kind string, nodeKind graph.NodeKind, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen, annotationSeen map[string]bool) {
+func (e *CSharpExtractor) emitContainer(m parser.QueryResult, kind string, nodeKind graph.NodeKind, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen, annotationSeen map[string]bool, localInterfaces map[string]bool) {
 	name := m.Captures[kind+".name"].Text
 	def := m.Captures[kind+".def"]
 	id := filePath + "::" + name
@@ -314,6 +336,14 @@ func (e *CSharpExtractor) emitContainer(m parser.QueryResult, kind string, nodeK
 	})
 	emitCSharpAnnotationEdges(csharpCollectAttributes(def.Node, src), id, filePath, result, annotationSeen)
 	emitCSharpGenericParamNodes(id, def.Node, src, filePath, def.StartLine+1, result)
+	// Only classes, structs, and records carry a base class / interface
+	// list that splits into EdgeExtends + EdgeImplements. Structs and
+	// `record struct` declarations have no base class — every base is an
+	// interface — which emitCSharpBaseList infers from the declaration.
+	switch kind {
+	case "class", "struct", "record":
+		emitCSharpBaseList(id, def.Node, src, filePath, localInterfaces, result)
+	}
 }
 
 // csharpVisibility scans a declaration's modifier children for an
@@ -622,6 +652,183 @@ func csharpDirectMemberOwner(member *sitter.Node, src []byte, allowed ...string)
 		}
 	}
 	return csharpOwner{}
+}
+
+// collectCSharpInterfaceNames walks the tree for every
+// interface_declaration and records its bare name. The base-list
+// heuristic consults this set first: a base type that names a
+// locally-declared interface is unambiguously an interface, regardless
+// of whether its name follows the `I`-prefix convention.
+func collectCSharpInterfaceNames(root *sitter.Node, src []byte) map[string]bool {
+	names := make(map[string]bool)
+	walkNodes(root, func(n *sitter.Node) {
+		if n.Type() != "interface_declaration" {
+			return
+		}
+		if nameNode := n.ChildByFieldName("name"); nameNode != nil {
+			names[nameNode.Content(src)] = true
+		}
+	})
+	return names
+}
+
+// emitCSharpBaseList splits a class/struct/record base list into
+// EdgeExtends (the superclass) and EdgeImplements (the interfaces).
+//
+// C# lists the optional base class and any implemented interfaces in a
+// single comma-separated base_list, and — unlike Go or Java — the
+// grammar does not tag which entry is the class. When a base type is
+// defined elsewhere (another compilation unit) the extractor cannot
+// resolve its kind, so it discriminates with a heuristic:
+//
+//  1. A base whose name matches a locally-declared interface (the
+//     prescan set) is definitively an interface → EdgeImplements.
+//  2. Otherwise a base whose name matches the `I`-prefix convention
+//     (^I[A-Z], generics stripped first so IList<T> → IList) is treated
+//     as an interface → EdgeImplements.
+//  3. The first base that is neither is the superclass → EdgeExtends.
+//     C# allows at most one base class and it must come first; every
+//     base after it is an interface. Structs and `record struct`
+//     declarations have no base class, so all of their bases are
+//     interfaces regardless of position.
+//
+// All edges ride at OriginASTInferred: the discrimination is a
+// heuristic, not a type-checked fact. Targets are left unresolved so
+// the resolver binds them like every other C# reference. A base that
+// resolves to a same-file class still flows through unchanged — it is
+// neither a known interface nor I-prefixed, so it lands as EdgeExtends.
+func emitCSharpBaseList(typeID string, decl *sitter.Node, src []byte, filePath string, localInterfaces map[string]bool, result *parser.ExtractionResult) {
+	if decl == nil {
+		return
+	}
+	baseList := decl.ChildByFieldName("bases")
+	if baseList == nil {
+		// `bases` is not a named field in every grammar revision; fall
+		// back to a direct child scan for the base_list node.
+		for i := 0; i < int(decl.ChildCount()); i++ {
+			c := decl.Child(i)
+			if c != nil && c.Type() == "base_list" {
+				baseList = c
+				break
+			}
+		}
+	}
+	if baseList == nil {
+		return
+	}
+	// Structs and `record struct` cannot derive from a base class — the
+	// CLR forbids it — so every entry in their base list is an interface
+	// and the "first non-interface is the superclass" branch never runs.
+	allowsBaseClass := csharpDeclAllowsBaseClass(decl)
+	extendsTaken := false
+	for i := 0; i < int(baseList.NamedChildCount()); i++ {
+		entry := baseList.NamedChild(i)
+		if entry == nil {
+			continue
+		}
+		name, isCtorBase := csharpBaseTypeName(entry, src)
+		if name == "" {
+			continue
+		}
+		line := int(entry.StartPoint().Row) + 1
+		// A primary_constructor_base_type (`: Base(args)`) invokes a base
+		// constructor, which is only valid for a base class — it is never
+		// an interface.
+		isInterface := !isCtorBase &&
+			(localInterfaces[name] || csharpInterfaceNamePattern.MatchString(name))
+		kind := graph.EdgeImplements
+		if !isInterface && allowsBaseClass && !extendsTaken {
+			kind = graph.EdgeExtends
+			extendsTaken = true
+		}
+		result.Edges = append(result.Edges, &graph.Edge{
+			From: typeID, To: "unresolved::" + name,
+			Kind: kind, FilePath: filePath, Line: line,
+			Origin: graph.OriginASTInferred,
+		})
+	}
+}
+
+// csharpDeclAllowsBaseClass reports whether a class/struct/record
+// declaration can have a base class. Structs never can; a record is a
+// struct when its declaration carries the `struct` keyword
+// (`record struct`), otherwise it is a reference type that can extend a
+// base record/class.
+func csharpDeclAllowsBaseClass(decl *sitter.Node) bool {
+	switch decl.Type() {
+	case "struct_declaration":
+		return false
+	case "record_declaration":
+		for i := 0; i < int(decl.ChildCount()); i++ {
+			if c := decl.Child(i); c != nil && c.Type() == "struct" {
+				return false
+			}
+		}
+		return true
+	default:
+		return true
+	}
+}
+
+// csharpBaseTypeName extracts the bare type name from a single base_list
+// entry, stripping generic arguments and namespace qualification so the
+// `I`-prefix test sees IList rather than IList<int> or System.IList. The
+// bool return reports whether the entry is a primary_constructor_base_type
+// (`Base(args)`), which can only ever be a base class.
+func csharpBaseTypeName(entry *sitter.Node, src []byte) (string, bool) {
+	switch entry.Type() {
+	case "identifier":
+		return entry.Content(src), false
+	case "generic_name":
+		// First child is the base identifier; the type_argument_list
+		// follows. IList<int> → IList.
+		if id := entry.ChildByFieldName("name"); id != nil {
+			return id.Content(src), false
+		}
+		for i := 0; i < int(entry.ChildCount()); i++ {
+			if c := entry.Child(i); c != nil && c.Type() == "identifier" {
+				return c.Content(src), false
+			}
+		}
+	case "qualified_name":
+		// System.Object → Object (the last identifier).
+		var last string
+		for i := 0; i < int(entry.ChildCount()); i++ {
+			if c := entry.Child(i); c != nil && c.Type() == "identifier" {
+				last = c.Content(src)
+			}
+		}
+		return last, false
+	case "primary_constructor_base_type":
+		// `: Base(args)` — record base-constructor call; always a class.
+		if id := entry.ChildByFieldName("type"); id != nil {
+			return normalizeCSharpBaseName(id.Content(src)), true
+		}
+		for i := 0; i < int(entry.ChildCount()); i++ {
+			c := entry.Child(i)
+			if c == nil {
+				continue
+			}
+			if c.Type() == "identifier" || c.Type() == "generic_name" || c.Type() == "qualified_name" {
+				return normalizeCSharpBaseName(c.Content(src)), true
+			}
+		}
+	}
+	return "", false
+}
+
+// normalizeCSharpBaseName reduces a raw base-type spelling to its bare
+// simple name: drops generic arguments (Foo<T> → Foo) and namespace
+// qualification (A.B.Foo → Foo).
+func normalizeCSharpBaseName(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if idx := strings.Index(raw, "<"); idx > 0 {
+		raw = raw[:idx]
+	}
+	if idx := strings.LastIndex(raw, "."); idx >= 0 {
+		raw = raw[idx+1:]
+	}
+	return strings.TrimSpace(raw)
 }
 
 // extractCSharpMethodReturnType walks a method_declaration node for

--- a/internal/parser/languages/csharp_test.go
+++ b/internal/parser/languages/csharp_test.go
@@ -409,3 +409,132 @@ func TestCSharpExtractor_DocAndVisibility(t *testing.T) {
 		t.Fatalf("Internal.vis = %q", internalT.Meta["visibility"])
 	}
 }
+
+// edgeTargetNames returns the bare target names of every edge of the
+// given kind whose From matches the given source ID. The C# base-list
+// heuristic emits unresolved targets (`unresolved::Name`), so the
+// prefix is stripped for readable assertions.
+func edgeTargetNames(edges []*graph.Edge, from string, kind graph.EdgeKind) []string {
+	var out []string
+	for _, e := range edges {
+		if e.Kind != kind || e.From != from {
+			continue
+		}
+		out = append(out, strings.TrimPrefix(e.To, "unresolved::"))
+	}
+	return out
+}
+
+func TestCSharpExtractor_BaseListDiscrimination(t *testing.T) {
+	e := NewCSharpExtractor()
+
+	t.Run("class with base class and interface", func(t *testing.T) {
+		src := []byte(`class Foo : BaseClass, IService {}`)
+		result, err := e.Extract("Foo.cs", src)
+		require.NoError(t, err)
+
+		extends := edgeTargetNames(result.Edges, "Foo.cs::Foo", graph.EdgeExtends)
+		implements := edgeTargetNames(result.Edges, "Foo.cs::Foo", graph.EdgeImplements)
+		assert.Equal(t, []string{"BaseClass"}, extends)
+		assert.Equal(t, []string{"IService"}, implements)
+
+		// Heuristic edges ride at the inferred tier, not resolved.
+		for _, ed := range result.Edges {
+			if ed.Kind == graph.EdgeExtends || ed.Kind == graph.EdgeImplements {
+				assert.Equal(t, graph.OriginASTInferred, ed.Origin)
+			}
+		}
+	})
+
+	t.Run("base resolved via local interface prescan", func(t *testing.T) {
+		// IThing breaks the I-prefix convention (it does, but we also
+		// confirm a same-file interface is honoured even by name): the
+		// prescan must classify Bar's base as an interface.
+		src := []byte(`interface IThing {}
+class Bar : IThing {}`)
+		result, err := e.Extract("Bar.cs", src)
+		require.NoError(t, err)
+
+		assert.Empty(t, edgeTargetNames(result.Edges, "Bar.cs::Bar", graph.EdgeExtends))
+		assert.Equal(t, []string{"IThing"},
+			edgeTargetNames(result.Edges, "Bar.cs::Bar", graph.EdgeImplements))
+	})
+
+	t.Run("prescan wins over name shape", func(t *testing.T) {
+		// Widget does not look like an interface (no I-prefix) but is
+		// declared as one in this file — the prescan must win, so it is
+		// implemented, not extended.
+		src := []byte(`interface Widget {}
+class Panel : Widget {}`)
+		result, err := e.Extract("Panel.cs", src)
+		require.NoError(t, err)
+
+		assert.Empty(t, edgeTargetNames(result.Edges, "Panel.cs::Panel", graph.EdgeExtends))
+		assert.Equal(t, []string{"Widget"},
+			edgeTargetNames(result.Edges, "Panel.cs::Panel", graph.EdgeImplements))
+	})
+
+	t.Run("struct implements only, never extends", func(t *testing.T) {
+		src := []byte(`struct S : IComparable {}`)
+		result, err := e.Extract("S.cs", src)
+		require.NoError(t, err)
+
+		assert.Empty(t, edgeTargetNames(result.Edges, "S.cs::S", graph.EdgeExtends))
+		assert.Equal(t, []string{"IComparable"},
+			edgeTargetNames(result.Edges, "S.cs::S", graph.EdgeImplements))
+	})
+
+	t.Run("generic interface strips type arguments", func(t *testing.T) {
+		src := []byte(`class L : IList<int> {}`)
+		result, err := e.Extract("L.cs", src)
+		require.NoError(t, err)
+
+		assert.Empty(t, edgeTargetNames(result.Edges, "L.cs::L", graph.EdgeExtends))
+		assert.Equal(t, []string{"IList"},
+			edgeTargetNames(result.Edges, "L.cs::L", graph.EdgeImplements))
+	})
+
+	t.Run("generic base class extends with stripped name", func(t *testing.T) {
+		src := []byte(`class C : Base<int>, IList<int> {}`)
+		result, err := e.Extract("C.cs", src)
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{"Base"},
+			edgeTargetNames(result.Edges, "C.cs::C", graph.EdgeExtends))
+		assert.Equal(t, []string{"IList"},
+			edgeTargetNames(result.Edges, "C.cs::C", graph.EdgeImplements))
+	})
+
+	t.Run("qualified base name reduced to simple name", func(t *testing.T) {
+		src := []byte(`class Outer : System.Object, ICloneable {}`)
+		result, err := e.Extract("Outer.cs", src)
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{"Object"},
+			edgeTargetNames(result.Edges, "Outer.cs::Outer", graph.EdgeExtends))
+		assert.Equal(t, []string{"ICloneable"},
+			edgeTargetNames(result.Edges, "Outer.cs::Outer", graph.EdgeImplements))
+	})
+
+	t.Run("record extends base and implements interface", func(t *testing.T) {
+		src := []byte(`record Rec(int X) : Base(X), IThing {}`)
+		result, err := e.Extract("Rec.cs", src)
+		require.NoError(t, err)
+
+		// The primary_constructor_base_type Base(X) is always a base class.
+		assert.Equal(t, []string{"Base"},
+			edgeTargetNames(result.Edges, "Rec.cs::Rec", graph.EdgeExtends))
+		assert.Equal(t, []string{"IThing"},
+			edgeTargetNames(result.Edges, "Rec.cs::Rec", graph.EdgeImplements))
+	})
+
+	t.Run("record struct implements only", func(t *testing.T) {
+		src := []byte(`record struct RS : IFoo {}`)
+		result, err := e.Extract("RS.cs", src)
+		require.NoError(t, err)
+
+		assert.Empty(t, edgeTargetNames(result.Edges, "RS.cs::RS", graph.EdgeExtends))
+		assert.Equal(t, []string{"IFoo"},
+			edgeTargetNames(result.Edges, "RS.cs::RS", graph.EdgeImplements))
+	})
+}

--- a/internal/parser/languages/di_container.go
+++ b/internal/parser/languages/di_container.go
@@ -80,8 +80,21 @@ func isSymfonyServicesYAML(root *yaml.Node) bool {
 	if root == nil || root.Kind != yaml.MappingNode {
 		return false
 	}
-	if svc := mappingGet(root, "services"); svc != nil && svc.Kind == yaml.MappingNode {
-		return true
+	svc := mappingGet(root, "services")
+	if svc == nil || svc.Kind != yaml.MappingNode {
+		return false
+	}
+	// Distinguish a Symfony services file from a docker-compose file —
+	// both have a top-level `services:`. Symfony service IDs are PHP FQCNs
+	// (contain a backslash) or the special `_defaults` / `_instanceof`
+	// keys; docker-compose service names are plain identifiers. Require at
+	// least one Symfony-shaped key so a compose file falls through to the
+	// generic YAML extractor.
+	for i := 0; i+1 < len(svc.Content); i += 2 {
+		key := strings.TrimSpace(svc.Content[i].Value)
+		if strings.Contains(key, `\`) || key == "_defaults" || key == "_instanceof" {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/parser/languages/di_container.go
+++ b/internal/parser/languages/di_container.go
@@ -1,0 +1,451 @@
+package languages
+
+import (
+	"bytes"
+	"encoding/xml"
+	"io"
+	"path"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+)
+
+// Dependency-injection container binding extraction.
+//
+// Frameworks like Symfony and Spring wire a constructor/field that is
+// typed as an *interface* to a *concrete class* at runtime via an
+// external config file (services.yaml, applicationContext.xml). The
+// PHP/Java source alone only shows the interface type, so a call site
+// typed as the interface looks like it has no implementation in the
+// graph. These extractors read the container config and emit the
+// interface→implementation binding so the cross-file resolver can land
+// the autowiring.
+//
+// The binding is modelled as an EdgeProvides carrying
+// binding:"useClass" + provides_for:<interface> and pointing at
+// `unresolved::<impl>`. That is the exact shape NestJS useClass and
+// Laravel `$this->app->bind` already produce, so the existing
+// resolver.buildProvidesForIndex pass — which rewrites abstract-typed
+// call sites onto the concrete impl — picks these up with no resolver
+// changes. Each edge is additionally stamped Meta["di"] = "symfony" /
+// "spring" so DI-sourced bindings are queryable as such, plus the full
+// FQCNs (interface_fqcn / impl_fqcn) for fidelity, while the
+// unresolved:: target uses the short class name (the last `\` or `.`
+// segment) because PHP/Java type nodes are keyed by short name and the
+// resolver reduces targets to a bare identifier before lookup.
+
+// diShortName returns the last `\`- or `.`-separated segment of a
+// fully-qualified class name, with a leading `@` (Symfony service
+// reference) and surrounding whitespace stripped. Returns "" for empty
+// input. `App\Foo\BarImpl` → `BarImpl`; `com.app.BarImpl` → `BarImpl`.
+func diShortName(fqcn string) string {
+	s := strings.TrimSpace(fqcn)
+	s = strings.TrimPrefix(s, "@")
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	if i := strings.LastIndexAny(s, "\\."); i >= 0 && i+1 < len(s) {
+		return s[i+1:]
+	}
+	return s
+}
+
+// looksLikeClassFQCN reports whether s looks like a PHP/Java class
+// reference rather than a primitive value, parameter reference, or
+// container expression. Symfony service ids are usually FQCNs but can
+// also be lowercase aliases; we accept any non-empty token that is not
+// obviously a non-class value (parameter `%foo%`, env `%env(...)%`,
+// yaml tag expression) so aliases still bind, while filtering noise.
+func looksLikeClassFQCN(s string) bool {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return false
+	}
+	if strings.HasPrefix(s, "%") || strings.HasPrefix(s, "!") {
+		return false // parameter / env / yaml tag expression
+	}
+	return true
+}
+
+// ---- Symfony services.yaml ---------------------------------------------
+
+// isSymfonyServicesYAML reports whether a parsed root mapping looks like
+// a Symfony container config: it has a top-level `services:` mapping.
+// Kept cheap — a single top-level key probe.
+func isSymfonyServicesYAML(root *yaml.Node) bool {
+	if root == nil || root.Kind != yaml.MappingNode {
+		return false
+	}
+	if svc := mappingGet(root, "services"); svc != nil && svc.Kind == yaml.MappingNode {
+		return true
+	}
+	return false
+}
+
+// extractSymfonyServicesYAML scans a YAML stream for a Symfony
+// `services:` block and emits the DI interface→implementation bindings
+// it can derive.
+//
+// Forms covered (under `services:`):
+//
+//	# explicit class
+//	App\SomeInterface:
+//	    class: App\ConcreteImpl
+//
+//	# alias to another service (value is `@id`)
+//	App\SomeInterface: '@App\ConcreteImpl'
+//	App\SomeInterface:
+//	    alias: '@App\ConcreteImpl'
+//	    # (Symfony also accepts a bare `alias: App\ConcreteImpl`)
+//
+//	# self-registration (no binding, just a concrete service)
+//	App\ConcreteImpl: ~
+//	App\ConcreteImpl:
+//	    class: App\ConcreteImpl   # redundant but legal
+//
+// Returns true when the file was recognised as a Symfony services file
+// (so the caller can skip the generic YAML key walk). A file with a
+// `services:` block but no derivable bindings still returns true.
+func extractSymfonyServicesYAML(filePath, fileID string, src []byte, result *parser.ExtractionResult) bool {
+	dec := yaml.NewDecoder(bytes.NewReader(src))
+	recognised := false
+	for {
+		var doc yaml.Node
+		if err := dec.Decode(&doc); err != nil {
+			break // EOF or malformed — keep what was decoded
+		}
+		root := documentMapping(&doc)
+		if !isSymfonyServicesYAML(root) {
+			continue
+		}
+		recognised = true
+		services := mappingGet(root, "services")
+		emitSymfonyServiceBindings(filePath, fileID, services, result)
+	}
+	return recognised
+}
+
+// emitSymfonyServiceBindings walks the entries of a `services:` mapping
+// and emits one EdgeProvides per interface→impl binding it derives.
+func emitSymfonyServiceBindings(filePath, fileID string, services *yaml.Node, result *parser.ExtractionResult) {
+	if services == nil || services.Kind != yaml.MappingNode {
+		return
+	}
+	for i := 0; i+1 < len(services.Content); i += 2 {
+		keyNode := services.Content[i]
+		valNode := services.Content[i+1]
+		if keyNode == nil {
+			continue
+		}
+		serviceID := strings.TrimSpace(keyNode.Value)
+		if serviceID == "" {
+			continue
+		}
+		// Container defaults / globals are not bindings.
+		switch serviceID {
+		case "_defaults", "_instanceof":
+			continue
+		}
+		line := keyNode.Line
+		if line <= 0 {
+			line = 1
+		}
+
+		impl := symfonyBindingTarget(valNode)
+		if impl == "" || !looksLikeClassFQCN(impl) {
+			// `App\ConcreteImpl: ~` self-registration, or a value we
+			// can't interpret as a class binding — nothing to wire.
+			continue
+		}
+		if !looksLikeClassFQCN(serviceID) {
+			continue
+		}
+		// Self-binding (`App\Impl: { class: App\Impl }`) is not an
+		// interface→impl relationship; skip it.
+		if serviceID == impl {
+			continue
+		}
+		emitDIProvides(result, fileID, filePath, line, serviceID, impl, "symfony")
+	}
+}
+
+// symfonyBindingTarget extracts the concrete implementation FQCN that a
+// single `services:` entry binds its key to. Handles:
+//   - scalar value `'@App\Impl'` (alias) and bare `App\Impl`;
+//   - mapping value with `class: App\Impl`;
+//   - mapping value with `alias: '@App\Impl'` / `alias: App\Impl`.
+//
+// Returns "" when the entry declares no concrete target (e.g. `~`).
+func symfonyBindingTarget(val *yaml.Node) string {
+	if val == nil {
+		return ""
+	}
+	switch val.Kind {
+	case yaml.ScalarNode:
+		// `App\Iface: '@App\Impl'` or `App\Iface: App\Impl`. A bare `~`
+		// / null decodes to a scalar with Tag "!!null" — skip it.
+		if val.Tag == "!!null" {
+			return ""
+		}
+		return strings.TrimSpace(val.Value)
+	case yaml.MappingNode:
+		if c := scalarOf(mappingGet(val, "class")); c != "" {
+			return strings.TrimSpace(c)
+		}
+		if a := scalarOf(mappingGet(val, "alias")); a != "" {
+			return strings.TrimSpace(a)
+		}
+	}
+	return ""
+}
+
+// ---- Spring applicationContext.xml -------------------------------------
+
+// SpringContextExtractor indexes a Spring XML application context
+// (`<beans>` root, the classic non-annotation DI config). It surfaces
+// the interface→implementation bindings the container declares so a
+// field/constructor typed as an interface resolves to the concrete bean
+// class.
+//
+// Two derivations (see emitSpringBeanBindings):
+//   - Direct: `<bean id="com.app.SomeInterface" class="com.app.Impl"/>`
+//     where the id is a class-shaped FQCN distinct from the class — the
+//     id is treated as the interface (the Symfony alias analogue).
+//   - Ref-based: a `<bean>` whose `<constructor-arg ref=…>` / `<property
+//     ref=…>` names another bean whose id is a class-shaped FQCN — that
+//     referenced bean's id→class is the wired interface→impl binding.
+//
+// `<beans>` uses the plain `.xml` extension shared with every other XML
+// document, so the extractor is content-gated on IsSpringBeansXML; a
+// misrouted plain-XML file yields just the file node.
+type SpringContextExtractor struct{}
+
+// NewSpringContextExtractor constructs a SpringContextExtractor.
+func NewSpringContextExtractor() *SpringContextExtractor { return &SpringContextExtractor{} }
+
+func (e *SpringContextExtractor) Language() string     { return "spring" }
+func (e *SpringContextExtractor) Extensions() []string { return []string{".xml"} }
+
+// IsSpringBeansXML reports whether src is a Spring XML application
+// context — recognised by a `<beans` root element (optionally namespaced)
+// plus a `<bean` child, or the Spring beans DTD/schema reference. Only
+// the document head is scanned, so the probe is cheap on large files.
+func IsSpringBeansXML(src []byte) bool {
+	head := src
+	const headCap = 8 * 1024
+	if len(head) > headCap {
+		head = head[:headCap]
+	}
+	lower := bytes.ToLower(head)
+	if bytes.Contains(lower, []byte("springframework.org/schema/beans")) ||
+		bytes.Contains(lower, []byte("springframework.org/dtd/spring-beans")) {
+		return true
+	}
+	// Root-element form: a `<beans` start tag (namespaced `<b:beans`
+	// counts via the local-name match in the decoder). Require a `<bean`
+	// child marker to avoid matching unrelated `<beans>`-named roots.
+	if bytes.Contains(lower, []byte("<beans")) && bytes.Contains(lower, []byte("<bean")) {
+		return true
+	}
+	return false
+}
+
+// springBean is a decoded `<bean>` element. Only the fields the binding
+// derivation needs are kept.
+type springBean struct {
+	id       string
+	class    string
+	line     int
+	ctorRefs []string // <constructor-arg ref="..">
+	propRefs []string // <property ref="..">
+}
+
+// Extract parses a Spring XML context. A document that is not a Spring
+// beans file yields only the file node. A malformed file yields whatever
+// was decoded before the error — never a hard failure.
+func (e *SpringContextExtractor) Extract(filePath string, src []byte) (*parser.ExtractionResult, error) {
+	result := &parser.ExtractionResult{}
+	fileNode := &graph.Node{
+		ID:       filePath,
+		Kind:     graph.KindFile,
+		Name:     path.Base(filePath),
+		FilePath: filePath,
+		Language: "spring",
+	}
+	result.Nodes = append(result.Nodes, fileNode)
+
+	if !IsSpringBeansXML(src) {
+		return result, nil
+	}
+
+	beans := parseSpringBeans(src)
+	emitSpringBeanBindings(filePath, fileNode.ID, beans, result)
+	return result, nil
+}
+
+// parseSpringBeans decodes the `<bean>` elements of a Spring context,
+// capturing id/class plus the refs declared by nested `<constructor-arg
+// ref>` / `<property ref>`. Namespace-agnostic on element/attr local
+// names.
+func parseSpringBeans(src []byte) []springBean {
+	dec := xml.NewDecoder(bytes.NewReader(src))
+	dec.Strict = false
+
+	var beans []springBean
+	var cur *springBean
+
+	flush := func() {
+		if cur != nil {
+			beans = append(beans, *cur)
+			cur = nil
+		}
+	}
+
+	for {
+		tok, err := dec.Token()
+		if err == io.EOF || err != nil {
+			break // EOF or malformed — keep what was decoded
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			switch strings.ToLower(t.Name.Local) {
+			case "bean":
+				flush()
+				b := springBean{
+					id:    xmlAttr(t, "id"),
+					class: xmlAttr(t, "class"),
+				}
+				if b.id == "" {
+					b.id = xmlAttr(t, "name")
+				}
+				b.line = 1 + bytes.Count(src[:clampOffset(dec.InputOffset(), len(src))], []byte{'\n'})
+				cur = &b
+			case "constructor-arg":
+				if cur != nil {
+					if ref := xmlAttr(t, "ref"); ref != "" {
+						cur.ctorRefs = append(cur.ctorRefs, ref)
+					}
+				}
+			case "property":
+				if cur != nil {
+					if ref := xmlAttr(t, "ref"); ref != "" {
+						cur.propRefs = append(cur.propRefs, ref)
+					}
+				}
+			}
+		case xml.EndElement:
+			if strings.ToLower(t.Name.Local) == "bean" {
+				flush()
+			}
+		}
+	}
+	flush()
+	return beans
+}
+
+// emitSpringBeanBindings turns decoded beans into DI binding edges.
+//
+// Two derivations:
+//  1. Direct: a `<bean id="com.app.SomeInterface" class="com.app.Impl">`
+//     where the id is a class-shaped FQCN distinct from the class — the
+//     id is treated as the interface (the Symfony alias analogue).
+//  2. Ref-based: a `<bean>` whose `<constructor-arg ref>` / `<property
+//     ref>` names another bean whose id is a class-shaped FQCN — the
+//     referenced bean's id is the wired interface, the referenced bean's
+//     class is the concrete impl. Deduped against derivation 1.
+func emitSpringBeanBindings(filePath, fileID string, beans []springBean, result *parser.ExtractionResult) {
+	byID := make(map[string]springBean, len(beans))
+	for _, b := range beans {
+		if b.id != "" {
+			byID[b.id] = b
+		}
+	}
+
+	emitted := make(map[string]struct{}) // dedupe by "iface->impl"
+	bind := func(iface, impl string, line int) {
+		if iface == "" || impl == "" || iface == impl {
+			return
+		}
+		if !looksLikeClassFQCN(iface) || !looksLikeClassFQCN(impl) {
+			return
+		}
+		key := iface + "->" + impl
+		if _, dup := emitted[key]; dup {
+			return
+		}
+		emitted[key] = struct{}{}
+		if line <= 0 {
+			line = 1
+		}
+		emitDIProvides(result, fileID, filePath, line, iface, impl, "spring")
+	}
+
+	for _, b := range beans {
+		// Derivation 1: id names an interface, class is the impl.
+		if b.id != "" && b.class != "" && b.id != b.class {
+			bind(b.id, b.class, b.line)
+		}
+		// Derivation 2: a ref points at a bean whose id is an
+		// interface FQCN — bind that bean's id→class.
+		for _, ref := range append(append([]string{}, b.ctorRefs...), b.propRefs...) {
+			target, ok := byID[ref]
+			if !ok || target.class == "" {
+				continue
+			}
+			if target.id != target.class {
+				bind(target.id, target.class, target.line)
+			}
+		}
+	}
+}
+
+// ---- shared emission ---------------------------------------------------
+
+// emitDIProvides appends one EdgeProvides modelling an interface→impl
+// container binding, shaped so resolver.buildProvidesForIndex consumes
+// it. From is the config file node (the only real node in a config
+// file); the resolver rewrites To onto the concrete class once the
+// PHP/Java class is indexed.
+func emitDIProvides(result *parser.ExtractionResult, fileID, filePath string, line int, ifaceFQCN, implFQCN, source string) {
+	implShort := diShortName(implFQCN)
+	if implShort == "" {
+		return
+	}
+	ifaceShort := diShortName(ifaceFQCN)
+	result.Edges = append(result.Edges, &graph.Edge{
+		From:     fileID,
+		To:       graph.UnresolvedMarker + implShort,
+		Kind:     graph.EdgeProvides,
+		FilePath: filePath,
+		Line:     line,
+		Origin:   graph.OriginASTInferred,
+		Meta: map[string]any{
+			"binding":        "useClass",
+			"provides_for":   ifaceShort,
+			"di":             source,
+			"interface_fqcn": diNormalizeFQCN(ifaceFQCN),
+			"impl_fqcn":      diNormalizeFQCN(implFQCN),
+		},
+	})
+}
+
+// diNormalizeFQCN trims whitespace and a leading `@` service-reference
+// marker from an FQCN for storage in Meta.
+func diNormalizeFQCN(fqcn string) string {
+	return strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(fqcn), "@"))
+}
+
+// xmlAttr returns the value of the attribute with the given local name
+// (namespace-agnostic), trimmed. Returns "" when absent.
+func xmlAttr(se xml.StartElement, local string) string {
+	for _, a := range se.Attr {
+		if a.Name.Local == local {
+			return strings.TrimSpace(a.Value)
+		}
+	}
+	return ""
+}

--- a/internal/parser/languages/di_container_test.go
+++ b/internal/parser/languages/di_container_test.go
@@ -1,0 +1,281 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+)
+
+// diBinding is a flattened view of a single DI EdgeProvides edge for
+// assertion convenience.
+type diBinding struct {
+	to            string
+	providesFor   string
+	di            string
+	interfaceFQCN string
+	implFQCN      string
+	binding       string
+	origin        string
+}
+
+// collectDIBindings pulls every EdgeProvides edge that carries the
+// Meta["di"] DI marker out of a result.
+func collectDIBindings(result *parser.ExtractionResult) []diBinding {
+	var out []diBinding
+	for _, e := range result.Edges {
+		if e.Kind != graph.EdgeProvides || e.Meta == nil {
+			continue
+		}
+		di, _ := e.Meta["di"].(string)
+		if di == "" {
+			continue
+		}
+		pf, _ := e.Meta["provides_for"].(string)
+		ifc, _ := e.Meta["interface_fqcn"].(string)
+		impl, _ := e.Meta["impl_fqcn"].(string)
+		b, _ := e.Meta["binding"].(string)
+		out = append(out, diBinding{
+			to:            e.To,
+			providesFor:   pf,
+			di:            di,
+			interfaceFQCN: ifc,
+			implFQCN:      impl,
+			binding:       b,
+			origin:        e.Origin,
+		})
+	}
+	return out
+}
+
+// findBinding returns the binding whose provides_for matches the given
+// interface short name, or (zero, false).
+func findBinding(bindings []diBinding, providesFor string) (diBinding, bool) {
+	for _, b := range bindings {
+		if b.providesFor == providesFor {
+			return b, true
+		}
+	}
+	return diBinding{}, false
+}
+
+func TestSymfonyServicesYAML_ClassForm(t *testing.T) {
+	// `services:` entry whose key is an interface FQCN and value carries
+	// `class: <ConcreteFQCN>`.
+	src := []byte(`services:
+    App\Domain\ClockInterface:
+        class: App\Infra\SystemClock
+`)
+	result := &parser.ExtractionResult{}
+	ok := extractSymfonyServicesYAML("services.yaml", "services.yaml", src, result)
+	require.True(t, ok, "services.yaml with services: block must be recognised")
+
+	bindings := collectDIBindings(result)
+	require.Len(t, bindings, 1)
+
+	b := bindings[0]
+	assert.Equal(t, "symfony", b.di)
+	assert.Equal(t, "useClass", b.binding)
+	assert.Equal(t, graph.OriginASTInferred, b.origin)
+	assert.Equal(t, "ClockInterface", b.providesFor, "provides_for is the interface short name")
+	assert.Equal(t, "unresolved::SystemClock", b.to, "To is the unresolved impl short name")
+	assert.Equal(t, "App\\Domain\\ClockInterface", b.interfaceFQCN)
+	assert.Equal(t, "App\\Infra\\SystemClock", b.implFQCN)
+}
+
+func TestSymfonyServicesYAML_AliasForm(t *testing.T) {
+	// alias form: `App\SomeInterface: '@App\ConcreteImpl'`.
+	src := []byte(`services:
+    App\SomeInterface: '@App\ConcreteImpl'
+`)
+	result := &parser.ExtractionResult{}
+	ok := extractSymfonyServicesYAML("services.yaml", "services.yaml", src, result)
+	require.True(t, ok)
+
+	bindings := collectDIBindings(result)
+	require.Len(t, bindings, 1)
+	b := bindings[0]
+	assert.Equal(t, "SomeInterface", b.providesFor)
+	assert.Equal(t, "unresolved::ConcreteImpl", b.to)
+	assert.Equal(t, "App\\ConcreteImpl", b.implFQCN, "leading @ stripped from impl FQCN")
+}
+
+func TestSymfonyServicesYAML_NestedAliasKey(t *testing.T) {
+	// alias declared via a nested `alias:` key.
+	src := []byte(`services:
+    App\SomeInterface:
+        alias: '@App\ConcreteImpl'
+        public: true
+`)
+	result := &parser.ExtractionResult{}
+	ok := extractSymfonyServicesYAML("services.yaml", "services.yaml", src, result)
+	require.True(t, ok)
+
+	bindings := collectDIBindings(result)
+	require.Len(t, bindings, 1)
+	assert.Equal(t, "unresolved::ConcreteImpl", bindings[0].to)
+	assert.Equal(t, "SomeInterface", bindings[0].providesFor)
+}
+
+func TestSymfonyServicesYAML_SelfRegistrationProducesNoBinding(t *testing.T) {
+	// `App\ConcreteImpl: ~` and a redundant self-class declaration are
+	// concrete service registrations, not interface→impl bindings.
+	src := []byte(`services:
+    App\Infra\SystemClock: ~
+    App\Infra\Mailer:
+        class: App\Infra\Mailer
+    App\Domain\ClockInterface:
+        class: App\Infra\SystemClock
+`)
+	result := &parser.ExtractionResult{}
+	ok := extractSymfonyServicesYAML("services.yaml", "services.yaml", src, result)
+	require.True(t, ok)
+
+	bindings := collectDIBindings(result)
+	// Only the ClockInterface→SystemClock entry is a real binding.
+	require.Len(t, bindings, 1)
+	assert.Equal(t, "ClockInterface", bindings[0].providesFor)
+	assert.Equal(t, "unresolved::SystemClock", bindings[0].to)
+}
+
+func TestSymfonyServicesYAML_DefaultsAndParametersIgnored(t *testing.T) {
+	src := []byte(`parameters:
+    locale: en
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+    App\SomeInterface: '@App\ConcreteImpl'
+`)
+	result := &parser.ExtractionResult{}
+	ok := extractSymfonyServicesYAML("services.yaml", "services.yaml", src, result)
+	require.True(t, ok)
+
+	bindings := collectDIBindings(result)
+	require.Len(t, bindings, 1, "_defaults must not produce a binding")
+	assert.Equal(t, "SomeInterface", bindings[0].providesFor)
+}
+
+func TestSymfonyServicesYAML_NotAServicesFile(t *testing.T) {
+	// A plain config YAML with no services: block is not recognised.
+	src := []byte(`framework:
+    secret: '%env(APP_SECRET)%'
+`)
+	result := &parser.ExtractionResult{}
+	ok := extractSymfonyServicesYAML("config.yaml", "config.yaml", src, result)
+	assert.False(t, ok)
+	assert.Empty(t, collectDIBindings(result))
+}
+
+func TestSymfonyServicesYAML_Malformed(t *testing.T) {
+	// Malformed YAML must not panic; it simply yields no bindings.
+	src := []byte("services:\n    App\\Foo: : : '@bad\n   - broken")
+	result := &parser.ExtractionResult{}
+	assert.NotPanics(t, func() {
+		extractSymfonyServicesYAML("services.yaml", "services.yaml", src, result)
+	})
+}
+
+func TestSpringContext_DirectIdClassBinding(t *testing.T) {
+	// <bean id="<interface FQCN>" class="<impl FQCN>"/> — the id names
+	// the interface, the class is the impl.
+	src := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans">
+    <bean id="com.app.GreetingService" class="com.app.GreetingServiceImpl"/>
+</beans>
+`)
+	e := NewSpringContextExtractor()
+	result, err := e.Extract("applicationContext.xml", src)
+	require.NoError(t, err)
+
+	bindings := collectDIBindings(result)
+	require.Len(t, bindings, 1)
+	b := bindings[0]
+	assert.Equal(t, "spring", b.di)
+	assert.Equal(t, "useClass", b.binding)
+	assert.Equal(t, graph.OriginASTInferred, b.origin)
+	assert.Equal(t, "GreetingService", b.providesFor)
+	assert.Equal(t, "unresolved::GreetingServiceImpl", b.to)
+	assert.Equal(t, "com.app.GreetingService", b.interfaceFQCN)
+	assert.Equal(t, "com.app.GreetingServiceImpl", b.implFQCN)
+}
+
+func TestSpringContext_RefBinding(t *testing.T) {
+	// A consumer bean references a provider bean whose id is an interface
+	// FQCN; the referenced bean's id→class is the wired binding.
+	src := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans">
+    <bean id="com.app.Repository" class="com.app.JpaRepository"/>
+    <bean id="userService" class="com.app.UserService">
+        <constructor-arg ref="com.app.Repository"/>
+    </bean>
+</beans>
+`)
+	e := NewSpringContextExtractor()
+	result, err := e.Extract("applicationContext.xml", src)
+	require.NoError(t, err)
+
+	bindings := collectDIBindings(result)
+	// Repository→JpaRepository is the interface→impl binding. userService
+	// (id != interface-shaped distinct class) also yields a direct id!=class
+	// binding (userService→UserService) which we accept as a concrete
+	// registration alias; assert the meaningful one is present.
+	b, ok := findBinding(bindings, "Repository")
+	require.True(t, ok, "ref-based binding for the interface bean must be emitted")
+	assert.Equal(t, "unresolved::JpaRepository", b.to)
+	assert.Equal(t, "com.app.JpaRepository", b.implFQCN)
+}
+
+func TestSpringContext_PropertyRefBinding(t *testing.T) {
+	src := []byte(`<beans xmlns="http://www.springframework.org/schema/beans">
+    <bean id="com.app.Mailer" class="com.app.SmtpMailer"/>
+    <bean id="notifier" class="com.app.Notifier">
+        <property name="mailer" ref="com.app.Mailer"/>
+    </bean>
+</beans>
+`)
+	e := NewSpringContextExtractor()
+	result, err := e.Extract("applicationContext.xml", src)
+	require.NoError(t, err)
+
+	b, ok := findBinding(collectDIBindings(result), "Mailer")
+	require.True(t, ok)
+	assert.Equal(t, "unresolved::SmtpMailer", b.to)
+}
+
+func TestSpringContext_NotASpringFile(t *testing.T) {
+	// Plain XML that is not a Spring beans file yields only the file node.
+	src := []byte(`<?xml version="1.0"?><configuration><foo bar="baz"/></configuration>`)
+	e := NewSpringContextExtractor()
+	result, err := e.Extract("config.xml", src)
+	require.NoError(t, err)
+	assert.Empty(t, collectDIBindings(result))
+	// The file node is always emitted.
+	require.Len(t, result.Nodes, 1)
+	assert.Equal(t, graph.KindFile, result.Nodes[0].Kind)
+}
+
+func TestSpringContext_Malformed(t *testing.T) {
+	// Truncated / malformed XML must not panic.
+	src := []byte(`<beans><bean id="com.app.A" class="com.app.AImpl"><constructor-arg ref=`)
+	e := NewSpringContextExtractor()
+	assert.NotPanics(t, func() {
+		_, _ = e.Extract("applicationContext.xml", src)
+	})
+}
+
+func TestDIShortName(t *testing.T) {
+	cases := map[string]string{
+		"App\\Foo\\BarImpl": "BarImpl",
+		"com.app.BarImpl":   "BarImpl",
+		"@App\\Concrete":    "Concrete",
+		"Bare":              "Bare",
+		"":                  "",
+	}
+	for in, want := range cases {
+		assert.Equalf(t, want, diShortName(in), "diShortName(%q)", in)
+	}
+}

--- a/internal/parser/languages/expo_modules.go
+++ b/internal/parser/languages/expo_modules.go
@@ -1,0 +1,94 @@
+package languages
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+)
+
+// Expo Modules cross-language support. An Expo native module is declared
+// in Swift or Kotlin with a DSL inside `definition() -> ModuleDefinition`:
+// `Name("Foo")` sets the JS module name and `Function("bar") { ... }` /
+// `AsyncFunction("baz") { ... }` declare the JS-callable methods. On the
+// JS side they are consumed via `requireNativeModule('Foo').bar(...)` —
+// which the JS/TS extractor already emits as an rn-native placeholder, so
+// the Expo bridge synthesizer can land it on these synthetic nodes.
+
+var (
+	expoNameRe     = regexp.MustCompile(`\bName\s*\(\s*"([^"]+)"`)
+	expoFunctionRe = regexp.MustCompile(`\b(Async)?Function\s*\(\s*"([^"]+)"`)
+)
+
+// expoExport is one Expo DSL method declaration.
+type expoExport struct {
+	module string
+	method string
+	async  bool
+	off    int
+}
+
+// extractExpoModules scans Swift/Kotlin source for the Expo module DSL
+// and returns each Function/AsyncFunction declaration attributed to the
+// most recent preceding Name("...") (its module). Returns nil when the
+// file is not an Expo module (no ModuleDefinition marker).
+func extractExpoModules(src []byte) []expoExport {
+	s := string(src)
+	if !strings.Contains(s, "ModuleDefinition") {
+		return nil
+	}
+	type marker struct {
+		off    int
+		isName bool
+		name   string
+		async  bool
+	}
+	var markers []marker
+	for _, m := range expoNameRe.FindAllStringSubmatchIndex(s, -1) {
+		markers = append(markers, marker{off: m[0], isName: true, name: s[m[2]:m[3]]})
+	}
+	for _, m := range expoFunctionRe.FindAllStringSubmatchIndex(s, -1) {
+		markers = append(markers, marker{off: m[0], name: s[m[4]:m[5]], async: m[2] >= 0})
+	}
+	sort.Slice(markers, func(i, j int) bool { return markers[i].off < markers[j].off })
+
+	curModule := ""
+	var out []expoExport
+	for _, mk := range markers {
+		if mk.isName {
+			curModule = mk.name
+			continue
+		}
+		if curModule == "" {
+			continue
+		}
+		out = append(out, expoExport{module: curModule, method: mk.name, async: mk.async, off: mk.off})
+	}
+	return out
+}
+
+// emitExpoModuleNodes materialises a synthetic JS-callable method node per
+// Expo Function/AsyncFunction declaration, carrying expo_module +
+// expo_method so the Expo bridge synthesizer can pair a JS
+// requireNativeModule('<module>').<method>() call to it.
+func emitExpoModuleNodes(src []byte, filePath, language, fileID string, result *parser.ExtractionResult, seen map[string]bool) {
+	for _, ex := range extractExpoModules(src) {
+		id := filePath + "::expo:" + ex.module + ":" + ex.method
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		line := lineAt(src, ex.off)
+		result.Nodes = append(result.Nodes, &graph.Node{
+			ID: id, Kind: graph.KindMethod, Name: ex.method,
+			FilePath: filePath, StartLine: line, EndLine: line,
+			Language: language,
+			Meta:     map[string]any{"expo_module": ex.module, "expo_method": ex.method, "expo_async": ex.async},
+		})
+		result.Edges = append(result.Edges, &graph.Edge{
+			From: fileID, To: id, Kind: graph.EdgeDefines, FilePath: filePath, Line: line,
+		})
+	}
+}

--- a/internal/parser/languages/expo_modules_test.go
+++ b/internal/parser/languages/expo_modules_test.go
@@ -1,0 +1,85 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func expoMethodMeta(nodes []*graph.Node) map[string][2]any {
+	out := map[string][2]any{}
+	for _, n := range nodes {
+		if n.Kind != graph.KindMethod || n.Meta == nil {
+			continue
+		}
+		mod, _ := n.Meta["expo_module"].(string)
+		if mod == "" {
+			continue
+		}
+		async, _ := n.Meta["expo_async"].(bool)
+		out[n.Name] = [2]any{mod, async}
+	}
+	return out
+}
+
+func TestSwiftExtract_ExpoModule(t *testing.T) {
+	src := `import ExpoModulesCore
+
+public class MathModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("Math")
+    Function("add") { (a: Int, b: Int) -> Int in
+      return a + b
+    }
+    AsyncFunction("fetchData") { (url: String) in
+    }
+  }
+}
+`
+	r, err := NewSwiftExtractor().Extract("MathModule.swift", []byte(src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	meta := expoMethodMeta(r.Nodes)
+	if got, ok := meta["add"]; !ok || got[0] != "Math" || got[1] != false {
+		t.Errorf("add = %v (ok=%v), want module Math, async false", meta["add"], ok)
+	}
+	if got, ok := meta["fetchData"]; !ok || got[0] != "Math" || got[1] != true {
+		t.Errorf("fetchData = %v (ok=%v), want module Math, async true", meta["fetchData"], ok)
+	}
+}
+
+func TestKotlinExtract_ExpoModule(t *testing.T) {
+	src := `package expo.modules.math
+
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+
+class MathModule : Module() {
+  override fun definition() = ModuleDefinition {
+    Name("Math")
+    Function("add") { a: Int, b: Int -> a + b }
+    AsyncFunction("fetchData") { url: String -> }
+  }
+}
+`
+	r, err := NewKotlinExtractor().Extract("MathModule.kt", []byte(src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	meta := expoMethodMeta(r.Nodes)
+	if got, ok := meta["add"]; !ok || got[0] != "Math" {
+		t.Errorf("add = %v (ok=%v), want module Math", meta["add"], ok)
+	}
+	if _, ok := meta["fetchData"]; !ok {
+		t.Errorf("fetchData not extracted")
+	}
+}
+
+func TestExtractExpoModules_NonExpoFileIgnored(t *testing.T) {
+	// A Swift file that happens to call Name("x")/Function("y") but is not
+	// an Expo module (no ModuleDefinition) must yield nothing.
+	if got := extractExpoModules([]byte(`func f() { Name("x"); Function("y") }`)); got != nil {
+		t.Errorf("non-Expo file produced %v, want nil", got)
+	}
+}

--- a/internal/parser/languages/fabric_test.go
+++ b/internal/parser/languages/fabric_test.go
@@ -1,0 +1,100 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func fabricNode(nodes []*graph.Node) *graph.Node {
+	for _, n := range nodes {
+		if n.Meta != nil {
+			if _, ok := n.Meta["fabric_component"]; ok {
+				return n
+			}
+		}
+	}
+	return nil
+}
+
+func TestTSExtract_FabricComponentSpec(t *testing.T) {
+	src := `import type { ViewProps } from 'react-native';
+import type { DirectEventHandler } from 'react-native/Libraries/Types/CodegenTypes';
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+
+export interface NativeProps extends ViewProps {
+  color?: string;
+  onColorChanged?: DirectEventHandler<{ color: string }>;
+}
+
+export default codegenNativeComponent<NativeProps>('RCTColorView');
+`
+	r, err := NewTypeScriptExtractor().Extract("ColorViewNativeComponent.ts", []byte(src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	n := fabricNode(r.Nodes)
+	if n == nil {
+		t.Fatal("no fabric component node emitted")
+	}
+	if n.Meta["fabric_component"] != "RCTColorView" {
+		t.Errorf("fabric_component = %v, want RCTColorView", n.Meta["fabric_component"])
+	}
+	events, _ := n.Meta["fabric_events"].([]string)
+	if len(events) != 1 || events[0] != "onColorChanged" {
+		t.Errorf("fabric_events = %v, want [onColorChanged]", n.Meta["fabric_events"])
+	}
+}
+
+func TestObjCExtract_FabricViewManager(t *testing.T) {
+	src := `@implementation RCTColorViewManager
+
+RCT_EXPORT_MODULE()
+
+RCT_EXPORT_VIEW_PROPERTY(color, NSString)
+RCT_EXPORT_VIEW_PROPERTY(onColorChanged, RCTDirectEventBlock)
+
+@end
+`
+	r, err := NewObjCExtractor().Extract("RCTColorViewManager.m", []byte(src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	n := fabricNode(r.Nodes)
+	if n == nil {
+		t.Fatal("no fabric view-manager node emitted")
+	}
+	// Class RCTColorViewManager → component RCTColorView (Manager stripped).
+	if n.Meta["fabric_component"] != "RCTColorView" {
+		t.Errorf("fabric_component = %v, want RCTColorView", n.Meta["fabric_component"])
+	}
+	props, _ := n.Meta["fabric_props"].([]string)
+	if len(props) != 2 {
+		t.Errorf("fabric_props = %v, want 2 props", props)
+	}
+}
+
+func TestJavaExtract_FabricViewManager(t *testing.T) {
+	src := `package com.example;
+import com.facebook.react.uimanager.annotations.ReactProp;
+
+public class ColorViewManager extends SimpleViewManager<ColorView> {
+    @Override
+    public String getName() { return "RCTColorView"; }
+
+    @ReactProp(name = "color")
+    public void setColor(ColorView view, String color) {}
+}
+`
+	r, err := NewJavaExtractor().Extract("ColorViewManager.java", []byte(src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	n := fabricNode(r.Nodes)
+	if n == nil {
+		t.Fatal("no fabric view-manager node emitted")
+	}
+	if n.Meta["fabric_component"] != "RCTColorView" {
+		t.Errorf("fabric_component = %v, want RCTColorView (from getName)", n.Meta["fabric_component"])
+	}
+}

--- a/internal/parser/languages/go_realtime.go
+++ b/internal/parser/languages/go_realtime.go
@@ -1,0 +1,58 @@
+package languages
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+)
+
+// goWSUpgradeRe matches the server-side WebSocket upgrade calls of the
+// common Go libraries: gorilla/websocket `upgrader.Upgrade(...)`,
+// gobwas/ws `ws.UpgradeHTTP(...)`, and coder/nhooyr `websocket.Accept(...)`.
+var goWSUpgradeRe = regexp.MustCompile(`\.Upgrade\s*\(|\.UpgradeHTTP\s*\(|websocket\.Accept\s*\(`)
+
+// emitGoWebSocketEdges marks each function that performs a WebSocket
+// upgrade as a real-time endpoint: it emits an EdgeListensOn from the
+// handler to a per-handler websocket KindEvent node, so `analyze
+// kind=pubsub` / architecture queries surface the WebSocket surface that
+// the call graph cannot see. Gated on the file importing a websocket
+// package to avoid matching unrelated `.Upgrade(` methods.
+func emitGoWebSocketEdges(src []byte, filePath string, result *parser.ExtractionResult) {
+	s := string(src)
+	if !strings.Contains(s, "websocket") && !strings.Contains(s, "gobwas/ws") {
+		return
+	}
+	locs := goWSUpgradeRe.FindAllStringIndex(s, -1)
+	if len(locs) == 0 {
+		return
+	}
+	funcRanges := buildFuncRanges(result)
+	seenNode := map[string]bool{}
+	for _, m := range locs {
+		line := lineAt(src, m[0])
+		callerID := findEnclosingFunc(funcRanges, line)
+		if callerID == "" {
+			continue
+		}
+		topic := callerID
+		if i := strings.LastIndexAny(topic, ":./"); i >= 0 {
+			topic = topic[i+1:]
+		}
+		nodeID := "event::pubsub::" + transportWebSocket + "::" + topic
+		if !seenNode[nodeID] {
+			seenNode[nodeID] = true
+			result.Nodes = append(result.Nodes, &graph.Node{
+				ID: nodeID, Kind: graph.KindEvent, Name: topic,
+				FilePath: filePath, Language: "go",
+				Meta: map[string]any{"event_kind": "pubsub", "transport": transportWebSocket, "name": topic},
+			})
+		}
+		result.Edges = append(result.Edges, &graph.Edge{
+			From: callerID, To: nodeID, Kind: graph.EdgeListensOn,
+			FilePath: filePath, Line: line, Origin: graph.OriginASTInferred,
+			Meta: map[string]any{"method": "upgrade", "transport": transportWebSocket},
+		})
+	}
+}

--- a/internal/parser/languages/golang.go
+++ b/internal/parser/languages/golang.go
@@ -826,6 +826,9 @@ func (e *GoExtractor) Extract(filePath string, src []byte) (*parser.ExtractionRe
 	// rewires any convention-derived EdgeModelsTable to the literal.
 	rewireORMTableNameOverrides(root, src, result)
 
+	// WebSocket upgrade handlers → real-time endpoint edges.
+	emitGoWebSocketEdges(src, filePath, result)
+
 	return result, nil
 }
 

--- a/internal/parser/languages/java.go
+++ b/internal/parser/languages/java.go
@@ -269,6 +269,30 @@ func (e *JavaExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 		result.Edges = append(result.Edges, edge)
 	}
 
+	// React Native Fabric / Paper view managers: a class with @ReactProp
+	// methods backs a JS component. Emit a component node so the Fabric
+	// synthesizer can link it to the codegen TS spec.
+	for _, fm := range extractJavaFabricManagers(src, rnModules) {
+		id := filePath + "::fabric:" + fm.component
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		node := &graph.Node{
+			ID: id, Kind: graph.KindType, Name: fm.component,
+			FilePath: filePath, StartLine: fm.line, EndLine: fm.line,
+			Language: "java",
+			Meta:     map[string]any{"fabric_component": fm.component, "fabric_native": "java"},
+		}
+		if len(fm.props) > 0 {
+			node.Meta["fabric_props"] = fm.props
+		}
+		result.Nodes = append(result.Nodes, node)
+		result.Edges = append(result.Edges, &graph.Edge{
+			From: fileID, To: id, Kind: graph.EdgeDefines, FilePath: filePath, Line: fm.line,
+		})
+	}
+
 	return result, nil
 }
 

--- a/internal/parser/languages/java.go
+++ b/internal/parser/languages/java.go
@@ -118,7 +118,8 @@ func (e *JavaExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 
 	seen := make(map[string]bool)
 	annotationSeen := make(map[string]bool)
-	ifaceMethods := make(map[string][]string) // interface name → declared method names
+	ifaceMethods := make(map[string][]string)  // interface name → declared method names
+	rnModules := extractJavaRNModuleNames(src) // class → React Native JS module name
 
 	var calls []javaDeferredCall
 	var varBuf []javaDeferredVar
@@ -136,7 +137,7 @@ func (e *JavaExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 			e.emitEnum(m, filePath, fileID, src, result, seen, annotationSeen)
 
 		case m.Captures["method.def"] != nil:
-			e.emitMethod(m, filePath, fileID, src, result, seen, annotationSeen, ifaceMethods)
+			e.emitMethod(m, filePath, fileID, src, result, seen, annotationSeen, ifaceMethods, rnModules)
 
 		case m.Captures["ctor.def"] != nil:
 			e.emitConstructor(m, filePath, fileID, src, result, seen)
@@ -416,7 +417,7 @@ func (e *JavaExtractor) emitEnumMember(m parser.QueryResult, filePath string, sr
 	})
 }
 
-func (e *JavaExtractor) emitMethod(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen, annotationSeen map[string]bool, ifaceMethods map[string][]string) {
+func (e *JavaExtractor) emitMethod(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen, annotationSeen map[string]bool, ifaceMethods map[string][]string, rnModules map[string]string) {
 	name := m.Captures["method.name"].Text
 	def := m.Captures["method.def"]
 	startLine1 := def.StartLine + 1
@@ -466,6 +467,17 @@ func (e *JavaExtractor) emitMethod(m parser.QueryResult, filePath, fileID string
 				if c := JavaComplexity(body); c > 1 {
 					node.Meta["complexity"] = c
 				}
+			}
+		}
+		// React Native: an @ReactMethod method is callable from JS as
+		// NativeModules.<module>.<method>(...). Stamp the JS module +
+		// method so the bridge synthesizer can land the JS call here.
+		if def.Node != nil && javaHasReactMethod(javaCollectAnnotations(def.Node, src)) {
+			node.Meta["rn_method"] = name
+			if mod := rnModules[className]; mod != "" {
+				node.Meta["rn_module"] = mod
+			} else {
+				node.Meta["rn_module"] = className
 			}
 		}
 		result.Nodes = append(result.Nodes, node)

--- a/internal/parser/languages/java_rn.go
+++ b/internal/parser/languages/java_rn.go
@@ -1,0 +1,85 @@
+package languages
+
+import (
+	"regexp"
+	"strings"
+)
+
+// React Native JVM native-module support. A Java native module is a
+// class whose @ReactMethod-annotated methods are callable from JS as
+// `NativeModules.<module>.<method>(...)`. The JS module name is the
+// string the class's getName() returns (or a @ReactModule(name=...)
+// override), defaulting to the class name.
+
+var (
+	javaClassDeclRe     = regexp.MustCompile(`\bclass\s+([A-Za-z_]\w*)`)
+	javaGetNameReturnRe = regexp.MustCompile(`getName\s*\(\s*\)\s*\{[^{}]*return\s+"([^"]+)"`)
+	javaReactModuleNmRe = regexp.MustCompile(`@ReactModule\s*\(\s*name\s*=\s*"([^"]+)"`)
+)
+
+// extractJavaRNModuleNames maps each class name in src to the JS module
+// name it exposes to React Native. Resolution order (later wins):
+// class name, getName() string-literal return, @ReactModule(name=...).
+func extractJavaRNModuleNames(src []byte) map[string]string {
+	s := string(src)
+	out := map[string]string{}
+	prevEnd := 0
+	for _, loc := range javaClassDeclRe.FindAllStringSubmatchIndex(s, -1) {
+		className := s[loc[2]:loc[3]]
+		module := className
+
+		// Class body span (balanced braces) for getName() inspection.
+		bodyOpen := strings.IndexByte(s[loc[1]:], '{')
+		bodyEnd := len(s)
+		if bodyOpen >= 0 {
+			bodyOpen += loc[1]
+			if e := javaMatchBrace(s, bodyOpen); e > bodyOpen {
+				bodyEnd = e
+				if m := javaGetNameReturnRe.FindStringSubmatch(s[bodyOpen:bodyEnd]); m != nil {
+					module = m[1]
+				}
+			}
+		}
+
+		// @ReactModule(name=...) sits in the annotation band just before
+		// the class keyword — search the gap since the previous class.
+		if m := javaReactModuleNmRe.FindStringSubmatch(s[prevEnd:loc[0]]); m != nil {
+			module = m[1]
+		}
+
+		out[className] = module
+		prevEnd = bodyEnd
+	}
+	return out
+}
+
+// javaMatchBrace returns the index just past the '}' matching the '{' at
+// openIdx, or -1 when unbalanced.
+func javaMatchBrace(s string, openIdx int) int {
+	if openIdx < 0 || openIdx >= len(s) || s[openIdx] != '{' {
+		return -1
+	}
+	depth := 0
+	for i := openIdx; i < len(s); i++ {
+		switch s[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i + 1
+			}
+		}
+	}
+	return -1
+}
+
+// javaHasReactMethod reports whether any annotation is @ReactMethod.
+func javaHasReactMethod(annos []javaAnnotation) bool {
+	for _, a := range annos {
+		if a.name == "ReactMethod" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/parser/languages/java_rn.go
+++ b/internal/parser/languages/java_rn.go
@@ -83,3 +83,78 @@ func javaHasReactMethod(annos []javaAnnotation) bool {
 	}
 	return false
 }
+
+// javaReactPropRe matches @ReactProp(name = "x") — the marker of a React
+// Native view-manager property.
+var javaReactPropRe = regexp.MustCompile(`@ReactProp\s*\(\s*name\s*=\s*"([^"]+)"`)
+
+// javaFabricManager is a native view manager discovered in a Java file.
+type javaFabricManager struct {
+	component string
+	props     []string
+	line      int
+}
+
+// extractJavaFabricManagers finds classes carrying @ReactProp methods
+// (React Native view managers) and resolves the JS component name from
+// getName() / @ReactModule (rnModules) or the class name, stripping the
+// RN "Manager" suffix. rnModules is the class→module map from
+// extractJavaRNModuleNames.
+func extractJavaFabricManagers(src []byte, rnModules map[string]string) []javaFabricManager {
+	s := string(src)
+	propLocs := javaReactPropRe.FindAllStringSubmatchIndex(s, -1)
+	if len(propLocs) == 0 {
+		return nil
+	}
+	type span struct {
+		name       string
+		start, end int
+	}
+	var spans []span
+	for _, loc := range javaClassDeclRe.FindAllStringSubmatchIndex(s, -1) {
+		className := s[loc[2]:loc[3]]
+		end := len(s)
+		if bodyOpen := strings.IndexByte(s[loc[1]:], '{'); bodyOpen >= 0 {
+			bodyOpen += loc[1]
+			if e := javaMatchBrace(s, bodyOpen); e > bodyOpen {
+				end = e
+			}
+		}
+		spans = append(spans, span{name: className, start: loc[0], end: end})
+	}
+	classForOff := func(off int) (string, bool) {
+		for _, sp := range spans {
+			if off >= sp.start && off < sp.end {
+				return sp.name, true
+			}
+		}
+		return "", false
+	}
+	propsByClass := map[string][]string{}
+	lineByClass := map[string]int{}
+	var order []string
+	for _, loc := range propLocs {
+		cls, ok := classForOff(loc[0])
+		if !ok {
+			continue
+		}
+		if _, seen := propsByClass[cls]; !seen {
+			order = append(order, cls)
+			lineByClass[cls] = lineAt(src, loc[0])
+		}
+		propsByClass[cls] = append(propsByClass[cls], s[loc[2]:loc[3]])
+	}
+	var out []javaFabricManager
+	for _, cls := range order {
+		comp := cls
+		if m := rnModules[cls]; m != "" {
+			comp = m
+		}
+		out = append(out, javaFabricManager{
+			component: objcComponentName(comp), // shared "Manager"-suffix stripper
+			props:     propsByClass[cls],
+			line:      lineByClass[cls],
+		})
+	}
+	return out
+}

--- a/internal/parser/languages/javascript.go
+++ b/internal/parser/languages/javascript.go
@@ -289,6 +289,8 @@ func (e *JavaScriptExtractor) Extract(filePath string, src []byte) (*parser.Extr
 			pubsubEvents = append(pubsubEvents, ev)
 		}
 	}
+	// WebSocket / EventSource real-time client channels.
+	pubsubEvents = append(pubsubEvents, detectJSRealtimeEvents(src)...)
 	emitPubsubEvents(pubsubEvents,
 		func(line int) string { return findEnclosingFunc(funcRanges, line) },
 		filePath, "javascript", result)

--- a/internal/parser/languages/javascript.go
+++ b/internal/parser/languages/javascript.go
@@ -76,7 +76,7 @@ func NewJavaScriptExtractor() *JavaScriptExtractor {
 	}
 }
 
-func (e *JavaScriptExtractor) Language() string     { return "javascript" }
+func (e *JavaScriptExtractor) Language() string { return "javascript" }
 func (e *JavaScriptExtractor) Extensions() []string {
 	return []string{".js", ".jsx", ".mjs", ".cjs"}
 }
@@ -292,6 +292,27 @@ func (e *JavaScriptExtractor) Extract(filePath string, src []byte) (*parser.Extr
 	emitPubsubEvents(pubsubEvents,
 		func(line int) string { return findEnclosingFunc(funcRanges, line) },
 		filePath, "javascript", result)
+
+	// --- React Native native-module bridge calls ---
+	rnVars := rnNativeModuleVars(src)
+	for _, c := range calls {
+		if !c.isMember {
+			continue
+		}
+		module := detectRNNativeModule(c.receiver, rnVars)
+		if module == "" {
+			continue
+		}
+		callerID := findEnclosingFunc(funcRanges, c.line)
+		if callerID == "" {
+			continue
+		}
+		result.Edges = append(result.Edges, &graph.Edge{
+			From: callerID, To: rnNativePlaceholder(module, c.name),
+			Kind: graph.EdgeCalls, FilePath: filePath, Line: c.line,
+			Meta: map[string]any{"via": rnNativeVia, "rn_module": module, "rn_method": c.name},
+		})
+	}
 
 	// Test-runner classification (Mocha / Bun-test / Jest / Vitest /
 	// node:test / Playwright / Cypress). Stamped on the file node so

--- a/internal/parser/languages/javascript.go
+++ b/internal/parser/languages/javascript.go
@@ -295,6 +295,11 @@ func (e *JavaScriptExtractor) Extract(filePath string, src []byte) (*parser.Extr
 		func(line int) string { return findEnclosingFunc(funcRanges, line) },
 		filePath, "javascript", result)
 
+	// SQL function call sites (Supabase/PostgREST .rpc('fn')).
+	emitSQLCallsiteEdges(src, "javascript",
+		func(line int) string { return findEnclosingFunc(funcRanges, line) },
+		filePath, result)
+
 	// --- React Native native-module bridge calls ---
 	rnVars := rnNativeModuleVars(src)
 	for _, c := range calls {

--- a/internal/parser/languages/jsts_fabric.go
+++ b/internal/parser/languages/jsts_fabric.go
@@ -1,0 +1,59 @@
+package languages
+
+import (
+	"regexp"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+)
+
+// React Native Fabric / Codegen view-component recognition. A Fabric
+// component is declared in a TS spec with
+// `codegenNativeComponent<NativeProps>('RCTMyView')`, and its NativeProps
+// interface declares event props typed `DirectEventHandler<T>` /
+// `BubblingEventHandler<T>`. This spec is the cross-language ground truth
+// the native view manager (an ObjC RCTViewManager with
+// RCT_EXPORT_VIEW_PROPERTY, or a Java ViewManager with @ReactProp)
+// implements. The Fabric synthesizer links the spec to the native manager
+// by component name.
+
+var (
+	// codegenNativeComponent<Props>('Name') — the type arg is optional.
+	fabricCodegenRe = regexp.MustCompile(`codegenNativeComponent\s*(?:<[^>]*>)?\s*\(\s*['"]([^'"]+)['"]`)
+	// onChange?: DirectEventHandler<ChangeEvent> / BubblingEventHandler<...>
+	fabricEventRe = regexp.MustCompile(`(?m)^\s*(\w+)\??\s*:\s*(?:Direct|Bubbling)EventHandler\s*<`)
+)
+
+// emitFabricComponentNodes scans a TS/JS Fabric spec for a
+// codegenNativeComponent declaration and emits a synthetic component node
+// carrying fabric_component plus the event-handler prop names parsed from
+// the spec, so the Fabric synthesizer can pair it with the native view
+// manager.
+func emitFabricComponentNodes(src []byte, filePath, language, fileID string, result *parser.ExtractionResult) {
+	s := string(src)
+	comp := fabricCodegenRe.FindStringSubmatch(s)
+	if comp == nil {
+		return
+	}
+	component := comp[1]
+	id := filePath + "::fabric:" + component
+
+	var events []string
+	for _, m := range fabricEventRe.FindAllStringSubmatch(s, -1) {
+		events = append(events, m[1])
+	}
+	line := lineAt(src, fabricCodegenRe.FindStringIndex(s)[0])
+	node := &graph.Node{
+		ID: id, Kind: graph.KindType, Name: component,
+		FilePath: filePath, StartLine: line, EndLine: line,
+		Language: language,
+		Meta:     map[string]any{"fabric_component": component},
+	}
+	if len(events) > 0 {
+		node.Meta["fabric_events"] = events
+	}
+	result.Nodes = append(result.Nodes, node)
+	result.Edges = append(result.Edges, &graph.Edge{
+		From: fileID, To: id, Kind: graph.EdgeDefines, FilePath: filePath, Line: line,
+	})
+}

--- a/internal/parser/languages/jsts_realtime.go
+++ b/internal/parser/languages/jsts_realtime.go
@@ -1,0 +1,55 @@
+package languages
+
+import "regexp"
+
+// Real-time transport edge extraction (WebSocket + Server-Sent Events).
+// A `new WebSocket(url)` or `new EventSource(url)` is the client side of a
+// real-time stream; modelling it as a subscribe edge onto a shared
+// KindEvent channel node (transport "websocket" / "sse") lets
+// `analyze kind=pubsub` / `event_emitters` and architecture queries see
+// the real-time surface the call graph otherwise misses. These transports
+// are cross-process, so the in-process event-channel synthesizer
+// deliberately does not pair them.
+
+const (
+	transportWebSocket = "websocket"
+	transportSSE       = "sse"
+)
+
+var (
+	// new WebSocket(<url-or-var>) — captures the first argument token,
+	// the channel URL (string literal) or the variable holding it.
+	jsWebSocketCtorRe = regexp.MustCompile("new\\s+WebSocket\\s*\\(\\s*[`'\"]?([^`'\",)\\s]*)")
+	// new EventSource(<url>) — also the ReconnectingEventSource polyfill.
+	jsEventSourceCtorRe = regexp.MustCompile("new\\s+(?:Reconnecting)?EventSource\\s*\\(\\s*[`'\"]?([^`'\",)\\s]*)")
+)
+
+// detectJSRealtimeEvents scans a JS/TS source for WebSocket / EventSource
+// client constructors and returns one subscribe pubsubEvent per site,
+// ready to flow through emitPubsubEvents alongside the broker pub/sub
+// events. The channel topic is the URL literal when present, else the
+// variable name, else "connection".
+func detectJSRealtimeEvents(src []byte) []pubsubEvent {
+	s := string(src)
+	var out []pubsubEvent
+	collect := func(transport string, re *regexp.Regexp) {
+		for _, m := range re.FindAllStringSubmatchIndex(s, -1) {
+			topic := "connection"
+			if m[2] >= 0 && m[3] > m[2] {
+				if arg := s[m[2]:m[3]]; arg != "" {
+					topic = arg
+				}
+			}
+			out = append(out, pubsubEvent{
+				role:      pubsubRoleSubscribe,
+				transport: transport,
+				topic:     topic,
+				method:    "new " + transport,
+				line:      lineAt(src, m[0]),
+			})
+		}
+	}
+	collect(transportWebSocket, jsWebSocketCtorRe)
+	collect(transportSSE, jsEventSourceCtorRe)
+	return out
+}

--- a/internal/parser/languages/jsts_rn.go
+++ b/internal/parser/languages/jsts_rn.go
@@ -1,0 +1,100 @@
+package languages
+
+import (
+	"regexp"
+	"strings"
+)
+
+// React Native JS/TS native-module call recognition. A JS call into a
+// native module — `NativeModules.Foo.bar(...)`, a binding to
+// `requireNativeModule('Foo')`, or `TurboModuleRegistry.getEnforcing('Foo')`
+// — is the consumer side of the RN bridge. This shared pass turns such a
+// call into a placeholder edge the resolver's React-Native bridge
+// synthesizer lands on the native implementation.
+
+// rnNativeVia marks a JS→native React Native bridge call edge.
+const rnNativeVia = "rn.native"
+
+var (
+	// const/let/var X = NativeModules.Foo
+	rnVarNativeModulesRe = regexp.MustCompile(`(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*NativeModules\.([A-Za-z_$][\w$]*)`)
+	// const/let/var X = requireNativeModule('Foo') | TurboModuleRegistry.get('Foo') | .getEnforcing('Foo')
+	rnVarRequireRe = regexp.MustCompile(`(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:requireNativeModule|TurboModuleRegistry\.(?:get|getEnforcing))\(\s*['"]([^'"]+)['"]`)
+	// const { Foo, Bar as Baz } = NativeModules
+	rnDestructureRe = regexp.MustCompile(`(?:const|let|var)\s*\{([^}]*)\}\s*=\s*NativeModules\b`)
+	// inline receiver `NativeModules.Foo`
+	rnInlineNativeModulesRe = regexp.MustCompile(`^NativeModules\.([A-Za-z_$][\w$]*)$`)
+	// inline receiver `requireNativeModule('Foo')` / `TurboModuleRegistry.get('Foo')`
+	rnInlineRequireRe = regexp.MustCompile(`^(?:requireNativeModule|TurboModuleRegistry\.(?:get|getEnforcing))\(\s*['"]([^'"]+)['"]\s*\)$`)
+)
+
+// rnNativeModuleVars scans a JS/TS source for local bindings to a React
+// Native native module and returns localName → moduleName, covering
+// direct assignment, requireNativeModule / TurboModuleRegistry, and
+// destructuring from NativeModules (with `as` aliases).
+func rnNativeModuleVars(src []byte) map[string]string {
+	s := string(src)
+	out := map[string]string{}
+	for _, m := range rnVarNativeModulesRe.FindAllStringSubmatch(s, -1) {
+		out[m[1]] = m[2]
+	}
+	for _, m := range rnVarRequireRe.FindAllStringSubmatch(s, -1) {
+		out[m[1]] = m[2]
+	}
+	for _, m := range rnDestructureRe.FindAllStringSubmatch(s, -1) {
+		for _, raw := range strings.Split(m[1], ",") {
+			name := strings.TrimSpace(raw)
+			if name == "" {
+				continue
+			}
+			if parts := strings.Fields(name); len(parts) == 3 && parts[1] == "as" {
+				// `Foo as Baz` → local Baz binds module Foo.
+				out[rnTrimIdent(parts[2])] = rnTrimIdent(parts[0])
+				continue
+			}
+			if ident := rnTrimIdent(name); ident != "" {
+				out[ident] = ident
+			}
+		}
+	}
+	return out
+}
+
+// rnTrimIdent returns the leading identifier of s, dropping any trailing
+// `: Type` annotation or `= default` the destructure entry may carry.
+func rnTrimIdent(s string) string {
+	s = strings.TrimSpace(s)
+	for i, r := range s {
+		isIdent := r == '_' || r == '$' ||
+			(r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9' && i > 0)
+		if !isIdent {
+			return s[:i]
+		}
+	}
+	return s
+}
+
+// detectRNNativeModule returns the React Native module name a member
+// call's receiver addresses, or "" when the receiver is not a native
+// module. Handles inline receivers and bindings recorded in varMap.
+func detectRNNativeModule(receiver string, varMap map[string]string) string {
+	receiver = strings.TrimSpace(receiver)
+	if m := rnInlineNativeModulesRe.FindStringSubmatch(receiver); m != nil {
+		return m[1]
+	}
+	if m := rnInlineRequireRe.FindStringSubmatch(receiver); m != nil {
+		return m[1]
+	}
+	if mod, ok := varMap[receiver]; ok {
+		return mod
+	}
+	return ""
+}
+
+// rnNativePlaceholder is the unresolved target a JS native-module call is
+// emitted onto for the React-Native bridge synthesizer to land on the
+// native implementation.
+func rnNativePlaceholder(module, method string) string {
+	return "unresolved::rn::" + module + "::" + method
+}

--- a/internal/parser/languages/kotlin.go
+++ b/internal/parser/languages/kotlin.go
@@ -675,17 +675,6 @@ type kotlinMemberOwner struct {
 	companionName string // declared companion name, "" if anonymous
 }
 
-// kotlinDirectMemberOwner returns the (name, container kind) of the
-// nearest class_declaration / object_declaration whose body directly
-// contains fn. Returns ("", "") for free functions and nested
-// functions — preserving the legacy nested-query semantics. Companion
-// members are attributed to their enclosing type (see
-// kotlinResolveMemberOwner).
-func kotlinDirectMemberOwner(fn *sitter.Node, src []byte) (string, string) {
-	o := kotlinResolveMemberOwner(fn, src)
-	return o.name, o.kind
-}
-
 // kotlinResolveMemberOwner walks up from a declaration to find its
 // container. It transparently sees through a companion_object wrapper:
 // `class Foo { companion object Factory { fun create() {} } }` resolves

--- a/internal/parser/languages/kotlin.go
+++ b/internal/parser/languages/kotlin.go
@@ -92,6 +92,18 @@ type kotlinDeferredProperty struct {
 	endLine     int
 }
 
+// kotlinLambdaScope records the parameters bound by one lambda literal
+// over the line span of its body. A use of such a parameter inside the
+// span is locally bound and must not be resolved against the outer type
+// environment (which would mis-attribute a `receiver_type` to an
+// unrelated outer variable / type of the same name). Implicit `it` is
+// always in scope inside a lambda that declares no explicit params.
+type kotlinLambdaScope struct {
+	params    map[string]bool
+	startLine int
+	endLine   int
+}
+
 func (e *KotlinExtractor) Extract(filePath string, src []byte) (*parser.ExtractionResult, error) {
 	tree, err := parser.ParseFile(src, e.lang)
 	if err != nil {
@@ -228,6 +240,32 @@ func (e *KotlinExtractor) Extract(filePath string, src []byte) (*parser.Extracti
 		})
 	}
 
+	// Companion-object properties (`companion object { const val NAME; val x }`)
+	// are statically accessible on the enclosing TYPE (`Foo.NAME`). Emit
+	// them as members of that type so the constant / property is
+	// discoverable, mirroring the companion-function attribution above.
+	for _, p := range props {
+		if p.defNode == nil {
+			continue
+		}
+		owner := kotlinResolveMemberOwner(p.defNode, src)
+		if !owner.companion || owner.name == "" {
+			continue
+		}
+		emitKotlinCompanionProperty(p, owner, filePath, src, result, seen)
+	}
+
+	// Type-name set for static (companion-object) dispatch. A call whose
+	// receiver names a class / object — or a named-companion alias
+	// (`Type.Companion`) — is a static access on the TYPE; attribute the
+	// receiver_type to the type name itself so it resolves to the
+	// companion's member (emitted with Meta["receiver"] = <enclosing type>).
+	typeNames := kotlinCollectTypeNames(result)
+
+	// Lambda-parameter scopes: receivers that name a lambda param are
+	// locally bound and must not pick up an outer receiver_type.
+	lambdaScopes := collectKotlinLambdaScopes(root, src)
+
 	// Resolve calls against funcRanges + tenv.
 	funcRanges := buildFuncRanges(result)
 	for _, c := range calls {
@@ -239,10 +277,14 @@ func (e *KotlinExtractor) Extract(filePath string, src []byte) (*parser.Extracti
 			From: callerID, To: "unresolved::*." + c.name,
 			Kind: graph.EdgeCalls, FilePath: filePath, Line: c.line,
 		}
-		if c.isMember {
-			if recvType, ok := tenv[c.receiver]; ok {
-				edge.Meta = map[string]any{"receiver_type": recvType}
-			} else if strings.Contains(c.receiver, ".") || strings.Contains(c.receiver, "(") {
+		if c.isMember && !kotlinReceiverIsLambdaParam(lambdaScopes, c.receiver, c.line) {
+			switch {
+			case tenv[c.receiver] != "":
+				edge.Meta = map[string]any{"receiver_type": tenv[c.receiver]}
+			case typeNames[c.receiver]:
+				// Static dispatch: `Foo.create()` / `Foo.Factory.thing()`.
+				edge.Meta = map[string]any{"receiver_type": c.receiver}
+			case strings.Contains(c.receiver, ".") || strings.Contains(c.receiver, "("):
 				if chainType := resolveChainType(c.receiver, tenv, result); chainType != "" {
 					edge.Meta = map[string]any{"receiver_type": chainType}
 				}
@@ -385,7 +427,8 @@ func (e *KotlinExtractor) emitFunction(m parser.QueryResult, filePath, fileID st
 	doc := ExtractDocAbove(src, def.StartLine, DocLangBlockStar)
 	visibility := kotlinVisibility(def.Node, src)
 
-	owner, ownerKind := kotlinDirectMemberOwner(def.Node, src)
+	ownerInfo := kotlinResolveMemberOwner(def.Node, src)
+	owner, ownerKind := ownerInfo.name, ownerInfo.kind
 	if ownerKind != "" {
 		id := filePath + "::" + owner + "." + name
 		if seen[id] {
@@ -398,6 +441,17 @@ func (e *KotlinExtractor) emitFunction(m parser.QueryResult, filePath, fileID st
 		meta := map[string]any{
 			"receiver":   owner,
 			"visibility": visibility,
+		}
+		// Companion-object members dispatch on the TYPE (`Foo.create()`),
+		// so the method is attributed to the enclosing class and flagged
+		// static. Without this an agent can't see that the companion's
+		// `create` is reachable via the class name.
+		if ownerInfo.companion {
+			meta["static"] = true
+			meta["companion"] = true
+			if ownerInfo.companionName != "" {
+				meta["companion_name"] = ownerInfo.companionName
+			}
 		}
 		if doc != "" {
 			meta["doc"] = doc
@@ -421,6 +475,41 @@ func (e *KotlinExtractor) emitFunction(m parser.QueryResult, filePath, fileID st
 		emitKotlinAnnotationEdges(kotlinCollectAnnotations(def.Node, src), id, filePath, result, annotationSeen)
 		if body := kotlinFunctionBody(def.Node); body != nil {
 			emitKotlinAsyncSpawns(id, body, src, filePath, result)
+		}
+
+		// Named companion: `companion object Factory { fun thing() }` is
+		// callable as both `Foo.thing()` (handled above via the enclosing
+		// owner) and `Foo.Factory.thing()`. Emit an alias method whose
+		// receiver is `Foo.Factory` so the qualified call resolves too.
+		if ownerInfo.companion && ownerInfo.companionName != "" {
+			aliasRecv := owner + "." + ownerInfo.companionName
+			aliasID := filePath + "::" + aliasRecv + "." + name
+			if !seen[aliasID] {
+				seen[aliasID] = true
+				aliasMeta := map[string]any{
+					"receiver":        aliasRecv,
+					"visibility":      visibility,
+					"static":          true,
+					"companion":       true,
+					"companion_name":  ownerInfo.companionName,
+					"companion_alias": true,
+				}
+				if doc != "" {
+					aliasMeta["doc"] = doc
+				}
+				if rt := extractKotlinReturnType(def.Node, src); rt != "" {
+					aliasMeta["return_type"] = rt
+				}
+				result.Nodes = append(result.Nodes, &graph.Node{
+					ID: aliasID, Kind: graph.KindMethod, Name: name,
+					FilePath: filePath, StartLine: startLine1, EndLine: endLine1,
+					Language: "kotlin",
+					Meta:     aliasMeta,
+				})
+				result.Edges = append(result.Edges, &graph.Edge{
+					From: aliasID, To: ownerID, Kind: graph.EdgeMemberOf, FilePath: filePath, Line: startLine1,
+				})
+			}
 		}
 		return
 	}
@@ -568,33 +657,272 @@ func (e *KotlinExtractor) emitImport(m parser.QueryResult, filePath, fileID stri
 
 // --- Helpers --------------------------------------------------------
 
+// kotlinMemberOwner describes the container a declaration belongs to.
+// For a plain class/object method, name is the type name and
+// companionName is empty. For a companion-object member, name is the
+// ENCLOSING class (so `Foo.create()` resolves to the companion's
+// create) and companionName carries the companion's declared name —
+// empty for an anonymous `companion object`, the identifier for a named
+// one like `companion object Factory`.
+type kotlinMemberOwner struct {
+	name          string // enclosing type/object name
+	kind          string // "class_declaration" | "object_declaration"
+	companion     bool   // member lives in a companion object
+	companionName string // declared companion name, "" if anonymous
+}
+
 // kotlinDirectMemberOwner returns the (name, container kind) of the
 // nearest class_declaration / object_declaration whose body directly
 // contains fn. Returns ("", "") for free functions and nested
-// functions — preserving the legacy nested-query semantics.
+// functions — preserving the legacy nested-query semantics. Companion
+// members are attributed to their enclosing type (see
+// kotlinResolveMemberOwner).
 func kotlinDirectMemberOwner(fn *sitter.Node, src []byte) (string, string) {
+	o := kotlinResolveMemberOwner(fn, src)
+	return o.name, o.kind
+}
+
+// kotlinResolveMemberOwner walks up from a declaration to find its
+// container. It transparently sees through a companion_object wrapper:
+// `class Foo { companion object Factory { fun create() {} } }` resolves
+// the owner of create to Foo while recording companion=true and
+// companionName="Factory". This is what makes `Foo.create()` (static
+// dispatch on the type) discoverable.
+func kotlinResolveMemberOwner(fn *sitter.Node, src []byte) kotlinMemberOwner {
 	if fn == nil {
-		return "", ""
+		return kotlinMemberOwner{}
 	}
 	parent := fn.Parent()
 	if parent == nil || parent.Type() != "class_body" {
-		return "", ""
+		return kotlinMemberOwner{}
 	}
 	grand := parent.Parent()
 	if grand == nil {
-		return "", ""
+		return kotlinMemberOwner{}
 	}
-	gtype := grand.Type()
-	if gtype != "class_declaration" && gtype != "object_declaration" {
-		return "", ""
-	}
-	for i := 0; i < int(grand.ChildCount()); i++ {
-		ch := grand.Child(i)
-		if ch != nil && ch.Type() == "type_identifier" {
-			return ch.Content(src), gtype
+
+	// Companion-object member: `class Foo { companion object [Name] { ... } }`.
+	// The grandparent is the companion_object; its enclosing class is two
+	// more levels up (class_body → class_declaration / object_declaration).
+	if grand.Type() == "companion_object" {
+		companionName := kotlinTypeIdentifierChild(grand, src)
+		outerBody := grand.Parent()
+		if outerBody == nil || outerBody.Type() != "class_body" {
+			return kotlinMemberOwner{}
+		}
+		outer := outerBody.Parent()
+		if outer == nil {
+			return kotlinMemberOwner{}
+		}
+		otype := outer.Type()
+		if otype != "class_declaration" && otype != "object_declaration" {
+			return kotlinMemberOwner{}
+		}
+		name := kotlinTypeIdentifierChild(outer, src)
+		if name == "" {
+			return kotlinMemberOwner{}
+		}
+		return kotlinMemberOwner{
+			name:          name,
+			kind:          otype,
+			companion:     true,
+			companionName: companionName,
 		}
 	}
-	return "", ""
+
+	gtype := grand.Type()
+	if gtype != "class_declaration" && gtype != "object_declaration" {
+		return kotlinMemberOwner{}
+	}
+	name := kotlinTypeIdentifierChild(grand, src)
+	if name == "" {
+		return kotlinMemberOwner{}
+	}
+	return kotlinMemberOwner{name: name, kind: gtype}
+}
+
+// kotlinTypeIdentifierChild returns the first type_identifier child of
+// node (the declared name of a class/object/companion), or "" when the
+// node is anonymous.
+func kotlinTypeIdentifierChild(node *sitter.Node, src []byte) string {
+	if node == nil {
+		return ""
+	}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		ch := node.Child(i)
+		if ch != nil && ch.Type() == "type_identifier" {
+			return ch.Content(src)
+		}
+	}
+	return ""
+}
+
+// kotlinCollectTypeNames returns the set of receiver strings that name a
+// type for the purpose of static (companion-object) dispatch: every
+// class / object / interface name, plus the `Type.Companion` aliases
+// emitted for named companion objects (so `Bar.Factory.thing()` lands on
+// the alias method's receiver). The companion alias receivers are read
+// back from the alias method nodes' Meta["receiver"].
+func kotlinCollectTypeNames(result *parser.ExtractionResult) map[string]bool {
+	names := map[string]bool{}
+	for _, n := range result.Nodes {
+		switch n.Kind {
+		case graph.KindType, graph.KindInterface:
+			if n.Name != "" {
+				names[n.Name] = true
+			}
+		case graph.KindMethod:
+			if n.Meta == nil {
+				continue
+			}
+			if alias, _ := n.Meta["companion_alias"].(bool); !alias {
+				continue
+			}
+			if recv, _ := n.Meta["receiver"].(string); recv != "" {
+				names[recv] = true
+			}
+		}
+	}
+	return names
+}
+
+// emitKotlinCompanionProperty emits one member node for a property
+// declared inside a companion object, attributed to the enclosing type
+// so `Foo.NAME` is discoverable. A `const`-modified property is a
+// KindConstant; a plain `val`/`var` is a KindField. Both carry
+// Meta["receiver"] = <enclosing type> and Meta["static"] = true. For a
+// named companion an alias member (`Type.Companion.NAME`) is added too.
+func emitKotlinCompanionProperty(p kotlinDeferredProperty, owner kotlinMemberOwner, filePath string, src []byte, result *parser.ExtractionResult, seen map[string]bool) {
+	kind := graph.KindField
+	if kotlinPropertyIsConst(p.defNode, src) {
+		kind = graph.KindConstant
+	}
+	emit := func(recv string) {
+		id := filePath + "::" + recv + "." + p.name
+		if seen[id] {
+			return
+		}
+		seen[id] = true
+		meta := map[string]any{
+			"receiver":  recv,
+			"static":    true,
+			"companion": true,
+		}
+		if owner.companionName != "" {
+			meta["companion_name"] = owner.companionName
+		}
+		ownerID := filePath + "::" + owner.name
+		result.Nodes = append(result.Nodes, &graph.Node{
+			ID: id, Kind: kind, Name: p.name,
+			FilePath: filePath, StartLine: p.line, EndLine: p.endLine,
+			Language: "kotlin",
+			Meta:     meta,
+		})
+		result.Edges = append(result.Edges, &graph.Edge{
+			From: id, To: ownerID, Kind: graph.EdgeMemberOf, FilePath: filePath, Line: p.line,
+		})
+	}
+	emit(owner.name)
+	if owner.companionName != "" {
+		emit(owner.name + "." + owner.companionName)
+	}
+}
+
+// kotlinPropertyIsConst reports whether a property_declaration carries a
+// `const` modifier.
+func kotlinPropertyIsConst(decl *sitter.Node, src []byte) bool {
+	if decl == nil {
+		return false
+	}
+	for i := 0; i < int(decl.ChildCount()); i++ {
+		c := decl.Child(i)
+		if c == nil || c.Type() != "modifiers" {
+			continue
+		}
+		for j := 0; j < int(c.ChildCount()); j++ {
+			tok := c.Child(j)
+			if tok == nil {
+				continue
+			}
+			if strings.TrimSpace(tok.Content(src)) == "const" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// collectKotlinLambdaScopes walks the tree for lambda_literal nodes and
+// records, for each, the parameter names it binds plus the line span of
+// its body. Explicit params come from the `lambda_parameters` child
+// (`{ a, b -> ... }`); a lambda with no declared params implicitly binds
+// `it` (`list.forEach { println(it) }`). These scopes let the call
+// resolver recognise that a member call whose receiver is a lambda
+// parameter is locally bound, so it is not mis-resolved against the
+// outer type environment.
+func collectKotlinLambdaScopes(root *sitter.Node, src []byte) []kotlinLambdaScope {
+	var scopes []kotlinLambdaScope
+	walkNodes(root, func(n *sitter.Node) {
+		if n == nil || n.Type() != "lambda_literal" {
+			return
+		}
+		params := map[string]bool{}
+		hasExplicit := false
+		for i := 0; i < int(n.ChildCount()); i++ {
+			ch := n.Child(i)
+			if ch == nil || ch.Type() != "lambda_parameters" {
+				continue
+			}
+			hasExplicit = true
+			// lambda_parameters → variable_declaration → simple_identifier,
+			// possibly several (destructuring / multi-param).
+			walkNodes(ch, func(p *sitter.Node) {
+				if p != nil && p.Type() == "simple_identifier" {
+					params[p.Content(src)] = true
+				}
+			})
+		}
+		if !hasExplicit {
+			// No declared params: the implicit single parameter `it`.
+			params["it"] = true
+		}
+		if len(params) == 0 {
+			return
+		}
+		scopes = append(scopes, kotlinLambdaScope{
+			params:    params,
+			startLine: int(n.StartPoint().Row) + 1,
+			endLine:   int(n.EndPoint().Row) + 1,
+		})
+	})
+	return scopes
+}
+
+// kotlinReceiverIsLambdaParam reports whether the head identifier of a
+// receiver expression names a lambda parameter that is in scope at the
+// call's line. The head is the first dotted segment, so both `it` and
+// `item` (in `item.x`) are caught.
+func kotlinReceiverIsLambdaParam(scopes []kotlinLambdaScope, receiver string, line int) bool {
+	head := receiver
+	if idx := strings.IndexByte(head, '.'); idx >= 0 {
+		head = head[:idx]
+	}
+	if idx := strings.IndexByte(head, '('); idx >= 0 {
+		head = head[:idx]
+	}
+	head = strings.TrimSpace(head)
+	if head == "" {
+		return false
+	}
+	for _, s := range scopes {
+		if line < s.startLine || line > s.endLine {
+			continue
+		}
+		if s.params[head] {
+			return true
+		}
+	}
+	return false
 }
 
 // normalizeKotlinTypeName strips generics and nullable markers from a Kotlin type name.

--- a/internal/parser/languages/kotlin.go
+++ b/internal/parser/languages/kotlin.go
@@ -293,6 +293,10 @@ func (e *KotlinExtractor) Extract(filePath string, src []byte) (*parser.Extracti
 		result.Edges = append(result.Edges, edge)
 	}
 
+	// Expo Modules native DSL (Name/Function/AsyncFunction) → synthetic
+	// JS-callable method nodes for the Expo bridge synthesizer.
+	emitExpoModuleNodes(src, filePath, "kotlin", fileID, result, seen)
+
 	return result, nil
 }
 

--- a/internal/parser/languages/kotlin_test.go
+++ b/internal/parser/languages/kotlin_test.go
@@ -443,3 +443,199 @@ internal fun helper() {}
 		t.Fatalf("helper.vis = %q", helper.Meta["visibility"])
 	}
 }
+
+// kotlinCallEdgeTo returns the first EdgeCalls whose target ends in the
+// given method name. Mirrors the lookup the type-env tests use.
+func kotlinCallEdgeTo(result *parser.ExtractionResult, method string) *graph.Edge {
+	for _, c := range edgesOfKind(result.Edges, graph.EdgeCalls) {
+		if strings.HasSuffix(c.To, "."+method) {
+			return c
+		}
+	}
+	return nil
+}
+
+func TestKotlinExtractor_CompanionObject_AnonymousStaticDispatch(t *testing.T) {
+	src := []byte(`class Foo {
+    companion object {
+        fun create(): Foo {
+            return Foo()
+        }
+    }
+}
+
+fun main() {
+    Foo.create()
+}
+`)
+	e := NewKotlinExtractor()
+	result, err := e.Extract("Foo.kt", src)
+	require.NoError(t, err)
+
+	byID := map[string]*graph.Node{}
+	for _, n := range result.Nodes {
+		byID[n.ID] = n
+	}
+
+	// The companion function is attributed to the enclosing class Foo.
+	create := byID["Foo.kt::Foo.create"]
+	require.NotNil(t, create, "companion create should be a member of Foo")
+	assert.Equal(t, graph.KindMethod, create.Kind)
+	assert.Equal(t, "Foo", create.Meta["receiver"])
+	assert.Equal(t, true, create.Meta["static"])
+	assert.Equal(t, true, create.Meta["companion"])
+
+	// EdgeMemberOf should point the method at Foo.
+	var memberOf bool
+	for _, ed := range edgesOfKind(result.Edges, graph.EdgeMemberOf) {
+		if ed.From == "Foo.kt::Foo.create" && ed.To == "Foo.kt::Foo" {
+			memberOf = true
+		}
+	}
+	assert.True(t, memberOf, "expected create -> Foo member_of edge")
+
+	// The Foo.create() call carries receiver_type=Foo so the resolver
+	// can land it on the companion's create method.
+	callEdge := kotlinCallEdgeTo(result, "create")
+	require.NotNil(t, callEdge, "expected a call edge to create")
+	require.NotNil(t, callEdge.Meta, "expected receiver_type meta on Foo.create() call")
+	assert.Equal(t, "Foo", callEdge.Meta["receiver_type"])
+}
+
+func TestKotlinExtractor_CompanionObject_NamedStaticDispatch(t *testing.T) {
+	src := []byte(`class Bar {
+    companion object Factory {
+        @JvmStatic
+        fun thing(): Bar = Bar()
+    }
+}
+
+fun main() {
+    Bar.thing()
+    Bar.Factory.thing()
+}
+`)
+	e := NewKotlinExtractor()
+	result, err := e.Extract("Bar.kt", src)
+	require.NoError(t, err)
+
+	byID := map[string]*graph.Node{}
+	for _, n := range result.Nodes {
+		byID[n.ID] = n
+	}
+
+	// Both the type-receiver method (Bar.thing) and the named-companion
+	// alias (Bar.Factory.thing) exist.
+	barThing := byID["Bar.kt::Bar.thing"]
+	require.NotNil(t, barThing, "expected Bar.thing member")
+	assert.Equal(t, "Bar", barThing.Meta["receiver"])
+	assert.Equal(t, "Factory", barThing.Meta["companion_name"])
+
+	aliasThing := byID["Bar.kt::Bar.Factory.thing"]
+	require.NotNil(t, aliasThing, "expected Bar.Factory.thing alias member")
+	assert.Equal(t, "Bar.Factory", aliasThing.Meta["receiver"])
+	assert.Equal(t, true, aliasThing.Meta["companion_alias"])
+
+	// Bar.thing() resolves via receiver_type=Bar; Bar.Factory.thing()
+	// resolves via receiver_type=Bar.Factory.
+	var sawBar, sawFactory bool
+	for _, c := range edgesOfKind(result.Edges, graph.EdgeCalls) {
+		if !strings.HasSuffix(c.To, ".thing") || c.Meta == nil {
+			continue
+		}
+		switch c.Meta["receiver_type"] {
+		case "Bar":
+			sawBar = true
+		case "Bar.Factory":
+			sawFactory = true
+		}
+	}
+	assert.True(t, sawBar, "expected Bar.thing() call with receiver_type=Bar")
+	assert.True(t, sawFactory, "expected Bar.Factory.thing() call with receiver_type=Bar.Factory")
+}
+
+func TestKotlinExtractor_CompanionObject_ConstProperty(t *testing.T) {
+	src := []byte(`class Config {
+    companion object {
+        const val NAME = "config"
+        val version = "1.0"
+    }
+}
+`)
+	e := NewKotlinExtractor()
+	result, err := e.Extract("Config.kt", src)
+	require.NoError(t, err)
+
+	byID := map[string]*graph.Node{}
+	for _, n := range result.Nodes {
+		byID[n.ID] = n
+	}
+
+	name := byID["Config.kt::Config.NAME"]
+	require.NotNil(t, name, "companion const should be a member of Config")
+	assert.Equal(t, graph.KindConstant, name.Kind)
+	assert.Equal(t, "Config", name.Meta["receiver"])
+	assert.Equal(t, true, name.Meta["static"])
+
+	version := byID["Config.kt::Config.version"]
+	require.NotNil(t, version, "companion val should be a member of Config")
+	assert.Equal(t, graph.KindField, version.Kind)
+	assert.Equal(t, "Config", version.Meta["receiver"])
+
+	// Companion props must not be emitted as top-level variables.
+	for _, n := range nodesOfKind(result.Nodes, graph.KindVariable) {
+		assert.NotEqual(t, "NAME", n.Name)
+		assert.NotEqual(t, "version", n.Name)
+	}
+}
+
+func TestKotlinExtractor_LambdaParam_NotMisresolved(t *testing.T) {
+	// `item` is also the name of a top-level value of a known type;
+	// inside the lambda it is a different, locally-bound parameter. The
+	// lambda use of item.toLong() must NOT pick up the outer item's type.
+	src := []byte(`class Widget {
+    fun render() {}
+}
+
+fun process(list: List<Int>) {
+    val item = Widget()
+    list.map { item -> item.toLong() }
+}
+`)
+	e := NewKotlinExtractor()
+	result, err := e.Extract("app.kt", src)
+	require.NoError(t, err)
+
+	toLong := kotlinCallEdgeTo(result, "toLong")
+	require.NotNil(t, toLong, "expected a call edge to toLong")
+	// The lambda parameter shadows the outer `item`, so no outer
+	// receiver_type (Widget) may be attached.
+	if toLong.Meta != nil {
+		assert.Nil(t, toLong.Meta["receiver_type"],
+			"lambda-param receiver must not be resolved against the outer type env")
+	}
+}
+
+func TestKotlinExtractor_LambdaImplicitIt_NotMisresolved(t *testing.T) {
+	// A top-level `it` of a known type exists; the implicit lambda `it`
+	// must shadow it inside `forEach { it.compute() }`.
+	src := []byte(`class Engine {
+    fun compute() {}
+}
+
+fun run(list: List<Int>) {
+    val it = Engine()
+    list.forEach { it.compute() }
+}
+`)
+	e := NewKotlinExtractor()
+	result, err := e.Extract("run.kt", src)
+	require.NoError(t, err)
+
+	compute := kotlinCallEdgeTo(result, "compute")
+	require.NotNil(t, compute, "expected a call edge to compute")
+	if compute.Meta != nil {
+		assert.Nil(t, compute.Meta["receiver_type"],
+			"implicit lambda `it` must not be resolved against the outer type env")
+	}
+}

--- a/internal/parser/languages/mybatis.go
+++ b/internal/parser/languages/mybatis.go
@@ -1,0 +1,266 @@
+package languages
+
+import (
+	"bytes"
+	"encoding/xml"
+	"io"
+	"path"
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+)
+
+// MyBatisExtractor indexes MyBatis mapper XML — the SQL-mapping layer of
+// a Java/MyBatis application. A mapper file binds a Java DAO/Mapper
+// interface (named by the `<mapper namespace="…">` FQCN) to a set of SQL
+// statements, one per `<select>/<insert>/<update>/<delete>` element keyed
+// by its `id`.
+//
+// What it surfaces:
+//   - the file node, stamped `mybatis_namespace` (the bound interface FQCN);
+//   - one node per statement element, with ID `<namespace>::<id>`
+//     (e.g. namespace `com.app.UserMapper`, statement id `findUser` →
+//     `com.app.UserMapper::findUser`). Each statement node is shaped like
+//     a method (graph.KindMethod), carries the SQL kind
+//     (select/insert/update/delete) in `mybatis_sql_kind` and the raw SQL
+//     body in `mybatis_sql`, and emits an unresolved::-keyed EdgeCalls
+//     placeholder back to the Java DAO method the synthesizer (see
+//     internal/resolver/mybatis_calls.go::ResolveMyBatisCalls) lands.
+//
+// MyBatis mapper XML uses the plain `.xml` extension — shared with every
+// other XML document — so the extractor is gated on the document content:
+// IsMyBatisMapper recognises the `<mapper namespace=…>` root and/or the
+// MyBatis DOCTYPE, and Extract returns just the file node (no statement
+// nodes) for any XML that is not a mapper. The registry routes a `.xml`
+// file here only when the content sniff matches, so ordinary XML is left
+// to the generic XML extractor.
+type MyBatisExtractor struct{}
+
+// NewMyBatisExtractor constructs a MyBatisExtractor.
+func NewMyBatisExtractor() *MyBatisExtractor { return &MyBatisExtractor{} }
+
+func (e *MyBatisExtractor) Language() string     { return "mybatis" }
+func (e *MyBatisExtractor) Extensions() []string { return []string{".xml"} }
+
+// myBatisStatementElems is the set of mapper child elements that name an
+// executable SQL statement. `<sql>` fragments and `<resultMap>` are
+// deliberately excluded — they are reusable building blocks, not
+// statements a DAO method invokes directly.
+var myBatisStatementElems = map[string]bool{
+	"select": true,
+	"insert": true,
+	"update": true,
+	"delete": true,
+}
+
+// myBatisUnresolvedPrefix keys the placeholder EdgeCalls target the
+// extractor emits from each statement node. The cross-file synthesizer
+// (ResolveMyBatisCalls) rewrites it onto the matching Java DAO method.
+const myBatisUnresolvedPrefix = "unresolved::mybatis::"
+
+// IsMyBatisMapper reports whether src is a MyBatis mapper XML document.
+// It accepts either the `<mapper namespace="…">` root element or the
+// MyBatis DOCTYPE (`mybatis.org//DTD Mapper`). Only the document head is
+// scanned, so the probe is cheap on large files.
+func IsMyBatisMapper(src []byte) bool {
+	head := src
+	const headCap = 8 * 1024
+	if len(head) > headCap {
+		head = head[:headCap]
+	}
+	lower := bytes.ToLower(head)
+	// DOCTYPE form: `<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" ...>`
+	if bytes.Contains(lower, []byte("mybatis.org//dtd mapper")) {
+		return true
+	}
+	// Root-element form: a `<mapper` start tag carrying a `namespace`
+	// attribute. Tolerant of attribute ordering and whitespace.
+	if i := bytes.Index(lower, []byte("<mapper")); i >= 0 {
+		rest := lower[i:]
+		if end := bytes.IndexByte(rest, '>'); end >= 0 {
+			rest = rest[:end]
+		}
+		if bytes.Contains(rest, []byte("namespace")) {
+			return true
+		}
+	}
+	return false
+}
+
+// Extract parses a MyBatis mapper XML file. A document that is not a
+// mapper (no `<mapper namespace>` root / MyBatis DOCTYPE) yields only the
+// file node, so a misrouted plain-XML file degrades gracefully. A
+// malformed mapper yields whatever was decoded before the error — never a
+// hard failure.
+func (e *MyBatisExtractor) Extract(filePath string, src []byte) (*parser.ExtractionResult, error) {
+	result := &parser.ExtractionResult{}
+	fileNode := &graph.Node{
+		ID:       filePath,
+		Kind:     graph.KindFile,
+		Name:     path.Base(filePath),
+		FilePath: filePath,
+		Language: "mybatis",
+	}
+	result.Nodes = append(result.Nodes, fileNode)
+
+	if !IsMyBatisMapper(src) {
+		return result, nil
+	}
+
+	dec := xml.NewDecoder(bytes.NewReader(src))
+	dec.Strict = false
+	namespace := ""
+	seenID := map[string]bool{}
+
+	for {
+		tok, err := dec.Token()
+		if err == io.EOF || err != nil {
+			break // EOF or malformed — keep what was decoded
+		}
+		se, ok := tok.(xml.StartElement)
+		if !ok {
+			continue
+		}
+		local := strings.ToLower(se.Name.Local)
+
+		if local == "mapper" {
+			if ns := myBatisAttr(se, "namespace"); ns != "" {
+				namespace = ns
+				fileNode.Meta = map[string]any{"mybatis_namespace": ns}
+			}
+			continue
+		}
+
+		if !myBatisStatementElems[local] {
+			continue
+		}
+		stmtID := myBatisAttr(se, "id")
+		if stmtID == "" || namespace == "" || seenID[stmtID] {
+			continue
+		}
+		seenID[stmtID] = true
+
+		// The statement's SQL body is read from the source slice rather
+		// than the decoder, so nested dynamic-SQL elements (<if>, <where>,
+		// <foreach>, …) are flattened to their text content. The decoder
+		// loop then walks those nested elements; none are statement elems,
+		// so they are skipped by the filter above.
+		startLine := 1 + bytes.Count(src[:clampOffset(dec.InputOffset(), len(src))], []byte{'\n'})
+		sql := myBatisStatementSQL(src, startLine)
+
+		stmtNodeID := namespace + "::" + stmtID
+		stmt := &graph.Node{
+			ID:        stmtNodeID,
+			Kind:      graph.KindMethod,
+			Name:      stmtID,
+			QualName:  namespace + "." + stmtID,
+			FilePath:  filePath,
+			StartLine: startLine,
+			EndLine:   startLine,
+			Language:  "mybatis",
+			Meta: map[string]any{
+				"mybatis_namespace": namespace,
+				"mybatis_statement": stmtID,
+				"mybatis_sql_kind":  local,
+				"mybatis_sql":       sql,
+			},
+		}
+		result.Nodes = append(result.Nodes, stmt)
+
+		// EdgeDefines from the file so the statement node is contained by
+		// its mapper file (matches every other extractor's file→symbol
+		// wiring).
+		result.Edges = append(result.Edges, &graph.Edge{
+			From: filePath, To: stmtNodeID, Kind: graph.EdgeDefines,
+			FilePath: filePath, Line: startLine,
+		})
+
+		// Placeholder call edge from the SQL statement back to the Java
+		// DAO method that executes it. The synthesizer rewrites the
+		// `To` onto the resolved Java method node; until then the edge
+		// terminates on a deterministic unresolved:: placeholder keyed by
+		// namespace::id.
+		result.Edges = append(result.Edges, &graph.Edge{
+			From: stmtNodeID,
+			To:   myBatisUnresolvedPrefix + stmtNodeID,
+			Kind: graph.EdgeCalls,
+			Meta: map[string]any{
+				"via":               "mybatis.mapper",
+				"mybatis_namespace": namespace,
+				"mybatis_statement": stmtID,
+			},
+			FilePath: filePath,
+			Line:     startLine,
+		})
+	}
+	return result, nil
+}
+
+// myBatisAttr returns the value of the attribute with the given local
+// name (namespace-agnostic).
+func myBatisAttr(se xml.StartElement, local string) string {
+	for _, a := range se.Attr {
+		if a.Name.Local == local {
+			return strings.TrimSpace(a.Value)
+		}
+	}
+	return ""
+}
+
+// myBatisStatementSQL returns the raw text body of the statement element
+// whose start tag opens on line startLine1 (1-based). It scans the source
+// for the element's `>` then captures up to the matching close tag,
+// stripping nested dynamic-SQL tags so the result reads as plain SQL.
+func myBatisStatementSQL(src []byte, startLine1 int) string {
+	// Locate the byte offset of the start of startLine1.
+	off := 0
+	line := 1
+	for off < len(src) && line < startLine1 {
+		if src[off] == '\n' {
+			line++
+		}
+		off++
+	}
+	// Find the end of the opening start tag ('>') from here.
+	gt := bytes.IndexByte(src[off:], '>')
+	if gt < 0 {
+		return ""
+	}
+	bodyStart := off + gt + 1
+	// Find the next matching statement close tag.
+	rest := src[bodyStart:]
+	endRel := -1
+	for _, ct := range [][]byte{
+		[]byte("</select>"), []byte("</insert>"), []byte("</update>"), []byte("</delete>"),
+		[]byte("</SELECT>"), []byte("</INSERT>"), []byte("</UPDATE>"), []byte("</DELETE>"),
+	} {
+		if i := bytes.Index(rest, ct); i >= 0 && (endRel < 0 || i < endRel) {
+			endRel = i
+		}
+	}
+	if endRel < 0 {
+		endRel = len(rest)
+	}
+	body := rest[:endRel]
+	return normaliseMyBatisSQL(body)
+}
+
+// normaliseMyBatisSQL strips nested XML tags from a statement body and
+// collapses whitespace so the stored SQL is a single readable string.
+func normaliseMyBatisSQL(body []byte) string {
+	var out []byte
+	depth := 0 // inside a nested <…> tag
+	for i := 0; i < len(body); i++ {
+		c := body[i]
+		switch {
+		case c == '<':
+			depth++
+		case c == '>' && depth > 0:
+			depth--
+		case depth == 0:
+			out = append(out, c)
+		}
+	}
+	return strings.Join(strings.Fields(string(out)), " ")
+}

--- a/internal/parser/languages/mybatis_test.go
+++ b/internal/parser/languages/mybatis_test.go
@@ -1,0 +1,112 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+const sampleMyBatisMapper = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.app.UserMapper">
+    <select id="findUser" resultType="com.app.User">
+        SELECT id, name FROM users WHERE id = #{id}
+    </select>
+    <insert id="insertUser">
+        INSERT INTO users (name) VALUES (#{name})
+    </insert>
+    <update id="updateUser">
+        UPDATE users SET name = #{name}
+        <where>
+            <if test="id != null">id = #{id}</if>
+        </where>
+    </update>
+    <delete id="deleteUser">DELETE FROM users WHERE id = #{id}</delete>
+    <sql id="cols">id, name</sql>
+    <resultMap id="userMap" type="com.app.User"/>
+</mapper>`
+
+func TestMyBatisExtractor_StatementNodes(t *testing.T) {
+	res, err := NewMyBatisExtractor().Extract("UserMapper.xml", []byte(sampleMyBatisMapper))
+	require.NoError(t, err)
+
+	var file *graph.Node
+	stmts := map[string]*graph.Node{}
+	for _, n := range res.Nodes {
+		switch n.Kind {
+		case graph.KindFile:
+			file = n
+		case graph.KindMethod:
+			stmts[n.ID] = n
+		}
+	}
+	require.NotNil(t, file)
+	require.Equal(t, "com.app.UserMapper", file.Meta["mybatis_namespace"])
+
+	// One node per <select>/<insert>/<update>/<delete> — <sql> and
+	// <resultMap> are excluded.
+	require.Len(t, stmts, 4)
+
+	cases := []struct {
+		id      string
+		kind    string
+		sqlPart string
+	}{
+		{"com.app.UserMapper::findUser", "select", "SELECT id, name FROM users"},
+		{"com.app.UserMapper::insertUser", "insert", "INSERT INTO users"},
+		{"com.app.UserMapper::updateUser", "update", "UPDATE users SET name"},
+		{"com.app.UserMapper::deleteUser", "delete", "DELETE FROM users"},
+	}
+	for _, c := range cases {
+		n := stmts[c.id]
+		require.NotNil(t, n, "missing statement node %s", c.id)
+		require.Equal(t, c.kind, n.Meta["mybatis_sql_kind"])
+		require.Equal(t, "com.app.UserMapper", n.Meta["mybatis_namespace"])
+		sql, _ := n.Meta["mybatis_sql"].(string)
+		require.Contains(t, sql, c.sqlPart, "statement %s SQL", c.id)
+	}
+
+	// The dynamic-SQL <where>/<if> body is flattened into the stored SQL.
+	require.Contains(t, stmts["com.app.UserMapper::updateUser"].Meta["mybatis_sql"], "id = #{id}")
+
+	// Each statement emits a placeholder call edge keyed by namespace::id.
+	placeholders := map[string]bool{}
+	for _, e := range res.Edges {
+		if e.Kind == graph.EdgeCalls {
+			if via, _ := e.Meta["via"].(string); via == "mybatis.mapper" {
+				placeholders[e.To] = true
+			}
+		}
+	}
+	require.True(t, placeholders["unresolved::mybatis::com.app.UserMapper::findUser"])
+	require.Len(t, placeholders, 4)
+}
+
+func TestMyBatisExtractor_NonMapperXMLYieldsOnlyFileNode(t *testing.T) {
+	plain := []byte(`<?xml version="1.0"?><config><setting name="x">1</setting></config>`)
+	res, err := NewMyBatisExtractor().Extract("config.xml", plain)
+	require.NoError(t, err)
+	require.Len(t, res.Nodes, 1) // file node only
+	require.Equal(t, graph.KindFile, res.Nodes[0].Kind)
+	require.Empty(t, res.Edges)
+}
+
+func TestIsMyBatisMapper(t *testing.T) {
+	require.True(t, IsMyBatisMapper([]byte(`<mapper namespace="com.app.X">`)))
+	require.True(t, IsMyBatisMapper([]byte(`<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "...">`)))
+	require.False(t, IsMyBatisMapper([]byte(`<config><x/></config>`)))
+	require.False(t, IsMyBatisMapper([]byte(`<mapper>no namespace here</mapper>`)))
+}
+
+func TestMyBatisExtractor_Malformed(t *testing.T) {
+	res, err := NewMyBatisExtractor().Extract("bad.xml", []byte(`<mapper namespace="com.app.X"><select id="q">SELECT 1`))
+	require.NoError(t, err)        // never a hard failure
+	require.NotEmpty(t, res.Nodes) // at least the file node survives
+}
+
+func TestMyBatisExtractor_Extensions(t *testing.T) {
+	require.Equal(t, []string{".xml"}, NewMyBatisExtractor().Extensions())
+}

--- a/internal/parser/languages/objc.go
+++ b/internal/parser/languages/objc.go
@@ -101,6 +101,29 @@ func (e *ObjCExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 		add(name, graph.KindFunction, line, findBlockEnd(lines, line))
 	}
 
+	// React Native native-module exports: RCT_EXPORT_MODULE declares the
+	// JS-visible module, RCT_EXPORT_METHOD / RCT_REMAP_METHOD expose a
+	// method to JS. Emit a method node per export carrying rn_module /
+	// rn_method so the React-Native bridge synthesizer can land a JS
+	// `NativeModules.<module>.<method>()` call on this native impl.
+	for _, rx := range extractObjCRNExports(src) {
+		id := filePath + "::" + rx.selector
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		result.Nodes = append(result.Nodes, &graph.Node{
+			ID: id, Kind: graph.KindMethod, Name: rx.selector,
+			FilePath: filePath, StartLine: rx.line, EndLine: findBlockEnd(lines, rx.line),
+			Language: "objc",
+			Meta:     map[string]any{"rn_module": rx.module, "rn_method": rx.jsName},
+		})
+		result.Edges = append(result.Edges, &graph.Edge{
+			From: fileNode.ID, To: id, Kind: graph.EdgeDefines,
+			FilePath: filePath, Line: rx.line,
+		})
+	}
+
 	emitImport := func(mod string, line int) {
 		if mod == "" {
 			return
@@ -194,6 +217,162 @@ func objcIsKeyword(s string) bool {
 		return true
 	}
 	return false
+}
+
+// objcRNExport is one React Native method export discovered in a file:
+// its full ObjC selector, the JS-visible method name, the JS module name
+// (the enclosing @implementation's RCT_EXPORT_MODULE name, defaulting to
+// the class name), and the source line.
+type objcRNExport struct {
+	selector string
+	jsName   string
+	module   string
+	line     int
+}
+
+var (
+	objcRCTModuleRe = regexp.MustCompile(`RCT_EXPORT_MODULE(?:_NO_LOAD)?\s*\(\s*([A-Za-z_]\w*)?\s*\)`)
+	objcRCTMethodRe = regexp.MustCompile(`RCT_(EXPORT|REMAP)_METHOD\s*\(`)
+)
+
+// extractObjCRNExports scans for React Native module/method export
+// macros and resolves each exported method to its JS module + method
+// name. Module attribution walks the enclosing @implementation block:
+// RCT_EXPORT_MODULE(arg) sets the JS name (arg, or the class name when
+// the macro has no argument).
+func extractObjCRNExports(src []byte) []objcRNExport {
+	type block struct {
+		name        string
+		start, end  int
+		moduleName  string
+		moduleKnown bool
+	}
+	var blocks []block
+	implIdx := objcImplRe.FindAllSubmatchIndex(src, -1)
+	for i, m := range implIdx {
+		start := m[0]
+		end := len(src)
+		if i+1 < len(implIdx) {
+			end = implIdx[i+1][0]
+		}
+		if e := objcKeywordEndOffset(src, m[1], "@end"); e >= 0 && e < end {
+			end = e
+		}
+		blocks = append(blocks, block{name: string(src[m[2]:m[3]]), start: start, end: end, moduleName: string(src[m[2]:m[3]])})
+	}
+	blockFor := func(off int) *block {
+		for i := range blocks {
+			if off >= blocks[i].start && off < blocks[i].end {
+				return &blocks[i]
+			}
+		}
+		return nil
+	}
+
+	// RCT_EXPORT_MODULE: set the JS module name for its block.
+	for _, m := range objcRCTModuleRe.FindAllSubmatchIndex(src, -1) {
+		b := blockFor(m[0])
+		if b == nil {
+			continue
+		}
+		if m[2] >= 0 {
+			if arg := strings.TrimSpace(string(src[m[2]:m[3]])); arg != "" {
+				b.moduleName = arg
+			}
+		}
+		b.moduleKnown = true
+	}
+
+	var out []objcRNExport
+	for _, loc := range objcRCTMethodRe.FindAllSubmatchIndex(src, -1) {
+		kind := string(src[loc[2]:loc[3]]) // EXPORT | REMAP
+		openParen := loc[1] - 1            // the '(' the regex ended on
+		inner, ok := objcBalancedParen(src, openParen)
+		if !ok {
+			continue
+		}
+		module := ""
+		if b := blockFor(loc[0]); b != nil {
+			module = b.moduleName
+		}
+		var selector, jsName string
+		if kind == "REMAP" {
+			// RCT_REMAP_METHOD(jsName, selectorParts...)
+			js, rest := objcSplitFirstComma(inner)
+			jsName = strings.TrimSpace(js)
+			selector = objcBuildSelector(rest)
+		} else {
+			selector = objcBuildSelector(inner)
+			jsName = selector
+			if i := strings.IndexByte(jsName, ':'); i >= 0 {
+				jsName = jsName[:i]
+			}
+		}
+		if selector == "" || jsName == "" || module == "" {
+			continue
+		}
+		out = append(out, objcRNExport{
+			selector: selector,
+			jsName:   jsName,
+			module:   module,
+			line:     lineAt(src, loc[0]),
+		})
+	}
+	return out
+}
+
+// objcBalancedParen returns the text between the '(' at openIdx and its
+// matching ')', honouring nested parentheses (ObjC type casts like
+// `(NSString *)`). ok is false when no balanced close is found.
+func objcBalancedParen(src []byte, openIdx int) (inner string, ok bool) {
+	if openIdx < 0 || openIdx >= len(src) || src[openIdx] != '(' {
+		return "", false
+	}
+	depth := 0
+	for i := openIdx; i < len(src); i++ {
+		switch src[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return string(src[openIdx+1 : i]), true
+			}
+		}
+	}
+	return "", false
+}
+
+// objcSplitFirstComma splits s at the first top-level comma (depth-0),
+// used to peel the JS name off an RCT_REMAP_METHOD's first argument.
+func objcSplitFirstComma(s string) (first, rest string) {
+	depth := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				return s[:i], s[i+1:]
+			}
+		}
+	}
+	return s, ""
+}
+
+// objcKeywordEndOffset returns the byte offset just past the first line
+// containing keyword at or after `from`, or -1 if none. Used to bound an
+// @implementation block at its @end.
+func objcKeywordEndOffset(src []byte, from int, keyword string) int {
+	idx := strings.Index(string(src[from:]), keyword)
+	if idx < 0 {
+		return -1
+	}
+	return from + idx + len(keyword)
 }
 
 var _ parser.Extractor = (*ObjCExtractor)(nil)

--- a/internal/parser/languages/objc.go
+++ b/internal/parser/languages/objc.go
@@ -124,6 +124,30 @@ func (e *ObjCExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 		})
 	}
 
+	// React Native Fabric / Paper view managers: an @implementation that
+	// exports view properties backs a JS component. Emit a component node
+	// so the Fabric synthesizer can link it to the codegen TS spec.
+	for _, fm := range extractObjCFabricManagers(src) {
+		id := filePath + "::fabric:" + fm.component
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		node := &graph.Node{
+			ID: id, Kind: graph.KindType, Name: fm.component,
+			FilePath: filePath, StartLine: fm.line, EndLine: findBlockEnd(lines, fm.line),
+			Language: "objc",
+			Meta:     map[string]any{"fabric_component": fm.component, "fabric_native": "objc"},
+		}
+		if len(fm.props) > 0 {
+			node.Meta["fabric_props"] = fm.props
+		}
+		result.Nodes = append(result.Nodes, node)
+		result.Edges = append(result.Edges, &graph.Edge{
+			From: fileNode.ID, To: id, Kind: graph.EdgeDefines, FilePath: filePath, Line: fm.line,
+		})
+	}
+
 	emitImport := func(mod string, line int) {
 		if mod == "" {
 			return
@@ -241,33 +265,8 @@ var (
 // RCT_EXPORT_MODULE(arg) sets the JS name (arg, or the class name when
 // the macro has no argument).
 func extractObjCRNExports(src []byte) []objcRNExport {
-	type block struct {
-		name        string
-		start, end  int
-		moduleName  string
-		moduleKnown bool
-	}
-	var blocks []block
-	implIdx := objcImplRe.FindAllSubmatchIndex(src, -1)
-	for i, m := range implIdx {
-		start := m[0]
-		end := len(src)
-		if i+1 < len(implIdx) {
-			end = implIdx[i+1][0]
-		}
-		if e := objcKeywordEndOffset(src, m[1], "@end"); e >= 0 && e < end {
-			end = e
-		}
-		blocks = append(blocks, block{name: string(src[m[2]:m[3]]), start: start, end: end, moduleName: string(src[m[2]:m[3]])})
-	}
-	blockFor := func(off int) *block {
-		for i := range blocks {
-			if off >= blocks[i].start && off < blocks[i].end {
-				return &blocks[i]
-			}
-		}
-		return nil
-	}
+	blocks := objcImplBlocks(src)
+	blockFor := func(off int) *objcImplBlock { return objcBlockForOffset(blocks, off) }
 
 	// RCT_EXPORT_MODULE: set the JS module name for its block.
 	for _, m := range objcRCTModuleRe.FindAllSubmatchIndex(src, -1) {
@@ -280,7 +279,6 @@ func extractObjCRNExports(src []byte) []objcRNExport {
 				b.moduleName = arg
 			}
 		}
-		b.moduleKnown = true
 	}
 
 	var out []objcRNExport
@@ -373,6 +371,104 @@ func objcKeywordEndOffset(src []byte, from int, keyword string) int {
 		return -1
 	}
 	return from + idx + len(keyword)
+}
+
+// objcImplBlock is one @implementation block: its class name, byte range
+// (start of the @implementation directive to its @end), and the JS module
+// name (defaults to the class name; RCT_EXPORT_MODULE may override it).
+type objcImplBlock struct {
+	name       string
+	start, end int
+	moduleName string
+}
+
+// objcImplBlocks returns every @implementation block in src with its byte
+// range, used to attribute macros (RCT_EXPORT_*) to their enclosing class.
+func objcImplBlocks(src []byte) []objcImplBlock {
+	var blocks []objcImplBlock
+	implIdx := objcImplRe.FindAllSubmatchIndex(src, -1)
+	for i, m := range implIdx {
+		start := m[0]
+		end := len(src)
+		if i+1 < len(implIdx) {
+			end = implIdx[i+1][0]
+		}
+		if e := objcKeywordEndOffset(src, m[1], "@end"); e >= 0 && e < end {
+			end = e
+		}
+		name := string(src[m[2]:m[3]])
+		blocks = append(blocks, objcImplBlock{name: name, start: start, end: end, moduleName: name})
+	}
+	return blocks
+}
+
+// objcBlockForOffset returns the @implementation block containing off.
+func objcBlockForOffset(blocks []objcImplBlock, off int) *objcImplBlock {
+	for i := range blocks {
+		if off >= blocks[i].start && off < blocks[i].end {
+			return &blocks[i]
+		}
+	}
+	return nil
+}
+
+// objcRCTViewPropRe matches RCT_EXPORT_VIEW_PROPERTY(propName, type) and
+// RCT_REMAP_VIEW_PROPERTY(propName, ...) — the markers of a Fabric / Paper
+// view manager.
+var objcRCTViewPropRe = regexp.MustCompile(`RCT_(?:EXPORT|REMAP)_VIEW_PROPERTY\s*\(\s*([A-Za-z_]\w*)`)
+
+// objcFabricManager is a native view manager discovered in a file: the JS
+// component name it backs, the props it exports, and the source line.
+type objcFabricManager struct {
+	component string
+	props     []string
+	line      int
+}
+
+// extractObjCFabricManagers finds @implementation blocks that export view
+// properties (RCT_EXPORT_VIEW_PROPERTY) — i.e. RN view managers — and
+// resolves the JS component name from the class name (RN strips a trailing
+// "Manager"). One entry per such block, with the exported prop names.
+func extractObjCFabricManagers(src []byte) []objcFabricManager {
+	propLocs := objcRCTViewPropRe.FindAllSubmatchIndex(src, -1)
+	if len(propLocs) == 0 {
+		return nil
+	}
+	blocks := objcImplBlocks(src)
+	propsByBlock := map[int][]string{}
+	for _, loc := range propLocs {
+		b := objcBlockForOffset(blocks, loc[0])
+		if b == nil {
+			continue
+		}
+		propsByBlock[b.start] = append(propsByBlock[b.start], string(src[loc[2]:loc[3]]))
+	}
+	var out []objcFabricManager
+	for i := range blocks {
+		props, ok := propsByBlock[blocks[i].start]
+		if !ok {
+			continue
+		}
+		out = append(out, objcFabricManager{
+			component: objcComponentName(blocks[i].name),
+			props:     props,
+			line:      lineAt(src, blocks[i].start),
+		})
+	}
+	return out
+}
+
+// objcComponentName maps a view-manager class name to its JS component
+// name by stripping the RN "Manager" suffix. RN names a view manager
+// "<ComponentName>Manager" — and the component name itself usually ends
+// in "View" (RCTColorView → RCTColorViewManager), so only the final
+// "Manager" is removed.
+func objcComponentName(class string) string {
+	const sfx = "Manager"
+	if len(class) > len(sfx) && strings.HasSuffix(class, sfx) {
+		return class[:len(class)-len(sfx)]
+	}
+	return class
 }
 
 var _ parser.Extractor = (*ObjCExtractor)(nil)

--- a/internal/parser/languages/python.go
+++ b/internal/parser/languages/python.go
@@ -262,6 +262,11 @@ func (e *PythonExtractor) Extract(filePath string, src []byte) (*parser.Extracti
 		func(line int) string { return findEnclosingFunc(funcRanges, line) },
 		filePath, "python", result)
 
+	// SQL function call sites (Supabase .rpc('fn'), SQLAlchemy func.fn()).
+	emitSQLCallsiteEdges(src, "python",
+		func(line int) string { return findEnclosingFunc(funcRanges, line) },
+		filePath, result)
+
 	MaybeEnrichDatabricks(filePath, fileID, src, result)
 
 	return result, nil

--- a/internal/parser/languages/realtime_test.go
+++ b/internal/parser/languages/realtime_test.go
@@ -1,0 +1,112 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// realtimeChannels returns transport→[]topic for every pub/sub event node
+// reachable via a listen/emit edge (the websocket/sse channels live
+// alongside broker topics under the same KindEvent model).
+func realtimeChannels(nodes []*graph.Node) map[string][]string {
+	out := map[string][]string{}
+	for _, n := range nodes {
+		if n.Kind != graph.KindEvent || n.Meta == nil {
+			continue
+		}
+		t, _ := n.Meta["transport"].(string)
+		out[t] = append(out[t], n.Name)
+	}
+	return out
+}
+
+func TestJSExtract_WebSocketAndSSE(t *testing.T) {
+	src := `function connect() {
+  const ws = new WebSocket('wss://api.example.com/ws');
+  const es = new EventSource('/events/stream');
+  ws.send('hi');
+}`
+	r, err := NewJavaScriptExtractor().Extract("rt.js", []byte(src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	ch := realtimeChannels(r.Nodes)
+	if got := ch[transportWebSocket]; len(got) != 1 || got[0] != "wss://api.example.com/ws" {
+		t.Errorf("websocket channels = %v, want [wss://api.example.com/ws]", got)
+	}
+	if got := ch[transportSSE]; len(got) != 1 || got[0] != "/events/stream" {
+		t.Errorf("sse channels = %v, want [/events/stream]", got)
+	}
+	// Each constructor produced a listen edge from connect().
+	listens := 0
+	for _, e := range r.Edges {
+		if e.Kind == graph.EdgeListensOn && e.From == "rt.js::connect" {
+			listens++
+		}
+	}
+	if listens < 2 {
+		t.Errorf("want >=2 listen edges from connect(), got %d", listens)
+	}
+}
+
+func TestTSExtract_EventSource(t *testing.T) {
+	src := `export function sub() {
+  const src = new EventSource('/sse');
+  src.onmessage = (e) => console.log(e);
+}`
+	r, err := NewTypeScriptExtractor().Extract("sub.ts", []byte(src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if got := realtimeChannels(r.Nodes)[transportSSE]; len(got) != 1 || got[0] != "/sse" {
+		t.Errorf("sse channels = %v, want [/sse]", got)
+	}
+}
+
+func TestGoExtract_WebSocketUpgrade(t *testing.T) {
+	src := `package server
+
+import "github.com/gorilla/websocket"
+
+var upgrader = websocket.Upgrader{}
+
+func handleWS(w http.ResponseWriter, r *http.Request) {
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+	_ = conn
+}`
+	res, err := NewGoExtractor().Extract("ws.go", []byte(src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	found := false
+	for _, e := range res.Edges {
+		if e.Kind == graph.EdgeListensOn && e.From == "ws.go::handleWS" && e.Meta != nil {
+			if e.Meta["transport"] == transportWebSocket {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Errorf("handleWS must produce a websocket listen edge")
+	}
+}
+
+func TestGoExtract_NonWebSocketUpgradeIgnored(t *testing.T) {
+	// A .Upgrade( call in a file with no websocket import must not be
+	// treated as a WebSocket endpoint.
+	src := `package db
+func migrate() { schema.Upgrade(ctx) }`
+	res, err := NewGoExtractor().Extract("db.go", []byte(src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	for _, n := range res.Nodes {
+		if n.Kind == graph.KindEvent {
+			t.Errorf("unexpected websocket event node %q in non-websocket file", n.ID)
+		}
+	}
+}

--- a/internal/parser/languages/register.go
+++ b/internal/parser/languages/register.go
@@ -29,11 +29,13 @@ func RegisterAll(reg *parser.Registry) {
 	reg.Register(NewDockerfileExtractor())
 	reg.Register(NewCSharpExtractor())
 	reg.Register(NewXAMLExtractor())
-	// MyBatis shares the .xml extension with the generic XML extractor;
-	// it is registered before registerForestLanguages (which re-claims
-	// .xml for "xml" as the default) and routed only for mapper documents
-	// via the content sniff in detect_content.go.
+	// MyBatis and Spring both share the .xml extension with the generic
+	// XML extractor; they are registered before registerForestLanguages
+	// (which re-claims .xml for "xml" as the default) and routed only for
+	// their respective documents via the content sniff in
+	// detect_content.go.
 	reg.Register(NewMyBatisExtractor())
+	reg.Register(NewSpringContextExtractor())
 	reg.Register(NewMarkdownExtractor())
 	reg.Register(NewOrgModeExtractor())
 	reg.Register(NewDartExtractor())

--- a/internal/parser/languages/register.go
+++ b/internal/parser/languages/register.go
@@ -29,6 +29,11 @@ func RegisterAll(reg *parser.Registry) {
 	reg.Register(NewDockerfileExtractor())
 	reg.Register(NewCSharpExtractor())
 	reg.Register(NewXAMLExtractor())
+	// MyBatis shares the .xml extension with the generic XML extractor;
+	// it is registered before registerForestLanguages (which re-claims
+	// .xml for "xml" as the default) and routed only for mapper documents
+	// via the content sniff in detect_content.go.
+	reg.Register(NewMyBatisExtractor())
 	reg.Register(NewMarkdownExtractor())
 	reg.Register(NewOrgModeExtractor())
 	reg.Register(NewDartExtractor())

--- a/internal/parser/languages/rn_bridge_test.go
+++ b/internal/parser/languages/rn_bridge_test.go
@@ -1,0 +1,153 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// rnMethodMeta returns a map of method-name → (rn_module, rn_method) for
+// every method node carrying React Native bridge metadata.
+func rnMethodMeta(nodes []*graph.Node) map[string][2]string {
+	out := map[string][2]string{}
+	for _, n := range nodes {
+		if n.Kind != graph.KindMethod || n.Meta == nil {
+			continue
+		}
+		mod, _ := n.Meta["rn_module"].(string)
+		meth, _ := n.Meta["rn_method"].(string)
+		if meth == "" {
+			continue
+		}
+		out[n.Name] = [2]string{mod, meth}
+	}
+	return out
+}
+
+func TestObjCExtract_RNExports(t *testing.T) {
+	src := `#import "RCTBridgeModule.h"
+
+@implementation CalendarModule
+
+RCT_EXPORT_MODULE();
+
+RCT_EXPORT_METHOD(addEvent:(NSString *)name location:(NSString *)location)
+{
+}
+
+RCT_REMAP_METHOD(getThing, fetchThingWithResolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+{
+}
+
+@end
+`
+	r, err := NewObjCExtractor().Extract("CalendarModule.m", []byte(src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	meta := rnMethodMeta(r.Nodes)
+	// RCT_EXPORT_METHOD: selector node "addEvent:location:", JS name "addEvent".
+	if got, ok := meta["addEvent:location:"]; !ok || got != [2]string{"CalendarModule", "addEvent"} {
+		t.Errorf("addEvent export = %v (ok=%v), want module CalendarModule method addEvent", meta["addEvent:location:"], ok)
+	}
+	// RCT_REMAP_METHOD: explicit JS name "getThing", native selector
+	// "fetchThingWithResolver:rejecter:".
+	if got, ok := meta["fetchThingWithResolver:rejecter:"]; !ok || got != [2]string{"CalendarModule", "getThing"} {
+		t.Errorf("getThing remap = %v (ok=%v), want module CalendarModule method getThing", meta["fetchThingWithResolver:rejecter:"], ok)
+	}
+}
+
+func TestObjCExtract_RNModuleExplicitName(t *testing.T) {
+	src := `@implementation Impl
+RCT_EXPORT_MODULE(MyJSName);
+RCT_EXPORT_METHOD(doStuff:(NSString *)x) {}
+@end
+`
+	r, err := NewObjCExtractor().Extract("Impl.m", []byte(src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	meta := rnMethodMeta(r.Nodes)
+	if got := meta["doStuff:"]; got != [2]string{"MyJSName", "doStuff"} {
+		t.Errorf("doStuff = %v, want module MyJSName method doStuff", got)
+	}
+}
+
+func TestJavaExtract_RNReactMethod(t *testing.T) {
+	src := `package com.example;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.module.annotations.ReactModule;
+
+@ReactModule(name = "Calendar")
+public class CalendarModule extends ReactContextBaseJavaModule {
+    @Override
+    public String getName() { return "Calendar"; }
+
+    @ReactMethod
+    public void createEvent(String name, String location) {}
+
+    public void notExported() {}
+}
+`
+	r, err := NewJavaExtractor().Extract("CalendarModule.java", []byte(src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	meta := rnMethodMeta(r.Nodes)
+	if got, ok := meta["createEvent"]; !ok || got != [2]string{"Calendar", "createEvent"} {
+		t.Errorf("createEvent = %v (ok=%v), want module Calendar (the @ReactModule override) method createEvent", meta["createEvent"], ok)
+	}
+	if _, ok := meta["notExported"]; ok {
+		t.Errorf("notExported must not carry RN metadata")
+	}
+}
+
+// rnCallTargets returns the To-ends of every rn.native placeholder call
+// edge emitted by a JS/TS extractor.
+func rnCallTargets(edges []*graph.Edge) []string {
+	var out []string
+	for _, e := range edges {
+		if e.Kind == graph.EdgeCalls && e.Meta != nil {
+			if v, _ := e.Meta["via"].(string); v == rnNativeVia {
+				out = append(out, e.To)
+			}
+		}
+	}
+	return out
+}
+
+func TestJSExtract_RNNativeCalls(t *testing.T) {
+	cases := map[string]string{
+		"direct": `import { NativeModules } from 'react-native';
+function go() { NativeModules.Calendar.createEvent('b', 'home'); }`,
+		"bound_var": `import { NativeModules } from 'react-native';
+const Cal = NativeModules.Calendar;
+function go() { Cal.createEvent('b', 'home'); }`,
+		"require_native": `const Cal = requireNativeModule('Calendar');
+function go() { Cal.createEvent('b'); }`,
+		"turbomodule": `const Cal = TurboModuleRegistry.getEnforcing('Calendar');
+function go() { Cal.createEvent('b'); }`,
+		"destructure": `import { NativeModules } from 'react-native';
+const { Calendar } = NativeModules;
+function go() { Calendar.createEvent('b'); }`,
+	}
+	for name, src := range cases {
+		t.Run(name, func(t *testing.T) {
+			r, err := NewJavaScriptExtractor().Extract("app.js", []byte(src))
+			if err != nil {
+				t.Fatalf("extract: %v", err)
+			}
+			targets := rnCallTargets(r.Edges)
+			want := "unresolved::rn::Calendar::createEvent"
+			found := false
+			for _, tg := range targets {
+				if tg == want {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("%s: rn native call targets = %v, want %q", name, targets, want)
+			}
+		})
+	}
+}

--- a/internal/parser/languages/rust.go
+++ b/internal/parser/languages/rust.go
@@ -90,6 +90,7 @@ func (e *RustExtractor) Extensions() []string { return []string{".rs"} }
 type rustDeferredCall struct {
 	name       string
 	receiver   string // selector receiver text (empty for plain/path calls)
+	path       string // full scoped_identifier text for path calls (e.g. "Foo::new", "crate::util::helper"); "" otherwise
 	line       int
 	isSelector bool
 }
@@ -186,10 +187,22 @@ func (e *RustExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 
 		case m.Captures["callp.expr"] != nil:
 			expr := m.Captures["callp.expr"]
-			calls = append(calls, rustDeferredCall{
+			c := rustDeferredCall{
 				name: m.Captures["callp.name"].Text,
 				line: expr.StartLine + 1,
-			})
+			}
+			// The query only captures the scoped_identifier's trailing
+			// segment, so the qualifier (Foo / Self / crate / super /
+			// module path) would otherwise be lost. Read the full
+			// `function` child text so the Rust scope resolver can bind
+			// `Type::method`, `Self::method`, and `crate::/super::/self::`
+			// module paths.
+			if expr.Node != nil {
+				if fn := expr.Node.ChildByFieldName("function"); fn != nil {
+					c.path = fn.Content(src)
+				}
+			}
+			calls = append(calls, c)
 
 		case m.Captures["call.expr"] != nil:
 			expr := m.Captures["call.expr"]
@@ -257,13 +270,31 @@ func (e *RustExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 					edge.Meta = map[string]any{"receiver_type": chainType}
 				}
 			}
+			// Record a self/Self receiver so the Rust scope resolver can
+			// bind a `self.method()` selector to the enclosing impl type
+			// without an explicit `receiver_type` hint. Only the
+			// self/Self receivers are stamped — other receivers carry no
+			// extra meta (their binding flows through receiver_type).
+			if c.receiver == "self" || c.receiver == "Self" {
+				if edge.Meta == nil {
+					edge.Meta = map[string]any{}
+				}
+				edge.Meta["rust_recv"] = c.receiver
+			}
 			result.Edges = append(result.Edges, edge)
 			continue
 		}
-		result.Edges = append(result.Edges, &graph.Edge{
+		edge := &graph.Edge{
 			From: callerID, To: "unresolved::" + c.name,
 			Kind: graph.EdgeCalls, FilePath: filePath, Line: c.line,
-		})
+		}
+		// Preserve the full scoped path (e.g. "Foo::new",
+		// "crate::util::helper") for the Rust scope resolver — the
+		// extractor's call target keeps only the trailing segment.
+		if c.path != "" && strings.Contains(c.path, "::") {
+			edge.Meta = map[string]any{"rust_path": c.path}
+		}
+		result.Edges = append(result.Edges, edge)
 	}
 
 	// Cross-language interop sentinel: when any function in this

--- a/internal/parser/languages/sql_callsites.go
+++ b/internal/parser/languages/sql_callsites.go
@@ -1,0 +1,67 @@
+package languages
+
+import (
+	"regexp"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+)
+
+// SQL function call-site extraction. A SQL CREATE FUNCTION is already a
+// first-class KindFunction node (sql.go); this pass captures the
+// cross-language call sites that invoke one so the resolver / SQL-callsite
+// synthesizer can link the calling code to the SQL function. Two dominant
+// patterns are recognised across JS/TS/Python:
+//
+//   - PostgREST / Supabase RPC: `client.rpc('fn_name', {...})` — the
+//     first string-literal argument is the SQL function name.
+//   - SQLAlchemy generative func namespace (Python): `func.fn_name(...)`.
+//
+// Each emits a placeholder EdgeCalls to `unresolved::sqlfn::<name>` with
+// Meta["via"]="sql.callsite" that ResolveSQLCallsites lands on the SQL
+// function node.
+const sqlCallsiteVia = "sql.callsite"
+
+var (
+	sqlRPCRe       = regexp.MustCompile(`\.rpc\s*\(\s*['"` + "`" + `]([A-Za-z_][\w]*)['"` + "`" + `]`)
+	sqlAlchemyFnRe = regexp.MustCompile(`\bfunc\.([A-Za-z_]\w*)\s*\(`)
+)
+
+// sqlCallPlaceholder is the unresolved target a SQL function call is
+// emitted onto for ResolveSQLCallsites to land on the SQL function node.
+func sqlCallPlaceholder(fn string) string { return "unresolved::sqlfn::" + fn }
+
+// emitSQLCallsiteEdges scans src for SQL function call sites and emits a
+// placeholder call edge from each call's enclosing function. The
+// SQLAlchemy `func.<name>` form is Python-only; the `.rpc('name')` form is
+// recognised in every language. callerFor maps a 1-based line to the
+// enclosing function ID.
+func emitSQLCallsiteEdges(src []byte, language string, callerFor func(line int) string, filePath string, result *parser.ExtractionResult) {
+	type site struct {
+		fn   string
+		line int
+	}
+	var sites []site
+	for _, m := range sqlRPCRe.FindAllSubmatchIndex(src, -1) {
+		sites = append(sites, site{fn: string(src[m[2]:m[3]]), line: lineAt(src, m[0])})
+	}
+	if language == "python" {
+		for _, m := range sqlAlchemyFnRe.FindAllSubmatchIndex(src, -1) {
+			sites = append(sites, site{fn: string(src[m[2]:m[3]]), line: lineAt(src, m[0])})
+		}
+	}
+	for _, s := range sites {
+		if s.fn == "" {
+			continue
+		}
+		caller := callerFor(s.line)
+		if caller == "" {
+			continue
+		}
+		result.Edges = append(result.Edges, &graph.Edge{
+			From: caller, To: sqlCallPlaceholder(s.fn), Kind: graph.EdgeCalls,
+			FilePath: filePath, Line: s.line, Origin: graph.OriginASTInferred,
+			Meta: map[string]any{"via": sqlCallsiteVia, "sql_function": s.fn},
+		})
+	}
+}

--- a/internal/parser/languages/sql_callsites_test.go
+++ b/internal/parser/languages/sql_callsites_test.go
@@ -1,0 +1,60 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func sqlCallTargets(edges []*graph.Edge) []string {
+	var out []string
+	for _, e := range edges {
+		if e.Kind == graph.EdgeCalls && e.Meta != nil {
+			if v, _ := e.Meta["via"].(string); v == sqlCallsiteVia {
+				out = append(out, e.To)
+			}
+		}
+	}
+	return out
+}
+
+func hasTarget(targets []string, want string) bool {
+	for _, t := range targets {
+		if t == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestTSExtract_SupabaseRPC(t *testing.T) {
+	src := `export async function load() {
+  const { data } = await supabase.rpc('get_user_stats', { uid: 1 });
+  return data;
+}`
+	r, err := NewTypeScriptExtractor().Extract("load.ts", []byte(src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if !hasTarget(sqlCallTargets(r.Edges), "unresolved::sqlfn::get_user_stats") {
+		t.Errorf("supabase.rpc call not captured: %v", sqlCallTargets(r.Edges))
+	}
+}
+
+func TestPyExtract_SupabaseAndSQLAlchemy(t *testing.T) {
+	src := `def report(db, supabase):
+    supabase.rpc("get_user_stats", {"uid": 1})
+    db.execute(select(func.calc_total(Order.id)))
+`
+	r, err := NewPythonExtractor().Extract("report.py", []byte(src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	targets := sqlCallTargets(r.Edges)
+	if !hasTarget(targets, "unresolved::sqlfn::get_user_stats") {
+		t.Errorf("supabase.rpc not captured: %v", targets)
+	}
+	if !hasTarget(targets, "unresolved::sqlfn::calc_total") {
+		t.Errorf("SQLAlchemy func.calc_total not captured: %v", targets)
+	}
+}

--- a/internal/parser/languages/swift.go
+++ b/internal/parser/languages/swift.go
@@ -334,6 +334,9 @@ func (e *SwiftExtractor) emitFunction(m parser.QueryResult, filePath, fileID str
 		if doc != "" {
 			meta["doc"] = doc
 		}
+		if sel := swiftObjCSelector(def.Node, name, src); sel != "" {
+			meta["objc_selector"] = sel
+		}
 		result.Nodes = append(result.Nodes, &graph.Node{
 			ID: id, Kind: graph.KindMethod, Name: name,
 			FilePath: filePath, StartLine: def.StartLine + 1, EndLine: def.EndLine + 1,

--- a/internal/parser/languages/swift.go
+++ b/internal/parser/languages/swift.go
@@ -164,6 +164,10 @@ func (e *SwiftExtractor) Extract(filePath string, src []byte) (*parser.Extractio
 		})
 	}
 
+	// Expo Modules native DSL (Name/Function/AsyncFunction) → synthetic
+	// JS-callable method nodes for the Expo bridge synthesizer.
+	emitExpoModuleNodes(src, filePath, "swift", fileID, result, seen)
+
 	return result, nil
 }
 

--- a/internal/parser/languages/swift_annotations.go
+++ b/internal/parser/languages/swift_annotations.go
@@ -106,6 +106,204 @@ func swiftAttributeNameAndArgs(attr *sitter.Node, src []byte) (string, string) {
 	return name, args
 }
 
+// swiftModifiers returns the `modifiers` child of a declaration node,
+// trying the named field first and falling back to a positional scan —
+// the two shapes Swift's tree-sitter grammar uses across versions.
+func swiftModifiers(defNode *sitter.Node) *sitter.Node {
+	if defNode == nil {
+		return nil
+	}
+	if mods := defNode.ChildByFieldName("modifiers"); mods != nil {
+		return mods
+	}
+	for i := 0; i < int(defNode.NamedChildCount()); i++ {
+		if c := defNode.NamedChild(i); c != nil && c.Type() == "modifiers" {
+			return c
+		}
+	}
+	return nil
+}
+
+// swiftObjCAttr reports whether a declaration carries @objc and, if so,
+// the explicit selector from an @objc(customSelector:) override (empty
+// when @objc is bare). The explicit form is read verbatim from the
+// attribute's parenthesised text so a full keyword selector
+// (`@objc(moveFrom:to:)`) survives intact.
+func swiftObjCAttr(defNode *sitter.Node, src []byte) (isObjC bool, explicit string) {
+	mods := swiftModifiers(defNode)
+	if mods == nil {
+		return false, ""
+	}
+	for i := 0; i < int(mods.NamedChildCount()); i++ {
+		attr := mods.NamedChild(i)
+		if attr == nil || attr.Type() != "attribute" {
+			continue
+		}
+		name, _ := swiftAttributeNameAndArgs(attr, src)
+		if name != "objc" {
+			continue
+		}
+		isObjC = true
+		text := attr.Content(src)
+		if open := strings.IndexByte(text, '('); open >= 0 {
+			if closeIdx := strings.LastIndexByte(text, ')'); closeIdx > open {
+				explicit = strings.TrimSpace(text[open+1 : closeIdx])
+			}
+		}
+		return isObjC, explicit
+	}
+	return false, ""
+}
+
+// swiftObjCSelector computes the Objective-C selector a Swift method is
+// exposed under when it carries @objc, or "" when it is not @objc. An
+// explicit @objc("sel:") override wins; otherwise the selector is derived
+// from the method's base name and argument labels per Swift's bridging
+// rules: the first argument label folds into the base name capitalised
+// (`move(from:to:)` → `moveFrom:to:`), `init` inserts "With"
+// (`init(frame:)` → `initWithFrame:`), an omitted label (`_`) contributes
+// a bare colon (`insertSubview(_:at:)` → `insertSubview:at:`), and a
+// no-argument method keeps its bare name (`viewDidLoad`).
+func swiftObjCSelector(defNode *sitter.Node, baseName string, src []byte) string {
+	isObjC, explicit := swiftObjCAttr(defNode, src)
+	if !isObjC {
+		return ""
+	}
+	if explicit != "" {
+		return explicit
+	}
+	return buildSwiftObjCSelector(baseName, swiftArgLabels(swiftParamClause(defNode, src)))
+}
+
+// swiftParamClause returns the text inside a declaration's parameter
+// parentheses, skipping any leading attribute parens (`@objc(x)`) by
+// starting the scan after the `func` keyword.
+func swiftParamClause(defNode *sitter.Node, src []byte) string {
+	if defNode == nil {
+		return ""
+	}
+	text := defNode.Content(src)
+	from := 0
+	if kw := strings.Index(text, "func"); kw >= 0 {
+		from = kw + len("func")
+	}
+	open := strings.IndexByte(text[from:], '(')
+	if open < 0 {
+		return ""
+	}
+	open += from
+	depth := 0
+	for i := open; i < len(text); i++ {
+		switch text[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return text[open+1 : i]
+			}
+		}
+	}
+	return ""
+}
+
+// swiftArgLabels splits a parameter clause at top-level commas and
+// returns each parameter's external argument label, with "_" (omitted
+// label) mapped to the empty string.
+func swiftArgLabels(paramClause string) []string {
+	paramClause = strings.TrimSpace(paramClause)
+	if paramClause == "" {
+		return nil
+	}
+	var labels []string
+	for _, p := range splitSwiftTopLevelCommas(paramClause) {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		label := firstSwiftArgLabel(p)
+		if label == "_" {
+			label = ""
+		}
+		labels = append(labels, label)
+	}
+	return labels
+}
+
+// firstSwiftArgLabel returns the first identifier token of a parameter
+// declaration — its external argument label — stripping a trailing colon
+// from the single-name form (`x: Int` → "x").
+func firstSwiftArgLabel(param string) string {
+	end := len(param)
+	for i, r := range param {
+		if r == ' ' || r == '\t' || r == ':' {
+			end = i
+			break
+		}
+	}
+	return param[:end]
+}
+
+// buildSwiftObjCSelector assembles the ObjC selector from a Swift base
+// name and its ordered argument labels.
+func buildSwiftObjCSelector(base string, labels []string) string {
+	if len(labels) == 0 {
+		return base
+	}
+	var sb strings.Builder
+	sb.WriteString(base)
+	for i, label := range labels {
+		switch {
+		case i == 0 && base == "init" && label != "":
+			sb.WriteString("With")
+			sb.WriteString(capitalizeFirst(label))
+		case i == 0 && label != "":
+			sb.WriteString(capitalizeFirst(label))
+		case i > 0:
+			sb.WriteString(label)
+		}
+		sb.WriteByte(':')
+	}
+	return sb.String()
+}
+
+// splitSwiftTopLevelCommas splits s at commas not nested inside (), <>,
+// [], or {} — so a generic / closure / default-value argument stays one
+// parameter.
+func splitSwiftTopLevelCommas(s string) []string {
+	var parts []string
+	depth := 0
+	start := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '(', '<', '[', '{':
+			depth++
+		case ')', '>', ']', '}':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				parts = append(parts, s[start:i])
+				start = i + 1
+			}
+		}
+	}
+	parts = append(parts, s[start:])
+	return parts
+}
+
+// capitalizeFirst upper-cases the first ASCII letter of s.
+func capitalizeFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	if s[0] >= 'a' && s[0] <= 'z' {
+		return string(s[0]-'a'+'A') + s[1:]
+	}
+	return s
+}
+
 // swiftUserTypeName pulls the trailing `type_identifier` out of a
 // `user_type` chain (`Foo.Bar.Baz` → "Baz") so qualified annotation
 // references collapse onto the same synthetic node.

--- a/internal/parser/languages/swift_objc_selector_test.go
+++ b/internal/parser/languages/swift_objc_selector_test.go
@@ -1,0 +1,98 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestBuildSwiftObjCSelector(t *testing.T) {
+	cases := []struct {
+		base   string
+		labels []string
+		want   string
+	}{
+		{"viewDidLoad", nil, "viewDidLoad"},
+		{"move", []string{"from", "to"}, "moveFrom:to:"},
+		{"insertSubview", []string{"", "at"}, "insertSubview:at:"},
+		{"init", []string{"frame"}, "initWithFrame:"},
+		{"doThing", []string{"with"}, "doThingWith:"},
+		{"reset", []string{""}, "reset:"},
+	}
+	for _, c := range cases {
+		if got := buildSwiftObjCSelector(c.base, c.labels); got != c.want {
+			t.Errorf("buildSwiftObjCSelector(%q, %v) = %q, want %q", c.base, c.labels, got, c.want)
+		}
+	}
+}
+
+func TestSwiftArgLabels(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"", nil},
+		{"x: Int", []string{"x"}},
+		{"from a: Int, to b: Int", []string{"from", "to"}},
+		{"_ view: UIView, at index: Int", []string{"", "at"}},
+		{"closure: (Int, String) -> Void, name: String", []string{"closure", "name"}},
+		{"items: [String], opts: [String: Int]", []string{"items", "opts"}},
+	}
+	for _, c := range cases {
+		got := swiftArgLabels(c.in)
+		if len(got) != len(c.want) {
+			t.Errorf("swiftArgLabels(%q) = %v, want %v", c.in, got, c.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != c.want[i] {
+				t.Errorf("swiftArgLabels(%q)[%d] = %q, want %q", c.in, i, got[i], c.want[i])
+			}
+		}
+	}
+}
+
+// TestSwiftExtract_StampsObjCSelector drives the full extractor and
+// asserts each @objc method node carries the computed ObjC selector,
+// while a non-@objc method does not.
+func TestSwiftExtract_StampsObjCSelector(t *testing.T) {
+	src := `import Foundation
+
+@objc class Mover: NSObject {
+    @objc func move(from a: Int, to b: Int) {}
+    @objc(customMove:) func moveCustom(x: Int) {}
+    @objc func viewDidLoad() {}
+    func notExposed(x: Int) {}
+}
+`
+	r, err := NewSwiftExtractor().Extract("Mover.swift", []byte(src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	got := map[string]string{}
+	for _, n := range r.Nodes {
+		if n.Kind != graph.KindMethod {
+			continue
+		}
+		sel := ""
+		if n.Meta != nil {
+			sel, _ = n.Meta["objc_selector"].(string)
+		}
+		got[n.Name] = sel
+	}
+	checks := map[string]string{
+		"move":       "moveFrom:to:",
+		"moveCustom": "customMove:",
+		"viewDidLoad": "viewDidLoad",
+		"notExposed": "",
+	}
+	for name, want := range checks {
+		if _, ok := got[name]; !ok {
+			t.Errorf("method %q not extracted", name)
+			continue
+		}
+		if got[name] != want {
+			t.Errorf("method %q objc_selector = %q, want %q", name, got[name], want)
+		}
+	}
+}

--- a/internal/parser/languages/ts_function_shape.go
+++ b/internal/parser/languages/ts_function_shape.go
@@ -586,8 +586,27 @@ func canonicalizeTSTypeRef(t string) string {
 	return t
 }
 
+// maxTSUnionMembers caps how many top-level union/intersection branches
+// splitTSUnionType returns. The TypeScript LSP and type-printer can
+// synthesise pathological type-texts — a 200-member string-literal union,
+// a distributive conditional type expanded over a large enum — where
+// emitting one EdgeReturns per branch produces dozens of noise edges to
+// ad-hoc literal types no traversal benefits from. Past this many
+// top-level branches the type is treated as opaque overflow:
+// splitTSUnionType returns nil so the caller emits no per-branch edges.
+// 16 comfortably covers real discriminated unions, which rarely exceed a
+// handful of variants.
+const maxTSUnionMembers = 16
+
 // splitTSUnionType splits a TypeScript type string at top-level `|`
-// boundaries (respecting <…>, (…), {…} nesting).
+// (union) and `&` (intersection) boundaries, respecting <…>, (…), {…},
+// […] nesting. A union member is a type the value may be at runtime; an
+// intersection member is a type the value simultaneously satisfies —
+// both are useful EdgeReturns targets, so both delimiters split (without
+// splitting, an intersection like `A & B` would mangle into a single
+// bogus `A & B` reference). Returns nil when the branch count exceeds
+// maxTSUnionMembers (the overflow guard) so a synthesised literal blob
+// never floods the graph.
 func splitTSUnionType(t string) []string {
 	t = strings.TrimSpace(t)
 	if t == "" {
@@ -598,24 +617,38 @@ func splitTSUnionType(t string) []string {
 	depth := 0
 	parts := []string{}
 	cur := strings.Builder{}
+	flush := func() {
+		if s := strings.TrimSpace(cur.String()); s != "" {
+			parts = append(parts, s)
+		}
+		cur.Reset()
+	}
 	for i := 0; i < len(t); i++ {
 		c := t[i]
 		switch c {
 		case '<', '(', '{', '[':
 			depth++
 		case '>', ')', '}', ']':
-			depth--
-		case '|':
+			// Guard against underflow on `=>` (arrow function types) and
+			// other stray closers — an unbalanced `>` must not drop depth
+			// below zero, or a later top-level `|` would never split.
+			if depth > 0 {
+				depth--
+			}
+		case '|', '&':
 			if depth == 0 {
-				parts = append(parts, strings.TrimSpace(cur.String()))
-				cur.Reset()
+				flush()
+				if len(parts) > maxTSUnionMembers {
+					return nil
+				}
 				continue
 			}
 		}
 		cur.WriteByte(c)
 	}
-	if cur.Len() > 0 {
-		parts = append(parts, strings.TrimSpace(cur.String()))
+	flush()
+	if len(parts) > maxTSUnionMembers {
+		return nil
 	}
 	return parts
 }

--- a/internal/parser/languages/ts_function_shape_test.go
+++ b/internal/parser/languages/ts_function_shape_test.go
@@ -1,6 +1,8 @@
 package languages
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/zzet/gortex/internal/graph"
@@ -346,6 +348,16 @@ func TestSplitTSUnionType(t *testing.T) {
 		{": User | null | undefined", []string{"User", "null", "undefined"}},
 		{"Map<string, User | null>", []string{"Map<string, User | null>"}}, // top-level only
 		{"Promise<User> | Error", []string{"Promise<User>", "Error"}},
+		// Intersection types split too — each component is a type the
+		// value simultaneously satisfies.
+		{"Props & RefAttributes", []string{"Props", "RefAttributes"}},
+		{"A & B | C", []string{"A", "B", "C"}},
+		{"Map<A & B, C>", []string{"Map<A & B, C>"}}, // intersection nested in generic stays whole
+		// Arrow function return types: the `>` in `=>` must not underflow
+		// depth and defeat the later top-level `|` split.
+		{"(x: number) => string | null", []string{"(x: number) => string", "null"}},
+		// Empty / stray-delimiter members are dropped, not emitted blank.
+		{"User |", []string{"User"}},
 	}
 	for _, c := range cases {
 		got := splitTSUnionType(c.in)
@@ -353,6 +365,25 @@ func TestSplitTSUnionType(t *testing.T) {
 			t.Errorf("splitTSUnionType(%q) = %v, want %v", c.in, got, c.want)
 		}
 	}
+
+	// Overflow guard: a pathological branch count past maxTSUnionMembers
+	// is treated as opaque — the splitter returns nil so no per-branch
+	// EdgeReturns flood the graph.
+	t.Run("overflow_guard", func(t *testing.T) {
+		members := make([]string, 0, maxTSUnionMembers+5)
+		for i := range maxTSUnionMembers + 5 {
+			members = append(members, fmt.Sprintf("'lit%d'", i))
+		}
+		big := strings.Join(members, " | ")
+		if got := splitTSUnionType(big); got != nil {
+			t.Errorf("splitTSUnionType(<%d-member union>) = %v, want nil (overflow)", len(members), got)
+		}
+		// Exactly at the cap is still split.
+		atCap := strings.Join(members[:maxTSUnionMembers], " | ")
+		if got := splitTSUnionType(atCap); len(got) != maxTSUnionMembers {
+			t.Errorf("splitTSUnionType(<%d-member union>) = %d parts, want %d", maxTSUnionMembers, len(got), maxTSUnionMembers)
+		}
+	})
 }
 
 func sliceEq(a, b []string) bool {

--- a/internal/parser/languages/typescript.go
+++ b/internal/parser/languages/typescript.go
@@ -416,6 +416,11 @@ func (e *TypeScriptExtractor) Extract(filePath string, src []byte) (*parser.Extr
 		func(line int) string { return findEnclosingFunc(funcRanges, line) },
 		filePath, "typescript", result)
 
+	// SQL function call sites (Supabase/PostgREST .rpc('fn')).
+	emitSQLCallsiteEdges(src, "typescript",
+		func(line int) string { return findEnclosingFunc(funcRanges, line) },
+		filePath, result)
+
 	// --- React Native native-module bridge calls ---
 	rnVars := rnNativeModuleVars(src)
 	for _, c := range calls {

--- a/internal/parser/languages/typescript.go
+++ b/internal/parser/languages/typescript.go
@@ -410,6 +410,8 @@ func (e *TypeScriptExtractor) Extract(filePath string, src []byte) (*parser.Extr
 			pubsubEvents = append(pubsubEvents, ev)
 		}
 	}
+	// WebSocket / EventSource real-time client channels.
+	pubsubEvents = append(pubsubEvents, detectJSRealtimeEvents(src)...)
 	emitPubsubEvents(pubsubEvents,
 		func(line int) string { return findEnclosingFunc(funcRanges, line) },
 		filePath, "typescript", result)

--- a/internal/parser/languages/typescript.go
+++ b/internal/parser/languages/typescript.go
@@ -103,7 +103,8 @@ func NewTypeScriptExtractor() *TypeScriptExtractor {
 	}
 }
 
-func (e *TypeScriptExtractor) Language() string     { return "typescript" }
+func (e *TypeScriptExtractor) Language() string { return "typescript" }
+
 // .mts (ES module TS) and .cts (CommonJS TS) parse with the plain TS
 // grammar; grammarFor only selects TSX for the .tsx suffix.
 func (e *TypeScriptExtractor) Extensions() []string {
@@ -412,6 +413,27 @@ func (e *TypeScriptExtractor) Extract(filePath string, src []byte) (*parser.Extr
 	emitPubsubEvents(pubsubEvents,
 		func(line int) string { return findEnclosingFunc(funcRanges, line) },
 		filePath, "typescript", result)
+
+	// --- React Native native-module bridge calls ---
+	rnVars := rnNativeModuleVars(src)
+	for _, c := range calls {
+		if !c.isMember {
+			continue
+		}
+		module := detectRNNativeModule(c.receiver, rnVars)
+		if module == "" {
+			continue
+		}
+		callerID := findEnclosingFunc(funcRanges, c.line)
+		if callerID == "" {
+			continue
+		}
+		result.Edges = append(result.Edges, &graph.Edge{
+			From: callerID, To: rnNativePlaceholder(module, c.method),
+			Kind: graph.EdgeCalls, FilePath: filePath, Line: c.line,
+			Meta: map[string]any{"via": rnNativeVia, "rn_module": module, "rn_method": c.method},
+		})
+	}
 
 	// Test-runner classification (Mocha / Bun-test / Jest / Vitest /
 	// node:test / Playwright / Cypress). Stamped on the file node so

--- a/internal/parser/languages/typescript.go
+++ b/internal/parser/languages/typescript.go
@@ -435,6 +435,9 @@ func (e *TypeScriptExtractor) Extract(filePath string, src []byte) (*parser.Extr
 		})
 	}
 
+	// --- React Native Fabric / Codegen component spec ---
+	emitFabricComponentNodes(src, filePath, "typescript", fileID, result)
+
 	// Test-runner classification (Mocha / Bun-test / Jest / Vitest /
 	// node:test / Playwright / Cypress). Stamped on the file node so
 	// the indexer's test-edge pass can propagate it to every is_test

--- a/internal/parser/languages/yaml.go
+++ b/internal/parser/languages/yaml.go
@@ -62,6 +62,9 @@ func (e *YAMLExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 	if extractDbtSchemaYAML(filePath, fileNode.ID, src, result) {
 		return result, nil
 	}
+	if extractSymfonyServicesYAML(filePath, fileNode.ID, src, result) {
+		return result, nil
+	}
 
 	// Walk only top-level block_mapping_pair nodes.
 	e.extractTopLevelKeys(root, src, filePath, fileNode.ID, result)

--- a/internal/resolver/event_channel_calls.go
+++ b/internal/resolver/event_channel_calls.go
@@ -1,0 +1,211 @@
+package resolver
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// eventChannelVia is the Edge.Meta["via"] marker on a synthesized
+// event-channel call edge.
+const eventChannelVia = "event.channel"
+
+// maxEventChannelFanout caps the emitter/listener count a single topic
+// may have before the pairing is skipped. An in-process channel with
+// dozens of emitters or listeners is almost always a generic logging /
+// telemetry bus where an emitter→listener call edge per pair would be
+// pure noise (and quadratic). Real domain event channels pair a handful
+// of publishers with a handful of handlers.
+const maxEventChannelFanout = 32
+
+// ResolveEventChannelCalls is the framework-dispatch synthesizer for
+// in-process and cross-language event channels. The pub/sub extractor
+// already materialises a shared KindEvent topic node per (transport,
+// topic) pair, with EdgeEmits from every publishing function and
+// EdgeListensOn from every subscribing function. Message brokers
+// (Kafka / NATS / RabbitMQ / Redis) get their producer↔consumer pairing
+// from the contracts layer (EdgeProducesTopic / EdgeConsumesTopic), so
+// this pass deliberately covers only the channels the contracts layer
+// does not: in-process emitters (Node EventEmitter, Socket.IO) and the
+// native cross-language bridges (React Native's NativeEventEmitter,
+// where a Swift/ObjC/Kotlin `sendEvent` is handled by a JS
+// `addListener`). For each such topic it synthesizes a `calls` edge from
+// each emitting function to each listening function — the runtime
+// dispatch the static call graph cannot see ("who actually runs when
+// this event fires?").
+//
+// Full recompute and idempotent: every edge is re-derived from the emit
+// / listen edges, graph.AddEdge dedupes by edge key, and graph.EvictFile
+// drops the synthesized edge in both directions when either endpoint's
+// file is reindexed — so a removed emitter or listener cannot leave a
+// dangling edge. Edges ride at ast_inferred (the pairing is a name-keyed
+// heuristic, not a typed dispatch) and carry full provenance.
+//
+// Returns the number of event-channel call edges synthesized this pass.
+func ResolveEventChannelCalls(g graph.Store) int {
+	if g == nil {
+		return 0
+	}
+
+	type emitSite struct {
+		from      string
+		filePath  string
+		line      int
+		transport string
+	}
+	emittersByEvent := map[string][]emitSite{}
+	for e := range g.EdgesByKind(graph.EdgeEmits) {
+		if e == nil || e.To == "" || e.From == "" {
+			continue
+		}
+		if !isPubsubEventNode(e.To) {
+			continue
+		}
+		emittersByEvent[e.To] = append(emittersByEvent[e.To], emitSite{
+			from:      e.From,
+			filePath:  e.FilePath,
+			line:      e.Line,
+			transport: edgeTransport(e),
+		})
+	}
+	if len(emittersByEvent) == 0 {
+		return 0
+	}
+
+	listenersByEvent := map[string][]string{}
+	for e := range g.EdgesByKind(graph.EdgeListensOn) {
+		if e == nil || e.To == "" || e.From == "" {
+			continue
+		}
+		if _, ok := emittersByEvent[e.To]; !ok {
+			continue
+		}
+		listenersByEvent[e.To] = append(listenersByEvent[e.To], e.From)
+	}
+
+	var batch []*graph.Edge
+	synthesized := 0
+	// Stable iteration so a re-run produces edges in the same order
+	// (Date/rand are unavailable in this layer anyway; this keeps logs
+	// and any downstream ordering deterministic).
+	eventIDs := make([]string, 0, len(emittersByEvent))
+	for id := range emittersByEvent {
+		eventIDs = append(eventIDs, id)
+	}
+	sort.Strings(eventIDs)
+
+	for _, eventID := range eventIDs {
+		emitters := emittersByEvent[eventID]
+		listeners := listenersByEvent[eventID]
+		if len(listeners) == 0 {
+			continue
+		}
+		// Only pair channels the contracts broker-pairing layer ignores.
+		transport := ""
+		for _, em := range emitters {
+			if em.transport != "" {
+				transport = em.transport
+				break
+			}
+		}
+		if transport == "" {
+			transport = transportFromEventID(eventID)
+		}
+		if !eventChannelInProcess(transport) {
+			continue
+		}
+		if len(emitters) > maxEventChannelFanout || len(listeners) > maxEventChannelFanout {
+			continue
+		}
+		topic := topicFromEventID(eventID, transport)
+
+		// Dedupe (from→to) pairs, keeping the emit site with the lowest
+		// line as the representative so the edge key is stable across runs
+		// even when a function emits the same event from several lines.
+		type pairKey struct{ from, to string }
+		rep := map[pairKey]emitSite{}
+		for _, em := range emitters {
+			for _, to := range listeners {
+				if em.from == "" || to == "" || em.from == to {
+					continue
+				}
+				k := pairKey{from: em.from, to: to}
+				if cur, ok := rep[k]; !ok || em.line < cur.line {
+					rep[k] = em
+				}
+			}
+		}
+		for k, em := range rep {
+			batch = append(batch, &graph.Edge{
+				From:            k.from,
+				To:              k.to,
+				Kind:            graph.EdgeCalls,
+				FilePath:        em.filePath,
+				Line:            em.line,
+				Confidence:      0.5,
+				ConfidenceLabel: graph.ConfidenceLabelFor(graph.EdgeCalls, 0.5),
+				Origin:          graph.OriginASTInferred,
+				Meta: map[string]any{
+					"via":             eventChannelVia,
+					"event_topic":     topic,
+					"event_transport": transport,
+					MetaSynthesizedBy: SynthEventChannel,
+					MetaProvenance:    ProvenanceHeuristic,
+				},
+			})
+			synthesized++
+		}
+	}
+
+	for _, e := range batch {
+		g.AddEdge(e)
+	}
+	return synthesized
+}
+
+// isPubsubEventNode reports whether an ID is a pub/sub KindEvent topic
+// node (event::pubsub::<transport>::<topic>).
+func isPubsubEventNode(id string) bool {
+	return strings.HasPrefix(id, "event::pubsub::")
+}
+
+// edgeTransport reads the transport label an emit/listen edge carries.
+func edgeTransport(e *graph.Edge) string {
+	if e == nil || e.Meta == nil {
+		return ""
+	}
+	t, _ := e.Meta["transport"].(string)
+	return t
+}
+
+// transportFromEventID recovers the transport segment of a pub/sub event
+// node ID when the edge Meta did not carry it.
+func transportFromEventID(id string) string {
+	rest := strings.TrimPrefix(id, "event::pubsub::")
+	if t, _, ok := strings.Cut(rest, "::"); ok {
+		return t
+	}
+	return ""
+}
+
+// topicFromEventID recovers the topic segment of a pub/sub event node ID.
+func topicFromEventID(id, transport string) string {
+	return strings.TrimPrefix(id, "event::pubsub::"+transport+"::")
+}
+
+// eventChannelInProcess reports whether a transport is an in-process or
+// native-bridge channel this pass should pair — i.e. one the contracts
+// broker-pairing layer (Kafka / NATS / RabbitMQ / Redis) does not handle.
+func eventChannelInProcess(transport string) bool {
+	switch transport {
+	case "eventemitter", "socketio":
+		return true
+	}
+	// Native cross-language bridges register their event channel under an
+	// "rn_*" / "native*" transport so a native `sendEvent` pairs with the
+	// JS `addListener` handler.
+	return strings.HasPrefix(transport, "rn_") ||
+		strings.HasPrefix(transport, "native") ||
+		strings.HasPrefix(transport, "rn-")
+}

--- a/internal/resolver/event_channel_calls_test.go
+++ b/internal/resolver/event_channel_calls_test.go
@@ -1,0 +1,151 @@
+package resolver
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// eventChannelTestGraph builds the minimal pub/sub shape the
+// ResolveEventChannelCalls pass consumes: emitter/listener function
+// nodes plus EdgeEmits / EdgeListensOn edges to a shared KindEvent topic
+// node.
+type eventChannelTestGraph struct{ g graph.Store }
+
+func newEventChannelTestGraph() *eventChannelTestGraph {
+	return &eventChannelTestGraph{g: graph.New()}
+}
+
+func (b *eventChannelTestGraph) fn(id, filePath string) {
+	b.g.AddNode(&graph.Node{ID: id, Kind: graph.KindFunction, Name: lastSeg(id), FilePath: filePath})
+}
+
+func (b *eventChannelTestGraph) eventNode(transport, topic string) string {
+	id := "event::pubsub::" + transport + "::" + topic
+	if b.g.GetNode(id) == nil {
+		b.g.AddNode(&graph.Node{ID: id, Kind: graph.KindEvent, Name: topic, Meta: map[string]any{"transport": transport, "event_kind": "pubsub"}})
+	}
+	return id
+}
+
+func (b *eventChannelTestGraph) emit(fromID, transport, topic, filePath string, line int) {
+	b.fn(fromID, filePath)
+	to := b.eventNode(transport, topic)
+	b.g.AddEdge(&graph.Edge{From: fromID, To: to, Kind: graph.EdgeEmits, FilePath: filePath, Line: line, Meta: map[string]any{"transport": transport}})
+}
+
+func (b *eventChannelTestGraph) listen(fromID, transport, topic, filePath string, line int) {
+	b.fn(fromID, filePath)
+	to := b.eventNode(transport, topic)
+	b.g.AddEdge(&graph.Edge{From: fromID, To: to, Kind: graph.EdgeListensOn, FilePath: filePath, Line: line, Meta: map[string]any{"transport": transport}})
+}
+
+// synthEventEdge returns the synthesized event-channel calls edge between
+// from and to, or nil.
+func synthEventEdge(g graph.Store, from, to string) *graph.Edge {
+	for e := range g.EdgesByKind(graph.EdgeCalls) {
+		if e == nil || e.From != from || e.To != to || e.Meta == nil {
+			continue
+		}
+		if v, _ := e.Meta["via"].(string); v == eventChannelVia {
+			return e
+		}
+	}
+	return nil
+}
+
+func TestResolveEventChannelCalls_PairsInProcessEmitterToListener(t *testing.T) {
+	b := newEventChannelTestGraph()
+	b.emit("pub/order.go::placeOrder", "eventemitter", "order.created", "pub/order.go", 10)
+	b.listen("sub/mailer.go::onOrder", "eventemitter", "order.created", "sub/mailer.go", 20)
+
+	n := ResolveEventChannelCalls(b.g)
+	assert.Equal(t, 1, n)
+
+	e := synthEventEdge(b.g, "pub/order.go::placeOrder", "sub/mailer.go::onOrder")
+	require.NotNil(t, e, "emitter must reach the listener via a synthesized call edge")
+	assert.Equal(t, graph.OriginASTInferred, e.Origin)
+	assert.Equal(t, "order.created", e.Meta["event_topic"])
+	assert.Equal(t, "eventemitter", e.Meta["event_transport"])
+	assert.Equal(t, SynthEventChannel, e.Meta[MetaSynthesizedBy])
+	assert.Equal(t, ProvenanceHeuristic, e.Meta[MetaProvenance])
+	// The listener sees the inbound synthesized edge.
+	require.Len(t, b.g.GetInEdges("sub/mailer.go::onOrder"), 1)
+}
+
+func TestResolveEventChannelCalls_FanOutAcrossListeners(t *testing.T) {
+	b := newEventChannelTestGraph()
+	b.emit("pub/order.go::placeOrder", "socketio", "order", "pub/order.go", 10)
+	b.listen("a.go::a", "socketio", "order", "a.go", 1)
+	b.listen("b.go::b", "socketio", "order", "b.go", 1)
+
+	n := ResolveEventChannelCalls(b.g)
+	assert.Equal(t, 2, n)
+	assert.NotNil(t, synthEventEdge(b.g, "pub/order.go::placeOrder", "a.go::a"))
+	assert.NotNil(t, synthEventEdge(b.g, "pub/order.go::placeOrder", "b.go::b"))
+}
+
+func TestResolveEventChannelCalls_NativeBridgeTransportPaired(t *testing.T) {
+	// A native (Swift/ObjC/Kotlin) sendEvent registered under an rn_*
+	// transport must pair with the JS addListener handler — the
+	// cross-language case.
+	b := newEventChannelTestGraph()
+	b.emit("ios/Native.swift::Native.sendBattery", "rn_native_event", "battery", "ios/Native.swift", 30)
+	b.listen("js/app.ts::onBattery", "rn_native_event", "battery", "js/app.ts", 5)
+
+	n := ResolveEventChannelCalls(b.g)
+	assert.Equal(t, 1, n)
+	assert.NotNil(t, synthEventEdge(b.g, "ios/Native.swift::Native.sendBattery", "js/app.ts::onBattery"))
+}
+
+func TestResolveEventChannelCalls_SkipsBrokerTransports(t *testing.T) {
+	// Kafka / NATS / RabbitMQ / Redis are paired by the contracts
+	// producer↔consumer layer (EdgeProducesTopic / EdgeConsumesTopic);
+	// this pass must not double-cover them.
+	for _, transport := range []string{"kafka", "nats", "rabbitmq", "redis", "unknown"} {
+		b := newEventChannelTestGraph()
+		b.emit("p.go::p", transport, "t", "p.go", 1)
+		b.listen("c.go::c", transport, "t", "c.go", 1)
+		assert.Equal(t, 0, ResolveEventChannelCalls(b.g), "transport %q must not be paired here", transport)
+	}
+}
+
+func TestResolveEventChannelCalls_NoSelfEdge(t *testing.T) {
+	b := newEventChannelTestGraph()
+	// Same function both emits and listens on the topic.
+	b.emit("x.go::x", "eventemitter", "tick", "x.go", 1)
+	b.listen("x.go::x", "eventemitter", "tick", "x.go", 2)
+	assert.Equal(t, 0, ResolveEventChannelCalls(b.g), "a function must not call itself via the event channel")
+}
+
+func TestResolveEventChannelCalls_Idempotent(t *testing.T) {
+	b := newEventChannelTestGraph()
+	b.emit("p.go::p", "eventemitter", "e", "p.go", 1)
+	b.listen("c.go::c", "eventemitter", "e", "c.go", 1)
+	first := ResolveEventChannelCalls(b.g)
+	second := ResolveEventChannelCalls(b.g)
+	assert.Equal(t, first, second, "pass count is stable across runs")
+	// Exactly one synthesized edge survives (AddEdge dedupes by key).
+	count := 0
+	for e := range b.g.EdgesByKind(graph.EdgeCalls) {
+		if e != nil && e.Meta != nil {
+			if v, _ := e.Meta["via"].(string); v == eventChannelVia {
+				count++
+			}
+		}
+	}
+	assert.Equal(t, 1, count)
+}
+
+func TestResolveEventChannelCalls_FanOutCap(t *testing.T) {
+	b := newEventChannelTestGraph()
+	b.emit("p.go::p", "eventemitter", "busy", "p.go", 1)
+	for i := range maxEventChannelFanout + 1 {
+		b.listen("l.go::l"+strconv.Itoa(i), "eventemitter", "busy", "l.go", i+1)
+	}
+	assert.Equal(t, 0, ResolveEventChannelCalls(b.g), "a pathological fan-out channel is skipped, not exploded")
+}

--- a/internal/resolver/expo_module_bridge.go
+++ b/internal/resolver/expo_module_bridge.go
@@ -1,0 +1,95 @@
+package resolver
+
+import "github.com/zzet/gortex/internal/graph"
+
+// expoBridgeVia marks a synthesized JS→Expo-native call edge.
+const expoBridgeVia = "expo.bridge"
+
+// ResolveExpoModuleBridge is the framework-dispatch synthesizer for Expo
+// Modules. The Swift/Kotlin extractors stamp expo_module + expo_method on
+// synthetic method nodes parsed from the Expo DSL (Name / Function /
+// AsyncFunction). The JS/TS extractor already emits an rn-native
+// placeholder call edge (Meta["via"]="rn.native", rn_module + rn_method)
+// for `requireNativeModule('Foo').bar()` — the canonical Expo JS consumer
+// form. This pass joins them: for each such JS call it synthesizes a calls
+// edge to every Expo native implementation of that (module, method).
+//
+// Full recompute and idempotent: graph.AddEdge dedupes by key,
+// graph.EvictFile drops the edge in both directions on reindex. Edges
+// ride at ast_inferred with synthesizer provenance.
+//
+// Returns the number of Expo bridge edges synthesized.
+func ResolveExpoModuleBridge(g graph.Store) int {
+	if g == nil {
+		return 0
+	}
+
+	type modKey struct{ module, method string }
+	expoByKey := map[modKey][]*graph.Node{}
+	for _, n := range nodesByKindsOrAll(g, graph.KindMethod) {
+		if n == nil || n.Meta == nil {
+			continue
+		}
+		mod, _ := n.Meta["expo_module"].(string)
+		meth, _ := n.Meta["expo_method"].(string)
+		if mod == "" || meth == "" {
+			continue
+		}
+		expoByKey[modKey{mod, meth}] = append(expoByKey[modKey{mod, meth}], n)
+	}
+	if len(expoByKey) == 0 {
+		return 0
+	}
+
+	type pairKey struct{ from, to string }
+	seenPair := map[pairKey]bool{}
+	var batch []*graph.Edge
+	synthesized := 0
+	for e := range g.EdgesByKind(graph.EdgeCalls) {
+		if e == nil || e.Meta == nil || e.From == "" {
+			continue
+		}
+		if v, _ := e.Meta["via"].(string); v != rnNativeVia {
+			continue
+		}
+		mod, _ := e.Meta["rn_module"].(string)
+		meth, _ := e.Meta["rn_method"].(string)
+		if mod == "" || meth == "" {
+			continue
+		}
+		for _, native := range expoByKey[modKey{mod, meth}] {
+			if native.ID == "" || native.ID == e.From {
+				continue
+			}
+			pk := pairKey{from: e.From, to: native.ID}
+			if seenPair[pk] {
+				continue
+			}
+			seenPair[pk] = true
+			batch = append(batch, &graph.Edge{
+				From:            e.From,
+				To:              native.ID,
+				Kind:            graph.EdgeCalls,
+				FilePath:        e.FilePath,
+				Line:            e.Line,
+				Confidence:      0.6,
+				ConfidenceLabel: graph.ConfidenceLabelFor(graph.EdgeCalls, 0.6),
+				Origin:          graph.OriginASTInferred,
+				Meta: map[string]any{
+					"via":             expoBridgeVia,
+					"expo_module":     mod,
+					"expo_method":     meth,
+					"native_language": native.Language,
+					MetaSynthesizedBy: SynthExpoModules,
+					MetaProvenance:    ProvenanceHeuristic,
+				},
+			})
+			synthesized++
+		}
+	}
+
+	for _, e := range batch {
+		g.AddEdge(e)
+	}
+	return synthesized
+}

--- a/internal/resolver/expo_module_bridge_test.go
+++ b/internal/resolver/expo_module_bridge_test.go
@@ -1,0 +1,63 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func expoNativeNode(g graph.Store, id, lang, module, method string) {
+	g.AddNode(&graph.Node{
+		ID: id, Kind: graph.KindMethod, Name: lastSeg(id),
+		FilePath: id, StartLine: 1, Language: lang,
+		Meta: map[string]any{"expo_module": module, "expo_method": method},
+	})
+}
+
+// expoJSCall adds a JS caller plus the rn.native placeholder edge a
+// requireNativeModule('mod').method() call produces.
+func expoJSCall(g graph.Store, callerID, module, method string) {
+	g.AddNode(&graph.Node{ID: callerID, Kind: graph.KindFunction, Name: lastSeg(callerID), FilePath: "app.ts", Language: "typescript"})
+	g.AddEdge(&graph.Edge{
+		From: callerID, To: "unresolved::rn::" + module + "::" + method,
+		Kind: graph.EdgeCalls, FilePath: "app.ts", Line: 4,
+		Meta: map[string]any{"via": rnNativeVia, "rn_module": module, "rn_method": method},
+	})
+}
+
+func expoBridgeEdge(g graph.Store, from, to string) *graph.Edge {
+	for _, e := range g.GetOutEdges(from) {
+		if e.To == to && e.Kind == graph.EdgeCalls && e.Meta != nil {
+			if v, _ := e.Meta["via"].(string); v == expoBridgeVia {
+				return e
+			}
+		}
+	}
+	return nil
+}
+
+func TestResolveExpoModuleBridge_Pairs(t *testing.T) {
+	g := graph.New()
+	expoJSCall(g, "app.ts::useMath", "Math", "add")
+	expoNativeNode(g, "ios/MathModule.swift::expo:Math:add", "swift", "Math", "add")
+	expoNativeNode(g, "android/MathModule.kt::expo:Math:add", "kotlin", "Math", "add")
+
+	n := ResolveExpoModuleBridge(g)
+	assert.Equal(t, 2, n, "JS call bridges to both the Swift and Kotlin Expo impls")
+
+	sw := expoBridgeEdge(g, "app.ts::useMath", "ios/MathModule.swift::expo:Math:add")
+	require.NotNil(t, sw)
+	assert.Equal(t, SynthExpoModules, sw.Meta[MetaSynthesizedBy])
+	assert.Equal(t, "swift", sw.Meta["native_language"])
+	require.NotNil(t, expoBridgeEdge(g, "app.ts::useMath", "android/MathModule.kt::expo:Math:add"))
+}
+
+func TestResolveExpoModuleBridge_NoMatch(t *testing.T) {
+	g := graph.New()
+	expoJSCall(g, "app.ts::useMath", "Math", "add")
+	expoNativeNode(g, "ios/Other.swift::expo:Other:sub", "swift", "Other", "sub")
+	assert.Equal(t, 0, ResolveExpoModuleBridge(g))
+}

--- a/internal/resolver/external_calls.go
+++ b/internal/resolver/external_calls.go
@@ -314,6 +314,32 @@ func isLanguageStdlib(lang, importPath string) bool {
 			return true
 		}
 		return false
+	case "java", "kotlin", "scala":
+		// JVM platform packages: the JDK (java.* / javax.*), the Jakarta
+		// EE successor (jakarta.*), and the JDK-internal trees (jdk.* /
+		// sun.* / com.sun.*). Everything else — including Kotlin/Scala
+		// stdlibs, which ship as ordinary Maven artifacts — is treated as
+		// a genuine dependency.
+		return hasDottedPrefix(importPath, "java", "javax", "jakarta", "jdk", "sun") ||
+			strings.HasPrefix(importPath, "com.sun.")
+	case "csharp", "fsharp":
+		// The .NET base class library: System.* and Microsoft.* (the
+		// framework-shipped namespaces) plus the legacy mscorlib. Third
+		// party NuGet packages live under their own vendor namespaces.
+		return hasDottedPrefix(importPath, "System", "Microsoft", "mscorlib", "netstandard")
+	}
+	return false
+}
+
+// hasDottedPrefix reports whether importPath equals one of roots or has
+// it as a dotted-namespace prefix (`java` matches `java` and `java.util`
+// but not `javafx`). Used by the JVM / .NET stdlib filters where the
+// platform namespace is the first dotted component.
+func hasDottedPrefix(importPath string, roots ...string) bool {
+	for _, r := range roots {
+		if importPath == r || strings.HasPrefix(importPath, r+".") {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/resolver/external_calls.go
+++ b/internal/resolver/external_calls.go
@@ -71,6 +71,32 @@ func SynthesizeExternalCalls(g graph.Store, enabled bool) int {
 	if g == nil || !enabled {
 		return 0
 	}
+	return synthesizeExternalCalls(g, func() []*graph.Edge { return externalCallCandidateEdges(g) })
+}
+
+// SynthesizeExternalCallsForFiles is the incremental counterpart of
+// SynthesizeExternalCalls: it materialises external-call nodes for only
+// the out-edges of the given changed files, so a single-file reindex does
+// O(edited-file) work instead of the full-graph recompute. The synthetic
+// per-package nodes are shared (deterministic ID), so a file that adds a
+// caller for an already-materialised package just dedups onto the existing
+// node; graph.EvictFile drops a removed file's synthesised edges before
+// reindex, so no orphan-cleanup pass is needed. A no-op when disabled or
+// when no files changed.
+func SynthesizeExternalCallsForFiles(g graph.Store, enabled bool, files []string) int {
+	if g == nil || !enabled || len(files) == 0 {
+		return 0
+	}
+	return synthesizeExternalCalls(g, func() []*graph.Edge { return externalCallCandidateEdgesForFiles(g, files) })
+}
+
+// synthesizeExternalCalls is the shared materialisation core. collect runs
+// under the resolve lock and returns the candidate call / reference edges
+// (external-package terminals plus any already-synthesised external-call::
+// edges, so the returned count stays "edges terminating on a synthetic
+// node after the pass"). Each genuine external terminal gets a shared
+// per-(ecosystem, import path) node and the edge is retargeted onto it.
+func synthesizeExternalCalls(g graph.Store, collect func() []*graph.Edge) int {
 	// Serialise against the other graph-wide passes that mutate the
 	// graph (markTestSymbolsAndEmitEdges, ResolveTemporalCalls,
 	// reach.BuildIndex). This pass calls AddNode and ReindexEdge; a
@@ -82,25 +108,20 @@ func SynthesizeExternalCalls(g graph.Store, enabled bool) int {
 
 	synthesized := 0
 	var reindexBatch []graph.EdgeReindex
-	// First sweep: collect every candidate edge and the From IDs we'll
-	// need to read Language off. Narrow to the call-like edge kinds
-	// server-side via EdgesByKinds — AllEdges scanned the whole bucket
-	// just to filter Kind Go-side.
 	type candidate struct {
 		edge                  *graph.Edge
 		ecosystem, importPath string
 	}
 	var candidates []candidate
 	fromIDSet := map[string]struct{}{}
-	callKinds := []graph.EdgeKind{graph.EdgeCalls, graph.EdgeReferences}
-	for e := range edgesByKinds(g, callKinds) {
+	for _, e := range collect() {
 		if e == nil {
 			continue
 		}
-		// Already pointing at a synthetic node — a prior run of this
-		// full-recompute pass landed it. Count it (the return value is
-		// "call edges terminating on a synthetic node after the pass")
-		// and leave it untouched, so re-running is a stable no-op.
+		// Already pointing at a synthetic node — a prior run landed it.
+		// Count it (the return value is "call edges terminating on a
+		// synthetic node after the pass") and leave it untouched, so
+		// re-running is a stable no-op.
 		if strings.HasPrefix(e.To, externalCallPrefix) {
 			synthesized++
 			continue
@@ -161,6 +182,78 @@ func SynthesizeExternalCalls(g graph.Store, enabled bool) int {
 		g.ReindexEdges(reindexBatch)
 	}
 	return synthesized
+}
+
+// externalCallCandidateEdges returns the call / reference edges whose
+// target is an un-indexed external-package terminal (dep:: / stdlib:: /
+// external::, including the per-repo-prefixed stdlib form) or an
+// already-synthesised external-call:: node. It uses the
+// ExternalCallCandidates pushdown capability when the backend implements
+// it — the disk backend then selects exactly these rows instead of
+// marshaling every call edge in the graph and filtering Go-side — and
+// falls back to the EdgesByKinds scan + prefix filter otherwise.
+func externalCallCandidateEdges(g graph.Store) []*graph.Edge {
+	if cap, ok := g.(graph.ExternalCallCandidates); ok {
+		return cap.ExternalCallCandidateEdges()
+	}
+	var out []*graph.Edge
+	for e := range edgesByKinds(g, []graph.EdgeKind{graph.EdgeCalls, graph.EdgeReferences}) {
+		if e != nil && isExternalCandidateTarget(e.To) {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// externalCallCandidateEdgesForFiles returns the external-terminal call /
+// reference out-edges originating in the given files only — the O(edited
+// files) input for incremental synthesis. Edges are gathered from the
+// out-edges of every symbol the files define.
+func externalCallCandidateEdgesForFiles(g graph.Store, files []string) []*graph.Edge {
+	idSet := make(map[string]struct{})
+	var ids []string
+	for _, f := range files {
+		for _, n := range g.GetFileNodes(f) {
+			if n == nil {
+				continue
+			}
+			if _, seen := idSet[n.ID]; seen {
+				continue
+			}
+			idSet[n.ID] = struct{}{}
+			ids = append(ids, n.ID)
+		}
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	var out []*graph.Edge
+	for _, edges := range g.GetOutEdgesByNodeIDs(ids) {
+		for _, e := range edges {
+			if e == nil {
+				continue
+			}
+			if e.Kind != graph.EdgeCalls && e.Kind != graph.EdgeReferences {
+				continue
+			}
+			if isExternalCandidateTarget(e.To) {
+				out = append(out, e)
+			}
+		}
+	}
+	return out
+}
+
+// isExternalCandidateTarget reports whether a target string is one that
+// synthesizeExternalCalls considers: an external-package terminal or an
+// already-materialised external-call:: node (kept so the pass's return
+// count stays stable across re-runs).
+func isExternalCandidateTarget(to string) bool {
+	if strings.HasPrefix(to, externalCallPrefix) {
+		return true
+	}
+	_, _, ok := parseExternalCallTarget(to)
+	return ok
 }
 
 // parseExternalCallTarget recognises the three bookkeeping-string

--- a/internal/resolver/external_calls_incremental_test.go
+++ b/internal/resolver/external_calls_incremental_test.go
@@ -1,0 +1,83 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// outCallTarget returns the To of the single call/reference out-edge of
+// nodeID (the tests below give each caller exactly one).
+func outCallTarget(g graph.Store, nodeID string) string {
+	for _, e := range g.GetOutEdges(nodeID) {
+		if e.Kind == graph.EdgeCalls || e.Kind == graph.EdgeReferences {
+			return e.To
+		}
+	}
+	return ""
+}
+
+func TestSynthesizeExternalCallsForFiles(t *testing.T) {
+	g := graph.New()
+	// app.go calls an external dependency.
+	g.AddNode(&graph.Node{ID: "app.go::run", Kind: graph.KindFunction, Name: "run", FilePath: "app.go", Language: "go"})
+	g.AddEdge(&graph.Edge{From: "app.go::run", To: "dep::github.com/stripe/stripe-go::Charge", Kind: graph.EdgeCalls, FilePath: "app.go", Line: 10})
+	// other.go also calls an external dependency — it must be untouched
+	// by a file-scoped pass over app.go alone.
+	g.AddNode(&graph.Node{ID: "other.go::f", Kind: graph.KindFunction, Name: "f", FilePath: "other.go", Language: "go"})
+	g.AddEdge(&graph.Edge{From: "other.go::f", To: "dep::github.com/aws/aws-sdk-go::New", Kind: graph.EdgeCalls, FilePath: "other.go", Line: 5})
+
+	n := SynthesizeExternalCallsForFiles(g, true, []string{"app.go"})
+	assert.Equal(t, 1, n, "only app.go's external call is synthesized")
+
+	want := externalCallNodeID("dep", "github.com/stripe/stripe-go")
+	assert.Equal(t, want, outCallTarget(g, "app.go::run"), "app.go's edge retargeted onto the synthetic node")
+	require.NotNil(t, g.GetNode(want), "synthetic external node materialised")
+
+	assert.Equal(t, "dep::github.com/aws/aws-sdk-go::New", outCallTarget(g, "other.go::f"),
+		"a file outside the scope keeps its raw external terminal")
+}
+
+func TestSynthesizeExternalCallsForFiles_StdlibFiltered(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "app.go::run", Kind: graph.KindFunction, Name: "run", FilePath: "app.go", Language: "go"})
+	g.AddEdge(&graph.Edge{From: "app.go::run", To: "stdlib::fmt::Sprintf", Kind: graph.EdgeCalls, FilePath: "app.go", Line: 3})
+	// A stdlib hop is noise — not synthesized.
+	assert.Equal(t, 0, SynthesizeExternalCallsForFiles(g, true, []string{"app.go"}))
+	assert.Equal(t, "stdlib::fmt::Sprintf", outCallTarget(g, "app.go::run"))
+}
+
+func TestSynthesizeExternalCallsForFiles_GatedAndEmpty(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "app.go::run", Kind: graph.KindFunction, Name: "run", FilePath: "app.go", Language: "go"})
+	g.AddEdge(&graph.Edge{From: "app.go::run", To: "dep::github.com/x/y::Z", Kind: graph.EdgeCalls, FilePath: "app.go", Line: 1})
+
+	assert.Equal(t, 0, SynthesizeExternalCallsForFiles(g, false, []string{"app.go"}), "disabled is a no-op")
+	assert.Equal(t, 0, SynthesizeExternalCallsForFiles(g, true, nil), "no files is a no-op")
+	// Untouched in both cases.
+	assert.Equal(t, "dep::github.com/x/y::Z", outCallTarget(g, "app.go::run"))
+}
+
+// TestSynthesizeExternalCalls_Equivalence pins that the file-scoped pass
+// over every file produces the same result as the full pass on a graph
+// where all external calls live in known files.
+func TestSynthesizeExternalCalls_Equivalence(t *testing.T) {
+	build := func() graph.Store {
+		g := graph.New()
+		g.AddNode(&graph.Node{ID: "a.go::f", Kind: graph.KindFunction, Name: "f", FilePath: "a.go", Language: "go"})
+		g.AddEdge(&graph.Edge{From: "a.go::f", To: "dep::github.com/x/y::Z", Kind: graph.EdgeCalls, FilePath: "a.go", Line: 1})
+		g.AddNode(&graph.Node{ID: "b.go::g", Kind: graph.KindFunction, Name: "g", FilePath: "b.go", Language: "go"})
+		g.AddEdge(&graph.Edge{From: "b.go::g", To: "external::svc.internal/api", Kind: graph.EdgeReferences, FilePath: "b.go", Line: 2})
+		return g
+	}
+	full := build()
+	scoped := build()
+	nf := SynthesizeExternalCalls(full, true)
+	ns := SynthesizeExternalCallsForFiles(scoped, true, []string{"a.go", "b.go"})
+	assert.Equal(t, nf, ns)
+	assert.Equal(t, outCallTarget(full, "a.go::f"), outCallTarget(scoped, "a.go::f"))
+	assert.Equal(t, outCallTarget(full, "b.go::g"), outCallTarget(scoped, "b.go::g"))
+}

--- a/internal/resolver/external_calls_stdlib_test.go
+++ b/internal/resolver/external_calls_stdlib_test.go
@@ -1,0 +1,73 @@
+package resolver
+
+import "testing"
+
+// TestIsLanguageStdlib_PerLanguage pins the language-aware stdlib filter
+// across every ecosystem external-call qualification now covers. The JVM
+// and .NET rows are the ones added so default-on synthesis doesn't
+// materialise a node for every JDK / BCL call.
+func TestIsLanguageStdlib_PerLanguage(t *testing.T) {
+	cases := []struct {
+		lang, path string
+		want       bool
+	}{
+		// Go: dotless first segment is stdlib; a domain-led path is a dep.
+		{"go", "fmt", true},
+		{"go", "net/http", true},
+		{"go", "github.com/foo/bar", false},
+		// Python: stdlib top-level packages vs pip packages.
+		{"python", "os.path", true},
+		{"python", "requests", false},
+		// Node: core modules (bare + node: form) vs npm packages.
+		{"javascript", "node:fs", true},
+		{"typescript", "fs", true},
+		{"typescript", "react", false},
+		// Rust: std distribution vs crates.
+		{"rust", "std::collections", true},
+		{"rust", "tokio::sync", false},
+		// JVM: JDK / Jakarta / internal trees are platform; everything
+		// else (incl. Kotlin/Scala stdlibs, which ship as Maven jars) is
+		// a dependency.
+		{"java", "java.util.List", true},
+		{"java", "javax.servlet.http", true},
+		{"java", "jakarta.persistence", true},
+		{"java", "sun.misc.Unsafe", true},
+		{"java", "com.sun.net.httpserver", true},
+		{"java", "com.google.common.collect", false},
+		{"kotlin", "java.io", true},
+		{"kotlin", "org.jetbrains.exposed", false},
+		// `javafx` must not be swallowed by the `java` prefix rule.
+		{"java", "javafx.scene", false},
+		// .NET: System.* / Microsoft.* are the BCL; vendor namespaces are
+		// NuGet packages.
+		{"csharp", "System.Collections.Generic", true},
+		{"csharp", "Microsoft.Extensions.Logging", true},
+		{"csharp", "mscorlib", true},
+		{"csharp", "Newtonsoft.Json", false},
+		// Unknown language: treat as external (one extra node beats
+		// dropping a real edge).
+		{"", "anything", false},
+	}
+	for _, c := range cases {
+		if got := isLanguageStdlib(c.lang, c.path); got != c.want {
+			t.Errorf("isLanguageStdlib(%q, %q) = %v, want %v", c.lang, c.path, got, c.want)
+		}
+	}
+}
+
+// TestExternalCallNodeID_StableCrossRepo documents the cross-repo
+// identity property: the synthetic node ID is a pure function of
+// (ecosystem, import path), so a call into the same package from two
+// different repositories lands on one shared node — the basis for
+// aggregating a service's external surface across repos.
+func TestExternalCallNodeID_StableCrossRepo(t *testing.T) {
+	repoA := externalCallNodeID("dep", "github.com/stripe/stripe-go")
+	repoB := externalCallNodeID("dep", "github.com/stripe/stripe-go")
+	if repoA != repoB {
+		t.Fatalf("same package must share one node ID: %q != %q", repoA, repoB)
+	}
+	other := externalCallNodeID("dep", "github.com/aws/aws-sdk-go")
+	if repoA == other {
+		t.Fatalf("distinct packages must get distinct node IDs")
+	}
+}

--- a/internal/resolver/fabric_components.go
+++ b/internal/resolver/fabric_components.go
@@ -1,0 +1,111 @@
+package resolver
+
+import (
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// fabricBridgeVia marks a synthesized Fabric spec↔native-view-manager edge.
+const fabricBridgeVia = "fabric.component"
+
+// ResolveFabricComponents is the framework-dispatch synthesizer for React
+// Native Fabric / Codegen view components. The TS extractor emits a node
+// per `codegenNativeComponent<Props>('Name')` spec (Meta
+// fabric_component, plus fabric_events from DirectEventHandler props); the
+// Objective-C and Java extractors emit a node per native view manager
+// (Meta fabric_component derived from the manager class name, plus
+// fabric_props). This pass binds the spec to its native implementation(s)
+// by component name with bidirectional EdgeReferences bridge edges, so a
+// Fabric component spec resolves to the native code that renders it.
+//
+// Full recompute and idempotent (graph.AddEdge dedupes; graph.EvictFile
+// drops the bridge on reindex). Edges ride at ast_inferred with
+// synthesizer provenance.
+//
+// Returns the number of Fabric specs bound to at least one native view
+// manager.
+func ResolveFabricComponents(g graph.Store) int {
+	if g == nil {
+		return 0
+	}
+
+	var specs []*graph.Node
+	nativeByComponent := map[string][]*graph.Node{}
+	for _, n := range nodesByKindsOrAll(g, graph.KindType) {
+		if n == nil || n.Meta == nil {
+			continue
+		}
+		comp, _ := n.Meta["fabric_component"].(string)
+		if comp == "" {
+			continue
+		}
+		if _, isNative := n.Meta["fabric_native"]; isNative {
+			nativeByComponent[fabricNormalize(comp)] = append(nativeByComponent[fabricNormalize(comp)], n)
+		} else {
+			specs = append(specs, n)
+		}
+	}
+	if len(specs) == 0 || len(nativeByComponent) == 0 {
+		return 0
+	}
+
+	var batch []*graph.Edge
+	bound := 0
+	for _, spec := range specs {
+		comp, _ := spec.Meta["fabric_component"].(string)
+		matches := nativeByComponent[fabricNormalize(comp)]
+		if len(matches) == 0 {
+			continue
+		}
+		linked := false
+		for _, native := range matches {
+			if native.ID == spec.ID {
+				continue
+			}
+			batch = append(batch,
+				fabricBridgeEdge(spec, native, comp),
+				fabricBridgeEdge(native, spec, comp),
+			)
+			linked = true
+		}
+		if linked {
+			bound++
+		}
+	}
+
+	for _, e := range batch {
+		g.AddEdge(e)
+	}
+	return bound
+}
+
+// fabricNormalize folds a component name for cross-language matching: the
+// native side often carries platform prefixes/suffixes the JS spec drops
+// (RCTWebView ↔ WebView). Lower-cases and strips a leading "rct"/"rn".
+func fabricNormalize(name string) string {
+	n := strings.ToLower(name)
+	n = strings.TrimPrefix(n, "rct")
+	n = strings.TrimPrefix(n, "rn")
+	return n
+}
+
+func fabricBridgeEdge(from, to *graph.Node, component string) *graph.Edge {
+	return &graph.Edge{
+		From:            from.ID,
+		To:              to.ID,
+		Kind:            graph.EdgeReferences,
+		FilePath:        from.FilePath,
+		Line:            from.StartLine,
+		Confidence:      0.6,
+		ConfidenceLabel: graph.ConfidenceLabelFor(graph.EdgeReferences, 0.6),
+		Origin:          graph.OriginASTInferred,
+		Meta: map[string]any{
+			"via":              fabricBridgeVia,
+			"fabric_component": component,
+			"to_language":      to.Language,
+			MetaSynthesizedBy:  SynthFabric,
+			MetaProvenance:     ProvenanceHeuristic,
+		},
+	}
+}

--- a/internal/resolver/fabric_components_test.go
+++ b/internal/resolver/fabric_components_test.go
@@ -1,0 +1,68 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func fabricSpecNode(g graph.Store, id, component string) {
+	g.AddNode(&graph.Node{
+		ID: id, Kind: graph.KindType, Name: component, FilePath: id, StartLine: 1,
+		Language: "typescript", Meta: map[string]any{"fabric_component": component},
+	})
+}
+
+func fabricNativeNode(g graph.Store, id, lang, component string) {
+	g.AddNode(&graph.Node{
+		ID: id, Kind: graph.KindType, Name: component, FilePath: id, StartLine: 1,
+		Language: lang, Meta: map[string]any{"fabric_component": component, "fabric_native": lang},
+	})
+}
+
+func fabricBridge(g graph.Store, from, to string) *graph.Edge {
+	for _, e := range g.GetOutEdges(from) {
+		if e.To == to && e.Kind == graph.EdgeReferences && e.Meta != nil {
+			if v, _ := e.Meta["via"].(string); v == fabricBridgeVia {
+				return e
+			}
+		}
+	}
+	return nil
+}
+
+func TestResolveFabricComponents_BindsSpecToNative(t *testing.T) {
+	g := graph.New()
+	// TS spec uses RCTColorView; native managers normalize to the same.
+	fabricSpecNode(g, "ColorViewNativeComponent.ts::fabric:RCTColorView", "RCTColorView")
+	fabricNativeNode(g, "RCTColorViewManager.m::fabric:RCTColorView", "objc", "RCTColorView")
+	fabricNativeNode(g, "ColorViewManager.java::fabric:RCTColorView", "java", "RCTColorView")
+
+	n := ResolveFabricComponents(g)
+	assert.Equal(t, 1, n, "one spec bound (to two native managers)")
+
+	objc := fabricBridge(g, "ColorViewNativeComponent.ts::fabric:RCTColorView", "RCTColorViewManager.m::fabric:RCTColorView")
+	require.NotNil(t, objc)
+	assert.Equal(t, SynthFabric, objc.Meta[MetaSynthesizedBy])
+	require.NotNil(t, fabricBridge(g, "RCTColorViewManager.m::fabric:RCTColorView", "ColorViewNativeComponent.ts::fabric:RCTColorView"), "bidirectional")
+	require.NotNil(t, fabricBridge(g, "ColorViewNativeComponent.ts::fabric:RCTColorView", "ColorViewManager.java::fabric:RCTColorView"))
+}
+
+func TestResolveFabricComponents_NormalizedMatch(t *testing.T) {
+	g := graph.New()
+	// Spec drops the RCT prefix; native keeps it — normalization bridges.
+	fabricSpecNode(g, "spec.ts::fabric:ColorView", "ColorView")
+	fabricNativeNode(g, "mgr.m::fabric:RCTColorView", "objc", "RCTColorView")
+	assert.Equal(t, 1, ResolveFabricComponents(g))
+	assert.NotNil(t, fabricBridge(g, "spec.ts::fabric:ColorView", "mgr.m::fabric:RCTColorView"))
+}
+
+func TestResolveFabricComponents_NoMatch(t *testing.T) {
+	g := graph.New()
+	fabricSpecNode(g, "spec.ts::fabric:ColorView", "ColorView")
+	fabricNativeNode(g, "mgr.m::fabric:Slider", "objc", "Slider")
+	assert.Equal(t, 0, ResolveFabricComponents(g))
+}

--- a/internal/resolver/framework_synth.go
+++ b/internal/resolver/framework_synth.go
@@ -112,6 +112,7 @@ func defaultFrameworkSynthesizers() []FrameworkSynthesizer {
 		synthFunc{name: SynthTemporalStub, fn: ResolveTemporalCalls},
 		synthFunc{name: SynthEventChannel, fn: ResolveEventChannelCalls},
 		synthFunc{name: SynthSwiftObjC, fn: ResolveSwiftObjCBridge},
+		synthFunc{name: SynthReactNative, fn: ResolveReactNativeBridge},
 	}
 }
 

--- a/internal/resolver/framework_synth.go
+++ b/internal/resolver/framework_synth.go
@@ -60,6 +60,7 @@ const (
 	SynthReactNative  = "react-native-bridge"
 	SynthExpoModules  = "expo-modules-bridge"
 	SynthFabric       = "fabric-codegen"
+	SynthMyBatis      = "mybatis"
 )
 
 // StampSynthesized marks an edge as the product of a framework
@@ -115,6 +116,7 @@ func defaultFrameworkSynthesizers() []FrameworkSynthesizer {
 		synthFunc{name: SynthReactNative, fn: ResolveReactNativeBridge},
 		synthFunc{name: SynthExpoModules, fn: ResolveExpoModuleBridge},
 		synthFunc{name: SynthFabric, fn: ResolveFabricComponents},
+		synthFunc{name: SynthMyBatis, fn: ResolveMyBatisCalls},
 	}
 }
 

--- a/internal/resolver/framework_synth.go
+++ b/internal/resolver/framework_synth.go
@@ -1,0 +1,144 @@
+package resolver
+
+import "github.com/zzet/gortex/internal/graph"
+
+// Framework-dispatch synthesizer engine.
+//
+// Direct AST/LSP resolution lands the calls a compiler can see. A large
+// class of real call edges, though, is wired by a *framework* at runtime
+// and is invisible to static resolution: a gRPC client stub dispatched
+// to its server handler, a Temporal workflow proxy to its activity, an
+// event published on one side of an in-process channel and handled on
+// the other, a JS bridge method routed to its native implementation.
+//
+// FrameworkSynthesizer is the plugin contract for a pass that
+// materialises one such family of edges. Every synthesizer is a
+// full-recompute, idempotent pass: it derives each edge it owns from
+// durable graph state (placeholder edges plus their Meta markers, shared
+// topic nodes, registration call edges) so a reindex of any endpoint
+// re-lands or un-lands the edge without leaving a stale one behind —
+// graph.AddEdge dedupes by edge key and graph.EvictFile drops a node's
+// edges in both directions. Every edge a synthesizer lands is stamped
+// with provenance (StampSynthesized) so its origin is auditable and the
+// `analyze kind=synthesizers` roll-up can attribute it.
+//
+// The engine is the single orchestration point: the indexers call
+// RunFrameworkSynthesizers at every settle point (full index, watcher
+// reindex, incremental reindex) in place of invoking each pass directly,
+// so adding a synthesizer (a native-bridge resolver, an event-channel
+// pass) is one line in defaultFrameworkSynthesizers rather than an edit
+// at six call sites.
+type FrameworkSynthesizer interface {
+	// Name is the stable provenance tag stamped on every edge the
+	// synthesizer lands (lower-kebab, e.g. "grpc-stub", "event-channel").
+	Name() string
+	// Synthesize runs the pass over g and returns the number of edges the
+	// synthesizer owns (landed on a real target) after this run.
+	Synthesize(g graph.Store) int
+}
+
+// Edge.Meta keys stamped by StampSynthesized.
+const (
+	// MetaSynthesizedBy names the synthesizer that produced an edge.
+	MetaSynthesizedBy = "synthesized_by"
+	// MetaProvenance records that an edge is a heuristic materialisation
+	// rather than a compiler-verified fact.
+	MetaProvenance = "provenance"
+	// ProvenanceHeuristic is the MetaProvenance value every framework
+	// synthesizer stamps — these edges are framework-dispatch inferences.
+	ProvenanceHeuristic = "heuristic"
+)
+
+// Stable per-synthesizer provenance names. Used both as the registry
+// label (for the report grouping) and as the value stamped on each
+// landed edge, so the two never drift.
+const (
+	SynthGRPCStub     = "grpc-stub"
+	SynthTemporalStub = "temporal-stub"
+	SynthEventChannel = "event-channel"
+	SynthSwiftObjC    = "swift-objc-bridge"
+	SynthReactNative  = "react-native-bridge"
+	SynthExpoModules  = "expo-modules-bridge"
+	SynthFabric       = "fabric-codegen"
+)
+
+// StampSynthesized marks an edge as the product of a framework
+// synthesizer: which synthesizer produced it (name) and that it is a
+// heuristic materialisation. Safe on an edge with a nil Meta map.
+func StampSynthesized(e *graph.Edge, name string) {
+	if e == nil {
+		return
+	}
+	if e.Meta == nil {
+		e.Meta = map[string]any{}
+	}
+	e.Meta[MetaSynthesizedBy] = name
+	if _, ok := e.Meta[MetaProvenance]; !ok {
+		e.Meta[MetaProvenance] = ProvenanceHeuristic
+	}
+}
+
+// UnstampSynthesized clears the provenance markers an edge picked up from
+// a synthesizer. Called when a pass re-orphans an edge (its target
+// disappeared) so the edge reads as a plain placeholder again.
+func UnstampSynthesized(e *graph.Edge) {
+	if e == nil || e.Meta == nil {
+		return
+	}
+	delete(e.Meta, MetaSynthesizedBy)
+	delete(e.Meta, MetaProvenance)
+}
+
+// synthFunc adapts a plain pass function into a FrameworkSynthesizer so
+// the existing passes (ResolveGRPCStubCalls, …) register without a
+// wrapper type each.
+type synthFunc struct {
+	name string
+	fn   func(graph.Store) int
+}
+
+func (s synthFunc) Name() string                 { return s.name }
+func (s synthFunc) Synthesize(g graph.Store) int { return s.fn(g) }
+
+// defaultFrameworkSynthesizers returns the registered framework
+// synthesizers in run order. Order is load-bearing: every synthesizer
+// here runs after InferImplements/InferOverrides (some depend on the
+// EdgeImplements edges they produce) and before DetectCrossRepoEdges (so
+// a cross-repo synthesized call gets its parallel cross_repo_calls edge).
+// Native-bridge resolvers append to this slice.
+func defaultFrameworkSynthesizers() []FrameworkSynthesizer {
+	return []FrameworkSynthesizer{
+		synthFunc{name: SynthGRPCStub, fn: ResolveGRPCStubCalls},
+		synthFunc{name: SynthTemporalStub, fn: ResolveTemporalCalls},
+		synthFunc{name: SynthEventChannel, fn: ResolveEventChannelCalls},
+	}
+}
+
+// SynthCount is the per-synthesizer result row in a FrameworkSynthReport.
+type SynthCount struct {
+	Name  string `json:"name"`
+	Edges int    `json:"edges"`
+}
+
+// FrameworkSynthReport is the aggregate result of one
+// RunFrameworkSynthesizers invocation.
+type FrameworkSynthReport struct {
+	Total int          `json:"total"`
+	Per   []SynthCount `json:"per_synthesizer"`
+}
+
+// RunFrameworkSynthesizers runs every registered framework synthesizer
+// over g, in registration order, and returns the per-synthesizer and
+// total landed-edge counts. A nil graph is a no-op.
+func RunFrameworkSynthesizers(g graph.Store) FrameworkSynthReport {
+	rep := FrameworkSynthReport{}
+	if g == nil {
+		return rep
+	}
+	for _, s := range defaultFrameworkSynthesizers() {
+		n := s.Synthesize(g)
+		rep.Per = append(rep.Per, SynthCount{Name: s.Name(), Edges: n})
+		rep.Total += n
+	}
+	return rep
+}

--- a/internal/resolver/framework_synth.go
+++ b/internal/resolver/framework_synth.go
@@ -114,6 +114,7 @@ func defaultFrameworkSynthesizers() []FrameworkSynthesizer {
 		synthFunc{name: SynthSwiftObjC, fn: ResolveSwiftObjCBridge},
 		synthFunc{name: SynthReactNative, fn: ResolveReactNativeBridge},
 		synthFunc{name: SynthExpoModules, fn: ResolveExpoModuleBridge},
+		synthFunc{name: SynthFabric, fn: ResolveFabricComponents},
 	}
 }
 

--- a/internal/resolver/framework_synth.go
+++ b/internal/resolver/framework_synth.go
@@ -62,6 +62,7 @@ const (
 	SynthFabric       = "fabric-codegen"
 	SynthMyBatis      = "mybatis"
 	SynthRustScope    = "rust-scope"
+	SynthSQLCallsite  = "sql-callsite"
 )
 
 // StampSynthesized marks an edge as the product of a framework
@@ -118,6 +119,7 @@ func defaultFrameworkSynthesizers() []FrameworkSynthesizer {
 		synthFunc{name: SynthExpoModules, fn: ResolveExpoModuleBridge},
 		synthFunc{name: SynthFabric, fn: ResolveFabricComponents},
 		synthFunc{name: SynthMyBatis, fn: ResolveMyBatisCalls},
+		synthFunc{name: SynthSQLCallsite, fn: ResolveSQLCallsites},
 		// Rust impl-block / self-receiver / module-path resolution
 		// completion. Runs in the same settle window so residual
 		// unresolved Rust calls land before external-call synthesis

--- a/internal/resolver/framework_synth.go
+++ b/internal/resolver/framework_synth.go
@@ -61,6 +61,7 @@ const (
 	SynthExpoModules  = "expo-modules-bridge"
 	SynthFabric       = "fabric-codegen"
 	SynthMyBatis      = "mybatis"
+	SynthRustScope    = "rust-scope"
 )
 
 // StampSynthesized marks an edge as the product of a framework
@@ -117,6 +118,11 @@ func defaultFrameworkSynthesizers() []FrameworkSynthesizer {
 		synthFunc{name: SynthExpoModules, fn: ResolveExpoModuleBridge},
 		synthFunc{name: SynthFabric, fn: ResolveFabricComponents},
 		synthFunc{name: SynthMyBatis, fn: ResolveMyBatisCalls},
+		// Rust impl-block / self-receiver / module-path resolution
+		// completion. Runs in the same settle window so residual
+		// unresolved Rust calls land before external-call synthesis
+		// classifies the rest as external.
+		synthFunc{name: SynthRustScope, fn: ResolveRustScopeCalls},
 	}
 }
 

--- a/internal/resolver/framework_synth.go
+++ b/internal/resolver/framework_synth.go
@@ -111,6 +111,7 @@ func defaultFrameworkSynthesizers() []FrameworkSynthesizer {
 		synthFunc{name: SynthGRPCStub, fn: ResolveGRPCStubCalls},
 		synthFunc{name: SynthTemporalStub, fn: ResolveTemporalCalls},
 		synthFunc{name: SynthEventChannel, fn: ResolveEventChannelCalls},
+		synthFunc{name: SynthSwiftObjC, fn: ResolveSwiftObjCBridge},
 	}
 }
 

--- a/internal/resolver/framework_synth.go
+++ b/internal/resolver/framework_synth.go
@@ -113,6 +113,7 @@ func defaultFrameworkSynthesizers() []FrameworkSynthesizer {
 		synthFunc{name: SynthEventChannel, fn: ResolveEventChannelCalls},
 		synthFunc{name: SynthSwiftObjC, fn: ResolveSwiftObjCBridge},
 		synthFunc{name: SynthReactNative, fn: ResolveReactNativeBridge},
+		synthFunc{name: SynthExpoModules, fn: ResolveExpoModuleBridge},
 	}
 }
 

--- a/internal/resolver/framework_synth_test.go
+++ b/internal/resolver/framework_synth_test.go
@@ -1,0 +1,60 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestStampSynthesized(t *testing.T) {
+	e := &graph.Edge{From: "a", To: "b", Kind: graph.EdgeCalls}
+	StampSynthesized(e, SynthEventChannel)
+	assert.Equal(t, SynthEventChannel, e.Meta[MetaSynthesizedBy])
+	assert.Equal(t, ProvenanceHeuristic, e.Meta[MetaProvenance])
+
+	// Does not clobber an explicit provenance already set.
+	e2 := &graph.Edge{From: "a", To: "b", Kind: graph.EdgeCalls, Meta: map[string]any{MetaProvenance: "verified"}}
+	StampSynthesized(e2, SynthGRPCStub)
+	assert.Equal(t, "verified", e2.Meta[MetaProvenance])
+	assert.Equal(t, SynthGRPCStub, e2.Meta[MetaSynthesizedBy])
+
+	UnstampSynthesized(e)
+	_, hasBy := e.Meta[MetaSynthesizedBy]
+	_, hasProv := e.Meta[MetaProvenance]
+	assert.False(t, hasBy)
+	assert.False(t, hasProv)
+
+	// nil-safe.
+	StampSynthesized(nil, SynthGRPCStub)
+	UnstampSynthesized(nil)
+}
+
+func TestRunFrameworkSynthesizers_Report(t *testing.T) {
+	b := newEventChannelTestGraph()
+	b.emit("p.go::p", "eventemitter", "e", "p.go", 1)
+	b.listen("c.go::c", "eventemitter", "e", "c.go", 1)
+
+	rep := RunFrameworkSynthesizers(b.g)
+	assert.Equal(t, 1, rep.Total, "the one event-channel pair is the only synthesized edge")
+
+	byName := map[string]int{}
+	for _, p := range rep.Per {
+		byName[p.Name] = p.Edges
+	}
+	// Every registered synthesizer reports a row, even at zero.
+	require.Contains(t, byName, SynthGRPCStub)
+	require.Contains(t, byName, SynthTemporalStub)
+	require.Contains(t, byName, SynthEventChannel)
+	assert.Equal(t, 0, byName[SynthGRPCStub])
+	assert.Equal(t, 0, byName[SynthTemporalStub])
+	assert.Equal(t, 1, byName[SynthEventChannel])
+}
+
+func TestRunFrameworkSynthesizers_NilGraph(t *testing.T) {
+	rep := RunFrameworkSynthesizers(nil)
+	assert.Equal(t, 0, rep.Total)
+	assert.Nil(t, rep.Per)
+}

--- a/internal/resolver/grpc_stub_calls.go
+++ b/internal/resolver/grpc_stub_calls.go
@@ -116,6 +116,7 @@ func ResolveGRPCStubCalls(g graph.Store) int {
 			e.Confidence = conf
 			e.ConfidenceLabel = graph.ConfidenceLabelFor(graph.EdgeCalls, conf)
 			e.Meta["grpc_resolution"] = origin
+			StampSynthesized(e, SynthGRPCStub)
 			resolved++
 		} else {
 			// Re-orphaned (handler removed since the last pass): drop the
@@ -125,6 +126,7 @@ func ResolveGRPCStubCalls(g graph.Store) int {
 			e.Confidence = 0
 			e.ConfidenceLabel = ""
 			delete(e.Meta, "grpc_resolution")
+			UnstampSynthesized(e)
 		}
 		reindexBatch = append(reindexBatch, graph.EdgeReindex{Edge: e, OldTo: oldTo})
 	}

--- a/internal/resolver/mybatis_calls.go
+++ b/internal/resolver/mybatis_calls.go
@@ -1,0 +1,246 @@
+package resolver
+
+import (
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// myBatisStubPrefix is the placeholder namespace the MyBatis mapper-XML
+// extractor emits for the call edge that runs from a SQL statement node
+// back to the Java DAO method that executes it
+// (`unresolved::mybatis::<namespace>::<id>`).
+const myBatisStubPrefix = unresolvedPrefix + "mybatis::"
+
+// ResolveMyBatisCalls is the graph-wide materialisation pass for the
+// MyBatis mapper layer. The mapper-XML extractor emits one node per
+// `<select>/<insert>/<update>/<delete>` statement (ID `<namespace>::<id>`)
+// plus an EdgeCalls edge from that statement node to a
+// `unresolved::mybatis::<namespace>::<id>` placeholder, carrying
+// `Meta["via"]="mybatis.mapper"` plus `mybatis_namespace` /
+// `mybatis_statement`. This pass joins each such edge onto the Java DAO /
+// Mapper interface method the statement implements.
+//
+// The `<mapper namespace>` is the Java interface FQCN
+// (`com.app.UserMapper`); the statement `id` is the method name
+// (`findUser`). The Java extractor emits interface methods as
+// `<filePath>::<SimpleClassName>.<method>`-shaped nodes carrying
+// `Meta["receiver"]=<SimpleClassName>`. The join therefore suffix-matches
+// `<SimpleClassName>.<id>` (the trailing `::Class.method` component of the
+// Java node ID) against every Java method node, preferring a same-repo
+// candidate and falling back to a unique workspace-wide match.
+//
+// The pass is a full recompute and idempotent: every mybatis.mapper
+// edge's target is recomputed from its own `mybatis_namespace` /
+// `mybatis_statement` meta on each call, so a reindex of either the mapper
+// XML or the Java interface leaves the meta intact and the next pass
+// re-lands (or un-lands) the edge. graph.ReindexEdges keeps the out/in
+// buckets consistent. An edge whose method is no longer in the graph is
+// reset back to the placeholder and loses its resolution-tier metadata.
+//
+// Resolved edges are stamped with provenance Meta
+// (`synthesized_by="mybatis"`, `provenance="heuristic"`) so downstream
+// consumers can tell a framework-synthesized binding from a directly
+// extracted call.
+//
+// Returns the number of mybatis.mapper edges pointing at a resolved Java
+// method after the pass.
+func ResolveMyBatisCalls(g graph.Store) int {
+	if g == nil {
+		return 0
+	}
+
+	idx := buildMyBatisMethodIndex(g)
+	resolved := 0
+	var reindexBatch []graph.EdgeReindex
+
+	// First sweep: collect every mybatis.mapper edge plus the From IDs we
+	// need to read RepoPrefix off, so the per-edge GetNode below collapses
+	// to a single GetNodesByIDs batch on disk backends.
+	type stubEdge struct {
+		edge                 *graph.Edge
+		namespace, statement string
+	}
+	var stubs []stubEdge
+	fromIDs := map[string]struct{}{}
+	for e := range g.EdgesByKind(graph.EdgeCalls) {
+		if e == nil || e.Meta == nil {
+			continue
+		}
+		if v, _ := e.Meta["via"].(string); v != "mybatis.mapper" {
+			continue
+		}
+		ns, _ := e.Meta["mybatis_namespace"].(string)
+		stmt, _ := e.Meta["mybatis_statement"].(string)
+		if ns == "" || stmt == "" {
+			continue
+		}
+		stubs = append(stubs, stubEdge{edge: e, namespace: ns, statement: stmt})
+		if e.From != "" {
+			fromIDs[e.From] = struct{}{}
+		}
+	}
+	fromList := make([]string, 0, len(fromIDs))
+	for id := range fromIDs {
+		fromList = append(fromList, id)
+	}
+	fromNodes := g.GetNodesByIDs(fromList)
+
+	for _, s := range stubs {
+		e := s.edge
+		callerRepo := ""
+		if from := fromNodes[e.From]; from != nil {
+			callerRepo = from.RepoPrefix
+		}
+		methodID, origin, conf := idx.lookup(s.namespace, s.statement, callerRepo)
+
+		want := methodID
+		if want == "" {
+			want = myBatisStubPlaceholder(s.namespace, s.statement)
+		}
+		if e.To == want {
+			if methodID != "" {
+				resolved++
+			}
+			continue
+		}
+
+		oldTo := e.To
+		e.To = want
+		if e.Meta == nil {
+			e.Meta = map[string]any{}
+		}
+		if methodID != "" {
+			e.Origin = origin
+			e.Confidence = conf
+			e.ConfidenceLabel = graph.ConfidenceLabelFor(graph.EdgeCalls, conf)
+			e.Meta["synthesized_by"] = "mybatis"
+			e.Meta["provenance"] = "heuristic"
+			e.Meta["mybatis_resolution"] = origin
+			resolved++
+		} else {
+			// Re-orphaned (method removed since the last pass): drop the
+			// resolution-tier metadata so the edge reads as a plain
+			// unresolved placeholder again.
+			e.Origin = ""
+			e.Confidence = 0
+			e.ConfidenceLabel = ""
+			delete(e.Meta, "synthesized_by")
+			delete(e.Meta, "provenance")
+			delete(e.Meta, "mybatis_resolution")
+		}
+		reindexBatch = append(reindexBatch, graph.EdgeReindex{Edge: e, OldTo: oldTo})
+	}
+	if len(reindexBatch) > 0 {
+		g.ReindexEdges(reindexBatch)
+	}
+	return resolved
+}
+
+// myBatisStubPlaceholder is the canonical placeholder target for an
+// unresolved MyBatis mapper-statement call.
+func myBatisStubPlaceholder(namespace, statement string) string {
+	return myBatisStubPrefix + namespace + "::" + statement
+}
+
+// myBatisMethodIndex maps a "<SimpleClassName>.<method>" key to the Java
+// method nodes that match it.
+type myBatisMethodIndex struct {
+	byKey map[string][]*graph.Node
+}
+
+// lookup returns the Java DAO method node for (namespace, statement),
+// preferring a same-repo candidate over a cross-repo one. namespace is
+// the interface FQCN (`com.app.UserMapper`); its simple class name plus
+// the statement id form the join key. Returns ("", "", 0) when no unique
+// method is found.
+func (idx *myBatisMethodIndex) lookup(namespace, statement, callerRepo string) (id, origin string, confidence float64) {
+	key := myBatisJoinKey(namespace, statement)
+	if key == "" {
+		return "", "", 0
+	}
+	cands := idx.byKey[key]
+	if len(cands) == 0 {
+		return "", "", 0
+	}
+	var sameRepo []*graph.Node
+	for _, n := range cands {
+		if callerRepo != "" && n.RepoPrefix == callerRepo {
+			sameRepo = append(sameRepo, n)
+		}
+	}
+	if len(sameRepo) == 1 {
+		return sameRepo[0].ID, graph.OriginASTInferred, 0.7
+	}
+	if len(sameRepo) == 0 && len(cands) == 1 {
+		return cands[0].ID, graph.OriginASTInferred, 0.7
+	}
+	return "", "", 0
+}
+
+// buildMyBatisMethodIndex walks every Java method node once and indexes
+// it by its "<SimpleClassName>.<method>" key, derived from the trailing
+// `::Class.method` component of the node ID (with the node's `receiver`
+// Meta as a cross-check). One pass replaces an AllNodes scan per edge.
+func buildMyBatisMethodIndex(g graph.Store) *myBatisMethodIndex {
+	idx := &myBatisMethodIndex{byKey: map[string][]*graph.Node{}}
+	for n := range g.NodesByKind(graph.KindMethod) {
+		if n == nil || n.Language != "java" {
+			continue
+		}
+		key := javaMethodJoinKey(n)
+		if key == "" {
+			continue
+		}
+		idx.byKey[key] = append(idx.byKey[key], n)
+	}
+	return idx
+}
+
+// myBatisJoinKey builds the "<SimpleClassName>.<statement>" join key from
+// a mapper namespace (interface FQCN) and a statement id. The simple
+// class name is the last dotted component of the FQCN
+// (`com.app.UserMapper` → `UserMapper`).
+func myBatisJoinKey(namespace, statement string) string {
+	if namespace == "" || statement == "" {
+		return ""
+	}
+	simple := namespace
+	if i := strings.LastIndex(simple, "."); i >= 0 {
+		simple = simple[i+1:]
+	}
+	if simple == "" {
+		return ""
+	}
+	return simple + "." + statement
+}
+
+// javaMethodJoinKey returns the "<SimpleClassName>.<method>" key for a
+// Java method node. The Java extractor emits method node IDs shaped
+// `<filePath>::<ClassName>.<method>` and stamps `Meta["receiver"]` with
+// the class name; the trailing `::`-delimited component of the ID is the
+// canonical source, with the receiver Meta as a fallback when the ID
+// carries a disambiguating suffix (e.g. `_L42`).
+func javaMethodJoinKey(n *graph.Node) string {
+	if n == nil {
+		return ""
+	}
+	tail := n.ID
+	if i := strings.LastIndex(tail, "::"); i >= 0 {
+		tail = tail[i+2:]
+	}
+	// The tail is normally "Class.method"; honour a one-off
+	// line-disambiguated suffix the extractor appends on collisions
+	// ("Class.method_L42") by reconstructing from receiver + Name.
+	if recv, _ := n.Meta["receiver"].(string); recv != "" && n.Name != "" {
+		simple := recv
+		if i := strings.LastIndex(simple, "."); i >= 0 {
+			simple = simple[i+1:]
+		}
+		return simple + "." + n.Name
+	}
+	if tail == "" || !strings.Contains(tail, ".") {
+		return ""
+	}
+	return tail
+}

--- a/internal/resolver/mybatis_calls_test.go
+++ b/internal/resolver/mybatis_calls_test.go
@@ -1,0 +1,110 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// myBatisTestGraph builds the minimal shape ResolveMyBatisCalls consumes:
+// a SQL-statement node with a mybatis.mapper placeholder call edge, plus a
+// Java DAO interface method node it should land on.
+type myBatisTestGraph struct {
+	g graph.Store
+}
+
+func newMyBatisTestGraph() *myBatisTestGraph { return &myBatisTestGraph{g: graph.New()} }
+
+// addStatement adds the mapper-XML statement node and its placeholder call
+// edge, exactly as the MyBatis extractor would emit them.
+func (b *myBatisTestGraph) addStatement(namespace, stmtID, filePath string) (*graph.Node, *graph.Edge) {
+	nodeID := namespace + "::" + stmtID
+	n := &graph.Node{
+		ID: nodeID, Kind: graph.KindMethod, Name: stmtID,
+		FilePath: filePath, Language: "mybatis",
+		Meta: map[string]any{
+			"mybatis_namespace": namespace,
+			"mybatis_statement": stmtID,
+			"mybatis_sql_kind":  "select",
+		},
+	}
+	b.g.AddNode(n)
+	e := &graph.Edge{
+		From: nodeID, To: myBatisStubPlaceholder(namespace, stmtID),
+		Kind: graph.EdgeCalls, FilePath: filePath, Line: 4,
+		Meta: map[string]any{
+			"via":               "mybatis.mapper",
+			"mybatis_namespace": namespace,
+			"mybatis_statement": stmtID,
+		},
+	}
+	b.g.AddEdge(e)
+	return n, e
+}
+
+// addJavaMethod adds a Java DAO/Mapper interface method node shaped like
+// the Java extractor's output: ID `<filePath>::<Class>.<method>` with a
+// `receiver` Meta.
+func (b *myBatisTestGraph) addJavaMethod(filePath, class, method, repo string) *graph.Node {
+	id := filePath + "::" + class + "." + method
+	n := &graph.Node{
+		ID: id, Kind: graph.KindMethod, Name: method,
+		FilePath: filePath, RepoPrefix: repo, Language: "java",
+		Meta: map[string]any{"receiver": class},
+	}
+	b.g.AddNode(n)
+	return n
+}
+
+func TestResolveMyBatisCalls_LandsOnJavaMethod(t *testing.T) {
+	b := newMyBatisTestGraph()
+	_, stubEdge := b.addStatement("com.app.UserMapper", "findUser", "mappers/UserMapper.xml")
+	javaMethod := b.addJavaMethod("src/com/app/UserMapper.java", "UserMapper", "findUser", "")
+	// A same-named method on an unrelated class must not be matched.
+	b.addJavaMethod("src/com/app/OrderMapper.java", "OrderMapper", "findUser", "")
+
+	resolved := ResolveMyBatisCalls(b.g)
+	require.Equal(t, 1, resolved)
+
+	require.Equal(t, javaMethod.ID, stubEdge.To, "stub edge should land on the Java DAO method")
+	require.Equal(t, graph.OriginASTInferred, stubEdge.Origin)
+	require.Equal(t, "mybatis", stubEdge.Meta["synthesized_by"])
+	require.Equal(t, "heuristic", stubEdge.Meta["provenance"])
+}
+
+func TestResolveMyBatisCalls_Idempotent(t *testing.T) {
+	b := newMyBatisTestGraph()
+	_, stubEdge := b.addStatement("com.app.UserMapper", "findUser", "mappers/UserMapper.xml")
+	javaMethod := b.addJavaMethod("src/com/app/UserMapper.java", "UserMapper", "findUser", "")
+
+	require.Equal(t, 1, ResolveMyBatisCalls(b.g))
+	require.Equal(t, 1, ResolveMyBatisCalls(b.g)) // stable re-run
+	require.Equal(t, javaMethod.ID, stubEdge.To)
+}
+
+func TestResolveMyBatisCalls_NoMatchStaysPlaceholder(t *testing.T) {
+	b := newMyBatisTestGraph()
+	_, stubEdge := b.addStatement("com.app.UserMapper", "findUser", "mappers/UserMapper.xml")
+	// No matching Java method present.
+
+	require.Equal(t, 0, ResolveMyBatisCalls(b.g))
+	require.Equal(t, myBatisStubPlaceholder("com.app.UserMapper", "findUser"), stubEdge.To)
+	require.Empty(t, stubEdge.Origin)
+	require.Nil(t, stubEdge.Meta["synthesized_by"])
+}
+
+func TestResolveMyBatisCalls_PrefersSameRepo(t *testing.T) {
+	b := newMyBatisTestGraph()
+	stmt, stubEdge := b.addStatement("com.app.UserMapper", "findUser", "mappers/UserMapper.xml")
+	// Place the statement's caller (the From node) in repo "svc-a".
+	stmt.RepoPrefix = "svc-a"
+	b.g.AddNode(stmt)
+
+	want := b.addJavaMethod("a/com/app/UserMapper.java", "UserMapper", "findUser", "svc-a")
+	b.addJavaMethod("b/com/app/UserMapper.java", "UserMapper", "findUser", "svc-b")
+
+	require.Equal(t, 1, ResolveMyBatisCalls(b.g))
+	require.Equal(t, want.ID, stubEdge.To)
+}

--- a/internal/resolver/react_native_bridge.go
+++ b/internal/resolver/react_native_bridge.go
@@ -1,0 +1,110 @@
+package resolver
+
+import "github.com/zzet/gortex/internal/graph"
+
+const (
+	// rnNativeVia marks the JS→native placeholder call edge the JS/TS
+	// extractor emits (mirrors languages.rnNativeVia, kept as a literal
+	// so the resolver doesn't import the parser package).
+	rnNativeVia = "rn.native"
+	// rnBridgeVia marks a synthesized JS→native-implementation edge.
+	rnBridgeVia = "rn.bridge"
+)
+
+// ResolveReactNativeBridge is the framework-dispatch synthesizer for the
+// React Native bridge. The JS/TS extractor emits a placeholder call edge
+// (Meta["via"]="rn.native", carrying rn_module + rn_method) for every
+// `NativeModules.<module>.<method>()` / `requireNativeModule(...)` /
+// `TurboModuleRegistry.get(...)` call. The Objective-C and Java
+// extractors stamp rn_module + rn_method on the native method nodes that
+// implement those modules (RCT_EXPORT_METHOD / RCT_REMAP_METHOD on iOS,
+// @ReactMethod on Android). This pass joins them: for each JS call it
+// synthesizes a calls edge to every native implementation of that
+// (module, method) — typically two, the iOS and Android sides — so a JS
+// call resolves into the native code that runs it and a native method
+// (otherwise unreferenced) shows its JS callers.
+//
+// Full recompute and idempotent: edges are re-derived from the
+// placeholder markers and the native metadata, graph.AddEdge dedupes by
+// key, and graph.EvictFile drops a synthesized edge in both directions
+// when either side's file is reindexed. Edges ride at ast_inferred and
+// carry synthesizer provenance.
+//
+// Returns the number of native bridge edges synthesized.
+func ResolveReactNativeBridge(g graph.Store) int {
+	if g == nil {
+		return 0
+	}
+
+	type modKey struct{ module, method string }
+	nativeByKey := map[modKey][]*graph.Node{}
+	for _, n := range nodesByKindsOrAll(g, graph.KindMethod) {
+		if n == nil || n.Meta == nil {
+			continue
+		}
+		mod, _ := n.Meta["rn_module"].(string)
+		meth, _ := n.Meta["rn_method"].(string)
+		if mod == "" || meth == "" {
+			continue
+		}
+		k := modKey{mod, meth}
+		nativeByKey[k] = append(nativeByKey[k], n)
+	}
+	if len(nativeByKey) == 0 {
+		return 0
+	}
+
+	// Dedupe (callerID → nativeID) so a caller invoking the same native
+	// method from several lines yields one edge per implementation.
+	type pairKey struct{ from, to string }
+	seenPair := map[pairKey]bool{}
+	var batch []*graph.Edge
+	synthesized := 0
+	for e := range g.EdgesByKind(graph.EdgeCalls) {
+		if e == nil || e.Meta == nil || e.From == "" {
+			continue
+		}
+		if v, _ := e.Meta["via"].(string); v != rnNativeVia {
+			continue
+		}
+		mod, _ := e.Meta["rn_module"].(string)
+		meth, _ := e.Meta["rn_method"].(string)
+		if mod == "" || meth == "" {
+			continue
+		}
+		for _, native := range nativeByKey[modKey{mod, meth}] {
+			if native.ID == "" || native.ID == e.From {
+				continue
+			}
+			pk := pairKey{from: e.From, to: native.ID}
+			if seenPair[pk] {
+				continue
+			}
+			seenPair[pk] = true
+			batch = append(batch, &graph.Edge{
+				From:            e.From,
+				To:              native.ID,
+				Kind:            graph.EdgeCalls,
+				FilePath:        e.FilePath,
+				Line:            e.Line,
+				Confidence:      0.6,
+				ConfidenceLabel: graph.ConfidenceLabelFor(graph.EdgeCalls, 0.6),
+				Origin:          graph.OriginASTInferred,
+				Meta: map[string]any{
+					"via":             rnBridgeVia,
+					"rn_module":       mod,
+					"rn_method":       meth,
+					"native_language": native.Language,
+					MetaSynthesizedBy: SynthReactNative,
+					MetaProvenance:    ProvenanceHeuristic,
+				},
+			})
+			synthesized++
+		}
+	}
+
+	for _, e := range batch {
+		g.AddEdge(e)
+	}
+	return synthesized
+}

--- a/internal/resolver/react_native_bridge_test.go
+++ b/internal/resolver/react_native_bridge_test.go
@@ -1,0 +1,86 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// rnNativeMethod adds a native (objc/java) method node carrying RN bridge
+// metadata.
+func rnNativeMethod(g graph.Store, id, lang, module, method string) {
+	g.AddNode(&graph.Node{
+		ID: id, Kind: graph.KindMethod, Name: lastSeg(id),
+		FilePath: id, StartLine: 1, Language: lang,
+		Meta: map[string]any{"rn_module": module, "rn_method": method},
+	})
+}
+
+// rnJSCall adds a JS caller plus its rn.native placeholder call edge.
+func rnJSCall(g graph.Store, callerID, module, method string) {
+	g.AddNode(&graph.Node{ID: callerID, Kind: graph.KindFunction, Name: lastSeg(callerID), FilePath: "app.js", Language: "javascript"})
+	g.AddEdge(&graph.Edge{
+		From: callerID, To: "unresolved::rn::" + module + "::" + method,
+		Kind: graph.EdgeCalls, FilePath: "app.js", Line: 3,
+		Meta: map[string]any{"via": rnNativeVia, "rn_module": module, "rn_method": method},
+	})
+}
+
+func rnBridgeEdge(g graph.Store, from, to string) *graph.Edge {
+	for _, e := range g.GetOutEdges(from) {
+		if e.To == to && e.Kind == graph.EdgeCalls && e.Meta != nil {
+			if v, _ := e.Meta["via"].(string); v == rnBridgeVia {
+				return e
+			}
+		}
+	}
+	return nil
+}
+
+func TestResolveReactNativeBridge_BothPlatforms(t *testing.T) {
+	g := graph.New()
+	rnJSCall(g, "app.js::go", "Calendar", "createEvent")
+	rnNativeMethod(g, "ios/Calendar.m::createEvent:location:", "objc", "Calendar", "createEvent")
+	rnNativeMethod(g, "android/Calendar.java::CalendarModule.createEvent", "java", "Calendar", "createEvent")
+
+	n := ResolveReactNativeBridge(g)
+	assert.Equal(t, 2, n, "a JS call bridges to both the iOS and Android native impls")
+
+	ios := rnBridgeEdge(g, "app.js::go", "ios/Calendar.m::createEvent:location:")
+	require.NotNil(t, ios)
+	assert.Equal(t, "objc", ios.Meta["native_language"])
+	assert.Equal(t, SynthReactNative, ios.Meta[MetaSynthesizedBy])
+	assert.Equal(t, graph.OriginASTInferred, ios.Origin)
+
+	android := rnBridgeEdge(g, "app.js::go", "android/Calendar.java::CalendarModule.createEvent")
+	require.NotNil(t, android)
+	assert.Equal(t, "java", android.Meta["native_language"])
+}
+
+func TestResolveReactNativeBridge_NoNativeNoEdge(t *testing.T) {
+	g := graph.New()
+	rnJSCall(g, "app.js::go", "Calendar", "createEvent")
+	rnNativeMethod(g, "ios/Other.m::doThing", "objc", "Other", "doThing")
+	assert.Equal(t, 0, ResolveReactNativeBridge(g))
+}
+
+func TestResolveReactNativeBridge_Idempotent(t *testing.T) {
+	g := graph.New()
+	rnJSCall(g, "app.js::go", "Calendar", "createEvent")
+	rnNativeMethod(g, "ios/Calendar.m::createEvent:", "objc", "Calendar", "createEvent")
+	first := ResolveReactNativeBridge(g)
+	second := ResolveReactNativeBridge(g)
+	assert.Equal(t, first, second)
+	count := 0
+	for e := range g.EdgesByKind(graph.EdgeCalls) {
+		if e != nil && e.Meta != nil {
+			if v, _ := e.Meta["via"].(string); v == rnBridgeVia {
+				count++
+			}
+		}
+	}
+	assert.Equal(t, 1, count)
+}

--- a/internal/resolver/rust_scope.go
+++ b/internal/resolver/rust_scope.go
@@ -1,0 +1,417 @@
+package resolver
+
+import (
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// ResolveRustScopeCalls is the graph-wide materialisation pass for the
+// Rust-specific scope layer. It lands Rust call edges the generic
+// resolver leaves unresolved by applying Rust's own scoping rules:
+//
+//  1. impl-block method owner. `Foo::new()` resolves to the `new`
+//     method defined in `impl Foo { fn new(...) }`. The Rust extractor
+//     stamps the full scoped path on the call edge as Meta["rust_path"]
+//     ("Foo::new"); this pass reads the qualifier ("Foo") and binds the
+//     trailing segment to a method whose owner type (Node.Meta
+//     ["receiver"]) is that qualifier. Resolved at ast_resolved — the
+//     receiver type is named in source, so the binding is structurally
+//     unambiguous within the qualifier's type.
+//
+//  2. self / Self receiver. Inside `impl Foo`, `self.bar()` and
+//     `Self::new()` resolve to Foo's methods. The caller is a Rust
+//     method node carrying Meta["receiver"]="Foo", so the enclosing
+//     impl type is read off the caller and the call binds to a method
+//     of that owner. Resolved at ast_resolved.
+//
+//  3. module-path. `crate::module::func()`, `super::func()`,
+//     `self::func()` and `module::func()` resolve to a free function
+//     named by the path's trailing segment. Gortex does not model the
+//     Rust module tree as graph nodes, so the binding matches the
+//     trailing segment against free functions in the caller's repo,
+//     preferring a same-file then same-directory candidate. Resolved at
+//     ast_inferred — the module prefix is not verified against a real
+//     module node, only the trailing name and locality.
+//
+// Local-shadows-import precedence: before binding a module-path call to
+// a free function, the pass checks whether the caller has a parameter
+// of the same name (a local binding that, in Rust, shadows an imported
+// item of the same identifier). When it does, the call is left
+// unresolved rather than bound to the (shadowed) import target.
+//
+// The pass only ever rewrites an edge whose target is still an
+// `unresolved::` placeholder, so it never fights or overrides a binding
+// the generic resolver already landed; it strictly fills in the
+// residual the generic pass missed. It is a full recompute and
+// idempotent — each candidate edge's target is recomputed from its own
+// Meta on every run, so a reindex of either endpoint's file leaves the
+// edge's resolution stable. graph.ReindexEdges keeps the out/in buckets
+// consistent.
+//
+// Ambiguity is resolved conservatively: when more than one candidate
+// matches, the pass skips the edge (zero false positives over breadth).
+//
+// Out of scope (left for the generic resolver, the cross-repo resolver,
+// or future work): cross-repo Rust calls, trait-bound / generic-typed
+// receivers, fully-qualified `<T as Trait>::method` UFCS, and resolving
+// a module path against a real module-tree node (only the trailing
+// segment + locality is used today).
+//
+// Returns the number of Rust call edges this pass landed on a concrete
+// node.
+func ResolveRustScopeCalls(g graph.Store) int {
+	if g == nil {
+		return 0
+	}
+
+	idx := buildRustScopeIndex(g)
+	if idx == nil {
+		return 0
+	}
+
+	resolved := 0
+	var reindexBatch []graph.EdgeReindex
+
+	// Collect candidate edges (still-unresolved Rust EdgeCalls) plus the
+	// caller IDs we need to read receiver type / repo / params off, so
+	// the per-edge node lookups collapse to one batch.
+	type candEdge struct {
+		edge *graph.Edge
+	}
+	var cands []candEdge
+	fromIDs := make(map[string]struct{})
+	for e := range g.EdgesByKind(graph.EdgeCalls) {
+		if e == nil {
+			continue
+		}
+		if !graph.IsUnresolvedTarget(e.To) {
+			continue
+		}
+		if !rustScopeEdgeCandidate(e) {
+			continue
+		}
+		cands = append(cands, candEdge{edge: e})
+		if e.From != "" {
+			fromIDs[e.From] = struct{}{}
+		}
+	}
+	if len(cands) == 0 {
+		return 0
+	}
+
+	fromList := make([]string, 0, len(fromIDs))
+	for id := range fromIDs {
+		fromList = append(fromList, id)
+	}
+	callerNodes := g.GetNodesByIDs(fromList)
+
+	for _, c := range cands {
+		e := c.edge
+		caller := callerNodes[e.From]
+		if caller == nil || caller.Language != "rust" {
+			continue
+		}
+		targetID := idx.resolve(e, caller)
+		if targetID == "" || targetID == e.To {
+			continue
+		}
+		oldTo := e.To
+		e.To = targetID
+		e.Origin = idx.lastOrigin
+		e.Confidence = idx.lastConfidence
+		e.ConfidenceLabel = graph.ConfidenceLabelFor(graph.EdgeCalls, idx.lastConfidence)
+		if e.Meta == nil {
+			e.Meta = map[string]any{}
+		}
+		e.Meta["rust_resolution"] = idx.lastReason
+		reindexBatch = append(reindexBatch, graph.EdgeReindex{Edge: e, OldTo: oldTo})
+		resolved++
+	}
+
+	if len(reindexBatch) > 0 {
+		g.ReindexEdges(reindexBatch)
+	}
+	return resolved
+}
+
+// rustScopeEdgeCandidate reports whether an unresolved call edge is one
+// this pass can attempt: a path call (Meta["rust_path"] set) or a
+// self/Self selector call (Meta["rust_recv"] in {self, Self}). Every
+// other selector call is left to the generic resolver's receiver-type
+// cascade.
+func rustScopeEdgeCandidate(e *graph.Edge) bool {
+	if e.Meta == nil {
+		return false
+	}
+	if p, _ := e.Meta["rust_path"].(string); strings.Contains(p, "::") {
+		return true
+	}
+	if r, _ := e.Meta["rust_recv"].(string); r == "self" || r == "Self" {
+		return true
+	}
+	return false
+}
+
+// rustScopeIndex holds the per-repo method/function lookup tables this
+// pass binds against. lastOrigin / lastConfidence / lastReason carry the
+// provenance of the most recent resolve() call so the edge-rewrite loop
+// can stamp it without resolve() returning a struct.
+type rustScopeIndex struct {
+	// methodsByOwner: (repo, ownerType) → method nodes of that type.
+	methodsByOwner map[rustOwnerKey][]*graph.Node
+	// freeFuncsByName: (repo, name) → free function nodes.
+	freeFuncsByName map[rustNameKey][]*graph.Node
+	// paramsByOwner: caller function/method ID → set of param names,
+	// for local-shadows-import precedence.
+	paramsByOwner map[string]map[string]struct{}
+
+	lastOrigin     string
+	lastConfidence float64
+	lastReason     string
+}
+
+type rustOwnerKey struct {
+	repo  string
+	owner string
+}
+
+type rustNameKey struct {
+	repo string
+	name string
+}
+
+// buildRustScopeIndex walks the graph once and indexes Rust method
+// owners, free functions, and caller params. Returns nil when the graph
+// has no Rust methods or functions (the pass is a no-op for non-Rust
+// graphs).
+func buildRustScopeIndex(g graph.Store) *rustScopeIndex {
+	idx := &rustScopeIndex{
+		methodsByOwner:  map[rustOwnerKey][]*graph.Node{},
+		freeFuncsByName: map[rustNameKey][]*graph.Node{},
+		paramsByOwner:   map[string]map[string]struct{}{},
+	}
+	any := false
+	for n := range g.NodesByKind(graph.KindMethod) {
+		if n == nil || n.Language != "rust" {
+			continue
+		}
+		owner := nodeReceiverType(n)
+		if owner == "" {
+			continue
+		}
+		idx.methodsByOwner[rustOwnerKey{repo: n.RepoPrefix, owner: owner}] = append(
+			idx.methodsByOwner[rustOwnerKey{repo: n.RepoPrefix, owner: owner}], n)
+		any = true
+	}
+	for n := range g.NodesByKind(graph.KindFunction) {
+		if n == nil || n.Language != "rust" {
+			continue
+		}
+		idx.freeFuncsByName[rustNameKey{repo: n.RepoPrefix, name: n.Name}] = append(
+			idx.freeFuncsByName[rustNameKey{repo: n.RepoPrefix, name: n.Name}], n)
+		any = true
+	}
+	if !any {
+		return nil
+	}
+	// Params are read lazily-but-once: index every Rust param by its
+	// enclosing function/method ID for the shadow check.
+	for n := range g.NodesByKind(graph.KindParam) {
+		if n == nil || n.Language != "rust" {
+			continue
+		}
+		owner := enclosingFunctionForBinding(n.ID)
+		if owner == "" {
+			continue
+		}
+		set := idx.paramsByOwner[owner]
+		if set == nil {
+			set = map[string]struct{}{}
+			idx.paramsByOwner[owner] = set
+		}
+		set[n.Name] = struct{}{}
+	}
+	return idx
+}
+
+// resolve returns the target node ID an unresolved Rust call edge should
+// bind to, or "" when the call can't be resolved unambiguously. It also
+// records the provenance (origin / confidence / reason) of a successful
+// binding on the index for the caller to stamp.
+func (idx *rustScopeIndex) resolve(e *graph.Edge, caller *graph.Node) string {
+	repo := caller.RepoPrefix
+
+	// Selector self/Self call: bind to a method of the caller's owner
+	// type. The caller is the enclosing impl method, so its receiver is
+	// the impl type.
+	if recv, _ := e.Meta["rust_recv"].(string); recv == "self" || recv == "Self" {
+		owner := nodeReceiverType(caller)
+		if owner == "" {
+			return ""
+		}
+		name := selectorCallName(e.To)
+		if name == "" {
+			return ""
+		}
+		if id := idx.uniqueMethod(repo, owner, name); id != "" {
+			idx.set(graph.OriginASTResolved, 0.92, "self_receiver")
+			return id
+		}
+		return ""
+	}
+
+	path, _ := e.Meta["rust_path"].(string)
+	if !strings.Contains(path, "::") {
+		return ""
+	}
+	segments := strings.Split(path, "::")
+	last := segments[len(segments)-1]
+	if last == "" {
+		return ""
+	}
+	qualifier := segments[len(segments)-2]
+
+	switch {
+	case qualifier == "Self":
+		// Self::method() — same binding as the self selector case.
+		owner := nodeReceiverType(caller)
+		if owner == "" {
+			return ""
+		}
+		if id := idx.uniqueMethod(repo, owner, last); id != "" {
+			idx.set(graph.OriginASTResolved, 0.92, "self_path")
+			return id
+		}
+		return ""
+
+	case isRustTypeName(qualifier):
+		// Type::method() — bind to a method whose owner type is the
+		// qualifier. The receiver type is named explicitly in source, so
+		// this is structurally resolved within that type.
+		if id := idx.uniqueMethod(repo, qualifier, last); id != "" {
+			idx.set(graph.OriginASTResolved, 0.9, "impl_owner")
+			return id
+		}
+		return ""
+
+	default:
+		// Module path: crate::/super::/self::/<module>::func(). Gortex
+		// doesn't model the module tree, so bind the trailing segment to
+		// a free function in the same repo, preferring locality. Skipped
+		// when a same-named caller param shadows the import.
+		if idx.callerShadows(e.From, last) {
+			return ""
+		}
+		if id := idx.uniqueFreeFunc(repo, last, caller.FilePath); id != "" {
+			idx.set(graph.OriginASTInferred, 0.75, "module_path")
+			return id
+		}
+		return ""
+	}
+}
+
+func (idx *rustScopeIndex) set(origin string, conf float64, reason string) {
+	idx.lastOrigin = origin
+	idx.lastConfidence = conf
+	idx.lastReason = reason
+}
+
+// uniqueMethod returns the ID of the single method named `name` owned by
+// (repo, owner), or "" when there is no match or the choice is
+// ambiguous (more than one).
+func (idx *rustScopeIndex) uniqueMethod(repo, owner, name string) string {
+	cands := idx.methodsByOwner[rustOwnerKey{repo: repo, owner: owner}]
+	var hit string
+	for _, m := range cands {
+		if m.Name != name {
+			continue
+		}
+		if hit != "" && hit != m.ID {
+			return "" // ambiguous
+		}
+		hit = m.ID
+	}
+	return hit
+}
+
+// uniqueFreeFunc returns the ID of a free function named `name` in repo,
+// preferring a same-file candidate, then a same-directory candidate,
+// then a unique candidate overall. Returns "" when nothing matches or
+// the choice is ambiguous (more than one across different files with no
+// locality tie-break).
+func (idx *rustScopeIndex) uniqueFreeFunc(repo, name, callerFile string) string {
+	cands := idx.freeFuncsByName[rustNameKey{repo: repo, name: name}]
+	if len(cands) == 0 {
+		return ""
+	}
+	if len(cands) == 1 {
+		return cands[0].ID
+	}
+	callerDir := rustParentDir(callerFile)
+	var sameFile, sameDir []*graph.Node
+	for _, f := range cands {
+		if f.FilePath == callerFile {
+			sameFile = append(sameFile, f)
+		}
+		if rustParentDir(f.FilePath) == callerDir {
+			sameDir = append(sameDir, f)
+		}
+	}
+	if len(sameFile) == 1 {
+		return sameFile[0].ID
+	}
+	if len(sameFile) == 0 && len(sameDir) == 1 {
+		return sameDir[0].ID
+	}
+	return "" // ambiguous across files
+}
+
+// callerShadows reports whether the calling function/method declares a
+// parameter named `name` — a local binding that shadows an import of
+// the same identifier under Rust's name-resolution rules.
+func (idx *rustScopeIndex) callerShadows(callerID, name string) bool {
+	set := idx.paramsByOwner[callerID]
+	if set == nil {
+		return false
+	}
+	_, ok := set[name]
+	return ok
+}
+
+// selectorCallName extracts the method name from a selector-call
+// placeholder target of the form `unresolved::*.<name>` (or the
+// per-repo `<repo>::unresolved::*.<name>` form).
+func selectorCallName(to string) string {
+	name := graph.UnresolvedName(to)
+	if name == "" {
+		return ""
+	}
+	name = strings.TrimPrefix(name, "*.")
+	if i := strings.LastIndex(name, "."); i >= 0 {
+		name = name[i+1:]
+	}
+	return name
+}
+
+// isRustTypeName reports whether s looks like a Rust type path qualifier
+// (UpperCamelCase) rather than a module/path keyword. Crate-relative
+// keywords (crate/super/self) and lowercase module names are not types.
+func isRustTypeName(s string) bool {
+	switch s {
+	case "", "crate", "super", "self", "Self":
+		return false
+	}
+	c := s[0]
+	return c >= 'A' && c <= 'Z'
+}
+
+// rustParentDir returns the slash-separated parent directory of a graph
+// file path. Graph paths are slash-normalised, so a plain byte scan is
+// correct on every OS.
+func rustParentDir(path string) string {
+	if i := strings.LastIndexByte(path, '/'); i >= 0 {
+		return path[:i]
+	}
+	return ""
+}

--- a/internal/resolver/rust_scope_test.go
+++ b/internal/resolver/rust_scope_test.go
@@ -1,0 +1,275 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+// buildRustGraph extracts each file via the real Rust extractor and
+// loads the result into a fresh in-memory graph, mirroring the
+// indexer's per-file ingest.
+func buildRustGraph(t *testing.T, files map[string]string) graph.Store {
+	t.Helper()
+	g := graph.New()
+	e := languages.NewRustExtractor()
+	for path, src := range files {
+		r, err := e.Extract(path, []byte(src))
+		require.NoError(t, err, "rust extract %s", path)
+		for _, n := range r.Nodes {
+			g.AddNode(n)
+		}
+		for _, ed := range r.Edges {
+			g.AddEdge(ed)
+		}
+	}
+	return g
+}
+
+// callTargetsFromRust collects the To-end of every call edge leaving
+// fromID, so a test can assert on the post-resolution shape of a
+// caller's outbound calls.
+func callTargetsFromRust(g graph.Store, fromID string) []string {
+	var out []string
+	for _, e := range g.GetOutEdges(fromID) {
+		if e.Kind == graph.EdgeCalls {
+			out = append(out, e.To)
+		}
+	}
+	return out
+}
+
+// TestRustScope_ImplMethodOwner: `Foo::new()` lands on impl Foo's new.
+func TestRustScope_ImplMethodOwner(t *testing.T) {
+	src := `
+struct Foo {}
+
+impl Foo {
+    fn new() -> Foo { Foo {} }
+}
+
+struct Bar {}
+
+impl Bar {
+    fn new() -> Bar { Bar {} }
+}
+
+fn run() {
+    let _f = Foo::new();
+}
+`
+	g := buildRustGraph(t, map[string]string{"lib.rs": src})
+
+	landed := ResolveRustScopeCalls(g)
+	require.GreaterOrEqual(t, landed, 1, "expected at least Foo::new to land")
+
+	wantNew := "lib.rs::Foo.new"
+	require.NotNil(t, g.GetNode(wantNew), "Foo.new method node should exist")
+
+	targets := callTargetsFromRust(g, "lib.rs::run")
+	require.Contains(t, targets, wantNew, "Foo::new() should resolve to impl Foo's new, got %v", targets)
+	// The other type's new must NOT be picked.
+	require.NotContains(t, targets, "lib.rs::Bar.new")
+}
+
+// TestRustScope_SelfReceiver: `self.bar()` inside impl Foo lands on
+// Foo.bar; `Self::new()` lands on Foo.new.
+func TestRustScope_SelfReceiver(t *testing.T) {
+	src := `
+struct Foo {}
+
+impl Foo {
+    fn new() -> Foo { Foo {} }
+    fn bar(&self) {}
+    fn run(&self) {
+        self.bar();
+        let _x = Self::new();
+    }
+}
+
+struct Other {}
+
+impl Other {
+    fn bar(&self) {}
+    fn new() -> Other { Other {} }
+}
+`
+	g := buildRustGraph(t, map[string]string{"lib.rs": src})
+
+	ResolveRustScopeCalls(g)
+
+	targets := callTargetsFromRust(g, "lib.rs::Foo.run")
+	require.Contains(t, targets, "lib.rs::Foo.bar", "self.bar() should resolve to Foo.bar, got %v", targets)
+	require.Contains(t, targets, "lib.rs::Foo.new", "Self::new() should resolve to Foo.new, got %v", targets)
+	require.NotContains(t, targets, "lib.rs::Other.bar")
+	require.NotContains(t, targets, "lib.rs::Other.new")
+}
+
+// TestRustScope_ModulePath: `crate::util::helper()` resolves to the
+// helper free function. Gortex doesn't node-model the module tree, so
+// the trailing-segment binding rides at ast_inferred.
+func TestRustScope_ModulePath(t *testing.T) {
+	src := `
+fn helper() {}
+
+fn run() {
+    crate::util::helper();
+    super::helper();
+    self::helper();
+}
+`
+	g := buildRustGraph(t, map[string]string{"lib.rs": src})
+
+	ResolveRustScopeCalls(g)
+
+	wantHelper := "lib.rs::helper"
+	require.NotNil(t, g.GetNode(wantHelper))
+
+	targets := callTargetsFromRust(g, "lib.rs::run")
+	count := 0
+	for _, tgt := range targets {
+		if tgt == wantHelper {
+			count++
+		}
+	}
+	require.GreaterOrEqual(t, count, 1, "crate::util::helper() should resolve to helper, got %v", targets)
+
+	// The module-path bindings should ride at ast_inferred.
+	for _, e := range g.GetOutEdges("lib.rs::run") {
+		if e.Kind == graph.EdgeCalls && e.To == wantHelper {
+			require.Equal(t, graph.OriginASTInferred, e.Origin, "module-path binding should be ast_inferred")
+		}
+	}
+}
+
+// TestRustScope_LocalShadowsImport: when a local binding (here a
+// parameter) shares a name with an imported item, the local wins — the
+// shadowed name is NOT resolved to the (module-path) free function.
+func TestRustScope_LocalShadowsImport(t *testing.T) {
+	src := `
+fn helper() {}
+
+fn run(helper: u32) {
+    self::helper();
+}
+`
+	g := buildRustGraph(t, map[string]string{"lib.rs": src})
+
+	ResolveRustScopeCalls(g)
+
+	// The param `helper` shadows the free function, so the module-path
+	// call must stay unresolved rather than binding to lib.rs::helper.
+	for _, e := range g.GetOutEdges("lib.rs::run") {
+		if e.Kind != graph.EdgeCalls {
+			continue
+		}
+		require.NotEqual(t, "lib.rs::helper", e.To,
+			"shadowed self::helper() must not resolve to the free function while a local `helper` is in scope")
+		require.True(t, graph.IsUnresolvedTarget(e.To),
+			"shadowed call should remain unresolved, got %s", e.To)
+	}
+}
+
+// TestRustScope_AmbiguousStaysUnresolved: a `Type::method` call where
+// two types of the same name each have the method is ambiguous and must
+// be left unresolved.
+func TestRustScope_AmbiguousStaysUnresolved(t *testing.T) {
+	// Two `impl Widget` blocks in two files, both defining `build`.
+	// Foo::build()-style ambiguity: a single owner name `Widget` mapping
+	// to two distinct method nodes (different files) → ambiguous.
+	fileA := `
+struct Widget {}
+
+impl Widget {
+    fn build() -> Widget { Widget {} }
+}
+`
+	fileB := `
+struct Widget {}
+
+impl Widget {
+    fn build() -> Widget { Widget {} }
+}
+
+fn run() {
+    let _w = Widget::build();
+}
+`
+	g := buildRustGraph(t, map[string]string{"a.rs": fileA, "b.rs": fileB})
+
+	ResolveRustScopeCalls(g)
+
+	for _, e := range g.GetOutEdges("b.rs::run") {
+		if e.Kind != graph.EdgeCalls {
+			continue
+		}
+		require.True(t, graph.IsUnresolvedTarget(e.To),
+			"ambiguous Widget::build() (two same-name owners) must stay unresolved, got %s", e.To)
+	}
+}
+
+// TestRustScope_Idempotent: a second run does not change the resolved
+// state nor produce additional rebindings.
+func TestRustScope_Idempotent(t *testing.T) {
+	src := `
+struct Foo {}
+
+impl Foo {
+    fn new() -> Foo { Foo {} }
+    fn run(&self) {
+        let _f = Foo::new();
+        self.helper();
+    }
+    fn helper(&self) {}
+}
+`
+	g := buildRustGraph(t, map[string]string{"lib.rs": src})
+
+	first := ResolveRustScopeCalls(g)
+	require.GreaterOrEqual(t, first, 2)
+
+	before := callTargetsFromRust(g, "lib.rs::Foo.run")
+
+	second := ResolveRustScopeCalls(g)
+	require.Equal(t, 0, second, "second run should land no NEW edges (already resolved)")
+
+	after := callTargetsFromRust(g, "lib.rs::Foo.run")
+	require.ElementsMatch(t, before, after, "edge targets must be stable across runs")
+}
+
+// TestRustScope_NoOpOnNonRust: the pass is a no-op when there are no
+// Rust nodes.
+func TestRustScope_NoOpOnNonRust(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "x.go::F", Kind: graph.KindFunction, Name: "F", Language: "go"})
+	require.Equal(t, 0, ResolveRustScopeCalls(g))
+}
+
+// Guard that the extractor stamps the metadata this pass depends on, so
+// a future extractor change that drops it fails loudly here rather than
+// silently regressing resolution.
+func TestRustScope_ExtractorStampsPathMeta(t *testing.T) {
+	src := `
+struct Foo {}
+impl Foo { fn new() -> Foo { Foo {} } }
+fn run() { let _f = Foo::new(); }
+`
+	g := buildRustGraph(t, map[string]string{"lib.rs": src})
+	e := findCallWithPathMeta(g, "lib.rs::run")
+	require.NotNil(t, e, "Foo::new() call edge should carry rust_path meta")
+	require.Equal(t, "Foo::new", e.Meta["rust_path"])
+}
+
+func findCallWithPathMeta(g graph.Store, fromID string) *graph.Edge {
+	for _, e := range g.GetOutEdges(fromID) {
+		if e.Kind != graph.EdgeCalls || e.Meta == nil {
+			continue
+		}
+		if _, ok := e.Meta["rust_path"]; ok {
+			return e
+		}
+	}
+	return nil
+}

--- a/internal/resolver/sql_callsites.go
+++ b/internal/resolver/sql_callsites.go
@@ -1,0 +1,88 @@
+package resolver
+
+import "github.com/zzet/gortex/internal/graph"
+
+// sqlCallsiteVia marks the placeholder call edge a JS/TS/Python SQL
+// function call site emits (mirrors languages.sqlCallsiteVia).
+const sqlCallsiteVia = "sql.callsite"
+
+// sqlCallPrefix is the placeholder namespace for an unresolved SQL
+// function call (`unresolved::sqlfn::<name>`).
+const sqlCallPrefix = unresolvedPrefix + "sqlfn::"
+
+// ResolveSQLCallsites is the framework-dispatch synthesizer that links a
+// cross-language SQL function call site (Supabase/PostgREST `.rpc('fn')`,
+// SQLAlchemy `func.fn()`) to the SQL `CREATE FUNCTION` node it invokes.
+// The language extractors emit a placeholder EdgeCalls to
+// `unresolved::sqlfn::<name>` carrying Meta["via"]="sql.callsite"; this
+// pass lands it on the unique SQL KindFunction node of that name.
+//
+// Full recompute and idempotent: the target is recomputed from the edge's
+// sql_function meta, so a reindex of either side re-lands or re-orphans
+// the edge. graph.ReindexEdges keeps the adjacency buckets consistent.
+// An ambiguous name (two SQL functions) is left on the placeholder.
+//
+// Returns the number of call edges landed on a SQL function.
+func ResolveSQLCallsites(g graph.Store) int {
+	if g == nil {
+		return 0
+	}
+	sqlFns := map[string][]*graph.Node{}
+	for _, n := range nodesByKindsOrAll(g, graph.KindFunction) {
+		if n != nil && n.Language == "sql" && n.Name != "" {
+			sqlFns[n.Name] = append(sqlFns[n.Name], n)
+		}
+	}
+	if len(sqlFns) == 0 {
+		return 0
+	}
+
+	resolved := 0
+	var reindex []graph.EdgeReindex
+	for e := range g.EdgesByKind(graph.EdgeCalls) {
+		if e == nil || e.Meta == nil {
+			continue
+		}
+		if v, _ := e.Meta["via"].(string); v != sqlCallsiteVia {
+			continue
+		}
+		fn, _ := e.Meta["sql_function"].(string)
+		if fn == "" {
+			continue
+		}
+		var target *graph.Node
+		if cands := sqlFns[fn]; len(cands) == 1 {
+			target = cands[0]
+		}
+		want := sqlCallPrefix + fn
+		if target != nil {
+			want = target.ID
+		}
+		if e.To == want {
+			if target != nil {
+				resolved++
+			}
+			continue
+		}
+		oldTo := e.To
+		e.To = want
+		if target != nil {
+			e.Origin = graph.OriginASTInferred
+			e.Confidence = 0.6
+			e.ConfidenceLabel = graph.ConfidenceLabelFor(graph.EdgeCalls, 0.6)
+			StampSynthesized(e, SynthSQLCallsite)
+			resolved++
+		} else {
+			// Re-orphaned (the SQL function disappeared / became ambiguous).
+			e.Origin = graph.OriginASTInferred
+			e.Confidence = 0
+			e.ConfidenceLabel = ""
+			UnstampSynthesized(e)
+		}
+		reindex = append(reindex, graph.EdgeReindex{Edge: e, OldTo: oldTo})
+	}
+	if len(reindex) > 0 {
+		g.ReindexEdges(reindex)
+	}
+	return resolved
+}

--- a/internal/resolver/sql_callsites_test.go
+++ b/internal/resolver/sql_callsites_test.go
@@ -1,0 +1,62 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func sqlFnNode(g graph.Store, id, name string) {
+	g.AddNode(&graph.Node{ID: id, Kind: graph.KindFunction, Name: name, FilePath: "schema.sql", Language: "sql"})
+}
+
+func sqlCaller(g graph.Store, callerID, fn string) *graph.Edge {
+	g.AddNode(&graph.Node{ID: callerID, Kind: graph.KindFunction, Name: lastSeg(callerID), FilePath: "app.ts", Language: "typescript"})
+	e := &graph.Edge{
+		From: callerID, To: "unresolved::sqlfn::" + fn, Kind: graph.EdgeCalls,
+		FilePath: "app.ts", Line: 2, Meta: map[string]any{"via": sqlCallsiteVia, "sql_function": fn},
+	}
+	g.AddEdge(e)
+	return e
+}
+
+func TestResolveSQLCallsites_Lands(t *testing.T) {
+	g := graph.New()
+	e := sqlCaller(g, "app.ts::load", "get_user_stats")
+	sqlFnNode(g, "schema.sql::get_user_stats", "get_user_stats")
+
+	n := ResolveSQLCallsites(g)
+	assert.Equal(t, 1, n)
+	assert.Equal(t, "schema.sql::get_user_stats", e.To)
+	assert.Equal(t, graph.OriginASTInferred, e.Origin)
+	assert.Equal(t, SynthSQLCallsite, e.Meta[MetaSynthesizedBy])
+	require.Len(t, g.GetInEdges("schema.sql::get_user_stats"), 1)
+}
+
+func TestResolveSQLCallsites_AmbiguousStaysPlaceholder(t *testing.T) {
+	g := graph.New()
+	e := sqlCaller(g, "app.ts::load", "calc")
+	sqlFnNode(g, "a.sql::calc", "calc")
+	sqlFnNode(g, "b.sql::calc", "calc")
+	assert.Equal(t, 0, ResolveSQLCallsites(g))
+	assert.Equal(t, "unresolved::sqlfn::calc", e.To, "ambiguous SQL function stays unresolved")
+}
+
+func TestResolveSQLCallsites_NoSQLFunction(t *testing.T) {
+	g := graph.New()
+	sqlCaller(g, "app.ts::load", "ghost")
+	assert.Equal(t, 0, ResolveSQLCallsites(g))
+}
+
+func TestResolveSQLCallsites_Idempotent(t *testing.T) {
+	g := graph.New()
+	sqlCaller(g, "app.ts::load", "fn")
+	sqlFnNode(g, "schema.sql::fn", "fn")
+	first := ResolveSQLCallsites(g)
+	second := ResolveSQLCallsites(g)
+	assert.Equal(t, first, second)
+	assert.Equal(t, 1, second)
+}

--- a/internal/resolver/swift_objc_bridge.go
+++ b/internal/resolver/swift_objc_bridge.go
@@ -1,0 +1,106 @@
+package resolver
+
+import "github.com/zzet/gortex/internal/graph"
+
+// swiftObjCBridgeVia marks a synthesized Swift↔ObjC bridge edge.
+const swiftObjCBridgeVia = "swift.objc.bridge"
+
+// ResolveSwiftObjCBridge is the framework-dispatch synthesizer for the
+// Swift ↔ Objective-C bridge. The Objective-C extractor names each method
+// node by its canonical selector (`moveFrom:to:`, `viewDidLoad`); the
+// Swift extractor stamps the ObjC selector a method is exposed under
+// (Meta["objc_selector"]) on every @objc method, derived from the
+// argument labels or an explicit @objc(custom:) override. This pass joins
+// the two: for each Swift @objc method whose selector matches an ObjC
+// method node, it synthesizes a pair of EdgeReferences bridge edges (one
+// each way) so navigation and find_usages span the language boundary —
+// an ObjC selector call resolves to the Swift implementation, and a Swift
+// method shows its ObjC-visible counterpart.
+//
+// Full recompute and idempotent: edges are re-derived from the selector
+// metadata, graph.AddEdge dedupes by edge key, and graph.EvictFile drops
+// the bridge in both directions when either side's file is reindexed.
+// Edges ride at ast_inferred (selector-name matching is a heuristic, not
+// a type-checked bind) and carry full synthesizer provenance.
+//
+// Returns the number of Swift methods bridged to at least one ObjC
+// selector counterpart.
+func ResolveSwiftObjCBridge(g graph.Store) int {
+	if g == nil {
+		return 0
+	}
+
+	objcBySelector := map[string][]*graph.Node{}
+	var swiftMethods []*graph.Node
+	for _, n := range nodesByKindsOrAll(g, graph.KindMethod, graph.KindFunction) {
+		if n == nil {
+			continue
+		}
+		switch n.Language {
+		case "objc":
+			if n.Kind == graph.KindMethod && n.Name != "" {
+				objcBySelector[n.Name] = append(objcBySelector[n.Name], n)
+			}
+		case "swift":
+			if n.Meta != nil {
+				if sel, _ := n.Meta["objc_selector"].(string); sel != "" {
+					swiftMethods = append(swiftMethods, n)
+				}
+			}
+		}
+	}
+	if len(objcBySelector) == 0 || len(swiftMethods) == 0 {
+		return 0
+	}
+
+	var batch []*graph.Edge
+	bridged := 0
+	for _, sm := range swiftMethods {
+		sel, _ := sm.Meta["objc_selector"].(string)
+		matches := objcBySelector[sel]
+		if len(matches) == 0 {
+			continue
+		}
+		linked := false
+		for _, om := range matches {
+			if om.ID == sm.ID {
+				continue
+			}
+			batch = append(batch,
+				swiftObjCBridgeEdge(sm, om, sel),
+				swiftObjCBridgeEdge(om, sm, sel),
+			)
+			linked = true
+		}
+		if linked {
+			bridged++
+		}
+	}
+
+	for _, e := range batch {
+		g.AddEdge(e)
+	}
+	return bridged
+}
+
+// swiftObjCBridgeEdge builds one direction of the cross-language bridge.
+func swiftObjCBridgeEdge(from, to *graph.Node, selector string) *graph.Edge {
+	return &graph.Edge{
+		From:            from.ID,
+		To:              to.ID,
+		Kind:            graph.EdgeReferences,
+		FilePath:        from.FilePath,
+		Line:            from.StartLine,
+		Confidence:      0.6,
+		ConfidenceLabel: graph.ConfidenceLabelFor(graph.EdgeReferences, 0.6),
+		Origin:          graph.OriginASTInferred,
+		Meta: map[string]any{
+			"via":              swiftObjCBridgeVia,
+			"objc_selector":    selector,
+			MetaSynthesizedBy:  SynthSwiftObjC,
+			MetaProvenance:     ProvenanceHeuristic,
+			"bridge_from_lang": from.Language,
+			"bridge_to_lang":   to.Language,
+		},
+	}
+}

--- a/internal/resolver/swift_objc_bridge_test.go
+++ b/internal/resolver/swift_objc_bridge_test.go
@@ -1,0 +1,90 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func swiftMethodNode(g graph.Store, id, selector string) {
+	g.AddNode(&graph.Node{
+		ID: id, Kind: graph.KindMethod, Name: lastSeg(id), FilePath: "ios/App.swift", StartLine: 10,
+		Language: "swift", Meta: map[string]any{"objc_selector": selector},
+	})
+}
+
+func objcMethodNode(g graph.Store, id, selector string) {
+	g.AddNode(&graph.Node{
+		ID: id, Kind: graph.KindMethod, Name: selector, FilePath: "ios/Legacy.m", StartLine: 5,
+		Language: "objc",
+	})
+}
+
+func bridgeEdgeBetween(g graph.Store, from, to string) *graph.Edge {
+	for _, e := range g.GetOutEdges(from) {
+		if e.To == to && e.Kind == graph.EdgeReferences && e.Meta != nil {
+			if v, _ := e.Meta["via"].(string); v == swiftObjCBridgeVia {
+				return e
+			}
+		}
+	}
+	return nil
+}
+
+func TestResolveSwiftObjCBridge_BindsSelector(t *testing.T) {
+	g := graph.New()
+	swiftMethodNode(g, "ios/App.swift::Mover.move", "moveFrom:to:")
+	objcMethodNode(g, "ios/Legacy.m::moveFrom:to:", "moveFrom:to:")
+
+	n := ResolveSwiftObjCBridge(g)
+	assert.Equal(t, 1, n)
+
+	fwd := bridgeEdgeBetween(g, "ios/App.swift::Mover.move", "ios/Legacy.m::moveFrom:to:")
+	require.NotNil(t, fwd, "swift→objc bridge edge")
+	assert.Equal(t, "moveFrom:to:", fwd.Meta["objc_selector"])
+	assert.Equal(t, SynthSwiftObjC, fwd.Meta[MetaSynthesizedBy])
+	assert.Equal(t, graph.OriginASTInferred, fwd.Origin)
+
+	rev := bridgeEdgeBetween(g, "ios/Legacy.m::moveFrom:to:", "ios/App.swift::Mover.move")
+	require.NotNil(t, rev, "objc→swift bridge edge (bidirectional)")
+}
+
+func TestResolveSwiftObjCBridge_ExplicitSelector(t *testing.T) {
+	g := graph.New()
+	swiftMethodNode(g, "ios/App.swift::Mover.moveCustom", "customMove:")
+	objcMethodNode(g, "ios/Legacy.m::customMove:", "customMove:")
+	objcMethodNode(g, "ios/Legacy.m::unrelated:", "unrelated:")
+
+	assert.Equal(t, 1, ResolveSwiftObjCBridge(g))
+	assert.NotNil(t, bridgeEdgeBetween(g, "ios/App.swift::Mover.moveCustom", "ios/Legacy.m::customMove:"))
+	assert.Nil(t, bridgeEdgeBetween(g, "ios/App.swift::Mover.moveCustom", "ios/Legacy.m::unrelated:"))
+}
+
+func TestResolveSwiftObjCBridge_NoMatchNoEdge(t *testing.T) {
+	g := graph.New()
+	swiftMethodNode(g, "ios/App.swift::Mover.move", "moveFrom:to:")
+	objcMethodNode(g, "ios/Legacy.m::other:", "other:")
+	assert.Equal(t, 0, ResolveSwiftObjCBridge(g))
+}
+
+func TestResolveSwiftObjCBridge_Idempotent(t *testing.T) {
+	g := graph.New()
+	swiftMethodNode(g, "ios/App.swift::Mover.move", "moveFrom:to:")
+	objcMethodNode(g, "ios/Legacy.m::moveFrom:to:", "moveFrom:to:")
+	first := ResolveSwiftObjCBridge(g)
+	second := ResolveSwiftObjCBridge(g)
+	assert.Equal(t, first, second)
+	// Exactly two bridge edges (one each direction) survive dedup.
+	count := 0
+	for e := range g.EdgesByKind(graph.EdgeReferences) {
+		if e != nil && e.Meta != nil {
+			if v, _ := e.Meta["via"].(string); v == swiftObjCBridgeVia {
+				count++
+			}
+		}
+	}
+	assert.Equal(t, 2, count)
+}

--- a/internal/resolver/temporal_calls.go
+++ b/internal/resolver/temporal_calls.go
@@ -145,12 +145,14 @@ func ResolveTemporalCalls(g graph.Store) int {
 			e.Confidence = conf
 			e.ConfidenceLabel = graph.ConfidenceLabelFor(graph.EdgeCalls, conf)
 			e.Meta["temporal_resolution"] = origin
+			StampSynthesized(e, SynthTemporalStub)
 			resolved++
 		} else {
 			e.Origin = ""
 			e.Confidence = 0
 			e.ConfidenceLabel = ""
 			delete(e.Meta, "temporal_resolution")
+			UnstampSynthesized(e)
 		}
 		reindexBatch = append(reindexBatch, graph.EdgeReindex{Edge: e, OldTo: oldTo})
 	}


### PR DESCRIPTION
 ## Summary

Closes a cluster of resolution / cross-language call-graph gaps in one branch — 23 commits, one logical change per commit, ~+9.7k/−172 across 89 files. The centerpiece is a unified **framework dynamic-dispatch synthesizer engine** that materialises the call edges a framework wires at runtime (which static resolution can't see); the mobile bridges, MyBatis, SQL call-sites, and event channels all plug into it as registered passes. The rest adds language-specific resolution (Rust, Kotlin, C#), web/service contract resolution (router-prefix joining, configurable HTTP client aliases, DI bindings), real-time edges (WebSocket/SSE), and two new query surfaces.

Every package's tests pass; `go build ./...`, `go vet ./...`, `make lint` (0 issues), and the full `go test ./...` are green.

## Framework dispatch synthesizer engine

A `FrameworkSynthesizer` registry + `RunFrameworkSynthesizers` replaces the ad-hoc gRPC/Temporal pass calls at all six indexer settle points. Each synthesizer is a full-recompute, idempotent pass that stamps `synthesized_by` + `provenance=heuristic` on every edge it lands, so the heuristic framework-dispatch edges are auditable apart from compiler-verified ones. Registered passes: gRPC stub, Temporal stub, event-channel, Swift↔ObjC, React Native, Expo, Fabric, MyBatis, SQL call-site, Rust scope.

- **Cross-language event channels** — pairs an in-process / native-bridge emitter to its listener handlers over the shared pub/sub topic node (EventEmitter, Socket.IO, native `rn_*`); brokers stay owned by the contracts layer, and a per-topic fan-out cap avoids exploding generic buses.
- **Swift → Objective-C bridge** — the Swift extractor computes the ObjC selector each `@objc` method is exposed under (explicit `@objc(custom:)`, argument-label folding, `init`→`initWith…`, omitted-label colons), and the synthesizer binds it to the matching ObjC method node both ways.
- **React Native bridge** — JS `NativeModules.X.y()` / `requireNativeModule` / `TurboModuleRegistry` calls link to the native implementations: ObjC `RCT_EXPORT_MODULE` / `RCT_EXPORT_METHOD` / `RCT_REMAP_METHOD` and Java `@ReactMethod` (module name from `@ReactModule`/`getName()`).
- **Expo Modules** — Swift/Kotlin `Name(...)` / `Function(...)` / `AsyncFunction(...)` DSL → the JS `requireNativeModule` call sites.
- **Fabric / Codegen view components** — `codegenNativeComponent<Props>('Name')` specs bind to the native view managers (ObjC `RCT_EXPORT_VIEW_PROPERTY`, Java `@ReactProp`) by component name.
- **MyBatis** — mapper XML is indexed (a node per `<select|insert|update|delete>`, qualified `<namespace>::<id>`), and Java DAO methods link to their SQL statements.
- **SQL function call-sites** — `supabase.rpc('fn')` (JS/TS/Python) and SQLAlchemy `func.fn()` (Python) link to the `CREATE FUNCTION` graph node.

## Language-specific resolution

- **Rust** — impl-block method-owner, `self`/`Self` receiver, and `crate::`/`super::`/module-path resolution as a dedicated pass (zero-false-positive bias; ambiguous calls left unresolved).
- **Kotlin** — companion-object static dispatch (`Type.member()` → companion fn, named companions too) and lambda-parameter scoped binding.
- **C#** — interface-vs-base-class discrimination for bases in another compilation unit (local-interface prescan, then the `I`-prefix convention) — adds `extends`/`implements` edges C# previously didn't emit.
- **TypeScript** — barrel re-export edge cases: Svelte/Vue default re-exports and `package.json` `exports` subpath maps (string + conditional targets, `"."`, `"./*"`, `..`-traversal rejection).
- **TS type-text** — split intersection (`&`) types and a 16-member union/intersection overflow guard, plus a depth-underflow fix on arrow-function return types.

## Web / service contracts

- **Router-prefix joining** — `include_router(prefix=)` / `app.use('/api', router)` / NestJS `@Controller` prefixes are joined into the HTTP contract path before pairing (FastAPI fully; Express/NestJS partial, documented).
- **Configurable HTTP client aliases** — register named wrapper-client functions so calls to them are recognised as HTTP consumers without touching extractor code.
- **DI container bindings** — Symfony `services.yaml` and Spring `applicationContext.xml` interface→implementation autowiring is emitted, consumed by the existing provides-index resolver. 
- **WebSocket / SSE** — client `new WebSocket(url)` / `new EventSource(url)` (JS/TS) and server upgrade handlers (Go gorilla/gobwas/coder) surface as real-time edges.

## New query surfaces

- `analyze kind=synthesizers` — per-synthesizer rollup of every synthesized edge.
- `analyze kind=resolution_outcomes` — structured resolver-suppression taxonomy (`ambiguous_multi_match` / `candidate_out_of_scope` / `cross_language_only` / `stub_only` / `no_definition`).
- `graph.Edge.Context` + `find_usages context:"parameter_type"` — classifies each usage by role (parameter_type / return_type / field / value / type / attribute / call) and filters by it.

## Performance: external-call qualification, default-on

External-package call qualification (stable cross-repo identity nodes, per-language complete including JVM/.NET stdlib filters) is now **on by default**. Naïvely defaulting it on regressed indexer throughput ~9× (the synthesis was a full-graph recompute run on every reindex). Two changes make default-on affordable:

- **Incremental hot path** — a single-file reindex re-materialises only that file's external terminals (O(edited files)) instead of recomputing the whole graph.
- **Disk pushdown** — sqlite selects only external-terminal edges via a GLOB predicate served by a new `edges_external` partial index, instead of marshaling every call edge into Go.

Indexer suite with synthesis on: **714s → ~120s**.

## Compatibility / rollout notes

- **Default-behavior change:** external-call synthesis is on by default (opt out with `index.synthesize_external_calls: false` or `GORTEX_SYNTH_EXTERNAL_CALLS=0`). It materialises a synthetic node per external package and retargets call/reference edges onto it.
- **Wire contract:** `graph.Edge` gains an additive `Context` field (gob-back-compatible — old snapshots decode with it blank); the wire-contract fingerprint golden was bumped accordingly.
- **Schema:** the sqlite backend creates the `edges_external` partial index on `Open` (idempotent).
- New `analyze` kinds are additive; existing tool shapes unchanged.