### PR TITLE
Render context snippets with the symbol's language fence

### DIFF
--- a/internal/mcp/tools_coding.go
+++ b/internal/mcp/tools_coding.go
@@ -1936,6 +1936,7 @@ func (s *Server) handleSmartContext(ctx context.Context, req mcp.CallToolRequest
 			"kind":       sym.Kind,
 			"name":       sym.Name,
 			"file_path":  sym.FilePath,
+			"language":   sym.Language,
 			"start_line": sym.StartLine,
 		}
 		if sig, ok := sym.Meta["signature"]; ok {

--- a/internal/mcp/tools_enhancements.go
+++ b/internal/mcp/tools_enhancements.go
@@ -3932,6 +3932,18 @@ func (s *Server) handleExportContext(ctx context.Context, req mcp.CallToolReques
 	return mcp.NewToolResultText(md), nil
 }
 
+// markdownFenceLang picks the Markdown code-fence info string for an embedded
+// source snippet. It prefers the symbol's indexed language (authoritative — the
+// graph already resolved it during indexing) and falls back to deriving one
+// from the file extension. An unrecognised language yields an empty info string
+// (a plain fence) rather than a wrong one, so a snippet is never mislabelled.
+func markdownFenceLang(language, filePath string) string {
+	if lang := strings.TrimSpace(strings.ToLower(language)); lang != "" {
+		return lang
+	}
+	return languageForExtension(filePath)
+}
+
 // renderContextMarkdown converts smart_context JSON output into a self-contained
 // markdown briefing suitable for sharing outside MCP.
 func renderContextMarkdown(data map[string]any, tokenBudget int) string {
@@ -3968,6 +3980,7 @@ func renderContextMarkdown(data map[string]any, tokenBudget int) string {
 			kind, _ := symMap["kind"].(string)
 			id, _ := symMap["id"].(string)
 			filePath, _ := symMap["file_path"].(string)
+			language, _ := symMap["language"].(string)
 			startLine, _ := symMap["start_line"].(float64)
 
 			fmt.Fprintf(&sb, "### `%s` (%s)\n\n", name, kind)
@@ -3978,10 +3991,12 @@ func renderContextMarkdown(data map[string]any, tokenBudget int) string {
 				fmt.Fprintf(&sb, "- **Signature:** `%s`\n", sig)
 			}
 
-			// Include source if within budget.
+			// Include source if within budget. The fence language tracks the
+			// symbol's own language rather than a hardcoded "go" so a snippet
+			// from any indexed language is highlighted correctly.
 			if source, ok := symMap["source"].(string); ok && source != "" {
 				if sb.Len()+len(source) < charBudget {
-					sb.WriteString("\n```go\n")
+					fmt.Fprintf(&sb, "\n```%s\n", markdownFenceLang(language, filePath))
 					sb.WriteString(source)
 					sb.WriteString("\n```\n")
 				} else {

--- a/internal/mcp/tools_export_context_test.go
+++ b/internal/mcp/tools_export_context_test.go
@@ -95,3 +95,83 @@ func TestExportContext_OuterRequestArgsUnmutated(t *testing.T) {
 	assert.Equal(t, "markdown", outerArgs["format"],
 		"outer args mutated by the inner-format override")
 }
+
+// TestRenderContextMarkdown_FenceMatchesSymbolLanguage is the regression
+// guard for the hardcoded-fence bug: embedded source snippets were always
+// wrapped in a ```go fence regardless of the symbol's real language, so a
+// TypeScript snippet was mislabelled as Go. The fence must track the
+// symbol's own indexed language.
+func TestRenderContextMarkdown_FenceMatchesSymbolLanguage(t *testing.T) {
+	data := map[string]any{
+		"task": "token invalidation",
+		"relevant_symbols": []any{
+			map[string]any{
+				"id":         "src/auth.ts::invalidateToken",
+				"kind":       "function",
+				"name":       "invalidateToken",
+				"file_path":  "src/auth.ts",
+				"language":   "typescript",
+				"start_line": float64(10),
+				"source":     "function invalidateToken(t: string) {}",
+			},
+		},
+	}
+
+	md := renderContextMarkdown(data, 2000)
+
+	assert.Contains(t, md, "```typescript\n",
+		"a TypeScript symbol must be fenced as typescript")
+	assert.NotContains(t, md, "```go",
+		"a TypeScript snippet must never be fenced as go")
+}
+
+// TestRenderContextMarkdown_FenceFallsBackToExtension covers the path where
+// the entry carries no language field (older/cached data or a federated
+// merge): the fence is derived from the file extension rather than defaulting
+// to go.
+func TestRenderContextMarkdown_FenceFallsBackToExtension(t *testing.T) {
+	data := map[string]any{
+		"task": "extension fallback",
+		"relevant_symbols": []any{
+			map[string]any{
+				"id":   "lib/util.py::helper",
+				"kind": "function",
+				"name": "helper",
+				// language deliberately omitted to exercise the fallback.
+				"file_path":  "lib/util.py",
+				"start_line": float64(1),
+				"source":     "def helper():\n    pass",
+			},
+		},
+	}
+
+	md := renderContextMarkdown(data, 2000)
+
+	assert.Contains(t, md, "```python\n",
+		"with no language field the fence must be derived from the .py extension")
+	assert.NotContains(t, md, "```go",
+		"the extension fallback must not produce a go fence")
+}
+
+// TestRenderContextMarkdown_GoSymbolStillFencedAsGo guards the common case:
+// the fix must not regress Go snippets, which should still be fenced as go.
+func TestRenderContextMarkdown_GoSymbolStillFencedAsGo(t *testing.T) {
+	data := map[string]any{
+		"task": "go path",
+		"relevant_symbols": []any{
+			map[string]any{
+				"id":         "main.go::run",
+				"kind":       "function",
+				"name":       "run",
+				"file_path":  "main.go",
+				"language":   "go",
+				"start_line": float64(1),
+				"source":     "func run() {}",
+			},
+		},
+	}
+
+	md := renderContextMarkdown(data, 2000)
+
+	assert.Contains(t, md, "```go\n", "a Go symbol must still be fenced as go")
+}


### PR DESCRIPTION
## Problem

`gortex context` / `export_context` rendered every embedded source snippet inside a hardcoded ` ```go ` Markdown fence, even when the symbol came from another language. The source content and file path were correct, but a TypeScript symbol was highlighted as Go.

Fixes #121.

## Cause

`renderContextMarkdown` (in `internal/mcp/tools_enhancements.go`) wrote a literal ` ```go ` fence around every snippet, and the upstream `smart_context` `relevant_symbols` entries didn't carry the symbol's language for the renderer to use.

## Fix

- `handleSmartContext` now includes each symbol's authoritative indexed `language` on its `relevant_symbols` entry.
- `renderContextMarkdown` picks the fence info string from that language, falling back to the file extension (`languageForExtension`) when it's absent, and to a plain fence when neither is known — so a snippet is never mislabelled.

Both surfaces named in the issue are covered: the `gortex context` CLI delegates to `export_context`, which uses this same renderer.

## Notes

- Additive only — a new map key plus a small helper; no signatures changed. The GCX wire encoder uses an explicit column list, so its output is unaffected.

## Tests

- New unit tests on `renderContextMarkdown`: a TypeScript symbol is fenced as `typescript` (and never `go`); a language-less entry falls back to the `.py` extension; a Go symbol still fences as `go`.
- `go build ./...`, `go vet ./internal/mcp/`, and the full `internal/mcp` package (2382 tests) all pass.