### PR TITLE
Fix Spring datasource config and @Bean consumer resolution

### DIFF
--- a/internal/contracts/spring_config.go
+++ b/internal/contracts/spring_config.go
@@ -38,6 +38,7 @@ func springConfigKeyID(key string) string {
 // springConfigFile reports whether path is a Spring application config file and
 // returns its profile (the `-prod` in application-prod.yml; "" for the base).
 func springConfigFile(path string) (profile string, ok bool) {
+	path = strings.ReplaceAll(path, "\\", "/")
 	base := path
 	if i := strings.LastIndexByte(path, '/'); i >= 0 {
 		base = path[i+1:]

--- a/internal/contracts/spring_config_test.go
+++ b/internal/contracts/spring_config_test.go
@@ -97,6 +97,7 @@ func TestSpringConfigFileDetection(t *testing.T) {
 	}{
 		{"application.yml", true, ""},
 		{"src/main/resources/application.yaml", true, ""},
+		{`src\main\resources\application.yml`, true, ""},
 		{"application-prod.properties", true, "prod"},
 		{"config/application-staging.yml", true, "staging"},
 		{"other.yml", false, ""},

--- a/internal/indexer/di_contracts.go
+++ b/internal/indexer/di_contracts.go
@@ -132,10 +132,10 @@ func (idx *Indexer) linkSpringBeans() {
 		}
 	}
 
-	// For each bean, walk Java constructor nodes whose params_src
-	// (captured at extraction time) mentions the return type. Dedupe
-	// by (consumer_class, bean_method) so an overloaded constructor
-	// only links once.
+	// For each bean, walk Java constructors and @Bean factory methods
+	// whose params_src (captured at extraction time) mentions the return
+	// type. Dedupe by (consumer_class, bean_method) so an overloaded
+	// constructor or factory method only links once.
 	linked := make(map[string]struct{})
 	for _, b := range beans {
 		for _, n := range candidates {

--- a/internal/indexer/spring_datasource_test.go
+++ b/internal/indexer/spring_datasource_test.go
@@ -101,6 +101,45 @@ public class JdbcConfig {
 		"JdbcConfig should have a spring.Bean edge to the DataSource factory because jdbcTemplate consumes DataSource")
 }
 
+func TestIndex_SpringDataSourcePlainMethodDoesNotLinkBeanFactory(t *testing.T) {
+	dir := t.TempDir()
+	javaDir := filepath.Join(dir, "src", "main", "java", "com", "example")
+	require.NoError(t, os.MkdirAll(javaDir, 0o755))
+
+	writeFile(t, filepath.Join(javaDir, "JdbcConfig.java"), `
+package com.example;
+
+import javax.sql.DataSource;
+import org.springframework.context.annotation.Bean;
+
+public class JdbcConfig {
+    @Bean
+    DataSource dataSource() {
+        return null;
+    }
+
+    void inspect(DataSource dataSource) {
+    }
+}
+`)
+
+	g := graph.New()
+	reg := parser.NewRegistry()
+	languages.RegisterAll(reg)
+	idx := New(g, reg, config.Default().Index, zap.NewNop())
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+
+	javaGraphPath := filepath.Join("src", "main", "java", "com", "example", "JdbcConfig.java")
+	classID := javaGraphPath + "::JdbcConfig"
+	dataSourceID := classID + ".dataSource"
+	if hasEdge(g, classID, dataSourceID, graph.EdgeCalls) {
+		t.Logf("calls edges: %v", edgePairsOfKind(g, graph.EdgeCalls))
+	}
+	require.False(t, hasEdge(g, classID, dataSourceID, graph.EdgeCalls),
+		"a plain method parameter should not make the class look like a Spring bean consumer")
+}
+
 func hasEdge(g *graph.Graph, from, to string, kind graph.EdgeKind) bool {
 	for _, e := range g.AllEdges() {
 		if e.From == from && e.To == to && e.Kind == kind {

--- a/internal/indexer/spring_datasource_test.go
+++ b/internal/indexer/spring_datasource_test.go
@@ -1,0 +1,131 @@
+package indexer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+func TestIndex_SpringDatasourceConditionalOnPropertyReadsConfig(t *testing.T) {
+	dir := t.TempDir()
+	javaDir := filepath.Join(dir, "src", "main", "java", "com", "example")
+	resDir := filepath.Join(dir, "src", "main", "resources")
+	require.NoError(t, os.MkdirAll(javaDir, 0o755))
+	require.NoError(t, os.MkdirAll(resDir, 0o755))
+
+	writeFile(t, filepath.Join(javaDir, "JdbcConfig.java"), `
+package com.example;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty(prefix = "spring.datasource", name = "url")
+public class JdbcConfig {
+}
+`)
+	writeFile(t, filepath.Join(resDir, "application.yml"), `
+spring:
+  datasource:
+    url: jdbc:h2:mem:test
+    username: sa
+`)
+
+	g := graph.New()
+	reg := parser.NewRegistry()
+	languages.RegisterAll(reg)
+	idx := New(g, reg, config.Default().Index, zap.NewNop())
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+
+	javaGraphPath := filepath.Join("src", "main", "java", "com", "example", "JdbcConfig.java")
+	cfgID := javaGraphPath + "::JdbcConfig"
+	keyID := "cfg::spring::spring.datasource.url"
+	if g.GetNode(keyID) == nil {
+		t.Logf("file nodes: %v", nodeIDsOfKind(g, graph.KindFile))
+		t.Logf("config nodes: %v", nodeIDsOfKind(g, graph.KindConfigKey))
+	}
+	require.NotNil(t, g.GetNode(keyID), "spring.datasource.url config key should be indexed")
+	require.True(t, hasEdge(g, cfgID, keyID, graph.EdgeReadsConfig),
+		"JdbcConfig should read spring.datasource.url via @ConditionalOnProperty")
+}
+
+func TestIndex_SpringExplicitDataSourceBeanLinksToBeanConsumers(t *testing.T) {
+	dir := t.TempDir()
+	javaDir := filepath.Join(dir, "src", "main", "java", "com", "example")
+	require.NoError(t, os.MkdirAll(javaDir, 0o755))
+
+	writeFile(t, filepath.Join(javaDir, "JdbcConfig.java"), `
+package com.example;
+
+import javax.sql.DataSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+public class JdbcConfig {
+    @Bean
+    DataSource dataSource() {
+        return null;
+    }
+
+    @Bean
+    JdbcTemplate jdbcTemplate(DataSource dataSource) {
+        return new JdbcTemplate(dataSource);
+    }
+}
+`)
+
+	g := graph.New()
+	reg := parser.NewRegistry()
+	languages.RegisterAll(reg)
+	idx := New(g, reg, config.Default().Index, zap.NewNop())
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+
+	javaGraphPath := filepath.Join("src", "main", "java", "com", "example", "JdbcConfig.java")
+	classID := javaGraphPath + "::JdbcConfig"
+	dataSourceID := classID + ".dataSource"
+	if !hasEdge(g, classID, dataSourceID, graph.EdgeCalls) {
+		t.Logf("calls edges: %v", edgePairsOfKind(g, graph.EdgeCalls))
+		t.Logf("provides edges: %v", edgePairsOfKind(g, graph.EdgeProvides))
+	}
+	require.True(t, hasEdge(g, classID, dataSourceID, graph.EdgeCalls),
+		"JdbcConfig should have a spring.Bean edge to the DataSource factory because jdbcTemplate consumes DataSource")
+}
+
+func hasEdge(g *graph.Graph, from, to string, kind graph.EdgeKind) bool {
+	for _, e := range g.AllEdges() {
+		if e.From == from && e.To == to && e.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func nodeIDsOfKind(g *graph.Graph, kind graph.NodeKind) []string {
+	var out []string
+	for _, n := range g.AllNodes() {
+		if n.Kind == kind {
+			out = append(out, n.ID)
+		}
+	}
+	return out
+}
+
+func edgePairsOfKind(g *graph.Graph, kind graph.EdgeKind) []string {
+	var out []string
+	for _, e := range g.AllEdges() {
+		if e.Kind == kind {
+			out = append(out, e.From+"->"+e.To)
+		}
+	}
+	return out
+}

--- a/internal/parser/languages/java.go
+++ b/internal/parser/languages/java.go
@@ -711,12 +711,15 @@ func (e *JavaExtractor) emitMethod(m parser.QueryResult, filePath, fileID string
 				"visibility":  javaVisibility(def.Node, src, VisibilityPackage),
 			},
 		}
+		isSpringBeanMethod := def.Node != nil && javaMethodHasAnnotation(def.Node, src, "Bean")
 		if def.Node != nil {
 			if rt := extractJavaMethodReturnType(def.Node, src); rt != "" {
 				node.Meta["return_type"] = rt
 			}
-			if params := javaParamsSource(def.Node, src); params != "" {
-				node.Meta["params_src"] = params
+			if isSpringBeanMethod {
+				if params := javaParamsSource(def.Node, src); params != "" {
+					node.Meta["params_src"] = params
+				}
 			}
 		}
 		if doc := ExtractDocAbove(src, def.StartLine, DocLangBlockStar); doc != "" {
@@ -755,7 +758,7 @@ func (e *JavaExtractor) emitMethod(m parser.QueryResult, filePath, fileID string
 		// type. Emit an EdgeProvides from the config class to the
 		// method so the indexer's DI post-pass links consumers typed
 		// as the return type back to this factory.
-		if def.Node != nil && javaMethodHasAnnotation(def.Node, src, "Bean") {
+		if isSpringBeanMethod {
 			if rt, _ := node.Meta["return_type"].(string); rt != "" {
 				result.Edges = append(result.Edges, &graph.Edge{
 					From:     classID,

--- a/internal/parser/languages/java.go
+++ b/internal/parser/languages/java.go
@@ -514,16 +514,19 @@ func (e *JavaExtractor) emitClass(m parser.QueryResult, filePath, fileID string,
 	if parent := extractJavaParentClass(def.Node, src); parent != "" {
 		meta["scope_parent"] = parent
 	}
-	result.Nodes = append(result.Nodes, &graph.Node{
+	anns := javaCollectAnnotations(def.Node, src)
+	node := &graph.Node{
 		ID: id, Kind: graph.KindType, Name: name,
 		FilePath: filePath, StartLine: def.StartLine + 1, EndLine: def.EndLine + 1,
 		Language: "java",
 		Meta:     meta,
-	})
+	}
+	stampJavaSpringConfigAnnotations(node, anns)
+	result.Nodes = append(result.Nodes, node)
 	result.Edges = append(result.Edges, &graph.Edge{
 		From: fileID, To: id, Kind: graph.EdgeDefines, FilePath: filePath, Line: def.StartLine + 1,
 	})
-	emitJavaAnnotationEdges(javaCollectAnnotations(def.Node, src), id, filePath, result, annotationSeen)
+	emitJavaAnnotationEdges(anns, id, filePath, result, annotationSeen)
 	emitJavaGenericParamNodes(id, def.Node, src, filePath, def.StartLine+1, result)
 	// JPA model attribution: @Entity / @Table → EdgeModelsTable.
 	emitJavaORMEdges(def.Node, src, id, name, filePath, result)
@@ -712,10 +715,15 @@ func (e *JavaExtractor) emitMethod(m parser.QueryResult, filePath, fileID string
 			if rt := extractJavaMethodReturnType(def.Node, src); rt != "" {
 				node.Meta["return_type"] = rt
 			}
+			if params := javaParamsSource(def.Node, src); params != "" {
+				node.Meta["params_src"] = params
+			}
 		}
 		if doc := ExtractDocAbove(src, def.StartLine, DocLangBlockStar); doc != "" {
 			node.Meta["doc"] = doc
 		}
+		anns := javaCollectAnnotations(def.Node, src)
+		stampJavaSpringConfigAnnotations(node, anns)
 		if def.Node != nil {
 			if body := def.Node.ChildByFieldName("body"); body != nil {
 				StampFunctionMetrics(node, body, "java")
@@ -724,7 +732,7 @@ func (e *JavaExtractor) emitMethod(m parser.QueryResult, filePath, fileID string
 		// React Native: an @ReactMethod method is callable from JS as
 		// NativeModules.<module>.<method>(...). Stamp the JS module +
 		// method so the bridge synthesizer can land the JS call here.
-		if def.Node != nil && javaHasReactMethod(javaCollectAnnotations(def.Node, src)) {
+		if def.Node != nil && javaHasReactMethod(anns) {
 			node.Meta["rn_method"] = name
 			if mod := rnModules[className]; mod != "" {
 				node.Meta["rn_module"] = mod
@@ -762,7 +770,7 @@ func (e *JavaExtractor) emitMethod(m parser.QueryResult, filePath, fileID string
 				})
 			}
 		}
-		emitJavaAnnotationEdges(javaCollectAnnotations(def.Node, src), id, filePath, result, annotationSeen)
+		emitJavaAnnotationEdges(anns, id, filePath, result, annotationSeen)
 		emitJavaThrowsEdges(def.Node, src, id, filePath, startLine1, result)
 		emitJavaFunctionShape(id, def.Node, src, filePath, startLine1, result)
 		return

--- a/internal/parser/languages/java_spring_config.go
+++ b/internal/parser/languages/java_spring_config.go
@@ -16,6 +16,10 @@ var (
 	// @ConfigurationProperties("p") prefix. Group 1 is the prefix.
 	javaConfPropsRe = regexp.MustCompile(`@ConfigurationProperties\s*\(\s*(?:prefix\s*=\s*)?["']([^"']+)["']`)
 	javaStringLitRe = regexp.MustCompile(`["']([^"']+)["']`)
+
+	javaAnnotationPrefixArgRe = regexp.MustCompile(`(?:^|[,{ \t\r\n])prefix\s*=\s*(\{[^}]*\}|["'][^"']*["'])`)
+	javaAnnotationNameArgRe   = regexp.MustCompile(`(?:^|[,{ \t\r\n])name\s*=\s*(\{[^}]*\}|["'][^"']*["'])`)
+	javaAnnotationValueArgRe  = regexp.MustCompile(`(?:^|[,{ \t\r\n])value\s*=\s*(\{[^}]*\}|["'][^"']*["'])`)
 )
 
 // mineSpringConfigReads stamps the Spring property keys a bean reads onto its
@@ -196,12 +200,28 @@ func firstJavaAnnotationStringArg(args, name string) string {
 }
 
 func javaAnnotationStringArgs(args, name string) []string {
-	re := regexp.MustCompile(`(?:^|[,{ \t\r\n])` + regexp.QuoteMeta(name) + `\s*=\s*(\{[^}]*\}|["'][^"']*["'])`)
+	re := javaAnnotationStringArgRe(name)
+	if re == nil {
+		return nil
+	}
 	m := re.FindStringSubmatch(args)
 	if len(m) < 2 {
 		return nil
 	}
 	return javaStringLiterals(m[1])
+}
+
+func javaAnnotationStringArgRe(name string) *regexp.Regexp {
+	switch name {
+	case "prefix":
+		return javaAnnotationPrefixArgRe
+	case "name":
+		return javaAnnotationNameArgRe
+	case "value":
+		return javaAnnotationValueArgRe
+	default:
+		return nil
+	}
 }
 
 func javaStringLiterals(s string) []string {

--- a/internal/parser/languages/java_spring_config.go
+++ b/internal/parser/languages/java_spring_config.go
@@ -2,6 +2,7 @@ package languages
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/parser"
@@ -14,6 +15,7 @@ var (
 	// javaConfPropsRe captures an @ConfigurationProperties(prefix = "p") /
 	// @ConfigurationProperties("p") prefix. Group 1 is the prefix.
 	javaConfPropsRe = regexp.MustCompile(`@ConfigurationProperties\s*\(\s*(?:prefix\s*=\s*)?["']([^"']+)["']`)
+	javaStringLitRe = regexp.MustCompile(`["']([^"']+)["']`)
 )
 
 // mineSpringConfigReads stamps the Spring property keys a bean reads onto its
@@ -36,6 +38,11 @@ func mineSpringConfigReads(src []byte, result *parser.ExtractionResult) {
 	}
 	var types []typeRange
 	for _, n := range result.Nodes {
+		if n.Meta != nil {
+			if k, _ := n.Meta["kind"].(string); k == "annotation" {
+				continue
+			}
+		}
 		if n.Kind == graph.KindType || n.Kind == graph.KindInterface {
 			types = append(types, typeRange{n.ID, n.StartLine, n.EndLine})
 		}
@@ -77,16 +84,7 @@ func mineSpringConfigReads(src []byte, result *parser.ExtractionResult) {
 		if n == nil {
 			return
 		}
-		if n.Meta == nil {
-			n.Meta = map[string]any{}
-		}
-		existing, _ := n.Meta["spring_config_keys"].([]string)
-		for _, e := range existing {
-			if e == key {
-				return
-			}
-		}
-		n.Meta["spring_config_keys"] = append(existing, key)
+		appendJavaSpringConfigKey(n, key)
 	}
 
 	if hasValue {
@@ -111,4 +109,119 @@ func mineSpringConfigReads(src []byte, result *parser.ExtractionResult) {
 			stamp(id, prefix+".*")
 		}
 	}
+}
+
+func stampJavaSpringConfigAnnotations(n *graph.Node, anns []javaAnnotation) {
+	for _, ann := range anns {
+		name := ann.name
+		if i := strings.LastIndexByte(name, '.'); i >= 0 {
+			name = name[i+1:]
+		}
+		if name != "ConditionalOnProperty" {
+			if name != "ConfigurationProperties" {
+				continue
+			}
+			if prefix := javaConfigurationPropertiesPrefix(ann.args); prefix != "" {
+				appendJavaSpringConfigKey(n, prefix+".*")
+			}
+			continue
+		}
+		for _, key := range javaConditionalOnPropertyKeys(ann.args) {
+			appendJavaSpringConfigKey(n, key)
+		}
+	}
+}
+
+func appendJavaSpringConfigKey(n *graph.Node, key string) {
+	if n == nil || key == "" {
+		return
+	}
+	if n.Meta == nil {
+		n.Meta = map[string]any{}
+	}
+	existing, _ := n.Meta["spring_config_keys"].([]string)
+	for _, e := range existing {
+		if e == key {
+			return
+		}
+	}
+	n.Meta["spring_config_keys"] = append(existing, key)
+}
+
+func javaConditionalOnPropertyKeys(args string) []string {
+	prefix := firstJavaAnnotationStringArg(args, "prefix")
+	names := javaAnnotationStringArgs(args, "name")
+	if len(names) == 0 {
+		names = javaAnnotationStringArgs(args, "value")
+	}
+	if len(names) == 0 && !strings.Contains(args, "=") {
+		names = javaStringLiterals(args)
+	}
+
+	var out []string
+	seen := map[string]bool{}
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		key := name
+		if prefix != "" {
+			key = strings.TrimSuffix(prefix, ".") + "." + strings.TrimPrefix(name, ".")
+		}
+		if key != "" && !seen[key] {
+			seen[key] = true
+			out = append(out, key)
+		}
+	}
+	return out
+}
+
+func javaConfigurationPropertiesPrefix(args string) string {
+	if prefix := firstJavaAnnotationStringArg(args, "prefix"); prefix != "" {
+		return prefix
+	}
+	if !strings.Contains(args, "=") {
+		return firstJavaStringLiteral(args)
+	}
+	return ""
+}
+
+func firstJavaAnnotationStringArg(args, name string) string {
+	vals := javaAnnotationStringArgs(args, name)
+	if len(vals) == 0 {
+		return ""
+	}
+	return vals[0]
+}
+
+func javaAnnotationStringArgs(args, name string) []string {
+	re := regexp.MustCompile(`(?:^|[,{ \t\r\n])` + regexp.QuoteMeta(name) + `\s*=\s*(\{[^}]*\}|["'][^"']*["'])`)
+	m := re.FindStringSubmatch(args)
+	if len(m) < 2 {
+		return nil
+	}
+	return javaStringLiterals(m[1])
+}
+
+func javaStringLiterals(s string) []string {
+	matches := javaStringLitRe.FindAllStringSubmatch(s, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		if len(m) > 1 {
+			out = append(out, m[1])
+		}
+	}
+	return out
+}
+
+func firstJavaStringLiteral(s string) string {
+	vals := javaStringLiterals(s)
+	if len(vals) == 0 {
+		return ""
+	}
+	return vals[0]
 }

--- a/internal/parser/languages/java_test.go
+++ b/internal/parser/languages/java_test.go
@@ -336,7 +336,10 @@ public class X {
 func TestJavaExtractor_BeanMethodParamsCaptured(t *testing.T) {
 	src := []byte(`
 package c;
+import org.springframework.context.annotation.Bean;
+
 public class X {
+    @Bean
     public JdbcTemplate jdbcTemplate(DataSource dataSource) { return null; }
 }
 `)
@@ -355,6 +358,29 @@ public class X {
 	params, _ := method.Meta["params_src"].(string)
 	assert.Contains(t, params, "DataSource")
 	assert.Contains(t, params, "dataSource")
+}
+
+func TestJavaExtractor_PlainMethodParamsNotCapturedForSpringBeanLinking(t *testing.T) {
+	src := []byte(`
+package c;
+public class X {
+    public void inspect(DataSource dataSource) {}
+}
+`)
+	e := NewJavaExtractor()
+	result, err := e.Extract("X.java", src)
+	require.NoError(t, err)
+
+	var method *graph.Node
+	for _, n := range nodesOfKind(result.Nodes, graph.KindMethod) {
+		if n.Name == "inspect" {
+			method = n
+			break
+		}
+	}
+	require.NotNil(t, method)
+	_, ok := method.Meta["params_src"]
+	assert.False(t, ok, "plain methods should not participate in Spring bean parameter matching")
 }
 
 func TestJavaExtractor_SpringConditionalOnPropertyReadsDatasource(t *testing.T) {

--- a/internal/parser/languages/java_test.go
+++ b/internal/parser/languages/java_test.go
@@ -333,6 +333,105 @@ public class X {
 	assert.Contains(t, params, "foo")
 }
 
+func TestJavaExtractor_BeanMethodParamsCaptured(t *testing.T) {
+	src := []byte(`
+package c;
+public class X {
+    public JdbcTemplate jdbcTemplate(DataSource dataSource) { return null; }
+}
+`)
+	e := NewJavaExtractor()
+	result, err := e.Extract("X.java", src)
+	require.NoError(t, err)
+
+	var method *graph.Node
+	for _, n := range nodesOfKind(result.Nodes, graph.KindMethod) {
+		if n.Name == "jdbcTemplate" {
+			method = n
+			break
+		}
+	}
+	require.NotNil(t, method)
+	params, _ := method.Meta["params_src"].(string)
+	assert.Contains(t, params, "DataSource")
+	assert.Contains(t, params, "dataSource")
+}
+
+func TestJavaExtractor_SpringConditionalOnPropertyReadsDatasource(t *testing.T) {
+	src := []byte(`
+package c;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+@ConditionalOnProperty(prefix = "spring.datasource", name = "url")
+public class JdbcConfig {
+}
+`)
+	e := NewJavaExtractor()
+	result, err := e.Extract("JdbcConfig.java", src)
+	require.NoError(t, err)
+
+	var cls *graph.Node
+	for _, n := range nodesOfKind(result.Nodes, graph.KindType) {
+		if n.Name == "JdbcConfig" {
+			cls = n
+			break
+		}
+	}
+	require.NotNil(t, cls)
+	keys, _ := cls.Meta["spring_config_keys"].([]string)
+	assert.Contains(t, keys, "spring.datasource.url")
+}
+
+func TestJavaExtractor_SpringConfigurationPropertiesStampsClass(t *testing.T) {
+	src := []byte(`
+package c;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties(prefix = "app.jdbc")
+public class JdbcFeatureProperties {
+}
+`)
+	e := NewJavaExtractor()
+	result, err := e.Extract("JdbcFeatureProperties.java", src)
+	require.NoError(t, err)
+
+	var cls *graph.Node
+	var ann *graph.Node
+	for _, n := range result.Nodes {
+		switch n.ID {
+		case "JdbcFeatureProperties.java::JdbcFeatureProperties":
+			cls = n
+		case "annotation::java::ConfigurationProperties":
+			ann = n
+		}
+	}
+	require.NotNil(t, cls)
+	keys, _ := cls.Meta["spring_config_keys"].([]string)
+	assert.Contains(t, keys, "app.jdbc.*")
+	if ann != nil {
+		_, stampedAnnotation := ann.Meta["spring_config_keys"]
+		assert.False(t, stampedAnnotation, "configuration property reads should be stamped on the annotated class")
+	}
+}
+
+func TestJavaConditionalOnPropertyKeys(t *testing.T) {
+	assert.Equal(t,
+		[]string{"spring.datasource.url", "spring.datasource.username"},
+		javaConditionalOnPropertyKeys(`prefix = "spring.datasource", name = {"url", "username"}`),
+	)
+	assert.Equal(t,
+		[]string{"spring.datasource.url"},
+		javaConditionalOnPropertyKeys(`"spring.datasource.url"`),
+	)
+}
+
+func TestJavaConfigurationPropertiesPrefix(t *testing.T) {
+	assert.Equal(t, "app.jdbc", javaConfigurationPropertiesPrefix(`prefix = "app.jdbc"`))
+	assert.Equal(t, "app.jdbc", javaConfigurationPropertiesPrefix(`"app.jdbc"`))
+}
+
 func TestJavaExtractor_DocAndVisibility(t *testing.T) {
 	src := []byte(`package x;
 


### PR DESCRIPTION
Detect Spring application config files with Windows paths, stamp @ConditionalOnProperty and @ConfigurationProperties reads onto the owning Java node, and capture method params so @Bean consumers link back to matching factory methods.

Adds regression coverage for datasource config reads, DataSource bean consumer linkage, and Spring config path detection.

## Summary

Fixes Spring datasource/config graph gaps in the Java indexer so Spring config readers and explicit `@Bean` consumers are linked to the right graph nodes.

## Changes

- Normalize Spring application config file paths so Windows `\` paths are detected.
- Parse `@ConditionalOnProperty` and stamp the resolved config keys on the owning Java class or method.
- Stamp `@ConfigurationProperties(prefix)` reads on the annotated Java class instead of the synthetic annotation node.
- Capture Java method parameter source text so Spring `@Bean` consumer methods can link back to matching factory methods by type.
- Add regression tests for datasource config reads, `DataSource` bean consumer linkage, and Windows Spring config path detection.

## Testing

- [x] All tests pass (`go test -count=1 ./...` in clean WSL/LF clone)
- [x] New tests added for new functionality
- [x] Benchmarks run if performance-relevant

## Checklist

- [x] Code follows existing patterns in the codebase
- [x] No unnecessary abstractions added
- [ ] Language extractor includes `Meta["methods"]` for interfaces (if applicable)
- [x] Methods have `EdgeMemberOf` edges to their containing type (if applicable)