### PR TITLE
Eleven code-intelligence features: call-path tracing, route impact, framework resolution, incremental scoping

### DIFF
--- a/cmd/gortex/trace.go
+++ b/cmd/gortex/trace.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	traceIndex             string
+	traceDepth             int
+	traceK                 int
+	traceMaxFrontier       int
+	traceMinTier           string
+	traceIncludeReferences bool
+	traceFormat            string
+)
+
+var traceCmd = &cobra.Command{
+	Use:   "trace <from-id> <to-id>",
+	Short: "Trace the shortest call path between two symbols",
+	Long: `Trace the shortest call path from one symbol to another over the call graph
+(calls + cross-service matches + method-value references).
+
+When no path exists, trace prints a why-unreachable diagnosis: the functions
+reachable from the source, the functions that can reach the sink, and the
+dynamic-dispatch / external boundaries where the chain breaks — so you know
+whether the two are genuinely disconnected or merely separated by an
+unresolved interface the graph could not bind.`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		toolArgs := map[string]any{
+			"source_id":          args[0],
+			"sink_id":            args[1],
+			"max_depth":          traceDepth,
+			"k":                  traceK,
+			"max_frontier":       traceMaxFrontier,
+			"include_references": traceIncludeReferences,
+		}
+		if traceMinTier != "" {
+			toolArgs["min_tier"] = traceMinTier
+		}
+		out, err := requireDaemonTool(traceIndex, "trace_path", toolArgs)
+		if err != nil {
+			return err
+		}
+		return printDaemonTracePath(cmd, out)
+	},
+}
+
+func init() {
+	traceCmd.Flags().StringVar(&traceIndex, "index", ".", "repository path the daemon must track")
+	traceCmd.Flags().IntVar(&traceDepth, "depth", 24, "maximum combined search depth")
+	traceCmd.Flags().IntVar(&traceK, "k", 1, "number of distinct shortest paths to return")
+	traceCmd.Flags().IntVar(&traceMaxFrontier, "max-frontier", 25, "cap on frontier nodes in the gap report")
+	traceCmd.Flags().StringVar(&traceMinTier, "min-tier", "", "minimum per-edge provenance tier to traverse (lsp_resolved|ast_resolved|...)")
+	traceCmd.Flags().BoolVar(&traceIncludeReferences, "include-references", true, "traverse method-value wiring edges (mux.HandleFunc, command tables)")
+	traceCmd.Flags().StringVar(&traceFormat, "format", "text", "output format: text|json")
+	rootCmd.AddCommand(traceCmd)
+}
+
+type traceFrontierNode struct {
+	ID    string `json:"id"`
+	Depth int    `json:"depth"`
+}
+
+// printDaemonTracePath renders trace_path: the path as a hop list for the
+// found case, and the full why-unreachable diagnosis otherwise.
+func printDaemonTracePath(cmd *cobra.Command, raw json.RawMessage) error {
+	if traceFormat == "json" {
+		return emitDaemonJSON(cmd, raw)
+	}
+	var payload struct {
+		Found  bool   `json:"found"`
+		SrcID  string `json:"source_id"`
+		SinkID string `json:"sink_id"`
+		Paths  []struct {
+			Nodes      []string `json:"nodes"`
+			Length     int      `json:"length"`
+			Confidence float64  `json:"confidence"`
+			WorstTier  string   `json:"worst_tier"`
+			Edges      []struct {
+				To   string `json:"to"`
+				Kind string `json:"kind"`
+				Tier string `json:"tier"`
+			} `json:"edges"`
+		} `json:"paths"`
+		Gap *struct {
+			Reason             string              `json:"reason"`
+			Message            string              `json:"message"`
+			ForwardReached     int                 `json:"forward_reached"`
+			BackwardReached    int                 `json:"backward_reached"`
+			FurthestFromSource []traceFrontierNode `json:"furthest_from_source"`
+			NearestToSink      []traceFrontierNode `json:"nearest_to_sink"`
+			BoundaryHits       []struct {
+				From     string `json:"from"`
+				Target   string `json:"target"`
+				Reason   string `json:"reason"`
+				EdgeKind string `json:"edge_kind"`
+			} `json:"boundary_hits"`
+		} `json:"gap"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return emitDaemonJSON(cmd, raw)
+	}
+	out := cmd.OutOrStdout()
+	if payload.Found {
+		for i, p := range payload.Paths {
+			if len(payload.Paths) > 1 {
+				_, _ = fmt.Fprintf(out, "Path %d (length %d, confidence %.2f, %s):\n", i+1, p.Length, p.Confidence, p.WorstTier)
+			}
+			if len(p.Nodes) > 0 {
+				_, _ = fmt.Fprintf(out, "  %s\n", p.Nodes[0])
+				for _, e := range p.Edges {
+					_, _ = fmt.Fprintf(out, "    --%s(%s)--> %s\n", e.Kind, e.Tier, e.To)
+				}
+			}
+		}
+		return nil
+	}
+	if payload.Gap == nil {
+		_, _ = fmt.Fprintln(out, "no path found")
+		return nil
+	}
+	g := payload.Gap
+	_, _ = fmt.Fprintf(out, "No call path from %s to %s.\n", payload.SrcID, payload.SinkID)
+	_, _ = fmt.Fprintf(out, "Reason: %s\n", g.Reason)
+	if g.Message != "" {
+		_, _ = fmt.Fprintf(out, "  %s\n", g.Message)
+	}
+	_, _ = fmt.Fprintf(out, "Forward reach: %d   Backward reach: %d\n", g.ForwardReached, g.BackwardReached)
+	if len(g.FurthestFromSource) > 0 {
+		_, _ = fmt.Fprintln(out, "Furthest reachable from source:")
+		for _, n := range g.FurthestFromSource {
+			_, _ = fmt.Fprintf(out, "  %s (depth %d)\n", n.ID, n.Depth)
+		}
+	}
+	if len(g.NearestToSink) > 0 {
+		_, _ = fmt.Fprintln(out, "Nearest that reach the sink:")
+		for _, n := range g.NearestToSink {
+			_, _ = fmt.Fprintf(out, "  %s (depth %d)\n", n.ID, n.Depth)
+		}
+	}
+	if len(g.BoundaryHits) > 0 {
+		_, _ = fmt.Fprintln(out, "Boundaries where the chain breaks:")
+		for _, b := range g.BoundaryHits {
+			_, _ = fmt.Fprintf(out, "  %s -> %s [%s via %s]\n", b.From, b.Target, b.Reason, b.EdgeKind)
+		}
+	}
+	return nil
+}

--- a/internal/agents/instructions.go
+++ b/internal/agents/instructions.go
@@ -109,6 +109,7 @@ The ` + "`flow_between`" + ` and ` + "`taint_paths`" + ` MCP tools answer **"whe
 |---------------------------------------|------------------------------------------|
 | Tracing a value through helpers by hand | ` + "`flow_between(source_id, sink_id, max_depth=8)`" + ` — ranked dataflow paths between two symbols |
 | Grepping for sources / sinks         | ` + "`taint_paths(source_pattern, sink_pattern)`" + ` — pattern-driven sweep. Patterns: bare token = name substring; ` + "`exact:Foo`" + `; ` + "`path:dir/`" + `; ` + "`kind:method`" + `. Sinks auto-expand functions to their params. |
+| Asking "can A reach B?" over the call graph | ` + "`trace_path(source_id, sink_id)`" + ` — shortest A→B call path (bidirectional BFS); on no-path returns a why-unreachable diagnosis naming the dynamic-dispatch / external boundary where the chain breaks. CLI: ` + "`gortex trace <from> <to>`" + `. |
 
 ### Structural Code Search
 

--- a/internal/agents/instructions.go
+++ b/internal/agents/instructions.go
@@ -396,6 +396,7 @@ The ` + "`analyze`" + ` MCP tool is a unified dispatcher. Supported ` + "`kind`"
 |---------------------------------------|------------------------------------------|
 | Manually tracking API routes/services | ` + "`contracts`" + ` (default ` + "`action: \"list\"`" + `) — lists HTTP, gRPC, GraphQL, topic, WebSocket, env, OpenAPI; filter by ` + "`repo`" + `, ` + "`project`" + `, or ` + "`ref`" + ` |
 | Guessing if APIs match across repos   | ` + "`contracts`" + ` with ` + "`action: \"check\"`" + ` — detects orphan providers/consumers and mismatches; scope with ` + "`repo`" + ` / ` + "`project`" + ` / ` + "`ref`" + ` |
+| Assessing what breaks before editing a route handler | ` + "`api_impact(route|file)`" + ` — one fused report: response shape, consumers + accessed fields, response-shape mismatches, middleware, execution flows, blast radius (callers + tests to run), fused risk |
 
 ### CPG-lite Dataflow
 

--- a/internal/analysis/impact.go
+++ b/internal/analysis/impact.go
@@ -41,6 +41,14 @@ type ImpactResult struct {
 	TotalAffected       int                      `json:"total_affected"`
 	CrossRepoImpact     bool                     `json:"cross_repo_impact,omitempty"`
 	ByRepo              map[string][]ImpactEntry `json:"by_repo,omitempty"`
+	// LowerBound is set when the blast radius crosses a dynamic-dispatch /
+	// interface site the resolver could not bind: the true affected count is
+	// then a floor (">=TotalAffected, could be more"), not an exact number.
+	LowerBound bool `json:"lower_bound,omitempty"`
+	// Boundaries names the unresolved/dispatch sites that make the count a
+	// floor, so an agent can act on them (e.g. find_implementations on the
+	// interface). Omitted when empty.
+	Boundaries []graph.EpistemicBoundary `json:"boundaries,omitempty"`
 }
 
 // AnalyzeImpact performs depth-tiered blast radius analysis on a set of symbols.
@@ -139,11 +147,23 @@ func AnalyzeImpact(g graph.Store, symbolIDs []string, communities *CommunityResu
 		sort.Strings(result.AffectedCommunities)
 	}
 
+	// Epistemic lower bound: blast radius is a count of *callers*, so a seed
+	// that implements/overrides an interface may be reached through dynamic
+	// dispatch the resolver could not attribute — the count is then a floor.
+	result.Boundaries = graph.CallerBoundaries(g, symbolIDs, 0)
+	result.LowerBound = graph.LowerBoundCaveat(result.Boundaries)
+
 	// Summary
 	result.Summary = fmt.Sprintf(
 		"%d direct dependents, %d transitively affected, %d test files, risk: %s",
 		d1, result.TotalAffected, len(result.TestFiles), result.Risk,
 	)
+	if result.LowerBound {
+		result.Summary += fmt.Sprintf(
+			" — lower bound: %d dispatch boundary(ies) may add more callers",
+			len(result.Boundaries),
+		)
+	}
 
 	// Group affected symbols by RepoPrefix and detect cross-repo impact.
 	repoSet := make(map[string]bool)

--- a/internal/analysis/impact_boundary_test.go
+++ b/internal/analysis/impact_boundary_test.go
@@ -1,0 +1,39 @@
+package analysis
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// TestAnalyzeImpact_LowerBound_InterfaceDispatch: a changed method that
+// implements an interface has callers that may dispatch through the interface,
+// so its blast radius is a floor, not an exact count.
+func TestAnalyzeImpact_LowerBound_InterfaceDispatch(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "pkg.T.M", Kind: graph.KindMethod, Name: "M"})
+	g.AddNode(&graph.Node{ID: "pkg.caller", Kind: graph.KindFunction, Name: "caller"})
+	g.AddEdge(&graph.Edge{From: "pkg.caller", To: "pkg.T.M", Kind: graph.EdgeCalls, Origin: graph.OriginASTResolved})
+	g.AddEdge(&graph.Edge{From: "pkg.T.M", To: "iface::I.M", Kind: graph.EdgeImplements, Origin: graph.OriginASTResolved})
+
+	res := AnalyzeImpact(g, []string{"pkg.T.M"}, nil, nil)
+	if !res.LowerBound {
+		t.Fatalf("expected LowerBound=true, got summary=%q boundaries=%+v", res.Summary, res.Boundaries)
+	}
+	if len(res.Boundaries) != 1 || res.Boundaries[0].Reason != graph.BoundaryInterfaceDispatch {
+		t.Errorf("expected one interface_dispatch boundary, got %+v", res.Boundaries)
+	}
+}
+
+// TestAnalyzeImpact_NoBoundary: a plain function with no dispatch participation
+// reports an exact count (no lower-bound flag).
+func TestAnalyzeImpact_NoBoundary(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "pkg.f", Kind: graph.KindFunction, Name: "f"})
+	g.AddNode(&graph.Node{ID: "pkg.g", Kind: graph.KindFunction, Name: "g"})
+	g.AddEdge(&graph.Edge{From: "pkg.g", To: "pkg.f", Kind: graph.EdgeCalls, Origin: graph.OriginASTResolved})
+	res := AnalyzeImpact(g, []string{"pkg.f"}, nil, nil)
+	if res.LowerBound || len(res.Boundaries) != 0 {
+		t.Errorf("expected no lower bound, got LowerBound=%v boundaries=%+v", res.LowerBound, res.Boundaries)
+	}
+}

--- a/internal/callpath/callpath.go
+++ b/internal/callpath/callpath.go
@@ -1,0 +1,647 @@
+// Package callpath answers targeted A→B reachability questions over the
+// CALLS-class call graph. It is the sibling of internal/dataflow (which walks
+// the dataflow edges value_flow/arg_of/returns_to) and of query.Engine's
+// single-source call BFS (get_call_chain): callpath traces a *targeted*
+// shortest path from one symbol to another and, when no path exists, reports a
+// structured why-unreachable diagnosis naming the dynamic-dispatch / external
+// boundary where the chain dies.
+//
+// The engine uses balanced bidirectional BFS: it alternately expands the
+// smaller of the two frontiers (one growing forward from the source over OUT
+// edges, one growing backward from the sink over IN edges) so it touches
+// O(b^(d/2)) nodes instead of O(b^d). BFS on the unweighted call graph yields a
+// genuinely shortest path; the level-synchronised meeting test keeps that
+// guarantee while collecting every equal-length route for the K-shortest case.
+package callpath
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Bounds for the bidirectional search. These mirror the spirit of
+// dataflow.DefaultMaxDepth/DefaultMaxPaths: the call-graph diameter is small,
+// so the depth cap is a safety valve rather than a tuning knob.
+const (
+	DefaultMaxDepth    = 24
+	DefaultMaxNodes    = 50000
+	DefaultMaxFrontier = 25
+	DefaultK           = 1
+
+	// maxBoundaryHits caps the boundary-hit list so a hub source that calls
+	// hundreds of unresolved targets cannot bloat the gap report.
+	maxBoundaryHits = 64
+)
+
+// callEdgeKinds is the CALLS-class edge set the engine traces, mirroring
+// get_callers/get_call_chain so the answer matches what agents already
+// understand: EdgeCalls (direct invocation), EdgeMatches (cross-service
+// producer/consumer bridge — lets a path cross repo/service boundaries) and
+// EdgeReferences (method-value wiring: mux.HandleFunc, command tables, defer
+// x.Cleanup — without it routing codebases look disconnected).
+var callEdgeKinds = []graph.EdgeKind{graph.EdgeCalls, graph.EdgeMatches, graph.EdgeReferences}
+
+// ReachReason classifies, for an unreachable pair, *why* the call graph fails
+// to connect source→sink. It mirrors the structured-reason pattern of
+// graph.ClassifyZeroEdge.
+type ReachReason string
+
+const (
+	ReasonSrcNotFound      ReachReason = "src_not_found"
+	ReasonSinkNotFound     ReachReason = "sink_not_found"
+	ReasonSrcNoOut         ReachReason = "src_no_out_edges"
+	ReasonSinkNoIn         ReachReason = "sink_no_in_edges"
+	ReasonDynamicDispatch  ReachReason = "crosses_dynamic_dispatch"
+	ReasonExternalBoundary ReachReason = "crosses_external_boundary"
+	ReasonDepthExceeded    ReachReason = "depth_exceeded"
+	ReasonDisconnected     ReachReason = "disconnected"
+)
+
+// Options tunes a ShortestPath query. The zero value is valid: empty fields
+// fall back to the package defaults / the full CALLS-class edge set.
+type Options struct {
+	// EdgeKinds overrides the traced edge set. Empty uses callEdgeKinds.
+	EdgeKinds []graph.EdgeKind
+	// IncludeReferences, when false, drops EdgeReferences from the default
+	// edge set for a pure direct-call path. Ignored when EdgeKinds is set.
+	IncludeReferences bool
+	MaxDepth          int
+	MaxNodes          int
+	// K is the number of distinct shortest-length paths to return (default 1).
+	K           int
+	MaxFrontier int
+	// MinTier prunes edges whose Origin tier is below the threshold during
+	// traversal (same semantics as flow_between's min_tier).
+	MinTier string
+	// WorkspaceID, when set, confines traversal to nodes in the same
+	// workspace, so cross-workspace noise does not leak into the gap report.
+	WorkspaceID string
+}
+
+// PathEdge is one hop on a returned path, carrying provenance so the agent
+// sees whether the hop was compiler-verified (lsp), tree-sitter resolved (ast)
+// or heuristic.
+type PathEdge struct {
+	From   string `json:"from"`
+	To     string `json:"to"`
+	Kind   string `json:"kind"`
+	Origin string `json:"origin,omitempty"`
+	Tier   string `json:"tier,omitempty"`
+}
+
+// Path is one source→sink route. Length is the hop count (edges); a 0-length
+// path means source == sink.
+type Path struct {
+	Nodes      []string   `json:"nodes"`
+	Edges      []PathEdge `json:"edges,omitempty"`
+	Length     int        `json:"length"`
+	Confidence float64    `json:"confidence"`
+	WorstTier  string     `json:"worst_tier,omitempty"`
+}
+
+// FrontierNode is one node on a search frontier, tagged with its BFS depth.
+type FrontierNode struct {
+	ID    string `json:"id"`
+	Depth int    `json:"depth"`
+}
+
+// BoundaryHit records a neighbour the forward search refused to traverse
+// because it was an unresolved/dynamic-dispatch target or an external/stub
+// boundary — precisely the sites that make the call graph un-connectable.
+type BoundaryHit struct {
+	From     string `json:"from"`
+	Target   string `json:"target"`
+	Reason   string `json:"reason"`
+	EdgeKind string `json:"edge_kind"`
+}
+
+// Gap is the why-unreachable diagnosis returned when no path exists.
+type Gap struct {
+	Reason             ReachReason    `json:"reason"`
+	Message            string         `json:"message"`
+	FurthestFromSource []FrontierNode `json:"furthest_from_source,omitempty"`
+	NearestToSink      []FrontierNode `json:"nearest_to_sink,omitempty"`
+	BoundaryHits       []BoundaryHit  `json:"boundary_hits,omitempty"`
+	ForwardReached     int            `json:"forward_reached"`
+	BackwardReached    int            `json:"backward_reached"`
+}
+
+// Result is the engine's answer. Exactly one of Paths / Gap is populated.
+type Result struct {
+	Found     bool   `json:"found"`
+	SrcID     string `json:"source_id"`
+	SinkID    string `json:"sink_id"`
+	Paths     []Path `json:"paths,omitempty"`
+	Gap       *Gap   `json:"gap,omitempty"`
+	Truncated bool   `json:"truncated,omitempty"`
+}
+
+// Engine is the call-path query backend. It holds a reference to the graph and
+// is concurrency-safe by relying only on graph.Store's read methods.
+type Engine struct {
+	g graph.Store
+}
+
+// New returns an engine backed by the given graph.
+func New(g graph.Store) *Engine { return &Engine{g: g} }
+
+// ShortestPath returns the shortest A→B path over the CALLS-class call graph
+// (and up to opts.K equal-length alternates), or a structured Gap diagnosing
+// why none exists.
+func (e *Engine) ShortestPath(src, sink string, opts Options) Result {
+	res := Result{SrcID: src, SinkID: sink}
+	if e == nil || e.g == nil || src == "" {
+		res.Gap = &Gap{Reason: ReasonSrcNotFound, Message: "source id is empty"}
+		return res
+	}
+	if sink == "" {
+		res.Gap = &Gap{Reason: ReasonSinkNotFound, Message: "sink id is empty"}
+		return res
+	}
+
+	maxDepth := orDefault(opts.MaxDepth, DefaultMaxDepth)
+	maxNodes := orDefault(opts.MaxNodes, DefaultMaxNodes)
+	k := orDefault(opts.K, DefaultK)
+	maxFrontier := orDefault(opts.MaxFrontier, DefaultMaxFrontier)
+	kindSet := e.kindSet(opts)
+
+	if e.g.GetNode(src) == nil {
+		res.Gap = &Gap{Reason: ReasonSrcNotFound, Message: fmt.Sprintf("%s is not in the graph", src)}
+		return res
+	}
+	if e.g.GetNode(sink) == nil {
+		res.Gap = &Gap{Reason: ReasonSinkNotFound, Message: fmt.Sprintf("%s is not in the graph", sink)}
+		return res
+	}
+	if src == sink {
+		res.Found = true
+		res.Paths = []Path{{Nodes: []string{src}, Length: 0, Confidence: 1}}
+		return res
+	}
+
+	// Pre-checks that make a path impossible regardless of search effort.
+	if !e.hasEdge(src, true, kindSet) {
+		res.Gap = e.simpleGap(ReasonSrcNoOut,
+			fmt.Sprintf("%s makes no calls — it is a leaf of the call graph, so nothing is reachable from it", src))
+		return res
+	}
+	if !e.hasEdge(sink, false, kindSet) {
+		res.Gap = e.simpleGap(ReasonSinkNoIn,
+			fmt.Sprintf("nothing calls %s — it has no incoming call edges, so it is unreachable from any source", sink))
+		return res
+	}
+
+	st := &search{
+		eng:         e,
+		opts:        opts,
+		kindSet:     kindSet,
+		maxNodes:    maxNodes,
+		fwdParent:   map[string]*graph.Edge{src: nil},
+		bwdChild:    map[string]*graph.Edge{sink: nil},
+		fwdDepth:    map[string]int{src: 0},
+		bwdDepth:    map[string]int{sink: 0},
+		boundarySee: map[string]bool{},
+	}
+	st.fwdFrontier = []string{src}
+	st.bwdFrontier = []string{sink}
+	st.lastFwd = st.fwdFrontier
+	st.lastBwd = st.bwdFrontier
+
+	fLevel, bLevel := 0, 0
+	depthExceeded := false
+	for len(st.fwdFrontier) > 0 && len(st.bwdFrontier) > 0 {
+		if fLevel+bLevel >= maxDepth {
+			depthExceeded = true
+			break
+		}
+		if len(st.fwdParent)+len(st.bwdChild) >= maxNodes {
+			st.truncated = true
+			break
+		}
+
+		var meetings []string
+		if len(st.fwdFrontier) <= len(st.bwdFrontier) {
+			st.fwdFrontier, meetings = st.expandForward(fLevel)
+			fLevel++
+			if len(st.fwdFrontier) > 0 {
+				st.lastFwd = st.fwdFrontier
+			}
+		} else {
+			st.bwdFrontier, meetings = st.expandBackward(bLevel)
+			bLevel++
+			if len(st.bwdFrontier) > 0 {
+				st.lastBwd = st.bwdFrontier
+			}
+		}
+
+		if len(meetings) > 0 {
+			paths := st.buildPaths(src, meetings, k)
+			if len(paths) > 0 {
+				res.Found = true
+				res.Paths = paths
+				res.Truncated = st.truncated
+				return res
+			}
+		}
+	}
+
+	// No meeting: the pair is unreachable. The balanced search stops as soon
+	// as either frontier empties, which can leave the *other* side barely
+	// explored — so the gap report would carry a one-sided picture. Complete
+	// both reach cones (bounded by depth/node caps) purely to populate a
+	// symmetric "A reaches … / … reaches B" diagnosis. This cannot surface a
+	// missed path: forward and backward apply identical boundary/tier/scope
+	// pruning, so any node reachable both ways would already have met.
+	if !depthExceeded && !st.truncated {
+		for len(st.fwdFrontier) > 0 && fLevel < maxDepth && len(st.fwdParent)+len(st.bwdChild) < maxNodes {
+			st.fwdFrontier, _ = st.expandForward(fLevel)
+			fLevel++
+			if len(st.fwdFrontier) > 0 {
+				st.lastFwd = st.fwdFrontier
+			}
+		}
+		for len(st.bwdFrontier) > 0 && bLevel < maxDepth && len(st.fwdParent)+len(st.bwdChild) < maxNodes {
+			st.bwdFrontier, _ = st.expandBackward(bLevel)
+			bLevel++
+			if len(st.bwdFrontier) > 0 {
+				st.lastBwd = st.bwdFrontier
+			}
+		}
+	}
+
+	res.Gap = st.buildGap(maxFrontier, depthExceeded)
+	res.Truncated = st.truncated
+	return res
+}
+
+// search holds the mutable state of one bidirectional sweep.
+type search struct {
+	eng      *Engine
+	opts     Options
+	kindSet  map[graph.EdgeKind]bool
+	maxNodes int
+
+	fwdParent map[string]*graph.Edge // node → edge that discovered it forward (edge.To == node)
+	bwdChild  map[string]*graph.Edge // node → edge toward the sink (edge.From == node)
+	fwdDepth  map[string]int
+	bwdDepth  map[string]int
+
+	fwdFrontier []string
+	bwdFrontier []string
+	lastFwd     []string
+	lastBwd     []string
+
+	boundary    []BoundaryHit
+	boundarySee map[string]bool
+	truncated   bool
+}
+
+func (s *search) expandForward(level int) (next []string, meetings []string) {
+	for _, u := range s.fwdFrontier {
+		for _, ed := range s.eng.g.GetOutEdges(u) {
+			if !s.kindSet[ed.Kind] {
+				continue
+			}
+			v := ed.To
+			if _, seen := s.fwdParent[v]; seen {
+				continue
+			}
+			if reason, isB := classifyBoundary(v); isB {
+				s.addBoundary(u, v, reason, string(ed.Kind))
+				continue
+			}
+			if !s.tierOK(ed) || !s.eng.scopeOK(v, s.opts) {
+				continue
+			}
+			s.fwdParent[v] = ed
+			s.fwdDepth[v] = level + 1
+			next = append(next, v)
+			if _, ok := s.bwdChild[v]; ok {
+				meetings = append(meetings, v)
+			}
+		}
+	}
+	return next, meetings
+}
+
+func (s *search) expandBackward(level int) (next []string, meetings []string) {
+	for _, u := range s.bwdFrontier {
+		for _, ed := range s.eng.g.GetInEdges(u) {
+			if !s.kindSet[ed.Kind] {
+				continue
+			}
+			w := ed.From
+			if _, seen := s.bwdChild[w]; seen {
+				continue
+			}
+			// A boundary node is never a real caller; skip without recording
+			// (boundary hits are a forward-search concept — they name the
+			// dynamic-dispatch sites the source's reach terminates at).
+			if _, isB := classifyBoundary(w); isB {
+				continue
+			}
+			if !s.tierOK(ed) || !s.eng.scopeOK(w, s.opts) {
+				continue
+			}
+			s.bwdChild[w] = ed
+			s.bwdDepth[w] = level + 1
+			next = append(next, w)
+			if _, ok := s.fwdParent[w]; ok {
+				meetings = append(meetings, w)
+			}
+		}
+	}
+	return next, meetings
+}
+
+func (s *search) tierOK(ed *graph.Edge) bool {
+	if s.opts.MinTier == "" {
+		return true
+	}
+	return graph.MeetsMinTier(edgeOriginOf(ed), s.opts.MinTier)
+}
+
+func (s *search) addBoundary(from, target, reason, edgeKind string) {
+	if s.boundarySee[target] || len(s.boundary) >= maxBoundaryHits {
+		return
+	}
+	s.boundarySee[target] = true
+	s.boundary = append(s.boundary, BoundaryHit{From: from, Target: target, Reason: reason, EdgeKind: edgeKind})
+}
+
+// buildPaths reconstructs distinct shortest-length paths through the supplied
+// meeting nodes. Among the meetings discovered in the meeting level it keeps
+// only those whose total length equals the minimum, then dedupes by node
+// sequence, ranks by (length asc, confidence desc) and returns up to k.
+func (s *search) buildPaths(src string, meetings []string, k int) []Path {
+	type cand struct {
+		total int
+		node  string
+	}
+	cands := make([]cand, 0, len(meetings))
+	minTotal := 1 << 30
+	for _, m := range meetings {
+		t := s.fwdDepth[m] + s.bwdDepth[m]
+		cands = append(cands, cand{total: t, node: m})
+		if t < minTotal {
+			minTotal = t
+		}
+	}
+	seen := map[string]bool{}
+	var paths []Path
+	for _, c := range cands {
+		if c.total != minTotal {
+			continue
+		}
+		p := s.reconstruct(src, c.node)
+		key := strings.Join(p.Nodes, ">")
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		paths = append(paths, p)
+	}
+	sort.SliceStable(paths, func(i, j int) bool {
+		if paths[i].Length != paths[j].Length {
+			return paths[i].Length < paths[j].Length
+		}
+		return paths[i].Confidence > paths[j].Confidence
+	})
+	if k > 0 && len(paths) > k {
+		paths = paths[:k]
+	}
+	return paths
+}
+
+// reconstruct splices the forward chain (src→meet) and the backward chain
+// (meet→sink) into one path.
+func (s *search) reconstruct(src, meet string) Path {
+	var fwd []*graph.Edge
+	for cur := meet; ; {
+		ed := s.fwdParent[cur]
+		if ed == nil {
+			break
+		}
+		fwd = append(fwd, ed)
+		cur = ed.From
+	}
+	// fwd is meet→…→src; reverse to src→…→meet.
+	for i, j := 0, len(fwd)-1; i < j; i, j = i+1, j-1 {
+		fwd[i], fwd[j] = fwd[j], fwd[i]
+	}
+	var bwd []*graph.Edge
+	for cur := meet; ; {
+		ed := s.bwdChild[cur]
+		if ed == nil {
+			break
+		}
+		bwd = append(bwd, ed)
+		cur = ed.To
+	}
+	all := append(fwd, bwd...)
+
+	nodes := make([]string, 0, len(all)+1)
+	nodes = append(nodes, src)
+	edges := make([]PathEdge, 0, len(all))
+	score := 1.0
+	worst := ""
+	for _, ed := range all {
+		nodes = append(nodes, ed.To)
+		origin := edgeOriginOf(ed)
+		tier := graph.ResolvedBy(origin)
+		edges = append(edges, PathEdge{From: ed.From, To: ed.To, Kind: string(ed.Kind), Origin: origin, Tier: tier})
+		score *= graph.EdgeTierScore(origin, ed.Kind)
+		worst = mergeWorstTier(worst, tier)
+	}
+	return Path{Nodes: nodes, Edges: edges, Length: len(all), Confidence: score, WorstTier: worst}
+}
+
+func (s *search) buildGap(maxFrontier int, depthExceeded bool) *Gap {
+	g := &Gap{
+		FurthestFromSource: s.frontierNodes(s.lastFwd, s.fwdDepth, maxFrontier),
+		NearestToSink:      s.frontierNodes(s.lastBwd, s.bwdDepth, maxFrontier),
+		BoundaryHits:       s.boundary,
+		ForwardReached:     len(s.fwdParent) - 1,
+		BackwardReached:    len(s.bwdChild) - 1,
+	}
+	hasDyn, hasExt := false, false
+	var dynNames []string
+	for _, b := range s.boundary {
+		if b.Reason == boundaryDynamicDispatch {
+			hasDyn = true
+			if len(dynNames) < 3 {
+				dynNames = append(dynNames, graph.UnresolvedName(b.Target))
+			}
+		} else {
+			hasExt = true
+		}
+	}
+	switch {
+	case depthExceeded:
+		g.Reason = ReasonDepthExceeded
+		g.Message = fmt.Sprintf("the search hit the depth bound before the forward reach (%d) and backward reach (%d) met — raise --depth or narrow the endpoints",
+			g.ForwardReached, g.BackwardReached)
+	case hasDyn:
+		g.Reason = ReasonDynamicDispatch
+		g.Message = fmt.Sprintf("%s reaches %d functions and %s is reachable from %d, but the forward reach terminates at %d dynamic-dispatch call site(s) (e.g. %s) that the resolver never bound — try find_implementations on the interface, or rerun with a lower min_tier",
+			s.srcLabel(), g.ForwardReached, s.sinkLabel(), g.BackwardReached, len(dynNames), strings.Join(dynNames, ", "))
+	case hasExt:
+		g.Reason = ReasonExternalBoundary
+		g.Message = fmt.Sprintf("%s reaches %d functions and %s is reachable from %d, but the chain leaves the indexed code at an external/stdlib boundary — the call graph cannot connect them through resolved code",
+			s.srcLabel(), g.ForwardReached, s.sinkLabel(), g.BackwardReached)
+	default:
+		g.Reason = ReasonDisconnected
+		g.Message = fmt.Sprintf("%s reaches %d functions and %s is reachable from %d, but the two reachable sets are disjoint — no call path connects them",
+			s.srcLabel(), g.ForwardReached, s.sinkLabel(), g.BackwardReached)
+	}
+	return g
+}
+
+func (s *search) srcLabel() string  { return shortLabel(s.fwdRoot()) }
+func (s *search) sinkLabel() string { return shortLabel(s.bwdRoot()) }
+
+func (s *search) fwdRoot() string {
+	for id, e := range s.fwdParent {
+		if e == nil {
+			return id
+		}
+	}
+	return ""
+}
+func (s *search) bwdRoot() string {
+	for id, e := range s.bwdChild {
+		if e == nil {
+			return id
+		}
+	}
+	return ""
+}
+
+func (s *search) frontierNodes(ids []string, depth map[string]int, max int) []FrontierNode {
+	if len(ids) == 0 {
+		return nil
+	}
+	out := make([]FrontierNode, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, FrontierNode{ID: id, Depth: depth[id]})
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	if max > 0 && len(out) > max {
+		out = out[:max]
+	}
+	return out
+}
+
+// simpleGap builds a one-line gap for the trivial impossible cases.
+func (e *Engine) simpleGap(reason ReachReason, msg string) *Gap {
+	return &Gap{Reason: reason, Message: msg}
+}
+
+func (e *Engine) kindSet(opts Options) map[graph.EdgeKind]bool {
+	kinds := opts.EdgeKinds
+	if len(kinds) == 0 {
+		// The default edge set mirrors get_callers (calls + matches +
+		// references). Callers wanting a pure direct-call path pass
+		// IncludeReferences=false, which drops the method-value wiring edges.
+		kinds = callEdgeKinds
+		if !opts.IncludeReferences {
+			kinds = []graph.EdgeKind{graph.EdgeCalls, graph.EdgeMatches}
+		}
+	}
+	set := make(map[graph.EdgeKind]bool, len(kinds))
+	for _, k := range kinds {
+		set[k] = true
+	}
+	return set
+}
+
+// hasEdge reports whether id has at least one edge of a traced kind in the
+// given direction (forward = out edges).
+func (e *Engine) hasEdge(id string, forward bool, kindSet map[graph.EdgeKind]bool) bool {
+	var edges []*graph.Edge
+	if forward {
+		edges = e.g.GetOutEdges(id)
+	} else {
+		edges = e.g.GetInEdges(id)
+	}
+	for _, ed := range edges {
+		if kindSet[ed.Kind] {
+			return true
+		}
+	}
+	return false
+}
+
+func (e *Engine) scopeOK(id string, opts Options) bool {
+	if opts.WorkspaceID == "" {
+		return true
+	}
+	n := e.g.GetNode(id)
+	if n == nil || n.WorkspaceID == "" {
+		return true
+	}
+	return n.WorkspaceID == opts.WorkspaceID
+}
+
+// boundary reason labels. dynamic_dispatch is special-cased in the gap
+// classifier; the rest come straight from graph.StubKind.
+const boundaryDynamicDispatch = "dynamic_dispatch"
+
+// classifyBoundary maps a neighbour id to a boundary reason, or returns
+// isBoundary=false for an ordinary in-graph node.
+func classifyBoundary(id string) (reason string, isBoundary bool) {
+	if graph.IsUnresolvedTarget(id) {
+		return boundaryDynamicDispatch, true
+	}
+	if strings.HasPrefix(id, "external::") {
+		return "external_namespace", true
+	}
+	if k := graph.StubKind(id); k != "" {
+		return k, true
+	}
+	return "", false
+}
+
+// edgeOriginOf returns the stamped Origin, falling back to DefaultOriginFor so
+// back-compat graphs classify cleanly (identical to dataflow.edgeOrigin).
+func edgeOriginOf(e *graph.Edge) string {
+	if e.Origin != "" {
+		return e.Origin
+	}
+	src, _ := e.Meta["semantic_source"].(string)
+	return graph.DefaultOriginFor(e.Kind, e.Confidence, src)
+}
+
+// tierRank orders the coarse tier labels worst→best for mergeWorstTier.
+var tierRank = map[string]int{"heuristic": 0, "ast": 1, "lsp": 2}
+
+// mergeWorstTier returns the weaker of two coarse tier labels.
+func mergeWorstTier(a, b string) string {
+	if a == "" {
+		return b
+	}
+	if b == "" {
+		return a
+	}
+	if tierRank[b] < tierRank[a] {
+		return b
+	}
+	return a
+}
+
+func shortLabel(id string) string {
+	if i := strings.LastIndex(id, "::"); i >= 0 {
+		return id[i+2:]
+	}
+	return id
+}
+
+func orDefault(v, def int) int {
+	if v <= 0 {
+		return def
+	}
+	return v
+}

--- a/internal/callpath/callpath_test.go
+++ b/internal/callpath/callpath_test.go
@@ -1,0 +1,285 @@
+package callpath
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func newGraph(ids ...string) *graph.Graph {
+	g := graph.New()
+	for _, id := range ids {
+		g.AddNode(&graph.Node{ID: id, Kind: graph.KindFunction, Name: id, FilePath: "test.go"})
+	}
+	return g
+}
+
+func calls(g *graph.Graph, from, to string) {
+	g.AddEdge(&graph.Edge{From: from, To: to, Kind: graph.EdgeCalls, FilePath: "test.go", Origin: graph.OriginASTResolved})
+}
+
+func callsTier(g *graph.Graph, from, to, origin string) {
+	g.AddEdge(&graph.Edge{From: from, To: to, Kind: graph.EdgeCalls, FilePath: "test.go", Origin: origin})
+}
+
+func TestShortestPath_Direct(t *testing.T) {
+	g := newGraph("A", "B")
+	calls(g, "A", "B")
+	res := New(g).ShortestPath("A", "B", Options{})
+	if !res.Found || len(res.Paths) != 1 {
+		t.Fatalf("expected 1 path, got found=%v paths=%d gap=%+v", res.Found, len(res.Paths), res.Gap)
+	}
+	p := res.Paths[0]
+	if p.Length != 1 || len(p.Nodes) != 2 || p.Nodes[0] != "A" || p.Nodes[1] != "B" {
+		t.Errorf("unexpected path: %+v", p)
+	}
+	if p.Confidence <= 0 || p.Confidence > 1 {
+		t.Errorf("confidence out of range: %v", p.Confidence)
+	}
+}
+
+func TestShortestPath_MultiHop(t *testing.T) {
+	g := newGraph("A", "B", "C", "D")
+	calls(g, "A", "B")
+	calls(g, "B", "C")
+	calls(g, "C", "D")
+	res := New(g).ShortestPath("A", "D", Options{})
+	if !res.Found || len(res.Paths) != 1 {
+		t.Fatalf("expected found, got %+v", res)
+	}
+	got := res.Paths[0].Nodes
+	want := []string{"A", "B", "C", "D"}
+	if len(got) != len(want) {
+		t.Fatalf("unexpected nodes: %v", got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("node %d = %q, want %q (path %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+// TestShortestPath_BidirectionalMeet asserts the engine returns the SHORTEST of
+// two routes (the length-2 diamond top, not a longer detour).
+func TestShortestPath_BidirectionalMeet(t *testing.T) {
+	g := newGraph("A", "B", "C", "D", "X", "Y", "Z")
+	// Short route: A->B->D
+	calls(g, "A", "B")
+	calls(g, "B", "D")
+	// Long route: A->C->X->Y->Z->D
+	calls(g, "A", "C")
+	calls(g, "C", "X")
+	calls(g, "X", "Y")
+	calls(g, "Y", "Z")
+	calls(g, "Z", "D")
+	res := New(g).ShortestPath("A", "D", Options{})
+	if !res.Found {
+		t.Fatalf("expected found, got %+v", res.Gap)
+	}
+	if res.Paths[0].Length != 2 {
+		t.Errorf("expected shortest length 2, got %d (%v)", res.Paths[0].Length, res.Paths[0].Nodes)
+	}
+}
+
+func TestShortestPath_Disconnected(t *testing.T) {
+	g := newGraph("A", "B", "C", "D")
+	calls(g, "A", "B")
+	calls(g, "C", "D")
+	res := New(g).ShortestPath("A", "D", Options{})
+	if res.Found {
+		t.Fatalf("expected no path, got %+v", res.Paths)
+	}
+	if res.Gap == nil || res.Gap.Reason != ReasonDisconnected {
+		t.Fatalf("expected disconnected, got %+v", res.Gap)
+	}
+	if res.Gap.ForwardReached != 1 || res.Gap.BackwardReached != 1 {
+		t.Errorf("expected 1 reached each side, got fwd=%d bwd=%d", res.Gap.ForwardReached, res.Gap.BackwardReached)
+	}
+	if len(res.Gap.FurthestFromSource) == 0 || len(res.Gap.NearestToSink) == 0 {
+		t.Errorf("expected frontier reports, got %+v", res.Gap)
+	}
+}
+
+func TestShortestPath_DynamicDispatchBoundary(t *testing.T) {
+	g := newGraph("A", "B", "sink")
+	calls(g, "A", "B")
+	// B's only onward call is to an unresolved (dynamic-dispatch) target.
+	g.AddNode(&graph.Node{ID: "unresolved::handler", Kind: graph.KindFunction, Name: "handler"})
+	calls(g, "B", "unresolved::handler")
+	// sink has an incoming edge from an unrelated, unreachable node.
+	g.AddNode(&graph.Node{ID: "Z", Kind: graph.KindFunction, Name: "Z"})
+	calls(g, "Z", "sink")
+	res := New(g).ShortestPath("A", "sink", Options{})
+	if res.Found {
+		t.Fatalf("expected no path, got %+v", res.Paths)
+	}
+	if res.Gap.Reason != ReasonDynamicDispatch {
+		t.Fatalf("expected dynamic_dispatch, got %s", res.Gap.Reason)
+	}
+	found := false
+	for _, b := range res.Gap.BoundaryHits {
+		if b.Target == "unresolved::handler" && b.Reason == boundaryDynamicDispatch {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected boundary hit for unresolved::handler, got %+v", res.Gap.BoundaryHits)
+	}
+}
+
+func TestShortestPath_StubBoundary(t *testing.T) {
+	g := newGraph("A", "B", "sink")
+	calls(g, "A", "B")
+	g.AddNode(&graph.Node{ID: "stdlib::fmt.Println", Kind: graph.KindFunction})
+	calls(g, "B", "stdlib::fmt.Println")
+	g.AddNode(&graph.Node{ID: "Z", Kind: graph.KindFunction})
+	calls(g, "Z", "sink")
+	res := New(g).ShortestPath("A", "sink", Options{})
+	if res.Found {
+		t.Fatalf("expected no path")
+	}
+	if res.Gap.Reason != ReasonExternalBoundary {
+		t.Fatalf("expected external boundary, got %s", res.Gap.Reason)
+	}
+	if len(res.Gap.BoundaryHits) == 0 || res.Gap.BoundaryHits[0].Reason != "stdlib" {
+		t.Errorf("expected stdlib boundary hit, got %+v", res.Gap.BoundaryHits)
+	}
+}
+
+func TestShortestPath_DepthExceeded(t *testing.T) {
+	g := newGraph("A", "B", "C", "D", "E")
+	calls(g, "A", "B")
+	calls(g, "B", "C")
+	calls(g, "C", "D")
+	calls(g, "D", "E")
+	res := New(g).ShortestPath("A", "E", Options{MaxDepth: 2})
+	if res.Found {
+		t.Fatalf("expected no path within depth 2, got %+v", res.Paths)
+	}
+	if res.Gap.Reason != ReasonDepthExceeded {
+		t.Fatalf("expected depth_exceeded, got %s", res.Gap.Reason)
+	}
+}
+
+func TestShortestPath_NotFound(t *testing.T) {
+	g := newGraph("A", "B")
+	calls(g, "A", "B")
+	if res := New(g).ShortestPath("MISSING", "B", Options{}); res.Found || res.Gap.Reason != ReasonSrcNotFound {
+		t.Errorf("expected src_not_found, got %+v", res)
+	}
+	if res := New(g).ShortestPath("A", "MISSING", Options{}); res.Found || res.Gap.Reason != ReasonSinkNotFound {
+		t.Errorf("expected sink_not_found, got %+v", res)
+	}
+}
+
+func TestShortestPath_SrcNoOutSinkNoIn(t *testing.T) {
+	g := newGraph("A", "B", "C")
+	calls(g, "B", "C")
+	// A has no out edges.
+	if res := New(g).ShortestPath("A", "C", Options{}); res.Found || res.Gap.Reason != ReasonSrcNoOut {
+		t.Errorf("expected src_no_out, got %+v", res.Gap)
+	}
+	// A has out edge to B but B is the target with no incoming... use a fresh
+	// graph where the sink genuinely has no in-edges.
+	g2 := newGraph("A", "B", "C")
+	calls(g2, "A", "B")
+	if res := New(g2).ShortestPath("A", "C", Options{}); res.Found || res.Gap.Reason != ReasonSinkNoIn {
+		t.Errorf("expected sink_no_in, got %+v", res.Gap)
+	}
+}
+
+func TestShortestPath_SameNode(t *testing.T) {
+	g := newGraph("A")
+	res := New(g).ShortestPath("A", "A", Options{})
+	if !res.Found || len(res.Paths) != 1 || res.Paths[0].Length != 0 {
+		t.Errorf("expected trivial 0-length path, got %+v", res)
+	}
+}
+
+func TestShortestPath_KShortest(t *testing.T) {
+	g := newGraph("A", "B", "C", "D")
+	// Two equal-length routes A->B->D and A->C->D.
+	calls(g, "A", "B")
+	calls(g, "B", "D")
+	calls(g, "A", "C")
+	calls(g, "C", "D")
+	res := New(g).ShortestPath("A", "D", Options{K: 2})
+	if !res.Found {
+		t.Fatalf("expected found, got %+v", res.Gap)
+	}
+	if len(res.Paths) != 2 {
+		t.Fatalf("expected 2 paths with K=2, got %d: %+v", len(res.Paths), res.Paths)
+	}
+	for _, p := range res.Paths {
+		if p.Length != 2 {
+			t.Errorf("expected length-2 path, got %d", p.Length)
+		}
+	}
+}
+
+func TestShortestPath_KShortest_RankedByConfidence(t *testing.T) {
+	g := newGraph("A", "B", "C", "D")
+	// A->B->D is all ast_resolved; A->C->D goes through a text_matched edge.
+	callsTier(g, "A", "B", graph.OriginASTResolved)
+	callsTier(g, "B", "D", graph.OriginASTResolved)
+	callsTier(g, "A", "C", graph.OriginTextMatched)
+	callsTier(g, "C", "D", graph.OriginASTResolved)
+	res := New(g).ShortestPath("A", "D", Options{K: 2})
+	if len(res.Paths) != 2 {
+		t.Fatalf("expected 2 paths, got %d", len(res.Paths))
+	}
+	if res.Paths[0].Nodes[1] != "B" {
+		t.Errorf("expected higher-confidence path (via B) first, got %v", res.Paths[0].Nodes)
+	}
+	if res.Paths[0].Confidence <= res.Paths[1].Confidence {
+		t.Errorf("expected paths ranked by confidence desc, got %v then %v",
+			res.Paths[0].Confidence, res.Paths[1].Confidence)
+	}
+}
+
+func TestShortestPath_MinTierPrune(t *testing.T) {
+	g := newGraph("A", "B", "C")
+	// Only route A->B->C exists, and B->C is text_matched.
+	callsTier(g, "A", "B", graph.OriginASTResolved)
+	callsTier(g, "B", "C", graph.OriginTextMatched)
+	// Without min_tier the path is found.
+	if res := New(g).ShortestPath("A", "C", Options{}); !res.Found {
+		t.Fatalf("expected found without min_tier, got %+v", res.Gap)
+	}
+	// With min_tier=ast_resolved the weak edge is pruned and no path remains.
+	res := New(g).ShortestPath("A", "C", Options{MinTier: graph.OriginASTResolved})
+	if res.Found {
+		t.Errorf("expected min_tier prune to drop the path, got %+v", res.Paths)
+	}
+}
+
+func TestShortestPath_EdgeMatchesCrossService(t *testing.T) {
+	g := newGraph("consumer", "providerContract", "handler")
+	g.AddNode(&graph.Node{ID: "consumerContract", Kind: graph.KindContract})
+	// consumer -> calls -> consumerContract -> matches -> providerContract -> calls -> handler
+	calls(g, "consumer", "consumerContract")
+	g.AddEdge(&graph.Edge{From: "consumerContract", To: "providerContract", Kind: graph.EdgeMatches, Origin: graph.OriginASTResolved})
+	calls(g, "providerContract", "handler")
+	res := New(g).ShortestPath("consumer", "handler", Options{})
+	if !res.Found {
+		t.Fatalf("expected cross-service path via EdgeMatches, got %+v", res.Gap)
+	}
+	if res.Paths[0].Length != 3 {
+		t.Errorf("expected length 3, got %d (%v)", res.Paths[0].Length, res.Paths[0].Nodes)
+	}
+}
+
+func TestShortestPath_IncludeReferencesFalse(t *testing.T) {
+	g := newGraph("A", "B", "C")
+	calls(g, "A", "B")
+	// Only wiring from B to C is an EdgeReferences (method-value registration).
+	g.AddEdge(&graph.Edge{From: "B", To: "C", Kind: graph.EdgeReferences, Origin: graph.OriginASTResolved})
+	// Default (references included) finds it.
+	if res := New(g).ShortestPath("A", "C", Options{IncludeReferences: true}); !res.Found {
+		t.Fatalf("expected path with references, got %+v", res.Gap)
+	}
+	// references excluded drops the wiring hop.
+	if res := New(g).ShortestPath("A", "C", Options{IncludeReferences: false}); res.Found {
+		t.Errorf("expected no pure-call path, got %+v", res.Paths)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -572,6 +572,49 @@ type IndexConfig struct {
 	// by default. Configured under `index.fallback_chunkers` in
 	// .gortex.yaml.
 	FallbackChunkers []FallbackChunkerSpec `mapstructure:"fallback_chunkers" yaml:"fallback_chunkers,omitempty"`
+
+	// EventBus declares producer/consumer boundaries for a bespoke event
+	// bus / SSE flow purely in config — no code change. Each spec matches
+	// call sites / decorators / interface bases and Gortex synthesizes real
+	// traversable provider↔consumer contract pairs (with dispatch guards)
+	// for the bus, so find_usages / trace_path / analyze pubsub all work on
+	// it. Empty by default. Configured under `index.event_bus` in
+	// .gortex.yaml; the CODEGRAPH_EVENT_CONFIG env var (a JSON list)
+	// overrides it for drop-in compatibility with pygraph/tsgraph.
+	EventBus []EventBusBoundarySpec `mapstructure:"event_bus" yaml:"event_bus,omitempty"`
+}
+
+// EventBusBoundarySpec declares one producer or consumer boundary of a
+// user-defined event bus / SSE flow. The schema is language-neutral and
+// drop-in compatible with pygraph/tsgraph's CODEGRAPH_EVENT_CONFIG entries.
+type EventBusBoundarySpec struct {
+	// Name groups producers and consumers of the same logical bus. A
+	// producer and consumer with the same Name + topic pair into an edge.
+	Name string `mapstructure:"name" yaml:"name"`
+	// Type is "producer" or "consumer".
+	Type string `mapstructure:"type" yaml:"type"`
+	// Callee is a dotted call suffix matched against producer/consumer call
+	// sites (e.g. "bus.publish", "producer.send"). Matched as a suffix so
+	// "self.producer.send(" matches "producer.send".
+	Callee string `mapstructure:"callee" yaml:"callee,omitempty"`
+	// CalleePattern is a looser substring match on the callee for SSE / hook
+	// forms (e.g. "EventSource", "useEventStream"). Alias: HookPattern.
+	CalleePattern string `mapstructure:"callee_pattern" yaml:"callee_pattern,omitempty"`
+	// HookPattern is an alias for CalleePattern (tsgraph compatibility).
+	HookPattern string `mapstructure:"hook_pattern" yaml:"hook_pattern,omitempty"`
+	// Decorator names a decorator that marks the decorated function as a
+	// consumer (e.g. "kafka_consumer"); the topic is read from its args.
+	Decorator string `mapstructure:"decorator" yaml:"decorator,omitempty"`
+	// Interface names a class base; every method of a class extending it is
+	// a consumer (paired on the bus wildcard topic).
+	Interface string `mapstructure:"interface" yaml:"interface,omitempty"`
+	// TopicArg names the argument carrying the topic / url that keys the
+	// producer↔consumer join: a positional index ("0") or a kwarg name
+	// ("topic"). Defaults to "topic".
+	TopicArg string `mapstructure:"topic_arg" yaml:"topic_arg,omitempty"`
+	// Guards, when true, extracts the consumer's first if/elif dispatch
+	// chain (field==value rules) onto the contract for routing queries.
+	Guards bool `mapstructure:"guards" yaml:"guards,omitempty"`
 }
 
 // GrammarSpec declares a user-supplied tree-sitter grammar to load at

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -532,6 +532,14 @@ type IndexConfig struct {
 	// per-repo with `.gortex.yaml::index::synthesize_speculative_dispatch:
 	// true` or the GORTEX_SYNTH_SPECULATIVE=1 environment override.
 	SynthesizeSpeculativeDispatch *bool `mapstructure:"synthesize_speculative_dispatch" yaml:"synthesize_speculative_dispatch,omitempty"`
+	// ScopedGlobalPasses scopes the global inference passes (InferImplements /
+	// InferOverrides) on incremental reindex to only the types/interfaces a
+	// change can affect, instead of re-running the whole-graph type×interface
+	// cross product on every single-file edit. Add-parity with the full pass
+	// (it re-derives exactly the edges eviction dropped). Tri-state, DEFAULT
+	// ON. Set false (or GORTEX_INDEX_SCOPED_GLOBAL_PASSES=0) to restore the
+	// whole-graph behaviour.
+	ScopedGlobalPasses *bool `mapstructure:"scoped_global_passes" yaml:"scoped_global_passes,omitempty"`
 	// Transforms are pluggable pre-ingestion content processors. Each
 	// rewrites a matching file's bytes before the parser sees them —
 	// expanding minified bundles, normalising SVG/TOON, converting a
@@ -1301,6 +1309,15 @@ func (i IndexConfig) SpeculativeDispatchEnabledOrDefault() bool {
 		return false
 	}
 	return *i.SynthesizeSpeculativeDispatch
+}
+
+// ScopedGlobalPassesEnabledOrDefault resolves the tri-state ScopedGlobalPasses
+// flag against a default-ON policy.
+func (i IndexConfig) ScopedGlobalPassesEnabledOrDefault() bool {
+	if i.ScopedGlobalPasses == nil {
+		return true
+	}
+	return *i.ScopedGlobalPasses
 }
 
 // EmbeddingProviderOrDefault returns the configured provider name,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -522,6 +522,16 @@ type IndexConfig struct {
 	// stdlib calls are filtered out regardless so the synthetic nodes
 	// only ever name genuine third-party packages.
 	SynthesizeExternalCalls *bool `mapstructure:"synthesize_external_calls" yaml:"synthesize_external_calls,omitempty"`
+	// SynthesizeSpeculativeDispatch mints opt-in, best-guess `calls` edges for
+	// dynamic-dispatch blind spots (computed-member calls obj["foo"](),
+	// getattr, decorator registries). Unlike external-call synthesis it
+	// DEFAULTS OFF (tri-state, nil = off) because the edges are heuristic
+	// fan-outs; when on they ride a strictly-lower confidence tier and are
+	// hidden from every default query (opt in per query with
+	// include_speculative, or audit via `analyze kind=speculative`). Enable
+	// per-repo with `.gortex.yaml::index::synthesize_speculative_dispatch:
+	// true` or the GORTEX_SYNTH_SPECULATIVE=1 environment override.
+	SynthesizeSpeculativeDispatch *bool `mapstructure:"synthesize_speculative_dispatch" yaml:"synthesize_speculative_dispatch,omitempty"`
 	// Transforms are pluggable pre-ingestion content processors. Each
 	// rewrites a matching file's bytes before the parser sees them —
 	// expanding minified bundles, normalising SVG/TOON, converting a
@@ -1279,6 +1289,18 @@ func (i IndexConfig) ExternalCallSynthesisEnabledOrDefault() bool {
 		return true
 	}
 	return *i.SynthesizeExternalCalls
+}
+
+// SpeculativeDispatchEnabledOrDefault resolves the tri-state
+// SynthesizeSpeculativeDispatch flag against a default-OFF policy: an unset
+// flag means speculative dynamic-dispatch synthesis is disabled (the edges are
+// heuristic fan-outs, opt-in only). Enable per-repo with the key set to true
+// or GORTEX_SYNTH_SPECULATIVE=1.
+func (i IndexConfig) SpeculativeDispatchEnabledOrDefault() bool {
+	if i.SynthesizeSpeculativeDispatch == nil {
+		return false
+	}
+	return *i.SynthesizeSpeculativeDispatch
 }
 
 // EmbeddingProviderOrDefault returns the configured provider name,

--- a/internal/config/speculative_config_test.go
+++ b/internal/config/speculative_config_test.go
@@ -1,0 +1,20 @@
+package config
+
+import "testing"
+
+func TestSpeculativeDispatchEnabledOrDefault(t *testing.T) {
+	var ic IndexConfig
+	if ic.SpeculativeDispatchEnabledOrDefault() {
+		t.Errorf("speculative dispatch must default OFF when unset")
+	}
+	tt := true
+	ic.SynthesizeSpeculativeDispatch = &tt
+	if !ic.SpeculativeDispatchEnabledOrDefault() {
+		t.Errorf("explicit true must enable")
+	}
+	ff := false
+	ic.SynthesizeSpeculativeDispatch = &ff
+	if ic.SpeculativeDispatchEnabledOrDefault() {
+		t.Errorf("explicit false must disable")
+	}
+}

--- a/internal/contracts/event_bus.go
+++ b/internal/contracts/event_bus.go
@@ -1,0 +1,284 @@
+package contracts
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// EventBusExtractor synthesizes provider/consumer contracts for a bespoke
+// event bus declared entirely in config — no code change, no per-language
+// parser work. It is the config-driven counterpart to the hard-coded
+// TopicExtractor: each user boundary matches call sites / decorators /
+// interface bases (language-agnostically, via regex over the source the same
+// way httpPatterns / topicPublishPatterns do) and emits a ContractTopic keyed
+// `topic::<bus>::<topic>`. The existing contract matcher then pairs a producer
+// and consumer of the same bus+topic into a traversable EdgeMatches edge —
+// strictly better than pygraph/tsgraph, which only stash isolated metadata on
+// each symbol and never build the producer→consumer link.
+//
+// Dispatch guards (the first if/elif chain of a consumer body) are extracted
+// best-effort onto the contract's Meta["guards"] so analyze can answer
+// "which handler dispatches on entity==ORDER".
+type EventBusExtractor struct {
+	Boundaries []EventBusBoundary
+}
+
+// EventBusBoundary is one declarative producer/consumer rule. It mirrors
+// config.EventBusBoundarySpec but lives in the contracts package so the
+// resolver/contracts layers never import internal/config (cycle-free); the
+// indexer converts specs to boundaries at construction.
+type EventBusBoundary struct {
+	Name          string
+	Type          string // "producer" | "consumer"
+	Callee        string // dotted call suffix (producer/consumer call)
+	CalleePattern string // substring match on the callee (SSE / hook)
+	Decorator     string // decorator name (consumer)
+	Interface     string // class base name (consumer)
+	TopicArg      string // positional index ("0") or kwarg name; default "topic"
+	Guards        bool   // extract dispatch guards from the consumer body
+}
+
+// eventBusLangs are the languages the config-driven bus runs over. It covers
+// the competitors' targets (Python, TS/JS) plus the other common backend
+// languages so one config rule works across a polyglot monorepo.
+var eventBusLangs = []string{
+	"python", "javascript", "typescript", "go", "java", "ruby", "php", "rust", "csharp", "kotlin",
+}
+
+func (e *EventBusExtractor) SupportedLanguages() []string { return eventBusLangs }
+
+func (e *EventBusExtractor) Extract(filePath string, src []byte, nodes []*graph.Node, edges []*graph.Edge) []Contract {
+	if len(e.Boundaries) == 0 {
+		return nil
+	}
+	text := string(src)
+	lines := strings.Split(text, "\n")
+	fileNodes := filterFileNodes(filePath, nodes)
+	sort.Slice(fileNodes, func(i, j int) bool { return fileNodes[i].StartLine < fileNodes[j].StartLine })
+
+	var out []Contract
+	for _, b := range e.Boundaries {
+		switch {
+		case b.Decorator != "":
+			out = append(out, e.matchDecorator(b, filePath, text, lines, fileNodes)...)
+		case b.Interface != "":
+			out = append(out, e.matchInterface(b, filePath, text, lines, fileNodes)...)
+		default:
+			out = append(out, e.matchCallee(b, filePath, text, lines, fileNodes)...)
+		}
+	}
+	return out
+}
+
+func (e *EventBusExtractor) role(b EventBusBoundary) Role {
+	if strings.EqualFold(b.Type, "producer") {
+		return RoleProvider
+	}
+	return RoleConsumer
+}
+
+// matchCallee handles producer calls (boundary.Callee) and SSE/hook consumer
+// calls (boundary.CalleePattern / HookPattern).
+func (e *EventBusExtractor) matchCallee(b EventBusBoundary, filePath, text string, lines []string, fileNodes []*graph.Node) []Contract {
+	var re *regexp.Regexp
+	switch {
+	case b.Callee != "":
+		// Substring match on the dotted callee so "self.producer.send(" matches "producer.send".
+		re = regexp.MustCompile(regexp.QuoteMeta(b.Callee) + `\s*\(`)
+	case b.CalleePattern != "":
+		re = regexp.MustCompile(regexp.QuoteMeta(b.CalleePattern) + `[\w.]*\s*\(`)
+	default:
+		return nil
+	}
+	var out []Contract
+	for _, m := range re.FindAllStringIndex(text, -1) {
+		args := callTrailSlice(text, m[0])
+		topic := extractTopicArg(splitPyParams(args), b.TopicArg)
+		if topic == "" {
+			continue
+		}
+		ln := lineAtOffset(lines, m[0])
+		c := e.contractFor(b, topic, findEnclosingSymbol(fileNodes, ln), filePath, ln)
+		if b.Guards && e.role(b) == RoleConsumer {
+			attachGuards(&c, lines, fileNodes, c.SymbolID)
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+// matchDecorator handles decorator-based consumers (@kafka_consumer(topic=...)).
+func (e *EventBusExtractor) matchDecorator(b EventBusBoundary, filePath, text string, lines []string, fileNodes []*graph.Node) []Contract {
+	re := regexp.MustCompile(`@` + regexp.QuoteMeta(b.Decorator) + `\b`)
+	var out []Contract
+	for _, m := range re.FindAllStringIndex(text, -1) {
+		ln := lineAtOffset(lines, m[0])
+		// The decorated function is the next function/method node at or after
+		// the decorator line.
+		sym := decoratedSymbol(fileNodes, ln)
+		if sym == "" {
+			sym = findEnclosingSymbol(fileNodes, ln)
+		}
+		// Topic from the decorator's args, when it is a call form.
+		topic := ""
+		if args := callTrailSlice(text, m[0]); args != "" {
+			topic = extractTopicArg(splitPyParams(args), b.TopicArg)
+		}
+		if topic == "" {
+			topic = "*"
+		}
+		c := e.contractFor(b, topic, sym, filePath, ln)
+		if b.Guards && e.role(b) == RoleConsumer {
+			attachGuards(&c, lines, fileNodes, sym)
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+// matchInterface handles interface-based consumers: every method of a class
+// that extends the named base is a consumer, paired on the bus wildcard topic.
+func (e *EventBusExtractor) matchInterface(b EventBusBoundary, filePath, text string, lines []string, fileNodes []*graph.Node) []Contract {
+	classRE := regexp.MustCompile(`class\s+(\w+)\s*[\(:][^\n{]*\b` + regexp.QuoteMeta(b.Interface) + `\b`)
+	var out []Contract
+	seen := map[string]bool{}
+	for _, m := range classRE.FindAllStringSubmatch(text, -1) {
+		className := m[1]
+		for _, n := range fileNodes {
+			if n.Kind != graph.KindMethod {
+				continue
+			}
+			recv, _ := n.Meta["receiver"].(string)
+			if recv != className && !strings.HasPrefix(n.ID, filePath+"::"+className+".") {
+				continue
+			}
+			if seen[n.ID] {
+				continue
+			}
+			seen[n.ID] = true
+			c := e.contractFor(b, "*", n.ID, filePath, n.StartLine)
+			if b.Guards && e.role(b) == RoleConsumer {
+				attachGuards(&c, lines, fileNodes, n.ID)
+			}
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+func (e *EventBusExtractor) contractFor(b EventBusBoundary, topic, symbolID, filePath string, line int) Contract {
+	meta := map[string]any{
+		"topic":     topic,
+		"bus":       b.Name,
+		"transport": "configbus",
+	}
+	return Contract{
+		ID:         fmt.Sprintf("topic::%s::%s", b.Name, topic),
+		Type:       ContractTopic,
+		Role:       e.role(b),
+		SymbolID:   symbolID,
+		FilePath:   filePath,
+		Line:       line,
+		Meta:       meta,
+		Confidence: 0.7,
+	}
+}
+
+// extractTopicArg pulls the topic/url literal from a parsed arg list by
+// positional index (TopicArg is numeric) or kwarg name, falling back to the
+// first positional string literal.
+func extractTopicArg(parts []string, topicArg string) string {
+	if topicArg == "" {
+		topicArg = "topic"
+	}
+	if idx, err := strconv.Atoi(topicArg); err == nil {
+		if idx >= 0 && idx < len(parts) {
+			if lit, ok := pyStringLiteral(parts[idx]); ok {
+				return lit
+			}
+		}
+		return firstPositionalString(parts)
+	}
+	for _, p := range parts {
+		eq := strings.IndexByte(p, '=')
+		if eq < 0 {
+			continue
+		}
+		if strings.TrimSpace(p[:eq]) == topicArg {
+			if lit, ok := pyStringLiteral(p[eq+1:]); ok {
+				return lit
+			}
+		}
+	}
+	return firstPositionalString(parts)
+}
+
+func firstPositionalString(parts []string) string {
+	for _, p := range parts {
+		if strings.Contains(p, "=") {
+			continue
+		}
+		if lit, ok := pyStringLiteral(p); ok {
+			return lit
+		}
+	}
+	return ""
+}
+
+// decoratedSymbol returns the ID of the first function/method node at or after
+// the decorator line.
+func decoratedSymbol(fileNodes []*graph.Node, decoratorLine int) string {
+	best := ""
+	bestLine := 1 << 30
+	for _, n := range fileNodes {
+		if n.Kind != graph.KindFunction && n.Kind != graph.KindMethod {
+			continue
+		}
+		if n.StartLine >= decoratorLine && n.StartLine < bestLine {
+			bestLine = n.StartLine
+			best = n.ID
+		}
+	}
+	return best
+}
+
+var (
+	guardEqRE  = regexp.MustCompile(`(?:if|elif)\s+(.+?)\s*==\s*['"]([^'"]+)['"]`)
+	guardGetRE = regexp.MustCompile(`\w+\.get\(\s*['"]([^'"]+)['"]`)
+)
+
+// attachGuards scans the consumer symbol's body for the first if/elif dispatch
+// chain (field==value rules) and records them on the contract's Meta["guards"].
+func attachGuards(c *Contract, lines []string, fileNodes []*graph.Node, symbolID string) {
+	start, end := symbolLineRange(fileNodes, symbolID)
+	if start == 0 || end < start {
+		return
+	}
+	var guards []map[string]string
+	for i := start - 1; i < end && i < len(lines); i++ {
+		for _, mm := range guardEqRE.FindAllStringSubmatch(lines[i], -1) {
+			field := strings.TrimSpace(mm[1])
+			if g := guardGetRE.FindStringSubmatch(field); len(g) == 2 {
+				field = g[1]
+			}
+			guards = append(guards, map[string]string{"field": field, "value": mm[2]})
+		}
+	}
+	if len(guards) > 0 {
+		c.Meta["guards"] = guards
+	}
+}
+
+func symbolLineRange(fileNodes []*graph.Node, symbolID string) (int, int) {
+	for _, n := range fileNodes {
+		if n.ID == symbolID {
+			return n.StartLine, n.EndLine
+		}
+	}
+	return 0, 0
+}

--- a/internal/contracts/event_bus_test.go
+++ b/internal/contracts/event_bus_test.go
@@ -1,0 +1,139 @@
+package contracts
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func ebFind(cs []Contract, id string, role Role) *Contract {
+	for i := range cs {
+		if cs[i].ID == id && cs[i].Role == role {
+			return &cs[i]
+		}
+	}
+	return nil
+}
+
+func TestEventBus_ProducerCallee(t *testing.T) {
+	src := []byte(`def emit():
+    producer.send(topic='orders')
+`)
+	ext := &EventBusExtractor{Boundaries: []EventBusBoundary{
+		{Name: "kafka", Type: "producer", Callee: "producer.send", TopicArg: "topic"},
+	}}
+	cs := ext.Extract("app.py", src, nil, nil)
+	c := ebFind(cs, "topic::kafka::orders", RoleProvider)
+	if c == nil {
+		t.Fatalf("expected provider topic::kafka::orders, got %+v", cs)
+	}
+	if c.Type != ContractTopic || c.Meta["topic"] != "orders" {
+		t.Errorf("unexpected contract: %+v", c)
+	}
+}
+
+func TestEventBus_SSEConsumerPattern(t *testing.T) {
+	src := []byte(`const es = new EventSource('/api/events')`)
+	ext := &EventBusExtractor{Boundaries: []EventBusBoundary{
+		{Name: "sse", Type: "consumer", CalleePattern: "EventSource", TopicArg: "0"},
+	}}
+	cs := ext.Extract("app.ts", src, nil, nil)
+	if ebFind(cs, "topic::sse::/api/events", RoleConsumer) == nil {
+		t.Fatalf("expected SSE consumer on /api/events, got %+v", cs)
+	}
+}
+
+func TestEventBus_DecoratorConsumer(t *testing.T) {
+	src := []byte(`@kafka_consumer(topic='orders')
+def handle_order(msg):
+    pass
+`)
+	nodes := []*graph.Node{
+		{ID: "app.py::handle_order", Kind: graph.KindFunction, Name: "handle_order", FilePath: "app.py", StartLine: 2, EndLine: 3},
+	}
+	ext := &EventBusExtractor{Boundaries: []EventBusBoundary{
+		{Name: "kafka", Type: "consumer", Decorator: "kafka_consumer", TopicArg: "topic"},
+	}}
+	cs := ext.Extract("app.py", src, nodes, nil)
+	c := ebFind(cs, "topic::kafka::orders", RoleConsumer)
+	if c == nil {
+		t.Fatalf("expected decorator consumer, got %+v", cs)
+	}
+	if c.SymbolID != "app.py::handle_order" {
+		t.Errorf("SymbolID = %q, want the decorated function", c.SymbolID)
+	}
+}
+
+func TestEventBus_InterfaceConsumer(t *testing.T) {
+	src := []byte(`class OrderHandler(CallbackHandler):
+    def handle(self):
+        pass
+`)
+	nodes := []*graph.Node{
+		{ID: "app.py::OrderHandler", Kind: graph.KindType, Name: "OrderHandler", FilePath: "app.py", StartLine: 1, EndLine: 3},
+		{ID: "app.py::OrderHandler.handle", Kind: graph.KindMethod, Name: "handle", FilePath: "app.py", StartLine: 2, EndLine: 3, Meta: map[string]any{"receiver": "OrderHandler"}},
+	}
+	ext := &EventBusExtractor{Boundaries: []EventBusBoundary{
+		{Name: "bus", Type: "consumer", Interface: "CallbackHandler"},
+	}}
+	cs := ext.Extract("app.py", src, nodes, nil)
+	c := ebFind(cs, "topic::bus::*", RoleConsumer)
+	if c == nil {
+		t.Fatalf("expected interface consumer on bus wildcard, got %+v", cs)
+	}
+	if c.SymbolID != "app.py::OrderHandler.handle" {
+		t.Errorf("SymbolID = %q, want the method node", c.SymbolID)
+	}
+}
+
+func TestEventBus_DispatchGuards(t *testing.T) {
+	src := []byte(`def dispatch(data):
+    if data.get('entity') == 'ORDER':
+        do_order()
+    elif command == 'CREATE':
+        do_create()
+`)
+	nodes := []*graph.Node{
+		{ID: "app.py::dispatch", Kind: graph.KindFunction, Name: "dispatch", FilePath: "app.py", StartLine: 1, EndLine: 5},
+	}
+	ext := &EventBusExtractor{Boundaries: []EventBusBoundary{
+		{Name: "cmd", Type: "consumer", Decorator: "command_handler", TopicArg: "topic", Guards: true},
+	}}
+	src2 := append([]byte("@command_handler(topic='cmd')\n"), src...)
+	// Shift node lines by 1 for the added decorator line.
+	nodes[0].StartLine = 2
+	nodes[0].EndLine = 6
+	cs := ext.Extract("app.py", src2, nodes, nil)
+	c := ebFind(cs, "topic::cmd::cmd", RoleConsumer)
+	if c == nil {
+		t.Fatalf("expected consumer, got %+v", cs)
+	}
+	guards, _ := c.Meta["guards"].([]map[string]string)
+	if len(guards) != 2 {
+		t.Fatalf("expected 2 dispatch guards, got %+v", c.Meta["guards"])
+	}
+	if guards[0]["field"] != "entity" || guards[0]["value"] != "ORDER" {
+		t.Errorf("guard[0] = %v, want entity==ORDER", guards[0])
+	}
+	if guards[1]["field"] != "command" || guards[1]["value"] != "CREATE" {
+		t.Errorf("guard[1] = %v, want command==CREATE", guards[1])
+	}
+}
+
+func TestEventBus_TopicArgPositional(t *testing.T) {
+	src := []byte(`bus.publish("events", payload)`)
+	ext := &EventBusExtractor{Boundaries: []EventBusBoundary{
+		{Name: "b", Type: "producer", Callee: "bus.publish", TopicArg: "0"},
+	}}
+	cs := ext.Extract("a.go", src, nil, nil)
+	if ebFind(cs, "topic::b::events", RoleProvider) == nil {
+		t.Fatalf("expected positional topic extraction, got %+v", cs)
+	}
+}
+
+func TestEventBus_EmptyBoundaries(t *testing.T) {
+	cs := (&EventBusExtractor{}).Extract("a.py", []byte(`producer.send(topic='x')`), nil, nil)
+	if len(cs) != 0 {
+		t.Errorf("expected no contracts with no boundaries, got %+v", cs)
+	}
+}

--- a/internal/contracts/http.go
+++ b/internal/contracts/http.go
@@ -792,6 +792,22 @@ func (h *HTTPExtractor) extract(
 		}
 	}
 
+	// Non-decorator Flask routing forms. flask-restful's
+	// api.add_resource(Class, '/path') and the imperative
+	// app.add_url_rule('/path', view_func=fn) reference a handler that is
+	// NOT on the call line (a resource class whose methods give the verbs,
+	// or a view_func defined elsewhere), so they need cross-symbol
+	// resolution the per-line httpPatterns table cannot do. They run as
+	// dedicated node-aware passes, gated by a cheap substring prefilter.
+	if lang == "python" {
+		if strings.Contains(text, "add_resource") {
+			out = append(out, h.extractFlaskRestfulRoutes(filePath, text, lines, fileNodes, lang, tree)...)
+		}
+		if strings.Contains(text, "add_url_rule") {
+			out = append(out, h.extractFlaskAddURLRule(filePath, text, lines, fileNodes, lang, tree)...)
+		}
+	}
+
 	// Configurable HTTP-client wrapper aliases. Calls to a
 	// project-named wrapper (e.g. apiGet('/users')) become consumer
 	// contracts even though no built-in fetch/axios pattern matched.

--- a/internal/contracts/http_flask.go
+++ b/internal/contracts/http_flask.go
@@ -1,0 +1,248 @@
+package contracts
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+)
+
+// Non-decorator Flask routing forms. Gortex's per-line httpPatterns table can
+// only see @app.route / @router.get decorators; the two imperative Flask forms
+// below reference their handler off the call line, so they resolve it against
+// the file's already-extracted symbol nodes:
+//
+//   - flask-restful: api.add_resource(ResourceClass, '/path'[, '/path2'])
+//     maps the class's get/post/put/delete/... methods to HTTP verbs.
+//   - imperative:    app.add_url_rule('/path', view_func=fn, methods=[...])
+//     the procedural equivalent of @app.route.
+//
+// Both emit Contracts in the exact shape the decorator path produces, so the
+// indexer materialises the same KindContract node + EdgeProvides +
+// EdgeHandlesRoute with no further wiring. Unlike pygraph (which points every
+// add_resource route at the class), gortex points each per-verb route at the
+// specific method node so analyze kind=routes / get_callers land on the real
+// method body.
+
+var (
+	addResourceCallRE = regexp.MustCompile(`\.add_resource\s*\(`)
+	addURLRuleCallRE  = regexp.MustCompile(`\.add_url_rule\s*\(`)
+	viewFuncKwargRE   = regexp.MustCompile(`view_func\s*=\s*([A-Za-z_][\w.]*)`)
+	methodsKwargRE    = regexp.MustCompile(`methods\s*=\s*(\[[^\]]*\]|\([^)]*\)|["'][^"']*["'])`)
+	quotedTokenRE     = regexp.MustCompile(`["']([^"']+)["']`)
+	pyIdentRE         = regexp.MustCompile(`^[A-Za-z_][\w.]*$`)
+)
+
+// flaskVerbMethods is the closed set of resource methods flask-restful maps to
+// HTTP verbs, in canonical order.
+var flaskVerbMethods = []string{"get", "post", "put", "delete", "patch", "head", "options"}
+
+// extractFlaskRestfulRoutes handles api.add_resource(ResourceClass, '/p'...).
+func (h *HTTPExtractor) extractFlaskRestfulRoutes(filePath, text string, lines []string, fileNodes []*graph.Node, lang string, tree *parser.ParseTree) []Contract {
+	var out []Contract
+	for _, m := range addResourceCallRE.FindAllStringIndex(text, -1) {
+		args := callTrailSlice(text, m[0])
+		if args == "" {
+			continue
+		}
+		parts := splitPyParams(args)
+		if len(parts) < 2 {
+			continue
+		}
+		className := pyBareIdentTail(strings.TrimSpace(parts[0]))
+		if className == "" {
+			continue
+		}
+		var paths []string
+		for _, p := range parts[1:] {
+			if lit, ok := pyStringLiteral(p); ok && lit != "" {
+				paths = append(paths, lit)
+			}
+		}
+		if len(paths) == 0 {
+			continue
+		}
+		lineNum := lineAtOffset(lines, m[0])
+		classID := filePath + "::" + className
+		verbMethods := resourceVerbMethods(fileNodes, classID)
+		classNode := findTypeNodeByName(fileNodes, className)
+
+		for _, path := range paths {
+			if len(verbMethods) > 0 {
+				for _, verb := range flaskVerbMethods {
+					mid, ok := verbMethods[verb]
+					if !ok {
+						continue
+					}
+					out = append(out, h.buildFlaskContract(filePath, strings.ToUpper(verb), path, mid, lineNum, lines, fileNodes, lang, tree))
+				}
+				continue
+			}
+			// GET fallback (parity with pygraph): the class is unresolvable or
+			// defines no HTTP-verb methods, but a route node should still
+			// appear for discoverability. Attach to the class node when known,
+			// else the enclosing symbol.
+			sym := findEnclosingSymbol(fileNodes, lineNum)
+			if classNode != nil {
+				sym = classNode.ID
+			}
+			out = append(out, h.buildFlaskContract(filePath, "GET", path, sym, lineNum, lines, fileNodes, lang, tree))
+		}
+	}
+	return out
+}
+
+// extractFlaskAddURLRule handles app.add_url_rule('/p', view_func=fn, methods=[...]).
+func (h *HTTPExtractor) extractFlaskAddURLRule(filePath, text string, lines []string, fileNodes []*graph.Node, lang string, tree *parser.ParseTree) []Contract {
+	var out []Contract
+	for _, m := range addURLRuleCallRE.FindAllStringIndex(text, -1) {
+		args := callTrailSlice(text, m[0])
+		if args == "" {
+			continue
+		}
+		parts := splitPyParams(args)
+		if len(parts) == 0 {
+			continue
+		}
+		path, ok := pyStringLiteral(parts[0])
+		if !ok || path == "" {
+			continue
+		}
+		// view_func from kwarg, else positional arg[1] if it is a bare ident.
+		viewFunc := ""
+		if mm := viewFuncKwargRE.FindStringSubmatch(args); len(mm) == 2 {
+			viewFunc = mm[1]
+		} else if len(parts) >= 2 {
+			cand := strings.TrimSpace(parts[1])
+			if pyIdentRE.MatchString(cand) && !strings.Contains(cand, "=") {
+				viewFunc = cand
+			}
+		}
+		if viewFunc == "" {
+			// Parity with pygraph: only emit when a view_func resolved.
+			continue
+		}
+		viewFunc = pyBareIdentTail(viewFunc)
+
+		methods := flaskMethodsKwarg(args)
+		if len(methods) == 0 {
+			methods = []string{"GET"}
+		}
+		lineNum := lineAtOffset(lines, m[0])
+		symbolID := findFunctionByName(fileNodes, viewFunc)
+		if symbolID == "" {
+			symbolID = findEnclosingSymbol(fileNodes, lineNum)
+		}
+		for _, method := range methods {
+			out = append(out, h.buildFlaskContract(filePath, method, path, symbolID, lineNum, lines, fileNodes, lang, tree))
+		}
+	}
+	return out
+}
+
+// buildFlaskContract builds a provider HTTP contract identical in shape to the
+// decorator path so the indexer materialises the same graph elements.
+func (h *HTTPExtractor) buildFlaskContract(filePath, method, path, symbolID string, lineNum int, lines []string, fileNodes []*graph.Node, lang string, tree *parser.ParseTree) Contract {
+	normPath, origNames := NormalizeHTTPPathWithParams(path)
+	contractID := fmt.Sprintf("http::%s::%s", method, normPath)
+	meta := map[string]any{
+		"method":    method,
+		"path":      normPath,
+		"framework": "flask",
+	}
+	if len(origNames) > 0 {
+		meta["path_param_names"] = origNames
+	}
+	c := Contract{
+		ID:         contractID,
+		Type:       ContractHTTP,
+		Role:       RoleProvider,
+		SymbolID:   symbolID,
+		FilePath:   filePath,
+		Line:       lineNum,
+		Meta:       meta,
+		Confidence: 0.9,
+	}
+	EnrichHTTPContractWithTree(&c, lines, fileNodes, lang, tree)
+	return c
+}
+
+// resourceVerbMethods returns verb→methodNodeID for the HTTP-verb methods a
+// resource class defines, keyed on the deterministic method node ID
+// (filePath::Class.verb).
+func resourceVerbMethods(fileNodes []*graph.Node, classID string) map[string]string {
+	out := map[string]string{}
+	for _, v := range flaskVerbMethods {
+		want := classID + "." + v
+		for _, n := range fileNodes {
+			if n.Kind == graph.KindMethod && n.ID == want {
+				out[v] = n.ID
+				break
+			}
+		}
+	}
+	return out
+}
+
+// findTypeNodeByName resolves a class/type node by short name (findFunctionByName
+// deliberately excludes KindType, so add_resource needs its own lookup).
+func findTypeNodeByName(fileNodes []*graph.Node, name string) *graph.Node {
+	for _, n := range fileNodes {
+		if n.Kind == graph.KindType && n.Name == name {
+			return n
+		}
+	}
+	return nil
+}
+
+// flaskMethodsKwarg parses methods=['POST','PUT'] / methods=('GET',) /
+// methods="GET" into upper-cased verb names.
+func flaskMethodsKwarg(argsText string) []string {
+	mm := methodsKwargRE.FindStringSubmatch(argsText)
+	if len(mm) < 2 {
+		return nil
+	}
+	var out []string
+	for _, q := range quotedTokenRE.FindAllStringSubmatch(mm[1], -1) {
+		out = append(out, strings.ToUpper(q[1]))
+	}
+	return out
+}
+
+// pyStringLiteral strips matching quotes (and an optional r/f/b prefix) from a
+// Python string-literal token, reporting whether the token was a literal.
+func pyStringLiteral(tok string) (string, bool) {
+	tok = strings.TrimSpace(tok)
+	for len(tok) > 1 {
+		switch tok[0] {
+		case 'r', 'R', 'f', 'F', 'b', 'B', 'u', 'U':
+			if tok[1] == '\'' || tok[1] == '"' {
+				tok = tok[1:]
+				continue
+			}
+		}
+		break
+	}
+	if len(tok) >= 2 {
+		q := tok[0]
+		if (q == '\'' || q == '"') && tok[len(tok)-1] == q {
+			return tok[1 : len(tok)-1], true
+		}
+	}
+	return "", false
+}
+
+// pyBareIdentTail strips a module qualifier (pkg.UserResource → UserResource)
+// and returns "" if the result is not a bare identifier.
+func pyBareIdentTail(tok string) string {
+	tok = strings.TrimSpace(tok)
+	if i := strings.LastIndex(tok, "."); i >= 0 {
+		tok = tok[i+1:]
+	}
+	if tok == "" || !pyIdentRE.MatchString(tok) {
+		return ""
+	}
+	return tok
+}

--- a/internal/contracts/http_flask_test.go
+++ b/internal/contracts/http_flask_test.go
@@ -1,0 +1,205 @@
+package contracts
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// flaskNode builds a graph node with an explicit kind for the Flask route tests
+// (the shared makeNodes helper only emits KindFunction).
+func flaskNode(id, name string, kind graph.NodeKind, start int) *graph.Node {
+	return &graph.Node{ID: id, Name: name, Kind: kind, FilePath: "app.py", StartLine: start, EndLine: start + 2}
+}
+
+func flaskFind(cs []Contract, method, path string) *Contract {
+	for i := range cs {
+		if cs[i].Meta["method"] == method && cs[i].Meta["path"] == path {
+			return &cs[i]
+		}
+	}
+	return nil
+}
+
+func TestHTTPExtractor_Python_FlaskRestful_SinglePath(t *testing.T) {
+	src := []byte(`from flask_restful import Api, Resource
+
+class UserResource(Resource):
+    def get(self, id):
+        return {}
+    def post(self):
+        return {}
+
+api.add_resource(UserResource, '/users/<int:id>')
+`)
+	nodes := []*graph.Node{
+		flaskNode("app.py::UserResource", "UserResource", graph.KindType, 3),
+		flaskNode("app.py::UserResource.get", "get", graph.KindMethod, 4),
+		flaskNode("app.py::UserResource.post", "post", graph.KindMethod, 6),
+	}
+	cs := (&HTTPExtractor{}).Extract("app.py", src, nodes, nil)
+
+	get := flaskFind(cs, "GET", "/users/{p1}")
+	post := flaskFind(cs, "POST", "/users/{p1}")
+	if get == nil || post == nil {
+		t.Fatalf("expected GET+POST on /users/{p1}, got %+v", contractPaths(cs))
+	}
+	if get.SymbolID != "app.py::UserResource.get" {
+		t.Errorf("GET SymbolID = %q, want the per-verb method node", get.SymbolID)
+	}
+	if post.SymbolID != "app.py::UserResource.post" {
+		t.Errorf("POST SymbolID = %q, want the per-verb method node", post.SymbolID)
+	}
+	if get.Meta["framework"] != "flask" {
+		t.Errorf("framework = %v, want flask", get.Meta["framework"])
+	}
+	if names, _ := get.Meta["path_param_names"].([]string); len(names) != 1 || names[0] != "id" {
+		t.Errorf("path_param_names = %v, want [id]", get.Meta["path_param_names"])
+	}
+}
+
+func TestHTTPExtractor_Python_FlaskRestful_MultiPath(t *testing.T) {
+	src := []byte(`class ItemResource(Resource):
+    def get(self): ...
+    def delete(self): ...
+
+api.add_resource(ItemResource, '/items', '/items/<int:id>')
+`)
+	nodes := []*graph.Node{
+		flaskNode("app.py::ItemResource", "ItemResource", graph.KindType, 1),
+		flaskNode("app.py::ItemResource.get", "get", graph.KindMethod, 2),
+		flaskNode("app.py::ItemResource.delete", "delete", graph.KindMethod, 3),
+	}
+	cs := (&HTTPExtractor{}).Extract("app.py", src, nodes, nil)
+	want := []struct{ m, p string }{
+		{"GET", "/items"}, {"DELETE", "/items"},
+		{"GET", "/items/{p1}"}, {"DELETE", "/items/{p1}"},
+	}
+	for _, w := range want {
+		if flaskFind(cs, w.m, w.p) == nil {
+			t.Errorf("missing %s %s; got %v", w.m, w.p, contractPaths(cs))
+		}
+	}
+	if n := countFlask(cs); n != 4 {
+		t.Errorf("expected 4 flask contracts, got %d: %v", n, contractPaths(cs))
+	}
+}
+
+func TestHTTPExtractor_Python_FlaskRestful_UnknownClassFallback(t *testing.T) {
+	src := []byte(`api.add_resource(PlainClass, '/plain')`)
+	cs := (&HTTPExtractor{}).Extract("app.py", src, nil, nil)
+	if countFlask(cs) != 1 {
+		t.Fatalf("expected 1 GET fallback contract, got %v", contractPaths(cs))
+	}
+	if flaskFind(cs, "GET", "/plain") == nil {
+		t.Errorf("expected GET /plain fallback, got %v", contractPaths(cs))
+	}
+}
+
+func TestHTTPExtractor_Python_FlaskRestful_NoVerbMethods(t *testing.T) {
+	src := []byte(`class HelperResource(Resource):
+    def helper(self): ...
+
+api.add_resource(HelperResource, '/helper')
+`)
+	nodes := []*graph.Node{
+		flaskNode("app.py::HelperResource", "HelperResource", graph.KindType, 1),
+		flaskNode("app.py::HelperResource.helper", "helper", graph.KindMethod, 2),
+	}
+	cs := (&HTTPExtractor{}).Extract("app.py", src, nodes, nil)
+	get := flaskFind(cs, "GET", "/helper")
+	if get == nil || countFlask(cs) != 1 {
+		t.Fatalf("expected 1 GET fallback, got %v", contractPaths(cs))
+	}
+	if get.SymbolID != "app.py::HelperResource" {
+		t.Errorf("fallback SymbolID = %q, want the class node", get.SymbolID)
+	}
+}
+
+func TestHTTPExtractor_Python_AddURLRule_ViewFuncMethods(t *testing.T) {
+	src := []byte(`def handler(): ...
+
+app.add_url_rule('/regular', view_func=handler, methods=['POST', 'PUT'])
+`)
+	nodes := []*graph.Node{flaskNode("app.py::handler", "handler", graph.KindFunction, 1)}
+	cs := (&HTTPExtractor{}).Extract("app.py", src, nodes, nil)
+	post := flaskFind(cs, "POST", "/regular")
+	put := flaskFind(cs, "PUT", "/regular")
+	if post == nil || put == nil {
+		t.Fatalf("expected POST+PUT on /regular, got %v", contractPaths(cs))
+	}
+	if post.SymbolID != "app.py::handler" {
+		t.Errorf("POST SymbolID = %q, want app.py::handler", post.SymbolID)
+	}
+}
+
+func TestHTTPExtractor_Python_AddURLRule_DefaultGET(t *testing.T) {
+	src := []byte(`def h(): ...
+app.add_url_rule('/x', view_func=h)
+`)
+	nodes := []*graph.Node{flaskNode("app.py::h", "h", graph.KindFunction, 1)}
+	cs := (&HTTPExtractor{}).Extract("app.py", src, nodes, nil)
+	if flaskFind(cs, "GET", "/x") == nil || countFlask(cs) != 1 {
+		t.Errorf("expected 1 GET /x, got %v", contractPaths(cs))
+	}
+}
+
+func TestHTTPExtractor_Python_AddURLRule_PositionalViewFunc(t *testing.T) {
+	src := []byte(`def h(): ...
+app.add_url_rule('/y', h)
+`)
+	nodes := []*graph.Node{flaskNode("app.py::h", "h", graph.KindFunction, 1)}
+	cs := (&HTTPExtractor{}).Extract("app.py", src, nodes, nil)
+	got := flaskFind(cs, "GET", "/y")
+	if got == nil {
+		t.Fatalf("expected GET /y, got %v", contractPaths(cs))
+	}
+	if got.SymbolID != "app.py::h" {
+		t.Errorf("SymbolID = %q, want app.py::h", got.SymbolID)
+	}
+}
+
+func TestHTTPExtractor_Python_AddURLRule_NoViewFunc(t *testing.T) {
+	src := []byte(`app.add_url_rule('/z')`)
+	cs := (&HTTPExtractor{}).Extract("app.py", src, nil, nil)
+	if countFlask(cs) != 0 {
+		t.Errorf("expected 0 contracts without view_func, got %v", contractPaths(cs))
+	}
+}
+
+func TestHTTPExtractor_Python_FlaskRestful_Multiline(t *testing.T) {
+	src := []byte(`class UserResource(Resource):
+    def get(self): ...
+
+api.add_resource(
+    UserResource,
+    '/users',
+)
+`)
+	nodes := []*graph.Node{
+		flaskNode("app.py::UserResource", "UserResource", graph.KindType, 1),
+		flaskNode("app.py::UserResource.get", "get", graph.KindMethod, 2),
+	}
+	cs := (&HTTPExtractor{}).Extract("app.py", src, nodes, nil)
+	if flaskFind(cs, "GET", "/users") == nil {
+		t.Errorf("expected multiline add_resource to resolve GET /users, got %v", contractPaths(cs))
+	}
+}
+
+func countFlask(cs []Contract) int {
+	n := 0
+	for _, c := range cs {
+		if c.Meta["framework"] == "flask" {
+			n++
+		}
+	}
+	return n
+}
+
+func contractPaths(cs []Contract) []string {
+	var out []string
+	for _, c := range cs {
+		out = append(out, c.Meta["method"].(string)+" "+c.Meta["path"].(string))
+	}
+	return out
+}

--- a/internal/dataflow/dataflow.go
+++ b/internal/dataflow/dataflow.go
@@ -241,28 +241,9 @@ func confidenceFromEdges(edges []EdgeStep) float64 {
 }
 
 func confidenceFromOrigin(origin, kind string) float64 {
-	switch origin {
-	case graph.OriginLSPResolved:
-		return 1
-	case graph.OriginLSPDispatch:
-		return 0.95
-	case graph.OriginASTResolved:
-		return 0.9
-	case graph.OriginASTInferred:
-		return 0.7
-	case graph.OriginTextMatched:
-		return 0.4
-	}
-	// Unstamped: fall back to the kind tier. value_flow is intra-
-	// procedural and cheap to ground; arg_of / returns_to are
-	// cross-call and start lower until the resolver lifts them.
-	switch kind {
-	case string(graph.EdgeValueFlow):
-		return 0.85
-	case string(graph.EdgeArgOf), string(graph.EdgeReturnsTo):
-		return 0.7
-	}
-	return 0.5
+	// Delegates to the shared graph.EdgeTierScore so dataflow and callpath
+	// compute path confidence from one provenance→weight mapping.
+	return graph.EdgeTierScore(origin, graph.EdgeKind(kind))
 }
 
 // TaintPattern resolves a source / sink pattern against the live

--- a/internal/graph/cpp_types.go
+++ b/internal/graph/cpp_types.go
@@ -1,0 +1,57 @@
+package graph
+
+import "strings"
+
+// NormalizeCppType reduces a C++ type spelling to a stable comparison key used
+// by both the extractor (stamping parameter types) and the overload resolver
+// (normalizing call-site argument hints), so the two always compare in the same
+// space. It strips template arguments, cv-qualifiers, ref/ptr punctuation, and
+// namespace qualifiers, and canonicalises a few stdlib aliases — while keeping
+// the integer/float ladder distinct (int vs long) so genuinely different
+// overloads stay rankable.
+func NormalizeCppType(raw string) string {
+	s := stripCppTemplateArgs(raw)
+	s = strings.ReplaceAll(s, "&&", " ")
+	s = strings.ReplaceAll(s, "&", " ")
+	s = strings.ReplaceAll(s, "*", " ")
+	fields := strings.Fields(s)
+	kept := fields[:0]
+	for _, f := range fields {
+		if f == "const" || f == "volatile" {
+			continue
+		}
+		kept = append(kept, f)
+	}
+	s = strings.Join(kept, " ")
+	if i := strings.LastIndex(s, "::"); i >= 0 {
+		s = s[i+2:]
+	}
+	s = strings.TrimSpace(s)
+	switch s {
+	case "string", "basic_string", "string_view":
+		return "string"
+	case "unsigned", "unsigned int", "uint", "size_t", "uint32_t", "uint64_t":
+		return "unsigned"
+	}
+	return s
+}
+
+func stripCppTemplateArgs(s string) string {
+	depth := 0
+	var b strings.Builder
+	for _, r := range s {
+		switch r {
+		case '<':
+			depth++
+		case '>':
+			if depth > 0 {
+				depth--
+			}
+		default:
+			if depth == 0 {
+				b.WriteRune(r)
+			}
+		}
+	}
+	return b.String()
+}

--- a/internal/graph/edge.go
+++ b/internal/graph/edge.go
@@ -714,6 +714,36 @@ func DefaultOriginFor(kind EdgeKind, confidence float64, semanticSource string) 
 	return OriginTextMatched
 }
 
+// EdgeTierScore maps an edge's Origin provenance tier to a 0..1 confidence
+// weight, falling back to the edge kind when Origin is unstamped. It is the one
+// shared provenance→confidence mapping consumed by the dataflow and callpath
+// path-confidence rankers, so a path's confidence means the same thing across
+// flow_between, taint_paths and trace_path.
+func EdgeTierScore(origin string, kind EdgeKind) float64 {
+	switch origin {
+	case OriginLSPResolved:
+		return 1
+	case OriginLSPDispatch:
+		return 0.95
+	case OriginASTResolved:
+		return 0.9
+	case OriginASTInferred:
+		return 0.7
+	case OriginTextMatched:
+		return 0.4
+	}
+	// Unstamped: fall back to the kind tier. value_flow is intra-procedural
+	// and cheap to ground; arg_of / returns_to are cross-call and start lower
+	// until the resolver lifts them.
+	switch kind {
+	case EdgeValueFlow:
+		return 0.85
+	case EdgeArgOf, EdgeReturnsTo:
+		return 0.7
+	}
+	return 0.5
+}
+
 // Provenance-attenuation weights for graph centrality (HITS /
 // PageRank) and the rerank provenance signal. Code intelligence
 // enriched by LSP providers (gopls, clangd, tsserver) materialises a

--- a/internal/graph/edge.go
+++ b/internal/graph/edge.go
@@ -600,7 +600,17 @@ const (
 	OriginASTResolved = "ast_resolved"
 	OriginASTInferred = "ast_inferred"
 	OriginTextMatched = "text_matched"
+	// OriginSpeculative ranks strictly below text_matched: a best-guess
+	// dynamic-dispatch edge (obj[name]() / getattr / decorator registry) that
+	// is present-but-hidden-by-default. Always carries Meta[MetaSpeculative]=true
+	// so queries exclude it unless the caller opts in.
+	OriginSpeculative = "speculative"
 )
+
+// MetaSpeculative is the edge Meta key marking a speculative (best-guess)
+// edge. It is the single source of truth for default-exclusion: any
+// edge-returning surface drops these unless the caller opts in.
+const MetaSpeculative = "speculative"
 
 // OriginRank returns a numeric rank for origin comparison. Higher = more
 // confident. Unknown or empty origin returns 0 so it sorts below all known
@@ -608,17 +618,29 @@ const (
 func OriginRank(origin string) int {
 	switch origin {
 	case OriginLSPResolved:
-		return 5
+		return 6
 	case OriginLSPDispatch:
-		return 4
+		return 5
 	case OriginASTResolved:
-		return 3
+		return 4
 	case OriginASTInferred:
-		return 2
+		return 3
 	case OriginTextMatched:
+		return 2
+	case OriginSpeculative:
 		return 1
 	}
 	return 0
+}
+
+// IsSpeculative reports whether the edge is a best-guess speculative edge
+// (excluded from default query results).
+func (e *Edge) IsSpeculative() bool {
+	if e == nil || e.Meta == nil {
+		return false
+	}
+	v, _ := e.Meta[MetaSpeculative].(bool)
+	return v
 }
 
 // MeetsMinTier returns true when origin is at least as confident as minTier.

--- a/internal/graph/epistemic_boundary.go
+++ b/internal/graph/epistemic_boundary.go
@@ -1,0 +1,187 @@
+package graph
+
+import (
+	"sort"
+	"strings"
+)
+
+// EpistemicBoundary names one unresolved/dynamic-dispatch site that makes a
+// traversal count a *floor* rather than an exact number. It is the honest
+// answer to "could the real blast radius / reachable set be larger?" — yes,
+// because the resolver could not bind this site, so an unknown number of
+// callers/callees hide behind it.
+//
+// It is an attribute of a *traversal*, not a graph element: no new NodeKind or
+// EdgeKind is introduced. Boundaries are recorded at exactly the sites a walk
+// would otherwise silently drop (an out-edge to an `unresolved::*` target) or
+// where dynamic dispatch is structurally possible (the seed implements an
+// interface, so callers may invoke it through that interface).
+type EpistemicBoundary struct {
+	SeedID    string         `json:"seed_id"`
+	SeedName  string         `json:"seed_name,omitempty"`
+	Target    string         `json:"target,omitempty"`
+	EdgeKind  string         `json:"edge_kind,omitempty"`
+	Reason    BoundaryReason `json:"reason"`
+	Direction string         `json:"direction"` // "callers" | "callees"
+}
+
+// BoundaryReason classifies why a boundary makes the count a floor. The
+// vocabulary aligns with the resolution-outcomes taxonomy's dynamic-dispatch
+// concept while staying graph-local (no name-resolution needed to compute it).
+type BoundaryReason string
+
+const (
+	// BoundaryDynamicDispatch: an out call/reference edge whose target the
+	// resolver left as `unresolved::*` — the callee set could be larger.
+	BoundaryDynamicDispatch BoundaryReason = "dynamic_dispatch"
+	// BoundaryInterfaceDispatch: the node implements/overrides an interface
+	// method, so callers may invoke it through the interface via dispatch that
+	// is not attributed to this node — the caller set could be larger.
+	BoundaryInterfaceDispatch BoundaryReason = "interface_dispatch"
+	// BoundaryExternal: an edge into the `external::` namespace — the chain
+	// leaves the indexed code. Listed for transparency; not floor-making.
+	BoundaryExternal BoundaryReason = "external_boundary"
+	// BoundaryStub: an edge into a stdlib/builtin/module stub. Listed; not
+	// floor-making (an external stdlib call adds no in-repo callers/callees).
+	BoundaryStub BoundaryReason = "stub"
+)
+
+// maxBoundaries caps the per-result boundary list so a pathological hub cannot
+// bloat a response. Mirrors impact.go's maxPerTier.
+const maxBoundaries = 50
+
+// ClassifyDroppedTarget classifies an edge target a traversal could not follow.
+// ok=false means it is an ordinary in-graph node (follow it normally).
+func ClassifyDroppedTarget(targetID string, kind EdgeKind) (BoundaryReason, bool) {
+	if IsUnresolvedTarget(targetID) {
+		return BoundaryDynamicDispatch, true
+	}
+	if strings.HasPrefix(targetID, "external::") {
+		return BoundaryExternal, true
+	}
+	if IsStub(targetID) {
+		return BoundaryStub, true
+	}
+	return "", false
+}
+
+// CalleeBoundaries scans the out-edges of the given nodes for call/reference
+// targets a forward (callee-direction) walk could not follow. Each such target
+// means the reachable callee set could be larger than what was returned.
+func CalleeBoundaries(g Store, nodeIDs []string, limit int) []EpistemicBoundary {
+	if g == nil {
+		return nil
+	}
+	if limit <= 0 {
+		limit = maxBoundaries
+	}
+	seen := map[string]bool{}
+	var out []EpistemicBoundary
+	for _, id := range nodeIDs {
+		for _, e := range g.GetOutEdges(id) {
+			if e.Kind != EdgeCalls && e.Kind != EdgeReferences {
+				continue
+			}
+			reason, ok := ClassifyDroppedTarget(e.To, e.Kind)
+			if !ok {
+				continue
+			}
+			key := id + "\x00" + e.To
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			out = append(out, EpistemicBoundary{
+				SeedID:    id,
+				SeedName:  nameForID(g, id),
+				Target:    boundaryTargetName(e.To),
+				EdgeKind:  string(e.Kind),
+				Reason:    reason,
+				Direction: "callees",
+			})
+			if len(out) >= limit {
+				return sortBoundaries(out)
+			}
+		}
+	}
+	return sortBoundaries(out)
+}
+
+// CallerBoundaries flags nodes whose *caller* count is a floor because dynamic
+// dispatch into them is structurally possible: each node that implements or
+// overrides an interface method may be reached through that interface by
+// callers not attributed to it directly. It names the interface so an agent
+// can run find_implementations / get_callers on it to widen the picture.
+func CallerBoundaries(g Store, nodeIDs []string, limit int) []EpistemicBoundary {
+	if g == nil {
+		return nil
+	}
+	if limit <= 0 {
+		limit = maxBoundaries
+	}
+	seen := map[string]bool{}
+	var out []EpistemicBoundary
+	for _, id := range nodeIDs {
+		for _, e := range g.GetOutEdges(id) {
+			if e.Kind != EdgeImplements && e.Kind != EdgeOverrides {
+				continue
+			}
+			key := id + "\x00" + e.To
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			out = append(out, EpistemicBoundary{
+				SeedID:    id,
+				SeedName:  nameForID(g, id),
+				Target:    boundaryTargetName(e.To),
+				EdgeKind:  string(e.Kind),
+				Reason:    BoundaryInterfaceDispatch,
+				Direction: "callers",
+			})
+			if len(out) >= limit {
+				return sortBoundaries(out)
+			}
+		}
+	}
+	return sortBoundaries(out)
+}
+
+// LowerBoundCaveat reports whether the boundary set makes the count a genuine
+// floor. Only dynamic-dispatch / interface-dispatch boundaries qualify: an
+// external/stdlib stub edge is listed for transparency but adds no hidden
+// in-repo callers/callees, so by itself it must not raise the flag (otherwise
+// nearly every symbol with a stdlib call would be flagged — see the design's
+// over-flagging guard).
+func LowerBoundCaveat(boundaries []EpistemicBoundary) bool {
+	for _, b := range boundaries {
+		if b.Reason == BoundaryDynamicDispatch || b.Reason == BoundaryInterfaceDispatch {
+			return true
+		}
+	}
+	return false
+}
+
+func boundaryTargetName(id string) string {
+	if IsUnresolvedTarget(id) {
+		return UnresolvedName(id)
+	}
+	return id
+}
+
+func nameForID(g Store, id string) string {
+	if n := g.GetNode(id); n != nil {
+		return n.Name
+	}
+	return ""
+}
+
+func sortBoundaries(bs []EpistemicBoundary) []EpistemicBoundary {
+	sort.SliceStable(bs, func(i, j int) bool {
+		if bs[i].SeedID != bs[j].SeedID {
+			return bs[i].SeedID < bs[j].SeedID
+		}
+		return bs[i].Target < bs[j].Target
+	})
+	return bs
+}

--- a/internal/graph/epistemic_boundary_test.go
+++ b/internal/graph/epistemic_boundary_test.go
@@ -1,0 +1,96 @@
+package graph
+
+import "testing"
+
+func boundaryGraph() *Graph {
+	g := New()
+	for _, id := range []string{"A", "B", "C"} {
+		g.AddNode(&Node{ID: id, Kind: KindMethod, Name: id})
+	}
+	// A implements an interface method → caller-side dispatch boundary.
+	g.AddEdge(&Edge{From: "A", To: "iface::I.M", Kind: EdgeImplements, Origin: OriginASTResolved})
+	// B calls an unresolved (dynamic-dispatch) target → callee-side floor.
+	g.AddEdge(&Edge{From: "B", To: "unresolved::handler", Kind: EdgeCalls, Origin: OriginASTInferred})
+	// C calls a stdlib stub → listed but not floor-making.
+	g.AddEdge(&Edge{From: "C", To: "stdlib::fmt.Println", Kind: EdgeCalls, Origin: OriginASTResolved})
+	return g
+}
+
+func TestCalleeBoundaries(t *testing.T) {
+	g := boundaryGraph()
+	bs := CalleeBoundaries(g, []string{"B", "C"}, 0)
+	if len(bs) != 2 {
+		t.Fatalf("expected 2 callee boundaries, got %d: %+v", len(bs), bs)
+	}
+	byReason := map[BoundaryReason]EpistemicBoundary{}
+	for _, b := range bs {
+		byReason[b.Reason] = b
+		if b.Direction != "callees" {
+			t.Errorf("expected callees direction, got %s", b.Direction)
+		}
+	}
+	if d, ok := byReason[BoundaryDynamicDispatch]; !ok || d.Target != "handler" {
+		t.Errorf("expected dynamic_dispatch boundary on 'handler', got %+v", byReason)
+	}
+	if _, ok := byReason[BoundaryStub]; !ok {
+		t.Errorf("expected stub boundary for stdlib call, got %+v", byReason)
+	}
+}
+
+func TestCallerBoundaries(t *testing.T) {
+	g := boundaryGraph()
+	bs := CallerBoundaries(g, []string{"A"}, 0)
+	if len(bs) != 1 {
+		t.Fatalf("expected 1 caller boundary, got %d: %+v", len(bs), bs)
+	}
+	b := bs[0]
+	if b.Reason != BoundaryInterfaceDispatch || b.Direction != "callers" {
+		t.Errorf("unexpected boundary: %+v", b)
+	}
+	// A method that implements nothing has no caller boundary.
+	if got := CallerBoundaries(g, []string{"B"}, 0); len(got) != 0 {
+		t.Errorf("expected no boundary for non-implementing node, got %+v", got)
+	}
+}
+
+func TestLowerBoundCaveat(t *testing.T) {
+	cases := []struct {
+		name string
+		bs   []EpistemicBoundary
+		want bool
+	}{
+		{"empty", nil, false},
+		{"dynamic", []EpistemicBoundary{{Reason: BoundaryDynamicDispatch}}, true},
+		{"interface", []EpistemicBoundary{{Reason: BoundaryInterfaceDispatch}}, true},
+		{"stub only", []EpistemicBoundary{{Reason: BoundaryStub}}, false},
+		{"external only", []EpistemicBoundary{{Reason: BoundaryExternal}}, false},
+		{"mixed", []EpistemicBoundary{{Reason: BoundaryStub}, {Reason: BoundaryDynamicDispatch}}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := LowerBoundCaveat(tc.bs); got != tc.want {
+				t.Errorf("LowerBoundCaveat = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClassifyDroppedTarget(t *testing.T) {
+	cases := []struct {
+		target string
+		kind   EdgeKind
+		reason BoundaryReason
+		ok     bool
+	}{
+		{"unresolved::Foo", EdgeCalls, BoundaryDynamicDispatch, true},
+		{"external::lodash.map", EdgeCalls, BoundaryExternal, true},
+		{"stdlib::fmt.Println", EdgeCalls, BoundaryStub, true},
+		{"pkg/x.go::Real", EdgeCalls, "", false},
+	}
+	for _, tc := range cases {
+		reason, ok := ClassifyDroppedTarget(tc.target, tc.kind)
+		if ok != tc.ok || reason != tc.reason {
+			t.Errorf("ClassifyDroppedTarget(%q) = (%q,%v), want (%q,%v)", tc.target, reason, ok, tc.reason, tc.ok)
+		}
+	}
+}

--- a/internal/graph/speculative_tier_test.go
+++ b/internal/graph/speculative_tier_test.go
@@ -1,0 +1,29 @@
+package graph
+
+import "testing"
+
+func TestOriginRank_Speculative(t *testing.T) {
+	if OriginRank(OriginSpeculative) >= OriginRank(OriginTextMatched) {
+		t.Errorf("speculative (%d) must rank below text_matched (%d)",
+			OriginRank(OriginSpeculative), OriginRank(OriginTextMatched))
+	}
+	if OriginRank(OriginSpeculative) <= OriginRank("") {
+		t.Errorf("speculative must rank above unknown/empty")
+	}
+	if MeetsMinTier(OriginSpeculative, OriginTextMatched) {
+		t.Errorf("min_tier=text_matched must exclude speculative edges")
+	}
+	if !MeetsMinTier(OriginSpeculative, "") {
+		t.Errorf("empty min_tier must pass speculative edges")
+	}
+}
+
+func TestEdge_IsSpeculative(t *testing.T) {
+	if (&Edge{}).IsSpeculative() {
+		t.Errorf("plain edge must not be speculative")
+	}
+	e := &Edge{Meta: map[string]any{MetaSpeculative: true}}
+	if !e.IsSpeculative() {
+		t.Errorf("edge with MetaSpeculative=true must be speculative")
+	}
+}

--- a/internal/graph/store.go
+++ b/internal/graph/store.go
@@ -986,6 +986,41 @@ type CloneShingleReader interface {
 	LoadCloneShingles(repoPrefix string) (map[string][]uint64, error)
 }
 
+// RefFact is one durable resolved-reference fact: a reference edge from
+// FromID resolved TO ToID with the provenance tier that resolved it. Persisted
+// per source file so a reference's resolution is an auditable, diffable record
+// — gortex persists the RESOLVED target + its 5-tier provenance (unlike
+// codegraph, which persists only unresolved refs behind a flat provenance
+// string). The candidate set the resolver chose AMONG (when ambiguous) rides
+// in Candidates for later disambiguation / audit.
+type RefFact struct {
+	RepoPrefix string
+	FromID     string
+	ToID       string
+	Kind       string // edge kind (calls / references / …)
+	RefName    string // the referenced symbol's bare name
+	Line       int
+	Origin     string // provenance tier (lsp_resolved … text_matched)
+	Tier       string // coarse provenance label
+	Candidates []string
+	FilePath   string // source file (denormalized for indexed per-file queries)
+	Lang       string
+}
+
+// RefFactsWriter is an optional capability backends MAY implement to persist
+// per-file resolved-reference facts in a dedicated sidecar table. Sibling of
+// CloneShingleWriter / FileMtimeWriter. Empty input is a no-op.
+type RefFactsWriter interface {
+	BulkSetRefFacts(repoPrefix string, facts []RefFact) error
+	DeleteRefFactsByFiles(repoPrefix string, files []string) error
+}
+
+// RefFactsReader is the read side of RefFactsWriter: the persisted facts for a
+// set of source files (all files when files is empty), as the audit/diff seed.
+type RefFactsReader interface {
+	LoadRefFactsByFiles(repoPrefix string, files []string) ([]RefFact, error)
+}
+
 // ChurnEnrichment is one node's git-churn enrichment, moved out of
 // nodes.meta into a typed sidecar (change A). Maps 1:1 to the payload
 // internal/churn.EnrichGraph used to stamp on Meta["churn"]/["churn_meta"].

--- a/internal/graph/store_sqlite/schema.go
+++ b/internal/graph/store_sqlite/schema.go
@@ -95,6 +95,29 @@ CREATE TABLE IF NOT EXISTS clone_shingles (
     shingles    BLOB
 ) WITHOUT ROWID;
 
+-- ref_facts is the resolved-reference sidecar: one row per reference edge
+-- that resolved to a concrete target, recording the target + the provenance
+-- tier that resolved it. Denormalized file_path + lang make "all reference
+-- facts originating in file X" a single indexed query (the scope unit for
+-- incremental re-resolution and the audit/diff surface). repo_prefix scopes
+-- per-repo. PK is (repo_prefix, from_id, to_id, kind, line) so re-resolving a
+-- file replaces its facts in place; WITHOUT ROWID — the PK index IS the table.
+CREATE TABLE IF NOT EXISTS ref_facts (
+    repo_prefix TEXT NOT NULL DEFAULT '',
+    from_id     TEXT NOT NULL,
+    to_id       TEXT NOT NULL,
+    kind        TEXT NOT NULL,
+    ref_name    TEXT NOT NULL DEFAULT '',
+    line        INTEGER NOT NULL DEFAULT 0,
+    origin      TEXT NOT NULL DEFAULT '',
+    tier        TEXT NOT NULL DEFAULT '',
+    candidates  TEXT NOT NULL DEFAULT '',
+    file_path   TEXT NOT NULL DEFAULT '',
+    lang        TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (repo_prefix, from_id, to_id, kind, line)
+) WITHOUT ROWID;
+CREATE INDEX IF NOT EXISTS ref_facts_by_file ON ref_facts(repo_prefix, file_path);
+
 CREATE TABLE IF NOT EXISTS vectors (
     node_id TEXT PRIMARY KEY,
     dims    INTEGER NOT NULL,

--- a/internal/graph/store_sqlite/store_reffacts.go
+++ b/internal/graph/store_sqlite/store_reffacts.go
@@ -1,0 +1,165 @@
+package store_sqlite
+
+import (
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Compile-time assertions that the SQLite Store satisfies the optional
+// reference-facts persistence capability. Persisting resolved-reference facts
+// in the same backend the graph lives in makes a reference's resolution an
+// auditable, diffable record and a warm-restart seed.
+var (
+	_ graph.RefFactsWriter = (*Store)(nil)
+	_ graph.RefFactsReader = (*Store)(nil)
+)
+
+// refFactChunk bounds rows per multi-row INSERT. 11 params/row; 80 rows = 880
+// host params, under SQLite's 999 default. Mirrors shingleChunk.
+const refFactChunk = 80
+
+// candidate-list separator (unit separator — never appears in identifiers).
+const refFactCandSep = "\x1f"
+
+func encodeCandidates(c []string) string { return strings.Join(c, refFactCandSep) }
+
+func decodeCandidates(s string) []string {
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, refFactCandSep)
+}
+
+// BulkSetRefFacts persists resolved-reference facts for one repo prefix in a
+// single transaction, chunked under the host-parameter limit. Idempotent on
+// (repo_prefix, from_id, to_id, kind, line). Empty input is a no-op.
+func (s *Store) BulkSetRefFacts(repoPrefix string, facts []graph.RefFact) error {
+	if len(facts) == 0 {
+		return nil
+	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck // rollback after Commit is a no-op
+
+	for start := 0; start < len(facts); start += refFactChunk {
+		end := start + refFactChunk
+		if end > len(facts) {
+			end = len(facts)
+		}
+		batch := facts[start:end]
+		args := make([]any, 0, len(batch)*11)
+		stmt := make([]byte, 0, 96+len(batch)*24)
+		stmt = append(stmt, "INSERT OR REPLACE INTO ref_facts (repo_prefix, from_id, to_id, kind, ref_name, line, origin, tier, candidates, file_path, lang) VALUES "...)
+		for i, f := range batch {
+			if i > 0 {
+				stmt = append(stmt, ',')
+			}
+			stmt = append(stmt, "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"...)
+			args = append(args, repoPrefix, f.FromID, f.ToID, f.Kind, f.RefName, f.Line, f.Origin, f.Tier, encodeCandidates(f.Candidates), f.FilePath, f.Lang)
+		}
+		if _, err := tx.Exec(string(stmt), args...); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// DeleteRefFactsByFiles drops all facts sourced in the supplied files for one
+// repo prefix, chunked into `file_path IN (…)` DELETEs. Empty input is a no-op.
+func (s *Store) DeleteRefFactsByFiles(repoPrefix string, files []string) error {
+	if len(files) == 0 {
+		return nil
+	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck // rollback after Commit is a no-op
+
+	for start := 0; start < len(files); start += refFactChunk {
+		end := start + refFactChunk
+		if end > len(files) {
+			end = len(files)
+		}
+		chunk := files[start:end]
+		args := make([]any, 0, len(chunk)+1)
+		args = append(args, repoPrefix)
+		stmt := make([]byte, 0, 64+len(chunk)*2)
+		stmt = append(stmt, "DELETE FROM ref_facts WHERE repo_prefix = ? AND file_path IN ("...)
+		for i, f := range chunk {
+			if i > 0 {
+				stmt = append(stmt, ',')
+			}
+			stmt = append(stmt, '?')
+			args = append(args, f)
+		}
+		stmt = append(stmt, ')')
+		if _, err := tx.Exec(string(stmt), args...); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// LoadRefFactsByFiles returns the persisted facts for one repo prefix, scoped
+// to the given files (all files when files is empty). Always non-nil.
+func (s *Store) LoadRefFactsByFiles(repoPrefix string, files []string) ([]graph.RefFact, error) {
+	out := []graph.RefFact{}
+	scan := func(query string, args ...any) error {
+		rows, err := s.db.Query(query, args...)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = rows.Close() }()
+		for rows.Next() {
+			var f graph.RefFact
+			var cand string
+			if err := rows.Scan(&f.FromID, &f.ToID, &f.Kind, &f.RefName, &f.Line, &f.Origin, &f.Tier, &cand, &f.FilePath, &f.Lang); err != nil {
+				return err
+			}
+			f.RepoPrefix = repoPrefix
+			f.Candidates = decodeCandidates(cand)
+			out = append(out, f)
+		}
+		return rows.Err()
+	}
+	const cols = `from_id, to_id, kind, ref_name, line, origin, tier, candidates, file_path, lang`
+	if len(files) == 0 {
+		if err := scan(`SELECT `+cols+` FROM ref_facts WHERE repo_prefix = ?`, repoPrefix); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}
+	for start := 0; start < len(files); start += refFactChunk {
+		end := start + refFactChunk
+		if end > len(files) {
+			end = len(files)
+		}
+		chunk := files[start:end]
+		args := make([]any, 0, len(chunk)+1)
+		args = append(args, repoPrefix)
+		stmt := make([]byte, 0, 96+len(chunk)*2)
+		stmt = append(stmt, "SELECT "+cols+" FROM ref_facts WHERE repo_prefix = ? AND file_path IN ("...)
+		for i, f := range chunk {
+			if i > 0 {
+				stmt = append(stmt, ',')
+			}
+			stmt = append(stmt, '?')
+			args = append(args, f)
+		}
+		stmt = append(stmt, ')')
+		if err := scan(string(stmt), args...); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}

--- a/internal/graph/store_sqlite/store_reffacts_test.go
+++ b/internal/graph/store_sqlite/store_reffacts_test.go
@@ -1,0 +1,100 @@
+package store_sqlite_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+)
+
+func openRefFactStore(t *testing.T) *store_sqlite.Store {
+	t.Helper()
+	s, err := store_sqlite.Open(filepath.Join(t.TempDir(), "rf.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func TestRefFacts_Roundtrip(t *testing.T) {
+	s := openRefFactStore(t)
+	facts := []graph.RefFact{
+		{RepoPrefix: "", FromID: "a.go::A", ToID: "b.go::B", Kind: "calls", RefName: "B", Line: 7, Origin: "ast_resolved", Tier: "ast", FilePath: "a.go", Lang: "go", Candidates: []string{"b.go::B", "c.go::B"}},
+		{RepoPrefix: "", FromID: "a.go::A", ToID: "d.go::D", Kind: "references", RefName: "D", Line: 9, Origin: "lsp_resolved", Tier: "lsp", FilePath: "a.go", Lang: "go"},
+	}
+	require.NoError(t, s.BulkSetRefFacts("", facts))
+
+	got, err := s.LoadRefFactsByFiles("", []string{"a.go"})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	byTo := map[string]graph.RefFact{}
+	for _, f := range got {
+		byTo[f.ToID] = f
+	}
+	require.Equal(t, "ast_resolved", byTo["b.go::B"].Origin)
+	require.Equal(t, []string{"b.go::B", "c.go::B"}, byTo["b.go::B"].Candidates)
+	require.Equal(t, 7, byTo["b.go::B"].Line)
+	require.Equal(t, "lsp_resolved", byTo["d.go::D"].Origin)
+
+	// LoadRefFactsByFiles with empty file list returns all for the repo.
+	all, err := s.LoadRefFactsByFiles("", nil)
+	require.NoError(t, err)
+	require.Len(t, all, 2)
+}
+
+func TestRefFacts_DeleteByFile(t *testing.T) {
+	s := openRefFactStore(t)
+	require.NoError(t, s.BulkSetRefFacts("", []graph.RefFact{
+		{FromID: "a.go::A", ToID: "x", Kind: "calls", FilePath: "a.go"},
+		{FromID: "b.go::B", ToID: "y", Kind: "calls", FilePath: "b.go"},
+	}))
+	require.NoError(t, s.DeleteRefFactsByFiles("", []string{"a.go"}))
+	got, err := s.LoadRefFactsByFiles("", nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "b.go", got[0].FilePath)
+}
+
+func TestRefFacts_RepoScoping(t *testing.T) {
+	s := openRefFactStore(t)
+	require.NoError(t, s.BulkSetRefFacts("repoA", []graph.RefFact{{FromID: "f::A", ToID: "tA", Kind: "calls", FilePath: "f.go"}}))
+	require.NoError(t, s.BulkSetRefFacts("repoB", []graph.RefFact{{FromID: "f::A", ToID: "tB", Kind: "calls", FilePath: "f.go"}}))
+
+	a, err := s.LoadRefFactsByFiles("repoA", []string{"f.go"})
+	require.NoError(t, err)
+	require.Len(t, a, 1)
+	require.Equal(t, "tA", a[0].ToID)
+
+	// Deleting repoA's file must not touch repoB.
+	require.NoError(t, s.DeleteRefFactsByFiles("repoA", []string{"f.go"}))
+	b, err := s.LoadRefFactsByFiles("repoB", []string{"f.go"})
+	require.NoError(t, err)
+	require.Len(t, b, 1)
+	require.Equal(t, "tB", b[0].ToID)
+}
+
+func TestRefFacts_Chunking(t *testing.T) {
+	s := openRefFactStore(t)
+	const n = 500 // > refFactChunk (80)
+	facts := make([]graph.RefFact, n)
+	for i := range facts {
+		facts[i] = graph.RefFact{FromID: fmt.Sprintf("a.go::f%d", i), ToID: fmt.Sprintf("t%d", i), Kind: "calls", FilePath: "a.go"}
+	}
+	require.NoError(t, s.BulkSetRefFacts("", facts))
+	got, err := s.LoadRefFactsByFiles("", []string{"a.go"})
+	require.NoError(t, err)
+	require.Len(t, got, n)
+}
+
+func TestRefFacts_EmptyNoop(t *testing.T) {
+	s := openRefFactStore(t)
+	require.NoError(t, s.BulkSetRefFacts("", nil))
+	require.NoError(t, s.DeleteRefFactsByFiles("", nil))
+	got, err := s.LoadRefFactsByFiles("", nil)
+	require.NoError(t, err)
+	require.Empty(t, got)
+}

--- a/internal/indexer/affected_set.go
+++ b/internal/indexer/affected_set.go
@@ -1,0 +1,75 @@
+package indexer
+
+import (
+	"os"
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// scopedGlobalPassesEnabled reports whether incremental reindex should scope
+// the global inference passes (InferImplements / InferOverrides) to the
+// changed-affected type set instead of re-running them over the whole graph.
+// GORTEX_INDEX_SCOPED_GLOBAL_PASSES overrides the config key. ON by default.
+func (idx *Indexer) scopedGlobalPassesEnabled() bool {
+	if v := os.Getenv("GORTEX_INDEX_SCOPED_GLOBAL_PASSES"); v != "" {
+		return v == "1" || strings.EqualFold(v, "true")
+	}
+	return idx.config.ScopedGlobalPassesEnabledOrDefault()
+}
+
+// affectedTypeSet computes the type/interface IDs whose inferred
+// implements/override edges a set of changed (stale) files can affect:
+//   - every KindType / KindInterface the changed files define (their inferred
+//     out/in edges were dropped on eviction), and
+//   - the owning type of every KindMethod in a changed file (a method add/remove
+//     changes the type's method-set, which can newly satisfy / break an
+//     interface defined in an unchanged file).
+//
+// types is the full re-check set; ifaces is the subset of changed interfaces
+// (every type must be re-checked against a changed interface). Re-checking
+// every (type, interface) pair with an endpoint in these sets re-lands exactly
+// the edges eviction dropped — add-parity with the full pass.
+func (idx *Indexer) affectedTypeSet(graphPaths []string) (types, ifaces map[string]bool) {
+	types = map[string]bool{}
+	ifaces = map[string]bool{}
+	for _, p := range graphPaths {
+		for _, n := range idx.graph.GetFileNodes(p) {
+			if n == nil {
+				continue
+			}
+			switch n.Kind {
+			case graph.KindType, graph.KindInterface:
+				types[n.ID] = true
+				if n.Kind == graph.KindInterface {
+					ifaces[n.ID] = true
+				}
+			case graph.KindMethod:
+				for _, e := range idx.graph.GetOutEdges(n.ID) {
+					if e.Kind == graph.EdgeMemberOf {
+						types[e.To] = true
+					}
+				}
+			}
+		}
+	}
+	return types, ifaces
+}
+
+// runScopedInferencePasses runs the implements/override inference passes scoped
+// to the types/interfaces a set of stale files can affect. Returns false when
+// scoping is disabled (caller should run the full passes). When nothing
+// type/interface-shaped changed, the passes are skipped entirely (the common
+// case for a function-body edit).
+func (idx *Indexer) runScopedInferencePasses(staleFiles []string) bool {
+	if !idx.scopedGlobalPassesEnabled() {
+		return false
+	}
+	types, ifaces := idx.affectedTypeSet(idx.graphFilePaths(staleFiles))
+	if len(types) == 0 && len(ifaces) == 0 {
+		return true // no type/interface change → no inferred edges to re-derive
+	}
+	idx.resolver.InferImplementsScoped(types, ifaces)
+	idx.resolver.InferOverridesScoped(types)
+	return true
+}

--- a/internal/indexer/capability_edges.go
+++ b/internal/indexer/capability_edges.go
@@ -140,6 +140,12 @@ func synthesizeCapabilityEdges(g graph.Store) (readsEnv, execProc, fieldAccess i
 	seen := map[string]bool{}
 	add := func(from, to string, kind graph.EdgeKind, origin, file string, line int, meta map[string]any) bool {
 		key := string(kind) + "\x00" + from + "\x00" + to
+		// Indirect mutations carry a `via`; key on it so a direct and an
+		// indirect write to the same field from the same method coexist as
+		// distinct-provenance edges.
+		if v, _ := meta["via"].(string); v != "" {
+			key += "\x00" + v
+		}
 		if seen[key] {
 			return false
 		}
@@ -179,6 +185,17 @@ func synthesizeCapabilityEdges(g graph.Store) (readsEnv, execProc, fieldAccess i
 			if add(e.From, e.To, graph.EdgeAccessesField, graph.OriginASTResolved, e.FilePath, e.Line, map[string]any{"access": mode}) {
 				fieldAccess++
 			}
+		}
+	}
+
+	// Indirect field mutations: `s.counter.Increment()` mutates counter, and
+	// `s.helper()` mutates whatever helper mutates — attributed transitively.
+	// Lower (ast_inferred) tier than the direct writes above; tagged indirect
+	// + via so it's distinguishable and downgradeable.
+	for _, s := range indirectMutationEdges(g) {
+		if add(s.from, s.to, graph.EdgeAccessesField, graph.OriginASTInferred, s.file, s.line,
+			map[string]any{"access": "write", "indirect": true, "via": s.via}) {
+			fieldAccess++
 		}
 	}
 

--- a/internal/indexer/cpp_overload_e2e_test.go
+++ b/internal/indexer/cpp_overload_e2e_test.go
@@ -1,0 +1,58 @@
+package indexer
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// callTargetName returns the resolved target's Name for the EdgeCalls edge from
+// `caller` to a function named `callee` (the resolved overload's enclosing
+// node's distinguishing meta).
+func cppCallTarget(t *testing.T, g *graph.Graph, caller string) *graph.Node {
+	t.Helper()
+	for _, n := range g.AllNodes() {
+		if n.Name != caller {
+			continue
+		}
+		for _, e := range g.GetOutEdges(n.ID) {
+			if e.Kind != graph.EdgeCalls {
+				continue
+			}
+			if tn := g.GetNode(e.To); tn != nil && tn.Name == "process" {
+				return tn
+			}
+		}
+	}
+	return nil
+}
+
+// TestCppOverload_ResolvesArithmetic indexes overloaded C++ functions and
+// asserts a call with a double literal resolves to process(double), and an int
+// literal to process(int) — in-engine, no clangd.
+func TestCppOverload_ResolvesArithmetic(t *testing.T) {
+	g := indexFixture(t, map[string]string{
+		"o.cpp": `void process(int x) { }
+void process(double x) { }
+
+void runDouble() { process(3.14); }
+void runInt() { process(42); }
+`,
+	})
+
+	dbl := cppCallTarget(t, g, "runDouble")
+	if dbl == nil {
+		t.Fatal("runDouble's process() call did not resolve")
+	}
+	if pt, _ := dbl.Meta["cpp_param_types"].(string); pt != "double" {
+		t.Errorf("runDouble should bind process(double), got param_types=%q (node %s)", pt, dbl.ID)
+	}
+
+	in := cppCallTarget(t, g, "runInt")
+	if in == nil {
+		t.Fatal("runInt's process() call did not resolve")
+	}
+	if pt, _ := in.Meta["cpp_param_types"].(string); pt != "int" {
+		t.Errorf("runInt should bind process(int), got param_types=%q (node %s)", pt, in.ID)
+	}
+}

--- a/internal/indexer/event_bus_synthesis.go
+++ b/internal/indexer/event_bus_synthesis.go
@@ -1,0 +1,128 @@
+package indexer
+
+import (
+	"encoding/json"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/contracts"
+)
+
+// eventBusBoundaries returns the configured event-bus boundaries for this
+// indexer, converting config specs to the contracts package's cycle-free
+// boundary type. The CODEGRAPH_EVENT_CONFIG env var (a JSON list, drop-in
+// compatible with pygraph/tsgraph) overrides .gortex.yaml's index.event_bus
+// when set and valid; GORTEX_EVENT_BUS_DISABLE=1 forces the bus off.
+func (idx *Indexer) eventBusBoundaries() []contracts.EventBusBoundary {
+	if os.Getenv("GORTEX_EVENT_BUS_DISABLE") == "1" {
+		return nil
+	}
+	specs := idx.config.EventBus
+	if env := strings.TrimSpace(os.Getenv("CODEGRAPH_EVENT_CONFIG")); env != "" {
+		if parsed, ok := parseEventConfigJSON(env); ok {
+			specs = parsed
+		}
+	}
+	if len(specs) == 0 {
+		return nil
+	}
+	out := make([]contracts.EventBusBoundary, 0, len(specs))
+	for _, s := range specs {
+		b := eventBusBoundaryFromSpec(s)
+		if b.Name == "" || (b.Callee == "" && b.CalleePattern == "" && b.Decorator == "" && b.Interface == "") {
+			continue // malformed spec: skip, never fail the index
+		}
+		out = append(out, b)
+	}
+	return out
+}
+
+func eventBusBoundaryFromSpec(s config.EventBusBoundarySpec) contracts.EventBusBoundary {
+	calleePattern := s.CalleePattern
+	if calleePattern == "" {
+		calleePattern = s.HookPattern // tsgraph alias
+	}
+	return contracts.EventBusBoundary{
+		Name:          s.Name,
+		Type:          s.Type,
+		Callee:        s.Callee,
+		CalleePattern: calleePattern,
+		Decorator:     s.Decorator,
+		Interface:     s.Interface,
+		TopicArg:      s.TopicArg,
+		Guards:        s.Guards,
+	}
+}
+
+// eventConfigJSONEntry is the CODEGRAPH_EVENT_CONFIG wire shape: each entry has
+// a top-level name/type plus a nested `match` block (pygraph/tsgraph format).
+type eventConfigJSONEntry struct {
+	Name  string `json:"name"`
+	Type  string `json:"type"`
+	Match struct {
+		Callee        string         `json:"callee"`
+		CalleePattern string         `json:"callee_pattern"`
+		HookPattern   string         `json:"hook_pattern"`
+		Decorator     string         `json:"decorator"`
+		Interface     string         `json:"interface"`
+		TopicArg      string         `json:"topic_arg"`
+		Args          map[string]any `json:"args"`
+		Guards        bool           `json:"guards"`
+	} `json:"match"`
+}
+
+// parseEventConfigJSON parses the env var into config specs. Returns ok=false
+// (so the caller falls back to .gortex.yaml) on malformed JSON.
+func parseEventConfigJSON(raw string) ([]config.EventBusBoundarySpec, bool) {
+	var entries []eventConfigJSONEntry
+	if err := json.Unmarshal([]byte(raw), &entries); err != nil {
+		return nil, false
+	}
+	out := make([]config.EventBusBoundarySpec, 0, len(entries))
+	for _, e := range entries {
+		topicArg := e.Match.TopicArg
+		if topicArg == "" {
+			// pygraph stores arg extraction under match.args{<out>:<int|str>};
+			// the topic/event_code/url key is the join key.
+			topicArg = eventArgTopicKey(e.Match.Args)
+		}
+		out = append(out, config.EventBusBoundarySpec{
+			Name:          e.Name,
+			Type:          e.Type,
+			Callee:        e.Match.Callee,
+			CalleePattern: e.Match.CalleePattern,
+			HookPattern:   e.Match.HookPattern,
+			Decorator:     e.Match.Decorator,
+			Interface:     e.Match.Interface,
+			TopicArg:      topicArg,
+			Guards:        e.Match.Guards,
+		})
+	}
+	return out, true
+}
+
+// eventArgTopicKey picks the arg whose extracted value should key the
+// producer↔consumer join from a pygraph-style match.args map, preferring
+// topic/event_code/url. The value (positional index or kwarg name) becomes
+// TopicArg.
+func eventArgTopicKey(args map[string]any) string {
+	for _, k := range []string{"topic", "event_code", "url", "channel", "subject"} {
+		if v, ok := args[k]; ok {
+			return argValueToTopicArg(v)
+		}
+	}
+	return ""
+}
+
+func argValueToTopicArg(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case float64:
+		// integer-valued positional index from JSON ("0", "1", ...)
+		return strconv.Itoa(int(t))
+	}
+	return ""
+}

--- a/internal/indexer/event_bus_synthesis_test.go
+++ b/internal/indexer/event_bus_synthesis_test.go
@@ -1,0 +1,113 @@
+package indexer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+func newEventBusIndexer(t *testing.T, specs []config.EventBusBoundarySpec) *Indexer {
+	t.Helper()
+	cfg := config.Default().Index
+	cfg.EventBus = specs
+	return New(graph.New(), parser.NewRegistry(), cfg, zap.NewNop())
+}
+
+func TestEventBusBoundaries_FromConfig(t *testing.T) {
+	idx := newEventBusIndexer(t, []config.EventBusBoundarySpec{
+		{Name: "k", Type: "producer", Callee: "p.send", TopicArg: "topic"},
+	})
+	b := idx.eventBusBoundaries()
+	require.Len(t, b, 1)
+	require.Equal(t, "k", b[0].Name)
+	require.Equal(t, "p.send", b[0].Callee)
+}
+
+func TestEventBusBoundaries_EnvOverride(t *testing.T) {
+	t.Setenv("CODEGRAPH_EVENT_CONFIG", `[{"name":"envbus","type":"consumer","match":{"callee_pattern":"EventSource","args":{"url":0}}}]`)
+	idx := newEventBusIndexer(t, []config.EventBusBoundarySpec{
+		{Name: "fromfile", Type: "producer", Callee: "x.y"},
+	})
+	b := idx.eventBusBoundaries()
+	require.Len(t, b, 1)
+	require.Equal(t, "envbus", b[0].Name, "env config must override index.event_bus")
+	require.Equal(t, "EventSource", b[0].CalleePattern)
+	require.Equal(t, "0", b[0].TopicArg, "args{url:0} should map to topic_arg 0")
+}
+
+func TestEventBusBoundaries_Disable(t *testing.T) {
+	t.Setenv("GORTEX_EVENT_BUS_DISABLE", "1")
+	idx := newEventBusIndexer(t, []config.EventBusBoundarySpec{
+		{Name: "k", Type: "producer", Callee: "p.send"},
+	})
+	require.Empty(t, idx.eventBusBoundaries())
+}
+
+func TestEventBusBoundaries_MalformedEnvFallsBack(t *testing.T) {
+	t.Setenv("CODEGRAPH_EVENT_CONFIG", `{not valid json`)
+	idx := newEventBusIndexer(t, []config.EventBusBoundarySpec{
+		{Name: "fromfile", Type: "producer", Callee: "x.y"},
+	})
+	b := idx.eventBusBoundaries()
+	require.Len(t, b, 1)
+	require.Equal(t, "fromfile", b[0].Name, "malformed env must fall back to index.event_bus")
+}
+
+func TestEventBusBoundaries_SkipsMalformedSpec(t *testing.T) {
+	idx := newEventBusIndexer(t, []config.EventBusBoundarySpec{
+		{Name: "ok", Type: "producer", Callee: "p.send"},
+		{Name: "", Type: "producer", Callee: "p.send"}, // no name → skip
+		{Name: "nomatch", Type: "consumer"},            // no match clause → skip
+	})
+	b := idx.eventBusBoundaries()
+	require.Len(t, b, 1)
+	require.Equal(t, "ok", b[0].Name)
+}
+
+// TestEventBus_EndToEnd indexes a producer + consumer of the same configured
+// bus topic and asserts the shared topic contract node carries both an
+// EdgeProvides (producer) and EdgeConsumes (consumer) edge — the boundaries
+// are now first-class, queryable graph elements.
+func TestEventBus_EndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "producer.py"), []byte(
+		"def emit():\n    bus.publish('orders', payload)\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "consumer.py"), []byte(
+		"@subscribe(topic='orders')\ndef on_order(msg):\n    pass\n"), 0o644))
+
+	cfg := config.Default().Index
+	cfg.EventBus = []config.EventBusBoundarySpec{
+		{Name: "orderbus", Type: "producer", Callee: "bus.publish", TopicArg: "0"},
+		{Name: "orderbus", Type: "consumer", Decorator: "subscribe", TopicArg: "topic"},
+	}
+	g := graph.New()
+	reg := parser.NewRegistry()
+	languages.RegisterAll(reg)
+	idx := New(g, reg, cfg, zap.NewNop())
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+	idx.ResolveAll()
+
+	node := g.GetNode("topic::orderbus::orders")
+	require.NotNil(t, node, "expected a shared topic contract node for the configured bus")
+
+	var provides, consumes int
+	for _, e := range g.GetInEdges("topic::orderbus::orders") {
+		switch e.Kind {
+		case graph.EdgeProvides:
+			provides++
+		case graph.EdgeConsumes:
+			consumes++
+		}
+	}
+	require.GreaterOrEqual(t, provides, 1, "producer should provide the topic")
+	require.GreaterOrEqual(t, consumes, 1, "consumer should consume the topic")
+}

--- a/internal/indexer/flask_routes_test.go
+++ b/internal/indexer/flask_routes_test.go
@@ -1,0 +1,62 @@
+package indexer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+// TestFlaskRestful_EndToEnd indexes a real flask-restful app and asserts the
+// add_resource route becomes a first-class KindContract node with an
+// EdgeHandlesRoute edge from the specific per-verb method node — proving the
+// extractor → commitContracts → graph pipeline works end to end.
+func TestFlaskRestful_EndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	src := `from flask import Flask
+from flask_restful import Api, Resource
+
+app = Flask(__name__)
+api = Api(app)
+
+class UserResource(Resource):
+    def get(self, id):
+        return {"user": id}
+
+    def post(self):
+        return {}
+
+api.add_resource(UserResource, '/users/<int:id>')
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "app.py"), []byte(src), 0o644))
+
+	g := graph.New()
+	reg := parser.NewRegistry()
+	languages.RegisterAll(reg)
+	idx := New(g, reg, config.Default().Index, zap.NewNop())
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+	idx.ResolveAll()
+
+	get := g.GetNode("http::GET::/users/{p1}")
+	post := g.GetNode("http::POST::/users/{p1}")
+	require.NotNil(t, get, "expected a GET route node from add_resource")
+	require.NotNil(t, post, "expected a POST route node from add_resource")
+
+	// The GET route must be handled by the resource's get() method node.
+	var handler *graph.Node
+	for _, e := range g.GetInEdges("http::GET::/users/{p1}") {
+		if e.Kind == graph.EdgeHandlesRoute {
+			handler = g.GetNode(e.From)
+		}
+	}
+	require.NotNil(t, handler, "expected an EdgeHandlesRoute into the GET route")
+	require.Equal(t, "get", handler.Name, "GET route should be handled by the get() method, not the class")
+}

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -3939,8 +3939,13 @@ func (idx *Indexer) IncrementalReindexPaths(root string, paths []string) (*Index
 	// eviction may have dropped edges. Skipped under deferGlobalPasses
 	// so a batch caller runs one global pass at the end.
 	if !idx.deferGlobalPasses && (len(staleFiles) > 0 || len(deletedFiles) > 0) {
-		idx.resolver.InferImplements()
-		idx.resolver.InferOverrides()
+		// Scoped inference passes re-derive only the affected types/interfaces
+		// (add-parity with the full pass); fall back to whole-graph when
+		// scoping is disabled.
+		if !idx.runScopedInferencePasses(staleFiles) {
+			idx.resolver.InferImplements()
+			idx.resolver.InferOverrides()
+		}
 		// Keep capability edges (reads_env / executes_process /
 		// accesses_field) fresh on incremental reindex — same idempotent
 		// re-derive RunGlobalGraphPasses runs at full index.
@@ -4152,8 +4157,12 @@ func (idx *Indexer) IncrementalReindex(root string) (*IndexResult, error) {
 	// caller (ReconcileAll, warmup) can run a single global pass at
 	// the end instead of paying O(global) per repo.
 	if !idx.deferGlobalPasses {
-		idx.resolver.InferImplements()
-		idx.resolver.InferOverrides()
+		// Scoped inference passes re-derive only the affected types/interfaces
+		// (add-parity with the full pass); fall back to whole-graph when off.
+		if !idx.runScopedInferencePasses(staleFiles) {
+			idx.resolver.InferImplements()
+			idx.resolver.InferOverrides()
+		}
 		// Capability edges (reads_env / executes_process / accesses_field)
 		// re-derived from the freshly re-indexed files' base edges so the
 		// daemon's capability surface — what a supply-chain / least-privilege

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -756,6 +756,13 @@ func (idx *Indexer) RunGlobalGraphPasses(ctx context.Context) {
 			zap.Int("edges", extCalls),
 		)
 	}
+	// Speculative dynamic-dispatch synthesis (opt-in, default off). Mints
+	// best-guess hidden-by-default call edges for blind-spot shapes.
+	if spec := resolver.ResolveSpeculativeDispatch(idx.graph, idx.speculativeDispatchEnabled()); spec > 0 {
+		idx.logger.Info("speculative dispatch edges synthesized (global)",
+			zap.Int("edges", spec),
+		)
+	}
 	// Cross-repo edge layer. Runs after InferImplements / InferOverrides
 	// so cross-repo implements / extends edges pick up their parallel
 	// cross_repo_* edges. No-op on single-repo graphs (no RepoPrefix).
@@ -2496,6 +2503,11 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 					zap.Int("edges", extCalls),
 				)
 			}
+			if spec := resolver.ResolveSpeculativeDispatch(idx.graph, idx.speculativeDispatchEnabled()); spec > 0 {
+				idx.logger.Info("speculative dispatch edges synthesized",
+					zap.Int("edges", spec),
+				)
+			}
 			// Reachability index — used to be precomputed for every
 			// impact seed here. The eager pass was retired because the
 			// breakeven was untenable on monorepo graphs (k8s:
@@ -2919,6 +2931,7 @@ func (idx *Indexer) ResolveAll() {
 	// resolver and stub passes so only genuinely un-indexed external
 	// targets remain to materialise.
 	resolver.SynthesizeExternalCalls(idx.graph, idx.externalCallSynthesisEnabled())
+	resolver.ResolveSpeculativeDispatch(idx.graph, idx.speculativeDispatchEnabled())
 	// CPG-lite dataflow rewriting must run after the call resolver
 	// has lifted unresolved:: targets; arg_of edges then point at
 	// real function/method nodes whose param nodes can be found,

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -4227,6 +4227,12 @@ func (idx *Indexer) buildPerFileContractExtractors() ([]contracts.Extractor, map
 		&contracts.WebSocketExtractor{},
 		&contracts.EnvVarExtractor{},
 	}
+	// Config-driven event bus: only registered when the user declared
+	// boundaries (index.event_bus / CODEGRAPH_EVENT_CONFIG), so the default
+	// extractor set is unchanged.
+	if b := idx.eventBusBoundaries(); len(b) > 0 {
+		extractors = append(extractors, &contracts.EventBusExtractor{Boundaries: b})
+	}
 	byLang := make(map[string][]contracts.Extractor)
 	for _, ex := range extractors {
 		for _, lang := range ex.SupportedLanguages() {

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -2803,6 +2803,10 @@ func (idx *Indexer) indexFile(filePath string, resolve bool) error {
 				detectClonesAndEmitEdges(idx.graph, idx.repoPrefix, idx.cloneThreshold())
 			}
 		}
+		// Persist this file's resolved-reference facts to the durable sidecar
+		// (delete-then-set so removed references don't linger). No-op on the
+		// in-memory backend.
+		idx.persistRefFactsForFiles([]string{graphPath})
 	}
 
 	// Update mtime for this file. relPath is already the canonical
@@ -2938,6 +2942,10 @@ func (idx *Indexer) ResolveAll() {
 	// and returns_to placeholders join cleanly against the
 	// now-resolved EdgeCalls edge at the same caller+line.
 	idx.materializeDataflowParams()
+
+	// Seed the durable reference-facts sidecar from the fully-resolved graph
+	// (no-op on the in-memory backend).
+	idx.persistAllRefFacts()
 }
 
 // EvictFile removes all nodes and edges belonging to filePath.
@@ -2964,6 +2972,7 @@ func (idx *Indexer) EvictFile(filePath string) (int, int) {
 	}
 	idx.restubIncomingRefs(graphPath)
 	idx.evictEnrichment(graphPath)
+	idx.deleteRefFactsForFiles(idx.repoPrefix, []string{graphPath})
 	return idx.graph.EvictFile(graphPath)
 }
 

--- a/internal/indexer/receiver_mutations.go
+++ b/internal/indexer/receiver_mutations.go
@@ -1,0 +1,215 @@
+package indexer
+
+import (
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// indirectMutSpec is one synthesized indirect field-mutation edge: `from`
+// (a method) mutates the field `to` indirectly by calling `via` on it (or on
+// its own receiver, which transitively mutates the field).
+type indirectMutSpec struct {
+	from, to, file, via string
+	line                int
+}
+
+// stdlibMutators are method names whose bodies are invisible to a source-level
+// pass (they live in compiled stdlib export data) but are known to mutate their
+// receiver: sync/atomic, sync.Mutex/RWMutex, WaitGroup, Once, sync.Map. A call
+// to one of these on a receiver field is an indirect mutation of that field.
+var stdlibMutators = map[string]bool{
+	// sync/atomic.*
+	"Store": true, "Swap": true, "CompareAndSwap": true, "Add": true,
+	// sync.Mutex / RWMutex
+	"Lock": true, "Unlock": true, "RLock": true, "RUnlock": true, "TryLock": true,
+	// sync.WaitGroup
+	"Done": true,
+	// sync.Once
+	"Do": true,
+	// sync.Map
+	"Delete": true, "LoadOrStore": true, "LoadAndDelete": true,
+}
+
+func isStdlibMutator(name string) bool { return stdlibMutators[name] }
+
+// bareCallName returns the trailing method name of an edge target id, stripping
+// any repo / unresolved / package qualifier ("unresolved::*.Store" → "Store").
+func bareCallName(id string) string {
+	if i := strings.LastIndex(id, "::"); i >= 0 {
+		id = id[i+2:]
+	}
+	if i := strings.LastIndex(id, "."); i >= 0 {
+		id = id[i+1:]
+	}
+	return id
+}
+
+// indirectMutationEdges computes, over the resolved graph, the indirect field
+// mutations: `s.counter.Increment()` mutates field counter because Increment
+// mutates its receiver; `s.helper()` mutates s's fields because helper does.
+// A transitive fixpoint propagates "this method mutates its receiver" through
+// own-receiver field-method calls and sibling-method calls — the piece gograph
+// explicitly defers. Pure graph traversal, no SSA, no type-checking.
+func indirectMutationEdges(g graph.Store) []indirectMutSpec {
+	if g == nil {
+		return nil
+	}
+	recvType := map[string]string{} // methodID → its receiver type
+	for n := range g.NodesByKind(graph.KindMethod) {
+		if n == nil || n.Meta == nil {
+			continue
+		}
+		if rt, _ := n.Meta["receiver"].(string); rt != "" {
+			recvType[n.ID] = rt
+		}
+	}
+	if len(recvType) == 0 {
+		return nil
+	}
+	// fieldByOwner[receiverType][fieldName] = fieldID.
+	fieldByOwner := map[string]map[string]string{}
+	for n := range g.NodesByKind(graph.KindField) {
+		if n == nil || n.Meta == nil {
+			continue
+		}
+		owner, _ := n.Meta["receiver"].(string)
+		if owner == "" || n.Name == "" {
+			continue
+		}
+		if fieldByOwner[owner] == nil {
+			fieldByOwner[owner] = map[string]string{}
+		}
+		fieldByOwner[owner][n.Name] = n.ID
+	}
+
+	// mutators[methodID] = set of own-receiver field names it mutates.
+	mutators := map[string]map[string]bool{}
+	addMut := func(m, f string) bool {
+		if mutators[m] == nil {
+			mutators[m] = map[string]bool{}
+		}
+		if mutators[m][f] {
+			return false
+		}
+		mutators[m][f] = true
+		return true
+	}
+	// Seed: a method that directly writes a field of its own receiver type.
+	for e := range g.EdgesByKind(graph.EdgeWrites) {
+		if e == nil {
+			continue
+		}
+		owner, ok := recvType[e.From]
+		if !ok {
+			continue
+		}
+		fn := g.GetNode(e.To)
+		if fn == nil || fn.Kind != graph.KindField {
+			continue
+		}
+		if fowner, _ := fn.Meta["receiver"].(string); fowner == owner {
+			addMut(e.From, fn.Name)
+		}
+	}
+
+	// Collect own-receiver calls once (recv_field or recv_self stamped).
+	type ocall struct {
+		from, calleeID, calleeName, recvField string
+		recvSelf                              bool
+		file                                  string
+		line                                  int
+	}
+	var ocalls []ocall
+	for e := range g.EdgesByKind(graph.EdgeCalls) {
+		if e == nil || e.Meta == nil {
+			continue
+		}
+		rf, _ := e.Meta["recv_field"].(string)
+		rs, _ := e.Meta["recv_self"].(bool)
+		if rf == "" && !rs {
+			continue
+		}
+		if _, ok := recvType[e.From]; !ok {
+			continue
+		}
+		name := bareCallName(e.To)
+		if cn := g.GetNode(e.To); cn != nil && cn.Kind == graph.KindMethod && cn.Name != "" {
+			name = cn.Name
+		}
+		ocalls = append(ocalls, ocall{
+			from: e.From, calleeID: e.To, calleeName: name,
+			recvField: rf, recvSelf: rs, file: e.FilePath, line: e.Line,
+		})
+	}
+
+	// Transitive fixpoint.
+	for {
+		changed := false
+		for _, c := range ocalls {
+			calleeMutates := len(mutators[c.calleeID]) > 0
+			switch {
+			case c.recvField != "":
+				if !calleeMutates && !isStdlibMutator(c.calleeName) {
+					continue
+				}
+				owner := recvType[c.from]
+				if fieldByOwner[owner][c.recvField] == "" {
+					continue // type-consistency: caller's receiver has this field
+				}
+				if addMut(c.from, c.recvField) {
+					changed = true
+				}
+			case c.recvSelf:
+				// Sibling method call on the own receiver: callee must be a
+				// method of the same receiver type, and it must mutate.
+				if !calleeMutates || recvType[c.calleeID] != recvType[c.from] || recvType[c.from] == "" {
+					continue
+				}
+				for f := range mutators[c.calleeID] {
+					if addMut(c.from, f) {
+						changed = true
+					}
+				}
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+
+	// Emit indirect accesses_field edges.
+	var out []indirectMutSpec
+	seen := map[string]bool{}
+	emit := func(from, fieldID, file, via string, line int) {
+		k := from + "\x00" + fieldID + "\x00" + via
+		if seen[k] {
+			return
+		}
+		seen[k] = true
+		out = append(out, indirectMutSpec{from: from, to: fieldID, file: file, via: via, line: line})
+	}
+	for _, c := range ocalls {
+		owner := recvType[c.from]
+		calleeMutates := len(mutators[c.calleeID]) > 0
+		switch {
+		case c.recvField != "":
+			if !calleeMutates && !isStdlibMutator(c.calleeName) {
+				continue
+			}
+			if fid := fieldByOwner[owner][c.recvField]; fid != "" {
+				emit(c.from, fid, c.file, c.calleeName, c.line)
+			}
+		case c.recvSelf && calleeMutates:
+			if recvType[c.calleeID] != owner || owner == "" {
+				continue
+			}
+			for f := range mutators[c.calleeID] {
+				if fid := fieldByOwner[owner][f]; fid != "" {
+					emit(c.from, fid, c.file, c.calleeName, c.line)
+				}
+			}
+		}
+	}
+	return out
+}

--- a/internal/indexer/receiver_mutations_test.go
+++ b/internal/indexer/receiver_mutations_test.go
@@ -1,0 +1,141 @@
+package indexer
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// indirectField returns true if some method named `caller` has an indirect
+// accesses_field write edge to a field named `field` with the given `via`.
+func indirectField(g *graph.Graph, caller, field, via string) bool {
+	for _, n := range g.AllNodes() {
+		if n.Kind != graph.KindMethod || n.Name != caller {
+			continue
+		}
+		for _, e := range g.GetOutEdges(n.ID) {
+			if e.Kind != graph.EdgeAccessesField || e.Meta == nil {
+				continue
+			}
+			if ind, _ := e.Meta["indirect"].(bool); !ind {
+				continue
+			}
+			fn := g.GetNode(e.To)
+			if fn == nil || fn.Name != field {
+				continue
+			}
+			if via == "" || e.Meta["via"] == via {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func TestIndirectMutation_FieldMethodCall(t *testing.T) {
+	g := indexFixture(t, map[string]string{
+		"m.go": `package main
+
+type Counter struct{ n int }
+
+func (c *Counter) Increment() { c.n++ }
+
+type Server struct {
+	counter Counter
+}
+
+func (s *Server) Tick() { s.counter.Increment() }
+`,
+	})
+	if !indirectField(g, "Tick", "counter", "Increment") {
+		t.Errorf("expected Tick to indirectly mutate counter via Increment")
+	}
+}
+
+func TestIndirectMutation_SiblingTransitive(t *testing.T) {
+	// gograph explicitly defers this transitive case; gortex ships it.
+	g := indexFixture(t, map[string]string{
+		"m.go": `package main
+
+type Server struct {
+	running int
+}
+
+func (s *Server) doWork() { s.running = 1 }
+
+func (s *Server) Run() { s.doWork() }
+`,
+	})
+	if !indirectField(g, "Run", "running", "doWork") {
+		t.Errorf("expected Run to transitively mutate running via doWork (sibling call)")
+	}
+}
+
+func TestIndirectMutation_TransitiveFieldChain(t *testing.T) {
+	// Increment mutates inner via Bump (field-method), so a caller that does
+	// s.counter.Increment() must still see counter as mutated — the fixpoint
+	// must mark Increment a mutator transitively.
+	g := indexFixture(t, map[string]string{
+		"m.go": `package main
+
+type Leaf struct{ v int }
+
+func (l *Leaf) Bump() { l.v++ }
+
+type Counter struct{ inner Leaf }
+
+func (c *Counter) Increment() { c.inner.Bump() }
+
+type Server struct{ counter Counter }
+
+func (s *Server) Tick() { s.counter.Increment() }
+`,
+	})
+	if !indirectField(g, "Increment", "inner", "Bump") {
+		t.Errorf("expected Increment to mutate inner via Bump")
+	}
+	if !indirectField(g, "Tick", "counter", "Increment") {
+		t.Errorf("expected Tick to transitively mutate counter via Increment")
+	}
+}
+
+func TestIndirectMutation_StdlibAllowlist(t *testing.T) {
+	g := indexFixture(t, map[string]string{
+		"m.go": `package main
+
+import "sync/atomic"
+
+type Server struct {
+	running atomic.Bool
+}
+
+func (s *Server) Start() { s.running.Store(true) }
+`,
+	})
+	if !indirectField(g, "Start", "running", "Store") {
+		t.Errorf("expected Start to indirectly mutate running via Store (stdlib allowlist)")
+	}
+}
+
+func TestIndirectMutation_NegativeLocalReceiver(t *testing.T) {
+	// A call on a local variable (not the receiver) must NOT be attributed to
+	// a receiver field.
+	g := indexFixture(t, map[string]string{
+		"m.go": `package main
+
+type Counter struct{ n int }
+
+func (c *Counter) Increment() { c.n++ }
+
+type Server struct{ counter Counter }
+
+func (s *Server) Stray() {
+	local := Counter{}
+	local.Increment()
+}
+`,
+	})
+	if indirectField(g, "Stray", "counter", "") {
+		t.Errorf("local.Increment() must not be attributed to the receiver field counter")
+	}
+}

--- a/internal/indexer/ref_facts.go
+++ b/internal/indexer/ref_facts.go
@@ -1,0 +1,126 @@
+package indexer
+
+import (
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Reference-facts sidecar persistence. After resolution settles, each resolved
+// reference edge becomes a durable, auditable fact (from → to + provenance
+// tier) persisted per source file in the backend's ref_facts table. Only the
+// on-disk store implements graph.RefFactsWriter; the in-memory backend has no
+// durable layer to seed, so persistence is a no-op there (the live edges ARE
+// the facts).
+
+// refFactsWriter returns the backend's reference-facts persistence capability
+// if it implements one.
+func (idx *Indexer) refFactsWriter() (graph.RefFactsWriter, bool) {
+	w, ok := idx.graph.(graph.RefFactsWriter)
+	return w, ok
+}
+
+// collectRefFacts derives the resolved-reference facts originating in the given
+// nodes: every resolvable reference edge whose target is a concrete (non-stub,
+// non-unresolved) node.
+func collectRefFacts(g graph.Store, nodes []*graph.Node) []graph.RefFact {
+	var facts []graph.RefFact
+	for _, n := range nodes {
+		if n == nil {
+			continue
+		}
+		for _, e := range g.GetOutEdges(n.ID) {
+			if e == nil || !graph.IsResolvableRefEdge(e.Kind) {
+				continue
+			}
+			if e.To == "" || graph.IsUnresolvedTarget(e.To) || graph.IsStub(e.To) {
+				continue
+			}
+			refName := ""
+			if t := g.GetNode(e.To); t != nil {
+				refName = t.Name
+			}
+			origin := e.Origin
+			if origin == "" {
+				sem, _ := e.Meta["semantic_source"].(string)
+				origin = graph.DefaultOriginFor(e.Kind, e.Confidence, sem)
+			}
+			facts = append(facts, graph.RefFact{
+				RepoPrefix: n.RepoPrefix,
+				FromID:     e.From,
+				ToID:       e.To,
+				Kind:       string(e.Kind),
+				RefName:    refName,
+				Line:       e.Line,
+				Origin:     origin,
+				Tier:       graph.ResolvedBy(origin),
+				FilePath:   n.FilePath,
+				Lang:       n.Language,
+			})
+		}
+	}
+	return facts
+}
+
+// persistRefFactsForFiles re-derives and persists the resolved-reference facts
+// for the given graph file paths (delete-then-set per file so stale facts from
+// removed references don't linger). No-op when the backend has no durable layer
+// or the file list is empty.
+func (idx *Indexer) persistRefFactsForFiles(graphPaths []string) {
+	w, ok := idx.refFactsWriter()
+	if !ok || len(graphPaths) == 0 {
+		return
+	}
+	byRepo := map[string][]graph.RefFact{}
+	filesByRepo := map[string]map[string]struct{}{}
+	for _, p := range graphPaths {
+		nodes := idx.graph.GetFileNodes(p)
+		for _, f := range collectRefFacts(idx.graph, nodes) {
+			byRepo[f.RepoPrefix] = append(byRepo[f.RepoPrefix], f)
+			if filesByRepo[f.RepoPrefix] == nil {
+				filesByRepo[f.RepoPrefix] = map[string]struct{}{}
+			}
+			filesByRepo[f.RepoPrefix][f.FilePath] = struct{}{}
+		}
+	}
+	for repo, fileSet := range filesByRepo {
+		files := make([]string, 0, len(fileSet))
+		for f := range fileSet {
+			files = append(files, f)
+		}
+		if err := w.DeleteRefFactsByFiles(repo, files); err != nil {
+			idx.logger.Debug("ref-facts: delete failed", zap.Error(err))
+			continue
+		}
+		if err := w.BulkSetRefFacts(repo, byRepo[repo]); err != nil {
+			idx.logger.Debug("ref-facts: persist failed", zap.Error(err))
+		}
+	}
+}
+
+// persistAllRefFacts persists reference facts for every indexed file. Called
+// once after a full resolve so a cold index seeds the durable sidecar.
+func (idx *Indexer) persistAllRefFacts() {
+	if _, ok := idx.refFactsWriter(); !ok {
+		return
+	}
+	var files []string
+	for n := range idx.graph.NodesByKind(graph.KindFile) {
+		if n != nil {
+			files = append(files, n.ID)
+		}
+	}
+	idx.persistRefFactsForFiles(files)
+}
+
+// deleteRefFactsForFiles drops persisted facts sourced in the given graph file
+// paths (used when a file is evicted/deleted). No-op without a durable backend.
+func (idx *Indexer) deleteRefFactsForFiles(repoPrefix string, graphPaths []string) {
+	w, ok := idx.refFactsWriter()
+	if !ok || len(graphPaths) == 0 {
+		return
+	}
+	if err := w.DeleteRefFactsByFiles(repoPrefix, graphPaths); err != nil {
+		idx.logger.Debug("ref-facts: delete-on-evict failed", zap.Error(err))
+	}
+}

--- a/internal/indexer/ref_facts_e2e_test.go
+++ b/internal/indexer/ref_facts_e2e_test.go
@@ -1,0 +1,49 @@
+package indexer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+// TestRefFacts_PersistedOnIndex indexes a Go fixture into a sqlite-backed graph
+// and asserts the resolved A->B call is persisted as a durable reference fact
+// (with provenance) in the ref_facts sidecar.
+func TestRefFacts_PersistedOnIndex(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "m.go"), []byte(
+		"package p\n\nfunc B() {}\n\nfunc A() { B() }\n"), 0o644))
+
+	store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "g.sqlite"))
+	require.NoError(t, err)
+	defer func() { _ = store.Close() }()
+
+	reg := parser.NewRegistry()
+	languages.RegisterAll(reg)
+	idx := New(store, reg, config.Default().Index, zap.NewNop())
+	_, err = idx.Index(dir)
+	require.NoError(t, err)
+	idx.ResolveAll()
+
+	facts, err := store.LoadRefFactsByFiles("", nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, facts, "expected resolved reference facts persisted to the sidecar")
+
+	var found bool
+	for _, f := range facts {
+		if f.Kind == "calls" && f.RefName == "B" {
+			found = true
+			require.NotEmpty(t, f.Origin, "fact must carry a provenance origin")
+			require.NotEmpty(t, f.Tier, "fact must carry a coarse tier")
+		}
+	}
+	require.True(t, found, "expected an A->B calls fact, got %+v", facts)
+}

--- a/internal/indexer/scoped_passes_e2e_test.go
+++ b/internal/indexer/scoped_passes_e2e_test.go
@@ -1,0 +1,71 @@
+package indexer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+func countImplements(g *graph.Graph) int {
+	n := 0
+	for _, e := range g.AllEdges() {
+		if e.Kind == graph.EdgeImplements {
+			n++
+		}
+	}
+	return n
+}
+
+// TestScopedPasses_InterfaceChangeParity is the EvictFile regression guard:
+// when an interface file is incrementally reindexed, EvictFile drops the
+// inferred A->I / B->I edges whose source types live in UNCHANGED files. The
+// scoped pass must re-derive them (because the interface is in the affected
+// set), so the implements-edge count is unchanged — identical to the full pass.
+func TestScopedPasses_InterfaceChangeParity(t *testing.T) {
+	run := func(t *testing.T, scoped bool) int {
+		if !scoped {
+			t.Setenv("GORTEX_INDEX_SCOPED_GLOBAL_PASSES", "0")
+		}
+		dir := t.TempDir()
+		write := func(name, body string) {
+			require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644))
+		}
+		write("iface.go", "package p\n\ntype I interface{ M() }\n")
+		write("a.go", "package p\n\ntype A struct{}\n\nfunc (a A) M() {}\n")
+		write("b.go", "package p\n\ntype B struct{}\n\nfunc (b B) M() {}\n")
+
+		g := graph.New()
+		reg := parser.NewRegistry()
+		languages.RegisterAll(reg)
+		idx := New(g, reg, config.Default().Index, zap.NewNop())
+		_, err := idx.Index(dir)
+		require.NoError(t, err)
+		idx.ResolveAll()
+
+		before := countImplements(g)
+		require.GreaterOrEqual(t, before, 2, "expected A->I and B->I before reindex")
+
+		// Change the interface file → its node + the inferred in-edges from
+		// a.go/b.go are evicted.
+		write("iface.go", "package p\n\n// touched\ntype I interface{ M() }\n")
+		_, err = idx.IncrementalReindexPaths(dir, []string{"iface.go"})
+		require.NoError(t, err)
+
+		after := countImplements(g)
+		require.Equal(t, before, after,
+			"implements edges must survive an interface-file reindex (scoped=%v)", scoped)
+		return after
+	}
+
+	scopedCount := run(t, true)
+	fullCount := run(t, false)
+	require.Equal(t, fullCount, scopedCount, "scoped and full passes must produce the same implements-edge count")
+}

--- a/internal/indexer/speculative_e2e_test.go
+++ b/internal/indexer/speculative_e2e_test.go
@@ -1,0 +1,57 @@
+package indexer
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func speculativeCallExists(g *graph.Graph, callerName, targetName string) bool {
+	for _, n := range g.AllNodes() {
+		if n.Name != callerName {
+			continue
+		}
+		for _, e := range g.GetOutEdges(n.ID) {
+			if e.Kind != graph.EdgeCalls || !e.IsSpeculative() {
+				continue
+			}
+			if tn := g.GetNode(e.To); tn != nil && tn.Name == targetName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestSpeculativeDispatch_EndToEnd indexes a Python computed-member dispatch
+// (obj["run"]()) with speculative synthesis enabled and asserts a best-guess
+// edge is minted to the same-name method — and that it is NOT minted when the
+// feature is off (default).
+func TestSpeculativeDispatch_EndToEnd(t *testing.T) {
+	fixture := map[string]string{
+		"m.py": `class Worker:
+    def run(self):
+        pass
+
+def dispatch(table):
+    table["run"]()
+`,
+	}
+
+	// Off by default → no speculative edge.
+	t.Run("default_off", func(t *testing.T) {
+		g := indexFixture(t, fixture)
+		if speculativeCallExists(g, "dispatch", "run") {
+			t.Errorf("speculative edge must NOT exist when synthesis is disabled (default)")
+		}
+	})
+
+	// Enabled via env override → speculative edge minted.
+	t.Run("enabled", func(t *testing.T) {
+		t.Setenv("GORTEX_SYNTH_SPECULATIVE", "1")
+		g := indexFixture(t, fixture)
+		if !speculativeCallExists(g, "dispatch", "run") {
+			t.Errorf("expected a speculative dispatch->run edge when synthesis is enabled")
+		}
+	})
+}

--- a/internal/indexer/speculative_synthesis.go
+++ b/internal/indexer/speculative_synthesis.go
@@ -1,0 +1,19 @@
+package indexer
+
+import (
+	"os"
+	"strings"
+)
+
+// speculativeDispatchEnabled reports whether the resolver should mint opt-in,
+// best-guess speculative call edges for dynamic-dispatch blind spots
+// (computed-member calls, getattr, decorator registries).
+// GORTEX_SYNTH_SPECULATIVE overrides the index.synthesize_speculative_dispatch
+// config key. OFF by default — these edges are heuristic fan-outs and are
+// hidden from every default query.
+func (idx *Indexer) speculativeDispatchEnabled() bool {
+	if v := os.Getenv("GORTEX_SYNTH_SPECULATIVE"); v != "" {
+		return v == "1" || strings.EqualFold(v, "true")
+	}
+	return idx.config.SpeculativeDispatchEnabledOrDefault()
+}

--- a/internal/indexer/store_factory_e2e_test.go
+++ b/internal/indexer/store_factory_e2e_test.go
@@ -1,0 +1,153 @@
+package indexer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+// storeActionCallers returns the names of functions that call a store action
+// (a KindFunction node named `member` carrying Meta["store_factory"]).
+func storeActionCallers(g *graph.Graph, member string) []string {
+	var callers []string
+	for _, n := range g.AllNodes() {
+		if n.Kind != graph.KindFunction || n.Meta == nil {
+			continue
+		}
+		if _, ok := n.Meta["store_factory"]; !ok {
+			continue
+		}
+		if sm, _ := n.Meta["store_member"].(string); sm != member {
+			continue
+		}
+		for _, e := range g.GetInEdges(n.ID) {
+			if e.Kind != graph.EdgeCalls {
+				continue
+			}
+			if cn := g.GetNode(e.From); cn != nil {
+				callers = append(callers, cn.Name)
+			}
+		}
+	}
+	return callers
+}
+
+func indexFixture(t *testing.T, files map[string]string) *graph.Graph {
+	t.Helper()
+	dir := t.TempDir()
+	for name, body := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644))
+	}
+	g := graph.New()
+	reg := parser.NewRegistry()
+	languages.RegisterAll(reg)
+	idx := New(g, reg, config.Default().Index, zap.NewNop())
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+	idx.ResolveAll()
+	return g
+}
+
+// TestStoreFactory_Zustand_TS mirrors the competitor's end-to-end test: a
+// Zustand store consumed cross-file via the getState() chain and via
+// destructuring. Both indirect calls must resolve to the action nodes.
+func TestStoreFactory_Zustand_TS(t *testing.T) {
+	g := indexFixture(t, map[string]string{
+		"store.ts": `import { create } from 'zustand'
+
+export const useStore = create((set, get) => ({
+  fetchUser: async () => {},
+  reset: () => {},
+}))
+`,
+		"caller.ts": `import { useStore } from './store'
+
+export function hardReset() {
+  useStore.getState().reset()
+}
+
+export function loginFlow() {
+  const { fetchUser } = useStore.getState()
+  fetchUser()
+}
+`,
+	})
+
+	resetCallers := storeActionCallers(g, "reset")
+	require.Contains(t, resetCallers, "hardReset", "chained useStore.getState().reset() should resolve")
+
+	fetchCallers := storeActionCallers(g, "fetchUser")
+	require.Contains(t, fetchCallers, "loginFlow", "destructured fetchUser() should resolve")
+}
+
+// TestStoreFactory_Zustand_JS covers the JavaScript extractor with a
+// middleware-wrapped store factory.
+func TestStoreFactory_Zustand_JS(t *testing.T) {
+	g := indexFixture(t, map[string]string{
+		"store.js": `import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+export const useStore = create(persist((set, get) => ({
+  increment: () => {},
+}), { name: 'c' }))
+`,
+		"caller.js": `import { useStore } from './store'
+
+export function bump() {
+  useStore.getState().increment()
+}
+`,
+	})
+	require.Contains(t, storeActionCallers(g, "increment"), "bump",
+		"middleware-wrapped store action should resolve through the getState() chain")
+}
+
+func hasStoreAction(g *graph.Graph, member string) bool {
+	for _, n := range g.AllNodes() {
+		if n.Meta == nil {
+			continue
+		}
+		if _, ok := n.Meta["store_factory"]; !ok {
+			continue
+		}
+		if sm, _ := n.Meta["store_member"].(string); sm == member {
+			return true
+		}
+	}
+	return false
+}
+
+// TestStoreFactory_PiniaAndRTK covers the non-function-return factory shapes:
+// Pinia's defineStore('id', {actions:{...}}) and Redux Toolkit's
+// createSlice({reducers:{...}}).
+func TestStoreFactory_PiniaAndRTK(t *testing.T) {
+	g := indexFixture(t, map[string]string{
+		"pinia.ts": `import { defineStore } from 'pinia'
+
+export const useS = defineStore('s', {
+  actions: {
+    save() {},
+  },
+})
+`,
+		"slice.ts": `import { createSlice } from '@reduxjs/toolkit'
+
+export const slice = createSlice({
+  name: 'counter',
+  reducers: {
+    tick() {},
+  },
+})
+`,
+	})
+	require.True(t, hasStoreAction(g, "save"), "Pinia defineStore actions should be stamped as store actions")
+	require.True(t, hasStoreAction(g, "tick"), "RTK createSlice reducers should be stamped as store actions")
+}

--- a/internal/mcp/gcx.go
+++ b/internal/mcp/gcx.go
@@ -1677,6 +1677,65 @@ func encodeChangeImpact(result map[string]any) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// encodeAPIImpact emits the fused route report as three GCX sections:
+// api_impact.routes (one row per route), api_impact.consumers and
+// api_impact.mismatches (one row each, carrying the route id so they regroup).
+func encodeAPIImpact(reports []apiImpactReport) ([]byte, error) {
+	var buf bytes.Buffer
+	routeEnc := newGCX(&buf, "api_impact.routes",
+		[]string{"route", "method", "path", "handler", "repo", "response_success", "response_error", "middleware", "risk", "direct_consumers", "affected_callers", "affected_flows", "test_files", "warning", "contract_risk_upgrade"},
+		"count", fmt.Sprintf("%d", len(reports)),
+	)
+	for _, r := range reports {
+		mw := strings.Join(r.Middleware, ",")
+		if mw == "" {
+			mw = r.MiddlewareDetection
+		}
+		if err := routeEnc.WriteRow(
+			r.Route, r.Method, r.Path, r.Handler, r.Repo,
+			strings.Join(r.ResponseShape.Success, ","),
+			strings.Join(r.ResponseShape.Error, ","),
+			mw,
+			r.ImpactSummary.RiskLevel,
+			r.ImpactSummary.DirectConsumers,
+			r.ImpactSummary.AffectedCallers,
+			r.ImpactSummary.AffectedFlows,
+			strings.Join(r.ImpactSummary.TestFilesToRun, ","),
+			r.ImpactSummary.Warning,
+			r.ImpactSummary.ContractRiskUpgrade,
+		); err != nil {
+			return nil, err
+		}
+	}
+	if err := routeEnc.Close(); err != nil {
+		return nil, err
+	}
+
+	consEnc := newGCX(&buf, "api_impact.consumers",
+		[]string{"route", "name", "file", "repo", "accesses", "attribution_note"})
+	for _, r := range reports {
+		for _, c := range r.Consumers {
+			if err := consEnc.WriteRow(r.Route, c.Name, c.File, c.Repo, strings.Join(c.Accesses, ","), c.AttributionNote); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if err := consEnc.Close(); err != nil {
+		return nil, err
+	}
+
+	mmEnc := newGCX(&buf, "api_impact.mismatches",
+		[]string{"route", "consumer", "field", "reason", "confidence"})
+	for _, r := range reports {
+		for _, m := range r.Mismatches {
+			if err := mmEnc.WriteRow(r.Route, m.Consumer, m.Field, m.Reason, m.Confidence); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return buf.Bytes(), mmEnc.Close()
+}
+
 // encodeCheckGuards emits one row per guard violation. The empty case
 // (no rules / no violations) still produces a valid envelope so agents
 // can rely on the GCX1 header to differentiate from an error payload —

--- a/internal/mcp/gcx.go
+++ b/internal/mcp/gcx.go
@@ -434,6 +434,11 @@ func encodeSubGraph(tool string, sg *query.SubGraph) ([]byte, error) {
 	if sg.StoppedAtDepth > 0 {
 		nodeMeta = append(nodeMeta, "stopped_at_depth", fmt.Sprintf("%d", sg.StoppedAtDepth))
 	}
+	// Epistemic lower-bound flag rides the node meta only when set, so a
+	// result with no dispatch boundary keeps its wire shape byte-for-byte.
+	if sg.LowerBound {
+		nodeMeta = append(nodeMeta, "lower_bound", boolString(sg.LowerBound))
+	}
 	nodeEnc := newGCX(&buf, tool+".nodes",
 		[]string{"id", "kind", "name", "path", "path_abs", "line", "is_test", "test_role", "test_runner"},
 		nodeMeta...,
@@ -473,27 +478,47 @@ func encodeSubGraph(tool string, sg *query.SubGraph) ([]byte, error) {
 	if err := edgeEnc.Close(); err != nil {
 		return nil, err
 	}
-	if len(sg.CallerNotes) == 0 {
-		return buf.Bytes(), nil
-	}
-	// caller_notes — one row per caller carrying a concurrency flag.
-	// Rows are sorted by node ID so the wire output is deterministic.
-	noteIDs := make([]string, 0, len(sg.CallerNotes))
-	for id := range sg.CallerNotes {
-		noteIDs = append(noteIDs, id)
-	}
-	sort.Strings(noteIDs)
-	noteEnc := newGCX(&buf, tool+".caller_notes",
-		[]string{"id", "sync_guarded", "sync_guarded_why", "cross_concurrent", "cross_concurrent_why"},
-		"count", fmt.Sprintf("%d", len(noteIDs)),
-	)
-	for _, id := range noteIDs {
-		a := sg.CallerNotes[id]
-		if err := noteEnc.WriteRow(id, a.SyncGuarded, a.SyncGuardedWhy, a.CrossConcurrent, a.CrossConcurrentWhy); err != nil {
+	// caller_notes — one row per caller carrying a concurrency flag. Emitted
+	// only when get_callers attached annotations, so other traversal tools'
+	// wire output is byte-identical to before.
+	if len(sg.CallerNotes) > 0 {
+		noteIDs := make([]string, 0, len(sg.CallerNotes))
+		for id := range sg.CallerNotes {
+			noteIDs = append(noteIDs, id)
+		}
+		sort.Strings(noteIDs)
+		noteEnc := newGCX(&buf, tool+".caller_notes",
+			[]string{"id", "sync_guarded", "sync_guarded_why", "cross_concurrent", "cross_concurrent_why"},
+			"count", fmt.Sprintf("%d", len(noteIDs)),
+		)
+		for _, id := range noteIDs {
+			a := sg.CallerNotes[id]
+			if err := noteEnc.WriteRow(id, a.SyncGuarded, a.SyncGuardedWhy, a.CrossConcurrent, a.CrossConcurrentWhy); err != nil {
+				return nil, err
+			}
+		}
+		if err := noteEnc.Close(); err != nil {
 			return nil, err
 		}
 	}
-	return buf.Bytes(), noteEnc.Close()
+	// boundaries — the epistemic lower-bound diagnosis. Emitted only when the
+	// walk crossed a dynamic-dispatch / unresolved site, so results with none
+	// keep their existing wire bytes.
+	if len(sg.Boundaries) > 0 {
+		bEnc := newGCX(&buf, tool+".boundaries",
+			[]string{"seed_id", "target", "edge_kind", "reason", "direction"},
+			"count", fmt.Sprintf("%d", len(sg.Boundaries)),
+		)
+		for _, b := range sg.Boundaries {
+			if err := bEnc.WriteRow(b.SeedID, b.Target, b.EdgeKind, string(b.Reason), b.Direction); err != nil {
+				return nil, err
+			}
+		}
+		if err := bEnc.Close(); err != nil {
+			return nil, err
+		}
+	}
+	return buf.Bytes(), nil
 }
 
 // encodeFileSummary emits one row per symbol in a file plus a trailing
@@ -1625,6 +1650,27 @@ func encodeChangeImpact(result map[string]any) ([]byte, error) {
 			}
 		}
 		if err := cavEnc.Close(); err != nil {
+			return nil, err
+		}
+	}
+
+	// boundaries — the epistemic lower-bound diagnosis. Emitted only when the
+	// blast radius crossed a dynamic-dispatch / interface site, so results
+	// with none keep their existing wire bytes. The section's presence (and
+	// its lower_bound meta flag) signals the count is a floor.
+	if boundaries, ok := result["boundaries"].([]graph.EpistemicBoundary); ok && len(boundaries) > 0 {
+		lb, _ := result["lower_bound"].(bool)
+		bEnc := newGCX(&buf, "explain_change_impact.boundaries",
+			[]string{"seed_id", "seed_name", "target", "edge_kind", "reason", "direction"},
+			"count", fmt.Sprintf("%d", len(boundaries)),
+			"lower_bound", boolString(lb),
+		)
+		for _, b := range boundaries {
+			if err := bEnc.WriteRow(b.SeedID, b.SeedName, b.Target, b.EdgeKind, string(b.Reason), b.Direction); err != nil {
+				return nil, err
+			}
+		}
+		if err := bEnc.Close(); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/mcp/query_log.go
+++ b/internal/mcp/query_log.go
@@ -69,6 +69,7 @@ var retrievalToolSpecs = map[string]queryToolSpec{
 	"find_usages":             {questionKeys: []string{"symbol", "id", "name"}, corpus: "usages"},
 	"get_callers":             {questionKeys: []string{"symbol", "id", "name"}, corpus: "callers"},
 	"get_call_chain":          {questionKeys: []string{"from", "to", "symbol"}, corpus: "call_chain"},
+	"trace_path":              {questionKeys: []string{"source_id", "sink_id"}, corpus: "call_path"},
 	"search_text":             {questionKeys: []string{"query", "pattern"}, corpus: "text"},
 	"search_ast":              {questionKeys: []string{"query", "pattern"}, corpus: "ast"},
 	"winnow_symbols":          {questionKeys: []string{"text_match", "query"}, corpus: "code"},

--- a/internal/mcp/scope_init.go
+++ b/internal/mcp/scope_init.go
@@ -118,6 +118,7 @@ var defaultToolScopes = map[string]ToolScope{
 	// cross-repo dataflow joins land.
 	"flow_between": ScopeRepo,
 	"taint_paths":  ScopeRepo,
+	"trace_path":   ScopeRepo,
 }
 
 // applyDefaultToolScopes registers the canonical scope for every

--- a/internal/mcp/tools_analysis.go
+++ b/internal/mcp/tools_analysis.go
@@ -308,6 +308,17 @@ func (s *Server) handleEnhancedChangeImpact(ctx context.Context, req mcp.CallToo
 		result["by_repo"] = impact.ByRepo
 	}
 
+	// Epistemic lower bound: the affected count is a floor when the blast
+	// radius crosses a dynamic-dispatch / interface site the resolver could
+	// not bind. Surface the flag + the boundary list so an agent knows
+	// ">=N, could be more" and can act on each named site.
+	if impact.LowerBound {
+		result["lower_bound"] = true
+	}
+	if len(impact.Boundaries) > 0 {
+		result["boundaries"] = impact.Boundaries
+	}
+
 	// When the blast radius is empty, an agent cannot tell genuinely
 	// safe-to-change symbols apart from symbols the extractor never
 	// wired up. Classify each input so a safety gate is not disarmed

--- a/internal/mcp/tools_analyze_edges.go
+++ b/internal/mcp/tools_analyze_edges.go
@@ -470,6 +470,86 @@ func (s *Server) handleAnalyzeSpeculative(ctx context.Context, req mcp.CallToolR
 	})
 }
 
+// handleAnalyzeRefFacts surfaces resolved-reference facts — each reference edge
+// that resolved to a concrete target, with the provenance tier that resolved
+// it. The durable form is the backend's ref_facts sidecar; this read derives
+// the same facts from the live graph (backend-agnostic). With `id` it scopes to
+// references originating in one file.
+func (s *Server) handleAnalyzeRefFacts(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := req.GetArguments()
+	fileFilter := strings.TrimSpace(stringArg(args, "id"))
+	if fileFilter == "" {
+		fileFilter = strings.TrimSpace(stringArg(args, "path"))
+	}
+	limit := 200
+	if v, ok := args["limit"].(float64); ok && v > 0 {
+		limit = int(v)
+	}
+
+	type fact struct {
+		From    string `json:"from"`
+		To      string `json:"to"`
+		Kind    string `json:"kind"`
+		RefName string `json:"ref_name,omitempty"`
+		Origin  string `json:"origin,omitempty"`
+		Tier    string `json:"tier,omitempty"`
+		File    string `json:"file,omitempty"`
+	}
+
+	var nodes []*graph.Node
+	if fileFilter != "" {
+		nodes = s.graph.GetFileNodes(fileFilter)
+	} else {
+		for _, k := range []graph.NodeKind{graph.KindFunction, graph.KindMethod} {
+			for n := range s.graph.NodesByKind(k) {
+				nodes = append(nodes, n)
+			}
+		}
+	}
+
+	var facts []fact
+	truncated := false
+	for _, n := range nodes {
+		if n == nil {
+			continue
+		}
+		for _, e := range s.graph.GetOutEdges(n.ID) {
+			if e == nil || !graph.IsResolvableRefEdge(e.Kind) {
+				continue
+			}
+			if e.To == "" || graph.IsUnresolvedTarget(e.To) || graph.IsStub(e.To) {
+				continue
+			}
+			refName := ""
+			if t := s.graph.GetNode(e.To); t != nil {
+				refName = t.Name
+			}
+			origin := e.Origin
+			if origin == "" {
+				sem, _ := e.Meta["semantic_source"].(string)
+				origin = graph.DefaultOriginFor(e.Kind, e.Confidence, sem)
+			}
+			facts = append(facts, fact{
+				From: e.From, To: e.To, Kind: string(e.Kind), RefName: refName,
+				Origin: origin, Tier: graph.ResolvedBy(origin), File: n.FilePath,
+			})
+			if len(facts) >= limit {
+				truncated = true
+				break
+			}
+		}
+		if truncated {
+			break
+		}
+	}
+
+	return s.respondJSONOrTOON(ctx, req, map[string]any{
+		"facts":     facts,
+		"total":     len(facts),
+		"truncated": truncated,
+	})
+}
+
 // ---------------------------------------------------------------------------
 // annotation_users — for an annotation node id (or list all when no
 // id), surface annotated symbols.

--- a/internal/mcp/tools_analyze_edges.go
+++ b/internal/mcp/tools_analyze_edges.go
@@ -343,6 +343,76 @@ func (s *Server) handleAnalyzeFieldWriters(ctx context.Context, req mcp.CallTool
 	return s.respondJSONOrTOON(ctx, req, resp)
 }
 
+// handleAnalyzeIndirectMutations lists fields mutated *indirectly* — via a
+// method call on the field (s.counter.Increment()) or a sibling call on the
+// receiver (s.helper()) — surfacing the `via` method for each. These are the
+// accesses_field edges tagged Meta["indirect"]=true synthesized by the
+// receiver-mutation fixpoint. With `id` it scopes to one field.
+func (s *Server) handleAnalyzeIndirectMutations(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := req.GetArguments()
+	idFilter := strings.TrimSpace(stringArg(args, "id"))
+	limit := 20
+	if v, ok := args["limit"].(float64); ok && v > 0 {
+		limit = int(v)
+	}
+
+	type mutator struct {
+		Function string `json:"function"`
+		Via      string `json:"via,omitempty"`
+		File     string `json:"file,omitempty"`
+		Line     int    `json:"line,omitempty"`
+	}
+	type fieldRow struct {
+		Field     string    `json:"field"`
+		Mutations int       `json:"mutations"`
+		Mutators  []mutator `json:"mutators,omitempty"`
+	}
+	byField := map[string]*fieldRow{}
+
+	for e := range edgesByKinds(s.graph, graph.EdgeAccessesField) {
+		if e.Meta == nil {
+			continue
+		}
+		if ind, _ := e.Meta["indirect"].(bool); !ind {
+			continue
+		}
+		if idFilter != "" && e.To != idFilter {
+			continue
+		}
+		via, _ := e.Meta["via"].(string)
+		row, ok := byField[e.To]
+		if !ok {
+			row = &fieldRow{Field: e.To}
+			byField[e.To] = row
+		}
+		row.Mutations++
+		row.Mutators = append(row.Mutators, mutator{Function: e.From, Via: via, File: e.FilePath, Line: e.Line})
+	}
+
+	rows := make([]*fieldRow, 0, len(byField))
+	for _, r := range byField {
+		sort.Slice(r.Mutators, func(i, j int) bool { return r.Mutators[i].Function < r.Mutators[j].Function })
+		rows = append(rows, r)
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Mutations != rows[j].Mutations {
+			return rows[i].Mutations > rows[j].Mutations
+		}
+		return rows[i].Field < rows[j].Field
+	})
+	truncated := false
+	if idFilter == "" && len(rows) > limit {
+		rows = rows[:limit]
+		truncated = true
+	}
+
+	return s.respondJSONOrTOON(ctx, req, map[string]any{
+		"fields":    rows,
+		"total":     len(rows),
+		"truncated": truncated,
+	})
+}
+
 // ---------------------------------------------------------------------------
 // annotation_users — for an annotation node id (or list all when no
 // id), surface annotated symbols.

--- a/internal/mcp/tools_analyze_edges.go
+++ b/internal/mcp/tools_analyze_edges.go
@@ -413,6 +413,63 @@ func (s *Server) handleAnalyzeIndirectMutations(ctx context.Context, req mcp.Cal
 	})
 }
 
+// handleAnalyzeSpeculative is the audit surface for opt-in speculative
+// dynamic-dispatch edges: it groups the best-guess call edges (Meta
+// speculative=true) by their shape (computed_member / getattr / …) with a
+// candidate-count histogram and samples, so an agent can review what the
+// best-guess synthesizer produced before trusting any of it.
+func (s *Server) handleAnalyzeSpeculative(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	type sample struct {
+		From           string `json:"from"`
+		To             string `json:"to"`
+		CandidateCount int    `json:"candidate_count,omitempty"`
+		Confidence     string `json:"confidence,omitempty"`
+	}
+	type shapeRow struct {
+		Shape   string   `json:"shape"`
+		Edges   int      `json:"edges"`
+		Samples []sample `json:"samples,omitempty"`
+	}
+	byShape := map[string]*shapeRow{}
+	total := 0
+	for e := range edgesByKinds(s.graph, graph.EdgeCalls) {
+		if !e.IsSpeculative() {
+			continue
+		}
+		total++
+		shape, _ := e.Meta["via"].(string)
+		shape = strings.TrimPrefix(shape, "speculative.")
+		if shape == "" {
+			shape = "unknown"
+		}
+		row, ok := byShape[shape]
+		if !ok {
+			row = &shapeRow{Shape: shape}
+			byShape[shape] = row
+		}
+		row.Edges++
+		if len(row.Samples) < 10 {
+			cc, _ := e.Meta["candidate_count"].(int)
+			row.Samples = append(row.Samples, sample{From: e.From, To: e.To, CandidateCount: cc, Confidence: e.ConfidenceLabel})
+		}
+	}
+	rows := make([]*shapeRow, 0, len(byShape))
+	for _, r := range byShape {
+		rows = append(rows, r)
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Edges != rows[j].Edges {
+			return rows[i].Edges > rows[j].Edges
+		}
+		return rows[i].Shape < rows[j].Shape
+	})
+	return s.respondJSONOrTOON(ctx, req, map[string]any{
+		"shapes": rows,
+		"total":  total,
+		"note":   "speculative edges are best-guess fan-outs, hidden from default queries; pass include_speculative:true to surface them",
+	})
+}
+
 // ---------------------------------------------------------------------------
 // annotation_users — for an annotation node id (or list all when no
 // id), surface annotated symbols.

--- a/internal/mcp/tools_api_impact.go
+++ b/internal/mcp/tools_api_impact.go
@@ -1,0 +1,444 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/zzet/gortex/internal/analysis"
+	"github.com/zzet/gortex/internal/contracts"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// api_impact is a fused, route-anchored pre-change report. Given a route path
+// (or handler file) substring, it composes four existing subsystems — the
+// contract registry (route + consumers), contracts.Validate (field-level
+// response-shape mismatch), analysis.AnalyzeImpact (the real blast radius:
+// callers, processes, test files), and best-effort middleware — into one
+// answer to "what breaks if I change this endpoint?". It is the single call an
+// agent makes BEFORE modifying an API handler.
+
+type apiImpactShape struct {
+	Success []string `json:"success"`
+	Error   []string `json:"error,omitempty"`
+	Note    string   `json:"note,omitempty"`
+}
+
+type apiImpactConsumer struct {
+	Name            string   `json:"name"`
+	File            string   `json:"file,omitempty"`
+	Repo            string   `json:"repo,omitempty"`
+	Accesses        []string `json:"accesses,omitempty"`
+	AttributionNote string   `json:"attribution_note,omitempty"`
+}
+
+type apiImpactMismatch struct {
+	Consumer   string `json:"consumer"`
+	Field      string `json:"field"`
+	Reason     string `json:"reason"`
+	Confidence string `json:"confidence"` // high | low
+}
+
+type apiImpactSummary struct {
+	DirectConsumers     int      `json:"direct_consumers"`
+	AffectedFlows       int      `json:"affected_flows"`
+	AffectedCallers     int      `json:"affected_callers"`
+	TestFilesToRun      []string `json:"test_files_to_run,omitempty"`
+	RiskLevel           string   `json:"risk_level"`
+	Warning             string   `json:"warning,omitempty"`
+	ContractRiskUpgrade string   `json:"contract_risk_upgrade,omitempty"`
+}
+
+type apiImpactReport struct {
+	Route               string              `json:"route"`
+	Method              string              `json:"method,omitempty"`
+	Path                string              `json:"path,omitempty"`
+	Handler             string              `json:"handler,omitempty"`
+	Repo                string              `json:"repo,omitempty"`
+	ResponseShape       apiImpactShape      `json:"response_shape"`
+	Middleware          []string            `json:"middleware,omitempty"`
+	MiddlewareDetection string              `json:"middleware_detection,omitempty"`
+	Consumers           []apiImpactConsumer `json:"consumers"`
+	Mismatches          []apiImpactMismatch `json:"mismatches,omitempty"`
+	ExecutionFlows      []string            `json:"execution_flows,omitempty"`
+	ImpactSummary       apiImpactSummary    `json:"impact_summary"`
+}
+
+func (s *Server) handleAPIImpact(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	route := strings.TrimSpace(req.GetString("route", ""))
+	file := strings.TrimSpace(req.GetString("file", ""))
+	if route == "" && file == "" {
+		return mcp.NewToolResultError("either route or file is required"), nil
+	}
+	allowed, err := s.resolveRepoFilter(ctx, req)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	reg := s.effectiveContractRegistry()
+	if reg == nil {
+		return mcp.NewToolResultError("no contract registry available — index a repo with API routes first"), nil
+	}
+
+	providers := resolveRouteTargets(reg, route, file, allowed)
+	if len(providers) == 0 {
+		target := route
+		if target == "" {
+			target = file
+		}
+		return mcp.NewToolResultError(fmt.Sprintf("no route matching %q", target)), nil
+	}
+
+	lookup := s.contractShapeLookup()
+	fanout := consumerFileFanout(reg)
+
+	reports := make([]apiImpactReport, 0, len(providers))
+	for _, p := range providers {
+		reports = append(reports, s.buildAPIImpactReport(p, reg, lookup, fanout))
+	}
+
+	var payload any
+	if len(reports) == 1 {
+		payload = reports[0]
+	} else {
+		payload = map[string]any{"routes": reports, "total": len(reports)}
+	}
+
+	if s.isGCX(ctx, req) {
+		return s.gcxResponseWithBudget(req)(encodeAPIImpact(reports))
+	}
+	if s.isTOON(ctx, req) {
+		return returnTOON(payload)
+	}
+	return s.respondJSONOrTOON(ctx, req, payload)
+}
+
+// resolveRouteTargets returns provider HTTP contracts whose path matches the
+// route substring or whose handler file matches the file substring, deduped by
+// canonical contract ID (first wins). Registry contracts carry FLAT meta, so
+// this avoids the contract_meta nesting gotcha on graph nodes.
+func resolveRouteTargets(reg *contracts.Registry, route, file string, allowed map[string]bool) []contracts.Contract {
+	seen := map[string]bool{}
+	var out []contracts.Contract
+	for _, c := range reg.All() {
+		if c.Role != contracts.RoleProvider || c.Type != contracts.ContractHTTP {
+			continue
+		}
+		if allowed != nil && c.RepoPrefix != "" && !allowed[c.RepoPrefix] {
+			continue
+		}
+		path := metaStr(c.Meta, "path")
+		match := false
+		if route != "" && path != "" && strings.Contains(path, route) {
+			match = true
+		}
+		if file != "" && c.FilePath != "" && strings.Contains(c.FilePath, file) {
+			match = true
+		}
+		if !match || seen[c.ID] {
+			continue
+		}
+		seen[c.ID] = true
+		out = append(out, c)
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+// consumerFileFanout counts, per consumer file, how many distinct route
+// contract IDs that file consumes — the multi-fetch heuristic that downgrades
+// a mismatch's confidence (one file fetching many routes is a weaker signal
+// that a given field belongs to a given route).
+func consumerFileFanout(reg *contracts.Registry) map[string]int {
+	perFile := map[string]map[string]bool{}
+	for _, c := range reg.All() {
+		if c.Role != contracts.RoleConsumer || c.FilePath == "" {
+			continue
+		}
+		if perFile[c.FilePath] == nil {
+			perFile[c.FilePath] = map[string]bool{}
+		}
+		perFile[c.FilePath][c.ID] = true
+	}
+	out := make(map[string]int, len(perFile))
+	for f, ids := range perFile {
+		out[f] = len(ids)
+	}
+	return out
+}
+
+func (s *Server) buildAPIImpactReport(p contracts.Contract, reg *contracts.Registry, lookup contracts.ShapeLookup, fanout map[string]int) apiImpactReport {
+	rep := apiImpactReport{
+		Route:   p.ID,
+		Method:  metaStr(p.Meta, "method"),
+		Path:    metaStr(p.Meta, "path"),
+		Handler: p.SymbolID,
+		Repo:    p.RepoPrefix,
+	}
+	rep.ResponseShape = apiImpactShape{Success: envelopeNames(p.Meta)}
+	if len(rep.ResponseShape.Success) == 0 {
+		rep.ResponseShape.Note = "no response envelope extracted for this route"
+	}
+
+	// Consumers = consumer-role contracts sharing this canonical ID (same-repo
+	// and cross-repo via the contract matcher's pairing).
+	repoToConsumer := map[string]string{}
+	for _, c := range reg.ByID(p.ID) {
+		if c.Role != contracts.RoleConsumer {
+			continue
+		}
+		name := s.nodeName(c.SymbolID)
+		cons := apiImpactConsumer{
+			Name:     name,
+			File:     c.FilePath,
+			Repo:     c.RepoPrefix,
+			Accesses: consumerAccesses(c, lookup),
+		}
+		if fanout[c.FilePath] > 1 {
+			cons.AttributionNote = fmt.Sprintf("file consumes %d routes; field attribution is approximate", fanout[c.FilePath])
+		}
+		rep.Consumers = append(rep.Consumers, cons)
+		if c.RepoPrefix != "" {
+			repoToConsumer[c.RepoPrefix] = name
+		}
+	}
+	sort.SliceStable(rep.Consumers, func(i, j int) bool { return rep.Consumers[i].Name < rep.Consumers[j].Name })
+
+	// Mismatches via real field-level shape diffing (contracts.Validate over a
+	// sub-registry of just this route + its consumers).
+	sub := contracts.NewRegistry()
+	sub.Add(p)
+	for _, c := range reg.ByID(p.ID) {
+		if c.Role == contracts.RoleConsumer {
+			sub.Add(c)
+		}
+	}
+	breaking := 0
+	for _, issue := range contracts.Validate(sub, lookup) {
+		if issue.Field == "" {
+			continue
+		}
+		if issue.Severity == contracts.SeverityBreaking {
+			breaking++
+		}
+		confidence := "low"
+		if issue.Severity == contracts.SeverityBreaking {
+			confidence = "high"
+		}
+		consumerName := repoToConsumer[issue.Consumer]
+		if consumerName == "" {
+			consumerName = issue.Consumer
+		}
+		// A consumer file fetching many routes weakens per-field attribution.
+		reason := issue.Details
+		if reason == "" {
+			reason = issue.Kind
+		}
+		rep.Mismatches = append(rep.Mismatches, apiImpactMismatch{
+			Consumer:   consumerName,
+			Field:      issue.Field,
+			Reason:     reason,
+			Confidence: confidence,
+		})
+	}
+	sort.SliceStable(rep.Mismatches, func(i, j int) bool {
+		if rep.Mismatches[i].Consumer != rep.Mismatches[j].Consumer {
+			return rep.Mismatches[i].Consumer < rep.Mismatches[j].Consumer
+		}
+		return rep.Mismatches[i].Field < rep.Mismatches[j].Field
+	})
+
+	// Blast radius + execution flows from the real impact analysis.
+	var impact *analysis.ImpactResult
+	if p.SymbolID != "" {
+		impact = analysis.AnalyzeImpact(s.graph, []string{p.SymbolID}, s.getCommunities(), s.getProcesses())
+	}
+	if impact != nil {
+		rep.ExecutionFlows = impact.AffectedProcesses
+		rep.ImpactSummary.AffectedFlows = len(impact.AffectedProcesses)
+		rep.ImpactSummary.AffectedCallers = impact.TotalAffected
+		rep.ImpactSummary.TestFilesToRun = impact.TestFiles
+	}
+
+	// Middleware: best-effort from annotation edges on the handler. Never
+	// fabricate — mark unavailable when nothing is extracted.
+	rep.Middleware = s.handlerMiddleware(p.SymbolID)
+	if len(rep.Middleware) == 0 {
+		rep.MiddlewareDetection = "unavailable: gortex does not extract HTTP middleware chains; none inferable from annotations"
+	}
+
+	// Risk fusion: consumer-count tier, bumped on any mismatch, max'd with the
+	// blast-radius risk, forced HIGH when the route carries breaking drift.
+	impactRisk := analysis.RiskLow
+	if impact != nil {
+		impactRisk = impact.Risk
+	}
+	risk, upgrade := fuseRouteRisk(len(rep.Consumers), len(rep.Mismatches), impactRisk, breaking)
+	rep.ImpactSummary.DirectConsumers = len(rep.Consumers)
+	rep.ImpactSummary.RiskLevel = string(risk)
+	rep.ImpactSummary.ContractRiskUpgrade = upgrade
+	if len(rep.Consumers) > 0 {
+		rep.ImpactSummary.Warning = fmt.Sprintf("changing the response shape of %s will affect %d consumer(s)", p.ID, len(rep.Consumers))
+	}
+	return rep
+}
+
+// fuseRouteRisk combines GitNexus's consumer-count heuristic (>=10 HIGH, >=4
+// MEDIUM, else LOW; +1 level on any mismatch) with gortex's real blast-radius
+// risk tier, and forces HIGH when the route is a contract boundary with
+// existing breaking drift.
+func fuseRouteRisk(consumers, mismatches int, impactRisk analysis.RiskLevel, breaking int) (analysis.RiskLevel, string) {
+	base := 0 // 0=LOW 1=MEDIUM 2=HIGH
+	switch {
+	case consumers >= 10:
+		base = 2
+	case consumers >= 4:
+		base = 1
+	}
+	if mismatches > 0 && base < 2 {
+		base++
+	}
+	if r := riskRank(impactRisk); r > base {
+		base = r
+	}
+	if breaking > 0 {
+		return analysis.RiskHigh, "risk raised to HIGH — route is a contract boundary with breaking response-shape drift"
+	}
+	return riskFromRank(base), ""
+}
+
+func riskRank(r analysis.RiskLevel) int {
+	switch r {
+	case analysis.RiskCritical, analysis.RiskHigh:
+		return 2
+	case analysis.RiskMedium:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func riskFromRank(n int) analysis.RiskLevel {
+	switch {
+	case n >= 2:
+		return analysis.RiskHigh
+	case n == 1:
+		return analysis.RiskMedium
+	default:
+		return analysis.RiskLow
+	}
+}
+
+// contractShapeLookup resolves a type symbol ID to its field-level Shape from
+// the graph (the same closure handleValidateContracts / computeContractImpact
+// use).
+func (s *Server) contractShapeLookup() contracts.ShapeLookup {
+	return contracts.ShapeLookup(func(id string) *contracts.Shape {
+		n := s.graph.GetNode(id)
+		if n == nil || n.Meta == nil {
+			return nil
+		}
+		switch v := n.Meta["shape"].(type) {
+		case *contracts.Shape:
+			return v
+		case contracts.Shape:
+			return &v
+		}
+		return nil
+	})
+}
+
+// consumerAccesses returns the field names a consumer expects from the route's
+// response — the fields of the consumer contract's response_type shape.
+func consumerAccesses(c contracts.Contract, lookup contracts.ShapeLookup) []string {
+	respType := metaStr(c.Meta, "response_type")
+	if respType == "" || lookup == nil {
+		return nil
+	}
+	sh := lookup(respType)
+	if sh == nil {
+		return nil
+	}
+	names := make([]string, 0, len(sh.Fields))
+	for _, f := range sh.Fields {
+		if f.Name != "" {
+			names = append(names, f.Name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// handlerMiddleware collects annotation targets on a handler symbol as a
+// best-effort middleware list (decorators like @UseGuards / withAuth).
+func (s *Server) handlerMiddleware(symbolID string) []string {
+	if symbolID == "" {
+		return nil
+	}
+	var out []string
+	seen := map[string]bool{}
+	for _, e := range s.graph.GetOutEdges(symbolID) {
+		if e.Kind != graph.EdgeAnnotated {
+			continue
+		}
+		name := s.nodeName(e.To)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// envelopeNames extracts the success response key names from a route's flat
+// response_envelope meta ([]map with a "name" key).
+func envelopeNames(meta map[string]any) []string {
+	raw, ok := meta["response_envelope"]
+	if !ok {
+		return nil
+	}
+	var names []string
+	switch env := raw.(type) {
+	case []map[string]any:
+		for _, row := range env {
+			if n, _ := row["name"].(string); n != "" {
+				names = append(names, n)
+			}
+		}
+	case []any:
+		for _, r := range env {
+			if row, ok := r.(map[string]any); ok {
+				if n, _ := row["name"].(string); n != "" {
+					names = append(names, n)
+				}
+			}
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+func metaStr(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	v, _ := m[key].(string)
+	return v
+}
+
+func (s *Server) nodeName(id string) string {
+	if id == "" {
+		return ""
+	}
+	if n := s.graph.GetNode(id); n != nil && n.Name != "" {
+		return n.Name
+	}
+	if i := strings.LastIndex(id, "::"); i >= 0 {
+		return id[i+2:]
+	}
+	return id
+}

--- a/internal/mcp/tools_api_impact_test.go
+++ b/internal/mcp/tools_api_impact_test.go
@@ -1,0 +1,162 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/analysis"
+	"github.com/zzet/gortex/internal/contracts"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/query"
+)
+
+func apiImpactTestServer(t *testing.T) *Server {
+	t.Helper()
+	g := graph.New()
+	// Handler + response type with a field-level shape.
+	g.AddNode(&graph.Node{ID: "api/users.go::ListUsers", Kind: graph.KindFunction, Name: "ListUsers", FilePath: "api/users.go"})
+	g.AddNode(&graph.Node{ID: "t.go::UsersResponse", Kind: graph.KindType, Name: "UsersResponse", FilePath: "t.go",
+		Meta: map[string]any{"shape": &contracts.Shape{Kind: "struct", Fields: []contracts.ShapeField{{Name: "data", Type: "[]User"}, {Name: "pagination", Type: "Pagination"}}}}})
+	// Two consumer shapes: one clean, one accessing a missing field.
+	g.AddNode(&graph.Node{ID: "web::CleanShape", Kind: graph.KindType, Name: "CleanShape",
+		Meta: map[string]any{"shape": &contracts.Shape{Kind: "interface", Fields: []contracts.ShapeField{{Name: "data", Type: "any"}, {Name: "pagination", Type: "any"}}}}})
+	g.AddNode(&graph.Node{ID: "web::MismatchShape", Kind: graph.KindType, Name: "MismatchShape",
+		Meta: map[string]any{"shape": &contracts.Shape{Kind: "interface", Fields: []contracts.ShapeField{{Name: "items", Type: "any"}}}}})
+	g.AddNode(&graph.Node{ID: "web/list.tsx::GrantsList", Kind: graph.KindFunction, Name: "GrantsList", FilePath: "web/list.tsx"})
+	g.AddNode(&graph.Node{ID: "web/hook.ts::useUsers", Kind: graph.KindFunction, Name: "useUsers", FilePath: "web/hook.ts"})
+
+	srv := NewServer(query.NewEngine(g), g, nil, nil, zap.NewNop(), nil)
+
+	reg := contracts.NewRegistry()
+	reg.Add(contracts.Contract{
+		ID: "http::GET::/v1/users", Type: contracts.ContractHTTP, Role: contracts.RoleProvider,
+		SymbolID: "api/users.go::ListUsers", FilePath: "api/users.go",
+		Meta: map[string]any{
+			"method": "GET", "path": "/v1/users",
+			"response_type":     "t.go::UsersResponse",
+			"response_envelope": []map[string]any{{"name": "data"}, {"name": "pagination"}},
+		},
+	})
+	reg.Add(contracts.Contract{
+		ID: "http::GET::/v1/users", Type: contracts.ContractHTTP, Role: contracts.RoleConsumer,
+		SymbolID: "web/list.tsx::GrantsList", FilePath: "web/list.tsx", RepoPrefix: "web",
+		Meta: map[string]any{"response_type": "web::CleanShape"},
+	})
+	reg.Add(contracts.Contract{
+		ID: "http::GET::/v1/users", Type: contracts.ContractHTTP, Role: contracts.RoleConsumer,
+		SymbolID: "web/hook.ts::useUsers", FilePath: "web/hook.ts", RepoPrefix: "web",
+		Meta: map[string]any{"response_type": "web::MismatchShape"},
+	})
+	srv.contractRegistry = reg
+	return srv
+}
+
+func callAPIImpact(t *testing.T, srv *Server, args map[string]any) *mcplib.CallToolResult {
+	t.Helper()
+	req := mcplib.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := srv.handleAPIImpact(t.Context(), req)
+	require.NoError(t, err)
+	return res
+}
+
+func TestAPIImpact_ResolveByRoute(t *testing.T) {
+	srv := apiImpactTestServer(t)
+	res := callAPIImpact(t, srv, map[string]any{"route": "/v1/users"})
+	require.False(t, res.IsError, "errored: %v", res)
+
+	var rep apiImpactReport
+	require.NoError(t, json.Unmarshal([]byte(res.Content[0].(mcplib.TextContent).Text), &rep))
+	require.Equal(t, "http::GET::/v1/users", rep.Route)
+	require.Equal(t, "GET", rep.Method)
+	require.Equal(t, "api/users.go::ListUsers", rep.Handler)
+	require.Equal(t, []string{"data", "pagination"}, rep.ResponseShape.Success)
+	require.Len(t, rep.Consumers, 2)
+	require.NotEmpty(t, rep.ImpactSummary.RiskLevel)
+	require.Equal(t, 2, rep.ImpactSummary.DirectConsumers)
+
+	// Consumer accessed fields come from each consumer's response_type shape.
+	byName := map[string][]string{}
+	for _, c := range rep.Consumers {
+		byName[c.Name] = c.Accesses
+	}
+	require.Equal(t, []string{"data", "pagination"}, byName["GrantsList"])
+	require.Equal(t, []string{"items"}, byName["useUsers"])
+}
+
+func TestAPIImpact_ResolveByFile(t *testing.T) {
+	srv := apiImpactTestServer(t)
+	res := callAPIImpact(t, srv, map[string]any{"file": "api/users"})
+	require.False(t, res.IsError)
+	var rep apiImpactReport
+	require.NoError(t, json.Unmarshal([]byte(res.Content[0].(mcplib.TextContent).Text), &rep))
+	require.Equal(t, "http::GET::/v1/users", rep.Route)
+}
+
+func TestAPIImpact_NoMatch(t *testing.T) {
+	srv := apiImpactTestServer(t)
+	res := callAPIImpact(t, srv, map[string]any{"route": "/nonexistent"})
+	require.True(t, res.IsError, "expected error for no matching route")
+}
+
+func TestAPIImpact_RequiresTarget(t *testing.T) {
+	srv := apiImpactTestServer(t)
+	res := callAPIImpact(t, srv, map[string]any{})
+	require.True(t, res.IsError, "expected error when neither route nor file is given")
+}
+
+func TestAPIImpact_MiddlewareUnavailable(t *testing.T) {
+	srv := apiImpactTestServer(t)
+	res := callAPIImpact(t, srv, map[string]any{"route": "/v1/users"})
+	var rep apiImpactReport
+	require.NoError(t, json.Unmarshal([]byte(res.Content[0].(mcplib.TextContent).Text), &rep))
+	require.Empty(t, rep.Middleware)
+	require.Contains(t, rep.MiddlewareDetection, "unavailable")
+}
+
+func TestAPIImpact_GCXFormat(t *testing.T) {
+	srv := apiImpactTestServer(t)
+	req := mcplib.CallToolRequest{}
+	req.Params.Name = "api_impact"
+	req.Params.Arguments = map[string]any{"route": "/v1/users", "format": "gcx"}
+	res, err := srv.handleAPIImpact(t.Context(), req)
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	text := res.Content[0].(mcplib.TextContent).Text
+	require.Contains(t, text, "api_impact.routes")
+	require.Contains(t, text, "api_impact.consumers")
+}
+
+func TestFuseRouteRisk(t *testing.T) {
+	cases := []struct {
+		name      string
+		consumers int
+		mismatch  int
+		impact    analysis.RiskLevel
+		breaking  int
+		want      analysis.RiskLevel
+		upgrade   bool
+	}{
+		{"many consumers", 11, 0, analysis.RiskLow, 0, analysis.RiskHigh, false},
+		{"medium consumers", 5, 0, analysis.RiskLow, 0, analysis.RiskMedium, false},
+		{"low bumped by mismatch", 2, 1, analysis.RiskLow, 0, analysis.RiskMedium, false},
+		{"breaking forces high", 0, 0, analysis.RiskLow, 1, analysis.RiskHigh, true},
+		{"impact dominates", 0, 0, analysis.RiskHigh, 0, analysis.RiskHigh, false},
+		{"all low", 1, 0, analysis.RiskLow, 0, analysis.RiskLow, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, upgrade := fuseRouteRisk(tc.consumers, tc.mismatch, tc.impact, tc.breaking)
+			if got != tc.want {
+				t.Errorf("fuseRouteRisk = %s, want %s", got, tc.want)
+			}
+			if (upgrade != "") != tc.upgrade {
+				t.Errorf("upgrade=%q, want present=%v", upgrade, tc.upgrade)
+			}
+		})
+	}
+}

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -31,6 +31,12 @@ const minTierParamDescription = "Filter edges by minimum confidence tier. " +
 	"text_matched (name-only). Omit for no filter. " +
 	"Use lsp_resolved for high-stakes refactors where false positives are expensive."
 
+const includeSpeculativeParamDescription = "Include best-guess speculative " +
+	"dynamic-dispatch edges (computed-member calls like obj[name](), getattr, " +
+	"decorator registries). Default false — these are hidden low-confidence " +
+	"fan-outs minted only when synthesize_speculative_dispatch is enabled; " +
+	"set true to surface them (each carries candidate_count + a speculative tier)."
+
 // isCompact checks if the compact flag is set in the request.
 func isCompact(req mcp.CallToolRequest) bool {
 	if v, ok := req.GetArguments()["compact"].(bool); ok {
@@ -844,6 +850,7 @@ func (s *Server) registerCoreTools() {
 			mcp.WithString("format", mcp.Description("Output format: json (default), gcx (GCX1 compact wire format), or toon")),
 			mcp.WithNumber("max_bytes", mcp.Description("Cap the marshaled response at this many bytes. The longest list is trimmed; truncation metadata rides on the response. Omit for no cap.")),
 			mcp.WithString("min_tier", mcp.Description(minTierParamDescription)),
+			mcp.WithBoolean("include_speculative", mcp.Description(includeSpeculativeParamDescription)),
 		),
 		s.handleGetDependencies,
 	)
@@ -858,6 +865,7 @@ func (s *Server) registerCoreTools() {
 			mcp.WithString("format", mcp.Description("Output format: json (default), gcx (GCX1 compact wire format), or toon")),
 			mcp.WithNumber("max_bytes", mcp.Description("Cap the marshaled response at this many bytes. The longest list is trimmed; truncation metadata rides on the response. Omit for no cap.")),
 			mcp.WithString("min_tier", mcp.Description(minTierParamDescription)),
+			mcp.WithBoolean("include_speculative", mcp.Description(includeSpeculativeParamDescription)),
 		),
 		s.handleGetDependents,
 	)
@@ -876,6 +884,7 @@ func (s *Server) registerCoreTools() {
 			mcp.WithString("project", mcp.Description("Filter results to repositories in a specific project")),
 			mcp.WithString("ref", mcp.Description("Filter results to repositories with a specific reference tag")),
 			mcp.WithString("min_tier", mcp.Description(minTierParamDescription)),
+			mcp.WithBoolean("include_speculative", mcp.Description(includeSpeculativeParamDescription)),
 		),
 		s.handleGetCallChain,
 	)
@@ -890,6 +899,7 @@ func (s *Server) registerCoreTools() {
 			mcp.WithString("format", mcp.Description("Output format: json (default), gcx (GCX1 compact wire format), or toon")),
 			mcp.WithNumber("max_bytes", mcp.Description("Cap the marshaled response at this many bytes. The longest list is trimmed; truncation metadata rides on the response. Omit for no cap.")),
 			mcp.WithString("min_tier", mcp.Description(minTierParamDescription)),
+			mcp.WithBoolean("include_speculative", mcp.Description(includeSpeculativeParamDescription)),
 			mcp.WithBoolean("exclude_tests", mcp.Description("Drop callers originating in test functions (set true when you want production callers only)")),
 		),
 		s.handleGetCallers,
@@ -902,6 +912,7 @@ func (s *Server) registerCoreTools() {
 			mcp.WithString("format", mcp.Description("Output format: json (default), gcx (GCX1 compact wire format), or toon")),
 			mcp.WithNumber("max_bytes", mcp.Description("Cap the marshaled response at this many bytes. The longest list is trimmed; truncation metadata rides on the response. Omit for no cap.")),
 			mcp.WithString("min_tier", mcp.Description(minTierParamDescription)),
+			mcp.WithBoolean("include_speculative", mcp.Description(includeSpeculativeParamDescription)),
 		),
 		s.handleFindImplementations,
 	)
@@ -914,6 +925,7 @@ func (s *Server) registerCoreTools() {
 			mcp.WithString("format", mcp.Description("Output format: json (default), gcx (GCX1 compact wire format), or toon")),
 			mcp.WithNumber("max_bytes", mcp.Description("Cap the marshaled response at this many bytes. The longest list is trimmed; truncation metadata rides on the response. Omit for no cap.")),
 			mcp.WithString("min_tier", mcp.Description(minTierParamDescription)),
+			mcp.WithBoolean("include_speculative", mcp.Description(includeSpeculativeParamDescription)),
 		),
 		s.handleFindOverrides,
 	)
@@ -928,6 +940,7 @@ func (s *Server) registerCoreTools() {
 			mcp.WithString("format", mcp.Description("Output format: json (default), gcx (GCX1 compact wire format), or toon")),
 			mcp.WithNumber("max_bytes", mcp.Description("Cap the marshaled response at this many bytes. The longest list is trimmed; truncation metadata rides on the response. Omit for no cap.")),
 			mcp.WithString("min_tier", mcp.Description(minTierParamDescription)),
+			mcp.WithBoolean("include_speculative", mcp.Description(includeSpeculativeParamDescription)),
 		),
 		s.handleGetClassHierarchy,
 	)
@@ -945,6 +958,7 @@ func (s *Server) registerCoreTools() {
 			mcp.WithString("project", mcp.Description("Filter results to repositories in a specific project")),
 			mcp.WithString("ref", mcp.Description("Filter results to repositories with a specific reference tag")),
 			mcp.WithString("min_tier", mcp.Description(minTierParamDescription)),
+			mcp.WithBoolean("include_speculative", mcp.Description(includeSpeculativeParamDescription)),
 			mcp.WithBoolean("exclude_tests", mcp.Description("Drop references originating in test functions (set true to see only production usages)")),
 			mcp.WithString("group_by", mcp.Description("Set to \"file\" to bucket the usages by the file each reference originates in -- each group carries the per-file use count and the enclosing symbol of every reference. Omit for the default flat result.")),
 			mcp.WithString("context", mcp.Description("Filter usages by their reference context — the role the symbol plays at each site: parameter_type, return_type, field, value, type, attribute, generic_arg, or call. Every returned usage also carries its classified context. Omit for all usages.")),
@@ -1889,6 +1903,7 @@ func (s *Server) handleGetDependencies(ctx context.Context, req mcp.CallToolRequ
 	}
 	sg := s.engineFor(ctx).GetDependencies(id, opts)
 	sg.FilterByMinTier(minTier)
+	sg.FilterSpeculative(req.GetBool("include_speculative", false))
 	enrichSubGraphEdges(sg)
 	return s.returnSubGraph(ctx, req, sg)
 }
@@ -1910,6 +1925,7 @@ func (s *Server) handleGetDependents(ctx context.Context, req mcp.CallToolReques
 	}
 	sg := s.engineFor(ctx).GetDependents(id, opts)
 	sg.FilterByMinTier(minTier)
+	sg.FilterSpeculative(req.GetBool("include_speculative", false))
 	enrichSubGraphEdges(sg)
 	return s.returnSubGraph(ctx, req, sg)
 }
@@ -1939,6 +1955,7 @@ func (s *Server) handleGetCallChain(ctx context.Context, req mcp.CallToolRequest
 	}
 	sg = filterSubGraph(sg, allowed)
 	sg.FilterByMinTier(minTier)
+	sg.FilterSpeculative(req.GetBool("include_speculative", false))
 	enrichSubGraphEdges(sg)
 	annotateProxyFreshness(sg)
 	return s.returnSubGraph(ctx, req, sg)
@@ -1963,6 +1980,7 @@ func (s *Server) handleGetCallers(ctx context.Context, req mcp.CallToolRequest) 
 	s.hydrateProxyTargets(ctx, id)
 	sg := s.engineFor(ctx).GetCallers(id, opts)
 	sg.FilterByMinTier(minTier)
+	sg.FilterSpeculative(req.GetBool("include_speculative", false))
 	enrichSubGraphEdges(sg)
 	annotateCallerConcurrency(s.engineFor(ctx).Reader(), sg, id)
 	if len(sg.Edges) == 0 {
@@ -2149,6 +2167,7 @@ func (s *Server) handleFindUsages(ctx context.Context, req mcp.CallToolRequest) 
 	}
 	sg = filterSubGraph(sg, allowed)
 	sg.FilterByMinTier(minTier)
+	sg.FilterSpeculative(req.GetBool("include_speculative", false))
 	enrichSubGraphEdges(sg)
 	// Classify each usage's reference context (parameter_type / return_type
 	// / field / value / type / attribute / call) and optionally filter to

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -1968,6 +1968,13 @@ func (s *Server) handleGetCallers(ctx context.Context, req mcp.CallToolRequest) 
 	if len(sg.Edges) == 0 {
 		sg.Caveat = graph.CaveatForZeroEdge(s.graph, id)
 	}
+	// Epistemic lower bound: a caller walk over in-edges cannot see callers
+	// that reach this symbol through interface dispatch the resolver left
+	// unbound. Flag the floor + name the interface so the agent can widen it.
+	if bs := graph.CallerBoundaries(s.graph, []string{id}, 0); len(bs) > 0 {
+		sg.Boundaries = bs
+		sg.LowerBound = graph.LowerBoundCaveat(bs)
+	}
 	annotateProxyFreshness(sg)
 	return s.returnSubGraph(ctx, req, sg)
 }

--- a/internal/mcp/tools_dataflow.go
+++ b/internal/mcp/tools_dataflow.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
 
 	wire "github.com/gortexhq/gcx-go"
+	"github.com/zzet/gortex/internal/callpath"
 	"github.com/zzet/gortex/internal/dataflow"
 	"github.com/zzet/gortex/internal/graph"
 )
@@ -51,6 +53,22 @@ func (s *Server) registerDataflowTools() {
 		),
 		s.handleTaintPaths,
 	)
+
+	s.addTool(
+		mcp.NewTool("trace_path",
+			mcp.WithDescription("Traces the shortest call path from one symbol to another over the CALLS-class graph (calls + cross-service matches + method-value references), and — when no path exists — returns a structured why-unreachable diagnosis. Distinct from flow_between (dataflow: where a *value* moves) and get_call_chain (single-source forward call BFS, no target): trace_path is a *targeted* A→B search using balanced bidirectional BFS, so it returns THE shortest route with per-hop provenance (lsp/ast/heuristic). On failure it names exactly where the chain dies: the furthest functions reachable from the source, the nearest set that can reach the sink, the dynamic-dispatch / external boundaries the reach terminated at, and a classified reason (crosses_dynamic_dispatch, crosses_external_boundary, depth_exceeded, disconnected, src_no_out_edges, sink_no_in_edges)."),
+			mcp.WithString("source_id", mcp.Required(), mcp.Description("Source symbol node ID — the call-path origin (typically a function or method)")),
+			mcp.WithString("sink_id", mcp.Required(), mcp.Description("Sink symbol node ID — the call-path destination")),
+			mcp.WithNumber("max_depth", mcp.Description("Maximum combined BFS depth before giving up (default: 24)")),
+			mcp.WithNumber("k", mcp.Description("Number of distinct shortest-length paths to return (default: 1)")),
+			mcp.WithNumber("max_frontier", mcp.Description("Cap on the number of frontier nodes reported in the gap diagnosis (default: 25)")),
+			mcp.WithString("min_tier", mcp.Description("Minimum per-edge Origin tier to traverse. Accepts one of: lsp_resolved, lsp_dispatch, ast_resolved, ast_inferred, text_matched. Empty (default) disables the filter.")),
+			mcp.WithBoolean("include_references", mcp.Description("Traverse EdgeReferences (method-value wiring: mux.HandleFunc, command tables) in addition to direct calls (default: true). Set false for a pure direct-call path.")),
+			mcp.WithString("format", mcp.Description("Output format: json (default), gcx (GCX1 compact wire format), or toon")),
+			mcp.WithNumber("max_bytes", mcp.Description("Cap the marshaled response at this many bytes. The longest list is trimmed; truncation metadata rides on the response. Omit for no cap.")),
+		),
+		s.handleTracePath,
+	)
 }
 
 func (s *Server) handleFlowBetween(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -84,6 +102,34 @@ func (s *Server) handleFlowBetween(ctx context.Context, req mcp.CallToolRequest)
 		return returnTOON(result)
 	}
 	return s.respondJSONOrTOON(ctx, req, result)
+}
+
+func (s *Server) handleTracePath(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	source, err := req.RequireString("source_id")
+	if err != nil {
+		return mcp.NewToolResultError("source_id is required"), nil
+	}
+	sink, err := req.RequireString("sink_id")
+	if err != nil {
+		return mcp.NewToolResultError("sink_id is required"), nil
+	}
+	opts := callpath.Options{
+		MaxDepth:          req.GetInt("max_depth", callpath.DefaultMaxDepth),
+		K:                 req.GetInt("k", callpath.DefaultK),
+		MaxFrontier:       req.GetInt("max_frontier", callpath.DefaultMaxFrontier),
+		MinTier:           req.GetString("min_tier", ""),
+		IncludeReferences: req.GetBool("include_references", true),
+	}
+	res := callpath.New(s.graph).ShortestPath(source, sink, opts)
+
+	if s.isGCX(ctx, req) {
+		payload, encErr := encodeTracePath(res)
+		return s.gcxResponseWithBudget(req)(payload, encErr)
+	}
+	if s.isTOON(ctx, req) {
+		return returnTOON(res)
+	}
+	return s.respondJSONOrTOON(ctx, req, res)
 }
 
 func (s *Server) handleTaintPaths(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -194,6 +240,112 @@ func encodeFlowBetween(source, sink string, paths []dataflow.Path) ([]byte, erro
 		}
 	}
 	return buf.Bytes(), pathEnc.Close()
+}
+
+// encodeTracePath emits a GCX1 envelope with up to three sections:
+// `trace_path.summary` (one row), `trace_path.paths` (one row per returned
+// path with the flattened node + edge sequences) and — only when no path was
+// found — `trace_path.gap` (one row carrying the why-unreachable diagnosis with
+// the frontier and boundary lists flattened).
+func encodeTracePath(res callpath.Result) ([]byte, error) {
+	var buf bytes.Buffer
+	reason := ""
+	if res.Gap != nil {
+		reason = string(res.Gap.Reason)
+	}
+	shortest := 0
+	worstAll := ""
+	if len(res.Paths) > 0 {
+		shortest = res.Paths[0].Length
+		for _, p := range res.Paths {
+			worstAll = mergeWorstTier(worstAll, p.WorstTier)
+		}
+	}
+	sumEnc := wire.NewEncoder(&buf, wire.Header{
+		Tool:   "trace_path.summary",
+		Fields: []string{"source", "sink", "found", "paths", "shortest", "worst_tier", "reason"},
+	})
+	if err := sumEnc.WriteRow(res.SrcID, res.SinkID, res.Found, len(res.Paths), shortest, worstAll, reason); err != nil {
+		return nil, err
+	}
+	if err := sumEnc.Close(); err != nil {
+		return nil, err
+	}
+	pathEnc := wire.NewEncoder(&buf, wire.Header{
+		Tool:   "trace_path.paths",
+		Fields: []string{"length", "confidence", "worst_tier", "nodes", "kinds", "origins", "tiers"},
+		Meta:   map[string]string{"count": fmt.Sprintf("%d", len(res.Paths))},
+	})
+	for _, p := range res.Paths {
+		if err := pathEnc.WriteRow(p.Length, p.Confidence, p.WorstTier,
+			strings.Join(p.Nodes, ","),
+			joinTraceField(p.Edges, func(e callpath.PathEdge) string { return e.Kind }),
+			joinTraceField(p.Edges, func(e callpath.PathEdge) string { return e.Origin }),
+			joinTraceField(p.Edges, func(e callpath.PathEdge) string { return traceTier(e) })); err != nil {
+			return nil, err
+		}
+	}
+	if err := pathEnc.Close(); err != nil {
+		return nil, err
+	}
+	if res.Gap != nil {
+		gapEnc := wire.NewEncoder(&buf, wire.Header{
+			Tool:   "trace_path.gap",
+			Fields: []string{"reason", "message", "forward_reached", "backward_reached", "furthest_from_source", "nearest_to_sink", "boundary_hits"},
+		})
+		if err := gapEnc.WriteRow(
+			string(res.Gap.Reason), res.Gap.Message,
+			res.Gap.ForwardReached, res.Gap.BackwardReached,
+			joinFrontier(res.Gap.FurthestFromSource),
+			joinFrontier(res.Gap.NearestToSink),
+			joinBoundaries(res.Gap.BoundaryHits)); err != nil {
+			return nil, err
+		}
+		if err := gapEnc.Close(); err != nil {
+			return nil, err
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+func traceTier(e callpath.PathEdge) string {
+	if e.Tier != "" {
+		return e.Tier
+	}
+	return graph.ResolvedBy(e.Origin)
+}
+
+func joinTraceField(edges []callpath.PathEdge, f func(callpath.PathEdge) string) string {
+	if len(edges) == 0 {
+		return ""
+	}
+	parts := make([]string, len(edges))
+	for i, e := range edges {
+		parts[i] = f(e)
+	}
+	return strings.Join(parts, ",")
+}
+
+func joinFrontier(ns []callpath.FrontierNode) string {
+	if len(ns) == 0 {
+		return ""
+	}
+	parts := make([]string, len(ns))
+	for i, n := range ns {
+		parts[i] = fmt.Sprintf("%s:%d", n.ID, n.Depth)
+	}
+	return strings.Join(parts, ",")
+}
+
+func joinBoundaries(bs []callpath.BoundaryHit) string {
+	if len(bs) == 0 {
+		return ""
+	}
+	parts := make([]string, len(bs))
+	for i, b := range bs {
+		parts[i] = fmt.Sprintf("%s|%s", b.Target, b.Reason)
+	}
+	return strings.Join(parts, ",")
 }
 
 // encodeTaintPaths emits a GCX1 envelope with two sections:

--- a/internal/mcp/tools_enhancements.go
+++ b/internal/mcp/tools_enhancements.go
@@ -294,6 +294,21 @@ func (s *Server) registerEnhancementTools() {
 		s.handleContracts,
 	)
 
+	// api_impact — fused pre-change report for an API route handler.
+	s.addTool(
+		mcp.NewTool("api_impact",
+			mcp.WithDescription("Fused pre-change impact report for an API route — call this BEFORE modifying any route handler. Given a route path substring (or handler file substring), returns ONE report composing: the route's response shape, every consumer (same-repo and cross-repo via contract pairing) with the fields it accesses, field-level response-shape mismatches (real type-aware diffing, not regex), best-effort middleware, the execution flows (processes) it triggers, the true blast radius (affected callers + test files to run), and a fused risk level. Beats hand-assembling routes + contracts validate + impact: one call, one answer to \"what breaks if I change this endpoint?\"."),
+			mcp.WithString("route", mcp.Description("Route path substring to match (e.g. /v1/users). At least one of route|file is required.")),
+			mcp.WithString("file", mcp.Description("Handler file path substring to match — an alternative to route.")),
+			mcp.WithString("repo", mcp.Description("Filter by repository prefix")),
+			mcp.WithString("project", mcp.Description("Filter to repositories in a specific project")),
+			mcp.WithString("ref", mcp.Description("Filter to repositories tagged with this ref")),
+			mcp.WithString("format", mcp.Description("Output format: json (default), gcx (GCX1 compact wire format), or toon")),
+			mcp.WithNumber("max_bytes", mcp.Description("Cap the marshaled response at this many bytes. The longest list is trimmed; truncation metadata rides on the response. Omit for no cap.")),
+		),
+		s.handleAPIImpact,
+	)
+
 	// feedback — unified feedback tool (record + query)
 	s.addTool(
 		mcp.NewTool("feedback",

--- a/internal/mcp/tools_enhancements.go
+++ b/internal/mcp/tools_enhancements.go
@@ -760,6 +760,8 @@ func (s *Server) handleAnalyze(ctx context.Context, req mcp.CallToolRequest) (*m
 		return s.handleAnalyzeIndirectMutations(ctx, req)
 	case "speculative":
 		return s.handleAnalyzeSpeculative(ctx, req)
+	case "ref_facts":
+		return s.handleAnalyzeRefFacts(ctx, req)
 	case "race_writes":
 		return s.handleAnalyzeRaceWrites(ctx, req)
 	case "unclosed_channels":

--- a/internal/mcp/tools_enhancements.go
+++ b/internal/mcp/tools_enhancements.go
@@ -756,6 +756,8 @@ func (s *Server) handleAnalyze(ctx context.Context, req mcp.CallToolRequest) (*m
 		return s.handleAnalyzeGoroutineSpawns(ctx, req)
 	case "field_writers":
 		return s.handleAnalyzeFieldWriters(ctx, req)
+	case "indirect_mutations":
+		return s.handleAnalyzeIndirectMutations(ctx, req)
 	case "race_writes":
 		return s.handleAnalyzeRaceWrites(ctx, req)
 	case "unclosed_channels":

--- a/internal/mcp/tools_enhancements.go
+++ b/internal/mcp/tools_enhancements.go
@@ -758,6 +758,8 @@ func (s *Server) handleAnalyze(ctx context.Context, req mcp.CallToolRequest) (*m
 		return s.handleAnalyzeFieldWriters(ctx, req)
 	case "indirect_mutations":
 		return s.handleAnalyzeIndirectMutations(ctx, req)
+	case "speculative":
+		return s.handleAnalyzeSpeculative(ctx, req)
 	case "race_writes":
 		return s.handleAnalyzeRaceWrites(ctx, req)
 	case "unclosed_channels":

--- a/internal/mcp/tools_trace_path_test.go
+++ b/internal/mcp/tools_trace_path_test.go
@@ -1,0 +1,129 @@
+package mcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+	"github.com/zzet/gortex/internal/query"
+)
+
+// tracePathTestServer indexes a Go file with a known call chain
+// A→B→C→D plus an isolated function so we can exercise both the found
+// and not-found branches of trace_path.
+func tracePathTestServer(t *testing.T) *Server {
+	t.Helper()
+	dir := t.TempDir()
+	src := `package main
+
+func D() {}
+
+func C() { D() }
+
+func B() { C() }
+
+func A() { B() }
+
+func Isolated() {}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte(src), 0o644))
+	g := graph.New()
+	reg := parser.NewRegistry()
+	languages.RegisterAll(reg)
+	cfg := config.Default()
+	idx := indexer.New(g, reg, cfg.Index, zap.NewNop())
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+	idx.ResolveAll()
+	eng := query.NewEngine(g)
+	return NewServer(eng, g, idx, nil, zap.NewNop(), nil)
+}
+
+func TestHandleTracePath_FoundChain(t *testing.T) {
+	srv := tracePathTestServer(t)
+	req := mcplib.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"source_id": findFunctionID(t, srv, "A"),
+		"sink_id":   findFunctionID(t, srv, "D"),
+	}
+	res, err := srv.handleTracePath(t.Context(), req)
+	require.NoError(t, err)
+	require.False(t, res.IsError, "tool errored: %v", res)
+
+	var payload struct {
+		Found bool `json:"found"`
+		Paths []struct {
+			Nodes  []string `json:"nodes"`
+			Length int      `json:"length"`
+		} `json:"paths"`
+	}
+	text := res.Content[0].(mcplib.TextContent).Text
+	require.NoError(t, json.Unmarshal([]byte(text), &payload))
+	require.True(t, payload.Found, "expected a path; got %s", text)
+	require.Len(t, payload.Paths, 1)
+	require.Equal(t, 3, payload.Paths[0].Length, "A→B→C→D is 3 hops: %s", text)
+	require.Len(t, payload.Paths[0].Nodes, 4)
+}
+
+func TestHandleTracePath_NotFoundDiagnosis(t *testing.T) {
+	srv := tracePathTestServer(t)
+	// A reaches B,C,D; Isolated has no incoming call edges → sink_no_in.
+	req := mcplib.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"source_id": findFunctionID(t, srv, "A"),
+		"sink_id":   findFunctionID(t, srv, "Isolated"),
+	}
+	res, err := srv.handleTracePath(t.Context(), req)
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var payload struct {
+		Found bool `json:"found"`
+		Gap   *struct {
+			Reason  string `json:"reason"`
+			Message string `json:"message"`
+		} `json:"gap"`
+	}
+	text := res.Content[0].(mcplib.TextContent).Text
+	require.NoError(t, json.Unmarshal([]byte(text), &payload))
+	require.False(t, payload.Found)
+	require.NotNil(t, payload.Gap, "expected a gap diagnosis: %s", text)
+	require.Equal(t, "sink_no_in_edges", payload.Gap.Reason)
+	require.NotEmpty(t, payload.Gap.Message)
+}
+
+func TestHandleTracePath_MissingSource(t *testing.T) {
+	srv := tracePathTestServer(t)
+	req := mcplib.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"sink_id": "anything"}
+	res, err := srv.handleTracePath(t.Context(), req)
+	require.NoError(t, err)
+	require.True(t, res.IsError, "expected error for missing source_id")
+}
+
+func TestHandleTracePath_GCXFormat(t *testing.T) {
+	srv := tracePathTestServer(t)
+	req := mcplib.CallToolRequest{}
+	req.Params.Name = "trace_path"
+	req.Params.Arguments = map[string]any{
+		"source_id": findFunctionID(t, srv, "A"),
+		"sink_id":   findFunctionID(t, srv, "D"),
+		"format":    "gcx",
+	}
+	res, err := srv.handleTracePath(t.Context(), req)
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	text := res.Content[0].(mcplib.TextContent).Text
+	require.Contains(t, text, "trace_path.summary")
+	require.Contains(t, text, "trace_path.paths")
+}

--- a/internal/parser/languages/cpp.go
+++ b/internal/parser/languages/cpp.go
@@ -281,6 +281,7 @@ func (e *CppExtractor) addMethodFromNode(funcNode *sitter.Node, src []byte, file
 	if ns := enclosingCppNamespace(funcNode, src); ns != "" {
 		meta["scope_ns"] = ns
 	}
+	stampCppSignature(meta, funcNode, src)
 	result.Nodes = append(result.Nodes, &graph.Node{
 		ID: id, Kind: graph.KindMethod, Name: methodName,
 		FilePath: filePath, StartLine: startLine, EndLine: endLine,
@@ -355,6 +356,7 @@ func (e *CppExtractor) emitFunction(m parser.QueryResult, filePath, fileID strin
 	if ns := enclosingCppNamespace(def.Node, src); ns != "" {
 		meta["scope_ns"] = ns
 	}
+	stampCppSignature(meta, def.Node, src)
 	result.Nodes = append(result.Nodes, &graph.Node{
 		ID: id, Kind: graph.KindFunction, Name: name,
 		FilePath: filePath, StartLine: startLine, EndLine: def.EndLine + 1,
@@ -497,7 +499,10 @@ func extractCppCallArgTypes(callNode *sitter.Node, src []byte) []string {
 		arg := args.NamedChild(i)
 		typeName := cppArgTypeHint(arg, src)
 		if typeName == "" {
-			continue
+			// Positional placeholder so the overload ranker keeps argument
+			// alignment (an unknown arg is compatible with any param). The ADL
+			// namespace pass ignores "?" (it yields no namespace).
+			typeName = "?"
 		}
 		out = append(out, typeName)
 	}
@@ -509,6 +514,19 @@ func cppArgTypeHint(arg *sitter.Node, src []byte) string {
 		return ""
 	}
 	switch arg.Type() {
+	case "number_literal":
+		if strings.ContainsAny(arg.Content(src), ".eE") && !strings.HasPrefix(arg.Content(src), "0x") {
+			return "double"
+		}
+		return "int"
+	case "string_literal", "raw_string_literal", "concatenated_string":
+		return "string"
+	case "char_literal":
+		return "char"
+	case "true", "false":
+		return "bool"
+	case "null", "nullptr":
+		return "null"
 	case "new_expression":
 		if t := arg.ChildByFieldName("type"); t != nil {
 			return strings.TrimSpace(t.Content(src))

--- a/internal/parser/languages/cpp_signature.go
+++ b/internal/parser/languages/cpp_signature.go
@@ -1,0 +1,151 @@
+package languages
+
+import (
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+	sitter "github.com/zzet/gortex/internal/parser/tsitter"
+)
+
+// C++ signature metadata extraction. The overload resolver needs each
+// function/method's parameter types, count, required count (minus defaults),
+// variadic flag, and per-param shape (value / pointer / lvalue-ref / rvalue-ref
+// + const) to rank candidates. These are stamped as compact Meta strings
+// (gob/sqlite-roundtrip-safe) on the node:
+//
+//	cpp_param_types  = comma-joined normalized base types ("int,double")
+//	cpp_param_shapes = parallel shape codes ("v,cp,l")  (see paramShapeCode)
+//	cpp_req_params   = number of non-default parameters
+//	cpp_variadic     = "1" when the signature ends in "..."
+//
+// param count is len(cpp_param_types). The base type is normalized so int vs
+// long stays distinct (unlike GitNexus which collapses them) while cv/ref/ptr
+// and namespace qualifiers are stripped for a stable comparison key.
+
+// cppSignature is the extracted per-call-target signature.
+type cppSignature struct {
+	ParamTypes  []string
+	ParamShapes []string
+	ReqParams   int
+	Variadic    bool
+}
+
+// extractCppSignature walks a function_definition (or declaration) node's
+// parameter list. ok is false only when no function_declarator is reachable.
+func extractCppSignature(funcNode *sitter.Node, src []byte) (sig cppSignature, ok bool) {
+	if funcNode == nil {
+		return sig, false
+	}
+	decl := findCppFunctionDeclarator(funcNode)
+	if decl == nil {
+		return sig, false
+	}
+	params := decl.ChildByFieldName("parameters")
+	if params == nil {
+		return sig, true // no parameter list visible — treat as zero params
+	}
+	// `...` may be an anonymous token rather than a named
+	// variadic_parameter_declaration node depending on grammar version.
+	if strings.Contains(params.Content(src), "...") {
+		sig.Variadic = true
+	}
+	n := int(params.NamedChildCount())
+	for i := 0; i < n; i++ {
+		p := params.NamedChild(i)
+		if p == nil {
+			continue
+		}
+		switch p.Type() {
+		case "variadic_parameter_declaration":
+			sig.Variadic = true
+		case "parameter_declaration", "optional_parameter_declaration":
+			typeText := cppParamTypeText(p, src)
+			// `(void)` is C++ for an explicit empty parameter list.
+			if n == 1 && strings.TrimSpace(typeText) == "void" && p.ChildByFieldName("declarator") == nil {
+				return sig, true
+			}
+			sig.ParamTypes = append(sig.ParamTypes, graph.NormalizeCppType(typeText))
+			sig.ParamShapes = append(sig.ParamShapes, paramShapeCode(p, typeText, src))
+			if p.Type() == "parameter_declaration" {
+				sig.ReqParams++
+			}
+		}
+	}
+	return sig, true
+}
+
+// stampCppSignature writes the extracted signature onto a node's Meta. The
+// cpp_sig marker lets the resolver tell "0 params, signature known" apart from
+// "no signature extracted".
+func stampCppSignature(meta map[string]any, funcNode *sitter.Node, src []byte) {
+	sig, ok := extractCppSignature(funcNode, src)
+	if !ok {
+		return
+	}
+	meta["cpp_sig"] = "1"
+	if len(sig.ParamTypes) > 0 {
+		meta["cpp_param_types"] = strings.Join(sig.ParamTypes, ",")
+		meta["cpp_param_shapes"] = strings.Join(sig.ParamShapes, ",")
+	}
+	if sig.ReqParams > 0 {
+		meta["cpp_req_params"] = sig.ReqParams
+	}
+	if sig.Variadic {
+		meta["cpp_variadic"] = "1"
+	}
+}
+
+// findCppFunctionDeclarator descends through return-type pointer/reference
+// wrappers to the function_declarator carrying the parameter list.
+func findCppFunctionDeclarator(node *sitter.Node) *sitter.Node {
+	cur := node.ChildByFieldName("declarator")
+	for cur != nil {
+		switch cur.Type() {
+		case "function_declarator":
+			return cur
+		case "pointer_declarator", "reference_declarator", "parenthesized_declarator":
+			cur = cur.ChildByFieldName("declarator")
+		default:
+			return nil
+		}
+	}
+	return nil
+}
+
+func cppParamTypeText(p *sitter.Node, src []byte) string {
+	if t := p.ChildByFieldName("type"); t != nil {
+		return t.Content(src)
+	}
+	return ""
+}
+
+// paramShapeCode encodes a parameter's indirection + const-ness into one token:
+// optional 'c' (const) followed by v(alue) / p(ointer) / l(value-ref) /
+// r(value-ref). The const flag is read from the type field text.
+func paramShapeCode(p *sitter.Node, typeText string, src []byte) string {
+	prefix := ""
+	// `const` is a sibling type_qualifier, not part of the type field, so check
+	// the whole parameter spelling.
+	if _ = typeText; strings.Contains(p.Content(src), "const") {
+		prefix = "c"
+	}
+	d := p.ChildByFieldName("declarator")
+	for d != nil {
+		switch d.Type() {
+		case "pointer_declarator", "abstract_pointer_declarator":
+			return prefix + "p"
+		case "reference_declarator", "abstract_reference_declarator":
+			if strings.Contains(d.Content(src), "&&") {
+				return prefix + "r"
+			}
+			return prefix + "l"
+		case "parenthesized_declarator":
+			d = d.ChildByFieldName("declarator")
+		default:
+			return prefix + "v"
+		}
+	}
+	return prefix + "v"
+}
+
+// Type normalization lives in graph.NormalizeCppType so the resolver shares it.

--- a/internal/parser/languages/cpp_signature_test.go
+++ b/internal/parser/languages/cpp_signature_test.go
@@ -1,0 +1,80 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func cppNodeMeta(t *testing.T, src, nodeID string) map[string]any {
+	t.Helper()
+	res, err := NewCppExtractor().Extract("t.cpp", []byte(src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	for _, n := range res.Nodes {
+		if n.ID == nodeID {
+			return n.Meta
+		}
+	}
+	t.Fatalf("node %q not found; nodes: %v", nodeID, func() []string {
+		var ids []string
+		for _, n := range res.Nodes {
+			if n.Kind == graph.KindFunction || n.Kind == graph.KindMethod {
+				ids = append(ids, n.ID)
+			}
+		}
+		return ids
+	}())
+	return nil
+}
+
+func TestExtractCppSignature_FreeFunctions(t *testing.T) {
+	src := `void f(int x, double y) { }
+void g(int x, int y) { }
+`
+	fm := cppNodeMeta(t, src, "t.cpp::f")
+	if fm["cpp_param_types"] != "int,double" {
+		t.Errorf("f param types = %v, want int,double", fm["cpp_param_types"])
+	}
+	if fm["cpp_sig"] != "1" {
+		t.Errorf("f must carry cpp_sig marker")
+	}
+}
+
+func TestExtractCppSignature_Shapes(t *testing.T) {
+	src := `struct Foo {};
+void h(const Foo& a, Foo* b) { }
+`
+	m := cppNodeMeta(t, src, "t.cpp::h")
+	// const Foo& → cl (const lvalue-ref); Foo* → p
+	if m["cpp_param_shapes"] != "cl,p" {
+		t.Errorf("h param shapes = %v, want cl,p", m["cpp_param_shapes"])
+	}
+	if m["cpp_param_types"] != "Foo,Foo" {
+		t.Errorf("h param types = %v, want Foo,Foo", m["cpp_param_types"])
+	}
+}
+
+func TestExtractCppSignature_DefaultsVariadicVoid(t *testing.T) {
+	defm := cppNodeMeta(t, "void d(int x, int y = 0) { }\n", "t.cpp::d")
+	if defm["cpp_param_types"] != "int,int" {
+		t.Errorf("d types = %v", defm["cpp_param_types"])
+	}
+	if got := defm["cpp_req_params"]; got != 1 {
+		t.Errorf("d req params = %v, want 1 (one default)", got)
+	}
+
+	varm := cppNodeMeta(t, "void v(int x, ...) { }\n", "t.cpp::v")
+	if varm["cpp_variadic"] != "1" {
+		t.Errorf("v must be variadic, meta=%v", varm)
+	}
+
+	voidm := cppNodeMeta(t, "void e(void) { }\n", "t.cpp::e")
+	if _, has := voidm["cpp_param_types"]; has {
+		t.Errorf("e(void) must have zero params, got %v", voidm["cpp_param_types"])
+	}
+	if voidm["cpp_sig"] != "1" {
+		t.Errorf("e must still carry cpp_sig marker")
+	}
+}

--- a/internal/parser/languages/golang.go
+++ b/internal/parser/languages/golang.go
@@ -591,6 +591,19 @@ func (e *GoExtractor) Extract(filePath string, src []byte) (*parser.ExtractionRe
 		return t, ok
 	}
 
+	// recvNameByID maps a method node ID to its receiver variable name, so a
+	// selector call can be classified as invoked on the method's own receiver
+	// (s.counter.Increment() / s.helper()) — the basis for indirect
+	// receiver-field-mutation attribution.
+	recvNameByID := map[string]string{}
+	for _, n := range result.Nodes {
+		if n.Kind == graph.KindMethod && n.Meta != nil {
+			if rn, _ := n.Meta["recv_name"].(string); rn != "" {
+				recvNameByID[n.ID] = rn
+			}
+		}
+	}
+
 	// --- Calls ---
 	for _, c := range calls {
 		callerID := findEnclosingFunc(funcRanges, c.line)
@@ -676,8 +689,23 @@ func (e *GoExtractor) Extract(filePath string, src []byte) (*parser.ExtractionRe
 			From: callerID, To: target,
 			Kind: graph.EdgeCalls, FilePath: filePath, Line: c.line,
 		}
+		// Classify the call against the enclosing method's own receiver so the
+		// capability synthesizer can attribute indirect field mutations:
+		//   s.counter.Increment()  → recv_field=counter (mutates s.counter)
+		//   s.helper()             → recv_self=true     (mutates s's fields
+		//                                                 transitively via helper)
+		if recvName := recvNameByID[callerID]; recvName != "" {
+			if c.receiver == recvName {
+				edge.Meta = map[string]any{"recv_self": true}
+			} else if f, ok := ownReceiverField(c.receiver, recvName); ok {
+				edge.Meta = map[string]any{"recv_field": f}
+			}
+		}
 		if recvType, ok := lookupRecvType(callerID, c.receiver); ok {
-			edge.Meta = map[string]any{"receiver_type": recvType}
+			if edge.Meta == nil {
+				edge.Meta = map[string]any{}
+			}
+			edge.Meta["receiver_type"] = recvType
 		} else if strings.Contains(c.receiver, ".") || strings.Contains(c.receiver, "(") {
 			// Chain walk needs both the file-wide tenv and the
 			// enclosing function's parameter scope as one map. Compose
@@ -693,7 +721,10 @@ func (e *GoExtractor) Extract(filePath string, src []byte) (*parser.ExtractionRe
 				}
 			}
 			if chainType := resolveChainType(c.receiver, composed, result); chainType != "" {
-				edge.Meta = map[string]any{"receiver_type": chainType}
+				if edge.Meta == nil {
+					edge.Meta = map[string]any{}
+				}
+				edge.Meta["receiver_type"] = chainType
 			}
 		}
 		applyGoGRPCRegisterMeta(edge, c, src, tenv)
@@ -926,6 +957,23 @@ func goFuncBody(decl *sitter.Node) *sitter.Node {
 	return nil
 }
 
+// ownReceiverField returns the single field name when a selector-call receiver
+// is exactly `<recvName>.<field>` — the one-hop case `s.counter.Increment()`
+// where counter is a field of the enclosing method's own receiver. Deeper
+// chains (s.a.b) and call expressions return ok=false so the indirect-mutation
+// synthesizer never over-attributes past the first own-receiver hop.
+func ownReceiverField(receiver, recvName string) (string, bool) {
+	prefix := recvName + "."
+	if !strings.HasPrefix(receiver, prefix) {
+		return "", false
+	}
+	rest := receiver[len(prefix):]
+	if rest == "" || strings.ContainsAny(rest, ".([ ") {
+		return "", false
+	}
+	return rest, true
+}
+
 func (e *GoExtractor) emitMethod(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, paramsByFunc map[string]typeEnv, imports map[string]string) {
 	name := m.Captures["method.name"].Text
 	def := m.Captures["method.def"]
@@ -956,6 +1004,9 @@ func (e *GoExtractor) emitMethod(m parser.QueryResult, filePath, fileID string, 
 		Meta: map[string]any{
 			"receiver": receiverType,
 		},
+	}
+	if recvName := extractReceiverName(receiverText); recvName != "" {
+		node.Meta["recv_name"] = recvName
 	}
 	node.Meta["signature"] = buildMethodSignature(receiverText, name, m.Captures["method.params"], m.Captures["method.result"])
 	if resultCap, ok := m.Captures["method.result"]; ok && resultCap.Text != "" {

--- a/internal/parser/languages/javascript.go
+++ b/internal/parser/languages/javascript.go
@@ -2,6 +2,7 @@ package languages
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/parser"
@@ -243,6 +244,22 @@ func (e *JavaScriptExtractor) Extract(filePath string, src []byte) (*parser.Extr
 		})
 	}
 
+	// Store-factory destructuring: `const {a,b} = useStore.getState()` binds
+	// later bare `a()` / `b()` calls to the store's actions.
+	destructured := map[string]string{} // local action name → store binding
+	for _, dm := range jsDestructureGetStateRE.FindAllStringSubmatch(string(src), -1) {
+		binding := dm[2]
+		for _, nm := range strings.Split(dm[1], ",") {
+			nm = strings.TrimSpace(nm)
+			if i := strings.IndexByte(nm, ':'); i >= 0 { // {a: alias} → key on alias
+				nm = strings.TrimSpace(nm[i+1:])
+			}
+			if nm != "" {
+				destructured[nm] = binding
+			}
+		}
+	}
+
 	// Resolve calls against funcRanges.
 	funcRanges := buildFuncRanges(result)
 	for _, c := range calls {
@@ -267,9 +284,43 @@ func (e *JavaScriptExtractor) Extract(filePath string, src []byte) (*parser.Extr
 					continue
 				}
 			}
+			// Store-factory chained call: `useStore.getState().action()`.
+			if binding, ok := jsParseGetStateChain(c.receiver); ok {
+				if memberID := objLiteralMembers[binding][c.name]; memberID != "" {
+					result.Edges = append(result.Edges, &graph.Edge{
+						From: callerID, To: memberID,
+						Kind: graph.EdgeCalls, FilePath: filePath, Line: c.line,
+						Origin: graph.OriginASTResolved, Confidence: 0.9,
+					})
+					continue
+				}
+				result.Edges = append(result.Edges, &graph.Edge{
+					From: callerID, To: "unresolved::*." + c.name,
+					Kind: graph.EdgeCalls, FilePath: filePath, Line: c.line,
+					Meta: map[string]any{"via": "store-factory", "store_binding": binding, "store_action": c.name},
+				})
+				continue
+			}
 			result.Edges = append(result.Edges, &graph.Edge{
 				From: callerID, To: "unresolved::*." + c.name,
 				Kind: graph.EdgeCalls, FilePath: filePath, Line: c.line,
+			})
+			continue
+		}
+		// Store-factory destructured call: `const {a}=useStore.getState(); a()`.
+		if binding, ok := destructured[c.name]; ok {
+			if memberID := objLiteralMembers[binding][c.name]; memberID != "" {
+				result.Edges = append(result.Edges, &graph.Edge{
+					From: callerID, To: memberID,
+					Kind: graph.EdgeCalls, FilePath: filePath, Line: c.line,
+					Origin: graph.OriginASTResolved, Confidence: 0.9,
+				})
+				continue
+			}
+			result.Edges = append(result.Edges, &graph.Edge{
+				From: callerID, To: "unresolved::" + c.name,
+				Kind: graph.EdgeCalls, FilePath: filePath, Line: c.line,
+				Meta: map[string]any{"via": "store-factory", "store_binding": binding, "store_action": c.name},
 			})
 			continue
 		}
@@ -482,6 +533,12 @@ func (e *JavaScriptExtractor) emitObjectLiteralMethod(m parser.QueryResult, file
 		return "", "", ""
 	}
 	owner = jsObjectOwnerName(def.Node, src)
+	storeFactory := ""
+	if owner == "" || jsIsStoreOptionKey(owner) {
+		if b, _, ok := jsStoreFactoryBinding(def.Node, src); ok {
+			owner, storeFactory = b, b
+		}
+	}
 	name := member
 	if owner != "" {
 		name = owner + "." + member
@@ -491,6 +548,10 @@ func (e *JavaScriptExtractor) emitObjectLiteralMethod(m parser.QueryResult, file
 		ID: id, Kind: graph.KindFunction, Name: name,
 		FilePath: filePath, StartLine: def.StartLine + 1, EndLine: def.EndLine + 1,
 		Language: "javascript", Meta: map[string]any{"signature": fmt.Sprintf("%s()", name)},
+	}
+	if storeFactory != "" {
+		node.Meta["store_factory"] = storeFactory
+		node.Meta["store_member"] = member
 	}
 	result.Nodes = append(result.Nodes, node)
 	result.Edges = append(result.Edges, &graph.Edge{
@@ -522,6 +583,12 @@ func (e *JavaScriptExtractor) emitObjectArrowField(m parser.QueryResult, filePat
 		return "", "", ""
 	}
 	owner = jsObjectOwnerName(def.Node, src)
+	storeFactory := ""
+	if owner == "" || jsIsStoreOptionKey(owner) {
+		if b, _, ok := jsStoreFactoryBinding(def.Node, src); ok {
+			owner, storeFactory = b, b
+		}
+	}
 	name := member
 	if owner != "" {
 		name = owner + "." + member
@@ -531,6 +598,10 @@ func (e *JavaScriptExtractor) emitObjectArrowField(m parser.QueryResult, filePat
 		ID: id, Kind: graph.KindFunction, Name: name,
 		FilePath: filePath, StartLine: def.StartLine + 1, EndLine: def.EndLine + 1,
 		Language: "javascript", Meta: map[string]any{"signature": fmt.Sprintf("%s: () =>", name)},
+	}
+	if storeFactory != "" {
+		node.Meta["store_factory"] = storeFactory
+		node.Meta["store_member"] = member
 	}
 	result.Nodes = append(result.Nodes, node)
 	result.Edges = append(result.Edges, &graph.Edge{

--- a/internal/parser/languages/python.go
+++ b/internal/parser/languages/python.go
@@ -46,6 +46,11 @@ const qPyAll = `
       object: (_) @callattr.receiver
       attribute: (identifier) @callattr.method)) @callattr.expr
 
+  (call
+    function: (subscript
+      value: (_) @subcall.receiver
+      subscript: (_) @subcall.key)) @subcall.expr
+
   (assignment
     left: (identifier) @var.name) @var.def
 
@@ -85,6 +90,36 @@ type pyDeferredCall struct {
 	line     int
 	isAttr   bool
 	expr     *sitter.Node // for FastAPI Depends() arg lookup
+	// dynShape / dynKey tag a dynamic-dispatch blind-spot call shape the
+	// resolver cannot bind statically (computed-member obj["foo"]()), so the
+	// opt-in speculative synthesizer can fan it to plausible targets. dynKey is
+	// the literal method name when the subscript is a string literal.
+	dynShape string
+	dynKey   string
+}
+
+// pyStringLiteralValue returns the unquoted value of a Python string-literal
+// token (handling an optional r/f/b/u prefix), or "" when the token is not a
+// string literal (e.g. a variable subscript key obj[name]).
+func pyStringLiteralValue(tok string) string {
+	tok = strings.TrimSpace(tok)
+	for len(tok) > 1 {
+		switch tok[0] {
+		case 'r', 'R', 'f', 'F', 'b', 'B', 'u', 'U':
+			if tok[1] == '\'' || tok[1] == '"' {
+				tok = tok[1:]
+				continue
+			}
+		}
+		break
+	}
+	if len(tok) >= 2 {
+		q := tok[0]
+		if (q == '\'' || q == '"') && tok[len(tok)-1] == q {
+			return tok[1 : len(tok)-1]
+		}
+	}
+	return ""
 }
 
 func (e *PythonExtractor) Extract(filePath string, src []byte) (*parser.ExtractionResult, error) {
@@ -149,6 +184,24 @@ func (e *PythonExtractor) Extract(filePath string, src []byte) (*parser.Extracti
 				expr: expr.Node,
 			})
 
+		case m.Captures["subcall.expr"] != nil:
+			// Computed-member call `obj["foo"]()` — a dynamic-dispatch blind
+			// spot. Captured for the opt-in speculative synthesizer; emits no
+			// edge by itself unless that pass is enabled.
+			expr := m.Captures["subcall.expr"]
+			dc := pyDeferredCall{
+				line:     expr.StartLine + 1,
+				expr:     expr.Node,
+				dynShape: "computed_member",
+			}
+			if r := m.Captures["subcall.receiver"]; r != nil {
+				dc.receiver = r.Text
+			}
+			if k := m.Captures["subcall.key"]; k != nil {
+				dc.dynKey = pyStringLiteralValue(k.Text)
+			}
+			calls = append(calls, dc)
+
 		case m.Captures["tvar.def"] != nil:
 			// Tier 0: explicit type annotation — overwrite tenv.
 			name := m.Captures["tvar.name"].Text
@@ -185,6 +238,23 @@ func (e *PythonExtractor) Extract(filePath string, src []byte) (*parser.Extracti
 	for _, c := range calls {
 		callerID := findEnclosingFunc(funcRanges, c.line)
 		if callerID == "" {
+			continue
+		}
+		if c.dynShape != "" {
+			// Tagged dynamic-dispatch blind-spot call. The placeholder carries
+			// the shape + literal key; the speculative synthesizer (opt-in)
+			// fans it to plausible targets.
+			meta := map[string]any{"dyn_shape": c.dynShape}
+			if c.dynKey != "" {
+				meta["dyn_key"] = c.dynKey
+			}
+			if c.receiver != "" {
+				meta["dyn_receiver"] = c.receiver
+			}
+			result.Edges = append(result.Edges, &graph.Edge{
+				From: callerID, To: "unresolved::*",
+				Kind: graph.EdgeCalls, FilePath: filePath, Line: c.line, Meta: meta,
+			})
 			continue
 		}
 		if c.isAttr {

--- a/internal/parser/languages/store_factory_resolve.go
+++ b/internal/parser/languages/store_factory_resolve.go
@@ -1,0 +1,113 @@
+package languages
+
+import (
+	"regexp"
+
+	sitter "github.com/zzet/gortex/internal/parser/tsitter"
+)
+
+// Store-factory action resolution (Zustand / Redux Toolkit / Pinia / MobX).
+// In these libraries an action is declared inside a factory call and invoked
+// indirectly — `useStore.getState().fetchUser()` or
+// `const {fetchUser} = useStore.getState(); fetchUser()`. The extractor stamps
+// each store-action node with Meta["store_factory"]=<binding> and resolves the
+// indirect call against the same-file store binding (or hands a provenance-
+// tagged placeholder to the store-factory synthesizer for cross-file binding).
+// Shared by the JavaScript and TypeScript extractors.
+
+// jsStoreFactoryCallNames is the set of factory callees that mark an object
+// literal as a store definition. Matched on the callee's last identifier so
+// `redux.createStore` and `create` both qualify. The name gate is what keeps
+// an ordinary `ctx.set({...})` object from being mistaken for a store.
+var jsStoreFactoryCallNames = map[string]bool{
+	"create":            true, // zustand
+	"createStore":       true, // redux / zustand vanilla
+	"configureStore":    true, // redux toolkit
+	"createSlice":       true, // redux toolkit
+	"defineStore":       true, // pinia
+	"makeAutoObservable": true, // mobx
+	"makeObservable":    true, // mobx
+	"observable":        true, // mobx
+}
+
+// jsGetStateChainRE recognises a store-accessor receiver:
+// `useStore.getState()`, `.getStore()`, `.getActions()`, `.use()`.
+var jsGetStateChainRE = regexp.MustCompile(`^(\w+)\.(?:getState|getStore|getActions|use)\(\)$`)
+
+// jsDestructureGetStateRE recognises `const {a, b} = useStore.getState()` so a
+// later bare `a()` / `b()` call binds to the store action.
+var jsDestructureGetStateRE = regexp.MustCompile(`(?:const|let|var)\s*\{([^}]*)\}\s*=\s*(\w+)\.(?:getState|getStore|getActions|use)\(\)`)
+
+// jsStoreFactoryBinding reports whether the given object-literal member node is
+// an action of a store-factory binding, returning the binding name and the
+// factory callee. It walks up from the member through the (possibly
+// middleware-wrapped) factory call to the variable_declarator that names the
+// store, requiring a recognised factory callee along the way.
+func jsStoreFactoryBinding(member *sitter.Node, src []byte) (binding, factory string, ok bool) {
+	if member == nil {
+		return "", "", false
+	}
+	saw := ""
+	for cur := member.Parent(); cur != nil; cur = cur.Parent() {
+		switch cur.Type() {
+		case "call_expression":
+			if fn := cur.ChildByFieldName("function"); fn != nil {
+				if name := jsCalleeLastName(fn, src); jsStoreFactoryCallNames[name] {
+					saw = name
+				}
+			}
+		case "variable_declarator":
+			if saw == "" {
+				return "", "", false
+			}
+			if name := cur.ChildByFieldName("name"); name != nil && name.Type() == "identifier" {
+				return name.Content(src), saw, true
+			}
+			return "", "", false
+		case "program", "class_body":
+			return "", "", false
+		}
+	}
+	return "", "", false
+}
+
+// jsCalleeLastName returns the trailing identifier of a call's function
+// expression: "create" for `create`, "createStore" for `redux.createStore`.
+func jsCalleeLastName(fn *sitter.Node, src []byte) string {
+	if fn == nil {
+		return ""
+	}
+	switch fn.Type() {
+	case "identifier":
+		return fn.Content(src)
+	case "member_expression":
+		if p := fn.ChildByFieldName("property"); p != nil {
+			return p.Content(src)
+		}
+	}
+	return ""
+}
+
+// jsStoreOptionKeys are the object-literal keys under which Pinia and Redux
+// Toolkit nest their action functions (`defineStore('id',{actions:{...}})`,
+// `createSlice({reducers:{...}})`). When jsObjectOwnerName resolves a member's
+// owner to one of these, the member is still a store action — the factory walk
+// confirms it — so the extractor reruns store-factory detection for them.
+var jsStoreOptionKeys = map[string]bool{
+	"actions":  true, // pinia / vuex
+	"reducers": true, // redux toolkit
+	"methods":  true, // generic
+}
+
+// jsIsStoreOptionKey reports whether an owner name is a store option key.
+func jsIsStoreOptionKey(owner string) bool { return jsStoreOptionKeys[owner] }
+
+// jsParseGetStateChain extracts the store binding from a member-call receiver
+// of the form `<binding>.getState()`.
+func jsParseGetStateChain(receiver string) (binding string, ok bool) {
+	m := jsGetStateChainRE.FindStringSubmatch(receiver)
+	if m == nil {
+		return "", false
+	}
+	return m[1], true
+}

--- a/internal/parser/languages/typescript.go
+++ b/internal/parser/languages/typescript.go
@@ -326,12 +326,44 @@ func (e *TypeScriptExtractor) Extract(filePath string, src []byte) (*parser.Extr
 	// range map used to attribute calls to their caller.
 	funcRanges := buildFuncRanges(result)
 
+	// Store-factory destructuring: `const {a,b} = useStore.getState()` binds
+	// later bare `a()` / `b()` calls to the store's actions.
+	destructured := map[string]string{} // local action name → store binding
+	for _, dm := range jsDestructureGetStateRE.FindAllStringSubmatch(string(src), -1) {
+		binding := dm[2]
+		for _, nm := range strings.Split(dm[1], ",") {
+			nm = strings.TrimSpace(nm)
+			if i := strings.IndexByte(nm, ':'); i >= 0 {
+				nm = strings.TrimSpace(nm[i+1:])
+			}
+			if nm != "" {
+				destructured[nm] = binding
+			}
+		}
+	}
+
 	for _, c := range calls {
 		callerID := findEnclosingFunc(funcRanges, c.line)
 		if callerID == "" {
 			continue
 		}
 		if !c.isMember {
+			if binding, ok := destructured[c.name]; ok {
+				if memberID := objLiteralMembers[binding][c.name]; memberID != "" {
+					result.Edges = append(result.Edges, &graph.Edge{
+						From: callerID, To: memberID,
+						Kind: graph.EdgeCalls, FilePath: filePath, Line: c.line,
+						Origin: graph.OriginASTResolved, Confidence: 0.9,
+					})
+					continue
+				}
+				result.Edges = append(result.Edges, &graph.Edge{
+					From: callerID, To: "unresolved::" + c.name,
+					Kind: graph.EdgeCalls, FilePath: filePath, Line: c.line,
+					Meta: map[string]any{"via": "store-factory", "store_binding": binding, "store_action": c.name},
+				})
+				continue
+			}
 			result.Edges = append(result.Edges, &graph.Edge{
 				From: callerID, To: "unresolved::" + c.name,
 				Kind: graph.EdgeCalls, FilePath: filePath, Line: c.line,
@@ -360,6 +392,23 @@ func (e *TypeScriptExtractor) Extract(filePath string, src []byte) (*parser.Extr
 			result.Edges = append(result.Edges, &graph.Edge{
 				From: callerID, To: "unresolved::extern::" + importPath + "::" + c.method,
 				Kind: graph.EdgeCalls, FilePath: filePath, Line: c.line,
+			})
+			continue
+		}
+		// Store-factory chained call: `useStore.getState().action()`.
+		if binding, ok := jsParseGetStateChain(c.receiver); ok {
+			if memberID := objLiteralMembers[binding][c.method]; memberID != "" {
+				result.Edges = append(result.Edges, &graph.Edge{
+					From: callerID, To: memberID,
+					Kind: graph.EdgeCalls, FilePath: filePath, Line: c.line,
+					Origin: graph.OriginASTResolved, Confidence: 0.9,
+				})
+				continue
+			}
+			result.Edges = append(result.Edges, &graph.Edge{
+				From: callerID, To: "unresolved::*." + c.method,
+				Kind: graph.EdgeCalls, FilePath: filePath, Line: c.line,
+				Meta: map[string]any{"via": "store-factory", "store_binding": binding, "store_action": c.method},
 			})
 			continue
 		}
@@ -565,6 +614,12 @@ func (e *TypeScriptExtractor) emitArrowField(m parser.QueryResult, filePath, fil
 	// Walk up: pair → object → ... look for the nearest variable_declarator
 	// or assignment whose name we can borrow.
 	owner := tsArrowFieldOwner(def.Node, src)
+	storeFactory := ""
+	if owner == "" || jsIsStoreOptionKey(owner) {
+		if b, _, ok := jsStoreFactoryBinding(def.Node, src); ok {
+			owner, storeFactory = b, b
+		}
+	}
 	name := prop
 	if owner != "" {
 		name = owner + "." + prop
@@ -574,6 +629,10 @@ func (e *TypeScriptExtractor) emitArrowField(m parser.QueryResult, filePath, fil
 	// the human-readable name visible as Node.Name.
 	id := fmt.Sprintf("%s::%s@%d", filePath, name, def.StartLine+1)
 	meta := map[string]any{"signature": fmt.Sprintf("%s: () =>", name)}
+	if storeFactory != "" {
+		meta["store_factory"] = storeFactory
+		meta["store_member"] = prop
+	}
 	if doc := ExtractDocAbove(src, def.StartLine, DocLangBlockStar); doc != "" {
 		meta["doc"] = doc
 	}
@@ -968,12 +1027,22 @@ func (e *TypeScriptExtractor) emitObjectLiteralMethod(m parser.QueryResult, file
 		return "", "", ""
 	}
 	owner = tsArrowFieldOwner(def.Node, src)
+	storeFactory := ""
+	if owner == "" || jsIsStoreOptionKey(owner) {
+		if b, _, ok := jsStoreFactoryBinding(def.Node, src); ok {
+			owner, storeFactory = b, b
+		}
+	}
 	name := member
 	if owner != "" {
 		name = owner + "." + member
 	}
 	id = fmt.Sprintf("%s::%s@%d", filePath, name, def.StartLine+1)
 	meta := map[string]any{"signature": fmt.Sprintf("%s()", name)}
+	if storeFactory != "" {
+		meta["store_factory"] = storeFactory
+		meta["store_member"] = member
+	}
 	if doc := ExtractDocAbove(src, def.StartLine, DocLangBlockStar); doc != "" {
 		meta["doc"] = doc
 	}

--- a/internal/query/engine.go
+++ b/internal/query/engine.go
@@ -1060,6 +1060,13 @@ func (e *Engine) bfs(nodeID string, opts QueryOptions, forward bool, edgeKinds [
 	var allEdges []*graph.Edge
 	truncated := false
 
+	// On a forward call-graph walk, record dropped dynamic-dispatch /
+	// unresolved out-edges as epistemic boundaries so get_call_chain can flag
+	// the reachable set as a floor rather than silently undercounting.
+	recordBoundaries := forward && !bidir && kindSet[graph.EdgeCalls]
+	var boundaries []graph.EpistemicBoundary
+	boundarySeen := map[string]bool{}
+
 	if n := e.g.GetNode(nodeID); n != nil {
 		// The seed always enters the result, regardless of scope —
 		// callers ask "what reaches X" with X already in mind. The
@@ -1074,8 +1081,29 @@ func (e *Engine) bfs(nodeID string, opts QueryOptions, forward bool, edgeKinds [
 	// of edge structs), then admits a new, in-scope, non-test neighbour
 	// and returns its id to enqueue ("" = skip).
 	admit := func(edge *graph.Edge, neighborID string, neighbor *graph.Node) string {
-		// Skip unresolved/external targets.
+		// Skip unresolved/external targets — but on a call-graph walk, record
+		// the dropped dynamic-dispatch / external target as an epistemic
+		// boundary first, so the reachable set is honestly flagged as a floor.
 		if graph.IsUnresolvedTarget(neighborID) || strings.HasPrefix(neighborID, "external::") {
+			if recordBoundaries && edge != nil {
+				if reason, ok := graph.ClassifyDroppedTarget(neighborID, edge.Kind); ok {
+					key := edge.From + "\x00" + neighborID
+					if !boundarySeen[key] && len(boundaries) < 50 {
+						boundarySeen[key] = true
+						target := neighborID
+						if graph.IsUnresolvedTarget(neighborID) {
+							target = graph.UnresolvedName(neighborID)
+						}
+						boundaries = append(boundaries, graph.EpistemicBoundary{
+							SeedID:    edge.From,
+							Target:    target,
+							EdgeKind:  string(edge.Kind),
+							Reason:    reason,
+							Direction: "callees",
+						})
+					}
+				}
+			}
 			return ""
 		}
 		// Once the node budget is full, stop recording edges too: the
@@ -1217,6 +1245,10 @@ func (e *Engine) bfs(nodeID string, opts QueryOptions, forward bool, edgeKinds [
 		TotalNodes: len(visited),
 		TotalEdges: len(allEdges),
 		Truncated:  truncated,
+	}
+	if len(boundaries) > 0 {
+		sg.Boundaries = boundaries
+		sg.LowerBound = graph.LowerBoundCaveat(boundaries)
 	}
 
 	if opts.Detail == "brief" {

--- a/internal/query/engine_boundary_test.go
+++ b/internal/query/engine_boundary_test.go
@@ -1,0 +1,44 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// TestGetCallChain_RecordsDispatchBoundary: a forward call-chain walk that
+// drops an unresolved (dynamic-dispatch) out-edge must flag the reachable set
+// as a floor and name the boundary.
+func TestGetCallChain_RecordsDispatchBoundary(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "A", Kind: graph.KindFunction, Name: "A"})
+	g.AddNode(&graph.Node{ID: "B", Kind: graph.KindFunction, Name: "B"})
+	g.AddEdge(&graph.Edge{From: "A", To: "B", Kind: graph.EdgeCalls, Origin: graph.OriginASTResolved})
+	// B dispatches to an unresolved target the resolver could not bind.
+	g.AddEdge(&graph.Edge{From: "B", To: "unresolved::handler", Kind: graph.EdgeCalls, Origin: graph.OriginASTInferred})
+
+	sg := NewEngine(g).GetCallChain("A", QueryOptions{Depth: 3, Limit: 50})
+	if !sg.LowerBound {
+		t.Fatalf("expected LowerBound=true, got boundaries=%+v", sg.Boundaries)
+	}
+	if len(sg.Boundaries) != 1 {
+		t.Fatalf("expected 1 boundary, got %d: %+v", len(sg.Boundaries), sg.Boundaries)
+	}
+	b := sg.Boundaries[0]
+	if b.SeedID != "B" || b.Target != "handler" || b.Reason != graph.BoundaryDynamicDispatch || b.Direction != "callees" {
+		t.Errorf("unexpected boundary: %+v", b)
+	}
+}
+
+// TestGetCallChain_NoBoundary: a fully-resolved chain reports no boundary and
+// no lower-bound flag (so existing responses are unchanged).
+func TestGetCallChain_NoBoundary(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "A", Kind: graph.KindFunction, Name: "A"})
+	g.AddNode(&graph.Node{ID: "B", Kind: graph.KindFunction, Name: "B"})
+	g.AddEdge(&graph.Edge{From: "A", To: "B", Kind: graph.EdgeCalls, Origin: graph.OriginASTResolved})
+	sg := NewEngine(g).GetCallChain("A", QueryOptions{Depth: 3, Limit: 50})
+	if sg.LowerBound || len(sg.Boundaries) != 0 {
+		t.Errorf("expected no boundary, got LowerBound=%v boundaries=%+v", sg.LowerBound, sg.Boundaries)
+	}
+}

--- a/internal/query/speculative_filter_test.go
+++ b/internal/query/speculative_filter_test.go
@@ -1,0 +1,28 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestFilterSpeculative(t *testing.T) {
+	mk := func() *SubGraph {
+		return &SubGraph{Edges: []*graph.Edge{
+			{From: "a", To: "b", Kind: graph.EdgeCalls},
+			{From: "a", To: "c", Kind: graph.EdgeCalls, Meta: map[string]any{graph.MetaSpeculative: true}},
+		}}
+	}
+	// Default-exclude: speculative dropped.
+	sg := mk()
+	sg.FilterSpeculative(false)
+	if len(sg.Edges) != 1 || sg.Edges[0].To != "b" {
+		t.Fatalf("FilterSpeculative(false) must drop speculative edges, got %d", len(sg.Edges))
+	}
+	// Opt-in: speculative kept.
+	sg2 := mk()
+	sg2.FilterSpeculative(true)
+	if len(sg2.Edges) != 2 {
+		t.Fatalf("FilterSpeculative(true) must keep speculative edges, got %d", len(sg2.Edges))
+	}
+}

--- a/internal/query/subgraph.go
+++ b/internal/query/subgraph.go
@@ -240,6 +240,23 @@ func (sg *SubGraph) FilterByMinTier(minTier string) {
 	sg.Edges = kept
 }
 
+// FilterSpeculative drops best-guess speculative edges (Meta[speculative]=true)
+// unless include is true. Called with include=false by default on every
+// edge-returning query, so speculative dynamic-dispatch edges never pollute a
+// default result — they are opt-in only.
+func (sg *SubGraph) FilterSpeculative(include bool) {
+	if include || sg == nil {
+		return
+	}
+	kept := sg.Edges[:0]
+	for _, e := range sg.Edges {
+		if !e.IsSpeculative() {
+			kept = append(kept, e)
+		}
+	}
+	sg.Edges = kept
+}
+
 // ToDot returns a Graphviz DOT representation of the subgraph.
 func (sg *SubGraph) ToDot() string {
 	var b strings.Builder

--- a/internal/query/subgraph.go
+++ b/internal/query/subgraph.go
@@ -44,6 +44,13 @@ type SubGraph struct {
 	// for a purely-local result, so a caller can see how fresh the
 	// remote-derived part of the answer is.
 	LastSynced *time.Time `json:"last_synced,omitempty"`
+	// LowerBound is set by call-graph traversals (get_call_chain) when the
+	// walk dropped one or more dynamic-dispatch / unresolved out-edges: the
+	// reachable set is then a floor, not exhaustive. Omitted when false.
+	LowerBound bool `json:"lower_bound,omitempty"`
+	// Boundaries names the unresolved/dispatch sites that made the result a
+	// floor. Populated only by call-graph traversals; omitted when empty.
+	Boundaries []graph.EpistemicBoundary `json:"boundaries,omitempty"`
 }
 
 // QueryOptions controls traversal depth, result limits, and detail level.

--- a/internal/resolver/cpp_overload.go
+++ b/internal/resolver/cpp_overload.go
@@ -1,0 +1,270 @@
+package resolver
+
+import (
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// In-engine C++ overload resolution. Picks which same-named function/method a
+// call binds to by ISO C++ rules — arity (with defaults + variadics), then
+// implicit-conversion-sequence (ICS) ranking with pairwise dominance for the
+// best-viable function — entirely from the signature metadata the cpp extractor
+// stamps, no compiler needed. It runs in CI/sandbox where clangd cannot.
+//
+// Strict invariant (from GitNexus, sharpened): DEGRADE, NEVER LIE. Any axis it
+// cannot decide keeps the candidate; a genuinely ambiguous best-viable set
+// (≥2 non-dominated) returns nil so the resolver suppresses the edge rather
+// than binding the wrong overload.
+
+const cppRankInf = 1 << 30
+
+// cppArithmetic is the set of normalized arithmetic base types eligible for
+// standard arithmetic conversions (rank 2).
+var cppArithmetic = map[string]bool{
+	"int": true, "double": true, "char": true, "bool": true,
+	"long": true, "short": true, "float": true, "unsigned": true,
+}
+
+// cppIntegralPromotion maps a small integral type to its promoted form
+// (rank 1, better than a general arithmetic conversion).
+var cppIntegralPromotion = map[string]string{
+	"char": "int", "bool": "int", "short": "int",
+}
+
+// cppShape is the decoded per-parameter indirection sidecar.
+type cppShape struct {
+	isPointer bool
+	isLRef    bool
+	isRRef    bool
+	isConst   bool
+}
+
+func decodeCppShape(code string) cppShape {
+	s := cppShape{}
+	if strings.HasPrefix(code, "c") {
+		s.isConst = true
+		code = code[1:]
+	}
+	switch code {
+	case "p":
+		s.isPointer = true
+	case "l":
+		s.isLRef = true
+	case "r":
+		s.isRRef = true
+	}
+	return s
+}
+
+// cppConversionRank returns the implicit-conversion-sequence rank from argType
+// to paramType (lower = better): 0 exact, 1 integral promotion, 2 standard
+// conversion (arithmetic, nullptr→T*, T*→bool, T*→void*), 3 nullptr→bool,
+// 5 ellipsis, cppRankInf mismatch. (User-defined conversions — rank 4 — need a
+// converting-ctor index not yet built; their absence means a UDC-only match is
+// conservatively a non-match, never a wrong bind.)
+func cppConversionRank(argType, paramType string, arg, param cppShape) int {
+	if argType == paramType {
+		if exactShapeCompatible(arg, param) {
+			return 0
+		}
+		return cppRankInf
+	}
+	if paramType == "..." {
+		return 5
+	}
+	if cppIntegralPromotion[argType] == paramType && paramType != "" {
+		return 1
+	}
+	if cppArithmetic[argType] && cppArithmetic[paramType] {
+		return 2
+	}
+	if argType == "null" && param.isPointer {
+		return 2
+	}
+	if argType == "null" && paramType == "bool" {
+		return 3
+	}
+	if arg.isPointer && paramType == "bool" {
+		return 2
+	}
+	if arg.isPointer && param.isPointer && paramType == "void" {
+		return 2
+	}
+	return cppRankInf
+}
+
+// exactShapeCompatible: an exact base-type match is only a rank-0 conversion
+// when the indirection agrees (int ≠ int*). A value arg binds to a value or a
+// (const) reference parameter; a pointer arg binds to a pointer parameter.
+func exactShapeCompatible(a, p cppShape) bool {
+	return a.isPointer == p.isPointer
+}
+
+// cppCandSig is a candidate's parsed signature.
+type cppCandSig struct {
+	node       *graph.Node
+	paramTypes []string
+	shapes     []cppShape
+	reqParams  int
+	variadic   bool
+}
+
+// parseCppCandidate reads the cpp_* signature Meta off a node. ok is false when
+// the node carries no extracted signature (so the resolver can't rank it).
+func parseCppCandidate(n *graph.Node) (cppCandSig, bool) {
+	if n == nil || n.Meta == nil {
+		return cppCandSig{}, false
+	}
+	if _, ok := n.Meta["cpp_sig"]; !ok {
+		return cppCandSig{}, false
+	}
+	c := cppCandSig{node: n}
+	if pt, _ := n.Meta["cpp_param_types"].(string); pt != "" {
+		c.paramTypes = strings.Split(pt, ",")
+	}
+	if ps, _ := n.Meta["cpp_param_shapes"].(string); ps != "" {
+		for _, code := range strings.Split(ps, ",") {
+			c.shapes = append(c.shapes, decodeCppShape(code))
+		}
+	}
+	c.reqParams = cppMetaInt(n.Meta, "cpp_req_params")
+	if _, ok := n.Meta["cpp_variadic"]; ok {
+		c.variadic = true
+	}
+	return c, true
+}
+
+func cppMetaInt(m map[string]any, k string) int {
+	switch v := m[k].(type) {
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	}
+	return 0
+}
+
+// ResolveCppOverload selects the best-viable overload among same-name
+// candidates, or nil to degrade to the caller's namespace cascade.
+func ResolveCppOverload(argHints []string, candidates []*graph.Node) *graph.Node {
+	var sigs []cppCandSig
+	for _, c := range candidates {
+		if c == nil || (c.Kind != graph.KindFunction && c.Kind != graph.KindMethod) {
+			continue
+		}
+		s, ok := parseCppCandidate(c)
+		if !ok {
+			continue // no signature → not rankable; leave to the cascade
+		}
+		if !cppArityCompatible(s, len(argHints)) {
+			continue
+		}
+		sigs = append(sigs, s)
+	}
+	switch len(sigs) {
+	case 0:
+		return nil
+	case 1:
+		return sigs[0].node
+	}
+	// Multiple arity-viable candidates: need argument types to rank further.
+	if len(argHints) == 0 {
+		return nil // can't disambiguate → suppress
+	}
+	normArgs := make([]string, len(argHints))
+	for i, a := range argHints {
+		normArgs[i] = graph.NormalizeCppType(a)
+	}
+	argShapes := make([]cppShape, len(argHints)) // literal/value args; unknown = value
+
+	type ranked struct {
+		node *graph.Node
+		vec  []int
+	}
+	var viable []ranked
+	for _, s := range sigs {
+		vec := make([]int, len(normArgs))
+		bad := false
+		for j := range normArgs {
+			if normArgs[j] == "" {
+				// Unknown arg type: compatible with any parameter, and neutral
+				// for dominance (every candidate scores 0 here). Degrade, never
+				// lie — an untyped arg never makes a candidate non-viable.
+				vec[j] = 0
+				continue
+			}
+			pt, psh := cppParamAt(s, j)
+			r := cppConversionRank(normArgs[j], pt, argShapes[j], psh)
+			if r >= cppRankInf {
+				bad = true
+				break
+			}
+			vec[j] = r
+		}
+		if !bad {
+			viable = append(viable, ranked{s.node, vec})
+		}
+	}
+	switch len(viable) {
+	case 0:
+		return nil
+	case 1:
+		return viable[0].node
+	}
+	// Pairwise dominance → non-dominated set ([over.ics.rank]).
+	var nondom []ranked
+	for i := range viable {
+		dominated := false
+		for k := range viable {
+			if i != k && cppDominates(viable[k].vec, viable[i].vec) {
+				dominated = true
+				break
+			}
+		}
+		if !dominated {
+			nondom = append(nondom, viable[i])
+		}
+	}
+	if len(nondom) == 1 {
+		return nondom[0].node
+	}
+	return nil // ≥2 non-dominated → ambiguous → suppress (never lie)
+}
+
+func cppParamAt(s cppCandSig, j int) (string, cppShape) {
+	if j < len(s.paramTypes) {
+		sh := cppShape{}
+		if j < len(s.shapes) {
+			sh = s.shapes[j]
+		}
+		return s.paramTypes[j], sh
+	}
+	if s.variadic {
+		return "...", cppShape{}
+	}
+	return "", cppShape{}
+}
+
+func cppArityCompatible(s cppCandSig, argCount int) bool {
+	if s.variadic {
+		return argCount >= s.reqParams
+	}
+	return argCount >= s.reqParams && argCount <= len(s.paramTypes)
+}
+
+// cppDominates: a is not-worse-everywhere and strictly-better-somewhere than b.
+func cppDominates(a, b []int) bool {
+	better := false
+	for i := range a {
+		if a[i] > b[i] {
+			return false
+		}
+		if a[i] < b[i] {
+			better = true
+		}
+	}
+	return better
+}

--- a/internal/resolver/cpp_overload_test.go
+++ b/internal/resolver/cpp_overload_test.go
@@ -1,0 +1,120 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestCppConversionRank(t *testing.T) {
+	v := cppShape{}
+	ptr := cppShape{isPointer: true}
+	ellipsis := cppShape{}
+	cases := []struct {
+		arg, param   string
+		ash, psh     cppShape
+		want         int
+	}{
+		{"int", "int", v, v, 0},          // exact
+		{"int", "int", v, ptr, cppRankInf}, // value≠pointer (shape-aware)
+		{"int", "int", ptr, ptr, 0},      // pointer exact
+		{"char", "int", v, v, 1},         // integral promotion
+		{"bool", "int", v, v, 1},         // bool→int promotion
+		{"int", "double", v, v, 2},       // arithmetic standard
+		{"null", "int", v, ptr, 2},       // nullptr→T*
+		{"null", "bool", v, v, 3},        // nullptr→bool (worse than →T*)
+		{"int", "...", v, ellipsis, 5},   // ellipsis
+		{"string", "int", v, v, cppRankInf}, // mismatch
+	}
+	for _, c := range cases {
+		if got := cppConversionRank(c.arg, c.param, c.ash, c.psh); got != c.want {
+			t.Errorf("rank(%q→%q) = %d, want %d", c.arg, c.param, got, c.want)
+		}
+	}
+}
+
+func cppFn(id, params, shapes string, req int) *graph.Node {
+	m := map[string]any{"cpp_sig": "1"}
+	if params != "" {
+		m["cpp_param_types"] = params
+	}
+	if shapes != "" {
+		m["cpp_param_shapes"] = shapes
+	}
+	if req > 0 {
+		m["cpp_req_params"] = req
+	}
+	return &graph.Node{ID: id, Kind: graph.KindFunction, Name: "process", Meta: m}
+}
+
+func TestResolveCppOverload_ArithmeticSelection(t *testing.T) {
+	intFn := cppFn("f::process#int", "int", "v", 1)
+	dblFn := cppFn("f::process#double", "double", "v", 1)
+	cands := []*graph.Node{intFn, dblFn}
+
+	if got := ResolveCppOverload([]string{"double"}, cands); got != dblFn {
+		t.Errorf("double arg should pick process(double), got %v", got)
+	}
+	if got := ResolveCppOverload([]string{"int"}, cands); got != intFn {
+		t.Errorf("int arg should pick process(int), got %v", got)
+	}
+	if got := ResolveCppOverload([]string{"char"}, cands); got != intFn {
+		t.Errorf("char arg should promote to process(int), got %v", got)
+	}
+}
+
+func TestResolveCppOverload_ShapeDistinguishesPointer(t *testing.T) {
+	valFn := cppFn("f::process#int", "int", "v", 1)
+	ptrFn := cppFn("f::process#intptr", "int", "p", 1)
+	// A value int literal must not match the int* overload.
+	if got := ResolveCppOverload([]string{"int"}, []*graph.Node{valFn, ptrFn}); got != valFn {
+		t.Errorf("int value arg should pick the value overload, got %v", got)
+	}
+}
+
+func TestResolveCppOverload_Arity(t *testing.T) {
+	zero := cppFn("f::process#0", "", "", 0)
+	one := cppFn("f::process#1", "int", "v", 1)
+	if got := ResolveCppOverload([]string{"int"}, []*graph.Node{zero, one}); got != one {
+		t.Errorf("1 arg should pick the 1-param overload, got %v", got)
+	}
+	if got := ResolveCppOverload(nil, []*graph.Node{zero, one}); got != zero {
+		t.Errorf("0 args should pick the 0-param overload, got %v", got)
+	}
+}
+
+func TestResolveCppOverload_DefaultsAndVariadic(t *testing.T) {
+	// process(int, int = 0): req 1, total 2.
+	def := cppFn("f::process#def", "int,int", "v,v", 1)
+	if got := ResolveCppOverload([]string{"int"}, []*graph.Node{def}); got != def {
+		t.Errorf("1 arg must satisfy a 2-param-with-default overload, got %v", got)
+	}
+	// variadic process(int, ...): req 1.
+	vfn := cppFn("f::process#var", "int", "v", 1)
+	vfn.Meta["cpp_variadic"] = "1"
+	if got := ResolveCppOverload([]string{"int", "double", "char"}, []*graph.Node{vfn}); got != vfn {
+		t.Errorf("variadic overload must accept extra args, got %v", got)
+	}
+}
+
+func TestResolveCppOverload_AmbiguousSuppressed(t *testing.T) {
+	// Two overloads the arg ranks equally well against → ambiguous → nil.
+	a := cppFn("f::process#a", "int", "v", 1)
+	b := cppFn("f::process#b", "int", "v", 1)
+	if got := ResolveCppOverload([]string{"int"}, []*graph.Node{a, b}); got != nil {
+		t.Errorf("equally-ranked overloads must suppress (nil), got %v", got)
+	}
+	// No arg hints + 2 viable → suppress.
+	if got := ResolveCppOverload(nil, []*graph.Node{cppFn("x", "int", "v", 1), cppFn("y", "double", "v", 1)}); got != nil {
+		t.Errorf("no hints with 2 viable must suppress, got %v", got)
+	}
+}
+
+func TestResolveCppOverload_NoSignatureDegrade(t *testing.T) {
+	// Candidates without extracted signatures → degrade (nil) to the cascade.
+	a := &graph.Node{ID: "x", Kind: graph.KindFunction, Name: "process"}
+	b := &graph.Node{ID: "y", Kind: graph.KindFunction, Name: "process"}
+	if got := ResolveCppOverload([]string{"int"}, []*graph.Node{a, b}); got != nil {
+		t.Errorf("no signature metadata must degrade to nil, got %v", got)
+	}
+}

--- a/internal/resolver/framework_synth.go
+++ b/internal/resolver/framework_synth.go
@@ -63,6 +63,7 @@ const (
 	SynthMyBatis      = "mybatis"
 	SynthRustScope    = "rust-scope"
 	SynthSQLCallsite  = "sql-callsite"
+	SynthStoreFactory = "store-factory"
 )
 
 // StampSynthesized marks an edge as the product of a framework
@@ -120,6 +121,9 @@ func defaultFrameworkSynthesizers() []FrameworkSynthesizer {
 		synthFunc{name: SynthFabric, fn: ResolveFabricComponents},
 		synthFunc{name: SynthMyBatis, fn: ResolveMyBatisCalls},
 		synthFunc{name: SynthSQLCallsite, fn: ResolveSQLCallsites},
+		// Store-factory (Zustand/Redux/Pinia/MobX) indirect action calls —
+		// binds getState()-chain and destructured calls to the action node.
+		synthFunc{name: SynthStoreFactory, fn: ResolveStoreFactoryCalls},
 		// Rust impl-block / self-receiver / module-path resolution
 		// completion. Runs in the same settle window so residual
 		// unresolved Rust calls land before external-call synthesis

--- a/internal/resolver/framework_synth.go
+++ b/internal/resolver/framework_synth.go
@@ -64,6 +64,7 @@ const (
 	SynthRustScope    = "rust-scope"
 	SynthSQLCallsite  = "sql-callsite"
 	SynthStoreFactory = "store-factory"
+	SynthSpeculative  = "speculative-dispatch"
 )
 
 // StampSynthesized marks an edge as the product of a framework

--- a/internal/resolver/infer_scoped_test.go
+++ b/internal/resolver/infer_scoped_test.go
@@ -1,0 +1,111 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// implementsFixture builds a graph where type A and type B each have a method M
+// matching interface I (same repo), so InferImplements should infer A→I, B→I.
+func implementsFixture() *graph.Graph {
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "iface.go::I", Kind: graph.KindInterface, Name: "I", Meta: map[string]any{"methods": []string{"M"}}})
+	for _, ty := range []string{"A", "B"} {
+		g.AddNode(&graph.Node{ID: "x.go::" + ty, Kind: graph.KindType, Name: ty})
+		g.AddNode(&graph.Node{ID: "x.go::" + ty + ".M", Kind: graph.KindMethod, Name: "M"})
+		g.AddEdge(&graph.Edge{From: "x.go::" + ty + ".M", To: "x.go::" + ty, Kind: graph.EdgeMemberOf})
+	}
+	return g
+}
+
+func implementsEdges(g *graph.Graph) map[string]bool {
+	out := map[string]bool{}
+	for _, e := range g.AllEdges() {
+		if e.Kind == graph.EdgeImplements {
+			out[e.From+"->"+e.To] = true
+		}
+	}
+	return out
+}
+
+// TestInferImplementsScoped_ParityFull asserts the scoped pass, given the
+// changed interface in its scope, re-derives the SAME implements edges as the
+// full pass — even for implementor types in unchanged files (the EvictFile
+// in-edge-drop regression guard).
+func TestInferImplementsScoped_ParityFull(t *testing.T) {
+	full := implementsFixture()
+	New(full).InferImplements()
+	wantEdges := implementsEdges(full)
+	if len(wantEdges) != 2 {
+		t.Fatalf("setup: expected 2 implements edges from full pass, got %d", len(wantEdges))
+	}
+
+	// Scope = the interface changed (its in-edges were dropped); scoped must
+	// re-check every type against it.
+	scoped := implementsFixture()
+	New(scoped).InferImplementsScoped(map[string]bool{}, map[string]bool{"iface.go::I": true})
+	if got := implementsEdges(scoped); len(got) != len(wantEdges) {
+		t.Fatalf("scoped (changed iface) = %v, want %v", got, wantEdges)
+	}
+}
+
+func TestInferImplementsScoped_AffectedType(t *testing.T) {
+	// Only type A is affected (changed); scoped must re-check A against all
+	// interfaces and add A->I, but not touch B.
+	g := implementsFixture()
+	New(g).InferImplementsScoped(map[string]bool{"x.go::A": true}, map[string]bool{})
+	got := implementsEdges(g)
+	if !got["x.go::A->iface.go::I"] {
+		t.Errorf("expected A->I from affected type A, got %v", got)
+	}
+	if got["x.go::B->iface.go::I"] {
+		t.Errorf("B was not affected and has no survivor edge here, must not be inferred: %v", got)
+	}
+}
+
+func TestInferImplementsScoped_EmptyScopeNoWork(t *testing.T) {
+	g := implementsFixture()
+	if n := New(g).InferImplementsScoped(map[string]bool{}, map[string]bool{}); n != 0 {
+		t.Errorf("empty scope must do zero work, added %d", n)
+	}
+	if len(implementsEdges(g)) != 0 {
+		t.Errorf("empty scope must add no edges")
+	}
+}
+
+// TestInferOverridesScoped_Parity: child C overrides parent P's method; scoped
+// with the parent in scope re-derives the override edge.
+func TestInferOverridesScoped_Parity(t *testing.T) {
+	build := func() *graph.Graph {
+		g := graph.New()
+		g.AddNode(&graph.Node{ID: "p.go::P", Kind: graph.KindType, Name: "P"})
+		g.AddNode(&graph.Node{ID: "p.go::P.M", Kind: graph.KindMethod, Name: "M", FilePath: "p.go"})
+		g.AddEdge(&graph.Edge{From: "p.go::P.M", To: "p.go::P", Kind: graph.EdgeMemberOf})
+		g.AddNode(&graph.Node{ID: "c.go::C", Kind: graph.KindType, Name: "C"})
+		g.AddNode(&graph.Node{ID: "c.go::C.M", Kind: graph.KindMethod, Name: "M", FilePath: "c.go"})
+		g.AddEdge(&graph.Edge{From: "c.go::C.M", To: "c.go::C", Kind: graph.EdgeMemberOf})
+		g.AddEdge(&graph.Edge{From: "c.go::C", To: "p.go::P", Kind: graph.EdgeExtends, Origin: graph.OriginASTResolved})
+		return g
+	}
+	overrideEdges := func(g *graph.Graph) int {
+		n := 0
+		for _, e := range g.AllEdges() {
+			if e.Kind == graph.EdgeOverrides {
+				n++
+			}
+		}
+		return n
+	}
+	full := build()
+	New(full).InferOverrides()
+	if overrideEdges(full) != 1 {
+		t.Fatalf("setup: expected 1 override edge from full pass, got %d", overrideEdges(full))
+	}
+	// Parent changed → scope includes P; scoped must re-derive C.M->P.M.
+	scoped := build()
+	New(scoped).InferOverridesScoped(map[string]bool{"p.go::P": true})
+	if overrideEdges(scoped) != 1 {
+		t.Errorf("scoped override (parent in scope) = %d, want 1", overrideEdges(scoped))
+	}
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -2248,7 +2248,20 @@ func structuralParentEdges(g graph.Store) []graph.StructuralParentEdgeRow {
 // InferImplements detects structural interface satisfaction by comparing
 // method sets and adds EdgeImplements edges from types to interfaces.
 // Returns the number of edges added.
-func (r *Resolver) InferImplements() int {
+func (r *Resolver) InferImplements() int { return r.inferImplements(nil, nil) }
+
+// InferImplementsScoped re-derives EdgeImplements only for (type, interface)
+// pairs where the type or the interface is in the affected set — used by
+// incremental reindex to avoid the whole-graph type×interface cross product.
+// It is add-parity with the full pass: an inferred edge is only ever dropped
+// when one of its endpoints' file is evicted, so re-checking every pair with an
+// affected endpoint re-lands exactly the dropped edges while the survivors are
+// left untouched. Empty scope maps mean "nothing affected" → zero work.
+func (r *Resolver) InferImplementsScoped(scopeTypes, scopeIfaces map[string]bool) int {
+	return r.inferImplements(scopeTypes, scopeIfaces)
+}
+
+func (r *Resolver) inferImplements(scopeTypes, scopeIfaces map[string]bool) int {
 	// Step 1: Collect all interfaces with their required method names.
 	type ifaceInfo struct {
 		id      string
@@ -2353,6 +2366,11 @@ func (r *Resolver) InferImplements() int {
 					if iface.id == typeID {
 						continue
 					}
+					// Scoped incremental: only re-check pairs touching an
+					// affected type or a changed interface.
+					if scopeTypes != nil && !scopeTypes[typeID] && !scopeIfaces[iface.id] {
+						continue
+					}
 					// Repo gate: structural method-set matching across
 					// repos is almost always coincidental — every type
 					// with a `String()` method would "implement" every
@@ -2418,7 +2436,14 @@ func (r *Resolver) InferImplements() int {
 // EdgeOverrides directly with that origin).
 //
 // This is the AST half of override inference — works without an LSP available.
-func (r *Resolver) InferOverrides() int {
+func (r *Resolver) InferOverrides() int { return r.inferOverrides(nil) }
+
+// InferOverridesScoped re-derives EdgeOverrides only for parent-edge rows whose
+// child or parent type is in the affected set (add-parity with the full pass,
+// same reasoning as InferImplementsScoped). Empty scope → zero work.
+func (r *Resolver) InferOverridesScoped(scope map[string]bool) int { return r.inferOverrides(scope) }
+
+func (r *Resolver) inferOverrides(scope map[string]bool) int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -2439,6 +2464,10 @@ func (r *Resolver) InferOverrides() int {
 	var pending []overridePair
 	for _, row := range structuralParentEdges(r.graph) {
 		if row.FromID == row.ToID {
+			continue
+		}
+		// Scoped incremental: only re-check parent edges touching an affected type.
+		if scope != nil && !scope[row.FromID] && !scope[row.ToID] {
 			continue
 		}
 		childMethods := typeMembers[row.FromID]

--- a/internal/resolver/scope.go
+++ b/internal/resolver/scope.go
@@ -112,6 +112,27 @@ func scopeArgTypeHints(m map[string]any) []string {
 	return out
 }
 
+// scopePositionalArgHints decodes MetaScopeArgTypes preserving argument
+// positions (unlike scopeArgTypeHints, which drops empties for ADL). A "?"
+// placeholder — an argument the extractor could not type — decodes to "" so the
+// overload ranker treats that slot as unknown (compatible with any parameter).
+func scopePositionalArgHints(m map[string]any) []string {
+	raw := scopeMetaString(m, MetaScopeArgTypes)
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, len(parts))
+	for i, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "?" {
+			p = ""
+		}
+		out[i] = p
+	}
+	return out
+}
+
 // scopeUseAliases decodes the MetaScopeUseAliases payload into a
 // map of (local-alias → fully-qualified target). Empty when the file
 // has no `use function` declarations.
@@ -201,6 +222,14 @@ func (r *Resolver) preferCStaticCandidate(e *graph.Edge, caller *graph.Node, can
 //  2. ADL: walk each scope_arg_types entry's namespace.
 //  3. Fall through to the generic cascade.
 func (r *Resolver) preferCppScopeCandidate(e *graph.Edge, caller *graph.Node, name string, candidates []*graph.Node) *graph.Node {
+	// In-engine overload resolution first: rank the candidates by C++ arity +
+	// implicit-conversion-sequence and pick the best-viable. Returns nil to
+	// DEGRADE to the namespace cascade when it cannot decide (no signatures,
+	// no viable candidate, or genuine ambiguity), so it never binds a wrong
+	// overload.
+	if best := ResolveCppOverload(scopePositionalArgHints(e.Meta), candidates); best != nil {
+		return best
+	}
 	callerNs := scopeMetaString(caller.Meta, MetaScopeNamespace)
 	if callerNs != "" {
 		for _, c := range candidates {

--- a/internal/resolver/speculative_dispatch.go
+++ b/internal/resolver/speculative_dispatch.go
@@ -1,0 +1,138 @@
+package resolver
+
+import (
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Speculative dynamic-dispatch synthesis. Some call shapes are genuine static
+// blind spots that no precision-first framework rule covers: computed member
+// calls `obj["foo"]()`, getattr-style dispatch `getattr(o, "foo")()`, and
+// decorator registries. The extractor stamps these dropped calls with
+// Meta["dyn_shape"] + Meta["dyn_key"] (the method name when it is a literal),
+// and this opt-in pass mints LOW-confidence best-guess `calls` edges to the
+// plausible same-name targets — tagged OriginSpeculative + Meta[speculative]
+// so they are hidden from every default query and surfaced only on demand.
+//
+// This is what codegraph's playbook refused as "partial coverage worse than
+// none": gortex can ship it because the edges are present-but-hidden-by-default
+// (zero pollution) and explicitly auditable via `analyze kind=speculative`.
+
+const (
+	// speculativeFanoutCap: above this many candidates the confidence floors;
+	// above the hard cap the whole set is dropped as noise (codegraph's rule).
+	speculativeFanoutCap = 12
+	speculativeHardCap    = 40
+)
+
+// ResolveSpeculativeDispatch mints speculative call edges for the tagged
+// blind-spot call shapes. No-op when disabled. Returns the edge count.
+func ResolveSpeculativeDispatch(g graph.Store, enabled bool) int {
+	if g == nil || !enabled {
+		return 0
+	}
+
+	// Existing resolved call pairs, so a speculative edge never duplicates a
+	// real one from the same caller to the same target.
+	existing := map[string]bool{}
+	for e := range g.EdgesByKind(graph.EdgeCalls) {
+		if e == nil || e.IsSpeculative() {
+			continue
+		}
+		if !graph.IsUnresolvedTarget(e.To) {
+			existing[e.From+"\x00"+e.To] = true
+		}
+	}
+
+	type spec struct {
+		from, to, file, shape, key string
+		line, n                    int
+	}
+	var specs []spec
+	seen := map[string]bool{}
+	for e := range g.EdgesByKind(graph.EdgeCalls) {
+		if e == nil || e.Meta == nil {
+			continue
+		}
+		shape, _ := e.Meta["dyn_shape"].(string)
+		if shape == "" {
+			continue
+		}
+		key, _ := e.Meta["dyn_key"].(string)
+		if key == "" {
+			continue // v1: literal-key shapes only (variable-key is unbounded)
+		}
+		callerLang := ""
+		if c := g.GetNode(e.From); c != nil {
+			callerLang = c.Language
+		}
+		cands := speculativeCandidates(g, key, callerLang)
+		if len(cands) == 0 || len(cands) > speculativeHardCap {
+			continue
+		}
+		for _, c := range cands {
+			if existing[e.From+"\x00"+c.ID] {
+				continue
+			}
+			k := e.From + "\x00" + c.ID
+			if seen[k] {
+				continue
+			}
+			seen[k] = true
+			specs = append(specs, spec{from: e.From, to: c.ID, file: e.FilePath, line: e.Line, shape: shape, key: key, n: len(cands)})
+		}
+	}
+
+	resolved := 0
+	for _, s := range specs {
+		conf := 1.0 / float64(s.n)
+		if s.n > speculativeFanoutCap {
+			conf = 0.05
+		}
+		if conf > 0.45 {
+			conf = 0.45
+		}
+		if conf < 0.05 {
+			conf = 0.05
+		}
+		g.AddEdge(&graph.Edge{
+			From: s.from, To: s.to, Kind: graph.EdgeCalls,
+			FilePath: s.file, Line: s.line,
+			Origin:          graph.OriginSpeculative,
+			Confidence:      conf,
+			ConfidenceLabel: graph.ConfidenceLabelFor(graph.EdgeCalls, conf),
+			Meta: map[string]any{
+				graph.MetaSpeculative: true,
+				MetaSynthesizedBy:     SynthSpeculative,
+				MetaProvenance:        ProvenanceHeuristic,
+				"via":                 "speculative." + s.shape,
+				"candidate_count":     s.n,
+				"dyn_key":             s.key,
+			},
+		})
+		resolved++
+	}
+	return resolved
+}
+
+// speculativeCandidates returns the plausible targets for a literal dispatch
+// key: function/method definitions of that exact name, in the caller's
+// language family, excluding stubs.
+func speculativeCandidates(g graph.Store, key, callerLang string) []*graph.Node {
+	var out []*graph.Node
+	for _, n := range g.FindNodesByName(key) {
+		if n == nil {
+			continue
+		}
+		if n.Kind != graph.KindFunction && n.Kind != graph.KindMethod {
+			continue
+		}
+		if graph.IsStub(n.ID) || graph.IsUnresolvedTarget(n.ID) {
+			continue
+		}
+		if callerLang != "" && n.Language != "" && n.Language != callerLang {
+			continue
+		}
+		out = append(out, n)
+	}
+	return out
+}

--- a/internal/resolver/speculative_dispatch_test.go
+++ b/internal/resolver/speculative_dispatch_test.go
@@ -1,0 +1,99 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func specGraph() *graph.Graph {
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "main.go::handler", Kind: graph.KindFunction, Name: "handler", FilePath: "main.go", Language: "go"})
+	g.AddNode(&graph.Node{ID: "a.go::A.run", Kind: graph.KindMethod, Name: "run", FilePath: "a.go", Language: "go"})
+	g.AddNode(&graph.Node{ID: "b.go::B.run", Kind: graph.KindMethod, Name: "run", FilePath: "b.go", Language: "go"})
+	// computed-member call `obj["run"]()` left unresolved + tagged.
+	g.AddEdge(&graph.Edge{
+		From: "main.go::handler", To: "unresolved::*", Kind: graph.EdgeCalls, FilePath: "main.go",
+		Meta: map[string]any{"dyn_shape": "computed_member", "dyn_key": "run"},
+	})
+	return g
+}
+
+func specEdges(g *graph.Graph, from string) []*graph.Edge {
+	var out []*graph.Edge
+	for _, e := range g.GetOutEdges(from) {
+		if e.Kind == graph.EdgeCalls && e.IsSpeculative() {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+func TestResolveSpeculativeDispatch_LiteralKey(t *testing.T) {
+	g := specGraph()
+	n := ResolveSpeculativeDispatch(g, true)
+	if n != 2 {
+		t.Fatalf("expected 2 speculative edges, got %d", n)
+	}
+	edges := specEdges(g, "main.go::handler")
+	if len(edges) != 2 {
+		t.Fatalf("expected 2 speculative out-edges, got %d", len(edges))
+	}
+	for _, e := range edges {
+		if e.Origin != graph.OriginSpeculative {
+			t.Errorf("expected OriginSpeculative, got %q", e.Origin)
+		}
+		if cc, _ := e.Meta["candidate_count"].(int); cc != 2 {
+			t.Errorf("expected candidate_count 2, got %v", e.Meta["candidate_count"])
+		}
+		if e.Confidence <= 0 || e.Confidence > 0.45 {
+			t.Errorf("speculative confidence out of range: %v", e.Confidence)
+		}
+	}
+}
+
+func TestResolveSpeculativeDispatch_DisabledNoop(t *testing.T) {
+	g := specGraph()
+	if n := ResolveSpeculativeDispatch(g, false); n != 0 {
+		t.Errorf("disabled pass must be a no-op, got %d", n)
+	}
+	if len(specEdges(g, "main.go::handler")) != 0 {
+		t.Errorf("disabled pass must not mint edges")
+	}
+}
+
+func TestResolveSpeculativeDispatch_NoLiteralKey(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "main.go::h", Kind: graph.KindFunction, Name: "h", FilePath: "main.go", Language: "go"})
+	g.AddNode(&graph.Node{ID: "a.go::A.run", Kind: graph.KindMethod, Name: "run", FilePath: "a.go", Language: "go"})
+	// variable-key obj[name]() — no dyn_key → unbounded → no guess in v1.
+	g.AddEdge(&graph.Edge{From: "main.go::h", To: "unresolved::*", Kind: graph.EdgeCalls, Meta: map[string]any{"dyn_shape": "computed_member"}})
+	if n := ResolveSpeculativeDispatch(g, true); n != 0 {
+		t.Errorf("variable-key (no literal) must not guess, got %d", n)
+	}
+}
+
+func TestResolveSpeculativeDispatch_HardCap(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "main.go::h", Kind: graph.KindFunction, Name: "h", FilePath: "main.go", Language: "go"})
+	for i := 0; i < speculativeHardCap+5; i++ {
+		id := "f" + string(rune('a'+i%26)) + string(rune('0'+i/26)) + ".go::T.run"
+		g.AddNode(&graph.Node{ID: id, Kind: graph.KindMethod, Name: "run", FilePath: id, Language: "go"})
+	}
+	g.AddEdge(&graph.Edge{From: "main.go::h", To: "unresolved::*", Kind: graph.EdgeCalls, Meta: map[string]any{"dyn_shape": "computed_member", "dyn_key": "run"}})
+	if n := ResolveSpeculativeDispatch(g, true); n != 0 {
+		t.Errorf("candidate set above hard cap must be dropped as noise, got %d", n)
+	}
+}
+
+func TestResolveSpeculativeDispatch_Idempotent(t *testing.T) {
+	g := specGraph()
+	first := ResolveSpeculativeDispatch(g, true)
+	second := ResolveSpeculativeDispatch(g, true)
+	if first != 2 {
+		t.Fatalf("expected 2, got %d", first)
+	}
+	if len(specEdges(g, "main.go::handler")) != 2 {
+		t.Errorf("idempotency: edge count must stay 2, got %d (second run reported %d)", len(specEdges(g, "main.go::handler")), second)
+	}
+}

--- a/internal/resolver/store_factory_calls.go
+++ b/internal/resolver/store_factory_calls.go
@@ -1,0 +1,128 @@
+package resolver
+
+import (
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// storeFactoryVia is the Meta["via"] tag the JS/TS extractors stamp on a
+// store-factory call placeholder the same-file pass could not bind (the store
+// lives in another file).
+const storeFactoryVia = "store-factory"
+
+// ResolveStoreFactoryCalls binds Zustand/Redux/Pinia/MobX indirect action
+// calls — `useStore.getState().fetchUser()` and `const {fetchUser} =
+// useStore.getState(); fetchUser()` — to the precise action node, across files.
+//
+// The extractors stamp each store-action node with Meta["store_factory"]=<binding>
+// + Meta["store_member"]=<member>, and stamp the cross-file call placeholder
+// with Meta["via"]="store-factory" + store_binding + store_action. This pass
+// joins them by (binding, member). It is strictly more precise than the
+// competitor's bare-name matching: two stores that each define `reset` do not
+// collide, because the placeholder carries the specific store binding and the
+// pass prefers the candidate in the caller's file (then a unique binding match,
+// then a singleton). Returns the number of call edges landed on an action.
+func ResolveStoreFactoryCalls(g graph.Store) int {
+	if g == nil {
+		return 0
+	}
+	// index: binding → member → action nodes (multiple files may reuse the
+	// same binding name, hence a slice).
+	index := map[string]map[string][]*graph.Node{}
+	for _, n := range nodesByKindsOrAll(g, graph.KindFunction) {
+		if n == nil || n.Meta == nil {
+			continue
+		}
+		binding, _ := n.Meta["store_factory"].(string)
+		if binding == "" {
+			continue
+		}
+		member, _ := n.Meta["store_member"].(string)
+		if member == "" {
+			member = n.Name
+		}
+		if index[binding] == nil {
+			index[binding] = map[string][]*graph.Node{}
+		}
+		index[binding][member] = append(index[binding][member], n)
+	}
+	if len(index) == 0 {
+		return 0
+	}
+
+	resolved := 0
+	var reindex []graph.EdgeReindex
+	for e := range g.EdgesByKind(graph.EdgeCalls) {
+		if e == nil || e.Meta == nil {
+			continue
+		}
+		if v, _ := e.Meta["via"].(string); v != storeFactoryVia {
+			continue
+		}
+		binding, _ := e.Meta["store_binding"].(string)
+		action, _ := e.Meta["store_action"].(string)
+		if binding == "" || action == "" {
+			continue
+		}
+		cands := index[binding][action]
+		target := pickStoreAction(g, e, cands)
+
+		want := "unresolved::*." + action
+		if target != nil {
+			want = target.ID
+		}
+		if e.To == want {
+			if target != nil {
+				resolved++
+			}
+			continue
+		}
+		oldTo := e.To
+		e.To = want
+		if target != nil {
+			e.Origin = graph.OriginASTInferred
+			e.Confidence = 0.75
+			e.ConfidenceLabel = graph.ConfidenceLabelFor(graph.EdgeCalls, 0.75)
+			StampSynthesized(e, SynthStoreFactory)
+			resolved++
+		} else {
+			e.Origin = graph.OriginASTInferred
+			e.Confidence = 0
+			e.ConfidenceLabel = ""
+			UnstampSynthesized(e)
+		}
+		reindex = append(reindex, graph.EdgeReindex{Edge: e, OldTo: oldTo})
+	}
+	if len(reindex) > 0 {
+		g.ReindexEdges(reindex)
+	}
+	return resolved
+}
+
+// pickStoreAction disambiguates action candidates for a call: prefer the
+// candidate in the caller's file, then a unique binding match, then a
+// singleton. Returns nil when the choice is ambiguous (never guesses).
+func pickStoreAction(g graph.Store, call *graph.Edge, cands []*graph.Node) *graph.Node {
+	switch len(cands) {
+	case 0:
+		return nil
+	case 1:
+		return cands[0]
+	}
+	// Multiple stores share this binding name across files. Prefer the one in
+	// the caller's file; if the caller's file imports exactly one candidate's
+	// file, prefer that; otherwise it's ambiguous.
+	callerFile := ""
+	if cn := g.GetNode(call.From); cn != nil {
+		callerFile = cn.FilePath
+	}
+	var sameFile *graph.Node
+	for _, c := range cands {
+		if c.FilePath == callerFile && callerFile != "" {
+			if sameFile != nil {
+				return nil // two same-file candidates: ambiguous
+			}
+			sameFile = c
+		}
+	}
+	return sameFile
+}

--- a/internal/resolver/store_factory_calls_test.go
+++ b/internal/resolver/store_factory_calls_test.go
@@ -1,0 +1,98 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func storeAction(g *graph.Graph, id, file, binding, member string) {
+	g.AddNode(&graph.Node{
+		ID: id, Kind: graph.KindFunction, Name: member, FilePath: file,
+		Meta: map[string]any{"store_factory": binding, "store_member": member},
+	})
+}
+
+func storeCall(g *graph.Graph, callerID, callerFile, binding, action string) {
+	g.AddNode(&graph.Node{ID: callerID, Kind: graph.KindFunction, Name: callerID, FilePath: callerFile})
+	g.AddEdge(&graph.Edge{
+		From: callerID, To: "unresolved::*." + action, Kind: graph.EdgeCalls, FilePath: callerFile,
+		Meta: map[string]any{"via": "store-factory", "store_binding": binding, "store_action": action},
+	})
+}
+
+func TestResolveStoreFactoryCalls_SingleBinding(t *testing.T) {
+	g := graph.New()
+	storeAction(g, "store.ts::useStore.reset@3", "store.ts", "useStore", "reset")
+	storeCall(g, "caller.ts::hardReset", "caller.ts", "useStore", "reset")
+
+	n := ResolveStoreFactoryCalls(g)
+	if n != 1 {
+		t.Fatalf("expected 1 resolved, got %d", n)
+	}
+	// hardReset should now call the reset action.
+	var bound bool
+	for _, e := range g.GetOutEdges("caller.ts::hardReset") {
+		if e.To == "store.ts::useStore.reset@3" && e.Kind == graph.EdgeCalls {
+			bound = true
+			if e.Meta["synthesized_by"] != SynthStoreFactory {
+				t.Errorf("expected synthesized_by=%s, got %v", SynthStoreFactory, e.Meta["synthesized_by"])
+			}
+		}
+	}
+	if !bound {
+		t.Errorf("hardReset edge not rebound to the reset action")
+	}
+}
+
+func TestResolveStoreFactoryCalls_CollisionPrefersSameFile(t *testing.T) {
+	g := graph.New()
+	// Two stores both bound to `useStore`, each with a reset, in different files.
+	storeAction(g, "a.ts::useStore.reset@1", "a.ts", "useStore", "reset")
+	storeAction(g, "b.ts::useStore.reset@1", "b.ts", "useStore", "reset")
+	// Caller lives in a.ts → must bind to a's reset, never b's.
+	storeCall(g, "a.ts::hardReset", "a.ts", "useStore", "reset")
+
+	ResolveStoreFactoryCalls(g)
+	for _, e := range g.GetOutEdges("a.ts::hardReset") {
+		if e.Kind == graph.EdgeCalls && e.To == "b.ts::useStore.reset@1" {
+			t.Fatalf("cross-store mis-bind: hardReset bound to b.ts reset")
+		}
+	}
+	found := false
+	for _, e := range g.GetOutEdges("a.ts::hardReset") {
+		if e.To == "a.ts::useStore.reset@1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected same-file bind to a.ts reset")
+	}
+}
+
+func TestResolveStoreFactoryCalls_AmbiguousNotBound(t *testing.T) {
+	g := graph.New()
+	storeAction(g, "a.ts::useStore.reset@1", "a.ts", "useStore", "reset")
+	storeAction(g, "b.ts::useStore.reset@1", "b.ts", "useStore", "reset")
+	// Caller in a third file that can't be disambiguated.
+	storeCall(g, "c.ts::hardReset", "c.ts", "useStore", "reset")
+
+	ResolveStoreFactoryCalls(g)
+	for _, e := range g.GetOutEdges("c.ts::hardReset") {
+		if e.Kind == graph.EdgeCalls && (e.To == "a.ts::useStore.reset@1" || e.To == "b.ts::useStore.reset@1") {
+			t.Fatalf("ambiguous call should not bind, but bound to %s", e.To)
+		}
+	}
+}
+
+func TestResolveStoreFactoryCalls_Idempotent(t *testing.T) {
+	g := graph.New()
+	storeAction(g, "store.ts::useStore.reset@3", "store.ts", "useStore", "reset")
+	storeCall(g, "caller.ts::hardReset", "caller.ts", "useStore", "reset")
+
+	first := ResolveStoreFactoryCalls(g)
+	second := ResolveStoreFactoryCalls(g)
+	if first != 1 || second != 1 {
+		t.Errorf("expected idempotent resolve count 1/1, got %d/%d", first, second)
+	}
+}


### PR DESCRIPTION
## Summary

Eleven self-contained features that broaden Gortex's cross-language coverage and deepen its resolver.
Every feature is implemented in full (no stubs, no deferred parts), with table-driven unit tests plus an end-to-end test, and one commit per feature.