### PR TITLE
Recover missing C function usages + faster LSP enrichment

### DIFF
--- a/internal/parser/detect_content.go
+++ b/internal/parser/detect_content.go
@@ -133,6 +133,16 @@ func sniffAmbiguous(filePath, ext string, content []byte) (string, bool) {
 		if hasCppMarkers(probe) {
 			return "cpp", true
 		}
+	case ".inc":
+		// A contested extension: assembly, PHP, and Pascal each claim it by
+		// default. Reroute to C only when the fragment carries an unmistakable
+		// C signal (a C preprocessor directive, or a C block comment alongside
+		// braces) and none of the other claimants' markers — so an X-macro /
+		// generated-C ".inc" is parsed as C while PHP / Pascal / asm includes
+		// keep their default language untouched.
+		if hasCFragmentMarkers(probe) && !hasPHPMarkers(probe) && !hasPascalMarkers(probe) {
+			return "c", true
+		}
 	case ".m":
 		// Objective-C / MATLAB / Mathematica source.
 		if hasObjCMarkers(probe) {
@@ -212,6 +222,53 @@ func hasCppMarkers(b []byte) bool {
 	} {
 		if bytes.Contains(b, []byte(m)) {
 			return true
+		}
+	}
+	return false
+}
+
+// hasCFragmentMarkers reports whether a contested-extension file carries an
+// unmistakable C signal — a line-leading C preprocessor directive, or a C block
+// comment together with a brace (the shape of a generated initializer / X-macro
+// table). Deliberately conservative so it never steals a PHP / Pascal / asm
+// include.
+func hasCFragmentMarkers(b []byte) bool {
+	for _, line := range bytes.Split(b, []byte("\n")) {
+		t := bytes.TrimLeft(line, " \t")
+		for _, d := range [][]byte{
+			[]byte("#include"), []byte("#define"), []byte("#ifndef"),
+			[]byte("#ifdef"), []byte("#pragma"), []byte("#undef"), []byte("#if "),
+		} {
+			if bytes.HasPrefix(t, d) {
+				return true
+			}
+		}
+	}
+	return bytes.Contains(b, []byte("/*")) && bytes.Contains(b, []byte("{"))
+}
+
+// hasPHPMarkers reports whether the content opens a PHP block — the marker that
+// keeps a Drupal `.inc` / `.module` include on the PHP extractor.
+func hasPHPMarkers(b []byte) bool {
+	return bytes.Contains(b, []byte("<?php")) || bytes.Contains(b, []byte("<?=")) ||
+		bytes.Contains(b, []byte("<?\n")) || bytes.Contains(b, []byte("<? "))
+}
+
+// hasPascalMarkers reports whether the content looks like a Pascal / Delphi
+// include — a unit/section keyword or a `{$...}` compiler directive.
+func hasPascalMarkers(b []byte) bool {
+	if bytes.Contains(b, []byte("{$")) {
+		return true
+	}
+	for _, line := range bytes.Split(b, []byte("\n")) {
+		t := bytes.ToLower(bytes.TrimLeft(line, " \t"))
+		for _, kw := range [][]byte{
+			[]byte("unit "), []byte("program "), []byte("interface"),
+			[]byte("implementation"), []byte("procedure "), []byte("uses "),
+		} {
+			if bytes.HasPrefix(t, kw) {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/parser/detect_content_test.go
+++ b/internal/parser/detect_content_test.go
@@ -117,6 +117,33 @@ func TestDetectLanguageContent_AmbiguousHeader(t *testing.T) {
 	assert.Equal(t, "objc", lang)
 }
 
+func TestDetectLanguageContent_CFragments(t *testing.T) {
+	r := NewRegistry()
+	r.Register(&mockExtractor{lang: "c", exts: []string{".c", ".h", ".def"}})
+	r.Register(&mockExtractor{lang: "php", exts: []string{".php", ".inc"}})
+	r.Register(&mockExtractor{lang: "pascal", exts: []string{".pas", ".inc"}})
+	r.Register(&mockExtractor{lang: "assembly", exts: []string{".asm", ".inc"}})
+
+	// A generated .def command table maps to C unconditionally (uncontested).
+	lang, ok := r.DetectLanguageContent("src/commands.def", []byte("{MAKE_CMD(\"get\", getCommand, 2)},\n"))
+	assert.True(t, ok)
+	assert.Equal(t, "c", lang)
+
+	// A clearly-C .inc fragment is content-routed to C despite the contested
+	// extension.
+	lang, ok = r.DetectLanguageContent("src/table.inc", []byte("#include \"server.h\"\n{MAKE_CMD(\"x\", xCommand)},\n"))
+	assert.True(t, ok)
+	assert.Equal(t, "c", lang)
+
+	// A PHP include is never stolen by the C reroute.
+	lang, _ = r.DetectLanguageContent("web/util.inc", []byte("<?php\nfunction f() {}\n"))
+	assert.NotEqual(t, "c", lang, "php include must not be detected as C")
+
+	// A Pascal include is never stolen by the C reroute.
+	lang, _ = r.DetectLanguageContent("src/types.inc", []byte("unit Types;\ninterface\nprocedure Foo;\n"))
+	assert.NotEqual(t, "c", lang, "pascal include must not be detected as C")
+}
+
 func TestDetectLanguageContent_AmbiguousDotM(t *testing.T) {
 	r := ambiguityRegistry()
 

--- a/internal/parser/languages/c.go
+++ b/internal/parser/languages/c.go
@@ -75,8 +75,16 @@ func NewCExtractor() *CExtractor {
 	}
 }
 
-func (e *CExtractor) Language() string     { return "c" }
-func (e *CExtractor) Extensions() []string { return []string{".c", ".h"} }
+func (e *CExtractor) Language() string { return "c" }
+
+// Extensions includes ".def" — the conventional extension for a generated C
+// fragment #include'd into a translation unit (an X-macro / command table like
+// redis's src/commands.def). No other extractor claims ".def"; a non-C ".def"
+// (a Windows linker module-definition file) degrades to tree-sitter ERROR nodes
+// and emits nothing meaningful. ".inc" is contested (assembly / PHP / Pascal),
+// so a clearly-C ".inc" fragment is routed to this extractor by content sniffing
+// (sniffAmbiguous) instead of an extension claim.
+func (e *CExtractor) Extensions() []string { return []string{".c", ".h", ".def"} }
 
 // --- Deferred match buffers ----------------------------------------
 
@@ -220,6 +228,7 @@ func (e *CExtractor) Extract(filePath string, src []byte) (*parser.ExtractionRes
 	captureValueRefCandidates(result, root, filePath, src)
 	captureFnValueCandidates(result, root, filePath, src)
 	captureCFnPointerDispatch(result, root, filePath, src)
+	captureCFnAddressRefs(result, root, filePath, fileID, src)
 	return result, nil
 }
 

--- a/internal/parser/languages/c.go
+++ b/internal/parser/languages/c.go
@@ -17,13 +17,22 @@ import (
 // Extract can branch on which name is set.
 const qCAll = `
 [
-  (function_definition
-    declarator: (function_declarator
-      declarator: (identifier) @func.name)) @func.def
+  (function_definition) @func.def
 
   (declaration
     declarator: (function_declarator
       declarator: (identifier) @proto.name)) @proto.def
+
+  (declaration
+    declarator: (pointer_declarator
+      declarator: (function_declarator
+        declarator: (identifier) @proto.name))) @proto.def
+
+  (declaration
+    declarator: (pointer_declarator
+      declarator: (pointer_declarator
+        declarator: (function_declarator
+          declarator: (identifier) @proto.name)))) @proto.def
 
   (struct_specifier
     name: (type_identifier) @struct.name) @struct.def
@@ -217,8 +226,17 @@ func (e *CExtractor) Extract(filePath string, src []byte) (*parser.ExtractionRes
 // --- Per-match emit helpers -----------------------------------------
 
 func (e *CExtractor) emitFunction(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen map[string]bool) {
-	name := m.Captures["func.name"].Text
 	def := m.Captures["func.def"]
+	// The name lives at the bottom of the declarator chain. A plain
+	// `int f()` nests function_declarator directly, but a pointer-return
+	// `robj *f()` / `robj **f()` wraps it in one or two pointer_declarators
+	// (and a fn-pointer-returning signature adds a parenthesized_declarator).
+	// cDeclName peels every wrapper down to the identifier, so the extractor
+	// no longer drops pointer-return definitions on the floor.
+	name := cDeclName(def.Node.ChildByFieldName("declarator"), src)
+	if name == "" {
+		return
+	}
 	id := filePath + "::" + name
 	if seen[id] {
 		return

--- a/internal/parser/languages/c_fnaddr.go
+++ b/internal/parser/languages/c_fnaddr.go
@@ -1,0 +1,159 @@
+package languages
+
+import (
+	"strconv"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	sitter "github.com/zzet/gortex/internal/parser/tsitter"
+)
+
+// C cross-file function-address references.
+//
+// A function used as a *value* rather than called — a command-table macro
+// argument (`{MAKE_CMD("get", ..., getCommand, ...)}`), a function-pointer
+// comparison (`c->cmd->proc != execCommand`), a function-pointer assignment, an
+// aggregate initializer element, or `&fn` — is a genuine reference the static
+// call graph misses. C has a flat extern namespace, so the referenced function
+// almost always lives in another translation unit; captureFnValueCandidates
+// pre-filters to same-file functions and therefore drops these entirely.
+//
+// This pass captures the bare identifier in those value positions when the name
+// is NOT declared in the current file (so it can only bind cross-module) and is
+// not a parameter / local. It emits the same fn-value candidate the resolver
+// gate already understands, marked ungated so ResolveFnValueCallbacks binds it
+// to a uniquely-named, non-file-local function anywhere in the repo. Unlike the
+// shared pass it attributes a file-scope reference (a command table lives
+// outside any function) to the file node, so a table entry becomes a usage.
+//
+// Flood control: value-position-only, plus dropping any name the file declares
+// (functions handled by the gated pass, variables / constants / types) or that
+// is a parameter / local. What survives is the small set of free identifiers a
+// gate lookup can turn into a real cross-TU function edge.
+func captureCFnAddressRefs(result *parser.ExtractionResult, root *sitter.Node, filePath, fileID string, src []byte) {
+	if root == nil || result == nil {
+		return
+	}
+	sameFileFunc := map[string]bool{}
+	localDecl := map[string]bool{}
+	for _, n := range result.Nodes {
+		if n == nil || n.FilePath != filePath {
+			continue
+		}
+		switch n.Kind {
+		case graph.KindFunction, graph.KindMethod:
+			sameFileFunc[n.Name] = true
+		case graph.KindVariable, graph.KindConstant, graph.KindType:
+			localDecl[n.Name] = true
+		}
+	}
+	shadowed := cCollectLocalNames(root, src)
+
+	funcRanges := buildFuncRanges(result)
+	seen := map[string]bool{}
+	var cands []FnValueCandidate
+	walkNodes(root, func(n *sitter.Node) {
+		if n.Type() != "identifier" {
+			return
+		}
+		form, ok := cFnAddressPosition(n)
+		if !ok {
+			return
+		}
+		name := n.Content(src)
+		if name == "" || isCFnAddressNonTarget(name) {
+			return
+		}
+		// A name the file itself declares (function / variable / constant /
+		// type) or that is a parameter / local can never be a cross-TU
+		// function address — resolve it locally or not at all.
+		if sameFileFunc[name] || localDecl[name] || shadowed[name] {
+			return
+		}
+		// Defensive callee guard: positions above exclude the callee, but a
+		// macro-call argument that is itself a call (`f(g())`) must not treat
+		// the inner callee as a value.
+		if byteAfterIdentStartsCall(src, int(n.EndByte())) {
+			return
+		}
+		line := int(n.StartPoint().Row) + 1
+		from := findEnclosingFunc(funcRanges, line)
+		if from == "" {
+			from = fileID // file-scope reference (command / dispatch table)
+		}
+		key := from + "\x00" + name + "\x00" + strconv.Itoa(line)
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		cands = append(cands, FnValueCandidate{
+			FromID: from, Name: name, FilePath: filePath, Line: line,
+			Form: form, Lang: "c", Ungated: true,
+		})
+	})
+	EmitFnValueCandidates(result, cands)
+}
+
+// cFnAddressPosition reports whether an identifier node sits in a C value
+// position that can hold a function address, and the fn_ref_form to tag ("" for
+// a plain value). These positions cover the generated-table shape: a macro /
+// call argument (`MAKE_CMD(..., getCommand, ...)`), an aggregate initializer
+// element (`{ ..., getCommand }`), and a designated initializer value
+// (`{ .proc = getCommand }`).
+func cFnAddressPosition(n *sitter.Node) (string, bool) {
+	p := n.Parent()
+	if p == nil {
+		return "", false
+	}
+	switch p.Type() {
+	case "argument_list", "initializer_list":
+		return "", true
+	case "initializer_pair":
+		if isFieldChild(p, "value", n) {
+			return "", true
+		}
+	}
+	return "", false
+}
+
+// isFieldChild reports whether n is exactly the `field`-named child of p (by
+// byte span), so an identifier is recognised only in the intended slot.
+func isFieldChild(p *sitter.Node, field string, n *sitter.Node) bool {
+	c := p.ChildByFieldName(field)
+	return c != nil && c.StartByte() == n.StartByte() && c.EndByte() == n.EndByte()
+}
+
+// cCollectLocalNames gathers parameter and initialised-local declarator names
+// across the file. A function address is never a parameter or local, so these
+// names are dropped from the cross-file candidate set — the dominant flood
+// source (every call passes locals / params by value).
+func cCollectLocalNames(root *sitter.Node, src []byte) map[string]bool {
+	out := map[string]bool{}
+	walkNodes(root, func(n *sitter.Node) {
+		switch n.Type() {
+		case "parameter_declaration":
+			if d := n.ChildByFieldName("declarator"); d != nil {
+				if name := cDeclName(d, src); name != "" {
+					out[name] = true
+				}
+			}
+		case "init_declarator":
+			if name := cDeclName(n.ChildByFieldName("declarator"), src); name != "" {
+				out[name] = true
+			}
+		}
+	})
+	return out
+}
+
+// isCFnAddressNonTarget reports whether a name is a C literal / keyword /
+// builtin constant that can never be a function address, so the capture skips it
+// before the candidate is emitted (the resolver gate would drop it anyway).
+func isCFnAddressNonTarget(name string) bool {
+	switch name {
+	case "NULL", "sizeof", "offsetof", "va_arg", "va_start", "va_end",
+		"true", "false", "nil", "Nil":
+		return true
+	}
+	return false
+}

--- a/internal/parser/languages/c_fnaddr.go
+++ b/internal/parser/languages/c_fnaddr.go
@@ -96,21 +96,47 @@ func captureCFnAddressRefs(result *parser.ExtractionResult, root *sitter.Node, f
 
 // cFnAddressPosition reports whether an identifier node sits in a C value
 // position that can hold a function address, and the fn_ref_form to tag ("" for
-// a plain value). These positions cover the generated-table shape: a macro /
-// call argument (`MAKE_CMD(..., getCommand, ...)`), an aggregate initializer
-// element (`{ ..., getCommand }`), and a designated initializer value
-// (`{ .proc = getCommand }`).
+// a plain value, "address_of" for `&fn`). Positions cover the generated-table
+// shape — a macro / call argument (`MAKE_CMD(..., getCommand, ...)`), an
+// aggregate initializer element (`{ ..., getCommand }`), a designated
+// initializer value (`{ .proc = getCommand }`) — and the in-function
+// function-pointer idioms: a `==` / `!=` comparison (`c->cmd->proc !=
+// execCommand`), an assignment or declaration-initializer right-hand side
+// (`c->proc = execCommand`, `cmdProc p = execCommand`), a return operand, and
+// `&fn`.
 func cFnAddressPosition(n *sitter.Node) (string, bool) {
 	p := n.Parent()
 	if p == nil {
 		return "", false
 	}
 	switch p.Type() {
-	case "argument_list", "initializer_list":
+	case "argument_list", "initializer_list", "return_statement":
 		return "", true
 	case "initializer_pair":
 		if isFieldChild(p, "value", n) {
 			return "", true
+		}
+	case "assignment_expression":
+		if isFieldChild(p, "right", n) {
+			return "", true
+		}
+	case "init_declarator":
+		if isFieldChild(p, "value", n) {
+			return "", true
+		}
+	case "binary_expression":
+		// A function pointer is compared for identity, never ordered — only
+		// `==` / `!=` operands are candidate function addresses.
+		if op := p.ChildByFieldName("operator"); op != nil {
+			if t := op.Type(); t == "==" || t == "!=" {
+				return "", true
+			}
+		}
+	case "pointer_expression":
+		// `&fn` address-of. tree-sitter-c models it as a pointer_expression
+		// with a '&' operator; a '*' operator is a dereference, not a value.
+		if op := p.ChildByFieldName("operator"); op != nil && op.Type() == "&" {
+			return "address_of", true
 		}
 	}
 	return "", false

--- a/internal/parser/languages/c_ptr_return_test.go
+++ b/internal/parser/languages/c_ptr_return_test.go
@@ -1,0 +1,87 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// TestCPointerReturnFunctions verifies that pointer-return function
+// definitions and prototypes produce nodes, and that call edges from inside a
+// pointer-return function body are attributed to the enclosing function (which
+// only works once the enclosing node exists).
+func TestCPointerReturnFunctions(t *testing.T) {
+	src := []byte(`
+robj *streamDup(robj *o) {
+    return copyObject(o);
+}
+
+static inline list *watchedKeyGetClients(int i) {
+    return listCreate();
+}
+
+robj **vectorDup(robj **v);
+
+int plain(void) { return 0; }
+`)
+	e := NewCExtractor()
+	res, err := e.Extract("t.c", src)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	nodes := map[string]*graph.Node{}
+	for _, n := range res.Nodes {
+		if n.Kind == graph.KindFunction {
+			nodes[n.Name] = n
+		}
+	}
+
+	for _, name := range []string{"streamDup", "watchedKeyGetClients", "vectorDup", "plain"} {
+		if nodes[name] == nil {
+			t.Errorf("expected function node %q, missing", name)
+		}
+	}
+
+	// static inline pointer-return keeps its file-local linkage stamp.
+	if n := nodes["watchedKeyGetClients"]; n != nil {
+		if v, _ := n.Meta["scope_static"].(bool); !v {
+			t.Errorf("watchedKeyGetClients should be scope_static, meta=%v", n.Meta)
+		}
+	}
+	// streamDup is not static.
+	if n := nodes["streamDup"]; n != nil {
+		if _, ok := n.Meta["scope_static"]; ok {
+			t.Errorf("streamDup should not be scope_static")
+		}
+	}
+	// The prototype-only vectorDup is marked as a prototype.
+	if n := nodes["vectorDup"]; n != nil {
+		if v, _ := n.Meta["prototype"].(bool); !v {
+			t.Errorf("vectorDup should be a prototype, meta=%v", n.Meta)
+		}
+	}
+
+	// The call to copyObject inside streamDup's body must be attributed to
+	// streamDup — the knock-on fix: without an enclosing node, the call edge
+	// is dropped.
+	var found bool
+	for _, ed := range res.Edges {
+		if ed.Kind == graph.EdgeCalls && ed.From == "t.c::streamDup" && ed.To == "unresolved::copyObject" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected call edge streamDup -> copyObject; edges=%v", callEdges(res.Edges))
+	}
+}
+
+func callEdges(edges []*graph.Edge) []string {
+	var out []string
+	for _, e := range edges {
+		if e.Kind == graph.EdgeCalls {
+			out = append(out, e.From+" -> "+e.To)
+		}
+	}
+	return out
+}

--- a/internal/parser/languages/cpp.go
+++ b/internal/parser/languages/cpp.go
@@ -40,6 +40,22 @@ const qCppAll = `
     declarator: (function_declarator
       declarator: (identifier) @func.name)) @func.def
 
+  (function_definition
+    declarator: (pointer_declarator
+      declarator: (function_declarator
+        declarator: (identifier) @func.name))) @func.def
+
+  (function_definition
+    declarator: (pointer_declarator
+      declarator: (pointer_declarator
+        declarator: (function_declarator
+          declarator: (identifier) @func.name)))) @func.def
+
+  (function_definition
+    declarator: (reference_declarator
+      (function_declarator
+        declarator: (identifier) @func.name))) @func.def
+
   (preproc_include
     path: (_) @include.path) @include.def
 
@@ -488,23 +504,64 @@ func (e *CppExtractor) emitInclude(m parser.QueryResult, filePath, fileID string
 // --- Helpers --------------------------------------------------------
 
 // extractFuncName walks a function_definition node to find the function name.
-// It handles both `identifier` (free functions) and `field_identifier` (methods).
+// It handles both `identifier` (free functions) and `field_identifier` (methods),
+// and peels pointer / reference / parenthesized declarator wrappers so a
+// pointer-return method (`robj *Cls::bar() {…}`, `Widget &make() {…}`) is not
+// dropped — the function_declarator nests one or two levels below the outer
+// declarator in those signatures.
 func extractFuncName(funcNode *sitter.Node, src []byte) string {
-	for i, _nc := 0, int(funcNode.NamedChildCount()); i < _nc; i++ {
-		child := funcNode.NamedChild(i)
-		if child.Type() == "function_declarator" {
-			for j, _nc := 0, int(child.NamedChildCount()); j < _nc; j++ {
-				gc := child.NamedChild(j)
-				switch gc.Type() {
-				case "identifier", "field_identifier", "destructor_name":
-					return gc.Content(src)
-				case "qualified_identifier":
-					return lastIdentifier(gc, src)
-				}
-			}
+	fd := cppFunctionDeclarator(funcNode.ChildByFieldName("declarator"))
+	if fd == nil {
+		return ""
+	}
+	for j, _nc := 0, int(fd.NamedChildCount()); j < _nc; j++ {
+		gc := fd.NamedChild(j)
+		switch gc.Type() {
+		case "identifier", "field_identifier", "destructor_name", "operator_name":
+			return gc.Content(src)
+		case "qualified_identifier":
+			return lastIdentifier(gc, src)
 		}
 	}
 	return ""
+}
+
+// cppFunctionDeclarator descends a declarator through pointer / reference /
+// parenthesized wrappers to the function_declarator that carries the name, or
+// nil when the declarator does not resolve to a function. Bounds the walk so a
+// pathological tree cannot loop.
+func cppFunctionDeclarator(decl *sitter.Node) *sitter.Node {
+	for i := 0; decl != nil && i < 8; i++ {
+		switch decl.Type() {
+		case "function_declarator":
+			return decl
+		case "pointer_declarator", "reference_declarator", "parenthesized_declarator":
+			decl = cppInnerDeclarator(decl)
+		default:
+			return nil
+		}
+	}
+	return nil
+}
+
+// cppInnerDeclarator returns the declarator nested inside a wrapper declarator:
+// the `declarator` field when the grammar names it (pointer_declarator), else
+// the first declarator-shaped named child (reference_declarator and
+// parenthesized_declarator carry it positionally).
+func cppInnerDeclarator(decl *sitter.Node) *sitter.Node {
+	if inner := decl.ChildByFieldName("declarator"); inner != nil {
+		return inner
+	}
+	for i, _nc := 0, int(decl.NamedChildCount()); i < _nc; i++ {
+		c := decl.NamedChild(i)
+		switch c.Type() {
+		case "function_declarator", "pointer_declarator", "reference_declarator",
+			"parenthesized_declarator", "identifier", "field_identifier",
+			"qualified_identifier", "destructor_name", "operator_name":
+			return c
+		}
+	}
+	return nil
 }
 
 // lastIdentifier extracts the last identifier from a qualified_identifier.

--- a/internal/resolver/c_cmdtable_test.go
+++ b/internal/resolver/c_cmdtable_test.go
@@ -1,0 +1,94 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+// loadCSources extracts each C-family fixture with the C extractor and loads
+// its nodes/edges into a fresh graph — the faithful extract→resolve harness for
+// generated-table reference recovery.
+func loadCSources(t *testing.T, files map[string]string) graph.Store {
+	t.Helper()
+	g := graph.New()
+	c := languages.NewCExtractor()
+	for path, src := range files {
+		r, err := c.Extract(path, []byte(src))
+		if err != nil {
+			t.Fatalf("extract %s: %v", path, err)
+		}
+		for _, n := range r.Nodes {
+			g.AddNode(n)
+		}
+		for _, e := range r.Edges {
+			g.AddEdge(e)
+		}
+	}
+	return g
+}
+
+func refEdgeAt(g graph.Store, from string, line int) *graph.Edge {
+	for _, e := range g.GetOutEdges(from) {
+		if e.Kind == graph.EdgeReferences && e.Line == line && e.Meta != nil {
+			if v, _ := e.Meta["via"].(string); v == fnValueRegistrationVia {
+				return e
+			}
+		}
+	}
+	return nil
+}
+
+// TestCCommandTableReferences pins the redis command-table shape: a generated
+// `.def` fragment holding `MAKE_CMD(..., fooCommand, ...)` rows produces a usage
+// edge from the fragment to the command function defined in another translation
+// unit. Without it, find_usages(fooCommand) returns zero and mislabels the
+// function as dead.
+func TestCCommandTableReferences(t *testing.T) {
+	g := loadCSources(t, map[string]string{
+		"commands.def": "" +
+			"struct redisCommand redisCommandTable[] = {\n" + // line 1
+			"{MAKE_CMD(\"get\", getCommand, 2)},\n" + //         line 2
+			"{MAKE_CMD(\"strlen\", strlenCommand, 2)},\n" + //   line 3
+			"};\n",
+		"t_string.c": "" +
+			"robj *getCommand(client *c) { return lookupKey(c); }\n" +
+			"void strlenCommand(client *c) { addReplyLongLong(c, 0); }\n",
+	})
+
+	require.Equal(t, "t_string.c::getCommand", resolveUniqueFnValue(g, "getCommand"),
+		"the pointer-return command function must be a real node")
+
+	ResolveFnValueCallbacks(g)
+
+	get := refEdgeAt(g, "commands.def", 2)
+	require.NotNil(t, get, "MAKE_CMD row must reference getCommand")
+	assert.Equal(t, "t_string.c::getCommand", get.To)
+	assert.Equal(t, "getCommand", get.Meta["fn_value_name"])
+
+	strlen := refEdgeAt(g, "commands.def", 3)
+	require.NotNil(t, strlen, "MAKE_CMD row must reference strlenCommand")
+	assert.Equal(t, "t_string.c::strlenCommand", strlen.To)
+}
+
+// TestCCommandTableDesignatedInitializer covers the designated-initializer table
+// form `{ .proc = fooCommand }`, not just the macro-call form.
+func TestCCommandTableDesignatedInitializer(t *testing.T) {
+	g := loadCSources(t, map[string]string{
+		"table.c": "" +
+			"struct cmd table[] = {\n" +
+			"{ .name = \"ping\", .proc = pingCommand },\n" + // line 2
+			"};\n",
+		"server.c": "void pingCommand(client *c) { addReply(c); }\n",
+	})
+
+	ResolveFnValueCallbacks(g)
+
+	e := refEdgeAt(g, "table.c", 2)
+	require.NotNil(t, e, "designated .proc initializer must reference pingCommand")
+	assert.Equal(t, "server.c::pingCommand", e.To)
+}

--- a/internal/resolver/c_fnaddr_test.go
+++ b/internal/resolver/c_fnaddr_test.go
@@ -1,0 +1,92 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCFnAddressCrossFileComparison pins the classic function-pointer identity
+// check: `c->cmd->proc != execCommand` in one translation unit references a
+// function defined in another. C's flat extern namespace makes these bind
+// repo-globally.
+func TestCFnAddressCrossFileComparison(t *testing.T) {
+	g := loadCSources(t, map[string]string{
+		"cmd.h":  "typedef void (*cmdProc)(void);\n",
+		"exec.c": "void execCommand(void) {}\n",
+		"server.c": "" +
+			"int isExec(cmdProc p) {\n" + // line 1
+			"  return p != execCommand;\n" + // line 2
+			"}\n",
+	})
+	ResolveFnValueCallbacks(g)
+	e := refEdgeAt(g, "server.c::isExec", 2)
+	require.NotNil(t, e, "cross-file function-address comparison must bind")
+	assert.Equal(t, "exec.c::execCommand", e.To)
+}
+
+// TestCFnAddressAssignment covers a function-pointer assignment right-hand side.
+func TestCFnAddressAssignment(t *testing.T) {
+	g := loadCSources(t, map[string]string{
+		"exec.c": "void execCommand(void) {}\n",
+		"wire.c": "" +
+			"void wire(cmdProc *slot) {\n" + // line 1
+			"  *slot = execCommand;\n" + // line 2
+			"}\n",
+	})
+	ResolveFnValueCallbacks(g)
+	e := refEdgeAt(g, "wire.c::wire", 2)
+	require.NotNil(t, e, "function-pointer assignment must bind")
+	assert.Equal(t, "exec.c::execCommand", e.To)
+}
+
+// TestCFnAddressAmpersand covers the `&fn` address-of form and its tag.
+func TestCFnAddressAmpersand(t *testing.T) {
+	g := loadCSources(t, map[string]string{
+		"h.c": "void handler(void) {}\n",
+		"reg.c": "" +
+			"void setup(void) {\n" + // line 1
+			"  install(&handler);\n" + // line 2
+			"}\n",
+	})
+	ResolveFnValueCallbacks(g)
+	e := refEdgeAt(g, "reg.c::setup", 2)
+	require.NotNil(t, e, "&handler must bind")
+	assert.Equal(t, "h.c::handler", e.To)
+	assert.Equal(t, "address_of", e.Meta["fn_ref_form"])
+}
+
+// TestCFnAddressStaticNotCrossFile pins the scope_static guard: a file-local
+// static function is invisible to another translation unit, so a same-named
+// cross-file reference must not bind it.
+func TestCFnAddressStaticNotCrossFile(t *testing.T) {
+	g := loadCSources(t, map[string]string{
+		"a.c": "static void helper(void) {}\n",
+		"b.c": "" +
+			"void use(cmdProc *slot) {\n" + // line 1
+			"  *slot = helper;\n" + // line 2
+			"}\n",
+	})
+	ResolveFnValueCallbacks(g)
+	assert.Nil(t, refEdgeAt(g, "b.c::use", 2),
+		"a cross-file reference must not bind a file-local static function")
+}
+
+// TestCFnAddressSameFileStaticWins pins same-file precedence: when a static in
+// the referencing file and an extern elsewhere share a name, the same-file
+// definition is chosen.
+func TestCFnAddressSameFileStaticWins(t *testing.T) {
+	g := loadCSources(t, map[string]string{
+		"a.c": "" +
+			"static void dispatch(void) {}\n" + // line 1
+			"void user(void) {\n" + // line 2
+			"  register_cb(dispatch);\n" + // line 3
+			"}\n",
+		"c.c": "void dispatch(void) {}\n", // extern, different file
+	})
+	ResolveFnValueCallbacks(g)
+	e := refEdgeAt(g, "a.c::user", 3)
+	require.NotNil(t, e, "same-file dispatch must bind")
+	assert.Equal(t, "a.c::dispatch", e.To, "same-file static wins over cross-file extern")
+}

--- a/internal/resolver/fn_value_gate.go
+++ b/internal/resolver/fn_value_gate.go
@@ -178,12 +178,42 @@ func resolveUniqueFnValue(g graph.Store, name string) string {
 	return match
 }
 
-// resolveFnValueCrossModule binds a qualified-path function value to a
-// uniquely-named function/method anywhere in the repo. The same-file path is
-// preferred by the caller; this is the cross-module fallback for an explicit
-// path value.
+// resolveFnValueCrossModule binds a function value to a uniquely-named
+// function/method anywhere in the repo, skipping any candidate with file-local
+// linkage (a C/C++ `static` function, stamped scope_static): such a definition
+// is invisible outside its translation unit, so a cross-module reference can
+// never target it, and a same-named static in an unrelated file must not make
+// the name look ambiguous. The same-file path is preferred by the caller; this
+// is the cross-module fallback.
 func resolveFnValueCrossModule(g graph.Store, name string) string {
-	return resolveUniqueFnValue(g, name)
+	match := ""
+	for _, n := range g.FindNodesByName(name) {
+		if n == nil {
+			continue
+		}
+		if n.Kind != graph.KindFunction && n.Kind != graph.KindMethod {
+			continue
+		}
+		if isFileLocalLinkage(n) {
+			continue
+		}
+		if match != "" && match != n.ID {
+			return "" // ambiguous — drop
+		}
+		match = n.ID
+	}
+	return match
+}
+
+// isFileLocalLinkage reports whether a node was stamped with translation-unit
+// (C/C++ static) linkage, so it cannot be the target of a cross-module value
+// reference.
+func isFileLocalLinkage(n *graph.Node) bool {
+	if n.Meta == nil {
+		return false
+	}
+	v, _ := n.Meta["scope_static"].(bool)
+	return v
 }
 
 // resolveMemberByType binds member to a uniquely-named method of typeName

--- a/internal/semantic/lsp/enrich_budget_test.go
+++ b/internal/semantic/lsp/enrich_budget_test.go
@@ -1,0 +1,145 @@
+package lsp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/semantic"
+)
+
+// TestLSP_Enrich_ConfirmDoesNotStarveAddPhase is the WS-D acceptance: a slow
+// references server that — with the old sequential, full-deadline confirm pass
+// — would burn the entire per-repo window before any hover / hierarchy work
+// ran, now leaves the add phase productive. Two levers make it so: the confirm
+// reference sweep fans out across maxParallel, and a fraction of the deadline
+// is reserved for the post-confirm sweep. The result is that both the confirm
+// counters AND the hover / hierarchy add counters come back non-zero under a
+// deadline that a sequential confirm pass alone (8 files x 60ms = 480ms > 400ms
+// budget) would have exhausted.
+func TestLSP_Enrich_ConfirmDoesNotStarveAddPhase(t *testing.T) {
+	const n = 8
+	const refDelay = 60 * time.Millisecond
+
+	repoRoot := t.TempDir()
+	g := graph.New()
+	for i := 0; i < n; i++ {
+		defFile := fmt.Sprintf("def%d.go", i)
+		callFile := fmt.Sprintf("call%d.go", i)
+		require.NoError(t, os.WriteFile(filepath.Join(repoRoot, defFile),
+			[]byte(fmt.Sprintf("package p\nfunc target%d() {}\n", i)), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(repoRoot, callFile),
+			[]byte(fmt.Sprintf("package p\nfunc call%d() { target%d() }\n", i, i)), 0o644))
+
+		targetID := fmt.Sprintf("%s::target%d", defFile, i)
+		callID := fmt.Sprintf("%s::call%d", callFile, i)
+		g.AddNode(&graph.Node{ID: targetID, Kind: graph.KindFunction, Name: fmt.Sprintf("target%d", i),
+			FilePath: defFile, StartLine: 2, EndLine: 2, Language: "go"})
+		g.AddNode(&graph.Node{ID: callID, Kind: graph.KindFunction, Name: fmt.Sprintf("call%d", i),
+			FilePath: callFile, StartLine: 2, EndLine: 2, Language: "go"})
+		// Ambiguous call edge — a confirm target AND a hierarchy-promotion
+		// target. Its site line (2) is where callI() invokes targetI().
+		g.AddEdge(&graph.Edge{
+			From: callID, To: targetID, Kind: graph.EdgeCalls,
+			FilePath: callFile, Line: 2,
+			Confidence: 0.7, ConfidenceLabel: "INFERRED", Origin: graph.OriginTextMatched,
+		})
+	}
+
+	server := newFakeLSPServer()
+	// The confirm pass's references call is the slow one. It returns nothing
+	// useful — its only role here is to eat time, so every confirmation that
+	// lands must come from the add phase's call hierarchy below.
+	server.handle("textDocument/references", func(_ json.RawMessage) (any, *jsonRPCError) {
+		time.Sleep(refDelay)
+		return []Location{}, nil
+	})
+	// The add phase: call hierarchy promotes each ambiguous callI->targetI edge
+	// to the lsp tier. prepareCallHierarchy yields the caller; outgoingCalls
+	// names the referent.
+	server.handle("textDocument/prepareCallHierarchy", func(params json.RawMessage) (any, *jsonRPCError) {
+		var req struct {
+			TextDocument struct {
+				URI string `json:"uri"`
+			} `json:"textDocument"`
+			Position Position `json:"position"`
+		}
+		_ = json.Unmarshal(params, &req)
+		base := filepath.Base(uriToAbsPath(req.TextDocument.URI))
+		var idx int
+		if _, err := fmt.Sscanf(base, "call%d.go", &idx); err != nil {
+			return []CallHierarchyItem{}, nil
+		}
+		return []CallHierarchyItem{{
+			Name: fmt.Sprintf("call%d", idx), Kind: 12,
+			URI:            req.TextDocument.URI,
+			Range:          Range{Start: Position{Line: 1, Character: 0}, End: Position{Line: 1, Character: 30}},
+			SelectionRange: Range{Start: Position{Line: 1, Character: 5}, End: Position{Line: 1, Character: 10}},
+		}}, nil
+	})
+	server.handle("callHierarchy/outgoingCalls", func(params json.RawMessage) (any, *jsonRPCError) {
+		var req struct {
+			Item CallHierarchyItem `json:"item"`
+		}
+		_ = json.Unmarshal(params, &req)
+		base := filepath.Base(uriToAbsPath(req.Item.URI))
+		var idx int
+		if _, err := fmt.Sscanf(base, "call%d.go", &idx); err != nil {
+			return []CallHierarchyOutgoingCall{}, nil
+		}
+		defURI := pathToURI(filepath.Join(repoRoot, fmt.Sprintf("def%d.go", idx)))
+		return []CallHierarchyOutgoingCall{{
+			To: CallHierarchyItem{
+				Name: fmt.Sprintf("target%d", idx), Kind: 12,
+				URI:            defURI,
+				Range:          Range{Start: Position{Line: 1, Character: 0}, End: Position{Line: 1, Character: 30}},
+				SelectionRange: Range{Start: Position{Line: 1, Character: 5}, End: Position{Line: 1, Character: 12}},
+			},
+		}}, nil
+	})
+	server.handle("callHierarchy/incomingCalls", func(_ json.RawMessage) (any, *jsonRPCError) {
+		return []CallHierarchyIncomingCall{}, nil
+	})
+	server.handle("textDocument/hover", func(_ json.RawMessage) (any, *jsonRPCError) {
+		return map[string]any{
+			"contents": map[string]any{"kind": "plaintext", "value": "func X()"},
+		}, nil
+	})
+
+	p, cleanup := providerWithFakeServerParallel(t, server, []string{"go"}, 2)
+	defer cleanup()
+
+	// A budget a sequential confirm pass (8 x 60ms = 480ms) alone would blow.
+	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+	var result *semantic.EnrichResult
+	var err error
+	go func() {
+		defer close(done)
+		result, err = p.EnrichRepoContext(ctx, g, "", repoRoot)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("EnrichRepoContext did not return")
+	}
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// The add phase ran despite the slow confirm pass: hover stamped symbols
+	// and call hierarchy promoted ambiguous edges. Both non-zero is the WS-D
+	// contract — the old sequential/full-deadline confirm pass would have left
+	// both at zero.
+	assert.Greater(t, result.NodesEnriched, 0, "hover add phase must progress, not be starved by confirm")
+	assert.Greater(t, result.EdgesConfirmed, 0, "call-hierarchy promotions must land under the reserved budget")
+}

--- a/internal/semantic/lsp/enrich_confirm.go
+++ b/internal/semantic/lsp/enrich_confirm.go
@@ -36,7 +36,7 @@ type confirmGroup struct {
 // where a confirmation resolves the most tiers — have already run. Ordering is
 // deterministic (count desc, then path) so a resumed / replayed index is
 // stable.
-func groupConfirmTargets(g graph.Store, targets []enrichTarget) []*confirmGroup {
+func (p *Provider) groupConfirmTargets(g graph.Store, targets []enrichTarget) []*confirmGroup {
 	byFile := map[string]*confirmGroup{}
 	var order []*confirmGroup
 	for _, t := range targets {
@@ -50,6 +50,9 @@ func groupConfirmTargets(g graph.Store, targets []enrichTarget) []*confirmGroup 
 		rel := nodeRelPath(toNode)
 		if rel == "" {
 			continue
+		}
+		if !p.servesFile(rel) {
+			continue // never open a referent file this server can't compile
 		}
 		grp := byFile[rel]
 		if grp == nil {

--- a/internal/semantic/lsp/enrich_confirm.go
+++ b/internal/semantic/lsp/enrich_confirm.go
@@ -1,0 +1,97 @@
+package lsp
+
+import (
+	"sort"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// enrichSweepReserveFraction is the slice of a repo's enrichment deadline held
+// back from the targeted-edge passes (implementations + reference confirm) for
+// the post-confirm hover / hierarchy sweep. Reserving it stops a round-trip-
+// bound confirm pass from consuming the whole window and starving the add
+// phase (edges_added stuck at 0). 0.4 keeps confirm-first — the majority of the
+// window still confirms tiers — while guaranteeing the sweep runs.
+const enrichSweepReserveFraction = 0.4
+
+// enrichTarget pairs an ambiguous edge with its (repo+language) source node —
+// the unit the reference-confirm pass promotes or refutes.
+type enrichTarget struct {
+	node *graph.Node
+	edge *graph.Edge
+}
+
+// confirmGroup is the confirm pass's per-file work unit: every ambiguous
+// target whose referent declaration lives in rel. Grouping lets one didOpen of
+// rel serve all its targets' reference queries.
+type confirmGroup struct {
+	rel     string
+	targets []enrichTarget
+}
+
+// groupConfirmTargets buckets confirm targets by the file of the referent
+// declaration (the file findReferences is positioned in) and orders the groups
+// highest-yield-first. The ordering is the value-prioritisation lever: when the
+// deadline cuts the pass short, the files carrying the most ambiguous edges —
+// where a confirmation resolves the most tiers — have already run. Ordering is
+// deterministic (count desc, then path) so a resumed / replayed index is
+// stable.
+func groupConfirmTargets(g graph.Store, targets []enrichTarget) []*confirmGroup {
+	byFile := map[string]*confirmGroup{}
+	var order []*confirmGroup
+	for _, t := range targets {
+		toNode := g.GetNode(t.edge.To)
+		if toNode == nil {
+			continue
+		}
+		if _, ok := lspLine(toNode); !ok {
+			continue
+		}
+		rel := nodeRelPath(toNode)
+		if rel == "" {
+			continue
+		}
+		grp := byFile[rel]
+		if grp == nil {
+			grp = &confirmGroup{rel: rel}
+			byFile[rel] = grp
+			order = append(order, grp)
+		}
+		grp.targets = append(grp.targets, t)
+	}
+	sort.SliceStable(order, func(i, j int) bool {
+		if len(order[i].targets) != len(order[j].targets) {
+			return len(order[i].targets) > len(order[j].targets)
+		}
+		return order[i].rel < order[j].rel
+	})
+	return order
+}
+
+// confirmRefMatchesSite reports whether the server's reference list ties the
+// edge's own call site to its target declaration — the identity anchor that
+// promotes an ambiguous edge to the lsp tier. A recorded site line is matched
+// exactly (±1 for wrapped call expressions); an edge without one falls back to
+// containment in the caller's span. Pure over its inputs, so it is safe to call
+// from the parallel sweep.
+func (p *Provider) confirmRefMatchesSite(refs []Location, absRoot, repoPrefix string, t enrichTarget) bool {
+	callerRel := nodeRelPath(t.node)
+	siteRel := edgeSiteRelPath(t.edge, repoPrefix, callerRel)
+	siteLine := t.edge.Line
+	for _, ref := range refs {
+		// uriToPath returns a repo-relative path while node/edge FilePaths are
+		// prefixed, so compare against stripped paths.
+		refPath := uriToPath(ref.URI, absRoot)
+		refLine := ref.Range.Start.Line + 1
+		if siteLine > 0 {
+			if refPath == siteRel && refLine >= siteLine-1 && refLine <= siteLine+1 {
+				return true
+			}
+			continue
+		}
+		if refPath == callerRel && refLine >= t.node.StartLine && refLine <= t.node.EndLine {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/semantic/lsp/enrich_crashloop_test.go
+++ b/internal/semantic/lsp/enrich_crashloop_test.go
@@ -1,0 +1,67 @@
+package lsp
+
+import (
+	"encoding/json"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLSP_Enrich_CrashLoopGuardAbandonsPass pins the crash-loop guard: a server
+// that connects cleanly but keeps exiting mid-request (the clangd/clang-tidy
+// failure shape) must not pin the pass in an endless crash -> reconnect -> crash
+// loop. After the per-pass cap the provider's enrichment is abandoned with an
+// error and a bounded reconnect count, and whatever landed earlier stays.
+func TestLSP_Enrich_CrashLoopGuardAbandonsPass(t *testing.T) {
+	repoRoot, g := seedRepo(t, 60)
+
+	server1 := newInstrumentedServer()
+	p, cleanup := providerWithInstrumentedServer(t, server1, []string{"go"}, 4)
+	defer cleanup()
+	// Keep backoff tiny so the crash loop churns quickly.
+	p.dialBackoffStart = 1 * time.Millisecond
+	p.maxDialBackoff = 2 * time.Millisecond
+
+	kill := func(c *Client) {
+		c.mu.Lock()
+		if !c.closed {
+			c.closed = true
+			close(c.done)
+		}
+		c.mu.Unlock()
+	}
+	// dyingHover kills its own client on the first hover, so the initial server
+	// and every reconnect's replacement die mid-request in turn.
+	dyingHover := func(c *Client) func(json.RawMessage) (any, *jsonRPCError) {
+		var once sync.Once
+		return func(_ json.RawMessage) (any, *jsonRPCError) {
+			once.Do(func() { kill(c) })
+			return nil, &jsonRPCError{Code: -32603, Message: "server exited"}
+		}
+	}
+	server1.handle("textDocument/hover", dyingHover(p.client))
+
+	var reconnects atomic.Int64
+	p.connectOnce = func(_ string) error {
+		reconnects.Add(1)
+		srv := newInstrumentedServer()
+		c, in, out, cl := newPipedClient(t)
+		go srv.run(in, out)
+		t.Cleanup(cl)
+		srv.handle("textDocument/hover", dyingHover(c))
+		p.client = c
+		return nil
+	}
+
+	err := runEnrich(t, p, g, repoRoot, 20*time.Second)
+	require.Error(t, err, "a server that keeps crashing must abandon the pass, not loop forever")
+
+	n := int(reconnects.Load())
+	assert.Greater(t, n, 0, "should have attempted at least one reconnect")
+	assert.LessOrEqual(t, n, maxEnrichReconnectCycles+1,
+		"reconnects must be bounded by the crash-loop cap, got %d", n)
+}

--- a/internal/semantic/lsp/enrich_hardening_test.go
+++ b/internal/semantic/lsp/enrich_hardening_test.go
@@ -36,8 +36,9 @@ type instrumentedServer struct {
 	handlers map[string]func(params json.RawMessage) (any, *jsonRPCError)
 
 	mu          sync.Mutex
-	openDocs    map[string]int // uri → currently-open count
-	maxOpen     int            // peak simultaneous open docs
+	openDocs    map[string]int  // uri → currently-open count
+	everOpened  map[string]bool // uri → ever received a didOpen
+	maxOpen     int             // peak simultaneous open docs
 	totalOpen   int
 	totalClose  int
 	notifLog    []string
@@ -46,9 +47,17 @@ type instrumentedServer struct {
 
 func newInstrumentedServer() *instrumentedServer {
 	return &instrumentedServer{
-		handlers: make(map[string]func(json.RawMessage) (any, *jsonRPCError)),
-		openDocs: make(map[string]int),
+		handlers:   make(map[string]func(json.RawMessage) (any, *jsonRPCError)),
+		openDocs:   make(map[string]int),
+		everOpened: make(map[string]bool),
 	}
+}
+
+// wasOpened reports whether the server ever received a didOpen for uri.
+func (s *instrumentedServer) wasOpened(uri string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.everOpened[uri]
 }
 
 func (s *instrumentedServer) handle(method string, fn func(params json.RawMessage) (any, *jsonRPCError)) {
@@ -65,6 +74,7 @@ func (s *instrumentedServer) recordOpen(uri string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.openDocs[uri]++
+	s.everOpened[uri] = true
 	s.totalOpen++
 	cur := 0
 	for _, n := range s.openDocs {

--- a/internal/semantic/lsp/enrich_provider_scope_test.go
+++ b/internal/semantic/lsp/enrich_provider_scope_test.go
@@ -1,0 +1,98 @@
+package lsp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// TestLSP_Enrich_SkipsFilesOutsideProviderCoverage pins that enrichment never
+// sends a language server a file its ServerSpec does not cover. An ambiguous
+// edge whose referent lives in an asset file (a `.png`) must not cause a
+// didOpen / references round trip against a C/C++ server, which would otherwise
+// try to build an AST with an inferred compile command and churn on invalid
+// ASTs for zero graph signal.
+func TestLSP_Enrich_SkipsFilesOutsideProviderCoverage(t *testing.T) {
+	repoRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "main.c"),
+		[]byte("void caller(void) {\n  helper();\n  useImg();\n}\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "def.c"),
+		[]byte("void helper(void) {}\n"), 0o644))
+	// logo.png is deliberately NOT written — the guard must skip it before any
+	// os.ReadFile / didOpen.
+
+	server := newInstrumentedServer()
+	var reqMu sync.Mutex
+	reqURIs := map[string]bool{}
+	recordReq := func(params json.RawMessage) {
+		var req struct {
+			TextDocument struct {
+				URI string `json:"uri"`
+			} `json:"textDocument"`
+		}
+		_ = json.Unmarshal(params, &req)
+		reqMu.Lock()
+		reqURIs[req.TextDocument.URI] = true
+		reqMu.Unlock()
+	}
+	for _, m := range []string{
+		"textDocument/references", "textDocument/hover",
+		"textDocument/prepareCallHierarchy", "textDocument/prepareTypeHierarchy",
+		"textDocument/implementation", "textDocument/definition",
+	} {
+		server.handle(m, func(params json.RawMessage) (any, *jsonRPCError) {
+			recordReq(params)
+			return []Location{}, nil
+		})
+	}
+
+	p, cleanup := providerWithInstrumentedServer(t, server, []string{"c", "cpp"}, 2)
+	defer cleanup()
+	// Scope the provider to C/C++ extensions, as the registry does for clangd.
+	p.spec = &ServerSpec{
+		Name:       "clangd",
+		Languages:  []string{"c", "cpp"},
+		Extensions: []string{".c", ".h", ".cpp", ".hpp"},
+	}
+
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "main.c::caller", Kind: graph.KindFunction, Name: "caller",
+		FilePath: "main.c", StartLine: 1, EndLine: 4, Language: "c"})
+	g.AddNode(&graph.Node{ID: "def.c::helper", Kind: graph.KindFunction, Name: "helper",
+		FilePath: "def.c", StartLine: 1, EndLine: 1, Language: "c"})
+	// A mis-tagged asset node (Language "c") — the shape that leaked .png files
+	// to clangd. It is both an ambiguous-edge referent and a would-be hover
+	// target, so both open paths must skip it.
+	g.AddNode(&graph.Node{ID: "logo.png::img", Kind: graph.KindFunction, Name: "img",
+		FilePath: "logo.png", StartLine: 1, EndLine: 1, Language: "c"})
+	g.AddEdge(&graph.Edge{From: "main.c::caller", To: "def.c::helper", Kind: graph.EdgeCalls,
+		FilePath: "main.c", Line: 2, Confidence: 0.7, ConfidenceLabel: "INFERRED", Origin: graph.OriginTextMatched})
+	g.AddEdge(&graph.Edge{From: "main.c::caller", To: "logo.png::img", Kind: graph.EdgeCalls,
+		FilePath: "main.c", Line: 3, Confidence: 0.7, ConfidenceLabel: "INFERRED", Origin: graph.OriginTextMatched})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_, err := p.EnrichRepoContext(ctx, g, "", repoRoot)
+	require.NoError(t, err)
+
+	pngURI := pathToURI(filepath.Join(repoRoot, "logo.png"))
+	defURI := pathToURI(filepath.Join(repoRoot, "def.c"))
+
+	assert.False(t, server.wasOpened(pngURI), "asset file must never be opened on the C/C++ server")
+	reqMu.Lock()
+	assert.False(t, reqURIs[pngURI], "no LSP request may target the asset file")
+	reqMu.Unlock()
+
+	// The guard is selective, not a blanket skip: served C files are still
+	// opened and queried.
+	assert.True(t, server.wasOpened(defURI), "a covered .c referent must still be opened")
+}

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -425,11 +425,8 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 	// Collect AMBIGUOUS edges (confidence < 1.0) whose source is one of this
 	// repo's language nodes — the references pass below confirms / refutes
 	// them. The indexed GetRepoEdges scan + the id-set replaces the AllEdges
-	// walk with a per-edge GetNode.
-	type enrichTarget struct {
-		node *graph.Node
-		edge *graph.Edge
-	}
+	// walk with a per-edge GetNode. (enrichTarget is package-scoped so the
+	// confirm-pass grouping / matching helpers can take it.)
 	var targets []enrichTarget
 	for _, e := range p.repoScopedEdges(g, repoPrefix) {
 		if e.Confidence >= 1.0 {
@@ -486,10 +483,27 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 	// graph tiers and find_usages accuracy, while hover only stamps type
 	// strings. Each item commits to the graph as soon as it resolves, so
 	// a deadline cut loses only the un-visited remainder.
+	//
+	// Deadline budgeting: the reference-confirm pass is round-trip bound and
+	// can, on a medium repo, consume the entire per-repo deadline before the
+	// hover / hierarchy add phase runs at all — leaving edges_added stuck at 0.
+	// targetedCtx caps the targeted-edge passes (implementations + confirm) at
+	// a fraction of the window, reserving the remainder for the sweep so both
+	// phases make progress. With no deadline (tests) it is the parent context.
+	targetedCtx := ctx
+	if dl, ok := ctx.Deadline(); ok {
+		window := dl.Sub(start)
+		reserve := time.Duration(float64(window) * enrichSweepReserveFraction)
+		if reserve > 0 && reserve < window {
+			var cancelTargeted context.CancelFunc
+			targetedCtx, cancelTargeted = context.WithDeadline(ctx, dl.Add(-reserve))
+			defer cancelTargeted()
+		}
+	}
 
 	// Query implementations for interface nodes.
 	for _, n := range langNodes {
-		if ctx.Err() != nil {
+		if targetedCtx.Err() != nil {
 			break
 		}
 		if n.Kind != graph.KindInterface {
@@ -550,100 +564,127 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 	// of the wrong target inside the caller's span rubber-stamped the
 	// edge bound at the OTHER member's line — a compiler-grade tier
 	// serving the wrong declaration.
+	//
+	// The sweep fans out across maxParallel, grouped by the referent's file
+	// so each file is opened once (per-goroutine, via enrichOpenDoc) and
+	// serves every target sharing it — turning the ~7 edges/s sequential
+	// round-trip loop into maxParallel-wide throughput. The definition-rebind
+	// fallback opens arbitrary call-site files, so it runs serially afterward
+	// over the targets the sweep left unconfirmed, keeping document open/close
+	// from overlapping across goroutines.
+	confirmGroups := groupConfirmTargets(g, targets)
+	var confirmMu sync.Mutex
+	var fallback []enrichTarget
+	{
+		sem := make(chan struct{}, p.maxParallel)
+		var wg sync.WaitGroup
+		for _, grp := range confirmGroups {
+			if targetedCtx.Err() != nil {
+				break
+			}
+			wg.Add(1)
+			sem <- struct{}{}
+			go func(grp *confirmGroup) {
+				defer func() {
+					<-sem
+					wg.Done()
+				}()
+				if targetedCtx.Err() != nil {
+					return
+				}
+				absPath := filepath.Join(absRoot, grp.rel)
+				content, err := os.ReadFile(absPath)
+				if err != nil {
+					return
+				}
+				// Per-goroutine didOpen against the shared client — the file
+				// is unique to this group, so no two goroutines open it.
+				if err := p.enrichOpenDoc(p.client, absPath, content); err != nil {
+					return
+				}
+				defer func() { _ = p.enrichCloseDoc(p.client, absPath) }()
+				for _, t := range grp.targets {
+					if targetedCtx.Err() != nil {
+						return
+					}
+					toNode := g.GetNode(t.edge.To)
+					if toNode == nil {
+						continue
+					}
+					line, ok := lspLine(toNode)
+					if !ok {
+						continue
+					}
+					col := identifierColumn(content, toNode.StartLine, toNode.Name)
+					refs, err := p.findReferences(absRoot, grp.rel, line, col)
+					if err != nil {
+						continue
+					}
+					if p.confirmRefMatchesSite(refs, absRoot, repoPrefix, t) {
+						rmu.Lock()
+						semantic.ConfirmEdge(t.edge, p.Name())
+						semantic.PersistEdge(g, t.edge)
+						rmu.Unlock()
+						confirmMu.Lock()
+						result.EdgesConfirmed++
+						confirmMu.Unlock()
+						continue
+					}
+					// Unconfirmed with a recorded site line: defer to the
+					// serial definition-rebind fallback below.
+					if t.edge.Line > 0 {
+						confirmMu.Lock()
+						fallback = append(fallback, t)
+						confirmMu.Unlock()
+					}
+				}
+			}(grp)
+		}
+		wg.Wait()
+	}
+
+	// Serial definition-rebind fallback: for a site the reference sweep did
+	// not tie to the edge's target, ask the server what the site actually
+	// resolves to (textDocument/definition at the site identifier). When the
+	// definition lands back on the target we confirm anyway (reference lists
+	// can be incomplete); when it names a DIFFERENT known declaration we
+	// rebind the edge to the correct target instead of leaving a
+	// misattribution behind. Runs after the parallel sweep so arbitrary
+	// call-site document opens never overlap across goroutines.
 	defSiteCache := map[string]*graph.Node{}
-	for _, t := range targets {
-		if ctx.Err() != nil {
+	for _, t := range fallback {
+		if targetedCtx.Err() != nil {
 			break
 		}
 		toNode := g.GetNode(t.edge.To)
 		if toNode == nil {
 			continue
 		}
-		line, ok := lspLine(toNode)
-		if !ok {
-			continue
-		}
-
-		toRel := nodeRelPath(toNode)
-		// Per-item doc lifecycle (no bulk pre-open): open the referent's
-		// file, query, close immediately so memory stays bounded.
-		if err := p.openDocument(absRoot, toRel); err != nil {
-			continue
-		}
-		col := identifierColumn(p.getSource(absRoot, toRel), toNode.StartLine, toNode.Name)
-		refs, err := p.findReferences(absRoot, toRel, line, col)
-		_ = p.closeDocument(filepath.Join(absRoot, toRel))
-		if err != nil {
-			continue
-		}
-
-		// uriToPath returns a repo-relative path while node/edge FilePaths
-		// are prefixed, so compare against stripped paths.
 		callerRel := nodeRelPath(t.node)
 		siteRel := edgeSiteRelPath(t.edge, repoPrefix, callerRel)
 		siteLine := t.edge.Line
-
-		confirmed := false
-		for _, ref := range refs {
-			refPath := uriToPath(ref.URI, absRoot)
-			refLine := ref.Range.Start.Line + 1
-			if siteLine > 0 {
-				// Site-anchored: a reference of the target declaration at
-				// the edge's recorded line proves this site binds to this
-				// declaration. ±1 tolerates wrapped call expressions where
-				// the extractor and the server anchor on adjacent lines.
-				if refPath == siteRel && refLine >= siteLine-1 && refLine <= siteLine+1 {
-					confirmed = true
-					break
-				}
-				continue
-			}
-			// Legacy fallback for edges without a recorded site line:
-			// containment in the caller's span is the best we can do.
-			if refPath == callerRel &&
-				refLine >= t.node.StartLine &&
-				refLine <= t.node.EndLine {
-				confirmed = true
-				break
-			}
-		}
-
-		if !confirmed && siteLine > 0 {
-			// The reference sweep did not tie this site to the edge's
-			// target. Ask the server what the site actually resolves to
-			// (textDocument/definition at the site identifier): when the
-			// definition lands back on the target we confirm anyway
-			// (reference lists can be incomplete); when it names a
-			// DIFFERENT known declaration we rebind the edge to the
-			// correct target instead of leaving a misattribution behind.
-			cand, ok := p.definitionNodeAtSite(g, repoPrefix, absRoot, siteRel, siteLine, toNode.Name, defSiteCache)
-			switch {
-			case !ok || cand == nil:
-				// No verdict — leave the edge at its heuristic tier so
-				// min_tier filtering excludes it.
-			case cand.ID == toNode.ID:
-				confirmed = true
-			case rebindTargetAcceptable(cand.Kind) && !edgeExistsAt(g, t.edge.From, cand.ID, t.edge.Kind, t.edge.Line):
-				rmu.Lock()
-				// Mutate the full edge state BEFORE ReindexEdge: disk
-				// backends persist the post-mutation struct verbatim
-				// (delete old key + insert current state), so anything
-				// stamped afterwards would be dropped.
-				oldTo := t.edge.To
-				t.edge.To = cand.ID
-				semantic.ConfirmEdge(t.edge, p.Name())
-				t.edge.Meta["rebound_from"] = oldTo
-				g.ReindexEdge(t.edge, oldTo)
-				rmu.Unlock()
-				result.EdgesConfirmed++
-				continue
-			}
-		}
-
-		if confirmed {
+		cand, ok := p.definitionNodeAtSite(g, repoPrefix, absRoot, siteRel, siteLine, toNode.Name, defSiteCache)
+		switch {
+		case !ok || cand == nil:
+			// No verdict — leave the edge at its heuristic tier so
+			// min_tier filtering excludes it.
+		case cand.ID == toNode.ID:
 			rmu.Lock()
 			semantic.ConfirmEdge(t.edge, p.Name())
 			semantic.PersistEdge(g, t.edge)
+			rmu.Unlock()
+			result.EdgesConfirmed++
+		case rebindTargetAcceptable(cand.Kind) && !edgeExistsAt(g, t.edge.From, cand.ID, t.edge.Kind, t.edge.Line):
+			rmu.Lock()
+			// Mutate the full edge state BEFORE ReindexEdge: disk
+			// backends persist the post-mutation struct verbatim
+			// (delete old key + insert current state), so anything
+			// stamped afterwards would be dropped.
+			oldTo := t.edge.To
+			t.edge.To = cand.ID
+			semantic.ConfirmEdge(t.edge, p.Name())
+			t.edge.Meta["rebound_from"] = oldTo
+			g.ReindexEdge(t.edge, oldTo)
 			rmu.Unlock()
 			result.EdgesConfirmed++
 		}

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -736,6 +736,11 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 	var aborted atomic.Bool
 	var abortErr error
 	var abortOnce sync.Once
+	// reconnectCycles counts distinct reconnect cycles this pass — a server
+	// that connects fine but keeps exiting mid-request (e.g. clangd crashing in
+	// a lint matcher) would otherwise reconnect endlessly, repeating work and
+	// pinning the process at high CPU. The crash-loop guard caps it.
+	var reconnectCycles atomic.Int64
 
 	// reconnect serialises mid-flight recovery so that when a burst of
 	// goroutines observe the same dead client only the first rebuilds it;
@@ -748,6 +753,25 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 		}
 		if cur := activeClient.Load(); cur != stale {
 			return cur, nil // someone else already reconnected
+		}
+		// Crash-loop guard: past the per-pass cap, abandon this provider's
+		// enrichment for the repo rather than reconnect again. Whatever already
+		// flushed stays in the graph; the caller sees the failure and the log
+		// names the provider, repo, and reconnect count.
+		if cycles := reconnectCycles.Add(1); cycles > maxEnrichReconnectCycles {
+			err := fmt.Errorf("LSP provider %q exited %d times during enrichment of repo %q; abandoning pass",
+				p.Name(), cycles, repoPrefix)
+			abortOnce.Do(func() {
+				abortErr = err
+				aborted.Store(true)
+			})
+			p.logger.Warn("LSP enrich: crash-loop guard tripped, abandoning provider",
+				zap.String("provider", p.Name()),
+				zap.String("repo_prefix", repoPrefix),
+				zap.Int64("reconnect_cycles", cycles),
+				zap.Int64("reconnect_attempts", p.reconnectAttempts.Load()),
+			)
+			return nil, err
 		}
 		newC, err := p.reconnectWithBackoff(absRoot)
 		if err != nil {
@@ -1983,6 +2007,13 @@ func isServerExitError(err error) bool {
 // at a time; backoff prevents a tight retry loop against a persistently
 // dead server.
 // KEYWORDS — lsp, reconnect, backoff, recovery
+// maxEnrichReconnectCycles caps how many times a single enrichment pass will
+// reconnect to a provider that keeps exiting mid-request. reconnectWithBackoff
+// (below) caps the connection retries within ONE cycle; this caps the number of
+// cycles, so a server that reconnects cleanly but crashes again on the next
+// request can't pin the pass in an endless crash -> reconnect -> crash loop.
+const maxEnrichReconnectCycles = 5
+
 func (p *Provider) reconnectWithBackoff(absRoot string) (*Client, error) {
 	const maxReconnectAttempts = 5
 	backoff := p.dialBackoffStart

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -515,6 +515,9 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 		}
 
 		rel := nodeRelPath(n)
+		if !p.servesFile(rel) {
+			continue // never open a file this server can't compile
+		}
 		// Per-item doc lifecycle (no bulk pre-open): open this interface's
 		// file, query, close immediately so memory stays bounded.
 		if err := p.openDocument(absRoot, rel); err != nil {
@@ -572,7 +575,7 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 	// fallback opens arbitrary call-site files, so it runs serially afterward
 	// over the targets the sweep left unconfirmed, keeping document open/close
 	// from overlapping across goroutines.
-	confirmGroups := groupConfirmTargets(g, targets)
+	confirmGroups := p.groupConfirmTargets(g, targets)
 	var confirmMu sync.Mutex
 	var fallback []enrichTarget
 	{
@@ -662,6 +665,9 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 		}
 		callerRel := nodeRelPath(t.node)
 		siteRel := edgeSiteRelPath(t.edge, repoPrefix, callerRel)
+		if !p.servesFile(siteRel) {
+			continue // never open a call-site file this server can't compile
+		}
 		siteLine := t.edge.Line
 		cand, ok := p.definitionNodeAtSite(g, repoPrefix, absRoot, siteRel, siteLine, toNode.Name, defSiteCache)
 		switch {
@@ -765,9 +771,13 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 	var fileList []*fileTargets
 	fileIndex := map[string]*fileTargets{}
 	for _, n := range langNodes {
+		rel := nodeRelPath(n)
+		if !p.servesFile(rel) {
+			continue // never open a file this server can't compile
+		}
 		ft := fileIndex[n.FilePath]
 		if ft == nil {
-			ft = &fileTargets{rel: nodeRelPath(n)}
+			ft = &fileTargets{rel: rel}
 			fileIndex[n.FilePath] = ft
 			fileList = append(fileList, ft)
 		}
@@ -2431,6 +2441,30 @@ func addOverrideEdges(g graph.Store, child, parent *graph.Node, provider, origin
 func (p *Provider) languageMatches(lang string) bool {
 	for _, l := range p.languages {
 		if l == lang {
+			return true
+		}
+	}
+	return false
+}
+
+// servesFile reports whether relPath's extension is one this provider's server
+// can actually compile — the guard that stops enrichment from ever sending a
+// language server a file outside its coverage. Without it, an ambiguous edge
+// or interface whose file is an asset (.png/.svg) or an unrelated script (.sh)
+// would be opened on, say, clangd, which then tries to build an AST with an
+// inferred C++ compile command and logs invalid-AST churn for zero signal.
+// With no ServerSpec (unit-test providers) it defaults to true so fakes that
+// drive arbitrary extensions are unaffected.
+func (p *Provider) servesFile(relPath string) bool {
+	if p.spec == nil || len(p.spec.Extensions) == 0 {
+		return true
+	}
+	ext := strings.ToLower(filepath.Ext(relPath))
+	if ext == "" {
+		return false
+	}
+	for _, e := range p.spec.Extensions {
+		if strings.ToLower(e) == ext {
 			return true
 		}
 	}

--- a/internal/semantic/lsp/registry.go
+++ b/internal/semantic/lsp/registry.go
@@ -320,10 +320,15 @@ var Servers = []ServerSpec{
 		Name:    "clangd",
 		Command: "clangd",
 		// `--background-index` keeps a project-wide symbol index hot in
-		// the daemon, which is essential for type-hierarchy precision in
-		// large C++ trees. `--header-insertion=never` avoids tactical
-		// edits when we only want graph signal.
-		Args:      []string{"--background-index", "--header-insertion=never"},
+		// the daemon, which is essential for cross-file references and
+		// type-hierarchy precision in large C++ trees. `--header-insertion=never`
+		// avoids tactical edits when we only want graph signal.
+		// `--clang-tidy=false` disables lint matchers during enrichment:
+		// Gortex consumes semantic graph signal, not clang-tidy diagnostics,
+		// and a broad repo `.clang-tidy` can crash clangd mid-pass — which,
+		// with reconnect, becomes a crash→reconnect→reindex loop that pins the
+		// server at high CPU for the whole pass.
+		Args:      []string{"--background-index", "--header-insertion=never", "--clang-tidy=false"},
 		Languages: []string{"c", "cpp", "objc", "objcpp"},
 		Extensions: []string{
 			".c", ".h",

--- a/internal/semantic/lsp/registry_test.go
+++ b/internal/semantic/lsp/registry_test.go
@@ -219,3 +219,22 @@ func TestSpecWithOverrides(t *testing.T) {
 		t.Errorf("base spec mutated: command=%q env=%v", base.Command, base.Env)
 	}
 }
+
+// TestClangdDisablesClangTidy pins that the clangd enrichment spec turns off
+// clang-tidy: Gortex consumes semantic graph signal, not lint diagnostics, and
+// a broad repo .clang-tidy can crash clangd into a reconnect/high-CPU loop.
+func TestClangdDisablesClangTidy(t *testing.T) {
+	spec := SpecByName("clangd")
+	if spec == nil {
+		t.Fatal("clangd spec missing")
+	}
+	joined := strings.Join(spec.Args, " ")
+	if !strings.Contains(joined, "--clang-tidy=false") {
+		t.Errorf("clangd args must disable clang-tidy, got %v", spec.Args)
+	}
+	// Cross-file references still need the background index — it must NOT be
+	// disabled.
+	if strings.Contains(joined, "--background-index=false") {
+		t.Errorf("clangd must keep --background-index for cross-file references, got %v", spec.Args)
+	}
+}


### PR DESCRIPTION
## Summary

Four independent fixes that recover C `find_usages` results clangd resolves but Gortex was silently missing (measured against clangd ground truth on redis), plus a cross-language enrichment-scheduling fix.

### 1. Pointer-return function definitions and prototypes are now extracted

The function-definition query only matched a bare `function_declarator`, so a pointer-return signature — `robj *streamDup()`, `static inline list *f()`, `robj **g()` — where tree-sitter nests the `function_declarator` under one or
two `pointer_declarator`s, produced no node at all. Call sites *inside* such a function's body then had no enclosing function, so their call edges were dropped too.

The definition is now matched broadly and the name derived by peeling the declarator chain; the C prototype and C++ free-function queries gain pointer-declarator alternations, and C++ `extractFuncName` descends pointer/reference/parenthesized wrappers so pointer-return methods are no longer dropped.

### 2. Generated `.def` command tables are indexed and their references recovered

A generated C fragment such as redis's `src/commands.def` — thousands of `MAKE_CMD(...)` rows `#include`d into a translation unit — was never parsed (`.def` had no extractor), so the only reference to a command function lived in an unindexed file and `find_usages` reported the function as unused and safe to remove.

`.def` is now parsed as C (an uncontested extension) and a clearly-C `.inc` fragment is content-routed to the C extractor without disturbing the PHP/Pascal/asm claimants. A bare function identifier used in a table value position (a macro/call argument, an aggregate initializer element, a designated `.field` initializer) is captured as a function-value reference attributed to the file node and bound by the resolver to the command function in its defining translation unit.

### 3. Cross-file function-address value references bind

A function used by address in another translation unit — a function-pointer identity check (`c->cmd->proc != execCommand`), a function-pointer assignment, a return of a function, or `&fn` — returned zero usages because same-file value capture drops any name the file does not declare, and C addresses functions across a flat extern namespace.

These in-function value positions are now captured and bound repo-globally, guarded so a file-local `static` function is never the target of a cross-module reference and a same-file definition wins over a same-named extern elsewhere.

### 4. LSP enrichment: parallel confirm pass + reserved add-phase budget

The reference-confirm pass ran sequentially — one open+references+close round trip per ambiguous edge (~7 edges/s) — under the full per-repo deadline, so on a medium repo it consumed the whole window before the hover / hierarchy add phase ran even once. `edges_added` stayed 0 and the lsp-tier answer set was a strict subset of an already-sparse graph. This reproduced across clangd, gopls, and rust-analyzer, so it is not a C quirk.

The reference sweep now fans out across `maxParallel`, grouped by referent file so each file is opened once and serves every target sharing it, ordered highest-yield-first so a deadline cut leaves the most confirmations landed. A
fraction of the per-repo deadline is reserved for the post-confirm sweep so a slow confirm pass can no longer starve it. The definition-rebind fallback (which opens arbitrary call-site files) runs serially after the parallel sweep so document open/close never overlaps across goroutines.

### 5. LSP enrichment reliability

Making enrichment faster and more concurrent amplifies crash storms and wasted work, so this PR also lands three adjacent reliability fixes for the same code path:

- **#220 — clang-tidy crashes / high CPU:** clangd now runs with  `--clang-tidy=false`. Gortex consumes semantic graph signal, not lint diagnostics, and a broad repo `.clang-tidy` could crash clangd into a crash → reconnect → reindex loop that pinned it at high CPU for the whole pass (observed ~113-minute runs). `--background-index` is kept — the reference-confirm pass depends on it for cross-file results. Closes #220
- **#221 — non-C/C++ files sent to clangd:** enrichment never opens a file whose extension is outside the provider's `ServerSpec` coverage. A `servesFile` guard is applied at every document-open site (implementation pass, confirm grouping, hover / hierarchy sweep, definition rebind fallback), so an asset (`.png` / `.svg`) or unrelated script (`.sh`) is no longer opened on clangd only to churn on an invalid AST. Closes #221
- **#222 — crash-loop guard:** a per-pass cap on reconnect cycles. `reconnectWithBackoff` already caps connection retries within one cycle; this caps the number of cycles, so a server that connects cleanly but keeps exiting mid-request is abandoned for the repo after the cap — with everything already flushed left intact and the provider / repo / reconnect count logged — instead of reconnecting without bound. A transient one-off exit still reconnects. Closes #222

## Testing

- New unit / end-to-end tests for each change: pointer-return extraction, command-table + designated-initializer binding, cross-file / static-guard binding, `.def` / `.inc` detection, the parallel-confirm reserved-budget path, the provider-coverage guard (asset files never reach clangd), and the crash-loop guard (a repeatedly-crashing server is abandoned, not looped).
- `go test ./...` green — the only failures were two wall-clock perf tests that are load-flaky under full-suite contention and pass in isolation.
- Touched packages pass under `-race`; the concurrent enrichment path is validated under `-race` and non-flaky.
- golangci-lint clean; wire-contract fingerprint unchanged (no graph node/edge schema changes).

## Notes

No changes to graph node/edge schemas. The end-to-end index benchmark on redis (and the Go regression benchmark) is the recommended pre-merge validation.
