### PR TITLE
PHP usages recall: references-driven enrichment + dispatch resolution

### DIFF
--- a/internal/graph/call_sites.go
+++ b/internal/graph/call_sites.go
@@ -1,0 +1,85 @@
+package graph
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Edge call-site multiplicity.
+//
+// The graph natively keys edges by (From, To, Kind, FilePath, Line), so an AST
+// extractor that emits one edge per call site preserves in-file multiplicity
+// on its own. A *synthesized* producer that can only mint one edge per
+// (From, To) — e.g. the LSP references-add pass, which sees N reference sites
+// for one declaration — would otherwise collapse those N sites to one. Rather
+// than mint N near-identical edges, such a producer keeps one edge (its
+// primary site in FilePath/Line) and records the additional sites in
+// Meta["call_sites"]; find_usages expands them back into one row per site.
+//
+// Meta-only: no Edge struct field is added, so no wire-contract / GCX encoder
+// churn. Edge.Meta round-trips through the store, so the sites survive a warm
+// restart on the sqlite backend (via AddBatch / PersistEdge).
+
+// AppendCallSite records an additional call/reference site on an edge whose
+// primary site stays in FilePath/Line. Extra sites are stored in
+// Meta["call_sites"] as sorted, deduped "<file>:<line>" strings; the primary
+// site is never duplicated there.
+func AppendCallSite(e *Edge, filePath string, line int) {
+	if e == nil || filePath == "" || line <= 0 {
+		return
+	}
+	if filePath == e.FilePath && line == e.Line {
+		return // the primary site lives in FilePath/Line, not call_sites
+	}
+	site := filePath + ":" + strconv.Itoa(line)
+	sites := CallSites(e)
+	for _, s := range sites {
+		if s == site {
+			return
+		}
+	}
+	sites = append(sites, site)
+	sort.Strings(sites)
+	if e.Meta == nil {
+		e.Meta = map[string]any{}
+	}
+	e.Meta["call_sites"] = sites
+}
+
+// CallSites returns the extra "<file>:<line>" sites recorded on an edge,
+// tolerating both the in-memory []string form and the []any form a JSON meta
+// round-trip (disk backend) produces.
+func CallSites(e *Edge) []string {
+	if e == nil || e.Meta == nil {
+		return nil
+	}
+	switch v := e.Meta["call_sites"].(type) {
+	case []string:
+		return v
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, x := range v {
+			if s, ok := x.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+// SplitCallSite splits a "<file>:<line>" call-site string into its file and
+// 1-based line, returning ("", 0) when malformed. It splits on the last colon
+// so a path that itself contains a colon is handled.
+func SplitCallSite(site string) (string, int) {
+	i := strings.LastIndexByte(site, ':')
+	if i <= 0 || i == len(site)-1 {
+		return "", 0
+	}
+	line, err := strconv.Atoi(site[i+1:])
+	if err != nil || line <= 0 {
+		return "", 0
+	}
+	return site[:i], line
+}

--- a/internal/graph/call_sites_test.go
+++ b/internal/graph/call_sites_test.go
@@ -1,0 +1,45 @@
+package graph
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAppendCallSite(t *testing.T) {
+	e := &Edge{From: "a", To: "b", Kind: EdgeCalls, FilePath: "f.go", Line: 12}
+
+	// The primary site is never duplicated into call_sites.
+	AppendCallSite(e, "f.go", 12)
+	assert.Empty(t, CallSites(e))
+
+	// Extra sites accumulate, sorted and deduped.
+	AppendCallSite(e, "f.go", 20)
+	AppendCallSite(e, "f.go", 14)
+	AppendCallSite(e, "f.go", 20) // duplicate — ignored
+	assert.Equal(t, []string{"f.go:14", "f.go:20"}, CallSites(e))
+
+	// Malformed inputs are ignored.
+	AppendCallSite(e, "", 5)
+	AppendCallSite(e, "g.go", 0)
+	AppendCallSite(nil, "g.go", 5)
+	assert.Equal(t, []string{"f.go:14", "f.go:20"}, CallSites(e))
+}
+
+func TestCallSites_JSONRoundTripForm(t *testing.T) {
+	// A meta round-trip through JSON (disk backend) yields []any, not []string.
+	e := &Edge{Meta: map[string]any{"call_sites": []any{"f.go:3", "f.go:9"}}}
+	assert.Equal(t, []string{"f.go:3", "f.go:9"}, CallSites(e))
+}
+
+func TestSplitCallSite(t *testing.T) {
+	f, l := SplitCallSite("dir/f.go:42")
+	assert.Equal(t, "dir/f.go", f)
+	assert.Equal(t, 42, l)
+
+	for _, bad := range []string{"bad", "f.go:", ":42", "f.go:abc", "f.go:0"} {
+		f, l := SplitCallSite(bad)
+		assert.Equal(t, "", f, "malformed %q", bad)
+		assert.Equal(t, 0, l, "malformed %q", bad)
+	}
+}

--- a/internal/graph/extraction_gap.go
+++ b/internal/graph/extraction_gap.go
@@ -55,6 +55,23 @@ type ZeroImpactCaveat struct {
 	Message string        `json:"message" toon:"message"`
 }
 
+// TierFilteredClass is the machine-checkable class of a min_tier-emptied
+// result — distinct from ZeroEdgeClass so a safety gate never confuses
+// "filtered out by min_tier" with "genuinely has no usages".
+const TierFilteredClass = "tier_filtered"
+
+// TierFilteredCaveat is attached to a find_usages / get_* result whose edge
+// list was emptied (or thinned) by a min_tier filter while lower-tier edges
+// still exist. Without it a min_tier that filters every edge is
+// indistinguishable from "no usages" — the honesty bug it fixes. Class is
+// always TierFilteredClass; EdgesBelowMinTier counts the edges dropped by the
+// filter and MaxAvailableTier names the best tier actually present.
+type TierFilteredCaveat struct {
+	Class            string `json:"class" toon:"class"`
+	EdgesBelowMinTier int   `json:"edges_below_min_tier" toon:"edges_below_min_tier"`
+	MaxAvailableTier string `json:"max_available_tier" toon:"max_available_tier"`
+}
+
 // usageEdgeKinds are the incoming edge kinds that count as a symbol
 // being "used" — calls, references, and the type/instantiation edges
 // that find_usages itself treats as usages. An incoming edge of any of

--- a/internal/mcp/gcx.go
+++ b/internal/mcp/gcx.go
@@ -384,6 +384,19 @@ func zeroEdgeCaveatMeta(c *graph.ZeroEdgeCaveat) []string {
 	return []string{"caveat", string(c.Class), "caveat_message", c.Message}
 }
 
+// tierFilteredCaveatMeta lowers a min_tier-filtered caveat into GCX meta so a
+// tier-emptied result reads as "filtered", not "no usages".
+func tierFilteredCaveatMeta(c *graph.TierFilteredCaveat) []string {
+	if c == nil {
+		return nil
+	}
+	return []string{
+		"tier_filtered", c.Class,
+		"edges_below_min_tier", fmt.Sprintf("%d", c.EdgesBelowMinTier),
+		"max_available_tier", c.MaxAvailableTier,
+	}
+}
+
 // encodeFindUsages emits one row per usage edge. Each row names the
 // caller symbol, its location, the edge kind, and the origin tier so
 // agents can filter without a second call.
@@ -391,6 +404,7 @@ func encodeFindUsages(sg *query.SubGraph, g graph.Store) ([]byte, error) {
 	var buf bytes.Buffer
 	meta := []string{"edges", fmt.Sprintf("%d", len(sg.Edges))}
 	meta = append(meta, zeroEdgeCaveatMeta(sg.Caveat)...)
+	meta = append(meta, tierFilteredCaveatMeta(sg.TierFiltered)...)
 	if sg.TextMatchedSuppressed > 0 {
 		meta = append(meta, "text_matched_suppressed", fmt.Sprintf("%d", sg.TextMatchedSuppressed))
 	}

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -2486,7 +2486,10 @@ func (s *Server) handleFindUsages(ctx context.Context, req mcp.CallToolRequest) 
 	// FROM node's own ui_component for `component`). Orphan nodes left
 	// with no incident edge are pruned.
 	s.filterUsagesByFlavor(sg, id, strings.TrimSpace(req.GetString("flavor", "")))
-	if len(sg.Edges) == 0 {
+	if len(sg.Edges) == 0 && sg.TierFiltered == nil {
+		// A tier_filtered emptiness is not "no usages" — FilterByMinTier
+		// already recorded why. Only reach for the extraction-gap / unused
+		// classification when the emptiness was NOT caused by min_tier.
 		sg.Caveat = graph.CaveatForZeroEdge(s.graph, id)
 	}
 	// group_by:"file" buckets the usages by the file each reference

--- a/internal/mcp/tools_enhancements.go
+++ b/internal/mcp/tools_enhancements.go
@@ -3102,6 +3102,21 @@ func (s *Server) buildIndexHealthPayload() map[string]any {
 	if len(enrichStatuses) > 0 {
 		result["semantic_enrichment"] = enrichStatuses
 		result["semantic_enrichment_ok"] = !enrichmentIncomplete
+		// Per-language lsp-tier edge rollup from the enrichment statuses — a
+		// cheap, graph-pass-free signal for whether min_tier=lsp_resolved is
+		// usable on a given language. Near-zero for a language means
+		// tier-filtered queries will under-report (the find_usages
+		// tier_filtered caveat explains it per query; this shows it up front).
+		lspEdgesByLang := map[string]int{}
+		for _, st := range enrichStatuses {
+			if st.Language == "" {
+				continue
+			}
+			lspEdgesByLang[st.Language] += st.EdgesAdded + st.EdgesConfirmed
+		}
+		if len(lspEdgesByLang) > 0 {
+			result["lsp_resolved_edges_by_language"] = lspEdgesByLang
+		}
 	}
 	if recommendation != "" {
 		result["recommendation"] = recommendation

--- a/internal/parser/languages/csharp_test.go
+++ b/internal/parser/languages/csharp_test.go
@@ -10,6 +10,38 @@ import (
 	"github.com/zzet/gortex/internal/parser"
 )
 
+// Regression: a bodyless interface-method signature must mint a
+// <file>::<Iface>.<name> KindMethod node (marked iface_member) so its id
+// resolves and dispatch calls bind to it — parity with PHP's extractMethod.
+func TestCSharpExtractor_BodylessInterfaceMethodNode(t *testing.T) {
+	src := []byte(`namespace App {
+    public interface ISink {
+        void Write(string msg);
+        string Flush();
+    }
+    public class FileSink : ISink {
+        public void Write(string msg) {}
+        public string Flush() { return ""; }
+    }
+}`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("Sink.cs", src)
+	require.NoError(t, err)
+
+	byID := map[string]*graph.Node{}
+	for _, n := range result.Nodes {
+		byID[n.ID] = n
+	}
+
+	m := byID["Sink.cs::ISink.Write"]
+	require.NotNil(t, m, "bodyless interface method must mint a node")
+	assert.Equal(t, graph.KindMethod, m.Kind)
+	assert.Equal(t, "ISink", m.Meta["receiver"])
+	assert.Equal(t, true, m.Meta["iface_member"])
+
+	require.NotNil(t, byID["Sink.cs::ISink.Flush"], "every bodyless interface method mints a node")
+}
+
 func TestCSharpExtractor_ClassWithMethods(t *testing.T) {
 	src := []byte(`public class UserService {
     public User FindById(string id) {

--- a/internal/parser/languages/php.go
+++ b/internal/parser/languages/php.go
@@ -188,6 +188,9 @@ func (e *PHPExtractor) extractClass(
 	if parent := extractPhpParentClass(node, src); parent != "" {
 		meta["scope_parent"] = parent
 	}
+	if ifaces := phpTypeClauseNames(node, src, "class_interface_clause"); len(ifaces) > 0 {
+		meta["scope_interfaces"] = strings.Join(ifaces, ",")
+	}
 	meta["type_flavor"] = "class"
 	result.Nodes = append(result.Nodes, &graph.Node{
 		ID: id, Kind: graph.KindType, Name: className,
@@ -244,6 +247,12 @@ func (e *PHPExtractor) extractInterface(
 		meta["doc"] = doc
 	}
 	meta["type_flavor"] = "interface"
+	// An interface's `extends A, B` is modelled as a base_clause in
+	// tree-sitter-php, so its parent interfaces land under scope_interfaces —
+	// feeding the dispatch resolver's ancestor closure.
+	if parents := phpTypeClauseNames(node, src, "base_clause"); len(parents) > 0 {
+		meta["scope_interfaces"] = strings.Join(parents, ",")
+	}
 	result.Nodes = append(result.Nodes, &graph.Node{
 		ID: id, Kind: graph.KindInterface, Name: ifaceName,
 		FilePath: filePath, StartLine: startLine, EndLine: endLine,
@@ -1498,6 +1507,24 @@ func extractPhpParentClass(classNode *sitter.Node, src []byte) string {
 		}
 	}
 	return ""
+}
+
+// phpTypeClauseNames returns the type names listed in the first direct child
+// of clauseType — "class_interface_clause" for a class's `implements I, J`,
+// "base_clause" for an interface's `extends A, B`. Names keep their namespace
+// qualification; the dispatch resolver reduces them to simple names. Nil when
+// there is no such clause.
+func phpTypeClauseNames(node *sitter.Node, src []byte, clauseType string) []string {
+	if node == nil {
+		return nil
+	}
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
+		child := node.NamedChild(i)
+		if child != nil && child.Type() == clauseType {
+			return phpClauseTypeNames(child, src)
+		}
+	}
+	return nil
 }
 
 // phpMemberVisibility returns the access modifier for a PHP class

--- a/internal/parser/languages/php.go
+++ b/internal/parser/languages/php.go
@@ -2,6 +2,7 @@ package languages
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/zzet/gortex/internal/graph"
@@ -210,6 +211,16 @@ func (e *PHPExtractor) extractClass(
 		return
 	}
 	methodNodes := e.extractPhpMembers(body, src, filePath, fileNode, result, seen, className, id)
+	// Magic-method surface: a class declaring __call / __callStatic can receive
+	// arbitrary member calls the extractor cannot mint nodes for; mark it so the
+	// resolver/read path knows unresolved members on it are not necessarily a gap.
+	if phpDeclaresMagicCall(methodNodes) {
+		meta["has_magic_call"] = true
+	}
+	// @method phpdoc virtuals: docblock-declared methods (magic accessors,
+	// mixins) that have no method_declaration node. Mint them so their ids
+	// resolve and member calls to them bind.
+	e.emitPHPDocMethods(node, src, filePath, fileNode, className, id, methodNodes, result, seen)
 	// Laravel-specific dispatch passes — run after methods are in the
 	// graph so action-method IDs are resolvable by name:
 	//   1. Controller middleware: `$this->middleware(X)->only([...])`
@@ -333,7 +344,11 @@ func (e *PHPExtractor) extractTrait(
 		From: fileNode.ID, To: id, Kind: graph.EdgeDefines, FilePath: filePath, Line: startLine,
 	})
 	if body := e.findChildByType(node, "declaration_list"); body != nil {
-		e.extractPhpMembers(body, src, filePath, fileNode, result, seen, name, id)
+		methodNodes := e.extractPhpMembers(body, src, filePath, fileNode, result, seen, name, id)
+		if phpDeclaresMagicCall(methodNodes) {
+			meta["has_magic_call"] = true
+		}
+		e.emitPHPDocMethods(node, src, filePath, fileNode, name, id, methodNodes, result, seen)
 	}
 }
 
@@ -1525,6 +1540,94 @@ func phpTypeClauseNames(node *sitter.Node, src []byte, clauseType string) []stri
 		}
 	}
 	return nil
+}
+
+// phpDocMethodRe matches a phpdoc `@method` tag: an optional `static`, an
+// optional return type token, then the method name immediately before `(`.
+// Return types with `|` / `?` / `\` / `[]` are captured as one token; the
+// name is always the identifier right before the parameter list.
+var phpDocMethodRe = regexp.MustCompile(`@method\s+(?:(static)\s+)?(?:([^\s()]+)\s+)?(\w+)\s*\(`)
+
+// phpDeclaresMagicCall reports whether a class/trait body declared __call or
+// __callStatic — the PHP magic-method dispatch hooks.
+func phpDeclaresMagicCall(methodNodes map[string]*sitter.Node) bool {
+	if methodNodes == nil {
+		return false
+	}
+	_, call := methodNodes["__call"]
+	_, callStatic := methodNodes["__callStatic"]
+	return call || callStatic
+}
+
+// phpDocBlockAbove returns the raw `/** ... */` docblock immediately preceding
+// a declaration, or "" when the preceding sibling is not a doc comment. Unlike
+// ExtractDocAbove (which keeps only the first paragraph) this returns the full
+// block so @method tags below the summary survive.
+func phpDocBlockAbove(node *sitter.Node, src []byte) string {
+	sib := node.PrevNamedSibling()
+	if sib == nil || sib.Type() != "comment" {
+		return ""
+	}
+	txt := sib.Content(src)
+	if !strings.HasPrefix(strings.TrimSpace(txt), "/**") {
+		return ""
+	}
+	return txt
+}
+
+// emitPHPDocMethods mints KindMethod nodes for `@method` tags in a class/trait
+// docblock — magic accessors and mixin methods that have no method_declaration
+// and would otherwise resolve not_found. A real declaration of the same name
+// always wins (the tag is skipped). Nodes are positioned on the class
+// declaration line (a positionless decl breaks the LSP hover path) and carry
+// virtual=phpdoc_method so consumers can tell them from concrete methods.
+func (e *PHPExtractor) emitPHPDocMethods(
+	node *sitter.Node, src []byte, filePath string, fileNode *graph.Node,
+	className, classID string, methodNodes map[string]*sitter.Node,
+	result *parser.ExtractionResult, seen map[string]bool,
+) {
+	doc := phpDocBlockAbove(node, src)
+	if doc == "" || !strings.Contains(doc, "@method") {
+		return
+	}
+	classLine := int(node.StartPoint().Row) + 1
+	minted := map[string]bool{}
+	for _, m := range phpDocMethodRe.FindAllStringSubmatch(doc, -1) {
+		isStatic, retType, name := m[1] != "", m[2], m[3]
+		if name == "" || minted[name] {
+			continue
+		}
+		minted[name] = true
+		if _, real := methodNodes[name]; real {
+			continue // a concrete declaration wins over the docblock virtual
+		}
+		id := filePath + "::" + className + "." + name
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		meta := map[string]any{
+			"receiver":    className,
+			"scope_class": className,
+			"visibility":  VisibilityPublic,
+			"virtual":     "phpdoc_method",
+		}
+		if isStatic {
+			meta["static"] = true
+		}
+		if retType != "" {
+			meta["return_type"] = retType
+		}
+		result.Nodes = append(result.Nodes, &graph.Node{
+			ID: id, Kind: graph.KindMethod, Name: name,
+			FilePath: filePath, StartLine: classLine, EndLine: classLine,
+			Language: "php", Meta: meta,
+		})
+		result.Edges = append(result.Edges,
+			&graph.Edge{From: fileNode.ID, To: id, Kind: graph.EdgeDefines, FilePath: filePath, Line: classLine},
+			&graph.Edge{From: id, To: classID, Kind: graph.EdgeMemberOf, FilePath: filePath, Line: classLine},
+		)
+	}
 }
 
 // phpMemberVisibility returns the access modifier for a PHP class

--- a/internal/parser/languages/php_test.go
+++ b/internal/parser/languages/php_test.go
@@ -33,6 +33,36 @@ class UserService {
 	assert.GreaterOrEqual(t, len(methods), 1)
 }
 
+func TestPHPExtractor_ScopeInterfaces(t *testing.T) {
+	src := []byte(`<?php
+interface HandlerInterface {}
+interface ProcessableInterface extends HandlerInterface {}
+class StreamHandler extends AbstractHandler implements HandlerInterface, ProcessableInterface {
+    public function handle(): bool { return true; }
+}
+`)
+	e := NewPHPExtractor()
+	result, err := e.Extract("h.php", src)
+	require.NoError(t, err)
+
+	byName := map[string]*graph.Node{}
+	for _, n := range result.Nodes {
+		byName[n.Name] = n
+	}
+
+	cls := byName["StreamHandler"]
+	require.NotNil(t, cls)
+	assert.Equal(t, "AbstractHandler", cls.Meta["scope_parent"], "extends → scope_parent")
+	ifaces, _ := cls.Meta["scope_interfaces"].(string)
+	assert.Contains(t, ifaces, "HandlerInterface", "implements → scope_interfaces")
+	assert.Contains(t, ifaces, "ProcessableInterface", "implements → scope_interfaces")
+
+	pi := byName["ProcessableInterface"]
+	require.NotNil(t, pi)
+	pifaces, _ := pi.Meta["scope_interfaces"].(string)
+	assert.Contains(t, pifaces, "HandlerInterface", "interface extends → scope_interfaces")
+}
+
 func TestPHPExtractor_Function(t *testing.T) {
 	src := []byte(`<?php
 function greet($name) {

--- a/internal/parser/languages/php_test.go
+++ b/internal/parser/languages/php_test.go
@@ -63,6 +63,53 @@ class StreamHandler extends AbstractHandler implements HandlerInterface, Process
 	assert.Contains(t, pifaces, "HandlerInterface", "interface extends → scope_interfaces")
 }
 
+func TestPHPExtractor_DocMethodVirtuals(t *testing.T) {
+	src := []byte(`<?php
+/**
+ * Handler for tests.
+ * @method bool hasErrorRecords()
+ * @method static self create(int $x)
+ * @method mixed getRecords()
+ */
+class TestHandler {
+    public function getRecords() { return []; }
+    public function __call($name, $args) {}
+}
+`)
+	e := NewPHPExtractor()
+	result, err := e.Extract("TestHandler.php", src)
+	require.NoError(t, err)
+
+	byID := map[string]*graph.Node{}
+	for _, n := range result.Nodes {
+		byID[n.ID] = n
+	}
+
+	// A @method with no concrete declaration is minted as a virtual node.
+	v := byID["TestHandler.php::TestHandler.hasErrorRecords"]
+	require.NotNil(t, v, "phpdoc @method must mint a node")
+	assert.Equal(t, graph.KindMethod, v.Kind)
+	assert.Equal(t, "phpdoc_method", v.Meta["virtual"])
+	assert.Equal(t, "TestHandler", v.Meta["receiver"])
+	assert.Equal(t, 8, v.StartLine, "positioned on the class declaration line")
+
+	// static @method carries the static marker + return type.
+	c := byID["TestHandler.php::TestHandler.create"]
+	require.NotNil(t, c)
+	assert.Equal(t, true, c.Meta["static"])
+	assert.Equal(t, "self", c.Meta["return_type"])
+
+	// A concrete declaration wins: getRecords is NOT a virtual node.
+	g := byID["TestHandler.php::TestHandler.getRecords"]
+	require.NotNil(t, g)
+	assert.Nil(t, g.Meta["virtual"], "concrete method must not be marked virtual")
+
+	// __call marks the class magic-call surface.
+	cls := byID["TestHandler.php::TestHandler"]
+	require.NotNil(t, cls)
+	assert.Equal(t, true, cls.Meta["has_magic_call"])
+}
+
 func TestPHPExtractor_Function(t *testing.T) {
 	src := []byte(`<?php
 function greet($name) {

--- a/internal/parser/languages/rust_test.go
+++ b/internal/parser/languages/rust_test.go
@@ -9,6 +9,40 @@ import (
 	"github.com/zzet/gortex/internal/graph"
 )
 
+// Regression: a bodyless trait-method signature must mint a
+// <file>::<Trait>.<name> KindMethod node (marked trait_decl) — the node
+// rust-analyzer binds every dispatch call site to. Parity with PHP's
+// extractMethod / C#'s bodyless interface methods.
+func TestRsExtractor_BodylessTraitMethodNode(t *testing.T) {
+	src := []byte(`trait Sink {
+    fn write(&self, msg: &str);
+    fn error_message(&self) -> String;
+}
+struct FileSink;
+impl Sink for FileSink {
+    fn write(&self, msg: &str) {}
+    fn error_message(&self) -> String { String::new() }
+}
+`)
+	e := NewRustExtractor()
+	result, err := e.Extract("sink.rs", src)
+	require.NoError(t, err)
+
+	byID := map[string]*graph.Node{}
+	for _, n := range result.Nodes {
+		byID[n.ID] = n
+	}
+
+	m := byID["sink.rs::Sink.write"]
+	require.NotNil(t, m, "bodyless trait method must mint a node")
+	assert.Equal(t, graph.KindMethod, m.Kind)
+	assert.Equal(t, "Sink", m.Meta["receiver"])
+	assert.Equal(t, "true", m.Meta["trait_decl"])
+
+	require.NotNil(t, byID["sink.rs::Sink.error_message"],
+		"a bodyless trait method with a return type mints a node too")
+}
+
 func TestRsExtractor_Function(t *testing.T) {
 	src := []byte(`fn greet(name: &str) -> String {
     format!("Hello {}", name)

--- a/internal/query/call_sites_expand_test.go
+++ b/internal/query/call_sites_expand_test.go
@@ -1,0 +1,63 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// An edge carrying Meta["call_sites"] expands into one usage row per site.
+func TestFindUsages_ExpandsCallSites(t *testing.T) {
+	g := graph.New()
+	target := "h.php::HandlerInterface.handle"
+	caller := "app.php::run"
+	g.AddNode(&graph.Node{ID: target, Kind: graph.KindMethod, Name: "handle", FilePath: "h.php", StartLine: 3, Language: "php"})
+	g.AddNode(&graph.Node{ID: caller, Kind: graph.KindFunction, Name: "run", FilePath: "app.php", StartLine: 2, EndLine: 10, Language: "php"})
+
+	e := &graph.Edge{From: caller, To: target, Kind: graph.EdgeCalls, FilePath: "app.php", Line: 5, Origin: graph.OriginLSPResolved}
+	graph.AppendCallSite(e, "app.php", 7)
+	graph.AppendCallSite(e, "app.php", 9)
+	g.AddEdge(e)
+
+	sg := NewEngine(g).FindUsages(target)
+
+	var lines []int
+	for _, ue := range sg.Edges {
+		if ue.From == caller && ue.To == target && ue.Kind == graph.EdgeCalls {
+			lines = append(lines, ue.Line)
+		}
+	}
+	assert.ElementsMatch(t, []int{5, 7, 9}, lines, "one usage row per call site")
+}
+
+// A call_sites entry that coincides with a real per-line edge is not
+// double-counted; the real edge wins.
+func TestFindUsages_CallSitesDedupAgainstRealEdge(t *testing.T) {
+	g := graph.New()
+	target := "h.php::X.foo"
+	caller := "app.php::run"
+	g.AddNode(&graph.Node{ID: target, Kind: graph.KindMethod, Name: "foo", FilePath: "h.php", StartLine: 3, Language: "php"})
+	g.AddNode(&graph.Node{ID: caller, Kind: graph.KindFunction, Name: "run", FilePath: "app.php", StartLine: 2, EndLine: 10, Language: "php"})
+
+	g.AddEdge(&graph.Edge{From: caller, To: target, Kind: graph.EdgeCalls, FilePath: "app.php", Line: 7, Origin: graph.OriginASTResolved})
+	e5 := &graph.Edge{From: caller, To: target, Kind: graph.EdgeCalls, FilePath: "app.php", Line: 5, Origin: graph.OriginLSPResolved}
+	graph.AppendCallSite(e5, "app.php", 7) // duplicates the real edge's site
+	g.AddEdge(e5)
+
+	sg := NewEngine(g).FindUsages(target)
+
+	countAt7 := 0
+	var lines []int
+	for _, ue := range sg.Edges {
+		if ue.To == target && ue.Kind == graph.EdgeCalls {
+			lines = append(lines, ue.Line)
+			if ue.Line == 7 {
+				countAt7++
+			}
+		}
+	}
+	assert.Equal(t, 1, countAt7, "site 7 must not be double-counted")
+	assert.ElementsMatch(t, []int{5, 7}, lines)
+}

--- a/internal/query/engine.go
+++ b/internal/query/engine.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -435,6 +436,11 @@ func (e *Engine) FindUsagesScoped(nodeID string, opts QueryOptions) *SubGraph {
 			}
 		}
 	}
+	// Expand any edge carrying Meta["call_sites"] into one usage row per site
+	// (a synthesized producer keeps one edge and records its extra sites there;
+	// see internal/graph/call_sites.go). Done here so both the GCX and
+	// plain-JSON find_usages paths render from the same edge slice.
+	filtered = expandCallSites(filtered)
 	// Include the target node itself (already in the batch above).
 	if n := fromByID[nodeID]; n != nil {
 		if !opts.hasScopeFilter() || opts.ScopeAllows(n) {
@@ -1523,6 +1529,58 @@ func calleeBoundariesFromAdjacency(
 			if len(out) >= 50 {
 				return out
 			}
+		}
+	}
+	return out
+}
+
+// expandCallSites fans an edge that carries additional Meta["call_sites"]
+// into one usage edge per recorded site (the primary stays in FilePath/Line).
+// Rows are deduped by (from, file, line) so a site that already exists as its
+// own edge is never double-counted; real edges are emitted first so they win
+// over a call_sites clone at the same location. Cheap no-op when no edge in
+// the set carries call_sites (the overwhelmingly common case).
+func expandCallSites(edges []*graph.Edge) []*graph.Edge {
+	hasSites := false
+	for _, e := range edges {
+		if len(graph.CallSites(e)) > 0 {
+			hasSites = true
+			break
+		}
+	}
+	if !hasSites {
+		return edges
+	}
+	key := func(from, file string, line int) string {
+		return from + "\x00" + file + ":" + strconv.Itoa(line)
+	}
+	seen := make(map[string]struct{}, len(edges))
+	out := make([]*graph.Edge, 0, len(edges))
+	// Pass 1: the real edges, deduped by location.
+	for _, e := range edges {
+		k := key(e.From, e.FilePath, e.Line)
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		out = append(out, e)
+	}
+	// Pass 2: expand call_sites, skipping any location already emitted.
+	for _, e := range edges {
+		for _, site := range graph.CallSites(e) {
+			file, line := graph.SplitCallSite(site)
+			if file == "" {
+				continue
+			}
+			k := key(e.From, file, line)
+			if _, dup := seen[k]; dup {
+				continue
+			}
+			seen[k] = struct{}{}
+			clone := *e
+			clone.FilePath = file
+			clone.Line = line
+			out = append(out, &clone)
 		}
 	}
 	return out

--- a/internal/query/subgraph.go
+++ b/internal/query/subgraph.go
@@ -37,6 +37,11 @@ type SubGraph struct {
 	// empty result reflects genuinely unused code or an extraction gap.
 	// Nil — and omitted from the response — for any non-empty result.
 	Caveat *graph.ZeroEdgeCaveat `json:"caveat,omitempty"`
+	// TierFiltered is attached when a min_tier filter dropped edges while
+	// lower-tier edges still existed — so a min_tier that empties the result
+	// is legible as "filtered", not "no usages". Set by FilterByMinTier;
+	// omitted when no min_tier was applied or nothing was below the tier.
+	TierFiltered *graph.TierFilteredCaveat `json:"tier_filtered,omitempty"`
 	// CallerNotes carries concurrency-safety annotations keyed by node
 	// ID. Populated only by get_callers (which classifies each caller);
 	// other traversal tools share this struct and leave it nil, so it
@@ -291,12 +296,33 @@ func (sg *SubGraph) FilterByMinTier(minTier string) {
 		return
 	}
 	kept := make([]*graph.Edge, 0, len(sg.Edges))
+	dropped := 0
+	maxDroppedRank := -1
+	maxDroppedOrigin := ""
 	for _, e := range sg.Edges {
-		if graph.MeetsMinTier(effectiveOrigin(e), minTier) {
+		origin := effectiveOrigin(e)
+		if graph.MeetsMinTier(origin, minTier) {
 			kept = append(kept, e)
+			continue
+		}
+		dropped++
+		if r := graph.OriginRank(origin); r > maxDroppedRank {
+			maxDroppedRank = r
+			maxDroppedOrigin = origin
 		}
 	}
 	sg.Edges = kept
+	// Record a caveat when the filter dropped edges that still exist below the
+	// tier — so an empty (or thinned) result reads as "tier-filtered", not as
+	// "no usages". Only meaningful when the filter actually emptied the visible
+	// set; a min_tier that leaves edges keeps its own rows as the signal.
+	if dropped > 0 && len(kept) == 0 {
+		sg.TierFiltered = &graph.TierFilteredCaveat{
+			Class:             graph.TierFilteredClass,
+			EdgesBelowMinTier: dropped,
+			MaxAvailableTier:  maxDroppedOrigin,
+		}
+	}
 }
 
 // effectiveOrigin returns the edge's origin tier, backfilled for edges

--- a/internal/query/tier_filtered_test.go
+++ b/internal/query/tier_filtered_test.go
@@ -1,0 +1,52 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// A min_tier that filters every edge while lower-tier edges exist records a
+// tier_filtered caveat instead of leaving a bare empty result that reads as
+// "no usages".
+func TestFilterByMinTier_TierFilteredCaveat(t *testing.T) {
+	sg := &SubGraph{Edges: []*graph.Edge{
+		{From: "a", To: "t", Kind: graph.EdgeCalls, Origin: graph.OriginTextMatched},
+		{From: "b", To: "t", Kind: graph.EdgeCalls, Origin: graph.OriginASTInferred},
+	}}
+	sg.FilterByMinTier("lsp_resolved")
+
+	assert.Empty(t, sg.Edges)
+	require.NotNil(t, sg.TierFiltered)
+	assert.Equal(t, graph.TierFilteredClass, sg.TierFiltered.Class)
+	assert.Equal(t, 2, sg.TierFiltered.EdgesBelowMinTier)
+	// ast_inferred (rank 3) outranks text_matched (rank 2), so it is the best
+	// tier actually available below lsp_resolved.
+	assert.Equal(t, graph.OriginASTInferred, sg.TierFiltered.MaxAvailableTier)
+}
+
+// When some edges survive the filter, no caveat is attached — the surviving
+// rows are their own signal.
+func TestFilterByMinTier_NoCaveatWhenEdgesSurvive(t *testing.T) {
+	sg := &SubGraph{Edges: []*graph.Edge{
+		{From: "a", To: "t", Kind: graph.EdgeCalls, Origin: graph.OriginLSPResolved},
+		{From: "b", To: "t", Kind: graph.EdgeCalls, Origin: graph.OriginTextMatched},
+	}}
+	sg.FilterByMinTier("lsp_resolved")
+
+	assert.Len(t, sg.Edges, 1)
+	assert.Nil(t, sg.TierFiltered, "caveat only when the filter empties the visible set")
+}
+
+// No min_tier is a no-op — no caveat, all edges kept.
+func TestFilterByMinTier_EmptyTierIsNoop(t *testing.T) {
+	sg := &SubGraph{Edges: []*graph.Edge{
+		{From: "a", To: "t", Kind: graph.EdgeCalls, Origin: graph.OriginTextMatched},
+	}}
+	sg.FilterByMinTier("")
+	assert.Len(t, sg.Edges, 1)
+	assert.Nil(t, sg.TierFiltered)
+}

--- a/internal/resolver/php_override_dispatch.go
+++ b/internal/resolver/php_override_dispatch.go
@@ -1,0 +1,347 @@
+package resolver
+
+import (
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// phpOverrideDispatchCap bounds how many overrides a single ambiguous PHP
+// call may fan out to. A name shared by more definitions than this is too
+// generic to attribute confidently, so the call is left ambiguous.
+const phpOverrideDispatchCap = 8
+
+// resolvePHPOverrideDispatch binds ambiguous PHP member / scoped calls that
+// static resolution left unresolved, using the class hierarchy:
+//
+//   - scope_kind parent|self  → the enclosing class's ancestor chain is
+//     walked to the nearest type declaring the method (a precise single
+//     bind). This makes parent::__construct() resolve through a multi-level
+//     extends chain, not only the direct parent.
+//   - plain member calls       → when the same-name candidates form an
+//     override family related through the hierarchy (a common interface /
+//     abstract base / used trait), the call fans out to every override — the
+//     fan-out-to-implementations semantics a language server presents.
+//
+// Edges land at the ast_inferred tier (visible in default find_usages, unlike
+// the speculative Java analogue) because the PHP dispatch surface is the
+// primary recall source for the language and the relatedness gate keeps
+// precision high: an untyped receiver whose candidates share no common
+// ancestor is left unresolved rather than sprayed repo-wide. Runs AFTER the
+// cross-package guard so its edges are never reverted. PHP-only.
+func (r *Resolver) resolvePHPOverrideDispatch() int {
+	g := r.graph
+	if g == nil {
+		return 0
+	}
+	direct, closure := r.phpTypeHierarchy()
+	if len(direct) == 0 {
+		return 0
+	}
+
+	type job struct {
+		edge   *graph.Edge
+		single *graph.Node // scope-bind target; nil for a fan-out job
+		base   *graph.Node
+		others []*graph.Node
+	}
+	var jobs []job
+
+	// Collect first — mutating the graph while ranging EdgesByKind is unsafe.
+	for e := range g.EdgesByKind(graph.EdgeCalls) {
+		if e == nil || e.IsSpeculative() {
+			continue
+		}
+		name := javaUnresolvedMemberName(e.To)
+		if name == "" || strings.HasSuffix(name, ".<init>") {
+			continue
+		}
+		caller := r.cachedGetNode(e.From)
+		if caller == nil || caller.Language != "php" {
+			continue
+		}
+		repo := r.callerRepoPrefix(e)
+
+		// Scope path: parent:: / self:: / static:: bind precisely up the
+		// enclosing class's ancestor chain.
+		if sk := phpEdgeMetaString(e, "scope_kind"); sk == "parent" || sk == "self" {
+			encloser := phpEnclosingClass(caller)
+			if encloser == "" {
+				continue
+			}
+			var start []string
+			if sk == "parent" {
+				for p := range direct[encloser] {
+					start = append(start, p)
+				}
+			} else {
+				start = []string{encloser}
+			}
+			if len(start) == 0 {
+				continue
+			}
+			if target := r.nearestPHPMethod(name, start, direct, repo); target != nil && target.ID != caller.ID {
+				jobs = append(jobs, job{edge: e, single: target})
+			}
+			continue
+		}
+
+		// Fan-out path: a plain member call whose same-name candidates are an
+		// override family related through the hierarchy.
+		cands := phpOverrideCandidates(r.cachedFindNodesByNameInRepo(name, repo))
+		if len(cands) < 2 || len(cands) > phpOverrideDispatchCap {
+			continue
+		}
+		if !javaOverridesRelated(cands, closure) {
+			continue
+		}
+		jobs = append(jobs, job{edge: e, base: cands[0], others: cands[1:]})
+	}
+
+	n := 0
+	for _, j := range jobs {
+		if j.single != nil {
+			if j.edge.To == j.single.ID {
+				continue
+			}
+			oldTo := j.edge.To
+			j.edge.To = j.single.ID
+			j.edge.Origin = graph.OriginASTInferred
+			if j.edge.Confidence < phpDispatchConfidence {
+				j.edge.Confidence = phpDispatchConfidence
+			}
+			phpEnsureMeta(j.edge)["dispatch"] = "scope"
+			g.ReindexEdges([]graph.EdgeReindex{{Edge: j.edge, OldTo: oldTo}})
+			n++
+			continue
+		}
+		oldTo := j.edge.To
+		j.edge.To = j.base.ID
+		j.edge.Origin = graph.OriginASTInferred
+		j.edge.Confidence = phpDispatchConfidence
+		phpEnsureMeta(j.edge)["dispatch"] = "override"
+		g.ReindexEdges([]graph.EdgeReindex{{Edge: j.edge, OldTo: oldTo}})
+		n++
+		for _, o := range j.others {
+			if phpEdgeExists(g, j.edge.From, o.ID) {
+				continue // idempotent: the extra override edge is already present
+			}
+			g.AddEdge(&graph.Edge{
+				From: j.edge.From, To: o.ID, Kind: graph.EdgeCalls,
+				FilePath: j.edge.FilePath, Line: j.edge.Line,
+				Origin:     graph.OriginASTInferred,
+				Confidence: phpDispatchConfidence,
+				Meta:       map[string]any{"dispatch": "override"},
+			})
+			n++
+		}
+	}
+	return n
+}
+
+// phpDispatchConfidence is the confidence stamped on a dispatch-resolved edge
+// — in the ast_inferred band so DefaultOriginFor agrees with the explicit
+// Origin and the read path keeps the edge visible.
+const phpDispatchConfidence = 0.7
+
+// phpTypeHierarchy builds the PHP class hierarchy: `direct` maps each type's
+// simple name to its DIRECT parents (superclass via scope_parent, implemented
+// / extended interfaces via scope_interfaces, used traits via EdgeExtends),
+// and `closure` is the transitive ancestor set used by the relatedness gate.
+func (r *Resolver) phpTypeHierarchy() (direct, closure map[string]map[string]bool) {
+	g := r.graph
+	direct = map[string]map[string]bool{}
+	add := func(child, parent string) {
+		child = phpBaseTypeName(child)
+		parent = phpBaseTypeName(parent)
+		if child == "" || parent == "" || child == parent {
+			return
+		}
+		set := direct[child]
+		if set == nil {
+			set = map[string]bool{}
+			direct[child] = set
+		}
+		set[parent] = true
+	}
+	for _, kind := range []graph.NodeKind{graph.KindType, graph.KindInterface} {
+		for n := range g.NodesByKind(kind) {
+			if n == nil || n.Language != "php" || n.Name == "" || n.Meta == nil {
+				continue
+			}
+			if p, ok := n.Meta[MetaScopeParentClass].(string); ok {
+				add(n.Name, p)
+			}
+			if ifaces, ok := n.Meta["scope_interfaces"].(string); ok && ifaces != "" {
+				for _, iface := range strings.Split(ifaces, ",") {
+					add(n.Name, iface)
+				}
+			}
+		}
+	}
+	// Trait `use` (and any other extends-shaped) relationship is a graph edge.
+	for e := range g.EdgesByKind(graph.EdgeExtends) {
+		if e == nil {
+			continue
+		}
+		from := r.cachedGetNode(e.From)
+		if from == nil || from.Language != "php" || from.Name == "" {
+			continue
+		}
+		add(from.Name, phpEdgeTargetName(g, e.To))
+	}
+	if len(direct) == 0 {
+		return direct, nil
+	}
+	closure = make(map[string]map[string]bool, len(direct))
+	var visit func(t string, acc, seen map[string]bool)
+	visit = func(t string, acc, seen map[string]bool) {
+		for p := range direct[t] {
+			if seen[p] {
+				continue
+			}
+			seen[p] = true
+			acc[p] = true
+			visit(p, acc, seen)
+		}
+	}
+	for t := range direct {
+		acc := map[string]bool{}
+		visit(t, acc, map[string]bool{t: true})
+		closure[t] = acc
+	}
+	return direct, closure
+}
+
+// nearestPHPMethod walks up the hierarchy from start (breadth-first, nearest
+// first) to the first ancestor type declaring method name, returning that
+// method node. Used by the parent::/self:: scope bind.
+func (r *Resolver) nearestPHPMethod(name string, start []string, direct map[string]map[string]bool, repo string) *graph.Node {
+	byRecv := map[string]*graph.Node{}
+	for _, m := range r.cachedFindNodesByNameInRepo(name, repo) {
+		if m == nil || m.Language != "php" || m.Kind != graph.KindMethod {
+			continue
+		}
+		if graph.IsStub(m.ID) || graph.IsUnresolvedTarget(m.ID) {
+			continue
+		}
+		if rc := nodeReceiverType(m); rc != "" {
+			if _, ok := byRecv[rc]; !ok {
+				byRecv[rc] = m
+			}
+		}
+	}
+	if len(byRecv) == 0 {
+		return nil
+	}
+	visited := map[string]bool{}
+	queue := append([]string{}, start...)
+	for _, s := range start {
+		visited[s] = true
+	}
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		if m := byRecv[cur]; m != nil {
+			return m
+		}
+		for p := range direct[cur] {
+			if !visited[p] {
+				visited[p] = true
+				queue = append(queue, p)
+			}
+		}
+	}
+	return nil
+}
+
+// phpOverrideCandidates filters name-matched nodes to in-repo PHP method
+// definitions, one per declaring type (deduped by receiver), excluding stubs
+// and definitions with no declaring type.
+func phpOverrideCandidates(raw []*graph.Node) []*graph.Node {
+	var out []*graph.Node
+	seen := map[string]bool{}
+	for _, n := range raw {
+		if n == nil || n.Language != "php" || n.Kind != graph.KindMethod {
+			continue
+		}
+		if graph.IsStub(n.ID) || graph.IsUnresolvedTarget(n.ID) {
+			continue
+		}
+		recv := nodeReceiverType(n)
+		if recv == "" || seen[recv] {
+			continue
+		}
+		seen[recv] = true
+		out = append(out, n)
+	}
+	return out
+}
+
+// phpEnclosingClass returns the simple name of the class a caller node belongs
+// to (its receiver / scope_class), or "" for a free function.
+func phpEnclosingClass(caller *graph.Node) string {
+	if caller == nil || caller.Meta == nil {
+		return ""
+	}
+	if r, ok := caller.Meta["receiver"].(string); ok && r != "" {
+		return phpBaseTypeName(r)
+	}
+	if r, ok := caller.Meta["scope_class"].(string); ok && r != "" {
+		return phpBaseTypeName(r)
+	}
+	return ""
+}
+
+// phpEdgeExists reports whether a call edge from→to already exists (used to
+// keep the fan-out idempotent across re-resolution).
+func phpEdgeExists(g graph.Store, from, to string) bool {
+	for _, e := range g.GetOutEdges(from) {
+		if e != nil && e.To == to && e.Kind == graph.EdgeCalls {
+			return true
+		}
+	}
+	return false
+}
+
+// phpEdgeTargetName resolves an edge target id to a simple type name, handling
+// both an unresolved::<name> stub and a resolved node id.
+func phpEdgeTargetName(g graph.Store, to string) string {
+	if graph.IsUnresolvedTarget(to) {
+		return graph.UnresolvedName(to)
+	}
+	if n := g.GetNode(to); n != nil {
+		return n.Name
+	}
+	return graph.UnresolvedName(to)
+}
+
+// phpBaseTypeName reduces a possibly namespace-qualified PHP type reference to
+// its simple name (`App\Service\User` → `User`, `\Foo` → `Foo`).
+func phpBaseTypeName(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, `\`)
+	if i := strings.LastIndexByte(s, '\\'); i >= 0 {
+		s = s[i+1:]
+	}
+	return strings.TrimSpace(s)
+}
+
+// phpEdgeMetaString reads a string-valued edge meta key, "" when absent.
+func phpEdgeMetaString(e *graph.Edge, key string) string {
+	if e == nil || e.Meta == nil {
+		return ""
+	}
+	if s, ok := e.Meta[key].(string); ok {
+		return s
+	}
+	return ""
+}
+
+// phpEnsureMeta returns the edge's meta map, allocating it when nil.
+func phpEnsureMeta(e *graph.Edge) map[string]any {
+	if e.Meta == nil {
+		e.Meta = map[string]any{}
+	}
+	return e.Meta
+}

--- a/internal/resolver/php_override_dispatch_test.go
+++ b/internal/resolver/php_override_dispatch_test.go
@@ -145,6 +145,33 @@ func TestResolvePHPOverrideDispatch_TraitProvidedMethod(t *testing.T) {
 	}
 }
 
+// A phpdoc @method virtual node joins the member-call binding population: a
+// unique-name call to it resolves like any other method (proving W4's virtual
+// nodes are first-class in the resolver, not just the extractor).
+func TestResolvePHP_PhpdocVirtualIsBindable(t *testing.T) {
+	var s graph.Store = graph.New()
+	f := "src/Foo.php"
+	app := "src/a.php"
+	phpType(s, f+"::Foo", "Foo", nil)
+	s.AddNode(&graph.Node{ID: f + "::Foo.magicAccessor", Kind: graph.KindMethod, Name: "magicAccessor",
+		FilePath: f, Language: "php", Meta: map[string]any{"receiver": "Foo", "virtual": "phpdoc_method"}})
+
+	caller := app + "::run"
+	s.AddNode(&graph.Node{ID: caller, Kind: graph.KindFunction, Name: "run", FilePath: app, Language: "php"})
+	s.AddEdge(&graph.Edge{From: caller, To: "unresolved::*.magicAccessor", Kind: graph.EdgeCalls, FilePath: app, Line: 2})
+
+	r := New(s)
+	r.ResolveAll()
+
+	var bound bool
+	for _, e := range s.GetOutEdges(caller) {
+		if e.Kind == graph.EdgeCalls && e.To == f+"::Foo.magicAccessor" {
+			bound = true
+		}
+	}
+	assert.True(t, bound, "a call to a unique phpdoc @method virtual must bind to it")
+}
+
 // Precision guard: same-name methods on UNRELATED types (no shared ancestor)
 // must never be sprayed together.
 func TestResolvePHPOverrideDispatch_UnrelatedNotFannedOut(t *testing.T) {

--- a/internal/resolver/php_override_dispatch_test.go
+++ b/internal/resolver/php_override_dispatch_test.go
@@ -1,0 +1,205 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func phpType(s graph.Store, id, name string, meta map[string]any) {
+	s.AddNode(&graph.Node{ID: id, Kind: graph.KindType, Name: name, FilePath: id, Language: "php", Meta: meta})
+}
+func phpIface(s graph.Store, id, name string, meta map[string]any) {
+	s.AddNode(&graph.Node{ID: id, Kind: graph.KindInterface, Name: name, FilePath: id, Language: "php", Meta: meta})
+}
+func phpMethod(s graph.Store, id, name, receiver string) {
+	s.AddNode(&graph.Node{ID: id, Kind: graph.KindMethod, Name: name, FilePath: id, Language: "php",
+		Meta: map[string]any{"receiver": receiver}})
+}
+
+// Interface-typed receiver: an ambiguous `$h->handle()` fans out to the
+// interface declaration + every in-repo implementation, related through the
+// `implements` clause (scope_interfaces). Edges land at ast_inferred so they
+// are visible in default find_usages.
+func TestResolvePHPOverrideDispatch_InterfaceFanOut(t *testing.T) {
+	var s graph.Store = graph.New()
+	iface := "src/HandlerInterface.php"
+	th := "src/TestHandler.php"
+	sh := "src/StreamHandler.php"
+	app := "src/app.php"
+
+	phpIface(s, iface+"::HandlerInterface", "HandlerInterface", nil)
+	phpMethod(s, iface+"::HandlerInterface.handle", "handle", "HandlerInterface")
+	phpType(s, th+"::TestHandler", "TestHandler", map[string]any{"scope_interfaces": "HandlerInterface"})
+	phpMethod(s, th+"::TestHandler.handle", "handle", "TestHandler")
+	phpType(s, sh+"::StreamHandler", "StreamHandler", map[string]any{"scope_interfaces": "HandlerInterface"})
+	phpMethod(s, sh+"::StreamHandler.handle", "handle", "StreamHandler")
+
+	caller := app + "::run"
+	s.AddNode(&graph.Node{ID: caller, Kind: graph.KindFunction, Name: "run", FilePath: app, Language: "php"})
+	s.AddEdge(&graph.Edge{From: caller, To: "unresolved::*.handle", Kind: graph.EdgeCalls, FilePath: app, Line: 5})
+
+	r := New(s)
+	n := r.resolvePHPOverrideDispatch()
+	assert.Positive(t, n, "at least one dispatch edge should be bound")
+
+	for _, target := range []string{
+		iface + "::HandlerInterface.handle",
+		th + "::TestHandler.handle",
+		sh + "::StreamHandler.handle",
+	} {
+		var found *graph.Edge
+		for _, in := range s.GetInEdges(target) {
+			if in.From == caller && in.Kind == graph.EdgeCalls {
+				found = in
+				break
+			}
+		}
+		require.NotNil(t, found, "expected fan-out call edge run→%s", target)
+		assert.Equal(t, graph.OriginASTInferred, found.Origin, "dispatch edge is ast_inferred (visible)")
+		assert.Equal(t, "override", found.Meta["dispatch"])
+		assert.Equal(t, 5, found.Line, "edge anchored at the call site")
+	}
+	// The ambiguous stub is gone.
+	for _, e := range s.GetOutEdges(caller) {
+		assert.NotEqual(t, "unresolved::*.handle", e.To)
+	}
+}
+
+// parent::__construct() must bind through a 3-deep extends chain (Leaf → Mid →
+// Base, only Base declares the constructor), a precise single bind.
+func TestResolvePHPOverrideDispatch_ParentConstructChain(t *testing.T) {
+	var s graph.Store = graph.New()
+	base := "src/Base.php"
+	mid := "src/Mid.php"
+	leaf := "src/Leaf.php"
+
+	phpType(s, base+"::Base", "Base", nil)
+	phpMethod(s, base+"::Base.__construct", "__construct", "Base")
+	phpType(s, mid+"::Mid", "Mid", map[string]any{"scope_parent": "Base"})
+	phpType(s, leaf+"::Leaf", "Leaf", map[string]any{"scope_parent": "Mid"})
+	phpMethod(s, leaf+"::Leaf.__construct", "__construct", "Leaf")
+
+	caller := leaf + "::Leaf.__construct"
+	s.AddEdge(&graph.Edge{
+		From: caller, To: "unresolved::*.__construct", Kind: graph.EdgeCalls,
+		FilePath: leaf, Line: 7, Meta: map[string]any{"scope_kind": "parent"},
+	})
+
+	r := New(s)
+	r.resolvePHPOverrideDispatch()
+
+	var bound *graph.Edge
+	for _, e := range s.GetOutEdges(caller) {
+		if e.Kind == graph.EdgeCalls && e.To == base+"::Base.__construct" {
+			bound = e
+			break
+		}
+	}
+	require.NotNil(t, bound, "parent::__construct must bind to Base.__construct up the 3-deep chain")
+	assert.Equal(t, graph.OriginASTInferred, bound.Origin)
+	assert.Equal(t, "scope", bound.Meta["dispatch"])
+	for _, e := range s.GetOutEdges(caller) {
+		assert.NotEqual(t, "unresolved::*.__construct", e.To)
+	}
+}
+
+// A trait-provided method binds via `use`: Button extends Widget, Widget uses
+// trait Renderer (an EdgeExtends), so `$x->render()` fans out to Renderer.render
+// (the trait) as well as Button.render — related through the trait in the
+// ancestor closure.
+func TestResolvePHPOverrideDispatch_TraitProvidedMethod(t *testing.T) {
+	var s graph.Store = graph.New()
+	trait := "src/Renderer.php"
+	widget := "src/Widget.php"
+	button := "src/Button.php"
+	app := "src/paint.php"
+
+	phpType(s, trait+"::Renderer", "Renderer", map[string]any{"type_flavor": "trait", "kind": "trait"})
+	phpMethod(s, trait+"::Renderer.render", "render", "Renderer")
+	phpType(s, widget+"::Widget", "Widget", nil)
+	// Widget uses the Renderer trait — modelled as an EdgeExtends to the stub.
+	s.AddEdge(&graph.Edge{From: widget + "::Widget", To: "unresolved::Renderer", Kind: graph.EdgeExtends,
+		FilePath: widget, Line: 3, Meta: map[string]any{"via": "trait"}})
+	phpType(s, button+"::Button", "Button", map[string]any{"scope_parent": "Widget"})
+	phpMethod(s, button+"::Button.render", "render", "Button")
+
+	caller := app + "::paint"
+	s.AddNode(&graph.Node{ID: caller, Kind: graph.KindFunction, Name: "paint", FilePath: app, Language: "php"})
+	s.AddEdge(&graph.Edge{From: caller, To: "unresolved::*.render", Kind: graph.EdgeCalls, FilePath: app, Line: 4})
+
+	r := New(s)
+	r.resolvePHPOverrideDispatch()
+
+	for _, target := range []string{trait + "::Renderer.render", button + "::Button.render"} {
+		var found bool
+		for _, in := range s.GetInEdges(target) {
+			if in.From == caller && in.Kind == graph.EdgeCalls {
+				found = true
+			}
+		}
+		assert.True(t, found, "expected fan-out call edge paint→%s (trait-related)", target)
+	}
+}
+
+// Precision guard: same-name methods on UNRELATED types (no shared ancestor)
+// must never be sprayed together.
+func TestResolvePHPOverrideDispatch_UnrelatedNotFannedOut(t *testing.T) {
+	var s graph.Store = graph.New()
+	a := "src/Alpha.php"
+	b := "src/Beta.php"
+	app := "src/main.php"
+
+	phpType(s, a+"::Alpha", "Alpha", nil)
+	phpMethod(s, a+"::Alpha.save", "save", "Alpha")
+	phpType(s, b+"::Beta", "Beta", nil)
+	phpMethod(s, b+"::Beta.save", "save", "Beta")
+
+	caller := app + "::go"
+	s.AddNode(&graph.Node{ID: caller, Kind: graph.KindFunction, Name: "go", FilePath: app, Language: "php"})
+	s.AddEdge(&graph.Edge{From: caller, To: "unresolved::*.save", Kind: graph.EdgeCalls, FilePath: app, Line: 3})
+
+	r := New(s)
+	r.resolvePHPOverrideDispatch()
+
+	// Unrelated save() methods share no ancestor → the call stays ambiguous.
+	var stillUnresolved bool
+	for _, e := range s.GetOutEdges(caller) {
+		if e.To == "unresolved::*.save" {
+			stillUnresolved = true
+		}
+	}
+	assert.True(t, stillUnresolved, "unrelated same-name methods must not be fanned out")
+}
+
+// Idempotency: a second pass over an already-bound graph must not duplicate
+// the fan-out edges.
+func TestResolvePHPOverrideDispatch_Idempotent(t *testing.T) {
+	var s graph.Store = graph.New()
+	iface := "src/I.php"
+	x := "src/X.php"
+	y := "src/Y.php"
+	app := "src/a.php"
+
+	phpIface(s, iface+"::I", "I", nil)
+	phpMethod(s, iface+"::I.run", "run", "I")
+	phpType(s, x+"::X", "X", map[string]any{"scope_interfaces": "I"})
+	phpMethod(s, x+"::X.run", "run", "X")
+	phpType(s, y+"::Y", "Y", map[string]any{"scope_interfaces": "I"})
+	phpMethod(s, y+"::Y.run", "run", "Y")
+
+	caller := app + "::z"
+	s.AddNode(&graph.Node{ID: caller, Kind: graph.KindFunction, Name: "z", FilePath: app, Language: "php"})
+	s.AddEdge(&graph.Edge{From: caller, To: "unresolved::*.run", Kind: graph.EdgeCalls, FilePath: app, Line: 2})
+
+	r := New(s)
+	r.resolvePHPOverrideDispatch()
+	countAfterFirst := len(s.GetOutEdges(caller))
+	// Re-stub the primary to simulate a restub→re-resolve cycle.
+	r.resolvePHPOverrideDispatch()
+	assert.Equal(t, countAfterFirst, len(s.GetOutEdges(caller)),
+		"re-running the pass must not duplicate fan-out edges")
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -552,6 +552,12 @@ func (r *Resolver) ResolveAll() *ResolveStats {
 	// Runs after the guard so its ast_inferred edges are never reverted.
 	r.resolveJavaOverrideDispatch()
 
+	// PHP dispatch resolution: bind ambiguous member/scoped calls the guard
+	// left unresolved via the class hierarchy — parent::/self:: up the extends
+	// chain, and interface/abstract/trait override families fanned out to
+	// every implementation. Same post-guard placement as the Java pass.
+	r.resolvePHPOverrideDispatch()
+
 	total := &ResolveStats{}
 	for i := range allStats {
 		total.Resolved += allStats[i].Resolved

--- a/internal/semantic/lsp/intelephense_storage.go
+++ b/internal/semantic/lsp/intelephense_storage.go
@@ -1,0 +1,51 @@
+package lsp
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/zzet/gortex/internal/platform"
+)
+
+// intelephenseStorageDir returns the per-repo index-cache directory
+// intelephense should use, rooted at Gortex's cache home (via
+// internal/platform, so XDG_CACHE_HOME overrides win and the path is
+// Windows-safe). Without an explicit storagePath intelephense writes its
+// index to a default global location outside the isolation every other
+// engine artifact honours, and two daemons indexing the same repo path
+// would collide there.
+func intelephenseStorageDir(repoRoot string) string {
+	sum := sha256.Sum256([]byte(repoRoot))
+	hash := hex.EncodeToString(sum[:])[:16]
+	return filepath.Join(platform.CacheDir(), "intelephense", hash)
+}
+
+// intelephenseGlobalStorageDir is the shared, repo-independent cache
+// intelephense uses for bundled stubs and cross-repo data.
+func intelephenseGlobalStorageDir() string {
+	return filepath.Join(platform.CacheDir(), "intelephense", "global")
+}
+
+// intelephenseInitOptions builds the initializationOptions that pin
+// intelephense's index caches inside Gortex's cache home. It is resolved at
+// initialize time (not a baked literal) because the path depends on the
+// per-user cache root and the indexed repo root. Best-effort MkdirAll so the
+// server can open the caches on first launch; errors are non-fatal.
+func intelephenseInitOptions(repoRoot string) json.RawMessage {
+	storage := intelephenseStorageDir(repoRoot)
+	global := intelephenseGlobalStorageDir()
+	_ = os.MkdirAll(storage, 0o755)
+	_ = os.MkdirAll(global, 0o755)
+	opts := struct {
+		StoragePath       string `json:"storagePath"`
+		GlobalStoragePath string `json:"globalStoragePath"`
+	}{StoragePath: storage, GlobalStoragePath: global}
+	b, err := json.Marshal(opts)
+	if err != nil {
+		return nil
+	}
+	return json.RawMessage(b)
+}

--- a/internal/semantic/lsp/intelephense_storage_test.go
+++ b/internal/semantic/lsp/intelephense_storage_test.go
@@ -1,0 +1,110 @@
+package lsp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestIntelephenseInitOptions_StoragePathUnderCacheDir(t *testing.T) {
+	cacheHome := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cacheHome)
+	repoRoot := "/some/repo/monolog"
+
+	raw := intelephenseInitOptions(repoRoot)
+	require.NotEmpty(t, raw)
+
+	var opts struct {
+		StoragePath       string `json:"storagePath"`
+		GlobalStoragePath string `json:"globalStoragePath"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &opts))
+
+	wantBase := filepath.Join(cacheHome, "gortex", "intelephense")
+	assert.True(t, strings.HasPrefix(opts.StoragePath, wantBase),
+		"storagePath %q should be under %q", opts.StoragePath, wantBase)
+	assert.Equal(t, filepath.Join(wantBase, "global"), opts.GlobalStoragePath)
+	assert.NotEqual(t, opts.StoragePath, opts.GlobalStoragePath)
+
+	// The per-repo dir is created so intelephense can open it on launch.
+	info, err := os.Stat(opts.StoragePath)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+}
+
+func TestProviderEffectiveInitOptions_AltPrecedence(t *testing.T) {
+	// The resolve-time func hook wins when it returns non-empty options.
+	pFunc := &Provider{altInitOptionsFunc: func(root string) json.RawMessage {
+		return json.RawMessage(`{"from":"func"}`)
+	}}
+	assert.JSONEq(t, `{"from":"func"}`, string(pFunc.effectiveInitOptions("/repo")))
+
+	// Static per-alternative options win over the spec-level blob.
+	pStatic := &Provider{
+		altInitOptions: json.RawMessage(`{"from":"alt"}`),
+		spec:           &ServerSpec{InitializationOptions: json.RawMessage(`{"from":"spec"}`)},
+	}
+	assert.JSONEq(t, `{"from":"alt"}`, string(pStatic.effectiveInitOptions("/repo")))
+
+	// Falls back to the spec when the alternative carries nothing.
+	pSpec := &Provider{spec: &ServerSpec{InitializationOptions: json.RawMessage(`{"from":"spec"}`)}}
+	assert.JSONEq(t, `{"from":"spec"}`, string(pSpec.effectiveInitOptions("/repo")))
+}
+
+func TestNewProviderFromSpec_CarriesResolvedAltStoragePath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH-based faux executable resolution is POSIX-only")
+	}
+	// Hermetic PATH: only a faux "intelephense" resolves; the primary
+	// "phpactor-not-on-path" is absent, so the alternative must win and
+	// carry its InitOptionsFunc onto the Provider.
+	binDir := t.TempDir()
+	fauxPath := filepath.Join(binDir, "intelephense")
+	require.NoError(t, os.WriteFile(fauxPath, []byte("#!/bin/sh\n"), 0o755))
+	t.Setenv("PATH", binDir)
+	cacheHome := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", cacheHome)
+
+	spec := &ServerSpec{
+		Name:    "phpactor",
+		Command: "phpactor-not-on-path",
+		Args:    []string{"language-server"},
+		AlternativeCommands: []ServerAlt{
+			{Command: "intelephense", Args: []string{"--stdio"}, InitOptionsFunc: intelephenseInitOptions},
+		},
+	}
+	p := NewProviderFromSpec(spec, zap.NewNop())
+	require.Equal(t, "intelephense", p.command)
+
+	raw := p.effectiveInitOptions("/some/repo/monolog")
+	require.NotEmpty(t, raw)
+	assert.Contains(t, string(raw), filepath.Join(cacheHome, "gortex", "intelephense"))
+	// The spec's default (intelephense's) cache location is never sent as-is:
+	// there is no baked storagePath literal on the spec.
+	assert.Empty(t, spec.InitializationOptions)
+}
+
+func TestPhpactorSpecPinsIntelephenseStorage(t *testing.T) {
+	var found bool
+	for i := range Servers {
+		if Servers[i].Name != "phpactor" {
+			continue
+		}
+		for _, alt := range Servers[i].AlternativeCommands {
+			if alt.Command != "intelephense" {
+				continue
+			}
+			found = true
+			require.NotNil(t, alt.InitOptionsFunc, "intelephense alt must pin a storagePath")
+			assert.Contains(t, string(alt.InitOptionsFunc("/repo")), "storagePath")
+		}
+	}
+	assert.True(t, found, "phpactor spec must list an intelephense alternative")
+}

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -44,6 +44,14 @@ type Provider struct {
 	// invocations — those fall back to single-language routing.
 	spec *ServerSpec
 
+	// altInitOptions / altInitOptionsFunc carry the InitializationOptions
+	// of the alternative command that won on PATH in NewProviderFromSpec.
+	// effectiveInitializationOptions(spec) cannot see them because it keys
+	// on the spec's primary command; a resolved-alternative server (e.g.
+	// intelephense standing in for phpactor) sends these instead.
+	altInitOptions     json.RawMessage
+	altInitOptionsFunc func(repoRoot string) json.RawMessage
+
 	client *Client
 
 	// sourceCache holds file contents read by openDocument so the
@@ -162,11 +170,15 @@ func NewProvider(command string, args []string, languages []string, daemon bool,
 func NewProviderFromSpec(spec *ServerSpec, logger *zap.Logger) *Provider {
 	cmd := spec.Command
 	args := spec.Args
+	var altInitOptions json.RawMessage
+	var altInitOptionsFunc func(repoRoot string) json.RawMessage
 	if _, err := exec.LookPath(cmd); err != nil {
 		for _, alt := range spec.AlternativeCommands {
 			if _, err := exec.LookPath(alt.Command); err == nil {
 				cmd = alt.Command
 				args = alt.Args
+				altInitOptions = alt.InitializationOptions
+				altInitOptionsFunc = alt.InitOptionsFunc
 				break
 			}
 		}
@@ -187,14 +199,35 @@ func NewProviderFromSpec(spec *ServerSpec, logger *zap.Logger) *Provider {
 		docVersions:      map[string]int{},
 		openDocs:         map[string]bool{},
 		lastDiag:         map[string][]Diagnostic{},
-		diagWaiters:      map[string][]chan []Diagnostic{},
-		dynamicCaps:      map[string]Registration{},
-		connect:          spec.Connect,
-		dialBackoff:      dialBackoffStart,
-		dialBackoffStart: dialBackoffStart,
-		maxDialBackoff:   maxDialBackoff,
+		diagWaiters:        map[string][]chan []Diagnostic{},
+		dynamicCaps:        map[string]Registration{},
+		connect:            spec.Connect,
+		altInitOptions:     altInitOptions,
+		altInitOptionsFunc: altInitOptionsFunc,
+		dialBackoff:        dialBackoffStart,
+		dialBackoffStart:   dialBackoffStart,
+		maxDialBackoff:     maxDialBackoff,
 	}
 	return p
+}
+
+// effectiveInitOptions resolves the initializationOptions to send in this
+// provider's initialize request. When the provider was built from a spec
+// whose primary command was absent and an alternative won on PATH, that
+// alternative's options take precedence over the spec-level blob (which is
+// keyed to the primary command and cannot see the resolved alternative).
+// InitOptionsFunc is consulted first so an alternative can root a per-repo
+// cache path under Gortex's cache home using workspaceRoot.
+func (p *Provider) effectiveInitOptions(workspaceRoot string) json.RawMessage {
+	if p.altInitOptionsFunc != nil {
+		if opts := p.altInitOptionsFunc(workspaceRoot); len(opts) > 0 {
+			return opts
+		}
+	}
+	if len(p.altInitOptions) > 0 {
+		return p.altInitOptions
+	}
+	return effectiveInitializationOptions(p.spec)
 }
 
 func (p *Provider) Name() string        { return "lsp-" + p.command }
@@ -1660,8 +1693,9 @@ func (p *Provider) ensureClient(workspaceRoot string) error {
 		},
 	}
 	// Pass server-specific InitializationOptions (e.g. Maven/Gradle import
-	// settings for jdtls) when the provider was built from a ServerSpec.
-	if opts := effectiveInitializationOptions(p.spec); len(opts) > 0 {
+	// settings for jdtls, or a per-repo storagePath for a resolved-
+	// alternative intelephense) when the provider was built from a ServerSpec.
+	if opts := p.effectiveInitOptions(workspaceRoot); len(opts) > 0 {
 		initParams.InitializationOptions = opts
 	}
 

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -745,6 +745,16 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 		}
 	}
 
+	// References-driven add pass: a server that enumerates references but has
+	// no call hierarchy (e.g. intelephense) never runs the per-file sweep's
+	// hierarchy hops, so the dispatch call sites it can see are confirmed but
+	// never ADDED. Ask textDocument/references per declaration and mint those
+	// call edges. Runs under the targeted budget (before the hover sweep) so
+	// a deadline cut sheds hover work, not the recall-bearing add.
+	if p.Supports("textDocument/references") && !p.Supports("textDocument/prepareCallHierarchy") {
+		p.referencesAddPass(targetedCtx, g, repoPrefix, absRoot, langNodes, rmu, result)
+	}
+
 	// Per-file document lifecycle + bounded concurrency. The original
 	// implementation bulk-opened every target file up front and closed
 	// them all in one deferred sweep after a fully sequential hover loop —

--- a/internal/semantic/lsp/references_add.go
+++ b/internal/semantic/lsp/references_add.go
@@ -39,11 +39,14 @@ func (p *Provider) referencesAddPass(ctx context.Context, g graph.Store, repoPre
 	// repo-relative path. Site files are read from disk, never opened on the
 	// server — attribution uses the graph, not the LSP.
 	siteSrc := map[string][]byte{}
-	// Within one pass a (caller, target) pair collapses to a single edge
-	// (first site wins its FilePath/Line), independent of backend write
-	// visibility, so a caller with N call sites to the same target does not
-	// mint N duplicate edges.
-	minted := map[string]bool{}
+	// Within one pass a (caller, target) pair maps to a single edge: the
+	// first site wins its FilePath/Line, later sites are recorded on the
+	// edge's call_sites so find_usages still renders one row per site (see
+	// internal/graph/call_sites.go). Edges W2 minted accumulate call_sites;
+	// pre-existing edges (which the AST already emits per call site) are only
+	// promoted, so their per-line siblings carry the multiplicity.
+	mintedEdge := map[string]*graph.Edge{}
+	promoted := map[string]bool{}
 
 	for _, n := range targets {
 		if ctx.Err() != nil {
@@ -79,9 +82,6 @@ func (p *Provider) referencesAddPass(ctx context.Context, g graph.Store, repoPre
 				continue // unattributable, or the declaration's own identifier
 			}
 			key := enclosing.ID + "\x00" + n.ID
-			if minted[key] {
-				continue
-			}
 			// Cheap text guard: the site line must actually contain the
 			// target's whole name token, to defuse a stale position or a
 			// server bug before minting a compiler-grade edge.
@@ -90,6 +90,18 @@ func (p *Provider) referencesAddPass(ctx context.Context, g graph.Store, repoPre
 					continue
 				}
 			}
+			// A later site of an edge W2 already minted: record it on the edge
+			// instead of minting a duplicate.
+			if e0, ok := mintedEdge[key]; ok {
+				graph.AppendCallSite(e0, enclosing.FilePath, siteLine)
+				semantic.PersistEdge(g, e0)
+				continue
+			}
+			// A later site of an edge the AST already produced per line — the
+			// promotion already ran, and its per-line siblings carry the sites.
+			if promoted[key] {
+				continue
+			}
 			if existing := semantic.FindMatchingEdge(g, enclosing.ID, n.ID, graph.EdgeCalls); existing != nil {
 				if graph.OriginRank(existing.Origin) < graph.OriginRank(graph.OriginLSPResolved) {
 					semantic.ConfirmEdge(existing, p.Name())
@@ -97,13 +109,12 @@ func (p *Provider) referencesAddPass(ctx context.Context, g graph.Store, repoPre
 					semantic.PersistEdge(g, existing)
 					result.EdgesConfirmed++
 				}
-				minted[key] = true
+				promoted[key] = true
 				continue
 			}
-			semantic.AddSemanticEdge(g, enclosing.ID, n.ID, graph.EdgeCalls,
+			mintedEdge[key] = semantic.AddSemanticEdge(g, enclosing.ID, n.ID, graph.EdgeCalls,
 				enclosing.FilePath, siteLine, p.Name())
 			result.EdgesAdded++
-			minted[key] = true
 		}
 		rmu.Unlock()
 	}

--- a/internal/semantic/lsp/references_add.go
+++ b/internal/semantic/lsp/references_add.go
@@ -1,0 +1,225 @@
+package lsp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/semantic"
+)
+
+// referencesAddPass adds call edges for a references-capable server whose
+// call hierarchy is absent (e.g. intelephense). For each function / method
+// declaration it asks textDocument/references and mints an lsp_resolved
+// EdgeCalls from each reference site's enclosing callable to the target —
+// the add-phase analogue of a call-hierarchy hop for servers that implement
+// only references. Without it the per-file sweep's hierarchy hops never run,
+// so the enrich pass confirms existing edges but never ADDS the dispatch
+// call sites the server can enumerate (the "confirm-only, edges_added 0"
+// outcome). Provider-generic: any references-capable, call-hierarchy-absent
+// server benefits.
+//
+// Targets are ordered dispatch-anchors-first (interface / trait members,
+// then abstract-marked methods, then by descending fan-in) so a per-repo
+// deadline is spent where recall is scarcest. Each declaration commits under
+// rmu as soon as its references land, so a deadline cut loses only the
+// unvisited remainder. Runs under the caller's targeted context (the same
+// budget the confirm pass uses), before the per-file hover sweep.
+func (p *Provider) referencesAddPass(ctx context.Context, g graph.Store, repoPrefix, absRoot string, langNodes []*graph.Node, rmu sync.Locker, result *semantic.EnrichResult) {
+	targets := selectReferencesAddTargets(g, langNodes)
+	if len(targets) == 0 {
+		return
+	}
+	result.ReferencesAddPass = true
+
+	// Site-file contents cached for the cheap name-token guard, keyed by
+	// repo-relative path. Site files are read from disk, never opened on the
+	// server — attribution uses the graph, not the LSP.
+	siteSrc := map[string][]byte{}
+	// Within one pass a (caller, target) pair collapses to a single edge
+	// (first site wins its FilePath/Line), independent of backend write
+	// visibility, so a caller with N call sites to the same target does not
+	// mint N duplicate edges.
+	minted := map[string]bool{}
+
+	for _, n := range targets {
+		if ctx.Err() != nil {
+			break
+		}
+		line, ok := lspLine(n)
+		if !ok {
+			continue
+		}
+		rel := nodeRelPath(n)
+		if !p.servesFile(rel) {
+			continue // never open a file this server can't compile
+		}
+		if err := p.openDocument(absRoot, rel); err != nil {
+			continue
+		}
+		col := identifierColumn(p.getSource(absRoot, rel), n.StartLine, n.Name)
+		refs, err := p.findReferences(absRoot, rel, line, col)
+		_ = p.closeDocument(filepath.Join(absRoot, rel))
+		if err != nil || len(refs) == 0 {
+			continue
+		}
+
+		rmu.Lock()
+		for _, loc := range refs {
+			sitePath := uriToPath(loc.URI, absRoot)
+			if sitePath == "" {
+				continue // reference outside the repo
+			}
+			siteLine := loc.Range.Start.Line + 1
+			enclosing := semantic.MatchCallableByFileLine(g, scopedPath(repoPrefix, sitePath), siteLine)
+			if enclosing == nil || enclosing.ID == n.ID {
+				continue // unattributable, or the declaration's own identifier
+			}
+			key := enclosing.ID + "\x00" + n.ID
+			if minted[key] {
+				continue
+			}
+			// Cheap text guard: the site line must actually contain the
+			// target's whole name token, to defuse a stale position or a
+			// server bug before minting a compiler-grade edge.
+			if content := siteFileContent(siteSrc, absRoot, nodeRelPath(enclosing)); content != nil {
+				if _, found := identifierColumnStrict(content, siteLine, n.Name); !found {
+					continue
+				}
+			}
+			if existing := semantic.FindMatchingEdge(g, enclosing.ID, n.ID, graph.EdgeCalls); existing != nil {
+				if graph.OriginRank(existing.Origin) < graph.OriginRank(graph.OriginLSPResolved) {
+					semantic.ConfirmEdge(existing, p.Name())
+					existing.Origin = graph.OriginLSPResolved
+					semantic.PersistEdge(g, existing)
+					result.EdgesConfirmed++
+				}
+				minted[key] = true
+				continue
+			}
+			semantic.AddSemanticEdge(g, enclosing.ID, n.ID, graph.EdgeCalls,
+				enclosing.FilePath, siteLine, p.Name())
+			result.EdgesAdded++
+			minted[key] = true
+		}
+		rmu.Unlock()
+	}
+}
+
+// selectReferencesAddTargets returns the function / method nodes to query,
+// ordered dispatch-anchors-first: interface / trait members (tier 2), then
+// abstract-marked methods (tier 1), then plain methods (tier 0); within a
+// tier by descending fan-in so a deadline is spent on the most-referenced
+// declarations first.
+func selectReferencesAddTargets(g graph.Store, langNodes []*graph.Node) []*graph.Node {
+	// Interface / trait type names in the repo — a method whose receiver is
+	// one of these is a dispatch anchor the reference set fans out across.
+	dispatchOwners := map[string]bool{}
+	for _, n := range langNodes {
+		switch {
+		case n.Kind == graph.KindInterface:
+			dispatchOwners[n.Name] = true
+		case n.Kind == graph.KindType && isTraitNode(n):
+			dispatchOwners[n.Name] = true
+		}
+	}
+
+	type scored struct {
+		n     *graph.Node
+		tier  int
+		fanIn int
+	}
+	var cand []scored
+	ids := make([]string, 0, len(langNodes))
+	for _, n := range langNodes {
+		if n.Kind != graph.KindFunction && n.Kind != graph.KindMethod {
+			continue
+		}
+		tier := 0
+		if recv, _ := n.Meta["receiver"].(string); recv != "" && dispatchOwners[recv] {
+			tier = 2
+		} else if isAbstractMarked(n) {
+			tier = 1
+		}
+		cand = append(cand, scored{n: n, tier: tier})
+		ids = append(ids, n.ID)
+	}
+	if len(cand) == 0 {
+		return nil
+	}
+	// One batched store call for fan-in instead of a point lookup per node.
+	inEdges := g.GetInEdgesByNodeIDs(ids)
+	for i := range cand {
+		cand[i].fanIn = len(inEdges[cand[i].n.ID])
+	}
+	sort.SliceStable(cand, func(i, j int) bool {
+		if cand[i].tier != cand[j].tier {
+			return cand[i].tier > cand[j].tier
+		}
+		return cand[i].fanIn > cand[j].fanIn
+	})
+	out := make([]*graph.Node, len(cand))
+	for i := range cand {
+		out[i] = cand[i].n
+	}
+	return out
+}
+
+// isTraitNode reports whether a KindType node models a trait (PHP traits are
+// KindType with a trait flavor, unlike C#/Rust which use KindInterface).
+func isTraitNode(n *graph.Node) bool {
+	if n.Meta == nil {
+		return false
+	}
+	if k, _ := n.Meta["kind"].(string); k == "trait" {
+		return true
+	}
+	if tf, _ := n.Meta["type_flavor"].(string); tf == "trait" {
+		return true
+	}
+	return false
+}
+
+// isAbstractMarked reports whether a method node is an abstract / interface /
+// trait / virtual declaration, across the per-language marker keys the
+// extractors stamp (php abstract, csharp iface_member, rust trait_decl,
+// phpdoc virtual).
+func isAbstractMarked(n *graph.Node) bool {
+	if n.Meta == nil {
+		return false
+	}
+	if b, ok := n.Meta["abstract"].(bool); ok && b {
+		return true
+	}
+	if b, ok := n.Meta["iface_member"].(bool); ok && b {
+		return true
+	}
+	if s, ok := n.Meta["trait_decl"].(string); ok && s == "true" {
+		return true
+	}
+	if _, ok := n.Meta["virtual"]; ok {
+		return true
+	}
+	return false
+}
+
+// siteFileContent reads (and caches) a repo-relative site file for the
+// name-token guard. A read error caches nil so a missing file is not retried.
+func siteFileContent(cache map[string][]byte, absRoot, rel string) []byte {
+	if rel == "" {
+		return nil
+	}
+	if c, ok := cache[rel]; ok {
+		return c
+	}
+	c, err := os.ReadFile(filepath.Join(absRoot, rel))
+	if err != nil {
+		cache[rel] = nil
+		return nil
+	}
+	cache[rel] = c
+	return c
+}

--- a/internal/semantic/lsp/references_add_test.go
+++ b/internal/semantic/lsp/references_add_test.go
@@ -100,6 +100,66 @@ func TestLSP_Provider_ReferencesAddPass_AddsCallEdges(t *testing.T) {
 	}
 }
 
+// Two reference sites from one caller collapse to a single minted edge whose
+// extra site is recorded in call_sites (so find_usages still renders both).
+func TestLSP_Provider_ReferencesAddPass_RecordsMultipleSites(t *testing.T) {
+	repoRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repoRoot, "handler.php"),
+		[]byte("<?php\ninterface HandlerInterface {\n    public function handle(array $record): bool;\n}\n"),
+		0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repoRoot, "app.php"),
+		[]byte("<?php\nfunction run(HandlerInterface $h): void {\n    $h->handle([]);\n    $h->handle([]);\n}\n"),
+		0o644,
+	))
+
+	// Two call sites inside run(): 0-based lines 2 and 3 (1-based 3 and 4).
+	server := newFakeLSPServer()
+	server.handle("textDocument/hover", func(params json.RawMessage) (any, *jsonRPCError) { return nil, nil })
+	server.handle("textDocument/references", func(params json.RawMessage) (any, *jsonRPCError) {
+		return []Location{
+			{URI: pathToURI(filepath.Join(repoRoot, "app.php")), Range: Range{Start: Position{Line: 2, Character: 8}}},
+			{URI: pathToURI(filepath.Join(repoRoot, "app.php")), Range: Range{Start: Position{Line: 3, Character: 8}}},
+		}, nil
+	})
+
+	p, cleanup := providerWithFakeServer(t, server, []string{"php"})
+	defer cleanup()
+	p.caps = ServerCapabilities{ReferencesProvider: true, HoverProvider: true}
+
+	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID: "handler.php::HandlerInterface", Kind: graph.KindInterface, Name: "HandlerInterface",
+		FilePath: "handler.php", StartLine: 2, EndLine: 4, Language: "php",
+	})
+	g.AddNode(&graph.Node{
+		ID: "handler.php::HandlerInterface.handle", Kind: graph.KindMethod, Name: "handle",
+		FilePath: "handler.php", StartLine: 3, EndLine: 3, Language: "php",
+		Meta: map[string]any{"receiver": "HandlerInterface"},
+	})
+	g.AddNode(&graph.Node{
+		ID: "app.php::run", Kind: graph.KindFunction, Name: "run",
+		FilePath: "app.php", StartLine: 2, EndLine: 5, Language: "php",
+	})
+
+	result, err := p.Enrich(g, repoRoot)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.EdgesAdded, "the two sites collapse to one edge")
+
+	var edge *graph.Edge
+	for _, e := range g.GetOutEdges("app.php::run") {
+		if e.Kind == graph.EdgeCalls && e.To == "handler.php::HandlerInterface.handle" {
+			edge = e
+			break
+		}
+	}
+	require.NotNil(t, edge)
+	assert.Equal(t, 3, edge.Line, "the first site is the primary")
+	assert.Equal(t, []string{"app.php:4"}, graph.CallSites(edge), "the second site is recorded in call_sites")
+}
+
 // When the server advertises call hierarchy, the references-add pass must NOT
 // run (call hierarchy is the richer add path) — the gate must be exclusive.
 func TestLSP_Provider_ReferencesAddPass_SkippedWhenCallHierarchyPresent(t *testing.T) {

--- a/internal/semantic/lsp/references_add_test.go
+++ b/internal/semantic/lsp/references_add_test.go
@@ -1,0 +1,139 @@
+package lsp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/semantic"
+)
+
+// A references-capable server with no call hierarchy (intelephense-shaped)
+// must ADD call edges via textDocument/references, attributing each site to
+// its enclosing caller and stamping the call-site line at the lsp tier. This
+// is the load-bearing fix: without it such a server confirms existing edges
+// but never adds the dispatch call sites it can enumerate (edges_added 0).
+func TestLSP_Provider_ReferencesAddPass_AddsCallEdges(t *testing.T) {
+	repoRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repoRoot, "handler.php"),
+		[]byte("<?php\ninterface HandlerInterface {\n    public function handle(array $record): bool;\n}\n"),
+		0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repoRoot, "app.php"),
+		[]byte("<?php\nfunction run(HandlerInterface $h): void {\n    $h->handle([]);\n}\n"),
+		0o644,
+	))
+
+	// The server reports the call site inside run() (0-based line 2 == 1-based 3).
+	callSite := Location{
+		URI:   pathToURI(filepath.Join(repoRoot, "app.php")),
+		Range: Range{Start: Position{Line: 2, Character: 8}, End: Position{Line: 2, Character: 14}},
+	}
+
+	server := newFakeLSPServer()
+	server.handle("textDocument/hover", func(params json.RawMessage) (any, *jsonRPCError) { return nil, nil })
+	server.handle("textDocument/references", func(params json.RawMessage) (any, *jsonRPCError) {
+		return []Location{callSite}, nil
+	})
+
+	p, cleanup := providerWithFakeServer(t, server, []string{"php"})
+	defer cleanup()
+	// References-only server: no call hierarchy → the references-add pass runs.
+	p.caps = ServerCapabilities{ReferencesProvider: true, HoverProvider: true}
+
+	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID: "handler.php::HandlerInterface", Kind: graph.KindInterface, Name: "HandlerInterface",
+		FilePath: "handler.php", StartLine: 2, EndLine: 4, Language: "php",
+	})
+	g.AddNode(&graph.Node{
+		ID: "handler.php::HandlerInterface.handle", Kind: graph.KindMethod, Name: "handle",
+		FilePath: "handler.php", StartLine: 3, EndLine: 3, Language: "php",
+		Meta: map[string]any{"receiver": "HandlerInterface"},
+	})
+	g.AddNode(&graph.Node{
+		ID: "app.php::run", Kind: graph.KindFunction, Name: "run",
+		FilePath: "app.php", StartLine: 2, EndLine: 4, Language: "php",
+	})
+
+	var result *semantic.EnrichResult
+	done := make(chan error, 1)
+	go func() {
+		r, err := p.Enrich(g, repoRoot)
+		result = r
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Enrich timed out")
+	}
+
+	require.NotNil(t, result)
+	assert.True(t, result.ReferencesAddPass, "references-add pass should be marked in the enrich report")
+	assert.GreaterOrEqual(t, result.EdgesAdded, 1, "at least the run→handle edge must be added")
+
+	var added *graph.Edge
+	for _, e := range g.GetOutEdges("app.php::run") {
+		if e.Kind == graph.EdgeCalls && e.To == "handler.php::HandlerInterface.handle" {
+			added = e
+			break
+		}
+	}
+	require.NotNil(t, added, "expected added EdgeCalls run→HandlerInterface.handle from references")
+	assert.Equal(t, graph.OriginLSPResolved, added.Origin, "references-add edges are lsp_resolved")
+	assert.Equal(t, "app.php", added.FilePath, "edge anchored in the caller's file")
+	assert.Equal(t, 3, added.Line, "stamped at the call-site line, not the declaration")
+
+	// The caller's own reference must not mint a self-call edge.
+	for _, e := range g.GetOutEdges("app.php::run") {
+		assert.NotEqual(t, "app.php::run", e.To, "no self-call edge from the reference to run itself")
+	}
+}
+
+// When the server advertises call hierarchy, the references-add pass must NOT
+// run (call hierarchy is the richer add path) — the gate must be exclusive.
+func TestLSP_Provider_ReferencesAddPass_SkippedWhenCallHierarchyPresent(t *testing.T) {
+	repoRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repoRoot, "a.php"),
+		[]byte("<?php\nfunction f(): void {}\n"),
+		0o644,
+	))
+
+	server := newFakeLSPServer()
+	server.handle("textDocument/hover", func(params json.RawMessage) (any, *jsonRPCError) { return nil, nil })
+	server.handle("textDocument/prepareCallHierarchy", func(params json.RawMessage) (any, *jsonRPCError) {
+		return []CallHierarchyItem{}, nil
+	})
+	referencesCalled := false
+	server.handle("textDocument/references", func(params json.RawMessage) (any, *jsonRPCError) {
+		referencesCalled = true
+		return []Location{}, nil
+	})
+
+	p, cleanup := providerWithFakeServer(t, server, []string{"php"})
+	defer cleanup()
+	p.caps = ServerCapabilities{ReferencesProvider: true, CallHierarchyProvider: true, HoverProvider: true}
+
+	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID: "a.php::f", Kind: graph.KindFunction, Name: "f",
+		FilePath: "a.php", StartLine: 2, EndLine: 2, Language: "php",
+	})
+
+	result, err := p.Enrich(g, repoRoot)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.False(t, result.ReferencesAddPass, "references-add pass must not run when call hierarchy is available")
+	assert.False(t, referencesCalled, "references must not be queried by the add pass when call hierarchy is present")
+}

--- a/internal/semantic/lsp/registry.go
+++ b/internal/semantic/lsp/registry.go
@@ -130,6 +130,18 @@ func (c *ConnectSpec) Validate() error {
 type ServerAlt struct {
 	Command string
 	Args    []string
+	// InitializationOptions overrides the spec-level InitializationOptions
+	// when this alternative wins on PATH. The spec-level blob is keyed to
+	// the primary command, so an alternative from a different vendor
+	// (e.g. intelephense standing in for phpactor) can carry its own
+	// options. Empty means "inherit the spec's InitializationOptions".
+	InitializationOptions json.RawMessage `json:"initializationOptions,omitempty"`
+	// InitOptionsFunc, when non-nil, is consulted at initialize time with
+	// the resolved workspace root so an alternative can root a per-repo
+	// cache path inside Gortex's cache home — a path only known at resolve
+	// time, not as a baked literal. It wins over InitializationOptions when
+	// it returns a non-empty result.
+	InitOptionsFunc func(repoRoot string) json.RawMessage `json:"-"`
 }
 
 // Servers is the canonical list of LSP servers Gortex knows how to
@@ -435,8 +447,10 @@ var Servers = []ServerSpec{
 		Daemon:      true,
 		MaxParallel: 6,
 		AlternativeCommands: []ServerAlt{
-			// intelephense ships as a Node CLI.
-			{Command: "intelephense", Args: []string{"--stdio"}},
+			// intelephense ships as a Node CLI. Pin its index cache under
+			// Gortex's cache home per repo so it doesn't write to its
+			// default global location outside the engine's isolation.
+			{Command: "intelephense", Args: []string{"--stdio"}, InitOptionsFunc: intelephenseInitOptions},
 		},
 	},
 	{

--- a/internal/semantic/manager.go
+++ b/internal/semantic/manager.go
@@ -468,6 +468,7 @@ func (m *Manager) setEnrichStatus(repo, provider, lang, state string, deadline t
 			result.BoundReason = enrichBoundReason(state, result)
 		}
 		st.BoundReason = result.BoundReason
+		st.ReferencesAddPass = result.ReferencesAddPass
 	}
 	m.mu.Lock()
 	m.enrichStatus[repo+"\x00"+provider] = st

--- a/internal/semantic/provider.go
+++ b/internal/semantic/provider.go
@@ -82,6 +82,11 @@ type EnrichResult struct {
 	// finished but some targets were skipped, e.g. no source position or an
 	// unservable file), or "completed_all" (every target visited).
 	BoundReason string `json:"bound_reason,omitempty"`
+	// ReferencesAddPass reports that the enrich pass added edges via
+	// textDocument/references (rather than call hierarchy) because the
+	// server advertised references but no call hierarchy — e.g. intelephense.
+	// Lets index_health distinguish this add mode from the hierarchy mode.
+	ReferencesAddPass bool `json:"references_add_pass,omitempty"`
 }
 
 // Bounding reasons for the enrichment add-phase (EnrichResult.BoundReason /
@@ -124,7 +129,11 @@ type EnrichmentStatus struct {
 	SymbolsCovered  int     `json:"symbols_covered"`
 	CoveragePercent float64 `json:"coverage_percent"`
 	BoundReason     string  `json:"bound_reason,omitempty"`
-	Detail          string  `json:"detail,omitempty"`
+	// ReferencesAddPass marks that this provider added edges via
+	// textDocument/references (no call hierarchy) — the intelephense-style
+	// add mode. Distinguishes it from the call-hierarchy add mode.
+	ReferencesAddPass bool   `json:"references_add_pass,omitempty"`
+	Detail            string `json:"detail,omitempty"`
 }
 
 // ProviderStatus represents the current state of a semantic provider.


### PR DESCRIPTION
Lifts PHP `find_usages` recall from near-zero on OOP-heavy libraries (monolog-shaped: `handle`/`format`/`write` dispatch across dozens of handlers) while preserving the existing precision guard. The dispatch surface is maximally ambiguous by design, so the graph's edges were *right* but there were almost none of them; this closes the recall gap on two independent fronts — the LSP enrichment path and the in-engine resolver — plus the supporting node/model fixes.

## LSP enrichment

- **Pin intelephense's index cache** (`9535a874`). `ServerAlt` can now carry `InitializationOptions` (static or a resolve-time `InitOptionsFunc(repoRoot)`), threaded through `NewProviderFromSpec` to the `initialize` request. When intelephense stands in for an absent phpactor, its `storagePath`/`globalStoragePath` are rooted under the gortex cache home per repo (honoring XDG) instead of intelephense's default global location.
- **Add call edges via references when call hierarchy is absent** (`86727bb4`) — the load-bearing fix. intelephense advertises `textDocument/references` but no call hierarchy, so enrichment previously only *confirmed* existing edges (`edges_added` stuck at 0). A references-driven add pass now queries references per declaration, attributes each in-repo site to its enclosing caller, and mints an `lsp_resolved` `EdgeCalls` at the call site. Provider-generic (any references-capable, call-hierarchy-absent server benefits), dispatch-anchors-first ordering under the existing deadline budget, with a `references_add_pass` marker on the enrichment report.

## In-engine resolver

- **Bind ambiguous PHP dispatch calls via the class hierarchy** (`df171475`). `parent::`/`self::` calls walk the enclosing class's extends chain to the nearest declaring type (precise single bind — `parent::__construct` now resolves through a multi-level chain); plain member calls whose same-name candidates form an override family related through a common interface / abstract base / used trait fan out to every implementation. Edges land at `ast_inferred` (visible in default `find_usages`), and the relatedness gate keeps precision high by leaving unrelated same-name methods ambiguous. The PHP extractor now records `implements` / interface-`extends` (`scope_interfaces`) so the ancestor closure spans implements + extends + trait use.
- **Mint phpdoc `@method` virtuals and mark `__call` classes** (`f7e3e9d9`). Docblock `@method` tags (magic accessors, mixins) get a `KindMethod` node so their ids resolve and calls bind; classes declaring `__call`/`__callStatic` are stamped `has_magic_call`.

## Cross-cutting model fixes

- **Preserve call-site multiplicity** (`072b3a22`). A synthesized producer that mints one edge per (from,to) records extra sites in `Edge.Meta[call_sites]`; `find_usages` expands them into one row per site, deduped against any real per-line edge. Meta-only (no `Edge` struct / wire change); survives a warm restart. AST extractors already key per call site, so their multiplicity is untouched.
- **Distinguish tier-filtered from no-usages** (`f1f671c8`). A `min_tier` that emptied the result was indistinguishable from dead code (and even attached a `likely_unused` caveat). `FilterByMinTier` now records a `tier_filtered` caveat `{class, edges_below_min_tier, max_available_tier}` that takes precedence over the zero-edge classification; `index_health` gains a per-language `lsp_resolved` edge rollup.
- **Bodyless interface/trait method nodes** (`50328900`, `7f65ffb1`) — regression tests pinning that the C# and Rust extractors mint `<file>::<Iface|Trait>.<name>` `KindMethod` nodes for bodyless signatures (parity with PHP's `extractMethod`).

## Verification

Per commit: `go build ./cmd/gortex/` + `go test -race` on the touched packages, golangci-lint, and the cmd/gortex golden. Rebased onto current `main`; post-rebase the full repo builds and 6099 `-race` tests across the eight touched packages pass, lint clean.