### PR TITLE
fix(lsp): always emit result member on reverse-RPC success replies

### DIFF
--- a/internal/semantic/lsp/client.go
+++ b/internal/semantic/lsp/client.go
@@ -531,10 +531,22 @@ func (c *Client) dispatchRequest(rawID json.RawMessage, method string, params js
 	h, ok := c.reqHandlers[method]
 	c.reqMu.RUnlock()
 
+	// Result is a json.RawMessage, not `any`, so we control exactly what
+	// lands on the wire. A JSON-RPC 2.0 *success* response MUST carry a
+	// "result" member — even when it is null. A nil handler result is a
+	// null success (the correct ack for client/registerCapability and
+	// workspace/applyEdit's negative case), NOT an absent field. Marshal
+	// it explicitly to "null" so the field is always present on success;
+	// `omitempty` then only drops Result on the error path (where it must
+	// be absent — the spec forbids result+error together). Strict servers
+	// (StreamJsonRpc, used by Roslyn / the C# server) reject a bare
+	// {"jsonrpc":"2.0","id":N} as "Unrecognized JSON-RPC 2.0 message" and
+	// tear down the whole connection, which is how a single nil ack to
+	// registerCapability used to kill every in-flight request.
 	type respWithRawID struct {
 		JSONRPC string          `json:"jsonrpc"`
 		ID      json.RawMessage `json:"id"`
-		Result  any             `json:"result,omitempty"`
+		Result  json.RawMessage `json:"result,omitempty"`
 		Error   *jsonRPCError   `json:"error,omitempty"`
 	}
 
@@ -542,19 +554,27 @@ func (c *Client) dispatchRequest(rawID json.RawMessage, method string, params js
 	if !ok {
 		resp.Error = &jsonRPCError{Code: -32601, Message: "method not found: " + method}
 	} else {
+		var res any
+		var rpcErr *jsonRPCError
 		func() {
 			defer func() {
 				if r := recover(); r != nil {
-					resp.Error = &jsonRPCError{Code: -32603, Message: "handler panicked"}
+					rpcErr = &jsonRPCError{Code: -32603, Message: "handler panicked"}
 				}
 			}()
-			res, err := h(method, params)
-			if err != nil {
-				resp.Error = err
-			} else {
-				resp.Result = res
-			}
+			res, rpcErr = h(method, params)
 		}()
+		if rpcErr != nil {
+			resp.Error = rpcErr
+		} else {
+			// json.Marshal(nil) → "null"; any marshal failure also
+			// falls back to a null success so the field is never empty.
+			raw, err := json.Marshal(res)
+			if err != nil || len(raw) == 0 {
+				raw = json.RawMessage("null")
+			}
+			resp.Result = raw
+		}
 	}
 	_ = c.send(resp)
 }

--- a/internal/semantic/lsp/registercap_test.go
+++ b/internal/semantic/lsp/registercap_test.go
@@ -134,10 +134,101 @@ func TestProvider_RegisterCapability_OneMethod(t *testing.T) {
 	resp := readAck(t, serverIn, registerCapWait)
 	assert.Equal(t, int64(42), resp.ID, "ack must echo the request id")
 	assert.Nil(t, resp.Error, "ack must not carry an error")
-	assert.True(t, len(resp.Result) == 0 || string(resp.Result) == "null",
-		"ack result must be null; got %q", string(resp.Result))
+	assert.Equal(t, "null", string(resp.Result),
+		"ack result must be the JSON literal null; got %q", string(resp.Result))
 
 	waitForSupports(t, p, "textDocument/foldingRange", true, registerCapWait)
+}
+
+// readRawAck waits up to timeout for the next framed message off the
+// client's stdin and returns its raw JSON body (undecoded). Unlike
+// readAck, it does NOT round-trip through jsonRPCResponse — that decode
+// collapses an absent "result" field and an explicit "result":null into
+// the same zero-length RawMessage, hiding the exact wire defect this
+// guards against.
+func readRawAck(t *testing.T, serverIn func() ([]byte, bool), timeout time.Duration) []byte {
+	t.Helper()
+	done := make(chan []byte, 1)
+	go func() {
+		if body, ok := serverIn(); ok {
+			done <- body
+		} else {
+			close(done)
+		}
+	}()
+	select {
+	case body, ok := <-done:
+		require.True(t, ok, "client did not reply before pipe closed")
+		return body
+	case <-time.After(timeout):
+		t.Fatal("timed out waiting for client to ack the request")
+		return nil
+	}
+}
+
+// TestProvider_RegisterCapability_AckCarriesResultMember is the
+// regression guard for the bug where a nil handler result serialized to
+// a bare {"jsonrpc":"2.0","id":N} — the "result" member omitted entirely
+// because the response struct used `Result any` with `omitempty`. A nil
+// interface is "empty", so the field vanished. Strict JSON-RPC servers
+// (StreamJsonRpc / Roslyn) reject such a message as "Unrecognized
+// JSON-RPC 2.0 message" and drop the connection, which manifested as the
+// C# language server exiting mid-initialize and enriching 0 nodes. The
+// fix forces a null literal on success; this test asserts on the RAW
+// bytes (readAck's struct decode cannot distinguish absent from null).
+func TestProvider_RegisterCapability_AckCarriesResultMember(t *testing.T) {
+	_, serverIn, serverOut, cleanup := providerWithRegisterCapHandlers(t)
+	defer cleanup()
+
+	serverOut(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "client/registerCapability",
+		"params": RegistrationParams{Registrations: []Registration{
+			{ID: "uuid-x", Method: "textDocument/foldingRange"},
+		}},
+	})
+
+	raw := readRawAck(t, serverIn, registerCapWait)
+
+	// Decode into a permissive map so we can assert key *presence*,
+	// which a struct decode cannot.
+	var m map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw, &m), "ack must be valid JSON: %s", raw)
+	_, hasResult := m["result"]
+	require.True(t, hasResult,
+		"success ack MUST include a result member (JSON-RPC 2.0 requires it; "+
+			"strict servers reject a bare id-only message); got %s", raw)
+	assert.Equal(t, "null", string(m["result"]),
+		"a nil handler result must serialize to the JSON literal null; got %s", raw)
+	_, hasError := m["error"]
+	assert.False(t, hasError, "success ack must not carry an error member; got %s", raw)
+}
+
+// TestProvider_DispatchRequest_ErrorOmitsResult confirms the symmetric
+// half of the contract: on the error path the response carries "error"
+// and MUST NOT carry "result" (the spec forbids both together). An
+// unhandled method drives the -32601 method-not-found path.
+func TestProvider_DispatchRequest_ErrorOmitsResult(t *testing.T) {
+	_, serverIn, serverOut, cleanup := providerWithRegisterCapHandlers(t)
+	defer cleanup()
+
+	serverOut(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      7,
+		"method":  "workspace/somethingUnhandled",
+		"params":  map[string]any{},
+	})
+
+	raw := readRawAck(t, serverIn, registerCapWait)
+
+	var m map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw, &m), "ack must be valid JSON: %s", raw)
+	_, hasError := m["error"]
+	require.True(t, hasError, "method-not-found ack must carry an error member; got %s", raw)
+	_, hasResult := m["result"]
+	assert.False(t, hasResult,
+		"error response must NOT carry a result member (spec forbids both); got %s", raw)
 }
 
 // TestProvider_RegisterCapability_MultipleMethods confirms a single


### PR DESCRIPTION
The reverse-RPC response in dispatchRequest used `Result any` with `omitempty`. Handlers for client/registerCapability and client/unregisterCapability return a successful *null* result (nil, nil), but a nil interface is "empty", so omitempty dropped the field entirely, serializing the ack as a bare {"jsonrpc":"2.0","id":N}.

JSON-RPC 2.0 requires a success response to carry a result member (even null). Strict servers — StreamJsonRpc, used by Roslyn / the C# language server — reject the id-only message as "Unrecognized JSON-RPC 2.0 message", throw ConnectionLostException, and tear down the whole connection. That single bad ack cascaded into failed dynamic capability registration, cancelled workspace/configuration, every hover returning "LSP server exited", and 0 nodes enriched. Lenient Go-based servers (gopls, rust-analyzer, jdtls) tolerated it, so it only surfaced on C#.

Switch Result to json.RawMessage and marshal explicitly: a nil handler result becomes the literal `null` on success, while omitempty still drops result on the error path (the spec forbids result+error together).

The bug escaped tests because the assertion decoded into a Go struct, where an absent result and result:null both collapse to a zero-length RawMessage. Add raw-wire-bytes regression tests asserting the result member is present on success and absent on error, and tighten the existing register-capability ack assertion.

## Summary

Brief description of what this PR does.

## Changes

- 

## Testing

- [x] All tests pass (`go test -race ./...`)
- [x] New tests added for new functionality
- [x] Benchmarks run if performance-relevant

## Checklist

- [x] Code follows existing patterns in the codebase
- [x] No unnecessary abstractions added
- [ ] Language extractor includes `Meta["methods"]` for interfaces (if applicable)
- [ ] Methods have `EdgeMemberOf` edges to their containing type (if applicable)
