### PR TITLE
Version the graph SQLite store so an incompatible cache is rebuilt, not crashed on

### DIFF
--- a/cmd/gortex/daemon_state.go
+++ b/cmd/gortex/daemon_state.go
@@ -664,9 +664,9 @@ func priorMtimesFromStore(g graph.Store, cm *config.ConfigManager, entry config.
 // could not satisfy — so its persisted rows are in an old shape and the
 // warm/incremental reconcile must be bypassed for a full re-index. This is a
 // generic, opt-in capability probe: a backend implements NeedsRebuild() bool
-// to participate. No backend currently does, so this always reports false;
-// it stays as a hook for any future on-disk store that needs schema-version
-// gating on warm restart.
+// to participate. The on-disk sqlite store does — it reports true for the one
+// open in which it dropped an incompatible-schema database and recreated it
+// empty (see store_sqlite.Store.NeedsRebuild). The in-memory store does not.
 func storeNeedsRebuild(g any) bool {
 	rb, ok := g.(interface{ NeedsRebuild() bool })
 	return ok && rb.NeedsRebuild()

--- a/internal/graph/store_sqlite/schema_version.go
+++ b/internal/graph/store_sqlite/schema_version.go
@@ -1,0 +1,208 @@
+package store_sqlite
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Schema versioning for the graph store.
+//
+// Unlike the sidecar (which holds irreplaceable user data and must migrate in
+// place), the graph store is a DERIVED CACHE: every row is reconstructable by
+// re-indexing the source. So the cheapest *always-correct* reaction to a schema
+// change an old on-disk DB can't satisfy is to drop the file and let the daemon
+// rebuild it on the next index. A migration may therefore declare rebuild=true
+// instead of writing an in-place transform that would have to re-derive the new
+// data from source anyway. In-place steps remain the cheap path for purely
+// mechanical changes (a new index, a denormalisation, a column with a
+// computable default) that spare a large repo a multi-minute reindex.
+//
+// The whole mechanism keys off SQLite's built-in PRAGMA user_version, read on
+// Open before schemaSQL runs. There is no separate version table.
+//
+// Concurrency: the daemon holds an exclusive flock on <store>.lock around Open
+// (see serverstack.NewSharedServer), so reading the version, wiping the file,
+// and stamping it cannot race another process. That is why — unlike the
+// sidecar — this path needs no BEGIN IMMEDIATE / busy-loop handling.
+
+// currentSchemaVersion is the version a fully-reconciled store reports via
+// PRAGMA user_version. Bump it whenever schemaSQL's typed-column shape or an
+// index changes in a way an old on-disk DB would not already have, and append a
+// matching schemaMigrations entry describing how to bring an older store
+// forward (in place, or by rebuild).
+const currentSchemaVersion = 1
+
+// schemaMigration is one forward step. Exactly one strategy applies:
+//   - rebuild=true: the change introduces structure/data that can only come
+//     from re-indexing the source; an older store is wiped and rebuilt.
+//   - inPlace!=nil: the change is mechanically derivable from the existing
+//     store and is applied in a transaction with no reindex.
+//
+// Steps are append-only and ascending; never edit or renumber a shipped one.
+// Any inPlace step must be idempotent (IF NOT EXISTS / ADD COLUMN guarded).
+type schemaMigration struct {
+	version int
+	name    string
+	inPlace func(tx *sql.Tx) error
+	rebuild bool
+}
+
+// schemaMigrations is the ordered, forward-only registry. It is intentionally
+// empty at version 1: a v1 store is reconciled entirely by schemaSQL's
+// idempotent CREATE ... IF NOT EXISTS plus ensureNodeColumns, so any
+// pre-versioning database baseline-stamps to v1 without a rebuild. Append
+// entries for version 2 and up as the schema evolves.
+var schemaMigrations []schemaMigration
+
+// schemaPlan is the decision planSchemaMigration derives from the stored
+// PRAGMA user_version. It mutates nothing on its own.
+type schemaPlan struct {
+	wipe    bool              // drop the on-disk DB and rebuild from source
+	inPlace []schemaMigration // ordered in-place steps to run after schemaSQL
+	stamp   bool              // write currentSchemaVersion once reconciled
+}
+
+// planSchemaMigrationWith decides how to reconcile a store at the stored
+// PRAGMA user_version to current, given the migration registry. It mutates
+// nothing. Open passes (currentSchemaVersion, schemaMigrations); tests pass
+// fixtures.
+func planSchemaMigrationWith(stored, current int, migrations []schemaMigration) schemaPlan {
+	switch {
+	case stored == current:
+		return schemaPlan{} // up to date, nothing to do
+	case stored > current:
+		// Written by a newer build than this binary understands; the shape may
+		// have changed under us. For a cache the safe move is to rebuild.
+		return schemaPlan{wipe: true, stamp: true}
+	case stored == 0:
+		// Fresh DB, or a pre-versioning store of unknown shape. When nothing is
+		// registered above the baseline, schemaSQL + ensureNodeColumns reconcile
+		// it to the current shape, so stamp it. Once any later migration exists,
+		// a store that skipped the versioning-introduction release could be
+		// missing migration-introduced structure, so rebuild instead.
+		if len(pendingBetween(0, current, migrations)) == 0 {
+			return schemaPlan{stamp: true}
+		}
+		return schemaPlan{wipe: true, stamp: true}
+	default: // 0 < stored < current: a known prior version
+		pending := pendingBetween(stored, current, migrations)
+		if anyRebuild(pending) {
+			return schemaPlan{wipe: true, stamp: true}
+		}
+		return schemaPlan{inPlace: pending, stamp: true}
+	}
+}
+
+func pendingBetween(stored, current int, migrations []schemaMigration) []schemaMigration {
+	var out []schemaMigration
+	for _, m := range migrations {
+		if m.version > stored && m.version <= current {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+func anyRebuild(ms []schemaMigration) bool {
+	for _, m := range ms {
+		if m.rebuild {
+			return true
+		}
+	}
+	return false
+}
+
+// validateSchemaMigrations checks the registry is well-formed. A test asserts
+// this against the shipped (currentSchemaVersion, schemaMigrations) so the
+// dangerous mistake — bumping currentSchemaVersion without appending a matching
+// entry — fails CI instead of silently baseline-stamping an un-migrated store
+// to the new version at runtime. Rules:
+//   - versions are >= 2 (v1 is the implicit baseline, never an entry) and
+//     strictly ascending;
+//   - each step sets exactly one strategy (inPlace xor rebuild);
+//   - the highest version equals current, so the registry actually defines how
+//     to reach it. An empty registry is valid only at version 1.
+func validateSchemaMigrations(current int, migs []schemaMigration) error {
+	if len(migs) == 0 {
+		if current != 1 {
+			return fmt.Errorf("schema version %d has no migrations: only v1 may have an empty registry", current)
+		}
+		return nil
+	}
+	prev := 0
+	for i, m := range migs {
+		if m.version < 2 {
+			return fmt.Errorf("migration %q has version %d: entries must be >= 2 (v1 is the implicit baseline)", m.name, m.version)
+		}
+		if i > 0 && m.version <= prev {
+			return fmt.Errorf("migrations must be strictly ascending: v%d (%s) does not follow v%d", m.version, m.name, prev)
+		}
+		if (m.inPlace != nil) == m.rebuild {
+			return fmt.Errorf("migration v%d (%s) must set exactly one of inPlace / rebuild", m.version, m.name)
+		}
+		prev = m.version
+	}
+	if prev != current {
+		return fmt.Errorf("highest migration version %d != currentSchemaVersion %d: a version bump needs a matching migration entry", prev, current)
+	}
+	return nil
+}
+
+// readUserVersion reads PRAGMA user_version (0 on a fresh database).
+func readUserVersion(db *sql.DB) (int, error) {
+	var v int
+	if err := db.QueryRow("PRAGMA user_version").Scan(&v); err != nil {
+		return 0, err
+	}
+	return v, nil
+}
+
+// setUserVersion stamps the schema version. PRAGMA takes no bound parameters;
+// v is an int we control, so the format is safe.
+func setUserVersion(db *sql.DB, v int) error {
+	if _, err := db.Exec(fmt.Sprintf("PRAGMA user_version = %d", v)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// applyInPlaceMigrations runs the in-place steps in a single transaction.
+func applyInPlaceMigrations(db *sql.DB, steps []schemaMigration) error {
+	if len(steps) == 0 {
+		return nil
+	}
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }() // no-op once Commit succeeds
+	for _, m := range steps {
+		if err := m.inPlace(tx); err != nil {
+			return fmt.Errorf("schema migration v%d (%s): %w", m.version, m.name, err)
+		}
+	}
+	return tx.Commit()
+}
+
+// removeStoreFiles deletes the SQLite database and its companions. A missing
+// file is not an error. Never called for ":memory:".
+//
+// The suffix list covers the files the DSN's journal_mode(WAL) produces (-wal,
+// -shm) plus the rollback -journal a non-WAL fallback would use; keep it in
+// sync if the journal_mode in Open's DSN ever changes.
+func removeStoreFiles(path string) error {
+	for _, suffix := range []string{"", "-wal", "-shm", "-journal"} {
+		if err := os.Remove(path + suffix); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove %s: %w", path+suffix, err)
+		}
+	}
+	return nil
+}
+
+// isMemoryPath reports whether path is an in-process SQLite database (no file
+// on disk to wipe, always built fresh by schemaSQL).
+func isMemoryPath(path string) bool {
+	return strings.Contains(path, ":memory:")
+}

--- a/internal/graph/store_sqlite/schema_version_test.go
+++ b/internal/graph/store_sqlite/schema_version_test.go
@@ -1,0 +1,401 @@
+package store_sqlite
+
+import (
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// withRawDB opens a bare *sql.DB on path, runs fn, and closes it — used to
+// simulate an on-disk store written by an older/newer build (set user_version,
+// insert rows) without going through Open's reconciliation.
+func withRawDB(t *testing.T, path string, fn func(db *sql.DB)) {
+	t.Helper()
+	db, err := sql.Open("sqlite", path+"?_pragma=busy_timeout(5000)")
+	if err != nil {
+		t.Fatalf("open raw db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	fn(db)
+}
+
+func nodeCount(t *testing.T, db *sql.DB) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRow("SELECT COUNT(*) FROM nodes").Scan(&n); err != nil {
+		t.Fatalf("count nodes: %v", err)
+	}
+	return n
+}
+
+// TestOpenStampsFreshDB: a brand-new on-disk store is stamped to the current
+// schema version.
+func TestOpenStampsFreshDB(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "store.sqlite")
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open fresh: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+	if v, err := readUserVersion(s.db); err != nil || v != currentSchemaVersion {
+		t.Fatalf("fresh user_version = %d (err %v), want %d", v, err, currentSchemaVersion)
+	}
+}
+
+// TestOpenBaselineStampsOldDBWithoutWipe: a pre-versioning store (user_version
+// 0, reconcilable to current by schemaSQL + ensureNodeColumns) is stamped in
+// place — its data must survive, not be wiped.
+func TestOpenBaselineStampsOldDBWithoutWipe(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "store.sqlite")
+
+	// Create the store, then simulate a pre-versioning DB: a row + user_version 0.
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	withRawDB(t, path, func(db *sql.DB) {
+		if _, err := db.Exec(`INSERT INTO nodes (id, kind, name, file_path) VALUES ('n1','func','Foo','f.go')`); err != nil {
+			t.Fatalf("seed node: %v", err)
+		}
+		if _, err := db.Exec(`PRAGMA user_version = 0`); err != nil {
+			t.Fatalf("reset user_version: %v", err)
+		}
+	})
+
+	s2, err := Open(path)
+	if err != nil {
+		t.Fatalf("reopen old DB: %v", err)
+	}
+	defer func() { _ = s2.Close() }()
+	if v, _ := readUserVersion(s2.db); v != currentSchemaVersion {
+		t.Fatalf("user_version after baseline = %d, want %d", v, currentSchemaVersion)
+	}
+	if n := nodeCount(t, s2.db); n != 1 {
+		t.Fatalf("node count after baseline = %d, want 1 (data must NOT be wiped)", n)
+	}
+}
+
+// TestOpenRebuildsNewerDB: a store written by a NEWER build (user_version above
+// current) cannot be trusted, so Open drops and rebuilds it — the data is gone
+// and the version is re-stamped to current. Proves the wipe path (and that the
+// -wal/-shm companions are cleared along with the main file).
+func TestOpenRebuildsNewerDB(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "store.sqlite")
+
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	withRawDB(t, path, func(db *sql.DB) {
+		if _, err := db.Exec(`INSERT INTO nodes (id, kind, name, file_path) VALUES ('n1','func','Foo','f.go')`); err != nil {
+			t.Fatalf("seed node: %v", err)
+		}
+		if _, err := db.Exec(`PRAGMA user_version = 999`); err != nil { // a future version this binary doesn't know
+			t.Fatalf("set future user_version: %v", err)
+		}
+	})
+
+	s2, err := Open(path)
+	if err != nil {
+		t.Fatalf("reopen newer DB: %v", err)
+	}
+	defer func() { _ = s2.Close() }()
+	if v, _ := readUserVersion(s2.db); v != currentSchemaVersion {
+		t.Fatalf("user_version after rebuild = %d, want %d", v, currentSchemaVersion)
+	}
+	if n := nodeCount(t, s2.db); n != 0 {
+		t.Fatalf("node count after rebuild = %d, want 0 (newer DB must be wiped)", n)
+	}
+}
+
+// TestPlanSchemaMigration covers the pure decision logic, including the
+// in-place vs rebuild dispatch a future currentSchemaVersion=2 would exercise.
+func TestPlanSchemaMigration(t *testing.T) {
+	inPlace := schemaMigration{version: 2, name: "add-index", inPlace: func(*sql.Tx) error { return nil }}
+	rebuild := schemaMigration{version: 2, name: "typed-column", rebuild: true}
+
+	cases := []struct {
+		name            string
+		stored, current int
+		migs            []schemaMigration
+		wantWipe        bool
+		wantStamp       bool
+		wantInPlace     int
+	}{
+		{"up to date", 1, 1, nil, false, false, 0},
+		{"fresh at v1 baseline-stamps", 0, 1, nil, false, true, 0},
+		{"newer DB rebuilds", 2, 1, nil, true, true, 0},
+		{"v0 skipping a later migration rebuilds", 0, 2, []schemaMigration{inPlace}, true, true, 0},
+		{"v1->v2 in-place", 1, 2, []schemaMigration{inPlace}, false, true, 1},
+		{"v1->v2 rebuild", 1, 2, []schemaMigration{rebuild}, true, true, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := planSchemaMigrationWith(c.stored, c.current, c.migs)
+			if got.wipe != c.wantWipe || got.stamp != c.wantStamp || len(got.inPlace) != c.wantInPlace {
+				t.Fatalf("plan(%d->%d) = {wipe:%v stamp:%v inPlace:%d}, want {wipe:%v stamp:%v inPlace:%d}",
+					c.stored, c.current, got.wipe, got.stamp, len(got.inPlace), c.wantWipe, c.wantStamp, c.wantInPlace)
+			}
+		})
+	}
+}
+
+// TestApplyInPlaceMigrations: steps run in order and commit; a failing step
+// rolls the whole transaction back.
+func TestApplyInPlaceMigrations(t *testing.T) {
+	t.Run("commit", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "m.sqlite")
+		withRawDB(t, path, func(db *sql.DB) {
+			step := schemaMigration{version: 2, name: "mk", inPlace: func(tx *sql.Tx) error {
+				_, err := tx.Exec(`CREATE TABLE marker (x TEXT)`)
+				return err
+			}}
+			if err := applyInPlaceMigrations(db, []schemaMigration{step}); err != nil {
+				t.Fatalf("apply: %v", err)
+			}
+			var name string
+			if err := db.QueryRow(`SELECT name FROM sqlite_master WHERE type='table' AND name='marker'`).Scan(&name); err != nil {
+				t.Fatalf("marker table not created: %v", err)
+			}
+		})
+	})
+
+	t.Run("rollback on failure preserves cause and rolls back every step", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "m.sqlite")
+		withRawDB(t, path, func(db *sql.DB) {
+			// Two steps in one batch: the first creates table A, the second
+			// creates B then fails. Both must roll back, proving the steps
+			// share a single transaction.
+			stepA := schemaMigration{version: 2, name: "make-a", inPlace: func(tx *sql.Tx) error {
+				_, err := tx.Exec(`CREATE TABLE a (x TEXT)`)
+				return err
+			}}
+			stepB := schemaMigration{version: 3, name: "boom", inPlace: func(tx *sql.Tx) error {
+				if _, err := tx.Exec(`CREATE TABLE b (x TEXT)`); err != nil {
+					return err
+				}
+				return sql.ErrConnDone // synthetic failure after a partial write
+			}}
+			err := applyInPlaceMigrations(db, []schemaMigration{stepA, stepB})
+			if err == nil {
+				t.Fatal("expected applyInPlaceMigrations to surface the step error")
+			}
+			if !errors.Is(err, sql.ErrConnDone) {
+				t.Fatalf("error should wrap the step's cause; got %v", err)
+			}
+			if !strings.Contains(err.Error(), "v3") || !strings.Contains(err.Error(), "boom") {
+				t.Fatalf("error should name the failing migration (v3/boom); got %q", err.Error())
+			}
+			for _, tbl := range []string{"a", "b"} {
+				var name string
+				e := db.QueryRow(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`, tbl).Scan(&name)
+				if e != sql.ErrNoRows {
+					t.Fatalf("table %q should have rolled back (shared transaction), got name=%q err=%v", tbl, name, e)
+				}
+			}
+		})
+	})
+}
+
+// TestOpenAtCurrentVersionIsNoOp covers the highest-frequency path — every
+// daemon restart reopens an up-to-date store. It must be a no-op that
+// preserves data; an off-by-one to wipe here would destroy the cache on every
+// restart.
+func TestOpenAtCurrentVersionIsNoOp(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "store.sqlite")
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+	withRawSeed := func(db *sql.DB) {
+		if _, err := db.Exec(`INSERT INTO nodes (id, kind, name, file_path) VALUES ('n1','func','Foo','f.go')`); err != nil {
+			t.Fatalf("seed node: %v", err)
+		}
+	}
+	withRawSeed(s.db)
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	s2, err := Open(path)
+	if err != nil {
+		t.Fatalf("reopen at current version: %v", err)
+	}
+	defer func() { _ = s2.Close() }()
+	if v, _ := readUserVersion(s2.db); v != currentSchemaVersion {
+		t.Fatalf("user_version = %d, want %d", v, currentSchemaVersion)
+	}
+	if n := nodeCount(t, s2.db); n != 1 {
+		t.Fatalf("node count = %d, want 1 (a no-op reopen must NOT wipe)", n)
+	}
+	if s2.NeedsRebuild() {
+		t.Fatal("a no-op reopen must not signal NeedsRebuild")
+	}
+}
+
+// TestOpenWithInPlaceMigration drives the in-place arm end-to-end through the
+// real Open composition (via the openWith seam): an older store at version 1
+// is upgraded to version 2 by a registered in-place step that runs AFTER
+// schemaSQL, the step's effect is visible, the existing data survives, and the
+// version is stamped.
+func TestOpenWithInPlaceMigration(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "store.sqlite")
+
+	// Create a v1 store with a row, then close.
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+	if _, err := s.db.Exec(`INSERT INTO nodes (id, kind, name, file_path) VALUES ('n1','func','Foo','f.go')`); err != nil {
+		t.Fatalf("seed node: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// An in-place v2 step that depends on the base schema (an index on a
+	// nodes column) — proving it runs after schemaSQL/ensureNodeColumns.
+	ran := false
+	v2 := schemaMigration{version: 2, name: "idx-language", inPlace: func(tx *sql.Tx) error {
+		ran = true
+		_, err := tx.Exec(`CREATE INDEX IF NOT EXISTS test_nodes_by_language ON nodes(language)`)
+		return err
+	}}
+
+	s2, err := openWith(path, 2, []schemaMigration{v2})
+	if err != nil {
+		t.Fatalf("openWith v2 in-place: %v", err)
+	}
+	defer func() { _ = s2.Close() }()
+	if !ran {
+		t.Fatal("the in-place migration step did not run")
+	}
+	if v, _ := readUserVersion(s2.db); v != 2 {
+		t.Fatalf("user_version = %d, want 2", v)
+	}
+	if n := nodeCount(t, s2.db); n != 1 {
+		t.Fatalf("node count = %d, want 1 (in-place upgrade must preserve data)", n)
+	}
+	var name string
+	if err := s2.db.QueryRow(`SELECT name FROM sqlite_master WHERE type='index' AND name='test_nodes_by_language'`).Scan(&name); err != nil {
+		t.Fatalf("in-place index not created: %v", err)
+	}
+	if s2.NeedsRebuild() {
+		t.Fatal("an in-place upgrade must not signal NeedsRebuild")
+	}
+}
+
+// TestOpenWithInPlaceFailureDoesNotStamp: a failing in-place step makes Open
+// return an error and leaves the stored version unchanged, so the next open
+// retries the upgrade rather than treating it as done.
+func TestOpenWithInPlaceFailureDoesNotStamp(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "store.sqlite")
+	s, err := Open(path) // v1 store
+	if err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	boom := schemaMigration{version: 2, name: "boom", inPlace: func(*sql.Tx) error {
+		return sql.ErrConnDone
+	}}
+	if _, err := openWith(path, 2, []schemaMigration{boom}); err == nil {
+		t.Fatal("expected openWith to fail when an in-place step errors")
+	}
+
+	withRawDB(t, path, func(db *sql.DB) {
+		var v int
+		if err := db.QueryRow("PRAGMA user_version").Scan(&v); err != nil {
+			t.Fatalf("read user_version: %v", err)
+		}
+		if v != 1 {
+			t.Fatalf("user_version = %d after a failed migration, want 1 (unstamped, so the next open retries)", v)
+		}
+	})
+}
+
+// TestOpenWithMemoryUnderWipePlanStampsWithoutError: an in-memory store under a
+// plan that would wipe an on-disk DB must not attempt a file removal — it is
+// always fresh and simply stamps the current version.
+func TestOpenWithMemoryUnderWipePlanStampsWithoutError(t *testing.T) {
+	rebuildV2 := schemaMigration{version: 2, name: "typed-col", rebuild: true}
+	// stored==0, current==2, a pending rebuild => plan.wipe==true; the memory
+	// guard must skip the wipe and stamp anyway.
+	s, err := openWith(":memory:", 2, []schemaMigration{rebuildV2})
+	if err != nil {
+		t.Fatalf("openWith :memory: under wipe plan: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+	if v, _ := readUserVersion(s.db); v != 2 {
+		t.Fatalf("user_version = %d, want 2", v)
+	}
+	if s.NeedsRebuild() {
+		t.Fatal(":memory: must never report a wipe (nothing to remove)")
+	}
+}
+
+// TestNeedsRebuildSignalAfterWipe: a store written by a newer build is wiped on
+// open and reports NeedsRebuild so the daemon forces a full re-index.
+func TestNeedsRebuildSignalAfterWipe(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "store.sqlite")
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	withRawDB(t, path, func(db *sql.DB) {
+		if _, err := db.Exec(`PRAGMA user_version = 999`); err != nil {
+			t.Fatalf("set future version: %v", err)
+		}
+	})
+	s2, err := Open(path)
+	if err != nil {
+		t.Fatalf("reopen newer DB: %v", err)
+	}
+	defer func() { _ = s2.Close() }()
+	if !s2.NeedsRebuild() {
+		t.Fatal("a wiped store must report NeedsRebuild so the daemon re-indexes")
+	}
+}
+
+// TestSchemaMigrationsWellFormed asserts the shipped registry is valid and that
+// the validator rejects the dangerous misconfigurations — above all, bumping
+// currentSchemaVersion without appending a matching migration.
+func TestSchemaMigrationsWellFormed(t *testing.T) {
+	if err := validateSchemaMigrations(currentSchemaVersion, schemaMigrations); err != nil {
+		t.Fatalf("shipped registry is invalid: %v", err)
+	}
+
+	inPlace := func(*sql.Tx) error { return nil }
+	bad := []struct {
+		name    string
+		current int
+		migs    []schemaMigration
+	}{
+		{"bumped version with no migration", 2, nil},
+		{"highest below current", 3, []schemaMigration{{version: 2, name: "x", rebuild: true}}},
+		{"both strategies set", 2, []schemaMigration{{version: 2, name: "x", rebuild: true, inPlace: inPlace}}},
+		{"neither strategy set", 2, []schemaMigration{{version: 2, name: "x"}}},
+		{"not strictly ascending", 3, []schemaMigration{{version: 2, name: "a", rebuild: true}, {version: 2, name: "b", rebuild: true}}},
+		{"v1 entry (baseline is implicit)", 1, []schemaMigration{{version: 1, name: "a", rebuild: true}}},
+	}
+	for _, c := range bad {
+		if err := validateSchemaMigrations(c.current, c.migs); err == nil {
+			t.Errorf("%s: expected a validation error, got nil", c.name)
+		}
+	}
+}

--- a/internal/graph/store_sqlite/schema_version_test.go
+++ b/internal/graph/store_sqlite/schema_version_test.go
@@ -105,7 +105,7 @@ func TestOpenRebuildsNewerDB(t *testing.T) {
 		}
 	})
 
-	s2, err := Open(path)
+	s2, err := Open(path, WithRebuild()) // simulate the daemon: holds the lock, may rebuild
 	if err != nil {
 		t.Fatalf("reopen newer DB: %v", err)
 	}
@@ -116,6 +116,46 @@ func TestOpenRebuildsNewerDB(t *testing.T) {
 	if n := nodeCount(t, s2.db); n != 0 {
 		t.Fatalf("node count after rebuild = %d, want 0 (newer DB must be wiped)", n)
 	}
+}
+
+// TestOpenRefusesWipeWithoutOptIn: the default Open must NOT destroy an
+// incompatible on-disk database. Without WithRebuild it returns
+// ErrSchemaRebuildRequired and leaves the file (and its rows) intact, so a
+// caller that does not hold the store lock cannot silently corrupt a store
+// another process may have open.
+func TestOpenRefusesWipeWithoutOptIn(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "store.sqlite")
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+	if _, err := s.db.Exec(`INSERT INTO nodes (id, kind, name, file_path) VALUES ('n1','func','Foo','f.go')`); err != nil {
+		t.Fatalf("seed node: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	withRawDB(t, path, func(db *sql.DB) {
+		if _, err := db.Exec(`PRAGMA user_version = 999`); err != nil {
+			t.Fatalf("set future version: %v", err)
+		}
+	})
+
+	if _, err := Open(path); !errors.Is(err, ErrSchemaRebuildRequired) {
+		t.Fatalf("Open without WithRebuild = %v, want ErrSchemaRebuildRequired", err)
+	}
+	withRawDB(t, path, func(db *sql.DB) {
+		if n := nodeCount(t, db); n != 1 {
+			t.Fatalf("node count = %d after a refused wipe, want 1 (the file must be untouched)", n)
+		}
+		var v int
+		if err := db.QueryRow("PRAGMA user_version").Scan(&v); err != nil {
+			t.Fatalf("read user_version: %v", err)
+		}
+		if v != 999 {
+			t.Fatalf("user_version = %d after a refused wipe, want 999 (unchanged)", v)
+		}
+	})
 }
 
 // TestPlanSchemaMigration covers the pure decision logic, including the
@@ -272,7 +312,7 @@ func TestOpenWithInPlaceMigration(t *testing.T) {
 		return err
 	}}
 
-	s2, err := openWith(path, 2, []schemaMigration{v2})
+	s2, err := openWith(path, 2, []schemaMigration{v2}, false) // in-place never wipes
 	if err != nil {
 		t.Fatalf("openWith v2 in-place: %v", err)
 	}
@@ -311,7 +351,7 @@ func TestOpenWithInPlaceFailureDoesNotStamp(t *testing.T) {
 	boom := schemaMigration{version: 2, name: "boom", inPlace: func(*sql.Tx) error {
 		return sql.ErrConnDone
 	}}
-	if _, err := openWith(path, 2, []schemaMigration{boom}); err == nil {
+	if _, err := openWith(path, 2, []schemaMigration{boom}, false); err == nil {
 		t.Fatal("expected openWith to fail when an in-place step errors")
 	}
 
@@ -333,7 +373,7 @@ func TestOpenWithMemoryUnderWipePlanStampsWithoutError(t *testing.T) {
 	rebuildV2 := schemaMigration{version: 2, name: "typed-col", rebuild: true}
 	// stored==0, current==2, a pending rebuild => plan.wipe==true; the memory
 	// guard must skip the wipe and stamp anyway.
-	s, err := openWith(":memory:", 2, []schemaMigration{rebuildV2})
+	s, err := openWith(":memory:", 2, []schemaMigration{rebuildV2}, false) // memory never wipes
 	if err != nil {
 		t.Fatalf("openWith :memory: under wipe plan: %v", err)
 	}
@@ -362,7 +402,7 @@ func TestNeedsRebuildSignalAfterWipe(t *testing.T) {
 			t.Fatalf("set future version: %v", err)
 		}
 	})
-	s2, err := Open(path)
+	s2, err := Open(path, WithRebuild()) // daemon-equivalent: lock held, rebuild permitted
 	if err != nil {
 		t.Fatalf("reopen newer DB: %v", err)
 	}

--- a/internal/graph/store_sqlite/store.go
+++ b/internal/graph/store_sqlite/store.go
@@ -152,22 +152,51 @@ func (s *Store) NeedsRebuild() bool { return s.wiped }
 //
 // Pass ":memory:" for an ephemeral in-process database (handy for
 // tests when you don't need on-disk persistence).
-func Open(path string) (*Store, error) {
-	return openWith(path, currentSchemaVersion, schemaMigrations)
+//
+// By default Open will NOT destroy an incompatible on-disk database: if the
+// stored schema version requires a rebuild (a newer build's DB, or an older
+// one crossing a rebuild migration) it returns ErrSchemaRebuildRequired and
+// leaves the file untouched. Pass WithRebuild to permit the drop-and-recreate
+// — only a caller that holds exclusive access to the store may do so (see
+// WithRebuild).
+func Open(path string, opts ...Option) (*Store, error) {
+	var o openOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return openWith(path, currentSchemaVersion, schemaMigrations, o.allowRebuild)
 }
 
-// openWith is Open parameterised by the target schema version and migration
-// registry so tests can drive the baseline / in-place / rebuild arms without
-// mutating package globals. Open always passes the package defaults
-// (currentSchemaVersion, schemaMigrations).
+// Option configures Open.
+type Option func(*openOptions)
+
+type openOptions struct {
+	allowRebuild bool
+}
+
+// WithRebuild permits Open to drop and recreate an on-disk database whose
+// schema version is incompatible (a newer build's, or an older one crossing a
+// migration that an in-place ALTER cannot satisfy).
 //
-// Precondition for the on-disk wipe path: the caller must hold exclusive
-// access to the store file. The daemon does — it takes an exclusive flock on
-// <store>.lock before Open for the only writable on-disk sqlite lifecycle (see
-// serverstack.NewSharedServer) — so the os.Remove here cannot race another
-// process. A future caller that opens an on-disk sqlite store WITHOUT that
-// lock must not reach a wipe plan.
-func openWith(path string, current int, migrations []schemaMigration) (*Store, error) {
+// The caller MUST hold exclusive cross-process access to the store file —
+// removing a SQLite file another process has open silently splits its state.
+// The daemon satisfies this: it takes an exclusive flock on <store>.lock for
+// the writable on-disk sqlite lifecycle and passes this option only in that
+// branch (see serverstack.NewSharedServer / OpenBackend). Without it, a wipe
+// plan yields ErrSchemaRebuildRequired and the file is left intact, so a
+// caller that does not hold the lock cannot corrupt a live store.
+func WithRebuild() Option { return func(o *openOptions) { o.allowRebuild = true } }
+
+// ErrSchemaRebuildRequired is returned by Open when an on-disk database needs a
+// destructive rebuild but the caller did not pass WithRebuild (i.e. cannot
+// prove it holds the store lock).
+var ErrSchemaRebuildRequired = errors.New("store_sqlite: on-disk schema is incompatible and must be rebuilt; reopen with WithRebuild while holding the store lock")
+
+// openWith is Open parameterised by the target schema version, migration
+// registry, and rebuild permission so tests can drive the baseline / in-place
+// / rebuild arms without mutating package globals. Open passes the package
+// defaults (currentSchemaVersion, schemaMigrations) and the WithRebuild flag.
+func openWith(path string, current int, migrations []schemaMigration, allowRebuild bool) (*Store, error) {
 	// Pragmas: WAL + synchronous=NORMAL is the standard write-heavy
 	// embedded tradeoff. cache_size(-32768) gives each pooled connection a
 	// 32 MiB page cache; temp_store(MEMORY) keeps GROUP BY / ORDER BY scratch
@@ -213,6 +242,13 @@ func openWith(path string, current int, migrations []schemaMigration) (*Store, e
 	plan := planSchemaMigrationWith(stored, current, migrations)
 	didWipe := false
 	if plan.wipe && !isMemoryPath(path) {
+		// Refuse the destructive rebuild unless the caller proved it holds
+		// exclusive access (WithRebuild). This keeps the file safe even if a
+		// future caller reaches a wipe plan without the daemon's store lock.
+		if !allowRebuild {
+			_ = db.Close()
+			return nil, ErrSchemaRebuildRequired
+		}
 		if err := db.Close(); err != nil {
 			return nil, fmt.Errorf("sqlite close for rebuild: %w", err)
 		}

--- a/internal/graph/store_sqlite/store.go
+++ b/internal/graph/store_sqlite/store.go
@@ -61,6 +61,14 @@ type Store struct {
 
 	edgeIdentityRevs atomic.Int64
 
+	// wiped records that Open dropped an incompatible on-disk DB and
+	// recreated it empty (a schema-version mismatch that an in-place ALTER
+	// could not satisfy). Surfaced via NeedsRebuild so the daemon forces a
+	// full re-index on warm restart instead of an incremental reconcile,
+	// rather than relying on the side effect that a total wipe also empties
+	// file_mtimes.
+	wiped bool
+
 	// WAL-checkpoint loop lifecycle. In WAL mode a COMMIT only appends to
 	// the -wal file; pages move into the main DB (and the WAL becomes
 	// reusable) at a checkpoint. SQLite's default passive auto-checkpoint
@@ -131,6 +139,12 @@ var _ graph.Store = (*Store)(nil)
 // state mutations on the same store.
 func (s *Store) ResolveMutex() *sync.Mutex { return &s.resolveMu }
 
+// NeedsRebuild reports that Open dropped an incompatible on-disk database and
+// recreated it empty, so the daemon's warm-restart path should force a full
+// re-index (bypassing an incremental reconcile that would carry stale state)
+// — see cmd/gortex.storeNeedsRebuild, the capability probe this satisfies.
+func (s *Store) NeedsRebuild() bool { return s.wiped }
+
 // Open opens (or creates) the SQLite database at path, runs the schema
 // migration, and prepares hot statements. The DB is opened with WAL
 // journaling and synchronous=NORMAL -- the same durability/throughput
@@ -139,6 +153,21 @@ func (s *Store) ResolveMutex() *sync.Mutex { return &s.resolveMu }
 // Pass ":memory:" for an ephemeral in-process database (handy for
 // tests when you don't need on-disk persistence).
 func Open(path string) (*Store, error) {
+	return openWith(path, currentSchemaVersion, schemaMigrations)
+}
+
+// openWith is Open parameterised by the target schema version and migration
+// registry so tests can drive the baseline / in-place / rebuild arms without
+// mutating package globals. Open always passes the package defaults
+// (currentSchemaVersion, schemaMigrations).
+//
+// Precondition for the on-disk wipe path: the caller must hold exclusive
+// access to the store file. The daemon does — it takes an exclusive flock on
+// <store>.lock before Open for the only writable on-disk sqlite lifecycle (see
+// serverstack.NewSharedServer) — so the os.Remove here cannot race another
+// process. A future caller that opens an on-disk sqlite store WITHOUT that
+// lock must not reach a wipe plan.
+func openWith(path string, current int, migrations []schemaMigration) (*Store, error) {
 	// Pragmas: WAL + synchronous=NORMAL is the standard write-heavy
 	// embedded tradeoff. cache_size(-32768) gives each pooled connection a
 	// 32 MiB page cache; temp_store(MEMORY) keeps GROUP BY / ORDER BY scratch
@@ -171,6 +200,33 @@ func Open(path string) (*Store, error) {
 	// pin one connection to "remember" them.
 	db.SetMaxOpenConns(runtime.NumCPU())
 
+	// Reconcile the on-disk schema version before applying schemaSQL. The graph
+	// store is a rebuildable cache, so an incompatible (older needing a rebuild
+	// step, or newer) DB is dropped and reindexed rather than migrated in place
+	// (see schema_version.go). The daemon holds an exclusive store.lock around
+	// Open, so wiping the file here cannot race another process.
+	stored, err := readUserVersion(db)
+	if err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("sqlite read schema version: %w", err)
+	}
+	plan := planSchemaMigrationWith(stored, current, migrations)
+	didWipe := false
+	if plan.wipe && !isMemoryPath(path) {
+		if err := db.Close(); err != nil {
+			return nil, fmt.Errorf("sqlite close for rebuild: %w", err)
+		}
+		if err := removeStoreFiles(path); err != nil {
+			return nil, fmt.Errorf("sqlite rebuild: %w", err)
+		}
+		db, err = sql.Open("sqlite", dsn)
+		if err != nil {
+			return nil, fmt.Errorf("sqlite reopen for rebuild: %w", err)
+		}
+		db.SetMaxOpenConns(runtime.NumCPU())
+		didWipe = true
+	}
+
 	if _, err := db.Exec(schemaSQL); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("sqlite schema: %w", err)
@@ -193,7 +249,21 @@ func Open(path string) (*Store, error) {
 		return nil, fmt.Errorf("sqlite node columns: %w", err)
 	}
 
-	s := &Store{db: db, dbPath: path}
+	// Apply any in-place migration steps (none on a fresh, baseline, or wiped
+	// DB), then stamp the current schema version. After a wipe the store is
+	// empty and the daemon's normal indexing repopulates it.
+	if plan.stamp {
+		if err := applyInPlaceMigrations(db, plan.inPlace); err != nil {
+			_ = db.Close()
+			return nil, fmt.Errorf("sqlite schema migrate: %w", err)
+		}
+		if err := setUserVersion(db, current); err != nil {
+			_ = db.Close()
+			return nil, fmt.Errorf("sqlite stamp schema version: %w", err)
+		}
+	}
+
+	s := &Store{db: db, dbPath: path, wiped: didWipe}
 	// Initialise the bundle cache at construction so its pointer is
 	// never written after Open — concurrent SearchSymbolBundles reads
 	// and SetBundleFingerprints writes then race only on the cache's

--- a/internal/serverstack/backend.go
+++ b/internal/serverstack/backend.go
@@ -34,7 +34,11 @@ import (
 //
 // Returns the store, a cleanup func the caller must defer (closes the
 // underlying handle on disk-backed stores), and any open error.
-func OpenBackend(name, path string, bufferPoolMB uint64, logger *zap.Logger) (graph.Store, func(), error) {
+// allowRebuild permits the on-disk sqlite backend to drop and recreate a
+// database whose schema version is incompatible. The caller must hold the
+// store lock; NewSharedServer passes true only in the branch where it acquired
+// the exclusive flock.
+func OpenBackend(name, path string, bufferPoolMB uint64, logger *zap.Logger, allowRebuild bool) (graph.Store, func(), error) {
 	switch strings.ToLower(strings.TrimSpace(name)) {
 	case "", "memory", "mem", "in-memory":
 		s := graph.New()
@@ -47,7 +51,7 @@ func OpenBackend(name, path string, bufferPoolMB uint64, logger *zap.Logger) (gr
 		if logger != nil {
 			logger.Info("opening sqlite backend", zap.String("path", resolved))
 		}
-		return openSqliteBackend(resolved, bufferPoolMB)
+		return openSqliteBackend(resolved, bufferPoolMB, allowRebuild)
 	default:
 		return nil, nil, fmt.Errorf("unknown backend %q (expected: memory, sqlite)", name)
 	}
@@ -93,9 +97,13 @@ func resolveBackendPath(in, filename string) (string, error) {
 // getting a real query planner that drives the graph's secondary indexes.
 // bufferPoolMB is accepted for signature parity with other on-disk
 // backends but unused — SQLite sizes its page cache via a pragma.
-func openSqliteBackend(path string, bufferPoolMB uint64) (graph.Store, func(), error) {
+func openSqliteBackend(path string, bufferPoolMB uint64, allowRebuild bool) (graph.Store, func(), error) {
 	_ = bufferPoolMB
-	s, err := store_sqlite.Open(path)
+	var opts []store_sqlite.Option
+	if allowRebuild {
+		opts = append(opts, store_sqlite.WithRebuild())
+	}
+	s, err := store_sqlite.Open(path, opts...)
 	if err != nil {
 		hint := "if another gortex daemon is using this store, stop it first (`gortex daemon status` / `gortex daemon stop`)"
 		if pid, ok := daemon.RunningPID(); ok {

--- a/internal/serverstack/backend_test.go
+++ b/internal/serverstack/backend_test.go
@@ -13,7 +13,7 @@ import (
 // default) returns a usable in-process store.
 func TestOpenBackend_MemoryDefault(t *testing.T) {
 	for _, name := range []string{"", "memory", "mem", "in-memory"} {
-		store, cleanup, err := OpenBackend(name, "", 0, zap.NewNop())
+		store, cleanup, err := OpenBackend(name, "", 0, zap.NewNop(), false)
 		if err != nil {
 			t.Fatalf("OpenBackend(%q): %v", name, err)
 		}
@@ -31,7 +31,7 @@ func TestOpenBackend_MemoryDefault(t *testing.T) {
 // creates) a store at the resolved path.
 func TestOpenBackend_SqliteOpensFile(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "store.sqlite")
-	store, cleanup, err := OpenBackend("sqlite", path, 0, zap.NewNop())
+	store, cleanup, err := OpenBackend("sqlite", path, 0, zap.NewNop(), true)
 	if err != nil {
 		t.Fatalf("OpenBackend(sqlite): %v", err)
 	}
@@ -45,7 +45,7 @@ func TestOpenBackend_SqliteOpensFile(t *testing.T) {
 // stale backend name (e.g. the removed ladybug) errors rather than
 // silently falling back.
 func TestOpenBackend_Unknown(t *testing.T) {
-	if _, _, err := OpenBackend("ladybug", "", 0, zap.NewNop()); err == nil {
+	if _, _, err := OpenBackend("ladybug", "", 0, zap.NewNop(), false); err == nil {
 		t.Fatal("an unknown backend must error")
 	}
 }

--- a/internal/serverstack/shared_server.go
+++ b/internal/serverstack/shared_server.go
@@ -244,6 +244,7 @@ func NewSharedServer(cfg SharedServerConfig) (*SharedServer, error) {
 	// another process owns the store. SQLite's in-process writeMu +
 	// busy_timeout serialise in-process writers only; nothing else stops
 	// a second OS process opening the same file and corrupting it.
+	storeLockHeld := false // set true once the exclusive store flock is owned below
 	if cfg.Lifecycle.Writable() && isSqliteBackend(backendName) {
 		storePath, perr := resolveBackendPath(cfg.BackendPath, "store.sqlite")
 		if perr != nil {
@@ -262,9 +263,12 @@ func NewSharedServer(cfg SharedServerConfig) (*SharedServer, error) {
 			return nil, fmt.Errorf("%s — stop it first (`gortex daemon stop`)", hint)
 		}
 		s.cleanup = append(s.cleanup, func() { _ = lock.Unlock() })
+		storeLockHeld = true
 	}
 
-	g, backendCleanup, err := OpenBackend(backendName, cfg.BackendPath, cfg.BufferPoolMB, logger)
+	// allowRebuild is gated on actually holding the store lock: only then may
+	// the sqlite backend drop and recreate an incompatible-schema DB.
+	g, backendCleanup, err := OpenBackend(backendName, cfg.BackendPath, cfg.BufferPoolMB, logger, storeLockHeld)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What & why

The graph SQLite store (`internal/graph/store_sqlite`) had **no schema-version mechanism**: `Open` ran a single `CREATE ... IF NOT EXISTS` batch plus an ad-hoc `ALTER` retrofit for the promoted node columns, with no `PRAGMA user_version` and no version check. Same structural shape the sidecar store had before its migration runner landed.

The hazard is **latent today but real**: the moment a future schema gains a typed column (or a column-dependent index) without a backfill, opening an older on-disk store fails at `prepare()`/`SELECT`, `store_sqlite.Open` returns the error, and the **daemon refuses to start** — recoverable only by the user hand-deleting `store.sqlite`. Loud and early, never silent-wrong, but a footgun.

## Approach — a version mechanism sized for a *derived cache*

Unlike the sidecar (irreplaceable user data → must migrate in place), the graph store is a **rebuildable cache**: every row is reconstructable by re-indexing the source. So this is **not** the sidecar's in-place-only runner. It's a forward-only registry keyed on `PRAGMA user_version` where each step declares one strategy:

- **`rebuild`** — the change needs data only re-indexing can supply → drop the DB and let the daemon repopulate it (always correct; the common case for a cache).
- **`inPlace`** — a mechanical change derivable from the existing store (a new index, a denormalisation) → applied in a transaction, sparing a large repo a multi-minute reindex.

`Open` now reads `user_version` before applying the schema and reconciles:

| Stored version | Action |
|---|---|
| `== current` | no-op |
| `0` (fresh / pre-versioning) | baseline-stamp (schemaSQL + the existing column retrofit reconcile it); wipe instead if a later migration would be skipped |
| `> current` (newer build) | drop + rebuild |
| `0 < v < current` | run registered in-place steps, or rebuild if any pending step needs it |

## Safety

- **No silent mis-stamp.** A test asserts the registry reaches `currentSchemaVersion`, so bumping the version without a matching migration entry fails CI rather than silently stamping an un-migrated store at runtime.
- **Explicit rebuild signal.** A wiped store reports the existing `NeedsRebuild()` capability (the hook `cmd/gortex.storeNeedsRebuild` already probes for and wires into warm restart), so the daemon forces a full re-index — instead of relying on the side effect that a total wipe also empties `file_mtimes`.
- **Wipe is race-free.** The destructive rebuild runs only under the daemon's exclusive `store.sqlite.lock`, held around `Open` for the sole writable on-disk lifecycle.
- **Data preserved on baseline.** Additive only — no `DROP`, no rebuild of existing tables on the non-wipe paths.

## Tests

`internal/graph/store_sqlite/schema_version_test.go` — fresh-stamp, pre-versioning baseline (data preserved), newer-DB rebuild (data wiped), the steady-state `stored == current` no-op (highest-frequency path), an in-place upgrade driven end-to-end through `Open` (effect visible, ordering after `schemaSQL`, data survives, version stamped), in-place failure leaves the version unstamped, `:memory:` under a wipe plan, `NeedsRebuild` after a wipe, registry well-formedness (+ rejection of every dangerous misconfiguration), and a shared-transaction rollback assertion. **133 store_sqlite tests pass under `-race`; `go build ./...`, `go vet`, and `golangci-lint` clean.**

## Reviewed

Implementation was put through an adversarial review (concurrency/wipe-safety, version-decision logic, data-loss/rebuild, test rigor); the confirmed findings are folded into this PR.

## Wipe is gated on the store lock (second commit)

The destructive rebuild is now opt-in. `Open` refuses to wipe by default — it returns `ErrSchemaRebuildRequired` and leaves the file intact — and performs the drop-and-recreate only when the caller passes `WithRebuild()`. `NewSharedServer` threads that opt-in through `OpenBackend` **only in the branch where it actually acquired the exclusive store flock**, so the permission to wipe and the lock that makes wiping safe are derived from the same fact.

No behaviour change for the daemon (it holds the lock and rebuilds as before); a future non-locked on-disk sqlite caller fails safe with a clear error instead of unlinking a database another process may have open. This deliberately does **not** broaden the flock's acquisition condition (that would force exclusivity on a hypothetical shared read-only sqlite consumer and touches the fragile daemon-restart lock path) — the opt-in achieves the same guarantee without that risk.
