### PR TITLE
feat(intake): apply admission gates in the dry-run manifest

### DIFF
--- a/internal/indexer/content_admission_test.go
+++ b/internal/indexer/content_admission_test.go
@@ -226,6 +226,73 @@ func TestIndex_SkipUntrackedAssets(t *testing.T) {
 	require.Nil(t, un.Meta["skip_reason"], "with the flag off, an untracked document is admitted")
 }
 
+// bucketByKey finds an intake bucket by its extension key.
+func bucketByKey(buckets []IntakeBucket, key string) (IntakeBucket, bool) {
+	for _, b := range buckets {
+		if b.Key == key {
+			return b, true
+		}
+	}
+	return IntakeBucket{}, false
+}
+
+// TestDryRunIntake_ReflectsContentGate verifies the dry-run manifest reports
+// oversized documents and data assets as skipped with the same reasons the
+// real index walk uses — so the preflight matches the indexer (#120).
+func TestDryRunIntake_ReflectsContentGate(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "code.go"), "package main\n\nfunc A() {}\n")
+	writeFile(t, filepath.Join(dir, "small.txt"), "short")
+	writeFile(t, filepath.Join(dir, "big.txt"), strings.Repeat("filler text ", 400))
+	writeFile(t, filepath.Join(dir, "vectors.npy"), "NUMPY-placeholder-bytes")
+
+	idx := newAssetTestIndexer(graph.New())
+	idx.config.Content.MaxDocumentBytes = 1024
+
+	m, err := idx.DryRunIntake(testCtx(), dir)
+	require.NoError(t, err)
+
+	txt, ok := bucketByKey(m.TopSkippedExtensionsByBytes, "txt")
+	require.True(t, ok, "oversized document must be reported skipped")
+	require.Equal(t, skipReasonLargeDocument, txt.Reason)
+	npy, ok := bucketByKey(m.TopSkippedExtensionsByBytes, "npy")
+	require.True(t, ok, "data asset must be reported skipped")
+	require.Equal(t, skipReasonVectorData, npy.Reason)
+
+	// Code and the small document stay admitted.
+	_, ok = bucketByKey(m.TopAdmittedExtensionsByBytes, "go")
+	require.True(t, ok)
+	smallTxt, ok := bucketByKey(m.TopAdmittedExtensionsByBytes, "txt")
+	require.True(t, ok)
+	require.Equal(t, 1, smallTxt.Files, "only the small document is admitted")
+}
+
+// TestDryRunIntake_ReflectsUntrackedGate verifies the dry-run manifest applies
+// the opt-in untracked-asset gate too.
+func TestDryRunIntake_ReflectsUntrackedGate(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available in PATH")
+	}
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-q", "-b", "main")
+	runGit(t, dir, "config", "user.email", "t@example.com")
+	runGit(t, dir, "config", "user.name", "T")
+	runGit(t, dir, "config", "commit.gpgsign", "false")
+	writeFile(t, filepath.Join(dir, "code.go"), "package main\n\nfunc A() {}\n")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-q", "-m", "init")
+	writeFile(t, filepath.Join(dir, "untracked.txt"), "scratch asset")
+
+	idx := newAssetTestIndexer(graph.New())
+	idx.config.SkipUntrackedAssets = true
+
+	m, err := idx.DryRunIntake(testCtx(), dir)
+	require.NoError(t, err)
+	txt, ok := bucketByKey(m.TopSkippedExtensionsByBytes, "txt")
+	require.True(t, ok)
+	require.Equal(t, skipReasonUntrackedAsset, txt.Reason)
+}
+
 // TestGitTrackedSet_NonGitDirInert verifies gitTrackedSet reports failure
 // (gate inert) outside a git repo.
 func TestGitTrackedSet_NonGitDirInert(t *testing.T) {

--- a/internal/indexer/intake_manifest.go
+++ b/internal/indexer/intake_manifest.go
@@ -54,13 +54,22 @@ type FileBucket struct {
 // DryRunIntake walks root with the same high-level language, ignore, prune and
 // max-size gates used before IndexCtx starts extraction. It does not parse,
 // extract, embed, or store anything.
-func (idx *Indexer) DryRunIntake(_ context.Context, root string) (*IntakeManifest, error) {
+func (idx *Indexer) DryRunIntake(ctx context.Context, root string) (*IntakeManifest, error) {
 	absRoot, err := filepath.Abs(root)
 	if err != nil {
 		return nil, err
 	}
 
 	maxSize := idx.config.MaxFileSize
+	// Apply the same corpus-admission gates the real index walk uses, so the
+	// manifest's admitted/skipped split matches what IndexCtx would actually
+	// do — oversized documents and (by default) data assets are reported as
+	// skipped (large_document / vector_data / large_data_asset), and, when
+	// index.skip_untracked_assets is on, untracked assets as untracked_asset.
+	// Without this the report would still count gigabytes of non-source files
+	// as admitted even though the indexer now drops them (#120).
+	contentGate := idx.newContentAdmissionGate()
+	untrackedGate := idx.newUntrackedAssetGate(ctx, absRoot)
 	manifest := &IntakeManifest{
 		SchemaVersion:           "gortex.index_intake.v1",
 		RawPathsIncluded:        false,
@@ -98,6 +107,10 @@ func (idx *Indexer) DryRunIntake(_ context.Context, root string) (*IntakeManifes
 			reason = "excluded"
 		} else if maxSize > 0 && size > maxSize {
 			reason = "max_file_size"
+		} else if r, skip := untrackedGate.skip(lang, path); skip {
+			reason = r
+		} else if r, skip := contentGate.skip(lang, size); skip {
+			reason = r
 		}
 
 		if reason != "" {
@@ -112,7 +125,6 @@ func (idx *Indexer) DryRunIntake(_ context.Context, root string) (*IntakeManifes
 			return nil
 		}
 
-		_ = lang // language detection is the admission gate; buckets stay extension-based for issue reports.
 		manifest.FilesAdmitted++
 		manifest.BytesAdmitted += size
 


### PR DESCRIPTION
## Summary

Follow-up to #163 (now merged) that closes the gap I flagged when it landed alongside #181 / #182.

`gortex init --dry-run-intake` reuses the index walk's language / exclude / max-size gates, but **not** the content-admission gate (#181) or the untracked-asset gate (#182). So after those merged, the manifest still counted oversized documents, data assets, and untracked files as **admitted** even though the indexer now drops them — the privacy-safe preflight no longer matched what the indexer would actually do.

`DryRunIntake` now builds both gates and applies them in the **same order as the real walk** (`no_language` → `excluded` → `max_file_size` → `untracked_asset` → content caps). Skipped buckets carry `large_document` / `vector_data` / `large_data_asset` / `untracked_asset` reasons, and `bytes_admitted` reflects the corpus the indexer would really parse. The `ctx` parameter (previously ignored) is now used to resolve the git tracked-set for the untracked gate.

This makes the manifest the accurate "rerun and confirm admitted bytes dropped" check it was designed to be — e.g. for the #120 reporter, admitted bytes now report ~50–65% lower instead of the full 4.42 GiB.

## Changes
- `internal/indexer/intake_manifest.go` — apply `newContentAdmissionGate()` + `newUntrackedAssetGate(ctx, absRoot)` in `DryRunIntake`.
- `internal/indexer/content_admission_test.go` — `TestDryRunIntake_ReflectsContentGate` (oversized doc → `large_document`, `.npy` → `vector_data`, code + small doc still admitted) and `TestDryRunIntake_ReflectsUntrackedGate` (untracked asset → `untracked_asset`).

## Validation
- `go build ./...` (CGO) — success
- `go test -race ./internal/indexer/` — 672 passed
- `go test ./cmd/gortex/ -run 'Intake|Init'` — 13 passed (the existing `--dry-run-intake` no-write test still passes)
- `go vet` + `golangci-lint` on changed packages — clean

Relates to #120. Builds on #163 / #181 / #182 (all merged).