### PR TITLE
Java usages accuracy: DI-field resolution, constructor edges, contract-edge leaks, enrichment telemetry

### DIFF
--- a/internal/graph/extraction_gap.go
+++ b/internal/graph/extraction_gap.go
@@ -124,7 +124,30 @@ func ClassifyZeroEdge(g Store, symbolID string) ZeroEdgeClass {
 	if importConsumerCount(g, symbolID) > 0 {
 		return ZeroEdgeCoverageIncomplete
 	}
+	// The graph still carries unresolved call candidates that name this
+	// symbol — `unresolved::*.<name>` call edges the resolver / enrichment
+	// pass never bound to it. Their existence is direct evidence that call
+	// sites reference this name; an empty usage set is a resolution/coverage
+	// gap, not proof the symbol is unused.
+	if hasUnresolvedSameNameCandidates(g, symbolID) {
+		return ZeroEdgeCoverageIncomplete
+	}
 	return ZeroEdgeLikelyUnused
+}
+
+// hasUnresolvedSameNameCandidates reports whether the graph holds any
+// unresolved member-call edge (`unresolved::*.<name>`) naming this callable
+// symbol. Unresolved call stubs are indexed by their target string, so this is
+// a single reverse-edge lookup — no scan. Non-callable symbols never match.
+func hasUnresolvedSameNameCandidates(g Store, symbolID string) bool {
+	n := g.GetNode(symbolID)
+	if n == nil || n.Name == "" {
+		return false
+	}
+	if n.Kind != KindFunction && n.Kind != KindMethod {
+		return false
+	}
+	return len(g.GetInEdges(UnresolvedMarker+"*."+n.Name)) > 0
 }
 
 // importConsumerCount counts the import-level consumer evidence for a
@@ -174,10 +197,12 @@ var zeroEdgeMessages = map[ZeroEdgeClass]string{
 		"normally indexed symbol always has at least a structural edge, so the " +
 		"extractor most likely did not process it — treat this empty result as " +
 		"unverified, not as proof the symbol is unused.",
-	ZeroEdgeCoverageIncomplete: "no resolved call or reference edges, but import/" +
-		"re-export edges point at this symbol or its file — consumers exist and " +
-		"reference-level resolution is incomplete for them. Treat this empty result " +
-		"as UNVERIFIED coverage, not as proof the symbol is unused or safe to remove.",
+	ZeroEdgeCoverageIncomplete: "no resolved call or reference edges, but the graph " +
+		"still carries consumer evidence — import/re-export edges pointing at this " +
+		"symbol or its file, or unresolved same-name call candidates the resolver / " +
+		"enrichment pass never bound to it. Reference-level resolution is incomplete, " +
+		"so treat this empty result as UNVERIFIED coverage, not as proof the symbol is " +
+		"unused or safe to remove.",
 }
 
 // zeroEdgeNotFoundMessage is the caveat text when the queried id is not in

--- a/internal/graph/extraction_gap_unresolved_test.go
+++ b/internal/graph/extraction_gap_unresolved_test.go
@@ -1,0 +1,36 @@
+package graph
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// A callable with no resolved incoming usages, but whose name still has
+// unresolved same-name call candidates in the graph, must be classified as
+// coverage-incomplete — not likely_unused. The unresolved stubs are direct
+// evidence that call sites reference the name; the empty usage set is a
+// resolution gap, not proof the symbol is dead.
+func TestClassifyZeroEdge_UnresolvedSameNameCandidates(t *testing.T) {
+	g := New()
+	g.AddNode(&Node{ID: "Crash.java", Kind: KindFile, Name: "Crash.java", FilePath: "Crash.java", Language: "java"})
+	g.AddNode(&Node{ID: "Crash.java::CrashController.triggerException", Kind: KindMethod, Name: "triggerException", FilePath: "Crash.java", Language: "java"})
+	g.AddNode(&Node{ID: "Test.java", Kind: KindFile, Name: "Test.java", FilePath: "Test.java", Language: "java"})
+	g.AddNode(&Node{ID: "Test.java::T.run", Kind: KindMethod, Name: "run", FilePath: "Test.java", Language: "java"})
+
+	// The method is indexed (defined) but has no resolved incoming usage.
+	g.AddEdge(&Edge{From: "Crash.java", To: "Crash.java::CrashController.triggerException", Kind: EdgeDefines})
+	// An unresolved same-name call candidate the resolver never bound.
+	g.AddEdge(&Edge{From: "Test.java::T.run", To: "unresolved::*.triggerException", Kind: EdgeCalls, FilePath: "Test.java", Line: 37})
+
+	got := ClassifyZeroEdge(g, "Crash.java::CrashController.triggerException")
+	assert.Equal(t, ZeroEdgeCoverageIncomplete, got,
+		"a symbol whose name still has unresolved call candidates must not be reported likely_unused")
+
+	// A genuinely unused method (no unresolved candidates naming it) still reads
+	// as likely_unused.
+	g.AddNode(&Node{ID: "Crash.java::CrashController.reallyDead", Kind: KindMethod, Name: "reallyDead", FilePath: "Crash.java", Language: "java"})
+	g.AddEdge(&Edge{From: "Crash.java", To: "Crash.java::CrashController.reallyDead", Kind: EdgeDefines})
+	assert.Equal(t, ZeroEdgeLikelyUnused, ClassifyZeroEdge(g, "Crash.java::CrashController.reallyDead"),
+		"a method with no unresolved candidates naming it stays likely_unused")
+}

--- a/internal/parser/languages/java.go
+++ b/internal/parser/languages/java.go
@@ -283,10 +283,18 @@ func (e *JavaExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 			calls = append(calls, dc)
 
 		case m.Captures["call.expr"] != nil:
-			// Plain-call pattern fires for `bar()` AND for the inner
-			// `bar` of `foo.bar()` — the legacy extractor emitted both
-			// edges, so we mirror that here.
+			// The plain-call pattern also fires for the inner `bar` of a
+			// selector call `foo.bar()`, which the callm case already emits
+			// WITH the receiver. Emitting a second receiver-less edge for the
+			// same site collides on the edge key (which excludes Meta) and
+			// clobbers the selector edge's receiver_type — sending the call to
+			// a same-named method in the caller's own class instead of the
+			// receiver's type. Skip it; only true bare calls (no object) fall
+			// through here.
 			expr := m.Captures["call.expr"]
+			if expr.Node != nil && expr.Node.ChildByFieldName("object") != nil {
+				return
+			}
 			calls = append(calls, javaDeferredCall{
 				name:        m.Captures["call.name"].Text,
 				line:        expr.StartLine + 1,

--- a/internal/parser/languages/java.go
+++ b/internal/parser/languages/java.go
@@ -408,7 +408,17 @@ func (e *JavaExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 			Kind: graph.EdgeCalls, FilePath: filePath, Line: c.line,
 		}
 		if c.isSelector {
-			if recvType, ok := tenv[c.receiver]; ok {
+			// `this.<field>` receivers resolve through the enclosing class's
+			// field types exactly like the bare `<field>` spelling: strip the
+			// `this.` qualifier and look the field up in the type env (field
+			// declarations already seed tenv). The two spellings must behave
+			// identically so a DI-injected repository called as `this.owners.x()`
+			// and `owners.x()` both stamp the field's declared type.
+			recv := c.receiver
+			if field, ok := strings.CutPrefix(recv, "this."); ok && field != "" && !strings.ContainsAny(field, ".([") {
+				recv = field
+			}
+			if recvType, ok := tenv[recv]; ok {
 				edge.Meta = map[string]any{"receiver_type": recvType}
 			} else if strings.Contains(c.receiver, ".") || strings.Contains(c.receiver, "(") {
 				stampFactoryChainReceiver(edge, c.receiver, resolveChainType(c.receiver, tenv, result))
@@ -801,11 +811,25 @@ func (e *JavaExtractor) emitMethod(m parser.QueryResult, filePath, fileID string
 		return
 	}
 	seen[id] = true
-	result.Nodes = append(result.Nodes, &graph.Node{
+	flatNode := &graph.Node{
 		ID: id, Kind: graph.KindMethod, Name: name,
 		FilePath: filePath, StartLine: startLine1, EndLine: def.EndLine + 1,
 		Language: "java",
-	})
+	}
+	// Interface and enum method nodes keep the flat `<file>::<name>` ID (the
+	// bench arm and existing graphs depend on it) but carry their declaring
+	// type as Meta["receiver"] so the resolver's exact-type method-call passes
+	// (nodeReceiverType == receiver_type) can bind to them the same way they
+	// bind to class methods.
+	if enclosing != nil {
+		switch enclosing.Type() {
+		case "interface_declaration", "enum_declaration":
+			if recv := javaIdentifierName(enclosing, src); recv != "" {
+				flatNode.Meta = map[string]any{"receiver": recv}
+			}
+		}
+	}
+	result.Nodes = append(result.Nodes, flatNode)
 	result.Edges = append(result.Edges, &graph.Edge{
 		From: fileID, To: id, Kind: graph.EdgeDefines, FilePath: filePath, Line: startLine1,
 	})

--- a/internal/parser/languages/java_ctorcall_test.go
+++ b/internal/parser/languages/java_ctorcall_test.go
@@ -1,0 +1,44 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// `new Foo(arg)` inside a method must emit a calls candidate targeting the
+// flat `Foo.<init>` constructor node, alongside the existing instantiates
+// edge. The candidate is class-qualified so resolution binds it precisely.
+func TestJavaExtractor_ConstructorCallEdge(t *testing.T) {
+	src := []byte(`public class Fixture {
+    void run() {
+        PetTypeFormatter f = new PetTypeFormatter(types);
+        var v = new Visit();
+        doThing(new Owner("x"));
+    }
+}
+`)
+	e := NewJavaExtractor()
+	result, err := e.Extract("Fixture.java", src)
+	require.NoError(t, err)
+
+	ctorCalls := map[string]string{} // target -> receiver_type
+	var sawInstantiate bool
+	for _, edge := range result.Edges {
+		if edge.Kind == graph.EdgeCalls && edge.From == "Fixture.java::Fixture.run" {
+			if rt, _ := edge.Meta["via"].(string); rt == "constructor" {
+				ctorCalls[edge.To], _ = edge.Meta["receiver_type"].(string)
+			}
+		}
+		if edge.Kind == graph.EdgeInstantiates {
+			sawInstantiate = true
+		}
+	}
+	assert.Equal(t, "PetTypeFormatter", ctorCalls["unresolved::*.PetTypeFormatter.<init>"],
+		"new PetTypeFormatter(types) must emit a constructor calls candidate")
+	assert.Contains(t, ctorCalls, "unresolved::*.Visit.<init>", "new Visit() must emit a constructor calls candidate")
+	assert.Contains(t, ctorCalls, "unresolved::*.Owner.<init>", "argument-position new Owner() must emit a constructor calls candidate")
+	assert.True(t, sawInstantiate, "the instantiates edge must still be emitted alongside the calls candidate")
+}

--- a/internal/parser/languages/java_difield_test.go
+++ b/internal/parser/languages/java_difield_test.go
@@ -1,0 +1,81 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// A `this.<field>.<method>()` call must stamp the same receiver_type as the
+// bare `<field>.<method>()` spelling, resolved through the enclosing class's
+// declared field type.
+func TestJavaExtractor_ThisFieldReceiverType(t *testing.T) {
+	src := []byte(`public class OwnerController {
+    private final OwnerRepository owners;
+    public OwnerController(OwnerRepository owners) { this.owners = owners; }
+    public void find() {
+        this.owners.findByLastNameStartingWith("Smith");
+        owners.findById(1);
+    }
+}
+`)
+	e := NewJavaExtractor()
+	result, err := e.Extract("OwnerController.java", src)
+	require.NoError(t, err)
+
+	got := map[string]string{}
+	for _, edge := range edgesOfKind(result.Edges, graph.EdgeCalls) {
+		if edge.Meta == nil {
+			continue
+		}
+		if rt, ok := edge.Meta["receiver_type"].(string); ok {
+			got[edge.To] = rt
+		}
+	}
+	assert.Equal(t, "OwnerRepository", got["unresolved::*.findByLastNameStartingWith"],
+		"this.owners.findByLastNameStartingWith() must stamp receiver_type=OwnerRepository")
+	assert.Equal(t, "OwnerRepository", got["unresolved::*.findById"],
+		"owners.findById() must stamp the identical receiver_type as the this.-qualified spelling")
+}
+
+// Interface and enum method nodes keep the flat `<file>::<name>` ID but must
+// carry their declaring type as Meta["receiver"] so typed call resolution can
+// bind to them.
+func TestJavaExtractor_InterfaceEnumMethodReceiverMeta(t *testing.T) {
+	iface := []byte(`public interface OwnerRepository {
+    Owner findByLastNameStartingWith(String lastName);
+}
+`)
+	e := NewJavaExtractor()
+	result, err := e.Extract("OwnerRepository.java", iface)
+	require.NoError(t, err)
+
+	var m *graph.Node
+	for _, n := range result.Nodes {
+		if n.Kind == graph.KindMethod && n.Name == "findByLastNameStartingWith" {
+			m = n
+		}
+	}
+	require.NotNil(t, m, "interface method node must exist")
+	assert.Equal(t, "OwnerRepository.java::findByLastNameStartingWith", m.ID, "flat node ID must be preserved")
+	require.NotNil(t, m.Meta)
+	assert.Equal(t, "OwnerRepository", m.Meta["receiver"], "interface method node must carry receiver meta")
+
+	enumSrc := []byte(`public enum Kind {
+    A, B;
+    public String label() { return name(); }
+}
+`)
+	res2, err := e.Extract("Kind.java", enumSrc)
+	require.NoError(t, err)
+	var em *graph.Node
+	for _, n := range res2.Nodes {
+		if n.Kind == graph.KindMethod && n.Name == "label" {
+			em = n
+		}
+	}
+	require.NotNil(t, em, "enum method node must exist")
+	assert.Equal(t, "Kind", em.Meta["receiver"], "enum method node must carry receiver meta")
+}

--- a/internal/parser/languages/java_lambda_calls_test.go
+++ b/internal/parser/languages/java_lambda_calls_test.go
@@ -1,0 +1,45 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Calls inside lambda bodies — expression form, block form, and lambdas in
+// argument position — must emit call edges attributed to the enclosing named
+// method, exactly like top-level statements. A test that only exercises the
+// caller through a lambda (assertThatThrownBy(() -> x.y())) is a real usage of
+// x.y() and must not vanish.
+func TestJavaExtractor_LambdaBodyCalls(t *testing.T) {
+	src := []byte(`public class Fixture {
+    void run() {
+        Runnable r = () -> foo.bar();
+        assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> testee.triggerException());
+        assertThat(values).allMatch(value -> value.getId() != null);
+        list.forEach(item -> { process(item); item.finish(); });
+    }
+}
+`)
+	e := NewJavaExtractor()
+	result, err := e.Extract("Fixture.java", src)
+	require.NoError(t, err)
+
+	targets := map[string]bool{}
+	for _, edge := range edgesOfKind(result.Edges, graph.EdgeCalls) {
+		if edge.From == "Fixture.java::Fixture.run" {
+			targets[edge.To] = true
+		}
+	}
+	for _, want := range []string{
+		"unresolved::*.bar",              // expression lambda in a local init
+		"unresolved::*.triggerException", // lambda in argument position
+		"unresolved::*.getId",            // argument-position lambda with a param
+		"unresolved::*.process",          // block-bodied lambda, statement 1
+		"unresolved::*.finish",           // block-bodied lambda, statement 2
+	} {
+		assert.True(t, targets[want], "expected a call edge to %s attributed to the enclosing method", want)
+	}
+}

--- a/internal/parser/languages/java_selector_call_test.go
+++ b/internal/parser/languages/java_selector_call_test.go
@@ -1,0 +1,42 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// A selector call `x.foo()` must emit exactly one call edge carrying the
+// receiver_type — not also a receiver-less plain-call edge. The two would
+// collide on the edge key (which excludes Meta) and the receiver-less one would
+// clobber the receiver_type, so the resolver would lose the type hint.
+func TestJavaExtractor_SelectorCallNoDuplicateEdge(t *testing.T) {
+	src := []byte(`public class T {
+    private final Dep dep;
+    void run() {
+        dep.doWork();
+        bare();
+    }
+}
+`)
+	e := NewJavaExtractor()
+	result, err := e.Extract("T.java", src)
+	require.NoError(t, err)
+
+	var doWork []*graph.Edge
+	var sawBare bool
+	for _, ed := range edgesOfKind(result.Edges, graph.EdgeCalls) {
+		switch ed.To {
+		case "unresolved::*.doWork":
+			doWork = append(doWork, ed)
+		case "unresolved::*.bare":
+			sawBare = true
+		}
+	}
+	require.Len(t, doWork, 1, "a selector call must emit exactly one call edge, not a receiver-less duplicate")
+	rt, _ := doWork[0].Meta["receiver_type"].(string)
+	assert.Equal(t, "Dep", rt, "the surviving selector edge must keep its receiver_type")
+	assert.True(t, sawBare, "a true bare call still emits its plain-call edge")
+}

--- a/internal/parser/languages/java_typeuse.go
+++ b/internal/parser/languages/java_typeuse.go
@@ -134,6 +134,30 @@ func emitJavaReferenceForms(root *sitter.Node, src []byte, filePath, fileID stri
 			// the walker reaches when it descends into this node.
 			if ty := javaCreatedTypeText(n, src); ty != "" {
 				emit(ty, line, "instantiate", graph.EdgeInstantiates, graph.OriginASTInferred)
+				// A `new Foo(...)` inside a function is a call of Foo's
+				// constructor. Emit a calls candidate targeting the flat
+				// `<Class>.<init>` node name so find_usages / get_callers on the
+				// constructor surface the instantiation site. The name is
+				// class-qualified and unique, so resolution binds it to that
+				// class's explicit constructor and to no other; a class with
+				// only an implicit default constructor has no `<Class>.<init>`
+				// node, so the edge stays unresolved and behaviour is unchanged.
+				if ownerID := findEnclosingFunc(funcRanges, line); ownerID != "" {
+					if cn := canonicalizeJavaTypeRef(ty); cn != "" && !isJavaPrimitive(cn) && isJavaTypeName(cn) {
+						ckey := ownerID + "|ctorcall|" + cn + "|" + strconv.Itoa(line)
+						if !seen[ckey] {
+							seen[ckey] = true
+							result.Edges = append(result.Edges, &graph.Edge{
+								From:     ownerID,
+								To:       "unresolved::*." + cn + ".<init>",
+								Kind:     graph.EdgeCalls,
+								FilePath: filePath,
+								Line:     line,
+								Meta:     map[string]any{"receiver_type": cn, "via": "constructor"},
+							})
+						}
+					}
+				}
 			}
 
 		case "array_creation_expression":

--- a/internal/query/engine.go
+++ b/internal/query/engine.go
@@ -392,6 +392,17 @@ func (e *Engine) FindUsagesScoped(nodeID string, opts QueryOptions) *SubGraph {
 	fromIDs = append(fromIDs, nodeID)
 	fromByID := e.g.GetNodesByIDs(fromIDs)
 
+	// Framework-contract edges (a @Configuration class "provides" a @Bean
+	// factory method, a handler "handles" a route, an emitter "produces" a
+	// topic) are the plumbing graph that analyze kind=routes / contracts
+	// consume — not usages of the code symbol they land on. When the queried
+	// symbol is a callable code symbol, drop these incoming edges from its
+	// usage set; they stay in the graph for the contract analyzers. On a
+	// DI-token / infra / contract target the same kinds ARE the meaningful
+	// relationship (find_usages on a token returns its providers), so they
+	// still pass.
+	dropContractOnCode := isCodeSymbolKind(fromByID[nodeID])
+
 	for _, edge := range edges {
 		// EdgeProvides + EdgeConsumes carry DI token relationships —
 		// `@Inject(TOKEN)` and `{ provide: TOKEN, useValue: ... }`
@@ -408,6 +419,9 @@ func (e *Engine) FindUsagesScoped(nodeID string, opts QueryOptions) *SubGraph {
 		// Service returns Ingresses routing to it (EdgeDependsOn);
 		// find_usages on an Image returns workloads pulling it.
 		if isUsageEdgeKind(edge.Kind) {
+			if dropContractOnCode && isFrameworkContractEdgeKind(edge.Kind) {
+				continue
+			}
 			from := fromByID[edge.From]
 			if opts.hasScopeFilter() && (from == nil || !opts.ScopeAllows(from)) {
 				continue
@@ -1541,6 +1555,29 @@ func isUsageEdgeKind(k graph.EdgeKind) bool {
 		return true
 	}
 	return false
+}
+
+// isFrameworkContractEdgeKind reports whether an edge kind is framework
+// plumbing — the contract graph analyze kind=routes / contracts / models
+// consume — rather than a genuine code usage. find_usages suppresses these
+// when the queried symbol is a callable code symbol (a @Bean factory method's
+// only "usage" was the provides contract edge from its @Configuration class),
+// while keeping them for DI-token / topic / table / route contract targets.
+func isFrameworkContractEdgeKind(k graph.EdgeKind) bool {
+	switch k {
+	case graph.EdgeProvides, graph.EdgeConsumes,
+		graph.EdgeHandlesRoute, graph.EdgeProducesTopic, graph.EdgeConsumesTopic,
+		graph.EdgeModelsTable, graph.EdgeRendersChild:
+		return true
+	}
+	return false
+}
+
+// isCodeSymbolKind reports whether a node is a callable code symbol —
+// a function or method (constructors are methods). find_usages drops
+// framework-contract incoming edges only for these targets.
+func isCodeSymbolKind(n *graph.Node) bool {
+	return n != nil && (n.Kind == graph.KindFunction || n.Kind == graph.KindMethod)
 }
 
 // isTestSource reports whether a node was flagged as a test by the

--- a/internal/query/find_usages_contract_test.go
+++ b/internal/query/find_usages_contract_test.go
@@ -1,0 +1,68 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// A framework-contract `provides` edge landing on a @Bean factory method is
+// plumbing, not a usage — find_usages on the method must exclude it while
+// keeping genuine call usages. The same `provides` kind landing on a DI token
+// (a non-code symbol) IS the meaningful relationship and must survive.
+func TestFindUsages_ExcludesFrameworkContractOnCode(t *testing.T) {
+	g := graph.New()
+	cfg := "Config.java::AppConfig"
+	bean := "Config.java::AppConfig.localeResolver"
+	caller := "Other.java::Other.use"
+	token := "Tokens.java::API_TOKEN"
+	provider := "Providers.java::Providers.register"
+
+	g.AddNode(&graph.Node{ID: "Config.java", Kind: graph.KindFile, Name: "Config.java", Language: "java"})
+	g.AddNode(&graph.Node{ID: cfg, Kind: graph.KindType, Name: "AppConfig", FilePath: "Config.java", Language: "java"})
+	g.AddNode(&graph.Node{ID: bean, Kind: graph.KindMethod, Name: "localeResolver", FilePath: "Config.java", Language: "java"})
+	g.AddNode(&graph.Node{ID: caller, Kind: graph.KindMethod, Name: "use", FilePath: "Other.java", Language: "java"})
+	g.AddNode(&graph.Node{ID: token, Kind: graph.KindConstant, Name: "API_TOKEN", FilePath: "Tokens.java", Language: "java"})
+	g.AddNode(&graph.Node{ID: provider, Kind: graph.KindMethod, Name: "register", FilePath: "Providers.java", Language: "java"})
+
+	// @Bean plumbing: AppConfig provides the localeResolver factory method.
+	g.AddEdge(&graph.Edge{From: cfg, To: bean, Kind: graph.EdgeProvides, FilePath: "Config.java", Line: 9})
+	// A genuine call usage of the bean method.
+	g.AddEdge(&graph.Edge{From: caller, To: bean, Kind: graph.EdgeCalls, FilePath: "Other.java", Line: 12})
+	// DI-token provider: register() provides the API_TOKEN.
+	g.AddEdge(&graph.Edge{From: provider, To: token, Kind: graph.EdgeProvides, FilePath: "Providers.java", Line: 4})
+
+	e := NewEngine(g)
+
+	beanUsages := e.FindUsages(bean)
+	var sawProvides, sawCall bool
+	for _, ed := range beanUsages.Edges {
+		switch ed.Kind {
+		case graph.EdgeProvides:
+			sawProvides = true
+		case graph.EdgeCalls:
+			sawCall = true
+		}
+	}
+	assert.False(t, sawProvides, "find_usages on a @Bean method must not surface the provides contract edge")
+	assert.True(t, sawCall, "find_usages on a @Bean method must still surface genuine call usages")
+
+	// The empty-usage @Bean case: a bean method whose only incoming edge is
+	// the provides contract must report zero usages.
+	g.AddNode(&graph.Node{ID: "Config.java::AppConfig.cacheCustomizer", Kind: graph.KindMethod, Name: "cacheCustomizer", FilePath: "Config.java", Language: "java"})
+	g.AddEdge(&graph.Edge{From: cfg, To: "Config.java::AppConfig.cacheCustomizer", Kind: graph.EdgeProvides, FilePath: "Config.java", Line: 15})
+	e2 := NewEngine(g)
+	emptyBean := e2.FindUsages("Config.java::AppConfig.cacheCustomizer")
+	assert.Empty(t, emptyBean.Edges, "a @Bean method whose only edge is the provides contract has no usages")
+
+	// A DI token keeps its providers.
+	tokenUsages := e2.FindUsages(token)
+	var tokenSawProvides bool
+	for _, ed := range tokenUsages.Edges {
+		if ed.Kind == graph.EdgeProvides {
+			tokenSawProvides = true
+		}
+	}
+	assert.True(t, tokenSawProvides, "find_usages on a DI token must still surface its providers")
+}

--- a/internal/query/find_usages_repeated_sites_test.go
+++ b/internal/query/find_usages_repeated_sites_test.go
@@ -1,0 +1,53 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+// Repeated calls to the same method from the same caller on separate lines are
+// distinct usages and must each surface in find_usages — call-edge identity is
+// keyed on the source line, so consecutive `vet.getSpecialties()` sites do not
+// collapse into a single reported usage.
+func TestFindUsages_RepeatedCallSitesSurvive(t *testing.T) {
+	src := []byte(`public class ClinicServiceTests {
+    private Vet vet;
+    void shouldFindVets() {
+        vet.getSpecialties();
+        vet.getSpecialties();
+    }
+}
+`)
+	e := languages.NewJavaExtractor()
+	result, err := e.Extract("ClinicServiceTests.java", src)
+	require.NoError(t, err)
+
+	g := graph.New()
+	// The callee lives in another file; wire it and the extracted nodes/edges.
+	g.AddNode(&graph.Node{ID: "Vet.java::Vet.getSpecialties", Kind: graph.KindMethod, Name: "getSpecialties", FilePath: "Vet.java", Language: "java"})
+	for _, n := range result.Nodes {
+		g.AddNode(n)
+	}
+	// Bind each extracted getSpecialties call edge to the callee (the resolver
+	// does this in the daemon; we bind directly to isolate find_usages).
+	for _, ed := range result.Edges {
+		if ed.Kind == graph.EdgeCalls && ed.To == "unresolved::*.getSpecialties" {
+			ed.To = "Vet.java::Vet.getSpecialties"
+		}
+		g.AddEdge(ed)
+	}
+
+	sg := NewEngine(g).FindUsages("Vet.java::Vet.getSpecialties")
+	lines := map[int]bool{}
+	for _, ed := range sg.Edges {
+		if ed.Kind == graph.EdgeCalls {
+			lines[ed.Line] = true
+		}
+	}
+	assert.True(t, lines[4], "the getSpecialties() call on line 4 must be a usage")
+	assert.True(t, lines[5], "the second getSpecialties() call on line 5 must also be a usage (repeated sites do not collapse)")
+}

--- a/internal/resolver/cross_pkg_guard.go
+++ b/internal/resolver/cross_pkg_guard.go
@@ -83,11 +83,21 @@ func (r *Resolver) guardCrossPackageCallEdges(jobs []reindexJob, closure map[str
 			continue
 		}
 		callerFile := r.edgeCallerFile(j.edge)
+		callerNode := r.cachedGetNode(j.edge.From)
 		target := r.cachedGetNode(j.newTo)
 		if callerFile == "" || target == nil {
 			continue
 		}
-		if r.targetImportReachable(callerFile, target, closure) {
+		if r.targetImportReachable(callerFile, callerNode, target, closure) {
+			continue
+		}
+		// A Java member call whose only in-repo definition of the name is
+		// this target is not a cross-package mis-guess — there is nowhere
+		// else the call could bind. Java's same-package callers import
+		// nothing and inherited-method calls (owner.getId() → BaseEntity.getId
+		// two packages up) never name the declaring package, so the import
+		// closure structurally misses them. Keep the resolution.
+		if r.javaLoneMemberDefnKeep(target, j.edge, j.oldTo) {
 			continue
 		}
 		// Not reachable — revert to the unresolved placeholder and
@@ -159,7 +169,7 @@ func (r *Resolver) edgeCallerFile(e *graph.Edge) string {
 // targetImportReachable reports whether target sits in a package the
 // caller's file can see: the caller's own directory (same package), or
 // a directory present in the caller's import closure.
-func (r *Resolver) targetImportReachable(callerFile string, target *graph.Node, closure map[string]map[string]struct{}) bool {
+func (r *Resolver) targetImportReachable(callerFile string, callerNode, target *graph.Node, closure map[string]map[string]struct{}) bool {
 	if target.FilePath == "" {
 		// A target with no file (synthetic / external stub) can't be
 		// shown unreachable — leave the edge alone.
@@ -168,6 +178,15 @@ func (r *Resolver) targetImportReachable(callerFile string, target *graph.Node, 
 	callerDir := filepath.Dir(callerFile)
 	targetDir := filepath.Dir(target.FilePath)
 	if targetDir == callerDir {
+		return true
+	}
+	// Same source package across different directories is reachable without
+	// an import edge. Maven splits one package across src/main/java and
+	// src/test/java, and JVM same-package callers import nothing — so a
+	// directory-only closure reports a false "unreachable" for every
+	// test→production same-package call. scope_pkg is stamped only on JVM
+	// member nodes, so this never fires for directory-scoped ecosystems.
+	if sameScopePackage(callerNode, target) {
 		return true
 	}
 	dirs, ok := closure[callerFile]
@@ -179,6 +198,78 @@ func (r *Resolver) targetImportReachable(callerFile string, target *graph.Node, 
 	}
 	_, reachable := dirs[targetDir]
 	return reachable
+}
+
+// scopePkgOf returns a node's stamped source package (scope_pkg Meta),
+// empty when absent. Only JVM extractors (Java / Kotlin) stamp it.
+func scopePkgOf(n *graph.Node) string {
+	if n == nil || n.Meta == nil {
+		return ""
+	}
+	if p, ok := n.Meta["scope_pkg"].(string); ok {
+		return p
+	}
+	return ""
+}
+
+// sameScopePackage reports whether two nodes belong to the same source
+// package of the same language. Empty package on either side is never a
+// match, so directory-scoped ecosystems (no scope_pkg) never qualify.
+func sameScopePackage(a, b *graph.Node) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	pa := scopePkgOf(a)
+	if pa == "" {
+		return false
+	}
+	return pa == scopePkgOf(b) && a.Language == b.Language
+}
+
+// javaLoneMemberDefnKeep reports whether a to-be-reverted Java member-call
+// edge should survive the cross-package guard because its target is the sole
+// in-repo definition of the method name. A name with exactly one candidate
+// cannot be a cross-package mis-guess. Scoped to Java — the guard's revert is
+// load-bearing for Go / TS / Python precision — and gated on the receiver, when
+// known, naming an in-repo type so an external-typed receiver (a logging
+// facade's `logger.info`) still reverts rather than latching onto an unrelated
+// same-named local method.
+func (r *Resolver) javaLoneMemberDefnKeep(target *graph.Node, e *graph.Edge, oldTo string) bool {
+	if target == nil || target.Language != "java" {
+		return false
+	}
+	name := strings.TrimPrefix(graph.UnresolvedName(oldTo), "*.")
+	if name == "" {
+		return false
+	}
+	repo := r.callerRepoPrefix(e)
+	if rt := edgeReceiverType(e); rt != "" && !r.hasInRepoType(rt, repo) {
+		return false
+	}
+	n := 0
+	for _, c := range r.cachedFindNodesByNameInRepo(name, repo) {
+		if c.Language != "java" {
+			continue
+		}
+		if c.Kind == graph.KindMethod || c.Kind == graph.KindFunction {
+			if n++; n > 1 {
+				return false
+			}
+		}
+	}
+	return n == 1
+}
+
+// hasInRepoType reports whether the repo defines a type/interface named
+// typeName — the gate that keeps javaLoneMemberDefnKeep from latching a
+// call on an external-typed receiver onto an unrelated in-repo method.
+func (r *Resolver) hasInRepoType(typeName, repo string) bool {
+	for _, c := range r.cachedFindNodesByNameInRepo(typeName, repo) {
+		if c.Kind == graph.KindType || c.Kind == graph.KindInterface {
+			return true
+		}
+	}
+	return false
 }
 
 // buildImportClosure maps each caller file path to the set of directories

--- a/internal/resolver/java_ctorcall_test.go
+++ b/internal/resolver/java_ctorcall_test.go
@@ -1,0 +1,38 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// A `new Foo(arg)` constructor-call candidate must bind to the class's explicit
+// constructor node, and a `new Bar()` whose class has only an implicit default
+// constructor (no `<init>` node) must stay unresolved rather than latching onto
+// an unrelated class's constructor.
+func TestResolveMethodCall_JavaConstructorCall(t *testing.T) {
+	g := graph.New()
+	fooFile := "src/main/java/org/example/PetTypeFormatter.java"
+	testFile := "src/test/java/org/example/PetTypeFormatterTests.java"
+	g.AddNode(&graph.Node{ID: fooFile, Kind: graph.KindFile, Name: "PetTypeFormatter.java", FilePath: fooFile, Language: "java"})
+	g.AddNode(&graph.Node{ID: testFile, Kind: graph.KindFile, Name: "PetTypeFormatterTests.java", FilePath: testFile, Language: "java"})
+	g.AddNode(&graph.Node{ID: fooFile + "::PetTypeFormatter", Kind: graph.KindType, Name: "PetTypeFormatter", FilePath: fooFile, Language: "java", Meta: map[string]any{"scope_pkg": "org.example"}})
+	// Explicit constructor node: flat name `<Class>.<init>`, receiver meta.
+	g.AddNode(&graph.Node{ID: fooFile + "::PetTypeFormatter.<init>", Kind: graph.KindMethod, Name: "PetTypeFormatter.<init>", FilePath: fooFile, Language: "java", Meta: map[string]any{"receiver": "PetTypeFormatter", "scope_pkg": "org.example"}})
+	g.AddNode(&graph.Node{ID: testFile + "::PetTypeFormatterTests.shouldFormat", Kind: graph.KindMethod, Name: "shouldFormat", FilePath: testFile, Language: "java", Meta: map[string]any{"receiver": "PetTypeFormatterTests", "scope_pkg": "org.example"}})
+
+	bound := &graph.Edge{From: testFile + "::PetTypeFormatterTests.shouldFormat", To: "unresolved::*.PetTypeFormatter.<init>", Kind: graph.EdgeCalls, FilePath: testFile, Line: 52, Meta: map[string]any{"receiver_type": "PetTypeFormatter", "via": "constructor"}}
+	// A class with only an implicit default constructor — no `<init>` node.
+	implicit := &graph.Edge{From: testFile + "::PetTypeFormatterTests.shouldFormat", To: "unresolved::*.Visit.<init>", Kind: graph.EdgeCalls, FilePath: testFile, Line: 53, Meta: map[string]any{"receiver_type": "Visit", "via": "constructor"}}
+	g.AddEdge(bound)
+	g.AddEdge(implicit)
+
+	r := New(g)
+	r.ResolveAll()
+
+	assert.Equal(t, fooFile+"::PetTypeFormatter.<init>", bound.To,
+		"new PetTypeFormatter() must bind to the explicit constructor node")
+	assert.Equal(t, "unresolved::*.Visit.<init>", implicit.To,
+		"new Visit() with no explicit constructor must stay unresolved, not latch onto another class's ctor")
+}

--- a/internal/resolver/java_difield_test.go
+++ b/internal/resolver/java_difield_test.go
@@ -1,0 +1,88 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// A test-tree caller invoking an interface method declared in the main tree —
+// same Java package, two Maven directories, `this.<field>` receiver stamped
+// with receiver_type — must resolve to the interface method node and survive
+// the cross-package guard (which reverts directory-only "unreachable" edges).
+func TestResolveMethodCall_JavaMavenThisFieldInterface(t *testing.T) {
+	const pkg = "org.springframework.samples.petclinic.owner"
+	g := graph.New()
+	mainFile := "src/main/java/org/springframework/samples/petclinic/owner/OwnerRepository.java"
+	testFile := "src/test/java/org/springframework/samples/petclinic/owner/OwnerControllerTests.java"
+	g.AddNode(&graph.Node{ID: mainFile, Kind: graph.KindFile, Name: "OwnerRepository.java", FilePath: mainFile, Language: "java"})
+	g.AddNode(&graph.Node{ID: testFile, Kind: graph.KindFile, Name: "OwnerControllerTests.java", FilePath: testFile, Language: "java"})
+	g.AddNode(&graph.Node{ID: mainFile + "::OwnerRepository", Kind: graph.KindInterface, Name: "OwnerRepository", FilePath: mainFile, Language: "java", Meta: map[string]any{"scope_pkg": pkg}})
+	// Flat interface method node carrying receiver meta (WS-A #2).
+	g.AddNode(&graph.Node{ID: mainFile + "::findByLastNameStartingWith", Kind: graph.KindMethod, Name: "findByLastNameStartingWith", FilePath: mainFile, Language: "java", Meta: map[string]any{"receiver": "OwnerRepository", "scope_pkg": pkg}})
+	g.AddNode(&graph.Node{ID: testFile + "::OwnerControllerTests.processFindFormSuccess", Kind: graph.KindMethod, Name: "processFindFormSuccess", FilePath: testFile, Language: "java", Meta: map[string]any{"receiver": "OwnerControllerTests", "scope_pkg": pkg}})
+
+	// `this.owners.findByLastNameStartingWith(...)` — receiver_type stamped by
+	// the extractor (WS-A #1).
+	edge := &graph.Edge{From: testFile + "::OwnerControllerTests.processFindFormSuccess", To: "unresolved::*.findByLastNameStartingWith", Kind: graph.EdgeCalls, FilePath: testFile, Line: 94, Meta: map[string]any{"receiver_type": "OwnerRepository"}}
+	g.AddEdge(edge)
+
+	r := New(g)
+	r.ResolveAll()
+
+	assert.Equal(t, mainFile+"::findByLastNameStartingWith", edge.To,
+		"same-package test→main interface method call must resolve and survive the cross-package guard")
+}
+
+// An inherited-method call — receiver typed as an in-repo class, callee
+// declared two packages up as the sole in-repo definition of the name — must
+// resolve via the lone-definition locality pick and not be reverted, even
+// though the declaring package is never imported by name.
+func TestResolveMethodCall_JavaInheritedLoneDefinition(t *testing.T) {
+	g := graph.New()
+	modelFile := "src/main/java/org/example/model/BaseEntity.java"
+	ownerFile := "src/main/java/org/example/owner/OwnerController.java"
+	g.AddNode(&graph.Node{ID: modelFile, Kind: graph.KindFile, Name: "BaseEntity.java", FilePath: modelFile, Language: "java"})
+	g.AddNode(&graph.Node{ID: ownerFile, Kind: graph.KindFile, Name: "OwnerController.java", FilePath: ownerFile, Language: "java"})
+	g.AddNode(&graph.Node{ID: modelFile + "::BaseEntity", Kind: graph.KindType, Name: "BaseEntity", FilePath: modelFile, Language: "java", Meta: map[string]any{"scope_pkg": "org.example.model"}})
+	g.AddNode(&graph.Node{ID: modelFile + "::BaseEntity.getId", Kind: graph.KindMethod, Name: "getId", FilePath: modelFile, Language: "java", Meta: map[string]any{"receiver": "BaseEntity", "scope_pkg": "org.example.model"}})
+	// The receiver's concrete type is in-repo (gate for the lone-defn keep).
+	g.AddNode(&graph.Node{ID: ownerFile + "::Owner", Kind: graph.KindType, Name: "Owner", FilePath: ownerFile, Language: "java", Meta: map[string]any{"scope_pkg": "org.example.owner"}})
+	g.AddNode(&graph.Node{ID: ownerFile + "::OwnerController.process", Kind: graph.KindMethod, Name: "process", FilePath: ownerFile, Language: "java", Meta: map[string]any{"receiver": "OwnerController", "scope_pkg": "org.example.owner"}})
+
+	edge := &graph.Edge{From: ownerFile + "::OwnerController.process", To: "unresolved::*.getId", Kind: graph.EdgeCalls, FilePath: ownerFile, Line: 20, Meta: map[string]any{"receiver_type": "Owner"}}
+	g.AddEdge(edge)
+
+	r := New(g)
+	r.ResolveAll()
+
+	assert.Equal(t, modelFile+"::BaseEntity.getId", edge.To,
+		"call to the sole in-repo definition of getId must resolve and survive the cross-package guard")
+	assert.Equal(t, graph.OriginASTInferred, edge.Origin, "lone-candidate Java pick must land at ast_inferred grade")
+}
+
+// An external-typed receiver whose method name happens to collide with an
+// unrelated in-repo method must NOT latch onto it — the guard's lone-defn
+// exception is gated on the receiver naming an in-repo type.
+func TestResolveMethodCall_JavaExternalReceiverStillReverts(t *testing.T) {
+	g := graph.New()
+	aFile := "src/main/java/org/example/a/Service.java"
+	bFile := "src/main/java/org/example/b/Widget.java"
+	g.AddNode(&graph.Node{ID: aFile, Kind: graph.KindFile, Name: "Service.java", FilePath: aFile, Language: "java"})
+	g.AddNode(&graph.Node{ID: bFile, Kind: graph.KindFile, Name: "Widget.java", FilePath: bFile, Language: "java"})
+	// Unrelated in-repo `info` method in a different package.
+	g.AddNode(&graph.Node{ID: bFile + "::Widget.info", Kind: graph.KindMethod, Name: "info", FilePath: bFile, Language: "java", Meta: map[string]any{"receiver": "Widget", "scope_pkg": "org.example.b"}})
+	g.AddNode(&graph.Node{ID: aFile + "::Service.run", Kind: graph.KindMethod, Name: "run", FilePath: aFile, Language: "java", Meta: map[string]any{"receiver": "Service", "scope_pkg": "org.example.a"}})
+
+	// `logger.info(...)` — receiver_type Logger is an external facade, not an
+	// in-repo type.
+	edge := &graph.Edge{From: aFile + "::Service.run", To: "unresolved::*.info", Kind: graph.EdgeCalls, FilePath: aFile, Line: 5, Meta: map[string]any{"receiver_type": "Logger"}}
+	g.AddEdge(edge)
+
+	r := New(g)
+	r.ResolveAll()
+
+	assert.Equal(t, "unresolved::*.info", edge.To,
+		"a call on an external-typed receiver must not latch onto an unrelated same-named in-repo method")
+}

--- a/internal/resolver/java_override_dispatch.go
+++ b/internal/resolver/java_override_dispatch.go
@@ -20,12 +20,14 @@ const javaOverrideDispatchCap = 8
 // type is a base class stays unresolved (two candidate overrides, no exact
 // type match) and reports as a usage of neither override.
 //
-// The primary edge binds to the common base override; each derived override
-// gets a parallel edge. All land at the ast_inferred tier with
-// Meta["dispatch"]="override" — visible in default find_usages (recall parity
-// with the language server), not gated behind the speculative filter — and no
-// longer classify as ambiguous_multi_match. Scoped to Java so Go/TS/Python
-// dispatch presentation is unchanged.
+// Because the picked target set is a best guess over legal runtime targets that
+// no receiver type disambiguated, the edges land at the speculative tier
+// (OriginSpeculative + Meta["speculative"]): hidden from default find_usages so
+// they never inflate a code symbol's usage set, surfaced on demand with
+// include_speculative and via analyze kind=speculative, and marked
+// Meta["dispatch"]="override". Resolving the primary out of the
+// `unresolved::*` state also clears the ambiguous_multi_match classification.
+// Scoped to Java so Go/TS/Python dispatch presentation is unchanged.
 func (r *Resolver) resolveJavaOverrideDispatch() int {
 	g := r.graph
 	if g == nil {
@@ -58,22 +60,22 @@ func (r *Resolver) resolveJavaOverrideDispatch() int {
 		if len(cands) < 2 || len(cands) > javaOverrideDispatchCap {
 			continue
 		}
-		base, others := pickJavaOverrideBase(cands, ancestors)
-		if base == nil {
+		if !javaOverridesRelated(cands, ancestors) {
 			continue
 		}
-		jobs = append(jobs, fanout{edge: e, base: base, others: others})
+		jobs = append(jobs, fanout{edge: e, base: cands[0], others: cands[1:]})
 	}
 
 	n := 0
 	for _, j := range jobs {
 		oldTo := j.edge.To
 		j.edge.To = j.base.ID
-		j.edge.Origin = graph.OriginASTInferred
-		j.edge.Confidence = 0.5
+		j.edge.Origin = graph.OriginSpeculative
+		j.edge.Confidence = 0.3
 		if j.edge.Meta == nil {
 			j.edge.Meta = map[string]any{}
 		}
+		j.edge.Meta[graph.MetaSpeculative] = true
 		j.edge.Meta["dispatch"] = "override"
 		g.ReindexEdges([]graph.EdgeReindex{{Edge: j.edge, OldTo: oldTo}})
 		n++
@@ -81,8 +83,9 @@ func (r *Resolver) resolveJavaOverrideDispatch() int {
 			g.AddEdge(&graph.Edge{
 				From: j.edge.From, To: o.ID, Kind: graph.EdgeCalls,
 				FilePath: j.edge.FilePath, Line: j.edge.Line,
-				Origin: graph.OriginASTInferred, Confidence: 0.5,
-				Meta: map[string]any{"dispatch": "override"},
+				Origin:     graph.OriginSpeculative,
+				Confidence: 0.3,
+				Meta:       map[string]any{graph.MetaSpeculative: true, "dispatch": "override"},
 			})
 			n++
 		}
@@ -127,62 +130,84 @@ func javaOverrideCandidates(raw []*graph.Node) []*graph.Node {
 	return out
 }
 
-// pickJavaOverrideBase returns the candidate whose declaring type is an
-// ancestor-or-self of every other candidate's declaring type (the common base
-// the others override), plus the remaining candidates. Returns (nil, nil) when
-// the candidates are not a single override hierarchy — the precision gate that
-// keeps unrelated same-name methods from being sprayed together.
-func pickJavaOverrideBase(cands []*graph.Node, ancestors map[string]map[string]bool) (*graph.Node, []*graph.Node) {
-	for i, base := range cands {
-		rb := nodeReceiverType(base)
-		isBaseOfAll := true
-		for k, other := range cands {
-			if k == i {
-				continue
-			}
-			ro := nodeReceiverType(other)
-			if ro == rb {
-				continue
-			}
-			if anc := ancestors[ro]; anc == nil || !anc[rb] {
-				isBaseOfAll = false
-				break
+// javaOverridesRelated reports whether the candidate methods are overrides of a
+// common supertype: their declaring types share at least one common ancestor
+// (or one is an ancestor of another). This is the precision gate — same-name
+// methods on unrelated types (no shared ancestor) are never sprayed together,
+// while genuine overrides of a common base (two entities overriding
+// BaseEntity's toString) fan out to every override the way a language server's
+// call hierarchy attributes them.
+func javaOverridesRelated(cands []*graph.Node, ancestors map[string]map[string]bool) bool {
+	var common map[string]bool
+	for i, c := range cands {
+		rc := nodeReceiverType(c)
+		if rc == "" {
+			return false
+		}
+		// Ancestor-or-self set of this candidate's declaring type.
+		set := map[string]bool{rc: true}
+		for a := range ancestors[rc] {
+			set[a] = true
+		}
+		if i == 0 {
+			common = set
+			continue
+		}
+		for k := range common {
+			if !set[k] {
+				delete(common, k)
 			}
 		}
-		if isBaseOfAll {
-			others := make([]*graph.Node, 0, len(cands)-1)
-			for k, c := range cands {
-				if k != i {
-					others = append(others, c)
-				}
-			}
-			return base, others
+		if len(common) == 0 {
+			return false
 		}
 	}
-	return nil, nil
+	return len(common) > 0
 }
 
-// javaTypeAncestors builds, for each Java type/interface simple name, the
-// transitive set of its supertype simple names via extends/implements/composes
-// edges. Empty when the graph indexes no Java hierarchy.
+// javaBaseTypeName reduces a possibly package-qualified, generic type reference
+// to its simple class name (`model.Person<X>` → `Person`).
+func javaBaseTypeName(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexByte(s, '<'); i >= 0 {
+		s = s[:i]
+	}
+	if i := strings.LastIndexByte(s, '.'); i >= 0 {
+		s = s[i+1:]
+	}
+	return s
+}
+
+// javaTypeAncestors builds, for each Java type simple name, the transitive set
+// of its superclass simple names. The direct superclass is read from each type
+// node's scope_parent meta — the same source the scope resolver's super-method
+// walk uses — because regular Java `extends` is recorded there, not as a graph
+// EdgeExtends (only anonymous classes emit that). So a cross-package
+// inheritance chain (`owner.Owner extends model.Person extends model.BaseEntity`)
+// contributes to the hierarchy even though its supertype references never
+// resolved to a type node. Empty when the graph indexes no Java hierarchy.
 func javaTypeAncestors(g graph.Store) map[string]map[string]bool {
-	// Direct parent map by simple name.
 	direct := map[string]map[string]bool{}
-	for _, row := range structuralParentEdges(g) {
-		from := g.GetNode(row.FromID)
-		to := g.GetNode(row.ToID)
-		if from == nil || to == nil || from.Language != "java" || to.Language != "java" {
-			continue
+	add := func(childName, parentName string) {
+		if childName == "" || parentName == "" || childName == parentName {
+			return
 		}
-		if from.Name == "" || to.Name == "" || from.Name == to.Name {
-			continue
-		}
-		set := direct[from.Name]
+		set := direct[childName]
 		if set == nil {
 			set = map[string]bool{}
-			direct[from.Name] = set
+			direct[childName] = set
 		}
-		set[to.Name] = true
+		set[parentName] = true
+	}
+	for _, kind := range []graph.NodeKind{graph.KindType, graph.KindInterface} {
+		for n := range g.NodesByKind(kind) {
+			if n == nil || n.Language != "java" || n.Name == "" || n.Meta == nil {
+				continue
+			}
+			if p, ok := n.Meta[MetaScopeParentClass].(string); ok {
+				add(n.Name, javaBaseTypeName(p))
+			}
+		}
 	}
 	if len(direct) == 0 {
 		return nil

--- a/internal/resolver/java_override_dispatch.go
+++ b/internal/resolver/java_override_dispatch.go
@@ -1,0 +1,209 @@
+package resolver
+
+import (
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// javaOverrideDispatchCap bounds how many overrides a single ambiguous call
+// may fan out to. A name shared by more definitions than this is too generic
+// to attribute confidently, so the call is left ambiguous rather than sprayed
+// across the graph.
+const javaOverrideDispatchCap = 8
+
+// resolveJavaOverrideDispatch fans out an ambiguous Java member call whose
+// same-name candidates are overrides related through the class hierarchy into
+// one call edge per override — the call-hierarchy semantics jdtls and gopls
+// present, where a call on a supertype-typed receiver is a usage of every
+// override in that hierarchy. Without this, a `x.toString()` site whose static
+// type is a base class stays unresolved (two candidate overrides, no exact
+// type match) and reports as a usage of neither override.
+//
+// The primary edge binds to the common base override; each derived override
+// gets a parallel edge. All land at the ast_inferred tier with
+// Meta["dispatch"]="override" — visible in default find_usages (recall parity
+// with the language server), not gated behind the speculative filter — and no
+// longer classify as ambiguous_multi_match. Scoped to Java so Go/TS/Python
+// dispatch presentation is unchanged.
+func (r *Resolver) resolveJavaOverrideDispatch() int {
+	g := r.graph
+	if g == nil {
+		return 0
+	}
+	ancestors := javaTypeAncestors(g)
+	if len(ancestors) == 0 {
+		return 0
+	}
+
+	type fanout struct {
+		edge   *graph.Edge
+		base   *graph.Node
+		others []*graph.Node
+	}
+	var jobs []fanout
+	for e := range g.EdgesByKind(graph.EdgeCalls) {
+		if e == nil || e.IsSpeculative() {
+			continue
+		}
+		name := javaUnresolvedMemberName(e.To)
+		if name == "" || strings.HasSuffix(name, ".<init>") {
+			continue
+		}
+		caller := r.cachedGetNode(e.From)
+		if caller == nil || caller.Language != "java" {
+			continue
+		}
+		cands := javaOverrideCandidates(r.cachedFindNodesByNameInRepo(name, r.callerRepoPrefix(e)))
+		if len(cands) < 2 || len(cands) > javaOverrideDispatchCap {
+			continue
+		}
+		base, others := pickJavaOverrideBase(cands, ancestors)
+		if base == nil {
+			continue
+		}
+		jobs = append(jobs, fanout{edge: e, base: base, others: others})
+	}
+
+	n := 0
+	for _, j := range jobs {
+		oldTo := j.edge.To
+		j.edge.To = j.base.ID
+		j.edge.Origin = graph.OriginASTInferred
+		j.edge.Confidence = 0.5
+		if j.edge.Meta == nil {
+			j.edge.Meta = map[string]any{}
+		}
+		j.edge.Meta["dispatch"] = "override"
+		g.ReindexEdges([]graph.EdgeReindex{{Edge: j.edge, OldTo: oldTo}})
+		n++
+		for _, o := range j.others {
+			g.AddEdge(&graph.Edge{
+				From: j.edge.From, To: o.ID, Kind: graph.EdgeCalls,
+				FilePath: j.edge.FilePath, Line: j.edge.Line,
+				Origin: graph.OriginASTInferred, Confidence: 0.5,
+				Meta: map[string]any{"dispatch": "override"},
+			})
+			n++
+		}
+	}
+	return n
+}
+
+// javaUnresolvedMemberName returns the method name of an `unresolved::*.<name>`
+// member-call target, or "" for any other target shape.
+func javaUnresolvedMemberName(to string) string {
+	name := graph.UnresolvedName(to)
+	if name == "" {
+		return ""
+	}
+	rest, ok := strings.CutPrefix(name, "*.")
+	if !ok || strings.Contains(rest, "::") {
+		return ""
+	}
+	return rest
+}
+
+// javaOverrideCandidates filters name-matched nodes to the in-repo Java method
+// definitions, one per declaring type (deduped by receiver), excluding stubs
+// and definitions with no declaring type.
+func javaOverrideCandidates(raw []*graph.Node) []*graph.Node {
+	var out []*graph.Node
+	seen := map[string]bool{}
+	for _, n := range raw {
+		if n == nil || n.Language != "java" || n.Kind != graph.KindMethod {
+			continue
+		}
+		if graph.IsStub(n.ID) || graph.IsUnresolvedTarget(n.ID) {
+			continue
+		}
+		recv := nodeReceiverType(n)
+		if recv == "" || seen[recv] {
+			continue
+		}
+		seen[recv] = true
+		out = append(out, n)
+	}
+	return out
+}
+
+// pickJavaOverrideBase returns the candidate whose declaring type is an
+// ancestor-or-self of every other candidate's declaring type (the common base
+// the others override), plus the remaining candidates. Returns (nil, nil) when
+// the candidates are not a single override hierarchy — the precision gate that
+// keeps unrelated same-name methods from being sprayed together.
+func pickJavaOverrideBase(cands []*graph.Node, ancestors map[string]map[string]bool) (*graph.Node, []*graph.Node) {
+	for i, base := range cands {
+		rb := nodeReceiverType(base)
+		isBaseOfAll := true
+		for k, other := range cands {
+			if k == i {
+				continue
+			}
+			ro := nodeReceiverType(other)
+			if ro == rb {
+				continue
+			}
+			if anc := ancestors[ro]; anc == nil || !anc[rb] {
+				isBaseOfAll = false
+				break
+			}
+		}
+		if isBaseOfAll {
+			others := make([]*graph.Node, 0, len(cands)-1)
+			for k, c := range cands {
+				if k != i {
+					others = append(others, c)
+				}
+			}
+			return base, others
+		}
+	}
+	return nil, nil
+}
+
+// javaTypeAncestors builds, for each Java type/interface simple name, the
+// transitive set of its supertype simple names via extends/implements/composes
+// edges. Empty when the graph indexes no Java hierarchy.
+func javaTypeAncestors(g graph.Store) map[string]map[string]bool {
+	// Direct parent map by simple name.
+	direct := map[string]map[string]bool{}
+	for _, row := range structuralParentEdges(g) {
+		from := g.GetNode(row.FromID)
+		to := g.GetNode(row.ToID)
+		if from == nil || to == nil || from.Language != "java" || to.Language != "java" {
+			continue
+		}
+		if from.Name == "" || to.Name == "" || from.Name == to.Name {
+			continue
+		}
+		set := direct[from.Name]
+		if set == nil {
+			set = map[string]bool{}
+			direct[from.Name] = set
+		}
+		set[to.Name] = true
+	}
+	if len(direct) == 0 {
+		return nil
+	}
+	// Transitive closure via DFS from each type.
+	closure := make(map[string]map[string]bool, len(direct))
+	var visit func(t string, acc map[string]bool, seen map[string]bool)
+	visit = func(t string, acc, seen map[string]bool) {
+		for p := range direct[t] {
+			if seen[p] {
+				continue
+			}
+			seen[p] = true
+			acc[p] = true
+			visit(p, acc, seen)
+		}
+	}
+	for t := range direct {
+		acc := map[string]bool{}
+		visit(t, acc, map[string]bool{t: true})
+		closure[t] = acc
+	}
+	return closure
+}

--- a/internal/resolver/java_override_dispatch_test.go
+++ b/internal/resolver/java_override_dispatch_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/zzet/gortex/internal/graph"
 )
 
-// An ambiguous member call whose same-name candidates are overrides related
-// through the class hierarchy fans out to every override (the base and its
-// derived overrides), matching the language server's call-hierarchy semantics.
-// Unrelated same-name methods are left ambiguous.
+// An ambiguous member call whose same-name candidates are overrides sharing a
+// common supertype fans out to every override at the speculative tier, matching
+// the language server's call-hierarchy semantics. Unrelated same-name methods
+// are left ambiguous.
 func TestResolveJavaOverrideDispatch(t *testing.T) {
 	g := graph.New()
 	baseF := "src/main/java/org/example/model/NamedEntity.java"
@@ -21,14 +21,16 @@ func TestResolveJavaOverrideDispatch(t *testing.T) {
 	for _, f := range []string{baseF, ownerF, sysF, widgetF} {
 		g.AddNode(&graph.Node{ID: f, Kind: graph.KindFile, Name: f, FilePath: f, Language: "java"})
 	}
-	// Hierarchy: Owner extends NamedEntity.
-	g.AddNode(&graph.Node{ID: baseF + "::NamedEntity", Kind: graph.KindType, Name: "NamedEntity", FilePath: baseF, Language: "java"})
-	g.AddNode(&graph.Node{ID: ownerF + "::Owner", Kind: graph.KindType, Name: "Owner", FilePath: ownerF, Language: "java"})
-	g.AddEdge(&graph.Edge{From: ownerF + "::Owner", To: baseF + "::NamedEntity", Kind: graph.EdgeExtends})
+	// Hierarchy recorded via scope_parent (how the Java extractor records a
+	// superclass — regular `extends` is not a graph EdgeExtends): both Owner
+	// and NamedEntity extend BaseEntity, so they share it as a common ancestor.
+	g.AddNode(&graph.Node{ID: baseF + "::NamedEntity", Kind: graph.KindType, Name: "NamedEntity", FilePath: baseF, Language: "java", Meta: map[string]any{"scope_parent": "BaseEntity"}})
+	g.AddNode(&graph.Node{ID: ownerF + "::Owner", Kind: graph.KindType, Name: "Owner", FilePath: ownerF, Language: "java", Meta: map[string]any{"scope_parent": "Person"}})
+	g.AddNode(&graph.Node{ID: ownerF + "::Person", Kind: graph.KindType, Name: "Person", FilePath: ownerF, Language: "java", Meta: map[string]any{"scope_parent": "BaseEntity"}})
 	// Both override toString.
 	g.AddNode(&graph.Node{ID: baseF + "::NamedEntity.toString", Kind: graph.KindMethod, Name: "toString", FilePath: baseF, Language: "java", Meta: map[string]any{"receiver": "NamedEntity"}})
 	g.AddNode(&graph.Node{ID: ownerF + "::Owner.toString", Kind: graph.KindMethod, Name: "toString", FilePath: ownerF, Language: "java", Meta: map[string]any{"receiver": "Owner"}})
-	// An unrelated Widget.toString in a separate hierarchy — must NOT join.
+	// An unrelated Widget.render in a separate hierarchy — must NOT join.
 	g.AddNode(&graph.Node{ID: widgetF + "::Widget", Kind: graph.KindType, Name: "Widget", FilePath: widgetF, Language: "java"})
 	g.AddNode(&graph.Node{ID: widgetF + "::Widget.render", Kind: graph.KindMethod, Name: "render", FilePath: widgetF, Language: "java", Meta: map[string]any{"receiver": "Widget"}})
 
@@ -43,17 +45,19 @@ func TestResolveJavaOverrideDispatch(t *testing.T) {
 	r := New(g)
 	r.ResolveAll()
 
-	// Every override receives the call at both sites, at the override tier.
+	// Every override receives the call at both sites, at the speculative
+	// override tier (present in the graph, gated out of default responses).
 	for _, target := range []string{baseF + "::NamedEntity.toString", ownerF + "::Owner.toString"} {
-		lines := map[int]string{}
+		got := map[int]bool{}
 		for _, in := range g.GetInEdges(target) {
 			if in.Kind == graph.EdgeCalls && in.From == caller {
-				d, _ := in.Meta["dispatch"].(string)
-				lines[in.Line] = d
+				assert.Equal(t, "override", in.Meta["dispatch"], "fan-out edge must be marked dispatch=override")
+				assert.True(t, in.IsSpeculative(), "override fan-out edge must land at the speculative tier")
+				got[in.Line] = true
 			}
 		}
-		assert.Equal(t, "override", lines[125], "toString override %s must receive call site 125 at the override tier", target)
-		assert.Equal(t, "override", lines[127], "toString override %s must receive call site 127", target)
+		assert.True(t, got[125], "toString override %s must receive call site 125", target)
+		assert.True(t, got[127], "toString override %s must receive call site 127", target)
 	}
 
 	// No `unresolved::*.toString` edge remains — the ambiguity is resolved.

--- a/internal/resolver/java_override_dispatch_test.go
+++ b/internal/resolver/java_override_dispatch_test.go
@@ -1,0 +1,63 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// An ambiguous member call whose same-name candidates are overrides related
+// through the class hierarchy fans out to every override (the base and its
+// derived overrides), matching the language server's call-hierarchy semantics.
+// Unrelated same-name methods are left ambiguous.
+func TestResolveJavaOverrideDispatch(t *testing.T) {
+	g := graph.New()
+	baseF := "src/main/java/org/example/model/NamedEntity.java"
+	ownerF := "src/main/java/org/example/owner/Owner.java"
+	sysF := "src/main/java/org/example/system/PropertiesLogger.java"
+	widgetF := "src/main/java/org/example/ui/Widget.java"
+
+	for _, f := range []string{baseF, ownerF, sysF, widgetF} {
+		g.AddNode(&graph.Node{ID: f, Kind: graph.KindFile, Name: f, FilePath: f, Language: "java"})
+	}
+	// Hierarchy: Owner extends NamedEntity.
+	g.AddNode(&graph.Node{ID: baseF + "::NamedEntity", Kind: graph.KindType, Name: "NamedEntity", FilePath: baseF, Language: "java"})
+	g.AddNode(&graph.Node{ID: ownerF + "::Owner", Kind: graph.KindType, Name: "Owner", FilePath: ownerF, Language: "java"})
+	g.AddEdge(&graph.Edge{From: ownerF + "::Owner", To: baseF + "::NamedEntity", Kind: graph.EdgeExtends})
+	// Both override toString.
+	g.AddNode(&graph.Node{ID: baseF + "::NamedEntity.toString", Kind: graph.KindMethod, Name: "toString", FilePath: baseF, Language: "java", Meta: map[string]any{"receiver": "NamedEntity"}})
+	g.AddNode(&graph.Node{ID: ownerF + "::Owner.toString", Kind: graph.KindMethod, Name: "toString", FilePath: ownerF, Language: "java", Meta: map[string]any{"receiver": "Owner"}})
+	// An unrelated Widget.toString in a separate hierarchy — must NOT join.
+	g.AddNode(&graph.Node{ID: widgetF + "::Widget", Kind: graph.KindType, Name: "Widget", FilePath: widgetF, Language: "java"})
+	g.AddNode(&graph.Node{ID: widgetF + "::Widget.render", Kind: graph.KindMethod, Name: "render", FilePath: widgetF, Language: "java", Meta: map[string]any{"receiver": "Widget"}})
+
+	caller := sysF + "::PropertiesLogger.printProperties"
+	g.AddNode(&graph.Node{ID: caller, Kind: graph.KindMethod, Name: "printProperties", FilePath: sysF, Language: "java", Meta: map[string]any{"receiver": "PropertiesLogger"}})
+	// sourceProperty.toString() at two call sites, receiver type unknown.
+	g.AddEdge(&graph.Edge{From: caller, To: "unresolved::*.toString", Kind: graph.EdgeCalls, FilePath: sysF, Line: 125})
+	g.AddEdge(&graph.Edge{From: caller, To: "unresolved::*.toString", Kind: graph.EdgeCalls, FilePath: sysF, Line: 127})
+	// A lone-candidate call that must NOT fan out (only render exists).
+	g.AddEdge(&graph.Edge{From: caller, To: "unresolved::*.render", Kind: graph.EdgeCalls, FilePath: sysF, Line: 130})
+
+	r := New(g)
+	r.ResolveAll()
+
+	// Every override receives the call at both sites, at the override tier.
+	for _, target := range []string{baseF + "::NamedEntity.toString", ownerF + "::Owner.toString"} {
+		lines := map[int]string{}
+		for _, in := range g.GetInEdges(target) {
+			if in.Kind == graph.EdgeCalls && in.From == caller {
+				d, _ := in.Meta["dispatch"].(string)
+				lines[in.Line] = d
+			}
+		}
+		assert.Equal(t, "override", lines[125], "toString override %s must receive call site 125 at the override tier", target)
+		assert.Equal(t, "override", lines[127], "toString override %s must receive call site 127", target)
+	}
+
+	// No `unresolved::*.toString` edge remains — the ambiguity is resolved.
+	for _, e := range g.GetOutEdges(caller) {
+		assert.NotEqual(t, "unresolved::*.toString", e.To, "no toString call should remain ambiguous after fan-out")
+	}
+}

--- a/internal/resolver/java_selector_receiver_test.go
+++ b/internal/resolver/java_selector_receiver_test.go
@@ -1,0 +1,33 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// A selector call `testee.triggerException()` whose method name collides with a
+// method in the caller's OWN class must bind to the receiver's type, not the
+// same-named enclosing-class method — even when the receiver's type lives in a
+// sibling Maven directory the import-reachability filter would otherwise drop.
+func TestResolveMethodCall_ReceiverTypeBeatsEnclosingClass(t *testing.T) {
+	g := graph.New()
+	mainF := "src/main/java/org/example/system/CrashController.java"
+	testF := "src/test/java/org/example/system/CrashControllerTests.java"
+	g.AddNode(&graph.Node{ID: mainF, Kind: graph.KindFile, Name: "CrashController.java", FilePath: mainF, Language: "java"})
+	g.AddNode(&graph.Node{ID: testF, Kind: graph.KindFile, Name: "CrashControllerTests.java", FilePath: testF, Language: "java"})
+	// The production method the receiver-typed call should bind to.
+	g.AddNode(&graph.Node{ID: mainF + "::CrashController.triggerException", Kind: graph.KindMethod, Name: "triggerException", FilePath: mainF, Language: "java", Meta: map[string]any{"receiver": "CrashController", "scope_class": "CrashController"}})
+	// A same-named method in the caller's own class — the wrong target.
+	g.AddNode(&graph.Node{ID: testF + "::CrashControllerTests.triggerException", Kind: graph.KindMethod, Name: "triggerException", FilePath: testF, Language: "java", Meta: map[string]any{"receiver": "CrashControllerTests", "scope_class": "CrashControllerTests"}})
+
+	// `testee.triggerException()` from the test method of the same name.
+	edge := &graph.Edge{From: testF + "::CrashControllerTests.triggerException", To: "unresolved::*.triggerException", Kind: graph.EdgeCalls, FilePath: testF, Line: 37, Meta: map[string]any{"receiver_type": "CrashController"}}
+	g.AddEdge(edge)
+
+	New(g).ResolveAll()
+
+	assert.Equal(t, mainF+"::CrashController.triggerException", edge.To,
+		"a receiver-typed selector call must bind to the receiver's type, not a same-named method in the caller's own class")
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -544,6 +544,14 @@ func (r *Resolver) ResolveAll() *ResolveStats {
 	// dep-module bridge has had its chance.
 	r.attributeNonGoModuleImports()
 
+	// Java override-dispatch fan-out. An ambiguous member call on a
+	// supertype-typed receiver (`x.toString()` with two candidate
+	// overrides) stays unresolved after the cross-package guard reverts
+	// the name-only guess; this pass fans it out to every override in the
+	// hierarchy, the call-hierarchy semantics the language server presents.
+	// Runs after the guard so its ast_inferred edges are never reverted.
+	r.resolveJavaOverrideDispatch()
+
 	total := &ResolveStats{}
 	for i := range allStats {
 		total.Resolved += allStats[i].Resolved

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -2202,6 +2202,18 @@ func (r *Resolver) resolveMethodCall(e *graph.Edge, methodName string, stats *Re
 		e.Origin = graph.OriginASTInferred
 	}
 
+	// A Java member call with exactly one method candidate for the name is a
+	// grounded inference, not a text-grade guess: there is nowhere else it
+	// could bind. Lift it to the ast_inferred tier so min_tier filtering and
+	// the cross-package guard treat it as the resolved target it is (the
+	// guard's Java lone-definition exception keeps it from being reverted).
+	if methodCount == 1 && anyMethod != nil && anyMethod.Language == "java" && e.Origin == "" {
+		e.Origin = graph.OriginASTInferred
+		if e.Confidence == 0 {
+			e.Confidence = 0.7
+		}
+	}
+
 	if sameDirMethod != nil {
 		e.To = sameDirMethod.ID
 		stats.Resolved++

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -2069,10 +2069,17 @@ func (r *Resolver) resolveMethodCall(e *graph.Edge, methodName string, stats *Re
 	callerDir := r.dirFor(e.FilePath)
 	receiverType := edgeReceiverType(e)
 
-	// If we have a type hint, try exact type match first.
+	// If we have a type hint, try exact type match first. These passes scan
+	// the UNFILTERED candidate set: a receiver typed as T binds to T's method
+	// regardless of whether the caller's file imports T's package. Import-
+	// reachability filtering can drop the receiver's own type when it lives in
+	// a sibling Maven directory (src/main vs src/test) the caller never
+	// imports, leaving a same-named method in the caller's own class as the
+	// only survivor — so the exact-type match must see every candidate, not
+	// just the reachable ones.
 	if receiverType != "" {
 		// Pass 1: same-directory + exact type match (highest confidence).
-		for _, c := range candidates {
+		for _, c := range rawCandidates {
 			if c.Kind == graph.KindMethod &&
 				r.dirFor(c.FilePath) == callerDir &&
 				nodeReceiverType(c) == receiverType {
@@ -2083,10 +2090,10 @@ func (r *Resolver) resolveMethodCall(e *graph.Edge, methodName string, stats *Re
 			}
 		}
 		// Pass 2: exact type match, any directory.
-		for _, c := range candidates {
+		for _, c := range rawCandidates {
 			if c.Kind == graph.KindMethod && nodeReceiverType(c) == receiverType {
 				e.To = c.ID
-				e.Confidence = 0.85
+				e.Confidence = 0.9
 				stats.Resolved++
 				return
 			}

--- a/internal/resolver/scope.go
+++ b/internal/resolver/scope.go
@@ -277,6 +277,15 @@ func (r *Resolver) preferJavaScopeCandidate(e *graph.Edge, caller *graph.Node, n
 	if enclosing == "" {
 		return nil
 	}
+	// A selector call whose receiver is typed as a DIFFERENT class is not an
+	// enclosing-class call: `testee.triggerException()` must bind to the
+	// receiver's type, not to a same-named method that merely happens to live
+	// in the caller's own class. Only bare calls (no receiver type) and calls
+	// on a receiver typed as the enclosing class itself use this rule; the
+	// receiver-type passes own everything else.
+	if rt := edgeReceiverType(e); rt != "" && rt != enclosing {
+		return nil
+	}
 	// Pass 1: exact same enclosing class.
 	for _, c := range candidates {
 		if c.Kind != graph.KindMethod {

--- a/internal/semantic/enrich_coverage_test.go
+++ b/internal/semantic/enrich_coverage_test.go
@@ -1,0 +1,52 @@
+package semantic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestEnrichBoundReason(t *testing.T) {
+	assert.Equal(t, EnrichBoundBudget, enrichBoundReason(EnrichStatePartial, &EnrichResult{SymbolsTotal: 100, SymbolsCovered: 40}))
+	assert.Equal(t, EnrichBoundBudget, enrichBoundReason(EnrichStateCompleted, &EnrichResult{Partial: true, SymbolsTotal: 100, SymbolsCovered: 40}))
+	assert.Equal(t, EnrichBoundCap, enrichBoundReason(EnrichStateCompleted, &EnrichResult{SymbolsTotal: 100, SymbolsCovered: 35}))
+	assert.Equal(t, EnrichBoundCompletedAll, enrichBoundReason(EnrichStateCompleted, &EnrichResult{SymbolsTotal: 100, SymbolsCovered: 100}))
+	assert.Equal(t, EnrichBoundCompletedAll, enrichBoundReason(EnrichStateCompleted, &EnrichResult{SymbolsTotal: 0}))
+}
+
+// A completed enrichment that covered only a sliver of its targets must surface
+// the coverage figure and a "cap" bounding reason on the status — never a bare
+// "completed" that reads as full enrichment.
+func TestSetEnrichStatus_CoverageSurfaced(t *testing.T) {
+	mgr := NewManager(Config{Enabled: true}, zap.NewNop())
+	res := &EnrichResult{
+		Provider:       "lsp-jdtls",
+		Language:       "java",
+		EdgesAdded:     156,
+		EdgesConfirmed: 554,
+		NodesEnriched:  35,
+		SymbolsTotal:   1500,
+		SymbolsCovered: 35,
+	}
+	res.CoveragePercent = float64(res.SymbolsCovered) / float64(res.SymbolsTotal) * 100
+	mgr.setEnrichStatus("petclinic", "lsp-jdtls", "java", EnrichStateCompleted, 0, res, "")
+
+	statuses := mgr.EnrichmentStatuses()
+	var st *EnrichmentStatus
+	for i := range statuses {
+		if statuses[i].Provider == "lsp-jdtls" {
+			st = &statuses[i]
+		}
+	}
+	if assert.NotNil(t, st) {
+		assert.Equal(t, EnrichStateCompleted, st.State)
+		assert.Equal(t, 1500, st.SymbolsTotal)
+		assert.Equal(t, 35, st.SymbolsCovered)
+		assert.InDelta(t, 2.33, st.CoveragePercent, 0.1)
+		assert.Equal(t, EnrichBoundCap, st.BoundReason,
+			"a completed pass covering <100% of targets must report the cap bounding reason")
+	}
+	// The reason is back-stamped onto the result too.
+	assert.Equal(t, EnrichBoundCap, res.BoundReason)
+}

--- a/internal/semantic/lsp/enrich_demand_test.go
+++ b/internal/semantic/lsp/enrich_demand_test.go
@@ -1,0 +1,32 @@
+package lsp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// The add-phase prioritises declarations that still carry unresolved same-name
+// call candidates, so a deadline-bound pass spends its budget where an LSP
+// references sweep can actually bind dropped call sites.
+func TestEnrichNodeHasUnresolvedDemand(t *testing.T) {
+	g := graph.New()
+	demanded := &graph.Node{ID: "Repo.java::OwnerRepository.findByLastNameStartingWith", Kind: graph.KindMethod, Name: "findByLastNameStartingWith", FilePath: "Repo.java", Language: "java"}
+	covered := &graph.Node{ID: "Repo.java::OwnerRepository.findById", Kind: graph.KindMethod, Name: "findById", FilePath: "Repo.java", Language: "java"}
+	g.AddNode(demanded)
+	g.AddNode(covered)
+	g.AddNode(&graph.Node{ID: "T.java::T.run", Kind: graph.KindMethod, Name: "run", FilePath: "T.java", Language: "java"})
+
+	// An unresolved same-name candidate names findByLastNameStartingWith.
+	g.AddEdge(&graph.Edge{From: "T.java::T.run", To: "unresolved::*.findByLastNameStartingWith", Kind: graph.EdgeCalls, FilePath: "T.java", Line: 94})
+	// findById is already covered — a resolved incoming call, no unresolved stub.
+	g.AddEdge(&graph.Edge{From: "T.java::T.run", To: covered.ID, Kind: graph.EdgeCalls, FilePath: "T.java", Line: 97})
+
+	assert.True(t, enrichNodeHasUnresolvedDemand(g, demanded),
+		"a declaration with unresolved same-name candidates has enrichment demand")
+	assert.False(t, enrichNodeHasUnresolvedDemand(g, covered),
+		"a fully-resolved declaration has no enrichment demand")
+	// A non-callable node never has demand.
+	assert.False(t, enrichNodeHasUnresolvedDemand(g, &graph.Node{ID: "x", Kind: graph.KindType, Name: "findByLastNameStartingWith"}))
+}

--- a/internal/semantic/lsp/jdtls_workspace.go
+++ b/internal/semantic/lsp/jdtls_workspace.go
@@ -1,0 +1,54 @@
+package lsp
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+
+	"github.com/zzet/gortex/internal/platform"
+)
+
+// isJdtlsCommand reports whether a resolved LSP command is the Eclipse JDT
+// language server, whether configured bare ("jdtls") or as an absolute path.
+func isJdtlsCommand(command string) bool {
+	return filepath.Base(command) == "jdtls"
+}
+
+// jdtlsWorkspaceDir returns the Eclipse workspace directory jdtls should use
+// for a repo root, rooted at Gortex's cache home (via internal/platform, so
+// XDG_CACHE_HOME overrides win and the path is Windows-safe). Without an
+// explicit -data the brew launcher defaults the workspace to
+// ~/Library/Caches/jdtls/<hash> — outside the isolation every other engine
+// artifact honours — and two daemons indexing the same repo path collide there.
+func jdtlsWorkspaceDir(repoRoot string) string {
+	sum := sha256.Sum256([]byte(repoRoot))
+	hash := hex.EncodeToString(sum[:])[:16]
+	return filepath.Join(platform.CacheDir(), "lsp", "jdtls", hash)
+}
+
+// jdtlsDataArgs appends `-data <workspace>` to a jdtls launch argv unless the
+// caller already pinned an explicit workspace. It creates the workspace and
+// clears a stale Eclipse lock so a workspace left locked by a crashed or killed
+// server does not wedge the next launch.
+func jdtlsDataArgs(baseArgs []string, repoRoot string) []string {
+	for _, a := range baseArgs {
+		if a == "-data" {
+			return baseArgs
+		}
+	}
+	dir := jdtlsWorkspaceDir(repoRoot)
+	prepareJdtlsWorkspace(dir)
+	out := append([]string(nil), baseArgs...)
+	return append(out, "-data", dir)
+}
+
+// prepareJdtlsWorkspace ensures the workspace directory exists and removes a
+// stale Eclipse lock (.metadata/.lock) left by a crashed or killed jdtls, which
+// would otherwise refuse to open the workspace and wedge enrichment. Best
+// effort — a live server re-creates the lock, and any error is non-fatal so a
+// launch is never blocked on workspace hygiene.
+func prepareJdtlsWorkspace(dir string) {
+	_ = os.MkdirAll(dir, 0o755)
+	_ = os.Remove(filepath.Join(dir, ".metadata", ".lock"))
+}

--- a/internal/semantic/lsp/jdtls_workspace_test.go
+++ b/internal/semantic/lsp/jdtls_workspace_test.go
@@ -1,0 +1,66 @@
+package lsp
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The jdtls launch must pass -data pointing inside the resolved cache home
+// (honouring XDG_CACHE_HOME), per repo — never letting the launcher default
+// the Eclipse workspace to ~/Library/Caches/jdtls.
+func TestJdtlsDataArgs_UnderCacheHome(t *testing.T) {
+	cache := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cache)
+
+	repo := "/Users/dev/code/petclinic"
+	args := jdtlsDataArgs([]string{}, repo)
+
+	require.Len(t, args, 2)
+	assert.Equal(t, "-data", args[0])
+	data := args[1]
+	assert.True(t, strings.HasPrefix(data, cache), "workspace %q must live under the resolved cache home %q", data, cache)
+	assert.Contains(t, data, filepath.Join("lsp", "jdtls"))
+	// The workspace directory is created.
+	info, err := os.Stat(data)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+
+	// Distinct repos get distinct per-repo workspaces; the same repo is stable.
+	assert.Equal(t, data, jdtlsDataArgs([]string{}, repo)[1])
+	assert.NotEqual(t, data, jdtlsDataArgs([]string{}, "/Users/dev/code/other")[1])
+}
+
+// An explicit -data configured by the operator is respected, not doubled.
+func TestJdtlsDataArgs_RespectsExplicit(t *testing.T) {
+	base := []string{"-data", "/custom/ws"}
+	assert.Equal(t, base, jdtlsDataArgs(base, "/Users/dev/code/petclinic"))
+}
+
+// A stale Eclipse lock left by a crashed jdtls is cleared so the next launch is
+// not wedged; the workspace directory (and its cached index) survives.
+func TestPrepareJdtlsWorkspace_ClearsStaleLock(t *testing.T) {
+	dir := t.TempDir()
+	meta := filepath.Join(dir, ".metadata")
+	require.NoError(t, os.MkdirAll(meta, 0o755))
+	lock := filepath.Join(meta, ".lock")
+	require.NoError(t, os.WriteFile(lock, []byte("stale"), 0o644))
+
+	prepareJdtlsWorkspace(dir)
+
+	_, err := os.Stat(lock)
+	assert.True(t, os.IsNotExist(err), "stale .metadata/.lock must be removed")
+	_, err = os.Stat(meta)
+	assert.NoError(t, err, "the workspace .metadata (cached index) must be preserved")
+}
+
+func TestIsJdtlsCommand(t *testing.T) {
+	assert.True(t, isJdtlsCommand("jdtls"))
+	assert.True(t, isJdtlsCommand("/opt/homebrew/bin/jdtls"))
+	assert.False(t, isJdtlsCommand("gopls"))
+	assert.False(t, isJdtlsCommand("/usr/bin/rust-analyzer"))
+}

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -1268,7 +1268,14 @@ func (p *Provider) dialOrSpawn(workspaceRoot string) (*Client, error) {
 	if p.command == "" {
 		return nil, fmt.Errorf("lsp: no command configured and no passive attach available")
 	}
-	return NewClient(p.command, p.args, p.env, workspaceRoot, p.logger)
+	args := p.args
+	// jdtls with no -data lets the launcher default its Eclipse workspace to
+	// ~/Library/Caches/jdtls/<hash>, outside Gortex's cache isolation. Pin it
+	// under the resolved cache home per repo instead.
+	if isJdtlsCommand(p.command) {
+		args = jdtlsDataArgs(args, workspaceRoot)
+	}
+	return NewClient(p.command, args, p.env, workspaceRoot, p.logger)
 }
 
 // defaultLSPCallTimeout bounds a single post-initialize LSP request.

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -224,6 +224,22 @@ func nodeRelPath(n *graph.Node) string {
 	return n.FilePath
 }
 
+// enrichNodeHasUnresolvedDemand reports whether a callable declaration still
+// has unresolved same-name call candidates in the graph — `unresolved::*.<name>`
+// edges the resolver never bound. Such declarations are the ones an LSP
+// references pass can actually connect, so the add-phase enriches them first.
+// Unresolved call stubs are indexed by their target string, so this is a
+// single reverse-edge lookup, not a scan.
+func enrichNodeHasUnresolvedDemand(g graph.Store, n *graph.Node) bool {
+	if n == nil || n.Name == "" {
+		return false
+	}
+	if n.Kind != graph.KindMethod && n.Kind != graph.KindFunction {
+		return false
+	}
+	return len(g.GetInEdges(graph.UnresolvedMarker+"*."+n.Name)) > 0
+}
+
 // scopedPath re-attaches repoPrefix to a repo-relative path the language
 // server handed back: uriToPath returns repo-relative, but graph node
 // FilePaths are prefixed, so node lookups must re-prefix to match in a
@@ -789,8 +805,9 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 	// spans all of its symbols. Files keep encounter order; symbols keep
 	// their order within a file.
 	type fileTargets struct {
-		rel   string
-		nodes []*graph.Node
+		rel    string
+		nodes  []*graph.Node
+		demand int // declarations still carrying unresolved same-name candidates
 	}
 	var fileList []*fileTargets
 	fileIndex := map[string]*fileTargets{}
@@ -806,7 +823,18 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 			fileList = append(fileList, ft)
 		}
 		ft.nodes = append(ft.nodes, n)
+		if enrichNodeHasUnresolvedDemand(g, n) {
+			ft.demand++
+		}
 	}
+	// Demand-driven ordering: enrich the files whose declarations still carry
+	// unresolved same-name call candidates first. Under a per-repo deadline the
+	// budget is then spent where the LSP references pass will actually bind
+	// dropped call sites, instead of on declarations static resolution already
+	// covered. Stable so files of equal demand keep encounter order.
+	sort.SliceStable(fileList, func(i, j int) bool {
+		return fileList[i].demand > fileList[j].demand
+	})
 
 	// Call- and type-hierarchy hops are collected per file (while the
 	// file is open) and applied in that file's flush below, so each

--- a/internal/semantic/manager.go
+++ b/internal/semantic/manager.go
@@ -459,10 +459,32 @@ func (m *Manager) setEnrichStatus(repo, provider, lang, state string, deadline t
 		st.EdgesConfirmed = result.EdgesConfirmed
 		st.EdgesAdded = result.EdgesAdded
 		st.NodesEnriched = result.NodesEnriched
+		st.SymbolsTotal = result.SymbolsTotal
+		st.SymbolsCovered = result.SymbolsCovered
+		st.CoveragePercent = result.CoveragePercent
+		// Fill (and back-stamp) the bounding reason so a "completed" state
+		// that covered < 100% of its targets is never read as full coverage.
+		if result.BoundReason == "" {
+			result.BoundReason = enrichBoundReason(state, result)
+		}
+		st.BoundReason = result.BoundReason
 	}
 	m.mu.Lock()
 	m.enrichStatus[repo+"\x00"+provider] = st
 	m.mu.Unlock()
+}
+
+// enrichBoundReason classifies why the add-phase stopped: a cut pass is
+// budget-bound; a finished pass that skipped some targets is cap-bound; a
+// finished pass that visited every target is completed-all.
+func enrichBoundReason(state string, r *EnrichResult) string {
+	if r.Partial || state == EnrichStatePartial || state == EnrichStateAbandoned {
+		return EnrichBoundBudget
+	}
+	if r.SymbolsTotal > 0 && r.SymbolsCovered < r.SymbolsTotal {
+		return EnrichBoundCap
+	}
+	return EnrichBoundCompletedAll
 }
 
 // EnrichmentStatuses returns a stable-ordered snapshot of every

--- a/internal/semantic/provider.go
+++ b/internal/semantic/provider.go
@@ -76,7 +76,21 @@ type EnrichResult struct {
 	// graph. AbortReason carries the cause when Partial is true.
 	Partial     bool   `json:"partial,omitempty"`
 	AbortReason string `json:"abort_reason,omitempty"`
+	// BoundReason states why the add-phase stopped where it did, so a
+	// "completed" state that covered < 100% of its targets is never read as
+	// full coverage: "budget" (a deadline cut the pass), "cap" (the pass
+	// finished but some targets were skipped, e.g. no source position or an
+	// unservable file), or "completed_all" (every target visited).
+	BoundReason string `json:"bound_reason,omitempty"`
 }
+
+// Bounding reasons for the enrichment add-phase (EnrichResult.BoundReason /
+// EnrichmentStatus.BoundReason).
+const (
+	EnrichBoundBudget       = "budget"
+	EnrichBoundCap          = "cap"
+	EnrichBoundCompletedAll = "completed_all"
+)
 
 // Enrichment lifecycle states surfaced per (repo, provider) via
 // Manager.EnrichmentStatuses — the health signal that lets an agent see
@@ -102,6 +116,14 @@ type EnrichmentStatus struct {
 	EdgesConfirmed  int     `json:"edges_confirmed"`
 	EdgesAdded      int     `json:"edges_added"`
 	NodesEnriched   int     `json:"nodes_enriched"`
+	// Add-phase coverage — the targets eligible for the hover/references
+	// pass, how many were visited, and why the pass stopped. Always emitted
+	// so a "completed" state that covered < 100% of targets is legible as a
+	// coverage sliver rather than trusted as full enrichment.
+	SymbolsTotal    int     `json:"symbols_total"`
+	SymbolsCovered  int     `json:"symbols_covered"`
+	CoveragePercent float64 `json:"coverage_percent"`
+	BoundReason     string  `json:"bound_reason,omitempty"`
 	Detail          string  `json:"detail,omitempty"`
 }
 


### PR DESCRIPTION
## Java usages accuracy

Improves `find_usages` / `get_callers` precision and recall on Java (measured
against spring-petclinic), where a set of specific, reproducible call shapes
silently dropped real references while every telemetry surface stayed green.

### Resolution & extraction

- **`this.<field>.<method>()` calls now resolve.** The `this.` qualifier
  diverted DI-injected field calls to the factory-chain path, leaving them
  untyped; they fell through to a name-only guess that the cross-package guard
  then reverted whenever the callee lived in a different Maven directory
  (`src/test/java` vs `src/main/java`) or an inherited superclass package. A
  repository method called only from the test suite reported a single usage.
  The `this.` qualifier is now stripped and the receiver resolved through the
  enclosing class's field type, identical to the bare-field spelling. Interface
  and enum method nodes carry their declaring type as a receiver so exact-type
  method resolution can bind to them, and same-source-package-different-directory
  is treated as import-reachable (a lone in-repo definition is never a
  cross-package mis-guess).

- **`new Foo(args)` emits constructor-call edges.** A new-expression produced an
  instantiates edge to the type but no call edge to the constructor, so
  `find_usages` on an explicit constructor returned nothing. Each
  new-expression now also emits a class-qualified `<Class>.<init>` call
  candidate; a class with only an implicit default constructor stays unresolved,
  so the observable graph is unchanged for those.

- **Ambiguous override-dispatch calls fan out to every override.** A call on a
  supertype-typed receiver (`x.toString()` with two candidate overrides) matched
  neither by exact type and was reverted, reporting as a usage of neither — while
  a language server attributes it to both overrides. A bounded, hierarchy-gated
  pass (grounded in each type's real superclass chain) now fans an ambiguous
  Java member call out to one edge per override that shares a common supertype.
  Because no receiver type disambiguated the target set, the fan-out lands at the
  **speculative tier** — cleared out of the `ambiguous_multi_match` bucket,
  hidden from default `find_usages` so it never inflates a code symbol's usage
  set, and surfaced on demand with `include_speculative` / `analyze
  kind=speculative`.

- **Selector calls bind to the receiver's type, not the caller's own class.** A
  `field.method()` whose name collided with a method in the caller's own class
  (a test method calling a production method of the same name through a mock
  field) bound to the wrong target: a receiver-less duplicate call edge clobbered
  the receiver_type on the edge key, and the exact-type resolution passes only
  scanned the import-reachability-filtered candidates, dropping the receiver's
  own type when it lived in a sibling Maven directory.

### `find_usages` truthfulness

- **Framework-contract edges no longer leak into `find_usages`.** A `@Bean`
  factory method's only incoming edge is the `provides` contract edge from its
  `@Configuration` class; `find_usages` reported that plumbing as the method's
  single usage. Contract edge kinds (`provides`, `handles_route`, topic/table/
  component edges) are now excluded when the queried symbol is a callable code
  symbol, while a DI-token / topic / table / route target still surfaces them.

- **Honest empty-result caveats.** `find_usages` returning empty for a symbol
  whose name still has unresolved same-name call candidates now emits the
  coverage-hedged caveat instead of `likely_unused` — an empty result is
  unverified coverage, not proof of dead code.

- **Repeated call sites survive** at line granularity (regression-locked).

### Enrichment observability

- The LSP add-phase could finish `completed` having enriched a sliver of its
  targets with nothing showing the coverage share. Enrichment status now carries
  `symbols_total` / `symbols_covered` / `coverage_percent` and a `bound_reason`
  (budget / cap / completed_all), and the add-phase worklist is demand-driven —
  files whose declarations still carry unresolved same-name candidates are
  enriched first, so a deadline spends its budget where an LSP references sweep
  can actually bind dropped call sites.

- jdtls is launched with an explicit `-data` workspace under the resolved cache
  home (per repo), instead of letting the launcher default it to
  `~/Library/Caches/jdtls`, outside the cache isolation. A stale Eclipse lock is
  cleared before launch so a locked workspace never wedges enrichment.

### Verification

`go build` (CGO), `go test -race` on every touched package, `golangci-lint` (0
issues), `go vet`, and the `cmd/gortex` wire-contract golden all pass. New unit
tests cover each behavior at the extractor, resolver, query, graph, and semantic
layers.

Measured end-to-end on spring-petclinic (fresh index, static resolution with
jdtls disabled):

| `find_usages` target | before | after |
|---|---|---|
| `OwnerRepository.findByLastNameStartingWith` | 1 | **9** (all 8 test refs) |
| `CrashController.triggerException` | 0 (`likely_unused`) | **1** |
| `PetTypeFormatter.<init>` | 0 (`likely_unused`) | **1** |
| `Vet.getSpecialties` (repeated sites) | 1 | **2** (`:211`, `:212`) |
| `@Bean` config methods (`provides` leak) | 1 | **0** |
| `NamedEntity.toString` / `Owner.toString` @ `include_speculative` | 0 | includes `:125`, `:127` |

Graph-wide on the same index: `candidate_out_of_scope` 178 → 46,
`ambiguous_multi_match` 21 → 3.
