### PR TITLE
Decompose TypeScript generic type arguments for usage edges

### DIFF
--- a/internal/parser/languages/ts_cast_typeuse_test.go
+++ b/internal/parser/languages/ts_cast_typeuse_test.go
@@ -1,0 +1,207 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// typedAsEdgeTo reports whether edges contains an EdgeTypedAs to
+// unresolved::<name> carrying the given Meta["use_kind"]. A blank
+// useKind matches any.
+func typedAsEdgeTo(edges []*graph.Edge, name, useKind string) bool {
+	target := "unresolved::" + name
+	for _, e := range edges {
+		if e.Kind != graph.EdgeTypedAs || e.To != target {
+			continue
+		}
+		if useKind == "" {
+			return true
+		}
+		if uk, _ := e.Meta["use_kind"].(string); uk == useKind {
+			return true
+		}
+	}
+	return false
+}
+
+func TestTSCast_AsSimpleType(t *testing.T) {
+	src := `function f(x: unknown) {
+	const el = x as ExcalidrawElement;
+	return el;
+}
+`
+	_, edges := runTSExtract(t, "src/cast.ts", src)
+	if !typedAsEdgeTo(edges, "ExcalidrawElement", "cast") {
+		t.Errorf("expected EdgeTypedAs use_kind=cast → unresolved::ExcalidrawElement; got %v",
+			edgeTargets(edgesByKind(edges, graph.EdgeTypedAs)))
+	}
+}
+
+func TestTSCast_AsArrayType(t *testing.T) {
+	src := `function f(x: unknown) {
+	const els = x as ExcalidrawElement[];
+	return els;
+}
+`
+	_, edges := runTSExtract(t, "src/cast.ts", src)
+	if !typedAsEdgeTo(edges, "ExcalidrawElement", "cast") {
+		t.Errorf("expected EdgeTypedAs use_kind=cast → unresolved::ExcalidrawElement from array cast; got %v",
+			edgeTargets(edgesByKind(edges, graph.EdgeTypedAs)))
+	}
+}
+
+func TestTSCast_AsGenericType(t *testing.T) {
+	src := `function f(x: unknown) {
+	const el = x as NonDeleted<ExcalidrawElement>;
+	return el;
+}
+`
+	_, edges := runTSExtract(t, "src/cast.ts", src)
+	// The inner user type must surface; NonDeleted is a user-defined
+	// utility generic so it surfaces too (not a builtin container).
+	if !typedAsEdgeTo(edges, "ExcalidrawElement", "cast") {
+		t.Errorf("expected EdgeTypedAs use_kind=cast → unresolved::ExcalidrawElement from generic cast; got %v",
+			edgeTargets(edgesByKind(edges, graph.EdgeTypedAs)))
+	}
+}
+
+func TestTSCast_AsPrimitiveEmitsNone(t *testing.T) {
+	src := `function f(x: unknown) {
+	const n = x as number;
+	return n;
+}
+`
+	_, edges := runTSExtract(t, "src/cast.ts", src)
+	for _, e := range edgesByKind(edges, graph.EdgeTypedAs) {
+		if uk, _ := e.Meta["use_kind"].(string); uk == "cast" {
+			t.Errorf("primitive cast `x as number` must emit no cast EdgeTypedAs; got %s", e.To)
+		}
+	}
+}
+
+func TestTSCast_SatisfiesType(t *testing.T) {
+	src := `function f(x: unknown) {
+	const c = x satisfies AppConfig;
+	return c;
+}
+`
+	_, edges := runTSExtract(t, "src/cast.ts", src)
+	if !typedAsEdgeTo(edges, "AppConfig", "cast") {
+		t.Errorf("expected EdgeTypedAs use_kind=cast → unresolved::AppConfig from satisfies; got %v",
+			edgeTargets(edgesByKind(edges, graph.EdgeTypedAs)))
+	}
+}
+
+func TestTSCast_AngleAssertionPlainTSOnly(t *testing.T) {
+	// `<Foo>x` is a type assertion in plain .ts.
+	tsSrc := `function f(x: unknown) {
+	const el = <ExcalidrawElement>x;
+	return el;
+}
+`
+	_, edges := runTSExtract(t, "src/assert.ts", tsSrc)
+	if !typedAsEdgeTo(edges, "ExcalidrawElement", "cast") {
+		t.Errorf("expected EdgeTypedAs use_kind=cast → unresolved::ExcalidrawElement from <T>x assertion in .ts; got %v",
+			edgeTargets(edgesByKind(edges, graph.EdgeTypedAs)))
+	}
+
+	// In .tsx the same text parses as JSX, never a type_assertion, so
+	// no cast edge to ExcalidrawElement is emitted from it.
+	tsxSrc := `function f(x: unknown) {
+	return <Foo>hello</Foo>;
+}
+`
+	_, tsxEdges := runTSExtract(t, "src/assert.tsx", tsxSrc)
+	for _, e := range edgesByKind(tsxEdges, graph.EdgeTypedAs) {
+		if uk, _ := e.Meta["use_kind"].(string); uk == "cast" && e.To == "unresolved::Foo" {
+			t.Errorf("`<Foo>...` in .tsx must not emit a cast EdgeTypedAs (it's JSX); got %s", e.To)
+		}
+	}
+}
+
+func TestTSTypeAliasBody_Union(t *testing.T) {
+	src := `type Bar = Foo | Baz;
+`
+	_, edges := runTSExtract(t, "src/alias.ts", src)
+	if !typedAsEdgeTo(edges, "Foo", "type_annotation") {
+		t.Errorf("expected EdgeTypedAs → unresolved::Foo from alias body; got %v",
+			edgeTargets(edgesByKind(edges, graph.EdgeTypedAs)))
+	}
+	if !typedAsEdgeTo(edges, "Baz", "type_annotation") {
+		t.Errorf("expected EdgeTypedAs → unresolved::Baz from alias body; got %v",
+			edgeTargets(edgesByKind(edges, graph.EdgeTypedAs)))
+	}
+	// The alias never references its own name.
+	if typedAsEdgeTo(edges, "Bar", "") {
+		t.Errorf("alias body must not self-reference Bar")
+	}
+	// The edge originates from the alias node, not the file node.
+	hasFromAlias := false
+	for _, e := range edgesByKind(edges, graph.EdgeTypedAs) {
+		if e.To == "unresolved::Foo" && e.From == "src/alias.ts::Bar" {
+			hasFromAlias = true
+		}
+	}
+	if !hasFromAlias {
+		t.Errorf("alias-body EdgeTypedAs must originate from src/alias.ts::Bar")
+	}
+}
+
+func TestTSTypeAliasBody_Generic(t *testing.T) {
+	src := `type Qux = NonDeleted<ExcalidrawElement>;
+`
+	_, edges := runTSExtract(t, "src/alias.ts", src)
+	if !typedAsEdgeTo(edges, "ExcalidrawElement", "type_annotation") {
+		t.Errorf("expected EdgeTypedAs → unresolved::ExcalidrawElement from generic alias body; got %v",
+			edgeTargets(edgesByKind(edges, graph.EdgeTypedAs)))
+	}
+}
+
+func TestTSTypeAliasBody_MapContainerDropped(t *testing.T) {
+	src := `type ElementMap = Map<string, ExcalidrawElement>;
+`
+	_, edges := runTSExtract(t, "src/alias.ts", src)
+	if !typedAsEdgeTo(edges, "ExcalidrawElement", "type_annotation") {
+		t.Errorf("expected EdgeTypedAs → unresolved::ExcalidrawElement from Map alias body; got %v",
+			edgeTargets(edgesByKind(edges, graph.EdgeTypedAs)))
+	}
+	// Map is a builtin container generic — dropped.
+	if typedAsEdgeTo(edges, "Map", "type_annotation") {
+		t.Errorf("Map (builtin container) must be dropped from alias-body type refs")
+	}
+}
+
+func TestTSTypeAliasBody_Intersection(t *testing.T) {
+	src := `export type X = A & B;
+`
+	_, edges := runTSExtract(t, "src/alias.ts", src)
+	if !typedAsEdgeTo(edges, "A", "type_annotation") || !typedAsEdgeTo(edges, "B", "type_annotation") {
+		t.Errorf("expected EdgeTypedAs → A and B from intersection alias body; got %v",
+			edgeTargets(edgesByKind(edges, graph.EdgeTypedAs)))
+	}
+}
+
+func TestTSTypeRefs_Decompose(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"ExcalidrawElement", []string{"ExcalidrawElement"}},
+		{"ExcalidrawElement[]", []string{"ExcalidrawElement"}},
+		{"NonDeleted<ExcalidrawElement>", []string{"NonDeleted", "ExcalidrawElement"}},
+		{"Map<string, ExcalidrawElement>", []string{"ExcalidrawElement"}},
+		{"Foo | Baz", []string{"Foo", "Baz"}},
+		{"A & B", []string{"A", "B"}},
+		{"Promise<User[]>", []string{"User"}},
+		{"number", nil},
+		{"string | null", nil},
+		{"Record<string, Foo | Bar>", []string{"Foo", "Bar"}},
+	}
+	for _, c := range cases {
+		got := tsTypeRefs(c.in)
+		if !sliceEq(got, c.want) {
+			t.Errorf("tsTypeRefs(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/parser/languages/ts_function_shape.go
+++ b/internal/parser/languages/ts_function_shape.go
@@ -807,3 +807,113 @@ func isTSPrimitive(t string) bool {
 	}
 	return false
 }
+
+// emitTSTypeRefEdges emits one EdgeTypedAs per named type in typeText
+// from ownerID to unresolved::<name>, tagged with use_kind so a
+// traversal can tell a cast (`x as Foo`) from an alias body
+// (`type Bar = Foo`) from an annotation. Decomposition is delegated to
+// tsTypeRefs (unions / intersections / arrays / generics handled,
+// primitives + container generics dropped). De-duplicated per name so a
+// position firing twice can't double-emit.
+func emitTSTypeRefEdges(ownerID, typeText, filePath string, line int, useKind string, result *parser.ExtractionResult) {
+	if ownerID == "" || typeText == "" {
+		return
+	}
+	for _, name := range tsTypeRefs(typeText) {
+		result.Edges = append(result.Edges, &graph.Edge{
+			From:     ownerID,
+			To:       "unresolved::" + name,
+			Kind:     graph.EdgeTypedAs,
+			FilePath: filePath,
+			Line:     line,
+			Origin:   graph.OriginASTInferred,
+			Meta:     map[string]any{"use_kind": useKind},
+		})
+	}
+}
+
+// emitTSCastTypeRefs walks a parsed TS/TSX file and emits a cast
+// type-reference edge for every type assertion:
+//
+//   - as_expression       — `x as Foo`, `x as Foo[]`, `x as NonDeleted<Foo>`
+//   - satisfies_expression — `x satisfies Foo`
+//   - type_assertion      — `<Foo>x` (plain .ts only; the TSX grammar
+//     never produces this node because `<Foo>` is a JSX opening element)
+//
+// Each names the asserted type(s); the edge is EdgeTypedAs to
+// unresolved::<name> with use_kind:"cast", attributed to the enclosing
+// function (fallback: the file node). Decomposition (unions, generics,
+// arrays, primitive/container dropping) is delegated to tsTypeRefs via
+// emitTSTypeRefEdges. De-duplicated per (owner, name, line) so an
+// expression that a future query might also match elsewhere can't
+// double-emit.
+func emitTSCastTypeRefs(root *sitter.Node, src []byte, filePath, fileID string, funcRanges []funcRange, result *parser.ExtractionResult) {
+	if root == nil {
+		return
+	}
+	seen := map[string]bool{}
+	emit := func(typeText string, line int) {
+		typeText = strings.TrimSpace(typeText)
+		if typeText == "" {
+			return
+		}
+		ownerID := findEnclosingFunc(funcRanges, line)
+		if ownerID == "" {
+			ownerID = fileID
+		}
+		for _, name := range tsTypeRefs(typeText) {
+			key := ownerID + "\x00" + name + "\x00" + strconv.Itoa(line)
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			result.Edges = append(result.Edges, &graph.Edge{
+				From:     ownerID,
+				To:       "unresolved::" + name,
+				Kind:     graph.EdgeTypedAs,
+				FilePath: filePath,
+				Line:     line,
+				Origin:   graph.OriginASTInferred,
+				Meta:     map[string]any{"use_kind": "cast"},
+			})
+		}
+	}
+	walkTSNodes(root, func(n *sitter.Node) bool {
+		switch n.Type() {
+		case "as_expression", "satisfies_expression":
+			// Shape: (as_expression <value> <type>) — the asserted type
+			// is the last named child (the first is the value expression).
+			if tn := tsCastTypeNode(n); tn != nil {
+				emit(tn.Content(src), int(n.StartPoint().Row)+1)
+			}
+		case "type_assertion":
+			// Shape: (type_assertion (type_arguments <type>) <value>) —
+			// the angle-bracket `<Foo>x` form, plain .ts only. The
+			// type_arguments text carries the surrounding `<…>`; the
+			// inner type_identifier(s) are the real reference, so trim
+			// the brackets before decomposing.
+			for i := 0; i < int(n.NamedChildCount()); i++ {
+				c := n.NamedChild(i)
+				if c != nil && c.Type() == "type_arguments" {
+					inner := strings.TrimSpace(c.Content(src))
+					inner = strings.TrimPrefix(inner, "<")
+					inner = strings.TrimSuffix(inner, ">")
+					emit(inner, int(n.StartPoint().Row)+1)
+					break
+				}
+			}
+		}
+		return true
+	})
+}
+
+// tsCastTypeNode returns the asserted-type node of an as_expression or
+// satisfies_expression — the last named child, since the value
+// expression precedes it. Returns nil for a malformed node.
+func tsCastTypeNode(n *sitter.Node) *sitter.Node {
+	count := int(n.NamedChildCount())
+	if count == 0 {
+		return nil
+	}
+	return n.NamedChild(count - 1)
+}

--- a/internal/parser/languages/ts_function_shape.go
+++ b/internal/parser/languages/ts_function_shape.go
@@ -463,10 +463,10 @@ func emitTSParamNodes(ownerID string, params *sitter.Node, src []byte, filePath 
 			Line:     startLine,
 			Origin:   graph.OriginASTResolved,
 		})
-		if canon := canonicalizeTSTypeRef(typeName); canon != "" && !isTSPrimitive(canon) {
+		for _, ref := range tsTypeRefs(typeName) {
 			result.Edges = append(result.Edges, &graph.Edge{
 				From:     paramID,
-				To:       "unresolved::" + canon,
+				To:       "unresolved::" + ref,
 				Kind:     graph.EdgeTypedAs,
 				FilePath: filePath,
 				Line:     startLine,
@@ -482,14 +482,7 @@ func emitTSParamNodes(ownerID string, params *sitter.Node, src []byte, filePath 
 // (`A | B`) emit one edge per branch so traversals can find every
 // possible runtime return type.
 func emitTSReturnEdges(ownerID, returnText, filePath string, line int, result *parser.ExtractionResult) {
-	if returnText == "" {
-		return
-	}
-	for i, raw := range splitTSUnionType(returnText) {
-		t := canonicalizeTSTypeRef(raw)
-		if t == "" || isTSPrimitive(t) {
-			continue
-		}
+	for i, t := range tsTypeRefs(returnText) {
 		result.Edges = append(result.Edges, &graph.Edge{
 			From:     ownerID,
 			To:       "unresolved::" + t,
@@ -511,14 +504,7 @@ func emitTSReturnEdges(ownerID, returnText, filePath string, line int, result *p
 // without an LSP. Union / intersection branches each emit an edge,
 // mirroring emitTSReturnEdges; primitives are skipped.
 func emitTSTypeUseEdges(ownerID, typeText, filePath string, line int, result *parser.ExtractionResult) {
-	if typeText == "" {
-		return
-	}
-	for _, raw := range splitTSUnionType(typeText) {
-		t := canonicalizeTSTypeRef(raw)
-		if t == "" || isTSPrimitive(t) {
-			continue
-		}
+	for _, t := range tsTypeRefs(typeText) {
 		result.Edges = append(result.Edges, &graph.Edge{
 			From:     ownerID,
 			To:       "unresolved::" + t,
@@ -528,6 +514,135 @@ func emitTSTypeUseEdges(ownerID, typeText, filePath string, line int, result *pa
 			Origin:   graph.OriginASTInferred,
 		})
 	}
+}
+
+// tsBuiltinGenerics are container / utility generics whose own name is not
+// a useful cross-file reference (they have no repo definition) but whose
+// type arguments are — so tsTypeRefs recurses into them without emitting
+// the wrapper itself. A user-defined wrapper (NonDeleted<Foo>) is NOT in
+// this set, so both NonDeleted and Foo surface as references.
+var tsBuiltinGenerics = map[string]bool{
+	"Promise": true, "PromiseLike": true, "Awaited": true,
+	"Array": true, "ReadonlyArray": true,
+	"Map": true, "ReadonlyMap": true, "WeakMap": true,
+	"Set": true, "ReadonlySet": true, "WeakSet": true,
+	"Record": true, "Readonly": true, "Partial": true, "Required": true,
+	"Pick": true, "Omit": true, "Exclude": true, "Extract": true,
+	"NonNullable": true, "Parameters": true, "ReturnType": true,
+	"InstanceType": true, "Iterable": true, "IterableIterator": true,
+	"Iterator": true, "Generator": true,
+}
+
+// tsTypeRefs returns the distinct named type references in a TypeScript type
+// annotation, decomposing unions / intersections, `readonly`, arrays,
+// parentheses and generic type arguments. A type used only as a type
+// argument — `Map<string, Foo>`, `NonDeleted<Foo>`, `readonly Foo[]` —
+// surfaces as a reference; primitives and container/utility generics are
+// dropped (but recursed into). This is what lets find_usages land a type
+// that never appears bare, only wrapped.
+func tsTypeRefs(typeText string) []string {
+	var out []string
+	seen := map[string]bool{}
+	var walk func(t string)
+	walk = func(t string) {
+		t = strings.TrimSpace(t)
+		t = strings.TrimPrefix(t, "readonly ")
+		t = strings.TrimSpace(t)
+		for strings.HasSuffix(t, "[]") {
+			t = strings.TrimSpace(strings.TrimSuffix(t, "[]"))
+		}
+		for strings.HasPrefix(t, "(") && strings.HasSuffix(t, ")") {
+			t = strings.TrimSpace(t[1 : len(t)-1])
+		}
+		if t == "" {
+			return
+		}
+		if parts := splitTSUnionType(t); len(parts) > 1 {
+			for _, p := range parts {
+				walk(p)
+			}
+			return
+		}
+		if i := strings.IndexByte(t, '<'); i >= 0 && strings.HasSuffix(t, ">") {
+			addTSRef(strings.TrimSpace(t[:i]), &out, seen)
+			for _, arg := range splitTSTypeArgs(t[i+1 : len(t)-1]) {
+				walk(arg)
+			}
+			return
+		}
+		addTSRef(t, &out, seen)
+	}
+	walk(typeText)
+	return out
+}
+
+// addTSRef appends a bare named type to out (deduped) after stripping
+// keyof/typeof prefixes and module qualifiers, skipping primitives,
+// container/utility generics, and anything that is not a plain identifier
+// (string-literal types, object-type literals, mapped types).
+func addTSRef(name string, out *[]string, seen map[string]bool) {
+	name = strings.TrimSpace(name)
+	name = strings.TrimPrefix(name, "keyof ")
+	name = strings.TrimPrefix(name, "typeof ")
+	name = strings.TrimSpace(name)
+	if i := strings.LastIndex(name, "."); i >= 0 {
+		name = name[i+1:]
+	}
+	if name == "" || isTSPrimitive(name) || tsBuiltinGenerics[name] || !isTSTypeName(name) || seen[name] {
+		return
+	}
+	seen[name] = true
+	*out = append(*out, name)
+}
+
+// isTSTypeName reports whether s is a plain (ASCII) type identifier, so a
+// string-literal type ("foo"), numeric literal, or object-type residue
+// never becomes a bogus unresolved target.
+func isTSTypeName(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		ok := c == '_' || c == '$' || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+		if i > 0 {
+			ok = ok || (c >= '0' && c <= '9')
+		}
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// splitTSTypeArgs splits a generic argument list at top-level commas,
+// respecting nested <>, (), {}, [].
+func splitTSTypeArgs(s string) []string {
+	var parts []string
+	depth := 0
+	cur := strings.Builder{}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch c {
+		case '<', '(', '{', '[':
+			depth++
+		case '>', ')', '}', ']':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				parts = append(parts, cur.String())
+				cur.Reset()
+				continue
+			}
+		}
+		cur.WriteByte(c)
+	}
+	if last := strings.TrimSpace(cur.String()); last != "" {
+		parts = append(parts, last)
+	}
+	return parts
 }
 
 // emitTSGenericParamNodes turns a TS function/class declaration's

--- a/internal/parser/languages/typescript.go
+++ b/internal/parser/languages/typescript.go
@@ -370,6 +370,15 @@ func (e *TypeScriptExtractor) Extract(filePath string, src []byte) (*parser.Extr
 		emitTSTypeUseEdges(ownerID, tu.typeText, filePath, tu.line, result)
 	}
 
+	// Cast / assertion type references: `x as Foo`, `x as Foo[]`,
+	// `x as NonDeleted<Foo>`, `x satisfies Foo`, and (plain .ts only)
+	// the angle-bracket assertion `<Foo>x`. Each names the type(s) it
+	// asserts, so find_usages(Foo) should surface the cast site. The
+	// angle-bracket form is intentionally skipped on .tsx, where the
+	// TSX grammar parses `<Foo>` as a JSX opening element, not a type
+	// assertion. Attributed to the enclosing function (fallback: file).
+	emitTSCastTypeRefs(root, src, filePath, fileID, funcRanges, result)
+
 	// Instantiation edges: `new Foo(...)` constructs Foo. Emitted as a typed
 	// EdgeInstantiates (not a flat call) attributed to the enclosing function,
 	// so the resolver lands it on the class and impact/trace see construction.
@@ -973,6 +982,16 @@ func (e *TypeScriptExtractor) emitTypeAlias(m parser.QueryResult, filePath, file
 		From: fileID, To: id, Kind: graph.EdgeDefines,
 		FilePath: filePath, Line: def.StartLine + 1,
 	})
+	// Alias-body type references: `type Bar = Foo | Baz` references Foo
+	// and Baz; `type Qux = NonDeleted<Foo>` references NonDeleted and
+	// Foo. Emit one EdgeTypedAs per named type on the RHS (the alias's
+	// own name is never a self-edge — it's not in the value text), so
+	// find_usages(Foo) surfaces the alias without an LSP.
+	if def.Node != nil {
+		if rhs := def.Node.ChildByFieldName("value"); rhs != nil {
+			emitTSTypeRefEdges(id, strings.TrimSpace(rhs.Content(src)), filePath, def.StartLine+1, "type_annotation", result)
+		}
+	}
 }
 
 func (e *TypeScriptExtractor) emitEnum(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult) {


### PR DESCRIPTION
## Summary

Follow-up to #143. That PR made tree-sitter emit type-usage edges without a language server, but the TypeScript canonicalizer only unwrapped a **fixed** list of wrappers (`Promise`/`Array`/`ReadonlyArray`/`Awaited`) and otherwise reduced a type to a single outer name. So a type used **only as a generic argument** produced no usage edge for the inner type.

On real code this is the dominant case. In **excalidraw**, the `ExcalidrawElement` type is almost always wrapped — `NonDeleted<ExcalidrawElement>`, `readonly NonDeleted<ExcalidrawElement>[]`, `Map<string, ExcalidrawElement>`, `Set<ExcalidrawElement>` — so most of its references stayed invisible.

## Change

Replace the single-name canonicalizer at the three TS emission sites (variable/field annotation, parameter, return) with a **decomposer** that walks unions, intersections, `readonly`, arrays, parentheses, and **generic type arguments** — emitting a usage edge per distinct named type. Primitives and container/utility generics (`Promise`/`Map`/`Record`/`Set`/`Pick`/…) are dropped but **recursed into**, while user-defined wrappers (`NonDeleted<Foo>`) yield both the wrapper and the argument. String-literal types, numeric literals, and object-type residue are filtered so they never become bogus targets.

## Measurement (in-process, LSP disabled, excalidraw's 536 TS files)

| type | before this PR | after |
|---|---|---|
| `ExcalidrawElement` | 312 | **393** |
| `NonDeletedExcalidrawElement` | ~0 | **111** |

(For reference, the same type resolved to **1** on the pre-#143 daemon — the generic-argument decomposition closes most of the remaining gap.)

## Testing
`go test -race` green for `internal/parser/languages` and `internal/resolver`; full CGO binary builds; `gofmt` / `go vet` clean; `golangci-lint --new-from-rev` reports 0 new issues.
