### PR TITLE
perf: cut single-file reindex latency (FTS docid delete, scoped attribution, candidate cache)

### DIFF
--- a/internal/graph/store_sqlite/fts_rowid_test.go
+++ b/internal/graph/store_sqlite/fts_rowid_test.go
@@ -1,0 +1,149 @@
+package store_sqlite
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func ftsRowCount(t *testing.T, s *Store, table, nodeID string) int {
+	t.Helper()
+	var n int
+	q := `SELECT count(*) FROM ` + table + ` WHERE node_id = ?`
+	if err := s.db.QueryRow(q, nodeID).Scan(&n); err != nil {
+		t.Fatalf("count %s: %v", table, err)
+	}
+	return n
+}
+
+func ftsHits(t *testing.T, s *Store, query string) int {
+	t.Helper()
+	hits, err := s.SearchSymbols(query, 20)
+	if err != nil {
+		t.Fatalf("SearchSymbols(%q): %v", query, err)
+	}
+	return len(hits)
+}
+
+// TestUpsertSymbolFTS_ReplacesWithoutDuplicates is the core correctness
+// guard for the rowid-map delete: re-upserting a symbol must drop its prior
+// row (by docid) and leave exactly one FTS row + one map row. A wrong
+// LastInsertId / stale map would leave the old tokens searchable and the
+// row count at 2 — so this also proves the FTS5 docid round-trips.
+func TestUpsertSymbolFTS_ReplacesWithoutDuplicates(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "fts.sqlite"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	const id = "pkg/x.go::A"
+	s.AddNode(mkFnNode(id, "AlphaWidget", "pkg/x.go"))
+
+	// Upsert three times: first insert, then two replacements that each
+	// exercise the mapped-entry docid delete.
+	for _, tokens := range []string{"alpha widget red", "alpha widget green", "alpha widget blue"} {
+		if err := s.UpsertSymbolFTS(id, tokens); err != nil {
+			t.Fatalf("UpsertSymbolFTS(%q): %v", tokens, err)
+		}
+	}
+
+	if got := ftsRowCount(t, s, "symbol_fts", id); got != 1 {
+		t.Fatalf("symbol_fts rows for %s = %d, want 1 (duplicate row leaked)", id, got)
+	}
+	if got := ftsRowCount(t, s, "symbol_fts_rowid", id); got != 1 {
+		t.Fatalf("symbol_fts_rowid rows for %s = %d, want 1", id, got)
+	}
+	// Only the latest tokens are searchable; the superseded ones are gone.
+	if got := ftsHits(t, s, "blue"); got != 1 {
+		t.Fatalf("search 'blue' (current tokens) = %d hits, want 1", got)
+	}
+	for _, stale := range []string{"red", "green"} {
+		if got := ftsHits(t, s, stale); got != 0 {
+			t.Fatalf("search %q (superseded tokens) = %d hits, want 0 (delete missed)", stale, got)
+		}
+	}
+}
+
+// TestBulkUpsertSymbolFTS_MaintainsRowidMap proves the bulk path keeps the
+// sidecar in lockstep, and that a follow-up incremental upsert on a
+// bulk-loaded symbol still replaces cleanly (no duplicate).
+func TestBulkUpsertSymbolFTS_MaintainsRowidMap(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "fts.sqlite"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	s.AddNode(mkFnNode("pkg/x.go::A", "AlphaWidget", "pkg/x.go"))
+	s.AddNode(mkFnNode("pkg/x.go::B", "BetaWidget", "pkg/x.go"))
+	if err := s.BulkUpsertSymbolFTS("", []graph.SymbolFTSItem{
+		{NodeID: "pkg/x.go::A", Tokens: "alpha widget red"},
+		{NodeID: "pkg/x.go::B", Tokens: "beta widget red"},
+	}); err != nil {
+		t.Fatalf("BulkUpsertSymbolFTS: %v", err)
+	}
+
+	var mapRows int
+	if err := s.db.QueryRow(`SELECT count(*) FROM symbol_fts_rowid`).Scan(&mapRows); err != nil {
+		t.Fatalf("count map: %v", err)
+	}
+	if mapRows != 2 {
+		t.Fatalf("symbol_fts_rowid rows = %d, want 2 after bulk", mapRows)
+	}
+
+	// Incremental replace on a bulk-loaded symbol — must not duplicate.
+	if err := s.UpsertSymbolFTS("pkg/x.go::A", "alpha widget blue"); err != nil {
+		t.Fatalf("UpsertSymbolFTS: %v", err)
+	}
+	if got := ftsRowCount(t, s, "symbol_fts", "pkg/x.go::A"); got != 1 {
+		t.Fatalf("symbol_fts rows after incremental replace = %d, want 1", got)
+	}
+	if got := ftsHits(t, s, "blue"); got != 1 {
+		t.Fatalf("search 'blue' = %d, want 1", got)
+	}
+}
+
+// TestBackfillSymbolFTSRowidMap simulates a database built before the
+// sidecar existed (rows in symbol_fts, none in the map) and proves the
+// backfill repopulates it so the next incremental upsert replaces cleanly
+// instead of leaking a duplicate.
+func TestBackfillSymbolFTSRowidMap(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "fts.sqlite"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	const id = "pkg/x.go::A"
+	s.AddNode(mkFnNode(id, "AlphaWidget", "pkg/x.go"))
+
+	// Simulate the legacy state: a row in symbol_fts with no map entry.
+	if _, err := s.db.Exec(
+		`INSERT INTO symbol_fts (node_id, repo_prefix, tokens) VALUES (?, '', ?)`,
+		id, "alpha widget red"); err != nil {
+		t.Fatalf("seed legacy fts row: %v", err)
+	}
+	if _, err := s.db.Exec(`DELETE FROM symbol_fts_rowid`); err != nil {
+		t.Fatalf("clear map: %v", err)
+	}
+
+	if err := backfillSymbolFTSRowidMap(s.db); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got := ftsRowCount(t, s, "symbol_fts_rowid", id); got != 1 {
+		t.Fatalf("map rows after backfill = %d, want 1", got)
+	}
+
+	// Now an incremental upsert must replace, not duplicate.
+	if err := s.UpsertSymbolFTS(id, "alpha widget blue"); err != nil {
+		t.Fatalf("UpsertSymbolFTS: %v", err)
+	}
+	if got := ftsRowCount(t, s, "symbol_fts", id); got != 1 {
+		t.Fatalf("symbol_fts rows after post-backfill replace = %d, want 1 (dup leaked)", got)
+	}
+	if got := ftsHits(t, s, "red"); got != 0 {
+		t.Fatalf("search 'red' (superseded) = %d, want 0", got)
+	}
+}

--- a/internal/graph/store_sqlite/schema.go
+++ b/internal/graph/store_sqlite/schema.go
@@ -263,15 +263,31 @@ CREATE INDEX IF NOT EXISTS blame_by_repo ON blame_enrichment(repo_prefix) WHERE 
 -- symbol_fts is the FTS5 full-text index over pre-tokenised symbol
 -- names. It replaces the multi-GB in-heap Bleve/BM25 index with an
 -- on-disk inverted index the SymbolSearcher / SymbolBundleSearcher
--- query through. A standard (NOT contentless) FTS5 table so we can
--- DELETE individual rows by node_id without an external content
--- shadow. node_id is the join key back to nodes.id; repo_prefix is
+-- query through. A standard (NOT contentless) FTS5 table; individual
+-- rows are deleted by their FTS5 docid via the symbol_fts_rowid sidecar
+-- below (node_id is UNINDEXED, so a DELETE keyed on it would full-scan
+-- the index). node_id is the join key back to nodes.id; repo_prefix is
 -- carried UNINDEXED so per-repo staleness wipes (DELETE … WHERE
 -- repo_prefix = ?) hit a literal column without a separate b-tree.
 -- Only "tokens" is indexed for matching. IF NOT EXISTS makes this
 -- idempotent on every Open, so an existing .sqlite gains the vtable
 -- on its next open + reindex.
 CREATE VIRTUAL TABLE IF NOT EXISTS symbol_fts USING fts5(node_id UNINDEXED, repo_prefix UNINDEXED, tokens);
+
+-- symbol_fts_rowid maps a node_id to the rowid (FTS5 docid) of its row in
+-- symbol_fts. node_id is UNINDEXED in the FTS5 vtable, so deleting a node's
+-- prior row with "DELETE … WHERE node_id = ?" full-scans the entire index
+-- once PER symbol — quadratic on the per-edit reindex hot path. This sidecar
+-- turns the delete into an O(log n) docid delete ("WHERE rowid = ?", the FTS5
+-- docid IS indexed). One row per indexed symbol, keyed by node_id (the join
+-- key back to nodes.id); repo_prefix scopes the per-repo wipe that
+-- BulkUpsertSymbolFTS performs in lockstep with symbol_fts. WITHOUT ROWID:
+-- the PK index IS the table, like file_mtimes / clone_shingles.
+CREATE TABLE IF NOT EXISTS symbol_fts_rowid (
+    node_id     TEXT PRIMARY KEY,
+    repo_prefix TEXT NOT NULL DEFAULT '',
+    fts_rowid   INTEGER NOT NULL
+) WITHOUT ROWID;
 
 -- content_fts is the FTS5 full-text index over CONTENT (data_class=
 -- "content") section bodies — text / pdf / pptx / xlsx chunks. It is

--- a/internal/graph/store_sqlite/store.go
+++ b/internal/graph/store_sqlite/store.go
@@ -286,6 +286,15 @@ func openWith(path string, current int, migrations []schemaMigration, allowRebui
 		return nil, fmt.Errorf("sqlite node columns: %w", err)
 	}
 
+	// Backfill the FTS rowid sidecar for databases built before it existed,
+	// so the first incremental UpsertSymbolFTS on an already-indexed symbol
+	// can do its O(log n) docid delete instead of leaking a duplicate row.
+	// One-time; a no-op once the map is populated or the FTS index is empty.
+	if err := backfillSymbolFTSRowidMap(db); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("sqlite fts rowid backfill: %w", err)
+	}
+
 	// Apply any in-place migration steps (none on a fresh, baseline, or wiped
 	// DB), then stamp the current schema version. After a wipe the store is
 	// empty and the daemon's normal indexing repopulates it.

--- a/internal/graph/store_sqlite/store_fts.go
+++ b/internal/graph/store_sqlite/store_fts.go
@@ -1,6 +1,7 @@
 package store_sqlite
 
 import (
+	"database/sql"
 	"strings"
 
 	"github.com/zzet/gortex/internal/graph"
@@ -52,11 +53,14 @@ const ftsInsertChunkRows = 300
 
 // UpsertSymbolFTS records (or replaces) the pre-tokenised text for
 // nodeID. FTS5 offers no UPSERT on a table with UNINDEXED columns, so
-// the write is delete-then-insert: drop any prior row for nodeID, then
-// insert the new tokens. The repo_prefix is derived from the owning
-// node (nodes.repo_prefix) so the per-repo staleness wipe in
-// BulkUpsertSymbolFTS can scope by prefix; if the node is absent the
-// prefix defaults to "".
+// the write is delete-then-insert. The delete targets the prior row's
+// FTS5 docid (rowid), looked up from the symbol_fts_rowid sidecar —
+// node_id is UNINDEXED, so "DELETE … WHERE node_id = ?" would full-scan
+// the whole index once per symbol, which is quadratic over a file's
+// symbols on the per-edit reindex hot path. The repo_prefix is derived
+// from the owning node (nodes.repo_prefix) so the per-repo staleness
+// wipe in BulkUpsertSymbolFTS can scope by prefix; if the node is absent
+// the prefix defaults to "".
 func (s *Store) UpsertSymbolFTS(nodeID, tokens string) error {
 	if nodeID == "" {
 		return nil
@@ -65,19 +69,45 @@ func (s *Store) UpsertSymbolFTS(nodeID, tokens string) error {
 	defer s.writeMu.Unlock()
 
 	var repoPrefix string
-	row := s.db.QueryRow(`SELECT repo_prefix FROM nodes WHERE id = ?`, nodeID)
 	// A missing node (or a scan error) leaves repoPrefix == "" — the
 	// row is still indexable, it just won't be reachable by a per-repo
 	// prefix wipe. The graph.Store contract has no error channel for
 	// the indexer's incremental writes, so we don't surface this.
-	_ = row.Scan(&repoPrefix)
+	_ = s.db.QueryRow(`SELECT repo_prefix FROM nodes WHERE id = ?`, nodeID).Scan(&repoPrefix)
 
-	if _, err := s.db.Exec(`DELETE FROM symbol_fts WHERE node_id = ?`, nodeID); err != nil {
+	// Delete the prior row by its docid (O(log n)) instead of by node_id
+	// (full FTS scan). A missing map entry means no prior row to drop —
+	// the sidecar is kept in lockstep with symbol_fts by every writer and
+	// backfilled at Open for databases built before it existed, so a miss
+	// here is a genuinely new symbol, not a stale row we're leaking.
+	var oldRowid int64
+	switch err := s.db.QueryRow(
+		`SELECT fts_rowid FROM symbol_fts_rowid WHERE node_id = ?`, nodeID,
+	).Scan(&oldRowid); err {
+	case nil:
+		if _, err := s.db.Exec(`DELETE FROM symbol_fts WHERE rowid = ?`, oldRowid); err != nil {
+			return err
+		}
+	case sql.ErrNoRows:
+		// new symbol — nothing to delete
+	default:
+		return err
+	}
+
+	res, err := s.db.Exec(
+		`INSERT INTO symbol_fts (node_id, repo_prefix, tokens) VALUES (?, ?, ?)`,
+		nodeID, repoPrefix, tokens,
+	)
+	if err != nil {
+		return err
+	}
+	newRowid, err := res.LastInsertId()
+	if err != nil {
 		return err
 	}
 	if _, err := s.db.Exec(
-		`INSERT INTO symbol_fts (node_id, repo_prefix, tokens) VALUES (?, ?, ?)`,
-		nodeID, repoPrefix, tokens,
+		`INSERT OR REPLACE INTO symbol_fts_rowid (node_id, repo_prefix, fts_rowid) VALUES (?, ?, ?)`,
+		nodeID, repoPrefix, newRowid,
 	); err != nil {
 		return err
 	}
@@ -142,6 +172,12 @@ func (s *Store) BulkUpsertSymbolFTS(repoPrefix string, items []graph.SymbolFTSIt
 	if _, err := tx.Exec(`DELETE FROM symbol_fts WHERE repo_prefix = ?`, repoPrefix); err != nil {
 		return err
 	}
+	// Drop this repo's rowid-map entries in lockstep with the symbol_fts
+	// wipe so the two never diverge; they are rebuilt from the freshly
+	// inserted rows below.
+	if _, err := tx.Exec(`DELETE FROM symbol_fts_rowid WHERE repo_prefix = ?`, repoPrefix); err != nil {
+		return err
+	}
 
 	for start := 0; start < len(items); start += ftsInsertChunkRows {
 		end := minInt(start+ftsInsertChunkRows, len(items))
@@ -162,11 +198,51 @@ func (s *Store) BulkUpsertSymbolFTS(repoPrefix string, items []graph.SymbolFTSIt
 		}
 	}
 
+	// Rebuild the rowid map for this repo from the rows just inserted. A
+	// full multi-row INSERT only exposes the last docid, so we read the
+	// docids back in one pass (a linear filter over the UNINDEXED
+	// repo_prefix column — the cold/bulk path, not the per-edit hot path).
+	if _, err := tx.Exec(
+		`INSERT OR REPLACE INTO symbol_fts_rowid (node_id, repo_prefix, fts_rowid)
+		 SELECT node_id, repo_prefix, rowid FROM symbol_fts WHERE repo_prefix = ?`,
+		repoPrefix,
+	); err != nil {
+		return err
+	}
+
 	if err := tx.Commit(); err != nil {
 		return err
 	}
 	commit = true
 	return nil
+}
+
+// backfillSymbolFTSRowidMap populates symbol_fts_rowid from symbol_fts for
+// a database built before the sidecar existed. Without it, the first
+// incremental UpsertSymbolFTS for an already-indexed symbol would find no
+// map entry, skip the delete, and leak a duplicate FTS row. It is a
+// one-time cost: skipped once the map has any row (steady state) or when
+// the FTS index is empty (a fresh DB the bulk path will populate with the
+// map maintained inline). Runs at Open, before any reader or writer.
+func backfillSymbolFTSRowidMap(db *sql.DB) error {
+	var mapped bool
+	if err := db.QueryRow(`SELECT EXISTS(SELECT 1 FROM symbol_fts_rowid)`).Scan(&mapped); err != nil {
+		return err
+	}
+	if mapped {
+		return nil
+	}
+	var hasFTS bool
+	if err := db.QueryRow(`SELECT EXISTS(SELECT 1 FROM symbol_fts)`).Scan(&hasFTS); err != nil {
+		return err
+	}
+	if !hasFTS {
+		return nil
+	}
+	_, err := db.Exec(
+		`INSERT OR REPLACE INTO symbol_fts_rowid (node_id, repo_prefix, fts_rowid)
+		 SELECT node_id, repo_prefix, rowid FROM symbol_fts`)
+	return err
 }
 
 // BuildSymbolIndex is a no-op for FTS5: the index is maintained

--- a/internal/indexer/editfile_bench_test.go
+++ b/internal/indexer/editfile_bench_test.go
@@ -1,0 +1,115 @@
+package indexer
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+// BenchmarkEditFileReindex measures the synchronous work an edit_file
+// request pays after the text splice: reindexFile -> IndexFile ->
+// indexFile(resolve=true). Because indexFile does NO change-diffing,
+// re-indexing an unchanged file does the exact same work as a real edit,
+// so we can measure the true hot path without writing to the repo.
+//
+// Corpus defaults to the repo root (../.. from internal/indexer) so the
+// graph matches production scale; override with GORTEX_BENCH_CORPUS (a
+// smaller subtree, e.g. internal/graph, runs far faster for before/after
+// comparison since the FTS-delete cost scales with corpus size). Target
+// file defaults to the sqlite store.go; override with GORTEX_BENCH_TARGET
+// (path relative to the corpus root).
+//
+// Run (bypass rtk — it eats benchmark output):
+//
+//	rtk proxy go test ./internal/indexer -run '^$' -bench BenchmarkEditFileReindex \
+//	    -benchtime=20x -cpuprofile=/tmp/edit.cpu
+//	go tool pprof -top -nodecount=60 -cum /tmp/edit.cpu
+func BenchmarkEditFileReindex(b *testing.B) {
+	corpus := os.Getenv("GORTEX_BENCH_CORPUS")
+	if corpus == "" {
+		corpus = "../.." // repo root, relative to internal/indexer
+	}
+	corpus, err := filepath.Abs(corpus)
+	if err != nil {
+		b.Fatalf("abs corpus: %v", err)
+	}
+	if _, err := os.Stat(corpus); err != nil {
+		b.Skipf("corpus %s not available: %v", corpus, err)
+	}
+
+	targetRel := os.Getenv("GORTEX_BENCH_TARGET")
+	if targetRel == "" {
+		targetRel = "internal/graph/store_sqlite/store.go"
+	}
+	target := filepath.Join(corpus, targetRel)
+	if _, err := os.Stat(target); err != nil {
+		b.Skipf("target %s not available: %v", target, err)
+	}
+
+	store, err := store_sqlite.Open(filepath.Join(b.TempDir(), "bench.sqlite"))
+	if err != nil {
+		b.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	reg := parser.NewRegistry()
+	languages.RegisterAll(reg)
+	cfg := config.Default().Index
+	cfg.Workers = runtime.NumCPU()
+
+	idx := New(store, reg, cfg, zap.NewNop())
+
+	// One-time bulk index (NOT timed). This is what the daemon already
+	// did; we are measuring the per-edit cost on top of a warm graph.
+	if _, err := idx.Index(corpus); err != nil {
+		b.Fatalf("bulk index: %v", err)
+	}
+	st := store.Stats()
+	b.Logf("graph: %d nodes, %d edges (corpus=%s, target=%s)",
+		st.TotalNodes, st.TotalEdges, corpus, targetRel)
+
+	// graphPath is the key indexFile derives for the reverse/resolver
+	// passes — relKey + repo prefix, exactly as indexFile computes it.
+	abs, _ := filepath.Abs(target)
+	graphPath := idx.prefixPath(idx.relKey(abs))
+
+	// 1. Full hot path: parse + evict + add + persist + resolve. This is
+	//    what edit_file pays today.
+	b.Run("IndexFile_resolve", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if err := idx.IndexFile(target); err != nil {
+				b.Fatalf("IndexFile: %v", err)
+			}
+		}
+	})
+
+	// 2. Same minus the per-file resolver call — isolates the parse +
+	//    EvictFile + AddBatch + persist (sidecar) cost, incl. the FTS
+	//    upsert loop.
+	b.Run("IndexFile_noresolve", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if err := idx.IndexFileNoResolve(target); err != nil {
+				b.Fatalf("IndexFileNoResolve: %v", err)
+			}
+		}
+	})
+
+	// 3. The resolver pass alone — buildPassIndexes (4 whole-graph index
+	//    builds) + forward + reverse resolve. (1)-(2) ~= this.
+	b.Run("ResolveFileAndIncoming", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			idx.resolver.ResolveFileAndIncoming(graphPath)
+		}
+	})
+}

--- a/internal/resolver/bare_name_scope_bind.go
+++ b/internal/resolver/bare_name_scope_bind.go
@@ -101,6 +101,47 @@ func (r *Resolver) bindBareNameScopeRefs() {
 	}
 }
 
+// bindBareNameScopeRefsForFile is the single-file scope of
+// bindBareNameScopeRefs. A bare-name reference binds to a KindLocal /
+// KindParam declared by its OWN enclosing function, and that function —
+// with all of its locals and params — lives entirely in the edited file.
+// So the scope index is built from the file's own KindLocal / KindParam
+// nodes and only the file's outgoing Read / Reference / ArgOf / ValueFlow
+// edges are considered. This produces the same binds as the whole-graph
+// sweep for a per-save resolve without scanning every KindLocal in the
+// graph (the single largest node kind).
+func (r *Resolver) bindBareNameScopeRefsForFile(filePath string) {
+	owned := map[string][]scopeNode{}
+	for _, n := range r.graph.GetFileNodes(filePath) {
+		if n.Kind != graph.KindLocal && n.Kind != graph.KindParam {
+			continue
+		}
+		owner := enclosingFunctionForBinding(n.ID)
+		if owner == "" {
+			continue
+		}
+		owned[owner] = append(owned[owner], scopeNode{
+			id: n.ID, name: n.Name, startLine: n.StartLine, kind: n.Kind,
+		})
+	}
+	if len(owned) == 0 {
+		return
+	}
+
+	var batch []graph.EdgeReindex
+	for _, e := range r.fileOutEdges(filePath) {
+		switch e.Kind {
+		case graph.EdgeReads, graph.EdgeReferences, graph.EdgeArgOf, graph.EdgeValueFlow:
+			if rewrote := r.tryBindBareName(e, owned); rewrote != "" {
+				batch = append(batch, graph.EdgeReindex{Edge: e, OldTo: rewrote})
+			}
+		}
+	}
+	if len(batch) > 0 {
+		r.graph.ReindexEdges(batch)
+	}
+}
+
 // tryBindBareName tries to rewrite e.To from `unresolved::<name>` to a
 // matching in-scope KindLocal/KindParam ID. Returns the original To
 // value when a rewrite happened (caller batches it for ReindexEdges)

--- a/internal/resolver/external_call_attribution.go
+++ b/internal/resolver/external_call_attribution.go
@@ -37,54 +37,86 @@ import (
 //
 // All AddNode / AddEdge calls are idempotent on ID, so a second run
 // of this pass (incremental ResolveFile re-invocation) is a no-op.
+// extKey identifies a unique external target across the attribution
+// passes; modKey identifies its owning module. Package-level so the
+// whole-graph and single-file collectors feed one materialiser.
+//
+// repoPrefix is part of the key because stdlib stubs are per-repo (see
+// internal/graph/stub.go) — two repos on different Go SDK versions emit
+// semantically distinct `<repoA>::stdlib::fmt::Errorf` and
+// `<repoB>::stdlib::fmt::Errorf` stubs that MUST round-trip through this
+// attribution as distinct nodes, not collide into one.
+type extKey struct {
+	repoPrefix, prefix, importPath, symbol string
+}
+
+type modKey struct{ repoPrefix, importPath string }
+
+// goExternalAttribKinds is every edge kind an extern-prefixed target can
+// show up on — the same set attributeGoBuiltins scans.
+var goExternalAttribKinds = []graph.EdgeKind{
+	graph.EdgeCalls,
+	graph.EdgeReferences,
+	graph.EdgeReads,
+	graph.EdgeArgOf,
+	graph.EdgeValueFlow,
+	graph.EdgeReturnsTo,
+	graph.EdgeTypedAs,
+	graph.EdgeReturns,
+	graph.EdgeInstantiates,
+	graph.EdgeCaptures,
+	graph.EdgeThrows,
+}
+
 func (r *Resolver) attributeGoExternalCalls() {
 	// Go-only pass: skip the external-prefix edge scan when the graph has
 	// no Go nodes.
 	if !r.graphHasLanguage("go") {
 		return
 	}
-	// Scan every edge whose target sits in one of the three external
-	// prefixes. Collect unique (repoPrefix, prefix, importPath, symbol)
-	// tuples so we materialise each one once even when many edges
-	// reference the same target. repoPrefix is included because
-	// stdlib stubs are per-repo (see internal/graph/stub.go) — two
-	// repos on different Go SDK versions emit semantically distinct
-	// `<repoA>::stdlib::fmt::Errorf` and `<repoB>::stdlib::fmt::Errorf`
-	// stubs that MUST round-trip through this attribution pass as
-	// distinct nodes, not collide into one.
-	type extKey struct {
-		repoPrefix, prefix, importPath, symbol string
-	}
 	seen := map[extKey]struct{}{}
-	depEdgesScan := func(kind graph.EdgeKind) {
-		for e := range r.graph.EdgesByKind(kind) {
-			if e.To == "" {
-				continue
-			}
-			prefix, importPath, symbol := splitGoExternalTarget(e.To)
-			if prefix == "" {
-				continue
-			}
-			seen[extKey{graph.StubRepoPrefix(e.To), prefix, importPath, symbol}] = struct{}{}
+	for _, k := range goExternalAttribKinds {
+		for e := range r.graph.EdgesByKind(k) {
+			collectGoExternalTarget(e, seen)
 		}
 	}
-	// Same edge-kind set as attributeGoBuiltins — anywhere an
-	// extern-prefixed target can show up.
-	for _, k := range []graph.EdgeKind{
-		graph.EdgeCalls,
-		graph.EdgeReferences,
-		graph.EdgeReads,
-		graph.EdgeArgOf,
-		graph.EdgeValueFlow,
-		graph.EdgeReturnsTo,
-		graph.EdgeTypedAs,
-		graph.EdgeReturns,
-		graph.EdgeInstantiates,
-		graph.EdgeCaptures,
-		graph.EdgeThrows,
-	} {
-		depEdgesScan(k)
+	r.materializeGoExternalSeen(seen)
+}
+
+// attributeGoExternalCallsForFile is the single-file scope of
+// attributeGoExternalCalls: an extern-prefixed target is referenced from
+// inside the edited file, so only that file's outgoing edges can
+// introduce a new one. Produces the same materialisation as the
+// whole-graph sweep for a per-save resolve.
+func (r *Resolver) attributeGoExternalCallsForFile(filePath string) {
+	if !r.graphHasLanguage("go") {
+		return
 	}
+	seen := map[extKey]struct{}{}
+	for _, e := range r.fileOutEdges(filePath) {
+		collectGoExternalTarget(e, seen)
+	}
+	r.materializeGoExternalSeen(seen)
+}
+
+// collectGoExternalTarget records e's external target (if any) into seen,
+// deduping by the per-repo (prefix, path, symbol) tuple.
+func collectGoExternalTarget(e *graph.Edge, seen map[extKey]struct{}) {
+	if e == nil || e.To == "" {
+		return
+	}
+	prefix, importPath, symbol := splitGoExternalTarget(e.To)
+	if prefix == "" {
+		return
+	}
+	seen[extKey{graph.StubRepoPrefix(e.To), prefix, importPath, symbol}] = struct{}{}
+}
+
+// materializeGoExternalSeen turns the collected external targets into
+// KindModule + KindFunction nodes and their EdgeMemberOf links. All
+// AddNode / AddEdge calls are idempotent on ID, so a second run (e.g. a
+// re-resolve of the same file) is a no-op.
+func (r *Resolver) materializeGoExternalSeen(seen map[extKey]struct{}) {
 	if len(seen) == 0 {
 		return
 	}
@@ -97,7 +129,6 @@ func (r *Resolver) attributeGoExternalCalls() {
 	// same SDK-version sensitivity its symbols do. Key includes the
 	// repo prefix so two repos importing the same path get distinct
 	// module nodes.
-	type modKey struct{ repoPrefix, importPath string }
 	modules := map[modKey]string{}
 	for k := range seen {
 		modKey := modKey{repoPrefix: k.repoPrefix, importPath: k.importPath}

--- a/internal/resolver/go_builtins_attribution.go
+++ b/internal/resolver/go_builtins_attribution.go
@@ -93,6 +93,27 @@ func (r *Resolver) attributeGoBuiltins() {
 	}
 }
 
+// attributeGoBuiltinsForFile is the single-file scope of attributeGoBuiltins:
+// it only inspects the edited file's outgoing edges. A builtin reference's
+// source endpoint is always inside the file that mentions it, so this
+// produces the same rewrites as the whole-graph sweep for a per-save
+// resolve without scanning every edge of eleven kinds across the graph.
+func (r *Resolver) attributeGoBuiltinsForFile(filePath string) {
+	if !r.graphHasLanguage("go") {
+		return
+	}
+	materialised := map[string]struct{}{}
+	var batch []graph.EdgeReindex
+	for _, e := range r.fileOutEdges(filePath) {
+		if old := r.tryAttributeGoBuiltin(e, materialised); old != "" {
+			batch = append(batch, graph.EdgeReindex{Edge: e, OldTo: old})
+		}
+	}
+	if len(batch) > 0 {
+		r.graph.ReindexEdges(batch)
+	}
+}
+
 // tryAttributeGoBuiltin checks if e.To is `unresolved::<bareName>`
 // where bareName is a Go builtin and the source language is Go (the
 // source is inside a Go function / file). On a match it materialises

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -869,7 +869,21 @@ func (r *Resolver) ResolveFilesAndIncoming(filePaths []string) *ResolveStats {
 // has built the per-pass indexes.
 func (r *Resolver) resolveFileLocked(filePath string, stats *ResolveStats) {
 	r.resolveFileEdgesLocked(filePath, stats)
-	r.runFileAttributionPassesLocked()
+	r.runFileAttributionPassesForFileLocked(filePath)
+}
+
+// fileOutEdges returns every outgoing edge of every node defined in
+// filePath — the scope a single-file attribution pass needs in place of
+// a whole-graph EdgesByKind sweep. Builtin / external / bare-name
+// attributions all act on edges whose source is inside the edited file,
+// so this is the complete candidate set for those passes.
+func (r *Resolver) fileOutEdges(filePath string) []*graph.Edge {
+	nodes := r.graph.GetFileNodes(filePath)
+	var out []*graph.Edge
+	for _, n := range nodes {
+		out = append(out, r.graph.GetOutEdges(n.ID)...)
+	}
+	return out
 }
 
 // resolveFileEdgesLocked walks one file's outgoing unresolved edges and
@@ -941,6 +955,24 @@ func (r *Resolver) runFileAttributionPassesLocked() {
 	r.bindGenericParamRefs()
 	r.attributeGoBuiltins()
 	r.attributeGoExternalCalls()
+}
+
+// runFileAttributionPassesForFileLocked is the single-file equivalent of
+// runFileAttributionPassesLocked. Builtin / external-call / bare-name
+// attribution only ever rewrite edges originating in the edited file, so
+// they run over that file's outgoing edges instead of sweeping the whole
+// graph once per save — the dominant per-edit resolver cost on a large
+// graph. The two passes that genuinely need cross-file context (method-
+// receiver rebind reads the package's type index; generic-param binding)
+// stay whole-graph; both are already batched and cheap. The pass ORDER
+// matches runFileAttributionPassesLocked: bare-name binding runs before
+// builtin attribution so a local named `len` shadows the builtin.
+func (r *Resolver) runFileAttributionPassesForFileLocked(filePath string) {
+	r.rebindGoMethodReceivers()
+	r.bindBareNameScopeRefsForFile(filePath)
+	r.bindGenericParamRefs()
+	r.attributeGoBuiltinsForFile(filePath)
+	r.attributeGoExternalCallsForFile(filePath)
 }
 
 // ResolveIncomingForFile is the reverse of ResolveFile: instead of

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -834,10 +834,61 @@ func (r *Resolver) ResolveFileAndIncoming(filePath string) *ResolveStats {
 	clear := r.buildPassIndexes()
 	defer clear()
 
+	// Warm the per-edge lookup cache for this file's pending forward and
+	// incoming edges. Without it the single-file path fires a fresh
+	// FindNodesByNameInRepo — a scanNode + meta-decode of every same-name
+	// candidate — once PER edge, re-materialising the same candidates for
+	// every edge that shares a name. Seeding the cache once (one batched
+	// FindNodesByNames, like ResolveAll) materialises each candidate once
+	// and the passes read it from memory.
+	r.warmLookupCache(r.pendingEdgesForFileAndIncoming(filePath))
+	defer r.clearLookupCache()
+
 	stats := &ResolveStats{}
 	r.resolveFileLocked(filePath, stats)
 	r.resolveIncomingLocked(filePath, stats)
 	return stats
+}
+
+// pendingEdgesForFileAndIncoming gathers the unresolved edges the forward
+// and reverse passes will visit — the file's own outgoing unresolved
+// edges plus the unresolved in-edges parked on the stub ids of the
+// referenceable symbols this file defines. It mirrors the edge walks
+// resolveFileEdgesLocked / resolveIncomingLocked perform, but only to seed
+// warmLookupCache; the result feeds caching, never resolution directly.
+func (r *Resolver) pendingEdgesForFileAndIncoming(filePath string) []*graph.Edge {
+	defNodes := r.graph.GetFileNodes(filePath)
+	var pending []*graph.Edge
+	seenNames := make(map[string]struct{}, len(defNodes))
+	for _, n := range defNodes {
+		if n == nil {
+			continue
+		}
+		for _, e := range r.graph.GetOutEdges(n.ID) {
+			if graph.IsUnresolvedTarget(e.To) {
+				pending = append(pending, e)
+			}
+		}
+		if n.Name == "" || !graph.IsReferenceableSymbol(n.Kind) {
+			continue
+		}
+		if _, dup := seenNames[n.Name]; dup {
+			continue
+		}
+		seenNames[n.Name] = struct{}{}
+		keys := []string{graph.UnresolvedMarker + n.Name}
+		if n.RepoPrefix != "" {
+			keys = append(keys, n.RepoPrefix+"::"+graph.UnresolvedMarker+n.Name)
+		}
+		for _, key := range keys {
+			for _, e := range r.graph.GetInEdges(key) {
+				if graph.IsUnresolvedTarget(e.To) {
+					pending = append(pending, e)
+				}
+			}
+		}
+	}
+	return pending
 }
 
 // ResolveFilesAndIncoming runs the forward and reverse passes for a

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -2083,7 +2083,32 @@ func (r *Resolver) buildReachabilityIndex() {
 		addDir(n.ID, filepath.Dir(n.FilePath))
 	}
 
+	// Materialise the import edges and batch-load the endpoints of the
+	// resolved ones (e.To naming a concrete node) in one GetNodesByIDs.
+	// A per-edge GetNode here is a query round-trip per import on a disk
+	// backend — the same batching buildImportClosure already applies.
+	// Unresolved / external targets never name an in-repo file node, so
+	// they're skipped from the batch (their directory comes from dirIndex
+	// or not at all).
+	var imports []*graph.Edge
+	ids := make(map[string]struct{})
 	for e := range r.graph.EdgesByKind(graph.EdgeImports) {
+		imports = append(imports, e)
+		if e.To == "" || graph.IsUnresolvedTarget(e.To) || strings.HasPrefix(e.To, "external::") {
+			continue
+		}
+		ids[e.To] = struct{}{}
+	}
+	var nodes map[string]*graph.Node
+	if len(ids) > 0 {
+		idList := make([]string, 0, len(ids))
+		for id := range ids {
+			idList = append(idList, id)
+		}
+		nodes = r.graph.GetNodesByIDs(idList)
+	}
+
+	for _, e := range imports {
 		var importedDir string
 		switch {
 		case graph.IsUnresolvedTarget(e.To) && strings.HasPrefix(graph.UnresolvedName(e.To), "import::"):
@@ -2098,7 +2123,7 @@ func (r *Resolver) buildReachabilityIndex() {
 		case strings.HasPrefix(e.To, "external::"):
 			// External / unindexed package — nothing to add.
 		default:
-			if n := r.graph.GetNode(e.To); n != nil && n.Kind == graph.KindFile {
+			if n := nodes[e.To]; n != nil && n.Kind == graph.KindFile {
 				importedDir = filepath.Dir(n.FilePath)
 			}
 		}


### PR DESCRIPTION
## Why

`edit_file` (and any single-file save → reindex) was slow. The text splice is instant; the cost is the **synchronous post-write reindex** `handleEditFile → reindexFile → IndexFile → indexFile(resolve=true)`. Synchronous is the right call (avoids concurrency races) — so the fix is to do **less work**, not defer it.

Every change here is **measurement-driven**: a new benchmark + CPU/alloc profile after each commit told us where to look next, and three originally-planned changes were **dropped because the profile said so**. Every change is structurally safe (same result, less work) and guarded by the existing `incremental == cold` convergence test.

## Result

Full per-edit reindex (`IndexFile_resolve`), on a 33.8k-node graph:

| file | start of work | this branch |
|---|---|---|
| **typical** (132-line file) | whole-graph passes made it slow | **116 ms** |
| **worst case** (5k-line `golang.go`) | ~11 s | **1.24 s** |

`IndexFile_noresolve` (parse+evict+addbatch+FTS) for a typical file is ~20ms; the resolver was the constant floor, and most of it is now scoped to the edited file.

## The fixes (each backed by a profile)

1. **`perf(store)`: delete FTS rows by docid, not UNINDEXED `node_id`** — `symbol_fts` is `fts5(node_id UNINDEXED…)`, so `DELETE … WHERE node_id` full-scanned the index *per symbol* (quadratic; **54% of edit CPU**, the single largest consumer). Added a `node_id → docid` sidecar and delete by rowid (O(log n)); maintained by both writers + backfilled at Open. Additive schema, no reindex.
2. **`perf(resolver)`: batch import-endpoint loads in `buildReachabilityIndex`** — per-edge `GetNode` → one `GetNodesByIDs`.
3. **`perf(resolver)`: scope per-file attribution to the edited file** — the Go builtin / external-call / bare-name passes ran as whole-graph sweeps (one scanned every `KindLocal`) on each save; they only rewrite the edited file's own out-edges, so they now run over those. **−58%** resolver time.
4. **`perf(resolver)`: warm the candidate cache on single-file resolve** — only `ResolveAll` warmed the lookup cache, so each unresolved edge re-materialised (`scanNode`+meta-decode) the same candidates per edge. Seed it once from the file's pending edges. **−82% allocations** (12.6M → 2.3M), −81% memory.
5. **`perf(indexer)`: batch param-position lookups in the per-file dataflow pass** — `paramNodeAtPosition` re-fetched a callee's whole in-edge list *per argument*; build a `callee→position→param` index once from two batched queries. Was 42% of `indexFile` on a large file.
6. **`perf(store)`: evict a file's edges in chunked `IN` batches** — eviction ran one `DELETE … WHERE from_id=? OR to_id=?` per node (a statement + WAL commit each); chunked `IN` makes it 2 index-driven deletes per ~900 nodes.
7. **`perf(resolver)`: scope method-receiver rebind to the edited file's package** — `rebindGoMethodReceivers` indexed every Go type and scanned every `MemberOf` edge on each save (a whole-graph sweep, **~94% of a *typical* edit's resolver cost**). A method's receiver type is in its own package, so the per-file path builds the type index from just that package's files and rebinds only the edited file's methods. This is the **715ms → 116ms** win for typical edits.

Plus `test(indexer)`: the `BenchmarkEditFileReindex` harness (re-indexing an unchanged file does the same work as a real edit, since `indexFile` doesn't diff — so it measures the hot path without touching the repo).

## Dropped (measurement-driven)

- **Cross-edit cache of the 4 resolver pass-indexes** — after #2 it was 0.35% of CPU on large files; on small files it's ~30%, but caching it safely across 19 repos sharing one store needs a stateful structural-generation counter with cross-repo invalidation — a correctness surface not worth ~35ms here. Left as a deliberate, documented stop.
- **Promote scope meta keys to columns / meta-skipping candidate scan** — audit showed candidate `.Meta` is load-bearing (C/C++/Java/PHP scope, overload, and framework resolution all read it); a blanket light-scan would silently mis-resolve. After #4, `decodeMeta` is 7% (from 29%) and the scope keys are emitted only by C++/Java/C#/PHP (zero benefit for Go/JS/Python).

## Tests
`-race` green on `store_sqlite`, `resolver`, `indexer`. New `fts_rowid_test.go` (upsert-replaces-without-duplicates, bulk map maintenance, backfill). Existing convergence + dataflow-scoped-equivalence tests guard that the scoped passes match the whole-graph result. gofmt / golangci-lint / wire-contract golden clean.
