### PR TITLE
Descend re-included subtrees under blanket-ignored directories

### DIFF
--- a/internal/excludes/hierarchical.go
+++ b/internal/excludes/hierarchical.go
@@ -79,6 +79,61 @@ func (h *Hierarchical) Match(absPath string, isDir bool) bool {
 	return false
 }
 
+// HasNegatedDescendant reports whether any per-directory ignore file
+// along the chain from the root down to absDir carries a re-include
+// ("!") pattern that could match a path strictly beneath absDir. The
+// index walk uses it to keep descending an excluded directory whose
+// subtree a negation could resurrect, instead of pruning it outright —
+// the per-directory counterpart of Matcher.HasNegatedDescendant. absDir
+// is an absolute directory path; a path outside the root never matches.
+func (h *Hierarchical) HasNegatedDescendant(absDir string) bool {
+	if h == nil || len(h.filenames) == 0 {
+		return false
+	}
+	absDir = filepath.Clean(absDir)
+	rel, err := filepath.Rel(h.root, absDir)
+	if err != nil {
+		return false
+	}
+	rel = filepath.ToSlash(rel)
+	if rel == ".." || strings.HasPrefix(rel, "../") {
+		return false
+	}
+
+	// Each directory's ignore patterns are anchored at that directory, so
+	// the question "is there a negated descendant of absDir?" is asked of
+	// every ancestor matcher (and absDir's own) with absDir expressed
+	// relative to that ancestor.
+	dir := h.root
+	if h.dirMatcher(dir).HasNegatedDescendant(relUnder(dir, absDir)) {
+		return true
+	}
+	if rel == "." || rel == "" {
+		return false
+	}
+	for _, seg := range strings.Split(rel, "/") {
+		dir = filepath.Join(dir, seg)
+		if h.dirMatcher(dir).HasNegatedDescendant(relUnder(dir, absDir)) {
+			return true
+		}
+	}
+	return false
+}
+
+// relUnder returns child expressed relative to dir, in forward-slash
+// form. It returns "" when child is dir itself.
+func relUnder(dir, child string) string {
+	rel, err := filepath.Rel(dir, child)
+	if err != nil {
+		return ""
+	}
+	rel = filepath.ToSlash(rel)
+	if rel == "." {
+		return ""
+	}
+	return rel
+}
+
 // dirMatcher returns the compiled ignore matcher for one directory,
 // reading and parsing its ignore files on first request. A directory
 // with no ignore files (or only empty ones) caches a nil matcher; the

--- a/internal/excludes/hierarchical_test.go
+++ b/internal/excludes/hierarchical_test.go
@@ -89,6 +89,52 @@ func TestHierarchical_Negation(t *testing.T) {
 	}
 }
 
+func TestHierarchical_HasNegatedDescendant(t *testing.T) {
+	root := t.TempDir()
+	// A blanket "dir/*" plus a re-include of one child, expressed in a
+	// per-directory ignore file. The walk must keep descending pkg/ so
+	// the re-included pkg/keep/ subtree is reached.
+	mkIgnore(t, filepath.Join(root, ".gortexignore"), "pkg/*\n!pkg/keep/\n")
+	h := NewHierarchical(root, ".gortexignore")
+
+	if !h.HasNegatedDescendant(filepath.Join(root, "pkg")) {
+		t.Error("pkg/ has a re-included child and must not be pruned")
+	}
+	if h.HasNegatedDescendant(filepath.Join(root, "pkg", "other")) {
+		t.Error("pkg/other has no re-included descendant and is prunable")
+	}
+	if h.HasNegatedDescendant(filepath.Join(root, "unrelated")) {
+		t.Error("an unrelated directory has no re-included descendant")
+	}
+}
+
+func TestHierarchical_HasNegatedDescendant_Anchored(t *testing.T) {
+	root := t.TempDir()
+	// The negation lives in a nested ignore file, anchored at internal/.
+	mkIgnore(t, filepath.Join(root, "internal", ".gortexignore"), "build/*\n!build/keep/\n")
+	h := NewHierarchical(root, ".gortexignore")
+
+	if !h.HasNegatedDescendant(filepath.Join(root, "internal", "build")) {
+		t.Error("internal/build has a re-included child via the nested ignore file")
+	}
+	if h.HasNegatedDescendant(filepath.Join(root, "build")) {
+		t.Error("a root-level build/ is unaffected by internal/.gortexignore")
+	}
+}
+
+func TestHierarchical_HasNegatedDescendant_NilAndEmpty(t *testing.T) {
+	var h *Hierarchical
+	if h.HasNegatedDescendant("/anything") {
+		t.Error("nil Hierarchical should report no negated descendants")
+	}
+	root := t.TempDir()
+	mkIgnore(t, filepath.Join(root, ".gortexignore"), "pkg/*\n!pkg/keep/\n")
+	empty := NewHierarchical(root) // no filenames configured
+	if empty.HasNegatedDescendant(filepath.Join(root, "pkg")) {
+		t.Error("an empty filename list should report no negated descendants")
+	}
+}
+
 func TestHierarchical_NoFiles(t *testing.T) {
 	root := t.TempDir()
 	mkIgnore(t, filepath.Join(root, "foo.go"), "package x\n")

--- a/internal/excludes/matcher.go
+++ b/internal/excludes/matcher.go
@@ -91,3 +91,84 @@ func (m *Matcher) MatchAbsDir(absPath, root string, isDir bool) bool {
 	}
 	return m.MatchRel(rel)
 }
+
+// HasNegatedDescendant reports whether any re-include ("!") pattern in
+// the matcher could match a path strictly beneath relDir.
+//
+// The index walk prunes an excluded directory with filepath.SkipDir so
+// it never descends a subtree it would only throw away. But go-gitignore
+// treats "*" as matching across "/", so a blanket like "a/b/*" reports
+// the directory "a/b" itself as excluded — pruning it would skip a later
+// "!a/b/keep/" re-include before the walk ever reaches the child. This
+// lets the walk ask "could a negation resurrect something under here?"
+// and keep descending when the answer is yes, mirroring git, which never
+// prunes a directory a negation could re-include a child from.
+//
+// relDir is a repo-root-relative, forward-slash directory path (a
+// trailing slash and a leading "./" are tolerated). The check is
+// deliberately conservative: an unanchored or wildcard-leading negation
+// can match at varying depths, so it is treated as "could be under
+// anything" and the directory is kept rather than pruned.
+func (m *Matcher) HasNegatedDescendant(relDir string) bool {
+	if m == nil {
+		return false
+	}
+	relDir = pathkey.Normalize(filepath.ToSlash(relDir))
+	relDir = strings.TrimPrefix(relDir, "./")
+	relDir = strings.TrimSuffix(relDir, "/")
+	if relDir == "." {
+		relDir = ""
+	}
+	for _, p := range m.patterns {
+		if !strings.HasPrefix(p, "!") {
+			continue
+		}
+		np := strings.TrimSpace(p[1:])
+		np = strings.TrimPrefix(np, "/")
+		np = strings.TrimSuffix(np, "/")
+		if np == "" {
+			continue
+		}
+		// A negation with no internal slash is unanchored: gitignore
+		// matches it at any depth, so it can re-include something under
+		// any directory. Keep descending.
+		if !strings.Contains(np, "/") {
+			return true
+		}
+		anchor := literalAnchor(np)
+		if anchor == "" {
+			// First segment is itself a wildcard ("*/...", "**/..."): it
+			// can match at varying depths, so stay conservative.
+			return true
+		}
+		// At the root, every anchored negation lives somewhere beneath us.
+		if relDir == "" {
+			return true
+		}
+		// The negation's match-set intersects relDir's subtree when its
+		// literal anchor sits at or under relDir, or relDir sits under the
+		// anchor (a wildcard tail can then still reach into relDir).
+		if anchor == relDir ||
+			strings.HasPrefix(anchor, relDir+"/") ||
+			strings.HasPrefix(relDir, anchor+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// literalAnchor returns the leading path segments of a slash-bearing
+// gitignore pattern up to (but excluding) the first segment that holds a
+// wildcard meta-character. It returns "" when the first segment is
+// itself a wildcard ("*", "**", "?foo", ...).
+func literalAnchor(pattern string) string {
+	segs := strings.Split(pattern, "/")
+	lit := make([]string, 0, len(segs))
+	for _, s := range segs {
+		if strings.ContainsAny(s, "*?[") {
+			break
+		}
+		lit = append(lit, s)
+	}
+	return strings.Join(lit, "/")
+}

--- a/internal/excludes/matcher_test.go
+++ b/internal/excludes/matcher_test.go
@@ -48,6 +48,100 @@ func TestMatcher_Negation(t *testing.T) {
 	}
 }
 
+func TestMatcher_HasNegatedDescendant(t *testing.T) {
+	cases := []struct {
+		name     string
+		patterns []string
+		relDir   string
+		want     bool
+	}{
+		{
+			// Issue #113: a blanket "dir/*" makes go-gitignore report the
+			// parent directory itself as excluded; the re-include lives
+			// beneath it, so the parent must keep being descended.
+			name:     "blanket plus reinclude under parent",
+			patterns: []string{"wp-content/plugins/*", "!wp-content/plugins/foo/"},
+			relDir:   "wp-content/plugins",
+			want:     true,
+		},
+		{
+			name:     "sibling without reinclude is prunable",
+			patterns: []string{"wp-content/plugins/*", "!wp-content/plugins/foo/"},
+			relDir:   "wp-content/plugins/other",
+			want:     false,
+		},
+		{
+			name:     "unrelated dir is prunable",
+			patterns: []string{"wp-content/plugins/*", "!wp-content/plugins/foo/"},
+			relDir:   "node_modules",
+			want:     false,
+		},
+		{
+			name:     "reinclude two levels down keeps grandparent",
+			patterns: []string{"a/*", "!a/b/c/"},
+			relDir:   "a",
+			want:     true,
+		},
+		{
+			name:     "reinclude two levels down keeps parent",
+			patterns: []string{"a/*", "!a/b/c/"},
+			relDir:   "a/b",
+			want:     true,
+		},
+		{
+			name:     "reinclude two levels down prunes uninvolved sibling",
+			patterns: []string{"a/*", "!a/b/c/", "!a/x"},
+			relDir:   "a/y",
+			want:     false,
+		},
+		{
+			name:     "unanchored basename negation keeps every dir",
+			patterns: []string{"build/", "!keep.txt"},
+			relDir:   "build",
+			want:     true,
+		},
+		{
+			name:     "wildcard-leading negation keeps every dir",
+			patterns: []string{"build/", "!**/keep/"},
+			relDir:   "build",
+			want:     true,
+		},
+		{
+			name:     "no negations never keeps",
+			patterns: []string{"build/", "dist/"},
+			relDir:   "build",
+			want:     false,
+		},
+		{
+			name:     "trailing-slash relDir is tolerated",
+			patterns: []string{"a/*", "!a/b/c/"},
+			relDir:   "a/b/",
+			want:     true,
+		},
+		{
+			name:     "leading-dot-slash relDir is tolerated",
+			patterns: []string{"a/*", "!a/b/c/"},
+			relDir:   "./a",
+			want:     true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := New(tc.patterns)
+			if got := m.HasNegatedDescendant(tc.relDir); got != tc.want {
+				t.Errorf("HasNegatedDescendant(%q) = %v, want %v", tc.relDir, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMatcher_HasNegatedDescendant_Nil(t *testing.T) {
+	var m *Matcher
+	if m.HasNegatedDescendant("anything") {
+		t.Fatal("nil matcher should report no negated descendants")
+	}
+}
+
 func TestMatcher_CommentsAndEmpty(t *testing.T) {
 	m := New([]string{"", "# comment", "foo/"})
 	pats := m.Patterns()

--- a/internal/indexer/gitignore_negation_test.go
+++ b/internal/indexer/gitignore_negation_test.go
@@ -1,0 +1,76 @@
+package indexer
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/excludes"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+// TestIndex_GitignoreDirNegation is the regression test for issue #113:
+// a WordPress repo blanket-ignores wp-content/plugins/* and re-includes
+// its custom plugins with "!wp-content/plugins/<name>/". go-gitignore's
+// "*" matches across "/", so the parent directory wp-content/plugins is
+// itself reported as excluded; the walk used to prune it with SkipDir
+// before ever reaching the re-included children, indexing only the
+// repo-root files. The walk must instead descend the parent and let the
+// per-file check honour the negation.
+func TestIndex_GitignoreDirNegation(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite := func(rel, content string) {
+		p := filepath.Join(dir, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+		writeFile(t, p, content)
+	}
+	php := func(fn string) string { return "<?php\nfunction " + fn + "() { return 1; }\n" }
+
+	// Re-included custom plugin — must be indexed, at any depth.
+	mustWrite("wp-content/plugins/foo/bar.php", php("fooBar"))
+	mustWrite("wp-content/plugins/foo/sub/deep.php", php("fooDeep"))
+	// Sibling plugin with no re-include — must stay excluded.
+	mustWrite("wp-content/plugins/other/baz.php", php("otherBaz"))
+
+	reg := parser.NewRegistry()
+	reg.Register(languages.NewPHPExtractor())
+	cfg := config.Default().Index
+	cfg.Workers = 2
+	// Emulate the layered exclude list ConfigManager hands the indexer
+	// when the repo's .gitignore carries the blanket + negation.
+	cfg.Exclude = append(append([]string{}, excludes.Builtin...),
+		"wp-content/plugins/*",
+		"!wp-content/plugins/foo/",
+	)
+
+	g := graph.New()
+	idx := New(g, reg, cfg, zap.NewNop())
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+
+	hasFile := func(suffix string) bool {
+		for _, n := range g.AllNodes() {
+			if strings.Contains(filepath.ToSlash(n.FilePath), suffix) {
+				return true
+			}
+		}
+		return false
+	}
+
+	if !hasFile("wp-content/plugins/foo/bar.php") {
+		t.Error("re-included plugin wp-content/plugins/foo/bar.php was not indexed")
+	}
+	if !hasFile("wp-content/plugins/foo/sub/deep.php") {
+		t.Error("re-included nested file wp-content/plugins/foo/sub/deep.php was not indexed")
+	}
+	if hasFile("wp-content/plugins/other/baz.php") {
+		t.Error("excluded sibling wp-content/plugins/other/baz.php leaked into the graph")
+	}
+}

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -1857,7 +1857,7 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 			return nil
 		}
 		if d.IsDir() {
-			if idx.shouldExclude(path, absRoot, true) {
+			if idx.shouldPruneDir(path, absRoot) {
 				return filepath.SkipDir
 			}
 			return nil
@@ -3757,6 +3757,30 @@ func (idx *Indexer) shouldExclude(path, root string, isDir bool) bool {
 	return idx.dirIgnoreMatcher(root).Match(path, isDir)
 }
 
+// shouldPruneDir reports whether the index walk may skip a directory
+// subtree wholesale (filepath.SkipDir) instead of descending it. A
+// directory is prunable only when it is excluded AND no re-include ("!")
+// pattern targets anything beneath it. go-gitignore's "*" matches across
+// "/", so a blanket like "wp-content/plugins/*" reports the parent
+// directory "wp-content/plugins" itself as excluded; pruning it would
+// skip a later "!wp-content/plugins/foo/" re-include before the walk ever
+// reaches the child. Mirroring git, we keep descending such a directory
+// and let the per-file shouldExclude check filter its contents.
+func (idx *Indexer) shouldPruneDir(path, root string) bool {
+	if !idx.shouldExclude(path, root, true) {
+		return false
+	}
+	if m := idx.excludeMatcher(); m != nil {
+		if rel, err := filepath.Rel(root, path); err == nil && m.HasNegatedDescendant(filepath.ToSlash(rel)) {
+			return false
+		}
+	}
+	if idx.dirIgnoreMatcher(root).HasNegatedDescendant(path) {
+		return false
+	}
+	return true
+}
+
 // dirIgnoreMatcher returns the per-directory ignore matcher, built lazily
 // against the repo root the index walk is anchored at.
 func (idx *Indexer) dirIgnoreMatcher(root string) *excludes.Hierarchical {
@@ -3933,7 +3957,7 @@ func (idx *Indexer) IncrementalReindexPaths(root string, paths []string) (*Index
 					return nil
 				}
 				if d.IsDir() {
-					if idx.shouldExclude(path, absRoot, true) {
+					if idx.shouldPruneDir(path, absRoot) {
 						return filepath.SkipDir
 					}
 					return nil
@@ -4162,7 +4186,7 @@ func (idx *Indexer) IncrementalReindex(root string) (*IndexResult, error) {
 			return nil
 		}
 		if d.IsDir() {
-			if idx.shouldExclude(path, absRoot, true) {
+			if idx.shouldPruneDir(path, absRoot) {
 				return filepath.SkipDir
 			}
 			return nil
@@ -6287,7 +6311,7 @@ func (idx *Indexer) HasChangesSinceMtimes(root string) bool {
 			return nil
 		}
 		if d.IsDir() {
-			if idx.shouldExclude(path, absRoot, true) {
+			if idx.shouldPruneDir(path, absRoot) {
 				return filepath.SkipDir
 			}
 			return nil


### PR DESCRIPTION
## Summary

Fixes the daemon-only failure reported in #113: a PHP/WordPress repo that blanket-ignores `wp-content/plugins/*` in `.gitignore` and re-includes its custom plugins with `!wp-content/plugins/<name>/` was indexed as **only the repo-root files** — the whole re-included plugin tree was silently dropped. The standalone `gortex index` succeeded because it doesn't consult `.gitignore`; the daemon does, which is why only it broke.

## Root cause

The index walk pruned **any** directory matching an exclude pattern with `filepath.SkipDir` before descending it:

```go
if d.IsDir() {
    if idx.shouldExclude(path, absRoot, true) { // true for "wp-content/plugins"
        return filepath.SkipDir                  // never descends
    }
    return nil
}
```

`go-gitignore`'s `*` matches across `/`, so the blanket `wp-content/plugins/*` reports the **parent** directory `wp-content/plugins` itself as excluded. The walk pruned that parent and never reached the later `!wp-content/plugins/foo/` re-include. Real git doesn't hit this because its `*` is single-segment, so it descends the parent and honours the negation per child.

The same bug silently broke workspace `Include:` force-includes (lowered to `!pattern`) of vendored / builtin-excluded subtrees.

## Fix

Make directory pruning negation-aware, mirroring git, which never prunes a directory a negation could resurrect a child from. A directory is skipped only when it is excluded **and** no re-include (`!`) pattern targets anything beneath it.

- `Matcher.HasNegatedDescendant(relDir)` — does any `!` pattern target a path under `relDir`? (anchored prefixes handled precisely; unanchored / wildcard-leading negations are treated conservatively so the directory keeps being descended)
- `Hierarchical.HasNegatedDescendant(absDir)` — the per-directory (`.gortexignore` / `.ignore` / `.rgignore`) counterpart
- `Indexer.shouldPruneDir` wraps `shouldExclude` with the negation check; all four index-walk prune sites (`IndexCtx`, `IncrementalReindex`, `IncrementalReindexPaths`, `HasChangesSinceMtimes`) route through it

Because `HasChangesSinceMtimes` is now negation-aware too, a warm restart actually discovers the re-included files instead of trusting a partial snapshot — which also mitigates the secondary "stale snapshot" symptom noted in the issue.

Common excludes (`node_modules/`, `vendor/`, …) have no `!` negations, so the prune fast-path is unchanged; the extra descent only happens for directories that genuinely have a re-included child.

## Tests

- `internal/excludes`: table tests for `Matcher.HasNegatedDescendant` and `Hierarchical.HasNegatedDescendant` (anchored, sibling, two-levels-deep, unanchored/wildcard, nil)
- `internal/indexer`: `TestIndex_GitignoreDirNegation` — an end-to-end walk over a WordPress-shaped tree asserting the re-included plugin (at any depth) is indexed while the un-re-included sibling stays excluded. Verified it **fails** before the fix and passes after.

`go build ./...` (CGO), `go test ./internal/excludes/ -race`, and the full `go test ./internal/indexer/` (613 tests) all pass.

Closes #113