### PR TITLE
harden: gate jdtls build execution + clamp temporal-verify source reads

### DIFF
--- a/internal/analyzer/temporal_verify.go
+++ b/internal/analyzer/temporal_verify.go
@@ -110,16 +110,43 @@ func (p *FileSourceProvider) fileBody(rel string) (string, bool) {
 	if b, ok := p.cache[rel]; ok {
 		return b, b != ""
 	}
-	raw, err := os.ReadFile(filepath.Join(p.root, rel))
+	abs, ok := p.resolveWithinRoot(rel)
+	if !ok {
+		p.cache[rel] = ""
+		return "", false
+	}
+	raw, err := os.ReadFile(abs)
 	if err != nil {
-		// Fall back to treating the recorded path as already-absolute.
-		if raw, err = os.ReadFile(rel); err != nil {
-			p.cache[rel] = ""
-			return "", false
-		}
+		p.cache[rel] = ""
+		return "", false
 	}
 	p.cache[rel] = string(raw)
 	return string(raw), true
+}
+
+// resolveWithinRoot resolves rel — relative to p.root, or absolute — and
+// confirms the result stays inside p.root. A node FilePath that escapes the
+// indexed tree (via "..", or an absolute path elsewhere) is refused, so a
+// crafted graph node can't make the verifier read arbitrary files off disk and
+// ship them to the LLM. An empty root refuses everything (nothing to bound to).
+func (p *FileSourceProvider) resolveWithinRoot(rel string) (string, bool) {
+	if p.root == "" || rel == "" {
+		return "", false
+	}
+	rootAbs, err := filepath.Abs(p.root)
+	if err != nil {
+		return "", false
+	}
+	cand := rel
+	if !filepath.IsAbs(cand) {
+		cand = filepath.Join(rootAbs, cand)
+	}
+	cand = filepath.Clean(cand)
+	relToRoot, err := filepath.Rel(rootAbs, cand)
+	if err != nil || relToRoot == ".." || strings.HasPrefix(relToRoot, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return cand, true
 }
 
 // --- LLM verifier ----------------------------------------------------------

--- a/internal/analyzer/temporal_verify_test.go
+++ b/internal/analyzer/temporal_verify_test.go
@@ -40,9 +40,9 @@ func TestParseTemporalVerdict(t *testing.T) {
 		{`{"verdict":"rejected","reason":"wrong target"}`, resolver.TemporalVerdictRejected},
 		{`{"verdict":"uncertain"}`, resolver.TemporalVerdictUncertain},
 		{`CONFIRMED is my answer: {"verdict":"CONFIRMED"}`, resolver.TemporalVerdictConfirmed}, // prose-wrapped + case
-		{"```json\n{\"verdict\":\"rejected\"}\n```", resolver.TemporalVerdictRejected},          // fenced
-		{`not json at all`, resolver.TemporalVerdictUncertain},                                  // unparseable → uncertain
-		{`{"verdict":"banana"}`, resolver.TemporalVerdictUncertain},                             // unknown → uncertain
+		{"```json\n{\"verdict\":\"rejected\"}\n```", resolver.TemporalVerdictRejected},         // fenced
+		{`not json at all`, resolver.TemporalVerdictUncertain},                                 // unparseable → uncertain
+		{`{"verdict":"banana"}`, resolver.TemporalVerdictUncertain},                            // unknown → uncertain
 	}
 	for _, c := range cases {
 		got := parseTemporalVerdict(c.raw)
@@ -108,4 +108,27 @@ func TestCachingVerifier_HitsCacheAndPersists(t *testing.T) {
 	r3, _ := c2.Verify(context.Background(), req)
 	assert.Equal(t, resolver.TemporalVerdictConfirmed, r3.Verdict, "loaded from disk, not the new delegate")
 	assert.Equal(t, 0, inner2.calls)
+}
+
+func TestFileSourceProvider_RefusesPathEscape(t *testing.T) {
+	dir := t.TempDir()
+	// A secret file OUTSIDE the indexed root.
+	outside := filepath.Join(filepath.Dir(dir), "secret.txt")
+	require.NoError(t, os.WriteFile(outside, []byte("TOPSECRET"), 0o644))
+	t.Cleanup(func() { _ = os.Remove(outside) })
+
+	p := NewFileSourceProvider(dir)
+
+	// Relative traversal via "..".
+	_, ok := p.NodeSource(&graph.Node{FilePath: "../secret.txt", StartLine: 1, EndLine: 1})
+	assert.False(t, ok, "must refuse a ../ escape out of the indexed root")
+
+	// Absolute path outside the root.
+	_, ok = p.NodeSource(&graph.Node{FilePath: outside, StartLine: 1, EndLine: 1})
+	assert.False(t, ok, "must refuse an absolute path outside the indexed root")
+
+	// A legit relative path inside the root still resolves.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "in.go"), []byte("package p"), 0o644))
+	_, ok = p.NodeSource(&graph.Node{FilePath: "in.go", StartLine: 1, EndLine: 1})
+	assert.True(t, ok, "a path inside the root must still resolve")
 }

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -169,17 +169,17 @@ func NewProviderFromSpec(spec *ServerSpec, logger *zap.Logger) *Provider {
 		maxParallel = 10
 	}
 	p := &Provider{
-		command:     cmd,
-		args:        args,
-		env:         spec.Env,
-		languages:   spec.Languages,
-		daemon:      spec.Daemon,
-		maxParallel: maxParallel,
-		logger:      logger,
-		spec:        spec,
-		docVersions: map[string]int{},
-		openDocs:    map[string]bool{},
-		lastDiag:    map[string][]Diagnostic{},
+		command:          cmd,
+		args:             args,
+		env:              spec.Env,
+		languages:        spec.Languages,
+		daemon:           spec.Daemon,
+		maxParallel:      maxParallel,
+		logger:           logger,
+		spec:             spec,
+		docVersions:      map[string]int{},
+		openDocs:         map[string]bool{},
+		lastDiag:         map[string][]Diagnostic{},
 		diagWaiters:      map[string][]chan []Diagnostic{},
 		dynamicCaps:      map[string]Registration{},
 		connect:          spec.Connect,
@@ -876,8 +876,8 @@ func (p *Provider) ensureClient(workspaceRoot string) error {
 	}
 	// Pass server-specific InitializationOptions (e.g. Maven/Gradle import
 	// settings for jdtls) when the provider was built from a ServerSpec.
-	if p.spec != nil && len(p.spec.InitializationOptions) > 0 {
-		initParams.InitializationOptions = p.spec.InitializationOptions
+	if opts := effectiveInitializationOptions(p.spec); len(opts) > 0 {
+		initParams.InitializationOptions = opts
 	}
 
 	var initResult InitializeResult

--- a/internal/semantic/lsp/registry.go
+++ b/internal/semantic/lsp/registry.go
@@ -3,6 +3,7 @@ package lsp
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -132,6 +133,71 @@ type ServerAlt struct {
 // Adding a new server: add the entry here and add its file extensions
 // to extToSpec at init time. The default config picks it up
 // automatically; users override priority / command via .gortex.yaml.
+// JdtlsTrustBuildEnv, when set to a truthy value ("1" / "true"), opts jdtls
+// into build-backed resolution (Maven/Gradle import + autobuild) for the
+// indexed repository. OFF by default: import and autobuild RUN the indexed
+// project's own build — Gradle build scripts execute during import, autobuild
+// compiles the sources — which is code execution from the indexed repo. Only
+// enable it for repositories you trust.
+const JdtlsTrustBuildEnv = "GORTEX_LSP_JDTLS_TRUST_BUILD"
+
+// jdtlsSafeInitOptions keeps jdtls in a no-build mode: JRE-only classpath, with
+// Maven/Gradle import and autobuild DISABLED. Resolution is more limited (jdtls
+// falls back to an "invisible project"), but indexing an untrusted Java repo
+// never executes its build. The default; opt into the build variant via
+// JdtlsTrustBuildEnv.
+const jdtlsSafeInitOptions = `{
+	"settings": {
+		"java": {
+			"import": {
+				"maven": {"enabled": false},
+				"gradle": {"enabled": false}
+			},
+			"autobuild": {"enabled": false}
+		}
+	},
+	"bundles": [],
+	"workspaceFolders": "auto"
+}`
+
+// jdtlsBuildInitOptions enables Maven/Gradle import + autobuild so jdtls
+// resolves real project dependencies. WARNING: import and autobuild execute the
+// indexed project's build (arbitrary code for Gradle). Sent only when the
+// operator has explicitly trusted the indexed repo via JdtlsTrustBuildEnv.
+const jdtlsBuildInitOptions = `{
+	"settings": {
+		"java": {
+			"import": {
+				"maven": {"enabled": true},
+				"gradle": {"enabled": true}
+			},
+			"autobuild": {"enabled": true}
+		}
+	},
+	"bundles": [],
+	"workspaceFolders": "auto"
+}`
+
+// effectiveInitializationOptions returns the InitializationOptions to send for
+// spec. jdtls is upgraded from its safe (no-build) defaults to build-backed
+// options ONLY when the operator opted in via JdtlsTrustBuildEnv; every other
+// server gets its spec options unchanged.
+func effectiveInitializationOptions(spec *ServerSpec) json.RawMessage {
+	if spec == nil {
+		return nil
+	}
+	if spec.Command == "jdtls" && envTruthy(JdtlsTrustBuildEnv) {
+		return json.RawMessage(jdtlsBuildInitOptions)
+	}
+	return spec.InitializationOptions
+}
+
+// envTruthy reports whether environment variable name is set to "1" or "true".
+func envTruthy(name string) bool {
+	v := strings.TrimSpace(os.Getenv(name))
+	return v == "1" || strings.EqualFold(v, "true")
+}
+
 var Servers = []ServerSpec{
 	{
 		Name:        "gopls",
@@ -288,23 +354,12 @@ var Servers = []ServerSpec{
 		Priority:    6, // jdtls is heavyweight; lower priority than scip-java.
 		Daemon:      true,
 		MaxParallel: 6,
-		// InitializationOptions for jdtls: enable Maven/Gradle import
-		// so jdtls resolves project dependencies instead of falling
-		// back to an "invisible project" with only JRE on classpath.
-		// Without this, hover/codeSelect returns empty for all symbols.
-		InitializationOptions: json.RawMessage(`{
-			"settings": {
-				"java": {
-					"import": {
-						"maven": {"enabled": true},
-						"gradle": {"enabled": true}
-					},
-					"autobuild": {"enabled": true}
-				}
-			},
-			"bundles": [],
-			"workspaceFolders": "auto"
-		}`),
+		// InitializationOptions for jdtls. SAFE BY DEFAULT (jdtlsSafeInitOptions):
+		// no Maven/Gradle import and no autobuild, so indexing an UNTRUSTED Java
+		// repo never runs its build. Build-backed resolution — which EXECUTES the
+		// repo's own build (Gradle scripts run on import; autobuild compiles) — is
+		// opt-in via GORTEX_LSP_JDTLS_TRUST_BUILD; see effectiveInitializationOptions.
+		InitializationOptions: json.RawMessage(jdtlsSafeInitOptions),
 	},
 	{
 		Name:       "kotlin-language-server",

--- a/internal/semantic/lsp/registry_build_gate_test.go
+++ b/internal/semantic/lsp/registry_build_gate_test.go
@@ -1,0 +1,36 @@
+package lsp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEffectiveInitializationOptions_JdtlsBuildGate(t *testing.T) {
+	spec := &ServerSpec{Command: "jdtls", InitializationOptions: json.RawMessage(jdtlsSafeInitOptions)}
+
+	// Default (gate unset): safe — no autobuild, no import.
+	t.Setenv(JdtlsTrustBuildEnv, "")
+	got := string(effectiveInitializationOptions(spec))
+	assert.Contains(t, got, `"autobuild": {"enabled": false}`)
+	assert.NotContains(t, got, `"autobuild": {"enabled": true}`)
+
+	// Opted-in: build-backed options.
+	t.Setenv(JdtlsTrustBuildEnv, "1")
+	got = string(effectiveInitializationOptions(spec))
+	assert.Contains(t, got, `"autobuild": {"enabled": true}`)
+	assert.Contains(t, got, `"gradle": {"enabled": true}`)
+
+	// Non-jdtls servers are never rewritten, even when the gate is on.
+	other := &ServerSpec{Command: "gopls", InitializationOptions: json.RawMessage(`{"x":1}`)}
+	assert.Equal(t, `{"x":1}`, string(effectiveInitializationOptions(other)))
+
+	// The shipped jdtls spec is safe by default.
+	for i := range Servers {
+		if Servers[i].Command == "jdtls" {
+			assert.Contains(t, string(Servers[i].InitializationOptions), `"autobuild": {"enabled": false}`,
+				"shipped jdtls spec must be no-build by default")
+		}
+	}
+}


### PR DESCRIPTION
Follow-up hardening from the temporal/LSP security review — two untrusted-repo safety fixes.

## (a) Gate jdtls Maven/Gradle build behind an explicit trust opt-in
The jdtls `InitializationOptions` enabled `maven`/`gradle` import + `autobuild`, which **execute the indexed project's own build** (Gradle build scripts run during import; autobuild compiles). Indexing an untrusted Java repo with semantic enrichment on was therefore a code-execution surface via the repo's build scripts.

- jdtls now ships **no-build by default** (`jdtlsSafeInitOptions` — import + autobuild disabled).
- Build-backed resolution is opt-in via **`GORTEX_LSP_JDTLS_TRUST_BUILD`** (`effectiveInitializationOptions`, resolved at connect time).
- Trade-off: default Java resolution is more limited (jdtls "invisible project"); enable the env var for repos you trust.

## (b) Clamp temporal-verify source reads to the indexed repo root
`FileSourceProvider` resolved a node's `FilePath` via `filepath.Join(root, rel)` with an absolute-path fallback and no bound — a crafted graph-node path could read files **outside** the indexed tree (`..` or an absolute path) and ship them to the LLM. `resolveWithinRoot` now refuses any path that escapes the root; the absolute fallback is removed. (The live MCP path already uses `resolveNodePath` and is unaffected.)

Tests: gate behavior (safe-by-default + opt-in + non-jdtls untouched + shipped spec is no-build) and path-escape refusal (`..` + absolute outside root, in-root still resolves). `go build ./...`, `go vet`, and `-race` across lsp/analyzer/resolver/mcp/indexer pass.

Context: no malicious code was found in the review — these close two legitimate-but-risky surfaces in the contributed temporal/LSP work.