### PR TITLE
[codex] fix pyright resolver workspace folders

### DIFF
--- a/internal/semantic/lsp/lsp_test.go
+++ b/internal/semantic/lsp/lsp_test.go
@@ -78,9 +78,10 @@ func TestLSP_NewClient_FailsForBadCommand(t *testing.T) {
 }
 
 func TestBuildWorkspaceFolders(t *testing.T) {
-	// No additional roots → nil, so rootUri-only servers are unaffected.
-	require.Nil(t, buildWorkspaceFolders("/repo", nil))
-	require.Nil(t, buildWorkspaceFolders("/repo", []string{}))
+	// Always include the primary root. Pyright relies on this to build
+	// workspace context for textDocument/definition even when rootUri is set.
+	require.Equal(t, []WorkspaceFolder{{URI: "file:///repo", Name: "repo"}}, buildWorkspaceFolders("/repo", nil))
+	require.Equal(t, []WorkspaceFolder{{URI: "file:///repo", Name: "repo"}}, buildWorkspaceFolders("/repo", []string{}))
 
 	folders := buildWorkspaceFolders("/repo/app", []string{"/repo/shared", "/repo/types"})
 	require.Len(t, folders, 3) // primary + 2 additional

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -1936,13 +1936,8 @@ func pathToURI(path string) string {
 }
 
 // buildWorkspaceFolders returns the LSP workspaceFolders list — the
-// primary root followed by any additional roots. It returns nil when
-// there are no additional roots so rootUri-only servers are unaffected
-// (the field is omitempty).
+// primary root followed by any additional roots.
 func buildWorkspaceFolders(primary string, additional []string) []WorkspaceFolder {
-	if len(additional) == 0 {
-		return nil
-	}
 	folders := make([]WorkspaceFolder, 0, len(additional)+1)
 	folders = append(folders, WorkspaceFolder{
 		URI:  pathToURI(primary),

--- a/internal/semantic/lsp/resolver_helper_integration_test.go
+++ b/internal/semantic/lsp/resolver_helper_integration_test.go
@@ -82,6 +82,53 @@ export function callIt(): number {
 	assert.Equal(t, 2, defLine)
 }
 
+func TestResolverHelper_RealPyright_DefinitionAcrossFiles(t *testing.T) {
+	if _, err := exec.LookPath("pyright-langserver"); err != nil {
+		t.Skip("pyright-langserver not on PATH")
+	}
+
+	workspace := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(workspace, "src", "pkg"), 0755))
+	mustWrite(t, filepath.Join(workspace, "pyrightconfig.json"), `{"include":["src"],"extraPaths":["src"]}`)
+	mustWrite(t, filepath.Join(workspace, "src", "pkg", "__init__.py"), ``)
+	mustWrite(t, filepath.Join(workspace, "src", "pkg", "dispatch.py"), `def dispatch_attempt() -> str:
+    return "ok"
+`)
+	mustWrite(t, filepath.Join(workspace, "src", "pkg", "scheduler.py"), `from pkg.dispatch import dispatch_attempt
+
+
+def scheduler_tick() -> str:
+    return dispatch_attempt()
+`)
+
+	spec := SpecByName("pyright")
+	require.NotNil(t, spec, "pyright spec must be in registry")
+
+	provider := NewProviderFromSpec(spec, zap.NewNop())
+	helper := NewResolverHelper(provider, workspace, 10*time.Second, zap.NewNop())
+	defer helper.Close()
+
+	var (
+		defPath string
+		defLine int
+		ok      bool
+	)
+	deadline := time.Now().Add(8 * time.Second)
+	for {
+		defPath, defLine, ok = helper.Definition("src/pkg/scheduler.py", 5, "dispatch_attempt")
+		if ok && defPath == "src/pkg/dispatch.py" {
+			break
+		}
+		if time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	require.True(t, ok, "pyright should eventually resolve dispatch_attempt across files")
+	assert.Equal(t, "src/pkg/dispatch.py", defPath)
+	assert.Equal(t, 1, defLine)
+}
+
 // TestResolverHelper_RealTsserver_NoMatchReturnsFalse — when the
 // identifier on the requested line doesn't resolve to anything
 // (typo, missing import), the helper returns ok=false rather than


### PR DESCRIPTION
## Summary

Follow-up to #141. That PR correctly wired resolve-time Pyright helpers for Python repos, but an end-to-end smoke test showed the user-facing graph still missed a simple imported Python call:

```python
from pkg.dispatch import dispatch_attempt

def scheduler_tick() -> str:
    return dispatch_attempt()
```

On current `main`, `get_callers(pyright-smoke/src/pkg/dispatch.py::dispatch_attempt)` still returned `likely_unused`, and the exported graph pointed `scheduler_tick` at `external-call::dep::pkg.dispatch.dispatch_attempt` instead of the real Python function node.

## Root Cause

Pyright itself resolved the fixture correctly when initialized with a primary `workspaceFolders` entry. Gortex's provider initialized the server with `rootUri`, but `buildWorkspaceFolders` returned `nil` when there were no extra workspace folders. In that shape, Pyright returned `null` for `textDocument/definition`, so the resolver fell through to the external-call placeholder path.

This patch always includes the primary workspace root in `workspaceFolders`, then appends any additional roots as before.

## Changes

- Always include the primary root in LSP `workspaceFolders`.
- Update the workspace folder unit test to lock in that behavior.
- Add a real Pyright resolver-helper regression test for cross-file `from ... import ...` resolution.

## Validation

Local checks run:

```bash
env PATH=/private/tmp/gortex-pyright-smoke-deps/node_modules/.bin:$PATH go test ./internal/semantic/lsp ./internal/serverstack
env PATH=/private/tmp/gortex-pyright-smoke-deps/node_modules/.bin:$PATH go test ./...
```

End-to-end daemon smoke test with a patched binary:

- tracked a two-repo fixture to exercise multi-repo prefixing
- started an isolated Gortex daemon with Pyright on `PATH`
- `query callers pyright-smoke/src/pkg/dispatch.py::dispatch_attempt` returned `scheduler_tick -> dispatch_attempt`
- `call get_dependencies --arg id=pyright-smoke/src/pkg/scheduler.py::scheduler_tick` returned the same edge with `origin: lsp_resolved`

No temporary smoke-test daemons were left running.
