### PR TITLE
fix(init): refresh Codex hooks with hooks-only

### DIFF
--- a/cmd/gortex/init.go
+++ b/cmd/gortex/init.go
@@ -344,15 +344,27 @@ func runInit(cmd *cobra.Command, args []string) (err error) {
 func runInitHooksOnly(cmd *cobra.Command, absRoot string) error {
 	opts := agents.ApplyOpts{DryRun: initDryRun, Force: initForce}
 
-	settingsPath := filepath.Join(absRoot, ".claude", "settings.local.json")
-	claudeAction, err := claudecode.InstallHookWithMode(cmd.ErrOrStderr(), settingsPath, initHookMode, opts)
+	registry := buildRegistry()
+	selected, err := registry.Filter(initAgents, initAgentsSkip)
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(cmd.ErrOrStderr(), "[gortex init --hooks-only] %s %s\n", claudeAction.Action, claudeAction.Path)
+	selectedAgents := make(map[string]bool, len(selected))
+	for _, a := range selected {
+		selectedAgents[a.Name()] = true
+	}
+
+	if selectedAgents[claudecode.Name] {
+		settingsPath := filepath.Join(absRoot, ".claude", "settings.local.json")
+		claudeAction, err := claudecode.InstallHookWithMode(cmd.ErrOrStderr(), settingsPath, initHookMode, opts)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.ErrOrStderr(), "[gortex init --hooks-only] %s %s\n", claudeAction.Action, claudeAction.Path)
+	}
 
 	home, _ := os.UserHomeDir()
-	if home == "" {
+	if home == "" || !selectedAgents[codex.Name] {
 		return nil
 	}
 	env := agents.Env{

--- a/cmd/gortex/init.go
+++ b/cmd/gortex/init.go
@@ -90,7 +90,7 @@ func init() {
 	initCmd.Flags().BoolVar(&initAnalyze, "analyze", false, "index the repo to generate a richer CLAUDE.md with codebase overview")
 	initCmd.Flags().BoolVar(&initInstallHooks, "hooks", true, "install supported agent hooks; use --no-hooks to skip")
 	initCmd.Flags().BoolVar(&initNoHooks, "no-hooks", false, "skip installing supported agent hooks (inverse of --hooks)")
-	initCmd.Flags().BoolVar(&initHooksOnly, "hooks-only", false, "only install/update Claude Code hooks in .claude/settings.local.json, skip everything else")
+	initCmd.Flags().BoolVar(&initHooksOnly, "hooks-only", false, "only install/update supported agent hooks, skip everything else")
 	initCmd.Flags().StringVar(&initHookMode, "hook-mode", "deny",
 		"hook posture: 'deny' (PreToolUse redirects Grep/Glob/Read of indexed source) or 'enrich' "+
 			"(PreToolUse never denies; PostToolUse appends graph context after the tool runs)")
@@ -200,19 +200,10 @@ func runInit(cmd *cobra.Command, args []string) (err error) {
 		}
 	}
 
-	// --hooks-only short-circuit: install/heal Claude Code hooks
+	// --hooks-only short-circuit: install/heal supported agent hooks
 	// and exit. Everything else is a no-op.
 	if initHooksOnly {
-		settingsPath := filepath.Join(absRoot, ".claude", "settings.local.json")
-		if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
-			return err
-		}
-		action, err := claudecode.InstallHookWithMode(cmd.ErrOrStderr(), settingsPath, initHookMode, agents.ApplyOpts{DryRun: initDryRun, Force: initForce})
-		if err != nil {
-			return err
-		}
-		fmt.Fprintf(cmd.ErrOrStderr(), "[gortex init --hooks-only] %s %s\n", action.Action, action.Path)
-		return nil
+		return runInitHooksOnly(cmd, absRoot)
 	}
 
 	realStderr := cmd.ErrOrStderr()
@@ -347,6 +338,43 @@ func runInit(cmd *cobra.Command, args []string) (err error) {
 			return err
 		}
 	}
+	return nil
+}
+
+func runInitHooksOnly(cmd *cobra.Command, absRoot string) error {
+	opts := agents.ApplyOpts{DryRun: initDryRun, Force: initForce}
+
+	settingsPath := filepath.Join(absRoot, ".claude", "settings.local.json")
+	claudeAction, err := claudecode.InstallHookWithMode(cmd.ErrOrStderr(), settingsPath, initHookMode, opts)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.ErrOrStderr(), "[gortex init --hooks-only] %s %s\n", claudeAction.Action, claudeAction.Path)
+
+	home, _ := os.UserHomeDir()
+	if home == "" {
+		return nil
+	}
+	env := agents.Env{
+		Root:         absRoot,
+		Home:         home,
+		HookCommand:  claudecode.ResolveHookCommand(cmd.ErrOrStderr()),
+		Mode:         agents.ModeProject,
+		InstallHooks: true,
+		HookMode:     initHookMode,
+		Stderr:       cmd.ErrOrStderr(),
+	}
+	detected, _ := codex.New().Detect(env)
+	if !detected {
+		return nil
+	}
+
+	codexPath := filepath.Join(home, ".codex", "config.toml")
+	codexAction, err := codex.InstallHooksOnly(cmd.ErrOrStderr(), codexPath, env, opts)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.ErrOrStderr(), "[gortex init --hooks-only] %s %s\n", codexAction.Action, codexAction.Path)
 	return nil
 }
 

--- a/cmd/gortex/init_integration_test.go
+++ b/cmd/gortex/init_integration_test.go
@@ -290,6 +290,94 @@ args = ["mcp", "--custom"]
 	}
 }
 
+func TestInitHooksOnlyRespectsAgentsAllowlist(t *testing.T) {
+	restore := saveInitGlobals(t)
+	defer restore()
+
+	repo := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.MkdirAll(filepath.Join(home, ".codex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	initYes = true
+	initHooksOnly = true
+	initDryRun = false
+	initJSON = false
+	initAgents = "claude-code"
+
+	var stdout, stderr bytes.Buffer
+	initCmd.SetOut(&stdout)
+	initCmd.SetErr(&stderr)
+	t.Cleanup(func() {
+		initCmd.SetOut(nil)
+		initCmd.SetErr(nil)
+	})
+
+	if err := runInit(initCmd, []string{repo}); err != nil {
+		t.Fatalf("runInit: %v\nstderr: %s", err, stderr.String())
+	}
+
+	if _, err := os.Stat(filepath.Join(repo, ".claude", "settings.local.json")); err != nil {
+		t.Fatalf("expected Claude Code hooks to be refreshed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".codex", "config.toml")); !os.IsNotExist(err) {
+		t.Fatalf("--agents=claude-code should not write Codex config, stat err=%v", err)
+	}
+}
+
+func TestInitHooksOnlyRespectsAgentsSkip(t *testing.T) {
+	restore := saveInitGlobals(t)
+	defer restore()
+
+	repo := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	codexDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(codexDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	codexConfig := filepath.Join(codexDir, "config.toml")
+	seed := `model = "gpt-5-codex"
+
+[mcp_servers.gortex]
+command = "custom-gortex"
+`
+	if err := os.WriteFile(codexConfig, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	initYes = true
+	initHooksOnly = true
+	initDryRun = false
+	initJSON = false
+	initAgentsSkip = "codex"
+
+	var stdout, stderr bytes.Buffer
+	initCmd.SetOut(&stdout)
+	initCmd.SetErr(&stderr)
+	t.Cleanup(func() {
+		initCmd.SetOut(nil)
+		initCmd.SetErr(nil)
+	})
+
+	if err := runInit(initCmd, []string{repo}); err != nil {
+		t.Fatalf("runInit: %v\nstderr: %s", err, stderr.String())
+	}
+
+	if _, err := os.Stat(filepath.Join(repo, ".claude", "settings.local.json")); err != nil {
+		t.Fatalf("expected Claude Code hooks to be refreshed: %v", err)
+	}
+	cfg := readTOMLFile(t, codexConfig)
+	if _, ok := cfg["hooks"]; ok {
+		t.Fatalf("--agents-skip=codex should not write Codex hooks: %#v", cfg["hooks"])
+	}
+	if cfg["model"] != "gpt-5-codex" {
+		t.Fatalf("Codex config was unexpectedly rewritten: %#v", cfg)
+	}
+}
+
 func TestInitHooksOnlyDryRunDoesNotWriteHooks(t *testing.T) {
 	restore := saveInitGlobals(t)
 	defer restore()

--- a/cmd/gortex/init_integration_test.go
+++ b/cmd/gortex/init_integration_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	toml "github.com/pelletier/go-toml/v2"
 )
 
 // TestInitDryRunJSONReportShape is the end-to-end contract test for
@@ -212,6 +214,123 @@ func TestInitDryRunSkipsProjectMarker(t *testing.T) {
 	}
 }
 
+func TestInitHooksOnlyRefreshesClaudeAndCodexHooks(t *testing.T) {
+	restore := saveInitGlobals(t)
+	defer restore()
+
+	repo := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	codexDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(codexDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	codexConfig := filepath.Join(codexDir, "config.toml")
+	seed := `model = "gpt-5-codex"
+
+[mcp_servers.gortex]
+command = "custom-gortex"
+args = ["mcp", "--custom"]
+`
+	if err := os.WriteFile(codexConfig, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	initYes = true
+	initHooksOnly = true
+	initHookMode = "enrich"
+	initDryRun = false
+	initJSON = false
+	initAgents = ""
+
+	var stdout, stderr bytes.Buffer
+	initCmd.SetOut(&stdout)
+	initCmd.SetErr(&stderr)
+	t.Cleanup(func() {
+		initCmd.SetOut(nil)
+		initCmd.SetErr(nil)
+	})
+
+	if err := runInit(initCmd, []string{repo}); err != nil {
+		t.Fatalf("runInit: %v\nstderr: %s", err, stderr.String())
+	}
+
+	if _, err := os.Stat(filepath.Join(repo, ".claude", "settings.local.json")); err != nil {
+		t.Fatalf("expected Claude Code hooks to be refreshed: %v", err)
+	}
+	cfg := readTOMLFile(t, codexConfig)
+	if cfg["model"] != "gpt-5-codex" {
+		t.Fatalf("Codex hooks-only clobbered model: %#v", cfg)
+	}
+	servers := cfg["mcp_servers"].(map[string]any)
+	gortexServer := servers["gortex"].(map[string]any)
+	if gortexServer["command"] != "custom-gortex" {
+		t.Fatalf("Codex hooks-only rewrote mcp_servers.gortex: %#v", gortexServer)
+	}
+	hooks, ok := cfg["hooks"].(map[string]any)
+	if !ok {
+		t.Fatalf("Codex hooks-only did not write hooks: %#v", cfg)
+	}
+	for _, event := range []string{"SessionStart", "PreToolUse", "PostToolUse"} {
+		if _, ok := hooks[event]; !ok {
+			t.Fatalf("Codex hooks-only missing %s hook: %#v", event, hooks)
+		}
+	}
+
+	for _, p := range []string{
+		filepath.Join(repo, ".gortex"),
+		filepath.Join(repo, "AGENTS.md"),
+		filepath.Join(repo, ".claude", "skills"),
+		filepath.Join(home, ".gortex", "config.yaml"),
+	} {
+		if _, err := os.Stat(p); err == nil {
+			t.Fatalf("hooks-only should not create %s", p)
+		}
+	}
+}
+
+func TestInitHooksOnlyDryRunDoesNotWriteHooks(t *testing.T) {
+	restore := saveInitGlobals(t)
+	defer restore()
+
+	repo := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.MkdirAll(filepath.Join(home, ".codex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	initYes = true
+	initHooksOnly = true
+	initDryRun = true
+	initJSON = false
+	initAgents = ""
+
+	var stdout, stderr bytes.Buffer
+	initCmd.SetOut(&stdout)
+	initCmd.SetErr(&stderr)
+	t.Cleanup(func() {
+		initCmd.SetOut(nil)
+		initCmd.SetErr(nil)
+	})
+
+	if err := runInit(initCmd, []string{repo}); err != nil {
+		t.Fatalf("runInit: %v\nstderr: %s", err, stderr.String())
+	}
+
+	for _, p := range []string{
+		filepath.Join(repo, ".claude", "settings.local.json"),
+		filepath.Join(home, ".codex", "config.toml"),
+		filepath.Join(repo, ".gortex"),
+		filepath.Join(repo, "AGENTS.md"),
+	} {
+		if _, err := os.Stat(p); err == nil {
+			t.Fatalf("dry-run hooks-only should not write %s", p)
+		}
+	}
+}
+
 func TestInitDryRunIntakeJSONDoesNotWrite(t *testing.T) {
 	saved := struct {
 		yes, dryRun, json, dryRunIntake bool
@@ -262,4 +381,47 @@ func TestInitDryRunIntakeJSONDoesNotWrite(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(repo, ".gortex")); err == nil {
 		t.Fatal("dry-run-intake wrote .gortex/ — must be inspection-only")
 	}
+}
+
+func saveInitGlobals(t *testing.T) func() {
+	t.Helper()
+	saved := struct {
+		analyze, installHooks, noHooks, hooksOnly bool
+		hookMode                                  string
+		skills, noSkills                          bool
+		skillsMinSize, skillsMaxSkills            int
+		yes, interactive                          bool
+		agents, agentsSkip                        string
+		json, dryRun, dryRunIntake, force         bool
+	}{
+		initAnalyze, initInstallHooks, initNoHooks, initHooksOnly,
+		initHookMode,
+		initSkills, initNoSkills,
+		initSkillsMinSize, initSkillsMaxSkills,
+		initYes, initInteractive,
+		initAgents, initAgentsSkip,
+		initJSON, initDryRun, initDryRunIntake, initForce,
+	}
+	return func() {
+		initAnalyze, initInstallHooks, initNoHooks, initHooksOnly = saved.analyze, saved.installHooks, saved.noHooks, saved.hooksOnly
+		initHookMode = saved.hookMode
+		initSkills, initNoSkills = saved.skills, saved.noSkills
+		initSkillsMinSize, initSkillsMaxSkills = saved.skillsMinSize, saved.skillsMaxSkills
+		initYes, initInteractive = saved.yes, saved.interactive
+		initAgents, initAgentsSkip = saved.agents, saved.agentsSkip
+		initJSON, initDryRun, initDryRunIntake, initForce = saved.json, saved.dryRun, saved.dryRunIntake, saved.force
+	}
+}
+
+func readTOMLFile(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var out map[string]any
+	if err := toml.Unmarshal(data, &out); err != nil {
+		t.Fatalf("parse %s: %v\n%s", path, err, data)
+	}
+	return out
 }

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -102,7 +102,7 @@ gortex init --agents=claude-code,cursor     # allow-list
 gortex init --agents-skip=antigravity       # block-list
 gortex init --dry-run --json         # plan, emit JSON report
 gortex init --force                  # overwrite merge-preserved keys
-gortex init --hooks-only             # refresh Claude Code hooks only
+gortex init --hooks-only             # refresh supported agent hooks only
 
 # Observe-only
 gortex init doctor                   # read-only state report

--- a/internal/agents/codex/adapter.go
+++ b/internal/agents/codex/adapter.go
@@ -14,6 +14,7 @@ package codex
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -109,13 +110,7 @@ func (a *Adapter) Apply(env agents.Env, opts agents.ApplyOpts) (*agents.Result, 
 		}
 
 		if env.InstallHooks {
-			if upsertSessionStartHook(root, opts) {
-				changed = true
-			}
-			if upsertPreToolUseHook(root, env, opts) {
-				changed = true
-			}
-			if upsertPostToolUseHook(root, env, opts) {
+			if upsertCodexHooks(root, env, opts) {
 				changed = true
 			}
 		}
@@ -154,6 +149,35 @@ func upsertPreToolUseHook(root map[string]any, env agents.Env, opts agents.Apply
 
 func upsertPostToolUseHook(root map[string]any, env agents.Env, opts agents.ApplyOpts) bool {
 	return upsertCodexHook(root, "PostToolUse", codexHookEntryIsGortexPostToolUse, codexPostToolUseHookEntry(env), opts)
+}
+
+// InstallHooksOnly refreshes the Codex lifecycle hooks in configPath without
+// touching MCP server entries, AGENTS.md, or any other Codex adapter surface.
+func InstallHooksOnly(w io.Writer, configPath string, env agents.Env, opts agents.ApplyOpts) (agents.FileAction, error) {
+	action, err := agents.MergeTOML(w, configPath, func(root map[string]any, _ bool) (bool, error) {
+		return upsertCodexHooks(root, env, opts), nil
+	}, opts)
+	if err != nil {
+		return agents.FileAction{}, err
+	}
+	if action.Action != agents.ActionSkip {
+		action.Keys = []string{"hooks"}
+	}
+	return action, nil
+}
+
+func upsertCodexHooks(root map[string]any, env agents.Env, opts agents.ApplyOpts) bool {
+	changed := false
+	if upsertSessionStartHook(root, opts) {
+		changed = true
+	}
+	if upsertPreToolUseHook(root, env, opts) {
+		changed = true
+	}
+	if upsertPostToolUseHook(root, env, opts) {
+		changed = true
+	}
+	return changed
 }
 
 func upsertCodexHook(root map[string]any, event string, isGortex func(any) bool, desired map[string]any, opts agents.ApplyOpts) bool {

--- a/internal/agents/codex/adapter.go
+++ b/internal/agents/codex/adapter.go
@@ -167,17 +167,10 @@ func InstallHooksOnly(w io.Writer, configPath string, env agents.Env, opts agent
 }
 
 func upsertCodexHooks(root map[string]any, env agents.Env, opts agents.ApplyOpts) bool {
-	changed := false
-	if upsertSessionStartHook(root, opts) {
-		changed = true
-	}
-	if upsertPreToolUseHook(root, env, opts) {
-		changed = true
-	}
-	if upsertPostToolUseHook(root, env, opts) {
-		changed = true
-	}
-	return changed
+	sessionChanged := upsertSessionStartHook(root, opts)
+	preChanged := upsertPreToolUseHook(root, env, opts)
+	postChanged := upsertPostToolUseHook(root, env, opts)
+	return sessionChanged || preChanged || postChanged
 }
 
 func upsertCodexHook(root map[string]any, event string, isGortex func(any) bool, desired map[string]any, opts agents.ApplyOpts) bool {

--- a/internal/agents/codex/adapter_test.go
+++ b/internal/agents/codex/adapter_test.go
@@ -174,6 +174,208 @@ func TestCodexInstallsPostToolUseHook(t *testing.T) {
 	}
 }
 
+func TestCodexInstallHooksOnlyCreatesOnlyHooks(t *testing.T) {
+	env := codexGlobalEnv(t)
+	path := codexConfigPath(env)
+
+	action, err := InstallHooksOnly(env.Stderr, path, env, agents.ApplyOpts{})
+	if err != nil {
+		t.Fatalf("install hooks only: %v", err)
+	}
+	if action.Action != agents.ActionCreate {
+		t.Fatalf("action=%s want create", action.Action)
+	}
+	if len(action.Keys) != 1 || action.Keys[0] != "hooks" {
+		t.Fatalf("keys=%#v want hooks only", action.Keys)
+	}
+
+	cfg := readCodexConfig(t, env)
+	if _, ok := cfg["mcp_servers"]; ok {
+		t.Fatalf("hooks-only should not write mcp_servers: %#v", cfg["mcp_servers"])
+	}
+	if _, err := os.Stat(filepath.Join(env.Root, "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatalf("hooks-only should not write AGENTS.md, stat err=%v", err)
+	}
+	if count := gortexSessionStartHookCount(t, cfg); count != 1 {
+		t.Fatalf("SessionStart hooks=%d want 1", count)
+	}
+	if count := gortexPreToolUseHookCount(t, cfg); count != 1 {
+		t.Fatalf("PreToolUse hooks=%d want 1", count)
+	}
+	if count := gortexPostToolUseHookCount(t, cfg); count != 1 {
+		t.Fatalf("PostToolUse hooks=%d want 1", count)
+	}
+
+	action, err = InstallHooksOnly(env.Stderr, path, env, agents.ApplyOpts{})
+	if err != nil {
+		t.Fatalf("second install hooks only: %v", err)
+	}
+	if action.Action != agents.ActionSkip {
+		t.Fatalf("second action=%s want skip", action.Action)
+	}
+}
+
+func TestCodexInstallHooksOnlyPreservesExistingConfig(t *testing.T) {
+	env := codexGlobalEnv(t)
+	path := codexConfigPath(env)
+	seed := `model = "gpt-5-codex"
+
+[mcp_servers.gortex]
+command = "custom-gortex"
+args = ["mcp", "--custom"]
+
+[mcp_servers.other]
+command = "other"
+
+[[hooks.PreToolUse]]
+matcher = "^Bash$"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "echo user-pretooluse"
+statusMessage = "User PreToolUse"
+
+[[hooks.PostToolUse]]
+matcher = "^Bash$"
+
+[[hooks.PostToolUse.hooks]]
+type = "command"
+command = "echo user-posttooluse"
+statusMessage = "User PostToolUse"
+`
+	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	action, err := InstallHooksOnly(env.Stderr, path, env, agents.ApplyOpts{})
+	if err != nil {
+		t.Fatalf("install hooks only: %v", err)
+	}
+	if action.Action != agents.ActionMerge {
+		t.Fatalf("action=%s want merge", action.Action)
+	}
+	if len(action.Keys) != 1 || action.Keys[0] != "hooks" {
+		t.Fatalf("keys=%#v want hooks only", action.Keys)
+	}
+
+	cfg := readCodexConfig(t, env)
+	if cfg["model"] != "gpt-5-codex" {
+		t.Fatalf("unrelated top-level key was clobbered: %#v", cfg)
+	}
+	servers := cfg["mcp_servers"].(map[string]any)
+	gortexServer := servers["gortex"].(map[string]any)
+	if gortexServer["command"] != "custom-gortex" {
+		t.Fatalf("hooks-only rewrote mcp_servers.gortex: %#v", gortexServer)
+	}
+	if _, ok := servers["other"]; !ok {
+		t.Fatalf("existing MCP server was clobbered: %#v", servers)
+	}
+	if !hasHookCommand(t, cfg, "PreToolUse", "echo user-pretooluse") {
+		t.Fatalf("user PreToolUse hook was not preserved: %#v", preToolUseEntries(t, cfg))
+	}
+	if !hasHookCommand(t, cfg, "PostToolUse", "echo user-posttooluse") {
+		t.Fatalf("user PostToolUse hook was not preserved: %#v", postToolUseEntries(t, cfg))
+	}
+	if count := gortexSessionStartHookCount(t, cfg); count != 1 {
+		t.Fatalf("SessionStart hooks=%d want 1", count)
+	}
+	if count := gortexPreToolUseHookCount(t, cfg); count != 1 {
+		t.Fatalf("PreToolUse hooks=%d want 1", count)
+	}
+	if count := gortexPostToolUseHookCount(t, cfg); count != 1 {
+		t.Fatalf("PostToolUse hooks=%d want 1", count)
+	}
+}
+
+func TestCodexInstallHooksOnlyForceReplacesOnlyGortexHooks(t *testing.T) {
+	env := codexGlobalEnv(t)
+	path := codexConfigPath(env)
+	seed := `[[hooks.PreToolUse]]
+matcher = "^Bash$"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "echo user-pretooluse"
+statusMessage = "User PreToolUse"
+
+[[hooks.PreToolUse]]
+matcher = "^Bash$"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "/tmp/old-gortex hook --agent=codex --mode=enrich"
+statusMessage = "Old Gortex PreToolUse"
+
+[[hooks.PostToolUse]]
+matcher = "^Bash$"
+
+[[hooks.PostToolUse.hooks]]
+type = "command"
+command = "echo user-posttooluse"
+statusMessage = "User PostToolUse"
+
+[[hooks.PostToolUse]]
+matcher = "^Bash$"
+
+[[hooks.PostToolUse.hooks]]
+type = "command"
+command = "/tmp/old-gortex hook --agent=codex --mode=enrich"
+statusMessage = "Old Gortex PostToolUse"
+`
+	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	if _, err := InstallHooksOnly(env.Stderr, path, env, agents.ApplyOpts{Force: true}); err != nil {
+		t.Fatalf("install hooks only: %v", err)
+	}
+
+	cfg := readCodexConfig(t, env)
+	if !hasHookCommand(t, cfg, "PreToolUse", "echo user-pretooluse") {
+		t.Fatalf("Force removed user PreToolUse hook: %#v", preToolUseEntries(t, cfg))
+	}
+	if !hasHookCommand(t, cfg, "PostToolUse", "echo user-posttooluse") {
+		t.Fatalf("Force removed user PostToolUse hook: %#v", postToolUseEntries(t, cfg))
+	}
+	if hasHookCommand(t, cfg, "PreToolUse", "/tmp/old-gortex hook --agent=codex --mode=enrich") {
+		t.Fatalf("Force kept stale Gortex PreToolUse hook: %#v", preToolUseEntries(t, cfg))
+	}
+	if hasHookCommand(t, cfg, "PostToolUse", "/tmp/old-gortex hook --agent=codex --mode=enrich") {
+		t.Fatalf("Force kept stale Gortex PostToolUse hook: %#v", postToolUseEntries(t, cfg))
+	}
+	if !hasHookCommand(t, cfg, "PreToolUse", "/tmp/test-gortex hook --agent=codex --mode=enrich") {
+		t.Fatalf("Force did not install current Gortex PreToolUse hook: %#v", preToolUseEntries(t, cfg))
+	}
+	if !hasHookCommand(t, cfg, "PostToolUse", "/tmp/test-gortex hook --agent=codex --mode=enrich") {
+		t.Fatalf("Force did not install current Gortex PostToolUse hook: %#v", postToolUseEntries(t, cfg))
+	}
+	if count := gortexPreToolUseHookCount(t, cfg); count != 1 {
+		t.Fatalf("Gortex PreToolUse hooks=%d want 1", count)
+	}
+	if count := gortexPostToolUseHookCount(t, cfg); count != 1 {
+		t.Fatalf("Gortex PostToolUse hooks=%d want 1", count)
+	}
+}
+
+func TestCodexInstallHooksOnlyDryRunDoesNotWrite(t *testing.T) {
+	env := codexGlobalEnv(t)
+	path := codexConfigPath(env)
+
+	action, err := InstallHooksOnly(env.Stderr, path, env, agents.ApplyOpts{DryRun: true})
+	if err != nil {
+		t.Fatalf("install hooks only dry-run: %v", err)
+	}
+	if action.Action != agents.ActionWouldCreate {
+		t.Fatalf("action=%s want would-create", action.Action)
+	}
+	if len(action.Keys) != 1 || action.Keys[0] != "hooks" {
+		t.Fatalf("keys=%#v want hooks only", action.Keys)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("dry-run should not write config.toml, stat err=%v", err)
+	}
+}
+
 func TestCodexPreToolUseCommandFallsBackToGortexHook(t *testing.T) {
 	command := codexPreToolUseCommand(agents.Env{})
 	if command != "gortex hook --agent=codex --mode=enrich" {


### PR DESCRIPTION
## Summary

- Extend `gortex init --hooks-only` so it refreshes Codex hooks in `~/.codex/config.toml` alongside Claude Code hooks.
- Keep hooks-only scoped to hook surfaces only: no MCP rewrite, no AGENTS.md, no skills/indexing, no project marker, and no global config update.
- Respect `--agents` / `--agents-skip` in hooks-only mode, matching normal init selection semantics.
- Document `--hooks-only` as refreshing supported agent hooks.

## Changes

- Added `codex.InstallHooksOnly(...)`, which reuses existing Codex hook upsert logic while touching only top-level `hooks`.
- Refactored Codex normal init to share the same hook upsert helper.
- Updated `runInitHooksOnly` to:
  - refresh Claude Code hooks when `claude-code` is selected;
  - detect and refresh Codex hooks when `codex` is selected;
  - skip Codex when filtered out by `--agents` or `--agents-skip`.
- Added integration coverage for hooks-only allow-list / skip behavior.
- Added Codex adapter tests for fresh install, idempotency, preserve user hooks, preserve MCP/unrelated keys, force replacement, and dry-run behavior.

## Out of scope

- Normal `gortex init` behavior changes.
- Codex hook semantics changes.
- Codex PostToolUse source-read or file-list enrichment.
- MCP tool-name hooks.
- `apply_patch` hooks.
- resolver, indexer, daemon, graph, or MCP tool changes.

## Tests

- `go test ./cmd/gortex`
- `go test ./internal/agents/codex`
- `go test ./internal/agents/claudecode`
- `git diff --check`