### PR TITLE
fix(java): nested-class indexing panic (#54) + Java analyzer parity

### DIFF
--- a/internal/analysis/deadcode.go
+++ b/internal/analysis/deadcode.go
@@ -400,6 +400,24 @@ func FindDeadCode(g graph.Store, processes *ProcessResult, excludePatterns []str
 				continue
 			}
 
+			// Java: a method tagged @Override implements or overrides a
+			// supertype member and is reachable through that contract even
+			// with no direct caller in the indexed graph. Public overrides
+			// are already excluded by visibility; this rescues protected /
+			// package-private overrides from a false positive.
+			if n.Language == "java" {
+				overridden := false
+				for _, e := range outEdges {
+					if e.Kind == graph.EdgeAnnotated && e.To == javaOverrideAnnoID {
+						overridden = true
+						break
+					}
+				}
+				if overridden {
+					continue
+				}
+			}
+
 			// Fallback: well-known standard-library interface methods.
 			// If the implements edge wasn't inferred, methods like ServeHTTP,
 			// MarshalJSON, String, etc. are still almost certainly alive.
@@ -434,7 +452,7 @@ func FindDeadCode(g graph.Store, processes *ProcessResult, excludePatterns []str
 		if isTestFilePath(n.FilePath) {
 			continue
 		}
-		if isExportedSymbol(n.Name, n.Language) && !isPackagePrivateByConvention(n.FilePath, n.Language) {
+		if isExportedNode(n) && !isPackagePrivateByConvention(n.FilePath, n.Language) {
 			continue
 		}
 		if matchesExcludePattern(n.FilePath, n.ID, excludePatterns) {
@@ -883,6 +901,40 @@ func isPackagePrivateByConvention(filePath, lang string) bool {
 	// from its enclosing tree.
 	return strings.Contains(filePath, "/internal/") ||
 		strings.HasPrefix(filePath, "internal/")
+}
+
+// keywordVisibilityLangs are languages whose access level is an explicit
+// modifier keyword (public/private/protected/...) that the extractor
+// records in Meta["visibility"], rather than a naming convention. For
+// these the name-based isExportedSymbol gives the wrong answer — every
+// Java identifier is non-underscore, so the underscore heuristic marks
+// them ALL exported and dead-code analysis skips the whole language.
+// Extend as other keyword-visibility extractors are verified to stamp
+// Meta["visibility"] with the same value set.
+var keywordVisibilityLangs = map[string]bool{
+	"java": true,
+}
+
+// javaOverrideAnnoID is the synthetic node ID the Java extractor emits
+// for @Override (mirrors languages.AnnotationNodeID("java", "Override"),
+// duplicated here to avoid an analysis→parser import).
+const javaOverrideAnnoID = "annotation::java::Override"
+
+// isExportedNode reports whether n is part of the public API surface and
+// therefore not a dead-code candidate even with zero callers. For
+// keyword-visibility languages it trusts the recorded modifier; for
+// everything else it falls back to the name-based isExportedSymbol.
+func isExportedNode(n *graph.Node) bool {
+	if keywordVisibilityLangs[n.Language] {
+		if v, ok := n.Meta["visibility"].(string); ok && v != "" {
+			// public / protected are reachable from outside the indexed
+			// graph (other packages, subclasses); private / package-private
+			// are fully visible to the indexed call graph, so an unused one
+			// is genuinely dead and worth reporting.
+			return v == "public" || v == "protected"
+		}
+	}
+	return isExportedSymbol(n.Name, n.Language)
 }
 
 // isExportedSymbol checks if a symbol name is exported (public API).

--- a/internal/analysis/deadcode_java_test.go
+++ b/internal/analysis/deadcode_java_test.go
@@ -1,0 +1,91 @@
+package analysis
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// addJavaMethod adds a Java method node with a recorded visibility and
+// no incoming edges (i.e. uncalled in the indexed graph).
+func addJavaMethod(g *graph.Graph, file, name, vis string) string {
+	id := file + "::" + name
+	g.AddNode(&graph.Node{
+		ID: id, Kind: graph.KindMethod, Name: name,
+		FilePath: file, Language: "java", StartLine: 1, EndLine: 3,
+		Meta: map[string]any{"visibility": vis},
+	})
+	return id
+}
+
+// TestFindDeadCode_JavaVisibility is the parity fix: dead-code must read
+// Java's recorded public/private modifier instead of the Go-style /
+// underscore name heuristic (which marked every Java symbol exported and
+// skipped the whole language).
+func TestFindDeadCode_JavaVisibility(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "Svc.java", Kind: graph.KindFile, FilePath: "Svc.java", Language: "java"})
+
+	privDead := addJavaMethod(g, "Svc.java", "computeInternal", "private")
+	pkgDead := addJavaMethod(g, "Svc.java", "helperPkg", "package")
+	pubAPI := addJavaMethod(g, "Svc.java", "doWork", "public")
+	protAPI := addJavaMethod(g, "Svc.java", "onInit", "protected")
+
+	dead := map[string]bool{}
+	for _, d := range FindDeadCode(g, nil, nil) {
+		dead[d.ID] = true
+	}
+
+	require.True(t, dead[privDead], "an uncalled private method is genuinely dead")
+	require.True(t, dead[pkgDead], "an uncalled package-private method is genuinely dead")
+	require.False(t, dead[pubAPI], "a public method is API surface, not dead")
+	require.False(t, dead[protAPI], "a protected method is subclass API, not dead")
+}
+
+// TestFindDeadCode_JavaOverrideRescued guards the false positive the
+// visibility fix would otherwise introduce: a non-public @Override
+// implements a supertype contract and is reached through it, so it must
+// not be reported even with no direct caller.
+func TestFindDeadCode_JavaOverrideRescued(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "Cmp.java", Kind: graph.KindFile, FilePath: "Cmp.java", Language: "java"})
+
+	plainPkg := addJavaMethod(g, "Cmp.java", "unusedPkgHelper", "package")
+	overridePkg := addJavaMethod(g, "Cmp.java", "compareTo", "package")
+	g.AddEdge(&graph.Edge{From: overridePkg, To: javaOverrideAnnoID, Kind: graph.EdgeAnnotated})
+
+	dead := map[string]bool{}
+	for _, d := range FindDeadCode(g, nil, nil) {
+		dead[d.ID] = true
+	}
+
+	require.True(t, dead[plainPkg], "a plain uncalled package-private method is dead")
+	require.False(t, dead[overridePkg], "a package-private @Override is reached via its contract")
+}
+
+// TestFindDeadCode_JavaEntryPointRescued confirms a framework-stamped
+// entry point (e.g. a package-private @PostConstruct callback) is not
+// flagged once visibility makes non-public methods eligible.
+func TestFindDeadCode_JavaEntryPointRescued(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "Bean.java", Kind: graph.KindFile, FilePath: "Bean.java", Language: "java"})
+
+	// Stamp it like entrypoints.detectJava would for @PostConstruct.
+	callback := "Bean.java::init"
+	g.AddNode(&graph.Node{
+		ID: callback, Kind: graph.KindMethod, Name: "init",
+		FilePath: "Bean.java", Language: "java", StartLine: 1, EndLine: 3,
+		Meta: map[string]any{
+			"visibility":       "package",
+			"entry_point":      true,
+			"entry_point_kind": "lifecycle:init",
+		},
+	})
+
+	dead := map[string]bool{}
+	for _, d := range FindDeadCode(g, nil, nil) {
+		dead[d.ID] = true
+	}
+	require.False(t, dead[callback], "a stamped framework callback is a live root")
+}

--- a/internal/analysis/processes.go
+++ b/internal/analysis/processes.go
@@ -142,7 +142,7 @@ func scoreEntryPoint(n *graph.Node, calleeCount, callerCount int) float64 {
 
 	// Export/visibility multiplier
 	exportMult := 1.0
-	if isExported(n.Name, n.Language) {
+	if isExportedForProcess(n) {
 		exportMult = 1.5
 	}
 
@@ -154,7 +154,32 @@ func scoreEntryPoint(n *graph.Node, calleeCount, callerCount int) float64 {
 		callerMult = 1.3
 	}
 
-	return base * nameMult * exportMult * callerMult
+	// Framework entry points stamped by the entrypoints detector (Spring
+	// handlers, JAX-RS resources, annotated servlets, the JVM main, …)
+	// are invoked by a runtime, not application code — the most reliable
+	// process roots. Test fixtures are stamped too (so dead-code keeps
+	// them live) but are noise as top-level processes, so skip the boost
+	// for them.
+	entryMult := 1.0
+	if ep, _ := n.Meta["entry_point"].(bool); ep {
+		if kind, _ := n.Meta["entry_point_kind"].(string); !strings.HasPrefix(kind, "junit:") {
+			entryMult = 2.0
+		}
+	}
+
+	return base * nameMult * exportMult * callerMult * entryMult
+}
+
+// isExportedForProcess mirrors the dead-code visibility logic: for
+// keyword-visibility languages (Java) it trusts the recorded modifier
+// so a private helper isn't handed the public-API entry-point boost.
+func isExportedForProcess(n *graph.Node) bool {
+	if n.Language == "java" {
+		if v, ok := n.Meta["visibility"].(string); ok && v != "" {
+			return v == "public" || v == "protected"
+		}
+	}
+	return isExported(n.Name, n.Language)
 }
 
 func namePatternMultiplier(name, lang string) float64 {

--- a/internal/analysis/processes_java_test.go
+++ b/internal/analysis/processes_java_test.go
@@ -1,0 +1,49 @@
+package analysis
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// TestScoreEntryPoint_JavaVisibility checks a private Java helper is not
+// handed the public-API entry-point boost (it must score below an
+// otherwise-identical public method).
+func TestScoreEntryPoint_JavaVisibility(t *testing.T) {
+	pub := &graph.Node{
+		ID: "S.java::doWork", Kind: graph.KindMethod, Name: "doWork", Language: "java",
+		Meta: map[string]any{"visibility": "public"},
+	}
+	priv := &graph.Node{
+		ID: "S.java::doWorkImpl", Kind: graph.KindMethod, Name: "doWorkImpl", Language: "java",
+		Meta: map[string]any{"visibility": "private"},
+	}
+	pubScore := scoreEntryPoint(pub, 3, 0)
+	privScore := scoreEntryPoint(priv, 3, 0)
+	require.Greater(t, pubScore, privScore, "public method must outscore an identical private one")
+}
+
+// TestScoreEntryPoint_JavaEntryBoost checks a stamped Spring handler is
+// boosted as a process root, while a stamped JUnit test is not (tests
+// stay live for dead-code but are noise as top-level processes).
+func TestScoreEntryPoint_JavaEntryBoost(t *testing.T) {
+	// All three share a name with no entry/util pattern boost, so the
+	// only score difference comes from the entry-point stamp.
+	plain := &graph.Node{
+		ID: "S.java::execute", Kind: graph.KindMethod, Name: "execute", Language: "java",
+		Meta: map[string]any{"visibility": "public"},
+	}
+	handler := &graph.Node{
+		ID: "C.java::execute", Kind: graph.KindMethod, Name: "execute", Language: "java",
+		Meta: map[string]any{"visibility": "public", "entry_point": true, "entry_point_kind": "spring:handler"},
+	}
+	test := &graph.Node{
+		ID: "T.java::execute", Kind: graph.KindMethod, Name: "execute", Language: "java",
+		Meta: map[string]any{"visibility": "public", "entry_point": true, "entry_point_kind": "junit:test"},
+	}
+	require.Greater(t, scoreEntryPoint(handler, 3, 0), scoreEntryPoint(plain, 3, 0),
+		"a stamped Spring handler must outscore a plain method")
+	require.Equal(t, scoreEntryPoint(test, 3, 0), scoreEntryPoint(plain, 3, 0),
+		"a JUnit test must not get the process-root boost")
+}

--- a/internal/entrypoints/entrypoints.go
+++ b/internal/entrypoints/entrypoints.go
@@ -22,10 +22,11 @@ const (
 	MetaEntryKind  = "entry_point_kind"
 )
 
-// Detect inspects one file's extracted nodes for framework entry
-// points and stamps the file node plus the relevant symbols. It
-// returns the number of nodes stamped.
-func Detect(relPath, lang string, nodes []*graph.Node) int {
+// Detect inspects one file's extracted nodes (and edges, for the
+// annotation-driven detectors) for framework entry points and stamps
+// the file node plus the relevant symbols. It returns the number of
+// nodes stamped.
+func Detect(relPath, lang string, nodes []*graph.Node, edges []*graph.Edge) int {
 	slashed := path.Clean(strings.ReplaceAll(relPath, "\\", "/"))
 	switch lang {
 	case "python":
@@ -34,6 +35,8 @@ func Detect(relPath, lang string, nodes []*graph.Node) int {
 		return detectNextJS(slashed, nodes)
 	case "csharp":
 		return detectASPNet(slashed, nodes)
+	case "java":
+		return detectJava(nodes, edges)
 	}
 	return 0
 }
@@ -162,6 +165,112 @@ func detectASPNet(relPath string, nodes []*graph.Node) int {
 			(n.Name == "Main" || n.Name == "ConfigureServices" || n.Name == "Configure"):
 			stamp(n, "aspnet:host")
 			count++
+		}
+	}
+	return count
+}
+
+// javaAnnoPrefix is the synthetic annotation node-ID prefix the Java
+// extractor emits (languages.AnnotationNodeID("java", name)); the bare
+// annotation name is the suffix.
+const javaAnnoPrefix = "annotation::java::"
+
+// javaEntryClassAnnos maps a class/interface-level annotation to the
+// entry-point kind it confers. These mark a *type* the framework
+// instantiates and drives (Spring stereotypes, JAX-RS resources,
+// annotated servlets / websocket endpoints).
+var javaEntryClassAnnos = map[string]string{
+	"RestController": "spring:controller",
+	"Controller":     "spring:controller",
+	"Service":        "spring:bean",
+	"Component":      "spring:bean",
+	"Repository":     "spring:bean",
+	"Configuration":  "spring:config",
+	"Path":           "jaxrs:resource",
+	"WebServlet":     "servlet:endpoint",
+	"ServerEndpoint": "websocket:endpoint",
+}
+
+// javaEntryMethodAnnos maps a method-level annotation to the entry-point
+// kind it confers. These mark a *method* the framework invokes directly
+// — request handlers, lifecycle callbacks, scheduled jobs, test cases —
+// which therefore has no in-application caller.
+var javaEntryMethodAnnos = map[string]string{
+	"RequestMapping":    "spring:handler",
+	"GetMapping":        "spring:handler",
+	"PostMapping":       "spring:handler",
+	"PutMapping":        "spring:handler",
+	"DeleteMapping":     "spring:handler",
+	"PatchMapping":      "spring:handler",
+	"EventListener":     "spring:listener",
+	"Scheduled":         "spring:scheduled",
+	"Bean":              "spring:bean",
+	"PostConstruct":     "lifecycle:init",
+	"PreDestroy":        "lifecycle:destroy",
+	"Test":              "junit:test",
+	"ParameterizedTest": "junit:test",
+	"RepeatedTest":      "junit:test",
+	"BeforeEach":        "junit:fixture",
+	"AfterEach":         "junit:fixture",
+	"BeforeAll":         "junit:fixture",
+	"AfterAll":          "junit:fixture",
+	"GET":               "jaxrs:handler",
+	"POST":              "jaxrs:handler",
+	"PUT":               "jaxrs:handler",
+	"DELETE":            "jaxrs:handler",
+	"HEAD":              "jaxrs:handler",
+}
+
+// detectJava flags Java framework entry points from annotation edges:
+// Spring stereotypes / request handlers, JAX-RS resources, annotated
+// servlets, JUnit test methods, lifecycle callbacks, and the JVM
+// `main` method. Unlike the path-based detectors it stamps the
+// individual annotated symbols, NOT the file node — a Spring controller
+// file can still hold genuinely-dead private helpers, and only the
+// framework-invoked members should be treated as live roots.
+func detectJava(nodes []*graph.Node, edges []*graph.Edge) int {
+	// symbol ID → set of annotation names applied to it.
+	annos := map[string]map[string]bool{}
+	for _, e := range edges {
+		if e.Kind != graph.EdgeAnnotated {
+			continue
+		}
+		name, ok := strings.CutPrefix(e.To, javaAnnoPrefix)
+		if !ok {
+			continue
+		}
+		if annos[e.From] == nil {
+			annos[e.From] = map[string]bool{}
+		}
+		annos[e.From][name] = true
+	}
+
+	count := 0
+	for _, n := range nodes {
+		switch n.Kind {
+		case graph.KindType, graph.KindInterface:
+			for a := range annos[n.ID] {
+				if kind, ok := javaEntryClassAnnos[a]; ok {
+					stamp(n, kind)
+					count++
+					break
+				}
+			}
+		case graph.KindFunction, graph.KindMethod:
+			kind := ""
+			for a := range annos[n.ID] {
+				if k, ok := javaEntryMethodAnnos[a]; ok {
+					kind = k
+					break
+				}
+			}
+			if kind == "" && n.Name == "main" {
+				kind = "java:main"
+			}
+			if kind != "" {
+				stamp(n, kind)
+				count++
+			}
 		}
 	}
 	return count

--- a/internal/entrypoints/entrypoints_test.go
+++ b/internal/entrypoints/entrypoints_test.go
@@ -15,7 +15,7 @@ func TestDetect_Alembic(t *testing.T) {
 		{ID: "f::downgrade", Kind: graph.KindFunction, Name: "downgrade"},
 		{ID: "f::revision", Kind: graph.KindVariable, Name: "revision"},
 	}
-	require.Equal(t, 3, Detect("alembic/versions/abc.py", "python", nodes))
+	require.Equal(t, 3, Detect("alembic/versions/abc.py", "python", nodes, nil))
 	require.Equal(t, true, nodes[0].Meta[MetaEntryPoint])
 	require.Equal(t, "alembic:migration", nodes[0].Meta[MetaEntryKind])
 	require.Equal(t, true, nodes[1].Meta[MetaEntryPoint]) // upgrade
@@ -29,7 +29,7 @@ func TestDetect_AlembicRequiresFullSignature(t *testing.T) {
 		{ID: "f.py", Kind: graph.KindFile, FilePath: "f.py"},
 		{ID: "f::upgrade", Kind: graph.KindFunction, Name: "upgrade"},
 	}
-	require.Equal(t, 0, Detect("f.py", "python", nodes))
+	require.Equal(t, 0, Detect("f.py", "python", nodes, nil))
 }
 
 func TestDetect_NextJSPagesRouter(t *testing.T) {
@@ -37,25 +37,25 @@ func TestDetect_NextJSPagesRouter(t *testing.T) {
 		{ID: "pages/users.tsx", Kind: graph.KindFile, FilePath: "pages/users.tsx"},
 		{ID: "f::getServerSideProps", Kind: graph.KindFunction, Name: "getServerSideProps"},
 	}
-	require.Equal(t, 2, Detect("pages/users.tsx", "typescript", nodes))
+	require.Equal(t, 2, Detect("pages/users.tsx", "typescript", nodes, nil))
 	require.Equal(t, "nextjs:page", nodes[0].Meta[MetaEntryKind])
 	require.Equal(t, true, nodes[1].Meta[MetaEntryPoint])
 }
 
 func TestDetect_NextJSAppRouter(t *testing.T) {
 	page := []*graph.Node{{ID: "src/app/dashboard/page.tsx", Kind: graph.KindFile, FilePath: "src/app/dashboard/page.tsx"}}
-	require.Equal(t, 1, Detect("src/app/dashboard/page.tsx", "typescript", page))
+	require.Equal(t, 1, Detect("src/app/dashboard/page.tsx", "typescript", page, nil))
 	require.Equal(t, "nextjs:page", page[0].Meta[MetaEntryKind])
 
 	route := []*graph.Node{{ID: "app/api/users/route.ts", Kind: graph.KindFile, FilePath: "app/api/users/route.ts"}}
-	require.Equal(t, 1, Detect("app/api/users/route.ts", "typescript", route))
+	require.Equal(t, 1, Detect("app/api/users/route.ts", "typescript", route, nil))
 	require.Equal(t, "nextjs:route", route[0].Meta[MetaEntryKind])
 }
 
 func TestDetect_NextJSGenericAppDirIgnored(t *testing.T) {
 	// A non-special file under app/ must NOT be flagged Next.js.
 	nodes := []*graph.Node{{ID: "app/helpers.ts", Kind: graph.KindFile, FilePath: "app/helpers.ts"}}
-	require.Equal(t, 0, Detect("app/helpers.ts", "typescript", nodes))
+	require.Equal(t, 0, Detect("app/helpers.ts", "typescript", nodes, nil))
 }
 
 func TestDetect_ASPNetHost(t *testing.T) {
@@ -64,7 +64,7 @@ func TestDetect_ASPNetHost(t *testing.T) {
 		{ID: "p::Main", Kind: graph.KindMethod, Name: "Main"},
 		{ID: "p::Helper", Kind: graph.KindMethod, Name: "Helper"},
 	}
-	require.Equal(t, 2, Detect("src/Program.cs", "csharp", nodes)) // file + Main
+	require.Equal(t, 2, Detect("src/Program.cs", "csharp", nodes, nil)) // file + Main
 	require.Equal(t, "aspnet:host", nodes[0].Meta[MetaEntryKind])
 	require.Equal(t, true, nodes[1].Meta[MetaEntryPoint])
 	require.Nil(t, nodes[2].Meta) // Helper is not a lifecycle method
@@ -72,5 +72,34 @@ func TestDetect_ASPNetHost(t *testing.T) {
 
 func TestDetect_NonEntryFileIgnored(t *testing.T) {
 	nodes := []*graph.Node{{ID: "src/util.go", Kind: graph.KindFile, FilePath: "src/util.go"}}
-	require.Equal(t, 0, Detect("src/util.go", "go", nodes))
+	require.Equal(t, 0, Detect("src/util.go", "go", nodes, nil))
+}
+
+func TestDetect_JavaSpringControllerAndMain(t *testing.T) {
+	nodes := []*graph.Node{
+		{ID: "UserController.java", Kind: graph.KindFile, FilePath: "UserController.java", Language: "java"},
+		{ID: "UserController.java::UserController", Kind: graph.KindType, Name: "UserController"},
+		{ID: "UserController.java::list", Kind: graph.KindMethod, Name: "list"},     // @GetMapping
+		{ID: "UserController.java::helper", Kind: graph.KindMethod, Name: "helper"}, // private, no annotation
+		{ID: "UserController.java::main", Kind: graph.KindMethod, Name: "main"},     // JVM entry
+	}
+	edges := []*graph.Edge{
+		{From: "UserController.java::UserController", To: "annotation::java::RestController", Kind: graph.EdgeAnnotated},
+		{From: "UserController.java::list", To: "annotation::java::GetMapping", Kind: graph.EdgeAnnotated},
+	}
+	// controller class + list handler + main = 3 (NOT the file node, NOT the helper).
+	require.Equal(t, 3, Detect("UserController.java", "java", nodes, edges))
+	require.Nil(t, nodes[0].Meta, "Java stamps annotated members, never the whole file")
+	require.Equal(t, "spring:controller", nodes[1].Meta[MetaEntryKind])
+	require.Equal(t, true, nodes[2].Meta[MetaEntryPoint])
+	require.Equal(t, "spring:handler", nodes[2].Meta[MetaEntryKind])
+	require.Nil(t, nodes[3].Meta, "a private helper with no entry annotation stays a dead-code candidate")
+	require.Equal(t, "java:main", nodes[4].Meta[MetaEntryKind])
+}
+
+func TestDetect_JavaJUnitTest(t *testing.T) {
+	nodes := []*graph.Node{{ID: "T.java::shouldWork", Kind: graph.KindMethod, Name: "shouldWork"}}
+	edges := []*graph.Edge{{From: "T.java::shouldWork", To: "annotation::java::Test", Kind: graph.EdgeAnnotated}}
+	require.Equal(t, 1, Detect("T.java", "java", nodes, edges))
+	require.Equal(t, "junit:test", nodes[0].Meta[MetaEntryKind])
 }

--- a/internal/indexer/crash_isolation.go
+++ b/internal/indexer/crash_isolation.go
@@ -188,6 +188,17 @@ func (idx *Indexer) extractFile(
 			return timeoutSkipResult(relPath, lang, budget), true,
 				fmt.Errorf("extraction exceeded %dms budget: %s", budget, relPath)
 		}
+		// An extractor panic was recovered in-process: isolate the file
+		// like the subprocess pool does — emit a quarantine node so it
+		// stays visible, record the error, and let indexing continue
+		// rather than crashing the whole run.
+		var pe *extractorPanicError
+		if errors.As(eerr, &pe) {
+			idx.logger.Warn("indexer: recovered extractor panic; file isolated",
+				zap.String("file", relPath), zap.String("reason", fmt.Sprint(pe.value)))
+			return quarantineResult(relPath, lang, "extractor panic: "+fmt.Sprint(pe.value)),
+				true, eerr
+		}
 		if eerr != nil {
 			return nil, false, eerr
 		}

--- a/internal/indexer/crash_isolation_test.go
+++ b/internal/indexer/crash_isolation_test.go
@@ -8,9 +8,20 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
 	"github.com/zzet/gortex/internal/parser/crashpool"
 	"github.com/zzet/gortex/internal/parser/languages"
 )
+
+// panicExtractor is a fake extractor that always panics — it stands in
+// for a real grammar/extractor fault on a malformed file.
+type panicExtractor struct{}
+
+func (panicExtractor) Language() string     { return "boom" }
+func (panicExtractor) Extensions() []string { return []string{".boom"} }
+func (panicExtractor) Extract(string, []byte) (*parser.ExtractionResult, error) {
+	panic("runtime error: slice bounds out of range [95:50]")
+}
 
 // crashWorkerEnv makes the indexer test binary re-execute itself as a
 // crashpool worker subprocess instead of running the test suite.
@@ -34,6 +45,36 @@ func TestExtractFile_InProcess(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, quarantined)
 	require.NotEmpty(t, result.Nodes)
+}
+
+// TestExtractFile_InProcessPanicIsolated guards issue #54: an extractor
+// panic on the in-process (pool == nil) path must be recovered and the
+// file quarantined, never crash the whole indexing run. Covers both the
+// no-budget direct call and the budgeted goroutine path.
+func TestExtractFile_InProcessPanicIsolated(t *testing.T) {
+	for _, budget := range []int{0, 5000} {
+		name := "no_budget"
+		if budget > 0 {
+			name = "with_budget"
+		}
+		t.Run(name, func(t *testing.T) {
+			g := graph.New()
+			idx := newTestIndexer(g)
+			idx.config.MaxExtractMillis = budget
+
+			result, quarantined, err := idx.extractFile(nil, nil, "boom.boom", "boom.boom",
+				"boom", panicExtractor{}, []byte("anything"))
+
+			require.Error(t, err, "a recovered panic must surface as an error")
+			var pe *extractorPanicError
+			require.ErrorAs(t, err, &pe, "error must be an extractorPanicError")
+			require.True(t, quarantined, "the file must be quarantined, not silently dropped")
+			require.Len(t, result.Nodes, 1)
+			require.Equal(t, graph.KindFile, result.Nodes[0].Kind)
+			require.Equal(t, true, result.Nodes[0].Meta["quarantined"])
+			require.Contains(t, result.Nodes[0].Meta["parse_error"], "extractor panic")
+		})
+	}
 }
 
 // TestExtractFile_SubprocessPool exercises the full parent→worker→parent

--- a/internal/indexer/entry_points_test.go
+++ b/internal/indexer/entry_points_test.go
@@ -56,3 +56,62 @@ def downgrade():
 		require.NotEqual(t, "downgrade", d.Name, "Alembic downgrade() must not be flagged dead")
 	}
 }
+
+// TestIndex_JavaDeadCodeAndEntryPoints is the end-to-end parity check:
+// after indexing a Spring controller, dead-code must (a) flag an
+// uncalled private method — which the old name-based heuristic could
+// never do for Java — while (b) leaving public API and framework
+// entry points alone.
+func TestIndex_JavaDeadCodeAndEntryPoints(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "UserController.java"), `package com.example.web;
+
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@RestController
+public class UserController {
+
+    @GetMapping("/users")
+    public String listUsers() {
+        return "ok";
+    }
+
+    private String deadHelper() {
+        return "never called";
+    }
+
+    public static void main(String[] args) {
+        new UserController();
+    }
+}
+`)
+	g := graph.New()
+	reg := parser.NewRegistry()
+	reg.Register(languages.NewJavaExtractor())
+	idx := New(g, reg, config.Default().Index, zap.NewNop())
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+
+	byName := map[string]*graph.Node{}
+	for _, n := range g.AllNodes() {
+		if n.Kind == graph.KindMethod || n.Kind == graph.KindType {
+			byName[n.Name] = n
+		}
+	}
+
+	// Framework entry points are stamped by entrypoints.Detect during indexing.
+	require.NotNil(t, byName["UserController"], "controller type must be indexed")
+	require.Equal(t, true, byName["UserController"].Meta["entry_point"], "@RestController is an entry point")
+	require.Equal(t, "spring:controller", byName["UserController"].Meta["entry_point_kind"])
+	require.NotNil(t, byName["listUsers"], "handler must be indexed")
+	require.Equal(t, true, byName["listUsers"].Meta["entry_point"], "@GetMapping handler is an entry point")
+
+	dead := map[string]bool{}
+	for _, d := range analysis.FindDeadCode(g, nil, nil) {
+		dead[d.Name] = true
+	}
+	require.True(t, dead["deadHelper"], "an uncalled private Java method must now be reported dead")
+	require.False(t, dead["listUsers"], "a public @GetMapping handler is not dead")
+	require.False(t, dead["main"], "main is the JVM entry point, not dead")
+}

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -1174,7 +1174,7 @@ func (idx *Indexer) applyCoverageDomains(relPath, lang string, src []byte, resul
 	// Framework entry points (Alembic migrations / Next.js pages /
 	// ASP.NET host files): symbols reachable only from a runtime.
 	// Stamped so dead-code analysis treats them as live roots.
-	entrypoints.Detect(relPath, lang, result.Nodes)
+	entrypoints.Detect(relPath, lang, result.Nodes, result.Edges)
 	if !idx.config.Coverage.IsEnabled("function_shape") {
 		stripFunctionShape(result)
 	}

--- a/internal/indexer/skip_telemetry.go
+++ b/internal/indexer/skip_telemetry.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"runtime/debug"
 	"time"
 
 	"github.com/zzet/gortex/internal/graph"
@@ -13,6 +14,34 @@ import (
 // errExtractTimeout is the sentinel returned when a file's extraction
 // exceeds IndexConfig.MaxExtractMillis.
 var errExtractTimeout = errors.New("extraction exceeded time budget")
+
+// extractorPanicError wraps a recovered extractor panic so callers can
+// tell a parser crash (quarantine the file, keep indexing) apart from
+// an ordinary extraction error. The original panic value and a stack
+// trace ride along for diagnostics.
+type extractorPanicError struct {
+	file  string
+	value any
+	stack []byte
+}
+
+func (e *extractorPanicError) Error() string {
+	return fmt.Sprintf("extractor panic on %s: %v", e.file, e.value)
+}
+
+// safeExtract runs ext.Extract guarded by a recover so a panic on a
+// single malformed file becomes an error instead of crashing the whole
+// indexing run. This is the in-process last line of defence behind the
+// subprocess crash-isolation pool (which only runs when enabled).
+func safeExtract(ext parser.Extractor, relPath string, src []byte) (result *parser.ExtractionResult, err error) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			result = nil
+			err = &extractorPanicError{file: relPath, value: rec, stack: debug.Stack()}
+		}
+	}()
+	return ext.Extract(relPath, src)
+}
 
 // skippedFile records a file dropped by the size cap, kept so a
 // synthetic telemetry node can be emitted after the parse pass.
@@ -42,7 +71,7 @@ type walkedFile struct {
 func (idx *Indexer) extractWithTimeout(ext parser.Extractor, relPath string, src []byte) (*parser.ExtractionResult, error) {
 	budget := idx.config.MaxExtractMillis
 	if budget <= 0 {
-		return ext.Extract(relPath, src)
+		return safeExtract(ext, relPath, src)
 	}
 	type outcome struct {
 		result *parser.ExtractionResult
@@ -50,12 +79,7 @@ func (idx *Indexer) extractWithTimeout(ext parser.Extractor, relPath string, src
 	}
 	ch := make(chan outcome, 1)
 	go func() {
-		defer func() {
-			if rec := recover(); rec != nil {
-				ch <- outcome{err: fmt.Errorf("extractor panic: %v", rec)}
-			}
-		}()
-		r, err := ext.Extract(relPath, src)
+		r, err := safeExtract(ext, relPath, src)
 		ch <- outcome{result: r, err: err}
 	}()
 	timer := time.NewTimer(time.Duration(budget) * time.Millisecond)

--- a/internal/parser/languages/java_rn.go
+++ b/internal/parser/languages/java_rn.go
@@ -43,12 +43,19 @@ func extractJavaRNModuleNames(src []byte) map[string]string {
 
 		// @ReactModule(name=...) sits in the annotation band just before
 		// the class keyword — search the gap since the previous class.
-		if m := javaReactModuleNmRe.FindStringSubmatch(s[prevEnd:loc[0]]); m != nil {
+		// Clamp the lower bound: for a nested class the enclosing
+		// class's body span (recorded in prevEnd) extends past this
+		// class's start, so prevEnd > loc[0] and the slice would panic.
+		bandStart := min(prevEnd, loc[0])
+		if m := javaReactModuleNmRe.FindStringSubmatch(s[bandStart:loc[0]]); m != nil {
 			module = m[1]
 		}
 
 		out[className] = module
-		prevEnd = bodyEnd
+		// Track the furthest body end seen so a nested class (whose own
+		// body ends before its enclosing class's) can't rewind prevEnd
+		// and re-scan an outer class's annotations.
+		prevEnd = max(prevEnd, bodyEnd)
 	}
 	return out
 }

--- a/internal/parser/languages/java_rn_test.go
+++ b/internal/parser/languages/java_rn_test.go
@@ -1,0 +1,112 @@
+package languages
+
+import "testing"
+
+// TestExtractJavaRNModuleNames_NestedClasses guards the slice-bounds bug
+// (issue #54): a nested class declaration starts inside its enclosing
+// class's body span, so the "annotation band since the previous class"
+// lower bound could exceed the current class's start and panic.
+func TestExtractJavaRNModuleNames_NestedClasses(t *testing.T) {
+	src := []byte(`package example.repro;
+
+class Parent {
+    static class Builder<T extends Builder<T>> {
+    }
+}
+
+public class MinimalNestedGenericBuilder {
+    public static class Builder extends Parent.Builder<Builder> {
+    }
+}
+`)
+	got := extractJavaRNModuleNames(src) // must not panic
+	for _, want := range []string{"Parent", "Builder", "MinimalNestedGenericBuilder"} {
+		if got[want] != want {
+			t.Errorf("module for %q = %q, want %q (default to class name)", want, got[want], want)
+		}
+	}
+}
+
+// TestExtractJavaRNModuleNames_NestedDoesNotStealOuterAnnotation makes
+// sure a @ReactModule on an outer class is not mis-attributed to a later
+// sibling once a nested class has rewound the scan window.
+func TestExtractJavaRNModuleNames_AnnotationStillResolves(t *testing.T) {
+	src := []byte(`package com.example;
+import com.facebook.react.module.annotations.ReactModule;
+
+class Outer {
+    static class Inner {}
+}
+
+@ReactModule(name = "Calendar")
+public class CalendarModule {
+    public String getName() { return "Calendar"; }
+}
+
+public class Unrelated {}
+`)
+	got := extractJavaRNModuleNames(src)
+	if got["CalendarModule"] != "Calendar" {
+		t.Errorf("CalendarModule module = %q, want Calendar (the @ReactModule override)", got["CalendarModule"])
+	}
+	// The @ReactModule on CalendarModule must not bleed onto a later
+	// sibling, and the nested Inner must default to its class name.
+	if got["Unrelated"] != "Unrelated" {
+		t.Errorf("Unrelated module = %q, want Unrelated", got["Unrelated"])
+	}
+	if got["Inner"] != "Inner" {
+		t.Errorf("Inner module = %q, want Inner", got["Inner"])
+	}
+}
+
+// TestJavaExtract_NestedGenericBuilder is the end-to-end form of the
+// issue #54 reproducer: the whole extractor must not panic and must
+// still emit the declared types.
+func TestJavaExtract_NestedGenericBuilder(t *testing.T) {
+	cases := map[string]string{
+		"minimal": `package example.repro;
+
+class Parent {
+    static class Builder<T extends Builder<T>> {
+    }
+}
+
+public class MinimalNestedGenericBuilder {
+    public static class Builder extends Parent.Builder<Builder> {
+    }
+}
+`,
+		"factory_with_interface": `package example.repro;
+
+interface Measurable {}
+
+public class MetricFactory extends BaseFactory implements Measurable {
+    public static class Builder extends BaseFactory.Builder<Builder> {
+        Builder measurement(String m) { return this; }
+    }
+
+    public static Builder builder() {
+        return new Builder().measurement("x");
+    }
+}
+`,
+	}
+	for name, src := range cases {
+		t.Run(name, func(t *testing.T) {
+			res, err := NewJavaExtractor().Extract(name+".java", []byte(src))
+			if err != nil {
+				t.Fatalf("extract: %v", err)
+			}
+			if len(res.Nodes) == 0 {
+				t.Fatalf("expected at least the file node, got none")
+			}
+			names := map[string]bool{}
+			for _, n := range res.Nodes {
+				names[n.Name] = true
+			}
+			if !names["Builder"] {
+				t.Errorf("expected a Builder type node; got names %v", names)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #54 — gortex index panics on Java files using a nested generic builder pattern — and closes the broader gap behind it: Java being a second-class language for crash safety and for the graph analyzers.