### PR TITLE
feat(codex): nudge Gortex MCP read tools toward compressed reads

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -24,7 +24,7 @@ commands accept `--agents=<csv>` to constrain setup and
 | `aider`         | `.aiderignore` block, `CONVENTIONS.md` communities block                                        | project    | https://aider.chat/docs/config/aider_conf.html                      |
 | `antigravity`   | `~/.gemini/antigravity/mcp_config.json` + Knowledge Item                                        | user       | https://antigravity.google/docs/mcp                                 |
 | `cline`         | `cline_mcp_settings.json` (per VS Code / Cursor globalStorage), `.clinerules/gortex-communities.md` | both     | https://docs.cline.bot/mcp/mcp-overview                             |
-| `codex`         | `~/.codex/config.toml` (`[mcp_servers.gortex]` + `SessionStart` / Bash `PreToolUse` / Bash `PostToolUse` hooks), `AGENTS.md` communities block | both       | https://developers.openai.com/codex/mcp                             |
+| `codex`         | `~/.codex/config.toml` (`[mcp_servers.gortex]` + `SessionStart` / Bash + Gortex MCP read-tool `PreToolUse` / Bash `PostToolUse` hooks), `AGENTS.md` communities block | both       | https://developers.openai.com/codex/mcp                             |
 | `continue`      | `.continue/mcpServers/gortex.json`, `.continue/rules/gortex-communities.md`                     | project    | https://docs.continue.dev/customize/deep-dives/mcp                  |
 | `cursor`        | `.cursor/mcp.json` (project) or `~/.cursor/mcp.json`, `.cursor/rules/gortex-communities.mdc`    | both       | https://docs.cursor.com/en/context/mcp                              |
 | `gemini`        | `.gemini/settings.json` or `~/.gemini/settings.json`, `GEMINI.md` communities block             | both       | https://geminicli.com/docs/tools/mcp-server/                        |
@@ -199,13 +199,13 @@ upsert a `[mcp_servers.gortex]` table there. When hooks are enabled
 (the default), we also add one user-level `SessionStart` hook matching
 `startup|resume|clear|compact`. It emits a short graph-tools
 orientation so new, resumed, cleared, and compacted Codex sessions see
-the same nudge. Codex also gets a Bash-only `PreToolUse` hook in
-soft-enrich mode: it can add `hookSpecificOutput.additionalContext`
-when a shell search/read shape should prefer Gortex graph tools. A
-Bash-only `PostToolUse` hook adds graph context for grep/rg/ag-style
-search output by reusing the existing post-tool enrichment path. Codex
-hooks do not deny, rewrite input, suppress output, or handle
-`apply_patch`.
+the same nudge. Codex also gets a Bash `PreToolUse` hook in soft-enrich
+mode for shell search/read/list shapes, plus a separate Gortex MCP
+read-tool `PreToolUse` hook for `read_file` and `get_editing_context`
+compress-bodies guidance. A Bash-only `PostToolUse` hook adds graph
+context for grep/rg/ag-style search output by reusing the existing
+post-tool enrichment path. Codex hooks do not deny, rewrite input,
+suppress output, or handle `apply_patch`.
 
 ### continue
 

--- a/internal/agents/codex/adapter.go
+++ b/internal/agents/codex/adapter.go
@@ -32,6 +32,7 @@ const codexSessionStartMessage = "IMPORTANT: Prefer Gortex MCP tools (search_sym
 const codexSessionStartCommand = "printf '%s\\n' '" + codexSessionStartMessage + "'"
 const codexSessionStartWindowsCommand = "powershell -NoProfile -Command \"Write-Output '" + codexSessionStartMessage + "'\""
 const codexPreToolUseMatcher = "^Bash$"
+const codexMCPReadPreToolUseMatcher = "^mcp__gortex__(read_file|get_editing_context)$"
 const codexPostToolUseMatcher = "^Bash$"
 const codexHookTimeoutSeconds = 5
 
@@ -144,7 +145,11 @@ func upsertSessionStartHook(root map[string]any, opts agents.ApplyOpts) bool {
 }
 
 func upsertPreToolUseHook(root map[string]any, env agents.Env, opts agents.ApplyOpts) bool {
-	return upsertCodexHook(root, "PreToolUse", codexHookEntryIsGortexPreToolUse, codexPreToolUseHookEntry(env), opts)
+	desired := []map[string]any{
+		codexPreToolUseHookEntry(env),
+		codexMCPReadPreToolUseHookEntry(env),
+	}
+	return upsertCodexHookSet(root, "PreToolUse", codexHookEntryIsGortexPreToolUse, desired, opts)
 }
 
 func upsertPostToolUseHook(root map[string]any, env agents.Env, opts agents.ApplyOpts) bool {
@@ -205,6 +210,67 @@ func upsertCodexHook(root map[string]any, event string, isGortex func(any) bool,
 	hooks[event] = append(kept, desired)
 	root["hooks"] = hooks
 	return true
+}
+
+func upsertCodexHookSet(root map[string]any, event string, isGortex func(any) bool, desired []map[string]any, opts agents.ApplyOpts) bool {
+	hooks, ok := root["hooks"].(map[string]any)
+	if !ok {
+		if _, exists := root["hooks"]; exists {
+			return false
+		}
+		hooks = make(map[string]any)
+	}
+
+	entries, ok := codexHookList(hooks[event])
+	if !ok {
+		return false
+	}
+
+	found := make([]bool, len(desired))
+	kept := make([]any, 0, len(entries)+len(desired))
+	for _, entry := range entries {
+		if isGortex(entry) {
+			if opts.Force {
+				continue
+			}
+			for i, want := range desired {
+				if !found[i] && codexHookEntryMatchesDesired(entry, want) {
+					found[i] = true
+					break
+				}
+			}
+		}
+		kept = append(kept, entry)
+	}
+
+	changed := false
+	for i, want := range desired {
+		if opts.Force || !found[i] {
+			kept = append(kept, want)
+			changed = true
+		}
+	}
+	if !changed {
+		return false
+	}
+
+	hooks[event] = kept
+	root["hooks"] = hooks
+	return true
+}
+
+func codexHookEntryMatchesDesired(entry any, desired map[string]any) bool {
+	matcher, _ := desired["matcher"].(string)
+	return codexHookEntryHasMatcher(entry, matcher) && codexHookEntryInvokesCodexHook(entry)
+}
+
+func codexHookEntryHasMatcher(entry any, matcher string) bool {
+	group, ok := entry.(map[string]any)
+	if !ok {
+		return false
+	}
+	got, _ := group["matcher"].(string)
+	return got == matcher
 }
 
 func codexHookList(v any) ([]any, bool) {
@@ -314,6 +380,20 @@ func codexPreToolUseHookEntry(env agents.Env) map[string]any {
 				"command":       codexPreToolUseCommand(env),
 				"timeout":       codexHookTimeoutSeconds,
 				"statusMessage": "Loading Gortex Bash guidance...",
+			},
+		},
+	}
+}
+
+func codexMCPReadPreToolUseHookEntry(env agents.Env) map[string]any {
+	return map[string]any{
+		"matcher": codexMCPReadPreToolUseMatcher,
+		"hooks": []any{
+			map[string]any{
+				"type":          "command",
+				"command":       codexPreToolUseCommand(env),
+				"timeout":       codexHookTimeoutSeconds,
+				"statusMessage": "Loading Gortex read guidance...",
 			},
 		},
 	}

--- a/internal/agents/codex/adapter_test.go
+++ b/internal/agents/codex/adapter_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/zzet/gortex/internal/agents/agentstest"
 )
 
+const testCodexHookCommand = "/tmp/test-gortex hook --agent=codex --mode=enrich"
+
 // TestCodexWritesMcpServersTOMLTable verifies we produce the
 // documented [mcp_servers.gortex] table — not a legacy
 // [mcp.gortex] or [mcpServers.gortex].
@@ -47,9 +49,7 @@ func TestCodexWritesMcpServersTOMLTable(t *testing.T) {
 	if count := gortexSessionStartHookCount(t, cfg); count != 1 {
 		t.Fatalf("expected one Gortex SessionStart hook, got %d: %#v", count, cfg["hooks"])
 	}
-	if count := gortexPreToolUseHookCount(t, cfg); count != 1 {
-		t.Fatalf("expected one Gortex PreToolUse hook, got %d: %#v", count, cfg["hooks"])
-	}
+	assertGortexPreToolUseHooks(t, cfg)
 	if count := gortexPostToolUseHookCount(t, cfg); count != 1 {
 		t.Fatalf("expected one Gortex PostToolUse hook, got %d: %#v", count, cfg["hooks"])
 	}
@@ -114,27 +114,26 @@ func TestCodexInstallsPreToolUseHook(t *testing.T) {
 
 	cfg := readCodexConfig(t, env)
 	entries := preToolUseEntries(t, cfg)
-	if len(entries) != 1 {
-		t.Fatalf("PreToolUse entries=%d want 1: %#v", len(entries), entries)
+	if len(entries) != 2 {
+		t.Fatalf("PreToolUse entries=%d want Bash+MCP read entries: %#v", len(entries), entries)
 	}
-	entry := entries[0].(map[string]any)
-	if entry["matcher"] != codexPreToolUseMatcher {
-		t.Fatalf("matcher=%v want %q", entry["matcher"], codexPreToolUseMatcher)
+	assertGortexPreToolUseHooks(t, cfg)
+
+	bashHandler := requireHookEntry(t, cfg, "PreToolUse", codexPreToolUseMatcher, testCodexHookCommand)
+	mcpHandler := requireHookEntry(t, cfg, "PreToolUse", codexMCPReadPreToolUseMatcher, testCodexHookCommand)
+	for name, handler := range map[string]map[string]any{"Bash": bashHandler, "MCP read": mcpHandler} {
+		if handler["type"] != "command" {
+			t.Errorf("%s hook type=%v want command", name, handler["type"])
+		}
+		if handler["timeout"] != int64(codexHookTimeoutSeconds) {
+			t.Errorf("%s timeout=%v want %d", name, handler["timeout"], codexHookTimeoutSeconds)
+		}
 	}
-	handlers, ok := codexHookList(entry["hooks"])
-	if !ok || len(handlers) != 1 {
-		t.Fatalf("handlers=%#v", entry["hooks"])
+	if bashHandler["statusMessage"] != "Loading Gortex Bash guidance..." {
+		t.Errorf("Bash statusMessage=%v", bashHandler["statusMessage"])
 	}
-	handler := handlers[0].(map[string]any)
-	if handler["type"] != "command" {
-		t.Errorf("hook type=%v want command", handler["type"])
-	}
-	command := handler["command"].(string)
-	if command != "/tmp/test-gortex hook --agent=codex --mode=enrich" {
-		t.Errorf("command=%v want test hook command with --agent=codex --mode=enrich", command)
-	}
-	if handler["timeout"] != int64(codexHookTimeoutSeconds) {
-		t.Errorf("timeout=%v want %d", handler["timeout"], codexHookTimeoutSeconds)
+	if mcpHandler["statusMessage"] != "Loading Gortex read guidance..." {
+		t.Errorf("MCP read statusMessage=%v", mcpHandler["statusMessage"])
 	}
 }
 
@@ -166,7 +165,7 @@ func TestCodexInstallsPostToolUseHook(t *testing.T) {
 		t.Errorf("hook type=%v want command", handler["type"])
 	}
 	command := handler["command"].(string)
-	if command != "/tmp/test-gortex hook --agent=codex --mode=enrich" {
+	if command != testCodexHookCommand {
 		t.Errorf("command=%v want test hook command with --agent=codex --mode=enrich", command)
 	}
 	if handler["timeout"] != int64(codexHookTimeoutSeconds) {
@@ -199,9 +198,7 @@ func TestCodexInstallHooksOnlyCreatesOnlyHooks(t *testing.T) {
 	if count := gortexSessionStartHookCount(t, cfg); count != 1 {
 		t.Fatalf("SessionStart hooks=%d want 1", count)
 	}
-	if count := gortexPreToolUseHookCount(t, cfg); count != 1 {
-		t.Fatalf("PreToolUse hooks=%d want 1", count)
-	}
+	assertGortexPreToolUseHooks(t, cfg)
 	if count := gortexPostToolUseHookCount(t, cfg); count != 1 {
 		t.Fatalf("PostToolUse hooks=%d want 1", count)
 	}
@@ -279,9 +276,7 @@ statusMessage = "User PostToolUse"
 	if count := gortexSessionStartHookCount(t, cfg); count != 1 {
 		t.Fatalf("SessionStart hooks=%d want 1", count)
 	}
-	if count := gortexPreToolUseHookCount(t, cfg); count != 1 {
-		t.Fatalf("PreToolUse hooks=%d want 1", count)
-	}
+	assertGortexPreToolUseHooks(t, cfg)
 	if count := gortexPostToolUseHookCount(t, cfg); count != 1 {
 		t.Fatalf("PostToolUse hooks=%d want 1", count)
 	}
@@ -305,6 +300,14 @@ matcher = "^Bash$"
 type = "command"
 command = "/tmp/old-gortex hook --agent=codex --mode=enrich"
 statusMessage = "Old Gortex PreToolUse"
+
+[[hooks.PreToolUse]]
+matcher = "^mcp__gortex__(read_file|get_editing_context)$"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "/tmp/old-gortex hook --agent=codex --mode=enrich"
+statusMessage = "Old Gortex MCP Read PreToolUse"
 
 [[hooks.PostToolUse]]
 matcher = "^Bash$"
@@ -343,15 +346,13 @@ statusMessage = "Old Gortex PostToolUse"
 	if hasHookCommand(t, cfg, "PostToolUse", "/tmp/old-gortex hook --agent=codex --mode=enrich") {
 		t.Fatalf("Force kept stale Gortex PostToolUse hook: %#v", postToolUseEntries(t, cfg))
 	}
-	if !hasHookCommand(t, cfg, "PreToolUse", "/tmp/test-gortex hook --agent=codex --mode=enrich") {
+	if !hasHookCommand(t, cfg, "PreToolUse", testCodexHookCommand) {
 		t.Fatalf("Force did not install current Gortex PreToolUse hook: %#v", preToolUseEntries(t, cfg))
 	}
-	if !hasHookCommand(t, cfg, "PostToolUse", "/tmp/test-gortex hook --agent=codex --mode=enrich") {
+	if !hasHookCommand(t, cfg, "PostToolUse", testCodexHookCommand) {
 		t.Fatalf("Force did not install current Gortex PostToolUse hook: %#v", postToolUseEntries(t, cfg))
 	}
-	if count := gortexPreToolUseHookCount(t, cfg); count != 1 {
-		t.Fatalf("Gortex PreToolUse hooks=%d want 1", count)
-	}
+	assertGortexPreToolUseHooks(t, cfg)
 	if count := gortexPostToolUseHookCount(t, cfg); count != 1 {
 		t.Fatalf("Gortex PostToolUse hooks=%d want 1", count)
 	}
@@ -400,9 +401,7 @@ func TestCodexSessionStartHookIdempotent(t *testing.T) {
 	if count := gortexSessionStartHookCount(t, cfg); count != 1 {
 		t.Fatalf("re-run duplicated Gortex SessionStart hook: got %d", count)
 	}
-	if count := gortexPreToolUseHookCount(t, cfg); count != 1 {
-		t.Fatalf("re-run duplicated Gortex PreToolUse hook: got %d", count)
-	}
+	assertGortexPreToolUseHooks(t, cfg)
 	if count := gortexPostToolUseHookCount(t, cfg); count != 1 {
 		t.Fatalf("re-run duplicated Gortex PostToolUse hook: got %d", count)
 	}
@@ -473,15 +472,13 @@ statusMessage = "User PostToolUse"
 		t.Fatalf("Gortex SessionStart hooks=%d want 1", count)
 	}
 	preEntries := preToolUseEntries(t, cfg)
-	if len(preEntries) != 2 {
-		t.Fatalf("PreToolUse entries=%d want user+gortex entries: %#v", len(preEntries), preEntries)
+	if len(preEntries) != 3 {
+		t.Fatalf("PreToolUse entries=%d want user+Bash+MCP read entries: %#v", len(preEntries), preEntries)
 	}
 	if !hasHookCommand(t, cfg, "PreToolUse", "echo user-pretooluse") {
 		t.Fatalf("user PreToolUse hook was not preserved: %#v", preEntries)
 	}
-	if count := gortexPreToolUseHookCount(t, cfg); count != 1 {
-		t.Fatalf("Gortex PreToolUse hooks=%d want 1", count)
-	}
+	assertGortexPreToolUseHooks(t, cfg)
 	postEntries := postToolUseEntries(t, cfg)
 	if len(postEntries) != 2 {
 		t.Fatalf("PostToolUse entries=%d want user+gortex entries: %#v", len(postEntries), postEntries)
@@ -512,6 +509,14 @@ matcher = "^Bash$"
 type = "command"
 command = "/tmp/old-gortex hook --agent=codex --mode=enrich"
 statusMessage = "Old Gortex PreToolUse"
+
+[[hooks.PreToolUse]]
+matcher = "^mcp__gortex__(read_file|get_editing_context)$"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "/tmp/old-gortex hook --agent=codex --mode=enrich"
+statusMessage = "Old Gortex MCP Read PreToolUse"
 `
 	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
 		t.Fatalf("seed config: %v", err)
@@ -526,8 +531,8 @@ statusMessage = "Old Gortex PreToolUse"
 
 	cfg := readCodexConfig(t, env)
 	preEntries := preToolUseEntries(t, cfg)
-	if len(preEntries) != 2 {
-		t.Fatalf("PreToolUse entries=%d want user+gortex entries: %#v", len(preEntries), preEntries)
+	if len(preEntries) != 3 {
+		t.Fatalf("PreToolUse entries=%d want user+Bash+MCP read entries: %#v", len(preEntries), preEntries)
 	}
 	if !hasHookCommand(t, cfg, "PreToolUse", "echo user-pretooluse") {
 		t.Fatalf("Force removed user PreToolUse hook: %#v", preEntries)
@@ -535,12 +540,10 @@ statusMessage = "Old Gortex PreToolUse"
 	if hasHookCommand(t, cfg, "PreToolUse", "/tmp/old-gortex hook --agent=codex --mode=enrich") {
 		t.Fatalf("Force kept stale Gortex PreToolUse hook: %#v", preEntries)
 	}
-	if !hasHookCommand(t, cfg, "PreToolUse", "/tmp/test-gortex hook --agent=codex --mode=enrich") {
+	if !hasHookCommand(t, cfg, "PreToolUse", testCodexHookCommand) {
 		t.Fatalf("Force did not install current Gortex PreToolUse hook: %#v", preEntries)
 	}
-	if count := gortexPreToolUseHookCount(t, cfg); count != 1 {
-		t.Fatalf("Gortex PreToolUse hooks=%d want 1", count)
-	}
+	assertGortexPreToolUseHooks(t, cfg)
 }
 
 func TestCodexNoHooksSkipsSessionStartHook(t *testing.T) {
@@ -650,12 +653,83 @@ func gortexPreToolUseHookCount(t *testing.T, cfg map[string]any) int {
 	return count
 }
 
+func assertGortexPreToolUseHooks(t *testing.T, cfg map[string]any) {
+	t.Helper()
+	if count := gortexPreToolUseHookCount(t, cfg); count != 2 {
+		t.Fatalf("Gortex PreToolUse hooks=%d want Bash+MCP read hooks: %#v", count, preToolUseEntries(t, cfg))
+	}
+	if count := hookMatcherCommandCount(t, cfg, "PreToolUse", codexPreToolUseMatcher, testCodexHookCommand); count != 1 {
+		t.Fatalf("Bash PreToolUse hook count=%d want 1: %#v", count, preToolUseEntries(t, cfg))
+	}
+	if count := hookMatcherCommandCount(t, cfg, "PreToolUse", codexMCPReadPreToolUseMatcher, testCodexHookCommand); count != 1 {
+		t.Fatalf("MCP read PreToolUse hook count=%d want 1: %#v", count, preToolUseEntries(t, cfg))
+	}
+}
+
 func gortexPostToolUseHookCount(t *testing.T, cfg map[string]any) int {
 	t.Helper()
 	count := 0
 	for _, entry := range postToolUseEntries(t, cfg) {
 		if codexHookEntryIsGortexPostToolUse(entry) {
 			count++
+		}
+	}
+	return count
+}
+
+func requireHookEntry(t *testing.T, cfg map[string]any, event, matcher, command string) map[string]any {
+	t.Helper()
+	for _, entry := range hookEntries(t, cfg, event) {
+		group, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		gotMatcher, _ := group["matcher"].(string)
+		if gotMatcher != matcher {
+			continue
+		}
+		handlers, ok := codexHookList(group["hooks"])
+		if !ok {
+			continue
+		}
+		for _, handler := range handlers {
+			hm, ok := handler.(map[string]any)
+			if !ok {
+				continue
+			}
+			if got, _ := hm["command"].(string); got == command {
+				return hm
+			}
+		}
+	}
+	t.Fatalf("missing %s hook matcher=%q command=%q in %#v", event, matcher, command, hookEntries(t, cfg, event))
+	return nil
+}
+
+func hookMatcherCommandCount(t *testing.T, cfg map[string]any, event, matcher, command string) int {
+	t.Helper()
+	count := 0
+	for _, entry := range hookEntries(t, cfg, event) {
+		group, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		gotMatcher, _ := group["matcher"].(string)
+		if gotMatcher != matcher {
+			continue
+		}
+		handlers, ok := codexHookList(group["hooks"])
+		if !ok {
+			continue
+		}
+		for _, handler := range handlers {
+			hm, ok := handler.(map[string]any)
+			if !ok {
+				continue
+			}
+			if got, _ := hm["command"].(string); got == command {
+				count++
+			}
 		}
 	}
 	return count

--- a/internal/hooks/codex.go
+++ b/internal/hooks/codex.go
@@ -29,9 +29,41 @@ func runCodex(data []byte, port int) {
 	switch {
 	case peek.HookEventName == "PreToolUse" && peek.ToolName == "Bash":
 		runPreToolUse(data, port, ModeEnrich)
+	case peek.HookEventName == "PreToolUse" && codexMCPReadPreToolUseTool(peek.ToolName):
+		runCodexMCPReadPreToolUse(data)
 	case peek.HookEventName == "PostToolUse" && peek.ToolName == "Bash":
 		runCodexPostToolUse(data, port)
 	}
+}
+
+func codexMCPReadPreToolUseTool(toolName string) bool {
+	switch toolName {
+	case gortexReadFileTool, gortexEditingContextTool:
+		return true
+	default:
+		return false
+	}
+}
+
+func runCodexMCPReadPreToolUse(data []byte) {
+	var input HookInput
+	if err := json.Unmarshal(data, &input); err != nil {
+		return
+	}
+	if input.HookEventName != "PreToolUse" || !codexMCPReadPreToolUseTool(input.ToolName) {
+		return
+	}
+
+	ctx := gortexReadNudge(input.ToolName, input.ToolInput)
+	if ctx == "" {
+		return
+	}
+	emitPreToolUse(HookOutput{
+		HookSpecificOutput: &HookSpecificOutput{
+			HookEventName:     "PreToolUse",
+			AdditionalContext: ctx,
+		},
+	})
 }
 
 func runCodexPostToolUse(data []byte, port int) {

--- a/internal/hooks/codex_test.go
+++ b/internal/hooks/codex_test.go
@@ -60,6 +60,140 @@ func TestRunCodexPreToolUseBashSoftAdditionalContext(t *testing.T) {
 	}
 }
 
+func TestRunCodexPreToolUseGortexMCPReadSoftAdditionalContext(t *testing.T) {
+	withForceCompress(t, false)
+	tests := []struct {
+		name string
+		tool string
+	}{
+		{
+			name: "read file",
+			tool: gortexReadFileTool,
+		},
+		{
+			name: "editing context",
+			tool: gortexEditingContextTool,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := codexPreToolPayload(tt.tool, `{"path":"internal/a.go"}`)
+			out := captureStdout(t, func() { runCodex(data, 0) })
+			if out == "" {
+				t.Fatal("expected Codex MCP read PreToolUse guidance, got empty output")
+			}
+			hso := decodeHookOutput(t, out).HookSpecificOutput
+			if hso == nil {
+				t.Fatalf("missing hookSpecificOutput: %s", out)
+			}
+			if hso.HookEventName != "PreToolUse" {
+				t.Fatalf("hookEventName=%q want PreToolUse", hso.HookEventName)
+			}
+			for _, want := range []string{"compress_bodies", "search_text", "keep"} {
+				if !strings.Contains(hso.AdditionalContext, want) {
+					t.Fatalf("additionalContext missing %q: %q", want, hso.AdditionalContext)
+				}
+			}
+			if hso.PermissionDecision != "" || hso.PermissionDecisionReason != "" {
+				t.Fatalf("Codex MCP read nudge must not deny: %#v", hso)
+			}
+		})
+	}
+}
+
+func TestRunCodexPreToolUseGortexMCPReadPermissiveModeStaysAdditionalContext(t *testing.T) {
+	withForceCompress(t, true)
+	tests := []struct {
+		name           string
+		permissionMode string
+	}{
+		{
+			name:           "auto",
+			permissionMode: "auto",
+		},
+		{
+			name:           "accept edits",
+			permissionMode: "acceptEdits",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := codexPreToolPayloadWithPermission(gortexReadFileTool, `{"path":"internal/a.go"}`, tt.permissionMode)
+			out := captureStdout(t, func() { runCodex(data, 0) })
+			if out == "" {
+				t.Fatal("expected Codex MCP read PreToolUse guidance, got empty output")
+			}
+			hso := decodeHookOutput(t, out).HookSpecificOutput
+			if hso == nil {
+				t.Fatalf("missing hookSpecificOutput: %s", out)
+			}
+			if !strings.Contains(hso.AdditionalContext, "compress_bodies") {
+				t.Fatalf("additionalContext missing compress_bodies guidance: %q", hso.AdditionalContext)
+			}
+			if hso.PermissionDecision != "" || hso.PermissionDecisionReason != "" {
+				t.Fatalf("Codex MCP read nudge must not emit permission decisions: %#v", hso)
+			}
+		})
+	}
+}
+
+func TestRunCodexPreToolUseGortexMCPReadSilentShapes(t *testing.T) {
+	withForceCompress(t, false)
+	tests := []struct {
+		name  string
+		tool  string
+		input string
+	}{
+		{
+			name:  "read_file compressed",
+			tool:  gortexReadFileTool,
+			input: `{"path":"internal/a.go","compress_bodies":true}`,
+		},
+		{
+			name:  "get_editing_context compressed",
+			tool:  gortexEditingContextTool,
+			input: `{"path":"internal/a.go","compress_bodies":true}`,
+		},
+		{
+			name:  "read_file max lines",
+			tool:  gortexReadFileTool,
+			input: `{"path":"internal/a.go","max_lines":80}`,
+		},
+		{
+			name:  "read_file max bytes",
+			tool:  gortexReadFileTool,
+			input: `{"path":"internal/a.go","max_bytes":4000}`,
+		},
+		{
+			name:  "get_editing_context max tokens",
+			tool:  gortexEditingContextTool,
+			input: `{"path":"internal/a.go","max_tokens":2000}`,
+		},
+		{
+			name:  "non-source file",
+			tool:  gortexReadFileTool,
+			input: `{"path":"README.md"}`,
+		},
+		{
+			name:  "other Gortex MCP tool",
+			tool:  gortexMCPToolPrefix + "search_symbols",
+			input: `{"path":"internal/a.go"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := codexPreToolPayload(tt.tool, tt.input)
+			out := captureStdout(t, func() { runCodex(data, 0) })
+			if out != "" {
+				t.Fatalf("expected silent no-op, got %q", out)
+			}
+		})
+	}
+}
+
 func TestRunCodexPostToolUseBashGrepOutputAdditionalContext(t *testing.T) {
 	port := stubBridge(t, nil,
 		map[string]struct{ ID, Name, Kind string }{
@@ -308,6 +442,14 @@ func TestRunCodexPostToolUseMalformedJSONNoop(t *testing.T) {
 
 func codexBashPayload(command string) []byte {
 	return []byte(`{"hook_event_name":"PreToolUse","tool_name":"Bash","session_id":"codex-shape","tool_input":{"command":` + strconv.Quote(command) + `}}`)
+}
+
+func codexPreToolPayload(toolName string, input string) []byte {
+	return []byte(`{"hook_event_name":"PreToolUse","tool_name":` + strconv.Quote(toolName) + `,"session_id":"codex-shape","tool_input":` + input + `}`)
+}
+
+func codexPreToolPayloadWithPermission(toolName string, input string, permissionMode string) []byte {
+	return []byte(`{"hook_event_name":"PreToolUse","tool_name":` + strconv.Quote(toolName) + `,"session_id":"codex-shape","permission_mode":` + strconv.Quote(permissionMode) + `,"tool_input":` + input + `}`)
 }
 
 func codexPostBashPayload(command string, response string) []byte {


### PR DESCRIPTION
## Summary

- Add a dedicated Codex `PreToolUse` matcher for Gortex MCP read-shaped tools:
  `mcp__gortex__read_file` and `mcp__gortex__get_editing_context`.
- Route those Codex MCP read tool events through a Codex-specific soft-only handler.
- Reuse the existing `gortexReadNudge` compress-bodies guidance without adding new policy.
- Keep Codex MCP read guidance advisory-only: emit `hookSpecificOutput.additionalContext`; no permission decision, deny, input rewrite, or output suppression.

## Design notes

- The Bash `PreToolUse` matcher remains separate from the MCP read-tool matcher.
- The Codex installer now manages two Gortex-owned `PreToolUse` entries: one for Bash and one for MCP read tools.
- Repeated apply remains idempotent; force refresh removes stale Gortex-owned `PreToolUse` entries and writes the two desired entries back.
- The MCP read-tool path intentionally does not call the generic `runPreToolUse` handler, so permissive `permission_mode` values cannot emit `permissionDecision:"allow"`.
- Claude, Gemini, and Antigravity behavior remains unchanged.

## Out of scope

- All other `mcp__gortex__*` tools
- PostToolUse MCP output
- `apply_patch`
- deny / enforcement behavior
- permission decisions
- input rewrite / `updatedInput`
- output suppression
- resolver / indexer / daemon / graph / MCP tool changes

## Tests

- `go test ./internal/agents/codex`
- `go test ./internal/hooks`
- `go test ./cmd/gortex`
- `git diff --check`