### PR TITLE
Fix dead_code false positive on type-asserted interfaces + combo reranker bugs

### DIFF
--- a/internal/mcp/combo.go
+++ b/internal/mcp/combo.go
@@ -93,6 +93,7 @@ func (cm *comboManager) maxAgeSec() int64 {
 // just for GC.
 func (cm *comboManager) reapStaleLocked() {
 	cutoff := cm.now() - cm.maxAgeSec()
+	queries := cm.store.Queries[:0]
 	for qi := range cm.store.Queries {
 		q := &cm.store.Queries[qi]
 		fresh := q.Matches[:0]
@@ -102,10 +103,18 @@ func (cm *comboManager) reapStaleLocked() {
 			}
 		}
 		q.Matches = fresh
+		// Drop a query once its last match expires. Without this the
+		// emptied shell lingers forever: it bloats findQueryLocked's
+		// linear scan and makes HasData report data that no longer exists.
+		if len(fresh) > 0 {
+			queries = append(queries, *q)
+		}
 	}
+	cm.store.Queries = queries
 	// The per-keyword index decays on the same clock as the
 	// whole-query index -- a keyword association no agent has
 	// reinforced inside the mode's window is stale noise.
+	keywords := cm.kwStore.Keywords[:0]
 	for ki := range cm.kwStore.Keywords {
 		k := &cm.kwStore.Keywords[ki]
 		fresh := k.Matches[:0]
@@ -115,7 +124,11 @@ func (cm *comboManager) reapStaleLocked() {
 			}
 		}
 		k.Matches = fresh
+		if len(fresh) > 0 {
+			keywords = append(keywords, *k)
+		}
 	}
+	cm.kwStore.Keywords = keywords
 }
 
 // normalizeQuery collapses whitespace and lowercases. Matches FFF's
@@ -328,6 +341,20 @@ func (cm *comboManager) moveToEndLocked(idx int) {
 	cm.store.Queries[len(cm.store.Queries)-1] = q
 }
 
+// moveKeywordToEndLocked rotates kwStore.Keywords so the entry at idx
+// lives at the tail, mirroring moveToEndLocked for the whole-query store.
+// SaveKeyword front-trims on overflow, so without this an early-inserted
+// but frequently-reinforced keyword would be evicted before a cold
+// late-inserted one. Caller must hold cm.mu.
+func (cm *comboManager) moveKeywordToEndLocked(idx int) {
+	if idx < 0 || idx >= len(cm.kwStore.Keywords)-1 {
+		return
+	}
+	k := cm.kwStore.Keywords[idx]
+	copy(cm.kwStore.Keywords[idx:], cm.kwStore.Keywords[idx+1:])
+	cm.kwStore.Keywords[len(cm.kwStore.Keywords)-1] = k
+}
+
 // HasData reports whether any queries have been recorded. Used by the
 // feedback tool to decide whether to surface combo stats.
 func (cm *comboManager) HasData() bool {
@@ -336,6 +363,9 @@ func (cm *comboManager) HasData() bool {
 	}
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
+	// Reap first so a store holding only expired (soon-to-be-pruned)
+	// entries doesn't report itself as having data.
+	cm.reapStaleLocked()
 	return len(cm.store.Queries) > 0
 }
 
@@ -423,6 +453,9 @@ func (cm *comboManager) recordKeywordsLocked(rawQuery, symbolID string, now int6
 		if cap := persistence.MaxKeywordEntries(); len(ka.Matches) > cap {
 			ka.Matches = ka.Matches[:cap]
 		}
+		// An existing keyword was re-touched: rotate it to the tail so
+		// SaveKeyword's front-trim evicts least-recently-used keywords.
+		cm.moveKeywordToEndLocked(idx)
 	}
 }
 
@@ -443,6 +476,7 @@ func (cm *comboManager) recordKeywordMissLocked(kw, symbolID string, now int64) 
 		if ka.Matches[i].SymbolID == symbolID {
 			ka.Matches[i].MissCount++
 			ka.Matches[i].LastUsed = now
+			cm.moveKeywordToEndLocked(idx)
 			return
 		}
 	}
@@ -455,6 +489,7 @@ func (cm *comboManager) recordKeywordMissLocked(kw, symbolID string, now int64) 
 		})
 		ka.Matches = ka.Matches[:cap]
 	}
+	cm.moveKeywordToEndLocked(idx)
 }
 
 // findKeywordLocked returns the index of kw in kwStore.Keywords, or
@@ -527,9 +562,14 @@ func (cm *comboManager) KeywordBoostMap(rawQuery string) map[string]float64 {
 	out := make(map[string]float64, len(per))
 	for sym, a := range per {
 		coverage := float64(a.matched) / n
-		// Each hit above the gate adds keywordBoostPerHit, scaled by
-		// the fraction of query keywords the symbol covered.
-		extra := float64(a.hits-keywordMinHits+1) * keywordBoostPerHit * coverage
+		// Each hit above the gate adds keywordBoostPerHit, scaled by the
+		// fraction of query keywords the symbol covered. Use the AVERAGE
+		// per-keyword strength, not the summed hits: a.hits already grows
+		// with the number of matched keywords, so multiplying the sum by
+		// coverage (which also grows with that count) would make the boost
+		// super-linear in coverage instead of the documented ~K/N.
+		avgHits := float64(a.hits) / float64(a.matched)
+		extra := (avgHits - keywordMinHits + 1) * keywordBoostPerHit * coverage
 		if extra < 0 {
 			extra = 0
 		}

--- a/internal/mcp/combo_test.go
+++ b/internal/mcp/combo_test.go
@@ -114,3 +114,24 @@ func TestComboManager_NilSafe(t *testing.T) {
 	assert.Nil(t, cm.BoostMap("x"))
 	assert.False(t, cm.HasData())
 }
+
+// TestComboManager_ReapPrunesEmptyShells confirms that once every match
+// for a query/keyword expires, the emptied outer entry is removed (not
+// left as a zero-match shell) and HasData reflects that.
+func TestComboManager_ReapPrunesEmptyShells(t *testing.T) {
+	now := int64(1_000_000_000)
+	cm := &comboManager{mode: ModeAI, now: func() int64 { return now }}
+	for i := 0; i < comboMinHits; i++ {
+		cm.Record("auth token", "sym-a")
+	}
+	require.True(t, cm.HasData())
+	require.Len(t, cm.store.Queries, 1)
+	require.NotEmpty(t, cm.kwStore.Keywords)
+
+	// Jump past the AI max-age window so every match is stale.
+	now += comboMaxAgeAISec + 1
+	// HasData reaps first, so it must both prune the shells and report false.
+	assert.False(t, cm.HasData(), "a store holding only expired matches must report no data")
+	assert.Empty(t, cm.store.Queries, "emptied query shells must be pruned, not retained")
+	assert.Empty(t, cm.kwStore.Keywords, "emptied keyword shells must be pruned, not retained")
+}

--- a/internal/mcp/keyword_combo_test.go
+++ b/internal/mcp/keyword_combo_test.go
@@ -75,6 +75,29 @@ func TestKeywordBoost_CoverageScaling(t *testing.T) {
 		"a symbol covering more query keywords should out-boost one covering fewer")
 }
 
+// TestKeywordBoost_CoverageIsLinear pins the boost above 1.0 to scale
+// linearly with coverage when per-keyword strength is equal: a symbol
+// matching 1 of 3 keywords earns ~1/3 of the full-coverage boost. Guards
+// against the super-linear (coverage-times-summed-hits) regression.
+func TestKeywordBoost_CoverageIsLinear(t *testing.T) {
+	cm := &comboManager{now: func() int64 { return 1 }}
+	// Equal per-keyword strength: sym-full under all 3 keywords, sym-partial
+	// under 1, each recorded the same number of times.
+	for i := 0; i < 4; i++ {
+		cm.Record("parse encode validate", "sym-full")
+		cm.Record("validate", "sym-partial")
+	}
+	kw := cm.KeywordBoostMap("parse encode validate")
+	require.NotNil(t, kw)
+	full := kw["sym-full"] - 1.0
+	partial := kw["sym-partial"] - 1.0
+	require.Greater(t, full, 0.0)
+	require.Greater(t, partial, 0.0)
+	// 3 keywords ⇒ full coverage boost is ~3× the 1-of-3 boost.
+	assert.InDelta(t, 3.0, full/partial, 0.05,
+		"partial-coverage boost should be ~1/N of full coverage (linear, not super-linear)")
+}
+
 // TestKeywordBoost_ExactQueryDominates confirms the exact whole-query
 // combo boost out-ranks a keyword-only boost when both fire -- the
 // keyword boost is capped below comboMaxBoost.

--- a/internal/parser/languages/golang.go
+++ b/internal/parser/languages/golang.go
@@ -87,6 +87,17 @@ const qGoAll = `
   (parameter_declaration
     type: (type_identifier) @ptype.name) @ptype.decl
 
+  ; Type assertions: x.(T) / x.(pkg.T). The asserted type is a
+  ; reference to T. Without this an interface used only via a type
+  ; assertion has no incoming edge and looks like dead code.
+  (type_assertion_expression
+    type: (type_identifier) @assert.name) @assert.decl
+
+  (type_assertion_expression
+    type: (qualified_type
+      package: (package_identifier) @assertq.pkg
+      name: (type_identifier) @assertq.name)) @assertq.decl
+
   (argument_list
     (selector_expression
       operand: (_) @selarg.receiver
@@ -460,6 +471,23 @@ func (e *GoExtractor) Extract(filePath string, src []byte) (*parser.ExtractionRe
 			decl := m.Captures["ptype.decl"]
 			typeRefs = append(typeRefs, goDeferredTypeRef{
 				typeName: m.Captures["ptype.name"].Text,
+				line:     decl.StartLine + 1,
+				kind:     graph.EdgeReferences,
+			})
+
+		case m.Captures["assert.decl"] != nil:
+			decl := m.Captures["assert.decl"]
+			typeRefs = append(typeRefs, goDeferredTypeRef{
+				typeName: m.Captures["assert.name"].Text,
+				line:     decl.StartLine + 1,
+				kind:     graph.EdgeReferences,
+			})
+
+		case m.Captures["assertq.decl"] != nil:
+			decl := m.Captures["assertq.decl"]
+			typeRefs = append(typeRefs, goDeferredTypeRef{
+				typeName: m.Captures["assertq.name"].Text,
+				pkg:      m.Captures["assertq.pkg"].Text,
 				line:     decl.StartLine + 1,
 				kind:     graph.EdgeReferences,
 			})

--- a/internal/parser/languages/golang_test.go
+++ b/internal/parser/languages/golang_test.go
@@ -1093,3 +1093,31 @@ func (s *Server) Process() {
 		assert.Equal(t, "Inner", c.Meta["receiver_type"])
 	}
 }
+
+func TestGoExtractor_TypeAssertionReferences(t *testing.T) {
+	src := []byte(`package main
+
+type Doer interface{ Do() }
+
+func run(x any) {
+	if d, ok := x.(Doer); ok {
+		d.Do()
+	}
+	_ = x.(other.Fooer)
+}
+`)
+	e := NewGoExtractor()
+	result, err := e.Extract("main.go", src)
+	require.NoError(t, err)
+
+	var targets []string
+	for _, r := range edgesOfKind(result.Edges, graph.EdgeReferences) {
+		targets = append(targets, r.To)
+	}
+	// Local type assertion x.(Doer) must reference the asserted type, so an
+	// interface used only via an assertion is not seen as dead code.
+	assert.Contains(t, targets, "unresolved::Doer")
+	// Qualified assertion x.(other.Fooer): the package qualifier is dropped
+	// and the type is resolved by bare name like every other type reference.
+	assert.Contains(t, targets, "unresolved::Fooer")
+}


### PR DESCRIPTION
## Summary

Two independent fixes that came out of investigating why the dead-code analyzer was flagging a live interface (graph.KCorer) and the comboManager methods:

1. Resolver — the Go extractor now emits a reference edge for the target type of a type assertion, so an interface used only via x.(T) is no longer seen as unused.
2. combo.go reranker — three real logic bugs in the search-result combo/keyword booster, found while auditing the flagged code.

No public API or behavior changes outside the reranker's scoring/GC.