### PR TITLE
Minimal MCP tool surface: presets, per-connection scoping, and find_files

### DIFF
--- a/cmd/gortex/daemon.go
+++ b/cmd/gortex/daemon.go
@@ -47,6 +47,8 @@ var (
 	daemonBackend               string
 	daemonBackendPath           string
 	daemonBackendBufferPoolMB   uint64
+	daemonTools                 string
+	daemonToolsMode             string
 )
 
 var daemonCmd = &cobra.Command{
@@ -115,6 +117,10 @@ func init() {
 		"path to the on-disk backend's store file (its parent directory is created if absent). Defaults to ~/.gortex/store/store.sqlite; ignored when --backend is memory")
 	daemonStartCmd.Flags().Uint64Var(&daemonBackendBufferPoolMB, "backend-buffer-pool-mb", 0,
 		"advisory page-cache cap (MiB) for on-disk backends. 0 reads $GORTEX_DAEMON_BUFFER_POOL_MB or lets the backend choose its own default; backends that manage their own cache (e.g. sqlite) ignore it")
+	daemonStartCmd.Flags().StringVar(&daemonTools, "tools", "",
+		"restrict the published MCP tool surface to a preset: full|readonly|edit|nav (optionally with ,+tool / ,-tool deltas). GORTEX_TOOLS overrides this")
+	daemonStartCmd.Flags().StringVar(&daemonToolsMode, "tools-mode", "",
+		"how a --tools preset hides tools: hide (remove from tools/list + block calls) or defer (keep reachable via tools_search). Default hide")
 	daemonLogsCmd.Flags().IntVarP(&daemonTail, "tail", "n", 50,
 		"show only the last N log lines")
 	daemonStatusCmd.Flags().BoolVarP(&daemonStatusWatch, "watch", "w", false,
@@ -648,7 +654,18 @@ func spawnDetachedDaemon() error {
 		return fmt.Errorf("open log file: %w", err)
 	}
 	child := exec.Command(exe, "daemon", "start")
-	child.Env = append(os.Environ(), "GORTEX_DAEMON_CHILD=1")
+	childEnv := append(os.Environ(), "GORTEX_DAEMON_CHILD=1")
+	// --detach re-execs `daemon start` with no flags, so the tool-preset
+	// selection must travel to the child via env (the GORTEX_TOOLS
+	// override path), mirroring how --embeddings propagates. Appended
+	// last so an explicit flag wins over any inherited GORTEX_TOOLS.
+	if daemonTools != "" {
+		childEnv = append(childEnv, "GORTEX_TOOLS="+daemonTools)
+	}
+	if daemonToolsMode != "" {
+		childEnv = append(childEnv, "GORTEX_TOOLS_MODE="+daemonToolsMode)
+	}
+	child.Env = childEnv
 	child.Stdout = logFile
 	child.Stderr = logFile
 	child.Stdin = nil

--- a/cmd/gortex/daemon_state.go
+++ b/cmd/gortex/daemon_state.go
@@ -121,6 +121,10 @@ func buildDaemonState(logger *zap.Logger) (*daemonState, error) {
 		return nil, fmt.Errorf("load config: %w", err)
 	}
 	gc, _ := config.LoadGlobal()
+	// Fold --tools / --tools-mode into mcp.tools (flag overrides config;
+	// GORTEX_TOOLS still overrides). Survives --detach because the
+	// re-exec'd child re-parses the same flags.
+	applyToolPresetFlags(cfg, daemonTools, daemonToolsMode)
 
 	ss, err := serverstack.NewSharedServer(serverstack.SharedServerConfig{
 		Lifecycle:    serverstack.LifecycleDaemon,

--- a/cmd/gortex/mcp.go
+++ b/cmd/gortex/mcp.go
@@ -42,6 +42,8 @@ var (
 	mcpSemanticMode    string
 	mcpNoDaemon        bool
 	mcpForceProxy      bool
+	mcpTools           string
+	mcpToolsMode       string
 )
 
 var mcpCmd = &cobra.Command{
@@ -72,6 +74,8 @@ func init() {
 	mcpCmd.Flags().StringVar(&mcpSemanticMode, "semantic-mode", "typecheck", "Go analysis mode: typecheck or callgraph")
 	mcpCmd.Flags().BoolVar(&mcpNoDaemon, "no-daemon", false, "deprecated no-op (warns when set); the embedded server is used automatically when no daemon is available")
 	mcpCmd.Flags().BoolVar(&mcpForceProxy, "proxy", false, "require a running daemon and proxy through it (error if unavailable)")
+	mcpCmd.Flags().StringVar(&mcpTools, "tools", "", "restrict the published MCP tool surface to a preset: full|readonly|edit|nav (optionally with ,+tool / ,-tool deltas). GORTEX_TOOLS overrides this")
+	mcpCmd.Flags().StringVar(&mcpToolsMode, "tools-mode", "", "how a --tools preset hides tools: hide (remove from tools/list + block calls) or defer (keep reachable via tools_search). Default hide")
 	rootCmd.AddCommand(mcpCmd)
 }
 
@@ -130,6 +134,9 @@ func runMCP(cmd *cobra.Command, args []string) error {
 	// Resolve the embedded semantic decision: --no-semantic forces off,
 	// --semantic forces on, otherwise semantic.enabled in config decides.
 	cfg.Semantic.Enabled = !mcpNoSemantic && (mcpSemantic || cfg.Semantic.Enabled)
+	// Fold --tools / --tools-mode into the mcp.tools config the server
+	// stack reads (flag overrides config; GORTEX_TOOLS still overrides).
+	applyToolPresetFlags(cfg, mcpTools, mcpToolsMode)
 
 	// Side-store layout for the embedded path: every store partitions
 	// per-repo under the indexed repo path, and the notebook is repo-local

--- a/cmd/gortex/mcp.go
+++ b/cmd/gortex/mcp.go
@@ -110,7 +110,7 @@ func runMCP(cmd *cobra.Command, args []string) error {
 	// presence + GORTEX_AUTOSTART, never by the flag.
 	switch resolveDaemonDecision() {
 	case daemonReady, daemonAutostarted:
-		ran, proxyErr := runProxy(cmd.Context())
+		ran, proxyErr := runProxy(cmd.Context(), proxyToolSurface())
 		if proxyErr != nil {
 			return proxyErr
 		}

--- a/cmd/gortex/proxy.go
+++ b/cmd/gortex/proxy.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/zzet/gortex/internal/daemon"
+	gortexmcp "github.com/zzet/gortex/internal/mcp"
 )
 
 // runProxy relays MCP JSON-RPC traffic between stdio (the MCP client) and
@@ -21,7 +22,7 @@ import (
 // Returns (true, nil) when the proxy ran and finished cleanly. Returns
 // (false, nil) when the daemon isn't reachable — the caller should fall
 // back to embedded mode. Any other error is a real problem.
-func runProxy(ctx context.Context) (ran bool, err error) {
+func runProxy(ctx context.Context, surface *gortexmcp.ToolSurface) (ran bool, err error) {
 	cwd, wdErr := resolveLaunchCWD()
 	if wdErr != nil {
 		return false, fmt.Errorf("cwd: %w", wdErr)
@@ -51,18 +52,29 @@ func runProxy(ctx context.Context) (ran bool, err error) {
 	// We run both on goroutines and exit when either side hits EOF.
 	errCh := make(chan error, 2)
 	var wg sync.WaitGroup
+	var outMu sync.Mutex // serialises the two writers into os.Stdout
 	wg.Add(2)
 
-	go func() {
-		defer wg.Done()
-		err := pumpLines(os.Stdin, client.Conn)
-		errCh <- err
-	}()
-	go func() {
-		defer wg.Done()
-		err := pumpLines(client.Conn, os.Stdout)
-		errCh <- err
-	}()
+	if surface.Active() {
+		fmt.Fprintf(os.Stderr, "[gortex mcp] tool surface restricted (preset %q)\n", surface.Preset())
+		go func() {
+			defer wg.Done()
+			errCh <- pumpRequestsFiltered(os.Stdin, client.Conn, os.Stdout, &outMu, surface)
+		}()
+		go func() {
+			defer wg.Done()
+			errCh <- pumpResponsesFiltered(client.Conn, os.Stdout, &outMu, surface)
+		}()
+	} else {
+		go func() {
+			defer wg.Done()
+			errCh <- pumpLines(os.Stdin, client.Conn)
+		}()
+		go func() {
+			defer wg.Done()
+			errCh <- pumpLines(client.Conn, os.Stdout)
+		}()
+	}
 
 	// Orphan watchdog: if our parent (the MCP client) dies, stdin EOF is the
 	// normal shutdown signal — but a client that is SIGKILLed, or whose stdin

--- a/cmd/gortex/proxy_filter.go
+++ b/cmd/gortex/proxy_filter.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"io"
+	"strconv"
+	"sync"
+
+	gortexmcp "github.com/zzet/gortex/internal/mcp"
+)
+
+// The stdio proxy relays newline-delimited JSON-RPC frames between the
+// MCP client (stdin/stdout) and the daemon socket. When a tool surface
+// is active (`gortex mcp --tools` / GORTEX_TOOLS), these helpers filter
+// the relayed traffic per connection — the daemon is never touched, so
+// one client can scope its own pipe while the daemon keeps serving the
+// full surface to everyone else. The filter runs from the first
+// tools/list, so it works on every client (no tools/list_changed needed).
+
+// toolPolicyConfigFromFlags builds a ToolPolicyConfig from the
+// --tools / --tools-mode flags. The config file is not consulted on the
+// proxy path (it governs the daemon); GORTEX_TOOLS / GORTEX_TOOLS_MODE
+// still override when NewToolSurface resolves it.
+func toolPolicyConfigFromFlags(flagTools, flagMode string) gortexmcp.ToolPolicyConfig {
+	var cfg gortexmcp.ToolPolicyConfig
+	if flagTools != "" {
+		preset, allow, deny := gortexmcp.ParseToolSpec(flagTools)
+		cfg.Preset, cfg.Allow, cfg.Deny = preset, allow, deny
+	}
+	cfg.Mode = flagMode
+	return cfg
+}
+
+// proxyToolSurface resolves the per-connection tool surface from the
+// --tools / --tools-mode flags plus the GORTEX_TOOLS env override. An
+// inactive surface (no flag, no env) leaves the proxy a raw byte pump.
+func proxyToolSurface() *gortexmcp.ToolSurface {
+	return gortexmcp.NewToolSurface(toolPolicyConfigFromFlags(mcpTools, mcpToolsMode), nil)
+}
+
+// gateToolCallFrame inspects one client→daemon frame. If it is a
+// tools/call request for a tool the surface forbids, it returns a
+// synthesized JSON-RPC error reply (to write back to the client) and
+// gated=true — the original frame must NOT reach the daemon, so a client
+// that hard-codes a hidden tool name cannot bypass the restriction.
+func gateToolCallFrame(line []byte, surface *gortexmcp.ToolSurface) (reply []byte, gated bool) {
+	if !surface.Active() {
+		return nil, false
+	}
+	var msg struct {
+		ID     json.RawMessage `json:"id"`
+		Method string          `json:"method"`
+		Params struct {
+			Name string `json:"name"`
+		} `json:"params"`
+	}
+	if err := json.Unmarshal(line, &msg); err != nil {
+		return nil, false // not a single JSON object — forward untouched
+	}
+	if msg.Method != "tools/call" || msg.Params.Name == "" || len(msg.ID) == 0 {
+		return nil, false
+	}
+	if surface.Allows(msg.Params.Name) {
+		return nil, false
+	}
+	out, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      msg.ID,
+		"error": map[string]any{
+			"code":    -32601,
+			"message": "tool " + strconv.Quote(msg.Params.Name) + " is not available in this client's tool set (gortex mcp --tools)",
+		},
+	})
+	if err != nil {
+		return nil, false
+	}
+	return append(out, '\n'), true
+}
+
+// filterToolsListFrame rewrites a daemon→client frame: if it is a
+// tools/list result, the tools array is filtered down to the surface.
+// Every other frame — and any frame that doesn't parse, or where nothing
+// is dropped — passes through verbatim.
+func filterToolsListFrame(line []byte, surface *gortexmcp.ToolSurface) []byte {
+	if !surface.Active() {
+		return line
+	}
+	var msg map[string]json.RawMessage
+	if err := json.Unmarshal(line, &msg); err != nil {
+		return line
+	}
+	resultRaw, ok := msg["result"]
+	if !ok {
+		return line
+	}
+	var result map[string]json.RawMessage
+	if err := json.Unmarshal(resultRaw, &result); err != nil {
+		return line
+	}
+	toolsRaw, ok := result["tools"]
+	if !ok {
+		return line
+	}
+	var tools []json.RawMessage
+	if err := json.Unmarshal(toolsRaw, &tools); err != nil {
+		return line
+	}
+	kept := make([]json.RawMessage, 0, len(tools))
+	for _, t := range tools {
+		var nameOnly struct {
+			Name string `json:"name"`
+		}
+		if err := json.Unmarshal(t, &nameOnly); err != nil || surface.Allows(nameOnly.Name) {
+			kept = append(kept, t)
+		}
+	}
+	if len(kept) == len(tools) {
+		return line // nothing dropped — preserve the original bytes
+	}
+	newTools, err := json.Marshal(kept)
+	if err != nil {
+		return line
+	}
+	result["tools"] = newTools
+	newResult, err := json.Marshal(result)
+	if err != nil {
+		return line
+	}
+	msg["result"] = newResult
+	out, err := json.Marshal(msg)
+	if err != nil {
+		return line
+	}
+	return append(out, '\n')
+}
+
+// pumpRequestsFiltered relays client→daemon frames, gating disallowed
+// tools/call frames with a synthesized error reply written to clientOut.
+func pumpRequestsFiltered(src io.Reader, daemonW, clientOut io.Writer, outMu *sync.Mutex, surface *gortexmcp.ToolSurface) error {
+	r := bufio.NewReaderSize(src, 1<<20)
+	for {
+		line, err := r.ReadBytes('\n')
+		if len(line) > 0 {
+			if reply, gated := gateToolCallFrame(line, surface); gated {
+				outMu.Lock()
+				_, werr := clientOut.Write(reply)
+				outMu.Unlock()
+				if werr != nil {
+					return werr
+				}
+			} else if _, werr := daemonW.Write(line); werr != nil {
+				return werr
+			}
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+	}
+}
+
+// pumpResponsesFiltered relays daemon→client frames, filtering tools/list
+// results down to the surface.
+func pumpResponsesFiltered(src io.Reader, clientOut io.Writer, outMu *sync.Mutex, surface *gortexmcp.ToolSurface) error {
+	r := bufio.NewReaderSize(src, 1<<20)
+	for {
+		line, err := r.ReadBytes('\n')
+		if len(line) > 0 {
+			out := filterToolsListFrame(line, surface)
+			outMu.Lock()
+			_, werr := clientOut.Write(out)
+			outMu.Unlock()
+			if werr != nil {
+				return werr
+			}
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+	}
+}

--- a/cmd/gortex/proxy_filter_test.go
+++ b/cmd/gortex/proxy_filter_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	gortexmcp "github.com/zzet/gortex/internal/mcp"
+)
+
+func editSurface(t *testing.T) *gortexmcp.ToolSurface {
+	t.Helper()
+	// Explicit allow list — exactly these tools (plus always-kept).
+	return gortexmcp.NewToolSurface(
+		gortexmcp.ToolPolicyConfig{Allow: []string{"search_symbols", "edit_file"}}, zap.NewNop())
+}
+
+func TestFilterToolsListFrame(t *testing.T) {
+	surface := editSurface(t)
+	require.True(t, surface.Active())
+
+	frame := []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[` +
+		`{"name":"search_symbols","description":"s"},` +
+		`{"name":"analyze","description":"a"},` +
+		`{"name":"edit_file","description":"e"},` +
+		`{"name":"tool_profile","description":"t"}],"nextCursor":"abc"}}` + "\n")
+
+	out := filterToolsListFrame(frame, surface)
+
+	var msg struct {
+		ID     int `json:"id"`
+		Result struct {
+			Tools []struct {
+				Name string `json:"name"`
+			} `json:"tools"`
+			NextCursor string `json:"nextCursor"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(out, &msg))
+
+	var names []string
+	for _, tl := range msg.Result.Tools {
+		names = append(names, tl.Name)
+	}
+	require.ElementsMatch(t, []string{"search_symbols", "edit_file", "tool_profile"}, names,
+		"analyze must be dropped; always-kept tool_profile must survive")
+	require.Equal(t, 1, msg.ID, "id preserved")
+	require.Equal(t, "abc", msg.Result.NextCursor, "other result fields preserved")
+}
+
+func TestFilterToolsListFrame_PassThrough(t *testing.T) {
+	surface := editSurface(t)
+
+	// A non-tools/list result (a tools/call result) is untouched.
+	callResult := []byte(`{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"x"}]}}` + "\n")
+	require.Equal(t, callResult, filterToolsListFrame(callResult, surface))
+
+	// An inactive surface never rewrites.
+	inactive := gortexmcp.NewToolSurface(gortexmcp.ToolPolicyConfig{}, zap.NewNop())
+	require.False(t, inactive.Active())
+	toolsList := []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"analyze"}]}}` + "\n")
+	require.Equal(t, toolsList, filterToolsListFrame(toolsList, inactive))
+}
+
+func TestGateToolCallFrame(t *testing.T) {
+	surface := editSurface(t)
+
+	// A call to a forbidden tool is gated with a JSON-RPC error reply.
+	blocked := []byte(`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"analyze","arguments":{}}}` + "\n")
+	reply, gated := gateToolCallFrame(blocked, surface)
+	require.True(t, gated)
+	var errMsg struct {
+		ID    int `json:"id"`
+		Error struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(reply, &errMsg))
+	require.Equal(t, 7, errMsg.ID)
+	require.Equal(t, -32601, errMsg.Error.Code)
+	require.Contains(t, errMsg.Error.Message, "analyze")
+
+	// A call to an allowed tool is forwarded (not gated).
+	allowed := []byte(`{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"edit_file"}}` + "\n")
+	_, gated = gateToolCallFrame(allowed, surface)
+	require.False(t, gated)
+
+	// Non-tools/call frames pass through.
+	listReq := []byte(`{"jsonrpc":"2.0","id":9,"method":"tools/list"}` + "\n")
+	_, gated = gateToolCallFrame(listReq, surface)
+	require.False(t, gated)
+
+	// An inactive surface gates nothing.
+	inactive := gortexmcp.NewToolSurface(gortexmcp.ToolPolicyConfig{}, zap.NewNop())
+	_, gated = gateToolCallFrame(blocked, inactive)
+	require.False(t, gated)
+}
+
+func TestToolPolicyConfigFromFlags(t *testing.T) {
+	cfg := toolPolicyConfigFromFlags("search_symbols,edit_file", "hide")
+	require.Equal(t, "", cfg.Preset)
+	require.Equal(t, []string{"search_symbols", "edit_file"}, cfg.Allow)
+	require.Equal(t, "hide", cfg.Mode)
+
+	cfg = toolPolicyConfigFromFlags("edit,+find_files", "")
+	require.Equal(t, "edit", cfg.Preset)
+	require.Equal(t, []string{"find_files"}, cfg.Allow)
+}

--- a/cmd/gortex/tool_preset_flags.go
+++ b/cmd/gortex/tool_preset_flags.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"github.com/zzet/gortex/internal/config"
+	gortexmcp "github.com/zzet/gortex/internal/mcp"
+)
+
+// applyToolPresetFlags folds the --tools / --tools-mode flags into the
+// loaded config's mcp.tools block before the server stack reads it
+// (flag overrides config file). GORTEX_TOOLS / GORTEX_TOOLS_MODE still
+// override at server construction, so the effective precedence is
+// env > flag > config > default(full).
+func applyToolPresetFlags(cfg *config.Config, flagTools, flagMode string) {
+	if cfg == nil {
+		return
+	}
+	if flagTools != "" {
+		preset, allow, deny := gortexmcp.ParseToolSpec(flagTools)
+		if preset != "" {
+			cfg.MCP.Tools.Preset = preset
+		}
+		cfg.MCP.Tools.Allow = append(cfg.MCP.Tools.Allow, allow...)
+		cfg.MCP.Tools.Deny = append(cfg.MCP.Tools.Deny, deny...)
+	}
+	if flagMode != "" {
+		cfg.MCP.Tools.Mode = flagMode
+	}
+}

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -3,6 +3,7 @@
 Gortex exposes a knowledge-graph query surface over the [Model Context Protocol](https://modelcontextprotocol.io): **100+ tools, 16 resources, 3 prompts**. Agents call the same surface from stdio, the daemon Unix socket, or the MCP 2026 Streamable HTTP endpoint.
 
 - [Tool discovery (lazy mode)](#tool-discovery-lazy-mode)
+- [Restricting the tool surface (presets)](#restricting-the-tool-surface-presets)
 - [Core navigation](#core-navigation)
 - [Graph traversal](#graph-traversal)
 - [Search & traversal extensions](#search--traversal-extensions)
@@ -43,7 +44,51 @@ By default the server publishes the entire tool surface in the initial `tools/li
 {"name":"tools_search","arguments":{"query":"memories invariants"}}
 ```
 
-Returned tools are auto-promoted (`promote:false` opts out) and the server fires `notifications/tools/list_changed`. The `tool_profile` tool reports the active surface — which tools are live vs. deferred, their scopes, and (with a `tool` argument) a single tool's enabled status.
+Returned tools are auto-promoted (`promote:false` opts out) and the server fires `notifications/tools/list_changed`. The `tool_profile` tool reports the active surface — which tools are live vs. deferred, their scopes and categories, the active preset (below), and (with a `tool` argument) a single tool's enabled status.
+
+## Restricting the tool surface (presets)
+
+The full ~170-tool surface is more than many agents need. A **tool preset** restricts what the server publishes — the basis for a minimal, headless editing harness (an agent on a trusted box driving a remote daemon through a small, fixed tool set).
+
+Four built-in presets:
+
+| Preset | Surface |
+|--------|---------|
+| `full` (default) | every tool |
+| `readonly` | everything except the mutating tools (`edit_file`, `write_file`, `index_repository`, …) |
+| `edit` | the minimal headless editing set — orient + navigate + mutate + verify (`smart_context`, `search_symbols`, `find_files`, `edit_file`, `verify_change`, `get_test_targets`, …) |
+| `nav` | read-only navigation / exploration; no editors |
+
+`tool_profile` and `tools_search` are always kept. Layer per-tool deltas on any preset with `allow` / `deny`.
+
+**Two modes** (`mode`, default `hide`):
+
+- `hide` — non-allowed tools are removed from `tools/list` **and** calls to them are hard-blocked. The locked-down surface; works on every client.
+- `defer` — non-allowed tools are kept out of the cold `tools/list` but stay reachable through `tools_search` (the lazy-discovery path). Only effective on clients that honour `notifications/tools/list_changed`.
+
+Select a preset three ways (precedence: **env > flag > config > default**):
+
+```yaml
+# .gortex.yaml — config file
+mcp:
+  tools:
+    preset: edit          # full | readonly | edit | nav
+    mode: hide            # hide | defer
+    allow: [find_files]   # add tools on top of the preset
+    deny: [write_file]    # remove tools from the preset
+```
+
+```bash
+# env (overrides config) — spec is "preset,+add,-remove"
+export GORTEX_TOOLS="edit,+analyze,-write_file"
+export GORTEX_TOOLS_MODE=hide
+
+# CLI flags (override config; env still wins)
+gortex mcp --tools edit --tools-mode hide
+gortex daemon start --tools readonly      # propagates to the detached child
+```
+
+`tool_profile` reports the active `preset` / `preset_mode`, the narrowed `live` set, and a `categories{}` map grouping every tool into a functional family (nav / read / edit / analysis / review / pr / memory / overlay / subscription / enrich / workspace / admin) for prefix-style filtering.
 
 **Prompt-injection screening.** Every tool call is screened by middleware that scans arguments and result text for injection patterns. On a hit it attaches a non-blocking `_meta.gortex_security` advisory — the call still succeeds and the result body is never mutated. Disable with `GORTEX_MCP_SANITIZE=0`.
 
@@ -54,6 +99,7 @@ Returned tools are auto-promoted (`promote:false` opts out) and the server fires
 | `graph_stats` | Node/edge counts by kind, language, per-repo stats, session token savings, and an `edge_identity_revisions` counter (edges re-keyed when their provenance changed) |
 | `search_symbols` | Find symbols by name (replaces Grep). Inline `kind:`/`lang:`/`path:` field clauses + `query_class` / `max_per_file` tuning; accepts `repo`, `project`, `ref`, `scope` params. `corpus: code\|docs\|all` selects the corpus (`docs` has its own retrieval channel + prose-tuned ranking); `vocab_anchored: true` constrains LLM expansion to the repo's own vocabulary; a zero-result identifier query is auto-decomposed into leaf terms (`decomposed: true`) |
 | `search_text` | Trigram-accelerated literal (or `regexp: true`) code search across the repo — the alt grep backbone. Returns file/line/text rows, each carrying the enclosing symbol (`symbol_id` / `symbol_name`) |
+| `find_files` | Find source files by **name** — the file-name counterpart of `search_symbols`. `query` (basename/path substring, ranked exact > prefix > substring) and/or `glob` (e.g. `internal/**/*_test.go`), with optional `fuzzy` subsequence matching and `path` / `repo` scoping. File nodes are excluded from the symbol index, so `search_symbols kind:file` cannot return them — use this |
 | `winnow_symbols` | Structured constraint-chain retrieval — `kind`, `language`, `community`, `path_prefix`, `min_fan_in`, `min_fan_out`, `min_churn`, `text_match` with per-axis score contributions |
 | `get_symbol` | Symbol location and signature (replaces Read). Accepts `repo`, `project`, `ref` params |
 | `get_file_summary` | All symbols and imports in a file. Accepts `repo`, `project`, `ref`, `max_bytes` / `max_tokens` budget caps |

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -88,6 +88,21 @@ gortex mcp --tools edit --tools-mode hide
 gortex daemon start --tools readonly      # propagates to the detached child
 ```
 
+**Per-connection (client-driven) scoping.** The selectors above applied to `gortex daemon start` narrow the *whole daemon* for every client. To let one client pick its own surface while the daemon keeps serving the full set to everyone else, set `--tools` / `GORTEX_TOOLS` on that client's **`gortex mcp`** invocation — the stdio proxy filters just that connection's `tools/list` and blocks calls to tools outside the set. Because the filter applies from the first `tools/list`, it works on **every** MCP client (no `tools/list_changed` dependency).
+
+```jsonc
+// An MCP client config giving this client a minimal editing surface,
+// against a daemon that still serves the full catalogue to others:
+{
+  "command": "gortex",
+  "args": ["mcp", "--tools", "search_symbols,find_files,edit_file,verify_change"],
+  // or: "args": ["mcp", "--tools", "edit"]  (a named preset)
+  // or: "env": { "GORTEX_TOOLS": "readonly" }
+}
+```
+
+A spec whose first token isn't a known preset (`search_symbols,find_files,…`) is an **explicit allow list** — exactly those tools — for experts who want to hand-pick the surface. A known preset followed by names (`edit,find_files`) keeps preset semantics plus the extra tools.
+
 `tool_profile` reports the active `preset` / `preset_mode`, the narrowed `live` set, and a `categories{}` map grouping every tool into a functional family (nav / read / edit / analysis / review / pr / memory / overlay / subscription / enrich / workspace / admin) for prefix-style filtering.
 
 **Prompt-injection screening.** Every tool call is screened by middleware that scans arguments and result text for injection patterns. On a hit it attaches a non-blocking `_meta.gortex_security` advisory — the call still succeeds and the result body is never mutated. Disable with `GORTEX_MCP_SANITIZE=0`.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1457,8 +1457,22 @@ func (e EmbeddingConfig) EmbeddingProviderOrDefault() string {
 }
 
 type MCPConfig struct {
-	Transport string `mapstructure:"transport" yaml:"transport,omitempty"`
-	Port      int    `mapstructure:"port"      yaml:"port,omitempty"`
+	Transport string         `mapstructure:"transport" yaml:"transport,omitempty"`
+	Port      int            `mapstructure:"port"      yaml:"port,omitempty"`
+	Tools     MCPToolsConfig `mapstructure:"tools"     yaml:"tools,omitempty"`
+}
+
+// MCPToolsConfig selects which MCP tools the server publishes. Preset is
+// one of full (default) / readonly / edit / nav; Allow / Deny are
+// per-tool deltas layered on the preset; Mode is "hide" (remove
+// non-allowed tools from tools/list and hard-block calls) or "defer"
+// (hide from the cold tools/list but keep reachable via tools_search).
+// GORTEX_TOOLS / GORTEX_TOOLS_MODE override these at runtime.
+type MCPToolsConfig struct {
+	Preset string   `mapstructure:"preset" yaml:"preset,omitempty"`
+	Mode   string   `mapstructure:"mode"   yaml:"mode,omitempty"`
+	Allow  []string `mapstructure:"allow"  yaml:"allow,omitempty"`
+	Deny   []string `mapstructure:"deny"   yaml:"deny,omitempty"`
 }
 
 // Default returns a Config with sensible defaults.

--- a/internal/mcp/lazy_tools.go
+++ b/internal/mcp/lazy_tools.go
@@ -34,6 +34,7 @@ import (
 // state" consult daemon.MutatingTools (internal/daemon/mutating.go).
 var hotEagerTools = map[string]bool{
 	"search_symbols":       true,
+	"find_files":           true,
 	"find_usages":          true,
 	"find_implementations": true,
 	"find_overrides":       true,

--- a/internal/mcp/lazy_tools.go
+++ b/internal/mcp/lazy_tools.go
@@ -115,6 +115,13 @@ type lazyToolRegistry struct {
 	// fires notifications/tools/list_changed).
 	promote func(*deferredTool)
 	enabled bool
+	// eager, when non-nil, replaces the hotEagerTools membership test
+	// in IsDeferred — a tool ships eagerly iff eager(name) is true.
+	// Set by a defer-mode tool preset (SetEagerPredicate) so the
+	// eager surface follows the preset's allow-set instead of the
+	// hard-coded hot set. Set once at construction before the register
+	// sweep, so no mutex is needed.
+	eager func(string) bool
 }
 
 func newLazyToolRegistry(enabled bool) *lazyToolRegistry {
@@ -160,7 +167,21 @@ func (r *lazyToolRegistry) IsDeferred(name string) bool {
 	if name == LazyToolsSearchName {
 		return false
 	}
+	if r.eager != nil {
+		return !r.eager(name)
+	}
 	return !hotEagerTools[name]
+}
+
+// SetEagerPredicate overrides the hotEagerTools membership test used by
+// IsDeferred: once set, a tool is eager iff f(name) is true. A defer-
+// mode tool preset wires this so the cold tools/list carries exactly
+// the preset's allow-set. Call before any Register (construction time).
+func (r *lazyToolRegistry) SetEagerPredicate(f func(string) bool) {
+	if r == nil {
+		return
+	}
+	r.eager = f
 }
 
 // Register stashes a tool in the deferred set. The caller has already

--- a/internal/mcp/scope_init.go
+++ b/internal/mcp/scope_init.go
@@ -73,6 +73,7 @@ var defaultToolScopes = map[string]ToolScope{
 	"get_untested_symbols": ScopeRepo,
 	"suggest_queries":      ScopeRepo,
 	"search_text":          ScopeRepo,
+	"find_files":           ScopeRepo,
 
 	// File / repo-level summaries.
 	"get_file_summary":    ScopeRepo,

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1059,6 +1059,7 @@ func NewServer(engine *query.Engine, g graph.Store, idx *indexer.Indexer, watche
 	s.registerToolsSearch()
 
 	s.registerCoreTools()
+	s.registerFindFilesTool()
 	s.registerCodingTools()
 	s.registerMoveInlineTools()
 	s.registerPostFilterTools()

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -400,6 +400,15 @@ type Server struct {
 	// is explicitly disabled — see lazyEnabledFromEnv.
 	lazy *lazyToolRegistry
 
+	// toolPolicy restricts the published tool surface to a named preset
+	// / allow-deny set (see tool_presets.go). Resolved at construction
+	// from MultiRepoOptions.ToolPolicy (the mcp.tools config block) plus
+	// the GORTEX_TOOLS / GORTEX_TOOLS_MODE env overrides. Nil or
+	// inactive means the full surface. Enforced in hide mode by
+	// toolSurfaceFilter + checkToolGate and in defer mode by the lazy
+	// registry's eager predicate.
+	toolPolicy *toolPolicy
+
 	// toolBudgetOnce / toolBudgetCached memoise the project-size-scaled
 	// exploration-call budget appended to navigation tools' descriptions
 	// (see tool_budget.go). Computed once from the graph node count.
@@ -958,6 +967,10 @@ type MultiRepoOptions struct {
 	// ScopeProject narrows further inside ScopeWorkspace (no effect
 	// without it).
 	ScopeProject string
+	// ToolPolicy restricts the published MCP tool surface to a named
+	// preset / allow-deny set (the `mcp.tools` config block). Nil leaves
+	// the full surface; GORTEX_TOOLS / GORTEX_TOOLS_MODE still override.
+	ToolPolicy *ToolPolicyConfig
 }
 
 // serverInstructions is the server-level `instructions` field returned
@@ -1054,7 +1067,16 @@ func NewServer(engine *query.Engine, g graph.Store, idx *indexer.Indexer, watche
 	// tools_search uses to migrate a tool from deferred → live on
 	// first use. See lazy_tools.go for the hot-set selection rules.
 	s.sanitizeInjection = sanitizeEnabledFromEnv()
-	s.lazy = newLazyToolRegistry(lazyEnabledFromEnv())
+	// Tool-surface preset (mcp.tools config + GORTEX_TOOLS env). In
+	// defer mode the preset's allow-set becomes the lazy registry's
+	// eager surface; hide mode is enforced later by toolSurfaceFilter /
+	// checkToolGate. Resolved before the register sweep so every
+	// addTool sees the policy.
+	s.toolPolicy = resolveToolPolicy(toolPolicyBaseFromOptions(opts), logger)
+	s.lazy = newLazyToolRegistry(lazyEnabledFromEnv() || s.toolPolicy.deferMode())
+	if s.toolPolicy.deferMode() {
+		s.lazy.SetEagerPredicate(s.toolPolicy.allows)
+	}
 	s.attachLazyRegistry()
 	s.registerToolsSearch()
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -97,6 +97,7 @@ func findAndCallHandler(srv *Server, name string, ctx context.Context, req mcpli
 		"get_repo_outline":      srv.handleGetRepoOutline,
 		"suggest_queries":       srv.handleSuggestQueries,
 		"search_text":           srv.handleSearchText,
+		"find_files":            srv.handleFindFiles,
 		"get_untested_symbols":  srv.handleGetUntestedSymbols,
 		"winnow_symbols":        srv.handleWinnowSymbols,
 		"edit_file":             srv.handleEditFile,

--- a/internal/mcp/tool_categories.go
+++ b/internal/mcp/tool_categories.go
@@ -1,0 +1,119 @@
+package mcp
+
+import "strings"
+
+// Tool categories group the flat tool namespace into coarse functional
+// families for tool_profile introspection and prefix-style filtering —
+// the "tools grouped for quick filtering" an operator reaches for when
+// the 170-tool surface is overwhelming. This is a best-effort label, NOT
+// a security boundary: enforcement lives in the tool preset (allow/deny),
+// the per-tool scope, and the authoritative daemon.MutatingTools set.
+const (
+	toolCatNav          = "nav"          // search / navigation / traversal
+	toolCatRead         = "read"         // read a file or symbol's source
+	toolCatEdit         = "edit"         // mutate source / refactor
+	toolCatAnalysis     = "analysis"     // graph analyses / metrics / ask
+	toolCatReview       = "review"       // code-review engine
+	toolCatPR           = "pr"           // pull-request triage / risk
+	toolCatMemory       = "memory"       // notes / memories / notebooks
+	toolCatOverlay      = "overlay"      // overlay / speculative / change-contract
+	toolCatSubscription = "subscription" // subscribe / unsubscribe pairs
+	toolCatEnrich       = "enrich"       // churn / coverage / release enrichment
+	toolCatWorkspace    = "workspace"    // repo / project / scope management
+	toolCatAdmin        = "admin"        // index / health / introspection
+	toolCatOther        = "other"        // unclassified
+)
+
+// toolCategoryOverrides pins the category for tools whose name prefix
+// does not reveal (or actively misleads about) their family — e.g.
+// edit_memory starts with "edit_" but belongs to the memory family.
+var toolCategoryOverrides = map[string]string{
+	// nav (no find_/search_ prefix)
+	"smart_context": toolCatNav, "nav": toolCatNav, "walk_graph": toolCatNav,
+	"graph_query": toolCatNav, "trace_path": toolCatNav, "flow_between": toolCatNav,
+	"taint_paths": toolCatNav, "context_closure": toolCatNav, "get_repo_outline": toolCatNav,
+	"get_callers": toolCatNav, "get_call_chain": toolCatNav, "get_dependencies": toolCatNav,
+	"get_dependents": toolCatNav, "get_class_hierarchy": toolCatNav, "winnow_symbols": toolCatNav,
+	"get_cluster": toolCatNav, "suggest_queries": toolCatNav, "graph_completion_search": toolCatNav,
+	// read
+	"read_file": toolCatRead, "get_symbol": toolCatRead, "get_symbol_source": toolCatRead,
+	"get_file_summary": toolCatRead, "get_editing_context": toolCatRead, "get_cfg": toolCatRead,
+	"get_symbol_history": toolCatRead, "batch_symbols": toolCatRead,
+	// edit (no edit_/write_ prefix)
+	"scaffold": toolCatEdit, "suggest_pattern": toolCatEdit, "apply_code_action": toolCatEdit,
+	"fix_all_in_file": toolCatEdit, "get_code_actions": toolCatEdit, "get_edit_plan": toolCatEdit,
+	// analysis
+	"analyze": toolCatAnalysis, "contracts": toolCatAnalysis, "ask": toolCatAnalysis,
+	"get_communities": toolCatAnalysis, "get_coupling_metrics": toolCatAnalysis,
+	"get_processes": toolCatAnalysis, "get_architecture": toolCatAnalysis,
+	"get_surprising_connections": toolCatAnalysis, "get_knowledge_gaps": toolCatAnalysis,
+	"get_extraction_candidates": toolCatAnalysis, "get_churn_rate": toolCatAnalysis,
+	"get_untested_symbols": toolCatAnalysis, "get_recent_changes": toolCatAnalysis,
+	"get_coupling": toolCatAnalysis, "find_clones": toolCatAnalysis,
+	"find_co_changing_symbols": toolCatAnalysis,
+	// review
+	"review": toolCatReview, "review_pack": toolCatReview, "post_review": toolCatReview,
+	"critique_review": toolCatReview, "suppress_finding": toolCatReview,
+	"sibling_diff_context": toolCatReview, "diff_context": toolCatReview,
+	"suggested_review_questions": toolCatReview, "pr_review_context": toolCatReview,
+	// pr
+	"pr_risk": toolCatPR, "list_prs": toolCatPR, "get_pr_impact": toolCatPR,
+	"triage_prs": toolCatPR, "conflicts_prs": toolCatPR, "suggest_reviewers": toolCatPR,
+	// memory (some carry edit_/rename_ prefixes)
+	"save_note": toolCatMemory, "query_notes": toolCatMemory, "distill_session": toolCatMemory,
+	"store_memory": toolCatMemory, "query_memories": toolCatMemory, "surface_memories": toolCatMemory,
+	"edit_memory": toolCatMemory, "rename_memory": toolCatMemory,
+	// overlay / speculative / change-contract
+	"preview_edit": toolCatOverlay, "simulate_chain": toolCatOverlay,
+	"compare_with_overlay": toolCatOverlay, "change_contract": toolCatOverlay,
+	"symbols_for_ranges": toolCatOverlay, "verify_change": toolCatOverlay,
+	"explain_change_impact": toolCatOverlay, "detect_changes": toolCatOverlay,
+	// workspace
+	"list_repos": toolCatWorkspace, "workspace_info": toolCatWorkspace,
+	"get_active_project": toolCatWorkspace, "set_active_project": toolCatWorkspace,
+	"save_scope": toolCatWorkspace, "delete_scope": toolCatWorkspace, "list_scopes": toolCatWorkspace,
+	"track_repository": toolCatWorkspace, "untrack_repository": toolCatWorkspace,
+	// admin / introspection
+	"graph_stats": toolCatAdmin, "index_health": toolCatAdmin, "index_repository": toolCatAdmin,
+	"reindex_repository": toolCatAdmin, "tool_profile": toolCatAdmin, "feedback": toolCatAdmin,
+	"get_diagnostics": toolCatAdmin, "plan_turn": toolCatAdmin, "set_planning_mode": toolCatAdmin,
+	"prefetch_context": toolCatAdmin, "workflow": toolCatAdmin, "check_guards": toolCatAdmin,
+	"get_test_targets": toolCatAdmin, LazyToolsSearchName: toolCatAdmin,
+}
+
+// toolCategory classifies a tool name into a functional family. An
+// explicit override wins; otherwise a handful of unambiguous name
+// prefixes decide; anything else is "other".
+func toolCategory(name string) string {
+	if c, ok := toolCategoryOverrides[name]; ok {
+		return c
+	}
+	switch {
+	case strings.HasPrefix(name, "overlay_"):
+		return toolCatOverlay
+	case strings.HasPrefix(name, "subscribe_"), strings.HasPrefix(name, "unsubscribe_"):
+		return toolCatSubscription
+	case strings.HasPrefix(name, "enrich_"):
+		return toolCatEnrich
+	case strings.HasPrefix(name, "notebook_"):
+		return toolCatMemory
+	case strings.HasPrefix(name, "find_"), strings.HasPrefix(name, "search_"):
+		return toolCatNav
+	case strings.HasPrefix(name, "edit_"), strings.HasPrefix(name, "write_"),
+		strings.HasPrefix(name, "rename_"), strings.HasPrefix(name, "move_"),
+		strings.HasPrefix(name, "inline_"), strings.HasPrefix(name, "batch_"),
+		strings.HasPrefix(name, "safe_delete"):
+		return toolCatEdit
+	default:
+		return toolCatOther
+	}
+}
+
+// toolCategories returns a name → category map for the given tool names.
+func toolCategories(names []string) map[string]string {
+	out := make(map[string]string, len(names))
+	for _, n := range names {
+		out[n] = toolCategory(n)
+	}
+	return out
+}

--- a/internal/mcp/tool_categories_test.go
+++ b/internal/mcp/tool_categories_test.go
@@ -1,0 +1,49 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestToolCategory(t *testing.T) {
+	cases := map[string]string{
+		// prefix-driven
+		"find_files":           toolCatNav,
+		"search_symbols":       toolCatNav,
+		"edit_file":            toolCatEdit,
+		"write_file":           toolCatEdit,
+		"rename_symbol":        toolCatEdit,
+		"overlay_push":         toolCatOverlay,
+		"subscribe_diagnostics": toolCatSubscription,
+		"unsubscribe_diagnostics": toolCatSubscription,
+		"enrich_churn":         toolCatEnrich,
+		"notebook_save":        toolCatMemory,
+		// override-driven (prefix would mislabel)
+		"edit_memory":          toolCatMemory,
+		"rename_memory":        toolCatMemory,
+		"smart_context":        toolCatNav,
+		"read_file":            toolCatRead,
+		"get_symbol_source":    toolCatRead,
+		"analyze":              toolCatAnalysis,
+		"review":               toolCatReview,
+		"pr_risk":              toolCatPR,
+		"list_repos":           toolCatWorkspace,
+		"graph_stats":          toolCatAdmin,
+		"tool_profile":         toolCatAdmin,
+		// unclassified
+		"some_unknown_future_tool": toolCatOther,
+	}
+	for name, want := range cases {
+		require.Equalf(t, want, toolCategory(name), "tool %q", name)
+	}
+}
+
+func TestToolCategories_Map(t *testing.T) {
+	got := toolCategories([]string{"edit_file", "search_symbols", "analyze"})
+	require.Equal(t, map[string]string{
+		"edit_file":      toolCatEdit,
+		"search_symbols": toolCatNav,
+		"analyze":        toolCatAnalysis,
+	}, got)
+}

--- a/internal/mcp/tool_presets.go
+++ b/internal/mcp/tool_presets.go
@@ -183,7 +183,7 @@ func (p *toolPolicy) allows(name string) bool {
 	return true
 }
 
-func (p *toolPolicy) isActive() bool { return p != nil && p.active }
+func (p *toolPolicy) isActive() bool  { return p != nil && p.active }
 func (p *toolPolicy) hideMode() bool  { return p.isActive() && p.mode == toolPolicyModeHide }
 func (p *toolPolicy) deferMode() bool { return p.isActive() && p.mode == toolPolicyModeDefer }
 

--- a/internal/mcp/tool_presets.go
+++ b/internal/mcp/tool_presets.go
@@ -124,26 +124,51 @@ func normalizeToolMode(mode string) string {
 // unrecognised preset name is logged and downgraded to the full surface
 // (fail-open — a typo never silently strands an agent with no tools).
 func newToolPolicy(cfg ToolPolicyConfig, logger *zap.Logger) *toolPolicy {
-	preset := strings.ToLower(strings.TrimSpace(cfg.Preset))
-	set, denyMutating, known := builtinToolPresetSet(preset)
-	if !known {
-		if logger != nil {
-			logger.Warn("unknown MCP tool preset; serving the full surface",
-				zap.String("preset", cfg.Preset),
-				zap.Strings("known", builtinPresetNames))
-		}
-		preset, set, denyMutating = "full", nil, false
-	}
-	if preset == "" || preset == "all" {
-		preset = "full"
-	}
+	rawPreset := strings.ToLower(strings.TrimSpace(cfg.Preset))
 	allow := toToolSet(cfg.Allow)
 	deny := toToolSet(cfg.Deny)
-	active := set != nil || denyMutating || len(allow) > 0 || len(deny) > 0
+
+	var (
+		explicit     map[string]bool
+		denyMutating bool
+		label        string
+	)
+	switch {
+	case rawPreset == "":
+		// No named preset. An explicit allow list (e.g. --tools
+		// search_symbols,edit_file) IS the surface; otherwise the full
+		// surface, minus any deny.
+		if len(allow) > 0 {
+			explicit = allow
+			label = "custom"
+		} else {
+			label = "full"
+		}
+	default:
+		set, dm, known := builtinToolPresetSet(rawPreset)
+		if known {
+			explicit = set
+			denyMutating = dm
+			label = rawPreset
+			if label == "all" {
+				label = "full"
+			}
+		} else {
+			// A typo'd preset fails open to the full surface (never
+			// strands an agent with no tools); allow deltas stay additive.
+			if logger != nil {
+				logger.Warn("unknown MCP tool preset; serving the full surface",
+					zap.String("preset", cfg.Preset),
+					zap.Strings("known", builtinPresetNames))
+			}
+			label = "full"
+		}
+	}
+	active := explicit != nil || denyMutating || len(allow) > 0 || len(deny) > 0
 	return &toolPolicy{
-		preset:       preset,
+		preset:       label,
 		mode:         normalizeToolMode(cfg.Mode),
-		explicit:     set,
+		explicit:     explicit,
 		denyMutating: denyMutating,
 		allow:        allow,
 		deny:         deny,
@@ -202,11 +227,30 @@ func toolPolicyConfigFromEnv() (ToolPolicyConfig, bool) {
 	return cfg, true
 }
 
-// parseToolSpec parses a spec like "edit,+find_files,-write_file": the
-// first bare token is the preset; +name adds an allow delta, -name a
-// deny delta.
+// isKnownPresetName reports whether name is one of the built-in preset
+// names (full / readonly / edit / nav + aliases).
+func isKnownPresetName(name string) bool {
+	name = strings.ToLower(strings.TrimSpace(name))
+	if name == "" {
+		return false
+	}
+	_, _, known := builtinToolPresetSet(name)
+	return known
+}
+
+// parseToolSpec parses a spec into a ToolPolicyConfig. The grammar is:
+//
+//   - the first bare token that names a built-in preset is the preset
+//     (full / readonly / edit / nav); any further bare tokens are added
+//     to the allow set — so "edit,find_files" means the edit preset plus
+//     find_files;
+//   - if the first bare token is NOT a known preset, every bare token is
+//     an explicit tool name — so "search_symbols,edit_file" means exactly
+//     those two tools (an expert allow list, no preset);
+//   - +name / -name are always allow / deny deltas.
 func parseToolSpec(spec string) ToolPolicyConfig {
 	var cfg ToolPolicyConfig
+	presetTaken := false
 	for _, tok := range strings.Split(spec, ",") {
 		tok = strings.TrimSpace(tok)
 		if tok == "" {
@@ -217,10 +261,11 @@ func parseToolSpec(spec string) ToolPolicyConfig {
 			cfg.Allow = append(cfg.Allow, strings.TrimPrefix(tok, "+"))
 		case strings.HasPrefix(tok, "-"):
 			cfg.Deny = append(cfg.Deny, strings.TrimPrefix(tok, "-"))
+		case !presetTaken && isKnownPresetName(tok):
+			cfg.Preset = tok
+			presetTaken = true
 		default:
-			if cfg.Preset == "" {
-				cfg.Preset = tok
-			}
+			cfg.Allow = append(cfg.Allow, tok)
 		}
 	}
 	return cfg
@@ -260,6 +305,40 @@ func mergeToolPolicyEnv(base ToolPolicyConfig) ToolPolicyConfig {
 // env overrides applied on top.
 func resolveToolPolicy(base ToolPolicyConfig, logger *zap.Logger) *toolPolicy {
 	return newToolPolicy(mergeToolPolicyEnv(base), logger)
+}
+
+// ToolSurface is a resolved tool-visibility predicate usable outside the
+// MCP server — the stdio proxy uses it to filter a daemon's tools/list
+// and gate calls per connection, so a client can scope its own pipe
+// (gortex mcp --tools / GORTEX_TOOLS) while the daemon stays full. Built
+// from the same ToolPolicyConfig + GORTEX_TOOLS env as the server.
+type ToolSurface struct{ p *toolPolicy }
+
+// NewToolSurface resolves a config (with the GORTEX_TOOLS env overrides
+// applied) into a queryable surface.
+func NewToolSurface(base ToolPolicyConfig, logger *zap.Logger) *ToolSurface {
+	return &ToolSurface{p: resolveToolPolicy(base, logger)}
+}
+
+// Active reports whether the surface restricts anything at all.
+func (s *ToolSurface) Active() bool { return s != nil && s.p.isActive() }
+
+// Allows reports whether a tool name is visible in this surface. A nil
+// or inactive surface allows everything.
+func (s *ToolSurface) Allows(name string) bool {
+	if s == nil {
+		return true
+	}
+	return s.p.allows(name)
+}
+
+// Preset returns the resolved preset label (full / readonly / edit / nav
+// / custom) for logging.
+func (s *ToolSurface) Preset() string {
+	if s == nil || s.p == nil {
+		return "full"
+	}
+	return s.p.preset
 }
 
 // toolPolicyBaseFromOptions extracts the config-supplied tool policy

--- a/internal/mcp/tool_presets.go
+++ b/internal/mcp/tool_presets.go
@@ -1,0 +1,273 @@
+package mcp
+
+import (
+	"os"
+	"strings"
+
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/daemon"
+)
+
+// ToolPolicyConfig is the operator-facing description of a restricted
+// tool surface: a named preset, per-tool allow/deny deltas, and a mode.
+// It is the wire between the `mcp.tools` config block, the GORTEX_TOOLS
+// / GORTEX_TOOLS_MODE env overrides, and the resolved in-memory
+// toolPolicy. Zero value (empty preset, no deltas) means "no
+// restriction" — the full surface.
+type ToolPolicyConfig struct {
+	Preset string
+	Mode   string // "hide" | "defer" — default hide
+	Allow  []string
+	Deny   []string
+}
+
+const (
+	// toolPolicyModeHide removes non-allowed tools from tools/list and
+	// hard-blocks calls to them. The minimal, locked-down surface a
+	// headless harness wants — works identically on every client.
+	toolPolicyModeHide = "hide"
+	// toolPolicyModeDefer keeps non-allowed tools out of the cold
+	// tools/list but still reachable via the tools_search discovery
+	// tool (which promotes on demand). Only effective on clients that
+	// honour notifications/tools/list_changed.
+	toolPolicyModeDefer = "defer"
+
+	toolPresetEnv     = "GORTEX_TOOLS"
+	toolPresetModeEnv = "GORTEX_TOOLS_MODE"
+)
+
+// editPresetTools is the minimal headless code-editing surface: orient,
+// navigate, mutate, verify. Sized so an agent can edit code safely on a
+// remote box without the full 170-tool catalogue. tool_profile and
+// tools_search are always kept on top of any preset (isAlwaysKeptTool).
+var editPresetTools = []string{
+	// orient + read
+	"smart_context", "get_editing_context", "read_file", "get_symbol_source",
+	"get_file_summary", "get_symbol",
+	// navigate
+	"search_symbols", "search_text", "find_files", "find_usages", "get_callers",
+	// mutate
+	"edit_file", "edit_symbol", "write_file", "batch_edit", "rename_symbol",
+	// verify
+	"verify_change", "get_test_targets", "check_guards", "get_diagnostics",
+	// orientation
+	"graph_stats",
+}
+
+// navPresetTools is the read-only navigation / exploration surface — no
+// editing tools at all.
+var navPresetTools = []string{
+	"smart_context", "get_editing_context", "read_file", "get_symbol_source",
+	"get_file_summary", "get_symbol",
+	"search_symbols", "search_text", "find_files", "find_usages",
+	"find_implementations", "find_overrides", "get_callers", "get_call_chain",
+	"get_dependencies", "get_dependents", "get_repo_outline", "graph_stats",
+}
+
+// builtinToolPresetSet resolves a preset name to its explicit allow-set.
+// A nil set with denyMutating=false is the sentinel for "no explicit
+// restriction" (the full surface); `readonly` carries denyMutating=true
+// instead of an explicit list so it tracks the authoritative
+// daemon.MutatingTools set as it evolves. known=false flags an
+// unrecognised preset name.
+func builtinToolPresetSet(name string) (set map[string]bool, denyMutating, known bool) {
+	switch name {
+	case "", "full", "all":
+		return nil, false, true
+	case "readonly", "read-only", "read_only":
+		return nil, true, true
+	case "edit", "editor", "edit-harness":
+		return toToolSet(editPresetTools), false, true
+	case "nav", "navigate", "explore":
+		return toToolSet(navPresetTools), false, true
+	default:
+		return nil, false, false
+	}
+}
+
+// builtinPresetNames lists the recognised preset names for diagnostics.
+var builtinPresetNames = []string{"full", "readonly", "edit", "nav"}
+
+// toolPolicy is the resolved, in-memory restriction applied to the tool
+// surface by the lazy registry (defer mode) and toolSurfaceFilter /
+// checkToolGate (hide mode). The zero/nil policy allows everything.
+type toolPolicy struct {
+	preset       string
+	mode         string
+	explicit     map[string]bool // non-nil => base surface is exactly this set
+	denyMutating bool            // drop daemon.MutatingTools (the `readonly` preset)
+	allow        map[string]bool // force-include (overrides the preset)
+	deny         map[string]bool // force-exclude (overrides everything)
+	active       bool
+}
+
+func toToolSet(names []string) map[string]bool {
+	m := make(map[string]bool, len(names))
+	for _, n := range names {
+		m[n] = true
+	}
+	return m
+}
+
+// normalizeToolMode maps a mode string to hide|defer (default hide).
+func normalizeToolMode(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case toolPolicyModeDefer, "lazy", "search":
+		return toolPolicyModeDefer
+	default:
+		return toolPolicyModeHide
+	}
+}
+
+// newToolPolicy resolves a ToolPolicyConfig into a toolPolicy. An
+// unrecognised preset name is logged and downgraded to the full surface
+// (fail-open — a typo never silently strands an agent with no tools).
+func newToolPolicy(cfg ToolPolicyConfig, logger *zap.Logger) *toolPolicy {
+	preset := strings.ToLower(strings.TrimSpace(cfg.Preset))
+	set, denyMutating, known := builtinToolPresetSet(preset)
+	if !known {
+		if logger != nil {
+			logger.Warn("unknown MCP tool preset; serving the full surface",
+				zap.String("preset", cfg.Preset),
+				zap.Strings("known", builtinPresetNames))
+		}
+		preset, set, denyMutating = "full", nil, false
+	}
+	if preset == "" || preset == "all" {
+		preset = "full"
+	}
+	allow := toToolSet(cfg.Allow)
+	deny := toToolSet(cfg.Deny)
+	active := set != nil || denyMutating || len(allow) > 0 || len(deny) > 0
+	return &toolPolicy{
+		preset:       preset,
+		mode:         normalizeToolMode(cfg.Mode),
+		explicit:     set,
+		denyMutating: denyMutating,
+		allow:        allow,
+		deny:         deny,
+		active:       active,
+	}
+}
+
+// isAlwaysKeptTool: introspection (tool_profile) and discovery
+// (tools_search) stay reachable under every preset so an agent can
+// always see its surface and, in defer mode, discover more. An explicit
+// deny still wins (checked before this in allows).
+func isAlwaysKeptTool(name string) bool {
+	return name == "tool_profile" || name == LazyToolsSearchName
+}
+
+// allows reports whether name is part of this policy's allowed surface.
+// A nil or inactive policy allows everything.
+func (p *toolPolicy) allows(name string) bool {
+	if !p.isActive() {
+		return true
+	}
+	if p.deny[name] {
+		return false
+	}
+	if isAlwaysKeptTool(name) {
+		return true
+	}
+	if p.allow[name] {
+		return true
+	}
+	if p.explicit != nil {
+		return p.explicit[name]
+	}
+	if p.denyMutating && daemon.IsMutating(name) {
+		return false
+	}
+	return true
+}
+
+func (p *toolPolicy) isActive() bool { return p != nil && p.active }
+func (p *toolPolicy) hideMode() bool  { return p.isActive() && p.mode == toolPolicyModeHide }
+func (p *toolPolicy) deferMode() bool { return p.isActive() && p.mode == toolPolicyModeDefer }
+
+// toolPolicyConfigFromEnv reads GORTEX_TOOLS / GORTEX_TOOLS_MODE. The
+// bool reports whether either var was set.
+func toolPolicyConfigFromEnv() (ToolPolicyConfig, bool) {
+	spec := strings.TrimSpace(os.Getenv(toolPresetEnv))
+	mode := strings.TrimSpace(os.Getenv(toolPresetModeEnv))
+	if spec == "" && mode == "" {
+		return ToolPolicyConfig{}, false
+	}
+	cfg := parseToolSpec(spec)
+	if mode != "" {
+		cfg.Mode = mode
+	}
+	return cfg, true
+}
+
+// parseToolSpec parses a spec like "edit,+find_files,-write_file": the
+// first bare token is the preset; +name adds an allow delta, -name a
+// deny delta.
+func parseToolSpec(spec string) ToolPolicyConfig {
+	var cfg ToolPolicyConfig
+	for _, tok := range strings.Split(spec, ",") {
+		tok = strings.TrimSpace(tok)
+		if tok == "" {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(tok, "+"):
+			cfg.Allow = append(cfg.Allow, strings.TrimPrefix(tok, "+"))
+		case strings.HasPrefix(tok, "-"):
+			cfg.Deny = append(cfg.Deny, strings.TrimPrefix(tok, "-"))
+		default:
+			if cfg.Preset == "" {
+				cfg.Preset = tok
+			}
+		}
+	}
+	return cfg
+}
+
+// ParseToolSpec parses a "preset,+tool,-tool" spec into its parts. The
+// first bare token is the preset; +name / -name are allow / deny deltas.
+// Exported for CLI flag folding (cmd/gortex).
+func ParseToolSpec(spec string) (preset string, allow, deny []string) {
+	cfg := parseToolSpec(spec)
+	return cfg.Preset, cfg.Allow, cfg.Deny
+}
+
+// mergeToolPolicyEnv overlays GORTEX_TOOLS / GORTEX_TOOLS_MODE over a
+// base (config-file / flag-folded) config: an env preset or mode
+// overrides the base when set; allow/deny deltas append. Mirrors the
+// repo-wide "GORTEX_* env overrides file config" convention.
+func mergeToolPolicyEnv(base ToolPolicyConfig) ToolPolicyConfig {
+	env, ok := toolPolicyConfigFromEnv()
+	if !ok {
+		return base
+	}
+	out := base
+	if env.Preset != "" {
+		out.Preset = env.Preset
+	}
+	if env.Mode != "" {
+		out.Mode = env.Mode
+	}
+	out.Allow = append(append([]string{}, base.Allow...), env.Allow...)
+	out.Deny = append(append([]string{}, base.Deny...), env.Deny...)
+	return out
+}
+
+// resolveToolPolicy builds the policy from a base config (threaded from
+// options / the config file) with the GORTEX_TOOLS / GORTEX_TOOLS_MODE
+// env overrides applied on top.
+func resolveToolPolicy(base ToolPolicyConfig, logger *zap.Logger) *toolPolicy {
+	return newToolPolicy(mergeToolPolicyEnv(base), logger)
+}
+
+// toolPolicyBaseFromOptions extracts the config-supplied tool policy
+// from the MultiRepoOptions, or the zero config when none was provided
+// (the GORTEX_TOOLS env override still applies in resolveToolPolicy).
+func toolPolicyBaseFromOptions(opts []MultiRepoOptions) ToolPolicyConfig {
+	if len(opts) > 0 && opts[0].ToolPolicy != nil {
+		return *opts[0].ToolPolicy
+	}
+	return ToolPolicyConfig{}
+}

--- a/internal/mcp/tool_presets.go
+++ b/internal/mcp/tool_presets.go
@@ -133,8 +133,7 @@ func newToolPolicy(cfg ToolPolicyConfig, logger *zap.Logger) *toolPolicy {
 		denyMutating bool
 		label        string
 	)
-	switch {
-	case rawPreset == "":
+	if rawPreset == "" {
 		// No named preset. An explicit allow list (e.g. --tools
 		// search_symbols,edit_file) IS the surface; otherwise the full
 		// surface, minus any deny.
@@ -144,25 +143,22 @@ func newToolPolicy(cfg ToolPolicyConfig, logger *zap.Logger) *toolPolicy {
 		} else {
 			label = "full"
 		}
-	default:
-		set, dm, known := builtinToolPresetSet(rawPreset)
-		if known {
-			explicit = set
-			denyMutating = dm
-			label = rawPreset
-			if label == "all" {
-				label = "full"
-			}
-		} else {
-			// A typo'd preset fails open to the full surface (never
-			// strands an agent with no tools); allow deltas stay additive.
-			if logger != nil {
-				logger.Warn("unknown MCP tool preset; serving the full surface",
-					zap.String("preset", cfg.Preset),
-					zap.Strings("known", builtinPresetNames))
-			}
+	} else if set, dm, known := builtinToolPresetSet(rawPreset); known {
+		explicit = set
+		denyMutating = dm
+		label = rawPreset
+		if label == "all" {
 			label = "full"
 		}
+	} else {
+		// A typo'd preset fails open to the full surface (never strands
+		// an agent with no tools); allow deltas stay additive.
+		if logger != nil {
+			logger.Warn("unknown MCP tool preset; serving the full surface",
+				zap.String("preset", cfg.Preset),
+				zap.Strings("known", builtinPresetNames))
+		}
+		label = "full"
 	}
 	active := explicit != nil || denyMutating || len(allow) > 0 || len(deny) > 0
 	return &toolPolicy{

--- a/internal/mcp/tool_presets_test.go
+++ b/internal/mcp/tool_presets_test.go
@@ -88,10 +88,44 @@ func TestToolPolicy_ModesAndUnknown(t *testing.T) {
 }
 
 func TestParseToolSpec(t *testing.T) {
+	// Preset + deltas.
 	preset, allow, deny := ParseToolSpec("edit,+find_files,-write_file")
 	require.Equal(t, "edit", preset)
 	require.Equal(t, []string{"find_files"}, allow)
 	require.Equal(t, []string{"write_file"}, deny)
+
+	// A known preset followed by a bare tool name → preset + allow delta.
+	preset, allow, _ = ParseToolSpec("edit,find_files")
+	require.Equal(t, "edit", preset)
+	require.Equal(t, []string{"find_files"}, allow)
+
+	// No known preset → every bare token is an explicit tool name.
+	preset, allow, _ = ParseToolSpec("search_symbols,edit_file,find_files")
+	require.Equal(t, "", preset)
+	require.Equal(t, []string{"search_symbols", "edit_file", "find_files"}, allow)
+}
+
+func TestToolPolicy_ExplicitList(t *testing.T) {
+	// An explicit comma list (no preset) is exactly that surface.
+	p := newToolPolicy(ToolPolicyConfig{Allow: []string{"search_symbols", "edit_file"}}, zap.NewNop())
+	require.True(t, p.isActive())
+	require.Equal(t, "custom", p.preset)
+	require.True(t, p.allows("search_symbols"))
+	require.True(t, p.allows("edit_file"))
+	require.True(t, p.allows("tool_profile")) // always kept
+	require.False(t, p.allows("analyze"))
+	require.False(t, p.allows("write_file"))
+
+	// End-to-end through the spec parser + env resolution.
+	cfg := func(spec string) ToolPolicyConfig {
+		pr, al, dn := ParseToolSpec(spec)
+		return ToolPolicyConfig{Preset: pr, Allow: al, Deny: dn}
+	}
+	surface := NewToolSurface(cfg("find_files,get_symbol_source"), zap.NewNop())
+	require.True(t, surface.Active())
+	require.True(t, surface.Allows("find_files"))
+	require.True(t, surface.Allows("get_symbol_source"))
+	require.False(t, surface.Allows("edit_file"))
 }
 
 func TestToolPolicy_EnvOverride(t *testing.T) {

--- a/internal/mcp/tool_presets_test.go
+++ b/internal/mcp/tool_presets_test.go
@@ -1,0 +1,161 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+	"github.com/zzet/gortex/internal/query"
+)
+
+func TestToolPolicy_Presets(t *testing.T) {
+	cases := []struct {
+		preset string
+		tool   string
+		want   bool
+	}{
+		// full → no restriction.
+		{"full", "analyze", true},
+		{"full", "edit_file", true},
+		{"", "analyze", true},
+		// edit → only the headless editing surface.
+		{"edit", "edit_file", true},
+		{"edit", "find_files", true},
+		{"edit", "search_symbols", true},
+		{"edit", "analyze", false},
+		{"edit", "get_communities", false},
+		// nav → read-only navigation; no editors.
+		{"nav", "search_symbols", true},
+		{"nav", "find_files", true},
+		{"nav", "edit_file", false},
+		{"nav", "write_file", false},
+		// readonly → everything except mutating tools.
+		{"readonly", "search_symbols", true},
+		{"readonly", "analyze", true},
+		{"readonly", "edit_file", false},
+		{"readonly", "write_file", false},
+		{"readonly", "index_repository", false},
+	}
+	for _, c := range cases {
+		p := newToolPolicy(ToolPolicyConfig{Preset: c.preset}, zap.NewNop())
+		require.Equalf(t, c.want, p.allows(c.tool),
+			"preset=%q tool=%q", c.preset, c.tool)
+	}
+}
+
+func TestToolPolicy_AlwaysKeptAndDeltas(t *testing.T) {
+	// tool_profile + tools_search survive any preset.
+	edit := newToolPolicy(ToolPolicyConfig{Preset: "edit"}, zap.NewNop())
+	require.True(t, edit.allows("tool_profile"))
+	require.True(t, edit.allows(LazyToolsSearchName))
+
+	// An explicit deny overrides the preset and the always-kept set.
+	denied := newToolPolicy(ToolPolicyConfig{Preset: "edit", Deny: []string{"edit_file", "tool_profile"}}, zap.NewNop())
+	require.False(t, denied.allows("edit_file"))
+	require.False(t, denied.allows("tool_profile"))
+
+	// An explicit allow adds a tool on top of the preset.
+	plus := newToolPolicy(ToolPolicyConfig{Preset: "edit", Allow: []string{"analyze"}}, zap.NewNop())
+	require.True(t, plus.allows("analyze"))
+
+	// Deny-only against the full surface is active and subtractive.
+	deny := newToolPolicy(ToolPolicyConfig{Deny: []string{"write_file"}}, zap.NewNop())
+	require.True(t, deny.isActive())
+	require.False(t, deny.allows("write_file"))
+	require.True(t, deny.allows("search_symbols"))
+}
+
+func TestToolPolicy_ModesAndUnknown(t *testing.T) {
+	require.True(t, newToolPolicy(ToolPolicyConfig{Preset: "edit"}, zap.NewNop()).hideMode())
+	require.False(t, newToolPolicy(ToolPolicyConfig{Preset: "edit"}, zap.NewNop()).deferMode())
+	require.True(t, newToolPolicy(ToolPolicyConfig{Preset: "edit", Mode: "defer"}, zap.NewNop()).deferMode())
+
+	// full is inactive regardless of mode.
+	require.False(t, newToolPolicy(ToolPolicyConfig{Preset: "full", Mode: "defer"}, zap.NewNop()).deferMode())
+
+	// Unknown preset fails open (full surface), never strands the agent.
+	unknown := newToolPolicy(ToolPolicyConfig{Preset: "bogus"}, zap.NewNop())
+	require.False(t, unknown.isActive())
+	require.True(t, unknown.allows("anything"))
+}
+
+func TestParseToolSpec(t *testing.T) {
+	preset, allow, deny := ParseToolSpec("edit,+find_files,-write_file")
+	require.Equal(t, "edit", preset)
+	require.Equal(t, []string{"find_files"}, allow)
+	require.Equal(t, []string{"write_file"}, deny)
+}
+
+func TestToolPolicy_EnvOverride(t *testing.T) {
+	t.Setenv(toolPresetEnv, "nav")
+	t.Setenv(toolPresetModeEnv, "defer")
+	// Base config says edit/hide; env must win.
+	p := resolveToolPolicy(ToolPolicyConfig{Preset: "edit"}, zap.NewNop())
+	require.Equal(t, "nav", p.preset)
+	require.True(t, p.deferMode())
+	require.True(t, p.allows("search_symbols"))
+	require.False(t, p.allows("edit_file"))
+}
+
+// setupPresetServer builds a server over a one-file repo with the given
+// tool policy so the registration + filtering paths can be exercised.
+func setupPresetServer(t *testing.T, cfg ToolPolicyConfig) *Server {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"),
+		[]byte("package app\n\nfunc Main() {}\n"), 0o644))
+	g := graph.New()
+	reg := parser.NewRegistry()
+	languages.RegisterAll(reg)
+	conf := config.Default()
+	idx := indexer.New(g, reg, conf.Index, zap.NewNop())
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+	eng := query.NewEngine(g)
+	return NewServer(eng, g, idx, nil, zap.NewNop(), nil, MultiRepoOptions{ToolPolicy: &cfg})
+}
+
+func TestToolPolicy_HideModeServer(t *testing.T) {
+	srv := setupPresetServer(t, ToolPolicyConfig{Preset: "edit"})
+
+	// The edit surface is visible; everything else is filtered out.
+	require.True(t, srv.IsToolEnabled("edit_file"))
+	require.True(t, srv.IsToolEnabled("find_files"))
+	require.True(t, srv.IsToolEnabled("tool_profile"))
+	require.False(t, srv.IsToolEnabled("analyze"))
+	require.Equal(t, "blocked", srv.toolStatus("analyze"))
+
+	live := srv.liveToolNames()
+	require.Contains(t, live, "edit_file")
+	require.NotContains(t, live, "analyze")
+
+	// Calls to filtered tools are hard-blocked; allowed tools pass.
+	require.NotNil(t, srv.checkToolPresetGate("analyze"))
+	require.Nil(t, srv.checkToolPresetGate("edit_file"))
+	require.Nil(t, srv.checkToolPresetGate("tool_profile"))
+}
+
+func TestToolPolicy_DeferModeServer(t *testing.T) {
+	srv := setupPresetServer(t, ToolPolicyConfig{Preset: "edit", Mode: "defer"})
+
+	// Defer mode parks non-allowed tools behind tools_search instead of
+	// removing them: allowed tools are live, the rest deferred.
+	require.True(t, srv.lazy.Enabled())
+	deferred := srv.lazy.DeferredNames()
+	require.Contains(t, deferred, "analyze")
+	require.NotContains(t, deferred, "edit_file")
+
+	// A deferred tool is still "enabled" (reachable via tools_search),
+	// never call-gated in defer mode.
+	require.True(t, srv.IsToolEnabled("analyze"))
+	require.Equal(t, "deferred", srv.toolStatus("analyze"))
+	require.Nil(t, srv.checkToolPresetGate("analyze"))
+}

--- a/internal/mcp/tool_profile.go
+++ b/internal/mcp/tool_profile.go
@@ -16,6 +16,12 @@ func (s *Server) IsToolEnabled(name string) bool {
 	if name == "" {
 		return false
 	}
+	// A hide-mode preset removes the tool from the surface entirely
+	// (filtered from tools/list and call-gated), even though it stays
+	// registered in the underlying MCP server.
+	if s.toolPolicy.hideMode() && !s.toolPolicy.allows(name) {
+		return false
+	}
 	if _, ok := s.mcpServer.ListTools()[name]; ok {
 		return true
 	}
@@ -28,6 +34,9 @@ func (s *Server) IsToolEnabled(name string) bool {
 // toolStatus classifies one tool name as live (eagerly in tools/list),
 // deferred (hidden behind tools_search), or absent (not registered).
 func (s *Server) toolStatus(name string) string {
+	if s.toolPolicy.hideMode() && !s.toolPolicy.allows(name) {
+		return "blocked"
+	}
 	if _, ok := s.mcpServer.ListTools()[name]; ok {
 		return "live"
 	}
@@ -43,6 +52,12 @@ func (s *Server) liveToolNames() []string {
 	live := s.mcpServer.ListTools()
 	out := make([]string, 0, len(live))
 	for n := range live {
+		// In hide mode the toolSurfaceFilter strips non-allowed tools
+		// from tools/list; mirror that here so the reported live surface
+		// matches what the agent actually sees.
+		if s.toolPolicy.hideMode() && !s.toolPolicy.allows(n) {
+			continue
+		}
 		out = append(out, n)
 	}
 	sort.Strings(out)
@@ -90,6 +105,13 @@ func (s *Server) handleToolProfile(ctx context.Context, req mcp.CallToolRequest)
 		"live":           live,
 		"deferred":       deferred,
 		"scopes":         scopes,
+	}
+	// Active tool preset (mcp.tools / GORTEX_TOOLS): report the preset
+	// name and mode so an agent knows its surface was deliberately
+	// narrowed rather than the daemon mis-registering tools.
+	if s.toolPolicy.isActive() {
+		profile["preset"] = s.toolPolicy.preset
+		profile["preset_mode"] = s.toolPolicy.mode
 	}
 	// Per-host runtime context — the resolved host name and its guidance
 	// fragment, when the MCP client identified itself (host_context.go).

--- a/internal/mcp/tool_profile.go
+++ b/internal/mcp/tool_profile.go
@@ -68,7 +68,7 @@ func (s *Server) liveToolNames() []string {
 func (s *Server) registerToolProfileTool() {
 	s.addTool(
 		mcp.NewTool("tool_profile",
-			mcp.WithDescription("Report the active MCP tool profile so the agent knows what is actually available instead of guessing. With no arguments: returns `{lazy_enabled, total, live_count, deferred_count, live[], deferred[], scopes{}}` — `live` tools are in the current tools/list, `deferred` tools are reachable via `tools_search`. With `tool:\"<name>\"`: returns `{tool, enabled, status, scope}` for that one tool (status ∈ live | deferred | absent)."),
+			mcp.WithDescription("Report the active MCP tool profile so the agent knows what is actually available instead of guessing. With no arguments: returns `{lazy_enabled, total, live_count, deferred_count, live[], deferred[], scopes{}, categories{}}` plus `preset` / `preset_mode` when a tool preset narrows the surface — `live` tools are in the current tools/list, `deferred` tools are reachable via `tools_search`, and `categories` groups every tool into a functional family (nav / read / edit / analysis / review / pr / memory / overlay / subscription / enrich / workspace / admin). With `tool:\"<name>\"`: returns `{tool, enabled, status, scope, category}` for that one tool (status ∈ live | deferred | blocked | absent)."),
 			mcp.WithString("tool", mcp.Description("Optional — report only this tool's enabled status and scope instead of the whole profile.")),
 		),
 		s.handleToolProfile,
@@ -82,10 +82,11 @@ func (s *Server) handleToolProfile(ctx context.Context, req mcp.CallToolRequest)
 	// Per-tool advisory mode.
 	if name, _ := args["tool"].(string); name != "" {
 		return s.respondJSONOrTOON(ctx, req, map[string]any{
-			"tool":    name,
-			"enabled": s.IsToolEnabled(name),
-			"status":  s.toolStatus(name),
-			"scope":   scopes[name],
+			"tool":     name,
+			"enabled":  s.IsToolEnabled(name),
+			"status":   s.toolStatus(name),
+			"scope":    scopes[name],
+			"category": toolCategory(name),
 		})
 	}
 
@@ -105,6 +106,7 @@ func (s *Server) handleToolProfile(ctx context.Context, req mcp.CallToolRequest)
 		"live":           live,
 		"deferred":       deferred,
 		"scopes":         scopes,
+		"categories":     toolCategories(append(append([]string{}, live...), deferred...)),
 	}
 	// Active tool preset (mcp.tools / GORTEX_TOOLS): report the preset
 	// name and mode so an agent knows its surface was deliberately

--- a/internal/mcp/tools_find_files.go
+++ b/internal/mcp/tools_find_files.go
@@ -1,0 +1,178 @@
+package mcp
+
+import (
+	"context"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// registerFindFilesTool wires `find_files` — the dedicated search-by-
+// file-NAME tool. File (KindFile) nodes are deliberately excluded from
+// the BM25 symbol index (Indexer.shouldIndexForSearch), so neither
+// search_symbols nor search_text can find a file by its name. This
+// tool closes that gap: it enumerates the KindFile bucket directly and
+// ranks by how well the query matches the basename (exact > prefix >
+// substring), falling back to a path-substring match, with optional
+// glob and fuzzy-subsequence matching.
+func (s *Server) registerFindFilesTool() {
+	s.addTool(
+		mcp.NewTool("find_files",
+			mcp.WithDescription("Find source files by NAME — the file-name counterpart of search_symbols. "+
+				"Pass `query` for a basename/path match (ranked exact > prefix > substring), `glob` for a "+
+				"path glob (e.g. \"internal/**/*_test.go\", \"*.proto\"), or both. Use this instead of search_symbols "+
+				"kind:file (which cannot return file nodes). Returns repo-relative paths with the repo prefix and "+
+				"language, ready to hand to get_file_summary / read_file. Pass format:\"gcx\" for the compact wire format."),
+			mcp.WithString("query", mcp.Description("Filename or path substring to match (case-insensitive). Ranked basename-exact > prefix > substring > path-substring.")),
+			mcp.WithString("glob", mcp.Description("Path glob over the repo-relative path. `*` stays within a segment, `**` crosses segments, a bare basename pattern like `*_test.go` matches basenames. ANDed with `query` when both are given.")),
+			mcp.WithBoolean("fuzzy", mcp.Description("Also accept fuzzy subsequence matches of `query` against the basename (e.g. \"tcgo\" matches \"tools_coding.go\"). Lowest-ranked. Default false.")),
+			mcp.WithString("path", mcp.Description("Restrict to one or more anchored sub-path prefixes (comma-separated), repo-root-relative — the monorepo-service slice.")),
+			mcp.WithString("repo", mcp.Description("Restrict to a single repository prefix.")),
+			mcp.WithNumber("limit", mcp.Description("Max files to return (default 50, capped at 500).")),
+			mcp.WithString("format", mcp.Description("Output format: json (default), gcx (compact wire format), or toon.")),
+		),
+		s.handleFindFiles,
+	)
+}
+
+// fileHit is one ranked find_files result.
+type fileHit struct {
+	Path     string `json:"path"`
+	Repo     string `json:"repo,omitempty"`
+	Language string `json:"language,omitempty"`
+	ID       string `json:"id"`
+	score    int
+	depth    int
+}
+
+func (s *Server) handleFindFiles(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	if s.graph == nil {
+		return mcp.NewToolResultError("find_files: no graph available"), nil
+	}
+	query := strings.TrimSpace(req.GetString("query", ""))
+	glob := strings.TrimSpace(req.GetString("glob", ""))
+	if query == "" && glob == "" {
+		return mcp.NewToolResultError("find_files: pass `query` (a filename/path substring) and/or `glob` (a path glob)"), nil
+	}
+	fuzzy := req.GetBool("fuzzy", false)
+	repoArg := strings.TrimSpace(req.GetString("repo", ""))
+	limit := req.GetInt("limit", 50)
+	if limit < 1 {
+		limit = 50
+	}
+	if limit > 500 {
+		limit = 500
+	}
+	pathFilter := s.resolvePathFilter(req, fieldQuery{})
+
+	hits := make([]fileHit, 0, 64)
+	for n := range s.graph.NodesByKind(graph.KindFile) {
+		if n == nil {
+			continue
+		}
+		if !s.nodeInSessionScope(ctx, n) {
+			continue
+		}
+		if repoArg != "" && n.RepoPrefix != repoArg {
+			continue
+		}
+		rel := repoRelativePath(n)
+		if len(pathFilter) > 0 && !pathMatchesAnyPrefix(rel, pathFilter) {
+			continue
+		}
+		base := path.Base(rel)
+
+		score := 0
+		if glob != "" {
+			if !matchFidelityGlob(glob, rel) {
+				continue
+			}
+			score += 5
+		}
+		if query != "" {
+			sc, ok := scoreFilenameMatch(query, base, rel, fuzzy)
+			if !ok {
+				continue
+			}
+			score += sc
+		}
+
+		hits = append(hits, fileHit{
+			Path:     rel,
+			Repo:     n.RepoPrefix,
+			Language: n.Language,
+			ID:       n.ID,
+			score:    score,
+			depth:    strings.Count(rel, "/"),
+		})
+	}
+
+	// Highest score first; tie-break toward shallower paths, then
+	// lexical — so a top-level match outranks a deeply-nested one and
+	// identical inputs produce identical output across restarts.
+	sort.Slice(hits, func(i, j int) bool {
+		if hits[i].score != hits[j].score {
+			return hits[i].score > hits[j].score
+		}
+		if hits[i].depth != hits[j].depth {
+			return hits[i].depth < hits[j].depth
+		}
+		return hits[i].Path < hits[j].Path
+	})
+	total := len(hits)
+	if len(hits) > limit {
+		hits = hits[:limit]
+	}
+
+	return s.respondJSONOrTOON(ctx, req, map[string]any{
+		"query":     query,
+		"glob":      glob,
+		"files":     hits,
+		"count":     len(hits),
+		"truncated": total > len(hits),
+	})
+}
+
+// scoreFilenameMatch ranks how well query matches a file's basename or
+// repo-relative path. The score tiers (basename-exact > basename-prefix
+// > basename-substring > path-substring > fuzzy) keep the most specific
+// match at the top. Returns (0, false) when nothing matches.
+func scoreFilenameMatch(query, base, rel string, fuzzy bool) (int, bool) {
+	q := strings.ToLower(query)
+	b := strings.ToLower(base)
+	r := strings.ToLower(rel)
+	switch {
+	case b == q:
+		return 100, true
+	case strings.HasPrefix(b, q):
+		return 70, true
+	case strings.Contains(b, q):
+		return 50, true
+	case strings.Contains(r, q):
+		return 30, true
+	}
+	if fuzzy && isSubsequence(q, b) {
+		return 10, true
+	}
+	return 0, false
+}
+
+// isSubsequence reports whether every rune of needle appears in haystack
+// in order (a cheap fzf-style filename match). Both are expected to be
+// lowercased by the caller.
+func isSubsequence(needle, haystack string) bool {
+	if needle == "" {
+		return true
+	}
+	i := 0
+	for j := 0; j < len(haystack) && i < len(needle); j++ {
+		if haystack[j] == needle[i] {
+			i++
+		}
+	}
+	return i == len(needle)
+}

--- a/internal/mcp/tools_find_files_test.go
+++ b/internal/mcp/tools_find_files_test.go
@@ -1,0 +1,145 @@
+package mcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+	"github.com/zzet/gortex/internal/query"
+)
+
+type findFilesResult struct {
+	Files []struct {
+		Path     string `json:"path"`
+		Language string `json:"language"`
+		ID       string `json:"id"`
+	} `json:"files"`
+	Count int `json:"count"`
+}
+
+func setupFindFilesServer(t *testing.T) *Server {
+	t.Helper()
+	dir := t.TempDir()
+	write := func(rel, body string) {
+		full := filepath.Join(dir, filepath.FromSlash(rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(body), 0o644))
+	}
+	write("main.go", "package app\n\nfunc Main() {}\n")
+	write("internal/handler.go", "package internal\n\nfunc Handle() {}\n")
+	write("internal/sub/handler_test.go", "package sub\n\nfunc TestHandle() {}\n")
+
+	g := graph.New()
+	reg := parser.NewRegistry()
+	languages.RegisterAll(reg)
+	cfg := config.Default()
+	idx := indexer.New(g, reg, cfg.Index, zap.NewNop())
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+	eng := query.NewEngine(g)
+	return NewServer(eng, g, idx, nil, zap.NewNop(), nil)
+}
+
+func decodeFindFiles(t *testing.T, res *mcplib.CallToolResult) findFilesResult {
+	t.Helper()
+	require.False(t, res.IsError)
+	var out findFilesResult
+	require.NoError(t, json.Unmarshal([]byte(res.Content[0].(mcplib.TextContent).Text), &out))
+	return out
+}
+
+func TestFindFiles_ByName(t *testing.T) {
+	srv := setupFindFilesServer(t)
+
+	// A basename substring matches both handler files; the shallower
+	// one ranks first (same score, fewer path segments).
+	resp := decodeFindFiles(t, callTool(t, srv, "find_files", map[string]any{"query": "handler"}))
+	require.GreaterOrEqual(t, resp.Count, 2)
+	require.Equal(t, "internal/handler.go", resp.Files[0].Path)
+
+	// An exact basename only matches the one file.
+	exact := decodeFindFiles(t, callTool(t, srv, "find_files", map[string]any{"query": "handler.go"}))
+	require.Equal(t, 1, exact.Count)
+	require.Equal(t, "internal/handler.go", exact.Files[0].Path)
+
+	// main.go is reachable by name.
+	main := decodeFindFiles(t, callTool(t, srv, "find_files", map[string]any{"query": "main"}))
+	require.Equal(t, 1, main.Count)
+	require.Equal(t, "main.go", main.Files[0].Path)
+}
+
+func TestFindFiles_Glob(t *testing.T) {
+	srv := setupFindFilesServer(t)
+
+	resp := decodeFindFiles(t, callTool(t, srv, "find_files", map[string]any{"glob": "*_test.go"}))
+	require.Equal(t, 1, resp.Count)
+	require.Equal(t, "internal/sub/handler_test.go", resp.Files[0].Path)
+}
+
+func TestFindFiles_Fuzzy(t *testing.T) {
+	srv := setupFindFilesServer(t)
+
+	// "hndlr" is a subsequence of "handler.go" but not a substring.
+	none := decodeFindFiles(t, callTool(t, srv, "find_files", map[string]any{"query": "hndlr"}))
+	require.Equal(t, 0, none.Count)
+
+	fuzzy := decodeFindFiles(t, callTool(t, srv, "find_files",
+		map[string]any{"query": "hndlr", "fuzzy": true}))
+	require.GreaterOrEqual(t, fuzzy.Count, 1)
+	require.Equal(t, "internal/handler.go", fuzzy.Files[0].Path)
+}
+
+func TestFindFiles_PathScoping(t *testing.T) {
+	srv := setupFindFilesServer(t)
+
+	scoped := decodeFindFiles(t, callTool(t, srv, "find_files",
+		map[string]any{"query": "handler", "path": "internal/sub"}))
+	require.Equal(t, 1, scoped.Count)
+	require.Equal(t, "internal/sub/handler_test.go", scoped.Files[0].Path)
+}
+
+func TestFindFiles_RequiresArg(t *testing.T) {
+	srv := setupFindFilesServer(t)
+	bad := callTool(t, srv, "find_files", map[string]any{})
+	require.True(t, bad.IsError)
+}
+
+func TestScoreFilenameMatch(t *testing.T) {
+	cases := []struct {
+		query, base, rel string
+		fuzzy            bool
+		want             int
+		ok               bool
+	}{
+		{"handler.go", "handler.go", "internal/handler.go", false, 100, true},
+		{"hand", "handler.go", "internal/handler.go", false, 70, true},
+		{"ndl", "handler.go", "internal/handler.go", false, 50, true},
+		{"internal", "handler.go", "internal/handler.go", false, 30, true},
+		{"nomatch", "handler.go", "internal/handler.go", false, 0, false},
+		{"hndlr", "handler.go", "internal/handler.go", true, 10, true},
+		{"hndlr", "handler.go", "internal/handler.go", false, 0, false},
+	}
+	for _, c := range cases {
+		got, ok := scoreFilenameMatch(c.query, c.base, c.rel, c.fuzzy)
+		require.Equal(t, c.ok, ok, "match? query=%q", c.query)
+		require.Equal(t, c.want, got, "score query=%q", c.query)
+	}
+}
+
+func TestIsSubsequence(t *testing.T) {
+	require.True(t, isSubsequence("", "anything"))
+	require.True(t, isSubsequence("abc", "aXbYcZ"))
+	require.True(t, isSubsequence("hndlr", "handler.go"))
+	require.False(t, isSubsequence("abc", "acb"))
+	require.False(t, isSubsequence("xyz", "abc"))
+}

--- a/internal/mcp/tools_mode.go
+++ b/internal/mcp/tools_mode.go
@@ -48,6 +48,19 @@ func (s *Server) toolSurfaceFilter(ctx context.Context, tools []mcp.Tool) []mcp.
 		}
 		tools = kept
 	}
+	// Tool-surface preset (hide mode): keep only the tools in the active
+	// preset's allow-set so a headless / restricted harness sees exactly
+	// its surface and nothing else.
+	if s.toolPolicy.hideMode() {
+		kept := make([]mcp.Tool, 0, len(tools))
+		for _, t := range tools {
+			if !s.toolPolicy.allows(t.Name) {
+				continue
+			}
+			kept = append(kept, t)
+		}
+		tools = kept
+	}
 	// Per-host adaptation: drop tools the host duplicates and apply any
 	// host-specific description overrides (see host_context.go).
 	return s.sessionHostContext(ctx).apply(tools)
@@ -64,7 +77,26 @@ func (s *Server) checkToolGate(ctx context.Context, toolName string) *mcp.CallTo
 	if blocked := s.checkWorkflowGate(ctx, toolName); blocked != nil {
 		return blocked
 	}
+	if blocked := s.checkToolPresetGate(toolName); blocked != nil {
+		return blocked
+	}
 	return nil
+}
+
+// checkToolPresetGate hard-blocks calls to tools outside the active
+// hide-mode preset, so a client that hard-codes a hidden tool name can't
+// bypass the restricted surface. Defer mode needs no gate — non-allowed
+// tools simply aren't registered live until tools_search promotes them.
+func (s *Server) checkToolPresetGate(toolName string) *mcp.CallToolResult {
+	if !s.toolPolicy.hideMode() || s.toolPolicy.allows(toolName) {
+		return nil
+	}
+	return NewStructuredErrorResult(StructuredError{
+		ErrorCode: ErrCodeToolBlockedByMode,
+		Message: fmt.Sprintf("%q is not part of the active tool preset %q — it has been removed from this "+
+			"server's tool surface. Call tool_profile to see the available tools.", toolName, s.toolPolicy.preset),
+		Data: map[string]any{"tool": toolName, "preset": s.toolPolicy.preset},
+	})
 }
 
 // checkPlanningModeGate blocks editing tools while the session is in

--- a/internal/serverstack/shared_server.go
+++ b/internal/serverstack/shared_server.go
@@ -433,6 +433,12 @@ func NewSharedServer(cfg SharedServerConfig) (*SharedServer, error) {
 	}
 	s.MultiIndexer = mi
 
+	toolPolicyCfg := gortexmcp.ToolPolicyConfig{
+		Preset: conf.MCP.Tools.Preset,
+		Mode:   conf.MCP.Tools.Mode,
+		Allow:  conf.MCP.Tools.Allow,
+		Deny:   conf.MCP.Tools.Deny,
+	}
 	var multiOpts []gortexmcp.MultiRepoOptions
 	if mi != nil || cm != nil {
 		multiOpts = append(multiOpts, gortexmcp.MultiRepoOptions{
@@ -441,6 +447,7 @@ func NewSharedServer(cfg SharedServerConfig) (*SharedServer, error) {
 			ActiveProject:  cfg.ActiveProject,
 			ScopeWorkspace: cfg.ScopeWorkspace,
 			ScopeProject:   cfg.ScopeProject,
+			ToolPolicy:     &toolPolicyCfg,
 		})
 	}
 


### PR DESCRIPTION
Gortex publishes ~170 MCP tools. For many agents — especially a **headless harness** where an agent on a trusted machine edits code on a remote box you don't mind disturbing — that's far more surface than needed, and there was no way to narrow it. This PR makes the tool surface configurable at three levels, adds a real file-name search tool, and surfaces a tool→category grouping.

 ## What's in it

 **1. `find_files` — search by file name.** File nodes are excluded from the symbol index, so `search_symbols kind:file` silently returned nothing. `find_files` enumerates file nodes directly and ranks by basename match (exact > prefix > substring > path-substring), with optional `glob` and `fuzzy` subsequence matching, honouring session scope and `path`/`repo` filters.

**2. Tool-surface presets.** Restrict the published surface to a named preset — `full` (default), `readonly` (everything minus mutating tools), `edit` (a minimal orient→navigate→mutate→verify set), or `nav` (read-only exploration) — plus `+allow` / `-deny` per-tool deltas. An **explicit comma list** whose first token isn't a preset (`search_symbols,edit_file,find_files`) is taken as the exact allow-set, for experts who want to hand-pick the surface. `tool_profile` and `tools_search` are always kept.

Two modes:
  - `hide` (default) — non-allowed tools are removed from `tools/list` **and** calls to them are hard-blocked. Works identically on every client.
  - `defer` — non-allowed tools stay reachable via `tools_search` (the lazy-discovery path); effective only on clients that honour `notifications/tools/list_changed`.

**3. Three ways to select it** (precedence **env > flag > config > default**):
  - config: `mcp.tools.{preset,mode,allow,deny}` in `.gortex.yaml`
  - env: `GORTEX_TOOLS` / `GORTEX_TOOLS_MODE`
  - flags: `--tools` / `--tools-mode` on `gortex mcp` and `gortex daemon start`

**4. Per-connection (client-driven) scoping.** `gortex daemon start --tools …` narrows the whole daemon. To let one client pick its own surface while the daemon keeps serving the full set to everyone else, `--tools` / `GORTEX_TOOLS` on a client's **`gortex mcp`** invocation now filters just that connection's `tools/list` and blocks calls to tools outside the set — enforced in the stdio proxy, daemon untouched. Because the filter applies from the first `tools/list`, it works on every MCP client regardless of `tools/list_changed` support. (Previously `--tools` only affected the embedded no-daemon server and was silently ignored when proxying.)

  ```jsonc
  // A client's MCP config — minimal editing surface against a full daemon:
  { "command": "gortex",
    "args": ["mcp", "--tools", "search_symbols,find_files,edit_file,verify_change"] }
  // or  ["mcp","--tools","edit"]   ·   or  "env": { "GORTEX_TOOLS": "readonly" }
  ```

**5. Tool categories.** `tool_profile` now reports a `category` per tool (nav / read / edit / analysis / review / pr / memory / overlay / subscription / enrich / workspace / admin), derived from the de-facto name prefixes with an override map for irregular names — so the flat namespace can be filtered by family.

 ## Design notes

- The single per-session `tools/list` filter (`toolSurfaceFilter`, already wired via `server.WithToolFilter`) is the enforcement point for `hide` mode; `defer` mode reuses the lazy registry by making the preset's allow-set its eager predicate. `checkToolGate` (on every call) hard-blocks `hide`-mode calls.
  - `--detach` re-execs `daemon start` with no flags, so the daemon path propagates the selection to the child via `GORTEX_TOOLS` env (same mechanism `--embeddings` uses).
  - The proxy filter is two JSON-RPC-aware pumps that rewrite `tools/list` results and synthesize a `-32601` reply for forbidden `tools/call`s; both stdout writers share a mutex.
  - Per-session preset negotiation *inside* the daemon (initialize/token → `SessionState`) was intentionally not built — the proxy approach gives the same outcome without touching the shared-server model.

## Docs

`docs/mcp.md` documents `find_files`, the preset selectors, the modes, and per-connection scoping.