### PR TITLE
feat(agents): give Pi tool registrations their full description

### DIFF
--- a/cmd/gortex/testdata/agent-render/pi.txt
+++ b/cmd/gortex/testdata/agent-render/pi.txt
@@ -195,6 +195,7 @@ function normalizeToolCall(
 interface ToolDescriptor {
   name: string;
   summary?: string;
+  description?: string;
 }
 
 // presetListArgs maps the configured preset to `gortex tools list` flags.
@@ -250,9 +251,7 @@ function registerOneTool(pi: any, desc: ToolDescriptor): void {
   safeRegister(pi, {
     name,
     label: name,
-    description:
-      (desc.summary ? desc.summary + " " : "") +
-      "(Gortex graph tool — prefer over raw file reads.)",
+    description: (desc.description || desc.summary || name).trim(),
     // Pass-through arguments: the model supplies whatever the underlying
     // Gortex tool accepts; `gortex call` validates names + args server
     // side and suggests near-matches on a typo.
@@ -295,27 +294,37 @@ function registerGortexTools(pi: any): void {
 
 const SEARCH_TOOL_NAME = piToolName("tools_search");
 
-// parseToolSearchText parses `gortex tools search` output — one
-// "<name>  <summary>" line per match (tool names never contain whitespace),
-// skipping the "no tools match ..." line emitted when nothing matches.
-function parseToolSearchText(raw: string): ToolDescriptor[] {
-  const out: ToolDescriptor[] = [];
-  for (const line of raw.split("\n")) {
-    const t = line.trim();
-    if (!t || t.startsWith("no tools match")) continue;
-    const sp = t.search(/\s/);
-    if (sp < 0) {
-      out.push({ name: t });
-    } else {
-      out.push({ name: t.slice(0, sp), summary: t.slice(sp).trim() });
-    }
+// firstSentence returns the leading sentence of a description, up to and
+// including the first ". " boundary.
+function firstSentence(desc: string): string {
+  const t = desc.trim();
+  if (!t) return "";
+  const i = t.indexOf(". ");
+  return i >= 0 ? t.slice(0, i + 1).trim() : t;
+}
+
+// parseToolSearchJSON parses `gortex tools search --format json` output —
+// an array of {name, description}.
+function parseToolSearchJSON(raw: string): ToolDescriptor[] {
+  let parsed: Array<{ name: string; description?: string }>;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
   }
-  return out;
+  if (!Array.isArray(parsed)) return [];
+  return parsed
+    .filter((e) => e && typeof e.name === "string" && e.name)
+    .map((e) => ({
+      name: e.name,
+      description: e.description ?? "",
+      summary: firstSentence(e.description ?? ""),
+    }));
 }
 
 function searchTools(query: string, limit: number): ToolDescriptor[] {
-  return parseToolSearchText(
-    runGortex(["tools", "search", query, "--limit", String(limit)]),
+  return parseToolSearchJSON(
+    runGortex(["tools", "search", query, "--limit", String(limit), "--format", "json"]),
   );
 }
 

--- a/cmd/gortex/tools_cmd.go
+++ b/cmd/gortex/tools_cmd.go
@@ -16,6 +16,7 @@ var (
 	toolsListPreset   string
 	toolsListFormat   string
 	toolsSearchLimit  int
+	toolsSearchFormat string
 )
 
 // toolsDaemonTool is the daemon-tool relay seam so the tools subcommands can be
@@ -62,6 +63,7 @@ func init() {
 	toolsListCmd.Flags().StringVar(&toolsListFormat, "format", "text", "output format: text or json")
 
 	toolsSearchCmd.Flags().IntVar(&toolsSearchLimit, "limit", 10, "max number of tools to return")
+	toolsSearchCmd.Flags().StringVar(&toolsSearchFormat, "format", "text", "output format: text or json")
 
 	toolsCmd.AddCommand(toolsListCmd)
 	toolsCmd.AddCommand(toolsSearchCmd)
@@ -72,11 +74,12 @@ func init() {
 // toolDescriptorCLI mirrors mcp.ToolDescriptor's wire shape (the per-tool
 // catalog tool_profile returns in its `descriptors` array).
 type toolDescriptorCLI struct {
-	Name     string   `json:"name"`
-	Category string   `json:"category"`
-	Mutating bool     `json:"mutating"`
-	Presets  []string `json:"presets"`
-	Summary  string   `json:"summary"`
+	Name        string   `json:"name"`
+	Category    string   `json:"category"`
+	Mutating    bool     `json:"mutating"`
+	Presets     []string `json:"presets"`
+	Summary     string   `json:"summary"`
+	Description string   `json:"description"`
 }
 
 func runToolsList(cmd *cobra.Command, _ []string) error {
@@ -171,6 +174,19 @@ func runToolsSearch(cmd *cobra.Command, args []string) error {
 	}
 	entries := parseToolsSearchEntries(raw)
 	out := cmd.OutOrStdout()
+	if toolsSearchFormat == "json" {
+		type searchResultJSON struct {
+			Name        string `json:"name"`
+			Description string `json:"description"`
+		}
+		results := make([]searchResultJSON, 0, len(entries))
+		for _, e := range entries {
+			results = append(results, searchResultJSON{Name: e.Name, Description: strings.TrimSpace(e.Description)})
+		}
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(results)
+	}
 	if len(entries) == 0 {
 		fmt.Fprintf(out, "no tools match %q\n", query)
 		return nil

--- a/cmd/gortex/tools_cmd_test.go
+++ b/cmd/gortex/tools_cmd_test.go
@@ -19,6 +19,7 @@ func newToolsTestCmd(t *testing.T, run func(*cobra.Command, []string) error) (*c
 	toolsListPreset = ""
 	toolsListFormat = "text"
 	toolsSearchLimit = 10
+	toolsSearchFormat = "text"
 
 	buf := &bytes.Buffer{}
 	cmd := &cobra.Command{Use: "tools", RunE: run}
@@ -121,6 +122,19 @@ func TestToolsList_JSON(t *testing.T) {
 	require.Equal(t, "edit_file", descs[0].Name) // sorted by name
 }
 
+// TestToolDescriptorCLI_JSONIncludesDescription asserts the CLI-side mirror
+// of mcp.ToolDescriptor serializes the new Description field.
+func TestToolDescriptorCLI_JSONIncludesDescription(t *testing.T) {
+	d := toolDescriptorCLI{Name: "get_callers", Summary: "Show who calls a function.", Description: "Show who calls a function.\nReturns the caller subgraph."}
+	b, err := json.Marshal(d)
+	require.NoError(t, err)
+	require.Contains(t, string(b), `"description":"Show who calls a function.\nReturns the caller subgraph."`)
+
+	var round toolDescriptorCLI
+	require.NoError(t, json.Unmarshal(b, &round))
+	require.Equal(t, d, round)
+}
+
 // cannedToolsSearchStructured is the structured tools_search payload shape (a
 // `tools` array with name / description / input_schema).
 const cannedToolsSearchStructured = `{
@@ -180,6 +194,32 @@ func TestToolsSearch_FunctionsBlock(t *testing.T) {
 	out := buf.String()
 	require.Contains(t, out, "edit_file")
 	require.Contains(t, out, "Edit a file at a path")
+}
+
+// TestToolsSearch_JSON asserts `tools search --format json` emits the full
+// (untruncated) trimmed description per match, not just the first line.
+func TestToolsSearch_JSON(t *testing.T) {
+	orig := toolsDaemonTool
+	t.Cleanup(func() { toolsDaemonTool = orig })
+	toolsDaemonTool = func(string, string, map[string]any) (json.RawMessage, error) {
+		return json.RawMessage(cannedToolsSearchStructured), nil
+	}
+
+	cmd, buf := newToolsTestCmd(t, runToolsSearch)
+	toolsSearchFormat = "json"
+	t.Cleanup(func() { toolsSearchFormat = "text" })
+	require.NoError(t, runToolsSearch(cmd, []string{"callers"}))
+
+	type searchResultJSON struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	}
+	var results []searchResultJSON
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &results))
+	require.Len(t, results, 2)
+	require.Equal(t, "get_callers", results[0].Name)
+	require.Equal(t, "Show who calls a function across the graph.\nReturns the caller subgraph.", results[0].Description)
+	require.Equal(t, "get_call_chain", results[1].Name)
 }
 
 // TestToolsDescribe asserts `tools describe` issues a select:<name> query and

--- a/internal/agents/pi/extension/index.ts
+++ b/internal/agents/pi/extension/index.ts
@@ -194,6 +194,7 @@ function normalizeToolCall(
 interface ToolDescriptor {
   name: string;
   summary?: string;
+  description?: string;
 }
 
 // presetListArgs maps the configured preset to `gortex tools list` flags.
@@ -249,9 +250,7 @@ function registerOneTool(pi: any, desc: ToolDescriptor): void {
   safeRegister(pi, {
     name,
     label: name,
-    description:
-      (desc.summary ? desc.summary + " " : "") +
-      "(Gortex graph tool — prefer over raw file reads.)",
+    description: (desc.description || desc.summary || name).trim(),
     // Pass-through arguments: the model supplies whatever the underlying
     // Gortex tool accepts; `gortex call` validates names + args server
     // side and suggests near-matches on a typo.
@@ -294,27 +293,37 @@ function registerGortexTools(pi: any): void {
 
 const SEARCH_TOOL_NAME = piToolName("tools_search");
 
-// parseToolSearchText parses `gortex tools search` output — one
-// "<name>  <summary>" line per match (tool names never contain whitespace),
-// skipping the "no tools match ..." line emitted when nothing matches.
-function parseToolSearchText(raw: string): ToolDescriptor[] {
-  const out: ToolDescriptor[] = [];
-  for (const line of raw.split("\n")) {
-    const t = line.trim();
-    if (!t || t.startsWith("no tools match")) continue;
-    const sp = t.search(/\s/);
-    if (sp < 0) {
-      out.push({ name: t });
-    } else {
-      out.push({ name: t.slice(0, sp), summary: t.slice(sp).trim() });
-    }
+// firstSentence returns the leading sentence of a description, up to and
+// including the first ". " boundary.
+function firstSentence(desc: string): string {
+  const t = desc.trim();
+  if (!t) return "";
+  const i = t.indexOf(". ");
+  return i >= 0 ? t.slice(0, i + 1).trim() : t;
+}
+
+// parseToolSearchJSON parses `gortex tools search --format json` output —
+// an array of {name, description}.
+function parseToolSearchJSON(raw: string): ToolDescriptor[] {
+  let parsed: Array<{ name: string; description?: string }>;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
   }
-  return out;
+  if (!Array.isArray(parsed)) return [];
+  return parsed
+    .filter((e) => e && typeof e.name === "string" && e.name)
+    .map((e) => ({
+      name: e.name,
+      description: e.description ?? "",
+      summary: firstSentence(e.description ?? ""),
+    }));
 }
 
 function searchTools(query: string, limit: number): ToolDescriptor[] {
-  return parseToolSearchText(
-    runGortex(["tools", "search", query, "--limit", String(limit)]),
+  return parseToolSearchJSON(
+    runGortex(["tools", "search", query, "--limit", String(limit), "--format", "json"]),
   );
 }
 

--- a/internal/mcp/tool_catalog.go
+++ b/internal/mcp/tool_catalog.go
@@ -16,11 +16,12 @@ import (
 // (tool_presets.go), and a one-line Summary distilled from its MCP
 // Description.
 type ToolDescriptor struct {
-	Name     string   `json:"name"`
-	Category string   `json:"category"`
-	Mutating bool     `json:"mutating"`
-	Presets  []string `json:"presets"`
-	Summary  string   `json:"summary"`
+	Name        string   `json:"name"`
+	Category    string   `json:"category"`
+	Mutating    bool     `json:"mutating"`
+	Presets     []string `json:"presets"`
+	Summary     string   `json:"summary"`
+	Description string   `json:"description"`
 }
 
 // ToolDescriptors enumerates EVERY registered tool — both live (in the
@@ -63,11 +64,12 @@ func (s *Server) ToolDescriptors() []ToolDescriptor {
 	out := make([]ToolDescriptor, 0, len(names))
 	for name, e := range names {
 		out = append(out, ToolDescriptor{
-			Name:     name,
-			Category: toolCategory(name),
-			Mutating: daemon.IsMutating(name),
-			Presets:  presetsContaining(name),
-			Summary:  firstSentence(e.desc),
+			Name:        name,
+			Category:    toolCategory(name),
+			Mutating:    daemon.IsMutating(name),
+			Presets:     presetsContaining(name),
+			Summary:     firstSentence(e.desc),
+			Description: strings.TrimSpace(e.desc),
 		})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })

--- a/internal/mcp/tool_catalog_test.go
+++ b/internal/mcp/tool_catalog_test.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/zzet/gortex/internal/daemon"
@@ -65,6 +66,52 @@ func TestToolDescriptors_MutatingMatchesDaemon(t *testing.T) {
 		if want := daemon.MutatingTools[d.Name]; d.Mutating != want {
 			t.Errorf("tool %q Mutating = %v, want %v (daemon.MutatingTools)", d.Name, d.Mutating, want)
 		}
+	}
+}
+
+// TestToolDescriptors_DescriptionNonEmptyAndTrimmed asserts every descriptor
+// with a non-blank raw MCP description carries a matching, whitespace-trimmed
+// Description, and that Summary is never longer than Description (Summary is
+// derived from Description via firstSentence, so it can only truncate it).
+func TestToolDescriptors_DescriptionNonEmptyAndTrimmed(t *testing.T) {
+	srv := newFullTestServer(t)
+	for _, d := range srv.ToolDescriptors() {
+		if d.Description != strings.TrimSpace(d.Description) {
+			t.Errorf("tool %q Description is not trimmed: %q", d.Name, d.Description)
+		}
+		if d.Summary != "" && len(d.Summary) > len(d.Description) {
+			t.Errorf("tool %q Summary (%q) is longer than Description (%q)", d.Name, d.Summary, d.Description)
+		}
+		if d.Description == "" && d.Summary != "" {
+			t.Errorf("tool %q has a Summary but an empty Description", d.Name)
+		}
+	}
+}
+
+// TestFirstSentence_DivergesFromDescriptionOnMultiSentenceInput asserts the
+// Summary/Description split ToolDescriptors relies on: firstSentence
+// truncates at the first ". " boundary, but a period immediately followed by
+// a newline (no space) does not count as a boundary, so the whole
+// (multi-line) description passes through unchanged.
+func TestFirstSentence_DivergesFromDescriptionOnMultiSentenceInput(t *testing.T) {
+	tests := []struct {
+		name string
+		desc string
+		want string
+	}{
+		{"empty", "", ""},
+		{"whitespace only", "   \n\t ", ""},
+		{"single sentence", "Show who calls a function", "Show who calls a function"},
+		{"multi-sentence period-space", "Show who calls a function. Returns the caller subgraph.", "Show who calls a function."},
+		{"period-newline is not a boundary", "Show who calls a function.\nReturns the caller subgraph.", "Show who calls a function.\nReturns the caller subgraph."},
+		{"leading/trailing whitespace trimmed", "  Show who calls a function.  ", "Show who calls a function."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := firstSentence(tt.desc); got != tt.want {
+				t.Errorf("firstSentence(%q) = %q, want %q", tt.desc, got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Brings the Pi extension's tool descriptions to parity with what real MCP clients already receive: `gortex tools search` gains a `--format json` mode, and `ToolDescriptor` (Go + CLI mirror) now carries the full untruncated `Description` alongside the existing first-sentence `Summary`. Pi's `registerOneTool` uses it directly instead of synthesizing a shortened description — removing a Pi-specific truncation that no other MCP agent was subject to.

## Changes

- Add `Description` field to `mcp.ToolDescriptor` and `cmd/gortex`'s `toolDescriptorCLI` mirror, populated via `strings.TrimSpace(e.desc)`.
- Add `--format json` to `gortex tools search`, emitting `{name, description}` per match instead of the truncated single-line text listing.
- Update the Pi extension (`internal/agents/pi/extension/index.ts`) to call `tools search --format json`, parse it with a new `parseToolSearchJSON`/`firstSentence`, and register each tool with its full `description` (falling back to `summary`, then `name`) instead of a hardcoded "(Gortex graph tool — prefer over raw file reads.)" suffix.

## Testing

- [x] All tests pass (`go test ./internal/mcp/... ./cmd/gortex/...`)
- [x] New tests added for new functionality
- [ ] Benchmarks run if performance-relevant (not performance-relevant)

## Checklist

- [x] Code follows existing patterns in the codebase
- [x] No unnecessary abstractions added
- [ ] Language extractor includes `Meta["methods"]` for interfaces (if applicable)
- [ ] Methods have `EdgeMemberOf` edges to their containing type (if applicable)
