### PR TITLE
fix(resolver): resolve type-use edges to the canonical definition

### DIFF
--- a/internal/resolver/canonical_type_pick_test.go
+++ b/internal/resolver/canonical_type_pick_test.go
@@ -1,0 +1,180 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// These tests pin the canonical-definition contract for type-use /
+// reference / instantiate edges: when several nodes share a name, the
+// resolver must land the edge on the *canonical* in-repo definition —
+// the one search_symbols returns — rather than a same-named rival
+// (external stub, test/mock definition, private or nested member type).
+// Each test seeds the rival shape that, before the fix, stole the edge
+// and left the canonical definition with zero incoming usage (the
+// "likely_unused" hard-0 for widely-imported and builder-pattern types).
+
+// usageIncoming counts the incoming edge kinds find_usages treats as
+// real usage (mirrors graph.ClassifyZeroEdge's usageEdgeKinds).
+func usageIncoming(g *graph.Graph, id string) int {
+	usage := map[graph.EdgeKind]bool{
+		graph.EdgeCalls: true, graph.EdgeReferences: true, graph.EdgeInstantiates: true,
+		graph.EdgeImplements: true, graph.EdgeExtends: true, graph.EdgeReads: true,
+		graph.EdgeWrites: true, graph.EdgeTests: true,
+	}
+	n := 0
+	for _, e := range g.GetInEdges(id) {
+		if usage[e.Kind] {
+			n++
+		}
+	}
+	return n
+}
+
+// A type-use edge must land on the real in-repo definition, never on a
+// same-named external / synthetic stub node.
+func TestCanonicalPick_PrefersRealDefOverExternalStub(t *testing.T) {
+	g := graph.New()
+	// Canonical definition in a normal source file.
+	canon := &graph.Node{
+		ID: "repoA/client/OkHttpClient.kt::OkHttpClient", Kind: graph.KindType, Name: "OkHttpClient",
+		FilePath: "repoA/client/OkHttpClient.kt", Language: "kotlin", RepoPrefix: "repoA",
+		Meta: map[string]any{"visibility": "public"},
+	}
+	g.AddNode(canon)
+	// A same-named synthetic external placeholder (re-export / external_call
+	// terminal). Marked external so the ranker demotes it hard.
+	g.AddNode(&graph.Node{
+		ID: "repoA/external::OkHttpClient", Kind: graph.KindType, Name: "OkHttpClient",
+		FilePath: "external::OkHttpClient", Language: "kotlin", RepoPrefix: "repoA",
+		Meta: map[string]any{"external": true, "synthetic": true},
+	})
+	// The caller node fixes the edge's repo (callerRepoPrefix reads it).
+	g.AddNode(&graph.Node{ID: "repoA/app/Main.kt::run", Kind: graph.KindFunction, Name: "run", FilePath: "repoA/app/Main.kt", Language: "kotlin", RepoPrefix: "repoA"})
+	g.AddNode(&graph.Node{ID: "repoA/app/Main.kt::field", Kind: graph.KindVariable, Name: "field", FilePath: "repoA/app/Main.kt", Language: "kotlin", RepoPrefix: "repoA"})
+
+	// instantiate + typed_as + references edges from another file.
+	inst := &graph.Edge{From: "repoA/app/Main.kt::run", To: "unresolved::OkHttpClient", Kind: graph.EdgeInstantiates, FilePath: "repoA/app/Main.kt", Line: 5}
+	typed := &graph.Edge{From: "repoA/app/Main.kt::field", To: "unresolved::OkHttpClient", Kind: graph.EdgeTypedAs, FilePath: "repoA/app/Main.kt", Line: 6}
+	g.AddEdge(inst)
+	g.AddEdge(typed)
+
+	New(g).ResolveAll()
+
+	assert.Equal(t, canon.ID, inst.To, "instantiate must land on the real definition, not the external stub")
+	assert.Equal(t, canon.ID, typed.To, "typed_as must land on the real definition, not the external stub")
+	assert.GreaterOrEqual(t, usageIncoming(g, canon.ID), 1, "canonical def must have incoming usage")
+}
+
+// A type-use edge must land on the non-test definition when a same-named
+// type also exists in a test source file.
+func TestCanonicalPick_PrefersNonTestOverTestDef(t *testing.T) {
+	g := graph.New()
+	canon := &graph.Node{
+		ID: "repoA/src/main/Response.kt::Response", Kind: graph.KindType, Name: "Response",
+		FilePath: "repoA/src/main/Response.kt", Language: "kotlin", RepoPrefix: "repoA",
+		Meta: map[string]any{"visibility": "public"},
+	}
+	g.AddNode(canon)
+	// Same-named class in a test source file — must not catch the edge.
+	g.AddNode(&graph.Node{
+		ID: "repoA/src/jvmTest/SomeTest.kt::Response", Kind: graph.KindType, Name: "Response",
+		FilePath: "repoA/src/jvmTest/SomeTest.kt", Language: "kotlin", RepoPrefix: "repoA",
+		Meta: map[string]any{"visibility": "public"},
+	})
+
+	g.AddNode(&graph.Node{ID: "repoA/src/jvmTest/SomeTest.kt::testIt", Kind: graph.KindFunction, Name: "testIt", FilePath: "repoA/src/jvmTest/SomeTest.kt", Language: "kotlin", RepoPrefix: "repoA"})
+
+	// The reference edge originates *from* the test file's directory, so a
+	// naive same-directory preference would have stolen it for the test def.
+	ref := &graph.Edge{From: "repoA/src/jvmTest/SomeTest.kt::testIt", To: "unresolved::Response", Kind: graph.EdgeReferences, FilePath: "repoA/src/jvmTest/SomeTest.kt", Line: 9}
+	g.AddEdge(ref)
+
+	New(g).ResolveAll()
+
+	assert.Equal(t, canon.ID, ref.To, "reference must land on the non-test definition even when the caller is in a test file")
+	assert.GreaterOrEqual(t, usageIncoming(g, canon.ID), 1)
+}
+
+// A type-use edge must prefer an exported/public definition over a
+// same-named private one.
+func TestCanonicalPick_PrefersExportedOverPrivate(t *testing.T) {
+	g := graph.New()
+	pub := &graph.Node{
+		ID: "repoA/api/AppState.ts::AppState", Kind: graph.KindInterface, Name: "AppState",
+		FilePath: "repoA/api/AppState.ts", Language: "typescript", RepoPrefix: "repoA",
+		Meta: map[string]any{"visibility": "public"},
+	}
+	g.AddNode(pub)
+	g.AddNode(&graph.Node{
+		ID: "repoA/internal/local.ts::AppState", Kind: graph.KindInterface, Name: "AppState",
+		FilePath: "repoA/internal/local.ts", Language: "typescript", RepoPrefix: "repoA",
+		Meta: map[string]any{"visibility": "private"},
+	})
+
+	g.AddNode(&graph.Node{ID: "repoA/app/use.ts::handler", Kind: graph.KindFunction, Name: "handler", FilePath: "repoA/app/use.ts", Language: "typescript", RepoPrefix: "repoA"})
+	typed := &graph.Edge{From: "repoA/app/use.ts::handler", To: "unresolved::AppState", Kind: graph.EdgeTypedAs, FilePath: "repoA/app/use.ts", Line: 3}
+	g.AddEdge(typed)
+
+	New(g).ResolveAll()
+
+	assert.Equal(t, pub.ID, typed.To, "typed_as must prefer the exported definition over a private same-named one")
+}
+
+// The nested-builder shape: a reference / instantiate of `Foo` must not
+// be stolen by a nested `Foo.Builder` member type, and an instantiate of
+// the nested `Foo.Builder` must not be stolen by the top-level `Foo`.
+func TestCanonicalPick_NestedBuilderDoesNotStealParentEdges(t *testing.T) {
+	g := graph.New()
+	// Top-level Foo.
+	foo := &graph.Node{
+		ID: "repoA/Foo.kt::Foo", Kind: graph.KindType, Name: "Foo",
+		FilePath: "repoA/Foo.kt", Language: "kotlin", RepoPrefix: "repoA",
+		Meta: map[string]any{"visibility": "public"},
+	}
+	g.AddNode(foo)
+	// Nested Foo.Builder, expressed as a dotted name (the qualified form a
+	// language that keeps the enclosing-type prefix emits).
+	builder := &graph.Node{
+		ID: "repoA/Foo.kt::Foo.Builder", Kind: graph.KindType, Name: "Foo.Builder",
+		FilePath: "repoA/Foo.kt", Language: "kotlin", RepoPrefix: "repoA",
+		Meta: map[string]any{"visibility": "public"},
+	}
+	g.AddNode(builder)
+	g.AddNode(&graph.Node{ID: "repoA/app/Main.kt::run", Kind: graph.KindFunction, Name: "run", FilePath: "repoA/app/Main.kt", Language: "kotlin", RepoPrefix: "repoA"})
+
+	// A reference to `Foo` must land on the top-level Foo, not Foo.Builder.
+	refFoo := &graph.Edge{From: "repoA/app/Main.kt::run", To: "unresolved::Foo", Kind: graph.EdgeReferences, FilePath: "repoA/app/Main.kt", Line: 4}
+	g.AddEdge(refFoo)
+	// An instantiate of the nested `Foo.Builder` must land on the builder,
+	// not on the top-level Foo.
+	instBuilder := &graph.Edge{From: "repoA/app/Main.kt::run", To: "unresolved::Foo.Builder", Kind: graph.EdgeInstantiates, FilePath: "repoA/app/Main.kt", Line: 5}
+	g.AddEdge(instBuilder)
+
+	New(g).ResolveAll()
+
+	assert.Equal(t, foo.ID, refFoo.To, "reference to Foo must not be stolen by the nested Foo.Builder")
+	assert.Equal(t, builder.ID, instBuilder.To, "instantiate of Foo.Builder must land on the nested builder, not on Foo")
+	assert.GreaterOrEqual(t, usageIncoming(g, foo.ID), 1, "top-level Foo must keep its own incoming usage")
+	assert.GreaterOrEqual(t, usageIncoming(g, builder.ID), 1, "nested Foo.Builder must keep its own incoming usage")
+}
+
+// Guard: with no rival, the single canonical type still resolves (the
+// fix must not narrow the common one-candidate case).
+func TestCanonicalPick_SingleCandidateStillResolves(t *testing.T) {
+	g := graph.New()
+	canon := &graph.Node{
+		ID: "repoA/Widget.kt::Widget", Kind: graph.KindType, Name: "Widget",
+		FilePath: "repoA/Widget.kt", Language: "kotlin", RepoPrefix: "repoA",
+	}
+	g.AddNode(canon)
+	g.AddNode(&graph.Node{ID: "repoA/app/Main.kt::run", Kind: graph.KindFunction, Name: "run", FilePath: "repoA/app/Main.kt", Language: "kotlin", RepoPrefix: "repoA"})
+	inst := &graph.Edge{From: "repoA/app/Main.kt::run", To: "unresolved::Widget", Kind: graph.EdgeInstantiates, FilePath: "repoA/app/Main.kt", Line: 2}
+	g.AddEdge(inst)
+
+	New(g).ResolveAll()
+
+	assert.Equal(t, canon.ID, inst.To)
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -1565,23 +1565,16 @@ func (r *Resolver) resolveTypeOrFunc(e *graph.Edge, name string, stats *ResolveS
 
 	callerDir := filepath.Dir(e.FilePath)
 
-	// Prefer same-package type match.
-	for _, c := range candidates {
-		if (c.Kind == graph.KindType || c.Kind == graph.KindInterface) &&
-			filepath.Dir(c.FilePath) == callerDir {
-			e.To = c.ID
-			stats.Resolved++
-			return
-		}
-	}
-
-	// Fall back to any same-repo type match.
-	for _, c := range candidates {
-		if c.Kind == graph.KindType || c.Kind == graph.KindInterface {
-			e.To = c.ID
-			stats.Resolved++
-			return
-		}
+	// Land the edge on the canonical type/interface definition (real,
+	// exported, top-level, non-test), preferring same-package only as a
+	// tiebreak. See bestTypeCandidate / resolveTypeRef for the rationale:
+	// without this an instantiate / reference edge for a widely-imported
+	// or builder-pattern type lands on whichever same-named rival sorts
+	// first, hiding all usage from the canonical definition node.
+	if best := bestTypeCandidate(candidates, callerDir); best != nil {
+		e.To = best.ID
+		stats.Resolved++
+		return
 	}
 
 	// If no type found, try as function (e.g., bare function name passed as value).
@@ -1625,22 +1618,17 @@ func (r *Resolver) resolveTypeRef(e *graph.Edge, name string, stats *ResolveStat
 	}
 	callerDir := filepath.Dir(e.FilePath)
 
-	// Prefer a same-directory type / interface (same package).
-	for _, c := range candidates {
-		if (c.Kind == graph.KindType || c.Kind == graph.KindInterface) &&
-			filepath.Dir(c.FilePath) == callerDir {
-			e.To = c.ID
-			stats.Resolved++
-			return
-		}
-	}
-	// Otherwise any same-repo type / interface.
-	for _, c := range candidates {
-		if c.Kind == graph.KindType || c.Kind == graph.KindInterface {
-			e.To = c.ID
-			stats.Resolved++
-			return
-		}
+	// Land the edge on the canonical type/interface definition. The
+	// ranker prefers a real, exported, top-level, non-test definition
+	// over same-named rivals (external stubs, test/mock defs, private or
+	// nested member types), with same-package proximity folded in only as
+	// a tiebreak — so a same-directory test/stub no longer steals the
+	// edge from a cross-directory canonical def (the bug that made
+	// widely-imported and builder-pattern types look unused).
+	if best := bestTypeCandidate(candidates, callerDir); best != nil {
+		e.To = best.ID
+		stats.Resolved++
+		return
 	}
 	stats.Unresolved++
 }
@@ -2145,6 +2133,173 @@ func nodeReceiverType(n *graph.Node) string {
 		return rt
 	}
 	return ""
+}
+
+// resolverTestPathRe-equivalent: a path-shaped test detector that the
+// candidate ranker uses to demote definitions that live in test sources.
+// It covers the file-suffix conventions (Go `_test.`, JS/TS `.test.` /
+// `.spec.`, Python `test_` prefix) and the directory conventions that the
+// JVM ecosystems use heavily and that a base-name check alone would miss
+// (`src/test/`, `src/jvmTest/`, `src/androidTest/`, `__tests__/`, …).
+// Kept resolver-local so the resolver does not import internal/analysis
+// (which depends on graph + resolver and would form an import cycle).
+func isTestSourcePath(path string) bool {
+	if path == "" {
+		return false
+	}
+	lower := strings.ToLower(path)
+	base := strings.ToLower(filepath.Base(path))
+	switch {
+	case strings.Contains(base, "_test."),
+		strings.Contains(base, ".test."),
+		strings.Contains(base, ".spec."),
+		strings.HasPrefix(base, "test_"):
+		return true
+	}
+	// Directory conventions. The slashes are normalised to "/" already on
+	// the relative paths the indexer stores; guard the leading-segment
+	// case too so a top-level "test/" or "tests/" dir is caught.
+	for _, seg := range []string{
+		"/test/", "/tests/", "/__tests__/", "/testing/",
+		"/jvmtest/", "/androidtest/", "/commontest/", "/androidhosttest/",
+		"/src/test/", "/test-utils/",
+	} {
+		if strings.Contains(lower, seg) {
+			return true
+		}
+	}
+	if strings.HasPrefix(lower, "test/") || strings.HasPrefix(lower, "tests/") {
+		return true
+	}
+	return false
+}
+
+// nodeIsExportedType reports whether a type/interface candidate is part
+// of the module's public surface. Two signals, in order: an explicit
+// `Meta["visibility"]` stamped by the extractor (Kotlin/TS/Swift/Java/…
+// emit "public" | "private" | "internal" | "protected"), and the
+// Go/Rust capitalisation convention as a fallback for languages that do
+// not stamp visibility. Unknown → treated as exported, so a candidate
+// that simply lacks the metadata is never demoted below an explicitly
+// private one.
+func nodeIsExportedType(n *graph.Node) bool {
+	if n.Meta != nil {
+		if vis, ok := n.Meta["visibility"].(string); ok && vis != "" {
+			switch strings.ToLower(vis) {
+			case "private", "internal", "fileprivate":
+				return false
+			default:
+				return true
+			}
+		}
+	}
+	// Capitalisation fallback (Go exported, Rust `pub` types are PascalCase
+	// by convention but not enforced — capitalisation is a weak signal,
+	// only used to break ties when no visibility metadata exists).
+	if n.Name == "" {
+		return true
+	}
+	r := rune(n.Name[0])
+	return r < 'a' || r > 'z'
+}
+
+// nodeIsNestedType reports whether a type candidate is a member /
+// nested type rather than a top-level definition — e.g. the inner
+// `Foo.Builder` rather than the top-level `Foo`. Detected from the
+// dotted qualified name (`Foo.Builder`) the extractor emits for nested
+// types in languages that keep the enclosing-type prefix. Languages
+// that flatten nested names to the bare leaf (so `Foo.Builder` is just
+// `Builder`) carry no nesting signal here — those candidates tie and
+// fall through to the deterministic id-order tiebreak.
+func nodeIsNestedType(n *graph.Node) bool {
+	return strings.Contains(n.Name, ".")
+}
+
+// typeCandidateRank scores a type/interface candidate for an
+// `unresolved::Name` type-position / reference / instantiate edge so
+// the resolver lands the edge on the *canonical* definition — the same
+// node search_symbols returns — rather than whichever same-named rival
+// (an external/stub node, a test-file or mock definition, a private /
+// nested member type) happens to sort first. Higher rank wins. The
+// fields are weighted most-significant-first; same-package proximity is
+// folded in by the caller as a final tiebreak so a genuinely local type
+// still wins among otherwise-equal candidates without letting a
+// same-directory test/stub beat a cross-directory canonical def.
+func typeCandidateRank(n *graph.Node) int {
+	rank := 0
+	// (1) A real, in-repo definition beats a synthetic stub / external
+	// placeholder by the widest margin.
+	if !graph.IsStub(n.ID) && !nodeIsSyntheticOrExternal(n) {
+		rank += 1000
+	}
+	// (2) A non-test definition beats a test/mock definition.
+	if !isTestSourcePath(n.FilePath) {
+		rank += 100
+	}
+	// (3) A top-level type beats a nested / member type.
+	if !nodeIsNestedType(n) {
+		rank += 10
+	}
+	// (4) An exported / public type beats a private / internal one.
+	if nodeIsExportedType(n) {
+		rank += 1
+	}
+	return rank
+}
+
+// nodeIsSyntheticOrExternal reports whether a node is a synthetic
+// placeholder (external-call terminal, import alias, re-export shell)
+// rather than a real source definition. These carry explicit Meta flags
+// stamped by the synthesis passes.
+func nodeIsSyntheticOrExternal(n *graph.Node) bool {
+	if n.Meta == nil {
+		return false
+	}
+	for _, k := range []string{"external", "external_call", "synthetic", "is_stub", "reexport"} {
+		if b, ok := n.Meta[k].(bool); ok && b {
+			return true
+		}
+	}
+	return false
+}
+
+// bestTypeCandidate picks the canonical type/interface definition from a
+// candidate slice for a type-position / reference / instantiate edge.
+// Candidates are ranked by typeCandidateRank (real-def > non-test >
+// top-level > exported); ties are broken by same-package proximity to
+// the caller's directory, then by lexicographically-smallest id for a
+// stable, deterministic result across runs and backends. Returns nil
+// when no KindType / KindInterface candidate exists.
+func bestTypeCandidate(candidates []*graph.Node, callerDir string) *graph.Node {
+	var best *graph.Node
+	bestRank := -1
+	bestSameDir := false
+	for _, c := range candidates {
+		if c.Kind != graph.KindType && c.Kind != graph.KindInterface {
+			continue
+		}
+		rank := typeCandidateRank(c)
+		sameDir := filepath.Dir(c.FilePath) == callerDir
+		if best == nil || candidateBeats(rank, sameDir, c.ID, bestRank, bestSameDir, best.ID) {
+			best, bestRank, bestSameDir = c, rank, sameDir
+		}
+	}
+	return best
+}
+
+// candidateBeats reports whether a candidate (rank/sameDir/id) should
+// replace the current best, applying the tiebreak order: higher rank,
+// then same-package proximity, then lexicographically-smallest id (for a
+// stable, deterministic result independent of candidate-iteration order
+// across in-memory and disk backends).
+func candidateBeats(rank int, sameDir bool, id string, bestRank int, bestSameDir bool, bestID string) bool {
+	if rank != bestRank {
+		return rank > bestRank
+	}
+	if sameDir != bestSameDir {
+		return sameDir
+	}
+	return id < bestID
 }
 
 // memberMethodInfosByType returns the storage layer's per-type member


### PR DESCRIPTION
## Summary

Fixes resolver candidate selection so type-use / reference / instantiation edges resolve to the **canonical definition** of a type — the same node `search_symbols` returns — instead of an arbitrary same-named rival (external/synthetic stub, re-export shell, test-file class, private variant, or a nested `Type.Builder` member). Previously the resolver picked first-match-after-same-directory, so when a name had multiple same-named nodes the edges piled onto whichever sorted first, leaving the real definition with `likely_unused` (0 incoming usage edges) for widely-imported and builder-pattern types.

## Fix
Language-agnostic ranker (`bestTypeCandidate`): real def (not stub/synthetic/external) > non-test file > top-level (not nested `Foo.Builder`) > exported, ties broken by same-package proximity (preserving the old same-dir behavior for equal-rank candidates) then deterministic id. Routed both `resolveTypeOrFunc` and `resolveTypeRef` through it. No per-language special-casing.

## Verification
- Hermetic regression tests: `PrefersRealDefOverExternalStub`, `PrefersNonTestOverTestDef`, `PrefersExportedOverPrivate`, `NestedBuilderDoesNotStealParentEdges`.
- Full `./internal/resolver/...`, `./internal/parser/languages/...`, `./internal/indexer/...` suites green (`-race`); gofmt / vet / golangci clean.
- Confirmed the multi-rival `Builder` case now lands deterministically on a real exported non-test Builder; in-process resolution of the existing wins (DataRequest/HTTPHeaders/RealCall/JoinHandle/QuerySet) unchanged.

## Not yet verified — needs a daemon benchmark re-run
The headline hard-0 types (`OkHttpClient`, `ExcalidrawElement`) do **not** reproduce in a bare in-process run (single canonical node, no rival) — the rival same-named nodes are created by the daemon's synthesis passes (external-call / re-export / source-set). So this fix's effect on those specific types should be confirmed by re-running the benchmark on a daemon build.

## Known separate mechanism (not addressed here)
`internal/graph/extraction_gap.go::usageEdgeKinds` (the "used" classifier behind `find_usages`' `likely_unused`) excludes `EdgeTypedAs`/`EdgeReturns`. A type used only in annotation/return position (e.g. a union type rarely instantiated) reads as `likely_unused` even when fully resolved — a complementary fix tracked separately.
