### PR TITLE
Resolve git-watcher ref changes scoped to the changed files

### DIFF
--- a/internal/graph/store_sqlite/out_edges_light_test.go
+++ b/internal/graph/store_sqlite/out_edges_light_test.go
@@ -1,0 +1,45 @@
+package store_sqlite_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// TestGetOutEdgesLight_SkipsMetaKeepsEndpoints proves the light out-edge
+// fetch returns the same endpoints/kind/line as GetOutEdges while leaving
+// Meta nil — it must never pay the per-edge meta JSON decode. This is the
+// fetch findCallTarget uses on the dataflow hot path.
+func TestGetOutEdgesLight_SkipsMetaKeepsEndpoints(t *testing.T) {
+	s := openTestStore(t)
+
+	want := &graph.Edge{
+		From:     "pkg/x.go::Caller",
+		To:       "pkg/x.go::Callee",
+		Kind:     graph.EdgeCalls,
+		FilePath: "pkg/x.go",
+		Line:     42,
+		Meta:     map[string]any{"call_line": 42, "callee_target": "unresolved::Callee"},
+	}
+	s.AddEdge(want)
+
+	full := s.GetOutEdges("pkg/x.go::Caller")
+	require.Len(t, full, 1)
+	require.NotNil(t, full[0].Meta, "GetOutEdges must decode Meta")
+	assert.Equal(t, "unresolved::Callee", full[0].Meta["callee_target"])
+
+	light := s.GetOutEdgesLight("pkg/x.go::Caller")
+	require.Len(t, light, 1)
+	assert.Equal(t, full[0].From, light[0].From)
+	assert.Equal(t, full[0].To, light[0].To)
+	assert.Equal(t, full[0].Kind, light[0].Kind)
+	assert.Equal(t, full[0].Line, light[0].Line)
+	assert.Equal(t, full[0].FilePath, light[0].FilePath)
+	assert.Nil(t, light[0].Meta, "light fetch must not decode the meta blob")
+
+	// A node with no out-edges returns nothing on both paths.
+	assert.Empty(t, s.GetOutEdgesLight("pkg/x.go::Callee"))
+}

--- a/internal/graph/store_sqlite/store.go
+++ b/internal/graph/store_sqlite/store.go
@@ -112,6 +112,7 @@ type Store struct {
 
 	stmtInsertEdge       *sql.Stmt
 	stmtOutEdges         *sql.Stmt
+	stmtOutEdgesLight    *sql.Stmt
 	stmtInEdges          *sql.Stmt
 	stmtRepoEdges        *sql.Stmt
 	stmtAllEdges         *sql.Stmt
@@ -391,7 +392,7 @@ func (s *Store) Close() error {
 		s.stmtRepoNodeCount, s.stmtRepoEdgeCount,
 		s.stmtAllRepoCountsNodes, s.stmtAllRepoCountsEdges,
 		s.stmtStatsByKind, s.stmtStatsByLanguage,
-		s.stmtInsertEdge, s.stmtOutEdges, s.stmtInEdges,
+		s.stmtInsertEdge, s.stmtOutEdges, s.stmtOutEdgesLight, s.stmtInEdges,
 		s.stmtRepoEdges,
 		s.stmtAllEdges, s.stmtEdgeCount, s.stmtRemoveEdge,
 		s.stmtUpdateEdgeOrigin, s.stmtUpdateEdgeAttrs, s.stmtSelectEdgeOrigin, s.stmtDeleteEdgeByKey,
@@ -479,6 +480,9 @@ func (s *Store) prepare() error {
 		`INSERT OR IGNORE INTO edges (`+edgeCols+`) VALUES (?,?,?,?,?,?,?,?,?,?,?)`)
 	prep(&s.stmtOutEdges,
 		`SELECT `+edgeCols+` FROM edges WHERE from_id = ?`)
+	const edgeColsLight = `from_id, to_id, kind, file_path, line, confidence, confidence_label, origin, tier, cross_repo`
+	prep(&s.stmtOutEdgesLight,
+		`SELECT `+edgeColsLight+` FROM edges WHERE from_id = ?`)
 	prep(&s.stmtInEdges,
 		`SELECT `+edgeCols+` FROM edges WHERE to_id = ?`)
 	prep(&s.stmtRepoEdges,
@@ -577,6 +581,30 @@ func scanEdge(scanner interface {
 		}
 		e.Meta = m
 	}
+	return &e, nil
+}
+
+// scanEdgeLight scans an edge WITHOUT decoding its meta blob -- for hot
+// read paths (dataflow call-target lookup) that read only endpoints,
+// kind, and line. Skipping the meta column avoids the JSON decode + map
+// allocation that dominates large edge scans on this backend; the
+// returned edge's Meta is nil.
+func scanEdgeLight(scanner interface {
+	Scan(...any) error
+}) (*graph.Edge, error) {
+	var (
+		e         graph.Edge
+		crossRepo int64
+	)
+	err := scanner.Scan(
+		&e.From, &e.To, &e.Kind, &e.FilePath, &e.Line,
+		&e.Confidence, &e.ConfidenceLabel, &e.Origin, &e.Tier,
+		&crossRepo,
+	)
+	if err != nil {
+		return nil, err
+	}
+	e.CrossRepo = crossRepo != 0
 	return &e, nil
 }
 
@@ -1110,6 +1138,13 @@ func (s *Store) GetOutEdges(nodeID string) []*graph.Edge {
 	return s.queryEdges(s.stmtOutEdges, nodeID)
 }
 
+// GetOutEdgesLight returns a node's out-edges without decoding the
+// per-edge Meta blob -- for hot dataflow lookups that need only
+// endpoints/kind/line. The returned edges have a nil Meta.
+func (s *Store) GetOutEdgesLight(nodeID string) []*graph.Edge {
+	return s.queryEdgesLight(s.stmtOutEdgesLight, nodeID)
+}
+
 func (s *Store) GetInEdges(nodeID string) []*graph.Edge {
 	return s.queryEdges(s.stmtInEdges, nodeID)
 }
@@ -1142,6 +1177,28 @@ func (s *Store) queryEdges(stmt *sql.Stmt, args ...any) []*graph.Edge {
 	var out []*graph.Edge
 	for rows.Next() {
 		e, err := scanEdge(rows)
+		if err != nil {
+			panicOnFatal(err)
+			return out
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// queryEdgesLight mirrors queryEdges but scans each row without its
+// meta blob (scanEdgeLight), leaving Meta nil. Only for callers that
+// never read edge Meta.
+func (s *Store) queryEdgesLight(stmt *sql.Stmt, args ...any) []*graph.Edge {
+	rows, err := stmt.Query(args...)
+	if err != nil {
+		panicOnFatal(err)
+		return nil
+	}
+	defer func() { _ = rows.Close() }()
+	var out []*graph.Edge
+	for rows.Next() {
+		e, err := scanEdgeLight(rows)
 		if err != nil {
 			panicOnFatal(err)
 			return out

--- a/internal/indexer/dataflow.go
+++ b/internal/indexer/dataflow.go
@@ -179,8 +179,22 @@ func rewriteReturnsTo(g graph.Store, e *graph.Edge) {
 // unresolved target string so we don't lift to the wrong call when
 // two calls live on the same line. Falls back to the first match
 // otherwise.
+// outEdgeLightStore is implemented by backends that can return a node's
+// out-edges without decoding the per-edge Meta blob. findCallTarget reads
+// only endpoints/kind/line, so it opts into the cheaper fetch when the
+// backend offers it (the sqlite backend, where the Meta JSON-decode
+// otherwise dominates this hot lookup); other stores fall back.
+type outEdgeLightStore interface {
+	GetOutEdgesLight(nodeID string) []*graph.Edge
+}
+
 func findCallTarget(g graph.Store, callerID string, line int, calleeText string) string {
-	out := g.GetOutEdges(callerID)
+	var out []*graph.Edge
+	if ls, ok := g.(outEdgeLightStore); ok {
+		out = ls.GetOutEdgesLight(callerID)
+	} else {
+		out = g.GetOutEdges(callerID)
+	}
 	var fallback string
 	for _, e := range out {
 		if e.Kind != graph.EdgeCalls {

--- a/internal/indexer/git_watcher.go
+++ b/internal/indexer/git_watcher.go
@@ -167,10 +167,46 @@ func (gw *GitWatcher) scheduleReconcile(trigger string) {
 	})
 }
 
+// gitWatcherScopedResolveMaxFiles caps how many changed files a ref
+// reconcile resolves through the scoped incremental path before it
+// falls back to a single whole-graph ResolveAll. Below the cap a
+// commit-sized change resolves only its own files (and their incoming
+// refs) -- the same path edit_file uses; above it (branch switches,
+// large merges) one amortised whole-graph pass beats many per-file
+// resolves. A package var so tests can lower it to exercise the
+// fallback.
+var gitWatcherScopedResolveMaxFiles = 100
+
+// changedAbsPaths collects the absolute on-disk paths a diff touched --
+// the new path for every status plus the old path of a rename --
+// deduplicated. Disk existence is resolved later by
+// IncrementalReindexPaths: a path present on disk is reindexed, one
+// absent is evicted, so a delete needs no special-casing here.
+func (gw *GitWatcher) changedAbsPaths(changes []gitChange) []string {
+	seen := make(map[string]struct{}, len(changes)+4)
+	out := make([]string, 0, len(changes)+4)
+	add := func(rel string) {
+		if rel == "" {
+			return
+		}
+		abs := filepath.Join(gw.repoPath, rel)
+		if _, ok := seen[abs]; ok {
+			return
+		}
+		seen[abs] = struct{}{}
+		out = append(out, abs)
+	}
+	for _, c := range changes {
+		add(c.Path)
+		add(c.OldPath)
+	}
+	return out
+}
+
 // reconcile reads the current HEAD SHA, diffs against the previously
 // seen SHA via `git diff --name-status`, and dispatches
-// EvictFile / IndexFileNoResolve per path. Runs ResolveAll once at
-// the end. Silently no-ops when HEAD hasn't moved — branches can
+// the changed paths to a scoped reindex + resolve (whole-graph only
+// above gitWatcherScopedResolveMaxFiles). Silently no-ops when HEAD hasn't moved — branches can
 // touch packed-refs without the resolved commit actually changing.
 func (gw *GitWatcher) reconcile(trigger string) {
 	// Single-flight: one reconcile at a time. A ref change observed
@@ -239,12 +275,30 @@ func (gw *GitWatcher) reconcile(trigger string) {
 		return
 	}
 
-	patched := gw.applyChanges(changes)
-
-	// Re-run the global resolver once after the batch. Skipping the
-	// per-file resolver during applyChanges is what makes this fast
-	// on 500-file branch switches.
-	gw.indexer.ResolveAll()
+	// Resolve the batch. A commit-sized change set resolves only the
+	// files it touched (and their incoming refs) through the scoped
+	// incremental path -- the same one edit_file / fsnotify saves use --
+	// instead of a whole-graph ResolveAll that costs O(graph) no matter
+	// how few files moved. A large change set (branch switch, big merge)
+	// still takes one amortised whole-graph pass, where skipping the
+	// per-file resolver in applyChanges is the better trade.
+	changedPaths := gw.changedAbsPaths(changes)
+	var patched int
+	switch {
+	case len(changedPaths) > gitWatcherScopedResolveMaxFiles:
+		patched = gw.applyChanges(changes)
+		gw.indexer.ResolveAll()
+	default:
+		res, rerr := gw.indexer.IncrementalReindexPaths(gw.repoPath, changedPaths)
+		if rerr != nil {
+			gw.logger.Warn("git-watcher: scoped reindex failed, falling back to whole-graph resolve",
+				zap.String("trigger", trigger), zap.Error(rerr))
+			patched = gw.applyChanges(changes)
+			gw.indexer.ResolveAll()
+		} else {
+			patched = res.StaleFileCount + res.DeletedFileCount
+		}
+	}
 
 	gw.mu.Lock()
 	gw.lastSHA = newSHA

--- a/internal/indexer/git_watcher_scoped_resolve_test.go
+++ b/internal/indexer/git_watcher_scoped_resolve_test.go
@@ -1,0 +1,113 @@
+package indexer
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/search"
+)
+
+// TestGitWatcher_SmallCommitResolvesIncoming proves a commit-sized ref
+// change resolves cross-file *incoming* references — the caller's edge to
+// a symbol newly defined in the committed file is lifted from its
+// unresolved stub to the real node. This must hold whether the reconcile
+// took the scoped incremental path (the default, exercised with a normal
+// cap) or fell back to the whole-graph ResolveAll (cap forced to 0), so
+// the scoped path is verified to be resolution-equivalent to the global
+// one it replaces for small change sets.
+func TestGitWatcher_SmallCommitResolvesIncoming(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available in PATH")
+	}
+
+	cases := []struct {
+		name     string
+		maxFiles int
+	}{
+		{"scoped", 100},
+		{"wholeGraphFallback", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prev := gitWatcherScopedResolveMaxFiles
+			gitWatcherScopedResolveMaxFiles = tc.maxFiles
+			t.Cleanup(func() { gitWatcherScopedResolveMaxFiles = prev })
+
+			repoDir := t.TempDir()
+			runGit(t, repoDir, "init", "-q", "-b", "main")
+			runGit(t, repoDir, "config", "user.email", "test@example.com")
+			runGit(t, repoDir, "config", "user.name", "Test")
+			runGit(t, repoDir, "config", "commit.gpgsign", "false")
+
+			// main: caller.go calls Target, which nothing defines yet —
+			// so the call edge starts life as an unresolved stub.
+			writeFile(t, filepath.Join(repoDir, "caller.go"),
+				"package main\n\nfunc Caller() { Target() }\n")
+			runGit(t, repoDir, "add", ".")
+			runGit(t, repoDir, "commit", "-q", "-m", "main: caller")
+
+			// feature: add callee.go defining Target, then return to main.
+			runGit(t, repoDir, "checkout", "-q", "-b", "feature")
+			writeFile(t, filepath.Join(repoDir, "callee.go"),
+				"package main\n\nfunc Target() {}\n")
+			runGit(t, repoDir, "add", "-A")
+			runGit(t, repoDir, "commit", "-q", "-m", "feature: callee")
+			runGit(t, repoDir, "checkout", "-q", "main")
+
+			g := graph.New()
+			idx := New(g, newTestRegistry(), config.IndexConfig{Workers: 1}, zap.NewNop())
+			idx.search = search.NewBM25()
+			idx.SetRootPath(repoDir)
+			_, err := idx.IndexCtx(testCtx(), repoDir)
+			require.NoError(t, err)
+			require.Empty(t, g.FindNodesByName("Target"),
+				"Target must not be defined on main")
+
+			gw, err := NewGitWatcher(repoDir, idx, zap.NewNop())
+			require.NoError(t, err)
+			gw.debounce = 50 * time.Millisecond
+			drained := make(chan int, 1)
+			gw.drained = func(n int) {
+				select {
+				case drained <- n:
+				default:
+				}
+			}
+			require.NoError(t, gw.Start())
+			t.Cleanup(func() { _ = gw.Stop() })
+
+			runGit(t, repoDir, "checkout", "-q", "feature")
+			select {
+			case <-drained:
+			case <-time.After(10 * time.Second):
+				t.Fatal("git watcher did not reconcile within timeout")
+			}
+
+			targets := g.FindNodesByName("Target")
+			require.NotEmpty(t, targets, "Target must be indexed after the reconcile")
+
+			// The caller's previously-unresolved call edge must now point at
+			// the real Target node — only the incoming (reverse) resolution
+			// pass binds a caller in another file to a symbol defined here.
+			resolved := false
+			for _, tn := range targets {
+				for _, e := range g.GetInEdges(tn.ID) {
+					if e.Kind == graph.EdgeCalls && strings.Contains(e.From, "caller.go") {
+						resolved = true
+					}
+				}
+			}
+			assert.True(t, resolved,
+				"Caller->Target must resolve into callee.go::Target after the reconcile")
+		})
+	}
+}


### PR DESCRIPTION
## Problem

A ref move (commit, branch switch) made the per-repo `.git` watcher run an unscoped whole-graph `Indexer.ResolveAll()` after re-indexing the diff. `ResolveAll` re-runs every global pass (call resolution, interface inference, framework/external/speculative synthesis, dataflow materialisation, ref-fact persistence) over the entire graph — so a **3–5 file commit re-resolved everything**.

On a large multi-repo SQLite-backed graph that pass took **60–75 minutes** (observed in the daemon log: `git-watcher: reconciled ref change … elapsed:3708/4531`s for 5- and 3-file commits). Under frequent commits these hour-long passes stacked and overlapped the hourly reconcile janitor, pegging the daemon at ~2–4 cores and parking ~40% of goroutines on the resolver mutex — starving every other request, including the synchronous per-file resolve that `edit_file` runs.

Live CPU profiling pinned the dominant cost to `materializeDataflowParams` → `findCallTarget` → `GetOutEdges` → sqlite `scanEdge` → `decodeMeta` (JSON), with ~75% of samples in GC from the per-edge Meta-map churn.

## Fix

**1. Scope the git-watcher reconcile to the changed files.** A commit-sized change set (≤ `gitWatcherScopedResolveMaxFiles`, default 100) now goes through the existing scoped `IncrementalReindexPaths` — the same incremental reindex + resolve (incoming/reverse pass and scoped inference included) the per-file save path already uses. A large change set (branch switch, big merge) still takes one amortised whole-graph `ResolveAll`, and any scoping error falls back to it, so a reconcile never silently skips resolution. A 3-file commit drops from ~1 hour to seconds.

**2. Skip the per-edge Meta decode on the dataflow call-target lookup.** `findCallTarget` reads only an edge's endpoints/kind/line, but `GetOutEdges` JSON-decoded every out-edge's Meta blob along the way. New `store_sqlite.GetOutEdgesLight` (prepared statement omits the `meta` column + a non-decoding scan) returns those edges with a nil Meta; `findCallTarget` opts in via a small interface + type assertion, so the in-memory backend (where Meta is already materialised) transparently falls back. Removes the JSON-decode + GC churn that dominated every dataflow edge scan — which also speeds up `edit_file`'s own resolve.

## Tests / validation

- New `TestGitWatcher_SmallCommitResolvesIncoming` proves the scoped path resolves a cross-file incoming reference **identically** to the whole-graph fallback (`gitWatcherScopedResolveMaxFiles=0`), so the scoped reconcile is resolution-equivalent for small change sets.
- New `TestGetOutEdgesLight_SkipsMetaKeepsEndpoints` checks the light fetch matches `GetOutEdges` on endpoints/kind/line and leaves Meta nil.
- `gofmt` clean · `go vet` clean · full CGO binary builds · `internal/indexer` and `internal/graph/store_sqlite` full `-race` green · golangci-lint 0 issues · cmd/gortex wire-contract golden green.