### PR TITLE
Improve type-use completeness: TypeScript JSX/heritage refs + Swift parse-error recovery

### DIFF
--- a/internal/parser/languages/swift.go
+++ b/internal/parser/languages/swift.go
@@ -104,6 +104,16 @@ func (e *SwiftExtractor) Extract(filePath string, src []byte) (*parser.Extractio
 	// type_identifier), so seed their ranges first; members inside an
 	// `extension Foo { ... }` then attribute to Foo like any other type member.
 	typeRanges = append(typeRanges, swiftExtensionRanges(src)...)
+	// Resilience net for parse errors: a tree-sitter error inside a type body
+	// (e.g. an unparseable `#if … && !canImport(...)`) can corrupt the enclosing
+	// class_declaration so the query never matches it — its members and every
+	// reference to the type would then strand on unresolved::Name. Seed the
+	// container ranges from a brace-matched text scan so members still attribute;
+	// gaps the query misses get a fallback container node after the match loop.
+	fallbackTypes := swiftFallbackTypeDecls(src)
+	for _, ft := range fallbackTypes {
+		typeRanges = append(typeRanges, swiftTypeRange{name: ft.name, startLine: ft.startLine, endLine: ft.endLine})
+	}
 	var calls []swiftDeferredCall
 
 	parser.EachMatch(e.qAll, root, src, func(m parser.QueryResult) {
@@ -148,6 +158,26 @@ func (e *SwiftExtractor) Extract(filePath string, src []byte) (*parser.Extractio
 			})
 		}
 	})
+
+	// Emit fallback container nodes for class/struct/actor/enum declarations the
+	// query missed (parse-error regions). `seen` already holds every container
+	// the query emitted, so this only fills gaps and never duplicates.
+	for _, ft := range fallbackTypes {
+		id := filePath + "::" + ft.name
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		result.Nodes = append(result.Nodes, &graph.Node{
+			ID: id, Kind: graph.KindType, Name: ft.name,
+			FilePath: filePath, StartLine: ft.startLine + 1, EndLine: ft.endLine + 1,
+			Language: "swift",
+			Meta:     map[string]any{"visibility": ft.visibility},
+		})
+		result.Edges = append(result.Edges, &graph.Edge{
+			From: fileID, To: id, Kind: graph.EdgeDefines, FilePath: filePath, Line: ft.startLine + 1,
+		})
+	}
 
 	// Stamp protocol method names onto protocol nodes' Meta["methods"].
 	for _, n := range result.Nodes {
@@ -621,6 +651,56 @@ func swiftExtensionRanges(src []byte) []swiftTypeRange {
 		})
 	}
 	return ranges
+}
+
+// swiftTypeDeclRe matches a class / struct / actor / enum declaration header at
+// the start of a line, capturing the type name. Leading attributes (`@objc`)
+// and access/other modifiers are skipped. Used as a parse-error resilience net
+// (see swiftFallbackTypeDecls).
+var swiftTypeDeclRe = regexp.MustCompile(`(?m)^[ \t]*(?:@[A-Za-z_]\w*(?:\([^)]*\))?[ \t]+)*(?:(?:public|private|internal|fileprivate|open|final|indirect)[ \t]+)*(?:class|struct|actor|enum)[ \t]+([A-Za-z_]\w*)`)
+
+type swiftFallbackType struct {
+	name       string
+	startLine  int // 0-based
+	endLine    int // 0-based
+	visibility string
+}
+
+// swiftFallbackTypeDecls finds class / struct / actor / enum declarations by a
+// brace-matched text scan — the resilience net for when a tree-sitter parse
+// error (e.g. an unparseable `#if … && !canImport(...)` inside a body) corrupts
+// the enclosing class_declaration so the query never matches it. Without this
+// the container node is absent and its members + every find_usages reference to
+// the type strand on unresolved::Name. Mirrors swiftExtensionRanges.
+func swiftFallbackTypeDecls(src []byte) []swiftFallbackType {
+	s := string(src)
+	var out []swiftFallbackType
+	for _, loc := range swiftTypeDeclRe.FindAllStringSubmatchIndex(s, -1) {
+		name := s[loc[2]:loc[3]]
+		rel := strings.IndexByte(s[loc[1]:], '{')
+		if rel < 0 {
+			continue
+		}
+		open := loc[1] + rel
+		end := swiftMatchBrace(s, open)
+		if end < 0 {
+			continue
+		}
+		vis := VisibilityInternal
+		switch prefix := s[loc[0]:loc[1]]; {
+		case strings.Contains(prefix, "public"), strings.Contains(prefix, "open"):
+			vis = VisibilityPublic
+		case strings.Contains(prefix, "private"), strings.Contains(prefix, "fileprivate"):
+			vis = VisibilityPrivate
+		}
+		out = append(out, swiftFallbackType{
+			name:       name,
+			startLine:  strings.Count(s[:open], "\n"),
+			endLine:    strings.Count(s[:end], "\n"),
+			visibility: vis,
+		})
+	}
+	return out
 }
 
 // swiftMatchBrace returns the index of the '}' that closes the '{' at open, or

--- a/internal/parser/languages/swift_classtwin_test.go
+++ b/internal/parser/languages/swift_classtwin_test.go
@@ -1,0 +1,93 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+)
+
+func swiftHasType(t *testing.T, src, name string) bool {
+	t.Helper()
+	res, err := NewSwiftExtractor().Extract("S.swift", []byte(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, n := range res.Nodes {
+		if n.Kind == graph.KindType && n.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSwiftExtractor_ParseErrorContainerFallback: when a construct inside a
+// type body defeats the tree-sitter grammar (here a compound
+// `#if … && !canImport(...)`), the enclosing class_declaration is corrupted and
+// the query never matches it. The brace-matched fallback must still emit the
+// container node — otherwise the type and every reference to it strand on
+// unresolved::Name (the alamofire Session 0-vs-449 bug). Self-proving: it only
+// asserts the fallback while the grammar genuinely errors on this body; if a
+// future grammar parses it cleanly the query covers the container and we skip.
+func TestSwiftExtractor_ParseErrorContainerFallback(t *testing.T) {
+	src := `open class Session: @unchecked Sendable {
+    public let session: URLSession
+
+    func send() {
+        #if compiler(>=6) && !canImport(FoundationNetworking)
+        doThing()
+        #endif
+    }
+}`
+	e := NewSwiftExtractor()
+	tree, err := parser.ParseFile([]byte(src), e.lang)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hasErr := tree.RootNode().HasError()
+	tree.Close()
+	if !hasErr {
+		t.Skip("grammar parses this body cleanly now; fallback path not exercised")
+	}
+
+	res, err := e.Extract("S.swift", []byte(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotType := false
+	for _, n := range res.Nodes {
+		if n.Kind == graph.KindType && n.Name == "Session" {
+			gotType = true
+		}
+		// The case-twin member must attribute to the container, not leak as a
+		// file-scope constant.
+		if n.ID == "S.swift::session" {
+			t.Errorf("stray file-scope ::session constant emitted (member not attributed to Session)")
+		}
+	}
+	if !gotType {
+		t.Errorf("class Session container node not emitted under a body parse error (fallback failed)")
+	}
+}
+
+// TestSwiftExtractor_CleanClassStillEmitted guards the common path: a clean
+// class (no parse error) is still emitted exactly once, not duplicated by the
+// fallback.
+func TestSwiftExtractor_CleanClassStillEmitted(t *testing.T) {
+	src := `public final class Widget {
+    let name: String
+}`
+	if !swiftHasType(t, src, "Widget") {
+		t.Errorf("clean class Widget not emitted")
+	}
+	res, _ := NewSwiftExtractor().Extract("S.swift", []byte(src))
+	n := 0
+	for _, node := range res.Nodes {
+		if node.Kind == graph.KindType && node.Name == "Widget" {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Errorf("clean class Widget emitted %d times, want 1 (fallback double-emit?)", n)
+	}
+}

--- a/internal/parser/languages/ts_function_shape.go
+++ b/internal/parser/languages/ts_function_shape.go
@@ -557,6 +557,17 @@ func tsTypeRefs(typeText string) []string {
 		if t == "" {
 			return
 		}
+		// Indexed-access (lookup) type `T[K]` — distinct from the array
+		// suffix `T[]` already stripped above. The object type T is a real
+		// reference (`ExcalidrawElement["type"]` references ExcalidrawElement);
+		// a non-literal key (`T[Key]`) is a type reference too, a string /
+		// number literal key is dropped by addTSRef. Split at the matching
+		// top-level `[` so the wrapped object type and the key both surface.
+		if obj, key, ok := splitTSLookupType(t); ok {
+			walk(obj)
+			walk(key)
+			return
+		}
 		if parts := splitTSUnionType(t); len(parts) > 1 {
 			for _, p := range parts {
 				walk(p)
@@ -643,6 +654,44 @@ func splitTSTypeArgs(s string) []string {
 		parts = append(parts, last)
 	}
 	return parts
+}
+
+// splitTSLookupType decomposes an indexed-access (lookup) type `T[K]` into
+// its object type T and key K. It only fires when the trailing `[…]` is a
+// non-empty index whose opening `[` is at top-level (not inside a generic
+// argument or nested bracket) — the array suffix `T[]` is empty and is
+// stripped by the caller before this runs, so it never matches here.
+// Returns (object, key, true) on a lookup type, ("", "", false) otherwise.
+func splitTSLookupType(t string) (string, string, bool) {
+	t = strings.TrimSpace(t)
+	if len(t) < 3 || !strings.HasSuffix(t, "]") {
+		return "", "", false
+	}
+	// Find the matching `[` for the trailing `]`, respecting nesting.
+	depth := 0
+	open := -1
+	for i := len(t) - 1; i >= 0; i-- {
+		switch t[i] {
+		case ']', ')', '}', '>':
+			depth++
+		case '[', '(', '{', '<':
+			depth--
+			if depth == 0 {
+				open = i
+				goto found
+			}
+		}
+	}
+found:
+	if open <= 0 {
+		return "", "", false
+	}
+	obj := strings.TrimSpace(t[:open])
+	key := strings.TrimSpace(t[open+1 : len(t)-1])
+	if obj == "" || key == "" {
+		return "", "", false
+	}
+	return obj, key, true
 }
 
 // emitTSGenericParamNodes turns a TS function/class declaration's

--- a/internal/parser/languages/ts_reffrm.go
+++ b/internal/parser/languages/ts_reffrm.go
@@ -1,0 +1,351 @@
+package languages
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	sitter "github.com/zzet/gortex/internal/parser/tsitter"
+)
+
+// emitTSReferenceForms walks a parsed TS / TSX file and emits the
+// usage-counted reference edges for the TypeScript forms the type-use,
+// cast, and render passes don't already cover. Every edge it produces is
+// an EdgeReferences / EdgeExtends / EdgeImplements — kinds find_usages
+// treats as a usage — so a type or component named only in one of these
+// positions still lands cross-file on a no-LSP name-based index:
+//
+//   - JSX element names (`<App/>`, `<App>…</App>`, `<Foo.Bar/>`) →
+//     EdgeReferences, ref_context="jsx". The existing EdgeRendersChild
+//     pass records the parent→child component tree but rides on a kind
+//     find_usages ignores and only fires inside function bodies; this
+//     pass covers file-scope JSX too and emits the usage edge so
+//     find_usages(App) surfaces the render site. Capitalised / qualified
+//     names are components; lowercase intrinsic HTML elements are skipped.
+//   - type-only import bindings (`import type { X }`, `import { type X }`)
+//     → EdgeReferences, ref_context="import_type". The name is a type
+//     used here, distinct from the module-level EdgeImports dependency.
+//   - type-only re-export bindings (`export type { X } from`,
+//     `export { type X } from`) → EdgeReferences, ref_context="export_type".
+//   - class / interface heritage (`class App extends Base implements I`,
+//     `interface Y extends Z`) → EdgeExtends / EdgeImplements.
+//
+// Decomposition / primitive + container dropping for heritage type
+// arguments is delegated to tsTypeRefs (same gate as every other TS
+// type-use form), so primitives, builtins, and lowercase non-components
+// never become bogus targets. De-duplicated per (owner, kind, name, line).
+func emitTSReferenceForms(root *sitter.Node, src []byte, filePath, fileID string, funcRanges []funcRange, result *parser.ExtractionResult) {
+	if root == nil {
+		return
+	}
+	seen := map[string]bool{}
+	emit := func(ownerID, name string, kind graph.EdgeKind, refContext string, line int) {
+		if ownerID == "" || name == "" {
+			return
+		}
+		key := ownerID + "\x00" + string(kind) + "\x00" + name + "\x00" + strconv.Itoa(line)
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		result.Edges = append(result.Edges, &graph.Edge{
+			From:     ownerID,
+			To:       "unresolved::" + name,
+			Kind:     kind,
+			FilePath: filePath,
+			Line:     line,
+			Origin:   graph.OriginASTResolved,
+			Meta:     map[string]any{"ref_context": refContext},
+		})
+	}
+	ownerFor := func(line int) string {
+		if owner := findEnclosingFunc(funcRanges, line); owner != "" {
+			return owner
+		}
+		return fileID
+	}
+
+	walkTSNodes(root, func(n *sitter.Node) bool {
+		switch n.Type() {
+		case "jsx_opening_element", "jsx_self_closing_element":
+			// jsx_element wraps a jsx_opening_element child; visiting the
+			// opening element directly covers both `<App>…</App>` and
+			// `<App/>` without double-emitting (the closing tag carries the
+			// same name but the dedup key collapses it anyway — and we only
+			// match opening / self-closing here).
+			if name := jsxElementName(n, src); name != "" && isJSXComponentName(name) {
+				line := int(n.StartPoint().Row) + 1
+				emit(ownerFor(line), name, graph.EdgeReferences, "jsx", line)
+			}
+		case "import_statement":
+			emitTSTypeOnlyImportRefs(n, src, fileID, graph.EdgeReferences, "import_type", emit)
+		case "export_statement":
+			emitTSTypeOnlyExportRefs(n, src, fileID, graph.EdgeReferences, "export_type", emit)
+		case "class_declaration", "class":
+			emitTSClassHeritageRefs(n, src, filePath, emit)
+		case "interface_declaration":
+			emitTSInterfaceHeritageRefs(n, src, filePath, emit)
+		}
+		return true
+	})
+}
+
+// emitTSTypeOnlyImportRefs emits one reference edge per type-only import
+// binding. Two shapes carry the `type` modifier:
+//
+//	import type { Foo, Bar } from "mod"   // statement-level: every binding is a type
+//	import { type Foo, value } from "mod" // specifier-level: only `type Foo` is a type
+//
+// A value import (`import { value }`) is intentionally not referenced —
+// `value` is already a call / read at its use sites; only the type-only
+// form names a type purely in import position with no other use edge.
+func emitTSTypeOnlyImportRefs(importNode *sitter.Node, src []byte, fileID string, kind graph.EdgeKind, refContext string, emit func(ownerID, name string, kind graph.EdgeKind, refContext string, line int)) {
+	stmtTypeOnly := tsImportStatementTypeOnly(importNode, src)
+	named := jsNamedImportsNode(importNode)
+	if named == nil {
+		return
+	}
+	for i := 0; i < int(named.NamedChildCount()); i++ {
+		spec := named.NamedChild(i)
+		if spec == nil || spec.Type() != "import_specifier" {
+			continue
+		}
+		if !stmtTypeOnly && !tsSpecifierTypeOnly(spec, src) {
+			continue
+		}
+		orig, _ := jsSpecifierNames(spec, src)
+		if orig == "" || isTSPrimitive(orig) || !isTSTypeName(orig) {
+			continue
+		}
+		emit(fileID, orig, kind, refContext, int(spec.StartPoint().Row)+1)
+	}
+}
+
+// emitTSTypeOnlyExportRefs mirrors emitTSTypeOnlyImportRefs for re-export
+// statements (`export type { X } from`, `export { type X } from`). A
+// type-only re-export names the original type, so the barrel file
+// references it — find_usages(X) should surface the forwarding site.
+func emitTSTypeOnlyExportRefs(exportNode *sitter.Node, src []byte, fileID string, kind graph.EdgeKind, refContext string, emit func(ownerID, name string, kind graph.EdgeKind, refContext string, line int)) {
+	clause := findChildByType(exportNode, "export_clause")
+	if clause == nil {
+		return
+	}
+	stmtTypeOnly := tsExportStatementTypeOnly(exportNode, src)
+	for i := 0; i < int(clause.NamedChildCount()); i++ {
+		spec := clause.NamedChild(i)
+		if spec == nil || spec.Type() != "export_specifier" {
+			continue
+		}
+		if !stmtTypeOnly && !tsSpecifierTypeOnly(spec, src) {
+			continue
+		}
+		orig, _ := jsSpecifierNames(spec, src)
+		if orig == "" || isTSPrimitive(orig) || !isTSTypeName(orig) {
+			continue
+		}
+		emit(fileID, orig, kind, refContext, int(spec.StartPoint().Row)+1)
+	}
+}
+
+// tsImportStatementTypeOnly reports whether an import_statement carries
+// the statement-level `type` modifier (`import type { … } from`). The
+// grammar exposes it as a bare `type` keyword token between `import` and
+// the import_clause rather than a named field, so scan the statement's
+// raw children for it, stopping at the clause body.
+func tsImportStatementTypeOnly(importNode *sitter.Node, src []byte) bool {
+	for i := 0; i < int(importNode.ChildCount()); i++ {
+		c := importNode.Child(i)
+		if c == nil {
+			continue
+		}
+		if c.Type() == "import_clause" {
+			break
+		}
+		if c.Type() == "type" || (!c.IsNamed() && c.Content(src) == "type") {
+			return true
+		}
+	}
+	return false
+}
+
+// tsExportStatementTypeOnly reports whether an export_statement carries
+// the statement-level `type` modifier (`export type { … } from`). The
+// keyword sits between `export` and the export_clause.
+func tsExportStatementTypeOnly(exportNode *sitter.Node, src []byte) bool {
+	for i := 0; i < int(exportNode.ChildCount()); i++ {
+		c := exportNode.Child(i)
+		if c == nil {
+			continue
+		}
+		if c.Type() == "export_clause" {
+			break
+		}
+		if c.Type() == "type" || (!c.IsNamed() && c.Content(src) == "type") {
+			return true
+		}
+	}
+	return false
+}
+
+// tsSpecifierTypeOnly reports whether a single import_specifier /
+// export_specifier carries an inline `type` modifier (`{ type Foo }`).
+func tsSpecifierTypeOnly(spec *sitter.Node, src []byte) bool {
+	for i := 0; i < int(spec.ChildCount()); i++ {
+		c := spec.Child(i)
+		if c == nil {
+			continue
+		}
+		if c.Type() == "type" {
+			return true
+		}
+		if !c.IsNamed() && c.Content(src) == "type" {
+			return true
+		}
+	}
+	return false
+}
+
+// emitTSClassHeritageRefs emits EdgeExtends for a class's `extends` base
+// and EdgeImplements for each `implements` interface. The base may be a
+// bare identifier (`extends Base`), a member expression
+// (`extends React.Component`), or carry type arguments
+// (`extends Component<Props, State>`) — each surfaces the named base type
+// plus any user-defined type arguments via tsTypeRefs.
+func emitTSClassHeritageRefs(classNode *sitter.Node, src []byte, filePath string, emit func(ownerID, name string, kind graph.EdgeKind, refContext string, line int)) {
+	classID := tsTypeDeclID(classNode, src, filePath)
+	if classID == "" {
+		return
+	}
+	heritage := findChildByType(classNode, "class_heritage")
+	if heritage == nil {
+		return
+	}
+	for i := 0; i < int(heritage.NamedChildCount()); i++ {
+		clause := heritage.NamedChild(i)
+		if clause == nil {
+			continue
+		}
+		switch clause.Type() {
+		case "extends_clause":
+			line := int(clause.StartPoint().Row) + 1
+			if val := clause.ChildByFieldName("value"); val != nil {
+				if name := tsHeritageName(val, src); name != "" {
+					emit(classID, name, graph.EdgeExtends, graph.RefContextInherit, line)
+				}
+			}
+			// Type arguments on the base (`extends Component<Props, State>`)
+			// are themselves references — decompose them through the same
+			// gate as every other type-use form.
+			if targs := clause.ChildByFieldName("type_arguments"); targs != nil {
+				for _, ref := range tsTypeRefs(targs.Content(src)) {
+					emit(classID, ref, graph.EdgeReferences, graph.RefContextGenericArg, line)
+				}
+			}
+		case "implements_clause":
+			line := int(clause.StartPoint().Row) + 1
+			for j := 0; j < int(clause.NamedChildCount()); j++ {
+				t := clause.NamedChild(j)
+				if t == nil {
+					continue
+				}
+				if name := tsHeritageName(t, src); name != "" {
+					emit(classID, name, graph.EdgeImplements, graph.RefContextInherit, line)
+				}
+			}
+		}
+	}
+}
+
+// emitTSInterfaceHeritageRefs emits EdgeExtends for each base of an
+// `interface Y extends Z, W<Foo>` declaration. The interface grammar
+// nests the bases under an extends_type_clause (distinct from the class
+// extends_clause); each base is a type_identifier or generic_type.
+func emitTSInterfaceHeritageRefs(ifaceNode *sitter.Node, src []byte, filePath string, emit func(ownerID, name string, kind graph.EdgeKind, refContext string, line int)) {
+	ifaceID := tsTypeDeclID(ifaceNode, src, filePath)
+	if ifaceID == "" {
+		return
+	}
+	clause := findChildByType(ifaceNode, "extends_type_clause")
+	if clause == nil {
+		return
+	}
+	line := int(clause.StartPoint().Row) + 1
+	for i := 0; i < int(clause.NamedChildCount()); i++ {
+		t := clause.NamedChild(i)
+		if t == nil {
+			continue
+		}
+		if name := tsHeritageName(t, src); name != "" {
+			emit(ifaceID, name, graph.EdgeExtends, graph.RefContextInherit, line)
+		}
+		// Type arguments on a base interface (`extends W<Foo>`) reference Foo.
+		if t.Type() == "generic_type" {
+			if targs := t.ChildByFieldName("type_arguments"); targs != nil {
+				for _, ref := range tsTypeRefs(targs.Content(src)) {
+					emit(ifaceID, ref, graph.EdgeReferences, graph.RefContextGenericArg, line)
+				}
+			}
+		}
+	}
+}
+
+// tsHeritageName returns the bare base-type name from a heritage node —
+// an identifier / type_identifier (`Base`), a member / nested expression
+// (`React.Component` → `Component`), or a generic_type (`W<Foo>` → `W`).
+// Returns "" when the name is a primitive (defensive — a heritage base
+// is never `string`, but the gate keeps the contract uniform).
+func tsHeritageName(n *sitter.Node, src []byte) string {
+	if n == nil {
+		return ""
+	}
+	switch n.Type() {
+	case "identifier", "type_identifier":
+		name := n.Content(src)
+		if isTSPrimitive(name) || !isTSTypeName(name) {
+			return ""
+		}
+		return name
+	case "member_expression", "nested_type_identifier", "nested_identifier":
+		// `React.Component` / `ns.Base` — the last segment is the type.
+		txt := strings.TrimSpace(n.Content(src))
+		if i := strings.LastIndex(txt, "."); i >= 0 {
+			txt = txt[i+1:]
+		}
+		if isTSPrimitive(txt) || !isTSTypeName(txt) {
+			return ""
+		}
+		return txt
+	case "generic_type":
+		if name := n.ChildByFieldName("name"); name != nil {
+			return tsHeritageName(name, src)
+		}
+		for i := 0; i < int(n.NamedChildCount()); i++ {
+			c := n.NamedChild(i)
+			if c != nil && (c.Type() == "type_identifier" || c.Type() == "identifier" || c.Type() == "nested_type_identifier") {
+				return tsHeritageName(c, src)
+			}
+		}
+	}
+	return ""
+}
+
+// tsTypeDeclID returns the graph node ID of a class_declaration /
+// interface_declaration — `<filePath>::<Name>`, matching the convention
+// emitClass / emitInterface stamp. Returns "" for an anonymous shape.
+func tsTypeDeclID(declNode *sitter.Node, src []byte, filePath string) string {
+	name := declNode.ChildByFieldName("name")
+	if name == nil {
+		for i := 0; i < int(declNode.NamedChildCount()); i++ {
+			c := declNode.NamedChild(i)
+			if c != nil && (c.Type() == "type_identifier" || c.Type() == "identifier") {
+				name = c
+				break
+			}
+		}
+	}
+	if name == nil {
+		return ""
+	}
+	return filePath + "::" + name.Content(src)
+}

--- a/internal/parser/languages/ts_reffrm_test.go
+++ b/internal/parser/languages/ts_reffrm_test.go
@@ -1,0 +1,304 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// refEdgeTo reports whether edges contains an edge of the given kind to
+// unresolved::<name> carrying the given Meta["ref_context"]. A blank
+// refContext matches any.
+func refEdgeTo(edges []*graph.Edge, kind graph.EdgeKind, name, refContext string) bool {
+	target := "unresolved::" + name
+	for _, e := range edges {
+		if e.Kind != kind || e.To != target {
+			continue
+		}
+		if refContext == "" {
+			return true
+		}
+		if rc, _ := e.Meta["ref_context"].(string); rc == refContext {
+			return true
+		}
+	}
+	return false
+}
+
+// refEdgeFrom is refEdgeTo with an additional From-owner assertion.
+func refEdgeFrom(edges []*graph.Edge, kind graph.EdgeKind, from, name, refContext string) bool {
+	target := "unresolved::" + name
+	for _, e := range edges {
+		if e.Kind != kind || e.To != target || e.From != from {
+			continue
+		}
+		if refContext == "" {
+			return true
+		}
+		if rc, _ := e.Meta["ref_context"].(string); rc == refContext {
+			return true
+		}
+	}
+	return false
+}
+
+// --- JSX component usage references ----------------------------------
+
+func TestTSRef_JSXSelfClosingReferencesComponent(t *testing.T) {
+	src := `function Shell() {
+	return <App foo="bar" />;
+}
+`
+	_, edges := runTSExtract(t, "src/shell.tsx", src)
+	if !refEdgeFrom(edges, graph.EdgeReferences, "src/shell.tsx::Shell", "App", "jsx") {
+		t.Errorf("expected EdgeReferences ref_context=jsx Shell -> unresolved::App; got %v",
+			edgeTargets(edgesByKind(edges, graph.EdgeReferences)))
+	}
+}
+
+func TestTSRef_JSXChildrenReferencesComponent(t *testing.T) {
+	src := `function Shell() {
+	return <App>hello</App>;
+}
+`
+	_, edges := runTSExtract(t, "src/shell.tsx", src)
+	if !refEdgeTo(edges, graph.EdgeReferences, "App", "jsx") {
+		t.Errorf("expected EdgeReferences ref_context=jsx -> unresolved::App from <App>...</App>; got %v",
+			edgeTargets(edgesByKind(edges, graph.EdgeReferences)))
+	}
+}
+
+func TestTSRef_JSXFileScopeReferencesComponent(t *testing.T) {
+	// File-scope JSX (not inside any function) attributes to the file
+	// node — the old render pass only ran inside function bodies.
+	src := `const tree = <App />;
+`
+	_, edges := runTSExtract(t, "src/tree.tsx", src)
+	if !refEdgeFrom(edges, graph.EdgeReferences, "src/tree.tsx", "App", "jsx") {
+		t.Errorf("expected file-scope EdgeReferences ref_context=jsx src/tree.tsx -> unresolved::App; got %v",
+			edgeTargets(edgesByKind(edges, graph.EdgeReferences)))
+	}
+}
+
+func TestTSRef_JSXQualifiedComponent(t *testing.T) {
+	src := `function Shell() {
+	return <Foo.Bar />;
+}
+`
+	_, edges := runTSExtract(t, "src/shell.tsx", src)
+	if !refEdgeTo(edges, graph.EdgeReferences, "Foo.Bar", "jsx") {
+		t.Errorf("expected EdgeReferences ref_context=jsx -> unresolved::Foo.Bar; got %v",
+			edgeTargets(edgesByKind(edges, graph.EdgeReferences)))
+	}
+}
+
+func TestTSRef_JSXIntrinsicHTMLSkipped(t *testing.T) {
+	// Zero false positives: lowercase intrinsic HTML elements must never
+	// produce a usage reference.
+	src := `function Shell() {
+	return <div><span>hi</span><p /></div>;
+}
+`
+	_, edges := runTSExtract(t, "src/shell.tsx", src)
+	for _, e := range edgesByKind(edges, graph.EdgeReferences) {
+		if rc, _ := e.Meta["ref_context"].(string); rc != "jsx" {
+			continue
+		}
+		switch e.To {
+		case "unresolved::div", "unresolved::span", "unresolved::p":
+			t.Errorf("intrinsic HTML element produced a jsx reference: %s", e.To)
+		}
+	}
+}
+
+func TestTSRef_JSXAlsoKeepsRendersChild(t *testing.T) {
+	// The usage reference is additive — the component-tree EdgeRendersChild
+	// edge must still be emitted alongside it.
+	src := `function Shell() {
+	return <App />;
+}
+`
+	_, edges := runTSExtract(t, "src/shell.tsx", src)
+	if !refEdgeTo(edges, graph.EdgeReferences, "App", "jsx") {
+		t.Errorf("expected jsx reference to App")
+	}
+	hasRender := false
+	for _, e := range edgesByKind(edges, graph.EdgeRendersChild) {
+		if e.To == "unresolved::App" {
+			hasRender = true
+		}
+	}
+	if !hasRender {
+		t.Errorf("EdgeRendersChild -> unresolved::App must still be emitted")
+	}
+}
+
+// --- type-only import references -------------------------------------
+
+func TestTSRef_ImportTypeBlockReferencesType(t *testing.T) {
+	src := `import type { ExcalidrawElement, AppState } from "./types";
+`
+	_, edges := runTSExtract(t, "src/a.ts", src)
+	if !refEdgeFrom(edges, graph.EdgeReferences, "src/a.ts", "ExcalidrawElement", "import_type") {
+		t.Errorf("expected import-type EdgeReferences -> unresolved::ExcalidrawElement; got %v",
+			edgeTargets(edgesByKind(edges, graph.EdgeReferences)))
+	}
+	if !refEdgeTo(edges, graph.EdgeReferences, "AppState", "import_type") {
+		t.Errorf("expected import-type EdgeReferences -> unresolved::AppState")
+	}
+}
+
+func TestTSRef_InlineTypeImportReferencesOnlyTypeBinding(t *testing.T) {
+	// `import { type Foo, normal }` — only Foo is type-only; `normal` is a
+	// value (already referenced by its call/read sites) and must NOT get
+	// an import_type reference.
+	src := `import { type Foo, normal } from "./mod";
+`
+	_, edges := runTSExtract(t, "src/a.ts", src)
+	if !refEdgeTo(edges, graph.EdgeReferences, "Foo", "import_type") {
+		t.Errorf("expected import-type EdgeReferences -> unresolved::Foo; got %v",
+			edgeTargets(edgesByKind(edges, graph.EdgeReferences)))
+	}
+	if refEdgeTo(edges, graph.EdgeReferences, "normal", "import_type") {
+		t.Errorf("value import `normal` must not produce an import_type reference")
+	}
+}
+
+func TestTSRef_PlainValueImportNotReferenced(t *testing.T) {
+	// Zero false positives: a non-type import emits no import_type ref.
+	src := `import { foo } from "./mod";
+`
+	_, edges := runTSExtract(t, "src/a.ts", src)
+	if refEdgeTo(edges, graph.EdgeReferences, "foo", "import_type") {
+		t.Errorf("plain value import must not produce an import_type reference")
+	}
+}
+
+// --- type-only re-export references ----------------------------------
+
+func TestTSRef_ExportTypeReexportReferencesType(t *testing.T) {
+	src := `export type { ExcalidrawElement, AppState } from "./types";
+`
+	_, edges := runTSExtract(t, "src/index.ts", src)
+	if !refEdgeFrom(edges, graph.EdgeReferences, "src/index.ts", "ExcalidrawElement", "export_type") {
+		t.Errorf("expected export-type EdgeReferences -> unresolved::ExcalidrawElement; got %v",
+			edgeTargets(edgesByKind(edges, graph.EdgeReferences)))
+	}
+	if !refEdgeTo(edges, graph.EdgeReferences, "AppState", "export_type") {
+		t.Errorf("expected export-type EdgeReferences -> unresolved::AppState")
+	}
+}
+
+func TestTSRef_InlineTypeReexportReferencesOnlyTypeBinding(t *testing.T) {
+	src := `export { type Foo, normal } from "./mod";
+`
+	_, edges := runTSExtract(t, "src/index.ts", src)
+	if !refEdgeTo(edges, graph.EdgeReferences, "Foo", "export_type") {
+		t.Errorf("expected export-type EdgeReferences -> unresolved::Foo; got %v",
+			edgeTargets(edgesByKind(edges, graph.EdgeReferences)))
+	}
+	if refEdgeTo(edges, graph.EdgeReferences, "normal", "export_type") {
+		t.Errorf("value re-export `normal` must not produce an export_type reference")
+	}
+}
+
+// --- class / interface heritage -------------------------------------
+
+func TestTSRef_ClassExtendsImplements(t *testing.T) {
+	src := `class App extends Component implements IThing, IOther {}
+`
+	_, edges := runTSExtract(t, "src/app.ts", src)
+	if !refEdgeFrom(edges, graph.EdgeExtends, "src/app.ts::App", "Component", "") {
+		t.Errorf("expected EdgeExtends App -> unresolved::Component; got %v",
+			edgeTargets(edgesByKind(edges, graph.EdgeExtends)))
+	}
+	if !refEdgeFrom(edges, graph.EdgeImplements, "src/app.ts::App", "IThing", "") {
+		t.Errorf("expected EdgeImplements App -> unresolved::IThing; got %v",
+			edgeTargets(edgesByKind(edges, graph.EdgeImplements)))
+	}
+	if !refEdgeTo(edges, graph.EdgeImplements, "IOther", "") {
+		t.Errorf("expected EdgeImplements -> unresolved::IOther")
+	}
+}
+
+func TestTSRef_ClassExtendsMemberExpressionWithTypeArgs(t *testing.T) {
+	// `extends React.Component<Props, State>` — base name is the last
+	// member segment; type args surface as generic-arg references.
+	src := `class App extends React.Component<Props, State> {}
+`
+	_, edges := runTSExtract(t, "src/app.tsx", src)
+	if !refEdgeFrom(edges, graph.EdgeExtends, "src/app.tsx::App", "Component", "") {
+		t.Errorf("expected EdgeExtends App -> unresolved::Component from member-expression base; got %v",
+			edgeTargets(edgesByKind(edges, graph.EdgeExtends)))
+	}
+	if !refEdgeTo(edges, graph.EdgeReferences, "Props", "generic_arg") {
+		t.Errorf("expected generic-arg EdgeReferences -> unresolved::Props")
+	}
+	if !refEdgeTo(edges, graph.EdgeReferences, "State", "generic_arg") {
+		t.Errorf("expected generic-arg EdgeReferences -> unresolved::State")
+	}
+}
+
+func TestTSRef_InterfaceExtends(t *testing.T) {
+	src := `interface Y extends Z, W<Foo> {}
+`
+	_, edges := runTSExtract(t, "src/y.ts", src)
+	if !refEdgeFrom(edges, graph.EdgeExtends, "src/y.ts::Y", "Z", "") {
+		t.Errorf("expected EdgeExtends Y -> unresolved::Z; got %v",
+			edgeTargets(edgesByKind(edges, graph.EdgeExtends)))
+	}
+	if !refEdgeTo(edges, graph.EdgeExtends, "W", "") {
+		t.Errorf("expected EdgeExtends Y -> unresolved::W")
+	}
+	if !refEdgeTo(edges, graph.EdgeReferences, "Foo", "generic_arg") {
+		t.Errorf("expected generic-arg EdgeReferences -> unresolved::Foo from interface base type arg")
+	}
+}
+
+// --- indexed-access (lookup) types -----------------------------------
+
+func TestTSRef_IndexedAccessTypeRefs(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{`ExcalidrawElement["type"]`, []string{"ExcalidrawElement"}},
+		{`Foo[Key]`, []string{"Foo", "Key"}},
+		{`Config["nested"]["deep"]`, []string{"Config"}},
+		{`number["x"]`, nil},       // primitive object type dropped
+		{`Foo[]`, []string{"Foo"}}, // array suffix still works, not a lookup
+	}
+	for _, c := range cases {
+		got := tsTypeRefs(c.in)
+		if !sliceEq(got, c.want) {
+			t.Errorf("tsTypeRefs(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestTSRef_IndexedAccessAliasBody(t *testing.T) {
+	src := `type Kind = ExcalidrawElement["type"];
+`
+	_, edges := runTSExtract(t, "src/kind.ts", src)
+	if !typedAsEdgeTo(edges, "ExcalidrawElement", "type_annotation") {
+		t.Errorf("expected EdgeTypedAs -> unresolved::ExcalidrawElement from indexed-access alias body; got %v",
+			edgeTargets(edgesByKind(edges, graph.EdgeTypedAs)))
+	}
+}
+
+// --- as-const zero-FP guard -----------------------------------------
+
+func TestTSRef_AsConstEmitsNoBogusRef(t *testing.T) {
+	// `x as const` must not emit a reference to a phantom `const` type.
+	src := `function f() {
+	const c = [1, 2] as const;
+	return c;
+}
+`
+	_, edges := runTSExtract(t, "src/c.ts", src)
+	for _, e := range edges {
+		if e.To == "unresolved::const" {
+			t.Errorf("`as const` must not reference a `const` type; got edge kind=%s", e.Kind)
+		}
+	}
+}

--- a/internal/parser/languages/typescript.go
+++ b/internal/parser/languages/typescript.go
@@ -379,6 +379,14 @@ func (e *TypeScriptExtractor) Extract(filePath string, src []byte) (*parser.Extr
 	// assertion. Attributed to the enclosing function (fallback: file).
 	emitTSCastTypeRefs(root, src, filePath, fileID, funcRanges, result)
 
+	// Reference forms the type-use / cast / render passes miss but that
+	// find_usages should count: JSX component sites (`<App/>`), type-only
+	// import / re-export bindings (`import type { X }`), and class /
+	// interface heritage (`extends` / `implements`). Each emits a
+	// usage-counted edge (references / extends / implements) attributed to
+	// the enclosing function (JSX) or the declaring type / file.
+	emitTSReferenceForms(root, src, filePath, fileID, funcRanges, result)
+
 	// Instantiation edges: `new Foo(...)` constructs Foo. Emitted as a typed
 	// EdgeInstantiates (not a flat call) attributed to the enclosing function,
 	// so the resolver lands it on the class and impact/trace see construction.

--- a/internal/semantic/tstypes/engine.go
+++ b/internal/semantic/tstypes/engine.go
@@ -628,7 +628,29 @@ func (a *applier) confirmAST(e *graph.Edge) bool {
 	// clobber both their tier and their semantic_source — so the only
 	// gate is the effective-rank comparison.
 	if graph.OriginRank(effectiveOrigin(e)) >= graph.OriginRank(graph.OriginASTResolved) {
-		return false
+		// Origin is already AST-or-better — never downgrade it. But an edge the
+		// extractor emitted carries OriginASTResolved with NO semantic_source
+		// (e.g. an AST-level extends/implements reference form); the engine
+		// grounded this relation, so still credit the provider and raise
+		// confidence to the AST ceiling when those are missing, without
+		// touching the origin/tier.
+		changed := false
+		if e.Meta == nil {
+			e.Meta = make(map[string]any)
+		}
+		if s, _ := e.Meta["semantic_source"].(string); s == "" {
+			e.Meta["semantic_source"] = a.provider
+			changed = true
+		}
+		if e.Confidence < astConfidence {
+			e.Confidence = astConfidence
+			e.ConfidenceLabel = graph.ConfidenceLabelFor(e.Kind, e.Confidence)
+			changed = true
+		}
+		if changed {
+			a.persistEdgeRow(e)
+		}
+		return changed
 	}
 	a.persistConfirmedAST(e)
 	return true


### PR DESCRIPTION
Follow-up to #158. Improves type-use reference completeness on a no-LSP (pure tree-sitter) index so `find_usages(Type)` no longer under-reports.

## TypeScript JSX / type-only / heritage references
The TS extractor missed several reference forms, so React components and types under-reported. Adds an AST reference-forms pass:
- **JSX component usage** — `<App/>` / `<App>…</App>` / `<Foo.Bar/>` previously emitted only `EdgeRendersChild` (which `find_usages` ignores); now also `EdgeReferences`. Intrinsic HTML (`<div/>`) skipped.
- **Class/interface heritage** — `extends` / `implements` (incl. `interface … extends`, member-expression bases, base type-args) — was entirely unhandled in TS.
- **Type-only import / re-export** — `import type {X}`, `export type {X} from`.
- **Indexed-access types** — `T[K]`.

Reuses existing TS normalizers so primitives / intrinsic HTML / value-imports are dropped (zero FP). Generics, arrays, casts, `keyof`/`typeof`, and annotation positions were already covered.

## Swift container recovery from parse errors
A tree-sitter parse error inside a Swift type body (e.g. a compound `#if … && !canImport(...)` conditional) corrupts the enclosing `class_declaration`, so the query never matches it — the container node was never emitted, its members leaked to file scope (a stored property whose name is the case-twin of the type surfaced as a file-scope constant), and every reference to the type stranded on `unresolved::Name`. Adds a brace-matched fallback (mirroring the existing extension scan) that seeds container ranges before the query and emits container nodes the query missed; clean declarations are deduped via the `seen` set.

## Verification
Full `internal/parser/languages` package green (1585), `go vet` + `golangci-lint` clean. Self-proving regression tests for both (JSX/import/export forms; Swift parse-error container recovery).
