### PR TITLE
Speed up schema-parity audit scan

### DIFF
--- a/internal/graph/parity_audit_test.go
+++ b/internal/graph/parity_audit_test.go
@@ -183,14 +183,24 @@ func scanKindUsage(repoRoot string, declared []kindDecl) (map[string]int, error)
 		declaringFiles[d.Name] = d.Path
 	}
 
-	patterns := make(map[string]*regexp.Regexp, len(declared))
+	// One combined alternation rather than one regex per kind. Matching
+	// every .go file in the repo against ~100 separate \bName\b patterns
+	// is O(files × kinds) and grows past the CI timeout as both the tree
+	// and the schema grow; a single \b(?:Name1|Name2|…)\b scanned once per
+	// file is O(files). The \b anchors keep the identifiers as distinct as
+	// before — `EdgeReads` still does NOT match inside `EdgeReadsCol`,
+	// because the inner \b fails between two word characters and the
+	// engine falls through to the longer alternative.
+	names := make([]string, 0, len(declared))
+	seen := make(map[string]bool, len(declared))
 	for _, d := range declared {
-		// \b doesn't treat _ as a word boundary in Go's regexp, which
-		// is exactly what we want — `EdgeReads` must NOT match
-		// `EdgeReadsCol`. The regex is anchored by word boundary on
-		// both sides.
-		patterns[d.Name] = regexp.MustCompile(`\b` + regexp.QuoteMeta(d.Name) + `\b`)
+		if seen[d.Name] {
+			continue
+		}
+		seen[d.Name] = true
+		names = append(names, regexp.QuoteMeta(d.Name))
 	}
+	re := regexp.MustCompile(`\b(?:` + strings.Join(names, "|") + `)\b`)
 
 	usage := make(map[string]int, len(declared))
 
@@ -230,13 +240,18 @@ func scanKindUsage(repoRoot string, declared []kindDecl) (map[string]int, error)
 			return nil // unreadable files don't fail the audit
 		}
 		text := stripGoComments(string(data))
-		for name, re := range patterns {
+		found := make(map[string]bool)
+		for _, m := range re.FindAllString(text, -1) {
+			found[m] = true
+		}
+		for name := range found {
+			// A constant referenced only inside its own declaring file
+			// is not a real consumer — exclude it exactly as the
+			// per-pattern scan did.
 			if path == declaringFiles[name] {
 				continue
 			}
-			if re.MatchString(text) {
-				usage[name]++
-			}
+			usage[name]++
 		}
 		return nil
 	})


### PR DESCRIPTION
## Problem

`TestSchemaParityAudit` (`internal/graph/parity_audit_test.go`) was timing out on CI after 10 minutes:

```
panic: test timed out after 10m0s
    running tests:
        TestSchemaParityAudit (9m58s)
...
github.com/zzet/gortex/internal/graph.scanKindUsage(...)
```

The test wasn't deadlocked — it was CPU-bound. `scanKindUsage` walks every `.go` file in the repo and, for each file, ran **one separate `\bName\b` regex per declared `NodeKind`/`EdgeKind`**. With ~108 kinds, the scan was **O(files × kinds)** regex passes, which crossed the timeout as both the tree and the schema grew. (The `tryBacktrack` frame in the trace is just Go's normal small-input regex engine being invoked 100k+ times, not catastrophic backtracking.)

## Fix

Replace the per-kind passes with a **single combined alternation** — `\b(?:Name1|Name2|…)\b` — scanned once per file (**O(files)**). Per file, the matches are deduped into a set and counted, with the declaring-file exclusion unchanged.

The `\b` anchors preserve the original distinctness guarantee: for `EdgeReadsCol`, the `EdgeReads` alternative matches but the inner `\b` fails between two word characters, so the engine falls through to the longer alternative. The audit's verdict is identical to before.

## Verification

- `go test ./internal/graph/ -run TestSchemaParityAudit` → **passes in ~1.05s** (was a 10-min timeout).
- `go vet ./internal/graph/` → clean.

Change is confined to the test helper; no production code is touched.