### PR TITLE
Broaden cross-language resolution, framework bridges, and reference capture

### DIFF
--- a/internal/contracts/http.go
+++ b/internal/contracts/http.go
@@ -659,6 +659,15 @@ func (h *HTTPExtractor) extract(
 
 	var out []Contract
 
+	// C# ASP.NET attribute routing needs class context: a controller's
+	// class-level [Route("api/[controller]")] prefix and its verb-less
+	// [Route("...")] method routes. Scanned once, consumed below.
+	var csControllers []csController
+	var csVerbless []csVerblessRoute
+	if lang == "csharp" {
+		csControllers, csVerbless = csharpScanControllerRoutes(lines, fileNodes)
+	}
+
 	// File-based routing, Django/DRF/Flask, Rails resources, Express/Fastify
 	// object routes — every structural framework route pass — run through the
 	// FrameworkRoutePass registry (framework_registry.go) below. React Router
@@ -723,6 +732,9 @@ func (h *HTTPExtractor) extract(
 				subtree = true
 			}
 
+			if pat.role == RoleProvider && lang == "csharp" {
+				path = csharpJoinControllerRoute(path, csControllers, lineNum, csharpActionName(fileNodes, lineNum))
+			}
 			normPath, origNames := NormalizeHTTPPathWithParams(path)
 			contractID := fmt.Sprintf("http::%s::%s", method, normPath)
 
@@ -854,6 +866,8 @@ func (h *HTTPExtractor) extract(
 			out = append(out, c)
 		}
 	}
+
+	out = append(out, h.csharpVerblessContracts(filePath, lines, fileNodes, csControllers, csVerbless, lang, tree)...)
 
 	// Structural framework route passes — Django/DRF/Flask, Rails resources,
 	// file-based routes, Express/Fastify object forms — run through the

--- a/internal/contracts/http_csharp.go
+++ b/internal/contracts/http_csharp.go
@@ -1,0 +1,200 @@
+package contracts
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+)
+
+// C# ASP.NET attribute-routing prefix-join. A controller's class-level
+// `[Route("api/[controller]")]` is the shared prefix of every action route, and
+// a method may declare a verb-less `[Route("search")]` (a route with no HTTP-verb
+// constraint). The per-line httpPatterns scan sees method routes in isolation, so
+// this pass supplies the class context: it joins the controller prefix onto each
+// RELATIVE method template (an absolute `/...` or `~/...` template ignores the
+// prefix, per ASP.NET) and materialises a contract for each verb-less route.
+
+var (
+	csharpRouteAttrRe    = regexp.MustCompile(`\[Route\(\s*"([^"]+)"\s*\)\]`)
+	csharpHTTPVerbAttrRe = regexp.MustCompile(`\[Http(?:Get|Post|Put|Delete|Patch|Head|Options)\b`)
+	csharpClassDeclRe    = regexp.MustCompile(`\bclass\s+(\w+)`)
+)
+
+// csController is a C# controller class's resolved class-level route prefix and
+// line span, used to prefix-join its method routes.
+type csController struct {
+	prefix    string
+	startLine int
+	endLine   int
+}
+
+// csVerblessRoute is a method-level `[Route("...")]` with no HTTP-verb attribute
+// in the same attribute block -- an ASP.NET route whose verb is unconstrained.
+type csVerblessRoute struct {
+	template string
+	line     int
+}
+
+// csharpScanControllerRoutes walks the C# source once, returning each
+// controller class's class-level [Route(...)] prefix (with [controller]
+// expanded) and each method-level verb-less [Route("...")] site.
+func csharpScanControllerRoutes(lines []string, fileNodes []*graph.Node) ([]csController, []csVerblessRoute) {
+	var controllers []csController
+	var verbless []csVerblessRoute
+	pendingRoute := ""
+	pendingVerb := false
+	blockLine := -1
+	reset := func() { pendingRoute, pendingVerb, blockLine = "", false, -1 }
+	for i, raw := range lines {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			continue
+		}
+		if m := csharpRouteAttrRe.FindStringSubmatch(line); m != nil {
+			pendingRoute = m[1]
+			if blockLine < 0 {
+				blockLine = i
+			}
+			continue
+		}
+		if csharpHTTPVerbAttrRe.MatchString(line) {
+			pendingVerb = true
+			if blockLine < 0 {
+				blockLine = i
+			}
+			continue
+		}
+		if strings.HasPrefix(line, "[") {
+			if blockLine < 0 {
+				blockLine = i
+			}
+			continue
+		}
+		// A declaration (or other code) terminates the attribute block.
+		if cm := csharpClassDeclRe.FindStringSubmatch(line); cm != nil {
+			if pendingRoute != "" {
+				prefix := csharpExpandRouteTokens(pendingRoute, cm[1], "")
+				start, end := csharpClassSpan(cm[1], fileNodes, i+1, len(lines))
+				controllers = append(controllers, csController{prefix: prefix, startLine: start, endLine: end})
+			}
+		} else if pendingRoute != "" && !pendingVerb && strings.Contains(line, "(") {
+			ln := blockLine
+			if ln < 0 {
+				ln = i
+			}
+			verbless = append(verbless, csVerblessRoute{template: pendingRoute, line: ln + 1})
+		}
+		reset()
+	}
+	return controllers, verbless
+}
+
+// csharpClassSpan returns the 1-based [start,end] line span of a class -- from
+// fileNodes when present, else a fallback of the declaration line to EOF.
+func csharpClassSpan(name string, fileNodes []*graph.Node, declLine, total int) (int, int) {
+	for _, n := range fileNodes {
+		if n != nil && n.Name == name && n.Kind == graph.KindType {
+			return n.StartLine, n.EndLine
+		}
+	}
+	return declLine, total
+}
+
+// csharpExpandRouteTokens resolves ASP.NET route tokens: [controller] -> the
+// controller name minus a trailing "Controller", lower-cased; [action] -> the
+// action (method) name, lower-cased. Tokens are matched case-insensitively.
+func csharpExpandRouteTokens(tmpl, controller, action string) string {
+	out := csharpReplaceToken(tmpl, "controller", strings.ToLower(strings.TrimSuffix(controller, "Controller")))
+	if action != "" {
+		out = csharpReplaceToken(out, "action", strings.ToLower(action))
+	}
+	return out
+}
+
+// csharpReplaceToken replaces every case-insensitive `[token]` in s with val.
+func csharpReplaceToken(s, token, val string) string {
+	needle := "[" + token + "]"
+	for {
+		lower := strings.ToLower(s)
+		idx := strings.Index(lower, needle)
+		if idx < 0 {
+			return s
+		}
+		s = s[:idx] + val + s[idx+len(needle):]
+	}
+}
+
+// csharpJoinControllerRoute prefix-joins a controller's class-level route onto a
+// method's RELATIVE template. A template that is absolute (starts with "/" or
+// "~/") ignores the controller prefix, per ASP.NET routing.
+func csharpJoinControllerRoute(path string, controllers []csController, line int, action string) string {
+	if strings.HasPrefix(path, "/") || strings.HasPrefix(path, "~/") {
+		return path
+	}
+	prefix := csharpControllerPrefixAt(controllers, line)
+	if prefix == "" {
+		return path
+	}
+	prefix = csharpReplaceToken(prefix, "action", strings.ToLower(action))
+	return strings.TrimRight(prefix, "/") + "/" + strings.TrimLeft(path, "/")
+}
+
+// csharpControllerPrefixAt returns the class-level route prefix of the innermost
+// controller whose span contains line, or "" when none.
+func csharpControllerPrefixAt(controllers []csController, line int) string {
+	best := ""
+	bestStart := -1
+	for _, c := range controllers {
+		if line >= c.startLine && line <= c.endLine && c.startLine > bestStart {
+			bestStart = c.startLine
+			best = c.prefix
+		}
+	}
+	return best
+}
+
+// csharpActionName returns the bare method name of the symbol enclosing line.
+func csharpActionName(fileNodes []*graph.Node, line int) string {
+	id := findEnclosingSymbol(fileNodes, line)
+	if i := strings.LastIndex(id, "::"); i >= 0 {
+		id = id[i+2:]
+	}
+	if i := strings.LastIndex(id, "."); i >= 0 {
+		return id[i+1:]
+	}
+	return id
+}
+
+// csharpVerblessContracts materialises a route Contract (verb "ANY") for each
+// verb-less method-level [Route("...")], prefix-joined to its controller.
+func (h *HTTPExtractor) csharpVerblessContracts(filePath string, lines []string, fileNodes []*graph.Node, controllers []csController, verbless []csVerblessRoute, lang string, tree *parser.ParseTree) []Contract {
+	var out []Contract
+	for _, vr := range verbless {
+		path := csharpJoinControllerRoute(vr.template, controllers, vr.line, csharpActionName(fileNodes, vr.line))
+		normPath, origNames := NormalizeHTTPPathWithParams(path)
+		method := "ANY"
+		c := Contract{
+			ID:       fmt.Sprintf("http::%s::%s", method, normPath),
+			Type:     ContractHTTP,
+			Role:     RoleProvider,
+			SymbolID: findEnclosingSymbol(fileNodes, vr.line),
+			FilePath: filePath,
+			Line:     vr.line,
+			Meta: map[string]any{
+				"method":    method,
+				"path":      normPath,
+				"framework": "aspnet",
+			},
+			Confidence: 0.9,
+		}
+		if len(origNames) > 0 {
+			c.Meta["path_param_names"] = origNames
+		}
+		EnrichHTTPContractWithTree(&c, lines, fileNodes, lang, tree)
+		out = append(out, c)
+	}
+	return out
+}

--- a/internal/contracts/http_test.go
+++ b/internal/contracts/http_test.go
@@ -959,3 +959,45 @@ func fetchUsers() {
 		}
 	}
 }
+
+func TestHTTPExtractor_CSharp_RoutePrefixJoin(t *testing.T) {
+	src := []byte(`using Microsoft.AspNetCore.Mvc;
+
+[ApiController]
+[Route("api/[controller]")]
+public class UsersController : ControllerBase {
+    [HttpGet("{id}")]
+    public IActionResult GetById(int id) { return Ok(); }
+
+    [Route("search")]
+    public IActionResult Search() { return Ok(); }
+}
+`)
+	nodes := []*graph.Node{
+		{ID: "Users.cs::UsersController", Name: "UsersController", Kind: graph.KindType, FilePath: "Users.cs", StartLine: 5, EndLine: 11},
+		{ID: "Users.cs::UsersController.GetById", Name: "GetById", Kind: graph.KindMethod, FilePath: "Users.cs", StartLine: 6, EndLine: 7},
+		{ID: "Users.cs::UsersController.Search", Name: "Search", Kind: graph.KindMethod, FilePath: "Users.cs", StartLine: 9, EndLine: 10},
+	}
+	cs := (&HTTPExtractor{}).Extract("Users.cs", src, nodes, nil)
+	byID := map[string]Contract{}
+	var ids []string
+	for _, c := range cs {
+		byID[c.ID] = c
+		ids = append(ids, c.ID)
+	}
+
+	get, ok := byID["http::GET::/api/users/{p1}"]
+	if !ok {
+		t.Fatalf("expected prefix-joined GET route http::GET::/api/users/{p1}, got %v", ids)
+	}
+	if get.SymbolID != "Users.cs::UsersController.GetById" {
+		t.Errorf("GET route should bind GetById, got %q", get.SymbolID)
+	}
+	search, ok := byID["http::ANY::/api/users/search"]
+	if !ok {
+		t.Fatalf("expected verb-less route http::ANY::/api/users/search, got %v", ids)
+	}
+	if search.SymbolID != "Users.cs::UsersController.Search" {
+		t.Errorf("verb-less route should bind Search, got %q", search.SymbolID)
+	}
+}

--- a/internal/parser/languages/cpp.go
+++ b/internal/parser/languages/cpp.go
@@ -85,6 +85,7 @@ type cppDeferredCall struct {
 	name     string
 	line     int
 	isMember bool
+	receiver string
 	argTypes []string
 }
 
@@ -142,6 +143,7 @@ func (e *CppExtractor) Extract(filePath string, src []byte) (*parser.ExtractionR
 				name:     m.Captures["callm.method"].Text,
 				line:     expr.StartLine + 1,
 				isMember: true,
+				receiver: cppCallReceiverText(expr.Node, src),
 				argTypes: extractCppCallArgTypes(expr.Node, src),
 			})
 
@@ -191,6 +193,9 @@ func (e *CppExtractor) Extract(filePath string, src []byte) (*parser.ExtractionR
 			edge.Meta = map[string]any{
 				"scope_arg_types": strings.Join(c.argTypes, ","),
 			}
+		}
+		if c.isMember && c.receiver != "" {
+			stampFactoryChainReceiver(edge, c.receiver, resolveChainType(c.receiver, nil, result))
 		}
 		result.Edges = append(result.Edges, edge)
 	}
@@ -652,4 +657,26 @@ func cppArgTypeHint(arg *sitter.Node, src []byte) string {
 		}
 	}
 	return ""
+}
+
+// cppCallReceiverText returns the receiver expression text of a member call
+// `recv.method(...)` / `recv->method(...)` -- the object of the call's
+// field_expression -- so a factory chain (`make().with().build()`) can be
+// typed by resolveChainType.
+func cppCallReceiverText(callNode *sitter.Node, src []byte) string {
+	if callNode == nil {
+		return ""
+	}
+	fn := callNode.ChildByFieldName("function")
+	if fn == nil || fn.Type() != "field_expression" {
+		return ""
+	}
+	obj := fn.ChildByFieldName("argument")
+	if obj == nil && fn.NamedChildCount() > 0 {
+		obj = fn.NamedChild(0)
+	}
+	if obj == nil {
+		return ""
+	}
+	return strings.TrimSpace(obj.Content(src))
 }

--- a/internal/parser/languages/cpp.go
+++ b/internal/parser/languages/cpp.go
@@ -196,6 +196,7 @@ func (e *CppExtractor) Extract(filePath string, src []byte) (*parser.ExtractionR
 	}
 
 	captureCFnPointerDispatch(result, root, filePath, src)
+	captureFnValueCandidates(result, root, filePath, src)
 
 	return result, nil
 }

--- a/internal/parser/languages/cpp_test.go
+++ b/internal/parser/languages/cpp_test.go
@@ -172,3 +172,35 @@ func TestCppExtractor_FnValueAddressOf(t *testing.T) {
 	assert.Equal(t, "address_of", forms["handler"], "&handler is an address-of form")
 	assert.Equal(t, "address_of", forms["Foo::method"], "&Foo::method is an address-of form")
 }
+
+func TestCppExtractor_FactoryChainReceiver(t *testing.T) {
+	src := []byte("struct Widget { Widget withX() { return *this; } };\n" +
+		"Widget builder() { return Widget(); }\n" +
+		"void run() {\n" +
+		"  builder().withX().build();\n" +
+		"}\n")
+	res, err := NewCppExtractor().Extract("w.cpp", src)
+	require.NoError(t, err)
+
+	var withX, build *graph.Edge
+	for _, e := range res.Edges {
+		if e.Kind != graph.EdgeCalls {
+			continue
+		}
+		switch e.To {
+		case "unresolved::*.withX":
+			withX = e
+		case "unresolved::*.build":
+			build = e
+		}
+	}
+	require.NotNil(t, withX, "withX() call edge")
+	require.NotNil(t, build, "build() call edge")
+	// builder() is a typed factory, so withX()'s receiver resolves to Widget.
+	assert.Equal(t, "Widget", withX.Meta["receiver_type"], "factory base resolves the chained receiver type")
+	// build()'s hop (withX) is not a typed node here, so the chain receiver
+	// expression is preserved for the graph-aware resolver to complete.
+	if got, _ := build.Meta["receiver_expr"].(string); got != "builder().withX()" {
+		t.Errorf("receiver_expr = %q, want builder().withX()", got)
+	}
+}

--- a/internal/parser/languages/cpp_test.go
+++ b/internal/parser/languages/cpp_test.go
@@ -138,3 +138,37 @@ func TestCppExtractor_Extensions(t *testing.T) {
 	assert.Contains(t, exts, ".hpp")
 	assert.NotContains(t, exts, ".h")
 }
+
+func TestCppExtractor_FnValueAddressOf(t *testing.T) {
+	src := []byte("void handler() {}\n" +
+		"struct Foo { void method() {} };\n" +
+		"void run() {\n" +
+		"  reg(&handler);\n" +
+		"  bind(&Foo::method);\n" +
+		"}\n")
+	res, err := NewCppExtractor().Extract("s.cpp", src)
+	require.NoError(t, err)
+
+	forms := map[string]string{} // fn_value_name -> fn_ref_form
+	for _, e := range res.Edges {
+		if e.Meta == nil {
+			continue
+		}
+		if v, _ := e.Meta["via"].(string); v != "callback_candidate" {
+			continue
+		}
+		if name, _ := e.Meta["fn_value_name"].(string); name != "" {
+			form, _ := e.Meta["fn_ref_form"].(string)
+			forms[name] = form
+			assert.Equal(t, "s.cpp::run", e.From, "captured in the enclosing function")
+		}
+	}
+	if _, ok := forms["handler"]; !ok {
+		t.Errorf("register(&handler) should capture handler as a function value (got %v)", forms)
+	}
+	if _, ok := forms["Foo::method"]; !ok {
+		t.Errorf("bind(&Foo::method) should capture Foo::method as a function value (got %v)", forms)
+	}
+	assert.Equal(t, "address_of", forms["handler"], "&handler is an address-of form")
+	assert.Equal(t, "address_of", forms["Foo::method"], "&Foo::method is an address-of form")
+}

--- a/internal/parser/languages/dart.go
+++ b/internal/parser/languages/dart.go
@@ -71,6 +71,7 @@ func (e *DartExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 
 	// Call sites.
 	e.extractCalls(root, src, filePath, result, imports)
+	e.mineDartFactoryChains(root, src, filePath, result)
 
 	// Cross-file type-usage edges for declaration-position types (fields,
 	// parameters, return types, typed locals) — runs after the symbol
@@ -830,4 +831,65 @@ func extractDartImportURI(text string) string {
 		return text[start+1 : start+1+end]
 	}
 	return ""
+}
+
+// mineDartFactoryChains emits a member call per chained `.method(...)` whose
+// receiver is itself a call -- a factory chain like builder().withX().build().
+// extractCalls anchors on the leading identifier and stops at the first call,
+// so these inner segments are otherwise dropped. Gated on a call-bearing
+// receiver (so plain recv.method() is left to extractCalls, not double-counted)
+// and carries the receiver text through the shared chained-receiver walker.
+func (e *DartExtractor) mineDartFactoryChains(root *sitter.Node, src []byte, filePath string, result *parser.ExtractionResult) {
+	funcRanges := buildFuncRanges(result)
+	if len(funcRanges) == 0 {
+		return
+	}
+	walkNodes(root, func(node *sitter.Node) {
+		if node.Type() != "identifier" {
+			return
+		}
+		if p := node.Parent(); p != nil {
+			switch p.Type() {
+			case "unconditional_assignable_selector", "conditional_assignable_selector", "selector":
+				return
+			}
+		}
+		var pending *sitter.Node
+		for sib := node.NextSibling(); sib != nil; sib = sib.NextSibling() {
+			if sib.Type() != "selector" {
+				break
+			}
+			var assignable *sitter.Node
+			hasArgs := false
+			for j := 0; j < int(sib.ChildCount()); j++ {
+				switch sib.Child(j).Type() {
+				case "argument_part", "arguments":
+					hasArgs = true
+				case "unconditional_assignable_selector", "conditional_assignable_selector":
+					assignable = sib.Child(j)
+				}
+			}
+			if assignable != nil {
+				pending = assignable
+				continue
+			}
+			if hasArgs && pending != nil {
+				if id := firstIdentifierChild(pending); id != nil {
+					receiver := strings.TrimSpace(string(src[node.StartByte():pending.StartByte()]))
+					if strings.Contains(receiver, "(") {
+						line := int(pending.StartPoint().Row) + 1
+						if callerID := findEnclosingFunc(funcRanges, line); callerID != "" {
+							edge := &graph.Edge{
+								From: callerID, To: "unresolved::*." + id.Content(src),
+								Kind: graph.EdgeCalls, FilePath: filePath, Line: line,
+							}
+							stampFactoryChainReceiver(edge, receiver, resolveChainType(receiver, nil, result))
+							result.Edges = append(result.Edges, edge)
+						}
+					}
+				}
+				pending = nil
+			}
+		}
+	})
 }

--- a/internal/parser/languages/dart_test.go
+++ b/internal/parser/languages/dart_test.go
@@ -428,3 +428,33 @@ class App {
 	}
 	assert.True(t, sawBuild, "the real method build should still be emitted")
 }
+
+func TestDartExtractor_FactoryChainReceiver(t *testing.T) {
+	src := []byte("Widget builder() { return Widget(); }\n" +
+		"void run() {\n" +
+		"  builder().withX().build();\n" +
+		"}\n")
+	res, err := NewDartExtractor().Extract("w.dart", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var build *graph.Edge
+	seen := map[string]int{}
+	for _, e := range res.Edges {
+		if e.Kind == graph.EdgeCalls {
+			seen[e.To]++
+			if e.To == "unresolved::*.build" {
+				build = e
+			}
+		}
+	}
+	if build == nil {
+		t.Fatal("build() call edge not found")
+	}
+	if got, _ := build.Meta["receiver_expr"].(string); got != "builder().withX()" {
+		t.Errorf("receiver_expr = %q, want builder().withX()", got)
+	}
+	if seen["unresolved::*.build"] != 1 {
+		t.Errorf("build() emitted %d times, want exactly 1 (no double-count)", seen["unresolved::*.build"])
+	}
+}

--- a/internal/parser/languages/expo_modules.go
+++ b/internal/parser/languages/expo_modules.go
@@ -12,67 +12,116 @@ import (
 // Expo Modules cross-language support. An Expo native module is declared
 // in Swift or Kotlin with a DSL inside `definition() -> ModuleDefinition`:
 // `Name("Foo")` sets the JS module name and `Function("bar") { ... }` /
-// `AsyncFunction("baz") { ... }` declare the JS-callable methods. On the
-// JS side they are consumed via `requireNativeModule('Foo').bar(...)` —
-// which the JS/TS extractor already emits as an rn-native placeholder, so
-// the Expo bridge synthesizer can land it on these synthetic nodes.
+// `AsyncFunction("baz") { ... }` declare the JS-callable methods, while
+// `Property("p")`, `Events("e")`, and `Constants { ... }` declare the other
+// member kinds. On the JS side they are consumed via
+// `requireNativeModule('Foo').bar(...)` — which the JS/TS extractor already
+// emits as an rn-native placeholder, so the Expo bridge synthesizer can land
+// it on these synthetic nodes.
 
 var (
-	expoNameRe     = regexp.MustCompile(`\bName\s*\(\s*"([^"]+)"`)
-	expoFunctionRe = regexp.MustCompile(`\b(Async)?Function\s*\(\s*"([^"]+)"`)
+	expoNameRe        = regexp.MustCompile(`\bName\s*\(\s*"([^"]+)"`)
+	expoMemberRe      = regexp.MustCompile(`\b(Function|AsyncFunction|Property|Events)\s*(?:<[^(]*>)?\s*\(\s*"([^"]+)"`)
+	expoConstantsRe   = regexp.MustCompile(`\bConstants\s*[({]`)
+	expoModuleClassRe = regexp.MustCompile(`\bclass\s+(\w+)\s*(?:\([^)]*\))?\s*:\s*Module\b`)
 )
 
-// expoExport is one Expo DSL method declaration.
+// expoExport is one Expo DSL member declaration (function, property, events,
+// or constants) attributed to a module.
 type expoExport struct {
 	module string
 	method string
 	async  bool
 	off    int
+	kind   string
 }
 
-// extractExpoModules scans Swift/Kotlin source for the Expo module DSL
-// and returns each Function/AsyncFunction declaration attributed to the
-// most recent preceding Name("...") (its module). Returns nil when the
-// file is not an Expo module (no ModuleDefinition marker).
+// extractExpoModules scans Swift/Kotlin source for the Expo module DSL and
+// returns each member declaration attributed to the most recent preceding
+// Name("..."). A definition() body with no Name() falls back to its enclosing
+// `class XxxModule : Module` (the "Module" suffix stripped) rather than being
+// dropped. Returns nil when the file is not an Expo module (no
+// ModuleDefinition marker).
 func extractExpoModules(src []byte) []expoExport {
 	s := string(src)
 	if !strings.Contains(s, "ModuleDefinition") {
 		return nil
 	}
 	type marker struct {
-		off    int
-		isName bool
-		name   string
-		async  bool
+		off   int
+		kind  string
+		name  string
+		async bool
 	}
 	var markers []marker
 	for _, m := range expoNameRe.FindAllStringSubmatchIndex(s, -1) {
-		markers = append(markers, marker{off: m[0], isName: true, name: s[m[2]:m[3]]})
+		markers = append(markers, marker{off: m[0], kind: "name", name: s[m[2]:m[3]]})
 	}
-	for _, m := range expoFunctionRe.FindAllStringSubmatchIndex(s, -1) {
-		markers = append(markers, marker{off: m[0], name: s[m[4]:m[5]], async: m[2] >= 0})
+	for _, m := range expoMemberRe.FindAllStringSubmatchIndex(s, -1) {
+		kw := s[m[2]:m[3]]
+		kind := "function"
+		switch kw {
+		case "Property":
+			kind = "property"
+		case "Events":
+			kind = "events"
+		}
+		markers = append(markers, marker{off: m[0], kind: kind, name: s[m[4]:m[5]], async: kw == "AsyncFunction"})
+	}
+	for _, m := range expoConstantsRe.FindAllStringIndex(s, -1) {
+		markers = append(markers, marker{off: m[0], kind: "constants", name: "Constants"})
 	}
 	sort.Slice(markers, func(i, j int) bool { return markers[i].off < markers[j].off })
+
+	// Module classes back the no-Name() fallback.
+	type classDecl struct {
+		off  int
+		name string
+	}
+	var classes []classDecl
+	for _, m := range expoModuleClassRe.FindAllStringSubmatchIndex(s, -1) {
+		classes = append(classes, classDecl{off: m[0], name: s[m[2]:m[3]]})
+	}
+	enclosingModule := func(off int) string {
+		name, best := "", -1
+		for _, cd := range classes {
+			if cd.off <= off && cd.off > best {
+				best, name = cd.off, cd.name
+			}
+		}
+		if name == "" {
+			return ""
+		}
+		if trimmed := strings.TrimSuffix(name, "Module"); trimmed != "" {
+			return trimmed
+		}
+		return name
+	}
 
 	curModule := ""
 	var out []expoExport
 	for _, mk := range markers {
-		if mk.isName {
+		if mk.kind == "name" {
 			curModule = mk.name
 			continue
 		}
-		if curModule == "" {
+		module := curModule
+		if module == "" {
+			module = enclosingModule(mk.off)
+		}
+		if module == "" {
 			continue
 		}
-		out = append(out, expoExport{module: curModule, method: mk.name, async: mk.async, off: mk.off})
+		out = append(out, expoExport{module: module, method: mk.name, async: mk.async, off: mk.off, kind: mk.kind})
 	}
 	return out
 }
 
-// emitExpoModuleNodes materialises a synthetic JS-callable method node per
-// Expo Function/AsyncFunction declaration, carrying expo_module +
-// expo_method so the Expo bridge synthesizer can pair a JS
-// requireNativeModule('<module>').<method>() call to it.
+// emitExpoModuleNodes materialises a synthetic node per Expo member
+// declaration, carrying expo_module + expo_method + expo_kind so the Expo
+// bridge synthesizer can pair a JS requireNativeModule('<module>').<member>
+// access to it. A Property becomes a field node; every other member kind a
+// method node.
 func emitExpoModuleNodes(src []byte, filePath, language, fileID string, result *parser.ExtractionResult, seen map[string]bool) {
 	for _, ex := range extractExpoModules(src) {
 		id := filePath + "::expo:" + ex.module + ":" + ex.method
@@ -81,11 +130,15 @@ func emitExpoModuleNodes(src []byte, filePath, language, fileID string, result *
 		}
 		seen[id] = true
 		line := lineAt(src, ex.off)
+		nodeKind := graph.KindMethod
+		if ex.kind == "property" {
+			nodeKind = graph.KindField
+		}
 		result.Nodes = append(result.Nodes, &graph.Node{
-			ID: id, Kind: graph.KindMethod, Name: ex.method,
+			ID: id, Kind: nodeKind, Name: ex.method,
 			FilePath: filePath, StartLine: line, EndLine: line,
 			Language: language,
-			Meta:     map[string]any{"expo_module": ex.module, "expo_method": ex.method, "expo_async": ex.async},
+			Meta:     map[string]any{"expo_module": ex.module, "expo_method": ex.method, "expo_async": ex.async, "expo_kind": ex.kind},
 		})
 		result.Edges = append(result.Edges, &graph.Edge{
 			From: fileID, To: id, Kind: graph.EdgeDefines, FilePath: filePath, Line: line,

--- a/internal/parser/languages/expo_modules_test.go
+++ b/internal/parser/languages/expo_modules_test.go
@@ -83,3 +83,75 @@ func TestExtractExpoModules_NonExpoFileIgnored(t *testing.T) {
 		t.Errorf("non-Expo file produced %v, want nil", got)
 	}
 }
+
+func expoMembers(nodes []*graph.Node) map[string]*graph.Node {
+	out := map[string]*graph.Node{}
+	for _, n := range nodes {
+		if n.Meta == nil {
+			continue
+		}
+		if _, ok := n.Meta["expo_module"]; ok {
+			out[n.Name] = n
+		}
+	}
+	return out
+}
+
+func TestExpoModule_MembersAndClassFallback_Swift(t *testing.T) {
+	src := `import ExpoModulesCore
+
+public class SettingsModule: Module {
+  public func definition() -> ModuleDefinition {
+    Property("theme")
+    Constants {
+      ["version": "1.0"]
+    }
+    Events("onChange")
+    AsyncFunction<Int>("compute") { (x: Int) in }
+  }
+}
+`
+	r, err := NewSwiftExtractor().Extract("SettingsModule.swift", []byte(src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	m := expoMembers(r.Nodes)
+	if p, ok := m["theme"]; !ok || p.Kind != graph.KindField || p.Meta["expo_module"] != "Settings" || p.Meta["expo_kind"] != "property" {
+		t.Errorf("Property theme = %+v (ok=%v), want field/Settings/property", m["theme"], ok)
+	}
+	if c, ok := m["Constants"]; !ok || c.Meta["expo_module"] != "Settings" || c.Meta["expo_kind"] != "constants" {
+		t.Errorf("Constants = %+v (ok=%v), want Settings/constants", m["Constants"], ok)
+	}
+	if e, ok := m["onChange"]; !ok || e.Meta["expo_module"] != "Settings" || e.Meta["expo_kind"] != "events" {
+		t.Errorf("Events onChange = %+v (ok=%v), want Settings/events", m["onChange"], ok)
+	}
+	if g, ok := m["compute"]; !ok || g.Meta["expo_module"] != "Settings" || g.Meta["expo_async"] != true {
+		t.Errorf("generic AsyncFunction<Int> compute = %+v (ok=%v), want Settings/async", m["compute"], ok)
+	}
+}
+
+func TestExpoModule_GenericAndClassFallback_Kotlin(t *testing.T) {
+	src := `package expo.modules.demo
+
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+
+class GeometryModule : Module() {
+  override fun definition() = ModuleDefinition {
+    Property("origin")
+    AsyncFunction<Float>("area") { r: Float -> }
+  }
+}
+`
+	r, err := NewKotlinExtractor().Extract("GeometryModule.kt", []byte(src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	m := expoMembers(r.Nodes)
+	if g, ok := m["area"]; !ok || g.Meta["expo_module"] != "Geometry" || g.Meta["expo_async"] != true {
+		t.Errorf("generic AsyncFunction<Float> area = %+v (ok=%v), want Geometry/async", m["area"], ok)
+	}
+	if p, ok := m["origin"]; !ok || p.Kind != graph.KindField || p.Meta["expo_module"] != "Geometry" {
+		t.Errorf("Property origin = %+v (ok=%v), want field/Geometry", m["origin"], ok)
+	}
+}

--- a/internal/parser/languages/fn_ref_spec.go
+++ b/internal/parser/languages/fn_ref_spec.go
@@ -129,6 +129,11 @@ func fnRefSpecFor(lang string) fnRefSpec {
 		// callables, Ruby `method(:sym)` / `&:sym`); the bare path stays on the
 		// byte heuristic.
 		return fnRefSpec{idNodeTypes: []string{"identifier"}, dispatch: dispatchByteParen}
+	case "lua", "luau":
+		// Lua functions are first-class values: a bare `setCallback(onClick)`
+		// and a table-member `register(handlers.onTick)` both pass a function
+		// by value. A dot_index_expression resolves to its trailing field name.
+		return fnRefSpec{idNodeTypes: []string{"identifier", "dot_index_expression"}, dispatch: dispatchByteParen}
 	}
 	return defaultFnRefSpec
 }
@@ -158,6 +163,14 @@ func fnRefNodeName(n *sitter.Node, src []byte) string {
 	case "member_access_expression":
 		if name := n.ChildByFieldName("name"); name != nil {
 			return name.Content(src)
+		}
+	case "dot_index_expression":
+		// Lua `tbl.method` -- the trailing identifier names the function.
+		if f := n.ChildByFieldName("field"); f != nil {
+			return f.Content(src)
+		}
+		if k := int(n.NamedChildCount()); k > 0 {
+			return n.NamedChild(k - 1).Content(src)
 		}
 	}
 	return n.Content(src)

--- a/internal/parser/languages/fn_ref_spec.go
+++ b/internal/parser/languages/fn_ref_spec.go
@@ -109,10 +109,21 @@ func fnRefSpecFor(lang string) fnRefSpec {
 			idNodeTypes: []string{"identifier", "member_access_expression"},
 			dispatch:    astCalleeField,
 		}
-	case "java", "c", "cpp", "dart":
+	case "java", "c", "dart":
 		// Bare-identifier value idiom; AST dispatch tightens the call check
 		// (Java `method_invocation`, C/Dart `call_expression`).
 		return fnRefSpec{idNodeTypes: []string{"identifier"}, dispatch: astCalleeField}
+	case "cpp":
+		// Bare-identifier value idiom plus the C++ address-of forms: a `&fn`
+		// value-arg (pointer_expression) and a `&Cls::method` pointer-to-member
+		// (qualified_identifier). The pointer-to-member names a method of
+		// another class, so it resolves ungated.
+		return fnRefSpec{
+			idNodeTypes: []string{"identifier", "qualified_identifier", "scoped_identifier"},
+			unwrapForms: map[string]string{"pointer_expression": "address_of", "unary_expression": "address_of"},
+			dispatch:    astCalleeField,
+			ungated:     true,
+		}
 	case "php", "ruby":
 		// First-class refs are dominated by the special forms (PHP string
 		// callables, Ruby `method(:sym)` / `&:sym`); the bare path stays on the
@@ -157,6 +168,7 @@ func fnRefNodeName(n *sitter.Node, src []byte) string {
 // resolve cross-module (ungated) when the trailing name is not file-local.
 var qualifiedFnRefNodeTypes = map[string]bool{
 	"scoped_identifier":        true,
+	"qualified_identifier":     true,
 	"selector_expression":      true,
 	"member_expression":        true,
 	"attribute":                true,

--- a/internal/parser/languages/java.go
+++ b/internal/parser/languages/java.go
@@ -379,6 +379,12 @@ func (e *JavaExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 	// above don't cover. Attributed to the enclosing method via funcRanges.
 	emitJavaReferenceForms(root, src, filePath, fileID, funcRanges, result)
 
+	// React Native native event emits (getJSModule(...).emit / sendEvent helper)
+	// pair with the JS addListener handler on the same rn_native_event topic.
+	mineRNJVMEmits(src, func(line int) string {
+		return findEnclosingFunc(funcRanges, line)
+	}, filePath, "java", result)
+
 	// @Value("${key:Default}") fields → their literal defaults, for invoker
 	// dispatch through a Spring-injected field (built only when invoker
 	// detection is configured).

--- a/internal/parser/languages/javascript.go
+++ b/internal/parser/languages/javascript.go
@@ -450,6 +450,7 @@ func (e *JavaScriptExtractor) Extract(filePath string, src []byte) (*parser.Extr
 	captureValueRefCandidates(result, root, filePath, src)
 	captureFnValueCandidates(result, root, filePath, src)
 	captureReduxThunkDispatches(result, root, filePath, src)
+	captureNgRxEffects(result, root, filePath, src)
 	captureObjectRegistryDispatches(result, root, filePath, src)
 	captureRTKQueryEndpoints(result, root, filePath, "javascript", src)
 	capturePiniaStoreCalls(result, root, filePath, src)

--- a/internal/parser/languages/jsts_ngrx_effects.go
+++ b/internal/parser/languages/jsts_ngrx_effects.go
@@ -1,0 +1,158 @@
+package languages
+
+import (
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	sitter "github.com/zzet/gortex/internal/parser/tsitter"
+)
+
+// NgRx effects dispatch detection. An effect declares the action(s) it reacts
+// to via `createEffect(() => this.actions$.pipe(ofType(SomeAction), ...))`. The
+// effect is registered with the EffectsModule, not called, so the static call
+// graph never links it to the action it handles. This pass tags the effect node
+// with Meta["ngrx_effect"] and stamps a placeholder EdgeCalls per ofType action,
+// which the resolver's ResolveNgRxEffects binds to the action node. Shared by
+// the JavaScript and TypeScript extractors.
+
+// ngrxEffectViaTag must match resolver.ngrxEffectVia -- the languages package
+// does not import resolver, so the two agree on the via tag by value.
+const ngrxEffectViaTag = "ngrx-effect"
+
+// ngrxEffectActionCap bounds the ofType actions mined from one effect.
+const ngrxEffectActionCap = 16
+
+// captureNgRxEffects finds `name$ = createEffect(() => actions$.pipe(
+// ofType(Action), ...))` class properties (and `const name$ = createEffect(...)`
+// functional effects), tags the effect node with Meta["ngrx_effect"], and stamps
+// a placeholder EdgeCalls from it to each ofType action. Runs at the tail of
+// Extract, after all nodes exist, so it can find and tag the effect node.
+func captureNgRxEffects(result *parser.ExtractionResult, root *sitter.Node, filePath string, src []byte) {
+	if root == nil || result == nil {
+		return
+	}
+	ngrxEffectWalk(root, func(n *sitter.Node) {
+		var nameNode, init *sitter.Node
+		switch n.Type() {
+		case "public_field_definition", "field_definition", "variable_declarator":
+			nameNode = n.ChildByFieldName("name")
+			init = n.ChildByFieldName("value")
+		default:
+			return
+		}
+		if nameNode == nil || init == nil || init.Type() != "call_expression" {
+			return
+		}
+		if jsCalleeLastName(init.ChildByFieldName("function"), src) != "createEffect" {
+			return
+		}
+		name := nameNode.Content(src)
+		if name == "" {
+			return
+		}
+		var actions []string
+		seen := map[string]bool{}
+		ngrxEffectWalk(init, func(c *sitter.Node) {
+			if len(actions) >= ngrxEffectActionCap || c.Type() != "call_expression" {
+				return
+			}
+			if jsCalleeLastName(c.ChildByFieldName("function"), src) != "ofType" {
+				return
+			}
+			args := c.ChildByFieldName("arguments")
+			if args == nil {
+				return
+			}
+			for i := 0; i < int(args.NamedChildCount()); i++ {
+				act := ngrxActionName(args.NamedChild(i), src)
+				if act == "" || seen[act] {
+					continue
+				}
+				seen[act] = true
+				actions = append(actions, act)
+			}
+		})
+		if len(actions) == 0 {
+			return
+		}
+		effectID := ngrxEffectTag(result, filePath, name)
+		line := int(n.StartPoint().Row) + 1
+		for _, act := range actions {
+			result.Edges = append(result.Edges, &graph.Edge{
+				From:     effectID,
+				To:       "unresolved::*." + act,
+				Kind:     graph.EdgeCalls,
+				FilePath: filePath,
+				Line:     line,
+				Meta: map[string]any{
+					"via":         ngrxEffectViaTag,
+					"ngrx_action": act,
+				},
+			})
+		}
+	})
+}
+
+// ngrxActionName returns the action name an ofType argument references: a bare
+// identifier (`LoadUsers`) or the trailing property of a member access
+// (`UserActions.load` -> "load").
+func ngrxActionName(n *sitter.Node, src []byte) string {
+	if n == nil {
+		return ""
+	}
+	switch n.Type() {
+	case "identifier":
+		return n.Content(src)
+	case "member_expression":
+		if p := n.ChildByFieldName("property"); p != nil {
+			return p.Content(src)
+		}
+	}
+	return ""
+}
+
+// ngrxEffectTag stamps Meta["ngrx_effect"] on the effect's node and returns its
+// ID. It prefers the exact-ID node (a functional effect `const name$ = ...`),
+// then a same-named class property / variable, and mints a node as a last resort
+// so the placeholder edge's From is always real.
+func ngrxEffectTag(result *parser.ExtractionResult, filePath, name string) string {
+	want := filePath + "::" + name
+	var fallback *graph.Node
+	for _, nd := range result.Nodes {
+		if nd == nil {
+			continue
+		}
+		if nd.ID == want {
+			ngrxStampEffect(nd, name)
+			return nd.ID
+		}
+		if fallback == nil && nd.Name == name &&
+			(nd.Kind == graph.KindVariable || nd.Kind == graph.KindConstant || nd.Kind == graph.KindField || nd.Kind == graph.KindFunction) {
+			fallback = nd
+		}
+	}
+	if fallback != nil {
+		ngrxStampEffect(fallback, name)
+		return fallback.ID
+	}
+	node := &graph.Node{ID: want, Kind: graph.KindVariable, Name: name, FilePath: filePath, Meta: map[string]any{"ngrx_effect": name}}
+	result.Nodes = append(result.Nodes, node)
+	return want
+}
+
+func ngrxStampEffect(n *graph.Node, name string) {
+	if n.Meta == nil {
+		n.Meta = map[string]any{}
+	}
+	n.Meta["ngrx_effect"] = name
+}
+
+// ngrxEffectWalk visits n and all its named descendants.
+func ngrxEffectWalk(n *sitter.Node, fn func(*sitter.Node)) {
+	if n == nil {
+		return
+	}
+	fn(n)
+	for i := 0; i < int(n.NamedChildCount()); i++ {
+		ngrxEffectWalk(n.NamedChild(i), fn)
+	}
+}

--- a/internal/parser/languages/jsts_ngrx_effects_test.go
+++ b/internal/parser/languages/jsts_ngrx_effects_test.go
@@ -1,0 +1,50 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestCaptureNgRxEffects(t *testing.T) {
+	src := `import { createEffect, ofType } from '@ngrx/effects';
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class UserEffects {
+  loadUsers$ = createEffect(() => this.actions$.pipe(
+    ofType(LoadUsers),
+    mergeMap(() => this.api.load())
+  ));
+}
+`
+	res, err := NewTypeScriptExtractor().Extract("effects.ts", []byte(src))
+	require.NoError(t, err)
+
+	var effect *graph.Node
+	for _, n := range res.Nodes {
+		if n.Name == "loadUsers$" {
+			effect = n
+		}
+	}
+	require.NotNil(t, effect, "effect property should be extracted")
+	assert.Equal(t, "loadUsers$", effect.Meta["ngrx_effect"], "effect node should be tagged")
+
+	var ph *graph.Edge
+	for _, e := range res.Edges {
+		if e.Meta == nil {
+			continue
+		}
+		if v, _ := e.Meta["via"].(string); v == "ngrx-effect" {
+			ph = e
+		}
+	}
+	require.NotNil(t, ph, "createEffect+ofType should emit a placeholder dispatch edge")
+	assert.Equal(t, effect.ID, ph.From, "placeholder attributed to the effect")
+	assert.Equal(t, "LoadUsers", ph.Meta["ngrx_action"])
+	assert.Equal(t, "unresolved::*.LoadUsers", ph.To)
+	assert.Equal(t, graph.EdgeCalls, ph.Kind)
+}

--- a/internal/parser/languages/kotlin.go
+++ b/internal/parser/languages/kotlin.go
@@ -354,6 +354,12 @@ func (e *KotlinExtractor) Extract(filePath string, src []byte) (*parser.Extracti
 	// JS-callable method nodes for the Expo bridge synthesizer.
 	emitExpoModuleNodes(src, filePath, "kotlin", fileID, result, seen)
 
+	// React Native native event emits (getJSModule(...).emit / sendEvent helper)
+	// pair with the JS addListener handler on the same rn_native_event topic.
+	mineRNJVMEmits(src, func(line int) string {
+		return findEnclosingFunc(funcRanges, line)
+	}, filePath, "kotlin", result)
+
 	stampScopePkg(result, kotlinPackageName(root, src))
 	captureValueRefCandidates(result, root, filePath, src)
 	captureFnValueCandidates(result, root, filePath, src)

--- a/internal/parser/languages/lua.go
+++ b/internal/parser/languages/lua.go
@@ -74,6 +74,10 @@ func (e *LuaExtractor) Extract(filePath string, src []byte) (*parser.ExtractionR
 	funcRanges := buildFuncRanges(result)
 	e.extractCalls(root, src, filePath, result, funcRanges)
 
+	// Lua functions are first-class values; capture bare-name and
+	// table-member callbacks passed as args / assigned but not called.
+	captureFnValueCandidates(result, root, filePath, src)
+
 	return result, nil
 }
 

--- a/internal/parser/languages/lua_test.go
+++ b/internal/parser/languages/lua_test.go
@@ -143,3 +143,39 @@ func TestLuaRobloxInstanceRequires(t *testing.T) {
 	require.NoError(t, err)
 	t.Run("luau", func(t *testing.T) { check(t, luau.Edges) })
 }
+
+func TestLuaExtractor_FnValueCapture(t *testing.T) {
+	src := []byte("function onClick() end\n" +
+		"local handlers = {}\n" +
+		"function handlers.onTick() end\n" +
+		"function run()\n" +
+		"  setCallback(onClick)\n" +
+		"  register(handlers.onTick)\n" +
+		"end\n")
+	res, err := NewLuaExtractor().Extract("s.lua", []byte(src))
+	require.NoError(t, err)
+
+	cands := map[string]bool{}
+	for _, e := range res.Edges {
+		if e.Meta == nil {
+			continue
+		}
+		if v, _ := e.Meta["via"].(string); v != "callback_candidate" {
+			continue
+		}
+		if name, _ := e.Meta["fn_value_name"].(string); name != "" {
+			cands[name] = true
+			assert.Equal(t, "s.lua::run", e.From, "captured in the enclosing function")
+		}
+	}
+	assert.True(t, cands["onClick"], "setCallback(onClick) should capture onClick (got %v)", keys2(cands))
+	assert.True(t, cands["onTick"], "register(handlers.onTick) should capture onTick (got %v)", keys2(cands))
+}
+
+func keys2(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/parser/languages/luau.go
+++ b/internal/parser/languages/luau.go
@@ -89,6 +89,10 @@ func (e *LuauExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 	funcRanges := buildFuncRanges(result)
 	e.extractCalls(root, src, filePath, result, funcRanges)
 
+	// Lua functions are first-class values; capture bare-name and
+	// table-member callbacks passed as args / assigned but not called.
+	captureFnValueCandidates(result, root, filePath, src)
+
 	return result, nil
 }
 

--- a/internal/parser/languages/luau_test.go
+++ b/internal/parser/languages/luau_test.go
@@ -145,3 +145,30 @@ end
 	}
 	assert.GreaterOrEqual(t, typedAs, 1, "expected at least one EdgeTypedAs to named type Account")
 }
+
+func TestLuauExtractor_FnValueCapture(t *testing.T) {
+	src := []byte("function onClick() end\n" +
+		"local handlers = {}\n" +
+		"function handlers.onTick() end\n" +
+		"function run()\n" +
+		"  setCallback(onClick)\n" +
+		"  register(handlers.onTick)\n" +
+		"end\n")
+	res, err := NewLuauExtractor().Extract("s.luau", []byte(src))
+	require.NoError(t, err)
+
+	cands := map[string]bool{}
+	for _, e := range res.Edges {
+		if e.Meta == nil {
+			continue
+		}
+		if v, _ := e.Meta["via"].(string); v != "callback_candidate" {
+			continue
+		}
+		if name, _ := e.Meta["fn_value_name"].(string); name != "" {
+			cands[name] = true
+		}
+	}
+	assert.True(t, cands["onClick"], "setCallback(onClick) should capture onClick")
+	assert.True(t, cands["onTick"], "register(handlers.onTick) should capture onTick")
+}

--- a/internal/parser/languages/objc.go
+++ b/internal/parser/languages/objc.go
@@ -109,6 +109,11 @@ func (e *ObjCExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 				stampObjCNodeMeta(result, filePath+"::"+name, "uikit_role", role)
 			}
 		}
+		// Protocol conformance: `@interface X : Base <P1, P2>` adopts P1, P2;
+		// stamp them for the Swift<->ObjC bridge synthesizer.
+		if protos := objcConformedProtocols(src, m[0]); protos != "" {
+			stampObjCNodeMeta(result, filePath+"::"+name, "objc_protocols", protos)
+		}
 	}
 	for _, m := range objcProtocolRe.FindAllSubmatchIndex(src, -1) {
 		name := string(src[m[2]:m[3]])
@@ -637,3 +642,30 @@ func objcComponentName(class string) string {
 }
 
 var _ parser.Extractor = (*ObjCExtractor)(nil)
+
+// objcConformedProtocols returns the comma-joined protocol names adopted on
+// an @interface declaration line (`@interface X : Base <P1, P2>` -> "P1,P2"),
+// or "" when none are adopted. The `<...>` clause on the declaration line is
+// the adopted-protocol list.
+func objcConformedProtocols(src []byte, from int) string {
+	end := from
+	for end < len(src) && src[end] != '\n' {
+		end++
+	}
+	line := string(src[from:end])
+	open := strings.IndexByte(line, '<')
+	if open < 0 {
+		return ""
+	}
+	closeIdx := strings.IndexByte(line[open:], '>')
+	if closeIdx < 0 {
+		return ""
+	}
+	var protos []string
+	for _, pr := range strings.Split(line[open+1:open+closeIdx], ",") {
+		if pr = strings.TrimSpace(pr); pr != "" {
+			protos = append(protos, pr)
+		}
+	}
+	return strings.Join(protos, ",")
+}

--- a/internal/parser/languages/objc.go
+++ b/internal/parser/languages/objc.go
@@ -14,14 +14,14 @@ import (
 var (
 	objcInterfaceRe = regexp.MustCompile(`(?m)^\s*@interface\s+(\w+)`)
 	// objcSuperRe captures the superclass of `@interface X : Super` (group 1).
-	objcSuperRe = regexp.MustCompile(`@interface\s+\w+\s*:\s*(\w+)`)
-	objcProtocolRe  = regexp.MustCompile(`(?m)^\s*@protocol\s+(\w+)`)
-	objcImplRe      = regexp.MustCompile(`(?m)^\s*@implementation\s+(\w+)`)
-	objcMethodRe    = regexp.MustCompile(`(?m)^\s*([-+])\s*\(\s*[^)]*\)\s*([A-Za-z_]\w*(?:\s*:\s*\([^)]*\)\s*\w+(?:\s+[A-Za-z_]\w*\s*:\s*\([^)]*\)\s*\w+)*)?)`)
-	objcFuncRe      = regexp.MustCompile(`(?m)^\s*(?:static\s+|extern\s+|inline\s+)*[A-Za-z_][\w\s\*]*?\s+([A-Za-z_]\w*)\s*\([^)]*\)\s*\{`)
-	objcImportQRe   = regexp.MustCompile(`(?m)^\s*#import\s+"([^"]+)"`)
-	objcImportARe   = regexp.MustCompile(`(?m)^\s*#import\s+<([^>]+)>`)
-	objcAtImportRe  = regexp.MustCompile(`(?m)^\s*@import\s+([\w.]+)`)
+	objcSuperRe    = regexp.MustCompile(`@interface\s+\w+\s*:\s*(\w+)`)
+	objcProtocolRe = regexp.MustCompile(`(?m)^\s*@protocol\s+(\w+)`)
+	objcImplRe     = regexp.MustCompile(`(?m)^\s*@implementation\s+(\w+)`)
+	objcMethodRe   = regexp.MustCompile(`(?m)^\s*([-+])\s*\(\s*[^)]*\)\s*([A-Za-z_]\w*(?:\s*:\s*\([^)]*\)\s*\w+(?:\s+[A-Za-z_]\w*\s*:\s*\([^)]*\)\s*\w+)*)?)`)
+	objcFuncRe     = regexp.MustCompile(`(?m)^\s*(?:static\s+|extern\s+|inline\s+)*[A-Za-z_][\w\s\*]*?\s+([A-Za-z_]\w*)\s*\([^)]*\)\s*\{`)
+	objcImportQRe  = regexp.MustCompile(`(?m)^\s*#import\s+"([^"]+)"`)
+	objcImportARe  = regexp.MustCompile(`(?m)^\s*#import\s+<([^>]+)>`)
+	objcAtImportRe = regexp.MustCompile(`(?m)^\s*@import\s+([\w.]+)`)
 )
 
 // ObjCExtractor extracts Objective-C / Objective-C++ source using regex.
@@ -253,6 +253,13 @@ func (e *ObjCExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 
 	// React Native native event emits pair with the JS addListener handler.
 	mineRNNativeEmits(src, rnObjCSendEventRe, func(line int) string {
+		return objcEnclosing(methodRanges, line)
+	}, filePath, "objc", result)
+
+	// A custom paren-form sendEvent(...) wrapper (distinct from the bracketed
+	// sendEventWithName:) is also an RN emit; the two forms are syntactically
+	// disjoint, so mining it separately does not double-count.
+	mineRNNativeEmits(src, rnSendEventWrapperRe, func(line int) string {
 		return objcEnclosing(methodRanges, line)
 	}, filePath, "objc", result)
 

--- a/internal/parser/languages/objc.go
+++ b/internal/parser/languages/objc.go
@@ -263,6 +263,10 @@ func (e *ObjCExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 		return objcEnclosing(methodRanges, line)
 	}, filePath, "objc", result)
 
+	// @selector(doThing:) literals reference a method by name without a call
+	// edge; capture each as a function-as-value reference to the selector.
+	captureObjCSelectors(src, methodRanges, filePath, result)
+
 	// @property declarations become field members of their enclosing class,
 	// carrying the declared type and the owning class so the property is a
 	// fully-attributed field, not a bare name.

--- a/internal/parser/languages/objc_selector.go
+++ b/internal/parser/languages/objc_selector.go
@@ -1,0 +1,53 @@
+package languages
+
+import (
+	"regexp"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+)
+
+// objcSelectorRe matches an Objective-C @selector(...) literal, capturing the
+// full selector including its colons (`doThing:`, `setX:y:`).
+var objcSelectorRe = regexp.MustCompile(`@selector\s*\(\s*([A-Za-z_][A-Za-z0-9_:]*)\s*\)`)
+
+// captureObjCSelectors records each @selector(sel) literal whose selector names
+// a method declared in the same file as a function-as-value reference, so the
+// targeted method is reachable through the selector even though no direct call
+// edge exists. Objective-C is regex-extracted, so this is a focused scan rather
+// than the tree-walking captureFnValueCandidates pass; it mirrors the Swift
+// #selector handling (recv hint <self>, resolved against same-file methods).
+func captureObjCSelectors(src []byte, methodRanges []objcSpan, filePath string, result *parser.ExtractionResult) {
+	funcs := map[string]bool{}
+	for _, n := range result.Nodes {
+		if n == nil || n.FilePath != filePath {
+			continue
+		}
+		if n.Kind == graph.KindMethod || n.Kind == graph.KindFunction {
+			funcs[n.Name] = true
+		}
+	}
+	var cands []FnValueCandidate
+	seen := map[string]bool{}
+	for _, m := range objcSelectorRe.FindAllSubmatchIndex(src, -1) {
+		sel := string(src[m[2]:m[3]])
+		if sel == "" || !funcs[sel] {
+			continue
+		}
+		line := lineAt(src, m[0])
+		fromID := objcEnclosing(methodRanges, line)
+		if fromID == "" {
+			continue
+		}
+		key := fromID + "\x00" + sel
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		cands = append(cands, FnValueCandidate{
+			FromID: fromID, Name: sel, FilePath: filePath, Line: line,
+			Form: "selector", RecvHint: "<self>", Lang: "objc",
+		})
+	}
+	EmitFnValueCandidates(result, cands)
+}

--- a/internal/parser/languages/objc_test.go
+++ b/internal/parser/languages/objc_test.go
@@ -119,3 +119,20 @@ func TestObjCExtractor_SelectorFnValue(t *testing.T) {
 	assert.Equal(t, "Widget.m::tap", found.From, "captured in the enclosing method")
 	assert.Equal(t, "selector", found.Meta["fn_ref_form"])
 }
+
+func TestObjCExtractor_ProtocolConformance(t *testing.T) {
+	const objc = `@interface Widget : NSObject <Drawable, Tappable>
+@end
+`
+	res, err := NewObjCExtractor().Extract("Widget.h", []byte(objc))
+	require.NoError(t, err)
+	var cls *graph.Node
+	for _, n := range res.Nodes {
+		if n.Name == "Widget" && n.Kind == graph.KindType {
+			cls = n
+		}
+	}
+	require.NotNil(t, cls, "interface Widget should be extracted")
+	require.NotNil(t, cls.Meta, "Widget should carry conformance meta")
+	assert.Equal(t, "Drawable,Tappable", cls.Meta["objc_protocols"])
+}

--- a/internal/parser/languages/objc_test.go
+++ b/internal/parser/languages/objc_test.go
@@ -91,3 +91,31 @@ func TestObjcPropertyTypeAndReceiver(t *testing.T) {
 	require.NotNil(t, byName["count"])
 	assert.Equal(t, "NSInteger", byName["count"].Meta["field_type"])
 }
+
+func TestObjCExtractor_SelectorFnValue(t *testing.T) {
+	const objc = `@implementation Widget
+- (void)doThing:(id)arg { }
+- (void)tap {
+    [self performSelector:@selector(doThing:)];
+}
+@end
+`
+	res, err := NewObjCExtractor().Extract("Widget.m", []byte(objc))
+	require.NoError(t, err)
+
+	var found *graph.Edge
+	for _, e := range res.Edges {
+		if e.Meta == nil {
+			continue
+		}
+		if v, _ := e.Meta["via"].(string); v != "callback_candidate" {
+			continue
+		}
+		if name, _ := e.Meta["fn_value_name"].(string); name == "doThing:" {
+			found = e
+		}
+	}
+	require.NotNil(t, found, "@selector(doThing:) should capture doThing: as a function value")
+	assert.Equal(t, "Widget.m::tap", found.From, "captured in the enclosing method")
+	assert.Equal(t, "selector", found.Meta["fn_ref_form"])
+}

--- a/internal/parser/languages/pascal.go
+++ b/internal/parser/languages/pascal.go
@@ -366,6 +366,20 @@ func (e *PascalExtractor) emitPascalCalls(n *sitter.Node, src []byte, filePath s
 			// First named child is the callee (identifier or genericDot).
 			if callee := pascalCallTargetName(c, src); callee != "" {
 				e.emitPascalCallEdge(fromID, callee, filePath, int(c.StartPoint().Row)+1, result, procIndex)
+			} else if dot := pascalFirstChild(c, "exprDot"); dot != nil {
+				// A chained `recv.Method()` whose receiver is itself a call --
+				// a factory chain Builder().WithX().Build(). The bare-callee path
+				// above misses these; emit the method with the receiver text so
+				// the shared walker can type the chain.
+				method, receiver := pascalDotMethodReceiver(dot, src)
+				if method != "" && strings.Contains(receiver, "(") {
+					edge := &graph.Edge{
+						From: fromID, To: "unresolved::*." + method,
+						Kind: graph.EdgeCalls, FilePath: filePath, Line: int(c.StartPoint().Row) + 1,
+					}
+					stampFactoryChainReceiver(edge, receiver, resolveChainType(receiver, nil, result))
+					result.Edges = append(result.Edges, edge)
+				}
 			}
 		case "statement":
 			// A statement whose only named child is a bare identifier /
@@ -482,6 +496,21 @@ func pascalReturnType(decl *sitter.Node, src []byte) string {
 
 // pascalCallTargetName returns the callee name of an exprCall (its first named
 // identifier / genericDot child).
+// pascalDotMethodReceiver splits an exprDot `recv.Method` into the method
+// name (its trailing identifier) and the receiver text (everything before).
+func pascalDotMethodReceiver(dot *sitter.Node, src []byte) (method, receiver string) {
+	for i := int(dot.ChildCount()) - 1; i >= 0; i-- {
+		if dot.Child(i).Type() == "identifier" {
+			method = strings.TrimSpace(dot.Child(i).Content(src))
+			break
+		}
+	}
+	if obj := dot.NamedChild(0); obj != nil {
+		receiver = strings.TrimSpace(obj.Content(src))
+	}
+	return method, receiver
+}
+
 func pascalCallTargetName(call *sitter.Node, src []byte) string {
 	for i := 0; i < int(call.ChildCount()); i++ {
 		c := call.Child(i)

--- a/internal/parser/languages/pascal_test.go
+++ b/internal/parser/languages/pascal_test.go
@@ -146,3 +146,30 @@ end.
 	assert.True(t, has("MyUnit.pas::TFoo.Baz", "unresolved::*.DoThing", graph.OriginTextMatched),
 		"paren-less call DoThing; should emit an edge; got %v", calls)
 }
+
+func TestPascalExtractor_FactoryChainReceiver(t *testing.T) {
+	src := []byte("procedure Run;\nbegin\n  Builder().WithX().Build();\nend;\n")
+	res, err := NewPascalExtractor().Extract("w.pas", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var build *graph.Edge
+	seen := map[string]int{}
+	for _, e := range res.Edges {
+		if e.Kind == graph.EdgeCalls {
+			seen[e.To]++
+			if e.To == "unresolved::*.Build" {
+				build = e
+			}
+		}
+	}
+	if build == nil {
+		t.Fatal("Build() call edge not found")
+	}
+	if got, _ := build.Meta["receiver_expr"].(string); got != "Builder().WithX()" {
+		t.Errorf("receiver_expr = %q, want Builder().WithX()", got)
+	}
+	if seen["unresolved::*.Build"] != 1 {
+		t.Errorf("Build() emitted %d times, want exactly 1", seen["unresolved::*.Build"])
+	}
+}

--- a/internal/parser/languages/php.go
+++ b/internal/parser/languages/php.go
@@ -883,6 +883,21 @@ func (e *PHPExtractor) extractCallSites(
 					}
 				}
 			}
+			// Chained-factory receiver: `make()->with()->build()` -- carry the
+			// receiver object (`->` normalised to `.`) so the shared walker can
+			// type the chain or preserve it for the graph-aware resolver.
+			if node.Type() == "member_call_expression" {
+				obj := node.ChildByFieldName("object")
+				if obj == nil && node.NamedChildCount() > 0 {
+					obj = node.NamedChild(0)
+				}
+				if obj != nil {
+					recv := strings.ReplaceAll(strings.TrimSpace(obj.Content(src)), "->", ".")
+					if strings.Contains(recv, ".") || strings.Contains(recv, "(") {
+						stampFactoryChainReceiver(edge, recv, resolveChainType(recv, nil, result))
+					}
+				}
+			}
 			result.Edges = append(result.Edges, edge)
 		}
 	}

--- a/internal/parser/languages/php_chain_test.go
+++ b/internal/parser/languages/php_chain_test.go
@@ -1,0 +1,30 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestPHPExtractor_FactoryChainReceiver(t *testing.T) {
+	src := []byte("<?php\n" +
+		"function builder() { return new Widget(); }\n" +
+		"function run() {\n" +
+		"    builder()->withX()->build();\n" +
+		"}\n")
+	res, err := NewPHPExtractor().Extract("w.php", src)
+	require.NoError(t, err)
+
+	var build *graph.Edge
+	for _, e := range res.Edges {
+		if e.Kind == graph.EdgeCalls && e.To == "unresolved::*.build" {
+			build = e
+		}
+	}
+	require.NotNil(t, build, "build() call edge")
+	if got, _ := build.Meta["receiver_expr"].(string); got != "builder().withX()" {
+		t.Errorf("receiver_expr = %q, want builder().withX()", got)
+	}
+}

--- a/internal/parser/languages/php_string_callable.go
+++ b/internal/parser/languages/php_string_callable.go
@@ -12,20 +12,33 @@ import (
 // one of these calls is a function-as-value reference the gate resolves
 // repo-wide (unique-or-drop), bypassing the same-file scope.
 var phpCallableHOFs = map[string]bool{
-	"array_map":                  true,
-	"array_filter":               true,
-	"array_walk":                 true,
-	"array_walk_recursive":       true,
-	"array_reduce":               true,
-	"usort":                      true,
-	"uasort":                     true,
-	"uksort":                     true,
-	"call_user_func":             true,
-	"call_user_func_array":       true,
-	"preg_replace_callback":      true,
-	"register_shutdown_function": true,
-	"set_error_handler":          true,
-	"spl_autoload_register":      true,
+	"array_map":                   true,
+	"array_filter":                true,
+	"array_walk":                  true,
+	"array_walk_recursive":        true,
+	"array_reduce":                true,
+	"usort":                       true,
+	"uasort":                      true,
+	"uksort":                      true,
+	"call_user_func":              true,
+	"call_user_func_array":        true,
+	"preg_replace_callback":       true,
+	"register_shutdown_function":  true,
+	"set_error_handler":           true,
+	"spl_autoload_register":       true,
+	"array_udiff":                 true,
+	"array_udiff_assoc":           true,
+	"array_uintersect":            true,
+	"array_uintersect_assoc":      true,
+	"forward_static_call":         true,
+	"forward_static_call_array":   true,
+	"preg_replace_callback_array": true,
+	"register_tick_function":      true,
+	"set_exception_handler":       true,
+	"ob_start":                    true,
+	"iterator_apply":              true,
+	"header_register_callback":    true,
+	"is_callable":                 true,
 }
 
 // capturePHPStringCallables records each string / array callable passed to a
@@ -55,7 +68,8 @@ func (e *PHPExtractor) capturePHPStringCallables(result *parser.ExtractionResult
 		if i := strings.LastIndex(callee, "\\"); i >= 0 {
 			callee = callee[i+1:]
 		}
-		if !phpCallableHOFs[strings.ToLower(callee)] {
+		calleeLower := strings.ToLower(callee)
+		if !phpCallableHOFs[calleeLower] {
 			return
 		}
 		args := n.ChildByFieldName("arguments")
@@ -67,24 +81,37 @@ func (e *PHPExtractor) capturePHPStringCallables(result *parser.ExtractionResult
 		if fromID == "" {
 			return
 		}
-		for i := 0; i < int(args.NamedChildCount()); i++ {
-			a := args.NamedChild(i)
-			if a == nil {
-				continue
-			}
-			name, recvHint, ok := e.phpCallableArg(a, src)
-			if !ok {
-				continue
-			}
-			key := fromID + "\x00php\x00" + name + "\x00" + recvHint
+		emit := func(name, recvHint string) {
+			key := fromID + "|" + name + "|" + recvHint
 			if seen[key] {
-				continue
+				return
 			}
 			seen[key] = true
 			cands = append(cands, FnValueCandidate{
 				FromID: fromID, Name: name, FilePath: filePath, Line: line,
 				Form: "php_string_callable", RecvHint: recvHint, Lang: "php", SkipGate: true,
 			})
+		}
+		// preg_replace_callback_array passes a `pattern => callback` map; the
+		// callbacks live on the value side, so resolve each value rather than
+		// scanning the array flat (its regex-pattern keys are not callables).
+		callbackArray := calleeLower == "preg_replace_callback_array"
+		for i := 0; i < int(args.NamedChildCount()); i++ {
+			a := args.NamedChild(i)
+			if a == nil {
+				continue
+			}
+			if callbackArray {
+				for _, cb := range e.phpCallbackArrayValues(a, src) {
+					emit(cb.name, cb.recvHint)
+				}
+				continue
+			}
+			name, recvHint, ok := e.phpCallableArg(a, src)
+			if !ok {
+				continue
+			}
+			emit(name, recvHint)
 		}
 	})
 	EmitFnValueCandidates(result, cands)
@@ -124,6 +151,41 @@ func (e *PHPExtractor) phpCallableArg(a *sitter.Node, src []byte) (name, recvHin
 		}
 	}
 	return "", "", false
+}
+
+// phpCallableRef is a resolved (name, receiver-hint) callable pair.
+type phpCallableRef struct{ name, recvHint string }
+
+// phpCallbackArrayValues resolves the value-side callable of each element of
+// a `pattern => callback` array literal -- the shape preg_replace_callback_array
+// takes. Keys (regex patterns) are skipped; each value runs through
+// phpCallableArg so string, `Class::method`, and `[$obj, 'm']` callbacks all
+// resolve.
+func (e *PHPExtractor) phpCallbackArrayValues(a *sitter.Node, src []byte) []phpCallableRef {
+	node := a
+	if a.Type() == "argument" && a.NamedChildCount() > 0 {
+		node = a.NamedChild(0)
+	}
+	if node == nil || node.Type() != "array_creation_expression" {
+		return nil
+	}
+	var out []phpCallableRef
+	for i := 0; i < int(node.NamedChildCount()); i++ {
+		el := node.NamedChild(i)
+		if el == nil || el.Type() != "array_element_initializer" {
+			continue
+		}
+		// The value side is the last named child: `key => value` has two,
+		// a bare `value` element has one.
+		val := el.NamedChild(int(el.NamedChildCount()) - 1)
+		if val == nil {
+			continue
+		}
+		if name, recvHint, ok := e.phpCallableArg(val, src); ok {
+			out = append(out, phpCallableRef{name: name, recvHint: recvHint})
+		}
+	}
+	return out
 }
 
 // phpCallableFromString parses a string callable into (function/method name,

--- a/internal/parser/languages/php_string_callable_test.go
+++ b/internal/parser/languages/php_string_callable_test.go
@@ -69,3 +69,27 @@ function run($a, $svc) {
 		t.Errorf("['Acme','isValid'] array callable not captured with recv hint (got: %v)", cands["isValid"])
 	}
 }
+
+func TestPHPStringCallable_ExtendedBuiltins(t *testing.T) {
+	src := []byte(`<?php
+function run($a, $b, $s, $obj) {
+    array_udiff($a, $b, 'cmp');
+    preg_replace_callback_array(['/x/' => 'cb', '/y/' => 'Acme::handle'], $s);
+    set_exception_handler('onError');
+    register_tick_function([$obj, 'tick']);
+}
+`)
+	res, err := NewPHPExtractor().Extract("a.php", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cands := fnValueCands(res)
+	for _, name := range []string{"cmp", "cb", "handle", "onError", "tick"} {
+		if _, ok := cands[name]; !ok {
+			t.Errorf("expected callable %q captured (got: %v)", name, keys(cands))
+		}
+	}
+	if m, ok := cands["handle"]; !ok || m["fn_ref_recv_hint"] != "Acme" {
+		t.Errorf("preg_replace_callback_array value Acme::handle recv hint = %v", cands["handle"])
+	}
+}

--- a/internal/parser/languages/rn_native_events.go
+++ b/internal/parser/languages/rn_native_events.go
@@ -17,9 +17,12 @@ const rnNativeEventTransport = "rn_native_event"
 // RCTEventEmitter emit, capturing the event name string.
 var rnObjCSendEventRe = regexp.MustCompile(`sendEventWithName:\s*@"([^"]+)"`)
 
-// rnSwiftSendEventRe matches a Swift `sendEvent(withName: "Name", …)`
-// RCTEventEmitter emit, capturing the event name string.
-var rnSwiftSendEventRe = regexp.MustCompile(`sendEvent\s*\(\s*withName:\s*"([^"]+)"`)
+// rnSendEventWrapperRe matches a paren-form `sendEvent(...)` emit -- both the
+// Swift labelled `sendEvent(withName: "Name", ...)` and a custom helper
+// wrapper `sendEvent(reactContext, "Name", body)` -- capturing the first
+// literal string argument as the event name. The `[^;{}]` guard keeps a
+// single match from spanning a statement boundary.
+var rnSendEventWrapperRe = regexp.MustCompile(`\bsendEvent\s*\([^;{}]*?"([^"]+)"`)
 
 // mineRNNativeEmits scans native source for React Native event-emit sites and
 // records one pub/sub publish per emit on the rn_native_event channel,

--- a/internal/parser/languages/rn_native_events.go
+++ b/internal/parser/languages/rn_native_events.go
@@ -50,3 +50,19 @@ func mineRNNativeEmits(src []byte, re *regexp.Regexp, callerLookup func(line int
 	}
 	emitPubsubEvents(events, callerLookup, filePath, language, result)
 }
+
+// rnJVMEmitRe matches an Android React Native device-event emit chain,
+// reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java).emit("Name", ...)
+// (Kotlin) / ....RCTDeviceEventEmitter.class).emit("Name", ...) (Java), capturing
+// the event name.
+var rnJVMEmitRe = regexp.MustCompile(`getJSModule\s*\([^;]*?\)\s*\.\s*emit\s*\(\s*"([^"]+)"`)
+
+// mineRNJVMEmits scans Java/Kotlin source for React Native native event emits --
+// the getJSModule(...).emit("Name", ...) device-event-emitter chain and the
+// common sendEvent(reactContext, "Name", ...) helper wrapper -- and records each
+// as a publish on the rn_native_event channel. The two forms are syntactically
+// disjoint, so neither double-counts the other.
+func mineRNJVMEmits(src []byte, callerLookup func(line int) string, filePath, language string, result *parser.ExtractionResult) {
+	mineRNNativeEmits(src, rnJVMEmitRe, callerLookup, filePath, language, result)
+	mineRNNativeEmits(src, rnSendEventWrapperRe, callerLookup, filePath, language, result)
+}

--- a/internal/parser/languages/rn_native_events_test.go
+++ b/internal/parser/languages/rn_native_events_test.go
@@ -81,3 +81,50 @@ function subscribe() {
 	assert.Equal(t, "rn_native_event", events[0].Meta["transport"])
 	assert.Len(t, fix.edgesByKind[graph.EdgeListensOn], 1)
 }
+
+func TestSwiftExtractor_RNCustomSendEventWrapper(t *testing.T) {
+	const swift = `class Notifier {
+    func emit() {
+        sendEvent(reactContext, "MyEvent", body)
+    }
+}
+`
+	res, err := NewSwiftExtractor().Extract("Notifier.swift", []byte(swift))
+	require.NoError(t, err)
+
+	topicID := "event::pubsub::rn_native_event::MyEvent"
+	emit := emitEdgeTo(res.Edges, graph.EdgeEmits, topicID)
+	require.NotNil(t, emit, "custom sendEvent(...) wrapper should emit an EdgeEmits to the topic")
+	assert.Equal(t, "Notifier.swift::Notifier.emit", emit.From, "emit attributed to the enclosing method")
+
+	count := 0
+	for _, e := range res.Edges {
+		if e.Kind == graph.EdgeEmits && e.To == topicID {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "wrapper form must not double-count the emit edge")
+}
+
+func TestObjCExtractor_RNCustomSendEventWrapper(t *testing.T) {
+	const objc = `@implementation Notifier
+- (void)emit {
+    sendEvent(self, @"MyEvent", @{});
+}
+@end
+`
+	res, err := NewObjCExtractor().Extract("Notifier.m", []byte(objc))
+	require.NoError(t, err)
+
+	topicID := "event::pubsub::rn_native_event::MyEvent"
+	emit := emitEdgeTo(res.Edges, graph.EdgeEmits, topicID)
+	require.NotNil(t, emit, "ObjC paren-form sendEvent(...) wrapper should emit an EdgeEmits to the topic")
+
+	count := 0
+	for _, e := range res.Edges {
+		if e.Kind == graph.EdgeEmits && e.To == topicID {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "wrapper form must not double-count the emit edge")
+}

--- a/internal/parser/languages/rn_native_events_test.go
+++ b/internal/parser/languages/rn_native_events_test.go
@@ -128,3 +128,64 @@ func TestObjCExtractor_RNCustomSendEventWrapper(t *testing.T) {
 	}
 	assert.Equal(t, 1, count, "wrapper form must not double-count the emit edge")
 }
+
+func TestKotlinExtractor_RNJVMEmit(t *testing.T) {
+	const kt = `package com.example
+
+class ScoreModule(reactContext: ReactApplicationContext) {
+    fun broadcast() {
+        reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java).emit("Score", params)
+    }
+}
+`
+	res, err := NewKotlinExtractor().Extract("ScoreModule.kt", []byte(kt))
+	require.NoError(t, err)
+
+	topicID := "event::pubsub::rn_native_event::Score"
+	emit := emitEdgeTo(res.Edges, graph.EdgeEmits, topicID)
+	require.NotNil(t, emit, "getJSModule(...).emit(\"Score\") should emit an EdgeEmits to the topic")
+	assert.NotEmpty(t, emit.From, "emit attributed to the enclosing method")
+}
+
+func TestJavaExtractor_RNJVMEmit(t *testing.T) {
+	const j = `package com.example;
+
+public class ScoreModule {
+    void broadcast() {
+        reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit("Score", params);
+    }
+}
+`
+	res, err := NewJavaExtractor().Extract("ScoreModule.java", []byte(j))
+	require.NoError(t, err)
+
+	topicID := "event::pubsub::rn_native_event::Score"
+	emit := emitEdgeTo(res.Edges, graph.EdgeEmits, topicID)
+	require.NotNil(t, emit, "getJSModule(...).emit(\"Score\") should emit an EdgeEmits to the topic")
+	assert.NotEmpty(t, emit.From, "emit attributed to the enclosing method")
+}
+
+func TestKotlinExtractor_RNSendEventWrapper(t *testing.T) {
+	const kt = `package com.example
+
+class ScoreModule {
+    fun broadcast() {
+        sendEvent(reactContext, "Score", params)
+    }
+}
+`
+	res, err := NewKotlinExtractor().Extract("ScoreModule.kt", []byte(kt))
+	require.NoError(t, err)
+
+	topicID := "event::pubsub::rn_native_event::Score"
+	emit := emitEdgeTo(res.Edges, graph.EdgeEmits, topicID)
+	require.NotNil(t, emit, "sendEvent(reactContext, \"Score\", ...) should emit an EdgeEmits to the topic")
+
+	count := 0
+	for _, e := range res.Edges {
+		if e.Kind == graph.EdgeEmits && e.To == topicID {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "wrapper form must not double-count the emit edge")
+}

--- a/internal/parser/languages/scala.go
+++ b/internal/parser/languages/scala.go
@@ -611,6 +611,7 @@ func (e *ScalaExtractor) extractCall(
 	}
 	callee := node.Child(0)
 	var callName string
+	var receiver string
 	switch callee.Type() {
 	case "identifier":
 		callName = callee.Content(src)
@@ -623,6 +624,10 @@ func (e *ScalaExtractor) extractCall(
 				callName = fc.Content(src)
 				break
 			}
+		}
+		// The object the method is selected on is the chained receiver.
+		if obj := callee.NamedChild(0); obj != nil {
+			receiver = strings.TrimSpace(obj.Content(src))
 		}
 	default:
 		return
@@ -637,10 +642,14 @@ func (e *ScalaExtractor) extractCall(
 	if callerID == "" {
 		return
 	}
-	result.Edges = append(result.Edges, &graph.Edge{
+	edge := &graph.Edge{
 		From: callerID, To: "unresolved::*." + callName,
 		Kind: graph.EdgeCalls, FilePath: filePath, Line: startLine,
-	})
+	}
+	if receiver != "" {
+		stampFactoryChainReceiver(edge, receiver, resolveChainType(receiver, nil, result))
+	}
+	result.Edges = append(result.Edges, edge)
 }
 
 // scalaFindChildIdentifier finds the first direct child of type "identifier"

--- a/internal/parser/languages/scala_test.go
+++ b/internal/parser/languages/scala_test.go
@@ -225,3 +225,37 @@ func TestScalaExtensionAndPackageScope(t *testing.T) {
 	assert.Equal(t, true, shout.Meta["extension"])
 	assert.Equal(t, "com.app.util", shout.Meta["scope_pkg"])
 }
+
+func TestScalaExtractor_FactoryChainReceiver(t *testing.T) {
+	src := []byte("object M {\n" +
+		"  def builder(): Widget = new Widget()\n" +
+		"  def run() = {\n" +
+		"    builder().withX().build()\n" +
+		"  }\n" +
+		"}\n")
+	res, err := NewScalaExtractor().Extract("w.scala", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var withX, build *graph.Edge
+	for _, e := range res.Edges {
+		if e.Kind != graph.EdgeCalls {
+			continue
+		}
+		switch e.To {
+		case "unresolved::*.withX":
+			withX = e
+		case "unresolved::*.build":
+			build = e
+		}
+	}
+	if withX == nil || build == nil {
+		t.Fatal("withX()/build() call edges not found")
+	}
+	if withX.Meta["receiver_type"] != "Widget" {
+		t.Errorf("withX receiver_type = %v, want Widget (builder() factory)", withX.Meta["receiver_type"])
+	}
+	if got, _ := build.Meta["receiver_expr"].(string); got != "builder().withX()" {
+		t.Errorf("build receiver_expr = %q, want builder().withX()", got)
+	}
+}

--- a/internal/parser/languages/svelte.go
+++ b/internal/parser/languages/svelte.go
@@ -49,6 +49,8 @@ func (e *SvelteExtractor) Extract(filePath string, src []byte) (*parser.Extracti
 	carveAndDelegateScripts(src, filePath, fileNode.ID, "svelte", e.ts, e.js, result)
 	mineTemplateComponentUsages(src, filePath, componentID, "svelte", result)
 	applyFrameworkTemplatePasses(src, filePath, componentID, "svelte", result)
+	// `$store` auto-subscriptions in markup resolve to the imported store.
+	mineSvelteStoreSubscriptions(src, filePath, componentID, result)
 	return result, nil
 }
 

--- a/internal/parser/languages/svelte_stores.go
+++ b/internal/parser/languages/svelte_stores.go
@@ -1,0 +1,59 @@
+package languages
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+)
+
+// svelteStoreRefRe matches a Svelte `$store` auto-subscription read in markup
+// (`$count`, `{$count}`), capturing the store name. The `$` prefix on an
+// imported store is Svelte's auto-subscribe sugar.
+var svelteStoreRefRe = regexp.MustCompile(`\$(\w+)`)
+
+// mineSvelteStoreSubscriptions resolves Svelte `$store` auto-subscriptions: a
+// `$foo` read in markup where `foo` is an imported store binds the component to
+// that store import (its subscribe contract) instead of dangling. Svelte 5 runes
+// ($state/$derived/...) are excluded -- they are framework macros, not stores.
+// Reuses the import edges the delegated script extractor already emitted.
+func mineSvelteStoreSubscriptions(src []byte, filePath, componentID string, result *parser.ExtractionResult) {
+	importedStores := map[string]string{}
+	for _, e := range result.Edges {
+		if e == nil || e.Kind != graph.EdgeImports || !graph.IsUnresolvedTarget(e.To) {
+			continue
+		}
+		name := graph.UnresolvedName(e.To)
+		i := strings.LastIndex(name, "::")
+		if i < 0 {
+			continue // a module-level import, not a named binding
+		}
+		if leaf := name[i+2:]; leaf != "" {
+			importedStores[leaf] = e.To
+		}
+	}
+	if len(importedStores) == 0 {
+		return
+	}
+	runes := frameworkSuppressionSets["svelte"]
+	tmpl := blankTemplateRegions(src, "svelte")
+	seen := map[string]bool{}
+	for _, m := range svelteStoreRefRe.FindAllSubmatchIndex(tmpl, -1) {
+		name := string(tmpl[m[2]:m[3]])
+		if name == "" || seen[name] || runes["$"+name] {
+			continue
+		}
+		target, ok := importedStores[name]
+		if !ok {
+			continue
+		}
+		seen[name] = true
+		result.Edges = append(result.Edges, &graph.Edge{
+			From: componentID, To: target, Kind: graph.EdgeReferences,
+			FilePath: filePath, Line: 1 + strings.Count(string(tmpl[:m[0]]), "\n"),
+			Origin: graph.OriginASTInferred,
+			Meta:   map[string]any{"via": "svelte_store", "ref_context": "store_subscription", "store": name},
+		})
+	}
+}

--- a/internal/parser/languages/svelte_test.go
+++ b/internal/parser/languages/svelte_test.go
@@ -45,3 +45,42 @@ func TestSvelteExtractor(t *testing.T) {
 		t.Errorf("increment StartLine = %d, want 4 (host-file coordinates)", incr.StartLine)
 	}
 }
+
+func TestSvelteExtractor_StoreSubscription(t *testing.T) {
+	const svelte = `<script>
+  import { count, name } from './store';
+  let local = 1;
+</script>
+
+<p>{$count}</p>
+<h1>{$name}</h1>
+<button>{local}</button>
+`
+	res, err := NewSvelteExtractor().Extract("Counter.svelte", []byte(svelte))
+	if err != nil {
+		t.Fatal(err)
+	}
+	stores := map[string]string{}
+	for _, e := range res.Edges {
+		if e.Meta == nil {
+			continue
+		}
+		if v, _ := e.Meta["via"].(string); v != "svelte_store" {
+			continue
+		}
+		s, _ := e.Meta["store"].(string)
+		stores[s] = e.To
+		if e.From != "Counter.svelte::Counter" {
+			t.Errorf("store subscription should be attributed to the component, got %q", e.From)
+		}
+		if e.Kind != graph.EdgeReferences {
+			t.Errorf("store subscription should be an EdgeReferences, got %v", e.Kind)
+		}
+	}
+	if stores["count"] != "unresolved::import::./store::count" {
+		t.Errorf("$count should resolve to the count store import, got %q", stores["count"])
+	}
+	if stores["name"] != "unresolved::import::./store::name" {
+		t.Errorf("$name should resolve to the name store import, got %q", stores["name"])
+	}
+}

--- a/internal/parser/languages/swift.go
+++ b/internal/parser/languages/swift.go
@@ -45,6 +45,10 @@ const qSwiftAll = `
 
   (call_expression
     (simple_identifier) @call.name) @call.expr
+
+  (call_expression
+    (navigation_expression
+      (navigation_suffix (simple_identifier) @callm.name)) @callm.nav) @callm.expr
 ]
 `
 
@@ -68,8 +72,10 @@ func (e *SwiftExtractor) Extensions() []string { return []string{".swift"} }
 // --- Deferred match buffers ----------------------------------------
 
 type swiftDeferredCall struct {
-	name string
-	line int
+	name     string
+	line     int
+	isMember bool
+	receiver string
 }
 
 type swiftTypeRange struct {
@@ -157,6 +163,24 @@ func (e *SwiftExtractor) Extract(filePath string, src []byte) (*parser.Extractio
 				name: m.Captures["call.name"].Text,
 				line: expr.StartLine + 1,
 			})
+
+		case m.Captures["callm.expr"] != nil:
+			expr := m.Captures["callm.expr"]
+			recv := ""
+			if nav := m.Captures["callm.nav"]; nav != nil && nav.Node != nil && nav.Node.NamedChildCount() > 0 {
+				recv = strings.TrimSpace(nav.Node.NamedChild(0).Content(src))
+			}
+			// Only chained-factory member calls (the receiver is itself a call)
+			// are captured here, so the bare-identifier query stays authoritative
+			// for ordinary obj.method() and the graph is not flooded.
+			if strings.Contains(recv, "(") {
+				calls = append(calls, swiftDeferredCall{
+					name:     m.Captures["callm.name"].Text,
+					line:     expr.StartLine + 1,
+					isMember: true,
+					receiver: recv,
+				})
+			}
 		}
 	})
 
@@ -200,10 +224,18 @@ func (e *SwiftExtractor) Extract(filePath string, src []byte) (*parser.Extractio
 		if callerID == "" {
 			continue
 		}
-		result.Edges = append(result.Edges, &graph.Edge{
-			From: callerID, To: "unresolved::" + c.name,
+		to := "unresolved::" + c.name
+		if c.isMember {
+			to = "unresolved::*." + c.name
+		}
+		edge := &graph.Edge{
+			From: callerID, To: to,
 			Kind: graph.EdgeCalls, FilePath: filePath, Line: c.line,
-		})
+		}
+		if c.isMember && c.receiver != "" {
+			stampFactoryChainReceiver(edge, c.receiver, resolveChainType(c.receiver, nil, result))
+		}
+		result.Edges = append(result.Edges, edge)
 	}
 
 	// React Native native event emits pair with the JS addListener handler.

--- a/internal/parser/languages/swift.go
+++ b/internal/parser/languages/swift.go
@@ -362,6 +362,9 @@ func (e *SwiftExtractor) emitProtocol(m parser.QueryResult, filePath, fileID str
 	}
 	seen[id] = true
 	meta := map[string]any{"visibility": swiftVisibility(def.Node, src)}
+	if swiftHasAttr(def.Node, "objc", src) {
+		meta["objc"] = true
+	}
 	if doc := ExtractDocAbove(src, def.StartLine, DocLangSlashSlash); doc != "" {
 		meta["doc"] = doc
 	}

--- a/internal/parser/languages/swift.go
+++ b/internal/parser/languages/swift.go
@@ -206,7 +206,7 @@ func (e *SwiftExtractor) Extract(filePath string, src []byte) (*parser.Extractio
 	}
 
 	// React Native native event emits pair with the JS addListener handler.
-	mineRNNativeEmits(src, rnSwiftSendEventRe, func(line int) string {
+	mineRNNativeEmits(src, rnSendEventWrapperRe, func(line int) string {
 		return findEnclosingFunc(funcRanges, line)
 	}, filePath, "swift", result)
 

--- a/internal/parser/languages/swift.go
+++ b/internal/parser/languages/swift.go
@@ -73,9 +73,10 @@ type swiftDeferredCall struct {
 }
 
 type swiftTypeRange struct {
-	name      string
-	startLine int // 0-based
-	endLine   int // 0-based
+	name        string
+	startLine   int  // 0-based
+	endLine     int  // 0-based
+	objcMembers bool // class declared @objcMembers -- exposes all members to ObjC
 }
 
 func (e *SwiftExtractor) Extract(filePath string, src []byte) (*parser.ExtractionResult, error) {
@@ -256,9 +257,10 @@ func (e *SwiftExtractor) emitTypeContainer(m parser.QueryResult, prefix, filePat
 	// class.def, once for enum.def on the same enum) is harmless: the
 	// findEnclosingType lookup picks the innermost match by size.
 	*typeRanges = append(*typeRanges, swiftTypeRange{
-		name:      name,
-		startLine: def.StartLine,
-		endLine:   def.EndLine,
+		name:        name,
+		startLine:   def.StartLine,
+		endLine:     def.EndLine,
+		objcMembers: swiftHasAttr(def.Node, "objcMembers", src),
 	})
 
 	if !seen[id] {
@@ -387,7 +389,8 @@ func (e *SwiftExtractor) emitFunction(m parser.QueryResult, filePath, fileID str
 		sig = "func " + name + "(...)"
 	}
 
-	if typeName, ok := findEnclosingSwiftType(typeRanges, startLine); ok {
+	if tr, ok := findEnclosingSwiftTypeRange(typeRanges, startLine); ok {
+		typeName := tr.name
 		id, idOK := disambiguateID(seen, filePath+"::"+typeName+"."+name, def.StartLine+1)
 		if !idOK {
 			return
@@ -401,7 +404,7 @@ func (e *SwiftExtractor) emitFunction(m parser.QueryResult, filePath, fileID str
 		if doc != "" {
 			meta["doc"] = doc
 		}
-		if sel := swiftObjCSelector(def.Node, name, src); sel != "" {
+		if sel := swiftObjCSelectorExposed(def.Node, name, tr.objcMembers, src); sel != "" {
 			meta["objc_selector"] = sel
 		}
 		result.Nodes = append(result.Nodes, &graph.Node{
@@ -460,7 +463,8 @@ func (e *SwiftExtractor) emitProperty(m parser.QueryResult, filePath, fileID str
 	mutable := swiftPropertyIsMutable(def.Node, src)
 	fieldType := swiftPropertyType(def.Node, src)
 
-	typeName, enclosed := findEnclosingSwiftType(typeRanges, def.StartLine)
+	tr, enclosed := findEnclosingSwiftTypeRange(typeRanges, def.StartLine)
+	typeName := tr.name
 	kind := graph.KindField
 	id := filePath + "::" + name
 	if enclosed {
@@ -485,7 +489,7 @@ func (e *SwiftExtractor) emitProperty(m parser.QueryResult, filePath, fileID str
 	if enclosed {
 		meta["receiver"] = typeName
 	}
-	if getter, setter := swiftObjCPropertySelectors(def.Node, name, mutable, src); getter != "" {
+	if getter, setter := swiftObjCPropertySelectorsExposed(def.Node, name, mutable, enclosed && tr.objcMembers, src); getter != "" {
 		meta["objc_selector"] = getter
 		if setter != "" {
 			meta["objc_setter_selector"] = setter
@@ -780,21 +784,43 @@ func (e *SwiftExtractor) emitImport(m parser.QueryResult, filePath, fileID strin
 // logic — picks the smallest enclosing range so nested types attribute
 // correctly.
 func findEnclosingSwiftType(ranges []swiftTypeRange, line int) (string, bool) {
-	best := ""
+	r, ok := findEnclosingSwiftTypeRange(ranges, line)
+	if !ok {
+		return "", false
+	}
+	return r.name, true
+}
+
+// findEnclosingSwiftTypeRange returns the innermost (smallest) type range
+// containing line, so a member can read its enclosing type's attributes
+// (e.g. @objcMembers), not just the type name.
+func findEnclosingSwiftTypeRange(ranges []swiftTypeRange, line int) (swiftTypeRange, bool) {
+	var best swiftTypeRange
+	found := false
 	bestSize := int(^uint(0) >> 1)
 	for _, r := range ranges {
 		if line >= r.startLine && line <= r.endLine {
 			size := r.endLine - r.startLine
 			if size < bestSize {
 				bestSize = size
-				best = r.name
+				best = r
+				found = true
 			}
 		}
 	}
-	if best == "" {
-		return "", false
+	// A type can hold two enclosing ranges -- the brace-matched fallback
+	// scan seeded before the query match, and the query match itself. Only
+	// the latter carries attributes, so OR the @objcMembers flag across
+	// every same-name range that contains the line.
+	if found && !best.objcMembers {
+		for _, r := range ranges {
+			if r.name == best.name && r.objcMembers && line >= r.startLine && line <= r.endLine {
+				best.objcMembers = true
+				break
+			}
+		}
 	}
-	return best, true
+	return best, found
 }
 
 // findEnclosingSwiftContainer walks the parent chain of n looking for

--- a/internal/parser/languages/swift_annotations.go
+++ b/internal/parser/languages/swift_annotations.go
@@ -360,3 +360,55 @@ func swiftUserTypeName(node *sitter.Node, src []byte) string {
 	}
 	return last
 }
+
+// swiftHasAttr reports whether a declaration carries the named attribute
+// (e.g. "objc", "nonobjc", "objcMembers") among its modifiers.
+func swiftHasAttr(defNode *sitter.Node, attrName string, src []byte) bool {
+	mods := swiftModifiers(defNode)
+	if mods == nil {
+		return false
+	}
+	for i := 0; i < int(mods.NamedChildCount()); i++ {
+		attr := mods.NamedChild(i)
+		if attr == nil || attr.Type() != "attribute" {
+			continue
+		}
+		if name, _ := swiftAttributeNameAndArgs(attr, src); name == attrName {
+			return true
+		}
+	}
+	return false
+}
+
+// swiftObjCSelectorExposed computes the Objective-C selector a Swift method
+// is exposed under, accounting for an @objcMembers class that exposes every
+// member implicitly. The member's own @objc wins; otherwise, when the
+// enclosing class is @objcMembers and the member is not opted out with
+// @nonobjc, the selector is derived as if the member were @objc. Returns ""
+// when the member is not exposed to Objective-C.
+func swiftObjCSelectorExposed(defNode *sitter.Node, baseName string, classObjCMembers bool, src []byte) string {
+	if sel := swiftObjCSelector(defNode, baseName, src); sel != "" {
+		return sel
+	}
+	if classObjCMembers && !swiftHasAttr(defNode, "nonobjc", src) {
+		return buildSwiftObjCSelector(baseName, swiftArgLabels(swiftParamClause(defNode, src)))
+	}
+	return ""
+}
+
+// swiftObjCPropertySelectorsExposed mirrors swiftObjCPropertySelectors but
+// also exposes a property implicitly when its enclosing class is
+// @objcMembers and the property is not opted out with @nonobjc.
+func swiftObjCPropertySelectorsExposed(defNode *sitter.Node, name string, mutable, classObjCMembers bool, src []byte) (getter, setter string) {
+	if g, s := swiftObjCPropertySelectors(defNode, name, mutable, src); g != "" {
+		return g, s
+	}
+	if name != "" && classObjCMembers && !swiftHasAttr(defNode, "nonobjc", src) {
+		getter = name
+		if mutable {
+			setter = "set" + capitalizeFirst(getter) + ":"
+		}
+		return getter, setter
+	}
+	return "", ""
+}

--- a/internal/parser/languages/swift_annotations_test.go
+++ b/internal/parser/languages/swift_annotations_test.go
@@ -168,3 +168,30 @@ class C {
 		t.Errorf("@nonobjc var secret must not be exposed, got selector %v", sel["secret"])
 	}
 }
+
+func TestSwift_ObjCProtocolFlag(t *testing.T) {
+	src := `@objc protocol Drawable {
+    func draw()
+}
+protocol Plain {
+    func x()
+}
+`
+	nodes, _ := runSwiftExtract(t, "P.swift", src)
+	flag := map[string]any{}
+	for _, n := range nodes {
+		if n.Kind == graph.KindInterface {
+			if n.Meta != nil {
+				flag[n.Name] = n.Meta["objc"]
+			} else {
+				flag[n.Name] = nil
+			}
+		}
+	}
+	if flag["Drawable"] != true {
+		t.Errorf("@objc protocol Drawable should carry Meta[objc]=true, got %v", flag["Drawable"])
+	}
+	if flag["Plain"] == true {
+		t.Errorf("plain protocol Plain must not carry Meta[objc]=true")
+	}
+}

--- a/internal/parser/languages/swift_annotations_test.go
+++ b/internal/parser/languages/swift_annotations_test.go
@@ -131,3 +131,40 @@ class Plain: NSObject {
 		}
 	}
 }
+
+func TestSwift_ObjCMembersPropagation(t *testing.T) {
+	src := `@objcMembers
+class C {
+    func a() {}
+    @nonobjc func b() {}
+    func move(from x: Int, to y: Int) {}
+    var title: String = ""
+    @nonobjc var secret: String = ""
+}
+`
+	nodes, _ := runSwiftExtract(t, "C.swift", src)
+	sel := map[string]any{}
+	for _, n := range nodes {
+		if n.Meta == nil {
+			continue
+		}
+		if s, ok := n.Meta["objc_selector"]; ok {
+			sel[n.Name] = s
+		}
+	}
+	if sel["a"] != "a" {
+		t.Errorf("@objcMembers should expose a with selector a, got %v", sel["a"])
+	}
+	if sel["move"] != "moveFrom:to:" {
+		t.Errorf("@objcMembers should derive move(from:to:) selector moveFrom:to:, got %v", sel["move"])
+	}
+	if sel["title"] != "title" {
+		t.Errorf("@objcMembers should expose property title, got %v", sel["title"])
+	}
+	if _, ok := sel["b"]; ok {
+		t.Errorf("@nonobjc func b must not be exposed, got selector %v", sel["b"])
+	}
+	if _, ok := sel["secret"]; ok {
+		t.Errorf("@nonobjc var secret must not be exposed, got selector %v", sel["secret"])
+	}
+}

--- a/internal/parser/languages/swift_test.go
+++ b/internal/parser/languages/swift_test.go
@@ -226,3 +226,28 @@ func internalHelper() {}
 		t.Fatalf("internalHelper.vis = %q", internalFn.Meta["visibility"])
 	}
 }
+
+func TestSwiftExtractor_FactoryChainReceiver(t *testing.T) {
+	src := `struct Widget { func withX() -> Widget { return self } }
+func builder() -> Widget { return Widget() }
+func run() {
+  builder().withX().build()
+}
+`
+	res, err := NewSwiftExtractor().Extract("w.swift", []byte(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var build *graph.Edge
+	for _, e := range res.Edges {
+		if e.Kind == graph.EdgeCalls && e.To == "unresolved::*.build" {
+			build = e
+		}
+	}
+	if build == nil {
+		t.Fatal("build() call edge not found")
+	}
+	if build.Meta["receiver_type"] != "Widget" {
+		t.Errorf("receiver_type = %v, want Widget (chain builder().withX() returns Widget)", build.Meta["receiver_type"])
+	}
+}

--- a/internal/parser/languages/typescript.go
+++ b/internal/parser/languages/typescript.go
@@ -642,6 +642,7 @@ func (e *TypeScriptExtractor) Extract(filePath string, src []byte) (*parser.Extr
 	captureValueRefCandidates(result, root, filePath, src)
 	captureFnValueCandidates(result, root, filePath, src)
 	captureReduxThunkDispatches(result, root, filePath, src)
+	captureNgRxEffects(result, root, filePath, src)
 	captureObjectRegistryDispatches(result, root, filePath, src)
 	captureRTKQueryEndpoints(result, root, filePath, "typescript", src)
 	capturePiniaStoreCalls(result, root, filePath, src)

--- a/internal/resolver/framework_synth.go
+++ b/internal/resolver/framework_synth.go
@@ -95,6 +95,7 @@ const (
 	SynthSQLCallsite       = "sql-callsite"
 	SynthStoreFactory      = "store-factory"
 	SynthReduxThunk        = "redux-thunk"
+	SynthNgRxEffect        = "ngrx-effect"
 	SynthObjectRegistry    = "object-registry"
 	SynthRTKQuery          = "rtk-query"
 	SynthVuexDispatch      = "vuex-dispatch"
@@ -207,6 +208,10 @@ func defaultFrameworkSynthesizers() []FrameworkSynthesizer {
 		// After store-factory so its action nodes are indexed for the
 		// thunk → reducer cross-link.
 		synthFunc{name: SynthReduxThunk, fn: ResolveReduxThunkCalls},
+		// NgRx effects: a createEffect(() => actions$.pipe(ofType(X))) effect ->
+		// the action X it reacts to. After the store/thunk passes so action
+		// creator nodes are indexed.
+		synthFunc{name: SynthNgRxEffect, fn: ResolveNgRxEffects},
 		// Object-literal command/handler registry dispatch →
 		// `new registry[key]().execute()`. Runs before the speculative
 		// pass so a claimed dispatch site suppresses the hidden best-guess.

--- a/internal/resolver/ngrx_effects.go
+++ b/internal/resolver/ngrx_effects.go
@@ -1,0 +1,89 @@
+package resolver
+
+import "github.com/zzet/gortex/internal/graph"
+
+// ngrxEffectVia is the Meta["via"] tag the JS/TS extractors stamp on an NgRx
+// effect's ofType placeholder -- `createEffect(() => actions$.pipe(ofType(X)))`
+// links the effect to the action X it reacts to, which the static call graph
+// cannot see because effects are registered with the EffectsModule, not called.
+const ngrxEffectVia = "ngrx-effect"
+
+// ResolveNgRxEffects binds NgRx effect dispatch: a `createEffect(() =>
+// this.actions$.pipe(ofType(LoadUsers), ...))` effect -> the LoadUsers action it
+// reacts to. The extractor tags the effect node with Meta["ngrx_effect"] and
+// stamps each ofType as a placeholder EdgeCalls from the effect to
+// `unresolved::*.<action>` with Meta["via"]="ngrx-effect" +
+// Meta["ngrx_action"]=<action>. This pass resolves each action against (1) a
+// same-file action node, then (2) a unique action match by name (the
+// createAction const / action creator / type). NgRx-gated: a no-op when no effect
+// placeholder edges exist.
+//
+// Returns the number of effect placeholders landed on a real action.
+func ResolveNgRxEffects(g graph.Store) int {
+	if g == nil {
+		return 0
+	}
+	var placeholders []*graph.Edge
+	for e := range g.EdgesByKind(graph.EdgeCalls) {
+		if e == nil || e.Meta == nil {
+			continue
+		}
+		if v, _ := e.Meta["via"].(string); v != ngrxEffectVia {
+			continue
+		}
+		placeholders = append(placeholders, e)
+	}
+	if len(placeholders) == 0 {
+		return 0
+	}
+
+	// Index candidate action nodes by name (createAction const / action creator
+	// / action-type class).
+	actionByName := map[string][]*graph.Node{}
+	for _, n := range nodesByKindsOrAll(g, graph.KindVariable, graph.KindConstant, graph.KindFunction, graph.KindType) {
+		if n == nil || n.Name == "" {
+			continue
+		}
+		actionByName[n.Name] = append(actionByName[n.Name], n)
+	}
+
+	resolved := 0
+	var reindex []graph.EdgeReindex
+	for _, e := range placeholders {
+		action, _ := e.Meta["ngrx_action"].(string)
+		if action == "" {
+			continue
+		}
+		target := pickStoreAction(g, e, sameBoundaryCandidates(g, e.From, actionByName[action]))
+
+		want := "unresolved::*." + action
+		if target != nil {
+			want = target.ID
+		}
+		if e.To == want {
+			if target != nil {
+				resolved++
+			}
+			continue
+		}
+		oldTo := e.To
+		e.To = want
+		if target != nil {
+			e.Origin = graph.OriginASTInferred
+			e.Confidence = ConfidenceHeuristic
+			e.ConfidenceLabel = graph.ConfidenceLabelFor(graph.EdgeCalls, ConfidenceHeuristic)
+			StampSynthesized(e, SynthNgRxEffect)
+			resolved++
+		} else {
+			e.Origin = graph.OriginASTInferred
+			e.Confidence = 0
+			e.ConfidenceLabel = ""
+			UnstampSynthesized(e)
+		}
+		reindex = append(reindex, graph.EdgeReindex{Edge: e, OldTo: oldTo})
+	}
+	if len(reindex) > 0 {
+		g.ReindexEdges(reindex)
+	}
+	return resolved
+}

--- a/internal/resolver/ngrx_effects_test.go
+++ b/internal/resolver/ngrx_effects_test.go
@@ -1,0 +1,44 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestResolveNgRxEffects(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID: "effects.ts::UserEffects.loadUsers$", Kind: graph.KindVariable, Name: "loadUsers$",
+		FilePath: "effects.ts", Language: "typescript", Meta: map[string]any{"ngrx_effect": "loadUsers$"},
+	})
+	g.AddNode(&graph.Node{
+		ID: "actions.ts::LoadUsers", Kind: graph.KindConstant, Name: "LoadUsers",
+		FilePath: "actions.ts", Language: "typescript",
+	})
+	g.AddEdge(&graph.Edge{
+		From: "effects.ts::UserEffects.loadUsers$", To: "unresolved::*.LoadUsers", Kind: graph.EdgeCalls,
+		FilePath: "effects.ts", Meta: map[string]any{"via": "ngrx-effect", "ngrx_action": "LoadUsers"},
+	})
+
+	n := ResolveNgRxEffects(g)
+	assert.Equal(t, 1, n, "one effect placeholder should resolve")
+
+	var found *graph.Edge
+	for _, e := range g.GetOutEdges("effects.ts::UserEffects.loadUsers$") {
+		if e.Kind == graph.EdgeCalls && e.To == "actions.ts::LoadUsers" {
+			found = e
+		}
+	}
+	require.NotNil(t, found, "effect should resolve to the LoadUsers action node")
+	assert.Equal(t, SynthNgRxEffect, found.Meta[MetaSynthesizedBy])
+}
+
+func TestResolveNgRxEffects_NoEffectsIsNoOp(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "a.ts::x", Kind: graph.KindFunction, Name: "x", FilePath: "a.ts"})
+	assert.Equal(t, 0, ResolveNgRxEffects(g))
+}

--- a/internal/resolver/swift_objc_bridge.go
+++ b/internal/resolver/swift_objc_bridge.go
@@ -1,6 +1,10 @@
 package resolver
 
-import "github.com/zzet/gortex/internal/graph"
+import (
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+)
 
 // swiftObjCBridgeVia marks a synthesized Swift↔ObjC bridge edge.
 const swiftObjCBridgeVia = "swift.objc.bridge"
@@ -40,7 +44,11 @@ func ResolveSwiftObjCBridge(g graph.Store) int {
 	objcBySelector := map[string][]*graph.Node{}
 	swiftByName := map[string][]*graph.Node{}
 	var swiftExact []swiftSelRef
-	for _, n := range nodesByKindsOrAll(g, graph.KindMethod, graph.KindFunction, graph.KindField) {
+	// Protocol-conformance bridge inputs: Swift @objc protocols by name and
+	// the ObjC @interface nodes that adopt protocols.
+	swiftObjCProto := map[string]*graph.Node{}
+	var objcConformers []*graph.Node
+	for _, n := range nodesByKindsOrAll(g, graph.KindMethod, graph.KindFunction, graph.KindField, graph.KindInterface, graph.KindType) {
 		if n == nil {
 			continue
 		}
@@ -48,6 +56,11 @@ func ResolveSwiftObjCBridge(g graph.Store) int {
 		case "objc":
 			if n.Kind == graph.KindMethod && n.Name != "" {
 				objcBySelector[n.Name] = append(objcBySelector[n.Name], n)
+			}
+			if n.Kind == graph.KindType && n.Meta != nil {
+				if protos, _ := n.Meta["objc_protocols"].(string); protos != "" {
+					objcConformers = append(objcConformers, n)
+				}
 			}
 		case "swift":
 			if n.Name != "" {
@@ -62,10 +75,17 @@ func ResolveSwiftObjCBridge(g graph.Store) int {
 				if sel, _ := n.Meta["objc_setter_selector"].(string); sel != "" {
 					swiftExact = append(swiftExact, swiftSelRef{n, sel})
 				}
+				if n.Kind == graph.KindInterface {
+					if isObjC, _ := n.Meta["objc"].(bool); isObjC {
+						swiftObjCProto[n.Name] = n
+					}
+				}
 			}
 		}
 	}
-	if len(objcBySelector) == 0 || len(swiftByName) == 0 {
+	noSelectorBridge := len(objcBySelector) == 0 || len(swiftByName) == 0
+	noProtocolBridge := len(swiftObjCProto) == 0 || len(objcConformers) == 0
+	if noSelectorBridge && noProtocolBridge {
 		return 0
 	}
 
@@ -104,10 +124,45 @@ func ResolveSwiftObjCBridge(g graph.Store) int {
 		}
 	}
 
+	// Protocol-conformance pass: an ObjC @interface adopting a Swift @objc
+	// protocol gets a cross-language EdgeImplements to that protocol node.
+	for _, oc := range objcConformers {
+		protos, _ := oc.Meta["objc_protocols"].(string)
+		for _, pname := range strings.Split(protos, ",") {
+			pname = strings.TrimSpace(pname)
+			if pn := swiftObjCProto[pname]; pn != nil && pn.ID != oc.ID {
+				batch = append(batch, swiftObjCImplementsEdge(oc, pn))
+				bridged[oc.ID] = true
+			}
+		}
+	}
+
 	for _, e := range batch {
 		g.AddEdge(e)
 	}
 	return len(bridged)
+}
+
+// swiftObjCImplementsEdge builds the cross-language conformance edge from an
+// ObjC class adopting a Swift @objc protocol to that protocol node.
+func swiftObjCImplementsEdge(from, to *graph.Node) *graph.Edge {
+	return &graph.Edge{
+		From:            from.ID,
+		To:              to.ID,
+		Kind:            graph.EdgeImplements,
+		FilePath:        from.FilePath,
+		Line:            from.StartLine,
+		Confidence:      0.6,
+		ConfidenceLabel: graph.ConfidenceLabelFor(graph.EdgeImplements, 0.6),
+		Origin:          graph.OriginASTInferred,
+		Meta: map[string]any{
+			"via":              swiftObjCBridgeVia,
+			MetaSynthesizedBy:  SynthSwiftObjC,
+			MetaProvenance:     ProvenanceHeuristic,
+			"bridge_from_lang": from.Language,
+			"bridge_to_lang":   to.Language,
+		},
+	}
 }
 
 // swiftObjCBridgeEdge builds one direction of the cross-language bridge.

--- a/internal/resolver/swift_objc_bridge_test.go
+++ b/internal/resolver/swift_objc_bridge_test.go
@@ -72,12 +72,12 @@ func TestResolveSwiftObjCBridge_CandidateBridge(t *testing.T) {
 
 func TestSwiftObjCBaseNameCandidates(t *testing.T) {
 	cases := map[string][]string{
-		"cellForRowAtIndexPath:":            {"cellForRowAtIndexPath", "cellForRow"},
-		"moveFrom:to:":                      {"moveFrom", "move"},
-		"initWithFrame:":                    {"initWithFrame"},
-		"tableView:numberOfRowsInSection:":  {"tableView"},
-		"viewDidLoad":                       {"viewDidLoad"},
-		"dataForKey:":                       {"dataForKey", "data"},
+		"cellForRowAtIndexPath:":           {"cellForRowAtIndexPath", "cellForRow"},
+		"moveFrom:to:":                     {"moveFrom", "move"},
+		"initWithFrame:":                   {"initWithFrame"},
+		"tableView:numberOfRowsInSection:": {"tableView"},
+		"viewDidLoad":                      {"viewDidLoad"},
+		"dataForKey:":                      {"dataForKey", "data"},
 	}
 	for sel, want := range cases {
 		assert.ElementsMatch(t, want, swiftObjCBaseNameCandidates(sel), "selector %q", sel)
@@ -160,4 +160,52 @@ func TestResolveSwiftObjCBridge_Idempotent(t *testing.T) {
 		}
 	}
 	assert.Equal(t, 2, count)
+}
+
+func TestResolveSwiftObjCBridge_ProtocolConformance(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID: "ios/P.swift::Drawable", Kind: graph.KindInterface, Name: "Drawable",
+		FilePath: "ios/P.swift", StartLine: 1, Language: "swift",
+		Meta: map[string]any{"objc": true},
+	})
+	g.AddNode(&graph.Node{
+		ID: "ios/C.m::Widget", Kind: graph.KindType, Name: "Widget",
+		FilePath: "ios/C.m", StartLine: 1, Language: "objc",
+		Meta: map[string]any{"objc_protocols": "Drawable"},
+	})
+
+	ResolveSwiftObjCBridge(g)
+
+	var impl *graph.Edge
+	for _, e := range g.GetOutEdges("ios/C.m::Widget") {
+		if e.To == "ios/P.swift::Drawable" && e.Kind == graph.EdgeImplements {
+			impl = e
+		}
+	}
+	require.NotNil(t, impl, "ObjC class adopting a Swift @objc protocol should get EdgeImplements")
+	assert.Equal(t, SynthSwiftObjC, impl.Meta[MetaSynthesizedBy])
+	assert.Equal(t, "objc", impl.Meta["bridge_from_lang"])
+	assert.Equal(t, "swift", impl.Meta["bridge_to_lang"])
+}
+
+func TestResolveSwiftObjCBridge_NonObjCProtocolNotBridged(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID: "ios/P.swift::Plain", Kind: graph.KindInterface, Name: "Plain",
+		FilePath: "ios/P.swift", StartLine: 1, Language: "swift",
+	})
+	g.AddNode(&graph.Node{
+		ID: "ios/C.m::Widget", Kind: graph.KindType, Name: "Widget",
+		FilePath: "ios/C.m", StartLine: 1, Language: "objc",
+		Meta: map[string]any{"objc_protocols": "Plain"},
+	})
+
+	ResolveSwiftObjCBridge(g)
+
+	for _, e := range g.GetOutEdges("ios/C.m::Widget") {
+		if e.To == "ios/P.swift::Plain" && e.Kind == graph.EdgeImplements {
+			t.Errorf("a non-@objc Swift protocol must not be bridged")
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Broadens Gortex's cross-language code intelligence with a batch of independent extractor / resolver / route improvements — one commit each, every one fixture-backed and verified against the live graph. The full `go test -race ./...` suite is green and `golangci-lint` is clean on every touched package; no wire-contract change (only `Meta` keys added).

### Function-as-value & reference capture
- **PHP** — recognise callbacks passed to 13 more higher-order builtins (`array_udiff` and friends, `forward_static_call`, `set_exception_handler`, `ob_start`, `iterator_apply`, `is_callable`, …); for `preg_replace_callback_array`, resolve the value side of each `pattern => callback` element.
- **C++** — capture `&fn` and `&Cls::method` (pointer-to-member) as function-value references.
- **Objective-C** — capture `@selector(...)` literals as function-value references to the named method.
- **Lua / Luau** — capture function values passed by bare name and `tbl.method`.

### React Native / Expo / mobile
- **React Native** — capture the custom `sendEvent(ctx, "Name", body)` wrapper emit (Swift/ObjC) and mine native→JS emits from Java/Kotlin (`getJSModule(...).emit` chain + the `sendEvent` helper), so Android/iOS native emits share the event topic node with JS `addListener` subscribers.
- **Expo Modules** — extract `Property` / `Constants` / `Events` members, tolerate a generic clause (`AsyncFunction<Int>("x")`), and attribute members of a `definition()` body with no `Name()` to its enclosing `XxxModule` class.

### Swift ↔ Objective-C interop
- **`@objcMembers`** — propagate implicit Objective-C exposure to a class's members (with the `@nonobjc` opt-out).
- **`@objc protocol`** — emit a cross-language `implements` edge from an Objective-C `@interface` to the Swift `@objc` protocol it adopts.

### Framework dispatch & resolution
- **NgRx** — synthesize a dispatch edge from a `createEffect(() => actions$.pipe(ofType(X)))` effect to the action `X` it reacts to.
- **Svelte** — resolve a `$store` auto-subscription in markup to the imported store (runes untouched).
- **C# ASP.NET** — prefix-join a controller's class-level `[Route("api/[controller]")]` onto each relative method route (an absolute `/...` / `~/...` template still ignores the prefix, per ASP.NET), and capture a verb-less method `[Route("...")]`.

### Factory-chain receiver typing
- Capture the receiver of a chained call so `builder().withX().build()` resolves the chained receiver type (or preserves the receiver expression for the graph-aware resolver when a hop isn't locally typed), across **C++, PHP, Swift, Scala, Dart, and Pascal**. The factory-chain work covers the languages whose call syntax fits the shared `.`-chain machinery; C (no member-call chains) and Objective-C (bracket message sends) are not applicable.

### Verification
- Every commit is behavior-only and independently builds + tests green.
- Full `go test -race ./...`: green (0 failures / panics / races).
- `golangci-lint run`: clean on all touched packages.
