### PR TITLE
feat(parser): decompose TypeScript generic type arguments for usage edges

### DIFF
--- a/internal/parser/languages/ts_function_shape.go
+++ b/internal/parser/languages/ts_function_shape.go
@@ -463,10 +463,10 @@ func emitTSParamNodes(ownerID string, params *sitter.Node, src []byte, filePath 
 			Line:     startLine,
 			Origin:   graph.OriginASTResolved,
 		})
-		if canon := canonicalizeTSTypeRef(typeName); canon != "" && !isTSPrimitive(canon) {
+		for _, ref := range tsTypeRefs(typeName) {
 			result.Edges = append(result.Edges, &graph.Edge{
 				From:     paramID,
-				To:       "unresolved::" + canon,
+				To:       "unresolved::" + ref,
 				Kind:     graph.EdgeTypedAs,
 				FilePath: filePath,
 				Line:     startLine,
@@ -482,14 +482,7 @@ func emitTSParamNodes(ownerID string, params *sitter.Node, src []byte, filePath 
 // (`A | B`) emit one edge per branch so traversals can find every
 // possible runtime return type.
 func emitTSReturnEdges(ownerID, returnText, filePath string, line int, result *parser.ExtractionResult) {
-	if returnText == "" {
-		return
-	}
-	for i, raw := range splitTSUnionType(returnText) {
-		t := canonicalizeTSTypeRef(raw)
-		if t == "" || isTSPrimitive(t) {
-			continue
-		}
+	for i, t := range tsTypeRefs(returnText) {
 		result.Edges = append(result.Edges, &graph.Edge{
 			From:     ownerID,
 			To:       "unresolved::" + t,
@@ -511,14 +504,7 @@ func emitTSReturnEdges(ownerID, returnText, filePath string, line int, result *p
 // without an LSP. Union / intersection branches each emit an edge,
 // mirroring emitTSReturnEdges; primitives are skipped.
 func emitTSTypeUseEdges(ownerID, typeText, filePath string, line int, result *parser.ExtractionResult) {
-	if typeText == "" {
-		return
-	}
-	for _, raw := range splitTSUnionType(typeText) {
-		t := canonicalizeTSTypeRef(raw)
-		if t == "" || isTSPrimitive(t) {
-			continue
-		}
+	for _, t := range tsTypeRefs(typeText) {
 		result.Edges = append(result.Edges, &graph.Edge{
 			From:     ownerID,
 			To:       "unresolved::" + t,
@@ -528,6 +514,135 @@ func emitTSTypeUseEdges(ownerID, typeText, filePath string, line int, result *pa
 			Origin:   graph.OriginASTInferred,
 		})
 	}
+}
+
+// tsBuiltinGenerics are container / utility generics whose own name is not
+// a useful cross-file reference (they have no repo definition) but whose
+// type arguments are — so tsTypeRefs recurses into them without emitting
+// the wrapper itself. A user-defined wrapper (NonDeleted<Foo>) is NOT in
+// this set, so both NonDeleted and Foo surface as references.
+var tsBuiltinGenerics = map[string]bool{
+	"Promise": true, "PromiseLike": true, "Awaited": true,
+	"Array": true, "ReadonlyArray": true,
+	"Map": true, "ReadonlyMap": true, "WeakMap": true,
+	"Set": true, "ReadonlySet": true, "WeakSet": true,
+	"Record": true, "Readonly": true, "Partial": true, "Required": true,
+	"Pick": true, "Omit": true, "Exclude": true, "Extract": true,
+	"NonNullable": true, "Parameters": true, "ReturnType": true,
+	"InstanceType": true, "Iterable": true, "IterableIterator": true,
+	"Iterator": true, "Generator": true,
+}
+
+// tsTypeRefs returns the distinct named type references in a TypeScript type
+// annotation, decomposing unions / intersections, `readonly`, arrays,
+// parentheses and generic type arguments. A type used only as a type
+// argument — `Map<string, Foo>`, `NonDeleted<Foo>`, `readonly Foo[]` —
+// surfaces as a reference; primitives and container/utility generics are
+// dropped (but recursed into). This is what lets find_usages land a type
+// that never appears bare, only wrapped.
+func tsTypeRefs(typeText string) []string {
+	var out []string
+	seen := map[string]bool{}
+	var walk func(t string)
+	walk = func(t string) {
+		t = strings.TrimSpace(t)
+		t = strings.TrimPrefix(t, "readonly ")
+		t = strings.TrimSpace(t)
+		for strings.HasSuffix(t, "[]") {
+			t = strings.TrimSpace(strings.TrimSuffix(t, "[]"))
+		}
+		for strings.HasPrefix(t, "(") && strings.HasSuffix(t, ")") {
+			t = strings.TrimSpace(t[1 : len(t)-1])
+		}
+		if t == "" {
+			return
+		}
+		if parts := splitTSUnionType(t); len(parts) > 1 {
+			for _, p := range parts {
+				walk(p)
+			}
+			return
+		}
+		if i := strings.IndexByte(t, '<'); i >= 0 && strings.HasSuffix(t, ">") {
+			addTSRef(strings.TrimSpace(t[:i]), &out, seen)
+			for _, arg := range splitTSTypeArgs(t[i+1 : len(t)-1]) {
+				walk(arg)
+			}
+			return
+		}
+		addTSRef(t, &out, seen)
+	}
+	walk(typeText)
+	return out
+}
+
+// addTSRef appends a bare named type to out (deduped) after stripping
+// keyof/typeof prefixes and module qualifiers, skipping primitives,
+// container/utility generics, and anything that is not a plain identifier
+// (string-literal types, object-type literals, mapped types).
+func addTSRef(name string, out *[]string, seen map[string]bool) {
+	name = strings.TrimSpace(name)
+	name = strings.TrimPrefix(name, "keyof ")
+	name = strings.TrimPrefix(name, "typeof ")
+	name = strings.TrimSpace(name)
+	if i := strings.LastIndex(name, "."); i >= 0 {
+		name = name[i+1:]
+	}
+	if name == "" || isTSPrimitive(name) || tsBuiltinGenerics[name] || !isTSTypeName(name) || seen[name] {
+		return
+	}
+	seen[name] = true
+	*out = append(*out, name)
+}
+
+// isTSTypeName reports whether s is a plain (ASCII) type identifier, so a
+// string-literal type ("foo"), numeric literal, or object-type residue
+// never becomes a bogus unresolved target.
+func isTSTypeName(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		ok := c == '_' || c == '$' || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+		if i > 0 {
+			ok = ok || (c >= '0' && c <= '9')
+		}
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// splitTSTypeArgs splits a generic argument list at top-level commas,
+// respecting nested <>, (), {}, [].
+func splitTSTypeArgs(s string) []string {
+	var parts []string
+	depth := 0
+	cur := strings.Builder{}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch c {
+		case '<', '(', '{', '[':
+			depth++
+		case '>', ')', '}', ']':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				parts = append(parts, cur.String())
+				cur.Reset()
+				continue
+			}
+		}
+		cur.WriteByte(c)
+	}
+	if last := strings.TrimSpace(cur.String()); last != "" {
+		parts = append(parts, last)
+	}
+	return parts
 }
 
 // emitTSGenericParamNodes turns a TS function/class declaration's


### PR DESCRIPTION
A type used only as a generic argument (Map<string, Foo>, NonDeleted<Foo>, readonly Foo[]) was canonicalized to a single outer name, so the inner type produced no usage edge. On a real codebase the impact is large: the excalidraw ExcalidrawElement type is almost always wrapped in NonDeleted<...> or an array, so most of its references were invisible. Replace the single-name canonicalizer at the three TS emission sites (variable/field, parameter, return) with a decomposer that walks unions, intersections, arrays, readonly, parentheses and generic type arguments -- emitting a usage edge per distinct named type, dropping primitives and container/utility generics (Promise/Map/Record/...) while still recursing into their arguments.

Measured LSP-free on excalidraw's 536 TS files: ExcalidrawElement resolved usages 312 -> 393, and NonDeletedExcalidrawElement -> 111 (both near-zero before this branch).
