### PR TITLE
feat(temporal): detect Go in-workflow query/signal/update handler declarations

### DIFF
--- a/internal/indexer/temporal_e2e_test.go
+++ b/internal/indexer/temporal_e2e_test.go
@@ -133,3 +133,37 @@ func setup(w Worker) {
 	assert.Equal(t, child.ID, stubCall.To)
 	assert.Equal(t, "workflow", stubCall.Meta["temporal_kind"])
 }
+
+// TestTemporalE2E_GoQueryHandler exercises in-workflow handler detection:
+// a workflow.SetQueryHandler call must surface as a via=temporal.handler
+// edge from the enclosing workflow carrying its kind + name.
+func TestTemporalE2E_GoQueryHandler(t *testing.T) {
+	dir := t.TempDir()
+
+	writeFile(t, filepath.Join(dir, "workflow.go"), `package wf
+
+import "go.temporal.io/sdk/workflow"
+
+func StatusWorkflow(ctx workflow.Context) error {
+	workflow.SetQueryHandler(ctx, "status", func() (string, error) { return "ok", nil })
+	return nil
+}
+`)
+
+	g := graph.New()
+	idx := newTestIndexer(g)
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+
+	wf := g.FindNodesByName("StatusWorkflow")[0]
+	var handler *graph.Edge
+	for _, e := range g.GetOutEdges(wf.ID) {
+		if e != nil && e.Meta != nil && e.Meta["via"] == "temporal.handler" {
+			handler = e
+			break
+		}
+	}
+	require.NotNil(t, handler, "workflow must have an outbound temporal.handler edge")
+	assert.Equal(t, "query", handler.Meta["temporal_kind"])
+	assert.Equal(t, "status", handler.Meta["temporal_name"])
+}

--- a/internal/parser/languages/go_temporal_test.go
+++ b/internal/parser/languages/go_temporal_test.go
@@ -200,3 +200,113 @@ func setup(w Worker) {
 	require.Len(t, stubs, 1)
 	require.Len(t, registers, 2)
 }
+
+// --- In-workflow handler declarations (query / signal / update) -----
+//
+// These mirror the Java SDK's @QueryMethod / @SignalMethod /
+// @UpdateMethod annotations: from inside a workflow body the Go SDK
+// declares the named query / signal / update channels the workflow
+// serves. We surface each as a `via=temporal.handler` EdgeCalls edge
+// carrying temporal_kind + temporal_name so the graph records, per
+// workflow, the named handlers it exposes — symmetric with the Java
+// side's per-method annotation edges.
+
+func TestGoTemporal_SetQueryHandler(t *testing.T) {
+	fix := runGoExtract(t, `package wf
+
+import "go.temporal.io/sdk/workflow"
+
+func OrderWorkflow(ctx workflow.Context) error {
+	workflow.SetQueryHandler(ctx, "status", func() (string, error) { return "ok", nil })
+	return nil
+}
+`)
+	edges := temporalEdgesByVia(fix, "temporal.handler")
+	require.Len(t, edges, 1)
+	e := edges[0]
+	assert.Equal(t, "query", e.Meta["temporal_kind"])
+	assert.Equal(t, "status", e.Meta["temporal_name"])
+	assert.Equal(t, "pkg/foo.go::OrderWorkflow", e.From,
+		"handler edge must originate from the enclosing workflow function")
+}
+
+func TestGoTemporal_GetSignalChannel(t *testing.T) {
+	fix := runGoExtract(t, `package wf
+
+import "go.temporal.io/sdk/workflow"
+
+func OrderWorkflow(ctx workflow.Context) error {
+	ch := workflow.GetSignalChannel(ctx, "cancel")
+	_ = ch
+	return nil
+}
+`)
+	edges := temporalEdgesByVia(fix, "temporal.handler")
+	require.Len(t, edges, 1)
+	assert.Equal(t, "signal", edges[0].Meta["temporal_kind"])
+	assert.Equal(t, "cancel", edges[0].Meta["temporal_name"])
+}
+
+func TestGoTemporal_SetUpdateHandler(t *testing.T) {
+	fix := runGoExtract(t, `package wf
+
+import "go.temporal.io/sdk/workflow"
+
+func OrderWorkflow(ctx workflow.Context) error {
+	workflow.SetUpdateHandler(ctx, "retry", func() error { return nil })
+	return nil
+}
+`)
+	edges := temporalEdgesByVia(fix, "temporal.handler")
+	require.Len(t, edges, 1)
+	assert.Equal(t, "update", edges[0].Meta["temporal_kind"])
+	assert.Equal(t, "retry", edges[0].Meta["temporal_name"])
+}
+
+func TestGoTemporal_SetUpdateHandlerWithOptions(t *testing.T) {
+	fix := runGoExtract(t, `package wf
+
+import "go.temporal.io/sdk/workflow"
+
+func OrderWorkflow(ctx workflow.Context) error {
+	workflow.SetUpdateHandlerWithOptions(ctx, "retry", func() error { return nil }, workflow.UpdateHandlerOptions{})
+	return nil
+}
+`)
+	edges := temporalEdgesByVia(fix, "temporal.handler")
+	require.Len(t, edges, 1)
+	assert.Equal(t, "update", edges[0].Meta["temporal_kind"])
+	assert.Equal(t, "retry", edges[0].Meta["temporal_name"])
+}
+
+func TestGoTemporal_HandlerNonLiteralNameUndetected(t *testing.T) {
+	// Query / signal / update names are matched by string at runtime;
+	// a non-literal name (variable / selector) can't be pinned here, so
+	// no handler edge is emitted — high-precision, no guessing.
+	fix := runGoExtract(t, `package wf
+
+import "go.temporal.io/sdk/workflow"
+
+func OrderWorkflow(ctx workflow.Context, q string) error {
+	workflow.SetQueryHandler(ctx, q, func() (string, error) { return "ok", nil })
+	return nil
+}
+`)
+	assert.Empty(t, temporalEdgesByVia(fix, "temporal.handler"),
+		"non-literal handler name must not be detected")
+}
+
+func TestGoTemporal_HandlerAliasedImportNotDetected(t *testing.T) {
+	// Consistent with the dispatch detector: only the canonical
+	// "workflow" receiver alias is recognised.
+	fix := runGoExtract(t, `package wf
+
+import wf "go.temporal.io/sdk/workflow"
+
+func OrderWorkflow(ctx wf.Context) error {
+	wf.SetQueryHandler(ctx, "status", func() (string, error) { return "ok", nil })
+	return nil
+}
+`)
+	assert.Empty(t, temporalEdgesByVia(fix, "temporal.handler"))
+}

--- a/internal/parser/languages/go_temporal_test.go
+++ b/internal/parser/languages/go_temporal_test.go
@@ -279,6 +279,39 @@ func OrderWorkflow(ctx workflow.Context) error {
 	assert.Equal(t, "retry", edges[0].Meta["temporal_name"])
 }
 
+func TestGoTemporal_SetQueryHandlerWithOptions(t *testing.T) {
+	fix := runGoExtract(t, `package wf
+
+import "go.temporal.io/sdk/workflow"
+
+func OrderWorkflow(ctx workflow.Context) error {
+	workflow.SetQueryHandlerWithOptions(ctx, "status", func() (string, error) { return "ok", nil }, workflow.QueryHandlerOptions{})
+	return nil
+}
+`)
+	edges := temporalEdgesByVia(fix, "temporal.handler")
+	require.Len(t, edges, 1)
+	assert.Equal(t, "query", edges[0].Meta["temporal_kind"])
+	assert.Equal(t, "status", edges[0].Meta["temporal_name"])
+}
+
+func TestGoTemporal_GetSignalChannelWithOptions(t *testing.T) {
+	fix := runGoExtract(t, `package wf
+
+import "go.temporal.io/sdk/workflow"
+
+func OrderWorkflow(ctx workflow.Context) error {
+	ch := workflow.GetSignalChannelWithOptions(ctx, "cancel", workflow.SignalChannelOptions{})
+	_ = ch
+	return nil
+}
+`)
+	edges := temporalEdgesByVia(fix, "temporal.handler")
+	require.Len(t, edges, 1)
+	assert.Equal(t, "signal", edges[0].Meta["temporal_kind"])
+	assert.Equal(t, "cancel", edges[0].Meta["temporal_name"])
+}
+
 func TestGoTemporal_HandlerNonLiteralNameUndetected(t *testing.T) {
 	// Query / signal / update names are matched by string at runtime;
 	// a non-literal name (variable / selector) can't be pinned here, so

--- a/internal/parser/languages/golang.go
+++ b/internal/parser/languages/golang.go
@@ -201,6 +201,12 @@ type goDeferredCall struct {
 	tempKind  string
 	tempName  string
 	tempLocal bool
+	// tempHandlerKind is "query" / "signal" / "update" when this call
+	// is a `workflow.SetQueryHandler` / `GetSignalChannel` /
+	// `SetUpdateHandler` in-workflow handler declaration; tempName then
+	// carries the handler's string name. `via=temporal.handler` meta is
+	// stamped on the emitted edge in the call post-pass below.
+	tempHandlerKind string
 }
 
 type goDeferredTypeRef struct {
@@ -344,6 +350,13 @@ func (e *GoExtractor) Extract(filePath string, src []byte) (*parser.ExtractionRe
 				// `w.RegisterActivity(F)` etc.
 				if name := goTemporalRegisterName(expr.Node, src); name != "" {
 					dc.tempKind = "register_" + kind
+					dc.tempName = name
+				}
+			} else if hkind, ok := goTemporalHandlerKind(receiver, method); ok {
+				// Temporal in-workflow handler declaration:
+				// `workflow.SetQueryHandler(ctx, "name", fn)` etc.
+				if name := goTemporalHandlerName(expr.Node, src); name != "" {
+					dc.tempHandlerKind = hkind
 					dc.tempName = name
 				}
 			}
@@ -668,6 +681,7 @@ func (e *GoExtractor) Extract(filePath string, src []byte) (*parser.ExtractionRe
 			}
 			applyGoGRPCRegisterMeta(edge, c, src, tenv)
 			applyGoTemporalRegisterMeta(edge, c)
+			applyGoTemporalHandlerMeta(edge, c)
 			result.Edges = append(result.Edges, edge)
 			emitGoSpawnEdge(c, callerID, target, filePath, result)
 			continue
@@ -680,6 +694,7 @@ func (e *GoExtractor) Extract(filePath string, src []byte) (*parser.ExtractionRe
 			}
 			applyGoGRPCRegisterMeta(edge, c, src, tenv)
 			applyGoTemporalRegisterMeta(edge, c)
+			applyGoTemporalHandlerMeta(edge, c)
 			result.Edges = append(result.Edges, edge)
 			emitGoSpawnEdge(c, callerID, target, filePath, result)
 			continue

--- a/internal/parser/languages/golang_temporal.go
+++ b/internal/parser/languages/golang_temporal.go
@@ -79,6 +79,68 @@ func goTemporalRegisterKind(method string) (kind string, plural bool, ok bool) {
 	return "", false, false
 }
 
+// goTemporalHandlerKind reports whether (receiver, method) names one of
+// the Temporal in-workflow handler-declaration helpers and, if so,
+// returns the canonical kind ("query" / "signal" / "update").
+//
+//	workflow.SetQueryHandler(ctx, "name", fn)
+//	workflow.GetSignalChannel(ctx, "name")
+//	workflow.SetUpdateHandler(ctx, "name", fn)
+//	workflow.SetUpdateHandlerWithOptions(ctx, "name", fn, opts)
+//
+// These mirror the Java SDK's `@QueryMethod` / `@SignalMethod` /
+// `@UpdateMethod` annotations: a workflow declares, from inside its
+// body, the named query / signal / update channels it serves. As with
+// the dispatch helpers we require the receiver text to be exactly the
+// canonical "workflow" alias.
+func goTemporalHandlerKind(receiver, method string) (kind string, ok bool) {
+	if receiver != "workflow" {
+		return "", false
+	}
+	switch method {
+	case "SetQueryHandler":
+		return "query", true
+	case "GetSignalChannel":
+		return "signal", true
+	case "SetUpdateHandler", "SetUpdateHandlerWithOptions":
+		return "update", true
+	}
+	return "", false
+}
+
+// goTemporalHandlerName extracts the query / signal / update name from a
+// handler-declaration call — the second positional argument (after the
+// workflow.Context). Unlike dispatch names we accept ONLY a string
+// literal: handler names are matched by string at runtime, so a
+// non-literal (variable / selector) can't be pinned to a name here and
+// is left undetected, keeping the detector high-precision. Returns ""
+// when the second argument is missing or is not a string literal.
+func goTemporalHandlerName(callNode *sitter.Node, src []byte) string {
+	if callNode == nil || callNode.Type() != "call_expression" {
+		return ""
+	}
+	args := callNode.ChildByFieldName("arguments")
+	if args == nil {
+		return ""
+	}
+	count := 0
+	for i := 0; i < int(args.NamedChildCount()); i++ {
+		c := args.NamedChild(i)
+		if c == nil {
+			continue
+		}
+		count++
+		if count == 2 {
+			switch c.Type() {
+			case "interpreted_string_literal", "raw_string_literal":
+				return goTemporalNameFromExpr(c, src)
+			}
+			return ""
+		}
+	}
+	return ""
+}
+
 // goTemporalDispatchName extracts the activity (or child-workflow)
 // name from a `workflow.ExecuteActivity(ctx, X, args...)` call. X is
 // the second positional argument and is either:
@@ -165,6 +227,28 @@ func applyGoTemporalRegisterMeta(edge *graph.Edge, c goDeferredCall) {
 	}
 	edge.Meta["via"] = "temporal.register"
 	edge.Meta["temporal_kind"] = kind
+	edge.Meta["temporal_name"] = c.tempName
+}
+
+// applyGoTemporalHandlerMeta stamps `via=temporal.handler` plus
+// `temporal_kind` (query / signal / update) and `temporal_name` (the
+// handler's string name) onto the EdgeCalls edge derived from a
+// `workflow.SetQueryHandler` / `GetSignalChannel` / `SetUpdateHandler`
+// call. No-op when c.tempHandlerKind / c.tempName are unset.
+//
+// The edge originates from the enclosing workflow function, so the
+// graph records — per workflow — the named query / signal / update
+// handlers it exposes, symmetric with the Java side's per-method
+// `@QueryMethod` / `@SignalMethod` / `@UpdateMethod` annotation edges.
+func applyGoTemporalHandlerMeta(edge *graph.Edge, c goDeferredCall) {
+	if edge == nil || c.tempHandlerKind == "" || c.tempName == "" {
+		return
+	}
+	if edge.Meta == nil {
+		edge.Meta = map[string]any{}
+	}
+	edge.Meta["via"] = "temporal.handler"
+	edge.Meta["temporal_kind"] = c.tempHandlerKind
 	edge.Meta["temporal_name"] = c.tempName
 }
 

--- a/internal/parser/languages/golang_temporal.go
+++ b/internal/parser/languages/golang_temporal.go
@@ -84,7 +84,9 @@ func goTemporalRegisterKind(method string) (kind string, plural bool, ok bool) {
 // returns the canonical kind ("query" / "signal" / "update").
 //
 //	workflow.SetQueryHandler(ctx, "name", fn)
+//	workflow.SetQueryHandlerWithOptions(ctx, "name", fn, opts)
 //	workflow.GetSignalChannel(ctx, "name")
+//	workflow.GetSignalChannelWithOptions(ctx, "name", opts)
 //	workflow.SetUpdateHandler(ctx, "name", fn)
 //	workflow.SetUpdateHandlerWithOptions(ctx, "name", fn, opts)
 //
@@ -98,9 +100,9 @@ func goTemporalHandlerKind(receiver, method string) (kind string, ok bool) {
 		return "", false
 	}
 	switch method {
-	case "SetQueryHandler":
+	case "SetQueryHandler", "SetQueryHandlerWithOptions":
 		return "query", true
-	case "GetSignalChannel":
+	case "GetSignalChannel", "GetSignalChannelWithOptions":
 		return "signal", true
 	case "SetUpdateHandler", "SetUpdateHandlerWithOptions":
 		return "update", true


### PR DESCRIPTION
## Summary

Surface Go-side Temporal **in-workflow handler declarations** (query / signal / update) as graph edges, symmetric with the Java side's existing `@QueryMethod` / `@SignalMethod` / `@UpdateMethod` annotation edges.

This is one half of a split from #75 (the other half — env-default dispatch names — is in a separate PR so each can be reviewed independently).

## Changes

- Recognises `workflow.SetQueryHandler` / `workflow.GetSignalChannel` / `workflow.SetUpdateHandler[WithOptions]` and emits a `via=temporal.handler` `EdgeCalls` edge from the enclosing workflow function, carrying `temporal_kind` (`query` / `signal` / `update`) + `temporal_name` (the handler's string name).
- Mirrors the existing `via=temporal.register` emission (`applyGoTemporalRegisterMeta`) exactly — same edge shape, same stamping site — so the graph gains a queryable, per-workflow record of the named handlers a Go workflow exposes.
- High-precision, consistent with the existing dispatch detector: only the canonical `workflow` receiver alias matches, and the handler name must be a string literal (query/signal/update names are matched by string at runtime, so a non-literal can't be pinned).

## Testing

- [x] All tests pass (`go test -race ./...`) for the touched packages (`internal/parser/languages`, `internal/indexer`). The only failures in my environment are the pre-existing `internal/indexer` **watcher** tests failing with `inotify ... too many open files` (a local WSL fd-limit issue, unrelated — no watcher files touched).
- [x] New tests added — parser-level (`go_temporal_test.go`: query/signal/update detection + negative cases for non-literal name and aliased import) and end-to-end (`temporal_e2e_test.go`).
- [ ] Benchmarks — n/a, the detector is a per-call AST check on the existing walk.

## Checklist

- [x] Code follows existing patterns in the codebase (mirrors `applyGoTemporalRegisterMeta`, the canonical-alias-only stance of the dispatch detector)
- [x] No unnecessary abstractions added
- [x] Language extractor includes `Meta["methods"]` for interfaces (if applicable) — n/a
- [x] Methods have `EdgeMemberOf` edges to their containing type (if applicable) — n/a

## Notes

The natural consumer of this data is the cross-language Java→Go match (a Java `@QueryMethod(name="status")` consumer ↔ this Go `SetQueryHandler(ctx, "status", …)` provider), which is proposed for design discussion in #77 — out of scope here; this PR only adds the Go-side provider edges.
