### PR TITLE
LSP-free type-usage resolution across 11 languages, plus memory and crash fixes

### DIFF
--- a/internal/graph/store_sqlite/closed_store_test.go
+++ b/internal/graph/store_sqlite/closed_store_test.go
@@ -1,0 +1,30 @@
+package store_sqlite_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// TestClosedStoreReadsDoNotPanic pins the teardown-race fix: after Close()
+// has shut the store (daemon shutdown / restart / store swap), an in-flight
+// reader — e.g. a deferred parallel-enrich goroutine still holding a cached
+// *sql.Stmt — must degrade to an empty result, never panic the whole daemon.
+// Before the fix this surfaced as `panic: store_sqlite: sql: statement is
+// closed` from GetNode under runDeferredEnrichParallel.
+func TestClosedStoreReadsDoNotPanic(t *testing.T) {
+	s := openTestStore(t)
+	s.AddNode(&graph.Node{ID: "p/a.go::Foo", Kind: graph.KindType, Name: "Foo", FilePath: "p/a.go"})
+	require.NotNil(t, s.GetNode("p/a.go::Foo"), "sanity: node readable before close")
+
+	require.NoError(t, s.Close())
+
+	assert.NotPanics(t, func() {
+		assert.Nil(t, s.GetNode("p/a.go::Foo"))
+		assert.Empty(t, s.FindNodesByName("Foo"))
+		assert.Empty(t, s.GetFileNodes("p/a.go"))
+	}, "reads after Close must degrade gracefully, not panic")
+}

--- a/internal/graph/store_sqlite/store.go
+++ b/internal/graph/store_sqlite/store.go
@@ -1480,7 +1480,26 @@ func panicOnFatal(err error) {
 	if errors.Is(err, sql.ErrNoRows) {
 		return
 	}
+	// A closed statement / database / connection is a teardown race, not
+	// data corruption: Close() shuts the store (daemon shutdown, restart,
+	// or store swap) while an in-flight reader -- e.g. a deferred
+	// parallel-enrich goroutine still holding a cached *sql.Stmt -- runs a
+	// query. Crashing the whole daemon over a benign shutdown race is
+	// strictly worse than the read returning empty (or a winding-down write
+	// being dropped), so treat these as non-fatal.
+	if errors.Is(err, sql.ErrConnDone) || isStoreClosedErr(err) {
+		return
+	}
 	panic(fmt.Errorf("store_sqlite: %w", err))
+}
+
+// isStoreClosedErr reports whether err is the database/sql sentinel for a
+// closed prepared statement or a closed database -- string-matched because
+// database/sql does not export these as typed errors.
+func isStoreClosedErr(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "statement is closed") ||
+		strings.Contains(msg, "database is closed")
 }
 
 // -- predicate-shaped reads ---------------------------------------------

--- a/internal/parser/languages/cpp.go
+++ b/internal/parser/languages/cpp.go
@@ -119,7 +119,7 @@ func (e *CppExtractor) Extract(filePath string, src []byte) (*parser.ExtractionR
 			e.emitClass(m, filePath, fileID, src, result, seen)
 
 		case m.Captures["struct.def"] != nil:
-			e.emitStruct(m, filePath, fileID, result, seen)
+			e.emitStruct(m, filePath, fileID, src, result, seen)
 
 		case m.Captures["enum.def"] != nil:
 			e.emitEnum(m, filePath, fileID, result, seen)
@@ -157,6 +157,15 @@ func (e *CppExtractor) Extract(filePath string, src []byte) (*parser.ExtractionR
 
 	// Resolve call edges against funcRanges.
 	funcRanges := buildFuncRanges(result)
+
+	// Emit type-use edges (EdgeTypedAs) for declaration positions the
+	// per-match pass leaves edge-less: local variable declarations,
+	// function parameters, and return types — each attributed to the
+	// enclosing function/method via funcRanges. Member/field type-uses
+	// are attributed to the owning class/struct node during the body
+	// walk above, so they're already in result.Edges.
+	collectCppTypeUseEdges(root, funcRanges, filePath, src, result)
+
 	for _, c := range calls {
 		callerID := findEnclosingFunc(funcRanges, c.line)
 		if callerID == "" {
@@ -240,6 +249,7 @@ func (e *CppExtractor) walkClassBody(classNode *sitter.Node, src []byte, filePat
 	if body == nil {
 		return
 	}
+	typeSeen := make(map[string]bool)
 	for i := 0; i < int(body.NamedChildCount()); i++ {
 		child := body.NamedChild(i)
 		switch child.Type() {
@@ -247,6 +257,15 @@ func (e *CppExtractor) walkClassBody(classNode *sitter.Node, src []byte, filePat
 			continue
 		case "function_definition":
 			e.addMethodFromNode(child, src, filePath, fileID, className, classID, seen, result)
+		case "field_declaration":
+			// Member/field type-use: a `Foo bar;` member references Foo.
+			// Attribute to the owning class node (the extractor doesn't
+			// materialise a per-field node). Smart-pointer / container
+			// fields unwrap to the inner type via the canonicaliser.
+			line := int(child.StartPoint().Row) + 1
+			if tn := child.ChildByFieldName("type"); tn != nil {
+				emitCppTypeUseEdges(classID, tn.Content(src), filePath, line, result, typeSeen)
+			}
 		case "declaration_list":
 			for j := 0; j < int(child.NamedChildCount()); j++ {
 				gc := child.NamedChild(j)
@@ -317,7 +336,7 @@ func cppReturnType(node *sitter.Node, src []byte) string {
 	return rt
 }
 
-func (e *CppExtractor) emitStruct(m parser.QueryResult, filePath, fileID string, result *parser.ExtractionResult, seen map[string]bool) {
+func (e *CppExtractor) emitStruct(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen map[string]bool) {
 	name := m.Captures["struct.name"].Text
 	def := m.Captures["struct.def"]
 	id := filePath + "::" + name
@@ -333,6 +352,41 @@ func (e *CppExtractor) emitStruct(m parser.QueryResult, filePath, fileID string,
 	result.Edges = append(result.Edges, &graph.Edge{
 		From: fileID, To: id, Kind: graph.EdgeDefines, FilePath: filePath, Line: def.StartLine + 1,
 	})
+	e.emitCppStructFieldTypeUse(def.Node, id, filePath, src, result)
+}
+
+// emitCppStructFieldTypeUse walks a struct_specifier (or class_specifier)
+// body's direct field_declaration members and emits EdgeTypedAs from the
+// owning type node to each member's referenced type. Structs don't get
+// the inline method/field walk classes do, so this is the field-position
+// type-use pass for them. Methods nested in a struct are handled
+// elsewhere; only data members carry a `type` field here.
+func (e *CppExtractor) emitCppStructFieldTypeUse(structNode *sitter.Node, ownerID, filePath string, src []byte, result *parser.ExtractionResult) {
+	if structNode == nil {
+		return
+	}
+	var body *sitter.Node
+	for i := 0; i < int(structNode.NamedChildCount()); i++ {
+		child := structNode.NamedChild(i)
+		if child.Type() == "field_declaration_list" {
+			body = child
+			break
+		}
+	}
+	if body == nil {
+		return
+	}
+	typeSeen := make(map[string]bool)
+	for i := 0; i < int(body.NamedChildCount()); i++ {
+		child := body.NamedChild(i)
+		if child.Type() != "field_declaration" {
+			continue
+		}
+		line := int(child.StartPoint().Row) + 1
+		if tn := child.ChildByFieldName("type"); tn != nil {
+			emitCppTypeUseEdges(ownerID, tn.Content(src), filePath, line, result, typeSeen)
+		}
+	}
 }
 
 func (e *CppExtractor) emitEnum(m parser.QueryResult, filePath, fileID string, result *parser.ExtractionResult, seen map[string]bool) {

--- a/internal/parser/languages/cpp_typeuse.go
+++ b/internal/parser/languages/cpp_typeuse.go
@@ -1,0 +1,302 @@
+package languages
+
+import (
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	sitter "github.com/zzet/gortex/internal/parser/tsitter"
+)
+
+// C++ type-use edges. A C++ type named in a declaration position —
+// local variable (`Foo x;`, `Foo* p;`, `std::shared_ptr<Foo> p;`),
+// member/field, function parameter, or return type — is a cross-file
+// reference to that type. The base extractor stamps return / parameter
+// types into Meta for overload ranking but never materialises a graph
+// edge, so `find_usages` on a type used only in declaration position
+// lands nothing without a language server.
+//
+// collectCppTypeUseEdges runs one post-pass tree walk and emits an
+// EdgeTypedAs from the owning symbol (enclosing function / method for
+// locals, parameters and return types; the class / struct node for
+// fields) to "unresolved::<Type>", at OriginASTInferred — the binding
+// is a tree-sitter inference, not an LSP-checked fact. The cpp resolver
+// later lands the unresolved target onto a real type node by name.
+//
+// Owner attribution reuses the extractor's funcRanges mechanism
+// (line → enclosing function/method); fields are attributed by the
+// caller, which already holds the class/struct node ID. Edges are
+// de-duplicated per (owner, type) so a type used many times in one
+// function contributes a single reference.
+
+// emitCppTypeUseEdges canonicalises typeText to its bare named type
+// (stripping const/volatile/&/*, unwrapping smart-pointer / container
+// generics, dropping namespace qualifiers) and appends one EdgeTypedAs
+// from ownerID to unresolved::<type>. Primitives and unparseable
+// spellings are skipped. seen, when non-nil, de-duplicates per
+// (owner, type) across a single Extract pass.
+func emitCppTypeUseEdges(ownerID, typeText, filePath string, line int, result *parser.ExtractionResult, seen map[string]bool) {
+	if ownerID == "" {
+		return
+	}
+	t := canonicalizeCppTypeRef(typeText)
+	if t == "" || isCppPrimitive(t) {
+		return
+	}
+	if seen != nil {
+		key := ownerID + "\x00" + t
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+	}
+	result.Edges = append(result.Edges, &graph.Edge{
+		From:     ownerID,
+		To:       "unresolved::" + t,
+		Kind:     graph.EdgeTypedAs,
+		FilePath: filePath,
+		Line:     line,
+		Origin:   graph.OriginASTInferred,
+	})
+}
+
+// cppTypeWrappers are the smart-pointer / container generics whose sole
+// type argument is the "real" type a declaration refers to. A
+// `std::shared_ptr<Foo>` field is, for reference purposes, a use of
+// Foo — so the canonicaliser unwraps one level (recursively) before
+// reducing to the bare name. Multi-arg generics (map, pair) are left
+// alone: there's no single inner type to pick, and the outer template
+// name is itself a meaningful type reference.
+var cppTypeWrappers = map[string]bool{
+	"shared_ptr":        true,
+	"unique_ptr":        true,
+	"weak_ptr":          true,
+	"auto_ptr":          true,
+	"vector":            true,
+	"list":              true,
+	"deque":             true,
+	"set":               true,
+	"unordered_set":     true,
+	"optional":          true,
+	"reference_wrapper": true,
+	"atomic":            true,
+	"initializer_list":  true,
+}
+
+// canonicalizeCppTypeRef reduces a C++ type spelling to the bare named
+// type the resolver can match against a type node:
+//
+//   - strip leading cv-qualifiers (const / volatile)
+//   - strip trailing & / && / * indirection and cv-qualifiers
+//   - unwrap a single-argument smart-pointer / container generic
+//     (shared_ptr<Foo> → Foo, vector<Bar> → Bar) recursively
+//   - for any other generic, drop the `<…>` template-argument tail and
+//     keep the template name (Map<K,V> → Map)
+//   - drop namespace / class qualifiers (ns::Foo → Foo, A::B::C → C)
+//
+// Returns "" when the result doesn't reduce to a plausible single
+// identifier — a defensive guard against macro / template noise where
+// the "type" text isn't a real type name. The caller additionally skips
+// primitives via isCppPrimitive.
+func canonicalizeCppTypeRef(raw string) string {
+	t := strings.TrimSpace(raw)
+	if t == "" {
+		return ""
+	}
+	// Strip leading cv-qualifiers and storage keywords that can prefix a
+	// declaration's type field text.
+	for {
+		trimmed := false
+		for _, kw := range []string{"const ", "volatile ", "constexpr ", "static ", "mutable ", "typename ", "struct ", "class ", "enum "} {
+			if strings.HasPrefix(t, kw) {
+				t = strings.TrimSpace(t[len(kw):])
+				trimmed = true
+			}
+		}
+		if !trimmed {
+			break
+		}
+	}
+	// Strip trailing indirection / cv tokens (`*`, `&`, `&&`, ` const`).
+	for {
+		old := t
+		t = strings.TrimSpace(t)
+		t = strings.TrimSuffix(t, "&&")
+		t = strings.TrimRight(t, " *&")
+		t = strings.TrimSpace(t)
+		t = strings.TrimSuffix(t, " const")
+		t = strings.TrimSuffix(t, " volatile")
+		if t == old {
+			break
+		}
+	}
+	t = strings.TrimSpace(t)
+	if t == "" {
+		return ""
+	}
+	// Unwrap / strip a template-argument tail.
+	if open := strings.IndexByte(t, '<'); open >= 0 && strings.HasSuffix(t, ">") {
+		head := strings.TrimSpace(t[:open])
+		inner := strings.TrimSpace(t[open+1 : len(t)-1])
+		base := lastCppSegment(head)
+		if cppTypeWrappers[base] && inner != "" {
+			// Single-argument wrapper: recurse on the inner type. For a
+			// multi-argument inner spelling (`map<K,V>` reached via a
+			// wrapper, unusual) keep only the first top-level argument.
+			if first := firstTopLevelTemplateArg(inner); first != "" {
+				inner = first
+			}
+			return canonicalizeCppTypeRef(inner)
+		}
+		// Non-wrapper generic: keep the template name itself.
+		t = head
+	}
+	t = lastCppSegment(t)
+	if !isPlausibleCppTypeName(t) {
+		return ""
+	}
+	return t
+}
+
+// lastCppSegment drops namespace / nested-class qualifiers, keeping the
+// final `::`-separated segment (ns::Foo → Foo, A::B::C → C).
+func lastCppSegment(t string) string {
+	t = strings.TrimSpace(t)
+	if i := strings.LastIndex(t, "::"); i >= 0 {
+		t = t[i+2:]
+	}
+	return strings.TrimSpace(t)
+}
+
+// firstTopLevelTemplateArg returns the first comma-separated argument of
+// a template-argument list, respecting nested <…> so `map<int,Foo>`
+// yields `map<int,Foo>` rather than `map<int`. Returns the whole string
+// when there's no top-level comma.
+func firstTopLevelTemplateArg(args string) string {
+	depth := 0
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case '<':
+			depth++
+		case '>':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				return strings.TrimSpace(args[:i])
+			}
+		}
+	}
+	return strings.TrimSpace(args)
+}
+
+// isPlausibleCppTypeName guards against macro / template noise: a real
+// type name reduces to a single identifier (letters, digits, underscore;
+// not starting with a digit). Anything with leftover punctuation,
+// whitespace, or template/operator residue is rejected so the graph
+// isn't flooded with bogus "unresolved::" targets.
+func isPlausibleCppTypeName(t string) bool {
+	if t == "" {
+		return false
+	}
+	for i := 0; i < len(t); i++ {
+		c := t[i]
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c >= '0' && c <= '9':
+			if i == 0 {
+				return false
+			}
+		case c == '_':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// isCppPrimitive reports whether t names a C++ builtin / stdlib alias
+// that doesn't warrant an EdgeTypedAs target — emitting these would
+// clutter the graph with unresolved::int / unresolved::string edges that
+// never land on a user-defined type node.
+func isCppPrimitive(t string) bool {
+	switch t {
+	case "", "void", "bool", "char", "char8_t", "char16_t", "char32_t",
+		"wchar_t", "short", "int", "long", "float", "double", "signed",
+		"unsigned", "auto", "decltype", "nullptr_t",
+		"int8_t", "int16_t", "int32_t", "int64_t",
+		"uint8_t", "uint16_t", "uint32_t", "uint64_t",
+		"size_t", "ssize_t", "ptrdiff_t", "intptr_t", "uintptr_t",
+		"string", "wstring", "string_view", "basic_string":
+		return true
+	}
+	return false
+}
+
+// collectCppTypeUseEdges walks the parsed tree once and emits type-use
+// edges for declaration positions the base extractor leaves edge-less:
+//
+//   - parameter_declaration  → enclosing function/method (param type)
+//   - local declaration      → enclosing function/method (variable type)
+//   - function_definition    → enclosing function/method (return type)
+//
+// Owner is the enclosing function/method, found by line against
+// funcRanges. Positions with no enclosing function (e.g. a field, or a
+// file-scope global) are skipped here — fields are emitted by the
+// class/struct body walk, which holds the owning type's node ID.
+func collectCppTypeUseEdges(root *sitter.Node, funcRanges []funcRange, filePath string, src []byte, result *parser.ExtractionResult) {
+	if root == nil || len(funcRanges) == 0 {
+		return
+	}
+	seen := make(map[string]bool)
+	var walk func(n *sitter.Node)
+	walk = func(n *sitter.Node) {
+		if n == nil {
+			return
+		}
+		switch n.Type() {
+		case "parameter_declaration", "optional_parameter_declaration":
+			emitCppDeclTypeUse(n, funcRanges, filePath, src, result, seen)
+		case "declaration":
+			// A `declaration` at namespace / file scope with a
+			// function_declarator is a prototype, not a typed value — its
+			// type is a return type covered by the function-node pass when
+			// it has a body. Plain typed locals (and typed file globals,
+			// which fall outside funcRanges and are skipped by the owner
+			// lookup) flow through emitCppDeclTypeUse.
+			emitCppDeclTypeUse(n, funcRanges, filePath, src, result, seen)
+		case "function_definition":
+			// Return type: the `type` field of the definition.
+			line := int(n.StartPoint().Row) + 1
+			owner := findEnclosingFunc(funcRanges, line)
+			if owner != "" {
+				if tn := n.ChildByFieldName("type"); tn != nil {
+					emitCppTypeUseEdges(owner, tn.Content(src), filePath, line, result, seen)
+				}
+			}
+		}
+		for i := 0; i < int(n.NamedChildCount()); i++ {
+			walk(n.NamedChild(i))
+		}
+	}
+	walk(root)
+}
+
+// emitCppDeclTypeUse pulls the `type` field off a declaration /
+// parameter node and attributes its canonicalised type to the enclosing
+// function/method. Declarations outside any function (file-scope
+// globals, prototypes) get owner "" and are skipped.
+func emitCppDeclTypeUse(n *sitter.Node, funcRanges []funcRange, filePath string, src []byte, result *parser.ExtractionResult, seen map[string]bool) {
+	tn := n.ChildByFieldName("type")
+	if tn == nil {
+		return
+	}
+	line := int(n.StartPoint().Row) + 1
+	owner := findEnclosingFunc(funcRanges, line)
+	if owner == "" {
+		return
+	}
+	emitCppTypeUseEdges(owner, tn.Content(src), filePath, line, result, seen)
+}

--- a/internal/parser/languages/cpp_typeuse_test.go
+++ b/internal/parser/languages/cpp_typeuse_test.go
@@ -1,0 +1,231 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func cppTypedAsTo(edges []*graph.Edge) map[string]bool {
+	out := map[string]bool{}
+	for _, e := range edges {
+		if e.Kind == graph.EdgeTypedAs {
+			out[e.To] = true
+		}
+	}
+	return out
+}
+
+func TestCppExtractor_TypeUse_LocalVariable(t *testing.T) {
+	src := []byte(`HttpResponse handle() {
+    HttpResponse resp = get();
+    int count = 0;
+    return resp;
+}
+`)
+	e := NewCppExtractor()
+	result, err := e.Extract("handler.cpp", src)
+	require.NoError(t, err)
+
+	typed := edgesOfKind(result.Edges, graph.EdgeTypedAs)
+	to := cppTypedAsTo(result.Edges)
+
+	// A local declaration `HttpResponse resp = get();` references HttpResponse.
+	assert.True(t, to["unresolved::HttpResponse"],
+		"expected EdgeTypedAs to unresolved::HttpResponse, got %v", to)
+	// `int count` is a primitive — no edge.
+	assert.False(t, to["unresolved::int"], "primitive int must not produce a type-use edge")
+
+	// Every type-use edge must ride at OriginASTInferred and originate
+	// from the enclosing function node, never the file node.
+	for _, edge := range typed {
+		assert.Equal(t, graph.OriginASTInferred, edge.Origin)
+		assert.NotEqual(t, "handler.cpp", edge.From, "type-use edge must attribute to the function, not the file")
+	}
+}
+
+func TestCppExtractor_TypeUse_PointerAndReference(t *testing.T) {
+	src := []byte(`void run() {
+    Foo* p = nullptr;
+    Bar& r = make();
+    const Baz& cb = get();
+}
+`)
+	e := NewCppExtractor()
+	result, err := e.Extract("ptr.cpp", src)
+	require.NoError(t, err)
+
+	to := cppTypedAsTo(result.Edges)
+	assert.True(t, to["unresolved::Foo"], "pointer `Foo* p` references Foo: %v", to)
+	assert.True(t, to["unresolved::Bar"], "reference `Bar& r` references Bar: %v", to)
+	assert.True(t, to["unresolved::Baz"], "const-reference `const Baz&` references Baz: %v", to)
+}
+
+func TestCppExtractor_TypeUse_SmartPointerAndContainer(t *testing.T) {
+	src := []byte(`void wire() {
+    std::shared_ptr<Service> svc = makeService();
+    std::unique_ptr<Connection> conn;
+    std::vector<Widget> widgets;
+    std::optional<Result> maybe;
+}
+`)
+	e := NewCppExtractor()
+	result, err := e.Extract("wire.cpp", src)
+	require.NoError(t, err)
+
+	to := cppTypedAsTo(result.Edges)
+	assert.True(t, to["unresolved::Service"], "shared_ptr<Service> unwraps to Service: %v", to)
+	assert.True(t, to["unresolved::Connection"], "unique_ptr<Connection> unwraps to Connection: %v", to)
+	assert.True(t, to["unresolved::Widget"], "vector<Widget> unwraps to Widget: %v", to)
+	assert.True(t, to["unresolved::Result"], "optional<Result> unwraps to Result: %v", to)
+
+	// The wrapper names themselves must not appear as targets.
+	assert.False(t, to["unresolved::shared_ptr"], "wrapper name must not be a target")
+	assert.False(t, to["unresolved::vector"], "wrapper name must not be a target")
+}
+
+func TestCppExtractor_TypeUse_NamespaceQualified(t *testing.T) {
+	src := []byte(`void f() {
+    ns::Baz b;
+    a::b::Deep d;
+}
+`)
+	e := NewCppExtractor()
+	result, err := e.Extract("ns.cpp", src)
+	require.NoError(t, err)
+
+	to := cppTypedAsTo(result.Edges)
+	assert.True(t, to["unresolved::Baz"], "ns::Baz strips to Baz: %v", to)
+	assert.True(t, to["unresolved::Deep"], "a::b::Deep strips to Deep: %v", to)
+}
+
+func TestCppExtractor_TypeUse_Parameters(t *testing.T) {
+	src := []byte(`void process(Request req, const std::string& name, Config cfg, int n) {
+}
+`)
+	e := NewCppExtractor()
+	result, err := e.Extract("params.cpp", src)
+	require.NoError(t, err)
+
+	to := cppTypedAsTo(result.Edges)
+	assert.True(t, to["unresolved::Request"], "parameter type Request: %v", to)
+	assert.True(t, to["unresolved::Config"], "parameter type Config: %v", to)
+	// std::string is a stdlib primitive alias — skipped.
+	assert.False(t, to["unresolved::string"], "std::string parameter must not produce an edge")
+	assert.False(t, to["unresolved::int"], "int parameter must not produce an edge")
+}
+
+func TestCppExtractor_TypeUse_ReturnType(t *testing.T) {
+	// A by-value return type names the returned type. (Pointer-returning
+	// free functions like `Connection* makeConn(...)` are not captured as
+	// function nodes by the base extractor's query — a separate pre-existing
+	// limitation — so we assert the by-value form here.)
+	src := []byte(`Connection makeConn(Config cfg) {
+    return Connection();
+}
+`)
+	e := NewCppExtractor()
+	result, err := e.Extract("ret.cpp", src)
+	require.NoError(t, err)
+
+	to := cppTypedAsTo(result.Edges)
+	assert.True(t, to["unresolved::Connection"], "return type Connection references Connection: %v", to)
+	assert.True(t, to["unresolved::Config"], "parameter type Config: %v", to)
+}
+
+func TestCppExtractor_TypeUse_Fields(t *testing.T) {
+	src := []byte(`class Widget {
+public:
+    HttpResponse resp;
+    std::shared_ptr<Service> svc;
+    int count;
+};
+
+struct Bundle {
+    Payload payload;
+    double weight;
+};
+`)
+	e := NewCppExtractor()
+	result, err := e.Extract("widget.cpp", src)
+	require.NoError(t, err)
+
+	to := cppTypedAsTo(result.Edges)
+	assert.True(t, to["unresolved::HttpResponse"], "class field type HttpResponse: %v", to)
+	assert.True(t, to["unresolved::Service"], "class field shared_ptr<Service> -> Service: %v", to)
+	assert.True(t, to["unresolved::Payload"], "struct field type Payload: %v", to)
+	// Primitives skipped.
+	assert.False(t, to["unresolved::int"], "int field must not produce an edge")
+	assert.False(t, to["unresolved::double"], "double field must not produce an edge")
+
+	// Field edges must originate from the owning class/struct node.
+	for _, edge := range result.Edges {
+		if edge.Kind != graph.EdgeTypedAs {
+			continue
+		}
+		if edge.To == "unresolved::HttpResponse" || edge.To == "unresolved::Service" {
+			assert.Equal(t, "widget.cpp::Widget", edge.From, "class field type-use owner")
+		}
+		if edge.To == "unresolved::Payload" {
+			assert.Equal(t, "widget.cpp::Bundle", edge.From, "struct field type-use owner")
+		}
+	}
+}
+
+func TestCppExtractor_TypeUse_NoDuplicateEdges(t *testing.T) {
+	// Same type used three times in one function must yield a single edge.
+	src := []byte(`void f() {
+    Foo a;
+    Foo b;
+    Foo c = make();
+}
+`)
+	e := NewCppExtractor()
+	result, err := e.Extract("dup.cpp", src)
+	require.NoError(t, err)
+
+	n := 0
+	for _, edge := range result.Edges {
+		if edge.Kind == graph.EdgeTypedAs && edge.To == "unresolved::Foo" {
+			n++
+		}
+	}
+	assert.Equal(t, 1, n, "repeated local type must produce exactly one type-use edge")
+}
+
+func TestCanonicalizeCppTypeRef(t *testing.T) {
+	cases := map[string]string{
+		"HttpResponse":                "HttpResponse",
+		"Foo*":                        "Foo",
+		"Foo **":                      "Foo",
+		"Bar&":                        "Bar",
+		"Baz&&":                       "Baz",
+		"const Foo&":                  "Foo",
+		"const std::string&":          "string",
+		"std::shared_ptr<Service>":    "Service",
+		"std::unique_ptr<Connection>": "Connection",
+		"std::vector<Widget>":         "Widget",
+		"std::optional<Result>":       "Result",
+		"ns::Baz":                     "Baz",
+		"a::b::c::Deep":               "Deep",
+		"Map<K, V>":                   "Map",
+		"int":                         "int",
+		"":                            "",
+		"  ":                          "",
+	}
+	for in, want := range cases {
+		got := canonicalizeCppTypeRef(in)
+		assert.Equal(t, want, got, "canonicalizeCppTypeRef(%q)", in)
+	}
+}
+
+func TestIsCppPrimitive(t *testing.T) {
+	for _, p := range []string{"int", "char", "bool", "float", "double", "void", "long", "short", "unsigned", "size_t", "auto", "string"} {
+		assert.True(t, isCppPrimitive(p), "%q should be primitive", p)
+	}
+	for _, np := range []string{"HttpResponse", "Foo", "Service", "Widget"} {
+		assert.False(t, isCppPrimitive(np), "%q should not be primitive", np)
+	}
+}

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -126,6 +126,16 @@ type csharpDeferredLocal struct {
 	defNode *sitter.Node
 }
 
+// csharpTypeUse buffers a type referenced only in a local-variable
+// annotation (`HttpResponse resp = Get();`) so the post-pass can emit an
+// EdgeTypedAs from the enclosing function once funcRanges are built.
+// Field / property annotations emit their edge inline from the member
+// node, so they don't ride this buffer.
+type csharpTypeUse struct {
+	typeText string
+	line     int
+}
+
 // Extract parses the C# source, adaptively recovering symbols that tree-sitter
 // silently drops inside conditional-compilation branches. The grammar parses a
 // #if/#elif/#else block without raising any error, yet omits every declaration
@@ -212,6 +222,7 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 
 	var calls []csharpDeferredCall
 	var locals []csharpDeferredLocal
+	var typeUses []csharpTypeUse
 
 	parser.EachMatch(e.qAll, root, src, func(m parser.QueryResult) {
 		switch {
@@ -276,6 +287,15 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 				rawType: m.Captures["lvar.type"].Text,
 				defNode: m.Captures["lvar.def"].Node,
 			})
+			// Buffer the annotated type so the post-pass (once
+			// funcRanges exist) can attribute an EdgeTypedAs to the
+			// enclosing function — a type used only in a local
+			// annotation seeds tenv but otherwise emits no reference,
+			// so find_usages would miss it without an LSP.
+			typeUses = append(typeUses, csharpTypeUse{
+				typeText: m.Captures["lvar.type"].Text,
+				line:     m.Captures["lvar.type"].StartLine + 1,
+			})
 		}
 	})
 
@@ -324,6 +344,19 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 
 	// Resolve calls against funcRanges + tenv.
 	funcRanges := buildFuncRanges(result)
+
+	// Local-variable type annotations → EdgeTypedAs from the enclosing
+	// function (file node as fallback). Mirrors the parameter/return
+	// type-use emission so a type referenced only in a local body
+	// declaration is still a navigable reference without an LSP.
+	for _, tu := range typeUses {
+		ownerID := findEnclosingFunc(funcRanges, tu.line)
+		if ownerID == "" {
+			ownerID = fileID
+		}
+		emitCSharpTypeUseEdges(ownerID, tu.typeText, filePath, tu.line, result)
+	}
+
 	for _, c := range calls {
 		callerID := findEnclosingFunc(funcRanges, c.line)
 		if callerID == "" {
@@ -760,8 +793,12 @@ func (e *CSharpExtractor) emitField(m parser.QueryResult, filePath, fileID strin
 		"receiver":   owner.name,
 		"visibility": csharpVisibility(def.Node, src, VisibilityPrivate),
 	}
-	if t := def.Node.ChildByFieldName("type"); t != nil {
-		meta["field_type"] = strings.TrimSpace(t.Content(src))
+	// A field_declaration's type lives on its nested variable_declaration
+	// (`field_declaration → variable_declaration[type] → variable_declarator`),
+	// not as a direct `type` field of the field_declaration itself.
+	fieldTypeRaw := csharpFieldDeclType(def.Node, src)
+	if fieldTypeRaw != "" {
+		meta["field_type"] = fieldTypeRaw
 	}
 	// A `const` field is a compile-time constant, not a mutable field —
 	// classify it as KindConstant so it joins the value-reference impact
@@ -792,6 +829,10 @@ func (e *CSharpExtractor) emitField(m parser.QueryResult, filePath, fileID strin
 	result.Edges = append(result.Edges, &graph.Edge{
 		From: id, To: ownerID, Kind: graph.EdgeMemberOf, FilePath: filePath, Line: def.StartLine + 1,
 	})
+	// Field type annotation → EdgeTypedAs from the field node, so a type
+	// used only as a field's declared type (`private Session _s;`) is a
+	// navigable reference without an LSP.
+	emitCSharpTypeUseEdges(id, fieldTypeRaw, filePath, def.StartLine+1, result)
 }
 
 func (e *CSharpExtractor) emitProperty(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen map[string]bool) {
@@ -811,8 +852,10 @@ func (e *CSharpExtractor) emitProperty(m parser.QueryResult, filePath, fileID st
 		"visibility": csharpVisibility(def.Node, src, VisibilityPrivate),
 		"kind":       "property",
 	}
+	var propTypeRaw string
 	if t := def.Node.ChildByFieldName("type"); t != nil {
-		meta["field_type"] = strings.TrimSpace(t.Content(src))
+		propTypeRaw = strings.TrimSpace(t.Content(src))
+		meta["field_type"] = propTypeRaw
 	}
 	if doc := extractCSharpDoc(src, def.StartLine); doc != "" {
 		meta["doc"] = doc
@@ -830,6 +873,8 @@ func (e *CSharpExtractor) emitProperty(m parser.QueryResult, filePath, fileID st
 	result.Edges = append(result.Edges, &graph.Edge{
 		From: id, To: ownerID, Kind: graph.EdgeMemberOf, FilePath: filePath, Line: def.StartLine + 1,
 	})
+	// Property type annotation → EdgeTypedAs from the property node.
+	emitCSharpTypeUseEdges(id, propTypeRaw, filePath, def.StartLine+1, result)
 }
 
 func (e *CSharpExtractor) emitUsing(m parser.QueryResult, filePath, fileID string, result *parser.ExtractionResult) {
@@ -1104,6 +1149,33 @@ func normalizeCSharpTypeName(t string) string {
 		return ""
 	}
 	return t
+}
+
+// csharpFieldDeclType returns the verbatim declared type of a
+// field_declaration. The type is a field of the nested
+// variable_declaration node, not of the field_declaration itself, so a
+// direct ChildByFieldName("type") on the field_declaration is always nil.
+func csharpFieldDeclType(fieldDecl *sitter.Node, src []byte) string {
+	if fieldDecl == nil {
+		return ""
+	}
+	for i := 0; i < int(fieldDecl.NamedChildCount()); i++ {
+		c := fieldDecl.NamedChild(i)
+		if c == nil || c.Type() != "variable_declaration" {
+			continue
+		}
+		if t := c.ChildByFieldName("type"); t != nil {
+			return strings.TrimSpace(t.Content(src))
+		}
+		// Fallback: first named child of the variable_declaration is the
+		// type in grammar revisions that don't tag the field.
+		if c.NamedChildCount() > 0 {
+			if first := c.NamedChild(0); first != nil && first.Type() != "variable_declarator" {
+				return strings.TrimSpace(first.Content(src))
+			}
+		}
+	}
+	return ""
 }
 
 // inferTypeFromCSharpNew extracts the type name from a C# object_creation_expression.

--- a/internal/parser/languages/csharp_function_shape.go
+++ b/internal/parser/languages/csharp_function_shape.go
@@ -221,12 +221,40 @@ func canonicalizeCSharpTypeRef(t string) string {
 
 func isCSharpPrimitive(t string) bool {
 	switch t {
-	case "", "void", "bool", "byte", "sbyte", "short", "ushort",
+	case "", "var", "void", "bool", "byte", "sbyte", "short", "ushort",
 		"int", "uint", "long", "ulong", "float", "double", "decimal",
 		"char", "string", "object", "dynamic":
 		return true
 	}
 	return false
+}
+
+// emitCSharpTypeUseEdges emits one EdgeTypedAs from ownerID to the bare
+// named type used in a variable / field / property annotation. The type
+// is canonicalised to its simple named form (nullable `T?`, arrays
+// `T[]`, and container generics like `List<T>` / `Task<T>` are unwrapped
+// by canonicalizeCSharpTypeRef) and primitives / `var` are skipped so
+// the graph isn't flooded with unresolved::int / unresolved::var edges
+// that never land. Edges ride at OriginASTInferred — the binding is a
+// tree-sitter inference, not an LSP-checked fact — so a type that a local
+// declaration uses (`HttpResponse resp = Get();`) becomes a traversable
+// reference even without a language server.
+func emitCSharpTypeUseEdges(ownerID, typeText, filePath string, line int, result *parser.ExtractionResult) {
+	if ownerID == "" {
+		return
+	}
+	canon := canonicalizeCSharpTypeRef(typeText)
+	if canon == "" || isCSharpPrimitive(canon) {
+		return
+	}
+	result.Edges = append(result.Edges, &graph.Edge{
+		From:     ownerID,
+		To:       "unresolved::" + canon,
+		Kind:     graph.EdgeTypedAs,
+		FilePath: filePath,
+		Line:     line,
+		Origin:   graph.OriginASTInferred,
+	})
 }
 
 // emitCSharpAsyncSpawns walks a C# method body for `await` expressions

--- a/internal/parser/languages/csharp_typeuse_test.go
+++ b/internal/parser/languages/csharp_typeuse_test.go
@@ -1,0 +1,136 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// TestCSharpTypeUse_LocalAnnotation verifies that a type used only in a
+// local-variable annotation inside a method body emits an EdgeTypedAs
+// attributed to the enclosing method — the gap this work closes: such a
+// type previously seeded only tenv and produced no reference, so
+// find_usages missed it without an LSP.
+func TestCSharpTypeUse_LocalAnnotation(t *testing.T) {
+	src := `public class Svc {
+	public void Handle() {
+		HttpResponse resp = Get();
+		int n = Count();
+	}
+}
+`
+	_, edges := runCSharpExtract(t, "x/Svc.cs", src)
+
+	typed := edgesByKind(edges, graph.EdgeTypedAs)
+
+	const methodID = "x/Svc.cs::Svc.Handle"
+	foundFromMethod := false
+	for _, e := range typed {
+		if e.To != "unresolved::HttpResponse" {
+			continue
+		}
+		if e.From != methodID {
+			t.Errorf("expected EdgeTypedAs → HttpResponse from enclosing method %q, got From=%q", methodID, e.From)
+		}
+		if e.Origin != graph.OriginASTInferred {
+			t.Errorf("expected Origin=OriginASTInferred, got %v", e.Origin)
+		}
+		foundFromMethod = true
+	}
+	if !foundFromMethod {
+		t.Errorf("expected EdgeTypedAs → unresolved::HttpResponse from a local annotation; got %v", edgeTargets(typed))
+	}
+
+	// A primitive local annotation (`int n = ...`) must NOT emit a
+	// type-use edge.
+	for _, e := range typed {
+		if e.To == "unresolved::int" {
+			t.Errorf("primitive int must not emit EdgeTypedAs; got %v", edgeTargets(typed))
+		}
+	}
+}
+
+// TestCSharpTypeUse_VarLocalNoEdge confirms that `var x = ...` — which
+// has no explicit annotation — emits no spurious unresolved::var edge.
+func TestCSharpTypeUse_VarLocalNoEdge(t *testing.T) {
+	src := `public class Svc {
+	public void Handle() {
+		var u = new User();
+	}
+}
+`
+	_, edges := runCSharpExtract(t, "x/Svc.cs", src)
+	for _, e := range edgesByKind(edges, graph.EdgeTypedAs) {
+		if e.To == "unresolved::var" {
+			t.Fatalf("`var` must not emit an EdgeTypedAs to unresolved::var")
+		}
+	}
+}
+
+// TestCSharpTypeUse_NullableAndGeneric verifies nullable (`Session?`) and
+// container-generic (`List<Order>`) local annotations canonicalise to
+// their bare named type.
+func TestCSharpTypeUse_NullableAndGeneric(t *testing.T) {
+	src := `using System.Collections.Generic;
+
+public class Svc {
+	public void Handle() {
+		Session? s = Resolve();
+		List<Order> orders = Load();
+	}
+}
+`
+	_, edges := runCSharpExtract(t, "x/Svc.cs", src)
+	typed := edgesByKind(edges, graph.EdgeTypedAs)
+	want := map[string]bool{"unresolved::Session": false, "unresolved::Order": false}
+	for _, e := range typed {
+		if _, ok := want[e.To]; ok {
+			want[e.To] = true
+		}
+	}
+	for tgt, found := range want {
+		if !found {
+			t.Errorf("expected EdgeTypedAs → %s (nullable/generic unwrapped); got %v", tgt, edgeTargets(typed))
+		}
+	}
+}
+
+// TestCSharpTypeUse_FieldAndProperty verifies that a type used only as a
+// field's or property's declared type emits an EdgeTypedAs from the
+// member node.
+func TestCSharpTypeUse_FieldAndProperty(t *testing.T) {
+	src := `public class Svc {
+	private Session _s;
+	private int _count;
+	public Repository Repo { get; set; }
+}
+`
+	_, edges := runCSharpExtract(t, "x/Svc.cs", src)
+	typed := edgesByKind(edges, graph.EdgeTypedAs)
+
+	type want struct {
+		from, to string
+	}
+	wants := []want{
+		{"x/Svc.cs::Svc._s", "unresolved::Session"},
+		{"x/Svc.cs::Svc.Repo", "unresolved::Repository"},
+	}
+	for _, w := range wants {
+		found := false
+		for _, e := range typed {
+			if e.From == w.from && e.To == w.to {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected EdgeTypedAs %s → %s; got %v", w.from, w.to, edgeTargets(typed))
+		}
+	}
+
+	// The primitive field `_count` (int) must not emit a type-use edge.
+	for _, e := range typed {
+		if e.To == "unresolved::int" {
+			t.Errorf("primitive int field must not emit EdgeTypedAs; got %v", edgeTargets(typed))
+		}
+	}
+}

--- a/internal/parser/languages/dart.go
+++ b/internal/parser/languages/dart.go
@@ -71,6 +71,11 @@ func (e *DartExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 	// Call sites.
 	e.extractCalls(root, src, filePath, result, imports)
 
+	// Cross-file type-usage edges for declaration-position types (fields,
+	// parameters, return types, typed locals) — runs after the symbol
+	// extractors so the enclosing-owner ranges are populated.
+	e.extractTypeUses(root, src, filePath, fileNode, result)
+
 	captureValueRefCandidates(result, root, filePath, src)
 	captureFnValueCandidates(result, root, filePath, src)
 	return result, nil

--- a/internal/parser/languages/dart_typeuse.go
+++ b/internal/parser/languages/dart_typeuse.go
@@ -1,0 +1,342 @@
+package languages
+
+import (
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	sitter "github.com/zzet/gortex/internal/parser/tsitter"
+)
+
+// extractTypeUses emits cross-file type-usage edges (EdgeTypedAs to
+// "unresolved::"+Type, Origin OriginASTInferred) for every Dart type that
+// appears in a declaration position the symbol extractors don't already
+// cover:
+//
+//   - class / mixin / extension fields (`final Foo foo;`)
+//   - function & method parameter types (`void f(Foo x)`)
+//   - function & method return types (`Foo build()`)
+//   - typed local variables (`Foo x = ...`, `final Foo x = ...`)
+//
+// This is the LSP-free guarantee: a Dart type named in a declaration always
+// produces a usage edge, so find_usages lands it without a language server.
+// Inferred bindings (`var x = ...`, `final x = ...`) carry no written type
+// and are skipped — there is nothing to attribute.
+//
+// Fields attribute to the file node (the extractor doesn't materialise a
+// per-field symbol node). Parameters and return types attribute to the
+// enclosing function / method node. Typed locals attribute to the enclosing
+// function via the same funcRange mechanism extractCalls uses, falling back
+// to the file node when no function encloses the line (e.g. a typed local in
+// a field initialiser).
+func (e *DartExtractor) extractTypeUses(
+	root *sitter.Node, src []byte, filePath string, fileNode *graph.Node,
+	result *parser.ExtractionResult,
+) {
+	funcRanges := buildFuncRanges(result)
+
+	// Dedup key across the whole file so a type that appears in two positions
+	// attributed to the same owner emits a single edge (no double-emit).
+	seen := map[string]bool{}
+	emit := func(ownerID, typeText string, line int) {
+		emitDartTypeUseEdges(ownerID, typeText, filePath, line, result, seen)
+	}
+
+	walkNodes(root, func(node *sitter.Node) {
+		switch node.Type() {
+		case "declaration":
+			// Class / mixin / extension field: `[final|const|static] Foo bar;`.
+			// Only treat it as a field when it lives in a type body — a bare
+			// `declaration` elsewhere (forward signatures) has no owning field
+			// node to attribute to.
+			parent := node.Parent()
+			if parent == nil {
+				return
+			}
+			switch parent.Type() {
+			case "class_body", "mixin_body", "extension_body", "enum_body":
+			default:
+				return
+			}
+			if t := dartLeadingTypeText(node, src); t != "" {
+				emit(fileNode.ID, t, int(node.StartPoint().Row)+1)
+			}
+
+		case "local_variable_declaration":
+			// `Foo x = ...;` inside a function/method body. The grammar wraps
+			// the binding in initialized_variable_definition; the leading type
+			// precedes the bound identifier.
+			ivd := dartFirstChildOfType(node, "initialized_variable_definition")
+			if ivd == nil {
+				return
+			}
+			t := dartLeadingTypeText(ivd, src)
+			if t == "" {
+				return
+			}
+			line := int(node.StartPoint().Row) + 1
+			owner := findEnclosingFunc(funcRanges, line)
+			if owner == "" {
+				owner = fileNode.ID
+			}
+			emit(owner, t, line)
+
+		case "formal_parameter":
+			// Parameter type: `Foo x` / `Foo? x` / `List<Foo> x`. Attribute to
+			// the enclosing function / method. Default-value-only parameters
+			// (`this.x`, `super.x`, untyped) carry no leading type → skipped.
+			t := dartLeadingTypeText(node, src)
+			if t == "" {
+				return
+			}
+			line := int(node.StartPoint().Row) + 1
+			owner := findEnclosingFunc(funcRanges, line)
+			if owner == "" {
+				owner = fileNode.ID
+			}
+			emit(owner, t, line)
+
+		case "function_signature":
+			// Declared return type — the type that precedes the function name.
+			// Attribute to the function / method node enclosing the signature
+			// line. dartMethodReturnType only captured the bare head; we want
+			// the full `Future<Response>` so generic args surface too.
+			t := dartReturnTypeText(node, src)
+			if t == "" {
+				return
+			}
+			line := int(node.StartPoint().Row) + 1
+			owner := findEnclosingFunc(funcRanges, line)
+			if owner == "" {
+				owner = fileNode.ID
+			}
+			emit(owner, t, line)
+		}
+	})
+}
+
+// emitDartTypeUseEdges canonicalizes typeText to its bare named type(s) and
+// appends one EdgeTypedAs (To "unresolved::"+type, Origin OriginASTInferred)
+// per distinct, non-primitive type, deduped on (ownerID, type) via seen.
+//
+// Nullable suffixes (`?`) are stripped; generic / container wrappers
+// (`List<Foo>`, `Future<Foo>`, `Map<K,Foo>`) are unwrapped to every named
+// type argument so a container-typed declaration still references the element
+// type. Dart primitives / builtins (int, double, num, bool, String, void,
+// dynamic, Object, var, …) carry no useful target and are skipped.
+func emitDartTypeUseEdges(ownerID, typeText, filePath string, line int, result *parser.ExtractionResult, seen map[string]bool) {
+	if ownerID == "" {
+		return
+	}
+	for _, t := range dartNamedTypes(typeText) {
+		if t == "" || isDartPrimitive(t) {
+			continue
+		}
+		key := ownerID + "\x00" + t
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		result.Edges = append(result.Edges, &graph.Edge{
+			From:     ownerID,
+			To:       "unresolved::" + t,
+			Kind:     graph.EdgeTypedAs,
+			FilePath: filePath,
+			Line:     line,
+			Origin:   graph.OriginASTInferred,
+		})
+	}
+}
+
+// dartLeadingTypeText returns the verbatim source of the leading type
+// annotation of a declaration-shaped node (class field declaration,
+// initialized_variable_definition, formal_parameter). It returns "" when the
+// declaration is type-inferred (`var` / `final` with no explicit type) or has
+// no annotation. The leading type is whatever precedes the first bound
+// identifier; a `nullable_type "?"` sibling is folded back in so `Foo?` is
+// reported as `Foo?`.
+func dartLeadingTypeText(node *sitter.Node, src []byte) string {
+	if node == nil {
+		return ""
+	}
+	typeText := ""
+	for i := 0; i < int(node.NamedChildCount()); i++ {
+		c := node.NamedChild(i)
+		if c == nil {
+			continue
+		}
+		switch c.Type() {
+		case "final_builtin", "const_builtin", "static", "late", "covariant",
+			"metadata", "documentation_comment", "comment":
+			// modifiers / annotations that precede the type — skip.
+			continue
+		case "inferred_type":
+			// `var` — no explicit type to attribute.
+			return ""
+		case "type_identifier", "type", "function_type", "record_type":
+			typeText = strings.TrimSpace(c.Content(src))
+		case "type_arguments":
+			// Generic args follow the head type_identifier; the head's
+			// Content does not include them, so append.
+			if typeText != "" {
+				typeText += strings.TrimSpace(c.Content(src))
+			}
+		case "nullable_type":
+			if typeText != "" {
+				typeText += "?"
+			}
+		case "initialized_identifier_list", "initialized_identifier", "identifier":
+			// Reached the bound name — the type (if any) is complete.
+			return typeText
+		}
+	}
+	return typeText
+}
+
+// dartReturnTypeText returns the full declared return type of a
+// function_signature, including generic arguments (`Future<Response>`). It
+// returns "" when the signature has no leading return type (an inferred-void
+// `build()`, a getter/setter, or an operator). The return type is whatever
+// precedes the function name identifier.
+func dartReturnTypeText(fnSig *sitter.Node, src []byte) string {
+	if fnSig == nil {
+		return ""
+	}
+	typeText := ""
+	for i := 0; i < int(fnSig.NamedChildCount()); i++ {
+		c := fnSig.NamedChild(i)
+		if c == nil {
+			continue
+		}
+		switch c.Type() {
+		case "type_identifier", "type", "void_type":
+			typeText = strings.TrimSpace(c.Content(src))
+		case "type_arguments":
+			if typeText != "" {
+				typeText += strings.TrimSpace(c.Content(src))
+			}
+		case "nullable_type":
+			if typeText != "" {
+				typeText += "?"
+			}
+		case "identifier", "function_type":
+			// Reached the function name — return type complete.
+			return typeText
+		}
+	}
+	return typeText
+}
+
+// dartFirstChildOfType returns the first named child of node whose type is
+// nodeType, or nil.
+func dartFirstChildOfType(node *sitter.Node, nodeType string) *sitter.Node {
+	if node == nil {
+		return nil
+	}
+	for i := 0; i < int(node.NamedChildCount()); i++ {
+		c := node.NamedChild(i)
+		if c != nil && c.Type() == nodeType {
+			return c
+		}
+	}
+	return nil
+}
+
+// dartNamedTypes canonicalizes a Dart type-text into the set of named types it
+// references. It strips nullable `?`, unwraps generic containers
+// (`List<Foo>`, `Future<Foo>`, `Map<K, Foo>`) to every named type argument,
+// and drops library prefixes (`prefix.Foo` → `Foo`). A simple `Foo` yields
+// `[Foo]`; `Map<String, User>` yields `[String, User]` (String filtered out
+// later as a primitive). Returns nil for empty / function / record types,
+// which have no single named target.
+func dartNamedTypes(typeText string) []string {
+	typeText = strings.TrimSpace(typeText)
+	if typeText == "" {
+		return nil
+	}
+	// Strip trailing nullable markers.
+	typeText = strings.TrimRight(typeText, "?")
+	typeText = strings.TrimSpace(typeText)
+	if typeText == "" {
+		return nil
+	}
+	// Function / record types have no single named target.
+	if strings.ContainsAny(typeText, "(") || strings.Contains(typeText, "Function") {
+		return nil
+	}
+
+	var out []string
+	// Split off generic arguments: head<args>.
+	head := typeText
+	args := ""
+	if lt := strings.IndexByte(typeText, '<'); lt >= 0 && strings.HasSuffix(typeText, ">") {
+		head = typeText[:lt]
+		args = typeText[lt+1 : len(typeText)-1]
+	}
+	if h := dartBareTypeName(head); h != "" {
+		out = append(out, h)
+	}
+	if args != "" {
+		for _, a := range splitDartTypeArgs(args) {
+			out = append(out, dartNamedTypes(a)...)
+		}
+	}
+	return out
+}
+
+// dartBareTypeName strips a library prefix (`p.Foo` → `Foo`), nullable
+// markers, and surrounding whitespace from a single (non-generic) type token.
+func dartBareTypeName(t string) string {
+	t = strings.TrimSpace(t)
+	t = strings.TrimRight(t, "?")
+	t = strings.TrimSpace(t)
+	if t == "" {
+		return ""
+	}
+	if idx := strings.LastIndex(t, "."); idx >= 0 {
+		t = t[idx+1:]
+	}
+	return strings.TrimSpace(t)
+}
+
+// splitDartTypeArgs splits a generic argument list at top-level commas,
+// respecting nested `<…>` so `Map<String, List<User>>` splits into
+// `String` and `List<User>`.
+func splitDartTypeArgs(args string) []string {
+	var parts []string
+	depth := 0
+	start := 0
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case '<', '(':
+			depth++
+		case '>', ')':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				parts = append(parts, args[start:i])
+				start = i + 1
+			}
+		}
+	}
+	parts = append(parts, args[start:])
+	for i := range parts {
+		parts[i] = strings.TrimSpace(parts[i])
+	}
+	return parts
+}
+
+// isDartPrimitive reports whether t names a Dart builtin / primitive type that
+// doesn't need a usage edge — emitting these would just clutter the graph with
+// unresolved::int / unresolved::String edges that never land on a workspace
+// declaration.
+func isDartPrimitive(t string) bool {
+	switch t {
+	case "", "int", "double", "num", "bool", "String", "void", "dynamic",
+		"Object", "Null", "Never", "var", "this":
+		return true
+	}
+	return false
+}

--- a/internal/parser/languages/dart_typeuse_test.go
+++ b/internal/parser/languages/dart_typeuse_test.go
@@ -1,0 +1,153 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// typedAsTargets collects every EdgeTypedAs `To` target whose `From` matches
+// owner (or any owner when owner == "").
+func typedAsTargets(edges []*graph.Edge, owner string) map[string]bool {
+	out := map[string]bool{}
+	for _, e := range edges {
+		if e.Kind != graph.EdgeTypedAs {
+			continue
+		}
+		if owner != "" && e.From != owner {
+			continue
+		}
+		out[e.To] = true
+	}
+	return out
+}
+
+// TestDartTypeUse_LocalVariable is the named acceptance test: a typed local
+// `HttpResponse resp = get();` must emit an EdgeTypedAs to
+// unresolved::HttpResponse attributed to the enclosing function, and a `int`
+// local must emit no type-use edge.
+func TestDartTypeUse_LocalVariable(t *testing.T) {
+	src := []byte(`class Api {
+  void load() {
+    HttpResponse resp = get();
+    int count = 0;
+  }
+}
+`)
+	res, err := NewDartExtractor().Extract("api.dart", src)
+	require.NoError(t, err)
+
+	// EdgeTypedAs to HttpResponse, attributed to the enclosing method.
+	require.True(t,
+		hasEdgeBetween(res.Edges, graph.EdgeTypedAs, "api.dart::Api.load", "unresolved::HttpResponse"),
+		"typed local `HttpResponse resp` should emit EdgeTypedAs to the enclosing method; edges=%v", res.Edges)
+
+	// Origin must be OriginASTInferred.
+	for _, e := range res.Edges {
+		if e.Kind == graph.EdgeTypedAs && e.To == "unresolved::HttpResponse" {
+			assert.Equal(t, graph.OriginASTInferred, e.Origin)
+		}
+	}
+
+	// Primitive `int` must never produce a type-use edge.
+	all := typedAsTargets(res.Edges, "")
+	assert.NotContains(t, all, "unresolved::int", "primitive int must not emit a type-use edge")
+}
+
+// TestDartTypeUse_FieldParamReturn covers the three remaining positions:
+// class fields, parameter types, and return types.
+func TestDartTypeUse_FieldParamReturn(t *testing.T) {
+	src := []byte(`class Service {
+  final HttpClient client;
+  Repository repo = makeRepo();
+
+  Future<Response> fetch(Request req, [Logger? log]) async {
+    return get();
+  }
+}
+
+User build(Config cfg) {
+  return User();
+}
+`)
+	res, err := NewDartExtractor().Extract("svc.dart", src)
+	require.NoError(t, err)
+
+	// Fields attribute to the file node.
+	fileTargets := typedAsTargets(res.Edges, "svc.dart")
+	assert.True(t, fileTargets["unresolved::HttpClient"], "field type HttpClient")
+	assert.True(t, fileTargets["unresolved::Repository"], "field type Repository")
+
+	// Method return + param types attribute to the method node.
+	methodTargets := typedAsTargets(res.Edges, "svc.dart::Service.fetch")
+	assert.True(t, methodTargets["unresolved::Future"], "return head Future")
+	assert.True(t, methodTargets["unresolved::Response"], "return generic arg Response")
+	assert.True(t, methodTargets["unresolved::Request"], "param type Request")
+	assert.True(t, methodTargets["unresolved::Logger"], "nullable param type Logger (? stripped)")
+
+	// Top-level function return + param attribute to the function node.
+	fnTargets := typedAsTargets(res.Edges, "svc.dart::build")
+	assert.True(t, fnTargets["unresolved::User"], "function return type User")
+	assert.True(t, fnTargets["unresolved::Config"], "function param type Config")
+
+	// No primitive / builtin leaked anywhere.
+	all := typedAsTargets(res.Edges, "")
+	for _, prim := range []string{"int", "double", "num", "bool", "String", "void", "dynamic", "Object", "var"} {
+		assert.NotContains(t, all, "unresolved::"+prim, "primitive %s must not emit a type-use edge", prim)
+	}
+}
+
+// TestDartTypeUse_GenericContainersUnwrapped verifies List<Foo> / Map<K,V>
+// unwrap to every named element type, and `var` / `final` (inferred) locals
+// emit nothing.
+func TestDartTypeUse_GenericContainersUnwrapped(t *testing.T) {
+	src := []byte(`class Store {
+  List<User> users = [];
+  Map<String, Token> tokens = {};
+
+  void run() {
+    var anything = compute();
+    final inferred = compute();
+    Set<Account> accounts = {};
+  }
+}
+`)
+	res, err := NewDartExtractor().Extract("store.dart", src)
+	require.NoError(t, err)
+
+	all := typedAsTargets(res.Edges, "")
+	assert.True(t, all["unresolved::User"], "List<User> unwraps to User")
+	assert.True(t, all["unresolved::Token"], "Map<String, Token> unwraps to Token")
+	assert.True(t, all["unresolved::Account"], "Set<Account> unwraps to Account")
+
+	// String is a primitive key — never emitted.
+	assert.NotContains(t, all, "unresolved::String")
+
+	// Inferred `var` / `final` locals carry no type → no edge for them.
+	// (compute is a call, captured as EdgeCalls, not EdgeTypedAs.)
+	runTargets := typedAsTargets(res.Edges, "store.dart::Store.run")
+	assert.True(t, runTargets["unresolved::Account"], "typed local Set<Account> attributes to run")
+}
+
+// TestDartTypeUse_NoDuplicateEdges guards against double-emitting the same
+// (owner, type) pair when a type appears in multiple positions of one owner.
+func TestDartTypeUse_NoDuplicateEdges(t *testing.T) {
+	src := []byte(`class C {
+  void f(Widget a, Widget b) {
+    Widget local = a;
+  }
+}
+`)
+	res, err := NewDartExtractor().Extract("c.dart", src)
+	require.NoError(t, err)
+
+	count := 0
+	for _, e := range res.Edges {
+		if e.Kind == graph.EdgeTypedAs && e.From == "c.dart::C.f" && e.To == "unresolved::Widget" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "Widget used in two params + a local must emit exactly one TypedAs edge for the method")
+}

--- a/internal/parser/languages/java.go
+++ b/internal/parser/languages/java.go
@@ -165,6 +165,17 @@ type javaDeferredVar struct {
 	isLocal  bool
 }
 
+// javaTypeUse buffers a local-variable / field type annotation whose
+// EdgeTypedAs is emitted after funcRanges is built, so the reference is
+// attributed to its enclosing method (falling back to the file node).
+// The raw annotation text is kept verbatim — emitJavaTypeUseEdges
+// canonicalizes it (strip generics / array / package prefix) and skips
+// primitives, mirroring the param / return type edges.
+type javaTypeUse struct {
+	typeText string
+	line     int // 1-based
+}
+
 func (e *JavaExtractor) Extract(filePath string, src []byte) (*parser.ExtractionResult, error) {
 	tree, err := parser.ParseFile(src, e.lang)
 	if err != nil {
@@ -190,6 +201,7 @@ func (e *JavaExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 
 	var calls []javaDeferredCall
 	var varBuf []javaDeferredVar
+	var typeUses []javaTypeUse
 
 	parser.EachMatch(e.qAll, root, src, func(m parser.QueryResult) {
 		switch {
@@ -226,6 +238,12 @@ func (e *JavaExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 				defNode:  m.Captures["fvar.def"].Node,
 				isLocal:  false,
 			})
+			// A typed field (`Foo bar;`) references type Foo — buffer it
+			// so find_usages(Foo) surfaces the declaration without an LSP.
+			typeUses = append(typeUses, javaTypeUse{
+				typeText: m.Captures["fvar.type"].Text,
+				line:     m.Captures["fvar.def"].StartLine + 1,
+			})
 
 		case m.Captures["lvar.def"] != nil:
 			varBuf = append(varBuf, javaDeferredVar{
@@ -233,6 +251,13 @@ func (e *JavaExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 				explicit: normalizeJavaTypeName(m.Captures["lvar.type"].Text),
 				defNode:  m.Captures["lvar.def"].Node,
 				isLocal:  true,
+			})
+			// A typed local (`HttpResponse resp = …`) references its type
+			// in declaration position — buffer the EdgeTypedAs so it's a
+			// first-class cross-file reference even without an LSP.
+			typeUses = append(typeUses, javaTypeUse{
+				typeText: m.Captures["lvar.type"].Text,
+				line:     m.Captures["lvar.def"].StartLine + 1,
 			})
 
 		case m.Captures["import.def"] != nil:
@@ -329,6 +354,22 @@ func (e *JavaExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 	// All function/method nodes have been emitted; map call sites to
 	// their enclosing definition.
 	funcRanges := buildFuncRanges(result)
+
+	// Type-use edges: a `Foo x = …` local declaration or a `Foo bar;`
+	// field declaration references type Foo. Attributed to the enclosing
+	// method (fallback: the file node) so find_usages(Foo) surfaces every
+	// declaration site without an LSP. EdgeTypedAs mirrors the param /
+	// return type edges; the resolver lands it cross-file via the same
+	// name-based pass. Params / return types already emit their own
+	// EdgeTypedAs via emitJavaFunctionShape, so this only covers the
+	// local / field annotation positions that were previously edge-less.
+	for _, tu := range typeUses {
+		ownerID := findEnclosingFunc(funcRanges, tu.line)
+		if ownerID == "" {
+			ownerID = fileID
+		}
+		emitJavaTypeUseEdges(ownerID, tu.typeText, filePath, tu.line, result)
+	}
 	// @Value("${key:Default}") fields → their literal defaults, for invoker
 	// dispatch through a Spring-injected field (built only when invoker
 	// detection is configured).

--- a/internal/parser/languages/java_function_shape.go
+++ b/internal/parser/languages/java_function_shape.go
@@ -152,6 +152,28 @@ func emitJavaReturnEdges(ownerID, returnText, filePath string, line int, result 
 	})
 }
 
+// emitJavaTypeUseEdges parses a local-variable / field type annotation
+// and emits one EdgeTypedAs to unresolved::<type>, so a type used only
+// in declaration position (`HttpResponse resp = client.get();`) is a
+// first-class cross-file reference the name-based resolver can land
+// without an LSP. Bare-type canonicalization (strip generics <…>, array
+// [], varargs …, package prefix) and primitive skipping reuse the same
+// helpers as the param / return type edges. Mirrors emitJavaReturnEdges.
+func emitJavaTypeUseEdges(ownerID, typeText, filePath string, line int, result *parser.ExtractionResult) {
+	t := canonicalizeJavaTypeRef(typeText)
+	if t == "" || isJavaPrimitive(t) {
+		return
+	}
+	result.Edges = append(result.Edges, &graph.Edge{
+		From:     ownerID,
+		To:       "unresolved::" + t,
+		Kind:     graph.EdgeTypedAs,
+		FilePath: filePath,
+		Line:     line,
+		Origin:   graph.OriginASTInferred,
+	})
+}
+
 func emitJavaGenericParamNodes(ownerID string, methodNode *sitter.Node, src []byte, filePath string, line int, result *parser.ExtractionResult) {
 	tparams := methodNode.ChildByFieldName("type_parameters")
 	if tparams == nil {

--- a/internal/parser/languages/java_typeuse_test.go
+++ b/internal/parser/languages/java_typeuse_test.go
@@ -1,0 +1,109 @@
+package languages
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// TestJavaTypeUse_LocalVariableEmitsTypedAs pins the LSP-free recall fix
+// for Java: a `HttpResponse resp = client.get();` local declaration
+// references type HttpResponse and must emit exactly one EdgeTypedAs to
+// unresolved::HttpResponse, attributed to the enclosing method. Before
+// the fix it only seeded the local type-env map (recall ~0 without an
+// LSP). A primitive (`int`) declaration in the same body must emit none.
+func TestJavaTypeUse_LocalVariableEmitsTypedAs(t *testing.T) {
+	src := `package app;
+
+public class Handler {
+	public void handle() {
+		HttpResponse resp = client.get();
+		int count = 0;
+		use(resp, count);
+	}
+}
+`
+	_, edges := runJavaExtract(t, "app/Handler.java", src)
+
+	var hits []*graph.Edge
+	for _, e := range edges {
+		if e.Kind == graph.EdgeTypedAs && e.To == "unresolved::HttpResponse" {
+			hits = append(hits, e)
+		}
+	}
+	if len(hits) != 1 {
+		t.Fatalf("expected exactly 1 EdgeTypedAs -> unresolved::HttpResponse for the local `HttpResponse resp`, got %d: %v", len(hits), edgeTargets(edgesByKind(edges, graph.EdgeTypedAs)))
+	}
+	if !strings.Contains(hits[0].From, "handle") {
+		t.Errorf("EdgeTypedAs From = %q, want it attributed to handle()", hits[0].From)
+	}
+	if hits[0].Origin != graph.OriginASTInferred {
+		t.Errorf("EdgeTypedAs Origin = %q, want OriginASTInferred", hits[0].Origin)
+	}
+
+	// The primitive local `int count` must not seed a type-use edge.
+	for _, e := range edges {
+		if e.Kind == graph.EdgeTypedAs && (e.To == "unresolved::int" || e.To == "unresolved::count") {
+			t.Errorf("primitive local emitted a type-use edge: %s -> %s", e.From, e.To)
+		}
+	}
+}
+
+// TestJavaTypeUse_FieldEmitsTypedAs pins the field-annotation half of the
+// fix: a typed field (`Clock clock;`) references type Clock and must emit
+// an EdgeTypedAs to unresolved::Clock without an LSP.
+func TestJavaTypeUse_FieldEmitsTypedAs(t *testing.T) {
+	src := `package app;
+
+public class Service {
+	private Clock clock;
+	private int retries;
+}
+`
+	_, edges := runJavaExtract(t, "app/Service.java", src)
+
+	var hits []*graph.Edge
+	for _, e := range edges {
+		if e.Kind == graph.EdgeTypedAs && e.To == "unresolved::Clock" {
+			hits = append(hits, e)
+		}
+	}
+	if len(hits) != 1 {
+		t.Fatalf("expected exactly 1 EdgeTypedAs -> unresolved::Clock for field `Clock clock`, got %d: %v", len(hits), edgeTargets(edgesByKind(edges, graph.EdgeTypedAs)))
+	}
+
+	// The primitive field `int retries` must not seed a type-use edge.
+	for _, e := range edges {
+		if e.Kind == graph.EdgeTypedAs && e.To == "unresolved::int" {
+			t.Errorf("primitive field emitted a type-use edge: %s -> %s", e.From, e.To)
+		}
+	}
+}
+
+// TestJavaTypeUse_GenericLocalUnwraps confirms a parameterized local
+// (`List<User> users = ...`) emits the bare element / container type per
+// canonicalizeJavaTypeRef (List<User> -> User), matching how param /
+// return edges treat the same wrappers.
+func TestJavaTypeUse_GenericLocalUnwraps(t *testing.T) {
+	src := `package app;
+
+public class Repo {
+	public void load() {
+		List<User> users = fetch();
+		use(users);
+	}
+}
+`
+	_, edges := runJavaExtract(t, "app/Repo.java", src)
+
+	hasUser := false
+	for _, e := range edges {
+		if e.Kind == graph.EdgeTypedAs && e.To == "unresolved::User" {
+			hasUser = true
+		}
+	}
+	if !hasUser {
+		t.Errorf("expected EdgeTypedAs -> unresolved::User (List<User> unwrapped); got %v", edgeTargets(edgesByKind(edges, graph.EdgeTypedAs)))
+	}
+}

--- a/internal/parser/languages/kotlin.go
+++ b/internal/parser/languages/kotlin.go
@@ -92,6 +92,17 @@ type kotlinDeferredProperty struct {
 	endLine     int
 }
 
+// kotlinTypeUse buffers a variable/property annotation (`val x: T`,
+// `var x: T`) for the post-pass that emits EdgeTypedAs from the enclosing
+// function (or the file node when the annotation is top-level). The
+// package has no shared deferredTypeUse type, so this mirrors the TS
+// deferredTypeUse struct locally. typeText is the verbatim annotation
+// source; it is normalized at emit time by emitKotlinTypeUseEdges.
+type kotlinTypeUse struct {
+	typeText string
+	line     int
+}
+
 // kotlinLambdaScope records the parameters bound by one lambda literal
 // over the line span of its body. A use of such a parameter inside the
 // span is locally bound and must not be resolved against the outer type
@@ -127,6 +138,7 @@ func (e *KotlinExtractor) Extract(filePath string, src []byte) (*parser.Extracti
 
 	var calls []kotlinDeferredCall
 	var props []kotlinDeferredProperty
+	var typeUses []kotlinTypeUse
 
 	parser.EachMatch(e.qAll, root, src, func(m parser.QueryResult) {
 		switch {
@@ -145,7 +157,8 @@ func (e *KotlinExtractor) Extract(filePath string, src []byte) (*parser.Extracti
 			// also see the same property via prop.def below for top-level
 			// node emission and Tier 1 fallback.
 			name := m.Captures["tprop.name"].Text
-			typeName := normalizeKotlinTypeName(m.Captures["tprop.type"].Text)
+			rawType := m.Captures["tprop.type"].Text
+			typeName := normalizeKotlinTypeName(rawType)
 			if typeName != "" {
 				// Stash on the matching prop entry by appending a sentinel;
 				// we'll merge in the post-pass. Use a separate slice keyed
@@ -155,6 +168,14 @@ func (e *KotlinExtractor) Extract(filePath string, src []byte) (*parser.Extracti
 					explicit: typeName,
 				})
 			}
+			// Buffer the annotation for a type-use edge: every `val x: T` /
+			// `var x: T` (local, property, or top-level) references type T.
+			// The owner (enclosing function, else the file node) is resolved
+			// in the post-pass once funcRanges is built.
+			typeUses = append(typeUses, kotlinTypeUse{
+				typeText: rawType,
+				line:     m.Captures["tprop.def"].StartLine + 1,
+			})
 
 		case m.Captures["prop.def"] != nil:
 			def := m.Captures["prop.def"]
@@ -274,6 +295,21 @@ func (e *KotlinExtractor) Extract(filePath string, src []byte) (*parser.Extracti
 
 	// Resolve calls against funcRanges + tenv.
 	funcRanges := buildFuncRanges(result)
+
+	// Variable / property annotations (`val x: T` / `var x: T`) reference
+	// type T. Attribute each EdgeTypedAs to the enclosing function (so a
+	// find_usages of T lands on the function that uses it), falling back to
+	// the file node for top-level / class-body properties outside any
+	// function range. Parameter and return-type edges are emitted inline by
+	// emitKotlinFunctionShape; this post-pass covers the body/property case.
+	for _, tu := range typeUses {
+		ownerID := findEnclosingFunc(funcRanges, tu.line)
+		if ownerID == "" {
+			ownerID = fileID
+		}
+		emitKotlinTypeUseEdges(ownerID, tu.typeText, filePath, tu.line, result)
+	}
+
 	for _, c := range calls {
 		callerID := findEnclosingFunc(funcRanges, c.line)
 		if callerID == "" {
@@ -517,6 +553,7 @@ func (e *KotlinExtractor) emitFunction(m parser.QueryResult, filePath, fileID st
 			From: id, To: ownerID, Kind: graph.EdgeMemberOf, FilePath: filePath, Line: startLine1,
 		})
 		emitKotlinAnnotationEdges(kotlinCollectAnnotations(def.Node, src), id, filePath, result, annotationSeen)
+		emitKotlinFunctionShape(id, def.Node, src, filePath, startLine1, result)
 		if body := kotlinFunctionBody(def.Node); body != nil {
 			emitKotlinAsyncSpawns(id, body, src, filePath, result)
 		}
@@ -582,6 +619,7 @@ func (e *KotlinExtractor) emitFunction(m parser.QueryResult, filePath, fileID st
 		From: fileID, To: id, Kind: graph.EdgeDefines, FilePath: filePath, Line: startLine1,
 	})
 	emitKotlinAnnotationEdges(kotlinCollectAnnotations(def.Node, src), id, filePath, result, annotationSeen)
+	emitKotlinFunctionShape(id, def.Node, src, filePath, startLine1, result)
 	if body := kotlinFunctionBody(def.Node); body != nil {
 		emitKotlinAsyncSpawns(id, body, src, filePath, result)
 	}

--- a/internal/parser/languages/kotlin_function_shape.go
+++ b/internal/parser/languages/kotlin_function_shape.go
@@ -1,6 +1,8 @@
 package languages
 
 import (
+	"strconv"
+
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/parser"
 	sitter "github.com/zzet/gortex/internal/parser/tsitter"
@@ -185,4 +187,172 @@ func kotlinFunctionBody(funcNode *sitter.Node) *sitter.Node {
 		}
 	}
 	return nil
+}
+
+// emitKotlinTypeUseEdges emits an EdgeTypedAs from ownerID to the bare
+// named type that typeText references, so a tree-sitter-only build still
+// links a Kotlin symbol to the type it is annotated with (parameter,
+// return, local `val`/`var`, or property). typeText is the verbatim
+// annotation source; it is normalized through normalizeKotlinTypeName,
+// which strips the nullable `?` suffix and generic `<…>` arguments and
+// drops Kotlin primitives (Int, String, Boolean, …) and lowercase names.
+// No edge is emitted for an empty or primitive type. The target is
+// `unresolved::<Type>`; the resolver lands it on a KindType / KindInterface
+// of the same name. Mirrors emitTSTypeUseEdges / emitPyTypeUseEdges.
+func emitKotlinTypeUseEdges(ownerID, typeText, filePath string, line int, result *parser.ExtractionResult) {
+	if ownerID == "" {
+		return
+	}
+	t := normalizeKotlinTypeName(typeText)
+	if t == "" {
+		return
+	}
+	result.Edges = append(result.Edges, &graph.Edge{
+		From:     ownerID,
+		To:       "unresolved::" + t,
+		Kind:     graph.EdgeTypedAs,
+		FilePath: filePath,
+		Line:     line,
+		Origin:   graph.OriginASTInferred,
+	})
+}
+
+// kotlinParamsList returns the function_value_parameters child of a
+// function_declaration, or nil when the function takes no parameters.
+func kotlinParamsList(funcNode *sitter.Node) *sitter.Node {
+	if funcNode == nil {
+		return nil
+	}
+	for i := 0; i < int(funcNode.NamedChildCount()); i++ {
+		c := funcNode.NamedChild(i)
+		if c != nil && c.Type() == "function_value_parameters" {
+			return c
+		}
+	}
+	return nil
+}
+
+// emitKotlinParamShape materialises one KindParam node per typed/untyped
+// parameter of a Kotlin function, plus an EdgeParamOf back to the owner
+// and (when the parameter carries a type annotation) an EdgeTypedAs to
+// the referenced type. Kotlin parameters are always `name: Type`, so the
+// name is the parameter's simple_identifier and the type is its
+// user_type / nullable_type child. Mirrors emitTSParamNodes /
+// emitPyParamNodes.
+func emitKotlinParamShape(ownerID string, funcNode *sitter.Node, src []byte, filePath string, declLine int, result *parser.ExtractionResult) {
+	params := kotlinParamsList(funcNode)
+	if params == nil {
+		return
+	}
+	pos := 0
+	for i := 0; i < int(params.NamedChildCount()); i++ {
+		p := params.NamedChild(i)
+		if p == nil || p.Type() != "parameter" {
+			continue
+		}
+		var name, typeText string
+		for j := 0; j < int(p.NamedChildCount()); j++ {
+			c := p.NamedChild(j)
+			if c == nil {
+				continue
+			}
+			switch c.Type() {
+			case "simple_identifier":
+				if name == "" {
+					name = c.Content(src)
+				}
+			case "user_type", "nullable_type", "function_type":
+				if typeText == "" {
+					typeText = c.Content(src)
+				}
+			}
+		}
+		if name == "" || name == "_" {
+			continue
+		}
+		paramID := ownerID + "#param:" + name + "@" + strconv.Itoa(pos)
+		meta := map[string]any{"position": pos}
+		if typeText != "" {
+			meta["type"] = typeText
+		}
+		startLine := int(p.StartPoint().Row) + 1
+		if startLine == 0 {
+			startLine = declLine
+		}
+		result.Nodes = append(result.Nodes, &graph.Node{
+			ID:        paramID,
+			Kind:      graph.KindParam,
+			Name:      name,
+			FilePath:  filePath,
+			StartLine: startLine,
+			EndLine:   int(p.EndPoint().Row) + 1,
+			Language:  "kotlin",
+			Meta:      meta,
+		})
+		result.Edges = append(result.Edges, &graph.Edge{
+			From:     paramID,
+			To:       ownerID,
+			Kind:     graph.EdgeParamOf,
+			FilePath: filePath,
+			Line:     startLine,
+			Origin:   graph.OriginASTResolved,
+		})
+		emitKotlinTypeUseEdges(paramID, typeText, filePath, startLine, result)
+		pos++
+	}
+}
+
+// emitKotlinReturnEdges emits an EdgeReturns from ownerID to the function's
+// declared return type, when present and non-primitive. The return type is
+// the user_type / nullable_type that follows the function_value_parameters
+// (and precedes the function_body). Mirrors emitTSReturnEdges /
+// emitPyReturnEdges.
+func emitKotlinReturnEdges(ownerID string, funcNode *sitter.Node, src []byte, filePath string, line int, result *parser.ExtractionResult) {
+	if ownerID == "" || funcNode == nil {
+		return
+	}
+	pastParams := false
+	for i := 0; i < int(funcNode.ChildCount()); i++ {
+		child := funcNode.Child(i)
+		if child == nil {
+			continue
+		}
+		switch child.Type() {
+		case "function_value_parameters":
+			pastParams = true
+		case "user_type", "nullable_type":
+			if !pastParams {
+				continue
+			}
+			t := normalizeKotlinTypeName(child.Content(src))
+			if t == "" {
+				return
+			}
+			result.Edges = append(result.Edges, &graph.Edge{
+				From:     ownerID,
+				To:       "unresolved::" + t,
+				Kind:     graph.EdgeReturns,
+				FilePath: filePath,
+				Line:     line,
+				Origin:   graph.OriginASTInferred,
+				Meta:     map[string]any{"position": 0},
+			})
+			return
+		case "function_body":
+			// Body reached before a return-type annotation → no return type.
+			return
+		}
+	}
+}
+
+// emitKotlinFunctionShape wires the parameter-type and return-type edges
+// for one Kotlin function/method declaration onto ownerID. Variable
+// annotations are handled separately in the Extract post-pass (they need
+// the enclosing-function lookup over all declarations).
+func emitKotlinFunctionShape(ownerID string, funcNode *sitter.Node, src []byte, filePath string, declLine int, result *parser.ExtractionResult) {
+	if funcNode == nil {
+		return
+	}
+	emitKotlinParamShape(ownerID, funcNode, src, filePath, declLine, result)
+	emitKotlinReturnEdges(ownerID, funcNode, src, filePath, declLine, result)
 }

--- a/internal/parser/languages/kotlin_typeuse_test.go
+++ b/internal/parser/languages/kotlin_typeuse_test.go
@@ -1,0 +1,158 @@
+package languages
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// kotlinTypeUseSrc exercises every type-use surface the tree-sitter-only
+// projection must emit: a typed parameter (`url: String` — primitive,
+// skipped), a nullable named parameter (`opts: RequestOptions?`), a
+// declared return type (`: HttpResponse`), a local `val` annotation
+// (`val client: OkHttpClient`), and a primitive local annotation
+// (`var count: Int` — skipped).
+const kotlinTypeUseSrc = `package x
+
+class Service {
+    fun fetch(url: String, opts: RequestOptions?): HttpResponse {
+        val client: OkHttpClient = OkHttpClient()
+        var count: Int = 0
+        return HttpResponse()
+    }
+}
+`
+
+func TestKotlinTypeUse_LocalAnnotationAndParam(t *testing.T) {
+	nodes, edges := runKotlinExtract(t, "x/Service.kt", kotlinTypeUseSrc)
+
+	typedAs := edgesByKind(edges, graph.EdgeTypedAs)
+	returns := edgesByKind(edges, graph.EdgeReturns)
+
+	// The enclosing method node id.
+	methodID := "x/Service.kt::Service.fetch"
+	if nodeByID(nodes, methodID) == nil {
+		t.Fatalf("expected method node %q; got %v", methodID, nodeNames(nodesOfKind(nodes, graph.KindMethod)))
+	}
+
+	// 1. Local `val client: OkHttpClient` must emit EdgeTypedAs →
+	//    unresolved::OkHttpClient, attributed to the enclosing method
+	//    (variable-annotation edges hang off the enclosing function).
+	foundLocal := false
+	for _, e := range typedAs {
+		if e.To == "unresolved::OkHttpClient" {
+			foundLocal = true
+			if e.From != methodID {
+				t.Errorf("local val type-use should attribute to enclosing method %q; got From=%q", methodID, e.From)
+			}
+			if e.Origin != graph.OriginASTInferred {
+				t.Errorf("local val type-use Origin = %v; want OriginASTInferred", e.Origin)
+			}
+		}
+	}
+	if !foundLocal {
+		t.Errorf("expected EdgeTypedAs → unresolved::OkHttpClient; got %v", edgeTargets(typedAs))
+	}
+
+	// 2. The typed parameter `opts: RequestOptions?` must emit a KindParam
+	//    node and an EdgeTypedAs → unresolved::RequestOptions (nullable `?`
+	//    stripped) from the param node.
+	var paramID string
+	for _, n := range nodesOfKind(nodes, graph.KindParam) {
+		if n.Name == "opts" {
+			paramID = n.ID
+		}
+	}
+	if paramID == "" {
+		t.Fatalf("expected KindParam node for `opts`; got %v", nodeNames(nodesOfKind(nodes, graph.KindParam)))
+	}
+	foundParamType := false
+	for _, e := range typedAs {
+		if e.From == paramID && e.To == "unresolved::RequestOptions" {
+			foundParamType = true
+		}
+	}
+	if !foundParamType {
+		t.Errorf("expected EdgeTypedAs %s → unresolved::RequestOptions; got %v", paramID, edgeTargets(typedAs))
+	}
+
+	// 3. The declared return type must emit EdgeReturns → unresolved::HttpResponse.
+	foundReturn := false
+	for _, e := range returns {
+		if e.From == methodID && e.To == "unresolved::HttpResponse" {
+			foundReturn = true
+		}
+	}
+	if !foundReturn {
+		t.Errorf("expected EdgeReturns %s → unresolved::HttpResponse; got %v", methodID, edgeTargets(returns))
+	}
+
+	// 4. Primitives must NOT emit type-use edges: neither the `url: String`
+	//    parameter nor the `var count: Int` local annotation.
+	for _, e := range typedAs {
+		if strings.HasSuffix(e.To, "::String") || strings.HasSuffix(e.To, "::Int") {
+			t.Errorf("primitive type %q must not emit EdgeTypedAs", e.To)
+		}
+	}
+	for _, e := range returns {
+		if strings.HasSuffix(e.To, "::Int") || strings.HasSuffix(e.To, "::String") {
+			t.Errorf("primitive type %q must not emit EdgeReturns", e.To)
+		}
+	}
+}
+
+// TestKotlinTypeUse_TopLevelFunctionAndProperty checks a free function's
+// parameter/return edges and a top-level property annotation falling back
+// to the file node as owner.
+func TestKotlinTypeUse_TopLevelFunctionAndProperty(t *testing.T) {
+	src := `package x
+
+val shared: OkHttpClient = OkHttpClient()
+
+fun build(cfg: Config): Builder {
+    return Builder()
+}
+`
+	nodes, edges := runKotlinExtract(t, "x/top.kt", src)
+	typedAs := edgesByKind(edges, graph.EdgeTypedAs)
+	returns := edgesByKind(edges, graph.EdgeReturns)
+
+	funcID := "x/top.kt::build"
+	if nodeByID(nodes, funcID) == nil {
+		t.Fatalf("expected function node %q", funcID)
+	}
+
+	// Top-level property annotation falls back to the file node.
+	foundTopProp := false
+	for _, e := range typedAs {
+		if e.To == "unresolved::OkHttpClient" && e.From == "x/top.kt" {
+			foundTopProp = true
+		}
+	}
+	if !foundTopProp {
+		t.Errorf("expected top-level property EdgeTypedAs file → unresolved::OkHttpClient; got %v", edgeTargets(typedAs))
+	}
+
+	// Parameter type edge.
+	foundParam := false
+	for _, e := range typedAs {
+		if e.To == "unresolved::Config" {
+			foundParam = true
+		}
+	}
+	if !foundParam {
+		t.Errorf("expected param EdgeTypedAs → unresolved::Config; got %v", edgeTargets(typedAs))
+	}
+
+	// Return type edge.
+	foundReturn := false
+	for _, e := range returns {
+		if e.From == funcID && e.To == "unresolved::Builder" {
+			foundReturn = true
+		}
+	}
+	if !foundReturn {
+		t.Errorf("expected EdgeReturns %s → unresolved::Builder; got %v", funcID, edgeTargets(returns))
+	}
+}

--- a/internal/parser/languages/php.go
+++ b/internal/parser/languages/php.go
@@ -427,6 +427,11 @@ func (e *PHPExtractor) extractPhpProperty(
 		result.Edges = append(result.Edges, &graph.Edge{
 			From: id, To: ownerID, Kind: graph.EdgeMemberOf, FilePath: filePath, Line: line,
 		})
+		// Typed property (`private Session $s;`): emit a usage edge from
+		// the field to the declared class so find_usages lands it without
+		// an LSP. Builtins / nullable / union / namespace are handled by
+		// emitPHPTypeUseEdges.
+		emitPHPTypeUseEdges(id, propType, filePath, line, result)
 	}
 }
 
@@ -505,6 +510,52 @@ func phpBuiltinType(t string) bool {
 	return false
 }
 
+// canonicalizePHPTypeRef reduces one PHP type atom (no `|`/`&` left) to its
+// bare class name: it strips the nullable `?` prefix and reduces a namespaced
+// reference (`\App\Http\HttpResponse`, `App\HttpResponse`) to its last segment,
+// so the name-based resolver can land it against the `Type` node defined under
+// its short name. Returns "" for an empty atom.
+func canonicalizePHPTypeRef(t string) string {
+	t = strings.TrimSpace(t)
+	t = strings.TrimPrefix(t, "?")
+	t = strings.TrimSpace(t)
+	if i := strings.LastIndex(t, `\`); i >= 0 {
+		t = t[i+1:]
+	}
+	return strings.TrimSpace(t)
+}
+
+// emitPHPTypeUseEdges parses a PHP type declaration used in property /
+// parameter position and emits one EdgeTypedAs from ownerID to the bare named
+// type for every non-builtin branch. PHP 8 union (`Foo|Bar`) and intersection
+// (`Foo&Bar`) declarations each contribute one branch; the nullable `?Foo`
+// shorthand and namespace prefixes are stripped by canonicalizePHPTypeRef.
+// Edges ride at OriginASTInferred — the binding is a tree-sitter inference, not
+// an LSP-checked fact — so a class used only in a type declaration becomes a
+// traversable cross-file reference find_usages can land without a language
+// server. Builtin scalar/pseudo types (int, string, void, self, …) are skipped.
+func emitPHPTypeUseEdges(ownerID, typeText, filePath string, line int, result *parser.ExtractionResult) {
+	if ownerID == "" || typeText == "" {
+		return
+	}
+	seen := map[string]bool{}
+	for _, atom := range strings.FieldsFunc(typeText, func(r rune) bool { return r == '|' || r == '&' }) {
+		t := canonicalizePHPTypeRef(atom)
+		if t == "" || phpBuiltinType(t) || seen[t] {
+			continue
+		}
+		seen[t] = true
+		result.Edges = append(result.Edges, &graph.Edge{
+			From:     ownerID,
+			To:       "unresolved::" + t,
+			Kind:     graph.EdgeTypedAs,
+			FilePath: filePath,
+			Line:     line,
+			Origin:   graph.OriginASTInferred,
+		})
+	}
+}
+
 // phpReturnType returns the declared return type of a method/function (the type
 // node after formal_parameters, before the body), or "".
 func phpReturnType(node *sitter.Node, src []byte) string {
@@ -523,6 +574,47 @@ func phpReturnType(node *sitter.Node, src []byte) string {
 		case "primitive_type", "named_type", "union_type", "nullable_type", "intersection_type", "optional_type", "qualified_name", "bottom_type":
 			return strings.TrimSpace(c.Content(src))
 		case "compound_statement":
+			return ""
+		}
+	}
+	return ""
+}
+
+// emitPHPParamTypeUseEdges walks a function/method's formal_parameters and
+// emits an EdgeTypedAs from ownerID to each non-builtin parameter type. PHP
+// has no separate param node in this extractor, so the usage is attributed to
+// the enclosing function/method — enough for find_usages to land a class used
+// only in a parameter type declaration (`function f(HttpResponse $r)`).
+func (e *PHPExtractor) emitPHPParamTypeUseEdges(node *sitter.Node, src []byte, ownerID, filePath string, result *parser.ExtractionResult) {
+	params := e.findChildByType(node, "formal_parameters")
+	if params == nil {
+		return
+	}
+	for i := 0; i < int(params.NamedChildCount()); i++ {
+		p := params.NamedChild(i)
+		switch p.Type() {
+		case "simple_parameter", "variadic_parameter", "property_promotion_parameter":
+		default:
+			continue
+		}
+		pt := phpParameterType(p, src)
+		if pt == "" {
+			continue
+		}
+		emitPHPTypeUseEdges(ownerID, pt, filePath, int(p.StartPoint().Row)+1, result)
+	}
+}
+
+// phpParameterType returns the declared type of a parameter node (the type
+// node before its variable_name), or "".
+func phpParameterType(node *sitter.Node, src []byte) string {
+	for i := 0; i < int(node.NamedChildCount()); i++ {
+		c := node.NamedChild(i)
+		switch c.Type() {
+		case "primitive_type", "named_type", "union_type", "nullable_type",
+			"intersection_type", "optional_type", "qualified_name":
+			return strings.TrimSpace(c.Content(src))
+		case "variable_name":
 			return ""
 		}
 	}
@@ -568,6 +660,8 @@ func (e *PHPExtractor) extractFunction(
 			From: id, To: "unresolved::" + rt, Kind: graph.EdgeReturns, FilePath: filePath, Line: startLine,
 		})
 	}
+	// Typed parameters → EdgeTypedAs usage edges on the function.
+	e.emitPHPParamTypeUseEdges(node, src, id, filePath, result)
 
 	// Extract call sites within the function body.
 	body := e.findChildByType(node, "compound_statement")
@@ -622,6 +716,8 @@ func (e *PHPExtractor) extractMethod(
 			From: id, To: "unresolved::" + rt, Kind: graph.EdgeReturns, FilePath: filePath, Line: startLine,
 		})
 	}
+	// Typed parameters → EdgeTypedAs usage edges on the method.
+	e.emitPHPParamTypeUseEdges(node, src, id, filePath, result)
 	annotationSeen := map[string]bool{}
 	emitPHPAnnotationEdgesFromAttrs(collectPhpAttributes(node, src), id, filePath, result, annotationSeen)
 	result.Edges = append(result.Edges, &graph.Edge{

--- a/internal/parser/languages/php_typeuse_test.go
+++ b/internal/parser/languages/php_typeuse_test.go
@@ -1,0 +1,114 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// phpTypedAsTargets collects the To-targets of every EdgeTypedAs edge whose From
+// matches the given owner ID (empty owner = any).
+func phpTypedAsTargets(edges []*graph.Edge, owner string) map[string]bool {
+	out := map[string]bool{}
+	for _, e := range edges {
+		if e.Kind != graph.EdgeTypedAs {
+			continue
+		}
+		if owner != "" && e.From != owner {
+			continue
+		}
+		out[e.To] = true
+	}
+	return out
+}
+
+// TestPHPExtractor_TypedPropertyUseEdge: a typed property `private HttpResponse
+// $r;` emits an EdgeTypedAs from the field to unresolved::HttpResponse; a scalar
+// property `int $count;` emits no type-use edge.
+func TestPHPExtractor_TypedPropertyUseEdge(t *testing.T) {
+	src := []byte(`<?php
+class Controller {
+    private HttpResponse $r;
+    public int $count;
+    protected ?Logger $logger;
+    public Foo|Bar $fb;
+}
+`)
+	e := NewPHPExtractor()
+	result, err := e.Extract("c.php", src)
+	require.NoError(t, err)
+
+	all := phpTypedAsTargets(result.Edges, "")
+	assert.True(t, all["unresolved::HttpResponse"], "typed property HttpResponse should emit EdgeTypedAs")
+	assert.True(t, all["unresolved::Logger"], "nullable ?Logger should strip ? and emit EdgeTypedAs")
+	assert.True(t, all["unresolved::Foo"], "union member Foo should emit EdgeTypedAs")
+	assert.True(t, all["unresolved::Bar"], "union member Bar should emit EdgeTypedAs")
+
+	// Scalars never produce a type-use edge.
+	assert.False(t, all["unresolved::int"], "scalar int must NOT emit EdgeTypedAs")
+
+	// The HttpResponse edge is attributed to the field node.
+	fieldEdge := phpTypedAsTargets(result.Edges, "c.php::Controller.r")
+	assert.True(t, fieldEdge["unresolved::HttpResponse"], "property type edge attributed to the field node")
+}
+
+// TestPHPExtractor_TypedParamAndReturnUseEdges: typed parameters emit
+// EdgeTypedAs on the owning function/method; a scalar param emits no type-use
+// edge; namespaced types reduce to the bare last segment; return types remain
+// covered by EdgeReturns (not double-emitted as EdgeTypedAs).
+func TestPHPExtractor_TypedParamAndReturnUseEdges(t *testing.T) {
+	src := []byte(`<?php
+function handle(HttpResponse $r, int $n, \App\Models\User $u): Session {
+    return new Session();
+}
+class Svc {
+    public function run(Request $req, string $s): void {}
+}
+`)
+	e := NewPHPExtractor()
+	result, err := e.Extract("h.php", src)
+	require.NoError(t, err)
+
+	fnEdges := phpTypedAsTargets(result.Edges, "h.php::handle")
+	assert.True(t, fnEdges["unresolved::HttpResponse"], "param type HttpResponse should emit EdgeTypedAs")
+	assert.True(t, fnEdges["unresolved::User"], "namespaced \\App\\Models\\User reduces to bare User")
+	assert.False(t, fnEdges["unresolved::int"], "scalar param int must NOT emit EdgeTypedAs")
+	// Return type is carried by EdgeReturns, not duplicated as EdgeTypedAs.
+	assert.False(t, fnEdges["unresolved::Session"], "return type must not be double-emitted as EdgeTypedAs")
+
+	methEdges := phpTypedAsTargets(result.Edges, "h.php::Svc.run")
+	assert.True(t, methEdges["unresolved::Request"], "method param type Request should emit EdgeTypedAs")
+	assert.False(t, methEdges["unresolved::string"], "scalar param string must NOT emit EdgeTypedAs")
+
+	// Return type still arrives as EdgeReturns.
+	var sawReturn bool
+	for _, ed := range result.Edges {
+		if ed.Kind == graph.EdgeReturns && ed.From == "h.php::handle" && ed.To == "unresolved::Session" {
+			sawReturn = true
+		}
+	}
+	assert.True(t, sawReturn, "non-builtin return type still emits EdgeReturns")
+}
+
+// TestPHPExtractor_TypeUseEdgeOrigin: type-use edges ride at OriginASTInferred,
+// matching the TS/C# templates so the resolver weights them as inferences.
+func TestPHPExtractor_TypeUseEdgeOrigin(t *testing.T) {
+	src := []byte(`<?php
+class C {
+    private Session $s;
+}
+`)
+	result, err := NewPHPExtractor().Extract("o.php", src)
+	require.NoError(t, err)
+
+	var found bool
+	for _, ed := range result.Edges {
+		if ed.Kind == graph.EdgeTypedAs && ed.To == "unresolved::Session" {
+			found = true
+			assert.Equal(t, graph.OriginASTInferred, ed.Origin, "type-use edge must be OriginASTInferred")
+		}
+	}
+	require.True(t, found, "expected an EdgeTypedAs to unresolved::Session")
+}

--- a/internal/parser/languages/py_function_shape.go
+++ b/internal/parser/languages/py_function_shape.go
@@ -299,6 +299,31 @@ func emitPyReturnEdges(ownerID, returnText, filePath string, line int, result *p
 	}
 }
 
+// emitPyTypeUseEdges parses a variable annotation type and emits one
+// EdgeTypedAs per top-level named type to unresolved::<type>, so a type
+// used only in `x: T` annotation position is a first-class cross-file
+// reference the name-based resolver can land without an LSP. Mirrors
+// emitPyReturnEdges; primitives are skipped.
+func emitPyTypeUseEdges(ownerID, typeText, filePath string, line int, result *parser.ExtractionResult) {
+	if typeText == "" {
+		return
+	}
+	for _, raw := range splitPyUnionType(typeText) {
+		t := canonicalizePyTypeRef(raw)
+		if t == "" || isPyPrimitive(t) {
+			continue
+		}
+		result.Edges = append(result.Edges, &graph.Edge{
+			From:     ownerID,
+			To:       "unresolved::" + t,
+			Kind:     graph.EdgeTypedAs,
+			FilePath: filePath,
+			Line:     line,
+			Origin:   graph.OriginASTInferred,
+		})
+	}
+}
+
 func emitPyGenericParamNodes(ownerID string, funcNode *sitter.Node, src []byte, filePath string, line int, result *parser.ExtractionResult) {
 	tparams := funcNode.ChildByFieldName("type_parameters")
 	if tparams == nil {

--- a/internal/parser/languages/py_typeuse_test.go
+++ b/internal/parser/languages/py_typeuse_test.go
@@ -1,0 +1,37 @@
+package languages
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// TestPyTypeUse_VariableAnnotationEmitsTypedAs pins the LSP-free recall
+// fix for Python: `x: Session` references type Session and must emit an
+// EdgeTypedAs to unresolved::Session. Before the fix it only seeded the
+// local type-env map (recall ~0 without an LSP).
+func TestPyTypeUse_VariableAnnotationEmitsTypedAs(t *testing.T) {
+	src := `from .db import Session
+
+def handler():
+    conn: Session = open_session()
+    use(conn)
+`
+	_, edges := runPyExtract(t, "app/handler.py", src)
+
+	var hits []*graph.Edge
+	for _, e := range edges {
+		if e.Kind == graph.EdgeTypedAs && e.To == "unresolved::Session" {
+			hits = append(hits, e)
+		}
+	}
+	if len(hits) == 0 {
+		t.Fatalf("expected EdgeTypedAs -> unresolved::Session for `conn: Session`, got none")
+	}
+	for _, e := range hits {
+		if !strings.Contains(e.From, "handler") {
+			t.Errorf("EdgeTypedAs From = %q, want it attributed to handler()", e.From)
+		}
+	}
+}

--- a/internal/parser/languages/python.go
+++ b/internal/parser/languages/python.go
@@ -151,6 +151,7 @@ func (e *PythonExtractor) Extract(filePath string, src []byte) (*parser.Extracti
 	tenvHasExplicit := make(map[string]bool) // names with Tier 0 type, lock from Tier 1 overwrite
 
 	var calls []pyDeferredCall
+	var typeUses []deferredTypeUse
 
 	parser.EachMatch(e.qAll, root, src, func(m parser.QueryResult) {
 		switch {
@@ -212,11 +213,16 @@ func (e *PythonExtractor) Extract(filePath string, src []byte) (*parser.Extracti
 		case m.Captures["tvar.def"] != nil:
 			// Tier 0: explicit type annotation — overwrite tenv.
 			name := m.Captures["tvar.name"].Text
-			typeName := normalizePyTypeName(m.Captures["tvar.type"].Text)
+			rawType := m.Captures["tvar.type"].Text
+			typeName := normalizePyTypeName(rawType)
 			if typeName != "" {
 				tenv[name] = typeName
 				tenvHasExplicit[name] = true
 			}
+			typeUses = append(typeUses, deferredTypeUse{
+				typeText: rawType,
+				line:     m.Captures["tvar.def"].StartLine + 1,
+			})
 
 		case m.Captures["uvar.def"] != nil:
 			// Tier 1: constructor-call inference. Only fills in keys
@@ -242,6 +248,18 @@ func (e *PythonExtractor) Extract(filePath string, src []byte) (*parser.Extracti
 	// All function/method nodes have been emitted; map call sites to
 	// their enclosing definition.
 	funcRanges := buildFuncRanges(result)
+
+	// Type-use edges: a `x: T` annotation references type T. Attributed
+	// to the enclosing function (fallback: the file node) so find_usages(T)
+	// surfaces every annotation site without an LSP.
+	for _, tu := range typeUses {
+		ownerID := findEnclosingFunc(funcRanges, tu.line)
+		if ownerID == "" {
+			ownerID = fileID
+		}
+		emitPyTypeUseEdges(ownerID, tu.typeText, filePath, tu.line, result)
+	}
+
 	for _, c := range calls {
 		callerID := findEnclosingFunc(funcRanges, c.line)
 		if callerID == "" {

--- a/internal/parser/languages/rust.go
+++ b/internal/parser/languages/rust.go
@@ -527,9 +527,9 @@ func rustTypeParams(item *sitter.Node, src []byte) []map[string]string {
 // emitRustThrowsEdges inspects a function's return type for a Result
 // wrapper and emits an EdgeThrows to the error type when found. Idiom:
 //
-//   fn parse(s: &str) -> Result<i32, ParseError> {…}     → throws ParseError
-//   fn open(p: &Path) -> Result<File, std::io::Error> {…} → throws Error
-//   fn no_error() -> i32 {…}                              → no edge
+//	fn parse(s: &str) -> Result<i32, ParseError> {…}     → throws ParseError
+//	fn open(p: &Path) -> Result<File, std::io::Error> {…} → throws Error
+//	fn no_error() -> i32 {…}                              → no edge
 //
 // `Origin: ASTInferred` because we're pattern-matching the return
 // type text, not type-checking it.
@@ -589,10 +589,10 @@ func rustRawReturnType(node *sitter.Node, src []byte) string {
 // the trailing identifier of the error parameter when the type is a
 // Result. Handles:
 //
-//   Result<T, E>            → E
-//   Result<T, std::io::E>   → E (trailing ident)
-//   Result<T, Box<dyn E>>   → E
-//   anyhow::Result<T>       → "" (single-arg form: error type elided)
+//	Result<T, E>            → E
+//	Result<T, std::io::E>   → E (trailing ident)
+//	Result<T, Box<dyn E>>   → E
+//	anyhow::Result<T>       → "" (single-arg form: error type elided)
 //
 // Returns "" for non-Result returns or when the error type can't be
 // extracted unambiguously.

--- a/internal/parser/languages/rust.go
+++ b/internal/parser/languages/rust.go
@@ -107,6 +107,8 @@ type rustDeferredCall struct {
 type rustDeferredLet struct {
 	name     string
 	explicit string       // normalized type from explicit annotation, "" if none
+	typeRaw  string       // verbatim explicit-annotation source (pre-canonicalization), "" if none
+	typeLine int          // 1-based line of the explicit annotation (0 if none)
 	value    *sitter.Node // RHS expression node, or nil
 }
 
@@ -174,6 +176,14 @@ func (e *RustExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 			}
 			if t, ok := m.Captures["lvar.type"]; ok {
 				d.explicit = normalizeRustTypeName(t.Text)
+				// Keep the verbatim annotation source + its line so the
+				// post-pass can emit a cross-file EdgeTypedAs from the
+				// enclosing function to the named type, mirroring the
+				// param/return function-shape emission. normalizeRustTypeName
+				// is lossy (drops wrappers the canonicalizer keeps), so we
+				// re-canonicalize from the raw text downstream.
+				d.typeRaw = t.Text
+				d.typeLine = t.StartLine + 1
 			}
 			if v, ok := m.Captures["lvar.value"]; ok && v.Node != nil {
 				d.value = v.Node
@@ -260,6 +270,24 @@ func (e *RustExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 	// All function/method nodes have been emitted; map call sites to
 	// their enclosing definition.
 	funcRanges := buildFuncRanges(result)
+
+	// Emit a cross-file type-usage edge for every `let x: Type = ...`
+	// binding annotation. Without this a type referenced only in a local
+	// binding (never in a param/return) is invisible to find_usages
+	// absent a language server. Attributed to the enclosing function
+	// (file node fallback), canonicalized to the bare named type, with
+	// primitives skipped — same shape as the param/return emission.
+	for _, l := range lets {
+		if l.typeRaw == "" {
+			continue
+		}
+		ownerID := findEnclosingFunc(funcRanges, l.typeLine)
+		if ownerID == "" {
+			ownerID = fileID
+		}
+		emitRustTypeUseEdges(ownerID, l.typeRaw, filePath, l.typeLine, result)
+	}
+
 	for _, c := range calls {
 		callerID := findEnclosingFunc(funcRanges, c.line)
 		if callerID == "" {

--- a/internal/parser/languages/rust_function_shape.go
+++ b/internal/parser/languages/rust_function_shape.go
@@ -263,6 +263,33 @@ func emitRustReturnEdges(ownerID, returnText, filePath string, line int, result 
 	})
 }
 
+// emitRustTypeUseEdges emits an EdgeTypedAs from ownerID to the named
+// type referenced by a `let x: Type = ...` binding annotation. typeText
+// is the verbatim annotation source; it's canonicalized to its bare
+// named form (references / generics / wrappers like Box<T>, Vec<T>,
+// Option<T>, Arc<T>, Rc<T>, Result<T, _> stripped to the inner named
+// type via canonicalizeRustTypeRef) and primitives are skipped, so the
+// edge only fires for workspace-resolvable types. Mirrors the param /
+// return function-shape emission so a type used only in a local binding
+// is still visible to find_usages without a language server.
+func emitRustTypeUseEdges(ownerID, typeText, filePath string, line int, result *parser.ExtractionResult) {
+	if ownerID == "" || typeText == "" {
+		return
+	}
+	canon := canonicalizeRustTypeRef(typeText)
+	if canon == "" || isRustPrimitive(canon) {
+		return
+	}
+	result.Edges = append(result.Edges, &graph.Edge{
+		From:     ownerID,
+		To:       "unresolved::" + canon,
+		Kind:     graph.EdgeTypedAs,
+		FilePath: filePath,
+		Line:     line,
+		Origin:   graph.OriginASTInferred,
+	})
+}
+
 func emitRustGenericParamNodes(ownerID string, funcNode *sitter.Node, src []byte, filePath string, line int, result *parser.ExtractionResult) {
 	tparams := rustTypeParams(funcNode, src)
 	if len(tparams) == 0 {

--- a/internal/parser/languages/rust_typeuse_test.go
+++ b/internal/parser/languages/rust_typeuse_test.go
@@ -1,0 +1,101 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// TestRustTypeUse_LetBinding asserts a type used only in a `let x: Type`
+// binding annotation (never in a param/return) still emits a cross-file
+// EdgeTypedAs attributed to the enclosing function.
+func TestRustTypeUse_LetBinding(t *testing.T) {
+	src := `fn run() {
+    let client: HttpClient = make();
+    let n: u32 = 0;
+}
+`
+	_, edges := runRustExtract(t, "src/lib.rs", src)
+
+	typed := edgesByKind(edges, graph.EdgeTypedAs)
+
+	var hit *graph.Edge
+	for _, e := range typed {
+		if e.To == "unresolved::HttpClient" {
+			hit = e
+		}
+	}
+	if hit == nil {
+		t.Fatalf("expected EdgeTypedAs → unresolved::HttpClient from let binding; got %v", edgeTargets(typed))
+	}
+	if hit.From != "src/lib.rs::run" {
+		t.Errorf("EdgeTypedAs → HttpClient should be owned by enclosing fn src/lib.rs::run; got %q", hit.From)
+	}
+	if hit.Kind != graph.EdgeTypedAs {
+		t.Errorf("expected EdgeTypedAs, got %v", hit.Kind)
+	}
+	if hit.Origin != graph.OriginASTInferred {
+		t.Errorf("expected Origin OriginASTInferred, got %v", hit.Origin)
+	}
+
+	// Primitive annotation (`u32`) must not emit a type-use edge.
+	for _, e := range typed {
+		if e.To == "unresolved::u32" {
+			t.Errorf("primitive u32 should not emit EdgeTypedAs; got %v", edgeTargets(typed))
+		}
+	}
+}
+
+// TestRustTypeUse_LetBindingWrappers asserts wrapper / reference types in
+// a let annotation canonicalize to the inner named type before the edge
+// is emitted (same canonicalization as the param/return emission).
+func TestRustTypeUse_LetBindingWrappers(t *testing.T) {
+	src := `fn run() {
+    let a: Box<Widget> = b();
+    let c: &Repo = d();
+    let e: Vec<Gadget> = f();
+}
+`
+	_, edges := runRustExtract(t, "src/lib.rs", src)
+	typed := edgesByKind(edges, graph.EdgeTypedAs)
+
+	want := map[string]bool{
+		"unresolved::Widget": false, // Box<Widget> -> Widget
+		"unresolved::Repo":   false, // &Repo -> Repo
+		"unresolved::Gadget": false, // Vec<Gadget> -> Gadget
+	}
+	for _, e := range typed {
+		if _, ok := want[e.To]; ok {
+			want[e.To] = true
+		}
+	}
+	for tgt, found := range want {
+		if !found {
+			t.Errorf("expected EdgeTypedAs → %s from let binding; got %v", tgt, edgeTargets(typed))
+		}
+	}
+}
+
+// TestRustTypeUse_TopLevelLetFallsBackToFile asserts a let binding at the
+// crate root (no enclosing function) attributes its type-use edge to the
+// file node rather than dropping it.
+func TestRustTypeUse_TopLevelLetFallsBackToFile(t *testing.T) {
+	// A `let` outside any fn is not valid top-level Rust, but the
+	// extractor must still degrade gracefully: a binding the
+	// enclosing-fn lookup can't place falls back to the file node ID.
+	src := `const _: () = {
+    let cfg: AppConfig = load();
+};
+`
+	_, edges := runRustExtract(t, "src/lib.rs", src)
+	typed := edgesByKind(edges, graph.EdgeTypedAs)
+	for _, e := range typed {
+		if e.To == "unresolved::AppConfig" {
+			if e.From == "" {
+				t.Errorf("EdgeTypedAs → AppConfig must have a non-empty owner")
+			}
+			return
+		}
+	}
+	t.Errorf("expected EdgeTypedAs → unresolved::AppConfig; got %v", edgeTargets(typed))
+}

--- a/internal/parser/languages/scala.go
+++ b/internal/parser/languages/scala.go
@@ -76,6 +76,15 @@ func (e *ScalaExtractor) extractAll(
 			if node.Parent() != nil && node.Parent().Type() == "compilation_unit" {
 				e.extractTopLevelFunction(node, src, filePath, fileNode, result, seen, annotationSeen)
 			}
+		case "val_definition", "var_definition", "val_declaration", "var_declaration":
+			// A file-level `val x: Foo` / `var x: Foo` (direct child of the
+			// compilation_unit, not a class/object/trait member — those are
+			// handled by extractMembersFromBody). Its declared type is a
+			// cross-file type usage attributed to the enclosing function when
+			// one exists, otherwise the file node.
+			if node.Parent() != nil && node.Parent().Type() == "compilation_unit" {
+				e.extractTopLevelValVar(node, src, filePath, fileNode, result)
+			}
 		case "call_expression":
 			e.extractCall(node, src, filePath, result)
 		}
@@ -134,6 +143,7 @@ func (e *ScalaExtractor) extractTrait(
 								FilePath: filePath, Line: mStartLine,
 							})
 							emitScalaAnnotationEdges(member, mID, filePath, src, result, annotationSeen)
+							emitScalaDefTypeUses(member, mID, filePath, src, result)
 						}
 					}
 				}
@@ -185,6 +195,7 @@ func (e *ScalaExtractor) extractClass(
 		FilePath: filePath, Line: startLine,
 	})
 	emitScalaAnnotationEdges(node, id, filePath, src, result, annotationSeen)
+	emitScalaClassParamTypeUses(node, id, filePath, src, result)
 
 	// Extract methods inside the class template_body.
 	e.extractMembersFromBody(node, src, filePath, fileNode, id, name, result, seen, annotationSeen)
@@ -279,6 +290,7 @@ func (e *ScalaExtractor) extractMembersFromBody(
 				FilePath: filePath, Line: mStartLine,
 			})
 			emitScalaAnnotationEdges(member, mID, filePath, src, result, annotationSeen)
+			emitScalaDefTypeUses(member, mID, filePath, src, result)
 		}
 	}
 }
@@ -359,9 +371,29 @@ func (e *ScalaExtractor) emitScalaField(member *sitter.Node, src []byte, filePat
 	})
 	result.Edges = append(result.Edges, &graph.Edge{From: fileNode.ID, To: id, Kind: graph.EdgeDefines, FilePath: filePath, Line: line})
 	result.Edges = append(result.Edges, &graph.Edge{From: id, To: ownerID, Kind: graph.EdgeMemberOf, FilePath: filePath, Line: line})
-	if typ != "" {
-		result.Edges = append(result.Edges, &graph.Edge{From: id, To: "unresolved::" + typ, Kind: graph.EdgeTypedAs, FilePath: filePath, Line: line})
+	// Emit the type-usage edge from the raw annotation (generics intact) so the
+	// container-unwrap canonicalizer can reach the element type — `field_type`
+	// meta keeps the stripped base name for backward compatibility.
+	if raw := scalaTypeAnnotationRaw(member, src); raw != "" {
+		emitScalaTypeUseEdges(id, raw, filePath, line, result)
 	}
+}
+
+// extractTopLevelValVar emits a type-use edge for a file-level `val/var x: Foo`
+// annotation. Top-level vals are not materialised as field nodes (they have no
+// enclosing type), so the usage edge is attributed to the enclosing function
+// when the binding sits inside one, falling back to the file node otherwise.
+func (e *ScalaExtractor) extractTopLevelValVar(member *sitter.Node, src []byte, filePath string, fileNode *graph.Node, result *parser.ExtractionResult) {
+	raw := scalaTypeAnnotationRaw(member, src)
+	if raw == "" {
+		return
+	}
+	line := int(member.StartPoint().Row) + 1
+	ownerID := findEnclosingFunc(buildFuncRanges(result), line)
+	if ownerID == "" {
+		ownerID = fileNode.ID
+	}
+	emitScalaTypeUseEdges(ownerID, raw, filePath, line, result)
 }
 
 // extractExtension models a Scala 3 `extension (x: T) def m = ...` block: each
@@ -403,6 +435,7 @@ func (e *ScalaExtractor) extractExtension(node *sitter.Node, src []byte, filePat
 		if recv != "" {
 			result.Edges = append(result.Edges, &graph.Edge{From: id, To: "unresolved::" + recv, Kind: graph.EdgeMemberOf, FilePath: filePath, Line: line})
 		}
+		emitScalaDefTypeUses(fn, id, filePath, src, result)
 	}
 }
 
@@ -554,6 +587,7 @@ func (e *ScalaExtractor) extractTopLevelFunction(
 		FilePath: filePath, Line: startLine,
 	})
 	emitScalaAnnotationEdges(node, id, filePath, src, result, annotationSeen)
+	emitScalaDefTypeUses(node, id, filePath, src, result)
 }
 
 // extractCall extracts a call_expression.

--- a/internal/parser/languages/scala_depth_test.go
+++ b/internal/parser/languages/scala_depth_test.go
@@ -33,7 +33,9 @@ class Account {
 		}
 	}
 
-	// val field with its type-annotation reference.
+	// val field keeps its base type in meta, but a primitive annotation
+	// (Int) deliberately emits no typed_as usage edge — those would just
+	// clutter the graph with unresolved::Int edges that never land.
 	balance := byName["balance"]
 	if balance == nil || balance.Kind != graph.KindField {
 		t.Fatalf("val 'balance' should be a field node, got %+v", balance)
@@ -41,8 +43,14 @@ class Account {
 	if balance.Meta["field_type"] != "Int" {
 		t.Errorf("balance field_type = %v, want Int", balance.Meta["field_type"])
 	}
-	if typedAs[balance.ID] != "unresolved::Int" {
-		t.Errorf("balance should have a typed_as edge to unresolved::Int, got %q", typedAs[balance.ID])
+	if _, ok := typedAs[balance.ID]; ok {
+		t.Errorf("primitive-typed balance should NOT have a typed_as edge, got %q", typedAs[balance.ID])
+	}
+
+	// A container generic surfaces its element type as a usage edge:
+	// `List[Transaction]` references Transaction.
+	if p := byName["pending"]; p != nil && typedAs[p.ID] != "unresolved::Transaction" {
+		t.Errorf("pending (List[Transaction]) should typed_as unresolved::Transaction, got %q", typedAs[p.ID])
 	}
 
 	// var field is flagged mutable; generic type reduced to its base.

--- a/internal/parser/languages/scala_typeuse.go
+++ b/internal/parser/languages/scala_typeuse.go
@@ -1,0 +1,245 @@
+package languages
+
+import (
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	sitter "github.com/zzet/gortex/internal/parser/tsitter"
+)
+
+// emitScalaTypeUseEdges emits a single EdgeTypedAs from ownerID to the named
+// type used in a type-annotation position (`val x: Foo`, `def f(p: Foo)`,
+// a `def`'s return type, …). It canonicalizes the raw annotation text to its
+// bare named type — stripping square-bracket generics, unwrapping the common
+// container/effect wrappers (Option / Seq / List / Future / …) to their inner
+// element, and dropping any dotted package prefix — then skips primitives so
+// the graph isn't flooded with unresolved::Int / unresolved::String edges that
+// never land. LSP-free: a Scala type used only in annotation position still
+// produces a usage edge the resolver can later bind to a workspace type node.
+func emitScalaTypeUseEdges(ownerID, typeText, filePath string, line int, result *parser.ExtractionResult) {
+	if ownerID == "" {
+		return
+	}
+	t := canonicalizeScalaTypeRef(typeText)
+	if t == "" || isScalaPrimitive(t) {
+		return
+	}
+	result.Edges = append(result.Edges, &graph.Edge{
+		From:     ownerID,
+		To:       "unresolved::" + t,
+		Kind:     graph.EdgeTypedAs,
+		FilePath: filePath,
+		Line:     line,
+		Origin:   graph.OriginASTInferred,
+	})
+}
+
+// scalaContainerWrappers are the generic container / effect types whose single
+// type argument is the "interesting" referenced type — `Option[User]` is, for
+// type-usage purposes, a use of `User`. Recursing through them lets a type
+// reachable only through such a wrapper still surface a usage edge.
+var scalaContainerWrappers = []string{
+	"Option", "Some", "Seq", "List", "Vector", "Set", "Array",
+	"Future", "Try", "Iterable", "IndexedSeq",
+}
+
+// canonicalizeScalaTypeRef reduces a Scala type expression to its bare named
+// type. Scala uses square brackets for generics (`Map[K, V]`, `Option[T]`), so
+// the generic argument list is `[...]`, not `<...>`. The function:
+//   - unwraps a known single-argument container/effect wrapper to its element
+//     type (`Option[User]` -> `User`, `Future[Seq[Repo]]` -> `Repo`);
+//   - otherwise strips the generic argument list (`Map[K, V]` -> `Map`);
+//   - strips any dotted package prefix (`pkg.Foo` -> `Foo`).
+//
+// It mirrors scalaBaseType for the non-wrapper path but additionally unwraps
+// containers, so `val xs: List[Widget]` references `Widget` rather than `List`.
+func canonicalizeScalaTypeRef(t string) string {
+	t = strings.TrimSpace(t)
+	t = strings.TrimPrefix(t, ":")
+	t = strings.TrimSpace(t)
+	if t == "" {
+		return ""
+	}
+	// Unwrap a known container wrapper around a single type argument.
+	if open := strings.IndexByte(t, '['); open > 0 && strings.HasSuffix(t, "]") {
+		head := strings.TrimSpace(t[:open])
+		head = bareScalaName(head)
+		inner := t[open+1 : len(t)-1]
+		for _, w := range scalaContainerWrappers {
+			if head == w {
+				// Only unwrap when the single argument is itself a single
+				// type (no top-level comma — a Map-like K,V is not unwrapped).
+				if !hasTopLevelComma(inner) {
+					return canonicalizeScalaTypeRef(inner)
+				}
+			}
+		}
+		// Not a wrapper (or multi-arg): the named type is the head.
+		return head
+	}
+	return bareScalaName(t)
+}
+
+// bareScalaName strips a dotted package/object prefix, leaving the simple name.
+func bareScalaName(t string) string {
+	t = strings.TrimSpace(t)
+	if i := strings.IndexByte(t, '['); i >= 0 {
+		t = t[:i]
+	}
+	if i := strings.LastIndexByte(t, '.'); i >= 0 {
+		t = t[i+1:]
+	}
+	return strings.TrimSpace(t)
+}
+
+// hasTopLevelComma reports whether s contains a comma outside any nested
+// `[...]` bracket group — i.e. the generic argument list has more than one
+// argument (`K, V`) rather than a single nested type (`Seq[Repo]`).
+func hasTopLevelComma(s string) bool {
+	depth := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '[':
+			depth++
+		case ']':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isScalaPrimitive reports whether t names a Scala builtin scalar / top-bottom
+// type that doesn't warrant a usage edge.
+func isScalaPrimitive(t string) bool {
+	switch t {
+	case "", "Int", "Long", "Short", "Byte", "Float", "Double",
+		"Boolean", "Char", "String", "Unit", "Any", "AnyRef", "AnyVal",
+		"Nothing", "Null", "Object":
+		return true
+	}
+	return false
+}
+
+// scalaTypeAnnotationRaw returns the raw type-annotation text of a val/var
+// declaration (`val x: Option[User] = …` -> `Option[User]`), generics intact,
+// by reading the type node directly from the declaration's children. The type
+// sits as a sibling of the bound identifier in the tree-sitter shape. Returns
+// "" when the val/var has no declared type (inferred).
+func scalaTypeAnnotationRaw(member *sitter.Node, src []byte) string {
+	for i := 0; i < int(member.NamedChildCount()); i++ {
+		c := member.NamedChild(i)
+		if c == nil {
+			continue
+		}
+		switch c.Type() {
+		case "type_identifier", "generic_type", "tuple_type", "compound_type",
+			"function_type", "stable_type_identifier", "projected_type":
+			return strings.TrimSpace(c.Content(src))
+		}
+	}
+	return ""
+}
+
+// scalaParamTypeText returns the raw type-annotation text of a `parameter` or
+// `class_parameter` node (the first type_identifier / generic_type child), or
+// "". The node shape is `name: Type` with the type as a sibling of the bound
+// identifier.
+func scalaParamTypeText(param *sitter.Node, src []byte) string {
+	for i := 0; i < int(param.NamedChildCount()); i++ {
+		c := param.NamedChild(i)
+		if c == nil {
+			continue
+		}
+		switch c.Type() {
+		case "type_identifier", "generic_type", "tuple_type", "compound_type",
+			"function_type", "stable_type_identifier", "projected_type":
+			return strings.TrimSpace(c.Content(src))
+		}
+	}
+	return ""
+}
+
+// scalaReturnTypeNode returns the return-type node of a `def` — the
+// type_identifier / generic_type child that follows the parameter list. Returns
+// nil when the def has no declared return type.
+func scalaReturnTypeNode(fn *sitter.Node) *sitter.Node {
+	seenParams := false
+	for i := 0; i < int(fn.NamedChildCount()); i++ {
+		c := fn.NamedChild(i)
+		if c == nil {
+			continue
+		}
+		switch c.Type() {
+		case "parameters", "class_parameters", "type_parameters":
+			seenParams = true
+			continue
+		case "type_identifier", "generic_type", "tuple_type", "compound_type",
+			"function_type", "stable_type_identifier", "projected_type":
+			// The first type node after the parameter list is the return
+			// type. (A def with no params still has its return type as the
+			// first type child, so the seenParams gate is permissive.)
+			_ = seenParams
+			return c
+		}
+	}
+	return nil
+}
+
+// emitScalaDefTypeUses emits EdgeTypedAs for every type used in a `def`'s
+// signature: each parameter's declared type and the declared return type. The
+// edges are attributed to ownerID (the function/method node). Parameters and
+// returns annotated only with a primitive emit nothing.
+func emitScalaDefTypeUses(fn *sitter.Node, ownerID, filePath string, src []byte, result *parser.ExtractionResult) {
+	if fn == nil || ownerID == "" {
+		return
+	}
+	for i := 0; i < int(fn.NamedChildCount()); i++ {
+		c := fn.NamedChild(i)
+		if c == nil || c.Type() != "parameters" {
+			continue
+		}
+		for j := 0; j < int(c.NamedChildCount()); j++ {
+			p := c.NamedChild(j)
+			if p == nil || p.Type() != "parameter" {
+				continue
+			}
+			if txt := scalaParamTypeText(p, src); txt != "" {
+				emitScalaTypeUseEdges(ownerID, txt, filePath, int(p.StartPoint().Row)+1, result)
+			}
+		}
+	}
+	if rt := scalaReturnTypeNode(fn); rt != nil {
+		emitScalaTypeUseEdges(ownerID, strings.TrimSpace(rt.Content(src)), filePath, int(rt.StartPoint().Row)+1, result)
+	}
+}
+
+// emitScalaClassParamTypeUses emits EdgeTypedAs for each constructor parameter
+// type of a class/case-class, attributed to the class's type node (ownerID).
+// `class User(repo: Repository)` references Repository.
+func emitScalaClassParamTypeUses(classNode *sitter.Node, ownerID, filePath string, src []byte, result *parser.ExtractionResult) {
+	if classNode == nil || ownerID == "" {
+		return
+	}
+	for i := 0; i < int(classNode.NamedChildCount()); i++ {
+		c := classNode.NamedChild(i)
+		if c == nil || c.Type() != "class_parameters" {
+			continue
+		}
+		for j := 0; j < int(c.NamedChildCount()); j++ {
+			p := c.NamedChild(j)
+			if p == nil || p.Type() != "class_parameter" {
+				continue
+			}
+			if txt := scalaParamTypeText(p, src); txt != "" {
+				emitScalaTypeUseEdges(ownerID, txt, filePath, int(p.StartPoint().Row)+1, result)
+			}
+		}
+	}
+}

--- a/internal/parser/languages/scala_typeuse_test.go
+++ b/internal/parser/languages/scala_typeuse_test.go
@@ -1,0 +1,132 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// scalaTypedAsTargets returns the set of EdgeTypedAs targets emitted for src,
+// asserting every such edge carries the AST-inferred origin.
+func scalaTypedAsTargets(t *testing.T, file string, src string) map[string]bool {
+	t.Helper()
+	res, err := NewScalaExtractor().Extract(file, []byte(src))
+	require.NoError(t, err)
+	targets := map[string]bool{}
+	for _, e := range edgesOfKind(res.Edges, graph.EdgeTypedAs) {
+		assert.Equal(t, graph.OriginASTInferred, e.Origin,
+			"EdgeTypedAs %s -> %s should be AST-inferred", e.From, e.To)
+		targets[e.To] = true
+	}
+	return targets
+}
+
+// TestScalaTypeUse_FieldValAnnotation covers a class-field `val resp:
+// HttpResponse = ...`: the named type surfaces as a usage edge, while a
+// primitive-typed field emits nothing.
+func TestScalaTypeUse_FieldValAnnotation(t *testing.T) {
+	targets := scalaTypedAsTargets(t, "Svc.scala", `class Svc {
+  val resp: HttpResponse = doThing()
+  var count: Int = 0
+}
+`)
+	assert.True(t, targets["unresolved::HttpResponse"],
+		"val resp: HttpResponse should emit a usage edge")
+	assert.False(t, targets["unresolved::Int"],
+		"primitive Int must not emit a usage edge")
+}
+
+// TestScalaTypeUse_LazyVal covers a lazy val annotation.
+func TestScalaTypeUse_LazyVal(t *testing.T) {
+	targets := scalaTypedAsTargets(t, "App.scala", `object App {
+  lazy val cfg: AppConfig = load()
+}
+`)
+	assert.True(t, targets["unresolved::AppConfig"],
+		"lazy val cfg: AppConfig should emit a usage edge")
+}
+
+// TestScalaTypeUse_DefParamsAndReturn covers `def f(p: Foo): Bar` — both the
+// parameter type and the return type surface, while a primitive parameter
+// (Int) and a primitive-ish return (Unit) emit nothing.
+func TestScalaTypeUse_DefParamsAndReturn(t *testing.T) {
+	targets := scalaTypedAsTargets(t, "H.scala", `object H {
+  def handle(req: Request, n: Int): HttpResponse = doThing()
+  def ack(req: Request): Unit = ()
+}
+`)
+	assert.True(t, targets["unresolved::Request"], "param Request should surface")
+	assert.True(t, targets["unresolved::HttpResponse"], "return HttpResponse should surface")
+	assert.False(t, targets["unresolved::Int"], "primitive param Int must not surface")
+	assert.False(t, targets["unresolved::Unit"], "Unit return must not surface")
+}
+
+// TestScalaTypeUse_TopLevelFunction covers a top-level (file-scope) def.
+func TestScalaTypeUse_TopLevelFunction(t *testing.T) {
+	targets := scalaTypedAsTargets(t, "top.scala", `def render(ctx: Context): Page = build(ctx)
+`)
+	assert.True(t, targets["unresolved::Context"], "top-level param Context should surface")
+	assert.True(t, targets["unresolved::Page"], "top-level return Page should surface")
+}
+
+// TestScalaTypeUse_ClassConstructorParams covers `class C(repo: Repository)`.
+func TestScalaTypeUse_ClassConstructorParams(t *testing.T) {
+	targets := scalaTypedAsTargets(t, "UserService.scala", `class UserService(repo: Repository, limit: Int) {
+  def noop(): Unit = ()
+}
+`)
+	assert.True(t, targets["unresolved::Repository"], "constructor param Repository should surface")
+	assert.False(t, targets["unresolved::Int"], "primitive constructor param must not surface")
+}
+
+// TestScalaTypeUse_ContainerUnwrap covers square-bracket generics: a type
+// reachable only through Option/Seq/Future surfaces as the inner element type,
+// and a multi-arg generic (Map) surfaces as the container name.
+func TestScalaTypeUse_ContainerUnwrap(t *testing.T) {
+	targets := scalaTypedAsTargets(t, "R.scala", `class R {
+  val one: Option[User] = None
+  val many: Seq[Widget] = Nil
+  val nested: Future[Seq[Repo]] = null
+  val lookup: Map[String, Account] = Map()
+}
+`)
+	assert.True(t, targets["unresolved::User"], "Option[User] should unwrap to User")
+	assert.True(t, targets["unresolved::Widget"], "Seq[Widget] should unwrap to Widget")
+	assert.True(t, targets["unresolved::Repo"], "Future[Seq[Repo]] should unwrap to Repo")
+	assert.True(t, targets["unresolved::Map"], "Map[K,V] (multi-arg) should surface as Map")
+	assert.False(t, targets["unresolved::Option"], "Option wrapper itself must not surface")
+}
+
+// TestScalaTypeUse_TopLevelVal covers a file-level `val x: Foo` annotation.
+func TestScalaTypeUse_TopLevelVal(t *testing.T) {
+	targets := scalaTypedAsTargets(t, "globals.scala", `val client: HttpClient = makeClient()
+`)
+	assert.True(t, targets["unresolved::HttpClient"],
+		"top-level val client: HttpClient should emit a usage edge")
+}
+
+// TestScalaTypeUse_TraitMethodSignatures covers abstract trait method
+// signatures (function_declaration, no body).
+func TestScalaTypeUse_TraitMethodSignatures(t *testing.T) {
+	targets := scalaTypedAsTargets(t, "Repo.scala", `trait Repo {
+  def findById(id: String): Option[User]
+  def save(user: User): Unit
+}
+`)
+	assert.True(t, targets["unresolved::User"],
+		"trait method param/return User should surface")
+}
+
+// TestScalaTypeUse_DottedTypePrefix covers a package-qualified annotation.
+func TestScalaTypeUse_DottedTypePrefix(t *testing.T) {
+	targets := scalaTypedAsTargets(t, "D.scala", `class D {
+  val s: com.example.HttpResponse = null
+}
+`)
+	assert.True(t, targets["unresolved::HttpResponse"],
+		"dotted prefix should be stripped to the simple name")
+	assert.False(t, targets["unresolved::com.example.HttpResponse"],
+		"the fully-qualified form must not be emitted")
+}

--- a/internal/parser/languages/swift.go
+++ b/internal/parser/languages/swift.go
@@ -379,6 +379,7 @@ func (e *SwiftExtractor) emitFunction(m parser.QueryResult, filePath, fileID str
 			From: id, To: typeID, Kind: graph.EdgeMemberOf, FilePath: filePath, Line: def.StartLine + 1,
 		})
 		emitSwiftAnnotationEdges(def.Node, id, filePath, src, result, annotationSeen)
+		emitSwiftFunctionTypeEdges(id, def.Node, src, filePath, def.StartLine+1, result)
 		return
 	}
 
@@ -403,6 +404,7 @@ func (e *SwiftExtractor) emitFunction(m parser.QueryResult, filePath, fileID str
 		From: fileID, To: id, Kind: graph.EdgeDefines, FilePath: filePath, Line: def.StartLine + 1,
 	})
 	emitSwiftAnnotationEdges(def.Node, id, filePath, src, result, annotationSeen)
+	emitSwiftFunctionTypeEdges(id, def.Node, src, filePath, def.StartLine+1, result)
 }
 
 // emitProperty extracts a stored property declaration. Inside a type it is a
@@ -469,9 +471,14 @@ func (e *SwiftExtractor) emitProperty(m parser.QueryResult, filePath, fileID str
 		})
 	}
 	if fieldType != "" {
-		result.Edges = append(result.Edges, &graph.Edge{
-			From: id, To: "unresolved::" + fieldType, Kind: graph.EdgeTypedAs, FilePath: filePath, Line: def.StartLine + 1,
-		})
+		// Emit the variable / property / local annotation as a type-use
+		// edge. Routing through emitSwiftTypeUseEdges skips Swift
+		// primitives (no `unresolved::Int` noise), stamps
+		// OriginASTInferred, and decomposes composite annotations
+		// (`[Foo]`, `Foo?`, `[K: V]`, `Bar<Baz>`) into per-leaf edges so
+		// a type used only in annotation position is reachable by
+		// find_usages without a language server.
+		emitSwiftTypeUseEdges(id, fieldType, filePath, def.StartLine+1, result)
 	}
 	emitSwiftAnnotationEdges(def.Node, id, filePath, src, result, annotationSeen)
 }

--- a/internal/parser/languages/swift_function_shape.go
+++ b/internal/parser/languages/swift_function_shape.go
@@ -1,0 +1,278 @@
+package languages
+
+import (
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	sitter "github.com/zzet/gortex/internal/parser/tsitter"
+)
+
+// emitSwiftTypeUseEdges emits an EdgeTypedAs from ownerID to
+// "unresolved::"+<bare type name> for the type named in typeText, once
+// per canonicalized leaf type. It mirrors the *_function_shape.go idiom
+// of the other language extractors: it splits wrapper / sugar types,
+// canonicalizes to the bare named type via swiftBaseTypeName (stripping
+// optionals `?`/`!`, arrays `[T]`, dictionaries `[K:V]`, generics
+// `Foo<Bar>`, opaque/existential `some`/`any`, and module qualification),
+// skips Swift primitives, and stamps Origin graph.OriginASTInferred so
+// the edge participates in LSP-free type resolution / find_usages.
+//
+// A dictionary type contributes both its key and value leaf type; a
+// generic type contributes the constructor name and each generic
+// argument (`Result<Value, Error>` → Result, Value, Error). Empty,
+// primitive, and already-emitted targets are dropped.
+func emitSwiftTypeUseEdges(ownerID, typeText, filePath string, line int, result *parser.ExtractionResult) {
+	if ownerID == "" || result == nil {
+		return
+	}
+	for _, leaf := range swiftTypeLeafNames(typeText) {
+		if leaf == "" || isSwiftPrimitive(leaf) {
+			continue
+		}
+		result.Edges = append(result.Edges, &graph.Edge{
+			From:     ownerID,
+			To:       "unresolved::" + leaf,
+			Kind:     graph.EdgeTypedAs,
+			FilePath: filePath,
+			Line:     line,
+			Origin:   graph.OriginASTInferred,
+		})
+	}
+}
+
+// swiftTypeLeafNames decomposes a Swift type expression into every named
+// leaf type it references. It walks composite forms — dictionaries
+// (`[K: V]` → K, V), generic arguments (`Foo<A, B>` → Foo, A, B),
+// optionals / arrays / module qualification — so each component lands a
+// separate type-use edge. Tuples and protocol compositions (`A & B`)
+// split on their separators too. Order-preserving, de-duplicated.
+func swiftTypeLeafNames(typeText string) []string {
+	typeText = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(typeText), ":"))
+	if typeText == "" {
+		return nil
+	}
+	var out []string
+	seen := map[string]bool{}
+	add := func(name string) {
+		name = strings.TrimSpace(name)
+		if name == "" || seen[name] {
+			return
+		}
+		seen[name] = true
+		out = append(out, name)
+	}
+	var walk func(t string)
+	walk = func(t string) {
+		t = strings.TrimSpace(t)
+		t = strings.TrimPrefix(t, "some ")
+		t = strings.TrimPrefix(t, "any ")
+		t = strings.TrimRight(t, "?!")
+		t = strings.TrimSpace(t)
+		if t == "" {
+			return
+		}
+		// Array / dictionary / tuple sugar: strip the outer bracket pair
+		// and recurse on the comma- or colon-separated inner types.
+		if (strings.HasPrefix(t, "[") && strings.HasSuffix(t, "]")) ||
+			(strings.HasPrefix(t, "(") && strings.HasSuffix(t, ")")) {
+			inner := t[1 : len(t)-1]
+			// Dictionary `K: V` and tuple `A, B` both split into parts.
+			parts := splitSwiftTopLevelCommas(inner)
+			for _, p := range parts {
+				if ci := swiftTopLevelColon(p); ci >= 0 {
+					walk(p[:ci])
+					walk(p[ci+1:])
+				} else {
+					walk(p)
+				}
+			}
+			return
+		}
+		// Protocol composition `A & B`.
+		if amp := swiftTopLevelByte(t, '&'); amp >= 0 {
+			walk(t[:amp])
+			walk(t[amp+1:])
+			return
+		}
+		// Generic `Foo<A, B>`: constructor + each argument.
+		if lt := strings.IndexByte(t, '<'); lt >= 0 && strings.HasSuffix(t, ">") {
+			add(swiftBaseTypeName(t[:lt]))
+			for _, arg := range splitSwiftTopLevelCommas(t[lt+1 : len(t)-1]) {
+				walk(arg)
+			}
+			return
+		}
+		add(swiftBaseTypeName(t))
+	}
+	walk(typeText)
+	return out
+}
+
+// swiftTopLevelColon returns the index of the first `:` in s that is not
+// nested inside <>, (), [], or {} (a dictionary key/value separator), or
+// -1 when none. Distinct from a `::` module path, which Swift does not use.
+func swiftTopLevelColon(s string) int {
+	depth := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '(', '<', '[', '{':
+			depth++
+		case ')', '>', ']', '}':
+			if depth > 0 {
+				depth--
+			}
+		case ':':
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// swiftTopLevelByte returns the index of the first b in s that is not
+// nested inside <>, (), [], or {}, or -1 when none.
+func swiftTopLevelByte(s string, b byte) int {
+	depth := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '(', '<', '[', '{':
+			depth++
+		case ')', '>', ']', '}':
+			if depth > 0 {
+				depth--
+			}
+		case b:
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// emitSwiftFunctionTypeEdges emits EdgeTypedAs edges for a function /
+// method declaration's parameter and return type annotations, attributed
+// to ownerID (the function or method node). Type-parameter names declared
+// on the function itself (`func g<T>(x: T)`) are skipped so a generic
+// placeholder doesn't synthesise a bogus `unresolved::T` edge.
+//
+// The Swift grammar exposes each parameter's type as a type-bearing child
+// of a `parameter` node and the return type as a type-bearing sibling of
+// `function_declaration` that follows the parameters and precedes the
+// `function_body` / `type_constraints`. Both are read verbatim and lowered
+// through emitSwiftTypeUseEdges.
+func emitSwiftFunctionTypeEdges(ownerID string, decl *sitter.Node, src []byte, filePath string, line int, result *parser.ExtractionResult) {
+	if decl == nil || ownerID == "" {
+		return
+	}
+	skip := swiftTypeParameterNames(decl, src)
+
+	emit := func(typeNode *sitter.Node) {
+		if typeNode == nil {
+			return
+		}
+		text := strings.TrimSpace(typeNode.Content(src))
+		for _, leaf := range swiftTypeLeafNames(text) {
+			if leaf == "" || isSwiftPrimitive(leaf) || skip[leaf] {
+				continue
+			}
+			result.Edges = append(result.Edges, &graph.Edge{
+				From:     ownerID,
+				To:       "unresolved::" + leaf,
+				Kind:     graph.EdgeTypedAs,
+				FilePath: filePath,
+				Line:     line,
+				Origin:   graph.OriginASTInferred,
+			})
+		}
+	}
+
+	for i := 0; i < int(decl.NamedChildCount()); i++ {
+		c := decl.NamedChild(i)
+		if c == nil {
+			continue
+		}
+		switch c.Type() {
+		case "parameter":
+			emit(swiftParamTypeNode(c))
+		case "user_type", "optional_type", "array_type", "dictionary_type",
+			"tuple_type", "protocol_composition_type", "function_type", "metatype":
+			// A type-bearing child of the function_declaration that is not
+			// inside a `parameter` is the return type (the grammar places it
+			// between the parameter list and the body).
+			emit(c)
+		}
+	}
+}
+
+// swiftParamTypeNode returns the type-bearing child of a `parameter`
+// node — the node carrying the declared type after the argument
+// label(s). Returns nil for an untyped parameter.
+func swiftParamTypeNode(param *sitter.Node) *sitter.Node {
+	if param == nil {
+		return nil
+	}
+	for i := 0; i < int(param.NamedChildCount()); i++ {
+		c := param.NamedChild(i)
+		if c == nil {
+			continue
+		}
+		switch c.Type() {
+		case "user_type", "optional_type", "array_type", "dictionary_type",
+			"tuple_type", "protocol_composition_type", "function_type", "metatype",
+			"type_identifier":
+			return c
+		}
+	}
+	return nil
+}
+
+// swiftTypeParameterNames returns the set of generic type-parameter names
+// declared on a function declaration's `type_parameters` clause
+// (`func g<T, U>` → {T, U}), so they can be excluded from type-use edges.
+func swiftTypeParameterNames(decl *sitter.Node, src []byte) map[string]bool {
+	out := map[string]bool{}
+	if decl == nil {
+		return out
+	}
+	for i := 0; i < int(decl.NamedChildCount()); i++ {
+		c := decl.NamedChild(i)
+		if c == nil || c.Type() != "type_parameters" {
+			continue
+		}
+		for j := 0; j < int(c.NamedChildCount()); j++ {
+			tp := c.NamedChild(j)
+			if tp == nil || tp.Type() != "type_parameter" {
+				continue
+			}
+			for k := 0; k < int(tp.NamedChildCount()); k++ {
+				id := tp.NamedChild(k)
+				if id != nil && id.Type() == "type_identifier" {
+					out[strings.TrimSpace(id.Content(src))] = true
+					break
+				}
+			}
+		}
+	}
+	return out
+}
+
+// isSwiftPrimitive reports whether t names a Swift built-in scalar /
+// standard-library primitive that should not produce a cross-file
+// type-use edge — emitting these would only clutter the graph with
+// unresolved::Int / unresolved::String targets that never land on a
+// user-defined type node.
+func isSwiftPrimitive(t string) bool {
+	switch t {
+	case "", "Int", "Int8", "Int16", "Int32", "Int64",
+		"UInt", "UInt8", "UInt16", "UInt32", "UInt64",
+		"Float", "Float16", "Float32", "Float64", "Double", "CGFloat",
+		"Bool", "String", "Character", "Substring",
+		"Void", "Never", "Any", "AnyObject", "AnyClass",
+		"Self", "Optional", "true", "false":
+		return true
+	}
+	return false
+}

--- a/internal/parser/languages/swift_typeuse_test.go
+++ b/internal/parser/languages/swift_typeuse_test.go
@@ -1,0 +1,141 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// swiftTypedAsTargets collects the To target of every EdgeTypedAs edge.
+func swiftTypedAsTargets(edges []*graph.Edge) map[string]bool {
+	out := map[string]bool{}
+	for _, e := range edges {
+		if e.Kind == graph.EdgeTypedAs {
+			out[e.To] = true
+		}
+	}
+	return out
+}
+
+// hasTypedAsFrom reports whether an EdgeTypedAs edge exists from `from`
+// to `unresolved::`+typeName, stamped with the AST-inferred origin.
+func hasTypedAsFrom(edges []*graph.Edge, from, typeName string) bool {
+	for _, e := range edges {
+		if e.Kind == graph.EdgeTypedAs && e.From == from &&
+			e.To == "unresolved::"+typeName && e.Origin == graph.OriginASTInferred {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSwiftExtractor_LocalVariableTypeUse(t *testing.T) {
+	// A type used ONLY in a local annotation must produce a usage edge so
+	// find_usages lands it without a language server. A primitive (Int)
+	// must NOT.
+	src := []byte(`func handle() {
+    let resp: HttpResponse = makeResponse()
+    let count: Int = 0
+}
+`)
+	res, err := NewSwiftExtractor().Extract("h.swift", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	targets := swiftTypedAsTargets(res.Edges)
+
+	if !targets["unresolved::HttpResponse"] {
+		t.Fatalf("expected EdgeTypedAs to unresolved::HttpResponse for `let resp: HttpResponse`; got %v", targets)
+	}
+	if !hasTypedAsFrom(res.Edges, "h.swift::resp", "HttpResponse") {
+		t.Errorf("HttpResponse type-use edge should originate from the resp binding with OriginASTInferred; edges=%v", res.Edges)
+	}
+	if targets["unresolved::Int"] {
+		t.Errorf("primitive `Int` must NOT produce a type-use edge; got %v", targets)
+	}
+}
+
+func TestSwiftExtractor_PropertyTypeUse(t *testing.T) {
+	// Stored-property annotation, including optional / array / dictionary
+	// / generic sugar — each names a user type that should land an edge,
+	// while the primitive component (Int key) is dropped.
+	src := []byte(`class Store {
+    let resp: HttpResponse = HttpResponse()
+    var widgets: [Widget] = []
+    var maybe: Thing? = nil
+    var table: [Int: Record] = [:]
+    var port: Int = 0
+}
+`)
+	res, err := NewSwiftExtractor().Extract("s.swift", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	targets := swiftTypedAsTargets(res.Edges)
+
+	for _, want := range []string{"HttpResponse", "Widget", "Thing", "Record"} {
+		if !targets["unresolved::"+want] {
+			t.Errorf("expected EdgeTypedAs to unresolved::%s; got %v", want, targets)
+		}
+	}
+	if !hasTypedAsFrom(res.Edges, "s.swift::Store.resp", "HttpResponse") {
+		t.Errorf("property type-use edge should originate from Store.resp; edges=%v", res.Edges)
+	}
+	if targets["unresolved::Int"] {
+		t.Errorf("primitive `Int` (dictionary key + port) must NOT produce a type-use edge; got %v", targets)
+	}
+}
+
+func TestSwiftExtractor_ParameterAndReturnTypeUse(t *testing.T) {
+	// Parameter and return type annotations must each emit a type-use
+	// edge attributed to the function / method node; primitives skipped;
+	// generic placeholders (T) skipped; generic arguments surfaced.
+	src := []byte(`func handle(req: Request, n: Int) -> HttpResponse {
+    return HttpResponse()
+}
+
+class Api {
+    func lookup(id: String) -> Result<User, Failure> {
+        return .success(User())
+    }
+}
+
+func generic<T>(x: T) -> Box<Widget> {
+    return Box()
+}
+`)
+	res, err := NewSwiftExtractor().Extract("api.swift", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Free function: param Request + return HttpResponse, no Int.
+	if !hasTypedAsFrom(res.Edges, "api.swift::handle", "Request") {
+		t.Errorf("expected param type-use edge handle -> Request; edges=%v", res.Edges)
+	}
+	if !hasTypedAsFrom(res.Edges, "api.swift::handle", "HttpResponse") {
+		t.Errorf("expected return type-use edge handle -> HttpResponse; edges=%v", res.Edges)
+	}
+
+	// Method: param String (primitive — skipped) + return Result<User, Failure>.
+	for _, want := range []string{"User", "Failure", "Result"} {
+		if !hasTypedAsFrom(res.Edges, "api.swift::Api.lookup", want) {
+			t.Errorf("expected type-use edge Api.lookup -> %s; edges=%v", want, res.Edges)
+		}
+	}
+
+	// Generic placeholder T must NOT leak as a type; generic arg Widget must.
+	targets := swiftTypedAsTargets(res.Edges)
+	if targets["unresolved::T"] {
+		t.Errorf("generic placeholder T must NOT produce a type-use edge; got %v", targets)
+	}
+	if !hasTypedAsFrom(res.Edges, "api.swift::generic", "Box") {
+		t.Errorf("expected return type-use edge generic -> Box; edges=%v", res.Edges)
+	}
+	if !hasTypedAsFrom(res.Edges, "api.swift::generic", "Widget") {
+		t.Errorf("expected generic-arg type-use edge generic -> Widget; edges=%v", res.Edges)
+	}
+	if targets["unresolved::String"] || targets["unresolved::Int"] {
+		t.Errorf("primitives String/Int must NOT produce type-use edges; got %v", targets)
+	}
+}

--- a/internal/parser/languages/ts_function_shape.go
+++ b/internal/parser/languages/ts_function_shape.go
@@ -504,6 +504,32 @@ func emitTSReturnEdges(ownerID, returnText, filePath string, line int, result *p
 	}
 }
 
+// emitTSTypeUseEdges parses a variable / const / field type annotation
+// and emits one EdgeTypedAs per top-level named type to
+// unresolved::<type>, so a type used only in annotation position is a
+// first-class cross-file reference the name-based resolver can land
+// without an LSP. Union / intersection branches each emit an edge,
+// mirroring emitTSReturnEdges; primitives are skipped.
+func emitTSTypeUseEdges(ownerID, typeText, filePath string, line int, result *parser.ExtractionResult) {
+	if typeText == "" {
+		return
+	}
+	for _, raw := range splitTSUnionType(typeText) {
+		t := canonicalizeTSTypeRef(raw)
+		if t == "" || isTSPrimitive(t) {
+			continue
+		}
+		result.Edges = append(result.Edges, &graph.Edge{
+			From:     ownerID,
+			To:       "unresolved::" + t,
+			Kind:     graph.EdgeTypedAs,
+			FilePath: filePath,
+			Line:     line,
+			Origin:   graph.OriginASTInferred,
+		})
+	}
+}
+
 // emitTSGenericParamNodes turns a TS function/class declaration's
 // type_parameters into KindGenericParam nodes plus EdgeMemberOf back
 // to the owner. Constraints and defaults are stored as meta.bound /

--- a/internal/parser/languages/ts_typeuse_test.go
+++ b/internal/parser/languages/ts_typeuse_test.go
@@ -1,0 +1,88 @@
+package languages
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// typedAsTo counts EdgeTypedAs edges whose target is unresolved::<name>.
+func typedAsTo(edges []*graph.Edge, name string) []*graph.Edge {
+	var out []*graph.Edge
+	for _, e := range edges {
+		if e.Kind == graph.EdgeTypedAs && e.To == "unresolved::"+name {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// TestTSTypeUse_VariableAnnotationEmitsTypedAs pins the LSP-free recall
+// fix: a type used only in variable / const annotation position must
+// emit an EdgeTypedAs to unresolved::<Type> so find_usages lands it
+// cross-file without a language server. Before the fix, `const el: T`
+// only seeded the local type-env map and emitted no edge (recall ~0).
+func TestTSTypeUse_VariableAnnotationEmitsTypedAs(t *testing.T) {
+	src := `import { ExcalidrawElement } from "./types";
+
+export function render(): void {
+	const el: ExcalidrawElement = getElement();
+	let pending: ExcalidrawElement[] = [];
+	doStuff(el, pending);
+}
+`
+	_, edges := runTSExtract(t, "src/render.ts", src)
+
+	hits := typedAsTo(edges, "ExcalidrawElement")
+	if len(hits) < 2 {
+		t.Fatalf("expected >=2 EdgeTypedAs -> unresolved::ExcalidrawElement (const + let), got %d", len(hits))
+	}
+	// Each usage must be attributed to its enclosing function, not dropped.
+	for _, e := range hits {
+		if !strings.Contains(e.From, "render") {
+			t.Errorf("EdgeTypedAs From = %q, want it attributed to render()", e.From)
+		}
+	}
+}
+
+// TestTSTypeUse_ClassFieldEmitsTypedAs pins the field-annotation case:
+// `field: T` references T. Primitives (number) must NOT emit an edge.
+func TestTSTypeUse_ClassFieldEmitsTypedAs(t *testing.T) {
+	src := `class Scene {
+	private active: ExcalidrawElement | null = null;
+	count: number = 0;
+}
+`
+	_, edges := runTSExtract(t, "src/scene.ts", src)
+
+	hits := typedAsTo(edges, "ExcalidrawElement")
+	if len(hits) == 0 {
+		t.Fatalf("expected field EdgeTypedAs -> unresolved::ExcalidrawElement, got none")
+	}
+	for _, e := range hits {
+		if !strings.Contains(e.From, "Scene") {
+			t.Errorf("field EdgeTypedAs From = %q, want it attributed to the Scene field", e.From)
+		}
+	}
+	if got := typedAsTo(edges, "number"); len(got) != 0 {
+		t.Errorf("primitive `number` must not emit EdgeTypedAs, got %d", len(got))
+	}
+}
+
+// TestTSTypeUse_TopLevelConstAttributesToFile pins the file-fallback: a
+// top-level `const x: T` outside any function attributes to the file
+// node rather than being dropped.
+func TestTSTypeUse_TopLevelConstAttributesToFile(t *testing.T) {
+	src := `const config: AppConfig = loadConfig();
+`
+	_, edges := runTSExtract(t, "src/config.ts", src)
+
+	hits := typedAsTo(edges, "AppConfig")
+	if len(hits) != 1 {
+		t.Fatalf("expected 1 EdgeTypedAs -> unresolved::AppConfig, got %d", len(hits))
+	}
+	if hits[0].From != "src/config.ts" {
+		t.Errorf("top-level const EdgeTypedAs From = %q, want the file node src/config.ts", hits[0].From)
+	}
+}

--- a/internal/parser/languages/typescript.go
+++ b/internal/parser/languages/typescript.go
@@ -157,6 +157,14 @@ type deferredVar struct {
 	endLn   int // 0-based
 }
 
+// deferredTypeUse holds a variable / const type annotation whose
+// EdgeTypedAs is emitted after funcRanges is built, so the reference is
+// attributed to its enclosing function (falling back to the file node).
+type deferredTypeUse struct {
+	typeText string
+	line     int // 1-based
+}
+
 func (e *TypeScriptExtractor) Extract(filePath string, src []byte) (*parser.ExtractionResult, error) {
 	lang, qAll := e.grammarFor(filePath)
 	tree, err := parser.ParseFile(src, lang)
@@ -183,6 +191,7 @@ func (e *TypeScriptExtractor) Extract(filePath string, src []byte) (*parser.Extr
 
 	var calls []deferredCall
 	var vars []deferredVar
+	var typeUses []deferredTypeUse
 	// objLiteralMembers maps a top-level object-literal owner name to the
 	// member-function node IDs declared inside it — both method shorthand
 	// (`{ process() {...} }`) and arrow fields (`{ health: () => ... }`).
@@ -287,9 +296,14 @@ func (e *TypeScriptExtractor) Extract(filePath string, src []byte) (*parser.Extr
 
 		case m.Captures["tvar.def"] != nil:
 			name := m.Captures["tvar.name"].Text
-			if tn := normalizeTypeName(m.Captures["tvar.type"].Text); tn != "" {
+			rawType := m.Captures["tvar.type"].Text
+			if tn := normalizeTypeName(rawType); tn != "" {
 				tenv[name] = tn
 			}
+			typeUses = append(typeUses, deferredTypeUse{
+				typeText: rawType,
+				line:     m.Captures["tvar.def"].StartLine + 1,
+			})
 
 		case m.Captures["var.def"] != nil:
 			def := m.Captures["var.def"]
@@ -342,6 +356,19 @@ func (e *TypeScriptExtractor) Extract(filePath string, src []byte) (*parser.Extr
 	// Now every function/method node is in result; build the line
 	// range map used to attribute calls to their caller.
 	funcRanges := buildFuncRanges(result)
+
+	// Type-use edges: a `const x: T` / `let x: T` annotation references
+	// type T. Attributed to the enclosing function (fallback: the file
+	// node) so find_usages(T) surfaces every annotation site without an
+	// LSP. EdgeTypedAs mirrors the param / return type edges; the
+	// resolver lands it cross-file via the same name-based pass.
+	for _, tu := range typeUses {
+		ownerID := findEnclosingFunc(funcRanges, tu.line)
+		if ownerID == "" {
+			ownerID = fileID
+		}
+		emitTSTypeUseEdges(ownerID, tu.typeText, filePath, tu.line, result)
+	}
 
 	// Instantiation edges: `new Foo(...)` constructs Foo. Emitted as a typed
 	// EdgeInstantiates (not a flat call) attributed to the enclosing function,
@@ -1272,6 +1299,11 @@ func (e *TypeScriptExtractor) emitClassProperty(m parser.QueryResult, filePath s
 		From: id, To: classID, Kind: graph.EdgeMemberOf,
 		FilePath: filePath, Line: def.StartLine + 1,
 	})
+	// A typed field (`field: T`) references type T — emit EdgeTypedAs so
+	// find_usages(T) surfaces the declaration site without an LSP.
+	if rawType := tsReturnTypeRaw(def.Node, src); rawType != "" {
+		emitTSTypeUseEdges(id, rawType, filePath, def.StartLine+1, result)
+	}
 	// Decorators on a class field can appear two ways depending on
 	// grammar version: as previous siblings in the class body, or as
 	// direct children of the public_field_definition node. Try both

--- a/internal/resolver/ts_typeuse_e2e_test.go
+++ b/internal/resolver/ts_typeuse_e2e_test.go
@@ -1,0 +1,98 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+// extractTSInto runs the real TypeScript extractor and adds its nodes /
+// edges to g, stamping a common RepoPrefix so the per-repo resolver
+// treats both files as one repo. Returns the emitted edges so callers
+// can locate one and assert its target after resolution. No LSP, no
+// type checker — pure tree-sitter extraction.
+func extractTSInto(t *testing.T, g *graph.Graph, repo, path, src string) []*graph.Edge {
+	t.Helper()
+	res, err := languages.NewTypeScriptExtractor().Extract(path, []byte(src))
+	require.NoError(t, err, "extract %s", path)
+	for _, n := range res.Nodes {
+		n.RepoPrefix = repo
+		g.AddNode(n)
+	}
+	for _, e := range res.Edges {
+		g.AddEdge(e)
+	}
+	return res.Edges
+}
+
+// TestTSTypeUse_VariableAnnotationResolvesCrossFileNoLSP proves the
+// recall fix end to end with NO language server: a type used only in a
+// variable annotation in render.ts resolves to its interface definition
+// in types.ts via tree-sitter extraction + the name-based resolver.
+// Before the fix, `const el: ExcalidrawElement` emitted no edge at all,
+// so find_usages reported zero references unless an LSP filled the gap.
+func TestTSTypeUse_VariableAnnotationResolvesCrossFileNoLSP(t *testing.T) {
+	g := graph.New()
+	extractTSInto(t, g, "app", "app/types.ts", `
+export interface ExcalidrawElement {
+	id: string;
+}
+`)
+	edges := extractTSInto(t, g, "app", "app/render.ts", `
+import { ExcalidrawElement } from "./types";
+
+export function render(): void {
+	const el: ExcalidrawElement = getElement();
+	use(el);
+}
+`)
+
+	var typeUse *graph.Edge
+	for _, e := range edges {
+		if e.Kind == graph.EdgeTypedAs && e.To == "unresolved::ExcalidrawElement" {
+			typeUse = e
+		}
+	}
+	require.NotNil(t, typeUse,
+		"extractor must emit EdgeTypedAs -> unresolved::ExcalidrawElement for the variable annotation")
+
+	New(g).ResolveAll()
+
+	assert.Equal(t, "app/types.ts::ExcalidrawElement", typeUse.To,
+		"variable-annotation type use must resolve cross-file to the interface def without LSP")
+}
+
+// TestTSTypeUse_FieldAnnotationResolvesCrossFileNoLSP does the same for a
+// class field annotation (`active: ExcalidrawElement | null`).
+func TestTSTypeUse_FieldAnnotationResolvesCrossFileNoLSP(t *testing.T) {
+	g := graph.New()
+	extractTSInto(t, g, "app", "app/types.ts", `
+export interface ExcalidrawElement {
+	id: string;
+}
+`)
+	edges := extractTSInto(t, g, "app", "app/scene.ts", `
+import { ExcalidrawElement } from "./types";
+
+export class Scene {
+	active: ExcalidrawElement | null = null;
+}
+`)
+
+	var typeUse *graph.Edge
+	for _, e := range edges {
+		if e.Kind == graph.EdgeTypedAs && e.To == "unresolved::ExcalidrawElement" {
+			typeUse = e
+		}
+	}
+	require.NotNil(t, typeUse, "extractor must emit EdgeTypedAs for the field annotation")
+
+	New(g).ResolveAll()
+
+	assert.Equal(t, "app/types.ts::ExcalidrawElement", typeUse.To,
+		"field type use must resolve cross-file without LSP")
+}

--- a/internal/semantic/goanalysis/provider.go
+++ b/internal/semantic/goanalysis/provider.go
@@ -5,7 +5,9 @@ import (
 	"go/ast"
 	"go/token"
 	"go/types"
+	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -43,17 +45,41 @@ type Provider struct {
 	// multiple repos are enriched (in any order, possibly concurrently) before
 	// their contracts are extracted, each repo's contract pass still finds its
 	// own loaded packages rather than the last writer's. Guarded by stateMu.
-	stateMu sync.RWMutex
-	stashes map[string]*goStash // absRoot → loaded package state
+	//
+	// A loaded stash holds the whole type-checked program (go/types.Info +
+	// every file's AST) for one repo — on the order of 1-2 GB for a large
+	// module. Retaining one per repo forever previously made the daemon's
+	// RSS grow without bound. The stash is therefore bounded under stateMu:
+	// an idle TTL (stashTTL) releases a repo's program once its contract
+	// pass goes quiet, and a count ceiling (maxStashes) caps how many
+	// coexist during a multi-repo warmup. A LookupTypeAtLine that misses an
+	// evicted stash returns ("", false) — the contract pipeline then falls
+	// back to its tree-sitter type tier, the intended graceful degradation.
+	stateMu    sync.RWMutex
+	stashes    map[string]*goStash // absRoot → loaded package state
+	maxStashes int                 // count ceiling (env GORTEX_GOTYPES_MAX_STASHES)
+	stashTTL   time.Duration       // idle release window (env GORTEX_GOTYPES_STASH_TTL)
+	sweepOnce  sync.Once
+	stopSweep  chan struct{}
 }
 
 // goStash is one repo's loaded go/packages state, retained for
-// LookupTypeAtLine after EnrichRepo returns.
+// LookupTypeAtLine after EnrichRepo returns. lastUsed drives idle
+// eviction; it is bumped under stateMu whenever a lookup touches the
+// repo, so an actively-queried program is never released mid-contract.
 type goStash struct {
-	pkgs    []*packages.Package
-	fset    *token.FileSet
-	absRoot string
+	pkgs     []*packages.Package
+	fset     *token.FileSet
+	absRoot  string
+	lastUsed time.Time
 }
+
+// Stash-retention bounds. Both overridable via env for operators who want
+// a different memory/recompute trade-off.
+const (
+	defaultMaxStashes = 8
+	defaultStashTTL   = 3 * time.Minute
+)
 
 // NewProvider creates a go/types provider.
 func NewProvider(mode LoadMode, includeTest bool, logger *zap.Logger) *Provider {
@@ -61,12 +87,30 @@ func NewProvider(mode LoadMode, includeTest bool, logger *zap.Logger) *Provider 
 		mode:        mode,
 		includeTest: includeTest,
 		logger:      logger,
+		maxStashes:  envPositiveInt("GORTEX_GOTYPES_MAX_STASHES", defaultMaxStashes),
+		stashTTL:    envPositiveDuration("GORTEX_GOTYPES_STASH_TTL", defaultStashTTL),
+		stopSweep:   make(chan struct{}),
 	}
 }
 
 func (p *Provider) Name() string        { return "go-types" }
 func (p *Provider) Languages() []string { return []string{"go"} }
-func (p *Provider) Close() error        { return nil }
+
+// Close stops the idle sweeper (idempotent) and drops every retained
+// type-checked program so a torn-down provider holds no memory.
+func (p *Provider) Close() error {
+	if p.stopSweep != nil {
+		select {
+		case <-p.stopSweep:
+		default:
+			close(p.stopSweep)
+		}
+	}
+	p.stateMu.Lock()
+	p.stashes = nil
+	p.stateMu.Unlock()
+	return nil
+}
 
 func (p *Provider) Available() bool {
 	// go/packages requires the Go toolchain. Check if 'go' is on PATH.
@@ -107,8 +151,12 @@ func (p *Provider) EnrichRepo(g graph.Store, repoPrefix, repoRoot string) (*sema
 	if p.stashes == nil {
 		p.stashes = make(map[string]*goStash)
 	}
-	p.stashes[absRoot] = &goStash{pkgs: pkgs, fset: fset, absRoot: absRoot}
+	p.stashes[absRoot] = &goStash{pkgs: pkgs, fset: fset, absRoot: absRoot, lastUsed: time.Now()}
+	p.evictLocked()
 	p.stateMu.Unlock()
+	// Release idle programs in the background so a quiet daemon doesn't hold
+	// every enriched repo's type tables until the next enrich.
+	p.startSweeper()
 
 	result := &semantic.EnrichResult{
 		Provider: p.Name(),
@@ -353,12 +401,13 @@ func (p *Provider) EnrichFile(g graph.Store, repoRoot, filePath string) (*semant
 // has run, the contract pipeline can ask for compiler-grade type
 // resolution at any line in the indexed source.
 func (p *Provider) LookupTypeAtLine(filePath string, line int) (string, bool) {
-	p.stateMu.RLock()
+	p.stateMu.Lock()
+	p.evictLocked()
 	stashes := make([]*goStash, 0, len(p.stashes))
 	for _, s := range p.stashes {
 		stashes = append(stashes, s)
 	}
-	p.stateMu.RUnlock()
+	p.stateMu.Unlock()
 	if len(stashes) == 0 {
 		return "", false
 	}
@@ -380,6 +429,9 @@ func (p *Provider) LookupTypeAtLine(filePath string, line int) (string, bool) {
 				if normalizeRelPath(relativePath(pos.Filename, st.absRoot)) != target {
 					continue
 				}
+				// This file belongs to st: keep the repo's program warm so the
+				// idle sweeper doesn't release it mid-contract-pass.
+				p.touch(st)
 				if t, ok := lookupTypeAtLineInFile(syntax, pkg.TypesInfo, st.fset, line); ok {
 					return t, true
 				}
@@ -387,6 +439,104 @@ func (p *Provider) LookupTypeAtLine(filePath string, line int) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// touch bumps a stash's lastUsed under the lock so the idle sweeper
+// treats an actively-queried repo as live.
+func (p *Provider) touch(st *goStash) {
+	p.stateMu.Lock()
+	st.lastUsed = time.Now()
+	p.stateMu.Unlock()
+}
+
+// evictLocked releases stashes idle past stashTTL and, if still over the
+// count ceiling, the least-recently-used ones. The caller holds stateMu.
+// Dropping a stash frees one repo's whole type-checked program for GC.
+func (p *Provider) evictLocked() {
+	if len(p.stashes) == 0 {
+		return
+	}
+	ttl := p.stashTTL
+	if ttl <= 0 {
+		ttl = defaultStashTTL
+	}
+	now := time.Now()
+	for root, st := range p.stashes {
+		if now.Sub(st.lastUsed) > ttl {
+			delete(p.stashes, root)
+		}
+	}
+	max := p.maxStashes
+	if max <= 0 {
+		max = defaultMaxStashes
+	}
+	for len(p.stashes) > max {
+		var lruRoot string
+		var lruTime time.Time
+		for root, st := range p.stashes {
+			if lruRoot == "" || st.lastUsed.Before(lruTime) {
+				lruRoot, lruTime = root, st.lastUsed
+			}
+		}
+		if lruRoot == "" {
+			break
+		}
+		delete(p.stashes, lruRoot)
+	}
+}
+
+// startSweeper lazily launches one background goroutine that periodically
+// releases idle stashes, so a daemon that has gone quiet drops its
+// retained type-checked programs instead of holding them until the next
+// enrich. Stopped by Close.
+func (p *Provider) startSweeper() {
+	p.sweepOnce.Do(func() {
+		if p.stopSweep == nil {
+			p.stopSweep = make(chan struct{})
+		}
+		interval := p.stashTTL
+		if interval <= 0 {
+			interval = defaultStashTTL
+		}
+		if interval /= 2; interval < 30*time.Second {
+			interval = 30 * time.Second
+		}
+		stop := p.stopSweep
+		go func() {
+			t := time.NewTicker(interval)
+			defer t.Stop()
+			for {
+				select {
+				case <-stop:
+					return
+				case <-t.C:
+					p.stateMu.Lock()
+					p.evictLocked()
+					p.stateMu.Unlock()
+				}
+			}
+		}()
+	})
+}
+
+// envPositiveInt / envPositiveDuration read an operator override, falling
+// back to def when the variable is unset or unparseable.
+func envPositiveInt(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return def
+}
+
+func envPositiveDuration(key string, def time.Duration) time.Duration {
+	if v := os.Getenv(key); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return def
 }
 
 // lookupTypeAtLineInFile walks the file's AST and returns the type


### PR DESCRIPTION
## Summary

Code-intelligence resolution previously leaned on a language server for a common case: a type used **only in an annotation position** (`const x: T`, `field: T`, `let x: T`, and in some languages typed parameters/returns) seeded only a local type-environment map and emitted **no graph edge**. So `find_usages` on such a type returned little or nothing unless an LSP was installed and running — and an LSP-less environment (CI, a minimal container) silently lost recall.

This branch makes the tree-sitter extractors emit a real `EdgeTypedAs` (and `EdgeReturns` where missing) for those positions, so the existing name-based resolver lands the reference cross-file **with no language server**. It also fixes two stability problems surfaced along the way.

## What changed

### 1. Type-usage edges across 11 languages (LSP-free recall)
Each extractor now emits a type-use edge from the enclosing function/owner (falling back to the file node) to `unresolved::<Type>`, which the resolver resolves intra-repo by name + kind — the same path that already handled parameter/return types.

| Language | Gap closed |
|---|---|
| TypeScript, Python | variable/const + field annotations |
| Kotlin | emitted **zero** type edges before — added params, returns, and variable annotations |
| C#, Java, Rust | local variable + field annotations |
| Swift, Scala | added gaps **and** fixed latent bugs (existing field edges had no primitive filter and an empty `Origin`) |
| C++ | emitted **zero** type edges before — all four positions added |
| Dart, PHP | typed locals/fields/params (PHP returns were already covered) |

Measured in-process, **with the LSP disabled**, over a 133-file TypeScript corpus — resolved cross-file usages rose entirely on the new annotation-position references:

| type | before | after |
|---|---|---|
| `Node` | 146 | **248** |
| `Edge` | 61 | **99** |
| `UnresolvedRef` | 83 | **103** |

### 2. Bound retained `go/types` programs (daemon memory)
The `go-types` semantic provider stashed each repo's fully type-checked program (`go/types.Info` + every file's AST — on the order of 1–2 GB for a large module) keyed by repo root and never released it, so a daemon tracking many repos grew its resident set without bound. The cache is now bounded under its existing lock: an idle TTL releases a repo's program once its contract pass goes quiet (a lazily-started background sweeper drops idle entries), and a count ceiling caps how many coexist during a multi-repo warmup. A lookup that misses an evicted program degrades to the tree-sitter type tier rather than reloading. Both bounds are env-overridable (`GORTEX_GOTYPES_MAX_STASHES`, `GORTEX_GOTYPES_STASH_TTL`).

### 3. Survive store teardown races (daemon crash)
`Store.Close()` closes every cached prepared statement and then the `*sql.DB`. On daemon shutdown/restart/store-swap this raced in-flight readers — notably the parallel deferred-enrichment goroutines (`runDeferredEnrichParallel` → `GetNode`) — so a reader hit a statement `Close()` had already shut and `database/sql` returned `sql: statement is closed`, which `panicOnFatal` escalated into a process panic that took the whole daemon down. Closed-statement / closed-database / `ErrConnDone` are now treated as benign teardown races: the read degrades to an empty result instead of crashing.

## On "LSP as a fallback"
The recall work removes the **dependence** on an LSP — the tree-sitter heuristic is now a complete primary resolver. The per-edge ordering (`resolveEdge` consults the LSP hot path first for TS/JS) is intentionally left unchanged: `TestLSPHotPath_BarrelReExport` shows it provides genuine disambiguation (picking the real re-exported declaration over a same-named decoy), which is the compiler-grade accuracy we want when an LSP *is* present. A follow-up can make the LSP call fire only when the heuristic is ambiguous (so it isn't consulted for the unambiguous common case) — that needs a candidate-count signal from the resolve functions and is a separate, low-risk change.

## Testing
- New per-language emission tests + a cross-file end-to-end resolution test (extract two files → `ResolveAll` → assert the annotation type resolves to its definition, no LSP).
- New `store_sqlite` regression test: reads after `Close()` return empty, never panic.
- `go test -race` green for `internal/parser/languages`, `internal/resolver`, `internal/semantic/goanalysis`, `internal/graph/store_sqlite`.
- Full CGO binary builds; `gofmt` and `go vet` clean on all touched files.
