### PR TITLE
Feat/daemon ready on resolve

### DIFF
--- a/cmd/gortex/daemon.go
+++ b/cmd/gortex/daemon.go
@@ -424,6 +424,7 @@ func runDaemonStart(cmd *cobra.Command, _ []string) error {
 			out := map[string]any{
 				"uptime_seconds": int64(time.Since(daemonStart).Seconds()),
 				"ready":          controllerCapture.IsReady(),
+				"enriched":       controllerCapture.IsEnriched(),
 				"warmup_seconds": int64(0),
 			}
 			if st, statusErr := controllerCapture.Status(context.Background()); statusErr == nil {
@@ -492,7 +493,11 @@ func runDaemonStart(cmd *cobra.Command, _ []string) error {
 	// on disk) so the gob+gzip snapshot is dead weight in that mode.
 	stopSnapshotter := func() {}
 	if mg, ok := state.graph.(*graph.Graph); ok {
-		stopSnapshotter = startPeriodicSnapshots(mg, state.multiIndexer, version, 10*time.Minute, controller.IsReady, logger)
+		// Gate on IsEnriched, not IsReady: ready now flips once references
+		// resolve (well before enrichment finishes), but a snapshot tick mid-
+		// enrichment still steals shard-lock budget from the enrichment passes
+		// writing those shards — exactly the stall this gate prevents.
+		stopSnapshotter = startPeriodicSnapshots(mg, state.multiIndexer, version, 10*time.Minute, controller.IsEnriched, logger)
 	}
 	defer stopSnapshotter()
 
@@ -523,7 +528,21 @@ func runDaemonStart(cmd *cobra.Command, _ []string) error {
 	go func() {
 		start := time.Now()
 		logger.Info("daemon: warmup starting")
-		mw := warmupDaemonState(state, logger)
+		// markReady fires once references are resolved and the graph is
+		// queryable — ahead of the slow enrichment pass — so clients can
+		// start issuing find_usages / get_callers immediately. Enrichment
+		// continues in this goroutine afterward and finishes at MarkEnriched.
+		markReady := func() {
+			elapsed := time.Since(start)
+			controller.MarkReady(elapsed)
+			logger.Info("daemon: graph queryable", zap.Duration("resolve", elapsed))
+			publishReadinessPhase(state, "ready", true, map[string]any{
+				"queryable":      true,
+				"warmup_seconds": int64(elapsed.Seconds()),
+				"warmup_ms":      elapsed.Milliseconds(),
+			})
+		}
+		mw := warmupDaemonState(state, logger, markReady)
 		controller.AttachWatcher(mw)
 		// Wire the daemon's MultiWatcher into the per-server history
 		// surface so `get_recent_changes` and `get_symbol_history` see
@@ -567,9 +586,10 @@ func runDaemonStart(cmd *cobra.Command, _ []string) error {
 			state.mcpServer.PrewarmCoChange()
 		}
 		elapsed := time.Since(start)
-		controller.MarkReady(elapsed)
-		logger.Info("daemon: ready", zap.Duration("warmup", elapsed))
-		publishReadinessPhase(state, "ready", true, map[string]any{
+		controller.MarkEnriched(elapsed)
+		logger.Info("daemon: enrichment complete", zap.Duration("warmup", elapsed))
+		publishReadinessPhase(state, "enrichment_complete", true, map[string]any{
+			"enriched":       true,
 			"warmup_seconds": int64(elapsed.Seconds()),
 			"warmup_ms":      elapsed.Milliseconds(),
 		})
@@ -1092,13 +1112,20 @@ func renderDaemonHeader(w io.Writer, st daemon.StatusResponse) {
 	t.AppendRow(table.Row{"pid", st.PID})
 	t.AppendRow(table.Row{"socket", st.SocketPath})
 	t.AppendRow(table.Row{"uptime", formatDuration(time.Duration(st.UptimeSeconds) * time.Second)})
-	if st.Ready {
+	switch {
+	case st.Ready && st.EnrichmentComplete:
 		t.AppendRow(table.Row{
 			"state",
-			fmt.Sprintf("ready (warmup %s)", formatDuration(time.Duration(st.WarmupSeconds)*time.Second)),
+			fmt.Sprintf("ready (warmup %s)", formatDuration(time.Duration(st.EnrichSeconds)*time.Second)),
 		})
-	} else {
-		t.AppendRow(table.Row{"state", "warming up (socket reachable, background re-index in progress)"})
+	case st.Ready:
+		t.AppendRow(table.Row{
+			"state",
+			fmt.Sprintf("ready — queryable (resolve %s); enrichment in progress",
+				formatDuration(time.Duration(st.WarmupSeconds)*time.Second)),
+		})
+	default:
+		t.AppendRow(table.Row{"state", "warming up (socket reachable, resolving references)"})
 	}
 	t.AppendRow(table.Row{"sessions", st.Sessions})
 	if st.MemoryBytes > 0 {

--- a/cmd/gortex/daemon_controller.go
+++ b/cmd/gortex/daemon_controller.go
@@ -57,13 +57,21 @@ type realController struct {
 	// main to flush savings, close the snapshot store, etc.
 	onShutdown func() error
 
-	// ready flips to true once warmup (per-repo re-index + watcher
-	// startup) finishes. The socket accepts connections before this —
-	// queries against not-yet-indexed repos return partial results
-	// until ready is true. warmupSeconds records how long warmup took
-	// so status can surface it.
+	// ready flips to true once references are resolved and the graph is
+	// queryable — find_usages / get_callers return complete results from
+	// this point. The socket accepts connections before this; queries
+	// against not-yet-resolved repos return partial results until ready.
+	// warmupSeconds records how long the parse + resolve stage took.
+	//
+	// enriched flips to true once the slow semantic-enrichment pass and the
+	// graph-wide derivation passes finish in the background, after ready.
+	// Background timers that must not fight the enrichment pipeline for
+	// shard locks (the periodic snapshotter) gate on enriched, not ready.
+	// enrichSeconds records the full warmup duration.
 	ready         atomic.Bool
 	warmupSeconds atomic.Int64
+	enriched      atomic.Bool
+	enrichSeconds atomic.Int64
 }
 
 // Track indexes a new repository and persists it to the global config.
@@ -773,13 +781,15 @@ func (c *realController) Status(_ context.Context) (daemon.StatusResponse, error
 			NumGC:        mem.NumGC,
 			NumGoroutine: runtime.NumGoroutine(),
 		},
-		PProfAddr:         daemonPProfAddr(),
-		Ready:             c.ready.Load(),
-		WarmupSeconds:     c.warmupSeconds.Load(),
-		Workspaces:        workspaces,
-		ConfiguredServers: c.collectConfiguredServers(),
-		LocalServerSlug:   c.localServerSlug(),
-		LSPRouter:         c.collectLSPRouterStatus(),
+		PProfAddr:          daemonPProfAddr(),
+		Ready:              c.ready.Load(),
+		WarmupSeconds:      c.warmupSeconds.Load(),
+		EnrichmentComplete: c.enriched.Load(),
+		EnrichSeconds:      c.enrichSeconds.Load(),
+		Workspaces:         workspaces,
+		ConfiguredServers:  c.collectConfiguredServers(),
+		LocalServerSlug:    c.localServerSlug(),
+		LSPRouter:          c.collectLSPRouterStatus(),
 	}, nil
 	// MCPSessions is populated by the daemon Server (it owns the
 	// SessionRegistry — the controller doesn't have a back-pointer).
@@ -912,18 +922,37 @@ func (c *realController) AttachWatcher(mw *indexer.MultiWatcher) {
 	c.multiWatcher = mw
 }
 
-// MarkReady flips the ready flag and records how long warmup took.
-// Safe to call concurrently with Status (atomic loads on the read side).
+// MarkReady flips the ready flag once references are resolved and the graph
+// is queryable, recording how long the parse + resolve stage took. Safe to
+// call concurrently with Status (atomic loads on the read side).
 func (c *realController) MarkReady(d time.Duration) {
 	c.warmupSeconds.Store(int64(d.Seconds()))
 	c.ready.Store(true)
 }
 
-// IsReady reports whether warmup has completed. Used by background
-// timers (snapshotter, janitor, savings flush, etc.) to skip work
-// that would fight the warmup pipeline for shard locks and GC budget.
+// IsReady reports whether the graph is resolved and queryable. The socket
+// accepts connections before this; callers waiting to issue queries should
+// wait for IsReady.
 func (c *realController) IsReady() bool {
 	return c.ready.Load()
+}
+
+// MarkEnriched flips the enrichment-complete flag once semantic enrichment
+// and the graph-wide derivation passes finish in the background, recording
+// the full warmup duration. It also sets ready, so the degenerate path where
+// MarkReady was skipped still reports a usable daemon.
+func (c *realController) MarkEnriched(d time.Duration) {
+	c.enrichSeconds.Store(int64(d.Seconds()))
+	c.enriched.Store(true)
+	c.ready.Store(true)
+}
+
+// IsEnriched reports whether the background enrichment + derivation passes
+// have finished. Background timers (the periodic snapshotter) gate on this
+// rather than IsReady so they don't fight the enrichment pipeline for shard
+// locks and GC budget.
+func (c *realController) IsEnriched() bool {
+	return c.enriched.Load()
 }
 
 // Shutdown gives the caller (the daemon main) a chance to flush any

--- a/cmd/gortex/daemon_state.go
+++ b/cmd/gortex/daemon_state.go
@@ -193,12 +193,14 @@ func buildDaemonState(logger *zap.Logger) (*daemonState, error) {
 	}, nil
 }
 
-// warmupDaemonState performs the per-repo TrackRepoCtx loop and brings
-// up the MultiWatcher. Split out from buildDaemonState so the daemon can
-// open its socket and accept connections before this work finishes —
-// re-extracting contracts across many repos can take tens of seconds
-// and there's no reason to make clients wait for it.
-func warmupDaemonState(state *daemonState, logger *zap.Logger) *indexer.MultiWatcher {
+// warmupDaemonState performs the per-repo parse loop, resolves references,
+// runs the background enrichment, and brings up the MultiWatcher. Split out
+// from buildDaemonState so the daemon can open its socket and accept
+// connections before this work finishes. markReady is invoked once references
+// are resolved and the graph is queryable — ahead of the slow enrichment pass
+// — so the daemon reports ready as soon as find_usages / get_callers return
+// complete results, not after enrichment finishes.
+func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func()) *indexer.MultiWatcher {
 	if state.multiIndexer == nil || state.configManager == nil {
 		return nil
 	}
@@ -424,18 +426,47 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger) *indexer.MultiWat
 		zap.Int("tracked_repos", len(repos)),
 		zap.Bool("global_passes", anyChanged))
 
-	// Drain deferred per-repo passes (ResolveAll / semantic enrich /
-	// contract extract+commit) serially across the indexers the parallel
-	// loop populated. Must run before RunGlobalResolve so cross-repo
-	// resolution sees fully-lifted per-repo placeholder edges.
+	// Resolve references ahead of the slow enrichment pass so find_usages /
+	// get_callers return complete results as soon as the daemon reports ready
+	// — independent of semantic enrichment. RunPreEnrichResolve materialises
+	// go.mod dep nodes, runs the same-repo master resolver, and runs the
+	// cross-repo resolver. On the warm-restart fast path nothing changed, so
+	// the persisted graph already carries resolved edges and we skip straight
+	// to marking ready.
 	if anyChanged {
 		phaseStart = time.Now()
-		publishReadinessPhase(state, "deferred_passes_all", false, nil)
+		publishReadinessPhase(state, "resolve", false, nil)
+		state.multiIndexer.RunPreEnrichResolve(ctx)
+		logger.Info("daemon: warmup phase done",
+			zap.String("phase", "resolve"),
+			zap.Duration("elapsed", time.Since(phaseStart)))
+		publishReadinessPhase(state, "resolve_done", false, map[string]any{
+			"elapsed_ms": time.Since(phaseStart).Milliseconds(),
+		})
+	}
+
+	// References are resolved (or unchanged and already resolved on the warm
+	// path): the graph is queryable. Flip ready before the multi-minute
+	// enrichment so clients can start issuing queries immediately. Everything
+	// below runs in the background after ready and finishes at MarkEnriched.
+	if markReady != nil {
+		markReady()
+	}
+
+	// Drain deferred per-repo passes (semantic enrich / contract
+	// extract+commit) serially across the indexers the parallel loop
+	// populated. These run after ready: enrichment is a precision upgrade on
+	// top of the already-queryable reference graph. RunDeferredPassesAll
+	// re-runs the master resolver at its tail to lift placeholder edges the
+	// enrichment + contract passes add.
+	if anyChanged {
+		phaseStart = time.Now()
+		publishReadinessPhase(state, "deferred_passes_all", true, nil)
 		state.multiIndexer.RunDeferredPassesAll(ctx)
 		logger.Info("daemon: warmup phase done",
 			zap.String("phase", "deferred_passes_all"),
 			zap.Duration("elapsed", time.Since(phaseStart)))
-		publishReadinessPhase(state, "deferred_passes_all_done", false, map[string]any{
+		publishReadinessPhase(state, "deferred_passes_all_done", true, map[string]any{
 			"elapsed_ms": time.Since(phaseStart).Milliseconds(),
 		})
 	}
@@ -513,12 +544,12 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger) *indexer.MultiWat
 	// changed too, so ReconcileContractEdges runs again.
 	if anyChanged {
 		phaseStart = time.Now()
-		publishReadinessPhase(state, "global_resolve", false, nil)
+		publishReadinessPhase(state, "global_resolve", true, nil)
 		state.multiIndexer.RunGlobalResolve()
 		logger.Info("daemon: warmup phase done",
 			zap.String("phase", "global_resolve"),
 			zap.Duration("elapsed", time.Since(phaseStart)))
-		publishReadinessPhase(state, "global_resolve_done", false, map[string]any{
+		publishReadinessPhase(state, "global_resolve_done", true, map[string]any{
 			"elapsed_ms": time.Since(phaseStart).Milliseconds(),
 		})
 	}
@@ -532,7 +563,7 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger) *indexer.MultiWat
 	// without re-running those passes — the persisted graph already has
 	// the derived edges.
 	phaseStart = time.Now()
-	publishReadinessPhase(state, "end_batch", false, nil)
+	publishReadinessPhase(state, "end_batch", true, nil)
 	if anyChanged {
 		state.multiIndexer.EndBatch()
 	} else {
@@ -541,7 +572,7 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger) *indexer.MultiWat
 	logger.Info("daemon: warmup phase done",
 		zap.String("phase", "end_batch"),
 		zap.Duration("elapsed", time.Since(phaseStart)))
-	publishReadinessPhase(state, "end_batch_done", false, map[string]any{
+	publishReadinessPhase(state, "end_batch_done", true, map[string]any{
 		"elapsed_ms": time.Since(phaseStart).Milliseconds(),
 	})
 
@@ -580,7 +611,7 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger) *indexer.MultiWat
 		return nil
 	}
 	logger.Info("daemon: watching", zap.Int("repos", len(watchCfgs)))
-	publishReadinessPhase(state, "watcher_started", false, map[string]any{
+	publishReadinessPhase(state, "watcher_started", true, map[string]any{
 		"watched_repos": len(watchCfgs),
 	})
 	return mw

--- a/internal/daemon/proto.go
+++ b/internal/daemon/proto.go
@@ -94,9 +94,9 @@ type ControlResponse struct {
 
 // Control operation kinds. One constant per kind so callers can't typo.
 const (
-	ControlTrack         = "track"
-	ControlUntrack       = "untrack"
-	ControlReload        = "reload"
+	ControlTrack   = "track"
+	ControlUntrack = "untrack"
+	ControlReload  = "reload"
 	// ControlProxy reloads servers.toml and rebuilds + atomically swaps
 	// the daemon's multi-server Router, then invalidates the roster
 	// cache — so `gortex proxy on/off/add/remove` apply to a running
@@ -167,11 +167,18 @@ type StatusResponse struct {
 	// string means pprof is not enabled on this daemon.
 	PProfAddr string `json:"pprof_addr,omitempty"`
 	// Ready is false while the daemon is still loading the snapshot and
-	// re-indexing tracked repos in the background. The socket is reachable
-	// even when Ready=false; queries against not-yet-indexed repos may
-	// return partial results until warmup completes.
+	// resolving references in the background. It flips true once references
+	// are resolved and the graph is queryable — which can be well before
+	// EnrichmentComplete. The socket is reachable even when Ready=false.
 	Ready         bool  `json:"ready"`
 	WarmupSeconds int64 `json:"warmup_seconds"`
+
+	// EnrichmentComplete is false while semantic enrichment and the
+	// graph-wide derivation passes are still running in the background.
+	// Ready can be true (references resolved and queryable) while this is
+	// still false. EnrichSeconds records the full warmup duration.
+	EnrichmentComplete bool  `json:"enrichment_complete"`
+	EnrichSeconds      int64 `json:"enrich_seconds,omitempty"`
 
 	// Workspaces aggregates TrackedRepos by workspace slug. Empty
 	// when no repo declares one (every repo defaults to its own

--- a/internal/hooks/sessionstart.go
+++ b/internal/hooks/sessionstart.go
@@ -138,9 +138,13 @@ func renderDaemonReadiness(s *daemon.StatusResponse) string {
 	}
 
 	var sb strings.Builder
-	if s.Ready {
+	switch {
+	case s.Ready && s.EnrichmentComplete:
 		fmt.Fprintf(&sb, "✓ Gortex daemon ready (v%s, uptime %s). ", s.Version, formatDuration(s.UptimeSeconds))
-	} else {
+	case s.Ready:
+		fmt.Fprintf(&sb, "✓ Gortex daemon ready — references queryable (v%s, uptime %s); semantic enrichment still running. ",
+			s.Version, formatDuration(s.UptimeSeconds))
+	default:
 		fmt.Fprintf(&sb, "⏳ Gortex daemon warming up (v%s, %s elapsed). Enforcement is partial until ready. ",
 			s.Version, formatDuration(s.WarmupSeconds))
 	}

--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -382,16 +382,16 @@ func (mi *MultiIndexer) BeginParallelBatch() {
 	}
 }
 
-// RunDeferredPassesAll runs RunDeferredPasses on every per-repo
-// Indexer that carries a pending contract registry. Pairs with
-// BeginParallelBatch: the parallel loop parses with deferResolve
-// turned on; this serial loop drains the deferred per-repo passes
-// (semantic enrich / contract extract+commit) without racing on the
-// shared graph. The per-repo resolver pass is suppressed on every
-// indexer because resolver.ResolveAll walks the entire shared graph
-// — paying it R times is O(R · E). One global resolver.New(graph).
-// ResolveAll at the end picks up every placeholder edge that the
-// per-repo passes added.
+// RunDeferredPassesAll drains the deferred per-repo passes (semantic
+// enrich / contract extract+commit) serially across the indexers the
+// parallel parse populated. Pairs with BeginParallelBatch: the parallel
+// loop parses with deferResolve on; this serial loop runs the passes that
+// would otherwise race on the shared graph. The references-completeness
+// resolve runs ahead of this in RunPreEnrichResolve (so the daemon can mark
+// itself queryable before enrichment); the per-repo resolver pass is
+// suppressed here because resolver.ResolveAll walks the entire shared graph
+// — paying it R times is O(R · E). One master resolver.New(graph).ResolveAll
+// runs at the end to lift the placeholder edges enrichment + contracts added.
 func (mi *MultiIndexer) RunDeferredPassesAll(ctx context.Context) {
 	mi.mu.RLock()
 	indexers := make([]*Indexer, 0, len(mi.indexers))
@@ -419,24 +419,62 @@ func (mi *MultiIndexer) RunDeferredPassesAll(ctx context.Context) {
 	for _, idx := range indexers {
 		idx.SetSkipResolveInDeferred(false)
 	}
-	if mi.graph != nil {
-		master := resolver.New(mi.graph)
-		master.SetLogger(mi.logger)
-		// Mirror the resolve-time LSP helper onto the master pass
-		// too — RunDeferredPassesAll is where placeholder edges
-		// added by deferred per-repo passes get resolved in batch,
-		// and TS/JS-family edges should pick up LSP-precision
-		// answers here just like the per-repo passes do.
-		if mi.resolverLSPHelper != nil {
-			master.SetLSPHelper(mi.resolverLSPHelper)
-		}
-		master.SetNpmAliasResolver(mi.npmAliasResolver())
-		master.SetPathAliasResolver(mi.pathAliasResolver())
-		master.SetWorkspaceMembership(mi.workspaceMembershipResolver())
-		mt := time.Now()
-		master.ResolveAll()
-		mi.logger.Info("DEFERRED-TIMING master.ResolveAll", zap.Duration("elapsed", time.Since(mt)))
+	// Re-run the master same-repo resolver to lift the placeholder edges the
+	// enrichment + contract passes just added. The references-completeness
+	// resolve already ran ahead of enrichment in RunPreEnrichResolve, so this
+	// is the idempotent catch-up pass for edges minted during enrichment.
+	mi.runMasterResolve()
+}
+
+// runMasterResolve runs one same-repo resolver over the whole shared graph,
+// lifting every placeholder edge to its canonical target. Split out so the
+// pre-enrichment resolve stage (RunPreEnrichResolve) and the post-enrichment
+// catch-up (RunDeferredPassesAll) share one implementation.
+func (mi *MultiIndexer) runMasterResolve() {
+	if mi.graph == nil {
+		return
 	}
+	master := resolver.New(mi.graph)
+	master.SetLogger(mi.logger)
+	// Mirror the resolve-time LSP helper onto the master pass so TS/JS-family
+	// edges pick up LSP-precision answers just like the per-repo passes do.
+	if mi.resolverLSPHelper != nil {
+		master.SetLSPHelper(mi.resolverLSPHelper)
+	}
+	master.SetNpmAliasResolver(mi.npmAliasResolver())
+	master.SetPathAliasResolver(mi.pathAliasResolver())
+	master.SetWorkspaceMembership(mi.workspaceMembershipResolver())
+	mt := time.Now()
+	master.ResolveAll()
+	mi.logger.Info("DEFERRED-TIMING master.ResolveAll", zap.Duration("elapsed", time.Since(mt)))
+}
+
+// RunPreEnrichResolve runs the resolution stage that makes references queryable
+// ahead of the slow semantic-enrichment pass. It materialises go.mod dep
+// contract nodes (so the resolver's import bridge can re-target Go imports of
+// declared modules), runs the same-repo master resolver to lift every
+// parse-time placeholder edge to its canonical target, then runs the cross-repo
+// resolver so references that span repo boundaries resolve too. Contract-bridge
+// reconciliation is intentionally left to RunGlobalResolve, which runs after the
+// contract pass has committed its nodes.
+//
+// The daemon warmup calls this between the parallel parse and the enrichment
+// phase, then marks itself ready — so find_usages / get_callers return complete
+// results as soon as the graph is queryable, independent of enrichment.
+func (mi *MultiIndexer) RunPreEnrichResolve(ctx context.Context) {
+	mi.mu.RLock()
+	indexers := make([]*Indexer, 0, len(mi.indexers))
+	for _, idx := range mi.indexers {
+		indexers = append(indexers, idx)
+	}
+	mi.mu.RUnlock()
+	for _, idx := range indexers {
+		idx.runDeferredGoMod()
+	}
+	mi.runMasterResolve()
+	// Cross-repo references resolve here too so a multi-repo workspace is fully
+	// queryable at "ready", not just within each repo.
+	mi.runCrossRepoResolve(false)
 }
 
 // runDeferredEnrichParallel runs each indexer's semantic enrichment in a

--- a/internal/indexer/workspace_resolve.go
+++ b/internal/indexer/workspace_resolve.go
@@ -274,6 +274,15 @@ func (mi *MultiIndexer) BackfillWorkspaceSlugs() (nodesStamped, contractsStamped
 // the daemon needs to refresh cross-repo edges without re-indexing
 // every file. Idempotent — safe to call repeatedly.
 func (mi *MultiIndexer) RunGlobalResolve() {
+	mi.runCrossRepoResolve(true)
+}
+
+// runCrossRepoResolve runs the cross-repo resolver over the shared graph,
+// lifting references that span repo boundaries. When reconcileContracts is
+// true it also reconciles contract-bridge edges; the pre-enrichment resolve
+// stage (RunPreEnrichResolve) passes false because the contract pass has not
+// committed its nodes yet.
+func (mi *MultiIndexer) runCrossRepoResolve(reconcileContracts bool) {
 	if mi == nil || mi.graph == nil {
 		return
 	}
@@ -285,7 +294,9 @@ func (mi *MultiIndexer) RunGlobalResolve() {
 	cr.SetWorkspaceMembership(mi.workspaceMembershipResolver())
 	mi.applyRemoteStitch(cr)
 	cr.ResolveAll()
-	mi.ReconcileContractEdges()
+	if reconcileContracts {
+		mi.ReconcileContractEdges()
+	}
 }
 
 // crossWorkspaceLookup builds a resolver.CrossWorkspaceDepLookup from

--- a/internal/mcp/readiness.go
+++ b/internal/mcp/readiness.go
@@ -16,9 +16,12 @@ import (
 // readinessBroadcaster fans `notifications/workspace_readiness` push
 // events to subscribed MCP sessions. Where `diagnostics` is event-
 // driven off LSP publishDiagnostics, readiness is phase-driven off the
-// daemon warmup pipeline: snapshot_loaded → parallel_parse →
-// deferred_passes_all → global_resolve → end_batch → watcher_started →
-// ready, plus steady-state ticks when re-indexing finishes.
+// daemon warmup pipeline: snapshot_loaded → parallel_parse → resolve →
+// ready (references resolved, graph queryable) → deferred_passes_all →
+// global_resolve → end_batch → watcher_started → enrichment_complete,
+// plus steady-state ticks when re-indexing finishes. `ready` flips true
+// at the `ready` phase — ahead of enrichment — and stays true; the later
+// phases carry ready:true and report enrichment progress.
 //
 // Sessions opt in via `subscribe_workspace_readiness`. The current
 // state is replayed immediately as `initial_replay: true` so a freshly
@@ -237,7 +240,7 @@ func (s *Server) ReadinessPhase() (phase string, ready bool) {
 func (s *Server) registerReadinessTools() {
 	s.addTool(
 		mcp.NewTool("subscribe_workspace_readiness",
-			mcp.WithDescription("Opt the current MCP session into `notifications/workspace_readiness` push events. Once subscribed, every daemon warmup-phase transition (snapshot_loaded → parallel_parse → deferred_passes_all → global_resolve → end_batch → watcher_started → ready) plus steady-state re-index completions are pushed to your session as `{phase, ready, ts, ...}`. The last-known state is replayed immediately as `initial_replay: true` so a freshly connected client knows where the daemon is on its warmup curve. Pair with `unsubscribe_workspace_readiness` to opt back out."),
+			mcp.WithDescription("Opt the current MCP session into `notifications/workspace_readiness` push events. Once subscribed, every daemon warmup-phase transition (snapshot_loaded → parallel_parse → resolve → ready → deferred_passes_all → global_resolve → end_batch → watcher_started → enrichment_complete) plus steady-state re-index completions are pushed to your session as `{phase, ready, ts, ...}`. `ready` flips true at the `ready` phase — once references are resolved and the graph is queryable — ahead of the slower semantic enrichment, which completes at `enrichment_complete`. The last-known state is replayed immediately as `initial_replay: true` so a freshly connected client knows where the daemon is on its warmup curve. Pair with `unsubscribe_workspace_readiness` to opt back out."),
 		),
 		s.handleSubscribeReadiness,
 	)

--- a/internal/mcp/warmup_fastpath.go
+++ b/internal/mcp/warmup_fastpath.go
@@ -35,20 +35,24 @@ import (
 // completion percentage. The pipeline runs the phases in this strict
 // order:
 //
-//	snapshot_loaded → parallel_parse → parallel_parse_done →
-//	deferred_passes_all → deferred_passes_all_done → global_resolve →
-//	global_resolve_done → end_batch → end_batch_done →
-//	watcher_started → ready
+//	snapshot_loaded → parallel_parse → parallel_parse_done → resolve →
+//	resolve_done → ready (queryable) → deferred_passes_all →
+//	deferred_passes_all_done → global_resolve → global_resolve_done →
+//	end_batch → end_batch_done → watcher_started → enrichment_complete
 //
 // The weights are cost-proportional rather than evenly spaced:
-// parallel_parse (parsing every tracked repo off disk) dominates
-// total warmup time, so it spans 15→55; the resolve / derivation
-// tail moves quickly by comparison. The numbers are derived from the
-// phase the daemon actually reports — never a placeholder.
+// parallel_parse (parsing every tracked repo off disk) dominates total
+// warmup time, so it spans 15→55. `ready` fires at the resolve point —
+// once references are queryable — so the warming envelope clears there;
+// the phases past it report background-enrichment progress and carry
+// ready:true. The numbers are derived from the phase the daemon actually
+// reports — never a placeholder.
 var warmupPhaseProgress = map[string]int{
 	"snapshot_loaded":          5,
 	"parallel_parse":           15,
 	"parallel_parse_done":      55,
+	"resolve":                  57,
+	"resolve_done":             59,
 	"deferred_passes_all":      60,
 	"deferred_passes_all_done": 75,
 	"global_resolve":           78,
@@ -57,6 +61,7 @@ var warmupPhaseProgress = map[string]int{
 	"end_batch_done":           95,
 	"watcher_started":          98,
 	"ready":                    100,
+	"enrichment_complete":      100,
 }
 
 // warmupExemptTools is the set of MCP tools that do NOT depend on the

--- a/internal/mcp/warmup_fastpath_test.go
+++ b/internal/mcp/warmup_fastpath_test.go
@@ -37,6 +37,8 @@ func TestWarmupStateFromSnapshot_PhaseProgress(t *testing.T) {
 		"snapshot_loaded",
 		"parallel_parse",
 		"parallel_parse_done",
+		"resolve",
+		"resolve_done",
 		"deferred_passes_all",
 		"deferred_passes_all_done",
 		"global_resolve",

--- a/internal/parser/languages/cpp_refform_test.go
+++ b/internal/parser/languages/cpp_refform_test.go
@@ -166,6 +166,56 @@ func TestCppRefForm_Negatives(t *testing.T) {
 	}
 }
 
+// TestCppRefForm_GenericArgs: a type named inside a template_argument_list
+// is a generic_arg reference, in every position — a variable declaration
+// (`std::vector<Foo>`), a function parameter (`std::map<std::string, Bar>`),
+// and a nested template (`std::map<int, std::vector<Widget>>`). A primitive
+// / non-type argument (`int`, the integer constant `5`) emits nothing.
+func TestCppRefForm_GenericArgs(t *testing.T) {
+	edges := cppRefEdges(t, `void use(std::map<std::string, Bar> m) {
+  std::vector<Foo> x;
+  std::map<int, std::vector<Widget>> nested;
+  std::array<int, 5> a;
+}`)
+	// Variable-decl template arg.
+	if !hasCppRefEdge(edges, "unresolved::Foo", graph.EdgeReferences, graph.RefContextGenericArg) {
+		t.Fatalf("want generic_arg -> unresolved::Foo (variable decl); got %+v", edges)
+	}
+	// Parameter template arg (the non-wrapper map's second argument).
+	if !hasCppRefEdge(edges, "unresolved::Bar", graph.EdgeReferences, graph.RefContextGenericArg) {
+		t.Fatalf("want generic_arg -> unresolved::Bar (parameter); got %+v", edges)
+	}
+	// Nested template arg.
+	if !hasCppRefEdge(edges, "unresolved::Widget", graph.EdgeReferences, graph.RefContextGenericArg) {
+		t.Fatalf("want generic_arg -> unresolved::Widget (nested template); got %+v", edges)
+	}
+	// Primitives / std aliases / integer constants must not appear as
+	// generic_arg references.
+	for _, e := range edges {
+		if e.refContext != graph.RefContextGenericArg {
+			continue
+		}
+		switch e.to {
+		case "unresolved::int", "unresolved::string", "unresolved::5",
+			"unresolved::vector", "unresolved::map", "unresolved::array":
+			t.Fatalf("false positive: generic_arg edge %+v for a non-user-type argument", e)
+		}
+	}
+	// generic_arg edges must be OriginASTResolved so the cross-pkg guard
+	// doesn't revert them.
+	res, err := NewCppExtractor().Extract("x.cpp", []byte(`void use() { std::vector<Foo> x; }`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range res.Edges {
+		if e.Kind == graph.EdgeReferences && e.To == "unresolved::Foo" {
+			if rc, _ := e.Meta["ref_context"].(string); rc == graph.RefContextGenericArg && e.Origin != graph.OriginASTResolved {
+				t.Fatalf("generic_arg edge origin = %q, want %q", e.Origin, graph.OriginASTResolved)
+			}
+		}
+	}
+}
+
 func TestCppRefForm_StdQualifiedTypeReducesToTrailing(t *testing.T) {
 	// A std::-qualified path whose trailing segment is a Capitalized type
 	// reduces to that type; a lowercase trailing one emits nothing.

--- a/internal/parser/languages/cpp_reffrm.go
+++ b/internal/parser/languages/cpp_reffrm.go
@@ -25,6 +25,13 @@ import (
 //   - scope / static access — `Foo::BAR`, `Foo::method()`
 //     (qualified_identifier whose scope is a Capitalized namespace / type)
 //     → EdgeReferences, ref_context=static_access.
+//   - generic / template arguments — every named type inside a
+//     `template_argument_list` (`std::vector<Foo>`, `std::map<K, Bar>`,
+//     `Foo<Bar>`, nested `std::map<std::string, std::vector<Widget>>`) →
+//     EdgeReferences, ref_context=generic_arg. The declaration-position
+//     canonicaliser keeps only the template head (or unwraps a single
+//     container arg), so the element types of multi-argument / user
+//     generics were otherwise dropped.
 //
 // emitCppReferenceForms runs one post-pass tree walk (mirroring
 // collectCppTypeUseEdges) and emits these edges, attributed to the
@@ -87,6 +94,8 @@ func emitCppReferenceForms(root *sitter.Node, src []byte, filePath, fileID strin
 			emitCppQualifiedCall(n, src, filePath, funcRanges, result, seen)
 		case "qualified_identifier":
 			emitCppStaticAccess(n, src, filePath, funcRanges, result, seen)
+		case "template_argument_list":
+			emitCppGenericArgs(n, src, filePath, funcRanges, result, seen)
 		}
 		for i := 0; i < int(n.NamedChildCount()); i++ {
 			walk(n.NamedChild(i))
@@ -316,6 +325,34 @@ func emitCppStaticAccess(n *sitter.Node, src []byte, filePath string, funcRanges
 	line := int(n.StartPoint().Row) + 1
 	owner := findEnclosingFunc(funcRanges, line)
 	emitCppReferenceEdge(owner, scope, graph.RefContextStaticAccess, filePath, line, result, seen)
+}
+
+// emitCppGenericArgs handles a `template_argument_list` (`<Foo>`,
+// `<std::string, Bar>`, `<int, 5>`): every `type_descriptor` child names a
+// type argument, which is a genuine reference to that type. Each is
+// attributed to the enclosing function/method via funcRanges (a top-level
+// generic outside any function — e.g. a global `std::vector<Foo> g;` — has
+// no owner and is skipped, matching the type-use pass). Non-type arguments
+// (integer constants, which the grammar nests as `number_literal` rather
+// than `type_descriptor`) are not iterated, and primitives / lowercase
+// leaves are dropped by emitCppReferenceEdge's canonicaliser +
+// Capitalization gate, so `<int, 5>` and `<std::string>` contribute
+// nothing. Nesting is handled by the enclosing tree walk, which reaches the
+// inner `template_argument_list` of `std::map<K, std::vector<Widget>>` as
+// its own node.
+func emitCppGenericArgs(n *sitter.Node, src []byte, filePath string, funcRanges []funcRange, result *parser.ExtractionResult, seen map[string]bool) {
+	line := int(n.StartPoint().Row) + 1
+	owner := findEnclosingFunc(funcRanges, line)
+	if owner == "" {
+		return
+	}
+	for i := 0; i < int(n.NamedChildCount()); i++ {
+		ch := n.NamedChild(i)
+		if ch == nil || ch.Type() != "type_descriptor" {
+			continue
+		}
+		emitCppReferenceEdge(owner, ch.Content(src), graph.RefContextGenericArg, filePath, line, result, seen)
+	}
 }
 
 // cppQualifiedScopeType returns the Capitalized type that names the scope

--- a/internal/parser/languages/csharp_refform_test.go
+++ b/internal/parser/languages/csharp_refform_test.go
@@ -175,6 +175,56 @@ func TestCSharpRefForm_OriginASTResolved(t *testing.T) {
 	}
 }
 
+// TestCSharpRefForm_GenericArgs verifies that the type arguments inside a
+// generic spelling — in a field/var annotation, a parameter, and a nested
+// generic — each emit an EdgeReferences with ref_context "generic_arg". The
+// canonicalising type-use pass strips the `<…>` and would otherwise lose
+// these element types. Predefined primitives (int/string) and the `var`
+// keyword must NOT produce a generic_arg edge.
+func TestCSharpRefForm_GenericArgs(t *testing.T) {
+	src := `using System.Collections.Generic;
+using System.Threading.Tasks;
+
+public class Svc {
+	private List<RestClient> _clients;
+
+	public Dictionary<string, RestError> Handle(Task<RestRequest> a) {
+		var d = new Dictionary<int, List<RestResponse>>();
+		return null;
+	}
+}
+`
+	_, edges := runCSharpExtract(t, "x/Svc.cs", src)
+
+	// Field annotation argument (List<RestClient>) — attributed to the file
+	// node, since a field declaration has no enclosing function.
+	if !hasCSharpRefEdge(edges, "x/Svc.cs", "RestClient", graph.EdgeReferences, "generic_arg") {
+		t.Errorf("expected EdgeReferences (generic_arg) from file → RestClient (field annotation)")
+	}
+
+	// Parameter argument (Task<RestRequest>), return-type arguments
+	// (Dictionary<string, RestError>), and the nested-generic arguments
+	// (new Dictionary<int, List<RestResponse>>()) are all inside the method,
+	// so they attribute to the method node.
+	for _, tgt := range []string{"RestRequest", "RestError", "List", "RestResponse"} {
+		if !hasCSharpRefEdge(edges, csharpRefMethodID, tgt, graph.EdgeReferences, "generic_arg") {
+			t.Errorf("expected EdgeReferences (generic_arg) %s → %s", csharpRefMethodID, tgt)
+		}
+	}
+
+	// Primitives inside the type arguments (string, int) and the `var`
+	// keyword must never be emitted as a generic_arg reference.
+	for _, e := range edges {
+		if rc, _ := e.Meta["ref_context"].(string); rc != "generic_arg" {
+			continue
+		}
+		switch e.To {
+		case "unresolved::string", "unresolved::int", "unresolved::var":
+			t.Errorf("generic_arg must not emit %s for a primitive / var", e.To)
+		}
+	}
+}
+
 // TestCSharpRefForm_Negatives confirms the scope guards: a lowercase free
 // call (`bar()`), an instance member access (`this.x`, `local.Foo`), a
 // primitive (`int`), and `var` produce no reference-form edge.

--- a/internal/parser/languages/csharp_typeuse.go
+++ b/internal/parser/languages/csharp_typeuse.go
@@ -26,6 +26,12 @@ import (
 //     → EdgeReferences, Meta["ref_context"]="static_access"
 //   - ATTRIBUTE TYPE  `[Foo]` / `[Foo(...)]` (attribute) names the type Foo
 //     → EdgeReferences, Meta["ref_context"]="attribute"
+//   - GENERIC ARG     the type arguments inside a `<…>` (type_argument_list):
+//     `List<Foo>`, `Dictionary<string, Bar>`, `Task<Baz>`, nested
+//     `Dictionary<int, List<Qux>>`. The annotation / param / return type-use
+//     pass canonicalises a generic to its head and drops the arguments, so
+//     these element types would otherwise be invisible.
+//     → EdgeReferences, Meta["ref_context"]="generic_arg"
 //
 // Inheritance (`class X : Base, IFoo`) is intentionally NOT handled here:
 // emitCSharpBaseList already splits the base_list into EdgeExtends /
@@ -163,6 +169,44 @@ func emitCSharpReferenceForms(root *sitter.Node, src []byte, filePath, fileID st
 			// `[Foo]` / `[Foo(...)]` names the attribute type Foo.
 			if name := csharpAttributeTypeName(n, src); name != "" {
 				emit(name, line, graph.EdgeReferences, "attribute")
+			}
+
+		case "type_argument_list":
+			// The `<…>` of a generic spelling (`List<Foo>`,
+			// `Dictionary<string, Bar>`, `Task<Baz>`, `Foo<Bar<Baz>>`).
+			// The annotation / param / return type-use pass strips the
+			// argument list when it canonicalises a type to its head, so the
+			// element types are otherwise invisible to find_usages. Each
+			// argument is a direct named child here; emit a reference for the
+			// ones that name a user type. A nested generic argument
+			// (`List<Qux>` in `Dictionary<int, List<Qux>>`) is its own
+			// generic_name whose own type_argument_list this walker visits in
+			// turn, so emitting that argument's *head* (List) here and letting
+			// the inner list contribute Qux covers every depth without a
+			// manual recursion. Predefined primitives (`int`, `string`) parse
+			// as predefined_type and are skipped; the canon/primitive/
+			// capitalization gate in emit drops everything else lowercase.
+			for i := 0; i < int(n.NamedChildCount()); i++ {
+				arg := n.NamedChild(i)
+				if arg == nil {
+					continue
+				}
+				switch arg.Type() {
+				case "predefined_type":
+					// `int` / `string` / … — never a user type.
+					continue
+				case "generic_name":
+					// `List<Qux>` — its head names a type; the nested
+					// type_argument_list (<Qux>) is visited separately.
+					if head := csharpFirstChildOfType(arg, "identifier"); head != nil {
+						emit(strings.TrimSpace(head.Content(src)), line, graph.EdgeReferences, "generic_arg")
+					}
+				case "identifier", "qualified_name", "nullable_type", "array_type":
+					// `Foo`, `Ns.Foo`, `Foo?`, `Foo[]` — canonicalizeCSharpTypeRef
+					// (called inside emit) strips the namespace / nullable /
+					// array decoration down to the bare named type.
+					emit(strings.TrimSpace(arg.Content(src)), line, graph.EdgeReferences, "generic_arg")
+				}
 			}
 		}
 	})

--- a/internal/parser/languages/dart_refform_test.go
+++ b/internal/parser/languages/dart_refform_test.go
@@ -224,6 +224,98 @@ func TestDartRefForm_Negatives(t *testing.T) {
 	}
 }
 
+// TestDartRefForm_GenericArgs verifies that the element type(s) of a
+// parameterised type surface as generic_arg references in every position:
+// a class field annotation, a parameter, a return type, a typed local, a
+// supertype clause (extends / with / implements), and nested generics. Each
+// rides EdgeReferences with Meta["ref_context"]="generic_arg" and
+// OriginASTResolved. Primitive element types (String) are filtered, and the
+// generic *parameter* declaration `<T>` (a type_parameters node, not a use) is
+// never read as a reference.
+func TestDartRefForm_GenericArgs(t *testing.T) {
+	src := []byte(`class Box<T> extends Base<Sup> with Mix<MixArg> implements Iface<IfArg> {
+  List<Field> field = [];
+  Map<String, List<Nested>> nested = {};
+
+  Future<Ret> fetch(Set<Param> accts, [List<Opt>? logs]) async {
+    List<Local> users = [];
+    return get();
+  }
+}
+`)
+	res, err := NewDartExtractor().Extract("box.dart", src)
+	require.NoError(t, err)
+
+	gen := func(typeName string) bool {
+		return dartRefEdge(res.Edges, graph.EdgeReferences, typeName, graph.RefContextGenericArg)
+	}
+
+	// Every element type, in every position, surfaces as a generic_arg.
+	assert.True(t, gen("Field"), "field List<Field> element; edges=%v", res.Edges)
+	assert.True(t, gen("Nested"), "nested Map<String, List<Nested>> element")
+	assert.True(t, gen("Ret"), "return Future<Ret> element")
+	assert.True(t, gen("Param"), "parameter Set<Param> element")
+	assert.True(t, gen("Opt"), "optional parameter List<Opt>? element")
+	assert.True(t, gen("Local"), "typed local List<Local> element")
+	assert.True(t, gen("Sup"), "supertype extends Base<Sup> element")
+	assert.True(t, gen("MixArg"), "mixin with Mix<MixArg> element")
+	assert.True(t, gen("IfArg"), "interface implements Iface<IfArg> element")
+
+	// Primitive element type String must never surface.
+	assert.False(t, gen("String"), "primitive generic arg String must not surface")
+
+	// The generic *parameter* declaration `<T>` is a type_parameters node, not a
+	// use — T must not be read as a generic_arg reference.
+	assert.False(t, gen("T"), "generic parameter declaration <T> must not be a use")
+
+	// Generic-arg references ride OriginASTResolved.
+	for _, e := range res.Edges {
+		if e.Kind == graph.EdgeReferences && e.Meta != nil &&
+			e.Meta["ref_context"] == graph.RefContextGenericArg {
+			assert.Equal(t, graph.OriginASTResolved, e.Origin,
+				"generic_arg reference Origin must be OriginASTResolved")
+		}
+	}
+
+	// Generic args inside fetch() attribute to the enclosing method; the
+	// supertype / field args (outside any function) fall back to the file node.
+	for _, e := range res.Edges {
+		if e.Kind != graph.EdgeReferences || e.Meta == nil ||
+			e.Meta["ref_context"] != graph.RefContextGenericArg {
+			continue
+		}
+		switch e.To {
+		case "unresolved::Ret", "unresolved::Param", "unresolved::Opt", "unresolved::Local":
+			assert.Equal(t, "box.dart::Box.fetch", e.From,
+				"generic arg %s should attribute to the enclosing method", e.To)
+		case "unresolved::Sup", "unresolved::MixArg", "unresolved::IfArg", "unresolved::Field", "unresolved::Nested":
+			assert.Equal(t, "box.dart", e.From,
+				"generic arg %s outside any function should attribute to the file node", e.To)
+		}
+	}
+}
+
+// TestDartRefForm_GenericArgsNoDuplicate guards the per-(owner,type,line,
+// ref_context) dedup: the same generic element type repeated on one line emits
+// a single generic_arg edge.
+func TestDartRefForm_GenericArgsNoDuplicate(t *testing.T) {
+	src := []byte(`void run() {
+  Map<Key, Key> m = {};
+}
+`)
+	res, err := NewDartExtractor().Extract("d.dart", src)
+	require.NoError(t, err)
+
+	n := 0
+	for _, e := range res.Edges {
+		if e.Kind == graph.EdgeReferences && e.To == "unresolved::Key" &&
+			e.Meta != nil && e.Meta["ref_context"] == graph.RefContextGenericArg {
+			n++
+		}
+	}
+	assert.Equal(t, 1, n, "Map<Key, Key> must dedup to one generic_arg edge for Key")
+}
+
 // TestDartRefForm_NoDuplicateEdges guards the per-(owner,type,line,ref_context)
 // dedup: the same static access twice on one line emits a single edge.
 func TestDartRefForm_NoDuplicateEdges(t *testing.T) {

--- a/internal/parser/languages/dart_reffrm.go
+++ b/internal/parser/languages/dart_reffrm.go
@@ -25,6 +25,11 @@ import (
 //   - STATIC ACCESS   `Foo.constant` / `Foo.staticMethod()` / `Foo.named()`
 //     — a member/static access whose head is a bare Capitalized identifier
 //     → EdgeReferences, Meta["ref_context"]="static_access"
+//   - GENERIC ARG     the element type(s) of a parameterised type
+//     `List<Foo>` / `Map<String, Bar>` / `Future<Response>` / a supertype
+//     `extends Base<Foo>`, in any position (variable annotation, parameter,
+//     return, supertype, or nested) → EdgeReferences,
+//     Meta["ref_context"]="generic_arg"
 //
 // Each edge attributes to the enclosing function / method (the file node when
 // nothing encloses the line) so find_usages lands the reference without a
@@ -56,9 +61,11 @@ import (
 //     chained `a.b.C` (whose head identifier is `a`) are all excluded, so a
 //     field read on an instance is never read as a static type reference.
 //   - The mixin / interface / superclass type identifiers are taken from the
-//     dedicated grammar clauses (superclass / mixins / interfaces), never from
-//     a generic type_identifier walk, so type arguments and annotations are
-//     not pulled in.
+//     dedicated grammar clauses (superclass / mixins / interfaces), so the
+//     inherit edge names the supertype itself and not its annotations. The
+//     supertype's *generic arguments* (`extends Base<Foo>`) are surfaced
+//     separately by the position-independent type_arguments walk as
+//     generic_arg references, not as inherit references.
 func (e *DartExtractor) emitDartReferenceForms(
 	root *sitter.Node, src []byte, filePath string, fileNode *graph.Node,
 	result *parser.ExtractionResult,
@@ -157,6 +164,24 @@ func (e *DartExtractor) emitDartReferenceForms(
 				emit(name, line, graph.EdgeReferences, graph.RefContextCast)
 			}
 
+		case "type_arguments":
+			// `<Foo>` / `<String, Bar>` — generic argument list. This is the
+			// position-independent generic-arg surface: a `type_arguments` node
+			// appears verbatim in every position a parameterised type can occur
+			// (variable annotation `List<Foo>`, parameter `Set<Account>`, return
+			// `Future<Response>`, a supertype clause `extends Base<Foo>` /
+			// `with Mix<Bar>` / `implements Iface<Baz>`, and nested inside another
+			// type_arguments `Map<String, List<Bar>>`). Each direct
+			// type_identifier child is an element type used here; a nested
+			// type_arguments child is its own node that walkNodes visits
+			// separately, so emitting only the *direct* element types avoids
+			// double-counting while still surfacing every level. The grammar's
+			// declaration-position node for `<T>` is type_parameters (a distinct
+			// node), so a generic *parameter* declaration is never misread as a
+			// use. The emit closure applies the Capitalization + primitive gate
+			// and the per-(owner,type,line,ref_context) dedup.
+			emitDartGenericArgs(n, src, line, emit)
+
 		case "identifier":
 			// A bare identifier that heads an expression: it is either an
 			// unadorned construction `Foo(...)` or a static access `Foo.member`
@@ -182,9 +207,11 @@ func (e *DartExtractor) emitDartReferenceForms(
 //	    implements
 //	    type_identifier ...    <- interfaces
 //
-// Only the dedicated clause type_identifiers are taken, so generic arguments
-// and the class's own name are never pulled in. The emit closure applies the
-// Capitalization + primitive gate, so a malformed clause yields nothing.
+// Only the dedicated clause type_identifiers are taken as inherit references,
+// so a supertype's generic arguments and the class's own name are never pulled
+// in here — the supertype's type_arguments (`extends Base<Foo>`) ride the
+// generic_arg walk instead. The emit closure applies the Capitalization +
+// primitive gate, so a malformed clause yields nothing.
 func emitDartInheritanceClauses(classNode *sitter.Node, src []byte, emit func(rawType string, line int, kind graph.EdgeKind, refContext string)) {
 	for i := 0; i < int(classNode.ChildCount()); i++ {
 		clause := classNode.Child(i)
@@ -292,6 +319,26 @@ func emitDartIdentifierHead(n *sitter.Node, src []byte, line int, localTypes map
 				emit(head, line, graph.EdgeInstantiates, "")
 			}
 			return
+		}
+	}
+}
+
+// emitDartGenericArgs emits a generic_arg reference for every direct
+// type_identifier child of a type_arguments node. Each element type rides
+// EdgeReferences with Meta["ref_context"]="generic_arg" and OriginASTResolved.
+//
+// Only *direct* children are read: a nested generic (`List<Bar>` inside
+// `Map<String, List<Bar>>`) is its own type_arguments node that the walk visits
+// independently, so descending here would double-count it. The line is the
+// outer type_arguments node's start row (the use site of these element types).
+func emitDartGenericArgs(targs *sitter.Node, src []byte, line int, emit func(rawType string, line int, kind graph.EdgeKind, refContext string)) {
+	if targs == nil {
+		return
+	}
+	for i := 0; i < int(targs.NamedChildCount()); i++ {
+		c := targs.NamedChild(i)
+		if c != nil && c.Type() == "type_identifier" {
+			emit(c.Content(src), line, graph.EdgeReferences, graph.RefContextGenericArg)
 		}
 	}
 }

--- a/internal/parser/languages/go_typeuse.go
+++ b/internal/parser/languages/go_typeuse.go
@@ -1,0 +1,176 @@
+package languages
+
+import (
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	sitter "github.com/zzet/gortex/internal/parser/tsitter"
+)
+
+// emitGoTypeArgReferences captures the composite/generic type positions
+// whose element / argument types are dropped by the primary type-name
+// passes, so a find_usages of a type surfaces every place the type is
+// mentioned — not just the bare-name declarations.
+//
+// The primary passes attribute a single name per type position:
+// canonicalizeGoTypeRef reduces `Foo[Bar]` to `Foo`, and returns "" for
+// `map[K]V` and `chan E` entirely. That means the argument `Bar`, the
+// map key `K` and value `V`, and the channel element `E` produce no
+// reference edge at all. This pass walks the three node kinds whose
+// inner types are otherwise lost and emits one EdgeReferences per
+// element/argument type:
+//
+//   - generic_type   `List[Foo]` / `Map[K, V]` — every type_arguments
+//     entry. Mirrors the Kotlin type_arguments handling.
+//   - map_type       `map[K]V` — both the key and the value type.
+//   - channel_type   `chan E` / `<-chan E` / `chan<- E` — the element.
+//
+// Nested composites are walked transitively (`map[string][]Foo`,
+// `chan Option[Bar]`, `List[map[K]V]`), so the innermost named types
+// surface regardless of how deeply they are wrapped. Slice / array /
+// pointer ELEMENT types are already canonicalised to a name by the
+// existing param / return / field passes, so the bare wrappers are not
+// re-emitted here on their own — but they are descended into when they
+// appear inside one of the three lost positions above.
+//
+// Zero false positives: only type_identifier / qualified_type leaves
+// are emitted, run through canonicalizeGoTypeRef (which drops
+// primitives, package qualifiers, and the generic suffix). Builtins
+// (`isGoBuiltinOrKeyword`) and type-parameter names declared anywhere
+// in the file (collected from type_parameter_list) are skipped, so a
+// generic instantiation `List[T]` inside a `func F[T any]` never emits
+// a reference to a phantom type `T`. Edges are deduped per
+// (owner, type, line, ref_context) and attributed to the enclosing
+// function (or the file node for package-level declarations).
+func emitGoTypeArgReferences(root *sitter.Node, src []byte, filePath, fileID string, funcRanges []funcRange, result *parser.ExtractionResult) {
+	if root == nil {
+		return
+	}
+	typeParams := collectGoTypeParamNames(root, src)
+	seen := map[string]bool{}
+	emit := func(name string, line int) {
+		t := canonicalizeGoTypeRef(name)
+		if t == "" || isGoBuiltinOrKeyword(t) || typeParams[t] {
+			return
+		}
+		ownerID := findEnclosingFunc(funcRanges, line)
+		if ownerID == "" {
+			ownerID = fileID
+		}
+		if ownerID == "" {
+			return
+		}
+		key := ownerID + "\x00" + t + "\x00" + intKey(line)
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		result.Edges = append(result.Edges, &graph.Edge{
+			From:     ownerID,
+			To:       "unresolved::" + t,
+			Kind:     graph.EdgeReferences,
+			FilePath: filePath,
+			Line:     line,
+			// OriginASTResolved (not Inferred): these are structural type
+			// references read straight off the AST — a generic argument,
+			// a map key/value, or a channel element. The name binds to
+			// the (unique) type of that name in the repo with no
+			// ambiguity, exactly like the type-position EdgeTypedAs /
+			// EdgeReturns edges, so ast_resolved keeps the cross-package
+			// name-match guard from dropping them as name-only guesses.
+			Origin: graph.OriginASTResolved,
+			Meta:   map[string]any{"ref_context": "generic_arg"},
+		})
+	}
+
+	// emitTypeLeaves descends a type subtree and emits a reference for
+	// every named-type leaf it finds, recursing through nested
+	// composites. Used on the inner positions of the three lost node
+	// kinds.
+	var emitTypeLeaves func(n *sitter.Node)
+	emitTypeLeaves = func(n *sitter.Node) {
+		if n == nil {
+			return
+		}
+		switch n.Type() {
+		case "type_identifier", "qualified_type":
+			emit(n.Content(src), int(n.StartPoint().Row)+1)
+		default:
+			for i := 0; i < int(n.NamedChildCount()); i++ {
+				emitTypeLeaves(n.NamedChild(i))
+			}
+		}
+	}
+
+	walkNodes(root, func(n *sitter.Node) {
+		switch n.Type() {
+		case "type_arguments":
+			// Generic instantiation arguments: the bracketed list under a
+			// generic_type. Each entry is a type_elem (or a bare type
+			// node on older grammars); descend into all of them.
+			for i := 0; i < int(n.NamedChildCount()); i++ {
+				emitTypeLeaves(n.NamedChild(i))
+			}
+		case "map_type":
+			// Both the key and the value type are otherwise lost. The
+			// grammar exposes them via the key/value fields when present;
+			// fall back to all named children so older grammar shapes
+			// (two bare type_identifier children) are still covered.
+			key := n.ChildByFieldName("key")
+			value := n.ChildByFieldName("value")
+			if key != nil || value != nil {
+				emitTypeLeaves(key)
+				emitTypeLeaves(value)
+			} else {
+				for i := 0; i < int(n.NamedChildCount()); i++ {
+					emitTypeLeaves(n.NamedChild(i))
+				}
+			}
+		case "channel_type":
+			// The element type of a channel. The value field names it
+			// when present; otherwise the sole named child is the
+			// element.
+			if value := n.ChildByFieldName("value"); value != nil {
+				emitTypeLeaves(value)
+			} else {
+				for i := 0; i < int(n.NamedChildCount()); i++ {
+					emitTypeLeaves(n.NamedChild(i))
+				}
+			}
+		}
+	})
+}
+
+// collectGoTypeParamNames returns the set of every type-parameter name
+// declared anywhere in the file (function, method, or type generic
+// parameter lists). These names are NOT real types — a generic
+// instantiation `List[T]` inside `func F[T any]` must not emit a
+// reference to a phantom type `T` — so the type-arg pass skips them.
+func collectGoTypeParamNames(root *sitter.Node, src []byte) map[string]bool {
+	out := map[string]bool{}
+	walkNodes(root, func(n *sitter.Node) {
+		t := n.Type()
+		if t != "type_parameter_declaration" && t != "parameter_declaration" {
+			return
+		}
+		// type_parameter_declaration is the modern grammar shape; older
+		// grammars reuse parameter_declaration inside type_parameter_list.
+		// Only the latter, when its parent is a type_parameter_list,
+		// declares type parameters.
+		if t == "parameter_declaration" {
+			parent := n.Parent()
+			if parent == nil || parent.Type() != "type_parameter_list" {
+				return
+			}
+		}
+		for i := 0; i < int(n.NamedChildCount()); i++ {
+			c := n.NamedChild(i)
+			if c == nil {
+				continue
+			}
+			if ct := c.Type(); ct == "identifier" || ct == "type_identifier" {
+				out[c.Content(src)] = true
+			}
+		}
+	})
+	return out
+}

--- a/internal/parser/languages/go_typeuse_test.go
+++ b/internal/parser/languages/go_typeuse_test.go
@@ -1,0 +1,110 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// genericArgRefs returns the set of unresolved:: target type names of
+// every EdgeReferences edge carrying ref_context=generic_arg.
+func genericArgRefs(fix *extractedFixture) map[string]bool {
+	out := map[string]bool{}
+	for _, e := range fix.edgesByKind[graph.EdgeReferences] {
+		if e.Meta == nil {
+			continue
+		}
+		if rc, _ := e.Meta["ref_context"].(string); rc != "generic_arg" {
+			continue
+		}
+		out[e.To] = true
+	}
+	return out
+}
+
+func TestGoTypeUse_GenericArgs(t *testing.T) {
+	src := `package foo
+
+type Foo struct{}
+type Bar struct{}
+type Baz struct{}
+type Qux struct{}
+type Option[T any] struct{}
+type Result[T any, E any] struct{}
+
+func consume(p Option[Foo]) Result[Bar, Baz] {
+	var m map[string]Qux
+	_ = m
+	ch := make(chan Foo)
+	_ = ch
+	return Result[Bar, Baz]{}
+}
+`
+	fix := runGoExtract(t, src)
+	got := genericArgRefs(fix)
+
+	// Generic args (Foo, Bar, Baz), map value (Qux), channel element (Foo).
+	want := []string{
+		"unresolved::Foo", "unresolved::Bar",
+		"unresolved::Baz", "unresolved::Qux",
+	}
+	for _, w := range want {
+		if !got[w] {
+			t.Errorf("missing generic_arg reference %q; got %v", w, got)
+		}
+	}
+
+	// Type parameters and the primitive key type must NOT be emitted as
+	// generic_arg references — zero false positives.
+	for _, bad := range []string{
+		"unresolved::T", "unresolved::E", "unresolved::string",
+		"unresolved::any",
+	} {
+		if got[bad] {
+			t.Errorf("unexpected generic_arg reference %q (type param / primitive); got %v", bad, got)
+		}
+	}
+
+	// Owner attribution: every generic_arg edge inside the function body
+	// is attributed to the enclosing function, not the file node.
+	for _, e := range fix.edgesByKind[graph.EdgeReferences] {
+		if e.Meta == nil {
+			continue
+		}
+		if rc, _ := e.Meta["ref_context"].(string); rc != "generic_arg" {
+			continue
+		}
+		if e.From == "" {
+			t.Errorf("generic_arg edge has empty owner: %+v", e)
+		}
+	}
+}
+
+func TestGoTypeUse_NestedComposites(t *testing.T) {
+	src := `package foo
+
+type Foo struct{}
+type Bar struct{}
+type List[T any] struct{}
+
+func f() {
+	var nested map[string][]Foo
+	_ = nested
+	var deep chan List[Bar]
+	_ = deep
+}
+`
+	fix := runGoExtract(t, src)
+	got := genericArgRefs(fix)
+
+	// map[string][]Foo → Foo (value element through the slice wrapper).
+	// chan List[Bar] → List (channel element) and Bar (its generic arg).
+	for _, w := range []string{"unresolved::Foo", "unresolved::List", "unresolved::Bar"} {
+		if !got[w] {
+			t.Errorf("missing nested-composite reference %q; got %v", w, got)
+		}
+	}
+	if got["unresolved::string"] {
+		t.Errorf("primitive map key string must not be emitted; got %v", got)
+	}
+}

--- a/internal/parser/languages/golang.go
+++ b/internal/parser/languages/golang.go
@@ -1233,6 +1233,12 @@ func (e *GoExtractor) Extract(filePath string, src []byte) (*parser.ExtractionRe
 	// Gin middleware-chain dispatcher + route registrations → resolver hints.
 	mineGinMiddleware(src, result)
 
+	// Composite/generic element type references — generic arguments,
+	// map key/value, channel element. These positions are dropped by the
+	// bare-name type passes, so without this find_usages of a type misses
+	// every place it appears only as an argument/element type.
+	emitGoTypeArgReferences(root, src, filePath, fileID, funcRanges, result)
+
 	return result, nil
 }
 

--- a/internal/parser/languages/java_refform_test.go
+++ b/internal/parser/languages/java_refform_test.go
@@ -41,7 +41,9 @@ func hasUseKindTo(edges []*graph.Edge, to, useKind string) bool {
 
 // TestJavaRefForm_Instantiation pins `new Foo()` / `new Foo[]` /
 // `new Outer.Inner()` → EdgeInstantiates (ref_context=instantiate), and
-// generic args of `new ArrayList<Request>()` → Request.
+// the generic arg of `new ArrayList<Request>()` → Request as a
+// generic_arg reference (handled by the type_arguments walker, not the
+// instantiation case).
 func TestJavaRefForm_Instantiation(t *testing.T) {
 	src := `package app;
 public class Factory {
@@ -66,8 +68,8 @@ public class Factory {
 	if refEdge(edges, graph.EdgeInstantiates, "unresolved::ArrayList", "instantiate") == nil {
 		t.Errorf("expected EdgeInstantiates -> ArrayList for `new java.util.ArrayList<>()`")
 	}
-	if refEdge(edges, graph.EdgeInstantiates, "unresolved::Request", "instantiate") == nil {
-		t.Errorf("expected EdgeInstantiates -> Request (generic arg of new ArrayList<Request>())")
+	if refEdge(edges, graph.EdgeReferences, "unresolved::Request", "generic_arg") == nil {
+		t.Errorf("expected EdgeReferences -> Request (generic_arg of new ArrayList<Request>())")
 	}
 }
 
@@ -175,7 +177,7 @@ public class C {
 		}
 		uk, _ := e.Meta["ref_context"].(string)
 		switch uk {
-		case "instantiate", "cast", "inherit", "static_access":
+		case "instantiate", "cast", "inherit", "static_access", "generic_arg":
 			to := e.To
 			// Strip the unresolved:: prefix for the check.
 			const p = "unresolved::"
@@ -203,10 +205,87 @@ public class C {
 		t.Errorf("instance receiver obj emitted a static_access reference")
 	}
 	for _, prim := range []string{"int", "field", "name", "value", "lower"} {
-		for _, uk := range []string{"instantiate", "cast", "inherit", "static_access"} {
+		for _, uk := range []string{"instantiate", "cast", "inherit", "static_access", "generic_arg"} {
 			if hasUseKindTo(edges, "unresolved::"+prim, uk) {
 				t.Errorf("primitive/lowercase %q emitted a %s reference-form edge", prim, uk)
 			}
 		}
+	}
+}
+
+// TestJavaRefForm_GenericArgs pins that the element types of a
+// `type_arguments` node are emitted as generic_arg references
+// (EdgeReferences, OriginASTResolved) in *every* position, not just the
+// expression positions. The declaration-position passes canonicalize the
+// annotation to its outer/wrapped type and drop the remaining element
+// types, so without the type_arguments walker `Foo` in `Map<String, Foo>`
+// is edge-less. This covers field, parameter, return, local, nested, and
+// instantiation/cast/inherit positions, and confirms String / wildcards /
+// primitives in the arg list contribute nothing.
+func TestJavaRefForm_GenericArgs(t *testing.T) {
+	src := `package app;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+public class Svc<T extends Bound> extends Base<Sup> implements Sink<Iface> {
+	private Map<String, FieldT> fieldMap;
+	private Cache<FieldU> fieldCache;
+	public Optional<RetT> getOpt(List<ParamT> items, Map<String, List<NestT>> nested) {
+		Map<String, LocalT> local = build();
+		Repository<WidgetT> repo = make();
+		List<NewT> made = new java.util.ArrayList<NewT>();
+		Object o = (Holder<CastT>) made;
+		boolean b = o instanceof Box<TestT>;
+		List<? extends WildLow> wild = wild();
+		List<Integer> nums = null;
+		return null;
+	}
+}
+`
+	_, edges := runJavaExtract(t, "app/Svc.java", src)
+
+	// Every element type, regardless of position, must surface as a
+	// generic_arg EdgeReferences (OriginASTResolved).
+	wantArgs := []string{
+		"FieldT",  // field Map<String, FieldT>
+		"FieldU",  // field Cache<FieldU>
+		"RetT",    // return Optional<RetT>
+		"ParamT",  // param List<ParamT>
+		"NestT",   // nested param Map<String, List<NestT>>
+		"LocalT",  // local Map<String, LocalT>
+		"WidgetT", // local Repository<WidgetT>
+		"NewT",    // new ArrayList<NewT>()
+		"CastT",   // (Holder<CastT>) cast
+		"TestT",   // instanceof Box<TestT>
+		"Sup",     // extends Base<Sup>
+		"Iface",   // implements Sink<Iface>
+	}
+	for _, want := range wantArgs {
+		e := refEdge(edges, graph.EdgeReferences, "unresolved::"+want, "generic_arg")
+		if e == nil {
+			t.Errorf("expected EdgeReferences -> %s (ref_context=generic_arg)", want)
+			continue
+		}
+		if e.Origin != graph.OriginASTResolved {
+			t.Errorf("generic_arg -> %s Origin = %q, want OriginASTResolved", want, e.Origin)
+		}
+	}
+
+	// Wildcard bound type (`? extends WildLow`) is also an element mention.
+	if refEdge(edges, graph.EdgeReferences, "unresolved::WildLow", "generic_arg") == nil {
+		t.Errorf("expected EdgeReferences -> WildLow (generic_arg of `? extends WildLow`)")
+	}
+
+	// `String` is treated as a primitive by isJavaPrimitive (same gate the
+	// declaration-position passes use), so a `Map<String, …>` key must NOT
+	// produce a generic_arg reference.
+	if hasUseKindTo(edges, "unresolved::String", "generic_arg") {
+		t.Errorf("String must not be emitted as a generic_arg reference (primitive gate)")
+	}
+	// A boxed type that is *not* on the primitive list (Integer) is a real
+	// type reference and must surface, confirming the gate is the same one
+	// the type-position edges use rather than an over-broad drop.
+	if refEdge(edges, graph.EdgeReferences, "unresolved::Integer", "generic_arg") == nil {
+		t.Errorf("expected EdgeReferences -> Integer (generic_arg of List<Integer>)")
 	}
 }

--- a/internal/parser/languages/java_typeuse.go
+++ b/internal/parser/languages/java_typeuse.go
@@ -16,9 +16,16 @@ import (
 // genuine `find_usages(Type)` hit that, without an LSP, was previously
 // edge-less:
 //
-//   - INSTANTIATION  `new Foo()`, `new Foo[3]`, `new Outer.Inner()`,
-//     plus the generic arguments of `new ArrayList<Request>()` —
+//   - INSTANTIATION  `new Foo()`, `new Foo[3]`, `new Outer.Inner()` —
 //     graph.EdgeInstantiates, ref_context=instantiate.
+//   - GENERIC ARGS   the element types of every `type_arguments` node, in
+//     any position (`Map<String, Foo>` field/param/return/local, plus
+//     `new List<Foo>()`, `(List<Foo>) x`, `extends Base<Foo>`). The
+//     declaration-position passes canonicalize an annotation to its
+//     outer/wrapped type and drop the rest, so these element types were
+//     otherwise edge-less. EdgeReferences, ref_context=generic_arg.
+//     Nested generics (`Map<K, List<V>>`) are covered because the walker
+//     descends into the inner type_arguments.
 //   - INHERITANCE    `class X extends Foo implements Bar, Baz` — the base
 //     extractor only stamps `scope_parent` meta (for the method-scope
 //     resolver), so the type reference for find_usages was missing.
@@ -83,15 +90,51 @@ func emitJavaReferenceForms(root *sitter.Node, src []byte, filePath, fileID stri
 		}
 		line := int(n.StartPoint().Row) + 1
 		switch n.Type() {
+		case "type_arguments":
+			// `<Foo>` / `<String, Foo>` / `<String, List<Foo>>` — every named
+			// element type is a genuine find_usages(Foo) hit. This single case
+			// covers generic arguments in *all* positions the AST can place a
+			// `type_arguments` node: field / parameter / return / local
+			// declarations (`Map<String, Foo> m`, `Optional<Foo> getX()`),
+			// as well as the expression positions (`new List<Foo>()`,
+			// `(List<Foo>) x`, `extends Base<Foo>`). The declaration-position
+			// passes (emitJavaFunctionShape / emitJavaTypeUseEdges) canonicalize
+			// the annotation to its outer/wrapped type and drop the remaining
+			// element types, so without this case `Foo` in `Map<String, Foo>`
+			// was edge-less. Nested generics are handled because the walker
+			// also descends into the inner `type_arguments` node and re-enters
+			// this case for it. A `wildcard` element (`? extends Foo` /
+			// `? super Foo`) carries its bound as a type-node child, so its
+			// bound is emitted too. Each element is canonicalized +
+			// primitive-gated by emit, so `<String, int>` contributes nothing.
+			emitArg := func(c *sitter.Node) {
+				if c == nil {
+					return
+				}
+				if isJavaTypeNode(c.Type()) {
+					emit(strings.TrimSpace(c.Content(src)), line, "generic_arg", graph.EdgeReferences, graph.OriginASTResolved)
+					return
+				}
+				if c.Type() == "wildcard" {
+					for j := 0; j < int(c.NamedChildCount()); j++ {
+						if w := c.NamedChild(j); w != nil && isJavaTypeNode(w.Type()) {
+							emit(strings.TrimSpace(w.Content(src)), line, "generic_arg", graph.EdgeReferences, graph.OriginASTResolved)
+						}
+					}
+				}
+			}
+			for i := 0; i < int(n.NamedChildCount()); i++ {
+				emitArg(n.NamedChild(i))
+			}
+
 		case "object_creation_expression":
-			// `new Foo(...)` / `new Outer.Inner(...)` / `new List<Req>()`.
+			// `new Foo(...)` / `new Outer.Inner(...)` / `new List<Req>()`. The
+			// generic arguments of the created type (`new ArrayList<Request>()`
+			// → Request) are emitted by the `type_arguments` case above, which
+			// the walker reaches when it descends into this node.
 			if ty := javaCreatedTypeText(n, src); ty != "" {
 				emit(ty, line, "instantiate", graph.EdgeInstantiates, graph.OriginASTInferred)
 			}
-			// Generic arguments of the created type are themselves
-			// instantiation-position references (`new ArrayList<Request>()`
-			// uses Request).
-			emitJavaTypeArgRefs(n, src, line, "instantiate", graph.EdgeInstantiates, graph.OriginASTInferred, emit)
 
 		case "array_creation_expression":
 			// `new Foo[3]` — the element type child.
@@ -174,9 +217,12 @@ func isJavaTypeNode(t string) bool {
 }
 
 // emitJavaTypeChildRefs emits a reference for every direct named type
-// child of node (and their generic arguments). Used for cast /
-// instanceof / extends / implements clauses, where the type(s) sit as
-// direct children.
+// child of node. Used for cast / instanceof / extends / implements
+// clauses, where the type(s) sit as direct children. The generic
+// arguments those types carry (`extends Base<Foo>`) are emitted
+// separately by the `type_arguments` case of the main walker, which the
+// walk reaches when it descends into the child `generic_type` node — so
+// this helper deliberately does not recurse into them.
 func emitJavaTypeChildRefs(node *sitter.Node, src []byte, line int, useKind string, kind graph.EdgeKind, origin string, emit func(string, int, string, graph.EdgeKind, string)) {
 	for i := 0; i < int(node.NamedChildCount()); i++ {
 		c := node.NamedChild(i)
@@ -184,26 +230,7 @@ func emitJavaTypeChildRefs(node *sitter.Node, src []byte, line int, useKind stri
 			continue
 		}
 		emit(strings.TrimSpace(c.Content(src)), line, useKind, kind, origin)
-		emitJavaTypeArgRefs(c, src, line, useKind, kind, origin, emit)
 	}
-}
-
-// emitJavaTypeArgRefs walks the `type_arguments` subtree of node and
-// emits a reference for each named type argument (`<Request>` →
-// Request). Recurses through nested generics (`Map<K, List<V>>`).
-func emitJavaTypeArgRefs(node *sitter.Node, src []byte, line int, useKind string, kind graph.EdgeKind, origin string, emit func(string, int, string, graph.EdgeKind, string)) {
-	walkNodes(node, func(n *sitter.Node) {
-		if n == nil || n.Type() != "type_arguments" {
-			return
-		}
-		for i := 0; i < int(n.NamedChildCount()); i++ {
-			c := n.NamedChild(i)
-			if c == nil || !isJavaTypeNode(c.Type()) {
-				continue
-			}
-			emit(strings.TrimSpace(c.Content(src)), line, useKind, kind, origin)
-		}
-	})
 }
 
 // javaCreatedTypeText returns the raw type text of an

--- a/internal/parser/languages/kotlin_refform_test.go
+++ b/internal/parser/languages/kotlin_refform_test.go
@@ -181,3 +181,32 @@ fun run(svc: Service) {
 		t.Fatalf("lowercase receiver svc must not produce a static_access reference")
 	}
 }
+
+// TestKotlinReferenceForm_GenericArgs: type arguments inside a generic — in any
+// type position (property annotation, parameter, nested return) — are captured
+// as generic_arg references. The type-annotation pass strips the `<…>` and keeps
+// only the head type, so without this the element types are invisible to
+// find_usages. Primitive args (String) are dropped.
+func TestKotlinReferenceForm_GenericArgs(t *testing.T) {
+	edges := extractKotlinRefEdges(t, `package p
+class Holder {
+  val client: Lazy<OkHttpClient> = lazy { something() }
+  fun chain(list: List<Interceptor>): Map<String, List<Response>> {
+    return emptyMap()
+  }
+}
+`)
+	for _, want := range []string{
+		"unresolved::OkHttpClient", // Lazy<OkHttpClient> property annotation
+		"unresolved::Interceptor",  // List<Interceptor> parameter
+		"unresolved::Response",     // nested Map<String, List<Response>> return
+	} {
+		if !hasRefEdge(edges, graph.EdgeReferences, want, "generic_arg") {
+			t.Fatalf("expected EdgeReferences -> %s (generic_arg); got %+v", want, edges)
+		}
+	}
+	// Primitive generic args (String) must not produce a reference edge.
+	if countTo(edges, "unresolved::String") != 0 {
+		t.Fatalf("primitive String generic arg must not produce a reference edge; got %+v", edges)
+	}
+}

--- a/internal/parser/languages/kotlin_typeuse.go
+++ b/internal/parser/languages/kotlin_typeuse.go
@@ -11,7 +11,7 @@ import (
 // find_usages of a type surfaces every place the type is mentioned — not
 // just the declarations that name it in a type position.
 //
-// Four forms, each emitted as an edge to `unresolved::<TypeName>` carrying
+// Five forms, each emitted as an edge to `unresolved::<TypeName>` carrying
 // Meta["ref_context"], attributed to the enclosing function (or the file node
 // for top-level expressions):
 //
@@ -27,6 +27,10 @@ import (
 //   - inherit        `class X : Bar(), Iface` (delegation_specifier) — the
 //     supertype / interface. EdgeExtends for a constructor_invocation superclass,
 //     EdgeReferences for a bare user_type supertype.
+//   - generic_arg    `List<OkHttpClient>` / `Map<String, Interceptor>` — each
+//     type named inside a type_arguments block, in any type position. The
+//     type-annotation / function-shape passes strip the `<…>` arguments, so the
+//     element types are captured here. EdgeReferences to each argument type.
 //
 // Scope/shadow safety: only Capitalized names are treated as types (so a
 // lowercase function call `foo()` or a local variable read never produces a
@@ -154,6 +158,39 @@ func emitKotlinReferenceForms(root *sitter.Node, src []byte, filePath, fileID st
 					emit(ownerID, c.Content(src), "inherit", graph.EdgeReferences, line)
 				}
 			}
+
+		case "type_arguments":
+			// Generic / collection element types: `List<OkHttpClient>`,
+			// `Map<String, Interceptor>`, `Lazy<Response>` in any type position
+			// (annotation, parameter, return, supertype, cast, explicit call
+			// type-arg). The type-annotation / function-shape passes keep only
+			// the head type and strip the `<…>` arguments, so the element types
+			// would otherwise be lost. Every type_identifier inside a
+			// type_arguments block names a type; emit each as a generic_arg
+			// reference (normalizeKotlinTypeName drops primitives + lowercase, so
+			// `List<String>` adds nothing extra). Nested generics like
+			// `Map<K, List<Foo>>` are reached when walkNodes visits the inner
+			// type_arguments node on its own pass.
+			gaLine := int(n.StartPoint().Row) + 1
+			gaOwner := owner(gaLine)
+			var collectGenericArgs func(*sitter.Node)
+			collectGenericArgs = func(m *sitter.Node) {
+				for i := 0; i < int(m.NamedChildCount()); i++ {
+					c := m.NamedChild(i)
+					if c == nil {
+						continue
+					}
+					switch c.Type() {
+					case "type_identifier":
+						emit(gaOwner, c.Content(src), "generic_arg", graph.EdgeReferences, gaLine)
+					case "type_arguments":
+						// Nested generic — walkNodes visits it separately.
+					default:
+						collectGenericArgs(c)
+					}
+				}
+			}
+			collectGenericArgs(n)
 		}
 	})
 }

--- a/internal/parser/languages/python_refform_test.go
+++ b/internal/parser/languages/python_refform_test.go
@@ -207,6 +207,55 @@ func TestPyRefForm_NegativeCases(t *testing.T) {
 	}
 }
 
+// TestPyRefForm_GenericArgs: element types inside a type-annotation
+// subscript (`List[Foo]`, `Dict[str, Bar]`, nested `Dict[str, List[Foo]]`,
+// and a parameter annotation) emit a "generic_arg" reference to each named
+// type, OriginASTResolved. Builtins (str/int) inside the subscript and a
+// runtime subscript (`arr[0]`) emit NO type reference.
+func TestPyRefForm_GenericArgs(t *testing.T) {
+	src := `from m import Foo, Bar, Baz
+
+xs: List[Foo] = []
+mapping: Dict[str, Bar] = {}
+nested: Dict[str, List[Foo]] = {}
+
+def handle(items: List[Baz]) -> None:
+    arr = [1, 2, 3]
+    return arr[0]
+`
+	_, edges := runPyExtract(t, "app/g.py", src)
+
+	for _, want := range []string{"Foo", "Bar", "Baz"} {
+		e := findRefEdge(edges, graph.EdgeReferences, "unresolved::"+want, "generic_arg")
+		if e == nil {
+			t.Fatalf("expected EdgeReferences -> unresolved::%s (ref_context=generic_arg); edges=%v", want, edgeDump(edges))
+		}
+		if e.Origin != graph.OriginASTResolved {
+			t.Errorf("generic_arg edge for %s Origin = %q, want OriginASTResolved", want, e.Origin)
+		}
+	}
+
+	// The element type inside the parameter annotation is attributed to the
+	// enclosing function, not the file.
+	if e := findRefEdge(edges, graph.EdgeReferences, "unresolved::Baz", "generic_arg"); e != nil && e.From != "app/g.py::handle" {
+		t.Errorf("parameter generic_arg From = %q, want app/g.py::handle", e.From)
+	}
+
+	// Builtins inside the subscript (str, int) must not produce a type ref.
+	for _, bad := range []string{"unresolved::str", "unresolved::int"} {
+		if hasEdgeTo(edges, bad) {
+			t.Errorf("builtin %q inside a subscript must not emit a type reference", bad)
+		}
+	}
+
+	// A runtime subscript `arr[0]` must not emit any generic_arg reference.
+	for _, e := range edges {
+		if uk, _ := e.Meta["ref_context"].(string); uk == "generic_arg" && e.To == "unresolved::arr" {
+			t.Errorf("runtime subscript arr[0] must not emit a generic_arg reference")
+		}
+	}
+}
+
 // edgeDump renders edges compactly for failure messages.
 func edgeDump(edges []*graph.Edge) []string {
 	out := make([]string, 0, len(edges))

--- a/internal/parser/languages/python_typeuse.go
+++ b/internal/parser/languages/python_typeuse.go
@@ -1,6 +1,7 @@
 package languages
 
 import (
+	"strings"
 	"unicode"
 
 	"github.com/zzet/gortex/internal/graph"
@@ -83,9 +84,53 @@ func emitPythonReferenceForms(root *sitter.Node, src []byte, filePath, fileID st
 			emitPyStaticAccessReference(n, src, emit)
 		case "decorator":
 			emitPyDecoratorReference(n, src, emit)
+		case "type_parameter":
+			// Element types inside a type-annotation subscript:
+			// `List[Foo]`, `Dict[str, Bar]`, `Optional[Baz]`,
+			// `Callable[..., Result]`. The annotation pass records only the
+			// canonicalized head (List / Dict / …) and drops the argument
+			// types, so without this they never appear as references.
+			emitPyGenericArgReferences(n, src, emit)
 		}
 		return true
 	})
+}
+
+// emitPyGenericArgReferences emits a "generic_arg" reference for each named
+// type appearing as a direct argument of a type-annotation subscript. The
+// node passed in is always a `type_parameter` — the grammar only produces
+// that inside a `generic_type`, which only appears inside a `type`
+// annotation. That structural nesting is the zero-false-positive gate: a
+// runtime subscript like `arr[0]` / `d[key]` parses as a `subscript` node
+// (never inside a `type`), so this case never fires for it.
+//
+// Each direct child is a `type` node wrapping an identifier (`Foo`), a
+// dotted name (`mod.Qux` — the leaf is the type), an ellipsis (`...` in
+// `Callable[..., R]` — no identifier, naturally skipped), a primitive
+// (`str`/`int` — dropped by the builtin filter at the emit site), or a
+// nested subscript (`List[Foo]` inside `Dict[str, List[Foo]]`). Nesting is
+// handled by the outer walk visiting each nested `type_parameter`
+// independently; here every direct child is run through the shared
+// canonicalizer + capitalization/builtin filter at the emit site, which
+// for a wrapper like `List[Foo]` yields the inner element (`Foo`).
+func emitPyGenericArgReferences(tparam *sitter.Node, src []byte, emit func(string, int, graph.EdgeKind, string)) {
+	line := int(tparam.StartPoint().Row) + 1
+	for i := 0; i < int(tparam.NamedChildCount()); i++ {
+		c := tparam.NamedChild(i)
+		if c == nil || c.Type() != "type" {
+			continue
+		}
+		// The argument's name: an identifier or the leaf of a dotted
+		// attribute. Subscript wrappers / ellipses are left to the
+		// canonicalizer + filter (Optional[X] → X, ... → dropped).
+		name := strings.TrimSpace(c.Content(src))
+		if inner := c.NamedChild(0); inner != nil && inner.Type() == "attribute" {
+			if a := inner.ChildByFieldName("attribute"); a != nil {
+				name = a.Content(src)
+			}
+		}
+		emit(name, line, graph.EdgeReferences, "generic_arg")
+	}
 }
 
 // emitPyCallReference handles a `call` node. Two cases:

--- a/internal/parser/languages/rust_typeuse.go
+++ b/internal/parser/languages/rust_typeuse.go
@@ -57,6 +57,15 @@ func emitRustReferenceForms(root *sitter.Node, funcRanges []funcRange, fileID, f
 	}
 	seen := make(map[string]bool)
 
+	// File-wide set of declared type-parameter names (`<T>`, `<K, V>` on
+	// any fn / impl / struct / enum / trait). A name in this set is a
+	// type-variable, not a real type, so a `type_arguments` member that
+	// names one (`HashMap<K, Bar>` → K) must not become a type reference.
+	// This is the precise signal Rust's grammar otherwise hides: a
+	// type-param is spelled with the same `type_identifier` node as a real
+	// type, so only the declaration site distinguishes them.
+	typeParams := rustDeclaredTypeParams(root, src)
+
 	owner := func(line int) string {
 		if id := findEnclosingFunc(funcRanges, line); id != "" {
 			return id
@@ -211,9 +220,100 @@ func emitRustReferenceForms(root *sitter.Node, funcRanges []funcRange, fileID, f
 			// `#[derive(Foo, Bar)]` — each derive macro name is a static
 			// reference to a trait/derive. Other attributes are ignored.
 			emitRustDeriveRefs(n, owner(line), src, emitRef, line)
+
+		case "type_arguments":
+			// Generic argument list `<Foo>`, `<K, Bar>`, `<Foo, MyError>`,
+			// `<dyn Trait>` — the element types the head wrapper carries.
+			// The annotation / param / return passes only project the head
+			// type of a `generic_type` (and canonicalize drops every arg of
+			// a non-wrapper like HashMap, plus the error arm of Result), so
+			// each arg type a generic mentions is otherwise lost. Emit a
+			// `generic_arg` reference for every named type child here.
+			//
+			// Nesting is handled by the walker: `HashMap<K, Vec<Bar>>` has
+			// an inner `Vec<Bar>` whose own `type_arguments` node this walk
+			// visits separately, so for a `generic_type` arg we record only
+			// its head spelling (Vec) and let that nested visit record Bar.
+			// emitRef's canonicalize + primitive/capitalization gates drop
+			// type-params (K), primitives (i32/str/String), lifetimes, and
+			// lowercase names exactly as the other Rust reference forms do.
+			emitArg := func(spelling string) {
+				canon := canonicalizeRustTypeRef(spelling)
+				if canon == "" || typeParams[canon] {
+					return
+				}
+				emitRef(owner(line), canon, graph.RefContextGenericArg, line)
+			}
+			for i := 0; i < int(n.NamedChildCount()); i++ {
+				c := n.NamedChild(i)
+				if c == nil {
+					continue
+				}
+				switch c.Type() {
+				case "type_identifier", "scoped_type_identifier":
+					emitArg(c.Content(src))
+				case "generic_type":
+					// Record the head only; the nested type_arguments visit
+					// records the inner args. Strip the `<...>` tail so
+					// canonicalize doesn't unwrap a wrapper head to its inner.
+					head := c.Content(src)
+					if idx := strings.IndexByte(head, '<'); idx > 0 {
+						head = head[:idx]
+					}
+					emitArg(head)
+				case "dynamic_type":
+					// `<dyn Trait>` — the dynamic_type case of the outer
+					// switch also fires for this node, but that is the
+					// `inherit` role; record the generic_arg role too.
+					emitArg(c.Content(src))
+				}
+			}
 		}
 		return true
 	})
+}
+
+// rustDeclaredTypeParams returns the set of type-parameter names declared
+// anywhere in the tree (`fn f<T>`, `impl<K, V>`, `struct S<E>`, …). A
+// `type_arguments` member whose name is in this set is a type-variable
+// reference, not a real type, and the generic_arg pass drops it so it
+// never produces a spurious `unresolved::<param>` edge. The set is
+// file-wide rather than per-scope: a `T` used as a generic arg in one fn
+// is overwhelmingly the same `T` the enclosing item declares, and a real
+// one-letter type that happens to collide with a param name elsewhere is
+// vanishingly rare next to the false positives a per-letter heuristic
+// would cause. Lifetimes carry their own node type and are ignored.
+func rustDeclaredTypeParams(root *sitter.Node, src []byte) map[string]bool {
+	params := map[string]bool{}
+	walkRustNodes(root, func(n *sitter.Node) bool {
+		if n.Type() != "type_parameters" {
+			return true
+		}
+		for i := 0; i < int(n.NamedChildCount()); i++ {
+			tp := n.NamedChild(i)
+			if tp == nil {
+				continue
+			}
+			switch tp.Type() {
+			case "lifetime", "const_parameter":
+				continue
+			case "type_identifier":
+				params[strings.TrimSpace(tp.Content(src))] = true
+			default:
+				// Constrained (`<T: Clone>`, `<T = u8>`) — the param name is
+				// the first type_identifier child.
+				for j := 0; j < int(tp.NamedChildCount()); j++ {
+					c := tp.NamedChild(j)
+					if c != nil && c.Type() == "type_identifier" {
+						params[strings.TrimSpace(c.Content(src))] = true
+						break
+					}
+				}
+			}
+		}
+		return true
+	})
+	return params
 }
 
 // emitRustDeriveRefs pulls the derive-macro names out of a

--- a/internal/parser/languages/rust_typeuse_test.go
+++ b/internal/parser/languages/rust_typeuse_test.go
@@ -76,6 +76,61 @@ func TestRustTypeUse_LetBindingWrappers(t *testing.T) {
 	}
 }
 
+// TestRustTypeUse_GenericArgs asserts that the element types inside a
+// generic argument list are captured as `generic_arg` reference edges in
+// every position — a let annotation, a parameter, a return type, and a
+// nested generic — while type-params and primitives are dropped. The
+// annotation / param / return passes only project the head of a
+// `generic_type` (and canonicalize loses every arg of a non-wrapper like
+// HashMap, plus the error arm of Result), so this is the surface those
+// passes leave uncovered.
+func TestRustTypeUse_GenericArgs(t *testing.T) {
+	src := `fn run<K>(m: HashMap<K, Bar>) -> Result<Baz, MyError> {
+    let x: Vec<Foo> = make();
+    let y: HashMap<K, Vec<Inner>> = make();
+    let n: Vec<u8> = bytes();
+    todo!()
+}
+`
+	_, edges := runRustExtract(t, "src/lib.rs", src)
+
+	// let annotation: Vec<Foo> — the element type Foo.
+	if !hasRef(t, edges, "Foo", graph.RefContextGenericArg) {
+		t.Errorf("let x: Vec<Foo> must emit generic_arg → Foo")
+	}
+	// parameter: HashMap<K, Bar> — HashMap is not a wrapper, so the head
+	// pass loses Bar; the generic_arg pass must recover it.
+	if !hasRef(t, edges, "Bar", graph.RefContextGenericArg) {
+		t.Errorf("param HashMap<K, Bar> must emit generic_arg → Bar")
+	}
+	// return type: Result<Baz, MyError> — both arms, including the error
+	// arm canonicalize drops.
+	if !hasRef(t, edges, "Baz", graph.RefContextGenericArg) {
+		t.Errorf("return Result<Baz, MyError> must emit generic_arg → Baz")
+	}
+	if !hasRef(t, edges, "MyError", graph.RefContextGenericArg) {
+		t.Errorf("return Result<Baz, MyError> must emit generic_arg → MyError")
+	}
+	// nested generic: HashMap<K, Vec<Inner>> — the inner element type.
+	if !hasRef(t, edges, "Inner", graph.RefContextGenericArg) {
+		t.Errorf("nested HashMap<K, Vec<Inner>> must emit generic_arg → Inner")
+	}
+
+	// Negatives: a type-parameter (K) and a primitive arg (u8) must never
+	// produce a generic_arg edge.
+	for _, e := range edges {
+		if e.Kind != graph.EdgeReferences || refEdgeUseKind(e) != graph.RefContextGenericArg {
+			continue
+		}
+		switch e.To {
+		case "unresolved::K":
+			t.Errorf("type-parameter K must not emit a generic_arg edge")
+		case "unresolved::u8":
+			t.Errorf("primitive u8 must not emit a generic_arg edge")
+		}
+	}
+}
+
 // TestRustTypeUse_TopLevelLetFallsBackToFile asserts a let binding at the
 // crate root (no enclosing function) attributes its type-use edge to the
 // file node rather than dropping it.

--- a/internal/parser/languages/scala_refform_test.go
+++ b/internal/parser/languages/scala_refform_test.go
@@ -137,6 +137,48 @@ class User {
 	}
 }
 
+// TestScalaRefFormGenericArgs covers Scala's square-bracket generic arguments
+// (`List[Foo]`, `Map[String, Bar]`, `Future[Seq[Repo]]`, parameterized
+// supertypes) across every position. The type-annotation pass keeps only the
+// container head or the single unwrapped element, so an argument in a non-unwrap
+// slot or nested deeper would never surface to find_usages without these
+// generic_arg reference edges.
+func TestScalaRefFormGenericArgs(t *testing.T) {
+	src := `
+package demo
+class Repo extends Base[Scope] with Mixin[Region] {
+  val one: List[Widget] = Nil
+  var lookup: Map[String, Account] = Map()
+  def f(a: Set[Audit], b: Seq[Log]): Option[Result] = None
+  val deep: Map[String, List[Invoice]] = Map()
+  val nested: Future[Seq[Tenant]] = null
+}
+`
+	edges := extractScalaRefEdges(t, src)
+
+	// Every element type, in every position, surfaces as a generic_arg ref.
+	for _, want := range []string{
+		"Scope",   // supertype type-arg:  extends Base[Scope]
+		"Region",  // mixin type-arg:      with Mixin[Region]
+		"Widget",  // val annotation:      List[Widget]
+		"Account", // var annotation slot: Map[String, Account]
+		"Audit",   // parameter:           Set[Audit]
+		"Log",     // parameter:           Seq[Log]
+		"Result",  // return type:         Option[Result]
+		"Invoice", // deep-nested:         Map[String, List[Invoice]]
+		"Tenant",  // nested:              Future[Seq[Tenant]]
+	} {
+		if !scalaHasRefEdge(edges, want, graph.EdgeReferences, graph.RefContextGenericArg) {
+			t.Errorf("expected generic_arg ref to %s, got %+v", want, edges)
+		}
+	}
+
+	// The String key of every Map is a primitive — filtered everywhere.
+	if countRefEdgesTo(edges, "String") != 0 {
+		t.Errorf("primitive String key must not emit a generic_arg ref, got %+v", edges)
+	}
+}
+
 func TestScalaRefFormNegatives(t *testing.T) {
 	src := `
 package demo

--- a/internal/parser/languages/scala_reffrm.go
+++ b/internal/parser/languages/scala_reffrm.go
@@ -145,6 +145,27 @@ func emitScalaReferenceForms(root *sitter.Node, filePath string, src []byte, res
 			}
 			line := int(n.StartPoint().Row) + 1
 			emit(ownerAt(line), name, filePath, line, graph.EdgeReferences, graph.RefContextStaticAccess)
+		case "generic_type":
+			// `List[Foo]`, `Map[String, Bar]`, `Future[Seq[Repo]]`, … — every
+			// type argument is a use of the named element type. The type-
+			// annotation pass only keeps the container head (`Map`) or the single
+			// unwrapped element (`Option[User]` -> `User`), so an argument in a
+			// non-unwrap position (`Map[String, Bar]` -> `Bar`) or a deeper-nested
+			// argument (`Map[String, List[Account]]` -> `Account`) would otherwise
+			// never surface to find_usages. This case emits a generic_arg
+			// reference for each direct argument's named head; nested
+			// `generic_type` arguments are revisited by the walker, so their own
+			// arguments are covered too.
+			//
+			// Fires for a `generic_type` in any position — val/var annotation,
+			// parameter, return type, a supertype in `extends_clause`, an
+			// isInstanceOf/asInstanceOf or pattern target, or nested inside
+			// another generic — because walkNodes visits them all.
+			line := int(n.StartPoint().Row) + 1
+			owner := ownerAt(line)
+			for _, arg := range scalaGenericArgHeads(n, src) {
+				emit(owner, arg, filePath, line, graph.EdgeReferences, graph.RefContextGenericArg)
+			}
 		}
 	})
 }
@@ -241,6 +262,58 @@ func scalaTypeArgNames(n *sitter.Node, src []byte) []string {
 		}
 	}
 	return out
+}
+
+// scalaGenericArgHeads returns the head type name of every direct argument in a
+// `generic_type` node's `type_arguments` child. A leaf `type_identifier`
+// argument (`Foo`) yields its bare name; a nested `generic_type` argument
+// (`Seq[Repo]`) yields its container head (`Seq`) — the walker revisits the
+// nested node so its own arguments (`Repo`) are captured on that visit. Other
+// type forms (tuple / function / wildcard arguments) are skipped. The emit
+// closure canonicalizes (dotted prefix / single-arg container unwrap) and
+// filters primitives, so this helper only locates the argument heads.
+func scalaGenericArgHeads(n *sitter.Node, src []byte) []string {
+	var out []string
+	for i := 0; i < int(n.NamedChildCount()); i++ {
+		ta := n.NamedChild(i)
+		if ta == nil || ta.Type() != "type_arguments" {
+			continue
+		}
+		for j := 0; j < int(ta.NamedChildCount()); j++ {
+			arg := ta.NamedChild(j)
+			if arg == nil {
+				continue
+			}
+			switch arg.Type() {
+			case "type_identifier", "stable_type_identifier", "projected_type":
+				if name := strings.TrimSpace(arg.Content(src)); name != "" {
+					out = append(out, name)
+				}
+			case "generic_type":
+				// Emit the nested container head (`Seq` of `Seq[Repo]`); the
+				// walker visits this nested node separately for its own args.
+				if head := scalaGenericHead(arg, src); head != "" {
+					out = append(out, head)
+				}
+			}
+		}
+	}
+	return out
+}
+
+// scalaGenericHead returns the head type_identifier text of a `generic_type`
+// node (`Seq[Repo]` -> "Seq"), or "".
+func scalaGenericHead(n *sitter.Node, src []byte) string {
+	for i := 0; i < int(n.NamedChildCount()); i++ {
+		c := n.NamedChild(i)
+		if c == nil {
+			continue
+		}
+		if c.Type() == "type_identifier" {
+			return strings.TrimSpace(c.Content(src))
+		}
+	}
+	return ""
 }
 
 // scalaPatternType returns the type a typed_pattern matches against

--- a/internal/parser/languages/swift_refform_test.go
+++ b/internal/parser/languages/swift_refform_test.go
@@ -153,6 +153,65 @@ func TestSwiftExtractor_StaticAccess(t *testing.T) {
 	}
 }
 
+func TestSwiftExtractor_GenericArgs(t *testing.T) {
+	// Element types named inside a generic argument clause (`Array<Foo>`,
+	// `Dictionary<String, Foo>`, `Result<Foo, E>`) or the array / dictionary
+	// sugar (`[Foo]`, `[K: Foo]`) are lost by the type-annotation pass (which
+	// normalises a type to its head and drops the `<…>` args). The reference
+	// form must recover each element type as an EdgeReferences ref_context=
+	// generic_arg in every type position — a var / property annotation, a
+	// parameter, and a (nested) return type — while a primitive argument
+	// (`Array<Int>`) emits nothing.
+	src := []byte(`func build(items: [Widget], lookup: Dictionary<String, Cache>) {
+    let xs: Array<Element> = []
+    let ns: Array<Int> = []
+}
+func make() -> Result<Box<Inner>, MyError> {
+    fatalError()
+}
+`)
+	res, err := NewSwiftExtractor().Extract("g.swift", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Var / property annotation inside build(): `Array<Element>` → Element.
+	if !swiftRefEdge(res.Edges, "g.swift::build", "Element", graph.EdgeReferences, "generic_arg") {
+		t.Errorf("expected generic_arg edge build -> Element for `Array<Element>`; edges=%v", res.Edges)
+	}
+	// Parameter array sugar `[Widget]` → Widget.
+	if !swiftRefEdge(res.Edges, "g.swift::build", "Widget", graph.EdgeReferences, "generic_arg") {
+		t.Errorf("expected generic_arg edge build -> Widget for `[Widget]`; edges=%v", res.Edges)
+	}
+	// Parameter generic `Dictionary<String, Cache>` → Cache (String dropped).
+	if !swiftRefEdge(res.Edges, "g.swift::build", "Cache", graph.EdgeReferences, "generic_arg") {
+		t.Errorf("expected generic_arg edge build -> Cache for `Dictionary<String, Cache>`; edges=%v", res.Edges)
+	}
+	// Nested return generic `Result<Box<Inner>, MyError>`: the outer clause
+	// contributes Box and MyError; the walker visits the inner `<Inner>`
+	// clause separately for Inner.
+	for _, typ := range []string{"Box", "MyError", "Inner"} {
+		if !swiftRefEdge(res.Edges, "g.swift::make", typ, graph.EdgeReferences, "generic_arg") {
+			t.Errorf("expected generic_arg edge make -> %s in `Result<Box<Inner>, MyError>`; edges=%v", typ, res.Edges)
+		}
+	}
+
+	// A primitive generic argument (`Array<Int>`) must NOT emit a generic_arg
+	// reference; String (the dictionary key) must not either.
+	for _, e := range res.Edges {
+		if e.Kind != graph.EdgeReferences || e.Meta == nil {
+			continue
+		}
+		if uk, _ := e.Meta["ref_context"].(string); uk != "generic_arg" {
+			continue
+		}
+		switch e.To {
+		case "unresolved::Int", "unresolved::String":
+			t.Errorf("primitive generic argument must NOT produce a generic_arg edge; got %v", e)
+		}
+	}
+}
+
 func TestSwiftExtractor_ReferenceFormNegatives(t *testing.T) {
 	// Nothing in this function names a user type via a reference form: a
 	// lowercase call, a self access, and a primitive annotation must each

--- a/internal/parser/languages/swift_typeuse.go
+++ b/internal/parser/languages/swift_typeuse.go
@@ -29,6 +29,12 @@ import (
 //     navigation_expression whose head is a bare Capitalized simple_identifier
 //     (not self / a lowercase value binding). Emitted as EdgeReferences with
 //     ref_context "static_access".
+//   - GENERIC TYPE ARGUMENTS / COLLECTION ELEMENTS — the element types named
+//     inside a generic argument clause (`Array<Foo>`, `Dictionary<String, Foo>`,
+//     `Result<Foo, E>`) or the array / dictionary sugar (`[Foo]`, `[K: Foo]`),
+//     in every type position. The type-annotation pass normalises a type to its
+//     head and strips the `<…>` args, so these element types would otherwise be
+//     lost. Emitted as EdgeReferences with ref_context "generic_arg".
 //
 // Every structural EdgeReferences edge is stamped Origin
 // graph.OriginASTResolved: cross_pkg_guard reverts weak-tier (text_matched /
@@ -143,6 +149,32 @@ func emitSwiftReferenceForms(root *sitter.Node, src []byte, filePath, fileID str
 			if name := swiftStaticAccessHead(n, src); name != "" {
 				line := int(n.StartPoint().Row) + 1
 				emit(owner(line), name, line, graph.EdgeReferences, graph.RefContextStaticAccess)
+			}
+
+		case "type_arguments", "array_type", "dictionary_type":
+			// GENERIC TYPE ARGUMENTS / COLLECTION ELEMENTS: the element types
+			// named inside a generic argument list (`Array<Foo>` → Foo,
+			// `Dictionary<String, Foo>` → Foo) or the array / dictionary sugar
+			// (`[Foo]` → Foo, `[K: Foo]` → Foo) — in every type position
+			// (annotation, parameter, return, supertype, cast), since the
+			// Swift grammar lowers each of those positions through a
+			// `user_type` whose generic clause is one of these nodes.
+			//
+			// Each direct `user_type` child contributes its head type name;
+			// `swiftBaseTypeName` (via emit) reduces a nested generic element
+			// (`Array<Result<Foo, E>>` → Result for the direct child) to its
+			// constructor, and the walker visits that element's own nested
+			// `type_arguments` separately, so Foo / E are captured one level
+			// down without recursing here. Primitives / lowercase names are
+			// dropped by emit, so a `[String]` or `Array<Int>` adds nothing.
+			line := int(n.StartPoint().Row) + 1
+			ownerID := owner(line)
+			for i := 0; i < int(n.NamedChildCount()); i++ {
+				c := n.NamedChild(i)
+				if c == nil || c.Type() != "user_type" {
+					continue
+				}
+				emit(ownerID, c.Content(src), line, graph.EdgeReferences, "generic_arg")
 			}
 		}
 	})

--- a/internal/search/rerank/canonical_pick_test.go
+++ b/internal/search/rerank/canonical_pick_test.go
@@ -1,0 +1,99 @@
+package rerank
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// addCallers wires n incoming EdgeCalls into target so the fan-in signal
+// sees it as load-bearing. Caller nodes are throwaway functions.
+func addCallers(g *graph.Graph, targetID, prefix string, n int) {
+	for i := range n {
+		cid := prefix + strconv.Itoa(i)
+		g.AddNode(&graph.Node{ID: cid, Name: cid, Kind: graph.KindFunction, FilePath: "callers.go"})
+		g.AddEdge(&graph.Edge{From: cid, To: targetID, Kind: graph.EdgeCalls})
+	}
+}
+
+func rankOf(out []*Candidate, id string) int {
+	for i, c := range out {
+		if c.Node.ID == id {
+			return i
+		}
+	}
+	return -1
+}
+
+func idOrder(out []*Candidate) string {
+	var b strings.Builder
+	for i, c := range out {
+		if i > 0 {
+			b.WriteString(" > ")
+		}
+		b.WriteString(c.Node.ID)
+	}
+	return b.String()
+}
+
+func scoreOf(out []*Candidate, id string) float64 {
+	for _, c := range out {
+		if c.Node.ID == id {
+			return c.Score
+		}
+	}
+	return -1
+}
+
+// TestCanonicalPick_TypeBeatsMethodForTypeQuery: a bare "Session" query must
+// land on the type `Session`, not a `urlSession` method that merely shares the
+// camelCase token — even when the method is more heavily called and BM25-ranked
+// ahead. Mirrors the resolver's bestTypeCandidate canonical pick on the search
+// side. Adversarial: the method gets the better BM25 rank AND far more fan-in.
+func TestCanonicalPick_TypeBeatsMethodForTypeQuery(t *testing.T) {
+	g := newTestGraph()
+	sess := mustNode(g, "net/session.go::Session", "Session", graph.KindType)
+	sess.FilePath = "net/session.go"
+	urlSess := mustNode(g, "net/client.go::urlSession", "urlSession", graph.KindMethod)
+	urlSess.FilePath = "net/client.go"
+
+	addCallers(g, urlSess.ID, "callurl", 30)
+	addCallers(g, sess.ID, "refsess", 1)
+
+	// Stack the deck against the type: the method is BM25 #1.
+	cands := []*Candidate{
+		candidateFor(urlSess, 0, -1),
+		candidateFor(sess, 1, -1),
+	}
+	out := NewDefault().Rerank("Session", cands, &Context{Graph: g})
+	if rankOf(out, sess.ID) != 0 {
+		t.Fatalf("expected type Session ranked #1 for query \"Session\"; got %s (Session=%.3f urlSession=%.3f)",
+			idOrder(out), scoreOf(out, sess.ID), scoreOf(out, urlSess.ID))
+	}
+}
+
+// TestCanonicalPick_ProductionBeatsTestDef: a bare "Model" query must land on
+// the production type, not a same-named definition in a _test.go file — even
+// when the test fixture is BM25 #1 and more heavily referenced.
+func TestCanonicalPick_ProductionBeatsTestDef(t *testing.T) {
+	g := newTestGraph()
+	prod := mustNode(g, "app/model.go::Model", "Model", graph.KindType)
+	prod.FilePath = "app/model.go"
+	test := mustNode(g, "app/model_test.go::Model", "Model", graph.KindType)
+	test.FilePath = "app/model_test.go"
+
+	addCallers(g, test.ID, "reftest", 15)
+	addCallers(g, prod.ID, "refprod", 1)
+
+	cands := []*Candidate{
+		candidateFor(test, 0, -1),
+		candidateFor(prod, 1, -1),
+	}
+	out := NewDefault().Rerank("Model", cands, &Context{Graph: g})
+	if rankOf(out, prod.ID) != 0 {
+		t.Fatalf("expected production Model ranked #1 for query \"Model\"; got %s (prod=%.3f test=%.3f)",
+			idOrder(out), scoreOf(out, prod.ID), scoreOf(out, test.ID))
+	}
+}


### PR DESCRIPTION
## Summary

Two changes that make `find_usages` / `get_callers` return complete results sooner and more completely.

### Mark the daemon ready once references resolve; enrich in the background
The same-repo type-ref resolve ran at the tail of the daemon batch-warmup deferred passes — **after** the multi-minute semantic enrichment. So immediately after indexing, `find_usages` on a widely-imported type returned incomplete results (edges still pointed at `unresolved::` placeholders) for minutes, and non-deterministically, until enrichment finished.

- A new `RunPreEnrichResolve` (go.mod dep nodes + same-repo master resolve + cross-repo resolve) runs right after the parallel parse, and the daemon marks itself **ready** there — references are correct as soon as the graph is queryable, independent of enrichment.
- `ready` now means *"references resolved / graph queryable"*; a new **`enriched`** state means *"fully warmed"*. Enrichment, contracts, the global derivation passes, and analysis continue in the background and finish at a distinct `enrichment_complete` signal.
- `StatusResponse` gains `enrichment_complete` + `enrich_seconds`; `gortex daemon status` and the SessionStart hook render the queryable-but-enriching state; the readiness push channel ends at `enrichment_complete`.
- The periodic snapshotter now gates on `IsEnriched` (not `IsReady`), so the earlier ready flip does not reintroduce a mid-enrichment snapshot stall.

### Capture Kotlin generic type arguments as type-use references
The Kotlin type-annotation / function-shape passes normalize a type to its head and strip the `<…>` arguments, so `List<OkHttpClient>`, `Map<String, Interceptor>`, `Lazy<Response>` recorded a reference to the container type but **lost the element types**. A new `type_arguments` case in the Kotlin reference-forms walker emits a `generic_arg` reference for every type named inside a type-argument block, in any position (annotation, parameter, return, supertype, cast, explicit call type-arg, nested). Primitives and lowercase names are dropped by the existing normalizer, so the form is zero-false-positive.

## Verification
- CGO build green; `go vet` clean; `golangci-lint` 0 issues.
- Tests pass: `internal/indexer`, `cmd/gortex`, `internal/daemon`, `internal/hooks`, `internal/mcp` (warmup / readiness / catalog goldens), `internal/parser/languages`.

### Search-ranking regression tests for canonical definition selection
Adds full-pipeline rerank tests asserting a bare type-name query ranks the exact-name type above a heavily-called partial-match method (`Session` vs `urlSession`) and a production definition above a same-named one in a `_test.go` file (`Model` vs test `Model`) — both hold even under adversarial BM25 + fan-in conditions. Confirms the "search picks the wrong definition" symptom was a pre-resolution probe artifact (edge-derived ranking signals incomplete before resolution), the same class as the timing bug fixed above — not a ranking-logic defect.

### Broaden generic type-argument type-use coverage across languages
The per-language type-annotation passes normalize a type to its head and strip the generic `<…>` (or `[…]`) arguments, so element types in `List<Foo>`, `Map<K, Foo>`, `Lazy<Foo>`, `Foo[]`, `List[Foo]` (Python/Scala), `map[K]V` / `chan E` (Go) were lost — `find_usages(Foo)` missed every site where `Foo` appears only as a type argument. Each language now emits a `generic_arg` reference for every type named in a generic-argument position, in all positions (annotation, parameter, return, supertype, cast, nested), reusing the language's own type-name normalizer so primitives/lowercase/type-params are dropped (zero false positives). One commit per language: **kotlin, swift, python, c#, c++, java, dart, scala, go, rust**. **TypeScript** and **PHP** were already complete / not applicable (TS's `tsTypeRefs` already recurses generic args; PHP has no native generics).
