### PR TITLE
perf(resolver): keep single-file edits fast during daemon warmup

### DIFF
--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -1680,6 +1680,7 @@ func (mi *MultiIndexer) ReconcileAll() map[string]*IndexResult {
 
 	results := make(map[string]*IndexResult, len(prefixes))
 	reindexed := 0
+	changedPrefixes := make(map[string]struct{})
 	for _, prefix := range prefixes {
 		mi.mu.RLock()
 		idx, ok := mi.indexers[prefix]
@@ -1694,11 +1695,12 @@ func (mi *MultiIndexer) ReconcileAll() map[string]*IndexResult {
 				zap.String("prefix", prefix), zap.Error(err))
 			continue
 		}
-		if result != nil && result.StaleFileCount > 0 {
+		if result != nil && (result.StaleFileCount > 0 || result.DeletedFileCount > 0) {
 			mi.logger.Info("janitor: reconciled repo",
 				zap.String("prefix", prefix),
 				zap.Int("stale_files_reindexed", result.StaleFileCount))
 			reindexed++
+			changedPrefixes[prefix] = struct{}{}
 		}
 		results[prefix] = result
 
@@ -1716,7 +1718,14 @@ func (mi *MultiIndexer) ReconcileAll() map[string]*IndexResult {
 		mi.ReconcileContractEdges()
 		// Only now — when at least one repo actually reindexed — is it
 		// worth the full-graph derivation pass. Nothing changed → skip it
-		// (the deferred ResetBatch still clears the batch flags).
+		// (the deferred ResetBatch still clears the batch flags). Scope the
+		// per-repo clone detection + Rebuild to just the repos that changed
+		// this cycle: an unchanged repo's clone edges are already on disk, so
+		// re-detecting all of them holds the resolve mutex for tens of seconds
+		// and stalls every concurrent interactive edit. Warmup arms the same
+		// scope; without this the janitor re-ran clone detection over every
+		// tracked repo on every cycle that touched even one file.
+		mi.ArmBatchScope(changedPrefixes)
 		mi.RunGlobalGraphPasses(context.Background())
 	}
 	return results

--- a/internal/resolver/cross_pkg_guard.go
+++ b/internal/resolver/cross_pkg_guard.go
@@ -53,6 +53,12 @@ func (r *Resolver) guardCrossPackageCallEdges(jobs []reindexJob, closure map[str
 	var reindexBatch []graph.EdgeReindex
 	for i := range jobs {
 		j := &jobs[i]
+		// A concurrent edit during a chunked ResolveAll yield may have evicted
+		// this edge since it resolved; reverting + reindexing it would
+		// half-resurrect it. Skip — it is no longer in the graph.
+		if r.validateLiveness && !edgeStillLive(r.graph, j.edge) {
+			continue
+		}
 		if !isCallLikeEdge(j.kind) {
 			continue
 		}

--- a/internal/resolver/cross_repo.go
+++ b/internal/resolver/cross_repo.go
@@ -415,6 +415,9 @@ func (cr *CrossRepoResolver) ResolveAll() *CrossRepoStats {
 			}
 		}
 		if len(scBatch) > 0 {
+			if cr.validateLiveness {
+				scBatch = cr.filterLiveReindex(scBatch)
+			}
 			cr.graph.ReindexEdges(scBatch)
 			reindexTotal += len(scBatch)
 		}
@@ -918,13 +921,6 @@ func (cr *CrossRepoResolver) cachedGetNodeByQualName(qualName string) *graph.Nod
 }
 
 func (cr *CrossRepoResolver) resolveEdge(e *graph.Edge, stats *CrossRepoStats, batch *[]graph.EdgeReindex) {
-	// On the chunked path a concurrent edit may have evicted this edge since
-	// the pending set was snapshotted. Resolving + reindexing an evicted edge
-	// half-resurrects it (re-adds its inEdges bucket while its outEdges slot
-	// is gone) and can panic; skip it — its file will re-resolve on its own.
-	if cr.validateLiveness && !edgeStillLive(cr.graph, e) {
-		return
-	}
 	oldTo := e.To
 	// UnresolvedName handles BOTH the bare `unresolved::X` and the
 	// multi-repo `<repo>::unresolved::X` forms; a plain TrimPrefix only
@@ -964,18 +960,30 @@ func (cr *CrossRepoResolver) resolveEdge(e *graph.Edge, stats *CrossRepoStats, b
 	}
 
 	if e.To != oldTo {
-		// On the chunked path the per-pass candidate indexes were built before
-		// inter-chunk yields, so a candidate may have been evicted by a
-		// concurrent edit. Refuse a resolution to a target that is no longer a
-		// live node (synthetic external placeholders are exempt — they are
-		// intentionally not graph nodes at resolve time); leave the edge
-		// unresolved rather than reindex it onto a missing target.
-		if cr.validateLiveness && !isSyntheticResolveTarget(e.To) && cr.graph.GetNode(e.To) == nil {
-			e.To = oldTo
-			return
-		}
 		*batch = append(*batch, graph.EdgeReindex{Edge: e, OldTo: oldTo})
 	}
+}
+
+// filterLiveReindex validates a resolved batch before applying it on the
+// chunked path: a concurrent edit during an inter-chunk yield may have evicted
+// an edge (reindexing it half-resurrects it and can panic) or its resolved
+// target node (a dangling edge). Drop evicted edges; revert a resolution whose
+// target is gone. O(batch) — only the edges that actually resolved, NOT the
+// whole pending set (an O(pending*out-degree) per-edge check stalled the pass).
+func (cr *CrossRepoResolver) filterLiveReindex(batch []graph.EdgeReindex) []graph.EdgeReindex {
+	out := batch[:0]
+	for _, r := range batch {
+		e := r.Edge
+		if e == nil || !edgeStillLive(cr.graph, e) {
+			continue
+		}
+		if !isSyntheticResolveTarget(e.To) && cr.graph.GetNode(e.To) == nil {
+			e.To = r.OldTo
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
 }
 
 // edgeStillLive reports whether e is currently present as an out-edge of its

--- a/internal/resolver/cross_repo.go
+++ b/internal/resolver/cross_repo.go
@@ -1,9 +1,11 @@
 package resolver
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -336,73 +338,101 @@ func (cr *CrossRepoResolver) ResolveAll() *CrossRepoStats {
 	// written concurrently. Batches are concatenated and applied once after
 	// the barrier (cr never reindexes per-edge mid-loop, so unlike the
 	// master pool no edge clone is needed); stats are summed.
-	workers := runtime.NumCPU()
-	// Clamp to the work count BEFORE flooring at 1: an empty pending slice
-	// must leave workers >= 1 so the chunk division below can't divide by
-	// zero. With workers == 1 and len(pending) == 0 the chunk is 0 and every
-	// worker's [start,end) is empty, so the pass is a correct no-op.
-	if workers > len(pending) {
-		workers = len(pending)
-	}
-	if workers < 1 {
-		workers = 1
-	}
-	perWorkerBatch := make([][]graph.EdgeReindex, workers)
-	perWorkerStats := make([]*CrossRepoStats, workers)
-	var wg sync.WaitGroup
-	chunk := (len(pending) + workers - 1) / workers
-	for w := 0; w < workers; w++ {
-		start := w * chunk
-		end := start + chunk
-		if end > len(pending) {
-			end = len(pending)
+	// Chunked resolve: process pending in super-chunks, releasing the resolve
+	// mutex between chunks so an interactive single-file edit can interleave
+	// instead of waiting out the whole pass. Each super-chunk's compute+apply
+	// runs entirely under the lock (atomic, fresh reads); only the inter-chunk
+	// gap is unlocked, where the pass holds no partial graph state. resolveEdge's
+	// liveness guards (cr.validateLiveness) skip any edge/candidate a yielded
+	// edit evicted. GORTEX_RESOLVE_CHUNK=0 restores one chunk == the prior
+	// whole-pass-locked behaviour.
+	cr.validateLiveness = resolveChunkEnabled()
+	superChunk := len(pending)
+	if cr.validateLiveness {
+		if sz := resolveChunkSize(); sz < superChunk {
+			superChunk = sz
 		}
-		if start >= end {
-			continue
-		}
-		wg.Add(1)
-		go func(idx int, slice []*graph.Edge) {
-			defer wg.Done()
-			ws := &CrossRepoStats{ByRepo: make(map[string]int)}
-			var batch []graph.EdgeReindex
-			for _, e := range slice {
-				cr.resolveEdge(e, ws, &batch)
-				processed.Add(1)
-			}
-			perWorkerStats[idx] = ws
-			perWorkerBatch[idx] = batch
-		}(w, pending[start:end])
 	}
-	wg.Wait()
-	close(progressDone)
+	if superChunk < 1 {
+		superChunk = 1
+	}
+	reindexTotal := 0
+	for base := 0; base < len(pending); base += superChunk {
+		hi := base + superChunk
+		if hi > len(pending) {
+			hi = len(pending)
+		}
+		sc := pending[base:hi]
 
-	var reindexBatch []graph.EdgeReindex
-	for i := range perWorkerBatch {
-		reindexBatch = append(reindexBatch, perWorkerBatch[i]...)
-	}
-	for _, ws := range perWorkerStats {
-		if ws == nil {
-			continue
+		workers := runtime.NumCPU()
+		if workers > len(sc) {
+			workers = len(sc)
 		}
-		stats.Resolved += ws.Resolved
-		stats.Unresolved += ws.Unresolved
-		stats.CrossRepoEdges += ws.CrossRepoEdges
-		for repo, n := range ws.ByRepo {
-			stats.ByRepo[repo] += n
+		if workers < 1 {
+			workers = 1
+		}
+		perWorkerBatch := make([][]graph.EdgeReindex, workers)
+		perWorkerStats := make([]*CrossRepoStats, workers)
+		var wg sync.WaitGroup
+		chunk := (len(sc) + workers - 1) / workers
+		for w := 0; w < workers; w++ {
+			start := w * chunk
+			end := start + chunk
+			if end > len(sc) {
+				end = len(sc)
+			}
+			if start >= end {
+				continue
+			}
+			wg.Add(1)
+			go func(idx int, slice []*graph.Edge) {
+				defer wg.Done()
+				ws := &CrossRepoStats{ByRepo: make(map[string]int)}
+				var batch []graph.EdgeReindex
+				for _, e := range slice {
+					cr.resolveEdge(e, ws, &batch)
+					processed.Add(1)
+				}
+				perWorkerStats[idx] = ws
+				perWorkerBatch[idx] = batch
+			}(w, sc[start:end])
+		}
+		wg.Wait()
+
+		var scBatch []graph.EdgeReindex
+		for i := range perWorkerBatch {
+			scBatch = append(scBatch, perWorkerBatch[i]...)
+		}
+		for _, ws := range perWorkerStats {
+			if ws == nil {
+				continue
+			}
+			stats.Resolved += ws.Resolved
+			stats.Unresolved += ws.Unresolved
+			stats.CrossRepoEdges += ws.CrossRepoEdges
+			for repo, n := range ws.ByRepo {
+				stats.ByRepo[repo] += n
+			}
+		}
+		if len(scBatch) > 0 {
+			cr.graph.ReindexEdges(scBatch)
+			reindexTotal += len(scBatch)
+		}
+		// Hand the resolve mutex to any waiting interactive edit before the
+		// next chunk. Held continuously within a chunk; released only here,
+		// where the pass holds no partial graph state.
+		if cr.validateLiveness && hi < len(pending) {
+			cr.mu.Unlock()
+			runtime.Gosched()
+			cr.mu.Lock()
 		}
 	}
+	close(progressDone)
 	cr.logger.Info("cross-repo resolve: compute done",
 		zap.Int("pending", len(pending)),
-		zap.Int("reindex_batch", len(reindexBatch)),
-		zap.Int("workers", workers),
+		zap.Int("reindex_batch", reindexTotal),
+		zap.Int("super_chunk", superChunk),
 		zap.Duration("elapsed", time.Since(passStart)))
-	if len(reindexBatch) > 0 {
-		applyStart := time.Now()
-		cr.graph.ReindexEdges(reindexBatch)
-		cr.logger.Info("cross-repo resolve: apply done",
-			zap.Int("edges", len(reindexBatch)),
-			zap.Duration("elapsed", time.Since(applyStart)))
-	}
 	// Materialise the cross_repo_* edge layer over the freshly lifted
 	// calls / implements / extends edges.
 	DetectCrossRepoEdges(cr.graph)
@@ -969,6 +999,31 @@ func edgeStillLive(g graph.Store, e *graph.Edge) bool {
 // target-liveness guard must not treat its absence as an evicted candidate).
 func isSyntheticResolveTarget(to string) bool {
 	return strings.HasPrefix(to, "external::") || strings.HasPrefix(to, "extern::")
+}
+
+// resolveChunkEnabled reports whether the global resolve passes process their
+// pending set in super-chunks, releasing the resolve mutex between chunks so
+// interactive single-file edits can interleave instead of waiting out the
+// whole pass. Default ON; GORTEX_RESOLVE_CHUNK=0 restores the prior
+// whole-pass-locked behaviour.
+func resolveChunkEnabled() bool {
+	if v := os.Getenv("GORTEX_RESOLVE_CHUNK"); v != "" {
+		return v != "0" && !strings.EqualFold(v, "false")
+	}
+	return true
+}
+
+// resolveChunkSize is the number of pending edges resolved + applied per chunk
+// before the resolve mutex is yielded. GORTEX_RESOLVE_CHUNK_SIZE overrides;
+// default 2048 — large enough to amortise the per-chunk worker barrier, small
+// enough that a waiting edit is delayed by at most one chunk's compute.
+func resolveChunkSize() int {
+	if v := os.Getenv("GORTEX_RESOLVE_CHUNK_SIZE"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return 2048
 }
 
 // callerRepoPrefix returns the RepoPrefix of the node that owns the edge's From field.

--- a/internal/resolver/cross_repo.go
+++ b/internal/resolver/cross_repo.go
@@ -100,6 +100,17 @@ type CrossRepoResolver struct {
 	// repo B even if the module path matches.
 	depModuleIndex       map[string][]depModuleEntry
 	mu                   *sync.Mutex
+	// validateLiveness turns on the concurrent-edit guards in resolveEdge.
+	// Set only on the chunked resolve path (ResolveAll with chunking), where
+	// the pass releases mu between chunks so an interactive single-file edit
+	// can interleave and evict nodes/edges the once-built per-pass indexes
+	// still reference. With it on, resolveEdge skips an edge that is no
+	// longer live (reindexing an evicted edge half-resurrects it and can
+	// panic) and refuses a resolution whose target node was evicted (a
+	// dangling edge). Off (the default, and the whole-pass-locked path) it is
+	// a no-op: nothing can mutate the graph mid-pass, so every edge and
+	// candidate is live by construction.
+	validateLiveness bool
 	crossWorkspaceLookup CrossWorkspaceDepLookup
 	// npmAlias rewrites a JS/TS import specifier that matches an
 	// npm-alias dependency key in the importing file's nearest-
@@ -877,6 +888,13 @@ func (cr *CrossRepoResolver) cachedGetNodeByQualName(qualName string) *graph.Nod
 }
 
 func (cr *CrossRepoResolver) resolveEdge(e *graph.Edge, stats *CrossRepoStats, batch *[]graph.EdgeReindex) {
+	// On the chunked path a concurrent edit may have evicted this edge since
+	// the pending set was snapshotted. Resolving + reindexing an evicted edge
+	// half-resurrects it (re-adds its inEdges bucket while its outEdges slot
+	// is gone) and can panic; skip it — its file will re-resolve on its own.
+	if cr.validateLiveness && !edgeStillLive(cr.graph, e) {
+		return
+	}
 	oldTo := e.To
 	// UnresolvedName handles BOTH the bare `unresolved::X` and the
 	// multi-repo `<repo>::unresolved::X` forms; a plain TrimPrefix only
@@ -916,8 +934,41 @@ func (cr *CrossRepoResolver) resolveEdge(e *graph.Edge, stats *CrossRepoStats, b
 	}
 
 	if e.To != oldTo {
+		// On the chunked path the per-pass candidate indexes were built before
+		// inter-chunk yields, so a candidate may have been evicted by a
+		// concurrent edit. Refuse a resolution to a target that is no longer a
+		// live node (synthetic external placeholders are exempt — they are
+		// intentionally not graph nodes at resolve time); leave the edge
+		// unresolved rather than reindex it onto a missing target.
+		if cr.validateLiveness && !isSyntheticResolveTarget(e.To) && cr.graph.GetNode(e.To) == nil {
+			e.To = oldTo
+			return
+		}
 		*batch = append(*batch, graph.EdgeReindex{Edge: e, OldTo: oldTo})
 	}
+}
+
+// edgeStillLive reports whether e is currently present as an out-edge of its
+// source node — i.e. it was not evicted by a concurrent single-file edit
+// since the resolve pass snapshotted its pending set. GetOutEdges returns the
+// live stored *Edge pointers, so identity comparison is exact.
+func edgeStillLive(g graph.Store, e *graph.Edge) bool {
+	if e == nil {
+		return false
+	}
+	for _, oe := range g.GetOutEdges(e.From) {
+		if oe == e {
+			return true
+		}
+	}
+	return false
+}
+
+// isSyntheticResolveTarget reports whether a resolved target is an intentional
+// placeholder rather than a concrete graph node (so the chunked path's
+// target-liveness guard must not treat its absence as an evicted candidate).
+func isSyntheticResolveTarget(to string) bool {
+	return strings.HasPrefix(to, "external::") || strings.HasPrefix(to, "extern::")
 }
 
 // callerRepoPrefix returns the RepoPrefix of the node that owns the edge's From field.

--- a/internal/resolver/cross_repo_concurrent_test.go
+++ b/internal/resolver/cross_repo_concurrent_test.go
@@ -1,0 +1,102 @@
+package resolver
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// TestCrossRepoResolveAll_ConcurrentEdits is the safety gate for the chunked
+// resolve. It runs CrossRepoResolver.ResolveAll while an "editor" goroutine
+// repeatedly evicts and re-indexes caller files, taking the SAME resolve mutex
+// an interactive single-file edit takes — exactly the interleaving the chunked
+// path enables. Without the resolveEdge liveness guards this corrupts the graph
+// (ReindexEdge half-resurrects an evicted edge and later panics with an
+// index-out-of-range during eviction); with them the run is clean and every
+// resolved edge points at a live node.
+//
+// Run with -race -count=N for scheduling variation.
+func TestCrossRepoResolveAll_ConcurrentEdits(t *testing.T) {
+	const (
+		files          = 40
+		callersPerFile = 600 // 24000 pending -> ~12 chunks at the default 2048
+	)
+	g := graph.New()
+
+	callerFile := func(k int) string { return fmt.Sprintf("repoA/a%d.go", k) }
+
+	// repoB targets: one Helper per (file,caller) slot.
+	for k := 0; k < files; k++ {
+		for i := 0; i < callersPerFile; i++ {
+			id := fmt.Sprintf("repoB/c%d_%d.go::Helper%d_%d", k, i, k, i)
+			g.AddNode(&graph.Node{
+				ID: id, Kind: graph.KindFunction, Name: fmt.Sprintf("Helper%d_%d", k, i),
+				FilePath: fmt.Sprintf("repoB/c%d_%d.go", k, i), Language: "go", RepoPrefix: "repoB",
+			})
+		}
+	}
+
+	// addCallerFile (re)indexes one repoA caller file: its caller functions, the
+	// unresolved call edges into repoB, and the import-reachability evidence.
+	addCallerFile := func(k int) {
+		for i := 0; i < callersPerFile; i++ {
+			g.AddNode(&graph.Node{
+				ID: fmt.Sprintf("%s::Caller%d_%d", callerFile(k), k, i), Kind: graph.KindFunction,
+				Name: fmt.Sprintf("Caller%d_%d", k, i), FilePath: callerFile(k), Language: "go", RepoPrefix: "repoA",
+			})
+			g.AddEdge(&graph.Edge{
+				From: fmt.Sprintf("%s::Caller%d_%d", callerFile(k), k, i),
+				To:   fmt.Sprintf("unresolved::Helper%d_%d", k, i),
+				Kind: graph.EdgeCalls, FilePath: callerFile(k), Line: i + 1,
+			})
+		}
+		wireImport(g, callerFile(k), "repoB", fmt.Sprintf("repoB/c%d_0.go", k))
+	}
+	for k := 0; k < files; k++ {
+		addCallerFile(k)
+	}
+
+	var resolveDone atomic.Bool
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		cr := NewCrossRepo(g)
+		cr.ResolveAll()
+		resolveDone.Store(true)
+	}()
+
+	// Editor: between ResolveAll's chunks (when it yields the resolve mutex),
+	// re-index a caller file — evict it (drops its nodes + the call edges the
+	// resolver's pending snapshot still points at) and add it back. Takes the
+	// resolve mutex, exactly as an interactive edit's ResolveFileAndIncoming does.
+	mu := g.ResolveMutex()
+	var edits int
+	for k := 0; !resolveDone.Load(); k = (k + 1) % files {
+		mu.Lock()
+		g.EvictFile(callerFile(k))
+		addCallerFile(k)
+		mu.Unlock()
+		edits++
+		runtime.Gosched()
+	}
+	wg.Wait()
+
+	require.Greater(t, edits, 0, "editor never interleaved — increase the work size")
+
+	// No resolved edge may point at a missing node: that is the dangling-edge /
+	// half-resurrection signature the guards exist to prevent.
+	for _, e := range g.AllEdges() {
+		if e == nil || strings.HasPrefix(e.To, "unresolved::") || isSyntheticResolveTarget(e.To) {
+			continue
+		}
+		require.NotNilf(t, g.GetNode(e.To),
+			"edge %s -> %s resolved to a node not in the graph (dangling)", e.From, e.To)
+	}
+}

--- a/internal/resolver/master_concurrent_test.go
+++ b/internal/resolver/master_concurrent_test.go
@@ -1,0 +1,88 @@
+package resolver
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// TestResolveAll_ConcurrentEdits is the safety gate for the chunked master
+// (same-repo) resolve. It runs Resolver.ResolveAll while an editor goroutine
+// evicts and re-indexes caller files under the same resolve mutex an
+// interactive edit takes — the interleaving the chunked path enables. Without
+// the apply / guardCrossPackageCallEdges liveness guards this corrupts the
+// graph (ReindexEdge half-resurrects an evicted edge and later panics with an
+// index-out-of-range during eviction). Run with -race -count=N.
+func TestResolveAll_ConcurrentEdits(t *testing.T) {
+	const (
+		files          = 40
+		callersPerFile = 600 // 24000 pending -> ~12 chunks at the default 2048
+	)
+	g := graph.New()
+	callerFile := func(k int) string { return fmt.Sprintf("r/a%d.go", k) }
+
+	// Same-repo targets, one unique Helper per (file,caller) slot.
+	for k := 0; k < files; k++ {
+		for i := 0; i < callersPerFile; i++ {
+			g.AddNode(&graph.Node{
+				ID: fmt.Sprintf("r/b%d_%d.go::Helper%d_%d", k, i, k, i), Kind: graph.KindFunction,
+				Name: fmt.Sprintf("Helper%d_%d", k, i), FilePath: fmt.Sprintf("r/b%d_%d.go", k, i),
+				Language: "go", RepoPrefix: "r",
+			})
+		}
+	}
+
+	addCallerFile := func(k int) {
+		for i := 0; i < callersPerFile; i++ {
+			g.AddNode(&graph.Node{
+				ID: fmt.Sprintf("%s::Caller%d_%d", callerFile(k), k, i), Kind: graph.KindFunction,
+				Name: fmt.Sprintf("Caller%d_%d", k, i), FilePath: callerFile(k), Language: "go", RepoPrefix: "r",
+			})
+			g.AddEdge(&graph.Edge{
+				From: fmt.Sprintf("%s::Caller%d_%d", callerFile(k), k, i),
+				To:   fmt.Sprintf("unresolved::Helper%d_%d", k, i),
+				Kind: graph.EdgeCalls, FilePath: callerFile(k), Line: i + 1,
+			})
+		}
+	}
+	for k := 0; k < files; k++ {
+		addCallerFile(k)
+	}
+
+	var resolveDone atomic.Bool
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		New(g).ResolveAll()
+		resolveDone.Store(true)
+	}()
+
+	mu := g.ResolveMutex()
+	var edits int
+	for k := 0; !resolveDone.Load(); k = (k + 1) % files {
+		mu.Lock()
+		g.EvictFile(callerFile(k))
+		addCallerFile(k)
+		mu.Unlock()
+		edits++
+		runtime.Gosched()
+	}
+	wg.Wait()
+
+	require.Greater(t, edits, 0, "editor never interleaved — increase the work size")
+
+	for _, e := range g.AllEdges() {
+		if e == nil || strings.HasPrefix(e.To, "unresolved::") || isSyntheticResolveTarget(e.To) {
+			continue
+		}
+		require.NotNilf(t, g.GetNode(e.To),
+			"edge %s -> %s resolved to a node not in the graph (dangling)", e.From, e.To)
+	}
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -100,6 +100,14 @@ type Resolver struct {
 	// edge mutations (resolveImport writes e.To while another
 	// goroutine iterates via graph.AllEdges()).
 	mu *sync.Mutex
+	// validateLiveness turns on the concurrent-edit guard on the chunked
+	// ResolveAll path: it releases mu between chunks so an interactive edit
+	// can interleave and evict an edge the pass already resolved. With it on,
+	// the per-chunk apply and guardCrossPackageCallEdges skip an evicted edge
+	// (reindexing one half-resurrects it and can panic). Off (the default and
+	// every non-chunked path) it is a no-op — nothing mutates the graph
+	// mid-pass. Set only inside ResolveAll.
+	validateLiveness bool
 
 	// lookupCache holds per-pass batched results from GetNodesByIDs /
 	// FindNodesByNames. Populated by ResolveAll/ResolveFile before
@@ -321,105 +329,128 @@ func (r *Resolver) ResolveAll() *ResolveStats {
 	r.warmLookupCache(pending)
 	defer r.clearLookupCache()
 
-	workers := runtime.NumCPU()
-	if workers < 1 {
-		workers = 1
+	// Chunked compute + apply: process pending in super-chunks and release the
+	// resolve mutex between chunks so an interactive single-file edit can
+	// interleave instead of waiting out the whole pass. Each chunk's
+	// compute+apply runs under the lock (atomic, fresh reads); only the
+	// inter-chunk gap is unlocked, where the pass holds no partial graph state.
+	// resolveEdge mutates a clone, so the live edge is only written at the
+	// per-chunk apply, which skips an edge a yielded edit evicted (reindexing
+	// it half-resurrects it and can panic). Accumulated jobs/stats feed the
+	// post-resolve passes once, after the loop. GORTEX_RESOLVE_CHUNK=0 restores
+	// the whole-pass-locked path.
+	r.validateLiveness = resolveChunkEnabled()
+	superChunk := len(pending)
+	if r.validateLiveness {
+		if sz := resolveChunkSize(); sz < superChunk {
+			superChunk = sz
+		}
 	}
-	if workers > len(pending) {
-		workers = len(pending)
+	if superChunk < 1 {
+		superChunk = 1
 	}
+	var allJobs [][]reindexJob
+	var allStats []ResolveStats
+	reindexTotal := 0
+	for base := 0; base < len(pending); base += superChunk {
+		hi := base + superChunk
+		if hi > len(pending) {
+			hi = len(pending)
+		}
+		scPending := pending[base:hi]
 
-	perWorkerStats := make([]ResolveStats, workers)
-	perWorkerJobs := make([][]reindexJob, workers)
-	var wg sync.WaitGroup
-	chunk := (len(pending) + workers - 1) / workers
-	for w := 0; w < workers; w++ {
-		start := w * chunk
-		end := start + chunk
-		if end > len(pending) {
-			end = len(pending)
+		workers := runtime.NumCPU()
+		if workers < 1 {
+			workers = 1
 		}
-		if start >= end {
-			continue
+		if workers > len(scPending) {
+			workers = len(scPending)
 		}
-		wg.Add(1)
-		go func(idx int, slice []*graph.Edge) {
-			defer wg.Done()
-			ws := &perWorkerStats[idx]
-			// Pre-size the jobs slice to the worker's chunk; over-
-			// allocates by ~5% (only resolved/external edges produce
-			// a job), but a few KB of headroom beats the growth
-			// amortisation cost across millions of edges.
-			jobs := make([]reindexJob, 0, len(slice))
-			for _, e := range slice {
-				clone := cloneEdgeForResolve(e)
-				oldTo, changed := r.resolveEdge(clone, ws)
-				processed.Add(1)
-				if changed {
-					jobs = append(jobs, reindexJob{
-						edge:       e,
-						oldTo:      oldTo,
-						newTo:      clone.To,
-						kind:       clone.Kind,
-						crossRepo:  clone.CrossRepo,
-						confidence: clone.Confidence,
-						origin:     clone.Origin,
-						meta:       clone.Meta,
-					})
-				}
-				// Return the clone shell to the pool. The Meta map (if
-				// any) is owned by the reindexJob now and lives on; the
-				// Edge struct itself is per-iteration garbage and is
-				// the part worth recycling.
-				releaseResolverClone(clone)
+		perWorkerStats := make([]ResolveStats, workers)
+		perWorkerJobs := make([][]reindexJob, workers)
+		var wg sync.WaitGroup
+		chunk := (len(scPending) + workers - 1) / workers
+		for w := 0; w < workers; w++ {
+			start := w * chunk
+			end := start + chunk
+			if end > len(scPending) {
+				end = len(scPending)
 			}
-			perWorkerJobs[idx] = jobs
-		}(w, pending[start:end])
+			if start >= end {
+				continue
+			}
+			wg.Add(1)
+			go func(idx int, slice []*graph.Edge) {
+				defer wg.Done()
+				ws := &perWorkerStats[idx]
+				jobs := make([]reindexJob, 0, len(slice))
+				for _, e := range slice {
+					clone := cloneEdgeForResolve(e)
+					oldTo, changed := r.resolveEdge(clone, ws)
+					processed.Add(1)
+					if changed {
+						jobs = append(jobs, reindexJob{
+							edge:       e,
+							oldTo:      oldTo,
+							newTo:      clone.To,
+							kind:       clone.Kind,
+							crossRepo:  clone.CrossRepo,
+							confidence: clone.Confidence,
+							origin:     clone.Origin,
+							meta:       clone.Meta,
+						})
+					}
+					releaseResolverClone(clone)
+				}
+				perWorkerJobs[idx] = jobs
+			}(w, scPending[start:end])
+		}
+		wg.Wait()
+
+		// Apply this chunk's mutations under the lock. An edit during a PRIOR
+		// inter-chunk yield may have evicted an edge this chunk resolved;
+		// reindexing it would half-resurrect it, so drop it (filter in place
+		// so allJobs carries only applied jobs for the post-passes).
+		reindexBatch := make([]graph.EdgeReindex, 0)
+		for i := range perWorkerJobs {
+			kept := perWorkerJobs[i][:0]
+			for _, j := range perWorkerJobs[i] {
+				if r.validateLiveness && !edgeStillLive(r.graph, j.edge) {
+					continue
+				}
+				j.edge.To = j.newTo
+				j.edge.Kind = j.kind
+				j.edge.CrossRepo = j.crossRepo
+				j.edge.Confidence = j.confidence
+				j.edge.Origin = j.origin
+				j.edge.Meta = j.meta
+				reindexBatch = append(reindexBatch, graph.EdgeReindex{Edge: j.edge, OldTo: j.oldTo})
+				kept = append(kept, j)
+			}
+			perWorkerJobs[i] = kept
+		}
+		if len(reindexBatch) > 0 {
+			r.graph.ReindexEdges(reindexBatch)
+			reindexTotal += len(reindexBatch)
+		}
+		allJobs = append(allJobs, perWorkerJobs...)
+		allStats = append(allStats, perWorkerStats...)
+
+		// Hand the resolve mutex to any waiting interactive edit before the
+		// next chunk.
+		if r.validateLiveness && hi < len(pending) {
+			r.mu.Unlock()
+			runtime.Gosched()
+			r.mu.Lock()
+		}
 	}
-	wg.Wait()
 	close(progressDone)
 	computeElapsed := time.Since(passStart)
-
-	// Apply mutations + ReindexEdge serially. Mutating e.To inside
-	// a worker would race with the bucket-maintenance reads inside
-	// every other worker's ReindexEdge — keyOf(swappedEdge) reads
-	// swappedEdge.To, which a neighbouring worker might be writing.
-	// Running both phases serially after the worker barrier removes
-	// the race entirely; it costs ~5% of resolver wall time on a
-	// 12k-edge vscode pass and buys a clean -race run plus simpler
-	// reasoning.
-	// Collect every mutation across all workers into one slice and hand
-	// the whole batch to ReindexEdges. Disk-backed stores commit per
-	// chunk inside the implementation; the in-memory store loops
-	// through the existing per-edge code. Per-edge ReindexEdge was the
-	// resolver's bottleneck against bbolt (10k+ ACID round-trips); the
-	// batch form folds it to ≤(N/5000) commits without changing any
-	// observable semantics.
-	totalJobs := 0
-	for i := range perWorkerJobs {
-		totalJobs += len(perWorkerJobs[i])
-	}
-	reindexBatch := make([]graph.EdgeReindex, 0, totalJobs)
-	for i := range perWorkerJobs {
-		for _, j := range perWorkerJobs[i] {
-			j.edge.To = j.newTo
-			j.edge.Kind = j.kind
-			j.edge.CrossRepo = j.crossRepo
-			j.edge.Confidence = j.confidence
-			j.edge.Origin = j.origin
-			j.edge.Meta = j.meta
-			reindexBatch = append(reindexBatch, graph.EdgeReindex{Edge: j.edge, OldTo: j.oldTo})
-		}
-	}
 	r.logger.Info("resolver: compute done",
 		zap.Int("pending", len(pending)),
-		zap.Int("reindex_batch", len(reindexBatch)),
+		zap.Int("reindex_batch", reindexTotal),
+		zap.Int("super_chunk", superChunk),
 		zap.Duration("elapsed", computeElapsed))
-	applyStart := time.Now()
-	r.graph.ReindexEdges(reindexBatch)
-	r.logger.Info("resolver: apply done",
-		zap.Int("edges", len(reindexBatch)),
-		zap.Duration("elapsed", time.Since(applyStart)))
 
 	// Cross-package name-match guard. The heuristic fallbacks above can
 	// resolve a call by name alone to a candidate in a package the
@@ -430,8 +461,8 @@ func (r *Resolver) ResolveAll() *ResolveStats {
 	// pre-resolution target so a reverted edge is restored exactly.
 	guarded := 0
 	if closure := r.buildImportClosure(); len(closure) > 0 {
-		for i := range perWorkerJobs {
-			guarded += r.guardCrossPackageCallEdges(perWorkerJobs[i], closure)
+		for i := range allJobs {
+			guarded += r.guardCrossPackageCallEdges(allJobs[i], closure)
 		}
 	}
 
@@ -504,10 +535,10 @@ func (r *Resolver) ResolveAll() *ResolveStats {
 	r.attributeNonGoModuleImports()
 
 	total := &ResolveStats{}
-	for i := range perWorkerStats {
-		total.Resolved += perWorkerStats[i].Resolved
-		total.Unresolved += perWorkerStats[i].Unresolved
-		total.External += perWorkerStats[i].External
+	for i := range allStats {
+		total.Resolved += allStats[i].Resolved
+		total.Unresolved += allStats[i].Unresolved
+		total.External += allStats[i].External
 	}
 	// A guarded edge was counted as resolved by the fallback that
 	// produced it; reverting it moves the tally back to unresolved.


### PR DESCRIPTION
## Problem

A single-file edit (file save / `edit_file`) while the daemon is warming up blocked for **tens of seconds** — comparable to indexing the whole repo, for one file. Measured: editing a heavily-referenced file (`internal/config/config.go`) during warmup took **44–120 s**.

## Root cause

Interactive edits and the warmup passes share **one** global resolve mutex (`g.resolveMu`): every `Resolver` built from a graph shares it, `ResolveFileAndIncoming` takes it, and three warmup passes held it for their whole duration:

- the cross-repo resolve (~70 s),
- the master same-repo resolve (~24 s),
- the janitor's clone detection, which re-detected **all** tracked repos on every cycle that touched a single file (~52 s for 21 repos).

So an edit landing mid-pass waited out the full pass — the edit wasn't doing work, it was blocked.

## Fix

- **Chunk both resolve passes.** Process the pending set in super-chunks and release the resolve mutex between chunks (default 2048; `GORTEX_RESOLVE_CHUNK=0` disables, `GORTEX_RESOLVE_CHUNK_SIZE` tunes). Each chunk's compute+apply is atomic under the lock; only the inter-chunk gap is unlocked, where the pass holds no partial graph state — so a waiting edit gets in within one chunk.
- **Scope the janitor's clone detection + Rebuild** to the repos that actually changed this cycle (warmup already did this; the periodic reconcile path didn't).
- **Liveness guards.** An edit during an inter-chunk yield can evict an edge the pass already resolved; reindexing an evicted edge half-resurrects it (re-adds its in-edges bucket while its out-edges slot is gone) and can panic. The per-chunk apply and `guardCrossPackageCallEdges` drop an edge that is no longer live — validating only the resolved batch, not every pending edge.

## Result (measured)

Editing `config.go` during warmup: **44–120 s → ~35 ms**. Warmup-log timings: master resolve 5.95 s, cross-repo resolve 28.6 s, clone passes scoped to 1 repo (2.2 s vs 52 s for 21).

## Safety

Two concurrent-edit stress tests (`TestCrossRepoResolveAll_ConcurrentEdits`, `TestResolveAll_ConcurrentEdits`) run each `ResolveAll` while an editor goroutine evicts files under the same mutex — green under `-race -count=5`. Full build, `golangci-lint` (0 issues), and the indexer race suite pass.
