### PR TITLE
fix(release): gitignore dist-darwin/ so goreleaser sees a clean tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,10 @@ __pycache__/
 dist/
 build/
 
+# Release: native-darwin archives the release job stages outside dist/ (which
+# --clean wipes). Must be ignored or goreleaser aborts on a dirty work tree.
+dist-darwin/
+
 # Testing
 .pytest_cache/
 .hypothesis/


### PR DESCRIPTION
## Problem

The `v0.53.0` release job failed ([run 28288459792](https://github.com/zzet/gortex/actions/runs/28288459792/job/83816632105)) with:

```
⨯ release failed after 0s
  error= git is in a dirty state
  Please check in your pipeline what can be changing the following files:
  ?? dist-darwin/
```

The native-darwin work added in #178 stages the macOS archives in `dist-darwin/` (downloaded as an artifact) **before** running `goreleaser release --clean`. goreleaser refuses to run on a dirty work tree, and the untracked `dist-darwin/` tripped that check, so goreleaser aborted before creating the release — no `v0.53.0` artifacts were published.

## Fix

`dist/` (goreleaser's own output) was already in `.gitignore` for exactly this reason; `dist-darwin/` was simply missed. Ignore it too:

```gitignore
# Release: native-darwin archives the release job stages outside dist/ (which
# --clean wipes). Must be ignored or goreleaser aborts on a dirty work tree.
dist-darwin/
```

## Verification

With `dist-darwin/` populated, `git status --porcelain` (what goreleaser's dirty check reads) no longer reports it; `git status --porcelain --ignored` confirms the rule matches (`!! dist-darwin/`). This fixes future releases, matching #178's note about the release path.

## Follow-up

The `v0.53.0` tag produced no release artifacts (goreleaser aborted). After this merges, re-cut the tag (delete + re-push `v0.53.0`, or bump to `v0.53.1`) to actually publish the release.