### PR TITLE
experimental: worktree multi workspace

### DIFF
--- a/cmd/gortex/daemon_controller.go
+++ b/cmd/gortex/daemon_controller.go
@@ -425,20 +425,41 @@ func (c *realController) Reload(ctx context.Context) (json.RawMessage, error) {
 	}
 
 	var added, removed int
-	wantedPrefixes := make(map[string]bool)
 
+	// Match configured entries to currently-tracked instances by ROOT
+	// PATH, not by a recomputed prefix. A worktree tracked as an
+	// independent instance registers under a derived `<base>@<workspace>`
+	// prefix, so keying the diff on config.ResolvePrefix(entry) (the bare
+	// basename) would fail to recognise it as wanted and untrack it on
+	// every reload. The root path is the stable identity of a checkout.
+	trackedByRoot := make(map[string]string) // absolute RootPath → prefix
+	for prefix, meta := range c.multiIndexer.AllMetadata() {
+		if meta != nil {
+			trackedByRoot[meta.RootPath] = prefix
+		}
+	}
+
+	wantedPrefixes := make(map[string]bool)
 	for _, entry := range c.configManager.Global().Repos {
-		prefix := config.ResolvePrefix(entry)
-		wantedPrefixes[prefix] = true
-		if _, exists := c.multiIndexer.AllMetadata()[prefix]; exists {
+		abs, err := filepath.Abs(entry.Path)
+		if err != nil {
+			abs = entry.Path
+		}
+		if prefix, ok := trackedByRoot[abs]; ok {
+			// Already tracked (under whatever prefix it registered) — keep it.
+			wantedPrefixes[prefix] = true
 			continue
 		}
-		if _, err := c.multiIndexer.TrackRepoCtx(ctx, entry); err != nil {
+		res, trackErr := c.multiIndexer.TrackRepoCtx(ctx, entry)
+		if trackErr != nil {
 			c.logger.Warn("reload: track failed",
-				zap.String("path", entry.Path), zap.Error(err))
+				zap.String("path", entry.Path), zap.Error(trackErr))
 			continue
 		}
 		added++
+		if res != nil && res.RepoPrefix != "" {
+			wantedPrefixes[res.RepoPrefix] = true
+		}
 	}
 
 	for prefix := range c.multiIndexer.AllMetadata() {

--- a/cmd/gortex/daemon_controller.go
+++ b/cmd/gortex/daemon_controller.go
@@ -69,7 +69,7 @@ func (c *realController) Track(ctx context.Context, p daemon.TrackParams) (json.
 	if err != nil {
 		return nil, fmt.Errorf("resolve path: %w", err)
 	}
-	entry := config.RepoEntry{Path: absPath, Name: p.Name, Ref: p.Ref}
+	entry := config.RepoEntry{Path: absPath, Name: p.Name, Ref: p.Ref, AsWorktree: p.AsWorktree}
 	result, err := c.multiIndexer.TrackRepoCtx(ctx, entry)
 	if err != nil {
 		return nil, err
@@ -77,6 +77,13 @@ func (c *realController) Track(ctx context.Context, p daemon.TrackParams) (json.
 	if result == nil {
 		// Already tracked — idempotent.
 		return json.RawMessage(fmt.Sprintf(`{"status":"already_tracked","path":%q}`, absPath)), nil
+	}
+	// TrackRepoCtx may have derived a worktree-instance prefix that the
+	// by-value entry above can't see — read the prefix it actually
+	// registered under for the watcher attach and the response.
+	prefix := result.RepoPrefix
+	if prefix == "" {
+		prefix = config.ResolvePrefix(entry)
 	}
 
 	// Project association from TrackParams.Project isn't wired yet — the
@@ -90,7 +97,6 @@ func (c *realController) Track(ctx context.Context, p daemon.TrackParams) (json.
 	// here are logged but don't fail the track — an indexed-but-
 	// unwatched repo is still queryable, just stale if edited.
 	if c.multiWatcher != nil && c.configManager != nil {
-		prefix := config.ResolvePrefix(entry)
 		wcfg := c.configManager.GetRepoConfig(prefix).Watch
 		if err := c.multiWatcher.AddRepo(prefix, wcfg); err != nil {
 			c.logger.Warn("track: attach watcher failed",
@@ -110,7 +116,7 @@ func (c *realController) Track(ctx context.Context, p daemon.TrackParams) (json.
 	return json.Marshal(map[string]any{
 		"status":     "tracked",
 		"path":       absPath,
-		"prefix":     config.ResolvePrefix(entry),
+		"prefix":     prefix,
 		"file_count": result.FileCount,
 		"node_count": result.NodeCount,
 		"edge_count": result.EdgeCount,

--- a/cmd/gortex/daemon_controller_worktree_test.go
+++ b/cmd/gortex/daemon_controller_worktree_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+	"github.com/zzet/gortex/internal/search"
+)
+
+func wtGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "git %v: %s", args, out)
+}
+
+// buildWorktreeController builds a realController whose MultiIndexer has
+// indexed a canonical checkout plus a linked worktree (declaring a
+// distinct workspace, with a colliding basename, so both would otherwise
+// resolve to the same prefix). Returns the controller, indexer, config
+// manager, and the two checkout paths.
+func buildWorktreeController(t *testing.T) (*realController, *indexer.MultiIndexer, *config.ConfigManager, string, string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available in PATH")
+	}
+	canon := filepath.Join(t.TempDir(), "oas-orm")
+	require.NoError(t, os.MkdirAll(canon, 0o755))
+	wtGit(t, canon, "init", "-q", "-b", "main")
+	require.NoError(t, os.WriteFile(filepath.Join(canon, "lib.go"),
+		[]byte("package lib\n\nfunc C() {}\n"), 0o644))
+	wtGit(t, canon, "add", ".")
+	wtGit(t, canon, "commit", "-q", "-m", "init")
+
+	wt := filepath.Join(t.TempDir(), "oas-orm")
+	wtGit(t, canon, "worktree", "add", "-q", "-b", "task", wt)
+	require.NoError(t, os.WriteFile(filepath.Join(wt, ".gortex.yaml"),
+		[]byte("workspace: task-ws\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(wt, "feature.go"),
+		[]byte("package lib\n\nfunc F() {}\n"), 0o644))
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	gc := &config.GlobalConfig{Repos: []config.RepoEntry{{Path: canon}, {Path: wt}}}
+	gc.SetConfigPath(cfgPath)
+	require.NoError(t, gc.Save())
+	cm, err := config.NewConfigManager(cfgPath)
+	require.NoError(t, err)
+
+	g := graph.New()
+	reg := parser.NewRegistry()
+	languages.RegisterAll(reg)
+	mi := indexer.NewMultiIndexer(g, reg, search.NewBM25(), cm, zap.NewNop())
+	_, err = mi.IndexAll()
+	require.NoError(t, err)
+
+	c := &realController{graph: g, multiIndexer: mi, configManager: cm, logger: zap.NewNop()}
+	return c, mi, cm, canon, wt
+}
+
+func reloadResult(t *testing.T, c *realController) (added, removed int) {
+	t.Helper()
+	raw, err := c.Reload(context.Background())
+	require.NoError(t, err)
+	var res struct {
+		Added   int `json:"added"`
+		Removed int `json:"removed"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &res))
+	return res.Added, res.Removed
+}
+
+// TestReload_KeepsWorktreeInstance is the regression for the reload
+// untrack-diff: a worktree tracked under a derived `<base>@<workspace>`
+// prefix must not be untracked on a no-op reload just because its config
+// entry's basename matches the canonical's prefix.
+func TestReload_KeepsWorktreeInstance(t *testing.T) {
+	c, mi, _, _, _ := buildWorktreeController(t)
+	require.NotNil(t, mi.GetMetadata("oas-orm"))
+	require.NotNil(t, mi.GetMetadata("oas-orm@task-ws"))
+
+	added, removed := reloadResult(t, c)
+	assert.Equal(t, 0, added)
+	assert.Equal(t, 0, removed, "reload must not untrack the worktree instance")
+	assert.NotNil(t, mi.GetMetadata("oas-orm@task-ws"), "worktree instance survives reload")
+	assert.NotNil(t, mi.GetMetadata("oas-orm"), "canonical survives reload")
+}
+
+// TestReload_UntracksRemovedWorktree confirms a worktree instance is
+// dropped when its entry leaves the config — matched by root path, not a
+// recomputed prefix.
+func TestReload_UntracksRemovedWorktree(t *testing.T) {
+	c, mi, cm, _, wt := buildWorktreeController(t)
+	require.NotNil(t, mi.GetMetadata("oas-orm@task-ws"))
+
+	require.NoError(t, cm.Global().RemoveRepo(wt))
+	require.NoError(t, cm.Global().Save())
+
+	_, removed := reloadResult(t, c)
+	assert.Equal(t, 1, removed)
+	assert.Nil(t, mi.GetMetadata("oas-orm@task-ws"), "removed worktree is untracked")
+	assert.NotNil(t, mi.GetMetadata("oas-orm"), "canonical remains tracked")
+}

--- a/cmd/gortex/daemon_state.go
+++ b/cmd/gortex/daemon_state.go
@@ -659,7 +659,7 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger) *indexer.MultiWat
 					skipped++
 					continue
 				}
-				prefix := strings.TrimPrefix(config.ResolvePrefix(entry), "/")
+				prefix := strings.TrimPrefix(indexer.EffectiveRepoPrefix(state.configManager, entry), "/")
 				absRootCapture := absRoot
 				helper := buildResolverLSPHelper(state.lspRouter, tsSpec, absRootCapture, poolSize, logger)
 				state.resolverLSPRegistry.Register(prefix, helper)
@@ -752,7 +752,7 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger) *indexer.MultiWat
 					// back to the snapshot's per-repo FileMtimes when the
 					// backend doesn't implement the reader (memory) or
 					// hasn't seen this repo yet.
-					priorMtimes := priorMtimesFromStore(state.graph, entry, logger)
+					priorMtimes := priorMtimesFromStore(state.graph, state.configManager, entry, logger)
 					if len(priorMtimes) == 0 {
 						priorMtimes = priorMtimesForEntry(state.snapshotRepos, entry)
 					}
@@ -1016,7 +1016,7 @@ func publishReadinessPhase(state *daemonState, phase string, ready bool, extra m
 // mtimes for the repo (fresh cold start). When non-nil it short-
 // circuits the gob-snapshot lookup so the warm path is driven by
 // data the backend persisted itself.
-func priorMtimesFromStore(g graph.Store, entry config.RepoEntry, logger *zap.Logger) map[string]int64 {
+func priorMtimesFromStore(g graph.Store, cm *config.ConfigManager, entry config.RepoEntry, logger *zap.Logger) map[string]int64 {
 	reader, ok := g.(graph.FileMtimeReader)
 	if !ok {
 		if logger != nil {
@@ -1024,7 +1024,11 @@ func priorMtimesFromStore(g graph.Store, entry config.RepoEntry, logger *zap.Log
 		}
 		return nil
 	}
-	prefix := strings.TrimPrefix(config.ResolvePrefix(entry), "/")
+	// Key by the prefix the indexer actually registers the repo under —
+	// a worktree instance persists its mtimes under `<base>@<workspace>`,
+	// not the bare basename, so a plain ResolvePrefix would load the
+	// canonical checkout's mtimes and force a full re-index every restart.
+	prefix := strings.TrimPrefix(indexer.EffectiveRepoPrefix(cm, entry), "/")
 	if prefix == "" {
 		if logger != nil {
 			logger.Info("daemon: priorMtimesFromStore: empty prefix",

--- a/cmd/gortex/track.go
+++ b/cmd/gortex/track.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -11,8 +12,14 @@ import (
 
 	"github.com/zzet/gortex/internal/config"
 	"github.com/zzet/gortex/internal/daemon"
+	"github.com/zzet/gortex/internal/indexer"
 	"github.com/zzet/gortex/internal/progress"
 	"github.com/zzet/gortex/internal/tui"
+)
+
+var (
+	trackName       string
+	trackAsWorktree bool
 )
 
 var trackCmd = &cobra.Command{
@@ -32,8 +39,28 @@ var untrackCmd = &cobra.Command{
 }
 
 func init() {
+	trackCmd.Flags().StringVar(&trackName, "name", "",
+		"Explicit repo prefix override (default: directory basename)")
+	trackCmd.Flags().BoolVar(&trackAsWorktree, "as-worktree", false,
+		"Track a linked git worktree as an independent instance even when its repo is already tracked elsewhere")
 	rootCmd.AddCommand(trackCmd)
 	rootCmd.AddCommand(untrackCmd)
+}
+
+// declaredWorkspace reads the `workspace:` slug from a repo's own
+// `.gortex.yaml`, or "" when the file is absent or declares none. Used by
+// the daemon-less track path to derive a stable worktree-instance prefix
+// the same way the daemon would.
+func declaredWorkspace(repoPath string) string {
+	cfgFile := filepath.Join(repoPath, ".gortex.yaml")
+	if _, err := os.Stat(cfgFile); err != nil {
+		return ""
+	}
+	cfg, err := config.Load(cfgFile)
+	if err != nil || cfg == nil {
+		return ""
+	}
+	return cfg.Workspace
 }
 
 func runTrack(cmd *cobra.Command, args []string) error {
@@ -64,14 +91,27 @@ func runTrack(cmd *cobra.Command, args []string) error {
 		c, err := daemon.Dial(daemon.Handshake{Mode: daemon.ModeControl, ClientName: "cli"})
 		if err == nil {
 			defer func() { _ = c.Close() }()
-			resp, ctlErr := c.Control(daemon.ControlTrack, daemon.TrackParams{Path: absPath})
+			resp, ctlErr := c.Control(daemon.ControlTrack, daemon.TrackParams{
+				Path:       absPath,
+				Name:       trackName,
+				AsWorktree: trackAsWorktree,
+			})
 			if ctlErr != nil {
 				return ctlErr
 			}
 			if !resp.OK {
 				return fmt.Errorf("track rejected: %s %s", resp.ErrorCode, resp.ErrorMsg)
 			}
-			emitTrackSummary(w, absPath, trackResult{viaDaemon: true})
+			tr := trackResult{viaDaemon: true}
+			var meta struct {
+				Prefix string `json:"prefix"`
+				Status string `json:"status"`
+			}
+			if len(resp.Result) > 0 && json.Unmarshal(resp.Result, &meta) == nil {
+				tr.prefix = meta.Prefix
+				tr.alreadyTracked = meta.Status == "already_tracked"
+			}
+			emitTrackSummary(w, absPath, tr)
 			return nil
 		}
 	}
@@ -92,13 +132,26 @@ func runTrack(cmd *cobra.Command, args []string) error {
 	}
 
 	entry := config.RepoEntry{Path: absPath}
+	switch {
+	case trackName != "":
+		entry.Name = trackName
+	case trackAsWorktree:
+		// The AsWorktree flag is not persisted, so pin the derived
+		// instance prefix as the entry Name now. The daemon reproduces it
+		// intrinsically for a declared-workspace worktree, but a forced
+		// (branch-tagged) instance must be recorded here to survive.
+		base := config.ResolvePrefix(entry)
+		if name, sep := indexer.WorktreeInstanceName(absPath, base, declaredWorkspace(absPath), true); sep {
+			entry.Name = name
+		}
+	}
 	if err := gc.AddRepo(entry); err != nil {
 		return err
 	}
 	if err := gc.Save(); err != nil {
 		return fmt.Errorf("saving global config: %w", err)
 	}
-	emitTrackSummary(w, absPath, trackResult{configOnly: true, repoCount: len(gc.Repos) + 1})
+	emitTrackSummary(w, absPath, trackResult{configOnly: true, repoCount: len(gc.Repos) + 1, prefix: config.ResolvePrefix(entry)})
 	return nil
 }
 
@@ -108,7 +161,8 @@ type trackResult struct {
 	viaDaemon      bool
 	configOnly     bool
 	alreadyTracked bool
-	repoCount      int // tracked repo count *after* this call (configOnly path)
+	repoCount      int    // tracked repo count *after* this call (configOnly path)
+	prefix         string // the prefix the repo was registered under (may differ from basename for worktree instances)
 }
 
 // emitTrackBanner prints the gortex mesh banner + subtitle indicating which
@@ -140,18 +194,25 @@ func emitTrackSummary(w io.Writer, absPath string, r trackResult) {
 	if !progress.IsTTY(w) {
 		// Preserve the legacy one-line output for non-TTY callers so
 		// scripts that grep this line keep working.
+		suffix := ""
+		if r.prefix != "" && r.prefix != filepath.Base(absPath) {
+			suffix = fmt.Sprintf(" as %q", r.prefix)
+		}
 		switch {
 		case r.viaDaemon:
-			_, _ = fmt.Fprintf(w, "[gortex] tracked %s (via daemon)\n", absPath)
+			_, _ = fmt.Fprintf(w, "[gortex] tracked %s%s (via daemon)\n", absPath, suffix)
 		case r.alreadyTracked:
 			_, _ = fmt.Fprintf(w, "[gortex] already tracked: %s\n", absPath)
 		case r.configOnly:
-			_, _ = fmt.Fprintf(w, "[gortex] tracked %s (config only — start daemon to index)\n", absPath)
+			_, _ = fmt.Fprintf(w, "[gortex] tracked %s%s (config only — start daemon to index)\n", absPath, suffix)
 		}
 		return
 	}
 
 	var stats []string
+	if r.prefix != "" && r.prefix != filepath.Base(absPath) {
+		stats = append(stats, progress.Stat("prefix", r.prefix, progress.StatGood))
+	}
 	switch {
 	case r.viaDaemon:
 		stats = append(stats, progress.Stat("via daemon", "", progress.StatGood))

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -41,6 +41,13 @@ type RepoEntry struct {
 	// Project is the matching override for the project slug. Same
 	// precedence rules as Workspace.
 	Project string `mapstructure:"project" yaml:"project,omitempty"`
+	// AsWorktree is a transient track-time directive (the `--as-worktree`
+	// flag), never persisted: when set, a linked git worktree of an
+	// already-tracked repo is registered as an INDEPENDENT instance under
+	// a derived `<base>@<tag>` prefix instead of coalescing into the
+	// canonical checkout. The decision is recorded by persisting the
+	// derived prefix into Name, so this flag does not need to round-trip.
+	AsWorktree bool `mapstructure:"-" yaml:"-"`
 }
 
 // ProjectConfig defines a named project grouping repos.

--- a/internal/daemon/proto.go
+++ b/internal/daemon/proto.go
@@ -121,6 +121,10 @@ type TrackParams struct {
 	Name    string `json:"name,omitempty"`
 	Project string `json:"project,omitempty"`
 	Ref     string `json:"ref,omitempty"`
+	// AsWorktree forces a linked git worktree of an already-tracked repo
+	// to be registered as an independent instance (the `--as-worktree`
+	// flag) rather than coalescing into the canonical checkout.
+	AsWorktree bool `json:"as_worktree,omitempty"`
 }
 
 // UntrackParams is the payload for ControlUntrack.

--- a/internal/indexer/identity.go
+++ b/internal/indexer/identity.go
@@ -115,6 +115,13 @@ func NormalizeRemoteURL(rawURL string) string {
 
 // DeduplicateRepos returns a deduplicated list of repo entries (last occurrence wins)
 // and warning messages for any duplicates detected by canonical identity.
+//
+// WARNING: dedup is keyed purely on git identity (remote URL / path), so
+// it treats a linked worktree of an already-tracked repo as a duplicate
+// of the canonical checkout. Do NOT wire this into the track / warmup
+// path: a worktree tracked as an independent instance (see
+// WorktreeInstanceName) shares the canonical's identity but is a
+// distinct, intentional entry. Currently unused — kept for reference.
 func DeduplicateRepos(entries []config.RepoEntry) ([]config.RepoEntry, []string) {
 	if len(entries) == 0 {
 		return entries, nil

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -87,6 +87,14 @@ type IndexResult struct {
 	DeletedFileCount int          `json:"deleted_file_count,omitempty"`
 	DurationMs       int64        `json:"duration_ms"`
 	Errors           []IndexError `json:"errors,omitempty"`
+	// RepoPrefix is the prefix the repo was actually registered under.
+	// It usually equals config.ResolvePrefix(entry), but a git worktree
+	// tracked as an independent instance gets a derived `<base>@<tag>`
+	// prefix that the caller cannot recompute from the (by-value) entry
+	// it passed in — callers that need to attach a watcher or report the
+	// outcome read it from here. Populated by the multi-repo track and
+	// reconcile paths; empty in single-repo mode.
+	RepoPrefix string `json:"repo_prefix,omitempty"`
 }
 
 // EdgeSanityViolated reports the post-reindex sanity-check failure: an

--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -1011,6 +1011,36 @@ func (mi *MultiIndexer) resolveTrackPrefix(entry *config.RepoEntry, absPath stri
 	return prefix, mi.configMgr.GetRepoConfig(prefix)
 }
 
+// EffectiveRepoPrefix returns the prefix a repo entry is tracked under,
+// accounting for git-worktree instancing — the same value
+// resolveTrackPrefix registers, minus the (rare) collision-guard suffix
+// it cannot reproduce without the live registry. Warm-restart keying
+// (the snapshot-store mtime lookup, the resolve-time LSP helper
+// registry) uses this instead of config.ResolvePrefix so a disk-backed
+// reconcile finds the worktree instance's own persisted state rather
+// than the canonical checkout's. For a plain repo it equals
+// config.ResolvePrefix(entry). cm may be nil (then only an explicit
+// RepoEntry.Workspace override can trigger instancing).
+func EffectiveRepoPrefix(cm *config.ConfigManager, entry config.RepoEntry) string {
+	base := config.ResolvePrefix(entry)
+	if base == "" || base == "." || entry.Name != "" {
+		return base
+	}
+	absPath, err := filepath.Abs(entry.Path)
+	if err != nil {
+		return base
+	}
+	declaredWS := entry.Workspace
+	if declaredWS == "" && cm != nil {
+		cm.LoadWorkspaceConfig(base, absPath)
+		if cfg := cm.GetRepoConfig(base); cfg != nil {
+			declaredWS = cfg.Workspace
+		}
+	}
+	name, _ := WorktreeInstanceName(absPath, base, declaredWS, entry.AsWorktree)
+	return name
+}
+
 // TrackRepoCtx is TrackRepo with a context, allowing callers to pipe progress
 // reporters (via progress.WithReporter) through to the underlying Index call.
 func (mi *MultiIndexer) TrackRepoCtx(ctx context.Context, entry config.RepoEntry) (*IndexResult, error) {

--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -643,6 +643,7 @@ func (mi *MultiIndexer) indexSingleRepo(entry config.RepoEntry) (map[string]*Ind
 	if err != nil {
 		return nil, fmt.Errorf("indexing %s: %w", absPath, err)
 	}
+	result.RepoPrefix = prefix
 
 	identity, _ := DetectIdentity(absPath)
 
@@ -690,40 +691,60 @@ func (mi *MultiIndexer) indexMultiRepo(repos []config.RepoEntry) (map[string]*In
 		err    error
 	}
 
-	// Pre-scan: build tracked repo module map from go.mod files.
-	// This enables cross-repo dependency detection via GoModExtractor.
+	// Resolve each repo's prefix serially first: git-worktree instancing,
+	// the derived-name persistence, and the cross-batch collision guard
+	// must be deterministic, not raced across the parallel index
+	// goroutines below. The same loop builds the tracked-module map used
+	// for cross-repo dependency detection.
+	type resolvedRepo struct {
+		entry    config.RepoEntry
+		prefix   string
+		cfg      *config.Config
+		absPath  string
+		identity *RepoIdentity
+	}
 	trackedModules := make(map[string]string)
+	resolved := make([]resolvedRepo, 0, len(repos))
+	seenPrefix := make(map[string]string, len(repos)) // prefix → absPath
+	var resolveErrors []string
 	for _, entry := range repos {
-		prefix := config.ResolvePrefix(entry)
-		absPath, _ := filepath.Abs(entry.Path)
+		absPath, err := filepath.Abs(entry.Path)
+		if err != nil {
+			resolveErrors = append(resolveErrors, fmt.Sprintf("resolving path %s: %v", entry.Path, err))
+			continue
+		}
+		identity, _ := DetectIdentity(absPath)
+		e := entry
+		prefix, cfg := mi.resolveTrackPrefix(&e, absPath, identity)
+		// Two distinct checkouts can still land on the same derived prefix
+		// (e.g. two worktrees declaring the same workspace). resolveTrackPrefix
+		// only sees already-tracked repos, so guard against collisions within
+		// this batch too.
+		if prev, ok := seenPrefix[prefix]; ok && prev != absPath {
+			prefix += "-" + shortPathHash(absPath)
+			e.Name = prefix
+		}
+		seenPrefix[prefix] = absPath
+		resolved = append(resolved, resolvedRepo{entry: e, prefix: prefix, cfg: cfg, absPath: absPath, identity: identity})
 		if mod := readGoModModule(absPath); mod != "" {
 			trackedModules[prefix] = mod
 			mi.logger.Debug("tracked repo module", zap.String("repo", prefix), zap.String("module", mod))
 		}
 	}
 
-	resultCh := make(chan repoResult, len(repos))
+	resultCh := make(chan repoResult, len(resolved))
 	var wg sync.WaitGroup
 
-	for _, entry := range repos {
+	for _, rr := range resolved {
 		wg.Add(1)
-		go func(e config.RepoEntry) {
+		go func(r resolvedRepo) {
 			defer wg.Done()
 
-			prefix := config.ResolvePrefix(e)
-			absPath, err := filepath.Abs(e.Path)
-			if err != nil {
-				resultCh <- repoResult{prefix: prefix, err: fmt.Errorf("resolving path %s: %w", e.Path, err)}
-				return
-			}
-
-			mi.configMgr.LoadWorkspaceConfig(prefix, absPath)
-			cfg := mi.configMgr.GetRepoConfig(prefix)
-			idx := mi.newPerRepoIndexer(cfg.Index)
-			idx.SetRepoPrefix(prefix)
-			entryCopy := e
-			idx.SetWorkspaceID(resolveWorkspaceID(&entryCopy, cfg, prefix))
-			idx.SetProjectID(resolveProjectID(&entryCopy, cfg, prefix))
+			idx := mi.newPerRepoIndexer(r.cfg.Index)
+			idx.SetRepoPrefix(r.prefix)
+			entryCopy := r.entry
+			idx.SetWorkspaceID(resolveWorkspaceID(&entryCopy, r.cfg, r.prefix))
+			idx.SetProjectID(resolveProjectID(&entryCopy, r.cfg, r.prefix))
 			idx.SetTrackedRepoModules(trackedModules)
 			// Defer the per-repo cross-cutting passes (ResolveAll,
 			// semantic enrich, contract extract+commit) so they don't
@@ -733,29 +754,28 @@ func (mi *MultiIndexer) indexMultiRepo(repos []config.RepoEntry) (map[string]*In
 			// the loop via mi.RunGlobalGraphPasses().
 			idx.SetDeferResolve(true)
 
-			result, err := idx.Index(absPath)
+			result, err := idx.Index(r.absPath)
 			if err != nil {
-				resultCh <- repoResult{prefix: prefix, err: fmt.Errorf("indexing %s: %w", absPath, err)}
+				resultCh <- repoResult{prefix: r.prefix, err: fmt.Errorf("indexing %s: %w", r.absPath, err)}
 				return
 			}
-
-			identity, _ := DetectIdentity(absPath)
+			result.RepoPrefix = r.prefix
 
 			meta := &RepoMetadata{
-				RepoPrefix:    prefix,
-				RootPath:      absPath,
-				Identity:      identity,
+				RepoPrefix:    r.prefix,
+				RootPath:      r.absPath,
+				Identity:      r.identity,
 				LastIndexTime: time.Now(),
 				FileCount:     result.FileCount,
 				NodeCount:     result.NodeCount,
 				EdgeCount:     result.EdgeCount,
 				ParseErrors:   result.Errors,
 				FileMtimes:    idx.FileMtimes(),
-				IsWorktree:    ResolveWorktree(absPath).IsWorktree,
+				IsWorktree:    ResolveWorktree(r.absPath).IsWorktree,
 			}
 
-			resultCh <- repoResult{prefix: prefix, result: result, idx: idx, meta: meta}
-		}(entry)
+			resultCh <- repoResult{prefix: r.prefix, result: result, idx: idx, meta: meta}
+		}(rr)
 	}
 
 	go func() {
@@ -764,7 +784,7 @@ func (mi *MultiIndexer) indexMultiRepo(repos []config.RepoEntry) (map[string]*In
 	}()
 
 	results := make(map[string]*IndexResult)
-	var indexErrors []string
+	indexErrors := resolveErrors
 
 	mi.mu.Lock()
 	for rr := range resultCh {
@@ -927,6 +947,70 @@ func (mi *MultiIndexer) TrackRepo(entry config.RepoEntry) (*IndexResult, error) 
 	return mi.TrackRepoCtx(context.Background(), entry)
 }
 
+// resolveTrackPrefix determines the repo prefix that absPath should be
+// registered under and loads the per-repo `.gortex.yaml` config keyed to
+// that prefix. It is the single place that decides whether a git
+// worktree of an already-tracked repo becomes an INDEPENDENT instance
+// (see WorktreeInstanceName); the track and reconcile paths both call it
+// before their "already tracked?" check so a worktree that joins a
+// different workspace than the canonical no longer silently coalesces
+// into it.
+//
+// When a separate instance is created the derived `<base>@<tag>` prefix
+// is written back into entry.Name so it is persisted to config and
+// reproduced deterministically on the next daemon warmup. entry is
+// mutated in place; callers pass a pointer to the value they will add to
+// the global config.
+func (mi *MultiIndexer) resolveTrackPrefix(entry *config.RepoEntry, absPath string, identity *RepoIdentity) (string, *config.Config) {
+	base := config.ResolvePrefix(*entry)
+	if base == "" || base == "." {
+		if identity != nil {
+			base = identity.RepoPrefix
+		}
+	}
+	if mi.configMgr == nil {
+		return base, config.Default()
+	}
+
+	// Load the repo's `.gortex.yaml` under the base prefix first so we can
+	// read its declared workspace before deciding the final prefix.
+	mi.configMgr.LoadWorkspaceConfig(base, absPath)
+	cfg := mi.configMgr.GetRepoConfig(base)
+
+	// An explicit Name already pins the prefix — honour it verbatim. This
+	// is also the warm-restart fast path: once a worktree instance has
+	// been persisted with its derived Name, every later load short-circuits
+	// here without re-deriving.
+	if entry.Name != "" {
+		return base, cfg
+	}
+
+	declaredWS := entry.Workspace
+	if declaredWS == "" && cfg != nil {
+		declaredWS = cfg.Workspace
+	}
+
+	name, separate := WorktreeInstanceName(absPath, base, declaredWS, entry.AsWorktree)
+	if !separate {
+		return base, cfg
+	}
+
+	// Guard against two different checkouts colliding on the same derived
+	// name (e.g. two worktrees that both declare workspace `x`): keep the
+	// first, suffix the rest with a path hash.
+	prefix := name
+	mi.mu.RLock()
+	existing, ok := mi.repos[prefix]
+	mi.mu.RUnlock()
+	if ok && existing != nil && existing.RootPath != absPath {
+		prefix = name + "-" + shortPathHash(absPath)
+	}
+
+	entry.Name = prefix // persist the decision so warmup reproduces it
+	mi.configMgr.LoadWorkspaceConfig(prefix, absPath)
+	return prefix, mi.configMgr.GetRepoConfig(prefix)
+}
+
 // TrackRepoCtx is TrackRepo with a context, allowing callers to pipe progress
 // reporters (via progress.WithReporter) through to the underlying Index call.
 func (mi *MultiIndexer) TrackRepoCtx(ctx context.Context, entry config.RepoEntry) (*IndexResult, error) {
@@ -949,10 +1033,17 @@ func (mi *MultiIndexer) TrackRepoCtx(ctx context.Context, entry config.RepoEntry
 		return nil, fmt.Errorf("detecting identity for %s: %w", absPath, err)
 	}
 
-	prefix := config.ResolvePrefix(entry)
-	if prefix == "" || prefix == "." {
-		prefix = identity.RepoPrefix
-	}
+	// Resolve the prefix (honouring git-worktree instancing) and load the
+	// per-repo `.gortex.yaml` BEFORE the already-tracked check, so a
+	// worktree that joins a different workspace than the canonical gets
+	// its own `<base>@<tag>` prefix instead of coalescing into it. cfg is
+	// keyed to the final prefix; entry.Name is set when a separate
+	// instance is created so the decision persists to config. Loading the
+	// `.gortex.yaml` here also gives GetRepoConfig the workspace / project
+	// slugs declared inside the repo (without it every repo would fall
+	// back to `workspace = repoPrefix`, making shared-workspace cross-repo
+	// matching impossible to express).
+	prefix, cfg := mi.resolveTrackPrefix(&entry, absPath, identity)
 
 	// Check if already tracked.
 	mi.mu.RLock()
@@ -980,17 +1071,6 @@ func (mi *MultiIndexer) TrackRepoCtx(ctx context.Context, entry config.RepoEntry
 	}
 	willBeMultiRepo := len(mi.repos)+1 >= 2 || totalConfigured >= 2
 
-	// Lazy-load the per-repo `.gortex.yaml` so GetRepoConfig sees the
-	// workspace / project slugs declared inside the repo. Without
-	// this the production code path never reads the file and every
-	// repo silently falls back to `workspace = repoPrefix`, making
-	// shared-workspace cross-repo matching impossible to express. Idempotent
-	// — repeated calls just re-cache the parse.
-	if mi.configMgr != nil {
-		mi.configMgr.LoadWorkspaceConfig(prefix, absPath)
-	}
-
-	cfg := mi.configMgr.GetRepoConfig(prefix)
 	idx := mi.newPerRepoIndexer(cfg.Index)
 	if willBeMultiRepo {
 		idx.SetRepoPrefix(prefix)
@@ -1010,6 +1090,7 @@ func (mi *MultiIndexer) TrackRepoCtx(ctx context.Context, entry config.RepoEntry
 	if err != nil {
 		return nil, fmt.Errorf("indexing %s: %w", absPath, err)
 	}
+	result.RepoPrefix = prefix
 
 	mi.mu.Lock()
 	mi.repos[prefix] = &RepoMetadata{
@@ -1075,10 +1156,12 @@ func (mi *MultiIndexer) ReconcileRepoCtx(ctx context.Context, entry config.RepoE
 		return nil, fmt.Errorf("detecting identity for %s: %w", absPath, err)
 	}
 
-	prefix := config.ResolvePrefix(entry)
-	if prefix == "" || prefix == "." {
-		prefix = identity.RepoPrefix
-	}
+	// Resolve the prefix (honouring git-worktree instancing) and load the
+	// per-repo `.gortex.yaml` before the already-tracked check. Mirrors
+	// TrackRepoCtx so a worktree instance keeps its derived prefix on the
+	// reconcile path too; config can change between sessions and warmup-
+	// time reconcile runs after a daemon restart.
+	prefix, cfg := mi.resolveTrackPrefix(&entry, absPath, identity)
 
 	// Already tracked — nothing to do.
 	mi.mu.RLock()
@@ -1091,7 +1174,9 @@ func (mi *MultiIndexer) ReconcileRepoCtx(ctx context.Context, entry config.RepoE
 	// Fall back to full TrackRepoCtx when we have no prior mtimes:
 	// there's nothing meaningful to reconcile against, and
 	// IncrementalReindex would treat every file as stale, producing
-	// the same duplicate-writes problem we're fixing.
+	// the same duplicate-writes problem we're fixing. entry.Name is
+	// already pinned by resolveTrackPrefix, so the fallback reproduces
+	// the same prefix.
 	if len(priorMtimes) == 0 {
 		return mi.TrackRepoCtx(ctx, entry)
 	}
@@ -1102,14 +1187,6 @@ func (mi *MultiIndexer) ReconcileRepoCtx(ctx context.Context, entry config.RepoE
 	}
 	willBeMultiRepo := len(mi.repos)+1 >= 2 || totalConfigured >= 2
 
-	// Pick up `.gortex.yaml` workspace/project declarations on
-	// reconcile too — config can change between sessions, and warmup-
-	// time reconcile is the path that runs after a daemon restart.
-	if mi.configMgr != nil {
-		mi.configMgr.LoadWorkspaceConfig(prefix, absPath)
-	}
-
-	cfg := mi.configMgr.GetRepoConfig(prefix)
 	idx := mi.newPerRepoIndexer(cfg.Index)
 	if willBeMultiRepo {
 		idx.SetRepoPrefix(prefix)
@@ -1157,6 +1234,7 @@ func (mi *MultiIndexer) ReconcileRepoCtx(ctx context.Context, entry config.RepoE
 	if err != nil {
 		return nil, fmt.Errorf("reconciling %s: %w", absPath, err)
 	}
+	result.RepoPrefix = prefix
 
 	mi.mu.Lock()
 	mi.repos[prefix] = &RepoMetadata{

--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -1622,13 +1622,25 @@ func (mi *MultiIndexer) ResolveFilePath(prefixedPath string) string {
 	mi.mu.RLock()
 	defer mi.mu.RUnlock()
 
+	// Longest matching prefix wins. With worktree instances two prefixes
+	// can share a leading segment (`oas-orm` vs `oas-orm@task-ws`); map
+	// iteration order is random, so a plain first-match could resolve a
+	// `oas-orm@task-ws/...` path against the shorter `oas-orm` root. The
+	// "/"-boundary check already keeps the two disjoint, but ranking by
+	// length makes that robust regardless of any future prefix shapes.
+	var bestPrefix, bestRoot string
 	for prefix, meta := range mi.repos {
-		if strings.HasPrefix(prefixedPath, prefix+"/") {
-			relPath := strings.TrimPrefix(prefixedPath, prefix+"/")
-			return filepath.Join(meta.RootPath, relPath)
+		if meta == nil {
+			continue
+		}
+		if strings.HasPrefix(prefixedPath, prefix+"/") && len(prefix) > len(bestPrefix) {
+			bestPrefix, bestRoot = prefix, meta.RootPath
 		}
 	}
-	return ""
+	if bestPrefix == "" {
+		return ""
+	}
+	return filepath.Join(bestRoot, strings.TrimPrefix(prefixedPath, bestPrefix+"/"))
 }
 
 // RepoPrefixes returns the set of registered repo prefixes. The returned

--- a/internal/indexer/worktree.go
+++ b/internal/indexer/worktree.go
@@ -2,7 +2,10 @@ package indexer
 
 import (
 	"errors"
+	"fmt"
+	"hash/fnv"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -114,4 +117,93 @@ func WorktreeRootGone(rootPath string) bool {
 		return false
 	}
 	return errors.Is(err, os.ErrNotExist)
+}
+
+// WorktreeInstanceName decides the repo prefix that absPath should be
+// tracked under, given the base prefix it would otherwise take and the
+// workspace it declares (via its own `.gortex.yaml` or a global-config
+// override). It returns (name, separate): when separate is true the
+// caller must register absPath as an INDEPENDENT repo instance under
+// `name`, distinct from any canonical checkout that shares the same git
+// identity; when false the caller keeps its single-instance behaviour.
+//
+// A separate instance is created when either:
+//   - asWorktree is set (the explicit `--as-worktree` directive), or
+//   - absPath is a linked git worktree that declares a workspace which
+//     differs from its base prefix. An explicit workspace on a worktree
+//     is the signal that the checkout means to join a workspace other
+//     than the canonical's, so we honour it automatically.
+//
+// The instance name is `<basePrefix>@<tag>`, where the tag is the
+// declared workspace when present, else the checked-out branch, else a
+// short hash of the path. The result is deterministic for a given
+// (path, declared-workspace) pair so it is stable across daemon
+// restarts. The tag is sanitised so the name never contains '/', which
+// would break the `<prefix>/<relpath>` node-ID layout.
+func WorktreeInstanceName(absPath, basePrefix, declaredWorkspace string, asWorktree bool) (string, bool) {
+	separate := asWorktree
+	if !separate && declaredWorkspace != "" && declaredWorkspace != basePrefix {
+		separate = ResolveWorktree(absPath).IsWorktree
+	}
+	if !separate {
+		return basePrefix, false
+	}
+
+	tag := ""
+	if declaredWorkspace != "" && declaredWorkspace != basePrefix {
+		tag = declaredWorkspace
+	}
+	if tag == "" {
+		tag = worktreeBranch(absPath)
+	}
+	if t := sanitizeInstanceTag(tag); t != "" {
+		return basePrefix + "@" + t, true
+	}
+	return basePrefix + "@" + shortPathHash(absPath), true
+}
+
+// worktreeBranch returns the short branch name checked out at absPath, or
+// "" when the path is not a git working tree or is in detached-HEAD
+// state. Used to disambiguate a forced worktree instance that declares
+// no workspace of its own.
+func worktreeBranch(absPath string) string {
+	cmd := exec.Command("git", "-C", absPath, "rev-parse", "--abbrev-ref", "HEAD")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	b := strings.TrimSpace(string(out))
+	if b == "" || b == "HEAD" { // detached HEAD has no branch name
+		return ""
+	}
+	return b
+}
+
+// sanitizeInstanceTag normalises a disambiguator (a workspace slug or a
+// branch name) into a token safe to embed in a repo prefix. A repo
+// prefix is the leading "<prefix>/" segment of every node ID, so the
+// token must never contain '/'; any character outside [A-Za-z0-9._-] is
+// folded to '-'. Leading/trailing '-' are trimmed; empty input maps to "".
+func sanitizeInstanceTag(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9',
+			r == '.', r == '_', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+// shortPathHash returns a short, stable hash of a filesystem path. It is
+// the last-resort disambiguator when a forced worktree instance has
+// neither a declared workspace nor a resolvable branch — two different
+// checkouts under the same name still get distinct prefixes.
+func shortPathHash(absPath string) string {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(filepath.Clean(absPath)))
+	return fmt.Sprintf("%08x", h.Sum32())
 }

--- a/internal/indexer/worktree.go
+++ b/internal/indexer/worktree.go
@@ -36,9 +36,11 @@ type WorktreeInfo struct {
 // repository, not a worktree. A main checkout or a non-git directory
 // likewise resolves to itself.
 //
-// Keying the index cache by MainRepoPath lets every worktree of one
-// repo share a base identity; combined with branch-keyed snapshots
-// each worktree still gets its own slot.
+// A worktree can be tracked either as part of its canonical repo (the
+// default) or, via WorktreeInstanceName, as an independent instance
+// keyed by its own working-directory path — letting one underlying
+// repository have multiple checkouts, each assigned to its own
+// workspace and indexed from its own branch / working tree.
 func ResolveWorktree(path string) WorktreeInfo {
 	abs, err := filepath.Abs(path)
 	if err != nil {

--- a/internal/indexer/worktree_instance_test.go
+++ b/internal/indexer/worktree_instance_test.go
@@ -1,0 +1,297 @@
+package indexer
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/search"
+)
+
+// gitInitRepo initialises a fresh git repo at dir with deterministic
+// commit settings, independent of the developer's global git config.
+func gitInitRepo(t *testing.T, dir string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	runGit(t, dir, "init", "-q", "-b", "main")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "Test")
+	runGit(t, dir, "config", "commit.gpgsign", "false")
+}
+
+// setupCollidingWorktree builds a canonical checkout and a linked git
+// worktree that SHARE A BASENAME (the issue's `oas-orm` collision) so
+// both would otherwise resolve to the same repo prefix. The worktree is
+// checked out on `branch`; when wtWorkspace is non-empty it gets a
+// `.gortex.yaml` declaring that workspace. Returns (canonPath, wtPath).
+func setupCollidingWorktree(t *testing.T, basename, branch, wtWorkspace string) (string, string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available in PATH")
+	}
+	canon := filepath.Join(t.TempDir(), basename)
+	gitInitRepo(t, canon)
+	writeFile(t, filepath.Join(canon, "lib.go"), "package lib\n\nfunc Canonical() {}\n")
+	runGit(t, canon, "add", ".")
+	runGit(t, canon, "commit", "-q", "-m", "init")
+
+	wt := filepath.Join(t.TempDir(), basename)
+	runGit(t, canon, "worktree", "add", "-q", "-b", branch, wt)
+	writeFile(t, filepath.Join(wt, "feature.go"), "package lib\n\nfunc Feature() {}\n")
+	if wtWorkspace != "" {
+		writeFile(t, filepath.Join(wt, ".gortex.yaml"), "workspace: "+wtWorkspace+"\n")
+	}
+	return canon, wt
+}
+
+func newWorktreeTestIndexer(t *testing.T, repos ...config.RepoEntry) (*graph.Graph, *MultiIndexer, *config.ConfigManager) {
+	t.Helper()
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	gc := &config.GlobalConfig{Repos: repos}
+	gc.SetConfigPath(cfgPath)
+	require.NoError(t, gc.Save())
+	cm, err := config.NewConfigManager(cfgPath)
+	require.NoError(t, err)
+	g := graph.New()
+	mi := NewMultiIndexer(g, newTestRegistry(), search.NewBM25(), cm, zap.NewNop())
+	return g, mi, cm
+}
+
+// TestWorktreeInstance_IndexAll_AutoSeparatesByWorkspace is the core
+// regression for issue #47: a worktree of an already-tracked repo, whose
+// `.gortex.yaml` declares a different workspace, must be indexed as an
+// INDEPENDENT instance instead of silently coalescing into the canonical.
+func TestWorktreeInstance_IndexAll_AutoSeparatesByWorkspace(t *testing.T) {
+	canon, wt := setupCollidingWorktree(t, "oas-orm", "task", "task-ws")
+
+	g, mi, _ := newWorktreeTestIndexer(t,
+		config.RepoEntry{Path: canon}, // canonical, base prefix oas-orm
+		config.RepoEntry{Path: wt},    // worktree declaring workspace task-ws
+	)
+	results, err := mi.IndexAll()
+	require.NoError(t, err)
+
+	// Two independent instances, not one coalesced entry.
+	require.Len(t, results, 2, "the worktree must not coalesce into the canonical")
+	canonMeta := mi.GetMetadata("oas-orm")
+	wtMeta := mi.GetMetadata("oas-orm@task-ws")
+	require.NotNil(t, canonMeta, "canonical keeps the base prefix")
+	require.NotNil(t, wtMeta, "worktree is tracked under a derived prefix")
+	assert.False(t, canonMeta.IsWorktree)
+	assert.True(t, wtMeta.IsWorktree)
+	assert.Equal(t, realpath(t, canon), realpath(t, canonMeta.RootPath))
+	assert.Equal(t, realpath(t, wt), realpath(t, wtMeta.RootPath))
+
+	// Each instance's files are namespaced under its own prefix and do
+	// not bleed into the other.
+	assert.NotEmpty(t, g.GetFileNodes("oas-orm/lib.go"))
+	assert.NotEmpty(t, g.GetFileNodes("oas-orm@task-ws/feature.go"))
+	assert.Empty(t, g.GetFileNodes("oas-orm/feature.go"),
+		"the worktree's branch-only file must not appear under the canonical")
+
+	// Per-instance workspace membership.
+	inTask := mi.ReposInWorkspace("task-ws")
+	assert.True(t, inTask["oas-orm@task-ws"], "worktree joins task-ws")
+	assert.False(t, inTask["oas-orm"], "canonical does not join task-ws")
+
+	// A session launched from inside the worktree resolves to its
+	// workspace, not the canonical's.
+	ws, _, prefix, ok := mi.ScopeForCWD(wt)
+	require.True(t, ok)
+	assert.Equal(t, "task-ws", ws)
+	assert.Equal(t, "oas-orm@task-ws", prefix)
+}
+
+// TestWorktreeInstance_PlainWorktreeStillCoalesces guards the opposite
+// case: a worktree that declares NO distinct workspace (and is not
+// flagged) keeps the legacy behaviour and coalesces into the canonical —
+// we don't want to double-index every incidental worktree.
+func TestWorktreeInstance_PlainWorktreeStillCoalesces(t *testing.T) {
+	canon, wt := setupCollidingWorktree(t, "oas-orm", "task", "") // no .gortex.yaml
+
+	_, mi, _ := newWorktreeTestIndexer(t,
+		config.RepoEntry{Path: canon},
+		config.RepoEntry{Path: wt},
+	)
+	results, err := mi.IndexAll()
+	require.NoError(t, err)
+
+	// Same basename, same (default) workspace → one instance wins; there
+	// is exactly one "oas-orm" and no "oas-orm@..." sibling.
+	assert.NotNil(t, mi.GetMetadata("oas-orm"))
+	for prefix := range mi.AllMetadata() {
+		assert.NotContains(t, prefix, "@",
+			"a plain worktree must not spawn a separate instance, got %q", prefix)
+	}
+	_ = results
+}
+
+// TestWorktreeInstance_TrackCtx_NoCoalesce_PersistsName exercises the
+// interactive runtime path: track the canonical, then track the worktree
+// as a brand-new path. The derived prefix must be returned and persisted
+// as the entry Name so a daemon restart reproduces it.
+func TestWorktreeInstance_TrackCtx_NoCoalesce_PersistsName(t *testing.T) {
+	canon, wt := setupCollidingWorktree(t, "oas-orm", "task", "task-ws")
+
+	// Pre-list canon plus a placeholder so multi-repo prefixing is on
+	// from the first track (single-repo mode would skip prefixes).
+	placeholder := filepath.Join(t.TempDir(), "placeholder")
+	require.NoError(t, os.MkdirAll(placeholder, 0o755))
+	_, mi, cm := newWorktreeTestIndexer(t,
+		config.RepoEntry{Path: canon},
+		config.RepoEntry{Path: placeholder},
+	)
+
+	rCanon, err := mi.TrackRepoCtx(testCtx(), config.RepoEntry{Path: canon})
+	require.NoError(t, err)
+	require.NotNil(t, rCanon)
+	assert.Equal(t, "oas-orm", rCanon.RepoPrefix)
+
+	rWt, err := mi.TrackRepoCtx(testCtx(), config.RepoEntry{Path: wt})
+	require.NoError(t, err)
+	require.NotNil(t, rWt, "worktree must not coalesce into the canonical")
+	assert.Equal(t, "oas-orm@task-ws", rWt.RepoPrefix)
+
+	// The derived prefix is persisted as the entry Name (wt was a fresh
+	// path, so AddRepo recorded it).
+	entry := cm.Global().FindRepoByPrefix("oas-orm@task-ws")
+	require.NotNil(t, entry, "the worktree instance must be persisted to config")
+	assert.Equal(t, "oas-orm@task-ws", entry.Name)
+	assert.Equal(t, realpath(t, wt), realpath(t, mustAbs(t, entry.Path)))
+
+	// Re-tracking the same worktree path is an idempotent no-op.
+	again, err := mi.TrackRepoCtx(testCtx(), config.RepoEntry{Path: wt})
+	require.NoError(t, err)
+	assert.Nil(t, again, "re-tracking the worktree must be already-tracked")
+}
+
+// TestWorktreeInstance_DeterministicAcrossRestart verifies the derived
+// prefix is stable: a fresh MultiIndexer over the same config reproduces
+// the same instance prefixes (the auto rule is intrinsic, so it does not
+// depend on a persisted Name or on tracking order).
+func TestWorktreeInstance_DeterministicAcrossRestart(t *testing.T) {
+	canon, wt := setupCollidingWorktree(t, "oas-orm", "task", "task-ws")
+
+	for _, pass := range []string{"first", "second"} {
+		_, mi, _ := newWorktreeTestIndexer(t,
+			config.RepoEntry{Path: canon},
+			config.RepoEntry{Path: wt},
+		)
+		_, err := mi.IndexAll()
+		require.NoError(t, err, pass)
+		require.NotNil(t, mi.GetMetadata("oas-orm"), pass)
+		require.NotNil(t, mi.GetMetadata("oas-orm@task-ws"), pass)
+	}
+}
+
+// TestWorktreeInstance_TwoWorktreesSameWorkspaceDisambiguated covers the
+// degenerate collision: two different worktrees of the same repo that
+// both declare the same workspace must still get distinct prefixes.
+func TestWorktreeInstance_TwoWorktreesSameWorkspaceDisambiguated(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available in PATH")
+	}
+	canon := filepath.Join(t.TempDir(), "oas-orm")
+	gitInitRepo(t, canon)
+	writeFile(t, filepath.Join(canon, "lib.go"), "package lib\n\nfunc Canonical() {}\n")
+	runGit(t, canon, "add", ".")
+	runGit(t, canon, "commit", "-q", "-m", "init")
+
+	wtA := filepath.Join(t.TempDir(), "oas-orm")
+	runGit(t, canon, "worktree", "add", "-q", "-b", "a", wtA)
+	writeFile(t, filepath.Join(wtA, ".gortex.yaml"), "workspace: shared\n")
+	writeFile(t, filepath.Join(wtA, "a.go"), "package lib\n\nfunc A() {}\n")
+
+	wtB := filepath.Join(t.TempDir(), "oas-orm")
+	runGit(t, canon, "worktree", "add", "-q", "-b", "b", wtB)
+	writeFile(t, filepath.Join(wtB, ".gortex.yaml"), "workspace: shared\n")
+	writeFile(t, filepath.Join(wtB, "b.go"), "package lib\n\nfunc B() {}\n")
+
+	_, mi, _ := newWorktreeTestIndexer(t,
+		config.RepoEntry{Path: canon},
+		config.RepoEntry{Path: wtA},
+		config.RepoEntry{Path: wtB},
+	)
+	_, err := mi.IndexAll()
+	require.NoError(t, err)
+
+	// Both worktrees want "oas-orm@shared"; one keeps it, the other gets
+	// a path-hash suffix. Exactly three distinct instances total.
+	assert.Len(t, mi.AllMetadata(), 3)
+	shared := 0
+	for prefix := range mi.AllMetadata() {
+		if prefix == "oas-orm@shared" || (len(prefix) > len("oas-orm@shared-") && prefix[:len("oas-orm@shared-")] == "oas-orm@shared-") {
+			shared++
+		}
+	}
+	assert.Equal(t, 2, shared, "two distinct worktree instances under the shared workspace")
+}
+
+func mustAbs(t *testing.T, p string) string {
+	t.Helper()
+	abs, err := filepath.Abs(p)
+	require.NoError(t, err)
+	return abs
+}
+
+func TestSanitizeInstanceTag(t *testing.T) {
+	cases := map[string]string{
+		"task-ws":       "task-ws",
+		"feature/foo":   "feature-foo", // branch slashes can't reach a node-ID
+		"a@b":           "a-b",
+		"  spaced  ":    "spaced",
+		"--edges--":     "edges",
+		"keep.dots_1":   "keep.dots_1",
+		"weird*chars!":  "weird-chars",
+		"":              "",
+		"///":           "",
+		"release/1.2.3": "release-1.2.3",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, sanitizeInstanceTag(in), "sanitizeInstanceTag(%q)", in)
+	}
+}
+
+func TestWorktreeInstanceName_Unit(t *testing.T) {
+	nonGit := t.TempDir() // not a git working tree
+
+	// No declared workspace and no flag → keep the base prefix.
+	name, sep := WorktreeInstanceName(nonGit, "lib", "", false)
+	assert.False(t, sep)
+	assert.Equal(t, "lib", name)
+
+	// Declared workspace equal to the base prefix is not a separation
+	// signal.
+	name, sep = WorktreeInstanceName(nonGit, "lib", "lib", false)
+	assert.False(t, sep)
+	assert.Equal(t, "lib", name)
+
+	// A declared workspace on a path that is NOT a linked worktree does
+	// not auto-separate (only real worktrees do).
+	name, sep = WorktreeInstanceName(nonGit, "lib", "other-ws", false)
+	assert.False(t, sep)
+	assert.Equal(t, "lib", name)
+
+	// The explicit flag forces separation; the declared workspace is the
+	// tag.
+	name, sep = WorktreeInstanceName(nonGit, "lib", "task-ws", true)
+	assert.True(t, sep)
+	assert.Equal(t, "lib@task-ws", name)
+
+	// Forced separation with no declared workspace and no resolvable
+	// branch falls back to a stable path hash.
+	name, sep = WorktreeInstanceName(nonGit, "lib", "", true)
+	assert.True(t, sep)
+	assert.True(t, len(name) > len("lib@"))
+	assert.Equal(t, "lib@"+shortPathHash(nonGit), name)
+	// Deterministic for the same path.
+	name2, _ := WorktreeInstanceName(nonGit, "lib", "", true)
+	assert.Equal(t, name, name2)
+}

--- a/internal/indexer/worktree_instance_test.go
+++ b/internal/indexer/worktree_instance_test.go
@@ -242,6 +242,29 @@ func TestWorktreeInstance_TwoWorktreesSameWorkspaceDisambiguated(t *testing.T) {
 	assert.Equal(t, 2, shared, "two distinct worktree instances under the shared workspace")
 }
 
+// TestEffectiveRepoPrefix_MatchesRegisteredPrefix guarantees the warm-
+// restart keying helper agrees with the prefix the indexer actually
+// registers — otherwise a disk-backed reconcile would key snapshot
+// mtimes by the wrong prefix and re-index the worktree every restart.
+func TestEffectiveRepoPrefix_MatchesRegisteredPrefix(t *testing.T) {
+	canon, wt := setupCollidingWorktree(t, "oas-orm", "task", "task-ws")
+	_, mi, cm := newWorktreeTestIndexer(t,
+		config.RepoEntry{Path: canon},
+		config.RepoEntry{Path: wt},
+	)
+	_, err := mi.IndexAll()
+	require.NoError(t, err)
+
+	// The helper reproduces the registered prefix for both checkouts.
+	assert.Equal(t, "oas-orm", EffectiveRepoPrefix(cm, config.RepoEntry{Path: canon}))
+	assert.Equal(t, "oas-orm@task-ws", EffectiveRepoPrefix(cm, config.RepoEntry{Path: wt}))
+	require.NotNil(t, mi.GetMetadata(EffectiveRepoPrefix(cm, config.RepoEntry{Path: wt})))
+	require.NotNil(t, mi.GetMetadata(EffectiveRepoPrefix(cm, config.RepoEntry{Path: canon})))
+
+	// An explicit Name is honoured verbatim (the interactive-track case).
+	assert.Equal(t, "custom", EffectiveRepoPrefix(cm, config.RepoEntry{Path: wt, Name: "custom"}))
+}
+
 func mustAbs(t *testing.T, p string) string {
 	t.Helper()
 	abs, err := filepath.Abs(p)

--- a/internal/indexer/worktree_instance_test.go
+++ b/internal/indexer/worktree_instance_test.go
@@ -107,6 +107,14 @@ func TestWorktreeInstance_IndexAll_AutoSeparatesByWorkspace(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "task-ws", ws)
 	assert.Equal(t, "oas-orm@task-ws", prefix)
+
+	// ResolveFilePath disambiguates the two overlapping prefixes
+	// (`oas-orm` vs `oas-orm@task-ws`) by longest match, mapping each
+	// prefixed graph path back to its own checkout.
+	assert.Equal(t, realpath(t, filepath.Join(wt, "feature.go")),
+		realpath(t, mi.ResolveFilePath("oas-orm@task-ws/feature.go")))
+	assert.Equal(t, realpath(t, filepath.Join(canon, "lib.go")),
+		realpath(t, mi.ResolveFilePath("oas-orm/lib.go")))
 }
 
 // TestWorktreeInstance_PlainWorktreeStillCoalesces guards the opposite

--- a/internal/mcp/tools_multi.go
+++ b/internal/mcp/tools_multi.go
@@ -21,6 +21,7 @@ func (s *Server) registerMultiRepoTools() {
 			mcp.WithDescription("Add a repository to the tracked workspace at runtime. Indexes immediately and persists to config."),
 			mcp.WithString("path", mcp.Required(), mcp.Description("Absolute path to repository")),
 			mcp.WithString("name", mcp.Description("Optional repo prefix override")),
+			mcp.WithBoolean("as_worktree", mcp.Description("Track a linked git worktree as an independent instance (derived `<base>@<workspace>` prefix) even when its repo is already tracked elsewhere. Auto-detected when the worktree's .gortex.yaml declares a different workspace; set this to force it.")),
 		),
 		s.handleTrackRepository,
 	)
@@ -90,6 +91,9 @@ func (s *Server) handleTrackRepository(ctx context.Context, req mcp.CallToolRequ
 	if name, ok := req.GetArguments()["name"].(string); ok && name != "" {
 		entry.Name = name
 	}
+	if asWT, ok := req.GetArguments()["as_worktree"].(bool); ok {
+		entry.AsWorktree = asWT
+	}
 
 	result, trackErr := s.multiIndexer.TrackRepoCtx(s.progressCtx(ctx, req), entry)
 	if trackErr != nil {
@@ -112,10 +116,14 @@ func (s *Server) handleTrackRepository(ctx context.Context, req mcp.CallToolRequ
 	// Re-run analysis after adding a new repo.
 	s.RunAnalysis()
 
+	prefix := result.RepoPrefix
+	if prefix == "" {
+		prefix = config.ResolvePrefix(entry)
+	}
 	return s.respondJSONOrTOON(ctx, req, map[string]any{
 		"status":     "tracked",
 		"path":       path,
-		"prefix":     config.ResolvePrefix(entry),
+		"prefix":     prefix,
 		"file_count": result.FileCount,
 		"node_count": result.NodeCount,
 		"edge_count": result.EdgeCount,

--- a/internal/mcp/tools_multi_worktree_test.go
+++ b/internal/mcp/tools_multi_worktree_test.go
@@ -1,0 +1,152 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+	"github.com/zzet/gortex/internal/query"
+	"github.com/zzet/gortex/internal/search"
+)
+
+// newWorktreeMCPServer builds a Server whose MultiIndexer has already
+// indexed the supplied config repos. Used to exercise the runtime
+// track_repository path for git-worktree instancing.
+func newWorktreeMCPServer(t *testing.T, repos ...config.RepoEntry) (*Server, *indexer.MultiIndexer) {
+	t.Helper()
+	tmpCfg := filepath.Join(t.TempDir(), "config.yaml")
+	gc := &config.GlobalConfig{Repos: repos}
+	gc.SetConfigPath(tmpCfg)
+	require.NoError(t, gc.Save())
+	cm, err := config.NewConfigManager(tmpCfg)
+	require.NoError(t, err)
+
+	preg := parser.NewRegistry()
+	languages.RegisterAll(preg)
+	g := graph.New()
+	mi := indexer.NewMultiIndexer(g, preg, search.NewBM25(), cm, zap.NewNop())
+	_, err = mi.IndexAll()
+	require.NoError(t, err)
+
+	eng := query.NewEngine(g)
+	singleton := indexer.New(g, preg, config.IndexConfig{}, zap.NewNop())
+	srv := NewServer(eng, g, singleton, nil, zap.NewNop(), nil, MultiRepoOptions{
+		ConfigManager: cm,
+		MultiIndexer:  mi,
+	})
+	return srv, mi
+}
+
+func gitInitWorktreeRepo(t *testing.T, dir string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	gitInit(t, dir, "init", "-q", "-b", "main")
+	gitInit(t, dir, "config", "user.email", "test@example.com")
+	gitInit(t, dir, "config", "user.name", "Test")
+	gitInit(t, dir, "config", "commit.gpgsign", "false")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "lib.go"),
+		[]byte("package lib\n\nfunc Canonical() {}\n"), 0o644))
+	gitInit(t, dir, "add", ".")
+	gitInit(t, dir, "commit", "-q", "-m", "init")
+}
+
+func trackRepoPrefix(t *testing.T, srv *Server, args map[string]any) (string, string) {
+	t.Helper()
+	req := mcplib.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := srv.handleTrackRepository(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.False(t, res.IsError, "track_repository failed: %+v", res.Content)
+	var payload struct {
+		Prefix string `json:"prefix"`
+		Status string `json:"status"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(extractTextFromContent(t, res.Content)), &payload))
+	return payload.Prefix, payload.Status
+}
+
+// TestTrackRepository_WorktreeAutoInstance exercises the issue #47 flow
+// end-to-end through the MCP track_repository tool: a worktree whose
+// `.gortex.yaml` declares a different workspace is auto-tracked as an
+// independent instance, and the tool reports the derived prefix.
+func TestTrackRepository_WorktreeAutoInstance(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available in PATH")
+	}
+	canon := filepath.Join(t.TempDir(), "oas-orm")
+	gitInitWorktreeRepo(t, canon)
+
+	// A placeholder repo keeps the indexer in multi-repo (prefixed) mode.
+	placeholder := filepath.Join(t.TempDir(), "placeholder")
+	require.NoError(t, os.MkdirAll(placeholder, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(placeholder, "p.go"),
+		[]byte("package p\n\nfunc P() {}\n"), 0o644))
+
+	srv, mi := newWorktreeMCPServer(t,
+		config.RepoEntry{Path: canon},
+		config.RepoEntry{Path: placeholder},
+	)
+	require.NotNil(t, mi.GetMetadata("oas-orm"))
+
+	// Linked worktree, colliding basename, declaring a distinct workspace.
+	wt := filepath.Join(t.TempDir(), "oas-orm")
+	gitInit(t, canon, "worktree", "add", "-q", "-b", "task", wt)
+	require.NoError(t, os.WriteFile(filepath.Join(wt, ".gortex.yaml"),
+		[]byte("workspace: task-ws\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(wt, "feature.go"),
+		[]byte("package lib\n\nfunc Feature() {}\n"), 0o644))
+
+	prefix, status := trackRepoPrefix(t, srv, map[string]any{"path": wt})
+	assert.Equal(t, "tracked", status)
+	assert.Equal(t, "oas-orm@task-ws", prefix, "worktree must get a derived instance prefix")
+
+	assert.NotNil(t, mi.GetMetadata("oas-orm@task-ws"), "worktree instance tracked")
+	assert.NotNil(t, mi.GetMetadata("oas-orm"), "canonical must remain tracked")
+}
+
+// TestTrackRepository_WorktreeForcedFlag covers the explicit
+// `as_worktree` directive on a worktree that declares no workspace: the
+// branch name (sanitised) becomes the instance tag.
+func TestTrackRepository_WorktreeForcedFlag(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available in PATH")
+	}
+	canon := filepath.Join(t.TempDir(), "oas-orm")
+	gitInitWorktreeRepo(t, canon)
+
+	placeholder := filepath.Join(t.TempDir(), "placeholder")
+	require.NoError(t, os.MkdirAll(placeholder, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(placeholder, "p.go"),
+		[]byte("package p\n\nfunc P() {}\n"), 0o644))
+
+	srv, mi := newWorktreeMCPServer(t,
+		config.RepoEntry{Path: canon},
+		config.RepoEntry{Path: placeholder},
+	)
+
+	wt := filepath.Join(t.TempDir(), "oas-orm")
+	gitInit(t, canon, "worktree", "add", "-q", "-b", "feature/login", wt)
+	require.NoError(t, os.WriteFile(filepath.Join(wt, "feature.go"),
+		[]byte("package lib\n\nfunc Feature() {}\n"), 0o644))
+
+	prefix, status := trackRepoPrefix(t, srv, map[string]any{"path": wt, "as_worktree": true})
+	assert.Equal(t, "tracked", status)
+	assert.Equal(t, "oas-orm@feature-login", prefix,
+		"forced worktree without a declared workspace is tagged by its sanitised branch")
+	assert.NotNil(t, mi.GetMetadata("oas-orm@feature-login"))
+	assert.NotNil(t, mi.GetMetadata("oas-orm"))
+}

--- a/internal/resolver/cross_repo.go
+++ b/internal/resolver/cross_repo.go
@@ -197,6 +197,64 @@ func (cr *CrossRepoResolver) crossWorkspaceEligible(sourceWS, targetWS, importPa
 	return false
 }
 
+// pickImportCandidate chooses the best cross-repo file candidate for an
+// import: a candidate in the importer's own workspace wins outright;
+// otherwise the first candidate the cross-workspace policy permits is
+// used. Returns nil when no candidate clears the boundary, so the caller
+// falls through to its dep-module / external handling.
+//
+// This replaces the old "first dir match, then a single boundary check
+// that bailed to external" rule, which mis-resolved when two same-named
+// modules live in different workspaces — the worktree-instance case,
+// where the importer's workspace has its own copy of the imported module
+// but the canonical copy (in another workspace) sorted first.
+func (cr *CrossRepoResolver) pickImportCandidate(callerWS, importPath string, candidates []*graph.Node) *graph.Node {
+	for _, c := range candidates {
+		if candidateWorkspaceID(c) == callerWS {
+			return c
+		}
+	}
+	for _, c := range candidates {
+		if cr.crossWorkspaceEligible(callerWS, candidateWorkspaceID(c), importPath) {
+			return c
+		}
+	}
+	return nil
+}
+
+// pickQualNameCandidate enumerates every node that shares qualName and
+// returns the one in the caller's own workspace, else the first the
+// cross-workspace policy permits, else nil. The graph's qual-name index
+// is single-valued, so when the same module is checked out twice (a
+// canonical checkout plus a worktree instance under its own prefix) only
+// one node is reachable by qual name; the two share a Name, so the
+// multi-valued by-name index recovers the full candidate set. `single`
+// is the node the single-valued lookup already returned — used to learn
+// the shared Name without a second qual-name probe.
+func (cr *CrossRepoResolver) pickQualNameCandidate(callerWS, qualName string, single *graph.Node) *graph.Node {
+	if single == nil || single.Name == "" {
+		return nil
+	}
+	all := cr.graph.FindNodesByNames([]string{single.Name})[single.Name]
+	var cands []*graph.Node
+	for _, c := range all {
+		if c != nil && c.QualName == qualName {
+			cands = append(cands, c)
+		}
+	}
+	for _, c := range cands {
+		if candidateWorkspaceID(c) == callerWS {
+			return c
+		}
+	}
+	for _, c := range cands {
+		if cr.crossWorkspaceEligible(callerWS, candidateWorkspaceID(c), qualName) {
+			return c
+		}
+	}
+	return nil
+}
+
 // ResolveAll resolves all unresolved edges in the graph, trying same-repo
 // matches first, then cross-repo search. Sets Edge.CrossRepo = true for
 // cross-repo matches.
@@ -911,25 +969,30 @@ func (cr *CrossRepoResolver) resolveImport(e *graph.Edge, importPath string, sta
 	importPath, npmAliased := rewriteNpmAliasImport(cr.npmAlias, e.FilePath, importPath)
 
 	// Look for a package node with matching qualified name.
-	node := cr.cachedGetNodeByQualName(importPath)
-	if node != nil {
-		// Workspace boundary check: if the candidate is in a
-		// different workspace, allow only when an explicit
-		// cross_workspace_dep declares it.
-		if !cr.crossWorkspaceEligible(callerWS, candidateWorkspaceID(node), importPath) {
-			// Treat as external — the dep wasn't opted in.
-			e.To = "external::" + importPath
-			stats.Unresolved++
+	if node := cr.cachedGetNodeByQualName(importPath); node != nil {
+		picked := node
+		if !cr.crossWorkspaceEligible(callerWS, candidateWorkspaceID(picked), importPath) {
+			// The qual-name index is single-valued, so a same-module
+			// instance in the caller's own workspace (a worktree of the
+			// imported module, tracked under its own prefix) can be
+			// shadowed by a copy in another workspace. Enumerate every
+			// node sharing this qual name and prefer the caller's
+			// workspace before giving up.
+			picked = cr.pickQualNameCandidate(callerWS, importPath, node)
+		}
+		if picked != nil {
+			e.To = picked.ID
+			if picked.RepoPrefix != callerRepo {
+				e.CrossRepo = true
+				stats.CrossRepoEdges++
+				stats.ByRepo[picked.RepoPrefix]++
+			}
+			stats.Resolved++
 			return
 		}
-		e.To = node.ID
-		if node.RepoPrefix != callerRepo {
-			e.CrossRepo = true
-			stats.CrossRepoEdges++
-			stats.ByRepo[node.RepoPrefix]++
-		}
-		stats.Resolved++
-		return
+		// A qual-name hit with no workspace-eligible instance falls
+		// through to the directory-match scan below rather than bailing
+		// straight to external.
 	}
 
 	// Look for file nodes whose directory matches the import path. Two
@@ -950,8 +1013,8 @@ func (cr *CrossRepoResolver) resolveImport(e *graph.Edge, importPath string, sta
 	// own workspace; otherwise the first same-repo hit short-circuits
 	// the scan as before.
 	collectAll := cr.workspaceMembers != nil
-	var sameRepo, crossRepo *graph.Node
-	var sameRepoAll []*graph.Node
+	var sameRepo *graph.Node
+	var sameRepoAll, crossRepoAll []*graph.Node
 	consider := func(n *graph.Node) {
 		if n.Kind != graph.KindFile {
 			return
@@ -969,9 +1032,11 @@ func (cr *CrossRepoResolver) resolveImport(e *graph.Edge, importPath string, sta
 		// suffix match. lastDirIndex / the full-scan fallback key on the
 		// last path component only, so without this gate an import of
 		// `.../tree-sitter-c/bindings/go` resolves to whichever
-		// `*/bindings/go` directory sorts first.
-		if crossRepo == nil && dirMatchesImport(filepath.Dir(n.FilePath), importPath) {
-			crossRepo = n
+		// `*/bindings/go` directory sorts first. Collect every match so
+		// the workspace-aware pick below can prefer the importer's own
+		// workspace instead of the first one encountered.
+		if dirMatchesImport(filepath.Dir(n.FilePath), importPath) {
+			crossRepoAll = append(crossRepoAll, n)
 		}
 	}
 	stop := func() bool { return sameRepo != nil && !collectAll }
@@ -1012,18 +1077,17 @@ func (cr *CrossRepoResolver) resolveImport(e *graph.Edge, importPath string, sta
 		stats.Resolved++
 		return
 	}
-	if crossRepo != nil {
-		// Apply workspace boundary on the directory-match path too.
-		if !cr.crossWorkspaceEligible(callerWS, candidateWorkspaceID(crossRepo), importPath) {
-			e.To = "external::" + importPath
-			stats.Unresolved++
-			return
-		}
-		e.To = crossRepo.ID
+	// Cross-repo directory match: prefer a candidate in the caller's own
+	// workspace, then any the cross-workspace policy permits. Never bail
+	// on the first ineligible candidate — a same-workspace instance (a
+	// worktree of the imported module tracked under its own prefix) may
+	// appear later in the list.
+	if picked := cr.pickImportCandidate(callerWS, importPath, crossRepoAll); picked != nil {
+		e.To = picked.ID
 		e.CrossRepo = true
 		stats.Resolved++
 		stats.CrossRepoEdges++
-		stats.ByRepo[crossRepo.RepoPrefix]++
+		stats.ByRepo[picked.RepoPrefix]++
 		return
 	}
 

--- a/internal/resolver/cross_repo_worktree_test.go
+++ b/internal/resolver/cross_repo_worktree_test.go
@@ -1,0 +1,120 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// strictBoundary returns a non-nil cross-workspace lookup that declares
+// no deps, so crossWorkspaceEligible enforces a hard workspace boundary.
+// (A nil lookup is intentionally permissive, which would mask the
+// worktree-instance preference under test.)
+func strictBoundary() CrossWorkspaceDepLookup {
+	return func(string) []CrossWorkspaceDepRule { return nil }
+}
+
+// worktreeImportGraph models the issue #47 cross-repo shape: module
+// `oas-orm` is checked out twice — the canonical copy in workspace
+// "base" and a worktree instance (its own prefix) in workspace "task" —
+// and a caller in `callerWS` imports it. The two module nodes share a
+// QualName, so the graph's single-valued qual-name index can only hold
+// one of them; resolution must still bind to the caller's own workspace.
+func worktreeImportGraph(callerWS string) (*graph.Graph, *graph.Edge) {
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "sherlock/main.go", Kind: graph.KindFile, Name: "main.go",
+		FilePath: "sherlock/main.go", Language: "go", RepoPrefix: "sherlock", WorkspaceID: callerWS})
+	// Canonical checkout (workspace "base").
+	g.AddNode(&graph.Node{ID: "oas-orm/orm.go::orm", Kind: graph.KindPackage, Name: "orm", QualName: "oas-orm",
+		FilePath: "oas-orm/orm.go", Language: "go", RepoPrefix: "oas-orm", WorkspaceID: "base"})
+	// Worktree instance of the SAME module (workspace "task").
+	g.AddNode(&graph.Node{ID: "oas-orm@task/orm.go::orm", Kind: graph.KindPackage, Name: "orm", QualName: "oas-orm",
+		FilePath: "oas-orm@task/orm.go", Language: "go", RepoPrefix: "oas-orm@task", WorkspaceID: "task"})
+	edge := &graph.Edge{From: "sherlock/main.go", To: "unresolved::import::oas-orm",
+		Kind: graph.EdgeImports, FilePath: "sherlock/main.go", Line: 3}
+	g.AddEdge(edge)
+	return g, edge
+}
+
+// TestCrossRepoImport_ResolvesIntoCallerWorkspaceWorktree is the core
+// resolver regression for issue #47: a caller in the task workspace
+// importing a module that exists both canonically (another workspace)
+// and as a worktree instance (its own workspace) must bind to the
+// worktree instance — regardless of which copy the single-valued
+// qual-name index happens to surface.
+func TestCrossRepoImport_ResolvesIntoCallerWorkspaceWorktree(t *testing.T) {
+	g, edge := worktreeImportGraph("task")
+	cr := NewCrossRepo(g)
+	cr.SetCrossWorkspaceDepLookup(strictBoundary())
+
+	stats := cr.ResolveAll()
+
+	require.Equal(t, 1, stats.Resolved)
+	assert.Equal(t, "oas-orm@task/orm.go::orm", edge.To,
+		"import from a task-workspace caller must bind to the worktree instance, not the canonical")
+	assert.True(t, edge.CrossRepo)
+}
+
+// TestCrossRepoImport_ResolvesIntoCanonicalForBaseWorkspace is the
+// mirror: a base-workspace caller binds to the canonical checkout, so
+// the two instances coexist without bleeding into one another.
+func TestCrossRepoImport_ResolvesIntoCanonicalForBaseWorkspace(t *testing.T) {
+	g, edge := worktreeImportGraph("base")
+	cr := NewCrossRepo(g)
+	cr.SetCrossWorkspaceDepLookup(strictBoundary())
+
+	stats := cr.ResolveAll()
+
+	require.Equal(t, 1, stats.Resolved)
+	assert.Equal(t, "oas-orm/orm.go::orm", edge.To,
+		"import from the base-workspace caller must bind to the canonical checkout")
+	assert.True(t, edge.CrossRepo)
+}
+
+// TestCrossRepoImport_UnrelatedWorkspaceStaysExternal guards the
+// boundary: a caller in a third workspace that imports neither instance
+// (no cross_workspace_deps) must stay external rather than mis-binding
+// to whichever copy the qual-name index surfaced.
+func TestCrossRepoImport_UnrelatedWorkspaceStaysExternal(t *testing.T) {
+	g, edge := worktreeImportGraph("other")
+	cr := NewCrossRepo(g)
+	cr.SetCrossWorkspaceDepLookup(strictBoundary())
+
+	stats := cr.ResolveAll()
+
+	assert.Equal(t, 0, stats.CrossRepoEdges, "unrelated workspace must not bind into either instance")
+	assert.Equal(t, "external::oas-orm", edge.To)
+	assert.False(t, edge.CrossRepo)
+}
+
+// TestCrossRepoImport_DeclaredDepResolvesToCanonical confirms the
+// existing cross_workspace_deps escape hatch still works alongside the
+// worktree preference: when "task" has no own instance but declares a
+// dep on "base", the import resolves across the boundary to the
+// canonical copy.
+func TestCrossRepoImport_DeclaredDepResolvesToCanonical(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "sherlock/main.go", Kind: graph.KindFile, Name: "main.go",
+		FilePath: "sherlock/main.go", Language: "go", RepoPrefix: "sherlock", WorkspaceID: "task"})
+	g.AddNode(&graph.Node{ID: "oas-orm/orm.go::orm", Kind: graph.KindPackage, Name: "orm", QualName: "oas-orm",
+		FilePath: "oas-orm/orm.go", Language: "go", RepoPrefix: "oas-orm", WorkspaceID: "base"})
+	edge := &graph.Edge{From: "sherlock/main.go", To: "unresolved::import::oas-orm",
+		Kind: graph.EdgeImports, FilePath: "sherlock/main.go", Line: 3}
+	g.AddEdge(edge)
+
+	cr := NewCrossRepo(g)
+	cr.SetCrossWorkspaceDepLookup(func(sourceWS string) []CrossWorkspaceDepRule {
+		if sourceWS == "task" {
+			return []CrossWorkspaceDepRule{{Workspace: "base", Modules: []string{"oas-orm"}}}
+		}
+		return nil
+	})
+
+	stats := cr.ResolveAll()
+
+	require.Equal(t, 1, stats.Resolved)
+	assert.Equal(t, "oas-orm/orm.go::orm", edge.To)
+	assert.True(t, edge.CrossRepo)
+}


### PR DESCRIPTION
## Summary

Fixes #47

A linked git worktree of an already-tracked repo can now be tracked as an independent repo instance — its own prefix, its own workspace, indexed from its own branch — instead of silently coalescing into the canonical checkout. This unblocks exactly the issue's workflow: a persistent base workspace of shared libraries plus disposable per-task worktrees that overlap on those libraries.

Root cause: the registry keys repos by prefix (basename / git-remote tail), so two checkouts of one repo got the same prefix and the `mi.repos[prefix]` exists → "already tracked" check dropped the worktree.

Core idea: a worktree instance gets a derived prefix `<base>@<tag>` (tag = its declared workspace, else branch, else a path hash; sanitised so it never contains `/`). The prefix is the per-checkout key for everything downstream — node IDs, watcher