### PR TITLE
Fix/mcp tooling ux

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,14 +120,14 @@ Useful kinds and tags: `invariant`, `constraint`, `convention`, `gotcha`, `decis
 
 These are not suggestions — run each step at the trigger.
 
-1. **Always call** `graph_stats` first to confirm the daemon is up and orient (check `per_repo` in multi-repo mode).
+1. Confirm the daemon is up with `index_health` (cheap liveness + scope). Call `graph_stats` only when you actually need node/edge counts or `per_repo` orientation — it returns a large payload and can block during warmup.
 2. If `total_nodes` is 0, **call** `index_repository` with `"."` before anything else.
 3. In multi-repo mode, **call** `get_active_project` to see scope; use `set_active_project` to switch.
-4. For every new task, **call** `smart_context` with the task description before reading any file.
+4. Open a non-trivial task with `smart_context` for orientation. For a single known symbol or file, go straight to `search_symbols` / `get_symbol_source` — don't front-load `smart_context` before every read.
 5. Immediately after `smart_context`, **call** `surface_memories task:"<task>" symbol_ids:"<top hits>"` to pick up any cross-session invariants / gotchas / decisions anchored to your working set. Skipping this re-derives knowledge other agents have already recorded.
 6. Before editing a file, **call** `get_editing_context` on it first.
 7. Before changing any function signature, **call** `verify_change` to catch broken callers and interface implementors (cross-repo).
 8. For any refactor, **call** `get_edit_plan` for the dependency-ordered file list, then **`batch_edit`** to apply atomically.
-9. After every edit, **call** `check_guards` (team conventions) then `get_test_targets` (includes cross-repo tests).
+9. Verify with the project's real build/test (`go build` / `go test`). Reserve `check_guards` for guard-relevant changes and `get_test_targets` (includes cross-repo tests) to find the tests covering a substantive change — not mechanically after every edit.
 10. Before committing, **call** `detect_changes` for scope and `diff_context` for graph-enriched review.
-11. When the task is done, **call** `feedback action: "record"` to score which `smart_context` suggestions were useful / not needed / missing. This is required — it improves future context quality. If the task surfaced a durable invariant / decision / gotcha worth teaching the team, **also call** `store_memory` so the next agent inherits the lesson.
+11. When the task is done, if you used `smart_context`, optionally **call** `feedback action: "record"` to score which suggestions were useful / not needed / missing — it improves future context quality. If the task surfaced a durable invariant / decision / gotcha worth teaching the team, **call** `store_memory` so the next agent inherits the lesson.

--- a/cmd/gortex/testdata/agent-render/cursor.txt
+++ b/cmd/gortex/testdata/agent-render/cursor.txt
@@ -36,7 +36,7 @@ This repository wires the **gortex** MCP server via .cursor/mcp.json (merge-mana
 
 You **MUST** prefer Gortex graph queries over text search and whole-file opens on every task. These are not suggestions.
 
-- **Always** start a new chat with **graph_stats** (or **index_health**) to confirm the daemon/index and orient in multi-repo workspaces.
+- **Start** a new chat with **index_health** to confirm the daemon/index (cheap); use **graph_stats** only when you need node/edge counts or multi-repo orientation.
 - **Use** **search_symbols**, **get_symbol_source**, **get_file_summary**, **get_call_chain**, **find_usages**, and **smart_context** instead of opening whole files or guessing with text search.
 - Before any signature or API change, **run** **verify_change**; for test selection **run** **get_test_targets**.
 

--- a/cmd/gortex/testdata/agent-render/hermes.txt
+++ b/cmd/gortex/testdata/agent-render/hermes.txt
@@ -507,7 +507,7 @@ If the diff is in the working tree (or a feature branch checked out), `detect_ch
 
 ## Checklist
 
-- `graph_stats` first — confirm Gortex sees the working tree
+- `index_health` — confirm Gortex sees the working tree (`graph_stats` for counts)
 - `detect_changes` + `diff_context` produce the graph-grounded scope + per-file risk
 - Walk the **10 gates** above in order; do not skip ahead on a blocker
 - `contracts({action: check})` is **mandatory** for any PR that touches a provider symbol — the orphan check catches wire drift the diff doesn't
@@ -820,7 +820,7 @@ The daemon can track several repositories at once. Scope your queries so results
 
 ## Quick Reference
 
-1. `graph_stats` — confirm the daemon is up and oriented.
+1. `index_health` — confirm the daemon is up and oriented (`graph_stats` for node/edge counts).
 2. `smart_context` with the task description — assemble the minimal working set.
 3. `search_symbols` / `find_usages` / `get_symbol_source` — navigate and read.
 4. `get_editing_context` then `edit_symbol` / `edit_file` / `rename_symbol` / `batch_edit` — edit safely.
@@ -1168,7 +1168,7 @@ metadata:
 
 ## Checklist
 
-- Call graph_stats to confirm Gortex is running
+- Call index_health to confirm Gortex is running (graph_stats only when you need node/edge counts)
 - Call smart_context first — one call replaces 5-10 exploration calls
 - Call get_communities for architecture overview when smart_context is not enough
 - Call search_symbols for the concept you want to understand
@@ -1595,7 +1595,7 @@ Use this **before** you touch `edit_file` / `edit_symbol` / `batch_edit` / `Edit
 
 ## Checklist
 
-- `smart_context` before reading any file
+- `smart_context` to orient a non-trivial task (skip for a single known symbol — use `search_symbols` / `get_symbol_source`)
 - `surface_memories` on the same working set — pick up cross-session decisions / gotchas
 - `preview_edit` (single edit) or `simulate_chain` (ordered chain) **before** any on-disk write
 - Treat `broken_callers` / `broken_implementors` as blockers, not warnings

--- a/cmd/gortex/testdata/agent-render/kiro.txt
+++ b/cmd/gortex/testdata/agent-render/kiro.txt
@@ -133,7 +133,7 @@ inclusion: manual
 
 ## Workflow
 
-1. `graph_stats` — confirm index, get node/edge counts
+1. `index_health` — confirm the index is ready (`graph_stats` for node/edge counts)
 2. `get_communities` — see functional clusters (architecture overview)
 3. `search_symbols({query: "<concept>"})` — find symbols related to a concept
 4. `get_processes` — discover execution flows
@@ -353,13 +353,13 @@ Store: invariants, conventions, incident learnings, API contracts not enforced b
 
 ## Session workflow
 
-1. Call `graph_stats` to confirm Gortex is running. If `total_nodes` is 0, call `index_repository` with path `"."`.
+1. Call `index_health` to confirm Gortex is running and indexed (`graph_stats` for counts). If `total_nodes` is 0, call `index_repository` with path `"."`.
 2. Call `distill_session` to recover prior session memory for this workspace.
 3. In multi-repo mode, call `get_active_project` to check scope. Use `set_active_project` to switch if needed.
 4. For a new task, call `smart_context` with the task description. Immediately after, call `surface_memories` with the same task description and the top symbol hits.
 5. Before editing any file, call `get_editing_context` first. If you've touched the symbol before, also call `query_notes symbol_id:"<id>"` and `query_memories symbol_id:"<id>"`.
 6. Before changing a function signature, call `verify_change` to catch contract violations — checks callers across all repos.
 7. Before any refactor, call `get_edit_plan` for dependency-ordered file list. Use `batch_edit` to apply atomically.
-8. After editing, call `check_guards` to verify team conventions, then `get_test_targets` for tests to run (includes cross-repo test files).
+8. Verify with the project's real build/test. Reserve `check_guards` for guard-relevant changes and `get_test_targets` to find the tests covering a substantive change (includes cross-repo test files).
 9. After making a meaningful decision or hitting a non-obvious constraint, call `save_note` so the next session can recover it. If the discovery is workspace-wide and worth teaching the team, call `store_memory` instead — that compounds across sessions.
 10. Before committing, call `detect_changes` to verify scope. Use `diff_context` for graph-enriched review.

--- a/internal/agents/claudecode/content.go
+++ b/internal/agents/claudecode/content.go
@@ -230,7 +230,7 @@ Quick reference for all Gortex MCP tools and the knowledge graph schema.
 
 ## Always Start Here
 
-1. **Call ` + "`graph_stats`" + `** — confirm Gortex is running, get node/edge counts
+1. **Call ` + "`index_health`" + `** — confirm Gortex is running (cheap); use ` + "`graph_stats`" + ` when you actually need node/edge counts
 2. **Match your task to a command below**
 3. **Follow the command's workflow**
 
@@ -528,7 +528,7 @@ const commandExplore = `# Exploring Codebases with Gortex
 
 ## Checklist
 
-- Call graph_stats to confirm Gortex is running
+- Call index_health to confirm Gortex is running (graph_stats only when you need node/edge counts)
 - Call smart_context first — one call replaces 5-10 exploration calls
 - Call get_communities for architecture overview when smart_context is not enough
 - Call search_symbols for the concept you want to understand
@@ -724,7 +724,7 @@ Use this **before** you touch ` + "`edit_file`" + ` / ` + "`edit_symbol`" + ` / 
 
 ## Checklist
 
-- ` + "`smart_context`" + ` before reading any file
+- ` + "`smart_context`" + ` to orient a non-trivial task (skip for a single known symbol — use ` + "`search_symbols`" + ` / ` + "`get_symbol_source`" + `)
 - ` + "`surface_memories`" + ` on the same working set — pick up cross-session decisions / gotchas
 - ` + "`preview_edit`" + ` (single edit) or ` + "`simulate_chain`" + ` (ordered chain) **before** any on-disk write
 - Treat ` + "`broken_callers`" + ` / ` + "`broken_implementors`" + ` as blockers, not warnings
@@ -1686,7 +1686,7 @@ If the diff is in the working tree (or a feature branch checked out), ` + "`dete
 
 ## Checklist
 
-- ` + "`graph_stats`" + ` first — confirm Gortex sees the working tree
+- ` + "`index_health`" + ` — confirm Gortex sees the working tree (` + "`graph_stats`" + ` for counts)
 - ` + "`detect_changes`" + ` + ` + "`diff_context`" + ` produce the graph-grounded scope + per-file risk
 - Walk the **10 gates** above in order; do not skip ahead on a blocker
 - ` + "`contracts({action: check})`" + ` is **mandatory** for any PR that touches a provider symbol — the orphan check catches wire drift the diff doesn't

--- a/internal/agents/cursor/adapter.go
+++ b/internal/agents/cursor/adapter.go
@@ -124,7 +124,7 @@ This repository wires the **gortex** MCP server via .cursor/mcp.json (merge-mana
 
 You **MUST** prefer Gortex graph queries over text search and whole-file opens on every task. These are not suggestions.
 
-- **Always** start a new chat with **graph_stats** (or **index_health**) to confirm the daemon/index and orient in multi-repo workspaces.
+- **Start** a new chat with **index_health** to confirm the daemon/index (cheap); use **graph_stats** only when you need node/edge counts or multi-repo orientation.
 - **Use** **search_symbols**, **get_symbol_source**, **get_file_summary**, **get_call_chain**, **find_usages**, and **smart_context** instead of opening whole files or guessing with text search.
 - Before any signature or API change, **run** **verify_change**; for test selection **run** **get_test_targets**.
 

--- a/internal/agents/hermes/content.go
+++ b/internal/agents/hermes/content.go
@@ -162,7 +162,7 @@ The daemon can track several repositories at once. Scope your queries so results
 
 ## Quick Reference
 
-1. ` + "`graph_stats`" + ` — confirm the daemon is up and oriented.
+1. ` + "`index_health`" + ` — confirm the daemon is up and oriented (` + "`graph_stats`" + ` for node/edge counts).
 2. ` + "`smart_context`" + ` with the task description — assemble the minimal working set.
 3. ` + "`search_symbols`" + ` / ` + "`find_usages`" + ` / ` + "`get_symbol_source`" + ` — navigate and read.
 4. ` + "`get_editing_context`" + ` then ` + "`edit_symbol`" + ` / ` + "`edit_file`" + ` / ` + "`rename_symbol`" + ` / ` + "`batch_edit`" + ` — edit safely.

--- a/internal/agents/instructions.go
+++ b/internal/agents/instructions.go
@@ -175,6 +175,14 @@ The flag replaces every function/method body in the returned source with a ` + "
 
 When the language has no grammar binding or tree-sitter can't parse the input, the flag is a no-op — raw source comes back and the response's ` + "`bodies_elided`" + ` flag stays absent. Safe to set unconditionally.
 
+### Reuse and freshness (don't re-fetch)
+
+Gortex exists to *save* tokens — treat what you fetch as cached for the task.
+
+- **Don't re-fetch what you already have.** Re-reading the same file or re-running the same query within a task is the most common avoidable cost — keep the earlier result and consult it again instead of re-calling.
+- **Re-validate cheaply with etags.** ` + "`read_file`" + ` / ` + "`get_symbol_source`" + ` / ` + "`get_file_summary`" + ` / ` + "`get_editing_context`" + ` / ` + "`smart_context`" + ` return an ` + "`etag`" + ` and accept ` + "`if_none_match`" + ` — an unchanged target comes back as ` + "`not_modified`" + ` at ~0 tokens. Use it to confirm freshness after an edit instead of re-reading the whole thing.
+- **A warming index is not an empty repo.** A ` + "`count: 0`" + ` / empty result while the daemon is still warming up (a ` + "`warming`" + ` block on the response, or ` + "`index_health`" + ` not yet ready) means *not indexed yet*, not *absent* — re-run shortly or check ` + "`index_health`" + `; don't conclude the symbol is missing and fall back to grep.
+
 ### Pagination, sparse fieldsets, and graceful degradation
 
 Every list-shaped tool runs through a per-response budget by default — the agent harness's spill-to-disk fallback is a true edge case, not the routine outcome on real-world payloads. When a response would exceed the budget, the server runs a priority-aware cascade:
@@ -293,6 +301,14 @@ When set on ` + "`get_symbol_source`" + ` / ` + "`get_editing_context`" + ` / ` 
 | Calling ` + "`get_editing_context`" + ` then fetching every neighbour's source for signatures | ` + "`get_editing_context`" + ` with ` + "`compress_bodies: true`" + ` — emits ` + "`source_compressed`" + ` alongside the structural sections |
 
 When the language has no grammar binding or tree-sitter can't parse the input, the flag is a no-op — raw source comes back and the response's ` + "`bodies_elided`" + ` flag stays absent. Safe to set unconditionally.
+
+### Reuse and freshness (don't re-fetch)
+
+Gortex exists to *save* tokens — treat what you fetch as cached for the task.
+
+- **Don't re-fetch what you already have.** Re-reading the same file or re-running the same query within a task is the most common avoidable cost — keep the earlier result and consult it again instead of re-calling.
+- **Re-validate cheaply with etags.** ` + "`read_file`" + ` / ` + "`get_symbol_source`" + ` / ` + "`get_file_summary`" + ` / ` + "`get_editing_context`" + ` / ` + "`smart_context`" + ` return an ` + "`etag`" + ` and accept ` + "`if_none_match`" + ` — an unchanged target comes back as ` + "`not_modified`" + ` at ~0 tokens. Use it to confirm freshness after an edit instead of re-reading the whole thing.
+- **A warming index is not an empty repo.** A ` + "`count: 0`" + ` / empty result while the daemon is still warming up (a ` + "`warming`" + ` block on the response, or ` + "`index_health`" + ` not yet ready) means *not indexed yet*, not *absent* — re-run shortly or check ` + "`index_health`" + `; don't conclude the symbol is missing and fall back to grep.
 
 ### Pagination, sparse fieldsets, and opt-in budget
 
@@ -545,15 +561,15 @@ Analyzer-backed rollups (read-only summaries; the only "argument" is the current
 
 ## Session start (Gortex)
 
-1. Call ` + "`graph_stats`" + ` to confirm Gortex is running and get repo orientation.
+1. Confirm Gortex is up with ` + "`index_health`" + ` (cheap liveness + scope). Call ` + "`graph_stats`" + ` only when you need node/edge counts or ` + "`per_repo`" + ` orientation — it's a heavy payload that can block during warmup.
 2. If ` + "`total_nodes`" + ` is 0, call ` + "`index_repository`" + ` with path ` + "`\".\"`" + `.
 3. Call ` + "`distill_session`" + ` to recover prior session memory for this workspace — decisions, pinned notes, recent excerpts. Use the digest to seed your mental model before reading any file.
 4. In multi-repo mode, call ` + "`get_active_project`" + ` to check scope. Use ` + "`set_active_project`" + ` to switch if needed.
-5. For a new task, call ` + "`smart_context`" + ` with the task description. Immediately after, call ` + "`surface_memories task:\"<task>\" symbol_ids:\"<top hits>\"`" + ` to pick up any cross-session invariants / gotchas / decisions anchored to your working set.
+5. Open a non-trivial task with ` + "`smart_context`" + ` for orientation — for a single known symbol or file, go straight to ` + "`search_symbols`" + ` / ` + "`get_symbol_source`" + ` instead. After a smart_context call, call ` + "`surface_memories task:\"<task>\" symbol_ids:\"<top hits>\"`" + ` to pick up any cross-session invariants / gotchas / decisions anchored to your working set.
 6. For every file you are about to edit, call ` + "`get_editing_context`" + ` first. If you've touched the symbol before, also call ` + "`query_notes symbol_id:\"<id>\"`" + ` and ` + "`query_memories symbol_id:\"<id>\"`" + ` to surface prior notes and durable memories.
 7. Before changing a function signature, call ` + "`verify_change`" + ` to catch contract violations — checks callers across all repos.
 8. Before any refactor, call ` + "`get_edit_plan`" + ` for dependency-ordered file list. Use ` + "`batch_edit`" + ` to apply atomically.
-9. After editing, call ` + "`check_guards`" + ` to verify team conventions, then ` + "`get_test_targets`" + ` for tests to run (includes cross-repo test files).
+9. Verify with the project's real build/test. Reserve ` + "`check_guards`" + ` for guard-relevant changes and ` + "`get_test_targets`" + ` to find the tests covering a substantive change (includes cross-repo test files) — not mechanically after every edit.
 10. After making a meaningful decision or hitting a non-obvious constraint, call ` + "`save_note tags:\"decision\" body:\"<what+why>\"`" + ` so the next session can recover it.
 11. Before committing, call ` + "`detect_changes`" + ` to verify scope. Use ` + "`diff_context`" + ` for graph-enriched review.
 

--- a/internal/agents/kiro/content.go
+++ b/internal/agents/kiro/content.go
@@ -160,14 +160,14 @@ Store: invariants, conventions, incident learnings, API contracts not enforced b
 
 ## Session workflow
 
-1. Call ` + "`graph_stats`" + ` to confirm Gortex is running. If ` + "`total_nodes`" + ` is 0, call ` + "`index_repository`" + ` with path ` + "`\".\"`" + `.
+1. Call ` + "`index_health`" + ` to confirm Gortex is running and indexed (` + "`graph_stats`" + ` for counts). If ` + "`total_nodes`" + ` is 0, call ` + "`index_repository`" + ` with path ` + "`\".\"`" + `.
 2. Call ` + "`distill_session`" + ` to recover prior session memory for this workspace.
 3. In multi-repo mode, call ` + "`get_active_project`" + ` to check scope. Use ` + "`set_active_project`" + ` to switch if needed.
 4. For a new task, call ` + "`smart_context`" + ` with the task description. Immediately after, call ` + "`surface_memories`" + ` with the same task description and the top symbol hits.
 5. Before editing any file, call ` + "`get_editing_context`" + ` first. If you've touched the symbol before, also call ` + "`query_notes symbol_id:\"<id>\"`" + ` and ` + "`query_memories symbol_id:\"<id>\"`" + `.
 6. Before changing a function signature, call ` + "`verify_change`" + ` to catch contract violations — checks callers across all repos.
 7. Before any refactor, call ` + "`get_edit_plan`" + ` for dependency-ordered file list. Use ` + "`batch_edit`" + ` to apply atomically.
-8. After editing, call ` + "`check_guards`" + ` to verify team conventions, then ` + "`get_test_targets`" + ` for tests to run (includes cross-repo test files).
+8. Verify with the project's real build/test. Reserve ` + "`check_guards`" + ` for guard-relevant changes and ` + "`get_test_targets`" + ` to find the tests covering a substantive change (includes cross-repo test files).
 9. After making a meaningful decision or hitting a non-obvious constraint, call ` + "`save_note`" + ` so the next session can recover it. If the discovery is workspace-wide and worth teaching the team, call ` + "`store_memory`" + ` instead — that compounds across sessions.
 10. Before committing, call ` + "`detect_changes`" + ` to verify scope. Use ` + "`diff_context`" + ` for graph-enriched review.
 `
@@ -180,7 +180,7 @@ inclusion: manual
 
 ## Workflow
 
-1. ` + "`graph_stats`" + ` — confirm index, get node/edge counts
+1. ` + "`index_health`" + ` — confirm the index is ready (` + "`graph_stats`" + ` for node/edge counts)
 2. ` + "`get_communities`" + ` — see functional clusters (architecture overview)
 3. ` + "`search_symbols({query: \"<concept>\"})`" + ` — find symbols related to a concept
 4. ` + "`get_processes`" + ` — discover execution flows

--- a/internal/claudemd/generator.go
+++ b/internal/claudemd/generator.go
@@ -76,14 +76,14 @@ func Generate(engine *query.Engine, _ int) string {
 	b.WriteString("Be especially deliberate with **behavior-critical code** — database migrations, retry / fallback / error-recovery paths, compatibility shims, concurrency-sensitive sections, and the tests that pin them. For these, call `get_symbol_source` and read the real implementation; never pass `compress_bodies:true`, which elides exactly the branches that carry the risk. Reserve compressed bodies and graph summaries for breadth (surveying many symbols); use full source for the few you are about to commit to.\n\n")
 	b.WriteString("## Required workflow (every task on this repo)\n\n")
 	b.WriteString("These are not suggestions — run each step at the trigger.\n\n")
-	b.WriteString("1. **Always call** `graph_stats` first to confirm the daemon is up and orient (check `per_repo` in multi-repo mode).\n")
+	b.WriteString("1. Confirm the daemon is up with `index_health` (cheap liveness + scope). Call `graph_stats` only when you actually need node/edge counts or `per_repo` orientation — it returns a large payload and can block during warmup.\n")
 	b.WriteString("2. If `total_nodes` is 0, **call** `index_repository` with `\".\"` before anything else.\n")
 	b.WriteString("3. In multi-repo mode, **call** `get_active_project` to check scope; use `set_active_project` to switch.\n")
-	b.WriteString("4. For every new task, **call** `smart_context` with the task description before reading any file.\n")
+	b.WriteString("4. Open a non-trivial task with `smart_context` for orientation. For a single known symbol or file, go straight to `search_symbols` / `get_symbol_source` — don't front-load `smart_context` before every read.\n")
 	b.WriteString("5. Before editing a file, **call** `get_editing_context` on it first.\n")
 	b.WriteString("6. Before changing any function signature, **call** `verify_change` to catch broken callers and interface implementors (cross-repo).\n")
 	b.WriteString("7. For any refactor, **call** `get_edit_plan` then `batch_edit` to apply atomically.\n")
-	b.WriteString("8. After every edit, **call** `check_guards` then `get_test_targets`.\n")
+	b.WriteString("8. Verify with the project's real build/test. Reserve `check_guards` for guard-relevant changes and `get_test_targets` to find the tests covering a substantive change — not mechanically after every edit.\n")
 
 	return b.String()
 }

--- a/internal/mcp/field_query.go
+++ b/internal/mcp/field_query.go
@@ -209,6 +209,30 @@ func pathMatchesAnyPrefix(path string, prefixes []string) bool {
 	return false
 }
 
+// expandPathPrefixesWithRepos returns the normalised sub-path prefixes
+// plus, for every non-empty repo prefix, the prefix-qualified form
+// (<repoPrefix>/<subpath>). In multi-repo mode trigram match paths carry
+// a repo prefix (gortex/internal/...) while callers pass repo-relative
+// sub-paths (internal/...); expanding the filter lets the repo-relative
+// form still match without loosening the anchored, segment-boundary
+// matching of pathMatchesAnyPrefix. Returns norm unchanged when there
+// are no repo prefixes (single-repo mode, where paths are unprefixed).
+func expandPathPrefixesWithRepos(norm, repoPrefixes []string) []string {
+	if len(repoPrefixes) == 0 {
+		return norm
+	}
+	out := make([]string, 0, len(norm)*(1+len(repoPrefixes)))
+	for _, p := range norm {
+		out = append(out, p)
+		for _, rp := range repoPrefixes {
+			if rp = strings.Trim(rp, "/"); rp != "" {
+				out = append(out, rp+"/"+p)
+			}
+		}
+	}
+	return out
+}
+
 // resolvePathFilter collects the sub-path filters that apply to a
 // search request, from three additive sources:
 //

--- a/internal/mcp/id_resolve.go
+++ b/internal/mcp/id_resolve.go
@@ -95,15 +95,31 @@ func (s *Server) resolveSymbolID(ctx context.Context, id string) string {
 		return id
 	}
 	cwd := SessionCWDFromContext(ctx)
-	if cwd == "" {
-		return id
-	}
-	if _, _, prefix, ok := s.multiIndexer.ScopeForCWD(cwd); ok && prefix != "" {
-		if cand := prefix + "/" + id; s.graph.GetNode(cand) != nil {
-			return cand
+	if cwd != "" {
+		if _, _, prefix, ok := s.multiIndexer.ScopeForCWD(cwd); ok && prefix != "" {
+			if cand := prefix + "/" + id; s.graph.GetNode(cand) != nil {
+				return cand
+			}
 		}
 	}
+	// Fallback: anchor the id's file-path part against the repo that owns
+	// the file on disk, so a repo-relative id still resolves when the
+	// session cwd doesn't map to a tracked repo (e.g. a cross-repo edit).
+	if rel := s.graphRelID(id); rel != id && s.graph.GetNode(rel) != nil {
+		return rel
+	}
 	return id
+}
+
+// graphRelID normalises the file-path part of a symbol id (path::Name) to
+// the graph's stored repo-prefixed form, leaving the name part untouched.
+// An id without a "::" path part is returned unchanged.
+func (s *Server) graphRelID(id string) string {
+	parts := strings.SplitN(id, "::", 2)
+	if len(parts) != 2 {
+		return id
+	}
+	return s.graphRelPath(parts[0]) + "::" + parts[1]
 }
 
 // symbolIDArg extracts the required "id" argument and normalizes it via

--- a/internal/mcp/tools_coding.go
+++ b/internal/mcp/tools_coding.go
@@ -316,6 +316,10 @@ func (s *Server) handleGetEditingContext(ctx context.Context, req mcp.CallToolRe
 	if err != nil {
 		return mcp.NewToolResultError("path is required"), nil
 	}
+	// Normalise to the graph's stored path form so a repo-relative path
+	// (internal/x.go) doesn't miss the repo-prefixed nodes in multi-repo
+	// mode — the cause of spurious "no symbols found for file" misses.
+	fp = s.graphRelPath(fp)
 
 	// Auto re-index stale file before querying.
 	s.ensureFresh([]string{fp})

--- a/internal/mcp/tools_coding.go
+++ b/internal/mcp/tools_coding.go
@@ -772,6 +772,72 @@ func (s *Server) handleGetRecentChanges(ctx context.Context, req mcp.CallToolReq
 	})
 }
 
+// suggestSymbolIDs builds a short "did you mean" hint for a symbol id that
+// could not be resolved. It offers in-scope ids that share the requested
+// name anywhere in the graph (the "right name, wrong path" case) and, when
+// the id carries a file path, the symbols defined in that file ranked by
+// name similarity (the "right path, stale name" case). Returns "" when
+// nothing plausible is nearby, so callers can append it unconditionally.
+func (s *Server) suggestSymbolIDs(ctx context.Context, id string) string {
+	eng := s.engineFor(ctx)
+	if eng == nil || s.graph == nil {
+		return ""
+	}
+	pathPart, namePart := "", id
+	if parts := strings.SplitN(id, "::", 2); len(parts) == 2 {
+		pathPart, namePart = parts[0], parts[1]
+	}
+	// Drop a receiver qualifier so Foo.Bar can match a stored "Bar".
+	base := namePart
+	if i := strings.LastIndex(base, "."); i >= 0 && i < len(base)-1 {
+		base = base[i+1:]
+	}
+	seen := map[string]bool{id: true}
+	var out []string
+	add := func(n *graph.Node) bool {
+		if n == nil || seen[n.ID] || !s.nodeInSessionScope(ctx, n) {
+			return false
+		}
+		seen[n.ID] = true
+		out = append(out, n.ID)
+		return len(out) >= 5
+	}
+	// 1. Same-named symbols anywhere — the common wrong-path case.
+	if base != "" {
+		for _, n := range eng.FindSymbols(base) {
+			if add(n) {
+				break
+			}
+		}
+	}
+	// 2. Nearest-named symbols in the same file — the stale-name case.
+	if pathPart != "" && len(out) < 5 {
+		if sg := eng.GetFileSymbols(s.graphRelPath(pathPart)); sg != nil {
+			type scored struct {
+				n    *graph.Node
+				dist int
+			}
+			ranked := make([]scored, 0, len(sg.Nodes))
+			for _, n := range sg.Nodes {
+				if n == nil || n.Kind == graph.KindFile {
+					continue
+				}
+				ranked = append(ranked, scored{n, levenshtein(strings.ToLower(n.Name), strings.ToLower(base))})
+			}
+			sort.Slice(ranked, func(i, j int) bool { return ranked[i].dist < ranked[j].dist })
+			for _, r := range ranked {
+				if add(r.n) {
+					break
+				}
+			}
+		}
+	}
+	if len(out) == 0 {
+		return ""
+	}
+	return " — did you mean: " + strings.Join(out, ", ")
+}
+
 func (s *Server) handleGetSymbolSource(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	id, err := s.symbolIDArg(ctx, req)
 	if err != nil {
@@ -785,7 +851,7 @@ func (s *Server) handleGetSymbolSource(ctx context.Context, req mcp.CallToolRequ
 
 	node := s.engineFor(ctx).GetSymbol(id)
 	if node == nil {
-		return mcp.NewToolResultError("symbol not found: " + id), nil
+		return mcp.NewToolResultError("symbol not found: " + id + s.suggestSymbolIDs(ctx, id)), nil
 	}
 	// A by-id fetch must not cross the session's workspace boundary —
 	// reported the same as a genuine miss so the boundary isn't
@@ -2561,7 +2627,7 @@ func (s *Server) handleEditSymbol(ctx context.Context, req mcp.CallToolRequest) 
 
 	node := s.engineFor(ctx).GetSymbol(id)
 	if node == nil {
-		return mcp.NewToolResultError("symbol not found: " + id), nil
+		return mcp.NewToolResultError("symbol not found: " + id + s.suggestSymbolIDs(ctx, id)), nil
 	}
 
 	if node.StartLine == 0 || node.EndLine == 0 {

--- a/internal/mcp/tools_coding_suggest_test.go
+++ b/internal/mcp/tools_coding_suggest_test.go
@@ -1,0 +1,64 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+	"github.com/zzet/gortex/internal/query"
+)
+
+// TestSymbolNotFound_DidYouMean pins the recovery hint on a missed symbol
+// id: a stale/typo'd name surfaces the nearest symbol in the same file, a
+// right-name/wrong-path id surfaces where the symbol actually lives, and a
+// genuinely unknown id in an empty path still errors cleanly with no hint.
+func TestSymbolNotFound_DidYouMean(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"),
+		[]byte("package app\n\nfunc AlphaHandler() {}\n\nfunc BetaHandler() {}\n"), 0o644))
+
+	g := graph.New()
+	reg := parser.NewRegistry()
+	languages.RegisterAll(reg)
+	cfg := config.Default()
+	idx := indexer.New(g, reg, cfg.Index, zap.NewNop())
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+	eng := query.NewEngine(g)
+	srv := NewServer(eng, g, idx, nil, zap.NewNop(), nil)
+
+	errText := func(res *mcplib.CallToolResult) string {
+		require.True(t, res.IsError)
+		return res.Content[0].(mcplib.TextContent).Text
+	}
+
+	// Typo'd name in the right file → nearest symbol in that file.
+	typo := errText(callTool(t, srv, "get_symbol_source", map[string]any{"id": "main.go::AlphaHandlr"}))
+	require.Contains(t, typo, "symbol not found")
+	require.Contains(t, typo, "did you mean")
+	require.Contains(t, typo, "AlphaHandler")
+
+	// Right name, wrong path → the id where the symbol actually lives.
+	wrongPath := errText(callTool(t, srv, "get_symbol_source", map[string]any{"id": "nope.go::BetaHandler"}))
+	require.Contains(t, wrongPath, "BetaHandler")
+
+	// edit_symbol shares the hint.
+	editMiss := errText(callTool(t, srv, "edit_symbol", map[string]any{
+		"id": "main.go::AlphaHandlr", "old_source": "a", "new_source": "b",
+	}))
+	require.Contains(t, editMiss, "did you mean")
+
+	// Unknown name in a path with no indexed symbols → clean error, no hint.
+	clean := errText(callTool(t, srv, "get_symbol_source", map[string]any{"id": "ghost.go::Nonexistent"}))
+	require.Contains(t, clean, "symbol not found")
+	require.NotContains(t, clean, "did you mean")
+}

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -1892,6 +1892,10 @@ func (s *Server) handleGetFileSummary(ctx context.Context, req mcp.CallToolReque
 	if err != nil {
 		return mcp.NewToolResultError("path is required"), nil
 	}
+	// Normalise to the graph's stored path form so a repo-relative path
+	// (internal/x.go) doesn't miss the repo-prefixed nodes in multi-repo
+	// mode — the cause of spurious file_not_indexed misses.
+	fp = s.graphRelPath(fp)
 
 	// Auto re-index stale file before querying.
 	s.ensureFresh([]string{fp})

--- a/internal/mcp/tools_fileops.go
+++ b/internal/mcp/tools_fileops.go
@@ -94,6 +94,20 @@ func (s *Server) resolveFilePath(rawPath string) (absPath, relPath string, err e
 				abs = worktreeRootedPath(abs, root, s.multiIndexer)
 				return abs, rawPath, nil
 			}
+			// No matched prefix and no lone repo: an unprefixed path is
+			// normally ambiguous across tracked repos. But when it names
+			// an existing file under exactly one repo there is no
+			// ambiguity — anchor it there, so an agent can edit
+			// gortex/internal/x.go as internal/x.go without first
+			// learning the prefix. A brand-new file (matches == 0) still
+			// requires an explicit prefix; a path present in several
+			// repos (matches > 1) is reported as such.
+			if abs, rel, matches := anchorUnprefixedExisting(s.multiIndexer, rawPath); matches == 1 {
+				return abs, rel, nil
+			} else if matches > 1 {
+				return "", "", fmt.Errorf("%w: path %q names a file in multiple tracked repos; prefix it with one of: %s/",
+					errPathUnresolved, rawPath, strings.Join(s.multiIndexer.RepoPrefixes(), "/, "))
+			}
 			prefixes := s.multiIndexer.RepoPrefixes()
 			return "", "", fmt.Errorf("%w: path %q does not start with a known repo prefix; expected one of: %s/, or an absolute path",
 				errPathUnresolved, rawPath, strings.Join(prefixes, "/, "))
@@ -229,6 +243,47 @@ func worktreeRootedPath(abs, root string, mi multiRepoLookup) string {
 		return match
 	}
 	return abs
+}
+
+// anchorUnprefixedExisting tries to anchor a bare repo-relative path —
+// one that carries no repo prefix — to the single tracked repo that
+// actually contains it. It joins rawPath against each repo root and
+// counts the repos where the resulting file exists on disk. A unique
+// match (matches == 1) is unambiguous and safe for the caller to honour:
+// absPath is the worktree-rooted absolute path and relPath the
+// repo-prefixed form used for session bookkeeping. matches == 0 means no
+// tracked repo has the file (e.g. a brand-new write target) and matches
+// > 1 means the path names a file in several repos; in both cases absPath
+// and relPath are unset and the caller decides how to report it. The
+// existence gate is what keeps this unambiguous — it never invents a
+// location for a path that does not already resolve to exactly one file.
+func anchorUnprefixedExisting(mi multiRepoLookup, rawPath string) (absPath, relPath string, matches int) {
+	if mi == nil || rawPath == "" || filepath.IsAbs(rawPath) {
+		return "", "", 0
+	}
+	for _, prefix := range mi.RepoPrefixes() {
+		if prefix == "" {
+			continue
+		}
+		root, ok := mi.RepoRoot(prefix)
+		if !ok || root == "" {
+			continue
+		}
+		cand := filepath.Clean(filepath.Join(root, rawPath))
+		if !pathContainedIn(cand, root) {
+			continue
+		}
+		if _, err := os.Stat(cand); err != nil {
+			continue
+		}
+		matches++
+		absPath = worktreeRootedPath(cand, root, mi)
+		relPath = prefix + "/" + rawPath
+	}
+	if matches != 1 {
+		return "", "", matches
+	}
+	return absPath, relPath, matches
 }
 
 // pathContainedIn reports whether abs sits at or beneath root, after
@@ -451,6 +506,24 @@ func (s *Server) resolveGraphPath(graphPath string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("%w: path=%q", errPathUnresolved, graphPath)
+}
+
+// graphRelPath normalises a caller-supplied file path to the
+// repo-relative form the graph stores its nodes under — repo-prefixed in
+// multi-repo mode (internal/x.go -> gortex/internal/x.go), unchanged in
+// single-repo mode, and converted from an absolute path when one is
+// given. It is the read-side companion to resolveFilePath's relPath:
+// both run the same anchoring, but graphRelPath never errors — a path
+// that cannot be anchored (e.g. a not-yet-created file) is returned
+// as-is so a graph lookup keyed on it degrades to exactly the raw-path
+// behaviour callers had before, never worse. Use it before GetFileSymbols
+// / FileEditingContext so a repo-relative path doesn't silently miss the
+// prefixed nodes in multi-repo mode.
+func (s *Server) graphRelPath(fp string) string {
+	if _, rel, err := s.resolveFilePath(fp); err == nil && rel != "" {
+		return rel
+	}
+	return fp
 }
 
 // fileAttributionNode synthesizes a node carrying just the repo prefix

--- a/internal/mcp/tools_fileops_repo_test.go
+++ b/internal/mcp/tools_fileops_repo_test.go
@@ -1,6 +1,9 @@
 package mcp
 
 import (
+	"os"
+	"path/filepath"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -25,4 +28,60 @@ func TestMatchedRepoPrefix_LongestMatchWins(t *testing.T) {
 	require.Equal(t, "", matchedRepoPrefix(fakeRepoPrefixLookup{prefixes: []string{"a"}}, "c/x.go"),
 		"a path under no tracked repo resolves to no prefix")
 	require.Equal(t, "", matchedRepoPrefix(nil, "a/x.go"))
+}
+
+// fakeRepoRoots maps repo prefixes to real on-disk roots so the
+// existence-gated anchoring in anchorUnprefixedExisting can be exercised
+// against actual files.
+type fakeRepoRoots struct{ roots map[string]string }
+
+func (f fakeRepoRoots) RepoPrefixes() []string {
+	ps := make([]string, 0, len(f.roots))
+	for p := range f.roots {
+		ps = append(ps, p)
+	}
+	sort.Strings(ps)
+	return ps
+}
+func (f fakeRepoRoots) RepoRoot(p string) (string, bool)    { r, ok := f.roots[p]; return r, ok }
+func (f fakeRepoRoots) LinkedWorktreeRoots(string) []string { return nil }
+
+// TestAnchorUnprefixedExisting pins the multi-repo convenience: a bare
+// repo-relative path is anchored only when exactly one tracked repo
+// actually contains it. Zero matches (new file) and multiple matches
+// (genuinely ambiguous) both refuse to guess.
+func TestAnchorUnprefixedExisting(t *testing.T) {
+	a, b := t.TempDir(), t.TempDir()
+	mustWrite := func(root, rel string) {
+		p := filepath.Join(root, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+		require.NoError(t, os.WriteFile(p, []byte("package x\n"), 0o644))
+	}
+	mustWrite(a, "internal/x.go")     // only in repo "alpha"
+	mustWrite(a, "shared/y.go")       // in both repos
+	mustWrite(b, "shared/y.go")       //
+	mi := fakeRepoRoots{roots: map[string]string{"alpha": a, "beta": b}}
+
+	// Unique existing match → anchored to the lone owning repo, with the
+	// repo-prefixed relPath for session bookkeeping.
+	abs, rel, n := anchorUnprefixedExisting(mi, "internal/x.go")
+	require.Equal(t, 1, n)
+	require.Equal(t, filepath.Join(a, "internal", "x.go"), abs)
+	require.Equal(t, "alpha/internal/x.go", rel)
+
+	// Present in two repos → ambiguous, caller must disambiguate.
+	_, _, n = anchorUnprefixedExisting(mi, "shared/y.go")
+	require.Equal(t, 2, n)
+
+	// Missing everywhere (a new write target) → no anchor.
+	_, _, n = anchorUnprefixedExisting(mi, "internal/new.go")
+	require.Equal(t, 0, n)
+
+	// A `..` traversal is rejected by the containment gate, not anchored.
+	_, _, n = anchorUnprefixedExisting(mi, "../escape.go")
+	require.Equal(t, 0, n)
+
+	// An absolute path is never an "unprefixed" path — left to the caller.
+	_, _, n = anchorUnprefixedExisting(mi, filepath.Join(a, "internal", "x.go"))
+	require.Equal(t, 0, n)
 }

--- a/internal/mcp/tools_search_text.go
+++ b/internal/mcp/tools_search_text.go
@@ -78,10 +78,15 @@ func (s *Server) handleSearchText(ctx context.Context, req mcp.CallToolRequest) 
 
 	// Sub-path scoping: a `path` argument or a `scope:`-named saved
 	// scope's paths narrow the literal hits to a monorepo service
-	// slice. trigram match paths are already repo-root-relative, so
-	// the anchored prefix test applies directly.
+	// slice. In multi-repo mode MultiIndexer.GrepText stamps a repo
+	// prefix onto every match path, so the repo-relative filter is
+	// expanded with the tracked repo prefixes before the anchored test.
 	if pathFilter := s.resolvePathFilter(req, fieldQuery{}); len(pathFilter) > 0 {
-		matches = filterTextMatchesByPath(matches, pathFilter)
+		var repoPrefixes []string
+		if s.multiIndexer != nil {
+			repoPrefixes = s.multiIndexer.RepoPrefixes()
+		}
+		matches = filterTextMatchesByPath(matches, pathFilter, repoPrefixes)
 	}
 
 	enriched := s.enrichTextMatches(matches)
@@ -93,15 +98,19 @@ func (s *Server) handleSearchText(ctx context.Context, req mcp.CallToolRequest) 
 }
 
 // filterTextMatchesByPath keeps only the trigram matches whose file
-// path sits under one of the anchored sub-path prefixes.
-func filterTextMatchesByPath(matches []trigram.Match, paths []string) []trigram.Match {
+// path sits under one of the anchored sub-path prefixes. repoPrefixes
+// carries the tracked repo prefixes (empty in single-repo mode) so a
+// repo-relative filter still matches the repo-prefixed paths that
+// MultiIndexer.GrepText stamps onto matches in multi-repo mode.
+func filterTextMatchesByPath(matches []trigram.Match, paths, repoPrefixes []string) []trigram.Match {
 	norm := normalizePathPrefixes(paths)
 	if len(norm) == 0 {
 		return matches
 	}
+	prefixes := expandPathPrefixesWithRepos(norm, repoPrefixes)
 	out := make([]trigram.Match, 0, len(matches))
 	for _, m := range matches {
-		if pathMatchesAnyPrefix(m.Path, norm) {
+		if pathMatchesAnyPrefix(m.Path, prefixes) {
 			out = append(out, m)
 		}
 	}

--- a/internal/mcp/tools_search_text_test.go
+++ b/internal/mcp/tools_search_text_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/zzet/gortex/internal/parser/languages"
 	"github.com/zzet/gortex/internal/query"
 	"github.com/zzet/gortex/internal/search"
+	"github.com/zzet/gortex/internal/search/trigram"
 )
 
 type searchTextMatch struct {
@@ -215,6 +216,93 @@ func TestSearchText_MultiRepoFanout(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(beta.Content[0].(mcplib.TextContent).Text), &betaOut))
 	require.Equal(t, 1, betaOut.Count)
 	require.True(t, strings.HasPrefix(betaOut.Matches[0].Path, "beta/"))
+}
+
+// TestGetFileSummary_MultiRepoRelativePath pins the multi-repo path
+// normalisation: get_file_summary (and get_editing_context, which shares
+// graphRelPath) must accept a repo-relative path and resolve it to the
+// owning repo's prefixed nodes. Before the fix the raw repo-relative path
+// missed the prefixed graph nodes and the tool returned file_not_indexed.
+func TestGetFileSummary_MultiRepoRelativePath(t *testing.T) {
+	mkRepo := func(name, rel, body string) string {
+		dir := filepath.Join(t.TempDir(), name)
+		require.NoError(t, os.MkdirAll(filepath.Dir(filepath.Join(dir, rel)), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, rel), []byte(body), 0o644))
+		return dir
+	}
+	repoA := mkRepo("alpha", "svc/a.go", "package svc\n\nfunc AlphaHandler() {}\n")
+	repoB := mkRepo("beta", "other/b.go", "package other\n\nfunc BetaHandler() {}\n")
+
+	tmpCfg := filepath.Join(t.TempDir(), "config.yaml")
+	gc := &config.GlobalConfig{Repos: []config.RepoEntry{
+		{Path: repoA, Name: "alpha"},
+		{Path: repoB, Name: "beta"},
+	}}
+	gc.SetConfigPath(tmpCfg)
+	require.NoError(t, gc.Save())
+	cm, err := config.NewConfigManager(tmpCfg)
+	require.NoError(t, err)
+
+	reg := parser.NewRegistry()
+	reg.Register(languages.NewGoExtractor())
+	g := graph.New()
+	mi := indexer.NewMultiIndexer(g, reg, search.NewBM25(), cm, zap.NewNop())
+	_, err = mi.IndexAll()
+	require.NoError(t, err)
+	require.True(t, mi.IsMultiRepo())
+
+	eng := query.NewEngine(g)
+	singleton := indexer.New(g, reg, config.IndexConfig{}, zap.NewNop())
+	srv := NewServer(eng, g, singleton, nil, zap.NewNop(), nil, MultiRepoOptions{
+		ConfigManager: cm,
+		MultiIndexer:  mi,
+	})
+
+	// A repo-relative path unique to one repo anchors to that repo's prefix.
+	require.Equal(t, "alpha/svc/a.go", srv.graphRelPath("svc/a.go"))
+
+	// get_file_summary with the repo-relative path now finds the symbols
+	// rather than returning a file_not_indexed miss.
+	res := callTool(t, srv, "get_file_summary", map[string]any{"path": "svc/a.go"})
+	require.False(t, res.IsError, "repo-relative path must resolve in multi-repo mode")
+	require.Contains(t, res.Content[0].(mcplib.TextContent).Text, "AlphaHandler")
+
+	// An already-prefixed path keeps working (idempotent normalisation).
+	require.Equal(t, "beta/other/b.go", srv.graphRelPath("beta/other/b.go"))
+}
+
+// TestFilterTextMatchesByPath_RepoPrefixed pins the multi-repo path
+// filter: a repo-relative sub-path (internal/mcp) must match the
+// repo-prefixed paths (gortex/internal/mcp/...) that
+// MultiIndexer.GrepText stamps onto matches. Before the fix the prefixed
+// paths never matched the repo-relative filter, so a path-scoped
+// search_text silently returned 0 even when the literal existed.
+func TestFilterTextMatchesByPath_RepoPrefixed(t *testing.T) {
+	matches := []trigram.Match{
+		{Path: "gortex/internal/mcp/tools_fileops.go"},
+		{Path: "gortex/internal/search/trigram/trigram.go"},
+		{Path: "other/internal/mcp/x.go"},
+	}
+	repoPrefixes := []string{"gortex", "other"}
+
+	// A repo-relative filter matches the prefixed paths across every repo.
+	got := filterTextMatchesByPath(matches, []string{"internal/mcp"}, repoPrefixes)
+	require.Len(t, got, 2)
+
+	// A prefix-qualified filter narrows to the one repo.
+	got = filterTextMatchesByPath(matches, []string{"gortex/internal/mcp"}, repoPrefixes)
+	require.Len(t, got, 1)
+	require.Equal(t, "gortex/internal/mcp/tools_fileops.go", got[0].Path)
+
+	// Anchored, segment-boundary matching is preserved — a partial
+	// segment must not match (no internal/mc → internal/mcp leak).
+	got = filterTextMatchesByPath(matches, []string{"internal/mc"}, repoPrefixes)
+	require.Empty(t, got)
+
+	// Single-repo mode (no repo prefixes): unprefixed paths match directly.
+	single := []trigram.Match{{Path: "internal/mcp/x.go"}}
+	got = filterTextMatchesByPath(single, []string{"internal/mcp"}, nil)
+	require.Len(t, got, 1)
 }
 
 // setupMiniRepoNamed mirrors setupMiniRepo but lets the caller supply


### PR DESCRIPTION
## Summary

Three improvements that came out of analyzing real dogfooding sessions. Stacked on `feat/node-kind-flavor`, so the diff is just these 3 commits — retarget to `main` after that branch merges.

### 1. Anchor repo-relative paths to the owning repo in multi-repo mode (`058c5a7e`)

In multi-repo mode the graph stores repo-prefixed paths (`gortex/internal/x.go`) but agents naturally pass repo-relative paths (`internal/x.go`). Three path handlers silently missed the prefixed nodes:

- `resolveFilePath` rejected an unprefixed path with *"does not start with a known repo prefix"* → `anchorUnprefixedExisting` anchors it to the lone tracked repo that contains the file (existence-gated, unique-match-only; 0 or >1 still errors).
- `search_text`'s `path:` filter matched the repo-relative filter against the repo-prefixed match paths and dropped every hit → `expandPathPrefixesWithRepos`.
- `get_editing_context` / `get_file_summary` looked up symbols by the raw repo-relative path → `graphRelPath` normalises to the stored form first.

### 2. "Did you mean" for unresolved symbol ids (`f6d6f8d4`)

`edit_symbol` / `get_symbol_source` now return a `did you mean: <ids>` hint (in-scope ids that share the requested name, plus the nearest-named symbols in the same file) instead of a bare *"symbol not found"*. Adds a `graphRelID` fallback so a repo-relative id resolves even when the session cwd doesn't map to a tracked repo.

### 3. Lean, token-saving agent guidance (`6fa30715`)

The mandated "run every step" workflow was largely performative in real sessions. Reworked across the generation surface (claudemd template, shared instructions, per-agent claudecode/cursor/hermes/kiro bodies; render goldens regenerated):

- liveness via `index_health`, not the heavy `graph_stats`-first ritual (`graph_stats` only when counts are needed)
- `smart_context` to orient a non-trivial task, not before every file read
- verify with the real build/test; reserve `check_guards` / `get_test_targets` for substantive changes
- new **Reuse and freshness** rules every agent inherits: don't re-fetch what you already have, re-validate with `if_none_match`/etag (`not_modified` is ~0 tokens), and treat a warming-index `count: 0` as not-yet-indexed rather than absent

## Verification

Full `internal/mcp` suite, `internal/agents/...`, `internal/claudemd`, and the `TestAgentsRenderGolden` drift fence all pass; `go vet` + `golangci-lint` clean. New unit/integration tests cover each path-resolution fix and the did-you-mean behavior.
