### PR TITLE
Make deferred MCP tools reachable by name from the CLI

### DIFF
--- a/cmd/gortex/call.go
+++ b/cmd/gortex/call.go
@@ -49,8 +49,9 @@ calling the daemon (works with no daemon running). Use --format to pick the
 wire format the tool renders (json|gcx|toon|text).
 
 Requires a running daemon that tracks the repo (except for --dry).`,
-	Args: cobra.ExactArgs(1),
-	RunE: runCall,
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true, // a tool/daemon error should read cleanly, not dump usage
+	RunE:         runCall,
 }
 
 func init() {

--- a/cmd/gortex/daemon_mcp.go
+++ b/cmd/gortex/daemon_mcp.go
@@ -119,6 +119,18 @@ func (d *mcpDispatcher) Dispatch(ctx context.Context, sess *daemon.Session, fram
 		}
 	}
 
+	// Promote-on-demand: a tools/call naming a deferred tool (one held out of
+	// the eager tools/list under the defer-mode surface) would otherwise return
+	// "tool not found" — the underlying MCP server only knows live tools until
+	// tools_search promotes them. A direct call by name (the CLI's `gortex call`
+	// and the curated `gortex` verbs reach the daemon this way) promotes it
+	// first, so a known tool name is reachable without a discovery round-trip.
+	// tools_search stays the discovery path; a hide-mode tool is never deferred,
+	// so this never bypasses the hide gate.
+	if name := peekFrameToolName(frame); name != "" {
+		d.srv.EnsureToolPromoted(name)
+	}
+
 	// HandleMessage returns either a JSONRPCResponse, a JSONRPCError, or
 	// nil (the message was a notification). It never panics on malformed
 	// JSON — it returns a JSON-RPC parse-error frame instead.
@@ -150,6 +162,22 @@ func peekFrameMethod(frame []byte) string {
 	}
 	_ = json.Unmarshal(frame, &peek)
 	return peek.Method
+}
+
+// peekFrameToolName returns the tool name of a tools/call frame, or "" when the
+// frame is not a tools/call or can't be parsed. Used to promote a deferred tool
+// on demand before local dispatch (see Dispatch).
+func peekFrameToolName(frame []byte) string {
+	var peek struct {
+		Method string `json:"method"`
+		Params struct {
+			Name string `json:"name"`
+		} `json:"params"`
+	}
+	if json.Unmarshal(frame, &peek) != nil || peek.Method != "tools/call" {
+		return ""
+	}
+	return peek.Params.Name
 }
 
 // rewriteUntrackedResponse swaps a successful initialize / tools/list response

--- a/cmd/gortex/daemon_mcp_promote_test.go
+++ b/cmd/gortex/daemon_mcp_promote_test.go
@@ -1,0 +1,29 @@
+package main
+
+import "testing"
+
+// TestPeekFrameToolName covers the helper that drives promote-on-demand: it
+// must return the tool name for a tools/call frame and "" for anything else,
+// so the dispatcher only promotes on a genuine tool call.
+func TestPeekFrameToolName(t *testing.T) {
+	cases := []struct {
+		name  string
+		frame string
+		want  string
+	}{
+		{"tools/call", `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"flow_between","arguments":{"source_id":"a"}}}`, "flow_between"},
+		{"tools/call no args", `{"method":"tools/call","params":{"name":"feedback"}}`, "feedback"},
+		{"tools/list is not a call", `{"method":"tools/list","params":{}}`, ""},
+		{"initialize is not a call", `{"method":"initialize","params":{"name":"x"}}`, ""},
+		{"missing name", `{"method":"tools/call","params":{}}`, ""},
+		{"malformed json", `{not json`, ""},
+		{"empty", ``, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := peekFrameToolName([]byte(c.frame)); got != c.want {
+				t.Fatalf("peekFrameToolName(%s) = %q, want %q", c.frame, got, c.want)
+			}
+		})
+	}
+}

--- a/cmd/gortex/tools_cmd.go
+++ b/cmd/gortex/tools_cmd.go
@@ -29,6 +29,7 @@ var toolsCmd = &cobra.Command{
 its category / read-write classification / presets, full-text search the
 catalog, or print one tool's full parameter schema. Requires a running daemon
 that tracks the repo.`,
+	SilenceUsage: true, // subcommands' daemon errors should read cleanly, not dump usage
 }
 
 var toolsListCmd = &cobra.Command{

--- a/internal/mcp/promote_on_demand_test.go
+++ b/internal/mcp/promote_on_demand_test.go
@@ -1,0 +1,59 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestEnsureToolPromoted_MakesDeferredToolCallable is the regression test for
+// the deferred-tool-unreachable bug: under the defer-mode surface a tool held
+// out of the eager tools/list lives in the lazy registry and is unknown to the
+// underlying MCP server, so a direct tools/call (the path the CLI's
+// `gortex call` and curated verbs take) returned "tool not found".
+// EnsureToolPromoted must promote it on demand so a known name is reachable
+// without a tools_search round-trip.
+func TestEnsureToolPromoted_MakesDeferredToolCallable(t *testing.T) {
+	t.Setenv("GORTEX_LAZY_TOOLS", "1")
+	srv, _ := setupTestServer(t)
+	require.NotNil(t, srv.lazy)
+	require.True(t, srv.lazy.Enabled())
+
+	// Pick a tool the lazy split defers (safe_delete_symbol is asserted
+	// deferred elsewhere; assert the precondition here too so this test
+	// fails loudly if the hot set ever absorbs it).
+	const tool = "safe_delete_symbol"
+	require.True(t, srv.lazy.IsDeferred(tool), "precondition: %s must be deferred", tool)
+	require.NotContains(t, srv.mcpServer.ListTools(), tool, "deferred tool must be absent from the live list before promotion")
+
+	// Promote on demand — the fix.
+	require.True(t, srv.EnsureToolPromoted(tool), "EnsureToolPromoted must report it promoted a deferred tool")
+
+	// Now it is a live, callable tool: appearing in the live tools/list is the
+	// proof that a direct tools/call by name will resolve. (IsDeferred is a
+	// static classification — "should this tool be lazy" — so it stays true;
+	// promotion is tracked separately and reflected by the live registry.)
+	require.Contains(t, srv.mcpServer.ListTools(), tool, "promoted tool must appear in the live tools/list")
+
+	// Idempotent: a second promote is a no-op — Promote returns only the names
+	// that newly transitioned, so an already-promoted tool yields false.
+	require.False(t, srv.EnsureToolPromoted(tool), "promoting an already-promoted tool must be a no-op")
+}
+
+// TestEnsureToolPromoted_NoopCases covers the guards: a live tool, an unknown
+// tool, an empty name, and a nil/lazy-less server are all no-ops (false).
+func TestEnsureToolPromoted_NoopCases(t *testing.T) {
+	t.Setenv("GORTEX_LAZY_TOOLS", "1")
+	srv, _ := setupTestServer(t)
+
+	// A hot/eager tool is live, never deferred.
+	require.False(t, srv.EnsureToolPromoted("graph_stats"), "a live tool is not deferred → no-op")
+	// An unknown tool name.
+	require.False(t, srv.EnsureToolPromoted("definitely_not_a_real_tool"))
+	// Empty name.
+	require.False(t, srv.EnsureToolPromoted(""))
+	// nil receiver / no lazy registry.
+	var nilSrv *Server
+	require.False(t, nilSrv.EnsureToolPromoted("safe_delete_symbol"))
+	require.False(t, (&Server{}).EnsureToolPromoted("safe_delete_symbol"))
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -2219,6 +2219,28 @@ func (s *Server) attachLazyRegistry() {
 	}
 }
 
+// EnsureToolPromoted makes a deferred tool callable by name. Under the
+// defer-mode tool surface (the `core` default) a tool that is held out of the
+// eager tools/list lives in the lazy registry and is unknown to the underlying
+// MCP server until tools_search promotes it — so a direct tools/call for it
+// returns "tool not found". A caller that dispatches a tools/call by name —
+// notably the CLI's `gortex call` and the curated `gortex` verbs, which reach
+// the daemon over the same socket — calls this first so the "reachable by name
+// regardless of tools/list visibility" contract actually holds. tools_search
+// stays the discovery path; this only makes an already-known name reachable
+// without a discovery round-trip. It is a no-op (returns false) when there is
+// no lazy registry or the tool is live, absent, or already promoted; a hidden
+// (hide-mode) tool is never deferred, so this never bypasses the hide gate.
+func (s *Server) EnsureToolPromoted(name string) bool {
+	if s == nil || s.lazy == nil || name == "" {
+		return false
+	}
+	if !s.lazy.IsDeferred(name) {
+		return false
+	}
+	return len(s.lazy.Promote(name)) > 0
+}
+
 // SetContractRegistry sets an explicit contract registry override for the MCP
 // server. Used by single-indexer callers and tests. In multi-repo mode the
 // server prefers a freshly-merged registry from MultiIndexer (see


### PR DESCRIPTION
Under the default core/defer tool surface, tools held out of the eager tools/list live in the lazy registry and are unknown to the underlying MCP server until tools_search promotes them — so a direct tools/call by name returned 'tool not found'. The CLI's gortex call and the curated verbs reach the daemon with exactly such direct calls, which left every deferred tool (get_edit_plan, query_memories/notes, distill_session, flow_between, taint_paths, find_clones, feedback, change_contract, safe_delete_symbol, and the rest of the deferred surface) unreachable from the shell. The daemon dispatcher now promotes a deferred tool on demand before dispatching a tools/call for it, so a known tool name is reachable without a discovery round-trip — the contract the CLI relied on — for every client, while tools_search stays the discovery path and the hide-mode gate is untouched (hidden tools are never deferred). Also set SilenceUsage on gortex call and gortex tools so a tool/daemon error reads cleanly instead of dumping cobra usage.