### PR TITLE
Lean index hot path

### DIFF
--- a/cmd/gortex/daemon_state.go
+++ b/cmd/gortex/daemon_state.go
@@ -294,6 +294,14 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 	// pure recomputation and get skipped, which is what makes a true warm
 	// restart near-instant instead of replaying the full cold-warmup cost.
 	var changedRepos atomic.Int64
+	// changedPrefixes records the repo prefix of every repo that did indexing
+	// work, so the end-of-warmup RunGlobalGraphPasses can scope the per-repo
+	// clone detection + Rebuild to just those repos instead of every tracked
+	// repo. scopeUnknown trips when a changed repo's prefix can't be
+	// determined (e.g. a failed reconcile) — then the scope is dropped and the
+	// whole-workspace clone pass runs, degrading toward correctness.
+	var changedPrefixes sync.Map
+	var scopeUnknown atomic.Bool
 	for i := 0; i < workers; i++ {
 		wg.Add(1)
 		go func() {
@@ -372,16 +380,27 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 							// passes still run — degrade toward correctness, not
 							// toward the fast path, when we can't trust the delta.
 							changedRepos.Add(1)
+							scopeUnknown.Store(true)
 						case res != nil && (res.StaleFileCount > 0 || res.DeletedFileCount > 0 || len(res.FailedFiles) > 0):
 							changedRepos.Add(1)
+							if res.RepoPrefix != "" {
+								changedPrefixes.Store(res.RepoPrefix, struct{}{})
+							} else {
+								scopeUnknown.Store(true)
+							}
 						}
 					} else {
 						// No prior mtimes → full cold (re)index of this repo,
 						// which is "changed" by definition.
 						changedRepos.Add(1)
-						if _, err := state.multiIndexer.TrackRepoCtx(ctx, entry); err != nil {
+						if res, err := state.multiIndexer.TrackRepoCtx(ctx, entry); err != nil {
 							logger.Warn("daemon: startup track failed",
 								zap.String("path", entry.Path), zap.Error(err))
+							scopeUnknown.Store(true)
+						} else if res != nil && res.RepoPrefix != "" {
+							changedPrefixes.Store(res.RepoPrefix, struct{}{})
+						} else {
+							scopeUnknown.Store(true)
 						}
 					}
 					elapsed := time.Since(repoStart)
@@ -562,6 +581,23 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 	// path (nothing changed) ResetBatch clears the deferred-batch flags
 	// without re-running those passes — the persisted graph already has
 	// the derived edges.
+	// Scope the per-repo clone detection + clone-index Rebuild in the
+	// end_batch graph passes to the repos that actually re-indexed this
+	// warmup. Dropped when a changed repo's prefix was indeterminate
+	// (scopeUnknown) so a repo whose clones genuinely need recomputing is
+	// never skipped. ArmBatchScope is a no-op when scoped global passes are
+	// disabled or the set is empty (run every repo, the prior behaviour).
+	if anyChanged && !scopeUnknown.Load() {
+		changed := make(map[string]struct{})
+		changedPrefixes.Range(func(k, _ any) bool {
+			if p, ok := k.(string); ok {
+				changed[p] = struct{}{}
+			}
+			return true
+		})
+		state.multiIndexer.ArmBatchScope(changed)
+	}
+
 	phaseStart = time.Now()
 	publishReadinessPhase(state, "end_batch", true, nil)
 	if anyChanged {

--- a/cmd/gortex/embedder_test.go
+++ b/cmd/gortex/embedder_test.go
@@ -17,24 +17,41 @@ func withEnv(t *testing.T, key, val string) {
 	t.Setenv(key, val)
 }
 
-// TestResolveEmbedder_DefaultOnStatic asserts the core default-on
-// behaviour: with no `--embeddings` flag, no GORTEX_EMBEDDINGS env, and
-// a config whose Embedding block is the zero value (Enabled == nil),
-// resolveEmbedder returns a working static GloVe provider.
-func TestResolveEmbedder_DefaultOnStatic(t *testing.T) {
+// TestResolveEmbedder_DefaultSkipsStatic asserts the FTS5-only default:
+// with no `--embeddings` flag, no GORTEX_EMBEDDINGS env, and a config whose
+// Embedding block is the zero value (Enabled == nil), resolveEmbedder builds
+// NO embedder. The baked static GloVe provider is opt-in, so the default index
+// skips the vector pass and relies on FTS5 text search.
+func TestResolveEmbedder_DefaultSkipsStatic(t *testing.T) {
 	withEnv(t, "GORTEX_EMBEDDINGS", "")
 	withEnv(t, "GORTEX_EMBEDDINGS_URL", "")
 
 	cfg := config.Default()
 	require.Nil(t, cfg.Embedding.Enabled, "precondition: default config leaves Enabled nil")
 
+	emb, _, err := resolveEmbedder(embedderRequest{}, cfg)
+	require.NoError(t, err)
+	assert.Nil(t, emb, "the static GloVe provider is opt-in; the default must build no embedder")
+}
+
+// TestResolveEmbedder_EnabledBuildsStatic asserts the opt-in: an explicit
+// `embedding.enabled: true` with the default (static) provider turns the baked
+// GloVe vector index back on.
+func TestResolveEmbedder_EnabledBuildsStatic(t *testing.T) {
+	withEnv(t, "GORTEX_EMBEDDINGS", "")
+	withEnv(t, "GORTEX_EMBEDDINGS_URL", "")
+
+	enabled := true
+	cfg := config.Default()
+	cfg.Embedding.Enabled = &enabled
+
 	emb, desc, err := resolveEmbedder(embedderRequest{}, cfg)
 	require.NoError(t, err)
-	require.NotNil(t, emb, "default-on must produce an embedder")
+	require.NotNil(t, emb, "embedding.enabled: true must build the static embedder")
 	defer emb.Close()
 
 	_, isStatic := emb.(*embedding.StaticProvider)
-	assert.True(t, isStatic, "the default-on embedder must be the static GloVe provider, got %T", emb)
+	assert.True(t, isStatic, "the opt-in default-provider embedder must be the static GloVe provider, got %T", emb)
 	assert.Contains(t, desc, "static")
 }
 
@@ -70,13 +87,13 @@ func TestResolveEmbedder_FlagOverridesConfig(t *testing.T) {
 	assert.Nil(t, emb, "an explicit --embeddings=false flag must override config-enabled")
 }
 
-// TestResolveEmbedder_EnvOverridesConfig asserts GORTEX_EMBEDDINGS=0
-// overrides a config that would otherwise enable the default-on path.
+// TestResolveEmbedder_EnvOverridesConfig asserts GORTEX_EMBEDDINGS=0 is an
+// explicit off that yields no embedder regardless of config.
 func TestResolveEmbedder_EnvOverridesConfig(t *testing.T) {
 	withEnv(t, "GORTEX_EMBEDDINGS", "0")
 	withEnv(t, "GORTEX_EMBEDDINGS_URL", "")
 
-	cfg := config.Default() // Enabled nil → default-on
+	cfg := config.Default() // Enabled nil; GORTEX_EMBEDDINGS=0 forces off
 
 	emb, _, err := resolveEmbedder(embedderRequest{}, cfg)
 	require.NoError(t, err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1434,14 +1434,18 @@ func (c SearchConfig) EffectiveKeywordSoupRewrite() string {
 // HybridBackend down-weights the vector channel for identifier-shaped
 // queries — never a replacement for text search. The default provider
 // is `static` (baked GloVe word vectors): it needs zero download and
-// is CPU-only, so semantic search is on by default at no setup cost.
+// is CPU-only. As of the lean-index default, the static provider no
+// longer builds a vector index automatically — FTS5/BM25 text search
+// serves the default, and the semantic channel turns on when a real
+// `local`/`api` provider (or `embedding.enabled: true`) is configured.
 type EmbeddingConfig struct {
 	// Enabled is tri-state. A nil pointer means "not configured" —
-	// the caller falls back to the default (semantic search ON with
-	// the static provider). An explicit `embedding.enabled: false`
-	// turns the vector channel off; `true` forces it on. Pointer so
-	// the loader can tell "absent" from "explicitly false", mirroring
-	// RespectGitignore.
+	// the vector channel is then built only when a real `local`/`api`
+	// provider is configured (the static default stays text-only). An
+	// explicit `embedding.enabled: false` turns the vector channel off;
+	// `true` forces it on, building whatever provider is configured
+	// (including the static one). Pointer so the loader can tell
+	// "absent" from "explicitly false", mirroring RespectGitignore.
 	Enabled *bool `mapstructure:"enabled" yaml:"enabled,omitempty"`
 
 	// Provider selects the embedding backend: `static` (baked GloVe,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -216,6 +216,16 @@ type SemanticConfig struct {
 	WatchDebounceMs   int                      `mapstructure:"watch_debounce_ms" yaml:"watch_debounce_ms,omitempty"`
 	RefuteUnconfirmed bool                     `mapstructure:"refute_unconfirmed" yaml:"refute_unconfirmed,omitempty"`
 	Providers         []SemanticProviderConfig `mapstructure:"providers" yaml:"providers,omitempty"`
+	// GoTypes enables the heavyweight go/packages type-check provider
+	// ("go-types"): a full `go list ./...` + go/types pass over the module
+	// (and its dependencies) on every index. The in-process tree-sitter Go
+	// resolver (go-ast-types) is the always-on floor and resolves the common
+	// receiver / cross-file call cases with no toolchain; the go/packages
+	// provider adds full cross-package / generic type precision but costs
+	// tens of seconds per Go module per warmup and, on an already-resolved
+	// graph, frequently confirms zero new edges. Tri-state, DEFAULT OFF —
+	// opt in for maximum Go type precision. Env override GORTEX_GO_TYPES=1/0.
+	GoTypes *bool `mapstructure:"go_types" yaml:"go_types,omitempty"`
 	// AdditionalWorkspaceFolders are extra directory roots passed to
 	// every LSP server's `initialize` request as workspace folders.
 	// This is how cross-package resolution works for a TypeScript (or
@@ -250,6 +260,17 @@ type SemanticConfig struct {
 	// anything that isn't worth embedding usually isn't worth
 	// full-text-indexing either. See DefaultSkipSearch.
 	SkipSearch []SkipEmbedRule `mapstructure:"skip_search" yaml:"skip_search,omitempty"`
+}
+
+// GoTypesEnabledOrDefault resolves the tri-state SemanticConfig.GoTypes.
+// The heavyweight go/packages type-check provider is OFF by default — the
+// always-on tree-sitter Go floor (go-ast-types) serves Go resolution — so
+// opt in explicitly for full cross-package type precision.
+func (s SemanticConfig) GoTypesEnabledOrDefault() bool {
+	if s.GoTypes == nil {
+		return false
+	}
+	return *s.GoTypes
 }
 
 // SkipEmbedRule says: when a node's Language matches Language AND its

--- a/internal/graph/out_edges_batch.go
+++ b/internal/graph/out_edges_batch.go
@@ -1,0 +1,27 @@
+package graph
+
+// outEdgesBatcher is implemented by backends that can fetch many nodes'
+// out-edges in a single query (the disk-backed stores), collapsing the
+// per-node N+1 the single-file resolve path would otherwise issue.
+type outEdgesBatcher interface {
+	GetOutEdgesForNodes(ids []string) map[string][]*Edge
+}
+
+// OutEdgesForNodes returns each node's outgoing edges, using the backend's
+// batched query when it offers one and falling back to per-node lookups
+// otherwise (the in-memory graph, where each lookup is already an O(1) map
+// hit). Nodes with no out-edges may be absent from the returned map.
+func OutEdgesForNodes(r interface {
+	GetOutEdges(nodeID string) []*Edge
+}, ids []string) map[string][]*Edge {
+	if b, ok := r.(outEdgesBatcher); ok {
+		return b.GetOutEdgesForNodes(ids)
+	}
+	out := make(map[string][]*Edge, len(ids))
+	for _, id := range ids {
+		if e := r.GetOutEdges(id); len(e) > 0 {
+			out[id] = e
+		}
+	}
+	return out
+}

--- a/internal/graph/store_sqlite/store.go
+++ b/internal/graph/store_sqlite/store.go
@@ -1234,6 +1234,45 @@ func (s *Store) GetInEdges(nodeID string) []*graph.Edge {
 	return s.queryEdges(s.stmtInEdges, nodeID)
 }
 
+// GetOutEdgesForNodes fetches the out-edges of many nodes in one batched query
+// (chunked) instead of a round-trip per node. The single-file resolve path
+// walks every node of the edited file, which is an N+1 query storm on a disk
+// backend; this collapses it to one query per chunk. Edges are grouped by
+// their from_id; nodes with no out-edges are absent from the map.
+func (s *Store) GetOutEdgesForNodes(ids []string) map[string][]*graph.Edge {
+	out := make(map[string][]*graph.Edge, len(ids))
+	if len(ids) == 0 {
+		return out
+	}
+	seen := make(map[string]struct{}, len(ids))
+	uniq := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		uniq = append(uniq, id)
+	}
+	for i := 0; i < len(uniq); i += lookupChunkSize {
+		end := minInt(i+lookupChunkSize, len(uniq))
+		chunk := uniq[i:end]
+		ph := make([]string, len(chunk))
+		args := make([]any, len(chunk))
+		for j, id := range chunk {
+			ph[j] = "?"
+			args[j] = id
+		}
+		q := `SELECT ` + lookupEdgeCols + ` FROM edges WHERE from_id IN (` + strings.Join(ph, ",") + `)`
+		for _, e := range s.queryEdgesSQL(q, args...) {
+			out[e.From] = append(out[e.From], e)
+		}
+	}
+	return out
+}
+
 func (s *Store) AllEdges() []*graph.Edge {
 	return s.queryEdges(s.stmtAllEdges)
 }

--- a/internal/indexer/editlatency_measure_test.go
+++ b/internal/indexer/editlatency_measure_test.go
@@ -1,0 +1,80 @@
+package indexer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+	"go.uber.org/zap"
+)
+
+// TestMeasureEditLatency builds a sqlite-backed graph from a real repo and
+// times ResolveFileAndIncoming + IndexFile (the per-edit reindex path), with
+// the resolver's buildPassIndexes breakdown logged at Debug. It quantifies the
+// whole-graph O(graph) cost a single-file edit pays. Opt-in:
+//
+//	GORTEX_MEASURE_REPO=/abs/path [GORTEX_MEASURE_FILE=rel/path.go] \
+//	  go test -run TestMeasureEditLatency -v -count=1 ./internal/indexer/
+func TestMeasureEditLatency(t *testing.T) {
+	repo := os.Getenv("GORTEX_MEASURE_REPO")
+	if repo == "" {
+		t.Skip("set GORTEX_MEASURE_REPO=/abs/path to run")
+	}
+	editRel := os.Getenv("GORTEX_MEASURE_FILE")
+	if editRel == "" {
+		editRel = "internal/resolver/resolver.go"
+	}
+
+	dbPath := os.Getenv("GORTEX_MEASURE_DB")
+	if dbPath == "" {
+		dbPath = filepath.Join(t.TempDir(), "store.sqlite")
+	}
+	store, err := store_sqlite.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	prebuilt := store.NodeCount() > 0 // reuse a persisted store across runs
+
+	logger, _ := zap.NewDevelopment() // Debug enabled -> buildPassIndexes timing
+	reg := parser.NewRegistry()
+	reg.Register(languages.NewGoExtractor())
+	reg.Register(languages.NewTypeScriptExtractor())
+	reg.Register(languages.NewPythonExtractor())
+	cfg := config.Default().Index
+	cfg.Workers = 8
+	idx := New(store, reg, cfg, logger)
+	idx.resolver.SetLogger(logger) // surface buildPassIndexes per-builder timing
+
+	if !prebuilt {
+		t0 := time.Now()
+		if _, err := idx.IndexCtx(testCtx(), repo); err != nil {
+			t.Fatalf("index: %v", err)
+		}
+		t.Logf("=== indexed %s in %v -- nodes=%d edges=%d", repo, time.Since(t0), store.NodeCount(), store.EdgeCount())
+	} else {
+		t.Logf("=== reusing prebuilt store %s -- nodes=%d edges=%d", dbPath, store.NodeCount(), store.EdgeCount())
+	}
+
+	absEdit := filepath.Join(repo, editRel)
+	if _, err := os.Stat(absEdit); err != nil {
+		t.Fatalf("edit file not found: %v", err)
+	}
+	graphPath := idx.prefixPath(idx.relKey(absEdit))
+	t.Logf("=== edit target graphPath=%q", graphPath)
+
+	// The full edit_file reindex path end-to-end. #0 runs on the freshly
+	// opened store (cold sqlite cache) = the cold-edit number; #1+ warm.
+	for i := 0; i < 4; i++ {
+		tt := time.Now()
+		if err := idx.IndexFile(absEdit); err != nil {
+			t.Logf("IndexFile err: %v", err)
+		}
+		t.Logf(">>> IndexFile #%d: %v", i, time.Since(tt))
+	}
+}

--- a/internal/indexer/incremental_resolve.go
+++ b/internal/indexer/incremental_resolve.go
@@ -1,0 +1,177 @@
+package indexer
+
+import (
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Incremental resolution reuse for the single-file edit path.
+//
+// A normal save evicts the whole file, re-parses it (every edge comes back
+// unresolved), and re-resolves all of them — on a large file that means
+// fetching tens of thousands of candidate nodes and scoring thousands of
+// edges, even for a one-line change. But only the edited region's references
+// actually changed; the rest resolve to exactly what they did before.
+//
+// So before eviction we snapshot the file's already-resolved outgoing edges,
+// keyed by their *source-side shape* (origin symbol, kind, receiver type,
+// referenced name) — independent of line number and of the resolved target.
+// After the re-parse, any freshly extracted edge whose shape matches a unique
+// captured resolution is pre-pointed at that target before it enters the
+// graph, so the resolver skips it and only touches genuinely-new edges.
+//
+// Correctness is conservative by construction: a shape that resolved to two
+// different targets (the key cannot tell them apart) is dropped and re-resolved
+// from scratch, and a captured target that no longer exists is ignored. The
+// reuse therefore can only ever reproduce a prior resolution or fall back to
+// the full resolver — never invent a wrong target.
+
+type reuseKey struct {
+	from string
+	kind graph.EdgeKind
+	recv string // receiver type for method calls; "" otherwise
+	name string // referenced identifier
+}
+
+type reuseVal struct {
+	to         string
+	confidence float64
+	confLabel  string
+	origin     string
+	tier       string
+}
+
+// captureIncrementalState snapshots, in one walk of the file's outgoing edges:
+//   - reuse: resolved in-repo edges keyed by source shape, so an unchanged
+//     reference recovers its exact target (ambiguous keys poisoned to nil).
+//   - priorUnresolved: shallow copies of the edges that were still unresolved,
+//     so the resolver's forward pass can skip re-trying them (they point at
+//     stubs the incoming pass binds when a target appears).
+//
+// external:: edges are neither reused nor skipped here: they are not
+// IsUnresolvedTarget, so the resolver already leaves them alone.
+func captureIncrementalState(g graph.Store, graphPath string) (reuse map[reuseKey]*reuseVal, priorUnresolved []*graph.Edge) {
+	reuse = map[reuseKey]*reuseVal{}
+	nodes := g.GetFileNodes(graphPath)
+	ids := make([]string, 0, len(nodes))
+	for _, n := range nodes {
+		if n != nil {
+			ids = append(ids, n.ID)
+		}
+	}
+	byNode := graph.OutEdgesForNodes(g, ids)
+	for _, n := range nodes {
+		if n == nil {
+			continue
+		}
+		for _, e := range byNode[n.ID] {
+			if e == nil || e.To == "" {
+				continue
+			}
+			if graph.IsUnresolvedTarget(e.To) {
+				priorUnresolved = append(priorUnresolved, &graph.Edge{
+					From: e.From, Kind: e.Kind, To: e.To, Meta: e.Meta,
+				})
+				continue
+			}
+			if !reusableResolvedEdge(e) {
+				continue
+			}
+			tgt := g.GetNode(e.To)
+			if tgt == nil || tgt.Name == "" {
+				continue
+			}
+			k := reuseKey{from: e.From, kind: e.Kind, recv: edgeReceiverType(e), name: tgt.Name}
+			if cur, seen := reuse[k]; seen {
+				if cur != nil && cur.to != e.To {
+					reuse[k] = nil // ambiguous -> never reuse
+				}
+				continue
+			}
+			reuse[k] = &reuseVal{
+				to:         e.To,
+				confidence: e.Confidence,
+				confLabel:  e.ConfidenceLabel,
+				origin:     e.Origin,
+				tier:       e.Tier,
+			}
+		}
+	}
+	return reuse, priorUnresolved
+}
+
+// applyResolvedOutEdges pre-resolves freshly extracted unresolved edges that
+// match a captured resolution, BEFORE they are added to the graph (so no edge
+// re-keying is needed). Returns how many edges were reused.
+func applyResolvedOutEdges(g graph.Store, edges []*graph.Edge, idx map[reuseKey]*reuseVal) int {
+	if len(idx) == 0 {
+		return 0
+	}
+	reused := 0
+	for _, e := range edges {
+		if e == nil || !graph.IsUnresolvedTarget(e.To) {
+			continue
+		}
+		name := reuseIdentifier(graph.UnresolvedName(e.To))
+		if name == "" {
+			continue // import/pyrel/grpc targets are owned by global passes
+		}
+		k := reuseKey{from: e.From, kind: e.Kind, recv: edgeReceiverType(e), name: name}
+		v := idx[k]
+		if v == nil {
+			continue // miss, or poisoned ambiguous key
+		}
+		if g.GetNode(v.to) == nil {
+			continue // captured target deleted since the snapshot
+		}
+		e.To = v.to
+		e.Confidence = v.confidence
+		e.ConfidenceLabel = v.confLabel
+		e.Origin = v.origin
+		e.Tier = v.tier
+		reused++
+	}
+	return reused
+}
+
+func reusableResolvedEdge(e *graph.Edge) bool {
+	if e == nil || e.To == "" {
+		return false
+	}
+	if graph.IsUnresolvedTarget(e.To) || strings.HasPrefix(e.To, "external::") {
+		return false
+	}
+	return true
+}
+
+func edgeReceiverType(e *graph.Edge) string {
+	if e == nil || e.Meta == nil {
+		return ""
+	}
+	if rt, ok := e.Meta["receiver_type"].(string); ok {
+		return rt
+	}
+	return ""
+}
+
+// reuseIdentifier mirrors resolver.identifierFromTarget for the reuse key:
+// it extracts the bare referenced name and returns "" for targets a dedicated
+// global pass owns (import/pyrel/grpc), so those are never reused here.
+func reuseIdentifier(target string) string {
+	switch {
+	case strings.HasPrefix(target, "*."):
+		return strings.TrimPrefix(target, "*.")
+	case strings.HasPrefix(target, "extern::"):
+		spec := strings.TrimPrefix(target, "extern::")
+		if sep := strings.LastIndex(spec, "::"); sep >= 0 {
+			return spec[sep+2:]
+		}
+		return ""
+	case strings.HasPrefix(target, "import::"),
+		strings.HasPrefix(target, "pyrel::"),
+		strings.HasPrefix(target, "grpc::"):
+		return ""
+	}
+	return target
+}

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -4778,17 +4778,19 @@ func (idx *Indexer) IncrementalReindex(root string) (*IndexResult, error) {
 			idx.resolver.InferOverrides()
 		}
 		// Capability edges (reads_env / executes_process / accesses_field)
-		// re-derived from the freshly re-indexed files' base edges so the
-		// daemon's capability surface — what a supply-chain / least-privilege
-		// audit traverses — stays fresh between full indexes. Whole-graph but
-		// idempotent (AddEdge dedupes), matching the other synthesis passes
-		// re-run here.
-		synthesizeCapabilityEdges(idx.graph)
-		// Framework dynamic-dispatch synthesis — re-run because eviction
-		// may have dropped a handler, a registration edge, or an emit /
-		// listen edge, and each synthesizer's index must be rebuilt
-		// against the fresh graph. Every pass is a full recompute.
-		resolver.RunFrameworkSynthesizers(idx.graph)
+		// and framework dynamic-dispatch synthesis are whole-graph recomputes
+		// that derive edges only from structural nodes in the changed files.
+		// When nothing structural changed — no stale code file (a doc/config
+		// edit or a true zero-change reconcile) and no deletion — they can
+		// produce no new edge, so re-running them is pure cost: the dominant
+		// waste in a no-op IncrementalReindex, which the periodic janitor runs
+		// per repo per tick. Gate them on the same predicate the path-scoped
+		// IncrementalReindexPaths already uses. Deletions still trigger a
+		// re-run because an evicted file may have been a dispatch endpoint.
+		if len(deletedFiles) > 0 || idx.staleFilesAffectDerivedEdges(staleFiles) {
+			synthesizeCapabilityEdges(idx.graph)
+			resolver.RunFrameworkSynthesizers(idx.graph)
+		}
 		// External-call synthesis (opt-in) — file-scoped to the reindexed
 		// files (O(edited files)), not a full-graph recompute. Eviction
 		// already dropped a removed file's synthetic edges; a re-indexed

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -3191,8 +3191,16 @@ func (idx *Indexer) indexFile(filePath string, resolve bool) error {
 	// reverse graph on a transient parse failure. A failure that yields no
 	// symbols is not the same as a symbol genuinely deleted from source.
 	var abSnap *affectedBySnapshot
+	var reuseIdx map[reuseKey]*reuseVal
+	var priorUnresolved []*graph.Edge
 	if resolve && !idx.deferGlobalPasses && !skipped {
 		abSnap = idx.snapshotAffectedBy(graphPath)
+		// Snapshot the file's outgoing edges before eviction: resolved ones so
+		// the re-parse recovers unchanged resolutions (reuseIdx), and the ones
+		// still unresolved so the forward pass can skip re-trying them
+		// (priorUnresolved). Together this makes a save re-resolve only the
+		// references it actually changed instead of the whole file.
+		reuseIdx, priorUnresolved = captureIncrementalState(idx.graph, graphPath)
 	}
 
 	// We hold a usable result: evict the old state now, then add the
@@ -3207,6 +3215,14 @@ func (idx *Indexer) indexFile(filePath string, resolve bool) error {
 	}
 
 	idx.applyRepoPrefix(result.Nodes, result.Edges)
+
+	// Reuse prior resolutions for edges whose source-side shape is unchanged
+	// (the common case on a small edit), so the resolver below only handles
+	// genuinely-new references instead of re-resolving the whole file.
+	if reused := applyResolvedOutEdges(idx.graph, result.Edges, reuseIdx); reused > 0 {
+		idx.logger.Debug("indexer: reused prior resolutions",
+			zap.Int("edges", reused), zap.String("file", graphPath))
+	}
 
 	// Content (incremental): clear this file's prior content rows, then
 	// re-stream + lean — mirrors the full-index per-file path so an edited
@@ -3255,7 +3271,14 @@ func (idx *Indexer) indexFile(filePath string, resolve bool) error {
 		// evicted. Scoped to this file's names — not a whole-graph
 		// ResolveAll — and run as one combined pass so the resolver's
 		// per-pass indexes are built once per save, not twice.
+		//
+		// Skip re-resolving references that were already unresolved before the
+		// edit and are unchanged: they stay parked on their stubs for the
+		// incoming pass, so a small edit to a reference-heavy file no longer
+		// re-runs the candidate cascade on thousands of stdlib/external calls.
+		idx.resolver.SetIncrementalSkip(priorUnresolved)
 		idx.resolver.ResolveFileAndIncoming(graphPath)
+		idx.resolver.SetIncrementalSkip(nil)
 		// CPG-lite dataflow placeholders for this file: inter-
 		// procedural callees may have just been lifted by
 		// ResolveFile, so re-run the dataflow materialisation pass
@@ -3274,7 +3297,15 @@ func (idx *Indexer) indexFile(filePath string, resolve bool) error {
 		// Skipped under deferGlobalPasses — a batch caller (ReconcileAll,
 		// warmup) runs the global pass once at the end.
 		if !idx.deferGlobalPasses {
-			if idx.cloneIndex != nil && idx.cloneIndex.built {
+			if idx.cloneIndex != nil {
+				// Seed the incremental clone index on first use — e.g. after a
+				// warm restart that loaded the graph from disk without a full
+				// re-index, `built` is false. Without this we'd fall to the
+				// whole-graph recompute on EVERY save; instead pay it once and
+				// then run the O(edited file) update.
+				if !idx.cloneIndex.built {
+					idx.cloneIndex.Rebuild(idx.graph, idx.repoPrefix)
+				}
 				idx.cloneIndex.EvictFuncs(idx.graph, oldFuncIDs)
 				idx.cloneIndex.UpdateFuncs(idx.graph, idx.repoPrefix, cloneFuncNodes(result.Nodes), idx.cloneThreshold())
 			} else {

--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -106,6 +106,20 @@ type MultiIndexer struct {
 	// flag covers a separate (cheaper) set of O(global) walks.
 	deferResolve bool
 
+	// batchChangedPrefixes scopes the per-repo clone-detection and
+	// clone-index Rebuild passes in RunGlobalGraphPasses to the repos that
+	// actually re-indexed in the current batch. nil — the default, and what
+	// every one-off EndBatch caller leaves it as — means "run the clone
+	// passes for every tracked repo", the prior whole-workspace behaviour.
+	// The daemon warmup arms it (ArmBatchScope) before EndBatch so an
+	// N-repo warm restart where only one repo changed stops paying ~N
+	// full-graph clone walks for repos whose clone edges are already on
+	// disk. Clone edges are per-repo (no cross-repo pair is ever formed),
+	// so an unchanged repo's persisted edges stay valid; its in-memory
+	// incremental clone index is reseeded lazily on its first later edit.
+	// Consumed and cleared by RunGlobalGraphPasses. Guarded by mi.mu.
+	batchChangedPrefixes map[string]struct{}
+
 	// resolverLSPHelper is the resolve-time LSP helper propagated
 	// onto every per-repo Indexer and onto the global post-pass
 	// resolver in RunDeferredPassesAll. nil means no LSP hot-path
@@ -526,6 +540,48 @@ func enrichConcurrency(repos int) int {
 // markTestSymbolsAndEmitEdges) once against the shared graph. Restores
 // the per-Indexer flag too so a subsequent one-off TrackRepoCtx call
 // runs the passes inline as expected.
+// ArmBatchScope records the prefixes of the repos that re-indexed in the
+// batch about to be ended, so the next RunGlobalGraphPasses runs the
+// per-repo clone-detection + clone-index Rebuild passes only for those
+// repos instead of for every tracked repo. An empty set, or scoped global
+// passes being disabled, leaves the scope nil (run all). Only the daemon
+// warmup arms it; every other EndBatch caller keeps the whole-workspace
+// behaviour.
+func (mi *MultiIndexer) ArmBatchScope(changedPrefixes map[string]struct{}) {
+	if mi == nil || len(changedPrefixes) == 0 || !mi.scopedGlobalPassesEnabled() {
+		return
+	}
+	mi.mu.Lock()
+	mi.batchChangedPrefixes = changedPrefixes
+	mi.mu.Unlock()
+}
+
+// takeBatchScope returns the armed clone-pass scope and clears it, so the
+// scope governs exactly one RunGlobalGraphPasses run. A nil result means
+// "no scope — run the clone passes for every repo".
+func (mi *MultiIndexer) takeBatchScope() map[string]struct{} {
+	mi.mu.Lock()
+	scope := mi.batchChangedPrefixes
+	mi.batchChangedPrefixes = nil
+	mi.mu.Unlock()
+	return scope
+}
+
+// scopedGlobalPassesEnabled reports whether per-repo global passes may be
+// scoped to the changed-repo set. GORTEX_INDEX_SCOPED_GLOBAL_PASSES
+// overrides the config key; default ON, mirroring Indexer.scopedGlobalPassesEnabled.
+func (mi *MultiIndexer) scopedGlobalPassesEnabled() bool {
+	if v := os.Getenv("GORTEX_INDEX_SCOPED_GLOBAL_PASSES"); v != "" {
+		return v == "1" || strings.EqualFold(v, "true")
+	}
+	mi.mu.RLock()
+	defer mi.mu.RUnlock()
+	for _, idx := range mi.indexers {
+		return idx.config.ScopedGlobalPassesEnabledOrDefault()
+	}
+	return true
+}
+
 func (mi *MultiIndexer) EndBatch() {
 	mi.mu.Lock()
 	mi.deferGlobalPasses = false
@@ -602,7 +658,27 @@ func (mi *MultiIndexer) RunGlobalGraphPasses(ctx context.Context) {
 		cloneIdx = append(cloneIdx, idx)
 	}
 	mi.mu.RUnlock()
+	// Scope to the repos that re-indexed this batch when the warmup armed a
+	// batch scope. An unchanged repo's clone edges are already on disk and
+	// its incremental clone index is reseeded lazily on its first later edit
+	// (indexFile: if !built → Rebuild), so skipping its full-graph detect +
+	// Rebuild here is sound and cuts an N-repo warm restart from N full-graph
+	// clone walks to just the changed repos'. A nil scope runs every repo.
+	scope := mi.takeBatchScope()
+	inCloneScope := func(prefix string) bool {
+		if scope == nil {
+			return true
+		}
+		_, ok := scope[prefix]
+		return ok
+	}
+	cloneDetectStart := time.Now()
+	clonesDetected := 0
 	for _, idx := range cloneIdx {
+		if !inCloneScope(idx.repoPrefix) {
+			continue
+		}
+		clonesDetected++
 		// Per-repo threshold, NOT a max-over-repos value: the batch must use
 		// the same cutoff the per-repo incremental maintainer uses
 		// (UpdateFuncs/Rebuild → idx.cloneThreshold()), or the batch and
@@ -625,11 +701,29 @@ func (mi *MultiIndexer) RunGlobalGraphPasses(ctx context.Context) {
 	// freshly-baselined signatures + sidecar (scoped to that repo's
 	// prefix) so steady-state single-file edits after this batch go
 	// incremental instead of re-running the whole-graph pass per file.
+	cloneRebuildStart := time.Now()
+	clonesRebuilt := 0
 	for _, idx := range cloneIdx {
+		if !inCloneScope(idx.repoPrefix) {
+			continue
+		}
 		if idx.cloneIndex != nil {
 			idx.cloneIndex.Rebuild(mi.graph, idx.repoPrefix)
+			clonesRebuilt++
 		}
 	}
+	// Aggregate timing for the clone passes — previously the most expensive
+	// and least observable part of a warm restart (the per-repo logs above
+	// only fire when a repo actually has clone pairs, so a long run could
+	// pass with no breadcrumbs).
+	mi.logger.Info("clone passes done (global)",
+		zap.Bool("scoped", scope != nil),
+		zap.Int("repos_total", len(cloneIdx)),
+		zap.Int("detected", clonesDetected),
+		zap.Int("rebuilt", clonesRebuilt),
+		zap.Duration("detect_elapsed", cloneRebuildStart.Sub(cloneDetectStart)),
+		zap.Duration("rebuild_elapsed", time.Since(cloneRebuildStart)),
+	)
 	// Framework dynamic-dispatch synthesis (gRPC stubs, Temporal
 	// workflow→activity, in-process / native event channels, native
 	// bridges). After InferImplements/InferOverrides (the

--- a/internal/parser/languages/c.go
+++ b/internal/parser/languages/c.go
@@ -92,7 +92,7 @@ func cDeclIsConst(decl *sitter.Node, src []byte) bool {
 	if decl == nil {
 		return false
 	}
-	for i := 0; i < int(decl.ChildCount()); i++ {
+	for i, _nc := 0, int(decl.ChildCount()); i < _nc; i++ {
 		ch := decl.Child(i)
 		if ch != nil && ch.Type() == "type_qualifier" && ch.Content(src) == "const" {
 			return true

--- a/internal/parser/languages/c_fnptr.go
+++ b/internal/parser/languages/c_fnptr.go
@@ -48,8 +48,8 @@ func captureCFnPointerDispatch(result *parser.ExtractionResult, root *sitter.Nod
 
 // structFields holds a struct's ordered field names and its fn-pointer set.
 type structFields struct {
-	order  []string
-	fnptr  map[string]bool
+	order []string
+	fnptr map[string]bool
 }
 
 // cFnPtrTypedefs collects the names of `typedef RET (*NAME)(...)` fn-pointer
@@ -90,7 +90,7 @@ func cStructFnPtrFields(root *sitter.Node, src []byte, typedefs map[string]bool)
 		}
 		structName := nameNode.Content(src)
 		sf := &structFields{fnptr: map[string]bool{}}
-		for i := 0; i < int(body.NamedChildCount()); i++ {
+		for i, _nc := 0, int(body.NamedChildCount()); i < _nc; i++ {
 			fd := body.NamedChild(i)
 			if fd == nil || fd.Type() != "field_declaration" {
 				continue
@@ -125,7 +125,7 @@ func cVarStructTypes(root *sitter.Node, src []byte) map[string]string {
 		if st == "" {
 			return
 		}
-		for i := 0; i < int(n.NamedChildCount()); i++ {
+		for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 			c := n.NamedChild(i)
 			if c == nil {
 				continue
@@ -152,7 +152,7 @@ func cEmitRegistrations(result *parser.ExtractionResult, root *sitter.Node, file
 			if sf == nil {
 				return
 			}
-			for i := 0; i < int(n.NamedChildCount()); i++ {
+			for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 				id := n.NamedChild(i)
 				if id == nil || id.Type() != "init_declarator" {
 					continue
@@ -164,7 +164,7 @@ func cEmitRegistrations(result *parser.ExtractionResult, root *sitter.Node, file
 				declTy := id.ChildByFieldName("declarator")
 				if declTy != nil && declTy.Type() == "array_declarator" {
 					// Array of structs: each element is a struct initializer.
-					for j := 0; j < int(val.NamedChildCount()); j++ {
+					for j, _nc := 0, int(val.NamedChildCount()); j < _nc; j++ {
 						if el := val.NamedChild(j); el != nil && el.Type() == "initializer_list" {
 							cEmitStructInit(result, filePath, src, st, sf, el)
 						}
@@ -183,7 +183,7 @@ func cEmitRegistrations(result *parser.ExtractionResult, root *sitter.Node, file
 // positional values by field order and designated values by field name.
 func cEmitStructInit(result *parser.ExtractionResult, filePath string, src []byte, st string, sf *structFields, init *sitter.Node) {
 	pos := 0
-	for i := 0; i < int(init.NamedChildCount()); i++ {
+	for i, _nc := 0, int(init.NamedChildCount()); i < _nc; i++ {
 		el := init.NamedChild(i)
 		if el == nil {
 			continue
@@ -356,7 +356,7 @@ func cFnValueName(val *sitter.Node, src []byte) string {
 // cDesignatorField returns the field name of an `initializer_pair`'s
 // `.field =` designator.
 func cDesignatorField(pair *sitter.Node, src []byte) string {
-	for i := 0; i < int(pair.NamedChildCount()); i++ {
+	for i, _nc := 0, int(pair.NamedChildCount()); i < _nc; i++ {
 		d := pair.NamedChild(i)
 		if d != nil && d.Type() == "field_designator" && d.NamedChildCount() > 0 {
 			return d.NamedChild(0).Content(src)
@@ -370,7 +370,7 @@ func cDesignatorField(pair *sitter.Node, src []byte) string {
 func cStructTypeOf(n *sitter.Node, src []byte) string {
 	t := n.ChildByFieldName("type")
 	if t == nil {
-		for i := 0; i < int(n.NamedChildCount()); i++ {
+		for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 			if c := n.NamedChild(i); c != nil && (c.Type() == "struct_specifier" || c.Type() == "union_specifier") {
 				t = c
 				break
@@ -437,7 +437,7 @@ func cTypeIdentifierIn(n *sitter.Node, src []byte) string {
 	if n.Type() == "type_identifier" {
 		return n.Content(src)
 	}
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		if x := cTypeIdentifierIn(n.NamedChild(i), src); x != "" {
 			return x
 		}
@@ -451,7 +451,7 @@ func cFnPtrWalk(n *sitter.Node, fn func(*sitter.Node)) {
 		return
 	}
 	fn(n)
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		cFnPtrWalk(n.NamedChild(i), fn)
 	}
 }

--- a/internal/parser/languages/cpp.go
+++ b/internal/parser/languages/cpp.go
@@ -254,7 +254,7 @@ func (e *CppExtractor) emitClass(m parser.QueryResult, filePath, fileID string, 
 
 func (e *CppExtractor) walkClassBody(classNode *sitter.Node, src []byte, filePath, fileID, className, classID string, seen map[string]bool, result *parser.ExtractionResult) {
 	var body *sitter.Node
-	for i := 0; i < int(classNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(classNode.NamedChildCount()); i < _nc; i++ {
 		child := classNode.NamedChild(i)
 		if child.Type() == "field_declaration_list" {
 			body = child
@@ -265,7 +265,7 @@ func (e *CppExtractor) walkClassBody(classNode *sitter.Node, src []byte, filePat
 		return
 	}
 	typeSeen := make(map[string]bool)
-	for i := 0; i < int(body.NamedChildCount()); i++ {
+	for i, _nc := 0, int(body.NamedChildCount()); i < _nc; i++ {
 		child := body.NamedChild(i)
 		switch child.Type() {
 		case "access_specifier":
@@ -282,7 +282,7 @@ func (e *CppExtractor) walkClassBody(classNode *sitter.Node, src []byte, filePat
 				emitCppTypeUseEdges(classID, tn.Content(src), filePath, line, result, typeSeen)
 			}
 		case "declaration_list":
-			for j := 0; j < int(child.NamedChildCount()); j++ {
+			for j, _nc := 0, int(child.NamedChildCount()); j < _nc; j++ {
 				gc := child.NamedChild(j)
 				if gc.Type() == "function_definition" {
 					e.addMethodFromNode(gc, src, filePath, fileID, className, classID, seen, result)
@@ -385,7 +385,7 @@ func (e *CppExtractor) emitCppStructFieldTypeUse(structNode *sitter.Node, ownerI
 		return
 	}
 	var body *sitter.Node
-	for i := 0; i < int(structNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(structNode.NamedChildCount()); i < _nc; i++ {
 		child := structNode.NamedChild(i)
 		if child.Type() == "field_declaration_list" {
 			body = child
@@ -396,7 +396,7 @@ func (e *CppExtractor) emitCppStructFieldTypeUse(structNode *sitter.Node, ownerI
 		return
 	}
 	typeSeen := make(map[string]bool)
-	for i := 0; i < int(body.NamedChildCount()); i++ {
+	for i, _nc := 0, int(body.NamedChildCount()); i < _nc; i++ {
 		child := body.NamedChild(i)
 		if child.Type() != "field_declaration" {
 			continue
@@ -490,10 +490,10 @@ func (e *CppExtractor) emitInclude(m parser.QueryResult, filePath, fileID string
 // extractFuncName walks a function_definition node to find the function name.
 // It handles both `identifier` (free functions) and `field_identifier` (methods).
 func extractFuncName(funcNode *sitter.Node, src []byte) string {
-	for i := 0; i < int(funcNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(funcNode.NamedChildCount()); i < _nc; i++ {
 		child := funcNode.NamedChild(i)
 		if child.Type() == "function_declarator" {
-			for j := 0; j < int(child.NamedChildCount()); j++ {
+			for j, _nc := 0, int(child.NamedChildCount()); j < _nc; j++ {
 				gc := child.NamedChild(j)
 				switch gc.Type() {
 				case "identifier", "field_identifier", "destructor_name":
@@ -510,7 +510,7 @@ func extractFuncName(funcNode *sitter.Node, src []byte) string {
 // lastIdentifier extracts the last identifier from a qualified_identifier.
 func lastIdentifier(node *sitter.Node, src []byte) string {
 	name := ""
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		child := node.NamedChild(i)
 		switch child.Type() {
 		case "identifier", "field_identifier", "destructor_name":
@@ -563,12 +563,12 @@ func extractCppParentClass(classNode *sitter.Node, src []byte) string {
 	if classNode == nil {
 		return ""
 	}
-	for i := 0; i < int(classNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(classNode.NamedChildCount()); i < _nc; i++ {
 		child := classNode.NamedChild(i)
 		if child.Type() != "base_class_clause" {
 			continue
 		}
-		for j := 0; j < int(child.NamedChildCount()); j++ {
+		for j, _nc := 0, int(child.NamedChildCount()); j < _nc; j++ {
 			sub := child.NamedChild(j)
 			switch sub.Type() {
 			case "type_identifier", "qualified_identifier":
@@ -601,7 +601,7 @@ func extractCppCallArgTypes(callNode *sitter.Node, src []byte) []string {
 		return nil
 	}
 	var out []string
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		arg := args.NamedChild(i)
 		typeName := cppArgTypeHint(arg, src)
 		if typeName == "" {

--- a/internal/parser/languages/cpp_reffrm.go
+++ b/internal/parser/languages/cpp_reffrm.go
@@ -97,7 +97,7 @@ func emitCppReferenceForms(root *sitter.Node, src []byte, filePath, fileID strin
 		case "template_argument_list":
 			emitCppGenericArgs(n, src, filePath, funcRanges, result, seen)
 		}
-		for i := 0; i < int(n.NamedChildCount()); i++ {
+		for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 			walk(n.NamedChild(i))
 		}
 	}
@@ -171,7 +171,7 @@ func emitCppInheritance(clause *sitter.Node, src []byte, filePath string, result
 		return
 	}
 	line := int(clause.StartPoint().Row) + 1
-	for i := 0; i < int(clause.NamedChildCount()); i++ {
+	for i, _nc := 0, int(clause.NamedChildCount()); i < _nc; i++ {
 		ch := clause.NamedChild(i)
 		switch ch.Type() {
 		case "type_identifier", "template_type", "qualified_identifier", "dependent_type":
@@ -233,7 +233,7 @@ func emitCppStackConstruction(n *sitter.Node, src []byte, filePath string, funcR
 // initializer — the marker that distinguishes a stack construction
 // (`Foo x(1)`, `Foo x{1}`) from a plain typed local (`Foo x;`, `int x = 5`).
 func cppDeclHasCtorInit(decl *sitter.Node) bool {
-	for i := 0; i < int(decl.NamedChildCount()); i++ {
+	for i, _nc := 0, int(decl.NamedChildCount()); i < _nc; i++ {
 		ch := decl.NamedChild(i)
 		if ch.Type() != "init_declarator" {
 			continue
@@ -280,7 +280,7 @@ func emitCppNamedCast(n *sitter.Node, src []byte, filePath string, funcRanges []
 	line := int(n.StartPoint().Row) + 1
 	owner := findEnclosingFunc(funcRanges, line)
 	// The first template argument is the cast target.
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		ch := args.NamedChild(i)
 		if ch.Type() == "type_descriptor" {
 			emitCppReferenceEdge(owner, ch.Content(src), graph.RefContextCast, filePath, line, result, seen)
@@ -346,7 +346,7 @@ func emitCppGenericArgs(n *sitter.Node, src []byte, filePath string, funcRanges 
 	if owner == "" {
 		return
 	}
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		ch := n.NamedChild(i)
 		if ch == nil || ch.Type() != "type_descriptor" {
 			continue

--- a/internal/parser/languages/cpp_typeuse.go
+++ b/internal/parser/languages/cpp_typeuse.go
@@ -277,7 +277,7 @@ func collectCppTypeUseEdges(root *sitter.Node, funcRanges []funcRange, filePath 
 				}
 			}
 		}
-		for i := 0; i < int(n.NamedChildCount()); i++ {
+		for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 			walk(n.NamedChild(i))
 		}
 	}

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -477,7 +477,7 @@ func (e *CSharpExtractor) emitContainer(m parser.QueryResult, kind string, nodeK
 // the enum — so an enum's members are navigable symbols, not lost in the type.
 func (e *CSharpExtractor) emitCSharpEnumMembers(enumNode *sitter.Node, src []byte, filePath, enumID, enumName string, result *parser.ExtractionResult, seen map[string]bool) {
 	var list *sitter.Node
-	for i := 0; i < int(enumNode.ChildCount()); i++ {
+	for i, _nc := 0, int(enumNode.ChildCount()); i < _nc; i++ {
 		if c := enumNode.Child(i); c != nil && c.Type() == "enum_member_declaration_list" {
 			list = c
 			break
@@ -486,7 +486,7 @@ func (e *CSharpExtractor) emitCSharpEnumMembers(enumNode *sitter.Node, src []byt
 	if list == nil {
 		return
 	}
-	for i := 0; i < int(list.NamedChildCount()); i++ {
+	for i, _nc := 0, int(list.NamedChildCount()); i < _nc; i++ {
 		mem := list.NamedChild(i)
 		if mem.Type() != "enum_member_declaration" {
 			continue
@@ -495,7 +495,7 @@ func (e *CSharpExtractor) emitCSharpEnumMembers(enumNode *sitter.Node, src []byt
 		if nn := mem.ChildByFieldName("name"); nn != nil {
 			nameNode = nn
 		}
-		for j := 0; j < int(mem.NamedChildCount()); j++ {
+		for j, _nc := 0, int(mem.NamedChildCount()); j < _nc; j++ {
 			c := mem.NamedChild(j)
 			if c.Type() == "identifier" && nameNode == nil {
 				nameNode = c
@@ -532,7 +532,7 @@ func csharpHasModifier(decl *sitter.Node, src []byte, mod string) bool {
 	if decl == nil {
 		return false
 	}
-	for i := 0; i < int(decl.ChildCount()); i++ {
+	for i, _nc := 0, int(decl.ChildCount()); i < _nc; i++ {
 		c := decl.Child(i)
 		if c != nil && c.Type() == "modifier" && strings.TrimSpace(c.Content(src)) == mod {
 			return true
@@ -550,7 +550,7 @@ func csharpEnclosingNamespace(node *sitter.Node, src []byte) string {
 			if nm := n.ChildByFieldName("name"); nm != nil {
 				return strings.TrimSpace(nm.Content(src))
 			}
-			for i := 0; i < int(n.NamedChildCount()); i++ {
+			for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 				c := n.NamedChild(i)
 				if c.Type() == "identifier" || c.Type() == "qualified_name" {
 					return strings.TrimSpace(c.Content(src))
@@ -595,7 +595,7 @@ func csharpVisibility(decl *sitter.Node, src []byte, defaultVis string) string {
 	if decl == nil {
 		return defaultVis
 	}
-	for i := 0; i < int(decl.ChildCount()); i++ {
+	for i, _nc := 0, int(decl.ChildCount()); i < _nc; i++ {
 		c := decl.Child(i)
 		if c == nil {
 			continue
@@ -627,12 +627,12 @@ func csharpCollectAttributes(decl *sitter.Node, src []byte) []javaAnnotation {
 		return nil
 	}
 	var out []javaAnnotation
-	for i := 0; i < int(decl.ChildCount()); i++ {
+	for i, _nc := 0, int(decl.ChildCount()); i < _nc; i++ {
 		c := decl.Child(i)
 		if c == nil || c.Type() != "attribute_list" {
 			continue
 		}
-		for j := 0; j < int(c.ChildCount()); j++ {
+		for j, _nc := 0, int(c.ChildCount()); j < _nc; j++ {
 			a := c.Child(j)
 			if a == nil || a.Type() != "attribute" {
 				continue
@@ -642,7 +642,7 @@ func csharpCollectAttributes(decl *sitter.Node, src []byte) []javaAnnotation {
 			if nm := a.ChildByFieldName("name"); nm != nil {
 				name = nm.Content(src)
 			}
-			for k := 0; k < int(a.ChildCount()); k++ {
+			for k, _nc := 0, int(a.ChildCount()); k < _nc; k++ {
 				inner := a.Child(k)
 				if inner == nil {
 					continue
@@ -981,7 +981,7 @@ func emitCSharpBaseList(typeID string, decl *sitter.Node, src []byte, filePath s
 	if baseList == nil {
 		// `bases` is not a named field in every grammar revision; fall
 		// back to a direct child scan for the base_list node.
-		for i := 0; i < int(decl.ChildCount()); i++ {
+		for i, _nc := 0, int(decl.ChildCount()); i < _nc; i++ {
 			c := decl.Child(i)
 			if c != nil && c.Type() == "base_list" {
 				baseList = c
@@ -997,7 +997,7 @@ func emitCSharpBaseList(typeID string, decl *sitter.Node, src []byte, filePath s
 	// and the "first non-interface is the superclass" branch never runs.
 	allowsBaseClass := csharpDeclAllowsBaseClass(decl)
 	extendsTaken := false
-	for i := 0; i < int(baseList.NamedChildCount()); i++ {
+	for i, _nc := 0, int(baseList.NamedChildCount()); i < _nc; i++ {
 		entry := baseList.NamedChild(i)
 		if entry == nil {
 			continue
@@ -1035,7 +1035,7 @@ func csharpDeclAllowsBaseClass(decl *sitter.Node) bool {
 	case "struct_declaration":
 		return false
 	case "record_declaration":
-		for i := 0; i < int(decl.ChildCount()); i++ {
+		for i, _nc := 0, int(decl.ChildCount()); i < _nc; i++ {
 			if c := decl.Child(i); c != nil && c.Type() == "struct" {
 				return false
 			}
@@ -1061,7 +1061,7 @@ func csharpBaseTypeName(entry *sitter.Node, src []byte) (string, bool) {
 		if id := entry.ChildByFieldName("name"); id != nil {
 			return id.Content(src), false
 		}
-		for i := 0; i < int(entry.ChildCount()); i++ {
+		for i, _nc := 0, int(entry.ChildCount()); i < _nc; i++ {
 			if c := entry.Child(i); c != nil && c.Type() == "identifier" {
 				return c.Content(src), false
 			}
@@ -1069,7 +1069,7 @@ func csharpBaseTypeName(entry *sitter.Node, src []byte) (string, bool) {
 	case "qualified_name":
 		// System.Object → Object (the last identifier).
 		var last string
-		for i := 0; i < int(entry.ChildCount()); i++ {
+		for i, _nc := 0, int(entry.ChildCount()); i < _nc; i++ {
 			if c := entry.Child(i); c != nil && c.Type() == "identifier" {
 				last = c.Content(src)
 			}
@@ -1080,7 +1080,7 @@ func csharpBaseTypeName(entry *sitter.Node, src []byte) (string, bool) {
 		if id := entry.ChildByFieldName("type"); id != nil {
 			return normalizeCSharpBaseName(id.Content(src)), true
 		}
-		for i := 0; i < int(entry.ChildCount()); i++ {
+		for i, _nc := 0, int(entry.ChildCount()); i < _nc; i++ {
 			c := entry.Child(i)
 			if c == nil {
 				continue
@@ -1113,7 +1113,7 @@ func extractCSharpMethodReturnType(methodNode *sitter.Node, src []byte, methodNa
 	if methodNode == nil {
 		return ""
 	}
-	for i := 0; i < int(methodNode.ChildCount()); i++ {
+	for i, _nc := 0, int(methodNode.ChildCount()); i < _nc; i++ {
 		child := methodNode.Child(i)
 		if child.Type() == "identifier" && string(src[child.StartByte():child.EndByte()]) == methodName {
 			break
@@ -1166,7 +1166,7 @@ func csharpFieldDeclType(fieldDecl *sitter.Node, src []byte) string {
 	if fieldDecl == nil {
 		return ""
 	}
-	for i := 0; i < int(fieldDecl.NamedChildCount()); i++ {
+	for i, _nc := 0, int(fieldDecl.NamedChildCount()); i < _nc; i++ {
 		c := fieldDecl.NamedChild(i)
 		if c == nil || c.Type() != "variable_declaration" {
 			continue
@@ -1188,7 +1188,7 @@ func csharpFieldDeclType(fieldDecl *sitter.Node, src []byte) string {
 // inferTypeFromCSharpNew extracts the type name from a C# object_creation_expression.
 // new UserService(...) -> "UserService"
 func inferTypeFromCSharpNew(node *sitter.Node, src []byte) string {
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		child := node.NamedChild(i)
 		if child.Type() == "identifier" || child.Type() == "type_identifier" ||
 			child.Type() == "generic_name" || child.Type() == "qualified_name" {

--- a/internal/parser/languages/csharp_function_shape.go
+++ b/internal/parser/languages/csharp_function_shape.go
@@ -29,7 +29,7 @@ func emitCSharpFunctionShape(ownerID string, methodNode *sitter.Node, src []byte
 
 func emitCSharpParamNodes(ownerID string, params *sitter.Node, src []byte, filePath string, declLine int, result *parser.ExtractionResult) {
 	pos := 0
-	for i := 0; i < int(params.NamedChildCount()); i++ {
+	for i, _nc := 0, int(params.NamedChildCount()); i < _nc; i++ {
 		decl := params.NamedChild(i)
 		if decl == nil {
 			continue
@@ -46,7 +46,7 @@ func emitCSharpParamNodes(ownerID string, params *sitter.Node, src []byte, fileP
 			typeRaw = strings.TrimSpace(t.Content(src))
 		}
 		// Look for `params` modifier — variadic in C#.
-		for j := 0; j < int(decl.NamedChildCount()); j++ {
+		for j, _nc := 0, int(decl.NamedChildCount()); j < _nc; j++ {
 			c := decl.NamedChild(j)
 			if c != nil && c.Type() == "parameter_modifier" && strings.Contains(c.Content(src), "params") {
 				variadic = true
@@ -137,7 +137,7 @@ func emitCSharpReturnEdges(ownerID, returnText, filePath string, line int, resul
 func emitCSharpGenericParamNodes(ownerID string, methodNode *sitter.Node, src []byte, filePath string, line int, result *parser.ExtractionResult) {
 	tparams := methodNode.ChildByFieldName("type_parameters")
 	if tparams == nil {
-		for i := 0; i < int(methodNode.NamedChildCount()); i++ {
+		for i, _nc := 0, int(methodNode.NamedChildCount()); i < _nc; i++ {
 			c := methodNode.NamedChild(i)
 			if c != nil && c.Type() == "type_parameter_list" {
 				tparams = c
@@ -148,13 +148,13 @@ func emitCSharpGenericParamNodes(ownerID string, methodNode *sitter.Node, src []
 	if tparams == nil {
 		return
 	}
-	for i := 0; i < int(tparams.NamedChildCount()); i++ {
+	for i, _nc := 0, int(tparams.NamedChildCount()); i < _nc; i++ {
 		tp := tparams.NamedChild(i)
 		if tp == nil || tp.Type() != "type_parameter" {
 			continue
 		}
 		var name string
-		for j := 0; j < int(tp.NamedChildCount()); j++ {
+		for j, _nc := 0, int(tp.NamedChildCount()); j < _nc; j++ {
 			c := tp.NamedChild(j)
 			if c != nil && c.Type() == "identifier" {
 				name = c.Content(src)
@@ -296,7 +296,7 @@ func emitCSharpAsyncSpawns(ownerID string, body *sitter.Node, src []byte, filePa
 			line := int(n.StartPoint().Row) + 1
 			// Look for an inner invocation_expression to grab the
 			// callee name.
-			for i := 0; i < int(n.NamedChildCount()); i++ {
+			for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 				c := n.NamedChild(i)
 				if c == nil {
 					continue
@@ -353,7 +353,7 @@ func walkCSharpNodes(n *sitter.Node, visit func(*sitter.Node) bool) {
 	if !visit(n) {
 		return
 	}
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		walkCSharpNodes(n.NamedChild(i), visit)
 	}
 }
@@ -389,7 +389,7 @@ func csharpFunctionBody(methodNode *sitter.Node) *sitter.Node {
 	if b := methodNode.ChildByFieldName("body"); b != nil {
 		return b
 	}
-	for i := 0; i < int(methodNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(methodNode.NamedChildCount()); i < _nc; i++ {
 		c := methodNode.NamedChild(i)
 		if c != nil && c.Type() == "block" {
 			return c

--- a/internal/parser/languages/csharp_mediatr.go
+++ b/internal/parser/languages/csharp_mediatr.go
@@ -59,7 +59,7 @@ func captureMediatRDispatch(result *parser.ExtractionResult, root *sitter.Node, 
 		if body == nil {
 			return
 		}
-		for i := 0; i < int(body.NamedChildCount()); i++ {
+		for i, _nc := 0, int(body.NamedChildCount()); i < _nc; i++ {
 			m := body.NamedChild(i)
 			if m == nil || m.Type() != "method_declaration" {
 				continue
@@ -145,12 +145,12 @@ func captureMediatRDispatch(result *parser.ExtractionResult, root *sitter.Node, 
 // interface, returning the request/notification type (first generic arg)
 // and the dispatch kind.
 func mediatrHandlerType(classDecl *sitter.Node, src []byte) (reqType, kind string) {
-	for i := 0; i < int(classDecl.NamedChildCount()); i++ {
+	for i, _nc := 0, int(classDecl.NamedChildCount()); i < _nc; i++ {
 		bl := classDecl.NamedChild(i)
 		if bl == nil || bl.Type() != "base_list" {
 			continue
 		}
-		for j := 0; j < int(bl.NamedChildCount()); j++ {
+		for j, _nc := 0, int(bl.NamedChildCount()); j < _nc; j++ {
 			base := bl.NamedChild(j)
 			if base == nil || base.Type() != "generic_name" {
 				continue
@@ -167,7 +167,7 @@ func mediatrHandlerType(classDecl *sitter.Node, src []byte) (reqType, kind strin
 // mediatrGenericNameParts splits a generic_name into its base identifier
 // and first type argument's simple name.
 func mediatrGenericNameParts(gn *sitter.Node, src []byte) (base, firstArg string) {
-	for i := 0; i < int(gn.NamedChildCount()); i++ {
+	for i, _nc := 0, int(gn.NamedChildCount()); i < _nc; i++ {
 		c := gn.NamedChild(i)
 		if c == nil {
 			continue
@@ -178,7 +178,7 @@ func mediatrGenericNameParts(gn *sitter.Node, src []byte) (base, firstArg string
 				base = c.Content(src)
 			}
 		case "type_argument_list":
-			for j := 0; j < int(c.NamedChildCount()); j++ {
+			for j, _nc := 0, int(c.NamedChildCount()); j < _nc; j++ {
 				a := c.NamedChild(j)
 				if a != nil && a.IsNamed() {
 					firstArg = mediatrSimpleType(a.Content(src))
@@ -197,7 +197,7 @@ func mediatrArgType(call *sitter.Node, src []byte) string {
 	if args == nil {
 		return ""
 	}
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		a := args.NamedChild(i)
 		if a == nil {
 			continue
@@ -243,7 +243,7 @@ func mediatrWalk(n *sitter.Node, fn func(*sitter.Node)) {
 		return
 	}
 	fn(n)
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		mediatrWalk(n.NamedChild(i), fn)
 	}
 }

--- a/internal/parser/languages/csharp_typeuse.go
+++ b/internal/parser/languages/csharp_typeuse.go
@@ -186,7 +186,7 @@ func emitCSharpReferenceForms(root *sitter.Node, src []byte, filePath, fileID st
 			// manual recursion. Predefined primitives (`int`, `string`) parse
 			// as predefined_type and are skipped; the canon/primitive/
 			// capitalization gate in emit drops everything else lowercase.
-			for i := 0; i < int(n.NamedChildCount()); i++ {
+			for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 				arg := n.NamedChild(i)
 				if arg == nil {
 					continue
@@ -232,7 +232,7 @@ func csharpFirstChildOfType(node *sitter.Node, nodeType string) *sitter.Node {
 	if node == nil {
 		return nil
 	}
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		c := node.NamedChild(i)
 		if c != nil && c.Type() == nodeType {
 			return c
@@ -249,7 +249,7 @@ func csharpCreationTypeName(n *sitter.Node, src []byte) string {
 	if t := n.ChildByFieldName("type"); t != nil {
 		return strings.TrimSpace(t.Content(src))
 	}
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		c := n.NamedChild(i)
 		if c == nil {
 			continue
@@ -269,7 +269,7 @@ func csharpArrayElementTypeName(arrayType *sitter.Node, src []byte) string {
 	if t := arrayType.ChildByFieldName("type"); t != nil {
 		return strings.TrimSpace(t.Content(src))
 	}
-	for i := 0; i < int(arrayType.NamedChildCount()); i++ {
+	for i, _nc := 0, int(arrayType.NamedChildCount()); i < _nc; i++ {
 		c := arrayType.NamedChild(i)
 		if c == nil {
 			continue
@@ -331,7 +331,7 @@ func csharpIsPatternTypeName(n *sitter.Node, src []byte) string {
 	switch pat.Type() {
 	case "declaration_pattern", "recursive_pattern":
 		// `Foo f` — the type is the leading type token.
-		for i := 0; i < int(pat.NamedChildCount()); i++ {
+		for i, _nc := 0, int(pat.NamedChildCount()); i < _nc; i++ {
 			c := pat.NamedChild(i)
 			if c == nil {
 				continue
@@ -357,7 +357,7 @@ func csharpUnaryTypeArgName(n *sitter.Node, src []byte) string {
 	if t := n.ChildByFieldName("type"); t != nil {
 		return strings.TrimSpace(t.Content(src))
 	}
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		c := n.NamedChild(i)
 		if c == nil {
 			continue
@@ -408,12 +408,12 @@ func csharpNameofTypeArg(n *sitter.Node, src []byte) string {
 	if args == nil {
 		return ""
 	}
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		arg := args.NamedChild(i)
 		if arg == nil || arg.Type() != "argument" {
 			continue
 		}
-		for j := 0; j < int(arg.NamedChildCount()); j++ {
+		for j, _nc := 0, int(arg.NamedChildCount()); j < _nc; j++ {
 			c := arg.NamedChild(j)
 			if c == nil {
 				continue
@@ -434,7 +434,7 @@ func csharpAttributeTypeName(n *sitter.Node, src []byte) string {
 	if nm := n.ChildByFieldName("name"); nm != nil {
 		return strings.TrimSpace(nm.Content(src))
 	}
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		c := n.NamedChild(i)
 		if c == nil {
 			continue

--- a/internal/parser/languages/dart.go
+++ b/internal/parser/languages/dart.go
@@ -173,17 +173,17 @@ func (e *DartExtractor) extractTypes(
 // reachable through the class — codegraph does not model mixins at all. The
 // grammar nests them as class_definition → superclass → mixins → type_identifier.
 func (e *DartExtractor) emitDartMixinEdges(classNode *sitter.Node, src []byte, classID, filePath string, result *parser.ExtractionResult) {
-	for i := 0; i < int(classNode.ChildCount()); i++ {
+	for i, _nc := 0, int(classNode.ChildCount()); i < _nc; i++ {
 		sup := classNode.Child(i)
 		if sup.Type() != "superclass" {
 			continue
 		}
-		for j := 0; j < int(sup.ChildCount()); j++ {
+		for j, _nc := 0, int(sup.ChildCount()); j < _nc; j++ {
 			mixins := sup.Child(j)
 			if mixins.Type() != "mixins" {
 				continue
 			}
-			for k := 0; k < int(mixins.ChildCount()); k++ {
+			for k, _nc := 0, int(mixins.ChildCount()); k < _nc; k++ {
 				m := mixins.Child(k)
 				if m.Type() != "type_identifier" {
 					continue
@@ -311,12 +311,12 @@ func dartIsGenerated(filePath string) bool {
 // Returns "" when the method has no leading return type (e.g. a void-inferred
 // `build()` or a getter/setter).
 func dartMethodReturnType(methodSig *sitter.Node, src []byte) string {
-	for i := 0; i < int(methodSig.NamedChildCount()); i++ {
+	for i, _nc := 0, int(methodSig.NamedChildCount()); i < _nc; i++ {
 		fs := methodSig.NamedChild(i)
 		if fs.Type() != "function_signature" {
 			continue
 		}
-		for j := 0; j < int(fs.NamedChildCount()); j++ {
+		for j, _nc := 0, int(fs.NamedChildCount()); j < _nc; j++ {
 			c := fs.NamedChild(j)
 			switch c.Type() {
 			case "type_identifier", "type", "nullable_type":
@@ -355,7 +355,7 @@ func (e *DartExtractor) extractTopLevelFunctions(
 	root *sitter.Node, src []byte, filePath string, fileNode *graph.Node,
 	result *parser.ExtractionResult, seen map[string]bool,
 ) {
-	for i := 0; i < int(root.ChildCount()); i++ {
+	for i, _nc := 0, int(root.ChildCount()); i < _nc; i++ {
 		child := root.Child(i)
 		if child.Type() != "function_signature" {
 			continue
@@ -407,7 +407,7 @@ func (e *DartExtractor) extractTopLevelVariables(
 	root *sitter.Node, src []byte, filePath string, fileNode *graph.Node,
 	result *parser.ExtractionResult, seen map[string]bool,
 ) {
-	for i := 0; i < int(root.ChildCount()); i++ {
+	for i, _nc := 0, int(root.ChildCount()); i < _nc; i++ {
 		child := root.Child(i)
 		switch child.Type() {
 		case "initialized_variable_definition":
@@ -433,7 +433,7 @@ func (e *DartExtractor) extractTopLevelVariables(
 
 		case "static_final_declaration_list":
 			// Walk children for static_final_declaration nodes.
-			for j := 0; j < int(child.ChildCount()); j++ {
+			for j, _nc := 0, int(child.ChildCount()); j < _nc; j++ {
 				decl := child.Child(j)
 				if decl.Type() != "static_final_declaration" {
 					continue
@@ -578,7 +578,7 @@ func (e *DartExtractor) extractCalls(
 			if sib.Type() != "selector" {
 				break
 			}
-			for j := 0; j < int(sib.ChildCount()); j++ {
+			for j, _nc := 0, int(sib.ChildCount()); j < _nc; j++ {
 				child := sib.Child(j)
 				switch child.Type() {
 				case "argument_part", "arguments":
@@ -641,7 +641,7 @@ func firstIdentifierChild(node *sitter.Node) *sitter.Node {
 	if node == nil {
 		return nil
 	}
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		c := node.Child(i)
 		if c != nil && c.Type() == "identifier" {
 			return c
@@ -653,7 +653,7 @@ func firstIdentifierChild(node *sitter.Node) *sitter.Node {
 // --- helpers ---
 
 func (e *DartExtractor) hasChildType(node *sitter.Node, typeName string) bool {
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		if node.Child(i).Type() == typeName {
 			return true
 		}
@@ -662,7 +662,7 @@ func (e *DartExtractor) hasChildType(node *sitter.Node, typeName string) bool {
 }
 
 func (e *DartExtractor) findChildIdentifier(node *sitter.Node, src []byte) string {
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		child := node.Child(i)
 		if child.Type() == "identifier" {
 			return child.Content(src)
@@ -675,7 +675,7 @@ func (e *DartExtractor) findChildIdentifier(node *sitter.Node, src []byte) strin
 // method_signature wraps function_signature, getter_signature, setter_signature,
 // constructor_signature, operator_signature, factory_constructor_signature.
 func (e *DartExtractor) extractMethodName(node *sitter.Node, src []byte) string {
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		child := node.Child(i)
 		switch child.Type() {
 		case "function_signature":
@@ -702,7 +702,7 @@ func (e *DartExtractor) extractMethodName(node *sitter.Node, src []byte) string 
 			return e.findChildIdentifier(child, src)
 		case "operator_signature":
 			// operator + binary_operator child
-			for j := 0; j < int(child.ChildCount()); j++ {
+			for j, _nc := 0, int(child.ChildCount()); j < _nc; j++ {
 				c := child.Child(j)
 				if c.Type() == "binary_operator" || c.Type() == "tilde_operator" {
 					return "operator " + strings.TrimSpace(c.Content(src))
@@ -861,7 +861,7 @@ func (e *DartExtractor) mineDartFactoryChains(root *sitter.Node, src []byte, fil
 			}
 			var assignable *sitter.Node
 			hasArgs := false
-			for j := 0; j < int(sib.ChildCount()); j++ {
+			for j, _nc := 0, int(sib.ChildCount()); j < _nc; j++ {
 				switch sib.Child(j).Type() {
 				case "argument_part", "arguments":
 					hasArgs = true

--- a/internal/parser/languages/dart_reffrm.go
+++ b/internal/parser/languages/dart_reffrm.go
@@ -213,14 +213,14 @@ func (e *DartExtractor) emitDartReferenceForms(
 // generic_arg walk instead. The emit closure applies the Capitalization +
 // primitive gate, so a malformed clause yields nothing.
 func emitDartInheritanceClauses(classNode *sitter.Node, src []byte, emit func(rawType string, line int, kind graph.EdgeKind, refContext string)) {
-	for i := 0; i < int(classNode.ChildCount()); i++ {
+	for i, _nc := 0, int(classNode.ChildCount()); i < _nc; i++ {
 		clause := classNode.Child(i)
 		if clause == nil {
 			continue
 		}
 		switch clause.Type() {
 		case "superclass":
-			for j := 0; j < int(clause.ChildCount()); j++ {
+			for j, _nc := 0, int(clause.ChildCount()); j < _nc; j++ {
 				c := clause.Child(j)
 				if c == nil {
 					continue
@@ -244,7 +244,7 @@ func emitDartInheritanceClauses(classNode *sitter.Node, src []byte, emit func(ra
 // emitDartClauseTypes emits an inherit reference for every type_identifier
 // child of a clause node (mixins / interfaces).
 func emitDartClauseTypes(clause *sitter.Node, src []byte, emit func(rawType string, line int, kind graph.EdgeKind, refContext string)) {
-	for i := 0; i < int(clause.ChildCount()); i++ {
+	for i, _nc := 0, int(clause.ChildCount()); i < _nc; i++ {
 		c := clause.Child(i)
 		if c != nil && c.Type() == "type_identifier" {
 			emit(c.Content(src), int(c.StartPoint().Row)+1, graph.EdgeReferences, graph.RefContextInherit)
@@ -298,7 +298,7 @@ func emitDartIdentifierHead(n *sitter.Node, src []byte, line int, localTypes map
 		}
 		isMember := false
 		isCall := false
-		for j := 0; j < int(sib.ChildCount()); j++ {
+		for j, _nc := 0, int(sib.ChildCount()); j < _nc; j++ {
 			switch sib.Child(j).Type() {
 			case "unconditional_assignable_selector",
 				"conditional_assignable_selector":
@@ -335,7 +335,7 @@ func emitDartGenericArgs(targs *sitter.Node, src []byte, line int, emit func(raw
 	if targs == nil {
 		return
 	}
-	for i := 0; i < int(targs.NamedChildCount()); i++ {
+	for i, _nc := 0, int(targs.NamedChildCount()); i < _nc; i++ {
 		c := targs.NamedChild(i)
 		if c != nil && c.Type() == "type_identifier" {
 			emit(c.Content(src), line, graph.EdgeReferences, graph.RefContextGenericArg)
@@ -350,7 +350,7 @@ func dartFirstTypeIdentifier(node *sitter.Node, src []byte) string {
 	if node == nil {
 		return ""
 	}
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		c := node.Child(i)
 		if c != nil && c.Type() == "type_identifier" {
 			return c.Content(src)

--- a/internal/parser/languages/dart_typeuse.go
+++ b/internal/parser/languages/dart_typeuse.go
@@ -160,7 +160,7 @@ func dartLeadingTypeText(node *sitter.Node, src []byte) string {
 		return ""
 	}
 	typeText := ""
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		c := node.NamedChild(i)
 		if c == nil {
 			continue
@@ -203,7 +203,7 @@ func dartReturnTypeText(fnSig *sitter.Node, src []byte) string {
 		return ""
 	}
 	typeText := ""
-	for i := 0; i < int(fnSig.NamedChildCount()); i++ {
+	for i, _nc := 0, int(fnSig.NamedChildCount()); i < _nc; i++ {
 		c := fnSig.NamedChild(i)
 		if c == nil {
 			continue
@@ -233,7 +233,7 @@ func dartFirstChildOfType(node *sitter.Node, nodeType string) *sitter.Node {
 	if node == nil {
 		return nil
 	}
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		c := node.NamedChild(i)
 		if c != nil && c.Type() == nodeType {
 			return c

--- a/internal/parser/languages/dockerfile.go
+++ b/internal/parser/languages/dockerfile.go
@@ -97,7 +97,7 @@ func (e *DockerfileExtractor) walk(node *sitter.Node, src []byte, filePath, file
 		e.extractInstruction(node, src, filePath, fileID, result, nodeType)
 	}
 
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		child := node.Child(i)
 		if child != nil {
 			e.walk(child, src, filePath, fileID, result, st)
@@ -116,7 +116,7 @@ func (e *DockerfileExtractor) extractFrom(node *sitter.Node, src []byte, filePat
 	endLine := int(node.EndPoint().Row) + 1
 
 	imageName := ""
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		child := node.Child(i)
 		if child == nil {
 			continue
@@ -196,7 +196,7 @@ func (e *DockerfileExtractor) extractFrom(node *sitter.Node, src []byte, filePat
 }
 
 func (e *DockerfileExtractor) extractEnvArg(node *sitter.Node, src []byte, filePath, fileID string, result *parser.ExtractionResult, prefix string, st *dockerfileState) {
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		child := node.Child(i)
 		if child == nil {
 			continue
@@ -345,7 +345,7 @@ func (e *DockerfileExtractor) extractInstruction(node *sitter.Node, src []byte, 
 }
 
 func (e *DockerfileExtractor) findChildOfType(node *sitter.Node, childType string) *sitter.Node {
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		child := node.Child(i)
 		if child != nil && child.Type() == childType {
 			return child

--- a/internal/parser/languages/elixir.go
+++ b/internal/parser/languages/elixir.go
@@ -88,7 +88,7 @@ func (e *ElixirExtractor) walkNode(node *sitter.Node, src []byte, filePath, file
 	}
 
 	// Recurse into children.
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		child := node.Child(i)
 		e.walkNode(child, src, filePath, fileID, currentModule, result, seen)
 	}
@@ -96,7 +96,7 @@ func (e *ElixirExtractor) walkNode(node *sitter.Node, src []byte, filePath, file
 
 // getCallTarget returns the identifier name of a call's target, or "".
 func (e *ElixirExtractor) getCallTarget(callNode *sitter.Node, src []byte) string {
-	for i := 0; i < int(callNode.ChildCount()); i++ {
+	for i, _nc := 0, int(callNode.ChildCount()); i < _nc; i++ {
 		child := callNode.Child(i)
 		if callNode.FieldNameForChild(i) == "target" && child.Type() == "identifier" {
 			return child.Content(src)
@@ -131,7 +131,7 @@ func (e *ElixirExtractor) handleDefmodule(callNode *sitter.Node, src []byte, fil
 	// Walk children with module context so functions become methods.
 	body := e.findDoBlock(callNode)
 	if body != nil {
-		for i := 0; i < int(body.ChildCount()); i++ {
+		for i, _nc := 0, int(body.ChildCount()); i < _nc; i++ {
 			e.walkNode(body.Child(i), src, filePath, fileID, modName, result, seen)
 		}
 		// Phoenix plug dispatch: `plug :name` (optionally with
@@ -245,7 +245,7 @@ func (e *ElixirExtractor) handleAttribute(node *sitter.Node, src []byte, filePat
 	}
 	// Check if operator is "@".
 	opText := ""
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		child := node.Child(i)
 		if child.Type() == "@" || (node.FieldNameForChild(i) == "operator" && child.Content(src) == "@") {
 			opText = "@"
@@ -258,7 +258,7 @@ func (e *ElixirExtractor) handleAttribute(node *sitter.Node, src []byte, filePat
 
 	// The operand is typically a call node with the attribute name as target.
 	attrName := ""
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		child := node.Child(i)
 		fieldName := node.FieldNameForChild(i)
 		if fieldName == "operand" {
@@ -306,7 +306,7 @@ func (e *ElixirExtractor) collectCalls(node *sitter.Node, src []byte, filePath, 
 	if node.Type() == "call" {
 		e.emitCallEdge(node, src, filePath, callerID, result)
 	}
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		e.collectCalls(node.Child(i), src, filePath, callerID, result)
 	}
 }
@@ -317,7 +317,7 @@ func (e *ElixirExtractor) collectCalls(node *sitter.Node, src []byte, filePath, 
 // (unresolved::name), filtered against elixirKeywords / do / end.
 func (e *ElixirExtractor) emitCallEdge(callNode *sitter.Node, src []byte, filePath, callerID string, result *parser.ExtractionResult) {
 	line := int(callNode.StartPoint().Row) + 1
-	for i := 0; i < int(callNode.ChildCount()); i++ {
+	for i, _nc := 0, int(callNode.ChildCount()); i < _nc; i++ {
 		child := callNode.Child(i)
 		if child == nil || callNode.FieldNameForChild(i) != "target" {
 			continue
@@ -349,7 +349,7 @@ func (e *ElixirExtractor) emitCallEdge(callNode *sitter.Node, src []byte, filePa
 // dotCallMethod returns the right-hand identifier of a `dot` node
 // (the method name in `Module.method`), or "" when absent.
 func (e *ElixirExtractor) dotCallMethod(dotNode *sitter.Node, src []byte) string {
-	for i := 0; i < int(dotNode.ChildCount()); i++ {
+	for i, _nc := 0, int(dotNode.ChildCount()); i < _nc; i++ {
 		child := dotNode.Child(i)
 		if child != nil && dotNode.FieldNameForChild(i) == "right" && child.Type() == "identifier" {
 			return child.Content(src)
@@ -367,7 +367,7 @@ func (e *ElixirExtractor) extractModuleName(callNode *sitter.Node, src []byte) s
 	if args == nil {
 		return ""
 	}
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		child := args.NamedChild(i)
 		t := child.Type()
 		if t == "alias" || t == "dot" {
@@ -392,7 +392,7 @@ func (e *ElixirExtractor) extractFuncName(callNode *sitter.Node, src []byte) str
 	if args == nil {
 		return ""
 	}
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		child := args.NamedChild(i)
 		if child.Type() == "call" {
 			// def func_name(args) -> call target is func_name
@@ -405,7 +405,7 @@ func (e *ElixirExtractor) extractFuncName(callNode *sitter.Node, src []byte) str
 		if child.Type() == "binary_operator" {
 			// Pattern: def func_name(args) when guard -> binary_operator with "when"
 			// The left side should be the call with the function name.
-			for j := 0; j < int(child.NamedChildCount()); j++ {
+			for j, _nc := 0, int(child.NamedChildCount()); j < _nc; j++ {
 				sub := child.NamedChild(j)
 				if sub.Type() == "call" {
 					name := e.getCallTarget(sub, src)
@@ -438,7 +438,7 @@ func (e *ElixirExtractor) extractFirstArgText(callNode *sitter.Node, src []byte)
 // In Elixir's tree-sitter grammar, the arguments node has no field name,
 // so we find it by its node type.
 func (e *ElixirExtractor) findArguments(callNode *sitter.Node) *sitter.Node {
-	for i := 0; i < int(callNode.ChildCount()); i++ {
+	for i, _nc := 0, int(callNode.ChildCount()); i < _nc; i++ {
 		child := callNode.Child(i)
 		if child.Type() == "arguments" {
 			return child
@@ -449,7 +449,7 @@ func (e *ElixirExtractor) findArguments(callNode *sitter.Node) *sitter.Node {
 
 // findDoBlock locates the do-block body within a call node.
 func (e *ElixirExtractor) findDoBlock(callNode *sitter.Node) *sitter.Node {
-	for i := 0; i < int(callNode.ChildCount()); i++ {
+	for i, _nc := 0, int(callNode.ChildCount()); i < _nc; i++ {
 		child := callNode.Child(i)
 		if child.Type() == "do_block" {
 			return child
@@ -458,7 +458,7 @@ func (e *ElixirExtractor) findDoBlock(callNode *sitter.Node) *sitter.Node {
 	// Also check inside arguments for inline do blocks.
 	args := e.findArguments(callNode)
 	if args != nil {
-		for i := 0; i < int(args.ChildCount()); i++ {
+		for i, _nc := 0, int(args.ChildCount()); i < _nc; i++ {
 			child := args.Child(i)
 			if child.Type() == "do_block" {
 				return child
@@ -484,7 +484,7 @@ func (e *ElixirExtractor) emitPhoenixPlugBindings(body *sitter.Node, src []byte,
 	actions := make(map[string]int) // name → start line
 	allPlugs := make(map[string]struct{})
 
-	for i := 0; i < int(body.ChildCount()); i++ {
+	for i, _nc := 0, int(body.ChildCount()); i < _nc; i++ {
 		c := body.Child(i)
 		if c == nil || c.Type() != "call" {
 			continue
@@ -551,7 +551,7 @@ type phoenixPlugParsed struct {
 func parsePhoenixPlugCall(callNode *sitter.Node, src []byte) phoenixPlugParsed {
 	var out phoenixPlugParsed
 	var args *sitter.Node
-	for i := 0; i < int(callNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(callNode.NamedChildCount()); i < _nc; i++ {
 		c := callNode.NamedChild(i)
 		if c != nil && c.Type() == "arguments" {
 			args = c
@@ -579,7 +579,7 @@ func parsePhoenixPlugCall(callNode *sitter.Node, src []byte) phoenixPlugParsed {
 			list := right.NamedChild(1)
 			if list != nil && list.Type() == "list" {
 				out.filter = make(map[string]struct{})
-				for i := 0; i < int(list.NamedChildCount()); i++ {
+				for i, _nc := 0, int(list.NamedChildCount()); i < _nc; i++ {
 					item := list.NamedChild(i)
 					if item != nil && item.Type() == "atom" {
 						out.filter[strings.TrimPrefix(item.Content(src), ":")] = struct{}{}

--- a/internal/parser/languages/elixir_heex.go
+++ b/internal/parser/languages/elixir_heex.go
@@ -16,9 +16,9 @@ import (
 // HEEx component syntax:
 //
 //   - `<.local_name attr="...">…</.local_name>`     → local component
-//                                                     in the same module
+//     in the same module
 //   - `<MyApp.Components.Card />`                   → cross-module
-//                                                     reference
+//     reference
 //
 // Lowercase HTML / SVG primitives (`<div>`, `<span>`) are skipped — the
 // rendering edge graph would be pure noise otherwise. Capital-letter
@@ -88,7 +88,7 @@ func isHEExSigil(n *sitter.Node, src []byte) bool {
 		// Some grammar variants don't expose the name as a field.
 		// Fall back to scanning the first few children for a
 		// sigil_name node carrying the letter.
-		for i := 0; i < int(n.NamedChildCount()); i++ {
+		for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 			c := n.NamedChild(i)
 			if c != nil && (c.Type() == "sigil_name" || c.Type() == "sigil_modifiers") {
 				nameNode = c

--- a/internal/parser/languages/elixir_orm.go
+++ b/internal/parser/languages/elixir_orm.go
@@ -15,8 +15,8 @@ import (
 //
 //   - schema "name" do …          (Ecto.Schema, the canonical case)
 //   - embedded_schema do …        (Ecto.Schema embedded — no table; we
-//                                  skip these because there's no DB
-//                                  binding to surface)
+//     skip these because there's no DB
+//     binding to surface)
 //
 // `use Ecto.Schema` and friends aren't required for detection — the
 // presence of a `schema "..." do` macro is the load-bearing signal.
@@ -120,7 +120,7 @@ func elixirCallArgs(call *sitter.Node) *sitter.Node {
 	if a := call.ChildByFieldName("arguments"); a != nil {
 		return a
 	}
-	for i := 0; i < int(call.NamedChildCount()); i++ {
+	for i, _nc := 0, int(call.NamedChildCount()); i < _nc; i++ {
 		c := call.NamedChild(i)
 		if c == nil {
 			continue
@@ -139,7 +139,7 @@ func elixirFirstArg(args *sitter.Node) *sitter.Node {
 	if args == nil {
 		return nil
 	}
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		c := args.NamedChild(i)
 		if c == nil {
 			continue
@@ -157,7 +157,7 @@ func elixirFirstArg(args *sitter.Node) *sitter.Node {
 // the literal characters. Strips quotes when no `quoted_content`
 // child is present.
 func elixirStringLiteral(node *sitter.Node, src []byte) string {
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		c := node.NamedChild(i)
 		if c != nil && c.Type() == "quoted_content" {
 			return c.Content(src)

--- a/internal/parser/languages/fn_ref_special.go
+++ b/internal/parser/languages/fn_ref_special.go
@@ -46,7 +46,7 @@ func normalizeFnRefSpecial(n *sitter.Node, src []byte) (refName, recvHint string
 // identifier is the member, an optional leading type/expression the qualifier.
 func splitColonColonRef(n *sitter.Node, src []byte) (refName, recvHint string, ok bool) {
 	var first, last *sitter.Node
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		c := n.NamedChild(i)
 		if c == nil {
 			continue
@@ -105,7 +105,7 @@ func rubyMethodSymbol(n *sitter.Node, src []byte) (refName, recvHint string, ok 
 	if args == nil {
 		return "", "", false
 	}
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		if a := args.NamedChild(i); a != nil && a.Type() == "simple_symbol" {
 			if name := strings.TrimPrefix(strings.TrimSpace(a.Content(src)), ":"); name != "" {
 				return name, "<self>", true
@@ -118,7 +118,7 @@ func rubyMethodSymbol(n *sitter.Node, src []byte) (refName, recvHint string, ok 
 // rubySymbolProc handles Ruby `&:sym` symbol-to-proc — the symbol names the
 // method invoked on each element; resolved repo-wide.
 func rubySymbolProc(n *sitter.Node, src []byte) (refName, recvHint string, ok bool) {
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		if c := n.NamedChild(i); c != nil && c.Type() == "simple_symbol" {
 			if name := strings.TrimPrefix(strings.TrimSpace(c.Content(src)), ":"); name != "" {
 				return name, "", true

--- a/internal/parser/languages/go_configs.go
+++ b/internal/parser/languages/go_configs.go
@@ -121,7 +121,7 @@ func detectGoConfigKey(callExpr *sitter.Node, receiver, method string, src []byt
 	if args == nil {
 		return "", "", "", false
 	}
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		c := args.NamedChild(i)
 		if c == nil {
 			continue

--- a/internal/parser/languages/go_dataflow.go
+++ b/internal/parser/languages/go_dataflow.go
@@ -115,7 +115,6 @@ func (w *goFlowWalker) bindLocal(name string, line int) string {
 	return id
 }
 
-
 // goFlowScope tracks the most recent source IDs for each named
 // binding inside a function body. Reassignment replaces the slice
 // (the new value supersedes the old one); short_var_decl creates a
@@ -183,7 +182,7 @@ func (w *goFlowWalker) walk(n *sitter.Node) {
 		w.handleCall(n, nil)
 		return
 	}
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		w.walk(n.NamedChild(i))
 	}
 }
@@ -341,7 +340,7 @@ func (w *goFlowWalker) expressionList(n *sitter.Node) []*sitter.Node {
 		return []*sitter.Node{n}
 	}
 	out := make([]*sitter.Node, 0, n.NamedChildCount())
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		c := n.NamedChild(i)
 		if c == nil {
 			continue
@@ -359,13 +358,13 @@ func (w *goFlowWalker) handleReturn(n *sitter.Node) {
 	// expression list — owner gets no extra edges (the function
 	// signature carries the structural contract via EdgeReturns).
 	var exprs []*sitter.Node
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		c := n.NamedChild(i)
 		if c == nil {
 			continue
 		}
 		if c.Type() == "expression_list" {
-			for j := 0; j < int(c.NamedChildCount()); j++ {
+			for j, _nc := 0, int(c.NamedChildCount()); j < _nc; j++ {
 				e := c.NamedChild(j)
 				if e != nil {
 					exprs = append(exprs, e)
@@ -506,7 +505,7 @@ func (w *goFlowWalker) callArguments(call *sitter.Node) []*sitter.Node {
 		return nil
 	}
 	out := make([]*sitter.Node, 0, args.NamedChildCount())
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		c := args.NamedChild(i)
 		if c == nil {
 			continue
@@ -572,7 +571,7 @@ func (w *goFlowWalker) calleeRef(call *sitter.Node) string {
 			_ = synthetic
 		}
 		// Inline: try the inner identifier.
-		for i := 0; i < int(fn.NamedChildCount()); i++ {
+		for i, _nc := 0, int(fn.NamedChildCount()); i < _nc; i++ {
 			c := fn.NamedChild(i)
 			if c == nil {
 				continue
@@ -654,7 +653,7 @@ func (w *goFlowWalker) exprSources(n *sitter.Node) []string {
 		w.handleCall(n, nil)
 		return []string{ref}
 	case "parenthesized_expression":
-		for i := 0; i < int(n.NamedChildCount()); i++ {
+		for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 			if r := w.exprSources(n.NamedChild(i)); len(r) > 0 {
 				return r
 			}
@@ -692,7 +691,7 @@ func (w *goFlowWalker) exprSources(n *sitter.Node) []string {
 		// composite_literal's element values may carry flow; collect
 		// from each named element to surface field-init dataflow.
 		var out []string
-		for i := 0; i < int(n.NamedChildCount()); i++ {
+		for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 			c := n.NamedChild(i)
 			if c == nil {
 				continue
@@ -702,7 +701,7 @@ func (w *goFlowWalker) exprSources(n *sitter.Node) []string {
 		return out
 	case "keyed_element", "literal_element":
 		// Collect from whichever child carries a value subtree.
-		for i := 0; i < int(n.NamedChildCount()); i++ {
+		for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 			c := n.NamedChild(i)
 			if c == nil {
 				continue

--- a/internal/parser/languages/go_flags.go
+++ b/internal/parser/languages/go_flags.go
@@ -75,7 +75,7 @@ func detectGoFlagCheck(callExpr *sitter.Node, method string, src []byte) (provid
 	if args == nil {
 		return "", "", false
 	}
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		c := args.NamedChild(i)
 		if c == nil {
 			continue

--- a/internal/parser/languages/go_function_shape.go
+++ b/internal/parser/languages/go_function_shape.go
@@ -61,7 +61,7 @@ func goParamNamesFromCapture(paramsCap *parser.CapturedNode, src []byte) map[str
 		return out
 	}
 	list := paramsCap.Node
-	for i := 0; i < int(list.NamedChildCount()); i++ {
+	for i, _nc := 0, int(list.NamedChildCount()); i < _nc; i++ {
 		decl := list.NamedChild(i)
 		if decl == nil {
 			continue
@@ -75,7 +75,7 @@ func goParamNamesFromCapture(paramsCap *parser.CapturedNode, src []byte) map[str
 		if typeNode != nil {
 			typeText = strings.TrimSpace(typeNode.Content(src))
 		}
-		for j := 0; j < int(decl.NamedChildCount()); j++ {
+		for j, _nc := 0, int(decl.NamedChildCount()); j < _nc; j++ {
 			c := decl.NamedChild(j)
 			if c == nil || c == typeNode {
 				continue
@@ -188,7 +188,7 @@ func emitGoParamNodes(ownerID string, paramsCap *parser.CapturedNode, src []byte
 	}
 	list := paramsCap.Node
 	pos := 0
-	for i := 0; i < int(list.NamedChildCount()); i++ {
+	for i, _nc := 0, int(list.NamedChildCount()); i < _nc; i++ {
 		decl := list.NamedChild(i)
 		if decl == nil {
 			continue
@@ -206,7 +206,7 @@ func emitGoParamNodes(ownerID string, paramsCap *parser.CapturedNode, src []byte
 		// One declaration may carry multiple identifier names sharing
 		// a single type. Walk all identifier children, skipping the
 		// type node itself.
-		for j := 0; j < int(decl.NamedChildCount()); j++ {
+		for j, _nc := 0, int(decl.NamedChildCount()); j < _nc; j++ {
 			c := decl.NamedChild(j)
 			if c == nil || c == typeNode {
 				continue
@@ -309,7 +309,7 @@ func splitGoReturnTypes(node *sitter.Node, src []byte) []string {
 		return []string{strings.TrimSpace(node.Content(src))}
 	}
 	var out []string
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		decl := node.NamedChild(i)
 		if decl == nil {
 			continue
@@ -319,7 +319,7 @@ func splitGoReturnTypes(node *sitter.Node, src []byte) []string {
 			if tn := decl.ChildByFieldName("type"); tn != nil {
 				// Multi-name declarations duplicate the type once per name.
 				names := 0
-				for j := 0; j < int(decl.NamedChildCount()); j++ {
+				for j, _nc := 0, int(decl.NamedChildCount()); j < _nc; j++ {
 					c := decl.NamedChild(j)
 					if c == nil || c == tn {
 						continue
@@ -736,7 +736,7 @@ func walkGoNodes(node *sitter.Node, visit func(*sitter.Node) bool) {
 	if !visit(node) {
 		return
 	}
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		walkGoNodes(node.NamedChild(i), visit)
 	}
 }

--- a/internal/parser/languages/go_goframe_routes.go
+++ b/internal/parser/languages/go_goframe_routes.go
@@ -71,12 +71,12 @@ func captureGoFrameRoutes(result *parser.ExtractionResult, root *sitter.Node, fi
 		result.Nodes = append(result.Nodes, &graph.Node{
 			ID: routeID, Kind: graph.KindContract, Name: method + " " + path,
 			FilePath: filePath, StartLine: int(n.StartPoint().Row) + 1, Language: "go",
-			Meta:     nodeMeta,
+			Meta: nodeMeta,
 		})
 		result.Edges = append(result.Edges, &graph.Edge{
 			From: routeID, To: "unresolved::*." + reqType, Kind: graph.EdgeCalls,
 			FilePath: filePath, Line: int(n.StartPoint().Row) + 1,
-			Meta:     edgeMeta,
+			Meta: edgeMeta,
 		})
 	})
 
@@ -116,7 +116,7 @@ func captureGoFrameRoutes(result *parser.ExtractionResult, root *sitter.Node, fi
 
 // goframeStructType returns the struct_type of a type_spec, or nil.
 func goframeStructType(typeSpec *sitter.Node) *sitter.Node {
-	for i := 0; i < int(typeSpec.NamedChildCount()); i++ {
+	for i, _nc := 0, int(typeSpec.NamedChildCount()); i < _nc; i++ {
 		if c := typeSpec.NamedChild(i); c != nil && c.Type() == "struct_type" {
 			return c
 		}
@@ -128,7 +128,7 @@ func goframeStructType(typeSpec *sitter.Node) *sitter.Node {
 // struct tag and returns the method + path.
 func goframeMetaTag(structType *sitter.Node, src []byte) (method, path string, ok bool) {
 	var fields *sitter.Node
-	for i := 0; i < int(structType.NamedChildCount()); i++ {
+	for i, _nc := 0, int(structType.NamedChildCount()); i < _nc; i++ {
 		if c := structType.NamedChild(i); c != nil && c.Type() == "field_declaration_list" {
 			fields = c
 			break
@@ -137,7 +137,7 @@ func goframeMetaTag(structType *sitter.Node, src []byte) (method, path string, o
 	if fields == nil {
 		return "", "", false
 	}
-	for i := 0; i < int(fields.NamedChildCount()); i++ {
+	for i, _nc := 0, int(fields.NamedChildCount()); i < _nc; i++ {
 		fd := fields.NamedChild(i)
 		if fd == nil || fd.Type() != "field_declaration" {
 			continue
@@ -165,7 +165,7 @@ func goframeMetaTag(structType *sitter.Node, src []byte) (method, path string, o
 // goframeIsMetaEmbed reports whether a field_declaration is an embedded
 // `g.Meta` (or `gmeta.Meta`) field.
 func goframeIsMetaEmbed(fd *sitter.Node, src []byte) bool {
-	for i := 0; i < int(fd.NamedChildCount()); i++ {
+	for i, _nc := 0, int(fd.NamedChildCount()); i < _nc; i++ {
 		c := fd.NamedChild(i)
 		if c != nil && c.Type() == "qualified_type" {
 			if t := c.ChildByFieldName("name"); t != nil && t.Content(src) == "Meta" {
@@ -180,12 +180,12 @@ func goframeIsMetaEmbed(fd *sitter.Node, src []byte) bool {
 // reading the literal's content child so the surrounding ` / " delimiters
 // (not the inner key:"value" quotes) are stripped.
 func goframeFieldTag(fd *sitter.Node, src []byte) string {
-	for i := 0; i < int(fd.NamedChildCount()); i++ {
+	for i, _nc := 0, int(fd.NamedChildCount()); i < _nc; i++ {
 		c := fd.NamedChild(i)
 		if c == nil || (c.Type() != "raw_string_literal" && c.Type() != "interpreted_string_literal") {
 			continue
 		}
-		for j := 0; j < int(c.NamedChildCount()); j++ {
+		for j, _nc := 0, int(c.NamedChildCount()); j < _nc; j++ {
 			if cc := c.NamedChild(j); cc != nil && strings.HasSuffix(cc.Type(), "content") {
 				return cc.Content(src)
 			}
@@ -219,7 +219,7 @@ func goframeTagValue(tag, key string) string {
 func goframeMethodParts(md *sitter.Node, src []byte) (name, recvType, reqType, reqPkg string, ok bool) {
 	var plists []*sitter.Node
 	var nameNode *sitter.Node
-	for i := 0; i < int(md.NamedChildCount()); i++ {
+	for i, _nc := 0, int(md.NamedChildCount()); i < _nc; i++ {
 		c := md.NamedChild(i)
 		if c == nil {
 			continue
@@ -251,7 +251,7 @@ func goframePackageName(root *sitter.Node, src []byte) string {
 		if pkg != "" || n.Type() != "package_clause" {
 			return
 		}
-		for i := 0; i < int(n.NamedChildCount()); i++ {
+		for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 			if c := n.NamedChild(i); c != nil && c.Type() == "package_identifier" {
 				pkg = strings.TrimSpace(c.Content(src))
 				return
@@ -264,7 +264,7 @@ func goframePackageName(root *sitter.Node, src []byte) string {
 // goframePointedType returns the (pointer-stripped) type name of a
 // parameter list's single parameter — used for the receiver type.
 func goframePointedType(plist *sitter.Node, src []byte) string {
-	for i := 0; i < int(plist.NamedChildCount()); i++ {
+	for i, _nc := 0, int(plist.NamedChildCount()); i < _nc; i++ {
 		pd := plist.NamedChild(i)
 		if pd == nil || pd.Type() != "parameter_declaration" {
 			continue
@@ -278,7 +278,7 @@ func goframePointedType(plist *sitter.Node, src []byte) string {
 // qualifier, "" when unqualified) of the last pointer-typed parameter — the
 // GoFrame request struct.
 func goframeLastPointerParamType(plist *sitter.Node, src []byte) (typeName, pkg string) {
-	for i := 0; i < int(plist.NamedChildCount()); i++ {
+	for i, _nc := 0, int(plist.NamedChildCount()); i < _nc; i++ {
 		pd := plist.NamedChild(i)
 		if pd == nil || pd.Type() != "parameter_declaration" {
 			continue
@@ -358,7 +358,7 @@ func goframeBoundControllers(root *sitter.Node, src []byte) map[string]bool {
 		if args == nil {
 			return
 		}
-		for i := 0; i < int(args.NamedChildCount()); i++ {
+		for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 			a := args.NamedChild(i)
 			if a == nil || a.Type() != "call_expression" {
 				continue
@@ -384,7 +384,7 @@ func goframeWalk(n *sitter.Node, fn func(*sitter.Node)) {
 		return
 	}
 	fn(n)
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		goframeWalk(n.NamedChild(i), fn)
 	}
 }

--- a/internal/parser/languages/go_observability.go
+++ b/internal/parser/languages/go_observability.go
@@ -64,7 +64,7 @@ func detectGoLogEvent(callExpr *sitter.Node, method string, src []byte) (string,
 	if args == nil {
 		return "", false
 	}
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		c := args.NamedChild(i)
 		if c == nil {
 			continue

--- a/internal/parser/languages/go_orm.go
+++ b/internal/parser/languages/go_orm.go
@@ -37,7 +37,7 @@ func detectGoORMModel(structNode *sitter.Node, src []byte, ownerID, ownerName, f
 
 	hasGormTag := false
 	embedsGormModel := false
-	for i := 0; i < int(fieldList.NamedChildCount()); i++ {
+	for i, _nc := 0, int(fieldList.NamedChildCount()); i < _nc; i++ {
 		decl := fieldList.NamedChild(i)
 		if decl == nil || decl.Type() != "field_declaration" {
 			continue
@@ -95,7 +95,7 @@ func detectGoORMModel(structNode *sitter.Node, src []byte, ownerID, ownerName, f
 // goStructFieldList returns the field_declaration_list node from a
 // struct_type, or nil when absent.
 func goStructFieldList(structNode *sitter.Node) *sitter.Node {
-	for i := 0; i < int(structNode.ChildCount()); i++ {
+	for i, _nc := 0, int(structNode.ChildCount()); i < _nc; i++ {
 		c := structNode.Child(i)
 		if c != nil && c.Type() == "field_declaration_list" {
 			return c
@@ -107,7 +107,7 @@ func goStructFieldList(structNode *sitter.Node) *sitter.Node {
 // structFieldHasGormTag reports whether a field_declaration carries a
 // `gorm:"..."` struct tag.
 func structFieldHasGormTag(decl *sitter.Node, src []byte) bool {
-	for i := 0; i < int(decl.NamedChildCount()); i++ {
+	for i, _nc := 0, int(decl.NamedChildCount()); i < _nc; i++ {
 		c := decl.NamedChild(i)
 		if c == nil || c.Type() != "raw_string_literal" {
 			continue
@@ -125,7 +125,7 @@ func structFieldHasGormTag(decl *sitter.Node, src []byte) bool {
 // `*gorm.Model` shapes.
 func structFieldEmbedsGormModel(decl *sitter.Node, src []byte) bool {
 	hasName := false
-	for i := 0; i < int(decl.NamedChildCount()); i++ {
+	for i, _nc := 0, int(decl.NamedChildCount()); i < _nc; i++ {
 		c := decl.NamedChild(i)
 		if c == nil {
 			continue
@@ -139,7 +139,7 @@ func structFieldEmbedsGormModel(decl *sitter.Node, src []byte) bool {
 		// An explicit field name means it isn't an embed.
 		return false
 	}
-	for i := 0; i < int(decl.NamedChildCount()); i++ {
+	for i, _nc := 0, int(decl.NamedChildCount()); i < _nc; i++ {
 		c := decl.NamedChild(i)
 		if c == nil {
 			continue
@@ -152,7 +152,7 @@ func structFieldEmbedsGormModel(decl *sitter.Node, src []byte) bool {
 			}
 		case "pointer_type":
 			// `*gorm.Model` — the qualified_type lives inside.
-			for j := 0; j < int(c.NamedChildCount()); j++ {
+			for j, _nc := 0, int(c.NamedChildCount()); j < _nc; j++ {
 				inner := c.NamedChild(j)
 				if inner != nil && inner.Type() == "qualified_type" &&
 					strings.TrimSpace(inner.Content(src)) == "gorm.Model" {
@@ -386,7 +386,7 @@ func walkAST(n *sitter.Node, visit func(*sitter.Node) bool) {
 	if !visit(n) {
 		return
 	}
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		walkAST(n.NamedChild(i), visit)
 	}
 }
@@ -400,7 +400,7 @@ func receiverTypeFromMethodNode(n *sitter.Node, src []byte) string {
 	if recv == nil {
 		return ""
 	}
-	for i := 0; i < int(recv.NamedChildCount()); i++ {
+	for i, _nc := 0, int(recv.NamedChildCount()); i < _nc; i++ {
 		decl := recv.NamedChild(i)
 		if decl == nil || decl.Type() != "parameter_declaration" {
 			continue
@@ -433,7 +433,7 @@ func firstStringReturnLiteral(body *sitter.Node, src []byte) string {
 			return true
 		}
 		// return_statement's first named child is the expression list.
-		for i := 0; i < int(n.NamedChildCount()); i++ {
+		for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 			c := n.NamedChild(i)
 			if c == nil {
 				continue

--- a/internal/parser/languages/go_pubsub.go
+++ b/internal/parser/languages/go_pubsub.go
@@ -63,7 +63,7 @@ func firstGoStringLiteralArg(callExpr *sitter.Node, src []byte) string {
 	if args == nil {
 		return ""
 	}
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		c := args.NamedChild(i)
 		if c == nil {
 			continue

--- a/internal/parser/languages/go_sql.go
+++ b/internal/parser/languages/go_sql.go
@@ -34,15 +34,15 @@ var goSQLExecMethods = map[string]struct{}{
 	"Exec":            {},
 	"ExecContext":     {},
 	"Prepare":         {},
-	"PrepareContext": {},
+	"PrepareContext":  {},
 	// sqlx
-	"Get":         {},
-	"GetContext":  {},
-	"Select":      {},
+	"Get":           {},
+	"GetContext":    {},
+	"Select":        {},
 	"SelectContext": {},
-	"NamedExec":   {},
-	"NamedQuery":  {},
-	"MustExec":    {},
+	"NamedExec":     {},
+	"NamedQuery":    {},
+	"MustExec":      {},
 	// pgx
 	"QueryRowContextScan": {},
 }
@@ -81,7 +81,7 @@ func detectGoSQLCall(callExpr *sitter.Node, method string, src []byte) ([]sql.Ta
 	if args == nil {
 		return nil, nil, "", false
 	}
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		c := args.NamedChild(i)
 		if c == nil {
 			continue
@@ -111,21 +111,21 @@ func detectGoSQLCall(callExpr *sitter.Node, method string, src []byte) ([]sql.Ta
 // suffix still resolves to postgres via prefix-stripped lookup).
 var goSQLDriverDialects = map[string]string{
 	// Postgres
-	"github.com/lib/pq":               "postgres",
-	"github.com/jackc/pgx":            "postgres",
-	"github.com/jackc/pgx/v4":         "postgres",
-	"github.com/jackc/pgx/v5":         "postgres",
-	"github.com/jackc/pgconn":         "postgres",
-	"github.com/jackc/pgxpool":        "postgres",
+	"github.com/lib/pq":        "postgres",
+	"github.com/jackc/pgx":     "postgres",
+	"github.com/jackc/pgx/v4":  "postgres",
+	"github.com/jackc/pgx/v5":  "postgres",
+	"github.com/jackc/pgconn":  "postgres",
+	"github.com/jackc/pgxpool": "postgres",
 	// MySQL / MariaDB
-	"github.com/go-sql-driver/mysql": "mysql",
+	"github.com/go-sql-driver/mysql":   "mysql",
 	"github.com/go-mysql-org/go-mysql": "mysql",
 	// SQLite
-	"github.com/mattn/go-sqlite3":    "sqlite",
-	"github.com/glebarez/go-sqlite":  "sqlite",
-	"modernc.org/sqlite":             "sqlite",
+	"github.com/mattn/go-sqlite3":   "sqlite",
+	"github.com/glebarez/go-sqlite": "sqlite",
+	"modernc.org/sqlite":            "sqlite",
 	// SQL Server
-	"github.com/microsoft/go-mssqldb": "mssql",
+	"github.com/microsoft/go-mssqldb":  "mssql",
 	"github.com/denisenkom/go-mssqldb": "mssql",
 }
 

--- a/internal/parser/languages/go_strings.go
+++ b/internal/parser/languages/go_strings.go
@@ -53,9 +53,9 @@ var goMetricMethods = map[string]bool{
 // heuristic — `errors.New(...)` and `fmt.Errorf(...)` are by far the
 // dominant idioms.
 var goErrorMessageCalls = map[[2]string]bool{
-	{"errors", "New"}:    true,
-	{"fmt", "Errorf"}:    true,
-	{"xerrors", "New"}:   true, // golang.org/x/xerrors
+	{"errors", "New"}:     true,
+	{"fmt", "Errorf"}:     true,
+	{"xerrors", "New"}:    true, // golang.org/x/xerrors
 	{"xerrors", "Errorf"}: true,
 }
 
@@ -188,7 +188,7 @@ func firstStringLiteralArg(callExpr *sitter.Node, src []byte) (string, bool) {
 	if args == nil {
 		return "", false
 	}
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		c := args.NamedChild(i)
 		if c == nil {
 			continue

--- a/internal/parser/languages/go_typeuse.go
+++ b/internal/parser/languages/go_typeuse.go
@@ -95,7 +95,7 @@ func emitGoTypeArgReferences(root *sitter.Node, src []byte, filePath, fileID str
 		case "type_identifier", "qualified_type":
 			emit(n.Content(src), int(n.StartPoint().Row)+1)
 		default:
-			for i := 0; i < int(n.NamedChildCount()); i++ {
+			for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 				emitTypeLeaves(n.NamedChild(i))
 			}
 		}
@@ -107,7 +107,7 @@ func emitGoTypeArgReferences(root *sitter.Node, src []byte, filePath, fileID str
 			// Generic instantiation arguments: the bracketed list under a
 			// generic_type. Each entry is a type_elem (or a bare type
 			// node on older grammars); descend into all of them.
-			for i := 0; i < int(n.NamedChildCount()); i++ {
+			for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 				emitTypeLeaves(n.NamedChild(i))
 			}
 		case "map_type":
@@ -121,7 +121,7 @@ func emitGoTypeArgReferences(root *sitter.Node, src []byte, filePath, fileID str
 				emitTypeLeaves(key)
 				emitTypeLeaves(value)
 			} else {
-				for i := 0; i < int(n.NamedChildCount()); i++ {
+				for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 					emitTypeLeaves(n.NamedChild(i))
 				}
 			}
@@ -132,7 +132,7 @@ func emitGoTypeArgReferences(root *sitter.Node, src []byte, filePath, fileID str
 			if value := n.ChildByFieldName("value"); value != nil {
 				emitTypeLeaves(value)
 			} else {
-				for i := 0; i < int(n.NamedChildCount()); i++ {
+				for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 					emitTypeLeaves(n.NamedChild(i))
 				}
 			}
@@ -162,7 +162,7 @@ func collectGoTypeParamNames(root *sitter.Node, src []byte) map[string]bool {
 				return
 			}
 		}
-		for i := 0; i < int(n.NamedChildCount()); i++ {
+		for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 			c := n.NamedChild(i)
 			if c == nil {
 				continue

--- a/internal/parser/languages/golang.go
+++ b/internal/parser/languages/golang.go
@@ -1312,7 +1312,7 @@ func goFuncBody(decl *sitter.Node) *sitter.Node {
 	if b := decl.ChildByFieldName("body"); b != nil {
 		return b
 	}
-	for i := 0; i < int(decl.ChildCount()); i++ {
+	for i, _nc := 0, int(decl.ChildCount()); i < _nc; i++ {
 		c := decl.Child(i)
 		if c != nil && c.Type() == "block" {
 			return c
@@ -1432,7 +1432,7 @@ func goTypeParams(decl *sitter.Node, src []byte) []map[string]string {
 	if tps == nil {
 		// type_spec uses a different field shape — fall back to a
 		// child-type scan.
-		for i := 0; i < int(decl.ChildCount()); i++ {
+		for i, _nc := 0, int(decl.ChildCount()); i < _nc; i++ {
 			c := decl.Child(i)
 			if c != nil && c.Type() == "type_parameter_list" {
 				tps = c
@@ -1444,7 +1444,7 @@ func goTypeParams(decl *sitter.Node, src []byte) []map[string]string {
 		return nil
 	}
 	var out []map[string]string
-	for i := 0; i < int(tps.NamedChildCount()); i++ {
+	for i, _nc := 0, int(tps.NamedChildCount()); i < _nc; i++ {
 		pd := tps.NamedChild(i)
 		if pd == nil {
 			continue
@@ -1461,7 +1461,7 @@ func goTypeParams(decl *sitter.Node, src []byte) []map[string]string {
 		// field 'name' for the leading identifier list. For multi-name
 		// declarations the grammar emits multiple entries with the
 		// same field name; we walk children to find them all.
-		for j := 0; j < int(pd.ChildCount()); j++ {
+		for j, _nc := 0, int(pd.ChildCount()); j < _nc; j++ {
 			c := pd.Child(j)
 			if c == nil {
 				continue
@@ -1662,7 +1662,7 @@ func emitGoStructFields(structNode *sitter.Node, src []byte, ownerID, ownerName,
 		return
 	}
 	var fieldList *sitter.Node
-	for i := 0; i < int(structNode.ChildCount()); i++ {
+	for i, _nc := 0, int(structNode.ChildCount()); i < _nc; i++ {
 		c := structNode.Child(i)
 		if c != nil && c.Type() == "field_declaration_list" {
 			fieldList = c
@@ -1672,7 +1672,7 @@ func emitGoStructFields(structNode *sitter.Node, src []byte, ownerID, ownerName,
 	if fieldList == nil {
 		return
 	}
-	for i := 0; i < int(fieldList.NamedChildCount()); i++ {
+	for i, _nc := 0, int(fieldList.NamedChildCount()); i < _nc; i++ {
 		decl := fieldList.NamedChild(i)
 		if decl == nil || decl.Type() != "field_declaration" {
 			continue
@@ -1685,7 +1685,7 @@ func emitGoStructFields(structNode *sitter.Node, src []byte, ownerID, ownerName,
 		// reliable form.
 		var nameNodes []*sitter.Node
 		var typeNode *sitter.Node
-		for j := 0; j < int(decl.NamedChildCount()); j++ {
+		for j, _nc := 0, int(decl.NamedChildCount()); j < _nc; j++ {
 			c := decl.NamedChild(j)
 			if c == nil {
 				continue
@@ -1779,7 +1779,7 @@ func embeddedFieldName(typeNode *sitter.Node, src []byte) string {
 		return typeNode.Content(src)
 	case "pointer_type":
 		// Recurse into the pointed-to type.
-		for i := 0; i < int(typeNode.NamedChildCount()); i++ {
+		for i, _nc := 0, int(typeNode.NamedChildCount()); i < _nc; i++ {
 			if n := embeddedFieldName(typeNode.NamedChild(i), src); n != "" {
 				return n
 			}
@@ -1794,7 +1794,7 @@ func embeddedFieldName(typeNode *sitter.Node, src []byte) string {
 		}
 	case "generic_type":
 		// Foo[T] — name is the inner type_identifier.
-		for i := 0; i < int(typeNode.NamedChildCount()); i++ {
+		for i, _nc := 0, int(typeNode.NamedChildCount()); i < _nc; i++ {
 			if n := embeddedFieldName(typeNode.NamedChild(i), src); n != "" {
 				return n
 			}
@@ -2068,7 +2068,7 @@ func goFuncSingleReturnLiteral(declNode *sitter.Node, src []byte) (string, bool)
 	}
 	var ret *sitter.Node
 	stmts := 0
-	for i := 0; i < int(stmtParent.NamedChildCount()); i++ {
+	for i, _nc := 0, int(stmtParent.NamedChildCount()); i < _nc; i++ {
 		c := stmtParent.NamedChild(i)
 		if c == nil || c.Type() == "comment" {
 			continue
@@ -2083,7 +2083,7 @@ func goFuncSingleReturnLiteral(declNode *sitter.Node, src []byte) (string, bool)
 	}
 	// return_statement -> expression_list -> single string literal
 	var expr *sitter.Node
-	for i := 0; i < int(ret.NamedChildCount()); i++ {
+	for i, _nc := 0, int(ret.NamedChildCount()); i < _nc; i++ {
 		n := ret.NamedChild(i)
 		if n == nil {
 			continue
@@ -2133,7 +2133,7 @@ func goConstLiteralValue(constSpec *sitter.Node, name string, src []byte) (strin
 		// one and no name match (defensive).
 		var found, only *sitter.Node
 		count := 0
-		for i := 0; i < int(spec.NamedChildCount()); i++ {
+		for i, _nc := 0, int(spec.NamedChildCount()); i < _nc; i++ {
 			c := spec.NamedChild(i)
 			if c == nil || c.Type() != "const_spec" {
 				continue
@@ -2181,7 +2181,7 @@ func goConstRefName(constDecl *sitter.Node, name string, src []byte) (string, bo
 	if constDecl == nil {
 		return "", false
 	}
-	for i := 0; i < int(constDecl.NamedChildCount()); i++ {
+	for i, _nc := 0, int(constDecl.NamedChildCount()); i < _nc; i++ {
 		spec := constDecl.NamedChild(i)
 		if spec == nil || spec.Type() != "const_spec" {
 			continue
@@ -2383,7 +2383,7 @@ func grpcRegisterArgNode(callNode *sitter.Node, funcName string) (service string
 	}
 	// Second positional argument names the server implementation.
 	count := 0
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		c := args.NamedChild(i)
 		if c == nil {
 			continue
@@ -2509,7 +2509,7 @@ func extractGoParamNames(paramList *sitter.Node, src []byte) map[string]bool {
 		return nil
 	}
 	out := map[string]bool{}
-	for i := 0; i < int(paramList.NamedChildCount()); i++ {
+	for i, _nc := 0, int(paramList.NamedChildCount()); i < _nc; i++ {
 		decl := paramList.NamedChild(i)
 		if decl == nil {
 			continue
@@ -2518,7 +2518,7 @@ func extractGoParamNames(paramList *sitter.Node, src []byte) map[string]bool {
 			continue
 		}
 		typeNode := decl.ChildByFieldName("type")
-		for j := 0; j < int(decl.NamedChildCount()); j++ {
+		for j, _nc := 0, int(decl.NamedChildCount()); j < _nc; j++ {
 			c := decl.NamedChild(j)
 			if c == nil || c == typeNode {
 				continue
@@ -2536,7 +2536,7 @@ func extractGoParamTypes(paramList *sitter.Node, src []byte) typeEnv {
 		return nil
 	}
 	out := typeEnv{}
-	for i := 0; i < int(paramList.NamedChildCount()); i++ {
+	for i, _nc := 0, int(paramList.NamedChildCount()); i < _nc; i++ {
 		decl := paramList.NamedChild(i)
 		if decl == nil {
 			continue
@@ -2556,7 +2556,7 @@ func extractGoParamTypes(paramList *sitter.Node, src []byte) typeEnv {
 		// Walk all identifier children — Go allows multiple names per
 		// parameter declaration sharing one type. Skip the type node
 		// itself (which may also be reported as a named child).
-		for j := 0; j < int(decl.NamedChildCount()); j++ {
+		for j, _nc := 0, int(decl.NamedChildCount()); j < _nc; j++ {
 			c := decl.NamedChild(j)
 			if c == nil || c == typeNode {
 				continue
@@ -2606,10 +2606,10 @@ func buildMethodSignature(receiver, name string, params, result *parser.Captured
 // and returns the names of all method_spec / method_elem entries.
 func extractInterfaceMethods(ifaceNode *sitter.Node, src []byte) []string {
 	var methods []string
-	for i := 0; i < int(ifaceNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(ifaceNode.NamedChildCount()); i < _nc; i++ {
 		child := ifaceNode.NamedChild(i)
 		if child.Type() == "method_elem" || child.Type() == "method_spec" {
-			for j := 0; j < int(child.NamedChildCount()); j++ {
+			for j, _nc := 0, int(child.NamedChildCount()); j < _nc; j++ {
 				nameNode := child.NamedChild(j)
 				if nameNode.Type() == "field_identifier" {
 					methods = append(methods, nameNode.Content(src))
@@ -2642,7 +2642,7 @@ func extractEmbeddedInterfaceTypes(ifaceNode *sitter.Node, src []byte) []string 
 			}
 		}
 	}
-	for i := 0; i < int(ifaceNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(ifaceNode.NamedChildCount()); i < _nc; i++ {
 		child := ifaceNode.NamedChild(i)
 		if child == nil {
 			continue
@@ -2652,7 +2652,7 @@ func extractEmbeddedInterfaceTypes(ifaceNode *sitter.Node, src []byte) []string 
 			// Modern grammar: each embedded type is one type_elem
 			// child. The named child of type_elem is the type
 			// reference itself.
-			for j := 0; j < int(child.NamedChildCount()); j++ {
+			for j, _nc := 0, int(child.NamedChildCount()); j < _nc; j++ {
 				visit(child.NamedChild(j))
 			}
 		case "type_identifier", "qualified_type", "generic_type":
@@ -2729,7 +2729,7 @@ func inferTypeFromGoExpr(node *sitter.Node, src []byte) string {
 	case "unary_expression":
 		// `&Foo{...}` — operator is "&" (first child), operand is
 		// the composite literal.
-		for i := 0; i < int(node.NamedChildCount()); i++ {
+		for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 			c := node.NamedChild(i)
 			if c != nil && c.Type() == "composite_literal" {
 				return compositeLiteralType(c, src)
@@ -2777,7 +2777,7 @@ func compositeLiteralType(lit *sitter.Node, src []byte) string {
 		}
 	case "pointer_type":
 		// *Foo{...} — rare but defensible.
-		for i := 0; i < int(t.NamedChildCount()); i++ {
+		for i, _nc := 0, int(t.NamedChildCount()); i < _nc; i++ {
 			c := t.NamedChild(i)
 			if c != nil && c.Type() == "type_identifier" {
 				return c.Content(src)

--- a/internal/parser/languages/golang_temporal.go
+++ b/internal/parser/languages/golang_temporal.go
@@ -74,7 +74,7 @@ func goWorkflowReceiverAlias(root *sitter.Node, src []byte) string {
 				}
 			}
 		}
-		for i := 0; i < int(n.NamedChildCount()); i++ {
+		for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 			walk(n.NamedChild(i))
 			if found != "" {
 				return
@@ -219,7 +219,7 @@ func goTemporalHandlerName(callNode *sitter.Node, src []byte) string {
 		return ""
 	}
 	count := 0
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		c := args.NamedChild(i)
 		if c == nil {
 			continue
@@ -256,7 +256,7 @@ func goTemporalDispatchArg(callNode *sitter.Node) *sitter.Node {
 		return nil
 	}
 	count := 0
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		c := args.NamedChild(i)
 		if c == nil {
 			continue
@@ -281,7 +281,7 @@ func goTemporalRegisterName(callNode *sitter.Node, src []byte) string {
 	if args == nil {
 		return ""
 	}
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		c := args.NamedChild(i)
 		if c == nil {
 			continue
@@ -402,7 +402,7 @@ func goTemporalRegisterNameOverride(callNode *sitter.Node, src []byte) string {
 	// Second positional argument = the options struct.
 	var opts *sitter.Node
 	count := 0
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		c := args.NamedChild(i)
 		if c == nil {
 			continue
@@ -437,7 +437,7 @@ func goTemporalRegisterNameOverride(callNode *sitter.Node, src []byte) string {
 		}
 		return n
 	}
-	for i := 0; i < int(body.NamedChildCount()); i++ {
+	for i, _nc := 0, int(body.NamedChildCount()); i < _nc; i++ {
 		kv := body.NamedChild(i)
 		if kv == nil || kv.Type() != "keyed_element" || kv.NamedChildCount() < 2 {
 			continue
@@ -570,7 +570,7 @@ func goTemporalNthArgName(callNode *sitter.Node, n int, src []byte) string {
 		return ""
 	}
 	count := 0
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		c := args.NamedChild(i)
 		if c == nil {
 			continue
@@ -616,7 +616,7 @@ func goTemporalNthStringLiteralArg(callNode *sitter.Node, n int, src []byte) str
 		return ""
 	}
 	count := 0
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		c := args.NamedChild(i)
 		if c == nil {
 			continue
@@ -723,7 +723,7 @@ func goTemporalEnvDefaultName(callNode *sitter.Node, name string, src []byte, ex
 			n.StartByte() < limit && goAssignHasTarget(n, name, src) {
 			assigns = append(assigns, n)
 		}
-		for i := 0; i < int(n.NamedChildCount()); i++ {
+		for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 			walk(n.NamedChild(i))
 		}
 	}
@@ -847,7 +847,7 @@ func goTemporalVarTrace(callNode *sitter.Node, name string, src []byte) (litDef,
 			assigns++
 			rhs = goAssignRHSExpr(n, name, src)
 		}
-		for i := 0; i < int(n.NamedChildCount()); i++ {
+		for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 			walk(n.NamedChild(i))
 		}
 	}
@@ -929,7 +929,7 @@ func goIdentIsFileConst(fromNode *sitter.Node, ident string, src []byte) bool {
 				return
 			}
 		}
-		for i := 0; i < int(n.NamedChildCount()); i++ {
+		for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 			walk(n.NamedChild(i))
 		}
 	}
@@ -972,7 +972,7 @@ func goTemporalFuncReturnName(call, fromNode *sitter.Node, src []byte) (litDef, 
 				return
 			}
 		}
-		for i := 0; i < int(n.NamedChildCount()); i++ {
+		for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 			find(n.NamedChild(i))
 		}
 	}
@@ -997,7 +997,7 @@ func goTemporalFuncReturnName(call, fromNode *sitter.Node, src []byte) (litDef, 
 				ret = n.NamedChild(0)
 			}
 		}
-		for i := 0; i < int(n.NamedChildCount()); i++ {
+		for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 			walk(n.NamedChild(i))
 		}
 	}
@@ -1054,7 +1054,7 @@ func goAssignHasTarget(assign *sitter.Node, name string, src []byte) bool {
 	if left == nil {
 		return false
 	}
-	for i := 0; i < int(left.NamedChildCount()); i++ {
+	for i, _nc := 0, int(left.NamedChildCount()); i < _nc; i++ {
 		c := left.NamedChild(i)
 		if c != nil && c.Type() == "identifier" && c.Content(src) == name {
 			return true
@@ -1076,7 +1076,7 @@ func goAssignRHSExpr(assign *sitter.Node, name string, src []byte) *sitter.Node 
 		return nil
 	}
 	idx := -1
-	for i := 0; i < int(left.NamedChildCount()); i++ {
+	for i, _nc := 0, int(left.NamedChildCount()); i < _nc; i++ {
 		c := left.NamedChild(i)
 		if c != nil && c.Type() == "identifier" && c.Content(src) == name {
 			idx = i
@@ -1172,7 +1172,7 @@ func goCallEnvDefaultLiteral(call *sitter.Node, src []byte) (val string, isConst
 	firstVal := ""
 	firstConst := false
 	haveDefault := false
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		c := args.NamedChild(i)
 		if c == nil {
 			continue

--- a/internal/parser/languages/hcl.go
+++ b/internal/parser/languages/hcl.go
@@ -82,7 +82,7 @@ func (e *HCLExtractor) walkTopLevel(node *sitter.Node, src []byte, filePath, dir
 	if node == nil {
 		return
 	}
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		child := node.Child(i)
 		if child == nil {
 			continue
@@ -102,7 +102,7 @@ func (e *HCLExtractor) extractBlock(node *sitter.Node, src []byte, filePath, dir
 	var blockType string
 	var labels []string
 	var body *sitter.Node
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		child := node.Child(i)
 		if child == nil {
 			continue
@@ -171,14 +171,14 @@ func (e *HCLExtractor) extractBlock(node *sitter.Node, src []byte, filePath, dir
 // block (addressed local.<key>) and links each to the blocks its value
 // expression references.
 func (e *HCLExtractor) extractLocals(body *sitter.Node, src []byte, filePath, dir, fileID string, result *parser.ExtractionResult, refSeen map[string]bool) {
-	for i := 0; i < int(body.ChildCount()); i++ {
+	for i, _nc := 0, int(body.ChildCount()); i < _nc; i++ {
 		attr := body.Child(i)
 		if attr == nil || attr.Type() != "attribute" {
 			continue
 		}
 		var key string
 		var expr *sitter.Node
-		for j := 0; j < int(attr.ChildCount()); j++ {
+		for j, _nc := 0, int(attr.ChildCount()); j < _nc; j++ {
 			c := attr.Child(j)
 			if c == nil {
 				continue
@@ -337,7 +337,7 @@ func hclRefAddress(head string, attrs []string) string {
 
 // hclIdentText returns the identifier text of a variable_expr node.
 func hclIdentText(varExpr *sitter.Node, src []byte) string {
-	for i := 0; i < int(varExpr.ChildCount()); i++ {
+	for i, _nc := 0, int(varExpr.ChildCount()); i < _nc; i++ {
 		c := varExpr.Child(i)
 		if c != nil && c.Type() == "identifier" {
 			return c.Content(src)
@@ -348,7 +348,7 @@ func hclIdentText(varExpr *sitter.Node, src []byte) string {
 
 // hclGetAttrName returns the attribute name of a get_attr node (".id" → "id").
 func hclGetAttrName(getAttr *sitter.Node, src []byte) string {
-	for i := 0; i < int(getAttr.ChildCount()); i++ {
+	for i, _nc := 0, int(getAttr.ChildCount()); i < _nc; i++ {
 		c := getAttr.Child(i)
 		if c != nil && c.Type() == "identifier" {
 			return c.Content(src)

--- a/internal/parser/languages/helpers_complexity.go
+++ b/internal/parser/languages/helpers_complexity.go
@@ -39,7 +39,7 @@ func walkComplexity(n *sitter.Node, decisionTypes, skipDescent map[string]bool, 
 	if skipDescent != nil && skipDescent[t] {
 		return
 	}
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		walkComplexity(n.NamedChild(i), decisionTypes, skipDescent, score)
 	}
 }
@@ -57,8 +57,8 @@ func walkComplexity(n *sitter.Node, decisionTypes, skipDescent map[string]bool, 
 // post-filter that checks the operator text.
 
 var goComplexityNodes = map[string]bool{
-	"if_statement":       true,
-	"for_statement":      true,
+	"if_statement":                true,
+	"for_statement":               true,
 	"expression_switch_statement": true,
 	"type_switch_statement":       true,
 	"select_statement":            true,
@@ -74,16 +74,16 @@ var goComplexitySkip = map[string]bool{
 }
 
 var tsComplexityNodes = map[string]bool{
-	"if_statement":          true,
-	"for_statement":         true,
-	"for_in_statement":      true,
-	"for_of_statement":      true,
-	"while_statement":       true,
-	"do_statement":          true,
-	"switch_case":           true,
-	"switch_default":        true,
-	"catch_clause":          true,
-	"ternary_expression":    true,
+	"if_statement":           true,
+	"for_statement":          true,
+	"for_in_statement":       true,
+	"for_of_statement":       true,
+	"while_statement":        true,
+	"do_statement":           true,
+	"switch_case":            true,
+	"switch_default":         true,
+	"catch_clause":           true,
+	"ternary_expression":     true,
 	"conditional_expression": true,
 }
 
@@ -96,18 +96,18 @@ var tsComplexitySkip = map[string]bool{
 }
 
 var pyComplexityNodes = map[string]bool{
-	"if_statement":          true,
-	"elif_clause":           true,
-	"for_statement":         true,
-	"while_statement":       true,
-	"except_clause":         true,
-	"match_statement":       true,
-	"case_clause":           true,
-	"conditional_expression": true,
-	"list_comprehension":    true,
+	"if_statement":             true,
+	"elif_clause":              true,
+	"for_statement":            true,
+	"while_statement":          true,
+	"except_clause":            true,
+	"match_statement":          true,
+	"case_clause":              true,
+	"conditional_expression":   true,
+	"list_comprehension":       true,
 	"dictionary_comprehension": true,
-	"set_comprehension":     true,
-	"generator_expression":  true,
+	"set_comprehension":        true,
+	"generator_expression":     true,
 }
 
 var pyComplexitySkip = map[string]bool{
@@ -118,30 +118,30 @@ var pyComplexitySkip = map[string]bool{
 }
 
 var rustComplexityNodes = map[string]bool{
-	"if_expression":      true,
-	"if_let_expression":  true,
-	"for_expression":     true,
-	"while_expression":   true,
-	"loop_expression":    true,
-	"match_arm":          true,
-	"match_expression":   true,
+	"if_expression":     true,
+	"if_let_expression": true,
+	"for_expression":    true,
+	"while_expression":  true,
+	"loop_expression":   true,
+	"match_arm":         true,
+	"match_expression":  true,
 }
 
 var rustComplexitySkip = map[string]bool{
-	"function_item":     true,
+	"function_item":      true,
 	"closure_expression": true,
 }
 
 var javaComplexityNodes = map[string]bool{
-	"if_statement":         true,
-	"for_statement":        true,
-	"enhanced_for_statement": true,
-	"while_statement":      true,
-	"do_statement":         true,
-	"switch_label":         true,
+	"if_statement":                 true,
+	"for_statement":                true,
+	"enhanced_for_statement":       true,
+	"while_statement":              true,
+	"do_statement":                 true,
+	"switch_label":                 true,
 	"switch_block_statement_group": true,
-	"catch_clause":         true,
-	"ternary_expression":   true,
+	"catch_clause":                 true,
+	"ternary_expression":           true,
 }
 
 var javaComplexitySkip = map[string]bool{
@@ -256,7 +256,7 @@ func CognitiveComplexity(body *sitter.Node, decisionTypes, nestingTypes, skipDes
 		if nestingTypes[t] {
 			childNesting++
 		}
-		for i := 0; i < int(n.NamedChildCount()); i++ {
+		for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 			walk(n.NamedChild(i), childNesting)
 		}
 	}
@@ -287,7 +287,7 @@ func MaxLoopDepth(body *sitter.Node, loopTypes, skipDescent map[string]bool) int
 		if skipDescent != nil && skipDescent[t] {
 			return
 		}
-		for i := 0; i < int(n.NamedChildCount()); i++ {
+		for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 			walk(n.NamedChild(i), d)
 		}
 	}

--- a/internal/parser/languages/helpers_jsimports.go
+++ b/internal/parser/languages/helpers_jsimports.go
@@ -20,7 +20,7 @@ const jsImportBindingCap = 64
 // exported name (re-exports). Returns ("", "") when no identifier is present.
 func jsSpecifierNames(spec *sitter.Node, src []byte) (orig, alias string) {
 	var ids []*sitter.Node
-	for i := 0; i < int(spec.NamedChildCount()); i++ {
+	for i, _nc := 0, int(spec.NamedChildCount()); i < _nc; i++ {
 		if c := spec.NamedChild(i); c != nil && c.Type() == "identifier" {
 			ids = append(ids, c)
 		}
@@ -37,7 +37,7 @@ func jsSpecifierNames(spec *sitter.Node, src []byte) (orig, alias string) {
 // jsCollectChildren returns every direct child of node whose type matches t.
 func jsCollectChildren(node *sitter.Node, t string) []*sitter.Node {
 	var out []*sitter.Node
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		if c := node.Child(i); c != nil && c.Type() == t {
 			out = append(out, c)
 		}

--- a/internal/parser/languages/helpers_macro.go
+++ b/internal/parser/languages/helpers_macro.go
@@ -47,7 +47,7 @@ func emitCMacro(defNode *sitter.Node, isFunc bool, filePath, fileID, lang string
 	}
 	var name, replacement string
 	var params []string
-	for i := 0; i < int(defNode.ChildCount()); i++ {
+	for i, _nc := 0, int(defNode.ChildCount()); i < _nc; i++ {
 		c := defNode.Child(i)
 		if c == nil {
 			continue
@@ -58,7 +58,7 @@ func emitCMacro(defNode *sitter.Node, isFunc bool, filePath, fileID, lang string
 				name = c.Content(src)
 			}
 		case "preproc_params":
-			for j := 0; j < int(c.NamedChildCount()); j++ {
+			for j, _nc := 0, int(c.NamedChildCount()); j < _nc; j++ {
 				p := c.NamedChild(j)
 				if p != nil && p.Type() == "identifier" {
 					params = append(params, p.Content(src))

--- a/internal/parser/languages/html.go
+++ b/internal/parser/languages/html.go
@@ -59,7 +59,7 @@ func (e *HTMLExtractor) walkNode(node *sitter.Node, src []byte, filePath, fileID
 	}
 
 	// Recurse into children.
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		child := node.Child(i)
 		if child != nil {
 			e.walkNode(child, src, filePath, fileID, result)
@@ -202,7 +202,7 @@ func htmlElementText(node *sitter.Node, src []byte) string {
 			}
 			b.WriteString(n.Content(src))
 		}
-		for i := 0; i < int(n.ChildCount()); i++ {
+		for i, _nc := 0, int(n.ChildCount()); i < _nc; i++ {
 			walk(n.Child(i))
 		}
 	}
@@ -217,7 +217,7 @@ func htmlElementText(node *sitter.Node, src []byte) string {
 
 // findChildByType finds the first child node with the given type.
 func findChildByType(node *sitter.Node, typeName string) *sitter.Node {
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		child := node.Child(i)
 		if child != nil && child.Type() == typeName {
 			return child
@@ -229,7 +229,7 @@ func findChildByType(node *sitter.Node, typeName string) *sitter.Node {
 // findAttribute looks for an attribute with the given name in a start_tag node
 // and returns its unquoted value.
 func findAttribute(startTag *sitter.Node, attrName string, src []byte) string {
-	for i := 0; i < int(startTag.ChildCount()); i++ {
+	for i, _nc := 0, int(startTag.ChildCount()); i < _nc; i++ {
 		child := startTag.Child(i)
 		if child == nil || child.Type() != "attribute" {
 			continue

--- a/internal/parser/languages/java.go
+++ b/internal/parser/languages/java.go
@@ -568,12 +568,12 @@ func javaVisibility(decl *sitter.Node, src []byte, defaultVis string) string {
 	if decl == nil {
 		return defaultVis
 	}
-	for i := 0; i < int(decl.ChildCount()); i++ {
+	for i, _nc := 0, int(decl.ChildCount()); i < _nc; i++ {
 		c := decl.Child(i)
 		if c == nil || c.Type() != "modifiers" {
 			continue
 		}
-		for j := 0; j < int(c.ChildCount()); j++ {
+		for j, _nc := 0, int(c.ChildCount()); j < _nc; j++ {
 			tok := c.Child(j)
 			if tok == nil {
 				continue
@@ -937,12 +937,12 @@ func javaIsStaticFinal(decl *sitter.Node, src []byte) bool {
 		return false
 	}
 	hasStatic, hasFinal := false, false
-	for i := 0; i < int(decl.ChildCount()); i++ {
+	for i, _nc := 0, int(decl.ChildCount()); i < _nc; i++ {
 		c := decl.Child(i)
 		if c == nil || c.Type() != "modifiers" {
 			continue
 		}
-		for j := 0; j < int(c.ChildCount()); j++ {
+		for j, _nc := 0, int(c.ChildCount()); j < _nc; j++ {
 			switch c.Child(j).Type() {
 			case "static":
 				hasStatic = true
@@ -957,12 +957,12 @@ func javaIsStaticFinal(decl *sitter.Node, src []byte) bool {
 // javaPackageName returns the dotted name of the file's `package` declaration,
 // or "".
 func javaPackageName(root *sitter.Node, src []byte) string {
-	for i := 0; i < int(root.NamedChildCount()); i++ {
+	for i, _nc := 0, int(root.NamedChildCount()); i < _nc; i++ {
 		c := root.NamedChild(i)
 		if c.Type() != "package_declaration" {
 			continue
 		}
-		for j := 0; j < int(c.NamedChildCount()); j++ {
+		for j, _nc := 0, int(c.NamedChildCount()); j < _nc; j++ {
 			id := c.NamedChild(j)
 			if t := id.Type(); t == "scoped_identifier" || t == "identifier" {
 				return strings.TrimSpace(id.Content(src))
@@ -998,12 +998,12 @@ func javaStaticFinalStringValue(decl *sitter.Node, src []byte) (string, bool) {
 		return "", false
 	}
 	hasStatic, hasFinal := false, false
-	for i := 0; i < int(decl.ChildCount()); i++ {
+	for i, _nc := 0, int(decl.ChildCount()); i < _nc; i++ {
 		c := decl.Child(i)
 		if c == nil || c.Type() != "modifiers" {
 			continue
 		}
-		for j := 0; j < int(c.ChildCount()); j++ {
+		for j, _nc := 0, int(c.ChildCount()); j < _nc; j++ {
 			tok := c.Child(j)
 			if tok == nil {
 				continue
@@ -1019,7 +1019,7 @@ func javaStaticFinalStringValue(decl *sitter.Node, src []byte) (string, bool) {
 	if !hasStatic || !hasFinal {
 		return "", false
 	}
-	for i := 0; i < int(decl.NamedChildCount()); i++ {
+	for i, _nc := 0, int(decl.NamedChildCount()); i < _nc; i++ {
 		c := decl.NamedChild(i)
 		if c == nil || c.Type() != "variable_declarator" {
 			continue
@@ -1117,7 +1117,7 @@ func javaParamsSource(methodNode *sitter.Node, src []byte) string {
 	if methodNode == nil {
 		return ""
 	}
-	for i := 0; i < int(methodNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(methodNode.NamedChildCount()); i < _nc; i++ {
 		c := methodNode.NamedChild(i)
 		if c != nil && c.Type() == "formal_parameters" {
 			return c.Content(src)
@@ -1135,12 +1135,12 @@ func javaCollectAnnotations(decl *sitter.Node, src []byte) []javaAnnotation {
 		return nil
 	}
 	var out []javaAnnotation
-	for i := 0; i < int(decl.NamedChildCount()); i++ {
+	for i, _nc := 0, int(decl.NamedChildCount()); i < _nc; i++ {
 		c := decl.NamedChild(i)
 		if c == nil || c.Type() != "modifiers" {
 			continue
 		}
-		for j := 0; j < int(c.NamedChildCount()); j++ {
+		for j, _nc := 0, int(c.NamedChildCount()); j < _nc; j++ {
 			m := c.NamedChild(j)
 			if m == nil {
 				continue
@@ -1185,12 +1185,12 @@ func emitJavaThrowsEdges(methodNode *sitter.Node, src []byte, fromID, filePath s
 	if methodNode == nil {
 		return
 	}
-	for i := 0; i < int(methodNode.ChildCount()); i++ {
+	for i, _nc := 0, int(methodNode.ChildCount()); i < _nc; i++ {
 		c := methodNode.Child(i)
 		if c == nil || c.Type() != "throws" {
 			continue
 		}
-		for j := 0; j < int(c.ChildCount()); j++ {
+		for j, _nc := 0, int(c.ChildCount()); j < _nc; j++ {
 			t := c.Child(j)
 			if t == nil {
 				continue
@@ -1239,12 +1239,12 @@ func emitJavaAnnotationEdges(anns []javaAnnotation, fromID, filePath string, res
 // a `modifiers` wrapper as either `marker_annotation` (no args) or
 // `annotation` (with args). Name is the bare identifier after @.
 func javaMethodHasAnnotation(methodNode *sitter.Node, src []byte, name string) bool {
-	for i := 0; i < int(methodNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(methodNode.NamedChildCount()); i < _nc; i++ {
 		c := methodNode.NamedChild(i)
 		if c == nil || c.Type() != "modifiers" {
 			continue
 		}
-		for j := 0; j < int(c.NamedChildCount()); j++ {
+		for j, _nc := 0, int(c.NamedChildCount()); j < _nc; j++ {
 			m := c.NamedChild(j)
 			if m == nil {
 				continue
@@ -1265,7 +1265,7 @@ func javaMethodHasAnnotation(methodNode *sitter.Node, src []byte, name string) b
 // the return type child (typically a type_identifier) and returns the
 // normalized type name.
 func extractJavaMethodReturnType(methodNode *sitter.Node, src []byte) string {
-	for i := 0; i < int(methodNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(methodNode.NamedChildCount()); i < _nc; i++ {
 		child := methodNode.NamedChild(i)
 		switch child.Type() {
 		case "type_identifier":
@@ -1295,7 +1295,7 @@ func extractJavaParentClass(classNode *sitter.Node, src []byte) string {
 	if sup == nil {
 		return ""
 	}
-	for i := 0; i < int(sup.NamedChildCount()); i++ {
+	for i, _nc := 0, int(sup.NamedChildCount()); i < _nc; i++ {
 		child := sup.NamedChild(i)
 		switch child.Type() {
 		case "type_identifier", "generic_type", "scoped_type_identifier":
@@ -1317,7 +1317,7 @@ func extractJavaParentClass(classNode *sitter.Node, src []byte) string {
 // inferTypeFromJavaNewExpr extracts the class name from an object_creation_expression node.
 // new User(...) -> "User", new ArrayList<String>() -> "ArrayList"
 func inferTypeFromJavaNewExpr(node *sitter.Node, src []byte) string {
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		child := node.NamedChild(i)
 		if child.Type() == "type_identifier" {
 			name := child.Content(src)

--- a/internal/parser/languages/java_function_shape.go
+++ b/internal/parser/languages/java_function_shape.go
@@ -29,7 +29,7 @@ func javaFormalParameters(methodNode *sitter.Node) *sitter.Node {
 	if p := methodNode.ChildByFieldName("parameters"); p != nil {
 		return p
 	}
-	for i := 0; i < int(methodNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(methodNode.NamedChildCount()); i < _nc; i++ {
 		c := methodNode.NamedChild(i)
 		if c != nil && c.Type() == "formal_parameters" {
 			return c
@@ -40,7 +40,7 @@ func javaFormalParameters(methodNode *sitter.Node) *sitter.Node {
 
 func emitJavaParamNodes(ownerID string, params *sitter.Node, src []byte, filePath string, declLine int, result *parser.ExtractionResult) {
 	pos := 0
-	for i := 0; i < int(params.NamedChildCount()); i++ {
+	for i, _nc := 0, int(params.NamedChildCount()); i < _nc; i++ {
 		decl := params.NamedChild(i)
 		if decl == nil {
 			continue
@@ -60,7 +60,7 @@ func emitJavaParamNodes(ownerID string, params *sitter.Node, src []byte, filePat
 		// Some grammar shapes (spread_parameter) wrap the name in a
 		// (variable_declarator name: (identifier)) — fall back.
 		if name == "" {
-			for j := 0; j < int(decl.NamedChildCount()); j++ {
+			for j, _nc := 0, int(decl.NamedChildCount()); j < _nc; j++ {
 				c := decl.NamedChild(j)
 				if c == nil {
 					continue
@@ -178,7 +178,7 @@ func emitJavaGenericParamNodes(ownerID string, methodNode *sitter.Node, src []by
 	tparams := methodNode.ChildByFieldName("type_parameters")
 	if tparams == nil {
 		// Look for unnamed type_parameters child.
-		for i := 0; i < int(methodNode.NamedChildCount()); i++ {
+		for i, _nc := 0, int(methodNode.NamedChildCount()); i < _nc; i++ {
 			c := methodNode.NamedChild(i)
 			if c != nil && c.Type() == "type_parameters" {
 				tparams = c
@@ -189,13 +189,13 @@ func emitJavaGenericParamNodes(ownerID string, methodNode *sitter.Node, src []by
 	if tparams == nil {
 		return
 	}
-	for i := 0; i < int(tparams.NamedChildCount()); i++ {
+	for i, _nc := 0, int(tparams.NamedChildCount()); i < _nc; i++ {
 		tp := tparams.NamedChild(i)
 		if tp == nil || tp.Type() != "type_parameter" {
 			continue
 		}
 		var name, bound string
-		for j := 0; j < int(tp.NamedChildCount()); j++ {
+		for j, _nc := 0, int(tp.NamedChildCount()); j < _nc; j++ {
 			c := tp.NamedChild(j)
 			if c == nil {
 				continue

--- a/internal/parser/languages/java_spring_events.go
+++ b/internal/parser/languages/java_spring_events.go
@@ -50,7 +50,7 @@ func captureSpringEvents(result *parser.ExtractionResult, root *sitter.Node, fil
 				return
 			}
 			if body := n.ChildByFieldName("body"); body != nil {
-				for i := 0; i < int(body.NamedChildCount()); i++ {
+				for i, _nc := 0, int(body.NamedChildCount()); i < _nc; i++ {
 					m := body.NamedChild(i)
 					if m != nil && m.Type() == "method_declaration" && springMethodName(m, src) == "onApplicationEvent" {
 						springTagListener(nodesByLine, m, src, evType)
@@ -131,7 +131,7 @@ func springFirstParamType(method *sitter.Node, src []byte) string {
 	if params == nil {
 		return ""
 	}
-	for i := 0; i < int(params.NamedChildCount()); i++ {
+	for i, _nc := 0, int(params.NamedChildCount()); i < _nc; i++ {
 		p := params.NamedChild(i)
 		if p == nil || p.Type() != "formal_parameter" {
 			continue
@@ -157,7 +157,7 @@ func springApplicationListenerArg(classDecl *sitter.Node, src []byte) string {
 			return
 		}
 		var base, args *sitter.Node
-		for i := 0; i < int(n.NamedChildCount()); i++ {
+		for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 			c := n.NamedChild(i)
 			switch {
 			case c == nil:
@@ -170,7 +170,7 @@ func springApplicationListenerArg(classDecl *sitter.Node, src []byte) string {
 		if base == nil || args == nil || springSimpleTypeName(base.Content(src)) != "ApplicationListener" {
 			return
 		}
-		for i := 0; i < int(args.NamedChildCount()); i++ {
+		for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 			a := args.NamedChild(i)
 			if a != nil && a.IsNamed() {
 				found = springSimpleTypeName(a.Content(src))
@@ -188,7 +188,7 @@ func springPublishedType(call *sitter.Node, src []byte) string {
 	if args == nil {
 		return ""
 	}
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		a := args.NamedChild(i)
 		if a == nil {
 			continue
@@ -227,7 +227,7 @@ func springWalk(n *sitter.Node, fn func(*sitter.Node)) {
 		return
 	}
 	fn(n)
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		springWalk(n.NamedChild(i), fn)
 	}
 }

--- a/internal/parser/languages/java_temporal.go
+++ b/internal/parser/languages/java_temporal.go
@@ -35,7 +35,7 @@ func javaTemporalStartWorkflowName(callNode *sitter.Node, method string, src []b
 		return ""
 	}
 	var first *sitter.Node
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		if c := args.NamedChild(i); c != nil {
 			first = c
 			break
@@ -96,7 +96,7 @@ func javaTemporalSignalQuery(callNode *sitter.Node, method string, src []byte) (
 		return "", ""
 	}
 	var first *sitter.Node
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		if c := args.NamedChild(i); c != nil {
 			first = c
 			break

--- a/internal/parser/languages/java_typeuse.go
+++ b/internal/parser/languages/java_typeuse.go
@@ -116,14 +116,14 @@ func emitJavaReferenceForms(root *sitter.Node, src []byte, filePath, fileID stri
 					return
 				}
 				if c.Type() == "wildcard" {
-					for j := 0; j < int(c.NamedChildCount()); j++ {
+					for j, _nc := 0, int(c.NamedChildCount()); j < _nc; j++ {
 						if w := c.NamedChild(j); w != nil && isJavaTypeNode(w.Type()) {
 							emit(strings.TrimSpace(w.Content(src)), line, "generic_arg", graph.EdgeReferences, graph.OriginASTResolved)
 						}
 					}
 				}
 			}
-			for i := 0; i < int(n.NamedChildCount()); i++ {
+			for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 				emitArg(n.NamedChild(i))
 			}
 
@@ -191,7 +191,7 @@ func emitJavaReferenceForms(root *sitter.Node, src []byte, filePath, fileID stri
 
 		case "super_interfaces":
 			// `implements Bar, Baz` — every interface in the type_list.
-			for i := 0; i < int(n.NamedChildCount()); i++ {
+			for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 				c := n.NamedChild(i)
 				if c == nil {
 					continue
@@ -224,7 +224,7 @@ func isJavaTypeNode(t string) bool {
 // walk reaches when it descends into the child `generic_type` node — so
 // this helper deliberately does not recurse into them.
 func emitJavaTypeChildRefs(node *sitter.Node, src []byte, line int, useKind string, kind graph.EdgeKind, origin string, emit func(string, int, string, graph.EdgeKind, string)) {
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		c := node.NamedChild(i)
 		if c == nil || !isJavaTypeNode(c.Type()) {
 			continue
@@ -245,7 +245,7 @@ func javaCreatedTypeText(node *sitter.Node, src []byte) string {
 // of node that names a type (type_identifier / scoped_type_identifier /
 // generic_type), or "".
 func javaFirstTypeChildText(node *sitter.Node, src []byte) string {
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		c := node.NamedChild(i)
 		if c == nil || !isJavaTypeNode(c.Type()) {
 			continue

--- a/internal/parser/languages/javascript.go
+++ b/internal/parser/languages/javascript.go
@@ -523,7 +523,7 @@ func jsArrowFunctionFromDef(def *sitter.Node) *sitter.Node {
 	if def == nil {
 		return nil
 	}
-	for i := 0; i < int(def.NamedChildCount()); i++ {
+	for i, _nc := 0, int(def.NamedChildCount()); i < _nc; i++ {
 		c := def.NamedChild(i)
 		if c == nil || c.Type() != "variable_declarator" {
 			continue

--- a/internal/parser/languages/jsts_express_inline.go
+++ b/internal/parser/languages/jsts_express_inline.go
@@ -192,7 +192,7 @@ func expressIsRouteReceiver(recv *sitter.Node, src []byte) bool {
 // expressFirstArgIsString reports whether the first call argument is a string
 // literal (the route path).
 func expressFirstArgIsString(args *sitter.Node) bool {
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		if c := args.NamedChild(i); c != nil {
 			return c.Type() == "string"
 		}
@@ -205,7 +205,7 @@ func expressFirstArgIsString(args *sitter.Node) bool {
 func expressHandlerPositionArgs(args *sitter.Node) []*sitter.Node {
 	var out []*sitter.Node
 	sawPath := false
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		c := args.NamedChild(i)
 		if c == nil {
 			continue
@@ -253,7 +253,7 @@ func expressHandlerParamNames(handler *sitter.Node, src []byte) map[string]bool 
 		}
 		return out
 	}
-	for i := 0; i < int(params.NamedChildCount()); i++ {
+	for i, _nc := 0, int(params.NamedChildCount()); i < _nc; i++ {
 		p := params.NamedChild(i)
 		if p == nil {
 			continue
@@ -273,7 +273,7 @@ func expressWalk(n *sitter.Node, fn func(*sitter.Node)) {
 		return
 	}
 	fn(n)
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		expressWalk(n.NamedChild(i), fn)
 	}
 }

--- a/internal/parser/languages/jsts_ngrx_effects.go
+++ b/internal/parser/languages/jsts_ngrx_effects.go
@@ -62,7 +62,7 @@ func captureNgRxEffects(result *parser.ExtractionResult, root *sitter.Node, file
 			if args == nil {
 				return
 			}
-			for i := 0; i < int(args.NamedChildCount()); i++ {
+			for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 				act := ngrxActionName(args.NamedChild(i), src)
 				if act == "" || seen[act] {
 					continue
@@ -152,7 +152,7 @@ func ngrxEffectWalk(n *sitter.Node, fn func(*sitter.Node)) {
 		return
 	}
 	fn(n)
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		ngrxEffectWalk(n.NamedChild(i), fn)
 	}
 }

--- a/internal/parser/languages/jsts_object_registry.go
+++ b/internal/parser/languages/jsts_object_registry.go
@@ -158,7 +158,7 @@ func objectRegistryBinding(obj *sitter.Node, src []byte) (string, bool) {
 // keys. Non-identifier values (nested objects, calls) are skipped.
 func objectRegistryEntries(obj *sitter.Node, src []byte) []string {
 	var out []string
-	for i := 0; i < int(obj.NamedChildCount()); i++ {
+	for i, _nc := 0, int(obj.NamedChildCount()); i < _nc; i++ {
 		pair := obj.NamedChild(i)
 		if pair == nil || pair.Type() != "pair" {
 			continue
@@ -257,7 +257,7 @@ func objectRegistryWalk(n *sitter.Node, fn func(*sitter.Node)) {
 		return
 	}
 	fn(n)
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		objectRegistryWalk(n.NamedChild(i), fn)
 	}
 }

--- a/internal/parser/languages/jsts_pinia_store.go
+++ b/internal/parser/languages/jsts_pinia_store.go
@@ -136,7 +136,7 @@ func tagPiniaSetupStoreActions(result *parser.ExtractionResult, root *sitter.Nod
 			return
 		}
 		returned := map[string]bool{}
-		for i := 0; i < int(obj.NamedChildCount()); i++ {
+		for i, _nc := 0, int(obj.NamedChildCount()); i < _nc; i++ {
 			c := obj.NamedChild(i)
 			if c == nil {
 				continue
@@ -179,7 +179,7 @@ func piniaSetupFn(call *sitter.Node) *sitter.Node {
 	if args == nil {
 		return nil
 	}
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		c := args.NamedChild(i)
 		if c == nil {
 			continue
@@ -198,7 +198,7 @@ func piniaWalk(n *sitter.Node, fn func(*sitter.Node)) {
 		return
 	}
 	fn(n)
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		piniaWalk(n.NamedChild(i), fn)
 	}
 }

--- a/internal/parser/languages/jsts_pubsub.go
+++ b/internal/parser/languages/jsts_pubsub.go
@@ -66,7 +66,7 @@ func firstJSPubsubTopicArg(callExpr *sitter.Node, src []byte) string {
 	if args == nil {
 		return ""
 	}
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		c := args.NamedChild(i)
 		if c == nil {
 			continue
@@ -89,7 +89,7 @@ func firstJSPubsubTopicArg(callExpr *sitter.Node, src []byte) string {
 // `string` node. The grammar wraps the body in a `string_fragment`
 // child; an empty literal (`""`) has no fragment and yields "".
 func jsStringLiteralContent(strNode *sitter.Node, src []byte) string {
-	for i := 0; i < int(strNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(strNode.NamedChildCount()); i < _nc; i++ {
 		c := strNode.NamedChild(i)
 		if c != nil && c.Type() == "string_fragment" {
 			return strings.TrimSpace(c.Content(src))
@@ -104,7 +104,7 @@ func jsStringLiteralContent(strNode *sitter.Node, src []byte) string {
 // subject / …) and whose value is a string literal, returning that
 // string. Used for kafkajs-style option-object call shapes.
 func jsObjectTopicValue(objNode *sitter.Node, src []byte) string {
-	for i := 0; i < int(objNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(objNode.NamedChildCount()); i < _nc; i++ {
 		pair := objNode.NamedChild(i)
 		if pair == nil || pair.Type() != "pair" {
 			continue

--- a/internal/parser/languages/jsts_react_hoc.go
+++ b/internal/parser/languages/jsts_react_hoc.go
@@ -73,7 +73,7 @@ func reactHOCRenderFn(call *sitter.Node) *sitter.Node {
 	if args == nil {
 		return nil
 	}
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		a := args.NamedChild(i)
 		if a == nil {
 			continue

--- a/internal/parser/languages/jsts_redux_thunk.go
+++ b/internal/parser/languages/jsts_redux_thunk.go
@@ -138,7 +138,7 @@ func reduxThunkPayloadCreator(call *sitter.Node) *sitter.Node {
 	if args == nil {
 		return nil
 	}
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		c := args.NamedChild(i)
 		if c == nil {
 			continue
@@ -172,7 +172,7 @@ func reduxThunkWalk(n *sitter.Node, fn func(*sitter.Node)) {
 		return
 	}
 	fn(n)
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		reduxThunkWalk(n.NamedChild(i), fn)
 	}
 }

--- a/internal/parser/languages/jsts_rtk_query.go
+++ b/internal/parser/languages/jsts_rtk_query.go
@@ -53,7 +53,7 @@ func captureRTKQueryEndpoints(result *parser.ExtractionResult, root *sitter.Node
 		if obj == nil {
 			return
 		}
-		for i := 0; i < int(obj.NamedChildCount()); i++ {
+		for i, _nc := 0, int(obj.NamedChildCount()); i < _nc; i++ {
 			pair := obj.NamedChild(i)
 			if pair == nil || pair.Type() != "pair" {
 				continue
@@ -118,12 +118,12 @@ func rtkEndpointsArrow(call *sitter.Node, src []byte) *sitter.Node {
 	if args == nil {
 		return nil
 	}
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		obj := args.NamedChild(i)
 		if obj == nil || obj.Type() != "object" {
 			continue
 		}
-		for j := 0; j < int(obj.NamedChildCount()); j++ {
+		for j, _nc := 0, int(obj.NamedChildCount()); j < _nc; j++ {
 			pair := obj.NamedChild(j)
 			if pair == nil || pair.Type() != "pair" {
 				continue
@@ -163,16 +163,16 @@ func rtkUnwrapObject(n *sitter.Node) *sitter.Node {
 	case "object":
 		return n
 	case "parenthesized_expression":
-		for i := 0; i < int(n.NamedChildCount()); i++ {
+		for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 			if o := rtkUnwrapObject(n.NamedChild(i)); o != nil {
 				return o
 			}
 		}
 	case "statement_block":
-		for i := 0; i < int(n.NamedChildCount()); i++ {
+		for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 			c := n.NamedChild(i)
 			if c != nil && c.Type() == "return_statement" {
-				for j := 0; j < int(c.NamedChildCount()); j++ {
+				for j, _nc := 0, int(c.NamedChildCount()); j < _nc; j++ {
 					if o := rtkUnwrapObject(c.NamedChild(j)); o != nil {
 						return o
 					}
@@ -214,7 +214,7 @@ func rtkWalk(n *sitter.Node, fn func(*sitter.Node)) {
 		return
 	}
 	fn(n)
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		rtkWalk(n.NamedChild(i), fn)
 	}
 }

--- a/internal/parser/languages/jsts_vuex_dispatch.go
+++ b/internal/parser/languages/jsts_vuex_dispatch.go
@@ -90,7 +90,7 @@ func vuexConfigObject(n *sitter.Node, src []byte) *sitter.Node {
 	if args == nil {
 		return nil
 	}
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		obj := args.NamedChild(i)
 		if obj == nil || obj.Type() != "object" {
 			continue
@@ -107,7 +107,7 @@ func vuexConfigObject(n *sitter.Node, src []byte) *sitter.Node {
 // modules (whose key joins the prefix only when `namespaced: true`).
 func processVuexConfig(obj *sitter.Node, prefix string, src []byte, nodesByLine map[int][]*graph.Node) {
 	namespace := strings.TrimSuffix(prefix, "/")
-	for i := 0; i < int(obj.NamedChildCount()); i++ {
+	for i, _nc := 0, int(obj.NamedChildCount()); i < _nc; i++ {
 		pair := obj.NamedChild(i)
 		if pair == nil || pair.Type() != "pair" {
 			continue
@@ -128,7 +128,7 @@ func processVuexConfig(obj *sitter.Node, prefix string, src []byte, nodesByLine 
 			}
 		case "modules":
 			if val.Type() == "object" {
-				for j := 0; j < int(val.NamedChildCount()); j++ {
+				for j, _nc := 0, int(val.NamedChildCount()); j < _nc; j++ {
 					mod := val.NamedChild(j)
 					if mod == nil || mod.Type() != "pair" {
 						continue
@@ -151,7 +151,7 @@ func processVuexConfig(obj *sitter.Node, prefix string, src []byte, nodesByLine 
 // vuexTagMembers stamps the action/mutation functions of an object literal
 // with their Vuex namespace, name, and kind.
 func vuexTagMembers(obj *sitter.Node, namespace, kind string, src []byte, nodesByLine map[int][]*graph.Node) {
-	for i := 0; i < int(obj.NamedChildCount()); i++ {
+	for i, _nc := 0, int(obj.NamedChildCount()); i < _nc; i++ {
 		c := obj.NamedChild(i)
 		if c == nil {
 			continue
@@ -223,7 +223,7 @@ func vuexEmitMapHelper(result *parser.ExtractionResult, call *sitter.Node, calle
 	}
 	namespace := ""
 	var names []string
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		a := args.NamedChild(i)
 		if a == nil {
 			continue
@@ -232,7 +232,7 @@ func vuexEmitMapHelper(result *parser.ExtractionResult, call *sitter.Node, calle
 		case "string":
 			namespace = jsStringLiteralContent(a, src)
 		case "array":
-			for j := 0; j < int(a.NamedChildCount()); j++ {
+			for j, _nc := 0, int(a.NamedChildCount()); j < _nc; j++ {
 				if el := a.NamedChild(j); el != nil && el.Type() == "string" {
 					if s := jsStringLiteralContent(el, src); s != "" {
 						names = append(names, s)
@@ -279,7 +279,7 @@ func vuexAppendPlaceholder(result *parser.ExtractionResult, from, name, key, kin
 }
 
 func vuexHasKey(obj *sitter.Node, key string, src []byte) bool {
-	for i := 0; i < int(obj.NamedChildCount()); i++ {
+	for i, _nc := 0, int(obj.NamedChildCount()); i < _nc; i++ {
 		pair := obj.NamedChild(i)
 		if pair != nil && pair.Type() == "pair" && rtkPairKey(pair, src) == key {
 			return true
@@ -289,7 +289,7 @@ func vuexHasKey(obj *sitter.Node, key string, src []byte) bool {
 }
 
 func vuexIsNamespaced(obj *sitter.Node, src []byte) bool {
-	for i := 0; i < int(obj.NamedChildCount()); i++ {
+	for i, _nc := 0, int(obj.NamedChildCount()); i < _nc; i++ {
 		pair := obj.NamedChild(i)
 		if pair == nil || pair.Type() != "pair" || rtkPairKey(pair, src) != "namespaced" {
 			continue
@@ -327,7 +327,7 @@ func vuexWalk(n *sitter.Node, fn func(*sitter.Node)) {
 		return
 	}
 	fn(n)
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		vuexWalk(n.NamedChild(i), fn)
 	}
 }

--- a/internal/parser/languages/kotlin.go
+++ b/internal/parser/languages/kotlin.go
@@ -370,7 +370,7 @@ func (e *KotlinExtractor) Extract(filePath string, src []byte) (*parser.Extracti
 // or "". It scans by content prefix so it is robust to the grammar's exact node
 // name for the header.
 func kotlinPackageName(root *sitter.Node, src []byte) string {
-	for i := 0; i < int(root.ChildCount()); i++ {
+	for i, _nc := 0, int(root.ChildCount()); i < _nc; i++ {
 		c := root.Child(i)
 		txt := strings.TrimSpace(c.Content(src))
 		if !strings.HasPrefix(txt, "package") {
@@ -403,7 +403,7 @@ func (e *KotlinExtractor) emitClassOrInterface(m parser.QueryResult, filePath, f
 	isInterface := false
 	var enumBody *sitter.Node
 	if def.Node != nil {
-		for i := 0; i < int(def.Node.ChildCount()); i++ {
+		for i, _nc := 0, int(def.Node.ChildCount()); i < _nc; i++ {
 			child := def.Node.Child(i)
 			switch child.Type() {
 			case "interface":
@@ -453,13 +453,13 @@ func (e *KotlinExtractor) emitClassOrInterface(m parser.QueryResult, filePath, f
 	if enumBody == nil {
 		return
 	}
-	for i := 0; i < int(enumBody.ChildCount()); i++ {
+	for i, _nc := 0, int(enumBody.ChildCount()); i < _nc; i++ {
 		entry := enumBody.Child(i)
 		if entry == nil || entry.Type() != "enum_entry" {
 			continue
 		}
 		var entryName string
-		for j := 0; j < int(entry.ChildCount()); j++ {
+		for j, _nc := 0, int(entry.ChildCount()); j < _nc; j++ {
 			ch := entry.Child(j)
 			if ch != nil && ch.Type() == "simple_identifier" {
 				entryName = ch.Content(src)
@@ -805,12 +805,12 @@ func kotlinCollectAnnotations(decl *sitter.Node, src []byte) []javaAnnotation {
 		return nil
 	}
 	var out []javaAnnotation
-	for i := 0; i < int(decl.ChildCount()); i++ {
+	for i, _nc := 0, int(decl.ChildCount()); i < _nc; i++ {
 		c := decl.Child(i)
 		if c == nil || c.Type() != "modifiers" {
 			continue
 		}
-		for j := 0; j < int(c.ChildCount()); j++ {
+		for j, _nc := 0, int(c.ChildCount()); j < _nc; j++ {
 			ann := c.Child(j)
 			if ann == nil {
 				continue
@@ -823,7 +823,7 @@ func kotlinCollectAnnotations(decl *sitter.Node, src []byte) []javaAnnotation {
 			}
 			var name, args string
 			line := int(ann.StartPoint().Row) + 1
-			for k := 0; k < int(ann.ChildCount()); k++ {
+			for k, _nc := 0, int(ann.ChildCount()); k < _nc; k++ {
 				inner := ann.Child(k)
 				if inner == nil {
 					continue
@@ -873,12 +873,12 @@ func kotlinVisibility(decl *sitter.Node, src []byte) string {
 	if decl == nil {
 		return VisibilityPublic
 	}
-	for i := 0; i < int(decl.ChildCount()); i++ {
+	for i, _nc := 0, int(decl.ChildCount()); i < _nc; i++ {
 		c := decl.Child(i)
 		if c == nil || c.Type() != "modifiers" {
 			continue
 		}
-		for j := 0; j < int(c.ChildCount()); j++ {
+		for j, _nc := 0, int(c.ChildCount()); j < _nc; j++ {
 			tok := c.Child(j)
 			if tok == nil {
 				continue
@@ -907,12 +907,12 @@ func kotlinModifierFlags(decl *sitter.Node, src []byte) (isAsync bool, kmpRole s
 	if decl == nil {
 		return false, ""
 	}
-	for i := 0; i < int(decl.ChildCount()); i++ {
+	for i, _nc := 0, int(decl.ChildCount()); i < _nc; i++ {
 		c := decl.Child(i)
 		if c == nil || c.Type() != "modifiers" {
 			continue
 		}
-		for j := 0; j < int(c.ChildCount()); j++ {
+		for j, _nc := 0, int(c.ChildCount()); j < _nc; j++ {
 			tok := c.Child(j)
 			if tok == nil {
 				continue
@@ -969,7 +969,7 @@ func kotlinExtensionReceiver(fn *sitter.Node, src []byte) string {
 		return ""
 	}
 	name := ""
-	for i := 0; i < int(ut.ChildCount()); i++ {
+	for i, _nc := 0, int(ut.ChildCount()); i < _nc; i++ {
 		if c := ut.Child(i); c != nil && c.Type() == "type_identifier" {
 			name = c.Content(src)
 		}
@@ -1068,7 +1068,7 @@ func kotlinTypeIdentifierChild(node *sitter.Node, src []byte) string {
 	if node == nil {
 		return ""
 	}
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		ch := node.Child(i)
 		if ch != nil && ch.Type() == "type_identifier" {
 			return ch.Content(src)
@@ -1154,12 +1154,12 @@ func kotlinPropertyIsConst(decl *sitter.Node, src []byte) bool {
 	if decl == nil {
 		return false
 	}
-	for i := 0; i < int(decl.ChildCount()); i++ {
+	for i, _nc := 0, int(decl.ChildCount()); i < _nc; i++ {
 		c := decl.Child(i)
 		if c == nil || c.Type() != "modifiers" {
 			continue
 		}
-		for j := 0; j < int(c.ChildCount()); j++ {
+		for j, _nc := 0, int(c.ChildCount()); j < _nc; j++ {
 			tok := c.Child(j)
 			if tok == nil {
 				continue
@@ -1188,7 +1188,7 @@ func collectKotlinLambdaScopes(root *sitter.Node, src []byte) []kotlinLambdaScop
 		}
 		params := map[string]bool{}
 		hasExplicit := false
-		for i := 0; i < int(n.ChildCount()); i++ {
+		for i, _nc := 0, int(n.ChildCount()); i < _nc; i++ {
 			ch := n.Child(i)
 			if ch == nil || ch.Type() != "lambda_parameters" {
 				continue
@@ -1274,7 +1274,7 @@ func extractKotlinReturnType(node *sitter.Node, src []byte) string {
 	}
 	// Look for user_type or nullable_type child after the function_value_parameters.
 	pastParams := false
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		child := node.Child(i)
 		if child.Type() == "function_value_parameters" {
 			pastParams = true
@@ -1300,7 +1300,7 @@ func extractKotlinReturnType(node *sitter.Node, src []byte) string {
 // Shared with other language extractors via package scope.
 func walkNodes(node *sitter.Node, fn func(*sitter.Node)) {
 	fn(node)
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		walkNodes(node.Child(i), fn)
 	}
 }

--- a/internal/parser/languages/kotlin_function_shape.go
+++ b/internal/parser/languages/kotlin_function_shape.go
@@ -71,7 +71,7 @@ func emitKotlinAsyncSpawns(ownerID string, body *sitter.Node, src []byte, filePa
 						continue
 					}
 					if c.Type() == "navigation_suffix" {
-						for j := 0; j < int(c.NamedChildCount()); j++ {
+						for j, _nc := 0, int(c.NamedChildCount()); j < _nc; j++ {
 							cc := c.NamedChild(j)
 							if cc != nil && cc.Type() == "simple_identifier" {
 								name = cc.Content(src)
@@ -107,7 +107,7 @@ func walkKotlinNodes(n *sitter.Node, visit func(*sitter.Node) bool) {
 	if !visit(n) {
 		return
 	}
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		walkKotlinNodes(n.NamedChild(i), visit)
 	}
 }
@@ -121,7 +121,7 @@ func emitKotlinGenericParamNodes(ownerID string, decl *sitter.Node, src []byte, 
 	}
 	tparams := decl.ChildByFieldName("type_parameters")
 	if tparams == nil {
-		for i := 0; i < int(decl.NamedChildCount()); i++ {
+		for i, _nc := 0, int(decl.NamedChildCount()); i < _nc; i++ {
 			c := decl.NamedChild(i)
 			if c != nil && c.Type() == "type_parameters" {
 				tparams = c
@@ -132,13 +132,13 @@ func emitKotlinGenericParamNodes(ownerID string, decl *sitter.Node, src []byte, 
 	if tparams == nil {
 		return
 	}
-	for i := 0; i < int(tparams.NamedChildCount()); i++ {
+	for i, _nc := 0, int(tparams.NamedChildCount()); i < _nc; i++ {
 		tp := tparams.NamedChild(i)
 		if tp == nil || tp.Type() != "type_parameter" {
 			continue
 		}
 		var name string
-		for j := 0; j < int(tp.NamedChildCount()); j++ {
+		for j, _nc := 0, int(tp.NamedChildCount()); j < _nc; j++ {
 			c := tp.NamedChild(j)
 			if c != nil && (c.Type() == "type_identifier" || c.Type() == "simple_identifier") && name == "" {
 				name = c.Content(src)
@@ -180,7 +180,7 @@ func kotlinFunctionBody(funcNode *sitter.Node) *sitter.Node {
 	if b := funcNode.ChildByFieldName("body"); b != nil {
 		return b
 	}
-	for i := 0; i < int(funcNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(funcNode.NamedChildCount()); i < _nc; i++ {
 		c := funcNode.NamedChild(i)
 		if c != nil && (c.Type() == "function_body" || c.Type() == "block") {
 			return c
@@ -223,7 +223,7 @@ func kotlinParamsList(funcNode *sitter.Node) *sitter.Node {
 	if funcNode == nil {
 		return nil
 	}
-	for i := 0; i < int(funcNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(funcNode.NamedChildCount()); i < _nc; i++ {
 		c := funcNode.NamedChild(i)
 		if c != nil && c.Type() == "function_value_parameters" {
 			return c
@@ -245,13 +245,13 @@ func emitKotlinParamShape(ownerID string, funcNode *sitter.Node, src []byte, fil
 		return
 	}
 	pos := 0
-	for i := 0; i < int(params.NamedChildCount()); i++ {
+	for i, _nc := 0, int(params.NamedChildCount()); i < _nc; i++ {
 		p := params.NamedChild(i)
 		if p == nil || p.Type() != "parameter" {
 			continue
 		}
 		var name, typeText string
-		for j := 0; j < int(p.NamedChildCount()); j++ {
+		for j, _nc := 0, int(p.NamedChildCount()); j < _nc; j++ {
 			c := p.NamedChild(j)
 			if c == nil {
 				continue
@@ -312,7 +312,7 @@ func emitKotlinReturnEdges(ownerID string, funcNode *sitter.Node, src []byte, fi
 		return
 	}
 	pastParams := false
-	for i := 0; i < int(funcNode.ChildCount()); i++ {
+	for i, _nc := 0, int(funcNode.ChildCount()); i < _nc; i++ {
 		child := funcNode.Child(i)
 		if child == nil {
 			continue

--- a/internal/parser/languages/kotlin_typeuse.go
+++ b/internal/parser/languages/kotlin_typeuse.go
@@ -147,7 +147,7 @@ func emitKotlinReferenceForms(root *sitter.Node, src []byte, filePath, fileID st
 			if ownerID == "" {
 				ownerID = fileID
 			}
-			for i := 0; i < int(n.NamedChildCount()); i++ {
+			for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 				c := n.NamedChild(i)
 				switch c.Type() {
 				case "constructor_invocation":
@@ -175,7 +175,7 @@ func emitKotlinReferenceForms(root *sitter.Node, src []byte, filePath, fileID st
 			gaOwner := owner(gaLine)
 			var collectGenericArgs func(*sitter.Node)
 			collectGenericArgs = func(m *sitter.Node) {
-				for i := 0; i < int(m.NamedChildCount()); i++ {
+				for i, _nc := 0, int(m.NamedChildCount()); i < _nc; i++ {
 					c := m.NamedChild(i)
 					if c == nil {
 						continue
@@ -217,7 +217,7 @@ func kotlinNavLastIdent(nav *sitter.Node, src []byte) string {
 			continue
 		}
 		if c.Type() == "navigation_suffix" {
-			for j := 0; j < int(c.NamedChildCount()); j++ {
+			for j, _nc := 0, int(c.NamedChildCount()); j < _nc; j++ {
 				cc := c.NamedChild(j)
 				if cc != nil && cc.Type() == "simple_identifier" {
 					return cc.Content(src)
@@ -255,7 +255,7 @@ func kotlinFirstUserType(node *sitter.Node) *sitter.Node {
 	if node == nil {
 		return nil
 	}
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		c := node.NamedChild(i)
 		if c == nil {
 			continue

--- a/internal/parser/languages/lua.go
+++ b/internal/parser/languages/lua.go
@@ -47,7 +47,7 @@ func (e *LuaExtractor) Extract(filePath string, src []byte) (*parser.ExtractionR
 	// the declaration. Same story for `local x = 1` which becomes a
 	// `variable_declaration` that's a `local_declaration` field of the
 	// chunk.
-	for i := 0; i < int(root.ChildCount()); i++ {
+	for i, _nc := 0, int(root.ChildCount()); i < _nc; i++ {
 		child := root.Child(i)
 		if child == nil {
 			continue
@@ -176,7 +176,7 @@ func (e *LuaExtractor) extractVariable(
 	result *parser.ExtractionResult, seen map[string]bool,
 ) {
 	var assign *sitter.Node
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		c := node.NamedChild(i)
 		if c == nil {
 			continue
@@ -191,7 +191,7 @@ func (e *LuaExtractor) extractVariable(
 	}
 
 	var varList *sitter.Node
-	for i := 0; i < int(assign.NamedChildCount()); i++ {
+	for i, _nc := 0, int(assign.NamedChildCount()); i < _nc; i++ {
 		c := assign.NamedChild(i)
 		if c != nil && c.Type() == "variable_list" {
 			varList = c
@@ -202,7 +202,7 @@ func (e *LuaExtractor) extractVariable(
 		return
 	}
 
-	for i := 0; i < int(varList.NamedChildCount()); i++ {
+	for i, _nc := 0, int(varList.NamedChildCount()); i < _nc; i++ {
 		ident := varList.NamedChild(i)
 		if ident == nil || ident.Type() != "identifier" {
 			continue
@@ -239,7 +239,7 @@ func (e *LuaExtractor) extractAssignmentFunc(
 	result *parser.ExtractionResult, seen map[string]bool,
 ) {
 	var varList, exprList *sitter.Node
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		c := node.NamedChild(i)
 		if c == nil {
 			continue
@@ -256,7 +256,7 @@ func (e *LuaExtractor) extractAssignmentFunc(
 	}
 	// Require RHS to be a function_definition (anonymous function literal).
 	hasFunc := false
-	for i := 0; i < int(exprList.NamedChildCount()); i++ {
+	for i, _nc := 0, int(exprList.NamedChildCount()); i < _nc; i++ {
 		c := exprList.NamedChild(i)
 		if c != nil && c.Type() == "function_definition" {
 			hasFunc = true
@@ -353,7 +353,7 @@ func extractLuaRequires(root *sitter.Node, src []byte, filePath, fileID string, 
 			return
 		}
 		var arg *sitter.Node
-		for i := 0; i < int(args.NamedChildCount()); i++ {
+		for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 			if a := args.NamedChild(i); a != nil {
 				arg = a
 				break
@@ -397,7 +397,7 @@ func resolveLuaRequireTarget(arg *sitter.Node, src []byte) (name, ipath string) 
 	case "function_call":
 		// e.g. script:WaitForChild("Bar") → leaf is the string argument.
 		if a := arg.ChildByFieldName("arguments"); a != nil {
-			for i := 0; i < int(a.NamedChildCount()); i++ {
+			for i, _nc := 0, int(a.NamedChildCount()); i < _nc; i++ {
 				if s := a.NamedChild(i); s != nil && s.Type() == "string" {
 					return strings.Trim(s.Content(src), `"'`+"`"), strings.TrimSpace(arg.Content(src))
 				}
@@ -417,7 +417,7 @@ func luaIndexLeaf(n *sitter.Node, src []byte) string {
 		return strings.TrimSpace(strings.Trim(f.Content(src), `"'[]`+"`"))
 	}
 	leaf := ""
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		c := n.NamedChild(i)
 		if c.Type() == "identifier" || c.Type() == "string" {
 			leaf = strings.TrimSpace(strings.Trim(c.Content(src), `"'`+"`"))

--- a/internal/parser/languages/luau.go
+++ b/internal/parser/languages/luau.go
@@ -59,7 +59,7 @@ func (e *LuauExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 	// as `variable_declaration`, `M.foo = function()` as
 	// `assignment_statement`. New to Luau: `type_definition` for type
 	// aliases.
-	for i := 0; i < int(root.ChildCount()); i++ {
+	for i, _nc := 0, int(root.ChildCount()); i < _nc; i++ {
 		child := root.Child(i)
 		if child == nil {
 			continue
@@ -197,7 +197,7 @@ func (e *LuauExtractor) extractVariable(
 	result *parser.ExtractionResult, seen map[string]bool,
 ) {
 	var assign *sitter.Node
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		c := node.NamedChild(i)
 		if c == nil {
 			continue
@@ -212,7 +212,7 @@ func (e *LuauExtractor) extractVariable(
 	}
 
 	var varList *sitter.Node
-	for i := 0; i < int(assign.NamedChildCount()); i++ {
+	for i, _nc := 0, int(assign.NamedChildCount()); i < _nc; i++ {
 		c := assign.NamedChild(i)
 		if c != nil && c.Type() == "variable_list" {
 			varList = c
@@ -223,7 +223,7 @@ func (e *LuauExtractor) extractVariable(
 		return
 	}
 
-	for i := 0; i < int(varList.NamedChildCount()); i++ {
+	for i, _nc := 0, int(varList.NamedChildCount()); i < _nc; i++ {
 		ident := varList.NamedChild(i)
 		if ident == nil || ident.Type() != "identifier" {
 			continue
@@ -258,7 +258,7 @@ func (e *LuauExtractor) extractAssignmentFunc(
 	result *parser.ExtractionResult, seen map[string]bool,
 ) {
 	var varList, exprList *sitter.Node
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		c := node.NamedChild(i)
 		if c == nil {
 			continue
@@ -275,7 +275,7 @@ func (e *LuauExtractor) extractAssignmentFunc(
 	}
 	// Require RHS to be a function_definition (anonymous function literal).
 	hasFunc := false
-	for i := 0; i < int(exprList.NamedChildCount()); i++ {
+	for i, _nc := 0, int(exprList.NamedChildCount()); i < _nc; i++ {
 		c := exprList.NamedChild(i)
 		if c != nil && c.Type() == "function_definition" {
 			hasFunc = true
@@ -363,7 +363,7 @@ func (e *LuauExtractor) extractType(
 	result *parser.ExtractionResult, seen map[string]bool,
 ) {
 	exported := false
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		c := node.Child(i)
 		if c != nil && c.Type() == "export" {
 			exported = true
@@ -512,7 +512,7 @@ func (e *LuauExtractor) emitGenericParamsFromNode(
 	result *parser.ExtractionResult, line int,
 ) {
 	first := true
-	for i := 0; i < int(gn.NamedChildCount()); i++ {
+	for i, _nc := 0, int(gn.NamedChildCount()); i < _nc; i++ {
 		c := gn.NamedChild(i)
 		if c == nil || c.Type() != "identifier" {
 			continue
@@ -549,7 +549,7 @@ func (e *LuauExtractor) emitTypeAnnotations(
 ) {
 	// Typed parameters.
 	if params := fnNode.ChildByFieldName("parameters"); params != nil {
-		for i := 0; i < int(params.NamedChildCount()); i++ {
+		for i, _nc := 0, int(params.NamedChildCount()); i < _nc; i++ {
 			p := params.NamedChild(i)
 			if p == nil || p.Type() != "parameter" {
 				continue
@@ -581,7 +581,7 @@ func (e *LuauExtractor) emitTypeAnnotations(
 
 // firstChildOfType returns the first direct child of the given type.
 func firstChildOfType(node *sitter.Node, typ string) *sitter.Node {
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		c := node.Child(i)
 		if c != nil && c.Type() == typ {
 			return c
@@ -594,7 +594,7 @@ func firstChildOfType(node *sitter.Node, typ string) *sitter.Node {
 // (`name: T`) — the named child after the `:` token, if present.
 func paramTypeNode(p *sitter.Node) *sitter.Node {
 	seenColon := false
-	for i := 0; i < int(p.ChildCount()); i++ {
+	for i, _nc := 0, int(p.ChildCount()); i < _nc; i++ {
 		c := p.Child(i)
 		if c == nil {
 			continue
@@ -620,7 +620,7 @@ func returnTypeNode(fnNode *sitter.Node) *sitter.Node {
 		return nil
 	}
 	afterParams := false
-	for i := 0; i < int(fnNode.ChildCount()); i++ {
+	for i, _nc := 0, int(fnNode.ChildCount()); i < _nc; i++ {
 		c := fnNode.Child(i)
 		if c == nil {
 			continue
@@ -643,7 +643,7 @@ func returnTypeNode(fnNode *sitter.Node) *sitter.Node {
 // — the named node after the `=` token.
 func typeAliasRHS(node *sitter.Node) *sitter.Node {
 	seenEq := false
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		c := node.Child(i)
 		if c == nil {
 			continue

--- a/internal/parser/languages/markdown.go
+++ b/internal/parser/languages/markdown.go
@@ -72,7 +72,7 @@ func (e *MarkdownExtractor) Extract(filePath string, src []byte) (*parser.Extrac
 			e.extractWikiLinks(text, filePath, fileNode.ID, seenLinks, result, line)
 		}
 
-		for i := 0; i < int(node.NamedChildCount()); i++ {
+		for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 			walk(node.NamedChild(i))
 		}
 	}
@@ -90,7 +90,7 @@ func (e *MarkdownExtractor) extractHeading(node *sitter.Node, src []byte, filePa
 	// Get heading level from marker type.
 	level := 0
 	var headingText string
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		child := node.NamedChild(i)
 		switch child.Type() {
 		case "atx_h1_marker":
@@ -133,10 +133,10 @@ func (e *MarkdownExtractor) extractHeading(node *sitter.Node, src []byte, filePa
 
 func (e *MarkdownExtractor) extractCodeBlock(node *sitter.Node, src []byte, filePath, _ string, seen map[string]bool, result *parser.ExtractionResult) {
 	// Extract language from info_string.
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		child := node.NamedChild(i)
 		if child.Type() == "info_string" {
-			for j := 0; j < int(child.NamedChildCount()); j++ {
+			for j, _nc := 0, int(child.NamedChildCount()); j < _nc; j++ {
 				langNode := child.NamedChild(j)
 				if langNode.Type() == "language" {
 					lang := strings.TrimSpace(langNode.Content(src))

--- a/internal/parser/languages/markdown_prose.go
+++ b/internal/parser/languages/markdown_prose.go
@@ -96,7 +96,7 @@ func (e *MarkdownExtractor) extractProseSections(root *sitter.Node, src []byte, 
 			appendText(int(node.StartPoint().Row)+1, node.Content(src))
 			return
 		}
-		for i := 0; i < int(node.NamedChildCount()); i++ {
+		for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 			walk(node.NamedChild(i))
 		}
 	}
@@ -145,7 +145,7 @@ func (e *MarkdownExtractor) extractProseSections(root *sitter.Node, src []byte, 
 func headingLevelText(node *sitter.Node, src []byte) (int, string) {
 	level := 0
 	var text string
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		child := node.NamedChild(i)
 		switch child.Type() {
 		case "atx_h1_marker":

--- a/internal/parser/languages/ocaml.go
+++ b/internal/parser/languages/ocaml.go
@@ -55,7 +55,7 @@ func (e *OCamlExtractor) walkExtract(
 	node *sitter.Node, src []byte, filePath string, fileNode *graph.Node,
 	result *parser.ExtractionResult, seen map[string]bool, modulePrefix string,
 ) {
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		child := node.Child(i)
 		if child == nil {
 			continue
@@ -95,7 +95,7 @@ func (e *OCamlExtractor) extractValueDef(
 	node *sitter.Node, src []byte, filePath string, fileNode *graph.Node,
 	result *parser.ExtractionResult, seen map[string]bool, modulePrefix string,
 ) {
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		child := node.NamedChild(i)
 		if child == nil {
 			continue
@@ -107,7 +107,7 @@ func (e *OCamlExtractor) extractValueDef(
 			hasParams := false
 
 			// Walk let_binding children to find pattern (name) and check for parameters.
-			for j := 0; j < int(child.NamedChildCount()); j++ {
+			for j, _nc := 0, int(child.NamedChildCount()); j < _nc; j++ {
 				part := child.NamedChild(j)
 				if part == nil {
 					continue
@@ -166,14 +166,14 @@ func (e *OCamlExtractor) extractTypeDef(
 	node *sitter.Node, src []byte, filePath string, fileNode *graph.Node,
 	result *parser.ExtractionResult, seen map[string]bool, modulePrefix string,
 ) {
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		child := node.NamedChild(i)
 		if child == nil || child.Type() != "type_binding" {
 			continue
 		}
 
 		name := ""
-		for j := 0; j < int(child.NamedChildCount()); j++ {
+		for j, _nc := 0, int(child.NamedChildCount()); j < _nc; j++ {
 			part := child.NamedChild(j)
 			if part != nil && (part.Type() == "type_constructor" || part.Type() == "type_variable") {
 				name = part.Content(src)
@@ -225,14 +225,14 @@ func (e *OCamlExtractor) extractModuleDef(
 	result *parser.ExtractionResult, seen map[string]bool, modulePrefix string,
 ) {
 	// Find module_binding child.
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		binding := node.NamedChild(i)
 		if binding == nil || binding.Type() != "module_binding" {
 			continue
 		}
 
 		name := ""
-		for j := 0; j < int(binding.NamedChildCount()); j++ {
+		for j, _nc := 0, int(binding.NamedChildCount()); j < _nc; j++ {
 			child := binding.NamedChild(j)
 			if child != nil && child.Type() == "module_name" {
 				name = child.Content(src)
@@ -268,7 +268,7 @@ func (e *OCamlExtractor) extractModuleDef(
 		})
 
 		// Recurse into module body (structure node) for nested definitions.
-		for j := 0; j < int(binding.NamedChildCount()); j++ {
+		for j, _nc := 0, int(binding.NamedChildCount()); j < _nc; j++ {
 			child := binding.NamedChild(j)
 			if child != nil && (child.Type() == "structure" || child.Type() == "struct_expression") {
 				e.walkExtract(child, src, filePath, fileNode, result, seen, qualName)
@@ -283,7 +283,7 @@ func (e *OCamlExtractor) extractModuleTypeDef(
 	result *parser.ExtractionResult, seen map[string]bool, modulePrefix string,
 ) {
 	name := ""
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		child := node.NamedChild(i)
 		if child != nil && child.Type() == "module_type_name" {
 			name = child.Content(src)
@@ -323,7 +323,7 @@ func (e *OCamlExtractor) extractOpen(
 	node *sitter.Node, src []byte, filePath string, fileNode *graph.Node,
 	result *parser.ExtractionResult,
 ) {
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		child := node.NamedChild(i)
 		if child != nil && (child.Type() == "module_path" || child.Type() == "module_name" || child.Type() == "extended_module_path") {
 			moduleName := child.Content(src)
@@ -341,14 +341,14 @@ func (e *OCamlExtractor) extractClassDef(
 	node *sitter.Node, src []byte, filePath string, fileNode *graph.Node,
 	result *parser.ExtractionResult, seen map[string]bool, modulePrefix string,
 ) {
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		child := node.NamedChild(i)
 		if child == nil || child.Type() != "class_binding" {
 			continue
 		}
 
 		name := ""
-		for j := 0; j < int(child.NamedChildCount()); j++ {
+		for j, _nc := 0, int(child.NamedChildCount()); j < _nc; j++ {
 			part := child.NamedChild(j)
 			if part != nil && (part.Type() == "class_name" || part.Type() == "value_name") {
 				name = part.Content(src)
@@ -398,7 +398,7 @@ func (e *OCamlExtractor) extractMethods(
 			return
 		}
 		name := ""
-		for i := 0; i < int(node.NamedChildCount()); i++ {
+		for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 			child := node.NamedChild(i)
 			if child != nil && child.Type() == "method_name" {
 				name = child.Content(src)
@@ -440,7 +440,7 @@ func (e *OCamlExtractor) extractExternal(
 	result *parser.ExtractionResult, seen map[string]bool, modulePrefix string,
 ) {
 	name := ""
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		child := node.NamedChild(i)
 		if child != nil && child.Type() == "value_name" {
 			name = child.Content(src)
@@ -482,7 +482,7 @@ func (e *OCamlExtractor) extractValueSpec(
 	result *parser.ExtractionResult, seen map[string]bool, modulePrefix string,
 ) {
 	name := ""
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		child := node.NamedChild(i)
 		if child != nil && child.Type() == "value_name" {
 			name = child.Content(src)

--- a/internal/parser/languages/orgmode.go
+++ b/internal/parser/languages/orgmode.go
@@ -86,7 +86,7 @@ func (e *OrgModeExtractor) Extract(filePath string, src []byte) (*parser.Extract
 		case "regular_link":
 			e.extractLink(node, parseSrc, filePath, fileNode.ID, seenLinks, result, startLine)
 		}
-		for i := 0; i < int(node.NamedChildCount()); i++ {
+		for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 			walk(node.NamedChild(i))
 		}
 	}
@@ -170,7 +170,7 @@ func (e *OrgModeExtractor) extractBlock(
 	startLine, endLine func(*sitter.Node) int,
 ) {
 	var blockType, params string
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		child := node.NamedChild(i)
 		switch child.Type() {
 		case "block_begin_name":
@@ -221,7 +221,7 @@ func (e *OrgModeExtractor) extractBlock(
 // so consumers can show the document title without re-parsing.
 func (e *OrgModeExtractor) maybeAttachKeyword(node *sitter.Node, src []byte, fileNode *graph.Node) {
 	var rawKey, val string
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		child := node.NamedChild(i)
 		switch child.Type() {
 		case "keyword_key":
@@ -255,7 +255,7 @@ func (e *OrgModeExtractor) extractLink(
 	startLine func(*sitter.Node) int,
 ) {
 	var target string
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		child := node.NamedChild(i)
 		if child.Type() == "pathreg" {
 			target = strings.TrimSpace(child.Content(src))

--- a/internal/parser/languages/pascal.go
+++ b/internal/parser/languages/pascal.go
@@ -103,7 +103,7 @@ func (e *PascalExtractor) emitPascalModule(n *sitter.Node, src []byte, filePath,
 }
 
 func (e *PascalExtractor) emitPascalUses(n *sitter.Node, src []byte, filePath, fileID string, result *parser.ExtractionResult) {
-	for i := 0; i < int(n.ChildCount()); i++ {
+	for i, _nc := 0, int(n.ChildCount()); i < _nc; i++ {
 		c := n.Child(i)
 		if c.Type() != "moduleName" {
 			continue
@@ -177,7 +177,7 @@ func (e *PascalExtractor) emitPascalType(n *sitter.Node, src []byte, filePath, f
 }
 
 func (e *PascalExtractor) emitPascalEnumMembers(enum *sitter.Node, src []byte, filePath, typeID string, result *parser.ExtractionResult, seen map[string]bool) {
-	for i := 0; i < int(enum.ChildCount()); i++ {
+	for i, _nc := 0, int(enum.ChildCount()); i < _nc; i++ {
 		c := enum.Child(i)
 		if c.Type() != "declEnumValue" {
 			continue
@@ -207,7 +207,7 @@ func (e *PascalExtractor) emitPascalEnumMembers(enum *sitter.Node, src []byte, f
 
 func (e *PascalExtractor) emitPascalClassBody(body *sitter.Node, src []byte, filePath, typeName, typeID string, result *parser.ExtractionResult, seen map[string]bool, procIndex map[string]string) {
 	// Base type(s): typeref children directly under the class header.
-	for i := 0; i < int(body.ChildCount()); i++ {
+	for i, _nc := 0, int(body.ChildCount()); i < _nc; i++ {
 		c := body.Child(i)
 		if c.Type() == "typeref" {
 			base := strings.TrimSpace(c.Content(src))
@@ -222,7 +222,7 @@ func (e *PascalExtractor) emitPascalClassBody(body *sitter.Node, src []byte, fil
 	visibility := VisibilityPublic
 	var walk func(n *sitter.Node)
 	walk = func(n *sitter.Node) {
-		for i := 0; i < int(n.ChildCount()); i++ {
+		for i, _nc := 0, int(n.ChildCount()); i < _nc; i++ {
 			c := n.Child(i)
 			switch c.Type() {
 			case "declSection":
@@ -419,7 +419,7 @@ func (e *PascalExtractor) emitPascalCallEdge(fromID, callee, filePath string, li
 
 // pascalFirstChild returns the first direct child of n with the given type.
 func pascalFirstChild(n *sitter.Node, typ string) *sitter.Node {
-	for i := 0; i < int(n.ChildCount()); i++ {
+	for i, _nc := 0, int(n.ChildCount()); i < _nc; i++ {
 		if c := n.Child(i); c.Type() == typ {
 			return c
 		}
@@ -438,13 +438,13 @@ func pascalChildText(n *sitter.Node, src []byte, typ string) string {
 // pascalTypeBody returns the declClass/declRecord/declEnum/declInterface node a
 // declType resolves to, unwrapping the intermediate `type` wrapper.
 func pascalTypeBody(declType *sitter.Node) *sitter.Node {
-	for i := 0; i < int(declType.ChildCount()); i++ {
+	for i, _nc := 0, int(declType.ChildCount()); i < _nc; i++ {
 		c := declType.Child(i)
 		switch c.Type() {
 		case "declClass", "declRecord", "declObject", "declInterface", "declEnum":
 			return c
 		case "type":
-			for j := 0; j < int(c.ChildCount()); j++ {
+			for j, _nc := 0, int(c.ChildCount()); j < _nc; j++ {
 				if inner := c.Child(j); inner.IsNamed() {
 					return inner
 				}
@@ -512,7 +512,7 @@ func pascalDotMethodReceiver(dot *sitter.Node, src []byte) (method, receiver str
 }
 
 func pascalCallTargetName(call *sitter.Node, src []byte) string {
-	for i := 0; i < int(call.ChildCount()); i++ {
+	for i, _nc := 0, int(call.ChildCount()); i < _nc; i++ {
 		c := call.Child(i)
 		if c.Type() == "identifier" || c.Type() == "genericDot" {
 			return strings.TrimSpace(c.Content(src))
@@ -525,7 +525,7 @@ func pascalCallTargetName(call *sitter.Node, src []byte) string {
 // statement whose sole named child is an identifier / genericDot — or "".
 func pascalParenlessCallee(stmt *sitter.Node, src []byte) string {
 	var named []*sitter.Node
-	for i := 0; i < int(stmt.ChildCount()); i++ {
+	for i, _nc := 0, int(stmt.ChildCount()); i < _nc; i++ {
 		if c := stmt.Child(i); c.IsNamed() {
 			named = append(named, c)
 		}

--- a/internal/parser/languages/php.go
+++ b/internal/parser/languages/php.go
@@ -115,7 +115,7 @@ func (e *PHPExtractor) walkChildren(
 	result *parser.ExtractionResult, seen map[string]bool,
 	currentClass string,
 ) {
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		child := node.NamedChild(i)
 		e.walkNode(child, src, filePath, fileNode, result, seen, currentClass)
 	}
@@ -150,13 +150,13 @@ func (e *PHPExtractor) extractNamespace(
 	// Walk children of namespace body.
 	body := e.findChildByType(node, "compound_statement")
 	if body != nil {
-		for i := 0; i < int(body.NamedChildCount()); i++ {
+		for i, _nc := 0, int(body.NamedChildCount()); i < _nc; i++ {
 			child := body.NamedChild(i)
 			e.walkNode(child, src, filePath, fileNode, result, seen, "")
 		}
 	}
 	// Some namespaces don't use braces; walk remaining children.
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		child := node.NamedChild(i)
 		if child.Type() != "namespace_name" && child.Type() != "compound_statement" {
 			e.walkNode(child, src, filePath, fileNode, result, seen, "")
@@ -270,7 +270,7 @@ func (e *PHPExtractor) extractPhpMembers(
 	ownerName, ownerID string,
 ) map[string]*sitter.Node {
 	methodNodes := make(map[string]*sitter.Node)
-	for i := 0; i < int(body.NamedChildCount()); i++ {
+	for i, _nc := 0, int(body.NamedChildCount()); i < _nc; i++ {
 		child := body.NamedChild(i)
 		switch child.Type() {
 		case "method_declaration":
@@ -372,7 +372,7 @@ func (e *PHPExtractor) extractPhpClassConst(
 	ownerName, ownerID string,
 ) {
 	vis := phpMemberVisibility(node, src)
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		ce := node.NamedChild(i)
 		if ce.Type() != "const_element" {
 			continue
@@ -410,7 +410,7 @@ func (e *PHPExtractor) extractPhpProperty(
 ) {
 	vis := phpMemberVisibility(node, src)
 	propType := phpPropertyType(node, src)
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		pe := node.NamedChild(i)
 		if pe.Type() != "property_element" {
 			continue
@@ -455,7 +455,7 @@ func (e *PHPExtractor) extractPhpProperty(
 // `use`s — modeling trait composition the way a mixin is modeled, so the
 // composed members are reachable through the class.
 func (e *PHPExtractor) extractPhpTraitUse(node *sitter.Node, src []byte, filePath, ownerID string, result *parser.ExtractionResult) {
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		c := node.NamedChild(i)
 		if c.Type() != "name" && c.Type() != "qualified_name" {
 			continue
@@ -502,7 +502,7 @@ func (e *PHPExtractor) extractPhpEnumCase(
 // phpPropertyType returns the declared type of a property_declaration (the type
 // node before the first property_element), or "".
 func phpPropertyType(node *sitter.Node, src []byte) string {
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		c := node.NamedChild(i)
 		switch c.Type() {
 		case "primitive_type", "named_type", "union_type", "nullable_type", "intersection_type", "optional_type", "qualified_name":
@@ -576,7 +576,7 @@ func emitPHPTypeUseEdges(ownerID, typeText, filePath string, line int, result *p
 // node after formal_parameters, before the body), or "".
 func phpReturnType(node *sitter.Node, src []byte) string {
 	seenParams := false
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		c := node.NamedChild(i)
 		t := c.Type()
 		if t == "formal_parameters" {
@@ -606,7 +606,7 @@ func (e *PHPExtractor) emitPHPParamTypeUseEdges(node *sitter.Node, src []byte, o
 	if params == nil {
 		return
 	}
-	for i := 0; i < int(params.NamedChildCount()); i++ {
+	for i, _nc := 0, int(params.NamedChildCount()); i < _nc; i++ {
 		p := params.NamedChild(i)
 		switch p.Type() {
 		case "simple_parameter", "variadic_parameter", "property_promotion_parameter":
@@ -624,7 +624,7 @@ func (e *PHPExtractor) emitPHPParamTypeUseEdges(node *sitter.Node, src []byte, o
 // phpParameterType returns the declared type of a parameter node (the type
 // node before its variable_name), or "".
 func phpParameterType(node *sitter.Node, src []byte) string {
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		c := node.NamedChild(i)
 		switch c.Type() {
 		case "primitive_type", "named_type", "union_type", "nullable_type",
@@ -758,7 +758,7 @@ func (e *PHPExtractor) extractUseImport(
 	result *parser.ExtractionResult,
 ) {
 	// use_declaration children can be namespace_use_clause or namespace_name.
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		child := node.NamedChild(i)
 		var importPath string
 		switch child.Type() {
@@ -796,7 +796,7 @@ func (e *PHPExtractor) extractRequireInclude(
 	result *parser.ExtractionResult,
 ) {
 	// Look for require, require_once, include, include_once expressions.
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		child := node.NamedChild(i)
 		ct := child.Type()
 		if ct == "require_expression" || ct == "require_once_expression" ||
@@ -903,7 +903,7 @@ func (e *PHPExtractor) extractCallSites(
 	}
 
 	// Recurse into children.
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		child := node.NamedChild(i)
 		e.extractCallSites(child, src, filePath, callerID, result)
 	}
@@ -911,7 +911,7 @@ func (e *PHPExtractor) extractCallSites(
 
 // findChildByType finds the first named child with the given type.
 func (e *PHPExtractor) findChildByType(node *sitter.Node, typeName string) *sitter.Node {
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		child := node.NamedChild(i)
 		if child.Type() == typeName {
 			return child
@@ -930,7 +930,7 @@ func (e *PHPExtractor) extractStringContent(node *sitter.Node, src []byte) strin
 	if node.Type() == "string_content" {
 		return node.Content(src)
 	}
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		if result := e.extractStringContent(node.NamedChild(i), src); result != "" {
 			return result
 		}
@@ -1030,7 +1030,7 @@ func (e *PHPExtractor) emitLaravelMiddleware(methodNodes map[string]*sitter.Node
 				}
 			}
 		}
-		for i := 0; i < int(n.ChildCount()); i++ {
+		for i, _nc := 0, int(n.ChildCount()); i < _nc; i++ {
 			walk(n.Child(i))
 		}
 	}
@@ -1164,7 +1164,7 @@ func (e *PHPExtractor) emitLaravelBindings(methodNodes map[string]*sitter.Node, 
 				})
 			}
 		}
-		for i := 0; i < int(n.ChildCount()); i++ {
+		for i, _nc := 0, int(n.ChildCount()); i < _nc; i++ {
 			walk(n.Child(i))
 		}
 	}
@@ -1209,7 +1209,7 @@ func phpExtractClassRef(arg *sitter.Node, src []byte) string {
 		return arg.Content(src)
 	case "string":
 		// middleware('auth') alias form — return the alias verbatim.
-		for i := 0; i < int(arg.NamedChildCount()); i++ {
+		for i, _nc := 0, int(arg.NamedChildCount()); i < _nc; i++ {
 			c := arg.NamedChild(i)
 			if c != nil && c.Type() == "string_content" {
 				return c.Content(src)
@@ -1237,7 +1237,7 @@ func phpExtractStringArray(arg *sitter.Node, src []byte) map[string]struct{} {
 	if arg.Type() != "array_creation_expression" {
 		return out
 	}
-	for i := 0; i < int(arg.NamedChildCount()); i++ {
+	for i, _nc := 0, int(arg.NamedChildCount()); i < _nc; i++ {
 		el := arg.NamedChild(i)
 		if el == nil {
 			continue
@@ -1253,7 +1253,7 @@ func phpExtractStringArray(arg *sitter.Node, src []byte) map[string]struct{} {
 		}
 		switch el.Type() {
 		case "string":
-			for j := 0; j < int(el.NamedChildCount()); j++ {
+			for j, _nc := 0, int(el.NamedChildCount()); j < _nc; j++ {
 				c := el.NamedChild(j)
 				if c != nil && c.Type() == "string_content" {
 					out[c.Content(src)] = struct{}{}
@@ -1338,17 +1338,17 @@ func emitPHPAnnotationEdgesFromAttrs(attrs []phpAttribute, fromID, filePath stri
 // each group. Returns nil when the node carries no attributes.
 func collectPhpAttributes(node *sitter.Node, src []byte) []phpAttribute {
 	var out []phpAttribute
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		c := node.NamedChild(i)
 		if c == nil || c.Type() != "attribute_list" {
 			continue
 		}
-		for j := 0; j < int(c.NamedChildCount()); j++ {
+		for j, _nc := 0, int(c.NamedChildCount()); j < _nc; j++ {
 			group := c.NamedChild(j)
 			if group == nil || group.Type() != "attribute_group" {
 				continue
 			}
-			for k := 0; k < int(group.NamedChildCount()); k++ {
+			for k, _nc := 0, int(group.NamedChildCount()); k < _nc; k++ {
 				attr := group.NamedChild(k)
 				if attr == nil || attr.Type() != "attribute" {
 					continue
@@ -1373,7 +1373,7 @@ func parsePhpAttribute(attr *sitter.Node, src []byte) phpAttribute {
 	if nameNode == nil {
 		// Grammar sometimes lacks the field name; fall back to the
 		// first child of type "name".
-		for i := 0; i < int(attr.NamedChildCount()); i++ {
+		for i, _nc := 0, int(attr.NamedChildCount()); i < _nc; i++ {
 			c := attr.NamedChild(i)
 			if c != nil && (c.Type() == "name" || c.Type() == "qualified_name") {
 				nameNode = c
@@ -1389,7 +1389,7 @@ func parsePhpAttribute(attr *sitter.Node, src []byte) phpAttribute {
 	args := attr.ChildByFieldName("arguments")
 	if args == nil {
 		// Some grammars expose arguments as a positional NamedChild.
-		for i := 0; i < int(attr.NamedChildCount()); i++ {
+		for i, _nc := 0, int(attr.NamedChildCount()); i < _nc; i++ {
 			c := attr.NamedChild(i)
 			if c != nil && c.Type() == "arguments" {
 				args = c
@@ -1401,7 +1401,7 @@ func parsePhpAttribute(attr *sitter.Node, src []byte) phpAttribute {
 		return out
 	}
 	out.args = make(map[string]string)
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		arg := args.NamedChild(i)
 		if arg == nil || arg.Type() != "argument" {
 			continue
@@ -1409,7 +1409,7 @@ func parsePhpAttribute(attr *sitter.Node, src []byte) phpAttribute {
 		// Named arguments have a `name` child first, then the value.
 		var key string
 		var valNode *sitter.Node
-		for j := 0; j < int(arg.NamedChildCount()); j++ {
+		for j, _nc := 0, int(arg.NamedChildCount()); j < _nc; j++ {
 			c := arg.NamedChild(j)
 			if c == nil {
 				continue
@@ -1478,12 +1478,12 @@ func extractPhpParentClass(classNode *sitter.Node, src []byte) string {
 	if classNode == nil {
 		return ""
 	}
-	for i := 0; i < int(classNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(classNode.NamedChildCount()); i < _nc; i++ {
 		child := classNode.NamedChild(i)
 		if child.Type() != "base_clause" {
 			continue
 		}
-		for j := 0; j < int(child.NamedChildCount()); j++ {
+		for j, _nc := 0, int(child.NamedChildCount()); j < _nc; j++ {
 			sub := child.NamedChild(j)
 			switch sub.Type() {
 			case "name", "qualified_name":
@@ -1505,7 +1505,7 @@ func phpMemberVisibility(member *sitter.Node, src []byte) string {
 	if member == nil {
 		return VisibilityPublic
 	}
-	for i := 0; i < int(member.ChildCount()); i++ {
+	for i, _nc := 0, int(member.ChildCount()); i < _nc; i++ {
 		c := member.Child(i)
 		if c == nil {
 			continue

--- a/internal/parser/languages/php_laravel_events.go
+++ b/internal/parser/languages/php_laravel_events.go
@@ -147,7 +147,7 @@ func laravelTagListenMap(prop *sitter.Node, src []byte, classNodeByName map[stri
 		return
 	}
 	var entries []string
-	for i := 0; i < int(arr.NamedChildCount()); i++ {
+	for i, _nc := 0, int(arr.NamedChildCount()); i < _nc; i++ {
 		el := arr.NamedChild(i)
 		if el == nil || el.Type() != "array_element_initializer" || el.NamedChildCount() < 2 {
 			continue
@@ -181,7 +181,7 @@ func laravelClassRefList(n *sitter.Node, src []byte) []string {
 		return out
 	}
 	if n.Type() == "array_creation_expression" {
-		for i := 0; i < int(n.NamedChildCount()); i++ {
+		for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 			el := n.NamedChild(i)
 			if el == nil {
 				continue
@@ -209,7 +209,7 @@ func laravelFirstNewArgType(call *sitter.Node, src []byte) string {
 	if args == nil {
 		return ""
 	}
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		a := args.NamedChild(i)
 		if a == nil {
 			continue
@@ -230,7 +230,7 @@ func laravelFirstNewArgType(call *sitter.Node, src []byte) string {
 
 // laravelNewType returns the simple class name of a `new X(...)`.
 func laravelNewType(newExpr *sitter.Node, src []byte) string {
-	for i := 0; i < int(newExpr.NamedChildCount()); i++ {
+	for i, _nc := 0, int(newExpr.NamedChildCount()); i < _nc; i++ {
 		c := newExpr.NamedChild(i)
 		if c == nil {
 			continue
@@ -250,7 +250,7 @@ func laravelFirstParamType(method *sitter.Node, src []byte) string {
 	if params == nil {
 		return ""
 	}
-	for i := 0; i < int(params.NamedChildCount()); i++ {
+	for i, _nc := 0, int(params.NamedChildCount()); i < _nc; i++ {
 		p := params.NamedChild(i)
 		if p == nil || p.Type() != "simple_parameter" {
 			continue
@@ -346,7 +346,7 @@ func laravelWalk(n *sitter.Node, fn func(*sitter.Node)) {
 		return
 	}
 	fn(n)
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		laravelWalk(n.NamedChild(i), fn)
 	}
 }

--- a/internal/parser/languages/php_reffrm.go
+++ b/internal/parser/languages/php_reffrm.go
@@ -217,7 +217,7 @@ func isPHPRelativeScope(name string) bool {
 // "\App\Client"). The type is the leading type-shaped named child; `new
 // $klass()` (dynamic) and `new class {}` (anonymous) have none and yield "".
 func phpCreationTypeName(n *sitter.Node, src []byte) string {
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		c := n.NamedChild(i)
 		if c == nil {
 			continue
@@ -238,7 +238,7 @@ func phpCreationTypeName(n *sitter.Node, src []byte) string {
 // base_clause (`extends Base`) or class_interface_clause (`implements I, J`).
 func phpClauseTypeNames(clause *sitter.Node, src []byte) []string {
 	var out []string
-	for i := 0; i < int(clause.NamedChildCount()); i++ {
+	for i, _nc := 0, int(clause.NamedChildCount()); i < _nc; i++ {
 		c := clause.NamedChild(i)
 		if c == nil {
 			continue
@@ -296,7 +296,7 @@ func phpAttributeRefName(n *sitter.Node, src []byte) string {
 	if nm := n.ChildByFieldName("name"); nm != nil {
 		return strings.TrimSpace(nm.Content(src))
 	}
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		c := n.NamedChild(i)
 		if c == nil {
 			continue

--- a/internal/parser/languages/php_string_callable.go
+++ b/internal/parser/languages/php_string_callable.go
@@ -96,7 +96,7 @@ func (e *PHPExtractor) capturePHPStringCallables(result *parser.ExtractionResult
 		// callbacks live on the value side, so resolve each value rather than
 		// scanning the array flat (its regex-pattern keys are not callables).
 		callbackArray := calleeLower == "preg_replace_callback_array"
-		for i := 0; i < int(args.NamedChildCount()); i++ {
+		for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 			a := args.NamedChild(i)
 			if a == nil {
 				continue
@@ -170,7 +170,7 @@ func (e *PHPExtractor) phpCallbackArrayValues(a *sitter.Node, src []byte) []phpC
 		return nil
 	}
 	var out []phpCallableRef
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		el := node.NamedChild(i)
 		if el == nil || el.Type() != "array_element_initializer" {
 			continue

--- a/internal/parser/languages/protobuf.go
+++ b/internal/parser/languages/protobuf.go
@@ -36,7 +36,7 @@ func (e *ProtobufExtractor) Extract(filePath string, src []byte) (*parser.Extrac
 	result.Nodes = append(result.Nodes, fileNode)
 	seen := make(map[string]bool)
 
-	for i := 0; i < int(root.NamedChildCount()); i++ {
+	for i, _nc := 0, int(root.NamedChildCount()); i < _nc; i++ {
 		child := root.NamedChild(i)
 		switch child.Type() {
 		case "message":
@@ -70,10 +70,10 @@ func (e *ProtobufExtractor) extractMessage(node *sitter.Node, src []byte, filePa
 		FilePath: filePath, Line: int(node.StartPoint().Row) + 1,
 	})
 
-	for j := 0; j < int(node.NamedChildCount()); j++ {
+	for j, _nc := 0, int(node.NamedChildCount()); j < _nc; j++ {
 		body := node.NamedChild(j)
 		if body.Type() == "message_body" {
-			for k := 0; k < int(body.NamedChildCount()); k++ {
+			for k, _nc := 0, int(body.NamedChildCount()); k < _nc; k++ {
 				field := body.NamedChild(k)
 				if field.Type() == "field" {
 					fieldName := findDirectIdent(field, src)
@@ -107,7 +107,7 @@ func (e *ProtobufExtractor) extractService(node *sitter.Node, src []byte, filePa
 	id := filePath + "::" + name
 
 	var methods []string
-	for j := 0; j < int(node.NamedChildCount()); j++ {
+	for j, _nc := 0, int(node.NamedChildCount()); j < _nc; j++ {
 		child := node.NamedChild(j)
 		if child.Type() == "rpc" {
 			rpcName := findProtoName(child, "rpc_name", src)
@@ -127,7 +127,7 @@ func (e *ProtobufExtractor) extractService(node *sitter.Node, src []byte, filePa
 		FilePath: filePath, Line: int(node.StartPoint().Row) + 1,
 	})
 
-	for j := 0; j < int(node.NamedChildCount()); j++ {
+	for j, _nc := 0, int(node.NamedChildCount()); j < _nc; j++ {
 		child := node.NamedChild(j)
 		if child.Type() == "rpc" {
 			rpcName := findProtoName(child, "rpc_name", src)
@@ -173,7 +173,7 @@ func (e *ProtobufExtractor) extractEnum(node *sitter.Node, src []byte, filePath,
 }
 
 func (e *ProtobufExtractor) extractImport(node *sitter.Node, src []byte, filePath, fileID string, result *parser.ExtractionResult) {
-	for j := 0; j < int(node.NamedChildCount()); j++ {
+	for j, _nc := 0, int(node.NamedChildCount()); j < _nc; j++ {
 		child := node.NamedChild(j)
 		if child.Type() == "string" {
 			path := child.Content(src)
@@ -189,10 +189,10 @@ func (e *ProtobufExtractor) extractImport(node *sitter.Node, src []byte, filePat
 }
 
 func findProtoName(node *sitter.Node, nameType string, src []byte) string {
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		child := node.NamedChild(i)
 		if child.Type() == nameType {
-			for j := 0; j < int(child.NamedChildCount()); j++ {
+			for j, _nc := 0, int(child.NamedChildCount()); j < _nc; j++ {
 				id := child.NamedChild(j)
 				if id.Type() == "identifier" {
 					return id.Content(src)
@@ -205,7 +205,7 @@ func findProtoName(node *sitter.Node, nameType string, src []byte) string {
 }
 
 func findDirectIdent(node *sitter.Node, src []byte) string {
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		child := node.NamedChild(i)
 		if child.Type() == "identifier" {
 			return child.Content(src)

--- a/internal/parser/languages/py_celery.go
+++ b/internal/parser/languages/py_celery.go
@@ -187,7 +187,7 @@ func celeryFirstStringArg(call *sitter.Node, src []byte) string {
 	if args == nil {
 		return ""
 	}
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		a := args.NamedChild(i)
 		if a != nil && a.Type() == "string" {
 			return pyStringLiteralContent(a, src)
@@ -202,7 +202,7 @@ func celeryWalk(n *sitter.Node, fn func(*sitter.Node)) {
 		return
 	}
 	fn(n)
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		celeryWalk(n.NamedChild(i), fn)
 	}
 }

--- a/internal/parser/languages/py_django.go
+++ b/internal/parser/languages/py_django.go
@@ -87,7 +87,7 @@ func djangoWalk(n *sitter.Node, fn func(*sitter.Node)) {
 		return
 	}
 	fn(n)
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		djangoWalk(n.NamedChild(i), fn)
 	}
 }

--- a/internal/parser/languages/py_function_shape.go
+++ b/internal/parser/languages/py_function_shape.go
@@ -71,7 +71,7 @@ func emitPyAsyncSpawns(ownerID string, body *sitter.Node, src []byte, filePath s
 		case "await":
 			// `await foo()` parses as (await (call …)). Walk for
 			// the call node directly.
-			for i := 0; i < int(n.NamedChildCount()); i++ {
+			for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 				c := n.NamedChild(i)
 				if c == nil || c.Type() != "call" {
 					continue
@@ -110,7 +110,7 @@ func walkPyNodes(n *sitter.Node, visit func(*sitter.Node) bool) {
 	if !visit(n) {
 		return
 	}
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		walkPyNodes(n.NamedChild(i), visit)
 	}
 }
@@ -137,7 +137,7 @@ func pyCallTargetName(call *sitter.Node, src []byte) string {
 
 func emitPyParamNodes(ownerID string, params *sitter.Node, src []byte, filePath string, declLine int, result *parser.ExtractionResult) {
 	pos := 0
-	for i := 0; i < int(params.NamedChildCount()); i++ {
+	for i, _nc := 0, int(params.NamedChildCount()); i < _nc; i++ {
 		decl := params.NamedChild(i)
 		if decl == nil {
 			continue
@@ -200,7 +200,7 @@ func pyParamShape(decl *sitter.Node, src []byte) (string, string, bool) {
 		// (typed_parameter name: (identifier) type: (type))
 		var name, typ string
 		variadic := false
-		for i := 0; i < int(decl.NamedChildCount()); i++ {
+		for i, _nc := 0, int(decl.NamedChildCount()); i < _nc; i++ {
 			c := decl.NamedChild(i)
 			if c == nil {
 				continue
@@ -214,7 +214,7 @@ func pyParamShape(decl *sitter.Node, src []byte) (string, string, bool) {
 				typ = strings.TrimSpace(c.Content(src))
 			case "list_splat_pattern":
 				variadic = true
-				for j := 0; j < int(c.NamedChildCount()); j++ {
+				for j, _nc := 0, int(c.NamedChildCount()); j < _nc; j++ {
 					cc := c.NamedChild(j)
 					if cc != nil && cc.Type() == "identifier" {
 						name = cc.Content(src)
@@ -222,7 +222,7 @@ func pyParamShape(decl *sitter.Node, src []byte) (string, string, bool) {
 				}
 			case "dictionary_splat_pattern":
 				variadic = true
-				for j := 0; j < int(c.NamedChildCount()); j++ {
+				for j, _nc := 0, int(c.NamedChildCount()); j < _nc; j++ {
 					cc := c.NamedChild(j)
 					if cc != nil && cc.Type() == "identifier" {
 						name = cc.Content(src)
@@ -248,7 +248,7 @@ func pyParamShape(decl *sitter.Node, src []byte) (string, string, bool) {
 		return name, typ, false
 	case "list_splat_pattern":
 		// *args bare (no annotation)
-		for i := 0; i < int(decl.NamedChildCount()); i++ {
+		for i, _nc := 0, int(decl.NamedChildCount()); i < _nc; i++ {
 			c := decl.NamedChild(i)
 			if c != nil && c.Type() == "identifier" {
 				return c.Content(src), "", true
@@ -256,7 +256,7 @@ func pyParamShape(decl *sitter.Node, src []byte) (string, string, bool) {
 		}
 	case "dictionary_splat_pattern":
 		// **kwargs bare
-		for i := 0; i < int(decl.NamedChildCount()); i++ {
+		for i, _nc := 0, int(decl.NamedChildCount()); i < _nc; i++ {
 			c := decl.NamedChild(i)
 			if c != nil && c.Type() == "identifier" {
 				return c.Content(src), "", true
@@ -267,7 +267,7 @@ func pyParamShape(decl *sitter.Node, src []byte) (string, string, bool) {
 }
 
 func pyReturnTypeRaw(funcNode *sitter.Node, src []byte) string {
-	for i := 0; i < int(funcNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(funcNode.NamedChildCount()); i < _nc; i++ {
 		c := funcNode.NamedChild(i)
 		if c != nil && c.Type() == "type" {
 			return strings.TrimSpace(c.Content(src))
@@ -329,7 +329,7 @@ func emitPyGenericParamNodes(ownerID string, funcNode *sitter.Node, src []byte, 
 	if tparams == nil {
 		return
 	}
-	for i := 0; i < int(tparams.NamedChildCount()); i++ {
+	for i, _nc := 0, int(tparams.NamedChildCount()); i < _nc; i++ {
 		tp := tparams.NamedChild(i)
 		if tp == nil || tp.Type() != "type_parameter" {
 			continue
@@ -340,7 +340,7 @@ func emitPyGenericParamNodes(ownerID string, funcNode *sitter.Node, src []byte, 
 		}
 		if name == "" {
 			// Fallback: first identifier child.
-			for j := 0; j < int(tp.NamedChildCount()); j++ {
+			for j, _nc := 0, int(tp.NamedChildCount()); j < _nc; j++ {
 				c := tp.NamedChild(j)
 				if c != nil && c.Type() == "identifier" {
 					name = c.Content(src)

--- a/internal/parser/languages/py_pubsub.go
+++ b/internal/parser/languages/py_pubsub.go
@@ -56,7 +56,7 @@ func firstPyPubsubTopicArg(callExpr *sitter.Node, src []byte) string {
 	if args == nil {
 		return ""
 	}
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		c := args.NamedChild(i)
 		if c == nil {
 			continue
@@ -92,7 +92,7 @@ func firstPyPubsubTopicArg(callExpr *sitter.Node, src []byte) string {
 // literal content — callers gate on the method classification, not the
 // string shape, and a stable-enough topic name is the common case.
 func pyStringLiteralContent(strNode *sitter.Node, src []byte) string {
-	for i := 0; i < int(strNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(strNode.NamedChildCount()); i < _nc; i++ {
 		c := strNode.NamedChild(i)
 		if c == nil {
 			continue

--- a/internal/parser/languages/python.go
+++ b/internal/parser/languages/python.go
@@ -509,7 +509,7 @@ func pyWalkRaises(node *sitter.Node, src []byte, fromID, filePath string, fromLi
 		}
 		return
 	}
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		c := node.NamedChild(i)
 		// Don't descend into nested function/class bodies — their raises
 		// belong to those functions, not to us.
@@ -528,7 +528,7 @@ func pyWalkRaises(node *sitter.Node, src []byte, fromID, filePath string, fromLi
 // and chained `raise X from Y` (we record X). Returns "" for bare
 // `raise` (re-raise).
 func pyRaiseExceptionName(raise *sitter.Node, src []byte) string {
-	for i := 0; i < int(raise.NamedChildCount()); i++ {
+	for i, _nc := 0, int(raise.NamedChildCount()); i < _nc; i++ {
 		c := raise.NamedChild(i)
 		if c == nil {
 			continue
@@ -603,7 +603,7 @@ func pyDecoratorNodes(defNode *sitter.Node) []*sitter.Node {
 		return nil
 	}
 	var out []*sitter.Node
-	for i := 0; i < int(parent.ChildCount()); i++ {
+	for i, _nc := 0, int(parent.ChildCount()); i < _nc; i++ {
 		c := parent.Child(i)
 		if c != nil && c.Type() == "decorator" {
 			out = append(out, c)
@@ -634,7 +634,7 @@ func pyDecoratorNameAndArgs(dec *sitter.Node, src []byte) (string, string) {
 	if dec == nil {
 		return "", ""
 	}
-	for i := 0; i < int(dec.NamedChildCount()); i++ {
+	for i, _nc := 0, int(dec.NamedChildCount()); i < _nc; i++ {
 		c := dec.NamedChild(i)
 		if c == nil {
 			continue
@@ -673,7 +673,7 @@ func pyDocstringFromDef(defNode *sitter.Node, src []byte) string {
 	if body == nil {
 		return ""
 	}
-	for i := 0; i < int(body.NamedChildCount()); i++ {
+	for i, _nc := 0, int(body.NamedChildCount()); i < _nc; i++ {
 		stmt := body.NamedChild(i)
 		if stmt == nil {
 			continue
@@ -682,7 +682,7 @@ func pyDocstringFromDef(defNode *sitter.Node, src []byte) string {
 			return ""
 		}
 		// Walk into expression_statement to find a string literal.
-		for j := 0; j < int(stmt.NamedChildCount()); j++ {
+		for j, _nc := 0, int(stmt.NamedChildCount()); j < _nc; j++ {
 			c := stmt.NamedChild(j)
 			if c == nil {
 				continue
@@ -711,7 +711,7 @@ func (e *PythonExtractor) emitImport(m parser.QueryResult, filePath, fileID stri
 		return
 	}
 	stmt := def.Node
-	for i := 0; i < int(stmt.NamedChildCount()); i++ {
+	for i, _nc := 0, int(stmt.NamedChildCount()); i < _nc; i++ {
 		child := stmt.NamedChild(i)
 		switch child.Type() {
 		case "dotted_name":
@@ -723,7 +723,7 @@ func (e *PythonExtractor) emitImport(m parser.QueryResult, filePath, fileID stri
 			imports[alias] = dotted
 		case "aliased_import":
 			var modulePath, alias string
-			for j := 0; j < int(child.NamedChildCount()); j++ {
+			for j, _nc := 0, int(child.NamedChildCount()); j < _nc; j++ {
 				cc := child.NamedChild(j)
 				switch cc.Type() {
 				case "dotted_name":
@@ -764,7 +764,7 @@ func (e *PythonExtractor) emitImportFrom(m parser.QueryResult, filePath, fileID 
 	// the optional `as <alias>`. `wildcard_import` (`from X import *`)
 	// is intentionally skipped — there's no specific name to bind.
 	moduleSeen := false
-	for i := 0; i < int(stmt.NamedChildCount()); i++ {
+	for i, _nc := 0, int(stmt.NamedChildCount()); i < _nc; i++ {
 		child := stmt.NamedChild(i)
 		switch child.Type() {
 		case "dotted_name":
@@ -779,7 +779,7 @@ func (e *PythonExtractor) emitImportFrom(m parser.QueryResult, filePath, fileID 
 			imports[name] = mod.Text + "." + name
 		case "aliased_import":
 			var importedName, alias string
-			for j := 0; j < int(child.NamedChildCount()); j++ {
+			for j, _nc := 0, int(child.NamedChildCount()); j < _nc; j++ {
 				cc := child.NamedChild(j)
 				switch cc.Type() {
 				case "dotted_name":
@@ -816,7 +816,7 @@ func (e *PythonExtractor) emitImportFromRelative(m parser.QueryResult, filePath,
 	relNode := relCap.Node
 	dots := 0
 	modPath := ""
-	for i := 0; i < int(relNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(relNode.NamedChildCount()); i < _nc; i++ {
 		child := relNode.NamedChild(i)
 		switch child.Type() {
 		case "import_prefix":
@@ -829,7 +829,7 @@ func (e *PythonExtractor) emitImportFromRelative(m parser.QueryResult, filePath,
 	// scan all children for `.` tokens when the named-child walk yields
 	// zero dots so we don't silently drop `from . import x`.
 	if dots == 0 {
-		for i := 0; i < int(relNode.ChildCount()); i++ {
+		for i, _nc := 0, int(relNode.ChildCount()); i < _nc; i++ {
 			child := relNode.Child(i)
 			if child.Type() == "." {
 				dots++
@@ -885,7 +885,7 @@ func (e *PythonExtractor) emitImportFromRelative(m parser.QueryResult, filePath,
 			Kind: graph.EdgeImports, FilePath: filePath, Line: importLine,
 		})
 	}
-	for i := 0; i < int(stmt.NamedChildCount()); i++ {
+	for i, _nc := 0, int(stmt.NamedChildCount()); i < _nc; i++ {
 		child := stmt.NamedChild(i)
 		switch child.Type() {
 		case "relative_import":
@@ -900,7 +900,7 @@ func (e *PythonExtractor) emitImportFromRelative(m parser.QueryResult, filePath,
 			emitSubmodule(name, "")
 		case "aliased_import":
 			var importedName, alias string
-			for j := 0; j < int(child.NamedChildCount()); j++ {
+			for j, _nc := 0, int(child.NamedChildCount()); j < _nc; j++ {
 				cc := child.NamedChild(j)
 				switch cc.Type() {
 				case "dotted_name":
@@ -1087,7 +1087,7 @@ func firstIdentifierArg(callNode *sitter.Node, src []byte) string {
 	if args == nil {
 		return ""
 	}
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		arg := args.NamedChild(i)
 		if arg == nil {
 			continue
@@ -1108,7 +1108,7 @@ func firstIdentifierArg(callNode *sitter.Node, src []byte) string {
 // extractPyReturnType walks a function_definition node for a return_type child
 // (the `-> Type` annotation) and returns the normalized type name.
 func extractPyReturnType(funcNode *sitter.Node, src []byte) string {
-	for i := 0; i < int(funcNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(funcNode.NamedChildCount()); i < _nc; i++ {
 		child := funcNode.NamedChild(i)
 		if child.Type() == "type" {
 			// Check if preceding sibling token is "->".

--- a/internal/parser/languages/python_orm.go
+++ b/internal/parser/languages/python_orm.go
@@ -113,7 +113,7 @@ func pyClassBaseNames(classNode *sitter.Node, src []byte) []string {
 		return nil
 	}
 	var out []string
-	for i := 0; i < int(supers.NamedChildCount()); i++ {
+	for i, _nc := 0, int(supers.NamedChildCount()); i < _nc; i++ {
 		c := supers.NamedChild(i)
 		if c == nil {
 			continue
@@ -171,7 +171,7 @@ func pyORMFlavor(bases []string) string {
 // the attribute the table came from (`__tablename__` / `db_table`).
 // Empty name when neither is set.
 func pyClassExplicitTableName(body *sitter.Node, src []byte) (string, string) {
-	for i := 0; i < int(body.NamedChildCount()); i++ {
+	for i, _nc := 0, int(body.NamedChildCount()); i < _nc; i++ {
 		stmt := body.NamedChild(i)
 		if stmt == nil {
 			continue
@@ -193,7 +193,7 @@ func pyClassExplicitTableName(body *sitter.Node, src []byte) (string, string) {
 			if metaBody == nil {
 				continue
 			}
-			for j := 0; j < int(metaBody.NamedChildCount()); j++ {
+			for j, _nc := 0, int(metaBody.NamedChildCount()); j < _nc; j++ {
 				sub := metaBody.NamedChild(j)
 				if sub == nil {
 					continue
@@ -259,7 +259,7 @@ func pyAssignmentStringLiteral(stmt *sitter.Node, src []byte) (string, bool) {
 	}
 	// Walk the string node to find the string_content child.
 	var content string
-	for i := 0; i < int(right.NamedChildCount()); i++ {
+	for i, _nc := 0, int(right.NamedChildCount()); i < _nc; i++ {
 		c := right.NamedChild(i)
 		if c != nil && c.Type() == "string_content" {
 			content = c.Content(src)

--- a/internal/parser/languages/python_typeuse.go
+++ b/internal/parser/languages/python_typeuse.go
@@ -115,7 +115,7 @@ func emitPythonReferenceForms(root *sitter.Node, src []byte, filePath, fileID st
 // for a wrapper like `List[Foo]` yields the inner element (`Foo`).
 func emitPyGenericArgReferences(tparam *sitter.Node, src []byte, emit func(string, int, graph.EdgeKind, string)) {
 	line := int(tparam.StartPoint().Row) + 1
-	for i := 0; i < int(tparam.NamedChildCount()); i++ {
+	for i, _nc := 0, int(tparam.NamedChildCount()); i < _nc; i++ {
 		c := tparam.NamedChild(i)
 		if c == nil || c.Type() != "type" {
 			continue
@@ -192,7 +192,7 @@ func emitPyTypeTestArgs(call *sitter.Node, src []byte, line int, emit func(strin
 	}
 	// Collect positional args (skip keyword_argument and the separators).
 	var positional []*sitter.Node
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		c := args.NamedChild(i)
 		if c == nil {
 			continue
@@ -220,7 +220,7 @@ func emitPyTypeOperand(n *sitter.Node, src []byte, line int, emit func(string, i
 			emit(a.Content(src), line, graph.EdgeReferences, "cast")
 		}
 	case "tuple", "parenthesized_expression":
-		for i := 0; i < int(n.NamedChildCount()); i++ {
+		for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 			emitPyTypeOperand(n.NamedChild(i), src, line, emit)
 		}
 	}
@@ -235,7 +235,7 @@ func emitPyInheritanceReferences(class *sitter.Node, src []byte, emit func(strin
 		return
 	}
 	line := int(class.StartPoint().Row) + 1
-	for i := 0; i < int(supers.NamedChildCount()); i++ {
+	for i, _nc := 0, int(supers.NamedChildCount()); i < _nc; i++ {
 		c := supers.NamedChild(i)
 		if c == nil {
 			continue
@@ -291,7 +291,7 @@ func emitPyStaticAccessReference(attr *sitter.Node, src []byte, emit func(string
 // `@app.route`) are excluded by the Capitalization gate.
 func emitPyDecoratorReference(dec *sitter.Node, src []byte, emit func(string, int, graph.EdgeKind, string)) {
 	line := int(dec.StartPoint().Row) + 1
-	for i := 0; i < int(dec.NamedChildCount()); i++ {
+	for i, _nc := 0, int(dec.NamedChildCount()); i < _nc; i++ {
 		c := dec.NamedChild(i)
 		if c == nil {
 			continue

--- a/internal/parser/languages/r.go
+++ b/internal/parser/languages/r.go
@@ -245,7 +245,7 @@ func (e *RExtractor) extractRClassSystems(src []byte, filePath string, res *pars
 				}
 			}
 		}
-		for i := 0; i < int(n.ChildCount()); i++ {
+		for i, _nc := 0, int(n.ChildCount()); i < _nc; i++ {
 			walk(n.Child(i))
 		}
 	}
@@ -319,7 +319,7 @@ func (e *RExtractor) extractRNamespaceCalls(src []byte, filePath string, res *pa
 				}
 			}
 		}
-		for i := 0; i < int(n.ChildCount()); i++ {
+		for i, _nc := 0, int(n.ChildCount()); i < _nc; i++ {
 			walk(n.Child(i))
 		}
 	}
@@ -331,7 +331,7 @@ func (e *RExtractor) extractRNamespaceCalls(src []byte, filePath string, res *pa
 // node — the package + function, or the receiver + member.
 func rNamespaceParts(op *sitter.Node, src []byte) (string, string) {
 	var ids []string
-	for i := 0; i < int(op.ChildCount()); i++ {
+	for i, _nc := 0, int(op.ChildCount()); i < _nc; i++ {
 		if c := op.Child(i); c != nil && c.Type() == "identifier" {
 			ids = append(ids, c.Content(src))
 		}
@@ -344,7 +344,7 @@ func rNamespaceParts(op *sitter.Node, src []byte) (string, string) {
 
 // rCallee returns the function name of an R call (its leading identifier).
 func rCallee(call *sitter.Node, src []byte) string {
-	for i := 0; i < int(call.ChildCount()); i++ {
+	for i, _nc := 0, int(call.ChildCount()); i < _nc; i++ {
 		c := call.Child(i)
 		if c.Type() == "identifier" {
 			return c.Content(src)
@@ -368,7 +368,7 @@ type rArg struct {
 // rCallArgs parses an R call's argument list into name/value pairs.
 func rCallArgs(call *sitter.Node, src []byte) []rArg {
 	var argsNode *sitter.Node
-	for i := 0; i < int(call.ChildCount()); i++ {
+	for i, _nc := 0, int(call.ChildCount()); i < _nc; i++ {
 		if call.Child(i).Type() == "arguments" {
 			argsNode = call.Child(i)
 			break
@@ -378,13 +378,13 @@ func rCallArgs(call *sitter.Node, src []byte) []rArg {
 		return nil
 	}
 	var out []rArg
-	for i := 0; i < int(argsNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(argsNode.NamedChildCount()); i < _nc; i++ {
 		arg := argsNode.NamedChild(i)
 		if arg.Type() != "argument" {
 			continue
 		}
 		var kids []*sitter.Node
-		for j := 0; j < int(arg.NamedChildCount()); j++ {
+		for j, _nc := 0, int(arg.NamedChildCount()); j < _nc; j++ {
 			kids = append(kids, arg.NamedChild(j))
 		}
 		var a rArg
@@ -407,7 +407,7 @@ func rCallArgs(call *sitter.Node, src []byte) []rArg {
 }
 
 func rStringContent(strNode *sitter.Node, src []byte) string {
-	for i := 0; i < int(strNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(strNode.NamedChildCount()); i < _nc; i++ {
 		if c := strNode.NamedChild(i); c.Type() == "string_content" {
 			return c.Content(src)
 		}

--- a/internal/parser/languages/react_context_capture.go
+++ b/internal/parser/languages/react_context_capture.go
@@ -55,7 +55,7 @@ func captureReactContextRefs(result *parser.ExtractionResult, root *sitter.Node,
 // reactFirstIdentArg returns the first call argument when it is a bare
 // identifier (the context object passed to useContext), else "".
 func reactFirstIdentArg(args *sitter.Node, src []byte) string {
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		a := args.NamedChild(i)
 		if a == nil {
 			continue

--- a/internal/parser/languages/return_usage.go
+++ b/internal/parser/languages/return_usage.go
@@ -181,7 +181,7 @@ func classifyAssign(parent, child *sitter.Node, sinkField string, src []byte, sp
 		return graph.ReturnUsageAssigned
 	}
 	total, blank := 0, 0
-	for i := 0; i < int(parent.ChildCount()); i++ {
+	for i, _nc := 0, int(parent.ChildCount()); i < _nc; i++ {
 		if parent.FieldNameForChild(i) != sinkField {
 			continue
 		}
@@ -224,7 +224,7 @@ func countSinkLeaves(n *sitter.Node, src []byte, spec *returnUsageSpec) (total, 
 		return strings.TrimSpace(c.Content(src)) == "_"
 	}
 	if spec.sinkLists[n.Type()] {
-		for i := 0; i < int(n.ChildCount()); i++ {
+		for i, _nc := 0, int(n.ChildCount()); i < _nc; i++ {
 			c := n.Child(i)
 			if c == nil {
 				continue

--- a/internal/parser/languages/ruby.go
+++ b/internal/parser/languages/ruby.go
@@ -254,7 +254,7 @@ func (e *RubyExtractor) emitRubyMixin(macro, typeID string, call *sitter.Node, s
 		return false
 	}
 	emitted := false
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		arg := args.NamedChild(i)
 		if arg.Type() != "constant" && arg.Type() != "scope_resolution" {
 			continue
@@ -287,7 +287,7 @@ func applyRubyVisibility(root *sitter.Node, src []byte, filePath string, result 
 	}
 	var walk func(n *sitter.Node)
 	walk = func(n *sitter.Node) {
-		for i := 0; i < int(n.NamedChildCount()); i++ {
+		for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 			c := n.NamedChild(i)
 			if c.Type() == "class" || c.Type() == "module" {
 				nameNode := c.ChildByFieldName("name")
@@ -313,7 +313,7 @@ func applyRubyBodyVisibility(body *sitter.Node, src []byte, filePath, className 
 			n.Meta["visibility"] = vis
 		}
 	}
-	for i := 0; i < int(body.NamedChildCount()); i++ {
+	for i, _nc := 0, int(body.NamedChildCount()); i < _nc; i++ {
 		c := body.NamedChild(i)
 		switch c.Type() {
 		case "identifier":
@@ -331,7 +331,7 @@ func applyRubyBodyVisibility(body *sitter.Node, src []byte, filePath, className 
 			}
 			// Targeted form `private :a, :b` — flip only the named methods.
 			if args := c.ChildByFieldName("arguments"); args != nil {
-				for i := 0; i < int(args.NamedChildCount()); i++ {
+				for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 					for _, sym := range collectRubySymbols(args.NamedChild(i), src) {
 						setVis(sym, vis)
 					}
@@ -621,7 +621,7 @@ func emitRailsCallbacks(root *sitter.Node, src []byte, filePath string, result *
 			// this synthetic edge.
 			methodIDs := make(map[string]string)
 			var bodyStatements *sitter.Node
-			for i := 0; i < int(n.NamedChildCount()); i++ {
+			for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 				c := n.NamedChild(i)
 				if c != nil && c.Type() == "body_statement" {
 					bodyStatements = c
@@ -633,7 +633,7 @@ func emitRailsCallbacks(root *sitter.Node, src []byte, filePath string, result *
 			}
 			// Collect methods first so callback macros can resolve
 			// symbol names to concrete IDs.
-			for i := 0; i < int(bodyStatements.NamedChildCount()); i++ {
+			for i, _nc := 0, int(bodyStatements.NamedChildCount()); i < _nc; i++ {
 				c := bodyStatements.NamedChild(i)
 				if c == nil {
 					continue
@@ -653,7 +653,7 @@ func emitRailsCallbacks(root *sitter.Node, src []byte, filePath string, result *
 			// `before_action :a; before_action :b` ends up binding a
 			// to guard b and vice versa.
 			allCallbacks := make(map[string]struct{})
-			for i := 0; i < int(bodyStatements.NamedChildCount()); i++ {
+			for i, _nc := 0, int(bodyStatements.NamedChildCount()); i < _nc; i++ {
 				c := bodyStatements.NamedChild(i)
 				if c == nil || c.Type() != "call" {
 					continue
@@ -669,7 +669,7 @@ func emitRailsCallbacks(root *sitter.Node, src []byte, filePath string, result *
 				if args == nil {
 					continue
 				}
-				for i := 0; i < int(args.NamedChildCount()); i++ {
+				for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 					arg := args.NamedChild(i)
 					if arg != nil && arg.Type() == "simple_symbol" {
 						allCallbacks[strings.TrimPrefix(arg.Content(src), ":")] = struct{}{}
@@ -677,7 +677,7 @@ func emitRailsCallbacks(root *sitter.Node, src []byte, filePath string, result *
 				}
 			}
 			// Second pass: emit edges.
-			for i := 0; i < int(bodyStatements.NamedChildCount()); i++ {
+			for i, _nc := 0, int(bodyStatements.NamedChildCount()); i < _nc; i++ {
 				c := bodyStatements.NamedChild(i)
 				if c == nil || c.Type() != "call" {
 					continue
@@ -698,7 +698,7 @@ func emitRailsCallbacks(root *sitter.Node, src []byte, filePath string, result *
 			}
 			return
 		}
-		for i := 0; i < int(n.NamedChildCount()); i++ {
+		for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 			walk(n.NamedChild(i))
 		}
 	}
@@ -715,7 +715,7 @@ func emitRailsCallbackEdges(args *sitter.Node, src []byte, filePath string, line
 	exceptFilter := map[string]struct{}{}
 	hasOnly := false
 	hasExcept := false
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		arg := args.NamedChild(i)
 		if arg == nil {
 			continue
@@ -821,7 +821,7 @@ func collectRubySymbols(n *sitter.Node, src []byte) []string {
 	case "simple_symbol":
 		out = append(out, strings.TrimPrefix(n.Content(src), ":"))
 	case "array":
-		for i := 0; i < int(n.NamedChildCount()); i++ {
+		for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 			c := n.NamedChild(i)
 			if c != nil && c.Type() == "simple_symbol" {
 				out = append(out, strings.TrimPrefix(c.Content(src), ":"))

--- a/internal/parser/languages/ruby_orm.go
+++ b/internal/parser/languages/ruby_orm.go
@@ -99,7 +99,7 @@ func rubyClassExtendsActiveRecord(classNode *sitter.Node, src []byte) bool {
 // rubyClassBody returns the class's body_statement node, or nil when the
 // class is empty or shaped unexpectedly.
 func rubyClassBody(classNode *sitter.Node) *sitter.Node {
-	for i := 0; i < int(classNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(classNode.NamedChildCount()); i < _nc; i++ {
 		c := classNode.NamedChild(i)
 		if c != nil && c.Type() == "body_statement" {
 			return c
@@ -111,7 +111,7 @@ func rubyClassBody(classNode *sitter.Node) *sitter.Node {
 // rubyClassTableNameAssign returns the literal of a top-level
 // `self.table_name = "..."` assignment in body, or ("", "") when absent.
 func rubyClassTableNameAssign(body *sitter.Node, src []byte) (string, string) {
-	for i := 0; i < int(body.NamedChildCount()); i++ {
+	for i, _nc := 0, int(body.NamedChildCount()); i < _nc; i++ {
 		stmt := body.NamedChild(i)
 		if stmt == nil || stmt.Type() != "assignment" {
 			continue
@@ -137,7 +137,7 @@ func rubyClassTableNameAssign(body *sitter.Node, src []byte) (string, string) {
 // the literal characters. Strips surrounding quotes when no
 // string_content child is present.
 func rubyStringContent(node *sitter.Node, src []byte) string {
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		c := node.NamedChild(i)
 		if c != nil && c.Type() == "string_content" {
 			return c.Content(src)

--- a/internal/parser/languages/ruby_sidekiq.go
+++ b/internal/parser/languages/ruby_sidekiq.go
@@ -107,7 +107,7 @@ func sidekiqWorkerClass(classDecl *sitter.Node, src []byte) bool {
 	if body == nil {
 		return false
 	}
-	for i := 0; i < int(body.NamedChildCount()); i++ {
+	for i, _nc := 0, int(body.NamedChildCount()); i < _nc; i++ {
 		c := body.NamedChild(i)
 		if c == nil || (c.Type() != "call" && c.Type() != "command") {
 			continue
@@ -120,7 +120,7 @@ func sidekiqWorkerClass(classDecl *sitter.Node, src []byte) bool {
 		if args == nil {
 			continue
 		}
-		for j := 0; j < int(args.NamedChildCount()); j++ {
+		for j, _nc := 0, int(args.NamedChildCount()); j < _nc; j++ {
 			a := args.NamedChild(j)
 			if a != nil && sidekiqIncludes[strings.TrimSpace(a.Content(src))] {
 				return true
@@ -157,7 +157,7 @@ func sidekiqWalk(n *sitter.Node, fn func(*sitter.Node)) {
 		return
 	}
 	fn(n)
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		sidekiqWalk(n.NamedChild(i), fn)
 	}
 }

--- a/internal/parser/languages/rust.go
+++ b/internal/parser/languages/rust.go
@@ -466,7 +466,7 @@ func rustTypeParams(item *sitter.Node, src []byte) []map[string]string {
 	if tps == nil {
 		// Some grammar versions don't expose the field name; fall
 		// back to a child-type scan.
-		for i := 0; i < int(item.ChildCount()); i++ {
+		for i, _nc := 0, int(item.ChildCount()); i < _nc; i++ {
 			c := item.Child(i)
 			if c != nil && c.Type() == "type_parameters" {
 				tps = c
@@ -478,7 +478,7 @@ func rustTypeParams(item *sitter.Node, src []byte) []map[string]string {
 		return nil
 	}
 	var out []map[string]string
-	for i := 0; i < int(tps.NamedChildCount()); i++ {
+	for i, _nc := 0, int(tps.NamedChildCount()); i < _nc; i++ {
 		tp := tps.NamedChild(i)
 		if tp == nil {
 			continue
@@ -496,7 +496,7 @@ func rustTypeParams(item *sitter.Node, src []byte) []map[string]string {
 		// versions emit these as `constrained_type_parameter`;
 		// newer ones flatten them under a `type_parameter` node.
 		entry := map[string]string{}
-		for j := 0; j < int(tp.ChildCount()); j++ {
+		for j, _nc := 0, int(tp.ChildCount()); j < _nc; j++ {
 			c := tp.Child(j)
 			if c == nil {
 				continue
@@ -569,7 +569,7 @@ func rustRawReturnType(node *sitter.Node, src []byte) string {
 		return ""
 	}
 	pastArrow := false
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		child := node.Child(i)
 		if child == nil {
 			continue
@@ -692,7 +692,7 @@ func rustCollectAttributes(item *sitter.Node) []*sitter.Node {
 func emitRustAnnotationEdges(attrs []*sitter.Node, fromID, filePath string, src []byte, result *parser.ExtractionResult, seen map[string]bool) {
 	for _, attr := range attrs {
 		var attrNode *sitter.Node
-		for i := 0; i < int(attr.NamedChildCount()); i++ {
+		for i, _nc := 0, int(attr.NamedChildCount()); i < _nc; i++ {
 			c := attr.NamedChild(i)
 			if c != nil && c.Type() == "attribute" {
 				attrNode = c
@@ -728,7 +728,7 @@ func rustAttributeNameAndArgs(attr *sitter.Node, src []byte) (string, string) {
 		return "", ""
 	}
 	var name, args string
-	for i := 0; i < int(attr.ChildCount()); i++ {
+	for i, _nc := 0, int(attr.ChildCount()); i < _nc; i++ {
 		c := attr.Child(i)
 		if c == nil {
 			continue
@@ -756,7 +756,7 @@ func rustVisibility(item *sitter.Node, src []byte) string {
 	if item == nil {
 		return VisibilityPrivate
 	}
-	for i := 0; i < int(item.ChildCount()); i++ {
+	for i, _nc := 0, int(item.ChildCount()); i < _nc; i++ {
 		c := item.Child(i)
 		if c == nil {
 			continue
@@ -1044,7 +1044,7 @@ func extractRustReturnType(node *sitter.Node, src []byte) string {
 	// In tree-sitter-rust, function_item has children: fn, name, parameters, ->, type, block.
 	// Look for a type child after "->".
 	pastArrow := false
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		child := node.Child(i)
 		text := string(src[child.StartByte():child.EndByte()])
 		if text == "->" {

--- a/internal/parser/languages/rust_function_shape.go
+++ b/internal/parser/languages/rust_function_shape.go
@@ -110,7 +110,7 @@ func walkRustNodes(n *sitter.Node, visit func(*sitter.Node) bool) {
 	if !visit(n) {
 		return
 	}
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		walkRustNodes(n.NamedChild(i), visit)
 	}
 }
@@ -150,7 +150,7 @@ func rustExprTailName(expr *sitter.Node, src []byte) string {
 
 func emitRustParamNodes(ownerID string, params *sitter.Node, src []byte, filePath string, declLine int, result *parser.ExtractionResult) {
 	pos := 0
-	for i := 0; i < int(params.NamedChildCount()); i++ {
+	for i, _nc := 0, int(params.NamedChildCount()); i < _nc; i++ {
 		decl := params.NamedChild(i)
 		if decl == nil {
 			continue
@@ -226,7 +226,7 @@ func rustParamName(decl *sitter.Node, src []byte) string {
 		// Older grammar shapes; rare.
 	}
 	// Walk for identifier child (mut_pattern (identifier)).
-	for i := 0; i < int(pat.NamedChildCount()); i++ {
+	for i, _nc := 0, int(pat.NamedChildCount()); i < _nc; i++ {
 		c := pat.NamedChild(i)
 		if c != nil && c.Type() == "identifier" {
 			return c.Content(src)

--- a/internal/parser/languages/rust_typeuse.go
+++ b/internal/parser/languages/rust_typeuse.go
@@ -180,7 +180,7 @@ func emitRustReferenceForms(root *sitter.Node, funcRanges []funcRange, fileID, f
 			// `: Bound + Other` on a type parameter, supertrait
 			// (`trait X: Y`), or where-predicate. Each named type child is
 			// a bound the bearer inherits.
-			for i := 0; i < int(n.NamedChildCount()); i++ {
+			for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 				c := n.NamedChild(i)
 				if c == nil {
 					continue
@@ -244,7 +244,7 @@ func emitRustReferenceForms(root *sitter.Node, funcRanges []funcRange, fileID, f
 				}
 				emitRef(owner(line), canon, graph.RefContextGenericArg, line)
 			}
-			for i := 0; i < int(n.NamedChildCount()); i++ {
+			for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 				c := n.NamedChild(i)
 				if c == nil {
 					continue
@@ -289,7 +289,7 @@ func rustDeclaredTypeParams(root *sitter.Node, src []byte) map[string]bool {
 		if n.Type() != "type_parameters" {
 			return true
 		}
-		for i := 0; i < int(n.NamedChildCount()); i++ {
+		for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 			tp := n.NamedChild(i)
 			if tp == nil {
 				continue
@@ -302,7 +302,7 @@ func rustDeclaredTypeParams(root *sitter.Node, src []byte) map[string]bool {
 			default:
 				// Constrained (`<T: Clone>`, `<T = u8>`) — the param name is
 				// the first type_identifier child.
-				for j := 0; j < int(tp.NamedChildCount()); j++ {
+				for j, _nc := 0, int(tp.NamedChildCount()); j < _nc; j++ {
 					c := tp.NamedChild(j)
 					if c != nil && c.Type() == "type_identifier" {
 						params[strings.TrimSpace(c.Content(src))] = true
@@ -320,7 +320,7 @@ func rustDeclaredTypeParams(root *sitter.Node, src []byte) map[string]bool {
 // `#[derive(A, B)]` attribute_item and emits a static_access reference for
 // each Capitalized name. Non-derive attributes contribute nothing.
 func emitRustDeriveRefs(attrItem *sitter.Node, ownerID string, src []byte, emitRef func(ownerID, typeName, useKind string, line int), line int) {
-	for i := 0; i < int(attrItem.NamedChildCount()); i++ {
+	for i, _nc := 0, int(attrItem.NamedChildCount()); i < _nc; i++ {
 		attr := attrItem.NamedChild(i)
 		if attr == nil || attr.Type() != "attribute" {
 			continue
@@ -330,12 +330,12 @@ func emitRustDeriveRefs(attrItem *sitter.Node, ownerID string, src []byte, emitR
 		if head == nil || head.Content(src) != "derive" {
 			continue
 		}
-		for j := 0; j < int(attr.NamedChildCount()); j++ {
+		for j, _nc := 0, int(attr.NamedChildCount()); j < _nc; j++ {
 			c := attr.NamedChild(j)
 			if c == nil || c.Type() != "token_tree" {
 				continue
 			}
-			for k := 0; k < int(c.NamedChildCount()); k++ {
+			for k, _nc := 0, int(c.NamedChildCount()); k < _nc; k++ {
 				id := c.NamedChild(k)
 				if id == nil {
 					continue

--- a/internal/parser/languages/scala.go
+++ b/internal/parser/languages/scala.go
@@ -115,10 +115,10 @@ func (e *ScalaExtractor) extractTrait(
 
 	// Collect method names from the template_body.
 	var methodNames []string
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		child := node.Child(i)
 		if child.Type() == "template_body" {
-			for j := 0; j < int(child.ChildCount()); j++ {
+			for j, _nc := 0, int(child.ChildCount()); j < _nc; j++ {
 				member := child.Child(j)
 				if member.Type() == "function_declaration" || member.Type() == "function_definition" {
 					mName := scalaFindChildIdentifier(member, src)
@@ -245,12 +245,12 @@ func (e *ScalaExtractor) extractMembersFromBody(
 	ownerID, ownerName string,
 	result *parser.ExtractionResult, seen, annotationSeen map[string]bool,
 ) {
-	for i := 0; i < int(parent.ChildCount()); i++ {
+	for i, _nc := 0, int(parent.ChildCount()); i < _nc; i++ {
 		child := parent.Child(i)
 		if child.Type() != "template_body" {
 			continue
 		}
-		for j := 0; j < int(child.ChildCount()); j++ {
+		for j, _nc := 0, int(child.ChildCount()); j < _nc; j++ {
 			member := child.Child(j)
 			switch member.Type() {
 			case "val_definition", "var_definition", "val_declaration", "var_declaration":
@@ -411,7 +411,7 @@ func (e *ScalaExtractor) extractTopLevelValVar(member *sitter.Node, src []byte, 
 // so `value.m` resolves to it even though m is declared outside T's body.
 func (e *ScalaExtractor) extractExtension(node *sitter.Node, src []byte, filePath string, fileNode *graph.Node, result *parser.ExtractionResult, seen map[string]bool) {
 	recv := scalaExtensionReceiver(node, src)
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		fn := node.NamedChild(i)
 		if fn.Type() != "function_definition" && fn.Type() != "function_declaration" {
 			continue
@@ -452,17 +452,17 @@ func (e *ScalaExtractor) extractExtension(node *sitter.Node, src []byte, filePat
 // scalaExtensionReceiver returns the extended type named in an extension's
 // receiver parameter `(x: T)`, or "".
 func scalaExtensionReceiver(node *sitter.Node, src []byte) string {
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		p := node.NamedChild(i)
 		if p.Type() != "parameters" {
 			continue
 		}
-		for j := 0; j < int(p.NamedChildCount()); j++ {
+		for j, _nc := 0, int(p.NamedChildCount()); j < _nc; j++ {
 			param := p.NamedChild(j)
 			if param.Type() != "parameter" {
 				continue
 			}
-			for k := 0; k < int(param.NamedChildCount()); k++ {
+			for k, _nc := 0, int(param.NamedChildCount()); k < _nc; k++ {
 				t := param.NamedChild(k)
 				if t.Type() == "type_identifier" || t.Type() == "generic_type" {
 					return scalaBaseType(strings.TrimSpace(t.Content(src)))
@@ -475,12 +475,12 @@ func scalaExtensionReceiver(node *sitter.Node, src []byte) string {
 
 // scalaPackageName returns the dotted name of the file's `package` clause, or "".
 func scalaPackageName(root *sitter.Node, src []byte) string {
-	for i := 0; i < int(root.NamedChildCount()); i++ {
+	for i, _nc := 0, int(root.NamedChildCount()); i < _nc; i++ {
 		c := root.NamedChild(i)
 		if c.Type() != "package_clause" {
 			continue
 		}
-		for j := 0; j < int(c.NamedChildCount()); j++ {
+		for j, _nc := 0, int(c.NamedChildCount()); j < _nc; j++ {
 			id := c.NamedChild(j)
 			if id.Type() == "package_identifier" {
 				return strings.TrimSpace(id.Content(src))
@@ -547,7 +547,7 @@ func (e *ScalaExtractor) extractImport(
 	result *parser.ExtractionResult,
 ) {
 	var parts []string
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		child := node.Child(i)
 		if child.Type() == "identifier" {
 			parts = append(parts, child.Content(src))
@@ -655,7 +655,7 @@ func (e *ScalaExtractor) extractCall(
 // scalaFindChildIdentifier finds the first direct child of type "identifier"
 // and returns its text content.
 func scalaFindChildIdentifier(node *sitter.Node, src []byte) string {
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		child := node.Child(i)
 		if child.Type() == "identifier" {
 			return child.Content(src)

--- a/internal/parser/languages/scala_annotations.go
+++ b/internal/parser/languages/scala_annotations.go
@@ -33,7 +33,7 @@ func emitScalaAnnotationEdges(
 	if defNode == nil || fromID == "" {
 		return
 	}
-	for i := 0; i < int(defNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(defNode.NamedChildCount()); i < _nc; i++ {
 		c := defNode.NamedChild(i)
 		if c == nil || c.Type() != "annotation" {
 			continue
@@ -62,7 +62,7 @@ func scalaAnnotationNameAndArgs(annot *sitter.Node, src []byte) (string, string)
 		return "", ""
 	}
 	var name, args string
-	for i := 0; i < int(annot.NamedChildCount()); i++ {
+	for i, _nc := 0, int(annot.NamedChildCount()); i < _nc; i++ {
 		c := annot.NamedChild(i)
 		if c == nil {
 			continue

--- a/internal/parser/languages/scala_reffrm.go
+++ b/internal/parser/languages/scala_reffrm.go
@@ -180,12 +180,12 @@ func emitScalaInheritEdges(def *sitter.Node, filePath string, src []byte, emit f
 		return
 	}
 	ownerID := filePath + "::" + name
-	for i := 0; i < int(def.NamedChildCount()); i++ {
+	for i, _nc := 0, int(def.NamedChildCount()); i < _nc; i++ {
 		c := def.NamedChild(i)
 		if c == nil || c.Type() != "extends_clause" {
 			continue
 		}
-		for j := 0; j < int(c.NamedChildCount()); j++ {
+		for j, _nc := 0, int(c.NamedChildCount()); j < _nc; j++ {
 			t := c.NamedChild(j)
 			if t == nil {
 				continue
@@ -203,7 +203,7 @@ func emitScalaInheritEdges(def *sitter.Node, filePath string, src []byte, emit f
 // instance_expression — the type_identifier / generic_type child following the
 // `new` keyword, generics intact — or "".
 func scalaInstanceType(n *sitter.Node, src []byte) string {
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		c := n.NamedChild(i)
 		if c == nil {
 			continue
@@ -220,7 +220,7 @@ func scalaInstanceType(n *sitter.Node, src []byte) string {
 // `x.isInstanceOf[...]` / `x.asInstanceOf[...]` invocation, by reading the
 // method-name identifier of its field_expression callee.
 func scalaIsInstanceCheck(n *sitter.Node, src []byte) bool {
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		fe := n.NamedChild(i)
 		if fe == nil || fe.Type() != "field_expression" {
 			continue
@@ -245,12 +245,12 @@ func scalaIsInstanceCheck(n *sitter.Node, src []byte) bool {
 // child (`[Foo, Bar]` -> ["Foo", "Bar"]), generics intact, or nil.
 func scalaTypeArgNames(n *sitter.Node, src []byte) []string {
 	var out []string
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		ta := n.NamedChild(i)
 		if ta == nil || ta.Type() != "type_arguments" {
 			continue
 		}
-		for j := 0; j < int(ta.NamedChildCount()); j++ {
+		for j, _nc := 0, int(ta.NamedChildCount()); j < _nc; j++ {
 			t := ta.NamedChild(j)
 			if t == nil {
 				continue
@@ -274,12 +274,12 @@ func scalaTypeArgNames(n *sitter.Node, src []byte) []string {
 // filters primitives, so this helper only locates the argument heads.
 func scalaGenericArgHeads(n *sitter.Node, src []byte) []string {
 	var out []string
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		ta := n.NamedChild(i)
 		if ta == nil || ta.Type() != "type_arguments" {
 			continue
 		}
-		for j := 0; j < int(ta.NamedChildCount()); j++ {
+		for j, _nc := 0, int(ta.NamedChildCount()); j < _nc; j++ {
 			arg := ta.NamedChild(j)
 			if arg == nil {
 				continue
@@ -304,7 +304,7 @@ func scalaGenericArgHeads(n *sitter.Node, src []byte) []string {
 // scalaGenericHead returns the head type_identifier text of a `generic_type`
 // node (`Seq[Repo]` -> "Seq"), or "".
 func scalaGenericHead(n *sitter.Node, src []byte) string {
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		c := n.NamedChild(i)
 		if c == nil {
 			continue
@@ -319,7 +319,7 @@ func scalaGenericHead(n *sitter.Node, src []byte) string {
 // scalaPatternType returns the type a typed_pattern matches against
 // (`case d: Foo` -> "Foo"), generics intact, or "".
 func scalaPatternType(n *sitter.Node, src []byte) string {
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		c := n.NamedChild(i)
 		if c == nil {
 			continue

--- a/internal/parser/languages/scala_typeuse.go
+++ b/internal/parser/languages/scala_typeuse.go
@@ -133,7 +133,7 @@ func isScalaPrimitive(t string) bool {
 // sits as a sibling of the bound identifier in the tree-sitter shape. Returns
 // "" when the val/var has no declared type (inferred).
 func scalaTypeAnnotationRaw(member *sitter.Node, src []byte) string {
-	for i := 0; i < int(member.NamedChildCount()); i++ {
+	for i, _nc := 0, int(member.NamedChildCount()); i < _nc; i++ {
 		c := member.NamedChild(i)
 		if c == nil {
 			continue
@@ -152,7 +152,7 @@ func scalaTypeAnnotationRaw(member *sitter.Node, src []byte) string {
 // "". The node shape is `name: Type` with the type as a sibling of the bound
 // identifier.
 func scalaParamTypeText(param *sitter.Node, src []byte) string {
-	for i := 0; i < int(param.NamedChildCount()); i++ {
+	for i, _nc := 0, int(param.NamedChildCount()); i < _nc; i++ {
 		c := param.NamedChild(i)
 		if c == nil {
 			continue
@@ -171,7 +171,7 @@ func scalaParamTypeText(param *sitter.Node, src []byte) string {
 // nil when the def has no declared return type.
 func scalaReturnTypeNode(fn *sitter.Node) *sitter.Node {
 	seenParams := false
-	for i := 0; i < int(fn.NamedChildCount()); i++ {
+	for i, _nc := 0, int(fn.NamedChildCount()); i < _nc; i++ {
 		c := fn.NamedChild(i)
 		if c == nil {
 			continue
@@ -200,12 +200,12 @@ func emitScalaDefTypeUses(fn *sitter.Node, ownerID, filePath string, src []byte,
 	if fn == nil || ownerID == "" {
 		return
 	}
-	for i := 0; i < int(fn.NamedChildCount()); i++ {
+	for i, _nc := 0, int(fn.NamedChildCount()); i < _nc; i++ {
 		c := fn.NamedChild(i)
 		if c == nil || c.Type() != "parameters" {
 			continue
 		}
-		for j := 0; j < int(c.NamedChildCount()); j++ {
+		for j, _nc := 0, int(c.NamedChildCount()); j < _nc; j++ {
 			p := c.NamedChild(j)
 			if p == nil || p.Type() != "parameter" {
 				continue
@@ -227,12 +227,12 @@ func emitScalaClassParamTypeUses(classNode *sitter.Node, ownerID, filePath strin
 	if classNode == nil || ownerID == "" {
 		return
 	}
-	for i := 0; i < int(classNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(classNode.NamedChildCount()); i < _nc; i++ {
 		c := classNode.NamedChild(i)
 		if c == nil || c.Type() != "class_parameters" {
 			continue
 		}
-		for j := 0; j < int(c.NamedChildCount()); j++ {
+		for j, _nc := 0, int(c.NamedChildCount()); j < _nc; j++ {
 			p := c.NamedChild(j)
 			if p == nil || p.Type() != "class_parameter" {
 				continue

--- a/internal/parser/languages/sql.go
+++ b/internal/parser/languages/sql.go
@@ -57,12 +57,12 @@ func (e *SQLExtractor) Extract(filePath string, src []byte) (*parser.ExtractionR
 	seen := make(map[string]bool)
 
 	// Walk top-level statements.
-	for i := 0; i < int(root.NamedChildCount()); i++ {
+	for i, _nc := 0, int(root.NamedChildCount()); i < _nc; i++ {
 		stmt := root.NamedChild(i)
 		if stmt.Type() != "statement" {
 			continue
 		}
-		for j := 0; j < int(stmt.NamedChildCount()); j++ {
+		for j, _nc := 0, int(stmt.NamedChildCount()); j < _nc; j++ {
 			child := stmt.NamedChild(j)
 			switch child.Type() {
 			case "create_table":
@@ -100,10 +100,10 @@ func (e *SQLExtractor) extractCreateTable(node *sitter.Node, src []byte, filePat
 	})
 
 	// Extract column names as variables with EdgeMemberOf.
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		child := node.NamedChild(i)
 		if child.Type() == "column_definitions" {
-			for k := 0; k < int(child.NamedChildCount()); k++ {
+			for k, _nc := 0, int(child.NamedChildCount()); k < _nc; k++ {
 				col := child.NamedChild(k)
 				if col.Type() == "column_definition" {
 					colName := firstNamedChildOfType(col, "identifier", src)
@@ -203,7 +203,7 @@ func (e *SQLExtractor) extractCreateTrigger(node *sitter.Node, src []byte, fileP
 // findObjectName extracts the name from a CREATE statement by finding
 // the first object_reference > identifier child.
 func findObjectName(node *sitter.Node, src []byte) string {
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		child := node.NamedChild(i)
 		if child.Type() == "object_reference" {
 			return firstNamedChildOfType(child, "identifier", src)
@@ -214,7 +214,7 @@ func findObjectName(node *sitter.Node, src []byte) string {
 }
 
 func firstNamedChildOfType(node *sitter.Node, nodeType string, src []byte) string {
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		child := node.NamedChild(i)
 		if child.Type() == nodeType {
 			return child.Content(src)

--- a/internal/parser/languages/swift.go
+++ b/internal/parser/languages/swift.go
@@ -334,13 +334,13 @@ func (e *SwiftExtractor) emitTypeContainer(m parser.QueryResult, prefix, filePat
 	if prefix != "enum" || bodyNode == nil {
 		return
 	}
-	for i := 0; i < int(bodyNode.ChildCount()); i++ {
+	for i, _nc := 0, int(bodyNode.ChildCount()); i < _nc; i++ {
 		entry := bodyNode.Child(i)
 		if entry == nil || entry.Type() != "enum_entry" {
 			continue
 		}
 		var caseName string
-		for j := 0; j < int(entry.ChildCount()); j++ {
+		for j, _nc := 0, int(entry.ChildCount()); j < _nc; j++ {
 			ch := entry.Child(j)
 			if ch != nil && ch.Type() == "simple_identifier" {
 				caseName = ch.Content(src)
@@ -563,7 +563,7 @@ func (e *SwiftExtractor) emitProperty(m parser.QueryResult, filePath, fileID str
 // swiftPropertyIsMutable reports whether a property is declared with `var`
 // (mutable) rather than `let`, reading the value_binding_pattern child.
 func swiftPropertyIsMutable(decl *sitter.Node, src []byte) bool {
-	for i := 0; i < int(decl.NamedChildCount()); i++ {
+	for i, _nc := 0, int(decl.NamedChildCount()); i < _nc; i++ {
 		if c := decl.NamedChild(i); c != nil && c.Type() == "value_binding_pattern" {
 			return strings.Contains(c.Content(src), "var")
 		}
@@ -574,7 +574,7 @@ func swiftPropertyIsMutable(decl *sitter.Node, src []byte) bool {
 // swiftPropertyType returns the base type named in a property's
 // type_annotation (`: [Foo]?` → "Foo"), or "" when the type is inferred.
 func swiftPropertyType(decl *sitter.Node, src []byte) string {
-	for i := 0; i < int(decl.NamedChildCount()); i++ {
+	for i, _nc := 0, int(decl.NamedChildCount()); i < _nc; i++ {
 		c := decl.NamedChild(i)
 		if c == nil || c.Type() != "type_annotation" {
 			continue
@@ -769,7 +769,7 @@ func swiftVisibility(decl *sitter.Node, src []byte) string {
 	if decl == nil {
 		return VisibilityInternal
 	}
-	for i := 0; i < int(decl.ChildCount()); i++ {
+	for i, _nc := 0, int(decl.ChildCount()); i < _nc; i++ {
 		c := decl.Child(i)
 		if c == nil {
 			continue

--- a/internal/parser/languages/swift_annotations.go
+++ b/internal/parser/languages/swift_annotations.go
@@ -40,7 +40,7 @@ func emitSwiftAnnotationEdges(
 		// Some declarations expose modifiers as a positional named
 		// child rather than via a named field; scan top-level
 		// children for a `modifiers` node as a fallback.
-		for i := 0; i < int(defNode.NamedChildCount()); i++ {
+		for i, _nc := 0, int(defNode.NamedChildCount()); i < _nc; i++ {
 			c := defNode.NamedChild(i)
 			if c != nil && c.Type() == "modifiers" {
 				mods = c
@@ -52,7 +52,7 @@ func emitSwiftAnnotationEdges(
 		return
 	}
 
-	for i := 0; i < int(mods.NamedChildCount()); i++ {
+	for i, _nc := 0, int(mods.NamedChildCount()); i < _nc; i++ {
 		attr := mods.NamedChild(i)
 		if attr == nil || attr.Type() != "attribute" {
 			continue
@@ -82,7 +82,7 @@ func swiftAttributeNameAndArgs(attr *sitter.Node, src []byte) (string, string) {
 	}
 	var name string
 	var argParts []string
-	for i := 0; i < int(attr.NamedChildCount()); i++ {
+	for i, _nc := 0, int(attr.NamedChildCount()); i < _nc; i++ {
 		c := attr.NamedChild(i)
 		if c == nil {
 			continue
@@ -116,7 +116,7 @@ func swiftModifiers(defNode *sitter.Node) *sitter.Node {
 	if mods := defNode.ChildByFieldName("modifiers"); mods != nil {
 		return mods
 	}
-	for i := 0; i < int(defNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(defNode.NamedChildCount()); i < _nc; i++ {
 		if c := defNode.NamedChild(i); c != nil && c.Type() == "modifiers" {
 			return c
 		}
@@ -134,7 +134,7 @@ func swiftObjCAttr(defNode *sitter.Node, src []byte) (isObjC bool, explicit stri
 	if mods == nil {
 		return false, ""
 	}
-	for i := 0; i < int(mods.NamedChildCount()); i++ {
+	for i, _nc := 0, int(mods.NamedChildCount()); i < _nc; i++ {
 		attr := mods.NamedChild(i)
 		if attr == nil || attr.Type() != "attribute" {
 			continue
@@ -335,7 +335,7 @@ func swiftUserTypeName(node *sitter.Node, src []byte) string {
 	// user_type nests left-to-right so the last identifier is the
 	// leaf.
 	var last string
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		c := node.NamedChild(i)
 		if c == nil {
 			continue
@@ -368,7 +368,7 @@ func swiftHasAttr(defNode *sitter.Node, attrName string, src []byte) bool {
 	if mods == nil {
 		return false
 	}
-	for i := 0; i < int(mods.NamedChildCount()); i++ {
+	for i, _nc := 0, int(mods.NamedChildCount()); i < _nc; i++ {
 		attr := mods.NamedChild(i)
 		if attr == nil || attr.Type() != "attribute" {
 			continue

--- a/internal/parser/languages/swift_function_shape.go
+++ b/internal/parser/languages/swift_function_shape.go
@@ -189,7 +189,7 @@ func emitSwiftFunctionTypeEdges(ownerID string, decl *sitter.Node, src []byte, f
 		}
 	}
 
-	for i := 0; i < int(decl.NamedChildCount()); i++ {
+	for i, _nc := 0, int(decl.NamedChildCount()); i < _nc; i++ {
 		c := decl.NamedChild(i)
 		if c == nil {
 			continue
@@ -214,7 +214,7 @@ func swiftParamTypeNode(param *sitter.Node) *sitter.Node {
 	if param == nil {
 		return nil
 	}
-	for i := 0; i < int(param.NamedChildCount()); i++ {
+	for i, _nc := 0, int(param.NamedChildCount()); i < _nc; i++ {
 		c := param.NamedChild(i)
 		if c == nil {
 			continue
@@ -237,17 +237,17 @@ func swiftTypeParameterNames(decl *sitter.Node, src []byte) map[string]bool {
 	if decl == nil {
 		return out
 	}
-	for i := 0; i < int(decl.NamedChildCount()); i++ {
+	for i, _nc := 0, int(decl.NamedChildCount()); i < _nc; i++ {
 		c := decl.NamedChild(i)
 		if c == nil || c.Type() != "type_parameters" {
 			continue
 		}
-		for j := 0; j < int(c.NamedChildCount()); j++ {
+		for j, _nc := 0, int(c.NamedChildCount()); j < _nc; j++ {
 			tp := c.NamedChild(j)
 			if tp == nil || tp.Type() != "type_parameter" {
 				continue
 			}
-			for k := 0; k < int(tp.NamedChildCount()); k++ {
+			for k, _nc := 0, int(tp.NamedChildCount()); k < _nc; k++ {
 				id := tp.NamedChild(k)
 				if id != nil && id.Type() == "type_identifier" {
 					out[strings.TrimSpace(id.Content(src))] = true

--- a/internal/parser/languages/swift_swiftui.go
+++ b/internal/parser/languages/swift_swiftui.go
@@ -79,7 +79,7 @@ func uikitRoleFor(conf map[string]bool) string {
 // direct type_identifier child (the modifiers / inheritance type_identifiers
 // are nested deeper, not direct children).
 func swiftUITypeName(decl *sitter.Node, src []byte) string {
-	for i := 0; i < int(decl.NamedChildCount()); i++ {
+	for i, _nc := 0, int(decl.NamedChildCount()); i < _nc; i++ {
 		if c := decl.NamedChild(i); c != nil && c.Type() == "type_identifier" {
 			return c.Content(src)
 		}
@@ -91,7 +91,7 @@ func swiftUITypeName(decl *sitter.Node, src []byte) string {
 // declaration's inheritance clause.
 func swiftUIConformances(decl *sitter.Node, src []byte) map[string]bool {
 	out := map[string]bool{}
-	for i := 0; i < int(decl.NamedChildCount()); i++ {
+	for i, _nc := 0, int(decl.NamedChildCount()); i < _nc; i++ {
 		c := decl.NamedChild(i)
 		if c == nil || c.Type() != "inheritance_specifier" {
 			continue
@@ -107,7 +107,7 @@ func swiftUIConformances(decl *sitter.Node, src []byte) map[string]bool {
 
 // swiftUIHasMainAttr reports whether a declaration carries the `@main` attribute.
 func swiftUIHasMainAttr(decl *sitter.Node, src []byte) bool {
-	for i := 0; i < int(decl.NamedChildCount()); i++ {
+	for i, _nc := 0, int(decl.NamedChildCount()); i < _nc; i++ {
 		c := decl.NamedChild(i)
 		if c == nil || c.Type() != "modifiers" {
 			continue
@@ -149,7 +149,7 @@ func swiftUIWalk(n *sitter.Node, fn func(*sitter.Node)) {
 		return
 	}
 	fn(n)
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		swiftUIWalk(n.NamedChild(i), fn)
 	}
 }

--- a/internal/parser/languages/swift_typeuse.go
+++ b/internal/parser/languages/swift_typeuse.go
@@ -169,7 +169,7 @@ func emitSwiftReferenceForms(root *sitter.Node, src []byte, filePath, fileID str
 			// dropped by emit, so a `[String]` or `Array<Int>` adds nothing.
 			line := int(n.StartPoint().Row) + 1
 			ownerID := owner(line)
-			for i := 0; i < int(n.NamedChildCount()); i++ {
+			for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 				c := n.NamedChild(i)
 				if c == nil || c.Type() != "user_type" {
 					continue
@@ -227,7 +227,7 @@ func swiftDeclaredTypeName(decl *sitter.Node, src []byte) string {
 	if decl == nil || decl.Type() != "class_declaration" {
 		return ""
 	}
-	for i := 0; i < int(decl.NamedChildCount()); i++ {
+	for i, _nc := 0, int(decl.NamedChildCount()); i < _nc; i++ {
 		c := decl.NamedChild(i)
 		if c == nil {
 			continue
@@ -252,7 +252,7 @@ func swiftDeclaredTypeName(decl *sitter.Node, src []byte) string {
 // descendant child of n (the RHS type of a cast, type test, or inheritance
 // specifier), or "".
 func swiftTypeChildName(n *sitter.Node, src []byte) string {
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		c := n.NamedChild(i)
 		if c == nil {
 			continue
@@ -297,12 +297,12 @@ func isSwiftInitNavigation(n *sitter.Node, src []byte) bool {
 // swiftNavigationSuffixName returns the trailing member name of a
 // navigation_expression's navigation_suffix (`Foo.bar` → "bar"), or "".
 func swiftNavigationSuffixName(n *sitter.Node, src []byte) string {
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		c := n.NamedChild(i)
 		if c == nil || c.Type() != "navigation_suffix" {
 			continue
 		}
-		for j := 0; j < int(c.NamedChildCount()); j++ {
+		for j, _nc := 0, int(c.NamedChildCount()); j < _nc; j++ {
 			id := c.NamedChild(j)
 			if id != nil && id.Type() == "simple_identifier" {
 				return strings.TrimSpace(id.Content(src))

--- a/internal/parser/languages/toml.go
+++ b/internal/parser/languages/toml.go
@@ -96,7 +96,7 @@ func (e *TOMLExtractor) walk(node *sitter.Node, src []byte, filePath, fileID str
 		}
 	}
 
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		child := node.Child(i)
 		if child != nil {
 			e.walk(child, src, filePath, fileID, result, seen)
@@ -106,7 +106,7 @@ func (e *TOMLExtractor) walk(node *sitter.Node, src []byte, filePath, fileID str
 
 func (e *TOMLExtractor) extractTableName(tableNode *sitter.Node, src []byte) string {
 	// Walk children looking for bare_key or dotted_key inside brackets.
-	for i := 0; i < int(tableNode.ChildCount()); i++ {
+	for i, _nc := 0, int(tableNode.ChildCount()); i < _nc; i++ {
 		child := tableNode.Child(i)
 		if child == nil {
 			continue
@@ -127,7 +127,7 @@ func (e *TOMLExtractor) extractTableName(tableNode *sitter.Node, src []byte) str
 }
 
 func (e *TOMLExtractor) findChild(node *sitter.Node, childType string) *sitter.Node {
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		child := node.Child(i)
 		if child != nil && child.Type() == childType {
 			return child

--- a/internal/parser/languages/ts_dataflow.go
+++ b/internal/parser/languages/ts_dataflow.go
@@ -90,7 +90,7 @@ func (w *tsBindingWalker) walk(n *sitter.Node) {
 		}
 		return
 	}
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		w.walk(n.NamedChild(i))
 	}
 }
@@ -101,7 +101,7 @@ func (w *tsBindingWalker) walk(n *sitter.Node) {
 // (object_pattern / array_pattern) — for patterns we descend and
 // emit one node per shorthand identifier.
 func (w *tsBindingWalker) handleVarDecl(decl *sitter.Node) {
-	for i := 0; i < int(decl.NamedChildCount()); i++ {
+	for i, _nc := 0, int(decl.NamedChildCount()); i < _nc; i++ {
 		c := decl.NamedChild(i)
 		if c == nil || c.Type() != "variable_declarator" {
 			continue
@@ -156,7 +156,7 @@ func (w *tsBindingWalker) emitFromPattern(node *sitter.Node, line int) {
 	case "identifier", "shorthand_property_identifier_pattern":
 		w.bindLocal(node.Content(w.src), line)
 	case "object_pattern", "array_pattern":
-		for i := 0; i < int(node.NamedChildCount()); i++ {
+		for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 			c := node.NamedChild(i)
 			if c == nil {
 				continue
@@ -169,7 +169,7 @@ func (w *tsBindingWalker) emitFromPattern(node *sitter.Node, line int) {
 					w.emitFromPattern(v, line)
 				}
 			case "rest_pattern":
-				for j := 0; j < int(c.NamedChildCount()); j++ {
+				for j, _nc := 0, int(c.NamedChildCount()); j < _nc; j++ {
 					w.emitFromPattern(c.NamedChild(j), line)
 				}
 			default:
@@ -183,7 +183,7 @@ func (w *tsBindingWalker) emitFromPattern(node *sitter.Node, line int) {
 			w.emitFromPattern(l, line)
 		}
 	case "rest_pattern":
-		for i := 0; i < int(node.NamedChildCount()); i++ {
+		for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 			w.emitFromPattern(node.NamedChild(i), line)
 		}
 	}

--- a/internal/parser/languages/ts_function_shape.go
+++ b/internal/parser/languages/ts_function_shape.go
@@ -249,13 +249,13 @@ func walkTSNodes(n *sitter.Node, visit func(*sitter.Node) bool) {
 	if !visit(n) {
 		return
 	}
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		walkTSNodes(n.NamedChild(i), visit)
 	}
 }
 
 func tsFindCallExpression(n *sitter.Node) *sitter.Node {
-	for i := 0; i < int(n.NamedChildCount()); i++ {
+	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		c := n.NamedChild(i)
 		if c == nil {
 			continue
@@ -297,7 +297,7 @@ func tsReturnTypeRaw(decl *sitter.Node, src []byte) string {
 	if decl == nil {
 		return ""
 	}
-	for i := 0; i < int(decl.NamedChildCount()); i++ {
+	for i, _nc := 0, int(decl.NamedChildCount()); i < _nc; i++ {
 		c := decl.NamedChild(i)
 		if c == nil || c.Type() != "type_annotation" {
 			continue
@@ -328,7 +328,7 @@ func tsParamName(p *sitter.Node, src []byte) string {
 			return pattern.Content(src)
 		case "rest_pattern":
 			// rest_pattern wraps an identifier child.
-			for i := 0; i < int(pattern.NamedChildCount()); i++ {
+			for i, _nc := 0, int(pattern.NamedChildCount()); i < _nc; i++ {
 				c := pattern.NamedChild(i)
 				if c != nil && c.Type() == "identifier" {
 					return c.Content(src)
@@ -338,7 +338,7 @@ func tsParamName(p *sitter.Node, src []byte) string {
 	}
 	// Fallback: scan named children for an identifier (older grammar
 	// shapes don't always set the pattern field).
-	for i := 0; i < int(p.NamedChildCount()); i++ {
+	for i, _nc := 0, int(p.NamedChildCount()); i < _nc; i++ {
 		c := p.NamedChild(i)
 		if c == nil {
 			continue
@@ -347,7 +347,7 @@ func tsParamName(p *sitter.Node, src []byte) string {
 			return c.Content(src)
 		}
 		if c.Type() == "rest_pattern" {
-			for j := 0; j < int(c.NamedChildCount()); j++ {
+			for j, _nc := 0, int(c.NamedChildCount()); j < _nc; j++ {
 				cc := c.NamedChild(j)
 				if cc != nil && cc.Type() == "identifier" {
 					return cc.Content(src)
@@ -367,7 +367,7 @@ func tsParamTypeRaw(p *sitter.Node, src []byte) string {
 	}
 	ta := p.ChildByFieldName("type")
 	if ta == nil {
-		for i := 0; i < int(p.NamedChildCount()); i++ {
+		for i, _nc := 0, int(p.NamedChildCount()); i < _nc; i++ {
 			c := p.NamedChild(i)
 			if c != nil && c.Type() == "type_annotation" {
 				ta = c
@@ -378,7 +378,7 @@ func tsParamTypeRaw(p *sitter.Node, src []byte) string {
 	if ta == nil {
 		return ""
 	}
-	for i := 0; i < int(ta.NamedChildCount()); i++ {
+	for i, _nc := 0, int(ta.NamedChildCount()); i < _nc; i++ {
 		c := ta.NamedChild(i)
 		if c == nil {
 			continue
@@ -400,7 +400,7 @@ func tsParamsList(decl *sitter.Node) *sitter.Node {
 	}
 	// Some grammar shapes use a formal_parameters child directly
 	// without a field name.
-	for i := 0; i < int(decl.ChildCount()); i++ {
+	for i, _nc := 0, int(decl.ChildCount()); i < _nc; i++ {
 		c := decl.Child(i)
 		if c != nil && (c.Type() == "formal_parameters" || c.Type() == "call_signature") {
 			return c
@@ -414,7 +414,7 @@ func tsParamsList(decl *sitter.Node) *sitter.Node {
 // present) EdgeTypedAs.
 func emitTSParamNodes(ownerID string, params *sitter.Node, src []byte, filePath string, declLine int, result *parser.ExtractionResult) {
 	pos := 0
-	for i := 0; i < int(params.NamedChildCount()); i++ {
+	for i, _nc := 0, int(params.NamedChildCount()); i < _nc; i++ {
 		decl := params.NamedChild(i)
 		if decl == nil {
 			continue
@@ -920,7 +920,7 @@ func emitTSCastTypeRefs(root *sitter.Node, src []byte, filePath, fileID string, 
 			// type_arguments text carries the surrounding `<…>`; the
 			// inner type_identifier(s) are the real reference, so trim
 			// the brackets before decomposing.
-			for i := 0; i < int(n.NamedChildCount()); i++ {
+			for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 				c := n.NamedChild(i)
 				if c != nil && c.Type() == "type_arguments" {
 					inner := strings.TrimSpace(c.Content(src))

--- a/internal/parser/languages/ts_reffrm.go
+++ b/internal/parser/languages/ts_reffrm.go
@@ -106,7 +106,7 @@ func emitTSTypeOnlyImportRefs(importNode *sitter.Node, src []byte, fileID string
 		// Default type-only import: `import type App from "mod"` binds App as a
 		// type (a specifier-level `import { type X }` carries no default form).
 		if clause := findChildByType(importNode, "import_clause"); clause != nil {
-			for i := 0; i < int(clause.NamedChildCount()); i++ {
+			for i, _nc := 0, int(clause.NamedChildCount()); i < _nc; i++ {
 				c := clause.NamedChild(i)
 				if c == nil || c.Type() != "identifier" {
 					continue
@@ -122,7 +122,7 @@ func emitTSTypeOnlyImportRefs(importNode *sitter.Node, src []byte, fileID string
 	if named == nil {
 		return
 	}
-	for i := 0; i < int(named.NamedChildCount()); i++ {
+	for i, _nc := 0, int(named.NamedChildCount()); i < _nc; i++ {
 		spec := named.NamedChild(i)
 		if spec == nil || spec.Type() != "import_specifier" {
 			continue
@@ -148,7 +148,7 @@ func emitTSTypeOnlyExportRefs(exportNode *sitter.Node, src []byte, fileID string
 		return
 	}
 	stmtTypeOnly := tsExportStatementTypeOnly(exportNode, src)
-	for i := 0; i < int(clause.NamedChildCount()); i++ {
+	for i, _nc := 0, int(clause.NamedChildCount()); i < _nc; i++ {
 		spec := clause.NamedChild(i)
 		if spec == nil || spec.Type() != "export_specifier" {
 			continue
@@ -170,7 +170,7 @@ func emitTSTypeOnlyExportRefs(exportNode *sitter.Node, src []byte, fileID string
 // the import_clause rather than a named field, so scan the statement's
 // raw children for it, stopping at the clause body.
 func tsImportStatementTypeOnly(importNode *sitter.Node, src []byte) bool {
-	for i := 0; i < int(importNode.ChildCount()); i++ {
+	for i, _nc := 0, int(importNode.ChildCount()); i < _nc; i++ {
 		c := importNode.Child(i)
 		if c == nil {
 			continue
@@ -189,7 +189,7 @@ func tsImportStatementTypeOnly(importNode *sitter.Node, src []byte) bool {
 // the statement-level `type` modifier (`export type { … } from`). The
 // keyword sits between `export` and the export_clause.
 func tsExportStatementTypeOnly(exportNode *sitter.Node, src []byte) bool {
-	for i := 0; i < int(exportNode.ChildCount()); i++ {
+	for i, _nc := 0, int(exportNode.ChildCount()); i < _nc; i++ {
 		c := exportNode.Child(i)
 		if c == nil {
 			continue
@@ -207,7 +207,7 @@ func tsExportStatementTypeOnly(exportNode *sitter.Node, src []byte) bool {
 // tsSpecifierTypeOnly reports whether a single import_specifier /
 // export_specifier carries an inline `type` modifier (`{ type Foo }`).
 func tsSpecifierTypeOnly(spec *sitter.Node, src []byte) bool {
-	for i := 0; i < int(spec.ChildCount()); i++ {
+	for i, _nc := 0, int(spec.ChildCount()); i < _nc; i++ {
 		c := spec.Child(i)
 		if c == nil {
 			continue
@@ -237,7 +237,7 @@ func emitTSClassHeritageRefs(classNode *sitter.Node, src []byte, filePath string
 	if heritage == nil {
 		return
 	}
-	for i := 0; i < int(heritage.NamedChildCount()); i++ {
+	for i, _nc := 0, int(heritage.NamedChildCount()); i < _nc; i++ {
 		clause := heritage.NamedChild(i)
 		if clause == nil {
 			continue
@@ -260,7 +260,7 @@ func emitTSClassHeritageRefs(classNode *sitter.Node, src []byte, filePath string
 			}
 		case "implements_clause":
 			line := int(clause.StartPoint().Row) + 1
-			for j := 0; j < int(clause.NamedChildCount()); j++ {
+			for j, _nc := 0, int(clause.NamedChildCount()); j < _nc; j++ {
 				t := clause.NamedChild(j)
 				if t == nil {
 					continue
@@ -287,7 +287,7 @@ func emitTSInterfaceHeritageRefs(ifaceNode *sitter.Node, src []byte, filePath st
 		return
 	}
 	line := int(clause.StartPoint().Row) + 1
-	for i := 0; i < int(clause.NamedChildCount()); i++ {
+	for i, _nc := 0, int(clause.NamedChildCount()); i < _nc; i++ {
 		t := clause.NamedChild(i)
 		if t == nil {
 			continue
@@ -336,7 +336,7 @@ func tsHeritageName(n *sitter.Node, src []byte) string {
 		if name := n.ChildByFieldName("name"); name != nil {
 			return tsHeritageName(name, src)
 		}
-		for i := 0; i < int(n.NamedChildCount()); i++ {
+		for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 			c := n.NamedChild(i)
 			if c != nil && (c.Type() == "type_identifier" || c.Type() == "identifier" || c.Type() == "nested_type_identifier") {
 				return tsHeritageName(c, src)
@@ -352,7 +352,7 @@ func tsHeritageName(n *sitter.Node, src []byte) string {
 func tsTypeDeclID(declNode *sitter.Node, src []byte, filePath string) string {
 	name := declNode.ChildByFieldName("name")
 	if name == nil {
-		for i := 0; i < int(declNode.NamedChildCount()); i++ {
+		for i, _nc := 0, int(declNode.NamedChildCount()); i < _nc; i++ {
 			c := declNode.NamedChild(i)
 			if c != nil && (c.Type() == "type_identifier" || c.Type() == "identifier") {
 				name = c

--- a/internal/parser/languages/ts_throws.go
+++ b/internal/parser/languages/ts_throws.go
@@ -64,7 +64,7 @@ func tsWalkThrows(node *sitter.Node, src []byte, fromID, filePath string, seen m
 		}
 		return
 	}
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		c := node.NamedChild(i)
 		if c == nil {
 			continue
@@ -92,7 +92,7 @@ func tsThrowTypeName(throwNode *sitter.Node, src []byte) string {
 	if throwNode == nil {
 		return ""
 	}
-	for i := 0; i < int(throwNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(throwNode.NamedChildCount()); i < _nc; i++ {
 		c := throwNode.NamedChild(i)
 		if c == nil {
 			continue

--- a/internal/parser/languages/ts_typeuse_extra.go
+++ b/internal/parser/languages/ts_typeuse_extra.go
@@ -27,7 +27,7 @@ func emitTSConstraintRefs(declNode *sitter.Node, ownerID, filePath string, src [
 	if tparams == nil {
 		return
 	}
-	for i := 0; i < int(tparams.NamedChildCount()); i++ {
+	for i, _nc := 0, int(tparams.NamedChildCount()); i < _nc; i++ {
 		tp := tparams.NamedChild(i)
 		if tp == nil || tp.Type() != "type_parameter" {
 			continue
@@ -96,7 +96,7 @@ func emitTSTypeNodeRefs(typeNode *sitter.Node, ownerID, filePath, useKind string
 			// member-expression child, not a type_identifier, so the
 			// type_identifier walk above skips it. Reference its (last) name
 			// so `InstanceType<typeof App>` reaches App.
-			for i := 0; i < int(n.NamedChildCount()); i++ {
+			for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 				c := n.NamedChild(i)
 				if c == nil {
 					continue

--- a/internal/parser/languages/typescript.go
+++ b/internal/parser/languages/typescript.go
@@ -341,7 +341,7 @@ func (e *TypeScriptExtractor) Extract(filePath string, src []byte) (*parser.Extr
 			if n.Type() != "variable_declarator" {
 				return
 			}
-			for i := 0; i < int(n.NamedChildCount()); i++ {
+			for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 				child := n.NamedChild(i)
 				if child.Type() == "new_expression" {
 					if tn := inferTypeFromNewExpr(child, src); tn != "" {
@@ -396,7 +396,7 @@ func (e *TypeScriptExtractor) Extract(filePath string, src []byte) (*parser.Extr
 		}
 		ctor := n.ChildByFieldName("constructor")
 		if ctor == nil {
-			for i := 0; i < int(n.NamedChildCount()); i++ {
+			for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 				c := n.NamedChild(i)
 				if t := c.Type(); t == "identifier" || t == "member_expression" || t == "generic_type" {
 					ctor = c
@@ -702,7 +702,7 @@ func tsFunctionBody(decl *sitter.Node) *sitter.Node {
 	if b := decl.ChildByFieldName("body"); b != nil {
 		return b
 	}
-	for i := 0; i < int(decl.ChildCount()); i++ {
+	for i, _nc := 0, int(decl.ChildCount()); i < _nc; i++ {
 		c := decl.Child(i)
 		if c != nil && (c.Type() == "statement_block" || c.Type() == "block") {
 			return c
@@ -935,7 +935,7 @@ func (e *TypeScriptExtractor) emitInterface(m parser.QueryResult, filePath, file
 // surface), which name-only member extraction misses.
 func emitTSInterfaceMemberTypeRefs(ifaceNode *sitter.Node, src []byte, ifaceID, filePath string, result *parser.ExtractionResult) {
 	var body *sitter.Node
-	for i := 0; i < int(ifaceNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(ifaceNode.NamedChildCount()); i < _nc; i++ {
 		c := ifaceNode.NamedChild(i)
 		if c.Type() == "interface_body" || c.Type() == "object_type" {
 			body = c
@@ -945,7 +945,7 @@ func emitTSInterfaceMemberTypeRefs(ifaceNode *sitter.Node, src []byte, ifaceID, 
 	if body == nil {
 		return
 	}
-	for i := 0; i < int(body.NamedChildCount()); i++ {
+	for i, _nc := 0, int(body.NamedChildCount()); i < _nc; i++ {
 		member := body.NamedChild(i)
 		ctx := ""
 		switch member.Type() {
@@ -983,7 +983,7 @@ func emitTSInterfaceMemberTypeRefs(ifaceNode *sitter.Node, src []byte, ifaceID, 
 					// — the queried value is a plain identifier / member access,
 					// not a type_identifier; reference its (last) name so a
 					// component referenced only through a typeof query surfaces.
-					for k := 0; k < int(n.NamedChildCount()); k++ {
+					for k, _nc := 0, int(n.NamedChildCount()); k < _nc; k++ {
 						q := n.NamedChild(k)
 						if q == nil {
 							continue
@@ -998,7 +998,7 @@ func emitTSInterfaceMemberTypeRefs(ifaceNode *sitter.Node, src []byte, ifaceID, 
 				}
 			})
 		}
-		for j := 0; j < int(member.NamedChildCount()); j++ {
+		for j, _nc := 0, int(member.NamedChildCount()); j < _nc; j++ {
 			child := member.NamedChild(j)
 			switch child.Type() {
 			case "type_annotation":
@@ -1026,7 +1026,7 @@ func tsCtorTypeName(ctor *sitter.Node, src []byte) string {
 			return p.Content(src)
 		}
 	case "generic_type":
-		for i := 0; i < int(ctor.NamedChildCount()); i++ {
+		for i, _nc := 0, int(ctor.NamedChildCount()); i < _nc; i++ {
 			c := ctor.NamedChild(i)
 			if t := c.Type(); t == "type_identifier" || t == "identifier" {
 				return c.Content(src)
@@ -1100,12 +1100,12 @@ func (e *TypeScriptExtractor) emitEnum(m parser.QueryResult, filePath, fileID st
 	}
 	// Walk the enum body for member names. The grammar yields enum_body
 	// → (property_identifier | enum_assignment) children; handle both.
-	for i := 0; i < int(def.Node.ChildCount()); i++ {
+	for i, _nc := 0, int(def.Node.ChildCount()); i < _nc; i++ {
 		child := def.Node.Child(i)
 		if child == nil || child.Type() != "enum_body" {
 			continue
 		}
-		for j := 0; j < int(child.ChildCount()); j++ {
+		for j, _nc := 0, int(child.ChildCount()); j < _nc; j++ {
 			mem := child.Child(j)
 			if mem == nil {
 				continue
@@ -1192,18 +1192,18 @@ func (e *TypeScriptExtractor) emitImport(m parser.QueryResult, filePath, fileID 
 	}
 	// Per-binding edges (`import { a, b as c }`) on top of the module edge.
 	emitJSPerBindingImports(defCap.Node, importPath, fileID, filePath, src, result)
-	for i := 0; i < int(defCap.Node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(defCap.Node.NamedChildCount()); i < _nc; i++ {
 		child := defCap.Node.NamedChild(i)
 		if child.Type() != "import_clause" {
 			continue
 		}
-		for j := 0; j < int(child.NamedChildCount()); j++ {
+		for j, _nc := 0, int(child.NamedChildCount()); j < _nc; j++ {
 			c := child.NamedChild(j)
 			switch c.Type() {
 			case "identifier": // default: `import Foo from ...`
 				imports[c.Content(src)] = importPath
 			case "namespace_import": // `import * as Foo from ...`
-				for k := 0; k < int(c.NamedChildCount()); k++ {
+				for k, _nc := 0, int(c.NamedChildCount()); k < _nc; k++ {
 					if id := c.NamedChild(k); id.Type() == "identifier" {
 						imports[id.Content(src)] = importPath
 					}
@@ -1409,7 +1409,7 @@ func (e *TypeScriptExtractor) emitClassProperty(m parser.QueryResult, filePath s
 	for sib := def.Node.PrevSibling(); sib != nil && sib.Type() == "decorator"; sib = sib.PrevSibling() {
 		emitTSAnnotationEdges([]*sitter.Node{sib}, id, filePath, src, result, annotationSeen)
 	}
-	for i := 0; i < int(def.Node.ChildCount()); i++ {
+	for i, _nc := 0, int(def.Node.ChildCount()); i < _nc; i++ {
 		c := def.Node.Child(i)
 		if c != nil && c.Type() == "decorator" {
 			emitTSAnnotationEdges([]*sitter.Node{c}, id, filePath, src, result, annotationSeen)
@@ -1437,7 +1437,7 @@ func findEnclosingClass(n *sitter.Node) *sitter.Node {
 func extractTSInterfaceMethods(ifaceNode *sitter.Node, src []byte) []string {
 	var methods []string
 	var body *sitter.Node
-	for i := 0; i < int(ifaceNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(ifaceNode.NamedChildCount()); i < _nc; i++ {
 		child := ifaceNode.NamedChild(i)
 		if child.Type() == "interface_body" || child.Type() == "object_type" {
 			body = child
@@ -1447,11 +1447,11 @@ func extractTSInterfaceMethods(ifaceNode *sitter.Node, src []byte) []string {
 	if body == nil {
 		return methods
 	}
-	for i := 0; i < int(body.NamedChildCount()); i++ {
+	for i, _nc := 0, int(body.NamedChildCount()); i < _nc; i++ {
 		child := body.NamedChild(i)
 		switch child.Type() {
 		case "method_signature", "property_signature":
-			for j := 0; j < int(child.NamedChildCount()); j++ {
+			for j, _nc := 0, int(child.NamedChildCount()); j < _nc; j++ {
 				nameNode := child.NamedChild(j)
 				if nameNode.Type() == "property_identifier" {
 					methods = append(methods, nameNode.Content(src))
@@ -1487,7 +1487,7 @@ func emitModuleBindings(classNode *sitter.Node, src []byte, classID, filePath st
 			continue
 		}
 		var config *sitter.Node
-		for i := 0; i < int(args.NamedChildCount()); i++ {
+		for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 			c := args.NamedChild(i)
 			if c != nil && c.Type() == "object" {
 				config = c
@@ -1510,7 +1510,7 @@ func emitProvidersFromObject(config *sitter.Node, src []byte, classID, filePath 
 	if providersNode == nil || providersNode.Type() != "array" {
 		return
 	}
-	for i := 0; i < int(providersNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(providersNode.NamedChildCount()); i < _nc; i++ {
 		entry := providersNode.NamedChild(i)
 		if entry == nil || entry.Type() != "object" {
 			continue
@@ -1634,13 +1634,13 @@ func dispatchConstructorMembers(method *sitter.Node, src []byte, classID, filePa
 	if params == nil {
 		return
 	}
-	for i := 0; i < int(params.NamedChildCount()); i++ {
+	for i, _nc := 0, int(params.NamedChildCount()); i < _nc; i++ {
 		p := params.NamedChild(i)
 		if p == nil {
 			continue
 		}
 		// @Inject decorator on the parameter → consumer edge.
-		for j := 0; j < int(p.ChildCount()); j++ {
+		for j, _nc := 0, int(p.ChildCount()); j < _nc; j++ {
 			c := p.Child(j)
 			if c != nil && c.Type() == "decorator" {
 				emitInjectFromDecorator(c, src, classID, filePath, result, seenInject)
@@ -1670,7 +1670,7 @@ func dispatchConstructorMembers(method *sitter.Node, src []byte, classID, filePa
 // type annotation; falls back to the type inferred from an
 // `inject(Foo)` initializer.
 func dispatchClassField(field *sitter.Node, src []byte, classID, filePath string, result *parser.ExtractionResult, tenv typeEnv, seenInject map[string]struct{}) {
-	for i := 0; i < int(field.ChildCount()); i++ {
+	for i, _nc := 0, int(field.ChildCount()); i < _nc; i++ {
 		c := field.Child(i)
 		if c != nil && c.Type() == "decorator" {
 			emitInjectFromDecorator(c, src, classID, filePath, result, seenInject)
@@ -1723,7 +1723,7 @@ func findReturnedConfigObject(body *sitter.Node) *sitter.Node {
 		if cfg != nil || m.Type() != "return_statement" {
 			return
 		}
-		for i := 0; i < int(m.NamedChildCount()); i++ {
+		for i, _nc := 0, int(m.NamedChildCount()); i < _nc; i++ {
 			c := m.NamedChild(i)
 			if c != nil && c.Type() == "object" {
 				cfg = c
@@ -1735,7 +1735,7 @@ func findReturnedConfigObject(body *sitter.Node) *sitter.Node {
 }
 
 func methodIsStatic(m *sitter.Node) bool {
-	for i := 0; i < int(m.ChildCount()); i++ {
+	for i, _nc := 0, int(m.ChildCount()); i < _nc; i++ {
 		c := m.Child(i)
 		if c != nil && c.Type() == "static" {
 			return true
@@ -1746,7 +1746,7 @@ func methodIsStatic(m *sitter.Node) bool {
 
 func classDecorators(classNode *sitter.Node) []*sitter.Node {
 	var decs []*sitter.Node
-	for i := 0; i < int(classNode.ChildCount()); i++ {
+	for i, _nc := 0, int(classNode.ChildCount()); i < _nc; i++ {
 		c := classNode.Child(i)
 		if c != nil && c.Type() == "decorator" {
 			decs = append(decs, c)
@@ -1754,7 +1754,7 @@ func classDecorators(classNode *sitter.Node) []*sitter.Node {
 	}
 	parent := classNode.Parent()
 	if parent != nil && parent.Type() == "export_statement" {
-		for i := 0; i < int(parent.ChildCount()); i++ {
+		for i, _nc := 0, int(parent.ChildCount()); i < _nc; i++ {
 			c := parent.Child(i)
 			if c != nil && c.Type() == "decorator" {
 				decs = append(decs, c)
@@ -1776,7 +1776,7 @@ func tsDecoratorNameAndArgs(dec *sitter.Node, src []byte) (string, string) {
 	// The first named child of a decorator node is typically either an
 	// identifier (`@Foo`), a member_expression (`@Foo.bar`), or a
 	// call_expression (`@Foo(...)`).
-	for i := 0; i < int(dec.NamedChildCount()); i++ {
+	for i, _nc := 0, int(dec.NamedChildCount()); i < _nc; i++ {
 		c := dec.NamedChild(i)
 		if c == nil {
 			continue
@@ -1819,7 +1819,7 @@ func emitTSAnnotationEdges(decs []*sitter.Node, fromID, filePath string, src []b
 }
 
 func objectFieldValue(objNode *sitter.Node, src []byte, name string) *sitter.Node {
-	for i := 0; i < int(objNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(objNode.NamedChildCount()); i < _nc; i++ {
 		p := objNode.NamedChild(i)
 		if p == nil || p.Type() != "pair" {
 			continue
@@ -1874,7 +1874,7 @@ func injectDecoratorArg(dec *sitter.Node, src []byte) string {
 	if args == nil {
 		return ""
 	}
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		arg := args.NamedChild(i)
 		if arg == nil {
 			continue
@@ -1916,7 +1916,7 @@ func emitDispatchFromDecorator(dec *sitter.Node, src []byte, methodID, filePath 
 	if args == nil {
 		return
 	}
-	for j := 0; j < int(args.NamedChildCount()); j++ {
+	for j, _nc := 0, int(args.NamedChildCount()); j < _nc; j++ {
 		arg := args.NamedChild(j)
 		if arg == nil || arg.Type() != "identifier" {
 			continue
@@ -1937,7 +1937,7 @@ func emitDispatchFromDecorator(dec *sitter.Node, src []byte, methodID, filePath 
 }
 
 func nestDecoratorCall(dec *sitter.Node) *sitter.Node {
-	for i := 0; i < int(dec.NamedChildCount()); i++ {
+	for i, _nc := 0, int(dec.NamedChildCount()); i < _nc; i++ {
 		c := dec.NamedChild(i)
 		if c != nil && c.Type() == "call_expression" {
 			return c
@@ -1955,12 +1955,12 @@ func classFieldName(field *sitter.Node, src []byte) string {
 }
 
 func classFieldTypeAnnotation(field *sitter.Node, src []byte) string {
-	for i := 0; i < int(field.NamedChildCount()); i++ {
+	for i, _nc := 0, int(field.NamedChildCount()); i < _nc; i++ {
 		c := field.NamedChild(i)
 		if c == nil || c.Type() != "type_annotation" {
 			continue
 		}
-		for j := 0; j < int(c.NamedChildCount()); j++ {
+		for j, _nc := 0, int(c.NamedChildCount()); j < _nc; j++ {
 			tn := c.NamedChild(j)
 			if tn == nil {
 				continue
@@ -1984,7 +1984,7 @@ func injectInitializerType(field *sitter.Node, src []byte) string {
 	if args == nil {
 		return ""
 	}
-	for i := 0; i < int(args.NamedChildCount()); i++ {
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
 		arg := args.NamedChild(i)
 		if arg == nil {
 			continue
@@ -1998,7 +1998,7 @@ func injectInitializerType(field *sitter.Node, src []byte) string {
 }
 
 func hasParameterPropertyModifier(p *sitter.Node) bool {
-	for i := 0; i < int(p.ChildCount()); i++ {
+	for i, _nc := 0, int(p.ChildCount()); i < _nc; i++ {
 		c := p.Child(i)
 		if c == nil {
 			continue
@@ -2018,7 +2018,7 @@ func paramIdentifier(p *sitter.Node, src []byte) string {
 	if pattern != nil && pattern.Type() == "identifier" {
 		return pattern.Content(src)
 	}
-	for i := 0; i < int(p.NamedChildCount()); i++ {
+	for i, _nc := 0, int(p.NamedChildCount()); i < _nc; i++ {
 		c := p.NamedChild(i)
 		if c != nil && c.Type() == "identifier" {
 			return c.Content(src)
@@ -2030,7 +2030,7 @@ func paramIdentifier(p *sitter.Node, src []byte) string {
 func paramTypeAnnotation(p *sitter.Node, src []byte) string {
 	ta := p.ChildByFieldName("type")
 	if ta == nil {
-		for i := 0; i < int(p.NamedChildCount()); i++ {
+		for i, _nc := 0, int(p.NamedChildCount()); i < _nc; i++ {
 			c := p.NamedChild(i)
 			if c != nil && c.Type() == "type_annotation" {
 				ta = c
@@ -2041,7 +2041,7 @@ func paramTypeAnnotation(p *sitter.Node, src []byte) string {
 	if ta == nil {
 		return ""
 	}
-	for i := 0; i < int(ta.NamedChildCount()); i++ {
+	for i, _nc := 0, int(ta.NamedChildCount()); i < _nc; i++ {
 		c := ta.NamedChild(i)
 		if c == nil {
 			continue
@@ -2113,7 +2113,7 @@ func tsMemberVisibility(member *sitter.Node, src []byte) string {
 	if member == nil {
 		return VisibilityPublic
 	}
-	for i := 0; i < int(member.ChildCount()); i++ {
+	for i, _nc := 0, int(member.ChildCount()); i < _nc; i++ {
 		c := member.Child(i)
 		if c == nil || c.Type() != "accessibility_modifier" {
 			continue
@@ -2131,7 +2131,7 @@ func tsMemberVisibility(member *sitter.Node, src []byte) string {
 }
 
 func extractTSMethodReturnType(methodNode *sitter.Node, src []byte) string {
-	for i := 0; i < int(methodNode.NamedChildCount()); i++ {
+	for i, _nc := 0, int(methodNode.NamedChildCount()); i < _nc; i++ {
 		child := methodNode.NamedChild(i)
 		if child.Type() == "type_annotation" {
 			if child.NamedChildCount() > 0 {
@@ -2144,7 +2144,7 @@ func extractTSMethodReturnType(methodNode *sitter.Node, src []byte) string {
 }
 
 func inferTypeFromNewExpr(node *sitter.Node, src []byte) string {
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		child := node.NamedChild(i)
 		if child.Type() == "identifier" || child.Type() == "type_identifier" {
 			name := child.Content(src)
@@ -2173,7 +2173,7 @@ func tsTypeParams(decl *sitter.Node, src []byte) []map[string]string {
 		return nil
 	}
 	var out []map[string]string
-	for i := 0; i < int(tps.NamedChildCount()); i++ {
+	for i, _nc := 0, int(tps.NamedChildCount()); i < _nc; i++ {
 		tp := tps.NamedChild(i)
 		if tp == nil || tp.Type() != "type_parameter" {
 			continue
@@ -2183,7 +2183,7 @@ func tsTypeParams(decl *sitter.Node, src []byte) []map[string]string {
 			entry["name"] = n.Content(src)
 		}
 		// constraint child is the `extends X` part.
-		for j := 0; j < int(tp.ChildCount()); j++ {
+		for j, _nc := 0, int(tp.ChildCount()); j < _nc; j++ {
 			c := tp.Child(j)
 			if c == nil {
 				continue

--- a/internal/parser/languages/typescript_jsx.go
+++ b/internal/parser/languages/typescript_jsx.go
@@ -84,7 +84,7 @@ func jsxElementName(node *sitter.Node, src []byte) string {
 	if nameNode == nil {
 		// Fallback: walk children for the name token. tree-sitter
 		// grammars vary on whether the field is exposed.
-		for i := 0; i < int(node.NamedChildCount()); i++ {
+		for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 			c := node.NamedChild(i)
 			if c != nil && (c.Type() == "identifier" || c.Type() == "member_expression" || c.Type() == "nested_identifier") {
 				nameNode = c

--- a/internal/parser/languages/typescript_orm.go
+++ b/internal/parser/languages/typescript_orm.go
@@ -93,7 +93,7 @@ func tsEntityDecoratorTableName(classNode *sitter.Node, src []byte) (string, str
 			return "", "", true
 		}
 		// Look at the first argument: string literal or object.
-		for i := 0; i < int(argsNode.NamedChildCount()); i++ {
+		for i, _nc := 0, int(argsNode.NamedChildCount()); i < _nc; i++ {
 			arg := argsNode.NamedChild(i)
 			if arg == nil {
 				continue
@@ -116,7 +116,7 @@ func tsEntityDecoratorTableName(classNode *sitter.Node, src []byte) (string, str
 // tsEntityStringArg unwraps a TS string literal to its content. Falls
 // back to stripping surrounding quotes when no fragment child exists.
 func tsEntityStringArg(node *sitter.Node, src []byte) string {
-	for i := 0; i < int(node.NamedChildCount()); i++ {
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		c := node.NamedChild(i)
 		if c != nil && c.Type() == "string_fragment" {
 			return c.Content(src)
@@ -131,7 +131,7 @@ func tsEntityStringArg(node *sitter.Node, src []byte) string {
 // name: "..." }) and similar options-object shapes.
 func tsObjectStringField(obj *sitter.Node, src []byte, key string) string {
 	keyRE := regexp.MustCompile(`^\s*` + regexp.QuoteMeta(key) + `\s*:\s*$`)
-	for i := 0; i < int(obj.NamedChildCount()); i++ {
+	for i, _nc := 0, int(obj.NamedChildCount()); i < _nc; i++ {
 		pair := obj.NamedChild(i)
 		if pair == nil || (pair.Type() != "pair" && pair.Type() != "property_name_value_pair") {
 			continue

--- a/internal/parser/languages/yaml.go
+++ b/internal/parser/languages/yaml.go
@@ -128,7 +128,7 @@ func (e *YAMLExtractor) findTopLevelPairs(node *sitter.Node, src []byte, filePat
 		return // Don't recurse into nested mappings.
 	}
 
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i, _nc := 0, int(node.ChildCount()); i < _nc; i++ {
 		child := node.Child(i)
 		if child != nil {
 			e.findTopLevelPairs(child, src, filePath, fileID, result, seen, depth+1)

--- a/internal/parser/tsitter/arena_test.go
+++ b/internal/parser/tsitter/arena_test.go
@@ -36,14 +36,45 @@ func TestNodeArenaStablePointers(t *testing.T) {
 func TestNodeArenaGeometricGrowth(t *testing.T) {
 	a := newNodeArena()
 	a.alloc()
-	if got := len(a.cur); got != arenaFirstChunk {
+	if got := len(a.chunks[0]); got != arenaFirstChunk {
 		t.Fatalf("first chunk size = %d, want %d", got, arenaFirstChunk)
 	}
-	// Drain well past the cap; the current chunk must never exceed the max.
+	// Drain well past the cap; no chunk may exceed the max.
 	for i := 0; i < arenaMaxChunk*3; i++ {
 		a.alloc()
-		if len(a.cur) > arenaMaxChunk {
-			t.Fatalf("chunk grew to %d, exceeds cap %d", len(a.cur), arenaMaxChunk)
+		if got := len(a.chunks[a.ci]); got > arenaMaxChunk {
+			t.Fatalf("chunk grew to %d, exceeds cap %d", got, arenaMaxChunk)
 		}
+	}
+}
+
+// TestNodeArenaResetReusesChunks is the pooling invariant: reset rewinds the
+// cursor but KEEPS the backing chunks, so refilling to the same size
+// allocates no new chunk, and any stale Node from the previous round is
+// cleared — a recycled arena must never pin a closed tree.
+func TestNodeArenaResetReusesChunks(t *testing.T) {
+	a := newNodeArena()
+	const n = arenaMaxChunk + 100 // span more than one chunk
+	for i := 0; i < n; i++ {
+		a.alloc().valid = true
+	}
+	want := len(a.chunks)
+	if want < 2 {
+		t.Fatalf("test needs a multi-chunk arena, got %d chunk(s)", want)
+	}
+
+	a.reset()
+	if len(a.chunks) != want {
+		t.Fatalf("reset dropped chunks: have %d, want %d (chunks must be retained)", len(a.chunks), want)
+	}
+	if a.chunks[0][0].valid {
+		t.Fatal("reset left a stale Node valid — a recycled arena would pin its tree")
+	}
+
+	for i := 0; i < n; i++ {
+		a.alloc().valid = true
+	}
+	if len(a.chunks) != want {
+		t.Fatalf("refill allocated fresh chunks: have %d, want %d (chunks not reused)", len(a.chunks), want)
 	}
 }

--- a/internal/parser/tsitter/arena_test.go
+++ b/internal/parser/tsitter/arena_test.go
@@ -1,0 +1,49 @@
+package tsitter
+
+import "testing"
+
+// TestNodeArenaStablePointers guards the arena's load-bearing invariant:
+// a pointer returned by alloc stays valid after later allocations grow the
+// arena onto a new backing chunk. If alloc ever appended into a single
+// reallocating slice, earlier &slice[i] pointers would dangle and node data
+// would silently corrupt mid-walk.
+func TestNodeArenaStablePointers(t *testing.T) {
+	a := newNodeArena()
+	const n = arenaMaxChunk*2 + 17 // cross several chunk boundaries incl. the max-size cap
+	ptrs := make([]*Node, n)
+	for i := range ptrs {
+		p := a.alloc()
+		if p == nil {
+			t.Fatalf("alloc %d returned nil", i)
+		}
+		p.valid = true
+		ptrs[i] = p
+	}
+	seen := make(map[*Node]bool, n)
+	for i, p := range ptrs {
+		if seen[p] {
+			t.Fatalf("alloc %d aliased an earlier node pointer", i)
+		}
+		seen[p] = true
+		if !p.valid {
+			t.Fatalf("node %d was clobbered by a later chunk allocation", i)
+		}
+	}
+}
+
+// TestNodeArenaGeometricGrowth confirms the first chunk is small (low waste
+// for tiny files) and chunks grow up to the cap (few objects for deep files).
+func TestNodeArenaGeometricGrowth(t *testing.T) {
+	a := newNodeArena()
+	a.alloc()
+	if got := len(a.cur); got != arenaFirstChunk {
+		t.Fatalf("first chunk size = %d, want %d", got, arenaFirstChunk)
+	}
+	// Drain well past the cap; the current chunk must never exceed the max.
+	for i := 0; i < arenaMaxChunk*3; i++ {
+		a.alloc()
+		if len(a.cur) > arenaMaxChunk {
+			t.Fatalf("chunk grew to %d, exceeds cap %d", len(a.cur), arenaMaxChunk)
+		}
+	}
+}

--- a/internal/parser/tsitter/node_cnav.go
+++ b/internal/parser/tsitter/node_cnav.go
@@ -1,0 +1,87 @@
+package tsitter
+
+// Direct C navigation for the hot child-access path.
+//
+// go-tree-sitter's Node navigation (Child / NamedChild / Parent, the cursor,
+// even the []Node value-slice helpers) funnels through newNode, which
+// heap-allocates a *ts.Node for every visited node. Profiling a large index
+// put that at ~43% of all bytes allocated — 95% of it NamedChild + Child +
+// Parent in the extractor child loops — and the resulting GC churn dominated
+// CPU under a memory cap.
+//
+// The tree-sitter C API returns nodes BY VALUE (TSNode is a 32-byte struct).
+// We call those C functions directly and drop the returned value straight
+// into the pooled Node arena, so a child visit costs one bump-allocated
+// wrapper and zero heap garbage.
+//
+// The functions are declared here rather than pulled from <tree_sitter/api.h>
+// so this file needs no -I path into the go-tree-sitter module cache (which
+// is version- and machine-specific). The symbols themselves are defined in
+// the tree-sitter C library that go-tree-sitter already compiles and links
+// into the binary; C has no name mangling, so a local prototype with the
+// identical ABI resolves to them at link time.
+
+/*
+#include <stdint.h>
+
+// Mirror of tree-sitter's TSNode (include/tree_sitter/api.h): a 4-word
+// context plus two opaque pointers. Layout must match exactly — it is
+// reinterpreted from ts.Node, whose sole field is this struct.
+typedef struct { uint32_t context[4]; const void *id; const void *tree; } GxTSNode;
+
+extern GxTSNode ts_node_child(GxTSNode, uint32_t);
+extern GxTSNode ts_node_named_child(GxTSNode, uint32_t);
+extern GxTSNode ts_node_parent(GxTSNode);
+*/
+import "C"
+
+import (
+	"unsafe"
+
+	ts "github.com/tree-sitter/go-tree-sitter"
+)
+
+// init fails fast if a tree-sitter upgrade ever changes the TSNode layout
+// out from under the reinterpret casts below, rather than silently corrupting
+// navigated nodes at runtime.
+func init() {
+	if unsafe.Sizeof(ts.Node{}) != unsafe.Sizeof(C.GxTSNode{}) {
+		panic("tsitter: ts.Node and TSNode size mismatch — tree-sitter ABI changed, update node_cnav.go")
+	}
+}
+
+// asC reinterprets an upstream ts.Node as the locally-declared C node. ts.Node
+// is `struct { _inner C.TSNode }`, so its bytes are exactly a TSNode and the
+// two share an identical ABI layout.
+func asC(n ts.Node) C.GxTSNode { return *(*C.GxTSNode)(unsafe.Pointer(&n)) }
+
+// asGo reinterprets a C node back into an upstream ts.Node value.
+func asGo(c C.GxTSNode) ts.Node { return *(*ts.Node)(unsafe.Pointer(&c)) }
+
+// childDirect returns parent's i-th child as a value, with no heap
+// allocation. ok is false for a null child (index past the end).
+func childDirect(parent ts.Node, i int) (ts.Node, bool) {
+	c := C.ts_node_child(asC(parent), C.uint32_t(i))
+	if c.id == nil {
+		return ts.Node{}, false
+	}
+	return asGo(c), true
+}
+
+// namedChildDirect is childDirect over named children only.
+func namedChildDirect(parent ts.Node, i int) (ts.Node, bool) {
+	c := C.ts_node_named_child(asC(parent), C.uint32_t(i))
+	if c.id == nil {
+		return ts.Node{}, false
+	}
+	return asGo(c), true
+}
+
+// parentDirect returns n's parent as a value. ok is false at the root.
+func parentDirect(n ts.Node) (ts.Node, bool) {
+	c := C.ts_node_parent(asC(n))
+	if c.id == nil {
+		return ts.Node{}, false
+	}
+	return asGo(c), true
+}

--- a/internal/parser/tsitter/node_cnav.go
+++ b/internal/parser/tsitter/node_cnav.go
@@ -29,9 +29,19 @@ package tsitter
 // reinterpreted from ts.Node, whose sole field is this struct.
 typedef struct { uint32_t context[4]; const void *id; const void *tree; } GxTSNode;
 
+// Mirror of TSTreeCursor — reinterpreted from *ts.TreeCursor (whose sole
+// field is this struct) so the cursor's current node can be read by value.
+typedef struct { const void *tree; const void *id; uint32_t context[3]; } GxTSTreeCursor;
+
 extern GxTSNode ts_node_child(GxTSNode, uint32_t);
 extern GxTSNode ts_node_named_child(GxTSNode, uint32_t);
 extern GxTSNode ts_node_parent(GxTSNode);
+extern GxTSNode ts_node_next_sibling(GxTSNode);
+extern GxTSNode ts_node_prev_sibling(GxTSNode);
+extern GxTSNode ts_node_next_named_sibling(GxTSNode);
+extern GxTSNode ts_node_prev_named_sibling(GxTSNode);
+extern GxTSNode ts_node_child_by_field_name(GxTSNode, const char *, uint32_t);
+extern GxTSNode ts_tree_cursor_current_node(const GxTSTreeCursor *);
 */
 import "C"
 
@@ -47,6 +57,9 @@ import (
 func init() {
 	if unsafe.Sizeof(ts.Node{}) != unsafe.Sizeof(C.GxTSNode{}) {
 		panic("tsitter: ts.Node and TSNode size mismatch — tree-sitter ABI changed, update node_cnav.go")
+	}
+	if unsafe.Sizeof(ts.TreeCursor{}) != unsafe.Sizeof(C.GxTSTreeCursor{}) {
+		panic("tsitter: ts.TreeCursor and TSTreeCursor size mismatch — tree-sitter ABI changed, update node_cnav.go")
 	}
 }
 
@@ -80,6 +93,64 @@ func namedChildDirect(parent ts.Node, i int) (ts.Node, bool) {
 // parentDirect returns n's parent as a value. ok is false at the root.
 func parentDirect(n ts.Node) (ts.Node, bool) {
 	c := C.ts_node_parent(asC(n))
+	if c.id == nil {
+		return ts.Node{}, false
+	}
+	return asGo(c), true
+}
+
+func nextSiblingDirect(n ts.Node) (ts.Node, bool) {
+	c := C.ts_node_next_sibling(asC(n))
+	if c.id == nil {
+		return ts.Node{}, false
+	}
+	return asGo(c), true
+}
+
+func prevSiblingDirect(n ts.Node) (ts.Node, bool) {
+	c := C.ts_node_prev_sibling(asC(n))
+	if c.id == nil {
+		return ts.Node{}, false
+	}
+	return asGo(c), true
+}
+
+func nextNamedSiblingDirect(n ts.Node) (ts.Node, bool) {
+	c := C.ts_node_next_named_sibling(asC(n))
+	if c.id == nil {
+		return ts.Node{}, false
+	}
+	return asGo(c), true
+}
+
+func prevNamedSiblingDirect(n ts.Node) (ts.Node, bool) {
+	c := C.ts_node_prev_named_sibling(asC(n))
+	if c.id == nil {
+		return ts.Node{}, false
+	}
+	return asGo(c), true
+}
+
+// cursorCurrentNode returns a tree cursor's current node by value, avoiding
+// TreeCursor.Node's per-step heap *Node. The cursor walk itself (GotoFirstChild
+// / GotoNextSibling) stays O(total children); only the node read is changed.
+func cursorCurrentNode(cursor *ts.TreeCursor) ts.Node {
+	return asGo(C.ts_tree_cursor_current_node((*C.GxTSTreeCursor)(unsafe.Pointer(cursor))))
+}
+
+// childByFieldNameDirect returns parent's child for a grammar field name. The
+// name's bytes are passed to C by pointer+length (ts_node_child_by_field_name
+// does not require NUL termination and reads them only for the duration of the
+// call), so no C string is allocated. ok is false when no such field exists.
+func childByFieldNameDirect(parent ts.Node, name string) (ts.Node, bool) {
+	if name == "" {
+		return ts.Node{}, false
+	}
+	c := C.ts_node_child_by_field_name(
+		asC(parent),
+		(*C.char)(unsafe.Pointer(unsafe.StringData(name))),
+		C.uint32_t(len(name)),
+	)
 	if c.id == nil {
 		return ts.Node{}, false
 	}

--- a/internal/parser/tsitter/tsitter.go
+++ b/internal/parser/tsitter/tsitter.go
@@ -291,20 +291,31 @@ func (n *Node) ChildCount() uint32 { return uint32(n.inner.ChildCount()) }
 // NamedChildCount returns the number of named children.
 func (n *Node) NamedChildCount() uint32 { return uint32(n.inner.NamedChildCount()) }
 
-// Child returns the i-th child (named or anonymous) or nil.
+// Child returns the i-th child (named or anonymous) or nil. It reaches the
+// child through a direct C call that returns the node by value, so the result
+// is bump-allocated in the arena with no go-tree-sitter heap node (newNode).
 func (n *Node) Child(i int) *Node {
 	if i < 0 {
 		return nil
 	}
-	return n.wrap(n.inner.Child(uint(i)))
+	c, ok := childDirect(n.inner, i)
+	if !ok {
+		return nil
+	}
+	return n.WrapVal(c)
 }
 
-// NamedChild returns the i-th named child or nil.
+// NamedChild returns the i-th named child or nil. Like Child, it avoids
+// go-tree-sitter's per-node heap allocation.
 func (n *Node) NamedChild(i int) *Node {
 	if i < 0 {
 		return nil
 	}
-	return n.wrap(n.inner.NamedChild(uint(i)))
+	c, ok := namedChildDirect(n.inner, i)
+	if !ok {
+		return nil
+	}
+	return n.WrapVal(c)
 }
 
 // NamedChildren yields n's named children, in order, walking the sibling
@@ -358,8 +369,15 @@ func (n *Node) FieldNameForChild(i int) string {
 	return n.inner.FieldNameForChild(uint32(i))
 }
 
-// Parent returns the parent node or nil for the root.
-func (n *Node) Parent() *Node { return n.wrap(n.inner.Parent()) }
+// Parent returns the parent node or nil for the root. Avoids
+// go-tree-sitter's per-node heap allocation via a direct C call.
+func (n *Node) Parent() *Node {
+	c, ok := parentDirect(n.inner)
+	if !ok {
+		return nil
+	}
+	return n.WrapVal(c)
+}
 
 // NextSibling returns the next sibling (named or anonymous) or nil.
 func (n *Node) NextSibling() *Node { return n.wrap(n.inner.NextSibling()) }

--- a/internal/parser/tsitter/tsitter.go
+++ b/internal/parser/tsitter/tsitter.go
@@ -198,24 +198,6 @@ func (n *Node) SetInner(inner ts.Node) {
 	n.valid = true
 }
 
-// wrap wraps a nullable *ts.Node reached by navigating from n, carrying
-// n's language key so Type() stays allocation-free across a tree walk.
-// Returns nil for nil input.
-func (n *Node) wrap(c *ts.Node) *Node {
-	if c == nil {
-		return nil
-	}
-	if n.arena == nil {
-		return &Node{inner: *c, valid: true, langKey: n.langKey}
-	}
-	nn := n.arena.alloc()
-	nn.inner = *c
-	nn.valid = true
-	nn.langKey = n.langKey
-	nn.arena = n.arena
-	return nn
-}
-
 // Inner returns a pointer to the underlying ts.Node. Internal use by
 // the parser package's query runners.
 func (n *Node) Inner() *ts.Node {
@@ -343,9 +325,9 @@ func (n *Node) NamedChildren() iter.Seq[*Node] {
 			return
 		}
 		for {
-			c := cursor.Node()
+			c := cursorCurrentNode(cursor)
 			if c.IsNamed() {
-				if !yield(n.WrapVal(*c)) {
+				if !yield(n.WrapVal(c)) {
 					return
 				}
 			}
@@ -357,8 +339,13 @@ func (n *Node) NamedChildren() iter.Seq[*Node] {
 }
 
 // ChildByFieldName returns the first child with the given field name or nil.
+// Uses a direct C call so the result is arena-allocated with no heap node.
 func (n *Node) ChildByFieldName(name string) *Node {
-	return n.wrap(n.inner.ChildByFieldName(name))
+	c, ok := childByFieldNameDirect(n.inner, name)
+	if !ok {
+		return nil
+	}
+	return n.WrapVal(c)
 }
 
 // FieldNameForChild returns the field name of the i-th child, or "" if none.
@@ -379,17 +366,42 @@ func (n *Node) Parent() *Node {
 	return n.WrapVal(c)
 }
 
-// NextSibling returns the next sibling (named or anonymous) or nil.
-func (n *Node) NextSibling() *Node { return n.wrap(n.inner.NextSibling()) }
+// NextSibling returns the next sibling (named or anonymous) or nil. Direct C
+// call, arena-allocated result, no heap node.
+func (n *Node) NextSibling() *Node {
+	c, ok := nextSiblingDirect(n.inner)
+	if !ok {
+		return nil
+	}
+	return n.WrapVal(c)
+}
 
 // PrevSibling returns the previous sibling (named or anonymous) or nil.
-func (n *Node) PrevSibling() *Node { return n.wrap(n.inner.PrevSibling()) }
+func (n *Node) PrevSibling() *Node {
+	c, ok := prevSiblingDirect(n.inner)
+	if !ok {
+		return nil
+	}
+	return n.WrapVal(c)
+}
 
 // NextNamedSibling returns the next named sibling or nil.
-func (n *Node) NextNamedSibling() *Node { return n.wrap(n.inner.NextNamedSibling()) }
+func (n *Node) NextNamedSibling() *Node {
+	c, ok := nextNamedSiblingDirect(n.inner)
+	if !ok {
+		return nil
+	}
+	return n.WrapVal(c)
+}
 
 // PrevNamedSibling returns the previous named sibling or nil.
-func (n *Node) PrevNamedSibling() *Node { return n.wrap(n.inner.PrevNamedSibling()) }
+func (n *Node) PrevNamedSibling() *Node {
+	c, ok := prevNamedSiblingDirect(n.inner)
+	if !ok {
+		return nil
+	}
+	return n.WrapVal(c)
+}
 
 // IsNamed reports whether the node corresponds to a named grammar rule.
 func (n *Node) IsNamed() bool { return n.inner.IsNamed() }

--- a/internal/parser/tsitter/tsitter.go
+++ b/internal/parser/tsitter/tsitter.go
@@ -72,9 +72,19 @@ type Node struct {
 // nodeArena is a per-tree bump allocator for Node wrappers. It is not
 // safe for concurrent use; each parse tree is walked by a single
 // goroutine, and distinct files use distinct trees (and arenas).
+//
+// Arenas are pooled and reused across files (see arenaPool): a Tree takes
+// one on its first RootNode() and returns it on Close(). reset() rewinds
+// the allocation cursor but RETAINS the backing chunks, so a warm pool
+// serves each file's node count with no fresh allocation. This is the
+// dominant GC-pressure lever on a large index: profiling vscode and
+// kubernetes put tree-sitter Node wrappers at 70–82% of every byte
+// allocated, almost all of it per-file chunk garbage. Retaining the chunks
+// turns that churn into a bounded, reused working set.
 type nodeArena struct {
-	cur  []Node
-	used int
+	chunks [][]Node // backing arrays, retained across resets for reuse
+	ci     int      // index of the current chunk within chunks
+	used   int      // slots used in chunks[ci]
 }
 
 const (
@@ -88,24 +98,66 @@ const (
 
 func newNodeArena() *nodeArena { return &nodeArena{} }
 
-// alloc returns a pointer to a fresh zeroed Node. The pointer is stable:
-// when the current chunk fills, a new (geometrically larger) backing array
-// is allocated and the old chunk stays alive through the Nodes that point
-// into it.
+// alloc returns a pointer to a fresh Node. The pointer is stable for the
+// life of the arena: a chunk is never resized in place — when the current
+// chunk fills, allocation advances to the next retained chunk, or appends a
+// geometrically larger one past the high-water mark, so earlier &chunk[i]
+// pointers never move. Callers overwrite all fields of the returned Node
+// immediately, so a reused slot needs no zeroing here; reset() clears stale
+// slots when the arena is recycled.
 func (a *nodeArena) alloc() *Node {
-	if a.used >= len(a.cur) {
-		size := len(a.cur) * 2
-		if size == 0 {
-			size = arenaFirstChunk
-		} else if size > arenaMaxChunk {
-			size = arenaMaxChunk
+	switch {
+	case len(a.chunks) == 0:
+		a.chunks = append(a.chunks, make([]Node, arenaFirstChunk))
+		a.ci, a.used = 0, 0
+	case a.used >= len(a.chunks[a.ci]):
+		a.ci++
+		if a.ci >= len(a.chunks) {
+			size := len(a.chunks[a.ci-1]) * 2
+			if size > arenaMaxChunk {
+				size = arenaMaxChunk
+			}
+			a.chunks = append(a.chunks, make([]Node, size))
 		}
-		a.cur = make([]Node, size)
 		a.used = 0
 	}
-	n := &a.cur[a.used]
+	n := &a.chunks[a.ci][a.used]
 	a.used++
 	return n
+}
+
+// reset rewinds the allocation cursor to the start while retaining the
+// backing chunks for reuse. It clears the slots touched since the last
+// reset so a stale Node value — whose embedded ts.Node pins its now-closed
+// *ts.Tree — cannot survive into the next file and leak. Clearing only the
+// used prefix keeps the cost proportional to the file just processed, not
+// the high-water capacity.
+func (a *nodeArena) reset() {
+	for i := 0; i <= a.ci && i < len(a.chunks); i++ {
+		end := len(a.chunks[i])
+		if i == a.ci {
+			end = a.used
+		}
+		clear(a.chunks[i][:end])
+	}
+	a.ci, a.used = 0, 0
+}
+
+// arenaPool recycles per-tree arenas — with their retained chunks — across
+// files. A Tree gets one lazily on its first RootNode() and returns it on
+// Close(). sync.Pool may drop entries under GC pressure; a cold Get then
+// just starts with no chunks and warms up again, so correctness never
+// depends on retention.
+var arenaPool = sync.Pool{New: func() any { return &nodeArena{} }}
+
+func getArena() *nodeArena { return arenaPool.Get().(*nodeArena) }
+
+func putArena(a *nodeArena) {
+	if a == nil {
+		return
+	}
+	a.reset()
+	arenaPool.Put(a)
 }
 
 // WrapNode wraps a value Node from the new API into our shim. It derives
@@ -360,6 +412,7 @@ func (n *Node) Equal(other *Node) bool {
 // Tree wraps *ts.Tree.
 type Tree struct {
 	inner *ts.Tree
+	arena *nodeArena // pooled; taken lazily on first RootNode, returned on Close
 }
 
 // WrapTree wraps a *ts.Tree for internal use by the parser package.
@@ -375,7 +428,13 @@ func (t *Tree) RootNode() *Node {
 	if root == nil {
 		return nil
 	}
-	a := newNodeArena()
+	// Take a pooled arena on first use and reuse it for any later RootNode
+	// call on the same tree, so every node walked from this tree allocates
+	// into one recycled arena. Close() returns it to the pool.
+	if t.arena == nil {
+		t.arena = getArena()
+	}
+	a := t.arena
 	nn := a.alloc()
 	nn.inner = *root
 	nn.valid = true
@@ -384,11 +443,23 @@ func (t *Tree) RootNode() *Node {
 	return nn
 }
 
-// Close releases the tree's C resources.
+// Close releases the tree's C resources and recycles its node arena.
+//
+// The arena is returned to the pool AFTER the C tree is freed: by the
+// Tree's contract every Node wrapper is dead once Close returns, so the
+// chunks the arena retains hold nothing live. putArena's reset() clears any
+// stale slot, so a recycled arena never pins a closed tree.
 func (t *Tree) Close() {
-	if t != nil && t.inner != nil {
+	if t == nil {
+		return
+	}
+	if t.inner != nil {
 		t.inner.Close()
 		t.inner = nil
+	}
+	if t.arena != nil {
+		putArena(t.arena)
+		t.arena = nil
 	}
 }
 

--- a/internal/parser/tsitter/tsitter.go
+++ b/internal/parser/tsitter/tsitter.go
@@ -58,19 +58,82 @@ type Node struct {
 	// call and no allocation. Nil means "not stamped" — Type() then
 	// derives the language, which is slower but still correct.
 	langKey unsafe.Pointer
+	// arena bump-allocates Node wrappers in chunks so a deep tree walk
+	// produces a few large backing arrays instead of millions of tiny heap
+	// objects. The per-object GC mark cost dominated CPU when indexing a
+	// large TS monorepo (vscode: ~70% of cycles in GC, scanning millions of
+	// 1-node spans). Chunks are never explicitly freed — they are reachable
+	// only through the Nodes that point into them and are reclaimed by the
+	// GC once the tree's nodes are dropped. A nil arena falls back to a plain
+	// heap Node (zero-value and SetInner-pooled nodes have no arena).
+	arena *nodeArena
+}
+
+// nodeArena is a per-tree bump allocator for Node wrappers. It is not
+// safe for concurrent use; each parse tree is walked by a single
+// goroutine, and distinct files use distinct trees (and arenas).
+type nodeArena struct {
+	cur  []Node
+	used int
+}
+
+const (
+	// arenaFirstChunk keeps the first backing array small so a file with a
+	// handful of nodes (the common case in a many-small-files repo) wastes
+	// little; chunks then double up to arenaMaxChunk so a deep file still
+	// ends up with only a few large objects.
+	arenaFirstChunk = 64
+	arenaMaxChunk   = 4096
+)
+
+func newNodeArena() *nodeArena { return &nodeArena{} }
+
+// alloc returns a pointer to a fresh zeroed Node. The pointer is stable:
+// when the current chunk fills, a new (geometrically larger) backing array
+// is allocated and the old chunk stays alive through the Nodes that point
+// into it.
+func (a *nodeArena) alloc() *Node {
+	if a.used >= len(a.cur) {
+		size := len(a.cur) * 2
+		if size == 0 {
+			size = arenaFirstChunk
+		} else if size > arenaMaxChunk {
+			size = arenaMaxChunk
+		}
+		a.cur = make([]Node, size)
+		a.used = 0
+	}
+	n := &a.cur[a.used]
+	a.used++
+	return n
 }
 
 // WrapNode wraps a value Node from the new API into our shim. It derives
-// the language key eagerly so navigation from the result stays alloc-free.
+// the language key eagerly so navigation from the result stays alloc-free,
+// and seeds a fresh arena so the subtree walk below it allocates in chunks.
 func WrapNode(n ts.Node) *Node {
-	return &Node{inner: n, valid: true, langKey: unsafe.Pointer(n.Language().Inner)}
+	a := newNodeArena()
+	nn := a.alloc()
+	nn.inner = n
+	nn.valid = true
+	nn.langKey = unsafe.Pointer(n.Language().Inner)
+	nn.arena = a
+	return nn
 }
 
 // WrapVal wraps a ts.Node reached from n (e.g. a query capture),
 // carrying n's language key so Type() on the result and its descendants
 // needs neither CGO nor allocation.
 func (n *Node) WrapVal(c ts.Node) *Node {
-	return &Node{inner: c, valid: true, langKey: n.langKey}
+	if n.arena == nil {
+		return &Node{inner: c, valid: true, langKey: n.langKey}
+	}
+	nn := n.arena.alloc()
+	nn.inner = c
+	nn.valid = true
+	nn.langKey = n.langKey
+	nn.arena = n.arena
+	return nn
 }
 
 // SetInner overwrites the receiver's wrapped ts.Node and marks it
@@ -90,7 +153,15 @@ func (n *Node) wrap(c *ts.Node) *Node {
 	if c == nil {
 		return nil
 	}
-	return &Node{inner: *c, valid: true, langKey: n.langKey}
+	if n.arena == nil {
+		return &Node{inner: *c, valid: true, langKey: n.langKey}
+	}
+	nn := n.arena.alloc()
+	nn.inner = *c
+	nn.valid = true
+	nn.langKey = n.langKey
+	nn.arena = n.arena
+	return nn
 }
 
 // Inner returns a pointer to the underlying ts.Node. Internal use by
@@ -304,11 +375,13 @@ func (t *Tree) RootNode() *Node {
 	if root == nil {
 		return nil
 	}
-	return &Node{
-		inner:   *root,
-		valid:   true,
-		langKey: unsafe.Pointer(root.Language().Inner),
-	}
+	a := newNodeArena()
+	nn := a.alloc()
+	nn.inner = *root
+	nn.valid = true
+	nn.langKey = unsafe.Pointer(root.Language().Inner)
+	nn.arena = a
+	return nn
 }
 
 // Close releases the tree's C resources.

--- a/internal/resolver/generic_param_bind.go
+++ b/internal/resolver/generic_param_bind.go
@@ -71,6 +71,49 @@ func (r *Resolver) bindGenericParamRefs() {
 	}
 }
 
+// bindGenericParamRefsForFile is the single-file-resolve form of
+// bindGenericParamRefs. A type parameter is visible only inside its own
+// function's body, which lives in this file, so both the owner index and the
+// edges to rewrite are scoped to the file — no whole-graph EdgesByKind sweep
+// (the dominant cost of an incremental edit on a large graph).
+func (r *Resolver) bindGenericParamRefsForFile(filePath string) {
+	owned := map[string]map[string]string{}
+	for _, n := range r.graph.GetFileNodes(filePath) {
+		if n == nil || n.Kind != graph.KindGenericParam || n.Language != "go" || n.Name == "" {
+			continue
+		}
+		owner := enclosingFunctionForBinding(n.ID)
+		if owner == "" || owner == n.ID {
+			continue
+		}
+		set, ok := owned[owner]
+		if !ok {
+			set = map[string]string{}
+			owned[owner] = set
+		}
+		if _, dup := set[n.Name]; dup {
+			set[n.Name] = ""
+			continue
+		}
+		set[n.Name] = n.ID
+	}
+	if len(owned) == 0 {
+		return
+	}
+	var batch []graph.EdgeReindex
+	for _, e := range r.fileOutEdges(filePath) {
+		switch e.Kind {
+		case graph.EdgeReferences, graph.EdgeTypedAs, graph.EdgeReturns, graph.EdgeInstantiates:
+			if old := r.tryBindGenericParam(e, owned); old != "" {
+				batch = append(batch, graph.EdgeReindex{Edge: e, OldTo: old})
+			}
+		}
+	}
+	if len(batch) > 0 {
+		r.graph.ReindexEdges(batch)
+	}
+}
+
 // tryBindGenericParam returns the old To value (for batched reindex)
 // when the edge was rewritten, or "" when left alone.
 func (r *Resolver) tryBindGenericParam(e *graph.Edge, owned map[string]map[string]string) string {

--- a/internal/resolver/incremental.go
+++ b/internal/resolver/incremental.go
@@ -1,0 +1,58 @@
+package resolver
+
+import "github.com/zzet/gortex/internal/graph"
+
+// Incremental single-file resolve: skip re-resolving a file's references that
+// were already unresolved before the edit.
+//
+// On a save the whole file is evicted, re-parsed (every edge unresolved), and
+// re-resolved. For a reference-heavy file most of those edges are stdlib /
+// external calls (strings.HasPrefix, fmt.Sprintf, …) that never bind to an
+// in-repo symbol — yet the resolver re-runs its full candidate fetch + cascade
+// on each of them every save. That re-work dominates edit latency.
+//
+// An edge that was unresolved before the edit and is unchanged will not bind
+// now either: it still points at the same stub, and the incoming pass already
+// rebinds it if a matching symbol later appears (when that symbol's file is
+// indexed). So the single-file path captures those prior-unresolved shapes and
+// the forward pass skips them, touching only references the edit actually
+// added or changed.
+
+// SetIncrementalSkip installs the prior-unresolved out-edge shapes for the
+// file about to be re-resolved (nil to clear afterwards). Only the forward
+// pass honours it; the incoming pass still rebinds other files' references to
+// this file's symbols. The per-file resolve runs single-goroutine under r.mu,
+// so this field needs no extra synchronisation.
+func (r *Resolver) SetIncrementalSkip(priorUnresolved []*graph.Edge) {
+	if len(priorUnresolved) == 0 {
+		r.incrementalSkip = nil
+		return
+	}
+	skip := make(map[string]struct{}, len(priorUnresolved))
+	for _, e := range priorUnresolved {
+		if e != nil {
+			skip[r.edgeShape(e)] = struct{}{}
+		}
+	}
+	r.incrementalSkip = skip
+}
+
+// edgeShape canonicalises an edge by its source-side identity — origin symbol,
+// kind, receiver type, referenced name — independent of line number and of
+// whether the edge is currently resolved. The captured prior edges and the
+// freshly re-parsed ones run through the same function, so an unchanged
+// reference produces the same key and is recognised as a carry-over.
+func (r *Resolver) edgeShape(e *graph.Edge) string {
+	name := identifierFromTarget(graph.UnresolvedName(e.To))
+	return e.From + "\x1f" + string(e.Kind) + "\x1f" + edgeReceiverType(e) + "\x1f" + name
+}
+
+// incrementalSkipped reports whether an unresolved edge should be left for the
+// incoming pass instead of re-running the forward cascade on it.
+func (r *Resolver) incrementalSkipped(e *graph.Edge) bool {
+	if r.incrementalSkip == nil {
+		return false
+	}
+	_, ok := r.incrementalSkip[r.edgeShape(e)]
+	return ok
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -74,6 +74,13 @@ type Resolver struct {
 	// `RegisterAll` resolving to `OverlayManager.Register` simply
 	// because "OverlayManager" sorts before "Registry".
 	reachableDirsByFile map[string]map[string]struct{}
+	// dirByFilePath memoises filepath.Dir(path) for every indexed file,
+	// built once alongside reachableDirsByFile. filterByReachability runs in
+	// the parallel resolver workers and otherwise recomputes filepath.Dir
+	// per candidate per edge — ~20% of resolution CPU on a large TS monorepo
+	// (filepathlite.Dir/Clean dominate). Read-only after build, so the
+	// workers share it lock-free.
+	dirByFilePath map[string]string
 	// depModuleIndex bridges Go imports to dep::<module> contract
 	// nodes emitted from go.mod. Keyed by RepoPrefix (the dep node's
 	// owning repo) so we never link an import in repo A to a dep
@@ -1384,7 +1391,7 @@ func (r *Resolver) resolveExtern(e *graph.Edge, spec string, stats *ResolveStats
 		if c.Kind != graph.KindFunction && c.Kind != graph.KindMethod && c.Kind != graph.KindType && c.Kind != graph.KindInterface {
 			continue
 		}
-		dir := filepath.Dir(c.FilePath)
+		dir := r.dirFor(c.FilePath)
 		crossRepo := callerRepo != "" && c.RepoPrefix != "" && c.RepoPrefix != callerRepo
 		var matches bool
 		if crossRepo {
@@ -1631,10 +1638,10 @@ func (r *Resolver) resolveFunctionCall(e *graph.Edge, funcName string, stats *Re
 	}
 
 	// Prefer same-package (same directory) match.
-	callerDir := filepath.Dir(e.FilePath)
+	callerDir := r.dirFor(e.FilePath)
 	for _, c := range candidates {
 		if (c.Kind == graph.KindFunction || c.Kind == graph.KindMethod) &&
-			filepath.Dir(c.FilePath) == callerDir {
+			r.dirFor(c.FilePath) == callerDir {
 			e.To = c.ID
 			stats.Resolved++
 			return
@@ -1667,7 +1674,7 @@ func (r *Resolver) resolveTypeOrFunc(e *graph.Edge, name string, stats *ResolveS
 		return
 	}
 
-	callerDir := filepath.Dir(e.FilePath)
+	callerDir := r.dirFor(e.FilePath)
 
 	// Land the edge on the canonical type/interface definition (real,
 	// exported, top-level, non-test), preferring same-package only as a
@@ -1684,7 +1691,7 @@ func (r *Resolver) resolveTypeOrFunc(e *graph.Edge, name string, stats *ResolveS
 	// If no type found, try as function (e.g., bare function name passed as value).
 	for _, c := range candidates {
 		if c.Kind == graph.KindFunction || c.Kind == graph.KindMethod {
-			if filepath.Dir(c.FilePath) == callerDir {
+			if r.dirFor(c.FilePath) == callerDir {
 				e.To = c.ID
 				stats.Resolved++
 				return
@@ -1720,7 +1727,7 @@ func (r *Resolver) resolveTypeRef(e *graph.Edge, name string, stats *ResolveStat
 		stats.Unresolved++
 		return
 	}
-	callerDir := filepath.Dir(e.FilePath)
+	callerDir := r.dirFor(e.FilePath)
 
 	// Land the edge on the canonical type/interface definition. The
 	// ranker prefers a real, exported, top-level, non-test definition
@@ -1748,13 +1755,13 @@ func (r *Resolver) resolveFieldRef(e *graph.Edge, fieldName string, stats *Resol
 	if len(candidates) == 0 {
 		return false
 	}
-	callerDir := filepath.Dir(e.FilePath)
+	callerDir := r.dirFor(e.FilePath)
 
 	// Pass 1: same-directory + exact-receiver-type field.
 	if receiverType != "" {
 		for _, c := range candidates {
 			if c.Kind == graph.KindField &&
-				filepath.Dir(c.FilePath) == callerDir &&
+				r.dirFor(c.FilePath) == callerDir &&
 				nodeReceiverType(c) == receiverType {
 				e.To = c.ID
 				e.Confidence = 0.95
@@ -1791,7 +1798,7 @@ func (r *Resolver) resolveFieldRef(e *graph.Edge, fieldName string, stats *Resol
 	// Pass 4: same-directory field of any owner type — last resort
 	// before falling through to method resolution.
 	for _, c := range candidates {
-		if c.Kind == graph.KindField && filepath.Dir(c.FilePath) == callerDir {
+		if c.Kind == graph.KindField && r.dirFor(c.FilePath) == callerDir {
 			e.To = c.ID
 			e.Confidence = 0.6
 			stats.Resolved++
@@ -1838,7 +1845,7 @@ func (r *Resolver) resolveMethodCall(e *graph.Edge, methodName string, stats *Re
 		return
 	}
 
-	callerDir := filepath.Dir(e.FilePath)
+	callerDir := r.dirFor(e.FilePath)
 	receiverType := edgeReceiverType(e)
 
 	// If we have a type hint, try exact type match first.
@@ -1846,7 +1853,7 @@ func (r *Resolver) resolveMethodCall(e *graph.Edge, methodName string, stats *Re
 		// Pass 1: same-directory + exact type match (highest confidence).
 		for _, c := range candidates {
 			if c.Kind == graph.KindMethod &&
-				filepath.Dir(c.FilePath) == callerDir &&
+				r.dirFor(c.FilePath) == callerDir &&
 				nodeReceiverType(c) == receiverType {
 				e.To = c.ID
 				e.Confidence = 0.95
@@ -1904,7 +1911,7 @@ func (r *Resolver) resolveMethodCall(e *graph.Edge, methodName string, stats *Re
 			// Same receiver type + same directory = very high confidence.
 			for _, c := range candidates {
 				if c.Kind == graph.KindMethod &&
-					filepath.Dir(c.FilePath) == callerDir &&
+					r.dirFor(c.FilePath) == callerDir &&
 					nodeReceiverType(c) == callerRecv {
 					e.To = c.ID
 					e.Confidence = 0.9
@@ -1946,14 +1953,14 @@ func (r *Resolver) resolveMethodCall(e *graph.Edge, methodName string, stats *Re
 		switch c.Kind {
 		case graph.KindMethod:
 			methodCount++
-			if filepath.Dir(c.FilePath) == callerDir && sameDirMethod == nil {
+			if r.dirFor(c.FilePath) == callerDir && sameDirMethod == nil {
 				sameDirMethod = c
 			}
 			if anyMethod == nil {
 				anyMethod = c
 			}
 		case graph.KindFunction:
-			if filepath.Dir(c.FilePath) == callerDir && sameDirFunc == nil {
+			if r.dirFor(c.FilePath) == callerDir && sameDirFunc == nil {
 				sameDirFunc = c
 			}
 			if anyFunc == nil {
@@ -2060,9 +2067,9 @@ func (r *Resolver) resolveTokenRef(e *graph.Edge, name string, stats *ResolveSta
 		stats.Unresolved++
 		return
 	}
-	callerDir := filepath.Dir(e.FilePath)
+	callerDir := r.dirFor(e.FilePath)
 	for _, c := range candidates {
-		if filepath.Dir(c.FilePath) == callerDir {
+		if r.dirFor(c.FilePath) == callerDir {
 			e.To = c.ID
 			e.Confidence = 0.9
 			stats.Resolved++
@@ -2161,9 +2168,13 @@ func (r *Resolver) buildReachabilityIndex() {
 		set[dir] = struct{}{}
 	}
 
-	// Seed with each indexed file's own directory.
+	// Seed with each indexed file's own directory, and memoise the per-file
+	// dir so filterByReachability never recomputes filepath.Dir per edge.
+	dirByPath := make(map[string]string)
 	for n := range r.graph.NodesByKind(graph.KindFile) {
-		addDir(n.ID, filepath.Dir(n.FilePath))
+		dir := filepath.Dir(n.FilePath)
+		dirByPath[n.FilePath] = dir
+		addDir(n.ID, dir)
 	}
 
 	// Materialise the import edges and batch-load the endpoints of the
@@ -2216,9 +2227,25 @@ func (r *Resolver) buildReachabilityIndex() {
 	}
 
 	r.reachableDirsByFile = idx
+	r.dirByFilePath = dirByPath
 }
 
-func (r *Resolver) clearReachabilityIndex() { r.reachableDirsByFile = nil }
+func (r *Resolver) clearReachabilityIndex() {
+	r.reachableDirsByFile = nil
+	r.dirByFilePath = nil
+}
+
+// dirFor returns filepath.Dir(path), served from the per-file memo built in
+// buildReachabilityIndex (every indexed file is keyed) and falling back to a
+// live computation for paths not in the index. The memo turns the per-edge
+// filepath.Dir in filterByReachability — ~20% of resolution CPU on a large
+// monorepo — into a map lookup.
+func (r *Resolver) dirFor(path string) string {
+	if d, ok := r.dirByFilePath[path]; ok {
+		return d
+	}
+	return filepath.Dir(path)
+}
 
 // filterByReachability narrows candidates to those whose defining file
 // sits in a package reachable from the caller file. "Reachable" means:
@@ -2238,7 +2265,7 @@ func (r *Resolver) filterByReachability(callerFileID string, candidates []*graph
 	}
 	out := candidates[:0:0]
 	for _, c := range candidates {
-		if _, ok := reachable[filepath.Dir(c.FilePath)]; ok {
+		if _, ok := reachable[r.dirFor(c.FilePath)]; ok {
 			out = append(out, c)
 		}
 	}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -115,6 +115,12 @@ type Resolver struct {
 	nodesByName     map[string][]*graph.Node
 	nodesByQualName map[string]*graph.Node
 
+	// incrementalSkip holds the source-shapes of a single re-resolved file's
+	// out-edges that were already unresolved before the edit; the forward
+	// pass skips them. Set/cleared around ResolveFileAndIncoming by the
+	// single-file index path. nil on every batch/whole-graph pass.
+	incrementalSkip map[string]struct{}
+
 	// lspHelper, when non-nil, is consulted before falling back to
 	// AST heuristics for cross-file dispatch in languages whose
 	// helper-reported extensions match (today: TS/JS/JSX/TSX via
@@ -886,12 +892,19 @@ func (r *Resolver) pendingEdgesForFileAndIncoming(filePath string) []*graph.Edge
 	defNodes := r.graph.GetFileNodes(filePath)
 	var pending []*graph.Edge
 	seenNames := make(map[string]struct{}, len(defNodes))
+	defIDs := make([]string, 0, len(defNodes))
+	for _, n := range defNodes {
+		if n != nil {
+			defIDs = append(defIDs, n.ID)
+		}
+	}
+	outByNode := graph.OutEdgesForNodes(r.graph, defIDs)
 	for _, n := range defNodes {
 		if n == nil {
 			continue
 		}
-		for _, e := range r.graph.GetOutEdges(n.ID) {
-			if graph.IsUnresolvedTarget(e.To) {
+		for _, e := range outByNode[n.ID] {
+			if graph.IsUnresolvedTarget(e.To) && !r.incrementalSkipped(e) {
 				pending = append(pending, e)
 			}
 		}
@@ -956,9 +969,14 @@ func (r *Resolver) resolveFileLocked(filePath string, stats *ResolveStats) {
 // so this is the complete candidate set for those passes.
 func (r *Resolver) fileOutEdges(filePath string) []*graph.Edge {
 	nodes := r.graph.GetFileNodes(filePath)
+	ids := make([]string, 0, len(nodes))
+	for _, n := range nodes {
+		ids = append(ids, n.ID)
+	}
+	byNode := graph.OutEdgesForNodes(r.graph, ids)
 	var out []*graph.Edge
 	for _, n := range nodes {
-		out = append(out, r.graph.GetOutEdges(n.ID)...)
+		out = append(out, byNode[n.ID]...)
 	}
 	return out
 }
@@ -978,10 +996,22 @@ func (r *Resolver) resolveFileEdgesLocked(filePath string, stats *ResolveStats) 
 	var jobs []reindexJob
 	var reindexBatch []graph.EdgeReindex
 	nodes := r.graph.GetFileNodes(filePath)
+	ids := make([]string, 0, len(nodes))
 	for _, n := range nodes {
-		edges := r.graph.GetOutEdges(n.ID)
+		ids = append(ids, n.ID)
+	}
+	byNode := graph.OutEdgesForNodes(r.graph, ids)
+	for _, n := range nodes {
+		edges := byNode[n.ID]
 		for _, e := range edges {
 			if !graph.IsUnresolvedTarget(e.To) {
+				continue
+			}
+			// Carry-over reference unchanged since the last resolve and
+			// already unresolved then — leave it for the incoming pass
+			// instead of re-running the cascade (the bulk of edit latency
+			// on reference-heavy files).
+			if r.incrementalSkipped(e) {
 				continue
 			}
 			oldTo, changed := r.resolveEdge(e, stats)
@@ -1047,7 +1077,7 @@ func (r *Resolver) runFileAttributionPassesLocked() {
 func (r *Resolver) runFileAttributionPassesForFileLocked(filePath string) {
 	r.rebindGoMethodReceiversForFile(filePath)
 	r.bindBareNameScopeRefsForFile(filePath)
-	r.bindGenericParamRefs()
+	r.bindGenericParamRefsForFile(filePath)
 	r.attributeGoBuiltinsForFile(filePath)
 	r.attributeGoExternalCallsForFile(filePath)
 }

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -731,7 +731,26 @@ func (r *Resolver) cachedFindNodesByNameInRepo(name, repo string) []*graph.Node 
 	}
 	if r.nodesByName != nil {
 		if hits, ok := r.nodesByName[name]; ok {
-			var out []*graph.Node
+			// Count repo matches before allocating. When every hit is in
+			// repo -- always so in single-repo mode, and common otherwise --
+			// hand back the cached slice (capped so a caller's append cannot
+			// scribble into the cache) instead of copying it. The per-call
+			// copy + growslice here was the largest allocation source during
+			// resolution on a large index; callers treat the result as
+			// read-only.
+			match := 0
+			for _, n := range hits {
+				if n != nil && n.RepoPrefix == repo {
+					match++
+				}
+			}
+			switch {
+			case match == 0:
+				return nil
+			case match == len(hits):
+				return hits[:len(hits):len(hits)]
+			}
+			out := make([]*graph.Node, 0, match)
 			for _, n := range hits {
 				if n != nil && n.RepoPrefix == repo {
 					out = append(out, n)

--- a/internal/semantic/goanalysis/provider.go
+++ b/internal/semantic/goanalysis/provider.go
@@ -6,6 +6,7 @@ import (
 	"go/token"
 	"go/types"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -112,10 +113,30 @@ func (p *Provider) Close() error {
 	return nil
 }
 
+// goToolchainOnce caches the one-time probe for the `go` command. The
+// provider shells out through go/packages (`go list`), so without the
+// toolchain on PATH it can only fail — and a shipped gortex binary often
+// runs on a machine with no Go installed. Probing once lets the manager's
+// Available() gate skip the provider instead of attempting a package load
+// that fails on every index.
+var (
+	goToolchainOnce sync.Once
+	goToolchainOK   bool
+)
+
+func goToolchainAvailable() bool {
+	goToolchainOnce.Do(func() {
+		_, err := exec.LookPath("go")
+		goToolchainOK = err == nil
+	})
+	return goToolchainOK
+}
+
 func (p *Provider) Available() bool {
-	// go/packages requires the Go toolchain. Check if 'go' is on PATH.
-	// Since this is a Go binary, the toolchain is almost always present.
-	return true
+	// go/packages requires the Go toolchain; gate on a cached PATH probe
+	// so a binary running without `go` skips this provider cleanly and
+	// the go-ast-types supplemental provider serves Go instead.
+	return goToolchainAvailable()
 }
 
 func (p *Provider) Enrich(g graph.Store, repoRoot string) (*semantic.EnrichResult, error) {

--- a/internal/semantic/lsp/router.go
+++ b/internal/semantic/lsp/router.go
@@ -16,6 +16,16 @@ import (
 )
 
 // fileExists reports whether path names an existing regular file.
+// spawnRubyLSPWithoutGemfile reports whether ruby-lsp should still be
+// launched for a workspace that has no Gemfile (and would therefore trigger
+// a network `bundle install` for its composed bundle on spawn). Default
+// false — skip it and rely on the in-process ruby resolver. Set
+// GORTEX_RUBY_LSP_NO_GEMFILE=1 to restore the spawn.
+func spawnRubyLSPWithoutGemfile() bool {
+	v := os.Getenv("GORTEX_RUBY_LSP_NO_GEMFILE")
+	return v == "1" || strings.EqualFold(v, "true")
+}
+
 func fileExists(path string) bool {
 	info, err := os.Stat(path)
 	return err == nil && !info.IsDir()
@@ -430,6 +440,15 @@ func (r *Router) forSpecWorkspace(spec *ServerSpec, workspace string, pin bool) 
 	if spec.UseWorkspaceBundleGemfile {
 		if gemfile := filepath.Join(workspace, "Gemfile"); fileExists(gemfile) {
 			p.env = append(append([]string(nil), p.env...), "BUNDLE_GEMFILE="+gemfile)
+		} else if !spawnRubyLSPWithoutGemfile() {
+			// No Gemfile: ruby-lsp runs a `bundle install` for its composed
+			// bundle on spawn — a multi-second network round-trip to
+			// rubygems.org — for a workspace where Ruby is typically only test
+			// fixtures. Skip the LSP; the in-process ruby-types resolver still
+			// covers Ruby. This is a per-workspace skip (NOT markSpawnFailed),
+			// so a sibling repo that does carry a Gemfile still spawns ruby-lsp.
+			// GORTEX_RUBY_LSP_NO_GEMFILE=1 forces the spawn.
+			return nil, fmt.Errorf("ruby-lsp: no Gemfile in %s; skipping composed-bundle install", workspace)
 		}
 	}
 	if err := p.EnsureClient(workspace); err != nil {

--- a/internal/serverstack/embedder.go
+++ b/internal/serverstack/embedder.go
@@ -55,10 +55,41 @@ func ResolveEmbedder(req EmbedderRequest, cfg *config.Config) (embedding.Provide
 		return buildConfiguredEmbedder(embCfg, "enabled by flag/env")
 	}
 
-	if !embCfg.EmbeddingEnabledOrDefault() {
+	// No explicit flag/env toggle. An explicit `embedding.enabled: false`
+	// still wins and disables the vector channel.
+	if embCfg.Enabled != nil && !*embCfg.Enabled {
 		return nil, "", nil
 	}
-	return buildConfiguredEmbedder(embCfg, "enabled by config default")
+	// An explicit `embedding.enabled: true` builds whatever provider is
+	// configured, including the baked static GloVe one.
+	if embCfg.Enabled != nil && *embCfg.Enabled {
+		return buildConfiguredEmbedder(embCfg, "enabled by config")
+	}
+	// Otherwise (the default, unset state) build a vector index ONLY when
+	// the user has configured a real, model-backed embedder. The static
+	// GloVe provider's dim-50 word vectors add little over FTS5/BM25 text
+	// search yet cost 0.6-0.7s of every index to build, so it is now
+	// opt-in: FTS5 text search serves the default, and semantic search
+	// turns on when a `local`/`api` provider (or embedding.enabled: true,
+	// or GORTEX_EMBEDDINGS=1) is configured.
+	if isRealEmbedder(embCfg.EmbeddingProviderOrDefault()) {
+		return buildConfiguredEmbedder(embCfg, "real embedder configured")
+	}
+	return nil, "", nil
+}
+
+// isRealEmbedder reports whether the named provider is a model-backed
+// embedder worth the index-time vector build. The baked `static` GloVe
+// provider is excluded: its dim-50 averaged word vectors add little over
+// FTS5 text search, so it no longer builds a vector index by default
+// (opt in with embedding.enabled: true or GORTEX_EMBEDDINGS=1).
+func isRealEmbedder(provider string) bool {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "local", "api":
+		return true
+	default:
+		return false
+	}
 }
 
 // explicitEmbeddingToggle reports whether the caller gave an explicit

--- a/internal/serverstack/shared_server.go
+++ b/internal/serverstack/shared_server.go
@@ -329,7 +329,15 @@ func NewSharedServer(cfg SharedServerConfig) (*SharedServer, error) {
 			goMode = goanalysis.ModeCallGraph
 		}
 		goProvider := goanalysis.NewProvider(goMode, false, logger)
-		semMgr.RegisterProvider(goProvider)
+		// The go/packages "go-types" provider is a full `go list ./...` +
+		// go/types pass over the module on every index — tens of seconds per
+		// Go module per warmup, and on an already-resolved graph it routinely
+		// confirms zero new edges (the always-on go-ast-types tree-sitter
+		// floor already covers Go). Keep it as the contracts binding resolver,
+		// but only register it for enrichment when explicitly opted in.
+		if goTypesEnrichEnabled(conf.Semantic) {
+			semMgr.RegisterProvider(goProvider)
+		}
 		contracts.SetBindingResolver(goProvider)
 
 		// In-process tree-sitter type resolvers — always-available
@@ -604,4 +612,15 @@ func NewSharedServer(cfg SharedServerConfig) (*SharedServer, error) {
 	}
 
 	return s, nil
+}
+
+// goTypesEnrichEnabled reports whether the heavyweight go/packages
+// "go-types" enrichment provider should be registered. Default OFF — the
+// always-on go-ast-types tree-sitter floor serves Go resolution at a
+// fraction of the cost. GORTEX_GO_TYPES=1/0 overrides the config key.
+func goTypesEnrichEnabled(sem config.SemanticConfig) bool {
+	if v := os.Getenv("GORTEX_GO_TYPES"); v != "" {
+		return v == "1" || strings.EqualFold(v, "true")
+	}
+	return sem.GoTypesEnabledOrDefault()
 }


### PR DESCRIPTION
## Summary

Performance work on the two hottest daemon paths — the **full index** of a large repository and the **single-file re-index** on an edit. Profiling showed both were dominated by avoidable work: GC churn from tree-sitter node wrappers on the index path, and whole-graph passes re-run on every save on the edit path.

Everything here was profiled (pprof CPU + heap) and measured before/after. Graph output is unchanged and `go test -race` is green across the touched packages.

## Full-index hot path

Profiling a vscode and a kubernetes index put **~40% of CPU in GC**, with **70–82% of every byte allocated being tree-sitter Node wrappers**. The index also did work the default never needs.

- **Skip the vector pass by default** — the static embedder is now opt-in, so a default index builds FTS only and skips the BM25/vector build. (`4c9aebe6`)
- **Gate the go/types provider** on a cached `go`-on-PATH probe so it never spawns when the toolchain is absent. (`ceb8bc86`)
- **Pool + reuse the tree-sitter Node arena** across files instead of allocating fresh backing chunks per file — arena allocation drops **84–91%**. (`40db4ca8`, `d8106603`)
- **Navigate children via direct C calls** (`ts_node_child` / `named_child` / `parent` / siblings / field-name / cursor-current-node) which return `TSNode` by value, instead of go-tree-sitter's per-node heap wrapper. This eliminates `newNode`, which was ~43% of allocations after pooling. (`2f2774f1`, `0e41466f`)
- **Hoist the child-count out of loop conditions** across the 100+ extractors. (`9263dd64`)
- **Stop copying the resolver name-lookup cache** — return the cached slice directly when every hit is in-repo (always so in single-repo mode), which was the largest single allocation source during resolution. (`089e8655`)
- **Memoise `filepath.Dir` per file** in the resolver. (`6056244f`)

**Result:** the tree-sitter Node churn that drove GC is largely gone (arena −84–91%, `newNode` eliminated, resolver copy eliminated), roughly halving total allocation. Under a memory cap — where the GC was thrashing — the core index time drops substantially, and a kubernetes index that previously **never finished under a 7 GB cap now completes**.

## Edit hot path (single-file re-index)

A single save re-ran several whole-graph / O(file·graph) operations, so one edit cost seconds on a large graph. Two of these were latent bugs.

- **Incremental resolve** — snapshot the file's resolved out-edges before eviction and restore unchanged references after the re-parse, and skip re-trying references that were already unresolved (they stay parked on stubs for the incoming pass). Only genuinely-new references hit the resolver cascade. Conservative: ambiguous shapes and missing targets re-resolve from scratch, so output can only ever match the full resolver.
- **Batched out-edge fetch** — `GetOutEdgesForNodes` fetches a file's nodes' out-edges in one query instead of an N+1 storm per node on the disk backend.
- **File-scope the generic-param binding pass** (bug) — it scanned every `References` / `TypedAs` / `Returns` / `Instantiates` edge in the whole graph on each save (1.3 s cold on this repo), although a type parameter is visible only in its own function's body, which lives in the edited file.
- **Seed the clone index lazily** (bug) — after a warm restart that loads the graph without a full re-index its `built` flag is false, so every save fell to the whole-graph clone recompute (~0.9 s); build it once on first use, then run the O(edited-file) update.

(`7f4cfd2a`)

**Result** (this repo, 184k nodes / 1M edges, sqlite backend):

| | before | after (warm) | after (cold first edit) |
|---|---|---|---|
| typical file (~240 lines) | — | **~205 ms** | ~1.35 s¹ |
| worst-case hub file (~3000 lines) | **~10 s** | **~1.3 s** | ~3.2 s¹ |

¹ The cold first edit is dominated by one-time costs (the lazy clone-index seed + sqlite page-cache warming); steady-state edits are the warm column.

## Testing & method

- `go test -race` green for `internal/parser/...`, `internal/resolver`, `internal/indexer`, `internal/graph/...`.
- Index path measured with pprof CPU + heap profiles in CPU/memory-capped Docker runs (vscode, kubernetes). Edit path measured with a sqlite-backed harness against this repo.
- Graph correctness checked by identical node/edge counts before/after, and the incremental reuse is conservative by construction (falls back to full resolution on any ambiguity).
