### PR TITLE
Bound index memory on content-heavy repos: shadow byte gate + content/code split

### DIFF
--- a/internal/analysis/communities.go
+++ b/internal/analysis/communities.go
@@ -69,6 +69,12 @@ func DetectCommunitiesLouvain(g graph.Store) *CommunityResult {
 		if graph.IsProxyNode(n) {
 			continue
 		}
+		// Content sections are leaf knowledge, not code structure — they
+		// must not form or join code communities (which seed the skills
+		// router and architecture layers).
+		if graph.IsContentNode(n) {
+			continue
+		}
 		if n.Kind != graph.KindFile && n.Kind != graph.KindImport {
 			symbolNodes[n.ID] = true
 		}

--- a/internal/graph/content.go
+++ b/internal/graph/content.go
@@ -15,3 +15,38 @@ func IsContentNode(n *Node) bool {
 	dc, _ := n.Meta["data_class"].(string)
 	return dc == "content"
 }
+
+// NonContentNodeReader is an optional store capability: a cheap (SQL-level
+// on the disk backend) enumeration of a repo's NON-content nodes, so the
+// code-oriented passes (search-index build, embedding, language detection)
+// never materialise a content-heavy repo's hundreds of thousands of content
+// sections just to iterate past them.
+type NonContentNodeReader interface {
+	GetRepoNonContentNodes(repoPrefix string) []*Node
+}
+
+// RepoCodeNodes returns repoPrefix's non-content nodes. It uses the store's
+// NonContentNodeReader fast path when available (the disk backend filters in
+// SQL, so 525k content sections never enter memory); otherwise it falls back
+// to materialising the repo's nodes and dropping content in Go — fine for the
+// in-memory store, which only backs small repos. An empty repoPrefix means
+// "all repos".
+func RepoCodeNodes(s Store, repoPrefix string) []*Node {
+	if r, ok := s.(NonContentNodeReader); ok {
+		return r.GetRepoNonContentNodes(repoPrefix)
+	}
+	var nodes []*Node
+	if repoPrefix != "" {
+		nodes = s.GetRepoNodes(repoPrefix)
+	}
+	if len(nodes) == 0 {
+		nodes = s.AllNodes()
+	}
+	out := make([]*Node, 0, len(nodes))
+	for _, n := range nodes {
+		if !IsContentNode(n) {
+			out = append(out, n)
+		}
+	}
+	return out
+}

--- a/internal/graph/content.go
+++ b/internal/graph/content.go
@@ -1,0 +1,17 @@
+package graph
+
+// IsContentNode reports whether n is a CONTENT section node — a KindDoc
+// chunk tagged data_class="content" (text / pdf / pptx / xlsx section
+// bodies). Content bodies are indexed in the dedicated content store
+// (ContentSearcher), never the symbol search, and are excluded from the
+// code-oriented analysis passes — so this predicate is the single place
+// every package agrees on what "content" means. Markdown prose (KindDoc
+// without data_class=content) and data assets (data_class="data") are NOT
+// content and keep their existing treatment.
+func IsContentNode(n *Node) bool {
+	if n == nil || n.Kind != KindDoc || n.Meta == nil {
+		return false
+	}
+	dc, _ := n.Meta["data_class"].(string)
+	return dc == "content"
+}

--- a/internal/graph/store.go
+++ b/internal/graph/store.go
@@ -408,6 +408,65 @@ type SymbolSearcher interface {
 	SearchSymbols(query string, limit int) ([]SymbolHit, error)
 }
 
+// ContentHit is one result from a ContentSearcher query: the content
+// section node's ID plus locating metadata (file + ordinal), its BM25
+// relevance score (higher = more relevant), and a short snippet excerpt
+// from the matched body for display.
+type ContentHit struct {
+	NodeID   string
+	FilePath string
+	Ordinal  int
+	Score    float64
+	Snippet  string
+}
+
+// ContentFTSItem is the payload AppendContent takes per content section:
+// the node's ID, its locating metadata, and the full section body. The
+// body is indexed in the content store and is deliberately NOT retained on
+// the graph node (the node keeps only a short snippet), so the symbol
+// index and the code-oriented passes stay free of bulk content text.
+type ContentFTSItem struct {
+	NodeID   string
+	FilePath string
+	Ordinal  int
+	Body     string
+}
+
+// ContentSearcher is an optional interface backends MAY implement to
+// expose a full-text index over CONTENT (data_class="content") section
+// text, kept physically separate from the symbol search (SymbolSearcher).
+// Content text never enters the symbol FTS or the code-oriented analysis
+// passes; it streams into this dedicated index per file during parsing, so
+// a content-heavy repo (a few hundred large PDFs / text dumps that explode
+// into hundreds of thousands of sections) cannot flood the symbol index or
+// pin every section body in graph nodes.
+//
+// Contract:
+//
+//   - WipeContent clears a repo's content rows before a full rebuild
+//     (empty prefix = whole table, single-repo / conformance behaviour).
+//
+//   - WipeContentFile clears one file's content rows — the incremental
+//     reindex path when a single content file changes.
+//
+//   - AppendContent inserts content rows for repoPrefix without wiping —
+//     the streamed per-file build path. Callers WipeContent (full) or
+//     WipeContentFile (incremental) first, then AppendContent each file's
+//     sections. Idempotent only in combination with a preceding wipe.
+//
+//   - SearchContent runs a query scoped to repoPrefix (empty = all repos)
+//     and returns hits ordered by score descending, each with a snippet.
+//
+//   - BuildContentIndex finalises the index after the bulk parse phase
+//     (segment merge / optimize). Idempotent — safe to call repeatedly.
+type ContentSearcher interface {
+	WipeContent(repoPrefix string) error
+	WipeContentFile(filePath string) error
+	AppendContent(repoPrefix string, items []ContentFTSItem) error
+	SearchContent(query, repoPrefix string, limit int) ([]ContentHit, error)
+	BuildContentIndex() error
+}
+
 // SymbolBundle is the rerank-shaped result of one search call: the
 // matched node, its BM25 score, AND the in/out edges the rerank
 // pipeline reads from. Backends that can compose this in a single

--- a/internal/graph/store.go
+++ b/internal/graph/store.go
@@ -459,12 +459,19 @@ type ContentFTSItem struct {
 //
 //   - BuildContentIndex finalises the index after the bulk parse phase
 //     (segment merge / optimize). Idempotent — safe to call repeatedly.
+//
+//   - ScanContent streams every stored content row (scoped to repoPrefix;
+//     empty = all repos) to fn with its FULL body — so a consumer that
+//     needs the whole section text (e.g. the content->code linker) reads it
+//     from here rather than the graph node, which keeps only a snippet.
+//     fn returns false to stop the scan early.
 type ContentSearcher interface {
 	WipeContent(repoPrefix string) error
 	WipeContentFile(filePath string) error
 	AppendContent(repoPrefix string, items []ContentFTSItem) error
 	SearchContent(query, repoPrefix string, limit int) ([]ContentHit, error)
 	BuildContentIndex() error
+	ScanContent(repoPrefix string, fn func(nodeID, filePath, body string) bool) error
 }
 
 // SymbolBundle is the rerank-shaped result of one search call: the

--- a/internal/graph/store_sqlite/content_node_filter_test.go
+++ b/internal/graph/store_sqlite/content_node_filter_test.go
@@ -1,0 +1,46 @@
+package store_sqlite
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// TestGetRepoNonContentNodes verifies the SQL-level content filter (which
+// json_extracts data_class out of the JSON meta blob) drops only content
+// section nodes — keeping code, markdown prose, and data assets — so the
+// code passes can enumerate without materialising content sections.
+func TestGetRepoNonContentNodes(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "n.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	s.AddBatch([]*graph.Node{
+		{ID: "code1", Kind: graph.KindFunction, Name: "Foo", RepoPrefix: "r"},
+		{ID: "content1", Kind: graph.KindDoc, Name: "doc.txt::0", RepoPrefix: "r",
+			Meta: map[string]any{"data_class": "content", "section_text": "x"}},
+		{ID: "prose1", Kind: graph.KindDoc, Name: "README.md::0", RepoPrefix: "r",
+			Meta: map[string]any{"asset_kind": "markdown_section"}},
+		{ID: "data1", Kind: graph.KindFile, Name: "x.parquet", RepoPrefix: "r",
+			Meta: map[string]any{"data_class": "data"}},
+	}, nil)
+
+	// Runtime assertion the store satisfies the optional capability.
+	var cr graph.NonContentNodeReader = s
+
+	ids := map[string]bool{}
+	for _, n := range cr.GetRepoNonContentNodes("r") {
+		ids[n.ID] = true
+	}
+	require.True(t, ids["code1"], "code node kept")
+	require.True(t, ids["prose1"], "markdown prose kept (not data_class=content)")
+	require.True(t, ids["data1"], "data asset kept (data_class=data, not content)")
+	require.False(t, ids["content1"], "content section dropped at the SQL level")
+	require.Len(t, ids, 3)
+
+	// Empty prefix spans all repos (still drops content).
+	require.Len(t, s.GetRepoNonContentNodes(""), 3)
+}

--- a/internal/graph/store_sqlite/schema.go
+++ b/internal/graph/store_sqlite/schema.go
@@ -244,4 +244,16 @@ CREATE INDEX IF NOT EXISTS blame_by_repo ON blame_enrichment(repo_prefix) WHERE 
 -- idempotent on every Open, so an existing .sqlite gains the vtable
 -- on its next open + reindex.
 CREATE VIRTUAL TABLE IF NOT EXISTS symbol_fts USING fts5(node_id UNINDEXED, repo_prefix UNINDEXED, tokens);
+
+-- content_fts is the FTS5 full-text index over CONTENT (data_class=
+-- "content") section bodies — text / pdf / pptx / xlsx chunks. It is
+-- kept SEPARATE from symbol_fts so content text never enters the symbol
+-- search or the code-oriented analysis passes: a content-heavy repo of a
+-- few hundred large documents explodes into hundreds of thousands of
+-- section nodes, and streaming their bodies here (per file, on disk)
+-- instead of into symbol_fts + graph nodes keeps the code index and the
+-- graph passes bounded. Only "body" is indexed for matching; node_id /
+-- repo_prefix / file_path / ordinal ride UNINDEXED so the per-repo and
+-- per-file staleness wipes hit literal columns without a b-tree.
+CREATE VIRTUAL TABLE IF NOT EXISTS content_fts USING fts5(node_id UNINDEXED, repo_prefix UNINDEXED, file_path UNINDEXED, ordinal UNINDEXED, body);
 `

--- a/internal/graph/store_sqlite/store.go
+++ b/internal/graph/store_sqlite/store.go
@@ -1134,6 +1134,43 @@ func (s *Store) queryNodes(stmt *sql.Stmt, args ...any) []*graph.Node {
 	return out
 }
 
+// GetRepoNonContentNodes is the graph.NonContentNodeReader fast path: a
+// SQL-level enumeration that drops CONTENT (data_class="content") section
+// nodes, so the code-oriented passes never materialise a content-heavy
+// repo's hundreds of thousands of sections. Meta is JSON (encodeMeta) in a
+// BLOB column, so json_extract reads it via CAST(... AS TEXT); the NULL-safe
+// `IS NOT 'content'` keeps every node whose meta is absent or carries any
+// other (or no) data_class. An empty repoPrefix spans all repos.
+func (s *Store) GetRepoNonContentNodes(repoPrefix string) []*graph.Node {
+	const filter = `json_extract(CAST(meta AS TEXT), '$.data_class') IS NOT 'content'`
+	if repoPrefix == "" {
+		return s.scanNodeQuery(`SELECT ` + lookupNodeCols + ` FROM nodes WHERE ` + filter)
+	}
+	return s.scanNodeQuery(`SELECT `+lookupNodeCols+` FROM nodes WHERE repo_prefix = ? AND `+filter, repoPrefix)
+}
+
+// scanNodeQuery runs an ad-hoc node SELECT (columns = lookupNodeCols) and
+// scans its rows into nodes — for the few non-hot enumerations that need a
+// WHERE clause the prepared statements don't cover.
+func (s *Store) scanNodeQuery(query string, args ...any) []*graph.Node {
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		panicOnFatal(err)
+		return nil
+	}
+	defer rows.Close()
+	var out []*graph.Node
+	for rows.Next() {
+		n, err := scanNode(rows)
+		if err != nil {
+			panicOnFatal(err)
+			return out
+		}
+		out = append(out, n)
+	}
+	return out
+}
+
 func (s *Store) GetOutEdges(nodeID string) []*graph.Edge {
 	return s.queryEdges(s.stmtOutEdges, nodeID)
 }

--- a/internal/graph/store_sqlite/store_content_fts.go
+++ b/internal/graph/store_sqlite/store_content_fts.go
@@ -1,6 +1,7 @@
 package store_sqlite
 
 import (
+	"database/sql"
 	"strings"
 
 	"github.com/zzet/gortex/internal/graph"
@@ -174,4 +175,32 @@ func (s *Store) SearchContent(query, repoPrefix string, limit int) ([]graph.Cont
 		return nil, err
 	}
 	return hits, nil
+}
+
+// ScanContent streams every content row (scoped to repoPrefix; empty = all
+// repos) to fn with its FULL body, read incrementally via a cursor so a
+// consumer iterating hundreds of thousands of sections stays bounded. fn
+// returns false to stop the scan early.
+func (s *Store) ScanContent(repoPrefix string, fn func(nodeID, filePath, body string) bool) error {
+	var rows *sql.Rows
+	var err error
+	if repoPrefix == "" {
+		rows, err = s.db.Query(`SELECT node_id, file_path, body FROM content_fts`)
+	} else {
+		rows, err = s.db.Query(`SELECT node_id, file_path, body FROM content_fts WHERE repo_prefix = ?`, repoPrefix)
+	}
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var nodeID, filePath, body string
+		if err := rows.Scan(&nodeID, &filePath, &body); err != nil {
+			return err
+		}
+		if !fn(nodeID, filePath, body) {
+			return nil
+		}
+	}
+	return rows.Err()
 }

--- a/internal/graph/store_sqlite/store_content_fts.go
+++ b/internal/graph/store_sqlite/store_content_fts.go
@@ -1,0 +1,177 @@
+package store_sqlite
+
+import (
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// This file implements graph.ContentSearcher on the SQLite backend using
+// the content_fts FTS5 virtual table declared in schema.go — the
+// dedicated, on-disk full-text index for CONTENT (data_class="content")
+// section bodies, kept physically separate from symbol_fts so content
+// text never reaches the symbol search or the code-oriented graph passes.
+//
+// Streamed build: WipeContent(repoPrefix) once at the start of a full
+// index, AppendContent each content file's sections as they are parsed
+// (no per-file wipe), then BuildContentIndex to merge segments.
+// Incremental reindex of one content file is WipeContentFile +
+// AppendContent.
+
+// Compile-time assertion: *Store satisfies the content-search capability.
+var _ graph.ContentSearcher = (*Store)(nil)
+
+// contentInsertChunkRows bounds rows per multi-row INSERT. Each row binds
+// 5 host params (node_id, repo_prefix, file_path, ordinal, body); 180 rows
+// is 900 params, comfortably under SQLite's default 999-variable limit.
+const contentInsertChunkRows = 180
+
+// WipeContent removes a repo's content rows before a full rebuild. Empty
+// repoPrefix wipes the whole table (single-repo / conformance behaviour).
+func (s *Store) WipeContent(repoPrefix string) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	_, err := s.db.Exec(`DELETE FROM content_fts WHERE repo_prefix = ?`, repoPrefix)
+	return err
+}
+
+// WipeContentFile removes one file's content rows — the incremental
+// reindex path when a single content file changes.
+func (s *Store) WipeContentFile(filePath string) error {
+	if filePath == "" {
+		return nil
+	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	_, err := s.db.Exec(`DELETE FROM content_fts WHERE file_path = ?`, filePath)
+	return err
+}
+
+// AppendContent inserts content rows for repoPrefix without wiping — the
+// streamed per-file build path. Callers wipe (whole repo or one file)
+// first. Rows with an empty NodeID are skipped.
+func (s *Store) AppendContent(repoPrefix string, items []graph.ContentFTSItem) error {
+	if len(items) == 0 {
+		return nil
+	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	commit := false
+	defer func() {
+		if !commit {
+			_ = tx.Rollback()
+		}
+	}()
+
+	for start := 0; start < len(items); start += contentInsertChunkRows {
+		end := minInt(start+contentInsertChunkRows, len(items))
+		chunk := items[start:end]
+
+		var b strings.Builder
+		b.WriteString(`INSERT INTO content_fts (node_id, repo_prefix, file_path, ordinal, body) VALUES `)
+		args := make([]any, 0, len(chunk)*5)
+		for _, it := range chunk {
+			if it.NodeID == "" {
+				continue
+			}
+			if len(args) > 0 {
+				b.WriteByte(',')
+			}
+			b.WriteString(`(?,?,?,?,?)`)
+			args = append(args, it.NodeID, repoPrefix, it.FilePath, it.Ordinal, it.Body)
+		}
+		if len(args) == 0 {
+			continue
+		}
+		if _, err := tx.Exec(b.String(), args...); err != nil {
+			return err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	commit = true
+	return nil
+}
+
+// BuildContentIndex opportunistically merges FTS5 segments (a read-latency
+// improvement). Like BuildSymbolIndex it is a no-op for correctness — the
+// FTS index is maintained incrementally on every insert — and idempotent.
+func (s *Store) BuildContentIndex() error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	_, _ = s.db.Exec(`INSERT INTO content_fts(content_fts) VALUES('optimize')`)
+	return nil
+}
+
+// SearchContent runs a content query scoped to repoPrefix (empty = all
+// repos) and returns hits ordered by descending relevance, each carrying a
+// short snippet excerpt from the matched body. Reuses the symbol path's
+// write-side tokeniser (buildFTSMatch) so the content corpus and queries
+// agree on camelCase / path-separator splitting.
+func (s *Store) SearchContent(query, repoPrefix string, limit int) ([]graph.ContentHit, error) {
+	if query == "" {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	match := s.buildFTSMatch(query)
+	if match == "" {
+		return nil, nil
+	}
+
+	var sb strings.Builder
+	// snippet() over the body column (index 4): no highlight marks, an
+	// ellipsis for elision, ~16 tokens of context. CAST(ordinal AS INTEGER)
+	// forces integer affinity so the FTS5 text column scans cleanly into an
+	// int.
+	sb.WriteString(`SELECT node_id, file_path, CAST(ordinal AS INTEGER), snippet(content_fts, 4, '', '', '…', 16), bm25(content_fts) FROM content_fts WHERE content_fts MATCH ?`)
+	args := []any{match}
+	if repoPrefix != "" {
+		sb.WriteString(` AND repo_prefix = ?`)
+		args = append(args, repoPrefix)
+	}
+	sb.WriteString(` ORDER BY bm25(content_fts) LIMIT ?`)
+	args = append(args, limit)
+
+	rows, err := s.db.Query(sb.String(), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var hits []graph.ContentHit
+	for rows.Next() {
+		var (
+			id, fp, snip string
+			ordinal      int
+			score        float64
+		)
+		if err := rows.Scan(&id, &fp, &ordinal, &snip, &score); err != nil {
+			return nil, err
+		}
+		if id == "" {
+			continue
+		}
+		// bm25() is negative-better in SQLite; negate so higher = better,
+		// matching the ContentHit contract. Rows already arrive best-first.
+		hits = append(hits, graph.ContentHit{
+			NodeID:   id,
+			FilePath: fp,
+			Ordinal:  ordinal,
+			Score:    -score,
+			Snippet:  snip,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return hits, nil
+}

--- a/internal/graph/store_sqlite/store_content_fts_test.go
+++ b/internal/graph/store_sqlite/store_content_fts_test.go
@@ -1,0 +1,82 @@
+package store_sqlite
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestContentFTS_BasicAndFileWipe(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "c.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	var cs graph.ContentSearcher = s // runtime assertion the store satisfies the capability
+
+	require.NoError(t, cs.WipeContent("")) // clean table
+	items := []graph.ContentFTSItem{
+		{NodeID: "a.txt::doc:section-0", FilePath: "a.txt", Ordinal: 0, Body: "the quick brown fox jumps over the lazy dog"},
+		{NodeID: "a.txt::doc:section-1", FilePath: "a.txt", Ordinal: 1, Body: "lorem ipsum dolor sit amet consectetur"},
+		{NodeID: "b.pdf::doc:pdf_page-0", FilePath: "b.pdf", Ordinal: 0, Body: "quantum entanglement and superposition explained"},
+	}
+	require.NoError(t, cs.AppendContent("", items))
+	require.NoError(t, cs.BuildContentIndex())
+
+	// A body term resolves to exactly its section, with a non-empty snippet.
+	hits, err := cs.SearchContent("quantum", "", 10)
+	require.NoError(t, err)
+	require.Len(t, hits, 1)
+	require.Equal(t, "b.pdf::doc:pdf_page-0", hits[0].NodeID)
+	require.Equal(t, "b.pdf", hits[0].FilePath)
+	require.Equal(t, 0, hits[0].Ordinal)
+	require.NotEmpty(t, hits[0].Snippet)
+
+	hits, err = cs.SearchContent("fox", "", 10)
+	require.NoError(t, err)
+	require.Len(t, hits, 1)
+	require.Equal(t, "a.txt::doc:section-0", hits[0].NodeID)
+	require.Equal(t, 0, hits[0].Ordinal)
+
+	// WipeContentFile drops only a.txt's rows; b.pdf survives.
+	require.NoError(t, cs.WipeContentFile("a.txt"))
+	hits, err = cs.SearchContent("fox", "", 10)
+	require.NoError(t, err)
+	require.Empty(t, hits)
+	hits, err = cs.SearchContent("quantum", "", 10)
+	require.NoError(t, err)
+	require.Len(t, hits, 1)
+}
+
+func TestContentFTS_RepoScoping(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "c.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	require.NoError(t, s.AppendContent("repoA", []graph.ContentFTSItem{
+		{NodeID: "repoA::x.txt::doc:section-0", FilePath: "x.txt", Body: "alpha beta gamma"},
+	}))
+	require.NoError(t, s.AppendContent("repoB", []graph.ContentFTSItem{
+		{NodeID: "repoB::y.txt::doc:section-0", FilePath: "y.txt", Body: "alpha delta epsilon"},
+	}))
+
+	// Scoped search returns only the matching repo's hit.
+	hits, err := s.SearchContent("alpha", "repoA", 10)
+	require.NoError(t, err)
+	require.Len(t, hits, 1)
+	require.Equal(t, "repoA::x.txt::doc:section-0", hits[0].NodeID)
+
+	// Unscoped search spans both repos.
+	hits, err = s.SearchContent("alpha", "", 10)
+	require.NoError(t, err)
+	require.Len(t, hits, 2)
+
+	// WipeContent scopes to one repo, leaving the sibling intact.
+	require.NoError(t, s.WipeContent("repoA"))
+	hits, err = s.SearchContent("alpha", "", 10)
+	require.NoError(t, err)
+	require.Len(t, hits, 1)
+	require.Equal(t, "repoB::y.txt::doc:section-0", hits[0].NodeID)
+}

--- a/internal/indexer/content_embed_exclusion_test.go
+++ b/internal/indexer/content_embed_exclusion_test.go
@@ -1,0 +1,41 @@
+package indexer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+)
+
+// TestCollectEmbedTexts_SkipsContent verifies C3: content (data_class=
+// content) section nodes are excluded from the vector embedding pass, so a
+// content-heavy repo's hundreds of thousands of sections never enter the
+// embed-text count (nor trip the 100k auto-disable). Code symbols are
+// embedded as before.
+func TestCollectEmbedTexts_SkipsContent(t *testing.T) {
+	idx := New(graph.New(), parser.NewRegistry(), config.Default().Index, zap.NewNop())
+
+	nodes := []*graph.Node{
+		{ID: "code1", Kind: graph.KindFunction, Name: "Foo", Language: "go"},
+		{ID: "code2", Kind: graph.KindMethod, Name: "Bar", Language: "go"},
+		{ID: "content1", Kind: graph.KindDoc, Name: "doc.txt::section-0",
+			Meta: map[string]any{"data_class": "content", "section_text": "hello content world"}},
+		{ID: "prose1", Kind: graph.KindDoc, Name: "README.md::section-0",
+			Meta: map[string]any{"section_text": "markdown prose about code"}},
+	}
+
+	_, ids, _, skipped := idx.collectEmbedTexts(nodes)
+
+	require.Contains(t, ids, "code1")
+	require.Contains(t, ids, "code2")
+	require.NotContains(t, ids, "content1",
+		"content section node must be excluded from the embedding pass")
+	require.Positive(t, skipped, "the content node must count as skipped")
+	// Markdown prose (no data_class=content) is unaffected.
+	require.Contains(t, ids, "prose1",
+		"markdown prose must still be embedded")
+}

--- a/internal/indexer/content_linking.go
+++ b/internal/indexer/content_linking.go
@@ -44,37 +44,57 @@ func (idx *Indexer) linkContentToCode() {
 	var edges []*graph.Edge
 	added := 0
 	truncated := false
-	for _, chunk := range g.AllNodes() {
-		if chunk == nil || chunk.Kind != graph.KindDoc || chunk.Meta == nil {
-			continue
-		}
-		if dc, _ := chunk.Meta["data_class"].(string); dc != "content" {
-			continue
-		}
-		text, _ := chunk.Meta["section_text"].(string)
+
+	// emit scans one chunk's FULL body for symbol references and mints the
+	// EdgeMotivates edges, honouring the single edge budget. Returns false
+	// when the budget is exhausted so the caller stops the scan.
+	emit := func(chunkID, filePath, text string) bool {
 		if text == "" {
-			continue
+			return true
 		}
 		signal := mineDocSignal(text)
 		for _, sym := range artifacts.ScanSymbolRefs([]byte(text), nameIndex) {
-			if sym == chunk.ID {
+			if sym == chunkID {
 				continue
 			}
 			if added >= budget {
 				truncated = true
-				break
+				return false
 			}
 			edges = append(edges, &graph.Edge{
-				From: chunk.ID, To: sym, Kind: graph.EdgeMotivates,
-				FilePath: chunk.FilePath, Origin: graph.OriginTextMatched,
+				From: chunkID, To: sym, Kind: graph.EdgeMotivates,
+				FilePath: filePath, Origin: graph.OriginTextMatched,
 				Meta: map[string]any{"signal": signal},
 			})
 			added++
 		}
-		if truncated {
-			break
+		return true
+	}
+
+	if cs := idx.contentSearcher(); cs != nil {
+		// Disk path: read FULL section bodies from the content index — the
+		// graph node keeps only a snippet — streamed so a content-heavy
+		// repo's hundreds of thousands of sections never materialise here.
+		// contentSearcher() resolves the disk sink even while idx.graph is
+		// the in-memory shadow (where the content rows were streamed to disk).
+		_ = cs.ScanContent(idx.repoPrefix, func(nodeID, filePath, body string) bool {
+			return emit(nodeID, filePath, body)
+		})
+	} else {
+		// In-memory fallback: with no content index the full text is still on
+		// the nodes (streamContentSections leans only when a content searcher
+		// exists), so scan the graph nodes directly.
+		for _, chunk := range g.AllNodes() {
+			if !graph.IsContentNode(chunk) {
+				continue
+			}
+			text, _ := chunk.Meta["section_text"].(string)
+			if !emit(chunk.ID, chunk.FilePath, text) {
+				break
+			}
 		}
 	}
+
 	if len(edges) > 0 {
 		g.AddBatch(nil, edges)
 	}

--- a/internal/indexer/content_linking_fullbody_test.go
+++ b/internal/indexer/content_linking_fullbody_test.go
@@ -1,0 +1,66 @@
+package indexer
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+// TestContentLink_UsesFullBodyNotSnippet verifies C8: the content->code
+// linker matches symbol references against the FULL section body (streamed
+// from the content index) rather than the leaned node snippet. The symbol
+// name is placed well past the snippet cap, so a link can only be minted if
+// the linker read the whole body. linkContentToCode is the post-index global
+// pass (RunGlobalGraphPasses), so the test drives it explicitly after IndexCtx.
+func TestContentLink_UsesFullBodyNotSnippet(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "code.go"), "package p\n\nfunc ZzWidgetMaker() {}\n")
+	// "ZzWidgetMaker" appears only after ~480 chars of filler — beyond the
+	// 240-byte snippet the node retains, so it lives only in the content index.
+	body := strings.Repeat("filler word ", 40) + " ZzWidgetMaker is described in this specification"
+	writeFile(t, filepath.Join(dir, "spec.txt"), body)
+
+	store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "s.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	reg := parser.NewRegistry()
+	languages.RegisterAll(reg)
+	cfg := config.Default().Index
+	cfg.Workers = 2
+	idx := New(store, reg, cfg, zap.NewNop())
+	_, err = idx.IndexCtx(context.Background(), dir)
+	require.NoError(t, err)
+
+	// Sanity: the content node's retained snippet does NOT contain the symbol.
+	for _, n := range store.AllNodes() {
+		if isContentNode(n) {
+			st, _ := n.Meta["section_text"].(string)
+			require.NotContains(t, st, "ZzWidgetMaker",
+				"precondition: the symbol must live past the node snippet")
+		}
+	}
+
+	// Drive the post-index content->code linking pass.
+	idx.linkContentToCode()
+
+	// The link must exist — proving it came from the full body, not the snippet.
+	var linked bool
+	for _, e := range store.AllEdges() {
+		if e.Kind == graph.EdgeMotivates && strings.Contains(e.To, "ZzWidgetMaker") {
+			linked = true
+		}
+	}
+	require.True(t, linked,
+		"content->code link must be minted from the full body (symbol past the snippet cap)")
+}

--- a/internal/indexer/content_split.go
+++ b/internal/indexer/content_split.go
@@ -1,0 +1,172 @@
+package indexer
+
+import (
+	"unicode/utf8"
+
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// contentSnippetCap bounds how much of a CONTENT (data_class="content")
+// section body is retained on the graph node after its full text has been
+// streamed into the dedicated content index. The full body lives in the
+// content FTS; the node keeps only this much for display (the why-layer,
+// get_symbol_source) — so a repo of hundreds of thousands of sections
+// holds ~240 B × N in the graph instead of ~4 KB × N (~17× less text).
+const contentSnippetCap = 240
+
+// isContentNode reports whether n is a CONTENT section node
+// (data_class="content") — text / pdf / pptx / xlsx chunks carrying a
+// section body. Markdown prose (KindDoc without data_class=content) and
+// data assets (data_class="data") are deliberately excluded so they keep
+// their existing treatment in the symbol search.
+func isContentNode(n *graph.Node) bool {
+	if n == nil || n.Kind != graph.KindDoc || n.Meta == nil {
+		return false
+	}
+	dc, _ := n.Meta["data_class"].(string)
+	return dc == "content"
+}
+
+// contentBody returns the full section text carried on a content node, or
+// "" if absent.
+func contentBody(n *graph.Node) string {
+	if n.Meta == nil {
+		return ""
+	}
+	b, _ := n.Meta["section_text"].(string)
+	return b
+}
+
+// metaInt reads an integer-valued Meta key, tolerating the int / int64 /
+// float64 forms a value can take across a gob round-trip.
+func metaInt(meta map[string]any, key string) int {
+	switch v := meta[key].(type) {
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	default:
+		return 0
+	}
+}
+
+// contentOrdinal returns the section's ordinal — "ordinal" for text /
+// office chunks, "page" for PDF pages.
+func contentOrdinal(n *graph.Node) int {
+	if o := metaInt(n.Meta, "ordinal"); o != 0 {
+		return o
+	}
+	return metaInt(n.Meta, "page")
+}
+
+// safeTruncate returns s clamped to at most maxBytes, never splitting a
+// multi-byte rune.
+func safeTruncate(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	cut := maxBytes
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut]
+}
+
+// leanContentNode strips a content node's full section body down to a
+// capped snippet once the full text has been captured for the content
+// index. The key stays "section_text" so display consumers keep working;
+// only the length changes. "content_indexed" marks that the full body
+// lives in the content index (so a reader knows the snippet is partial).
+func leanContentNode(n *graph.Node) {
+	body := contentBody(n)
+	if len(body) <= contentSnippetCap {
+		return
+	}
+	n.Meta["section_text"] = safeTruncate(body, contentSnippetCap)
+	n.Meta["content_indexed"] = true
+}
+
+// collectContentItems pulls one ContentFTSItem per content section node in
+// the batch, carrying the FULL body for the content index. Returns nil
+// when the batch has no content.
+func collectContentItems(nodes []*graph.Node) []graph.ContentFTSItem {
+	var items []graph.ContentFTSItem
+	for _, n := range nodes {
+		if !isContentNode(n) {
+			continue
+		}
+		body := contentBody(n)
+		if body == "" {
+			continue
+		}
+		items = append(items, graph.ContentFTSItem{
+			NodeID:   n.ID,
+			FilePath: n.FilePath,
+			Ordinal:  contentOrdinal(n),
+			Body:     body,
+		})
+	}
+	return items
+}
+
+// firstContentFilePath returns the FilePath of the first content node in
+// the batch (all of one file's content nodes share it), or "" if none. The
+// incremental reindex path uses it to wipe a single file's content rows
+// before re-streaming.
+func firstContentFilePath(nodes []*graph.Node) string {
+	for _, n := range nodes {
+		if isContentNode(n) {
+			return n.FilePath
+		}
+	}
+	return ""
+}
+
+// contentSearcher returns the ContentSearcher this index writes content
+// section bodies to: the disk sink captured at the shadow swap (so content
+// reaches disk even while idx.graph is the in-memory shadow), else
+// idx.graph itself when it is a disk store. Returns nil for an in-memory
+// store with no content index — in which case content text is left on the
+// nodes and falls back to the symbol search (the small-repo / CLI case).
+func (idx *Indexer) contentSearcher() graph.ContentSearcher {
+	if idx.contentSink != nil {
+		return idx.contentSink
+	}
+	if cs, ok := idx.graph.(graph.ContentSearcher); ok {
+		return cs
+	}
+	return nil
+}
+
+// streamContentSections is the per-file content path: it streams a parsed
+// file's content section bodies into the dedicated content index, then
+// leans the nodes to a snippet — so the bulk text never enters the graph,
+// the symbol search, or the materialising code passes. Called in the parse
+// worker before AddBatch, so the nodes added to the graph are already
+// lean. A nil content searcher (in-memory store) leaves the nodes full.
+func (idx *Indexer) streamContentSections(nodes []*graph.Node) {
+	cs := idx.contentSearcher()
+	if cs == nil {
+		return
+	}
+	items := collectContentItems(nodes)
+	if len(items) == 0 {
+		return
+	}
+	if err := cs.AppendContent(idx.RepoPrefix(), items); err != nil {
+		// Keep the full body on the nodes if the append failed, so content
+		// stays searchable via the symbol-search fallback rather than lost.
+		idx.logger.Warn("indexer: content index append failed; leaving section text on nodes",
+			zap.Error(err))
+		return
+	}
+	for _, n := range nodes {
+		if isContentNode(n) {
+			leanContentNode(n)
+		}
+	}
+}

--- a/internal/indexer/content_split.go
+++ b/internal/indexer/content_split.go
@@ -16,17 +16,10 @@ import (
 // holds ~240 B × N in the graph instead of ~4 KB × N (~17× less text).
 const contentSnippetCap = 240
 
-// isContentNode reports whether n is a CONTENT section node
-// (data_class="content") — text / pdf / pptx / xlsx chunks carrying a
-// section body. Markdown prose (KindDoc without data_class=content) and
-// data assets (data_class="data") are deliberately excluded so they keep
-// their existing treatment in the symbol search.
+// isContentNode is the indexer-local alias for graph.IsContentNode — the
+// shared predicate for a CONTENT section node (KindDoc, data_class=content).
 func isContentNode(n *graph.Node) bool {
-	if n == nil || n.Kind != graph.KindDoc || n.Meta == nil {
-		return false
-	}
-	dc, _ := n.Meta["data_class"].(string)
-	return dc == "content"
+	return graph.IsContentNode(n)
 }
 
 // contentBody returns the full section text carried on a content node, or

--- a/internal/indexer/content_split_test.go
+++ b/internal/indexer/content_split_test.go
@@ -1,0 +1,79 @@
+package indexer
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+// TestContentSplit_StreamedToIndexAndLeaned verifies the C1 contract: a
+// content file's section bodies are streamed into the dedicated content
+// index (searchable, full text) while the graph nodes are leaned to a
+// capped snippet. Proven by a unique marker placed BEYOND the snippet cap:
+// it must be findable via the content index but absent from the node.
+// Run on both the shadow path (generous byte budget) and the non-shadow
+// disk path (tiny budget forces Fix B's per-call route).
+func TestContentSplit_StreamedToIndexAndLeaned(t *testing.T) {
+	for _, tc := range []struct{ name, budget string }{
+		{"shadow_path", "1073741824"}, // 1 GiB — the tiny repo takes the in-memory shadow
+		{"disk_path", "1"},            // 1 byte — forces the bounded non-shadow disk path
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("GORTEX_SHADOW_MAX_BYTES", tc.budget)
+			dir := t.TempDir()
+			// One section (< 4000 chars): a head marker inside the snippet,
+			// filler, then a tail marker past the 240-byte snippet cap.
+			body := "zzheadmarker " + strings.Repeat("filler word ", 60) + " zztailmarker"
+			writeFile(t, filepath.Join(dir, "doc.txt"), body)
+
+			store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "store.sqlite"))
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = store.Close() })
+
+			reg := parser.NewRegistry()
+			languages.RegisterAll(reg)
+			cfg := config.Default().Index
+			cfg.Workers = 2
+			_, err = New(store, reg, cfg, zap.NewNop()).IndexCtx(context.Background(), dir)
+			require.NoError(t, err)
+
+			// The full body is searchable via the content index — including
+			// the tail marker that lives only past the node snippet, proving
+			// the index holds the whole body, not just the snippet.
+			hits, err := store.SearchContent("zztailmarker", "", 10)
+			require.NoError(t, err)
+			require.NotEmpty(t, hits, "full content body must be searchable via the content index")
+			require.Contains(t, hits[0].NodeID, "doc.txt")
+
+			// The content node is lean: section_text is a capped snippet, the
+			// tail marker is gone from the node, and it is marked indexed.
+			var contentNodes int
+			for _, n := range store.AllNodes() {
+				if !isContentNode(n) {
+					continue
+				}
+				contentNodes++
+				st, _ := n.Meta["section_text"].(string)
+				require.LessOrEqual(t, len(st), contentSnippetCap,
+					"content node section_text must be trimmed to the snippet cap")
+				require.NotContains(t, st, "zztailmarker",
+					"the full body must not remain on the node")
+				require.Equal(t, true, n.Meta["content_indexed"],
+					"content node must be marked content_indexed")
+			}
+			require.Positive(t, contentNodes, "expected at least one content section node")
+
+			_ = graph.ContentSearcher(store) // store satisfies the capability
+		})
+	}
+}

--- a/internal/indexer/content_symbol_exclusion_test.go
+++ b/internal/indexer/content_symbol_exclusion_test.go
@@ -1,0 +1,69 @@
+package indexer
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+// TestContentSplit_ExcludedFromSymbolSearch verifies C2: content
+// (data_class=content) section bodies never enter the symbol search — a
+// body term yields no content node from SearchSymbols — while remaining
+// findable via the dedicated content index, and code symbol search is
+// unaffected.
+func TestContentSplit_ExcludedFromSymbolSearch(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "doc.txt"),
+		"zzcontentterm "+strings.Repeat("filler word ", 60))
+	writeFile(t, filepath.Join(dir, "code.go"),
+		"package p\n\nfunc ZzCodeFunc() {}\n")
+
+	store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "store.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	reg := parser.NewRegistry()
+	languages.RegisterAll(reg)
+	cfg := config.Default().Index
+	cfg.Workers = 2
+	_, err = New(store, reg, cfg, zap.NewNop()).IndexCtx(context.Background(), dir)
+	require.NoError(t, err)
+
+	// Content nodes exist in the graph...
+	var contentExists bool
+	for _, n := range store.AllNodes() {
+		if isContentNode(n) {
+			contentExists = true
+			break
+		}
+	}
+	require.True(t, contentExists, "content section nodes must exist in the graph")
+
+	// ...but the symbol search returns no content node for a body term.
+	symHits, err := store.SearchSymbols("zzcontentterm", 50)
+	require.NoError(t, err)
+	for _, h := range symHits {
+		n := store.GetNode(h.NodeID)
+		require.False(t, n != nil && isContentNode(n),
+			"content node leaked into symbol search: %s", h.NodeID)
+	}
+
+	// The content index does return it.
+	cHits, err := store.SearchContent("zzcontentterm", "", 10)
+	require.NoError(t, err)
+	require.NotEmpty(t, cHits, "content term must be findable via the content index")
+
+	// Code symbol search is unaffected.
+	codeHits, err := store.SearchSymbols("ZzCodeFunc", 10)
+	require.NoError(t, err)
+	require.NotEmpty(t, codeHits, "code symbol search must still work")
+}

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -1976,6 +1976,20 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 	// so disk-non-empty is safe.
 	firstIndex := idx.indexCount.Load() == 0
 	belowShadowMax := len(files) <= shadowMaxFileCount()
+	// The file-count ceiling is blind to the few-huge-files shape: a
+	// content repo of a few hundred PDFs / text dumps / spreadsheets is
+	// far under shadowMaxFileCount yet holds multiple GB that explode
+	// into hundreds of thousands of section nodes. Gate the in-memory
+	// shadow on total input bytes too, so such a repo falls through to
+	// the bounded per-call disk path instead of pinning the whole
+	// post-parse graph in RAM and OOMing (see #120).
+	var totalFileBytes int64
+	for i := range files {
+		totalFileBytes += files[i].size
+	}
+	maxShadowBytes := shadowMaxBytes()
+	belowShadowBytes := totalFileBytes <= maxShadowBytes
+	shadowTaken := blOK && firstIndex && belowShadowMax && belowShadowBytes
 	preNodes := idx.graph.NodeCount()
 	preEdges := idx.graph.EdgeCount()
 	idx.logger.Info("indexer: shadow-swap decision",
@@ -1987,9 +2001,12 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 		zap.Int("files", len(files)),
 		zap.Int("shadow_max_files", shadowMaxFileCount()),
 		zap.Bool("below_shadow_max", belowShadowMax),
-		zap.Bool("shadow_taken", blOK && firstIndex && belowShadowMax),
+		zap.Int64("total_file_bytes", totalFileBytes),
+		zap.Int64("shadow_max_bytes", maxShadowBytes),
+		zap.Bool("below_shadow_bytes", belowShadowBytes),
+		zap.Bool("shadow_taken", shadowTaken),
 	)
-	if blOK && firstIndex && belowShadowMax {
+	if shadowTaken {
 		// Warm-restart safety. `firstIndex` is a PER-INDEXER sentinel, and
 		// a fresh per-repo Indexer is constructed on every daemon restart,
 		// so firstIndex is true on every restart — even when the
@@ -2149,10 +2166,14 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 			}
 		}()
 	} else if diskTarget == nil && idx.graph.NodeCount() == 0 && idx.graph.EdgeCount() == 0 {
-		if _, isBulk := idx.graph.(graph.BulkLoader); isBulk && len(files) > shadowMaxFileCount() {
-			idx.logger.Info("indexer: skipping in-memory shadow above threshold",
+		if _, isBulk := idx.graph.(graph.BulkLoader); isBulk && firstIndex && (!belowShadowMax || !belowShadowBytes) {
+			idx.logger.Info("indexer: skipping in-memory shadow; building against disk store (bounded RAM)",
 				zap.Int("files", len(files)),
-				zap.Int("threshold", shadowMaxFileCount()))
+				zap.Int("file_threshold", shadowMaxFileCount()),
+				zap.Bool("over_file_count", !belowShadowMax),
+				zap.Int64("total_file_bytes", totalFileBytes),
+				zap.Int64("byte_threshold", maxShadowBytes),
+				zap.Bool("over_byte_budget", !belowShadowBytes))
 		}
 	}
 

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -3698,12 +3698,13 @@ func flattenEmbedResults(results [][][]float32) [][]float32 {
 // AllNodes() path because nodes there carry an empty RepoPrefix and
 // GetRepoNodes("") would miss them.
 func (idx *Indexer) buildSearchIndex() {
-	var nodes []*graph.Node
-	if idx.repoPrefix != "" {
-		nodes = idx.graph.GetRepoNodes(idx.repoPrefix)
-	} else {
-		nodes = idx.graph.AllNodes()
-	}
+	// Code-only enumeration: content (data_class=content) sections live in
+	// the content index, never the symbol search or the vector store, so the
+	// FTS loop below and collectEmbedTexts both skip them anyway. Fetching
+	// the non-content set up front means a content-heavy repo's hundreds of
+	// thousands of sections never enter memory here (the disk backend filters
+	// them in SQL), instead of being materialised only to be skipped.
+	nodes := graph.RepoCodeNodes(idx.graph, idx.repoPrefix)
 
 	// Install the learned sub-word boundary table on the BM25 layer
 	// before populating postings, so the optional sparse-ngram

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -210,6 +210,13 @@ type Indexer struct {
 	// Set during the shadow swap, cleared when idx.graph is restored.
 	bulkVectorSink graph.VectorSearcher
 
+	// contentSink mirrors bulkVectorSink for the content full-text index:
+	// the disk store captured at the shadow swap, so the per-file content
+	// stream reaches content_fts on disk even while idx.graph points at the
+	// in-memory shadow (which does not implement graph.ContentSearcher).
+	// Set during the shadow swap, cleared when idx.graph is restored.
+	contentSink graph.ContentSearcher
+
 	// embedChunkOpts tunes the AST sub-chunking buildSearchIndex applies
 	// to large symbols before embedding. The zero value makes the
 	// chunker fall back to its package defaults.
@@ -2040,6 +2047,9 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 		// FK to `nodes`, so upserting before FlushBulk persists the nodes is
 		// safe. Cleared when idx.graph is restored below.
 		idx.bulkVectorSink, _ = diskTarget.(graph.VectorSearcher)
+		// Same capture for the content index: the per-file content stream
+		// must reach content_fts on disk while idx.graph is the shadow.
+		idx.contentSink, _ = diskTarget.(graph.ContentSearcher)
 		// The resolver was constructed at indexer.New with the disk
 		// Store. Redirect it at the shadow too, otherwise ResolveAll
 		// reads from the empty disk Store, finds no pending edges,
@@ -2053,6 +2063,7 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 			if retErr != nil {
 				idx.graph = diskTarget
 				idx.bulkVectorSink = nil
+				idx.contentSink = nil
 				if idx.resolver != nil {
 					idx.resolver.SetGraph(diskTarget)
 				}
@@ -2156,6 +2167,7 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 			reporter.Report("persisting bulk graph", 1, 1)
 			idx.graph = diskTarget
 			idx.bulkVectorSink = nil
+			idx.contentSink = nil
 			// Mirror of the SetGraph(inMemShadow) above: the resolver
 			// must follow the graph pointer back to the disk store, or
 			// every post-index per-file resolve (the watcher save path,
@@ -2174,6 +2186,16 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 				zap.Int64("total_file_bytes", totalFileBytes),
 				zap.Int64("byte_threshold", maxShadowBytes),
 				zap.Bool("over_byte_budget", !belowShadowBytes))
+		}
+	}
+
+	// Clear this repo's prior content rows before the per-file streaming
+	// appends below, so a full reindex (cold or warm) rebuilds the content
+	// index from a clean slate instead of accumulating stale sections.
+	// No-op on a cold store; cheap per-repo DELETE on a warm one.
+	if cs := idx.contentSearcher(); cs != nil {
+		if err := cs.WipeContent(idx.RepoPrefix()); err != nil {
+			idx.logger.Warn("indexer: content index wipe failed", zap.Error(err))
 		}
 	}
 
@@ -2306,6 +2328,7 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 								continue
 							}
 							idx.applyRepoPrefix(result.Nodes, result.Edges)
+							idx.streamContentSections(result.Nodes)
 							idx.graph.AddBatch(result.Nodes, result.Edges)
 							idx.persistConstValues(result)
 							continue
@@ -2417,6 +2440,13 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 						}
 					}
 
+					// Stream this file's content (data_class=content) section
+					// bodies into the dedicated content index and lean the
+					// nodes to a snippet BEFORE AddBatch, so the bulk text
+					// never enters the graph, the symbol search, or the
+					// materialising code passes.
+					idx.streamContentSections(result.Nodes)
+
 					// Batch the per-file insert into one shard-grouped pass
 					// so each shard's lock is acquired at most once per
 					// file instead of N + 2·E times. Profiling showed 69
@@ -2504,6 +2534,14 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 		idx.graph = streamingDisk
 	} else {
 		parseChunk(files)
+	}
+
+	// Finalise the content index after the per-file streaming appends so
+	// its FTS5 segments are merged before the first content query.
+	if cs := idx.contentSearcher(); cs != nil {
+		if err := cs.BuildContentIndex(); err != nil {
+			idx.logger.Warn("indexer: content index build failed", zap.Error(err))
+		}
 	}
 
 	if processed > 0 {
@@ -2972,6 +3010,19 @@ func (idx *Indexer) indexFile(filePath string, resolve bool) error {
 	}
 
 	idx.applyRepoPrefix(result.Nodes, result.Edges)
+
+	// Content (incremental): clear this file's prior content rows, then
+	// re-stream + lean — mirrors the full-index per-file path so an edited
+	// content file leaves no stale rows and doesn't revert to full text on
+	// the node.
+	if cs := idx.contentSearcher(); cs != nil {
+		if fp := firstContentFilePath(result.Nodes); fp != "" {
+			if err := cs.WipeContentFile(fp); err != nil {
+				idx.logger.Warn("indexer: content index file wipe failed", zap.Error(err))
+			}
+		}
+	}
+	idx.streamContentSections(result.Nodes)
 
 	idx.graph.AddBatch(result.Nodes, result.Edges)
 	idx.persistConstValues(result)

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -3428,6 +3428,15 @@ func (idx *Indexer) collectEmbedTexts(nodes []*graph.Node) (texts []string, ids 
 		if n.Kind == graph.KindFile || n.Kind == graph.KindImport {
 			continue
 		}
+		// CONTENT section bodies are served by the content index, not the
+		// vector store — excluding them keeps the embed-text count (and the
+		// 100k auto-disable check) code-only, so a content-heavy repo no
+		// longer drowns the embedding pass in hundreds of thousands of
+		// section texts.
+		if isContentNode(n) {
+			skipped++
+			continue
+		}
 		if config.ShouldSkipEmbed(idx.config.SkipEmbed, n.Language, string(n.Kind)) {
 			skipped++
 			continue

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -543,6 +543,13 @@ func (idx *Indexer) shouldIndexForSearch(n *graph.Node) bool {
 	if n.Kind == graph.KindBuiltin {
 		return false
 	}
+	// CONTENT (data_class="content") section nodes live in the dedicated
+	// content index (content_fts), never the symbol search — keeping the
+	// symbol corpus code-only and bounded. Markdown prose (KindDoc without
+	// data_class=content) is unaffected and still honours IndexProse below.
+	if isContentNode(n) {
+		return false
+	}
 	// Prose-section nodes are searchable only when prose indexing is
 	// enabled (search.index_prose); the rest of the graph is
 	// unaffected by the toggle.

--- a/internal/indexer/shadow_byte_budget_test.go
+++ b/internal/indexer/shadow_byte_budget_test.go
@@ -1,0 +1,101 @@
+package indexer
+
+import (
+	"context"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+func TestShadowMaxBytes(t *testing.T) {
+	require.Equal(t, defaultShadowMaxBytes, shadowMaxBytes(), "unset falls back to the default")
+	t.Setenv("GORTEX_SHADOW_MAX_BYTES", "4096")
+	require.Equal(t, int64(4096), shadowMaxBytes(), "a positive override wins")
+	t.Setenv("GORTEX_SHADOW_MAX_BYTES", "0")
+	require.Equal(t, defaultShadowMaxBytes, shadowMaxBytes(), "zero falls back to the default")
+	t.Setenv("GORTEX_SHADOW_MAX_BYTES", "-5")
+	require.Equal(t, defaultShadowMaxBytes, shadowMaxBytes(), "a negative value falls back to the default")
+	t.Setenv("GORTEX_SHADOW_MAX_BYTES", "notanumber")
+	require.Equal(t, defaultShadowMaxBytes, shadowMaxBytes(), "a non-numeric value falls back to the default")
+}
+
+// TestShadowSwap_ByteBudgetRoutesToDiskPath verifies the byte gate added
+// for #120: a repo whose combined input bytes exceed the budget but whose
+// file count is far under shadowMaxFileCount — the few-huge-files content
+// shape — must be refused the all-in-memory shadow and built against the
+// bounded per-call disk path instead. Crucially the gate changes only the
+// build strategy, never the result: the same node set must come out either
+// way.
+func TestShadowSwap_ByteBudgetRoutesToDiskPath(t *testing.T) {
+	dir := t.TempDir()
+	// 8 files, ~50 KiB each (~400 KiB total). Far under the 50k file-count
+	// ceiling, so only the byte gate can trip.
+	const perFile = 50 * 1024
+	for i := 0; i < 8; i++ {
+		writeFile(t, filepath.Join(dir, "f"+strconv.Itoa(i)+".go"),
+			"package p\n\nvar Blob"+strconv.Itoa(i)+" = \""+strings.Repeat("x", perFile)+"\"\n")
+	}
+
+	run := func(t *testing.T, budget string) (decision map[string]any, nodes map[string]bool) {
+		t.Helper()
+		t.Setenv("GORTEX_SHADOW_MAX_BYTES", budget)
+		store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "store.sqlite"))
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = store.Close() })
+		// Sanity: only sqlite's BulkLoader path exercises the shadow swap.
+		_, isBulk := graph.Store(store).(graph.BulkLoader)
+		require.True(t, isBulk, "sqlite must implement BulkLoader for this test")
+
+		core, logs := observer.New(zapcore.InfoLevel)
+		reg := parser.NewRegistry()
+		languages.RegisterAll(reg)
+		cfg := config.Default().Index
+		cfg.Workers = 2
+		_, err = New(store, reg, cfg, zap.New(core)).IndexCtx(context.Background(), dir)
+		require.NoError(t, err)
+
+		entries := logs.FilterMessage("indexer: shadow-swap decision").All()
+		require.NotEmpty(t, entries, "the shadow-swap decision must be logged")
+		decision = entries[0].ContextMap()
+
+		nodes = map[string]bool{}
+		for _, n := range store.AllNodes() {
+			nodes[n.ID] = true
+		}
+		return decision, nodes
+	}
+
+	// Tiny budget (64 KiB): combined input (~400 KiB) exceeds it while the
+	// file count stays under the ceiling → the shadow must be refused.
+	over, overNodes := run(t, "65536")
+	require.True(t, over["below_shadow_max"].(bool),
+		"file count is under the count ceiling — only the byte gate should trip")
+	require.False(t, over["below_shadow_bytes"].(bool),
+		"combined input exceeds the byte budget")
+	require.False(t, over["shadow_taken"].(bool),
+		"over the byte budget the in-memory shadow must be refused")
+
+	// Generous budget (1 GiB): the same files now fit → the shadow engages.
+	under, underNodes := run(t, "1073741824")
+	require.True(t, under["below_shadow_bytes"].(bool),
+		"combined input fits the generous byte budget")
+	require.True(t, under["shadow_taken"].(bool),
+		"under the byte budget the shadow path engages")
+
+	// The byte gate is a build-strategy switch, not a content filter: the
+	// bounded disk path and the shadow path must produce identical graphs.
+	require.Equal(t, underNodes, overNodes,
+		"byte gate must not drop, add, or duplicate any node")
+}

--- a/internal/indexer/shadow_threshold.go
+++ b/internal/indexer/shadow_threshold.go
@@ -41,6 +41,35 @@ func shadowMaxFileCount() int {
 	return defaultShadowMaxFileCount
 }
 
+// defaultShadowMaxBytes caps the total raw input bytes above which the
+// in-memory shadow swap is refused even when the file count is under
+// shadowMaxFileCount. The file-count ceiling alone is blind to the
+// few-huge-files shape (a content repo of a few hundred PDFs / text
+// dumps / spreadsheets is well under 50k files but can hold multiple
+// GB of bytes that explode into hundreds of thousands of section
+// nodes). The all-in-memory shadow holds the whole post-parse graph —
+// nodes, edges, retained section text, the in-process search index —
+// for the entire pipeline, so a multi-GB input pins multiples of that
+// in RAM and OOMs on a content-heavy repo (see #120). 1 GiB of input
+// keeps a normal source tree on the fast shadow path while routing
+// content-heavy / data-dump repos to the bounded per-call disk path.
+const defaultShadowMaxBytes int64 = 1 << 30 // 1 GiB
+
+// shadowMaxBytes returns the active total-input-byte ceiling for the
+// in-memory shadow swap. GORTEX_SHADOW_MAX_BYTES overrides the
+// default; a high value (e.g. 1<<60) effectively disables the byte
+// guard, leaving only the file-count ceiling. Non-numeric, zero, or
+// negative values fall back to the default.
+func shadowMaxBytes() int64 {
+	if v := os.Getenv("GORTEX_SHADOW_MAX_BYTES"); v != "" {
+		n, err := strconv.ParseInt(v, 10, 64)
+		if err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultShadowMaxBytes
+}
+
 // streamingFlushActive reports whether the streaming-flush parse path
 // should engage for this IndexCtx. Requirements:
 //

--- a/internal/mcp/content_why_staleness_test.go
+++ b/internal/mcp/content_why_staleness_test.go
@@ -1,0 +1,69 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/query"
+)
+
+// TestWhy_OnLeanContentNode verifies C5: the why-layer still resolves a
+// content document that motivates a symbol after the content/code split —
+// the lean content node carries name, asset_kind, and a snippet, and the
+// EdgeMotivates edge is intact, so the one-hop walk returns the content
+// entry unchanged in shape (the snippet stands in for the full body, which
+// now lives in the content index).
+func TestWhy_OnLeanContentNode(t *testing.T) {
+	s := newTestServer(t)
+	s.graph.AddBatch([]*graph.Node{
+		{
+			ID: "spec.pdf::doc:pdf_page-3", Kind: graph.KindDoc, Name: "spec.pdf p.3", FilePath: "spec.pdf",
+			Meta: map[string]any{
+				"data_class": "content", "asset_kind": "pdf_page",
+				"section_text": "the snippet preview", "content_indexed": true,
+			},
+		},
+		{ID: "pkg/x.go::DoThing", Kind: graph.KindFunction, Name: "DoThing", FilePath: "pkg/x.go"},
+	}, []*graph.Edge{
+		{From: "spec.pdf::doc:pdf_page-3", To: "pkg/x.go::DoThing", Kind: graph.EdgeMotivates,
+			Meta: map[string]any{"signal": "names_symbol"}},
+	})
+	s.engine = query.NewEngine(s.graph)
+
+	entries := s.whyEntriesFor(context.Background(), "pkg/x.go::DoThing")
+	require.Len(t, entries, 1)
+	require.Equal(t, "content", entries[0].Kind)
+	require.Equal(t, "pdf_page", entries[0].AssetKind)
+	require.Equal(t, "spec.pdf::doc:pdf_page-3", entries[0].SourceID)
+	require.Equal(t, "the snippet preview", entries[0].Text,
+		"the why-layer surfaces the lean node's snippet as the motivating text")
+	require.Equal(t, "names_symbol", entries[0].Signal)
+}
+
+// TestDocStaleness_OnLeanContentNode verifies C5: doc-staleness still flags
+// a content document whose referenced symbol is gone, after leaning. It
+// reads the source node's File/Name and the EdgeMotivates edges — never the
+// body — so the lean node is fully sufficient.
+func TestDocStaleness_OnLeanContentNode(t *testing.T) {
+	g := graph.New()
+	g.AddBatch([]*graph.Node{
+		{
+			ID: "spec.pdf::doc:pdf_page-0", Kind: graph.KindDoc, Name: "spec.pdf", FilePath: "spec.pdf",
+			Meta: map[string]any{"data_class": "content", "asset_kind": "pdf_page", "section_text": "snippet"},
+		},
+	}, []*graph.Edge{
+		// Motivates a symbol that does not exist → dangling.
+		{From: "spec.pdf::doc:pdf_page-0", To: "pkg/x.go::Gone", Kind: graph.EdgeMotivates},
+	})
+
+	res := analyzeDocStaleness(g, 50)
+	require.Equal(t, 1, res.AssessedLinks)
+	require.Len(t, res.Stale, 1)
+	require.Equal(t, "dangling", res.Stale[0].WorstState)
+	require.Equal(t, 1, res.Stale[0].Dangling)
+	require.Equal(t, "spec.pdf", res.Stale[0].File)
+	require.Equal(t, "spec.pdf::doc:pdf_page-0", res.Stale[0].Source)
+}

--- a/internal/mcp/search_corpus.go
+++ b/internal/mcp/search_corpus.go
@@ -50,12 +50,20 @@ func parseCorpus(req mcpgo.CallToolRequest) (searchCorpus, error) {
 	}
 }
 
-// includesDocs reports whether the corpus admits prose-section nodes. Content
-// (corpusContent) rides the same doc-retrieval channel — content chunks are
-// KindDoc — so it admits docs at fetch time and narrows to content in the
-// post-filter.
+// includesDocs reports whether the corpus admits Markdown prose-section
+// nodes, which the symbol search still serves. Content (pdf / office / text)
+// now rides its own content-index channel — see includesContent — so
+// corpusContent does NOT pull the prose channel.
 func (c searchCorpus) includesDocs() bool {
-	return c == corpusDocs || c == corpusAll || c == corpusContent
+	return c == corpusDocs || c == corpusAll
+}
+
+// includesContent reports whether the corpus admits content-index sections
+// (data_class=content), served by the dedicated ContentSearcher rather than
+// the symbol search. corpusDocs keeps the historical superset semantic (all
+// KindDoc), so it pulls the content channel too.
+func (c searchCorpus) includesContent() bool {
+	return c == corpusContent || c == corpusDocs || c == corpusAll
 }
 
 // includesCode reports whether the corpus admits code-symbol nodes.
@@ -128,6 +136,56 @@ func (s *Server) mergeDocChannel(ctx context.Context, query string, nodes []*gra
 	return merged
 }
 
+// mergeContentChannel is the retrieval channel for content sections. Since
+// content (data_class=content) bodies live in the dedicated content index
+// (content_fts) and not the symbol search, the primary + doc fetches above
+// can never surface them — this queries the ContentSearcher directly,
+// scoped to the session's repo, materialises the matched content nodes by
+// ID, and merges them into the candidate pool (dedup by node ID). A nil
+// content searcher (in-memory store) or empty result returns the input
+// unchanged.
+func (s *Server) mergeContentChannel(ctx context.Context, query string, nodes []*graph.Node, fetchLimit int) []*graph.Node {
+	if strings.TrimSpace(query) == "" {
+		return nodes
+	}
+	cs, ok := s.graph.(graph.ContentSearcher)
+	if !ok {
+		return nodes
+	}
+	limit := fetchLimit * docChannelFetchMultiple
+	if limit > docChannelMaxLimit {
+		limit = docChannelMaxLimit
+	}
+	if limit <= fetchLimit {
+		limit = fetchLimit
+	}
+	repoPrefix, _ := s.sessionLocality(ctx)
+	hits, err := cs.SearchContent(query, repoPrefix, limit)
+	if err != nil || len(hits) == 0 {
+		return nodes
+	}
+
+	seen := make(map[string]struct{}, len(nodes))
+	for _, n := range nodes {
+		if n != nil {
+			seen[n.ID] = struct{}{}
+		}
+	}
+	merged := nodes
+	for _, h := range hits {
+		if _, dup := seen[h.NodeID]; dup {
+			continue
+		}
+		n := s.graph.GetNode(h.NodeID)
+		if n == nil {
+			continue
+		}
+		seen[h.NodeID] = struct{}{}
+		merged = append(merged, n)
+	}
+	return merged
+}
+
 // filterNodesByCorpus drops nodes that fall outside the selected
 // corpus. KindDoc nodes are the "docs" corpus; every other kind is
 // "code". corpusAll is a no-op.
@@ -158,9 +216,9 @@ func filterNodesByCorpus(nodes []*graph.Node, c searchCorpus) []*graph.Node {
 	return out
 }
 
-// isContentNode reports whether n is a content-corpus chunk — a KindDoc node
-// tagged data_class=content by a content extractor (pdf / pptx / xlsx / txt).
+// isContentNode is the mcp-local alias for graph.IsContentNode — a KindDoc
+// node tagged data_class=content by a content extractor (pdf / pptx / xlsx /
+// txt).
 func isContentNode(n *graph.Node) bool {
-	dc, _ := n.Meta["data_class"].(string)
-	return dc == "content"
+	return graph.IsContentNode(n)
 }

--- a/internal/mcp/search_corpus_channel_test.go
+++ b/internal/mcp/search_corpus_channel_test.go
@@ -1,0 +1,54 @@
+package mcp
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+)
+
+// TestMergeContentChannel_PullsFromContentIndex verifies C4: with content
+// out of the symbol search, the content retrieval channel pulls matching
+// content sections from the dedicated ContentSearcher and materialises the
+// nodes — even when a body term appears nowhere in the symbol index.
+func TestMergeContentChannel_PullsFromContentIndex(t *testing.T) {
+	store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "s.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	// A lean content node in the graph + its full body in the content index.
+	store.AddNode(&graph.Node{
+		ID:       "doc.txt::doc:section-0",
+		Kind:     graph.KindDoc,
+		FilePath: "doc.txt",
+		Meta:     map[string]any{"data_class": "content", "section_text": "snippet"},
+	})
+	require.NoError(t, store.AppendContent("", []graph.ContentFTSItem{
+		{NodeID: "doc.txt::doc:section-0", FilePath: "doc.txt", Body: "the zzcontentterm appears only in the full body"},
+	}))
+	require.NoError(t, store.BuildContentIndex())
+
+	s := &Server{
+		graph:      store,
+		session:    newSessionState(),
+		tokenStats: &tokenStats{},
+		symHistory: &symbolHistory{entries: make(map[string][]SymbolModification)},
+		sessions:   newSessionMap(),
+		toolScopes: newScopeRegistry(),
+	}
+
+	merged := s.mergeContentChannel(context.Background(), "zzcontentterm", nil, 10)
+	var ids []string
+	for _, n := range merged {
+		ids = append(ids, n.ID)
+	}
+	require.Contains(t, ids, "doc.txt::doc:section-0",
+		"the content channel must surface the content node from the content index")
+
+	// A term in no content body yields nothing extra.
+	require.Empty(t, s.mergeContentChannel(context.Background(), "zznomatchterm", nil, 10))
+}

--- a/internal/mcp/search_corpus_content_test.go
+++ b/internal/mcp/search_corpus_content_test.go
@@ -48,8 +48,10 @@ func TestFilterNodesByCorpus_Content(t *testing.T) {
 }
 
 func TestIsContentNode(t *testing.T) {
-	require.True(t, isContentNode(&graph.Node{Meta: map[string]any{"data_class": "content"}}))
-	require.False(t, isContentNode(&graph.Node{Meta: map[string]any{"data_class": "data"}}))
-	require.False(t, isContentNode(&graph.Node{Meta: map[string]any{}}))
+	require.True(t, isContentNode(&graph.Node{Kind: graph.KindDoc, Meta: map[string]any{"data_class": "content"}}))
+	require.False(t, isContentNode(&graph.Node{Kind: graph.KindDoc, Meta: map[string]any{"data_class": "data"}}))
+	require.False(t, isContentNode(&graph.Node{Kind: graph.KindDoc, Meta: map[string]any{}}))
 	require.False(t, isContentNode(&graph.Node{}))
+	// A non-KindDoc node is never content, even if mistagged.
+	require.False(t, isContentNode(&graph.Node{Kind: graph.KindFunction, Meta: map[string]any{"data_class": "content"}}))
 }

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -1419,6 +1419,13 @@ func (s *Server) handleSearchSymbols(ctx context.Context, req mcp.CallToolReques
 	if corpus.includesDocs() {
 		nodes = s.mergeDocChannel(ctx, q, nodes, fetchLimit, scope, timings)
 	}
+	// Content retrieval channel: content (data_class=content) sections live
+	// in the dedicated content index, not the symbol search, so the fetches
+	// above can't surface them — pull them from the ContentSearcher and
+	// merge before the corpus filter runs.
+	if corpus.includesContent() {
+		nodes = s.mergeContentChannel(ctx, q, nodes, fetchLimit)
+	}
 
 	candsAfterGather := len(nodes)
 	mergedCount := len(nodes) // pre-filter; comparable to primaryCount

--- a/internal/semantic/manager.go
+++ b/internal/semantic/manager.go
@@ -293,10 +293,12 @@ func (m *Manager) EnrichAll(g graph.Store, roots map[string]string) ([]*EnrichRe
 func (m *Manager) repoLanguages(g graph.Store, roots map[string]string) map[string]bool {
 	present := make(map[string]bool)
 	for repoPrefix := range roots {
-		nodes := g.GetRepoNodes(repoPrefix)
-		if len(nodes) == 0 && repoPrefix == "" {
-			nodes = g.AllNodes()
-		}
+		// Code-only enumeration: content (data_class=content) sections carry
+		// no enrichable language (pdf/text have no semantic provider), so
+		// dropping them at the store level keeps a content-heavy repo's
+		// hundreds of thousands of sections out of memory here. Content file
+		// nodes (KindFile) are kept, so a content language still registers.
+		nodes := graph.RepoCodeNodes(g, repoPrefix)
 		for _, n := range nodes {
 			// Include file/import nodes too: the per-provider EnrichRepo gate
 			// can spawn on an ambiguous edge sourced from a file/import node, so


### PR DESCRIPTION
## Problem

Indexing a content-heavy repo (a few hundred PDFs / slides / spreadsheets / text dumps — issue #120) OOM'd: a 4.9 GB / 369-file corpus drove peak memory to ~20 GB and was OOM-killed. Two root causes:

1. The in-memory shadow swap was gated only on **file count** (50k) — blind to a few-hundred-file repo that holds multiple GB.
2. **Content** (pdf / office / text) flowed through the **code** pipeline — ~525k section bodies held in graph nodes, flooding the symbol search and materialised by every whole-graph pass.

## Fixes

**Shadow byte gate** — gate the in-memory shadow on total input bytes (default 1 GiB, `GORTEX_SHADOW_MAX_BYTES`), not just file count. Over budget → the bounded per-call disk path.

**Content / code split** — content gets its own bounded index lane, separate from the code graph and symbol search:

- A `ContentSearcher` interface + a dedicated `content_fts` table.
- Stream content section bodies into `content_fts` per file during parsing; lean the graph nodes to a ~240-char snippet (~17× less text held in the graph).
- Exclude content from the symbol search, the vector embed, and code communities.
- Rewire `search_corpus` content retrieval to the content index.
- A SQL-level code-only node enumeration so the post-parse passes (search-index build, embedding, language detection) never materialise the content sections.
- Link content→code from the **full body** (streamed from the content index), not the leaned snippet — preserving the why-layer's coverage.

## Measured (real 4.9 GB / 369-file corpus, isolated sqlite daemon, macOS `phys_footprint`)

| Path | Peak | Outcome |
|---|---|---|
| in-memory `gortex index` (original) | ~20 GB | OOM |
| + byte gate | 6.2 GB | guard-killed |
| + content/code split | 4.2 GB | guard-killed |
| + code-only passes | **3.0 GB** | **completes** |

Content stays searchable (`search_corpus corpus:content`), the why-layer's content→code links work (full-body matching), and the symbol + vector indexes are code-only (52 vectors vs 524,963 before). The residual ~3 GB is the parse-phase read buffers (reading 192 MB files), not content — tunable separately.

## Tests

Per-commit `-race` tests + golangci-lint; full regression green (graph, store_sqlite, analysis, mcp, indexer); wire-contract golden unchanged.

closes issue https://github.com/zzet/gortex/issues/120