### PR TITLE
Fix `gortex daemon stop` respawn (#68)

### DIFF
--- a/cmd/gortex/daemon.go
+++ b/cmd/gortex/daemon.go
@@ -132,10 +132,14 @@ func init() {
 // with GORTEX_DAEMON_CHILD=1 set, which the inner exec picks up and runs
 // the actual serve loop.
 func runDaemonStart(cmd *cobra.Command, _ []string) error {
-	// An explicit start (user, supervisor, or autostart spawn) supersedes any
-	// prior `daemon stop` — clear the stay-down mark so autostart works again.
-	daemon.ClearStopIntent()
-	if daemon.IsRunning() {
+	// An explicit start (user or supervisor) supersedes a prior `daemon stop` —
+	// clear the stay-down mark so autostart works again. The autostart-spawned
+	// child (GORTEX_DAEMON_CHILD=1) must NOT clear it: that would let an
+	// in-flight autostart erase a stop-intent the user wrote in the meantime.
+	if os.Getenv("GORTEX_DAEMON_CHILD") != "1" {
+		daemon.ClearStopIntent()
+	}
+	if isDaemonRunning() {
 		return fmt.Errorf("daemon already running (socket: %s)", daemon.SocketPath())
 	}
 	// IsRunning only probes the socket. A daemon that is mid-shutdown — or
@@ -755,7 +759,9 @@ func runDaemonStop(cmd *cobra.Command, _ []string) error {
 	// the daemon we're about to stop. A `daemon restart` re-clears it via the
 	// following start, so only a standalone stop is sticky.
 	if !daemonRestartActive {
-		_ = daemon.MarkStopIntent()
+		if err := daemon.MarkStopIntent(); err != nil {
+			fmt.Fprintf(w, "[gortex daemon] warning: could not record stop intent (%v); daemon may auto-respawn\n", err)
+		}
 		// If an OS supervisor (systemd --user / launchd) owns the daemon, stop
 		// it THROUGH the supervisor — a socket-level stop just kills the worker
 		// and the supervisor restarts it. `daemon restart` skips this and

--- a/cmd/gortex/daemon.go
+++ b/cmd/gortex/daemon.go
@@ -760,7 +760,7 @@ func runDaemonStop(cmd *cobra.Command, _ []string) error {
 	// following start, so only a standalone stop is sticky.
 	if !daemonRestartActive {
 		if err := daemon.MarkStopIntent(); err != nil {
-			fmt.Fprintf(w, "[gortex daemon] warning: could not record stop intent (%v); daemon may auto-respawn\n", err)
+			_, _ = fmt.Fprintf(w, "[gortex daemon] warning: could not record stop intent (%v); daemon may auto-respawn\n", err)
 		}
 		// If an OS supervisor (systemd --user / launchd) owns the daemon, stop
 		// it THROUGH the supervisor — a socket-level stop just kills the worker

--- a/cmd/gortex/daemon.go
+++ b/cmd/gortex/daemon.go
@@ -756,6 +756,13 @@ func runDaemonStop(cmd *cobra.Command, _ []string) error {
 	// following start, so only a standalone stop is sticky.
 	if !daemonRestartActive {
 		_ = daemon.MarkStopIntent()
+		// If an OS supervisor (systemd --user / launchd) owns the daemon, stop
+		// it THROUGH the supervisor — a socket-level stop just kills the worker
+		// and the supervisor restarts it. `daemon restart` skips this and
+		// bounces via the supervisor instead.
+		if serviceActive() {
+			return serviceStop(w)
+		}
 	}
 	if !daemon.IsRunning() {
 		// The socket is gone, but a process may still be alive and holding
@@ -900,6 +907,14 @@ func runDaemonRestart(cmd *cobra.Command, args []string) error {
 	defer func() { daemonRestartActive = false }()
 
 	emitDaemonRestartBanner(cmd.ErrOrStderr())
+
+	// When an OS supervisor owns the daemon, bounce it THROUGH the supervisor so
+	// the supervisor keeps ownership; a manual stop+start would orphan the new
+	// daemon from the unit (the unit reads inactive while a hand-started process
+	// holds the socket).
+	if serviceActive() {
+		return serviceRestart(cmd.ErrOrStderr())
+	}
 
 	// Stop is idempotent when not running and now blocks until the old
 	// process has fully exited — releasing the store's on-disk lock — before

--- a/cmd/gortex/daemon.go
+++ b/cmd/gortex/daemon.go
@@ -132,6 +132,9 @@ func init() {
 // with GORTEX_DAEMON_CHILD=1 set, which the inner exec picks up and runs
 // the actual serve loop.
 func runDaemonStart(cmd *cobra.Command, _ []string) error {
+	// An explicit start (user, supervisor, or autostart spawn) supersedes any
+	// prior `daemon stop` — clear the stay-down mark so autostart works again.
+	daemon.ClearStopIntent()
 	if daemon.IsRunning() {
 		return fmt.Errorf("daemon already running (socket: %s)", daemon.SocketPath())
 	}
@@ -747,6 +750,13 @@ func emitDaemonStartSummary(w io.Writer, pid int, elapsed time.Duration) {
 
 func runDaemonStop(cmd *cobra.Command, _ []string) error {
 	w := cmd.ErrOrStderr()
+	// Record the user's "stay down" intent so the autostart path (a live
+	// `gortex mcp` proxy relaunched by an editor) doesn't immediately respawn
+	// the daemon we're about to stop. A `daemon restart` re-clears it via the
+	// following start, so only a standalone stop is sticky.
+	if !daemonRestartActive {
+		_ = daemon.MarkStopIntent()
+	}
 	if !daemon.IsRunning() {
 		// The socket is gone, but a process may still be alive and holding
 		// the store lock — a daemon mid-shutdown, or one whose socket wedged.

--- a/cmd/gortex/daemon_service.go
+++ b/cmd/gortex/daemon_service.go
@@ -73,7 +73,14 @@ func runDaemonInstallService(cmd *cobra.Command, _ []string) error {
 	// doesn't fight with it over the socket.
 	if daemon.IsRunning() {
 		_, _ = fmt.Fprintln(w, "[gortex daemon] stopping existing daemon before install")
-		if err := runDaemonStop(cmd, nil); err != nil {
+		// This is an internal lifecycle bounce — the supervisor starts the
+		// daemon right after — not a user "stay down". Suppress the stop-intent
+		// marker (as `daemon restart` does) so a failed install can't leave
+		// autostart permanently disabled with no daemon and no service.
+		daemonRestartActive = true
+		err := runDaemonStop(cmd, nil)
+		daemonRestartActive = false
+		if err != nil {
 			return fmt.Errorf("stop existing daemon: %w", err)
 		}
 	}

--- a/cmd/gortex/daemon_service.go
+++ b/cmd/gortex/daemon_service.go
@@ -119,8 +119,11 @@ func runDaemonServiceStatus(cmd *cobra.Command, _ []string) error {
 
 // --- launchd (macOS) ------------------------------------------------------
 
-// launchdPlistTemplate renders the LaunchAgent plist. KeepAlive ensures
-// crashes auto-restart; RunAtLoad starts on login.
+// launchdPlistTemplate renders the LaunchAgent plist. KeepAlive uses the
+// SuccessfulExit=false policy so the agent is restarted on a crash but NOT on a
+// clean exit — the launchd analogue of systemd's Restart=on-failure, so an
+// explicit `gortex daemon stop` (which exits 0) stays down instead of being
+// resurrected by KeepAlive. RunAtLoad starts on login.
 //
 // StandardOutPath / StandardErrorPath redirect logs into the same file
 // `gortex daemon logs` tails, so users don't need to remember two paths.
@@ -139,7 +142,10 @@ const launchdPlistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
-    <true/>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
     <key>StandardOutPath</key>
     <string>{{.LogPath}}</string>
     <key>StandardErrorPath</key>

--- a/cmd/gortex/daemon_stop_intent_test.go
+++ b/cmd/gortex/daemon_stop_intent_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/zzet/gortex/internal/daemon"
+)
+
+// The stop-intent contract is two-sided: `daemon stop` writes a sticky marker
+// and an explicit `daemon start` clears it. If the clear ever regresses, a
+// single `daemon stop` would suppress autostart forever — worse than the
+// original bug — so guard both sides directly.
+
+func TestRunDaemonStart_ClearsStopIntent(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	defer restoreSeams()
+
+	if err := daemon.MarkStopIntent(); err != nil {
+		t.Fatal(err)
+	}
+	// Short-circuit start at the "already running" guard, which sits right
+	// after the clear — so no real serve loop is needed.
+	isDaemonRunning = func() bool { return true }
+	_ = runDaemonStart(&cobra.Command{}, nil)
+
+	if daemon.StopIntentActive() {
+		t.Fatal("an explicit `daemon start` must clear the stop-intent marker")
+	}
+}
+
+func TestRunDaemonStart_AutostartChildDoesNotClearStopIntent(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	t.Setenv("GORTEX_DAEMON_CHILD", "1")
+	defer restoreSeams()
+
+	if err := daemon.MarkStopIntent(); err != nil {
+		t.Fatal(err)
+	}
+	isDaemonRunning = func() bool { return true }
+	_ = runDaemonStart(&cobra.Command{}, nil)
+
+	// The autostart-spawned child must not erase a stop-intent the user may
+	// have written after the autostart decision (the TOCTOU window).
+	if !daemon.StopIntentActive() {
+		t.Fatal("autostart child must NOT clear the stop-intent marker")
+	}
+}
+
+func TestRunDaemonStop_UnsupervisedRecordsStopIntent(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	defer restoreServiceSeams()
+
+	// The reporter's path: no service supervisor installed.
+	serviceActive = func() bool { return false }
+	// Daemon already down → stop returns via the already-down path after
+	// recording intent; no real daemon required.
+	if err := runDaemonStop(&cobra.Command{}, nil); err != nil {
+		t.Fatalf("runDaemonStop: %v", err)
+	}
+	if !daemon.StopIntentActive() {
+		t.Fatal("an unsupervised `daemon stop` must record stop-intent")
+	}
+}

--- a/cmd/gortex/daemon_supervisor.go
+++ b/cmd/gortex/daemon_supervisor.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// Supervisor-aware stop / restart.
+//
+// When the daemon is owned by an OS supervisor installed via
+// `gortex daemon install-service` (systemd --user on Linux, launchd on macOS),
+// a plain socket-level `daemon stop` just kills the worker — and the supervisor
+// promptly restarts it (launchd KeepAlive; systemd on a non-clean exit). So
+// when a supervisor owns the daemon we drive the lifecycle THROUGH it:
+//
+//   - stop    → tell the supervisor to stop the unit (stays installed/enabled),
+//   - restart → tell the supervisor to bounce the unit, keeping its ownership.
+//
+// A manual stop+start under a supervisor would orphan the freshly-started
+// daemon from the unit (the unit reads inactive while a hand-started process
+// holds the socket), so restart must route through the supervisor too.
+//
+// The three entry points are function vars so the routing in runDaemonStop /
+// runDaemonRestart is testable without a real systemd / launchd.
+var (
+	serviceActive  = defaultServiceActive
+	serviceStop    = defaultServiceStop
+	serviceRestart = defaultServiceRestart
+)
+
+// defaultServiceActive reports whether an installed service unit currently owns
+// the daemon (unit file present AND the supervisor reports it active/loaded).
+// It short-circuits on a missing unit file so the common, unsupervised case
+// never shells out.
+func defaultServiceActive() bool {
+	switch runtime.GOOS {
+	case "linux":
+		path, err := systemdUnitPath()
+		if err != nil {
+			return false
+		}
+		if _, err := os.Stat(path); err != nil {
+			return false
+		}
+		out, _ := exec.Command("systemctl", "--user", "is-active", daemonServiceName).Output()
+		return strings.TrimSpace(string(out)) == "active"
+	case "darwin":
+		path, err := launchdPlistPath()
+		if err != nil {
+			return false
+		}
+		if _, err := os.Stat(path); err != nil {
+			return false
+		}
+		// `launchctl list <label>` exits 0 when the agent is loaded.
+		return exec.Command("launchctl", "list", daemonServiceName).Run() == nil
+	default:
+		return false
+	}
+}
+
+// defaultServiceStop stops the daemon via its supervisor so it stays down — the
+// unit remains installed/enabled and comes back at next login or an explicit
+// `daemon start`.
+func defaultServiceStop(w io.Writer) error {
+	switch runtime.GOOS {
+	case "linux":
+		if err := runCmd(w, "systemctl", "--user", "stop", daemonServiceName); err != nil {
+			return fmt.Errorf("systemctl --user stop: %w", err)
+		}
+	case "darwin":
+		// bootout stops + unloads for this login session; KeepAlive can't
+		// resurrect a booted-out agent. RunAtLoad reloads it at next login.
+		label := fmt.Sprintf("gui/%d/%s", os.Getuid(), daemonServiceName)
+		if err := runCmd(w, "launchctl", "bootout", label); err != nil {
+			return fmt.Errorf("launchctl bootout: %w", err)
+		}
+	default:
+		return fmt.Errorf("supervised stop not supported on %s", runtime.GOOS)
+	}
+	_, _ = fmt.Fprintln(w, "[gortex daemon] stopped via service supervisor")
+	return nil
+}
+
+// defaultServiceRestart bounces the daemon through its supervisor so the
+// supervisor keeps owning the new process.
+func defaultServiceRestart(w io.Writer) error {
+	switch runtime.GOOS {
+	case "linux":
+		if err := runCmd(w, "systemctl", "--user", "restart", daemonServiceName); err != nil {
+			return fmt.Errorf("systemctl --user restart: %w", err)
+		}
+	case "darwin":
+		label := fmt.Sprintf("gui/%d/%s", os.Getuid(), daemonServiceName)
+		if err := runCmd(w, "launchctl", "kickstart", "-k", label); err != nil {
+			return fmt.Errorf("launchctl kickstart -k: %w", err)
+		}
+	default:
+		return fmt.Errorf("supervised restart not supported on %s", runtime.GOOS)
+	}
+	_, _ = fmt.Fprintln(w, "[gortex daemon] restarted via service supervisor")
+	return nil
+}

--- a/cmd/gortex/daemon_supervisor_test.go
+++ b/cmd/gortex/daemon_supervisor_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"io"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/zzet/gortex/internal/daemon"
+)
+
+func restoreServiceSeams() {
+	serviceActive = defaultServiceActive
+	serviceStop = defaultServiceStop
+	serviceRestart = defaultServiceRestart
+}
+
+func TestRunDaemonStop_SupervisedRoutesToServiceStop(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	defer restoreServiceSeams()
+
+	var stopCalls int32
+	serviceActive = func() bool { return true }
+	serviceStop = func(io.Writer) error { atomic.AddInt32(&stopCalls, 1); return nil }
+	serviceRestart = func(io.Writer) error { t.Fatal("restart must not be called by stop"); return nil }
+
+	if err := runDaemonStop(&cobra.Command{}, nil); err != nil {
+		t.Fatalf("runDaemonStop: %v", err)
+	}
+	if got := atomic.LoadInt32(&stopCalls); got != 1 {
+		t.Fatalf("serviceStop calls = %d, want 1 (supervised stop must route through the supervisor)", got)
+	}
+	// The stay-down mark is still recorded so a stray `gortex mcp` proxy
+	// doesn't autostart a second, unsupervised daemon either.
+	if !daemon.StopIntentActive() {
+		t.Fatal("supervised stop must still record stop-intent")
+	}
+}
+
+func TestRunDaemonRestart_SupervisedRoutesToServiceRestart(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	defer restoreServiceSeams()
+
+	var restartCalls int32
+	serviceActive = func() bool { return true }
+	serviceRestart = func(io.Writer) error { atomic.AddInt32(&restartCalls, 1); return nil }
+	serviceStop = func(io.Writer) error { t.Fatal("restart must not stop the supervisor"); return nil }
+
+	if err := runDaemonRestart(&cobra.Command{}, nil); err != nil {
+		t.Fatalf("runDaemonRestart: %v", err)
+	}
+	if got := atomic.LoadInt32(&restartCalls); got != 1 {
+		t.Fatalf("serviceRestart calls = %d, want 1 (supervised restart must bounce via the supervisor)", got)
+	}
+}
+
+func TestDefaultServiceActive_NoUnitFileIsInactive(t *testing.T) {
+	// Point HOME (and cache) at an empty dir so no unit file exists; detection
+	// must short-circuit to false without shelling out to the supervisor.
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CACHE_HOME", tmp)
+	if defaultServiceActive() {
+		t.Fatal("no installed unit file => service must be reported inactive")
+	}
+}
+
+func TestLaunchdTemplate_RestartsOnlyOnFailure(t *testing.T) {
+	// KeepAlive must be the SuccessfulExit=false policy, not bare <true/>, so a
+	// clean `daemon stop` is not resurrected on macOS.
+	if !strings.Contains(launchdPlistTemplate, "<key>SuccessfulExit</key>") {
+		t.Error("launchd plist must use the KeepAlive SuccessfulExit policy")
+	}
+	if strings.Contains(launchdPlistTemplate, "<key>KeepAlive</key>\n    <true/>") {
+		t.Error("launchd plist must not use unconditional KeepAlive=true")
+	}
+}
+
+func TestSystemdTemplate_RestartsOnlyOnFailure(t *testing.T) {
+	if !strings.Contains(systemdUnitTemplate, "Restart=on-failure") {
+		t.Error("systemd unit must restart only on failure so a clean stop sticks")
+	}
+}

--- a/cmd/gortex/ensure_daemon.go
+++ b/cmd/gortex/ensure_daemon.go
@@ -34,8 +34,9 @@ const (
 // Injectable seams so the race/fallback/spawn-failure branches are
 // testable without a real daemon.
 var (
-	isDaemonRunning = daemon.IsRunning
-	spawnDaemon     = spawnDetachedDaemon
+	isDaemonRunning  = daemon.IsRunning
+	spawnDaemon      = spawnDetachedDaemon
+	stopIntentActive = daemon.StopIntentActive
 )
 
 // resolveDaemonDecision probes the socket and, when auto-start is enabled
@@ -53,6 +54,13 @@ func ensureDaemonReady(autostart bool) daemonDecision {
 		return daemonReady
 	}
 	if !autostart {
+		return daemonUnavailable
+	}
+	// Respect an explicit `daemon stop`: do not resurrect a daemon the user
+	// deliberately stopped. The mark is cleared by `daemon start` / `restart`.
+	// A suppressed `gortex mcp` falls back to the embedded server, so this
+	// declines the background daemon without breaking the tool surface.
+	if stopIntentActive() {
 		return daemonUnavailable
 	}
 

--- a/cmd/gortex/ensure_daemon_test.go
+++ b/cmd/gortex/ensure_daemon_test.go
@@ -66,6 +66,27 @@ func TestEnsureDaemon_StopIntentSuppressesAutostart(t *testing.T) {
 	}
 }
 
+func TestEnsureDaemon_RealStopIntentMarkerSuppresses(t *testing.T) {
+	isolateSpawnLock(t) // points XDG_CACHE_HOME at a fresh temp dir
+	defer restoreSeams()
+	stopIntentActive = daemon.StopIntentActive // exercise the real FS-backed check
+	var spawned int32
+	isDaemonRunning = func() bool { return false }
+	spawnDaemon = func() error { atomic.AddInt32(&spawned, 1); return nil }
+	if err := daemon.MarkStopIntent(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { daemon.ClearStopIntent() })
+	// End-to-end: the real marker write + real read must agree on the path and
+	// suppress the spawn — not just the stubbed seam.
+	if d := ensureDaemonReady(true); d != daemonUnavailable {
+		t.Fatalf("a real stop-intent marker must suppress autostart, got %d", d)
+	}
+	if atomic.LoadInt32(&spawned) != 0 {
+		t.Fatal("must not spawn while a real stop-intent marker is present")
+	}
+}
+
 func TestEnsureDaemon_SingleFlight(t *testing.T) {
 	isolateSpawnLock(t)
 	defer restoreSeams()

--- a/cmd/gortex/ensure_daemon_test.go
+++ b/cmd/gortex/ensure_daemon_test.go
@@ -14,6 +14,7 @@ import (
 func restoreSeams() {
 	isDaemonRunning = daemon.IsRunning
 	spawnDaemon = spawnDetachedDaemon
+	stopIntentActive = daemon.StopIntentActive
 }
 
 // isolateSpawnLock points the spawn lock + fail marker at a fresh temp
@@ -46,6 +47,22 @@ func TestEnsureDaemon_AutostartOff(t *testing.T) {
 	spawnDaemon = func() error { t.Fatal("no spawn when autostart is off"); return nil }
 	if d := ensureDaemonReady(false); d != daemonUnavailable {
 		t.Fatalf("want daemonUnavailable, got %d", d)
+	}
+}
+
+func TestEnsureDaemon_StopIntentSuppressesAutostart(t *testing.T) {
+	defer restoreSeams()
+	var spawned int32
+	isDaemonRunning = func() bool { return false }
+	stopIntentActive = func() bool { return true }
+	spawnDaemon = func() error { atomic.AddInt32(&spawned, 1); return nil }
+	// Autostart is on, but the user explicitly stopped the daemon: it must
+	// stay down rather than be resurrected by the proxy's autostart path.
+	if d := ensureDaemonReady(true); d != daemonUnavailable {
+		t.Fatalf("stop-intent must suppress autostart => daemonUnavailable, got %d", d)
+	}
+	if atomic.LoadInt32(&spawned) != 0 {
+		t.Fatal("a deliberately-stopped daemon must not be auto-respawned")
 	}
 }
 

--- a/internal/daemon/stop_intent.go
+++ b/internal/daemon/stop_intent.go
@@ -1,0 +1,58 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+)
+
+// Stop-intent marker.
+//
+// `gortex daemon stop` is a user's explicit "stay down" signal. But the
+// daemon is auto-startable: any `gortex mcp` proxy (the process an editor /
+// AI agent keeps alive) re-runs the autostart path on its next launch and
+// would immediately respawn the daemon the user just stopped. The stop-intent
+// marker records that intent so the autostart single-flight (ensureDaemonReady)
+// declines to resurrect a deliberately-stopped daemon.
+//
+// Unlike the spawn-fail marker, this one is sticky — it has no TTL and is
+// cleared only by an explicit `gortex daemon start` / `restart`. Suppressing
+// autostart does not break `gortex mcp`: a suppressed proxy falls back to the
+// embedded in-process server exactly as it does under GORTEX_AUTOSTART=0.
+
+// StopIntentMarkerPath returns the sentinel file recording an explicit
+// `daemon stop`. Co-located with the socket / PID / spawn-lock under the
+// per-user state dir so it shares the daemon's lifecycle directory.
+func StopIntentMarkerPath() string {
+	if dir, ok := stateDir(); ok {
+		return filepath.Join(dir, "daemon.stopped")
+	}
+	return filepath.Join(os.TempDir(), "gortex-daemon.stopped")
+}
+
+// MarkStopIntent records that the user explicitly stopped the daemon, so the
+// autostart path will not respawn it until an explicit start clears the mark.
+// The marker content is the stamp time (nanos) for debuggability; only its
+// presence is load-bearing.
+func MarkStopIntent() error {
+	path := StopIntentMarkerPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(strconv.FormatInt(time.Now().UnixNano(), 10)), 0o600)
+}
+
+// ClearStopIntent removes the stop-intent marker, re-enabling autostart. An
+// explicit `daemon start` / `restart` is the user (or supervisor) asking for a
+// running daemon, which supersedes a prior stop. Absent marker is a no-op.
+func ClearStopIntent() {
+	_ = os.Remove(StopIntentMarkerPath())
+}
+
+// StopIntentActive reports whether the user has an outstanding `daemon stop`
+// that no subsequent start has cleared.
+func StopIntentActive() bool {
+	_, err := os.Stat(StopIntentMarkerPath())
+	return err == nil
+}

--- a/internal/daemon/stop_intent_test.go
+++ b/internal/daemon/stop_intent_test.go
@@ -1,0 +1,48 @@
+package daemon
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestStopIntent_MarkClearRoundtrip(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	if StopIntentActive() {
+		t.Fatal("no marker should exist on a fresh state dir")
+	}
+	if err := MarkStopIntent(); err != nil {
+		t.Fatalf("MarkStopIntent: %v", err)
+	}
+	if !StopIntentActive() {
+		t.Fatal("marker must be active after MarkStopIntent")
+	}
+	// Idempotent: a second mark keeps it active, not an error.
+	if err := MarkStopIntent(); err != nil {
+		t.Fatalf("second MarkStopIntent: %v", err)
+	}
+	if !StopIntentActive() {
+		t.Fatal("marker must still be active after a repeat mark")
+	}
+	ClearStopIntent()
+	if StopIntentActive() {
+		t.Fatal("marker must be gone after ClearStopIntent")
+	}
+	// Clearing an absent marker is a no-op, not a panic/error.
+	ClearStopIntent()
+	if StopIntentActive() {
+		t.Fatal("clearing twice must leave the marker absent")
+	}
+}
+
+func TestStopIntentMarkerPath_UnderStateDir(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	marker := StopIntentMarkerPath()
+	if filepath.Base(marker) != "daemon.stopped" {
+		t.Errorf("marker basename = %q, want daemon.stopped", filepath.Base(marker))
+	}
+	// Co-located with the rest of the daemon's runtime state.
+	if filepath.Dir(marker) != filepath.Dir(SpawnLockPath()) {
+		t.Error("stop-intent marker should be a sibling of the spawn lock")
+	}
+}


### PR DESCRIPTION
Fixes #68.

## Problem
`gortex daemon stop` reports a clean shutdown, but the daemon reappears ~5 seconds later. `daemon stop` itself is correct — it sends a graceful `ControlShutdown`, waits for the process to exit, and removes the socket/PID files. Something *external* brings the daemon back. 

There are two such respawners:
1. **MCP-client autostart (the common case).** An editor / AI agent keeps a `gortex mcp` stdio proxy alive. When `daemon stop` closes the socket, that proxy exits on EOF; the MCP host relaunches it, and a fresh `gortex mcp` re-runs the autostart path (`ensureDaemonReady` → `spawnDetachedDaemon`). Autostart is on by default, so the daemon comes straight back.
2. **OS service supervisor.** If `gortex daemon install-service` was run, a systemd `--user` unit (or launchd agent) owns the daemon. A socket-level stop just kills the worker, and the supervisor restarts it — unconditionally on macOS (`KeepAlive=true`), or on a non-clean exit on Linux.

The process shows in `htop` as `gortex start` — that's column truncation of the real argv `gortex daemon start` (the only daemon-spawn argv in the tree), not a separate command.

## What this PR changes

### 1. Sticky stop-intent (closes cause 1)
  - `daemon stop` records a `daemon.stopped` marker (`internal/daemon/stop_intent.go`).
  - `ensureDaemonReady` declines to autostart while the marker is present, so a relaunched `gortex mcp` no longer resurrects a deliberately-stopped daemon.
  - `daemon start` / `daemon restart` clear the marker (an explicit start supersedes a stop). The autostart-spawned child does **not** clear it.
  - Suppressing autostart does **not** break tooling: a suppressed `gortex mcp` falls back to the embedded in-process server, exactly as it does under `GORTEX_AUTOSTART=0`. `gortex track` stays offline-safe (registers the repo in config; the daemon picks it up on next start).

### 2. Supervisor-aware stop / restart (closes cause 2)
  - New `cmd/gortex/daemon_supervisor.go` detects an active service unit and routes:
    - `daemon stop` → `systemctl --user stop` / `launchctl bootout` (unit stays installed/enabled, just stopped).
    - `daemon restart` → `systemctl --user restart` / `launchctl kickstart -k` (supervisor keeps ownership instead of orphaning a hand-started daemon).
  - launchd `KeepAlive` changed to `SuccessfulExit=false` — the analogue of systemd's `Restart=on-failure` — so a clean stop is no longer resurrected on macOS. (Existing installs need a `gortex daemon install-service` re-run to pick up the new plist.)
  - Detection short-circuits on a missing unit file, so the unsupervised common case never shells out.

### 3. Hardening (from an adversarial review pass)
  - `install-service`'s internal pre-stop no longer records a stay-down marker, so a failed `enable --now` can't leave autostart permanently disabled.
  - The autostart child (`GORTEX_DAEMON_CHILD=1`) doesn't clear the marker — closes a TOCTOU window where an in-flight autostart could erase a stop-intent the user just wrote.
  - A failed `MarkStopIntent` write now warns instead of being swallowed.

  ## Behavior changes

  - After `gortex daemon stop`, the daemon stays down until an explicit `gortex daemon start` / `restart`. While stopped, an editor's `gortex mcp` runs in embedded (single-repo) mode rather than respawning the daemon.
  - On supervised hosts, `daemon stop` / `restart` now act through the supervisor.