### PR TITLE
fix(lsp): Windows-correct file:// URI conversion (jdtls no-op on Windows)

### DIFF
--- a/internal/lspuri/lspuri.go
+++ b/internal/lspuri/lspuri.go
@@ -1,0 +1,121 @@
+// Package lspuri converts between filesystem paths and file:// URIs
+// correctly on both POSIX and Windows.
+//
+// PURPOSE — the naive `"file://" + path` concatenation is correct on
+// POSIX (an absolute path already starts with `/`, yielding the required
+// three slashes) but BROKEN on Windows: `C:\repo\Main.java` becomes
+// `file://C:\repo\Main.java` — the drive letter lands in the authority,
+// backslashes are not URI separators, and the round-trip back to a path
+// drops the drive. The net effect on Windows is a silent no-op: an LSP
+// server (jdtls, etc.) cannot match the document we open, and the URIs it
+// returns fail to map back to a repo path, so every definition/reference/
+// implementation result is discarded and no edge is ever enriched.
+//
+// RATIONALE — centralise the conversion so didOpen, position requests,
+// and result fold-back all agree on URI shape, and so the Windows-specific
+// drive-letter / separator handling lives (and is tested) in exactly one
+// place rather than being re-derived at each call site.
+//
+// KEYWORDS — file-uri, windows, drive-letter, lsp, path-conversion
+package lspuri
+
+import (
+	"net/url"
+	"path/filepath"
+	"strings"
+)
+
+// PathToURI converts a filesystem path to a file:// URI.
+//
+//	POSIX:   /repo/Main.java   -> file:///repo/Main.java
+//	Windows: C:\repo\Main.java -> file:///C:/repo/Main.java
+//
+// Relative paths are made absolute first. Returns "" for an empty path.
+func PathToURI(path string) string {
+	if path == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		abs = path
+	}
+	return slashAbsToURI(filepath.ToSlash(abs))
+}
+
+// URIToAbsPath converts a file:// URI to an OS-native absolute path.
+//
+//	file:///C:/repo/Main.java -> C:\repo\Main.java (Windows) / C:/repo/Main.java (POSIX runtime)
+//	file:///repo/Main.java    -> /repo/Main.java
+//
+// Returns "" for non-file or unparseable URIs. URL-encoded octets
+// (e.g. %20) are decoded.
+func URIToAbsPath(uri string) string {
+	slash := uriToSlashAbs(uri)
+	if slash == "" {
+		return ""
+	}
+	return filepath.FromSlash(slash)
+}
+
+// URIToRepoRel converts a file:// URI to a forward-slash path relative to
+// repoRoot, or "" when the URI is outside repoRoot or unparseable.
+//
+// Uses filepath.Rel (case-insensitive on Windows) rather than a string
+// prefix so drive-letter casing and separator differences never cause a
+// false miss — the failure mode that made LSP fold-back silently drop
+// every result on Windows.
+func URIToRepoRel(uri, repoRoot string) string {
+	abs := URIToAbsPath(uri)
+	if abs == "" || repoRoot == "" {
+		return ""
+	}
+	rel, err := filepath.Rel(repoRoot, abs)
+	if err != nil {
+		return ""
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "" // outside the repo
+	}
+	return filepath.ToSlash(rel)
+}
+
+// slashAbsToURI builds a file URI from a forward-slash absolute path.
+// Pure (no filepath / OS dependency) so it is deterministically testable
+// for both POSIX ("/repo/x") and Windows-drive ("C:/repo/x") shapes.
+func slashAbsToURI(slashAbs string) string {
+	if slashAbs == "" {
+		return ""
+	}
+	if !strings.HasPrefix(slashAbs, "/") {
+		slashAbs = "/" + slashAbs // C:/repo -> /C:/repo so the URI gets file:///C:/repo
+	}
+	return (&url.URL{Scheme: "file", Path: slashAbs}).String()
+}
+
+// uriToSlashAbs extracts the forward-slash absolute path from a file URI.
+// Pure; testable for both shapes. Strips the spurious leading slash that
+// precedes a Windows drive letter (/C:/.. -> C:/..).
+func uriToSlashAbs(uri string) string {
+	if uri == "" {
+		return ""
+	}
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return ""
+	}
+	if parsed.Scheme != "" && parsed.Scheme != "file" {
+		return ""
+	}
+	p := parsed.Path
+	if p == "" {
+		p = parsed.Opaque // tolerate `file:relative` shapes
+	}
+	if len(p) >= 3 && p[0] == '/' && isDriveLetter(p[1]) && p[2] == ':' {
+		p = p[1:] // /C:/repo -> C:/repo
+	}
+	return p
+}
+
+func isDriveLetter(c byte) bool {
+	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+}

--- a/internal/lspuri/lspuri_test.go
+++ b/internal/lspuri/lspuri_test.go
@@ -1,0 +1,84 @@
+package lspuri
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// The drive-letter / separator handling is the OS-independent core of the
+// Windows bug, exercised here via the pure helpers so these assertions run
+// (and would have caught the bug) on the Linux/macOS CI runners — Windows
+// only builds in CI, it does not run the test suite.
+
+func TestSlashAbsToURI(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"/repo/Main.java", "file:///repo/Main.java"},          // POSIX
+		{"C:/repo/Main.java", "file:///C:/repo/Main.java"},     // Windows drive (forward-slashed)
+		{"/repo/a b.java", "file:///repo/a%20b.java"},          // space is percent-encoded
+		{"D:/proj/src/X.java", "file:///D:/proj/src/X.java"},   // another drive
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := slashAbsToURI(c.in); got != c.want {
+			t.Errorf("slashAbsToURI(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestURIToSlashAbs(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"file:///repo/Main.java", "/repo/Main.java"},            // POSIX
+		{"file:///C:/repo/Main.java", "C:/repo/Main.java"},       // Windows: strip leading slash before drive
+		{"file:///c:/repo/Main.java", "c:/repo/Main.java"},       // lowercase drive
+		{"file:///repo/a%20b.java", "/repo/a b.java"},            // percent-decoded
+		{"http://example.com/x", ""},                             // non-file scheme rejected
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := uriToSlashAbs(c.in); got != c.want {
+			t.Errorf("uriToSlashAbs(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestRoundTrip_Windows proves the exact failure that broke jdtls on
+// Windows is now fixed: a Windows file URI maps back to a repo-relative
+// path. Asserts the OS-independent slash form so it runs on Linux CI.
+func TestURIToSlashAbs_WindowsDriveRoundTrip(t *testing.T) {
+	uri := slashAbsToURI("C:/repo/pkg/Service.java")
+	if uri != "file:///C:/repo/pkg/Service.java" {
+		t.Fatalf("built URI = %q", uri)
+	}
+	back := uriToSlashAbs(uri)
+	if back != "C:/repo/pkg/Service.java" {
+		t.Fatalf("round-trip = %q, want C:/repo/pkg/Service.java", back)
+	}
+}
+
+// TestPathToURI_RoundTrip_NativeOS exercises the public funcs end to end
+// on whatever OS the test runs, guarding the POSIX path from regression
+// (and the full Windows path when run on Windows).
+func TestPathToURI_RoundTrip_NativeOS(t *testing.T) {
+	abs, err := filepath.Abs(filepath.Join("repo", "pkg", "File.java"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	uri := PathToURI(abs)
+	got := URIToAbsPath(uri)
+	if got != abs {
+		t.Errorf("round-trip on %s: PathToURI(%q) -> %q -> %q", runtime.GOOS, abs, uri, got)
+	}
+}
+
+func TestURIToRepoRel(t *testing.T) {
+	repo, _ := filepath.Abs("myrepo")
+	inside, _ := filepath.Abs(filepath.Join("myrepo", "src", "Main.java"))
+	if got := URIToRepoRel(PathToURI(inside), repo); got != "src/Main.java" {
+		t.Errorf("URIToRepoRel inside = %q, want src/Main.java", got)
+	}
+	outside, _ := filepath.Abs(filepath.Join("other", "X.java"))
+	if got := URIToRepoRel(PathToURI(outside), repo); got != "" {
+		t.Errorf("URIToRepoRel outside = %q, want \"\"", got)
+	}
+}

--- a/internal/mcp/diagnostics.go
+++ b/internal/mcp/diagnostics.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"go.uber.org/zap"
 
+	"github.com/zzet/gortex/internal/lspuri"
 	"github.com/zzet/gortex/internal/semantic/lsp"
 )
 
@@ -257,15 +258,10 @@ func hashDiagnostics(diags []lsp.Diagnostic) string {
 }
 
 // pathToFileURI converts an absolute filesystem path to a file:// URI.
-// Centralised so push payloads match the URI shape MCP clients expect.
+// Centralised (via internal/lspuri) so push payloads match the URI shape
+// MCP clients expect — Windows-correct (drive letter + separators).
 func pathToFileURI(absPath string) string {
-	if absPath == "" {
-		return ""
-	}
-	if absPath[0] == '/' {
-		return "file://" + absPath
-	}
-	return "file:///" + absPath
+	return lspuri.PathToURI(absPath)
 }
 
 // registerDiagnosticsTools wires the subscribe/unsubscribe MCP tools.

--- a/internal/mcp/tools_simulate.go
+++ b/internal/mcp/tools_simulate.go
@@ -45,6 +45,7 @@ import (
 	"github.com/zzet/gortex/internal/analysis"
 	"github.com/zzet/gortex/internal/daemon"
 	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/lspuri"
 	"github.com/zzet/gortex/internal/query"
 	"github.com/zzet/gortex/internal/semantic/lsp"
 )
@@ -823,13 +824,13 @@ func normaliseEditURI(raw string) string {
 	if raw == "" {
 		return ""
 	}
-	if stripped, ok := strings.CutPrefix(raw, "file://"); ok {
-		// Drop the optional `localhost` host part. uriToAbsPath
-		// handles malformed input gracefully so any failure falls
-		// back to the raw string.
-		stripped = strings.TrimPrefix(stripped, "localhost")
-		if stripped != "" {
-			return stripped
+	if strings.HasPrefix(raw, "file://") {
+		// lspuri.URIToAbsPath parses the URI: drops the optional host
+		// (e.g. localhost), decodes %xx, and fixes the Windows
+		// drive-letter / separator shape. Any parse failure falls back
+		// to the raw string.
+		if p := lspuri.URIToAbsPath(raw); p != "" {
+			return p
 		}
 	}
 	return raw

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -3,7 +3,6 @@ package lsp
 import (
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,6 +13,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/lspuri"
 	"github.com/zzet/gortex/internal/semantic"
 )
 
@@ -747,14 +747,7 @@ func (p *Provider) DiagnosticsSnapshot() map[string][]Diagnostic {
 // uriToAbsPath converts a file:// URI to an absolute filesystem path.
 // Returns "" for non-file URIs or malformed input.
 func uriToAbsPath(uri string) string {
-	parsed, err := url.Parse(uri)
-	if err != nil {
-		return ""
-	}
-	if parsed.Scheme != "" && parsed.Scheme != "file" {
-		return ""
-	}
-	return parsed.Path
+	return lspuri.URIToAbsPath(uri)
 }
 
 // openDocument sends textDocument/didOpen for a file. Tracks version
@@ -1459,10 +1452,9 @@ func (p *Provider) subtypes(item TypeHierarchyItem) ([]TypeHierarchyItem, error)
 	return items, nil
 }
 
-// pathToURI converts a file path to a file:// URI.
+// pathToURI converts a file path to a file:// URI (Windows-correct).
 func pathToURI(path string) string {
-	absPath, _ := filepath.Abs(path)
-	return "file://" + absPath
+	return lspuri.PathToURI(path)
 }
 
 // buildWorkspaceFolders returns the LSP workspaceFolders list — the
@@ -1493,21 +1485,9 @@ func buildWorkspaceFolders(primary string, additional []string) []WorkspaceFolde
 	return folders
 }
 
-// uriToPath converts a file:// URI to a repo-relative path.
+// uriToPath converts a file:// URI to a repo-relative path (Windows-correct).
 func uriToPath(uri, repoRoot string) string {
-	parsed, err := url.Parse(uri)
-	if err != nil {
-		return ""
-	}
-	absPath := parsed.Path
-	if !strings.HasPrefix(absPath, repoRoot) {
-		return ""
-	}
-	rel, err := filepath.Rel(repoRoot, absPath)
-	if err != nil {
-		return ""
-	}
-	return filepath.ToSlash(rel)
+	return lspuri.URIToRepoRel(uri, repoRoot)
 }
 
 // identifierColumn returns the 0-based column of the first

--- a/internal/semantic/lsp/resolver_helper.go
+++ b/internal/semantic/lsp/resolver_helper.go
@@ -2,7 +2,6 @@ package lsp
 
 import (
 	"fmt"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -11,6 +10,8 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/lspuri"
 )
 
 // ResolverHelper adapts one or more *Provider instances for resolve-
@@ -395,11 +396,7 @@ func uriToAbsLocalPath(uri string) string {
 		return ""
 	}
 	if strings.HasPrefix(uri, "file://") {
-		parsed, err := url.Parse(uri)
-		if err != nil {
-			return ""
-		}
-		return parsed.Path
+		return lspuri.URIToAbsPath(uri)
 	}
 	// Some servers (rare) reply with a bare absolute path.
 	if filepath.IsAbs(uri) {


### PR DESCRIPTION
## What

Centralises filesystem-path ↔ `file://` URI conversion in a new leaf package `internal/lspuri` and routes all six previously hand-rolled sites through it, fixing a **Windows-only** bug that made the LSP layer (jdtls etc.) a silent no-op.

## The bug

The naive `"file://" + path` is correct on POSIX — an absolute path already starts with `/`, so `file://` + `/repo/X.java` = `file:///repo/X.java` (the required three slashes). On **Windows** it breaks:

- **Outbound:** `C:\repo\Main.java` → `file://C:\repo\Main.java` — the drive letter lands in the URI *authority* and backslashes aren't URI separators, so the server can't match the document we `didOpen`.
- **Inbound:** the server returns `file:///C:/repo/Main.java`; the old `uriToPath` took `url.Parse(...).Path` = `/C:/repo/Main.java` and did `strings.HasPrefix(absPath, repoRoot)` against `C:\repo` → **always false** → the result is silently dropped.

Net effect on native Windows: jdtls is detected and `initialize` succeeds, but every `didOpen` + `definition`/`references`/`implementation` round-trip no-ops — **zero Java edges get enriched** (`ast_inferred` → `lsp_resolved`), with no error logged. POSIX/macOS were unaffected, so it went unnoticed.

## Fix

New `internal/lspuri`:
- `PathToURI` — `C:\repo\Main.java` → `file:///C:/repo/Main.java`; `/repo/Main.java` → `file:///repo/Main.java` (ToSlash, drive leading-slash, `%xx`-safe via `net/url`).
- `URIToAbsPath` — inverse, strips the spurious leading slash before a drive letter, `FromSlash`, decodes `%xx`.
- `URIToRepoRel` — uses `filepath.Rel` (case-insensitive on Windows) instead of a string prefix, so drive-casing / separators never cause a false miss.

Routed through it (all had the same bug class):
- `internal/semantic/lsp/provider.go` — `pathToURI`, `uriToAbsPath`, `uriToPath`
- `internal/semantic/lsp/resolver_helper.go` — `uriToAbsLocalPath`
- `internal/mcp/diagnostics.go` — `pathToFileURI`
- `internal/mcp/tools_simulate.go` — `normaliseEditURI` (now also decodes `%xx` and drops the host via `url`)

## Tests

`internal/lspuri` unit tests exercise the drive-letter / separator logic via pure helpers, so the Windows behaviour is verified on the **Linux/macOS CI runners** (Windows only builds in CI, it doesn't run the suite). `go build ./...`, `go vet`, `internal/lspuri` and `internal/mcp` suites pass. (Pre-existing unrelated failure `TestPassiveProvider_DialFailsNoFallback` reproduces on `main` without this change — it needs a live LSP server.)

## Follow-up (not in this PR)

If jdtls still under-resolves after this, the next suspects are async readiness (no wait for jdtls workspace-import to finish before querying) and Java-project recognition (no `pom.xml`/`build.gradle` ⇒ no classpath).
