### PR TITLE
Serialize concurrent sidecar opens so they don't fail with SQLITE_BUSY

### DIFF
--- a/internal/persistence/sidecar_migrate.go
+++ b/internal/persistence/sidecar_migrate.go
@@ -58,6 +58,34 @@ func runMigrations(db *sql.DB) error {
 	return nil
 }
 
+// runBaseSchema applies the idempotent base shape (sidecarSchema) inside one
+// IMMEDIATE-locked transaction. The sidecar DSN's _txlock=immediate makes
+// db.Begin() emit BEGIN IMMEDIATE, so the reserved write lock is held from the
+// start of the batch.
+//
+// This matters for the same reason applyOne wraps its work: the base schema's
+// CREATE TABLE / CREATE INDEX IF NOT EXISTS statements write, and run in
+// autocommit each one first takes a read lock and then tries to promote to a
+// write lock. SQLite answers that promotion with an un-retryable SQLITE_BUSY
+// (busy_timeout is not consulted on a lock upgrade) when another process is
+// concurrently creating the same objects — so several gortex processes opening
+// a fresh or stale DB at once would race here, before runMigrations' own
+// IMMEDIATE transactions ever run, and the losers would fail the open. Taking
+// the write lock at BEGIN instead makes a concurrent opener block on
+// busy_timeout and then re-run the IF NOT EXISTS statements as clean no-ops, so
+// every opener succeeds.
+func runBaseSchema(db *sql.DB) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }() // no-op once Commit succeeds
+	if _, err := tx.Exec(sidecarSchema); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
 // applyOne applies a single migration if the DB's user_version is below it.
 //
 // The sidecar DSN sets _txlock=immediate, so db.Begin() emits BEGIN IMMEDIATE

--- a/internal/persistence/sidecar_sqlite.go
+++ b/internal/persistence/sidecar_sqlite.go
@@ -237,9 +237,23 @@ func OpenSidecar(path string) (*SidecarStore, error) {
 	// up unbounded under steady writes with ever-present readers (same WAL
 	// growth class the graph store guards against).
 	//
+	// busy_timeout is listed FIRST, before journal_mode: modernc applies
+	// _pragma settings in DSN order, and the very first connection to a DB
+	// created in rollback-journal mode runs PRAGMA journal_mode=WAL, which
+	// takes a brief EXCLUSIVE lock to convert the file. Unlike the graph store
+	// (one process), the sidecar is opened concurrently by the daemon, every
+	// per-repo `gortex mcp` subprocess, and the CLI — so that conversion races.
+	// With busy_timeout set first the loser blocks and retries; set after
+	// journal_mode it would still be 0 during the conversion and fail
+	// immediately with SQLITE_BUSY.
+	//
 	// _txlock=immediate makes db.Begin() emit BEGIN IMMEDIATE so a write
-	// transaction takes the reserved lock at BEGIN. runMigrations depends on
-	// this: it reads PRAGMA user_version inside the transaction, and a plain
+	// transaction takes the reserved lock at BEGIN. Both runBaseSchema (the
+	// CREATE ... IF NOT EXISTS batch) and runMigrations depend on this so
+	// several processes opening the same DB at once serialise on busy_timeout
+	// instead of racing on an un-retryable lock-promotion SQLITE_BUSY.
+	// runMigrations additionally reads PRAGMA user_version inside the
+	// transaction, and a plain
 	// DEFERRED begin would not hold the write lock at that point — two
 	// processes opening a stale DB at once could both pass the version gate,
 	// and the loser would hit an un-retryable SQLITE_BUSY on lock upgrade
@@ -248,12 +262,12 @@ func OpenSidecar(path string) (*SidecarStore, error) {
 	// bumped version and skips cleanly. Harmless for the savings write
 	// transactions (already serialised in-process by writeMu); only changes
 	// when their write lock is taken, not whether.
-	dsn := abs + "?_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=busy_timeout(5000)&_pragma=foreign_keys(OFF)&_pragma=journal_size_limit(67108864)&_txlock=immediate"
+	dsn := abs + "?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(OFF)&_pragma=journal_size_limit(67108864)&_txlock=immediate"
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("persistence: open sidecar: %w", err)
 	}
-	if _, err := db.Exec(sidecarSchema); err != nil {
+	if err := runBaseSchema(db); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("persistence: sidecar schema: %w", err)
 	}


### PR DESCRIPTION
## Problem

`TestOpenSidecarConcurrentProcesses` failed on CI:

```
--- FAIL: TestOpenSidecarConcurrentProcesses
    sidecar_migrate_test.go:314: concurrent opener 3 errored (none may): exit status 3
        stderr: child OpenSidecar failed: persistence: sidecar schema: database is locked (5) (SQLITE_BUSY)
```

The sidecar DB is the one SQLite database opened **concurrently** by the daemon, every per-repo `gortex mcp` subprocess, and the CLI (the graph `store_sqlite` is single-process and never hits this). Two distinct, un-retryable `SQLITE_BUSY` races made simultaneous opens of a fresh or stale DB fail intermittently.

## Root cause

1. **Base schema ran in autocommit.** `OpenSidecar` executed the `CREATE TABLE/INDEX IF NOT EXISTS` batch via `db.Exec` *before* the migrations. Each autocommit DDL statement reads `sqlite_master` (read lock) then promotes to a write lock — and SQLite returns an immediate `SQLITE_BUSY` on a lock *promotion* rather than honoring `busy_timeout`. The migration path already guarded against this with `BEGIN IMMEDIATE`, but the base-schema exec was left exposed.

2. **DSN pragma ordering.** modernc applies `_pragma=` settings in DSN order. The first connection to a rollback-journal DB runs `PRAGMA journal_mode=WAL`, which takes a brief exclusive lock to convert the file. `busy_timeout` was listed *after* `journal_mode`, so it was still 0 during the conversion and failed immediately under contention.

## Fix

- New `runBaseSchema` helper runs `sidecarSchema` inside a `BEGIN IMMEDIATE` transaction (via the DSN's `_txlock=immediate`), mirroring `applyOne`. A concurrent opener now blocks on `busy_timeout` and re-runs the `IF NOT EXISTS` statements as no-ops.
- Move `busy_timeout(5000)` to the front of the DSN so the WAL conversion respects the timeout.

Both fixes are required — the transaction wrap alone just moved the failure to `db.Begin()` (the WAL conversion). `store_sqlite`'s DSN is intentionally left unchanged: it shares the old ordering but is single-process and safe.

## Verification

- `go build` (CGO), `go vet`, `golangci-lint` clean
- Full `persistence` package green with `-race`
- The previously-flaky test: **150 consecutive `-race` passes** (6 child processes each), vs 1-in-20 failures with only the transaction wrap