### PR TITLE
 MCP tool ergonomics: edit safety, transport reliability & multi-agent coordination

### DIFF
--- a/cmd/gortex/proxy.go
+++ b/cmd/gortex/proxy.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/zzet/gortex/internal/daemon"
 )
@@ -63,17 +64,79 @@ func runProxy(ctx context.Context) (ran bool, err error) {
 		errCh <- err
 	}()
 
-	// Wait for first completion; exit on context cancellation too.
+	// Orphan watchdog: if our parent (the MCP client) dies, stdin EOF is the
+	// normal shutdown signal — but a client that is SIGKILLed, or whose stdin
+	// pipe is inherited and held open elsewhere, can leave this proxy wedged
+	// forever, pinning a daemon session. Poll the parent PID and unblock the
+	// select when we get reparented (to init or a subreaper).
+	orphanCh := make(chan struct{}, 1)
+	watchCtx, cancelWatch := context.WithCancel(ctx)
+	defer cancelWatch()
+	go orphanWatch(watchCtx, orphanPollInterval, os.Getppid, func() {
+		fmt.Fprintln(os.Stderr, "[gortex mcp] parent process exited; closing proxy")
+		select {
+		case orphanCh <- struct{}{}:
+		default:
+		}
+	})
+
+	// Wait for first completion; exit on context cancellation or orphaning too.
 	select {
 	case pumpErr := <-errCh:
 		if pumpErr != nil && !errors.Is(pumpErr, io.EOF) {
 			return true, fmt.Errorf("proxy pump: %w", pumpErr)
 		}
+	case <-orphanCh:
 	case <-ctx.Done():
 	}
+	cancelWatch()
 	_ = client.Close()
-	wg.Wait()
+	// Bound the drain: a pump blocked reading a never-closing stdin (the exact
+	// orphan case) must not pin shutdown — the process is exiting regardless.
+	drained := make(chan struct{})
+	go func() { wg.Wait(); close(drained) }()
+	select {
+	case <-drained:
+	case <-time.After(proxyDrainTimeout):
+	}
 	return true, nil
+}
+
+// orphanPollInterval is how often the proxy checks whether its parent
+// process is still alive; proxyDrainTimeout bounds the post-close drain.
+// Both are vars so tests can shorten them.
+var (
+	orphanPollInterval = 5 * time.Second
+	proxyDrainTimeout  = 2 * time.Second
+)
+
+// orphanWatch polls getppid every interval and invokes onOrphan exactly
+// once when the proxy's parent process has gone away — detected as a change
+// of parent PID (reparented to init=1 on classic Unix, or to the nearest
+// subreaper). Watching for a *change* is strictly more robust than testing
+// for PID 1 alone, which misses subreaper reparenting (containers, systemd
+// user sessions, a wrapping CLI that calls prctl(PR_SET_CHILD_SUBREAPER)).
+// It self-disarms when there is no meaningful parent to watch (orig <= 1),
+// and is an inert no-op on platforms that never reparent — there the parent
+// PID stays equal to orig for the whole process lifetime.
+func orphanWatch(ctx context.Context, interval time.Duration, getppid func() int, onOrphan func()) {
+	orig := getppid()
+	if orig <= 1 || interval <= 0 {
+		return
+	}
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if getppid() != orig {
+				onOrphan()
+				return
+			}
+		}
+	}
 }
 
 // pumpLines copies newline-delimited frames from src to dst. Uses a

--- a/cmd/gortex/proxy_test.go
+++ b/cmd/gortex/proxy_test.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // TestResolveLaunchCWDFallsBackFromHome exercises the gortexhq/gortex#19
@@ -117,5 +120,99 @@ func TestResolveLaunchCWDFallsBackToPWDFromRoot(t *testing.T) {
 	gotResolved, _ := filepath.EvalSymlinks(got)
 	if gotResolved != wantResolved {
 		t.Errorf("resolveLaunchCWD from / = %q, want %q (the PWD fallback)", got, project)
+	}
+}
+
+// TestOrphanWatch_FiresOnReparent confirms the watchdog fires once when the
+// parent PID changes (the parent process died and we were reparented).
+func TestOrphanWatch_FiresOnReparent(t *testing.T) {
+	var calls atomic.Int32
+	getppid := func() int {
+		if calls.Add(1) == 1 {
+			return 4242 // original parent observed at arm time
+		}
+		return 1 // reparented to init after the parent exited
+	}
+	fired := make(chan struct{}, 1)
+	go orphanWatch(context.Background(), time.Millisecond, getppid, func() { fired <- struct{}{} })
+
+	select {
+	case <-fired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("orphanWatch did not fire after the parent PID changed")
+	}
+}
+
+// TestOrphanWatch_FiresOnSubreaperReparent confirms the change-detection
+// catches reparenting to a subreaper (PID != 1) — the case a bare `== 1`
+// check would miss in containers / systemd user sessions.
+func TestOrphanWatch_FiresOnSubreaperReparent(t *testing.T) {
+	var calls atomic.Int32
+	getppid := func() int {
+		if calls.Add(1) == 1 {
+			return 4242
+		}
+		return 99 // reparented to a subreaper, not init
+	}
+	fired := make(chan struct{}, 1)
+	go orphanWatch(context.Background(), time.Millisecond, getppid, func() { fired <- struct{}{} })
+
+	select {
+	case <-fired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("orphanWatch must fire on subreaper reparenting, not just PID 1")
+	}
+}
+
+// TestOrphanWatch_StableParentNeverFires confirms a live, unchanging parent
+// never trips the watchdog.
+func TestOrphanWatch_StableParentNeverFires(t *testing.T) {
+	getppid := func() int { return 4242 }
+	fired := make(chan struct{}, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	go orphanWatch(ctx, time.Millisecond, getppid, func() { fired <- struct{}{} })
+
+	time.Sleep(50 * time.Millisecond) // ~50 stable polls
+	cancel()
+	select {
+	case <-fired:
+		t.Fatal("orphanWatch fired despite a stable parent PID")
+	default:
+	}
+}
+
+// TestOrphanWatch_Disarms confirms the watchdog never arms when there is no
+// meaningful parent to watch (already init / no parent) or the interval is
+// non-positive — it returns immediately and never fires.
+func TestOrphanWatch_Disarms(t *testing.T) {
+	cases := map[string]struct {
+		ppid     int
+		interval time.Duration
+	}{
+		"already init":     {1, time.Millisecond},
+		"no parent":        {0, time.Millisecond},
+		"non-pos interval": {4242, 0},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			fired := make(chan struct{}, 1)
+			done := make(chan struct{})
+			go func() {
+				orphanWatch(context.Background(), tc.interval,
+					func() int { return tc.ppid },
+					func() { fired <- struct{}{} })
+				close(done)
+			}()
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+				t.Fatal("orphanWatch should return immediately when disarmed")
+			}
+			select {
+			case <-fired:
+				t.Fatal("orphanWatch must not fire when disarmed")
+			default:
+			}
+		})
 	}
 }

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -50,6 +50,37 @@ user-level instructions surface — the guidance lives once per user
 descriptions carry the teaching. Only codebase-derived community
 routing lands in per-repo instructions files.
 
+## Subagent tool propagation
+
+A *subagent* runs in a fresh context window with its own scoped tool
+allowlist. Whether a subagent can use Gortex's MCP tools depends
+entirely on whether that allowlist names them — a subagent does **not**
+automatically inherit every tool the parent has.
+
+- **Claude Code** has a first-class subagent concept with per-subagent
+  tool allowlists, and Gortex propagates explicitly. `gortex install`
+  writes two subagent definitions to `~/.claude/agents/` —
+  `gortex-search` (locate / trace / explore) and `gortex-impact`
+  (blast-radius / verification) — each with an explicit
+  `tools: mcp__gortex__…` frontmatter listing exactly the graph tools it
+  needs. The allowlist is **graph-only by construction**: it contains no
+  `Bash`/`Grep`/`Glob`, so a spawned subagent cannot escape the graph.
+  A `PreToolUse` Task hook additionally briefs spawned subagents. The
+  allowlists are validated in CI (`subagents_test.go`) so a tool rename
+  can't silently drop a subagent's access. Programmatic access:
+  `claudecode.SubAgentTools(def)` parses an allowlist out of a definition.
+- **Session-inheriting hosts** (e.g. `opencode`): subagents inherit the
+  *parent's* MCP session at the client level, so they see Gortex tools
+  transparently **only if the host propagates the session to the child**.
+  This is a client-side behaviour — Gortex configures the MCP server for
+  the host but cannot force a client to share its session with a subagent.
+- **Hosts with no subagent concept**: the question does not arise; the
+  single agent already holds the configured Gortex tools.
+
+If a subagent reports it cannot see `mcp__gortex__*` tools, check the
+subagent's own tool allowlist first — that is where propagation is
+decided, not the server.
+
 ## Common CLI flags
 
 ```

--- a/go.mod
+++ b/go.mod
@@ -241,6 +241,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.3.1
 	github.com/pkoukk/tiktoken-go v0.1.8
 	github.com/pkoukk/tiktoken-go-loader v0.0.2
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/sgtdi/fswatcher v1.3.0
 	github.com/spf13/cobra v1.10.2
@@ -346,7 +347,6 @@ require (
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect

--- a/internal/agents/claudecode/hooks.go
+++ b/internal/agents/claudecode/hooks.go
@@ -148,7 +148,7 @@ func HookCommandPathIsEphemeral(cmd string) bool {
 // entries whose path is healthy are also left alone.
 func healStaleHookCommands(hooks map[string]any, newCommand string) int {
 	healed := 0
-	for _, event := range []string{"PreToolUse", "PreCompact", "Stop", "SessionStart"} {
+	for _, event := range []string{"PreToolUse", "PreCompact", "Stop", "SessionStart", "UserPromptSubmit"} {
 		list, ok := hooks[event].([]any)
 		if !ok {
 			continue
@@ -303,7 +303,7 @@ func commandInvokesGortexHook(cmd string) bool {
 // rewritten entries.
 func rewriteGortexHookMode(hooks map[string]any, newCommand string) int {
 	rewritten := 0
-	for _, event := range []string{"PreToolUse", "PostToolUse", "PreCompact", "Stop", "SessionStart"} {
+	for _, event := range []string{"PreToolUse", "PostToolUse", "PreCompact", "Stop", "SessionStart", "UserPromptSubmit"} {
 		list, ok := hooks[event].([]any)
 		if !ok {
 			continue
@@ -443,7 +443,8 @@ func InstallHookWithMode(w io.Writer, settingsPath string, mode string, opts age
 		dedupGortexEntries(hooks, "PreCompact") +
 		dedupGortexEntries(hooks, "PostToolUse") +
 		dedupGortexEntries(hooks, "Stop") +
-		dedupGortexEntries(hooks, "SessionStart")
+		dedupGortexEntries(hooks, "SessionStart") +
+		dedupGortexEntries(hooks, "UserPromptSubmit")
 
 	// PostToolUse is only present when mode=enrich. Removing it on a
 	// switch to any other posture keeps settings.json clean — agents
@@ -457,6 +458,7 @@ func InstallHookWithMode(w io.Writer, settingsPath string, mode string, opts age
 	preCompactInstalled := hasGortexHookEntry(hooks, "PreCompact")
 	stopInstalled := hasGortexHookEntry(hooks, "Stop")
 	sessionStartInstalled := hasGortexHookEntry(hooks, "SessionStart")
+	userPromptSubmitInstalled := hasGortexHookEntry(hooks, "UserPromptSubmit")
 	postToolUseInstalled := hasGortexHookEntry(hooks, "PostToolUse")
 
 	if !preToolUseInstalled {
@@ -512,6 +514,22 @@ func InstallHookWithMode(w io.Writer, settingsPath string, mode string, opts age
 			},
 		})
 	}
+	if !userPromptSubmitInstalled {
+		// UserPromptSubmit fires before every user turn — the moment to
+		// proactively inject graph symbols relevant to the prompt so the
+		// model reaches for Gortex instead of grepping. It is best-effort
+		// and time-bounded; a miss is a silent no-op.
+		appendHookEntry(hooks, "UserPromptSubmit", map[string]any{
+			"hooks": []any{
+				map[string]any{
+					"type":          "command",
+					"command":       hookCommand,
+					"timeout":       3000,
+					"statusMessage": "Surfacing relevant Gortex symbols...",
+				},
+			},
+		})
+	}
 	// PostToolUse is only installed in enrich mode. It augments
 	// Grep / Glob / Read responses with graph context (enclosing
 	// symbols, file footprints) so the agent sees the graph value
@@ -533,7 +551,7 @@ func InstallHookWithMode(w io.Writer, settingsPath string, mode string, opts age
 	}
 
 	allPresent := preToolUseInstalled && preCompactInstalled && stopInstalled && sessionStartInstalled &&
-		(mode != HookModeEnrich || postToolUseInstalled)
+		userPromptSubmitInstalled && (mode != HookModeEnrich || postToolUseInstalled)
 	noChanges := allPresent && !matcherUpgraded && dedupedCount == 0 && healedCount == 0 &&
 		modeRewriteCount == 0 && postToolUseRemoved == 0 && !postToolUseAdded
 	if noChanges {
@@ -582,6 +600,9 @@ func InstallHookWithMode(w io.Writer, settingsPath string, mode string, opts age
 	}
 	if !sessionStartInstalled {
 		changes = append(changes, "installed SessionStart")
+	}
+	if !userPromptSubmitInstalled {
+		changes = append(changes, "installed UserPromptSubmit")
 	}
 	if postToolUseAdded {
 		changes = append(changes, "installed PostToolUse (enrich mode)")

--- a/internal/agents/claudecode/hooks_test.go
+++ b/internal/agents/claudecode/hooks_test.go
@@ -399,6 +399,21 @@ func TestInstallHookWithMode_DenyMode(t *testing.T) {
 		"deny mode keeps the bare command — no --mode flag")
 }
 
+func TestInstallHook_InstallsUserPromptSubmit(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.local.json")
+	t.Setenv("PATH", t.TempDir()) // force fallback to bare "gortex hook"
+
+	_, err := InstallHookWithMode(io.Discard, settingsPath, HookModeDeny, agentsApplyOptsZero())
+	require.NoError(t, err)
+
+	hooks := readSettingsHooks(t, settingsPath)
+	require.Contains(t, hooks, "UserPromptSubmit",
+		"UserPromptSubmit hook must be installed for per-turn context injection")
+	cmd := extractCmd(t, hooks, "UserPromptSubmit", 0)
+	assert.Equal(t, "gortex hook", cmd)
+}
+
 func TestInstallHookWithMode_EnrichMode(t *testing.T) {
 	dir := t.TempDir()
 	settingsPath := filepath.Join(dir, "settings.local.json")

--- a/internal/agents/claudecode/subagents.go
+++ b/internal/agents/claudecode/subagents.go
@@ -1,5 +1,7 @@
 package claudecode
 
+import "strings"
+
 // SubAgents maps the filename under .claude/agents/ to the markdown
 // body of a Claude Code sub-agent definition.
 //
@@ -16,8 +18,32 @@ package claudecode
 // ~/.claude/agents/ and emitted into the marketplace plugin under
 // agents/ — never written in project mode.
 var SubAgents = map[string]string{
-	"gortex-search.md":  subagentSearch,
-	"gortex-impact.md":  subagentImpact,
+	"gortex-search.md": subagentSearch,
+	"gortex-impact.md": subagentImpact,
+}
+
+// SubAgentTools parses the `tools:` allowlist out of a sub-agent definition's
+// YAML frontmatter, returning the declared MCP tool names in order (nil when
+// the definition declares no tools line). Claude Code spawns each sub-agent in
+// a fresh context restricted to exactly this allowlist, so the list is how
+// Gortex propagates its MCP tools to sub-agents — and how it guarantees a
+// sub-agent stays graph-only (no Bash/Grep/Glob escape).
+func SubAgentTools(def string) []string {
+	for _, line := range strings.Split(def, "\n") {
+		t := strings.TrimSpace(line)
+		if !strings.HasPrefix(t, "tools:") {
+			continue
+		}
+		rest := strings.TrimSpace(strings.TrimPrefix(t, "tools:"))
+		var out []string
+		for _, name := range strings.Split(rest, ",") {
+			if n := strings.TrimSpace(name); n != "" {
+				out = append(out, n)
+			}
+		}
+		return out
+	}
+	return nil
 }
 
 // subagentSearch handles exploratory codebase questions: locating

--- a/internal/agents/claudecode/subagents_test.go
+++ b/internal/agents/claudecode/subagents_test.go
@@ -1,0 +1,50 @@
+package claudecode
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSubAgentToolPropagation locks in the invariant that every Gortex
+// sub-agent declares an explicit, graph-only MCP tool allowlist — the
+// mechanism by which Gortex propagates its tools to sub-agents and prevents a
+// sub-agent from escaping to Bash/Grep/Glob.
+func TestSubAgentToolPropagation(t *testing.T) {
+	require.Contains(t, SubAgents, "gortex-search.md")
+	require.Contains(t, SubAgents, "gortex-impact.md")
+
+	for name, def := range SubAgents {
+		t.Run(name, func(t *testing.T) {
+			tools := SubAgentTools(def)
+			require.NotEmpty(t, tools,
+				"%s must declare a tools allowlist so the sub-agent inherits Gortex tools", name)
+
+			seen := map[string]bool{}
+			for _, tool := range tools {
+				require.Truef(t, strings.HasPrefix(tool, "mcp__gortex__"),
+					"%s lists non-gortex tool %q — the allowlist must be graph-only (no Bash/Grep/Glob escape)", name, tool)
+				require.Falsef(t, seen[tool], "%s lists duplicate tool %q", name, tool)
+				seen[tool] = true
+			}
+			// smart_context is the shared entry point every sub-agent should hold.
+			require.Truef(t, seen["mcp__gortex__smart_context"],
+				"%s should grant smart_context (the one-call working-set entry point)", name)
+		})
+	}
+}
+
+// TestSubAgentFrontmatterNameMatchesFile guards against a rename drifting the
+// frontmatter `name:` away from the installed filename.
+func TestSubAgentFrontmatterNameMatchesFile(t *testing.T) {
+	for name, def := range SubAgents {
+		base := strings.TrimSuffix(name, ".md")
+		require.Containsf(t, def, "name: "+base,
+			"%s frontmatter name must match its filename", name)
+	}
+}
+
+func TestSubAgentToolsParsesEmpty(t *testing.T) {
+	require.Nil(t, SubAgentTools("---\nname: x\ndescription: no tools line\n---\nbody"))
+}

--- a/internal/graph/node.go
+++ b/internal/graph/node.go
@@ -226,6 +226,15 @@ const (
 	// otherwise be hidden behind macro expansion (a call site `SQ(2)`
 	// resolves to the macro, whose body-calls then continue the chain).
 	KindMacro NodeKind = "macro"
+	// KindAgent represents a live coding agent participating in a
+	// multi-agent session — a first-class, queryable presence entity
+	// distinct from a transport session. ID convention: `agent::<id>`.
+	// Carries Meta["cursor"] (the symbol/file the agent is focused on),
+	// Meta["status"], Meta["locked_paths"], and Meta["last_seen"]. Agent
+	// presence is volatile and lives in an in-memory registry rather than
+	// the persistent code graph; this kind names the entity so it reads as
+	// first-class in tool output and query filters.
+	KindAgent NodeKind = "agent"
 )
 
 var validNodeKinds = map[NodeKind]bool{
@@ -242,7 +251,7 @@ var validNodeKinds = map[NodeKind]bool{
 	KindRelease: true, KindLicense: true, KindString: true,
 	KindResource: true, KindKustomization: true, KindImage: true,
 	KindArtifact: true, KindDoc: true, KindTopic: true,
-	KindMacro: true,
+	KindMacro: true, KindAgent: true,
 }
 
 type Node struct {

--- a/internal/hooks/dispatch.go
+++ b/internal/hooks/dispatch.go
@@ -117,5 +117,7 @@ func Run(port int, mode Mode) {
 		runPostTask(data, port)
 	case "SessionStart":
 		runSessionStart(data)
+	case "UserPromptSubmit":
+		runUserPromptSubmit(data)
 	}
 }

--- a/internal/hooks/userpromptsubmit.go
+++ b/internal/hooks/userpromptsubmit.go
@@ -1,0 +1,112 @@
+package hooks
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// UserPromptSubmitInput is the JSON Claude Code sends on UserPromptSubmit. We
+// only consume the fields we use; unknown fields are ignored.
+type UserPromptSubmitInput struct {
+	HookEventName string `json:"hook_event_name"`
+	SessionID     string `json:"session_id"`
+	CWD           string `json:"cwd"`
+	Prompt        string `json:"prompt"`
+}
+
+// userPromptProbeTimeout bounds the pre-turn context probe. It runs on every
+// user turn, so it must be fast and must never block the turn.
+const userPromptProbeTimeout = 800 * time.Millisecond
+
+// maxInjectedHits caps how many relevant symbols are injected per turn so the
+// block stays a nudge, not a wall of text.
+const maxInjectedHits = 6
+
+// runUserPromptSubmit handles a UserPromptSubmit hook: it proactively searches
+// the graph for symbols relevant to the user's prompt and injects them as
+// additionalContext, so the model reaches for Gortex's knowledge instead of
+// blindly grepping. It is best-effort — any miss (daemon down, no hits, a
+// trivial / non-code prompt) is a silent no-op so the turn is never blocked or
+// polluted, and no warning is emitted (SessionStart already warns once when the
+// daemon is down; doing so every turn would be noise).
+func runUserPromptSubmit(data []byte) {
+	var input UserPromptSubmitInput
+	if err := json.Unmarshal(data, &input); err != nil {
+		return
+	}
+	if input.HookEventName != "UserPromptSubmit" {
+		return
+	}
+	query := promptQuery(input.Prompt)
+	if query == "" {
+		return
+	}
+	hits, err := probeViaDaemon(query, userPromptProbeTimeout)
+	if err != nil || len(hits) == 0 {
+		return
+	}
+	block := buildPromptInjection(hits)
+	if block == "" {
+		return
+	}
+	out, err := json.Marshal(HookOutput{
+		HookSpecificOutput: &HookSpecificOutput{
+			HookEventName:     "UserPromptSubmit",
+			AdditionalContext: block,
+		},
+	})
+	if err != nil {
+		return
+	}
+	fmt.Print(string(out))
+}
+
+// promptQuery normalizes a raw prompt into a search query, or "" when the
+// prompt is too trivial / not code-related to bother probing. Slash commands
+// and one-word acknowledgements ("ok", "go on") are skipped.
+func promptQuery(prompt string) string {
+	p := strings.TrimSpace(prompt)
+	if p == "" || strings.HasPrefix(p, "/") {
+		return ""
+	}
+	p = strings.Join(strings.Fields(p), " ") // collapse newlines / runs of spaces
+	if r := []rune(p); len(r) > 240 {
+		p = strings.TrimSpace(string(r[:240]))
+	}
+	// Require at least one token of length >= 3 so "ok", "yes" don't probe.
+	for _, w := range strings.Fields(p) {
+		if len(w) >= 3 {
+			return p
+		}
+	}
+	return ""
+}
+
+// buildPromptInjection renders the additionalContext block from search hits.
+func buildPromptInjection(hits []grepSymbolHit) string {
+	if len(hits) == 0 {
+		return ""
+	}
+	if len(hits) > maxInjectedHits {
+		hits = hits[:maxInjectedHits]
+	}
+	var sb strings.Builder
+	sb.WriteString("## Gortex — relevant indexed symbols for your request\n\n")
+	sb.WriteString("Before reaching for grep/Read, these graph symbols look relevant to what you just asked:\n\n")
+	for _, h := range hits {
+		kind := h.Kind
+		if kind == "" {
+			kind = "symbol"
+		}
+		if h.Line > 0 {
+			fmt.Fprintf(&sb, "- `%s` (%s) — %s:%d\n", h.Name, kind, h.FilePath, h.Line)
+		} else {
+			fmt.Fprintf(&sb, "- `%s` (%s) — %s\n", h.Name, kind, h.FilePath)
+		}
+	}
+	sb.WriteString("\nRead any of them with `get_symbol_source`, trace with `find_usages` / `get_callers`, " +
+		"or call `smart_context` for the full working set. These are indexed graph facts — prefer them over grep/Read.\n")
+	return sb.String()
+}

--- a/internal/hooks/userpromptsubmit_test.go
+++ b/internal/hooks/userpromptsubmit_test.go
@@ -1,0 +1,70 @@
+package hooks
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPromptQuery(t *testing.T) {
+	cases := []struct {
+		name   string
+		prompt string
+		want   string
+	}{
+		{"empty", "", ""},
+		{"whitespace", "   \n  ", ""},
+		{"slash command", "/clear", ""},
+		{"short ack", "ok", ""},
+		{"two-letter word", "go", ""},
+		{"normal task", "fix the auth bug", "fix the auth bug"},
+		{"collapses whitespace", "fix\n\n  the   bug", "fix the bug"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, promptQuery(tc.prompt))
+		})
+	}
+}
+
+func TestPromptQueryTruncatesLongPrompts(t *testing.T) {
+	long := strings.Repeat("token ", 100) // ~600 chars
+	got := promptQuery(long)
+	require.LessOrEqual(t, len([]rune(got)), 240)
+	require.NotEmpty(t, got)
+}
+
+func TestBuildPromptInjection(t *testing.T) {
+	require.Equal(t, "", buildPromptInjection(nil), "no hits → no block")
+
+	hits := []grepSymbolHit{
+		{Name: "ValidateToken", Kind: "function", FilePath: "internal/auth/token.go", Line: 42},
+		{Name: "AuthMiddleware", Kind: "type", FilePath: "internal/auth/mw.go"}, // no line
+	}
+	block := buildPromptInjection(hits)
+	require.Contains(t, block, "relevant indexed symbols")
+	require.Contains(t, block, "`ValidateToken` (function) — internal/auth/token.go:42")
+	require.Contains(t, block, "`AuthMiddleware` (type) — internal/auth/mw.go")
+	require.Contains(t, block, "smart_context")
+}
+
+func TestBuildPromptInjectionCapsHits(t *testing.T) {
+	var hits []grepSymbolHit
+	for i := 0; i < 20; i++ {
+		hits = append(hits, grepSymbolHit{Name: "Sym", Kind: "function", FilePath: "f.go", Line: i + 1})
+	}
+	block := buildPromptInjection(hits)
+	require.Equal(t, maxInjectedHits, strings.Count(block, "- `Sym`"), "injection is capped")
+}
+
+// TestRunUserPromptSubmitTrivialPromptIsNoOp confirms a trivial prompt never
+// even probes the daemon (and so produces no output).
+func TestRunUserPromptSubmitTrivialPromptIsNoOp(t *testing.T) {
+	// A slash command produces an empty query → early return, no panic, no
+	// daemon dial. We assert it doesn't panic and returns cleanly.
+	runUserPromptSubmit([]byte(`{"hook_event_name":"UserPromptSubmit","prompt":"/clear"}`))
+	runUserPromptSubmit([]byte(`{"hook_event_name":"UserPromptSubmit","prompt":"ok"}`))
+	// Wrong event name is also a no-op.
+	runUserPromptSubmit([]byte(`{"hook_event_name":"SessionStart","prompt":"do something big"}`))
+}

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -1,0 +1,188 @@
+// Package lint runs external language linters/formatters against a single file
+// and normalizes their output into structured diagnostics. It is the engine
+// behind the lint_file MCP tool: an LSP-free, on-demand syntax/lint check that
+// complements the LSP-backed diagnostics path. A linter that is not installed
+// is reported as skipped — never as a hard error — so the bridge degrades
+// gracefully on machines that lack a given tool.
+package lint
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Severity is the normalized severity of a diagnostic across linters.
+type Severity string
+
+const (
+	SeverityError   Severity = "error"
+	SeverityWarning Severity = "warning"
+	SeverityInfo    Severity = "info"
+)
+
+// Diagnostic is one normalized linter finding.
+type Diagnostic struct {
+	File     string   `json:"file"`
+	Line     int      `json:"line"`
+	Column   int      `json:"column,omitempty"`
+	Severity Severity `json:"severity"`
+	Message  string   `json:"message"`
+	Rule     string   `json:"rule,omitempty"`
+	Linter   string   `json:"linter"`
+}
+
+// parserKind selects how a linter's output is normalized.
+type parserKind int
+
+const (
+	parseGCC       parserKind = iota // file:line[:col]: message
+	parseShellcheck                  // file:line:col: severity: message [SCxxxx]
+	parseRuffJSON                    // ruff --output-format=json
+)
+
+// Linter describes one external tool invocation.
+type Linter struct {
+	Name      string
+	Languages []string
+	Bin       string
+	// Args is the command line; the literal token "{file}" is replaced with
+	// the absolute path of the file being linted.
+	Args      []string
+	parser    parserKind
+	useStderr bool // parse stderr instead of stdout (gofmt prints errors there)
+}
+
+// Available reports whether the linter's binary is on PATH.
+func (l Linter) Available() bool {
+	_, err := exec.LookPath(l.Bin)
+	return err == nil
+}
+
+// DefaultLinters returns the built-in linter set. Each entry runs read-only
+// and reports diagnostics without modifying the file.
+func DefaultLinters() []Linter {
+	return []Linter{
+		// gofmt -e parses the file and prints any syntax error to stderr as
+		// `file:line:col: message`; the reformatted source on stdout is ignored.
+		{Name: "gofmt", Languages: []string{"go"}, Bin: "gofmt", Args: []string{"-e", "{file}"}, parser: parseGCC, useStderr: true},
+		{Name: "shellcheck", Languages: []string{"shell"}, Bin: "shellcheck", Args: []string{"-f", "gcc", "{file}"}, parser: parseShellcheck},
+		{Name: "ruff", Languages: []string{"python"}, Bin: "ruff", Args: []string{"check", "--output-format=json", "{file}"}, parser: parseRuffJSON},
+	}
+}
+
+// Skipped records a linter that did not run and why.
+type Skipped struct {
+	Linter string `json:"linter"`
+	Reason string `json:"reason"`
+}
+
+// Result is the outcome of linting one file.
+type Result struct {
+	Language    string       `json:"language"`
+	Diagnostics []Diagnostic `json:"diagnostics"`
+	Ran         []string     `json:"linters_ran"`
+	Skipped     []Skipped    `json:"linters_skipped"`
+}
+
+// Registry holds the linters available to Run.
+type Registry struct {
+	linters []Linter
+}
+
+// NewRegistry builds a registry from the given linters, or the built-in set
+// when none are supplied. Passing custom linters is the extension point for
+// config-defined tools.
+func NewRegistry(linters ...Linter) *Registry {
+	if len(linters) == 0 {
+		linters = DefaultLinters()
+	}
+	return &Registry{linters: linters}
+}
+
+const defaultTimeout = 5 * time.Second
+
+// ForLanguage returns the registered linters that target lang.
+func (r *Registry) ForLanguage(lang string) []Linter {
+	var out []Linter
+	for _, l := range r.linters {
+		for _, lg := range l.Languages {
+			if lg == lang {
+				out = append(out, l)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// Run executes every registered linter for lang against absPath and returns
+// normalized diagnostics. A linter that is not installed, or that fails to
+// start / times out, is recorded in Skipped — it never fails the call. A
+// non-zero exit (the normal signal that a linter found issues) is not an
+// error. timeout <= 0 uses the default.
+func (r *Registry) Run(ctx context.Context, absPath, lang string, timeout time.Duration) Result {
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
+	res := Result{Language: lang, Diagnostics: []Diagnostic{}, Ran: []string{}, Skipped: []Skipped{}}
+	for _, l := range r.ForLanguage(lang) {
+		if !l.Available() {
+			res.Skipped = append(res.Skipped, Skipped{Linter: l.Name, Reason: "not installed (" + l.Bin + " not on PATH)"})
+			continue
+		}
+		diags, err := runOne(ctx, l, absPath, timeout)
+		if err != nil {
+			res.Skipped = append(res.Skipped, Skipped{Linter: l.Name, Reason: err.Error()})
+			continue
+		}
+		res.Ran = append(res.Ran, l.Name)
+		res.Diagnostics = append(res.Diagnostics, diags...)
+	}
+	return res
+}
+
+func runOne(ctx context.Context, l Linter, absPath string, timeout time.Duration) ([]Diagnostic, error) {
+	cctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	args := make([]string, len(l.Args))
+	for i, a := range l.Args {
+		args[i] = strings.ReplaceAll(a, "{file}", absPath)
+	}
+	cmd := exec.CommandContext(cctx, l.Bin, args...)
+	cmd.Dir = filepath.Dir(absPath) // so per-project linter config is discovered
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+
+	if cctx.Err() == context.DeadlineExceeded {
+		return nil, fmt.Errorf("timed out after %s", timeout)
+	}
+	if runErr != nil {
+		// A non-zero exit is how a linter signals it found issues — expected.
+		// Only a genuine start failure (binary vanished, etc.) is an error.
+		if _, ok := runErr.(*exec.ExitError); !ok {
+			return nil, runErr
+		}
+	}
+
+	switch l.parser {
+	case parseRuffJSON:
+		return parseRuff(stdout.Bytes(), l.Name), nil
+	case parseShellcheck:
+		return parseShellcheckGCC(stdout.Bytes(), l.Name), nil
+	default:
+		out := stdout.Bytes()
+		if l.useStderr {
+			out = stderr.Bytes()
+		}
+		return parseGCCFormat(out, l.Name), nil
+	}
+}

--- a/internal/lint/lint_test.go
+++ b/internal/lint/lint_test.go
@@ -1,0 +1,94 @@
+package lint
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLanguageForPath(t *testing.T) {
+	require.Equal(t, "go", LanguageForPath("a/b/main.go"))
+	require.Equal(t, "python", LanguageForPath("x.py"))
+	require.Equal(t, "shell", LanguageForPath("deploy.sh"))
+	require.Equal(t, "shell", LanguageForPath("X.BASH")) // case-insensitive
+	require.Equal(t, "", LanguageForPath("notes.txt"))
+}
+
+func TestParseGCCFormat(t *testing.T) {
+	out := "main.go:3:5: expected '}', found EOF\nmain.go:1: bad\n\n"
+	diags := parseGCCFormat([]byte(out), "gofmt")
+	require.Len(t, diags, 2)
+	require.Equal(t, 3, diags[0].Line)
+	require.Equal(t, 5, diags[0].Column)
+	require.Equal(t, SeverityError, diags[0].Severity)
+	require.Equal(t, "expected '}', found EOF", diags[0].Message)
+	require.Equal(t, "gofmt", diags[0].Linter)
+	require.Equal(t, 1, diags[1].Line)
+	require.Equal(t, 0, diags[1].Column, "missing column parses as 0")
+}
+
+func TestParseShellcheckGCC(t *testing.T) {
+	out := "deploy.sh:2:1: warning: x is referenced but not assigned [SC2154]\n" +
+		"deploy.sh:5:3: error: syntax error [SC1009]\n"
+	diags := parseShellcheckGCC([]byte(out), "shellcheck")
+	require.Len(t, diags, 2)
+	require.Equal(t, SeverityWarning, diags[0].Severity)
+	require.Equal(t, "SC2154", diags[0].Rule)
+	require.Equal(t, 2, diags[0].Line)
+	require.Equal(t, SeverityError, diags[1].Severity)
+	require.Equal(t, "SC1009", diags[1].Rule)
+}
+
+func TestParseRuff(t *testing.T) {
+	out := `[
+	  {"code":"F401","message":"unused import","filename":"a.py","location":{"row":1,"column":8}},
+	  {"code":null,"message":"SyntaxError: invalid syntax","filename":"a.py","location":{"row":3,"column":1}}
+	]`
+	diags := parseRuff([]byte(out), "ruff")
+	require.Len(t, diags, 2)
+	require.Equal(t, SeverityWarning, diags[0].Severity)
+	require.Equal(t, "F401", diags[0].Rule)
+	require.Equal(t, SeverityError, diags[1].Severity, "a null-code SyntaxError is an error")
+	require.Empty(t, parseRuff([]byte("  "), "ruff"))
+}
+
+func TestRunSkipsMissingLinter(t *testing.T) {
+	reg := NewRegistry(Linter{
+		Name: "ghostlinter", Languages: []string{"go"},
+		Bin: "gortex-nonexistent-linter-xyz", Args: []string{"{file}"}, parser: parseGCC,
+	})
+	res := reg.Run(context.Background(), "/tmp/x.go", "go", time.Second)
+	require.Empty(t, res.Ran)
+	require.Len(t, res.Skipped, 1)
+	require.Equal(t, "ghostlinter", res.Skipped[0].Linter)
+	require.Contains(t, res.Skipped[0].Reason, "not installed")
+}
+
+// TestRunGofmtEndToEnd exercises a real gofmt invocation on a broken and a
+// clean Go file. Skips when gofmt is not on PATH.
+func TestRunGofmtEndToEnd(t *testing.T) {
+	reg := NewRegistry()
+	gofmt := reg.ForLanguage("go")
+	require.NotEmpty(t, gofmt)
+	if !gofmt[0].Available() {
+		t.Skip("gofmt not on PATH")
+	}
+
+	dir := t.TempDir()
+	broken := filepath.Join(dir, "broken.go")
+	require.NoError(t, os.WriteFile(broken, []byte("package main\n\nfunc main() {\n"), 0o644))
+	res := reg.Run(context.Background(), broken, "go", 5*time.Second)
+	require.Contains(t, res.Ran, "gofmt")
+	require.NotEmpty(t, res.Diagnostics, "gofmt should report the missing brace")
+	require.Equal(t, SeverityError, res.Diagnostics[0].Severity)
+
+	clean := filepath.Join(dir, "clean.go")
+	require.NoError(t, os.WriteFile(clean, []byte("package main\n\nfunc main() {}\n"), 0o644))
+	res = reg.Run(context.Background(), clean, "go", 5*time.Second)
+	require.Contains(t, res.Ran, "gofmt")
+	require.Empty(t, res.Diagnostics, "a clean file yields no diagnostics")
+}

--- a/internal/lint/parse.go
+++ b/internal/lint/parse.go
@@ -1,0 +1,142 @@
+package lint
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// extLang maps file extensions to the linter languages this package supports.
+var extLang = map[string]string{
+	".go":   "go",
+	".py":   "python",
+	".pyi":  "python",
+	".sh":   "shell",
+	".bash": "shell",
+	".zsh":  "shell",
+	".ksh":  "shell",
+}
+
+// LanguageForPath infers the linter language from a file's extension, or "" if
+// no built-in linter targets that type.
+func LanguageForPath(p string) string {
+	return extLang[strings.ToLower(filepath.Ext(p))]
+}
+
+// gccLineRe matches the `file:line[:col]: message` convention emitted by gofmt
+// -e and many other compilers/linters.
+var gccLineRe = regexp.MustCompile(`^(.*?):(\d+):(?:(\d+):)?\s*(.*)$`)
+
+func parseGCCFormat(out []byte, linter string) []Diagnostic {
+	var diags []Diagnostic
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimRight(line, "\r")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		m := gccLineRe.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		ln, _ := strconv.Atoi(m[2])
+		col := 0
+		if m[3] != "" {
+			col, _ = strconv.Atoi(m[3])
+		}
+		diags = append(diags, Diagnostic{
+			File:     m[1],
+			Line:     ln,
+			Column:   col,
+			Severity: SeverityError,
+			Message:  strings.TrimSpace(m[4]),
+			Linter:   linter,
+		})
+	}
+	return diags
+}
+
+// shellcheckRe matches shellcheck's `-f gcc` output:
+// `file:line:col: severity: message [SCxxxx]`.
+var shellcheckRe = regexp.MustCompile(`^(.*?):(\d+):(\d+):\s*(\w+):\s*(.*?)(?:\s*\[(SC\d+)\])?$`)
+
+func parseShellcheckGCC(out []byte, linter string) []Diagnostic {
+	var diags []Diagnostic
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimRight(line, "\r")
+		m := shellcheckRe.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		ln, _ := strconv.Atoi(m[2])
+		col, _ := strconv.Atoi(m[3])
+		diags = append(diags, Diagnostic{
+			File:     m[1],
+			Line:     ln,
+			Column:   col,
+			Severity: shellcheckSeverity(m[4]),
+			Message:  strings.TrimSpace(m[5]),
+			Rule:     m[6],
+			Linter:   linter,
+		})
+	}
+	return diags
+}
+
+func shellcheckSeverity(s string) Severity {
+	switch strings.ToLower(s) {
+	case "error":
+		return SeverityError
+	case "warning":
+		return SeverityWarning
+	default: // note, style, info
+		return SeverityInfo
+	}
+}
+
+type ruffEntry struct {
+	Code     string `json:"code"`
+	Message  string `json:"message"`
+	Filename string `json:"filename"`
+	Location struct {
+		Row    int `json:"row"`
+		Column int `json:"column"`
+	} `json:"location"`
+}
+
+func parseRuff(out []byte, linter string) []Diagnostic {
+	out = bytes.TrimSpace(out)
+	if len(out) == 0 {
+		return nil
+	}
+	var entries []ruffEntry
+	if err := json.Unmarshal(out, &entries); err != nil {
+		return nil
+	}
+	diags := make([]Diagnostic, 0, len(entries))
+	for _, e := range entries {
+		diags = append(diags, Diagnostic{
+			File:     e.Filename,
+			Line:     e.Location.Row,
+			Column:   e.Location.Column,
+			Severity: ruffSeverity(e.Code, e.Message),
+			Message:  e.Message,
+			Rule:     e.Code,
+			Linter:   linter,
+		})
+	}
+	return diags
+}
+
+// ruffSeverity treats syntax errors (E999, the E9 class, or a SyntaxError
+// message — ruff emits these with a null code) as errors; everything else is a
+// lint warning.
+func ruffSeverity(code, message string) Severity {
+	if code == "" || strings.HasPrefix(code, "E9") ||
+		strings.Contains(strings.ToLower(message), "syntaxerror") {
+		return SeverityError
+	}
+	return SeverityWarning
+}

--- a/internal/mcp/agent_registry.go
+++ b/internal/mcp/agent_registry.go
@@ -1,0 +1,373 @@
+package mcp
+
+import (
+	"context"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// agentTTL is how long an agent survives without a heartbeat before it is
+// pruned from the registry as dead.
+const agentTTL = 2 * time.Minute
+
+// agentRecord is the live presence of one coding agent in a multi-agent
+// session. Presence is volatile (heartbeat-driven), so it lives in this
+// in-memory registry rather than the persistent code graph; the graph.KindAgent
+// kind names the entity so it reads as first-class in tool output.
+type agentRecord struct {
+	ID          string
+	Name        string
+	Cursor      string // symbol ID / file the agent is focused on
+	Status      string // free-form: editing, reviewing, idle, ...
+	LockedPaths []string
+	SessionID   string
+	LastSeen    time.Time
+}
+
+func (a *agentRecord) clone() *agentRecord {
+	cp := *a
+	cp.LockedPaths = append([]string(nil), a.LockedPaths...)
+	return &cp
+}
+
+// pathConflict reports a path an agent tried to lock that another live agent
+// already holds.
+type pathConflict struct {
+	Path   string `json:"path"`
+	HeldBy string `json:"held_by"`
+}
+
+// agentRegistry is a thread-safe, heartbeat-expiring registry of live agents
+// plus their advisory path locks. Locks are cooperative: lock() reports
+// conflicts but never blocks — it is up to agents to honour them.
+type agentRegistry struct {
+	mu     sync.Mutex
+	agents map[string]*agentRecord
+	ttl    time.Duration
+	now    func() time.Time
+}
+
+func newAgentRegistry() *agentRegistry {
+	return &agentRegistry{
+		agents: map[string]*agentRecord{},
+		ttl:    agentTTL,
+		now:    time.Now,
+	}
+}
+
+// prune drops agents whose last heartbeat is older than the TTL. Caller holds mu.
+func (r *agentRegistry) prune() {
+	cutoff := r.now().Add(-r.ttl)
+	for id, a := range r.agents {
+		if a.LastSeen.Before(cutoff) {
+			delete(r.agents, id)
+		}
+	}
+}
+
+func (r *agentRegistry) register(id, name, cursor, status, sessionID string, paths []string) *agentRecord {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.prune()
+	if id == "" {
+		if sessionID != "" {
+			id = sessionID
+		} else {
+			id = name
+		}
+	}
+	a := r.agents[id]
+	if a == nil {
+		a = &agentRecord{ID: id}
+		r.agents[id] = a
+	}
+	if name != "" {
+		a.Name = name
+	}
+	if sessionID != "" {
+		a.SessionID = sessionID
+	}
+	if cursor != "" {
+		a.Cursor = cursor
+	}
+	if status != "" {
+		a.Status = status
+	}
+	for _, p := range paths {
+		a.LockedPaths = addPath(a.LockedPaths, normalizeLockPath(p))
+	}
+	a.LastSeen = r.now()
+	return a.clone()
+}
+
+func (r *agentRegistry) heartbeat(id, cursor, status string) (*agentRecord, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.prune()
+	a := r.agents[id]
+	if a == nil {
+		return nil, false
+	}
+	if cursor != "" {
+		a.Cursor = cursor
+	}
+	if status != "" {
+		a.Status = status
+	}
+	a.LastSeen = r.now()
+	return a.clone(), true
+}
+
+func (r *agentRegistry) lock(id string, paths []string) (locked []string, conflicts []pathConflict, found bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.prune()
+	a := r.agents[id]
+	if a == nil {
+		return nil, nil, false
+	}
+	a.LastSeen = r.now()
+
+	owned := map[string]string{} // path -> other agent id
+	for oid, oa := range r.agents {
+		if oid == id {
+			continue
+		}
+		for _, p := range oa.LockedPaths {
+			owned[p] = oid
+		}
+	}
+	for _, raw := range paths {
+		p := normalizeLockPath(raw)
+		if p == "" {
+			continue
+		}
+		if other, taken := owned[p]; taken {
+			conflicts = append(conflicts, pathConflict{Path: p, HeldBy: other})
+			continue
+		}
+		a.LockedPaths = addPath(a.LockedPaths, p)
+		locked = append(locked, p)
+	}
+	return locked, conflicts, true
+}
+
+func (r *agentRegistry) unlock(id string, paths []string) (*agentRecord, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.prune()
+	a := r.agents[id]
+	if a == nil {
+		return nil, false
+	}
+	a.LastSeen = r.now()
+	if len(paths) == 0 {
+		a.LockedPaths = nil
+	} else {
+		drop := map[string]bool{}
+		for _, p := range paths {
+			drop[normalizeLockPath(p)] = true
+		}
+		kept := a.LockedPaths[:0]
+		for _, p := range a.LockedPaths {
+			if !drop[p] {
+				kept = append(kept, p)
+			}
+		}
+		a.LockedPaths = append([]string(nil), kept...)
+	}
+	return a.clone(), true
+}
+
+func (r *agentRegistry) unregister(id string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.prune()
+	if _, ok := r.agents[id]; !ok {
+		return false
+	}
+	delete(r.agents, id)
+	return true
+}
+
+func (r *agentRegistry) list() []*agentRecord {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.prune()
+	out := make([]*agentRecord, 0, len(r.agents))
+	for _, a := range r.agents {
+		out = append(out, a.clone())
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out
+}
+
+func addPath(paths []string, p string) []string {
+	if p == "" {
+		return paths
+	}
+	for _, e := range paths {
+		if e == p {
+			return paths
+		}
+	}
+	return append(paths, p)
+}
+
+func normalizeLockPath(p string) string {
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return ""
+	}
+	return filepath.ToSlash(filepath.Clean(p))
+}
+
+// view renders an agent as a graph.KindAgent-shaped node for tool output, so
+// agents read as first-class graph entities.
+func (r *agentRegistry) view(a *agentRecord, now time.Time) map[string]any {
+	return map[string]any{
+		"id":           "agent::" + a.ID,
+		"kind":         string(graph.KindAgent),
+		"agent_id":     a.ID,
+		"name":         a.Name,
+		"cursor":       a.Cursor,
+		"status":       a.Status,
+		"locked_paths": a.LockedPaths,
+		"session_id":   a.SessionID,
+		"last_seen":    a.LastSeen.UTC().Format(time.RFC3339),
+		"age_seconds":  int(now.Sub(a.LastSeen).Seconds()),
+	}
+}
+
+func (s *Server) registerAgentRegistryTools() {
+	s.addTool(
+		mcp.NewTool("agent_registry",
+			mcp.WithDescription("Multi-agent coordination registry. Several agents working the same repo announce presence here, see each other's focus (cursor), and claim advisory locks on paths to avoid concurrent-edit conflicts. Agents are first-class graph entities (kind=agent) and expire after a heartbeat TTL. Actions:\n  • list (default): all live agents with cursor + locked paths.\n  • register: announce/refresh this agent (name, optional cursor/status/paths).\n  • heartbeat: keep this agent alive and update its cursor/status.\n  • lock: claim advisory locks on paths; returns any conflicts (paths another live agent already holds).\n  • unlock: release paths (or all when none given).\n  • unregister: leave the session."),
+			mcp.WithString("action", mcp.Description("list (default), register, heartbeat, lock, unlock, or unregister")),
+			mcp.WithString("id", mcp.Description("Agent ID. Defaults to the MCP session ID on register; required for heartbeat/lock/unlock/unregister.")),
+			mcp.WithString("name", mcp.Description("(register) Human-readable agent name.")),
+			mcp.WithString("cursor", mcp.Description("(register/heartbeat) Symbol ID or file the agent is currently focused on.")),
+			mcp.WithString("status", mcp.Description("(register/heartbeat) Free-form status, e.g. editing / reviewing / idle.")),
+			mcp.WithString("paths", mcp.Description("(register/lock/unlock) Comma-separated paths to lock or release.")),
+			mcp.WithString("format", mcp.Description("Output format: json (default), gcx, or toon")),
+		),
+		s.handleAgentRegistry,
+	)
+}
+
+func (s *Server) handleAgentRegistry(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	if s.agentReg == nil {
+		s.agentReg = newAgentRegistry()
+	}
+	action := strings.ToLower(strings.TrimSpace(req.GetString("action", "list")))
+	id := strings.TrimSpace(req.GetString("id", ""))
+	paths := splitPathList(req.GetString("paths", ""))
+	now := s.agentReg.now()
+
+	switch action {
+	case "", "list":
+		agents := s.agentReg.list()
+		views := make([]map[string]any, 0, len(agents))
+		for _, a := range agents {
+			views = append(views, s.agentReg.view(a, now))
+		}
+		return s.respondJSONOrTOON(ctx, req, map[string]any{
+			"agents": views,
+			"total":  len(views),
+		})
+
+	case "register":
+		name := strings.TrimSpace(req.GetString("name", ""))
+		if id == "" {
+			id = SessionIDFromContext(ctx)
+		}
+		a := s.agentReg.register(id, name, req.GetString("cursor", ""), req.GetString("status", ""), SessionIDFromContext(ctx), paths)
+		return s.respondJSONOrTOON(ctx, req, map[string]any{
+			"status": "registered",
+			"agent":  s.agentReg.view(a, now),
+		})
+
+	case "heartbeat":
+		if id == "" {
+			id = SessionIDFromContext(ctx)
+		}
+		a, ok := s.agentReg.heartbeat(id, req.GetString("cursor", ""), req.GetString("status", ""))
+		if !ok {
+			return mcp.NewToolResultError("unknown agent: " + id + " — call action=register first"), nil
+		}
+		return s.respondJSONOrTOON(ctx, req, map[string]any{
+			"status": "ok",
+			"agent":  s.agentReg.view(a, now),
+		})
+
+	case "lock":
+		if id == "" {
+			id = SessionIDFromContext(ctx)
+		}
+		if len(paths) == 0 {
+			return mcp.NewToolResultError("lock requires paths"), nil
+		}
+		locked, conflicts, ok := s.agentReg.lock(id, paths)
+		if !ok {
+			return mcp.NewToolResultError("unknown agent: " + id + " — call action=register first"), nil
+		}
+		if conflicts == nil {
+			conflicts = []pathConflict{}
+		}
+		return s.respondJSONOrTOON(ctx, req, map[string]any{
+			"status":    "ok",
+			"locked":    locked,
+			"conflicts": conflicts,
+		})
+
+	case "unlock":
+		if id == "" {
+			id = SessionIDFromContext(ctx)
+		}
+		a, ok := s.agentReg.unlock(id, paths)
+		if !ok {
+			return mcp.NewToolResultError("unknown agent: " + id), nil
+		}
+		return s.respondJSONOrTOON(ctx, req, map[string]any{
+			"status": "ok",
+			"agent":  s.agentReg.view(a, now),
+		})
+
+	case "unregister":
+		if id == "" {
+			id = SessionIDFromContext(ctx)
+		}
+		if !s.agentReg.unregister(id) {
+			return mcp.NewToolResultError("unknown agent: " + id), nil
+		}
+		return s.respondJSONOrTOON(ctx, req, map[string]any{"status": "unregistered", "id": id})
+
+	default:
+		return mcp.NewToolResultError("unknown action: " + action + " (want list/register/heartbeat/lock/unlock/unregister)"), nil
+	}
+}
+
+func splitPathList(s string) []string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/internal/mcp/agent_registry_test.go
+++ b/internal/mcp/agent_registry_test.go
@@ -1,0 +1,106 @@
+package mcp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func fixedClockRegistry() (*agentRegistry, *time.Time) {
+	clock := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	r := newAgentRegistry()
+	r.now = func() time.Time { return clock }
+	return r, &clock
+}
+
+func TestAgentRegistry_RegisterAndList(t *testing.T) {
+	r, _ := fixedClockRegistry()
+	r.register("a1", "alice", "pkg/x.go::Foo", "editing", "sess-a", nil)
+	r.register("b1", "bob", "", "reviewing", "sess-b", nil)
+
+	agents := r.list()
+	require.Len(t, agents, 2)
+	require.Equal(t, "alice", agents[0].Name) // sorted by name
+	require.Equal(t, "pkg/x.go::Foo", agents[0].Cursor)
+	require.Equal(t, "bob", agents[1].Name)
+}
+
+func TestAgentRegistry_HeartbeatUnknown(t *testing.T) {
+	r, _ := fixedClockRegistry()
+	_, ok := r.heartbeat("ghost", "", "")
+	require.False(t, ok, "heartbeat for an unregistered agent must fail")
+
+	r.register("a1", "alice", "", "", "", nil)
+	a, ok := r.heartbeat("a1", "pkg/y.go::Bar", "editing")
+	require.True(t, ok)
+	require.Equal(t, "pkg/y.go::Bar", a.Cursor)
+}
+
+func TestAgentRegistry_LockConflict(t *testing.T) {
+	r, _ := fixedClockRegistry()
+	r.register("a1", "alice", "", "", "", nil)
+	r.register("b1", "bob", "", "", "", nil)
+
+	locked, conflicts, ok := r.lock("a1", []string{"internal/x.go", "internal/y.go"})
+	require.True(t, ok)
+	require.ElementsMatch(t, []string{"internal/x.go", "internal/y.go"}, locked)
+	require.Empty(t, conflicts)
+
+	// bob tries to lock one already-held + one free path.
+	locked, conflicts, ok = r.lock("b1", []string{"internal/x.go", "internal/z.go"})
+	require.True(t, ok)
+	require.Equal(t, []string{"internal/z.go"}, locked)
+	require.Len(t, conflicts, 1)
+	require.Equal(t, "internal/x.go", conflicts[0].Path)
+	require.Equal(t, "a1", conflicts[0].HeldBy)
+}
+
+func TestAgentRegistry_Unlock(t *testing.T) {
+	r, _ := fixedClockRegistry()
+	r.register("a1", "alice", "", "", "", nil)
+	r.lock("a1", []string{"a.go", "b.go", "c.go"})
+
+	a, ok := r.unlock("a1", []string{"b.go"})
+	require.True(t, ok)
+	require.ElementsMatch(t, []string{"a.go", "c.go"}, a.LockedPaths)
+
+	a, _ = r.unlock("a1", nil) // unlock all
+	require.Empty(t, a.LockedPaths)
+}
+
+func TestAgentRegistry_TTLPrune(t *testing.T) {
+	r, clock := fixedClockRegistry()
+	r.register("a1", "alice", "", "", "", nil)
+	require.Len(t, r.list(), 1)
+
+	*clock = clock.Add(r.ttl + time.Second) // past the TTL
+	require.Empty(t, r.list(), "a stale agent must be pruned")
+}
+
+// TestAgentRegistryTool_EndToEnd drives the MCP dispatcher: two agents
+// register, list, and contend for the same path.
+func TestAgentRegistryTool_EndToEnd(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	reg := callEditHandlerJSON(t, srv.handleAgentRegistry, map[string]any{
+		"action": "register", "id": "alice", "name": "alice", "cursor": "main.go::helper",
+	})
+	require.Equal(t, "registered", reg["status"])
+	agent := reg["agent"].(map[string]any)
+	require.Equal(t, "agent", agent["kind"])
+	require.Equal(t, "agent::alice", agent["id"])
+
+	callEditHandlerJSON(t, srv.handleAgentRegistry, map[string]any{"action": "register", "id": "bob", "name": "bob"})
+
+	list := callEditHandlerJSON(t, srv.handleAgentRegistry, map[string]any{"action": "list"})
+	require.EqualValues(t, 2, list["total"])
+
+	lock := callEditHandlerJSON(t, srv.handleAgentRegistry, map[string]any{"action": "lock", "id": "alice", "paths": "main.go"})
+	require.Empty(t, lock["conflicts"])
+
+	lock = callEditHandlerJSON(t, srv.handleAgentRegistry, map[string]any{"action": "lock", "id": "bob", "paths": "main.go"})
+	conflicts := lock["conflicts"].([]any)
+	require.Len(t, conflicts, 1)
+	require.Equal(t, "alice", conflicts[0].(map[string]any)["held_by"])
+}

--- a/internal/mcp/batch_edit_hetero_test.go
+++ b/internal/mcp/batch_edit_hetero_test.go
@@ -1,0 +1,125 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+// callBatchEdit invokes handleBatchEdit directly: the shared callTool test
+// helper's handler map does not register batch_edit.
+func callBatchEdit(t *testing.T, srv *Server, args map[string]any) *mcplib.CallToolResult {
+	t.Helper()
+	req := mcplib.CallToolRequest{}
+	req.Params.Name = "batch_edit"
+	req.Params.Arguments = args
+	res, err := srv.handleBatchEdit(context.Background(), req)
+	require.NoError(t, err)
+	return res
+}
+
+func TestParseBatchEdits(t *testing.T) {
+	// Legacy JSON-string form.
+	items, err := parseBatchEdits(`[{"id":"a","old_source":"x","new_source":"y"}]`)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	require.Equal(t, "a", items[0].SymbolID)
+
+	// Structured array form (what a typed-schema client now sends).
+	items, err = parseBatchEdits([]any{
+		map[string]any{"op": "edit_file", "path": "p", "old_string": "o", "new_string": "n"},
+	})
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	require.Equal(t, "edit_file", items[0].kind())
+	require.Equal(t, "p", items[0].Path)
+
+	_, err = parseBatchEdits(nil)
+	require.Error(t, err, "missing edits must error")
+
+	_, err = parseBatchEdits(`{not json`)
+	require.Error(t, err, "malformed edits must error")
+}
+
+func TestBatchEditItemKind(t *testing.T) {
+	require.Equal(t, "edit_symbol", batchEditItem{SymbolID: "a"}.kind(), "default is edit_symbol")
+	require.Equal(t, "edit_file", batchEditItem{Path: "p"}.kind(), "a path infers edit_file")
+	require.Equal(t, "edit_file", batchEditItem{Op: "edit_file", Path: "p"}.kind())
+	require.Equal(t, "edit_symbol", batchEditItem{Op: "edit_symbol", Path: "p"}.kind(), "explicit op wins over inference")
+}
+
+func TestBatchEditItemsSchemaOneOf(t *testing.T) {
+	schema := batchEditItemsSchema()
+	branches, ok := schema["oneOf"].([]any)
+	require.True(t, ok, "items schema must be a oneOf")
+	require.Len(t, branches, 2)
+	for _, b := range branches {
+		m := b.(map[string]any)
+		require.Equal(t, "object", m["type"])
+		props := m["properties"].(map[string]any)
+		op := props["op"].(map[string]any)
+		require.Contains(t, []any{"edit_symbol", "edit_file"}, op["const"], "each branch is discriminated by an op const")
+		require.NotEmpty(t, m["required"], "each branch declares required fields")
+	}
+}
+
+// TestBatchEditHeterogeneousApply drives a real mixed batch (one symbol edit +
+// one file edit) against the same file and asserts both land on disk.
+func TestBatchEditHeterogeneousApply(t *testing.T) {
+	srv, dir := setupTestServer(t)
+	mainGo := filepath.Join(dir, "main.go")
+
+	edits := []any{
+		map[string]any{
+			"op":         "edit_symbol",
+			"id":         "main.go::helper",
+			"old_source": "func helper() {}",
+			"new_source": "func helper() { _ = 1 }",
+		},
+		map[string]any{
+			"op":         "edit_file",
+			"path":       mainGo,
+			"old_string": "Port int",
+			"new_string": "Port int // configured",
+		},
+	}
+
+	res := callBatchEdit(t, srv, map[string]any{"edits": edits})
+	require.False(t, res.IsError, "batch should succeed: %v", res.Content)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal([]byte(res.Content[0].(mcplib.TextContent).Text), &resp))
+	summary := resp["summary"].(map[string]any)
+	require.EqualValues(t, 2, summary["applied"])
+	require.EqualValues(t, 0, summary["failed"])
+
+	got, err := os.ReadFile(mainGo)
+	require.NoError(t, err)
+	require.Contains(t, string(got), "func helper() { _ = 1 }", "symbol edit applied")
+	require.Contains(t, string(got), "Port int // configured", "file edit applied")
+}
+
+// TestBatchEditDryRunReportsOps confirms dry_run reports the op kind per entry
+// and orders symbol edits before file edits.
+func TestBatchEditDryRunReportsOps(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	edits := []any{
+		map[string]any{"id": "main.go::helper", "old_source": "x", "new_source": "y"},
+		map[string]any{"op": "edit_file", "path": "main.go", "old_string": "a", "new_string": "b"},
+	}
+	res := callBatchEdit(t, srv, map[string]any{"edits": edits, "dry_run": true})
+	require.False(t, res.IsError)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal([]byte(res.Content[0].(mcplib.TextContent).Text), &resp))
+	require.Equal(t, true, resp["dry_run"])
+	plan := resp["plan"].([]any)
+	require.Len(t, plan, 2)
+	require.Equal(t, "edit_symbol", plan[0].(map[string]any)["op"], "symbol edits sort first")
+	require.Equal(t, "edit_file", plan[1].(map[string]any)["op"], "file edits sort last")
+}

--- a/internal/mcp/diff_preview.go
+++ b/internal/mcp/diff_preview.go
@@ -1,0 +1,27 @@
+package mcp
+
+import (
+	"github.com/pmezard/go-difflib/difflib"
+)
+
+// unifiedDiff renders a standard unified diff (3 lines of context) between
+// oldContent and newContent, labelled with the given repo-relative path. It
+// powers the dry_run previews of the edit tools so an agent can see exactly
+// what a write would change — and review it — before committing the edit.
+// Returns "" when the inputs are identical or a diff cannot be produced.
+func unifiedDiff(path, oldContent, newContent string) string {
+	if oldContent == newContent {
+		return ""
+	}
+	out, err := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+		A:        difflib.SplitLines(oldContent),
+		B:        difflib.SplitLines(newContent),
+		FromFile: "a/" + path,
+		ToFile:   "b/" + path,
+		Context:  3,
+	})
+	if err != nil {
+		return ""
+	}
+	return out
+}

--- a/internal/mcp/diff_preview_test.go
+++ b/internal/mcp/diff_preview_test.go
@@ -1,0 +1,103 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnifiedDiff(t *testing.T) {
+	require.Equal(t, "", unifiedDiff("x.go", "same\n", "same\n"), "identical content yields no diff")
+
+	d := unifiedDiff("x.go", "line one\nline two\n", "line one\nline TWO\n")
+	require.Contains(t, d, "--- a/x.go")
+	require.Contains(t, d, "+++ b/x.go")
+	require.Contains(t, d, "@@")
+	require.Contains(t, d, "-line two")
+	require.Contains(t, d, "+line TWO")
+}
+
+func callEditHandlerJSON(t *testing.T, h func(context.Context, mcplib.CallToolRequest) (*mcplib.CallToolResult, error), args map[string]any) map[string]any {
+	t.Helper()
+	req := mcplib.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := h(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, res.IsError, "tool returned error: %v", res.Content)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal([]byte(res.Content[0].(mcplib.TextContent).Text), &resp))
+	return resp
+}
+
+func TestEditSymbolDryRunPreviewsWithoutWriting(t *testing.T) {
+	srv, dir := setupTestServer(t)
+	mainGo := filepath.Join(dir, "main.go")
+	before, err := os.ReadFile(mainGo)
+	require.NoError(t, err)
+
+	resp := callEditHandlerJSON(t, srv.handleEditSymbol, map[string]any{
+		"id":         "main.go::helper",
+		"old_source": "func helper() {}",
+		"new_source": "func helper() { _ = 1 }",
+		"dry_run":    true,
+	})
+
+	require.Equal(t, "would_apply", resp["status"])
+	require.Equal(t, true, resp["dry_run"])
+	diff, _ := resp["diff"].(string)
+	require.Contains(t, diff, "+func helper() { _ = 1 }")
+	require.Contains(t, diff, "-func helper() {}")
+
+	after, err := os.ReadFile(mainGo)
+	require.NoError(t, err)
+	require.Equal(t, string(before), string(after), "dry_run must not modify the file")
+}
+
+func TestEditFileDryRunIncludesDiff(t *testing.T) {
+	srv, dir := setupTestServer(t)
+	mainGo := filepath.Join(dir, "main.go")
+	before, err := os.ReadFile(mainGo)
+	require.NoError(t, err)
+
+	resp := callEditHandlerJSON(t, srv.handleEditFile, map[string]any{
+		"path":       mainGo,
+		"old_string": "Port int",
+		"new_string": "Port int // edited",
+		"dry_run":    true,
+	})
+
+	require.Equal(t, "would_apply", resp["status"])
+	diff, _ := resp["diff"].(string)
+	require.Contains(t, diff, "+\tPort int // edited")
+
+	after, err := os.ReadFile(mainGo)
+	require.NoError(t, err)
+	require.Equal(t, string(before), string(after), "dry_run must not modify the file")
+}
+
+func TestWriteFileDryRunIncludesDiff(t *testing.T) {
+	srv, dir := setupTestServer(t)
+	mainGo := filepath.Join(dir, "main.go")
+	before, err := os.ReadFile(mainGo)
+	require.NoError(t, err)
+
+	resp := callEditHandlerJSON(t, srv.handleWriteFile, map[string]any{
+		"path":    mainGo,
+		"content": "package main\n\nfunc main() {}\n",
+		"dry_run": true,
+	})
+
+	require.Equal(t, "would_overwrite", resp["status"])
+	diff, _ := resp["diff"].(string)
+	require.True(t, strings.Contains(diff, "-") && strings.Contains(diff, "@@"), "overwrite diff should show removed lines")
+
+	after, err := os.ReadFile(mainGo)
+	require.NoError(t, err)
+	require.Equal(t, string(before), string(after), "dry_run must not modify the file")
+}

--- a/internal/mcp/param_alias.go
+++ b/internal/mcp/param_alias.go
@@ -31,6 +31,11 @@ var aliasCanonicals = map[string][]string{
 	"text":    {"query"},
 	"term":    {"query"},
 	"keyword": {"query"},
+	// `pattern` only resolves to `query` on tools that have no real `pattern`
+	// parameter (search_symbols / search_text). On search_ast / grep_results /
+	// ctx_grep — where `pattern` is a real parameter — it is never treated as
+	// unknown, so the alias is inert there.
+	"pattern": {"query"},
 	// edit payloads
 	"new_body":    {"new_string", "new_source", "content"},
 	"new_content": {"new_string", "new_source", "content"},

--- a/internal/mcp/param_alias_test.go
+++ b/internal/mcp/param_alias_test.go
@@ -45,6 +45,30 @@ func TestReconcileArgKeys_KeepsExplicitCanonical(t *testing.T) {
 	require.Contains(t, args, "search", "the alias key stays untouched when the canonical is already set")
 }
 
+// TestReconcileArgKeys_PatternAlias confirms `pattern` rewrites to `query`
+// on search-side tools that have no real `pattern` parameter, and stays
+// inert on tools (search_ast / grep_results / ctx_grep) where `pattern` is
+// itself a real parameter.
+func TestReconcileArgKeys_PatternAlias(t *testing.T) {
+	t.Run("rewrites to query on search tools", func(t *testing.T) {
+		// search_symbols / search_text expose `query`, not `pattern`.
+		real := map[string]bool{"query": true, "path": true, "kind": true}
+		args := map[string]any{"pattern": "validateToken"}
+		reconcileArgKeys(args, real)
+		require.Equal(t, "validateToken", args["query"], "pattern must alias to query")
+		require.NotContains(t, args, "pattern", "the aliased pattern key must be removed")
+	})
+	t.Run("inert when pattern is a real parameter", func(t *testing.T) {
+		// search_ast / grep_results expose a real `pattern` parameter; an
+		// agent's `pattern` is valid input and must never be rewritten.
+		real := map[string]bool{"pattern": true, "query": true}
+		args := map[string]any{"pattern": "(identifier) @match"}
+		reconcileArgKeys(args, real)
+		require.Equal(t, "(identifier) @match", args["pattern"], "a real pattern parameter must be left untouched")
+		require.NotContains(t, args, "query", "no spurious query key must be synthesized")
+	})
+}
+
 func TestLevenshtein(t *testing.T) {
 	require.Equal(t, 0, levenshtein("query", "query"))
 	require.Equal(t, 1, levenshtein("quary", "query"))

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -277,6 +277,10 @@ type Server struct {
 	// by ResolveToolScope before each handler runs.
 	toolScopes *scopeRegistry
 
+	// agentReg is the in-memory multi-agent coordination registry backing
+	// the agent_registry tool (presence, cursors, advisory path locks).
+	agentReg *agentRegistry
+
 	// overlays is the optional editor-overlay manager. When non-nil,
 	// every `tools/call` whose session carries overlay buffers is
 	// wrapped (via s.addTool → wrapToolHandler) with the per-request
@@ -761,6 +765,7 @@ func NewServer(engine *query.Engine, g graph.Store, idx *indexer.Indexer, watche
 		sessions:   newSessionMap(),
 		guardRules: guardRules,
 		toolScopes: newScopeRegistry(),
+		agentReg:   newAgentRegistry(),
 	}
 	// Wire the process-wide tokenStats as the parent of every
 	// per-session counter so record() fanout aggregates daemon-wide.
@@ -838,6 +843,7 @@ func NewServer(engine *query.Engine, g graph.Store, idx *indexer.Indexer, watche
 	s.registerEnhancementTools()
 	s.registerLSPTools()
 	s.registerLintTools()
+	s.registerAgentRegistryTools()
 	s.registerDiagnosticsTools()
 	s.registerReadinessTools()
 	s.registerHealthTools()

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -837,6 +837,7 @@ func NewServer(engine *query.Engine, g graph.Store, idx *indexer.Indexer, watche
 	s.registerAnalysisTools()
 	s.registerEnhancementTools()
 	s.registerLSPTools()
+	s.registerLintTools()
 	s.registerDiagnosticsTools()
 	s.registerReadinessTools()
 	s.registerHealthTools()

--- a/internal/mcp/tools_coding.go
+++ b/internal/mcp/tools_coding.go
@@ -2568,19 +2568,26 @@ func (s *Server) handleEditSymbol(ctx context.Context, req mcp.CallToolRequest) 
 	sess.recordModified(node.FilePath)
 	sess.recordSymbol(id)
 
+	reindexed := s.reindexFile(absPath)
+
 	// Count lines changed.
 	oldLines := strings.Count(oldSource, "\n") + 1
 	newLines := strings.Count(newSource, "\n") + 1
 
-	return s.respondJSONOrTOON(ctx, req, map[string]any{
+	resp := map[string]any{
 		"file":         node.FilePath,
 		"symbol":       id,
 		"lines_before": oldLines,
 		"lines_after":  newLines,
 		"start_line":   node.StartLine,
 		"status":       "applied",
+		"reindexed":    reindexed,
 		"new_sha":      gitBlobSHA(newContentBytes),
-	})
+	}
+	if health := s.fileSyntaxHealth(node.FilePath, absPath); health != nil {
+		resp["syntax_health"] = health
+	}
+	return s.respondJSONOrTOON(ctx, req, resp)
 }
 
 // readSingleLineAt reads a single line from an absolute filesystem path.

--- a/internal/mcp/tools_coding.go
+++ b/internal/mcp/tools_coding.go
@@ -116,6 +116,7 @@ func (s *Server) registerCodingTools() {
 			mcp.WithString("old_source", mcp.Required(), mcp.Description("Exact source fragment to replace (must be unique within the symbol)")),
 			mcp.WithString("new_source", mcp.Required(), mcp.Description("Replacement source fragment")),
 			mcp.WithString("base_sha", mcp.Description("Optional git blob SHA-1 the caller observed at read time. When set, the call refuses to write if the on-disk file's current SHA differs (drift guard against silent clobbers).")),
+			mcp.WithBoolean("dry_run", mcp.Description("Validate the edit and return a unified-diff preview without writing (status: would_apply). Use to review the change before committing it.")),
 		),
 		s.handleEditSymbol,
 	)
@@ -2429,6 +2430,7 @@ func (s *Server) handleEditSymbol(ctx context.Context, req mcp.CallToolRequest) 
 		return mcp.NewToolResultError("new_source is required"), nil
 	}
 	baseSHA := normalizeExpectedSHA(req.GetString("base_sha", ""))
+	dryRun := req.GetBool("dry_run", false)
 
 	if oldSource == newSource {
 		return mcp.NewToolResultError("old_source and new_source are identical"), nil
@@ -2541,6 +2543,22 @@ func (s *Server) handleEditSymbol(ctx context.Context, req mcp.CallToolRequest) 
 	editEnd := editStart + len(oldSource)
 	newContent := fileStr[:editStart] + newSource + fileStr[editEnd:]
 	newContentBytes := []byte(newContent)
+
+	if dryRun {
+		// Validate everything but skip the write; return a unified-diff
+		// preview so the caller can review the change before committing.
+		return s.respondJSONOrTOON(ctx, req, map[string]any{
+			"file":         node.FilePath,
+			"symbol":       id,
+			"lines_before": strings.Count(oldSource, "\n") + 1,
+			"lines_after":  strings.Count(newSource, "\n") + 1,
+			"start_line":   node.StartLine,
+			"status":       "would_apply",
+			"dry_run":      true,
+			"diff":         unifiedDiff(node.FilePath, fileStr, newContent),
+			"new_sha":      gitBlobSHA(newContentBytes),
+		})
+	}
 
 	// Write the file.
 	if err := os.WriteFile(absPath, newContentBytes, 0o644); err != nil {

--- a/internal/mcp/tools_enhancements.go
+++ b/internal/mcp/tools_enhancements.go
@@ -259,9 +259,12 @@ func (s *Server) registerEnhancementTools() {
 	// batch_edit
 	s.addTool(
 		mcp.NewTool("batch_edit",
-			mcp.WithDescription("Applies multiple symbol edits in dependency order. Re-indexes after each edit. Stops on failure and reports status."),
-			mcp.WithString("edits", mcp.Required(), mcp.Description("JSON array of {id, old_source, new_source} objects")),
-			mcp.WithBoolean("dry_run", mcp.Description("Return dependency-ordered plan without applying changes")),
+			mcp.WithDescription("Applies multiple edits in one atomic, dependency-ordered batch. Symbol edits are ordered definitions→callers; the graph re-indexes after each edit; the batch stops on the first failure and skips the rest. Each edit is one of two operations selected by `op`:\n  • edit_symbol (default): {id, old_source, new_source} — replace a fragment inside a symbol's body.\n  • edit_file: {op:\"edit_file\", path, old_string, new_string, replace_all?} — replace a string in any file (imports, config, comments).\nPass `edits` as a JSON array of objects (a JSON-encoded string of the same array is also accepted for backward compatibility)."),
+			mcp.WithArray("edits", mcp.Required(),
+				mcp.Description("Edit operations. Each item is an edit_symbol or edit_file object selected by the `op` discriminator."),
+				mcp.Items(batchEditItemsSchema()),
+			),
+			mcp.WithBoolean("dry_run", mcp.Description("Return the dependency-ordered plan without applying changes")),
 			mcp.WithBoolean("compact", mcp.Description("One-line-per-edit summary")),
 		),
 		s.handleBatchEdit,
@@ -2830,29 +2833,110 @@ func (s *Server) handleGetSymbolHistory(ctx context.Context, req mcp.CallToolReq
 // ---------------------------------------------------------------------------
 
 // batchEditItem represents a single edit in a batch.
+// batchEditItem is one operation in a batch_edit call. It is a discriminated
+// union over `op`: an edit_symbol op carries {id, old_source, new_source}; an
+// edit_file op carries {path, old_string, new_string, replace_all?}. When `op`
+// is omitted it is inferred (edit_file when a path is present, else edit_symbol)
+// so the legacy homogeneous {id, old_source, new_source} payload still works.
 type batchEditItem struct {
-	SymbolID  string `json:"id"`
-	OldSource string `json:"old_source"`
-	NewSource string `json:"new_source"`
+	Op string `json:"op,omitempty"`
+	// edit_symbol
+	SymbolID  string `json:"id,omitempty"`
+	OldSource string `json:"old_source,omitempty"`
+	NewSource string `json:"new_source,omitempty"`
+	// edit_file
+	Path       string `json:"path,omitempty"`
+	OldString  string `json:"old_string,omitempty"`
+	NewString  string `json:"new_string,omitempty"`
+	ReplaceAll bool   `json:"replace_all,omitempty"`
+}
+
+// kind resolves the operation kind for an item: an explicit, recognised `op`
+// wins; otherwise edit_file is inferred when a path is present, else
+// edit_symbol.
+func (it batchEditItem) kind() string {
+	switch it.Op {
+	case "edit_file", "edit_symbol":
+		return it.Op
+	}
+	if it.Path != "" {
+		return "edit_file"
+	}
+	return "edit_symbol"
 }
 
 // batchEditResult represents the outcome of a single edit in the batch.
 type batchEditResult struct {
-	SymbolID string `json:"id"`
+	Op       string `json:"op,omitempty"`
+	SymbolID string `json:"id,omitempty"`
 	FilePath string `json:"path"`
 	Status   string `json:"status"` // "applied", "failed", "skipped"
 	Error    string `json:"error,omitempty"`
 }
 
-func (s *Server) handleBatchEdit(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	editsStr, err := req.RequireString("edits")
-	if err != nil {
-		return mcp.NewToolResultError("edits is required"), nil
+// batchEditItemsSchema is the JSON Schema for one batch_edit item: a
+// discriminated union over the `op` field. Declaring the branches as a oneOf
+// gives the model per-operation field validation instead of a single
+// permissive, stringly-typed payload — the dominant source of malformed
+// batch_edit calls.
+func batchEditItemsSchema() map[string]any {
+	return map[string]any{
+		"oneOf": []any{
+			map[string]any{
+				"type":        "object",
+				"description": "Replace a fragment inside a symbol's body.",
+				"properties": map[string]any{
+					"op":         map[string]any{"const": "edit_symbol", "description": "Operation kind (optional; inferred as edit_symbol when omitted and `id` is present)."},
+					"id":         map[string]any{"type": "string", "description": "Symbol ID, e.g. pkg/foo.go::Bar."},
+					"old_source": map[string]any{"type": "string", "description": "Exact fragment to replace within the symbol's source."},
+					"new_source": map[string]any{"type": "string", "description": "Replacement fragment."},
+				},
+				"required": []any{"id", "old_source", "new_source"},
+			},
+			map[string]any{
+				"type":        "object",
+				"description": "Replace a string in any file (imports, config, comments — non-symbol edits).",
+				"properties": map[string]any{
+					"op":          map[string]any{"const": "edit_file", "description": "Operation kind. Required to select a file edit."},
+					"path":        map[string]any{"type": "string", "description": "File path (repo-relative or absolute)."},
+					"old_string":  map[string]any{"type": "string", "description": "Exact text to replace; must be unique unless replace_all is set."},
+					"new_string":  map[string]any{"type": "string", "description": "Replacement text."},
+					"replace_all": map[string]any{"type": "boolean", "description": "Replace every occurrence instead of requiring uniqueness."},
+				},
+				"required": []any{"op", "path", "old_string", "new_string"},
+			},
+		},
 	}
+}
 
+// parseBatchEdits accepts the `edits` argument as either a structured JSON
+// array (the typed-schema path) or a JSON-encoded string of the same array
+// (the legacy path), and decodes it into batch edit items.
+func parseBatchEdits(raw any) ([]batchEditItem, error) {
+	var data []byte
+	switch v := raw.(type) {
+	case nil:
+		return nil, fmt.Errorf("edits is required")
+	case string:
+		data = []byte(v)
+	default:
+		b, err := json.Marshal(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid edits: %v", err)
+		}
+		data = b
+	}
 	var edits []batchEditItem
-	if err := json.Unmarshal([]byte(editsStr), &edits); err != nil {
-		return mcp.NewToolResultError("invalid edits JSON: " + err.Error()), nil
+	if err := json.Unmarshal(data, &edits); err != nil {
+		return nil, fmt.Errorf("invalid edits JSON: %v", err)
+	}
+	return edits, nil
+}
+
+func (s *Server) handleBatchEdit(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	edits, perr := parseBatchEdits(req.GetArguments()["edits"])
+	if perr != nil {
+		return mcp.NewToolResultError(perr.Error()), nil
 	}
 	if len(edits) == 0 {
 		return mcp.NewToolResultError("edits array is empty"), nil
@@ -2867,12 +2951,21 @@ func (s *Server) handleBatchEdit(ctx context.Context, req mcp.CallToolRequest) (
 	// Definitions first, then implementations, then callers.
 	type editWithOrder struct {
 		edit  batchEditItem
+		op    string
 		order int
 		file  string
+		idx   int
 	}
 
 	var ordered []editWithOrder
-	for _, edit := range edits {
+	for i, edit := range edits {
+		op := edit.kind()
+		if op == "edit_file" {
+			// File edits carry no graph dependency; apply them after all
+			// symbol edits (order 1000), preserving input order via idx.
+			ordered = append(ordered, editWithOrder{edit: edit, op: op, order: 1000, file: edit.Path, idx: i})
+			continue
+		}
 		node := s.engineFor(ctx).GetSymbol(edit.SymbolID)
 		order := 50 // default middle priority
 		filePath := ""
@@ -2901,15 +2994,19 @@ func (s *Server) handleBatchEdit(ctx context.Context, req mcp.CallToolRequest) (
 				}
 			}
 		}
-		ordered = append(ordered, editWithOrder{edit: edit, order: order, file: filePath})
+		ordered = append(ordered, editWithOrder{edit: edit, op: op, order: order, file: filePath, idx: i})
 	}
 
-	// Sort by order ascending (lowest = edit first)
+	// Sort by order ascending (lowest = edit first), tie-broken by file then
+	// by original index so same-bucket edits stay in a deterministic order.
 	sort.SliceStable(ordered, func(i, j int) bool {
 		if ordered[i].order != ordered[j].order {
 			return ordered[i].order < ordered[j].order
 		}
-		return ordered[i].file < ordered[j].file
+		if ordered[i].file != ordered[j].file {
+			return ordered[i].file < ordered[j].file
+		}
+		return ordered[i].idx < ordered[j].idx
 	})
 
 	if dryRun {
@@ -2917,6 +3014,7 @@ func (s *Server) handleBatchEdit(ctx context.Context, req mcp.CallToolRequest) (
 		for i, o := range ordered {
 			entry := map[string]any{
 				"order":  i + 1,
+				"op":     o.op,
 				"id":     o.edit.SymbolID,
 				"path":   o.file,
 				"status": "planned",
@@ -2939,145 +3037,42 @@ func (s *Server) handleBatchEdit(ctx context.Context, req mcp.CallToolRequest) (
 		})
 	}
 
-	// Apply edits sequentially
+	// Apply edits sequentially, dispatching per operation kind. Stop on the
+	// first failure and mark the remainder skipped.
 	var results []batchEditResult
 	failed := false
 
 	for _, o := range ordered {
 		if failed {
 			results = append(results, batchEditResult{
+				Op:       o.op,
 				SymbolID: o.edit.SymbolID,
 				FilePath: o.file,
 				Status:   "skipped",
 			})
 			continue
 		}
-
-		node := s.engineFor(ctx).GetSymbol(o.edit.SymbolID)
-		if node == nil {
-			results = append(results, batchEditResult{
-				SymbolID: o.edit.SymbolID,
-				FilePath: o.file,
-				Status:   "failed",
-				Error:    "symbol not found: " + o.edit.SymbolID,
-			})
+		var r batchEditResult
+		switch o.op {
+		case "edit_file":
+			r = s.applyBatchFileEdit(o.edit)
+		default:
+			r = s.applyBatchSymbolEdit(ctx, o.edit)
+		}
+		results = append(results, r)
+		if r.Status == "failed" {
 			failed = true
-			continue
 		}
-
-		if node.StartLine == 0 || node.EndLine == 0 {
-			results = append(results, batchEditResult{
-				SymbolID: o.edit.SymbolID,
-				FilePath: node.FilePath,
-				Status:   "failed",
-				Error:    "symbol has no line range",
-			})
-			failed = true
-			continue
-		}
-
-		// Resolve file path
-		absPath, resolveErr := s.resolveNodePath(node)
-		if resolveErr != nil {
-			results = append(results, batchEditResult{
-				SymbolID: o.edit.SymbolID,
-				FilePath: node.FilePath,
-				Status:   "failed",
-				Error:    resolveErr.Error(),
-			})
-			failed = true
-			continue
-		}
-
-		// Read file
-		content, readErr := os.ReadFile(absPath)
-		if readErr != nil {
-			results = append(results, batchEditResult{
-				SymbolID: o.edit.SymbolID,
-				FilePath: node.FilePath,
-				Status:   "failed",
-				Error:    fmt.Sprintf("could not read file: %v", readErr),
-			})
-			failed = true
-			continue
-		}
-
-		fileStr := string(content)
-		lines := strings.Split(fileStr, "\n")
-
-		if node.StartLine > len(lines) || node.EndLine > len(lines) {
-			results = append(results, batchEditResult{
-				SymbolID: o.edit.SymbolID,
-				FilePath: node.FilePath,
-				Status:   "failed",
-				Error:    "symbol line range exceeds file length",
-			})
-			failed = true
-			continue
-		}
-
-		symbolSource := strings.Join(lines[node.StartLine-1:node.EndLine], "\n")
-		if !strings.Contains(symbolSource, o.edit.OldSource) {
-			results = append(results, batchEditResult{
-				SymbolID: o.edit.SymbolID,
-				FilePath: node.FilePath,
-				Status:   "failed",
-				Error:    "old_source not found within symbol",
-			})
-			failed = true
-			continue
-		}
-
-		// Compute offset within file
-		symbolStart := 0
-		for i := 0; i < node.StartLine-1 && i < len(lines); i++ {
-			symbolStart += len(lines[i]) + 1
-		}
-		symbolEnd := min(symbolStart+len(symbolSource), len(fileStr))
-
-		offset := strings.Index(fileStr[symbolStart:symbolEnd], o.edit.OldSource)
-		if offset < 0 {
-			results = append(results, batchEditResult{
-				SymbolID: o.edit.SymbolID,
-				FilePath: node.FilePath,
-				Status:   "failed",
-				Error:    "old_source not found in symbol region",
-			})
-			failed = true
-			continue
-		}
-
-		editStart := symbolStart + offset
-		editEnd := editStart + len(o.edit.OldSource)
-		newContent := fileStr[:editStart] + o.edit.NewSource + fileStr[editEnd:]
-
-		if writeErr := os.WriteFile(absPath, []byte(newContent), 0o644); writeErr != nil {
-			results = append(results, batchEditResult{
-				SymbolID: o.edit.SymbolID,
-				FilePath: node.FilePath,
-				Status:   "failed",
-				Error:    fmt.Sprintf("could not write file: %v", writeErr),
-			})
-			failed = true
-			continue
-		}
-
-		// Re-index the file after edit
-		if s.indexer != nil {
-			_ = s.indexer.IndexFile(absPath)
-		}
-
-		results = append(results, batchEditResult{
-			SymbolID: o.edit.SymbolID,
-			FilePath: node.FilePath,
-			Status:   "applied",
-		})
 	}
 
 	if isCompact(req) {
 		var b strings.Builder
 		for _, r := range results {
-			fmt.Fprintf(&b, "%s %s %s\n", r.SymbolID, r.FilePath, r.Status)
+			target := r.SymbolID
+			if target == "" {
+				target = r.FilePath
+			}
+			fmt.Fprintf(&b, "%s %s %s\n", r.Op, target, r.Status)
 		}
 		return mcp.NewToolResultText(b.String()), nil
 	}
@@ -3104,6 +3099,121 @@ func (s *Server) handleBatchEdit(ctx context.Context, req mcp.CallToolRequest) (
 			"total":   len(results),
 		},
 	})
+}
+
+// applyBatchSymbolEdit applies one edit_symbol operation: it locates the
+// symbol's source range, replaces old_source with new_source inside it, writes
+// the file, and re-indexes. Semantics match the legacy single-op batch_edit.
+func (s *Server) applyBatchSymbolEdit(ctx context.Context, edit batchEditItem) batchEditResult {
+	res := batchEditResult{Op: "edit_symbol", SymbolID: edit.SymbolID}
+	node := s.engineFor(ctx).GetSymbol(edit.SymbolID)
+	if node == nil {
+		res.Status, res.Error = "failed", "symbol not found: "+edit.SymbolID
+		return res
+	}
+	res.FilePath = node.FilePath
+	if node.StartLine == 0 || node.EndLine == 0 {
+		res.Status, res.Error = "failed", "symbol has no line range"
+		return res
+	}
+	absPath, resolveErr := s.resolveNodePath(node)
+	if resolveErr != nil {
+		res.Status, res.Error = "failed", resolveErr.Error()
+		return res
+	}
+	content, readErr := os.ReadFile(absPath)
+	if readErr != nil {
+		res.Status, res.Error = "failed", fmt.Sprintf("could not read file: %v", readErr)
+		return res
+	}
+	fileStr := string(content)
+	lines := strings.Split(fileStr, "\n")
+	if node.StartLine > len(lines) || node.EndLine > len(lines) {
+		res.Status, res.Error = "failed", "symbol line range exceeds file length"
+		return res
+	}
+	symbolSource := strings.Join(lines[node.StartLine-1:node.EndLine], "\n")
+	if !strings.Contains(symbolSource, edit.OldSource) {
+		res.Status, res.Error = "failed", "old_source not found within symbol"
+		return res
+	}
+	symbolStart := 0
+	for i := 0; i < node.StartLine-1 && i < len(lines); i++ {
+		symbolStart += len(lines[i]) + 1
+	}
+	symbolEnd := min(symbolStart+len(symbolSource), len(fileStr))
+	offset := strings.Index(fileStr[symbolStart:symbolEnd], edit.OldSource)
+	if offset < 0 {
+		res.Status, res.Error = "failed", "old_source not found in symbol region"
+		return res
+	}
+	editStart := symbolStart + offset
+	editEnd := editStart + len(edit.OldSource)
+	newContent := fileStr[:editStart] + edit.NewSource + fileStr[editEnd:]
+	if writeErr := os.WriteFile(absPath, []byte(newContent), 0o644); writeErr != nil {
+		res.Status, res.Error = "failed", fmt.Sprintf("could not write file: %v", writeErr)
+		return res
+	}
+	if s.indexer != nil {
+		_ = s.indexer.IndexFile(absPath)
+	}
+	res.Status = "applied"
+	return res
+}
+
+// applyBatchFileEdit applies one edit_file operation: it replaces old_string
+// with new_string in the file at path, mirroring edit_file's uniqueness and
+// replace_all semantics, then re-indexes.
+func (s *Server) applyBatchFileEdit(edit batchEditItem) batchEditResult {
+	res := batchEditResult{Op: "edit_file", FilePath: edit.Path}
+	if edit.Path == "" {
+		res.Status, res.Error = "failed", "edit_file op requires path"
+		return res
+	}
+	if edit.OldString == edit.NewString {
+		res.Status, res.Error = "failed", "old_string and new_string are identical"
+		return res
+	}
+	absPath, relPath, resolveErr := s.resolveFilePath(edit.Path)
+	if resolveErr != nil {
+		res.Status, res.Error = "failed", resolveErr.Error()
+		return res
+	}
+	res.FilePath = relPath
+	content, readErr := os.ReadFile(absPath)
+	if readErr != nil {
+		res.Status, res.Error = "failed", fmt.Sprintf("could not read file: %v", readErr)
+		return res
+	}
+	fileStr := string(content)
+	count := strings.Count(fileStr, edit.OldString)
+	if count == 0 {
+		res.Status, res.Error = "failed", "old_string not found in file"
+		return res
+	}
+	if count > 1 && !edit.ReplaceAll {
+		res.Status, res.Error = "failed", fmt.Sprintf(
+			"old_string matches %d locations%s. Provide a larger fragment for uniqueness or set replace_all=true.",
+			count, matchLocationsHint(fileStr, edit.OldString))
+		return res
+	}
+	var newContent string
+	if edit.ReplaceAll {
+		newContent = strings.ReplaceAll(fileStr, edit.OldString, edit.NewString)
+	} else {
+		newContent = strings.Replace(fileStr, edit.OldString, edit.NewString, 1)
+	}
+	perm := os.FileMode(0o644)
+	if info, e := os.Stat(absPath); e == nil {
+		perm = info.Mode().Perm()
+	}
+	if writeErr := os.WriteFile(absPath, []byte(newContent), perm); writeErr != nil {
+		res.Status, res.Error = "failed", fmt.Sprintf("could not write file: %v", writeErr)
+		return res
+	}
+	s.reindexFile(absPath)
+	res.Status = "applied"
+	return res
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/mcp/tools_fileops.go
+++ b/internal/mcp/tools_fileops.go
@@ -449,6 +449,7 @@ func (s *Server) handleEditFile(ctx context.Context, req mcp.CallToolRequest) (*
 			"replacements":  replacements,
 			"bytes_written": len(newContentBytes),
 			"reindexed":     false,
+			"diff":          unifiedDiff(relPath, fileStr, newContent),
 			"new_sha":       newSHA,
 		})
 	}
@@ -526,10 +527,15 @@ func (s *Server) handleWriteFile(ctx context.Context, req mcp.CallToolRequest) (
 	newSHA := gitBlobSHA(contentBytes)
 
 	if dryRun {
-		// Dry-run: skip the write + reindex but report what would happen.
+		// Dry-run: skip the write + reindex but report what would happen,
+		// including a unified-diff preview of the change.
 		dryStatus := "would_create"
+		oldContent := ""
 		if status == "overwritten" {
 			dryStatus = "would_overwrite"
+			if existing, e := os.ReadFile(absPath); e == nil {
+				oldContent = string(existing)
+			}
 		}
 		return s.respondJSONOrTOON(ctx, req, map[string]any{
 			"path":          relPath,
@@ -537,6 +543,7 @@ func (s *Server) handleWriteFile(ctx context.Context, req mcp.CallToolRequest) (
 			"dry_run":       true,
 			"bytes_written": len(contentBytes),
 			"reindexed":     false,
+			"diff":          unifiedDiff(relPath, oldContent, content),
 			"new_sha":       newSHA,
 		})
 	}

--- a/internal/mcp/tools_fileops.go
+++ b/internal/mcp/tools_fileops.go
@@ -377,6 +377,45 @@ func (s *Server) reindexFile(absPath string) bool {
 	return false
 }
 
+// fileSyntaxHealth reads back the parse-error stamp the indexer places on a
+// file node during (re)indexing, and returns a syntax_health block to attach
+// to an edit response — but ONLY when the file now has parse errors, so a
+// clean edit stays quiet. This lets an agent notice immediately that an edit
+// left the file syntactically broken, before it trusts graph queries against
+// it. Returns nil when the file parsed cleanly or its health is unknown.
+func (s *Server) fileSyntaxHealth(relPath, absPath string) map[string]any {
+	if s.graph == nil {
+		return nil
+	}
+	graphPath := s.resolveOverlayGraphPath(relPath, absPath)
+	for _, n := range s.graph.GetFileNodes(graphPath) {
+		if n == nil || n.Kind != graph.KindFile || n.Meta == nil {
+			continue
+		}
+		broken, _ := n.Meta["has_parse_errors"].(bool)
+		if !broken {
+			continue
+		}
+		count := 0
+		switch v := n.Meta["parse_errors"].(type) {
+		case int:
+			count = v
+		case int64:
+			count = int(v)
+		case float64:
+			count = int(v)
+		}
+		return map[string]any{
+			"healthy":      false,
+			"parse_errors": count,
+			"warning": fmt.Sprintf(
+				"file has %d parse error(s) after this edit — it may be syntactically broken; review before relying on graph queries for it.",
+				count),
+		}
+	}
+	return nil
+}
+
 func (s *Server) handleEditFile(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	rawPath, err := req.RequireString("path")
 	if err != nil {
@@ -467,14 +506,18 @@ func (s *Server) handleEditFile(ctx context.Context, req mcp.CallToolRequest) (*
 
 	reindexed := s.reindexFile(absPath)
 
-	return s.respondJSONOrTOON(ctx, req, map[string]any{
+	resp := map[string]any{
 		"path":          relPath,
 		"status":        "applied",
 		"replacements":  replacements,
 		"bytes_written": len(newContentBytes),
 		"reindexed":     reindexed,
 		"new_sha":       newSHA,
-	})
+	}
+	if health := s.fileSyntaxHealth(relPath, absPath); health != nil {
+		resp["syntax_health"] = health
+	}
+	return s.respondJSONOrTOON(ctx, req, resp)
 }
 
 func (s *Server) handleWriteFile(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -557,13 +600,17 @@ func (s *Server) handleWriteFile(ctx context.Context, req mcp.CallToolRequest) (
 
 	reindexed := s.reindexFile(absPath)
 
-	return s.respondJSONOrTOON(ctx, req, map[string]any{
+	resp := map[string]any{
 		"path":          relPath,
 		"status":        status,
 		"bytes_written": len(contentBytes),
 		"reindexed":     reindexed,
 		"new_sha":       newSHA,
-	})
+	}
+	if health := s.fileSyntaxHealth(relPath, absPath); health != nil {
+		resp["syntax_health"] = health
+	}
+	return s.respondJSONOrTOON(ctx, req, resp)
 }
 
 // matchLocationsHint returns a brief " (lines X, Y, Z)" hint listing up to

--- a/internal/mcp/tools_lint.go
+++ b/internal/mcp/tools_lint.go
@@ -1,0 +1,81 @@
+package mcp
+
+import (
+	"context"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/zzet/gortex/internal/lint"
+)
+
+func (s *Server) registerLintTools() {
+	s.addTool(
+		mcp.NewTool("lint_file",
+			mcp.WithDescription("Runs the available external linters/formatters against a file and returns normalized diagnostics — an LSP-free, on-demand syntax/lint check that complements get_diagnostics (which needs a running language server). Built-in linters: gofmt (Go), ruff (Python), shellcheck (shell). A linter that is not installed is reported under linters_skipped, never as an error. Use after an edit to confirm a file is syntactically sound, or to surface lint issues a structural check would miss."),
+			mcp.WithString("path", mcp.Required(), mcp.Description("File to lint (absolute, or repo-relative).")),
+			mcp.WithString("language", mcp.Description("Override the language (go, python, shell). Inferred from the file extension when omitted.")),
+			mcp.WithNumber("timeout_ms", mcp.Description("Per-linter timeout in milliseconds (default 5000).")),
+		),
+		s.handleLintFile,
+	)
+}
+
+func (s *Server) handleLintFile(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	rawPath, err := req.RequireString("path")
+	if err != nil {
+		return mcp.NewToolResultError("path is required"), nil
+	}
+	absPath, relPath, resolveErr := s.resolveFilePath(rawPath)
+	if resolveErr != nil {
+		return mcp.NewToolResultError(resolveErr.Error()), nil
+	}
+
+	lang := req.GetString("language", "")
+	if lang == "" {
+		lang = lint.LanguageForPath(absPath)
+	}
+	if lang == "" {
+		return s.respondJSONOrTOON(ctx, req, map[string]any{
+			"path":            relPath,
+			"language":        "",
+			"healthy":         true,
+			"diagnostics":     []any{},
+			"linters_ran":     []any{},
+			"linters_skipped": []any{},
+			"note":            "no built-in linter is configured for this file type",
+		})
+	}
+
+	timeout := time.Duration(req.GetInt("timeout_ms", 5000)) * time.Millisecond
+	result := lint.NewRegistry().Run(ctx, absPath, lang, timeout)
+
+	// Report diagnostics against the repo-relative path the caller passed.
+	for i := range result.Diagnostics {
+		result.Diagnostics[i].File = relPath
+	}
+
+	errCount, warnCount := 0, 0
+	for _, d := range result.Diagnostics {
+		switch d.Severity {
+		case lint.SeverityError:
+			errCount++
+		case lint.SeverityWarning:
+			warnCount++
+		}
+	}
+
+	return s.respondJSONOrTOON(ctx, req, map[string]any{
+		"path":            relPath,
+		"language":        lang,
+		"healthy":         errCount == 0,
+		"diagnostics":     result.Diagnostics,
+		"linters_ran":     result.Ran,
+		"linters_skipped": result.Skipped,
+		"summary": map[string]int{
+			"errors":   errCount,
+			"warnings": warnCount,
+			"total":    len(result.Diagnostics),
+		},
+	})
+}

--- a/internal/mcp/tools_lint_test.go
+++ b/internal/mcp/tools_lint_test.go
@@ -1,0 +1,82 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/lint"
+)
+
+func goLinterAvailable(t *testing.T) {
+	t.Helper()
+	ls := lint.NewRegistry().ForLanguage("go")
+	if len(ls) == 0 || !ls[0].Available() {
+		t.Skip("gofmt not on PATH")
+	}
+}
+
+func TestLintFileReportsGoSyntaxError(t *testing.T) {
+	goLinterAvailable(t)
+	srv, dir := setupTestServer(t)
+	broken := filepath.Join(dir, "broken.go")
+	require.NoError(t, os.WriteFile(broken, []byte("package main\n\nfunc main() {\n"), 0o644))
+
+	resp := callEditHandlerJSON(t, srv.handleLintFile, map[string]any{"path": broken})
+	require.Equal(t, false, resp["healthy"])
+	require.NotEmpty(t, resp["diagnostics"].([]any))
+	require.Contains(t, resp["linters_ran"], "gofmt")
+}
+
+func TestLintFileCleanGo(t *testing.T) {
+	goLinterAvailable(t)
+	srv, dir := setupTestServer(t)
+	clean := filepath.Join(dir, "clean.go")
+	require.NoError(t, os.WriteFile(clean, []byte("package main\n\nfunc f() {}\n"), 0o644))
+
+	resp := callEditHandlerJSON(t, srv.handleLintFile, map[string]any{"path": clean})
+	require.Equal(t, true, resp["healthy"])
+	require.Equal(t, "go", resp["language"])
+}
+
+func TestLintFileUnknownLanguageIsHealthy(t *testing.T) {
+	srv, dir := setupTestServer(t)
+	txt := filepath.Join(dir, "notes.txt")
+	require.NoError(t, os.WriteFile(txt, []byte("hello\n"), 0o644))
+
+	resp := callEditHandlerJSON(t, srv.handleLintFile, map[string]any{"path": txt})
+	require.Equal(t, true, resp["healthy"])
+	require.Equal(t, "", resp["language"])
+}
+
+func TestEditFileSurfacesSyntaxHealthOnBreak(t *testing.T) {
+	srv, dir := setupTestServer(t)
+	mainGo := filepath.Join(dir, "main.go")
+
+	// Drop helper's closing brace — the file no longer parses.
+	resp := callEditHandlerJSON(t, srv.handleEditFile, map[string]any{
+		"path":       mainGo,
+		"old_string": "func helper() {}",
+		"new_string": "func helper() {",
+	})
+	require.Equal(t, "applied", resp["status"])
+	health, ok := resp["syntax_health"].(map[string]any)
+	require.True(t, ok, "a broken edit must surface syntax_health")
+	require.Equal(t, false, health["healthy"])
+}
+
+func TestEditFileCleanEditOmitsSyntaxHealth(t *testing.T) {
+	srv, dir := setupTestServer(t)
+	mainGo := filepath.Join(dir, "main.go")
+
+	resp := callEditHandlerJSON(t, srv.handleEditFile, map[string]any{
+		"path":       mainGo,
+		"old_string": "Port int",
+		"new_string": "Port int // ok",
+	})
+	require.Equal(t, "applied", resp["status"])
+	_, has := resp["syntax_health"]
+	require.False(t, has, "a clean edit must not surface syntax_health")
+}


### PR DESCRIPTION
## Summary

Eight self-contained improvements to how agents drive the Gortex MCP server — making edits safer and more validating, the stdio transport more robust, and the server multi-agent–aware. Each feature is one commit, fully tested. No behaviour is removed; every existing payload shape still works.

## Edit ergonomics & safety
- pattern accepted as an alias for query on search tools. It only resolves on tools that have no real pattern parameter (search_symbols / search_text), so it stays inert on search_ast / grep_results / ctx_grep where pattern is first-class.
- batch_edit now has a typed, discriminated schema — edits is an array whose items are a oneOf over an op discriminator, so the model gets per-operation validation instead of an opaque JSON string. The batch is now heterogeneous: it can mix edit_symbol ({id, old_source, new_source}) and edit_file ({op:"edit_file", path, old_string, new_string, replace_all?}) operations in one dependency-ordered, atomic run — file edits previously had no batch path at all.
- dry_run previews now show a unified diff. edit_symbol gained a dry_run mode (it was the only content editor without one), and edit_file / edit_symbol / write_file all attach a diff field to their dry-run response.
- Post-edit syntax health. After an edit re-indexes a file, the editors surface a syntax_health block only when the edit left the file unparseable — so a clean edit stays quiet, and an agent notices a broken edit before trusting graph queries on it.
- New lint_file tool — runs the available external linters (gofmt, ruff, shellcheck) and returns normalized diagnostics. LSP-free (complements get_diagnostics), degrades gracefully when a linter isn't installed (reported under linters_skipped), bounded per-linter timeout, and a non-zero linter exit (issues found) is not treated as a failure. Backed by a new, config-extensible internal/lint registry.

## Transport & process reliability
- Orphan-proxy watchdog. The stdio proxy now closes itself when its parent process dies, instead of relying solely on stdin EOF (which a SIGKILLed client or an inherited-and-held stdin pipe can leave hanging, pinning a daemon session). It detects a change of parent PID — catching subreaper reparenting in containers / systemd user sessions, not just reparenting to PID 1 — and the post-close drain is now time-bounded.

## Multi-agent coordination
- Agent registry. A new agent graph node kind plus an in-memory registry behind a new agent_registry tool: agents register, heartbeat (TTL-expiring liveness), publish a cursor (the symbol/file they're focused on), and claim advisory path locks with conflict detection so concurrent agents avoid clobbering each other. Presence is volatile and heartbeat-driven, so it lives in a dedicated registry rather than the persistent code graph.
- Pre-turn context injection. A new UserPromptSubmit hook fires before every user turn, searches the graph for symbols relevant to the prompt, and injects them — so the model reaches for graph tools instead of grepping. This is the proactive counterpart to SessionStart (once per session) and PreToolUse (reactive). Time-bounded and best-effort: a trivial/slash-command prompt, a missing daemon, or zero hits is a silent no-op. The Claude Code adapter installs it alongside the other hooks.
- Subagent tool propagation — documented & guarded. A SubAgentTools parser plus a CI test that locks the invariant that every Gortex subagent declares a non-empty, duplicate-free, graph-only MCP allowlist (no Bash/Grep/Glob escape) granting smart_context — so a tool rename can't silently strip a subagent's access. A new docs/agents.md section explains propagation across all adapter classes (explicit per-subagent allowlist, client-side session inheritance, and no-subagent hosts).

## New MCP surface

  - Tools: lint_file, agent_registry.
  - Node kind: agent.
  - Hook event: UserPromptSubmit.

## Backward compatibility

  - batch_edit still accepts the legacy JSON-string edits payload and the bare {id, old_source, new_source} item shape.
  - New response fields (diff, syntax_health) are additive and only appear when relevant.
  - No tools removed or renamed.