### PR TITLE
test(hooks): keep the unrelated-repo decoy outside cwd in workspace-root test

### DIFF
--- a/internal/hooks/sessionstart_test.go
+++ b/internal/hooks/sessionstart_test.go
@@ -95,7 +95,7 @@ func TestRunSessionStart_DaemonReady_CwdContainsRepos(t *testing.T) {
 			TrackedRepos: []daemon.TrackedRepoStatus{
 				{Name: "gortex", Path: "/tmp/gortex"},
 				{Name: "cloud_web", Path: "/tmp/cloud_web"},
-				{Name: "project1", Path: "/tmp/project1"},
+				{Name: "project1", Path: "/opt/project1"}, // unrelated: NOT under cwd /tmp
 			},
 		}, nil
 	})


### PR DESCRIPTION
`TestRunSessionStart_DaemonReady_CwdContainsRepos` is hermetic (mocked daemon status, cwd from the hook JSON, `classifyCwd` is pure string comparison — no filesystem), so it fails deterministically on CI too. Its `project1` decoy is meant to be an *unrelated* repo excluded from a `cwd=/tmp` workspace-root briefing, but the fixture path was `/tmp/project1` (under the cwd), so it was correctly counted (3 repos) and the `2 repos / no project1` assertions failed. Move the decoy to `/opt/project1`. Test-only.