### PR TITLE
perf: scope dataflow, eviction, and method-receiver rebind to the edited file (follow-up to #187)

### DIFF
--- a/internal/graph/store_sqlite/store.go
+++ b/internal/graph/store_sqlite/store.go
@@ -1047,19 +1047,31 @@ func (s *Store) evictByScopeLocked(selectIDs, deleteNodes *sql.Stmt, scope strin
 		return 0, 0
 	}
 
-	// Delete every edge touching one of these nodes. We run a single
-	// DELETE per node id to avoid bumping into SQLite's bound-variable
-	// limit on big batches; under the write lock this is a
-	// straight-line walk.
+	// Delete every edge touching one of these nodes. A DELETE-per-node
+	// (… WHERE from_id = ? OR to_id = ?) is one statement round-trip and
+	// WAL commit per node — hundreds of them when evicting a large file on
+	// the per-edit reindex path. Instead delete in chunked IN batches
+	// keyed on from_id then to_id, so each chunk is one index-driven
+	// DELETE; the chunk size stays under SQLite's bound-variable limit.
 	var edgesRemoved int
-	for _, id := range ids {
-		res, err := s.db.Exec(`DELETE FROM edges WHERE from_id = ? OR to_id = ?`, id, id)
-		if err != nil {
-			panicOnFatal(err)
-			return 0, edgesRemoved
-		}
-		if n, err := res.RowsAffected(); err == nil {
-			edgesRemoved += int(n)
+	const evictEdgeChunk = 900
+	for _, col := range []string{"from_id", "to_id"} {
+		for start := 0; start < len(ids); start += evictEdgeChunk {
+			end := minInt(start+evictEdgeChunk, len(ids))
+			chunk := ids[start:end]
+			placeholders := strings.TrimSuffix(strings.Repeat("?,", len(chunk)), ",")
+			args := make([]any, len(chunk))
+			for i, id := range chunk {
+				args[i] = id
+			}
+			res, err := s.db.Exec(`DELETE FROM edges WHERE `+col+` IN (`+placeholders+`)`, args...)
+			if err != nil {
+				panicOnFatal(err)
+				return 0, edgesRemoved
+			}
+			if n, err := res.RowsAffected(); err == nil {
+				edgesRemoved += int(n)
+			}
 		}
 	}
 

--- a/internal/indexer/dataflow.go
+++ b/internal/indexer/dataflow.go
@@ -102,7 +102,11 @@ func (idx *Indexer) materializeDataflowParamsForFile(graphPath string, fileEdges
 	// A synthetic From can be shared across files, so restrict the rewrite
 	// to edges this file actually emitted: every arg_of / returns_to edge
 	// carries its call-site FilePath, so the filter keeps the set exactly
-	// the file's own.
+	// the file's own. Collect the file's arg_of / returns_to edges plus the
+	// distinct callees the arg_of rewrites target, so the per-callee param
+	// lookup is batched once instead of re-fetched per argument.
+	var argEdges, retEdges []*graph.Edge
+	callees := make(map[string]struct{})
 	for _, edges := range g.GetOutEdgesByNodeIDs(froms) {
 		for _, e := range edges {
 			if e == nil || e.FilePath != graphPath {
@@ -110,34 +114,58 @@ func (idx *Indexer) materializeDataflowParamsForFile(graphPath string, fileEdges
 			}
 			switch e.Kind {
 			case graph.EdgeArgOf:
-				rewriteArgOf(g, e)
+				argEdges = append(argEdges, e)
+				if callee, _, ok := argOfRewriteTarget(e); ok {
+					callees[callee] = struct{}{}
+				}
 			case graph.EdgeReturnsTo:
-				rewriteReturnsTo(g, e)
+				retEdges = append(retEdges, e)
 			}
 		}
 	}
+	paramIdx := buildParamPositionIndex(g, callees)
+	for _, e := range argEdges {
+		rewriteArgOfIndexed(g, e, paramIdx)
+	}
+	for _, e := range retEdges {
+		rewriteReturnsTo(g, e)
+	}
+}
+
+// argOfRewriteTarget reports whether an arg_of edge is a rewrite
+// candidate and, if so, the resolved callee id and the argument
+// position. An edge already pointing at a param node, or still
+// pointing at an unresolved / external stub, is not a candidate. Shared
+// by the per-edge (rewriteArgOf) and indexed (rewriteArgOfIndexed) paths
+// so the guard lives in one place.
+func argOfRewriteTarget(e *graph.Edge) (calleeID string, pos int, ok bool) {
+	if e == nil || e.Meta == nil {
+		return "", 0, false
+	}
+	pos, ok = argPositionFromMeta(e.Meta)
+	if !ok {
+		return "", 0, false
+	}
+	to := e.To
+	if strings.Contains(to, "#param:") {
+		return "", 0, false
+	}
+	if strings.HasPrefix(to, "unresolved::") || strings.HasPrefix(to, "external::") {
+		return "", 0, false
+	}
+	return to, pos, true
 }
 
 // rewriteArgOf walks the resolved callee's incoming param_of edges
 // and lifts the edge target from the function node to the param
 // node at the recorded position. Edges that already point at a
-// param node are left alone.
+// param node are left alone. Used by the whole-graph (cold) pass; the
+// per-file pass uses the batched rewriteArgOfIndexed instead.
 func rewriteArgOf(g graph.Store, e *graph.Edge) {
-	if e == nil || e.Meta == nil {
-		return
-	}
-	pos, ok := argPositionFromMeta(e.Meta)
+	calleeID, pos, ok := argOfRewriteTarget(e)
 	if !ok {
 		return
 	}
-	to := e.To
-	if strings.Contains(to, "#param:") {
-		return
-	}
-	if strings.HasPrefix(to, "unresolved::") || strings.HasPrefix(to, "external::") {
-		return
-	}
-	calleeID := to
 	paramID := paramNodeAtPosition(g, calleeID, pos)
 	if paramID == "" {
 		return
@@ -146,6 +174,87 @@ func rewriteArgOf(g graph.Store, e *graph.Edge) {
 	g.RemoveEdge(e.From, oldTo, e.Kind)
 	e.To = paramID
 	g.AddEdge(e)
+}
+
+// rewriteArgOfIndexed is rewriteArgOf with the callee→position→param
+// lookup served from a prebuilt index instead of a per-edge
+// paramNodeAtPosition (which re-fetched the callee's entire in-edge list
+// once per argument). Same rewrite, same guards.
+func rewriteArgOfIndexed(g graph.Store, e *graph.Edge, paramIdx map[string]map[int]string) {
+	calleeID, pos, ok := argOfRewriteTarget(e)
+	if !ok {
+		return
+	}
+	m := paramIdx[calleeID]
+	if m == nil {
+		return
+	}
+	paramID := m[pos]
+	if paramID == "" {
+		return
+	}
+	oldTo := e.To
+	g.RemoveEdge(e.From, oldTo, e.Kind)
+	e.To = paramID
+	g.AddEdge(e)
+}
+
+// buildParamPositionIndex maps each callee id to its argument
+// position → param-node-id table, built from two batched queries
+// (in-edges of all callees, then the param nodes those edges point
+// from). It replaces a per-arg_of-edge paramNodeAtPosition, which
+// re-fetched a popular callee's whole in-edge list once per argument —
+// the dominant cost of the per-file dataflow pass on a large file. The
+// position is read from the param node's Meta exactly as
+// paramNodeAtPosition does, with the first param at a position winning.
+func buildParamPositionIndex(g graph.Store, callees map[string]struct{}) map[string]map[int]string {
+	if len(callees) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(callees))
+	for id := range callees {
+		ids = append(ids, id)
+	}
+	inEdges := g.GetInEdgesByNodeIDs(ids)
+	type ownerParam struct{ owner, param string }
+	var pairs []ownerParam
+	paramSet := make(map[string]struct{})
+	for owner, edges := range inEdges {
+		for _, e := range edges {
+			if e != nil && e.Kind == graph.EdgeParamOf && e.From != "" {
+				pairs = append(pairs, ownerParam{owner: owner, param: e.From})
+				paramSet[e.From] = struct{}{}
+			}
+		}
+	}
+	if len(pairs) == 0 {
+		return nil
+	}
+	paramIDs := make([]string, 0, len(paramSet))
+	for id := range paramSet {
+		paramIDs = append(paramIDs, id)
+	}
+	nodes := g.GetNodesByIDs(paramIDs)
+	idx := make(map[string]map[int]string, len(inEdges))
+	for _, pr := range pairs {
+		n := nodes[pr.param]
+		if n == nil || n.Kind != graph.KindParam {
+			continue
+		}
+		pos, ok := intFromMeta(n.Meta, "position")
+		if !ok {
+			continue
+		}
+		m := idx[pr.owner]
+		if m == nil {
+			m = make(map[int]string)
+			idx[pr.owner] = m
+		}
+		if _, exists := m[pos]; !exists {
+			m[pos] = n.ID
+		}
+	}
+	return idx
 }
 
 // rewriteReturnsTo lifts the placeholder From by joining on the

--- a/internal/resolver/method_receiver_rebind.go
+++ b/internal/resolver/method_receiver_rebind.go
@@ -35,8 +35,12 @@ import (
 // Scope: Go only — other languages (Java / TS / Python) group methods
 // inside the class body in the same file, so the cross-file pattern
 // doesn't arise. The method node's Language gates the rebind.
+// pkgKey identifies a Go type by its package directory and name — the
+// key the receiver-rebind type index is built on. Package-level so the
+// whole-graph and per-file builders share it.
+type pkgKey struct{ pkg, name string }
+
 func (r *Resolver) rebindGoMethodReceivers() {
-	type pkgKey struct{ pkg, name string }
 	typesIdx := make(map[pkgKey]string)
 	for _, kind := range []graph.NodeKind{graph.KindType, graph.KindInterface} {
 		// Server-side language scope: only Go type/interface nodes cross
@@ -45,41 +49,85 @@ func (r *Resolver) rebindGoMethodReceivers() {
 		// just to discard the non-Go majority — the bulk of this pass's
 		// cost on a large single-language graph.
 		for n := range r.nodesByKindLang(kind, "go") {
-			if n.Name == "" || n.FilePath == "" {
-				continue
-			}
-			k := pkgKey{filepath.Dir(n.FilePath), n.Name}
-			if existing, ok := typesIdx[k]; ok && existing != n.ID {
-				// Two distinct type nodes with the same name in the
-				// same package directory shouldn't happen in valid Go,
-				// but guard against it — leave the edge alone rather
-				// than pick an arbitrary winner.
-				typesIdx[k] = ""
-				continue
-			}
-			typesIdx[k] = n.ID
+			addGoTypeToIndex(typesIdx, n)
 		}
 	}
 	if len(typesIdx) == 0 {
 		return
 	}
-	// Materialise the MemberOf edges and batch-load their endpoints in one
-	// GetNodesByIDs: a per-edge GetNode(e.From)+GetNode(e.To) here is two
-	// query round-trips per method on a disk backend — across tens of
-	// thousands of methods it was a multi-minute cold-warmup stall.
 	var memberOf []*graph.Edge
-	ids := make(map[string]struct{})
 	for e := range r.graph.EdgesByKind(graph.EdgeMemberOf) {
 		memberOf = append(memberOf, e)
+	}
+	r.rebindMemberOf(typesIdx, memberOf)
+}
+
+// rebindGoMethodReceiversForFile is the single-file scope of
+// rebindGoMethodReceivers. A Go method's receiver type lives in the same
+// package (directory) as the method, and only the edited file's methods
+// carry a freshly-extracted phantom `<file>::Type` receiver — so the type
+// index is built from just that package's files and the MemberOf edges
+// from just the edited file's methods, instead of indexing every Go type
+// and scanning every MemberOf edge in the graph on each save (the
+// dominant per-edit cost on a large graph). dirIndex (built by
+// buildPassIndexes before this runs) supplies the package's files.
+func (r *Resolver) rebindGoMethodReceiversForFile(filePath string) {
+	typesIdx := make(map[pkgKey]string)
+	for _, fn := range r.dirIndex[filepath.Dir(filePath)] {
+		for _, n := range r.graph.GetFileNodes(fn.FilePath) {
+			if n != nil && n.Language == "go" &&
+				(n.Kind == graph.KindType || n.Kind == graph.KindInterface) {
+				addGoTypeToIndex(typesIdx, n)
+			}
+		}
+	}
+	if len(typesIdx) == 0 {
+		return
+	}
+	var memberOf []*graph.Edge
+	for _, n := range r.graph.GetFileNodes(filePath) {
+		for _, e := range r.graph.GetOutEdges(n.ID) {
+			if e.Kind == graph.EdgeMemberOf {
+				memberOf = append(memberOf, e)
+			}
+		}
+	}
+	r.rebindMemberOf(typesIdx, memberOf)
+}
+
+// addGoTypeToIndex records a Go type/interface node under (dir, name).
+// Two distinct nodes with the same name in the same package directory
+// shouldn't happen in valid Go; if they do, the entry is poisoned to ""
+// so the rebind leaves the edge alone rather than pick an arbitrary
+// winner.
+func addGoTypeToIndex(idx map[pkgKey]string, n *graph.Node) {
+	if n == nil || n.Name == "" || n.FilePath == "" {
+		return
+	}
+	k := pkgKey{filepath.Dir(n.FilePath), n.Name}
+	if existing, ok := idx[k]; ok && existing != n.ID {
+		idx[k] = ""
+		return
+	}
+	idx[k] = n.ID
+}
+
+// rebindMemberOf lifts each Go method's MemberOf edge from a phantom
+// `<methodfile>::TypeName` target onto the canonical type node from
+// typesIdx. Endpoints are batch-loaded in one GetNodesByIDs (a per-edge
+// GetNode here is two query round-trips per method on a disk backend).
+func (r *Resolver) rebindMemberOf(typesIdx map[pkgKey]string, memberOf []*graph.Edge) {
+	if len(memberOf) == 0 {
+		return
+	}
+	ids := make(map[string]struct{}, len(memberOf)*2)
+	for _, e := range memberOf {
 		if e.From != "" {
 			ids[e.From] = struct{}{}
 		}
 		if e.To != "" {
 			ids[e.To] = struct{}{}
 		}
-	}
-	if len(memberOf) == 0 {
-		return
 	}
 	idList := make([]string, 0, len(ids))
 	for id := range ids {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -1019,7 +1019,7 @@ func (r *Resolver) runFileAttributionPassesLocked() {
 // matches runFileAttributionPassesLocked: bare-name binding runs before
 // builtin attribution so a local named `len` shadows the builtin.
 func (r *Resolver) runFileAttributionPassesForFileLocked(filePath string) {
-	r.rebindGoMethodReceivers()
+	r.rebindGoMethodReceiversForFile(filePath)
 	r.bindBareNameScopeRefsForFile(filePath)
 	r.bindGenericParamRefs()
 	r.attributeGoBuiltinsForFile(filePath)


### PR DESCRIPTION
## Why

Follow-up to #187 (merged at its 5-commit state). That PR landed the FTS docid-delete, attribution scoping, and candidate-cache warming. Profiling the result revealed three more whole-graph / per-edge passes that dominate the *remaining* per-edit reindex cost — especially for **typical small edits**, where the constant-cost passes don't shrink with file size. Same measurement-driven, structurally-safe approach; guarded by the existing `incremental == cold` convergence + dataflow-scoped-equivalence tests.

## Result (full per-edit `IndexFile_resolve`, on a 33.8k-node graph)

| file | after #187 | this PR |
|---|---|---|
| **typical** (132-line file) | 715 ms | **116 ms** |
| **worst case** (5k-line `golang.go`) | 3.2 s* | **1.24 s** |

\* #187 lowered the worst case to ~3.2s; these three take it to 1.24s.

## The three fixes

1. **`perf(indexer)`: batch param-position lookups in the per-file dataflow pass** — `materializeDataflowParamsForFile` rewrote each `arg_of` edge via `paramNodeAtPosition → GetInEdges(callee)`, re-fetching a popular callee's entire in-edge list *once per argument* (42% of `indexFile` on a large file). Build a `callee → position → param` index once from two batched queries. **4.3s → 2.2s.**
2. **`perf(store)`: evict a file's edges in chunked `IN` batches** — eviction ran one `DELETE … WHERE from_id=? OR to_id=?` per node (a statement + WAL commit each); chunked `IN` makes it 2 index-driven deletes per ~900 nodes. **2.2s → 1.3s.**
3. **`perf(resolver)`: scope method-receiver rebind to the edited file's package** — `rebindGoMethodReceivers` indexed every Go type and scanned every `MemberOf` edge on each save: a whole-graph sweep that's **~94% of a typical edit's resolver cost** and constant in file size. A Go method's receiver type lives in its own package, so the per-file path builds the type index from just that package's files and rebinds only the edited file's methods. **This is the 715ms → 116ms typical-edit win.**

## Tests
`-race` green on `store_sqlite`, `resolver`, `indexer`. The convergence and dataflow-scoped-equivalence tests guard that the scoped passes match the whole-graph result exactly; `EvictFile`/`EvictRepo` conformance covers the chunked delete. gofmt / golangci-lint / wire-contract golden clean.
