### PR TITLE
feat(codex): add Bash PostToolUse graph guidance

### DIFF
--- a/cmd/gortex/hook.go
+++ b/cmd/gortex/hook.go
@@ -36,8 +36,8 @@ var hookCmd = &cobra.Command{
 			return
 		case "codex":
 			// Codex support is intentionally soft-only for now: the adapter
-			// installs a Bash PreToolUse hook that emits additionalContext
-			// without ever denying the tool call.
+			// installs Bash PreToolUse/PostToolUse hooks that emit
+			// additionalContext without ever denying the tool call.
 			hooks.RunCodex(hookPort)
 			return
 		case "", "claude":
@@ -55,6 +55,6 @@ func init() {
 	hookCmd.Flags().StringVar(&hookMode, "mode", "deny",
 		"hook posture: 'deny' (redirect Grep/Glob/Read of indexed source), 'enrich' (never deny; PostToolUse appends graph context), 'consult-unlock' (deny fallback reads until the graph is queried once this session), or 'nudge' (soft-deny once per burst of non-symbolic calls)")
 	hookCmd.Flags().StringVar(&hookAgent, "agent", "",
-		"hook wire protocol: empty/'claude' (Claude Code PreToolUse/UserPromptSubmit), 'codex' (Codex Bash PreToolUse soft nudge), 'hermes' (NousResearch hermes-agent pre_tool_call/pre_llm_call), 'pi' (earendil-works/pi extension bridge — normalized PiEvent envelope in, PiDecision out), or 'gemini'/'antigravity' (emits hookSpecificOutput.additionalContext). Default (empty) is the Claude Code format.")
+		"hook wire protocol: empty/'claude' (Claude Code PreToolUse/UserPromptSubmit), 'codex' (Codex Bash PreToolUse/PostToolUse soft context), 'hermes' (NousResearch hermes-agent pre_tool_call/pre_llm_call), 'pi' (earendil-works/pi extension bridge — normalized PiEvent envelope in, PiDecision out), or 'gemini'/'antigravity' (emits hookSpecificOutput.additionalContext). Default (empty) is the Claude Code format.")
 	rootCmd.AddCommand(hookCmd)
 }

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -24,7 +24,7 @@ commands accept `--agents=<csv>` to constrain setup and
 | `aider`         | `.aiderignore` block, `CONVENTIONS.md` communities block                                        | project    | https://aider.chat/docs/config/aider_conf.html                      |
 | `antigravity`   | `~/.gemini/antigravity/mcp_config.json` + Knowledge Item                                        | user       | https://antigravity.google/docs/mcp                                 |
 | `cline`         | `cline_mcp_settings.json` (per VS Code / Cursor globalStorage), `.clinerules/gortex-communities.md` | both     | https://docs.cline.bot/mcp/mcp-overview                             |
-| `codex`         | `~/.codex/config.toml` (`[mcp_servers.gortex]` + `SessionStart` / Bash `PreToolUse` hooks), `AGENTS.md` communities block | both       | https://developers.openai.com/codex/mcp                             |
+| `codex`         | `~/.codex/config.toml` (`[mcp_servers.gortex]` + `SessionStart` / Bash `PreToolUse` / Bash `PostToolUse` hooks), `AGENTS.md` communities block | both       | https://developers.openai.com/codex/mcp                             |
 | `continue`      | `.continue/mcpServers/gortex.json`, `.continue/rules/gortex-communities.md`                     | project    | https://docs.continue.dev/customize/deep-dives/mcp                  |
 | `cursor`        | `.cursor/mcp.json` (project) or `~/.cursor/mcp.json`, `.cursor/rules/gortex-communities.mdc`    | both       | https://docs.cursor.com/en/context/mcp                              |
 | `gemini`        | `.gemini/settings.json` or `~/.gemini/settings.json`, `GEMINI.md` communities block             | both       | https://geminicli.com/docs/tools/mcp-server/                        |
@@ -201,9 +201,11 @@ upsert a `[mcp_servers.gortex]` table there. When hooks are enabled
 orientation so new, resumed, cleared, and compacted Codex sessions see
 the same nudge. Codex also gets a Bash-only `PreToolUse` hook in
 soft-enrich mode: it can add `hookSpecificOutput.additionalContext`
-when a shell search/read shape should prefer Gortex graph tools, but it
-does not deny, rewrite input, handle `apply_patch`, or install
-`PostToolUse`.
+when a shell search/read shape should prefer Gortex graph tools. A
+Bash-only `PostToolUse` hook adds graph context for grep/rg/ag-style
+search output by reusing the existing post-tool enrichment path. Codex
+hooks do not deny, rewrite input, suppress output, or handle
+`apply_patch`.
 
 ### continue
 

--- a/internal/agents/codex/adapter.go
+++ b/internal/agents/codex/adapter.go
@@ -31,6 +31,7 @@ const codexSessionStartMessage = "IMPORTANT: Prefer Gortex MCP tools (search_sym
 const codexSessionStartCommand = "printf '%s\\n' '" + codexSessionStartMessage + "'"
 const codexSessionStartWindowsCommand = "powershell -NoProfile -Command \"Write-Output '" + codexSessionStartMessage + "'\""
 const codexPreToolUseMatcher = "^Bash$"
+const codexPostToolUseMatcher = "^Bash$"
 const codexHookTimeoutSeconds = 5
 
 type Adapter struct{}
@@ -114,6 +115,9 @@ func (a *Adapter) Apply(env agents.Env, opts agents.ApplyOpts) (*agents.Result, 
 			if upsertPreToolUseHook(root, env, opts) {
 				changed = true
 			}
+			if upsertPostToolUseHook(root, env, opts) {
+				changed = true
+			}
 		}
 		return changed, nil
 	}, opts)
@@ -146,6 +150,10 @@ func upsertSessionStartHook(root map[string]any, opts agents.ApplyOpts) bool {
 
 func upsertPreToolUseHook(root map[string]any, env agents.Env, opts agents.ApplyOpts) bool {
 	return upsertCodexHook(root, "PreToolUse", codexHookEntryIsGortexPreToolUse, codexPreToolUseHookEntry(env), opts)
+}
+
+func upsertPostToolUseHook(root map[string]any, env agents.Env, opts agents.ApplyOpts) bool {
+	return upsertCodexHook(root, "PostToolUse", codexHookEntryIsGortexPostToolUse, codexPostToolUseHookEntry(env), opts)
 }
 
 func upsertCodexHook(root map[string]any, event string, isGortex func(any) bool, desired map[string]any, opts agents.ApplyOpts) bool {
@@ -225,6 +233,14 @@ func codexHookEntryIsGortexSessionStart(entry any) bool {
 }
 
 func codexHookEntryIsGortexPreToolUse(entry any) bool {
+	return codexHookEntryInvokesCodexHook(entry)
+}
+
+func codexHookEntryIsGortexPostToolUse(entry any) bool {
+	return codexHookEntryInvokesCodexHook(entry)
+}
+
+func codexHookEntryInvokesCodexHook(entry any) bool {
 	group, ok := entry.(map[string]any)
 	if !ok {
 		return false
@@ -286,7 +302,25 @@ func codexPreToolUseHookEntry(env agents.Env) map[string]any {
 	}
 }
 
+func codexPostToolUseHookEntry(env agents.Env) map[string]any {
+	return map[string]any{
+		"matcher": codexPostToolUseMatcher,
+		"hooks": []any{
+			map[string]any{
+				"type":          "command",
+				"command":       codexHookCommand(env),
+				"timeout":       codexHookTimeoutSeconds,
+				"statusMessage": "Loading Gortex Bash output context...",
+			},
+		},
+	}
+}
+
 func codexPreToolUseCommand(env agents.Env) string {
+	return codexHookCommand(env)
+}
+
+func codexHookCommand(env agents.Env) string {
 	base := strings.TrimSpace(env.HookCommand)
 	if base == "" {
 		base = "gortex hook"

--- a/internal/agents/codex/adapter_test.go
+++ b/internal/agents/codex/adapter_test.go
@@ -50,6 +50,9 @@ func TestCodexWritesMcpServersTOMLTable(t *testing.T) {
 	if count := gortexPreToolUseHookCount(t, cfg); count != 1 {
 		t.Fatalf("expected one Gortex PreToolUse hook, got %d: %#v", count, cfg["hooks"])
 	}
+	if count := gortexPostToolUseHookCount(t, cfg); count != 1 {
+		t.Fatalf("expected one Gortex PostToolUse hook, got %d: %#v", count, cfg["hooks"])
+	}
 
 	agentstest.AssertIdempotent(t, a, env)
 }
@@ -133,8 +136,41 @@ func TestCodexInstallsPreToolUseHook(t *testing.T) {
 	if handler["timeout"] != int64(codexHookTimeoutSeconds) {
 		t.Errorf("timeout=%v want %d", handler["timeout"], codexHookTimeoutSeconds)
 	}
-	if _, ok := cfg["hooks"].(map[string]any)["PostToolUse"]; ok {
-		t.Fatalf("Codex should not install PostToolUse: %#v", cfg["hooks"])
+}
+
+func TestCodexInstallsPostToolUseHook(t *testing.T) {
+	env := codexGlobalEnv(t)
+	a := New()
+
+	res, err := a.Apply(env, agents.ApplyOpts{})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionCreate: 1})
+
+	cfg := readCodexConfig(t, env)
+	entries := postToolUseEntries(t, cfg)
+	if len(entries) != 1 {
+		t.Fatalf("PostToolUse entries=%d want 1: %#v", len(entries), entries)
+	}
+	entry := entries[0].(map[string]any)
+	if entry["matcher"] != codexPostToolUseMatcher {
+		t.Fatalf("matcher=%v want %q", entry["matcher"], codexPostToolUseMatcher)
+	}
+	handlers, ok := codexHookList(entry["hooks"])
+	if !ok || len(handlers) != 1 {
+		t.Fatalf("handlers=%#v", entry["hooks"])
+	}
+	handler := handlers[0].(map[string]any)
+	if handler["type"] != "command" {
+		t.Errorf("hook type=%v want command", handler["type"])
+	}
+	command := handler["command"].(string)
+	if command != "/tmp/test-gortex hook --agent=codex --mode=enrich" {
+		t.Errorf("command=%v want test hook command with --agent=codex --mode=enrich", command)
+	}
+	if handler["timeout"] != int64(codexHookTimeoutSeconds) {
+		t.Errorf("timeout=%v want %d", handler["timeout"], codexHookTimeoutSeconds)
 	}
 }
 
@@ -165,6 +201,9 @@ func TestCodexSessionStartHookIdempotent(t *testing.T) {
 	if count := gortexPreToolUseHookCount(t, cfg); count != 1 {
 		t.Fatalf("re-run duplicated Gortex PreToolUse hook: got %d", count)
 	}
+	if count := gortexPostToolUseHookCount(t, cfg); count != 1 {
+		t.Fatalf("re-run duplicated Gortex PostToolUse hook: got %d", count)
+	}
 }
 
 func TestCodexSessionStartHookPreservesExistingConfig(t *testing.T) {
@@ -190,6 +229,14 @@ matcher = "^Bash$"
 type = "command"
 command = "echo user-pretooluse"
 statusMessage = "User PreToolUse"
+
+[[hooks.PostToolUse]]
+matcher = "^Bash$"
+
+[[hooks.PostToolUse.hooks]]
+type = "command"
+command = "echo user-posttooluse"
+statusMessage = "User PostToolUse"
 `
 	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
 		t.Fatalf("seed config: %v", err)
@@ -232,6 +279,16 @@ statusMessage = "User PreToolUse"
 	}
 	if count := gortexPreToolUseHookCount(t, cfg); count != 1 {
 		t.Fatalf("Gortex PreToolUse hooks=%d want 1", count)
+	}
+	postEntries := postToolUseEntries(t, cfg)
+	if len(postEntries) != 2 {
+		t.Fatalf("PostToolUse entries=%d want user+gortex entries: %#v", len(postEntries), postEntries)
+	}
+	if !hasHookCommand(t, cfg, "PostToolUse", "echo user-posttooluse") {
+		t.Fatalf("user PostToolUse hook was not preserved: %#v", postEntries)
+	}
+	if count := gortexPostToolUseHookCount(t, cfg); count != 1 {
+		t.Fatalf("Gortex PostToolUse hooks=%d want 1", count)
 	}
 }
 
@@ -351,6 +408,11 @@ func preToolUseEntries(t *testing.T, cfg map[string]any) []any {
 	return hookEntries(t, cfg, "PreToolUse")
 }
 
+func postToolUseEntries(t *testing.T, cfg map[string]any) []any {
+	t.Helper()
+	return hookEntries(t, cfg, "PostToolUse")
+}
+
 func hookEntries(t *testing.T, cfg map[string]any, event string) []any {
 	t.Helper()
 	hooks, ok := cfg["hooks"].(map[string]any)
@@ -380,6 +442,17 @@ func gortexPreToolUseHookCount(t *testing.T, cfg map[string]any) int {
 	count := 0
 	for _, entry := range preToolUseEntries(t, cfg) {
 		if codexHookEntryIsGortexPreToolUse(entry) {
+			count++
+		}
+	}
+	return count
+}
+
+func gortexPostToolUseHookCount(t *testing.T, cfg map[string]any) int {
+	t.Helper()
+	count := 0
+	for _, entry := range postToolUseEntries(t, cfg) {
+		if codexHookEntryIsGortexPostToolUse(entry) {
 			count++
 		}
 	}

--- a/internal/hooks/codex.go
+++ b/internal/hooks/codex.go
@@ -6,9 +6,9 @@ import (
 	"os"
 )
 
-// RunCodex handles the Codex hook wire shape. The first Codex hook is a
-// narrow Bash-only PreToolUse nudge; it deliberately forces ModeEnrich so
-// a hand-edited --mode=deny command cannot turn Codex into an enforcing hook.
+// RunCodex handles the Codex hook wire shape. Codex support is deliberately
+// soft-only: PreToolUse is forced through ModeEnrich, and PostToolUse only
+// emits additionalContext.
 func RunCodex(port int) {
 	data, err := io.ReadAll(os.Stdin)
 	if err != nil {
@@ -25,8 +25,36 @@ func runCodex(data []byte, port int) {
 	if err := json.Unmarshal(data, &peek); err != nil {
 		return
 	}
-	if peek.HookEventName != "PreToolUse" || peek.ToolName != "Bash" {
+
+	switch {
+	case peek.HookEventName == "PreToolUse" && peek.ToolName == "Bash":
+		runPreToolUse(data, port, ModeEnrich)
+	case peek.HookEventName == "PostToolUse" && peek.ToolName == "Bash":
+		runCodexPostToolUse(data, port)
+	}
+}
+
+func runCodexPostToolUse(data []byte, port int) {
+	var input postHookInput
+	if err := json.Unmarshal(data, &input); err != nil {
 		return
 	}
-	runPreToolUse(data, port, ModeEnrich)
+	if input.HookEventName != "PostToolUse" || input.ToolName != "Bash" {
+		return
+	}
+
+	cmd, _ := input.ToolInput["command"].(string)
+	if classifyBashCommand(cmd).Action != BashActionGrepLike {
+		return
+	}
+
+	// Codex wraps grep/rg/ag in Bash. Re-label that narrow shape as Grep so
+	// the existing PostToolUse enrichment can parse path:line output and do
+	// the graph lookup without changing Claude Code behavior.
+	input.ToolName = "Grep"
+	normalized, err := json.Marshal(input)
+	if err != nil {
+		return
+	}
+	runPostToolUse(normalized, port)
 }

--- a/internal/hooks/codex_test.go
+++ b/internal/hooks/codex_test.go
@@ -1,6 +1,7 @@
 package hooks
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -13,11 +14,11 @@ func TestRunCodexMalformedJSONNoop(t *testing.T) {
 	}
 }
 
-func TestRunCodexIgnoresNonPreToolUse(t *testing.T) {
+func TestRunCodexPostToolUseWithoutParseableOutputSilent(t *testing.T) {
 	data := []byte(`{"hook_event_name":"PostToolUse","tool_name":"Bash","tool_input":{"command":"rg Foo"}}`)
 	out := captureStdout(t, func() { runCodex(data, 0) })
 	if out != "" {
-		t.Fatalf("non-PreToolUse event should be silent, got %q", out)
+		t.Fatalf("PostToolUse without parseable output should be silent, got %q", out)
 	}
 }
 
@@ -57,4 +58,112 @@ func TestRunCodexPreToolUseBashSoftAdditionalContext(t *testing.T) {
 	if hso.PermissionDecision != "" || hso.PermissionDecisionReason != "" {
 		t.Fatalf("Codex soft nudge must not deny: %#v", hso)
 	}
+}
+
+func TestRunCodexPostToolUseBashGrepOutputAdditionalContext(t *testing.T) {
+	port := stubBridge(t, nil,
+		map[string]struct{ ID, Name, Kind string }{
+			"internal/a.go:7": {ID: "internal/a.go::MyType", Name: "MyType", Kind: "type"},
+		}, nil)
+
+	data := codexPostBashPayload("rg -n MyType", "internal/a.go:7:type MyType struct{}\n")
+	out := captureStdout(t, func() { runCodex(data, port) })
+	if out == "" {
+		t.Fatal("expected Codex Bash PostToolUse graph context, got empty output")
+	}
+	hso := decodeHookOutput(t, out).HookSpecificOutput
+	if hso == nil {
+		t.Fatalf("missing hookSpecificOutput: %s", out)
+	}
+	if hso.HookEventName != "PostToolUse" {
+		t.Fatalf("hookEventName=%q want PostToolUse", hso.HookEventName)
+	}
+	if !strings.Contains(hso.AdditionalContext, "type MyType") {
+		t.Fatalf("additionalContext missing enclosing symbol: %q", hso.AdditionalContext)
+	}
+	if hso.PermissionDecision != "" || hso.PermissionDecisionReason != "" {
+		t.Fatalf("Codex PostToolUse enrichment must not deny: %#v", hso)
+	}
+}
+
+func TestRunCodexPostToolUseBashCommandShapes(t *testing.T) {
+	tests := []struct {
+		name     string
+		command  string
+		response string
+	}{
+		{
+			name:     "grep with no path line output stays quiet",
+			command:  "grep -rn handleFoo .",
+			response: "no matches\n",
+		},
+		{
+			name:     "piped grep is filter not search",
+			command:  "go test ./... | grep FAIL",
+			response: "pkg/x_test.go:12: FAIL\n",
+		},
+		{
+			name:     "find name is left to PreToolUse only",
+			command:  `find . -name "Handler*"`,
+			response: "internal/handler.go\n",
+		},
+		{
+			name:     "cat source output stays quiet",
+			command:  "cat /repo/handler.go",
+			response: "internal/a.go:7:type MyType struct{}\n",
+		},
+		{
+			name:     "unsupported sed range read stays quiet",
+			command:  `sed -n '1,80p' /repo/handler.go`,
+			response: "internal/a.go:7:type MyType struct{}\n",
+		},
+		{
+			name:     "unsupported awk source scan stays quiet",
+			command:  `awk 'NR>=1 && NR<=80 {print}' /repo/handler.go`,
+			response: "internal/a.go:7:type MyType struct{}\n",
+		},
+		{
+			name:     "ls stays quiet",
+			command:  "ls /repo",
+			response: "internal/a.go\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			port := stubBridge(t, nil,
+				map[string]struct{ ID, Name, Kind string }{
+					"internal/a.go:7": {ID: "internal/a.go::MyType", Name: "MyType", Kind: "type"},
+				}, nil)
+
+			data := codexPostBashPayload(tt.command, tt.response)
+			out := captureStdout(t, func() { runCodex(data, port) })
+			if out != "" {
+				t.Fatalf("expected silent no-op, got %q", out)
+			}
+		})
+	}
+}
+
+func TestRunCodexPostToolUseIgnoresNonBash(t *testing.T) {
+	data := []byte(`{"hook_event_name":"PostToolUse","tool_name":"Read","tool_input":{"file_path":"internal/a.go"},"tool_response":"internal/a.go:7:type MyType struct{}\n"}`)
+	out := captureStdout(t, func() { runCodex(data, 0) })
+	if out != "" {
+		t.Fatalf("non-Bash PostToolUse should be silent, got %q", out)
+	}
+}
+
+func TestRunCodexPostToolUseMalformedJSONNoop(t *testing.T) {
+	out := captureStdout(t, func() { runCodexPostToolUse([]byte(`{`), 0) })
+	if out != "" {
+		t.Fatalf("malformed JSON should be silent, got %q", out)
+	}
+}
+
+func codexBashPayload(command string) []byte {
+	return []byte(`{"hook_event_name":"PreToolUse","tool_name":"Bash","session_id":"codex-shape","tool_input":{"command":` + strconv.Quote(command) + `}}`)
+}
+
+func codexPostBashPayload(command string, response string) []byte {
+	return []byte(`{"hook_event_name":"PostToolUse","tool_name":"Bash","session_id":"codex-shape","tool_input":{"command":` + strconv.Quote(command) + `},"tool_response":` + strconv.Quote(response) + `}`)
 }

--- a/internal/hooks/codex_test.go
+++ b/internal/hooks/codex_test.go
@@ -37,7 +37,7 @@ func TestRunCodexPreToolUseBashSoftAdditionalContext(t *testing.T) {
 	}
 	t.Cleanup(func() { grepProbe = oldProbe })
 
-	data := []byte(`{"hook_event_name":"PreToolUse","tool_name":"Bash","session_id":"codex-1","tool_input":{"command":"rg Foo"}}`)
+	data := codexBashPayload("rg Foo")
 	out := captureStdout(t, func() {
 		withStdin(t, data, func() { RunCodex(0) })
 	})


### PR DESCRIPTION
## Summary

- Install a Codex `PostToolUse` hook for Bash alongside the existing Codex `SessionStart` / `PreToolUse` hooks.
- Route Codex `PostToolUse` Bash events through a small normalization layer when the command is grep-family, then reuse the existing `runPostToolUse` / `postGrep` enrichment path.
- Keep Codex soft-only: only emit `hookSpecificOutput.additionalContext`; no deny, stop, suppress, or input rewrite.
- Preserve user hooks, keep hook installation idempotent, and continue respecting `--no-hooks`.
- Document the Codex Bash `PostToolUse` hook.

## Design notes

- This intentionally handles only grep-family Bash output.
- Broader Bash output enrichment such as `cat` / `sed` / `awk` / source-read output, `apply_patch`, and MCP tool names are left for later PRs.
- Codex uses its dedicated dispatcher, so Claude, Gemini, and Antigravity hook behavior remains unchanged.
- The installed hook uses the portable `command` form: `gortex hook --agent=codex --mode=enrich`. Unlike the `SessionStart` text hook, this does not rely on POSIX-only shell output, so this PR does not add a `command_windows` override.

## Out of scope

- `apply_patch`
- MCP tool-name matching
- `cat` / `sed` / `awk` / general Bash output enrichment
- deny / enforcement behavior
- input rewrite
- output suppression
- Claude / Gemini / Antigravity behavior changes

## Tests

- `go test ./internal/agents/codex`
- `go test ./internal/hooks`
- `go test ./cmd/gortex`
- `git diff --check`

Related to https://github.com/zzet/gortex/issues/206