### PR TITLE
Render graded-fidelity context manifests in the markdown briefing

### DIFF
--- a/internal/mcp/manifest.go
+++ b/internal/mcp/manifest.go
@@ -101,6 +101,7 @@ func (s *Server) buildContextManifest(ctx context.Context, focus, outlineCandida
 			"kind":       string(n.Kind),
 			"name":       n.Name,
 			"file_path":  n.FilePath,
+			"language":   n.Language,
 			"start_line": n.StartLine,
 			"relation":      "",
 			"distance":      0,

--- a/internal/mcp/tools_enhancements.go
+++ b/internal/mcp/tools_enhancements.go
@@ -3944,6 +3944,72 @@ func markdownFenceLang(language, filePath string) string {
 	return languageForExtension(filePath)
 }
 
+// contextSymbolEntries returns the symbol entries the briefing should render
+// and how many the source pipeline omitted for budget. The graded-fidelity
+// context_manifest is preferred when present — it carries the tiered,
+// budget-packed source — otherwise the flat relevant_symbols list is used. In
+// graded mode relevant_symbols is built without source, so falling back to it
+// blindly would render an empty briefing.
+func contextSymbolEntries(data map[string]any) (entries []any, omitted int) {
+	if mani, ok := data["context_manifest"].(map[string]any); ok {
+		if me, ok := mani["entries"].([]any); ok && len(me) > 0 {
+			if o, ok := mani["omitted"].(float64); ok {
+				omitted = int(o)
+			}
+			return me, omitted
+		}
+	}
+	entries, _ = data["relevant_symbols"].([]any)
+	return entries, 0
+}
+
+// renderSymbolEntries writes the "Key Symbols" body for a list of symbol
+// entries. The entry shape is shared by the flat relevant_symbols list and the
+// graded manifest, so manifest-only fields (tier, compressed) are rendered when
+// present and skipped otherwise. Each source snippet is fenced with its own
+// language rather than a hardcoded "go".
+func renderSymbolEntries(sb *strings.Builder, entries []any, charBudget int) {
+	for _, raw := range entries {
+		em, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := em["name"].(string)
+		kind, _ := em["kind"].(string)
+		id, _ := em["id"].(string)
+		filePath, _ := em["file_path"].(string)
+		language, _ := em["language"].(string)
+		startLine, _ := em["start_line"].(float64)
+
+		fmt.Fprintf(sb, "### `%s` (%s)\n\n", name, kind)
+		fmt.Fprintf(sb, "- **ID:** `%s`\n", id)
+		fmt.Fprintf(sb, "- **File:** `%s:%d`\n", filePath, int(startLine))
+		if tier, ok := em["tier"].(string); ok && tier != "" {
+			fmt.Fprintf(sb, "- **Tier:** %s\n", tier)
+		}
+		if sig, ok := em["signature"].(string); ok && sig != "" {
+			fmt.Fprintf(sb, "- **Signature:** `%s`\n", sig)
+		}
+
+		// Include source if within budget. The fence language tracks the
+		// symbol's own language rather than a hardcoded "go" so a snippet from
+		// any indexed language is highlighted correctly.
+		if source, ok := em["source"].(string); ok && source != "" {
+			if sb.Len()+len(source) < charBudget {
+				if compressed, _ := em["compressed"].(bool); compressed {
+					sb.WriteString("- *(source compressed — bodies elided)*\n")
+				}
+				fmt.Fprintf(sb, "\n```%s\n", markdownFenceLang(language, filePath))
+				sb.WriteString(source)
+				sb.WriteString("\n```\n")
+			} else {
+				sb.WriteString("- *(source omitted — token budget exceeded)*\n")
+			}
+		}
+		sb.WriteString("\n")
+	}
+}
+
 // renderContextMarkdown converts smart_context JSON output into a self-contained
 // markdown briefing suitable for sharing outside MCP.
 func renderContextMarkdown(data map[string]any, tokenBudget int) string {
@@ -3968,42 +4034,17 @@ func renderContextMarkdown(data map[string]any, tokenBudget int) string {
 		sb.WriteString("\n\n")
 	}
 
-	// Key symbols.
-	if symbols, ok := data["relevant_symbols"].([]any); ok && len(symbols) > 0 {
+	// Key symbols. The graded-fidelity manifest carries the richest
+	// (tiered, budget-packed) source set; prefer it when present and fall
+	// back to the flat relevant_symbols list otherwise. Both share the same
+	// entry shape, so one renderer handles either — without this, a graded
+	// briefing showed no source at all, because the flat list it falls back
+	// to is built source-less in graded mode.
+	if symbols, omitted := contextSymbolEntries(data); len(symbols) > 0 {
 		sb.WriteString("## Key Symbols\n\n")
-		for _, sym := range symbols {
-			symMap, ok := sym.(map[string]any)
-			if !ok {
-				continue
-			}
-			name, _ := symMap["name"].(string)
-			kind, _ := symMap["kind"].(string)
-			id, _ := symMap["id"].(string)
-			filePath, _ := symMap["file_path"].(string)
-			language, _ := symMap["language"].(string)
-			startLine, _ := symMap["start_line"].(float64)
-
-			fmt.Fprintf(&sb, "### `%s` (%s)\n\n", name, kind)
-			fmt.Fprintf(&sb, "- **ID:** `%s`\n", id)
-			fmt.Fprintf(&sb, "- **File:** `%s:%d`\n", filePath, int(startLine))
-
-			if sig, ok := symMap["signature"].(string); ok && sig != "" {
-				fmt.Fprintf(&sb, "- **Signature:** `%s`\n", sig)
-			}
-
-			// Include source if within budget. The fence language tracks the
-			// symbol's own language rather than a hardcoded "go" so a snippet
-			// from any indexed language is highlighted correctly.
-			if source, ok := symMap["source"].(string); ok && source != "" {
-				if sb.Len()+len(source) < charBudget {
-					fmt.Fprintf(&sb, "\n```%s\n", markdownFenceLang(language, filePath))
-					sb.WriteString(source)
-					sb.WriteString("\n```\n")
-				} else {
-					sb.WriteString("- *(source omitted — token budget exceeded)*\n")
-				}
-			}
-			sb.WriteString("\n")
+		renderSymbolEntries(&sb, symbols, charBudget)
+		if omitted > 0 {
+			fmt.Fprintf(&sb, "*(%d more symbol(s) omitted — token budget)*\n\n", omitted)
 		}
 	}
 

--- a/internal/mcp/tools_export_context_test.go
+++ b/internal/mcp/tools_export_context_test.go
@@ -175,3 +175,85 @@ func TestRenderContextMarkdown_GoSymbolStillFencedAsGo(t *testing.T) {
 
 	assert.Contains(t, md, "```go\n", "a Go symbol must still be fenced as go")
 }
+
+// TestRenderContextMarkdown_GradedManifestRendersSource is the regression
+// guard for the graded-fidelity path: smart_context with fidelity:graded emits
+// a context_manifest holding the source and builds relevant_symbols without
+// source. The renderer previously only looked at relevant_symbols, so a graded
+// briefing showed symbol headers but no code at all. The manifest must be
+// rendered, fenced by each entry's own language.
+func TestRenderContextMarkdown_GradedManifestRendersSource(t *testing.T) {
+	data := map[string]any{
+		"task": "token invalidation",
+		// In graded mode relevant_symbols carries no source — only the
+		// manifest does. The renderer must prefer the manifest.
+		"relevant_symbols": []any{
+			map[string]any{
+				"id":         "src/auth.ts::invalidateToken",
+				"kind":       "function",
+				"name":       "invalidateToken",
+				"file_path":  "src/auth.ts",
+				"language":   "typescript",
+				"start_line": float64(10),
+			},
+		},
+		"context_manifest": map[string]any{
+			"omitted": float64(2),
+			"entries": []any{
+				map[string]any{
+					"id":         "src/auth.ts::invalidateToken",
+					"kind":       "function",
+					"name":       "invalidateToken",
+					"file_path":  "src/auth.ts",
+					"language":   "typescript",
+					"start_line": float64(10),
+					"tier":       "focus",
+					"source":     "function invalidateToken(t: string) {}",
+				},
+			},
+		},
+	}
+
+	md := renderContextMarkdown(data, 2000)
+
+	assert.Contains(t, md, "function invalidateToken(t: string) {}",
+		"graded manifest source must be rendered")
+	assert.Contains(t, md, "```typescript\n",
+		"manifest source must be fenced by the entry's language")
+	assert.NotContains(t, md, "```go",
+		"a TypeScript manifest snippet must never be fenced as go")
+	assert.Contains(t, md, "**Tier:** focus",
+		"the manifest tier should be surfaced")
+	assert.Contains(t, md, "2 more symbol(s) omitted",
+		"the manifest omitted count should be surfaced")
+}
+
+// TestRenderContextMarkdown_GradedManifestMarksCompressed verifies a
+// compressed (body-elided) manifest entry is labelled as such so the reader
+// knows the snippet is a skeleton rather than the full body.
+func TestRenderContextMarkdown_GradedManifestMarksCompressed(t *testing.T) {
+	data := map[string]any{
+		"task": "compressed entry",
+		"context_manifest": map[string]any{
+			"entries": []any{
+				map[string]any{
+					"id":         "pkg/big.go::Huge",
+					"kind":       "type",
+					"name":       "Huge",
+					"file_path":  "pkg/big.go",
+					"language":   "go",
+					"start_line": float64(1),
+					"tier":       "focus",
+					"compressed": true,
+					"source":     "type Huge struct { /* … */ }",
+				},
+			},
+		},
+	}
+
+	md := renderContextMarkdown(data, 2000)
+
+	assert.Contains(t, md, "source compressed",
+		"a compressed manifest entry must be labelled compressed")
+	assert.Contains(t, md, "```go\n", "the compressed snippet must still be fenced")
+}


### PR DESCRIPTION
## Problem

`export_context` — and the `gortex context` CLI that delegates to it — produced a briefing with **no source code at all** when called with `fidelity: graded`.

`smart_context` has two output shapes: the default `flat` list (`relevant_symbols`, with `source` embedded on the top entries) and the richer `graded` `context_manifest` (tiered, budget-packed entries that carry the source). In graded mode the `relevant_symbols` entries are built *without* source — the manifest holds it. But `renderContextMarkdown` only ever read `relevant_symbols`, so a graded briefing rendered symbol headers with empty bodies and silently dropped the manifest's source.

This was discovered while fixing #121 (the hardcoded-`go` fence); it's the same renderer, a different fidelity path.

## Fix

- `renderContextMarkdown` now prefers the `context_manifest` entries when present and falls back to the flat `relevant_symbols` list otherwise. Both shapes share one entry renderer (`renderSymbolEntries`).
- Each manifest entry now carries its indexed `language` (added in `buildContextManifest`), so snippets are fenced by their own language — reusing the `markdownFenceLang` helper from #121 rather than reintroducing a hardcoded fence.
- The renderer surfaces the manifest's **tier** (focus/ring/outline), marks **compressed** (body-elided) stubs so a skeleton isn't mistaken for full source, and reports the **omitted-for-budget** count instead of dropping symbols silently.

## Notes

- Additive: one new map key plus two small render helpers; no signatures changed. The GCX encoder uses an explicit column list, so its output is unaffected.
- Flat-mode output is byte-identical to before (manifest-only fields are skipped when absent).

## Tests

- New `renderContextMarkdown` tests: a graded manifest renders its TypeScript source fenced as `typescript` (never `go`), surfaces the tier and the omitted count, and labels a compressed entry; the existing flat-path tests (including the #121 fence guards) still pass.
- `go build ./...`, `go vet ./internal/mcp/`, and the full `internal/mcp` package (2384 tests) all pass.