### PR TITLE
fix(hooks): route file-indexed probe through daemon socket so hard-de…

### DIFF
--- a/internal/hooks/edit_test.go
+++ b/internal/hooks/edit_test.go
@@ -2,8 +2,6 @@ package hooks
 
 import (
 	"encoding/json"
-	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -16,33 +14,30 @@ func withEditBlocking(t *testing.T, on bool) {
 	t.Setenv(editBlockingEnvVar, map[bool]string{true: "1", false: ""}[on])
 }
 
-// fakeIndexedBridge stands up an HTTP server matching the bridge's
-// /api/graph/file shape so queryFileIndexed treats the named file as
-// indexed.
-func fakeIndexedBridge(t *testing.T, indexedPaths map[string]bool) (port int) {
+// fakeIndexedBridge stubs the daemon file-indexed probe so the named
+// files are treated as indexed (one symbol each) for the duration of the
+// test, restoring the real probe on cleanup.
+// Returns a dummy port (0) so the legacy `port := fakeIndexedBridge(...)`
+// call sites still compile; the value is unused now that the indexed check
+// routes through the stubbed fileIndexedFn seam rather than an HTTP port.
+func fakeIndexedBridge(t *testing.T, indexedPaths map[string]bool) int {
 	t.Helper()
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/graph/file" {
-			http.NotFound(w, r)
-			return
+	prev := fileIndexedFn
+	t.Cleanup(func() { fileIndexedFn = prev })
+	fileIndexedFn = func(_, filePath string) (bool, int) {
+		if indexedPaths[filePath] {
+			return true, 1
 		}
-		path := r.URL.Query().Get("path")
-		if !indexedPaths[path] {
-			_, _ = w.Write([]byte(`{"nodes":[]}`))
-			return
-		}
-		// Emit two nodes so queryFileIndexed sees ≥2 (file node + one).
-		_, _ = w.Write([]byte(`{"nodes":[{"id":"file"},{"id":"sym"}]}`))
-	}))
-	t.Cleanup(srv.Close)
-	return portFromURL(t, srv.URL)
+		return false, 0
+	}
+	return 0
 }
 
 func TestEnrichEdit_Disabled_NoOp(t *testing.T) {
 	withEditBlocking(t, false)
-	port := fakeIndexedBridge(t, map[string]bool{"/repo/foo.go": true})
+	fakeIndexedBridge(t, map[string]bool{"/repo/foo.go": true})
 
-	result := enrichEdit(map[string]any{"file_path": "/repo/foo.go"}, port)
+	result := enrichEdit(map[string]any{"file_path": "/repo/foo.go"}, "")
 	if result.deny || result.context != "" {
 		t.Errorf("disabled ⇒ silent; got deny=%v ctx=%q", result.deny, result.context)
 	}
@@ -50,9 +45,9 @@ func TestEnrichEdit_Disabled_NoOp(t *testing.T) {
 
 func TestEnrichEdit_NonSource_PassThrough(t *testing.T) {
 	withEditBlocking(t, true)
-	port := fakeIndexedBridge(t, map[string]bool{"/repo/README.md": true})
+	fakeIndexedBridge(t, map[string]bool{"/repo/README.md": true})
 
-	result := enrichEdit(map[string]any{"file_path": "/repo/README.md"}, port)
+	result := enrichEdit(map[string]any{"file_path": "/repo/README.md"}, "")
 	if result.deny || result.context != "" {
 		t.Errorf("non-source ⇒ pass through; got deny=%v ctx=%q", result.deny, result.context)
 	}
@@ -60,9 +55,9 @@ func TestEnrichEdit_NonSource_PassThrough(t *testing.T) {
 
 func TestEnrichEdit_NotIndexed_PassThrough(t *testing.T) {
 	withEditBlocking(t, true)
-	port := fakeIndexedBridge(t, map[string]bool{"/repo/other.go": true})
+	fakeIndexedBridge(t, map[string]bool{"/repo/other.go": true})
 
-	result := enrichEdit(map[string]any{"file_path": "/repo/foo.go"}, port)
+	result := enrichEdit(map[string]any{"file_path": "/repo/foo.go"}, "")
 	if result.deny || result.context != "" {
 		t.Errorf("unindexed source ⇒ pass through; got deny=%v ctx=%q", result.deny, result.context)
 	}
@@ -70,9 +65,9 @@ func TestEnrichEdit_NotIndexed_PassThrough(t *testing.T) {
 
 func TestEnrichEdit_IndexedSource_Denies(t *testing.T) {
 	withEditBlocking(t, true)
-	port := fakeIndexedBridge(t, map[string]bool{"/repo/foo.go": true})
+	fakeIndexedBridge(t, map[string]bool{"/repo/foo.go": true})
 
-	result := enrichEdit(map[string]any{"file_path": "/repo/foo.go"}, port)
+	result := enrichEdit(map[string]any{"file_path": "/repo/foo.go"}, "")
 	if !result.deny {
 		t.Fatal("expected deny for Edit on indexed source")
 	}
@@ -85,9 +80,9 @@ func TestEnrichEdit_IndexedSource_Denies(t *testing.T) {
 
 func TestEnrichWrite_IndexedSource_Denies(t *testing.T) {
 	withEditBlocking(t, true)
-	port := fakeIndexedBridge(t, map[string]bool{"/repo/server.go": true})
+	fakeIndexedBridge(t, map[string]bool{"/repo/server.go": true})
 
-	result := enrichWrite(map[string]any{"file_path": "/repo/server.go"}, port)
+	result := enrichWrite(map[string]any{"file_path": "/repo/server.go"}, "")
 	if !result.deny {
 		t.Fatal("expected deny for Write on indexed source")
 	}
@@ -98,9 +93,9 @@ func TestEnrichWrite_IndexedSource_Denies(t *testing.T) {
 
 func TestEnrichWrite_NewFile_PassThrough(t *testing.T) {
 	withEditBlocking(t, true)
-	port := fakeIndexedBridge(t, map[string]bool{}) // nothing indexed
+	fakeIndexedBridge(t, map[string]bool{}) // nothing indexed
 
-	result := enrichWrite(map[string]any{"file_path": "/repo/new.go"}, port)
+	result := enrichWrite(map[string]any{"file_path": "/repo/new.go"}, "")
 	if result.deny || result.context != "" {
 		t.Errorf("new file ⇒ pass through; got deny=%v ctx=%q", result.deny, result.context)
 	}
@@ -108,10 +103,10 @@ func TestEnrichWrite_NewFile_PassThrough(t *testing.T) {
 
 func TestEnrichEdit_DispatchedFromEnrich(t *testing.T) {
 	withEditBlocking(t, true)
-	port := fakeIndexedBridge(t, map[string]bool{"/repo/x.go": true})
+	fakeIndexedBridge(t, map[string]bool{"/repo/x.go": true})
 
 	input := HookInput{ToolName: "Edit", ToolInput: map[string]any{"file_path": "/repo/x.go"}}
-	result := enrich(input, port)
+	result := enrich(input, 0)
 	if !result.deny {
 		t.Errorf("dispatcher must route Edit to enrichEdit; got deny=%v", result.deny)
 	}
@@ -148,10 +143,10 @@ func TestEnrichEdit_ReturnsValidJSONWhenWrappedByDispatcher(t *testing.T) {
 	// the underlying enrichEdit denies. Catches future regressions
 	// where a struct tag drift breaks the wire format.
 	withEditBlocking(t, true)
-	port := fakeIndexedBridge(t, map[string]bool{"/repo/handler.go": true})
+	fakeIndexedBridge(t, map[string]bool{"/repo/handler.go": true})
 
 	payload := []byte(`{"hook_event_name":"PreToolUse","tool_name":"Edit","tool_input":{"file_path":"/repo/handler.go"}}`)
-	out := captureStdout(t, func() { runPreToolUse(payload, port, ModeDeny) })
+	out := captureStdout(t, func() { runPreToolUse(payload, 0, ModeDeny) })
 	if out == "" {
 		t.Fatal("expected JSON output for deny path")
 	}

--- a/internal/hooks/enrich_bash_test.go
+++ b/internal/hooks/enrich_bash_test.go
@@ -1,35 +1,22 @@
 package hooks
 
 import (
-	"encoding/json"
-	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 )
 
-// newIndexedBridge returns a test HTTP server that answers /api/graph/file?path=…
-// as if every requested file were indexed with the given symbol count, and
-// returns the parsed port. Used to exercise enrichBash's ReadSource path
-// without standing up a real daemon.
+// newIndexedBridge stubs the daemon file-indexed probe so every queried
+// file looks indexed with the given symbol count, for the duration of the
+// test. Used to exercise enrichBash's ReadSource path without a real daemon.
+// Returns a dummy port (0) so the legacy `port := newIndexedBridge(...)`
+// call sites still compile; the value is unused now that the indexed check
+// routes through the stubbed fileIndexedFn seam rather than an HTTP port.
 func newIndexedBridge(t *testing.T, symbols int) int {
 	t.Helper()
-	mux := http.NewServeMux()
-	mux.HandleFunc("/api/graph/file", func(w http.ResponseWriter, _ *http.Request) {
-		nodes := make([]any, symbols+1) // file node + symbol nodes
-		_ = json.NewEncoder(w).Encode(map[string]any{"nodes": nodes})
-	})
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
-	// httptest URLs are http://127.0.0.1:<port>; queryGortex concatenates
-	// "http://localhost:<port>" so we need the numeric port.
-	parts := strings.Split(strings.TrimPrefix(srv.URL, "http://"), ":")
-	var port int
-	if _, err := fmt.Sscanf(parts[1], "%d", &port); err != nil {
-		t.Fatalf("parse port: %v", err)
-	}
-	return port
+	prev := fileIndexedFn
+	t.Cleanup(func() { fileIndexedFn = prev })
+	fileIndexedFn = func(_, _ string) (bool, int) { return symbols > 0, symbols }
+	return 0
 }
 
 func TestEnrichBash_GrepHit_Denies(t *testing.T) {
@@ -38,7 +25,7 @@ func TestEnrichBash_GrepHit_Denies(t *testing.T) {
 		{Name: "handleFoo", Kind: "function", FilePath: "internal/a.go", Line: 42},
 	}, nil)
 
-	r := enrichBash(map[string]any{"command": `grep -rn "handleFoo" .`}, 0)
+	r := enrichBash(map[string]any{"command": `grep -rn "handleFoo" .`}, "")
 	if !r.deny {
 		t.Fatalf("expected deny on grep hit, got %+v", r)
 	}
@@ -54,7 +41,7 @@ func TestEnrichBash_GrepMiss_SoftGuidance(t *testing.T) {
 	redirectTelemetry(t)
 	stubProbe(t, nil, nil) // daemon reachable, no hits
 
-	r := enrichBash(map[string]any{"command": `grep -rn "handleFoo" .`}, 0)
+	r := enrichBash(map[string]any{"command": `grep -rn "handleFoo" .`}, "")
 	if r.deny {
 		t.Fatal("miss should not deny")
 	}
@@ -66,7 +53,7 @@ func TestEnrichBash_GrepMiss_SoftGuidance(t *testing.T) {
 func TestEnrichBash_GrepPiped_PassesThrough(t *testing.T) {
 	// grep after | is a filter on upstream output — not a codebase search.
 	rec := stubProbe(t, nil, nil)
-	r := enrichBash(map[string]any{"command": `go test ./... | grep FAIL`}, 0)
+	r := enrichBash(map[string]any{"command": `go test ./... | grep FAIL`}, "")
 	if r.deny || r.context != "" {
 		t.Errorf("piped grep should pass through, got %+v", r)
 	}
@@ -81,7 +68,7 @@ func TestEnrichBash_RgBare_Denies(t *testing.T) {
 		{Name: "MyType", Kind: "type", FilePath: "a.go", Line: 5},
 	}, nil)
 
-	r := enrichBash(map[string]any{"command": `rg MyType`}, 0)
+	r := enrichBash(map[string]any{"command": `rg MyType`}, "")
 	if !r.deny {
 		t.Fatalf("expected deny, got %+v", r)
 	}
@@ -93,7 +80,7 @@ func TestEnrichBash_FindName_Denies(t *testing.T) {
 		{Name: "Handler", Kind: "type", FilePath: "x.go", Line: 10},
 	}, nil)
 
-	r := enrichBash(map[string]any{"command": `find . -name "Handler*"`}, 0)
+	r := enrichBash(map[string]any{"command": `find . -name "Handler*"`}, "")
 	if !r.deny {
 		t.Fatalf("expected deny for find -name with symbol-shaped root, got %+v", r)
 	}
@@ -103,7 +90,7 @@ func TestEnrichBash_FindNameGoFiles_NoProbe(t *testing.T) {
 	// `-name "*.go"` reduces to ".go" which is not symbol-shaped — no probe,
 	// no deny. Returns soft guidance because the pattern is >2 chars.
 	rec := stubProbe(t, nil, nil)
-	r := enrichBash(map[string]any{"command": `find . -name "*.go"`}, 0)
+	r := enrichBash(map[string]any{"command": `find . -name "*.go"`}, "")
 	if r.deny {
 		t.Fatal("find -name *.go should not deny")
 	}
@@ -114,7 +101,7 @@ func TestEnrichBash_FindNameGoFiles_NoProbe(t *testing.T) {
 
 func TestEnrichBash_FindTypeD_Passthrough(t *testing.T) {
 	rec := stubProbe(t, nil, nil)
-	r := enrichBash(map[string]any{"command": `find . -maxdepth 3 -type d`}, 0)
+	r := enrichBash(map[string]any{"command": `find . -maxdepth 3 -type d`}, "")
 	if r.deny || r.context != "" {
 		t.Errorf("find -type d should pass through, got %+v", r)
 	}
@@ -124,8 +111,8 @@ func TestEnrichBash_FindTypeD_Passthrough(t *testing.T) {
 }
 
 func TestEnrichBash_CatIndexedSource_Denies(t *testing.T) {
-	port := newIndexedBridge(t, 17)
-	r := enrichBash(map[string]any{"command": `cat /repo/handler.go`}, port)
+	newIndexedBridge(t, 17)
+	r := enrichBash(map[string]any{"command": `cat /repo/handler.go`}, "")
 	if !r.deny {
 		t.Fatalf("expected deny for cat of indexed source, got %+v", r)
 	}
@@ -141,8 +128,8 @@ func TestEnrichBash_CatIndexedSource_Denies(t *testing.T) {
 }
 
 func TestEnrichBash_CatUnindexedSource_SoftGuidance(t *testing.T) {
-	// port 0 → bridge unreachable → file treated as not indexed.
-	r := enrichBash(map[string]any{"command": `head -20 /tmp/foo.go`}, 0)
+	// probe not stubbed → file treated as not indexed.
+	r := enrichBash(map[string]any{"command": `head -20 /tmp/foo.go`}, "")
 	if r.deny {
 		t.Fatal("unindexed source should not deny")
 	}
@@ -152,14 +139,14 @@ func TestEnrichBash_CatUnindexedSource_SoftGuidance(t *testing.T) {
 }
 
 func TestEnrichBash_CatLogfile_Passthrough(t *testing.T) {
-	r := enrichBash(map[string]any{"command": `cat /tmp/app.log`}, 0)
+	r := enrichBash(map[string]any{"command": `cat /tmp/app.log`}, "")
 	if r.deny || r.context != "" {
 		t.Errorf("cat of non-source file should pass through, got %+v", r)
 	}
 }
 
 func TestEnrichBash_EmptyCommand(t *testing.T) {
-	r := enrichBash(map[string]any{"command": ""}, 0)
+	r := enrichBash(map[string]any{"command": ""}, "")
 	if r.deny || r.context != "" {
 		t.Errorf("empty command should pass through, got %+v", r)
 	}
@@ -173,7 +160,7 @@ func TestEnrichBash_UnrelatedCommand(t *testing.T) {
 		`git status`,
 		`echo hello`,
 	} {
-		r := enrichBash(map[string]any{"command": cmd}, 0)
+		r := enrichBash(map[string]any{"command": cmd}, "")
 		if r.deny || r.context != "" {
 			t.Errorf("%q should pass through, got %+v", cmd, r)
 		}
@@ -189,7 +176,7 @@ func TestEnrichBash_TelemetryTaggedAsBash(t *testing.T) {
 		{Name: "handleFoo", Kind: "function", FilePath: "a.go", Line: 1},
 	}, nil)
 
-	_ = enrichBash(map[string]any{"command": `grep -rn handleFoo .`}, 0)
+	_ = enrichBash(map[string]any{"command": `grep -rn handleFoo .`}, "")
 
 	recs := readDecisions(t, logPath)
 	if len(recs) != 1 {

--- a/internal/hooks/hermes.go
+++ b/internal/hooks/hermes.go
@@ -184,12 +184,12 @@ func runHermesPreToolCall(data []byte, port int, mode Mode) {
 // key, which Hermes names `path` rather than Claude's `file_path`);
 // terminal reuses enrichBash, whose `command` key Hermes already
 // matches. Any other tool is a no-op.
-func hermesEnrich(input hermesPreToolInput, port int) enrichResult {
+func hermesEnrich(input hermesPreToolInput, _ int) enrichResult {
 	switch input.ToolName {
 	case hermesReadFileTool:
-		return enrichRead(hermesNormalizeReadInput(input.ToolInput), port)
+		return enrichRead(hermesNormalizeReadInput(input.ToolInput), input.CWD)
 	case hermesTerminalTool:
-		return enrichBash(input.ToolInput, port)
+		return enrichBash(input.ToolInput, input.CWD)
 	default:
 		return enrichResult{}
 	}

--- a/internal/hooks/main_test.go
+++ b/internal/hooks/main_test.go
@@ -15,5 +15,10 @@ func TestMain(m *testing.M) {
 		_ = os.Setenv("GORTEX_HOOK_LOG", filepath.Join(dir, "hook-decisions.jsonl"))
 		defer func() { _ = os.RemoveAll(dir) }()
 	}
+	// Default the file-indexed probe to "not indexed" so no test dials a
+	// real daemon. Tests needing an indexed verdict stub fileIndexedFn
+	// (fakeIndexedBridge / newIndexedBridge / stubBridge) and restore this
+	// default on cleanup.
+	fileIndexedFn = func(_, _ string) (bool, int) { return false, 0 }
 	os.Exit(m.Run())
 }

--- a/internal/hooks/posttooluse.go
+++ b/internal/hooks/posttooluse.go
@@ -139,7 +139,7 @@ func postGlob(input postHookInput, port int) string {
 	indexed := make([]fileSummary, 0, maxFiles)
 	unindexed := 0
 	for _, p := range paths {
-		ok, n := queryFileIndexed(port, p)
+		ok, n := queryFileIndexed(input.CWD, p)
 		if !ok {
 			unindexed++
 			continue
@@ -177,7 +177,7 @@ func postRead(input postHookInput, port int) string {
 	if filePath == "" {
 		return ""
 	}
-	ok, symbolCount := queryFileIndexed(port, filePath)
+	ok, symbolCount := queryFileIndexed(input.CWD, filePath)
 	if !ok {
 		return ""
 	}

--- a/internal/hooks/posttooluse_test.go
+++ b/internal/hooks/posttooluse_test.go
@@ -30,6 +30,17 @@ func stubBridge(
 	callers map[string]int, // path → external-caller count
 ) int {
 	t.Helper()
+
+	// The file-indexed check now routes through the daemon socket probe
+	// (fileIndexedFn), not the HTTP bridge; stub it from the same `indexed`
+	// map. callers / symbol-at still go over HTTP below (via the port).
+	prevIndexed := fileIndexedFn
+	t.Cleanup(func() { fileIndexedFn = prevIndexed })
+	fileIndexedFn = func(_, filePath string) (bool, int) {
+		n, ok := indexed[filePath]
+		return ok && n > 0, n
+	}
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/graph/file", func(w http.ResponseWriter, r *http.Request) {
 		p := r.URL.Query().Get("path")

--- a/internal/hooks/pretooluse.go
+++ b/internal/hooks/pretooluse.go
@@ -7,9 +7,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/zzet/gortex/internal/daemon"
@@ -287,7 +288,7 @@ func nudgeReason(guidance string) string {
 func enrich(input HookInput, port int) enrichResult {
 	switch input.ToolName {
 	case "Read":
-		return enrichRead(input.ToolInput, port)
+		return enrichRead(input.ToolInput, input.CWD)
 	case "Grep":
 		return enrichGrep(input.ToolInput, port)
 	case "Glob":
@@ -295,11 +296,11 @@ func enrich(input HookInput, port int) enrichResult {
 	case "Task":
 		return enrichTask(input.ToolInput, port)
 	case "Bash":
-		return enrichBash(input.ToolInput, port)
+		return enrichBash(input.ToolInput, input.CWD)
 	case "Edit":
-		return enrichEdit(input.ToolInput, port)
+		return enrichEdit(input.ToolInput, input.CWD)
 	case "Write":
-		return enrichWrite(input.ToolInput, port)
+		return enrichWrite(input.ToolInput, input.CWD)
 	case gortexReadFileTool, gortexEditingContextTool:
 		return enrichGortexRead(input.ToolName, input.ToolInput)
 	default:
@@ -309,7 +310,7 @@ func enrich(input HookInput, port int) enrichResult {
 
 // enrichRead blocks whole-file reads of indexed source files and suggests graph tools.
 // Narrow reads (with offset+limit for editing) are allowed through with advisory context.
-func enrichRead(toolInput map[string]any, port int) enrichResult {
+func enrichRead(toolInput map[string]any, cwd string) enrichResult {
 	filePath, ok := toolInput["file_path"].(string)
 	if !ok || filePath == "" {
 		return enrichResult{}
@@ -326,7 +327,7 @@ func enrichRead(toolInput map[string]any, port int) enrichResult {
 		return enrichResult{}
 	}
 
-	fileIndexed, symbolCount := queryFileIndexed(port, filePath)
+	fileIndexed, symbolCount := queryFileIndexed(cwd, filePath)
 
 	// If the file is indexed, BLOCK the read and provide graph alternatives.
 	if fileIndexed {
@@ -510,26 +511,182 @@ func formatGrepDeny(pattern string, hits []grepSymbolHit) string {
 	return b.String()
 }
 
-// queryFileIndexed asks the local bridge whether the file at filePath is
-// indexed, returning the symbol count when it is. Shared by enrichRead and
-// enrichBash. A zero return (false, 0) is the "no signal" case — daemon
-// unreachable, malformed response, or file genuinely not indexed; callers
-// treat all three the same (fall through to soft guidance).
-func queryFileIndexed(port int, filePath string) (bool, int) {
-	resp, err := queryGortex(port, "/api/graph/file?path="+url.QueryEscape(filePath))
-	if err != nil || resp == "" {
+// queryFileIndexed reports whether the file at filePath is indexed by the
+// daemon, with the symbol count when it is. cwd scopes the probe to the
+// right workspace (and absolutises a relative filePath). A zero return
+// (false, 0) is the "no signal" case — daemon unreachable, malformed
+// response, or file genuinely not indexed; callers treat all three the
+// same (fall through to soft guidance).
+//
+// fileIndexedFn is the seam tests stub; production routes through the
+// daemon's MCP socket (the old HTTP :8765 /api/graph/file endpoint this
+// used to hit was removed when the web API migrated to the daemon, which
+// is why the hard deny silently stopped firing for every agent).
+func queryFileIndexed(cwd, filePath string) (bool, int) {
+	return fileIndexedFn(cwd, filePath)
+}
+
+// fileIndexedTimeout bounds the daemon probe so a wedged daemon never
+// stalls the PreToolUse critical path.
+const fileIndexedTimeout = 2 * time.Second
+
+var fileIndexedFn = fileIndexedViaDaemon
+
+// fileIndexedViaDaemon asks the daemon's get_file_summary tool how many
+// definition symbols the file carries, over the AF_UNIX MCP channel. The
+// graph keys files by their repo-relative path, so the absolute file path
+// is resolved against its tracked-repo root and the root-relative path is
+// what gets queried (with the handshake CWD set to that root for scoping).
+//
+// TODO(hook-local perf): each probe opens a fresh MCP connection, so a wide
+// postGlob still pays one dial per file even though repoRootForFile's status
+// fetch is now memoised. Reusing a single connection across the batch — or a
+// count-only probe that skips get_file_summary's ensureFresh re-index on the
+// hot path — is the next optimisation. Deferred so the test seam
+// (fileIndexedFn) stays a simple per-file func; left to the maintainer.
+func fileIndexedViaDaemon(cwd, filePath string) (bool, int) {
+	abs := filePath
+	if !filepath.IsAbs(abs) {
+		if cwd == "" {
+			return false, 0
+		}
+		abs = filepath.Join(cwd, abs)
+	}
+
+	root := repoRootForFile(abs)
+	if root == "" {
+		return false, 0 // outside every tracked repo → not indexed
+	}
+	rel, err := filepath.Rel(root, abs)
+	if err != nil {
 		return false, 0
 	}
-	var result struct {
-		Nodes []any `json:"nodes"`
-	}
-	if err := json.Unmarshal([]byte(resp), &result); err != nil {
+
+	client, err := daemon.Dial(daemon.Handshake{
+		Mode:       daemon.ModeMCP,
+		ClientName: "gortex-hook",
+		CWD:        root,
+	})
+	if err != nil {
 		return false, 0
 	}
-	if len(result.Nodes) <= 1 {
+	defer client.Close()
+	_ = client.Conn.SetDeadline(time.Now().Add(fileIndexedTimeout))
+
+	frame, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      "get_file_summary",
+			"arguments": map[string]any{"path": rel, "format": "json"},
+		},
+	})
+	if err != nil {
 		return false, 0
 	}
-	return true, len(result.Nodes) - 1 // subtract the file node itself
+	if err := client.WriteMCPFrame(frame); err != nil {
+		return false, 0
+	}
+	resp, err := client.ReadMCPFrame()
+	if err != nil {
+		return false, 0
+	}
+	return parseFileSummaryIndexed(resp)
+}
+
+// daemonStatusCacheTTL bounds how long a fetched tracked-repo list is reused
+// within one hook process. The set is effectively static for the lifetime of
+// a short-lived hook invocation, so a few seconds collapses a wide postGlob
+// (which probes every matched path) from one control-status round-trip per
+// file to ~one for the whole batch.
+const daemonStatusCacheTTL = 5 * time.Second
+
+var (
+	statusCacheMu  sync.Mutex
+	statusCacheVal *daemon.StatusResponse
+	statusCacheErr error
+	statusCacheAt  time.Time
+)
+
+// cachedDaemonStatus memoises fetchDaemonStatus for daemonStatusCacheTTL so
+// repoRootForFile — called once per probed file — does not re-dial the daemon
+// and re-marshal the entire tracked-repo list on every file in a postGlob
+// loop. The error is cached too: within one short hook process the daemon does
+// not realistically flip reachable↔unreachable, and a cached "down" short-
+// circuits N failed dials straight to soft-fallback.
+func cachedDaemonStatus() (*daemon.StatusResponse, error) {
+	statusCacheMu.Lock()
+	defer statusCacheMu.Unlock()
+	if !statusCacheAt.IsZero() && time.Since(statusCacheAt) < daemonStatusCacheTTL {
+		return statusCacheVal, statusCacheErr
+	}
+	statusCacheVal, statusCacheErr = fetchDaemonStatus()
+	statusCacheAt = time.Now()
+	return statusCacheVal, statusCacheErr
+}
+
+// repoRootForFile returns the tracked-repo root that contains abs (longest
+// match wins for nested repos), or "" when no tracked repo owns it.
+//
+// TODO(hook-local altitude): this hand-rolls a subset of the MCP server's
+// resolveFilePath (abs → repo-relative key) because get_file_summary does no
+// path resolution of its own — it looks the path up verbatim in the graph's
+// by-file index. It is also symlink-naive (no EvalSymlinks) where
+// resolveFilePath enforces the SECURITY.md repo-confinement guard, and yields
+// a bare repo-relative path that can diverge from the graph key in multi-repo
+// mode. The deeper fix is to route get_file_summary's path through
+// resolveFilePath server-side and have the hook forward {cwd, file_path}
+// verbatim — left to the maintainer as it touches a shared handler.
+func repoRootForFile(abs string) string {
+	status, err := cachedDaemonStatus()
+	if err != nil || status == nil {
+		return ""
+	}
+	var best string
+	for _, r := range status.TrackedRepos {
+		if r.Path == "" {
+			continue
+		}
+		if abs == r.Path || strings.HasPrefix(abs, r.Path+string(filepath.Separator)) {
+			if len(r.Path) > len(best) {
+				best = r.Path
+			}
+		}
+	}
+	return best
+}
+
+// parseFileSummaryIndexed unwraps a get_file_summary tools/call response —
+// JSON-RPC envelope → first content block (the JSON payload as text) →
+// total_nodes. get_file_summary strips the file/import nodes, so
+// total_nodes is the definition-symbol count; a not-indexed file comes back
+// as a tool error / guidance text, which fails the parse → (false, 0).
+func parseFileSummaryIndexed(resp []byte) (bool, int) {
+	var rpc struct {
+		Result struct {
+			Content []struct {
+				Text string `json:"text"`
+			} `json:"content"`
+			IsError bool `json:"isError"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(resp, &rpc); err != nil {
+		return false, 0
+	}
+	if rpc.Result.IsError || len(rpc.Result.Content) == 0 {
+		return false, 0
+	}
+	var summary struct {
+		TotalNodes int `json:"total_nodes"`
+	}
+	if err := json.Unmarshal([]byte(rpc.Result.Content[0].Text), &summary); err != nil {
+		return false, 0
+	}
+	if summary.TotalNodes <= 0 {
+		return false, 0
+	}
+	return true, summary.TotalNodes
 }
 
 // enrichBash classifies the Bash command and routes codebase-search shapes
@@ -537,7 +694,7 @@ func queryFileIndexed(port int, filePath string) (bool, int) {
 // not recognised as a codebase search passes through silently — false-deny
 // is more disruptive than a miss, so the classifier only flags primary
 // grep/rg/find-name/cat-source invocations.
-func enrichBash(toolInput map[string]any, port int) enrichResult {
+func enrichBash(toolInput map[string]any, cwd string) enrichResult {
 	cmd, _ := toolInput["command"].(string)
 	if cmd == "" {
 		return enrichResult{}
@@ -556,7 +713,7 @@ func enrichBash(toolInput map[string]any, port int) enrichResult {
 		return probeSymbolPattern("Bash", c.Pattern, defaultGrepGuidance())
 
 	case BashActionReadSource:
-		indexed, symbolCount := queryFileIndexed(port, c.Path)
+		indexed, symbolCount := queryFileIndexed(cwd, c.Path)
 		if indexed {
 			var reason strings.Builder
 			fmt.Fprintf(&reason,
@@ -706,7 +863,7 @@ func envGateEnabled(name string) bool {
 // Gortex MCP edit tools. Behind GORTEX_HOOK_BLOCK_EDIT until the
 // classifier is proven; without it the hook is a no-op so Edit
 // behaves exactly as it did pre-feature.
-func enrichEdit(toolInput map[string]any, port int) enrichResult {
+func enrichEdit(toolInput map[string]any, cwd string) enrichResult {
 	if !editBlockingEnabled() {
 		return enrichResult{}
 	}
@@ -717,7 +874,7 @@ func enrichEdit(toolInput map[string]any, port int) enrichResult {
 	if !looksLikeSourceFile(filePath) {
 		return enrichResult{}
 	}
-	indexed, _ := queryFileIndexed(port, filePath)
+	indexed, _ := queryFileIndexed(cwd, filePath)
 	if !indexed {
 		return enrichResult{}
 	}
@@ -735,7 +892,7 @@ func enrichEdit(toolInput map[string]any, port int) enrichResult {
 // enrichWrite mirrors enrichEdit for whole-file Write. New files
 // (not yet indexed) pass through; rewrites of existing indexed
 // files are redirected to `edit_file` / `write_file`.
-func enrichWrite(toolInput map[string]any, port int) enrichResult {
+func enrichWrite(toolInput map[string]any, cwd string) enrichResult {
 	if !editBlockingEnabled() {
 		return enrichResult{}
 	}
@@ -746,7 +903,7 @@ func enrichWrite(toolInput map[string]any, port int) enrichResult {
 	if !looksLikeSourceFile(filePath) {
 		return enrichResult{}
 	}
-	indexed, _ := queryFileIndexed(port, filePath)
+	indexed, _ := queryFileIndexed(cwd, filePath)
 	if !indexed {
 		return enrichResult{}
 	}

--- a/internal/hooks/pretooluse_test.go
+++ b/internal/hooks/pretooluse_test.go
@@ -100,7 +100,7 @@ func TestIsGreedySourceGlob(t *testing.T) {
 func TestEnrichRead_NonIndexed_Guidance(t *testing.T) {
 	// Port 0 means bridge won't respond — file is not indexed.
 	// Should return advisory guidance (not deny).
-	result := enrichRead(map[string]any{"file_path": "/tmp/foo.go"}, 0)
+	result := enrichRead(map[string]any{"file_path": "/tmp/foo.go"}, "")
 	if result.context == "" {
 		t.Fatal("expected guidance for unindexed source file, got empty")
 	}
@@ -116,7 +116,7 @@ func TestEnrichRead_NonIndexed_Guidance(t *testing.T) {
 }
 
 func TestEnrichRead_NonSourceFile(t *testing.T) {
-	result := enrichRead(map[string]any{"file_path": "/tmp/config.json"}, 0)
+	result := enrichRead(map[string]any{"file_path": "/tmp/config.json"}, "")
 	if result.context != "" || result.deny {
 		t.Errorf("expected pass-through for non-source file, got: context=%q deny=%v", result.context, result.deny)
 	}
@@ -128,7 +128,7 @@ func TestEnrichRead_NarrowRead_Allowed(t *testing.T) {
 		"file_path": "/tmp/foo.go",
 		"offset":    float64(100),
 		"limit":     float64(20),
-	}, 0)
+	}, "")
 	if result.deny {
 		t.Error("narrow read (offset+limit) should not be denied")
 	}
@@ -141,7 +141,7 @@ func TestEnrichRead_OffsetOnly_Allowed(t *testing.T) {
 	result := enrichRead(map[string]any{
 		"file_path": "/tmp/foo.go",
 		"offset":    float64(50),
-	}, 0)
+	}, "")
 	if result.deny {
 		t.Error("read with offset only should not be denied")
 	}
@@ -151,7 +151,7 @@ func TestEnrichRead_SmallLimit_Allowed(t *testing.T) {
 	result := enrichRead(map[string]any{
 		"file_path": "/tmp/foo.go",
 		"limit":     float64(30),
-	}, 0)
+	}, "")
 	if result.deny {
 		t.Error("read with small limit should not be denied")
 	}
@@ -162,7 +162,7 @@ func TestEnrichRead_LargeLimit_NotNarrow(t *testing.T) {
 	result := enrichRead(map[string]any{
 		"file_path": "/tmp/foo.go",
 		"limit":     float64(500),
-	}, 0)
+	}, "")
 	// Not indexed (port 0), so advisory only.
 	if result.deny {
 		t.Error("should not deny unindexed file")


### PR DESCRIPTION
## Summary

The PreToolUse hook is meant to **hard-deny** whole-file `Read`/`cat`/`Edit`/`Write`
of indexed source and redirect to graph tools. Commit `7208e77a` ("server: drop
--web, salvage /v1/graph + /v1/events, delete internal/web", 2026-04-18) deleted
the `internal/web` server, removing the `/api/graph/file` endpoint the hook
probed. Since then `queryFileIndexed` always returned `(false, 0)`, so the deny
silently degraded to soft guidance for **every** agent. Masked because the tests
mocked the endpoint and the fallback still printed advice.

This re-points the file-indexed probe at the daemon's MCP socket
(`get_file_summary`) - the always-present, authoritative graph owner.

> ⚠️ Intentionally hook-local and minimal, **not** a complete fix. The deeper
> path-resolution work is left as inline TODOs for a maintainer to direct; I'm
> happy to add follow-up commits once the direction is decided.

## Changes

- Replace the dead `/api/graph/file` HTTP probe with a daemon socket call to
  `get_file_summary`, behind a `fileIndexedFn` test seam.
- Thread `cwd` (from `HookInput.CWD`) through `enrich -> enrichRead/enrichBash/
  enrichEdit/enrichWrite -> queryFileIndexed` so the probe scopes to the workspace
  and resolves the repo-relative graph key.
- Memoize the daemon status fetch (5s TTL) so a wide `postGlob` makes ~one
  control-status round-trip instead of one per file.
- Migrate the HTTP-mock hook tests to stub the new seam.
- **TODOs left for maintainer review** (documented inline): route the path
  through the server's existing `resolveFilePath` (abs -> repo-relative + symlink
  confinement) instead of hand-rolling root resolution; reuse one MCP connection
  per batch / count-only probe. Note: the `file-callers` + `symbol-at` probes in
  `posttooluse.go` were never served — out of scope here.

## Testing

  - [x] All tests pass (`go test -race ./...`)
  - [x] New tests added for new functionality
  - [ ] Benchmarks run if performance-relevant

  ## Checklist

  - [x] Code follows existing patterns in the codebase
  - [x] No unnecessary abstractions added
  - [ ] Language extractor includes `Meta["methods"]` for interfaces (if applicable)
  - [ ] Methods have `EdgeMemberOf` edges to their containing type (if applicable)