### PR TITLE
feat: add dry-run intake manifest

### DIFF
--- a/cmd/gortex/init.go
+++ b/cmd/gortex/init.go
@@ -61,13 +61,14 @@ var (
 	initSkillsMaxSkills int
 
 	// Non-interactive / reporting knobs
-	initYes         bool
-	initInteractive bool
-	initAgents      string
-	initAgentsSkip  string
-	initJSON        bool
-	initDryRun      bool
-	initForce       bool
+	initYes          bool
+	initInteractive  bool
+	initAgents       string
+	initAgentsSkip   string
+	initJSON         bool
+	initDryRun       bool
+	initDryRunIntake bool
+	initForce        bool
 )
 
 var initCmd = &cobra.Command{
@@ -103,6 +104,7 @@ func init() {
 	initCmd.Flags().StringVar(&initAgentsSkip, "agents-skip", "", "comma-separated list of agents to skip (composable with --agents)")
 	initCmd.Flags().BoolVar(&initJSON, "json", false, "emit a structured JSON report on stdout")
 	initCmd.Flags().BoolVar(&initDryRun, "dry-run", false, "plan writes without modifying disk")
+	initCmd.Flags().BoolVar(&initDryRunIntake, "dry-run-intake", false, "emit a privacy-safe corpus intake manifest and exit before parsing or writing")
 	initCmd.Flags().BoolVar(&initForce, "force", false, "overwrite keys we would otherwise preserve during a merge")
 
 	rootCmd.AddCommand(initCmd)
@@ -155,7 +157,7 @@ func runInit(cmd *cobra.Command, args []string) (err error) {
 	//   * Non-TTY or --yes: fall through to the legacy bufio prompt for
 	//     the single hooks question so CI scripts that piped a yes/no
 	//     line into `gortex init` keep working.
-	wantWizard := initInteractive || (!initYes && !initHooksOnly && progress.IsTTY(cmd.ErrOrStderr()) && isInteractive())
+	wantWizard := initInteractive || (!initDryRunIntake && !initYes && !initHooksOnly && progress.IsTTY(cmd.ErrOrStderr()) && isInteractive())
 	if wantWizard {
 		cancelled, err := runInitWizard(cmd, &cobraInitState{
 			rootPath: root,
@@ -179,6 +181,9 @@ func runInit(cmd *cobra.Command, args []string) (err error) {
 	absRoot, err := filepath.Abs(root)
 	if err != nil {
 		return err
+	}
+	if initDryRunIntake {
+		return emitInitDryRunIntake(cmd, absRoot)
 	}
 
 	// Bind this directory as a single-project entry point so the MCP

--- a/cmd/gortex/init_intake.go
+++ b/cmd/gortex/init_intake.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+func emitInitDryRunIntake(cmd *cobra.Command, root string) error {
+	cfg, err := config.Load("")
+	if err != nil {
+		cfg = &config.Config{}
+	}
+
+	g := graph.New()
+	reg := parser.NewRegistry()
+	languages.RegisterAll(reg)
+	idx := indexer.New(g, reg, cfg.Index, zap.NewNop())
+
+	manifest, err := idx.DryRunIntake(context.Background(), root)
+	if err != nil {
+		return err
+	}
+	manifest.RepoRef = gitRepoRef(root)
+
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(manifest)
+}
+
+func gitRepoRef(root string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	headBytes, err := exec.CommandContext(ctx, "git", "-C", root, "rev-parse", "--short", "HEAD").Output()
+	if err != nil {
+		return "unknown"
+	}
+	head := strings.TrimSpace(string(headBytes))
+	if head == "" {
+		head = "unknown"
+	}
+
+	statusBytes, err := exec.CommandContext(ctx, "git", "-C", root, "status", "--porcelain").Output()
+	if err != nil {
+		return head
+	}
+	if strings.TrimSpace(string(statusBytes)) != "" {
+		return head + "+dirty"
+	}
+	return head
+}

--- a/cmd/gortex/init_integration_test.go
+++ b/cmd/gortex/init_integration_test.go
@@ -179,11 +179,11 @@ func TestInitCreatesProjectMarker(t *testing.T) {
 // would silently bind the directory.
 func TestInitDryRunSkipsProjectMarker(t *testing.T) {
 	saved := struct {
-		yes, dryRun, json bool
-		agents            string
-	}{initYes, initDryRun, initJSON, initAgents}
+		yes, dryRun, json, dryRunIntake bool
+		agents                          string
+	}{initYes, initDryRun, initJSON, initDryRunIntake, initAgents}
 	t.Cleanup(func() {
-		initYes, initDryRun, initJSON = saved.yes, saved.dryRun, saved.json
+		initYes, initDryRun, initJSON, initDryRunIntake = saved.yes, saved.dryRun, saved.json, saved.dryRunIntake
 		initAgents = saved.agents
 	})
 
@@ -209,5 +209,57 @@ func TestInitDryRunSkipsProjectMarker(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(repo, ".gortex")); err == nil {
 		t.Fatal("dry-run wrote .gortex/ — must be planning-only")
+	}
+}
+
+func TestInitDryRunIntakeJSONDoesNotWrite(t *testing.T) {
+	saved := struct {
+		yes, dryRun, json, dryRunIntake bool
+		agents                          string
+	}{initYes, initDryRun, initJSON, initDryRunIntake, initAgents}
+	t.Cleanup(func() {
+		initYes, initDryRun, initJSON, initDryRunIntake = saved.yes, saved.dryRun, saved.json, saved.dryRunIntake
+		initAgents = saved.agents
+	})
+
+	repo := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	if err := os.WriteFile(filepath.Join(repo, "main.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "notes.txt"), []byte(strings.Repeat("x", 32)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	initYes = true
+	initDryRunIntake = true
+	initDryRun = false
+	initJSON = false
+	initAgents = ""
+
+	var stdout, stderr bytes.Buffer
+	initCmd.SetOut(&stdout)
+	initCmd.SetErr(&stderr)
+	t.Cleanup(func() {
+		initCmd.SetOut(nil)
+		initCmd.SetErr(nil)
+	})
+
+	if err := runInit(initCmd, []string{repo}); err != nil {
+		t.Fatalf("runInit: %v\nstderr: %s", err, stderr.String())
+	}
+
+	var report map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("non-JSON stdout: %v\n%s", err, stdout.String())
+	}
+	if report["schema_version"] != "gortex.index_intake.v1" {
+		t.Fatalf("unexpected schema: %v", report["schema_version"])
+	}
+	if report["raw_paths_included"] != false || report["raw_file_contents_included"] != false {
+		t.Fatalf("manifest must not include raw paths/content: %v", report)
+	}
+	if _, err := os.Stat(filepath.Join(repo, ".gortex")); err == nil {
+		t.Fatal("dry-run-intake wrote .gortex/ — must be inspection-only")
 	}
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -3,6 +3,7 @@
 ```
 gortex install               One-time machine-wide setup (user-level MCP, skills, hooks, daemon wiring)
 gortex init [path]           Per-repo setup (.mcp.json, hooks, community routing, per-community SKILL.md)
+gortex init --dry-run-intake Emit a privacy-safe intake manifest and exit before parsing/writes
 gortex init doctor           Zero-op drift report across all detected agents (human or --json)
 gortex mcp [flags]           Start the MCP stdio server (auto-detects daemon; --no-daemon / --proxy; --server adds HTTP API)
 gortex daemon start [flags]  Start the daemon; --http-addr <addr> serves the HTTP/JSON API under /v1/* plus the MCP /mcp transport (--http-auth-token, --cors-origin)
@@ -75,6 +76,8 @@ gortex init --no-skills                 # skip community-routing generation
 gortex init --skills-min-size 5 --skills-max 10   # tune the generator
 gortex init --hooks-only                # (re)install repo-local hooks only, skip everything else
 gortex init --no-hooks                  # full init but skip hook installation
+gortex init --dry-run-intake --json     # inspect admitted/skipped corpus buckets; no parsing/storage/writes,
+                                        # no raw paths or file contents in the report
 
 # Run the MCP server standalone (auto-detects daemon via stdio; --no-daemon forces embedded):
 gortex mcp --index /path/to/repo --watch

--- a/internal/indexer/intake_manifest.go
+++ b/internal/indexer/intake_manifest.go
@@ -1,0 +1,225 @@
+package indexer
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// IntakeManifest is a privacy-safe, pre-extraction view of the corpus
+// admitted by the index walk. It intentionally reports aggregate buckets and
+// path hashes instead of raw paths or file contents so users can share it in
+// issue reports for private repositories.
+type IntakeManifest struct {
+	SchemaVersion                string         `json:"schema_version"`
+	RepoRef                      string         `json:"repo_ref,omitempty"`
+	FilesSeen                    int            `json:"files_seen"`
+	BytesSeen                    int64          `json:"bytes_seen"`
+	FilesAdmitted                int            `json:"files_admitted"`
+	BytesAdmitted                int64          `json:"bytes_admitted"`
+	FilesSkipped                 int            `json:"files_skipped"`
+	BytesSkipped                 int64          `json:"bytes_skipped"`
+	TopAdmittedExtensionsByBytes []IntakeBucket `json:"top_admitted_extensions_by_bytes"`
+	TopSkippedExtensionsByBytes  []IntakeBucket `json:"top_skipped_extensions_by_bytes"`
+	TopAdmittedDirsByBytes       []DirBucket    `json:"top_admitted_dirs_by_bytes"`
+	LargestAdmittedFiles         []FileBucket   `json:"largest_admitted_files"`
+	RawPathsIncluded             bool           `json:"raw_paths_included"`
+	RawFileContentsIncluded      bool           `json:"raw_file_contents_included"`
+}
+
+type IntakeBucket struct {
+	Key    string `json:"key"`
+	Files  int    `json:"files"`
+	Bytes  int64  `json:"bytes"`
+	Reason string `json:"reason,omitempty"`
+}
+
+type DirBucket struct {
+	PathHash string `json:"path_hash"`
+	Depth    int    `json:"depth"`
+	Files    int    `json:"files"`
+	Bytes    int64  `json:"bytes"`
+}
+
+type FileBucket struct {
+	PathHash string `json:"path_hash"`
+	Ext      string `json:"ext"`
+	Bytes    int64  `json:"bytes"`
+}
+
+// DryRunIntake walks root with the same high-level language, ignore, prune and
+// max-size gates used before IndexCtx starts extraction. It does not parse,
+// extract, embed, or store anything.
+func (idx *Indexer) DryRunIntake(_ context.Context, root string) (*IntakeManifest, error) {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, err
+	}
+
+	maxSize := idx.config.MaxFileSize
+	manifest := &IntakeManifest{
+		SchemaVersion:           "gortex.index_intake.v1",
+		RawPathsIncluded:        false,
+		RawFileContentsIncluded: false,
+	}
+	admittedExt := map[string]*IntakeBucket{}
+	skippedExt := map[string]*IntakeBucket{}
+	admittedDirs := map[string]*DirBucket{}
+	largest := make([]FileBucket, 0, 16)
+
+	err = filepath.WalkDir(absRoot, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if d.IsDir() {
+			if idx.shouldPruneDir(path, absRoot) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		info, statErr := d.Info()
+		if statErr != nil {
+			return nil
+		}
+		size := info.Size()
+		manifest.FilesSeen++
+		manifest.BytesSeen += size
+
+		reason := ""
+		lang, ok := idx.effectiveLanguage(path, nil)
+		if !ok {
+			reason = "no_language"
+		} else if idx.shouldExclude(path, absRoot, false) {
+			reason = "excluded"
+		} else if maxSize > 0 && size > maxSize {
+			reason = "max_file_size"
+		}
+
+		if reason != "" {
+			manifest.FilesSkipped++
+			manifest.BytesSkipped += size
+			b := ensureIntakeBucket(skippedExt, extKey(path))
+			b.Files++
+			b.Bytes += size
+			if b.Reason == "" {
+				b.Reason = reason
+			}
+			return nil
+		}
+
+		_ = lang // language detection is the admission gate; buckets stay extension-based for issue reports.
+		manifest.FilesAdmitted++
+		manifest.BytesAdmitted += size
+
+		ext := extKey(path)
+		extBucket := ensureIntakeBucket(admittedExt, ext)
+		extBucket.Files++
+		extBucket.Bytes += size
+
+		key, depth := hashedDirBucket(absRoot, path)
+		dirBucket := admittedDirs[key]
+		if dirBucket == nil {
+			dirBucket = &DirBucket{PathHash: key, Depth: depth}
+			admittedDirs[key] = dirBucket
+		}
+		dirBucket.Files++
+		dirBucket.Bytes += size
+
+		rel, _ := filepath.Rel(absRoot, path)
+		largest = append(largest, FileBucket{PathHash: hashPath(rel), Ext: ext, Bytes: size})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	manifest.TopAdmittedExtensionsByBytes = topIntakeBuckets(admittedExt, 20)
+	manifest.TopSkippedExtensionsByBytes = topIntakeBuckets(skippedExt, 20)
+	manifest.TopAdmittedDirsByBytes = topDirBuckets(admittedDirs, 20)
+	manifest.LargestAdmittedFiles = topFileBuckets(largest, 20)
+	return manifest, nil
+}
+
+func ensureIntakeBucket(m map[string]*IntakeBucket, key string) *IntakeBucket {
+	b := m[key]
+	if b == nil {
+		b = &IntakeBucket{Key: key}
+		m[key] = b
+	}
+	return b
+}
+
+func extKey(path string) string {
+	ext := strings.TrimPrefix(strings.ToLower(filepath.Ext(path)), ".")
+	if ext == "" {
+		return "[none]"
+	}
+	return ext
+}
+
+func hashedDirBucket(root, path string) (string, int) {
+	rel, err := filepath.Rel(root, filepath.Dir(path))
+	if err != nil || rel == "." || rel == "" {
+		return hashPath("."), 0
+	}
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	depth := 1
+	return hashPath(parts[0]), depth
+}
+
+func hashPath(rel string) string {
+	sum := sha256.Sum256([]byte(filepath.ToSlash(rel)))
+	return hex.EncodeToString(sum[:8])
+}
+
+func topIntakeBuckets(m map[string]*IntakeBucket, limit int) []IntakeBucket {
+	out := make([]IntakeBucket, 0, len(m))
+	for _, b := range m {
+		out = append(out, *b)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Bytes == out[j].Bytes {
+			return out[i].Key < out[j].Key
+		}
+		return out[i].Bytes > out[j].Bytes
+	})
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
+
+func topDirBuckets(m map[string]*DirBucket, limit int) []DirBucket {
+	out := make([]DirBucket, 0, len(m))
+	for _, b := range m {
+		out = append(out, *b)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Bytes == out[j].Bytes {
+			return out[i].PathHash < out[j].PathHash
+		}
+		return out[i].Bytes > out[j].Bytes
+	})
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
+
+func topFileBuckets(files []FileBucket, limit int) []FileBucket {
+	sort.Slice(files, func(i, j int) bool {
+		if files[i].Bytes == files[j].Bytes {
+			return files[i].PathHash < files[j].PathHash
+		}
+		return files[i].Bytes > files[j].Bytes
+	})
+	if len(files) > limit {
+		files = files[:limit]
+	}
+	return files
+}


### PR DESCRIPTION
## Summary

Implements the privacy-safe intake diagnostic discussed in #120:

- adds `gortex init --dry-run-intake`
- exits before parsing/extraction/storage/writes
- emits JSON with aggregate intake counts, top admitted/skipped extensions by bytes, hashed top admitted dirs, hashed largest admitted files, repo ref, and explicit privacy flags
- reuses the index walk's language/ignore/prune/max-file-size gates so the report answers "what enters the expensive index pipeline?" without exposing raw paths or file contents

This is meant for private mixed repos where maintainers need to distinguish corpus admission from downstream extractor/flush memory growth.

## Validation

- `go test ./internal/indexer -run TestNonexistent -count=0`
- `go test ./cmd/gortex -run 'TestInitDryRunIntakeJSONDoesNotWrite|TestInitDryRunSkipsProjectMarker' -count=1`
- `go test ./cmd/gortex -run TestNonexistent -count=0`
- `git diff --check`
- smoke: built `/tmp/gortex-intake`, ran `gortex init --dry-run-intake` on a temp repo with source + binary-ish assets, verified schema/privacy flags/files counts

Full `go test ./internal/indexer ./cmd/gortex` was attempted first, but exceeded the local 180s command timeout while compiling/running the larger cmd/indexer package set; the targeted compile/tests above passed.
