### PR TITLE
feat(codex): enrich Bash source-read PostToolUse output

### DIFF
--- a/internal/hooks/codex.go
+++ b/internal/hooks/codex.go
@@ -44,14 +44,26 @@ func runCodexPostToolUse(data []byte, port int) {
 	}
 
 	cmd, _ := input.ToolInput["command"].(string)
-	if classifyBashCommand(cmd).Action != BashActionGrepLike {
+	classification := classifyBashCommand(cmd)
+	switch classification.Action {
+	case BashActionGrepLike:
+		// Codex wraps grep/rg/ag in Bash. Re-label that narrow shape as Grep so
+		// the existing PostToolUse enrichment can parse path:line output and do
+		// the graph lookup without changing Claude Code behavior.
+		input.ToolName = "Grep"
+	case BashActionReadSource:
+		if classification.Path == "" {
+			return
+		}
+		if input.ToolInput == nil {
+			input.ToolInput = make(map[string]any)
+		}
+		input.ToolName = "Read"
+		input.ToolInput["file_path"] = classification.Path
+	default:
 		return
 	}
 
-	// Codex wraps grep/rg/ag in Bash. Re-label that narrow shape as Grep so
-	// the existing PostToolUse enrichment can parse path:line output and do
-	// the graph lookup without changing Claude Code behavior.
-	input.ToolName = "Grep"
 	normalized, err := json.Marshal(input)
 	if err != nil {
 		return

--- a/internal/hooks/codex_test.go
+++ b/internal/hooks/codex_test.go
@@ -86,6 +86,57 @@ func TestRunCodexPostToolUseBashGrepOutputAdditionalContext(t *testing.T) {
 	}
 }
 
+func TestRunCodexPostToolUseBashReadSourceAdditionalContext(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+	}{
+		{
+			name:    "cat",
+			command: "cat internal/a.go",
+		},
+		{
+			name:    "head",
+			command: "head -20 internal/a.go",
+		},
+		{
+			name:    "tail",
+			command: "tail -n 50 internal/a.go",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			port := stubBridge(t, map[string]int{"internal/a.go": 3}, nil, map[string]int{"internal/a.go": 2})
+
+			data := codexPostBashPayload(tt.command, "package internal\n")
+			out := captureStdout(t, func() { runCodex(data, port) })
+			if out == "" {
+				t.Fatal("expected Codex Bash PostToolUse Read graph context, got empty output")
+			}
+			hso := decodeHookOutput(t, out).HookSpecificOutput
+			if hso == nil {
+				t.Fatalf("missing hookSpecificOutput: %s", out)
+			}
+			if hso.HookEventName != "PostToolUse" {
+				t.Fatalf("hookEventName=%q want PostToolUse", hso.HookEventName)
+			}
+			if !strings.Contains(hso.AdditionalContext, "Graph footprint for internal/a.go") {
+				t.Fatalf("additionalContext missing file footprint: %q", hso.AdditionalContext)
+			}
+			if !strings.Contains(hso.AdditionalContext, "3 indexed symbol(s)") {
+				t.Fatalf("additionalContext missing symbol count: %q", hso.AdditionalContext)
+			}
+			if !strings.Contains(hso.AdditionalContext, "2 unique external caller(s)") {
+				t.Fatalf("additionalContext missing caller count: %q", hso.AdditionalContext)
+			}
+			if hso.PermissionDecision != "" || hso.PermissionDecisionReason != "" {
+				t.Fatalf("Codex PostToolUse enrichment must not deny: %#v", hso)
+			}
+		})
+	}
+}
+
 func TestRunCodexPostToolUseBashCommandShapes(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -108,7 +159,7 @@ func TestRunCodexPostToolUseBashCommandShapes(t *testing.T) {
 			response: "internal/handler.go\n",
 		},
 		{
-			name:     "cat source output stays quiet",
+			name:     "unindexed cat source output stays quiet",
 			command:  "cat /repo/handler.go",
 			response: "internal/a.go:7:type MyType struct{}\n",
 		},


### PR DESCRIPTION
## Summary

- Extend Codex Bash `PostToolUse` enrichment beyond grep-family output to source-read Bash commands recognized by the existing classifier.
- Normalize Codex `cat` / `head` / `tail` Bash events to the existing `Read` PostToolUse shape and reuse `postRead` graph footprint enrichment.
- Preserve the existing grep-family normalization from #211.
- Keep Codex soft-only: only emit `hookSpecificOutput.additionalContext`; no deny, stop, suppress, or input rewrite.

## Design notes

- This is intentionally limited to `BashActionReadSource` from the existing Bash classifier.
- Reusing `runPostToolUse` / `postRead` keeps behavior aligned with existing Claude Code PostToolUse enrichment while remaining inside the Codex dispatcher.
- Claude, Gemini, and Antigravity hook behavior remains unchanged.

## Out of scope

- grep-family behavior changes
- `sed` / `awk`
- `find -name` / file-list output
- general Bash output enrichment
- `apply_patch`
- MCP tool-name matching
- deny / enforcement behavior
- input rewrite
- output suppression
- hook installation / init behavior changes
- Claude / Gemini / Antigravity behavior changes

## Tests

- `go test ./internal/hooks`
- `go test ./cmd/gortex`
- `git diff --check`