### PR TITLE
fix(indexer): re-stamp repo freshness on git-watcher reconcile

### DIFF
--- a/internal/indexer/git_watcher.go
+++ b/internal/indexer/git_watcher.go
@@ -305,6 +305,12 @@ func (gw *GitWatcher) reconcile(trigger string) {
 	drained := gw.drained
 	gw.mu.Unlock()
 
+	// Re-stamp the on-disk freshness row at the new HEAD. The graph now
+	// reflects this commit, but the persisted repo_index_state row is
+	// otherwise written only by a full (re)index — leave it and
+	// `gortex repos` keeps reporting the repo stale after every commit.
+	gw.indexer.reconcileRepoIndexState(gw.repoPath)
+
 	gw.logger.Info("git-watcher: reconciled ref change",
 		zap.String("from", oldSHA[:min(len(oldSHA), 12)]),
 		zap.String("to", newSHA[:min(len(newSHA), 12)]),

--- a/internal/indexer/git_watcher_freshness_test.go
+++ b/internal/indexer/git_watcher_freshness_test.go
@@ -1,0 +1,114 @@
+package indexer
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+)
+
+// TestGitWatcher_ReconcileUpdatesFreshness is the regression for the
+// "repo reported stale after a reconcile event was logged" bug: after a
+// commit the git-watcher reconciled the in-memory graph to the new HEAD
+// and logged it, but `gortex repos` kept reporting the repo stale. The
+// freshness row (repo_index_state) was written only by a FULL index, so
+// the incremental reconcile left it pointing at the previous commit —
+// only a daemon restart (which re-runs a full index) cleared it.
+//
+// The fix re-stamps that row at the new HEAD at the end of every
+// reconcile. This test proves the persisted IndexedSHA advances to the
+// commit the watcher caught up to.
+func TestGitWatcher_ReconcileUpdatesFreshness(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available in PATH")
+	}
+
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init", "-q", "-b", "main")
+	runGit(t, repoDir, "config", "user.email", "test@example.com")
+	runGit(t, repoDir, "config", "user.name", "Test")
+	runGit(t, repoDir, "config", "commit.gpgsign", "false")
+
+	writeFile(t, filepath.Join(repoDir, "a.go"), "package main\n\nfunc Alpha() {}\n")
+	runGit(t, repoDir, "add", ".")
+	runGit(t, repoDir, "commit", "-q", "-m", "first")
+	firstSHA := gitHead(t, repoDir)
+
+	// A durable backend is required: the in-memory graph is not a
+	// RepoIndexStateWriter, so freshness is never persisted there.
+	store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "store.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	reader, ok := graph.Store(store).(graph.RepoIndexStateReader)
+	require.True(t, ok, "sqlite store must implement RepoIndexStateReader")
+
+	idx := New(graph.Store(store), newTestRegistry(), config.IndexConfig{Workers: 1}, zap.NewNop())
+	idx.SetRepoPrefix("repo")
+	idx.SetRootPath(repoDir)
+	_, err = idx.IndexCtx(testCtx(), repoDir)
+	require.NoError(t, err)
+
+	// Baseline: the full index recorded the first commit.
+	st, found, err := reader.GetRepoIndexState("repo")
+	require.NoError(t, err)
+	require.True(t, found, "full index must persist a freshness row")
+	require.Equal(t, firstSHA, st.IndexedSHA, "freshness row must record the indexed commit")
+
+	gw, err := NewGitWatcher(repoDir, idx, zap.NewNop())
+	require.NoError(t, err)
+	gw.debounce = 50 * time.Millisecond
+	drained := make(chan int, 1)
+	gw.drained = func(n int) {
+		select {
+		case drained <- n:
+		default:
+		}
+	}
+	require.NoError(t, gw.Start())
+	t.Cleanup(func() { _ = gw.Stop() })
+
+	// A second commit advances HEAD on the watched branch.
+	writeFile(t, filepath.Join(repoDir, "b.go"), "package main\n\nfunc Beta() {}\n")
+	runGit(t, repoDir, "add", ".")
+	runGit(t, repoDir, "commit", "-q", "-m", "second")
+	secondSHA := gitHead(t, repoDir)
+	require.NotEqual(t, firstSHA, secondSHA)
+
+	select {
+	case <-drained:
+	case <-time.After(10 * time.Second):
+		t.Fatal("git watcher did not reconcile within timeout")
+	}
+
+	st, found, err = reader.GetRepoIndexState("repo")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, secondSHA, st.IndexedSHA,
+		"reconcile must re-stamp the freshness row at the new HEAD")
+	assert.False(t, st.Dirty, "working tree is clean after the commit")
+}
+
+// gitHead returns the full HEAD commit SHA of a repo, isolated from any
+// machine-global git config the same way runGit is.
+func gitHead(t *testing.T, dir string) string {
+	t.Helper()
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"GIT_CONFIG_SYSTEM=/dev/null",
+	)
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "git rev-parse HEAD: %s", string(out))
+	return strings.TrimSpace(string(out))
+}

--- a/internal/indexer/index_state.go
+++ b/internal/indexer/index_state.go
@@ -43,6 +43,26 @@ func (idx *Indexer) persistRepoIndexState(diskTarget graph.Store, rootAbs, works
 	}
 }
 
+// reconcileRepoIndexState re-stamps the per-repo freshness row at the
+// current HEAD after the git-watcher catches the index up to a new
+// commit. The full (re)index is otherwise the only writer of this row,
+// so without this the row keeps the SHA from the last full index and
+// `gortex repos` reports the repo stale even though the in-memory graph
+// already reflects HEAD. The Merkle baseline (WorkspaceFP) from that
+// last full index is preserved — the incremental reconcile diffs against
+// it but never rebuilds it. No-op on backends without durable index
+// state (the in-memory graph is not a RepoIndexStateWriter).
+func (idx *Indexer) reconcileRepoIndexState(rootAbs string) {
+	prevFP := ""
+	if r, ok := graph.Store(idx.graph).(graph.RepoIndexStateReader); ok {
+		if prev, found, _ := r.GetRepoIndexState(idx.repoPrefix); found {
+			prevFP = prev.WorkspaceFP
+		}
+	}
+	nodes, edges := idx.repoNodeEdgeCount()
+	idx.persistRepoIndexState(nil, rootAbs, prevFP, nodes, edges)
+}
+
 // repoHeadAndDirty returns the working tree's current commit SHA and
 // whether it has uncommitted changes. Best-effort: a non-git directory or
 // any git error yields ("", false) — freshness provenance never blocks


### PR DESCRIPTION
Fixes #173.

## Problem

After committing in a tracked repo, `gortex repos` reports the repo as `stale` even though the daemon logs a successful reconcile to the new HEAD. Only `gortex daemon restart` clears it.

## Root cause

`gortex repos` derives freshness from the persisted `repo_index_state` row — a repo is fresh when its recorded `IndexedSHA` equals current HEAD (`describeRepo`). That row is written **only** by a full index (`persistRepoIndexState`, called from `IndexCtx`).

When you commit, the git-watcher's `reconcile` catches the in-memory graph up via the incremental path (`IncrementalReindexPaths`) and advances its in-memory `lastSHA`, but never re-stamps the persisted `repo_index_state` row. So the row keeps the SHA from the last full index and `repos` reports `stale`. A daemon restart "fixes" it because restart runs a full index, which rewrites the row.

## Fix

`reconcile` now re-stamps the freshness row at the current HEAD at the end of every reconcile (new helper `reconcileRepoIndexState`), preserving the Merkle baseline (`WorkspaceFP`) recorded by the last full index. It is a no-op on backends without durable index state, like the existing persist path. This covers the reported `paths:0` case too, since it re-stamps regardless of how many files changed.

## Tests

- New regression test `TestGitWatcher_ReconcileUpdatesFreshness`: full-index a repo on a sqlite store, start the watcher, make a second commit, assert the persisted `IndexedSHA` advances to the new HEAD. Verified to **fail without the fix** and pass with it.
- `go build ./...`, `go vet ./internal/indexer/`, and `go test -race ./internal/indexer/` all green.