### PR TITLE
feat(codex): add Bash PreToolUse graph guidance

### DIFF
--- a/cmd/gortex/hook.go
+++ b/cmd/gortex/hook.go
@@ -34,6 +34,12 @@ var hookCmd = &cobra.Command{
 			// envelope on stdin and applying the PiDecision read back.
 			hooks.RunPi(hookPort, hooks.ParseMode(hookMode))
 			return
+		case "codex":
+			// Codex support is intentionally soft-only for now: the adapter
+			// installs a Bash PreToolUse hook that emits additionalContext
+			// without ever denying the tool call.
+			hooks.RunCodex(hookPort)
+			return
 		case "", "claude":
 			// Claude Code — handled below.
 		default:
@@ -49,6 +55,6 @@ func init() {
 	hookCmd.Flags().StringVar(&hookMode, "mode", "deny",
 		"hook posture: 'deny' (redirect Grep/Glob/Read of indexed source), 'enrich' (never deny; PostToolUse appends graph context), 'consult-unlock' (deny fallback reads until the graph is queried once this session), or 'nudge' (soft-deny once per burst of non-symbolic calls)")
 	hookCmd.Flags().StringVar(&hookAgent, "agent", "",
-		"hook wire protocol: empty/'claude' (Claude Code PreToolUse/UserPromptSubmit), 'hermes' (NousResearch hermes-agent pre_tool_call/pre_llm_call), 'pi' (earendil-works/pi extension bridge — normalized PiEvent envelope in, PiDecision out), or 'gemini'/'antigravity' (emits hookSpecificOutput.additionalContext). Default (empty) is the Claude Code format.")
+		"hook wire protocol: empty/'claude' (Claude Code PreToolUse/UserPromptSubmit), 'codex' (Codex Bash PreToolUse soft nudge), 'hermes' (NousResearch hermes-agent pre_tool_call/pre_llm_call), 'pi' (earendil-works/pi extension bridge — normalized PiEvent envelope in, PiDecision out), or 'gemini'/'antigravity' (emits hookSpecificOutput.additionalContext). Default (empty) is the Claude Code format.")
 	rootCmd.AddCommand(hookCmd)
 }

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -24,7 +24,7 @@ commands accept `--agents=<csv>` to constrain setup and
 | `aider`         | `.aiderignore` block, `CONVENTIONS.md` communities block                                        | project    | https://aider.chat/docs/config/aider_conf.html                      |
 | `antigravity`   | `~/.gemini/antigravity/mcp_config.json` + Knowledge Item                                        | user       | https://antigravity.google/docs/mcp                                 |
 | `cline`         | `cline_mcp_settings.json` (per VS Code / Cursor globalStorage), `.clinerules/gortex-communities.md` | both     | https://docs.cline.bot/mcp/mcp-overview                             |
-| `codex`         | `~/.codex/config.toml` (`[mcp_servers.gortex]` + `SessionStart` hook), `AGENTS.md` communities block | both       | https://developers.openai.com/codex/mcp                             |
+| `codex`         | `~/.codex/config.toml` (`[mcp_servers.gortex]` + `SessionStart` / Bash `PreToolUse` hooks), `AGENTS.md` communities block | both       | https://developers.openai.com/codex/mcp                             |
 | `continue`      | `.continue/mcpServers/gortex.json`, `.continue/rules/gortex-communities.md`                     | project    | https://docs.continue.dev/customize/deep-dives/mcp                  |
 | `cursor`        | `.cursor/mcp.json` (project) or `~/.cursor/mcp.json`, `.cursor/rules/gortex-communities.mdc`    | both       | https://docs.cursor.com/en/context/mcp                              |
 | `gemini`        | `.gemini/settings.json` or `~/.gemini/settings.json`, `GEMINI.md` communities block             | both       | https://geminicli.com/docs/tools/mcp-server/                        |
@@ -199,7 +199,11 @@ upsert a `[mcp_servers.gortex]` table there. When hooks are enabled
 (the default), we also add one user-level `SessionStart` hook matching
 `startup|resume|clear|compact`. It emits a short graph-tools
 orientation so new, resumed, cleared, and compacted Codex sessions see
-the same nudge without installing PreToolUse/PostToolUse hooks.
+the same nudge. Codex also gets a Bash-only `PreToolUse` hook in
+soft-enrich mode: it can add `hookSpecificOutput.additionalContext`
+when a shell search/read shape should prefer Gortex graph tools, but it
+does not deny, rewrite input, handle `apply_patch`, or install
+`PostToolUse`.
 
 ### continue
 

--- a/internal/agents/codex/adapter.go
+++ b/internal/agents/codex/adapter.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/zzet/gortex/internal/agents"
 	"github.com/zzet/gortex/internal/agents/internalutil"
@@ -29,6 +30,8 @@ const codexSessionStartMatcher = "startup|resume|clear|compact"
 const codexSessionStartMessage = "IMPORTANT: Prefer Gortex MCP tools (search_symbols, get_callers, get_file_summary, edit_file) over Read/Grep/Glob/Edit."
 const codexSessionStartCommand = "printf '%s\\n' '" + codexSessionStartMessage + "'"
 const codexSessionStartWindowsCommand = "powershell -NoProfile -Command \"Write-Output '" + codexSessionStartMessage + "'\""
+const codexPreToolUseMatcher = "^Bash$"
+const codexHookTimeoutSeconds = 5
 
 type Adapter struct{}
 
@@ -104,8 +107,13 @@ func (a *Adapter) Apply(env agents.Env, opts agents.ApplyOpts) (*agents.Result, 
 			changed = true
 		}
 
-		if env.InstallHooks && upsertSessionStartHook(root, opts) {
-			changed = true
+		if env.InstallHooks {
+			if upsertSessionStartHook(root, opts) {
+				changed = true
+			}
+			if upsertPreToolUseHook(root, env, opts) {
+				changed = true
+			}
 		}
 		return changed, nil
 	}, opts)
@@ -133,6 +141,14 @@ func (a *Adapter) Apply(env agents.Env, opts agents.ApplyOpts) (*agents.Result, 
 }
 
 func upsertSessionStartHook(root map[string]any, opts agents.ApplyOpts) bool {
+	return upsertCodexHook(root, "SessionStart", codexHookEntryIsGortexSessionStart, codexSessionStartHookEntry(), opts)
+}
+
+func upsertPreToolUseHook(root map[string]any, env agents.Env, opts agents.ApplyOpts) bool {
+	return upsertCodexHook(root, "PreToolUse", codexHookEntryIsGortexPreToolUse, codexPreToolUseHookEntry(env), opts)
+}
+
+func upsertCodexHook(root map[string]any, event string, isGortex func(any) bool, desired map[string]any, opts agents.ApplyOpts) bool {
 	hooks, ok := root["hooks"].(map[string]any)
 	if !ok {
 		if _, exists := root["hooks"]; exists {
@@ -141,7 +157,7 @@ func upsertSessionStartHook(root map[string]any, opts agents.ApplyOpts) bool {
 		hooks = make(map[string]any)
 	}
 
-	entries, ok := codexHookList(hooks["SessionStart"])
+	entries, ok := codexHookList(hooks[event])
 	if !ok {
 		return false
 	}
@@ -149,7 +165,7 @@ func upsertSessionStartHook(root map[string]any, opts agents.ApplyOpts) bool {
 	found := false
 	kept := make([]any, 0, len(entries)+1)
 	for _, entry := range entries {
-		if codexHookEntryIsGortexSessionStart(entry) {
+		if isGortex(entry) {
 			found = true
 			if opts.Force {
 				continue
@@ -161,7 +177,7 @@ func upsertSessionStartHook(root map[string]any, opts agents.ApplyOpts) bool {
 		return false
 	}
 
-	hooks["SessionStart"] = append(kept, codexSessionStartHookEntry())
+	hooks[event] = append(kept, desired)
 	root["hooks"] = hooks
 	return true
 }
@@ -208,6 +224,39 @@ func codexHookEntryIsGortexSessionStart(entry any) bool {
 	return false
 }
 
+func codexHookEntryIsGortexPreToolUse(entry any) bool {
+	group, ok := entry.(map[string]any)
+	if !ok {
+		return false
+	}
+	handlers, ok := codexHookList(group["hooks"])
+	if !ok {
+		return false
+	}
+	for _, handler := range handlers {
+		hm, ok := handler.(map[string]any)
+		if !ok {
+			continue
+		}
+		if cmd, _ := hm["command"].(string); codexCommandInvokesCodexHook(cmd) {
+			return true
+		}
+	}
+	return false
+}
+
+func codexCommandInvokesCodexHook(cmd string) bool {
+	cmd = strings.TrimSpace(cmd)
+	if cmd == "" {
+		return false
+	}
+	lower := strings.ToLower(cmd)
+	if !strings.Contains(lower, "gortex") || !strings.Contains(lower, "hook") {
+		return false
+	}
+	return strings.Contains(cmd, "--agent=codex") || strings.Contains(cmd, "--agent codex")
+}
+
 func codexSessionStartHookEntry() map[string]any {
 	return map[string]any{
 		"matcher": codexSessionStartMatcher,
@@ -216,9 +265,31 @@ func codexSessionStartHookEntry() map[string]any {
 				"type":            "command",
 				"command":         codexSessionStartCommand,
 				"command_windows": codexSessionStartWindowsCommand,
-				"timeout":         5,
+				"timeout":         codexHookTimeoutSeconds,
 				"statusMessage":   "Loading Gortex graph orientation...",
 			},
 		},
 	}
+}
+
+func codexPreToolUseHookEntry(env agents.Env) map[string]any {
+	return map[string]any{
+		"matcher": codexPreToolUseMatcher,
+		"hooks": []any{
+			map[string]any{
+				"type":          "command",
+				"command":       codexPreToolUseCommand(env),
+				"timeout":       codexHookTimeoutSeconds,
+				"statusMessage": "Loading Gortex Bash guidance...",
+			},
+		},
+	}
+}
+
+func codexPreToolUseCommand(env agents.Env) string {
+	base := strings.TrimSpace(env.HookCommand)
+	if base == "" {
+		base = "gortex hook"
+	}
+	return base + " --agent=codex --mode=enrich"
 }

--- a/internal/agents/codex/adapter_test.go
+++ b/internal/agents/codex/adapter_test.go
@@ -47,6 +47,9 @@ func TestCodexWritesMcpServersTOMLTable(t *testing.T) {
 	if count := gortexSessionStartHookCount(t, cfg); count != 1 {
 		t.Fatalf("expected one Gortex SessionStart hook, got %d: %#v", count, cfg["hooks"])
 	}
+	if count := gortexPreToolUseHookCount(t, cfg); count != 1 {
+		t.Fatalf("expected one Gortex PreToolUse hook, got %d: %#v", count, cfg["hooks"])
+	}
 
 	agentstest.AssertIdempotent(t, a, env)
 }
@@ -96,6 +99,52 @@ func TestCodexInstallsSessionStartHook(t *testing.T) {
 	}
 }
 
+func TestCodexInstallsPreToolUseHook(t *testing.T) {
+	env := codexGlobalEnv(t)
+	a := New()
+
+	res, err := a.Apply(env, agents.ApplyOpts{})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionCreate: 1})
+
+	cfg := readCodexConfig(t, env)
+	entries := preToolUseEntries(t, cfg)
+	if len(entries) != 1 {
+		t.Fatalf("PreToolUse entries=%d want 1: %#v", len(entries), entries)
+	}
+	entry := entries[0].(map[string]any)
+	if entry["matcher"] != codexPreToolUseMatcher {
+		t.Fatalf("matcher=%v want %q", entry["matcher"], codexPreToolUseMatcher)
+	}
+	handlers, ok := codexHookList(entry["hooks"])
+	if !ok || len(handlers) != 1 {
+		t.Fatalf("handlers=%#v", entry["hooks"])
+	}
+	handler := handlers[0].(map[string]any)
+	if handler["type"] != "command" {
+		t.Errorf("hook type=%v want command", handler["type"])
+	}
+	command := handler["command"].(string)
+	if command != "/tmp/test-gortex hook --agent=codex --mode=enrich" {
+		t.Errorf("command=%v want test hook command with --agent=codex --mode=enrich", command)
+	}
+	if handler["timeout"] != int64(codexHookTimeoutSeconds) {
+		t.Errorf("timeout=%v want %d", handler["timeout"], codexHookTimeoutSeconds)
+	}
+	if _, ok := cfg["hooks"].(map[string]any)["PostToolUse"]; ok {
+		t.Fatalf("Codex should not install PostToolUse: %#v", cfg["hooks"])
+	}
+}
+
+func TestCodexPreToolUseCommandFallsBackToGortexHook(t *testing.T) {
+	command := codexPreToolUseCommand(agents.Env{})
+	if command != "gortex hook --agent=codex --mode=enrich" {
+		t.Fatalf("fallback command=%q", command)
+	}
+}
+
 func TestCodexSessionStartHookIdempotent(t *testing.T) {
 	env := codexGlobalEnv(t)
 	a := New()
@@ -112,6 +161,9 @@ func TestCodexSessionStartHookIdempotent(t *testing.T) {
 	cfg := readCodexConfig(t, env)
 	if count := gortexSessionStartHookCount(t, cfg); count != 1 {
 		t.Fatalf("re-run duplicated Gortex SessionStart hook: got %d", count)
+	}
+	if count := gortexPreToolUseHookCount(t, cfg); count != 1 {
+		t.Fatalf("re-run duplicated Gortex PreToolUse hook: got %d", count)
 	}
 }
 
@@ -130,6 +182,14 @@ matcher = "startup"
 type = "command"
 command = "echo user-session-start"
 statusMessage = "User hook"
+
+[[hooks.PreToolUse]]
+matcher = "^Bash$"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "echo user-pretooluse"
+statusMessage = "User PreToolUse"
 `
 	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
 		t.Fatalf("seed config: %v", err)
@@ -162,6 +222,65 @@ statusMessage = "User hook"
 	}
 	if count := gortexSessionStartHookCount(t, cfg); count != 1 {
 		t.Fatalf("Gortex SessionStart hooks=%d want 1", count)
+	}
+	preEntries := preToolUseEntries(t, cfg)
+	if len(preEntries) != 2 {
+		t.Fatalf("PreToolUse entries=%d want user+gortex entries: %#v", len(preEntries), preEntries)
+	}
+	if !hasHookCommand(t, cfg, "PreToolUse", "echo user-pretooluse") {
+		t.Fatalf("user PreToolUse hook was not preserved: %#v", preEntries)
+	}
+	if count := gortexPreToolUseHookCount(t, cfg); count != 1 {
+		t.Fatalf("Gortex PreToolUse hooks=%d want 1", count)
+	}
+}
+
+func TestCodexForceReplacesOnlyGortexPreToolUseHook(t *testing.T) {
+	env := codexGlobalEnv(t)
+	path := codexConfigPath(env)
+	seed := `[[hooks.PreToolUse]]
+matcher = "^Bash$"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "echo user-pretooluse"
+statusMessage = "User PreToolUse"
+
+[[hooks.PreToolUse]]
+matcher = "^Bash$"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "/tmp/old-gortex hook --agent=codex --mode=enrich"
+statusMessage = "Old Gortex PreToolUse"
+`
+	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	a := New()
+	res, err := a.Apply(env, agents.ApplyOpts{Force: true})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionMerge: 1})
+
+	cfg := readCodexConfig(t, env)
+	preEntries := preToolUseEntries(t, cfg)
+	if len(preEntries) != 2 {
+		t.Fatalf("PreToolUse entries=%d want user+gortex entries: %#v", len(preEntries), preEntries)
+	}
+	if !hasHookCommand(t, cfg, "PreToolUse", "echo user-pretooluse") {
+		t.Fatalf("Force removed user PreToolUse hook: %#v", preEntries)
+	}
+	if hasHookCommand(t, cfg, "PreToolUse", "/tmp/old-gortex hook --agent=codex --mode=enrich") {
+		t.Fatalf("Force kept stale Gortex PreToolUse hook: %#v", preEntries)
+	}
+	if !hasHookCommand(t, cfg, "PreToolUse", "/tmp/test-gortex hook --agent=codex --mode=enrich") {
+		t.Fatalf("Force did not install current Gortex PreToolUse hook: %#v", preEntries)
+	}
+	if count := gortexPreToolUseHookCount(t, cfg); count != 1 {
+		t.Fatalf("Gortex PreToolUse hooks=%d want 1", count)
 	}
 }
 
@@ -224,13 +343,23 @@ func readCodexConfig(t *testing.T, env agents.Env) map[string]any {
 
 func sessionStartEntries(t *testing.T, cfg map[string]any) []any {
 	t.Helper()
+	return hookEntries(t, cfg, "SessionStart")
+}
+
+func preToolUseEntries(t *testing.T, cfg map[string]any) []any {
+	t.Helper()
+	return hookEntries(t, cfg, "PreToolUse")
+}
+
+func hookEntries(t *testing.T, cfg map[string]any, event string) []any {
+	t.Helper()
 	hooks, ok := cfg["hooks"].(map[string]any)
 	if !ok {
 		t.Fatalf("missing hooks map: %#v", cfg)
 	}
-	entries, ok := codexHookList(hooks["SessionStart"])
+	entries, ok := codexHookList(hooks[event])
 	if !ok {
-		t.Fatalf("hooks.SessionStart has unexpected shape: %#v", hooks["SessionStart"])
+		t.Fatalf("hooks.%s has unexpected shape: %#v", event, hooks[event])
 	}
 	return entries
 }
@@ -246,9 +375,25 @@ func gortexSessionStartHookCount(t *testing.T, cfg map[string]any) int {
 	return count
 }
 
+func gortexPreToolUseHookCount(t *testing.T, cfg map[string]any) int {
+	t.Helper()
+	count := 0
+	for _, entry := range preToolUseEntries(t, cfg) {
+		if codexHookEntryIsGortexPreToolUse(entry) {
+			count++
+		}
+	}
+	return count
+}
+
 func hasSessionStartCommand(t *testing.T, cfg map[string]any, command string) bool {
 	t.Helper()
-	for _, entry := range sessionStartEntries(t, cfg) {
+	return hasHookCommand(t, cfg, "SessionStart", command)
+}
+
+func hasHookCommand(t *testing.T, cfg map[string]any, event string, command string) bool {
+	t.Helper()
+	for _, entry := range hookEntries(t, cfg, event) {
 		group, ok := entry.(map[string]any)
 		if !ok {
 			continue

--- a/internal/hooks/codex.go
+++ b/internal/hooks/codex.go
@@ -1,0 +1,32 @@
+package hooks
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+)
+
+// RunCodex handles the Codex hook wire shape. The first Codex hook is a
+// narrow Bash-only PreToolUse nudge; it deliberately forces ModeEnrich so
+// a hand-edited --mode=deny command cannot turn Codex into an enforcing hook.
+func RunCodex(port int) {
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return
+	}
+	runCodex(data, port)
+}
+
+func runCodex(data []byte, port int) {
+	var peek struct {
+		HookEventName string `json:"hook_event_name"`
+		ToolName      string `json:"tool_name"`
+	}
+	if err := json.Unmarshal(data, &peek); err != nil {
+		return
+	}
+	if peek.HookEventName != "PreToolUse" || peek.ToolName != "Bash" {
+		return
+	}
+	runPreToolUse(data, port, ModeEnrich)
+}

--- a/internal/hooks/codex_test.go
+++ b/internal/hooks/codex_test.go
@@ -1,0 +1,60 @@
+package hooks
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunCodexMalformedJSONNoop(t *testing.T) {
+	out := captureStdout(t, func() { runCodex([]byte(`{`), 0) })
+	if out != "" {
+		t.Fatalf("malformed JSON should be silent, got %q", out)
+	}
+}
+
+func TestRunCodexIgnoresNonPreToolUse(t *testing.T) {
+	data := []byte(`{"hook_event_name":"PostToolUse","tool_name":"Bash","tool_input":{"command":"rg Foo"}}`)
+	out := captureStdout(t, func() { runCodex(data, 0) })
+	if out != "" {
+		t.Fatalf("non-PreToolUse event should be silent, got %q", out)
+	}
+}
+
+func TestRunCodexIgnoresNonBash(t *testing.T) {
+	data := []byte(`{"hook_event_name":"PreToolUse","tool_name":"Read","tool_input":{"file_path":"internal/x.go"}}`)
+	out := captureStdout(t, func() { runCodex(data, 0) })
+	if out != "" {
+		t.Fatalf("non-Bash PreToolUse should be silent, got %q", out)
+	}
+}
+
+func TestRunCodexPreToolUseBashSoftAdditionalContext(t *testing.T) {
+	oldProbe := grepProbe
+	grepProbe = func(string, time.Duration) ([]grepSymbolHit, error) {
+		return nil, errDaemonUnreachable
+	}
+	t.Cleanup(func() { grepProbe = oldProbe })
+
+	data := []byte(`{"hook_event_name":"PreToolUse","tool_name":"Bash","session_id":"codex-1","tool_input":{"command":"rg Foo"}}`)
+	out := captureStdout(t, func() {
+		withStdin(t, data, func() { RunCodex(0) })
+	})
+	if out == "" {
+		t.Fatal("expected Codex Bash PreToolUse guidance, got empty output")
+	}
+	dec := decodeHookOutput(t, out)
+	if dec.HookSpecificOutput == nil {
+		t.Fatalf("missing hookSpecificOutput: %s", out)
+	}
+	hso := dec.HookSpecificOutput
+	if hso.HookEventName != "PreToolUse" {
+		t.Fatalf("hookEventName=%q want PreToolUse", hso.HookEventName)
+	}
+	if !strings.Contains(hso.AdditionalContext, "PREFER graph tools over Grep") {
+		t.Fatalf("additionalContext missing graph guidance: %q", hso.AdditionalContext)
+	}
+	if hso.PermissionDecision != "" || hso.PermissionDecisionReason != "" {
+		t.Fatalf("Codex soft nudge must not deny: %#v", hso)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a Codex-specific Bash `PreToolUse` hook that nudges shell search/read commands toward Gortex graph tools in soft enrich mode only.

## Changes

- Install a Codex `PreToolUse` hook for `^Bash$` alongside the existing `SessionStart` hook.
- Route `gortex hook --agent=codex` through a Codex-specific dispatcher.
- Force Codex `PreToolUse` handling through `ModeEnrich`, so it emits `hookSpecificOutput.additionalContext` without denying tool calls.
- Preserve existing user Codex hooks and keep repeated installs idempotent.
- Replace only Gortex-owned Codex hook entries under `--force`.
- Document Codex `SessionStart` plus Bash-only soft `PreToolUse` behavior.

## Design notes
From the Codex hook behavior spike:

- Codex can consume `hookSpecificOutput.additionalContext`, so this uses the existing `HookOutput` JSON shape instead of plain stdout guidance.
- The installed hook command includes `--mode=enrich` for readability, but Codex handling is clamped in code: `RunCodex` always calls `runPreToolUse(..., ModeEnrich)` and does not read the CLI `--mode` flag. This keeps Codex soft-only even if the hook command is hand-edited.
- This PR adds only the portable `command` form for the Codex `PreToolUse` hook. Unlike `SessionStart`, this command just invokes `gortex hook`; it does not rely on POSIX-only shell text like `printf`. A Windows-specific `command_windows` override can be added later if native Windows hook behavior needs it.
- Codex uses a dedicated dispatcher rather than extending `RunExternalAgent`, keeping Gemini / Antigravity lifecycle hook behavior unchanged.

## Testing

- [x] New tests added for new functionality
- [x] Benchmarks run if performance-relevant (not performance-relevant)

Ran:

- `go test ./internal/agents/codex`
- `go test ./internal/hooks`
- `go test ./cmd/gortex`
- `git diff --check`

## Checklist

- [x] Code follows existing patterns in the codebase
- [x] No unnecessary abstractions added
- [ ] Language extractor includes `Meta["methods"]` for interfaces (if applicable)
- [ ] Methods have `EdgeMemberOf` edges to their containing type (if applicable)

Related to https://github.com/zzet/gortex/issues/206