### PR TITLE
feat(analyze): describe every kind in `analyze kinds`

### DIFF
--- a/cmd/gortex/analyze.go
+++ b/cmd/gortex/analyze.go
@@ -55,11 +55,27 @@ Requires a running daemon that tracks the repo.`,
 // SSOT — no daemon needed.
 var analyzeKindsCmd = &cobra.Command{
 	Use:   "kinds",
-	Short: "List the valid analyze kinds (no daemon needed)",
+	Short: "List the valid analyze kinds with a one-line description (no daemon needed)",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		for _, k := range gortexmcp.AnalyzeKinds() {
-			fmt.Fprintln(cmd.OutOrStdout(), k)
+		kinds := gortexmcp.AnalyzeKinds()
+
+		// Width the kind column to the widest name so the descriptions
+		// line up into a readable two-column reference listing.
+		width := 0
+		for _, k := range kinds {
+			if len(k) > width {
+				width = len(k)
+			}
+		}
+
+		out := cmd.OutOrStdout()
+		for _, k := range kinds {
+			if desc := gortexmcp.AnalyzeKindDescription(k); desc != "" {
+				fmt.Fprintf(out, "%-*s  %s\n", width, k, desc)
+			} else {
+				fmt.Fprintln(out, k)
+			}
 		}
 		return nil
 	},

--- a/internal/mcp/analyze_kinds.go
+++ b/internal/mcp/analyze_kinds.go
@@ -108,3 +108,99 @@ func AnalyzeKinds() []string {
 func analyzeKindsCSV() string {
 	return strings.Join(analyzeKinds, ", ")
 }
+
+// analyzeKindDescriptions is a one-line summary for every analyze kind,
+// so `gortex analyze kinds` is self-documenting and a user need not reach
+// for docs/source to learn what a kind does. It must stay in lock-step
+// with analyzeKinds: the anti-drift test in analyze_kinds_test.go asserts
+// every kind has a non-empty description here and that no description key
+// is an orphan (a kind that no longer exists). Keep each value to a single
+// terse line — the CLI aligns them into a two-column reference listing.
+var analyzeKindDescriptions = map[string]string{
+	"annotation_users":            "EdgeAnnotated rollup — sites using an annotation/decorator; scope with id/name (e.g. @Deprecated)",
+	"blame":                       "Stamp meta.last_authored on every blame-eligible node from git blame",
+	"bottlenecks":                 "Rank functions by computation-bottleneck risk — complexity, loop depth, transitive/hidden-O(n^k) nesting, unguarded recursion",
+	"cgo_users":                   "Files that import C (uses_cgo edge)",
+	"channel_ops":                 "Channels grouped by sends/receives — producer/consumer mismatches",
+	"clusters":                    "Community detection as an analyzer (algorithm=leiden/louvain/spectral, min_size)",
+	"components":                  "UI parent↔child fan-in/out from render edges (JSX/TSX + Phoenix HEEx)",
+	"concepts":                    "Concept clusters mined over the graph",
+	"config_readers":              "config_key nodes grouped by reads_config edges; name filter",
+	"connectivity_health":         "Graph-extraction quality — isolated nodes, leaf/source/sink counts, dead-weight by file",
+	"constructors_missing_fields": "Constructors that leave one or more struct fields unset",
+	"coverage":                    "Stamp meta.coverage_pct on executable symbols from a cover profile",
+	"coverage_gaps":               "Symbols inside [min_pct, max_pct) — undertested code",
+	"coverage_summary":            "Per-directory coverage rollup (avg, covered, partial, uncovered)",
+	"cross_repo":                  "Repo-boundary-crossing call/implements/extends edges grouped by repo pair + relation",
+	"cycles":                      "Dependency cycles via Tarjan's SCC, with severity classification",
+	"dbt_models":                  "dbt/SQLMesh models, seeds, snapshots, sources with column count + lineage fan-in/out",
+	"dead_code":                   "Symbols with zero incoming edges (excludes entry points, tests, exports)",
+	"def_use":                     "Per-function reaching-definition def→use chains over the on-demand CFG (pairs with get_cfg)",
+	"doc_staleness":               "Docs/decisions whose content→code links have gone dangling or pending — stale references",
+	"domain":                      "Results of pluggable TOML domain-extractor rules — project-specific node/edge kinds",
+	"drupal_hooks":                "Detected Drupal hook implementations grouped by the hook they implement",
+	"edge_audit":                  "Graph-completeness / edge-sanity diagnostic — missing or suspect edges",
+	"env_var_users":               "reads_config edges restricted to env-var keys, grouped by variable",
+	"error_surface":               "Function/method nodes with their throws targets — refactor blast radius",
+	"event_emitters":              "Event/log/metric emit sites grouped by emit edges; level/name filters",
+	"external_calls":              "Stdlib/module-cache attribution — module rollup of call/symbol counts",
+	"field_writers":               "Mutability hotspots — fields ranked by write edges; id scopes to one field",
+	"fixes_history":               "Mine git for bug-fix commits and rank fix-prone files",
+	"goroutine_spawns":            "Spawn edges grouped by spawned target + mode (goroutine/async/promise)",
+	"health_score":                "Composite per-symbol health 0-100 + A–F grade (coverage/complexity/recency/churn)",
+	"hotspots":                    "Over-coupled symbols ranked by fan-in, fan-out, and community crossings",
+	"hygiene":                     "SAST hygiene scan (alias of sast) — CWE/OWASP-tagged rules across 8 languages",
+	"images":                      "Container images (Dockerfile FROM / K8s container.image) with consumer count",
+	"impact":                      "Composite 0-100 change-impact score + risk label over 5 axes (PageRank, reach, complexity, co-change, span)",
+	"indirect_mutations":          "Fields mutated indirectly via a method/sibling call on the receiver — surfaces the via method",
+	"k8s_resources":               "Kubernetes resource fan-out (depends_on/configures/mounts/exposes/uses_env); k8s_kind/namespace filters",
+	"kcore":                       "k-core decomposition — the densely-connected graph core by k-degree (the infrastructure every layer leans on)",
+	"kustomize":                   "Kustomize overlay tree with base/resource fan-out; dir filter",
+	"log_events":                  "Logging-call sites surfaced as events",
+	"louvain":                     "Louvain community partitioning (typically more granular than the Leiden clusters kind)",
+	"models":                      "ORM model→table edges (gorm/SQLAlchemy/Django/ActiveRecord/JPA/TypeORM/Ecto); orm/table/model filters",
+	"named":                       "Run a named query bundle — built-ins cover sql-injection/xss/ssrf/hardcoded-secrets/…; repo bundles from .gortex.yaml",
+	"orphan_tables":               "Tables queried but missing a migration that provides them",
+	"ownership":                   "Per-author rollup with symbol/file counts and oldest/newest timestamps",
+	"pagerank":                    "PageRank centrality — symbols ranked by random-walk authority",
+	"pubsub":                      "Pub/sub topics with publishers + subscribers (NATS/Kafka/RabbitMQ/Redis/EventEmitter/Socket.IO)",
+	"race_writes":                 "Concurrent-write race detection",
+	"ref_facts":                   "Resolved-reference facts — each reference edge + the provenance tier that resolved it",
+	"releases":                    "Stamp meta.added_in on file nodes from git tags",
+	"resolution_outcomes":         "Classify unresolved call/ref edges by why the resolver gave up (ambiguous/out-of-scope/cross-language/stub/no-def)",
+	"retrieval_log":               "Mine the retrieval query log — zero-result queries + per-tool latency/result-size rollups for recall tuning",
+	"review":                      "Idiomatic/correctness rulepack (NPE, thread-safety check-then-act, N+1, logic-error; Go+Python) — the engine behind gortex review",
+	"role":                        "Per-symbol architectural-role classification",
+	"route_frameworks":            "Registered structural route passes + route-contract node count per framework",
+	"routes":                      "Handler↔route pairs from route edges (HTTP/gRPC/WS/GraphQL/topic); method/path/type filters",
+	"sast":                        "Bandit-parity SAST — 190+ rules across 8 languages, CWE/OWASP tagged; severity/cwe/tag/detector filters",
+	"scc":                         "Strongly connected components of the directed graph",
+	"speculative":                 "Audit best-guess speculative dynamic-dispatch edges grouped by shape with a candidate histogram",
+	"sql_call_sites":              "Query edges grouped by calling symbol with table read/write split",
+	"sql_rebuild":                 "Re-derive the SQL table layer from the string-literal registry",
+	"stale_code":                  "Symbols whose last-author timestamp is older than older_than days",
+	"stale_flags":                 "Feature flags whose every toggling caller is older than older_than days",
+	"string_emitters":             "String-literal emission sites surfaced as events",
+	"suggest_boundaries":          "Seed an architecture: block from detected Leiden communities — a ready-to-paste .gortex.yaml layer map",
+	"swiftui_views":               "SwiftUI types grouped by classified role (component/app_entry)",
+	"synthesizers":                "Framework-dispatch-synthesized edges grouped by the pass that produced them",
+	"temporal_orphans":            "Temporal call-graph integrity — broken dispatches, handler-less signals/queries, undispatched activities/workflows",
+	"temporal_verify":             "LLM cleaning pass over Temporal dispatch edges (requires a configured LLM provider)",
+	"tests_as_edges":              "View over the test→code edge layer; group_by symbol or test",
+	"todos":                       "TODO/FIXME/HACK/XXX/NOTE nodes; filter by tag/assignee/ticket",
+	"uikit_classes":               "UIKit types grouped by classified role (view_controller/view/cell)",
+	"unclosed_channels":           "Channels that are opened but never closed",
+	"unreferenced_tables":         "Tables provided by a migration but with zero queries against them",
+	"unsafe_patterns":             "Panic-prone / undefined-behavior primitive scan across all languages",
+	"wasm_users":                  "Files that use #[wasm_bindgen] (uses_wasm_bindgen edge)",
+	"wcc":                         "Weakly connected components of the graph",
+	"would_create_cycle":          "Pre-flight check before adding a dependency — would the new edge close a cycle?",
+}
+
+// AnalyzeKindDescription returns the one-line summary for an analyze kind,
+// or the empty string if kind is not a canonical analyze kind. Every kind
+// in AnalyzeKinds() is guaranteed (by analyze_kinds_test.go) to have a
+// non-empty description.
+func AnalyzeKindDescription(kind string) string {
+	return analyzeKindDescriptions[kind]
+}

--- a/internal/mcp/analyze_kinds_test.go
+++ b/internal/mcp/analyze_kinds_test.go
@@ -96,6 +96,36 @@ func collectAnalyzeSwitchCases(t *testing.T, file *ast.File) []string {
 	return cases
 }
 
+// TestAnalyzeKindDescriptions_Complete is the anti-drift guard for the
+// per-kind descriptions surfaced by `gortex analyze kinds`: it asserts
+// every canonical kind has a non-empty description, and that the map
+// carries no orphan key (a description for a kind that no longer exists).
+// Adding a kind to analyzeKinds without describing it — or removing one
+// without dropping its description — fails here.
+func TestAnalyzeKindDescriptions_Complete(t *testing.T) {
+	have := make(map[string]bool, len(analyzeKinds))
+	for _, k := range analyzeKinds {
+		have[k] = true
+		desc, ok := analyzeKindDescriptions[k]
+		if !ok || desc == "" {
+			t.Errorf("analyze kind %q has no description in analyzeKindDescriptions", k)
+		}
+		if got := AnalyzeKindDescription(k); got != desc {
+			t.Errorf("AnalyzeKindDescription(%q) = %q, want %q", k, got, desc)
+		}
+	}
+	for k := range analyzeKindDescriptions {
+		if !have[k] {
+			t.Errorf("analyzeKindDescriptions key %q has no matching analyze kind", k)
+		}
+	}
+
+	// An unknown kind resolves to the empty string, not a panic.
+	if got := AnalyzeKindDescription("definitely_not_a_kind"); got != "" {
+		t.Errorf("AnalyzeKindDescription(unknown) = %q, want empty", got)
+	}
+}
+
 // TestAnalyzeKinds_SortedDefensiveCopy asserts AnalyzeKinds returns a
 // sorted copy that callers may mutate without corrupting the package
 // source.


### PR DESCRIPTION
## Problem

`gortex analyze kinds` listed only the bare kind names — 78 of them — with no hint of what each analyzer does. To learn what `field_writers`, `ref_facts`, or `kcore` mean, a user had to leave the terminal for the docs or read the dispatcher source. That's a poor experience for what should be a self-describing reference command.

## Change

Each kind now prints with a one-line description in an aligned two-column listing:

```
dead_code                    Symbols with zero incoming edges (excludes entry points, tests, exports)
impact                       Composite 0-100 change-impact score + risk label over 5 axes (PageRank, reach, complexity, co-change, span)
sast                         Bandit-parity SAST — 190+ rules across 8 languages, CWE/OWASP tagged; severity/cwe/tag/detector filters
```

- **`internal/mcp/analyze_kinds.go`** — adds `analyzeKindDescriptions`, a one-line summary for every kind, kept right next to the `analyzeKinds` SSOT slice, plus an exported `AnalyzeKindDescription` accessor. Descriptions are drawn from each analyzer's actual behavior and doc-comments.
- **`cmd/gortex/analyze.go`** — the `kinds` subcommand widths the name column and renders `kind  description`. Still requires no daemon; falls back to the bare name if a description is ever absent.
- **`internal/mcp/analyze_kinds_test.go`** — adds an anti-drift guard (`TestAnalyzeKindDescriptions_Complete`) mirroring the existing switch-vs-slice test: every kind must have a non-empty description and the map may carry no orphan key. Adding a new `analyze` kind now forces describing it, so the listing can't silently go stale.

## Verification

- `go build` of both packages
- `go test -race ./internal/mcp/ ./cmd/gortex/` — pass, including the existing `TestAnalyzeKinds_PrintsKindsNoDaemon` and the new completeness test
- `gofmt -l` clean, `go vet` clean
- Ran the rebuilt binary — all 78 kinds render with aligned descriptions