### PR TITLE
docs(temporal): Java EE / Jakarta EE edge-resolver spec + design + plan

### DIFF
--- a/docs/design/06-javaee-synthesizer.md
+++ b/docs/design/06-javaee-synthesizer.md
@@ -1,0 +1,333 @@
+# ТЗ: Java EE / Jakarta EE edge resolvers для графа gortex (объединённый)
+
+> Объединяет: исходный ТЗ `docs/java-ee-edge-resolvers.md` (проблема, корпус, приоритеты,
+> критерии приёмки) + архитектурный дизайн встройки в gortex + правки архитектурного ревью
+> (oracle). Цель — buildable-план без параллельной системы и без уверенно-неверных рёбер.
+
+## 1. Проблема
+
+Статический анализатор (tree-sitter) строит граф по прямым вызовам `a.b()`. В Java EE-монолитах
+компоненты связываются **декларативно** — через аннотации и дескрипторы, а не вызовами. Слепые
+зоны на архитектурных границах:
+
+- JMS: `queueSender.send()` → MDB `onMessage()` — нет ребра
+- EJB: `@EJB`/`@Inject` интерфейса → `@Stateless` impl — нет ребра
+- REST: `@GET @Path("/x")` → метод-handler / клиент — нет ребра
+- SOAP: `@WebService`/`@WebMethod` → endpoint — нет ребра
+- Servlet: `web.xml` / `@WebServlet` → класс; filter-chain — нет рёбер
+- CDI: `@Inject` интерфейса → `@ApplicationScoped` bean — нет ребра
+
+На реальном BSS-монолите (~240K нод) это ≈ **30% потерянных рёбер** на границах. Сегодня gortex
+уже умеет: Spring `@Bean` DI (`di_contracts.go`), JAX-RS/Spring HTTP *как entrypoints* +
+HTTP-контракты (`contracts/http.go`, `schema_enrich_java.go`), JPA `@Entity`→table, MyBatis XML.
+Чего нет: CDI/EJB wiring, JMS sender↔listener, REST route→handler dispatch + клиенты, JAX-WS,
+servlet/filter chains.
+
+## 2. Цель
+
+Дополнить индексер **annotation/descriptor-aware резолверами**, достраивающими рёбра тех же
+типов, что и существующие (`calls`, `implements`, `references`, `provides`, `matches`, `spawns`),
+с честным `origin`/`confidence`. **Реюзать существующие подсистемы gortex** (synthesizer-фреймворк
+и contracts), а не строить параллельную.
+
+## 3. Архитектура встройки в gortex
+
+### 3.1 Двухслойный extract→resolve (устоявшийся паттерн)
+
+- **Extract (Java-экстрактор):** на парсинге клеит аннотации + *placeholder*-рёбра на
+  `unresolved::<token>` с meta. Без резолва. Зеркалит TS-DI (`emitInjectFromDecorator`,
+  `emitProvidersFromObject` в `typescript.go`) и конвенцию `di_token`/`provides_for`.
+- **Resolve (`FrameworkSynthesizer`):** идемпотентный полно-пересчётный проход, приземляющий
+  placeholder'ы на реальные цели.
+
+Интерфейс (`internal/resolver/framework_synth.go:31`):
+```go
+type FrameworkSynthesizer interface {
+    Name() string                  // провенанс-тег: "cdi", "ejb", "jms", ...
+    Synthesize(g graph.Store) int  // сколько рёбер приземлено за прогон
+}
+```
+Регистрация в `defaultFrameworkSynthesizers()` (`framework_synth.go:114`) как
+`synthFunc{name: SynthCDI, fn: ResolveCDIInjection}`; новые имена занести в `Synth*`-const-блок
+(:55-67), чтобы `analyze kind=synthesizers` их атрибутировал. Порядок load-bearing: после
+`InferImplements` (нужны `EdgeImplements`), до `DetectCrossRepoEdges`. Точка вызова уже есть:
+`indexer.go:743` (`RunGlobalGraphPasses`) и `:2491` (inline). **Менять pipeline не нужно.**
+
+Каноническое ребро + провенанс (копия MyBatis, `mybatis_calls.go:110`):
+```go
+e.To = target
+e.Origin = origin                          // OriginASTResolved/Inferred/Speculative
+e.Confidence = conf
+e.ConfidenceLabel = graph.ConfidenceLabelFor(graph.EdgeCalls, conf)
+StampSynthesized(e, SynthCDI)              // Meta["synthesized_by"], Meta["provenance"]
+// идемпотентность: собрать EdgeReindex{Edge, OldTo}, применить g.ReindexEdges(batch)
+```
+
+### 3.2 Владение слоями — КЛЮЧЕВОЕ (правка ревью)
+
+Contract-пасс (`extractDIContracts`→`commitContracts`, `indexer.go:2444`/`860`) и
+synthesizer-пасс (`RunFrameworkSynthesizers`, `indexer.go:2491`/`743`) — **разные стадии с
+разными типами рёбер** (`EdgeMatches` vs `EdgeCalls`). Один `@Inject` нельзя гнать через оба
+(получишь дубль-рёбра — это и есть «параллельная система», которой избегаем).
+
+| Подсистема | Форма | Владелец (пасс) | Тип ребра | In-repo резолв | Cross-repo |
+|---|---|---|---|---|---|
+| **EJB, CDI** | dispatch synthesis | `FrameworkSynthesizer` | `EdgeCalls` | `EdgeImplements`+`EdgeExtends` + producer-индекс | `di::` contract matcher **только** |
+| **JMS** | channel | synthesizer + промежуточная нода | `spawns` через `jms::<dest>` ноду | destination литерал/const | `jms::` matcher |
+| **REST, SOAP** | contract enrichment | **contracts-подсистема** (`contracts/http.go`) | `EdgeMatches` | route↔client по id | `http::`/`soap::` matcher (нативно) |
+| **Servlet/filter-chain** | ordered edges | отдельный проход | `references` + `order` meta | url→class, порядок chain | n/a |
+
+**Итог: EJB/CDI/JMS = synthesizer; REST/SOAP = contract-enrichment (уже почти есть); filter-chain
+= ordered-edge pass.** Общий у них только `StampSynthesized`.
+
+Два кода-факта, ограничивающих дизайн (проверено):
+- **`InferImplements` — только интерфейсы и repo-gated** (`resolver.go:2302,2411`): сверяет
+  method-set'ы только `KindInterface` и `continue`'ит между репозиториями. ⇒ abstract-class бины
+  (`@Inject FooBase`, это `KindType`) нужно резолвить через **`EdgeExtends`**, а структурный CDI
+  **не работает cross-repo** — cross-repo только через `di::` contract-matcher.
+- **`contracts.Matcher.Match` даёт полный декартов продукт** (`matcher.go:81`). Политика «N>1 →
+  none» (§7) может жить **только в synthesizer'е (`EdgeCalls`)**, не в contract-слое. Чтобы
+  бакеты не пухли — фолдить qualifier в id: `di::<token>::<qualifier>`.
+
+### 3.3 Synthetic-ноды
+
+Резолверы создают synthetic-ноды для не-Java-классов; они обогащают `contracts list`,
+`get_callers`, `api_impact`:
+
+| Kind | Пример | Описание |
+|---|---|---|
+| `queue` | `jms::BSSSingleChangePPQueue` | JMS queue/topic (промежуточная нода sender→queue→MDB) |
+| `contract` (http) | `http::GET::/request/changePricePlan` | REST/servlet endpoint |
+| `contract` (ws) | `soap::SubscriberService::changePP` | SOAP endpoint |
+
+### 3.4 Origin / confidence
+
+| Origin (gortex const) | Conf | Когда |
+|---|---|---|
+| `OriginASTResolved` | 0.9 | прямой вызов; **или** binding подтверждён дескриптором (`<servlet-mapping>`, enabled `@Alternative`, `@EJB(beanName)`) |
+| `OriginASTInferred` | 0.7 | аннотация + уникальный impl через `EdgeImplements`/`EdgeExtends`; qualifier-disambiguated |
+| `OriginSpeculative` (hidden, `Meta[MetaSpeculative]=true`) | 0.45 | эвристический destination; multi-candidate без qualifier (если выбрана recall-политика) |
+| `OriginTextMatched` | 0 | существующая эвристика по имени |
+
+Уникальный structural-match даём **0.7** (как MyBatis, `mybatis_calls.go:173`), не инфлейтим до
+0.9 «просто потому что уникален». 0.9 — только для дескриптор-подтверждённых binding'ов.
+
+### 3.5 Производительность (правка ревью)
+
+Synthesizer'ы полно-пересчётны каждый settle (`framework_synth.go:18`). На 240K-монолите:
+- XML парсить в ноды **один раз на extract**, в проходе читать из meta (не пере-парсить файл);
+- producer-индекс **repo-scope'ить** как `di_contracts.go` (`GetRepoNodes`/`GetRepoEdges`,
+  :44/:122) — без этого rebuild индекса по всем Java-нодам каждый settle = обрыв.
+
+## 4. Подсистемы
+
+### 4.1 EJB interface→impl  (P0)
+
+**Сигналы.** Интерфейс с `@Local`/`@Remote`; impl `@Stateless`/`@Stateful`/`@Singleton`
+`implements` его; инъекция `@EJB`/`@Inject` интерфейса + вызов `ref.method()`.
+
+**Резолв (synthesizer `ejb`).** Индекс `интерфейс → []impl` (по `EdgeImplements` + EJB-аннотации
+класса). На `@EJB`/`@Inject` интерфейса:
+- 1 impl → `EdgeCalls` точка→impl.method, `OriginASTInferred` 0.85;
+- N impl → §7 (политика неоднозначности);
+- `@EJB(beanName="X")` / `<ejb-link>` → точный маппинг, 0.9;
+- `@LocalBean` (no-interface) → пропустить (обычный класс);
+- `@Remote` — пометить (может быть вне графа, cross-JVM).
+
+### 4.2 JMS producer→consumer  (P0)
+
+**Сигналы.** Listener: `@MessageDriven` + `@ActivationConfigProperty(destination=X)` /
+`MessageListener.onMessage` / Spring `@JmsListener`. Sender: `jmsContext.createProducer().send(
+dest, …)`, `jmsTemplate.convertAndSend("q", …)`. Destination: `@Resource(lookup="jms/Q")`,
+`@JMSDestinationDefinition`, `@ActivationConfigProperty`, литерал/const (reuse const-deref).
+
+**Резолв (synthesizer `jms`).**
+1. На extract: для `@MessageDriven` извлечь `destination`+`destinationType`, нормализовать JNDI.
+2. Synthetic-нода `jms::<destination>` (kind=`queue`/`topic` по `destinationType`).
+3. `spawns` от `jms::<dest>` → `MDB.onMessage()`.
+4. Для каждого `send()` с destination-ссылкой X → `calls` от метода-отправителя → `jms::<dest>`.
+5. Итог двух-хоп: `Sender.send() → jms::X → MDB.onMessage()` (виден в `get_callers(onMessage)`).
+6. Tier: destination литерал/const → 0.8; только эвристика → 0.45 hidden.
+
+⚠️ `@Resource` перегружен: `@Resource DataSource` (DI) vs `@Resource(lookup="jms/Q")` (JMS) —
+различать по `lookup`/`name` + типу цели, иначе DataSource-инъекции попадут в JMS-контракты.
+
+### 4.3 CDI `@Inject` / `@Produces`  (P1, общая машинерия с EJB)
+
+**Сигналы.** Инъекция: `@Inject` поле/конструктор-параметр. Провайдеры: `@Produces` метод/поле;
+managed-bean классы (`@ApplicationScoped`/`@RequestScoped`/`@Dependent`/…) провайдят свой тип +
+все `implements`-интерфейсы. Qualifier: `@Named("x")`, `@Default`, user `@Qualifier`.
+
+**Extract.** `@Inject FooService svc` → `EdgeConsumes {via:"@Inject", di_token:"FooService",
+qualifiers:[...]}`. `@Produces FooService make()` → `EdgeProvides {binding:"cdi.produces",
+provides_for:"FooService"}`. Managed-bean → провайдер своего типа + интерфейсов.
+
+**Резолв (synthesizer `cdi`).** Producer-индекс `тип → []провайдер` из (a) `@Produces`,
+(b) managed-bean классов, (c) интерфейсов через `EdgeImplements`, (d) abstract-class через
+`EdgeExtends`. На `@Inject`:
+- 1 кандидат → `EdgeCalls`, 0.8 (интерфейс) / 0.85 (конкретный класс);
+- `@Named`/`@Qualifier` → точный, 0.9;
+- N без qualifier → §7.
+
+⚠️ **`diContractFromEdge` switch закрыт** (`di_contracts.go:243-253`): неизвестный `binding`
+падает в `default: return zero,false` и тихо дропается. Добавление `cdi.produces`/`cdi.managed`
+требует правки **и** этого switch, иначе контракты исчезнут без ошибки. **Cross-repo CDI — только
+через `di::<token>::<qualifier>` contract-matcher** (structural implements repo-gated).
+
+### 4.4 REST: JAX-RS + Spring MVC  (P1, contract-enrichment)
+
+Server-side частично есть. Закрыть: конкатенацию class-`@Path` + method-`@Path`
+(+ `@ApplicationPath`) → `http::<METHOD>::<normalized-path>`; client-консьюмеры (JAX-RS
+`client.target(..).path(..).request().get()`, Spring `RestTemplate`/`WebClient`/`@FeignClient`).
+Парность server↔client — нативным HTTP-matcher'ом (`contracts/http.go`, `schema_enrich_java.go`),
+**не synthesizer'ом**. `provides` метод→contract 0.95; параметры пути сохранять как pattern
+(`/request/{id}`). Абстрактные классы — не создавать endpoint.
+
+### 4.5 Servlet / Filter  (P2)
+
+Аннотации: `@WebServlet(urlPatterns=…)` (есть как entrypoint) + `@WebFilter`/`@WebListener` →
+entrypoints + HTTP-провайдер-контракты; `doGet/doPost/…` → `provides` к contract, 0.9. XML (§4.7):
+`web.xml` `<servlet-mapping>` (class→url), `<filter-mapping>` (ordered filter-chain — моделировать
+`references` с `order` meta). Servlet без `urlPatterns` → пропустить (abstract base).
+
+### 4.6 SOAP / JAX-WS  (P2)
+
+`@WebService(name=,serviceName=)` → contract `soap::<service>`; `@WebMethod` → `provides`, 0.9;
+`@WebServiceRef` на клиенте → `consumes`. WSDL-first (`wsdlLocation`) → парсить WSDL если доступен
+(§4.7). `@HandlerChain` — не контракт (метаданные трассировки).
+
+### 4.7 Deployment descriptor parser  (P3 / confidence-upgrade)
+
+Файлы: `WEB-INF/web.xml`, `META-INF/ejb-jar.xml`, `META-INF/application.xml`, `META-INF/beans.xml`,
+`META-INF/persistence.xml`, vendor: `jboss-web.xml`, `ibm-web-bnd.xml`, `glassfish-web.xml`.
+
+**Как ингестить (рекоменд.):** встроенный content-sniffed XML-экстрактор по образцу MyBatis
+(`mybatis.go` `IsMyBatisMapper`-гейтинг). Добавить `javaee_xml.go`: снифф root-элемента/DOCTYPE
+(`<beans>`/`<web-app>`/`<ejb-jar>`/`<persistence>`/`<definitions>`), эмит нод (`KindType` для
+`<bean>`/`<servlet>`/`<message-driven>`, `KindArtifact` для дока) + рёбер. Без форка, fail-soft
+(нода-файл при любой ошибке). Escape-hatch для команд: `index.extractor_plugins` (subprocess
+JSON) / `fallback_chunkers` (regex) / `artifacts:` (text-scan).
+
+**Правила:** парсинг XML **после** Java-индексации; XML мёржится с аннотациями, **XML имеет
+приоритет** при конфликте (override); XML-рёбра — `origin` дескрипторного binding'а (0.9 для
+явного `<servlet-mapping>`/enabled `@Alternative`; иначе на ~0.05 ниже аннотации).
+
+⚠️ `beans.xml` **discovery-mode**: `bean-discovery-mode="annotated"` (дефолт Jakarta) vs `"all"`
+меняет, считаются ли un-annotated классы бинами — парсить; дефолт `annotated`.
+
+## 5. Граничные случаи / известные ловушки
+
+- **`@Alternative`/`@Specializes`/`@Priority` инвертируют резолв** (ПРИНЯТО — D3): `@Alternative`
+  бины по умолчанию **выключены** → исключать из видимых тиров; остался один не-alternative →
+  видимый 0.7; ноль/N>1 → hidden (§7). `@Specializes` безусловно заменяет родителя → демотить
+  родителя уже в Phase A. Полный резолв включённых альтернатив — Phase D (`beans.xml`
+  `<alternatives>`).
+- **`@Resource` перегружен** (DI vs JMS) (ПРИНЯТО — D2): приоритет **сигналов**, не типа —
+  `lookup=`/`mappedName=` по JMS-JNDI-паттерну → JMS; иначе JMS API-тип (`jakarta/javax.jms.*`) →
+  JMS; иначе `DataSource`/`EntityManager` → DI; голый нерезолвимый `@Resource` → abstain (не
+  угадывать JMS). См. §4.2.
+- **`Instance<T>` / `Provider<T>`** — lazy, несколько кандидатов → speculative.
+- **`@EJB(beanName)` / `<ejb-link>`** — точный маппинг 0.9.
+- **abstract-class инъекция** — через `EdgeExtends` (не `EdgeImplements`).
+- **JNDI/строковые destination/lookup** — reuse const-deref + allow-list; неизвестное → 0.45.
+- **`@Remote`** — может быть cross-JVM/вне графа.
+
+## 6. Cross-repo
+
+Provider↔consumer-спеки (DI/HTTP/JMS/SOAP) — через contract-matcher с общими id (workspace =
+жёсткая граница, project = мягкая). **Structural `EdgeImplements`/`EdgeExtends` repo-gated
+(`resolver.go:2411`) — НЕ cross-repo.** Поэтому cross-repo CDI/EJB только через
+`di::<token>::<qualifier>` контракт (и consumer, и provider эмитят контракт). Не заявлять
+implements как cross-repo.
+
+## 7. Тиры неоднозначности (ПРИНЯТО — D1+D4)
+
+Решающий факт: speculative-рёбра (`Meta[MetaSpeculative]=true`, `OriginSpeculative` 0.45)
+**скрыты из всех дефолтных запросов** гейтом `FilterSpeculative(false)` (`query/subgraph.go:247`,
+вызывается в `get_callers`/`find_usages`/`get_call_chain`/`api_impact`/`smart_context`,
+`tools_core.go:1945–2209`); видны только при `include_speculative:true`. Прецедент —
+`ResolveSpeculativeDispatch` (`speculative_dispatch.go`): эмитит все одноимённые кандидаты в
+hidden-тир с `candidate_count` + капами (soft 12, hard 40).
+
+Политика (N>1 impl без qualifier):
+- эмитить **все** кандидаты в `OriginSpeculative` 0.45, `Meta[MetaSpeculative]=true`,
+  `candidate_count` в meta, конфиденс `1/N` (floor 0.05, ceil 0.45), капы 12/40 (выше 40 — дроп);
+- **промоутер:** ровно один кандидат в том же файле/пакете → его в видимый `OriginASTInferred`
+  0.7 (как MyBatis `mybatis_calls.go:166`), остальных — в hidden;
+- integrity-finding («add @Qualifier») — как дополнение, не замена.
+
+Это precision-first для агента (дефолт скрывает) И recall для аудита (`include_speculative` /
+`review --audience human`) одним эмитом. **D4: видимость — read-time; никакого index-флага и
+вторых меток** (граф общий на сессии; `--audience` — review-слой `review/summary.go`). Единственная
+доработка: `review --audience human` должен ставить `include_speculative:true` на чтения графа.
+
+Прецеденс провайдеров: явный `@Produces`/`@Bean` > implicit managed-bean; qualifier override.
+
+## 8. Приоритеты / фазы
+
+| Приоритет | Resolver | Покрытие | Сложность | Тип |
+|---|---|---|---|---|
+| **P0** | EJB interface→impl | критично (связь слоёв) | средняя | synthesizer |
+| **P0** | JMS producer→consumer | критично (processor=0 callers) | средняя | synthesizer |
+| **P1** | CDI `@Inject`/`@Produces` | высокое (общая машинерия с EJB) | высокая | synthesizer |
+| **P1** | REST endpoint + client | важно (HTTP→метод) | низкая | contract-enrich |
+| **P2** | Servlet/Filter | legacy entrypoints | низкая | entrypoint+ordered |
+| **P2** | SOAP/JAX-WS | мало в монолите | низкая | contract-enrich |
+| **P3** | Deployment descriptor parser | upgrade до 0.9 + XML-only бины | средняя | XML-extractor |
+
+Каждая фаза — атомарный PR: build + unit (extractor) + e2e (index→resolve fixture) + `analyze`
+integrity-finding для неоднозначных/неразрешённых. Приземлять на inferred-тиры; XML апгрейдит 0.9.
+(EJB legacy-skewed: если целевой корпус Quarkus/Spring — CDI и REST-client поднять выше EJB.)
+
+## 9. Критерии приёмки + метрики
+
+**P0 (обязательные):**
+1. `get_callers(ChangePricePlanProcessor.processRequest)` ≥1 caller (через JMS-ноду).
+2. `get_callers(NewOfferingService.retrieveAvailablePricePlans)` → impl `NewOfferingServicesEJB`, conf ≥0.8.
+3. `contracts list` показывает REST endpoints (method + path).
+4. `get_call_chain(VIPChangePricePlanBO.buildChangePricePlanRequest)` доходит до `processRequest` через JMS-ноду.
+
+**P1:** SOAP/Servlet endpoints в `contracts list`; `api_impact` REST учитывает downstream.
+
+| Метрика | До | P0 | P0+P1 |
+|---|---|---|---|
+| Callers `processRequest` | 0 | ≥2 | ≥2 |
+| Contracts | 0 | ≥12 REST | ≥14 (REST+SOAP) |
+| EJB interface→impl edges | 0 | ≥3 | ≥3 |
+| `find_usages(MDB.onMessage)` | 0 | ≥1 | ≥1 |
+
+## 10. Ограничения (не покрывается)
+
+Reflection (`Class.forName`/`Method.invoke`), JNDI lookup строкой в runtime, dynamic proxy,
+Spring XML `<bean class=>` (отдельный resolver), JMS message-selector фильтрация. Interceptor/
+decorator chains, producer disposal — метаданные/порядок, не dispatch-рёбра (defer).
+
+## 11. Принятые решения (с обоснованием)
+
+1. **Неоднозначность (D1)** — все кандидаты в hidden-speculative + видимый same-package промоутер +
+   integrity-finding (§7). *Почему:* hidden-by-default даёт precision агенту и recall аудиту одним
+   эмитом; прецедент `ResolveSpeculativeDispatch`. Чистый «emit none» отвергнут — теряет бесплатный recall.
+2. **`@Resource` (D2)** — приоритет сигналов (`lookup=`→тип→abstain), не type-first (§4.2/§5).
+   *Почему:* экстрактор часто не резолвит тип → type-first fail-open; `lookup=` — локальный надёжный сигнал.
+3. **`@Alternative`/`@Specializes` (D3)** — супрессия в Phase A (исключить выключенные альтернативы из
+   видимых тиров; демотить родителя `@Specializes`); полный резолв — Phase D (`beans.xml`) (§5).
+   *Почему:* видимое ребро в вытесненный бин — худший (инвертированный) случай; супрессия закрывает дыру дёшево.
+4. **Audience-split (D4)** — read-time через `MetaSpeculative` + `include_speculative`; **без**
+   index-флага и вторых меток (слит с D1) (§7). *Почему:* граф общий на сессии, переиндексация под
+   audience прохибитивна; `--audience` живёт в review-слое.
+
+⚠️ **Перед реализацией:** добавить `cdi.produces`/`cdi.managed` в switch `diContractFromEdge`
+(`di_contracts.go:243-253`) — иначе неизвестный `binding` тихо дропается (`default: return zero,false`).
+Опционально: `analyze kind=javaee_orphans` (зеркало `temporal_orphans`) для аудита hidden-рёбер.
+
+## 12. Карта в код gortex (точки касания)
+
+- Synthesizer: `internal/resolver/framework_synth.go` (интерфейс :31, реестр :114, `StampSynthesized` :70, `Synth*` :55-67).
+- Образцы: `mybatis_calls.go`, `grpc_stub_calls.go`, `temporal_calls.go`.
+- DI: `internal/indexer/di_contracts.go` (`diContractFromEdge` :243-253 ⚠ закрытый switch, `linkSpringBeans` :161, repo-scope :44/:122).
+- Impl-резолв: `internal/resolver/resolver.go` (`inferImplements` :2293-2450; interface-only :2302; repo-gate :2411).
+- Contracts: `internal/contracts/{contract.go,http.go,schema_enrich_java.go,matcher.go(:81 Cartesian),bind.go}`; reconcile `multi.go:2180`.
+- XML-ингест: `internal/parser/languages/mybatis.go` (`IsMyBatisMapper`), `extractor_plugin.go`; `internal/config/config.go` (`ArtifactEntry`/`ExtractorPluginSpec`/`FallbackChunkerSpec`); `internal/artifacts/artifacts.go`.
+- Allow-list: `internal/config/temporal_allowlist.go` (gate `GORTEX_ALLOW_LOCAL_*`, empty=off) → зеркалить `GORTEX_ALLOW_LOCAL_JAVAEE`, файл `.gortex/javaee.yaml`, лоадер в `internal/config`.
+- Pipeline: `indexer.go` (synthesizer :743/:2491; contract-пасс :2444/:860).
+- Edge/Node kinds: `internal/graph/edge.go` (Calls/Implements/Extends/Provides/Consumes/Matches/References/Annotated; origins :597-608), `node.go` (Method/Interface/Type/Field/Artifact).

--- a/docs/design/07-javaee-implementation-plan.md
+++ b/docs/design/07-javaee-implementation-plan.md
@@ -1,0 +1,151 @@
+# Java EE edge resolvers — implementation plan
+
+> Buildable execution plan derived from the spec `docs/design/06-javaee-synthesizer.md`
+> (which itself merges `docs/java-ee-edge-resolvers.md` + gortex-integration design + review).
+> Each task is atomic, lands a PR, and ships with build + unit (extractor) + e2e
+> (index→resolve fixture) + an `analyze` integrity surface. Decisions D1–D4 are settled in §11
+> of the spec and assumed here.
+
+Legend: `[ ]` task · **(file)** primary touch-point · → produced edge/tier.
+
+---
+
+## Phase 0 — Shared infrastructure (prerequisite for A/C; do first)
+
+- [ ] **0.1 Synthesizer skeleton + registration.** Add `SynthCDI`, `SynthEJB`, `SynthJMS` to the
+  `Synth*` const block and register `synthFunc{name, fn}` in `defaultFrameworkSynthesizers()`
+  **(internal/resolver/framework_synth.go:55-67,114)**. No-op bodies first (green build).
+- [ ] **0.2 Annotation capture.** Confirm/extend the Java extractor to emit `EdgeAnnotated` +
+  per-annotation args into edge/node `Meta` for the Java EE annotation set **(internal/parser/
+  languages/java.go `javaCollectAnnotations` ~885)**. Needed args: `@Named`/`@Qualifier` value,
+  `@ActivationConfigProperty`, `@Resource(lookup=,name=,mappedName=)`, `@Path`, `@EJB(beanName=)`,
+  `@WebServlet(urlPatterns=)`, `@WebService(name=,serviceName=)`.
+- [ ] **0.3 Subtype index helper (SHARED, repo-scoped).** `subtypeIndex(g, repo)` mapping a type
+  → concrete impls via **both** `EdgeImplements` (interfaces) **and** `EdgeExtends` (abstract
+  classes). Repo-scope with `GetRepoNodes`/`GetRepoEdges` for perf. Consumed by EJB + CDI.
+  *Why both edges:* `InferImplements` is interface-only **(resolver.go:2302)** so abstract-class
+  injection needs `EdgeExtends`.
+- [ ] **0.4 di_contracts switch (BLOCKER GOTCHA).** Add `cdi.produces` and `cdi.managed` `binding`
+  cases to `diContractFromEdge` **(internal/indexer/di_contracts.go:243-253)** — the closed
+  `default: return zero,false` silently drops unknown bindings (will look like "resolver emits
+  nothing"). Contract id `di::<token>::<qualifier>`.
+- [ ] **0.5 Speculative-emit helper.** Reuse `ResolveSpeculativeDispatch`'s shape
+  **(internal/resolver/speculative_dispatch.go)**: emit all N candidates at `OriginSpeculative`
+  0.45, `Meta[MetaSpeculative]=true`, `candidate_count`, conf `1/N` (floor 0.05, ceil 0.45),
+  fanout caps (soft 12, hard 40 → drop). Same-file/same-package promoter → one visible 0.7 edge.
+- [ ] **0.6 Config allow-list.** `internal/config/javaee.go` mirroring `temporal_allowlist.go`:
+  gate `GORTEX_ALLOW_LOCAL_JAVAEE`, file `.gortex/javaee.yaml`, **empty=off**. Keys:
+  `cdi_producers`, `cdi_qualifiers`, `jms_destinations`.
+- [ ] **0.7 e2e harness.** Fixture helper (clone `internal/indexer/temporal_e2e_test.go` shape):
+  write Java sources to tmp → index → assert edges/tiers.
+- [ ] **0.8 `analyze kind=javaee_orphans`.** Mirror `temporal_orphans` **(internal/resolver/
+  temporal_orphans.go + internal/mcp/tools_analyze_temporal.go)**: surface ambiguous injections,
+  unresolved `@Inject`, MDB with no sender, JMS sender with no listener.
+
+---
+
+## Phase A — EJB + CDI  (P0/P1, synthesizer, code-only) — highest ROI
+
+- [ ] **A1 Extract managed beans + injection points.** Tag `@Stateless/@Stateful/@Singleton`
+  (EJB) and `@ApplicationScoped/@RequestScoped/@Dependent/@SessionScoped` (CDI) classes as
+  providers of their own type + implemented/extended types. Emit `EdgeConsumes {via, di_token,
+  qualifiers}` for `@Inject`/`@EJB` points; `EdgeProvides {binding:"cdi.produces"/"cdi.managed",
+  provides_for}` for `@Produces`/managed beans. **(java.go)**
+- [ ] **A2 EJB resolver** `ResolveEJBInjection` **(internal/resolver/ejb_calls.go new)**: for each
+  `@EJB`/`@Inject` of an interface → subtypeIndex (0.3). Unique impl → `EdgeCalls` 0.85 visible;
+  `@EJB(beanName=X)`/`<ejb-link>` → 0.9; N>1 → speculative (0.5); `@LocalBean` → skip;
+  `@Remote` → tag (may be out-of-graph).
+- [ ] **A3 CDI resolver** `ResolveCDIInjection` **(internal/resolver/cdi_calls.go new)**: producer
+  index = `@Produces` ∪ managed beans ∪ subtypeIndex. `@Named`/`@Qualifier` → 0.9; unique → 0.8
+  (iface) / 0.85 (concrete); N>1 → speculative + same-package promoter.
+- [ ] **A4 `@Alternative`/`@Specializes` suppression (D3).** Tag alternatives; exclude from visible
+  tiers (they're disabled until beans.xml, Phase D); `@Specializes` → demote parent in index.
+- [ ] **A5 Cross-repo DI.** Consumer + provider both emit `di::<token>::<qualifier>` contract so
+  the matcher pairs across repos (structural subtype edges are repo-gated, resolver.go:2411).
+- [ ] **A6 Tests + acceptance.** e2e: `@EJB NewOfferingService` → `NewOfferingServicesEJB` impl,
+  conf ≥0.8 (spec acceptance #2); `@Inject` interface w/ single impl resolves; N>1 → hidden;
+  `@Named` exact. Integrity rows for ambiguous.
+
+---
+
+## Phase C — JMS producer→consumer  (P0, synthesizer + synthetic node) — parallel to A
+
+- [ ] **C1 Extract listeners.** `@MessageDriven` + `@ActivationConfigProperty(destination=,
+  destinationType=)`, Spring `@JmsListener`, `MessageListener.onMessage`. Normalise JNDI dest. **(java.go)**
+- [ ] **C2 Extract senders.** `jmsContext.createProducer().send(dest,…)`,
+  `jmsTemplate.convertAndSend("q",…)`. Resolve `dest` via **D2 signal-priority**: `@Resource(lookup=)`
+  JMS-JNDI pattern → JMS; JMS API type → JMS; else const-deref; else abstain.
+- [ ] **C3 Resolver** `ResolveJMSDispatch` **(internal/resolver/jms_calls.go new)**: synthetic
+  `jms::<dest>` node (kind `queue`/`topic`); `spawns` → MDB.onMessage; `calls` sender →
+  `jms::<dest>`. Two-hop `Sender.send() → jms::X → MDB.onMessage()`. Tier 0.8 literal/const, 0.45 heuristic.
+- [ ] **C4 Tests + acceptance.** e2e: `get_callers(processRequest)` ≥1 via JMS node (acceptance #1);
+  `get_call_chain` reaches across the queue (acceptance #4); Queue vs Topic by `destinationType`.
+
+---
+
+## Phase B — REST (JAX-RS + Spring MVC) + Servlet  (P1, contract-enrichment) — independent
+
+- [ ] **B1 Route contracts.** Concat class `@Path` + method `@Path` (+ JAX-RS `@ApplicationPath`),
+  emit provider contract `http::<METHOD>::<normalized-path>` **(internal/contracts/
+  schema_enrich_java.go, http.go)**. Path params → pattern (`/req/{id}`). Abstract class → no endpoint.
+- [ ] **B2 Client consumers.** JAX-RS `client.target(..).path(..).request().get()`, Spring
+  `RestTemplate`/`WebClient`/`@FeignClient` → consumer contracts. Pair via existing HTTP matcher.
+- [ ] **B3 Servlet/Filter.** `@WebServlet(urlPatterns=)` (+ `@WebFilter`/`@WebListener`) → entrypoints
+  + provider contracts; `doGet/doPost/…` → `provides` 0.9. **(internal/entrypoints/entrypoints.go)**
+- [ ] **B4 Tests + acceptance.** `contracts list` shows REST endpoints w/ method+path (acceptance #3);
+  `api_impact` counts downstream.
+
+---
+
+## Phase D — Deployment descriptors  (P3, confidence-upgrade; completes D3)
+
+- [ ] **D1 Built-in XML extractor** `internal/parser/languages/javaee_xml.go` — content-sniff
+  (root/DOCTYPE) per MyBatis precedent **(mybatis.go `IsMyBatisMapper`)**: `beans.xml`, `web.xml`,
+  `ejb-jar.xml`, `persistence.xml`, `application.xml` (+ vendor `jboss-web.xml`/`ibm-web-bnd.xml`/
+  `glassfish-web.xml`). Emit nodes/edges; fail-soft (file node on error). Parse once at extract.
+- [ ] **D2 beans.xml `<alternatives>` + discovery-mode.** Enabled alternative → promote to visible/0.9,
+  demote default (finishes D3). `bean-discovery-mode` default `annotated`.
+- [ ] **D3 web.xml mappings.** `<servlet-mapping>` class→url; `<filter-mapping>` ordered chain
+  (`references` + `order` meta). `ejb-jar.xml` `<message-driven>` dest (XML-only MDBs); `<ejb-link>` exact.
+- [ ] **D4 Override merge.** XML overrides annotations on conflict; XML-confirmed binding → 0.9.
+
+---
+
+## Phase E — SOAP / JAX-WS  (P2, lowest priority)
+
+- [ ] **E1 Endpoints.** `@WebService(name=,serviceName=)` → contract `soap::<service>::<op>`;
+  `@WebMethod` → `provides` 0.9; `@WebServiceRef` → `consumes`.
+- [ ] **E2 WSDL ingest.** `*.wsdl` via artifacts / extractor to enumerate operations + bind clients.
+
+---
+
+## Sequencing & dependencies
+
+```
+Phase 0 ──┬─► Phase A (EJB → CDI; CDI reuses 0.3/0.4/0.5/A5)
+          ├─► Phase C (JMS; independent — parallel with A)        ◄ P0 corpus priority: A(EJB)+C(JMS) first
+          └─► Phase B (REST/Servlet; independent — contracts)
+Phase A/B/C ──► Phase D (XML upgrades A/B/C to 0.9, completes @Alternative) ──► Phase E
+```
+
+P0 (spec): EJB interface→impl (A2) + JMS (C) — without them processor `callers=0`. CDI (A3) P1.
+If target corpus is Quarkus/Spring rather than legacy EJB, raise CDI + REST-client above EJB.
+
+## Cross-cutting invariants
+
+- **Visibility (D1/D4):** every multi-candidate resolution → hidden `MetaSpeculative`; visibility is
+  read-time (`include_speculative` / `review --audience human`). No index-time audience flag.
+- **Perf:** repo-scope all indexes; parse XML once at extract, resolve from meta in the pass
+  (synthesizers full-recompute every settle — framework_synth.go:18).
+- **Tiers:** 0.9 descriptor/exact; 0.7–0.85 annotation+unique-subtype; 0.45 hidden speculative.
+- **PR discipline:** one PR per task-group, build + unit + e2e + integrity finding, land inferred-tier.
+
+## Risk gates (verify before/at implementation)
+
+1. **diContractFromEdge switch** (0.4) — edit or CDI contracts silently vanish.
+2. **InferImplements interface-only + repo-gated** (resolver.go:2302,2411) → EdgeExtends (0.3) + di:: cross-repo (A5).
+3. **@Resource overload** (D2) → signal-priority ladder, abstain branch mandatory.
+4. **LSP/jdtls prerequisite** — accurate Java type/interface resolution (used by subtype matching &
+   `@Inject` type targets) is materially better with jdtls. The Windows `file://` URI fix
+   (PR #92 / `internal/lspuri`) is a prerequisite for jdtls-grade Java resolution on Windows; land
+   it first so Java EE resolvers aren't fighting a degraded base graph.

--- a/docs/java-ee-edge-resolvers.md
+++ b/docs/java-ee-edge-resolvers.md
@@ -1,0 +1,404 @@
+# ТЗ: Java EE Edge Resolvers для статического графа вызовов
+
+## 1. Проблема
+
+Статический анализатор (tree-sitter) строит граф вызовов по прямым вызовам `a.b()`.
+В Java EE монолитах компоненты связываются **декларативно** — через аннотации и конфигурацию,
+а не через вызовы кода. Это создаёт слепые зоны в графе:
+
+- JMS: `queueSender.send()` → MDB `onMessage()` — нет ребра
+- EJB: `@Inject` интерфейс → `@Stateless` impl — нет ребра
+- REST: `@GET @Path("/x")` → метод — нет ребра
+- SOAP: `@WebService` → endpoint — нет ребра
+- Servlet: `web.xml` / `@WebServlet` → класс — нет ребра
+- CDI: `@Inject` → `@ApplicationScoped` bean — нет ребра
+
+Для монолита ~240K нод это означает ~30% потерянных рёбер на архитектурных границах.
+
+## 2. Цель
+
+Дополнить индексер annotation-aware edge resolver'ами, которые создают рёбра
+на основе Java EE аннотаций и дескрипторов развертывания. Рёбра должны быть
+того же типа что и существующие (calls, implements, references), с пометкой
+origin=`annotation_resolved` и confidence по шкале 0..1.
+
+## 3. JMS Resolver
+
+### 3.1 Входные данные
+
+**Producer** (отправитель в очередь):
+```java
+@Inject JMSContext context;
+@Inject @JMSConnectionFactory("jms/BSSJMSConnectionFactory")
+private JMSContext jmsContext;
+
+@Resource(lookup = "jms/BSSSingleChangePPQueue")
+private Queue singleChangePPQueue;
+
+// отправка
+jmsContext.createProducer().send(singleChangePPQueue, message);
+context.createProducer().send(queue, message);
+```
+
+**Consumer** (MDB — слушатель очереди):
+```java
+@MessageDriven(activationConfig = {
+    @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue"),
+    @ActivationConfigProperty(propertyName = "destination", propertyValue = "jms/BSSSingleChangePPQueue")
+})
+public class SingleChangePPQueueMDB implements MessageListener {
+    public void onMessage(Message message) { ... }
+}
+```
+
+**Deployment descriptor** (альтернатива аннотациям):
+```xml
+<message-driven>
+    <ejb-name>SingleChangePPQueueMDB</ejb-name>
+    <messaging-type>javax.jms.MessageListener</messaging-type>
+    <activation-config>
+        <activation-config-property>
+            <activation-config-property-name>destination</activation-config-property-name>
+            <activation-config-property-value>jms/BSSSingleChangePPQueue</activation-config-property-value>
+        </activation-config-property>
+    </activation-config>
+</message-driven>
+```
+
+### 3.2 Правила создания рёбер
+
+| Паттерн | Ребро | Confidence |
+|---------|-------|------------|
+| `@ActivationConfigProperty(destination=X)` на MDB → метод `onMessage()` | `calls` от MDB.onMessage к отправителю (если найден) | 0.7 |
+| `@Resource(lookup=X)` типа Queue/Topic в классе A + `send()` | `spawns` от A.send → MDB.onMessage (если X совпадает с destination MDB) | 0.8 |
+| `ejb-jar.xml` → `destination` + `destinationType` | аналогично аннотации | 0.7 |
+
+### 3.3 Алгоритм
+
+1. На этапе индексации: для каждого класса с `@MessageDriven` извлечь `destination` и `destinationType`
+2. Создать synthetic-ноду `jms/queue/<destination>` (kind=queue)
+3. Создать ребро `spawns` от `jms/queue/<destination>` → `MDB.onMessage()`
+4. Для каждого `@Resource(lookup=X)` типа Queue/Topic: создать ребро `calls` от метода с `send()` → `jms/queue/<destination>`
+5. Итого: `Sender.send() → jms/queue/X → MDB.onMessage()` — две вершины через промежуточную ноду очереди
+
+### 3.4 Граничные случаи
+
+- Destination задан через JNDI lookup строкой → извлечь строку
+- Destination задан через `@Resource(lookup="java:/jms/queue/X")` → нормализовать JNDI-имя
+- Topic vs Queue — различать по `destinationType`
+- MDB без аннотаций (только ejb-jar.xml) → парсить XML
+
+## 4. EJB Interface→Implementation Resolver
+
+### 4.1 Входные данные
+
+**Интерфейс**:
+```java
+@Local
+public interface NewOfferingService {
+    AvailableSocServiceDO retrieveAvailablePricePlans(...);
+    SubscriberPricePlanInfoDO retrieveSubscriberPricePlanInfo(...);
+}
+```
+
+**Реализация**:
+```java
+@Stateless
+public class NewOfferingServicesEJB implements NewOfferingService {
+    @Override
+    public AvailableSocServiceDO retrieveAvailablePricePlans(...) { ... }
+}
+```
+
+**Инъекция**:
+```java
+@EJB
+private NewOfferingService offeringService;
+
+// вызов
+offeringService.retrieveAvailablePricePlans(...);
+```
+
+### 4.2 Правила создания рёбер
+
+| Паттерн | Ребро | Confidence |
+|---------|-------|------------|
+| `class X implements Y` + `Y` имеет `@Local`/`@Remote` | `implements` от X к Y | 0.95 |
+| `@EJB` инъекция интерфейса Y в класс A + вызов `y.method()` | `calls` от A.method() → X.method() (impl) | 0.85 |
+| `@Inject` CDI инъекция интерфейса Y | `calls` от A.method() → X.method() (impl) | 0.7 |
+
+### 4.3 Алгоритм
+
+1. Собрать маппинг: интерфейс → список реализаций (по `implements` + `@Stateless`/`@Stateful`/`@Singleton`)
+2. При встрече `@EJB`/`@Inject` типа-интерфейса: разрешить к конкретной реализации
+3. Если реализация одна → confidence 0.85
+4. Если реализаций несколько → создать рёбра ко всем с confidence 0.7 + пометить `speculative_dispatch`
+5. Вызовы через интерфейсную ссылку: `interfaceRef.method()` → направить к impl.method() через `implements` ребро
+
+### 4.4 Граничные случаи
+
+- `@EJB(beanName="specificImpl")` → точный маппинг, confidence 0.95
+- `@LocalBean` (no-interface view) → пропустить, обычный класс
+- `@Remote` vs `@Local` — различать (remote = cross-JVM, может быть не в графе)
+- `ejb-jar.xml` с `<ejb-link>` → точный маппинг
+
+## 5. REST Endpoint Resolver (JAX-RS)
+
+### 5.1 Входные данные
+
+```java
+@Path("/request")
+public class RequestRS {
+    @GET
+    @Path("/changePricePlan")
+    public Response changePricePlan(@QueryParam(...) ...) { ... }
+
+    @PUT
+    @Path("/changePricePlan")
+    public Response changePricePlanCvg(@RequestBody ...) { ... }
+}
+```
+
+Или на уровне метода:
+```java
+@GET
+@Path("/info/pricePlan")
+@Produces(MediaType.APPLICATION_JSON)
+public Response getPricePlanInfo() { ... }
+```
+
+### 5.2 Правила создания рёбер
+
+| Патattern | Ребро | Confidence |
+|-----------|-------|------------|
+| `@GET`/`@PUT`/`@POST`/`@DELETE` на методе | Создать synthetic-ноду `http://GET /request/changePricePlan` (kind=contract, type=http) | — |
+| Метод с `@GET @Path(X)` | `provides` от метода к contract-ноде | 0.95 |
+| Класс с `@Path(Y)` + метод с `@Path(X)` | URL = Y + X → contract-нода | 0.95 |
+| `@Consumes`/`@Produces` | Записать media type в meta contract-ноды | — |
+
+### 5.3 Алгоритм
+
+1. При парсинге класса с `@Path` на уровне класса — запомнить basePath
+2. Для каждого метода с HTTP-аннотацией (`@GET`, `@PUT`, `@POST`, `@DELETE`, `@PATCH`):
+   - Вычислить полный URL: basePath + methodPath
+   - Создать contract-ноду `http://<METHOD> <fullPath>`
+   - Создать ребро `provides` от метода к contract-ноде
+3. Contract-ноды обогащают `contracts list` и `api_impact`
+
+### 5.4 Граничные случаи
+
+- `@Path` с параметрами: `/request/{id}/changePricePlan` → сохранить как pattern
+- `@Path("")` или отсутствие → basePath = ""
+- Наследование: `@Path` на родителе + `@GET` на потомке → комбинировать
+- Подклассы: `@Path` на абстрактном классе → не создавать endpoint
+
+## 6. SOAP Web Service Resolver (JAX-WS)
+
+### 6.1 Входные данные
+
+```java
+@WebService(name = "SubscriberInterface", serviceName = "SubscriberService")
+@SOAPBinding(style = SOAPBinding.Style.DOCUMENT)
+public class SubscriberWS {
+    @WebMethod
+    public ChangePPResponse changePP(@WebParam ChangePPRequest request) { ... }
+}
+```
+
+### 6.2 Правила создания рёбер
+
+| Паттерн | Ребро | Confidence |
+|---------|-------|------------|
+| `@WebService` на классе | Создать contract-ноду `ws://<serviceName>` (kind=contract, type=ws) | — |
+| `@WebMethod` | `provides` от метода к contract-ноде | 0.9 |
+| `@WebService(name=X)` | Записать portType=X в meta | — |
+
+### 6.3 Граничные случаи
+
+- `@WebServiceRef` на клиенте → создать `consumes` ребро к contract-ноде
+- WSDL-first подход (wsdlLocation в аннотации) → парсить WSDL если доступен
+- `@HandlerChain` — обработчики не являются частью контракта, но могут быть полезны для трассировки
+
+## 7. Servlet Resolver
+
+### 7.1 Входные данные
+
+**Аннотация**:
+```java
+@WebServlet(urlPatterns = {"/servlet/ivrRequest", "/servlet/uivr_moscow"})
+public class IvrServlet extends HttpServlet {
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) { ... }
+}
+```
+
+**web.xml**:
+```xml
+<servlet>
+    <servlet-name>UssdServlet</servlet-name>
+    <servlet-class>com.amdocs.uss.rp.servlet.UssdServlet</servlet-class>
+</servlet>
+<servlet-mapping>
+    <servlet-name>UssdServlet</servlet-name>
+    <url-pattern>/servlet/ussdRequest</url-pattern>
+</servlet-mapping>
+```
+
+### 7.2 Правила создания рёбер
+
+| Паттерн | Ребро | Confidence |
+|---------|-------|------------|
+| `@WebServlet(urlPatterns=X)` на классе | Создать contract-ноду `http://POST <urlPattern>` (kind=contract, type=http) | 0.9 |
+| `<servlet-class>` + `<url-pattern>` в web.xml | Аналогично | 0.9 |
+| `doGet`/`doPost`/`doPut`/`doDelete` | `provides` от метода к contract-ноде | 0.9 |
+
+### 7.3 Граничные случаи
+
+- Filter (`@WebFilter`) → аналогично servlet, но с `urlPatterns` без HTTP method
+- Servlet без `urlPatterns` → пропустить (abstract base servlet)
+- `HttpRequestHandler` (Spring) → другая аннотация, отдельный resolver
+
+## 8. CDI Resolver
+
+### 8.1 Входные данные
+
+```java
+@ApplicationScoped
+public class B2CTariffConnector {
+    public void changePricePlan(...) { ... }
+}
+
+// В другом классе
+@Inject
+private B2CTariffConnector b2cTariffConnector;
+
+// или через интерфейс
+@Inject
+private TariffConnector tariffConnector; // → B2CTariffConnector (единственный impl)
+```
+
+### 8.2 Правила создания рёбер
+
+| Паттерн | Ребро | Confidence |
+|---------|-------|------------|
+| `@Inject` конкретного класса | `calls` от точки инъекции к impl (трассировка вызовов) | 0.85 |
+| `@Inject` интерфейса + единственный impl | `calls` от точки инъекции к impl | 0.8 |
+| `@Inject` интерфейса + несколько impl | `calls` ко всем impl с `speculative_dispatch` | 0.6 |
+| `@Named("beanName")` + `@Inject` | Точный маппинг | 0.9 |
+| `@Produces` на методе/поле | `provides` от producer к типу | 0.85 |
+
+### 8.3 Граничные случаи
+
+- `@Any`, `@Default` — квалификаторы по умолчанию
+- `Instance<T>` — lazy resolution, несколько кандидатов
+- `Provider<T>` — аналогично
+- `@Alternative` — активная альтернатива зависит от beans.xml
+
+## 9. Deployment Descriptor Parser
+
+### 9.1 Поддерживаемые файлы
+
+| Файл | 内容 |
+|------|------|
+| `WEB-INF/web.xml` | Servlet, Filter, Listener mappings |
+| `META-INF/ejb-jar.xml` | EJB definitions, MDB destinations |
+| `META-INF/application.xml` | EAR module definitions |
+| `WEB-INF/jboss-web.xml` | JBoss-specific servlet config |
+| `WEB-INF/ibm-web-bnd.xml` | WAS-specific bindings |
+| `WEB-INF/glassfish-web.xml` | GF-specific config |
+
+### 9.2 Правила
+
+- Парсинг XML идёт **после** Java-индексации
+- XML-данные мёржатся с аннотациями (XML имеет приоритет при конфликте — переопределение)
+- Созданные через XML рёбра получают origin=`xml_resolved` с confidence на 0.05 ниже аннотаций
+
+## 10. Общая архитектура resolver'ов
+
+### 10.1 Pipeline
+
+```
+Java source files
+       │
+       ▼
+  tree-sitter parse ──→ AST nodes + structural edges (ast_resolved)
+       │
+       ▼
+  annotation scanner ──→ synthetic nodes (contracts, queues) + annotation edges
+       │
+       ▼
+  deployment descriptor parser ──→ merge/override edges (xml_resolved)
+       │
+       ▼
+  LSP enrichment ──→ upgrade edges to lsp_resolved where possible
+```
+
+### 10.2 Synthetic nodes
+
+Resolver'ы создают **synthetic-ноды** для элементов которые не являются Java-классами:
+
+| Kind | Пример | Описание |
+|------|--------|----------|
+| `queue` | `jms/BSSSingleChangePPQueue` | JMS queue/topic |
+| `contract` | `http://GET /request/changePricePlan` | HTTP endpoint |
+| `contract` | `ws://SubscriberService` | SOAP endpoint |
+| `topic` | `jms/pricePlanChanged` | Pub/sub topic |
+
+Synthetic-ноды обогащают существующие Gortex-инструменты:
+- `contracts list` → показывает HTTP/SOAP endpoints
+- `get_callers(MDB.onMessage)` → показывает producer'ов через queue-ноду
+- `api_impact` → учитывает synthetic-ноды
+
+### 10.3 Edge origin classification
+
+| Origin | Confidence | Описание |
+|--------|-----------|----------|
+| `lsp_resolved` | 1.0 | LSP подтвердил |
+| `ast_resolved` | 0.92 | Tree-sitter нашёл прямой вызов |
+| `annotation_resolved` | 0.7..0.9 | Выведен из аннотации (JMS, EJB, REST) |
+| `xml_resolved` | 0.65..0.85 | Выведен из deployment descriptor |
+| `text_matched` | 0 | Эвристика по имени (существующий) |
+
+## 11. Приоритеты реализации
+
+| Приоритет | Resolver | Покрытие дыр | Сложность |
+|-----------|----------|--------------|-----------|
+| **P0** | EJB interface→impl | Критично: без него нет связи между слоями | Средняя |
+| **P0** | JMS producer→consumer | Критично: без него processor = 0 callers | Средняя |
+| **P1** | REST endpoint resolver | Важно: без этого нет связи HTTP→метод | Низкая |
+| **P1** | SOAP endpoint resolver | Средне: мало WS в монолите | Низкая |
+| **P2** | Servlet resolver | Средне: legacy entry points | Низкая |
+| **P2** | CDI resolver | Полезно, но CDI-вызовы частично резолвятся через implements | Высокая |
+| **P3** | Deployment descriptor parser | Улучшает покрытие для проектов с XML-конфигурацией | Средняя |
+
+## 12. Критерии приёмки
+
+### P0 (обязательные)
+
+1. `get_callers(ChangePricePlanProcessor.processRequest)` возвращает ≥1 caller (через JMS queue synthetic-ноду)
+2. `get_callers(NewOfferingService.retrieveAvailablePricePlans)` возвращает impl (NewOfferingServicesEJB) с confidence ≥0.8
+3. `contracts list` показывает REST endpoints с HTTP method + path
+4. `get_call_chain(VIPChangePricePlanBO.buildChangePricePlanRequest)` доходит до `ChangePricePlanProcessor.processRequest` через JMS synthetic-ноду
+
+### P1 (желательные)
+
+5. SOAP endpoints видны в `contracts list`
+6. Servlet entry points видны в `contracts list`
+7. `api_impact` для REST endpoint учитывает downstream callers
+
+### Измеримые метрики
+
+| Метрика | До | После (P0) | После (P0+P1) |
+|---------|-----|------------|---------------|
+| Callers для `processRequest` | 0 | ≥2 (Single+Mass MDB) | ≥2 |
+| Contracts обнаружено | 0 | ≥12 REST endpoints | ≥14 (REST+SOAP) |
+| EJB interface→impl edges | 0 | ≥3 ключевых | ≥3 |
+| `find_usages(MDB.onMessage)` | 0 | ≥1 (через queue) | ≥1 |
+
+## 13. Ограничения (не покрывается)
+
+- **Reflection**: `Class.forName()`, `Method.invoke()` — невозможно статически
+- **JNDI lookup** строкой: `new InitialContext().lookup("jms/X")` — требует runtime-данных
+- **Spring XML config**: `<bean class="...">` — отдельный resolver
+- **Dynamic proxy**: `Proxy.newProxyInstance()` — runtime
+- **Message selector**: JMS selector на MDB фильтрует сообщения — не учитывается


### PR DESCRIPTION
## What

Adds the Java EE / Jakarta EE edge-resolver **design docs** (no code):

- `docs/java-ee-edge-resolvers.md` — the spec/ТЗ: problem (Java EE wires components declaratively via annotations/descriptors → ~30% lost edges on a large monolith), per-subsystem rules (JMS, EJB, REST, SOAP, Servlet, CDI), synthetic nodes, edge-origin classification, priorities, acceptance criteria + metrics.
- `docs/design/06-javaee-synthesizer.md` — how it maps onto gortex internals: the `FrameworkSynthesizer` extract→resolve split, layer-ownership table (EJB/CDI/JMS = synthesizer `EdgeCalls`; REST/SOAP = contract enrichment `EdgeMatches`; filter-chain = ordered-edge pass), `EdgeImplements`/`EdgeExtends` subtype resolution, contract-matcher reuse for cross-repo, confidence tiers, and settled decisions (ambiguity → hidden-speculative; `@Resource` signal-priority; `@Alternative`/`@Specializes`; audience via `MetaSpeculative`).
- `docs/design/07-javaee-implementation-plan.md` — phased execution plan (0 shared infra, A EJB+CDI, B REST/Servlet, C JMS, D XML descriptors, E SOAP) with file touch-points, edge tiers, tests, sequencing and risk gates.

## Why

Captures the design + roadmap for closing gortex's Java EE blind spots (today Java symbols index via tree-sitter but CDI/EJB/JMS/JAX-RS dispatch edges are missing) so the implementation can land as reviewable, independently-shippable PRs. Grounded in the actual gortex synthesizer/contract machinery (file:line touch-points in §12 of doc 06).

Docs-only — no code changes.
