### PR TITLE
Resolve hook/MCP to the same binary; add find_usages completeness cues; cross-link nav tools

### DIFF
--- a/internal/agents/claudecode/hooks.go
+++ b/internal/agents/claudecode/hooks.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -82,23 +81,27 @@ func hookCommandWithMode(base, mode string) string {
 }
 
 // ResolveHookCommand returns the shell command to bake into Claude
-// Code's hook config. It prefers the `gortex` binary on PATH so
-// installers (brew, `go install`) get a stable absolute path; falls
-// back to bare "gortex hook" when no installed binary is found.
+// Code's hook config. It routes through agents.ResolveGortexHookBinary,
+// which shares the same same-file decision core as the MCP server
+// stanza (agents.ResolveGortexCommand): the hook and the MCP stanza
+// must resolve to the same binary file whenever the running binary is
+// usable, so a side-by-side install can never point the hook at a
+// different daemon than the one serving the session's graph tools. The
+// hook keeps an absolute-path preference (it avoids PATH-at-fire-time
+// fragility); it falls back to bare "gortex hook" only when no stable
+// binary is resolvable at all.
 //
-// A warning is written to w because the fallback relies on PATH
-// resolution at hook-fire time — fragile when the user's shell
+// A warning is written to w on the bare fallback because it relies on
+// PATH resolution at hook-fire time — fragile when the user's shell
 // environment differs between Claude Code and a terminal.
 func ResolveHookCommand(w io.Writer) string {
-	if path, err := exec.LookPath("gortex"); err == nil {
-		return shellSafeHookBinary(path) + " hook"
-	}
-	if w != nil {
+	bin := agents.ResolveGortexHookBinary()
+	if bin == "gortex" && w != nil {
 		fmt.Fprintln(w,
 			"[gortex init] warning: `gortex` not found on PATH; "+
 				"writing bare \"gortex hook\" into settings — install gortex to PATH for a stable hook command")
 	}
-	return "gortex hook"
+	return shellSafeHookBinary(bin) + " hook"
 }
 
 // shellSafeHookBinary normalizes a resolved binary path into a form

--- a/internal/agents/claudecode/hooks_test.go
+++ b/internal/agents/claudecode/hooks_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -158,6 +159,31 @@ func TestResolveHookCommand(t *testing.T) {
 		got := ResolveHookCommand(io.Discard)
 		assert.NotContains(t, got, "\\",
 			"baked hook command must use forward slashes — Git Bash on Windows mangles backslash paths")
+	})
+
+	t.Run("agreesWithMCPStanzaBinary", func(t *testing.T) {
+		// The hook command and the MCP server stanza must launch the same
+		// gortex binary; a side-by-side install must never split them
+		// across two daemons. With a gortex on PATH the hook pins the
+		// absolute path while the stanza collapses to the bare name — both
+		// resolve to the same file.
+		dir := t.TempDir()
+		fake := filepath.Join(dir, "gortex")
+		require.NoError(t, os.WriteFile(fake, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+		t.Setenv("PATH", dir)
+
+		hookBin := strings.TrimSuffix(ResolveHookCommand(io.Discard), " hook")
+		mcpCmd := agents.ResolveGortexCommand()
+		// Map the bare name to the PATH gortex it launches, then compare
+		// the concrete on-disk binaries.
+		launched := func(cmd string) string {
+			if cmd == "gortex" {
+				return fake
+			}
+			return cmd
+		}
+		assert.Equal(t, launched(mcpCmd), launched(hookBin),
+			"hook command and MCP stanza must resolve to the same gortex binary")
 	})
 }
 

--- a/internal/agents/mcp.go
+++ b/internal/agents/mcp.go
@@ -173,6 +173,57 @@ func resolveGortexCommandFrom(exe string, exeErr error, lookPath string, lookErr
 	return "gortex"
 }
 
+// ResolveGortexHookBinary returns the gortex binary reference a Claude
+// Code hook command should embed. It shares ResolveGortexCommand's
+// same-file decision core so the hook process and the MCP server/daemon
+// never resolve to different binaries — a side-by-side install (CI
+// sandbox, a downloaded release run before linking, a dev build) would
+// otherwise bake the running binary into the MCP stanza but a stray
+// PATH gortex into the hook, and the hook could then consult a
+// different daemon than the one serving the session's graph tools.
+//
+// It differs from ResolveGortexCommand only in output preference: a
+// hook fires in a shell whose PATH may not match install time, so it
+// pins an absolute path whenever the running binary is usable rather
+// than the bare name. The returned value is a bare binary reference
+// with no subcommand — callers append " hook" (and any --mode suffix).
+func ResolveGortexHookBinary() string {
+	exe, exeErr := os.Executable()
+	lp, lpErr := exec.LookPath("gortex")
+	return resolveGortexHookBinaryFrom(exe, exeErr, lp, lpErr, sameFile)
+}
+
+// resolveGortexHookBinaryFrom is the pure decision core of
+// ResolveGortexHookBinary, split out so the PATH/executable inputs can
+// be injected in tests. It resolves to the same on-disk binary as
+// resolveGortexCommandFrom in every case where the running binary is
+// usable (both pin the running exe, or the bare name that PATH resolves
+// back to it); it only prefers an absolute path over the bare name.
+//
+// The ephemeral guard is deliberately on the running binary alone
+// (exeUsable's !isUnderTempDir(exe)): a `go run` transient build must
+// never be baked into a long-lived hook, so we fall back to the PATH
+// gortex — the same file the MCP stanza collapses to — instead. A
+// PATH lookup that itself points into a temp dir is the user's own
+// PATH and is left to resolve, matching resolveGortexCommandFrom.
+func resolveGortexHookBinaryFrom(exe string, exeErr error, lookPath string, lookErr error, same func(a, b string) bool) string {
+	exeUsable := exeErr == nil && exe != "" && gortexCommandBase(exe) == "gortex" && !isUnderTempDir(exe)
+	if exeUsable {
+		// The running binary is a stable, non-ephemeral gortex: pin it.
+		// This is the same file the MCP stanza launches — whether that
+		// stanza used the bare name (PATH gortex IS this binary) or the
+		// absolute exe (off-PATH, or a different gortex on PATH).
+		return exe
+	}
+	if lookErr == nil && lookPath != "" {
+		// Running binary isn't a bakeable path (go run temp build,
+		// unstattable, or not named gortex). Fall back to PATH's gortex
+		// — the file the MCP stanza collapses to — as an absolute path.
+		return lookPath
+	}
+	return "gortex"
+}
+
 // isUnderTempDir reports whether p lives under the OS temp directory —
 // the tell-tale of a `go run` / `go test` transient build that must not
 // be baked into a long-lived config.

--- a/internal/agents/mcp_test.go
+++ b/internal/agents/mcp_test.go
@@ -275,3 +275,84 @@ func TestResolveGortexCommandFrom(t *testing.T) {
 		})
 	}
 }
+
+// TestResolveGortexHookBinaryFrom mirrors TestResolveGortexCommandFrom's
+// table for the hook resolver, and additionally asserts the load-bearing
+// invariant: the hook binary and the MCP stanza launch the SAME on-disk
+// file in every case. The hook only prefers an absolute path over the
+// bare name (it fires in a shell whose PATH may differ from install
+// time); it must never point at a different gortex than the MCP server.
+func TestResolveGortexHookBinaryFrom(t *testing.T) {
+	sameTrue := func(a, b string) bool { return true }
+	sameFalse := func(a, b string) bool { return false }
+	notFound := errors.New("executable file not found in $PATH")
+
+	cases := []struct {
+		name     string
+		exe      string
+		exeErr   error
+		lookPath string
+		lookErr  error
+		same     func(a, b string) bool
+		want     string
+	}{
+		{
+			name:     "on PATH and same binary -> pin absolute (hook avoids PATH at fire time)",
+			exe:      "/usr/local/bin/gortex",
+			lookPath: "/usr/local/bin/gortex",
+			same:     sameTrue,
+			want:     "/usr/local/bin/gortex",
+		},
+		{
+			name:     "installed but not on PATH -> pin absolute path",
+			exe:      `C:\Users\daoti\AppData\Local\Programs\gortex\gortex.exe`,
+			lookPath: "",
+			lookErr:  notFound,
+			same:     sameFalse,
+			want:     `C:\Users\daoti\AppData\Local\Programs\gortex\gortex.exe`,
+		},
+		{
+			name:     "on PATH but a different gortex -> pin the running binary, not the PATH one",
+			exe:      "/opt/build/gortex",
+			lookPath: "/usr/local/bin/gortex",
+			same:     sameFalse,
+			want:     "/opt/build/gortex",
+		},
+		{
+			name:     "go run transient temp build + gortex on PATH -> PATH gortex, never the temp build",
+			exe:      filepath.Join(os.TempDir(), "go-build1234", "agents.test"),
+			lookPath: "/usr/local/bin/gortex",
+			same:     sameFalse,
+			want:     "/usr/local/bin/gortex",
+		},
+		{
+			name:    "nothing resolvable -> bare gortex last resort",
+			exe:     "",
+			exeErr:  errors.New("os.Executable failed"),
+			lookErr: notFound,
+			same:    sameFalse,
+			want:    "gortex",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveGortexHookBinaryFrom(tc.exe, tc.exeErr, tc.lookPath, tc.lookErr, tc.same)
+			if got != tc.want {
+				t.Errorf("resolveGortexHookBinaryFrom() = %q, want %q", got, tc.want)
+			}
+			// Map each resolver output to the concrete file it launches:
+			// an absolute path is itself; the bare name resolves via PATH
+			// to lookPath. The two must never disagree.
+			launched := func(resolved string) string {
+				if resolved == "gortex" {
+					return tc.lookPath
+				}
+				return resolved
+			}
+			mcp := resolveGortexCommandFrom(tc.exe, tc.exeErr, tc.lookPath, tc.lookErr, tc.same)
+			if hf, mf := launched(got), launched(mcp); hf != mf {
+				t.Errorf("hook/MCP disagree on binary file: hook %q -> %q, mcp %q -> %q", got, hf, mcp, mf)
+			}
+		})
+	}
+}

--- a/internal/mcp/find_usages_summary_test.go
+++ b/internal/mcp/find_usages_summary_test.go
@@ -1,0 +1,103 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/query"
+	"github.com/zzet/gortex/internal/search"
+)
+
+// usagesSummaryServer builds a server whose graph references `Foo` from
+// four call sites across three files — two in pkg/a.go, one in pkg/b.go,
+// and one in a *_test.go caller flagged is_test — plus an unreferenced
+// symbol. So a complete find_usages over Foo must report n_refs=4,
+// n_files=3, n_test_refs=1, and the unreferenced symbol must carry no
+// summary at all.
+func usagesSummaryServer(t *testing.T) (srv *Server, fooID, unusedID string) {
+	t.Helper()
+	g := graph.New()
+	foo := &graph.Node{ID: "pkg/foo.go::Foo", Kind: graph.KindFunction, Name: "Foo", FilePath: "pkg/foo.go", StartLine: 1}
+	unused := &graph.Node{ID: "pkg/foo.go::Unused", Kind: graph.KindFunction, Name: "Unused", FilePath: "pkg/foo.go", StartLine: 20}
+	use1 := &graph.Node{ID: "pkg/a.go::Use1", Kind: graph.KindFunction, Name: "Use1", FilePath: "pkg/a.go", StartLine: 3}
+	use2 := &graph.Node{ID: "pkg/a.go::Use2", Kind: graph.KindFunction, Name: "Use2", FilePath: "pkg/a.go", StartLine: 8}
+	use3 := &graph.Node{ID: "pkg/b.go::Use3", Kind: graph.KindFunction, Name: "Use3", FilePath: "pkg/b.go", StartLine: 5}
+	testUse := &graph.Node{
+		ID: "pkg/foo_test.go::TestUse", Kind: graph.KindFunction, Name: "TestUse",
+		FilePath: "pkg/foo_test.go", StartLine: 12, Meta: map[string]any{"is_test": true},
+	}
+	for _, n := range []*graph.Node{foo, unused, use1, use2, use3, testUse} {
+		g.AddNode(n)
+	}
+	g.AddEdge(&graph.Edge{From: use1.ID, To: foo.ID, Kind: graph.EdgeCalls, FilePath: "pkg/a.go", Line: 3})
+	g.AddEdge(&graph.Edge{From: use2.ID, To: foo.ID, Kind: graph.EdgeCalls, FilePath: "pkg/a.go", Line: 8})
+	g.AddEdge(&graph.Edge{From: use3.ID, To: foo.ID, Kind: graph.EdgeCalls, FilePath: "pkg/b.go", Line: 5})
+	g.AddEdge(&graph.Edge{From: testUse.ID, To: foo.ID, Kind: graph.EdgeCalls, FilePath: "pkg/foo_test.go", Line: 12})
+
+	eng := query.NewEngine(g)
+	eng.SetSearch(search.NewBM25())
+	return NewServer(eng, g, nil, nil, zap.NewNop(), nil), foo.ID, unused.ID
+}
+
+func findUsagesText(t *testing.T, srv *Server, args map[string]any) string {
+	t.Helper()
+	req := mcplib.CallToolRequest{}
+	req.Params.Name = "find_usages"
+	req.Params.Arguments = args
+	res, err := srv.handleFindUsages(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	return res.Content[0].(mcplib.TextContent).Text
+}
+
+// TestFindUsages_SummaryJSON pins the completeness rollup on the plain
+// JSON path: the split (refs / files / test refs) an agent needs to know
+// the usage list already covers tests.
+func TestFindUsages_SummaryJSON(t *testing.T) {
+	srv, fooID, unusedID := usagesSummaryServer(t)
+
+	var resp struct {
+		UsageSummary *query.UsageSummary `json:"usage_summary"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(findUsagesText(t, srv, map[string]any{"id": fooID})), &resp))
+	require.NotNil(t, resp.UsageSummary, "usage_summary must be present for a referenced symbol")
+	require.Equal(t, 4, resp.UsageSummary.NRefs, "n_refs")
+	require.Equal(t, 3, resp.UsageSummary.NFiles, "n_files")
+	require.Equal(t, 1, resp.UsageSummary.NTestRefs, "n_test_refs")
+
+	// A symbol with no usages carries the zero-edge caveat, not an
+	// all-zero summary — the summary must be omitted entirely.
+	var empty map[string]any
+	require.NoError(t, json.Unmarshal([]byte(findUsagesText(t, srv, map[string]any{"id": unusedID})), &empty))
+	_, has := empty["usage_summary"]
+	require.False(t, has, "usage_summary must be omitted for a symbol with no usages")
+}
+
+// TestFindUsages_SummaryGCX pins the rollup on the GCX wire path: the
+// three counts ride in the response meta.
+func TestFindUsages_SummaryGCX(t *testing.T) {
+	srv, fooID, _ := usagesSummaryServer(t)
+	out := findUsagesText(t, srv, map[string]any{"id": fooID, "format": "gcx"})
+	require.Contains(t, out, "n_refs=4")
+	require.Contains(t, out, "n_files=3")
+	require.Contains(t, out, "n_test_refs=1")
+}
+
+// TestFindUsages_SummaryTOON pins the rollup on the TOON wire path.
+func TestFindUsages_SummaryTOON(t *testing.T) {
+	srv, fooID, _ := usagesSummaryServer(t)
+	out := findUsagesText(t, srv, map[string]any{"id": fooID, "format": "toon"})
+	require.Contains(t, out, "usage_summary")
+	require.Contains(t, out, "n_refs")
+	require.Contains(t, out, "n_test_refs")
+	// The tabular edge section must still be present alongside the rollup.
+	require.True(t, strings.Contains(out, "edges") || strings.Contains(out, "nodes"),
+		"TOON must retain the subgraph body, not just the summary")
+}

--- a/internal/mcp/gcx.go
+++ b/internal/mcp/gcx.go
@@ -411,6 +411,17 @@ func encodeFindUsages(sg *query.SubGraph, g graph.Store) ([]byte, error) {
 	if sg.SuppressionCaveat != "" {
 		meta = append(meta, "suppression_caveat", sg.SuppressionCaveat)
 	}
+	if s := sg.UsageSummary; s != nil {
+		// Completeness rollup, same three numbers as the JSON / TOON
+		// usage_summary so an agent reads the split without re-grepping
+		// tests. n_refs mirrors edges above; both are kept so the summary
+		// is self-contained across wire formats.
+		meta = append(meta,
+			"n_refs", fmt.Sprintf("%d", s.NRefs),
+			"n_files", fmt.Sprintf("%d", s.NFiles),
+			"n_test_refs", fmt.Sprintf("%d", s.NTestRefs),
+		)
+	}
 	enc := newGCX(&buf, "find_usages",
 		[]string{"from", "to", "edge_kind", "context", "return_usage", "origin", "tier", "confidence", "from_name", "from_path", "from_line", "from_is_test", "from_test_role", "from_test_runner", "from_type_flavor", "from_ui_component"},
 		meta...,

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -902,7 +902,7 @@ func (s *Server) registerCoreTools() {
 
 	s.addTool(
 		mcp.NewTool("search_symbols",
-			mcp.WithDescription("Use instead of Grep to find symbols across the whole codebase. Supports natural language queries with camelCase-aware tokenization and BM25 ranking — 'validate token auth' finds validateToken, AuthMiddleware, parseJWT."),
+			mcp.WithDescription("Use instead of Grep to find symbols across the whole codebase. Supports natural language queries with camelCase-aware tokenization and BM25 ranking — 'validate token auth' finds validateToken, AuthMiddleware, parseJWT. For the concrete types that implement an interface, or the methods that override a method, use find_implementations / find_overrides — a name search alone can't tell an implementor from an unrelated same-named symbol."),
 			mcp.WithString("query", mcp.Required(), mcp.Description("Search query — symbol name, concept, or keywords. Also accepts inline field-qualified clauses: `kind:function lang:go path:internal/ repo:gortex project:web validateToken` — recognised fields are kind, flavor, lang (aliases ts/js/py/rs/…), path, repo, project; everything else is free text. A field-qualified query that matches nothing retries on the free text alone (response carries `filters_relaxed: true`).")),
 			mcp.WithNumber("limit", mcp.Description("Max results (default: 20)")),
 			mcp.WithString("cursor", mcp.Description("Opaque pagination cursor returned in `next_cursor` from a previous call. Pass it back to fetch the next page. Omit for the first page.")),
@@ -1011,7 +1011,7 @@ func (s *Server) registerCoreTools() {
 
 	s.addTool(
 		mcp.NewTool("get_callers",
-			mcp.WithDescription("Returns all callers of a function without reading source. Use instead of Grep when you need to know who calls a function."),
+			mcp.WithDescription("Returns all callers of a function without reading source. Use instead of Grep when you need to know who calls a function. For every reference — not just call sites, but type uses, field access, and imports — use find_usages."),
 			mcp.WithString("id", mcp.Required(), mcp.Description("Function node ID")),
 			mcp.WithNumber("depth", mcp.Description("Traversal depth (default: 2)")),
 			mcp.WithNumber("limit", mcp.Description("Max nodes (default: 50)")),
@@ -1032,7 +1032,7 @@ func (s *Server) registerCoreTools() {
 
 	s.addTool(
 		mcp.NewTool("find_implementations",
-			mcp.WithDescription("Finds all concrete types that implement an interface. Use before changing an interface to identify all types that will be affected."),
+			mcp.WithDescription("Finds all concrete types that implement an interface — 'what implements X', interface satisfaction, which structs satisfy this contract. Use before changing an interface to identify all types that will be affected. For method-level overrides (which methods override this one, or the parents it overrides) use find_overrides."),
 			mcp.WithString("id", mcp.Required(), mcp.Description("Interface node ID")),
 			mcp.WithString("format", mcp.Description("Output format: json (default), gcx (GCX1 compact wire format), or toon")),
 			mcp.WithNumber("max_bytes", mcp.Description("Cap the marshaled response at this many bytes. The longest list is trimmed; truncation metadata rides on the response. Omit for no cap.")),
@@ -1087,7 +1087,7 @@ func (s *Server) registerCoreTools() {
 
 	s.addTool(
 		mcp.NewTool("find_usages",
-			mcp.WithDescription("Use instead of Grep to find every reference to a symbol across the codebase. Returns precise locations with zero false positives."),
+			mcp.WithDescription("Use instead of Grep to find every reference to a symbol across the codebase. Returns precise locations with zero false positives. For just the call sites of a function use get_callers; for the concrete types that implement an interface use find_implementations."),
 			mcp.WithString("id", mcp.Required(), mcp.Description("Node ID")),
 			mcp.WithNumber("limit", mcp.Description("Max nodes (default: 50)")),
 			mcp.WithBoolean("compact", mcp.Description("One-line-per-symbol text output (saves 50-70% tokens)")),

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -118,6 +118,7 @@ type toonSubGraphResult struct {
 	TextMatchedSuppressed int                   `toon:"text_matched_suppressed,omitempty"`
 	SuppressionCaveat     string                `toon:"suppression_caveat,omitempty"`
 	CallerNotes           []toonCallerNoteRow   `toon:"caller_notes,omitempty"`
+	UsageSummary          *query.UsageSummary   `toon:"usage_summary,omitempty"`
 }
 
 // toonSearchResult wraps search results for TOON tabular output.
@@ -342,6 +343,7 @@ func subGraphToTOON(sg *query.SubGraph) (*mcp.CallToolResult, error) {
 		TextMatchedSuppressed: sg.TextMatchedSuppressed,
 		SuppressionCaveat:     sg.SuppressionCaveat,
 		CallerNotes:           callerNotesToTOONRows(sg.CallerNotes),
+		UsageSummary:          sg.UsageSummary,
 	}
 	data, err := toon.Marshal(result)
 	if err != nil {
@@ -2492,6 +2494,11 @@ func (s *Server) handleFindUsages(ctx context.Context, req mcp.CallToolRequest) 
 		// classification when the emptiness was NOT caused by min_tier.
 		sg.Caveat = graph.CaveatForZeroEdge(s.graph, id)
 	}
+	// Completeness rollup (n_refs / n_files / n_test_refs) so an agent can
+	// tell at a glance whether the usage list already covers tests instead
+	// of re-grepping *_test.go files. Rides every wire format below; nil
+	// for an empty result (the Caveat above covers that case).
+	sg.UsageSummary = usageSummaryOf(sg)
 	// group_by:"file" buckets the usages by the file each reference
 	// originates in -- an opt-in shape for callers that want a
 	// per-file rollup. The flat SubGraph stays the default so
@@ -2777,6 +2784,45 @@ func groupUsagesByFile(sg *query.SubGraph) map[string]any {
 		"total_uses": len(sg.Edges),
 		"groups":     out,
 		"truncated":  sg.Truncated,
+	}
+}
+
+// usageSummaryOf computes the compact completeness rollup attached to a
+// find_usages response: the total reference count, the number of
+// distinct files those references live in, and how many originate in
+// test files. It reuses the exact per-node test classification
+// (nodeIsTest — the from_is_test column) and file resolution as the
+// per-usage rows, so the rollup never disagrees with the edges it
+// summarizes. Returns nil for an empty result — the zero-edge Caveat
+// already explains that case, and an all-zero summary would be noise.
+func usageSummaryOf(sg *query.SubGraph) *query.UsageSummary {
+	if sg == nil || len(sg.Edges) == 0 {
+		return nil
+	}
+	nodeByID := make(map[string]*graph.Node, len(sg.Nodes))
+	for _, n := range sg.Nodes {
+		nodeByID[n.ID] = n
+	}
+	files := make(map[string]struct{}, len(sg.Edges))
+	testRefs := 0
+	for _, e := range sg.Edges {
+		from := nodeByID[e.From]
+		file := e.FilePath
+		if file == "" && from != nil {
+			file = from.FilePath
+		}
+		if file == "" {
+			file = "(unknown)"
+		}
+		files[file] = struct{}{}
+		if nodeIsTest(from) {
+			testRefs++
+		}
+	}
+	return &query.UsageSummary{
+		NRefs:     len(sg.Edges),
+		NFiles:    len(files),
+		NTestRefs: testRefs,
 	}
 }
 

--- a/internal/query/subgraph.go
+++ b/internal/query/subgraph.go
@@ -78,6 +78,25 @@ type SubGraph struct {
 	// Boundaries names the unresolved/dispatch sites that made the result a
 	// floor. Populated only by call-graph traversals; omitted when empty.
 	Boundaries []graph.EpistemicBoundary `json:"boundaries,omitempty"`
+	// UsageSummary is a compact completeness rollup attached only by
+	// find_usages: the total reference count, the number of distinct
+	// files those references span, and the test-file share. Nil — and
+	// omitted — for every other traversal that shares this struct, and
+	// for an empty result (the Caveat already explains that case). Lets
+	// an agent see at a glance whether the usage list already covers
+	// tests instead of re-grepping *_test.go files to find out.
+	UsageSummary *UsageSummary `json:"usage_summary,omitempty"`
+}
+
+// UsageSummary is the compact completeness rollup on a find_usages
+// result: NRefs total references, spread across NFiles distinct files,
+// of which NTestRefs originate in test files. It is derived from the
+// same edges and per-node test classification as the per-usage rows, so
+// the rollup never disagrees with the references it summarizes.
+type UsageSummary struct {
+	NRefs     int `json:"n_refs" toon:"n_refs"`
+	NFiles    int `json:"n_files" toon:"n_files"`
+	NTestRefs int `json:"n_test_refs" toon:"n_test_refs"`
 }
 
 // QueryOptions controls traversal depth, result limits, and detail level.


### PR DESCRIPTION
## Summary

Three independent improvements to install-time binary consistency and navigation-tool ergonomics, surfaced while observing how a headless agent uses the graph.

### 1. Hook command and MCP stanza resolve to the same binary

`gortex install --agents=claude-code` resolved the Claude Code hook command via `exec.LookPath("gortex")` unconditionally, while the MCP server stanza pins the running binary (`os.Executable`) when it differs from PATH's gortex. A side-by-side install — a CI sandbox, a downloaded release run before linking, or a dev build — therefore baked one binary into `.claude.json` `mcpServers` but a different PATH gortex into `settings.local.json` hooks, so the hook could consult a **different daemon** than the one serving the session's graph tools.

Hook resolution now routes through a shared same-file decision core (`ResolveGortexHookBinary`, mirroring `ResolveGortexCommand`): the hook and the MCP stanza launch the same on-disk file whenever the running binary is usable. The hook keeps its absolute-path preference (it avoids PATH-at-fire-time fragility) and the existing guards — the go-run temp-build check, Windows backslash normalization, and `--mode` suffixing — are preserved.

### 2. `find_usages` carries a completeness rollup

Responses now include a compact `usage_summary` — `n_refs` (total references), `n_files` (distinct files they span), and `n_test_refs` (how many originate in tests) — reusing the existing per-node test classification behind the
`from_is_test` column, so the rollup never disagrees with the rows it summarizes. It rides all three wire formats (json / toon / gcx) with the same field names, and is omitted for an empty result (the zero-edge caveat already explains that). This lets an agent tell at a glance whether the usage list already covers tests instead of re-grepping `*_test.go` files.

### 3. Navigation tools cross-reference each other

Tool descriptions now point at each other so an agent discovers the right tool from `tools/list`: `search_symbols` → `find_implementations` / `find_overrides` for implementors and overrides; `find_implementations` gains the discovery phrasing an agent actually searches for ("what implements X", interface satisfaction) and points to `find_overrides`; `get_callers` ↔ `find_usages` for call-sites vs every reference. Description-only, no schema change.

## Verification

- `go build ./...` (CGO) and `go test -race` on `internal/agents`, `internal/agents/claudecode`, `internal/query`, `internal/mcp` — all green.
- golangci-lint: 0 issues on the touched packages.
- Wire-contract fingerprint golden: **unchanged** — `usage_summary` lives on `query.SubGraph`, which the snapshot fingerprint (Node/Edge/snapshot types) does not cover.
- `gortex agents render` drift golden: unchanged.
- End-to-end: installing an off-PATH binary while a *different* gortex is on PATH now bakes the same binary into both the hook command and the MCP stanza (previously they diverged).
