### PR TITLE
fix(indexer): cap large document assets and skip vector data by default

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -741,6 +741,74 @@ type IndexConfig struct {
 	// .gortex.yaml; the CODEGRAPH_EVENT_CONFIG env var (a JSON list)
 	// overrides it for drop-in compatibility with pygraph/tsgraph.
 	EventBus []EventBusBoundarySpec `mapstructure:"event_bus" yaml:"event_bus,omitempty"`
+
+	// Content bounds admission of large non-source content / data
+	// artifacts — PDF / office documents and binary / columnar / vector
+	// data files — so a content-heavy corpus (a RAG repo of hundreds of
+	// decks, spreadsheets, and dataset shards) can't pull gigabytes of
+	// non-code files into the parse pipeline and OOM the indexer (#120).
+	// Documents over a per-file cap and (by default) all data assets are
+	// dropped at the walk with a skip-telemetry node, so they stay
+	// listable without being read or extracted. See
+	// ContentAdmissionConfig. Configured under `index.content`.
+	Content ContentAdmissionConfig `mapstructure:"content" yaml:"content,omitempty"`
+}
+
+// ContentAdmissionConfig gates which large non-source artifacts enter the
+// index. The defaults keep the multimodal feature working for normal-size
+// documents while bounding the corpus-admission memory blow-up that a
+// content-heavy repo otherwise triggers.
+type ContentAdmissionConfig struct {
+	// MaxDocumentBytes caps individual document assets — PDF, pptx, xlsx,
+	// plain text — that are ingested as searchable content (one KindDoc
+	// node per page / slide / sheet). A file larger than the cap is
+	// skipped at the walk with a `large_document` telemetry node instead
+	// of being read and extracted. Tri-state: >0 caps at that many bytes;
+	// 0 (absent) uses the built-in default (defaultMaxDocumentBytes,
+	// 10 MiB); <0 disables the cap (index documents of any size).
+	// Configured under `index.content.max_document_bytes`.
+	MaxDocumentBytes int64 `mapstructure:"max_document_bytes" yaml:"max_document_bytes,omitempty"`
+	// IndexData admits binary / columnar / vector data artifacts
+	// (.parquet, .npy, .npz, .lance, .arrow, .feather) as metadata-only
+	// nodes. Off by default: these are never code-intelligence content and
+	// in a RAG / data repo they dominate the admitted byte weight, so they
+	// are skipped at the walk with a `vector_data` telemetry node unless
+	// explicitly opted in. Configured under `index.content.index_data`.
+	IndexData bool `mapstructure:"index_data" yaml:"index_data,omitempty"`
+	// MaxDataBytes caps data assets when IndexData is on — a guard against
+	// admitting a multi-GB shard even when data indexing is wanted. Same
+	// tri-state as MaxDocumentBytes (>0 caps; 0 uses the built-in default,
+	// defaultMaxDataBytes; <0 disables the cap). Ignored when IndexData is
+	// off. Configured under `index.content.max_data_bytes`.
+	MaxDataBytes int64 `mapstructure:"max_data_bytes" yaml:"max_data_bytes,omitempty"`
+}
+
+// EffectiveMaxDocumentBytes resolves MaxDocumentBytes' tri-state into a
+// concrete cap. capped is false when documents are admitted at any size
+// (the field was set negative); otherwise limit is the active per-file cap.
+func (c ContentAdmissionConfig) EffectiveMaxDocumentBytes() (limit int64, capped bool) {
+	switch {
+	case c.MaxDocumentBytes < 0:
+		return 0, false
+	case c.MaxDocumentBytes == 0:
+		return defaultMaxDocumentBytes, true
+	default:
+		return c.MaxDocumentBytes, true
+	}
+}
+
+// EffectiveMaxDataBytes resolves MaxDataBytes' tri-state into a concrete
+// cap, used only when IndexData is on. capped is false when admitted data
+// assets are uncapped (the field was set negative).
+func (c ContentAdmissionConfig) EffectiveMaxDataBytes() (limit int64, capped bool) {
+	switch {
+	case c.MaxDataBytes < 0:
+		return 0, false
+	case c.MaxDataBytes == 0:
+		return defaultMaxDataBytes, true
+	default:
+		return c.MaxDataBytes, true
+	}
 }
 
 // EventBusBoundarySpec declares one producer or consumer boundary of a
@@ -1515,6 +1583,17 @@ type MCPToolsConfig struct {
 // content assets (PDFs, office documents, datasets).
 const defaultMaxParseBytesInFlight = 512 << 20
 
+// defaultMaxDocumentBytes is the built-in per-file cap for document
+// assets (PDF / pptx / xlsx / text). 10 MiB keeps normal-size documents
+// searchable while dropping the few huge decks / spreadsheets that
+// dominate a content repo's admitted bytes and blow up parse memory.
+const defaultMaxDocumentBytes = 10 << 20
+
+// defaultMaxDataBytes is the built-in per-file cap applied to data assets
+// only when index.content.index_data opts them in — a backstop against a
+// multi-GB shard. Matches the data extractor's stream-hash ceiling.
+const defaultMaxDataBytes = 64 << 20
+
 // Default returns a Config with sensible defaults.
 //
 // Exclude is intentionally empty here — the builtin baseline lives in
@@ -1531,6 +1610,13 @@ func Default() *Config {
 			// Prose indexing is on by default; the ConfigManager
 			// re-derives this from search.index_prose.
 			IndexProse: true,
+			// Corpus-admission defaults: cap document assets at 10 MiB
+			// and skip binary/vector data assets unless opted in (#120).
+			Content: ContentAdmissionConfig{
+				MaxDocumentBytes: defaultMaxDocumentBytes,
+				IndexData:        false,
+				MaxDataBytes:     defaultMaxDataBytes,
+			},
 		},
 		Watch: WatchConfig{
 			Enabled:    false,

--- a/internal/indexer/content_admission.go
+++ b/internal/indexer/content_admission.go
@@ -1,0 +1,109 @@
+package indexer
+
+import (
+	"path/filepath"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+)
+
+// Content-admission skip reasons. They ride on a synthetic file node's
+// Meta["skip_reason"] so a dropped asset stays listable and index_health
+// rolls it up, mirroring the size / timeout / minified skip telemetry.
+const (
+	skipReasonLargeDocument = "large_document"   // document over the per-file cap
+	skipReasonVectorData    = "vector_data"      // data asset, data indexing off
+	skipReasonLargeData     = "large_data_asset" // data asset over the per-file cap
+)
+
+// contentAdmissionGate decides, by asset class, whether a non-source artifact
+// is admitted into extraction. It is built once before a walk from the
+// registry's asset-class map and the resolved config caps, so the hot
+// per-file check is a single map lookup. A nil gate is inert — the common
+// all-code repo (no asset extractors registered) pays nothing.
+type contentAdmissionGate struct {
+	classes    map[string]parser.AssetClass
+	docLimit   int64
+	docCapped  bool
+	indexData  bool
+	dataLimit  int64
+	dataCapped bool
+}
+
+// newContentAdmissionGate builds the gate from the indexer's registry and
+// config. Returns nil when no asset extractors are registered.
+func (idx *Indexer) newContentAdmissionGate() *contentAdmissionGate {
+	classes := idx.registry.AssetClasses()
+	if len(classes) == 0 {
+		return nil
+	}
+	c := idx.config.Content
+	docLimit, docCapped := c.EffectiveMaxDocumentBytes()
+	dataLimit, dataCapped := c.EffectiveMaxDataBytes()
+	return &contentAdmissionGate{
+		classes:    classes,
+		docLimit:   docLimit,
+		docCapped:  docCapped,
+		indexData:  c.IndexData,
+		dataLimit:  dataLimit,
+		dataCapped: dataCapped,
+	}
+}
+
+// skip reports whether a file of the given walk-time language and size should
+// be dropped before it is read and extracted, and the telemetry reason. A
+// non-asset language (the gate has no entry for it) is never gated.
+func (g *contentAdmissionGate) skip(lang string, size int64) (string, bool) {
+	if g == nil {
+		return "", false
+	}
+	switch g.classes[lang] {
+	case parser.AssetDocument:
+		if g.docCapped && size > g.docLimit {
+			return skipReasonLargeDocument, true
+		}
+	case parser.AssetData:
+		if !g.indexData {
+			return skipReasonVectorData, true
+		}
+		if g.dataCapped && size > g.dataLimit {
+			return skipReasonLargeData, true
+		}
+	}
+	return "", false
+}
+
+// contentSkipNode builds a synthetic file node for a content / data asset
+// dropped by the admission gate, carrying the skip reason and size so the
+// file stays visible (queryable, index_health rollup) without being read or
+// parsed — the same treatment size-capped files get.
+func contentSkipNode(sf skippedFile) *graph.Node {
+	return &graph.Node{
+		ID:        sf.relPath,
+		Kind:      graph.KindFile,
+		Name:      filepath.Base(sf.relPath),
+		FilePath:  sf.relPath,
+		Language:  sf.lang,
+		StartLine: 1,
+		Meta: map[string]any{
+			"skip_reason":            sf.reason,
+			"skipped_due_to_content": true,
+			"file_size_bytes":        sf.size,
+		},
+	}
+}
+
+// emitContentSkipNodes adds a synthetic file node for every asset dropped by
+// the content-admission gate, so the file stays listable with skip telemetry
+// instead of vanishing silently.
+func (idx *Indexer) emitContentSkipNodes(skipped []skippedFile) {
+	if len(skipped) == 0 {
+		return
+	}
+	nodes := make([]*graph.Node, 0, len(skipped))
+	for _, sf := range skipped {
+		nodes = append(nodes, contentSkipNode(sf))
+	}
+	idx.applyRepoPrefix(nodes, nil)
+	idx.graph.AddBatch(nodes, nil)
+}

--- a/internal/indexer/content_admission_test.go
+++ b/internal/indexer/content_admission_test.go
@@ -1,0 +1,192 @@
+package indexer
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+// newAssetTestIndexer registers the code + asset extractors the
+// content-admission gate keys off, so a temp repo of documents / data
+// files exercises the real walk-time gate.
+func newAssetTestIndexer(g graph.Store) *Indexer {
+	reg := parser.NewRegistry()
+	reg.Register(languages.NewGoExtractor())
+	reg.Register(languages.NewTextExtractor())
+	reg.Register(languages.NewPDFExtractor())
+	reg.Register(languages.NewPptxExtractor())
+	reg.Register(languages.NewXlsxExtractor())
+	reg.Register(languages.NewDataAssetExtractor())
+	cfg := config.Default().Index
+	cfg.Workers = 2
+	return New(g, reg, cfg, zap.NewNop())
+}
+
+func TestContentAdmissionConfig_EffectiveCaps(t *testing.T) {
+	// 0 (absent) → built-in default, capped.
+	lim, capped := config.ContentAdmissionConfig{MaxDocumentBytes: 0}.EffectiveMaxDocumentBytes()
+	require.True(t, capped)
+	require.Equal(t, int64(10<<20), lim)
+
+	// >0 → explicit cap.
+	lim, capped = config.ContentAdmissionConfig{MaxDocumentBytes: 4096}.EffectiveMaxDocumentBytes()
+	require.True(t, capped)
+	require.Equal(t, int64(4096), lim)
+
+	// <0 → no cap.
+	_, capped = config.ContentAdmissionConfig{MaxDocumentBytes: -1}.EffectiveMaxDocumentBytes()
+	require.False(t, capped)
+
+	// Same tri-state for data.
+	_, capped = config.ContentAdmissionConfig{MaxDataBytes: -1}.EffectiveMaxDataBytes()
+	require.False(t, capped)
+	lim, capped = config.ContentAdmissionConfig{MaxDataBytes: 7}.EffectiveMaxDataBytes()
+	require.True(t, capped)
+	require.Equal(t, int64(7), lim)
+}
+
+func TestContentAdmissionGate_Skip(t *testing.T) {
+	idx := newAssetTestIndexer(graph.New())
+
+	// Default policy: documents capped at 10 MiB, data skipped.
+	idx.config.Content = config.Default().Index.Content
+	gate := idx.newContentAdmissionGate()
+	require.NotNil(t, gate)
+
+	// Code is never gated.
+	_, skip := gate.skip("go", 1<<30)
+	require.False(t, skip)
+
+	// A small document is admitted; a huge one is dropped.
+	_, skip = gate.skip("text", 1024)
+	require.False(t, skip)
+	reason, skip := gate.skip("text", 11<<20)
+	require.True(t, skip)
+	require.Equal(t, skipReasonLargeDocument, reason)
+
+	// Data assets are skipped by default at any size.
+	reason, skip = gate.skip("data", 1)
+	require.True(t, skip)
+	require.Equal(t, skipReasonVectorData, reason)
+
+	// Opting data in admits it, subject to its own cap.
+	idx.config.Content.IndexData = true
+	idx.config.Content.MaxDataBytes = 1024
+	gate = idx.newContentAdmissionGate()
+	_, skip = gate.skip("data", 512)
+	require.False(t, skip)
+	reason, skip = gate.skip("data", 4096)
+	require.True(t, skip)
+	require.Equal(t, skipReasonLargeData, reason)
+
+	// A negative document cap disables document gating entirely.
+	idx.config.Content = config.ContentAdmissionConfig{MaxDocumentBytes: -1}
+	gate = idx.newContentAdmissionGate()
+	_, skip = gate.skip("text", 1<<30)
+	require.False(t, skip)
+}
+
+// TestContentAdmissionGate_NilInert verifies a nil gate (no asset extractors
+// registered) never skips — the all-code-repo fast path.
+func TestContentAdmissionGate_NilInert(t *testing.T) {
+	var g *contentAdmissionGate
+	_, skip := g.skip("text", 1<<30)
+	require.False(t, skip)
+}
+
+func TestContentSkipNode(t *testing.T) {
+	n := contentSkipNode(skippedFile{
+		relPath: "data/deck.pptx", lang: "pptx", size: 50 << 20, reason: skipReasonLargeDocument,
+	})
+	require.Equal(t, graph.KindFile, n.Kind)
+	require.Equal(t, "data/deck.pptx", n.ID)
+	require.Equal(t, "deck.pptx", n.Name)
+	require.Equal(t, "pptx", n.Language)
+	require.Equal(t, skipReasonLargeDocument, n.Meta["skip_reason"])
+	require.Equal(t, true, n.Meta["skipped_due_to_content"])
+	require.Equal(t, int64(50<<20), n.Meta["file_size_bytes"])
+}
+
+// TestIndex_DocumentCapSkip verifies a document over the cap becomes a
+// large_document skip node while a small one is still ingested as content.
+func TestIndex_DocumentCapSkip(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "small.txt"), "a short note")
+	writeFile(t, filepath.Join(dir, "big.txt"), strings.Repeat("filler text ", 400)) // ~4.8 KiB
+	writeFile(t, filepath.Join(dir, "code.go"), "package main\n\nfunc A() {}\n")
+
+	g := graph.New()
+	idx := newAssetTestIndexer(g)
+	idx.config.Content.MaxDocumentBytes = 1024 // big.txt is over the cap
+
+	result, err := idx.Index(dir)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.SkippedFiles)
+
+	big := g.GetNode("big.txt")
+	require.NotNil(t, big, "an over-cap document must still leave a skip node")
+	require.Equal(t, skipReasonLargeDocument, big.Meta["skip_reason"])
+	require.Equal(t, true, big.Meta["skipped_due_to_content"])
+
+	// The small document was admitted (no skip reason).
+	small := g.GetNode("small.txt")
+	require.NotNil(t, small)
+	require.Nil(t, small.Meta["skip_reason"])
+}
+
+// TestIndex_DataAssetSkippedByDefault verifies a vector/data artifact is
+// dropped by default and admitted as a metadata node when opted in.
+func TestIndex_DataAssetSkippedByDefault(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "embeddings.npy"), "NUMPY-array-placeholder-bytes")
+
+	// Default: skipped with vector_data.
+	g := graph.New()
+	idx := newAssetTestIndexer(g)
+	result, err := idx.Index(dir)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.SkippedFiles)
+	n := g.GetNode("embeddings.npy")
+	require.NotNil(t, n)
+	require.Equal(t, skipReasonVectorData, n.Meta["skip_reason"])
+
+	// Opt in: admitted as a data metadata node, no skip reason.
+	g2 := graph.New()
+	idx2 := newAssetTestIndexer(g2)
+	idx2.config.Content.IndexData = true
+	_, err = idx2.Index(dir)
+	require.NoError(t, err)
+	n2 := g2.GetNode("embeddings.npy")
+	require.NotNil(t, n2)
+	require.Nil(t, n2.Meta["skip_reason"])
+	require.Equal(t, "data", n2.Meta["data_class"])
+}
+
+// TestIndexFile_ContentSkip verifies the incremental (watcher) path applies
+// the same gate, so a document the cold walk would skip doesn't get parsed
+// back in on re-index.
+func TestIndexFile_ContentSkip(t *testing.T) {
+	dir := t.TempDir()
+	g := graph.New()
+	idx := newAssetTestIndexer(g)
+	idx.config.Content.MaxDocumentBytes = 1024
+	if _, err := idx.Index(dir); err != nil {
+		t.Fatalf("index: %v", err)
+	}
+
+	big := filepath.Join(dir, "report.txt")
+	writeFile(t, big, strings.Repeat("report line ", 400))
+	require.NoError(t, idx.indexFile(big, false))
+
+	n := g.GetNode("report.txt")
+	require.NotNil(t, n)
+	require.Equal(t, skipReasonLargeDocument, n.Meta["skip_reason"])
+}

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -73,10 +73,12 @@ type IndexResult struct {
 	// Meta["parse_error"] node. Zero unless crash isolation is on.
 	QuarantinedFiles int `json:"quarantined_files,omitempty"`
 	// SkippedFiles is the number of files skipped by the size cap
-	// (MaxFileSize) or the per-file extraction timeout
-	// (MaxExtractMillis). Each is recorded in the graph as a synthetic
-	// file node carrying skipped_due_to_size / skipped_due_to_timeout
-	// telemetry. Zero unless one of those caps is set.
+	// (MaxFileSize), the per-file extraction timeout (MaxExtractMillis),
+	// or the content-admission policy (index.content — oversized documents
+	// and, by default, binary/vector data assets). Each is recorded in the
+	// graph as a synthetic file node carrying skipped_due_to_size /
+	// skipped_due_to_timeout / skipped_due_to_content telemetry. Zero
+	// unless one of those gates fires.
 	SkippedFiles int `json:"skipped_files,omitempty"`
 	// DeletedFileCount is the number of previously-indexed files that
 	// were evicted this pass because they no longer exist on disk (only
@@ -1945,10 +1947,18 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 	// syscall per file regardless; trading one walk-time stat for two
 	// later stats is the net win.
 	maxSize := idx.config.MaxFileSize
+	// Corpus-admission gate: drops oversized document assets and (by
+	// default) binary/vector data artifacts at the walk, before they are
+	// read and extracted, so a content-heavy repo can't pull gigabytes of
+	// non-source files into the parse pipeline and OOM (#120). Inert for
+	// all-code repos.
+	contentGate := idx.newContentAdmissionGate()
 	var files []walkedFile
 	var skippedLarge int
 	var skippedBytes int64
 	var skippedBySize []skippedFile
+	var skippedByContent []skippedFile
+	var skippedContentBytes int64
 	var parseFailedFiles []skippedFile
 	err = filepath.WalkDir(absRoot, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
@@ -1982,6 +1992,14 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 			})
 			return nil
 		}
+		if reason, skip := contentGate.skip(lang, info.Size()); skip {
+			skippedContentBytes += info.Size()
+			rel, _ := filepath.Rel(absRoot, path)
+			skippedByContent = append(skippedByContent, skippedFile{
+				relPath: filepath.ToSlash(rel), lang: lang, size: info.Size(), reason: reason,
+			})
+			return nil
+		}
 		files = append(files, walkedFile{
 			path:      path,
 			lang:      lang,
@@ -1998,6 +2016,11 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 			zap.Int("count", skippedLarge),
 			zap.Int64("total_bytes", skippedBytes),
 			zap.Int64("limit_bytes", maxSize))
+	}
+	if len(skippedByContent) > 0 {
+		idx.logger.Info("indexer: skipped content/data assets by admission policy",
+			zap.Int("count", len(skippedByContent)),
+			zap.Int64("total_bytes", skippedContentBytes))
 	}
 	reporter.Report("walking files", len(files), len(files))
 
@@ -2614,6 +2637,7 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 	// they stay visible in the graph with skip telemetry attached
 	// instead of vanishing silently.
 	idx.emitSizeSkipNodes(skippedBySize)
+	idx.emitContentSkipNodes(skippedByContent)
 	idx.emitParseFailedSkipNodes(parseFailedFiles)
 
 	// Populate fileMtimes for all detected files. Keyed through
@@ -2896,7 +2920,7 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 		EdgeCount:        edges,
 		FileCount:        int(fileCount),
 		QuarantinedFiles: quarantine.Len(),
-		SkippedFiles:     len(skippedBySize) + int(skippedByTimeout) + int(skippedByMinified),
+		SkippedFiles:     len(skippedBySize) + len(skippedByContent) + int(skippedByTimeout) + int(skippedByMinified),
 		DurationMs:       time.Since(start).Milliseconds(),
 		Errors:           errors,
 	}
@@ -3013,6 +3037,20 @@ func (idx *Indexer) indexFile(filePath string, resolve bool) error {
 		n := sizeSkipNode(skippedFile{
 			relPath: filepath.ToSlash(relPath), lang: lang, size: int64(len(src)),
 		}, maxSize)
+		idx.applyRepoPrefix([]*graph.Node{n}, nil)
+		evictExisting()
+		idx.graph.AddBatch([]*graph.Node{n}, nil)
+		return nil
+	}
+
+	// Honour the content-admission gate on the incremental path too, so a
+	// document over its cap (or a data asset, by default) the cold walk
+	// would skip doesn't get parsed back in when the watcher re-indexes it
+	// — same synthetic-skip-node treatment as the size cap above.
+	if reason, skip := idx.newContentAdmissionGate().skip(lang, int64(len(src))); skip {
+		n := contentSkipNode(skippedFile{
+			relPath: filepath.ToSlash(relPath), lang: lang, size: int64(len(src)), reason: reason,
+		})
 		idx.applyRepoPrefix([]*graph.Node{n}, nil)
 		evictExisting()
 		idx.graph.AddBatch([]*graph.Node{n}, nil)

--- a/internal/indexer/skip_telemetry.go
+++ b/internal/indexer/skip_telemetry.go
@@ -52,6 +52,10 @@ type skippedFile struct {
 	lang    string
 	size    int64
 	cause   string
+	// reason is the content-admission skip reason (large_document /
+	// vector_data / large_data_asset) for files the asset gate dropped at
+	// the walk; empty for size / parse-failure skips.
+	reason string
 }
 
 // walkedFile records a file that survived the walk-time filters,

--- a/internal/parser/extractor.go
+++ b/internal/parser/extractor.go
@@ -60,6 +60,49 @@ type StreamingExtractor interface {
 	ExtractStream(filePath string, r io.ReaderAt, size int64, emit func(*graph.Node, []*graph.Edge)) error
 }
 
+// AssetClass labels a non-code extractor by the kind of large
+// binary/document/data artifact it ingests, so the indexer can apply
+// corpus-admission caps before a heavy file is ever read and extracted.
+// Code extractors return the empty class and are never gated.
+type AssetClass string
+
+const (
+	// AssetDocument is a human document ingested as searchable content
+	// (one KindDoc node per page / slide / sheet): PDF, pptx, xlsx,
+	// plain text. Large ones dominate parse memory, so they are subject
+	// to a per-file size cap.
+	AssetDocument AssetClass = "document"
+	// AssetData is a pure binary / columnar / vector artifact recorded
+	// as a metadata-only node and never parsed: parquet, npy, lance, …
+	// Not code-intelligence content; admitted only when opted in.
+	AssetData AssetClass = "data"
+	// AssetImage is an image asset (metadata-only node). Cheap to
+	// admit; kept un-gated by default.
+	AssetImage AssetClass = "image"
+)
+
+// AssetExtractor is an optional Extractor capability: a non-code extractor
+// that ingests large binary/document/data artifacts rather than source.
+// The indexer reads AssetClass at walk time (via the registry, keyed by the
+// detected language) to decide admission — a per-file size cap for documents
+// and an opt-in gate for data assets — so a content-heavy corpus can't pull
+// gigabytes of non-source artifacts into the parse pipeline. Extractors that
+// don't implement it are treated as code (always admitted).
+type AssetExtractor interface {
+	Extractor
+	AssetClass() AssetClass
+}
+
+// AssetClassOf returns e's AssetClass when e implements AssetExtractor, or the
+// empty class (code) otherwise. The single place callers map an extractor to
+// its admission class.
+func AssetClassOf(e Extractor) AssetClass {
+	if a, ok := e.(AssetExtractor); ok {
+		return a.AssetClass()
+	}
+	return ""
+}
+
 // ExtractionResult holds the nodes and edges extracted from a single
 // file, plus an optional handle to the parse tree the extractor used.
 //

--- a/internal/parser/languages/dataasset.go
+++ b/internal/parser/languages/dataasset.go
@@ -26,8 +26,12 @@ func (e *DataAssetExtractor) Language() string { return "data" }
 func (e *DataAssetExtractor) Extensions() []string {
 	return []string{".parquet", ".npy", ".npz", ".lance", ".arrow", ".feather"}
 }
+func (e *DataAssetExtractor) AssetClass() parser.AssetClass { return parser.AssetData }
 
-var _ parser.StreamingExtractor = (*DataAssetExtractor)(nil)
+var (
+	_ parser.StreamingExtractor = (*DataAssetExtractor)(nil)
+	_ parser.AssetExtractor     = (*DataAssetExtractor)(nil)
+)
 
 func (e *DataAssetExtractor) Extract(filePath string, src []byte) (*parser.ExtractionResult, error) {
 	sum := sha256.Sum256(src)

--- a/internal/parser/languages/multimodal.go
+++ b/internal/parser/languages/multimodal.go
@@ -45,6 +45,9 @@ func (e *ImageAssetExtractor) Language() string { return "image" }
 func (e *ImageAssetExtractor) Extensions() []string {
 	return []string{".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff", ".tif", ".ico", ".svg"}
 }
+func (e *ImageAssetExtractor) AssetClass() parser.AssetClass { return parser.AssetImage }
+
+var _ parser.AssetExtractor = (*ImageAssetExtractor)(nil)
 
 var svgOpenRe = regexp.MustCompile(`(?is)<svg\b[^>]*>`)
 var svgAttrRe = regexp.MustCompile(`(?i)\b(width|height)\s*=\s*["']?\s*([0-9.]+)`)
@@ -151,8 +154,9 @@ type PDFExtractor struct{}
 
 func NewPDFExtractor() *PDFExtractor { return &PDFExtractor{} }
 
-func (e *PDFExtractor) Language() string     { return "pdf" }
-func (e *PDFExtractor) Extensions() []string { return []string{".pdf"} }
+func (e *PDFExtractor) Language() string              { return "pdf" }
+func (e *PDFExtractor) Extensions() []string          { return []string{".pdf"} }
+func (e *PDFExtractor) AssetClass() parser.AssetClass { return parser.AssetDocument }
 
 // pdfPageTextCap bounds the per-page text stored on a KindDoc node so a
 // large PDF can't bloat the graph; the head of each page is enough for
@@ -160,8 +164,12 @@ func (e *PDFExtractor) Extensions() []string { return []string{".pdf"} }
 const pdfPageTextCap = 4000
 
 // compile-time guarantee that PDFExtractor offers the streaming route the
-// indexer prefers (one page at a time, never the whole file in memory).
-var _ parser.StreamingExtractor = (*PDFExtractor)(nil)
+// indexer prefers (one page at a time, never the whole file in memory), and
+// that it is gated as a document asset.
+var (
+	_ parser.StreamingExtractor = (*PDFExtractor)(nil)
+	_ parser.AssetExtractor     = (*PDFExtractor)(nil)
+)
 
 func (e *PDFExtractor) Extract(filePath string, src []byte) (*parser.ExtractionResult, error) {
 	result := &parser.ExtractionResult{}

--- a/internal/parser/languages/office.go
+++ b/internal/parser/languages/office.go
@@ -121,10 +121,14 @@ type PptxExtractor struct{}
 
 func NewPptxExtractor() *PptxExtractor { return &PptxExtractor{} }
 
-func (e *PptxExtractor) Language() string     { return "pptx" }
-func (e *PptxExtractor) Extensions() []string { return []string{".pptx"} }
+func (e *PptxExtractor) Language() string              { return "pptx" }
+func (e *PptxExtractor) Extensions() []string          { return []string{".pptx"} }
+func (e *PptxExtractor) AssetClass() parser.AssetClass { return parser.AssetDocument }
 
-var _ parser.StreamingExtractor = (*PptxExtractor)(nil)
+var (
+	_ parser.StreamingExtractor = (*PptxExtractor)(nil)
+	_ parser.AssetExtractor     = (*PptxExtractor)(nil)
+)
 
 func (e *PptxExtractor) Extract(filePath string, src []byte) (*parser.ExtractionResult, error) {
 	res := &parser.ExtractionResult{}
@@ -177,10 +181,14 @@ type XlsxExtractor struct{}
 
 func NewXlsxExtractor() *XlsxExtractor { return &XlsxExtractor{} }
 
-func (e *XlsxExtractor) Language() string     { return "xlsx" }
-func (e *XlsxExtractor) Extensions() []string { return []string{".xlsx"} }
+func (e *XlsxExtractor) Language() string              { return "xlsx" }
+func (e *XlsxExtractor) Extensions() []string          { return []string{".xlsx"} }
+func (e *XlsxExtractor) AssetClass() parser.AssetClass { return parser.AssetDocument }
 
-var _ parser.StreamingExtractor = (*XlsxExtractor)(nil)
+var (
+	_ parser.StreamingExtractor = (*XlsxExtractor)(nil)
+	_ parser.AssetExtractor     = (*XlsxExtractor)(nil)
+)
 
 func (e *XlsxExtractor) Extract(filePath string, src []byte) (*parser.ExtractionResult, error) {
 	res := &parser.ExtractionResult{}

--- a/internal/parser/languages/plaintext.go
+++ b/internal/parser/languages/plaintext.go
@@ -19,10 +19,14 @@ type TextExtractor struct{}
 
 func NewTextExtractor() *TextExtractor { return &TextExtractor{} }
 
-func (e *TextExtractor) Language() string     { return "text" }
-func (e *TextExtractor) Extensions() []string { return []string{".txt", ".text"} }
+func (e *TextExtractor) Language() string              { return "text" }
+func (e *TextExtractor) Extensions() []string          { return []string{".txt", ".text"} }
+func (e *TextExtractor) AssetClass() parser.AssetClass { return parser.AssetDocument }
 
-var _ parser.StreamingExtractor = (*TextExtractor)(nil)
+var (
+	_ parser.StreamingExtractor = (*TextExtractor)(nil)
+	_ parser.AssetExtractor     = (*TextExtractor)(nil)
+)
 
 func (e *TextExtractor) Extract(filePath string, src []byte) (*parser.ExtractionResult, error) {
 	res := &parser.ExtractionResult{}

--- a/internal/parser/registry.go
+++ b/internal/parser/registry.go
@@ -115,3 +115,18 @@ func (r *Registry) SupportedLanguages() []string {
 	}
 	return langs
 }
+
+// AssetClasses maps each registered language whose extractor is an
+// AssetExtractor to its AssetClass. Languages backed by ordinary code
+// extractors are absent. The indexer builds this once before a walk so it
+// can apply corpus-admission caps by language without a per-file interface
+// assertion.
+func (r *Registry) AssetClasses() map[string]AssetClass {
+	out := make(map[string]AssetClass)
+	for lang, ext := range r.extractors {
+		if class := AssetClassOf(ext); class != "" {
+			out[lang] = class
+		}
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

Fixes the content-repo OOM in #120. A RAG corpus (the reporter's repo: ~2,045 admitted files / ~4.42 GiB, ~85% pptx/xlsx/pdf, ~99% non-source documents + vector data) could exhaust memory during indexing because **every document and data artifact was admitted into the read+extract pipeline with no per-class cap and no opt-out** — so a few hundred large non-source files pulled gigabytes into memory.

Prior fixes bounded the symptom (#132 large-read gate, #137 bytes-in-flight semaphore + shadow-bytes guard + content/code split) but not the cause: there was no *corpus admission* control. This adds one.

## What changed

A walk-time **corpus-admission gate** drops non-source artifacts **before** they are read and extracted:

- Non-code extractors declare an `AssetClass` (`document` / `data` / `image`) via a new `parser.AssetExtractor` marker interface. The indexer builds a `language -> class` map from the registry once per walk (inert for all-code repos).
- **Documents** (pdf/pptx/xlsx/text) over a per-file cap (**default 10 MiB**) are skipped with `skip_reason: large_document`.
- **Binary/vector data** (parquet/npy/npz/lance/arrow/feather) are **skipped entirely by default** with `skip_reason: vector_data`.

Skipped files become synthetic `KindFile` nodes (`skipped_due_to_content`) so they stay listable and roll up in `index_health`, mirroring the existing size/timeout skip telemetry. The gate runs on **both** the cold `IndexCtx` walk and the incremental `indexFile` (watcher) path, so the live path can't re-admit what the cold path skipped.

Markdown prose and code are never gated.

## Configuration

All behaviour is configurable under `index.content`:

```yaml
index:
  content:
    max_document_bytes: 10485760   # >0 cap | 0 default | <0 no cap
    index_data: false              # opt in to admit data assets
    max_data_bytes: 67108864       # cap applied only when index_data is on
```

Caps are tri-state (`>0` cap / `0` built-in default / `<0` no cap), so a zero-valued config still yields the correct defaults regardless of how it was constructed. Users who want the prior behaviour set `max_document_bytes: -1` and `index_data: true`.

## Behaviour change

This changes defaults for existing users: documents over 10 MiB and all vector/data artifacts are no longer indexed unless opted in. This is the intended outcome per the issue discussion — the multimodal feature stays intact for normal-size documents.

## Validation

- `go build ./...` (CGO) — success
- `go test -race ./internal/config/... ./internal/parser/...` — 1942 passed
- `go test -race ./internal/indexer/` — 668 passed (incl. new `content_admission_test.go`)
- `go vet` + `golangci-lint` on changed packages — clean
- `cmd/gortex` wire-contract golden — unaffected (no graph node/edge field change)
- Confirmed no test fixtures regress (data-asset files only exist under `eval/.venv/`)

## Notes

The in-memory `gortex init` path (`graph.New`, nil content sink) still retains full section text; the admission gate shrinks how much it accumulates, but unconditional content-node leaning was intentionally skipped to avoid regressing in-memory content search on the `--backend memory` case. Left as a possible follow-up.

Closes #120