### PR TITLE
feat(csharp): find_usages parity — interface members, extensions, dispatch synthesis, receiver gating

### DIFF
--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -707,11 +707,16 @@ func (e *CSharpExtractor) emitMethod(m parser.QueryResult, filePath, fileID stri
 		return
 	}
 
-	// Interface methods: legacy only collected names; no graph node was
-	// emitted for them. Mirror that.
-	if owner.kind == "interface_declaration" {
+	// Interface members feed the interface node's method-name list (read
+	// back where interface nodes are stamped). Beyond that list they also
+	// need their own member-level node: a through-interface call site binds
+	// to the interface member, so find_usages can only answer — and the
+	// member-level dispatch synthesis can only fan out to implementations —
+	// when that node exists. A C# 8 default interface method carries a body
+	// and otherwise flows through the concrete-method path unchanged.
+	isIface := owner.kind == "interface_declaration"
+	if isIface {
 		ifaceMethods[owner.name] = append(ifaceMethods[owner.name], name)
-		return
 	}
 
 	id := filePath + "::" + owner.name + "." + name
@@ -722,9 +727,22 @@ func (e *CSharpExtractor) emitMethod(m parser.QueryResult, filePath, fileID stri
 		return
 	}
 	seen[id] = true
+	// Interface members are implicitly public; an explicit modifier (a C# 8
+	// default member marked private/protected) still wins via csharpVisibility.
+	defaultVis := VisibilityPrivate
+	if isIface {
+		defaultVis = VisibilityPublic
+	}
 	meta := map[string]any{
 		"receiver":   owner.name,
-		"visibility": csharpVisibility(def.Node, src, VisibilityPrivate),
+		"visibility": csharpVisibility(def.Node, src, defaultVis),
+	}
+	// Distinguish a bodyless interface declaration from a concrete method so
+	// dispatch synthesis and analyzers can tell them apart; a bodyless
+	// member must never be treated as a dead-code candidate just for lacking
+	// a body.
+	if isIface {
+		meta["iface_member"] = true
 	}
 	if rt := extractCSharpMethodReturnType(def.Node, src, name); rt != "" {
 		meta["return_type"] = rt
@@ -799,7 +817,7 @@ func (e *CSharpExtractor) emitConstructor(m parser.QueryResult, filePath, fileID
 
 func (e *CSharpExtractor) emitField(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen map[string]bool) {
 	def := m.Captures["field.def"]
-	owner := csharpDirectMemberOwner(def.Node, src, "class_declaration", "struct_declaration")
+	owner := csharpDirectMemberOwner(def.Node, src, "class_declaration", "struct_declaration", "interface_declaration")
 	if owner.kind == "" {
 		return
 	}
@@ -809,9 +827,18 @@ func (e *CSharpExtractor) emitField(m parser.QueryResult, filePath, fileID strin
 		return
 	}
 	seen[id] = true
+	// Interface fields (C# 8+ static/const members) are implicitly public.
+	isIface := owner.kind == "interface_declaration"
+	defaultVis := VisibilityPrivate
+	if isIface {
+		defaultVis = VisibilityPublic
+	}
 	meta := map[string]any{
 		"receiver":   owner.name,
-		"visibility": csharpVisibility(def.Node, src, VisibilityPrivate),
+		"visibility": csharpVisibility(def.Node, src, defaultVis),
+	}
+	if isIface {
+		meta["iface_member"] = true
 	}
 	// A field_declaration's type lives on its nested variable_declaration
 	// (`field_declaration → variable_declaration[type] → variable_declarator`),
@@ -857,7 +884,7 @@ func (e *CSharpExtractor) emitField(m parser.QueryResult, filePath, fileID strin
 
 func (e *CSharpExtractor) emitProperty(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen map[string]bool) {
 	def := m.Captures["prop.def"]
-	owner := csharpDirectMemberOwner(def.Node, src, "class_declaration", "struct_declaration")
+	owner := csharpDirectMemberOwner(def.Node, src, "class_declaration", "struct_declaration", "interface_declaration")
 	if owner.kind == "" {
 		return
 	}
@@ -867,10 +894,19 @@ func (e *CSharpExtractor) emitProperty(m parser.QueryResult, filePath, fileID st
 		return
 	}
 	seen[id] = true
+	// Interface properties are implicitly public; explicit modifiers still win.
+	isIface := owner.kind == "interface_declaration"
+	defaultVis := VisibilityPrivate
+	if isIface {
+		defaultVis = VisibilityPublic
+	}
 	meta := map[string]any{
 		"receiver":   owner.name,
-		"visibility": csharpVisibility(def.Node, src, VisibilityPrivate),
+		"visibility": csharpVisibility(def.Node, src, defaultVis),
 		"kind":       "property",
+	}
+	if isIface {
+		meta["iface_member"] = true
 	}
 	var propTypeRaw string
 	if t := def.Node.ChildByFieldName("type"); t != nil {

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -554,6 +554,59 @@ func csharpHasModifier(decl *sitter.Node, src []byte, mod string) bool {
 	return false
 }
 
+// csharpExtensionReceiverType returns the generics- and namespace-stripped
+// type of a method's first parameter when that parameter carries the `this`
+// modifier — the receiver type of a C# extension method (`static int Foo(this
+// string s)` → "string"). Returns "" for a non-extension method. Unlike
+// normalizeCSharpTypeName it keeps primitive receivers (string / int), since
+// extension methods commonly extend them.
+func csharpExtensionReceiverType(methodNode *sitter.Node, src []byte) string {
+	if methodNode == nil {
+		return ""
+	}
+	params := methodNode.ChildByFieldName("parameters")
+	if params == nil {
+		return ""
+	}
+	var first *sitter.Node
+	for i, _nc := 0, int(params.NamedChildCount()); i < _nc; i++ {
+		c := params.NamedChild(i)
+		if c != nil && c.Type() == "parameter" {
+			first = c
+			break
+		}
+	}
+	if first == nil {
+		return ""
+	}
+	hasThis := false
+	for i, _nc := 0, int(first.ChildCount()); i < _nc; i++ {
+		c := first.Child(i)
+		if c == nil {
+			continue
+		}
+		// The `this` marker is a `modifier` child (grammar revisions may also
+		// spell it `parameter_modifier` or a bare `this` keyword node).
+		ct := c.Type()
+		if (ct == "modifier" || ct == "parameter_modifier") && strings.TrimSpace(c.Content(src)) == "this" {
+			hasThis = true
+			break
+		}
+		if ct == "this" {
+			hasThis = true
+			break
+		}
+	}
+	if !hasThis {
+		return ""
+	}
+	t := first.ChildByFieldName("type")
+	if t == nil {
+		return ""
+	}
+	return normalizeCSharpBaseName(t.Content(src))
+}
+
 // csharpEnclosingNamespace returns the dotted name of the nearest enclosing
 // namespace declaration (block or file-scoped), or "".
 func csharpEnclosingNamespace(node *sitter.Node, src []byte) string {
@@ -752,6 +805,13 @@ func (e *CSharpExtractor) emitMethod(m parser.QueryResult, filePath, fileID stri
 	}
 	if csharpHasModifier(def.Node, src, "static") {
 		meta["static"] = true
+	}
+	// Extension method: a static method whose first parameter carries the
+	// `this` modifier. Record the receiver type it extends so member-call
+	// resolution can bind `x.Foo()` to it (the id stays <StaticClass>.<name>).
+	if extType := csharpExtensionReceiverType(def.Node, src); extType != "" {
+		meta["extension"] = true
+		meta["this_param_type"] = extType
 	}
 	if ns := csharpEnclosingNamespace(def.Node, src); ns != "" {
 		meta["scope_ns"] = ns

--- a/internal/parser/languages/csharp_test.go
+++ b/internal/parser/languages/csharp_test.go
@@ -60,6 +60,68 @@ func TestCSharpExtractor_Interface(t *testing.T) {
 	assert.Equal(t, []string{"FindById", "Save"}, methods)
 }
 
+// TestCSharpExtractor_InterfaceMembers verifies that interface member
+// declarations — overloaded methods, a property, and a C# 8 default (bodied)
+// method — each get their own <file>::<Iface>.<member> node marked
+// iface_member, while the interface node still carries its method-name list.
+func TestCSharpExtractor_InterfaceMembers(t *testing.T) {
+	src := []byte(`public interface ITruncator {
+    string Truncate(string value);
+    string Truncate(string value, int length);
+    int Count { get; }
+    string Describe() => "default";
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("ITruncator.cs", src)
+	require.NoError(t, err)
+
+	// First Truncate overload keeps the bare id; the second gets the
+	// _L<line> suffix (line 3 in the source above).
+	t1 := nodeByID(result.Nodes, "ITruncator.cs::ITruncator.Truncate")
+	require.NotNil(t, t1, "first Truncate overload node")
+	assert.Equal(t, graph.KindMethod, t1.Kind)
+	assert.Equal(t, "ITruncator", t1.Meta["receiver"])
+	assert.Equal(t, VisibilityPublic, t1.Meta["visibility"])
+	assert.Equal(t, true, t1.Meta["iface_member"])
+
+	t2 := nodeByID(result.Nodes, "ITruncator.cs::ITruncator.Truncate_L3")
+	require.NotNil(t, t2, "overloaded Truncate gets the _L<line> id")
+	assert.Equal(t, true, t2.Meta["iface_member"])
+
+	// Property member — a KindField node marked property + iface_member.
+	count := nodeByID(result.Nodes, "ITruncator.cs::ITruncator.Count")
+	require.NotNil(t, count, "interface property node")
+	assert.Equal(t, graph.KindField, count.Kind)
+	assert.Equal(t, "property", count.Meta["kind"])
+	assert.Equal(t, true, count.Meta["iface_member"])
+
+	// C# 8 default (bodied) method — must NOT leak as a bare function and
+	// is still marked an interface member.
+	describe := nodeByID(result.Nodes, "ITruncator.cs::ITruncator.Describe")
+	require.NotNil(t, describe, "default interface method node")
+	assert.Equal(t, graph.KindMethod, describe.Kind)
+	assert.Equal(t, true, describe.Meta["iface_member"])
+	assert.Nil(t, nodeByID(result.Nodes, "ITruncator.cs::Describe"),
+		"default method must not leak as a bare function")
+
+	// Each member is a MemberOf the interface type node.
+	memberOf := 0
+	for _, ed := range result.Edges {
+		if ed.Kind == graph.EdgeMemberOf && ed.To == "ITruncator.cs::ITruncator" {
+			memberOf++
+		}
+	}
+	assert.Equal(t, 4, memberOf, "2 method overloads + property + default method")
+
+	// Backward compat: the interface node still lists its method names.
+	iface := nodeByID(result.Nodes, "ITruncator.cs::ITruncator")
+	require.NotNil(t, iface)
+	names, _ := iface.Meta["methods"].([]string)
+	assert.Contains(t, names, "Truncate")
+	assert.Contains(t, names, "Describe")
+}
+
 // csharpSymbolNames returns the set of non-file node names in a result.
 func csharpSymbolNames(res *parser.ExtractionResult) map[string]bool {
 	names := map[string]bool{}
@@ -281,9 +343,10 @@ namespace MyApp.Services
 	types := nodesOfKind(result.Nodes, graph.KindType)
 	assert.Len(t, types, 3)
 
-	// 3 methods: constructor + FindById + Save
+	// 5 methods: the 2 interface members (IUserService.FindById / .Save)
+	// plus the concrete UserService constructor + FindById + Save.
 	methods := nodesOfKind(result.Nodes, graph.KindMethod)
-	assert.Len(t, methods, 3)
+	assert.Len(t, methods, 5)
 
 	// 2 imports
 	imports := edgesOfKind(result.Edges, graph.EdgeImports)

--- a/internal/parser/languages/csharp_test.go
+++ b/internal/parser/languages/csharp_test.go
@@ -122,6 +122,39 @@ func TestCSharpExtractor_InterfaceMembers(t *testing.T) {
 	assert.Contains(t, names, "Describe")
 }
 
+// TestCSharpExtractor_ExtensionMethod verifies extension methods (a static
+// method whose first parameter carries the `this` modifier) are stamped with
+// extension=true + this_param_type, keep their <StaticClass>.<name> id, and a
+// plain static method is not misflagged.
+func TestCSharpExtractor_ExtensionMethod(t *testing.T) {
+	src := []byte(`public static class Exts {
+    public static string Dehumanize(this string value) { return value; }
+    public static int AddTo(this int x, int y) { return x + y; }
+    public static string Plain(string value) { return value; }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("Exts.cs", src)
+	require.NoError(t, err)
+
+	deh := nodeByID(result.Nodes, "Exts.cs::Exts.Dehumanize")
+	require.NotNil(t, deh, "extension method id stays <StaticClass>.<name>")
+	assert.Equal(t, true, deh.Meta["extension"])
+	assert.Equal(t, "string", deh.Meta["this_param_type"])
+	assert.Equal(t, true, deh.Meta["static"])
+
+	add := nodeByID(result.Nodes, "Exts.cs::Exts.AddTo")
+	require.NotNil(t, add)
+	assert.Equal(t, true, add.Meta["extension"])
+	assert.Equal(t, "int", add.Meta["this_param_type"])
+
+	// A plain static method (no `this`) must not be flagged an extension.
+	plain := nodeByID(result.Nodes, "Exts.cs::Exts.Plain")
+	require.NotNil(t, plain)
+	_, isExt := plain.Meta["extension"]
+	assert.False(t, isExt, "plain static method must not be an extension")
+}
+
 // csharpSymbolNames returns the set of non-file node names in a result.
 func csharpSymbolNames(res *parser.ExtractionResult) map[string]bool {
 	names := map[string]bool{}

--- a/internal/resolver/csharp_extension.go
+++ b/internal/resolver/csharp_extension.go
@@ -1,0 +1,102 @@
+package resolver
+
+import "github.com/zzet/gortex/internal/graph"
+
+// isCSharpExtension reports whether n is a C# extension method (a static method
+// whose first parameter carries the `this` modifier). Such methods are bound
+// only by the type-directed extension rule, never by the locality fallback. The
+// Language check keeps this C#-only: other languages (e.g. Scala) also stamp
+// Meta["extension"], and their locality resolution must be left unchanged.
+func isCSharpExtension(n *graph.Node) bool {
+	if n == nil || n.Language != "csharp" || n.Meta == nil {
+		return false
+	}
+	v, _ := n.Meta["extension"].(bool)
+	return v
+}
+
+// csharpHasCompetingMethod reports whether a non-extension method of the same
+// name is among the candidates. C# resolves an instance/interface member over
+// an extension, so without receiver-type evidence the extension must not
+// preempt a competing member the locality fallback would otherwise bind.
+func csharpHasCompetingMethod(candidates []*graph.Node) bool {
+	for _, c := range candidates {
+		if c != nil && c.Kind == graph.KindMethod && !isCSharpExtension(c) {
+			return true
+		}
+	}
+	return false
+}
+
+// tryBindCSharpExtension binds a failed C# member call `x.Foo(...)` to a static
+// extension method `Foo(this X x)`. It runs after the receiver-type passes (an
+// instance or interface member always wins over an extension in C#) and before
+// the locality fallback. Candidates are the raw same-name in-repo nodes, so a
+// reachability drop cannot hide a valid extension. Returns true when it binds.
+//
+// Precision rules — never guess on ambiguity, which would recreate the
+// same-name-wrong-type misattribution the receiver-type gate exists to prevent:
+//   - with receiver-type evidence: bind when exactly one extension's
+//     this_param_type matches the receiver; more than one stays unresolved.
+//   - without a matching type: bind only when the name maps to exactly one
+//     extension method in the repo; otherwise stay unresolved.
+func (r *Resolver) tryBindCSharpExtension(e *graph.Edge, methodName, receiverType string, candidates []*graph.Node, stats *ResolveStats) bool {
+	// C#-only: a non-C# caller must never bind to a C# extension method even
+	// when a same-named one exists in a mixed-language repo.
+	if cn := r.cachedGetNode(e.From); cn == nil || cn.Language != "csharp" {
+		return false
+	}
+	var exts []*graph.Node
+	for _, c := range candidates {
+		if isCSharpExtension(c) {
+			exts = append(exts, c)
+		}
+	}
+	if len(exts) == 0 {
+		return false
+	}
+
+	// With receiver-type evidence, prefer the extension whose this_param_type
+	// matches the receiver. Exactly one match binds; more than one is an
+	// overload/ambiguity we refuse to guess on.
+	if receiverType != "" {
+		var typed []*graph.Node
+		for _, c := range exts {
+			if tp, _ := c.Meta["this_param_type"].(string); tp != "" && tp == receiverType {
+				typed = append(typed, c)
+			}
+		}
+		if len(typed) == 1 {
+			r.bindCSharpExtension(e, typed[0], 0.9, stats)
+			return true
+		}
+		if len(typed) > 1 {
+			return false
+		}
+	}
+
+	// No type evidence (or no typed match): bind only when the name is
+	// unambiguous across the repo's extension methods AND no non-extension
+	// member of that name competes (C# instance-method precedence — let the
+	// locality fallback bind the instance method instead).
+	if len(exts) == 1 && !csharpHasCompetingMethod(candidates) {
+		r.bindCSharpExtension(e, exts[0], 0.75, stats)
+		return true
+	}
+	return false
+}
+
+// bindCSharpExtension points a member-call edge at a resolved extension method
+// at the ast_inferred tier — the binding is type-directed but not compiler-
+// verified (extension visibility depends on `using` scope we do not fully model).
+func (r *Resolver) bindCSharpExtension(e *graph.Edge, target *graph.Node, conf float64, stats *ResolveStats) {
+	e.To = target.ID
+	e.Origin = graph.OriginASTInferred
+	e.Confidence = conf
+	e.ConfidenceLabel = graph.ConfidenceLabelFor(graph.EdgeCalls, conf)
+	if e.Meta == nil {
+		e.Meta = map[string]any{}
+	}
+	e.Meta["resolution"] = "extension_method"
+	stats.Resolved++
+}

--- a/internal/resolver/csharp_extension_test.go
+++ b/internal/resolver/csharp_extension_test.go
@@ -1,0 +1,181 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// fooCallTarget returns the To-end of the single Foo call edge leaving fromID.
+func fooCallTarget(g graph.Store, fromID string) string {
+	for _, e := range g.GetOutEdges(fromID) {
+		if e.Kind != graph.EdgeCalls {
+			continue
+		}
+		if graph.IsUnresolvedTarget(e.To) {
+			if graph.UnresolvedName(e.To) == "*.Foo" || graph.UnresolvedName(e.To) == "Foo" {
+				return e.To
+			}
+			continue
+		}
+		if n := g.GetNode(e.To); n != nil && n.Name == "Foo" {
+			return e.To
+		}
+	}
+	return ""
+}
+
+// TestResolveCSharpExtension_UniqueBinds: a call on a literal receiver with no
+// type evidence binds to the sole extension method of that name.
+func TestResolveCSharpExtension_UniqueBinds(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Ext.cs": `namespace App {
+    public static class StringExt {
+        public static int Foo(this string s) { return 1; }
+    }
+}`,
+		"Caller.cs": `namespace App {
+    public class Runner {
+        public void Run() {
+            "a".Foo();
+        }
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	target := fooCallTarget(g, "Caller.cs::Runner.Run")
+	require.Equal(t, "Ext.cs::StringExt.Foo", target)
+	e := g.GetNode(target)
+	require.NotNil(t, e)
+}
+
+// TestResolveCSharpExtension_TypedDisambiguates: with a known receiver type, the
+// extension whose this_param_type matches wins over a same-named extension on
+// another type.
+func TestResolveCSharpExtension_TypedDisambiguates(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Exts.cs": `namespace App {
+    public static class E {
+        public static int Foo(this Widget w) { return 1; }
+        public static int Foo(this Gadget x) { return 2; }
+    }
+    public class Widget {}
+    public class Gadget {}
+}`,
+		"Caller.cs": `namespace App {
+    public class Runner {
+        public void Run() {
+            Widget w = new Widget();
+            w.Foo();
+        }
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	target := fooCallTarget(g, "Caller.cs::Runner.Run")
+	require.NotEmpty(t, target)
+	require.False(t, graph.IsUnresolvedTarget(target), "typed receiver should resolve")
+	n := g.GetNode(target)
+	require.NotNil(t, n)
+	assert.Equal(t, "Widget", n.Meta["this_param_type"], "should bind the Widget extension")
+}
+
+// TestResolveCSharpExtension_AmbiguousStaysUnresolved: two same-named extensions
+// on different types + a receiver with no type evidence must not be guessed —
+// neither the extension rule nor the locality fallback may pick one.
+func TestResolveCSharpExtension_AmbiguousStaysUnresolved(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Exts.cs": `namespace App {
+    public static class E1 { public static int Foo(this string s) { return 1; } }
+    public static class E2 { public static int Foo(this int n) { return 2; } }
+}`,
+		"Caller.cs": `namespace App {
+    public class Runner {
+        public void Run(Thing t) {
+            t.Foo();
+        }
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	target := fooCallTarget(g, "Caller.cs::Runner.Run")
+	require.NotEmpty(t, target)
+	assert.True(t, graph.IsUnresolvedTarget(target),
+		"ambiguous extension call must stay unresolved, got %q", target)
+}
+
+// TestResolveCSharpExtension_InstanceWinsUntypedReceiver: with an untyped
+// receiver (a field, no receiver_type), the sole extension must NOT preempt a
+// same-named instance method — the locality fallback binds the instance method.
+func TestResolveCSharpExtension_InstanceWinsUntypedReceiver(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Types.cs": `namespace App {
+    public class Repo { public int Count() { return 0; } }
+    public static class StringExt { public static int Count(this string s) { return s.Length; } }
+}`,
+		"Consumer.cs": `namespace App {
+    public class Consumer {
+        private Repo _repo = new Repo();
+        public void Run() {
+            _repo.Count();
+        }
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	var target string
+	for _, e := range g.GetOutEdges("Consumer.cs::Consumer.Run") {
+		if e.Kind == graph.EdgeCalls && !graph.IsUnresolvedTarget(e.To) {
+			if n := g.GetNode(e.To); n != nil && n.Name == "Count" {
+				target = e.To
+			}
+		}
+	}
+	assert.Equal(t, "Types.cs::Repo.Count", target,
+		"an untyped receiver must not let the extension preempt the instance method")
+}
+
+// TestIsCSharpExtension_LanguageGated: the extension guard is C#-only, so a
+// Scala extension-method node (which also stamps Meta[extension]) is never
+// treated as a C# extension — keeping Scala's locality resolution unchanged.
+func TestIsCSharpExtension_LanguageGated(t *testing.T) {
+	cs := &graph.Node{Kind: graph.KindMethod, Language: "csharp", Meta: map[string]any{"extension": true}}
+	scala := &graph.Node{Kind: graph.KindMethod, Language: "scala", Meta: map[string]any{"extension": true}}
+	assert.True(t, isCSharpExtension(cs))
+	assert.False(t, isCSharpExtension(scala),
+		"a Scala extension node must not be treated as a C# extension")
+}
+
+// TestResolveCSharpExtension_InstanceWins: an instance method beats an extension
+// of the same name (C# member-lookup precedence).
+func TestResolveCSharpExtension_InstanceWins(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Types.cs": `namespace App {
+    public class Widget {
+        public int Foo() { return 0; }
+    }
+    public static class E {
+        public static int Foo(this Widget w) { return 1; }
+    }
+}`,
+		"Caller.cs": `namespace App {
+    public class Runner {
+        public void Run() {
+            Widget w = new Widget();
+            w.Foo();
+        }
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	target := fooCallTarget(g, "Caller.cs::Runner.Run")
+	require.Equal(t, "Types.cs::Widget.Foo", target, "instance method should win over the extension")
+}

--- a/internal/resolver/csharp_iface_dispatch.go
+++ b/internal/resolver/csharp_iface_dispatch.go
@@ -1,0 +1,164 @@
+package resolver
+
+import "github.com/zzet/gortex/internal/graph"
+
+// Member-level C# interface-dispatch synthesis.
+//
+// A through-interface call site — `x.Convert(1)` where `x` is typed as the
+// interface — binds to the interface *member* declaration node
+// (<file>::IConverter.Convert), which the extractor now emits. But the method
+// a compiler would actually dispatch to at runtime lives on each concrete
+// implementation of that interface. This pass mints one best-guess `calls`
+// edge from the call site to the same-named member on every in-repo
+// implementation, so a forward/backward call walk can reach the concrete
+// bodies that a purely static binding leaves invisible.
+//
+// Only one implementation runs at any given site, so the fan-out is genuinely
+// a guess: the edges ride at the speculative tier (OriginSpeculative +
+// Meta[speculative]=true) — present-but-hidden-by-default, excluded by
+// min_tier filtering, and auditable via `analyze kind=speculative`. Keeping
+// them hidden is also what protects precision: a visible fan-out would attach
+// every interface-dispatch call site to every implementation's member.
+
+// csharpIfaceDispatchCap bounds the per-site fan-out. A widely-implemented
+// interface (Humanizer's INumberToWordsConverter has ~40 language impls) must
+// not mint an unbounded edge set from a single call site; above the cap the
+// whole fan-out is dropped as noise. Mirrors speculativeHardCap.
+const csharpIfaceDispatchCap = 40
+
+// ResolveCSharpInterfaceDispatch fans calls bound to a C# interface member out
+// to the concrete same-named member of each in-repo implementation. Returns
+// the number of fan-out edges landed.
+func ResolveCSharpInterfaceDispatch(g graph.Store) int {
+	if g == nil {
+		return 0
+	}
+
+	// interface type node id → its in-repo implementation type node ids.
+	// EdgeImplements is From=type, To=interface; only resolved targets count.
+	implsByIface := map[string][]string{}
+	for e := range g.EdgesByKind(graph.EdgeImplements) {
+		if e == nil || e.From == "" || graph.IsUnresolvedTarget(e.To) {
+			continue
+		}
+		implsByIface[e.To] = append(implsByIface[e.To], e.From)
+	}
+	if len(implsByIface) == 0 {
+		return 0
+	}
+	// implementation type node id → member name → concrete method node.
+	membersByType := memberMethodNodesByType(g)
+
+	// Existing resolved (From,To) call pairs, so a fan-out edge never
+	// duplicates a real call (e.g. a caller that already reaches the concrete
+	// member directly).
+	existing := map[string]bool{}
+	for e := range g.EdgesByKind(graph.EdgeCalls) {
+		if e == nil || e.IsSpeculative() || graph.IsUnresolvedTarget(e.To) {
+			continue
+		}
+		existing[e.From+"\x00"+e.To] = true
+	}
+
+	var batch []*graph.Edge
+	seen := map[string]bool{}
+	for e := range g.EdgesByKind(graph.EdgeCalls) {
+		if e == nil || e.IsSpeculative() || graph.IsUnresolvedTarget(e.To) {
+			continue
+		}
+		target := g.GetNode(e.To)
+		if target == nil || target.Kind != graph.KindMethod || target.Language != "csharp" ||
+			!csharpIsIfaceMember(target) {
+			continue
+		}
+		ifaceTypeID := csharpMemberOwnerType(g, target.ID)
+		if ifaceTypeID == "" {
+			continue
+		}
+		impls := implsByIface[ifaceTypeID]
+		if len(impls) == 0 || len(impls) > csharpIfaceDispatchCap {
+			continue
+		}
+		method := target.Name
+		for _, implTypeID := range impls {
+			byName := membersByType[implTypeID]
+			if byName == nil {
+				continue
+			}
+			impl := byName[method]
+			if impl == nil || impl.ID == target.ID {
+				continue
+			}
+			// In-repo only: the implementation must live in the interface's
+			// repo (cross-repo dispatch is CrossRepoResolver's domain).
+			if impl.RepoPrefix != target.RepoPrefix {
+				continue
+			}
+			if existing[e.From+"\x00"+impl.ID] {
+				continue
+			}
+			k := e.From + "\x00" + impl.ID
+			if seen[k] {
+				continue
+			}
+			seen[k] = true
+			batch = append(batch, csharpIfaceDispatchEdge(e, impl.ID, ifaceTypeID, len(impls)))
+		}
+	}
+	for _, ne := range batch {
+		g.AddEdge(ne)
+	}
+	return len(batch)
+}
+
+// csharpIsIfaceMember reports whether n is a bodyless (or default) interface
+// member declaration emitted by the C# extractor.
+func csharpIsIfaceMember(n *graph.Node) bool {
+	if n == nil || n.Meta == nil {
+		return false
+	}
+	v, _ := n.Meta["iface_member"].(bool)
+	return v
+}
+
+// csharpMemberOwnerType returns the type/interface node id a member belongs to,
+// via its EdgeMemberOf edge, or "" when unresolved.
+func csharpMemberOwnerType(g graph.Store, memberID string) string {
+	for _, oe := range g.GetOutEdges(memberID) {
+		if oe.Kind == graph.EdgeMemberOf && !graph.IsUnresolvedTarget(oe.To) {
+			return oe.To
+		}
+	}
+	return ""
+}
+
+// csharpIfaceDispatchEdge builds one speculative fan-out call edge from the
+// call site e to a concrete implementation member. Confidence is 1/N over the
+// fan-out width, floored/capped like the speculative-dispatch pass.
+func csharpIfaceDispatchEdge(e *graph.Edge, to, ifaceTypeID string, fanout int) *graph.Edge {
+	conf := 1.0
+	if fanout > 0 {
+		conf = 1.0 / float64(fanout)
+	}
+	if conf > 0.45 {
+		conf = 0.45
+	}
+	if conf < 0.05 {
+		conf = 0.05
+	}
+	ne := &graph.Edge{
+		From: e.From, To: to, Kind: graph.EdgeCalls,
+		FilePath: e.FilePath, Line: e.Line,
+		Origin:          graph.OriginSpeculative,
+		Confidence:      conf,
+		ConfidenceLabel: graph.ConfidenceLabelFor(graph.EdgeCalls, conf),
+		Meta: map[string]any{
+			graph.MetaSpeculative: true,
+			"via":                 "csharp-iface-dispatch",
+			"iface_type":          ifaceTypeID,
+			"candidate_count":     fanout,
+		},
+	}
+	StampSynthesized(ne, SynthCSharpIfaceDispatch)
+	return ne
+}

--- a/internal/resolver/csharp_iface_dispatch_test.go
+++ b/internal/resolver/csharp_iface_dispatch_test.go
@@ -1,0 +1,152 @@
+package resolver
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+// buildCSharpResolverGraph extracts each C# fixture with the real extractor and
+// loads its nodes/edges into a fresh graph — the same unresolved shape a live
+// index produces, ready for New(g).ResolveAll().
+func buildCSharpResolverGraph(t *testing.T, files map[string]string) graph.Store {
+	t.Helper()
+	g := graph.New()
+	e := languages.NewCSharpExtractor()
+	for path, src := range files {
+		r, err := e.Extract(path, []byte(src))
+		require.NoError(t, err, "csharp extract %s", path)
+		for _, n := range r.Nodes {
+			g.AddNode(n)
+		}
+		for _, ed := range r.Edges {
+			g.AddEdge(ed)
+		}
+	}
+	return g
+}
+
+// TestResolveCSharpInterfaceDispatch_EndToEnd drives the full path: the
+// extractor emits the interface member + the through-interface call, ResolveAll
+// binds the call to the interface member, and the synthesizer fans it out to
+// both concrete implementations at the speculative tier.
+func TestResolveCSharpInterfaceDispatch_EndToEnd(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"IConverter.cs": `namespace App {
+    public interface IConverter {
+        string Convert(int n);
+    }
+}`,
+		"English.cs": `namespace App {
+    public class EnglishConverter : IConverter {
+        public string Convert(int n) { return "en"; }
+    }
+}`,
+		"Ukrainian.cs": `namespace App {
+    public class UkrainianConverter : IConverter {
+        public string Convert(int n) { return "uk"; }
+    }
+}`,
+		"Runner.cs": `namespace App {
+    public class Runner {
+        public void Run(IConverter c) {
+            IConverter conv = c;
+            conv.Convert(1);
+        }
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	callerID := "Runner.cs::Runner.Run"
+	ifaceMember := "IConverter.cs::IConverter.Convert"
+
+	// (a) the through-interface call binds to the interface member.
+	require.Contains(t, callTargetsFrom(g, callerID), ifaceMember,
+		"through-interface call should bind to the interface member node")
+
+	// (b) fan-out to both implementations, speculative tier.
+	n := ResolveCSharpInterfaceDispatch(g)
+	require.Equal(t, 2, n, "one fan-out edge per implementation")
+
+	spec := map[string]*graph.Edge{}
+	for _, e := range g.GetOutEdges(callerID) {
+		if e.Kind == graph.EdgeCalls && e.IsSpeculative() {
+			spec[e.To] = e
+		}
+	}
+	for _, id := range []string{"English.cs::EnglishConverter.Convert", "Ukrainian.cs::UkrainianConverter.Convert"} {
+		e := spec[id]
+		require.NotNil(t, e, "expected speculative fan-out edge to %s", id)
+		assert.Equal(t, graph.OriginSpeculative, e.Origin)
+		assert.True(t, e.IsSpeculative())
+		assert.Equal(t, SynthCSharpIfaceDispatch, e.Meta[MetaSynthesizedBy])
+	}
+}
+
+// TestResolveCSharpInterfaceDispatch_FanoutTierAndCap uses a hand-built graph to
+// pin the fan-out shape, provenance/tier, dedup, and the fan-out cap.
+func TestResolveCSharpInterfaceDispatch_FanoutTierAndCap(t *testing.T) {
+	newGraph := func(nImpls int) graph.Store {
+		g := graph.New()
+		g.AddNode(&graph.Node{ID: "I.cs::IC", Kind: graph.KindInterface, Name: "IC", FilePath: "I.cs", Language: "csharp"})
+		g.AddNode(&graph.Node{ID: "I.cs::IC.Do", Kind: graph.KindMethod, Name: "Do", FilePath: "I.cs", Language: "csharp",
+			Meta: map[string]any{"receiver": "IC", "iface_member": true}})
+		g.AddEdge(&graph.Edge{From: "I.cs::IC.Do", To: "I.cs::IC", Kind: graph.EdgeMemberOf, FilePath: "I.cs"})
+		for i := 0; i < nImpls; i++ {
+			typ := fmt.Sprintf("Impl%d", i)
+			file := typ + ".cs"
+			g.AddNode(&graph.Node{ID: file + "::" + typ, Kind: graph.KindType, Name: typ, FilePath: file, Language: "csharp"})
+			g.AddNode(&graph.Node{ID: file + "::" + typ + ".Do", Kind: graph.KindMethod, Name: "Do", FilePath: file, Language: "csharp",
+				Meta: map[string]any{"receiver": typ}})
+			g.AddEdge(&graph.Edge{From: file + "::" + typ + ".Do", To: file + "::" + typ, Kind: graph.EdgeMemberOf, FilePath: file})
+			g.AddEdge(&graph.Edge{From: file + "::" + typ, To: "I.cs::IC", Kind: graph.EdgeImplements, FilePath: file})
+		}
+		g.AddNode(&graph.Node{ID: "C.cs::App.Run", Kind: graph.KindMethod, Name: "Run", FilePath: "C.cs", Language: "csharp",
+			Meta: map[string]any{"receiver": "App"}})
+		g.AddEdge(&graph.Edge{From: "C.cs::App.Run", To: "I.cs::IC.Do", Kind: graph.EdgeCalls, FilePath: "C.cs", Line: 3})
+		return g
+	}
+
+	t.Run("fan-out tier + dedup", func(t *testing.T) {
+		g := newGraph(2)
+		require.Equal(t, 2, ResolveCSharpInterfaceDispatch(g))
+
+		spec := map[string]*graph.Edge{}
+		for _, e := range g.GetOutEdges("C.cs::App.Run") {
+			if e.Kind == graph.EdgeCalls && e.IsSpeculative() {
+				spec[e.To] = e
+			}
+		}
+		require.Len(t, spec, 2)
+		for _, id := range []string{"Impl0.cs::Impl0.Do", "Impl1.cs::Impl1.Do"} {
+			e := spec[id]
+			require.NotNil(t, e, id)
+			assert.Equal(t, graph.OriginSpeculative, e.Origin)
+			assert.Equal(t, SynthCSharpIfaceDispatch, e.Meta[MetaSynthesizedBy])
+			assert.Equal(t, "C.cs", e.FilePath)
+			assert.Equal(t, 3, e.Line)
+		}
+
+		// Idempotent: a second run dedups, leaving exactly two fan-out edges.
+		ResolveCSharpInterfaceDispatch(g)
+		got := 0
+		for _, e := range g.GetOutEdges("C.cs::App.Run") {
+			if e.Kind == graph.EdgeCalls && e.IsSpeculative() {
+				got++
+			}
+		}
+		assert.Equal(t, 2, got, "re-run must not duplicate fan-out edges")
+	})
+
+	t.Run("fan-out cap drops noise", func(t *testing.T) {
+		g := newGraph(csharpIfaceDispatchCap + 1)
+		assert.Equal(t, 0, ResolveCSharpInterfaceDispatch(g),
+			"a fan-out wider than the cap is dropped as noise")
+	})
+}

--- a/internal/resolver/csharp_receiver_gate.go
+++ b/internal/resolver/csharp_receiver_gate.go
@@ -1,0 +1,204 @@
+package resolver
+
+import (
+	"strconv"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Receiver-type gating for C# member-call attribution.
+//
+// The extractor stamps Meta["receiver_type"] on a member-call candidate when
+// the local type environment knows the receiver. When such a call cannot bind
+// to a member of that exact type (nor of a base/interface it derives from) and
+// a weak resolver tier falls back to a same-named member on an *unrelated*
+// type, the attribution is wrong: an edge that names its receiver type must not
+// attach to a same-named member of an unrelated type. This pass demotes those
+// edges to the speculative tier so they drop out of every default query and
+// min_tier filter — while a genuine inherited / interface-dispatch call (where
+// the target's receiver is a super-type of the receiver_type) and a valid
+// extension-method binding are both preserved, so the gate adds no false
+// negatives.
+//
+// The demotion re-writes the edge (remove + re-add as speculative) rather than
+// mutating it in place: an in-place Origin/Meta change is a no-op on the
+// non-memory backends, which return decoded copies from EdgesByKind. RemoveEdge
+// is keyed only by (from,to,kind), so every edge in an affected group is
+// snapshotted and re-added, preserving legitimately-typed sibling calls.
+
+// demoteCSharpMisattributedMemberCalls demotes weak-tier C# member calls whose
+// bound target belongs to a type unrelated to the edge's receiver_type. Returns
+// the number of edges demoted.
+func demoteCSharpMisattributedMemberCalls(g graph.Store) int {
+	if g == nil {
+		return 0
+	}
+	// C# type/interface name → node ids, and each type's super-type / interface
+	// (up) edges, for hierarchy-relatedness checks by name.
+	nameToTypeIDs := map[string][]string{}
+	for _, n := range nodesByKindsOrAll(g, graph.KindType, graph.KindInterface) {
+		if n == nil || n.Language != "csharp" || n.Name == "" {
+			continue
+		}
+		nameToTypeIDs[n.Name] = append(nameToTypeIDs[n.Name], n.ID)
+	}
+	if len(nameToTypeIDs) == 0 {
+		return 0
+	}
+	up := map[string][]string{}
+	for _, k := range []graph.EdgeKind{graph.EdgeExtends, graph.EdgeImplements} {
+		for e := range g.EdgesByKind(k) {
+			if e == nil || e.From == "" || graph.IsUnresolvedTarget(e.To) {
+				continue
+			}
+			up[e.From] = append(up[e.From], e.To)
+		}
+	}
+
+	groupKey := func(from, to string, kind graph.EdgeKind) string {
+		return from + "\x00" + to + "\x00" + string(kind)
+	}
+	edgeKey := func(e *graph.Edge) string {
+		return e.From + "\x00" + e.To + "\x00" + string(e.Kind) + "\x00" + e.FilePath + "\x00" + strconv.Itoa(e.Line)
+	}
+
+	// Pass 1: which edges to demote, and which (from,to,kind) groups they touch.
+	demote := map[string]bool{}
+	affected := map[string]bool{}
+	for e := range g.EdgesByKind(graph.EdgeCalls) {
+		if !csharpShouldDemote(g, e, nameToTypeIDs, up) {
+			continue
+		}
+		demote[edgeKey(e)] = true
+		affected[groupKey(e.From, e.To, e.Kind)] = true
+	}
+	if len(affected) == 0 {
+		return 0
+	}
+
+	// Pass 2: snapshot every edge in an affected group (siblings included) so
+	// the coarse RemoveEdge can be reversed precisely.
+	groups := map[string][]*graph.Edge{}
+	for e := range g.EdgesByKind(graph.EdgeCalls) {
+		gk := groupKey(e.From, e.To, e.Kind)
+		if affected[gk] {
+			groups[gk] = append(groups[gk], e)
+		}
+	}
+
+	demoted := 0
+	for _, edges := range groups {
+		if len(edges) == 0 {
+			continue
+		}
+		f := edges[0]
+		g.RemoveEdge(f.From, f.To, f.Kind)
+		for _, e := range edges {
+			if demote[edgeKey(e)] {
+				e.Origin = graph.OriginSpeculative
+				if e.Meta == nil {
+					e.Meta = map[string]any{}
+				}
+				e.Meta[graph.MetaSpeculative] = true
+				e.Meta["demoted"] = "receiver_type_mismatch"
+				demoted++
+			}
+			g.AddEdge(e)
+		}
+	}
+	return demoted
+}
+
+// csharpShouldDemote reports whether a resolved C# member-call edge is a
+// same-named-unrelated-type misattribution that should be demoted.
+func csharpShouldDemote(g graph.Store, e *graph.Edge, nameToTypeIDs, up map[string][]string) bool {
+	if e == nil || e.Meta == nil || e.IsSpeculative() || graph.IsUnresolvedTarget(e.To) {
+		return false
+	}
+	rt, _ := e.Meta["receiver_type"].(string)
+	if rt == "" {
+		return false
+	}
+	// A valid extension binding names the extension's static host class as the
+	// target receiver, which is by definition unrelated to the receiver it
+	// extends — never demote those.
+	if res, _ := e.Meta["resolution"].(string); res == "extension_method" {
+		return false
+	}
+	// Only the weak tiers are gated; never demote ast_resolved / lsp evidence.
+	// An empty Origin resolves to its confidence-derived tier.
+	eff := e.Origin
+	if eff == "" {
+		eff = graph.DefaultOriginFor(e.Kind, e.Confidence, "")
+	}
+	if graph.OriginRank(eff) > graph.OriginRank(graph.OriginASTInferred) {
+		return false
+	}
+	caller := g.GetNode(e.From)
+	if caller == nil || caller.Language != "csharp" {
+		return false
+	}
+	target := g.GetNode(e.To)
+	if target == nil || target.Kind != graph.KindMethod || target.Language != "csharp" || target.Meta == nil {
+		return false
+	}
+	// An extension target reached without the extension_method resolution tag
+	// (e.g. a locality pick) is still a legitimate extension — keep it.
+	if isCSharpExtension(target) {
+		return false
+	}
+	tr, _ := target.Meta["receiver"].(string)
+	if tr == "" || tr == rt {
+		return false
+	}
+	// Only demote when both endpoints are known indexed types — otherwise we
+	// cannot establish that the mismatch is a genuinely unrelated-type
+	// misattribution, and keeping the edge avoids a false negative.
+	if len(nameToTypeIDs[rt]) == 0 || len(nameToTypeIDs[tr]) == 0 {
+		return false
+	}
+	// A related receiver (the target lives on a base type / interface the
+	// receiver_type derives from) is a legitimate polymorphic call — keep.
+	return !csharpTypesRelated(nameToTypeIDs, up, rt, tr)
+}
+
+// csharpTypesRelated reports whether type names a and b are related through the
+// C# type hierarchy in either direction (one derives from / implements the
+// other, transitively).
+func csharpTypesRelated(nameToTypeIDs, up map[string][]string, a, b string) bool {
+	if a == b {
+		return true
+	}
+	return csharpNameReaches(nameToTypeIDs, up, a, b) || csharpNameReaches(nameToTypeIDs, up, b, a)
+}
+
+// csharpNameReaches reports whether any type named `from` reaches any type named
+// `to` by following super-type / interface (up) edges transitively.
+func csharpNameReaches(nameToTypeIDs, up map[string][]string, from, to string) bool {
+	targets := map[string]bool{}
+	for _, id := range nameToTypeIDs[to] {
+		targets[id] = true
+	}
+	if len(targets) == 0 {
+		return false
+	}
+	visited := map[string]bool{}
+	queue := append([]string{}, nameToTypeIDs[from]...)
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		if visited[cur] {
+			continue
+		}
+		visited[cur] = true
+		for _, p := range up[cur] {
+			if targets[p] {
+				return true
+			}
+			if !visited[p] {
+				queue = append(queue, p)
+			}
+		}
+	}
+	return false
+}

--- a/internal/resolver/csharp_receiver_gate_test.go
+++ b/internal/resolver/csharp_receiver_gate_test.go
@@ -1,0 +1,164 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func findCallEdge(g graph.Store, from, to string) *graph.Edge {
+	for _, e := range g.GetOutEdges(from) {
+		if e.Kind == graph.EdgeCalls && e.To == to {
+			return e
+		}
+	}
+	return nil
+}
+
+// TestReceiverGate_DemotesUnrelatedAttribution: a `g.Convert()` on a Gadget
+// (which has no Convert) locality-falls-back to an unrelated Ukrainian.Convert;
+// the receiver-type gate demotes that misattribution to the speculative tier so
+// find_usages on Ukrainian.Convert no longer returns the Gadget site.
+func TestReceiverGate_DemotesUnrelatedAttribution(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Widget.cs": `namespace App {
+    public class Gadget {}
+    public class Widget {
+        public void DoThing() {
+            Gadget g = new Gadget();
+            g.Convert();
+        }
+    }
+}`,
+		"Ukr.cs": `namespace App {
+    public class Ukrainian {
+        public string Convert() { return "uk"; }
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	edge := findCallEdge(g, "Widget.cs::Widget.DoThing", "Ukr.cs::Ukrainian.Convert")
+	require.NotNil(t, edge, "locality fallback should have bound the misattribution")
+	require.Equal(t, "Gadget", edge.Meta["receiver_type"])
+	require.False(t, edge.IsSpeculative(), "edge is visible before the gate")
+
+	n := demoteCSharpMisattributedMemberCalls(g)
+	require.Equal(t, 1, n)
+	// Re-fetch: the demotion removes and re-adds the edge, so query the graph
+	// for its current state rather than trusting the pre-demote pointer.
+	edge = findCallEdge(g, "Widget.cs::Widget.DoThing", "Ukr.cs::Ukrainian.Convert")
+	require.NotNil(t, edge)
+	assert.True(t, edge.IsSpeculative(), "unrelated-type attribution must be demoted")
+	assert.Equal(t, graph.OriginSpeculative, edge.Origin)
+	assert.Equal(t, "receiver_type_mismatch", edge.Meta["demoted"])
+}
+
+// TestReceiverGate_PreservesValidExtensionBinding: the extension rule binds
+// `w.Foo()` to a `static Foo(this Widget)` extension whose target receiver is
+// the static host class (unrelated to Widget). The gate must NOT demote that
+// valid binding.
+func TestReceiverGate_PreservesValidExtensionBinding(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Types.cs": `namespace App {
+    public class Widget {}
+    public static class E {
+        public static int Foo(this Widget w) { return 1; }
+    }
+}`,
+		"Caller.cs": `namespace App {
+    public class Runner {
+        public void Run() {
+            Widget w = new Widget();
+            w.Foo();
+        }
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	edge := findCallEdge(g, "Caller.cs::Runner.Run", "Types.cs::E.Foo")
+	require.NotNil(t, edge, "w.Foo() should bind to the extension E.Foo")
+	require.Equal(t, "Widget", edge.Meta["receiver_type"])
+	require.Equal(t, "extension_method", edge.Meta["resolution"])
+
+	n := demoteCSharpMisattributedMemberCalls(g)
+	assert.Equal(t, 0, n, "a valid extension binding must not be demoted")
+	edge = findCallEdge(g, "Caller.cs::Runner.Run", "Types.cs::E.Foo")
+	require.NotNil(t, edge)
+	assert.False(t, edge.IsSpeculative(), "extension binding stays visible")
+}
+
+// TestReceiverGate_PreservesSiblingCall: when a caller has both a misattributed
+// and a correctly-typed call to the same target, only the misattribution is
+// demoted; the coarse RemoveEdge must not drop the legitimate sibling.
+func TestReceiverGate_PreservesSiblingCall(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Types.cs": `namespace App {
+    public class Gadget {}
+    public class Ukrainian { public string Convert() { return "uk"; } }
+}`,
+		"Caller.cs": `namespace App {
+    public class Runner {
+        public void Run() {
+            Gadget g = new Gadget();
+            g.Convert();
+            Ukrainian u = new Ukrainian();
+            u.Convert();
+        }
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	n := demoteCSharpMisattributedMemberCalls(g)
+	require.Equal(t, 1, n, "only the Gadget-receiver misattribution is demoted")
+
+	var visible, speculative int
+	for _, e := range g.GetOutEdges("Caller.cs::Runner.Run") {
+		if e.Kind != graph.EdgeCalls || e.To != "Types.cs::Ukrainian.Convert" {
+			continue
+		}
+		if e.IsSpeculative() {
+			speculative++
+		} else {
+			visible++
+		}
+	}
+	assert.Equal(t, 1, visible, "the correctly-typed u.Convert() call stays visible")
+	assert.Equal(t, 1, speculative, "the Gadget-receiver call is demoted")
+}
+
+// TestReceiverGate_PreservesInheritedCall: a call on a subtype receiver bound to
+// a method declared on its base type is a legitimate inherited call; the gate
+// must NOT demote it (no false negatives on polymorphism).
+func TestReceiverGate_PreservesInheritedCall(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Base.cs": `namespace App {
+    public class Base {
+        public string Describe() { return "base"; }
+    }
+}`,
+		"Derived.cs": `namespace App {
+    public class Derived : Base {}
+    public class User {
+        public void Use() {
+            Derived d = new Derived();
+            d.Describe();
+        }
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	edge := findCallEdge(g, "Derived.cs::User.Use", "Base.cs::Base.Describe")
+	require.NotNil(t, edge, "inherited call should bind to the base method")
+	require.Equal(t, "Derived", edge.Meta["receiver_type"])
+
+	n := demoteCSharpMisattributedMemberCalls(g)
+	assert.Equal(t, 0, n, "an inherited (related-type) call must not be demoted")
+	assert.False(t, edge.IsSpeculative())
+}

--- a/internal/resolver/framework_synth.go
+++ b/internal/resolver/framework_synth.go
@@ -76,51 +76,52 @@ const (
 // label (for the report grouping) and as the value stamped on each
 // landed edge, so the two never drift.
 const (
-	SynthGRPCStub          = "grpc-stub"
-	SynthTemporalStub      = "temporal-stub"
-	SynthEventChannel      = "event-channel"
-	SynthSwiftObjC         = "swift-objc-bridge"
-	SynthReactNative       = "react-native-bridge"
-	SynthReactNativePair   = "react-native-native-pair"
-	SynthObserverChannel   = "observer-channel"
-	SynthClosureCollection = "closure-collection"
-	SynthReactSetState     = "react-setstate"
-	SynthFlutterSetState   = "flutter-setstate"
-	SynthKMPExpectActual   = "kmp-expect-actual"
-	SynthExpoModules       = "expo-modules-bridge"
-	SynthFabric            = "fabric-codegen"
-	SynthMyBatis           = "mybatis"
-	SynthRustScope         = "rust-scope"
-	SynthFactoryChain      = "factory-chain"
-	SynthSQLCallsite       = "sql-callsite"
-	SynthStoreFactory      = "store-factory"
-	SynthReduxThunk        = "redux-thunk"
-	SynthNgRxEffect        = "ngrx-effect"
-	SynthObjectRegistry    = "object-registry"
-	SynthRTKQuery          = "rtk-query"
-	SynthVuexDispatch      = "vuex-dispatch"
-	SynthCelery            = "celery-dispatch"
-	SynthSpringEvent       = "spring-event"
-	SynthMediatR           = "mediatr-dispatch"
-	SynthSidekiq           = "sidekiq-dispatch"
-	SynthLaravelEvent      = "laravel-event"
-	SynthFnPointerDispatch = "fn-pointer-dispatch"
-	SynthMacroExpansion    = "macro-expansion"
-	SynthGoFrameRoute      = "goframe-route"
-	SynthDjangoDescriptor  = "django-descriptor"
-	SynthExpressResolve    = "express-resolve"
-	SynthReactResolve      = "react-resolve"
-	SynthFastAPIResolve    = "fastapi-resolve"
-	SynthRailsResolve      = "rails-resolve"
-	SynthSwiftUIResolve    = "swiftui-resolve"
-	SynthUIKitResolve      = "uikit-resolve"
-	SynthVaporResolve      = "vapor-resolve"
-	SynthGinMiddleware     = "gin-middleware"
-	SynthSvelteKitLoad     = "sveltekit-load"
-	SynthSpeculative       = "speculative-dispatch"
-	SynthFnValue           = SynthFnValueCallback
-	SynthPascalFormName    = SynthPascalForm
-	SynthValueRefName      = SynthValueRef
+	SynthGRPCStub            = "grpc-stub"
+	SynthTemporalStub        = "temporal-stub"
+	SynthEventChannel        = "event-channel"
+	SynthSwiftObjC           = "swift-objc-bridge"
+	SynthReactNative         = "react-native-bridge"
+	SynthReactNativePair     = "react-native-native-pair"
+	SynthObserverChannel     = "observer-channel"
+	SynthClosureCollection   = "closure-collection"
+	SynthReactSetState       = "react-setstate"
+	SynthFlutterSetState     = "flutter-setstate"
+	SynthKMPExpectActual     = "kmp-expect-actual"
+	SynthExpoModules         = "expo-modules-bridge"
+	SynthFabric              = "fabric-codegen"
+	SynthMyBatis             = "mybatis"
+	SynthRustScope           = "rust-scope"
+	SynthFactoryChain        = "factory-chain"
+	SynthSQLCallsite         = "sql-callsite"
+	SynthStoreFactory        = "store-factory"
+	SynthReduxThunk          = "redux-thunk"
+	SynthNgRxEffect          = "ngrx-effect"
+	SynthObjectRegistry      = "object-registry"
+	SynthRTKQuery            = "rtk-query"
+	SynthVuexDispatch        = "vuex-dispatch"
+	SynthCelery              = "celery-dispatch"
+	SynthSpringEvent         = "spring-event"
+	SynthMediatR             = "mediatr-dispatch"
+	SynthCSharpIfaceDispatch = "csharp-iface-dispatch"
+	SynthSidekiq             = "sidekiq-dispatch"
+	SynthLaravelEvent        = "laravel-event"
+	SynthFnPointerDispatch   = "fn-pointer-dispatch"
+	SynthMacroExpansion      = "macro-expansion"
+	SynthGoFrameRoute        = "goframe-route"
+	SynthDjangoDescriptor    = "django-descriptor"
+	SynthExpressResolve      = "express-resolve"
+	SynthReactResolve        = "react-resolve"
+	SynthFastAPIResolve      = "fastapi-resolve"
+	SynthRailsResolve        = "rails-resolve"
+	SynthSwiftUIResolve      = "swiftui-resolve"
+	SynthUIKitResolve        = "uikit-resolve"
+	SynthVaporResolve        = "vapor-resolve"
+	SynthGinMiddleware       = "gin-middleware"
+	SynthSvelteKitLoad       = "sveltekit-load"
+	SynthSpeculative         = "speculative-dispatch"
+	SynthFnValue             = SynthFnValueCallback
+	SynthPascalFormName      = SynthPascalForm
+	SynthValueRefName        = SynthValueRef
 )
 
 // StampSynthesized marks an edge as the product of a framework
@@ -232,6 +233,11 @@ func defaultFrameworkSynthesizers() []FrameworkSynthesizer {
 		// MediatR CQRS dispatch: Send(new X()) → the IRequestHandler<X>
 		// Handle, Publish(new X()) → every INotificationHandler<X>.
 		synthFunc{name: SynthMediatR, fn: ResolveMediatRCalls},
+		// C# member-level interface dispatch: a call bound to an interface
+		// member fans out to the same-named member on each in-repo
+		// implementation, at the speculative (hidden-by-default) tier. After
+		// the implements-producing passes so the impl fan-out is complete.
+		synthFunc{name: SynthCSharpIfaceDispatch, fn: ResolveCSharpInterfaceDispatch},
 		// Sidekiq job dispatch: Worker.perform_async(...) → the worker's
 		// perform, namespace-aware. Include-gated, typed tier.
 		synthFunc{name: SynthSidekiq, fn: ResolveSidekiqCalls},

--- a/internal/resolver/framework_synth.go
+++ b/internal/resolver/framework_synth.go
@@ -327,6 +327,10 @@ type FrameworkSynthReport struct {
 	// cross-language-family gate (coincidental PascalCase collisions across
 	// two known, different families; bridge synthesizers are exempt).
 	Gated int `json:"gated_cross_family,omitempty"`
+	// ReceiverGated counts C# member-call edges demoted to the speculative
+	// tier because they attach to a same-named member of a type unrelated to
+	// the edge's receiver_type.
+	ReceiverGated int `json:"receiver_type_gated,omitempty"`
 }
 
 // RunFrameworkSynthesizers runs every registered framework synthesizer
@@ -356,6 +360,9 @@ func RunFrameworkSynthesizers(g graph.Store) FrameworkSynthReport {
 		rep.Per = append(rep.Per, SynthCount{Name: r.Name(), Edges: n})
 		rep.Total += n
 	}
+	// Receiver-type gate runs last: it corrects (demotes) already-bound C#
+	// member calls, so it must see the settled call graph.
+	rep.ReceiverGated = demoteCSharpMisattributedMemberCalls(g)
 	return rep
 }
 

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -2144,6 +2144,15 @@ func (r *Resolver) resolveMethodCall(e *graph.Edge, methodName string, stats *Re
 		}
 	}
 
+	// C# extension methods: an `x.Foo()` with no matching instance or
+	// interface member Foo may be a call to a `static Foo(this X x)`
+	// extension. Bind precisely (typed match, else unambiguous name);
+	// ambiguous stays unresolved rather than misattributing to a same-name
+	// method on an unrelated type.
+	if r.tryBindCSharpExtension(e, methodName, receiverType, rawCandidates, stats) {
+		return
+	}
+
 	// Locality fallback (replaces the previous alphabetical name-only
 	// pick). At this point candidates have survived Pass 0 — they all
 	// live in packages reachable from the caller. Prefer in this order:
@@ -2163,6 +2172,12 @@ func (r *Resolver) resolveMethodCall(e *graph.Edge, methodName string, stats *Re
 	var sameDirMethod, sameDirFunc, anyMethod, anyFunc *graph.Node
 	methodCount := 0
 	for _, c := range candidates {
+		// Extension methods are bound only by the type-directed extension
+		// rule above; a locality guess must never pick one, which would
+		// misattribute `x.Foo()` to an unrelated extension named Foo.
+		if isCSharpExtension(c) {
+			continue
+		}
 		switch c.Kind {
 		case graph.KindMethod:
 			methodCount++

--- a/internal/semantic/lsp/csharp_alt_test.go
+++ b/internal/semantic/lsp/csharp_alt_test.go
@@ -1,0 +1,58 @@
+package lsp
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// TestOmniSharpSpec_HasCSharpLsAlternative pins the registry wiring: the C#
+// server spec still serves csharp and now offers csharp-ls (a Roslyn stdio
+// LSP that is far more commonly installed than OmniSharp) as an alternative
+// command.
+func TestOmniSharpSpec_HasCSharpLsAlternative(t *testing.T) {
+	spec := SpecByName("omnisharp")
+	require.NotNil(t, spec, "omnisharp spec must exist")
+
+	servesCS := false
+	for _, l := range spec.Languages {
+		if l == "csharp" {
+			servesCS = true
+		}
+	}
+	require.True(t, servesCS, "omnisharp spec must still list csharp")
+
+	hasAlt := false
+	for _, alt := range spec.AlternativeCommands {
+		if alt.Command == "csharp-ls" {
+			hasAlt = true
+		}
+	}
+	require.True(t, hasAlt, "omnisharp spec must offer csharp-ls as an alternative")
+}
+
+// TestProviderFromSpec_ResolvesCSharpLsAlternative verifies that when omnisharp
+// is not on PATH but csharp-ls is, NewProviderFromSpec resolves to csharp-ls —
+// and the resulting Provider still reports servesCSharp() == true, so the
+// C#-scoped hardening (pre-restore, NU19xx advisory-diagnostic filter,
+// MSBuild-wedge timeout) applies to the alternative unchanged.
+func TestProviderFromSpec_ResolvesCSharpLsAlternative(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH exec-bit faking is POSIX-only")
+	}
+	dir := t.TempDir()
+	// A fake csharp-ls on PATH; omnisharp is absent because PATH is only dir.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "csharp-ls"), []byte("#!/bin/sh\n"), 0o755))
+	t.Setenv("PATH", dir)
+
+	p := NewProviderFromSpec(SpecByName("omnisharp"), zap.NewNop())
+	require.NotNil(t, p)
+	assert.Equal(t, "csharp-ls", p.command, "alt command should win when omnisharp is off PATH")
+	assert.True(t, p.servesCSharp(), "a csharp-ls-constructed provider still serves C#")
+	assert.Contains(t, p.Languages(), "csharp")
+}

--- a/internal/semantic/lsp/registry.go
+++ b/internal/semantic/lsp/registry.go
@@ -397,6 +397,13 @@ var Servers = []ServerSpec{
 		Priority:    5,
 		Daemon:      true,
 		MaxParallel: 6,
+		// csharp-ls is a Roslyn stdio LSP (`dotnet tool install csharp-ls`)
+		// that speaks plain LSP with no args and auto-discovers a .sln under
+		// the workspace root. It is far more commonly installed than
+		// OmniSharp on dev machines, so try it when omnisharp is not on PATH.
+		AlternativeCommands: []ServerAlt{
+			{Command: "csharp-ls"},
+		},
 	},
 	{
 		Name:       "ruby-lsp",


### PR DESCRIPTION
## C# find_usages parity

Brings C# `find_usages` up to par with the other typed languages. On the
Humanizer diagnostic, C# was the weakest arm — interface-dispatch recall was
~0.04 with a 67% silent-zero rate — because through-interface call sites bind
to a node that did not exist, no installed C# language server could ever run,
and the text tier attributed bare-name calls to same-named members of
unrelated types. Five dependency-ordered features, one commit each.

### F1 — Emit interface member declaration nodes
Interface method / property / field declarations now get their own
`<file>::<Iface>.<member>` node (marked `iface_member`, public by default), in
addition to the interface node's existing method-name list. A through-interface
call binds to the interface member, so that node has to exist for `find_usages`
to answer and for dispatch synthesis to fan out. C# 8 default (bodied) methods
flow through as members too; a bodyless member is never a dead-code candidate
just for lacking a body.

### F2 — Register csharp-ls as an alternative C# server
The C# spec listed only OmniSharp; csharp-ls (a Roslyn stdio LSP,
`dotnet tool install csharp-ls`) is the commonly-installed one. Added as an
`AlternativeCommands` entry. The provider's language list comes from the spec,
so a csharp-ls-backed provider still reports `servesCSharp() == true` and the
existing C#-scoped hardening applies unchanged.

### F3 — Member-level interface dispatch synthesis
A call bound to an interface member fans out to the same-named member on each
in-repo implementation, at the **speculative (hidden-by-default)** tier —
present-but-hidden, `min_tier`-excluded, auditable. Only one implementation
runs per site, so hiding both reflects the guess and protects default-view
precision. Registered in the framework-synthesizer engine; per-site fan-out is
capped and de-duplicated against real edges.

### F4 — Extension-method extraction + resolution
Extension methods (a static method whose first parameter carries `this`) are
marked `extension` + `this_param_type`. A member call with no matching instance
or interface member binds to a `static Foo(this X x)` extension — typed when a
`this_param_type` matches, else only when the name is unambiguous in the repo.
Ambiguous names stay unresolved, and the locality fallback no longer picks an
extension, so a same-named extension on an unrelated type is never guessed.

### F5 — Receiver-type gating
A member call carrying a known `receiver_type` that a weak tier attached to a
same-named member of an **unrelated** type is demoted to the speculative tier,
so it drops from default queries. It fires only when both types are known and
unrelated through the hierarchy — an inherited or interface-dispatch call
(target on a super-type) is preserved, so the gate adds no false negatives.

### Scope / safety
- C#-only behaviour changes; shared machinery is gated on the C# language so no
  other language's output changes.
- No new `graph.Node`/`graph.Edge` struct fields (only Meta keys + a resolver
  report field) — the wire-contract golden is unchanged.
- `CGO_ENABLED=1 go build` clean; `go test -race` green; golangci-lint clean on
  the touched packages.

### Verification note
F2's `lsp_resolved` acceptance and the Humanizer bench end-to-end require
`csharp-ls` on PATH (`~/.dotnet/tools`), which is not installed in this
environment, so the LSP arm and bench score were not run here. The static
features (F1, F3, F4, F5) are covered by unit + end-to-end resolver tests.
