### PR TITLE
fix(mcp): confine agent-facing write tools to indexed repository roots

### DIFF
--- a/internal/mcp/tools_export.go
+++ b/internal/mcp/tools_export.go
@@ -34,6 +34,22 @@ func (s *Server) registerExportTools() {
 	)
 }
 
+// confineCallerPaths reports whether caller-supplied filesystem paths in the
+// current request must be confined to an indexed repository root.
+//
+// It is true for an MCP agent session — the prompt-injection surface, where a
+// tool's path argument can be attacker-influenced — and false for the local
+// control / CLI channel, which is operator-driven and may write anywhere it
+// likes (e.g. `gortex export --out /any/path`).
+//
+// The discriminator is the session cwd: the MCP proxy stamps every agent
+// session with the connecting client's working directory (daemon.Handshake.CWD)
+// before any tool call, and an agent cannot clear it from a tool-call frame.
+// The control / CLI channel and the embedded stdio server carry none.
+func (s *Server) confineCallerPaths(ctx context.Context) bool {
+	return SessionCWDFromContext(ctx) != ""
+}
+
 func (s *Server) handleExportGraph(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	g := s.graph
 	if g == nil {
@@ -60,6 +76,27 @@ func (s *Server) handleExportGraph(ctx context.Context, req mcp.CallToolRequest)
 
 	outputPath := stringArg(args, "output_path")
 	outputDir := stringArg(args, "output_dir")
+
+	// Confine caller-named output paths to indexed repository roots when the
+	// request comes from an MCP agent — a prompt-injected agent must not be
+	// able to drive the daemon into writing (or MkdirAll-creating) a tree
+	// outside any indexed repo. The local CLI / control channel is
+	// operator-driven and exempt: `gortex export --out/--out-dir` asks for the
+	// write in the user's own name and may target any path.
+	if s.confineCallerPaths(ctx) {
+		for _, p := range []string{outputPath, outputDir} {
+			if p == "" {
+				continue
+			}
+			abs, err := filepath.Abs(p)
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("export: resolve output path %q: %v", p, err)), nil
+			}
+			if err := s.guardSymlinkWithinRepo(abs); err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+		}
+	}
 
 	// Mermaid multi-file: one file per scope under output_dir.
 	if format == "mermaid" && outputDir != "" {

--- a/internal/mcp/tools_export_confine_test.go
+++ b/internal/mcp/tools_export_confine_test.go
@@ -1,0 +1,66 @@
+package mcp
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func exportGraphTool(t *testing.T, srv *Server, ctx context.Context, args map[string]any) *mcplib.CallToolResult {
+	t.Helper()
+	req := mcplib.CallToolRequest{}
+	req.Params.Name = "export_graph"
+	req.Params.Arguments = args
+	res, err := srv.handleExportGraph(ctx, req)
+	require.NoError(t, err)
+	return res
+}
+
+// TestExportGraph_ConfinesAgentOutputPaths proves the export write sink
+// confines caller-named output_path / output_dir to indexed repository roots
+// for an MCP agent session (the prompt-injection surface) while leaving the
+// local CLI / control channel — which carries no session cwd — free to write
+// anywhere the operator names.
+func TestExportGraph_ConfinesAgentOutputPaths(t *testing.T) {
+	srv, _, repoRoot := newSingleRepoServer(t)
+	// Resolve the repo root the way the guard does (EvalSymlinks), so an
+	// in-repo target compares equal on platforms where the temp dir is a
+	// symlink (macOS /var -> /private/var).
+	realRoot, err := filepath.EvalSymlinks(repoRoot)
+	require.NoError(t, err)
+	outside := t.TempDir()
+
+	escapeFile := filepath.Join(outside, "escape.cypher")
+	escapeDir := filepath.Join(outside, "escape-dir")
+
+	// An MCP agent session always carries the connecting client's cwd.
+	agentCtx := WithSessionCWD(context.Background(), realRoot)
+
+	// 1. Agent + absolute output_path outside every repo root → refused, no write.
+	res := exportGraphTool(t, srv, agentCtx, map[string]any{"format": "cypher", "output_path": escapeFile})
+	require.True(t, res.IsError, "agent write outside every repo root must be refused")
+	txt, _ := singleTextContent(res)
+	require.Contains(t, txt, "outside every indexed repository")
+	require.NoFileExists(t, escapeFile)
+
+	// 2. Agent + absolute output_dir outside every repo root → refused before MkdirAll runs.
+	res = exportGraphTool(t, srv, agentCtx, map[string]any{"format": "mermaid", "scope": "architecture", "output_dir": escapeDir})
+	require.True(t, res.IsError, "agent out-dir outside every repo root must be refused")
+	require.NoDirExists(t, escapeDir)
+
+	// 3. Agent + in-repo output_path → allowed (no false positive: agents may still export within the repo).
+	inFile := filepath.Join(realRoot, "graph.cypher")
+	res = exportGraphTool(t, srv, agentCtx, map[string]any{"format": "cypher", "output_path": inFile})
+	okTxt, _ := singleTextContent(res)
+	require.False(t, res.IsError, "in-repo agent export must be allowed: %s", okTxt)
+	require.FileExists(t, inFile)
+
+	// 4. Local CLI / control channel (no session cwd) → may write outside the repo.
+	cliRes := exportGraphTool(t, srv, context.Background(), map[string]any{"format": "cypher", "output_path": escapeFile})
+	cliTxt, _ := singleTextContent(cliRes)
+	require.False(t, cliRes.IsError, "CLI export must be unrestricted: %s", cliTxt)
+	require.FileExists(t, escapeFile)
+}

--- a/internal/mcp/tools_lsp.go
+++ b/internal/mcp/tools_lsp.go
@@ -168,11 +168,32 @@ func (s *Server) handleGetCodeActions(ctx context.Context, req mcp.CallToolReque
 	})
 }
 
+// guardCallerPath confines an agent-supplied file path to an indexed
+// repository root. It is a no-op for the local CLI / control channel
+// (confineCallerPaths == false, e.g. the `gortex` CLI verbs). It returns a
+// non-nil error when an MCP agent names a path resolving outside every
+// indexed root, so a prompt-injected agent cannot drive an LSP write
+// (apply_code_action / fix_all_in_file) onto a file outside the repo that
+// the daemon user happens to be able to reach.
+func (s *Server) guardCallerPath(ctx context.Context, path string) error {
+	if !s.confineCallerPaths(ctx) {
+		return nil
+	}
+	abs, err := s.absolutePath(path)
+	if err != nil {
+		return err
+	}
+	return s.guardSymlinkWithinRepo(abs)
+}
+
 // handleApplyCodeAction implements the `apply_code_action` tool.
 func (s *Server) handleApplyCodeAction(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	path, err := req.RequireString("path")
 	if err != nil {
 		return mcp.NewToolResultError("path is required"), nil
+	}
+	if cerr := s.guardCallerPath(ctx, path); cerr != nil {
+		return mcp.NewToolResultError(cerr.Error()), nil
 	}
 	idx := req.GetInt("index", -1)
 	if idx < 0 {
@@ -220,6 +241,9 @@ func (s *Server) handleFixAllInFile(ctx context.Context, req mcp.CallToolRequest
 	path, err := req.RequireString("path")
 	if err != nil {
 		return mcp.NewToolResultError("path is required"), nil
+	}
+	if cerr := s.guardCallerPath(ctx, path); cerr != nil {
+		return mcp.NewToolResultError(cerr.Error()), nil
 	}
 	provider, absPath, err := s.lspProviderForPath(path)
 	if err != nil {

--- a/internal/mcp/tools_lsp_confine_test.go
+++ b/internal/mcp/tools_lsp_confine_test.go
@@ -1,0 +1,66 @@
+package mcp
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func lspWriteTool(t *testing.T, srv *Server, ctx context.Context, tool string, args map[string]any) *mcplib.CallToolResult {
+	t.Helper()
+	req := mcplib.CallToolRequest{}
+	req.Params.Name = tool
+	req.Params.Arguments = args
+	var (
+		res *mcplib.CallToolResult
+		err error
+	)
+	switch tool {
+	case "apply_code_action":
+		res, err = srv.handleApplyCodeAction(ctx, req)
+	case "fix_all_in_file":
+		res, err = srv.handleFixAllInFile(ctx, req)
+	default:
+		t.Fatalf("unknown tool %q", tool)
+	}
+	require.NoError(t, err)
+	return res
+}
+
+// TestLSPWrite_ConfinesAgentPaths proves apply_code_action / fix_all_in_file
+// refuse an agent-supplied path that escapes every indexed repository root —
+// otherwise the LSP would open and rewrite a file outside the repo — while the
+// local CLI / control channel (no session cwd) stays exempt. The confinement
+// guard runs before any LSP is consulted, so this test needs no language
+// server (an in-repo path simply fails later for lack of a provider).
+func TestLSPWrite_ConfinesAgentPaths(t *testing.T) {
+	srv, _, repoRoot := newSingleRepoServer(t)
+	realRoot, err := filepath.EvalSymlinks(repoRoot)
+	require.NoError(t, err)
+	outside := filepath.Join(t.TempDir(), "victim.go")
+
+	agentCtx := WithSessionCWD(context.Background(), realRoot)
+	const confined = "outside every indexed repository"
+
+	for _, tool := range []string{"apply_code_action", "fix_all_in_file"} {
+		// Agent + out-of-repo path → refused by the confinement guard.
+		res := lspWriteTool(t, srv, agentCtx, tool, map[string]any{"path": outside, "index": 0})
+		require.True(t, res.IsError, "%s: agent out-of-repo path must be refused", tool)
+		txt, _ := singleTextContent(res)
+		require.Contains(t, txt, confined, "%s: expected confinement error", tool)
+
+		// Agent + in-repo path → passes confinement (fails later for lack of an LSP, not confinement).
+		inRepo := filepath.Join(realRoot, "main.go")
+		res = lspWriteTool(t, srv, agentCtx, tool, map[string]any{"path": inRepo, "index": 0})
+		inTxt, _ := singleTextContent(res)
+		require.NotContains(t, inTxt, confined, "%s: in-repo path must pass confinement", tool)
+
+		// CLI / control channel (no session cwd) + out-of-repo path → exempt.
+		res = lspWriteTool(t, srv, context.Background(), tool, map[string]any{"path": outside, "index": 0})
+		cliTxt, _ := singleTextContent(res)
+		require.NotContains(t, cliTxt, confined, "%s: CLI path must be exempt from confinement", tool)
+	}
+}


### PR DESCRIPTION
## What

Two MCP write tools resolved caller-supplied filesystem paths without confining them to indexed repository roots, so an MCP agent (the prompt-injection threat surface) could drive a write outside every indexed repo. This brings them in line with the read tools (`read_file` / `get_symbol_source`), which already confine via `guardSymlinkWithinRepo`.

## Fixes
- **`export_graph`** (`7d233f3b`) — `output_path` / `output_dir` were passed straight to `os.WriteFile` / `os.MkdirAll`+`os.Create`. Now confined for agent sessions (the `output_dir` + `MkdirAll` path could also auto-create a tree).
- **`apply_code_action` / `fix_all_in_file`** (`dfe08a98`) — the caller `path` flowed through `lspProviderForPath → absolutePath`, which returns absolute paths verbatim; the LSP would then open and rewrite the named file. Now confined before the LSP is consulted. (Lower severity: LSP-computed edits, existing files only, needs an LSP on `PATH`.)

## Mechanism
A shared `confineCallerPaths(ctx)` gates the guard: it is **true for an MCP agent session** (which always carries the client's cwd, stamped by the proxy at handshake) and **false for the local CLI / control channel**. So `gortex export --out /any/path` and the other `gortex` verbs keep working unrestricted, while agent calls are confined — both go through the same daemon handler, so the session cwd is the forge-proof discriminator.

## Not affected
- `scaffold` writes `Join(RootPath(), <graph-derived relative path>)` — confined by construction.
- `export_context` returns inline; never writes.
- Read-only LSP tools are unchanged.

## Tests
`tools_export_confine_test.go` and `tools_lsp_confine_test.go` assert the matrix: agent + out-of-root path → refused; agent + in-root path → allowed (no false positive); CLI (no session cwd) → unrestricted. `go vet` clean; tests pass under `-race`.