### PR TITLE
Fix gortex repos always reporting repos as never indexed

### DIFF
--- a/cmd/gortex/repos_cmd.go
+++ b/cmd/gortex/repos_cmd.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"time"
@@ -12,7 +13,10 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
 	"github.com/zzet/gortex/internal/persistence"
+	"github.com/zzet/gortex/internal/platform"
 	"github.com/zzet/gortex/internal/progress"
 	"github.com/zzet/gortex/internal/tui"
 )
@@ -24,6 +28,12 @@ var reposJSON bool
 // (~/.gortex/cache/) — the same slot `gortex server` / `gortex mcp`
 // persist to. Overridable so tests can point at a temp store.
 var reposCacheDir string
+
+// reposBackendPath is the on-disk SQLite backend file `gortex repos`
+// reads index-freshness provenance (the repo_index_state table) from.
+// Empty resolves to the daemon's default store (~/.gortex/store/store.sqlite).
+// Overridable so tests can point at an isolated store.
+var reposBackendPath string
 
 var reposCmd = &cobra.Command{
 	Use:   "repos",
@@ -78,6 +88,12 @@ type repoStatus struct {
 	// Indexed is true when a persisted index snapshot was found for
 	// the repo's current branch slot.
 	Indexed bool `json:"indexed"`
+	// IndexedDirty is true when the recorded index was built from a
+	// working tree with uncommitted changes (the repo_index_state.dirty
+	// flag). Omitted from JSON when false / unknown. The index still
+	// counts as fresh when its commit matches HEAD — this is provenance,
+	// not a staleness signal.
+	IndexedDirty bool `json:"indexed_dirty,omitempty"`
 }
 
 func runRepos(cmd *cobra.Command, _ []string) error {
@@ -86,10 +102,17 @@ func runRepos(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	// The persistence store is read-only here — we only inspect what
-	// `gortex server` / `gortex mcp` already persisted. An empty
-	// cache dir resolves to the default (~/.gortex/cache/), the same
-	// slot those commands write to.
+	// Primary freshness source: the daemon's on-disk SQLite backend
+	// records one repo_index_state row per repo at the end of every
+	// (re)index. Read it once, read-only, so a single open serves the
+	// whole list. An unavailable / empty store yields an empty map and
+	// we fall back to the snapshot store below.
+	indexStates := loadRepoIndexStates()
+
+	// The persistence store is the legacy fallback freshness source —
+	// the embedded `gortex mcp --index` path persists a per-repo
+	// snapshot here on shutdown. An empty cache dir resolves to the
+	// default (~/.gortex/cache/).
 	store, err := persistence.NewFileStore(reposCacheDir, version)
 	if err != nil {
 		return fmt.Errorf("open persistence store: %w", err)
@@ -98,7 +121,7 @@ func runRepos(cmd *cobra.Command, _ []string) error {
 
 	entries := make([]repoStatus, 0, len(repos))
 	for _, r := range repos {
-		entries = append(entries, describeRepo(store, r))
+		entries = append(entries, describeRepo(store, indexStates, len(repos), r))
 	}
 	// Stable order regardless of config-file ordering so scripted
 	// diffs and the table stay deterministic.
@@ -118,12 +141,35 @@ func runRepos(cmd *cobra.Command, _ []string) error {
 	return renderReposTable(cmd, entries)
 }
 
+// loadRepoIndexStates reads the daemon's per-repo index-freshness rows
+// (the SQLite repo_index_state table) keyed by repo prefix. It opens the
+// backend store read-only so it is safe to run while a daemon holds the
+// same store. Any failure (no store yet, unreadable cache) degrades to an
+// empty map so `gortex repos` falls back to the snapshot store rather than
+// erroring out.
+func loadRepoIndexStates() map[string]graph.RepoIndexState {
+	path := reposBackendPath
+	if path == "" {
+		path = filepath.Join(platform.StoreDir(), "store.sqlite")
+	}
+	states, err := store_sqlite.ReadRepoIndexStates(path)
+	if err != nil {
+		return map[string]graph.RepoIndexState{}
+	}
+	return states
+}
+
 // describeRepo resolves one RepoEntry into a repoStatus by reading the
-// repo's current git HEAD and looking up the persisted index snapshot
-// for its branch slot. Snapshots are keyed by (repo, branch), so a slot
-// found for the current branch carries the commit it was last indexed
-// at — staleness is HEAD having advanced past that commit.
-func describeRepo(store persistence.Store, r config.RepoEntry) repoStatus {
+// repo's current git HEAD and looking up its recorded index freshness.
+//
+// The authoritative source is the daemon's repo_index_state row, keyed by
+// the repo's resolved prefix (config.ResolvePrefix — the entry Name, else
+// the path basename); this is what `gortex index` and daemon warmup write.
+// When there is exactly one tracked repo, a lone-repo index keyed under the
+// empty prefix counts too. Failing that, the legacy snapshot store (keyed by
+// canonical path + branch) written by the embedded `gortex mcp --index` path
+// is consulted. A repo is fresh when the recorded commit matches HEAD.
+func describeRepo(store persistence.Store, indexStates map[string]graph.RepoIndexState, repoCount int, r config.RepoEntry) repoStatus {
 	head := gitCommitHash(r.Path)
 	branch := gitBranch(r.Path)
 
@@ -133,14 +179,35 @@ func describeRepo(store persistence.Store, r config.RepoEntry) repoStatus {
 		Workspace:  r.Workspace,
 		HeadCommit: head,
 		Branch:     branch,
-		// Default to stale; cleared below only when a persisted
+		// Default to stale; cleared below only when a recorded
 		// index is found whose commit matches HEAD.
 		Stale: true,
 	}
 
-	// Snapshots are keyed under the canonical (main) repo path so
-	// every worktree of a repo shares a base slot — match the key
-	// `gortex server` writes with.
+	// Primary: the daemon's freshness row for this repo's prefix.
+	prefix := config.ResolvePrefix(r)
+	st, ok := indexStates[prefix]
+	if !ok && repoCount == 1 {
+		// A single-repo (lone) index is keyed under the empty prefix.
+		st, ok = indexStates[""]
+	}
+	if ok {
+		entry.Indexed = true
+		entry.IndexedCommit = st.IndexedSHA
+		entry.IndexedDirty = st.Dirty
+		if st.IndexedAt > 0 {
+			ts := time.Unix(st.IndexedAt, 0)
+			entry.LastIndexed = &ts
+		}
+		// Fresh only when the recorded index was built from the exact
+		// commit HEAD currently points at. An empty HeadCommit (not a
+		// git repo) or an empty recorded SHA can never be fresh.
+		entry.Stale = head == "" || st.IndexedSHA == "" || st.IndexedSHA != head
+		return entry
+	}
+
+	// Fallback: the embedded-server snapshot, keyed under the canonical
+	// (main) repo path so every worktree of a repo shares a base slot.
 	repoKey := canonicalRepo(r.Path)
 	snap, loadErr := store.Load(repoKey, branch, head)
 	if loadErr != nil || snap == nil {
@@ -152,9 +219,6 @@ func describeRepo(store persistence.Store, r config.RepoEntry) repoStatus {
 	entry.IndexedCommit = snap.CommitHash
 	indexedAt := snap.IndexedAt
 	entry.LastIndexed = &indexedAt
-	// Fresh only when the persisted index was built from the exact
-	// commit HEAD currently points at. An empty HeadCommit (not a
-	// git repo) can never be fresh.
 	entry.Stale = head == "" || snap.CommitHash != head
 	return entry
 }

--- a/cmd/gortex/repos_cmd_test.go
+++ b/cmd/gortex/repos_cmd_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
 	"github.com/zzet/gortex/internal/persistence"
 )
 
@@ -80,10 +82,34 @@ func reposTestEnv(t *testing.T, repos []config.RepoEntry) {
 	cfgFile = gcPath
 	prevCache := reposCacheDir
 	reposCacheDir = filepath.Join(root, "cache")
+	prevBackend := reposBackendPath
+	// Isolate the SQLite freshness store at a per-test path so the
+	// command never reads the developer's real ~/.gortex/store. Tests
+	// that exercise the repo_index_state path seed this file; the rest
+	// leave it absent so describeRepo falls back to the snapshot store.
+	reposBackendPath = filepath.Join(root, "store", "store.sqlite")
 	t.Cleanup(func() {
 		cfgFile = prevCfg
 		reposCacheDir = prevCache
+		reposBackendPath = prevBackend
 	})
+}
+
+// seedIndexState writes a repo_index_state freshness row into the test's
+// isolated SQLite backend store — the same table `gortex index` / daemon
+// warmup write, and the authoritative source describeRepo reads first.
+func seedIndexState(t *testing.T, prefix, sha string, dirty bool, indexedAt time.Time) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(reposBackendPath), 0o755))
+	st, err := store_sqlite.Open(reposBackendPath)
+	require.NoError(t, err)
+	require.NoError(t, st.SetRepoIndexState(graph.RepoIndexState{
+		RepoPrefix: prefix,
+		IndexedSHA: sha,
+		Dirty:      dirty,
+		IndexedAt:  indexedAt.Unix(),
+	}))
+	require.NoError(t, st.Close())
 }
 
 // seedSnapshot writes a persisted index snapshot for (repoPath, branch,
@@ -253,6 +279,142 @@ func TestRunRepos_StaleWhenBranchSlotMissing(t *testing.T) {
 	require.Len(t, got, 1)
 	assert.False(t, got[0].Indexed, "a snapshot on a different branch must not count")
 	assert.True(t, got[0].Stale)
+}
+
+// TestRunRepos_IndexStateFreshness covers the primary freshness source:
+// the daemon's repo_index_state rows (keyed by repo prefix). This is the
+// path that was dead before — `gortex repos` read only the embedded-server
+// snapshot store, which the daemon never writes, so every daemon-indexed
+// repo wrongly reported "never indexed".
+func TestRunRepos_IndexStateFreshness(t *testing.T) {
+	base := t.TempDir()
+	freshDir := filepath.Join(base, "alpha")
+	staleDir := filepath.Join(base, "beta")
+	dirtyDir := filepath.Join(base, "gamma")
+	neverDir := filepath.Join(base, "delta")
+
+	freshHead := gitInitRepo(t, freshDir)
+	oldHead := gitInitRepo(t, staleDir)
+	dirtyHead := gitInitRepo(t, dirtyDir)
+	gitInitRepo(t, neverDir)
+
+	reposTestEnv(t, []config.RepoEntry{
+		{Path: freshDir, Name: "alpha"},
+		{Path: staleDir, Name: "beta"},
+		{Path: dirtyDir, Name: "gamma"},
+		{Path: neverDir, Name: "delta"},
+	})
+
+	indexedAt := time.Now().Add(-30 * time.Minute).Truncate(time.Second)
+	// alpha: indexed at the exact current HEAD → fresh.
+	seedIndexState(t, "alpha", freshHead, false, indexedAt)
+	// beta: indexed at the old HEAD, then HEAD advances → stale.
+	seedIndexState(t, "beta", oldHead, false, indexedAt)
+	newHead := gitCommitMore(t, staleDir, "second.txt")
+	require.NotEqual(t, oldHead, newHead)
+	// gamma: indexed at the current HEAD but from a dirty tree → fresh + dirty.
+	seedIndexState(t, "gamma", dirtyHead, true, indexedAt)
+	// delta: no row → never indexed.
+
+	reposJSON = true
+	t.Cleanup(func() { reposJSON = false })
+
+	cmd, buf := newReposCmd()
+	require.NoError(t, runRepos(cmd, nil))
+
+	var got []repoStatus
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	require.Len(t, got, 4)
+	byName := map[string]repoStatus{}
+	for _, e := range got {
+		byName[e.Name] = e
+	}
+
+	alpha := byName["alpha"]
+	assert.True(t, alpha.Indexed)
+	assert.False(t, alpha.Stale, "index commit matches HEAD → fresh")
+	assert.Equal(t, freshHead, alpha.IndexedCommit)
+	assert.False(t, alpha.IndexedDirty)
+	require.NotNil(t, alpha.LastIndexed)
+	assert.Equal(t, indexedAt.Unix(), alpha.LastIndexed.Unix())
+
+	beta := byName["beta"]
+	assert.True(t, beta.Indexed)
+	assert.True(t, beta.Stale, "HEAD advanced past the indexed commit → stale")
+	assert.Equal(t, oldHead, beta.IndexedCommit)
+	assert.Equal(t, newHead, beta.HeadCommit)
+
+	gamma := byName["gamma"]
+	assert.True(t, gamma.Indexed)
+	assert.False(t, gamma.Stale, "a dirty-tree index whose commit matches HEAD is still fresh")
+	assert.True(t, gamma.IndexedDirty, "dirty provenance is surfaced")
+
+	delta := byName["delta"]
+	assert.False(t, delta.Indexed, "no repo_index_state row → never indexed")
+	assert.True(t, delta.Stale)
+	assert.Nil(t, delta.LastIndexed)
+}
+
+// TestRunRepos_IndexStateLoneRepoEmptyPrefix covers single-repo (lone) mode,
+// where the index is keyed under the empty repo prefix. A single tracked
+// repo must match that "" row even though its resolved prefix is its name.
+func TestRunRepos_IndexStateLoneRepoEmptyPrefix(t *testing.T) {
+	base := t.TempDir()
+	dir := filepath.Join(base, "solo")
+	head := gitInitRepo(t, dir)
+
+	reposTestEnv(t, []config.RepoEntry{{Path: dir, Name: "solo"}})
+	indexedAt := time.Now().Add(-time.Minute).Truncate(time.Second)
+	// Lone-repo mode writes the freshness row under the empty prefix.
+	seedIndexState(t, "", head, false, indexedAt)
+
+	reposJSON = true
+	t.Cleanup(func() { reposJSON = false })
+	cmd, buf := newReposCmd()
+	require.NoError(t, runRepos(cmd, nil))
+
+	var got []repoStatus
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	require.Len(t, got, 1)
+	assert.True(t, got[0].Indexed, "the empty-prefix lone-repo row must count for a single tracked repo")
+	assert.False(t, got[0].Stale)
+	assert.Equal(t, head, got[0].IndexedCommit)
+}
+
+// TestRunRepos_IndexStateBeatsSnapshot proves the repo_index_state row is the
+// authoritative source: when both a freshness row and a (stale) snapshot
+// exist, the row wins.
+func TestRunRepos_IndexStateBeatsSnapshot(t *testing.T) {
+	base := t.TempDir()
+	dirA := filepath.Join(base, "one")
+	dirB := filepath.Join(base, "two")
+	headA := gitInitRepo(t, dirA)
+	gitInitRepo(t, dirB)
+
+	reposTestEnv(t, []config.RepoEntry{
+		{Path: dirA, Name: "one"},
+		{Path: dirB, Name: "two"},
+	})
+	indexedAt := time.Now().Add(-time.Minute).Truncate(time.Second)
+	// Snapshot says an old/wrong commit; the index-state row says HEAD.
+	seedSnapshot(t, dirA, "main", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", indexedAt)
+	seedIndexState(t, "one", headA, false, indexedAt)
+
+	reposJSON = true
+	t.Cleanup(func() { reposJSON = false })
+	cmd, buf := newReposCmd()
+	require.NoError(t, runRepos(cmd, nil))
+
+	var got []repoStatus
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	byName := map[string]repoStatus{}
+	for _, e := range got {
+		byName[e.Name] = e
+	}
+	one := byName["one"]
+	assert.True(t, one.Indexed)
+	assert.Equal(t, headA, one.IndexedCommit, "repo_index_state row wins over the snapshot store")
+	assert.False(t, one.Stale)
 }
 
 // TestShortSHA covers the table SHA abbreviation helper.

--- a/internal/graph/store_sqlite/read_index_state.go
+++ b/internal/graph/store_sqlite/read_index_state.go
@@ -1,0 +1,74 @@
+package store_sqlite
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// ReadRepoIndexStates opens the SQLite store at path read-only and returns
+// every repo_index_state freshness row keyed by repo_prefix.
+//
+// It is a deliberately lightweight side door for read-only callers (notably
+// `gortex repos`) that must inspect index freshness WITHOUT going through
+// Open — which runs schema migrations, alters columns, starts a checkpoint
+// goroutine, and (on a version mismatch) can refuse to open or rebuild the
+// file. None of that is appropriate for a status command that may run while
+// a daemon holds the same store open.
+//
+// The connection is query-only and inherits the database's existing journal
+// mode, so it reads safely alongside a running daemon (WAL permits concurrent
+// readers). A missing store file, or a database that predates the
+// repo_index_state table, both yield an empty map and a nil error — that is
+// "nothing recorded yet", not a failure, so the caller can fall back to other
+// freshness sources rather than surfacing an error to the user.
+func ReadRepoIndexStates(path string) (map[string]graph.RepoIndexState, error) {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return map[string]graph.RepoIndexState{}, nil
+		}
+		return nil, fmt.Errorf("stat sqlite store %q: %w", path, err)
+	}
+
+	// query_only blocks accidental writes; busy_timeout keeps a brief read
+	// from erroring out if the daemon happens to hold the write lock for a
+	// moment. We deliberately do NOT set journal_mode — forcing it could try
+	// to switch the live database's mode; inheriting the on-disk WAL mode is
+	// exactly what a concurrent reader wants.
+	dsn := path + "?_pragma=busy_timeout(2000)&_pragma=query_only(1)"
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open sqlite store %q: %w", path, err)
+	}
+	defer func() { _ = db.Close() }()
+	db.SetMaxOpenConns(1)
+
+	rows, err := db.Query(`
+SELECT repo_prefix, indexed_sha, dirty, indexed_at, workspace_fp, node_count, edge_count, extractor_versions
+  FROM repo_index_state`)
+	if err != nil {
+		// A store written before the repo_index_state table existed (or any
+		// other read error) is treated as "no freshness recorded yet" — a
+		// status command must never hard-fail on a degraded cache.
+		return map[string]graph.RepoIndexState{}, nil
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := map[string]graph.RepoIndexState{}
+	for rows.Next() {
+		var st graph.RepoIndexState
+		var dirty int
+		if err := rows.Scan(&st.RepoPrefix, &st.IndexedSHA, &dirty, &st.IndexedAt,
+			&st.WorkspaceFP, &st.NodeCount, &st.EdgeCount, &st.ExtractorVersions); err != nil {
+			return nil, fmt.Errorf("scan repo_index_state: %w", err)
+		}
+		st.Dirty = dirty != 0
+		out[st.RepoPrefix] = st
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate repo_index_state: %w", err)
+	}
+	return out, nil
+}

--- a/internal/graph/store_sqlite/read_index_state_test.go
+++ b/internal/graph/store_sqlite/read_index_state_test.go
@@ -1,0 +1,78 @@
+package store_sqlite_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+)
+
+// A store file that does not exist yet reads back as an empty map, not an
+// error — "nothing indexed", so callers fall back to other sources.
+func TestReadRepoIndexStates_MissingFile(t *testing.T) {
+	got, err := store_sqlite.ReadRepoIndexStates(filepath.Join(t.TempDir(), "absent.sqlite"))
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+// The read-only reader returns exactly the rows SetRepoIndexState wrote,
+// keyed by repo prefix, including the empty (lone-repo) prefix.
+func TestReadRepoIndexStates_RoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "is.sqlite")
+
+	s, err := store_sqlite.Open(path)
+	require.NoError(t, err)
+	require.NoError(t, s.SetRepoIndexState(graph.RepoIndexState{
+		RepoPrefix: "alpha", IndexedSHA: "aaa111", Dirty: false, IndexedAt: 1700000000,
+		WorkspaceFP: "fp-a", NodeCount: 10, EdgeCount: 20, ExtractorVersions: `{"go":1}`,
+	}))
+	require.NoError(t, s.SetRepoIndexState(graph.RepoIndexState{
+		RepoPrefix: "", IndexedSHA: "bbb222", Dirty: true, IndexedAt: 1700000001,
+	}))
+	require.NoError(t, s.Close())
+
+	got, err := store_sqlite.ReadRepoIndexStates(path)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	alpha, ok := got["alpha"]
+	require.True(t, ok)
+	require.Equal(t, "aaa111", alpha.IndexedSHA)
+	require.False(t, alpha.Dirty)
+	require.EqualValues(t, 1700000000, alpha.IndexedAt)
+	require.Equal(t, 10, alpha.NodeCount)
+
+	lone, ok := got[""]
+	require.True(t, ok)
+	require.Equal(t, "bbb222", lone.IndexedSHA)
+	require.True(t, lone.Dirty)
+}
+
+// Reading is non-destructive and repeatable while the underlying store is
+// reopened for writing — the read path must never lock the writer out.
+func TestReadRepoIndexStates_ConcurrentWithOpenStore(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "is.sqlite")
+
+	s, err := store_sqlite.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	require.NoError(t, s.SetRepoIndexState(graph.RepoIndexState{
+		RepoPrefix: "live", IndexedSHA: "c0ffee", IndexedAt: 1700000002,
+	}))
+
+	// Read while the writer store is still open (WAL allows concurrent readers).
+	got, err := store_sqlite.ReadRepoIndexStates(path)
+	require.NoError(t, err)
+	require.Equal(t, "c0ffee", got["live"].IndexedSHA)
+
+	// A subsequent write is still possible — the reader did not wedge the writer.
+	require.NoError(t, s.SetRepoIndexState(graph.RepoIndexState{
+		RepoPrefix: "live", IndexedSHA: "feedface", IndexedAt: 1700000003,
+	}))
+	got, err = store_sqlite.ReadRepoIndexStates(path)
+	require.NoError(t, err)
+	require.Equal(t, "feedface", got["live"].IndexedSHA)
+}


### PR DESCRIPTION
## Summary

Fixes #114. `gortex repos` reported **INDEXED=(none)**, **LAST INDEXED=(never)**, **FRESHNESS=not indexed** for every tracked repo even immediately after a successful `gortex index` — while `gortex status` and `gortex query stats` showed fully populated graphs.

## Root cause

There are two freshness sources, and `gortex repos` was reading the wrong one:

- **`persistence.FileStore` snapshot** — what `describeRepo` read. It is written *only* by the embedded `gortex mcp --index` path on shutdown, and **never** in the daemon-first workflow (`gortex daemon start` + `gortex index`). So `store.Load(...)` always returned `ErrNotFound` → "never indexed".
- **`repo_index_state` table** (SQLite backend) — what `gortex index` and daemon indexing actually write (via `persistRepoIndexState` → `SetRepoIndexState`). This is the populated table the issue reporter found in `~/.gortex/store/store.sqlite`, keyed by `repo_prefix`.

The data was there the whole time; the command just never read it.

## Fix

- Add `store_sqlite.ReadRepoIndexStates(path)` — a read-only reader for `repo_index_state`. It opens query-only and inherits the on-disk WAL mode, so it reads safely **alongside a running daemon** and never triggers schema migrations or the checkpoint goroutine that `Open` would. A missing file / pre-feature DB returns an empty map (not an error).
- `gortex repos` now consults `repo_index_state` first, keyed by the repo's resolved prefix (`config.ResolvePrefix` = entry name, else path basename — the same key the indexer writes). For a single tracked repo, the lone-repo empty-prefix row also counts. The `FileStore` snapshot remains a fallback for the embedded path.
- Surface the indexed SHA, the indexed-at timestamp, dirty provenance (new `indexed_dirty` JSON field), and a correct fresh/stale verdict (HEAD vs the recorded commit).

## Verification

Against a live daemon store, before → after on the same repo:

```
before:  gortex   5e9b7da3f83f   (none)         (never)               not indexed
after:   gortex   5e9b7da3f83f   6405c7c9ff22   2026-06-19 13:50:50   stale
```

(`stale` is correct — HEAD has advanced past the indexed commit; re-indexing at HEAD shows `fresh`.)

- New unit tests for the read-only reader (missing file, round-trip, concurrent read while the writer store is open).
- New `runRepos` tests covering the `repo_index_state` path: fresh / stale / dirty-but-fresh / never-indexed, the lone-repo empty prefix, and `repo_index_state` taking precedence over a stale snapshot.
- `go build`, `go vet`, `golangci-lint`, and `go test -race` (509 tests across the two touched packages) all green.