### PR TITLE
Fix live-reindex edge loss, enrichment scheduling, C# gates, and TS barrel usages

### DIFF
--- a/internal/graph/restub_provenance.go
+++ b/internal/graph/restub_provenance.go
@@ -48,14 +48,19 @@ func StashRestubProvenance(e *Edge) {
 // keys (whether or not it restored). A rebind to a different target, or a stub
 // that never rebound, keeps the honest fresh tier the resolver assigned (or
 // none). No-op when there is nothing stashed.
-func RestoreRestubProvenance(e *Edge) {
+//
+// Returns true when it actually re-applied the stashed provenance — the caller
+// uses that to persist the in-place mutation, since a disk backend hands out
+// freshly-decoded edge pointers whose changes are lost unless written back.
+func RestoreRestubProvenance(e *Edge) bool {
 	if e == nil || e.Meta == nil {
-		return
+		return false
 	}
 	prevTo, ok := e.Meta[metaRestubPrevTo]
 	if !ok {
-		return
+		return false
 	}
+	restored := false
 	if to, isStr := prevTo.(string); isStr && to == e.To && !IsUnresolvedTarget(e.To) {
 		if o, ok := e.Meta[metaRestubPrevOrigin].(string); ok {
 			e.Origin = o
@@ -66,9 +71,11 @@ func RestoreRestubProvenance(e *Edge) {
 		if c, ok := e.Meta[metaRestubPrevConf].(float64); ok {
 			e.Confidence = c
 		}
+		restored = true
 	}
 	delete(e.Meta, metaRestubPrevTo)
 	delete(e.Meta, metaRestubPrevOrigin)
 	delete(e.Meta, metaRestubPrevTier)
 	delete(e.Meta, metaRestubPrevConf)
+	return restored
 }

--- a/internal/indexer/incremental_resolve_revert_test.go
+++ b/internal/indexer/incremental_resolve_revert_test.go
@@ -1,0 +1,192 @@
+package indexer
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/search"
+)
+
+// newSqliteGraph opens a temp-file sqlite-backed graph store for a test.
+// A disk file (not :memory:) is required because the store pools
+// connections and an in-memory sqlite DB is per-connection.
+func newSqliteGraph(t *testing.T) graph.Store {
+	t.Helper()
+	st, err := store_sqlite.Open(filepath.Join(t.TempDir(), "graph.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+	return st
+}
+
+// incomingCallEdges returns the EdgeCalls edges currently bound INTO node id
+// (its resolved callers).
+func incomingCallEdges(t *testing.T, g graph.Store, id string) []*graph.Edge {
+	t.Helper()
+	var out []*graph.Edge
+	for _, e := range g.GetInEdges(id) {
+		if e != nil && e.Kind == graph.EdgeCalls {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// stampLSP marks an edge compiler-grade and persists it (the tier the
+// track-time semantic-enrichment pass mints once).
+func stampLSP(t *testing.T, g graph.Store, e *graph.Edge) {
+	t.Helper()
+	g.SetEdgeProvenance(e, graph.OriginLSPResolved)
+	e.Tier = graph.ResolvedBy(graph.OriginLSPResolved)
+	e.Confidence = 1.0
+	g.ReindexEdges([]graph.EdgeReindex{{Edge: e, OldTo: e.To}})
+}
+
+// TestIncrementalReindex_DoubleCycle_Sqlite_IntraFileCaller models the live
+// staleness-probe REVERT conditions the in-memory double-cycle test omits: a
+// sqlite backend (GetInEdges returns freshly-decoded edge pointers, so an
+// in-place provenance restore that is not persisted is lost) AND an appended
+// symbol that CALLS the target (an intra-file caller added on the ADD cycle and
+// removed on the REVERT cycle). After BOTH cycles the cross-file caller edge
+// must still resolve to the definition and keep its lsp_resolved provenance —
+// find_usages hides text_matched by default, so a demotion here reads as a
+// silent zero.
+func TestIncrementalReindex_DoubleCycle_Sqlite_IntraFileCaller(t *testing.T) {
+	dir := t.TempDir()
+	defPath := filepath.Join(dir, "debug.go")
+	callerPath := filepath.Join(dir, "caller.go")
+	writeFile(t, defPath, "package p\n\nfunc Foo() {}\n")
+	writeFile(t, callerPath, "package p\n\nfunc Bar() { Foo() }\n")
+
+	g := newSqliteGraph(t)
+	idx := New(g, newTestRegistry(), config.IndexConfig{Workers: 1}, zap.NewNop())
+	idx.search = search.NewBM25()
+	idx.SetRootPath(dir)
+	_, err := idx.IndexCtx(testCtx(), dir)
+	require.NoError(t, err)
+
+	fooID := fnNodeID(t, g, "debug.go", "Foo")
+	barID := fnNodeID(t, g, "caller.go", "Bar")
+	require.Equal(t, fooID, callTargetFrom(t, g, barID))
+
+	stampLSP(t, g, callEdgeFrom(t, g, barID))
+
+	cycles := []string{
+		"package p\n\nfunc Foo() {}\n\nfunc Probe() { Foo() }\n", // append + intra-file caller
+		"package p\n\nfunc Foo() {}\n",                          // revert (removes intra-file caller)
+	}
+	for i, content := range cycles {
+		writeFile(t, defPath, content)
+		require.NoError(t, idx.IndexFile(defPath))
+
+		after := callEdgeFrom(t, g, fnNodeID(t, g, "caller.go", "Bar"))
+		assert.Falsef(t, graph.IsUnresolvedTarget(after.To),
+			"cycle %d: Bar's cross-file caller edge must not remain a stub", i)
+		assert.Equalf(t, fnNodeID(t, g, "debug.go", "Foo"), after.To,
+			"cycle %d: Bar's cross-file caller edge must still resolve to Foo", i)
+		assert.Equalf(t, graph.OriginLSPResolved, after.Origin,
+			"cycle %d: incoming edge must keep its lsp origin (no ratchet-down)", i)
+	}
+}
+
+// TestReresolveFileScoped_RebindsDroppedIncomingEdges is the recovery half of
+// the WS-1 self-heal: whatever mechanism drops a surviving definition's
+// incoming callers to stubs, the forced scoped re-resolve the incoming-aware
+// regression guard enqueues must rebind every one and restore its lsp
+// provenance — on a disk backend, where the restore has to be persisted, not
+// just mutated in place.
+func TestReresolveFileScoped_RebindsDroppedIncomingEdges(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "def.go"), "package p\n\nfunc Foo() {}\n")
+	callers := []string{"c0.go", "c1.go", "c2.go"}
+	for i, c := range callers {
+		writeFile(t, filepath.Join(dir, c), fmt.Sprintf("package p\n\nfunc Bar%d() { Foo() }\n", i))
+	}
+
+	g := newSqliteGraph(t)
+	idx := New(g, newTestRegistry(), config.IndexConfig{Workers: 1}, zap.NewNop())
+	idx.search = search.NewBM25()
+	idx.SetRootPath(dir)
+	_, err := idx.IndexCtx(testCtx(), dir)
+	require.NoError(t, err)
+
+	fooID := fnNodeID(t, g, "def.go", "Foo")
+	for i, c := range callers {
+		e := callEdgeFrom(t, g, fnNodeID(t, g, c, fmt.Sprintf("Bar%d", i)))
+		require.Equal(t, fooID, e.To)
+		stampLSP(t, g, e)
+	}
+	require.Len(t, incomingCallEdges(t, g, fooID), len(callers), "baseline: all callers bound")
+
+	// Simulate the live drop: restub Foo's incoming caller edges to
+	// unresolved::Foo (what a re-parse of def.go does before it re-resolves).
+	idx.restubIncomingRefs("def.go")
+	require.Empty(t, incomingCallEdges(t, g, fooID), "precondition: callers dropped to stubs")
+
+	// The forced scoped re-resolve must rebind every dropped caller AND restore
+	// its lsp provenance on the sqlite backend.
+	require.NoError(t, idx.ReresolveFileScoped("def.go"))
+	got := incomingCallEdges(t, g, fooID)
+	require.Len(t, got, len(callers), "every dropped caller rebound")
+	for _, e := range got {
+		assert.Equal(t, graph.OriginLSPResolved, e.Origin,
+			"rebound caller must recover its lsp origin (restore persisted)")
+	}
+}
+
+// TestGuardResolvedEdgeRegression_IncomingArm_FiresOnRevert asserts the
+// incoming arm of the regression guard: an external revert removes the appended
+// probe symbol (nodesAfter < nodesBefore, so the out-edge arm stays silent) yet
+// the surviving definition lost every caller — the guard must still enqueue a
+// forced scoped re-resolve so the drop self-heals.
+func TestGuardResolvedEdgeRegression_IncomingArm_FiresOnRevert(t *testing.T) {
+	g := newSqliteGraph(t)
+	idx := New(g, newTestRegistry(), config.IndexConfig{Workers: 1}, zap.NewNop())
+	w, err := NewWatcher(idx, config.WatchConfig{}, zap.NewNop())
+	require.NoError(t, err)
+
+	fired := make(chan map[string]struct{}, 1)
+	w.reresolveFn = func(files map[string]struct{}) { fired <- files }
+
+	w.guardResolvedEdgeRegression("def.go",
+		/*nodesBefore*/ 6, /*nodesAfter*/ 5, // probe removed
+		/*resolvedBefore*/ 0, /*resolvedAfter*/ 0, // out-edges never regressed
+		/*incomingBefore*/ 8, /*incomingAfter*/ 0) // callers all dropped
+
+	select {
+	case files := <-fired:
+		_, ok := files["def.go"]
+		assert.True(t, ok, "revert must enqueue a forced re-resolve of the definition file")
+	case <-time.After(2 * time.Second):
+		t.Fatal("incoming-edge regression did not enqueue a re-resolve")
+	}
+}
+
+// TestGuardResolvedEdgeRegression_NoFireWhenStable proves the guard does not
+// churn: a re-parse that kept both its out-edges and its incoming callers must
+// not enqueue anything.
+func TestGuardResolvedEdgeRegression_NoFireWhenStable(t *testing.T) {
+	g := newSqliteGraph(t)
+	idx := New(g, newTestRegistry(), config.IndexConfig{Workers: 1}, zap.NewNop())
+	w, err := NewWatcher(idx, config.WatchConfig{}, zap.NewNop())
+	require.NoError(t, err)
+
+	fired := make(chan struct{}, 1)
+	w.reresolveFn = func(map[string]struct{}) { fired <- struct{}{} }
+
+	w.guardResolvedEdgeRegression("def.go", 5, 5, 10, 10, 8, 8)
+
+	select {
+	case <-fired:
+		t.Fatal("a stable re-parse must not enqueue a re-resolve")
+	case <-time.After(300 * time.Millisecond):
+	}
+}

--- a/internal/indexer/reresolve_guard_test.go
+++ b/internal/indexer/reresolve_guard_test.go
@@ -50,7 +50,7 @@ func TestGuardResolvedEdgeRegression(t *testing.T) {
 
 	// Resolved edges more than halved, symbols intact, above the floor: fires.
 	before := ResolutionRegressions()
-	w.guardResolvedEdgeRegression("a.go", 5, 5, 10, 2)
+	w.guardResolvedEdgeRegression("a.go", 5, 5, 10, 2, 0, 0)
 	select {
 	case files := <-reresolved:
 		_, ok := files["a.go"]
@@ -62,9 +62,9 @@ func TestGuardResolvedEdgeRegression(t *testing.T) {
 
 	// None of the negatives may fire.
 	base := ResolutionRegressions()
-	w.guardResolvedEdgeRegression("below-floor.go", 5, 5, 3, 0) // resolvedBefore < floor
-	w.guardResolvedEdgeRegression("symbol-removed.go", 5, 3, 10, 2)
-	w.guardResolvedEdgeRegression("modest-drop.go", 5, 5, 10, 6) // dropped <= 50%
+	w.guardResolvedEdgeRegression("below-floor.go", 5, 5, 3, 0, 0, 0) // resolvedBefore < floor
+	w.guardResolvedEdgeRegression("symbol-removed.go", 5, 3, 10, 2, 0, 0)
+	w.guardResolvedEdgeRegression("modest-drop.go", 5, 5, 10, 6, 0, 0) // dropped <= 50%
 	select {
 	case f := <-reresolved:
 		t.Fatalf("a non-regression must not enqueue a re-resolve, got %v", f)

--- a/internal/indexer/watcher.go
+++ b/internal/indexer/watcher.go
@@ -1006,6 +1006,7 @@ func (w *Watcher) patchGraph(path string, kind ChangeKind) {
 		priorNodes := w.indexer.graph.GetFileNodes(relPath)
 		fileEdgesBefore := w.countFileEdges(priorNodes)
 		resolvedBefore := w.countResolvedFileEdges(priorNodes)
+		incomingBeforeByID := w.resolvedIncomingByNode(priorNodes)
 		if err := w.indexer.IndexFile(path); err != nil {
 			w.logger.Warn("reindex file failed", zap.String("path", path), zap.Error(err))
 			return
@@ -1027,7 +1028,8 @@ func (w *Watcher) patchGraph(path string, kind ChangeKind) {
 		// most of its resolved edges is a transient resolution failure, not a
 		// real deletion — flag it and enqueue a forced scoped re-resolve so it
 		// self-heals instead of persisting the degraded shape.
-		w.guardResolvedEdgeRegression(path, len(priorNodes), len(newSymbols), resolvedBefore, w.countResolvedFileEdges(newSymbols))
+		incomingBefore, incomingAfter := w.incomingRegressionForSurvivors(incomingBeforeByID, newSymbols)
+		w.guardResolvedEdgeRegression(path, len(priorNodes), len(newSymbols), resolvedBefore, w.countResolvedFileEdges(newSymbols), incomingBefore, incomingAfter)
 
 		// Notify callback with old and new symbols.
 		w.symbolChangeCbMu.RLock()
@@ -1161,21 +1163,34 @@ func (w *Watcher) countResolvedFileEdges(nodes []*graph.Node) int {
 	return total
 }
 
-// guardResolvedEdgeRegression fires when a modify patch KEPT (or grew) its
-// symbols but lost more than half its resolved out-edges — a transient
-// resolution failure (a dependency mid-write, an LSP provider not yet warm),
-// not a real deletion. It logs loudly, bumps the process-global regression
-// counter, and enqueues the file for a forced scoped re-resolve so the graph
-// self-heals instead of persisting the degraded shape.
-func (w *Watcher) guardResolvedEdgeRegression(path string, nodesBefore, nodesAfter, resolvedBefore, resolvedAfter int) {
-	if resolvedBefore < resolvedEdgeRegressionFloor {
+// guardResolvedEdgeRegression fires when a modify patch lost most of its
+// resolved edges on either side of the graph: the file's own out-edges dropped
+// while it kept its symbols, OR a surviving definition lost most of the callers
+// bound into it. Both are transient resolution failures (a dependency mid-write,
+// an LSP provider not yet warm, an external revert re-parsing a definition
+// file), not real deletions. It logs loudly, bumps the process-global
+// regression counter, and enqueues the file for a forced scoped re-resolve so
+// the graph self-heals instead of persisting the degraded shape.
+func (w *Watcher) guardResolvedEdgeRegression(path string, nodesBefore, nodesAfter, resolvedBefore, resolvedAfter, incomingBefore, incomingAfter int) {
+	// Out-edge regression: this file's own references lost their resolutions
+	// while it kept (or grew) its symbols. Gated on nodesAfter >= nodesBefore —
+	// a symbol removal legitimately drops out-edges.
+	outRegressed := resolvedBefore >= resolvedEdgeRegressionFloor &&
+		nodesAfter >= nodesBefore &&
+		resolvedAfter*2 < resolvedBefore
+	// Incoming-edge regression: a definition that SURVIVED the re-parse lost
+	// most of the callers bound INTO it. The caller restricts the counts to
+	// surviving definitions, so a genuinely deleted symbol's lost callers do
+	// not read as a loss — which is why this arm is deliberately NOT gated on
+	// nodesAfter >= nodesBefore. An external revert removes the appended probe
+	// symbol (node count drops) yet the definition it leaves behind must keep
+	// its incoming resolved edges; their loss is a resolution failure, not a
+	// deletion, and without this arm the revert never self-heals the way the
+	// symmetric add does.
+	inRegressed := incomingBefore >= resolvedEdgeRegressionFloor &&
+		incomingAfter*2 < incomingBefore
+	if !outRegressed && !inRegressed {
 		return
-	}
-	if nodesAfter < nodesBefore {
-		return // symbols were removed — a real deletion, not a resolution loss
-	}
-	if resolvedAfter*2 >= resolvedBefore {
-		return // dropped <= 50%
 	}
 	RecordResolutionRegression()
 	if w.logger != nil {
@@ -1184,9 +1199,71 @@ func (w *Watcher) guardResolvedEdgeRegression(path string, nodesBefore, nodesAft
 			zap.Int("nodes_before", nodesBefore),
 			zap.Int("nodes_after", nodesAfter),
 			zap.Int("resolved_edges_before", resolvedBefore),
-			zap.Int("resolved_edges_after", resolvedAfter))
+			zap.Int("resolved_edges_after", resolvedAfter),
+			zap.Int("incoming_resolved_before", incomingBefore),
+			zap.Int("incoming_resolved_after", incomingAfter))
 	}
 	w.enqueueReresolve(path)
+}
+
+// resolvedIncomingByNode returns, per referenceable definition node in `nodes`,
+// the count of resolvable reference edges currently bound INTO it (callers,
+// type/field references, …). countResolvedFileEdges is out-edge-only and so is
+// structurally blind to a definition losing its incoming callers on a re-parse
+// — this is the signal that catches an external revert zeroing a surviving
+// symbol's usages.
+func (w *Watcher) resolvedIncomingByNode(nodes []*graph.Node) map[string]int {
+	if len(nodes) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(nodes))
+	for _, n := range nodes {
+		if n != nil && graph.IsReferenceableSymbol(n.Kind) {
+			ids = append(ids, n.ID)
+		}
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	byNode := make(map[string]int, len(ids))
+	for id, edges := range w.indexer.graph.GetInEdgesByNodeIDs(ids) {
+		c := 0
+		for _, e := range edges {
+			if e != nil && graph.IsResolvableRefEdge(e.Kind) {
+				c++
+			}
+		}
+		if c > 0 {
+			byNode[id] = c
+		}
+	}
+	return byNode
+}
+
+// incomingRegressionForSurvivors sums the incoming resolved-edge counts, before
+// and after the re-parse, over only the definitions that SURVIVED it (present
+// in both snapshots by node ID). Restricting to survivors keeps a genuinely
+// deleted symbol's lost callers from reading as a regression, so the guard's
+// incoming arm fires only when a symbol that is still defined lost the callers
+// bound into it. `before` is the resolvedIncomingByNode snapshot captured on
+// the pre-re-parse nodes; `after` is the file's fresh node set.
+func (w *Watcher) incomingRegressionForSurvivors(before map[string]int, after []*graph.Node) (sumBefore, sumAfter int) {
+	if len(before) == 0 || len(after) == 0 {
+		return 0, 0
+	}
+	afterByID := w.resolvedIncomingByNode(after)
+	for _, n := range after {
+		if n == nil {
+			continue
+		}
+		b, ok := before[n.ID]
+		if !ok {
+			continue
+		}
+		sumBefore += b
+		sumAfter += afterByID[n.ID]
+	}
+	return sumBefore, sumAfter
 }
 
 // enqueueReresolve batches shape-degraded files for a forced scoped re-resolve.

--- a/internal/mcp/reexport_barrel.go
+++ b/internal/mcp/reexport_barrel.go
@@ -1,0 +1,143 @@
+package mcp
+
+import (
+	"path"
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Barrel re-export resolve-through for find_usages.
+//
+// A JS/TS barrel forwards a binding it does not declare —
+// `export { persist } from './middleware/persist'` — and the extractor records
+// that only as an EdgeReExports edge from the barrel FILE; it mints no node for
+// the forwarded binding. So a consumer's public import path
+// (`src/middleware.ts::persist`) has nothing to resolve and find_usages returns
+// not_found even though the canonical declaration has usages.
+//
+// reExportBindingCanonical maps such a barrel-binding id to the canonical
+// declaration id by walking the re-export chain (named, aliased, and chained
+// barrels, plus `export * from`). It is consulted ONLY when the queried id is
+// not itself a node, so it can never change the answer for a real symbol — the
+// canonical strata stay byte-identical. Bare / path-aliased specifiers (needing
+// tsconfig `paths` or npm-alias resolution the query layer does not carry) are
+// out of scope; relative barrels — the dominant form — are covered.
+
+// jsBarrelExts are the module file extensions probed when resolving a relative
+// re-export specifier to a file node, in precedence order.
+var jsBarrelExts = []string{".ts", ".tsx", ".mts", ".cts", ".d.ts", ".js", ".jsx", ".mjs", ".cjs"}
+
+const maxReExportChainDepth = 8
+
+// reExportBindingCanonical returns the canonical declaration id a barrel-binding
+// id forwards to, or "" when id is not a resolvable barrel binding.
+func reExportBindingCanonical(g graph.Store, id string, depth int) string {
+	if g == nil || depth > maxReExportChainDepth {
+		return ""
+	}
+	barrelFile, name, ok := splitBarrelID(id)
+	if !ok || !hasJSTSExt(barrelFile) {
+		return ""
+	}
+	if g.GetNode(barrelFile) == nil {
+		return ""
+	}
+	for _, e := range g.GetOutEdges(barrelFile) {
+		if e == nil || e.Kind != graph.EdgeReExports {
+			continue
+		}
+		spec, orig := parseReExportTarget(e.To)
+		if spec == "" || !strings.HasPrefix(spec, ".") {
+			continue // bare / aliased specifier — out of scope
+		}
+		switch {
+		case orig != "":
+			// Named (optionally aliased) re-export. The public binding name is
+			// the alias when renamed, else the original.
+			binding := e.Alias
+			if binding == "" {
+				binding = orig
+			}
+			if binding != name {
+				continue
+			}
+			if canon := probeBindingInFile(g, barrelFile, spec, orig, depth); canon != "" {
+				return canon
+			}
+		case e.Alias == "":
+			// `export * from './x'` — any of x's exports is forwarded under its
+			// own name, so probe the target for the queried name.
+			if canon := probeBindingInFile(g, barrelFile, spec, name, depth); canon != "" {
+				return canon
+			}
+		}
+	}
+	return ""
+}
+
+// probeBindingInFile resolves the relative spec to a target file and returns
+// the canonical id for `orig` there — either a real symbol node, or, when the
+// target is itself a barrel, the result of recursing through it.
+func probeBindingInFile(g graph.Store, fromFile, spec, orig string, depth int) string {
+	tf := probeRelativeModuleFile(g, fromFile, spec)
+	if tf == "" {
+		return ""
+	}
+	if canon := tf + "::" + orig; g.GetNode(canon) != nil {
+		return canon
+	}
+	return reExportBindingCanonical(g, tf+"::"+orig, depth+1)
+}
+
+// splitBarrelID splits `<file>::<name>` on the last `::`.
+func splitBarrelID(id string) (file, name string, ok bool) {
+	i := strings.LastIndex(id, "::")
+	if i < 0 {
+		return "", "", false
+	}
+	return id[:i], id[i+2:], true
+}
+
+// parseReExportTarget decodes an EdgeReExports edge's target
+// (`unresolved::import::<spec>[::<orig>]`) into its import specifier and, for a
+// named re-export, the original binding name ("" for a wildcard / namespace).
+func parseReExportTarget(to string) (spec, orig string) {
+	payload, ok := strings.CutPrefix(graph.UnresolvedName(to), "import::")
+	if !ok || payload == "" {
+		return "", ""
+	}
+	if i := strings.LastIndex(payload, "::"); i >= 0 {
+		return payload[:i], payload[i+2:]
+	}
+	return payload, ""
+}
+
+// probeRelativeModuleFile joins a relative specifier against the importing
+// file's directory and returns the matching file node's id, trying the module
+// extensions and an index file, or "" when no such file node exists.
+func probeRelativeModuleFile(g graph.Store, fromFile, spec string) string {
+	stem := path.Clean(path.Join(path.Dir(fromFile), spec))
+	for _, ext := range jsBarrelExts {
+		if g.GetNode(stem+ext) != nil {
+			return stem + ext
+		}
+	}
+	for _, ext := range jsBarrelExts {
+		if cand := path.Join(stem, "index"+ext); g.GetNode(cand) != nil {
+			return cand
+		}
+	}
+	return ""
+}
+
+// hasJSTSExt reports whether a file path is a JS/TS module the barrel walk
+// applies to.
+func hasJSTSExt(file string) bool {
+	for _, ext := range jsBarrelExts {
+		if strings.HasSuffix(file, ext) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/mcp/reexport_barrel_test.go
+++ b/internal/mcp/reexport_barrel_test.go
@@ -1,0 +1,85 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// buildBarrelGraph wires a canonical declaration plus a chain of barrels that
+// forward it, the way the JS/TS extractor records a re-export (a file-level
+// EdgeReExports edge, no node for the forwarded binding).
+func buildBarrelGraph(t *testing.T) graph.Store {
+	t.Helper()
+	g := graph.New()
+	addFile := func(id string) {
+		g.AddNode(&graph.Node{ID: id, Kind: graph.KindFile, Name: id, FilePath: id, Language: "typescript"})
+	}
+	// Canonical declaration: src/middleware/persist.ts::persist.
+	addFile("src/middleware/persist.ts")
+	g.AddNode(&graph.Node{ID: "src/middleware/persist.ts::persist", Kind: graph.KindFunction,
+		Name: "persist", FilePath: "src/middleware/persist.ts", Language: "typescript"})
+
+	// Barrel: src/middleware.ts — `export { persist } from './middleware/persist'`.
+	addFile("src/middleware.ts")
+	g.AddEdge(&graph.Edge{From: "src/middleware.ts",
+		To: "unresolved::import::./middleware/persist::persist", Kind: graph.EdgeReExports,
+		FilePath: "src/middleware.ts", Line: 1})
+
+	// Chained barrel: src/index.ts — `export { persist } from './middleware'`.
+	addFile("src/index.ts")
+	g.AddEdge(&graph.Edge{From: "src/index.ts",
+		To: "unresolved::import::./middleware::persist", Kind: graph.EdgeReExports,
+		FilePath: "src/index.ts", Line: 1})
+
+	// Aliased re-export: src/ssr.ts — `export { ssrSafe as unstable_ssrSafe } from './impl'`.
+	addFile("src/impl.ts")
+	g.AddNode(&graph.Node{ID: "src/impl.ts::ssrSafe", Kind: graph.KindFunction,
+		Name: "ssrSafe", FilePath: "src/impl.ts", Language: "typescript"})
+	addFile("src/ssr.ts")
+	g.AddEdge(&graph.Edge{From: "src/ssr.ts",
+		To: "unresolved::import::./impl::ssrSafe", Kind: graph.EdgeReExports,
+		Alias: "unstable_ssrSafe", FilePath: "src/ssr.ts", Line: 1})
+
+	// Wildcard barrel: src/all.ts — `export * from './middleware/persist'`.
+	addFile("src/all.ts")
+	g.AddEdge(&graph.Edge{From: "src/all.ts",
+		To: "unresolved::import::./middleware/persist", Kind: graph.EdgeReExports,
+		FilePath: "src/all.ts", Line: 1})
+
+	// Bare-package re-export (out of scope): src/vendor.ts — `export { x } from 'react'`.
+	addFile("src/vendor.ts")
+	g.AddEdge(&graph.Edge{From: "src/vendor.ts",
+		To: "unresolved::import::react::x", Kind: graph.EdgeReExports,
+		FilePath: "src/vendor.ts", Line: 1})
+
+	return g
+}
+
+func TestReExportBindingCanonical(t *testing.T) {
+	g := buildBarrelGraph(t)
+	const canonical = "src/middleware/persist.ts::persist"
+
+	assert.Equal(t, canonical, reExportBindingCanonical(g, "src/middleware.ts::persist", 0),
+		"a named re-export maps to the canonical declaration")
+
+	assert.Equal(t, canonical, reExportBindingCanonical(g, "src/index.ts::persist", 0),
+		"a chained barrel resolves through both hops")
+
+	assert.Equal(t, "src/impl.ts::ssrSafe", reExportBindingCanonical(g, "src/ssr.ts::unstable_ssrSafe", 0),
+		"an aliased re-export resolves under the alias id to the original declaration")
+
+	assert.Equal(t, canonical, reExportBindingCanonical(g, "src/all.ts::persist", 0),
+		"`export * from` forwards a binding under its own name")
+
+	assert.Empty(t, reExportBindingCanonical(g, "src/vendor.ts::x", 0),
+		"a bare-package re-export is out of scope (needs alias resolution the query layer lacks)")
+
+	assert.Empty(t, reExportBindingCanonical(g, "src/ssr.ts::ssrSafe", 0),
+		"the original name is not the public binding when a re-export is aliased")
+
+	assert.Empty(t, reExportBindingCanonical(g, "src/middleware/persist.ts::persist", 0),
+		"the canonical declaration itself is not a barrel binding")
+}

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -2454,6 +2454,16 @@ func (s *Server) handleFindUsages(ctx context.Context, req mcp.CallToolRequest) 
 		return errResult, nil
 	}
 	eng := s.engineFor(ctx)
+	// Barrel re-export resolve-through: a public import path that names a
+	// forwarded binding (`src/middleware.ts::persist`) has no node of its own —
+	// map it to the canonical declaration so find_usages answers with the real
+	// usages instead of not_found. Gated on the id not already being a node, so
+	// a real symbol's result is never altered.
+	if eng.GetSymbol(id) == nil {
+		if canon := reExportBindingCanonical(s.graph, id, 0); canon != "" {
+			id = canon
+		}
+	}
 	if node := eng.GetSymbol(id); node != nil && !resolvedScopeAllowsNode(resolved, node) {
 		return symbolNotFoundGuidance(id), nil
 	}

--- a/internal/resolver/csharp_receiver_gate.go
+++ b/internal/resolver/csharp_receiver_gate.go
@@ -46,9 +46,20 @@ func demoteCSharpMisattributedMemberCalls(g graph.Store) int {
 		return 0
 	}
 	up := map[string][]string{}
+	// incompleteHier[name] marks a C# type that declares a base or interface the
+	// index could not resolve (an external assembly, a generic type parameter) —
+	// its hierarchy is only partially known, so an "unrelated to the target"
+	// verdict for a receiver of that type is unreliable.
+	incompleteHier := map[string]bool{}
 	for _, k := range []graph.EdgeKind{graph.EdgeExtends, graph.EdgeImplements} {
 		for e := range g.EdgesByKind(k) {
-			if e == nil || e.From == "" || graph.IsUnresolvedTarget(e.To) {
+			if e == nil || e.From == "" {
+				continue
+			}
+			if graph.IsUnresolvedTarget(e.To) {
+				if from := g.GetNode(e.From); from != nil && from.Language == "csharp" && from.Name != "" {
+					incompleteHier[from.Name] = true
+				}
 				continue
 			}
 			up[e.From] = append(up[e.From], e.To)
@@ -66,7 +77,7 @@ func demoteCSharpMisattributedMemberCalls(g graph.Store) int {
 	demote := map[string]bool{}
 	affected := map[string]bool{}
 	for e := range g.EdgesByKind(graph.EdgeCalls) {
-		if !csharpShouldDemote(g, e, nameToTypeIDs, up) {
+		if !csharpShouldDemote(g, e, nameToTypeIDs, up, incompleteHier) {
 			continue
 		}
 		demote[edgeKey(e)] = true
@@ -111,7 +122,7 @@ func demoteCSharpMisattributedMemberCalls(g graph.Store) int {
 
 // csharpShouldDemote reports whether a resolved C# member-call edge is a
 // same-named-unrelated-type misattribution that should be demoted.
-func csharpShouldDemote(g graph.Store, e *graph.Edge, nameToTypeIDs, up map[string][]string) bool {
+func csharpShouldDemote(g graph.Store, e *graph.Edge, nameToTypeIDs, up map[string][]string, incompleteHier map[string]bool) bool {
 	if e == nil || e.Meta == nil || e.IsSpeculative() || graph.IsUnresolvedTarget(e.To) {
 		return false
 	}
@@ -155,6 +166,14 @@ func csharpShouldDemote(g graph.Store, e *graph.Edge, nameToTypeIDs, up map[stri
 	// cannot establish that the mismatch is a genuinely unrelated-type
 	// misattribution, and keeping the edge avoids a false negative.
 	if len(nameToTypeIDs[rt]) == 0 || len(nameToTypeIDs[tr]) == 0 {
+		return false
+	}
+	// A receiver whose own hierarchy is incompletely indexed may reach the
+	// target through the unindexed base/interface, so the "unrelated" verdict is
+	// unreliable — keep rather than demote a possibly-legitimate polymorphic
+	// call. This is the same conservatism as the both-endpoints-known guard
+	// above, extended to hierarchy completeness.
+	if incompleteHier[rt] {
 		return false
 	}
 	// A related receiver (the target lives on a base type / interface the

--- a/internal/resolver/csharp_receiver_gate_test.go
+++ b/internal/resolver/csharp_receiver_gate_test.go
@@ -162,3 +162,40 @@ func TestReceiverGate_PreservesInheritedCall(t *testing.T) {
 	assert.Equal(t, 0, n, "an inherited (related-type) call must not be demoted")
 	assert.False(t, edge.IsSpeculative())
 }
+
+// TestReceiverGate_PreservesCallThroughIncompleteHierarchy: a receiver whose
+// base/interface is defined outside the indexed set (another assembly) has an
+// unresolved supertype edge, so its hierarchy is only partially known. A call
+// that locality-binds to a same-named method on an unrelated indexed type must
+// NOT be demoted — the real target may live on the unindexed supertype. Without
+// the hierarchy-completeness guard this legitimate polymorphic call is trimmed.
+func TestReceiverGate_PreservesCallThroughIncompleteHierarchy(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Shape.cs": `namespace App {
+    public class Shape {
+        public void Draw() {}
+    }
+}`,
+		"Widget.cs": `namespace App {
+    public class Widget : IExternalDrawable {
+        public void Render() {
+            Widget w = new Widget();
+            w.Draw();
+        }
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	edge := findCallEdge(g, "Widget.cs::Widget.Render", "Shape.cs::Shape.Draw")
+	require.NotNil(t, edge, "w.Draw() locality-binds to the only indexed Draw")
+	require.Equal(t, "Widget", edge.Meta["receiver_type"])
+	require.False(t, edge.IsSpeculative())
+
+	n := demoteCSharpMisattributedMemberCalls(g)
+	assert.Equal(t, 0, n, "a call through an incompletely-indexed hierarchy must not be demoted")
+	edge = findCallEdge(g, "Widget.cs::Widget.Render", "Shape.cs::Shape.Draw")
+	require.NotNil(t, edge)
+	assert.False(t, edge.IsSpeculative(),
+		"a possibly-legitimate polymorphic call through an unindexed supertype stays visible")
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -1210,8 +1210,9 @@ func (r *Resolver) resolveIncomingLocked(filePath string, stats *ResolveStats) {
 			// so a rebind elsewhere / a still-unresolved stub carries only the
 			// honest tier the resolver just assigned. Runs before the job is
 			// captured so the cross-package guard below sees the real origin.
-			graph.RestoreRestubProvenance(e)
-			if changed {
+			restored := graph.RestoreRestubProvenance(e)
+			switch {
+			case changed:
 				reindexBatch = append(reindexBatch, graph.EdgeReindex{Edge: e, OldTo: oldTo})
 				jobs = append(jobs, reindexJob{
 					edge:       e,
@@ -1221,6 +1222,17 @@ func (r *Resolver) resolveIncomingLocked(filePath string, stats *ResolveStats) {
 					confidence: e.Confidence,
 					origin:     e.Origin,
 				})
+			case restored:
+				// The stub rebound to the SAME concrete target it already
+				// carried, so resolveEdge reported no To-change — but the
+				// restore mutated Origin/Tier/Confidence/Meta in place. A disk
+				// backend's GetInEdges handed us a freshly-decoded edge pointer,
+				// so that in-place mutation is lost unless it is written back.
+				// Re-index against the edge's own (unchanged) key to persist the
+				// restored provenance. Kept out of the cross-package guard's job
+				// list: its origin is the verified tier the restore re-applied,
+				// not a fresh name-only guess to second-guess.
+				reindexBatch = append(reindexBatch, graph.EdgeReindex{Edge: e, OldTo: e.To})
 			}
 		}
 	}

--- a/internal/semantic/enrich_order_test.go
+++ b/internal/semantic/enrich_order_test.go
@@ -1,0 +1,58 @@
+package semantic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestOrderLangsByComposition pins the deterministic, primary-language-first
+// provider order that replaces EnrichAll's old randomised map-range: the
+// language with the most enrichable nodes runs first, ties break by name, and
+// the order is stable across calls (so a Go-dominant repo's gopls always runs
+// before a minor TS tree's tsserver).
+func TestOrderLangsByComposition(t *testing.T) {
+	providers := map[string]Provider{
+		"go":         nil,
+		"typescript": nil,
+		"python":     nil,
+	}
+	// Go dominates; python and typescript are minor, python == typescript so the
+	// tie must break by name (python < typescript).
+	langCounts := map[string]int{"go": 5000, "typescript": 40, "python": 40}
+
+	first := orderLangsByComposition(providers, langCounts)
+	assert.Equal(t, []string{"go", "python", "typescript"}, first,
+		"most enrichable nodes first; ties break by language name")
+
+	// Determinism: the exact same inputs must yield the exact same order.
+	second := orderLangsByComposition(providers, langCounts)
+	assert.Equal(t, first, second, "ordering must be deterministic across calls")
+
+	// Every registered provider language appears exactly once.
+	assert.Len(t, first, len(providers))
+}
+
+// TestOrderLangsByComposition_NoCounts falls back to a name-sorted order when
+// there is no composition signal (an unindexed / empty graph), so the schedule
+// is still deterministic.
+func TestOrderLangsByComposition_NoCounts(t *testing.T) {
+	providers := map[string]Provider{"rust": nil, "go": nil, "c": nil}
+	assert.Equal(t, []string{"c", "go", "rust"},
+		orderLangsByComposition(providers, map[string]int{}))
+}
+
+// TestSortedRootNames pins the deterministic per-repo visit order: most
+// enrichable nodes first, ties by name, and a stable name order when counts are
+// absent.
+func TestSortedRootNames(t *testing.T) {
+	roots := map[string]string{"a": "/a", "b": "/b", "c": "/c"}
+
+	assert.Equal(t, []string{"b", "a", "c"},
+		sortedRootNames(roots, map[string]int{"a": 100, "b": 900, "c": 100}),
+		"repo with the most enrichable nodes first; ties break by name")
+
+	assert.Equal(t, []string{"a", "b", "c"},
+		sortedRootNames(roots, nil),
+		"no counts falls back to a stable name order")
+}

--- a/internal/semantic/enrich_readiness_test.go
+++ b/internal/semantic/enrich_readiness_test.go
@@ -1,0 +1,81 @@
+package semantic
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// slowSolutionProvider models a Roslyn/MSBuild-class server: its queries only
+// succeed once its solution has loaded, which the manager triggers by calling
+// WaitReady before the enrichment deadline. It records whether readiness ran
+// and only lands edges when it did.
+type slowSolutionProvider struct {
+	name      string
+	languages []string
+	waited    bool
+	ready     bool
+}
+
+func (s *slowSolutionProvider) Name() string        { return s.name }
+func (s *slowSolutionProvider) Languages() []string { return s.languages }
+func (s *slowSolutionProvider) Available() bool     { return true }
+func (s *slowSolutionProvider) Close() error        { return nil }
+
+func (s *slowSolutionProvider) Enrich(g graph.Store, repoRoot string) (*EnrichResult, error) {
+	return nil, nil
+}
+
+func (s *slowSolutionProvider) EnrichFile(g graph.Store, repoRoot, filePath string) (*EnrichResult, error) {
+	return nil, nil
+}
+
+func (s *slowSolutionProvider) WaitReady(ctx context.Context, repoRoot string) error {
+	s.waited = true
+	s.ready = true
+	return nil
+}
+
+func (s *slowSolutionProvider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPrefix, repoRoot string) (*EnrichResult, error) {
+	res := &EnrichResult{Provider: s.name, Language: s.languages[0]}
+	// A solution-load server serves empty results until its load finishes; the
+	// readiness gate must run first for the pass to land any edges.
+	if s.ready {
+		res.EdgesAdded = 3
+	}
+	return res, nil
+}
+
+// TestRunEnrichOne_ReadinessGate: a ReadinessProber provider is brought to
+// readiness BEFORE the enrichment deadline starts, so its pass lands edges
+// instead of spending the whole budget on the cold solution load.
+func TestRunEnrichOne_ReadinessGate(t *testing.T) {
+	mgr := NewManager(Config{Enabled: true}, zap.NewNop())
+	p := &slowSolutionProvider{name: "csharp-like", languages: []string{"csharp"}}
+
+	results := mgr.runEnrichOne(graph.New(), "repo", "/tmp/repo", "csharp", p, 10, nil)
+
+	require.True(t, p.waited, "readiness prober must be invoked before the enrichment pass")
+	require.Len(t, results, 1)
+	assert.Equal(t, 3, results[0].EdgesAdded,
+		"the pass lands edges because the deadline started only after readiness")
+}
+
+// TestRunEnrichOne_FastProviderSkipsReadiness: a provider that does not
+// implement ReadinessProber (a gopls-shaped server, ready after initialize)
+// runs without incurring the readiness wait.
+func TestRunEnrichOne_FastProviderSkipsReadiness(t *testing.T) {
+	mgr := NewManager(Config{Enabled: true}, zap.NewNop())
+	// mockProvider (from manager_test.go) does not implement ReadinessProber.
+	p := &mockProvider{name: "gopls-like", languages: []string{"go"}, available: true}
+
+	results := mgr.runEnrichOne(graph.New(), "repo", "/tmp/repo", "go", p, 10, nil)
+
+	require.Len(t, results, 1, "a fast provider still runs; the readiness gate is simply skipped")
+	assert.Equal(t, "gopls-like", results[0].Provider)
+}

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -1737,6 +1737,32 @@ func (p *Provider) ensureClient(workspaceRoot string) error {
 	return nil
 }
 
+// WaitReady implements semantic.ReadinessProber for the Roslyn / MSBuild-class
+// C# servers (csharp-ls, OmniSharp), whose workspace load continues past
+// `initialize` and serves empty results until the solution finishes loading.
+// Bringing the client up here — spawn, optional `dotnet restore`, and the
+// `initialize` handshake — moves that cold-start latency OUT of the per-repo
+// enrichment deadline the Manager starts immediately afterward, so the query
+// budget is not consumed by the load. Every other server is ready to answer
+// once initialized and does not implement ReadinessProber, so it never waits.
+// The call runs synchronously (it completes before the enrichment pass calls
+// ensureClient again, which then no-ops), so there is no concurrent client
+// setup to race; ctx bounds the caller's expectation and short-circuits an
+// already-cancelled budget.
+func (p *Provider) WaitReady(ctx context.Context, repoRoot string) error {
+	if !p.servesCSharp() {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	absRoot, err := filepath.Abs(repoRoot)
+	if err != nil {
+		return err
+	}
+	return p.ensureClient(absRoot)
+}
+
 // fanoutDiagnostics wakes everyone who called WaitForDiagnostics for
 // this absPath AND invokes the persistent hook installed via
 // SetDiagnosticsHook (if any). Runs with no provider lock held.

--- a/internal/semantic/manager.go
+++ b/internal/semantic/manager.go
@@ -456,6 +456,13 @@ const (
 // Var (not const) so tests can shrink it.
 var enrichCancelGrace = 2 * time.Minute
 
+// enrichReadinessBudget bounds how long the manager waits for a ReadinessProber
+// provider's server to become ready (its Roslyn / MSBuild solution load to
+// finish) BEFORE the per-repo enrichment deadline starts. Capping the wait
+// keeps a server that never becomes ready from stalling the pipeline — the pass
+// then proceeds best-effort. Var (not const) so tests can shrink it.
+var enrichReadinessBudget = 3 * time.Minute
+
 // scaleEnrichTimeout returns the size-scaled per-repo enrichment
 // deadline for a repo with nodeCount enrichable nodes: floor + per-node
 // cost, capped at the ceiling. A fixed 10-minute bound was tuned for
@@ -575,6 +582,29 @@ func (m *Manager) EnrichmentStatuses() []EnrichmentStatus {
 // as "abandoned" in the enrichment status.
 func (m *Manager) runEnrichOne(g graph.Store, repoName, repoRoot, lang string, provider Provider, nodeCount int, results []*EnrichResult) []*EnrichResult {
 	start := time.Now()
+
+	// Readiness gate: a server whose workspace load continues past `initialize`
+	// (Roslyn / MSBuild, behind csharp-ls / OmniSharp) answers `initialize`
+	// quickly but serves empty results until the solution finishes loading.
+	// Bringing it to readiness BEFORE the enrichment deadline starts keeps that
+	// cold-load latency out of the query budget — without it the deadline
+	// elapses during the load and the pass lands zero edges. Only providers that
+	// opt in (ReadinessProber) pay it; a server ready right after initialize does
+	// not implement the interface, so gopls / rust-analyzer never wait. Bounded
+	// and best-effort: a probe timeout or error just proceeds.
+	if rp, ok := provider.(ReadinessProber); ok && enrichReadinessBudget > 0 {
+		rctx, rcancel := context.WithTimeout(context.Background(), enrichReadinessBudget)
+		if err := rp.WaitReady(rctx, repoRoot); err != nil {
+			m.logger.Debug("semantic enrichment: readiness probe did not confirm; proceeding best-effort",
+				zap.String("provider", provider.Name()),
+				zap.String("language", lang),
+				zap.String("repo", repoName),
+				zap.Error(err),
+			)
+		}
+		rcancel()
+	}
+
 	d := enrichRepoTimeout(nodeCount)
 	m.logger.Info("semantic enrichment starting",
 		zap.String("provider", provider.Name()),

--- a/internal/semantic/manager.go
+++ b/internal/semantic/manager.go
@@ -165,7 +165,7 @@ func (m *Manager) EnrichAll(g graph.Store, roots map[string]string) ([]*EnrichRe
 	// gate — providers fall through to their own per-pass gate as before.
 	// nodeCounts (enrichable nodes per repo) feeds the size-scaled per-repo
 	// deadline — see enrichRepoTimeout.
-	present, nodeCounts := m.repoLanguages(g, roots)
+	present, nodeCounts, langCounts := m.repoLanguages(g, roots)
 	gateOnPresence := len(present) > 0
 	if gateOnPresence {
 		langs := make([]string, 0, len(present))
@@ -180,7 +180,15 @@ func (m *Manager) EnrichAll(g graph.Store, roots map[string]string) ([]*EnrichRe
 
 	var results []*EnrichResult
 
-	for lang, provider := range langProviders {
+	// Deterministic, primary-language-first order: the language with the most
+	// enrichable nodes runs first, so on a multi-language repo the dominant
+	// language's provider claims the bounded enrichment window before a minor
+	// language's. Ties break by language name. This replaces a Go map-range
+	// whose randomised order let whichever language the map happened to yield
+	// first win the wall-clock — a Go-primary repo with a minor TS tree could
+	// see its gopls pass never run because tsserver enriched first.
+	for _, lang := range orderLangsByComposition(langProviders, langCounts) {
+		provider := langProviders[lang]
 		if !provider.Available() {
 			m.logger.Debug("semantic provider unavailable, skipping",
 				zap.String("provider", provider.Name()),
@@ -251,7 +259,8 @@ func (m *Manager) EnrichAll(g graph.Store, roots map[string]string) ([]*EnrichRe
 			// Fetch a provider per repo root (keyed by workspace) rather than
 			// one shared default-workspace provider, so concurrent cross-repo
 			// enrichment never shares a single LSP connection or document cache.
-			for repoName, repoRoot := range roots {
+			for _, repoName := range sortedRootNames(roots, nodeCounts) {
+				repoRoot := roots[repoName]
 				provider, err := m.lspRouter.ProviderForSpecWorkspace(name, repoRoot)
 				if err != nil {
 					m.logger.Debug("router-backed LSP provider unavailable, skipping",
@@ -304,10 +313,15 @@ func (m *Manager) EnrichAll(g graph.Store, roots map[string]string) ([]*EnrichRe
 //
 // The second return value counts the enrichable nodes per repo (same
 // filters), which sizes the per-repo enrichment deadline — see
-// enrichRepoTimeout.
-func (m *Manager) repoLanguages(g graph.Store, roots map[string]string) (map[string]bool, map[string]int) {
+// enrichRepoTimeout. The third counts them per language across all repos — the
+// composition signal EnrichAll orders providers by (primary language first).
+func (m *Manager) repoLanguages(g graph.Store, roots map[string]string) (map[string]bool, map[string]int, map[string]int) {
 	present := make(map[string]bool)
 	counts := make(map[string]int, len(roots))
+	// langCounts is the enrichable-node count per language across all repos —
+	// the composition signal EnrichAll ranks providers by so the dominant
+	// language enriches first.
+	langCounts := make(map[string]int)
 	for repoPrefix := range roots {
 		// Code-only enumeration: content (data_class=content) sections carry
 		// no enrichable language (pdf/text have no semantic provider), so
@@ -331,9 +345,10 @@ func (m *Manager) repoLanguages(g graph.Store, roots map[string]string) (map[str
 			}
 			present[n.Language] = true
 			counts[repoPrefix]++
+			langCounts[n.Language]++
 		}
 	}
-	return present, counts
+	return present, counts, langCounts
 }
 
 // anyLangPresent reports whether any of langs is in the present set.
@@ -344,6 +359,42 @@ func anyLangPresent(langs []string, present map[string]bool) bool {
 		}
 	}
 	return false
+}
+
+// orderLangsByComposition returns the languages of langProviders sorted by the
+// repo set's composition: most enrichable nodes first (from langCounts), ties
+// broken by language name. It gives EnrichAll a deterministic, primary-first
+// provider run order in place of a randomised map-range.
+func orderLangsByComposition(langProviders map[string]Provider, langCounts map[string]int) []string {
+	langs := make([]string, 0, len(langProviders))
+	for lang := range langProviders {
+		langs = append(langs, lang)
+	}
+	sort.Slice(langs, func(i, j int) bool {
+		if ci, cj := langCounts[langs[i]], langCounts[langs[j]]; ci != cj {
+			return ci > cj
+		}
+		return langs[i] < langs[j]
+	})
+	return langs
+}
+
+// sortedRootNames returns the repo keys of roots in a deterministic order (most
+// enrichable nodes first, ties by name), so a per-repo enrichment loop no
+// longer visits repos in Go's randomised map-iteration order. counts may be nil
+// (falls back to name order).
+func sortedRootNames(roots map[string]string, counts map[string]int) []string {
+	names := make([]string, 0, len(roots))
+	for name := range roots {
+		names = append(names, name)
+	}
+	sort.Slice(names, func(i, j int) bool {
+		if ci, cj := counts[names[i]], counts[names[j]]; ci != cj {
+			return ci > cj
+		}
+		return names[i] < names[j]
+	})
+	return names
 }
 
 // providerDisabled reports an explicit `enabled: false` config entry
@@ -375,8 +426,8 @@ func (m *Manager) configPriorityFor(name string) (int, bool) {
 // the logging + lastResults bookkeeping between eager and Router-backed
 // providers.
 func (m *Manager) runEnrichForProvider(g graph.Store, roots map[string]string, lang string, provider Provider, nodeCounts map[string]int, results []*EnrichResult) []*EnrichResult {
-	for repoName, repoRoot := range roots {
-		results = m.runEnrichOne(g, repoName, repoRoot, lang, provider, nodeCounts[repoName], results)
+	for _, repoName := range sortedRootNames(roots, nodeCounts) {
+		results = m.runEnrichOne(g, repoName, roots[repoName], lang, provider, nodeCounts[repoName], results)
 	}
 	return results
 }

--- a/internal/semantic/provider.go
+++ b/internal/semantic/provider.go
@@ -58,6 +58,22 @@ type ContextEnricher interface {
 	EnrichRepoContext(ctx context.Context, g graph.Store, repoPrefix, repoRoot string) (*EnrichResult, error)
 }
 
+// ReadinessProber is an optional interface a Provider MAY implement when its
+// server answers `initialize` quickly but is not ready to serve semantic
+// queries until a slower background load finishes — the Roslyn / MSBuild
+// solution load a csharp-ls / OmniSharp pass sits behind. The Manager calls
+// WaitReady BEFORE it starts the per-repo enrichment deadline, so that cold
+// load does not consume the query budget (which otherwise elapses during the
+// load, leaving the pass with zero useful edges). WaitReady must respect ctx
+// (a bounded readiness budget) and should return promptly for a server that is
+// already ready — providers whose servers serve queries immediately after
+// initialize simply do not implement this interface. The returned error is
+// best-effort: enrichment proceeds regardless, so a probe failure never blocks
+// the pass.
+type ReadinessProber interface {
+	WaitReady(ctx context.Context, repoRoot string) error
+}
+
 // EnrichResult contains statistics from an enrichment pass.
 type EnrichResult struct {
 	Provider        string  `json:"provider"`


### PR DESCRIPTION
Five independent correctness/fidelity fixes across the reindex, enrichment, and query paths.

## Self-heal cross-file caller edges dropped on external re-parse
An external re-parse of a definition file (git checkout, editor undo) could leave a surviving symbol's incoming cross-file caller edges stubbed, so `find_usages` collapsed to zero and never recovered — the append case self-healed but a revert did not. The resolved-edge regression guard now watches a definition's **incoming** resolved edges (restricted to surviving definitions, and not gated on the node count dropping — a revert removes the appended probe yet the surviving definition must keep its callers), so a revert enqueues the same forced scoped re-resolve the append path already used. The incoming-resolve pass also persists a restored edge even when the per-edge resolve reports no target change, so a disk backend's freshly decoded edge no longer loses the in-place provenance restore.

## Deterministic primary-language-first enrichment scheduling
`EnrichAll` ran its providers and per-repo passes in Go map-iteration order, which is randomised. On a multi-language repo that let whichever language the map yielded first claim the bounded enrichment window — a Go-primary repo with a minor TS subtree could see its gopls pass never run. Providers are now ordered by the repo's language composition (most enrichable nodes first, ties by language name), and the per-repo loops visit repos in a deterministic order. Single-language repos are unaffected — one provider, one order.

## Readiness gate for solution-load LSP servers
A Roslyn/MSBuild-class C# server answers `initialize` quickly but keeps loading its solution afterward, serving empty results until that finishes — and the per-repo enrichment deadline started immediately, so it elapsed during the load and the pass landed zero edges. Providers may now implement an optional readiness interface; the manager brings such a server to readiness before starting the deadline, moving the cold-load latency out of the query budget. Only opted-in providers pay it (a server ready after `initialize` never waits); the wait is bounded and best-effort.

## Keep C# member calls through an incompletely-indexed hierarchy
The C# receiver-type gate demoted a member call whenever its resolved target sat on a type unrelated to the call's receiver in the indexed hierarchy. When the receiver derives from a base or interface the index could not resolve (an external assembly, a generic type parameter), the relatedness walk misses the link and a legitimate polymorphic call is wrongly demoted. The gate now keeps the edge when the receiver declares an unresolved supertype — the same conservatism the both-endpoints-known guard already applies, extended to hierarchy completeness. A genuinely unrelated call still demotes.

## Resolve find_usages through JS/TS barrel re-exports
A barrel that forwards a binding it does not declare (`export { persist } from './middleware/persist'`) was recorded only as a file-level re-export edge; no node was minted for the forwarded binding, so `find_usages` on the public import path a consumer imports (`src/middleware.ts::persist`) returned `not_found`. `find_usages` now maps a barrel-binding id to its canonical declaration by walking the re-export chain — named, aliased, chained barrels, and `export * from`. The mapping runs only when the queried id is not itself a node, so a real symbol's result is never altered and no usages are double-counted.

## Testing
- Unit tests for every change: sqlite double-cycle regression lock + self-heal recovery + guard-arm tests; provider-ordering and repo-visit tests; fake slow-solution-server readiness tests; a receiver-gate keep-case (with the true-positive demote still asserted); named/aliased/chained/wildcard barrel-resolution tests.
- `go build ./...` (incl. CGO `cmd/gortex`), `go vet`, and golangci-lint are clean on the touched packages; `-race` is green; the wire-contract golden is unchanged (Meta-only additions, no struct fields).
- The live recall/staleness bench gates were not run here and should be exercised before merge.
