### PR TITLE
feat(lsp): harden enrichment — bounded concurrency, per-doc lifecycle, reconnect

### DIFF
--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -21,6 +21,7 @@ import (
 	"github.com/zzet/gortex/internal/resolver"
 	"github.com/zzet/gortex/internal/search"
 	"github.com/zzet/gortex/internal/search/trigram"
+	"github.com/zzet/gortex/internal/semantic"
 )
 
 // RepoMetadata holds per-repo indexing state.
@@ -144,6 +145,13 @@ type MultiIndexer struct {
 	// API-backed embedder, propagated to every per-repo Indexer. Zero
 	// keeps the built-in default.
 	embedAPIConcurrency int
+
+	// semanticMgr is the semantic enrichment manager propagated to
+	// every per-repo Indexer. When nil (the default), per-repo
+	// deferred passes skip semantic enrichment — this is the root
+	// cause of "enrich:0" in daemon mode. Set by the daemon via
+	// SetSemanticManager before IndexAll / TrackRepo.
+	semanticMgr *semantic.Manager
 }
 
 // SetEmbedder installs the embedding provider every per-repo indexer
@@ -216,6 +224,9 @@ func (mi *MultiIndexer) newPerRepoIndexer(cfg config.IndexConfig) *Indexer {
 	if mi.resolverLSPHelper != nil {
 		idx.SetResolverLSPHelper(mi.resolverLSPHelper)
 	}
+	if mi.semanticMgr != nil {
+		idx.SetSemanticManager(mi.semanticMgr)
+	}
 	return idx
 }
 
@@ -268,6 +279,24 @@ func (mi *MultiIndexer) SetEmbeddingAPIConcurrency(n int) {
 	mi.mu.Unlock()
 	for _, idx := range live {
 		idx.SetEmbeddingAPIConcurrency(n)
+	}
+}
+
+// SetSemanticManager installs the semantic enrichment manager every
+// per-repo Indexer this MultiIndexer constructs should use, and
+// re-applies it to every per-repo Indexer already built. Without
+// this call, daemon-mode enrichment produces zero results because
+// the per-repo Indexers never receive the semantic manager.
+func (mi *MultiIndexer) SetSemanticManager(m *semantic.Manager) {
+	mi.mu.Lock()
+	mi.semanticMgr = m
+	live := make([]*Indexer, 0, len(mi.indexers))
+	for _, idx := range mi.indexers {
+		live = append(live, idx)
+	}
+	mi.mu.Unlock()
+	for _, idx := range live {
+		idx.SetSemanticManager(m)
 	}
 }
 

--- a/internal/semantic/lsp/enrich_hardening_test.go
+++ b/internal/semantic/lsp/enrich_hardening_test.go
@@ -496,6 +496,57 @@ func TestLSP_Enrich_AbortsWhenReconnectFails(t *testing.T) {
 	assert.GreaterOrEqual(t, int(attempts.Load()), 3, "must retry reconnect at least 3 times before giving up")
 }
 
+// TestLSP_Enrich_ReopensDocsOnNewServerAfterReconnect verifies the strict
+// post-reconnect contract: after the server dies mid-flight while a file is
+// held open, documents are re-opened on the FRESH server (which has no record
+// of the dead session's opens) rather than hovered against an assumed-open
+// doc. The new server must therefore receive a paired didOpen/didClose.
+func TestLSP_Enrich_ReopensDocsOnNewServerAfterReconnect(t *testing.T) {
+	repoRoot, g := seedRepo(t, 8) // 8 nodes, all in main.go
+
+	server1 := newInstrumentedServer()
+	p, cleanup := providerWithInstrumentedServer(t, server1, []string{"go"}, 8)
+	defer cleanup()
+	deadClient := p.client
+
+	var killOnce sync.Once
+	server1.handle("textDocument/hover", func(params json.RawMessage) (any, *jsonRPCError) {
+		// Kill on the first hover so the whole burst observes the exit
+		// while main.go is still held open on server1.
+		killOnce.Do(func() {
+			deadClient.mu.Lock()
+			if !deadClient.closed {
+				deadClient.closed = true
+				close(deadClient.done)
+			}
+			deadClient.mu.Unlock()
+		})
+		return nil, &jsonRPCError{Code: -32603, Message: "dying"}
+	})
+
+	server2 := newInstrumentedServer()
+	server2.handle("textDocument/hover", func(params json.RawMessage) (any, *jsonRPCError) {
+		return map[string]any{"contents": map[string]any{"kind": "plaintext", "value": "func F()"}}, nil
+	})
+	p.connectOnce = func(absRoot string) error {
+		c2, in2, out2, cl2 := newPipedClient(t)
+		go server2.run(in2, out2)
+		t.Cleanup(cl2)
+		p.client = c2
+		return nil
+	}
+	p.dialBackoffStart = 1 * time.Millisecond
+	p.maxDialBackoff = 5 * time.Millisecond
+
+	require.NoError(t, runEnrich(t, p, g, repoRoot, 15*time.Second))
+
+	_, opens2, closes2 := server2.stats()
+	assert.GreaterOrEqual(t, opens2, 1,
+		"main.go must be re-opened on the fresh server after reconnect, not assumed open")
+	assert.Equal(t, opens2, closes2,
+		"every didOpen on the new server must be paired with a didClose (opens=%d closes=%d)", opens2, closes2)
+}
+
 // ---------------------------------------------------------------------------
 // isServerExitError detection.
 // ---------------------------------------------------------------------------

--- a/internal/semantic/lsp/enrich_hardening_test.go
+++ b/internal/semantic/lsp/enrich_hardening_test.go
@@ -1,0 +1,510 @@
+package lsp
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// ---------------------------------------------------------------------------
+// Hardening test harness — an instrumented fake LSP server that tracks the
+// open-document lifecycle (didOpen / didClose pairing), peak concurrency, and
+// can simulate a mid-flight server exit + a clean reconnect.
+//
+// These tests cover the LSP enrichment hardening spec
+// (docs/spec-lsp-enrichment-hardening.md): per-goroutine doc lifecycle,
+// bounded concurrency, and reconnect-with-backoff on server exit.
+// ---------------------------------------------------------------------------
+
+// instrumentedServer wraps fakeLSPServer-style routing with lifecycle counters
+// so a test can assert didOpen↔didClose pairing and peak concurrency.
+type instrumentedServer struct {
+	handlers map[string]func(params json.RawMessage) (any, *jsonRPCError)
+
+	mu          sync.Mutex
+	openDocs    map[string]int // uri → currently-open count
+	maxOpen     int            // peak simultaneous open docs
+	totalOpen   int
+	totalClose  int
+	notifLog    []string
+	outMu       sync.Mutex // serialises concurrent response writes
+}
+
+func newInstrumentedServer() *instrumentedServer {
+	return &instrumentedServer{
+		handlers: make(map[string]func(json.RawMessage) (any, *jsonRPCError)),
+		openDocs: make(map[string]int),
+	}
+}
+
+func (s *instrumentedServer) handle(method string, fn func(params json.RawMessage) (any, *jsonRPCError)) {
+	s.handlers[method] = fn
+}
+
+func (s *instrumentedServer) stats() (peak, opens, closes int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.maxOpen, s.totalOpen, s.totalClose
+}
+
+func (s *instrumentedServer) notifications() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.notifLog))
+	copy(out, s.notifLog)
+	return out
+}
+
+func (s *instrumentedServer) recordOpen(uri string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.openDocs[uri]++
+	s.totalOpen++
+	cur := 0
+	for _, n := range s.openDocs {
+		cur += n
+	}
+	if cur > s.maxOpen {
+		s.maxOpen = cur
+	}
+}
+
+func (s *instrumentedServer) recordClose(uri string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.openDocs[uri] > 0 {
+		s.openDocs[uri]--
+	}
+	s.totalClose++
+}
+
+// run consumes framed JSON-RPC messages, tracking didOpen/didClose, and
+// dispatches requests to registered handlers.
+func (s *instrumentedServer) run(in *bufio.Reader, out io.Writer) {
+	for {
+		body, ok := readFramed(in)
+		if !ok {
+			return
+		}
+		var probe struct {
+			Method string `json:"method"`
+			ID     *int64 `json:"id,omitempty"`
+		}
+		if err := json.Unmarshal(body, &probe); err != nil {
+			continue
+		}
+
+		if probe.ID == nil {
+			// Notification — track open/close lifecycle.
+			s.mu.Lock()
+			s.notifLog = append(s.notifLog, probe.Method)
+			s.mu.Unlock()
+			switch probe.Method {
+			case "textDocument/didOpen":
+				var p struct {
+					TextDocument struct {
+						URI string `json:"uri"`
+					} `json:"textDocument"`
+				}
+				var wrap struct {
+					Params json.RawMessage `json:"params"`
+				}
+				_ = json.Unmarshal(body, &wrap)
+				if json.Unmarshal(wrap.Params, &p) == nil {
+					s.recordOpen(p.TextDocument.URI)
+				}
+			case "textDocument/didClose":
+				var p struct {
+					TextDocument struct {
+						URI string `json:"uri"`
+					} `json:"textDocument"`
+				}
+				var wrap struct {
+					Params json.RawMessage `json:"params"`
+				}
+				_ = json.Unmarshal(body, &wrap)
+				if json.Unmarshal(wrap.Params, &p) == nil {
+					s.recordClose(p.TextDocument.URI)
+				}
+			}
+			continue
+		}
+
+		var req struct {
+			ID     int64           `json:"id"`
+			Method string          `json:"method"`
+			Params json.RawMessage `json:"params"`
+		}
+		if err := json.Unmarshal(body, &req); err != nil {
+			continue
+		}
+		// Dispatch each request in its own goroutine — a real language
+		// server services hover requests concurrently, which is what lets
+		// the concurrency-bound assertions observe genuine overlap.
+		go func(req struct {
+			ID     int64           `json:"id"`
+			Method string          `json:"method"`
+			Params json.RawMessage `json:"params"`
+		}) {
+			resp := jsonRPCResponse{JSONRPC: "2.0", ID: req.ID}
+			if h, ok := s.handlers[req.Method]; ok {
+				result, errResp := h(req.Params)
+				if errResp != nil {
+					resp.Error = errResp
+				} else if result != nil {
+					raw, err := json.Marshal(result)
+					if err != nil {
+						resp.Error = &jsonRPCError{Code: -32603, Message: "marshal: " + err.Error()}
+					} else {
+						resp.Result = raw
+					}
+				}
+			} else {
+				resp.Result = json.RawMessage("null")
+			}
+			data, err := json.Marshal(resp)
+			if err != nil {
+				return
+			}
+			s.outMu.Lock()
+			_, _ = fmt.Fprintf(out, "Content-Length: %d\r\n\r\n", len(data))
+			_, _ = out.Write(data)
+			s.outMu.Unlock()
+		}(req)
+	}
+}
+
+// providerWithInstrumentedServer wires a Provider to a running instrumented
+// server. maxParallel is honored (0 → default 10).
+func providerWithInstrumentedServer(t *testing.T, server *instrumentedServer, languages []string, maxParallel int) (*Provider, func()) {
+	t.Helper()
+	c, serverIn, serverOut, cleanup := newPipedClient(t)
+	go server.run(serverIn, serverOut)
+	p := NewProvider("fake-lsp", nil, languages, false, maxParallel, zap.NewNop())
+	p.client = c
+	return p, cleanup
+}
+
+// writeManyGoNodes writes a single .go file and seeds n function nodes into g,
+// returning the repo root.
+func seedRepo(t *testing.T, n int) (string, graph.Store) {
+	t.Helper()
+	repoRoot := t.TempDir()
+	var sb strings.Builder
+	sb.WriteString("package main\n\n")
+	g := graph.New()
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("F%d", i)
+		sb.WriteString(fmt.Sprintf("func %s() {}\n", name))
+		g.AddNode(&graph.Node{
+			ID: "main.go::" + name, Kind: graph.KindFunction, Name: name,
+			FilePath: "main.go", StartLine: 3 + i, EndLine: 3 + i, Language: "go",
+		})
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "main.go"), []byte(sb.String()), 0o644))
+	return repoRoot, g
+}
+
+func runEnrich(t *testing.T, p *Provider, g graph.Store, repoRoot string, timeout time.Duration) error {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() {
+		_, err := p.Enrich(g, repoRoot)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(timeout):
+		t.Fatal("Enrich timed out")
+		return nil
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Issue 1 — concurrency bound: at most maxParallel goroutines run at once.
+// ---------------------------------------------------------------------------
+
+func TestLSP_Enrich_ConcurrencyBounded(t *testing.T) {
+	repoRoot, g := seedRepo(t, 50)
+
+	var inFlight atomic.Int64
+	var peak atomic.Int64
+	server := newInstrumentedServer()
+	server.handle("textDocument/hover", func(params json.RawMessage) (any, *jsonRPCError) {
+		cur := inFlight.Add(1)
+		for {
+			old := peak.Load()
+			if cur <= old || peak.CompareAndSwap(old, cur) {
+				break
+			}
+		}
+		time.Sleep(5 * time.Millisecond) // hold the slot so overlap is observable
+		inFlight.Add(-1)
+		return map[string]any{"contents": map[string]any{"kind": "plaintext", "value": "func F()"}}, nil
+	})
+
+	const maxParallel = 4
+	p, cleanup := providerWithInstrumentedServer(t, server, []string{"go"}, maxParallel)
+	defer cleanup()
+
+	require.NoError(t, runEnrich(t, p, g, repoRoot, 10*time.Second))
+
+	assert.LessOrEqual(t, int(peak.Load()), maxParallel,
+		"peak concurrent hovers (%d) must not exceed maxParallel (%d)", peak.Load(), maxParallel)
+	assert.Greater(t, int(peak.Load()), 1, "expected some concurrency, got serial execution")
+}
+
+// ---------------------------------------------------------------------------
+// Issue 2 — per-goroutine doc lifecycle: every didOpen is paired with a
+// didClose, and at most maxParallel docs are open at once.
+// ---------------------------------------------------------------------------
+
+func TestLSP_Enrich_DocLifecyclePairedAndBounded(t *testing.T) {
+	repoRoot := t.TempDir()
+	// Many distinct files so each node opens its own document.
+	g := graph.New()
+	const nFiles = 20
+	for i := 0; i < nFiles; i++ {
+		fn := fmt.Sprintf("f%d.go", i)
+		require.NoError(t, os.WriteFile(
+			filepath.Join(repoRoot, fn),
+			[]byte("package main\n\nfunc F() {}\n"),
+			0o644,
+		))
+		g.AddNode(&graph.Node{
+			ID: fn + "::F", Kind: graph.KindFunction, Name: "F",
+			FilePath: fn, StartLine: 3, EndLine: 3, Language: "go",
+		})
+	}
+
+	server := newInstrumentedServer()
+	server.handle("textDocument/hover", func(params json.RawMessage) (any, *jsonRPCError) {
+		time.Sleep(2 * time.Millisecond)
+		return map[string]any{"contents": map[string]any{"kind": "plaintext", "value": "func F()"}}, nil
+	})
+
+	const maxParallel = 5
+	p, cleanup := providerWithInstrumentedServer(t, server, []string{"go"}, maxParallel)
+	defer cleanup()
+
+	require.NoError(t, runEnrich(t, p, g, repoRoot, 10*time.Second))
+
+	peak, opens, closes := server.stats()
+	assert.Equal(t, opens, closes, "every didOpen must be matched by a didClose (opens=%d closes=%d)", opens, closes)
+	assert.Equal(t, nFiles, opens, "expected one didOpen per distinct file")
+	assert.LessOrEqual(t, peak, maxParallel,
+		"peak simultaneously-open docs (%d) must not exceed maxParallel (%d)", peak, maxParallel)
+}
+
+// didClose must happen even when hover fails.
+func TestLSP_Enrich_DocClosedEvenOnHoverError(t *testing.T) {
+	repoRoot := t.TempDir()
+	g := graph.New()
+	const nFiles = 8
+	for i := 0; i < nFiles; i++ {
+		fn := fmt.Sprintf("f%d.go", i)
+		require.NoError(t, os.WriteFile(
+			filepath.Join(repoRoot, fn),
+			[]byte("package main\n\nfunc F() {}\n"),
+			0o644,
+		))
+		g.AddNode(&graph.Node{
+			ID: fn + "::F", Kind: graph.KindFunction, Name: "F",
+			FilePath: fn, StartLine: 3, EndLine: 3, Language: "go",
+		})
+	}
+
+	server := newInstrumentedServer()
+	server.handle("textDocument/hover", func(params json.RawMessage) (any, *jsonRPCError) {
+		// Every hover fails — but NOT a server-exit error, so no reconnect.
+		return nil, &jsonRPCError{Code: -32603, Message: "internal error"}
+	})
+
+	p, cleanup := providerWithInstrumentedServer(t, server, []string{"go"}, 4)
+	defer cleanup()
+
+	require.NoError(t, runEnrich(t, p, g, repoRoot, 10*time.Second))
+
+	_, opens, closes := server.stats()
+	assert.Equal(t, opens, closes, "didClose must fire even when hover errors (opens=%d closes=%d)", opens, closes)
+	assert.Equal(t, nFiles, closes, "each opened doc must be closed")
+}
+
+// ---------------------------------------------------------------------------
+// Issue 3 — reconnect with backoff on server exit.
+// ---------------------------------------------------------------------------
+
+// TestLSP_Enrich_ReconnectsOnServerExit drives one goroutine into a
+// "LSP server exited" error, then verifies the provider reconnects (via the
+// connectOnce seam) and the enrichment completes without error.
+func TestLSP_Enrich_ReconnectsOnServerExit(t *testing.T) {
+	repoRoot, g := seedRepo(t, 12)
+
+	// First server: after the 3rd hover, it "dies" (we close its client's
+	// done channel from the handler), so subsequent Call()s return
+	// "LSP server exited".
+	server1 := newInstrumentedServer()
+	var hoverCount atomic.Int64
+	var killOnce sync.Once
+
+	p, cleanup := providerWithInstrumentedServer(t, server1, []string{"go"}, 3)
+	defer cleanup()
+	deadClient := p.client
+
+	server1.handle("textDocument/hover", func(params json.RawMessage) (any, *jsonRPCError) {
+		n := hoverCount.Add(1)
+		if n == 3 {
+			// Simulate the server process dying: close the client's done
+			// channel so all in-flight + future Call()s observe exit.
+			killOnce.Do(func() {
+				deadClient.mu.Lock()
+				if !deadClient.closed {
+					deadClient.closed = true
+					close(deadClient.done)
+				}
+				deadClient.mu.Unlock()
+			})
+			return nil, &jsonRPCError{Code: -32603, Message: "dying"}
+		}
+		return map[string]any{"contents": map[string]any{"kind": "plaintext", "value": "func F()"}}, nil
+	})
+
+	// Wire the reconnect seam: build a fresh in-memory client backed by a
+	// healthy second server.
+	server2 := newInstrumentedServer()
+	server2.handle("textDocument/hover", func(params json.RawMessage) (any, *jsonRPCError) {
+		return map[string]any{"contents": map[string]any{"kind": "plaintext", "value": "func F()"}}, nil
+	})
+	var reconnects atomic.Int64
+	p.connectOnce = func(absRoot string) error {
+		reconnects.Add(1)
+		c2, in2, out2, cl2 := newPipedClient(t)
+		go server2.run(in2, out2)
+		t.Cleanup(cl2)
+		p.client = c2
+		return nil
+	}
+	// Pin backoff small so the test is fast.
+	p.dialBackoffStart = 1 * time.Millisecond
+	p.maxDialBackoff = 5 * time.Millisecond
+
+	require.NoError(t, runEnrich(t, p, g, repoRoot, 15*time.Second))
+
+	assert.GreaterOrEqual(t, int(reconnects.Load()), 1, "expected at least one reconnect on server exit")
+}
+
+// TestLSP_Enrich_SingleReconnectUnderConcurrency verifies that when many
+// goroutines observe server-exit simultaneously, only ONE reconnection is
+// performed (others wait and retry).
+func TestLSP_Enrich_SingleReconnectUnderConcurrency(t *testing.T) {
+	repoRoot, g := seedRepo(t, 40)
+
+	server1 := newInstrumentedServer()
+	p, cleanup := providerWithInstrumentedServer(t, server1, []string{"go"}, 10)
+	defer cleanup()
+	deadClient := p.client
+
+	var killOnce sync.Once
+	server1.handle("textDocument/hover", func(params json.RawMessage) (any, *jsonRPCError) {
+		// Kill the server on the very first hover so a burst of concurrent
+		// goroutines all observe the exit together.
+		killOnce.Do(func() {
+			deadClient.mu.Lock()
+			if !deadClient.closed {
+				deadClient.closed = true
+				close(deadClient.done)
+			}
+			deadClient.mu.Unlock()
+		})
+		return nil, &jsonRPCError{Code: -32603, Message: "dying"}
+	})
+
+	server2 := newInstrumentedServer()
+	server2.handle("textDocument/hover", func(params json.RawMessage) (any, *jsonRPCError) {
+		return map[string]any{"contents": map[string]any{"kind": "plaintext", "value": "func F()"}}, nil
+	})
+	var reconnects atomic.Int64
+	var mu sync.Mutex
+	p.connectOnce = func(absRoot string) error {
+		reconnects.Add(1)
+		mu.Lock()
+		c2, in2, out2, cl2 := newPipedClient(t)
+		go server2.run(in2, out2)
+		t.Cleanup(cl2)
+		p.client = c2
+		mu.Unlock()
+		return nil
+	}
+	p.dialBackoffStart = 1 * time.Millisecond
+	p.maxDialBackoff = 5 * time.Millisecond
+
+	require.NoError(t, runEnrich(t, p, g, repoRoot, 15*time.Second))
+
+	// Exactly one reconnect even though up to 10 goroutines saw the exit.
+	assert.Equal(t, int64(1), reconnects.Load(),
+		"only one reconnection should occur even under concurrent server-exit detection")
+}
+
+// TestLSP_Enrich_AbortsWhenReconnectFails verifies that a permanently-dead
+// server causes Enrich to return an error after exhausting retries.
+func TestLSP_Enrich_AbortsWhenReconnectFails(t *testing.T) {
+	repoRoot, g := seedRepo(t, 6)
+
+	server1 := newInstrumentedServer()
+	p, cleanup := providerWithInstrumentedServer(t, server1, []string{"go"}, 2)
+	defer cleanup()
+	deadClient := p.client
+
+	var killOnce sync.Once
+	server1.handle("textDocument/hover", func(params json.RawMessage) (any, *jsonRPCError) {
+		killOnce.Do(func() {
+			deadClient.mu.Lock()
+			if !deadClient.closed {
+				deadClient.closed = true
+				close(deadClient.done)
+			}
+			deadClient.mu.Unlock()
+		})
+		return nil, &jsonRPCError{Code: -32603, Message: "dying"}
+	})
+
+	var attempts atomic.Int64
+	p.connectOnce = func(absRoot string) error {
+		attempts.Add(1)
+		return fmt.Errorf("dial refused")
+	}
+	p.dialBackoffStart = 1 * time.Millisecond
+	p.maxDialBackoff = 3 * time.Millisecond
+
+	err := runEnrich(t, p, g, repoRoot, 15*time.Second)
+	require.Error(t, err, "Enrich must return an error when reconnection fails permanently")
+	assert.GreaterOrEqual(t, int(attempts.Load()), 3, "must retry reconnect at least 3 times before giving up")
+}
+
+// ---------------------------------------------------------------------------
+// isServerExitError detection.
+// ---------------------------------------------------------------------------
+
+func TestLSP_IsServerExitError(t *testing.T) {
+	assert.True(t, isServerExitError(fmt.Errorf("LSP server exited")))
+	assert.True(t, isServerExitError(fmt.Errorf("write |1: broken pipe")))
+	assert.True(t, isServerExitError(fmt.Errorf("read tcp: connection reset by peer")))
+	assert.True(t, isServerExitError(fmt.Errorf("client is closed")))
+	assert.False(t, isServerExitError(nil))
+	assert.False(t, isServerExitError(&jsonRPCError{Code: -32603, Message: "internal error"}))
+}

--- a/internal/semantic/lsp/enrich_hardening_test.go
+++ b/internal/semantic/lsp/enrich_hardening_test.go
@@ -61,14 +61,6 @@ func (s *instrumentedServer) stats() (peak, opens, closes int) {
 	return s.maxOpen, s.totalOpen, s.totalClose
 }
 
-func (s *instrumentedServer) notifications() []string {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	out := make([]string, len(s.notifLog))
-	copy(out, s.notifLog)
-	return out
-}
-
 func (s *instrumentedServer) recordOpen(uri string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -209,7 +201,7 @@ func seedRepo(t *testing.T, n int) (string, graph.Store) {
 	g := graph.New()
 	for i := 0; i < n; i++ {
 		name := fmt.Sprintf("F%d", i)
-		sb.WriteString(fmt.Sprintf("func %s() {}\n", name))
+		fmt.Fprintf(&sb, "func %s() {}\n", name)
 		g.AddNode(&graph.Node{
 			ID: "main.go::" + name, Kind: graph.KindFunction, Name: name,
 			FilePath: "main.go", StartLine: 3 + i, EndLine: 3 + i, Language: "go",

--- a/internal/semantic/lsp/protocol.go
+++ b/internal/semantic/lsp/protocol.go
@@ -1,6 +1,9 @@
 package lsp
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // LSP protocol types — minimal subset needed for semantic enrichment.
 // Based on LSP 3.17.
@@ -257,8 +260,70 @@ type HoverParams struct {
 
 // HoverResult is the response for textDocument/hover.
 type HoverResult struct {
-	Contents MarkupContent `json:"contents"`
+	Contents HoverContents `json:"contents"`
 	Range    *Range        `json:"range,omitempty"`
+}
+
+// HoverContents handles the three LSP hover content formats:
+//   - MarkupContent (object with kind + value)
+//   - MarkedString (plain string or {language, value} object)
+//   - MarkedString[] (array of the above)
+//
+// jdtls returns an array, which caused "cannot unmarshal array into Go struct"
+// when Contents was typed as MarkupContent directly.
+type HoverContents struct {
+	Value string // the concatenated hover text
+}
+
+func (hc *HoverContents) UnmarshalJSON(data []byte) error {
+	// Try MarkupContent first (object with kind + value).
+	var mc MarkupContent
+	if err := json.Unmarshal(data, &mc); err == nil && mc.Value != "" {
+		hc.Value = mc.Value
+		return nil
+	}
+
+	// Try MarkedString[] (array).
+	var arr []json.RawMessage
+	if err := json.Unmarshal(data, &arr); err == nil {
+		var parts []string
+		for _, raw := range arr {
+			// Each element can be a string or a MarkedString object.
+			var s string
+			if json.Unmarshal(raw, &s) == nil {
+				parts = append(parts, s)
+				continue
+			}
+			var ms MarkedString
+			if json.Unmarshal(raw, &ms) == nil {
+				parts = append(parts, ms.Value)
+			}
+		}
+		hc.Value = strings.Join(parts, "\n")
+		return nil
+	}
+
+	// Try plain string (MarkedString without array).
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		hc.Value = s
+		return nil
+	}
+
+	// Fallback: single MarkedString object.
+	var ms MarkedString
+	if err := json.Unmarshal(data, &ms); err == nil {
+		hc.Value = ms.Value
+		return nil
+	}
+
+	return nil // empty/unrecognised — leave Value empty
+}
+
+// MarkedString represents a {language, value} object in hover content.
+type MarkedString struct {
+	Language string `json:"language"`
+	Value    string `json:"value"`
 }
 
 // MarkupContent represents hover content.

--- a/internal/semantic/lsp/protocol.go
+++ b/internal/semantic/lsp/protocol.go
@@ -14,6 +14,10 @@ type InitializeParams struct {
 	// servers that only understand rootUri keep working.
 	WorkspaceFolders []WorkspaceFolder  `json:"workspaceFolders,omitempty"`
 	Capabilities     ClientCapabilities `json:"capabilities"`
+	// InitializationOptions carries server-specific initialization
+	// parameters. For jdtls this includes Maven/Gradle import settings;
+	// for other servers it is nil/omitted.
+	InitializationOptions json.RawMessage `json:"initializationOptions,omitempty"`
 }
 
 // WorkspaceFolder is one root in a multi-folder LSP workspace.

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -91,6 +92,29 @@ type Provider struct {
 	// attempts. Doubles on each failure (capped at maxDialBackoff)
 	// and resets to dialBackoffStart on the first success.
 	dialBackoff time.Duration
+
+	// dialBackoffStart / maxDialBackoff are the per-instance bounds for
+	// the reconnect-with-backoff loop (Enrich hover recovery). They
+	// default to the package consts of the same name; tests pin them to
+	// tiny values to keep recovery fast. dialOrSpawn keeps using the
+	// package consts directly — only the mid-flight reconnect path reads
+	// these fields.
+	dialBackoffStart time.Duration
+	maxDialBackoff   time.Duration
+
+	// reconnectMu serialises mid-flight reconnection attempts so that
+	// when many enrichment goroutines observe "LSP server exited" at the
+	// same instant, exactly one of them rebuilds the client while the
+	// others wait and then retry their hover against the fresh session.
+	reconnectMu sync.Mutex
+	// reconnectAttempts counts how many reconnect *cycles* ran across the
+	// whole Enrich pass. Surfaced in the final metrics log.
+	reconnectAttempts atomic.Int64
+
+	// connectOnce establishes a fresh client connection (one attempt, no
+	// backoff). Defaults to ensureClient. Injected in tests to swap in an
+	// in-memory piped client instead of spawning a subprocess.
+	connectOnce func(absRoot string) error
 }
 
 // Dial-retry constants for passive-attach reconnect. The window
@@ -108,17 +132,19 @@ func NewProvider(command string, args []string, languages []string, daemon bool,
 		maxParallel = 10
 	}
 	return &Provider{
-		command:     command,
-		args:        args,
-		languages:   languages,
-		daemon:      daemon,
-		maxParallel: maxParallel,
-		logger:      logger,
-		docVersions: map[string]int{},
-		openDocs:    map[string]bool{},
-		lastDiag:    map[string][]Diagnostic{},
-		diagWaiters: map[string][]chan []Diagnostic{},
-		dynamicCaps: map[string]Registration{},
+		command:          command,
+		args:             args,
+		languages:        languages,
+		daemon:           daemon,
+		maxParallel:      maxParallel,
+		logger:           logger,
+		docVersions:      map[string]int{},
+		openDocs:         map[string]bool{},
+		lastDiag:         map[string][]Diagnostic{},
+		diagWaiters:      map[string][]chan []Diagnostic{},
+		dynamicCaps:      map[string]Registration{},
+		dialBackoffStart: dialBackoffStart,
+		maxDialBackoff:   maxDialBackoff,
 	}
 }
 
@@ -154,10 +180,12 @@ func NewProviderFromSpec(spec *ServerSpec, logger *zap.Logger) *Provider {
 		docVersions: map[string]int{},
 		openDocs:    map[string]bool{},
 		lastDiag:    map[string][]Diagnostic{},
-		diagWaiters: map[string][]chan []Diagnostic{},
-		dynamicCaps: map[string]Registration{},
-		connect:     spec.Connect,
-		dialBackoff: dialBackoffStart,
+		diagWaiters:      map[string][]chan []Diagnostic{},
+		dynamicCaps:      map[string]Registration{},
+		connect:          spec.Connect,
+		dialBackoff:      dialBackoffStart,
+		dialBackoffStart: dialBackoffStart,
+		maxDialBackoff:   maxDialBackoff,
 	}
 	return p
 }
@@ -189,6 +217,15 @@ func (p *Provider) Enrich(g graph.Store, repoRoot string) (*semantic.EnrichResul
 	if err := p.ensureClient(absRoot); err != nil {
 		return nil, fmt.Errorf("start LSP server: %w", err)
 	}
+
+	// Default the reconnect seam to the real ensureClient unless a test
+	// injected its own (in-memory piped client). Set once per pass.
+	if p.connectOnce == nil {
+		p.connectOnce = p.ensureClient
+	}
+	// Reset the cross-pass reconnect counter so the metrics log reflects
+	// only this Enrich invocation.
+	p.reconnectAttempts.Store(0)
 
 	result := &semantic.EnrichResult{
 		Provider: p.Name(),
@@ -235,38 +272,15 @@ func (p *Provider) Enrich(g graph.Store, repoRoot string) (*semantic.EnrichResul
 		}
 	}
 
-	// Open documents for files that have targets. Track absolute
-	// paths so the matching closeDocument calls below release the
-	// LSP server's per-file state — without the cleanup, every
-	// Enrich pass on a large repo grows the server's didOpen set
-	// monotonically until the subprocess is restarted.
-	openedFiles := make(map[string]bool)
-	openedAbs := make(map[string]bool)
-	for _, t := range targets {
-		if !openedFiles[t.node.FilePath] {
-			if err := p.openDocument(absRoot, t.node.FilePath); err != nil {
-				p.logger.Debug("LSP: failed to open document",
-					zap.String("file", t.node.FilePath),
-					zap.Error(err),
-				)
-				continue
-			}
-			openedFiles[t.node.FilePath] = true
-			openedAbs[filepath.Join(absRoot, t.node.FilePath)] = true
-		}
-	}
-	defer func() {
-		for abs := range openedAbs {
-			if err := p.closeDocument(abs); err != nil {
-				p.logger.Debug("LSP: failed to close document",
-					zap.String("file", abs),
-					zap.Error(err),
-				)
-			}
-		}
-	}()
-
-	// Query hover info for nodes to enrich metadata.
+	// Per-goroutine document lifecycle + bounded concurrency (spec
+	// docs/spec-lsp-enrichment-hardening.md, Issues 1 & 2). The previous
+	// implementation bulk-opened every target file up front and closed
+	// them all in one deferred sweep after a fully sequential hover loop —
+	// at peak that pinned tens of thousands of documents open in the
+	// language server and OOM-killed it. Now each node is handled by its
+	// own goroutine that opens its file, hovers, and closes it
+	// immediately; a semaphore caps both the goroutine count and the
+	// simultaneously-open documents at maxParallel.
 	enrichedNodes := make(map[string]bool)
 	// EnrichNodeMeta mutates Node.Meta in place; on disk backends n is a
 	// per-call AllNodes reconstruction, so collect stamped nodes and
@@ -274,14 +288,92 @@ func (p *Provider) Enrich(g graph.Store, repoRoot string) (*semantic.EnrichResul
 	// stamp is discarded on the disk backend. See semantic.EnrichNodeMeta.
 	var stampedNodes []*graph.Node
 
-	// DIAGNOSTIC counters for debugging enrichment=0
-	var diagTotalNodes, diagHoverErr, diagHoverNil, diagTypeEmpty, diagEnriched int
-	var diagFirstHoverValue string
-	var diagFirstHoverError string
-	var diagFirstNodeName string
-	var diagFirstNodeFile string
+	// Race-safe metric counters for the concurrent hover phase.
+	var diagTotalNodes, diagHoverOK, diagHoverErr, diagHoverNil, diagTypeEmpty, diagEnriched atomic.Int64
+
+	// mu guards the cross-goroutine aggregation: stampedNodes,
+	// enrichedNodes, the EnrichResult counters, and the best-effort
+	// first-sample diagnostics below.
+	var mu sync.Mutex
+	var diagFirstHoverValue, diagFirstHoverError, diagFirstNodeName, diagFirstNodeFile string
+
+	// activeClient is the client the hover goroutines currently target.
+	// reconnectWithBackoff swaps it (under reconnectMu) when the server
+	// dies mid-flight; goroutines load it atomically so the swap never
+	// races an in-flight hover.
+	var activeClient atomic.Pointer[Client]
+	activeClient.Store(p.client)
+
+	// Abort coordination: if reconnection fails permanently, the first
+	// goroutine to learn it records the error and flips aborted; the rest
+	// stop early and Enrich returns that error.
+	var aborted atomic.Bool
+	var abortErr error
+	var abortOnce sync.Once
+
+	// reconnect serialises mid-flight recovery so that when a burst of
+	// goroutines observe the same dead client only the first rebuilds it;
+	// the others wait on reconnectMu and then reuse the fresh client.
+	reconnect := func(stale *Client) (*Client, error) {
+		p.reconnectMu.Lock()
+		defer p.reconnectMu.Unlock()
+		if aborted.Load() {
+			return nil, abortErr
+		}
+		if cur := activeClient.Load(); cur != stale {
+			return cur, nil // someone else already reconnected
+		}
+		newC, err := p.reconnectWithBackoff(absRoot)
+		if err != nil {
+			abortOnce.Do(func() {
+				abortErr = err
+				aborted.Store(true)
+			})
+			return nil, err
+		}
+		activeClient.Store(newC)
+		return newC, nil
+	}
+
+	// Open-document reference counting: several nodes can live in one
+	// file, but the server must still see exactly one didOpen / didClose
+	// per file (TestLSP_Provider_OpensEachFileOnce). The first node into a
+	// file opens it; the last one out closes it. Peak open files therefore
+	// stays bounded by the number of distinct files in flight, itself
+	// bounded by the semaphore at maxParallel.
+	openRefs := map[string]int{}
+	var openMu sync.Mutex
+	acquireDoc := func(c *Client, absPath string, content []byte) error {
+		openMu.Lock()
+		defer openMu.Unlock()
+		if openRefs[absPath] == 0 {
+			if err := p.enrichOpenDoc(c, absPath, content); err != nil {
+				return err
+			}
+		}
+		openRefs[absPath]++
+		return nil
+	}
+	releaseDoc := func(c *Client, absPath string) {
+		openMu.Lock()
+		openRefs[absPath]--
+		last := openRefs[absPath] <= 0
+		if last {
+			delete(openRefs, absPath)
+		}
+		openMu.Unlock()
+		if last {
+			_ = p.enrichCloseDoc(c, absPath)
+		}
+	}
+
+	sem := make(chan struct{}, p.maxParallel)
+	var wg sync.WaitGroup
 
 	for _, n := range g.AllNodes() {
+		if aborted.Load() {
+			break
+		}
 		if n.Kind == graph.KindFile || n.Kind == graph.KindImport {
 			continue
 		}
@@ -296,70 +388,113 @@ func (p *Provider) Enrich(g graph.Store, repoRoot string) (*semantic.EnrichResul
 			continue
 		}
 
-		diagTotalNodes++
+		diagTotalNodes.Add(1)
+		wg.Add(1)
+		sem <- struct{}{} // acquire — bounds concurrency AND open docs
+		go func(n *graph.Node) {
+			defer func() {
+				<-sem
+				wg.Done()
+			}()
+			if aborted.Load() {
+				return
+			}
 
-		if !openedFiles[n.FilePath] {
-			if err := p.openDocument(absRoot, n.FilePath); err != nil {
-				if diagTotalNodes <= 5 {
-					p.logger.Debug("ENRICH-DBG: openDocument failed",
-						zap.String("file", n.FilePath),
-						zap.Error(err),
-					)
+			absPath := filepath.Join(absRoot, n.FilePath)
+			content, err := os.ReadFile(absPath)
+			if err != nil {
+				p.logger.Debug("LSP enrich: read source failed",
+					zap.String("file", n.FilePath), zap.Error(err))
+				return
+			}
+
+			c := activeClient.Load()
+			if err := acquireDoc(c, absPath, content); err != nil {
+				p.logger.Debug("LSP enrich: didOpen failed",
+					zap.String("file", n.FilePath), zap.Error(err))
+				return
+			}
+			// Release (and close on the last node out) always, even on
+			// hover error (acceptance criterion 2). Use the current client
+			// so a post-reconnect close lands on the live session.
+			defer releaseDoc(activeClient.Load(), absPath)
+
+			col := identifierColumn(content, n.StartLine, n.Name)
+			hoverResult, err := p.hoverWith(c, absRoot, n.FilePath, n.StartLine-1, col)
+			if err != nil && isServerExitError(err) {
+				// Server died mid-flight — recover once and retry this
+				// node's hover against the fresh session.
+				newC, rerr := reconnect(c)
+				if rerr != nil {
+					return // aborted; wg.Wait + abort check below handles it
 				}
-				continue
+				c = newC
+				hoverResult, err = p.hoverWith(c, absRoot, n.FilePath, n.StartLine-1, col)
 			}
-			openedFiles[n.FilePath] = true
-			openedAbs[filepath.Join(absRoot, n.FilePath)] = true
-		}
+			if err != nil {
+				diagHoverErr.Add(1)
+				mu.Lock()
+				if diagFirstHoverError == "" {
+					diagFirstHoverError = err.Error()
+					diagFirstNodeName = n.Name
+					diagFirstNodeFile = n.FilePath
+				}
+				mu.Unlock()
+				return
+			}
+			if hoverResult == nil {
+				diagHoverNil.Add(1)
+				return
+			}
+			diagHoverOK.Add(1)
 
-		col := identifierColumn(p.getSource(absRoot, n.FilePath), n.StartLine, n.Name)
-		hoverResult, err := p.hover(absRoot, n.FilePath, n.StartLine-1, col)
-		if err != nil {
-			diagHoverErr++
-			if diagFirstHoverError == "" {
-				diagFirstHoverError = err.Error()
-				diagFirstNodeName = n.Name
-				diagFirstNodeFile = n.FilePath
+			typeInfo := extractTypeFromHover(hoverResult.Contents.Value)
+			mu.Lock()
+			if diagFirstHoverValue == "" {
+				diagFirstHoverValue = hoverResult.Contents.Value
+				if len(diagFirstHoverValue) > 200 {
+					diagFirstHoverValue = diagFirstHoverValue[:200]
+				}
 			}
-			continue
-		}
-		if hoverResult == nil {
-			diagHoverNil++
-			continue
-		}
+			mu.Unlock()
+			if typeInfo == "" {
+				diagTypeEmpty.Add(1)
+				return
+			}
 
-		typeInfo := extractTypeFromHover(hoverResult.Contents.Value)
-		if diagFirstHoverValue == "" {
-			diagFirstHoverValue = hoverResult.Contents.Value
-			if len(diagFirstHoverValue) > 200 {
-				diagFirstHoverValue = diagFirstHoverValue[:200]
-			}
-		}
-		if typeInfo != "" {
 			semantic.EnrichNodeMeta(n, "semantic_type", typeInfo, p.Name())
+			diagEnriched.Add(1)
+			mu.Lock()
 			stampedNodes = append(stampedNodes, n)
 			if !enrichedNodes[n.ID] {
 				result.NodesEnriched++
 				result.SymbolsCovered++
 				enrichedNodes[n.ID] = true
 			}
-			diagEnriched++
-		} else {
-			diagTypeEmpty++
-		}
+			mu.Unlock()
+		}(n)
 	}
-	// DIAGNOSTIC: log enrichment counters
-	p.logger.Info("ENRICH-DBG: hover loop complete",
-		zap.Int("total_nodes", diagTotalNodes),
-		zap.Int("hover_err", diagHoverErr),
-		zap.Int("hover_nil", diagHoverNil),
-		zap.Int("type_empty", diagTypeEmpty),
-		zap.Int("enriched", diagEnriched),
+	wg.Wait()
+
+	// Enrichment metrics (acceptance criterion 6).
+	p.logger.Info("LSP enrich: hover phase complete",
+		zap.Int64("total_nodes", diagTotalNodes.Load()),
+		zap.Int64("hover_ok", diagHoverOK.Load()),
+		zap.Int64("hover_err", diagHoverErr.Load()),
+		zap.Int64("hover_nil", diagHoverNil.Load()),
+		zap.Int64("type_empty", diagTypeEmpty.Load()),
+		zap.Int64("enriched", diagEnriched.Load()),
+		zap.Int64("reconnect_attempts", p.reconnectAttempts.Load()),
 		zap.String("first_hover_value", diagFirstHoverValue),
 		zap.String("first_hover_error", diagFirstHoverError),
 		zap.String("first_node_name", diagFirstNodeName),
 		zap.String("first_node_file", diagFirstNodeFile),
 	)
+
+	if aborted.Load() {
+		return result, fmt.Errorf("LSP enrichment aborted: %w", abortErr)
+	}
+
 	if len(stampedNodes) > 0 {
 		g.AddBatch(stampedNodes, nil)
 	}
@@ -380,8 +515,14 @@ func (p *Provider) Enrich(g graph.Store, repoRoot string) (*semantic.EnrichResul
 			continue
 		}
 
+		// Per-item doc lifecycle (no bulk pre-open): open this interface's
+		// file, query, close immediately so memory stays bounded.
+		if err := p.openDocument(absRoot, n.FilePath); err != nil {
+			continue
+		}
 		col := identifierColumn(p.getSource(absRoot, n.FilePath), n.StartLine, n.Name)
 		impls, err := p.findImplementations(absRoot, n.FilePath, n.StartLine-1, col)
+		_ = p.closeDocument(filepath.Join(absRoot, n.FilePath))
 		if err != nil || len(impls) == 0 {
 			continue
 		}
@@ -430,8 +571,14 @@ func (p *Provider) Enrich(g graph.Store, repoRoot string) (*semantic.EnrichResul
 			continue
 		}
 
+		// Per-item doc lifecycle (no bulk pre-open): open the referent's
+		// file, query, close immediately so memory stays bounded.
+		if err := p.openDocument(absRoot, toNode.FilePath); err != nil {
+			continue
+		}
 		col := identifierColumn(p.getSource(absRoot, toNode.FilePath), toNode.StartLine, toNode.Name)
 		refs, err := p.findReferences(absRoot, toNode.FilePath, toNode.StartLine-1, col)
+		_ = p.closeDocument(filepath.Join(absRoot, toNode.FilePath))
 		if err != nil || len(refs) == 0 {
 			continue
 		}
@@ -997,6 +1144,16 @@ func (p *Provider) getSource(repoRoot, relPath string) []byte {
 
 // hover queries hover info for a position.
 func (p *Provider) hover(repoRoot, relPath string, line, col int) (*HoverResult, error) {
+	return p.hoverWith(p.client, repoRoot, relPath, line, col)
+}
+
+// hoverWith issues textDocument/hover against an explicit client.
+// PURPOSE — race-free per-goroutine hover during concurrent enrichment.
+// RATIONALE — enrichment goroutines pass the client they captured
+// atomically, so a concurrent reconnect that swaps p.client never races
+// an in-flight hover (the goroutine holds its own pointer value).
+// KEYWORDS — lsp, hover, concurrency, reconnect
+func (p *Provider) hoverWith(c *Client, repoRoot, relPath string, line, col int) (*HoverResult, error) {
 	absPath := filepath.Join(repoRoot, relPath)
 	params := HoverParams{
 		TextDocumentPositionParams: TextDocumentPositionParams{
@@ -1006,13 +1163,113 @@ func (p *Provider) hover(repoRoot, relPath string, line, col int) (*HoverResult,
 	}
 
 	var result HoverResult
-	if err := p.client.Call("textDocument/hover", params, &result); err != nil {
+	if err := c.Call("textDocument/hover", params, &result); err != nil {
 		return nil, err
 	}
 	if result.Contents.Value == "" {
 		return nil, nil
 	}
 	return &result, nil
+}
+
+// enrichOpenDoc sends a bare textDocument/didOpen against an explicit
+// client without touching the shared openDocs / sourceCache tables.
+// PURPOSE — per-goroutine document open for the concurrent hover phase.
+// RATIONALE — each enrichment goroutine owns its document's lifecycle, so
+// it must not contend on the provider-wide doc maps; the matching close
+// is enrichCloseDoc, always deferred.
+// KEYWORDS — lsp, didOpen, enrichment, per-goroutine
+func (p *Provider) enrichOpenDoc(c *Client, absPath string, content []byte) error {
+	return c.Notify("textDocument/didOpen", DidOpenTextDocumentParams{
+		TextDocument: TextDocumentItem{
+			URI:        pathToURI(absPath),
+			LanguageID: p.languageIDFor(absPath),
+			Version:    1,
+			Text:       string(content),
+		},
+	})
+}
+
+// enrichCloseDoc sends a bare textDocument/didClose against an explicit
+// client — the counterpart to enrichOpenDoc.
+// PURPOSE — release the server's per-document state immediately after a
+// node's hover so simultaneously-open docs stay capped at maxParallel.
+// RATIONALE — bulk-holding documents open was the enrichment OOM root
+// cause; closing eagerly per goroutine bounds heap pressure.
+// KEYWORDS — lsp, didClose, enrichment, lifecycle
+func (p *Provider) enrichCloseDoc(c *Client, absPath string) error {
+	return c.Notify("textDocument/didClose", DidCloseTextDocumentParams{
+		TextDocument: TextDocumentIdentifier{URI: pathToURI(absPath)},
+	})
+}
+
+// isServerExitError reports whether err signals that the language server
+// process / transport is gone, so the enrichment loop should reconnect
+// rather than keep hammering a dead session.
+// PURPOSE — classify hover errors into "server died" vs "ordinary".
+// RATIONALE — only transport/exit failures warrant a reconnect; protocol
+// errors (e.g. an internal-error JSON-RPC reply) must not.
+// KEYWORDS — lsp, reconnect, server-exit, error-classification
+func isServerExitError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	for _, marker := range []string{
+		"LSP server exited",
+		"client is closed",
+		"broken pipe",
+		"connection reset",
+		"use of closed network connection",
+	} {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// reconnectWithBackoff rebuilds the LSP client after the server exits
+// mid-enrichment. It retries connectOnce with exponential backoff
+// (dialBackoffStart → maxDialBackoff) up to maxReconnectAttempts and
+// returns the fresh client, or an error if every attempt failed.
+// PURPOSE — automatic recovery so one mid-flight crash doesn't fail every
+// remaining hover.
+// RATIONALE — callers hold reconnectMu, so exactly one reconnection runs
+// at a time; backoff prevents a tight retry loop against a persistently
+// dead server.
+// KEYWORDS — lsp, reconnect, backoff, recovery
+func (p *Provider) reconnectWithBackoff(absRoot string) (*Client, error) {
+	const maxReconnectAttempts = 5
+	backoff := p.dialBackoffStart
+	if backoff <= 0 {
+		backoff = dialBackoffStart
+	}
+	maxBackoff := p.maxDialBackoff
+	if maxBackoff <= 0 {
+		maxBackoff = maxDialBackoff
+	}
+	var lastErr error
+	for attempt := 1; attempt <= maxReconnectAttempts; attempt++ {
+		p.reconnectAttempts.Add(1)
+		p.logger.Warn("LSP enrich: reconnecting after server exit",
+			zap.Int("attempt", attempt),
+			zap.Int("max_attempts", maxReconnectAttempts),
+		)
+		if err := p.connectOnce(absRoot); err != nil {
+			lastErr = err
+			p.logger.Warn("LSP enrich: reconnect attempt failed",
+				zap.Int("attempt", attempt), zap.Error(err))
+			time.Sleep(backoff)
+			if backoff *= 2; backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+			continue
+		}
+		p.logger.Info("LSP enrich: reconnected", zap.Int("attempt", attempt))
+		return p.client, nil
+	}
+	return nil, fmt.Errorf("LSP reconnect failed after %d attempts: %w", maxReconnectAttempts, lastErr)
 }
 
 // findImplementations queries textDocument/implementation.

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -273,6 +273,14 @@ func (p *Provider) Enrich(g graph.Store, repoRoot string) (*semantic.EnrichResul
 	// round-trip them through the store at the end or the semantic_type
 	// stamp is discarded on the disk backend. See semantic.EnrichNodeMeta.
 	var stampedNodes []*graph.Node
+
+	// DIAGNOSTIC counters for debugging enrichment=0
+	var diagTotalNodes, diagHoverErr, diagHoverNil, diagTypeEmpty, diagEnriched int
+	var diagFirstHoverValue string
+	var diagFirstHoverError string
+	var diagFirstNodeName string
+	var diagFirstNodeFile string
+
 	for _, n := range g.AllNodes() {
 		if n.Kind == graph.KindFile || n.Kind == graph.KindImport {
 			continue
@@ -288,8 +296,16 @@ func (p *Provider) Enrich(g graph.Store, repoRoot string) (*semantic.EnrichResul
 			continue
 		}
 
+		diagTotalNodes++
+
 		if !openedFiles[n.FilePath] {
 			if err := p.openDocument(absRoot, n.FilePath); err != nil {
+				if diagTotalNodes <= 5 {
+					p.logger.Debug("ENRICH-DBG: openDocument failed",
+						zap.String("file", n.FilePath),
+						zap.Error(err),
+					)
+				}
 				continue
 			}
 			openedFiles[n.FilePath] = true
@@ -298,11 +314,27 @@ func (p *Provider) Enrich(g graph.Store, repoRoot string) (*semantic.EnrichResul
 
 		col := identifierColumn(p.getSource(absRoot, n.FilePath), n.StartLine, n.Name)
 		hoverResult, err := p.hover(absRoot, n.FilePath, n.StartLine-1, col)
-		if err != nil || hoverResult == nil {
+		if err != nil {
+			diagHoverErr++
+			if diagFirstHoverError == "" {
+				diagFirstHoverError = err.Error()
+				diagFirstNodeName = n.Name
+				diagFirstNodeFile = n.FilePath
+			}
+			continue
+		}
+		if hoverResult == nil {
+			diagHoverNil++
 			continue
 		}
 
 		typeInfo := extractTypeFromHover(hoverResult.Contents.Value)
+		if diagFirstHoverValue == "" {
+			diagFirstHoverValue = hoverResult.Contents.Value
+			if len(diagFirstHoverValue) > 200 {
+				diagFirstHoverValue = diagFirstHoverValue[:200]
+			}
+		}
 		if typeInfo != "" {
 			semantic.EnrichNodeMeta(n, "semantic_type", typeInfo, p.Name())
 			stampedNodes = append(stampedNodes, n)
@@ -311,8 +343,23 @@ func (p *Provider) Enrich(g graph.Store, repoRoot string) (*semantic.EnrichResul
 				result.SymbolsCovered++
 				enrichedNodes[n.ID] = true
 			}
+			diagEnriched++
+		} else {
+			diagTypeEmpty++
 		}
 	}
+	// DIAGNOSTIC: log enrichment counters
+	p.logger.Info("ENRICH-DBG: hover loop complete",
+		zap.Int("total_nodes", diagTotalNodes),
+		zap.Int("hover_err", diagHoverErr),
+		zap.Int("hover_nil", diagHoverNil),
+		zap.Int("type_empty", diagTypeEmpty),
+		zap.Int("enriched", diagEnriched),
+		zap.String("first_hover_value", diagFirstHoverValue),
+		zap.String("first_hover_error", diagFirstHoverError),
+		zap.String("first_node_name", diagFirstNodeName),
+		zap.String("first_node_file", diagFirstNodeFile),
+	)
 	if len(stampedNodes) > 0 {
 		g.AddBatch(stampedNodes, nil)
 	}

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -1160,11 +1160,6 @@ func (p *Provider) getSource(repoRoot, relPath string) []byte {
 	return p.sourceCache[filepath.Join(repoRoot, relPath)]
 }
 
-// hover queries hover info for a position.
-func (p *Provider) hover(repoRoot, relPath string, line, col int) (*HoverResult, error) {
-	return p.hoverWith(p.client, repoRoot, relPath, line, col)
-}
-
 // hoverWith issues textDocument/hover against an explicit client.
 // PURPOSE — race-free per-goroutine hover during concurrent enrichment.
 // RATIONALE — enrichment goroutines pass the client they captured

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -335,31 +335,40 @@ func (p *Provider) Enrich(g graph.Store, repoRoot string) (*semantic.EnrichResul
 		return newC, nil
 	}
 
-	// Open-document reference counting: several nodes can live in one
-	// file, but the server must still see exactly one didOpen / didClose
-	// per file (TestLSP_Provider_OpensEachFileOnce). The first node into a
-	// file opens it; the last one out closes it. Peak open files therefore
-	// stays bounded by the number of distinct files in flight, itself
-	// bounded by the semaphore at maxParallel.
-	openRefs := map[string]int{}
+	// Open-document reference counting, keyed by (client, file): several
+	// nodes can live in one file, but each client must see exactly one
+	// didOpen / didClose per file (TestLSP_Provider_OpensEachFileOnce).
+	// Keying by client is what makes reconnection strict — a reconnect's
+	// fresh client starts with an empty open-set, so the first node to
+	// touch a file after recovery re-opens it on the new session instead
+	// of hovering against a document the dead session held. Peak open
+	// files stays bounded by the distinct files in flight, itself bounded
+	// by the semaphore at maxParallel.
+	type enrichDocKey struct {
+		c    *Client
+		path string
+	}
+	openRefs := map[enrichDocKey]int{}
 	var openMu sync.Mutex
 	acquireDoc := func(c *Client, absPath string, content []byte) error {
+		key := enrichDocKey{c: c, path: absPath}
 		openMu.Lock()
 		defer openMu.Unlock()
-		if openRefs[absPath] == 0 {
+		if openRefs[key] == 0 {
 			if err := p.enrichOpenDoc(c, absPath, content); err != nil {
 				return err
 			}
 		}
-		openRefs[absPath]++
+		openRefs[key]++
 		return nil
 	}
 	releaseDoc := func(c *Client, absPath string) {
+		key := enrichDocKey{c: c, path: absPath}
 		openMu.Lock()
-		openRefs[absPath]--
-		last := openRefs[absPath] <= 0
+		openRefs[key]--
+		last := openRefs[key] <= 0
 		if last {
-			delete(openRefs, absPath)
+			delete(openRefs, key)
 		}
 		openMu.Unlock()
 		if last {
@@ -415,20 +424,29 @@ func (p *Provider) Enrich(g graph.Store, repoRoot string) (*semantic.EnrichResul
 				return
 			}
 			// Release (and close on the last node out) always, even on
-			// hover error (acceptance criterion 2). Use the current client
-			// so a post-reconnect close lands on the live session.
-			defer releaseDoc(activeClient.Load(), absPath)
+			// hover error (acceptance criterion 2). Bound to the client we
+			// opened on — args are captured here, so a later reconnect that
+			// reassigns c does not redirect this close to the wrong session.
+			defer releaseDoc(c, absPath)
 
 			col := identifierColumn(content, n.StartLine, n.Name)
 			hoverResult, err := p.hoverWith(c, absRoot, n.FilePath, n.StartLine-1, col)
 			if err != nil && isServerExitError(err) {
 				// Server died mid-flight — recover once and retry this
-				// node's hover against the fresh session.
+				// node's hover against the fresh session. The new client
+				// has no record of our document, so re-open it there (and
+				// close it on the way out) before retrying.
 				newC, rerr := reconnect(c)
 				if rerr != nil {
 					return // aborted; wg.Wait + abort check below handles it
 				}
 				c = newC
+				if err := acquireDoc(c, absPath, content); err != nil {
+					p.logger.Debug("LSP enrich: reopen after reconnect failed",
+						zap.String("file", n.FilePath), zap.Error(err))
+					return
+				}
+				defer releaseDoc(c, absPath)
 				hoverResult, err = p.hoverWith(c, absRoot, n.FilePath, n.StartLine-1, col)
 			}
 			if err != nil {

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -662,6 +662,11 @@ func (p *Provider) ensureClient(workspaceRoot string) error {
 			},
 		},
 	}
+	// Pass server-specific InitializationOptions (e.g. Maven/Gradle import
+	// settings for jdtls) when the provider was built from a ServerSpec.
+	if p.spec != nil && len(p.spec.InitializationOptions) > 0 {
+		initParams.InitializationOptions = p.spec.InitializationOptions
+	}
 
 	var initResult InitializeResult
 	if err := client.Call("initialize", initParams, &initResult); err != nil {
@@ -1537,6 +1542,7 @@ func identifierColumn(src []byte, oneBasedLine int, name string) int {
 func extractTypeFromHover(hover string) string {
 	// Remove markdown code fences.
 	hover = strings.TrimPrefix(hover, "```go\n")
+	hover = strings.TrimPrefix(hover, "```java\n")
 	hover = strings.TrimPrefix(hover, "```\n")
 	hover = strings.TrimSuffix(hover, "\n```")
 	hover = strings.TrimSpace(hover)
@@ -1544,6 +1550,7 @@ func extractTypeFromHover(hover string) string {
 	lines := strings.SplitN(hover, "\n", 2)
 	if len(lines) > 0 {
 		line := strings.TrimSpace(lines[0])
+		// Go keywords
 		if strings.HasPrefix(line, "func ") ||
 			strings.HasPrefix(line, "type ") ||
 			strings.HasPrefix(line, "var ") ||
@@ -1552,7 +1559,24 @@ func extractTypeFromHover(hover string) string {
 			strings.HasPrefix(line, "package ") {
 			return line
 		}
-		// Short type like "string", "*Foo", "[]byte".
+		// Java keywords / modifiers — jdtls hover format:
+		//   "public class Foo", "void bar()", "private String baz",
+		//   "abstract class X", "interface Y", "@Deprecated",
+		//   "static final int N", "enum Color", "protected Object"
+		if strings.HasPrefix(line, "public ") ||
+			strings.HasPrefix(line, "private ") ||
+			strings.HasPrefix(line, "protected ") ||
+			strings.HasPrefix(line, "abstract ") ||
+			strings.HasPrefix(line, "static ") ||
+			strings.HasPrefix(line, "final ") ||
+			strings.HasPrefix(line, "class ") ||
+			strings.HasPrefix(line, "interface ") ||
+			strings.HasPrefix(line, "enum ") ||
+			strings.HasPrefix(line, "void ") ||
+			strings.HasPrefix(line, "@") {
+			return line
+		}
+		// Short type like "string", "*Foo", "[]byte", "int", "boolean".
 		if !strings.Contains(line, " ") && len(line) > 0 && len(line) < 100 {
 			return line
 		}

--- a/internal/semantic/lsp/provider_test.go
+++ b/internal/semantic/lsp/provider_test.go
@@ -136,8 +136,8 @@ func TestLSP_Provider_EnrichesNodeMetaFromHover(t *testing.T) {
 
 	server := newFakeLSPServer()
 	server.handle("textDocument/hover", func(params json.RawMessage) (any, *jsonRPCError) {
-		return HoverResult{
-			Contents: MarkupContent{Kind: "plaintext", Value: "func F() string"},
+		return map[string]any{
+			"contents": map[string]any{"kind": "plaintext", "value": "func F() string"},
 		}, nil
 	})
 
@@ -489,7 +489,7 @@ func TestLSP_Provider_EnrichSurvivesHoverFailures(t *testing.T) {
 		if hoverCalls == 1 {
 			return nil, &jsonRPCError{Code: -32603, Message: "internal error"}
 		}
-		return HoverResult{Contents: MarkupContent{Kind: "plaintext", Value: "func G()"}}, nil
+		return map[string]any{"contents": map[string]any{"kind": "plaintext", "value": "func G()"}}, nil
 	})
 
 	p, cleanup := providerWithFakeServer(t, server, []string{"go"})

--- a/internal/semantic/lsp/registry.go
+++ b/internal/semantic/lsp/registry.go
@@ -1,6 +1,7 @@
 package lsp
 
 import (
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -56,6 +57,13 @@ type ServerSpec struct {
 	// every built-in spec; populated only when a user overrides a
 	// server via .gortex.yaml (e.g. pinning JAVA_HOME for jdtls).
 	Env []string
+	// InitializationOptions carries server-specific initialization
+	// parameters sent in the "initialize" request. For jdtls this
+	// includes Maven/Gradle import settings so the server can resolve
+	// project dependencies instead of falling back to an "invisible
+	// project" with only JRE on the classpath. Nil/empty for servers
+	// that don't need it (gopls, rust-analyzer, etc.).
+	InitializationOptions json.RawMessage `json:"initializationOptions,omitempty"`
 	// Connect, when non-nil, switches this spec from spawn mode to
 	// passive-attach: instead of starting a subprocess via Command +
 	// Args, Gortex dials the configured network endpoint and uses
@@ -280,6 +288,23 @@ var Servers = []ServerSpec{
 		Priority:    6, // jdtls is heavyweight; lower priority than scip-java.
 		Daemon:      true,
 		MaxParallel: 6,
+		// InitializationOptions for jdtls: enable Maven/Gradle import
+		// so jdtls resolves project dependencies instead of falling
+		// back to an "invisible project" with only JRE on classpath.
+		// Without this, hover/codeSelect returns empty for all symbols.
+		InitializationOptions: json.RawMessage(`{
+			"settings": {
+				"java": {
+					"import": {
+						"maven": {"enabled": true},
+						"gradle": {"enabled": true}
+					},
+					"autobuild": {"enabled": true}
+				}
+			},
+			"bundles": [],
+			"workspaceFolders": "auto"
+		}`),
 	},
 	{
 		Name:       "kotlin-language-server",

--- a/internal/serverstack/shared_server.go
+++ b/internal/serverstack/shared_server.go
@@ -246,6 +246,7 @@ func NewSharedServer(cfg SharedServerConfig) (*SharedServer, error) {
 	// spec whose binary resolves on PATH (per-spec / GORTEX_LSP_DISABLE
 	// opt-out). All lifecycles get this (reconciles the prior mcp-only
 	// drift where the embedded path skipped auto-registration).
+	var semMgr *semantic.Manager
 	if conf.Semantic.Enabled {
 		semCfg := semantic.Config{
 			Enabled:           conf.Semantic.Enabled,
@@ -275,7 +276,7 @@ func NewSharedServer(cfg SharedServerConfig) (*SharedServer, error) {
 			}
 			semCfg.Providers = append(semCfg.Providers, out)
 		}
-		semMgr := semantic.NewManager(semCfg, logger)
+		semMgr = semantic.NewManager(semCfg, logger)
 
 		goMode := goanalysis.ModeTypeCheck
 		if cfg.SemanticMode == "callgraph" {
@@ -402,6 +403,13 @@ func NewSharedServer(cfg SharedServerConfig) (*SharedServer, error) {
 			mi.SetEmbeddingChunkOptions(EmbeddingChunkOptions(conf))
 			mi.SetEmbeddingMaxSymbols(conf.Embedding.MaxSymbols)
 			mi.SetEmbeddingAPIConcurrency(conf.Embedding.APIConcurrency)
+		}
+		// Propagate the semantic manager so per-repo Indexers
+		// created by the MultiIndexer can run LSP enrichment.
+		// Without this, daemon-mode enrichment produces zero
+		// results (enrich:0 in DEFERRED-TIMING).
+		if semMgr != nil {
+			mi.SetSemanticManager(semMgr)
 		}
 		if s.ResolverLSPRegistry != nil {
 			mi.SetResolverLSPHelper(s.ResolverLSPRegistry)


### PR DESCRIPTION
> **Depends on / stacked on #99.** This branch is built on top of `pr/lsp-jdtls-enrichment`, so until #99 merges this PR's diff also shows #99's three commits. Once #99 lands in `main`, GitHub will collapse this down to just the two hardening commits. Please review/merge #99 first.

Hardens the LSP hover-enrichment pass so it scales to large repos without OOM-killing the language server or stalling on a mid-flight crash. Three fixes, applied in this order:

## Issue 2 — per-document lifecycle (the OOM root cause)
The old pass bulk-opened every target file up front and closed them all in one deferred sweep after a fully sequential hover loop — at peak that pinned tens of thousands of documents open in the server (Java heap OOM). Now each node opens its file, hovers, and closes it immediately. Opens are reference-counted by `(client, file)`, so each file still gets exactly one `didOpen`/`didClose` per session, and `didClose` always fires — even on hover error. The implementations/references phases also open/close per item, so the bulk pre-open is gone entirely.

## Issue 1 — bounded concurrency
A `maxParallel` semaphore + `WaitGroup` bounds both the goroutine count and the number of simultaneously-open documents. Shared counters are atomic; result aggregation is mutex-guarded.

## Issue 3 — reconnect with backoff on server exit
When the server exits mid-pass, `reconnectWithBackoff` rebuilds the client (exponential backoff `dialBackoffStart → maxDialBackoff`, up to 5 attempts). Goroutines read the client via `atomic.Pointer` and coordinate through `reconnectMu`, so exactly one reconnection runs per server-exit while the rest wait and retry. After recovery the document is re-opened on the fresh session (a reconnect's new client starts with an empty open-set) before the retry hover. Permanent failure aborts the pass with an error. `isServerExitError` classifies transport/exit failures so ordinary protocol errors don't trigger a reconnect.

The final metrics log gains `hover_ok` and `reconnect_attempts`.

## Tests
`enrich_hardening_test.go` covers: concurrency bound, `didOpen`/`didClose` pairing (incl. on hover error), reconnect on server exit, single-reconnect under concurrent detection, re-open on the fresh server after reconnect, abort on permanent failure, and `isServerExitError`. All pass under `-race`. `go build ./...`, `go vet`, and the indexer suite pass (the inotify-bound watcher/poller tests are environment-limited, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)