### PR TITLE
Scope semantic enrichment to the repo being enriched and skip absent-language servers

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -223,6 +223,12 @@ type SemanticConfig struct {
 	// the indexed repo root — the language server is told to treat
 	// those folders as part of the same workspace.
 	AdditionalWorkspaceFolders []string `mapstructure:"additional_workspace_folders" yaml:"additional_workspace_folders,omitempty"`
+	// ExcludeGlobs lists path globs to skip for semantic enrichment, in
+	// addition to the built-in generated/vendored heuristic (vendored deps,
+	// tree-sitter generated parser.c, protobuf-generated files, …). A file
+	// matching any glob is not enriched and does not count toward a repo's
+	// present languages, so a language server is not spawned just to index it.
+	ExcludeGlobs []string `mapstructure:"exclude_globs" yaml:"exclude_globs,omitempty"`
 	// SkipEmbed lists (language, kind) combinations that should be
 	// indexed for graph queries but *not* embedded into the vector
 	// search. Design tokens (CSS custom properties), terraform

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -827,11 +827,7 @@ func (idx *Indexer) RunDeferredPasses(ctx context.Context) {
 	tphase := time.Now()
 	var dGoMod, dResolve, dEnrich, dContract time.Duration
 
-	// Materialise dep::<module> contract nodes from go.mod BEFORE
-	// ResolveAll so the resolver's import bridge can re-target Go
-	// imports of declared modules to their dep contract node instead
-	// of producing an `external::` stub.
-	idx.extractGoModContracts(idx.pendingContractReg)
+	idx.runDeferredGoMod()
 	dGoMod = time.Since(tphase)
 	tphase = time.Now()
 
@@ -848,38 +844,13 @@ func (idx *Indexer) RunDeferredPasses(ctx context.Context) {
 	dResolve = time.Since(tphase)
 	tphase = time.Now()
 
-	if idx.semanticMgr != nil && idx.semanticMgr.Enabled() && idx.semanticMgr.HasProviders() {
-		reporter.Report("semantic enrichment", 0, 0)
-		// Key by the repo prefix so a repo-scoped provider can scope file
-		// selection to this repo (empty in single-repo mode).
-		roots := map[string]string{idx.repoPrefix: idx.rootPath}
-		results, err := idx.semanticMgr.EnrichAll(idx.graph, roots)
-		if err != nil {
-			idx.logger.Warn("semantic enrichment failed", zap.Error(err))
-		} else if len(results) > 0 {
-			for _, r := range results {
-				idx.logger.Info("semantic enrichment result",
-					zap.String("provider", r.Provider),
-					zap.String("language", r.Language),
-					zap.Int("confirmed", r.EdgesConfirmed),
-					zap.Int("added", r.EdgesAdded),
-					zap.Int("refuted", r.EdgesRefuted),
-					zap.Float64("coverage", r.CoveragePercent),
-				)
-			}
-		}
-	}
-
+	reporter.Report("semantic enrichment", 0, 0)
+	idx.runDeferredEnrich()
 	dEnrich = time.Since(tphase)
 	tphase = time.Now()
 
 	reporter.Report("extracting contracts", 0, 0)
-	// extractGoModContracts already ran (see above) so dep nodes
-	// were available during ResolveAll's import-bridge pass.
-	idx.extractExternalModules()
-	idx.extractDIContracts(idx.pendingContractReg)
-	idx.commitContracts(idx.pendingContractReg)
-	idx.pendingContractReg = nil
+	idx.runDeferredContracts()
 	dContract = time.Since(tphase)
 	idx.logger.Info("DEFERRED-TIMING per-repo",
 		zap.String("repo", idx.repoPrefix),
@@ -887,6 +858,63 @@ func (idx *Indexer) RunDeferredPasses(ctx context.Context) {
 		zap.Duration("resolve", dResolve),
 		zap.Duration("enrich", dEnrich),
 		zap.Duration("contract_commit", dContract))
+}
+
+// runDeferredGoMod materialises dep::<module> contract nodes from go.mod
+// BEFORE ResolveAll so the resolver's import bridge can re-target Go imports
+// of declared modules to their dep contract node instead of an external::
+// stub. Split out of RunDeferredPasses so the batch driver can run it
+// serially across repos ahead of the parallel enrichment phase.
+func (idx *Indexer) runDeferredGoMod() {
+	if idx.pendingContractReg == nil {
+		return
+	}
+	idx.extractGoModContracts(idx.pendingContractReg)
+}
+
+// runDeferredEnrich runs semantic enrichment for this repo. Safe to run
+// concurrently across repos: the manager fetches a per-repo LSP provider
+// instance (keyed by the repo's workspace), the go-types stash is keyed by
+// repo root, tstypes is stateless, and every provider serialises its graph
+// mutations on the backend resolve mutex.
+func (idx *Indexer) runDeferredEnrich() {
+	if idx.semanticMgr == nil || !idx.semanticMgr.Enabled() || !idx.semanticMgr.HasProviders() {
+		return
+	}
+	// Key by the repo prefix so a repo-scoped provider can scope file
+	// selection to this repo (empty in single-repo mode).
+	roots := map[string]string{idx.repoPrefix: idx.rootPath}
+	results, err := idx.semanticMgr.EnrichAll(idx.graph, roots)
+	if err != nil {
+		idx.logger.Warn("semantic enrichment failed", zap.Error(err))
+		return
+	}
+	for _, r := range results {
+		idx.logger.Info("semantic enrichment result",
+			zap.String("provider", r.Provider),
+			zap.String("language", r.Language),
+			zap.Int("confirmed", r.EdgesConfirmed),
+			zap.Int("added", r.EdgesAdded),
+			zap.Int("refuted", r.EdgesRefuted),
+			zap.Float64("coverage", r.CoveragePercent),
+		)
+	}
+}
+
+// runDeferredContracts extracts and commits this repo's contract nodes and
+// clears the pending registration. extractGoModContracts already ran via
+// runDeferredGoMod. Mutates the shared graph and walks repo edges, so the
+// batch driver runs it serially after the parallel enrichment phase. The
+// go-types LookupTypeAtLine it relies on reads the per-repo stash, so it is
+// correct even though every repo's enrichment ran before any contracts.
+func (idx *Indexer) runDeferredContracts() {
+	if idx.pendingContractReg == nil {
+		return
+	}
+	idx.extractExternalModules()
+	idx.extractDIContracts(idx.pendingContractReg)
+	idx.commitContracts(idx.pendingContractReg)
+	idx.pendingContractReg = nil
 }
 
 // RootPath returns the root path used for relative path computation.

--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -401,8 +402,19 @@ func (mi *MultiIndexer) RunDeferredPassesAll(ctx context.Context) {
 	for _, idx := range indexers {
 		idx.SetSkipResolveInDeferred(true)
 	}
+	// Per-repo deferred work in three phases. gomod (materialises dep
+	// contract nodes) and contracts (extract + commit, which walk repo edges)
+	// mutate the shared graph in ways that race across repos, so they stay
+	// serial. Enrichment is the dominant cost — LSP background-indexing and
+	// hover I/O — and is safe to overlap across repos: the manager hands each
+	// repo its own LSP provider instance, go-types stashes per repo, and every
+	// provider serialises its graph mutations on the backend resolve mutex.
 	for _, idx := range indexers {
-		idx.RunDeferredPasses(ctx)
+		idx.runDeferredGoMod()
+	}
+	mi.runDeferredEnrichParallel(indexers)
+	for _, idx := range indexers {
+		idx.runDeferredContracts()
 	}
 	for _, idx := range indexers {
 		idx.SetSkipResolveInDeferred(false)
@@ -424,6 +436,50 @@ func (mi *MultiIndexer) RunDeferredPassesAll(ctx context.Context) {
 		master.ResolveAll()
 		mi.logger.Info("DEFERRED-TIMING master.ResolveAll", zap.Duration("elapsed", time.Since(mt)))
 	}
+}
+
+// runDeferredEnrichParallel runs each indexer's semantic enrichment in a
+// bounded worker pool. Concurrency is capped so at most a few LSP servers
+// background-index at once (the memory-sensitive part). The manager pins each
+// repo's LSP provider in-use for the duration of its pass, so the router's
+// LRU evictor never closes a provider another repo is still enriching against.
+func (mi *MultiIndexer) runDeferredEnrichParallel(indexers []*Indexer) {
+	conc := enrichConcurrency(len(indexers))
+	if conc <= 1 {
+		for _, idx := range indexers {
+			idx.runDeferredEnrich()
+		}
+		return
+	}
+
+	sem := make(chan struct{}, conc)
+	var wg sync.WaitGroup
+	for _, idx := range indexers {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(idx *Indexer) {
+			defer func() { <-sem; wg.Done() }()
+			idx.runDeferredEnrich()
+		}(idx)
+	}
+	wg.Wait()
+}
+
+// enrichConcurrency caps how many repos enrich at once during batch warmup.
+// Half the CPUs, clamped to [1,4] and to the repo count — a few concurrent
+// LSP servers background-index in parallel without a memory blow-up.
+func enrichConcurrency(repos int) int {
+	c := runtime.NumCPU() / 2
+	if c > 4 {
+		c = 4
+	}
+	if c < 1 {
+		c = 1
+	}
+	if c > repos {
+		c = repos
+	}
+	return c
 }
 
 // EndBatch turns off deferred-global-passes mode and runs the graph-

--- a/internal/semantic/config.go
+++ b/internal/semantic/config.go
@@ -10,6 +10,12 @@ type Config struct {
 	WatchDebounceMs   int              `mapstructure:"watch_debounce_ms" yaml:"watch_debounce_ms,omitempty"`
 	RefuteUnconfirmed bool             `mapstructure:"refute_unconfirmed" yaml:"refute_unconfirmed,omitempty"`
 	Providers         []ProviderConfig `mapstructure:"providers" yaml:"providers,omitempty"`
+	// ExcludeGlobs lists path globs to skip for semantic enrichment, in
+	// addition to the built-in generated/vendored heuristic. A file matching
+	// any glob is not enriched and does not count toward a repo's present
+	// languages (so a language server is not spawned for a repo whose only
+	// files of that language are excluded).
+	ExcludeGlobs []string `mapstructure:"exclude_globs" yaml:"exclude_globs,omitempty"`
 }
 
 // ProviderConfig holds configuration for a single semantic provider.

--- a/internal/semantic/enrichfilter.go
+++ b/internal/semantic/enrichfilter.go
@@ -1,0 +1,90 @@
+package semantic
+
+import (
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// vendoredSegments are path segments whose contents are third-party /
+// dependency code that is low value to enrich semantically.
+var vendoredSegments = []string{"/vendor/", "/third_party/", "/node_modules/", "/.git/"}
+
+// generatedSuffixes are filename suffixes for machine-generated sources.
+var generatedSuffixes = []string{".pb.go", ".pb.cc", ".pb.h", ".pb.py", "_pb2.py", "_generated.go", ".gen.go"}
+
+// IsLowValueForEnrichment reports whether a file should be skipped for
+// semantic enrichment because it is machine-generated or vendored. Such
+// files — vendored dependencies, and especially huge generated parsers like
+// tree-sitter's src/parser.c plus the tree_sitter runtime headers — are low
+// value to enrich and dominate language-server background-indexing time
+// (clangd indexing a generated parser.c is by far the slowest part of a
+// fresh index). Detection is a built-in generated/vendored heuristic plus
+// any user-configured exclude globs.
+func IsLowValueForEnrichment(filePath string, userGlobs []string) bool {
+	if filePath == "" {
+		return false
+	}
+	p := filepath.ToSlash(filePath)
+	lower := strings.ToLower(p)
+
+	for _, seg := range vendoredSegments {
+		if strings.Contains(lower, seg) {
+			return true
+		}
+	}
+	// Tree-sitter runtime headers (src/tree_sitter/{alloc,array,parser}.h) and
+	// generated grammar parsers/scanners.
+	if strings.Contains(lower, "/tree_sitter/") || strings.HasPrefix(lower, "tree_sitter/") {
+		return true
+	}
+	switch strings.ToLower(path.Base(p)) {
+	case "parser.c", "parser.h", "scanner.c", "scanner.cc", "grammar.json":
+		return true
+	}
+	for _, suf := range generatedSuffixes {
+		if strings.HasSuffix(lower, suf) {
+			return true
+		}
+	}
+	for _, g := range userGlobs {
+		if matchExcludeGlob(g, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchExcludeGlob matches a user-supplied glob against a slash path.
+// Supports `*` / `?` / `[...]` (within a segment, via path.Match) and `**`
+// (across segments). A pattern with no glob metacharacters matches as a
+// path substring or an exact basename.
+func matchExcludeGlob(pattern, p string) bool {
+	pattern = filepath.ToSlash(pattern)
+	if pattern == "" {
+		return false
+	}
+	if strings.Contains(pattern, "**") {
+		idx := 0
+		for _, part := range strings.Split(pattern, "**") {
+			part = strings.Trim(part, "/")
+			if part == "" {
+				continue
+			}
+			j := strings.Index(p[idx:], part)
+			if j < 0 {
+				return false
+			}
+			idx += j + len(part)
+		}
+		return true
+	}
+	if !strings.ContainsAny(pattern, "*?[") {
+		return strings.Contains(p, pattern) || path.Base(p) == pattern
+	}
+	if ok, _ := path.Match(pattern, p); ok {
+		return true
+	}
+	ok, _ := path.Match(pattern, path.Base(p))
+	return ok
+}

--- a/internal/semantic/enrichfilter_test.go
+++ b/internal/semantic/enrichfilter_test.go
@@ -1,0 +1,41 @@
+package semantic
+
+import "testing"
+
+func TestIsLowValueForEnrichment(t *testing.T) {
+	userGlobs := []string{"**/generated/**", "*.thrift.go", "legacy/*.c"}
+	cases := []struct {
+		path string
+		want bool
+	}{
+		// tree-sitter generated parsers + runtime (the dominant clangd cost)
+		{"tree-sitter-dart/src/parser.c", true},
+		{"tree-sitter-dart/src/scanner.c", true},
+		{"tree-sitter-dart/src/tree_sitter/array.h", true},
+		{"tree-sitter-dart/src/tree_sitter/parser.h", true},
+		{"some/repo/src/parser.h", true},
+		// vendored / dependency dirs
+		{"foo/vendor/bar/x.go", true},
+		{"app/node_modules/lib/index.js", true},
+		{"svc/third_party/proto/x.cc", true},
+		// generated suffixes
+		{"api/types.pb.go", true},
+		{"gen/service_pb2.py", true},
+		{"x_generated.go", true},
+		// user globs
+		{"src/generated/model.go", true},
+		{"rpc/order.thrift.go", true},
+		{"legacy/old.c", true},
+		// real, hand-written sources — must NOT be excluded
+		{"internal/semantic/manager.go", false},
+		{"web/src/app/page.tsx", false},
+		{"src/myparser.c", false}, // not exactly parser.c
+		{"cmd/main.go", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := IsLowValueForEnrichment(c.path, userGlobs); got != c.want {
+			t.Errorf("IsLowValueForEnrichment(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}

--- a/internal/semantic/goanalysis/provider.go
+++ b/internal/semantic/goanalysis/provider.go
@@ -37,10 +37,19 @@ type Provider struct {
 	includeTest bool
 	logger      *zap.Logger
 
-	// Cached state from the last Enrich() — used by LookupTypeAtLine
-	// to answer per-binding type queries from the contract pipeline
-	// without re-loading packages. Guarded by stateMu.
+	// Cached per-repo state from EnrichRepo — used by LookupTypeAtLine to
+	// answer per-binding type queries from the contract pipeline without
+	// re-loading packages. Keyed by the repo's absolute root so that, when
+	// multiple repos are enriched (in any order, possibly concurrently) before
+	// their contracts are extracted, each repo's contract pass still finds its
+	// own loaded packages rather than the last writer's. Guarded by stateMu.
 	stateMu sync.RWMutex
+	stashes map[string]*goStash // absRoot → loaded package state
+}
+
+// goStash is one repo's loaded go/packages state, retained for
+// LookupTypeAtLine after EnrichRepo returns.
+type goStash struct {
 	pkgs    []*packages.Package
 	fset    *token.FileSet
 	absRoot string
@@ -90,14 +99,15 @@ func (p *Provider) EnrichRepo(g graph.Store, repoPrefix, repoRoot string) (*sema
 		return nil, fmt.Errorf("load packages: %w", err)
 	}
 
-	// Stash the loaded state so LookupTypeAtLine can serve per-binding
-	// type queries from the contract pipeline without paying the
-	// 5-10s loadPackages cost again. The state survives until the
-	// next Enrich call (which replaces it).
+	// Stash the loaded state, keyed by this repo's root, so LookupTypeAtLine
+	// can serve per-binding type queries from the contract pipeline without
+	// paying the 5-10s loadPackages cost again — and so a later repo's enrich
+	// does not clobber this repo's state before its contracts are extracted.
 	p.stateMu.Lock()
-	p.pkgs = pkgs
-	p.fset = fset
-	p.absRoot = absRoot
+	if p.stashes == nil {
+		p.stashes = make(map[string]*goStash)
+	}
+	p.stashes[absRoot] = &goStash{pkgs: pkgs, fset: fset, absRoot: absRoot}
 	p.stateMu.Unlock()
 
 	result := &semantic.EnrichResult{
@@ -344,28 +354,35 @@ func (p *Provider) EnrichFile(g graph.Store, repoRoot, filePath string) (*semant
 // resolution at any line in the indexed source.
 func (p *Provider) LookupTypeAtLine(filePath string, line int) (string, bool) {
 	p.stateMu.RLock()
-	pkgs := p.pkgs
-	fset := p.fset
-	absRoot := p.absRoot
+	stashes := make([]*goStash, 0, len(p.stashes))
+	for _, s := range p.stashes {
+		stashes = append(stashes, s)
+	}
 	p.stateMu.RUnlock()
-	if len(pkgs) == 0 || fset == nil || absRoot == "" {
+	if len(stashes) == 0 {
 		return "", false
 	}
+	// Try every repo's stash; the file resolves under exactly one repo root.
 	target := normalizeRelPath(filePath)
-	for _, pkg := range pkgs {
-		if pkg.TypesInfo == nil {
+	for _, st := range stashes {
+		if len(st.pkgs) == 0 || st.fset == nil || st.absRoot == "" {
 			continue
 		}
-		for _, syntax := range pkg.Syntax {
-			if syntax == nil {
+		for _, pkg := range st.pkgs {
+			if pkg.TypesInfo == nil {
 				continue
 			}
-			pos := fset.Position(syntax.Pos())
-			if normalizeRelPath(relativePath(pos.Filename, absRoot)) != target {
-				continue
-			}
-			if t, ok := lookupTypeAtLineInFile(syntax, pkg.TypesInfo, fset, line); ok {
-				return t, true
+			for _, syntax := range pkg.Syntax {
+				if syntax == nil {
+					continue
+				}
+				pos := st.fset.Position(syntax.Pos())
+				if normalizeRelPath(relativePath(pos.Filename, st.absRoot)) != target {
+					continue
+				}
+				if t, ok := lookupTypeAtLineInFile(syntax, pkg.TypesInfo, st.fset, line); ok {
+					return t, true
+				}
 			}
 		}
 	}

--- a/internal/semantic/goanalysis/provider.go
+++ b/internal/semantic/goanalysis/provider.go
@@ -105,6 +105,15 @@ func (p *Provider) EnrichRepo(g graph.Store, repoPrefix, repoRoot string) (*sema
 		Language: "go",
 	}
 
+	// Serialise the graph-touching work below on the backend resolve mutex —
+	// the same lock every other edge-mutating pass holds — so this pass can run
+	// concurrently with other repos' enrichment. loadPackages (the expensive
+	// go/packages load) already ran above, outside the lock, so it still
+	// overlaps across repos; only the in-memory graph build is serialised.
+	rmu := g.ResolveMutex()
+	rmu.Lock()
+	defer rmu.Unlock()
+
 	// Build symbol map: go/types objects → Gortex node IDs.
 	symMap := semantic.NewSymbolMap()
 	objToNode := make(map[types.Object]string) // types.Object → Gortex node ID

--- a/internal/semantic/goanalysis/provider.go
+++ b/internal/semantic/goanalysis/provider.go
@@ -255,7 +255,7 @@ func (p *Provider) EnrichRepo(g graph.Store, repoPrefix, repoRoot string) (*sema
 	result.NodesEnriched += externals.nodesAdded
 
 	// Phase 3: Interface implementations via go/types.
-	result.EdgesConfirmed += p.enrichImplements(g, repoPrefix, pkgs, objToNode)
+	result.EdgesConfirmed += p.enrichImplements(g, pkgs, objToNode)
 	result.EdgesAdded += p.addMissingImplements(g, pkgs, objToNode, absRoot)
 
 	// Phase 4: Enrich node metadata with type info.
@@ -576,19 +576,8 @@ func repoGoNodes(g graph.Store, repoPrefix string) []*graph.Node {
 	return out
 }
 
-// repoGoEdges returns the edges whose source node belongs to repoPrefix via
-// the indexed GetRepoEdges scan, falling back to AllEdges only for the
-// embedded single-repo ("") path where GetRepoEdges returns nothing.
-func repoGoEdges(g graph.Store, repoPrefix string) []*graph.Edge {
-	edges := g.GetRepoEdges(repoPrefix)
-	if len(edges) == 0 && repoPrefix == "" {
-		return g.AllEdges()
-	}
-	return edges
-}
-
 // enrichImplements confirms existing EdgeImplements edges using go/types.
-func (p *Provider) enrichImplements(g graph.Store, repoPrefix string, pkgs []*packages.Package, objToNode map[types.Object]string) int {
+func (p *Provider) enrichImplements(g graph.Store, pkgs []*packages.Package, objToNode map[types.Object]string) int {
 	confirmed := 0
 
 	// Collect all interfaces from the loaded packages.
@@ -601,12 +590,12 @@ func (p *Provider) enrichImplements(g graph.Store, repoPrefix string, pkgs []*pa
 		}
 	}
 
-	// Check existing EdgeImplements edges (scoped to this repo's edges; the
-	// implementing type must live in this repo's loaded packages to confirm).
-	for _, e := range repoGoEdges(g, repoPrefix) {
-		if e.Kind != graph.EdgeImplements {
-			continue
-		}
+	// Check existing EdgeImplements edges. Iterate the kind-indexed edge set
+	// (not a whole-graph AllEdges scan, but still graph-wide for this kind) so
+	// a cross-repo implements edge — concrete type in another repo, interface
+	// in this repo's loaded packages — is still confirmed, matching the
+	// original behavior.
+	for e := range g.EdgesByKind(graph.EdgeImplements) {
 		fromNode := g.GetNode(e.From)
 		if fromNode == nil || fromNode.Language != "go" {
 			continue

--- a/internal/semantic/goanalysis/provider.go
+++ b/internal/semantic/goanalysis/provider.go
@@ -66,6 +66,17 @@ func (p *Provider) Available() bool {
 }
 
 func (p *Provider) Enrich(g graph.Store, repoRoot string) (*semantic.EnrichResult, error) {
+	return p.EnrichRepo(g, "", repoRoot)
+}
+
+// EnrichRepo runs the go/types enrichment pass with its graph scans scoped
+// to repoPrefix (the multi-repo scope key; "" for a single-repo / in-memory
+// graph). The go/packages load is already scoped to repoRoot; scoping the
+// graph-side symbol count and implements-edge scan to one repo stops a
+// multi-repo warmup from paying a whole-graph AllNodes / AllEdges walk per
+// repo. Implementing this makes the provider a semantic.RepoScopedProvider,
+// so the manager dispatches it per repo with the repo's prefix.
+func (p *Provider) EnrichRepo(g graph.Store, repoPrefix, repoRoot string) (*semantic.EnrichResult, error) {
 	start := time.Now()
 
 	absRoot, err := filepath.Abs(repoRoot)
@@ -128,9 +139,12 @@ func (p *Provider) Enrich(g graph.Store, repoRoot string) (*semantic.EnrichResul
 		}
 	}
 
-	// Count total Go symbols.
-	for _, n := range g.AllNodes() {
-		if n.Language == "go" && n.Kind != graph.KindFile && n.Kind != graph.KindImport {
+	// Count total Go symbols in this repo via the indexed repo-scoped scan
+	// rather than a whole-graph AllNodes walk (which, in a multi-repo graph,
+	// also wrongly counted every other repo's Go nodes against this repo's
+	// coverage).
+	for _, n := range repoGoNodes(g, repoPrefix) {
+		if n.Kind != graph.KindFile && n.Kind != graph.KindImport {
 			result.SymbolsTotal++
 		}
 	}
@@ -241,7 +255,7 @@ func (p *Provider) Enrich(g graph.Store, repoRoot string) (*semantic.EnrichResul
 	result.NodesEnriched += externals.nodesAdded
 
 	// Phase 3: Interface implementations via go/types.
-	result.EdgesConfirmed += p.enrichImplements(g, pkgs, objToNode)
+	result.EdgesConfirmed += p.enrichImplements(g, repoPrefix, pkgs, objToNode)
 	result.EdgesAdded += p.addMissingImplements(g, pkgs, objToNode, absRoot)
 
 	// Phase 4: Enrich node metadata with type info.
@@ -542,8 +556,39 @@ func (p *Provider) loadPackages(dir string) ([]*packages.Package, *token.FileSet
 	return valid, cfg.Fset, nil
 }
 
+// repoGoNodes returns the repo's Go-language nodes via the indexed
+// GetRepoNodes scan, falling back to a language-filtered AllNodes pass for
+// the embedded single-repo ("") path where GetRepoNodes can come back empty.
+func repoGoNodes(g graph.Store, repoPrefix string) []*graph.Node {
+	filter := func(nodes []*graph.Node) []*graph.Node {
+		out := make([]*graph.Node, 0, len(nodes))
+		for _, n := range nodes {
+			if n.Language == "go" && n.RepoPrefix == repoPrefix {
+				out = append(out, n)
+			}
+		}
+		return out
+	}
+	out := filter(g.GetRepoNodes(repoPrefix))
+	if len(out) == 0 && repoPrefix == "" {
+		return filter(g.AllNodes())
+	}
+	return out
+}
+
+// repoGoEdges returns the edges whose source node belongs to repoPrefix via
+// the indexed GetRepoEdges scan, falling back to AllEdges only for the
+// embedded single-repo ("") path where GetRepoEdges returns nothing.
+func repoGoEdges(g graph.Store, repoPrefix string) []*graph.Edge {
+	edges := g.GetRepoEdges(repoPrefix)
+	if len(edges) == 0 && repoPrefix == "" {
+		return g.AllEdges()
+	}
+	return edges
+}
+
 // enrichImplements confirms existing EdgeImplements edges using go/types.
-func (p *Provider) enrichImplements(g graph.Store, pkgs []*packages.Package, objToNode map[types.Object]string) int {
+func (p *Provider) enrichImplements(g graph.Store, repoPrefix string, pkgs []*packages.Package, objToNode map[types.Object]string) int {
 	confirmed := 0
 
 	// Collect all interfaces from the loaded packages.
@@ -556,8 +601,9 @@ func (p *Provider) enrichImplements(g graph.Store, pkgs []*packages.Package, obj
 		}
 	}
 
-	// Check existing EdgeImplements edges.
-	for _, e := range g.AllEdges() {
+	// Check existing EdgeImplements edges (scoped to this repo's edges; the
+	// implementing type must live in this repo's loaded packages to confirm).
+	for _, e := range repoGoEdges(g, repoPrefix) {
 		if e.Kind != graph.EdgeImplements {
 			continue
 		}

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -260,44 +260,35 @@ func (p *Provider) EnrichRepo(g graph.Store, repoPrefix, repoRoot string) (*sema
 		Language: p.languages[0],
 	}
 
-	// Gather this repo's symbols of the provider's language via the indexed
-	// repo-scoped scan, NOT a whole-graph AllNodes / AllEdges walk: on a disk
-	// backend the latter is O(graph) per provider per repo (a whole-graph
-	// AllEdges plus a point GetNode per edge), which dominated fresh-index
-	// warmup. langNodes drives the spawn gate, the symbol count, the per-file
-	// fan-out, and the interface-implementation pass below.
-	langNodes := p.repoLangNodes(g, repoPrefix)
-
-	// Lazy server spawn: the hover / implements / call- and type-hierarchy
-	// passes all operate on this language's symbols, so what makes the pass
-	// worth a server spin-up is at least one in-repo node of the provider's
-	// language. When the repo has none (a Swift or TS server scoped to a Go
-	// repo, or a language whose nodes all live in a different repo) return
-	// without starting the server. This is what stops a per-language LSP
-	// spin-up — process launch, initialize handshake, and a whole-repo
-	// sweep — for zero enrichment.
-	if len(langNodes) == 0 {
-		if p.logger != nil {
-			p.logger.Debug("LSP enrich: skipped, repo has no nodes for language",
-				zap.String("provider", p.Name()),
-				zap.String("repo_prefix", repoPrefix),
-			)
+	// Gather this repo's nodes via the indexed repo-scoped scan, NOT a
+	// whole-graph AllNodes / AllEdges walk: on a disk backend the latter is
+	// O(graph) per provider per repo (a whole-graph AllEdges plus a point
+	// GetNode per edge), which dominated fresh-index warmup. Split into two
+	// views from one scan:
+	//   - langNodes: SYMBOL nodes (file/import excluded) — drives the symbol
+	//     count, the per-file fan-out, and the interface-implementation pass.
+	//   - langAllByID: every repo+language node id INCLUDING file/import — the
+	//     original ambiguous-edge target scan matched any repo+language source
+	//     node (file/import edges like EdgeImports included), so the
+	//     references-confirm pass must keep matching those too.
+	repoNodes := p.repoScopedNodes(g, repoPrefix)
+	langAllByID := make(map[string]*graph.Node, len(repoNodes))
+	langNodes := make([]*graph.Node, 0, len(repoNodes))
+	for _, n := range repoNodes {
+		if n.RepoPrefix != repoPrefix || !p.languageMatches(n.Language) {
+			continue
 		}
-		result.DurationMs = time.Since(start).Milliseconds()
-		return result, nil
-	}
-
-	// Index repo+language nodes by ID so the ambiguous-edge scan can filter
-	// the repo-scoped edge set without a per-edge GetNode round-trip.
-	langByID := make(map[string]*graph.Node, len(langNodes))
-	for _, n := range langNodes {
-		langByID[n.ID] = n
+		langAllByID[n.ID] = n
+		if n.Kind == graph.KindFile || n.Kind == graph.KindImport {
+			continue
+		}
+		langNodes = append(langNodes, n)
 	}
 
 	// Collect AMBIGUOUS edges (confidence < 1.0) whose source is one of this
 	// repo's language nodes — the references pass below confirms / refutes
-	// them. The indexed GetRepoEdges scan + the langByID set replaces the
-	// AllEdges walk with a per-edge GetNode.
+	// them. The indexed GetRepoEdges scan + the id-set replaces the AllEdges
+	// walk with a per-edge GetNode.
 	type enrichTarget struct {
 		node *graph.Node
 		edge *graph.Edge
@@ -307,9 +298,26 @@ func (p *Provider) EnrichRepo(g graph.Store, repoPrefix, repoRoot string) (*sema
 		if e.Confidence >= 1.0 {
 			continue
 		}
-		if from, ok := langByID[e.From]; ok {
+		if from, ok := langAllByID[e.From]; ok {
 			targets = append(targets, enrichTarget{node: from, edge: e})
 		}
+	}
+
+	// Lazy server spawn: spin up only when there is something to do — at least
+	// one symbol node of the language, OR an ambiguous edge to confirm (the
+	// same condition the original whole-graph gate applied). When the repo has
+	// neither (a Swift / TS server scoped to a Go repo, or a language whose
+	// nodes all live in another repo) return without starting the server — this
+	// stops a per-language LSP spin-up for zero enrichment.
+	if len(langNodes) == 0 && len(targets) == 0 {
+		if p.logger != nil {
+			p.logger.Debug("LSP enrich: skipped, repo has no nodes for language",
+				zap.String("provider", p.Name()),
+				zap.String("repo_prefix", repoPrefix),
+			)
+		}
+		result.DurationMs = time.Since(start).Milliseconds()
+		return result, nil
 	}
 
 	// Start or reuse the client now that there is work to do.
@@ -1797,34 +1805,17 @@ func (p *Provider) languageMatches(lang string) bool {
 	return false
 }
 
-// repoLangNodes returns the repo's symbol nodes (excluding file / import
-// nodes) whose language this provider serves, using the indexed
-// GetRepoNodes scan rather than a whole-graph AllNodes walk — the latter
-// is O(graph) per provider per repo on a disk backend. For the embedded
-// single-repo path (repoPrefix == "") where GetRepoNodes can return empty
-// on some backends, it falls back to a language-filtered AllNodes pass so
-// the standalone server still enriches.
-func (p *Provider) repoLangNodes(g graph.Store, repoPrefix string) []*graph.Node {
-	filter := func(nodes []*graph.Node) []*graph.Node {
-		out := make([]*graph.Node, 0, len(nodes))
-		for _, n := range nodes {
-			if n.Kind == graph.KindFile || n.Kind == graph.KindImport {
-				continue
-			}
-			if n.RepoPrefix != repoPrefix {
-				continue
-			}
-			if p.languageMatches(n.Language) {
-				out = append(out, n)
-			}
-		}
-		return out
+// repoScopedNodes returns the repo's nodes via the indexed GetRepoNodes scan
+// rather than a whole-graph AllNodes walk — the latter is O(graph) per
+// provider per repo on a disk backend. For the embedded single-repo path
+// (repoPrefix == "") where GetRepoNodes can return empty on some backends,
+// it falls back to AllNodes so the standalone server still enriches.
+func (p *Provider) repoScopedNodes(g graph.Store, repoPrefix string) []*graph.Node {
+	nodes := g.GetRepoNodes(repoPrefix)
+	if len(nodes) == 0 && repoPrefix == "" {
+		return g.AllNodes()
 	}
-	out := filter(g.GetRepoNodes(repoPrefix))
-	if len(out) == 0 && repoPrefix == "" {
-		return filter(g.AllNodes())
-	}
-	return out
+	return nodes
 }
 
 // repoScopedEdges returns the edges whose source node belongs to

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -696,8 +696,17 @@ func (p *Provider) EnrichRepo(g graph.Store, repoPrefix, repoRoot string) (*sema
 		return result, fmt.Errorf("LSP enrichment aborted: %w", abortErr)
 	}
 
+	// The graph-mutation blocks below serialise on the backend resolve mutex
+	// (the same lock every other edge-mutating pass holds) so this pass can run
+	// concurrently with other repos' enrichment. Only the in-memory mutations
+	// are locked — the per-item findImplementations / findReferences LSP I/O
+	// stays outside the lock so concurrent language servers still overlap.
+	rmu := g.ResolveMutex()
+
 	if len(stampedNodes) > 0 {
+		rmu.Lock()
 		g.AddBatch(stampedNodes, nil)
+		rmu.Unlock()
 	}
 
 	// Query implementations for interface nodes.
@@ -719,6 +728,7 @@ func (p *Provider) EnrichRepo(g graph.Store, repoPrefix, repoRoot string) (*sema
 			continue
 		}
 
+		rmu.Lock()
 		for _, loc := range impls {
 			implPath := uriToPath(loc.URI, absRoot)
 			if implPath == "" {
@@ -741,6 +751,7 @@ func (p *Provider) EnrichRepo(g graph.Store, repoPrefix, repoRoot string) (*sema
 				result.EdgesAdded++
 			}
 		}
+		rmu.Unlock()
 	}
 
 	// Apply the call- and type-hierarchy hops collected while each file was
@@ -748,12 +759,14 @@ func (p *Provider) EnrichRepo(g graph.Store, repoPrefix, repoRoot string) (*sema
 	// the graph — promoting AST-missed call edges to lsp_resolved, or adding
 	// the cross-file call / extends / implements edges the AST extractor
 	// could not follow (the single biggest non-Go win).
+	rmu.Lock()
 	for _, h := range callHops {
 		p.recordHierarchyCall(g, repoPrefix, absRoot, h.n, h.other, h.asOutgoing, result)
 	}
 	for _, h := range typeHops {
 		p.linkTypeHierarchy(g, repoPrefix, absRoot, h.n, h.other, h.asSupertype, result)
 	}
+	rmu.Unlock()
 
 	// Query references for AMBIGUOUS edges to confirm/refute.
 	for _, t := range targets {
@@ -791,7 +804,9 @@ func (p *Provider) EnrichRepo(g graph.Store, repoPrefix, repoRoot string) (*sema
 		}
 
 		if confirmed {
+			rmu.Lock()
 			semantic.ConfirmEdge(t.edge, p.Name())
+			rmu.Unlock()
 			result.EdgesConfirmed++
 		}
 	}

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -260,53 +260,23 @@ func (p *Provider) EnrichRepo(g graph.Store, repoPrefix, repoRoot string) (*sema
 		Language: p.languages[0],
 	}
 
-	// Collect nodes that need enrichment (AMBIGUOUS or INFERRED edges),
-	// scoped to this repo + language. Done BEFORE the server starts so an
-	// empty target set skips the spawn entirely.
-	type enrichTarget struct {
-		node *graph.Node
-		edge *graph.Edge
-	}
-	var targets []enrichTarget
-	for _, e := range g.AllEdges() {
-		if e.Confidence >= 1.0 {
-			continue
-		}
-		fromNode := g.GetNode(e.From)
-		if fromNode == nil || fromNode.RepoPrefix != repoPrefix {
-			continue
-		}
-		if p.languageMatches(fromNode.Language) {
-			targets = append(targets, enrichTarget{node: fromNode, edge: e})
-		}
-	}
+	// Gather this repo's symbols of the provider's language via the indexed
+	// repo-scoped scan, NOT a whole-graph AllNodes / AllEdges walk: on a disk
+	// backend the latter is O(graph) per provider per repo (a whole-graph
+	// AllEdges plus a point GetNode per edge), which dominated fresh-index
+	// warmup. langNodes drives the spawn gate, the symbol count, the per-file
+	// fan-out, and the interface-implementation pass below.
+	langNodes := p.repoLangNodes(g, repoPrefix)
 
 	// Lazy server spawn: the hover / implements / call- and type-hierarchy
 	// passes all operate on this language's symbols, so what makes the pass
 	// worth a server spin-up is at least one in-repo node of the provider's
-	// language — an ambiguous edge to confirm, or any function / type /
-	// interface to interrogate. When the repo has none (a Swift or TS
-	// server scoped to a Go repo, or a language whose nodes all live in a
-	// different repo) return without starting the server. This is what
-	// stops a warm restart from paying a full per-language LSP spin-up —
-	// process launch, initialize handshake, and a whole-repo sweep — for
-	// zero enrichment.
-	hasWork := len(targets) > 0
-	if !hasWork {
-		for _, n := range g.AllNodes() {
-			if n.RepoPrefix != repoPrefix {
-				continue
-			}
-			if n.Kind == graph.KindFile || n.Kind == graph.KindImport {
-				continue
-			}
-			if p.languageMatches(n.Language) {
-				hasWork = true
-				break
-			}
-		}
-	}
-	if !hasWork {
+	// language. When the repo has none (a Swift or TS server scoped to a Go
+	// repo, or a language whose nodes all live in a different repo) return
+	// without starting the server. This is what stops a per-language LSP
+	// spin-up — process launch, initialize handshake, and a whole-repo
+	// sweep — for zero enrichment.
+	if len(langNodes) == 0 {
 		if p.logger != nil {
 			p.logger.Debug("LSP enrich: skipped, repo has no nodes for language",
 				zap.String("provider", p.Name()),
@@ -315,6 +285,31 @@ func (p *Provider) EnrichRepo(g graph.Store, repoPrefix, repoRoot string) (*sema
 		}
 		result.DurationMs = time.Since(start).Milliseconds()
 		return result, nil
+	}
+
+	// Index repo+language nodes by ID so the ambiguous-edge scan can filter
+	// the repo-scoped edge set without a per-edge GetNode round-trip.
+	langByID := make(map[string]*graph.Node, len(langNodes))
+	for _, n := range langNodes {
+		langByID[n.ID] = n
+	}
+
+	// Collect AMBIGUOUS edges (confidence < 1.0) whose source is one of this
+	// repo's language nodes — the references pass below confirms / refutes
+	// them. The indexed GetRepoEdges scan + the langByID set replaces the
+	// AllEdges walk with a per-edge GetNode.
+	type enrichTarget struct {
+		node *graph.Node
+		edge *graph.Edge
+	}
+	var targets []enrichTarget
+	for _, e := range p.repoScopedEdges(g, repoPrefix) {
+		if e.Confidence >= 1.0 {
+			continue
+		}
+		if from, ok := langByID[e.From]; ok {
+			targets = append(targets, enrichTarget{node: from, edge: e})
+		}
 	}
 
 	// Start or reuse the client now that there is work to do.
@@ -330,18 +325,9 @@ func (p *Provider) EnrichRepo(g graph.Store, repoPrefix, repoRoot string) (*sema
 	// only this Enrich invocation.
 	p.reconnectAttempts.Store(0)
 
-	// Count total symbols (scoped to repo + language).
-	for _, n := range g.AllNodes() {
-		if n.Kind == graph.KindFile || n.Kind == graph.KindImport {
-			continue
-		}
-		if n.RepoPrefix != repoPrefix {
-			continue
-		}
-		if p.languageMatches(n.Language) {
-			result.SymbolsTotal++
-		}
-	}
+	// Total symbols scoped to repo + language — langNodes already excludes
+	// file / import nodes and is filtered to this provider's languages.
+	result.SymbolsTotal = len(langNodes)
 
 	// Per-file document lifecycle + bounded concurrency. The original
 	// implementation bulk-opened every target file up front and closed
@@ -422,13 +408,7 @@ func (p *Provider) EnrichRepo(g graph.Store, repoPrefix, repoRoot string) (*sema
 	}
 	var fileList []*fileTargets
 	fileIndex := map[string]*fileTargets{}
-	for _, n := range g.AllNodes() {
-		if n.Kind == graph.KindFile || n.Kind == graph.KindImport {
-			continue
-		}
-		if n.RepoPrefix != repoPrefix || !p.languageMatches(n.Language) {
-			continue
-		}
+	for _, n := range langNodes {
 		ft := fileIndex[n.FilePath]
 		if ft == nil {
 			ft = &fileTargets{rel: nodeRelPath(n)}
@@ -713,11 +693,8 @@ func (p *Provider) EnrichRepo(g graph.Store, repoPrefix, repoRoot string) (*sema
 	}
 
 	// Query implementations for interface nodes.
-	for _, n := range g.AllNodes() {
+	for _, n := range langNodes {
 		if n.Kind != graph.KindInterface {
-			continue
-		}
-		if n.RepoPrefix != repoPrefix || !p.languageMatches(n.Language) {
 			continue
 		}
 
@@ -1818,6 +1795,48 @@ func (p *Provider) languageMatches(lang string) bool {
 		}
 	}
 	return false
+}
+
+// repoLangNodes returns the repo's symbol nodes (excluding file / import
+// nodes) whose language this provider serves, using the indexed
+// GetRepoNodes scan rather than a whole-graph AllNodes walk — the latter
+// is O(graph) per provider per repo on a disk backend. For the embedded
+// single-repo path (repoPrefix == "") where GetRepoNodes can return empty
+// on some backends, it falls back to a language-filtered AllNodes pass so
+// the standalone server still enriches.
+func (p *Provider) repoLangNodes(g graph.Store, repoPrefix string) []*graph.Node {
+	filter := func(nodes []*graph.Node) []*graph.Node {
+		out := make([]*graph.Node, 0, len(nodes))
+		for _, n := range nodes {
+			if n.Kind == graph.KindFile || n.Kind == graph.KindImport {
+				continue
+			}
+			if n.RepoPrefix != repoPrefix {
+				continue
+			}
+			if p.languageMatches(n.Language) {
+				out = append(out, n)
+			}
+		}
+		return out
+	}
+	out := filter(g.GetRepoNodes(repoPrefix))
+	if len(out) == 0 && repoPrefix == "" {
+		return filter(g.AllNodes())
+	}
+	return out
+}
+
+// repoScopedEdges returns the edges whose source node belongs to
+// repoPrefix via the indexed GetRepoEdges scan, falling back to AllEdges
+// only for the embedded single-repo ("") path where GetRepoEdges returns
+// nothing by contract.
+func (p *Provider) repoScopedEdges(g graph.Store, repoPrefix string) []*graph.Edge {
+	edges := g.GetRepoEdges(repoPrefix)
+	if len(edges) == 0 && repoPrefix == "" {
+		return g.AllEdges()
+	}
+	return edges
 }
 
 // prepareCallHierarchy queries textDocument/prepareCallHierarchy and

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -32,6 +32,10 @@ type Provider struct {
 	daemon           bool
 	maxParallel      int
 	logger           *zap.Logger
+	// excludeGlobs are user-configured path globs to skip for enrichment, on
+	// top of the built-in generated/vendored heuristic. Set by the router from
+	// config when the provider is spawned.
+	excludeGlobs []string
 	// spec is the ServerSpec this provider was built from (when the
 	// caller used NewProviderFromSpec). nil for legacy NewProvider
 	// invocations — those fall back to single-language routing.
@@ -276,6 +280,12 @@ func (p *Provider) EnrichRepo(g graph.Store, repoPrefix, repoRoot string) (*sema
 	langNodes := make([]*graph.Node, 0, len(repoNodes))
 	for _, n := range repoNodes {
 		if n.RepoPrefix != repoPrefix || !p.languageMatches(n.Language) {
+			continue
+		}
+		// Skip machine-generated / vendored files (e.g. tree-sitter's generated
+		// parser.c) so the language server never opens or indexes them — that
+		// indexing is by far the slowest part of a fresh index for zero value.
+		if semantic.IsLowValueForEnrichment(n.FilePath, p.excludeGlobs) {
 			continue
 		}
 		langAllByID[n.ID] = n

--- a/internal/semantic/lsp/registry.go
+++ b/internal/semantic/lsp/registry.go
@@ -73,6 +73,12 @@ type ServerSpec struct {
 	// already running, rather than spawning a duplicate 200-500 MB
 	// subprocess per language.
 	Connect *ConnectSpec
+	// UseWorkspaceBundleGemfile, when true, makes the router set
+	// BUNDLE_GEMFILE to the spawned workspace's own Gemfile (when one
+	// exists) in the server's environment. ruby-lsp runs a `bundle install`
+	// for a "composed bundle" on spawn unless BUNDLE_GEMFILE is already set;
+	// pointing it at the project Gemfile skips that install for enrichment.
+	UseWorkspaceBundleGemfile bool
 }
 
 // ConnectSpec carries the transport coordinates for passive LSP attach
@@ -396,9 +402,10 @@ var Servers = []ServerSpec{
 			".rb":   "ruby",
 			".rake": "ruby",
 		},
-		Priority:    5,
-		Daemon:      true,
-		MaxParallel: 6,
+		Priority:                  5,
+		Daemon:                    true,
+		MaxParallel:               6,
+		UseWorkspaceBundleGemfile: true,
 		AlternativeCommands: []ServerAlt{
 			{Command: "solargraph", Args: []string{"stdio"}},
 		},

--- a/internal/semantic/lsp/router.go
+++ b/internal/semantic/lsp/router.go
@@ -2,6 +2,7 @@ package lsp
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
@@ -13,6 +14,12 @@ import (
 
 	"github.com/zzet/gortex/internal/semantic"
 )
+
+// fileExists reports whether path names an existing regular file.
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
 
 // Router is a daemon-managed pool of LSP providers keyed by ServerSpec.
 // It routes requests to the right provider by file extension, spawns
@@ -417,6 +424,14 @@ func (r *Router) forSpecWorkspace(spec *ServerSpec, workspace string, pin bool) 
 	p := NewProviderFromSpec(spec, r.logger)
 	p.workspaceFolders = r.additionalWorkspaceFolders
 	p.excludeGlobs = r.enrichExcludeGlobs
+	// ruby-lsp (and any spec opting in) runs a `bundle install` for a composed
+	// bundle on spawn unless BUNDLE_GEMFILE is set; point it at the workspace's
+	// own Gemfile when present so enrichment skips that install.
+	if spec.UseWorkspaceBundleGemfile {
+		if gemfile := filepath.Join(workspace, "Gemfile"); fileExists(gemfile) {
+			p.env = append(append([]string(nil), p.env...), "BUNDLE_GEMFILE="+gemfile)
+		}
+	}
 	if err := p.EnsureClient(workspace); err != nil {
 		// A binary that resolves on PATH but cannot launch (e.g. a rustup
 		// `rust-analyzer` shim whose toolchain lacks the component) would

--- a/internal/semantic/lsp/router.go
+++ b/internal/semantic/lsp/router.go
@@ -346,6 +346,11 @@ func (r *Router) ForSpecWorkspace(spec *ServerSpec, workspace string) (*Provider
 	p := NewProviderFromSpec(spec, r.logger)
 	p.workspaceFolders = r.additionalWorkspaceFolders
 	if err := p.EnsureClient(workspace); err != nil {
+		// A binary that resolves on PATH but cannot launch (e.g. a rustup
+		// `rust-analyzer` shim whose toolchain lacks the component) would
+		// otherwise be re-attempted on every repo. Mark it unavailable so the
+		// router stops retrying it for this session.
+		r.markSpawnFailed(spec.Name, err)
 		return nil, fmt.Errorf("spawn %s: %w", spec.Name, err)
 	}
 	// Attach the diagnostics hook (if any) before publishing to the
@@ -508,6 +513,27 @@ func (r *Router) specAvailable(spec *ServerSpec) bool {
 	r.avail[spec.Name] = avail
 	r.availMu.Unlock()
 	return avail
+}
+
+// markSpawnFailed records that a spec's server process failed to start, so
+// the availability cache reports it unavailable and the router stops
+// retrying it for the life of the daemon (until restart). Enrichment is
+// best-effort: a binary that resolves on PATH but cannot launch should be
+// dropped once with a clear warning rather than re-attempted on every repo.
+// The warning is emitted only on the transition to unavailable so a single
+// failure is reported once, not once per repo.
+func (r *Router) markSpawnFailed(specName string, err error) {
+	r.availMu.Lock()
+	prev, known := r.avail[specName]
+	r.avail[specName] = false
+	r.availMu.Unlock()
+	if known && !prev {
+		return // already marked unavailable — don't re-log
+	}
+	r.logger.Warn("LSP server failed to start; skipping its language enrichment this session",
+		zap.String("spec", specName),
+		zap.Error(err),
+	)
 }
 
 // LanguageIDForPath proxies to the package-level helper for callers

--- a/internal/semantic/lsp/router.go
+++ b/internal/semantic/lsp/router.go
@@ -77,6 +77,11 @@ type routedProvider struct {
 	workspace string
 	provider  *Provider
 	lastUsed  time.Time
+	// inUse counts callers currently holding this provider for a long
+	// operation (an enrichment pass). The LRU evictor skips any provider
+	// with inUse > 0 so a slow in-flight pass is never Close()d mid-use by
+	// another repo's concurrent spawn. Guarded by r.mu.
+	inUse int
 }
 
 // providerKey identifies a (spec, workspace) pair in the cache. Each
@@ -208,6 +213,24 @@ func (r *Router) ProviderForSpec(name string) (semantic.Provider, error) {
 	return r.ForSpec(spec)
 }
 
+// ProviderForSpecWorkspace returns the lazy-spawned LSP provider for the
+// named spec scoped to a specific workspace root, so each repo gets its own
+// provider instance keyed by (spec, workspace) instead of sharing the
+// default-workspace one. Used by per-repo enrichment so concurrent passes
+// across repos do not share a single Provider's connection / document caches.
+func (r *Router) ProviderForSpecWorkspace(name, workspace string) (semantic.Provider, error) {
+	r.mu.Lock()
+	spec, ok := r.enabled[name]
+	r.mu.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("LSP spec %q not registered", name)
+	}
+	// forSpecWorkspace with pin=true increments inUse inside the same locked
+	// section it publishes/looks up the provider, closing the spawn→pin race.
+	// The caller MUST pair this with ReleaseSpecWorkspace.
+	return r.forSpecWorkspace(spec, workspace, true)
+}
+
 // SpecAvailable reports whether the named spec is registered AND its
 // command resolves on PATH. Pure read — no subprocess spawn. Caches
 // the PATH-lookup result like specAvailable does for ForSpec.
@@ -290,6 +313,30 @@ func (r *Router) WithMaxAlive(n int) *Router {
 	return r
 }
 
+// workspaceKey resolves a workspace string to the cache key form
+// ForSpecWorkspace uses (default-substituted, absolutised).
+func (r *Router) workspaceKey(specName, workspace string) providerKey {
+	if workspace == "" {
+		workspace = r.defaultWorkspace
+	}
+	if abs, err := filepath.Abs(workspace); err == nil {
+		workspace = abs
+	}
+	return providerKey{specName: specName, workspace: workspace}
+}
+
+// ReleaseSpecWorkspace marks a provider previously obtained via
+// ProviderForSpecWorkspace as no longer in active use, so the LRU evictor /
+// reaper may reclaim it again. Pairs one-to-one with ProviderForSpecWorkspace.
+func (r *Router) ReleaseSpecWorkspace(name, workspace string) {
+	key := r.workspaceKey(name, workspace)
+	r.mu.Lock()
+	if rp := r.providers[key]; rp != nil && rp.inUse > 0 {
+		rp.inUse--
+	}
+	r.mu.Unlock()
+}
+
 // For returns the provider responsible for the given file path under
 // the router's defaultWorkspace. Convenience wrapper for single-
 // workspace callers; multi-repo daemons should use ForWorkspace and
@@ -322,6 +369,15 @@ func (r *Router) ForSpec(spec *ServerSpec) (*Provider, error) {
 // given workspace root, spawning it on first call. The (spec,
 // workspace) tuple uniquely identifies the cached Provider.
 func (r *Router) ForSpecWorkspace(spec *ServerSpec, workspace string) (*Provider, error) {
+	return r.forSpecWorkspace(spec, workspace, false)
+}
+
+// forSpecWorkspace is ForSpecWorkspace with an optional in-use pin. When pin
+// is true the returned provider's inUse count is incremented in the SAME
+// locked section that looks it up or publishes it — so a concurrent spawn's
+// LRU eviction can never Close a freshly-returned-but-not-yet-pinned provider
+// (the spawn→pin TOCTOU). A pinned fetch MUST be paired with ReleaseSpecWorkspace.
+func (r *Router) forSpecWorkspace(spec *ServerSpec, workspace string, pin bool) (*Provider, error) {
 	if !r.specAvailable(spec) {
 		return nil, fmt.Errorf("LSP server %q not available on PATH", spec.Name)
 	}
@@ -337,6 +393,9 @@ func (r *Router) ForSpecWorkspace(spec *ServerSpec, workspace string) (*Provider
 	rp, ok := r.providers[key]
 	if ok {
 		rp.lastUsed = time.Now()
+		if pin {
+			rp.inUse++
+		}
 		r.mu.Unlock()
 		return rp.provider, nil
 	}
@@ -364,15 +423,24 @@ func (r *Router) ForSpecWorkspace(spec *ServerSpec, workspace string) (*Provider
 	// initializing. Prefer the existing one and shut down our duplicate.
 	if existing, ok := r.providers[key]; ok {
 		existing.lastUsed = time.Now()
+		if pin {
+			existing.inUse++
+		}
 		go func() { _ = p.Close() }()
 		return existing.provider, nil
 	}
-	r.providers[key] = &routedProvider{
+	newRP := &routedProvider{
 		spec:      spec,
 		workspace: workspace,
 		provider:  p,
 		lastUsed:  time.Now(),
 	}
+	// Pin BEFORE maybeEvictLRULocked runs so the just-published provider is
+	// never the eviction victim, and is protected the instant it is reachable.
+	if pin {
+		newRP.inUse = 1
+	}
+	r.providers[key] = newRP
 	r.maybeEvictLRULocked()
 	return p, nil
 }
@@ -550,6 +618,9 @@ func (r *Router) Reap() []string {
 	r.mu.Lock()
 	var victims []*routedProvider
 	for key, rp := range r.providers {
+		if rp.inUse > 0 {
+			continue // a provider held by an in-flight pass is not idle
+		}
 		if rp.lastUsed.Before(cut) {
 			victims = append(victims, rp)
 			delete(r.providers, key)
@@ -576,6 +647,9 @@ func (r *Router) maybeEvictLRULocked() {
 	var oldest *routedProvider
 	var oldestKey providerKey
 	for key, rp := range r.providers {
+		if rp.inUse > 0 {
+			continue // never evict a provider held by an in-flight pass
+		}
 		if oldest == nil || rp.lastUsed.Before(oldest.lastUsed) {
 			oldest = rp
 			oldestKey = key

--- a/internal/semantic/lsp/router.go
+++ b/internal/semantic/lsp/router.go
@@ -47,6 +47,10 @@ type Router struct {
 	// root) so a server can resolve cross-package imports.
 	additionalWorkspaceFolders []string
 
+	// enrichExcludeGlobs are user-configured path globs to skip for
+	// enrichment, propagated to every spawned provider.
+	enrichExcludeGlobs []string
+
 	mu        sync.Mutex
 	providers map[providerKey]*routedProvider // (spec.Name, workspace) → cached provider
 	enabled   map[string]*ServerSpec          // spec.Name → spec marked enabled by config (no spawn until For/ForSpec)
@@ -287,6 +291,14 @@ func (r *Router) WithAdditionalWorkspaceFolders(folders []string) *Router {
 	return r
 }
 
+// WithEnrichExcludeGlobs sets user-configured path globs that every spawned
+// provider skips for enrichment (on top of the built-in generated/vendored
+// heuristic). Builder-style.
+func (r *Router) WithEnrichExcludeGlobs(globs []string) *Router {
+	r.enrichExcludeGlobs = globs
+	return r
+}
+
 // WithReaperInterval starts a background reaper that calls Reap() at
 // the given cadence. Idempotent — calling twice replaces the previous
 // reaper. A zero duration disables reaping.
@@ -404,6 +416,7 @@ func (r *Router) forSpecWorkspace(spec *ServerSpec, workspace string, pin bool) 
 	// Spawn outside the lock — initialize() blocks on stdio I/O.
 	p := NewProviderFromSpec(spec, r.logger)
 	p.workspaceFolders = r.additionalWorkspaceFolders
+	p.excludeGlobs = r.enrichExcludeGlobs
 	if err := p.EnsureClient(workspace); err != nil {
 		// A binary that resolves on PATH but cannot launch (e.g. a rustup
 		// `rust-analyzer` shim whose toolchain lacks the component) would

--- a/internal/semantic/manager.go
+++ b/internal/semantic/manager.go
@@ -40,6 +40,21 @@ type LSPRouter interface {
 	// if the spec is not enabled or its command is not on PATH.
 	ProviderForSpec(name string) (Provider, error)
 
+	// ProviderForSpecWorkspace is ProviderForSpec scoped to a workspace
+	// root, so each repo gets its own provider instance (keyed by
+	// (spec, workspace)). Per-repo instances are what let cross-repo
+	// enrichment run concurrently without sharing one provider's LSP
+	// connection or document caches. While the returned provider is held,
+	// it is pinned in-use; the caller MUST pair it with ReleaseSpecWorkspace.
+	ProviderForSpecWorkspace(name, workspace string) (Provider, error)
+
+	// ReleaseSpecWorkspace marks a provider obtained via
+	// ProviderForSpecWorkspace as no longer in active use, so the router's
+	// LRU evictor / idle reaper may reclaim it. Pairs one-to-one with
+	// ProviderForSpecWorkspace so a slow, in-use server is never evicted
+	// mid-pass by another repo's concurrent spawn.
+	ReleaseSpecWorkspace(name, workspace string)
+
 	// Close shuts down every active provider. Called by Manager.Close.
 	Close() error
 }
@@ -222,19 +237,30 @@ func (m *Manager) EnrichAll(g graph.Store, roots map[string]string) ([]*EnrichRe
 		}
 		sort.Strings(runOrder)
 		for _, name := range runOrder {
-			provider, err := m.lspRouter.ProviderForSpec(name)
-			if err != nil {
-				m.logger.Debug("router-backed LSP provider unavailable, skipping",
-					zap.String("spec", name),
-					zap.Error(err),
-				)
-				continue
+			// Fetch a provider per repo root (keyed by workspace) rather than
+			// one shared default-workspace provider, so concurrent cross-repo
+			// enrichment never shares a single LSP connection or document cache.
+			for repoName, repoRoot := range roots {
+				provider, err := m.lspRouter.ProviderForSpecWorkspace(name, repoRoot)
+				if err != nil {
+					m.logger.Debug("router-backed LSP provider unavailable, skipping",
+						zap.String("spec", name),
+						zap.String("repo", repoName),
+						zap.Error(err),
+					)
+					continue
+				}
+				// ProviderForSpecWorkspace pinned the provider in-use; release
+				// it once this repo's pass returns so the evictor can reclaim it.
+				func() {
+					defer m.lspRouter.ReleaseSpecWorkspace(name, repoRoot)
+					langs := provider.Languages()
+					if len(langs) == 0 {
+						return
+					}
+					results = m.runEnrichOne(g, repoName, repoRoot, langs[0], provider, results)
+				}()
 			}
-			langs := provider.Languages()
-			if len(langs) == 0 {
-				continue
-			}
-			results = m.runEnrichForProvider(g, roots, langs[0], provider, results)
 		}
 	}
 
@@ -324,52 +350,62 @@ func (m *Manager) configPriorityFor(name string) (int, bool) {
 // providers.
 func (m *Manager) runEnrichForProvider(g graph.Store, roots map[string]string, lang string, provider Provider, results []*EnrichResult) []*EnrichResult {
 	for repoName, repoRoot := range roots {
-		start := time.Now()
-		m.logger.Info("semantic enrichment starting",
+		results = m.runEnrichOne(g, repoName, repoRoot, lang, provider, results)
+	}
+	return results
+}
+
+// runEnrichOne runs one provider against one repo root and appends the
+// result. Split out of runEnrichForProvider so the Router-backed path can
+// fetch a per-repo provider instance (keyed by the repo's workspace) before
+// dispatching — distinct providers per repo are what makes concurrent
+// cross-repo enrichment safe.
+func (m *Manager) runEnrichOne(g graph.Store, repoName, repoRoot, lang string, provider Provider, results []*EnrichResult) []*EnrichResult {
+	start := time.Now()
+	m.logger.Info("semantic enrichment starting",
+		zap.String("provider", provider.Name()),
+		zap.String("language", lang),
+		zap.String("repo", repoName),
+	)
+
+	// repoName is the roots-map key. In multi-repo mode it carries the
+	// repo prefix (the MultiIndexer keys roots by prefix; the per-repo
+	// indexer passes its own RepoPrefix()); a repo-scoped provider uses
+	// it to scope file selection to the repo actually being enriched.
+	var result *EnrichResult
+	var err error
+	if rsp, ok := provider.(RepoScopedProvider); ok {
+		result, err = rsp.EnrichRepo(g, repoName, repoRoot)
+	} else {
+		result, err = provider.Enrich(g, repoRoot)
+	}
+	if err != nil {
+		m.logger.Warn("semantic enrichment failed",
 			zap.String("provider", provider.Name()),
 			zap.String("language", lang),
-			zap.String("repo", repoName),
+			zap.Error(err),
 		)
+		return results
+	}
 
-		// repoName is the roots-map key. In multi-repo mode it carries the
-		// repo prefix (the MultiIndexer keys roots by prefix; the per-repo
-		// indexer passes its own RepoPrefix()); a repo-scoped provider uses
-		// it to scope file selection to the repo actually being enriched.
-		var result *EnrichResult
-		var err error
-		if rsp, ok := provider.(RepoScopedProvider); ok {
-			result, err = rsp.EnrichRepo(g, repoName, repoRoot)
-		} else {
-			result, err = provider.Enrich(g, repoRoot)
-		}
-		if err != nil {
-			m.logger.Warn("semantic enrichment failed",
-				zap.String("provider", provider.Name()),
-				zap.String("language", lang),
-				zap.Error(err),
-			)
-			continue
-		}
+	if result != nil {
+		result.DurationMs = time.Since(start).Milliseconds()
+		results = append(results, result)
 
-		if result != nil {
-			result.DurationMs = time.Since(start).Milliseconds()
-			results = append(results, result)
+		m.mu.Lock()
+		m.lastResults[provider.Name()] = result
+		m.mu.Unlock()
 
-			m.mu.Lock()
-			m.lastResults[provider.Name()] = result
-			m.mu.Unlock()
-
-			m.logger.Info("semantic enrichment complete",
-				zap.String("provider", provider.Name()),
-				zap.String("language", lang),
-				zap.Int("confirmed", result.EdgesConfirmed),
-				zap.Int("added", result.EdgesAdded),
-				zap.Int("refuted", result.EdgesRefuted),
-				zap.Int("nodes_enriched", result.NodesEnriched),
-				zap.Float64("coverage", result.CoveragePercent),
-				zap.Int64("duration_ms", result.DurationMs),
-			)
-		}
+		m.logger.Info("semantic enrichment complete",
+			zap.String("provider", provider.Name()),
+			zap.String("language", lang),
+			zap.Int("confirmed", result.EdgesConfirmed),
+			zap.Int("added", result.EdgesAdded),
+			zap.Int("refuted", result.EdgesRefuted),
+			zap.Int("nodes_enriched", result.NodesEnriched),
+			zap.Float64("coverage", result.CoveragePercent),
+			zap.Int64("duration_ms", result.DurationMs),
+		)
 	}
 	return results
 }

--- a/internal/semantic/manager.go
+++ b/internal/semantic/manager.go
@@ -128,11 +128,42 @@ func (m *Manager) EnrichAll(g graph.Store, roots map[string]string) ([]*EnrichRe
 	// registered via RegisterProvider.
 	langProviders := m.selectProviders()
 
+	// Languages actually present (in symbol-bearing nodes) across the repos
+	// being enriched, from the indexed repo-scoped node scan. A provider — and
+	// the LSP server spawn it would trigger — is skipped when none of its
+	// languages are present, so a clangd / sourcekit / ruby-lsp never starts
+	// for a repo that has no C / Swift / Ruby. This is the same condition the
+	// per-provider EnrichRepo gate already applies, lifted ahead of the spawn.
+	//
+	// The gate fires only on POSITIVE evidence of absence: when the repo set
+	// has indexed symbols (present is non-empty) but none in a provider's
+	// languages. An empty / unindexed graph yields no evidence, so we don't
+	// gate — providers fall through to their own per-pass gate as before.
+	present := m.repoLanguages(g, roots)
+	gateOnPresence := len(present) > 0
+	if gateOnPresence {
+		langs := make([]string, 0, len(present))
+		for l := range present {
+			langs = append(langs, l)
+		}
+		sort.Strings(langs)
+		m.logger.Info("semantic enrichment: repo languages present",
+			zap.Strings("languages", langs),
+		)
+	}
+
 	var results []*EnrichResult
 
 	for lang, provider := range langProviders {
 		if !provider.Available() {
 			m.logger.Debug("semantic provider unavailable, skipping",
+				zap.String("provider", provider.Name()),
+				zap.String("language", lang),
+			)
+			continue
+		}
+		if gateOnPresence && !anyLangPresent(provider.Languages(), present) {
+			m.logger.Debug("semantic provider skipped, no nodes for its languages",
 				zap.String("provider", provider.Name()),
 				zap.String("language", lang),
 			)
@@ -162,6 +193,13 @@ func (m *Manager) EnrichAll(g graph.Store, roots map[string]string) ([]*EnrichRe
 			}
 			for _, lang := range m.lspRouter.SpecLanguages(name) {
 				if _, eagerCovered := langProviders[lang]; eagerCovered {
+					continue
+				}
+				// Only compete for a language the repo set actually contains —
+				// a spec that wins no present language never enters runOrder and
+				// so is never spawned via ProviderForSpec. Skipped when there is
+				// no presence evidence at all (empty / unindexed graph).
+				if gateOnPresence && !present[lang] {
 					continue
 				}
 				cur, exists := bestSpec[lang]
@@ -211,10 +249,49 @@ func (m *Manager) EnrichAll(g graph.Store, roots map[string]string) ([]*EnrichRe
 		if len(langs) == 0 {
 			continue
 		}
+		if gateOnPresence && !anyLangPresent(langs, present) {
+			continue
+		}
 		results = m.runEnrichForProvider(g, roots, langs[0], p, results)
 	}
 
 	return results, nil
+}
+
+// repoLanguages returns the union of languages present (in symbol-bearing
+// nodes) across the given repo roots, computed from the indexed repo-scoped
+// node scan. Used to skip providers — and the LSP server spawns they would
+// trigger — for languages a repo set does not contain. Mirrors the
+// node-language condition the per-provider EnrichRepo gate applies, so a
+// provider is gated here exactly when its own pass would have found no work.
+func (m *Manager) repoLanguages(g graph.Store, roots map[string]string) map[string]bool {
+	present := make(map[string]bool)
+	for repoPrefix := range roots {
+		nodes := g.GetRepoNodes(repoPrefix)
+		if len(nodes) == 0 && repoPrefix == "" {
+			nodes = g.AllNodes()
+		}
+		for _, n := range nodes {
+			// Include file/import nodes too: the per-provider EnrichRepo gate
+			// can spawn on an ambiguous edge sourced from a file/import node, so
+			// presence here must be at least as permissive — otherwise we would
+			// gate out a provider whose own pass would have run.
+			if n.RepoPrefix == repoPrefix && n.Language != "" {
+				present[n.Language] = true
+			}
+		}
+	}
+	return present
+}
+
+// anyLangPresent reports whether any of langs is in the present set.
+func anyLangPresent(langs []string, present map[string]bool) bool {
+	for _, l := range langs {
+		if present[l] {
+			return true
+		}
+	}
+	return false
 }
 
 // providerDisabled reports an explicit `enabled: false` config entry

--- a/internal/semantic/manager.go
+++ b/internal/semantic/manager.go
@@ -302,9 +302,16 @@ func (m *Manager) repoLanguages(g graph.Store, roots map[string]string) map[stri
 			// can spawn on an ambiguous edge sourced from a file/import node, so
 			// presence here must be at least as permissive — otherwise we would
 			// gate out a provider whose own pass would have run.
-			if n.RepoPrefix == repoPrefix && n.Language != "" {
-				present[n.Language] = true
+			if n.RepoPrefix != repoPrefix || n.Language == "" {
+				continue
 			}
+			// Generated / vendored files don't make a language "present" — a
+			// repo whose only C is tree-sitter's generated parser.c should not
+			// spawn clangd just to index it.
+			if IsLowValueForEnrichment(n.FilePath, m.config.ExcludeGlobs) {
+				continue
+			}
+			present[n.Language] = true
 		}
 	}
 	return present

--- a/internal/semantic/manager_test.go
+++ b/internal/semantic/manager_test.go
@@ -227,6 +227,22 @@ func (f *fakeRouter) ProviderForSpec(name string) (Provider, error) {
 	return p, nil
 }
 
+func (f *fakeRouter) ProviderForSpecWorkspace(name, workspace string) (Provider, error) {
+	f.calls = append(f.calls, "ProviderForSpecWorkspace:"+name)
+	if err, ok := f.providerErrs[name]; ok {
+		return nil, err
+	}
+	p, ok := f.providers[name]
+	if !ok {
+		return nil, assertionError("no provider for spec " + name)
+	}
+	return p, nil
+}
+
+func (f *fakeRouter) ReleaseSpecWorkspace(name, workspace string) {
+	f.calls = append(f.calls, "ReleaseSpecWorkspace:"+name)
+}
+
 func (f *fakeRouter) Close() error {
 	f.closeCalls++
 	return nil

--- a/internal/semantic/manager_test.go
+++ b/internal/semantic/manager_test.go
@@ -307,6 +307,49 @@ func TestManager_EnrichAll_SkipsCoveredLanguages(t *testing.T) {
 	assert.Equal(t, "eager-go", results[0].Provider)
 }
 
+// TestManager_EnrichAll_GatesAbsentLanguages — on a populated repo (positive
+// presence evidence), a router-backed spec whose language the repo does NOT
+// contain is never spawned (ProviderForSpec is not called for it), while a
+// provider whose language IS present still runs.
+func TestManager_EnrichAll_GatesAbsentLanguages(t *testing.T) {
+	logger := zap.NewNop()
+	cfg := Config{
+		Enabled: true,
+		Providers: []ProviderConfig{
+			{Name: "eager-go", Languages: []string{"go"}, Priority: 1, Enabled: true},
+		},
+	}
+	mgr := NewManager(cfg, logger)
+	mgr.RegisterProvider(&mockProvider{name: "eager-go", languages: []string{"go"}, available: true})
+
+	// A router spec serving rust — a language this repo does not contain.
+	rustProvider := &mockProvider{name: "lsp-rust-analyzer", languages: []string{"rust"}, available: true}
+	r := &fakeRouter{
+		specs:     []string{"rust-analyzer"},
+		available: map[string]bool{"rust-analyzer": true},
+		languages: map[string][]string{"rust-analyzer": {"rust"}},
+		providers: map[string]Provider{"rust-analyzer": rustProvider},
+	}
+	mgr.SetLSPRouter(r)
+
+	// Populated repo: one Go node tagged with the roots-key prefix, no Rust.
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "myrepo/main.go::main", Kind: graph.KindFunction, Name: "main", FilePath: "myrepo/main.go", Language: "go", RepoPrefix: "myrepo"})
+
+	roots := map[string]string{"myrepo": "/tmp/r"}
+	results, err := mgr.EnrichAll(g, roots)
+	require.NoError(t, err)
+
+	// The eager Go provider runs; the Rust spec is gated out before any spawn.
+	require.Len(t, results, 1)
+	assert.Equal(t, "eager-go", results[0].Provider)
+	for _, c := range r.calls {
+		if c == "ProviderForSpec:rust-analyzer" {
+			t.Fatalf("rust spec should be gated out (repo has no rust nodes), but ProviderForSpec was called — calls: %v", r.calls)
+		}
+	}
+}
+
 // TestManager_HasProviders_RouterOnly — a router-only setup with at
 // least one available spec returns true, and the check does NOT
 // trigger ProviderForSpec (which would lazy-spawn a real LSP).

--- a/internal/semantic/tstypes/provider.go
+++ b/internal/semantic/tstypes/provider.go
@@ -132,7 +132,7 @@ func (p *Provider) EnrichRepo(g graph.Store, repoPrefix, repoRoot string) (*sema
 		for _, facts := range all {
 			analyzed[facts.file] = true
 		}
-		p.countCoverage(g, analyzed, res)
+		p.countCoverage(g, repoPrefix, analyzed, res)
 		mu.Unlock()
 	}
 
@@ -181,7 +181,7 @@ func (p *Provider) EnrichFile(g graph.Store, repoRoot, filePath string) (*semant
 		ap := newApplier(g, p.spec, p.Name())
 		ap.applyAll([]*fileFacts{facts}, res)
 		ap.flush()
-		p.countCoverage(g, map[string]bool{facts.file: true}, res)
+		p.countCoverage(g, fileNode.RepoPrefix, map[string]bool{facts.file: true}, res)
 		mu.Unlock()
 	}
 	res.DurationMs = time.Since(start).Milliseconds()
@@ -191,13 +191,20 @@ func (p *Provider) EnrichFile(g graph.Store, repoRoot, filePath string) (*semant
 // countCoverage fills the symbols-covered counters: total is every
 // symbol of the provider's languages, covered is the subset living in
 // files the pass analyzed.
-func (p *Provider) countCoverage(g graph.Store, analyzed map[string]bool, res *semantic.EnrichResult) {
+func (p *Provider) countCoverage(g graph.Store, repoPrefix string, analyzed map[string]bool, res *semantic.EnrichResult) {
 	langs := make(map[string]bool, len(p.spec.Languages))
 	for _, l := range p.spec.Languages {
 		langs[l] = true
 	}
-	for _, n := range g.AllNodes() {
-		if !langs[n.Language] || n.Kind == graph.KindFile || n.Kind == graph.KindImport {
+	// Indexed repo-scoped scan rather than a whole-graph AllNodes walk; the
+	// whole-graph form also counted every other repo's symbols against this
+	// repo's coverage. Fall back to AllNodes only for the embedded ("") path.
+	nodes := g.GetRepoNodes(repoPrefix)
+	if len(nodes) == 0 && repoPrefix == "" {
+		nodes = g.AllNodes()
+	}
+	for _, n := range nodes {
+		if n.RepoPrefix != repoPrefix || !langs[n.Language] || n.Kind == graph.KindFile || n.Kind == graph.KindImport {
 			continue
 		}
 		res.SymbolsTotal++

--- a/internal/serverstack/shared_server.go
+++ b/internal/serverstack/shared_server.go
@@ -299,6 +299,7 @@ func NewSharedServer(cfg SharedServerConfig) (*SharedServer, error) {
 			EnrichOnWatch:     conf.Semantic.EnrichOnWatch,
 			WatchDebounceMs:   conf.Semantic.WatchDebounceMs,
 			RefuteUnconfirmed: conf.Semantic.RefuteUnconfirmed,
+			ExcludeGlobs:      conf.Semantic.ExcludeGlobs,
 		}
 		for _, pc := range conf.Semantic.Providers {
 			out := semantic.ProviderConfig{
@@ -348,7 +349,8 @@ func NewSharedServer(cfg SharedServerConfig) (*SharedServer, error) {
 			WithIdleTimeout(10 * time.Minute).
 			WithReaperInterval(time.Minute).
 			WithMaxAlive(6).
-			WithAdditionalWorkspaceFolders(conf.Semantic.AdditionalWorkspaceFolders)
+			WithAdditionalWorkspaceFolders(conf.Semantic.AdditionalWorkspaceFolders).
+			WithEnrichExcludeGlobs(conf.Semantic.ExcludeGlobs)
 		semMgr.SetLSPRouter(lspRouter)
 
 		for _, pc := range semCfg.Providers {


### PR DESCRIPTION
## Summary

A fresh multi-repo index spent almost all of its warmup in semantic enrichment — on a 21-repo workspace, ~46 of 50 minutes. Three root causes:

1. **O(graph) scans per provider per repo.** Each provider's per-repo enrichment collected its work set by walking the whole graph (an `AllEdges` pass with a point `GetNode` per edge, plus several `AllNodes` passes). On a disk-backed store that is O(graph) work paid once per provider per repo — so a language server with no nodes in a repo still paid a full-graph scan to discover it had nothing to do.
2. **Language servers spawned for absent languages.** The manager dispatched every provider and arbitrated every LSP spec independent of repo content, so a clangd / sourcekit / ruby-lsp spun up for repos with no C / Swift / Ruby.
3. **Language servers indexing machine-generated code.** The slowest single thing was clangd background-indexing tree-sitter's generated `parser.c` across grammar repos — for essentially zero enrichment value.

## What changed

- **Repo-scoped enrichment scans** — the LSP, go-types, and tstypes providers now use the indexed `GetRepoNodes` / `GetRepoEdges` (and kind-indexed `EdgesByKind` for the graph-wide implements pass) instead of whole-graph walks. Two parity fixes keep the scoped scans equivalent to the original (file/import-sourced ambiguous edges; cross-repo implements confirmation).
- **Presence gate** — `EnrichAll` computes the languages actually present in a repo once and skips a provider, before any LSP spawn, when none of its languages are present (fires only on positive evidence, so an empty graph is never gated).
- **Spawn-failure negative cache** — a server that resolves on PATH but fails to launch (e.g. a rustup `rust-analyzer` shim) is marked unavailable and not retried per repo.
- **Generated/vendored exclusion** — a built-in heuristic (vendored dirs, tree-sitter `parser.c`/runtime, generated suffixes) plus a configurable `semantic.exclude_globs` skips those files, both at the presence gate and in each server's work set, so generated code is never indexed.
- **Concurrent cross-repo enrichment** — enrichment runs across repos in a bounded worker pool. To make that safe, providers serialise graph mutations on the resolve mutex, each repo gets its own LSP provider instance (keyed by its workspace, with an in-use pin so the LRU evictor never closes an in-flight server), and go-types stashes loaded packages per repo.
- **ruby-lsp composed-bundle skip** — point `BUNDLE_GEMFILE` at a repo's own Gemfile (when present) so ruby-lsp skips its on-spawn `bundle install`.

Enrichment results (edges added / confirmed / refuted) are unchanged; the per-repo provider model additionally fixes latent under-enrichment from the previously-shared default-workspace server.

## Result

Clean re-index of the same 21-repo workspace, idle machine:

| | Before | After |
|---|---|---|
| **Warmup to ready** | 50.1 min | **7.4 min** (~6.7×) |
| Enrichment phase (`deferred_passes_all`) | 47.4 min | **2.3 min** (~20×) |

clangd indexing of generated code is eliminated; no panics or data races across repeated fresh indexes.

## Tests

`go build` (CGO) plus `go test -race ./internal/semantic/... ./internal/indexer/...` pass.