### PR TITLE
Typed/indexable node columns + per-file files sidecar for index_health

### DIFF
--- a/cmd/gortex/wire_contract_test.go
+++ b/cmd/gortex/wire_contract_test.go
@@ -134,14 +134,14 @@ func describeFields(t reflect.Type) string {
 func wireContractGolden(name string) string {
 	switch name {
 	case "graph.Node":
-		// Bumped when the federation proxy-node fields Origin / Stub /
-		// FetchedAt were added — written only by the (gated, not-yet-built)
-		// cross-daemon mint path; empty on every locally-indexed node.
+		// Bumped when the source column-offset fields StartColumn / EndColumn
+		// were added (promoted to typed nodes columns on the SQLite backend).
 		// Additive: gob decodes unknown fields as zero, so older snapshots
-		// still load with them blank, and proxy nodes are never persisted.
-		// Previously bumped when AbsoluteFilePath, then WorkspaceID /
+		// still load with them blank.
+		// Previously bumped when the federation proxy-node fields Origin /
+		// Stub / FetchedAt, then AbsoluteFilePath, then WorkspaceID /
 		// ProjectID, were added.
-		return "3b8920ab88d05028e215d68d5917445e2e6d05bdad23aef6dcdf6c9920647823"
+		return "a600bd906c9e09ffa0828427f5d6622acd5fe244798a61d5712c151053be5dac"
 	case "graph.Edge":
 		// Bumped when Alias was added — the renamed name carried by a
 		// per-binding import (`import { x as alias }`) or a re-export

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -501,6 +501,11 @@ type Graph struct {
 	// prefix. Guarded by constValuesMu.
 	constValuesMu sync.Mutex
 	constValues   map[string]constValueEntry
+
+	// fileMetas holds per-file metadata rows keyed by repoPrefix -> filePath
+	// (the files sidecar feeding index_health). Guarded by fileMetasMu.
+	fileMetasMu sync.Mutex
+	fileMetas   map[string]map[string]FileMetaRow
 }
 
 // cloneShingleEntry is one in-memory clone_shingles row: the owning
@@ -687,6 +692,63 @@ func (g *Graph) ConstantValuesByNodeIDs(nodeIDs []string) (map[string]string, er
 		if entry, ok := g.constValues[id]; ok {
 			out[id] = entry.value
 		}
+	}
+	return out, nil
+}
+
+// SetFileMetas is the in-memory FileMetaWriter. It records each per-file row
+// for one repo prefix, replacing any prior row in place. Empty input is a
+// no-op.
+func (g *Graph) SetFileMetas(repoPrefix string, rows []FileMetaRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	g.fileMetasMu.Lock()
+	defer g.fileMetasMu.Unlock()
+	if g.fileMetas == nil {
+		g.fileMetas = make(map[string]map[string]FileMetaRow)
+	}
+	byFile := g.fileMetas[repoPrefix]
+	if byFile == nil {
+		byFile = make(map[string]FileMetaRow, len(rows))
+		g.fileMetas[repoPrefix] = byFile
+	}
+	for _, r := range rows {
+		if r.FilePath == "" {
+			continue
+		}
+		byFile[r.FilePath] = r
+	}
+	return nil
+}
+
+// DeleteFileMetasByFiles drops the rows for the supplied files in one repo
+// prefix so a reindex replaces them cleanly.
+func (g *Graph) DeleteFileMetasByFiles(repoPrefix string, files []string) error {
+	if len(files) == 0 {
+		return nil
+	}
+	g.fileMetasMu.Lock()
+	defer g.fileMetasMu.Unlock()
+	byFile := g.fileMetas[repoPrefix]
+	if byFile == nil {
+		return nil
+	}
+	for _, f := range files {
+		delete(byFile, f)
+	}
+	return nil
+}
+
+// FileMetasForRepo is the in-memory FileMetaReader: every recorded file row
+// for the repo prefix. Always non-nil.
+func (g *Graph) FileMetasForRepo(repoPrefix string) ([]FileMetaRow, error) {
+	g.fileMetasMu.Lock()
+	defer g.fileMetasMu.Unlock()
+	byFile := g.fileMetas[repoPrefix]
+	out := make([]FileMetaRow, 0, len(byFile))
+	for _, r := range byFile {
+		out = append(out, r)
 	}
 	return out, nil
 }

--- a/internal/graph/node.go
+++ b/internal/graph/node.go
@@ -291,8 +291,13 @@ type Node struct {
 	FilePath  string   `json:"file_path"`
 	StartLine int      `json:"start_line"`
 	// EndLine is omitted when zero — File-kind nodes don't have ranges.
-	EndLine    int            `json:"end_line,omitempty"`
-	Language   string         `json:"language"`
+	EndLine int `json:"end_line,omitempty"`
+	// StartColumn / EndColumn are 0-based source column offsets of the
+	// symbol's span. Omitted when zero (most extractors record only line
+	// ranges); promoted to typed nodes columns on the SQLite backend.
+	StartColumn int            `json:"start_column,omitempty"`
+	EndColumn   int            `json:"end_column,omitempty"`
+	Language    string         `json:"language"`
 	Meta       map[string]any `json:"meta,omitempty"`
 	RepoPrefix string         `json:"repo_prefix,omitempty"`
 	// WorkspaceID is the hard graph boundary slug. Two nodes with

--- a/internal/graph/store.go
+++ b/internal/graph/store.go
@@ -1100,6 +1100,32 @@ type ConstantValueRow struct {
 	Value    string
 }
 
+// FileMetaRow is one per-file metadata record: the BLAKE3 content hash (the
+// Merkle leaf), byte size, extracted node count, and a JSON array of
+// parse-error locations ("" when clean). The Merkle tree stays the
+// authoritative change detector; this row is queryable supplementary metadata
+// that index_health surfaces per file.
+type FileMetaRow struct {
+	FilePath    string
+	ContentHash string
+	Size        int
+	NodeCount   int
+	Errors      string
+}
+
+// FileMetaWriter persists per-file metadata rows. Implemented by the on-disk
+// and in-memory backends; the indexer writes through it after each file's
+// nodes are batched.
+type FileMetaWriter interface {
+	SetFileMetas(repoPrefix string, rows []FileMetaRow) error
+	DeleteFileMetasByFiles(repoPrefix string, files []string) error
+}
+
+// FileMetaReader is the read side: every recorded file row for a repo prefix.
+type FileMetaReader interface {
+	FileMetasForRepo(repoPrefix string) ([]FileMetaRow, error)
+}
+
 // RefFact is one durable resolved-reference fact: a reference edge from
 // FromID resolved TO ToID with the provenance tier that resolved it. Persisted
 // per source file so a reference's resolution is an auditable, diffable record

--- a/internal/graph/store_sqlite/meta_json.go
+++ b/internal/graph/store_sqlite/meta_json.go
@@ -372,11 +372,38 @@ var promotedMetaColumns = []struct {
 	{"visibility", "visibility TEXT"},
 	{"doc", "doc TEXT"},
 	{"external", "external INTEGER"},
+	{"return_type", "return_type TEXT"},
+	{"is_async", "is_async INTEGER"},
+	{"is_static", "is_static INTEGER"},
+	{"is_abstract", "is_abstract INTEGER"},
+	{"is_exported", "is_exported INTEGER"},
+	{"updated_at", "updated_at INTEGER"},
 }
 
-// ensureNodeColumns adds the promoted columns to a nodes table created
-// before they existed. A fresh DB already has them from the DDL, so this is
-// a no-op; an older DB is altered in place (ADD COLUMN defaults to NULL).
+// structNodeColumns are typed nodes columns read and written directly from
+// Node struct fields (not the Meta blob): the source column offsets. They are
+// NOT NULL DEFAULT 0 like start_line / end_line, so an ALTER on an existing DB
+// backfills 0.
+var structNodeColumns = []struct {
+	name string
+	ddl  string
+}{
+	{"start_column", "start_column INTEGER NOT NULL DEFAULT 0"},
+	{"end_column", "end_column INTEGER NOT NULL DEFAULT 0"},
+}
+
+// promotedNodeMeta holds the typed column values lifted out of a node's Meta
+// blob. A NULL (invalid) field means the key was absent (or had an unexpected
+// type and stayed in the blob).
+type promotedNodeMeta struct {
+	sig, vis, doc, returnType                           sql.NullString
+	external, isAsync, isStatic, isAbstract, isExported sql.NullBool
+	updatedAt                                           sql.NullInt64
+}
+
+// ensureNodeColumns adds the promoted + struct columns to a nodes table
+// created before they existed. A fresh DB already has them from the DDL, so
+// this is a no-op; an older DB is altered in place.
 func ensureNodeColumns(db *sql.DB) error {
 	rows, err := db.Query(`PRAGMA table_info(nodes)`)
 	if err != nil {
@@ -400,11 +427,20 @@ func ensureNodeColumns(db *sql.DB) error {
 		return err
 	}
 	_ = rows.Close()
-	for _, c := range promotedMetaColumns {
-		if existing[c.name] {
-			continue
+	add := func(name, ddl string) error {
+		if existing[name] {
+			return nil
 		}
-		if _, err := db.Exec(`ALTER TABLE nodes ADD COLUMN ` + c.ddl); err != nil {
+		_, err := db.Exec(`ALTER TABLE nodes ADD COLUMN ` + ddl)
+		return err
+	}
+	for _, c := range structNodeColumns {
+		if err := add(c.name, c.ddl); err != nil {
+			return err
+		}
+	}
+	for _, c := range promotedMetaColumns {
+		if err := add(c.name, c.ddl); err != nil {
 			return err
 		}
 	}
@@ -415,7 +451,7 @@ func ensureNodeColumns(db *sql.DB) error {
 // values and returns the remaining map destined for the JSON blob. m is
 // not mutated; a copy is made only when a promoted key is present and has
 // the expected type (otherwise the value stays in the blob).
-func extractPromotedMeta(m map[string]any) (sig, vis, doc sql.NullString, ext sql.NullBool, rest map[string]any) {
+func extractPromotedMeta(m map[string]any) (p promotedNodeMeta, rest map[string]any) {
 	rest = m
 	if len(m) == 0 {
 		return
@@ -431,54 +467,128 @@ func extractPromotedMeta(m map[string]any) (sig, vis, doc sql.NullString, ext sq
 		return
 	}
 	rest = make(map[string]any, len(m))
+	str := func(v any) (sql.NullString, bool) {
+		if s, ok := v.(string); ok {
+			return sql.NullString{String: s, Valid: true}, true
+		}
+		return sql.NullString{}, false
+	}
+	boolean := func(v any) (sql.NullBool, bool) {
+		if b, ok := v.(bool); ok {
+			return sql.NullBool{Bool: b, Valid: true}, true
+		}
+		return sql.NullBool{}, false
+	}
 	for k, v := range m {
+		var promoted bool
 		switch k {
 		case "signature":
-			if s, ok := v.(string); ok {
-				sig = sql.NullString{String: s, Valid: true}
-				continue
+			if nv, ok := str(v); ok {
+				p.sig, promoted = nv, true
 			}
 		case "visibility":
-			if s, ok := v.(string); ok {
-				vis = sql.NullString{String: s, Valid: true}
-				continue
+			if nv, ok := str(v); ok {
+				p.vis, promoted = nv, true
 			}
 		case "doc":
-			if s, ok := v.(string); ok {
-				doc = sql.NullString{String: s, Valid: true}
-				continue
+			if nv, ok := str(v); ok {
+				p.doc, promoted = nv, true
+			}
+		case "return_type":
+			if nv, ok := str(v); ok {
+				p.returnType, promoted = nv, true
 			}
 		case "external":
-			if b, ok := v.(bool); ok {
-				ext = sql.NullBool{Bool: b, Valid: true}
-				continue
+			if nv, ok := boolean(v); ok {
+				p.external, promoted = nv, true
+			}
+		case "is_async":
+			if nv, ok := boolean(v); ok {
+				p.isAsync, promoted = nv, true
+			}
+		case "is_static":
+			if nv, ok := boolean(v); ok {
+				p.isStatic, promoted = nv, true
+			}
+		case "is_abstract":
+			if nv, ok := boolean(v); ok {
+				p.isAbstract, promoted = nv, true
+			}
+		case "is_exported":
+			if nv, ok := boolean(v); ok {
+				p.isExported, promoted = nv, true
+			}
+		case "updated_at":
+			if i, ok := metaToInt64(v); ok {
+				p.updatedAt, promoted = sql.NullInt64{Int64: i, Valid: true}, true
 			}
 		}
-		rest[k] = v
+		if !promoted {
+			// Absent / wrong type: keep the value in the JSON blob.
+			rest[k] = v
+		}
 	}
 	return
+}
+
+// metaToInt64 coerces a meta numeric value (int / int64 / float64 / json.Number)
+// to int64 for a promoted timestamp column.
+func metaToInt64(v any) (int64, bool) {
+	switch x := v.(type) {
+	case int64:
+		return x, true
+	case int:
+		return int64(x), true
+	case float64:
+		return int64(x), true
+	case json.Number:
+		if i, err := x.Int64(); err == nil {
+			return i, true
+		}
+	}
+	return 0, false
 }
 
 // restorePromotedMeta writes the non-NULL promoted columns back into the
 // node's Meta. A NULL column is left alone so a legacy gob row's blob value
 // survives.
-func restorePromotedMeta(n *graph.Node, sig, vis, doc sql.NullString, ext sql.NullBool) {
-	if !sig.Valid && !vis.Valid && !doc.Valid && !ext.Valid {
+func restorePromotedMeta(n *graph.Node, p promotedNodeMeta) {
+	if !p.sig.Valid && !p.vis.Valid && !p.doc.Valid && !p.returnType.Valid &&
+		!p.external.Valid && !p.isAsync.Valid && !p.isStatic.Valid &&
+		!p.isAbstract.Valid && !p.isExported.Valid && !p.updatedAt.Valid {
 		return
 	}
 	if n.Meta == nil {
-		n.Meta = make(map[string]any, 4)
+		n.Meta = make(map[string]any, 8)
 	}
-	if sig.Valid {
-		n.Meta["signature"] = sig.String
+	if p.sig.Valid {
+		n.Meta["signature"] = p.sig.String
 	}
-	if vis.Valid {
-		n.Meta["visibility"] = vis.String
+	if p.vis.Valid {
+		n.Meta["visibility"] = p.vis.String
 	}
-	if doc.Valid {
-		n.Meta["doc"] = doc.String
+	if p.doc.Valid {
+		n.Meta["doc"] = p.doc.String
 	}
-	if ext.Valid {
-		n.Meta["external"] = ext.Bool
+	if p.returnType.Valid {
+		n.Meta["return_type"] = p.returnType.String
+	}
+	if p.external.Valid {
+		n.Meta["external"] = p.external.Bool
+	}
+	if p.isAsync.Valid {
+		n.Meta["is_async"] = p.isAsync.Bool
+	}
+	if p.isStatic.Valid {
+		n.Meta["is_static"] = p.isStatic.Bool
+	}
+	if p.isAbstract.Valid {
+		n.Meta["is_abstract"] = p.isAbstract.Bool
+	}
+	if p.isExported.Valid {
+		n.Meta["is_exported"] = p.isExported.Bool
+	}
+	if p.updatedAt.Valid {
+		n.Meta["updated_at"] = p.updatedAt.Int64
 	}
 }

--- a/internal/graph/store_sqlite/meta_promoted_test.go
+++ b/internal/graph/store_sqlite/meta_promoted_test.go
@@ -64,6 +64,82 @@ func TestPromotedColumns_RoundTrip(t *testing.T) {
 	}
 }
 
+// TestPromotedColumns_NewColumns verifies the added promoted meta columns
+// (is_async / is_static / is_abstract / is_exported / return_type / updated_at)
+// and the struct-field columns (start_column / end_column) round-trip through
+// their typed columns, and that a SQL filter on is_async resolves WITHOUT
+// decoding the meta blob — the indexable-column acceptance.
+func TestPromotedColumns_NewColumns(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "p.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	s.AddNode(&graph.Node{
+		ID: "f.go::Async", Kind: graph.KindFunction, Name: "Async", FilePath: "f.go",
+		StartLine: 10, EndLine: 20, StartColumn: 4, EndColumn: 1,
+		Meta: map[string]any{
+			"is_async":    true,
+			"is_static":   false,
+			"is_abstract": true,
+			"is_exported": true,
+			"return_type": "error",
+			"updated_at":  int64(1700000000),
+			"complexity":  3, // non-promoted — stays in the blob
+		},
+	})
+	// A second, non-async node to prove the filter is selective.
+	s.AddNode(&graph.Node{
+		ID: "f.go::Sync", Kind: graph.KindFunction, Name: "Sync", FilePath: "f.go",
+		Meta: map[string]any{"is_async": false},
+	})
+
+	// Read-back restores every promoted key into Meta with its exact type,
+	// and the struct columns into the Node fields.
+	n := s.GetNode("f.go::Async")
+	if n == nil {
+		t.Fatal("GetNode returned nil")
+	}
+	assertType[bool](t, n.Meta, "is_async", true)
+	assertType[bool](t, n.Meta, "is_static", false)
+	assertType[bool](t, n.Meta, "is_abstract", true)
+	assertType[bool](t, n.Meta, "is_exported", true)
+	assertType[string](t, n.Meta, "return_type", "error")
+	assertType[int64](t, n.Meta, "updated_at", int64(1700000000))
+	assertType[int](t, n.Meta, "complexity", 3)
+	if n.StartColumn != 4 || n.EndColumn != 1 {
+		t.Errorf("column offsets = (%d,%d), want (4,1)", n.StartColumn, n.EndColumn)
+	}
+
+	// The promoted keys are stripped from the JSON blob; complexity is not.
+	var blob []byte
+	if err := s.db.QueryRow(`SELECT meta FROM nodes WHERE id=?`, "f.go::Async").Scan(&blob); err != nil {
+		t.Fatal(err)
+	}
+	for _, k := range []string{"is_async", "is_abstract", "return_type", "updated_at"} {
+		if strings.Contains(string(blob), k) {
+			t.Errorf("blob still contains promoted key %q: %s", k, blob)
+		}
+	}
+	if !strings.Contains(string(blob), "complexity") {
+		t.Errorf("blob missing non-promoted key complexity: %s", blob)
+	}
+
+	// Acceptance: a SQL filter on the typed column resolves the node without
+	// touching the meta blob (only id is selected).
+	var id string
+	var startCol, endCol int
+	if err := s.db.QueryRow(
+		`SELECT id, start_column, end_column FROM nodes WHERE is_async = 1`,
+	).Scan(&id, &startCol, &endCol); err != nil {
+		t.Fatalf("is_async column filter failed: %v", err)
+	}
+	if id != "f.go::Async" || startCol != 4 || endCol != 1 {
+		t.Errorf("filter result = (%q,%d,%d), want (f.go::Async,4,1)", id, startCol, endCol)
+	}
+}
+
 // TestPromotedColumns_ExternalFalse guards the NULL-vs-false distinction:
 // a stored false must round-trip as false, not vanish.
 func TestPromotedColumns_ExternalFalse(t *testing.T) {

--- a/internal/graph/store_sqlite/schema.go
+++ b/internal/graph/store_sqlite/schema.go
@@ -155,6 +155,26 @@ CREATE TABLE IF NOT EXISTS constant_values (
 
 CREATE INDEX IF NOT EXISTS constant_values_by_file ON constant_values(repo_prefix, file_path);
 
+-- files is the per-file metadata sidecar: one row per indexed file carrying
+-- the BLAKE3 content hash (the Merkle leaf), byte size, extracted node count,
+-- and a JSON array of parse-error locations. The Merkle tree stays the
+-- authoritative change detector; this table is queryable supplementary
+-- metadata (index_health reports per-file parse errors + node counts from it).
+-- PK is (repo_prefix, file_path) so a reindex replaces the row in place;
+-- WITHOUT ROWID — the PK index IS the table, like file_mtimes.
+CREATE TABLE IF NOT EXISTS files (
+    repo_prefix  TEXT NOT NULL DEFAULT '',
+    file_path    TEXT NOT NULL,
+    content_hash TEXT NOT NULL DEFAULT '',
+    size         INTEGER NOT NULL DEFAULT 0,
+    node_count   INTEGER NOT NULL DEFAULT 0,
+    errors       TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (repo_prefix, file_path)
+) WITHOUT ROWID;
+-- files_with_errors backs the index_health "files with parse errors" rollup
+-- so it scans only the (usually tiny) set of erroring files, not every row.
+CREATE INDEX IF NOT EXISTS files_with_errors ON files(repo_prefix) WHERE errors <> '';
+
 -- ref_facts is the resolved-reference sidecar: one row per reference edge
 -- that resolved to a concrete target, recording the target + the provenance
 -- tier that resolved it. Denormalized file_path + lang make "all reference

--- a/internal/graph/store_sqlite/schema.go
+++ b/internal/graph/store_sqlite/schema.go
@@ -48,6 +48,8 @@ CREATE TABLE IF NOT EXISTS nodes (
     file_path     TEXT NOT NULL,
     start_line    INTEGER NOT NULL DEFAULT 0,
     end_line      INTEGER NOT NULL DEFAULT 0,
+    start_column  INTEGER NOT NULL DEFAULT 0,
+    end_column    INTEGER NOT NULL DEFAULT 0,
     language      TEXT NOT NULL DEFAULT '',
     repo_prefix   TEXT NOT NULL DEFAULT '',
     workspace_id  TEXT NOT NULL DEFAULT '',
@@ -56,6 +58,12 @@ CREATE TABLE IF NOT EXISTS nodes (
     visibility    TEXT,
     doc           TEXT,
     external      INTEGER,
+    return_type   TEXT,
+    is_async      INTEGER,
+    is_static     INTEGER,
+    is_abstract   INTEGER,
+    is_exported   INTEGER,
+    updated_at    INTEGER,
     meta          BLOB
 ) WITHOUT ROWID;
 

--- a/internal/graph/store_sqlite/store.go
+++ b/internal/graph/store_sqlite/store.go
@@ -425,7 +425,7 @@ func (s *Store) prepare() error {
 	const nodeCols = lookupNodeCols
 
 	prep(&s.stmtInsertNode,
-		`INSERT OR REPLACE INTO nodes (`+nodeCols+`) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`)
+		`INSERT OR REPLACE INTO nodes (`+nodeCols+`) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`)
 	prep(&s.stmtGetNode,
 		`SELECT `+nodeCols+` FROM nodes WHERE id = ?`)
 	prep(&s.stmtGetNodeByQual,
@@ -529,16 +529,17 @@ func scanNode(scanner interface {
 	Scan(...any) error
 }) (*graph.Node, error) {
 	var (
-		n             graph.Node
-		metaBlob      []byte
-		sig, vis, doc sql.NullString
-		ext           sql.NullBool
+		n        graph.Node
+		metaBlob []byte
+		p        promotedNodeMeta
 	)
 	err := scanner.Scan(
 		&n.ID, &n.Kind, &n.Name, &n.QualName, &n.FilePath,
-		&n.StartLine, &n.EndLine, &n.Language,
+		&n.StartLine, &n.EndLine, &n.StartColumn, &n.EndColumn, &n.Language,
 		&n.RepoPrefix, &n.WorkspaceID, &n.ProjectID,
-		&sig, &vis, &doc, &ext, &metaBlob,
+		&p.sig, &p.vis, &p.doc, &p.external, &p.returnType,
+		&p.isAsync, &p.isStatic, &p.isAbstract, &p.isExported, &p.updatedAt,
+		&metaBlob,
 	)
 	if err != nil {
 		return nil, err
@@ -553,7 +554,7 @@ func scanNode(scanner interface {
 	// Restore the promoted columns into Meta. They are authoritative for
 	// rows written after the promotion; a NULL column (legacy gob rows)
 	// is left alone so the blob-carried value survives.
-	restorePromotedMeta(&n, sig, vis, doc, ext)
+	restorePromotedMeta(&n, p)
 	return &n, nil
 }
 
@@ -637,16 +638,18 @@ func (s *Store) AddNode(n *graph.Node) {
 }
 
 func (s *Store) insertNodeLocked(stmt *sql.Stmt, n *graph.Node) error {
-	sig, vis, doc, ext, blobMeta := extractPromotedMeta(n.Meta)
+	p, blobMeta := extractPromotedMeta(n.Meta)
 	metaBlob, err := encodeMeta(blobMeta)
 	if err != nil {
 		return err
 	}
 	_, err = stmt.Exec(
 		n.ID, string(n.Kind), n.Name, n.QualName, n.FilePath,
-		n.StartLine, n.EndLine, n.Language,
+		n.StartLine, n.EndLine, n.StartColumn, n.EndColumn, n.Language,
 		n.RepoPrefix, n.WorkspaceID, n.ProjectID,
-		sig, vis, doc, ext, metaBlob,
+		p.sig, p.vis, p.doc, p.external, p.returnType,
+		p.isAsync, p.isStatic, p.isAbstract, p.isExported, p.updatedAt,
+		metaBlob,
 	)
 	return err
 }

--- a/internal/graph/store_sqlite/store_files.go
+++ b/internal/graph/store_sqlite/store_files.go
@@ -1,0 +1,118 @@
+package store_sqlite
+
+import (
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Compile-time assertions that the SQLite Store satisfies the optional
+// per-file metadata persistence capability (the files sidecar feeding
+// index_health's per-file parse-error / node-count rollup).
+var (
+	_ graph.FileMetaWriter = (*Store)(nil)
+	_ graph.FileMetaReader = (*Store)(nil)
+)
+
+// fileMetaChunk bounds rows per multi-row INSERT (6 params/row; 80 rows =
+// 480 host params, well under SQLite's 999 default).
+const fileMetaChunk = 80
+
+// SetFileMetas upserts per-file metadata rows for one repo prefix in a single
+// transaction, chunked under the host-parameter limit. Idempotent on the
+// (repo_prefix, file_path) primary key. Empty input is a no-op.
+func (s *Store) SetFileMetas(repoPrefix string, rows []graph.FileMetaRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck // rollback after Commit is a no-op
+
+	for start := 0; start < len(rows); start += fileMetaChunk {
+		end := start + fileMetaChunk
+		if end > len(rows) {
+			end = len(rows)
+		}
+		batch := rows[start:end]
+		args := make([]any, 0, len(batch)*6)
+		stmt := make([]byte, 0, 96+len(batch)*24)
+		stmt = append(stmt, "INSERT OR REPLACE INTO files (repo_prefix, file_path, content_hash, size, node_count, errors) VALUES "...)
+		for i, r := range batch {
+			if i > 0 {
+				stmt = append(stmt, ',')
+			}
+			stmt = append(stmt, "(?, ?, ?, ?, ?, ?)"...)
+			args = append(args, repoPrefix, r.FilePath, r.ContentHash, r.Size, r.NodeCount, r.Errors)
+		}
+		if _, err := tx.Exec(string(stmt), args...); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// DeleteFileMetasByFiles drops the metadata rows for the supplied files in one
+// repo prefix, chunked into `file_path IN (…)` DELETEs. Empty input is a no-op.
+func (s *Store) DeleteFileMetasByFiles(repoPrefix string, files []string) error {
+	if len(files) == 0 {
+		return nil
+	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck // rollback after Commit is a no-op
+
+	for start := 0; start < len(files); start += fileMetaChunk {
+		end := start + fileMetaChunk
+		if end > len(files) {
+			end = len(files)
+		}
+		chunk := files[start:end]
+		args := make([]any, 0, len(chunk)+1)
+		args = append(args, repoPrefix)
+		stmt := make([]byte, 0, 64+len(chunk)*2)
+		stmt = append(stmt, "DELETE FROM files WHERE repo_prefix = ? AND file_path IN ("...)
+		for i, f := range chunk {
+			if i > 0 {
+				stmt = append(stmt, ',')
+			}
+			stmt = append(stmt, '?')
+			args = append(args, f)
+		}
+		stmt = append(stmt, ')')
+		if _, err := tx.Exec(string(stmt), args...); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// FileMetasForRepo returns every recorded file row for the repo prefix.
+// Always non-nil.
+func (s *Store) FileMetasForRepo(repoPrefix string) ([]graph.FileMetaRow, error) {
+	rows, err := s.db.Query(
+		`SELECT file_path, content_hash, size, node_count, errors FROM files WHERE repo_prefix = ? ORDER BY file_path`,
+		repoPrefix,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []graph.FileMetaRow{}
+	for rows.Next() {
+		var r graph.FileMetaRow
+		if err := rows.Scan(&r.FilePath, &r.ContentHash, &r.Size, &r.NodeCount, &r.Errors); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}

--- a/internal/graph/store_sqlite/store_files_test.go
+++ b/internal/graph/store_sqlite/store_files_test.go
@@ -1,0 +1,69 @@
+package store_sqlite
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// TestFileMetas_RoundTrip pins the per-file metadata sidecar: rows upsert,
+// read back per repo, carry their errors JSON, and a per-file delete removes
+// just the named file.
+func TestFileMetas_RoundTrip(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "f.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	rows := []graph.FileMetaRow{
+		{FilePath: "a/x.go", ContentHash: "h1", Size: 100, NodeCount: 7, Errors: ""},
+		{FilePath: "a/broken.go", ContentHash: "h2", Size: 50, NodeCount: 1, Errors: `["3:5","4:1"]`},
+	}
+	if err := s.SetFileMetas("repoA", rows); err != nil {
+		t.Fatal(err)
+	}
+	// A different repo's row must not bleed in.
+	if err := s.SetFileMetas("repoB", []graph.FileMetaRow{{FilePath: "b/y.go", NodeCount: 2}}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.FileMetasForRepo("repoA")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("FileMetasForRepo(repoA) = %d rows, want 2", len(got))
+	}
+	byFile := map[string]graph.FileMetaRow{}
+	for _, r := range got {
+		byFile[r.FilePath] = r
+	}
+	if r := byFile["a/x.go"]; r.NodeCount != 7 || r.Size != 100 || r.ContentHash != "h1" || r.Errors != "" {
+		t.Errorf("x.go row = %+v", r)
+	}
+	if r := byFile["a/broken.go"]; r.NodeCount != 1 || r.Errors != `["3:5","4:1"]` {
+		t.Errorf("broken.go row = %+v", r)
+	}
+
+	// Upsert replaces in place.
+	if err := s.SetFileMetas("repoA", []graph.FileMetaRow{{FilePath: "a/x.go", NodeCount: 9, Errors: ""}}); err != nil {
+		t.Fatal(err)
+	}
+	got, _ = s.FileMetasForRepo("repoA")
+	for _, r := range got {
+		if r.FilePath == "a/x.go" && r.NodeCount != 9 {
+			t.Errorf("upsert did not replace node_count: %+v", r)
+		}
+	}
+
+	// Per-file delete removes only the named file.
+	if err := s.DeleteFileMetasByFiles("repoA", []string{"a/broken.go"}); err != nil {
+		t.Fatal(err)
+	}
+	got, _ = s.FileMetasForRepo("repoA")
+	if len(got) != 1 || got[0].FilePath != "a/x.go" {
+		t.Errorf("after delete, rows = %+v, want only a/x.go", got)
+	}
+}

--- a/internal/graph/store_sqlite/store_lookups.go
+++ b/internal/graph/store_sqlite/store_lookups.go
@@ -14,9 +14,11 @@ import (
 
 // lookupNodeCols is the canonical node column list (and scan order) for
 // every node-shaped SELECT in the package. It must stay in sync with
-// scanNode. The promoted columns (signature/visibility/doc/external)
-// precede meta.
-const lookupNodeCols = `id, kind, name, qual_name, file_path, start_line, end_line, language, repo_prefix, workspace_id, project_id, signature, visibility, doc, external, meta`
+// scanNode. The struct columns (start_column/end_column) sit with the line
+// range; the promoted meta columns (signature/visibility/doc/external/
+// return_type/is_async/is_static/is_abstract/is_exported/updated_at) precede
+// meta.
+const lookupNodeCols = `id, kind, name, qual_name, file_path, start_line, end_line, start_column, end_column, language, repo_prefix, workspace_id, project_id, signature, visibility, doc, external, return_type, is_async, is_static, is_abstract, is_exported, updated_at, meta`
 const lookupEdgeCols = `from_id, to_id, kind, file_path, line, confidence, confidence_label, origin, tier, cross_repo, meta`
 
 // FindNodesByNameContaining returns nodes whose Name contains substr,

--- a/internal/indexer/file_meta.go
+++ b/internal/indexer/file_meta.go
@@ -1,0 +1,57 @@
+package indexer
+
+import (
+	"encoding/hex"
+	"encoding/json"
+
+	"github.com/zeebo/blake3"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+)
+
+// persistFileMeta records one file's per-file metadata row — the BLAKE3
+// content hash (the same algorithm as the Merkle leaf), byte size, extracted
+// node count, and a JSON array of parse-error locations — in the backend's
+// files sidecar (when it implements graph.FileMetaWriter; the on-disk and
+// in-memory backends both do). index_health reads these rows to report
+// per-file parse errors + node counts; the Merkle tree stays the authoritative
+// change detector.
+//
+// relPath / src are the pre-repo-prefix path and the (transformed) content;
+// the persisted file_path is repo-prefixed so it matches the graph node ids.
+// The file's prior row is deleted first so a reindex replaces it cleanly.
+func (idx *Indexer) persistFileMeta(relPath string, src []byte, result *parser.ExtractionResult) {
+	if result == nil || relPath == "" {
+		return
+	}
+	fw, ok := idx.graph.(graph.FileMetaWriter)
+	if !ok {
+		return
+	}
+	filePath := relPath
+	if idx.repoPrefix != "" {
+		filePath = idx.repoPrefix + "/" + relPath
+	}
+
+	h := blake3.New()
+	_, _ = h.Write(src)
+	contentHash := hex.EncodeToString(h.Sum(nil))
+
+	errs := ""
+	if locs := result.Tree.ParseErrorLocations(); len(locs) > 0 {
+		if b, err := json.Marshal(locs); err == nil {
+			errs = string(b)
+		}
+	}
+
+	row := graph.FileMetaRow{
+		FilePath:    filePath,
+		ContentHash: contentHash,
+		Size:        len(src),
+		NodeCount:   len(result.Nodes),
+		Errors:      errs,
+	}
+	_ = fw.DeleteFileMetasByFiles(idx.repoPrefix, []string{filePath})
+	_ = fw.SetFileMetas(idx.repoPrefix, []graph.FileMetaRow{row})
+}

--- a/internal/indexer/file_meta_test.go
+++ b/internal/indexer/file_meta_test.go
@@ -1,0 +1,55 @@
+package indexer
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// TestPersistFileMeta_PopulatesFilesSidecar pins the end-to-end population of
+// the per-file metadata sidecar: indexing a file records a row with a non-empty
+// content hash, a positive byte size, and the extracted node count — the data
+// index_health reports per file.
+func TestPersistFileMeta_PopulatesFilesSidecar(t *testing.T) {
+	src := `package main
+
+func Alpha() {}
+
+func Beta() {}
+`
+	g := indexAll(t, src) // single-repo mode → repoPrefix ""
+
+	reader, ok := g.(graph.FileMetaReader)
+	if !ok {
+		t.Fatal("in-memory graph must implement FileMetaReader")
+	}
+	rows, err := reader.FileMetasForRepo("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) == 0 {
+		t.Fatal("no file metadata rows recorded after indexing")
+	}
+	var found bool
+	for _, r := range rows {
+		if r.FilePath != "main.go" {
+			continue
+		}
+		found = true
+		if r.ContentHash == "" {
+			t.Error("content_hash empty")
+		}
+		if r.Size == 0 {
+			t.Errorf("size = 0, want > 0")
+		}
+		if r.NodeCount == 0 {
+			t.Errorf("node_count = 0, want > 0 (file node + 2 functions)")
+		}
+		if r.Errors != "" {
+			t.Errorf("clean file recorded errors: %q", r.Errors)
+		}
+	}
+	if !found {
+		t.Errorf("no row for main.go; rows = %+v", rows)
+	}
+}

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -2465,6 +2465,7 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 					// per-edge path during cold-start warmup.
 					idx.graph.AddBatch(result.Nodes, result.Edges)
 					idx.persistConstValues(result)
+					idx.persistFileMeta(relPath, src, result)
 
 					if !skipped && fileGraphPath != "" {
 						exts := contractExtractorsByLang[lang]
@@ -3037,6 +3038,7 @@ func (idx *Indexer) indexFile(filePath string, resolve bool) error {
 
 	idx.graph.AddBatch(result.Nodes, result.Edges)
 	idx.persistConstValues(result)
+	idx.persistFileMeta(relPath, src, result)
 
 	// Add new symbols to search index. shouldIndexForSearch enforces
 	// the same SkipSearch filter used by the bulk and upgrade paths.

--- a/internal/indexer/multi_watcher_test.go
+++ b/internal/indexer/multi_watcher_test.go
@@ -160,8 +160,11 @@ func ModifiedA() {}
 	ev := waitForMultiEvent(t, mw, 3*time.Second)
 	assert.Equal(t, ChangeModified, ev.Kind)
 
-	// Graph should reflect the change.
-	assert.NotEmpty(t, mi.Graph().FindNodesByName("ModifiedA"))
+	// Graph should reflect the change. The reindex runs asynchronously after
+	// the change event, so poll rather than assert immediately.
+	require.Eventually(t, func() bool {
+		return len(mi.Graph().FindNodesByName("ModifiedA")) > 0
+	}, 3*time.Second, 20*time.Millisecond, "ModifiedA should be indexed")
 }
 
 func TestMultiWatcher_Events_MergedFromMultipleRepos(t *testing.T) {
@@ -183,9 +186,15 @@ func ChangedB() {}
 `)
 	_ = waitForMultiEvent(t, mw, 3*time.Second)
 
-	// Both changes should be reflected in the graph.
-	assert.NotEmpty(t, mi.Graph().FindNodesByName("ChangedA"))
-	assert.NotEmpty(t, mi.Graph().FindNodesByName("ChangedB"))
+	// Both changes should be reflected in the graph. The change event fires
+	// when the modification is DETECTED; the reindex that materialises the new
+	// symbol runs asynchronously after, so poll for the nodes rather than
+	// asserting immediately — the fixed-instant assert raced the reindex and
+	// flaked under CI load.
+	require.Eventually(t, func() bool {
+		return len(mi.Graph().FindNodesByName("ChangedA")) > 0 &&
+			len(mi.Graph().FindNodesByName("ChangedB")) > 0
+	}, 3*time.Second, 20*time.Millisecond, "both ChangedA and ChangedB should be indexed")
 }
 
 func TestMultiWatcher_AddRepo(t *testing.T) {

--- a/internal/mcp/tools_enhancements.go
+++ b/internal/mcp/tools_enhancements.go
@@ -2756,14 +2756,24 @@ func (s *Server) buildIndexHealthPayload() map[string]any {
 	// can see WHY a file is missing from the graph (size / timeout /
 	// minified / parse_failed / parse_panic) instead of guessing.
 	skipped := map[string]int{}
+	repoPrefixes := map[string]struct{}{}
 	for n := range s.graph.NodesByKind(graph.KindFile) {
-		if n == nil || n.Meta == nil {
+		if n == nil {
+			continue
+		}
+		repoPrefixes[n.RepoPrefix] = struct{}{}
+		if n.Meta == nil {
 			continue
 		}
 		if reason, _ := n.Meta["skip_reason"].(string); reason != "" {
 			skipped[reason]++
 		}
 	}
+
+	// Per-file rollup from the files sidecar (when the backend records it):
+	// the files that failed to parse, with their error locations + node
+	// counts. Bounded so a pathological repo can't bloat the payload.
+	filesWithErrors, indexedFileCount := s.buildIndexHealthFileRollup(repoPrefixes)
 
 	// Density plausibility: even a trivial source file yields a file node
 	// plus at least one symbol, so a populated graph averaging barely more
@@ -2822,6 +2832,12 @@ func (s *Server) buildIndexHealthPayload() map[string]any {
 		"edges_ok":             edgesOK,
 		"nodes_per_file":       nodesPerFile,
 	}
+	if indexedFileCount > 0 {
+		result["indexed_file_count"] = indexedFileCount
+	}
+	if len(filesWithErrors) > 0 {
+		result["files_with_parse_errors"] = filesWithErrors
+	}
 	if len(skipped) > 0 {
 		result["skipped"] = skipped
 	}
@@ -2836,6 +2852,41 @@ func (s *Server) buildIndexHealthPayload() map[string]any {
 	}
 
 	return result
+}
+
+// buildIndexHealthFileRollup reads the per-file metadata sidecar (when the
+// backend implements graph.FileMetaReader) across the supplied repo prefixes
+// and returns the files that recorded parse errors — each with its error
+// locations + node count — plus the total indexed-file count. The error list
+// is bounded so a badly-broken repo can't bloat the index_health payload.
+func (s *Server) buildIndexHealthFileRollup(repoPrefixes map[string]struct{}) (filesWithErrors []map[string]any, indexedFileCount int) {
+	reader, ok := s.graph.(graph.FileMetaReader)
+	if !ok {
+		return nil, 0
+	}
+	const maxErrorFiles = 100
+	for prefix := range repoPrefixes {
+		rows, err := reader.FileMetasForRepo(prefix)
+		if err != nil {
+			continue
+		}
+		indexedFileCount += len(rows)
+		for _, r := range rows {
+			if r.Errors == "" || len(filesWithErrors) >= maxErrorFiles {
+				continue
+			}
+			entry := map[string]any{
+				"file":       r.FilePath,
+				"node_count": r.NodeCount,
+			}
+			var locs []string
+			if json.Unmarshal([]byte(r.Errors), &locs) == nil && len(locs) > 0 {
+				entry["errors"] = locs
+			}
+			filesWithErrors = append(filesWithErrors, entry)
+		}
+	}
+	return filesWithErrors, indexedFileCount
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/parser/parsetree.go
+++ b/internal/parser/parsetree.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"fmt"
 	"sync/atomic"
 
 	sitter "github.com/zzet/gortex/internal/parser/tsitter"
@@ -133,5 +134,40 @@ func walkParseErrors(n *sitter.Node, count *int) {
 	childCount := int(n.ChildCount())
 	for i := 0; i < childCount; i++ {
 		walkParseErrors(n.Child(i), count)
+	}
+}
+
+// parseErrorLocationCap bounds the number of error locations collected so a
+// pathologically broken file can't produce a multi-kilobyte errors blob.
+const parseErrorLocationCap = 50
+
+// ParseErrorLocations returns the 1-based "row:col" location of each ERROR /
+// MISSING node, capped at parseErrorLocationCap. Returns nil when the tree is
+// nil or clean — the per-file metadata sidecar stores these as a JSON array
+// so index_health can point at where a file failed to parse.
+func (pt *ParseTree) ParseErrorLocations() []string {
+	if pt == nil || pt.tree == nil {
+		return nil
+	}
+	root := pt.tree.RootNode()
+	if root == nil {
+		return nil
+	}
+	var locs []string
+	walkParseErrorLocations(root, &locs)
+	return locs
+}
+
+func walkParseErrorLocations(n *sitter.Node, locs *[]string) {
+	if n == nil || len(*locs) >= parseErrorLocationCap {
+		return
+	}
+	if n.Type() == "ERROR" || n.IsMissing() {
+		p := n.StartPoint()
+		*locs = append(*locs, fmt.Sprintf("%d:%d", p.Row+1, p.Column+1))
+	}
+	childCount := int(n.ChildCount())
+	for i := 0; i < childCount && len(*locs) < parseErrorLocationCap; i++ {
+		walkParseErrorLocations(n.Child(i), locs)
 	}
 }


### PR DESCRIPTION
Adds the two storage-schema items, building on the reference-completeness work that already merged (#160). Follow-up because those commits landed after #160 was merged.

### Typed / indexable node columns
Promote `is_async` / `is_static` / `is_abstract` / `is_exported` / `return_type` / `updated_at` out of the JSON meta blob into typed, nullable SQLite columns — stripped from the blob on write and restored into `Meta` on read, the same mechanism as `signature` / `visibility` / `doc` / `external`. Also adds `start_column` / `end_column` as first-class `Node` struct fields with their own `NOT NULL DEFAULT 0` columns. A `SELECT … WHERE is_async = 1` filter now resolves without decoding the blob. `ensureNodeColumns` ALTERs older databases in place; the wire-contract fingerprint is bumped for the additive `Node` fields (old gob snapshots still decode with them zero).

### Per-file `files` sidecar
A per-file metadata table — BLAKE3 content hash (the Merkle leaf), byte size, extracted node count, and a JSON array of parse-error locations — written by the indexer after each file's nodes are batched, with both the on-disk and in-memory backends implementing the `FileMetaWriter` / `FileMetaReader` capability. The Merkle tree stays the authoritative change detector; this is queryable supplementary metadata. `index_health` now reports `indexed_file_count` and `files_with_parse_errors` (per-file error locations + node counts), and a `ParseTree.ParseErrorLocations` helper surfaces where a file failed to parse.

### Verification
Unit tests for both: `TestPromotedColumns_NewColumns` (the no-blob-decode `is_async` filter + struct-column round-trip), `TestFileMetas_RoundTrip` (sidecar CRUD), `TestPersistFileMeta_PopulatesFilesSidecar` (end-to-end population). `internal/graph`, `internal/graph/store_sqlite`, `internal/indexer`, `internal/parser`, `internal/mcp`, and `cmd/gortex` (wire-contract golden) are all `-race` green.
