### PR TITLE
feat(agents): wire gortex into Hermes pre_tool_call + pre_llm_call hooks

### DIFF
--- a/cmd/gortex/hook.go
+++ b/cmd/gortex/hook.go
@@ -14,13 +14,22 @@ var (
 
 var hookCmd = &cobra.Command{
 	Use:    "hook",
-	Short:  "Agent hook handler (Claude Code by default; --agent for Gemini / Antigravity)",
+	Short:  "Agent hook handler (Claude Code by default; --agent for Gemini / Antigravity / Hermes)",
 	Hidden: true, // Not for direct user invocation.
 	Run: func(_ *cobra.Command, _ []string) {
-		// A non-Claude agent (Gemini CLI, Antigravity) shares the
-		// hookSpecificOutput.additionalContext wire shape but a different
-		// event vocabulary, so it routes to the external-agent handler.
-		if hookAgent != "" {
+		// --agent selects the hook wire protocol. Empty (the default) is the
+		// Claude Code format. Hermes (NousResearch hermes-agent) sends
+		// snake_case events and expects an action/message decision shape, so
+		// it gets its own dispatcher. Any other non-empty agent (Gemini CLI,
+		// Antigravity) shares the hookSpecificOutput.additionalContext wire
+		// shape and routes to the external-agent handler.
+		switch hookAgent {
+		case "hermes":
+			hooks.RunHermes(hookPort, hooks.ParseMode(hookMode))
+			return
+		case "", "claude":
+			// Claude Code — handled below.
+		default:
 			hooks.RunExternalAgent()
 			return
 		}
@@ -33,6 +42,6 @@ func init() {
 	hookCmd.Flags().StringVar(&hookMode, "mode", "deny",
 		"hook posture: 'deny' (redirect Grep/Glob/Read of indexed source), 'enrich' (never deny; PostToolUse appends graph context), 'consult-unlock' (deny fallback reads until the graph is queried once this session), or 'nudge' (soft-deny once per burst of non-symbolic calls)")
 	hookCmd.Flags().StringVar(&hookAgent, "agent", "",
-		"non-Claude agent hook handler: 'gemini' or 'antigravity' (emits hookSpecificOutput.additionalContext). Default (empty) is the Claude Code format.")
+		"hook wire protocol: empty/'claude' (Claude Code PreToolUse/UserPromptSubmit), 'hermes' (NousResearch hermes-agent pre_tool_call/pre_llm_call), or 'gemini'/'antigravity' (emits hookSpecificOutput.additionalContext). Default (empty) is the Claude Code format.")
 	rootCmd.AddCommand(hookCmd)
 }

--- a/cmd/gortex/uninstall.go
+++ b/cmd/gortex/uninstall.go
@@ -212,7 +212,7 @@ func emitUninstallSummary(w io.Writer, removed int, failures []string, totalPres
 		_, _ = fmt.Fprintln(w, "Note: CLAUDE.md was not modified — remove the Gortex block manually if needed.")
 		_, _ = fmt.Fprintln(w, "Note: .kiro/steering/ files with 'gortex-' prefix were removed. Other .kiro/ files were preserved.")
 		_, _ = fmt.Fprintln(w, "Note: Antigravity KIs are global and were not removed. Manually delete ~/.gemini/antigravity/knowledge/gortex-workflow if desired.")
-		_, _ = fmt.Fprintln(w, "Note: Hermes config is global and was not removed. Manually delete the gortex entry in ~/.hermes/config.yaml (+ profiles) and the gortex / gortex-* skill directories under ~/.hermes/skills/ if desired.")
+		_, _ = fmt.Fprintln(w, "Note: Hermes config is global and was not removed. Manually delete the gortex entry in ~/.hermes/config.yaml (+ profiles), the gortex pre_tool_call / pre_llm_call entries under its `hooks:` block, and the gortex / gortex-* skill directories under ~/.hermes/skills/ if desired.")
 		return
 	}
 

--- a/internal/agents/hermes/adapter.go
+++ b/internal/agents/hermes/adapter.go
@@ -69,8 +69,15 @@ func (a *Adapter) Plan(env agents.Env) (*agents.Plan, error) {
 	if env.Home == "" {
 		return &agents.Plan{}, nil
 	}
+	// The global config carries mcp_servers always, and the gortex
+	// pre_tool_call / pre_llm_call hooks when hook installation is on —
+	// so `init doctor` (which runs Plan) reports the hooks surface too.
+	globalKeys := []string{"mcp_servers"}
+	if env.InstallHooks {
+		globalKeys = append(globalKeys, "hooks")
+	}
 	files := []agents.FileAction{
-		{Path: globalConfigPath(env.Home), Action: agents.ActionWouldMerge, Keys: []string{"mcp_servers"}},
+		{Path: globalConfigPath(env.Home), Action: agents.ActionWouldMerge, Keys: globalKeys},
 	}
 	for _, p := range profileConfigPaths(env.Home) {
 		files = append(files, agents.FileAction{Path: p, Action: agents.ActionWouldMerge, Keys: []string{"mcp_servers"}})
@@ -98,12 +105,19 @@ func (a *Adapter) Apply(env agents.Env, opts agents.ApplyOpts) (*agents.Result, 
 	command := resolveGortexCommand()
 
 	// 1. Global config — the entry every profile inherits when it
-	//    doesn't re-declare its own server map.
-	globalAction, err := upsertGortexServer(env.Stderr, globalConfigPath(env.Home), command, opts)
+	//    doesn't re-declare its own server map, plus (when hooks are
+	//    enabled) the gortex pre_tool_call / pre_llm_call hooks. Both
+	//    ride one comment-preserving merge of ~/.hermes/config.yaml.
+	globalAction, err := upsertGlobalConfig(env.Stderr, globalConfigPath(env.Home), command, env.HookMode, env.InstallHooks, opts)
 	if err != nil {
 		return res, fmt.Errorf("hermes global config: %w", err)
 	}
 	res.Files = append(res.Files, globalAction)
+	if env.InstallHooks {
+		internalutil.Logf(env.Stderr, "[gortex init] wired Hermes pre_tool_call + pre_llm_call hooks (posture: %s)", hermesHookModeLabel(env.HookMode))
+	} else {
+		internalutil.Logf(env.Stderr, "[gortex init] skipping Hermes hook installation (--no-hooks)")
+	}
 
 	// 2. Per-profile configs — Hermes profiles may carry their own
 	//    mcp_servers block, so upsert into each existing one too. A
@@ -149,11 +163,49 @@ func (a *Adapter) Apply(env agents.Env, opts agents.ApplyOpts) (*agents.Result, 
 
 // upsertGortexServer merges the gortex stdio stanza into the
 // `mcp_servers` map of a Hermes YAML config, preserving comments and
-// unrelated keys.
+// unrelated keys. Used for per-profile configs, which carry only the
+// server stanza.
 func upsertGortexServer(w io.Writer, path, command string, opts agents.ApplyOpts) (agents.FileAction, error) {
 	return agents.MergeYAML(w, path, func(root *yaml.Node, _ bool) (bool, error) {
 		return agents.UpsertYAMLMapEntry(root, "mcp_servers", gortexServerName, gortexMCPEntry(command), opts.Force)
 	}, opts)
+}
+
+// upsertGlobalConfig merges the gortex MCP server stanza — and, when
+// hook installation is enabled, the gortex pre_tool_call / pre_llm_call
+// hook entries — into the global ~/.hermes/config.yaml in a single
+// comment-preserving pass. Hooks are global-only: unlike mcp_servers
+// (which a profile can re-declare), Hermes documents shell hooks only at
+// global scope, so this is the one place they're written.
+func upsertGlobalConfig(w io.Writer, path, command, hookMode string, installHooks bool, opts agents.ApplyOpts) (agents.FileAction, error) {
+	return agents.MergeYAML(w, path, func(root *yaml.Node, _ bool) (bool, error) {
+		serverChanged, err := agents.UpsertYAMLMapEntry(root, "mcp_servers", gortexServerName, gortexMCPEntry(command), opts.Force)
+		if err != nil {
+			return false, err
+		}
+		if !installHooks {
+			return serverChanged, nil
+		}
+		hooksChanged, err := upsertGortexHooks(root, hookMode, opts.Force)
+		if err != nil {
+			return false, err
+		}
+		return serverChanged || hooksChanged, nil
+	}, opts)
+}
+
+// hermesHookModeLabel renders the posture name for the install log,
+// normalising the empty / unknown default to "deny".
+func hermesHookModeLabel(mode string) string {
+	m := strings.ToLower(strings.TrimSpace(mode))
+	switch m {
+	case "enrich", "consult-unlock", "nudge":
+		return m
+	case "adaptive-nudge":
+		return "nudge"
+	default:
+		return "deny"
+	}
 }
 
 // resolveGortexCommand returns the command Hermes should launch for the

--- a/internal/agents/hermes/hooks.go
+++ b/internal/agents/hermes/hooks.go
@@ -1,0 +1,243 @@
+package hermes
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/agents/claudecode"
+	yaml "gopkg.in/yaml.v3"
+)
+
+// Hermes shell-hook wiring. The Claude Code adapter installs PreToolUse
+// (+ UserPromptSubmit / SessionStart) hooks that redirect Grep / Glob /
+// Read of indexed source to graph tools; Hermes exposes the equivalent
+// primitives under the `hooks:` block of ~/.hermes/config.yaml, so this
+// file gives Hermes the same graph-first enforcement.
+//
+// Two events are wired (the only two that can affect a turn — Hermes'
+// on_session_start is observer-only and post_tool_call is
+// fire-and-forget, so neither can inject context or block):
+//
+//   - pre_tool_call (matcher "read_file|terminal"): the block/redirect
+//     hook. read_file covers whole-file reads of indexed source;
+//     terminal covers shell grep / find / cat (Hermes has no separate
+//     Grep / Glob tool — every shell command rides the one terminal
+//     tool). Honours the posture flag the same way Claude Code does.
+//   - pre_llm_call (no matcher): context injection. It does double duty
+//     — the Gortex orientation briefing on the first turn (Claude's
+//     SessionStart equivalent, which Hermes lacks) and relevant-symbol
+//     surfacing on every later turn (Claude's UserPromptSubmit).
+//
+// Both events are written only to the GLOBAL ~/.hermes/config.yaml.
+// Unlike `mcp_servers` (which a profile can re-declare, so we upsert
+// per-profile too), Hermes documents shell hooks only at global scope.
+const (
+	// hermesPreToolEvent / hermesPreLLMEvent are the snake_case event
+	// keys under the config's `hooks:` map.
+	hermesPreToolEvent = "pre_tool_call"
+	hermesPreLLMEvent  = "pre_llm_call"
+
+	// hermesToolMatcher is the regex Hermes matches against tool_name
+	// for the pre_tool_call hook. It must agree with the tool names the
+	// hooks.RunHermes dispatcher inspects (read_file + terminal).
+	hermesToolMatcher = "read_file|terminal"
+
+	// hermesHookTimeoutSecs bounds each hook invocation. Hermes hook
+	// timeouts are in SECONDS (default 60, max 300) — unlike Claude
+	// Code's millisecond timeouts. 5s is generous for a localhost daemon
+	// probe yet well under the ceiling, so a wedged daemon can't stall a
+	// turn for long.
+	hermesHookTimeoutSecs = 5
+)
+
+// upsertGortexHooks merges the gortex pre_tool_call + pre_llm_call
+// entries into the `hooks:` block of an already-open config root,
+// preserving comments and unrelated hooks. It is called from inside the
+// global-config MergeYAML mutate so the whole config.yaml (mcp_servers +
+// hooks) is written in a single comment-preserving pass. Returns whether
+// it changed anything.
+func upsertGortexHooks(root *yaml.Node, mode string, force bool) (bool, error) {
+	hooksNode, err := ensureHooksMapping(root)
+	if err != nil {
+		return false, err
+	}
+
+	binary := hermesHookBinary()
+	preToolCmd := binary + " hook --agent hermes" + hermesModeSuffix(mode)
+	preLLMCmd := binary + " hook --agent hermes"
+
+	// pre_tool_call carries the matcher + posture; pre_llm_call is the
+	// matcher-less injection hook (its posture is irrelevant — it never
+	// blocks).
+	changedTool := upsertHookEvent(hooksNode, hermesPreToolEvent, hermesToolMatcher, preToolCmd, force)
+	changedLLM := upsertHookEvent(hooksNode, hermesPreLLMEvent, "", preLLMCmd, force)
+	return changedTool || changedLLM, nil
+}
+
+// ensureHooksMapping returns the `hooks:` mapping node, creating it when
+// absent or replacing an explicit-null value (`hooks:` with nothing, or
+// `hooks: {}` decoded to null) in place so its leading comment survives.
+// A non-mapping `hooks:` value is refused rather than clobbered.
+func ensureHooksMapping(root *yaml.Node) (*yaml.Node, error) {
+	node := agents.YAMLMapValue(root, "hooks")
+	switch {
+	case node == nil, yamlIsNull(node):
+		node = &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+		agents.YAMLSetMapValue(root, "hooks", node)
+	case node.Kind == yaml.MappingNode:
+		// Reuse in place.
+	default:
+		return nil, &hooksShapeError{}
+	}
+	return node, nil
+}
+
+// upsertHookEvent ensures hooks[event] is a sequence holding exactly one
+// gortex entry with the desired matcher + command + timeout. An existing
+// gortex entry is re-stamped in place when it drifts (binary path moved,
+// posture switched) so user-added fields and comments survive; a missing
+// one is appended; an up-to-date one is left untouched unless force.
+// Non-gortex entries in the same sequence are never touched.
+func upsertHookEvent(hooksNode *yaml.Node, event, matcher, command string, force bool) bool {
+	seq := agents.YAMLMapValue(hooksNode, event)
+	if seq == nil || yamlIsNull(seq) {
+		seq = &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq"}
+		agents.YAMLSetMapValue(hooksNode, event, seq)
+	} else if seq.Kind != yaml.SequenceNode {
+		// `event:` holds a scalar/mapping rather than a list — not a
+		// shape we can splice an entry into. Leave it alone.
+		return false
+	}
+
+	existing := findGortexHookEntry(seq)
+	if existing == nil {
+		seq.Content = append(seq.Content, hermesHookEntryNode(matcher, command))
+		return true
+	}
+	if hookEntryMatches(existing, matcher, command) && !force {
+		return false
+	}
+	// Re-stamp the existing entry's contents in place (keeps node
+	// identity, so any HeadComment the user attached to it survives).
+	desired := hermesHookEntryNode(matcher, command)
+	existing.Content = desired.Content
+	return true
+}
+
+// findGortexHookEntry returns the first sequence item that is a gortex
+// hook entry (its `command` invokes `gortex hook --agent hermes`), or
+// nil. Identifies our entry by the command string so a re-install
+// updates it in place rather than appending a duplicate.
+func findGortexHookEntry(seq *yaml.Node) *yaml.Node {
+	if seq == nil || seq.Kind != yaml.SequenceNode {
+		return nil
+	}
+	for _, item := range seq.Content {
+		if item.Kind != yaml.MappingNode {
+			continue
+		}
+		cmd := agents.YAMLMapValue(item, "command")
+		if cmd != nil && cmd.Kind == yaml.ScalarNode && commandIsGortexHermesHook(cmd.Value) {
+			return item
+		}
+	}
+	return nil
+}
+
+// commandIsGortexHermesHook reports whether a hook command string is a
+// gortex Hermes hook invocation: it runs the `hook` subcommand of a
+// gortex binary with the hermes agent protocol selected. Robust to the
+// binary being an absolute path and to `--agent hermes` vs
+// `--agent=hermes`.
+func commandIsGortexHermesHook(cmd string) bool {
+	lower := strings.ToLower(cmd)
+	if !strings.Contains(lower, "gortex") || !strings.Contains(lower, "hook") {
+		return false
+	}
+	return strings.Contains(cmd, "--agent hermes") || strings.Contains(cmd, "--agent=hermes")
+}
+
+// hookEntryMatches reports whether an existing hook entry already has
+// the desired matcher + command + timeout, so an idempotent re-run is a
+// no-op. A missing matcher (pre_llm_call) must mean no matcher key.
+func hookEntryMatches(entry *yaml.Node, matcher, command string) bool {
+	if scalarValue(agents.YAMLMapValue(entry, "command")) != command {
+		return false
+	}
+	if scalarValue(agents.YAMLMapValue(entry, "matcher")) != matcher {
+		return false
+	}
+	return scalarValue(agents.YAMLMapValue(entry, "timeout")) == strconv.Itoa(hermesHookTimeoutSecs)
+}
+
+// hermesHookEntryNode builds one `hooks:` list entry: an optional
+// matcher (omitted when empty — pre_llm_call takes no matcher), the
+// command, and the timeout. matcher + command are double-quoted to
+// match the documented Hermes example shape and to survive any future
+// special characters in a binary path.
+func hermesHookEntryNode(matcher, command string) *yaml.Node {
+	entry := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	if matcher != "" {
+		agents.YAMLSetMapValue(entry, "matcher", yamlQuoted(matcher))
+	}
+	agents.YAMLSetMapValue(entry, "command", yamlQuoted(command))
+	agents.YAMLSetMapValue(entry, "timeout", yamlInt(hermesHookTimeoutSecs))
+	return entry
+}
+
+// hermesHookBinary resolves the gortex binary path for the hook command
+// and normalises backslashes to forward slashes. Hermes runs hook
+// commands through a shell; on Windows that shell is Git Bash, which
+// mangles backslash path separators — forward slashes survive there and
+// are correct everywhere else. Same treatment the Claude Code adapter
+// applies to its hook command.
+func hermesHookBinary() string {
+	return strings.ReplaceAll(resolveGortexCommand(), "\\", "/")
+}
+
+// hermesModeSuffix renders the `--mode=<mode>` suffix for the
+// pre_tool_call command. deny is the historical default and emitted bare
+// so a deny install carries no suffix; every other posture is explicit.
+// Reuses the Claude Code adapter's canonical mode strings so the two
+// adapters can't drift on what a posture is called.
+func hermesModeSuffix(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case claudecode.HookModeEnrich:
+		return " --mode=enrich"
+	case claudecode.HookModeConsultUnlock:
+		return " --mode=consult-unlock"
+	case claudecode.HookModeAdaptiveNudge, "adaptive-nudge":
+		return " --mode=nudge"
+	default:
+		return ""
+	}
+}
+
+// yamlIsNull reports whether n is a YAML null — an explicit null scalar
+// (`~`, `null`) or an empty value (`key:` with nothing after it). A
+// local copy of the agents-package predicate, which is unexported.
+func yamlIsNull(n *yaml.Node) bool {
+	return n != nil && n.Kind == yaml.ScalarNode && (n.Tag == "!!null" || n.Value == "")
+}
+
+// yamlQuoted builds a double-quoted string scalar node.
+func yamlQuoted(s string) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Style: yaml.DoubleQuotedStyle, Value: s}
+}
+
+// scalarValue returns a scalar node's value, or "" for a nil / non-scalar.
+func scalarValue(n *yaml.Node) string {
+	if n == nil || n.Kind != yaml.ScalarNode {
+		return ""
+	}
+	return n.Value
+}
+
+// hooksShapeError is returned when `hooks:` holds a non-mapping value we
+// refuse to overwrite.
+type hooksShapeError struct{}
+
+func (*hooksShapeError) Error() string {
+	return "hermes: `hooks` is not a mapping; refusing to overwrite"
+}

--- a/internal/agents/hermes/hooks_test.go
+++ b/internal/agents/hermes/hooks_test.go
@@ -1,0 +1,267 @@
+package hermes
+
+import (
+	"os"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/agents/agentstest"
+	yaml "gopkg.in/yaml.v3"
+)
+
+// hookEntries returns the list of hook entries under hooks[event] in a
+// parsed Hermes config, or nil. Each entry is a map[string]any.
+func hookEntries(t *testing.T, cfg map[string]any, event string) []map[string]any {
+	t.Helper()
+	hooks, ok := cfg["hooks"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	raw, ok := hooks[event].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(raw))
+	for _, e := range raw {
+		if m, ok := e.(map[string]any); ok {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// gortexHookEntry returns the single gortex hook entry under
+// hooks[event], failing if absent or duplicated.
+func gortexHookEntry(t *testing.T, cfg map[string]any, event string) map[string]any {
+	t.Helper()
+	var found map[string]any
+	count := 0
+	for _, e := range hookEntries(t, cfg, event) {
+		if cmd, _ := e["command"].(string); strings.Contains(cmd, "--agent hermes") {
+			found = e
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("hooks[%s]: expected exactly 1 gortex entry, got %d", event, count)
+	}
+	return found
+}
+
+// hookEnv returns a global-mode env with hook installation enabled at
+// the given posture.
+func hookEnv(t *testing.T, mode string) agents.Env {
+	t.Helper()
+	env, _ := agentstest.NewEnv(t)
+	seedHermesHome(t, env.Home)
+	env.InstallHooks = true
+	env.HookMode = mode
+	return env
+}
+
+// TestHermesInstallsHooks is the acceptance test for issue #51:
+// `gortex install --agents=hermes --hooks` writes a valid pre_tool_call
+// (matcher read_file|terminal) and pre_llm_call (no matcher) entry, and
+// a re-run is a pure no-op.
+func TestHermesInstallsHooks(t *testing.T) {
+	env := hookEnv(t, "deny")
+	a := New()
+	if _, err := a.Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	cfg := agentstest.ReadYAML(t, globalConfigPath(env.Home))
+
+	// pre_tool_call: matcher + gortex hook command + a seconds timeout.
+	pt := gortexHookEntry(t, cfg, hermesPreToolEvent)
+	if pt["matcher"] != hermesToolMatcher {
+		t.Errorf("pre_tool_call matcher = %v, want %q", pt["matcher"], hermesToolMatcher)
+	}
+	cmd, _ := pt["command"].(string)
+	if !strings.Contains(cmd, "hook --agent hermes") {
+		t.Errorf("pre_tool_call command should invoke the hermes hook: %q", cmd)
+	}
+	if strings.Contains(cmd, "--mode") {
+		t.Errorf("deny posture should be emitted bare (no --mode): %q", cmd)
+	}
+	if pt["timeout"] != hermesHookTimeoutSecs {
+		t.Errorf("pre_tool_call timeout = %v, want %d", pt["timeout"], hermesHookTimeoutSecs)
+	}
+
+	// pre_llm_call: NO matcher (Hermes rejects matchers on non-tool events).
+	pl := gortexHookEntry(t, cfg, hermesPreLLMEvent)
+	if _, hasMatcher := pl["matcher"]; hasMatcher {
+		t.Errorf("pre_llm_call must not carry a matcher: %#v", pl)
+	}
+	if cmd, _ := pl["command"].(string); !strings.Contains(cmd, "hook --agent hermes") {
+		t.Errorf("pre_llm_call command should invoke the hermes hook: %q", cmd)
+	}
+
+	// The MCP server stanza must still be present — hooks ride the same merge.
+	if _, ok := cfg["mcp_servers"].(map[string]any)["gortex"]; !ok {
+		t.Error("mcp_servers.gortex lost when hooks were added")
+	}
+
+	agentstest.AssertIdempotent(t, a, env)
+}
+
+// TestHermesNoHooksSkips verifies --no-hooks leaves the hooks block
+// untouched while still writing the MCP server stanza.
+func TestHermesNoHooksSkips(t *testing.T) {
+	env, _ := agentstest.NewEnv(t)
+	seedHermesHome(t, env.Home)
+	env.InstallHooks = false
+
+	a := New()
+	if _, err := a.Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	cfg := agentstest.ReadYAML(t, globalConfigPath(env.Home))
+	if _, ok := cfg["hooks"]; ok {
+		t.Errorf("--no-hooks should not write a hooks block: %#v", cfg["hooks"])
+	}
+	if _, ok := cfg["mcp_servers"].(map[string]any)["gortex"]; !ok {
+		t.Error("mcp_servers.gortex should still be written under --no-hooks")
+	}
+}
+
+// TestHermesHookModeSwitch verifies switching posture re-stamps the
+// pre_tool_call command in place (deny → enrich adds --mode=enrich)
+// without duplicating the entry.
+func TestHermesHookModeSwitch(t *testing.T) {
+	env := hookEnv(t, "deny")
+	a := New()
+	if _, err := a.Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply deny: %v", err)
+	}
+
+	env.HookMode = "enrich"
+	if _, err := a.Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply enrich: %v", err)
+	}
+
+	cfg := agentstest.ReadYAML(t, globalConfigPath(env.Home))
+	pt := gortexHookEntry(t, cfg, hermesPreToolEvent) // also asserts no duplicate
+	cmd, _ := pt["command"].(string)
+	if !strings.Contains(cmd, "--mode=enrich") {
+		t.Errorf("posture switch should re-stamp command with --mode=enrich: %q", cmd)
+	}
+}
+
+// TestHermesHooksPreserveExistingEntriesAndComments guards the
+// comment-rich merge: a hand-edited config keeps its comments, its
+// unrelated keys, and any non-gortex hook entries.
+func TestHermesHooksPreserveExistingEntriesAndComments(t *testing.T) {
+	env := hookEnv(t, "deny")
+	cfgPath := globalConfigPath(env.Home)
+	original := `# my hermes config
+model: hermes-4 # the good one
+
+hooks:
+  pre_tool_call:
+    # block dangerous shell commands
+    - matcher: terminal
+      command: ~/.hermes/agent-hooks/guard.sh
+      timeout: 10
+hooks_auto_accept: true
+`
+	if err := os.WriteFile(cfgPath, []byte(original), 0o644); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	a := New()
+	if _, err := a.Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	out, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{"# my hermes config", "the good one", "block dangerous shell commands"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("lost comment %q:\n%s", want, got)
+		}
+	}
+
+	cfg := agentstest.ReadYAML(t, cfgPath)
+	if cfg["hooks_auto_accept"] != true {
+		t.Errorf("unrelated key hooks_auto_accept clobbered: %v", cfg["hooks_auto_accept"])
+	}
+	// The pre-existing guard.sh hook survives alongside the gortex one.
+	entries := hookEntries(t, cfg, hermesPreToolEvent)
+	var hasGuard, hasGortex bool
+	for _, e := range entries {
+		cmd, _ := e["command"].(string)
+		if strings.Contains(cmd, "guard.sh") {
+			hasGuard = true
+		}
+		if strings.Contains(cmd, "--agent hermes") {
+			hasGortex = true
+		}
+	}
+	if !hasGuard {
+		t.Error("pre-existing guard.sh hook was dropped")
+	}
+	if !hasGortex {
+		t.Error("gortex hook was not added alongside the existing one")
+	}
+}
+
+// TestHermesPlanReportsHooks verifies Plan lists the hooks key when hook
+// installation is enabled (so `init doctor` reports it) and omits it
+// otherwise.
+func TestHermesPlanReportsHooks(t *testing.T) {
+	a := New()
+
+	withHooks := hookEnv(t, "deny")
+	plan, err := a.Plan(withHooks)
+	if err != nil {
+		t.Fatalf("plan: %v", err)
+	}
+	if !planGlobalHasKey(plan, withHooks.Home, "hooks") {
+		t.Error("Plan should report the hooks key when InstallHooks is set")
+	}
+
+	noHooks, _ := agentstest.NewEnv(t)
+	seedHermesHome(t, noHooks.Home)
+	noHooks.InstallHooks = false
+	plan, err = a.Plan(noHooks)
+	if err != nil {
+		t.Fatalf("plan: %v", err)
+	}
+	if planGlobalHasKey(plan, noHooks.Home, "hooks") {
+		t.Error("Plan should not report the hooks key under --no-hooks")
+	}
+}
+
+// planGlobalHasKey reports whether the global-config FileAction in plan
+// lists key among its merge keys.
+func planGlobalHasKey(plan *agents.Plan, home, key string) bool {
+	target := globalConfigPath(home)
+	for _, f := range plan.Files {
+		if f.Path != target {
+			continue
+		}
+		if slices.Contains(f.Keys, key) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestUpsertHookEvent_RefusesNonSequence verifies that a malformed
+// `hooks.pre_tool_call` scalar is left untouched rather than clobbered.
+func TestUpsertHookEvent_RefusesNonSequence(t *testing.T) {
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte("pre_tool_call: nonsense\n"), &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	hooksNode := doc.Content[0]
+	if changed := upsertHookEvent(hooksNode, "pre_tool_call", "m", "cmd", false); changed {
+		t.Error("non-sequence event value should be left untouched (no change)")
+	}
+}

--- a/internal/hooks/hermes.go
+++ b/internal/hooks/hermes.go
@@ -1,0 +1,319 @@
+package hooks
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"os"
+	"strings"
+)
+
+// Hermes (NousResearch hermes-agent) speaks a different hook wire
+// protocol than Claude Code, so it gets its own dispatcher rather than
+// riding Run. Three things differ:
+//
+//   - Event names are snake_case (`pre_tool_call`, `pre_llm_call`)
+//     instead of Claude's PascalCase (`PreToolUse`, `UserPromptSubmit`).
+//   - The tool surface is narrower: file reads are a single `read_file`
+//     tool and every shell command (grep / rg / find / cat) rides inside
+//     one `terminal` tool — there is no separate Grep / Glob / Bash.
+//   - The stdout decision shape is `{"action":"block","message":...}`
+//     (canonical) or `{"context":...}` (pre_llm_call injection), not
+//     Claude's `hookSpecificOutput` envelope.
+//
+// The leaf enrichment logic (enrichRead / enrichBash, the daemon probe,
+// the session-state postures, the prompt-injection builder) is shared
+// with the Claude Code handlers — only the input decoding and output
+// encoding are Hermes-specific.
+
+// Hermes hook event names, as documented in hermes-agent's
+// website/docs/user-guide/features/hooks.md.
+const (
+	hermesEventPreToolCall = "pre_tool_call"
+	hermesEventPreLLMCall  = "pre_llm_call"
+)
+
+// Hermes tool names the pre_tool_call matcher targets. read_file is the
+// file-read tool; terminal wraps every shell invocation (the grep / find
+// / cat redirect inspects its `command` argument). These are the strings
+// the installed matcher regex ("read_file|terminal") must agree with.
+const (
+	hermesReadFileTool = "read_file"
+	hermesTerminalTool = "terminal"
+)
+
+// hermesDecision is the Hermes-canonical hook response. A blocking
+// decision sets Action="block" + Message; a pre_llm_call injection sets
+// Context. An all-empty struct marshals to `{}` — a no-op Hermes
+// ignores. We emit the canonical action/message shape (Hermes also
+// accepts the Claude-compatible decision/reason shape, but the native
+// one is the stable contract across versions).
+type hermesDecision struct {
+	Action  string `json:"action,omitempty"`
+	Message string `json:"message,omitempty"`
+	Context string `json:"context,omitempty"`
+}
+
+// hermesPreToolInput decodes the pre_tool_call / post_tool_call payload.
+// The field names match Claude's HookInput by design — Hermes pipes the
+// same snake_case keys — so we keep a dedicated struct only to document
+// the Hermes shape and stay decoupled from Claude's permission_mode.
+type hermesPreToolInput struct {
+	HookEventName string         `json:"hook_event_name"`
+	ToolName      string         `json:"tool_name"`
+	ToolInput     map[string]any `json:"tool_input"`
+	SessionID     string         `json:"session_id"`
+	CWD           string         `json:"cwd"`
+}
+
+// hermesPreLLMInput decodes the pre_llm_call payload. Hermes carries the
+// event-specific fields (user_message, is_first_turn, conversation
+// history) inside an `extra` dict, but some versions also surface them
+// at the top level — we read both and coalesce so the handler works
+// regardless of which layout a given Hermes build sends.
+type hermesPreLLMInput struct {
+	HookEventName string `json:"hook_event_name"`
+	SessionID     string `json:"session_id"`
+	CWD           string `json:"cwd"`
+	UserMessage   string `json:"user_message"`
+	IsFirstTurn   bool   `json:"is_first_turn"`
+	Extra         struct {
+		UserMessage string `json:"user_message"`
+		IsFirstTurn bool   `json:"is_first_turn"`
+		CWD         string `json:"cwd"`
+	} `json:"extra"`
+}
+
+// RunHermes reads a single Hermes hook payload from stdin, peeks at
+// hook_event_name, and dispatches. Like Run, any read / parse failure is
+// a silent no-op — a hook must never abort the agent's flow.
+func RunHermes(port int, mode Mode) {
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return
+	}
+
+	var peek struct {
+		HookEventName string `json:"hook_event_name"`
+	}
+	if err := json.Unmarshal(data, &peek); err != nil {
+		return
+	}
+
+	switch peek.HookEventName {
+	case hermesEventPreToolCall:
+		runHermesPreToolCall(data, port, mode)
+	case hermesEventPreLLMCall:
+		runHermesPreLLMCall(data)
+	}
+}
+
+// emitHermes marshals a Hermes decision to stdout. An empty decision is
+// still emitted as `{}` so a hook that decided "no-op" produces valid
+// JSON rather than empty stdout. A marshal failure is swallowed.
+func emitHermes(d hermesDecision) {
+	out, err := json.Marshal(d)
+	if err != nil {
+		return
+	}
+	fmt.Print(string(out))
+}
+
+// runHermesPreToolCall maps a Hermes tool call onto the shared
+// enrichment logic and, when the call should be blocked, emits a
+// Hermes block decision. The four postures mirror the Claude Code
+// PreToolUse modes — with one structural difference: pre_tool_call has
+// no soft-context channel (it can only block or pass), so ModeEnrich
+// degrades to "never block" and the agent's guidance is delivered via
+// the pre_llm_call injection instead.
+func runHermesPreToolCall(data []byte, port int, mode Mode) {
+	var input hermesPreToolInput
+	if err := json.Unmarshal(data, &input); err != nil {
+		return
+	}
+	if input.HookEventName != hermesEventPreToolCall {
+		return
+	}
+
+	// pre_tool_call can only block or pass — it has no soft-context
+	// channel like Claude's additionalContext. ModeEnrich never blocks,
+	// so it is a pure no-op here; the graph nudge rides on the
+	// pre_llm_call injection instead. Returning before the daemon probe
+	// keeps an enrich install cheap.
+	if mode == ModeEnrich {
+		return
+	}
+
+	isGortexTool := isHermesGortexTool(input.ToolName)
+
+	// Consult-unlock handshake: the first Gortex graph tool call this
+	// session flips the marker that downgrades subsequent denies. The
+	// call itself is a pass-through.
+	if mode == ModeConsultUnlock && isGortexTool {
+		st := loadSessionState(input.SessionID)
+		if !st.GraphConsulted {
+			st.GraphConsulted = true
+			saveSessionState(input.SessionID, st)
+		}
+		return
+	}
+
+	result := hermesEnrich(input, port)
+
+	switch mode {
+	case ModeConsultUnlock:
+		if result.deny {
+			if loadSessionState(input.SessionID).GraphConsulted {
+				return
+			}
+			result.reason = consultUnlockReason(result.reason)
+		}
+	case ModeAdaptiveNudge:
+		result = hermesAdaptiveNudge(input, isGortexTool, result)
+	}
+
+	if !result.deny {
+		return
+	}
+	emitHermes(hermesDecision{Action: "block", Message: result.reason})
+}
+
+// hermesEnrich routes a Hermes tool call to the matching Claude-side
+// enrichment. read_file reuses enrichRead (after normalising the path
+// key, which Hermes names `path` rather than Claude's `file_path`);
+// terminal reuses enrichBash, whose `command` key Hermes already
+// matches. Any other tool is a no-op.
+func hermesEnrich(input hermesPreToolInput, port int) enrichResult {
+	switch input.ToolName {
+	case hermesReadFileTool:
+		return enrichRead(hermesNormalizeReadInput(input.ToolInput), port)
+	case hermesTerminalTool:
+		return enrichBash(input.ToolInput, port)
+	default:
+		return enrichResult{}
+	}
+}
+
+// hermesNormalizeReadInput returns a tool-input map enrichRead
+// understands: it copies the original (so offset/limit narrow-read
+// hints survive) and ensures a `file_path` key, sourced from whichever
+// path key Hermes used. Hermes' read_file tool names its argument
+// `path`; we also accept the Claude-style `file_path` and a couple of
+// common aliases so the redirect fires regardless of the exact schema.
+func hermesNormalizeReadInput(in map[string]any) map[string]any {
+	out := make(map[string]any, len(in)+1)
+	maps.Copy(out, in)
+	if _, ok := out["file_path"].(string); ok {
+		return out
+	}
+	for _, key := range []string{"path", "filename", "file"} {
+		if p, ok := in[key].(string); ok && p != "" {
+			out["file_path"] = p
+			break
+		}
+	}
+	return out
+}
+
+// isHermesGortexTool reports whether a Hermes tool name is one of
+// Gortex's own MCP graph tools (as opposed to read_file / terminal).
+// Used by the consult-unlock and nudge postures to detect that the
+// agent consulted the graph. Hermes namespaces an MCP server's tools
+// with the server name ("gortex"), so a substring match is the robust
+// test across Hermes' naming variants (gortex.search_symbols,
+// gortex__search_symbols, …) without hard-coding the full tool list.
+func isHermesGortexTool(name string) bool {
+	n := strings.ToLower(strings.TrimSpace(name))
+	if n == hermesReadFileTool || n == hermesTerminalTool {
+		return false
+	}
+	return strings.Contains(n, "gortex")
+}
+
+// hermesAdaptiveNudge is the Hermes counterpart of adaptiveNudge: it
+// tracks a per-session streak of non-symbolic fallback calls and
+// soft-denies once when the streak crosses nudgeThreshold, then resets.
+// A Gortex graph tool call (or any call enrich didn't flag) resets the
+// streak. Kept separate from adaptiveNudge because that helper is keyed
+// to Claude's enrichResult flow; the posture logic is identical.
+func hermesAdaptiveNudge(input hermesPreToolInput, isGortexTool bool, result enrichResult) enrichResult {
+	if isGortexTool || !result.deny {
+		st := loadSessionState(input.SessionID)
+		if st.NonSymbolicStreak != 0 {
+			st.NonSymbolicStreak = 0
+			saveSessionState(input.SessionID, st)
+		}
+		return enrichResult{}
+	}
+
+	st := loadSessionState(input.SessionID)
+	st.NonSymbolicStreak++
+	if st.NonSymbolicStreak >= nudgeThreshold {
+		st.NonSymbolicStreak = 0
+		saveSessionState(input.SessionID, st)
+		logHookDecision(input.ToolName, "", DecisionNudged, 0, 0)
+		return enrichResult{deny: true, reason: nudgeReason(downgradeReason(result))}
+	}
+	saveSessionState(input.SessionID, st)
+	return enrichResult{}
+}
+
+// runHermesPreLLMCall handles the pre_llm_call event — Hermes' single
+// context-injection point, which it joins into the user message
+// (preserving the prompt cache). It does double duty, covering two
+// Claude Code surfaces at once:
+//
+//   - On the first turn (is_first_turn) it injects the Gortex session
+//     orientation briefing — the equivalent of Claude's SessionStart
+//     hook, which has no Hermes counterpart (on_session_start is
+//     observer-only and cannot inject).
+//   - On every later turn it surfaces graph symbols relevant to the
+//     user's message — the equivalent of Claude's UserPromptSubmit.
+//
+// Best-effort throughout: a daemon miss, an empty result, or a trivial
+// prompt is a silent no-op so a turn is never blocked or padded.
+func runHermesPreLLMCall(data []byte) {
+	var input hermesPreLLMInput
+	if err := json.Unmarshal(data, &input); err != nil {
+		return
+	}
+	if input.HookEventName != hermesEventPreLLMCall {
+		return
+	}
+
+	userMessage := firstNonEmpty(input.UserMessage, input.Extra.UserMessage)
+	isFirstTurn := input.IsFirstTurn || input.Extra.IsFirstTurn
+	cwd := firstNonEmpty(input.CWD, input.Extra.CWD)
+
+	var ctx string
+	if isFirstTurn {
+		ctx = buildSessionStartBriefing(cwd)
+	} else {
+		query := promptQuery(userMessage)
+		if query == "" {
+			return
+		}
+		hits, err := probeViaDaemon(query, userPromptProbeTimeout)
+		if err != nil || len(hits) == 0 {
+			return
+		}
+		ctx = buildPromptInjection(hits)
+	}
+	if ctx == "" {
+		return
+	}
+	emitHermes(hermesDecision{Context: ctx})
+}
+
+// firstNonEmpty returns the first non-empty string of its arguments, or
+// "" when all are empty. Used to coalesce the top-level vs `extra`
+// layouts of the pre_llm_call payload.
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/hooks/hermes_test.go
+++ b/internal/hooks/hermes_test.go
@@ -1,0 +1,268 @@
+package hooks
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/daemon"
+)
+
+// decodeHermes decodes a Hermes hook stdout payload, failing the test on
+// invalid JSON. An empty string decodes to the zero decision.
+func decodeHermes(t *testing.T, out string) hermesDecision {
+	t.Helper()
+	var d hermesDecision
+	if strings.TrimSpace(out) == "" {
+		return d
+	}
+	if err := json.Unmarshal([]byte(out), &d); err != nil {
+		t.Fatalf("invalid Hermes decision JSON: %v\n%s", err, out)
+	}
+	return d
+}
+
+func TestRunHermes_IgnoresUnknownEvent(t *testing.T) {
+	// runHermesPreToolCall / runHermesPreLLMCall both guard on the event
+	// name, so a mismatched payload is a clean no-op.
+	out := captureStdout(t, func() {
+		runHermesPreToolCall([]byte(`{"hook_event_name":"post_tool_call","tool_name":"read_file"}`), 0, ModeDeny)
+	})
+	if out != "" {
+		t.Errorf("non pre_tool_call should be a no-op, got %q", out)
+	}
+	out = captureStdout(t, func() {
+		runHermesPreLLMCall([]byte(`{"hook_event_name":"on_session_start"}`))
+	})
+	if out != "" {
+		t.Errorf("non pre_llm_call should be a no-op, got %q", out)
+	}
+}
+
+func TestHermesPreToolCall_ReadFileIndexed_Blocks(t *testing.T) {
+	port := newIndexedBridge(t, 12)
+	data := []byte(`{"hook_event_name":"pre_tool_call","tool_name":"read_file","tool_input":{"path":"/repo/handler.go"}}`)
+	out := captureStdout(t, func() { runHermesPreToolCall(data, port, ModeDeny) })
+
+	d := decodeHermes(t, out)
+	if d.Action != "block" {
+		t.Fatalf("expected action=block, got %+v", d)
+	}
+	if !strings.Contains(d.Message, "/repo/handler.go") {
+		t.Errorf("message should name the file: %q", d.Message)
+	}
+	if !strings.Contains(d.Message, "get_symbol_source") {
+		t.Errorf("message should redirect to graph tools: %q", d.Message)
+	}
+	// Canonical Hermes shape — never Claude's envelope.
+	if strings.Contains(out, "hookSpecificOutput") || strings.Contains(out, "permissionDecision") {
+		t.Errorf("output leaked the Claude shape: %s", out)
+	}
+}
+
+func TestHermesPreToolCall_ReadFileFilePathKey(t *testing.T) {
+	// Claude-style file_path key is also accepted, not just Hermes' path.
+	port := newIndexedBridge(t, 3)
+	data := []byte(`{"hook_event_name":"pre_tool_call","tool_name":"read_file","tool_input":{"file_path":"/repo/a.go"}}`)
+	out := captureStdout(t, func() { runHermesPreToolCall(data, port, ModeDeny) })
+	if d := decodeHermes(t, out); d.Action != "block" {
+		t.Fatalf("expected block for file_path key, got %+v", d)
+	}
+}
+
+func TestHermesPreToolCall_ReadFileNotIndexed_NoBlock(t *testing.T) {
+	// port 0 → bridge unreachable → not indexed → no block in deny mode.
+	data := []byte(`{"hook_event_name":"pre_tool_call","tool_name":"read_file","tool_input":{"path":"/tmp/x.go"}}`)
+	out := captureStdout(t, func() { runHermesPreToolCall(data, 0, ModeDeny) })
+	if out != "" {
+		t.Errorf("unindexed read should not block (no soft channel on pre_tool_call), got %q", out)
+	}
+}
+
+func TestHermesPreToolCall_ReadNonSource_NoBlock(t *testing.T) {
+	port := newIndexedBridge(t, 99)
+	data := []byte(`{"hook_event_name":"pre_tool_call","tool_name":"read_file","tool_input":{"path":"/repo/README.md"}}`)
+	out := captureStdout(t, func() { runHermesPreToolCall(data, port, ModeDeny) })
+	if out != "" {
+		t.Errorf("non-source read should pass through, got %q", out)
+	}
+}
+
+func TestHermesPreToolCall_TerminalGrepHit_Blocks(t *testing.T) {
+	redirectTelemetry(t)
+	stubProbe(t, []grepSymbolHit{
+		{Name: "handleFoo", Kind: "function", FilePath: "internal/a.go", Line: 42},
+	}, nil)
+
+	data := []byte(`{"hook_event_name":"pre_tool_call","tool_name":"terminal","tool_input":{"command":"grep -rn handleFoo ."}}`)
+	out := captureStdout(t, func() { runHermesPreToolCall(data, 0, ModeDeny) })
+
+	d := decodeHermes(t, out)
+	if d.Action != "block" {
+		t.Fatalf("expected block for terminal grep hit, got %+v", d)
+	}
+	if !strings.Contains(d.Message, "handleFoo") {
+		t.Errorf("message should mention the matched symbol: %q", d.Message)
+	}
+}
+
+func TestHermesPreToolCall_TerminalUnrelated_NoBlock(t *testing.T) {
+	stubProbe(t, nil, nil)
+	data := []byte(`{"hook_event_name":"pre_tool_call","tool_name":"terminal","tool_input":{"command":"go build ./..."}}`)
+	out := captureStdout(t, func() { runHermesPreToolCall(data, 0, ModeDeny) })
+	if out != "" {
+		t.Errorf("unrelated terminal command should pass through, got %q", out)
+	}
+}
+
+func TestHermesPreToolCall_EnrichNeverBlocks(t *testing.T) {
+	// Indexed read that would block under deny must pass through under
+	// enrich — pre_tool_call has no soft-context channel.
+	port := newIndexedBridge(t, 20)
+	data := []byte(`{"hook_event_name":"pre_tool_call","tool_name":"read_file","tool_input":{"path":"/repo/x.go"}}`)
+	out := captureStdout(t, func() { runHermesPreToolCall(data, port, ModeEnrich) })
+	if out != "" {
+		t.Errorf("enrich mode must never block, got %q", out)
+	}
+}
+
+func TestHermesPreToolCall_ConsultUnlock(t *testing.T) {
+	t.Setenv(hookSessionDirEnvVar, t.TempDir())
+	port := newIndexedBridge(t, 7)
+	read := []byte(`{"hook_event_name":"pre_tool_call","tool_name":"read_file","session_id":"s1","tool_input":{"path":"/repo/x.go"}}`)
+
+	// Before consulting the graph: indexed read is blocked, with the
+	// unlock hint appended.
+	out := captureStdout(t, func() { runHermesPreToolCall(read, port, ModeConsultUnlock) })
+	d := decodeHermes(t, out)
+	if d.Action != "block" {
+		t.Fatalf("expected block before graph consulted, got %+v", d)
+	}
+	if !strings.Contains(d.Message, "consult-unlock") {
+		t.Errorf("block should carry the unlock hint: %q", d.Message)
+	}
+
+	// A Gortex graph tool call flips the marker (pass-through, no output).
+	gortexCall := []byte(`{"hook_event_name":"pre_tool_call","tool_name":"gortex.search_symbols","session_id":"s1","tool_input":{}}`)
+	if got := captureStdout(t, func() { runHermesPreToolCall(gortexCall, port, ModeConsultUnlock) }); got != "" {
+		t.Errorf("gortex tool call should be a silent pass-through, got %q", got)
+	}
+
+	// After consulting: the same read is no longer blocked.
+	if got := captureStdout(t, func() { runHermesPreToolCall(read, port, ModeConsultUnlock) }); got != "" {
+		t.Errorf("read should be unlocked after a graph call, got %q", got)
+	}
+}
+
+func TestHermesPreToolCall_NudgeFiresOncePerBurst(t *testing.T) {
+	t.Setenv(hookSessionDirEnvVar, t.TempDir())
+	redirectTelemetry(t)
+	stubProbe(t, []grepSymbolHit{{Name: "Foo", Kind: "type", FilePath: "a.go", Line: 1}}, nil)
+	grep := []byte(`{"hook_event_name":"pre_tool_call","tool_name":"terminal","session_id":"n1","tool_input":{"command":"grep -rn Foo ."}}`)
+
+	// Below the threshold: no block.
+	for i := range nudgeThreshold - 1 {
+		if got := captureStdout(t, func() { runHermesPreToolCall(grep, 0, ModeAdaptiveNudge) }); got != "" {
+			t.Fatalf("call %d under nudge threshold should not block, got %q", i+1, got)
+		}
+	}
+	// Threshold crossed: one soft-deny.
+	out := captureStdout(t, func() { runHermesPreToolCall(grep, 0, ModeAdaptiveNudge) })
+	d := decodeHermes(t, out)
+	if d.Action != "block" {
+		t.Fatalf("expected one nudge block at the threshold, got %+v", d)
+	}
+	// Streak reset: the next call proceeds.
+	if got := captureStdout(t, func() { runHermesPreToolCall(grep, 0, ModeAdaptiveNudge) }); got != "" {
+		t.Errorf("post-nudge call should proceed, got %q", got)
+	}
+}
+
+func TestHermesPreLLMCall_FirstTurnInjectsOrientation(t *testing.T) {
+	withFakeStatus(t, func() (*daemon.StatusResponse, error) {
+		return nil, errDaemonUnreachable // briefing is emitted even when down
+	})
+	data := []byte(`{"hook_event_name":"pre_llm_call","is_first_turn":true,"cwd":"/tmp/x"}`)
+	out := captureStdout(t, func() { runHermesPreLLMCall(data) })
+
+	d := decodeHermes(t, out)
+	if d.Context == "" {
+		t.Fatal("first turn should inject an orientation context")
+	}
+	if !strings.Contains(d.Context, "Gortex Session Orientation") {
+		t.Errorf("context should be the orientation briefing: %q", d.Context)
+	}
+	if d.Action != "" {
+		t.Errorf("pre_llm_call must never block: %+v", d)
+	}
+}
+
+func TestHermesPreLLMCall_FirstTurnInExtra(t *testing.T) {
+	withFakeStatus(t, func() (*daemon.StatusResponse, error) {
+		return nil, errDaemonUnreachable
+	})
+	// Some Hermes builds carry is_first_turn / cwd inside `extra`.
+	data := []byte(`{"hook_event_name":"pre_llm_call","extra":{"is_first_turn":true,"cwd":"/tmp/x"}}`)
+	out := captureStdout(t, func() { runHermesPreLLMCall(data) })
+	if d := decodeHermes(t, out); d.Context == "" {
+		t.Fatal("is_first_turn in extra should still inject orientation")
+	}
+}
+
+func TestHermesPreLLMCall_LaterTurnTrivialPrompt_NoOp(t *testing.T) {
+	// Not the first turn, and a trivial message → no probe, no output.
+	for _, data := range []string{
+		`{"hook_event_name":"pre_llm_call","is_first_turn":false,"user_message":"ok"}`,
+		`{"hook_event_name":"pre_llm_call","user_message":"/clear"}`,
+		`{"hook_event_name":"pre_llm_call","extra":{"user_message":""}}`,
+	} {
+		if got := captureStdout(t, func() { runHermesPreLLMCall([]byte(data)) }); got != "" {
+			t.Errorf("trivial later-turn prompt should be a no-op, got %q for %s", got, data)
+		}
+	}
+}
+
+func TestHermesNormalizeReadInput(t *testing.T) {
+	cases := []struct {
+		name string
+		in   map[string]any
+		want string
+	}{
+		{"path key", map[string]any{"path": "/a.go"}, "/a.go"},
+		{"file_path wins", map[string]any{"file_path": "/b.go", "path": "/a.go"}, "/b.go"},
+		{"filename alias", map[string]any{"filename": "/c.go"}, "/c.go"},
+		{"file alias", map[string]any{"file": "/d.go"}, "/d.go"},
+		{"none", map[string]any{"offset": 10}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, _ := hermesNormalizeReadInput(tc.in)["file_path"].(string)
+			if got != tc.want {
+				t.Errorf("file_path = %q, want %q", got, tc.want)
+			}
+		})
+	}
+	// The original keys must survive so enrichRead's narrow-read detection
+	// still sees offset/limit.
+	out := hermesNormalizeReadInput(map[string]any{"path": "/a.go", "offset": 5, "limit": 10})
+	if out["offset"] != 5 || out["limit"] != 10 {
+		t.Errorf("narrow-read hints dropped: %#v", out)
+	}
+}
+
+func TestIsHermesGortexTool(t *testing.T) {
+	cases := map[string]bool{
+		"read_file":               false,
+		"terminal":                false,
+		"gortex.search_symbols":   true,
+		"gortex__find_usages":     true,
+		"mcp__gortex__get_symbol": true,
+		"web_search":              false,
+		"":                        false,
+	}
+	for name, want := range cases {
+		if got := isHermesGortexTool(name); got != want {
+			t.Errorf("isHermesGortexTool(%q) = %v, want %v", name, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #51. 

The Hermes adapter wires the gortex MCP server + skills in #42 but not hooks — the Claude Code adapter additionally installs `PreToolUse` / `UserPromptSubmit` / `SessionStart` hooks that redirect `Grep`/`Glob`/`Read` of indexed source to graph tools. This closes that parity gap.

Hermes wire protocol (verified against hermes-agent v0.15.1 docs):

- `pre_tool_call` (matcher `"read_file|terminal"`): the `block/redirect` hook. `read_file` covers whole-file reads of indexed source; terminal covers shell `grep/find/cat` (Hermes has no separate `Grep`/`Glob` tool). Honours the `deny` / `consult-unlock` / `nudge` postures; enrich is a no-op at this boundary (`pre_tool_call` has no soft-context channel) and rides `pre_llm_call` instead. Emits the canonical `{"action":"block","message"}`.
- `pre_llm_call` (no matcher): context injection. Does double duty — the orientation briefing on the first turn (Claude `SessionStart` has no Hermes counterpart: `on_session_start` is observer-only) and relevant-symbol surfacing on later turns (Claude `UserPromptSubmit`). Emits `{"context": ...}`.

`post_tool_call` is fire-and-forget (no decision accepted), so enrich-mode output augmentation has no clean Hermes equivalent — documented, skipped.