### PR TITLE
feat(embedding): authenticated, size-robust API embedder + vector persistence + warm-restart fix

### DIFF
--- a/cmd/gortex/daemon.go
+++ b/cmd/gortex/daemon.go
@@ -37,7 +37,13 @@ var (
 	// (the function has no *cobra.Command of its own) to decide whether
 	// the flag overrides the `embedding:` config block. Set once in
 	// runDaemonStart before buildDaemonState runs.
-	daemonEmbeddingsChanged     bool
+	daemonEmbeddingsChanged bool
+	// daemonEmbeddingsURL / daemonEmbeddingsModel mirror `gortex mcp`'s
+	// --embeddings-url / --embeddings-model so the daemon can be started with an
+	// explicit OpenAI-compatible (or Ollama) embedding API. A non-empty URL forces
+	// the api provider in ResolveEmbedder, overriding the embedding: config block.
+	daemonEmbeddingsURL         string
+	daemonEmbeddingsModel       string
 	daemonStatusWatch           bool
 	daemonStatusInterval        time.Duration
 	daemonHTTPAddr              string
@@ -103,6 +109,10 @@ func init() {
 		"fork to background after starting (logs to the daemon log file — see `gortex daemon logs`)")
 	daemonStartCmd.Flags().BoolVar(&daemonEmbeddings, "embeddings", false,
 		"load a semantic embedding provider (opt-in — adds ~87 MB model download on first use and ~60 ms/symbol warmup)")
+	daemonStartCmd.Flags().StringVar(&daemonEmbeddingsURL, "embeddings-url", "",
+		"OpenAI-compatible (or Ollama) embedding API base URL (e.g. https://api.openai.com/v1). A non-empty URL forces the api provider, overriding the embedding: config. Key via $GORTEX_EMBEDDINGS_API_KEY or $OPENAI_API_KEY (openai.com only).")
+	daemonStartCmd.Flags().StringVar(&daemonEmbeddingsModel, "embeddings-model", "",
+		"embedding model for --embeddings-url (default: auto-detect — text-embedding-3-small for OpenAI, nomic-embed-text for Ollama)")
 	daemonStartCmd.Flags().StringVar(&daemonHTTPAddr, "http-addr", "",
 		"also expose the MCP 2026 Streamable HTTP transport on this TCP address (e.g. 127.0.0.1:7411); empty disables")
 	daemonStartCmd.Flags().StringVar(&daemonHTTPAuthToken, "http-auth-token", "",

--- a/cmd/gortex/daemon_state.go
+++ b/cmd/gortex/daemon_state.go
@@ -641,8 +641,15 @@ func priorMtimesFromStore(g graph.Store, cm *config.ConfigManager, entry config.
 	// a worktree instance persists its mtimes under `<base>@<workspace>`,
 	// not the bare basename, so a plain ResolvePrefix would load the
 	// canonical checkout's mtimes and force a full re-index every restart.
-	prefix := strings.TrimPrefix(indexer.EffectiveRepoPrefix(cm, entry), "/")
-	if prefix == "" {
+	effective := strings.TrimPrefix(indexer.EffectiveRepoPrefix(cm, entry), "/")
+	repoCount := 1
+	if cm != nil {
+		if g := cm.Global(); g != nil {
+			repoCount = len(g.Repos)
+		}
+	}
+	prefix, ok := warmMtimePrefix(effective, repoCount)
+	if !ok {
 		if logger != nil {
 			logger.Info("daemon: priorMtimesFromStore: empty prefix",
 				zap.String("entry_path", entry.Path),
@@ -654,9 +661,39 @@ func priorMtimesFromStore(g graph.Store, cm *config.ConfigManager, entry config.
 	if logger != nil {
 		logger.Info("daemon: priorMtimesFromStore loaded",
 			zap.String("prefix", prefix),
+			zap.Bool("single_repo", repoCount < 2),
 			zap.Int("count", len(mtimes)))
 	}
 	return mtimes
+}
+
+// warmMtimePrefix picks the repo_prefix to look up persisted file mtimes
+// (and, by extension, to decide whether the warm-restart reconcile can run)
+// for a repo whose EffectiveRepoPrefix is `effective` in a daemon tracking
+// `repoCount` repos total.
+//
+// PURPOSE: single-repo daemons index WITHOUT a prefix — MultiIndexer.
+// indexSingleRepo / ReconcileRepoCtx only switch on a repo prefix once a
+// SECOND repo joins (the willBeMultiRepo gate). So a lone repo's nodes and
+// file_mtimes rows are persisted under "", while EffectiveRepoPrefix returns
+// the path basename (e.g. "drools"). Looking mtimes up under the basename
+// finds zero rows and forces a full cold re-index — and, with an API
+// embedder, a full (paid) re-embed — on every restart.
+//
+// RATIONALE: mirror the indexer's own single-vs-multi decision here so the
+// warm path keys mtimes exactly where they were written. In multi-repo mode
+// an empty effective prefix is untrustworthy (it would collide across repos),
+// so report ok=false and let the caller fall back to a cold index.
+//
+// KEYWORDS: warm-restart, repo-prefix, single-repo, file_mtimes, re-embed
+func warmMtimePrefix(effective string, repoCount int) (prefix string, ok bool) {
+	if repoCount < 2 {
+		return "", true
+	}
+	if effective == "" {
+		return "", false
+	}
+	return effective, true
 }
 
 // storeNeedsRebuild reports whether the backend signalled, via the optional

--- a/cmd/gortex/daemon_state.go
+++ b/cmd/gortex/daemon_state.go
@@ -138,6 +138,8 @@ func buildDaemonState(logger *zap.Logger) (*daemonState, error) {
 		Embedder: serverstack.EmbedderRequest{
 			FlagChanged: daemonEmbeddingsChanged,
 			FlagEnabled: daemonEmbeddings,
+			FlagURL:     daemonEmbeddingsURL,
+			FlagModel:   daemonEmbeddingsModel,
 		},
 		// Workspace-global side-store layout: notes/memories partition
 		// under the "daemon" key in the shared DataDir sidecar; the

--- a/cmd/gortex/daemon_state_test.go
+++ b/cmd/gortex/daemon_state_test.go
@@ -73,3 +73,33 @@ func TestLSPDisabledSet_Empty(t *testing.T) {
 		t.Fatalf("expected empty map, got %v", got)
 	}
 }
+
+// TestWarmMtimePrefix covers the single- vs multi-repo prefix decision the
+// warm-restart mtime lookup hangs on. The bug it guards: a lone repo indexes
+// unprefixed (rows under ""), but EffectiveRepoPrefix returns the basename, so
+// looking up the basename finds nothing and forces a paid cold re-index every
+// restart.
+func TestWarmMtimePrefix(t *testing.T) {
+	cases := []struct {
+		name       string
+		effective  string
+		repoCount  int
+		wantPrefix string
+		wantOK     bool
+	}{
+		{"single repo uses empty prefix (the bug)", "drools", 1, "", true},
+		{"single repo, zero configured still unprefixed", "drools", 0, "", true},
+		{"multi-repo keeps its derived prefix", "drools", 2, "drools", true},
+		{"multi-repo with no prefix is untrustworthy", "", 3, "", false},
+		{"single repo already empty prefix", "", 1, "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotPrefix, gotOK := warmMtimePrefix(tc.effective, tc.repoCount)
+			if gotPrefix != tc.wantPrefix || gotOK != tc.wantOK {
+				t.Fatalf("warmMtimePrefix(%q, %d) = (%q, %v), want (%q, %v)",
+					tc.effective, tc.repoCount, gotPrefix, gotOK, tc.wantPrefix, tc.wantOK)
+			}
+		})
+	}
+}

--- a/internal/embedding/api.go
+++ b/internal/embedding/api.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -18,10 +19,48 @@ import (
 // fails and the caller aborts to text-only search.
 const maxRetryAfterWait = 60 * time.Second
 
+// maxEmbedInputBytes caps each embedding input. OpenAI's embedding models
+// reject inputs over 8192 tokens with a 400 that aborts the WHOLE batch
+// (and the vector index). A BPE tokenizer never emits more tokens than
+// input characters, and for single-byte (ASCII) source — the overwhelming
+// majority of code — characters equal bytes, so capping the head at 8000
+// bytes guarantees ≤8000 tokens, safely under the 8192 limit, regardless
+// of how token-dense the snippet is. The truncated head still carries the
+// symbol's signature and leading body — enough signal for nearest-neighbour
+// search. Head-truncation beats dropping the whole index over a few giant
+// generated symbols.
+const maxEmbedInputBytes = 8000
+
+// truncateEmbedInputs head-truncates any input over the byte cap, on a
+// UTF-8 rune boundary so the JSON payload stays valid. Returns the same
+// slice when nothing needed trimming (the common case).
+func truncateEmbedInputs(texts []string) []string {
+	var out []string
+	for i, t := range texts {
+		if len(t) <= maxEmbedInputBytes {
+			continue
+		}
+		if out == nil {
+			out = make([]string, len(texts))
+			copy(out, texts)
+		}
+		b := []byte(t[:maxEmbedInputBytes])
+		for len(b) > 0 && b[len(b)-1]&0xC0 == 0x80 { // back off mid-rune
+			b = b[:len(b)-1]
+		}
+		out[i] = string(b)
+	}
+	if out == nil {
+		return texts
+	}
+	return out
+}
+
 // APIProvider calls an external embedding API (Ollama or OpenAI-compatible).
 type APIProvider struct {
 	url    string
 	model  string
+	apiKey string
 	client *http.Client
 	dims   int
 	format apiFormat
@@ -50,9 +89,21 @@ func NewAPIProvider(url, model string) *APIProvider {
 		}
 	}
 
+	// API key for authenticated embedding backends (OpenAI, Azure, and
+	// OpenAI-compatible gateways). Ollama on localhost is keyless, so the
+	// key stays optional and an unset value just omits the header. Prefer
+	// an explicit GORTEX_EMBEDDINGS_API_KEY; fall back to OPENAI_API_KEY
+	// only when the endpoint is api.openai.com, so a stray OPENAI_API_KEY
+	// can never leak to an arbitrary third-party URL.
+	apiKey := os.Getenv("GORTEX_EMBEDDINGS_API_KEY")
+	if apiKey == "" && strings.Contains(url, "openai.com") {
+		apiKey = os.Getenv("OPENAI_API_KEY")
+	}
+
 	return &APIProvider{
 		url:    strings.TrimRight(url, "/"),
 		model:  model,
+		apiKey: apiKey,
 		client: &http.Client{Timeout: 30 * time.Second},
 		format: format,
 	}
@@ -155,7 +206,7 @@ type ollamaResponse struct {
 func (p *APIProvider) embedOllama(ctx context.Context, texts []string) ([][]float32, error) {
 	reqBody := ollamaRequest{
 		Model: p.model,
-		Input: texts,
+		Input: truncateEmbedInputs(texts),
 	}
 
 	body, err := json.Marshal(reqBody)
@@ -169,6 +220,9 @@ func (p *APIProvider) embedOllama(ctx context.Context, texts []string) ([][]floa
 		return nil, fmt.Errorf("create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	if p.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+p.apiKey)
+	}
 
 	resp, err := p.doRequest(ctx, req, body)
 	if err != nil {
@@ -212,7 +266,7 @@ type openAIEmbedding struct {
 func (p *APIProvider) embedOpenAI(ctx context.Context, texts []string) ([][]float32, error) {
 	reqBody := openAIRequest{
 		Model: p.model,
-		Input: texts,
+		Input: truncateEmbedInputs(texts),
 	}
 
 	body, err := json.Marshal(reqBody)
@@ -226,6 +280,9 @@ func (p *APIProvider) embedOpenAI(ctx context.Context, texts []string) ([][]floa
 		return nil, fmt.Errorf("create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	if p.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+p.apiKey)
+	}
 
 	resp, err := p.doRequest(ctx, req, body)
 	if err != nil {

--- a/internal/embedding/api.go
+++ b/internal/embedding/api.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 )
 
@@ -64,7 +65,19 @@ type APIProvider struct {
 	client *http.Client
 	dims   int
 	format apiFormat
+
+	// tokensUsed accumulates the `usage.total_tokens` reported by the
+	// embedding backend across every request, so the indexer can log the
+	// actual token spend of a paid embedding pass (otherwise invisible).
+	// Touched from several goroutines under the concurrent embedding pool,
+	// hence atomic.
+	tokensUsed int64
 }
+
+// TokensUsed reports the total embedding tokens this provider has been
+// billed for so far, summed from each response's usage.total_tokens.
+// Returns 0 for backends that don't report usage (e.g. Ollama).
+func (p *APIProvider) TokensUsed() int64 { return atomic.LoadInt64(&p.tokensUsed) }
 
 type apiFormat int
 
@@ -255,7 +268,15 @@ type openAIRequest struct {
 }
 
 type openAIResponse struct {
-	Data []openAIEmbedding `json:"data"`
+	Data  []openAIEmbedding `json:"data"`
+	Usage openAIUsage       `json:"usage"`
+}
+
+// openAIUsage carries the token accounting OpenAI returns alongside every
+// embeddings response. total_tokens is what the request is billed on.
+type openAIUsage struct {
+	PromptTokens int `json:"prompt_tokens"`
+	TotalTokens  int `json:"total_tokens"`
 }
 
 type openAIEmbedding struct {
@@ -298,6 +319,10 @@ func (p *APIProvider) embedOpenAI(ctx context.Context, texts []string) ([][]floa
 	var result openAIResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, fmt.Errorf("decode response: %w", err)
+	}
+
+	if result.Usage.TotalTokens > 0 {
+		atomic.AddInt64(&p.tokensUsed, int64(result.Usage.TotalTokens))
 	}
 
 	vecs := make([][]float32, len(result.Data))

--- a/internal/embedding/api.go
+++ b/internal/embedding/api.go
@@ -143,6 +143,40 @@ func (p *APIProvider) EmbedBatch(ctx context.Context, texts []string) ([][]float
 func (p *APIProvider) Dimensions() int { return p.dims }
 func (p *APIProvider) Close() error    { return nil }
 
+// ProbeDimensions makes one tiny embedding call to discover and cache the
+// provider's vector width, so Dimensions() reports the true value *before*
+// the first indexing pass. An APIProvider learns its width only from the
+// first real embed (embedOpenAI / embedOllama set p.dims from the returned
+// vector); until then Dimensions() returns 0, which has two concrete
+// consequences at daemon startup: the "embeddings enabled" log mislabels
+// the width as dim:0, and the snapshot-vector reload gate
+// (daemon_state.go: vec.Dims == EmbedderDims) rejects a correctly-sized
+// persisted index, forcing a needless full re-embed on every restart.
+//
+// Idempotent: a no-op once the width is known. Best-effort: on any
+// transport/auth error it returns the error and leaves dims at 0 — the
+// caller logs a warning, the lazy path still sets the width from the first
+// real vector, and indexing degrades to BM25 if embeddings are truly
+// unreachable. The probe also doubles as an early connectivity/credential
+// check, surfacing a bad key or URL at startup instead of mid-index.
+func (p *APIProvider) ProbeDimensions(ctx context.Context) (int, error) {
+	if d := p.Dimensions(); d > 0 {
+		return d, nil
+	}
+	pctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+	vec, err := p.Embed(pctx, "gortex embedding dimension probe")
+	if err != nil {
+		return 0, err
+	}
+	// Embed -> EmbedBatch -> embed{OpenAI,Ollama} already cached p.dims from
+	// the response; fall back to the returned vector's length defensively.
+	if p.dims == 0 && len(vec) > 0 {
+		p.dims = len(vec)
+	}
+	return p.dims, nil
+}
+
 // Concurrent reports that this provider is safe — and worth — calling
 // from several goroutines at once. An external HTTP embedding endpoint
 // gains from overlapped round-trips; the indexer's embedding pool uses
@@ -295,7 +329,16 @@ func (p *APIProvider) embedOpenAI(ctx context.Context, texts []string) ([][]floa
 		return nil, fmt.Errorf("marshal request: %w", err)
 	}
 
-	url := p.url + "/v1/embeddings"
+	// OpenAI-compatible bases are conventionally given WITH the version
+	// segment (OpenAI "https://api.openai.com/v1", OpenRouter
+	// "https://openrouter.ai/api/v1"). Append "/v1" only when it is absent,
+	// so a "…/v1" base does not become "…/v1/v1/embeddings" (a 404 that
+	// silently degrades the whole vector index to BM25).
+	endpoint := "/v1/embeddings"
+	if strings.HasSuffix(p.url, "/v1") {
+		endpoint = "/embeddings"
+	}
+	url := p.url + endpoint
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)

--- a/internal/embedding/api_test.go
+++ b/internal/embedding/api_test.go
@@ -105,3 +105,60 @@ func TestAPIProvider_PersistentRateLimitFails(t *testing.T) {
 	assert.LessOrEqual(t, atomic.LoadInt32(&calls), int32(2),
 		"the 429 retry is bounded to a single re-attempt")
 }
+
+// TestAPIProvider_SendsAuthorizationHeader asserts that an embeddings API
+// key (GORTEX_EMBEDDINGS_API_KEY) is forwarded as an Authorization: Bearer
+// header — the fix that lets gortex use authenticated backends like OpenAI.
+func TestAPIProvider_SendsAuthorizationHeader(t *testing.T) {
+	t.Setenv("GORTEX_EMBEDDINGS_API_KEY", "test-secret")
+
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"embedding":[0.1,0.2],"index":0}]}`))
+	}))
+	defer srv.Close()
+
+	// A non-Ollama URL selects the OpenAI format (the /v1/embeddings path).
+	p := NewAPIProvider(srv.URL, "text-embedding-3-small")
+	_, err := p.EmbedBatch(context.Background(), []string{"hello"})
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer test-secret", gotAuth)
+}
+
+// TestAPIProvider_NoKeyOmitsAuthorizationHeader asserts that with no key
+// configured, no Authorization header is sent (keyless Ollama stays keyless
+// and a stray OPENAI_API_KEY does not leak to a non-OpenAI endpoint).
+func TestAPIProvider_NoKeyOmitsAuthorizationHeader(t *testing.T) {
+	t.Setenv("GORTEX_EMBEDDINGS_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+
+	var hadAuth bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, hadAuth = r.Header["Authorization"]
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"embedding":[0.1],"index":0}]}`))
+	}))
+	defer srv.Close()
+
+	p := NewAPIProvider(srv.URL, "text-embedding-3-small")
+	_, err := p.EmbedBatch(context.Background(), []string{"hi"})
+	require.NoError(t, err)
+	assert.False(t, hadAuth, "no Authorization header without a configured key")
+}
+
+// TestTruncateEmbedInputs asserts oversized inputs are head-truncated to the
+// byte cap (so OpenAI's 8192-token limit can't abort the whole vector index)
+// while normal inputs pass through untouched.
+func TestTruncateEmbedInputs(t *testing.T) {
+	short := "small symbol"
+	long := string(make([]byte, maxEmbedInputBytes+500))
+
+	out := truncateEmbedInputs([]string{short, long})
+	assert.Equal(t, short, out[0], "short input untouched")
+	assert.LessOrEqual(t, len(out[1]), maxEmbedInputBytes, "long input capped")
+
+	in := []string{"a", "b"}
+	assert.Equal(t, in, truncateEmbedInputs(in), "no oversize → same slice values")
+}

--- a/internal/embedding/api_test.go
+++ b/internal/embedding/api_test.go
@@ -148,6 +148,28 @@ func TestAPIProvider_NoKeyOmitsAuthorizationHeader(t *testing.T) {
 	assert.False(t, hadAuth, "no Authorization header without a configured key")
 }
 
+// TestAPIProvider_AccumulatesTokenUsage asserts the provider reads the
+// OpenAI `usage.total_tokens` field off each embedding response and
+// accumulates it across calls — the signal the indexer logs so the paid
+// embedding pass reports its actual token spend (it otherwise vanishes).
+func TestAPIProvider_AccumulatesTokenUsage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"embedding":[0.1,0.2],"index":0}],"usage":{"prompt_tokens":7,"total_tokens":7}}`))
+	}))
+	defer srv.Close()
+
+	p := NewAPIProvider(srv.URL, "text-embedding-3-small")
+	assert.Equal(t, int64(0), p.TokensUsed(), "no tokens before any call")
+
+	_, err := p.EmbedBatch(context.Background(), []string{"hello"})
+	require.NoError(t, err)
+	_, err = p.EmbedBatch(context.Background(), []string{"world"})
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(14), p.TokensUsed(), "usage accumulates across batches")
+}
+
 // TestTruncateEmbedInputs asserts oversized inputs are head-truncated to the
 // byte cap (so OpenAI's 8192-token limit can't abort the whole vector index)
 // while normal inputs pass through untouched.

--- a/internal/embedding/api_test.go
+++ b/internal/embedding/api_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -168,6 +169,105 @@ func TestAPIProvider_AccumulatesTokenUsage(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, int64(14), p.TokensUsed(), "usage accumulates across batches")
+}
+
+// TestAPIProvider_OpenAIBaseURLVariants asserts the OpenAI request path is
+// "/v1/embeddings" whether the base URL is given with or without the "/v1"
+// version segment. OpenAI-compatible bases conventionally include "/v1"
+// (OpenAI, OpenRouter); without this normalization a "…/v1" base produced
+// "…/v1/v1/embeddings" → 404 → silent fallback to BM25.
+func TestAPIProvider_OpenAIBaseURLVariants(t *testing.T) {
+	for _, suffix := range []string{"", "/v1"} {
+		suffix := suffix
+		t.Run("base"+suffix, func(t *testing.T) {
+			var gotPath string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"data":[{"embedding":[0.1,0.2],"index":0}]}`))
+			}))
+			defer srv.Close()
+
+			p := NewAPIProvider(srv.URL+suffix, "text-embedding-3-small")
+			_, err := p.EmbedBatch(context.Background(), []string{"hi"})
+			require.NoError(t, err)
+			assert.Equal(t, "/v1/embeddings", gotPath,
+				"both base forms must resolve to a single /v1/embeddings path")
+		})
+	}
+}
+
+// TestAPIProvider_ProbeDimensions asserts the probe discovers the vector
+// width with exactly one embedding call, caches it (so Dimensions() then
+// reports the true width up front), and is idempotent — a second probe
+// issues no further HTTP. This is the fix for the daemon logging dim:0 and
+// the snapshot-vector reload gate rejecting a correctly-sized cached index.
+func TestAPIProvider_ProbeDimensions(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		// A 4-dimensional vector stands in for OpenAI's 1536-d response.
+		_, _ = w.Write([]byte(`{"data":[{"embedding":[0.1,0.2,0.3,0.4],"index":0}],"usage":{"total_tokens":3}}`))
+	}))
+	defer srv.Close()
+
+	p := NewAPIProvider(srv.URL, "text-embedding-3-small")
+	assert.Equal(t, 0, p.Dimensions(), "width unknown before the first call")
+
+	dim, err := p.ProbeDimensions(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 4, dim, "probe reports the response vector width")
+	assert.Equal(t, 4, p.Dimensions(), "width is cached after the probe")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "the probe is a single call")
+
+	dim2, err := p.ProbeDimensions(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 4, dim2)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "a second probe issues no further HTTP")
+}
+
+// TestAPIProvider_ProbeDimensionsError asserts that a probe against an
+// unreachable / erroring backend surfaces the error and leaves the width at
+// 0 (best-effort) — the caller only warns and indexing falls back to BM25.
+func TestAPIProvider_ProbeDimensionsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"bad key"}`))
+	}))
+	defer srv.Close()
+
+	p := NewAPIProvider(srv.URL, "text-embedding-3-small")
+	dim, err := p.ProbeDimensions(context.Background())
+	require.Error(t, err, "an auth failure must surface as an error")
+	assert.Equal(t, 0, dim)
+	assert.Equal(t, 0, p.Dimensions(), "a failed probe leaves the width unset")
+}
+
+// TestAPIProvider_ProbeDimensionsLive hits the REAL OpenAI embeddings API to
+// prove the fork's embedder is genuinely wired end-to-end (not a stub): the
+// probe returns text-embedding-3-small's true 1536-d width, a batch embed
+// returns 1536-d vectors, and token usage is accounted. Skipped unless a key
+// is present so CI without credentials stays green.
+//
+//	OPENAI_API_KEY=sk-... go test ./internal/embedding -run ProbeDimensionsLive -v
+func TestAPIProvider_ProbeDimensionsLive(t *testing.T) {
+	if os.Getenv("GORTEX_EMBEDDINGS_API_KEY") == "" && os.Getenv("OPENAI_API_KEY") == "" {
+		t.Skip("no embeddings API key (set OPENAI_API_KEY) — skipping live OpenAI probe")
+	}
+
+	p := NewAPIProvider("https://api.openai.com/v1", "text-embedding-3-small")
+	dim, err := p.ProbeDimensions(context.Background())
+	require.NoError(t, err, "live probe against OpenAI must succeed")
+	assert.Equal(t, 1536, dim, "text-embedding-3-small is 1536-dimensional")
+	assert.Equal(t, 1536, p.Dimensions())
+
+	vecs, err := p.EmbedBatch(context.Background(), []string{"rule engine evaluates facts", "knowledge base"})
+	require.NoError(t, err)
+	require.Len(t, vecs, 2)
+	assert.Len(t, vecs[0], 1536, "each returned vector is 1536-d")
+	assert.Len(t, vecs[1], 1536)
+	assert.Greater(t, p.TokensUsed(), int64(0), "the paid embedding pass accounts token usage")
 }
 
 // TestTruncateEmbedInputs asserts oversized inputs are head-truncated to the

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -194,6 +194,16 @@ type Indexer struct {
 	// vectors when an embedder is present.
 	skipVectorBuild bool
 
+	// bulkVectorSink holds the disk store captured at the bulk-load
+	// shadow swap, so buildSearchIndex can still persist the vector
+	// index to the backend while idx.graph points at the in-memory
+	// shadow (which does not implement graph.VectorSearcher). Without
+	// it the embedding pass under the bulk loader builds vectors only
+	// in the in-process HNSW — they never reach the `vectors` table and
+	// are lost on the next daemon restart, forcing a paid re-embed.
+	// Set during the shadow swap, cleared when idx.graph is restored.
+	bulkVectorSink graph.VectorSearcher
+
 	// embedChunkOpts tunes the AST sub-chunking buildSearchIndex applies
 	// to large symbols before embedding. The zero value makes the
 	// chunker fall back to its package defaults.
@@ -1950,6 +1960,12 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 		diskTarget = idx.graph
 		inMemShadow = graph.New()
 		idx.graph = inMemShadow
+		// Capture the disk store as the vector sink: buildSearchIndex runs
+		// while idx.graph is the shadow (no VectorSearcher), so without this
+		// the embedded vectors never land on disk. The `vectors` table has no
+		// FK to `nodes`, so upserting before FlushBulk persists the nodes is
+		// safe. Cleared when idx.graph is restored below.
+		idx.bulkVectorSink, _ = diskTarget.(graph.VectorSearcher)
 		// The resolver was constructed at indexer.New with the disk
 		// Store. Redirect it at the shadow too, otherwise ResolveAll
 		// reads from the empty disk Store, finds no pending edges,
@@ -1962,6 +1978,7 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 		defer func() {
 			if retErr != nil {
 				idx.graph = diskTarget
+				idx.bulkVectorSink = nil
 				if idx.resolver != nil {
 					idx.resolver.SetGraph(diskTarget)
 				}
@@ -2064,6 +2081,7 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 			}
 			reporter.Report("persisting bulk graph", 1, 1)
 			idx.graph = diskTarget
+			idx.bulkVectorSink = nil
 			// Mirror of the SetGraph(inMemShadow) above: the resolver
 			// must follow the graph pointer back to the disk store, or
 			// every post-index per-file resolve (the watcher save path,
@@ -3643,15 +3661,28 @@ func (idx *Indexer) buildSearchIndex() {
 	// index lands with the same corpus the in-process one would
 	// have built.
 	vecSearcher, _ := idx.graph.(graph.VectorSearcher)
-	var backendItems []graph.VectorItem
 	if vecSearcher != nil {
 		vecBackend.SetDelegate(&vectorSearcherDelegate{s: vecSearcher})
+	}
+	// persistSink is where the embedded vectors are written to the backend
+	// so they survive a restart. Normally it is the active graph (a disk
+	// store). Under the bulk loader idx.graph is the in-memory shadow, which
+	// does not implement VectorSearcher; fall back to the disk store captured
+	// at the shadow swap (bulkVectorSink) so the vector index still reaches
+	// the `vectors` table instead of living only in the in-process HNSW and
+	// vanishing on the next restart (which would force a paid re-embed).
+	persistSink := vecSearcher
+	if persistSink == nil {
+		persistSink = idx.bulkVectorSink
+	}
+	var backendItems []graph.VectorItem
+	if persistSink != nil {
 		backendItems = make([]graph.VectorItem, 0, len(vectors))
 	}
 	for i, vec := range vectors {
 		if vec != nil {
 			vecBackend.Add(ids[i], vec)
-			if vecSearcher != nil {
+			if persistSink != nil {
 				backendItems = append(backendItems, graph.VectorItem{
 					NodeID: ids[i],
 					Vec:    vec,
@@ -3659,11 +3690,11 @@ func (idx *Indexer) buildSearchIndex() {
 			}
 		}
 	}
-	if vecSearcher != nil && len(backendItems) > 0 {
-		if err := vecSearcher.BulkUpsertEmbeddings(backendItems); err != nil {
+	if persistSink != nil && len(backendItems) > 0 {
+		if err := persistSink.BulkUpsertEmbeddings(backendItems); err != nil {
 			idx.logger.Warn("indexer: backend vector bulk upsert failed",
 				zap.Error(err))
-		} else if err := vecSearcher.BuildVectorIndex(dims); err != nil {
+		} else if err := persistSink.BuildVectorIndex(dims); err != nil {
 			idx.logger.Warn("indexer: backend vector index build failed",
 				zap.Error(err))
 		}
@@ -3692,10 +3723,20 @@ func (idx *Indexer) buildSearchIndex() {
 		inner = hyb.TextBackend()
 	}
 	sw.Swap(search.NewHybrid(inner, vecBackend, idx.embedder))
-	idx.logger.Info("vector index built",
+	fields := []zap.Field{
 		zap.Int("vectors", vecBackend.Count()),
 		zap.Int("chunk_vectors", len(chunkMap)),
-		zap.Int("dimensions", dims))
+		zap.Int("dimensions", dims),
+	}
+	// Surface the actual token spend of a paid embedding pass when the
+	// backend reports usage (API providers do; in-process ones don't).
+	// Without this the cost of an embedding run is invisible after the fact.
+	if acc, ok := idx.embedder.(interface{ TokensUsed() int64 }); ok {
+		if tokens := acc.TokensUsed(); tokens > 0 {
+			fields = append(fields, zap.Int64("embed_tokens", tokens))
+		}
+	}
+	idx.logger.Info("vector index built", fields...)
 }
 
 // dirIgnoreFiles are the per-directory ignore-file basenames honored by

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -3557,6 +3558,15 @@ func (idx *Indexer) buildSearchIndex() {
 	embedMaxSymbols := defaultEmbedMaxSymbols
 	if idx.embedMaxSymbols > 0 {
 		embedMaxSymbols = idx.embedMaxSymbols
+	}
+	// Env override wins over both the default and the config-wired cap —
+	// a reliable knob independent of the config plumbing. Lets an operator
+	// lift the vector-index size guard for a large repo without editing
+	// (or debugging) the layered config.
+	if env := os.Getenv("GORTEX_EMBEDDINGS_MAX_SYMBOLS"); env != "" {
+		if n, err := strconv.Atoi(strings.TrimSpace(env)); err == nil && n > 0 {
+			embedMaxSymbols = n
+		}
 	}
 	if len(texts) > embedMaxSymbols {
 		idx.logger.Warn("vector index disabled — embedding text count exceeds threshold",

--- a/internal/indexer/vector_persist_test.go
+++ b/internal/indexer/vector_persist_test.go
@@ -1,0 +1,71 @@
+package indexer
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+// TestBulkLoad_PersistsVectorsToBackend guards the fix where the embedding
+// pass run under the bulk-load shadow swap dropped the vector index on the
+// floor. During a bulk index idx.graph points at the in-memory shadow, which
+// does not implement graph.VectorSearcher — so the embedded vectors only ever
+// reached the in-process HNSW and never the sqlite `vectors` table. They were
+// lost on the next daemon restart, forcing a full (paid) re-embed every time.
+//
+// The fix captures the disk store at the shadow swap (idx.bulkVectorSink) and
+// persists the vectors against it. This test indexes a tiny repo into a sqlite
+// store with an embedder wired in, then asserts the backend's vectors table is
+// populated — it was empty before the fix.
+func TestBulkLoad_PersistsVectorsToBackend(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "app.py"), `
+def fetch(url):
+    return url
+
+def store(value):
+    return value
+`)
+
+	sqliteDir := t.TempDir()
+	store, err := store_sqlite.Open(filepath.Join(sqliteDir, "store.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	// Sanity: sqlite is a BulkLoader (so the shadow swap engages, which is the
+	// code path that regressed) and a VectorSearcher (so it CAN persist).
+	_, isBulk := graph.Store(store).(graph.BulkLoader)
+	require.True(t, isBulk, "sqlite must be a BulkLoader to exercise the shadow swap")
+	_, isVec := graph.Store(store).(graph.VectorSearcher)
+	require.True(t, isVec, "sqlite must be a VectorSearcher to persist embeddings")
+
+	reg := parser.NewRegistry()
+	reg.Register(languages.NewPythonExtractor())
+	cfg := config.Default().Index
+	cfg.Workers = 2
+	idx := New(store, reg, cfg, zap.NewNop())
+	idx.SetEmbedder(&poolEmbedder{})
+
+	_, err = idx.IndexCtx(context.Background(), dir)
+	require.NoError(t, err)
+
+	var allIDs []string
+	for _, n := range store.AllNodes() {
+		allIDs = append(allIDs, n.ID)
+	}
+	require.NotEmpty(t, allIDs, "the index must have produced nodes")
+
+	embs := store.GetEmbeddings(allIDs)
+	require.NotEmpty(t, embs,
+		"embedded vectors must be persisted to the sqlite backend under the bulk loader "+
+			"(regression: vectors lived only in the in-process HNSW and were lost on restart)")
+}

--- a/internal/serverstack/shared_server.go
+++ b/internal/serverstack/shared_server.go
@@ -1,6 +1,7 @@
 package serverstack
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -371,6 +372,26 @@ func NewSharedServer(cfg SharedServerConfig) (*SharedServer, error) {
 	// Embeddings: explicit flag/env > `embedding:` config > default (on,
 	// static GloVe).
 	embedder, embDesc, embErr := ResolveEmbedder(cfg.Embedder, conf)
+	// Probe API-backed providers up front so Dimensions() is truthful before
+	// we log it and — crucially — before EmbedderDims gates snapshot-vector
+	// reload. An APIProvider reports 0 until its first embed; without this the
+	// log reads dim:0 and the warm-restart vector reload rejects a
+	// correctly-sized cached index, re-embedding the whole graph needlessly.
+	// Static / local providers know their width natively and don't implement
+	// the prober, so they skip this. Best-effort: a probe failure (bad key /
+	// unreachable URL) only warns — indexing still falls back to BM25.
+	if embedder != nil {
+		if prober, ok := embedder.(interface {
+			ProbeDimensions(context.Context) (int, error)
+		}); ok {
+			if dim, perr := prober.ProbeDimensions(context.Background()); perr != nil {
+				logger.Warn("serverstack: embedding dimension probe failed — width unknown until first embed",
+					zap.Error(perr))
+			} else {
+				logger.Info("serverstack: embedding dimension probed", zap.Int("dim", dim))
+			}
+		}
+	}
 	switch {
 	case embErr != nil:
 		logger.Warn("serverstack: embeddings requested but unavailable", zap.Error(embErr))


### PR DESCRIPTION
Makes the OpenAI-compatible **api embedder** usable against real hosted backends and large repos, fixes vector persistence under the bulk loader, and fixes a warm-restart re-index bug. Four focused commits; CI-green; tests included.

### What & why

1. **`feat(embedding)` — authenticated + size-robust embedder**
   - Send `Authorization: Bearer` from `GORTEX_EMBEDDINGS_API_KEY` (falls back to `OPENAI_API_KEY` only for `*openai.com*` URLs). The embedder was Ollama-oriented and keyless → OpenAI returned **401**.
   - Head-truncate each embedding input to 8000 bytes. OpenAI rejects >8192-token inputs with a 400 that **aborts the whole vector index**; tokens ≤ bytes for ASCII source, so an 8000-byte head is provably safe.
   - `GORTEX_EMBEDDINGS_MAX_SYMBOLS` env override for the vector-index size cap — `embedding.max_symbols` config did not reach the indexer via the flag/env embedder path.

2. **`feat(embedding,indexer,daemon)` — vector persistence + warm-restart prefix fix**
   - **Vectors never persisted under the bulk loader** (`bulkVectorSink`): during a bulk index `idx.graph` is the in-memory shadow (no `VectorSearcher`), so `buildSearchIndex` skipped `BulkUpsertEmbeddings` — the sqlite `vectors` table stayed empty and a restart had no vectors to restore. Fix: capture the disk store at the shadow swap and persist there.
   - **Warm-restart prefix bug**: single-repo daemons persist `file_mtimes` under prefix `""` but `priorMtimesFromStore` looked them up under the path basename → 0 rows → every restart did a full cold re-index (and a paid re-embed). Fix: single-repo lookup under `""`.

3. **`feat(daemon)` — expose `--embeddings-url` / `--embeddings-model` on `daemon start`.**

4. **`fix(embedding)` — probe API embedder dims at startup + tolerate a `/v1` base URL.**

### Tests
`internal/embedding/api_test.go` (auth header, no-key case, truncation, dims probe / `/v1`), `internal/indexer/vector_persist_test.go`, `cmd/gortex/daemon_state_test.go`. `go build ./...` clean; `embedding` / `indexer` / `serverstack` / `cmd/gortex` test packages pass.

These were developed in a downstream fork and split out here as a self-contained, generic bundle. Happy to split further or adjust per your preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
