### PR TITLE
feat(rust): improve find_usages precision and recall for Rust call sites

### DIFF
--- a/internal/parser/languages/rust.go
+++ b/internal/parser/languages/rust.go
@@ -323,7 +323,12 @@ func (e *RustExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 	for _, c := range calls {
 		callerID := findEnclosingFunc(funcRanges, c.line)
 		if callerID == "" {
-			continue
+			// A call outside any function body — e.g. inside a const/static
+			// initialiser (`const ALIASES = [alias(...), alias(...)]`).
+			// Attribute it to the file node instead of dropping the site, so
+			// find_usages still surfaces the call. Mirrors the let-binding
+			// type-use pass's file-node fallback.
+			callerID = fileID
 		}
 		if c.isSelector {
 			edge := &graph.Edge{

--- a/internal/parser/languages/rust.go
+++ b/internal/parser/languages/rust.go
@@ -144,7 +144,7 @@ func (e *RustExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 			e.emitFunction(m, filePath, fileID, src, result, seen, annotationSeen)
 
 		case m.Captures["sig.def"] != nil:
-			e.recordTraitMethod(m, src, traitMethods)
+			e.recordTraitMethod(m, filePath, fileID, src, result, traitMethods, seen, annotationSeen)
 
 		case m.Captures["struct.def"] != nil:
 			e.emitStruct(m, filePath, fileID, src, result, seen, annotationSeen)
@@ -417,14 +417,35 @@ func (e *RustExtractor) emitFunction(m parser.QueryResult, filePath, fileID stri
 		result.Edges = append(result.Edges, &graph.Edge{
 			From: id, To: typeID, Kind: graph.EdgeMemberOf, FilePath: filePath, Line: startLine1,
 		})
+		// `impl Trait for Type` methods override the trait declaration's
+		// method. Emit a method-level EdgeOverrides so find_implementations
+		// pairs them and find_usages can fan dispatch sites out through the
+		// trait — resolved (possibly cross-file) by the Rust scope pass. This
+		// covers impls on external types (io::Error) that inferOverrides
+		// cannot, since inferOverrides needs both endpoints to be local type
+		// nodes and an external type has none.
+		if traitBase := rustImplTraitName(def.Node, src); traitBase != "" {
+			result.Edges = append(result.Edges, &graph.Edge{
+				From: id, To: "unresolved::" + traitBase + "." + name,
+				Kind: graph.EdgeOverrides, FilePath: filePath, Line: startLine1,
+			})
+		}
 		emitRustAnnotationEdges(rustCollectAttributes(def.Node), id, filePath, src, result, annotationSeen)
 		emitRustThrowsEdges(def.Node, src, id, filePath, startLine1, result)
 		emitRustFunctionShape(id, def.Node, src, filePath, startLine1, result)
 		return
 	}
 
-	// Free function (or trait default-impl). Mirror the legacy
-	// rsQFunction pass — emit as KindFunction.
+	// A fn directly inside a trait body is a default-method declaration:
+	// emit it as <file>::<Trait>.<method> (KindMethod) like the impl case
+	// rather than a bare free function, so trait-dispatch resolution and
+	// find_implementations pairing see a consistent method node.
+	if traitName := rustTraitMethodOwner(def.Node, src); traitName != "" {
+		e.emitTraitMethodNode(traitName, name, def, filePath, fileID, src, result, seen, annotationSeen)
+		return
+	}
+
+	// Free function. Mirror the legacy rsQFunction pass — emit as KindFunction.
 	id, ok := disambiguateID(seen, filePath+"::"+name, startLine1)
 	if !ok {
 		return
@@ -779,7 +800,7 @@ func rustVisibility(item *sitter.Node, src []byte) string {
 	return VisibilityPrivate
 }
 
-func (e *RustExtractor) recordTraitMethod(m parser.QueryResult, src []byte, traitMethods map[string][]string) {
+func (e *RustExtractor) recordTraitMethod(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, traitMethods map[string][]string, seen, annotationSeen map[string]bool) {
 	def := m.Captures["sig.def"]
 	traitNode := findEnclosingRustContainer(def.Node, "trait_item")
 	if traitNode == nil {
@@ -789,7 +810,12 @@ func (e *RustExtractor) recordTraitMethod(m parser.QueryResult, src []byte, trai
 	if traitName == "" {
 		return
 	}
-	traitMethods[traitName] = append(traitMethods[traitName], m.Captures["sig.name"].Text)
+	name := m.Captures["sig.name"].Text
+	traitMethods[traitName] = append(traitMethods[traitName], name)
+	// A dyn-dispatch call site binds to the trait *declaration*, so the
+	// signature needs its own <file>::<Trait>.<method> node for find_usages
+	// to answer and for inferOverrides to pair impl methods against it.
+	e.emitTraitMethodNode(traitName, name, def, filePath, fileID, src, result, seen, annotationSeen)
 }
 
 func (e *RustExtractor) emitStruct(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen, annotationSeen map[string]bool) {
@@ -1024,6 +1050,119 @@ func rustImplMethodReceiver(fn *sitter.Node, src []byte) string {
 		return ""
 	}
 	return typeNode.Content(src)
+}
+
+// rustTraitMethodOwner returns the trait name when fn is a direct member
+// of a trait_item's declaration_list — a trait-method declaration (a
+// signature or a default-body method). Mirrors rustImplMethodReceiver but
+// for trait bodies; returns "" for impl bodies, nested fns and free fns.
+func rustTraitMethodOwner(fn *sitter.Node, src []byte) string {
+	if fn == nil {
+		return ""
+	}
+	parent := fn.Parent()
+	if parent == nil || parent.Type() != "declaration_list" {
+		return ""
+	}
+	grand := parent.Parent()
+	if grand == nil || grand.Type() != "trait_item" {
+		return ""
+	}
+	nameNode := grand.ChildByFieldName("name")
+	if nameNode == nil {
+		return ""
+	}
+	return nameNode.Content(src)
+}
+
+// rustImplTraitName returns the base name of the trait a fn's enclosing
+// impl block implements (`impl Trait for Type`), or "" when fn is not an
+// impl method or the impl is inherent (`impl Type`). Unwraps scoped and
+// generic trait paths (fmt::Display -> Display, Iterator<Item=u8> ->
+// Iterator).
+func rustImplTraitName(fn *sitter.Node, src []byte) string {
+	if fn == nil {
+		return ""
+	}
+	parent := fn.Parent()
+	if parent == nil || parent.Type() != "declaration_list" {
+		return ""
+	}
+	impl := parent.Parent()
+	if impl == nil || impl.Type() != "impl_item" {
+		return ""
+	}
+	tr := impl.ChildByFieldName("trait")
+	if tr == nil {
+		return ""
+	}
+	return rustTraitPathBaseName(tr.Content(src))
+}
+
+// rustTraitPathBaseName reduces a trait reference (possibly scoped and/or
+// generic) to its base type name: `fmt::Display` -> `Display`,
+// `Iterator<Item = u8>` -> `Iterator`.
+func rustTraitPathBaseName(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.Index(s, "<"); i >= 0 {
+		s = s[:i]
+	}
+	if i := strings.LastIndex(s, "::"); i >= 0 {
+		s = s[i+2:]
+	}
+	return strings.TrimSpace(s)
+}
+
+// emitTraitMethodNode emits a KindMethod node for a trait-declaration
+// method — a signature (function_signature_item, no body) or a default
+// method (function_item with a body). Named <file>::<Trait>.<method> so
+// the id scheme matches impl methods; EdgeMemberOf points at the trait's
+// interface node so inferOverrides pairs each concrete impl method against
+// its declaration. Meta["trait_decl"]="true" marks the node as a
+// declaration rather than a concrete impl.
+func (e *RustExtractor) emitTraitMethodNode(traitName, name string, def *parser.CapturedNode, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen, annotationSeen map[string]bool) {
+	if def == nil || def.Node == nil {
+		return
+	}
+	startLine1 := def.StartLine + 1
+	id, ok := disambiguateID(seen, filePath+"::"+traitName+"."+name, startLine1)
+	if !ok {
+		return
+	}
+	complexity, cognitive, loopDepth := 0, 0, 0
+	if body := def.Node.ChildByFieldName("body"); body != nil {
+		complexity, cognitive, loopDepth = BodyComplexityMetrics(body, "rust")
+	}
+	meta := map[string]any{
+		"receiver":   traitName,
+		"trait_decl": "true",
+		"signature":  "fn " + name + "(...)",
+		"visibility": rustVisibility(def.Node, src),
+	}
+	if doc := ExtractDocAbove(src, def.StartLine, DocLangSlashSlash); doc != "" {
+		meta["doc"] = doc
+	}
+	if rt := extractRustReturnType(def.Node, src); rt != "" {
+		meta["return_type"] = rt
+	}
+	if tps := rustTypeParams(def.Node, src); len(tps) > 0 {
+		meta["type_params"] = tps
+	}
+	ApplyComplexityMeta(meta, complexity, cognitive, loopDepth)
+	result.Nodes = append(result.Nodes, &graph.Node{
+		ID: id, Kind: graph.KindMethod, Name: name,
+		FilePath: filePath, StartLine: startLine1, EndLine: def.EndLine + 1,
+		Language: "rust", Meta: meta,
+	})
+	result.Edges = append(result.Edges, &graph.Edge{
+		From: fileID, To: id, Kind: graph.EdgeDefines, FilePath: filePath, Line: startLine1,
+	})
+	result.Edges = append(result.Edges, &graph.Edge{
+		From: id, To: filePath + "::" + traitName, Kind: graph.EdgeMemberOf, FilePath: filePath, Line: startLine1,
+	})
+	emitRustAnnotationEdges(rustCollectAttributes(def.Node), id, filePath, src, result, annotationSeen)
+	emitRustThrowsEdges(def.Node, src, id, filePath, startLine1, result)
+	emitRustFunctionShape(id, def.Node, src, filePath, startLine1, result)
 }
 
 // rustDeclName returns the source text of the `name` field on a Rust

--- a/internal/parser/languages/rust.go
+++ b/internal/parser/languages/rust.go
@@ -112,6 +112,14 @@ type rustDeferredLet struct {
 	value    *sitter.Node // RHS expression node, or nil
 }
 
+// rustFuncDef buffers a function/method definition node for the post-emit
+// per-function receiver-scope build (paramsByFunc).
+type rustFuncDef struct {
+	node  *sitter.Node
+	owner string // impl/trait type that self binds to; "" for free functions
+	line  int    // 1-based start line, mapped back to the emitted id via funcRanges
+}
+
 func (e *RustExtractor) Extract(filePath string, src []byte) (*parser.ExtractionResult, error) {
 	tree, err := parser.ParseFile(src, e.lang)
 	if err != nil {
@@ -136,15 +144,24 @@ func (e *RustExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 
 	var calls []rustDeferredCall
 	var lets []rustDeferredLet
+	var funcDefs []rustFuncDef
 
 	parser.EachMatch(e.qAll, root, src, func(m parser.QueryResult) {
 		switch {
 
 		case m.Captures["func.def"] != nil:
 			e.emitFunction(m, filePath, fileID, src, result, seen, annotationSeen)
+			fd := m.Captures["func.def"]
+			owner := rustImplMethodReceiver(fd.Node, src)
+			if owner == "" {
+				owner = rustTraitMethodOwner(fd.Node, src)
+			}
+			funcDefs = append(funcDefs, rustFuncDef{node: fd.Node, owner: owner, line: fd.StartLine + 1})
 
 		case m.Captures["sig.def"] != nil:
 			e.recordTraitMethod(m, filePath, fileID, src, result, traitMethods, seen, annotationSeen)
+			sd := m.Captures["sig.def"]
+			funcDefs = append(funcDefs, rustFuncDef{node: sd.Node, owner: rustTraitMethodOwner(sd.Node, src), line: sd.StartLine + 1})
 
 		case m.Captures["struct.def"] != nil:
 			e.emitStruct(m, filePath, fileID, src, result, seen, annotationSeen)
@@ -271,6 +288,21 @@ func (e *RustExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 	// their enclosing definition.
 	funcRanges := buildFuncRanges(result)
 
+	// Per-function receiver scope: map each function/method's parameters and
+	// self receiver to their types so a selector call on a parameter receiver
+	// (args.foo()) resolves — mirroring Go's paramsByFunc. Keyed by the
+	// enclosing function id via funcRanges.
+	paramsByFunc := make(map[string]map[string]string)
+	for _, fd := range funcDefs {
+		id := findEnclosingFunc(funcRanges, fd.line)
+		if id == "" {
+			continue
+		}
+		if pm := rustFuncParamTypes(fd.node, fd.owner, src); len(pm) > 0 {
+			paramsByFunc[id] = pm
+		}
+	}
+
 	// Emit a cross-file type-usage edge for every `let x: Type = ...`
 	// binding annotation. Without this a type referenced only in a local
 	// binding (never in a param/return) is invisible to find_usages
@@ -298,7 +330,7 @@ func (e *RustExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 				From: callerID, To: "unresolved::*." + c.name,
 				Kind: graph.EdgeCalls, FilePath: filePath, Line: c.line,
 			}
-			if recvType, ok := tenv[c.receiver]; ok {
+			if recvType, ok := lookupRustRecvType(paramsByFunc, tenv, callerID, c.receiver); ok {
 				edge.Meta = map[string]any{"receiver_type": recvType}
 			} else if strings.Contains(c.receiver, ".") || strings.Contains(c.receiver, "(") {
 				stampFactoryChainReceiver(edge, c.receiver, resolveChainType(c.receiver, tenv, result))
@@ -1234,6 +1266,61 @@ func normalizeRustTypeName(t string) string {
 		return ""
 	}
 	return t
+}
+
+// rustFuncParamTypes returns a map from parameter name to its normalized,
+// non-primitive type for a function/method node. A self parameter binds to
+// ownerType (the enclosing impl/trait type) when known. Mirrors Go's
+// paramsByFunc so a selector call on a parameter or self receiver resolves.
+func rustFuncParamTypes(fn *sitter.Node, ownerType string, src []byte) map[string]string {
+	if fn == nil {
+		return nil
+	}
+	params := fn.ChildByFieldName("parameters")
+	if params == nil {
+		return nil
+	}
+	out := map[string]string{}
+	for i, n := 0, int(params.NamedChildCount()); i < n; i++ {
+		p := params.NamedChild(i)
+		if p == nil {
+			continue
+		}
+		switch p.Type() {
+		case "self_parameter":
+			if ownerType != "" {
+				out["self"] = ownerType
+			}
+		case "parameter":
+			pat := p.ChildByFieldName("pattern")
+			ty := p.ChildByFieldName("type")
+			if pat == nil || ty == nil {
+				continue
+			}
+			if t := normalizeRustTypeName(ty.Content(src)); t != "" {
+				out[pat.Content(src)] = t
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// lookupRustRecvType resolves a selector-call receiver name to a type,
+// checking the caller's own parameter/self scope before the file-wide let
+// environment so a parameter shadows a same-named binding elsewhere.
+func lookupRustRecvType(paramsByFunc map[string]map[string]string, tenv typeEnv, callerID, name string) (string, bool) {
+	if callerID != "" {
+		if scope, ok := paramsByFunc[callerID]; ok {
+			if t, ok := scope[name]; ok {
+				return t, true
+			}
+		}
+	}
+	t, ok := tenv[name]
+	return t, ok
 }
 
 // inferTypeFromRustExpr inspects a tree-sitter expression node to infer

--- a/internal/parser/languages/rust.go
+++ b/internal/parser/languages/rust.go
@@ -350,6 +350,16 @@ func (e *RustExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 					edge.Meta = map[string]any{}
 				}
 				edge.Meta["rust_recv"] = c.receiver
+			} else if _, hasType := edge.Meta["receiver_type"]; !hasType &&
+				strings.HasPrefix(c.receiver, "self.") && !strings.ContainsAny(c.receiver, "()[]") {
+				// A field-access receiver rooted at self (self.config.line_term
+				// .method()). Its type can't be read from a single param/local,
+				// but the scope resolver can walk the struct field types from the
+				// enclosing impl type. Record the chain so it can.
+				if edge.Meta == nil {
+					edge.Meta = map[string]any{}
+				}
+				edge.Meta["rust_recv_expr"] = c.receiver
 			}
 			stampReturnUsage(edge, c.returnUsage)
 			result.Edges = append(result.Edges, edge)

--- a/internal/parser/languages/rust_recvtype_test.go
+++ b/internal/parser/languages/rust_recvtype_test.go
@@ -1,0 +1,64 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func recvTypeOfCall(edges []*graph.Edge, from string) string {
+	for _, ed := range edges {
+		if ed.Kind == graph.EdgeCalls && ed.From == from {
+			if rt, _ := ed.Meta["receiver_type"].(string); rt != "" {
+				return rt
+			}
+		}
+	}
+	return ""
+}
+
+// A selector call on a parameter receiver stamps receiver_type from the
+// caller's own parameter scope (mirrors Go's paramsByFunc), so the resolver
+// can bind it to the right method.
+func TestRsExtractor_ParamReceiverType(t *testing.T) {
+	src := []byte(`struct HiArgs {}
+impl HiArgs { fn has_implicit_path(&self) -> bool { true } }
+fn search(args: &HiArgs) -> bool { args.has_implicit_path() }
+`)
+	e := NewRustExtractor()
+	result, err := e.Extract("main.rs", src)
+	require.NoError(t, err)
+	assert.Equal(t, "HiArgs", recvTypeOfCall(result.Edges, "main.rs::search"))
+}
+
+// A self selector call binds to the enclosing impl type via the self scope.
+func TestRsExtractor_SelfReceiverType(t *testing.T) {
+	src := []byte(`struct Foo {}
+impl Foo {
+    fn a(&self) { self.b() }
+    fn b(&self) {}
+}
+`)
+	e := NewRustExtractor()
+	result, err := e.Extract("foo.rs", src)
+	require.NoError(t, err)
+	assert.Equal(t, "Foo", recvTypeOfCall(result.Edges, "foo.rs::Foo.a"))
+}
+
+// A parameter shadows a same-named file-wide let binding at call resolution.
+func TestRsExtractor_ParamShadowsLet(t *testing.T) {
+	src := []byte(`struct A {}
+struct B {}
+impl A { fn go(&self) {} }
+impl B { fn go(&self) {} }
+fn outer(x: &A) { x.go(); }
+fn other() { let x = B {}; x.go(); }
+`)
+	e := NewRustExtractor()
+	result, err := e.Extract("m.rs", src)
+	require.NoError(t, err)
+	assert.Equal(t, "A", recvTypeOfCall(result.Edges, "m.rs::outer"))
+	assert.Equal(t, "B", recvTypeOfCall(result.Edges, "m.rs::other"))
+}

--- a/internal/parser/languages/rust_traitmethod_test.go
+++ b/internal/parser/languages/rust_traitmethod_test.go
@@ -1,0 +1,103 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Trait-declaration methods (both signatures and default methods) get their
+// own <file>::<Trait>.<method> KindMethod node so dyn-dispatch call sites that
+// bind to the declaration are answerable and find_implementations can pair the
+// concrete impls against them.
+func TestRsExtractor_TraitMethodNodes(t *testing.T) {
+	src := []byte(`pub trait SinkError: Sized {
+    fn error_message<T>(message: T) -> Self;
+
+    fn default_impl(&self) -> bool {
+        true
+    }
+}
+`)
+	e := NewRustExtractor()
+	result, err := e.Extract("sink.rs", src)
+	require.NoError(t, err)
+
+	em := nodeByID(result.Nodes, "sink.rs::SinkError.error_message")
+	require.NotNil(t, em, "signature method node")
+	assert.Equal(t, graph.KindMethod, em.Kind)
+	assert.Equal(t, "SinkError", em.Meta["receiver"])
+	assert.Equal(t, "true", em.Meta["trait_decl"])
+
+	di := nodeByID(result.Nodes, "sink.rs::SinkError.default_impl")
+	require.NotNil(t, di, "default method node")
+	assert.Equal(t, graph.KindMethod, di.Kind)
+	assert.Equal(t, "true", di.Meta["trait_decl"])
+
+	// The default method must NOT leak as a bare free function.
+	assert.Nil(t, nodeByID(result.Nodes, "sink.rs::default_impl"))
+
+	// Each trait method is a member of the trait interface node.
+	members := 0
+	for _, ed := range result.Edges {
+		if ed.Kind == graph.EdgeMemberOf && ed.To == "sink.rs::SinkError" &&
+			(ed.From == "sink.rs::SinkError.error_message" || ed.From == "sink.rs::SinkError.default_impl") {
+			members++
+		}
+	}
+	assert.Equal(t, 2, members)
+
+	// Backward compat: the interface node still lists method names in Meta.
+	iface := nodeByID(result.Nodes, "sink.rs::SinkError")
+	require.NotNil(t, iface)
+	names, _ := iface.Meta["methods"].([]string)
+	assert.Contains(t, names, "error_message")
+}
+
+// `impl Trait for Type` methods emit a method-level EdgeOverrides at the impl
+// method, even when the implemented-for type is external (io::Error) and thus
+// has no local type node — the case inferOverrides cannot cover.
+func TestRsExtractor_TraitImplOverrides(t *testing.T) {
+	src := []byte(`pub trait SinkError: Sized {
+    fn error_message<T>(message: T) -> Self;
+}
+
+impl SinkError for io::Error {
+    fn error_message<T>(message: T) -> io::Error {
+        io::Error::new(io::ErrorKind::Other, message.to_string())
+    }
+}
+`)
+	e := NewRustExtractor()
+	result, err := e.Extract("sink.rs", src)
+	require.NoError(t, err)
+
+	require.NotNil(t, nodeByID(result.Nodes, "sink.rs::io::Error.error_message"))
+
+	var ov *graph.Edge
+	for _, ed := range result.Edges {
+		if ed.Kind == graph.EdgeOverrides && ed.From == "sink.rs::io::Error.error_message" {
+			ov = ed
+			break
+		}
+	}
+	require.NotNil(t, ov, "impl method should emit an EdgeOverrides")
+	assert.Equal(t, "unresolved::SinkError.error_message", ov.To)
+}
+
+// An inherent impl (no trait) must not emit any override edge.
+func TestRsExtractor_InherentImplNoOverride(t *testing.T) {
+	src := []byte(`struct Foo {}
+impl Foo {
+    fn bar(&self) {}
+}
+`)
+	e := NewRustExtractor()
+	result, err := e.Extract("foo.rs", src)
+	require.NoError(t, err)
+	for _, ed := range result.Edges {
+		assert.NotEqual(t, graph.EdgeOverrides, ed.Kind, "inherent impl should not override")
+	}
+}

--- a/internal/query/subgraph.go
+++ b/internal/query/subgraph.go
@@ -328,7 +328,7 @@ func (sg *SubGraph) SuppressRedundantTextMatches() {
 		// Drop exactly the text_matched tier. Untagged edges (rank 0)
 		// stay: they predate origin stamping and carry unknown — not
 		// low — confidence.
-		if graph.OriginRank(effectiveOrigin(e)) == textRank {
+		if e.Origin == graph.OriginTextMatched {
 			dropped++
 			continue
 		}

--- a/internal/query/suppress_empty_origin_test.go
+++ b/internal/query/suppress_empty_origin_test.go
@@ -1,0 +1,30 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Empty-origin call edges are resolver-bound usages (the common case for
+// languages the resolver binds by name), not name-only text-match fan-out.
+// They must survive suppression even when a stronger (LSP-confirmed) edge
+// exists for the same target — the rust-analyzer partial-enrichment case
+// that otherwise collapsed find_usages from hundreds of sites to a handful.
+func TestSuppressRedundantTextMatches_KeepsEmptyOriginWhenResolvedExists(t *testing.T) {
+	sg := suppressSubGraph(
+		&graph.Edge{From: "a::caller", To: "b::foo", Kind: graph.EdgeCalls, Origin: graph.OriginLSPResolved},
+		&graph.Edge{From: "c::c1", To: "b::foo", Kind: graph.EdgeCalls}, // empty origin — resolver-bound
+		&graph.Edge{From: "d::c2", To: "b::foo", Kind: graph.EdgeCalls}, // empty origin — resolver-bound
+		&graph.Edge{From: "e::noise", To: "b::foo", Kind: graph.EdgeCalls, Origin: graph.OriginTextMatched},
+	)
+	sg.SuppressRedundantTextMatches()
+
+	// Only the explicitly text_matched edge is dropped.
+	require.Equal(t, 3, len(sg.Edges))
+	require.Equal(t, 1, sg.TextMatchedSuppressed)
+	for _, e := range sg.Edges {
+		require.NotEqual(t, graph.OriginTextMatched, e.Origin)
+	}
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -1431,6 +1431,14 @@ func (r *Resolver) resolveEdge(e *graph.Edge, stats *ResolveStats) (oldTo string
 		// for calls edges, resolve as a function (original behavior).
 		if e.Kind == graph.EdgeInstantiates || e.Kind == graph.EdgeReferences {
 			r.resolveTypeOrFunc(e, target, stats)
+		} else if rp, _ := e.Meta["rust_path"].(string); strings.Contains(rp, "::") {
+			// A Rust qualified path call (`MatchStrategy::new`,
+			// `crate::mod::baz`) keeps its full path in Meta["rust_path"].
+			// The generic function-call cascade only sees the trailing
+			// segment ("new"), so it would mis-bind the call to the first
+			// same-named symbol. Leave it unresolved for the SynthRustScope
+			// pass, which reads the qualifier and binds the right owner.
+			break
 		} else {
 			before := e.To
 			r.resolveFunctionCall(e, target, stats)

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -1811,10 +1811,18 @@ func (r *Resolver) resolveFunctionCall(e *graph.Edge, funcName string, stats *Re
 		}
 	}
 
-	// Fall back to the first same-repo function/method match.
+	// Fall back to the first same-repo function/method match. This is a
+	// name-only guess (no directory/import evidence), so tag it text_matched
+	// — the weakest tier — so the redundant-text suppression drops it when a
+	// language server later confirms the real target, and the cross-package
+	// guard can revert it when unreachable. Same-file / same-directory picks
+	// above stay untagged (structural locality evidence) and survive.
 	for _, c := range candidates {
 		if c.Kind == graph.KindFunction || c.Kind == graph.KindMethod {
 			e.To = c.ID
+			if e.Origin == "" {
+				e.Origin = graph.OriginTextMatched
+			}
 			stats.Resolved++
 			return
 		}
@@ -2262,23 +2270,43 @@ func (r *Resolver) resolveMethodCall(e *graph.Edge, methodName string, stats *Re
 		}
 	}
 
+	// Every locality-fallback pick is a name-only guess: no receiver-type
+	// evidence tied the call to this method/function, only same-name +
+	// reachability. Tag it text_matched (unless the interface-dispatch or
+	// Java lone-definition branch above already stamped a tier) so
+	// redundant-text suppression drops it once a language server confirms the
+	// real target — a common method name like `Get` otherwise fans a call to
+	// every same-named method in the package. (Free-function calls resolve in
+	// resolveFunctionCall, whose same-directory pick stays untagged.)
 	if sameDirMethod != nil {
 		e.To = sameDirMethod.ID
+		if e.Origin == "" {
+			e.Origin = graph.OriginTextMatched
+		}
 		stats.Resolved++
 		return
 	}
 	if anyMethod != nil {
 		e.To = anyMethod.ID
+		if e.Origin == "" {
+			e.Origin = graph.OriginTextMatched
+		}
 		stats.Resolved++
 		return
 	}
 	if sameDirFunc != nil {
 		e.To = sameDirFunc.ID
+		if e.Origin == "" {
+			e.Origin = graph.OriginTextMatched
+		}
 		stats.Resolved++
 		return
 	}
 	if anyFunc != nil {
 		e.To = anyFunc.ID
+		if e.Origin == "" {
+			e.Origin = graph.OriginTextMatched
+		}
 		stats.Resolved++
 		return
 	}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -2078,6 +2078,12 @@ func (r *Resolver) resolveMethodCall(e *graph.Edge, methodName string, stats *Re
 	// only survivor — so the exact-type match must see every candidate, not
 	// just the reachable ones.
 	if receiverType != "" {
+		// An exact receiver-type match is structural evidence — the
+		// receiver's type is known and the method belongs to it — so it
+		// resolves at ast_resolved (not the name-only ast_inferred tier the
+		// cross-package guard reverts) and does not need import-reachability
+		// corroboration, which Rust re-exports and unsplit `use a::{b, c}`
+		// import groups routinely leave unresolved.
 		// Pass 1: same-directory + exact type match (highest confidence).
 		for _, c := range rawCandidates {
 			if c.Kind == graph.KindMethod &&
@@ -2085,18 +2091,30 @@ func (r *Resolver) resolveMethodCall(e *graph.Edge, methodName string, stats *Re
 				nodeReceiverType(c) == receiverType {
 				e.To = c.ID
 				e.Confidence = 0.95
+				e.Origin = graph.OriginASTResolved
 				stats.Resolved++
 				return
 			}
 		}
-		// Pass 2: exact type match, any directory.
+		// Pass 2: exact type match, any directory, over the UNFILTERED
+		// candidate set with a uniqueness guard (so a same-named type in
+		// another package is never mis-picked).
+		var exact *graph.Node
 		for _, c := range rawCandidates {
 			if c.Kind == graph.KindMethod && nodeReceiverType(c) == receiverType {
-				e.To = c.ID
-				e.Confidence = 0.9
-				stats.Resolved++
-				return
+				if exact != nil && exact.ID != c.ID {
+					exact = nil
+					break
+				}
+				exact = c
 			}
+		}
+		if exact != nil {
+			e.To = exact.ID
+			e.Confidence = 0.85
+			e.Origin = graph.OriginASTResolved
+			stats.Resolved++
+			return
 		}
 		// Pass 2b: DI useClass binding. When receiver_type is an
 		// abstract/base class that has no method of this name (Passes

--- a/internal/resolver/rust_field_receiver_test.go
+++ b/internal/resolver/rust_field_receiver_test.go
@@ -1,0 +1,34 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A selector call on a self-rooted field-access receiver
+// (`self.config.line_term.as_byte()`) binds by walking the declared field
+// types from the enclosing impl type down the chain: Searcher.config ->
+// Config, Config.line_term -> LineTerminator, then LineTerminator.as_byte.
+func TestRustScope_FieldReceiverWalk(t *testing.T) {
+	g := buildRustGraph(t, map[string]string{
+		"lib.rs": `
+struct LineTerminator { b: u8 }
+impl LineTerminator {
+    fn as_byte(&self) -> u8 { self.b }
+}
+
+struct Config { line_term: LineTerminator }
+
+struct Searcher { config: Config }
+impl Searcher {
+    fn run(&self) -> u8 {
+        self.config.line_term.as_byte()
+    }
+}
+`,
+	})
+	ResolveRustScopeCalls(g)
+	targets := callTargetsFromRust(g, "lib.rs::Searcher.run")
+	require.Contains(t, targets, "lib.rs::LineTerminator.as_byte")
+}

--- a/internal/resolver/rust_override_test.go
+++ b/internal/resolver/rust_override_test.go
@@ -1,0 +1,49 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// A method-level EdgeOverrides emitted by the extractor for an
+// `impl Trait for Type` block resolves to the trait declaration's method
+// node — even when the impl-for type is external (io::Error) and thus has
+// no local type node.
+func TestRustScope_TraitOverrideResolves(t *testing.T) {
+	g := buildRustGraph(t, map[string]string{
+		"sink.rs": `
+pub trait SinkError {
+    fn error_message(message: String) -> Self;
+}
+
+impl SinkError for io::Error {
+    fn error_message(message: String) -> io::Error {
+        panic!()
+    }
+}
+`,
+	})
+	n := ResolveRustScopeCalls(g)
+	_ = n
+
+	implID := "sink.rs::io::Error.error_message"
+	traitID := "sink.rs::SinkError.error_message"
+
+	found := false
+	for _, e := range g.GetOutEdges(implID) {
+		if e.Kind == graph.EdgeOverrides && e.To == traitID {
+			found = true
+		}
+	}
+	require.True(t, found, "impl override should resolve to the trait method")
+
+	inbound := 0
+	for _, e := range g.GetInEdges(traitID) {
+		if e.Kind == graph.EdgeOverrides {
+			inbound++
+		}
+	}
+	require.Equal(t, 1, inbound, "trait method should have one inbound override")
+}

--- a/internal/resolver/rust_owner_alias_test.go
+++ b/internal/resolver/rust_owner_alias_test.go
@@ -1,0 +1,28 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A `Type::method()` call resolves to a method whose impl type carries
+// generic/lifetime args (Candidate<'a>), via the base-name owner alias.
+func TestRustScope_GenericOwnerAlias(t *testing.T) {
+	g := buildRustGraph(t, map[string]string{
+		"lib.rs": `
+struct Candidate<'a> { x: &'a str }
+
+impl<'a> Candidate<'a> {
+    fn new(s: &'a str) -> Candidate<'a> { Candidate { x: s } }
+}
+
+fn make() {
+    let _c = Candidate::new("x");
+}
+`,
+	})
+	ResolveRustScopeCalls(g)
+	targets := callTargetsFromRust(g, "lib.rs::make")
+	require.Contains(t, targets, "lib.rs::Candidate<'a>.new")
+}

--- a/internal/resolver/rust_receiver_selector_test.go
+++ b/internal/resolver/rust_receiver_selector_test.go
@@ -1,0 +1,32 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A `mat.buffer()` selector call, where `mat` is a param typed with a
+// generic struct (`&SinkMatch<'_>`), binds to that struct's `buffer`
+// method — not to its like-named field, and not left unresolved. The
+// generic resolver keys methods by their verbatim receiver
+// (`SinkMatch<'b>`), which the generics-stripped inferred receiver_type
+// (`SinkMatch`) misses; the scope pass' base-name alias binds it.
+func TestRustScope_ReceiverTypeSelector(t *testing.T) {
+	g := buildRustGraph(t, map[string]string{
+		"lib.rs": `
+struct SinkMatch<'b> { buffer: &'b [u8] }
+
+impl<'b> SinkMatch<'b> {
+    fn buffer(&self) -> &'b [u8] { self.buffer }
+}
+
+fn take(mat: &SinkMatch<'_>) {
+    let _b = mat.buffer();
+}
+`,
+	})
+	ResolveRustScopeCalls(g)
+	targets := callTargetsFromRust(g, "lib.rs::take")
+	require.Contains(t, targets, "lib.rs::SinkMatch<'b>.buffer")
+}

--- a/internal/resolver/rust_samecrate_test.go
+++ b/internal/resolver/rust_samecrate_test.go
@@ -1,0 +1,35 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A bare `RegexMatcherBuilder::new()` call is ambiguous when two crates
+// define that type, but a same-crate call almost always means the same-crate
+// type. The scope pass breaks the tie by the caller's crate (the path up to
+// "/src/").
+func TestRustScope_SameCrateDisambiguation(t *testing.T) {
+	g := buildRustGraph(t, map[string]string{
+		"crates/regex/src/matcher.rs": `
+struct RegexMatcherBuilder {}
+impl RegexMatcherBuilder {
+    fn new() -> RegexMatcherBuilder { RegexMatcherBuilder {} }
+}
+fn make() {
+    let _b = RegexMatcherBuilder::new();
+}
+`,
+		"crates/pcre2/src/matcher.rs": `
+struct RegexMatcherBuilder {}
+impl RegexMatcherBuilder {
+    fn new() -> RegexMatcherBuilder { RegexMatcherBuilder {} }
+}
+`,
+	})
+	ResolveRustScopeCalls(g)
+	targets := callTargetsFromRust(g, "crates/regex/src/matcher.rs::make")
+	require.Contains(t, targets, "crates/regex/src/matcher.rs::RegexMatcherBuilder.new")
+	require.NotContains(t, targets, "crates/pcre2/src/matcher.rs::RegexMatcherBuilder.new")
+}

--- a/internal/resolver/rust_scope.go
+++ b/internal/resolver/rust_scope.go
@@ -231,6 +231,9 @@ func rustScopeEdgeCandidate(e *graph.Edge) bool {
 	if rt, _ := e.Meta["receiver_type"].(string); rt != "" {
 		return true
 	}
+	if ex, _ := e.Meta["rust_recv_expr"].(string); strings.HasPrefix(ex, "self.") {
+		return true
+	}
 	return false
 }
 
@@ -246,6 +249,9 @@ type rustScopeIndex struct {
 	// paramsByOwner: caller function/method ID → set of param names,
 	// for local-shadows-import precedence.
 	paramsByOwner map[string]map[string]struct{}
+	// fieldTypesByOwner: (repo, ownerType, fieldName) → declared field type
+	// (base name), for walking self.<field>.<field> receiver chains.
+	fieldTypesByOwner map[rustFieldKey]string
 
 	lastOrigin     string
 	lastConfidence float64
@@ -262,15 +268,22 @@ type rustNameKey struct {
 	name string
 }
 
+type rustFieldKey struct {
+	repo  string
+	owner string
+	field string
+}
+
 // buildRustScopeIndex walks the graph once and indexes Rust method
 // owners, free functions, and caller params. Returns nil when the graph
 // has no Rust methods or functions (the pass is a no-op for non-Rust
 // graphs).
 func buildRustScopeIndex(g graph.Store) *rustScopeIndex {
 	idx := &rustScopeIndex{
-		methodsByOwner:  map[rustOwnerKey][]*graph.Node{},
-		freeFuncsByName: map[rustNameKey][]*graph.Node{},
-		paramsByOwner:   map[string]map[string]struct{}{},
+		methodsByOwner:    map[rustOwnerKey][]*graph.Node{},
+		freeFuncsByName:   map[rustNameKey][]*graph.Node{},
+		paramsByOwner:     map[string]map[string]struct{}{},
+		fieldTypesByOwner: map[rustFieldKey]string{},
 	}
 	any := false
 	for n := range g.NodesByKind(graph.KindMethod) {
@@ -320,6 +333,23 @@ func buildRustScopeIndex(g graph.Store) *rustScopeIndex {
 		}
 		set[n.Name] = struct{}{}
 	}
+	// Struct fields carry their declared type + owner in Meta, indexed by
+	// generics-stripped base names so a self.<field> chain can be walked.
+	for n := range g.NodesByKind(graph.KindField) {
+		if n == nil || n.Language != "rust" {
+			continue
+		}
+		owner, _ := n.Meta["receiver"].(string)
+		ft, _ := n.Meta["field_type"].(string)
+		if owner == "" || ft == "" {
+			continue
+		}
+		idx.fieldTypesByOwner[rustFieldKey{
+			repo:  n.RepoPrefix,
+			owner: rustBaseTypeName(owner),
+			field: n.Name,
+		}] = rustBaseTypeName(ft)
+	}
 	return idx
 }
 
@@ -347,6 +377,21 @@ func (idx *rustScopeIndex) resolve(e *graph.Edge, caller *graph.Node) string {
 			return id
 		}
 		return ""
+	}
+
+	// Selector call on a self-rooted field-access receiver
+	// (`self.config.line_term.as_byte()`). Walk the field types from the
+	// enclosing impl type down the chain, then bind the method on the type
+	// the chain lands on.
+	if expr, _ := e.Meta["rust_recv_expr"].(string); strings.HasPrefix(expr, "self.") {
+		if name := selectorCallName(e.To); name != "" {
+			if t := idx.fieldWalk(repo, nodeReceiverType(caller), expr); t != "" {
+				if id := idx.uniqueMethod(repo, t, name); id != "" {
+					idx.set(graph.OriginASTResolved, 0.82, "field_receiver")
+					return id
+				}
+			}
+		}
 	}
 
 	// Selector call on a typed variable/param (`mat.buffer()` where
@@ -507,6 +552,30 @@ func (idx *rustScopeIndex) methodBySameCrate(repo, owner, name, callerFile strin
 		hit = m.ID
 	}
 	return hit
+}
+
+// fieldWalk resolves the type a self-rooted field-access receiver lands on.
+// Given the enclosing impl type (`Searcher`) and a receiver expression
+// (`self.config.line_term`), it walks each field via the field-type index —
+// Searcher.config -> Config, Config.line_term -> LineTerminator — and
+// returns the final type, or "" if any hop is unknown or ambiguous.
+func (idx *rustScopeIndex) fieldWalk(repo, implType, expr string) string {
+	t := rustBaseTypeName(implType)
+	if t == "" {
+		return ""
+	}
+	fields := strings.Split(strings.TrimPrefix(expr, "self."), ".")
+	for _, f := range fields {
+		if f == "" {
+			return ""
+		}
+		next := idx.fieldTypesByOwner[rustFieldKey{repo: repo, owner: t, field: f}]
+		if next == "" {
+			return ""
+		}
+		t = next
+	}
+	return t
 }
 
 // rustCrateOf returns a stable identifier for the crate a Rust source file

--- a/internal/resolver/rust_scope.go
+++ b/internal/resolver/rust_scope.go
@@ -75,7 +75,9 @@ func ResolveRustScopeCalls(g graph.Store) int {
 		return bound
 	}
 
-	resolved := 0
+	// Trait-impl override edges bind independently of unresolved call edges,
+	// so resolve them before the call-edge early-out below.
+	resolved := resolveRustTraitOverrides(g, idx)
 	var reindexBatch []graph.EdgeReindex
 
 	// Collect candidate edges (still-unresolved Rust EdgeCalls) plus the
@@ -102,7 +104,7 @@ func ResolveRustScopeCalls(g graph.Store) int {
 		}
 	}
 	if len(cands) == 0 {
-		return bound
+		return bound + resolved
 	}
 
 	fromList := make([]string, 0, len(fromIDs))
@@ -138,6 +140,76 @@ func ResolveRustScopeCalls(g graph.Store) int {
 		g.ReindexEdges(reindexBatch)
 	}
 	return bound + resolved
+}
+
+// resolveRustTraitOverrides binds the unresolved EdgeOverrides the extractor
+// emits for `impl Trait for Type` methods (target unresolved::<Trait>.<method>)
+// to the trait declaration's method node. The trait may live in another file
+// or crate, so the binding runs off the trait-method index rather than the
+// caller's file. Returns the number of override edges bound.
+func resolveRustTraitOverrides(g graph.Store, idx *rustScopeIndex) int {
+	var cands []*graph.Edge
+	fromIDs := make(map[string]struct{})
+	for e := range g.EdgesByKind(graph.EdgeOverrides) {
+		if e == nil || !graph.IsUnresolvedTarget(e.To) {
+			continue
+		}
+		if _, _, ok := parseRustOverrideTarget(e.To); !ok {
+			continue
+		}
+		cands = append(cands, e)
+		if e.From != "" {
+			fromIDs[e.From] = struct{}{}
+		}
+	}
+	if len(cands) == 0 {
+		return 0
+	}
+	fromList := make([]string, 0, len(fromIDs))
+	for id := range fromIDs {
+		fromList = append(fromList, id)
+	}
+	fromNodes := g.GetNodesByIDs(fromList)
+
+	bound := 0
+	var batch []graph.EdgeReindex
+	for _, e := range cands {
+		trait, method, _ := parseRustOverrideTarget(e.To)
+		from := fromNodes[e.From]
+		if from == nil || from.Language != "rust" {
+			continue
+		}
+		target := idx.uniqueTraitMethod(from.RepoPrefix, trait, method)
+		if target == "" || target == e.To {
+			continue
+		}
+		oldTo := e.To
+		e.To = target
+		e.Origin = graph.OriginASTResolved
+		e.Confidence = 1.0
+		e.ConfidenceLabel = graph.ConfidenceLabelFor(graph.EdgeOverrides, 1.0)
+		if e.Meta == nil {
+			e.Meta = map[string]any{}
+		}
+		e.Meta["rust_resolution"] = "trait_override"
+		batch = append(batch, graph.EdgeReindex{Edge: e, OldTo: oldTo})
+		bound++
+	}
+	if len(batch) > 0 {
+		g.ReindexEdges(batch)
+	}
+	return bound
+}
+
+// parseRustOverrideTarget splits an unresolved::<Trait>.<method> override
+// target into its trait + method components.
+func parseRustOverrideTarget(to string) (trait, method string, ok bool) {
+	name := graph.UnresolvedName(to)
+	i := strings.LastIndex(name, ".")
+	if i <= 0 || i >= len(name)-1 {
+		return "", "", false
+	}
+	return name[:i], name[i+1:], true
 }
 
 // rustScopeEdgeCandidate reports whether an unresolved call edge is one
@@ -334,6 +406,28 @@ func (idx *rustScopeIndex) uniqueMethod(repo, owner, name string) string {
 		}
 		if hit != "" && hit != m.ID {
 			return "" // ambiguous
+		}
+		hit = m.ID
+	}
+	return hit
+}
+
+// uniqueTraitMethod returns the ID of the single trait-declaration method
+// named `name` owned by trait `owner` in repo, or "" on no match or
+// ambiguity. Only nodes marked Meta["trait_decl"]="true" qualify, so an
+// inherent method on a same-named type is never mistaken for the trait's.
+func (idx *rustScopeIndex) uniqueTraitMethod(repo, owner, name string) string {
+	cands := idx.methodsByOwner[rustOwnerKey{repo: repo, owner: owner}]
+	var hit string
+	for _, m := range cands {
+		if m.Name != name || m.Meta == nil {
+			continue
+		}
+		if td, _ := m.Meta["trait_decl"].(string); td != "true" {
+			continue
+		}
+		if hit != "" && hit != m.ID {
+			return ""
 		}
 		hit = m.ID
 	}

--- a/internal/resolver/rust_scope.go
+++ b/internal/resolver/rust_scope.go
@@ -377,6 +377,15 @@ func (idx *rustScopeIndex) resolve(e *graph.Edge, caller *graph.Node) string {
 			idx.set(graph.OriginASTResolved, 0.9, "impl_owner")
 			return id
 		}
+		// Ambiguous by type name alone — the same type name is defined in
+		// more than one crate/module (e.g. grep::regex::RegexMatcherBuilder
+		// and grep::pcre2::RegexMatcherBuilder). Disambiguate with the
+		// qualified path's crate/module segments: bind to the candidate
+		// whose file lives under a directory named by a path segment.
+		if id := idx.methodByPathSegments(repo, qualifier, last, segments); id != "" {
+			idx.set(graph.OriginASTResolved, 0.9, "impl_owner_path")
+			return id
+		}
 		return ""
 
 	default:
@@ -415,6 +424,34 @@ func (idx *rustScopeIndex) uniqueMethod(repo, owner, name string) string {
 			return "" // ambiguous
 		}
 		hit = m.ID
+	}
+	return hit
+}
+
+// methodByPathSegments disambiguates a Type::method call whose type name is
+// defined in more than one crate/module by matching the qualified path's
+// crate/module segments (grep::regex::Foo::bar -> a candidate whose file
+// lives under a `regex` directory) against each candidate's file path.
+// Returns the ID only when exactly one candidate matches a path segment.
+func (idx *rustScopeIndex) methodByPathSegments(repo, owner, name string, segments []string) string {
+	cands := idx.methodsByOwner[rustOwnerKey{repo: repo, owner: owner}]
+	var hit string
+	for _, m := range cands {
+		if m.Name != name {
+			continue
+		}
+		for _, seg := range segments {
+			if seg == "" || seg == owner || seg == name {
+				continue
+			}
+			if strings.Contains(m.FilePath, "/"+seg+"/") {
+				if hit != "" && hit != m.ID {
+					return "" // more than one crate/module matched
+				}
+				hit = m.ID
+				break
+			}
+		}
 	}
 	return hit
 }

--- a/internal/resolver/rust_scope.go
+++ b/internal/resolver/rust_scope.go
@@ -277,8 +277,15 @@ func buildRustScopeIndex(g graph.Store) *rustScopeIndex {
 		if owner == "" {
 			continue
 		}
-		idx.methodsByOwner[rustOwnerKey{repo: n.RepoPrefix, owner: owner}] = append(
-			idx.methodsByOwner[rustOwnerKey{repo: n.RepoPrefix, owner: owner}], n)
+		// Index under the verbatim owner AND a generics/lifetime-stripped
+		// base (Candidate<'a> -> Candidate) so a call qualifier or inferred
+		// receiver_type that names the base binds to a method whose impl type
+		// carries generic args. The module path is kept to avoid cross-module
+		// name collisions (io::Error stays io::Error).
+		for _, key := range rustOwnerLookupKeys(owner) {
+			k := rustOwnerKey{repo: n.RepoPrefix, owner: key}
+			idx.methodsByOwner[k] = append(idx.methodsByOwner[k], n)
+		}
 		any = true
 	}
 	for n := range g.NodesByKind(graph.KindFunction) {
@@ -513,4 +520,37 @@ func rustParentDir(path string) string {
 		return path[:i]
 	}
 	return ""
+}
+
+// rustOwnerLookupKeys returns the keys a method's verbatim owner type should
+// be indexed under: the verbatim text plus a generics/lifetime/ref-stripped
+// base (module path kept). "Candidate<'a>" -> ["Candidate<'a>", "Candidate"];
+// "io::Error" -> ["io::Error"]; "Foo" -> ["Foo"].
+func rustOwnerLookupKeys(owner string) []string {
+	keys := []string{owner}
+	if base := rustBaseTypeName(owner); base != "" && base != owner {
+		keys = append(keys, base)
+	}
+	return keys
+}
+
+// rustBaseTypeName strips references, a leading lifetime and generic args from
+// a verbatim Rust type, keeping the module path: "&'a mut Candidate<'a>" ->
+// "Candidate", "io::Error" -> "io::Error".
+func rustBaseTypeName(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "&mut ")
+	s = strings.TrimPrefix(s, "&")
+	s = strings.TrimSpace(s)
+	if strings.HasPrefix(s, "'") {
+		if i := strings.IndexByte(s, ' '); i >= 0 {
+			s = strings.TrimSpace(s[i+1:])
+			s = strings.TrimPrefix(s, "mut ")
+			s = strings.TrimSpace(s)
+		}
+	}
+	if i := strings.Index(s, "<"); i >= 0 {
+		s = strings.TrimSpace(s[:i])
+	}
+	return s
 }

--- a/internal/resolver/rust_scope.go
+++ b/internal/resolver/rust_scope.go
@@ -213,10 +213,11 @@ func parseRustOverrideTarget(to string) (trait, method string, ok bool) {
 }
 
 // rustScopeEdgeCandidate reports whether an unresolved call edge is one
-// this pass can attempt: a path call (Meta["rust_path"] set) or a
-// self/Self selector call (Meta["rust_recv"] in {self, Self}). Every
-// other selector call is left to the generic resolver's receiver-type
-// cascade.
+// this pass can attempt: a path call (Meta["rust_path"] set), a self/Self
+// selector call (Meta["rust_recv"] in {self, Self}), or a selector call on
+// a typed receiver (Meta["receiver_type"] set) that the generic resolver
+// left unresolved because it keys methods by their verbatim (generic)
+// receiver. Every other selector call is left to the generic resolver.
 func rustScopeEdgeCandidate(e *graph.Edge) bool {
 	if e.Meta == nil {
 		return false
@@ -225,6 +226,9 @@ func rustScopeEdgeCandidate(e *graph.Edge) bool {
 		return true
 	}
 	if r, _ := e.Meta["rust_recv"].(string); r == "self" || r == "Self" {
+		return true
+	}
+	if rt, _ := e.Meta["receiver_type"].(string); rt != "" {
 		return true
 	}
 	return false
@@ -343,6 +347,21 @@ func (idx *rustScopeIndex) resolve(e *graph.Edge, caller *graph.Node) string {
 			return id
 		}
 		return ""
+	}
+
+	// Selector call on a typed variable/param (`mat.buffer()` where
+	// `mat: &SinkMatch<'_>`). The generic resolver keys methods by their
+	// verbatim receiver ("SinkMatch<'b>"), so a generics-stripped inferred
+	// receiver_type ("SinkMatch") misses it. The scope index carries a
+	// base-name alias, so bind here when the type owns exactly one such
+	// method.
+	if rt, _ := e.Meta["receiver_type"].(string); rt != "" {
+		if name := selectorCallName(e.To); name != "" {
+			if id := idx.uniqueMethod(repo, rustBaseTypeName(rt), name); id != "" {
+				idx.set(graph.OriginASTResolved, 0.88, "receiver_type")
+				return id
+			}
+		}
 	}
 
 	path, _ := e.Meta["rust_path"].(string)

--- a/internal/resolver/rust_scope.go
+++ b/internal/resolver/rust_scope.go
@@ -405,6 +405,14 @@ func (idx *rustScopeIndex) resolve(e *graph.Edge, caller *graph.Node) string {
 			idx.set(graph.OriginASTResolved, 0.9, "impl_owner_path")
 			return id
 		}
+		// Still ambiguous, and the call named no disambiguating path segment
+		// (bare `RegexMatcherBuilder::new()`). Prefer the candidate defined in
+		// the caller's own crate: a same-crate associated-function call almost
+		// always means the same-crate type.
+		if id := idx.methodBySameCrate(repo, qualifier, last, caller.FilePath); id != "" {
+			idx.set(graph.OriginASTResolved, 0.85, "impl_owner_crate")
+			return id
+		}
 		return ""
 
 	default:
@@ -473,6 +481,46 @@ func (idx *rustScopeIndex) methodByPathSegments(repo, owner, name string, segmen
 		}
 	}
 	return hit
+}
+
+// methodBySameCrate disambiguates a `Type::method` call that names no
+// disambiguating path segment by preferring the candidate defined in the
+// caller's own crate. Returns the ID only when exactly one candidate lives
+// in that crate.
+func (idx *rustScopeIndex) methodBySameCrate(repo, owner, name, callerFile string) string {
+	callerCrate := rustCrateOf(callerFile)
+	if callerCrate == "" {
+		return ""
+	}
+	cands := idx.methodsByOwner[rustOwnerKey{repo: repo, owner: owner}]
+	var hit string
+	for _, m := range cands {
+		if m.Name != name {
+			continue
+		}
+		if rustCrateOf(m.FilePath) != callerCrate {
+			continue
+		}
+		if hit != "" && hit != m.ID {
+			return "" // more than one candidate in the caller's crate
+		}
+		hit = m.ID
+	}
+	return hit
+}
+
+// rustCrateOf returns a stable identifier for the crate a Rust source file
+// belongs to: the path up to (and excluding) the "/src/" segment that marks
+// a cargo crate root (crates/regex/src/matcher.rs -> "crates/regex",
+// myproj/src/lib.rs -> "myproj"). Files with no "/src/" segment — flat
+// scripts, test-dir files, or synthetic fixtures — have no determinable
+// crate and return "", so the same-crate tiebreaker stays conservative and
+// never guesses across an unknown boundary.
+func rustCrateOf(path string) string {
+	if i := strings.Index(path, "/src/"); i >= 0 {
+		return path[:i]
+	}
+	return ""
 }
 
 // uniqueTraitMethod returns the ID of the single trait-declaration method


### PR DESCRIPTION
Rust `find_usages` previously returned almost nothing for most methods and associated functions: the extractor left receiver types unrecorded, the resolver could not bind qualified or generic-owner calls, and a query-time suppression pass dropped the resolver-bound edges that did exist. This change teaches the extractor and Rust scope resolver to recover receiver types from several call shapes, disambiguates `Type::method` across crates, models trait declarations and override edges, and stops suppression from collapsing legitimate call sites. The net effect is that method and function usage lists are now populated from the compiler-independent edges alone, before any language-server confirmation runs.

## What changed

- **Query-time suppression fix.** `SuppressRedundantTextMatches` mapped empty-origin (resolver-bound) edges onto the `text_matched` tier, so a single stronger edge for a target dropped every untagged resolver edge — collapsing a method's usage list to a handful of sites. Suppression now drops only edges explicitly tagged `OriginTextMatched` and keeps untagged resolver-bound edges. Two supporting origin-tiering fixes: exact receiver-type method matches are now stamped `ast_resolved` (structural evidence, out of the cross-package guard's reach so re-export / import-unreachable calls survive), while the name-only locality fallback is tagged `text_matched` so it is correctly masked once a real target is confirmed.
- **Receiver-type resolution.**
  - *Params and self:* selector calls on a parameter or `self` receiver (`args.foo()`, `self.bar()`) now stamp `receiver_type` from the enclosing function's own parameter scope, mirroring the Go per-function param map, and a parameter shadows a same-named file-wide binding. The scope resolver additionally indexes each method under a generics/lifetime-stripped owner alias so a call naming the base type binds to a method whose impl type carries generic arguments.
  - *Typed-var selectors:* a selector call on a typed variable or param (`mat.buffer()` where `mat: &SinkMatch<'_>`) carries a generics-stripped inferred receiver type; these edges are now admitted to the scope pass and bound via the base-name owner alias when the type owns exactly one method of that name, skipping like-named struct fields.
  - *Self-rooted field-access chains:* a call like `self.config.line_term.as_byte()` whose receiver is a field chain now records the chain, and the resolver walks declared struct field types from the enclosing impl type down the chain to bind the method on the type the chain lands on.
  - Calls in const/static initialisers (no enclosing function) fall back to the file node as caller so the site is recorded rather than dropped.
- **Cross-crate / same-crate `Type::method` disambiguation.** Calls carrying a `::`-qualified path are deferred from the bare-name function-call cascade to the Rust scope pass, which reads the qualifier; when a type name is defined in more than one crate/module the qualifier's path segments pick the candidate whose file lives under a matching directory. For a bare `Type::method` call that names no disambiguating segment, an associated-function call is broken to the caller's own crate (the path up to `/src/`), staying conservative — files with no crate root keep genuinely ambiguous cross-file calls unresolved.
- **Trait-declaration method nodes + override edges.** Trait method signatures and default methods now get their own `<file>::<Trait>.<method>` method nodes with receiver / `trait_decl` metadata and a member-of edge to the trait interface, so a dyn-dispatch call binding to the declaration is answerable and impls can be paired against it. `impl Trait for Type` methods emit method-level override edges resolved (possibly cross-file / crate) via a trait-method index, covering impls on external types that structural inference cannot.

## Results

On the ripgrep `find_usages` benchmark, the default (non-LSP) arm now measures line precision ~0.96 and line recall ~0.92, up from ~0.11 recall. These figures are produced by the compiler-independent extractor / resolver edges alone — no language-server confirmation is required to reach them.

## Testing

- `go build ./...` and `go test -race` pass on the touched and cross-language packages (query, resolver, parser/languages, semantic/lsp, semantic/tstypes).
- `golangci-lint` clean; the `cmd/gortex` wire-contract golden is unchanged.
- New unit tests accompany each fix: receiver-type seeding and typed-receiver selector binding, self-rooted field-access chain resolution, same-crate and cross-crate `Type::method` disambiguation, owner-alias binding, trait-declaration nodes and override edges, and empty-origin suppression retention.

## Known limitations

- One builder-method-chain shape still returns a silent zero: a fluent chain whose intermediate receiver type is only known from a prior builder return is not yet threaded, so usages of the chained method can be missed.
- The trait benchmark stratum is effectively vacuous — its ground truth targets impl methods reached only through trait-object dispatch, which have no direct static callers, so there is nothing for the compiler-independent arm to recover.
- The language-server-tier arm remains bounded by rust-analyzer instability under constrained memory: on tight memory budgets the server becomes deadline-bound and confirms only a prefix of declarations.
- Cross-crate type-reference disambiguation for re-exported, ambiguous type names is a follow-up: when the same type name is re-exported from multiple crates and the call names no disambiguating segment, the caller's-crate tiebreaker does not cover the re-export case and those references stay unresolved.
