### PR TITLE
read_file: add offset/limit line-window for bounded reads

### DIFF
--- a/internal/mcp/read_file_window_test.go
+++ b/internal/mcp/read_file_window_test.go
@@ -1,0 +1,90 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReadFile_LineWindow covers the offset/limit line-window added to
+// read_file: a bounded read returns exactly the requested lines plus a
+// window descriptor, instead of the whole file.
+func TestReadFile_LineWindow(t *testing.T) {
+	srv, dir := setupTestServer(t)
+	var b strings.Builder
+	for i := 1; i <= 10; i++ {
+		b.WriteString("line")
+		b.WriteByte(byte('0' + i%10))
+		b.WriteByte('\n')
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "lines.txt"), []byte(b.String()), 0o644))
+
+	// offset + limit: lines 3..5 inclusive.
+	r := callTool(t, srv, "read_file", map[string]any{
+		"path":   "lines.txt",
+		"offset": 3,
+		"limit":  3,
+	})
+	m := extractTextResult(t, r)
+	assert.Equal(t, "line3\nline4\nline5", m["content"],
+		"offset/limit must return exactly the requested line window")
+	win, ok := m["window"].(map[string]any)
+	require.True(t, ok, "windowed read must carry a window descriptor")
+	assert.EqualValues(t, 3, win["start_line"])
+	assert.EqualValues(t, 5, win["end_line"])
+	assert.EqualValues(t, 10, win["total_lines"])
+
+	// limit-only starts at line 1.
+	r = callTool(t, srv, "read_file", map[string]any{"path": "lines.txt", "limit": 2})
+	m = extractTextResult(t, r)
+	assert.Equal(t, "line1\nline2", m["content"])
+
+	// offset-only reads to EOF.
+	r = callTool(t, srv, "read_file", map[string]any{"path": "lines.txt", "offset": 9})
+	m = extractTextResult(t, r)
+	assert.Equal(t, "line9\nline0", m["content"])
+	win, _ = m["window"].(map[string]any)
+	assert.EqualValues(t, 10, win["end_line"])
+
+	// offset past EOF yields an empty window, not an error.
+	r = callTool(t, srv, "read_file", map[string]any{"path": "lines.txt", "offset": 99})
+	m = extractTextResult(t, r)
+	assert.Equal(t, "", m["content"])
+
+	// No offset/limit => whole file, no window descriptor.
+	r = callTool(t, srv, "read_file", map[string]any{"path": "lines.txt"})
+	m = extractTextResult(t, r)
+	assert.Contains(t, m["content"], "line1\n")
+	assert.Contains(t, m["content"], "line0")
+	_, has := m["window"]
+	assert.False(t, has, "a full read must not carry a window descriptor")
+}
+
+// TestWindowFileLines unit-tests the slicing helper directly, including the
+// trailing-newline phantom-line handling.
+func TestWindowFileLines(t *testing.T) {
+	content := []byte("a\nb\nc\nd\n") // 4 lines + trailing newline
+
+	out, applied, start, end, total := windowFileLines(content, 2, 2)
+	assert.True(t, applied)
+	assert.Equal(t, "b\nc", string(out))
+	assert.Equal(t, 2, start)
+	assert.Equal(t, 3, end)
+	assert.Equal(t, 4, total, "trailing newline must not inflate the line count")
+
+	// Unset => no window.
+	out, applied, _, _, _ = windowFileLines(content, 0, 0)
+	assert.False(t, applied)
+	assert.Equal(t, content, out)
+
+	// limit past EOF clamps to the last line.
+	out, _, start, end, total = windowFileLines(content, 3, 99)
+	assert.Equal(t, "c\nd", string(out))
+	assert.Equal(t, 3, start)
+	assert.Equal(t, 4, end)
+	assert.Equal(t, 4, total)
+}

--- a/internal/mcp/tools_coding.go
+++ b/internal/mcp/tools_coding.go
@@ -128,8 +128,10 @@ func (s *Server) registerCodingTools() {
 
 	s.addTool(
 		mcp.NewTool("read_file",
-			mcp.WithDescription("Reads a whole file by path and returns its content. Use sparingly — prefer get_symbol_source / get_editing_context for code. Useful when you need a non-indexed file (config, fixture, raw markdown) or when you genuinely need the full body. With compress_bodies=true, every function/method body is replaced by a `{ /* N lines elided */ }` stub — signatures + structure preserved, ~30-40% of original tokens. Composable with format:\"gcx\"."),
+			mcp.WithDescription("Reads a file by path and returns its content. Pass offset (1-based start line) and/or limit (line count) to read a specific line WINDOW of a large file instead of the whole thing. Use sparingly — prefer get_symbol_source / get_editing_context for code. Useful when you need a non-indexed file (config, fixture, raw markdown) or when you genuinely need the full body. With compress_bodies=true, every function/method body is replaced by a `{ /* N lines elided */ }` stub — signatures + structure preserved, ~30-40% of original tokens. Composable with format:\"gcx\"."),
 			mcp.WithString("path", mcp.Required(), mcp.Description("Absolute path, or repo-prefixed / repo-root-relative path")),
+			mcp.WithNumber("offset", mcp.Description("1-based line number to start reading from. Pair with limit to read a window of a large file. Omit or 0 to start at the first line.")),
+			mcp.WithNumber("limit", mcp.Description("Maximum number of lines to return starting at offset. Omit or 0 to read to end of file. Set this (with or without offset) to read a bounded window instead of the whole file.")),
 			mcp.WithBoolean("compress_bodies", mcp.Description("Replace function/method bodies with elided stubs (default: false)")),
 			mcp.WithBoolean("allow_secrets", mcp.Description("Serve secret-shaped values in config / data-leaf files (.env, *.yaml, *.toml, *.properties, ...) verbatim. By default such values are withheld and only their keys are shown. Default: false.")),
 			mcp.WithString("keep", mcp.Description("Comma-separated symbol names, IDs, or node kinds whose bodies stay verbatim when compress_bodies is set — every other body in the file is still stubbed. Ignored unless compress_bodies is true.")),

--- a/internal/mcp/tools_fileops.go
+++ b/internal/mcp/tools_fileops.go
@@ -895,6 +895,40 @@ func (s *Server) attachFileDependents(result map[string]any, fileID string) {
 	}
 }
 
+// windowFileLines slices content to the 1-based line window [offset,
+// offset+limit). offset <= 0 starts at line 1; limit <= 0 reads to EOF.
+// Returns the windowed bytes, whether a window was applied, and the
+// 1-based inclusive start/end lines plus the file's total line count. A
+// trailing newline's phantom final line is excluded from the count and the
+// window, so total_lines matches what an editor shows. An offset past EOF
+// yields empty content (not an error).
+func windowFileLines(content []byte, offset, limit int) (out []byte, applied bool, start, end, total int) {
+	if offset <= 0 && limit <= 0 {
+		return content, false, 0, 0, 0
+	}
+	lines := strings.Split(string(content), "\n")
+	total = len(lines)
+	if total > 0 && lines[total-1] == "" {
+		// Trailing newline produced a phantom empty final element — don't
+		// count it as a line.
+		total--
+	}
+	start = offset
+	if start < 1 {
+		start = 1
+	}
+	if start > total {
+		return []byte{}, true, start, start - 1, total
+	}
+	end = total
+	if limit > 0 {
+		if e := start + limit - 1; e < end {
+			end = e
+		}
+	}
+	return []byte(strings.Join(lines[start-1:end], "\n")), true, start, end, total
+}
+
 func (s *Server) handleReadFile(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	rawPath, err := req.RequireString("path")
 	if err != nil {
@@ -927,6 +961,17 @@ func (s *Server) handleReadFile(ctx context.Context, req mcp.CallToolRequest) (*
 	}
 
 	originalBytes := len(content)
+
+	// Line-window: when offset/limit are given, return only that slice of
+	// the file's lines. This is the bounded-read path for large files — the
+	// salience/compress transforms below reshape a whole body, whereas a
+	// window is a plain "lines M..N" cut the caller asked for explicitly.
+	windowed := false
+	var winStart, winEnd, winTotal int
+	if offset := req.GetInt("offset", 0); offset > 0 || req.GetInt("limit", 0) > 0 {
+		content, windowed, winStart, winEnd, winTotal = windowFileLines(content, offset, req.GetInt("limit", 0))
+	}
+
 	isBinary := looksBinary(content)
 	bodiesElided := false
 	var keptSymbols []string
@@ -1005,6 +1050,13 @@ func (s *Server) handleReadFile(ctx context.Context, req mcp.CallToolRequest) (*
 	if salienceTruncated {
 		result["salience_truncated"] = true
 	}
+	if windowed {
+		result["window"] = map[string]any{
+			"start_line":  winStart,
+			"end_line":    winEnd,
+			"total_lines": winTotal,
+		}
+	}
 
 	// Omission notes: tell the model what the payload deliberately
 	// leaves out or reshapes, so it does not reason about absent code.
@@ -1020,6 +1072,10 @@ func (s *Server) handleReadFile(ctx context.Context, req mcp.CallToolRequest) (*
 	if salienceTruncated {
 		omissions = append(omissions, omission("truncated",
 			"oversized source reduced toward its control-flow skeleton; runs of leaf statements collapsed"))
+	}
+	if windowed {
+		omissions = append(omissions, omission("windowed",
+			fmt.Sprintf("returned lines %d-%d of %d; the rest of the file was not included (offset/limit window)", winStart, winEnd, winTotal)))
 	}
 	if secretsRedacted {
 		omissions = append(omissions, omission("secrets_withheld",
@@ -1045,7 +1101,7 @@ func (s *Server) handleReadFile(ctx context.Context, req mcp.CallToolRequest) (*
 		contentStr := string(content)
 		returned := tokens.CachedCountInt64(contentStr)
 		fullFile := returned
-		if bodiesElided || salienceTruncated {
+		if bodiesElided || salienceTruncated || windowed {
 			fullFile = int64(tokens.EstimateFromSample(originalBytes, contentStr))
 		}
 		s.tokenStatsFor(ctx).record(s.fileAttributionNode(relPath, language), "read_file", returned, fullFile)


### PR DESCRIPTION
## Problem

`read_file` could only return a whole file, a `max_lines` salience-collapsed view, or a `compress_bodies` stubbed view. None is a plain bounded read:

- `max_bytes` is applied by the shared response budget, which trims **list-shaped** fields — but `read_file`'s payload is the scalar `content` string, so `max_bytes` never bounds the body.
- `max_lines` collapses leaf-statement runs (structure-preserving), not a line window.

So a large file had **no** windowed-read path: a request for a slice silently returned the entire file and overflowed the caller's token cap. (This is exactly what bit an agent reading a ~2700-line source file — the host then suggests "use offset and limit", which `read_file` didn't support.)

## Fix

Add `offset` (1-based start line) and `limit` (line count) parameters that slice the file to that line window:

- returns exactly lines `[offset, offset+limit)`;
- attaches a `window` descriptor `{start_line, end_line, total_lines}` and a `windowed` omission note;
- trailing-newline phantom line excluded from `total_lines`;
- `offset` past EOF yields an empty window, not an error;
- composes with the existing transforms; a full read (no offset/limit) is unchanged and carries no `window`.

This makes the host's generic "use offset and limit" oversized-result hint actionable for `read_file`.

## Tests

`internal/mcp/read_file_window_test.go`: end-to-end windowed reads (offset+limit, limit-only, offset-only-to-EOF, past-EOF, full-read) plus a direct unit test of the `windowFileLines` slicer including trailing-newline handling. Existing `read_file` / omissions / compress / redact tests still pass.