### PR TITLE
Fix live-reindex resolution fidelity (same-file demotion, suppression, restub idempotence, degradation guards)

### DIFF
--- a/cmd/gortex/daemon_boot_guard_test.go
+++ b/cmd/gortex/daemon_boot_guard_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// TestSnapshotRoundTrip_RepoNodeEdgeCounts proves the additive per-repo
+// NodeCount / EdgeCount fields survive a save + load cycle — the baseline the
+// boot shape-degradation guard compares a reloaded repo against.
+func TestSnapshotRoundTrip_RepoNodeEdgeCounts(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("GORTEX_DAEMON_SNAPSHOT", filepath.Join(dir, "snap.gob.gz"))
+
+	orig := graph.New()
+	orig.AddNode(&graph.Node{ID: "r/a.go::Foo", Name: "Foo", Kind: graph.KindFunction, FilePath: "r/a.go"})
+
+	repos := []snapshotRepo{{
+		RepoPrefix: "r",
+		RootPath:   "/tmp/r",
+		FileMtimes: map[string]int64{"r/a.go": 123},
+		NodeCount:  8956,
+		EdgeCount:  58491,
+	}}
+	saveSnapshot(orig, repos, nil, snapshotVector{}, version, zap.NewNop())
+
+	restored := graph.New()
+	result, err := loadSnapshot(restored, zap.NewNop())
+	require.NoError(t, err)
+	require.True(t, result.Loaded)
+
+	rec, ok := result.Repos["r"]
+	require.True(t, ok, "repo record must round-trip keyed by prefix")
+	assert.Equal(t, 8956, rec.NodeCount, "per-repo node count must round-trip")
+	assert.Equal(t, 58491, rec.EdgeCount, "per-repo edge count must round-trip")
+}
+
+func TestBootShapeShortfall(t *testing.T) {
+	// Baseline: a repo that saved 8956 nodes / 58491 edges.
+	snap := map[string]*snapshotRepo{
+		"r": {RepoPrefix: "r", NodeCount: 8956, EdgeCount: 58491},
+		// A legacy / newly-tracked record with no recorded counts.
+		"legacy": {RepoPrefix: "legacy", NodeCount: 0, EdgeCount: 0},
+	}
+
+	t.Run("edge collapse trips", func(t *testing.T) {
+		// The measured degradation: 58491 -> 45026 edges is a 23% drop, which
+		// does NOT trip the 50% floor — a modest shrink is tolerated.
+		assert.False(t, bootShapeShortfall(snap, "r", 8512, 45026),
+			"a 23% edge shrink is below the collapse floor")
+		// A true collapse (edges more than halved) trips.
+		assert.True(t, bootShapeShortfall(snap, "r", 8956, 20000),
+			"edges more than halved must trip the guard")
+	})
+
+	t.Run("node collapse trips", func(t *testing.T) {
+		assert.True(t, bootShapeShortfall(snap, "r", 3000, 58491),
+			"nodes more than halved must trip the guard")
+	})
+
+	t.Run("healthy reload does not trip", func(t *testing.T) {
+		assert.False(t, bootShapeShortfall(snap, "r", 8956, 58491),
+			"an unchanged reload must not trip")
+	})
+
+	t.Run("zero baseline never trips", func(t *testing.T) {
+		assert.False(t, bootShapeShortfall(snap, "legacy", 0, 0),
+			"a record with no recorded counts has no baseline to compare")
+	})
+
+	t.Run("unknown prefix never trips", func(t *testing.T) {
+		assert.False(t, bootShapeShortfall(snap, "absent", 1, 1),
+			"a prefix absent from the snapshot has no baseline")
+	})
+}

--- a/cmd/gortex/daemon_snapshot.go
+++ b/cmd/gortex/daemon_snapshot.go
@@ -42,6 +42,13 @@ type snapshotRepo struct {
 	RepoPrefix string
 	RootPath   string
 	FileMtimes map[string]int64
+	// NodeCount / EdgeCount are the per-repo graph shape at save time. Added
+	// additively — a snapshot written before this field decodes them as zero,
+	// which the boot shape-degradation guard reads as "no baseline to compare"
+	// and skips. Used on reload to catch a persisted graph that came back
+	// materially short of what it held when saved.
+	NodeCount int
+	EdgeCount int
 }
 
 // snapshotContract is the wire form of contracts.Contract. Persisted so
@@ -538,6 +545,25 @@ func snapshotWouldCollapse(path string, newNodes, newEdges int, logger *zap.Logg
 		zap.Int("new_edges", newEdges),
 		zap.Int("shrink_floor_percent", snapshotShrinkFloorPercent))
 	return true
+}
+
+// bootShapeShortfall reports whether a warm-reloaded repo's live node/edge
+// counts have collapsed against what the snapshot recorded for it — the
+// per-repo, boot-time analogue of snapshotWouldCollapse (which guards the
+// whole graph at save time). Only a drastic drop trips (the same floor share
+// as the persist-side shrink guard); a snapshot with no recorded counts
+// (legacy / newly tracked, both zero) returns false, since there is nothing
+// trustworthy to compare against.
+func bootShapeShortfall(snap map[string]*snapshotRepo, prefix string, liveNodes, liveEdges int) bool {
+	rec, ok := snap[prefix]
+	if !ok || rec == nil || rec.NodeCount == 0 || rec.EdgeCount == 0 {
+		return false
+	}
+	// Cross-multiply to avoid floating-point rounding:
+	//   live < rec * floor/100   ⇔   live*100 < rec*floor
+	nodesShort := liveNodes*100 < rec.NodeCount*snapshotShrinkFloorPercent
+	edgesShort := liveEdges*100 < rec.EdgeCount*snapshotShrinkFloorPercent
+	return nodesShort || edgesShort
 }
 
 // toSnapshotContract flattens a contracts.Contract into its wire form.

--- a/cmd/gortex/daemon_state.go
+++ b/cmd/gortex/daemon_state.go
@@ -388,6 +388,31 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 							} else {
 								scopeUnknown.Store(true)
 							}
+						default:
+							// Warm no-op path: the repo re-indexed nothing, so its
+							// graph is served straight from the persisted store.
+							// Vet the freshly-recomputed per-repo counts against
+							// what the snapshot recorded — a material shortfall
+							// means the store came back shape-degraded relative to
+							// the snapshot metadata (a persisted resolution
+							// regression). Mark the repo changed so the
+							// end-of-warmup global re-resolve + derivation passes
+							// run for it instead of silently serving the shrunken
+							// graph, and surface the event so a ratchet can't hide
+							// behind an all-green index_health.
+							if res != nil && bootShapeShortfall(state.snapshotRepos, res.RepoPrefix, res.NodeCount, res.EdgeCount) {
+								indexer.RecordResolutionRegression()
+								logger.Warn("daemon: boot shape-degradation guard — repo graph materially short of snapshot; re-running resolution",
+									zap.String("prefix", res.RepoPrefix),
+									zap.Int("live_nodes", res.NodeCount),
+									zap.Int("live_edges", res.EdgeCount))
+								changedRepos.Add(1)
+								if res.RepoPrefix != "" {
+									changedPrefixes.Store(res.RepoPrefix, struct{}{})
+								} else {
+									scopeUnknown.Store(true)
+								}
+							}
 						}
 					} else {
 						// No prior mtimes → full cold (re)index of this repo,
@@ -807,6 +832,8 @@ func collectSnapshotRepos(mi *indexer.MultiIndexer) []snapshotRepo {
 			RepoPrefix: prefix,
 			RootPath:   m.RootPath,
 			FileMtimes: mtimes,
+			NodeCount:  m.NodeCount,
+			EdgeCount:  m.EdgeCount,
 		})
 	}
 	return out

--- a/cmd/gortex/wire_contract_test.go
+++ b/cmd/gortex/wire_contract_test.go
@@ -159,7 +159,11 @@ func wireContractGolden(name string) string {
 		// Previously bumped when BinaryMtimeUnix was added.
 		return "a0f604616d04c757ffec4d084fc53cf6c3db03c8add1a8af0f32f902c1b1fe92"
 	case "snapshotRepo":
-		return "8a78544c6e8d6c384f95b971df43408e7bc5f5ab4c7f2052d038bd3ffa4e1311"
+		// Bumped when the per-repo NodeCount / EdgeCount fields were added —
+		// the baseline the boot shape-degradation guard compares a reloaded
+		// repo against. Additive: gob decodes older snapshots with both zero,
+		// which the guard reads as "no baseline to compare" and skips.
+		return "ddb90a625b70b681e3ac4015db3192991c37e6cdf8b0edef501db282bdfe3de3"
 	case "snapshotContract":
 		// New wire type introduced with per-repo contract persistence.
 		// Mirrors contracts.Contract but stores Type/Role as strings so

--- a/internal/graph/edge.go
+++ b/internal/graph/edge.go
@@ -700,6 +700,14 @@ const (
 // edge-returning surface drops these unless the caller opts in.
 const MetaSpeculative = "speculative"
 
+// MetaReparsePendingEnrichment is a KindFile-node Meta key (not an edge key)
+// set by the indexer when a live watch re-parse resolved the file's references
+// without re-running semantic enrichment — so the file's edges may sit below
+// the tier the enrichment pass would mint. find_usages / get_callers read it
+// to flag their default text_matched suppression as re-verification-pending,
+// making a hidden-but-real usage diagnosable instead of silently dropped.
+const MetaReparsePendingEnrichment = "reparse_pending_enrichment"
+
 // OriginRank returns a numeric rank for origin comparison. Higher = more
 // confident. Unknown or empty origin returns 0 so it sorts below all known
 // tiers; filters treat it as "untagged" and fall back to legacy inference.

--- a/internal/graph/restub_provenance.go
+++ b/internal/graph/restub_provenance.go
@@ -1,0 +1,74 @@
+package graph
+
+// Restub provenance handoff.
+//
+// When a file is re-parsed, its symbols are evicted and every incoming
+// reference edge is restubbed to an `unresolved::<name>` target so the
+// incoming-resolve pass can rebind it once the symbols come back. The edge
+// keeps its identity, but its resolved provenance (origin / tier / confidence)
+// is now a lie: it points at an unresolved stub. Two failure modes follow if
+// the provenance is left untouched — a genuinely deleted definition leaves a
+// stub advertising a compiler-grade tier, and a rebind to a *different* target
+// inherits the old tier it never earned.
+//
+// StashRestubProvenance clears the live provenance and records it in the edge's
+// Meta; RestoreRestubProvenance re-applies it only when the stub rebinds to the
+// exact same target (an idempotent re-parse: unchanged binding, unchanged
+// tier), and always drops the transient keys. The restub pass (indexer) and the
+// incoming-resolve pass (resolver) live in different packages, so this handoff
+// rides the edge Meta between them.
+const (
+	metaRestubPrevTo     = "restub_prev_to"
+	metaRestubPrevOrigin = "restub_prev_origin"
+	metaRestubPrevTier   = "restub_prev_tier"
+	metaRestubPrevConf   = "restub_prev_conf"
+)
+
+// StashRestubProvenance records e's current target + resolved provenance in its
+// Meta and clears the live provenance, so a restubbed edge no longer advertises
+// the resolved tier it held while bound. Call it just before rewriting e.To to
+// the unresolved stub. No-op on a nil edge.
+func StashRestubProvenance(e *Edge) {
+	if e == nil {
+		return
+	}
+	if e.Meta == nil {
+		e.Meta = map[string]any{}
+	}
+	e.Meta[metaRestubPrevTo] = e.To
+	e.Meta[metaRestubPrevOrigin] = e.Origin
+	e.Meta[metaRestubPrevTier] = e.Tier
+	e.Meta[metaRestubPrevConf] = e.Confidence
+	e.Origin, e.Tier, e.Confidence = "", "", 0
+}
+
+// RestoreRestubProvenance re-applies stashed provenance to e when e is now
+// resolved to the SAME target it had before the restub — the binding is
+// unchanged, so its verified tier is too — and always drops the transient stash
+// keys (whether or not it restored). A rebind to a different target, or a stub
+// that never rebound, keeps the honest fresh tier the resolver assigned (or
+// none). No-op when there is nothing stashed.
+func RestoreRestubProvenance(e *Edge) {
+	if e == nil || e.Meta == nil {
+		return
+	}
+	prevTo, ok := e.Meta[metaRestubPrevTo]
+	if !ok {
+		return
+	}
+	if to, isStr := prevTo.(string); isStr && to == e.To && !IsUnresolvedTarget(e.To) {
+		if o, ok := e.Meta[metaRestubPrevOrigin].(string); ok {
+			e.Origin = o
+		}
+		if tr, ok := e.Meta[metaRestubPrevTier].(string); ok {
+			e.Tier = tr
+		}
+		if c, ok := e.Meta[metaRestubPrevConf].(float64); ok {
+			e.Confidence = c
+		}
+	}
+	delete(e.Meta, metaRestubPrevTo)
+	delete(e.Meta, metaRestubPrevOrigin)
+	delete(e.Meta, metaRestubPrevTier)
+	delete(e.Meta, metaRestubPrevConf)
+}

--- a/internal/indexer/file_meta.go
+++ b/internal/indexer/file_meta.go
@@ -55,3 +55,32 @@ func (idx *Indexer) persistFileMeta(relPath string, src []byte, result *parser.E
 	_ = fw.DeleteFileMetasByFiles(idx.repoPrefix, []string{filePath})
 	_ = fw.SetFileMetas(idx.repoPrefix, []graph.FileMetaRow{row})
 }
+
+// setReparsePendingEnrichment sets or clears
+// graph.MetaReparsePendingEnrichment on a file's KindFile node, marking
+// whether the most recent live re-parse resolved the file without re-running
+// semantic enrichment. It round-trips the node through AddNode so a disk
+// backend persists the meta change (an in-place map write is lost on sqlite),
+// and skips the write entirely when the marker is already in the desired state
+// so a save storm never re-persists unchanged nodes.
+func (idx *Indexer) setReparsePendingEnrichment(graphPath string, pending bool) {
+	for _, n := range idx.graph.GetFileNodes(graphPath) {
+		if n.Kind != graph.KindFile {
+			continue
+		}
+		_, had := n.Meta[graph.MetaReparsePendingEnrichment]
+		switch {
+		case pending && !had:
+			if n.Meta == nil {
+				n.Meta = map[string]any{}
+			}
+			n.Meta[graph.MetaReparsePendingEnrichment] = true
+		case !pending && had:
+			delete(n.Meta, graph.MetaReparsePendingEnrichment)
+		default:
+			return // already in the desired state — no round-trip
+		}
+		idx.graph.AddNode(n)
+		return
+	}
+}

--- a/internal/indexer/incremental_resolve.go
+++ b/internal/indexer/incremental_resolve.go
@@ -104,7 +104,18 @@ func captureIncrementalState(g graph.Store, graphPath string) (reuse map[reuseKe
 // applyResolvedOutEdges pre-resolves freshly extracted unresolved edges that
 // match a captured resolution, BEFORE they are added to the graph (so no edge
 // re-keying is needed). Returns how many edges were reused.
-func applyResolvedOutEdges(g graph.Store, edges []*graph.Edge, idx map[reuseKey]*reuseVal) int {
+//
+// newIDs holds the IDs of the nodes about to be re-added by the caller's
+// AddBatch. It exists for the same-file case: when a call's target lives in the
+// re-parsed file, eviction removed the target node before this runs, so a bare
+// GetNode(v.to) lookup would miss and the edge would fall through to a full
+// re-resolve — which rebinds the target correctly but drops its origin/tier to
+// the resolver's heuristic default. Because node IDs are file::Name (line- and
+// content-independent), a same-file target re-appears under an identical ID, so
+// "present in newIDs" recovers exactly the reuse that a not-yet-added target
+// would otherwise lose. A target absent from BOTH the graph and newIDs was
+// genuinely deleted and is still skipped.
+func applyResolvedOutEdges(g graph.Store, edges []*graph.Edge, idx map[reuseKey]*reuseVal, newIDs map[string]struct{}) int {
 	if len(idx) == 0 {
 		return 0
 	}
@@ -123,7 +134,11 @@ func applyResolvedOutEdges(g graph.Store, edges []*graph.Edge, idx map[reuseKey]
 			continue // miss, or poisoned ambiguous key
 		}
 		if g.GetNode(v.to) == nil {
-			continue // captured target deleted since the snapshot
+			if _, reAdded := newIDs[v.to]; !reAdded {
+				continue // captured target genuinely deleted since the snapshot
+			}
+			// Same-file target: evicted above, re-added by AddBatch below under
+			// an identical ID — reuse its prior resolution and provenance tier.
 		}
 		e.To = v.to
 		e.Confidence = v.confidence

--- a/internal/indexer/incremental_resolve_test.go
+++ b/internal/indexer/incremental_resolve_test.go
@@ -30,13 +30,20 @@ func fnNodeID(t *testing.T, g graph.Store, file, name string) string {
 // node `fromID`.
 func callTargetFrom(t *testing.T, g graph.Store, fromID string) string {
 	t.Helper()
+	return callEdgeFrom(t, g, fromID).To
+}
+
+// callEdgeFrom returns the (single) EdgeCalls edge pointer leaving node
+// `fromID`, failing the test if there is none.
+func callEdgeFrom(t *testing.T, g graph.Store, fromID string) *graph.Edge {
+	t.Helper()
 	for _, e := range g.GetOutEdges(fromID) {
 		if e.Kind == graph.EdgeCalls {
-			return e.To
+			return e
 		}
 	}
 	t.Fatalf("no call edge from %s", fromID)
-	return ""
+	return nil
 }
 
 // TestIncrementalReindex_PreservesIncomingCallerEdges is the proof of
@@ -121,4 +128,54 @@ func TestEvictFile_DropsEnrichmentSidecars(t *testing.T) {
 	assert.Empty(t, g.(graph.ChurnEnrichmentReader).ChurnRows(""), "churn rows must be evicted with the file")
 	assert.Empty(t, g.(graph.CoverageEnrichmentReader).CoverageRows(""), "coverage rows must be evicted")
 	assert.Empty(t, g.(graph.BlameEnrichmentReader).BlameRows(""), "blame rows must be evicted")
+}
+
+// TestIncrementalReuse_SameFileEdge_KeepsTier is the F1 regression: a call
+// whose target lives in the SAME file must keep its resolved provenance across
+// a structural re-parse of that file. Before the fix, eviction removed the
+// target node before applyResolvedOutEdges ran, so the same-file edge missed
+// reuse (GetNode(v.to) == nil) and the forward resolver rebound it at the
+// heuristic default — silently demoting an lsp_resolved edge, which find_usages
+// then suppresses. Node IDs are file::Name (line/content-independent), so an
+// EOF append re-adds the target under an identical ID and the reuse must
+// recover the prior resolution AND its tier.
+func TestIncrementalReuse_SameFileEdge_KeepsTier(t *testing.T) {
+	dir := t.TempDir()
+	aPath := filepath.Join(dir, "a.go")
+	writeFile(t, aPath, "package p\n\nfunc Foo() {}\n\nfunc Baz() { Foo() }\n")
+
+	g := graph.New()
+	idx := New(g, newTestRegistry(), config.IndexConfig{Workers: 1}, zap.NewNop())
+	idx.search = search.NewBM25()
+	idx.SetRootPath(dir)
+	_, err := idx.IndexCtx(testCtx(), dir)
+	require.NoError(t, err)
+
+	fooID := fnNodeID(t, g, "a.go", "Foo")
+	bazID := fnNodeID(t, g, "a.go", "Baz")
+	require.Equal(t, fooID, callTargetFrom(t, g, bazID),
+		"baseline: Baz's same-file call must resolve to Foo")
+
+	// Stamp the same-file call edge compiler-grade (lsp), the tier the
+	// semantic-enrichment pass mints once at track time.
+	e := callEdgeFrom(t, g, bazID)
+	g.SetEdgeProvenance(e, graph.OriginLSPResolved)
+	e.Tier = graph.ResolvedBy(graph.OriginLSPResolved)
+	e.Confidence = 1.0
+
+	// EOF-append a new function: a structural edit that drives the single-file
+	// incremental reindex (evict -> re-parse -> reuse -> resolve) without
+	// shifting Foo's or Baz's lines.
+	writeFile(t, aPath, "package p\n\nfunc Foo() {}\n\nfunc Baz() { Foo() }\n\nfunc Extra() {}\n")
+	require.NoError(t, idx.IndexFile(aPath))
+
+	// The call still points at Foo AND keeps its resolved provenance — not
+	// demoted to the resolver's heuristic default.
+	after := callEdgeFrom(t, g, fnNodeID(t, g, "a.go", "Baz"))
+	assert.Equal(t, fnNodeID(t, g, "a.go", "Foo"), after.To,
+		"same-file call must still resolve to Foo after the re-parse")
+	assert.Equal(t, graph.OriginLSPResolved, after.Origin,
+		"same-file edge must keep its lsp_resolved origin across the re-parse (F1)")
+	assert.Equal(t, graph.ResolvedBy(graph.OriginLSPResolved), after.Tier,
+		"same-file edge must keep its lsp tier across the re-parse (F1)")
 }

--- a/internal/indexer/incremental_resolve_test.go
+++ b/internal/indexer/incremental_resolve_test.go
@@ -179,3 +179,33 @@ func TestIncrementalReuse_SameFileEdge_KeepsTier(t *testing.T) {
 	assert.Equal(t, graph.ResolvedBy(graph.OriginLSPResolved), after.Tier,
 		"same-file edge must keep its lsp tier across the re-parse (F1)")
 }
+
+// TestSetReparsePendingEnrichment_SetAndClear covers the F2.2 file-node marker
+// the MCP find_usages rider reads: it sets the marker on the KindFile node and
+// clears it, and is a no-op when the marker is already in the desired state.
+func TestSetReparsePendingEnrichment_SetAndClear(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "a.go", Kind: graph.KindFile, Name: "a.go", FilePath: "a.go"})
+	idx := New(g, newTestRegistry(), config.IndexConfig{Workers: 1}, zap.NewNop())
+
+	fileMeta := func() map[string]any {
+		for _, n := range g.GetFileNodes("a.go") {
+			if n.Kind == graph.KindFile {
+				return n.Meta
+			}
+		}
+		t.Fatalf("file node a.go not found")
+		return nil
+	}
+
+	_, had := fileMeta()[graph.MetaReparsePendingEnrichment]
+	require.False(t, had, "marker absent on a freshly-added file node")
+
+	idx.setReparsePendingEnrichment("a.go", true)
+	_, had = fileMeta()[graph.MetaReparsePendingEnrichment]
+	assert.True(t, had, "marker must be set when the live re-parse skipped enrichment")
+
+	idx.setReparsePendingEnrichment("a.go", false)
+	_, had = fileMeta()[graph.MetaReparsePendingEnrichment]
+	assert.False(t, had, "marker must be cleared when enrichment re-ran")
+}

--- a/internal/indexer/incremental_resolve_test.go
+++ b/internal/indexer/incremental_resolve_test.go
@@ -104,6 +104,87 @@ func TestIncrementalReindex_PreservesIncomingCallerEdges(t *testing.T) {
 		"re-adding Foo must rebind Bar's pending caller edge via the reverse pass")
 }
 
+// TestIncrementalReindex_DoubleCycle_PreservesIncomingTier is the F3
+// regression: re-parsing a definition file twice (append then revert — the
+// exact staleness-probe sequence) must not ratchet an incoming caller edge's
+// tier down or leave it a stub. Before the fix the first cycle preserved the
+// caller edge but the second could collapse it; this asserts stability across
+// BOTH cycles.
+func TestIncrementalReindex_DoubleCycle_PreservesIncomingTier(t *testing.T) {
+	dir := t.TempDir()
+	aPath := filepath.Join(dir, "a.go")
+	bPath := filepath.Join(dir, "b.go")
+	writeFile(t, aPath, "package p\n\nfunc Foo() {}\n")
+	writeFile(t, bPath, "package p\n\nfunc Bar() { Foo() }\n")
+
+	g := graph.New()
+	idx := New(g, newTestRegistry(), config.IndexConfig{Workers: 1}, zap.NewNop())
+	idx.search = search.NewBM25()
+	idx.SetRootPath(dir)
+	_, err := idx.IndexCtx(testCtx(), dir)
+	require.NoError(t, err)
+
+	fooID := fnNodeID(t, g, "a.go", "Foo")
+	barID := fnNodeID(t, g, "b.go", "Bar")
+	require.Equal(t, fooID, callTargetFrom(t, g, barID))
+
+	// Stamp B's incoming call edge compiler-grade.
+	e := callEdgeFrom(t, g, barID)
+	g.SetEdgeProvenance(e, graph.OriginLSPResolved)
+	e.Tier = graph.ResolvedBy(graph.OriginLSPResolved)
+
+	cycles := []string{
+		"package p\n\nfunc Foo() {}\n\nfunc Extra() {}\n", // append
+		"package p\n\nfunc Foo() {}\n",                     // revert
+	}
+	for i, content := range cycles {
+		writeFile(t, aPath, content)
+		require.NoError(t, idx.IndexFile(aPath))
+		after := callEdgeFrom(t, g, fnNodeID(t, g, "b.go", "Bar"))
+		assert.Falsef(t, graph.IsUnresolvedTarget(after.To),
+			"cycle %d: Bar's caller edge must not remain a stub", i)
+		assert.Equalf(t, fnNodeID(t, g, "a.go", "Foo"), after.To,
+			"cycle %d: Bar's caller edge must still resolve to Foo", i)
+		assert.Equalf(t, graph.OriginLSPResolved, after.Origin,
+			"cycle %d: incoming edge must keep its lsp origin (no ratchet-down)", i)
+	}
+}
+
+// TestIncrementalReindex_DeletedDefinition_NoStaleTierOnStub locks F3's
+// provenance honesty: when a definition is genuinely deleted, the incoming
+// caller edge reverts to an unresolved stub and must NOT keep claiming the
+// compiler-grade tier it carried while bound — an unresolved stub advertising
+// lsp_resolved is a provenance lie.
+func TestIncrementalReindex_DeletedDefinition_NoStaleTierOnStub(t *testing.T) {
+	dir := t.TempDir()
+	aPath := filepath.Join(dir, "a.go")
+	bPath := filepath.Join(dir, "b.go")
+	writeFile(t, aPath, "package p\n\nfunc Foo() {}\n")
+	writeFile(t, bPath, "package p\n\nfunc Bar() { Foo() }\n")
+
+	g := graph.New()
+	idx := New(g, newTestRegistry(), config.IndexConfig{Workers: 1}, zap.NewNop())
+	idx.search = search.NewBM25()
+	idx.SetRootPath(dir)
+	_, err := idx.IndexCtx(testCtx(), dir)
+	require.NoError(t, err)
+
+	barID := fnNodeID(t, g, "b.go", "Bar")
+	e := callEdgeFrom(t, g, barID)
+	g.SetEdgeProvenance(e, graph.OriginLSPResolved)
+	e.Tier = graph.ResolvedBy(graph.OriginLSPResolved)
+
+	idx.EvictFile(aPath)
+
+	stub := callEdgeFrom(t, g, barID)
+	require.True(t, graph.IsUnresolvedTarget(stub.To),
+		"deleting Foo must leave Bar's call as an unresolved stub")
+	assert.NotEqual(t, graph.OriginLSPResolved, stub.Origin,
+		"an unresolved stub must not keep advertising a compiler-grade origin")
+	assert.Empty(t, stub.Tier,
+		"an unresolved stub must not keep a resolved tier")
+}
+
 // TestEvictFile_DropsEnrichmentSidecars proves the change-A eviction
 // cascade: deleting a file drops its nodes' churn/coverage/blame
 // sidecar rows, leaving no orphan enrichment.

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -3342,13 +3342,25 @@ func (idx *Indexer) indexFile(filePath string, resolve bool) error {
 			// LSP / compiler provider) instead of leaving the file's edges at
 			// their pre-enrichment tier until the next full reindex. Gated
 			// internally on Config.EnrichOnWatch; a no-op when disabled.
-			if idx.semanticMgr != nil && idx.semanticMgr.Enabled() && idx.semanticMgr.HasProviders() {
+			providersPresent := idx.semanticMgr != nil && idx.semanticMgr.Enabled() && idx.semanticMgr.HasProviders()
+			reEnriched := false
+			if providersPresent {
 				if _, err := idx.semanticMgr.EnrichFile(idx.graph, idx.rootPath, graphPath); err != nil {
 					idx.logger.Debug("indexer: incremental semantic enrichment failed",
 						zap.String("file", graphPath),
 						zap.Error(err))
+				} else {
+					reEnriched = idx.semanticMgr.EnrichesOnWatch()
 				}
 			}
+			// Record whether this live re-parse left the file below the
+			// enrichment tier: providers exist (so there IS an lsp/ast tier to
+			// fall short of) but the save did not re-run enrichment. When set,
+			// find_usages / get_callers flag their default text_matched
+			// suppression as re-verification-pending so a hidden-but-real usage
+			// is diagnosable rather than silently dropped. Cleared when
+			// enrichment did re-run for the file.
+			idx.setReparsePendingEnrichment(graphPath, providersPresent && !reEnriched)
 		}
 	}
 

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -3602,6 +3602,12 @@ func (idx *Indexer) restubIncomingRefs(graphPath string) {
 				continue // already a pending stub
 			}
 			oldTo := e.To
+			// Stash + clear the edge's resolved provenance before restubbing:
+			// an `unresolved::` stub must not keep advertising a resolved
+			// tier. The incoming-resolve pass restores it verbatim if the stub
+			// rebinds to the same target (idempotent re-parse); a deleted or
+			// moved target leaves the stub honestly unresolved.
+			graph.StashRestubProvenance(e)
 			e.To = stub
 			batch = append(batch, graph.EdgeReindex{Edge: e, OldTo: oldTo})
 		}

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -3532,6 +3532,40 @@ func (idx *Indexer) EvictFile(filePath string) (int, int) {
 	return idx.graph.EvictFile(graphPath)
 }
 
+// ReresolveFileScoped forces the scoped re-resolution + LSP re-verify a normal
+// IndexFile performs, WITHOUT re-parsing and WITHOUT the IsStale gate — used by
+// the watcher's shape-degradation self-heal, where the file's mtime is already
+// current (IndexFile just ran) yet its resolved edges came out degraded, so a
+// plain IncrementalReindexPaths would stale-gate it out. Re-runs only this
+// file's forward + incoming resolve and, when a watch-enabled provider is
+// wired, its incremental enrichment. O(file), no whole-graph pass. No-op when
+// the file has no nodes (evicted since it was enqueued).
+func (idx *Indexer) ReresolveFileScoped(filePath string) error {
+	absPath := filePath
+	if !filepath.IsAbs(absPath) {
+		absPath = filepath.Join(idx.rootPath, filePath)
+	}
+	graphPath := idx.prefixPath(idx.relKey(absPath))
+	if len(idx.graph.GetFileNodes(graphPath)) == 0 {
+		return nil // file gone / evicted; nothing to re-resolve
+	}
+	idx.resolver.ResolveFileAndIncoming(graphPath)
+	providersPresent := idx.semanticMgr != nil && idx.semanticMgr.Enabled() && idx.semanticMgr.HasProviders()
+	reEnriched := false
+	if providersPresent {
+		if _, err := idx.semanticMgr.EnrichFile(idx.graph, idx.rootPath, graphPath); err != nil {
+			idx.logger.Debug("indexer: forced scoped enrichment failed",
+				zap.String("file", graphPath), zap.Error(err))
+		} else {
+			reEnriched = idx.semanticMgr.EnrichesOnWatch()
+		}
+	}
+	// Keep the find_usages staleness marker consistent with the enrichment
+	// that actually ran during this forced re-resolve (mirrors indexFile).
+	idx.setReparsePendingEnrichment(graphPath, providersPresent && !reEnriched)
+	return nil
+}
+
 // restubIncomingRefs rewrites every resolved reference edge that points
 // INTO a symbol of graphPath from a surviving (other-file) source back
 // to an `unresolved::<Name>` stub, in place, BEFORE the file's nodes are

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -3218,8 +3218,18 @@ func (idx *Indexer) indexFile(filePath string, resolve bool) error {
 
 	// Reuse prior resolutions for edges whose source-side shape is unchanged
 	// (the common case on a small edit), so the resolver below only handles
-	// genuinely-new references instead of re-resolving the whole file.
-	if reused := applyResolvedOutEdges(idx.graph, result.Edges, reuseIdx); reused > 0 {
+	// genuinely-new references instead of re-resolving the whole file. The
+	// about-to-be-added node IDs let the reuse recover same-file targets that
+	// eviction removed and this AddBatch re-adds under identical IDs — without
+	// them a same-file call's resolution + tier is lost to a full re-resolve on
+	// every structural save.
+	newNodeIDs := make(map[string]struct{}, len(result.Nodes))
+	for _, n := range result.Nodes {
+		if n != nil {
+			newNodeIDs[n.ID] = struct{}{}
+		}
+	}
+	if reused := applyResolvedOutEdges(idx.graph, result.Edges, reuseIdx, newNodeIDs); reused > 0 {
 		idx.logger.Debug("indexer: reused prior resolutions",
 			zap.Int("edges", reused), zap.String("file", graphPath))
 	}

--- a/internal/indexer/regressions.go
+++ b/internal/indexer/regressions.go
@@ -1,0 +1,21 @@
+package indexer
+
+import "sync/atomic"
+
+// resolutionRegressions counts how many times a shape-degradation guard has
+// fired since process start: a live per-file patch or a warm reload that lost
+// a material share of a unit's resolved edges with no matching symbol removal.
+// It is the tamper-evidence signal a ratchet can no longer hide behind — the
+// guards self-heal (persist-side re-resolve; boot-side re-index) AND bump this
+// counter, so index_health surfaces that the daemon caught a regression rather
+// than silently serving a shrunken graph. Process-global because the two guards
+// live in different packages (indexer watcher, cmd/gortex boot) and the reader
+// (index_health) in a third.
+var resolutionRegressions atomic.Int64
+
+// RecordResolutionRegression bumps the process-global regression counter.
+func RecordResolutionRegression() { resolutionRegressions.Add(1) }
+
+// ResolutionRegressions returns the number of shape-degradation guard firings
+// since process start.
+func ResolutionRegressions() int64 { return resolutionRegressions.Load() }

--- a/internal/indexer/reresolve_guard_test.go
+++ b/internal/indexer/reresolve_guard_test.go
@@ -1,0 +1,74 @@
+package indexer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// TestCountResolvedFileEdges proves the resolved-edge count excludes stub
+// (`unresolved::`) targets — the signal countFileEdges cannot give, since an
+// edge demoted from a concrete target to a stub keeps the incident-edge total
+// identical.
+func TestCountResolvedFileEdges(t *testing.T) {
+	idx, _ := newToggleIndexer(t)
+	g := idx.graph
+	g.AddBatch([]*graph.Node{
+		{ID: "a.go", Kind: graph.KindFile, Name: "a.go", FilePath: "a.go"},
+		{ID: "a.go::Foo", Kind: graph.KindFunction, Name: "Foo", FilePath: "a.go"},
+	}, []*graph.Edge{
+		{From: "a.go::Foo", To: "b.go::Bar", Kind: graph.EdgeCalls, FilePath: "a.go"},
+		{From: "a.go::Foo", To: "unresolved::Baz", Kind: graph.EdgeCalls, FilePath: "a.go"},
+	})
+
+	w, err := NewWatcher(idx, config.WatchConfig{Enabled: true}, zap.NewNop())
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, w.countResolvedFileEdges(g.GetFileNodes("a.go")),
+		"only the resolved out-edge counts; the unresolved stub does not")
+}
+
+// TestGuardResolvedEdgeRegression covers the F4.1 shape-degradation guard: a
+// modify that kept its symbols but lost more than half its resolved edges
+// enqueues a forced scoped re-resolve and bumps the regression counter, while
+// below-floor / symbol-removal / modest-drop cases stay quiet.
+func TestGuardResolvedEdgeRegression(t *testing.T) {
+	idx, _ := newToggleIndexer(t)
+	w, err := NewWatcher(idx, config.WatchConfig{Enabled: true, DebounceMs: 10}, zap.NewNop())
+	require.NoError(t, err)
+
+	reresolved := make(chan map[string]struct{}, 4)
+	w.reconcileMu.Lock()
+	w.reresolveFn = func(files map[string]struct{}) { reresolved <- files }
+	w.reconcileMu.Unlock()
+
+	// Resolved edges more than halved, symbols intact, above the floor: fires.
+	before := ResolutionRegressions()
+	w.guardResolvedEdgeRegression("a.go", 5, 5, 10, 2)
+	select {
+	case files := <-reresolved:
+		_, ok := files["a.go"]
+		assert.True(t, ok, "the degraded file must be enqueued for a forced re-resolve")
+	case <-time.After(2 * time.Second):
+		t.Fatal("a resolved-edge collapse must enqueue a forced re-resolve")
+	}
+	assert.Equal(t, before+1, ResolutionRegressions(), "the regression counter must increment")
+
+	// None of the negatives may fire.
+	base := ResolutionRegressions()
+	w.guardResolvedEdgeRegression("below-floor.go", 5, 5, 3, 0) // resolvedBefore < floor
+	w.guardResolvedEdgeRegression("symbol-removed.go", 5, 3, 10, 2)
+	w.guardResolvedEdgeRegression("modest-drop.go", 5, 5, 10, 6) // dropped <= 50%
+	select {
+	case f := <-reresolved:
+		t.Fatalf("a non-regression must not enqueue a re-resolve, got %v", f)
+	case <-time.After(150 * time.Millisecond):
+	}
+	assert.Equal(t, base, ResolutionRegressions(), "non-regressions must not bump the counter")
+}

--- a/internal/indexer/watcher.go
+++ b/internal/indexer/watcher.go
@@ -51,20 +51,20 @@ type SymbolChangeCallback func(filePath string, oldSymbols, newSymbols []*graph.
 
 // Watcher keeps the knowledge graph in live sync with the filesystem.
 type Watcher struct {
-	indexer   *Indexer
-	fsw       fswatcher.Watcher
-	fsCancel  context.CancelFunc
-	config    config.WatchConfig
+	indexer  *Indexer
+	fsw      fswatcher.Watcher
+	fsCancel context.CancelFunc
+	config   config.WatchConfig
 	// degradedNoFsnotify is set when Start detected a slow mount (a WSL2
 	// 9p/drvfs Windows drive, an SMB share) and skipped the native fsnotify
 	// backend, relying on the adaptive poller + git hooks instead.
 	degradedNoFsnotify bool
 	excludes           *excludes.Matcher
-	events    chan GraphChangeEvent
-	history   []GraphChangeEvent
-	historyMu sync.Mutex
-	pending   map[string]*time.Timer
-	mu        sync.Mutex
+	events             chan GraphChangeEvent
+	history            []GraphChangeEvent
+	historyMu          sync.Mutex
+	pending            map[string]*time.Timer
+	mu                 sync.Mutex
 	// patchMu serialises per-path patchGraph invocations so the
 	// post-patch reach rebuild (which scans every Node.Meta) cannot
 	// race with another debounced patch's IndexFile / EvictFile /
@@ -133,6 +133,15 @@ type Watcher struct {
 	pendingScanDirs map[string]struct{}
 	dirScanActive   bool
 	scanFn          func(map[string]struct{})
+
+	// pendingReresolve coalesces files the shape-degradation guard flagged
+	// for a forced scoped re-resolve (see enqueueReresolve). reresolveActive
+	// guards a single in-flight drainer; reresolveFn is a test seam, nil in
+	// production (the real ReresolveFileScoped runs). All three are guarded
+	// by reconcileMu.
+	pendingReresolve map[string]struct{}
+	reresolveActive  bool
+	reresolveFn      func(map[string]struct{})
 }
 
 const maxHistory = 1000
@@ -996,6 +1005,7 @@ func (w *Watcher) patchGraph(path string, kind ChangeKind) {
 		// the net node delta is zero.
 		priorNodes := w.indexer.graph.GetFileNodes(relPath)
 		fileEdgesBefore := w.countFileEdges(priorNodes)
+		resolvedBefore := w.countResolvedFileEdges(priorNodes)
 		if err := w.indexer.IndexFile(path); err != nil {
 			w.logger.Warn("reindex file failed", zap.String("path", path), zap.Error(err))
 			return
@@ -1013,6 +1023,11 @@ func (w *Watcher) patchGraph(path string, kind ChangeKind) {
 		} else {
 			edgesRemoved = fileEdgesBefore - fileEdgesAfter
 		}
+		// Shape-degradation guard: a modify that kept its symbols but lost
+		// most of its resolved edges is a transient resolution failure, not a
+		// real deletion — flag it and enqueue a forced scoped re-resolve so it
+		// self-heals instead of persisting the degraded shape.
+		w.guardResolvedEdgeRegression(path, len(priorNodes), len(newSymbols), resolvedBefore, w.countResolvedFileEdges(newSymbols))
 
 		// Notify callback with old and new symbols.
 		w.symbolChangeCbMu.RLock()
@@ -1114,6 +1129,110 @@ func (w *Watcher) countFileEdges(nodes []*graph.Node) int {
 		}
 	}
 	return total
+}
+
+// resolvedEdgeRegressionFloor is the minimum pre-patch resolved-edge count
+// below which the shape-degradation guard stays quiet — a 1→0 or 3→1 file is
+// noise, not a resolution collapse worth self-healing.
+const resolvedEdgeRegressionFloor = 4
+
+// countResolvedFileEdges counts this file's OUTGOING edges whose target is a
+// concrete (resolved) node — an edge pointing at an `unresolved::` stub does
+// not count. Restricted to out-edges: an incoming edge's resolution state is
+// owned by the OTHER file, not this one. This is the signal countFileEdges
+// cannot give: an edge demoted from a resolved target to a stub keeps the total
+// incident-edge count identical while losing a resolution.
+func (w *Watcher) countResolvedFileEdges(nodes []*graph.Node) int {
+	if len(nodes) == 0 {
+		return 0
+	}
+	ids := make([]string, 0, len(nodes))
+	for _, n := range nodes {
+		ids = append(ids, n.ID)
+	}
+	total := 0
+	for _, edges := range w.indexer.graph.GetOutEdgesByNodeIDs(ids) {
+		for _, e := range edges {
+			if e != nil && !graph.IsUnresolvedTarget(e.To) {
+				total++
+			}
+		}
+	}
+	return total
+}
+
+// guardResolvedEdgeRegression fires when a modify patch KEPT (or grew) its
+// symbols but lost more than half its resolved out-edges — a transient
+// resolution failure (a dependency mid-write, an LSP provider not yet warm),
+// not a real deletion. It logs loudly, bumps the process-global regression
+// counter, and enqueues the file for a forced scoped re-resolve so the graph
+// self-heals instead of persisting the degraded shape.
+func (w *Watcher) guardResolvedEdgeRegression(path string, nodesBefore, nodesAfter, resolvedBefore, resolvedAfter int) {
+	if resolvedBefore < resolvedEdgeRegressionFloor {
+		return
+	}
+	if nodesAfter < nodesBefore {
+		return // symbols were removed — a real deletion, not a resolution loss
+	}
+	if resolvedAfter*2 >= resolvedBefore {
+		return // dropped <= 50%
+	}
+	RecordResolutionRegression()
+	if w.logger != nil {
+		w.logger.Warn("watcher: resolved-edge regression — file kept its symbols but lost most resolved edges; enqueuing forced scoped re-resolve",
+			zap.String("file", path),
+			zap.Int("nodes_before", nodesBefore),
+			zap.Int("nodes_after", nodesAfter),
+			zap.Int("resolved_edges_before", resolvedBefore),
+			zap.Int("resolved_edges_after", resolvedAfter))
+	}
+	w.enqueueReresolve(path)
+}
+
+// enqueueReresolve batches shape-degraded files for a forced scoped re-resolve.
+// Copies enqueueDirScan's coalescing drainer so a save-storm of degraded files
+// runs at most one drainer goroutine and only ever O(file) scoped re-resolves
+// (never a whole-graph pass). reresolveFn is a test seam.
+func (w *Watcher) enqueueReresolve(path string) {
+	w.reconcileMu.Lock()
+	if w.pendingReresolve == nil {
+		w.pendingReresolve = make(map[string]struct{})
+	}
+	w.pendingReresolve[path] = struct{}{}
+	if w.reresolveActive {
+		w.reconcileMu.Unlock()
+		return
+	}
+	w.reresolveActive = true
+	w.reconcileMu.Unlock()
+
+	go func() {
+		for {
+			w.reconcileMu.Lock()
+			files := w.pendingReresolve
+			w.pendingReresolve = nil
+			if len(files) == 0 {
+				w.reresolveActive = false
+				w.reconcileMu.Unlock()
+				return
+			}
+			fn := w.reresolveFn
+			w.reconcileMu.Unlock()
+			func() {
+				defer w.guardWatcherPanic("reresolve")
+				if fn != nil {
+					fn(files)
+					return
+				}
+				for p := range files {
+					if err := w.indexer.ReresolveFileScoped(p); err != nil && w.logger != nil {
+						w.logger.Warn("watcher: forced scoped re-resolve failed",
+							zap.String("file", p), zap.Error(err))
+					}
+				}
+			}()
+		}
+	}()
 }
 
 // recordInertModify finishes a ChangeModified patch that the

--- a/internal/mcp/find_usages_suppression_test.go
+++ b/internal/mcp/find_usages_suppression_test.go
@@ -1,0 +1,77 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/query"
+)
+
+// buildSuppressionGraph returns a graph where Target has one resolver-verified
+// (lsp_resolved) usage and two name-only (text_matched) usages — so the
+// adaptive default suppresses the two text_matched edges and reports
+// TextMatchedSuppressed == 2.
+func buildSuppressionGraph() graph.Store {
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "a.go", Kind: graph.KindFile, Name: "a.go", FilePath: "a.go", Language: "go"})
+	g.AddNode(&graph.Node{ID: "b.go", Kind: graph.KindFile, Name: "b.go", FilePath: "b.go", Language: "go"})
+	g.AddNode(&graph.Node{ID: "a.go::Target", Kind: graph.KindFunction, Name: "Target", FilePath: "a.go", Language: "go"})
+	g.AddNode(&graph.Node{ID: "a.go::Strong", Kind: graph.KindFunction, Name: "Strong", FilePath: "a.go", Language: "go"})
+	g.AddNode(&graph.Node{ID: "b.go::Weak1", Kind: graph.KindFunction, Name: "Weak1", FilePath: "b.go", Language: "go"})
+	g.AddNode(&graph.Node{ID: "b.go::Weak2", Kind: graph.KindFunction, Name: "Weak2", FilePath: "b.go", Language: "go"})
+
+	g.AddEdge(&graph.Edge{From: "a.go::Strong", To: "a.go::Target", Kind: graph.EdgeCalls, FilePath: "a.go", Line: 3, Origin: graph.OriginLSPResolved})
+	g.AddEdge(&graph.Edge{From: "b.go::Weak1", To: "a.go::Target", Kind: graph.EdgeCalls, FilePath: "b.go", Line: 5, Origin: graph.OriginTextMatched})
+	g.AddEdge(&graph.Edge{From: "b.go::Weak2", To: "a.go::Target", Kind: graph.EdgeCalls, FilePath: "b.go", Line: 7, Origin: graph.OriginTextMatched})
+	return g
+}
+
+func serverForGraph(t *testing.T, g graph.Store) *Server {
+	t.Helper()
+	return NewServer(query.NewEngine(g), g, nil, nil, zap.NewNop(), nil)
+}
+
+func findUsagesSubGraph(t *testing.T, srv *Server) query.SubGraph {
+	t.Helper()
+	result := callTool(t, srv, "find_usages", map[string]any{"id": "a.go::Target"})
+	require.False(t, result.IsError)
+	var resp query.SubGraph
+	require.NoError(t, json.Unmarshal([]byte(result.Content[0].(mcplib.TextContent).Text), &resp))
+	return resp
+}
+
+// TestFindUsages_SuppressionCaveat is the F2.2 regression: the diagnosable
+// rider fires only when text_matched edges were suppressed AND the target's
+// file is in the re-parsed-but-not-re-enriched window (the file node carries
+// graph.MetaReparsePendingEnrichment). On a converged graph the suppressed
+// count is still reported but no rider is attached.
+func TestFindUsages_SuppressionCaveat(t *testing.T) {
+	g := buildSuppressionGraph()
+
+	// Converged file (no pending-enrichment marker): suppression happens but
+	// the rider must stay absent so it can't cry wolf on a fresh graph.
+	fresh := findUsagesSubGraph(t, serverForGraph(t, g))
+	assert.Equal(t, 2, fresh.TextMatchedSuppressed, "two text_matched usages must be suppressed")
+	assert.Empty(t, fresh.SuppressionCaveat, "no rider on a converged (non-stale) file")
+
+	// Mark a.go re-parsed without re-enrichment, then re-query: the rider must
+	// appear and name the hidden count.
+	fn := g.GetNode("a.go")
+	if fn.Meta == nil {
+		fn.Meta = map[string]any{}
+	}
+	fn.Meta[graph.MetaReparsePendingEnrichment] = true
+	g.AddNode(fn)
+
+	stale := findUsagesSubGraph(t, serverForGraph(t, g))
+	assert.Equal(t, 2, stale.TextMatchedSuppressed, "suppressed count unchanged by the marker")
+	require.NotEmpty(t, stale.SuppressionCaveat, "rider must fire on a re-parsed-not-re-enriched file")
+	assert.Contains(t, stale.SuppressionCaveat, "2 candidate")
+	assert.Contains(t, stale.SuppressionCaveat, "min_tier")
+}

--- a/internal/mcp/gcx.go
+++ b/internal/mcp/gcx.go
@@ -394,6 +394,9 @@ func encodeFindUsages(sg *query.SubGraph, g graph.Store) ([]byte, error) {
 	if sg.TextMatchedSuppressed > 0 {
 		meta = append(meta, "text_matched_suppressed", fmt.Sprintf("%d", sg.TextMatchedSuppressed))
 	}
+	if sg.SuppressionCaveat != "" {
+		meta = append(meta, "suppression_caveat", sg.SuppressionCaveat)
+	}
 	enc := newGCX(&buf, "find_usages",
 		[]string{"from", "to", "edge_kind", "context", "return_usage", "origin", "tier", "confidence", "from_name", "from_path", "from_line", "from_is_test", "from_test_role", "from_test_runner", "from_type_flavor", "from_ui_component"},
 		meta...,
@@ -483,6 +486,9 @@ func encodeSubGraph(tool string, sg *query.SubGraph) ([]byte, error) {
 	edgeMeta = append(edgeMeta, zeroEdgeCaveatMeta(sg.Caveat)...)
 	if sg.TextMatchedSuppressed > 0 {
 		edgeMeta = append(edgeMeta, "text_matched_suppressed", fmt.Sprintf("%d", sg.TextMatchedSuppressed))
+	}
+	if sg.SuppressionCaveat != "" {
+		edgeMeta = append(edgeMeta, "suppression_caveat", sg.SuppressionCaveat)
 	}
 	edgeEnc := newGCX(&buf, tool+".edges",
 		// line + file_path on the edge let the caller distinguish two

--- a/internal/mcp/index_health_regressions_test.go
+++ b/internal/mcp/index_health_regressions_test.go
@@ -1,0 +1,27 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/indexer"
+)
+
+// TestIndexHealth_SurfacesResolutionRegressions proves the shape-degradation
+// guard counter is visible in index_health — so a ratchet the guards caught (and
+// self-healed) can never again hide behind an otherwise all-green health report.
+func TestIndexHealth_SurfacesResolutionRegressions(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	payload := srv.buildIndexHealthPayload()
+	require.NotNil(t, payload)
+	before, ok := payload["resolution_regressions"].(int64)
+	require.True(t, ok, "index_health must carry the resolution_regressions counter")
+
+	indexer.RecordResolutionRegression()
+
+	after, _ := srv.buildIndexHealthPayload()["resolution_regressions"].(int64)
+	assert.Equal(t, before+1, after, "a recorded regression must surface in index_health")
+}

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -32,7 +32,9 @@ const minTierParamDescription = "Filter edges by minimum confidence tier. " +
 	"text_matched (name-only). When omitted, text_matched edges are " +
 	"auto-suppressed whenever resolver-verified evidence exists — the " +
 	"response then carries text_matched_suppressed with the hidden count; " +
-	"pass min_tier:\"text_matched\" to include them. " +
+	"pass min_tier:\"text_matched\" to include them. If the target's file was " +
+	"re-parsed after the last enrichment pass, the response also carries " +
+	"suppression_caveat warning the hidden rows may be real. " +
 	"Use lsp_resolved for high-stakes refactors where false positives are expensive."
 
 const includeSpeculativeParamDescription = "Include best-guess speculative " +
@@ -108,12 +110,14 @@ type toonCallerNoteRow struct {
 
 // toonSubGraphResult wraps nodes and edges for TOON tabular output.
 type toonSubGraphResult struct {
-	Nodes       []toonNodeRow         `toon:"nodes"`
-	Edges       []toonEdgeRow         `toon:"edges"`
-	Total       int                   `toon:"total"`
-	Truncated   bool                  `toon:"truncated"`
-	Caveat      *graph.ZeroEdgeCaveat `toon:"caveat,omitempty"`
-	CallerNotes []toonCallerNoteRow   `toon:"caller_notes,omitempty"`
+	Nodes                 []toonNodeRow         `toon:"nodes"`
+	Edges                 []toonEdgeRow         `toon:"edges"`
+	Total                 int                   `toon:"total"`
+	Truncated             bool                  `toon:"truncated"`
+	Caveat                *graph.ZeroEdgeCaveat `toon:"caveat,omitempty"`
+	TextMatchedSuppressed int                   `toon:"text_matched_suppressed,omitempty"`
+	SuppressionCaveat     string                `toon:"suppression_caveat,omitempty"`
+	CallerNotes           []toonCallerNoteRow   `toon:"caller_notes,omitempty"`
 }
 
 // toonSearchResult wraps search results for TOON tabular output.
@@ -330,12 +334,14 @@ func subGraphToTOON(sg *query.SubGraph) (*mcp.CallToolResult, error) {
 		})
 	}
 	result := toonSubGraphResult{
-		Nodes:       nodesToTOONRows(sg.Nodes),
-		Edges:       edgeRows,
-		Total:       sg.TotalNodes,
-		Truncated:   sg.Truncated,
-		Caveat:      sg.Caveat,
-		CallerNotes: callerNotesToTOONRows(sg.CallerNotes),
+		Nodes:                 nodesToTOONRows(sg.Nodes),
+		Edges:                 edgeRows,
+		Total:                 sg.TotalNodes,
+		Truncated:             sg.Truncated,
+		Caveat:                sg.Caveat,
+		TextMatchedSuppressed: sg.TextMatchedSuppressed,
+		SuppressionCaveat:     sg.SuppressionCaveat,
+		CallerNotes:           callerNotesToTOONRows(sg.CallerNotes),
 	}
 	data, err := toon.Marshal(result)
 	if err != nil {
@@ -2244,6 +2250,7 @@ func (s *Server) handleGetCallers(ctx context.Context, req mcp.CallToolRequest) 
 		// Same adaptive default as find_usages: hide the name-only
 		// fan-out once resolver-verified callers exist.
 		sg.SuppressRedundantTextMatches()
+		s.attachSuppressionCaveat(sg, id)
 	}
 	enrichSubGraphEdges(sg)
 	annotateCallerConcurrency(eng.Reader(), sg, id)
@@ -2463,6 +2470,7 @@ func (s *Server) handleFindUsages(ctx context.Context, req mcp.CallToolRequest) 
 		// text_matched fan-out is noise — suppress it and report the count
 		// via text_matched_suppressed. min_tier:"text_matched" restores it.
 		sg.SuppressRedundantTextMatches()
+		s.attachSuppressionCaveat(sg, id)
 	}
 	enrichSubGraphEdges(sg)
 	// Classify each usage's reference context (parameter_type / return_type
@@ -2520,6 +2528,48 @@ type usageNode struct {
 type usageResponse struct {
 	*query.SubGraph
 	Nodes []usageNode `json:"nodes"`
+}
+
+// attachSuppressionCaveat adds a human-readable rider to sg when the adaptive
+// default hid text_matched edges AND the target's file is in the
+// re-parsed-but-not-re-enriched window (see suppressionMayBeStale) — so a
+// hidden-but-real usage is diagnosable instead of silently dropped. No-op when
+// nothing was suppressed or the file is not stale; the existing
+// text_matched_suppressed count carries the number in every response either way.
+func (s *Server) attachSuppressionCaveat(sg *query.SubGraph, id string) {
+	if sg == nil || sg.TextMatchedSuppressed == 0 {
+		return
+	}
+	if !s.suppressionMayBeStale(id) {
+		return
+	}
+	sg.SuppressionCaveat = fmt.Sprintf(
+		"%d candidate usage(s) hidden pending re-verification; "+
+			"pass min_tier:\"text_matched\" to see them",
+		sg.TextMatchedSuppressed)
+}
+
+// suppressionMayBeStale reports whether id's file was re-parsed on the live
+// watch path without re-running semantic enrichment — the window in which the
+// resolver-verified edges that triggered text_matched suppression may sit
+// below the enrichment tier, so the suppressed name-only usages could be the
+// real ones. Reads graph.MetaReparsePendingEnrichment, which the indexer
+// stamps on the file's KindFile node. Conservative: false whenever the marker
+// is absent (no rider rather than a false alarm on a converged graph).
+func (s *Server) suppressionMayBeStale(id string) bool {
+	n := s.graph.GetNode(id)
+	if n == nil || n.FilePath == "" {
+		return false
+	}
+	for _, fn := range s.graph.GetFileNodes(n.FilePath) {
+		if fn.Kind != graph.KindFile {
+			continue
+		}
+		v, ok := fn.Meta[graph.MetaReparsePendingEnrichment]
+		b, _ := v.(bool)
+		return ok && b
+	}
+	return false
 }
 
 // newUsageResponse resolves the from_* fields for each node (pure read

--- a/internal/mcp/tools_enhancements.go
+++ b/internal/mcp/tools_enhancements.go
@@ -3079,6 +3079,10 @@ func (s *Server) buildIndexHealthPayload() map[string]any {
 		"edge_count":           stats.TotalEdges,
 		"edges_ok":             edgesOK,
 		"nodes_per_file":       nodesPerFile,
+		// Shape-degradation guard firings since process start. Nonzero means
+		// the daemon caught (and self-healed) a live-patch or boot-reload
+		// resolution regression rather than silently serving a shrunken graph.
+		"resolution_regressions": indexer.ResolutionRegressions(),
 	}
 	if indexedFileCount > 0 {
 		result["indexed_file_count"] = indexedFileCount

--- a/internal/query/subgraph.go
+++ b/internal/query/subgraph.go
@@ -22,6 +22,16 @@ type SubGraph struct {
 	// Zero — and omitted — when nothing was suppressed. Re-run with
 	// min_tier:"text_matched" to include the hidden rows.
 	TextMatchedSuppressed int `json:"text_matched_suppressed,omitempty"`
+	// SuppressionCaveat is attached by the adaptive text_matched default
+	// (find_usages / get_callers) when TextMatchedSuppressed > 0 AND the
+	// target's file was re-parsed on the live watch path without re-running
+	// semantic enrichment — so the resolver-verified edges that triggered
+	// suppression may be below the tier the enrichment pass would mint, and
+	// the hidden name-only usages could be the real ones. Empty (omitted)
+	// otherwise. Independent of Caveat, which only fires for a zero-edge
+	// result — and since suppression only runs when a stronger edge exists,
+	// the two never coexist.
+	SuppressionCaveat string `json:"suppression_caveat,omitempty"`
 	// Caveat is attached only when an edge-returning query (find_usages,
 	// get_callers) comes back with no edges, classifying whether the
 	// empty result reflects genuinely unused code or an extraction gap.

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -1190,6 +1190,13 @@ func (r *Resolver) resolveIncomingLocked(filePath string, stats *ResolveStats) {
 				continue
 			}
 			oldTo, changed := r.resolveEdge(e, stats)
+			// Restore the provenance the restub stashed when the stub rebound
+			// to the same target it had before the re-parse (unchanged binding
+			// keeps its verified tier); always drops the transient stash keys,
+			// so a rebind elsewhere / a still-unresolved stub carries only the
+			// honest tier the resolver just assigned. Runs before the job is
+			// captured so the cross-package guard below sees the real origin.
+			graph.RestoreRestubProvenance(e)
 			if changed {
 				reindexBatch = append(reindexBatch, graph.EdgeReindex{Edge: e, OldTo: oldTo})
 				jobs = append(jobs, reindexJob{

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -1760,13 +1760,34 @@ func (r *Resolver) resolveFunctionCall(e *graph.Edge, funcName string, stats *Re
 	// caller's own helper should receive — zustand's persistSync tests
 	// bound to persistAsync's `createStore` helper purely by candidate
 	// iteration order.
+	var sameFile *graph.Node
+	sameFileCount := 0
 	for _, c := range candidates {
 		if (c.Kind == graph.KindFunction || c.Kind == graph.KindMethod) &&
 			c.FilePath != "" && c.FilePath == e.FilePath {
-			e.To = c.ID
-			stats.Resolved++
-			return
+			if sameFile == nil {
+				sameFile = c
+			}
+			sameFileCount++
 		}
+	}
+	if sameFile != nil {
+		e.To = sameFile.ID
+		// A bare-name call to the sole same-file definition is structurally
+		// unambiguous — grammar-grounded, no type system needed — so stamp it
+		// ast_resolved rather than leaving it to backfill to the name-only
+		// tier that find_usages suppresses by default. This is what keeps a
+		// freshly-added same-file call site (the common edit) visible instead
+		// of silently hidden. Two same-name same-file definitions (a func and
+		// a method sharing a name) stay untagged so suppression can still drop
+		// the ambiguous pick. Only genuine call edges are promoted; bare-value
+		// reads (cobra RunE wire-ups) keep the heuristic tier.
+		if sameFileCount == 1 && e.Kind == graph.EdgeCalls && e.Origin == "" {
+			e.Origin = graph.OriginASTResolved
+			e.Confidence = 0.9
+		}
+		stats.Resolved++
+		return
 	}
 
 	// Import-evidence disambiguation (JS/TS only; see import_evidence.go
@@ -1792,15 +1813,34 @@ func (r *Resolver) resolveFunctionCall(e *graph.Edge, funcName string, stats *Re
 		return
 	}
 
-	// Prefer same-package (same directory) match.
+	// Prefer same-package (same directory) match. When exactly one
+	// same-package function/method carries this name, a bare-name call to the
+	// sole same-package definition is structurally unambiguous, so stamp it
+	// ast_resolved (same rationale as the same-file pick above). Multiple
+	// same-name same-package candidates stay untagged so redundant-text
+	// suppression can still drop them. Method-name fan-out (x.Get()) never
+	// reaches here — it resolves in resolveMethodCall and stays text_matched,
+	// preserving that precision guard.
 	callerDir := r.dirFor(e.FilePath)
+	var samePkg *graph.Node
+	samePkgCount := 0
 	for _, c := range candidates {
 		if (c.Kind == graph.KindFunction || c.Kind == graph.KindMethod) &&
 			r.dirFor(c.FilePath) == callerDir {
-			e.To = c.ID
-			stats.Resolved++
-			return
+			if samePkg == nil {
+				samePkg = c
+			}
+			samePkgCount++
 		}
+	}
+	if samePkg != nil {
+		e.To = samePkg.ID
+		if samePkgCount == 1 && e.Kind == graph.EdgeCalls && e.Origin == "" {
+			e.Origin = graph.OriginASTResolved
+			e.Confidence = 0.9
+		}
+		stats.Resolved++
+		return
 	}
 
 	// Fall back to the first same-repo function/method match.

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -24,6 +24,52 @@ func TestResolveAll_InternalCall(t *testing.T) {
 
 	assert.Equal(t, 1, stats.Resolved)
 	assert.Equal(t, "pkg/b.go::Bar", callEdge.To)
+	// A unique same-package bare-name call is structurally unambiguous, so it
+	// is stamped ast_resolved — not left to backfill to the name-only tier
+	// that find_usages suppresses by default.
+	assert.Equal(t, graph.OriginASTResolved, callEdge.Origin,
+		"a unique same-package bare-name call must be ast_resolved, not text_matched")
+}
+
+// TestResolveFunctionCall_UniqueBareCallTier is the F2.1 regression: a
+// bare-name call to the sole same-file or same-package definition is
+// grammar-grounded and structurally unambiguous, so it must be stamped
+// ast_resolved (above the name-only tier find_usages suppresses by default).
+// Ambiguous picks and non-call edges stay untagged so suppression can still
+// drop them.
+func TestResolveFunctionCall_UniqueBareCallTier(t *testing.T) {
+	t.Run("same-file unique call is ast_resolved", func(t *testing.T) {
+		g := graph.New()
+		g.AddNode(&graph.Node{ID: "pkg/a.go", Kind: graph.KindFile, Name: "a.go", FilePath: "pkg/a.go", Language: "go"})
+		g.AddNode(&graph.Node{ID: "pkg/a.go::Foo", Kind: graph.KindFunction, Name: "Foo", FilePath: "pkg/a.go", Language: "go"})
+		g.AddNode(&graph.Node{ID: "pkg/a.go::Baz", Kind: graph.KindFunction, Name: "Baz", FilePath: "pkg/a.go", Language: "go"})
+		e := &graph.Edge{From: "pkg/a.go::Baz", To: "unresolved::Foo", Kind: graph.EdgeCalls, FilePath: "pkg/a.go", Line: 3}
+		g.AddEdge(e)
+
+		New(g).ResolveAll()
+
+		assert.Equal(t, "pkg/a.go::Foo", e.To, "same-file call must resolve to Foo")
+		assert.Equal(t, graph.OriginASTResolved, e.Origin, "unique same-file call must be ast_resolved")
+	})
+
+	t.Run("ambiguous same-package pick stays untagged", func(t *testing.T) {
+		g := graph.New()
+		g.AddNode(&graph.Node{ID: "pkg/a.go", Kind: graph.KindFile, Name: "a.go", FilePath: "pkg/a.go", Language: "go"})
+		g.AddNode(&graph.Node{ID: "pkg/b.go", Kind: graph.KindFile, Name: "b.go", FilePath: "pkg/b.go", Language: "go"})
+		g.AddNode(&graph.Node{ID: "pkg/c.go", Kind: graph.KindFile, Name: "c.go", FilePath: "pkg/c.go", Language: "go"})
+		// Two same-package definitions carry the name Foo (a function and a
+		// method) — enough to make the bare-name pick ambiguous.
+		g.AddNode(&graph.Node{ID: "pkg/a.go::Foo", Kind: graph.KindFunction, Name: "Foo", FilePath: "pkg/a.go", Language: "go"})
+		g.AddNode(&graph.Node{ID: "pkg/b.go::T.Foo", Kind: graph.KindMethod, Name: "Foo", FilePath: "pkg/b.go", Language: "go"})
+		g.AddNode(&graph.Node{ID: "pkg/c.go::Caller", Kind: graph.KindFunction, Name: "Caller", FilePath: "pkg/c.go", Language: "go"})
+		e := &graph.Edge{From: "pkg/c.go::Caller", To: "unresolved::Foo", Kind: graph.EdgeCalls, FilePath: "pkg/c.go", Line: 3}
+		g.AddEdge(e)
+
+		New(g).ResolveAll()
+
+		assert.Equal(t, "", e.Origin,
+			"an ambiguous same-package pick must stay untagged so suppression can drop it")
+	})
 }
 
 func TestResolveAll_ExternalImport(t *testing.T) {

--- a/internal/semantic/manager.go
+++ b/internal/semantic/manager.go
@@ -865,6 +865,16 @@ func (m *Manager) HasProviders() bool {
 	return false
 }
 
+// EnrichesOnWatch reports whether a single-file watch save re-runs semantic
+// enrichment for the saved file (EnrichFile is a no-op otherwise). When this
+// is false but providers exist, a live re-parse leaves the file's edges at
+// their pre-enrichment tier until the next full enrichment — the window the
+// indexer records so find_usages can flag suppressed usages as re-verification
+// pending.
+func (m *Manager) EnrichesOnWatch() bool {
+	return m.config.Enabled && m.config.EnrichOnWatch
+}
+
 // AllProviders returns the unfiltered list of registered providers.
 // Used by the daemon's LSP-action surface to find the right LSP
 // provider for a file (call sites need the *lsp.Provider concrete


### PR DESCRIPTION
## Live-reindex resolution fidelity

Fixes the family of bugs where, after a source file changes on disk (editor save, `git checkout`), the daemon's answer to `find_usages` on symbols defined or called in that file degrades and never recovers — a one-way ratchet that survives restarts and is healed only by an `edit_file` cycle or a fresh `track`.

Four interacting mechanisms; none individually wrong, their composition was. Landed as one commit each.

### 1. Preserve resolved edge tiers across a same-file re-parse
A structural save evicts the file's nodes before the incremental-reuse pass runs, so a call whose target lives in the *same* file couldn't find its target in the graph and fell through to a full re-resolve — which rebound the target correctly but dropped the edge's origin/tier to the resolver's heuristic default. `find_usages` suppresses that tier by default, so same-file call sites silently vanished after every edit. The reuse pass now accepts a target that eviction removed and `AddBatch` is about to re-add under an identical ID (node IDs are `file::Name`, line-independent), reusing its prior resolution and provenance instead of demoting it.

### 2. Stop hiding grammar-grounded same-package calls; flag stale suppression
A bare-name call to the sole same-file or same-package function was left untagged and backfilled to the name-only tier `find_usages` suppresses — so a freshly-added call site never appeared. It now binds at `ast_resolved` (structurally unambiguous). Multiple same-name candidates and method-name fan-out (`x.Get()`) stay `text_matched`, preserving the precision guard. Additionally, when the target's file was re-parsed on the live watch path without re-running semantic enrichment, `find_usages` / `get_callers` attach a `suppression_caveat` telling the caller the hidden usages may be real — so a suppressed-but-real edge is diagnosable, not silently dropped. The rider rides the JSON, GCX, and TOON encoders (which also gain the previously-dropped `text_matched_suppressed` count).

### 3. Make the evict→restub→re-resolve cycle idempotent
Restubbing an incoming reference kept the edge's resolved provenance, so a genuinely deleted definition left the stub advertising a compiler-grade tier it no longer earned, and a rebind to a different target inherited a tier it never had. The provenance is now stashed and cleared on restub, and restored verbatim by the incoming-resolve pass only when the stub rebinds to the exact same target (an idempotent re-parse keeps its verified tier). A double re-parse (append then revert) round-trips an incoming edge's tier; a deleted definition leaves an honestly-unresolved stub.

### 4. Refuse to silently persist or serve a shape-degraded graph
Two guards plus a health surface so a regression can never again ratchet down invisibly:
- **Persist-side:** after a live modify patch, a drop past half of a file's resolved out-edges with no symbol removal logs loudly, bumps a process-global regression counter, and enqueues the file for a forced scoped re-resolve (a coalesced, storm-safe drainer that only ever runs O(file) work) so the graph self-heals.
- **Boot-side:** per-repo node/edge counts are recorded in the snapshot; on a warm reload a repo whose live graph is materially short of what the snapshot recorded is re-run through the global resolve pass instead of served shrunken.
- Both increment `resolution_regressions`, now surfaced in `index_health`.

## Tests
- indexer: same-file lsp-stamped edge preserved across an EOF-append reindex; double-cycle (append/revert) incoming-tier stability; deleted-definition leaves no stale tier on the stub; resolved-edge-regression guard fires (and stays quiet below floor / on symbol removal / on a modest drop); pending-enrichment marker set/clear.
- resolver: a unique same-file / same-package bare-name call binds `ast_resolved`; an ambiguous same-package pick stays untagged.
- mcp: `find_usages` attaches `suppression_caveat` only on a re-parsed-not-re-enriched file; `index_health` surfaces `resolution_regressions`.
- daemon: per-repo snapshot node/edge counts round-trip; boot shape-shortfall helper (collapse trips, modest shrink / zero-baseline / unknown-prefix do not); wire-contract golden updated for the additive `snapshotRepo` fields.

All touched-package suites pass (`go test ./internal/graph/ ./internal/semantic/ ./internal/indexer/ ./internal/resolver/ ./internal/query/ ./internal/mcp/ ./cmd/gortex/`); full tree builds; the concurrency-adjacent indexer/resolver/graph paths pass under `-race`.

**Acceptance gate (external):** run `make staleness` in `gortex-bench` (and `make phase0` as the precision dual-gate) against a fresh `gin` track — the end-to-end probe this change is measured by.
