### PR TITLE
Write OpenCode MCP config to opencode.json, not .opencode/config.json

### DIFF
--- a/cmd/gortex/testdata/agent-render/opencode.txt
+++ b/cmd/gortex/testdata/agent-render/opencode.txt
@@ -1,4 +1,9 @@
-=== root/.opencode/config.json ===
+=== root/AGENTS.md ===
+<!-- gortex:communities:start -->
+- [example-community](.claude/skills/example/SKILL.md) — example routing block
+
+<!-- gortex:communities:end -->
+=== root/opencode.json ===
 {
   "$schema": "https://opencode.ai/config.json",
   "mcp": {
@@ -15,8 +20,3 @@
     }
   }
 }
-=== root/AGENTS.md ===
-<!-- gortex:communities:start -->
-- [example-community](.claude/skills/example/SKILL.md) — example routing block
-
-<!-- gortex:communities:end -->

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -33,7 +33,7 @@ commands accept `--agents=<csv>` to constrain setup and
 | `kilocode`      | `mcp_settings.json` + `.kilocode/mcp.json`, `.kilocoderules` communities block                  | both       | https://kilo.ai/docs/features/mcp/using-mcp-in-kilo-code            |
 | `kiro`          | `.kiro/settings/mcp.json` + steering/hooks or user-level                                        | both       | https://kiro.dev/docs/mcp/configuration                             |
 | `oh-my-pi`      | `.omp/mcp.json`                                                                                 | project    | https://github.com/can1357/oh-my-pi/blob/main/docs/mcp-config.md   |
-| `opencode`      | `.opencode/config.json`, `AGENTS.md` communities block                                          | project    | https://opencode.ai/docs/mcp                                        |
+| `opencode`      | `opencode.json` (or existing `opencode.jsonc`), `AGENTS.md` communities block                   | project    | https://opencode.ai/docs/mcp                                        |
 | `openclaw`      | `~/.openclaw/openclaw.json` (`mcp.servers.gortex`)                                              | user       | https://docs.openclaw.ai/cli/mcp                                    |
 | `vscode`        | `.vscode/mcp.json` (`servers` key, 1.102+), `.github/copilot-instructions.md` communities block | project    | https://code.visualstudio.com/docs/copilot/chat/mcp-servers         |
 | `windsurf`      | `~/.codeium/mcp_config.json`, `.windsurfrules` communities block                                | both       | https://docs.windsurf.com/plugins/cascade/mcp                       |
@@ -236,9 +236,12 @@ keys Kiro's UI expects.
 
 ### opencode
 
-OpenCode's schema differs from the canonical form: top-level
-`mcp.<name>` (not `mcpServers`), `command` is an array, env key
-is `environment`, plus a `$schema` pointer at
+The MCP config is written to a root `opencode.json` (or merged into an
+existing `opencode.json` / `opencode.jsonc`) — the files OpenCode
+actually reads. It does **not** read `.opencode/config.json`, which
+Gortex wrote historically. OpenCode's schema also differs from the
+canonical form: top-level `mcp.<name>` (not `mcpServers`), `command` is
+an array, env key is `environment`, plus a `$schema` pointer at
 `https://opencode.ai/config.json`.
 
 ### openclaw

--- a/internal/agents/opencode/adapter.go
+++ b/internal/agents/opencode/adapter.go
@@ -1,5 +1,13 @@
 // Package opencode implements the Gortex init integration for
-// OpenCode. OpenCode uses a different MCP schema than the canonical
+// OpenCode. OpenCode reads its project config from `opencode.json` or
+// `opencode.jsonc` at the repo root (and `~/.config/opencode/` for the
+// global config); it does NOT read `.opencode/config.json` — Gortex
+// wrote there historically and OpenCode silently ignored it, so the MCP
+// server was never registered. We now write the MCP stanza to a root
+// `opencode.json` (or merge into an existing `opencode.json` /
+// `opencode.jsonc`).
+//
+// OpenCode uses a different MCP schema than the canonical
 // Claude / Cursor shape:
 //
 //	{
@@ -51,9 +59,24 @@ func (a *Adapter) Detect(env agents.Env) (bool, error) {
 	return false, nil
 }
 
+// projectConfigPath resolves the file the MCP stanza should be written
+// into. OpenCode reads `opencode.json` / `opencode.jsonc` from the repo
+// root, so we merge into an existing one (preferring `.jsonc`, since a
+// hand-authored, comment-bearing config keeps its extension) and
+// otherwise default to a fresh `opencode.json`.
+func projectConfigPath(root string) string {
+	for _, name := range []string{"opencode.jsonc", "opencode.json"} {
+		p := filepath.Join(root, name)
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	return filepath.Join(root, "opencode.json")
+}
+
 func (a *Adapter) Plan(env agents.Env) (*agents.Plan, error) {
 	p := &agents.Plan{Files: []agents.FileAction{
-		{Path: filepath.Join(env.Root, ".opencode", "config.json"), Action: agents.ActionWouldMerge, Keys: []string{"mcp"}},
+		{Path: projectConfigPath(env.Root), Action: agents.ActionWouldMerge, Keys: []string{"mcp"}},
 	}}
 	if env.Mode != agents.ModeGlobal && env.SkillsRouting != "" {
 		p.Files = append(p.Files, agents.FileAction{
@@ -77,7 +100,15 @@ func (a *Adapter) Apply(env agents.Env, opts agents.ApplyOpts) (*agents.Result, 
 	}
 	internalutil.Logf(env.Stderr, "[gortex init] setting up OpenCode integration...")
 
-	path := filepath.Join(env.Root, ".opencode", "config.json")
+	path := projectConfigPath(env.Root)
+	// Gortex used to write `.opencode/config.json`, which OpenCode does
+	// not read. If that stale file is still around, point the user at
+	// the config we're actually writing now.
+	if legacy := filepath.Join(env.Root, ".opencode", "config.json"); legacy != path {
+		if _, err := os.Stat(legacy); err == nil {
+			internalutil.Logf(env.Stderr, "[gortex init] note: %s is no longer read by OpenCode; writing the MCP config to %s instead", legacy, filepath.Base(path))
+		}
+	}
 	action, err := agents.MergeJSON(env.Stderr, path, func(root map[string]any, _ bool) (bool, error) {
 		mcpSection, ok := root["mcp"].(map[string]any)
 		if !ok {

--- a/internal/agents/opencode/adapter_test.go
+++ b/internal/agents/opencode/adapter_test.go
@@ -11,9 +11,13 @@ import (
 
 // TestOpenCodeUsesMCPSectionKey verifies we write under "mcp",
 // not "mcpServers" — OpenCode's schema differs from the canonical
-// Claude / Cursor shape.
+// Claude / Cursor shape — and that the config lands in a root
+// `opencode.json`, the file OpenCode actually reads (not the legacy
+// `.opencode/config.json`).
 func TestOpenCodeUsesMCPSectionKey(t *testing.T) {
 	env, _ := agentstest.NewEnv(t)
+	// `.opencode/` is OpenCode's detection sentinel (it holds agents,
+	// commands, skills) — present, but the MCP config does not live in it.
 	if err := os.MkdirAll(filepath.Join(env.Root, ".opencode"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -23,11 +27,16 @@ func TestOpenCodeUsesMCPSectionKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("apply: %v", err)
 	}
-	// Two creates: .opencode/config.json for MCP plus AGENTS.md for
-	// the instructions block OpenCode reads on every task.
+	// Two creates: opencode.json for MCP plus AGENTS.md for the
+	// instructions block OpenCode reads on every task.
 	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionCreate: 2})
 
-	cfg := agentstest.ReadJSON(t, filepath.Join(env.Root, ".opencode", "config.json"))
+	// The MCP config must be the root opencode.json, not the ignored
+	// .opencode/config.json.
+	if _, err := os.Stat(filepath.Join(env.Root, ".opencode", "config.json")); err == nil {
+		t.Fatalf("must not write the legacy .opencode/config.json (OpenCode ignores it)")
+	}
+	cfg := agentstest.ReadJSON(t, filepath.Join(env.Root, "opencode.json"))
 	if _, ok := cfg["mcpServers"]; ok {
 		t.Fatalf("should not write mcpServers (that's Claude/Cursor shape): %v", cfg)
 	}
@@ -45,6 +54,98 @@ func TestOpenCodeUsesMCPSectionKey(t *testing.T) {
 	}
 	if cfg["$schema"] != SchemaURL {
 		t.Fatalf("expected $schema=%q, got %v", SchemaURL, cfg["$schema"])
+	}
+
+	agentstest.AssertIdempotent(t, a, env)
+}
+
+// TestOpenCodeMergesIntoExistingJSON verifies that when a project
+// already has an opencode.json, we merge into it without clobbering
+// the user's own keys, rather than creating a competing file.
+func TestOpenCodeMergesIntoExistingJSON(t *testing.T) {
+	env, _ := agentstest.NewEnv(t)
+	cfgPath := filepath.Join(env.Root, "opencode.json")
+	agentstest.WriteJSON(t, cfgPath, map[string]any{
+		"$schema": SchemaURL,
+		"theme":   "tokyonight",
+		"mcp": map[string]any{
+			"other": map[string]any{
+				"type":    "local",
+				"command": []string{"other-server"},
+				"enabled": true,
+			},
+		},
+	})
+	a := New()
+
+	if _, err := a.Apply(env, agents.ApplyOpts{ForceDetect: true}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	cfg := agentstest.ReadJSON(t, cfgPath)
+	if cfg["theme"] != "tokyonight" {
+		t.Fatalf("merge clobbered user's top-level key: %v", cfg)
+	}
+	mcp, ok := cfg["mcp"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing 'mcp' section: %v", cfg)
+	}
+	if _, ok := mcp["other"]; !ok {
+		t.Fatalf("merge clobbered existing 'other' server: %v", mcp)
+	}
+	if _, ok := mcp["gortex"]; !ok {
+		t.Fatalf("merge didn't add 'gortex': %v", mcp)
+	}
+
+	agentstest.AssertIdempotent(t, a, env)
+}
+
+// TestOpenCodeMergesIntoExistingJSONC verifies that an existing
+// opencode.jsonc — comments and trailing commas included — is the file
+// we merge into, the user's data survives, and no competing
+// opencode.json is created.
+func TestOpenCodeMergesIntoExistingJSONC(t *testing.T) {
+	env, _ := agentstest.NewEnv(t)
+	jsoncPath := filepath.Join(env.Root, "opencode.jsonc")
+	const jsonc = `{
+  // OpenCode project config
+  "$schema": "https://opencode.ai/config.json",
+  "theme": "tokyonight", /* dark theme */
+  "mcp": {
+    "other": { "type": "local", "command": ["other-server"], "enabled": true },
+  },
+}`
+	if err := os.WriteFile(jsoncPath, []byte(jsonc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	a := New()
+
+	if _, err := a.Apply(env, agents.ApplyOpts{ForceDetect: true}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	// We must have merged into the .jsonc, not created a sibling .json.
+	if _, err := os.Stat(filepath.Join(env.Root, "opencode.json")); err == nil {
+		t.Fatalf("must not create opencode.json when opencode.jsonc already exists")
+	}
+	// A commented config is valid JSONC, not malformed — no backup.
+	if _, err := os.Stat(jsoncPath + ".bak"); err == nil {
+		t.Fatalf("a valid commented .jsonc must not be backed up as malformed")
+	}
+
+	cfg := agentstest.ReadJSON(t, jsoncPath)
+	if cfg["theme"] != "tokyonight" {
+		t.Fatalf("merge dropped user's data keys: %v", cfg)
+	}
+	mcp, ok := cfg["mcp"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing 'mcp' section: %v", cfg)
+	}
+	if _, ok := mcp["other"]; !ok {
+		t.Fatalf("merge clobbered existing 'other' server: %v", mcp)
+	}
+	if _, ok := mcp["gortex"]; !ok {
+		t.Fatalf("merge didn't add 'gortex': %v", mcp)
 	}
 
 	agentstest.AssertIdempotent(t, a, env)

--- a/internal/agents/writer.go
+++ b/internal/agents/writer.go
@@ -178,7 +178,18 @@ func MergeJSON(w io.Writer, path string, mutate func(root map[string]any, existe
 			// An empty (or whitespace-only) file is an empty object, not
 			// malformed — no backup, nothing to preserve.
 		default:
-			if err := json.Unmarshal(data, &root); err != nil {
+			// `.jsonc` / `.json5` configs (e.g. OpenCode's
+			// opencode.jsonc) may carry comments and trailing commas
+			// that encoding/json rejects. Sanitize those before the
+			// parse so a commented config merges instead of being
+			// treated as malformed and clobbered. Comments are not
+			// round-tripped through the re-marshal — same policy as
+			// MergeTOML.
+			parse := data
+			if isJSONCPath(path) {
+				parse = stripJSONComments(data)
+			}
+			if err := json.Unmarshal(parse, &root); err != nil {
 				// Don't silently overwrite the user's file even if it's
 				// malformed — keep a backup for recovery. The backup is
 				// written only on the real write path below, so a DryRun
@@ -231,6 +242,109 @@ func MergeJSON(w io.Writer, path string, mutate func(root map[string]any, existe
 	}
 	logf(w, "[gortex init] %s %s", actionVerb(action), path)
 	return FileAction{Path: path, Action: action, Keys: keys}, nil
+}
+
+// isJSONCPath reports whether path uses a JSON-with-comments extension
+// (`.jsonc` / `.json5`) whose contents may need sanitising before they
+// can be handed to encoding/json.
+func isJSONCPath(path string) bool {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".jsonc", ".json5":
+		return true
+	default:
+		return false
+	}
+}
+
+// stripJSONComments rewrites JSONC / JSON5-style input into strict JSON
+// that encoding/json can parse: it drops `//` line comments, `/* */`
+// block comments, and trailing commas before `}` / `]`. String literals
+// (and their escape sequences) are copied through untouched, so a `//`
+// or comma inside a quoted value is preserved. The result is only used
+// for parsing — the merged map is re-marshalled fresh, so the original
+// comments and formatting are not carried over (matching MergeTOML).
+func stripJSONComments(b []byte) []byte {
+	out := make([]byte, 0, len(b))
+	inString, escaped := false, false
+	for i := 0; i < len(b); i++ {
+		c := b[i]
+		if inString {
+			out = append(out, c)
+			switch {
+			case escaped:
+				escaped = false
+			case c == '\\':
+				escaped = true
+			case c == '"':
+				inString = false
+			}
+			continue
+		}
+		switch {
+		case c == '"':
+			inString = true
+			out = append(out, c)
+		case c == '/' && i+1 < len(b) && b[i+1] == '/':
+			// Line comment: skip to (but keep) the newline.
+			for i+1 < len(b) && b[i+1] != '\n' {
+				i++
+			}
+		case c == '/' && i+1 < len(b) && b[i+1] == '*':
+			// Block comment: skip through the closing */.
+			i += 2
+			for i+1 < len(b) && (b[i] != '*' || b[i+1] != '/') {
+				i++
+			}
+			i++ // step onto '/', loop's i++ moves past it
+		default:
+			out = append(out, c)
+		}
+	}
+	return stripTrailingCommas(out)
+}
+
+// stripTrailingCommas removes a comma that is followed (ignoring
+// whitespace) by a `}` or `]` — JSONC / JSON5 permit it, strict JSON
+// does not. Commas inside string literals are left alone.
+func stripTrailingCommas(b []byte) []byte {
+	out := make([]byte, 0, len(b))
+	inString, escaped := false, false
+	for i := range len(b) {
+		c := b[i]
+		if inString {
+			out = append(out, c)
+			switch {
+			case escaped:
+				escaped = false
+			case c == '\\':
+				escaped = true
+			case c == '"':
+				inString = false
+			}
+			continue
+		}
+		if c == '"' {
+			inString = true
+			out = append(out, c)
+			continue
+		}
+		if c == ',' {
+			j := i + 1
+			for j < len(b) {
+				switch b[j] {
+				case ' ', '\t', '\n', '\r':
+					j++
+					continue
+				}
+				break
+			}
+			if j < len(b) && (b[j] == '}' || b[j] == ']') {
+				continue // drop the trailing comma
+			}
+		}
+		out = append(out, c)
+	}
+	return out
 }
 
 // actionVerb renders an ActionKind for human-readable log lines.

--- a/internal/agents/writer_test.go
+++ b/internal/agents/writer_test.go
@@ -174,6 +174,73 @@ func TestMergeJSONCreatesMergesAndSkipsIdempotent(t *testing.T) {
 	}
 }
 
+// TestStripJSONComments covers the JSONC sanitiser: comments and
+// trailing commas are removed, but `//`, `/* */`, and commas inside
+// string literals are preserved.
+func TestStripJSONComments(t *testing.T) {
+	in := `{
+  // a line comment
+  "url": "https://example.com/path", /* block */
+  "note": "a, b, c // not a comment",
+  "list": [1, 2, 3,],
+  "obj": { "k": "v", },
+}`
+	got := stripJSONComments([]byte(in))
+	var out map[string]any
+	if err := json.Unmarshal(got, &out); err != nil {
+		t.Fatalf("sanitised JSONC did not parse: %v\n---\n%s", err, got)
+	}
+	if out["url"] != "https://example.com/path" {
+		t.Fatalf("`//` inside a string was stripped: %v", out["url"])
+	}
+	if out["note"] != "a, b, c // not a comment" {
+		t.Fatalf("comment/comma inside a string was altered: %v", out["note"])
+	}
+	if list, ok := out["list"].([]any); !ok || len(list) != 3 {
+		t.Fatalf("trailing comma handling broke the array: %v", out["list"])
+	}
+}
+
+// TestMergeJSON_JSONCMergesInsteadOfClobbering guards the OpenCode
+// path: merging into an existing `.jsonc` with comments must preserve
+// the user's data keys (not back the file up as malformed and start
+// fresh).
+func TestMergeJSON_JSONCMergesInsteadOfClobbering(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "opencode.jsonc")
+	if err := os.WriteFile(path, []byte(`{
+  // user config
+  "theme": "dark",
+}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	add := func(root map[string]any, _ bool) (bool, error) {
+		root["added"] = true
+		return true, nil
+	}
+	a, err := MergeJSON(io.Discard, path, add, ApplyOpts{})
+	if err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+	if a.Action != ActionMerge {
+		t.Fatalf("expected merge, got %q", a.Action)
+	}
+	if _, err := os.Stat(path + ".bak"); err == nil {
+		t.Fatalf("a valid commented .jsonc must not be backed up as malformed")
+	}
+	var out map[string]any
+	data, _ := os.ReadFile(path)
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("re-marshalled output not valid JSON: %v", err)
+	}
+	if out["theme"] != "dark" {
+		t.Fatalf("merge dropped the user's data key: %v", out)
+	}
+	if out["added"] != true {
+		t.Fatalf("merge didn't apply the mutation: %v", out)
+	}
+}
+
 // TestRegistryFilterValidatesNames ensures we hard-error on typos
 // rather than silently dropping them — a key UX requirement from the
 // init plan.


### PR DESCRIPTION
## Problem

`gortex init` wrote the OpenCode MCP stanza to `.opencode/config.json`, but OpenCode reads its project config from `opencode.json` / `opencode.jsonc` at the repo root (and `~/.config/opencode/` globally) — it does **not** read `.opencode/config.json`. As a result the gortex MCP server was never registered at project level.

Fixes #164.

## Changes

- **`internal/agents/opencode/adapter.go`** — new `projectConfigPath()` resolves the target: prefer an existing root `opencode.jsonc`, then `opencode.json`, otherwise create `opencode.json`; `Plan`/`Apply` use it. When a stale `.opencode/config.json` is present, logs a note pointing at the file now being written. `Detect` is unchanged (`.opencode/` is still a valid OpenCode sentinel — it holds agents/skills/commands).
- **`internal/agents/writer.go`** — `MergeJSON` gains JSONC tolerance (`//` + `/* */` comments and trailing commas stripped, string contents preserved) for `.jsonc`/`.json5` targets, so merging into a commented `opencode.jsonc` preserves the user's data keys instead of treating the file as malformed. Comments are not carried through the re-marshal — same policy as the existing `MergeTOML`.
- **Tests** — updated `TestOpenCodeUsesMCPSectionKey` (asserts root `opencode.json`, no legacy file), added merge-into-existing `.json` / `.jsonc` adapter tests, plus `stripJSONComments` + JSONC-merge unit tests. Regenerated the `opencode.txt` render golden.
- **`docs/agents.md`** — updated the path table and the `### opencode` section.

## Verification

Built binary, real `gortex init` runs:
- Fresh project → creates `opencode.json`.
- Existing commented `opencode.jsonc` → merges in, preserves `theme` + other MCP servers, no competing `.json`.
- Legacy `.opencode/config.json` present → creates `opencode.json`, prints the migration note, leaves the legacy file untouched.

`go vet`, `golangci-lint`, `go test -race` on touched packages, and the full `cmd/gortex` suite (522 tests) all pass.