### PR TITLE
fix(analyze): clamp community/synthesizer kinds to the session workspace

### DIFF
--- a/internal/analyzer/synthesizers.go
+++ b/internal/analyzer/synthesizers.go
@@ -53,11 +53,22 @@ type SynthesizersOption func(*synthConfig)
 
 type synthConfig struct {
 	nameFilter string
+	repoScope  map[string]bool
 }
 
 // WithSynthesizerNameFilter restricts the result to a single synthesizer name.
 func WithSynthesizerNameFilter(name string) SynthesizersOption {
 	return func(c *synthConfig) { c.nameFilter = name }
+}
+
+// WithSynthesizerRepoScope restricts the result to synthesized edges
+// whose source node lives in one of the given repository prefixes — the
+// repos of the caller's workspace. A nil/empty set disables the clamp
+// (the whole-index default). Used to keep `analyze synthesizers` inside
+// the session workspace boundary even though it is not repo-narrowed in
+// v1.
+func WithSynthesizerRepoScope(repos map[string]bool) SynthesizersOption {
+	return func(c *synthConfig) { c.repoScope = repos }
 }
 
 // AnalyzeSynthesizers groups every synthesized edge in the graph by the
@@ -79,6 +90,12 @@ func AnalyzeSynthesizers(g graph.Store, opts ...SynthesizersOption) Synthesizers
 			continue
 		}
 		if cfg.nameFilter != "" && by != cfg.nameFilter {
+			continue
+		}
+		// Workspace clamp: drop edges whose source node is outside the
+		// caller's workspace repos so the count, by-kind tally, and
+		// samples never span sibling workspaces.
+		if len(cfg.repoScope) > 0 && !cfg.repoScope[graph.RepoPrefixOfID(e.From)] {
 			continue
 		}
 		row, ok := rows[by]

--- a/internal/analyzer/synthesizers_repo_scope_test.go
+++ b/internal/analyzer/synthesizers_repo_scope_test.go
@@ -1,0 +1,50 @@
+package analyzer_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/analyzer"
+)
+
+// TestAnalyzeSynthesizers_RepoScope verifies WithSynthesizerRepoScope
+// drops synthesized edges whose source node lives outside the given
+// workspace repos — the clamp that keeps `analyze synthesizers` inside
+// the session workspace boundary even though the kind is not
+// repo-narrowed in v1.
+func TestAnalyzeSynthesizers_RepoScope(t *testing.T) {
+	g := newTestGraph()
+	// repo-a is the session workspace; repo-b stands in for a sibling
+	// workspace whose synthesized edges must never surface.
+	addSynthEdge(g, "repo-a/a.go::A", "repo-a/b.go::B", "event-channel", "event.channel")
+	addSynthEdge(g, "repo-a/a.go::A", "repo-a/c.go::C", "event-channel", "event.channel")
+	addSynthEdge(g, "repo-b/x.go::X", "repo-b/y.go::Y", "event-channel", "event.channel")
+	addSynthEdge(g, "repo-b/cli.go::run", "repo-b/svc.go::Handle", "grpc-stub", "grpc.stub")
+
+	// No clamp (and an empty set) is a no-op: every edge counts.
+	if res := analyzer.AnalyzeSynthesizers(g); res.TotalEdges != 4 {
+		t.Fatalf("unclamped: expected TotalEdges=4, got %d", res.TotalEdges)
+	}
+	if res := analyzer.AnalyzeSynthesizers(g, analyzer.WithSynthesizerRepoScope(nil)); res.TotalEdges != 4 {
+		t.Fatalf("nil clamp: expected TotalEdges=4, got %d", res.TotalEdges)
+	}
+
+	// Clamp to repo-a: only the two repo-a edges survive, and the
+	// repo-b-only grpc-stub group disappears entirely.
+	res := analyzer.AnalyzeSynthesizers(g, analyzer.WithSynthesizerRepoScope(map[string]bool{"repo-a": true}))
+	if res.TotalEdges != 2 {
+		t.Fatalf("clamped: expected TotalEdges=2, got %d", res.TotalEdges)
+	}
+	if len(res.Synthesizers) != 1 {
+		t.Fatalf("clamped: expected 1 synthesizer group (event-channel), got %d", len(res.Synthesizers))
+	}
+	row := res.Synthesizers[0]
+	if row.Name != "event-channel" || row.Edges != 2 {
+		t.Fatalf("clamped: expected event-channel with 2 edges, got %q/%d", row.Name, row.Edges)
+	}
+	for _, smp := range row.Samples {
+		if !strings.HasPrefix(smp.From, "repo-a/") {
+			t.Errorf("clamped sample leaked a non-repo-a source: %s", smp.From)
+		}
+	}
+}

--- a/internal/graph/repo_prefix.go
+++ b/internal/graph/repo_prefix.go
@@ -1,0 +1,21 @@
+package graph
+
+import "strings"
+
+// RepoPrefixOfID returns the repository prefix encoded in a node ID or
+// file path — the leading path segment before the first "/". In
+// multi-repo mode every node ID and file path is prefixed with the repo
+// it belongs to (e.g. "gortex/internal/mcp/server.go::NewServer" →
+// "gortex"), so this recovers the owning repo without a node lookup.
+//
+// Returns "" for IDs that carry no repo prefix: unresolved sentinels
+// like "unresolved::Name", and single-repo-mode IDs that were never
+// prefixed. Callers use it only inside a workspace-bound (multi-repo)
+// path, where every real node is prefixed, so an empty result simply
+// never matches a workspace's repo set.
+func RepoPrefixOfID(id string) string {
+	if i := strings.IndexByte(id, '/'); i > 0 {
+		return id[:i]
+	}
+	return ""
+}

--- a/internal/mcp/analyze_community_scope_test.go
+++ b/internal/mcp/analyze_community_scope_test.go
@@ -1,0 +1,50 @@
+package mcp
+
+// Tests for the workspace clamp on the community / synthesizer analyze
+// kinds. These kinds run a global graph algorithm over the whole index
+// (one shared partition / one edge sweep), so without a clamp a
+// workspace-bound caller would see results whose members live in a
+// sibling workspace — a breach of the hard workspace isolation boundary.
+// The "repo-a" / "repo-b" substring probe mirrors analyze_scope_test.go:
+// multi-repo node IDs and file paths are repo-prefixed, so a result
+// scoped to ws-a must never contain the string "repo-b".
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAnalyzeScope_Clusters_WorkspaceClamp(t *testing.T) {
+	// repo-a and repo-b sit in SEPARATE workspaces, so a session bound to
+	// one must never surface the other's community.
+	srv, paths := newAnalyzeServer(t, true,
+		analyzeRepoSpec{name: "repo-a", workspace: "ws-a", body: structuralBody("a")},
+		analyzeRepoSpec{name: "repo-b", workspace: "ws-b", body: structuralBody("b")},
+	)
+
+	// Bound to repo-a (workspace ws-a): must show repo-a, never leak
+	// repo-b's sibling-workspace community.
+	ctxA := sessionCtx("s-a", paths["repo-a"])
+	textA, applied, _ := runAnalyze(t, srv, ctxA, map[string]any{"kind": "clusters"})
+	assert.Contains(t, textA, "repo-a", "clusters in ws-a must include repo-a's own community")
+	assert.NotContains(t, textA, "repo-b", "clusters in ws-a must not leak repo-b (sibling workspace)")
+	assert.Equal(t, "workspace", applied)
+	// The applied scope is disclosed in the response BODY, not just _meta
+	// (which clients such as Claude Code do not surface).
+	assert.Contains(t, textA, "workspace:ws-a", "clusters must disclose the applied workspace scope in the body")
+
+	// Bound to repo-b: the global partition genuinely contains repo-b's
+	// community (so the probe above is not vacuous), and repo-a must not
+	// leak the other way.
+	ctxB := sessionCtx("s-b", paths["repo-b"])
+	textB, _, _ := runAnalyze(t, srv, ctxB, map[string]any{"kind": "clusters"})
+	assert.Contains(t, textB, "repo-b", "clusters in ws-b must include repo-b's own community")
+	assert.NotContains(t, textB, "repo-a", "clusters in ws-b must not leak repo-a (sibling workspace)")
+
+	// A repo narrowing arg on a kind that is workspace-bound but not
+	// repo-narrowed in v1 self-discloses the widening in the body.
+	textNote, _, _ := runAnalyze(t, srv, ctxA, map[string]any{"kind": "clusters", "repo": "repo-a"})
+	assert.Contains(t, textNote, "not repo/project-narrowed",
+		"a narrowing arg on clusters must self-disclose the v1 no-op in the body")
+}

--- a/internal/mcp/analyze_kinds.go
+++ b/internal/mcp/analyze_kinds.go
@@ -188,6 +188,20 @@ var analyzeScopeAwareKinds = map[string]bool{
 	"unsafe_patterns": true,
 }
 
+// analyzeWorkspaceClampedKinds are the not-repo-narrowed analyze kinds
+// (community detection + synthesizer enumeration) that now clamp their
+// rows to the session workspace and self-disclose that via a body-
+// visible `scope` block (workspaceScopeBlock). They are excluded from
+// the _meta stampScopeNote path, whose text predates the clamp and would
+// otherwise wrongly claim the result "may span the entire index / all
+// workspaces".
+var analyzeWorkspaceClampedKinds = map[string]bool{
+	"clusters":           true,
+	"concepts":           true,
+	"suggest_boundaries": true,
+	"synthesizers":       true,
+}
+
 // AnalyzeKinds returns a defensive copy of the canonical analyze-kind
 // set, in sorted order. Callers must not mutate the returned slice's
 // backing array of the package-level source.

--- a/internal/mcp/analyze_scope_test.go
+++ b/internal/mcp/analyze_scope_test.go
@@ -306,17 +306,23 @@ func TestAnalyzeScope_ScopeNote_BypassKind(t *testing.T) {
 	// Membership gate is the source of truth.
 	require.True(t, analyzeScopeAwareKinds["health_score"], "health_score must be scope-aware")
 	require.False(t, analyzeScopeAwareKinds["clusters"], "clusters must NOT be scope-aware (community-detection bypass)")
+	require.True(t, analyzeWorkspaceClampedKinds["clusters"], "clusters is workspace-clamped and self-discloses in the body")
 
 	fx := newSharedWorkspaceServer(t, true)
 	ctx := sessionCtx("s-a", fx.repoA)
 
-	// Bypass kind + narrowing arg → scope_note discloses the no-op.
+	// clusters is workspace-clamped but not repo-narrowed: a narrowing
+	// arg is disclosed in the response BODY (visible to every client),
+	// not via the now-stale _meta scope_note. scope_applied stays uniform
+	// and truthful about the resolved scope.
 	r, err := fx.srv.handleAnalyze(ctx, makeReq("analyze", map[string]any{"kind": "clusters", "repo": "repo-a"}))
 	require.NoError(t, err)
-	require.False(t, r.IsError, "pubsub errored: %s", toolResultText(r))
+	require.False(t, r.IsError, "clusters errored: %s", toolResultText(r))
 	require.NotNil(t, r.Meta)
-	note, _ := r.Meta.AdditionalFields["scope_note"].(string)
-	assert.NotEmpty(t, note, "a bypass kind asked to narrow must carry a scope_note")
+	assert.Contains(t, toolResultText(r), "not repo/project-narrowed",
+		"a workspace-clamped bypass kind asked to narrow must disclose the no-op in the body")
+	_, hasMetaNote := r.Meta.AdditionalFields["scope_note"]
+	assert.False(t, hasMetaNote, "a self-disclosing clamped kind must not also carry the stale _meta scope_note")
 	assert.Equal(t, "repo:repo-a", r.Meta.AdditionalFields["scope_applied"],
 		"scope_applied stays uniform/truthful about the resolved scope")
 

--- a/internal/mcp/scope_resolve.go
+++ b/internal/mcp/scope_resolve.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 
+	"github.com/zzet/gortex/internal/analysis"
+	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/query"
 )
 
@@ -338,4 +340,93 @@ func intersectRepoSets(a, b map[string]bool) map[string]bool {
 		}
 	}
 	return out
+}
+
+// sessionWorkspaceRepoSet returns the set of repo prefixes inside the
+// current session's workspace and whether the session is workspace-
+// bound. An unbound session (no cwd / no multi-repo indexer) returns
+// (nil, false) — its callers must not clamp. This is the workspace
+// ceiling for the analyze kinds that run a global graph algorithm and
+// cannot honour the repo allow-set in v1.
+func (s *Server) sessionWorkspaceRepoSet(ctx context.Context) (map[string]bool, bool) {
+	sessWS, _, bound := s.sessionScope(ctx)
+	if !bound || s.multiIndexer == nil {
+		return nil, false
+	}
+	return s.multiIndexer.ReposInWorkspace(sessWS), true
+}
+
+// communitiesInSessionScope returns a workspace-clamped copy of cr for a
+// workspace-bound session: each community keeps only the members / files
+// inside the session workspace, and communities left with no in-workspace
+// member are dropped. Community detection runs over the whole index (one
+// shared partition), so without this the community analyze kinds
+// (clusters / concepts / suggest_boundaries) would surface clusters from
+// sibling workspaces — a breach of the workspace isolation boundary. The
+// cached partition is never mutated: the copy gets fresh member / file
+// slices. An unbound session gets cr back unchanged.
+func (s *Server) communitiesInSessionScope(ctx context.Context, cr *analysis.CommunityResult) *analysis.CommunityResult {
+	wsRepos, bound := s.sessionWorkspaceRepoSet(ctx)
+	if !bound || len(wsRepos) == 0 || cr == nil {
+		return cr
+	}
+	out := *cr
+	out.Communities = make([]analysis.Community, 0, len(cr.Communities))
+	for _, c := range cr.Communities {
+		members := make([]string, 0, len(c.Members))
+		for _, m := range c.Members {
+			if wsRepos[graph.RepoPrefixOfID(m)] {
+				members = append(members, m)
+			}
+		}
+		if len(members) == 0 {
+			continue
+		}
+		files := make([]string, 0, len(c.Files))
+		for _, f := range c.Files {
+			if wsRepos[graph.RepoPrefixOfID(f)] {
+				files = append(files, f)
+			}
+		}
+		c.Members = members
+		c.Files = files
+		c.Size = len(members)
+		out.Communities = append(out.Communities, c)
+	}
+	return &out
+}
+
+// scopeNarrowingRequested reports whether the caller passed an explicit
+// repo / project / scope / ref narrowing arg (other than the "*"
+// all-repos escape hatch).
+func scopeNarrowingRequested(req mcp.CallToolRequest) bool {
+	if repo := strings.TrimSpace(req.GetString("repo", "")); repo != "" && repo != "*" {
+		return true
+	}
+	return strings.TrimSpace(req.GetString("project", "")) != "" ||
+		strings.TrimSpace(req.GetString("scope", "")) != "" ||
+		strings.TrimSpace(req.GetString("ref", "")) != ""
+}
+
+// workspaceScopeBlock returns a body-visible disclosure of the scope a
+// not-repo-narrowed analyze kind actually applied: it honours the session
+// workspace boundary but cannot apply a repo / project narrow in v1.
+// Unlike the _meta scope_note (which several clients, Claude Code among
+// them, do not surface), this rides in the response payload so an agent
+// always sees it. Returns nil for an unbound session — nothing to
+// disclose, and the result was never clamped.
+func (s *Server) workspaceScopeBlock(ctx context.Context, req mcp.CallToolRequest, kind string) map[string]any {
+	sessWS, _, bound := s.sessionScope(ctx)
+	if !bound {
+		return nil
+	}
+	applied := "workspace"
+	if sessWS != "" {
+		applied = "workspace:" + sessWS
+	}
+	blk := map[string]any{"applied": applied}
+	if scopeNarrowingRequested(req) {
+		blk["note"] = "kind '" + kind + "' is clamped to the session workspace but is not repo/project-narrowed in v1; the requested narrowing was widened to the whole workspace"
+	}
+	return blk
 }

--- a/internal/mcp/tools_analyze_clusters.go
+++ b/internal/mcp/tools_analyze_clusters.go
@@ -70,13 +70,22 @@ func (s *Server) handleAnalyzeClusters(ctx context.Context, req mcp.CallToolRequ
 			" (expected: leiden, louvain, spectral)"), nil
 	}
 
+	// Clamp the global partition to the session workspace so a
+	// workspace-bound caller never sees clusters whose members live in a
+	// sibling workspace (community detection runs over the whole index).
+	cr = s.communitiesInSessionScope(ctx, cr)
+
 	if cr == nil || len(cr.Communities) == 0 {
-		return s.respondJSONOrTOON(ctx, req, map[string]any{
+		empty := map[string]any{
 			"clusters":  []map[string]any{},
 			"total":     0,
 			"algorithm": algorithm,
-			"note":      "no communities detected on this graph",
-		})
+			"note":      "no communities detected in the session workspace",
+		}
+		if blk := s.workspaceScopeBlock(ctx, req, "clusters"); blk != nil {
+			empty["scope"] = blk
+		}
+		return s.respondJSONOrTOON(ctx, req, empty)
 	}
 
 	type clusterRow struct {
@@ -248,6 +257,9 @@ func (s *Server) handleAnalyzeClusters(ctx context.Context, req mcp.CallToolRequ
 		detection["resolution"] = resolution
 		resp["detection"] = detection
 	}
+	if blk := s.workspaceScopeBlock(ctx, req, "clusters"); blk != nil {
+		resp["scope"] = blk
+	}
 	return s.respondJSONOrTOON(ctx, req, resp)
 }
 
@@ -262,6 +274,8 @@ func (s *Server) handleAnalyzeConcepts(ctx context.Context, req mcp.CallToolRequ
 	useLLM := requestBoolDefault(req, "use_llm", s.llmService != nil && s.llmService.Enabled())
 
 	cr := s.getCommunities()
+	// Clamp to the session workspace (community detection is global).
+	cr = s.communitiesInSessionScope(ctx, cr)
 	if cr == nil || len(cr.Communities) == 0 {
 		return s.respondJSONOrTOON(ctx, req, map[string]any{
 			"concepts": []map[string]any{},
@@ -299,10 +313,14 @@ func (s *Server) handleAnalyzeConcepts(ctx context.Context, req mcp.CallToolRequ
 		})
 	}
 
-	return s.respondJSONOrTOON(ctx, req, map[string]any{
+	resp := map[string]any{
 		"concepts": out,
 		"total":    len(out),
-	})
+	}
+	if blk := s.workspaceScopeBlock(ctx, req, "concepts"); blk != nil {
+		resp["scope"] = blk
+	}
+	return s.respondJSONOrTOON(ctx, req, resp)
 }
 
 // labelConcept returns a theme label for the cluster + the source

--- a/internal/mcp/tools_analyze_synthesizers.go
+++ b/internal/mcp/tools_analyze_synthesizers.go
@@ -31,6 +31,12 @@ func (s *Server) handleAnalyzeSynthesizers(ctx context.Context, req mcp.CallTool
 	if nameFilter != "" {
 		opts = append(opts, analyzer.WithSynthesizerNameFilter(nameFilter))
 	}
+	// Clamp to the session workspace (synthesizer edge enumeration is
+	// global) so a workspace-bound caller never sees edges from sibling
+	// workspaces.
+	if wsRepos, bound := s.sessionWorkspaceRepoSet(ctx); bound {
+		opts = append(opts, analyzer.WithSynthesizerRepoScope(wsRepos))
+	}
 	result := analyzer.AnalyzeSynthesizers(s.graph, opts...)
 
 	if isCompact(req) {
@@ -49,8 +55,12 @@ func (s *Server) handleAnalyzeSynthesizers(ctx context.Context, req mcp.CallTool
 		return mcp.NewToolResultText(b.String()), nil
 	}
 
-	return s.respondJSONOrTOON(ctx, req, map[string]any{
+	resp := map[string]any{
 		"synthesizers": result.Synthesizers,
 		"total_edges":  result.TotalEdges,
-	})
+	}
+	if blk := s.workspaceScopeBlock(ctx, req, "synthesizers"); blk != nil {
+		resp["scope"] = blk
+	}
+	return s.respondJSONOrTOON(ctx, req, resp)
 }

--- a/internal/mcp/tools_enhancements.go
+++ b/internal/mcp/tools_enhancements.go
@@ -963,7 +963,8 @@ func (s *Server) handleAnalyze(ctx context.Context, req mcp.CallToolRequest) (*m
 	// truthful about the resolved scope; scope_note prevents it from
 	// misleading a caller whose kind ignored the narrowing ("no silent
 	// no-ops").
-	if err == nil && res != nil && resolved.RepoAllow != nil && !analyzeScopeAwareKinds[kind] {
+	if err == nil && res != nil && resolved.RepoAllow != nil &&
+		!analyzeScopeAwareKinds[kind] && !analyzeWorkspaceClampedKinds[kind] {
 		stampScopeNote(res, kind)
 	}
 	return withScopeResult(res, err, resolved)

--- a/internal/mcp/tools_suggest_boundaries.go
+++ b/internal/mcp/tools_suggest_boundaries.go
@@ -27,6 +27,10 @@ type suggestedLayer struct {
 
 func (s *Server) handleSuggestBoundaries(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	comms := s.getCommunities()
+	// Clamp to the session workspace (community detection is global) so
+	// boundaries are seeded only from in-workspace communities and never
+	// leak a sibling workspace's layers.
+	comms = s.communitiesInSessionScope(ctx, comms)
 	if comms == nil || len(comms.Communities) == 0 {
 		return mcp.NewToolResultError("no communities detected — run `analyze kind=clusters` (or reindex) first so boundaries can be seeded"), nil
 	}
@@ -111,13 +115,17 @@ func (s *Server) handleSuggestBoundaries(ctx context.Context, req mcp.CallToolRe
 		})
 	}
 
-	return s.respondJSONOrTOON(ctx, req, map[string]any{
+	resp := map[string]any{
 		"suggested_layers": layers,
 		"yaml":             renderArchitectureYAML(layers),
 		"community_count":  len(comms.Communities),
 		"modularity":       comms.Modularity,
 		"note":             "Starter architecture block seeded from detected communities. Review the layer names and allow lists, then paste into .gortex.yaml; change_contract's architecture family enforces it (set architecture.severity: error to make breaks refuse).",
-	})
+	}
+	if blk := s.workspaceScopeBlock(ctx, req, "suggest_boundaries"); blk != nil {
+		resp["scope"] = blk
+	}
+	return s.respondJSONOrTOON(ctx, req, resp)
 }
 
 // commonDirPrefix returns the longest shared leading directory segments across


### PR DESCRIPTION
## Summary

Follow-up to the intent-based scoping in #202. While validating that change, the community / synthesizer `analyze` kinds were found to **cross the workspace isolation boundary**: in a multi-repo workspace, `analyze kind=clusters` (and `synthesizers`) returned members / edges from repos in *other* workspaces. The kinds are documented as "workspace-bound but not repo-narrowed in v1", but the implementation applied no workspace filter at all.

Concretely, from a session bound to the `gortex` workspace, `analyze kind=clusters repo:gortex` returned cluster members living in `vioportals/` and `rate_checkers_detector/` — repos that an explicit `repo:` arg is otherwise hard-rejected for as cross-workspace.

## Root cause

- `handleAnalyzeClusters` / `handleAnalyzeConcepts` / `handleSuggestBoundaries` run community detection over the whole `s.graph` and filtered results only by `min_size` / `path_prefix`.
- `handleAnalyzeSynthesizers` swept `g.AllEdges()` with no workspace filter.
- The only disclosure (`scope_note`) rode in MCP `_meta`, which several clients (Claude Code among them) do not surface — so the leak was silent to an agent.

## Change

- **Workspace clamp.** New `graph.RepoPrefixOfID` + `Server.communitiesInSessionScope` return a workspace-filtered *copy* of the cached community partition (the shared cache is never mutated); applied to clusters / concepts / suggest_boundaries. `AnalyzeSynthesizers` gains `WithSynthesizerRepoScope`, which drops edges whose source is outside the workspace and re-tallies counts / by-kind / samples.
- **Visible disclosure.** A `scope` block now rides in the response **body** (`{applied, note}`) instead of the invisible `_meta` note, so an agent sees the applied workspace and — when a narrowing arg is passed — that the kind is workspace-bound but not repo/project-narrowed in v1.
- The now-stale `_meta` `scope_note` is suppressed for these self-disclosing kinds so the two signals don't contradict.

Single-repo / unbound sessions are unaffected (no clamp, no scope block).

## Testing

- New `TestAnalyzeSynthesizers_RepoScope` (analyzer) and `TestAnalyzeScope_Clusters_WorkspaceClamp` (mcp, bidirectional non-vacuous cross-workspace probe + body-disclosure assertion).
- Updated `TestAnalyzeScope_ScopeNote_BypassKind` to the new body-disclosure behavior.
- `go build ./...`, `go vet`, `go test ./internal/analyzer/ ./internal/graph/ ./internal/mcp/` all pass, including `-race` on the touched packages.
