### PR TITLE
Limit concurrent large file reads during indexing

### DIFF
--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -142,7 +142,7 @@ type Indexer struct {
 	// path so a query word matching it doesn't earn a useless uniform
 	// path-field boost across every document. "" disables the de-weighting.
 	projectName string
-	logger        *zap.Logger
+	logger      *zap.Logger
 
 	// Crash-isolation parser pool, lazily created and then reused
 	// across single-file re-indexes so the watcher hot path never
@@ -1898,6 +1898,7 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 		files = append(files, walkedFile{
 			path:      path,
 			lang:      lang,
+			size:      info.Size(),
 			mtimeNano: info.ModTime().UnixNano(),
 		})
 		return nil
@@ -2182,6 +2183,16 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 	var skippedByTimeout int64
 	var skippedByMinified int64
 
+	largeReadGate := make(chan struct{}, largeFileReadParallelism(workers))
+	readFile := func(wf walkedFile) ([]byte, error) {
+		if wf.size < largeFileReadThresholdBytes {
+			return os.ReadFile(wf.path)
+		}
+		largeReadGate <- struct{}{}
+		defer func() { <-largeReadGate }()
+		return os.ReadFile(wf.path)
+	}
+
 	// parseChunk runs the per-file worker pool over the supplied
 	// slice. Closure over outer state (errors, counters, contract
 	// registry, parsePool, quarantine) so it can be called multiple
@@ -2203,7 +2214,7 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 						reporter.Report("parsing", int(p), totalFiles)
 					}
 
-					src, err := os.ReadFile(path)
+					src, err := readFile(wf)
 					if err != nil {
 						errMu.Lock()
 						errors = append(errors, IndexError{FilePath: path, Error: err.Error()})

--- a/internal/indexer/skip_telemetry.go
+++ b/internal/indexer/skip_telemetry.go
@@ -63,7 +63,21 @@ type skippedFile struct {
 type walkedFile struct {
 	path      string
 	lang      string
+	size      int64
 	mtimeNano int64
+}
+
+// Files above this threshold are large enough that reading several of
+// them concurrently can dominate RSS before extraction even starts. Keep
+// normal source-file throughput high while bounding the “few huge PDFs /
+// spreadsheets / vector artifacts” class reported in #120.
+const largeFileReadThresholdBytes int64 = 16 << 20 // 16 MiB
+
+func largeFileReadParallelism(workers int) int {
+	if workers <= 1 {
+		return 1
+	}
+	return min(2, workers)
 }
 
 // extractWithTimeout runs ext.Extract under the per-file extraction

--- a/internal/indexer/skip_telemetry_test.go
+++ b/internal/indexer/skip_telemetry_test.go
@@ -60,6 +60,14 @@ func TestSizeSkipNode(t *testing.T) {
 	require.Equal(t, int64(9_000_000), n.Meta["file_size_bytes"])
 }
 
+func TestLargeFileReadParallelism(t *testing.T) {
+	require.Equal(t, 1, largeFileReadParallelism(0))
+	require.Equal(t, 1, largeFileReadParallelism(1))
+	require.Equal(t, 2, largeFileReadParallelism(2))
+	require.Equal(t, 2, largeFileReadParallelism(20))
+	require.Equal(t, int64(16<<20), largeFileReadThresholdBytes)
+}
+
 func TestTimeoutSkipResult(t *testing.T) {
 	r := timeoutSkipResult("huge.ts", "typescript", 10000)
 	require.Len(t, r.Nodes, 1)
@@ -81,7 +89,7 @@ func TestIndex_SizeSkipTelemetry(t *testing.T) {
 
 	result, err := idx.Index(dir)
 	require.NoError(t, err)
-	require.Equal(t, 1, result.FileCount)   // only small.go parsed
+	require.Equal(t, 1, result.FileCount)    // only small.go parsed
 	require.Equal(t, 1, result.SkippedFiles) // big.go skipped
 
 	n := g.GetNode("big.go")


### PR DESCRIPTION
## Summary

Adds a small back-pressure gate around `os.ReadFile` for files larger than 16 MiB during full indexing.

The goal is to address the #120 failure mode where a repo contains a few hundred large content artifacts (`pdf`, `pptx`, `xlsx`, vector/RAG outputs, etc.) and `workers == NumCPU` allows many huge files to be read into memory at once before extraction has a chance to flush/compact anything.

This keeps normal source-file parallelism unchanged, but limits large-file reads to at most 2 concurrent reads (1 when the worker count is <= 1). It is deliberately narrow: it does not change `MaxFileSize` defaults, skip behavior, parsers, graph logic, or DB batching.

## Why this shape

For code-heavy repos, most files are small, so existing worker throughput remains the same.
For content-heavy repos, peak read-side memory is bounded closer to:

`min(2, workers) × large_file_size`

instead of:

`workers × large_file_size`

which matches the issue discussion around memory being dominated by in-flight file reads/extractor expansion rather than the graph itself.

## Test

```bash
go test ./internal/indexer -run 'TestLargeFileReadParallelism|TestIndex_SizeSkipTelemetry|TestIndex_ExtractTimeoutSkip|TestSizeSkipNode'
```
