### PR TITLE
fix(daemon): keep daemon responsive when LSP enrichment wedges

### DIFF
--- a/cmd/gortex/daemon_controller.go
+++ b/cmd/gortex/daemon_controller.go
@@ -613,6 +613,21 @@ func resolveSearchBackend(b search.Backend) searchBackendInfo {
 // fields (PID, uptime, socket, session count) are filled in by the
 // daemon itself before the response goes out.
 func (c *realController) Status(_ context.Context) (daemon.StatusResponse, error) {
+	// Compute the per-repo memory estimate BEFORE taking the coarse
+	// controller mutex. On the SQLite backend AllRepoMemoryEstimates is a
+	// COUNT … GROUP BY scan that turns pathologically slow under
+	// enrichment write load; holding c.mu across it stalls every other
+	// control request (status / track / reload) queued on the mutex — the
+	// daemon-looks-crashed symptom. Snapshot the graph handle under a
+	// brief lock, then run the (store-memoised) estimate lock-free.
+	c.mu.Lock()
+	g := c.graph
+	c.mu.Unlock()
+	var memEstimates map[string]graph.RepoMemoryEstimate
+	if g != nil {
+		memEstimates = g.AllRepoMemoryEstimates()
+	}
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -622,18 +637,11 @@ func (c *realController) Status(_ context.Context) (daemon.StatusResponse, error
 		totalNodes               int
 	)
 	if c.multiIndexer != nil {
-		// Pull every repo's running counters (node/edge counts + byte
-		// estimates) in one pass — O(shard count · repo count), no
-		// graph walk. This used to call c.graph.RepoStats() which
-		// walked every edge to attribute by source-repo (the per-edge
-		// fromNode lookup), and then c.graph.RepoMemoryEstimate(prefix)
-		// inside the per-repo loop — combined cost ~1.2s on a 1.1M-edge
-		// graph and the single biggest source of writer-lock blocking
-		// during warmup.
-		var memEstimates map[string]graph.RepoMemoryEstimate
-		if c.graph != nil {
-			memEstimates = c.graph.AllRepoMemoryEstimates()
-		}
+		// memEstimates (per-repo node/edge counts + byte estimates) was
+		// computed above, before the controller mutex was taken — see the
+		// note at the top of Status. The SQLite store memoises it so a
+		// burst of status polls collapses onto one COUNT … GROUP BY scan;
+		// the in-memory store serves maintained shard counters directly.
 
 		// Diagnostic: when AllMetadata has tracked repos but
 		// AllRepoMemoryEstimates returns nothing (or a much smaller

--- a/internal/graph/store_sqlite/store.go
+++ b/internal/graph/store_sqlite/store.go
@@ -90,6 +90,17 @@ type Store struct {
 	// makes SearchSymbolBundles fall through to the uncached path.
 	bundles *bundleCache
 
+	// memEst memoises AllRepoMemoryEstimates for a short TTL. That query
+	// is two COUNT(*) … GROUP BY repo scans; on a large graph under
+	// enrichment write load the pure-Go modernc sqlite count is
+	// pathologically slow, and the daemon status path can call it
+	// repeatedly. The TTL (and the mutex held across the recompute)
+	// collapses a burst of status polls onto a single scan; a few
+	// seconds of staleness is irrelevant for an advisory estimate.
+	memEstMu  sync.Mutex
+	memEstVal map[string]graph.RepoMemoryEstimate
+	memEstAt  time.Time
+
 	// Prepared statements (compiled once in Open, closed in Close).
 	stmtInsertNode         *sql.Stmt
 	stmtGetNode            *sql.Stmt
@@ -1433,7 +1444,30 @@ func (s *Store) RepoMemoryEstimate(repoPrefix string) graph.RepoMemoryEstimate {
 	return est
 }
 
+// memEstTTL bounds how long AllRepoMemoryEstimates serves a memoised
+// result before recomputing. The estimate is advisory (status display),
+// so a few seconds of staleness is fine, and the TTL keeps a burst of
+// status polls from each triggering a full COUNT … GROUP BY scan.
+const memEstTTL = 3 * time.Second
+
+func cloneRepoMemEstimates(m map[string]graph.RepoMemoryEstimate) map[string]graph.RepoMemoryEstimate {
+	out := make(map[string]graph.RepoMemoryEstimate, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
 func (s *Store) AllRepoMemoryEstimates() map[string]graph.RepoMemoryEstimate {
+	// Hold memEstMu across the recompute so a burst of concurrent status
+	// polls collapses onto one scan: the first caller computes and
+	// caches, the rest block briefly and then hit the fresh cache.
+	s.memEstMu.Lock()
+	defer s.memEstMu.Unlock()
+	if s.memEstVal != nil && time.Since(s.memEstAt) < memEstTTL {
+		return cloneRepoMemEstimates(s.memEstVal)
+	}
+
 	out := map[string]graph.RepoMemoryEstimate{}
 	rows, err := s.stmtAllRepoCountsNodes.Query()
 	if err != nil {
@@ -1474,7 +1508,12 @@ func (s *Store) AllRepoMemoryEstimates() map[string]graph.RepoMemoryEstimate {
 		out[repo] = est
 	}
 	_ = rows.Close()
-	return out
+
+	// Cache only on the full-success path — the early error returns above
+	// leave a partial `out` and must not poison the cache.
+	s.memEstVal = out
+	s.memEstAt = time.Now()
+	return cloneRepoMemEstimates(out)
 }
 
 // -- helpers --------------------------------------------------------------

--- a/internal/graph/store_sqlite/store_memest_test.go
+++ b/internal/graph/store_sqlite/store_memest_test.go
@@ -1,0 +1,54 @@
+package store_sqlite_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+)
+
+// TestAllRepoMemoryEstimates_Memoized verifies the short-TTL memoisation:
+// within the TTL a second call serves the cached estimate instead of
+// re-running the COUNT … GROUP BY scan, so the status path can poll cheaply
+// even while enrichment is writing to the same store.
+func TestAllRepoMemoryEstimates_Memoized(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "g.sqlite")
+	s, err := store_sqlite.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	totalNodes := func(m map[string]graph.RepoMemoryEstimate) int {
+		n := 0
+		for _, e := range m {
+			n += e.NodeCount
+		}
+		return n
+	}
+
+	s.AddBatch([]*graph.Node{
+		{ID: "a.go::Foo", Kind: graph.KindFunction, Name: "Foo", FilePath: "a.go", RepoPrefix: "r1"},
+		{ID: "a.go::Bar", Kind: graph.KindFunction, Name: "Bar", FilePath: "a.go", RepoPrefix: "r1"},
+	}, nil)
+
+	first := s.AllRepoMemoryEstimates()
+	require.Equal(t, 2, totalNodes(first))
+
+	// Add another node; within the memoisation TTL the estimate is served
+	// from cache, so the freshly-added node is intentionally not yet
+	// reflected — proof the COUNT scan was skipped.
+	s.AddBatch([]*graph.Node{
+		{ID: "b.go::Baz", Kind: graph.KindFunction, Name: "Baz", FilePath: "b.go", RepoPrefix: "r1"},
+	}, nil)
+	cached := s.AllRepoMemoryEstimates()
+	require.Equal(t, 2, totalNodes(cached), "within the TTL the result should be the memoised value, not a fresh COUNT")
+
+	// The returned map is a copy: mutating it must not corrupt the cache.
+	for k := range cached {
+		delete(cached, k)
+	}
+	again := s.AllRepoMemoryEstimates()
+	require.Equal(t, 2, totalNodes(again), "the cache must hand back an independent copy")
+}

--- a/internal/semantic/enrich_deadline_test.go
+++ b/internal/semantic/enrich_deadline_test.go
@@ -1,0 +1,99 @@
+package semantic
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// TestManager_EnrichOne_AbandonsOnDeadline verifies the per-repo enrichment
+// deadline: a provider that blocks past the deadline is abandoned (the
+// enrichment WaitGroup proceeds) rather than pinning it indefinitely — the
+// MSBuild/Roslyn-stuck failure mode, generalised to "slow across many
+// symbols".
+func TestManager_EnrichOne_AbandonsOnDeadline(t *testing.T) {
+	t.Setenv("GORTEX_LSP_ENRICH_TIMEOUT", "50ms")
+
+	cfg := Config{
+		Enabled: true,
+		Providers: []ProviderConfig{
+			{Name: "slow-go", Languages: []string{"go"}, Priority: 1, Enabled: true},
+		},
+	}
+	mgr := NewManager(cfg, zap.NewNop())
+
+	release := make(chan struct{})
+	var enrichReturned atomic.Bool
+	mgr.RegisterProvider(&mockProvider{
+		name:      "slow-go",
+		languages: []string{"go"},
+		available: true,
+		enrichFunc: func(g graph.Store, root string) (*EnrichResult, error) {
+			<-release // block well past the 50ms deadline
+			enrichReturned.Store(true)
+			return &EnrichResult{Provider: "slow-go", Language: "go"}, nil
+		},
+	})
+
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "main.go::main", Kind: graph.KindFunction, Name: "main", FilePath: "main.go", Language: "go"})
+	roots := map[string]string{"default": "/tmp/test"}
+
+	resultCh := make(chan []*EnrichResult, 1)
+	go func() {
+		res, _ := mgr.EnrichAll(g, roots)
+		resultCh <- res
+	}()
+
+	select {
+	case res := <-resultCh:
+		// The abandoned provider contributes no result.
+		assert.Empty(t, res, "enrichment past the per-repo deadline must be abandoned, yielding no result")
+	case <-time.After(3 * time.Second):
+		close(release)
+		t.Fatal("EnrichAll blocked on a slow provider instead of abandoning it at the deadline")
+	}
+
+	// Unblock the detached goroutine so it unwinds cleanly.
+	close(release)
+	require.Eventually(t, enrichReturned.Load, time.Second, 10*time.Millisecond,
+		"the abandoned enrichment goroutine should still drain and return")
+}
+
+// TestManager_EnrichOne_DisabledDeadline verifies the bound can be switched
+// off: with GORTEX_LSP_ENRICH_TIMEOUT=off a provider runs to completion even
+// if slow.
+func TestManager_EnrichOne_DisabledDeadline(t *testing.T) {
+	t.Setenv("GORTEX_LSP_ENRICH_TIMEOUT", "off")
+
+	cfg := Config{
+		Enabled: true,
+		Providers: []ProviderConfig{
+			{Name: "go", Languages: []string{"go"}, Priority: 1, Enabled: true},
+		},
+	}
+	mgr := NewManager(cfg, zap.NewNop())
+	mgr.RegisterProvider(&mockProvider{
+		name:      "go",
+		languages: []string{"go"},
+		available: true,
+		enrichFunc: func(g graph.Store, root string) (*EnrichResult, error) {
+			time.Sleep(80 * time.Millisecond)
+			return &EnrichResult{Provider: "go", Language: "go", EdgesConfirmed: 7}, nil
+		},
+	})
+
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "main.go::main", Kind: graph.KindFunction, Name: "main", FilePath: "main.go", Language: "go"})
+
+	results, err := mgr.EnrichAll(g, map[string]string{"default": "/tmp/test"})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, 7, results[0].EdgesConfirmed)
+}

--- a/internal/semantic/lsp/client.go
+++ b/internal/semantic/lsp/client.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"go.uber.org/zap"
 )
@@ -31,6 +32,16 @@ type Client struct {
 	pending   sync.Map // reqID → chan *jsonRPCResponse
 	logger    *zap.Logger
 	done      chan struct{}
+
+	// callTimeout bounds how long a single Call waits for a reply
+	// before giving up. Zero means unbounded (the historical
+	// behaviour). It is set after the initialize handshake completes
+	// (see Provider.ensureClient) so a wedged server — e.g. csharp-ls
+	// stuck loading an MSBuild workspace, alive but never replying —
+	// can no longer block an enrichment hover / findReferences Call
+	// forever. Stored atomically: SetCallTimeout may race the read
+	// loop and concurrent Call goroutines.
+	callTimeout atomic.Int64 // time.Duration nanoseconds
 
 	mu     sync.Mutex
 	closed bool
@@ -289,6 +300,12 @@ func (c *Client) OnRequest(method string, h RequestHandler) {
 // terminates (server exited or stdin/stdout error).
 func (c *Client) Done() <-chan struct{} { return c.done }
 
+// SetCallTimeout bounds how long subsequent Call invocations wait for a
+// reply. A non-positive duration restores the unbounded behaviour.
+// Callers typically set this only after the initialize handshake has
+// completed, leaving the (possibly slow) cold-workspace load unbounded.
+func (c *Client) SetCallTimeout(d time.Duration) { c.callTimeout.Store(int64(d)) }
+
 // Call sends a request and waits for the response.
 func (c *Client) Call(method string, params any, result any) error {
 	id := c.reqID.Add(1)
@@ -308,7 +325,17 @@ func (c *Client) Call(method string, params any, result any) error {
 		return fmt.Errorf("send %s: %w", method, err)
 	}
 
-	// Wait for response.
+	// Wait for response. A bounded callTimeout (set after the
+	// initialize handshake) guards against a server that is alive but
+	// never replies. A nil timer channel — callTimeout <= 0 — blocks
+	// forever in the select, preserving the historical unbounded
+	// behaviour for callers that never set a timeout.
+	var timeout <-chan time.Time
+	if d := time.Duration(c.callTimeout.Load()); d > 0 {
+		t := time.NewTimer(d)
+		defer t.Stop()
+		timeout = t.C
+	}
 	select {
 	case resp := <-respCh:
 		if resp.Error != nil {
@@ -320,6 +347,8 @@ func (c *Client) Call(method string, params any, result any) error {
 		return nil
 	case <-c.done:
 		return fmt.Errorf("LSP server exited")
+	case <-timeout:
+		return fmt.Errorf("LSP call %s: timeout after %s", method, time.Duration(c.callTimeout.Load()))
 	}
 }
 
@@ -421,6 +450,16 @@ func (c *Client) readResponses() {
 		c.mu.Unlock()
 	}()
 
+	// malformedFrames counts consecutive header blocks that yielded no
+	// usable Content-Length. A healthy server never does this; a
+	// desynced or chatty one can emit a run of blank / garbage lines
+	// that would otherwise spin this loop on `continue`, burning a core
+	// (and, since the read loop never returns, never closing c.done to
+	// unblock pending Call()s). We tolerate a bounded run so a transient
+	// desync self-heals, then drop the connection.
+	const maxMalformedFrames = 64
+	malformedFrames := 0
+
 	for {
 		// Read headers.
 		contentLength := -1
@@ -440,8 +479,15 @@ func (c *Client) readResponses() {
 		}
 
 		if contentLength < 0 {
+			malformedFrames++
+			if malformedFrames >= maxMalformedFrames {
+				c.logger.Debug("LSP: too many malformed frames, dropping connection",
+					zap.Int("count", malformedFrames))
+				return
+			}
 			continue
 		}
+		malformedFrames = 0
 
 		// Read body.
 		body := make([]byte, contentLength)

--- a/internal/semantic/lsp/client_timeout_test.go
+++ b/internal/semantic/lsp/client_timeout_test.go
@@ -1,0 +1,92 @@
+package lsp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLSP_Client_CallTimesOut verifies that a bounded callTimeout unblocks a
+// Call against a server that received the request but never replies — the
+// csharp-ls-stuck-in-MSBuild failure mode. Without the bound this Call would
+// block forever and stall the enrichment WaitGroup.
+func TestLSP_Client_CallTimesOut(t *testing.T) {
+	c, serverIn, _, cleanup := newPipedClient(t)
+	defer cleanup()
+
+	c.SetCallTimeout(50 * time.Millisecond)
+
+	// Fake server: consume the request so the client's framed send
+	// completes, then go silent — never write a response.
+	go func() {
+		_, _ = readFramed(serverIn)
+	}()
+
+	done := make(chan error, 1)
+	go func() { done <- c.Call("test/never", nil, nil) }()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "timeout")
+		assert.Contains(t, err.Error(), "test/never")
+	case <-time.After(2 * time.Second):
+		t.Fatal("Call did not return after its call timeout — the timeout case never fired")
+	}
+}
+
+// TestLSP_Client_CallHonorsTimeoutHappyPath verifies the timer case does not
+// disturb the normal round-trip: a server that replies well within the bound
+// still resolves successfully.
+func TestLSP_Client_CallHonorsTimeoutHappyPath(t *testing.T) {
+	c, serverIn, serverOut, cleanup := newPipedClient(t)
+	defer cleanup()
+
+	c.SetCallTimeout(5 * time.Second)
+
+	go func() {
+		body, ok := readFramed(serverIn)
+		if !ok {
+			return
+		}
+		var req jsonRPCRequest
+		_ = json.Unmarshal(body, &req)
+		writeFramed(t, serverOut, jsonRPCResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Result:  json.RawMessage(`"ok"`),
+		})
+	}()
+
+	var result string
+	require.NoError(t, c.Call("test/echo", nil, &result))
+	assert.Equal(t, "ok", result)
+}
+
+// TestLSP_Client_ReadLoopDropsOnMalformedFrames verifies the read loop does
+// not spin forever on a server that emits a run of Content-Length-less header
+// blocks: past the bounded tolerance it drops the connection (closing done so
+// pending Call()s unblock) instead of burning a core on `continue`.
+func TestLSP_Client_ReadLoopDropsOnMalformedFrames(t *testing.T) {
+	c, _, serverOut, cleanup := newPipedClient(t)
+	defer cleanup()
+
+	// Each blank line is one header block that terminates immediately with
+	// no Content-Length — a malformed frame. Emit comfortably more than the
+	// drop threshold in one write; bufio buffers them, so readResponses
+	// processes them without the pipe write blocking past the drop point.
+	go func() {
+		_, _ = serverOut.Write([]byte(strings.Repeat("\r\n", 128)))
+	}()
+
+	select {
+	case <-c.Done():
+		// readResponses returned and closed done — the spin guard fired.
+	case <-time.After(2 * time.Second):
+		t.Fatal("read loop did not drop the connection on a flood of malformed frames")
+	}
+}

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -920,6 +920,32 @@ func (p *Provider) dialOrSpawn(workspaceRoot string) (*Client, error) {
 	return NewClient(p.command, p.args, p.env, workspaceRoot, p.logger)
 }
 
+// defaultLSPCallTimeout bounds a single post-initialize LSP request.
+// A wedged server — e.g. csharp-ls stuck loading an MSBuild workspace,
+// alive but never replying — would otherwise let an enrichment hover /
+// findReferences Call block forever and stall the whole enrichment
+// WaitGroup. The initialize handshake itself is left unbounded (a cold
+// .NET / Java workspace load can legitimately run for minutes).
+const defaultLSPCallTimeout = 30 * time.Second
+
+// lspCallTimeout resolves the post-initialize Call bound, honouring the
+// GORTEX_LSP_CALL_TIMEOUT env override (a Go duration such as "45s";
+// "0" / "off" / "none" disables the bound). An unparseable value falls
+// back to the default.
+func lspCallTimeout() time.Duration {
+	switch v := strings.TrimSpace(os.Getenv("GORTEX_LSP_CALL_TIMEOUT")); v {
+	case "":
+		return defaultLSPCallTimeout
+	case "0", "off", "none":
+		return 0
+	default:
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+		return defaultLSPCallTimeout
+	}
+}
+
 // ensureClient starts the LSP server if not already running, OR
 // reconnects if the previous client's transport went away (e.g. the
 // IDE that owned a passive-attach LSP restarted, closing the socket).
@@ -1100,6 +1126,11 @@ func (p *Provider) ensureClient(workspaceRoot string) error {
 		_ = client.Shutdown()
 		return fmt.Errorf("initialized: %w", err)
 	}
+
+	// The (possibly slow) cold-workspace load is done — bound every
+	// subsequent request so a server that wedges mid-session can no
+	// longer block an enrichment Call forever. See lspCallTimeout.
+	client.SetCallTimeout(lspCallTimeout())
 
 	p.client = client
 	return nil

--- a/internal/semantic/manager.go
+++ b/internal/semantic/manager.go
@@ -2,7 +2,9 @@ package semantic
 
 import (
 	"fmt"
+	"os"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -364,6 +366,34 @@ func (m *Manager) runEnrichForProvider(g graph.Store, roots map[string]string, l
 	return results
 }
 
+// defaultEnrichRepoTimeout caps how long one provider's per-repo
+// enrichment may run before the manager abandons it and moves on. The
+// per-call LSP timeout (see lsp.Provider.ensureClient) already bounds a
+// single wedged request; this bounds a provider that is merely slow
+// across many symbols — e.g. a server stuck behind a never-finishing
+// MSBuild/Roslyn load — so it can no longer pin the enrichment WaitGroup
+// for hours. Generous on purpose: a legitimately large repo enriches
+// well within it. 0 / "off" disables the bound.
+const defaultEnrichRepoTimeout = 10 * time.Minute
+
+// enrichRepoTimeout resolves the per-repo enrichment deadline, honouring
+// the GORTEX_LSP_ENRICH_TIMEOUT env override (a Go duration such as
+// "5m"; "0" / "off" / "none" disables it). An unparseable value falls
+// back to the default.
+func enrichRepoTimeout() time.Duration {
+	switch v := strings.TrimSpace(os.Getenv("GORTEX_LSP_ENRICH_TIMEOUT")); v {
+	case "":
+		return defaultEnrichRepoTimeout
+	case "0", "off", "none":
+		return 0
+	default:
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+		return defaultEnrichRepoTimeout
+	}
+}
+
 // runEnrichOne runs one provider against one repo root and appends the
 // result. Split out of runEnrichForProvider so the Router-backed path can
 // fetch a per-repo provider instance (keyed by the repo's workspace) before
@@ -381,12 +411,50 @@ func (m *Manager) runEnrichOne(g graph.Store, repoName, repoRoot, lang string, p
 	// repo prefix (the MultiIndexer keys roots by prefix; the per-repo
 	// indexer passes its own RepoPrefix()); a repo-scoped provider uses
 	// it to scope file selection to the repo actually being enriched.
+	//
+	// Run the (possibly long) provider pass on its own goroutine and bound
+	// it with a per-repo deadline: a provider that is slow across many
+	// symbols — e.g. a server stuck behind an MSBuild/Roslyn load — must
+	// not pin the enrichment WaitGroup indefinitely. On deadline we log
+	// and move on; the detached goroutine still drains (its LSP calls are
+	// individually bounded and its graph mutations are internally
+	// synchronized) and exits on its own.
+	type enrichOutcome struct {
+		result *EnrichResult
+		err    error
+	}
+	done := make(chan enrichOutcome, 1)
+	go func() {
+		var result *EnrichResult
+		var err error
+		if rsp, ok := provider.(RepoScopedProvider); ok {
+			result, err = rsp.EnrichRepo(g, repoName, repoRoot)
+		} else {
+			result, err = provider.Enrich(g, repoRoot)
+		}
+		done <- enrichOutcome{result, err}
+	}()
+
 	var result *EnrichResult
 	var err error
-	if rsp, ok := provider.(RepoScopedProvider); ok {
-		result, err = rsp.EnrichRepo(g, repoName, repoRoot)
+	if d := enrichRepoTimeout(); d > 0 {
+		timer := time.NewTimer(d)
+		select {
+		case oc := <-done:
+			timer.Stop()
+			result, err = oc.result, oc.err
+		case <-timer.C:
+			m.logger.Warn("semantic enrichment exceeded per-repo deadline; abandoning",
+				zap.String("provider", provider.Name()),
+				zap.String("language", lang),
+				zap.String("repo", repoName),
+				zap.Duration("deadline", d),
+			)
+			return results
+		}
 	} else {
-		result, err = provider.Enrich(g, repoRoot)
+		oc := <-done
+		result, err = oc.result, oc.err
 	}
 	if err != nil {
 		m.logger.Warn("semantic enrichment failed",


### PR DESCRIPTION
keep daemon responsive when LSP enrichment wedges
A repo containing .NET projects could make the daemon look crashed
(control socket present, every tool call i/o timeout, CPU pegged): the
C# LSP gets stuck loading an MSBuild/Roslyn workspace and an enrichment
findReferences Call blocks forever, while the status path runs a slow
SQLite COUNT … GROUP BY under the coarse controller mutex and stalls
every queued control request.

Fix https://github.com/zzet/gortex/pull/1 (core) — bound a single post-initialize LSP request:
- lsp.Client gains an atomic callTimeout + SetCallTimeout; Call selects
  on a timer (nil channel = unbounded, preserving prior behaviour).
- Provider.ensureClient applies it AFTER the initialize/initialized
  handshake (default 30s, GORTEX_LSP_CALL_TIMEOUT, "0"/"off"/"none" to
  disable) so a cold workspace load stays unbounded but a server that
  wedges mid-session can no longer block enrichment forever.
- Manager.runEnrichOne runs the provider on a goroutine bounded by a
  per-repo deadline (default 10m, GORTEX_LSP_ENRICH_TIMEOUT); on
  deadline it logs and moves on while the detached goroutine drains.

Fix https://github.com/zzet/gortex/pull/2 — read-loop spin guard: readResponses drops the connection after
maxMalformedFrames (64) consecutive Content-Length-less header blocks
instead of spinning on continue and pinning a core.

Fix #3a — lock-light Status: AllRepoMemoryEstimates is memoised in the
SQLite store with a 3s TTL (mutex held across recompute = singleflight),
and realController.Status computes it off the controller mutex.

Tests: client_timeout_test.go, enrich_deadline_test.go,
store_memest_test.go. go build ./... clean; go test -race green on
internal/semantic, internal/semantic/lsp, internal/graph/store_sqlite,
cmd/gortex.
- 

## Testing

- [ ] All tests pass (`go test -race ./...`)
- [ ] New tests added for new functionality
- [ ] Benchmarks run if performance-relevant

## Checklist

- [ ] Code follows existing patterns in the codebase
- [ ] No unnecessary abstractions added
- [ ] Language extractor includes `Meta["methods"]` for interfaces (if applicable)
- [ ] Methods have `EdgeMemberOf` edges to their containing type (if applicable)
