### PR TITLE
feat(codex): install SessionStart graph orientation hook

### DIFF
--- a/cmd/gortex/init.go
+++ b/cmd/gortex/init.go
@@ -76,7 +76,7 @@ var initCmd = &cobra.Command{
 	Use:   "init [path]",
 	Short: "Wire Gortex into the current repository for every detected AI coding assistant",
 	Long: `Configure Gortex for this repository: per-repo MCP and instruction files for each
-detected assistant, optional Claude Code hooks, community-derived routing, and (with --analyze)
+detected assistant, optional agent hooks, community-derived routing, and (with --analyze)
 a richer CLAUDE.md overview.
 
 For one-time machine-wide setup (user MCP config, user skills /
@@ -87,8 +87,8 @@ Knowledge Items, user hooks), run ` + "`gortex install`" + ` once.`,
 
 func init() {
 	initCmd.Flags().BoolVar(&initAnalyze, "analyze", false, "index the repo to generate a richer CLAUDE.md with codebase overview")
-	initCmd.Flags().BoolVar(&initInstallHooks, "hooks", true, "install Claude Code hooks (PreToolUse + PreCompact + Stop); use --no-hooks to skip")
-	initCmd.Flags().BoolVar(&initNoHooks, "no-hooks", false, "skip installing Claude Code hooks (inverse of --hooks)")
+	initCmd.Flags().BoolVar(&initInstallHooks, "hooks", true, "install supported agent hooks; use --no-hooks to skip")
+	initCmd.Flags().BoolVar(&initNoHooks, "no-hooks", false, "skip installing supported agent hooks (inverse of --hooks)")
 	initCmd.Flags().BoolVar(&initHooksOnly, "hooks-only", false, "only install/update Claude Code hooks in .claude/settings.local.json, skip everything else")
 	initCmd.Flags().StringVar(&initHookMode, "hook-mode", "deny",
 		"hook posture: 'deny' (PreToolUse redirects Grep/Glob/Read of indexed source) or 'enrich' "+

--- a/cmd/gortex/init_interactive.go
+++ b/cmd/gortex/init_interactive.go
@@ -38,7 +38,7 @@ func runInteractiveInit(in io.Reader, out io.Writer, hooksPreset bool) (interact
 		return choice, true
 	}
 
-	fmt.Fprint(out, "Install Claude Code hooks (PreToolUse + PreCompact + Stop)? [Y/n]: ")
+	fmt.Fprint(out, "Install agent hooks (Claude Code + Codex SessionStart where supported)? [Y/n]: ")
 	line, err := reader.ReadString('\n')
 	if err != nil {
 		return interactiveChoice{}, false

--- a/cmd/gortex/init_interactive_test.go
+++ b/cmd/gortex/init_interactive_test.go
@@ -23,7 +23,7 @@ func TestInteractiveWizard_DefaultHooksYes(t *testing.T) {
 	// Pressing Enter at the hooks prompt defaults to yes.
 	choice, out := runWizard(t, "\n")
 	assert.True(t, choice.Hooks, "empty input must default to yes")
-	assert.Contains(t, out, "Install Claude Code hooks")
+	assert.Contains(t, out, "Install agent hooks")
 }
 
 func TestInteractiveWizard_DeclineHooks(t *testing.T) {
@@ -41,7 +41,7 @@ func TestInteractiveWizard_HooksPresetSkipsPrompt(t *testing.T) {
 	choice, ok := runInteractiveInit(in, &out, true)
 	assert.True(t, ok, "preset path must return ok without reading input")
 	assert.True(t, choice.Hooks, "preset default is Hooks=true; caller overrides later")
-	assert.NotContains(t, out.String(), "Install Claude Code hooks",
+	assert.NotContains(t, out.String(), "Install agent hooks",
 		"hooks prompt must be suppressed when hooksPreset=true")
 }
 

--- a/cmd/gortex/init_wizard.go
+++ b/cmd/gortex/init_wizard.go
@@ -46,7 +46,7 @@ var agentDetails = map[string]string{
 	"aider":       ".aider.conf.yml",
 	"antigravity": ".antigravity/mcp.json",
 	"cline":       ".clinerules + cline_mcp_settings.json",
-	"codex":       "AGENTS.md + config.toml",
+	"codex":       "AGENTS.md + config.toml hooks",
 	"continue":    ".continue/config.json",
 	"gemini":      ".gemini/settings.json",
 	"hermes":      "~/.hermes/config.yaml + profiles + skills",
@@ -158,9 +158,9 @@ func newInitWizardModel(rootPath string, registered []agents.Adapter, detected m
 	opts := tui.OptionsPanel{
 		Toggles: []tui.Toggle{
 			{
-				Label:  "Claude Code hooks",
-				Hint:   "PreToolUse + PreCompact + Stop",
-				Detail: "redirect Read/Grep/Glob of indexed source through the graph",
+				Label:  "Agent hooks",
+				Hint:   "Claude Code + Codex",
+				Detail: "inject graph orientation and redirect indexed source reads where supported",
 				On:     defaults.hooks,
 			},
 			{

--- a/cmd/gortex/install.go
+++ b/cmd/gortex/install.go
@@ -64,8 +64,8 @@ func init() {
 	installCmd.Flags().BoolVar(&installJSON, "json", false, "emit a structured JSON report on stdout (banner still goes to stderr)")
 	installCmd.Flags().BoolVar(&installDryRun, "dry-run", false, "plan writes without modifying disk")
 	installCmd.Flags().BoolVar(&installForce, "force", false, "overwrite keys we would otherwise preserve during a merge")
-	installCmd.Flags().BoolVar(&installHooks, "hooks", true, "install user-level Claude Code hooks; use --no-hooks to skip")
-	installCmd.Flags().BoolVar(&installNoHooks, "no-hooks", false, "skip user-level Claude Code hooks (inverse of --hooks)")
+	installCmd.Flags().BoolVar(&installHooks, "hooks", true, "install user-level hooks for supported agents; use --no-hooks to skip")
+	installCmd.Flags().BoolVar(&installNoHooks, "no-hooks", false, "skip user-level hooks for supported agents (inverse of --hooks)")
 	installCmd.Flags().StringVar(&installHookMode, "hook-mode", "deny",
 		"hook posture: 'deny' (PreToolUse redirects Grep/Glob/Read of indexed source), 'enrich' "+
 			"(PreToolUse never denies; PostToolUse appends graph context after the tool runs — easier onboarding), "+

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -6,11 +6,10 @@ machine. Seventeen adapters ship today.
 
 - `gortex install` writes user-level machinery: `~/.claude.json` MCP,
   `~/.claude/skills/gortex-*`, `~/.claude/commands/gortex-*.md`,
-  `~/.gemini/antigravity/` Knowledge Items, user-level Claude Code
-  hooks.
+  `~/.gemini/antigravity/` Knowledge Items, and user-level hooks.
 - `gortex init` writes per-repo machinery: `.mcp.json`, per-agent
   MCP configs (`.cursor/mcp.json`, `.vscode/mcp.json`, …), repo-local
-  Claude Code hooks, per-agent marker-guarded community-routing
+  hooks where supported, per-agent marker-guarded community-routing
   blocks, and `.claude/skills/generated/` per-community SKILL.md.
 
 Run `gortex init doctor` to see what's currently configured. Both
@@ -25,7 +24,7 @@ commands accept `--agents=<csv>` to constrain setup and
 | `aider`         | `.aiderignore` block, `CONVENTIONS.md` communities block                                        | project    | https://aider.chat/docs/config/aider_conf.html                      |
 | `antigravity`   | `~/.gemini/antigravity/mcp_config.json` + Knowledge Item                                        | user       | https://antigravity.google/docs/mcp                                 |
 | `cline`         | `cline_mcp_settings.json` (per VS Code / Cursor globalStorage), `.clinerules/gortex-communities.md` | both     | https://docs.cline.bot/mcp/mcp-overview                             |
-| `codex`         | `~/.codex/config.toml` (`[mcp_servers.gortex]`), `AGENTS.md` communities block                  | both       | https://developers.openai.com/codex/mcp                             |
+| `codex`         | `~/.codex/config.toml` (`[mcp_servers.gortex]` + `SessionStart` hook), `AGENTS.md` communities block | both       | https://developers.openai.com/codex/mcp                             |
 | `continue`      | `.continue/mcpServers/gortex.json`, `.continue/rules/gortex-communities.md`                     | project    | https://docs.continue.dev/customize/deep-dives/mcp                  |
 | `cursor`        | `.cursor/mcp.json` (project) or `~/.cursor/mcp.json`, `.cursor/rules/gortex-communities.mdc`    | both       | https://docs.cursor.com/en/context/mcp                              |
 | `gemini`        | `.gemini/settings.json` or `~/.gemini/settings.json`, `GEMINI.md` communities block             | both       | https://geminicli.com/docs/tools/mcp-server/                        |
@@ -195,7 +194,11 @@ directory that exists. Auto-approval field is `alwaysAllow` (not
 ### codex
 
 OpenAI Codex CLI stores config in `~/.codex/config.toml`. We
-upsert a `[mcp_servers.gortex]` table there.
+upsert a `[mcp_servers.gortex]` table there. When hooks are enabled
+(the default), we also add one user-level `SessionStart` hook matching
+`startup|resume|clear|compact`. It emits a short graph-tools
+orientation so new, resumed, cleared, and compacted Codex sessions see
+the same nudge without installing PreToolUse/PostToolUse hooks.
 
 ### continue
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -12,7 +12,7 @@ Just installed Gortex? This is the shortest path from "it's on my machine" to "i
 
 Setup is split into two commands so codebase-agnostic machinery lives once per user, not once per repo:
 
-- **`gortex install`** — run **once per machine**. Writes user-level artifacts: `~/.claude.json` (MCP config), `~/.claude/skills/gortex-*` (tool-usage skills), `~/.claude/commands/gortex-*.md` (slash commands), `~/.gemini/antigravity/` Knowledge Items, and (optionally) user-level Claude Code hooks. Also sets up the daemon — pass `--start` to spawn it, `--track` to register the current directory.
+- **`gortex install`** — run **once per machine**. Writes user-level artifacts: `~/.claude.json` (MCP config), `~/.claude/skills/gortex-*` (tool-usage skills), `~/.claude/commands/gortex-*.md` (slash commands), `~/.gemini/antigravity/` Knowledge Items, and (optionally) user-level hooks. Also sets up the daemon — pass `--start` to spawn it, `--track` to register the current directory.
 - **`gortex init`** — run **once per repo**. Writes per-repo artifacts: `.mcp.json`, `.claude/settings.{json,local.json}`, `CLAUDE.md` with the codebase overview and community routing, `.claude/skills/generated/` per-community SKILL.md files, and a marker-guarded community-routing block in every other detected agent's per-repo instructions file.
 
 You can run them independently — `gortex init` doesn't require `gortex install` first; it just writes less if the user-level wiring isn't there.
@@ -50,7 +50,7 @@ Open your AI assistant in that repo and ask it to do something real. It'll use G
 ```bash
 gortex install                    # MCP config, skills, slash commands, KIs at ~/
 gortex install --start --track    # also spawn the daemon + track current dir
-gortex install --no-hooks         # skip user-level Claude Code hooks
+gortex install --no-hooks         # skip user-level hooks
 ```
 
 This writes under `$HOME` only. It's idempotent — re-running it is safe. Think of it like `brew install`.

--- a/internal/agents/agents.go
+++ b/internal/agents/agents.go
@@ -76,8 +76,8 @@ type Env struct {
 	Mode Mode
 
 	// InstallHooks is false when the user passed --no-hooks or
-	// answered "no" to the wizard. Only the Claude Code adapter
-	// currently honours it.
+	// answered "no" to the wizard. Hook-capable adapters use it to
+	// skip their lifecycle hook surfaces while still installing MCP.
 	InstallHooks bool
 
 	// HookMode is the posture for the PreToolUse / PostToolUse hook

--- a/internal/agents/codex/adapter.go
+++ b/internal/agents/codex/adapter.go
@@ -26,7 +26,7 @@ const Name = "codex"
 const DocsURL = "https://developers.openai.com/codex/mcp"
 
 const codexSessionStartMatcher = "startup|resume|clear|compact"
-const codexSessionStartMessage = "[Gortex] Prefer Gortex graph tools (search_symbols, get_callers, get_file_summary) before Read/Grep/Glob over large files."
+const codexSessionStartMessage = "IMPORTANT: Prefer Gortex MCP tools (search_symbols, get_callers, get_file_summary, edit_file) over Read/Grep/Glob/Edit."
 const codexSessionStartCommand = "printf '%s\\n' '" + codexSessionStartMessage + "'"
 const codexSessionStartWindowsCommand = "powershell -NoProfile -Command \"Write-Output '" + codexSessionStartMessage + "'\""
 

--- a/internal/agents/codex/adapter.go
+++ b/internal/agents/codex/adapter.go
@@ -25,6 +25,11 @@ import (
 const Name = "codex"
 const DocsURL = "https://developers.openai.com/codex/mcp"
 
+const codexSessionStartMatcher = "startup|resume|clear|compact"
+const codexSessionStartMessage = "[Gortex] Prefer Gortex graph tools (search_symbols, get_callers, get_file_summary) before Read/Grep/Glob over large files."
+const codexSessionStartCommand = "printf '%s\\n' '" + codexSessionStartMessage + "'"
+const codexSessionStartWindowsCommand = "powershell -NoProfile -Command \"Write-Output '" + codexSessionStartMessage + "'\""
+
 type Adapter struct{}
 
 func New() *Adapter                { return &Adapter{} }
@@ -48,10 +53,14 @@ func (a *Adapter) Detect(env agents.Env) (bool, error) {
 func (a *Adapter) Plan(env agents.Env) (*agents.Plan, error) {
 	p := &agents.Plan{}
 	if env.Home != "" {
+		keys := []string{"mcp_servers"}
+		if env.InstallHooks {
+			keys = append(keys, "hooks")
+		}
 		p.Files = append(p.Files, agents.FileAction{
 			Path:   filepath.Join(env.Home, ".codex", "config.toml"),
 			Action: agents.ActionWouldMerge,
-			Keys:   []string{"mcp_servers"},
+			Keys:   keys,
 		})
 	}
 	if env.Mode != agents.ModeGlobal && env.SkillsRouting != "" {
@@ -78,22 +87,27 @@ func (a *Adapter) Apply(env agents.Env, opts agents.ApplyOpts) (*agents.Result, 
 
 	path := filepath.Join(env.Home, ".codex", "config.toml")
 	action, err := agents.MergeTOML(env.Stderr, path, func(root map[string]any, _ bool) (bool, error) {
+		changed := false
 		servers, ok := root["mcp_servers"].(map[string]any)
 		if !ok {
 			servers = make(map[string]any)
 		}
-		if _, exists := servers["gortex"]; exists && !opts.Force {
-			return false, nil
+		if _, exists := servers["gortex"]; !exists || opts.Force {
+			servers["gortex"] = map[string]any{
+				"command": "gortex",
+				"args":    []string{"mcp"},
+				"env": map[string]any{
+					"GORTEX_INDEX_WORKERS": "8",
+				},
+			}
+			root["mcp_servers"] = servers
+			changed = true
 		}
-		servers["gortex"] = map[string]any{
-			"command": "gortex",
-			"args":    []string{"mcp"},
-			"env": map[string]any{
-				"GORTEX_INDEX_WORKERS": "8",
-			},
+
+		if env.InstallHooks && upsertSessionStartHook(root, opts) {
+			changed = true
 		}
-		root["mcp_servers"] = servers
-		return true, nil
+		return changed, nil
 	}, opts)
 	if err != nil {
 		return res, err
@@ -116,4 +130,95 @@ func (a *Adapter) Apply(env agents.Env, opts agents.ApplyOpts) (*agents.Result, 
 
 	res.Configured = true
 	return res, nil
+}
+
+func upsertSessionStartHook(root map[string]any, opts agents.ApplyOpts) bool {
+	hooks, ok := root["hooks"].(map[string]any)
+	if !ok {
+		if _, exists := root["hooks"]; exists {
+			return false
+		}
+		hooks = make(map[string]any)
+	}
+
+	entries, ok := codexHookList(hooks["SessionStart"])
+	if !ok {
+		return false
+	}
+
+	found := false
+	kept := make([]any, 0, len(entries)+1)
+	for _, entry := range entries {
+		if codexHookEntryIsGortexSessionStart(entry) {
+			found = true
+			if opts.Force {
+				continue
+			}
+		}
+		kept = append(kept, entry)
+	}
+	if found && !opts.Force {
+		return false
+	}
+
+	hooks["SessionStart"] = append(kept, codexSessionStartHookEntry())
+	root["hooks"] = hooks
+	return true
+}
+
+func codexHookList(v any) ([]any, bool) {
+	if v == nil {
+		return nil, true
+	}
+	switch list := v.(type) {
+	case []any:
+		return append([]any(nil), list...), true
+	case []map[string]any:
+		out := make([]any, 0, len(list))
+		for _, entry := range list {
+			out = append(out, entry)
+		}
+		return out, true
+	default:
+		return nil, false
+	}
+}
+
+func codexHookEntryIsGortexSessionStart(entry any) bool {
+	group, ok := entry.(map[string]any)
+	if !ok {
+		return false
+	}
+	handlers, ok := codexHookList(group["hooks"])
+	if !ok {
+		return false
+	}
+	for _, handler := range handlers {
+		hm, ok := handler.(map[string]any)
+		if !ok {
+			continue
+		}
+		if cmd, _ := hm["command"].(string); cmd == codexSessionStartCommand {
+			return true
+		}
+		if cmd, _ := hm["command_windows"].(string); cmd == codexSessionStartWindowsCommand {
+			return true
+		}
+	}
+	return false
+}
+
+func codexSessionStartHookEntry() map[string]any {
+	return map[string]any{
+		"matcher": codexSessionStartMatcher,
+		"hooks": []any{
+			map[string]any{
+				"type":            "command",
+				"command":         codexSessionStartCommand,
+				"command_windows": codexSessionStartWindowsCommand,
+				"timeout":         5,
+				"statusMessage":   "Loading Gortex graph orientation...",
+			},
+		},
+	}
 }

--- a/internal/agents/codex/adapter_test.go
+++ b/internal/agents/codex/adapter_test.go
@@ -84,8 +84,15 @@ func TestCodexInstallsSessionStartHook(t *testing.T) {
 	if handler["command_windows"] != codexSessionStartWindowsCommand {
 		t.Errorf("command_windows=%v want %q", handler["command_windows"], codexSessionStartWindowsCommand)
 	}
-	if !strings.Contains(handler["command"].(string), "Prefer Gortex graph tools") {
+	command := handler["command"].(string)
+	if !strings.Contains(command, "IMPORTANT: Prefer Gortex MCP tools") {
 		t.Errorf("command should emit the graph-tools orientation: %v", handler["command"])
+	}
+	if !strings.Contains(command, "edit_file") {
+		t.Errorf("command should mention edit_file: %v", handler["command"])
+	}
+	if strings.Contains(command, "[Gortex]") {
+		t.Errorf("command should not duplicate the Gortex label: %v", handler["command"])
 	}
 }
 

--- a/internal/agents/codex/adapter_test.go
+++ b/internal/agents/codex/adapter_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	toml "github.com/pelletier/go-toml/v2"
+
 	"github.com/zzet/gortex/internal/agents"
 	"github.com/zzet/gortex/internal/agents/agentstest"
 )
@@ -41,5 +43,222 @@ func TestCodexWritesMcpServersTOMLTable(t *testing.T) {
 		t.Fatalf("expected gortex entry: %s", got)
 	}
 
+	cfg := readCodexConfig(t, env)
+	if count := gortexSessionStartHookCount(t, cfg); count != 1 {
+		t.Fatalf("expected one Gortex SessionStart hook, got %d: %#v", count, cfg["hooks"])
+	}
+
 	agentstest.AssertIdempotent(t, a, env)
+}
+
+func TestCodexInstallsSessionStartHook(t *testing.T) {
+	env := codexGlobalEnv(t)
+	a := New()
+
+	res, err := a.Apply(env, agents.ApplyOpts{})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionCreate: 1})
+
+	cfg := readCodexConfig(t, env)
+	entries := sessionStartEntries(t, cfg)
+	if len(entries) != 1 {
+		t.Fatalf("SessionStart entries=%d want 1: %#v", len(entries), entries)
+	}
+	entry := entries[0].(map[string]any)
+	if entry["matcher"] != codexSessionStartMatcher {
+		t.Fatalf("matcher=%v want %q", entry["matcher"], codexSessionStartMatcher)
+	}
+	handlers, ok := codexHookList(entry["hooks"])
+	if !ok || len(handlers) != 1 {
+		t.Fatalf("handlers=%#v", entry["hooks"])
+	}
+	handler := handlers[0].(map[string]any)
+	if handler["type"] != "command" {
+		t.Errorf("hook type=%v want command", handler["type"])
+	}
+	if handler["command"] != codexSessionStartCommand {
+		t.Errorf("command=%v want %q", handler["command"], codexSessionStartCommand)
+	}
+	if handler["command_windows"] != codexSessionStartWindowsCommand {
+		t.Errorf("command_windows=%v want %q", handler["command_windows"], codexSessionStartWindowsCommand)
+	}
+	if !strings.Contains(handler["command"].(string), "Prefer Gortex graph tools") {
+		t.Errorf("command should emit the graph-tools orientation: %v", handler["command"])
+	}
+}
+
+func TestCodexSessionStartHookIdempotent(t *testing.T) {
+	env := codexGlobalEnv(t)
+	a := New()
+
+	if _, err := a.Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+	res, err := a.Apply(env, agents.ApplyOpts{})
+	if err != nil {
+		t.Fatalf("second apply: %v", err)
+	}
+	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionSkip: 1})
+
+	cfg := readCodexConfig(t, env)
+	if count := gortexSessionStartHookCount(t, cfg); count != 1 {
+		t.Fatalf("re-run duplicated Gortex SessionStart hook: got %d", count)
+	}
+}
+
+func TestCodexSessionStartHookPreservesExistingConfig(t *testing.T) {
+	env := codexGlobalEnv(t)
+	path := codexConfigPath(env)
+	seed := `model = "gpt-5-codex"
+
+[mcp_servers.other]
+command = "other"
+
+[[hooks.SessionStart]]
+matcher = "startup"
+
+[[hooks.SessionStart.hooks]]
+type = "command"
+command = "echo user-session-start"
+statusMessage = "User hook"
+`
+	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	a := New()
+	res, err := a.Apply(env, agents.ApplyOpts{})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionMerge: 1})
+
+	cfg := readCodexConfig(t, env)
+	if cfg["model"] != "gpt-5-codex" {
+		t.Fatalf("unrelated top-level key was clobbered: %#v", cfg)
+	}
+	servers := cfg["mcp_servers"].(map[string]any)
+	if _, ok := servers["other"]; !ok {
+		t.Fatalf("existing MCP server was clobbered: %#v", servers)
+	}
+	if _, ok := servers["gortex"]; !ok {
+		t.Fatalf("gortex MCP server missing after merge: %#v", servers)
+	}
+	entries := sessionStartEntries(t, cfg)
+	if len(entries) != 2 {
+		t.Fatalf("SessionStart entries=%d want user+gortex entries: %#v", len(entries), entries)
+	}
+	if !hasSessionStartCommand(t, cfg, "echo user-session-start") {
+		t.Fatalf("user SessionStart hook was not preserved: %#v", entries)
+	}
+	if count := gortexSessionStartHookCount(t, cfg); count != 1 {
+		t.Fatalf("Gortex SessionStart hooks=%d want 1", count)
+	}
+}
+
+func TestCodexNoHooksSkipsSessionStartHook(t *testing.T) {
+	env := codexGlobalEnv(t)
+	env.InstallHooks = false
+	a := New()
+
+	if _, err := a.Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	cfg := readCodexConfig(t, env)
+	if _, ok := cfg["hooks"]; ok {
+		t.Fatalf("--no-hooks should not write Codex hooks: %#v", cfg["hooks"])
+	}
+	if _, ok := cfg["mcp_servers"].(map[string]any)["gortex"]; !ok {
+		t.Fatal("mcp_servers.gortex should still be written under --no-hooks")
+	}
+
+	plan, err := a.Plan(env)
+	if err != nil {
+		t.Fatalf("plan: %v", err)
+	}
+	if len(plan.Files) != 1 {
+		t.Fatalf("plan files=%d want 1", len(plan.Files))
+	}
+	for _, key := range plan.Files[0].Keys {
+		if key == "hooks" {
+			t.Fatalf("Plan should not report hooks under --no-hooks: %#v", plan.Files[0].Keys)
+		}
+	}
+}
+
+func codexGlobalEnv(t *testing.T) agents.Env {
+	t.Helper()
+	env, _ := agentstest.NewEnv(t)
+	env.Mode = agents.ModeGlobal
+	if err := os.MkdirAll(filepath.Join(env.Home, ".codex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return env
+}
+
+func codexConfigPath(env agents.Env) string {
+	return filepath.Join(env.Home, ".codex", "config.toml")
+}
+
+func readCodexConfig(t *testing.T, env agents.Env) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(codexConfigPath(env))
+	if err != nil {
+		t.Fatalf("read config.toml: %v", err)
+	}
+	var out map[string]any
+	if err := toml.Unmarshal(data, &out); err != nil {
+		t.Fatalf("parse config.toml: %v\n%s", err, data)
+	}
+	return out
+}
+
+func sessionStartEntries(t *testing.T, cfg map[string]any) []any {
+	t.Helper()
+	hooks, ok := cfg["hooks"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing hooks map: %#v", cfg)
+	}
+	entries, ok := codexHookList(hooks["SessionStart"])
+	if !ok {
+		t.Fatalf("hooks.SessionStart has unexpected shape: %#v", hooks["SessionStart"])
+	}
+	return entries
+}
+
+func gortexSessionStartHookCount(t *testing.T, cfg map[string]any) int {
+	t.Helper()
+	count := 0
+	for _, entry := range sessionStartEntries(t, cfg) {
+		if codexHookEntryIsGortexSessionStart(entry) {
+			count++
+		}
+	}
+	return count
+}
+
+func hasSessionStartCommand(t *testing.T, cfg map[string]any, command string) bool {
+	t.Helper()
+	for _, entry := range sessionStartEntries(t, cfg) {
+		group, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		handlers, ok := codexHookList(group["hooks"])
+		if !ok {
+			continue
+		}
+		for _, handler := range handlers {
+			hm, ok := handler.(map[string]any)
+			if !ok {
+				continue
+			}
+			if got, _ := hm["command"].(string); got == command {
+				return true
+			}
+		}
+	}
+	return false
 }


### PR DESCRIPTION
  ## Summary

  Adds minimal Codex hook support by installing a `SessionStart` orientation hook into `~/.codex/config.toml`.

  When Codex starts or resumes a session, the hook prints a short reminder to prefer Gortex graph tools before large direct file reads. This mirrors the existing agent onboarding intent without changing MCP
  behavior or adding tool interception.

  This intentionally keeps the first Codex hook PR small: it only covers `SessionStart`, not `PreToolUse` / `PostToolUse`.

  ## Changes

  - Install an idempotent Codex `SessionStart` hook when hooks are enabled
  - Match Codex start sources with `startup|resume|clear|compact`
  - Preserve existing Codex hooks and existing `mcp_servers.gortex` config
  - Respect `--no-hooks` / `InstallHooks=false` for Codex hook installation
  - Add POSIX and Windows hook commands
  - Update install/init copy and docs for supported agent hooks
  - Add focused tests for fresh install, repeated install, existing config merge, and no-hooks behavior

  Out of scope:

  - Codex `PreToolUse` / `PostToolUse` hooks
  - Dynamic hook handling or context injection
  - Changes to Claude Code hook behavior
  - Changes to MCP tools, indexing, daemon, LSP, resolver, or graph storage
  - Expanding `--hooks-only` beyond its current Claude Code behavior

  ## Testing

  - [x] `go test ./internal/agents/...`
  - [x] `go test ./cmd/gortex/...`
  - [x] `go test -race ./internal/agents/codex ./internal/agents`
  - [x] `git diff --check`
  - [x] `go test -run '^$' -bench . ./internal/agents/...`
  - [x] New tests added for new functionality
  - [x] All tests pass (`go test -race ./...`)
  - [x] Benchmarks run if performance-relevant

  Benchmarks are not performance-relevant for this config-writing change; the scoped benchmark build passed and there are no benchmark cases in the changed agent packages.

  ## Checklist

  - [x] Code follows existing patterns in the codebase
  - [x] No unnecessary abstractions added
  - [ ] Language extractor includes `Meta["methods"]` for interfaces (if applicable)
  - [ ] Methods have `EdgeMemberOf` edges to their containing type (if applicable)

Related to https://github.com/zzet/gortex/issues/206