### PR TITLE
Fix/daemon churn hotpath

### DIFF
--- a/internal/daemon/overlay.go
+++ b/internal/daemon/overlay.go
@@ -521,6 +521,45 @@ func (m *OverlayManager) SweepIdle() int {
 	return dropped
 }
 
+// StartJanitor launches the background sweeper that enforces IdleTTL.
+// Without it SweepIdle never runs and a session whose proxy vanished
+// without an observed disconnect pins its pushed buffers for the
+// daemon's lifetime. interval <= 0 derives a default from the TTL
+// (TTL/4, floored at one minute). onSweep, when non-nil, is invoked
+// with the dropped count after any sweep that removed sessions —
+// telemetry stays the caller's concern. The returned stop func
+// terminates the goroutine and is safe to call more than once. A
+// manager with expiry disabled (idleTTL <= 0) starts no goroutine
+// and returns a no-op stop.
+func (m *OverlayManager) StartJanitor(interval time.Duration, onSweep func(dropped int)) (stop func()) {
+	if m.idleTTL <= 0 {
+		return func() {}
+	}
+	if interval <= 0 {
+		interval = m.idleTTL / 4
+		if interval < time.Minute {
+			interval = time.Minute
+		}
+	}
+	done := make(chan struct{})
+	var once sync.Once
+	go func() {
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-t.C:
+				if dropped := m.SweepIdle(); dropped > 0 && onSweep != nil {
+					onSweep(dropped)
+				}
+			case <-done:
+				return
+			}
+		}
+	}()
+	return func() { once.Do(func() { close(done) }) }
+}
+
 // ---------------------------------------------------------------------------
 // Branching surface: fork, list, switch, merge, drop_branch.
 // ---------------------------------------------------------------------------

--- a/internal/daemon/overlay_test.go
+++ b/internal/daemon/overlay_test.go
@@ -109,6 +109,42 @@ func TestOverlayManager_SweepIdleHonoursTTL(t *testing.T) {
 	require.False(t, m.Has(id))
 }
 
+func TestOverlayManager_StartJanitorSweepsAndStops(t *testing.T) {
+	m := NewOverlayManager(20 * time.Millisecond)
+	id := m.Register("ws")
+	require.True(t, m.Has(id))
+
+	swept := make(chan int, 1)
+	stop := m.StartJanitor(10*time.Millisecond, func(dropped int) {
+		select {
+		case swept <- dropped:
+		default:
+		}
+	})
+	defer stop()
+
+	select {
+	case dropped := <-swept:
+		require.Equal(t, 1, dropped, "janitor must reap the idle session")
+	case <-time.After(2 * time.Second):
+		t.Fatal("janitor never swept the idle session")
+	}
+	require.False(t, m.Has(id))
+
+	// stop is idempotent and terminates the goroutine.
+	stop()
+	stop()
+}
+
+func TestOverlayManager_StartJanitorDisabledTTL(t *testing.T) {
+	m := NewOverlayManager(0)
+	stop := m.StartJanitor(time.Millisecond, func(int) {
+		t.Error("janitor must not run when expiry is disabled")
+	})
+	stop()
+	stop()
+}
+
 // TestOverlayManager_SnapshotForBumpsLastUsed proves the load-bearing
 // "reads count as activity" guarantee: a session that only queries
 // (no further Push) keeps its lease alive as long as the view-build

--- a/internal/graph/store_sqlite/schema.go
+++ b/internal/graph/store_sqlite/schema.go
@@ -72,6 +72,12 @@ CREATE TABLE IF NOT EXISTS edges (
 
 CREATE INDEX IF NOT EXISTS edges_by_from ON edges(from_id, kind);
 CREATE INDEX IF NOT EXISTS edges_by_to   ON edges(to_id, kind);
+-- edges_by_kind backs EdgesByKind / EdgesByKinds (resolver whole-graph
+-- passes probe single kinds like provides/imports on every file save);
+-- without it those are full edges-table scans — edges_by_from/to lead
+-- with an id column and the partial edges_external index only covers
+-- its own predicate.
+CREATE INDEX IF NOT EXISTS edges_by_kind ON edges(kind);
 
 CREATE TABLE IF NOT EXISTS file_mtimes (
     repo_prefix TEXT NOT NULL,

--- a/internal/graph/storetest/storetest.go
+++ b/internal/graph/storetest/storetest.go
@@ -165,6 +165,7 @@ func testAddGetNode(t *testing.T, factory Factory) {
 	got := s.GetNode("a.go::Foo")
 	if got == nil {
 		t.Fatalf("GetNode returned nil for inserted node")
+		return
 	}
 	if got.Name != "Foo" || got.FilePath != "a.go" || got.Kind != graph.KindFunction {
 		t.Fatalf("round-trip mismatch: %+v", got)
@@ -805,6 +806,7 @@ func testMetaPreserved(t *testing.T, factory Factory) {
 	got := s.GetNode("a.go::Foo")
 	if got == nil {
 		t.Fatalf("GetNode returned nil")
+		return
 	}
 	if got.Meta == nil {
 		t.Fatalf("Meta not preserved")
@@ -1201,6 +1203,7 @@ func testSymbolBundleSearcher(t *testing.T, factory Factory) {
 	for _, b := range bundles {
 		if b.Node == nil {
 			t.Fatalf("bundle has nil node: %+v", b)
+			continue
 		}
 		gotIDs[b.Node.ID] = b
 	}
@@ -1997,6 +2000,7 @@ func testNodesByKindsScanner(t *testing.T, factory Factory) {
 	}
 	if fn1Got == nil {
 		t.Fatalf("Fn1 missing from result")
+		return
 	}
 	if pct, _ := fn1Got.Meta["coverage_pct"].(float64); pct != 42.5 {
 		t.Fatalf("Fn1.Meta.coverage_pct = %v, want 42.5", fn1Got.Meta["coverage_pct"])
@@ -3168,6 +3172,7 @@ func testFileEditingContext(t *testing.T, factory Factory) {
 	res := scan.FileEditingContext("a.go", []graph.NodeKind{graph.KindFunction, graph.KindMethod})
 	if res == nil {
 		t.Fatalf("FileEditingContext returned nil for a.go")
+		return
 	}
 	if res.FileNode == nil || res.FileNode.ID != "a.go" {
 		t.Fatalf("FileNode missing or wrong: %+v", res.FileNode)

--- a/internal/indexer/git_watcher.go
+++ b/internal/indexer/git_watcher.go
@@ -42,6 +42,14 @@ type GitWatcher struct {
 	fireTimer   *time.Timer
 	loopStarted bool
 	stopCalled  bool
+	// reconciling single-flights reconcile: a ref event landing while
+	// one is in flight sets rerun instead of spawning a second
+	// concurrent reconcile from the same stale base (each AfterFunc
+	// fires on its own goroutine, and lastSHA only advances at the
+	// END of a reconcile — overlapping runs would diff and apply the
+	// same range twice and race applyChanges/ResolveAll).
+	reconciling bool
+	rerun       bool
 	// drained is a test hook that fires after a reconcile completes
 	// with the number of files patched. nil in production.
 	drained func(int)
@@ -165,6 +173,30 @@ func (gw *GitWatcher) scheduleReconcile(trigger string) {
 // the end. Silently no-ops when HEAD hasn't moved — branches can
 // touch packed-refs without the resolved commit actually changing.
 func (gw *GitWatcher) reconcile(trigger string) {
+	// Single-flight: one reconcile at a time. A ref change observed
+	// mid-flight is coalesced into exactly one follow-up run that
+	// diffs the (now advanced) lastSHA against wherever HEAD ended
+	// up — so we always converge on the latest state without ever
+	// running two whole-graph passes concurrently.
+	gw.mu.Lock()
+	if gw.reconciling {
+		gw.rerun = true
+		gw.mu.Unlock()
+		return
+	}
+	gw.reconciling = true
+	gw.mu.Unlock()
+	defer func() {
+		gw.mu.Lock()
+		gw.reconciling = false
+		again := gw.rerun && !gw.stopCalled
+		gw.rerun = false
+		gw.mu.Unlock()
+		if again {
+			go gw.reconcile("coalesced")
+		}
+	}()
+
 	if gw.rebaseInProgress() {
 		// Defer until the rebase lands. The final rebase state
 		// either updates HEAD (triggering another fsnotify fire) or

--- a/internal/indexer/git_watcher_integration_test.go
+++ b/internal/indexer/git_watcher_integration_test.go
@@ -124,6 +124,90 @@ func TestGitWatcher_BranchSwitchReconciles(t *testing.T) {
 		"after checkout feature, Beta must be indexed")
 }
 
+// TestGitWatcher_ReconcileSingleFlight proves overlapping reconciles
+// coalesce instead of running concurrently from the same stale base:
+// a reconcile arriving while one is in flight only marks a rerun, and
+// the in-flight run's completion replays exactly one follow-up that
+// converges on the latest HEAD (and no-ops when HEAD didn't move).
+func TestGitWatcher_ReconcileSingleFlight(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available in PATH")
+	}
+
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init", "-q", "-b", "main")
+	runGit(t, repoDir, "config", "user.email", "test@example.com")
+	runGit(t, repoDir, "config", "user.name", "Test")
+	runGit(t, repoDir, "config", "commit.gpgsign", "false")
+
+	writeFile(t, filepath.Join(repoDir, "a.go"), "package main\nfunc Alpha() {}\n")
+	runGit(t, repoDir, "add", ".")
+	runGit(t, repoDir, "commit", "-q", "-m", "main: Alpha")
+
+	g := graph.New()
+	idx := New(g, newTestRegistry(), config.IndexConfig{Workers: 1}, zap.NewNop())
+	idx.search = search.NewBM25()
+	idx.SetRootPath(repoDir)
+	_, err := idx.IndexCtx(testCtx(), repoDir)
+	require.NoError(t, err)
+
+	gw, err := NewGitWatcher(repoDir, idx, zap.NewNop())
+	require.NoError(t, err)
+	gw.lastSHA, err = gw.currentSHA(testCtx())
+	require.NoError(t, err)
+
+	drained := make(chan int, 2)
+	gw.drained = func(n int) { drained <- n }
+
+	// A reconcile arriving while one is in flight must coalesce: it
+	// leaves the graph and lastSHA untouched and records the rerun.
+	gw.mu.Lock()
+	gw.reconciling = true
+	gw.mu.Unlock()
+	gw.reconcile("overlapping")
+	gw.mu.Lock()
+	require.True(t, gw.rerun, "overlapping reconcile must coalesce into a rerun")
+	gw.reconciling = false
+	gw.mu.Unlock()
+	select {
+	case <-drained:
+		t.Fatal("coalesced reconcile must not apply changes")
+	default:
+	}
+
+	// Move HEAD, then run the real reconcile with the rerun flag still
+	// set: it applies the branch switch, and its completion replays
+	// exactly one follow-up that no-ops on the unchanged HEAD.
+	runGit(t, repoDir, "checkout", "-q", "-b", "feature")
+	require.NoError(t, os.Remove(filepath.Join(repoDir, "a.go")))
+	writeFile(t, filepath.Join(repoDir, "b.go"), "package main\nfunc Beta() {}\n")
+	runGit(t, repoDir, "add", "-A")
+	runGit(t, repoDir, "commit", "-q", "-m", "feature: Beta replaces Alpha")
+
+	gw.reconcile("real")
+
+	select {
+	case n := <-drained:
+		require.GreaterOrEqual(t, n, 1, "real reconcile must touch files")
+	case <-time.After(5 * time.Second):
+		t.Fatal("reconcile did not complete")
+	}
+	assert.Empty(t, g.GetFileNodes("a.go"), "Alpha must be evicted")
+	assert.NotEmpty(t, g.GetFileNodes("b.go"), "Beta must be indexed")
+
+	// The replayed follow-up settles without applying anything.
+	require.Eventually(t, func() bool {
+		gw.mu.Lock()
+		defer gw.mu.Unlock()
+		return !gw.reconciling && !gw.rerun
+	}, 5*time.Second, 10*time.Millisecond, "coalesced follow-up must settle")
+	select {
+	case <-drained:
+		t.Fatal("follow-up reconcile on unchanged HEAD must not apply changes")
+	default:
+	}
+}
+
 // TestGitWatcher_NoopWhenHeadUnchanged covers the "ref file touched
 // but commit unchanged" case — e.g., a git gc that packs refs without
 // moving any branch. The watcher should read the current SHA, find

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -2769,15 +2769,15 @@ func (idx *Indexer) indexFile(filePath string, resolve bool) error {
 	}
 
 	if resolve {
-		idx.resolver.ResolveFile(graphPath)
-		// Reverse pass: bind callers in OTHER files that reference a
-		// symbol (re)defined here. ResolveFile above only fixed this
-		// file's OUTGOING edges; a symbol newly defined or changed here
-		// leaves callers elsewhere pointing at the unresolved stub
+		// Forward pass (this file's outgoing references) plus the
+		// reverse pass binding callers in OTHER files that reference a
+		// symbol (re)defined here — a symbol newly defined or changed
+		// here leaves callers elsewhere pointing at the unresolved stub
 		// restubIncomingRefs left when the prior concrete node was
 		// evicted. Scoped to this file's names — not a whole-graph
-		// ResolveAll.
-		idx.resolver.ResolveIncomingForFile(graphPath)
+		// ResolveAll — and run as one combined pass so the resolver's
+		// per-pass indexes are built once per save, not twice.
+		idx.resolver.ResolveFileAndIncoming(graphPath)
 		// CPG-lite dataflow placeholders for this file: inter-
 		// procedural callees may have just been lifted by
 		// ResolveFile, so re-run the dataflow materialisation pass

--- a/internal/indexer/watcher.go
+++ b/internal/indexer/watcher.go
@@ -812,9 +812,6 @@ func (w *Watcher) patchGraph(path string, kind ChangeKind) {
 	start := time.Now()
 	var nodesAdded, nodesRemoved, edgesAdded, edgesRemoved int
 
-	nodesBefore := w.indexer.graph.NodeCount()
-	edgesBefore := w.indexer.graph.EdgeCount()
-
 	// Compute the relative path for snapshotting old symbols. RelKey
 	// folds it to the canonical key (slash form, Unicode NFC) so the
 	// GetFileNodes / snapshotSymbols lookups below hit the same graph
@@ -832,15 +829,15 @@ func (w *Watcher) patchGraph(path string, kind ChangeKind) {
 			w.logger.Warn("index file failed", zap.String("path", path), zap.Error(err))
 			return
 		}
-		nodesAdded = w.indexer.graph.NodeCount() - nodesBefore
-		edgesAdded = w.indexer.graph.EdgeCount() - edgesBefore
+		newSymbols := w.indexer.graph.GetFileNodes(relPath)
+		nodesAdded = len(newSymbols)
+		edgesAdded = w.countFileEdges(newSymbols)
 
 		// Notify callback: no old symbols, only new symbols.
 		w.symbolChangeCbMu.RLock()
 		cb := w.symbolChangeCb
 		w.symbolChangeCbMu.RUnlock()
 		if cb != nil {
-			newSymbols := w.indexer.graph.GetFileNodes(relPath)
 			cb(relPath, nil, newSymbols)
 		}
 
@@ -874,20 +871,24 @@ func (w *Watcher) patchGraph(path string, kind ChangeKind) {
 		// count first (still present pre-swap) so removed/added telemetry
 		// stays gross: a rename removes one node and adds one even though
 		// the net node delta is zero.
-		priorFileNodes := len(w.indexer.graph.GetFileNodes(relPath))
+		priorNodes := w.indexer.graph.GetFileNodes(relPath)
+		fileEdgesBefore := w.countFileEdges(priorNodes)
 		if err := w.indexer.IndexFile(path); err != nil {
 			w.logger.Warn("reindex file failed", zap.String("path", path), zap.Error(err))
 			return
 		}
-		nodesRemoved = priorFileNodes
-		nodesAdded = len(w.indexer.graph.GetFileNodes(relPath))
-		// Edge churn as the net graph-wide delta — per-file edge counting
-		// would need a subgraph walk, which this watch-patch telemetry
-		// doesn't need.
-		if edgesAfter := w.indexer.graph.EdgeCount(); edgesAfter >= edgesBefore {
-			edgesAdded = edgesAfter - edgesBefore
+		nodesRemoved = len(priorNodes)
+		newSymbols := w.indexer.graph.GetFileNodes(relPath)
+		nodesAdded = len(newSymbols)
+		// Edge churn scoped to this file's nodes. A graph-wide
+		// EdgeCount delta would also pick up edges landed by whatever
+		// else mutates the graph during this patch (concurrent
+		// reconciles, deferred passes), which made the edges+ figure
+		// meaningless noise on a busy daemon.
+		if fileEdgesAfter := w.countFileEdges(newSymbols); fileEdgesAfter >= fileEdgesBefore {
+			edgesAdded = fileEdgesAfter - fileEdgesBefore
 		} else {
-			edgesRemoved = edgesBefore - edgesAfter
+			edgesRemoved = fileEdgesBefore - fileEdgesAfter
 		}
 
 		// Notify callback with old and new symbols.
@@ -895,7 +896,6 @@ func (w *Watcher) patchGraph(path string, kind ChangeKind) {
 		cb := w.symbolChangeCb
 		w.symbolChangeCbMu.RUnlock()
 		if cb != nil {
-			newSymbols := w.indexer.graph.GetFileNodes(relPath)
 			cb(relPath, oldSymbols, newSymbols)
 		}
 
@@ -963,6 +963,34 @@ func (w *Watcher) patchGraph(path string, kind ChangeKind) {
 		zap.Int("edges-", edgesRemoved),
 		zap.Int64("ms", ev.DurationMs),
 	)
+}
+
+// countFileEdges counts the edges incident to the given file nodes:
+// every out-edge plus the in-edges that originate outside the file
+// (an intra-file edge is already counted on its From side). Batched
+// so a disk backend pays two bulk lookups instead of 2N point queries.
+func (w *Watcher) countFileEdges(nodes []*graph.Node) int {
+	if len(nodes) == 0 {
+		return 0
+	}
+	ids := make([]string, 0, len(nodes))
+	inFile := make(map[string]struct{}, len(nodes))
+	for _, n := range nodes {
+		ids = append(ids, n.ID)
+		inFile[n.ID] = struct{}{}
+	}
+	total := 0
+	for _, edges := range w.indexer.graph.GetOutEdgesByNodeIDs(ids) {
+		total += len(edges)
+	}
+	for _, edges := range w.indexer.graph.GetInEdgesByNodeIDs(ids) {
+		for _, e := range edges {
+			if _, ok := inFile[e.From]; !ok {
+				total++
+			}
+		}
+	}
+	return total
 }
 
 // recordInertModify finishes a ChangeModified patch that the

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -761,23 +761,61 @@ func (r *Resolver) lookupDepModule(callerRepo, importPath string) *graph.Node {
 	return nil
 }
 
+// buildPassIndexes builds the four per-pass lookup indexes every
+// resolve pass needs and returns the matching teardown (which also
+// drops the lazily-built LSP index). Factored so entry points that
+// run several passes under one lock — the per-save ResolveFile +
+// ResolveIncomingForFile pair — build them once instead of once per
+// pass.
+func (r *Resolver) buildPassIndexes() (clear func()) {
+	r.buildDirIndexes()
+	r.buildDepModuleIndex()
+	r.buildProvidesForIndex()
+	r.buildReachabilityIndex()
+	return func() {
+		r.clearDirIndexes()
+		r.clearDepModuleIndex()
+		r.clearProvidesForIndex()
+		r.clearReachabilityIndex()
+		r.clearLSPIndex()
+	}
+}
+
 // ResolveFile resolves unresolved edges originating from a specific file.
 func (r *Resolver) ResolveFile(filePath string) *ResolveStats {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	r.buildDirIndexes()
-	defer r.clearDirIndexes()
-	r.buildDepModuleIndex()
-	defer r.clearDepModuleIndex()
-	r.buildProvidesForIndex()
-	defer r.clearProvidesForIndex()
-	r.buildReachabilityIndex()
-	defer r.clearReachabilityIndex()
-	defer r.clearLSPIndex()
+	clear := r.buildPassIndexes()
+	defer clear()
 
 	stats := &ResolveStats{}
+	r.resolveFileLocked(filePath, stats)
+	return stats
+}
 
+// ResolveFileAndIncoming runs the forward (this file's outgoing
+// references) and reverse (other files' references to symbols defined
+// here) passes under one lock with one build of the per-pass indexes.
+// The per-save hot path calls this instead of ResolveFile +
+// ResolveIncomingForFile back-to-back, which built and tore down the
+// same four indexes twice per save.
+func (r *Resolver) ResolveFileAndIncoming(filePath string) *ResolveStats {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	clear := r.buildPassIndexes()
+	defer clear()
+
+	stats := &ResolveStats{}
+	r.resolveFileLocked(filePath, stats)
+	r.resolveIncomingLocked(filePath, stats)
+	return stats
+}
+
+// resolveFileLocked is the forward-pass core. Caller holds r.mu and
+// has built the per-pass indexes.
+func (r *Resolver) resolveFileLocked(filePath string, stats *ResolveStats) {
 	// Get all nodes in the file, then check their outgoing edges.
 	// Single-threaded path — collect mutations into a batch and flush
 	// in one ReindexEdges call after the file's edges are walked, so a
@@ -839,8 +877,6 @@ func (r *Resolver) ResolveFile(filePath string) *ResolveStats {
 	r.bindGenericParamRefs()
 	r.attributeGoBuiltins()
 	r.attributeGoExternalCalls()
-
-	return stats
 }
 
 // ResolveIncomingForFile is the reverse of ResolveFile: instead of
@@ -859,15 +895,8 @@ func (r *Resolver) ResolveIncomingForFile(filePath string) *ResolveStats {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	r.buildDirIndexes()
-	defer r.clearDirIndexes()
-	r.buildDepModuleIndex()
-	defer r.clearDepModuleIndex()
-	r.buildProvidesForIndex()
-	defer r.clearProvidesForIndex()
-	r.buildReachabilityIndex()
-	defer r.clearReachabilityIndex()
-	defer r.clearLSPIndex()
+	clear := r.buildPassIndexes()
+	defer clear()
 
 	stats := &ResolveStats{}
 	r.resolveIncomingLocked(filePath, stats)

--- a/internal/serverstack/shared_server.go
+++ b/internal/serverstack/shared_server.go
@@ -432,6 +432,10 @@ func NewSharedServer(cfg SharedServerConfig) (*SharedServer, error) {
 	overlays := daemon.NewOverlayManager(daemon.OverlayIdleTTLFromEnv(0))
 	srv.SetOverlayManager(overlays)
 	s.Overlays = overlays
+	stopOverlayJanitor := overlays.StartJanitor(0, func(dropped int) {
+		logger.Info("overlay janitor: swept idle sessions", zap.Int("dropped", dropped))
+	})
+	s.cleanup = append(s.cleanup, stopOverlayJanitor)
 
 	if semMgr := idx.SemanticManager(); semMgr != nil {
 		srv.SetSemanticManager(semMgr)


### PR DESCRIPTION
## Summary

fixed bugs:
- patchGraph telemetry scoped per-file — new Watcher.countFileEdges (batched out/in edge lookups, intra-file dedup) replaces the global EdgeCount delta
- Overlay janitor actually starts — OverlayManager.StartJanitor (TTL/4 tick, idempotent stop, no-op when TTL disabled), wired into NewSharedServer's cleanup chain
- edges_by_kind index in the sqlite schema — EdgesByKind claimed "indexed SELECT" but was a full 650k-row scan; IF NOT EXISTS doubles as migration on next daemon start
- git-watcher reconcile single-flight — mid-flight ref events coalesce into exactly one follow-up that diffs the advanced lastSHA against current HEAD; no more overlapping 1.9h reconciles from the same stale base
- Resolver pass indexes built once per save — buildPassIndexes factored, new ResolveFileAndIncoming runs forward+reverse passes under one lock/one index build; the save hot path previously built all four whole-graph indexes twice per save