### PR TITLE
Broaden function-as-value capture and refine framework route and dispatch resolution

### DIFF
--- a/internal/contracts/route_prefix.go
+++ b/internal/contracts/route_prefix.go
@@ -61,6 +61,7 @@ var routePrefixFrameworks = map[string]bool{
 	"axum":          true, // axum Router .nest mounts
 	"fiber":         true, // gin/echo uppercase verbs label as fiber; same .Group model
 	"vapor":         true, // Vapor .grouped(...) route groups
+	"actix":         true, // Actix web::scope(...) cross-file config mounts
 }
 
 // vaporGroupedRE matches a Vapor route-group binding
@@ -178,6 +179,21 @@ var axumNestRE = regexp.MustCompile(`\.nest\(\s*"([^"]+)"\s*,\s*(\w+)\s*\)`)
 // axumLetBindingRE recovers the router variable a route chain is bound to,
 // e.g. `let api = Router::new().route("/users", get(list));` → "api".
 var axumLetBindingRE = regexp.MustCompile(`let\s+(\w+)\s*=`)
+
+// --- Actix / Rust ----------------------------------------------------------
+
+// actixScopeConfigRE matches a cross-file Actix scope mount,
+// `web::scope("/api").configure(api_routes)` /
+// `web::scope("/api").service(users::routes)`. Group 1 is the scope prefix,
+// group 2 the config-function reference the scope mounts (possibly
+// path-qualified). The config function — defined in another file — registers
+// the routes that inherit the scope prefix.
+var actixScopeConfigRE = regexp.MustCompile(`web::scope\(\s*"([^"]+)"\s*\)\s*\.(?:configure|service)\(\s*([\w:]+)\s*\)`)
+
+// actixFnDefRE matches a Rust function definition `fn api_routes(` / `pub fn
+// api_routes(`. Group 1 is the function name. Used to recover the enclosing
+// config function a route is declared in.
+var actixFnDefRE = regexp.MustCompile(`\bfn\s+(\w+)\s*\(`)
 
 // --- Spring / Rails / Laravel block-scoped prefixes ------------------------
 
@@ -308,6 +324,16 @@ func JoinRouterPrefixes(reg *Registry, scanFiles []string, srcFor func(filePath 
 		// axum: app.nest("/api", api_router)
 		for _, m := range axumNestRE.FindAllStringSubmatch(text, -1) {
 			prefix, child := cleanPrefix(m[1]), m[2]
+			if _, ok := f.mountPrefix[child]; !ok {
+				f.mountPrefix[child] = prefix
+			}
+		}
+
+		// Actix: web::scope("/api").configure(api_routes) — the mounted
+		// config function (in this or another file) registers the routes
+		// that inherit the scope prefix.
+		for _, m := range actixScopeConfigRE.FindAllStringSubmatch(text, -1) {
+			prefix, child := cleanPrefix(m[1]), lastPathSeg(m[2])
 			if _, ok := f.mountPrefix[child]; !ok {
 				f.mountPrefix[child] = prefix
 			}
@@ -595,6 +621,16 @@ func prefixForRoute(
 			return ""
 		}
 		return chainPrefix(varName, map[string]bool{})
+	case "actix":
+		// actix: a route's enclosing config function is mounted under a
+		// web::scope(...) prefix (possibly in another file). Single-file
+		// inline scopes are already joined by the extractor, so this only
+		// adds the cross-file scope-config mount prefix.
+		fnName := routeReceiver(c, framework, srcFor)
+		if fnName == "" {
+			return ""
+		}
+		return chainPrefix(fnName, map[string]bool{})
 	case "nestjs":
 		// Class-level @Controller('cats') prefix, found by scanning
 		// upward from the route line for the nearest preceding
@@ -621,6 +657,11 @@ func prefixForRoute(
 // on, by re-reading the contract's source line. Returns "" when the
 // line can't be read or no receiver is found.
 func routeReceiver(c Contract, framework string, srcFor func(filePath string) []byte) string {
+	// Actix's receiver is the enclosing config function, recovered by
+	// scanning upward over multiple lines rather than from the route line.
+	if framework == "actix" {
+		return actixEnclosingFn(c, srcFor)
+	}
 	line := sourceLine(srcFor(c.FilePath), c.Line)
 	if line == "" {
 		return ""
@@ -652,6 +693,37 @@ func routeReceiver(c Contract, framework string, srcFor func(filePath string) []
 		}
 	}
 	return ""
+}
+
+// actixEnclosingFn scans upward from an Actix route line for the nearest
+// enclosing `fn <name>(` definition and returns that function name, or "" when
+// the route sits outside any function. The function name is the "router var"
+// the cross-file scope-config mount keys on.
+func actixEnclosingFn(c Contract, srcFor func(filePath string) []byte) string {
+	src := srcFor(c.FilePath)
+	if src == nil {
+		return ""
+	}
+	lines := strings.Split(string(src), "\n")
+	idx := c.Line - 1
+	if idx < 0 || idx >= len(lines) {
+		return ""
+	}
+	for i := idx; i >= 0; i-- {
+		if m := actixFnDefRE.FindStringSubmatch(lines[i]); m != nil {
+			return m[1]
+		}
+	}
+	return ""
+}
+
+// lastPathSeg returns the final `::`-separated segment of a Rust path, e.g.
+// "users::routes" -> "routes", "routes" -> "routes".
+func lastPathSeg(ref string) string {
+	if i := strings.LastIndex(ref, "::"); i >= 0 {
+		return ref[i+2:]
+	}
+	return ref
 }
 
 // springClassPrefix scans upward from a Spring route line for the

--- a/internal/contracts/route_prefix.go
+++ b/internal/contracts/route_prefix.go
@@ -69,6 +69,12 @@ var routePrefixFrameworks = map[string]bool{
 // (one or more) path-segment string literals.
 var vaporGroupedRE = regexp.MustCompile(`\b(?:let|var)\s+(\w+)\s*=\s*([\w.]+)\.grouped\(\s*("[^"]*"(?:\s*,\s*"[^"]*")*)`)
 
+// vaporClosureGroupRE matches the closure-block route-group form
+// `app.group("api") {` / `routes.group("v1") { g in`. Routes registered
+// inside the brace block inherit the group prefix. Group 1 is the (one or
+// more) path-segment string literals.
+var vaporClosureGroupRE = regexp.MustCompile(`\.group\(\s*("[^"]*"(?:\s*,\s*"[^"]*")*)\s*\)\s*\{`)
+
 // vaporRouteReceiverRE recovers the receiver variable a Vapor route is declared
 // on — `api` in `api.get("users", use: list)`.
 var vaporRouteReceiverRE = regexp.MustCompile(`\b(\w+)\.(?:get|post|put|delete|patch)\(`)
@@ -561,13 +567,25 @@ func prefixForRoute(
 		// carries its own .Group / .grouped prefix, parents contribute theirs
 		// via the mount chain.
 		varName := routeReceiver(c, framework, srcFor)
-		if varName == "" {
-			return ""
+		mount, self := "", ""
+		if varName != "" {
+			mount = chainPrefix(varName, map[string]bool{})
+			if ps, ok := globalSelf[varName]; ok && !selfConflict[varName] {
+				self = ps
+			}
 		}
-		mount := chainPrefix(varName, map[string]bool{})
-		self := ""
-		if ps, ok := globalSelf[varName]; ok && !selfConflict[varName] {
-			self = ps
+		if framework == "vapor" {
+			// Vapor's closure-block group form `app.group("api") { ... }`
+			// binds no group var, so its prefix is recovered by balancing
+			// braces upward from the route line over the enclosing blocks.
+			closure := vaporClosureGroupPrefix(c, srcFor)
+			joined := joinPaths(closure, mount, self)
+			if joined != "" {
+				return joined
+			}
+			if varName == "" {
+				return ""
+			}
 		}
 		return joinPaths(mount, self)
 	case "axum":
@@ -733,6 +751,47 @@ func laravelGroupPrefix(c Contract, srcFor func(filePath string) []byte) string 
 				// Enclosing open brace: prepend its prefix clause, if any.
 				if m := laravelPrefixRE.FindStringSubmatch(line); m != nil {
 					parts = append([]string{cleanPrefix(m[1])}, parts...)
+				}
+			}
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return joinPaths(parts...)
+}
+
+// vaporClosureGroupPrefix walks upward from a Vapor route line, balancing
+// braces, and joins the prefixes of every enclosing
+// `app.group("api") { ... }` / `routes.group("v1") { g in ... }` closure
+// block. Returns "" when the route sits in no group closure.
+func vaporClosureGroupPrefix(c Contract, srcFor func(filePath string) []byte) string {
+	src := srcFor(c.FilePath)
+	if src == nil {
+		return ""
+	}
+	lines := strings.Split(string(src), "\n")
+	idx := c.Line - 1
+	if idx < 0 || idx >= len(lines) {
+		return ""
+	}
+	depth := 0
+	var parts []string
+	for i := idx - 1; i >= 0; i-- {
+		line := lines[i]
+		for j := len(line) - 1; j >= 0; j-- {
+			switch line[j] {
+			case '}':
+				depth++
+			case '{':
+				if depth > 0 {
+					depth--
+					continue
+				}
+				// Enclosing open brace at depth 0: prepend its group
+				// prefix when the brace opens a `.group(...)` closure.
+				if m := vaporClosureGroupRE.FindStringSubmatch(line); m != nil {
+					parts = append([]string{vaporGroupSegments(m[1])}, parts...)
 				}
 			}
 		}

--- a/internal/contracts/route_prefix_test.go
+++ b/internal/contracts/route_prefix_test.go
@@ -520,6 +520,58 @@ func routes(_ app: Application) throws {
 	}
 }
 
+// TestJoinRouterPrefixes_ActixCrossFileScope joins a web::scope("/api")
+// .configure(api_routes) mount in main.rs onto a resource the api_routes
+// config function registers in a sibling file.
+func TestJoinRouterPrefixes_ActixCrossFileScope(t *testing.T) {
+	files := srcMap{
+		"main.rs": `
+fn app() {
+    App::new().service(web::scope("/api").configure(api_routes));
+}
+`,
+		"api.rs": `
+fn api_routes(cfg: &mut web::ServiceConfig) {
+    cfg.service(web::resource("/users").route(web::get().to(list)));
+}
+async fn list() {}
+`,
+	}
+	reg := NewRegistry()
+	extractInto(t, reg, files, "svc", "svc")
+	JoinRouterPrefixes(reg, files.paths(), files.reader())
+	ids := idSet(reg)
+	if !ids["http::GET::/api/users"] {
+		t.Errorf("expected actix cross-file-scope-joined http::GET::/api/users; got %v", keysOfBool(ids))
+	}
+}
+
+// TestJoinRouterPrefixes_ActixCrossFileScopeService joins a web::scope mounted
+// via .service(<path::fn>), confirming the path-qualified config reference is
+// keyed on its final segment.
+func TestJoinRouterPrefixes_ActixCrossFileScopeService(t *testing.T) {
+	files := srcMap{
+		"main.rs": `
+fn app() {
+    App::new().service(web::scope("/v2").service(users::routes));
+}
+`,
+		"users.rs": `
+fn routes(cfg: &mut web::ServiceConfig) {
+    cfg.service(web::resource("/me").route(web::get().to(me)));
+}
+async fn me() {}
+`,
+	}
+	reg := NewRegistry()
+	extractInto(t, reg, files, "svc", "svc")
+	JoinRouterPrefixes(reg, files.paths(), files.reader())
+	ids := idSet(reg)
+	if !ids["http::GET::/v2/me"] {
+		t.Errorf("expected actix cross-file-scope-joined http::GET::/v2/me; got %v", keysOfBool(ids))
+	}
+}
+
 func TestJoinRouterPrefixes_Axum(t *testing.T) {
 	files := srcMap{
 		"main.rs": `

--- a/internal/contracts/route_prefix_test.go
+++ b/internal/contracts/route_prefix_test.go
@@ -452,6 +452,74 @@ Route::prefix('admin')->group(function () {
 	}
 }
 
+// TestJoinRouterPrefixes_VaporGrouped joins the assignment route-group form
+// `let api = app.grouped("api")` onto a route declared on that group var.
+func TestJoinRouterPrefixes_VaporGrouped(t *testing.T) {
+	files := srcMap{
+		"routes.swift": `
+func routes(_ app: Application) throws {
+    let api = app.grouped("api")
+    api.get("users") { req in "ok" }
+}
+`,
+	}
+	reg := NewRegistry()
+	extractInto(t, reg, files, "svc", "svc")
+	JoinRouterPrefixes(reg, files.paths(), files.reader())
+	ids := idSet(reg)
+	if !ids["http::GET::/api/users"] {
+		t.Errorf("expected vapor-joined http::GET::/api/users; got %v", keysOfBool(ids))
+	}
+}
+
+// TestJoinRouterPrefixes_VaporClosureGroup joins the closure-block route-group
+// form `app.group("api") { ... }` onto a route declared inside the brace block.
+func TestJoinRouterPrefixes_VaporClosureGroup(t *testing.T) {
+	files := srcMap{
+		"routes.swift": `
+func routes(_ app: Application) throws {
+    app.group("api") {
+        app.get("users") { req in "ok" }
+    }
+}
+`,
+	}
+	reg := NewRegistry()
+	extractInto(t, reg, files, "svc", "svc")
+	JoinRouterPrefixes(reg, files.paths(), files.reader())
+	ids := idSet(reg)
+	if !ids["http::GET::/api/users"] {
+		t.Errorf("expected vapor closure-joined http::GET::/api/users; got %v", keysOfBool(ids))
+	}
+}
+
+// TestJoinRouterPrefixes_VaporClosureGroupNested chains nested closure groups
+// and leaves a sibling route outside the block unprefixed.
+func TestJoinRouterPrefixes_VaporClosureGroupNested(t *testing.T) {
+	files := srcMap{
+		"routes.swift": `
+func routes(_ app: Application) throws {
+    routes.group("v1") { g in
+        g.group("admin") { a in
+            a.post("ban") { req in "ok" }
+        }
+    }
+    app.get("health") { req in "ok" }
+}
+`,
+	}
+	reg := NewRegistry()
+	extractInto(t, reg, files, "svc", "svc")
+	JoinRouterPrefixes(reg, files.paths(), files.reader())
+	ids := idSet(reg)
+	if !ids["http::POST::/v1/admin/ban"] {
+		t.Errorf("expected nested vapor closure-joined http::POST::/v1/admin/ban; got %v", keysOfBool(ids))
+	}
+	if !ids["http::GET::/health"] {
+		t.Errorf("expected unscoped route to stay http::GET::/health; got %v", keysOfBool(ids))
+	}
+}
+
 func TestJoinRouterPrefixes_Axum(t *testing.T) {
 	files := srcMap{
 		"main.rs": `

--- a/internal/indexer/cpp_compile_db.go
+++ b/internal/indexer/cpp_compile_db.go
@@ -30,13 +30,16 @@ var cppIncludeDirCache = newCppIncludeDirCache()
 // build*/compile_commands.json), reconstructing each TU's ordered include search
 // path (the `-I` / `-isystem` / `-iquote` dirs) normalized to repo-relative slash
 // paths, dropping directories outside the repo (toolchain / system). The result
-// is cached per repo root; clearCppIncludeDirCache invalidates it on reindex /
-// compile_commands.json change.
+// is cached per repo root, keyed on the newest compile_commands.json modtime: a
+// later edit to compile_commands.json (even with no other source change) is
+// re-read on the next load. clearCppIncludeDirCache also invalidates it on a full
+// reindex.
 func loadCompileCommands(repoRoot string) map[string]cppTU {
 	if repoRoot == "" {
 		return nil
 	}
-	if c, ok := cppIncludeDirCache.get(repoRoot); ok {
+	mtime := compileDBMtime(repoRoot)
+	if c, ok := cppIncludeDirCache.get(repoRoot, mtime); ok {
 		return c
 	}
 
@@ -59,8 +62,26 @@ func loadCompileCommands(repoRoot string) map[string]cppTU {
 		}
 	}
 
-	cppIncludeDirCache.put(repoRoot, out)
+	cppIncludeDirCache.put(repoRoot, out, mtime)
 	return out
+}
+
+// compileDBMtime returns the newest modtime (unix nanoseconds) across the
+// compile_commands.json files that loadCompileCommands reads for repoRoot, or 0
+// when none exist. It is the cache freshness key: when this exceeds the cached
+// entry's recorded mtime, the entry is reloaded.
+func compileDBMtime(repoRoot string) int64 {
+	var newest int64
+	for _, dbPath := range compileDBLocations(repoRoot) {
+		fi, err := os.Stat(dbPath)
+		if err != nil {
+			continue
+		}
+		if m := fi.ModTime().UnixNano(); m > newest {
+			newest = m
+		}
+	}
+	return newest
 }
 
 // clearCppIncludeDirCache drops the cached include-dir set for a repo root so

--- a/internal/indexer/cpp_compile_db_test.go
+++ b/internal/indexer/cpp_compile_db_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -116,15 +117,26 @@ func TestLoadCompileCommands_CacheAndClear(t *testing.T) {
 	path := filepath.Join(root, "compile_commands.json")
 	t.Cleanup(func() { clearCppIncludeDirCache(root) })
 
+	// write replaces the DB body while preserving its modtime, so this test
+	// isolates the explicit-clear path from the mtime-keyed reload (covered by
+	// TestLoadCompileCommands_MtimeReload).
 	write := func(incDir string) {
+		var keep time.Time
+		if fi, err := os.Stat(path); err == nil {
+			keep = fi.ModTime()
+		}
 		body := `[{"directory":"` + root + `","file":"src/main.c","command":"cc -I` + incDir + ` -c src/main.c"}]`
 		require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
+		if !keep.IsZero() {
+			require.NoError(t, os.Chtimes(path, keep, keep))
+		}
 	}
 
 	write("inc1")
 	require.Equal(t, []string{"inc1"}, loadCompileCommands(root)["src/main.c"].includeDirs)
 
-	// Editing the DB on disk is not observed until the cache is invalidated.
+	// Editing the DB on disk (without bumping its modtime) is not observed until
+	// the cache is invalidated.
 	write("inc2")
 	assert.Equal(t, []string{"inc1"}, loadCompileCommands(root)["src/main.c"].includeDirs,
 		"second load returns the cached result")
@@ -133,4 +145,34 @@ func TestLoadCompileCommands_CacheAndClear(t *testing.T) {
 	clearCppIncludeDirCache(root)
 	assert.Equal(t, []string{"inc2"}, loadCompileCommands(root)["src/main.c"].includeDirs,
 		"after clear the edited -I dir is picked up")
+}
+
+// TestLoadCompileCommands_MtimeReload pins the mtime-keyed invalidation: editing
+// only compile_commands.json (changing an -I dir) and re-loading picks up the new
+// include dir without any explicit cache clear / full reindex — the cache reloads
+// because the file's modtime advanced.
+func TestLoadCompileCommands_MtimeReload(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "compile_commands.json")
+	t.Cleanup(func() { clearCppIncludeDirCache(root) })
+
+	write := func(incDir string, mtime time.Time) {
+		body := `[{"directory":"` + root + `","file":"src/main.c","command":"cc -I` + incDir + ` -c src/main.c"}]`
+		require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
+		require.NoError(t, os.Chtimes(path, mtime, mtime))
+	}
+
+	t0 := time.Now().Add(-time.Hour)
+	write("inc1", t0)
+	require.Equal(t, []string{"inc1"}, loadCompileCommands(root)["src/main.c"].includeDirs)
+
+	// Edit only compile_commands.json, advancing its modtime. No clearCppIncludeDirCache
+	// call — the next load must observe the newer file and re-read it.
+	write("inc2", t0.Add(time.Minute))
+	assert.Equal(t, []string{"inc2"}, loadCompileCommands(root)["src/main.c"].includeDirs,
+		"a newer compile_commands.json is re-read without an explicit cache clear")
+
+	// A subsequent load with no further edit is served from the (now-warm) cache.
+	assert.Equal(t, []string{"inc2"}, loadCompileCommands(root)["src/main.c"].includeDirs,
+		"unchanged compile_commands.json stays cached")
 }

--- a/internal/indexer/cpp_include_cache.go
+++ b/internal/indexer/cpp_include_cache.go
@@ -26,6 +26,11 @@ type cppIncludeCacheEntry struct {
 	key   string
 	tus   map[string]cppTU
 	bytes int64
+	// mtime is the newest modtime (unix nanoseconds) across the compile_commands.json
+	// files this entry was built from. A lookup whose on-disk files are newer than
+	// this is treated as a miss, so an isolated edit to compile_commands.json is
+	// picked up on the next load without a full reindex.
+	mtime int64
 }
 
 // newCppIncludeDirCache builds the cache, reading GORTEX_RESOLVER_CACHE_MAX_MB
@@ -41,22 +46,30 @@ func newCppIncludeDirCache() *cppIncludeDirCacheT {
 }
 
 // get returns the cached include-dir set for root, promoting it to
-// most-recently-used. The second return is false on a miss.
-func (c *cppIncludeDirCacheT) get(root string) (map[string]cppTU, bool) {
+// most-recently-used. diskMtime is the newest modtime currently on disk across
+// the compile_commands.json files for root; an entry whose recorded mtime is
+// older is treated as stale (a miss) so an edited compile_commands.json is
+// re-read on the next load without a full reindex. The second return is false on
+// a miss.
+func (c *cppIncludeDirCacheT) get(root string, diskMtime int64) (map[string]cppTU, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	el, ok := c.m[root]
 	if !ok {
 		return nil, false
 	}
+	e := el.Value.(*cppIncludeCacheEntry)
+	if diskMtime > e.mtime {
+		return nil, false
+	}
 	c.ll.MoveToFront(el)
-	return el.Value.(*cppIncludeCacheEntry).tus, true
+	return e.tus, true
 }
 
-// put stores the include-dir set for root, evicting least-recently-used
-// entries until within the memory budget (at least the just-stored entry is
-// retained).
-func (c *cppIncludeDirCacheT) put(root string, tus map[string]cppTU) {
+// put stores the include-dir set for root along with the modtime it was built
+// from, evicting least-recently-used entries until within the memory budget (at
+// least the just-stored entry is retained).
+func (c *cppIncludeDirCacheT) put(root string, tus map[string]cppTU, mtime int64) {
 	sz := cppTUMapBytes(tus)
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -65,11 +78,12 @@ func (c *cppIncludeDirCacheT) put(root string, tus map[string]cppTU) {
 		c.curBytes += sz - e.bytes
 		e.tus = tus
 		e.bytes = sz
+		e.mtime = mtime
 		c.ll.MoveToFront(el)
 		c.evictLocked()
 		return
 	}
-	el := c.ll.PushFront(&cppIncludeCacheEntry{key: root, tus: tus, bytes: sz})
+	el := c.ll.PushFront(&cppIncludeCacheEntry{key: root, tus: tus, bytes: sz, mtime: mtime})
 	c.m[root] = el
 	c.curBytes += sz
 	c.evictLocked()

--- a/internal/indexer/cpp_include_cache_test.go
+++ b/internal/indexer/cpp_include_cache_test.go
@@ -26,15 +26,15 @@ func TestCppIncludeDirCache_Eviction(t *testing.T) {
 	mk := func(f string) map[string]cppTU {
 		return map[string]cppTU{f: {file: f, includeDirs: []string{"inc"}}}
 	}
-	c.put("repoA", mk("a.c"))
-	c.put("repoB", mk("b.c"))
-	c.put("repoC", mk("c.c"))
+	c.put("repoA", mk("a.c"), 0)
+	c.put("repoB", mk("b.c"), 0)
+	c.put("repoC", mk("c.c"), 0)
 
-	_, okA := c.get("repoA")
+	_, okA := c.get("repoA", 0)
 	assert.False(t, okA, "least-recently-used repoA evicted under the budget")
-	_, okB := c.get("repoB")
+	_, okB := c.get("repoB", 0)
 	assert.True(t, okB, "repoB retained")
-	_, okC := c.get("repoC")
+	_, okC := c.get("repoC", 0)
 	assert.True(t, okC, "most-recently-used repoC retained")
 }
 
@@ -47,14 +47,14 @@ func TestCppIncludeDirCache_GetPromotes(t *testing.T) {
 	mk := func(f string) map[string]cppTU {
 		return map[string]cppTU{f: {file: f, includeDirs: []string{"inc"}}}
 	}
-	c.put("repoA", mk("a.c"))
-	c.put("repoB", mk("b.c"))
-	c.get("repoA")            // promote A ahead of B
-	c.put("repoC", mk("c.c")) // evicts the now-LRU repoB
+	c.put("repoA", mk("a.c"), 0)
+	c.put("repoB", mk("b.c"), 0)
+	c.get("repoA", 0)            // promote A ahead of B
+	c.put("repoC", mk("c.c"), 0) // evicts the now-LRU repoB
 
-	_, okA := c.get("repoA")
+	_, okA := c.get("repoA", 0)
 	assert.True(t, okA, "promoted repoA survives")
-	_, okB := c.get("repoB")
+	_, okB := c.get("repoB", 0)
 	assert.False(t, okB, "repoB evicted as least-recently-used")
 }
 
@@ -63,10 +63,25 @@ func TestCppIncludeDirCache_GetPromotes(t *testing.T) {
 func TestCppIncludeDirCache_UnboundedKeepsAll(t *testing.T) {
 	c := newCppIncludeDirCache() // maxBytes 0
 	for _, r := range []string{"r1", "r2", "r3"} {
-		c.put(r, map[string]cppTU{r: {file: r}})
+		c.put(r, map[string]cppTU{r: {file: r}}, 0)
 	}
 	for _, r := range []string{"r1", "r2", "r3"} {
-		_, ok := c.get(r)
+		_, ok := c.get(r, 0)
 		assert.True(t, ok, "unbounded cache retains %s", r)
 	}
+}
+
+// TestCppIncludeDirCache_MtimeStaleMiss pins the freshness check: a get whose
+// disk modtime exceeds the entry's recorded mtime is a miss, while an equal or
+// older modtime is a hit.
+func TestCppIncludeDirCache_MtimeStaleMiss(t *testing.T) {
+	c := newCppIncludeDirCache()
+	c.put("repo", map[string]cppTU{"a.c": {file: "a.c"}}, 100)
+
+	_, ok := c.get("repo", 100)
+	assert.True(t, ok, "equal modtime is a hit")
+	_, ok = c.get("repo", 50)
+	assert.True(t, ok, "older modtime is a hit")
+	_, ok = c.get("repo", 200)
+	assert.False(t, ok, "newer modtime is a stale miss")
 }

--- a/internal/parser/languages/dart.go
+++ b/internal/parser/languages/dart.go
@@ -447,8 +447,17 @@ func (e *DartExtractor) extractTopLevelVariables(
 					continue
 				}
 				seen[id] = true
+				// A static_final_declaration is a `const` / `final` / `static
+				// final` binding — immutable by grammar. A distinctive-named one
+				// is a Dart value constant; kind it as KindConstant so
+				// value-reference impact analysis reaches its readers (mirrors
+				// the Scala/Ruby constant handling).
+				declKind := graph.KindVariable
+				if isDistinctiveConstName(name) {
+					declKind = graph.KindConstant
+				}
 				result.Nodes = append(result.Nodes, &graph.Node{
-					ID: id, Kind: graph.KindVariable, Name: name,
+					ID: id, Kind: declKind, Name: name,
 					FilePath: filePath, StartLine: startLine, EndLine: int(decl.EndPoint().Row) + 1,
 					Language: "dart",
 				})

--- a/internal/parser/languages/fn_ref_spec.go
+++ b/internal/parser/languages/fn_ref_spec.go
@@ -32,6 +32,13 @@ const (
 	// dispatchByteParen is the original disambiguator: an identifier whose next
 	// non-whitespace source byte is '(' or '`' is a callee, not a value.
 	dispatchByteParen fnRefDispatch = iota
+	// astCalleeField additionally rejects a token that is the callee child of a
+	// call node in the parse tree, catching calls the byte heuristic misses
+	// because a non-'(' token sits between the name and its '(' — optional
+	// chaining `f?.()`, non-null `f!()`, generic instantiation `f<T>()`. It only
+	// ever classifies more tokens as calls than dispatchByteParen, never fewer,
+	// so it strictly tightens precision (fewer spurious value candidates).
+	astCalleeField
 )
 
 func (s fnRefSpec) matchesIDNode(t string) bool {
@@ -81,6 +88,36 @@ func fnRefSpecFor(lang string) fnRefSpec {
 			unwrapForms: map[string]string{"exprUnary": "address_of", "unary_expression": "address_of"},
 			dispatch:    dispatchByteParen,
 		}
+	case "javascript", "typescript", "tsx":
+		// `el.addEventListener('x', this.onX)` / `setTimeout(mod.tick)` — a
+		// member value whose property names a same-file fn. AST dispatch rejects
+		// `f?.()` / `f!()` / `f<T>()` calls the byte heuristic would miss.
+		return fnRefSpec{
+			idNodeTypes: []string{"identifier", "member_expression"},
+			dispatch:    astCalleeField,
+		}
+	case "python":
+		// `signal.connect(self.on_change)` — an attribute value whose trailing
+		// attribute names the fn.
+		return fnRefSpec{
+			idNodeTypes: []string{"identifier", "attribute"},
+			dispatch:    astCalleeField,
+		}
+	case "csharp":
+		// `list.ForEach(this.Handle)` — a member-access value.
+		return fnRefSpec{
+			idNodeTypes: []string{"identifier", "member_access_expression"},
+			dispatch:    astCalleeField,
+		}
+	case "java", "c", "cpp", "dart":
+		// Bare-identifier value idiom; AST dispatch tightens the call check
+		// (Java `method_invocation`, C/Dart `call_expression`).
+		return fnRefSpec{idNodeTypes: []string{"identifier"}, dispatch: astCalleeField}
+	case "php", "ruby":
+		// First-class refs are dominated by the special forms (PHP string
+		// callables, Ruby `method(:sym)` / `&:sym`); the bare path stays on the
+		// byte heuristic.
+		return fnRefSpec{idNodeTypes: []string{"identifier"}, dispatch: dispatchByteParen}
 	}
 	return defaultFnRefSpec
 }
@@ -99,8 +136,67 @@ func fnRefNodeName(n *sitter.Node, src []byte) string {
 		if field := n.ChildByFieldName("field"); field != nil {
 			return field.Content(src)
 		}
+	case "member_expression":
+		if prop := n.ChildByFieldName("property"); prop != nil {
+			return prop.Content(src)
+		}
+	case "attribute":
+		if attr := n.ChildByFieldName("attribute"); attr != nil {
+			return attr.Content(src)
+		}
+	case "member_access_expression":
+		if name := n.ChildByFieldName("name"); name != nil {
+			return name.Content(src)
+		}
 	}
 	return n.Content(src)
+}
+
+// qualifiedFnRefNodeTypes are the value-position node types that name a function
+// through a path / member access rather than a bare leaf — the forms a spec may
+// resolve cross-module (ungated) when the trailing name is not file-local.
+var qualifiedFnRefNodeTypes = map[string]bool{
+	"scoped_identifier":        true,
+	"selector_expression":      true,
+	"member_expression":        true,
+	"attribute":                true,
+	"member_access_expression": true,
+}
+
+func isQualifiedFnRefNode(t string) bool { return qualifiedFnRefNodeTypes[t] }
+
+// nodeIsCallCallee reports whether n sits in callee position of a call node —
+// the `function` / `name` child of a call/invocation — across the grammars the
+// fn-value walk targets. Used by astCalleeField dispatch to reject calls whose
+// `(` is separated from the callee by `?.`, `!`, or `<T>`.
+func nodeIsCallCallee(n *sitter.Node) bool {
+	p := n.Parent()
+	if p == nil {
+		return false
+	}
+	var callee *sitter.Node
+	switch p.Type() {
+	case "call_expression", "call", "invocation_expression":
+		callee = p.ChildByFieldName("function")
+	case "method_invocation":
+		callee = p.ChildByFieldName("name")
+	}
+	if callee == nil {
+		return false
+	}
+	return callee.StartByte() == n.StartByte() && callee.EndByte() == n.EndByte()
+}
+
+// fnRefStartsCall reports whether the value-position node n is actually the
+// callee of a call (so not a function-as-value). It always applies the original
+// byte heuristic and, under astCalleeField dispatch, additionally consults the
+// parse tree so modern call syntax (`f?.()`, `f!()`, `f<T>()`) is not mistaken
+// for a value reference.
+func fnRefStartsCall(spec fnRefSpec, n *sitter.Node, src []byte) bool {
+	if spec.dispatch == astCalleeField && nodeIsCallCallee(n) {
+		return true
+	}
+	return byteAfterIdentStartsCall(src, int(n.EndByte()))
 }
 
 // fnRefForm reports the wrapper form (address_of / eta) a captured node sits in

--- a/internal/parser/languages/fn_ref_spec_test.go
+++ b/internal/parser/languages/fn_ref_spec_test.go
@@ -129,3 +129,90 @@ func keys(m map[string]map[string]any) []string {
 	}
 	return []string{strings.Join(out, ",")}
 }
+
+// TestFnRefSpecFor_MemberValueForms pins the broadened per-language table: the
+// member/attribute value forms and the astCalleeField dispatch tier.
+func TestFnRefSpecFor_MemberValueForms(t *testing.T) {
+	js := fnRefSpecFor("javascript")
+	if !js.matchesIDNode("member_expression") || js.dispatch != astCalleeField {
+		t.Error("javascript spec should match member_expression with astCalleeField dispatch")
+	}
+	if !fnRefSpecFor("python").matchesIDNode("attribute") {
+		t.Error("python spec should match attribute")
+	}
+	if !fnRefSpecFor("csharp").matchesIDNode("member_access_expression") {
+		t.Error("csharp spec should match member_access_expression")
+	}
+	if fnRefSpecFor("java").dispatch != astCalleeField {
+		t.Error("java spec should use astCalleeField dispatch")
+	}
+	for _, nt := range []string{"member_expression", "attribute", "member_access_expression", "scoped_identifier", "selector_expression"} {
+		if !isQualifiedFnRefNode(nt) {
+			t.Errorf("%s should be a qualified fn-ref node", nt)
+		}
+	}
+	if isQualifiedFnRefNode("identifier") {
+		t.Error("bare identifier is not a qualified fn-ref node")
+	}
+}
+
+// TestFnValueCapture_JSMemberValue pins capture of a same-file function passed
+// by value through a member expression (`bus.onReady`), gated on the file
+// declaring `onReady`. The called member `subscribe` must not be captured.
+func TestFnValueCapture_JSMemberValue(t *testing.T) {
+	src := []byte(`function onReady() {}
+
+function setup(bus) {
+  bus.subscribe(bus.onReady);
+}
+`)
+	res, err := NewJavaScriptExtractor().Extract("app.js", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cands := fnValueCands(res)
+	if _, ok := cands["onReady"]; !ok {
+		t.Fatalf("JS member-expression method value not captured (got: %v)", keys(cands))
+	}
+	if _, bad := cands["subscribe"]; bad {
+		t.Error("the called member `subscribe` must not be captured")
+	}
+}
+
+// TestFnValueCapture_ASTCalleeRejectsOptionalCall pins the astCalleeField
+// precision win: `tick?.()` is a call (the callee child of a call node), so the
+// byte heuristic's would-be value candidate is rejected.
+func TestFnValueCapture_ASTCalleeRejectsOptionalCall(t *testing.T) {
+	src := []byte(`function tick() {}
+
+function run() {
+  tick?.();
+}
+`)
+	res, err := NewJavaScriptExtractor().Extract("app.js", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, bad := fnValueCands(res)["tick"]; bad {
+		t.Error("optional-call `tick?.()` must not be captured as a function value")
+	}
+}
+
+// TestFnValueCapture_PythonAttributeValue pins capture of a same-file function
+// passed by value through a non-self attribute (`mod.on_change`).
+func TestFnValueCapture_PythonAttributeValue(t *testing.T) {
+	src := []byte(`def on_change():
+    pass
+
+def setup(signal, mod):
+    signal.connect(mod.on_change)
+`)
+	res, err := NewPythonExtractor().Extract("app.py", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cands := fnValueCands(res)
+	if _, ok := cands["on_change"]; !ok {
+		t.Fatalf("Python attribute method value not captured (got: %v)", keys(cands))
+	}
+}

--- a/internal/parser/languages/fn_ref_special_test.go
+++ b/internal/parser/languages/fn_ref_special_test.go
@@ -113,3 +113,68 @@ end
 	}
 	specialCand(t, res, "handle")
 }
+
+// TestFnRefSpecial_RubySymbolProc pins Ruby `&:handle` symbol-to-proc capture —
+// the symbol names the method invoked on each element, resolved repo-wide so the
+// receiver hint is empty.
+func TestFnRefSpecial_RubySymbolProc(t *testing.T) {
+	src := []byte(`class C
+  def handle
+  end
+
+  def wire(items)
+    items.map(&:handle)
+  end
+end
+`)
+	res, err := NewRubyExtractor().Extract("c.rb", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta := specialCand(t, res, "handle")
+	// A repo-wide symbol-proc carries no receiver hint, so the key is absent
+	// (distinct from a "<self>"-scoped form).
+	if rh, ok := meta["fn_ref_recv_hint"]; ok {
+		t.Errorf("recv_hint = %v, want no hint (repo-wide symbol-proc)", rh)
+	}
+}
+
+// TestFnRefSpecial_CSharpThisMethod pins C# `this.Handle` member access scoped
+// to the enclosing type.
+func TestFnRefSpecial_CSharpThisMethod(t *testing.T) {
+	src := []byte(`class C {
+    void Handle() {}
+    void Wire() {
+        Register(this.Handle);
+    }
+}
+`)
+	res, err := NewCSharpExtractor().Extract("C.cs", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta := specialCand(t, res, "Handle")
+	if meta["fn_ref_recv_hint"] != "<self>" {
+		t.Errorf("recv_hint = %v, want <self>", meta["fn_ref_recv_hint"])
+	}
+}
+
+// TestFnRefSpecial_SwiftSelector pins Swift `#selector(handle)` capture scoped to
+// the enclosing type.
+func TestFnRefSpecial_SwiftSelector(t *testing.T) {
+	src := []byte(`class C {
+    func handle() {}
+    func wire() {
+        let s = #selector(handle)
+    }
+}
+`)
+	res, err := NewSwiftExtractor().Extract("C.swift", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta := specialCand(t, res, "handle")
+	if meta["fn_ref_recv_hint"] != "<self>" {
+		t.Errorf("recv_hint = %v, want <self>", meta["fn_ref_recv_hint"])
+	}
+}

--- a/internal/parser/languages/fn_value_capture.go
+++ b/internal/parser/languages/fn_value_capture.go
@@ -109,7 +109,7 @@ func captureFnValueCandidates(result *parser.ExtractionResult, root *sitter.Node
 			if !typeQualified && !funcs[refName] {
 				return
 			}
-			if byteAfterIdentStartsCall(src, int(n.EndByte())) {
+			if fnRefStartsCall(spec, n, src) {
 				return
 			}
 			line := int(n.StartPoint().Row) + 1
@@ -149,12 +149,12 @@ func captureFnValueCandidates(result *parser.ExtractionResult, root *sitter.Node
 			// only when it is an explicit qualified path (e.g. Rust `m::f`) —
 			// a bare identifier that is not a same-file function is a local /
 			// param / builtin and is dropped to avoid flooding the gate.
-			if !spec.ungated || n.Type() != "scoped_identifier" {
+			if !spec.ungated || !isQualifiedFnRefNode(n.Type()) {
 				return
 			}
 			ungated = true
 		}
-		if byteAfterIdentStartsCall(src, int(n.EndByte())) {
+		if fnRefStartsCall(spec, n, src) {
 			return // callee of a call (incl. tagged template), not a value use
 		}
 		line := int(n.StartPoint().Row) + 1

--- a/internal/parser/languages/go_goframe_routes.go
+++ b/internal/parser/languages/go_goframe_routes.go
@@ -34,6 +34,12 @@ func captureGoFrameRoutes(result *parser.ExtractionResult, root *sitter.Node, fi
 		}
 	}
 
+	// The file's own package — the qualifier of a request struct declared here.
+	// A handler in another package refers to it as `*<pkg>.CreateReq`, so this
+	// name pins which package a route's request type belongs to and prevents a
+	// same-named struct in another package from claiming the route.
+	filePkg := goframePackageName(root, src)
+
 	// Controllers bound via `g.Bind(new(Ctrl))` — the addonRoot tiebreak set.
 	bound := goframeBoundControllers(root, src)
 
@@ -53,18 +59,24 @@ func captureGoFrameRoutes(result *parser.ExtractionResult, root *sitter.Node, fi
 		}
 		reqType := nameNode.Content(src)
 		routeID := "route::goframe::" + method + "::" + path
+		nodeMeta := map[string]any{
+			"type": "http", "role": "provider", "method": method, "path": path,
+			"framework": "goframe", "goframe_request_type": reqType,
+		}
+		edgeMeta := map[string]any{"via": goframeRouteViaTag, "goframe_request_type": reqType, "goframe_route": routeID}
+		if filePkg != "" {
+			nodeMeta["goframe_request_pkg"] = filePkg
+			edgeMeta["goframe_request_pkg"] = filePkg
+		}
 		result.Nodes = append(result.Nodes, &graph.Node{
 			ID: routeID, Kind: graph.KindContract, Name: method + " " + path,
 			FilePath: filePath, StartLine: int(n.StartPoint().Row) + 1, Language: "go",
-			Meta: map[string]any{
-				"type": "http", "role": "provider", "method": method, "path": path,
-				"framework": "goframe", "goframe_request_type": reqType,
-			},
+			Meta:     nodeMeta,
 		})
 		result.Edges = append(result.Edges, &graph.Edge{
 			From: routeID, To: "unresolved::*." + reqType, Kind: graph.EdgeCalls,
 			FilePath: filePath, Line: int(n.StartPoint().Row) + 1,
-			Meta: map[string]any{"via": goframeRouteViaTag, "goframe_request_type": reqType, "goframe_route": routeID},
+			Meta:     edgeMeta,
 		})
 	})
 
@@ -73,9 +85,14 @@ func captureGoFrameRoutes(result *parser.ExtractionResult, root *sitter.Node, fi
 		if n.Type() != "method_declaration" {
 			return
 		}
-		name, recvType, reqType, ok := goframeMethodParts(n, src)
+		name, recvType, reqType, reqPkg, ok := goframeMethodParts(n, src)
 		if !ok {
 			return
+		}
+		// A bare `*CreateReq` param names a struct in this file's package; a
+		// qualified `*api.CreateReq` carries its own package qualifier.
+		if reqPkg == "" {
+			reqPkg = filePkg
 		}
 		line := int(n.StartPoint().Row) + 1
 		for _, nd := range methodByLine[line] {
@@ -86,6 +103,9 @@ func captureGoFrameRoutes(result *parser.ExtractionResult, root *sitter.Node, fi
 				nd.Meta = map[string]any{}
 			}
 			nd.Meta["goframe_request_type"] = reqType
+			if reqPkg != "" {
+				nd.Meta["goframe_request_pkg"] = reqPkg
+			}
 			if bound[recvType] {
 				nd.Meta["goframe_bound"] = true
 			}
@@ -193,9 +213,10 @@ func goframeTagValue(tag, key string) string {
 }
 
 // goframeMethodParts reads a method_declaration: name, receiver type, the
-// request-struct type of its pointer parameter, and whether it has the
-// GoFrame handler shape (a pointer request parameter + a result list).
-func goframeMethodParts(md *sitter.Node, src []byte) (name, recvType, reqType string, ok bool) {
+// request-struct type of its pointer parameter (plus its package qualifier, ""
+// for a same-package bare type), and whether it has the GoFrame handler shape
+// (a pointer request parameter + a result list).
+func goframeMethodParts(md *sitter.Node, src []byte) (name, recvType, reqType, reqPkg string, ok bool) {
 	var plists []*sitter.Node
 	var nameNode *sitter.Node
 	for i := 0; i < int(md.NamedChildCount()); i++ {
@@ -213,14 +234,31 @@ func goframeMethodParts(md *sitter.Node, src []byte) (name, recvType, reqType st
 		}
 	}
 	if nameNode == nil || len(plists) < 3 {
-		return "", "", "", false // need receiver + params + results
+		return "", "", "", "", false // need receiver + params + results
 	}
 	recvType = goframePointedType(plists[0], src)
-	reqType = goframeLastPointerParamType(plists[1], src)
+	reqType, reqPkg = goframeLastPointerParamType(plists[1], src)
 	if reqType == "" {
-		return "", "", "", false
+		return "", "", "", "", false
 	}
-	return nameNode.Content(src), recvType, reqType, true
+	return nameNode.Content(src), recvType, reqType, reqPkg, true
+}
+
+// goframePackageName returns the file's package name from its package_clause.
+func goframePackageName(root *sitter.Node, src []byte) string {
+	pkg := ""
+	goframeWalk(root, func(n *sitter.Node) {
+		if pkg != "" || n.Type() != "package_clause" {
+			return
+		}
+		for i := 0; i < int(n.NamedChildCount()); i++ {
+			if c := n.NamedChild(i); c != nil && c.Type() == "package_identifier" {
+				pkg = strings.TrimSpace(c.Content(src))
+				return
+			}
+		}
+	})
+	return pkg
 }
 
 // goframePointedType returns the (pointer-stripped) type name of a
@@ -236,20 +274,20 @@ func goframePointedType(plist *sitter.Node, src []byte) string {
 	return ""
 }
 
-// goframeLastPointerParamType returns the pointed-to type of the last
-// pointer-typed parameter (the GoFrame request struct).
-func goframeLastPointerParamType(plist *sitter.Node, src []byte) string {
-	last := ""
+// goframeLastPointerParamType returns the pointed-to type (and its package
+// qualifier, "" when unqualified) of the last pointer-typed parameter — the
+// GoFrame request struct.
+func goframeLastPointerParamType(plist *sitter.Node, src []byte) (typeName, pkg string) {
 	for i := 0; i < int(plist.NamedChildCount()); i++ {
 		pd := plist.NamedChild(i)
 		if pd == nil || pd.Type() != "parameter_declaration" {
 			continue
 		}
-		if t := goframePointerParamType(pd, src); t != "" {
-			last = t
+		if t, p := goframePointerParamType(pd, src); t != "" {
+			typeName, pkg = t, p
 		}
 	}
-	return last
+	return typeName, pkg
 }
 
 // goframeParamTypeName returns the type identifier of a parameter,
@@ -268,18 +306,37 @@ func goframeParamTypeName(pd *sitter.Node, src []byte) string {
 	return ""
 }
 
-// goframePointerParamType returns the pointed-to type identifier of a
-// pointer parameter, or "".
-func goframePointerParamType(pd *sitter.Node, src []byte) string {
+// goframePointerParamType returns the pointed-to type identifier of a pointer
+// parameter and its package qualifier. A bare `*CreateReq` yields ("CreateReq",
+// ""); a qualified `*api.CreateReq` yields ("CreateReq", "api"). Returns "" for
+// a non-pointer or otherwise unrecognised parameter.
+func goframePointerParamType(pd *sitter.Node, src []byte) (typeName, pkg string) {
 	t := pd.ChildByFieldName("type")
 	if t == nil || t.Type() != "pointer_type" || t.NamedChildCount() == 0 {
-		return ""
+		return "", ""
 	}
 	inner := t.NamedChild(0)
-	if inner != nil && inner.Type() == "type_identifier" {
-		return inner.Content(src)
+	if inner == nil {
+		return "", ""
 	}
-	return ""
+	switch inner.Type() {
+	case "type_identifier":
+		return inner.Content(src), ""
+	case "qualified_type":
+		// `pkg.Type` — the package qualifier pins which package the request
+		// struct belongs to across packages.
+		name := inner.ChildByFieldName("name")
+		pkgNode := inner.ChildByFieldName("package")
+		if name == nil {
+			return "", ""
+		}
+		p := ""
+		if pkgNode != nil {
+			p = strings.TrimSpace(pkgNode.Content(src))
+		}
+		return name.Content(src), p
+	}
+	return "", ""
 }
 
 // goframeBoundControllers collects controller types registered via

--- a/internal/parser/languages/go_goframe_routes_test.go
+++ b/internal/parser/languages/go_goframe_routes_test.go
@@ -86,6 +86,55 @@ func TestGoFrame_RouteNodeAndMethodTagging(t *testing.T) {
 	}
 }
 
+func TestGoFrame_RequestPackageStamped(t *testing.T) {
+	// A request struct's declaring package qualifies its route, and a handler's
+	// pointer param carries that package — bare for a same-package param, the
+	// qualifier for a cross-package `*api.CreateReq`. Both sides must agree so
+	// the resolver can join across packages without colliding on the bare name.
+	src := "package api\n" +
+		"type CreateReq struct {\n" +
+		"\tg.Meta `path:\"/users\" method:\"POST\"`\n" +
+		"}\n" +
+		"type CreateRes struct{}\n" +
+		"type SameCtrl struct{}\n" +
+		"func (c *SameCtrl) Same(ctx context.Context, req *CreateReq) (*CreateRes, error) { return nil, nil }\n" +
+		"type CrossCtrl struct{}\n" +
+		"func (c *CrossCtrl) Cross(ctx context.Context, req *other.CreateReq) (*CreateRes, error) { return nil, nil }\n"
+	res, err := NewGoExtractor().Extract("api/user.go", []byte(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	route := goframeRouteNode(res.Nodes, "POST", "/users")
+	if route == nil {
+		t.Fatalf("no POST /users route node materialised")
+	}
+	if pkg, _ := route.Meta["goframe_request_pkg"].(string); pkg != "api" {
+		t.Errorf("route request pkg = %q (want api)", pkg)
+	}
+
+	same := goframeMethodNode(res.Nodes, "Same")
+	if same == nil {
+		t.Fatalf("same-package handler Same not tagged")
+	}
+	// A bare `*CreateReq` param inherits the file's package.
+	if pkg, _ := same.Meta["goframe_request_pkg"].(string); pkg != "api" {
+		t.Errorf("Same request pkg = %q (want api, the file package)", pkg)
+	}
+
+	cross := goframeMethodNode(res.Nodes, "Cross")
+	if cross == nil {
+		t.Fatalf("cross-package handler Cross not tagged")
+	}
+	// A qualified `*other.CreateReq` param carries its own package qualifier.
+	if rt, _ := cross.Meta["goframe_request_type"].(string); rt != "CreateReq" {
+		t.Errorf("Cross request type = %q (want CreateReq)", rt)
+	}
+	if pkg, _ := cross.Meta["goframe_request_pkg"].(string); pkg != "other" {
+		t.Errorf("Cross request pkg = %q (want other, the param qualifier)", pkg)
+	}
+}
+
 func TestGoFrame_NonRequestStructIgnored(t *testing.T) {
 	// A plain struct without an embedded g.Meta tag is not a route.
 	src := "package m\n" +

--- a/internal/parser/languages/php_drupal_hooks.go
+++ b/internal/parser/languages/php_drupal_hooks.go
@@ -30,20 +30,111 @@ var drupalImplementsRE = regexp.MustCompile(`(?i)Implements\s+(hook_\w+)`)
 
 // drupalKnownHookSuffixes is the hook-name set (without the `hook_` prefix)
 // the name-pattern detector recognises when there is no `@Implements`
-// docblock. Curated to the common, distinctive Drupal hooks so an ordinary
-// `{module}_helper()` function is not mistaken for a hook.
+// docblock. Curated to the common, distinctive Drupal core hooks so an ordinary
+// `{module}_helper()` function is not mistaken for a hook. Variable-segment
+// hook families (hook_form_FORM_ID_alter, hook_preprocess_HOOK, …) are matched
+// separately by drupalHookPatterns.
 var drupalKnownHookSuffixes = map[string]bool{
+	// Node entity lifecycle + access.
 	"node_insert": true, "node_update": true, "node_delete": true,
 	"node_load": true, "node_view": true, "node_presave": true, "node_access": true,
+	"node_predelete": true, "node_prepare_form": true, "node_access_records": true,
+	"node_grants": true, "node_links_alter": true,
+	// Generic entity lifecycle + access + view.
 	"entity_insert": true, "entity_update": true, "entity_delete": true,
 	"entity_presave": true, "entity_load": true, "entity_view": true,
+	"entity_create": true, "entity_predelete": true, "entity_access": true,
+	"entity_create_access": true, "entity_field_access": true,
+	"entity_view_alter": true, "entity_base_field_info": true,
+	"entity_bundle_field_info": true, "entity_type_alter": true,
+	"entity_type_build": true, "entity_operation": true, "entity_operation_alter": true,
+	"entity_extra_field_info": true,
+	// User entity lifecycle + access.
 	"user_login": true, "user_logout": true, "user_insert": true, "user_delete": true,
-	"form_alter": true, "menu": true, "menu_alter": true, "theme": true,
-	"permission": true, "cron": true, "init": true, "boot": true,
-	"install": true, "uninstall": true, "schema": true, "requirements": true,
-	"help": true, "mail": true, "mail_alter": true, "views_data": true,
-	"preprocess_page": true, "preprocess_node": true, "library_info_alter": true,
-	"token_info": true, "tokens": true, "page_attachments": true,
+	"user_update": true, "user_presave": true, "user_load": true,
+	"user_cancel": true, "user_format_name_alter": true,
+	// Forms.
+	"form_alter": true,
+	// Menu, routing, links, local tasks.
+	"menu": true, "menu_alter": true, "menu_links_discovered_alter": true,
+	"menu_local_tasks_alter": true, "menu_local_actions_alter": true,
+	"local_tasks_alter": true,
+	// Theme, render, page attachments.
+	"theme": true, "theme_registry_alter": true, "theme_suggestions_alter": true,
+	"page_attachments": true, "page_attachments_alter": true,
+	"page_top": true, "page_bottom": true, "element_info_alter": true,
+	"library_info_alter": true, "library_info_build": true, "js_settings_alter": true,
+	"js_alter": true, "css_alter": true,
+	// Permissions / access / authorization.
+	"permission": true, "permissions": true,
+	// Module / install lifecycle.
+	"init": true, "boot": true, "install": true, "uninstall": true,
+	"schema": true, "schema_alter": true, "requirements": true,
+	"modules_installed": true, "modules_uninstalled": true,
+	"update_dependencies": true, "update_last_removed": true,
+	"install_tasks": true, "install_tasks_alter": true,
+	// Cron, queue, batch.
+	"cron": true, "queue_info_alter": true,
+	// Help, mail, messaging.
+	"help": true, "mail": true, "mail_alter": true,
+	// Tokens.
+	"token_info": true, "token_info_alter": true, "tokens": true, "tokens_alter": true,
+	// Views.
+	"views_data": true, "views_data_alter": true, "views_query_alter": true,
+	"views_pre_render": true, "views_post_render": true, "views_pre_execute": true,
+	// Fields / widgets / formatters.
+	"field_info_alter": true, "field_widget_info_alter": true,
+	"field_formatter_info_alter": true, "field_widget_complete_form_alter": true,
+	// Blocks.
+	"block_access": true, "block_alter": true, "block_build_alter": true,
+	"block_view_alter": true,
+	// Comments.
+	"comment_insert": true, "comment_update": true, "comment_delete": true,
+	"comment_presave": true, "comment_publish": true, "comment_unpublish": true,
+	// Taxonomy / file / search.
+	"taxonomy_term_insert": true, "taxonomy_term_update": true, "taxonomy_term_delete": true,
+	"file_download": true, "file_url_alter": true,
+	"search_info": true, "ranking": true,
+	// Language / locale.
+	"language_switch_links_alter": true, "language_types_info": true,
+	// Cache / config / data.
+	"cache_flush": true, "rebuild": true,
+	"config_schema_info_alter": true, "data_type_info_alter": true,
+	// Toolbar / contextual / batch.
+	"toolbar": true, "toolbar_alter": true, "contextual_links_view_alter": true,
+	"batch_alter": true,
+	// Mail / cron / system.
+	"system_info_alter": true, "flush_caches": true,
+}
+
+// drupalHookPattern matches a Drupal hook family whose name carries a variable
+// segment (a form id, theme hook, or entity type), which an exact-suffix lookup
+// cannot capture. The match is anchored to keep it precise: a function name's
+// suffix must start with prefix, end with suffix (when set), and have a
+// non-empty variable middle — `{module}_form_user_login_form_alter` matches
+// `hook_form_FORM_ID_alter`, but `{module}_form_alter` (the bare hook) is left
+// to the exact set. canonical is the placeholder hook name reported, so every
+// implementation of a family wires to one synthetic node.
+type drupalHookPattern struct {
+	prefix    string // required leading segment, e.g. "form_"
+	suffix    string // required trailing segment (may be empty), e.g. "_alter"
+	canonical string // reported hook name, e.g. "hook_form_FORM_ID_alter"
+}
+
+// drupalHookPatterns are the variable-segment hook families, checked only when
+// the exact-suffix lookup misses.
+var drupalHookPatterns = []drupalHookPattern{
+	// hook_form_FORM_ID_alter / hook_form_BASE_FORM_ID_alter.
+	{prefix: "form_", suffix: "_alter", canonical: "hook_form_FORM_ID_alter"},
+	// hook_preprocess_HOOK (template preprocess for a specific theme hook).
+	{prefix: "preprocess_", canonical: "hook_preprocess_HOOK"},
+	// hook_process_HOOK.
+	{prefix: "process_", canonical: "hook_process_HOOK"},
+	// hook_theme_suggestions_HOOK / hook_theme_suggestions_HOOK_alter.
+	{prefix: "theme_suggestions_", suffix: "_alter", canonical: "hook_theme_suggestions_HOOK_alter"},
+	{prefix: "theme_suggestions_", canonical: "hook_theme_suggestions_HOOK"},
+	// hook_field_widget_WIDGET_TYPE_form_alter / hook_field_widget_complete_WIDGET_TYPE_form_alter.
+	{prefix: "field_widget_", suffix: "_form_alter", canonical: "hook_field_widget_WIDGET_TYPE_form_alter"},
 }
 
 // captureDrupalHooks flags hook-implementation functions and wires them to a
@@ -107,6 +198,34 @@ func drupalHookFor(n *graph.Node, module string, moduleFile bool) string {
 		if drupalKnownHookSuffixes[suffix] {
 			return "hook_" + suffix
 		}
+		if hook := drupalHookFromPattern(suffix); hook != "" {
+			return hook
+		}
+	}
+	return ""
+}
+
+// drupalHookFromPattern resolves a variable-segment hook family (a function
+// suffix like `form_user_login_form_alter` or `preprocess_node`) to its
+// canonical placeholder hook name, or "" when no family matches. Each match
+// requires a non-empty variable middle so a bare hook (already in the exact
+// set) does not double-match here.
+func drupalHookFromPattern(suffix string) string {
+	for _, p := range drupalHookPatterns {
+		if !strings.HasPrefix(suffix, p.prefix) {
+			continue
+		}
+		mid := suffix[len(p.prefix):]
+		if p.suffix != "" {
+			if !strings.HasSuffix(mid, p.suffix) {
+				continue
+			}
+			mid = mid[:len(mid)-len(p.suffix)]
+		}
+		if mid == "" {
+			continue
+		}
+		return p.canonical
 	}
 	return ""
 }

--- a/internal/parser/languages/php_drupal_hooks_test.go
+++ b/internal/parser/languages/php_drupal_hooks_test.go
@@ -73,6 +73,80 @@ function mymodule_helper_util() {}
 	}
 }
 
+func TestDrupalHooks_BroadenedCoreHooks(t *testing.T) {
+	// Common core hooks added to the allowlist plus the variable-segment
+	// families, alongside a couple of plain helpers that must stay unflagged.
+	src := `<?php
+function mymodule_form_alter(&$form, $form_state, $form_id) {}
+
+function mymodule_form_user_login_form_alter(&$form, $form_state) {}
+
+function mymodule_node_access($node, $op, $account) {}
+
+function mymodule_entity_access($entity, $op, $account) {}
+
+function mymodule_preprocess_node(&$variables) {}
+
+function mymodule_theme($existing, $type, $theme, $path) {}
+
+function mymodule_cron() {}
+
+function mymodule_mail($key, &$message, $params) {}
+
+function mymodule_views_data() {}
+
+function mymodule_tokens($type, $tokens, $data, $options) {}
+
+function mymodule_library_info_alter(&$libraries, $extension) {}
+
+function mymodule_field_widget_single_element_string_textfield_form_alter(&$element, $form_state, $context) {}
+
+function mymodule_helper_util() {}
+
+function mymodule_build_thing() {}
+`
+	res, err := NewPHPExtractor().Extract("modules/mymodule/mymodule.module", []byte(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := map[string]string{
+		"mymodule_form_alter":                 "hook_form_alter",
+		"mymodule_form_user_login_form_alter": "hook_form_FORM_ID_alter",
+		"mymodule_node_access":                "hook_node_access",
+		"mymodule_entity_access":              "hook_entity_access",
+		"mymodule_preprocess_node":            "hook_preprocess_HOOK",
+		"mymodule_theme":                      "hook_theme",
+		"mymodule_cron":                       "hook_cron",
+		"mymodule_mail":                       "hook_mail",
+		"mymodule_views_data":                 "hook_views_data",
+		"mymodule_tokens":                     "hook_tokens",
+		"mymodule_library_info_alter":         "hook_library_info_alter",
+		"mymodule_field_widget_single_element_string_textfield_form_alter": "hook_field_widget_WIDGET_TYPE_form_alter",
+	}
+	for fn, hook := range want {
+		if got := drupalHookOf(res.Nodes, fn); got != hook {
+			t.Errorf("%s detected as %q, want %q", fn, got, hook)
+		}
+	}
+
+	// Plain helpers must not be mistaken for hooks (precision guard).
+	for _, fn := range []string{"mymodule_helper_util", "mymodule_build_thing"} {
+		if got := drupalHookOf(res.Nodes, fn); got != "" {
+			t.Errorf("non-hook %s wrongly flagged as %q", fn, got)
+		}
+	}
+
+	// The variable-segment families collapse to one synthetic node + EdgeImplements.
+	hookNode := drupalHookNode(res.Nodes, "hook_form_FORM_ID_alter")
+	if hookNode == nil {
+		t.Fatalf("no synthetic hook_form_FORM_ID_alter node")
+	}
+	if !drupalImplements(res.Edges, "modules/mymodule/mymodule.module::mymodule_form_user_login_form_alter", hookNode.ID) {
+		t.Errorf("missing EdgeImplements for the form_FORM_ID_alter implementation")
+	}
+}
+
 func TestDrupalHooks_NonModuleFileNamePatternIgnored(t *testing.T) {
 	// In a plain .php file (not a Drupal module file), the name pattern does
 	// not apply — only the @Implements docblock would.

--- a/internal/parser/languages/value_refs_dart_pascal_test.go
+++ b/internal/parser/languages/value_refs_dart_pascal_test.go
@@ -1,0 +1,97 @@
+package languages
+
+import (
+	"testing"
+)
+
+// TestValueRefKind_DartConst pins that a distinctive top-level Dart `const`
+// declaration is kinded as a constant and its read is captured as a value-ref
+// candidate.
+func TestValueRefKind_DartConst(t *testing.T) {
+	src := []byte(`const MAX_RETRIES = 3;
+
+void useIt() {
+  print(MAX_RETRIES);
+}
+`)
+	res, err := NewDartExtractor().Extract("cfg.dart", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if constNode(res, "MAX_RETRIES") == nil {
+		t.Error("Dart distinctive const MAX_RETRIES should be KindConstant")
+	}
+	if !valueRefRead(res, "MAX_RETRIES") {
+		t.Error("read of MAX_RETRIES should be captured as a value-ref candidate")
+	}
+}
+
+// TestValueRefKind_DartFinal pins that a distinctive top-level Dart `final`
+// declaration (immutable by grammar) is kinded as a constant and its read is
+// captured.
+func TestValueRefKind_DartFinal(t *testing.T) {
+	src := []byte(`final API_BASE = 'https://x';
+
+void useIt() {
+  print(API_BASE);
+}
+`)
+	res, err := NewDartExtractor().Extract("cfg.dart", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if constNode(res, "API_BASE") == nil {
+		t.Error("Dart distinctive final API_BASE should be KindConstant")
+	}
+	if !valueRefRead(res, "API_BASE") {
+		t.Error("read of API_BASE should be captured as a value-ref candidate")
+	}
+}
+
+// TestValueRefKind_DartLowerVarNotConst pins the precision boundary: an ordinary
+// lowerCamelCase top-level `var` stays a KindVariable and emits no value-ref
+// candidate (the distinctive-name gate filters it out).
+func TestValueRefKind_DartLowerVarNotConst(t *testing.T) {
+	src := []byte(`var counter = 0;
+
+void useIt() {
+  print(counter);
+}
+`)
+	res, err := NewDartExtractor().Extract("cfg.dart", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if constNode(res, "counter") != nil {
+		t.Error("ordinary var counter must not be re-kinded to KindConstant")
+	}
+	if valueRefRead(res, "counter") {
+		t.Error("non-distinctive var counter must not be captured as a value-ref candidate")
+	}
+}
+
+// TestValueRefKind_PascalConst pins that a Pascal `const` declaration is kinded
+// as a constant and its read is captured as a value-ref candidate.
+func TestValueRefKind_PascalConst(t *testing.T) {
+	src := []byte(`unit Foo;
+interface
+const
+  MAX_RETRIES = 3;
+implementation
+procedure UseIt;
+begin
+  WriteLn(MAX_RETRIES);
+end;
+end.
+`)
+	res, err := NewPascalExtractor().Extract("foo.pas", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if constNode(res, "MAX_RETRIES") == nil {
+		t.Error("Pascal const MAX_RETRIES should be KindConstant")
+	}
+	if !valueRefRead(res, "MAX_RETRIES") {
+		t.Error("read of MAX_RETRIES should be captured as a value-ref candidate")
+	}
+}

--- a/internal/resolver/django_descriptor_test.go
+++ b/internal/resolver/django_descriptor_test.go
@@ -67,6 +67,20 @@ func TestClaimingResolver_GenericTierClaimsResidualRef(t *testing.T) {
 	assert.True(t, bound, "the unresolved ref was rebound before external-call synthesis")
 }
 
+// The Django descriptor resolver must stay wired into the default claiming
+// registry — a drift fence so it cannot be silently dropped and quietly stop
+// claiming Django's named-class references. Asserts membership by Name()
+// directly, independent of any one resolver's functional behaviour.
+func TestDefaultClaimingResolvers_IncludesDjangoDescriptor(t *testing.T) {
+	names := map[string]bool{}
+	for _, r := range defaultClaimingResolvers() {
+		require.NotNil(t, r, "registered claiming resolvers are non-nil")
+		names[r.Name()] = true
+	}
+	require.True(t, names[SynthDjangoDescriptor],
+		"DjangoDescriptorResolver must be registered in defaultClaimingResolvers (got %v)", names)
+}
+
 func djangoIter(g *graph.Graph, id, file, class string) {
 	g.AddNode(&graph.Node{ID: id, Kind: graph.KindMethod, Name: "__iter__", FilePath: file, Language: "python",
 		Meta: map[string]any{"receiver": class}})

--- a/internal/resolver/goframe_route_calls.go
+++ b/internal/resolver/goframe_route_calls.go
@@ -102,10 +102,13 @@ func ResolveGoFrameRoutes(g graph.Store) int {
 }
 
 // goframePickMethod selects the handler for a route from the methods of a
-// request type: a bound controller (addonRoot) wins, then a method in the
+// request type: candidates are first narrowed to the route's request-struct
+// package (so a same-named request type in another package can never claim the
+// route), then a bound controller (addonRoot) wins, then a method in the
 // route's directory, then a unique match.
 func goframePickMethod(g graph.Store, route *graph.Edge, cands []*graph.Node) *graph.Node {
 	cands = sameBoundaryCandidates(g, route.From, cands)
+	cands = goframeSamePackage(route, cands)
 	if len(cands) == 0 {
 		return nil
 	}
@@ -146,6 +149,35 @@ func goframePickMethod(g graph.Store, route *graph.Edge, cands []*graph.Node) *g
 		return cands[0]
 	}
 	return nil
+}
+
+// goframeSamePackage narrows candidates to those whose request-struct package
+// matches the route's. A route materialised from `pkg.CreateReq` must bind only
+// to a handler taking `*pkg.CreateReq` — never to a same-named `CreateReq` in
+// another package. The package qualifier is the extractor's `goframe_request_pkg`
+// stamp; when the route carries none (a same-package, bare-name binding the
+// extractor could not qualify), candidates pass through unfiltered so existing
+// single-package resolution is never weakened.
+func goframeSamePackage(route *graph.Edge, cands []*graph.Node) []*graph.Node {
+	routePkg := ""
+	if route.Meta != nil {
+		routePkg, _ = route.Meta["goframe_request_pkg"].(string)
+	}
+	if routePkg == "" {
+		return cands
+	}
+	out := make([]*graph.Node, 0, len(cands))
+	for _, c := range cands {
+		if c == nil || c.Meta == nil {
+			continue
+		}
+		// A candidate with no package qualifier cannot be proven to belong to
+		// the route's package, so it is excluded once the route is qualified.
+		if cp, _ := c.Meta["goframe_request_pkg"].(string); cp == routePkg {
+			out = append(out, c)
+		}
+	}
+	return out
 }
 
 func goframeDir(path string) string {

--- a/internal/resolver/goframe_route_calls_test.go
+++ b/internal/resolver/goframe_route_calls_test.go
@@ -76,6 +76,57 @@ func TestResolveGoFrameRoutes_AddonRootTiebreak(t *testing.T) {
 	assert.Nil(t, synthGoFrameCall(g, "route::goframe::POST::/users", "b/ctrl.go::OtherCtrl.Create"))
 }
 
+// goframeRoutePkg adds a route whose request struct is qualified by its
+// declaring package (the `goframe_request_pkg` stamp the extractor derives from
+// the struct file's package clause).
+func goframeRoutePkg(g *graph.Graph, routeID, file, method, path, reqType, pkg string) {
+	g.AddNode(&graph.Node{ID: routeID, Kind: graph.KindContract, Name: method + " " + path, FilePath: file,
+		Meta: map[string]any{"type": "http", "method": method, "path": path, "framework": "goframe",
+			"goframe_request_type": reqType, "goframe_request_pkg": pkg}})
+	g.AddEdge(&graph.Edge{From: routeID, To: "unresolved::*." + reqType, Kind: graph.EdgeCalls, FilePath: file,
+		Meta: map[string]any{"via": goframeRouteVia, "goframe_request_type": reqType,
+			"goframe_request_pkg": pkg, "goframe_route": routeID}})
+}
+
+// goframeMethodPkg adds a handler whose request param is qualified
+// (`*pkg.CreateReq`), so the resolver can join by (package, type), never by a
+// bare same-named type across packages.
+func goframeMethodPkg(g *graph.Graph, id, file, reqType, pkg string, bound bool) {
+	meta := map[string]any{"goframe_request_type": reqType, "goframe_request_pkg": pkg}
+	if bound {
+		meta["goframe_bound"] = true
+	}
+	g.AddNode(&graph.Node{ID: id, Kind: graph.KindMethod, Name: lastSeg(id), FilePath: file, Language: "go", Meta: meta})
+}
+
+func TestResolveGoFrameRoutes_CrossPackageSameTypeName(t *testing.T) {
+	// Two packages each declare their own `CreateReq` request struct (each
+	// tagged via g.Meta) and a handler for it. The req struct (route source)
+	// and the controller live in different directories — the realistic GoFrame
+	// layout (api/ vs controller/) — so the same-directory tiebreak cannot
+	// disambiguate. Each route must bind to ITS OWN package's handler; a route
+	// must never cross-bind to the other package's same-named handler.
+	g := graph.New()
+	// Package a: route declared in package "a", handler takes *a.CreateReq.
+	goframeRoutePkg(g, "route::goframe::POST::/a/create", "a/api/create.go", "POST", "/a/create", "CreateReq", "a")
+	goframeMethodPkg(g, "a/controller/create.go::ACtrl.Create", "a/controller/create.go", "CreateReq", "a", false)
+	// Package b: route declared in package "b", handler takes *b.CreateReq.
+	goframeRoutePkg(g, "route::goframe::POST::/b/create", "b/api/create.go", "POST", "/b/create", "CreateReq", "b")
+	goframeMethodPkg(g, "b/controller/create.go::BCtrl.Create", "b/controller/create.go", "CreateReq", "b", false)
+
+	ResolveGoFrameRoutes(g)
+
+	assert.NotNil(t, synthGoFrameCall(g, "route::goframe::POST::/a/create", "a/controller/create.go::ACtrl.Create"),
+		"package a's route binds to package a's handler")
+	assert.Nil(t, synthGoFrameCall(g, "route::goframe::POST::/a/create", "b/controller/create.go::BCtrl.Create"),
+		"package a's route must NOT cross-bind to package b's handler")
+
+	assert.NotNil(t, synthGoFrameCall(g, "route::goframe::POST::/b/create", "b/controller/create.go::BCtrl.Create"),
+		"package b's route binds to package b's handler")
+	assert.Nil(t, synthGoFrameCall(g, "route::goframe::POST::/b/create", "a/controller/create.go::ACtrl.Create"),
+		"package b's route must NOT cross-bind to package a's handler")
+}
+
 func TestResolveGoFrameRoutes_NoHandlerStaysPlaceholder(t *testing.T) {
 	g := graph.New()
 	goframeRoute(g, "route::goframe::GET::/x", "r.go", "GET", "/x", "XReq")

--- a/internal/resolver/store_factory_calls.go
+++ b/internal/resolver/store_factory_calls.go
@@ -99,7 +99,8 @@ func ResolveStoreFactoryCalls(g graph.Store) int {
 }
 
 // pickStoreAction disambiguates action candidates for a call: prefer the
-// candidate in the caller's file, then a unique binding match, then a
+// candidate defined in the same file as the `useXStore` getter the call's
+// store binding resolves to, then the candidate in the caller's file, then a
 // singleton. Returns nil when the choice is ambiguous (never guesses).
 func pickStoreAction(g graph.Store, call *graph.Edge, cands []*graph.Node) *graph.Node {
 	switch len(cands) {
@@ -108,9 +109,29 @@ func pickStoreAction(g graph.Store, call *graph.Edge, cands []*graph.Node) *grap
 	case 1:
 		return cands[0]
 	}
-	// Multiple stores share this binding name across files. Prefer the one in
-	// the caller's file; if the caller's file imports exactly one candidate's
-	// file, prefer that; otherwise it's ambiguous.
+	// Multiple stores reuse this binding name across files. The strongest
+	// signal is the store DEFINITION file: the call's `store_binding` names a
+	// `useXStore` getter, which lives in exactly one file. Prefer the candidate
+	// action defined there — it is the store the binding actually refers to,
+	// regardless of where the call sits.
+	binding, _ := call.Meta["store_binding"].(string)
+	if getterFile := storeGetterFile(g, binding); getterFile != "" {
+		var inGetterFile *graph.Node
+		for _, c := range cands {
+			if c.FilePath == getterFile {
+				if inGetterFile != nil {
+					inGetterFile = nil // two candidates in the getter's file: no win
+					break
+				}
+				inGetterFile = c
+			}
+		}
+		if inGetterFile != nil {
+			return inGetterFile
+		}
+	}
+	// No definition-file signal. Fall back to the caller's file: prefer the
+	// candidate co-located with the call; otherwise it's ambiguous.
 	callerFile := ""
 	if cn := g.GetNode(call.From); cn != nil {
 		callerFile = cn.FilePath
@@ -125,4 +146,34 @@ func pickStoreAction(g graph.Store, call *graph.Edge, cands []*graph.Node) *grap
 		}
 	}
 	return sameFile
+}
+
+// storeGetterFile returns the file that defines the `useXStore` getter named by
+// binding — the variable/function/const a `defineStore` / `create` call is
+// assigned to. The getter is the store DEFINITION anchor, so its file pins which
+// store a binding refers to even when the same binding name is reused across
+// files. Returns "" when no getter, or more than one, carries the name (no
+// unambiguous definition site).
+func storeGetterFile(g graph.Store, binding string) string {
+	if g == nil || binding == "" {
+		return ""
+	}
+	file := ""
+	for _, n := range nodesByKindsOrAll(g, graph.KindVariable, graph.KindFunction, graph.KindConstant) {
+		if n == nil || n.Name != binding || n.FilePath == "" {
+			continue
+		}
+		// A getter node anchors a store: it is the assignment target of the
+		// factory call, never itself a store-factory action.
+		if n.Meta != nil {
+			if _, isAction := n.Meta["store_factory"]; isAction {
+				continue
+			}
+		}
+		if file != "" && file != n.FilePath {
+			return "" // binding defined in two files: ambiguous
+		}
+		file = n.FilePath
+	}
+	return file
 }

--- a/internal/resolver/store_factory_calls_test.go
+++ b/internal/resolver/store_factory_calls_test.go
@@ -97,6 +97,36 @@ func TestResolveStoreFactoryCalls_Idempotent(t *testing.T) {
 	}
 }
 
+// storeGetter adds the `useXStore` getter node a `defineStore`/`create` call is
+// assigned to — the store DEFINITION anchor. It is NOT a store-factory action.
+func storeGetter(g *graph.Graph, id, file, name string) {
+	g.AddNode(&graph.Node{ID: id, Kind: graph.KindConstant, Name: name, FilePath: file})
+}
+
+func TestResolveStoreFactoryCalls_DefinitionFilePrefersGetterStore(t *testing.T) {
+	// Two stores in DIFFERENT files both reuse the binding name `useUserStore`
+	// and both define `login`, so the candidate list collides on (binding,
+	// member). The User store's getter is defined in user.ts; a
+	// useUserStore().login() call — from a component in neither store file —
+	// must bind to user.ts's login, never the other store's.
+	g := graph.New()
+	storeGetter(g, "user.ts::useUserStore", "user.ts", "useUserStore")
+	storeAction(g, "user.ts::useUserStore.login@5", "user.ts", "useUserStore", "login")
+	storeAction(g, "legacy.ts::useUserStore.login@5", "legacy.ts", "useUserStore", "login")
+	storeCall(g, "Login.vue::submit", "Login.vue", "useUserStore", "login")
+
+	ResolveStoreFactoryCalls(g)
+	var bound string
+	for _, e := range g.GetOutEdges("Login.vue::submit") {
+		if e.Kind == graph.EdgeCalls && e.Meta["synthesized_by"] == SynthStoreFactory {
+			bound = e.To
+		}
+	}
+	if bound != "user.ts::useUserStore.login@5" {
+		t.Fatalf("useUserStore().login() bound to %q (want user.ts login defined beside the getter)", bound)
+	}
+}
+
 func TestResolveStoreFactoryCalls_PiniaGetterDisambiguates(t *testing.T) {
 	// Two stores each define `login`, keyed by their getter name. A
 	// useUserStore-bound call must reach the user store's login, never the

--- a/internal/resolver/value_refs_dart_pascal_test.go
+++ b/internal/resolver/value_refs_dart_pascal_test.go
@@ -1,0 +1,94 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+// loadExtract runs an extractor's output into a fresh graph so a resolver pass
+// can act on the same nodes/edges the indexer would settle.
+func loadExtract(t *testing.T, g graph.Store, res *parser.ExtractionResult) {
+	t.Helper()
+	for _, n := range res.Nodes {
+		g.AddNode(n)
+	}
+	for _, e := range res.Edges {
+		g.AddEdge(e)
+	}
+}
+
+// TestValueRefDart_EndToEnd extracts a Dart file whose function reads a
+// distinctive top-level constant, then confirms ResolveValueRefs binds the
+// captured candidate into a tiered EdgeReads from the reader to the constant —
+// so the reader lands in the constant's blast radius.
+func TestValueRefDart_EndToEnd(t *testing.T) {
+	src := `const MAX_RETRIES = 3;
+
+void useIt() {
+  print(MAX_RETRIES);
+}
+`
+	res, err := languages.NewDartExtractor().Extract("cfg.dart", []byte(src))
+	require.NoError(t, err)
+
+	g := graph.New()
+	loadExtract(t, g, res)
+
+	n := ResolveValueRefs(g)
+	assert.GreaterOrEqual(t, n, 1, "the distinctive Dart constant read must bind")
+
+	e := readsEdge(g, "cfg.dart::useIt", "cfg.dart::MAX_RETRIES")
+	require.NotNil(t, e, "useIt should gain a value-ref EdgeReads to MAX_RETRIES")
+	assert.Equal(t, graph.OriginASTResolved, e.Origin, "the read must ride a provenance tier")
+
+	// Impact-radius property: the reader is among the constant's incoming
+	// (non-Defines/MemberOf) edges, which blast-radius analysis walks.
+	var inRadius bool
+	for _, in := range g.GetInEdges("cfg.dart::MAX_RETRIES") {
+		if in.From == "cfg.dart::useIt" && in.Kind != graph.EdgeDefines && in.Kind != graph.EdgeMemberOf {
+			inRadius = true
+		}
+	}
+	assert.True(t, inRadius, "useIt must appear in MAX_RETRIES' impact radius")
+}
+
+// TestValueRefPascal_EndToEnd does the same for a Pascal unit-level constant.
+func TestValueRefPascal_EndToEnd(t *testing.T) {
+	src := `unit Foo;
+interface
+const
+  MAX_RETRIES = 3;
+implementation
+procedure UseIt;
+begin
+  WriteLn(MAX_RETRIES);
+end;
+end.
+`
+	res, err := languages.NewPascalExtractor().Extract("foo.pas", []byte(src))
+	require.NoError(t, err)
+
+	g := graph.New()
+	loadExtract(t, g, res)
+
+	n := ResolveValueRefs(g)
+	assert.GreaterOrEqual(t, n, 1, "the distinctive Pascal constant read must bind")
+
+	e := readsEdge(g, "foo.pas::UseIt", "foo.pas::MAX_RETRIES")
+	require.NotNil(t, e, "UseIt should gain a value-ref EdgeReads to MAX_RETRIES")
+	assert.Equal(t, graph.OriginASTResolved, e.Origin, "the read must ride a provenance tier")
+
+	var inRadius bool
+	for _, in := range g.GetInEdges("foo.pas::MAX_RETRIES") {
+		if in.From == "foo.pas::UseIt" && in.Kind != graph.EdgeDefines && in.Kind != graph.EdgeMemberOf {
+			inRadius = true
+		}
+	}
+	assert.True(t, inRadius, "UseIt must appear in MAX_RETRIES' impact radius")
+}

--- a/internal/resolver/vapor_resolve.go
+++ b/internal/resolver/vapor_resolve.go
@@ -9,13 +9,15 @@ import (
 // Vapor (server-side Swift) directory-convention name-resolution. A fallback
 // for the references sourcekit-lsp leaves unresolved: a `*Controller` binds to
 // /Controllers/, a `*Middleware` to /Middleware/. Fluent models are bare
-// PascalCase (`final class User: Model`) and resolve to /Models/ through the
-// shared SwiftUI model fallback, so they are not re-handled here. The
+// PascalCase (`final class User: Model`) and resolve to /Models/; that case is
+// gated on the resolved definition actually living under a /Models/ directory
+// so a built-in or unrelated same-named type is never mis-bound. The
 // `*ViewController` shape is left to the UIKit pass.
 
 var (
 	vaporControllerDirs = []string{"/Controllers/", "/Controller/"}
 	vaporMiddlewareDirs = []string{"/Middleware/", "/Middlewares/"}
+	vaporModelDirs      = []string{"/Models/", "/Model/"}
 )
 
 // ResolveVaporRefs binds residual unresolved Vapor references to their
@@ -35,7 +37,7 @@ func ResolveVaporRefs(g graph.Store) int {
 			if name == "" || strings.ContainsRune(name, '.') {
 				continue
 			}
-			dirs, ok := vaporDirsFor(name)
+			dirs, modelOnly, ok := vaporDirsFor(name)
 			if !ok {
 				continue
 			}
@@ -49,6 +51,15 @@ func ResolveVaporRefs(g graph.Store) int {
 			targetID, conf := ResolveByConvention(g, name, "", dirs, fromFile)
 			if targetID == "" {
 				continue
+			}
+			if modelOnly {
+				// A bare-PascalCase model binds only when its definition
+				// actually lives under a /Models/ directory, so a built-in
+				// or unrelated same-named type is never mis-bound.
+				tn := g.GetNode(targetID)
+				if tn == nil || !swiftUIPathHasDir(tn.FilePath, vaporModelDirs) {
+					continue
+				}
 			}
 			oldTo := e.To
 			e.To = targetID
@@ -66,14 +77,19 @@ func ResolveVaporRefs(g graph.Store) int {
 	return resolved
 }
 
-// vaporDirsFor classifies a Vapor reference name into its convention dirs. A
-// `*ViewController` is excluded — that is the UIKit pass's shape.
-func vaporDirsFor(name string) ([]string, bool) {
+// vaporDirsFor classifies a Vapor reference name into its convention dirs;
+// modelOnly marks the bare-PascalCase Fluent-model fallback, which is
+// additionally gated on the resolved definition living under a /Models/
+// directory. A `*ViewController` is excluded — that is the UIKit pass's shape.
+func vaporDirsFor(name string) (dirs []string, modelOnly bool, ok bool) {
 	switch {
 	case strings.HasSuffix(name, "Controller") && !strings.HasSuffix(name, "ViewController"):
-		return vaporControllerDirs, true
+		return vaporControllerDirs, false, true
 	case strings.HasSuffix(name, "Middleware"):
-		return vaporMiddlewareDirs, true
+		return vaporMiddlewareDirs, false, true
 	}
-	return nil, false
+	if c := name[0]; c >= 'A' && c <= 'Z' {
+		return vaporModelDirs, true, true
+	}
+	return nil, false, false
 }

--- a/internal/resolver/vapor_resolve_test.go
+++ b/internal/resolver/vapor_resolve_test.go
@@ -50,6 +50,33 @@ func TestResolveVaporRefs_ViewControllerLeftToUIKit(t *testing.T) {
 	require.Equal(t, 0, ResolveVaporRefs(g))
 }
 
+func TestResolveVaporRefs_FluentModelBindsToModelsDir(t *testing.T) {
+	g := graph.New()
+	const route = "Sources/App/routes.swift::routes"
+	g.AddNode(&graph.Node{ID: route, Kind: graph.KindFunction, Name: "routes", FilePath: "Sources/App/routes.swift", Language: "swift"})
+	convNode(g, "Sources/App/Models/User.swift::User", "Sources/App/Models/User.swift", "User")
+
+	g.AddEdge(&graph.Edge{From: route, To: "unresolved::User", Kind: graph.EdgeReferences, FilePath: "Sources/App/routes.swift"})
+
+	require.Equal(t, 1, ResolveVaporRefs(g))
+	assert.NotNil(t, synthVaporEdge(g, graph.EdgeReferences, route, "Sources/App/Models/User.swift::User"),
+		"bare-PascalCase model binds to its /Models/ definition")
+}
+
+func TestResolveVaporRefs_ModelOutsideModelsDirLeftAlone(t *testing.T) {
+	// A bare-PascalCase ref whose sole candidate is not under /Models/ must
+	// not be bound — the model gate guards against mis-binding a built-in or
+	// unrelated same-named type.
+	g := graph.New()
+	const route = "Sources/App/routes.swift::routes"
+	g.AddNode(&graph.Node{ID: route, Kind: graph.KindFunction, Name: "routes", FilePath: "Sources/App/routes.swift", Language: "swift"})
+	convNode(g, "Sources/App/Helpers/Token.swift::Token", "Sources/App/Helpers/Token.swift", "Token")
+
+	g.AddEdge(&graph.Edge{From: route, To: "unresolved::Token", Kind: graph.EdgeReferences, FilePath: "Sources/App/routes.swift"})
+
+	require.Equal(t, 0, ResolveVaporRefs(g))
+}
+
 func TestResolveVaporRefs_AmbiguousLeftAlone(t *testing.T) {
 	g := graph.New()
 	const route = "Sources/App/r.swift::r"


### PR DESCRIPTION
## What

Extends the framework and language coverage with a set of capture, resolution, and dispatch refinements, plus one route-resolution bug fix.

### Function-as-value capture
- Per-grammar value-position specs now cover every supported language (previously only Rust/Go/Swift/Kotlin/Scala/Pascal had non-default specs). Member/attribute value forms (`member_expression`, `attribute`, `member_access_expression`) name the referenced function by its trailing segment, and the cross-module branch is generalized to any qualified path node.
- A new AST-aware call/value dispatch rejects a token in callee position of a call node, so modern call syntax (`f?.()`, `f!()`, `f<T>()`) is no longer mistaken for a function-as-value reference.

### Value references
- Distinctive top-level Dart `const`/`final` declarations are kinded as constants so their readers enter the constant's impact radius. Dart and Pascal value-reference participation is covered by new tests.

### Framework routes
- Vapor closure-block route groups (`app.group("api") { ... }`) join their prefix onto nested routes; bare-PascalCase Fluent-model references resolve to `/Models/`.
- Cross-file Actix `web::scope` config mounts join their prefix onto resources defined in other files.

### Resolution and dispatch
- `compile_commands.json` include directories reload when the file changes on disk, so an edited `-I` path takes effect on the next resolve without a full reindex.
- Broader Drupal core hook detection, including variable-segment families (`hook_form_FORM_ID_alter`, `hook_preprocess_HOOK`, `hook_field_widget_*_form_alter`, …) with precision guards.
- Store-factory calls prefer the action defined in the store's own file when a binding name collides across stores.
- **Fix:** GoFrame routes bound handlers by the bare request-struct name, cross-binding across packages that share a type name. Handlers and routes are now qualified by the request struct's package, and the resolver narrows candidates to the route's package before existing tiebreaks.

### Tests
- Added coverage for Swift `#selector`, C# self-member, and Ruby `&:sym` function references; a drift fence ensuring the Django claiming resolver stays registered; and a GoFrame cross-package regression.

## Verification

`go build ./...`, `go test -race -timeout 900s` (parser/languages, resolver, contracts, indexer, excludes — all pass), and `golangci-lint` (0 issues). Per-feature commits; no changes outside `internal/`.
