### PR TITLE
Make local embeddings reliable: truncate over-budget inputs and surface silent fallbacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,15 @@ jobs:
       - name: Build default (Hugot bundled — no tag)
         run: go build -o gortex-default ./cmd/gortex/
 
+      - name: Install rust tokenizers library
+        # hugot's XLA session uses the rust tokenizer, statically linked as
+        # -ltokenizers, so the embeddings_gomlx XLA build needs libtokenizers.a
+        # on the linker path. (The pure-Go default and the ONNX build do not.)
+        run: |
+          curl -fsSL https://github.com/daulet/tokenizers/releases/download/v1.27.0/libtokenizers.linux-amd64.tar.gz | tar -xz
+          sudo cp libtokenizers.a /usr/lib/
+          sudo cp libtokenizers.a /usr/local/lib/
+
       - name: Build with GoMLX + XLA tags
         run: go build -tags "embeddings_gomlx XLA" -o gortex-gomlx ./cmd/gortex/
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,11 @@ jobs:
       - name: Build default (Hugot bundled — no tag)
         run: go build -o gortex-default ./cmd/gortex/
 
-      - name: Build with GoMLX tag
-        run: go build -tags embeddings_gomlx -o gortex-gomlx ./cmd/gortex/
+      - name: Build with GoMLX + XLA tags
+        run: go build -tags "embeddings_gomlx XLA" -o gortex-gomlx ./cmd/gortex/
+
+      - name: Build with GoMLX tag only (compat — some docs/scripts still pass it alone)
+        run: go build -tags embeddings_gomlx -o gortex-gomlx-noxla ./cmd/gortex/
 
   benchmark:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build-onnx: deps-onnx
 	go build -tags embeddings_onnx -ldflags '$(LDFLAGS)' -o $(BINARY) ./cmd/gortex/
 
 build-gomlx: deps-gomlx
-	go build -tags embeddings_gomlx -ldflags '$(LDFLAGS)' -o $(BINARY) ./cmd/gortex/
+	go build -tags "embeddings_gomlx XLA" -ldflags '$(LDFLAGS)' -o $(BINARY) ./cmd/gortex/
 
 # Hugot is bundled by default now — this target is kept as a compatibility
 # alias and also ensures the dep is explicitly recorded in go.mod.

--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,23 @@ deps-gomlx:
 	@echo "=== GoMLX dependency ==="
 	go get github.com/gomlx/gomlx@latest
 	go get github.com/gomlx/onnx-gomlx@latest
-	@echo "✓ GoMLX + ONNX converter installed"
+	@echo "=== rust tokenizers (the XLA session links libtokenizers.a statically) ==="
+	@if [ -f /usr/lib/libtokenizers.a ] || [ -f /usr/local/lib/libtokenizers.a ]; then \
+		echo "✓ libtokenizers.a already present"; \
+	else \
+		os=$$(uname -s | tr '[:upper:]' '[:lower:]'); arch=$$(uname -m); \
+		case "$$os-$$arch" in \
+			darwin-arm64) asset=libtokenizers.darwin-arm64.tar.gz; dest=/usr/local/lib ;; \
+			darwin-x86_64) asset=libtokenizers.darwin-x86_64.tar.gz; dest=/usr/local/lib ;; \
+			linux-x86_64|linux-amd64) asset=libtokenizers.linux-amd64.tar.gz; dest=/usr/lib ;; \
+			linux-aarch64|linux-arm64) asset=libtokenizers.linux-arm64.tar.gz; dest=/usr/lib ;; \
+			*) echo "No prebuilt libtokenizers for $$os-$$arch — build it from https://github.com/daulet/tokenizers and place libtokenizers.a on the linker path"; exit 1 ;; \
+		esac; \
+		echo "  downloading $$asset -> $$dest"; \
+		curl -fsSL "https://github.com/daulet/tokenizers/releases/download/v1.27.0/$$asset" | tar -xz -C /tmp; \
+		sudo cp /tmp/libtokenizers.a "$$dest/"; \
+	fi
+	@echo "✓ GoMLX + ONNX converter + rust tokenizers installed"
 	@echo "  Note: XLA/PJRT plugin will auto-download on first run (~100MB)"
 
 # Hugot — uses same XLA/PJRT backend as GoMLX

--- a/cmd/gortex/embedder.go
+++ b/cmd/gortex/embedder.go
@@ -12,5 +12,6 @@ import (
 type embedderRequest = serverstack.EmbedderRequest
 
 func resolveEmbedder(req embedderRequest, cfg *config.Config) (embedding.Provider, string, error) {
-	return serverstack.ResolveEmbedder(req, cfg)
+	p, desc, _, err := serverstack.ResolveEmbedder(req, cfg)
+	return p, desc, err
 }

--- a/cmd/gortex/eval_embedders.go
+++ b/cmd/gortex/eval_embedders.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"gopkg.in/yaml.v3"
 
 	"github.com/zzet/gortex/internal/config"
@@ -194,6 +195,16 @@ func pickVariants(csv string) []string {
 	}
 }
 
+// vectorBuildNote turns an indexer's LastVectorBuildError into the row note:
+// the concrete cause when the vector build failed, otherwise the generic
+// "empty corpus" note.
+func vectorBuildNote(err error) string {
+	if err != nil {
+		return "vector build failed: " + err.Error()
+	}
+	return "no vector data after indexing"
+}
+
 // benchVariant loads one ONNX variant, measures init + embed latency,
 // optionally re-indexes + runs the semantic ranker, and returns one row.
 func benchVariant(name string, probeTexts []string, fixture recall.Fixture, cfg *config.Config, absIndex string, skipQuality bool) (embedderResult, error) {
@@ -242,7 +253,15 @@ func benchVariant(name string, probeTexts []string, fixture recall.Fixture, cfg 
 	g := graph.New()
 	reg := parser.NewRegistry()
 	languages.RegisterAll(reg)
-	idx := indexer.New(g, reg, cfg.Index, zap.NewNop())
+	// A WARN-level stderr logger (not zap.NewNop) so the indexer's vector-build
+	// warnings — chunk timeouts, the over-threshold guard, the chunk-failure
+	// abort — are visible during the benchmark instead of being swallowed.
+	warnLog := zap.New(zapcore.NewCore(
+		zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig()),
+		zapcore.AddSync(os.Stderr),
+		zapcore.WarnLevel,
+	))
+	idx := indexer.New(g, reg, cfg.Index, warnLog)
 	idx.SetEmbedder(prov)
 
 	idxStart := time.Now()
@@ -258,7 +277,10 @@ func benchVariant(name string, probeTexts []string, fixture recall.Fixture, cfg 
 	}
 	hybrid, _ := inner.(*search.HybridBackend)
 	if hybrid == nil || hybrid.VectorIndex() == nil || hybrid.VectorIndex().Count() == 0 {
-		row.Notes = "no vector data after indexing"
+		// Distinguish an actual vector-build failure (chunk-embed error,
+		// all-invalid vectors, over-threshold guard) from a genuinely empty
+		// corpus, so the row reports the real cause rather than a bare note.
+		row.Notes = vectorBuildNote(idx.LastVectorBuildError())
 		return row, nil
 	}
 

--- a/cmd/gortex/eval_embedders_note_test.go
+++ b/cmd/gortex/eval_embedders_note_test.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestVectorBuildNote(t *testing.T) {
+	if got := vectorBuildNote(nil); got != "no vector data after indexing" {
+		t.Fatalf("nil-error note = %q, want the generic empty-corpus note", got)
+	}
+	got := vectorBuildNote(errors.New("chunk embedding failed: boom"))
+	if want := "vector build failed: chunk embedding failed: boom"; got != want {
+		t.Fatalf("error note = %q, want %q", got, want)
+	}
+}

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -72,11 +72,13 @@ The combo store now keys symbol associations both on the whole query and per key
 Opt-in faster local backends via build tags:
 
 ```bash
-go build -tags embeddings_onnx ./cmd/gortex/   # needs: brew install onnxruntime
-go build -tags embeddings_gomlx ./cmd/gortex/  # auto-downloads XLA plugin
+go build -tags embeddings_onnx ./cmd/gortex/          # needs: brew install onnxruntime
+go build -tags "embeddings_gomlx XLA" ./cmd/gortex/   # activates the XLA/GoMLX backend; PJRT plugin auto-downloads at runtime
 ```
 
 The `embeddings_onnx` backend (GTE-small) **never auto-downloads**: place `model.onnx` and `vocab.txt` in `~/.gortex/models/gte-small/` yourself and install the ONNX Runtime native library (`brew install onnxruntime`, or the distro equivalent). Without both, the backend reports "ONNX model not found" and the local chain falls through to the pure-Go Hugot backend.
+
+The GoMLX/XLA backend requires **both** tags — `embeddings_gomlx` alone links a disabled XLA stub and always falls through to the pure-Go backend; the `XLA` tag is what compiles the real XLA session. The tag pair is compile-verified, but XLA/PJRT runtime viability is platform-dependent and still experimental — if the plugin fails to load, the local chain degrades to the pure-Go Hugot backend and the startup log names the failed backend (see Troubleshooting). The default pure-Go backend needs no tags and is the reliable path.
 
 The legacy `--embeddings` / `--embeddings-url` / `--embeddings-model` CLI flags and the `GORTEX_EMBEDDINGS*` env vars still take precedence over the config block — useful for one-shot overrides without editing `.gortex.yaml`.
 

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -20,6 +20,14 @@ embedding:
 
 Selecting a different embedding model (`variant`, or `GORTEX_EMBEDDINGS_VARIANT`) that changes vector dimensionality re-embeds the graph on next index; the persisted index guards against a dimension mismatch.
 
+### Where the config lives — and what wins
+
+The `embedding:` block can sit in more than one place; precedence, highest first:
+
+1. **`--embeddings` / `--embeddings-url` / `--embeddings-model` flags** and the **`GORTEX_EMBEDDINGS*` env vars** — one-shot overrides. A URL forces the `api` provider; `GORTEX_EMBEDDINGS=0/1` toggles the vector channel; `GORTEX_EMBEDDINGS_VARIANT` pins a local model.
+2. **Repo-local `.gortex.yaml`** — the per-project `embedding:` block (loaded by viper, so `GORTEX_EMBEDDING_*` env keys also merge here).
+3. **Global `~/.gortex/config.yaml`** — a user-level `embedding:` block layered *under* the repo-local one: every field the repo leaves unset inherits the global value (the tri-state `enabled:` too), so one block can serve every repo. An unrecognised top-level key in this file is ignored with a startup warning (`contains keys gortex does not recognize`) rather than silently dropped — the usual cause of an `embedding:` block that "does nothing" is placing it under the wrong key here.
+
 | Provider | Quality | Offline | Native deps | Notes |
 |---|---|---|---|---|
 | `static` (default) | Good for identifier-shaped queries | Yes | None | Baked GloVe-50d table, CPU-only, zero setup |
@@ -29,6 +37,10 @@ Selecting a different embedding model (`variant`, or `GORTEX_EMBEDDINGS_VARIANT`
 ## AST sub-chunking
 
 Symbols longer than `chunk_threshold_lines` are split into AST-aware windows (block statements, case clauses, field groups) before embedding; each window is vectorised independently and de-duplicated back to the parent symbol at query time, so a large function lands as one hit grounded in the specific chunk that matched — chunk IDs never leak into results.
+
+## Input truncation
+
+Every embedding input is capped at the model's positional budget — `max_position_embeddings` from the model's `config.json` minus the two special-token slots (510 for MiniLM/BERT; larger for wide-context variants) — before it reaches inference. A transformer cannot attend past that window, so trimming the tail is lossless by construction, and it is load-bearing: the pure-Go tokenizer path does not enforce the limit itself, so a single over-budget input would otherwise reach inference at full length and abort the *entire* vector-index build with a tensor shape mismatch — dropping the daemon to text-only search. AST chunking already splits long symbols into sub-budget windows, so truncation only ever trims a pathological single chunk. If the model directory lacks a readable `config.json` the budget falls back to 510; if the tokenizer itself can't load, truncation degrades to a rune clamp rather than disabling the backend.
 
 ## Persistent index
 
@@ -80,7 +92,24 @@ The `embeddings_onnx` backend (GTE-small) **never auto-downloads**: place `model
 
 The GoMLX/XLA backend requires **both** tags — `embeddings_gomlx` alone links a disabled XLA stub and always falls through to the pure-Go backend; the `XLA` tag is what compiles the real XLA session. The tag pair is compile-verified, but XLA/PJRT runtime viability is platform-dependent and still experimental — if the plugin fails to load, the local chain degrades to the pure-Go Hugot backend and the startup log names the failed backend (see Troubleshooting). The default pure-Go backend needs no tags and is the reliable path.
 
+| Build tag | Backend | Model | Extra dependency | Status |
+|---|---|---|---|---|
+| _(none)_ | Hugot pure-Go | MiniLM-L6-v2 (auto-download) | none | **default — reliable path** |
+| `embeddings_gomlx XLA` | Hugot + XLA/GoMLX | MiniLM-L6-v2 (auto-download) | PJRT plugin (runtime download) | experimental — compile-verified; XLA/PJRT runtime is platform-dependent |
+| `embeddings_onnx` | ONNX Runtime | GTE-small (manual placement) | libonnxruntime + hand-placed model | manual setup — never auto-downloads |
+
 The legacy `--embeddings` / `--embeddings-url` / `--embeddings-model` CLI flags and the `GORTEX_EMBEDDINGS*` env vars still take precedence over the config block — useful for one-shot overrides without editing `.gortex.yaml`.
+
+## Troubleshooting
+
+Semantic search degrading to text-only (BM25 / FTS5) is always logged — match the daemon log line to the cause:
+
+- **`embeddings enabled ... provider: local (hugot/fp32), dim: 384`** — working as intended: the transformer backend is active at its true width.
+- **`embeddings enabled ... provider: local → static fallback, dim: 50`** — a `local` config could not construct any transformer backend and fell back to static GloVe. The preceding `embedding backend unavailable — degraded to static fallback` warnings name each backend and why (an uncached model with downloads disabled, a missing `embeddings_onnx` model, …). Fix the named backend or accept static; the width and provider name now tell the truth rather than echoing the configured name.
+- **`vector index aborted on chunk failure`** — an embedding call failed (API timeout / auth, or an over-long input on a build without truncation) and the whole vector index was dropped to avoid a half-embedded, mis-scoring index. Text search stays live. `gortex eval embedders` reports the concrete cause as `vector build failed: …` instead of a bare "no vector data".
+- **`vector index built ... dropped: N`** (N > 0) — N malformed vectors (nil / wrong width) were skipped; the `sample_ids` warning names the first few. A non-zero `dropped` from a healthy provider is worth investigating.
+- **`vector index disabled — embedding text count exceeds threshold`** — the corpus is larger than `embedding.max_symbols`; raise it if you have the memory headroom.
+- **`~/.gortex/config.yaml contains keys gortex does not recognize`** — a top-level key (commonly an `embedding:` block nested one level too deep, or a typo) is being ignored; move it to a recognised key.
 
 ## `search_symbols` `assist:` modes
 

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -85,17 +85,17 @@ Opt-in faster local backends via build tags:
 
 ```bash
 go build -tags embeddings_onnx ./cmd/gortex/          # needs: brew install onnxruntime
-go build -tags "embeddings_gomlx XLA" ./cmd/gortex/   # activates the XLA/GoMLX backend; PJRT plugin auto-downloads at runtime
+go build -tags "embeddings_gomlx XLA" ./cmd/gortex/   # needs libtokenizers.a on the linker path — use `make build-gomlx` (see below)
 ```
 
 The `embeddings_onnx` backend (GTE-small) **never auto-downloads**: place `model.onnx` and `vocab.txt` in `~/.gortex/models/gte-small/` yourself and install the ONNX Runtime native library (`brew install onnxruntime`, or the distro equivalent). Without both, the backend reports "ONNX model not found" and the local chain falls through to the pure-Go Hugot backend.
 
-The GoMLX/XLA backend requires **both** tags — `embeddings_gomlx` alone links a disabled XLA stub and always falls through to the pure-Go backend; the `XLA` tag is what compiles the real XLA session. The tag pair is compile-verified, but XLA/PJRT runtime viability is platform-dependent and still experimental — if the plugin fails to load, the local chain degrades to the pure-Go Hugot backend and the startup log names the failed backend (see Troubleshooting). The default pure-Go backend needs no tags and is the reliable path.
+The GoMLX/XLA backend requires **both** tags — `embeddings_gomlx` alone links a disabled XLA stub and always falls through to the pure-Go backend; the `XLA` tag is what compiles the real XLA session. It also statically links the rust tokenizer, so the build needs `libtokenizers.a` on the linker path (a prebuilt archive from [daulet/tokenizers](https://github.com/daulet/tokenizers) releases, at `/usr/lib` or `/usr/local/lib`); `make build-gomlx` downloads it for you. At runtime the XLA/PJRT plugin auto-downloads (~100 MB). XLA/PJRT runtime viability is platform-dependent and still experimental — if the plugin fails to load, the local chain degrades to the pure-Go Hugot backend and the startup log names the failed backend (see Troubleshooting). The default pure-Go backend needs no tags and no native libraries, and is the reliable path.
 
 | Build tag | Backend | Model | Extra dependency | Status |
 |---|---|---|---|---|
 | _(none)_ | Hugot pure-Go | MiniLM-L6-v2 (auto-download) | none | **default — reliable path** |
-| `embeddings_gomlx XLA` | Hugot + XLA/GoMLX | MiniLM-L6-v2 (auto-download) | PJRT plugin (runtime download) | experimental — compile-verified; XLA/PJRT runtime is platform-dependent |
+| `embeddings_gomlx XLA` | Hugot + XLA/GoMLX | MiniLM-L6-v2 (auto-download) | libtokenizers.a (build) + PJRT plugin (runtime download) | experimental — XLA/PJRT runtime is platform-dependent |
 | `embeddings_onnx` | ONNX Runtime | GTE-small (manual placement) | libonnxruntime + hand-placed model | manual setup — never auto-downloads |
 
 The legacy `--embeddings` / `--embeddings-url` / `--embeddings-model` CLI flags and the `GORTEX_EMBEDDINGS*` env vars still take precedence over the config block — useful for one-shot overrides without editing `.gortex.yaml`.

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -76,6 +76,8 @@ go build -tags embeddings_onnx ./cmd/gortex/   # needs: brew install onnxruntime
 go build -tags embeddings_gomlx ./cmd/gortex/  # auto-downloads XLA plugin
 ```
 
+The `embeddings_onnx` backend (GTE-small) **never auto-downloads**: place `model.onnx` and `vocab.txt` in `~/.gortex/models/gte-small/` yourself and install the ONNX Runtime native library (`brew install onnxruntime`, or the distro equivalent). Without both, the backend reports "ONNX model not found" and the local chain falls through to the pure-Go Hugot backend.
+
 The legacy `--embeddings` / `--embeddings-url` / `--embeddings-model` CLI flags and the `GORTEX_EMBEDDINGS*` env vars still take precedence over the config block — useful for one-shot overrides without editing `.gortex.yaml`.
 
 ## `search_symbols` `assist:` modes

--- a/go.mod
+++ b/go.mod
@@ -224,6 +224,7 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/fwcd/tree-sitter-kotlin v0.0.0-20260411204054-55622a49bd59
 	github.com/gofrs/flock v0.13.0
+	github.com/gomlx/go-huggingface v0.3.5
 	github.com/google/go-github/v88 v88.0.0
 	github.com/google/uuid v1.6.0
 	github.com/gortexhq/gcx-go v0.1.0
@@ -326,7 +327,6 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/gomlx/exceptions v0.0.3 // indirect
-	github.com/gomlx/go-huggingface v0.3.5 // indirect
 	github.com/gomlx/go-xla v0.2.2 // indirect
 	github.com/gomlx/gomlx v0.27.3 // indirect
 	github.com/gomlx/onnx-gomlx v0.4.2 // indirect

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 
@@ -75,6 +76,13 @@ type GlobalConfig struct {
 	// without duplicating an `llm:` block in every `.gortex.yaml`.
 	LLM llm.Config `mapstructure:"llm" yaml:"llm,omitempty"`
 
+	// Embedding is the user-level semantic-search config (`embedding.provider:`
+	// etc.). Merged into the repo-local Config.Embedding at daemon startup via
+	// MergeEmbeddingInto — local non-zero fields win, global fills the rest —
+	// so an `embedding:` block can live in ~/.gortex/config.yaml and apply
+	// across repos instead of being duplicated in every `.gortex.yaml`.
+	Embedding EmbeddingConfig `mapstructure:"embedding" yaml:"embedding,omitempty"`
+
 	// configPath stores the file path used for Save(). Set by LoadGlobal or SetConfigPath.
 	configPath string `yaml:"-"`
 }
@@ -94,6 +102,82 @@ func (gc *GlobalConfig) MergeLLMInto(local llm.Config) llm.Config {
 	}
 	local.Local.Model = expandHome(local.Local.Model)
 	return local
+}
+
+// MergeEmbeddingInto layers a repo-local EmbeddingConfig over the global user
+// config: each zero-valued field of local is filled from gc.Embedding, so an
+// `embedding:` block in ~/.gortex/config.yaml applies across repos while any
+// per-repo `.gortex.yaml` value still wins. Enabled is a tri-state pointer, so
+// a local nil (unset) inherits the global toggle. Safe on a nil receiver.
+func (gc *GlobalConfig) MergeEmbeddingInto(local EmbeddingConfig) EmbeddingConfig {
+	if gc == nil {
+		return local
+	}
+	g := gc.Embedding
+	if local.Enabled == nil {
+		local.Enabled = g.Enabled
+	}
+	if local.Provider == "" {
+		local.Provider = g.Provider
+	}
+	if local.APIURL == "" {
+		local.APIURL = g.APIURL
+	}
+	if local.APIModel == "" {
+		local.APIModel = g.APIModel
+	}
+	if local.MaxSymbols == 0 {
+		local.MaxSymbols = g.MaxSymbols
+	}
+	if local.ChunkThresholdLines == 0 {
+		local.ChunkThresholdLines = g.ChunkThresholdLines
+	}
+	if local.ChunkWindowLines == 0 {
+		local.ChunkWindowLines = g.ChunkWindowLines
+	}
+	if local.APIConcurrency == 0 {
+		local.APIConcurrency = g.APIConcurrency
+	}
+	if local.Variant == "" {
+		local.Variant = g.Variant
+	}
+	return local
+}
+
+// knownGlobalTopLevelKeys is the set of top-level keys LoadGlobal understands.
+// Anything else in ~/.gortex/config.yaml is silently dropped by yaml.Unmarshal,
+// so UnknownGlobalKeys surfaces it for a startup warning.
+var knownGlobalTopLevelKeys = map[string]bool{
+	"projects": true, "repos": true, "active_project": true,
+	"exclude": true, "llm": true, "embedding": true,
+}
+
+// UnknownGlobalKeys returns the top-level keys present in the global config file
+// that gortex does not recognise — e.g. an `embedding:` block placed under the
+// wrong nesting, or a typo. It never fails: a missing or unparseable file yields
+// no keys, so forward compatibility (an older binary reading a newer config) is
+// preserved. Pass a path to override the default ~/.gortex/config.yaml.
+func UnknownGlobalKeys(configPath ...string) []string {
+	path := DefaultGlobalConfigPath()
+	if len(configPath) > 0 && configPath[0] != "" {
+		path = configPath[0]
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var top map[string]any
+	if err := yaml.Unmarshal(data, &top); err != nil {
+		return nil
+	}
+	var unknown []string
+	for k := range top {
+		if !knownGlobalTopLevelKeys[k] {
+			unknown = append(unknown, k)
+		}
+	}
+	sort.Strings(unknown)
+	return unknown
 }
 
 // expandHome resolves a leading `~/` in a path against $HOME so users

--- a/internal/config/global_embedding_test.go
+++ b/internal/config/global_embedding_test.go
@@ -1,0 +1,122 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestLoadGlobal_EmbeddingSectionRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`active_project: ""
+repos: []
+embedding:
+    enabled: true
+    provider: local
+    variant: jina_code
+    max_symbols: 50000
+`), 0o644))
+
+	gc, err := LoadGlobal(cfgPath)
+	require.NoError(t, err)
+	require.NotNil(t, gc)
+	require.NotNil(t, gc.Embedding.Enabled)
+	assert.True(t, *gc.Embedding.Enabled)
+	assert.Equal(t, "local", gc.Embedding.Provider)
+	assert.Equal(t, "jina_code", gc.Embedding.Variant)
+	assert.Equal(t, 50000, gc.Embedding.MaxSymbols)
+}
+
+func TestGlobalConfig_MergeEmbeddingInto_FillsZeroFields(t *testing.T) {
+	gc := &GlobalConfig{Embedding: EmbeddingConfig{
+		Enabled:        boolPtr(true),
+		Provider:       "local",
+		Variant:        "bge_small",
+		APIConcurrency: 8,
+	}}
+
+	got := gc.MergeEmbeddingInto(EmbeddingConfig{})
+	require.NotNil(t, got.Enabled)
+	assert.True(t, *got.Enabled)
+	assert.Equal(t, "local", got.Provider)
+	assert.Equal(t, "bge_small", got.Variant)
+	assert.Equal(t, 8, got.APIConcurrency)
+}
+
+func TestGlobalConfig_MergeEmbeddingInto_LocalWinsPerField(t *testing.T) {
+	gc := &GlobalConfig{Embedding: EmbeddingConfig{
+		Enabled:  boolPtr(true),
+		Provider: "static",
+		Variant:  "bge_small",
+	}}
+
+	got := gc.MergeEmbeddingInto(EmbeddingConfig{
+		Enabled:  boolPtr(false), // explicit local off wins over global on
+		Provider: "local",        // local provider wins
+		// Variant left empty -> inherits global
+	})
+	require.NotNil(t, got.Enabled)
+	assert.False(t, *got.Enabled, "explicit local Enabled:false must win over global true")
+	assert.Equal(t, "local", got.Provider)
+	assert.Equal(t, "bge_small", got.Variant, "empty local variant inherits the global one")
+}
+
+func TestGlobalConfig_MergeEmbeddingInto_NilReceiver(t *testing.T) {
+	var gc *GlobalConfig
+	local := EmbeddingConfig{Provider: "api", APIURL: "http://x"}
+	got := gc.MergeEmbeddingInto(local)
+	assert.Equal(t, local, got, "nil receiver returns local unchanged")
+}
+
+func TestUnknownGlobalKeys(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`active_project: ""
+llm:
+    provider: local
+embedding:
+    provider: local
+embeddings:            # <- typo: the ignored, unrecognised key
+    provider: local
+totally_unknown: 1
+`), 0o644))
+
+	unknown := UnknownGlobalKeys(cfgPath)
+	assert.Equal(t, []string{"embeddings", "totally_unknown"}, unknown)
+
+	// The recognised keys still load fine — an unknown key never fails the load.
+	gc, err := LoadGlobal(cfgPath)
+	require.NoError(t, err)
+	assert.Equal(t, "local", gc.Embedding.Provider)
+}
+
+func TestUnknownGlobalKeys_CleanConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`embedding:
+    provider: local
+llm:
+    provider: local
+`), 0o644))
+	assert.Empty(t, UnknownGlobalKeys(cfgPath))
+
+	// A missing file is not an error and yields no keys.
+	assert.Empty(t, UnknownGlobalKeys(filepath.Join(dir, "does-not-exist.yaml")))
+}
+
+func TestGlobalConfig_SaveEmbeddingRoundTrip(t *testing.T) {
+	gc := &GlobalConfig{Embedding: EmbeddingConfig{Provider: "local", Variant: "jina_code"}}
+	gc.SetConfigPath(filepath.Join(t.TempDir(), "config.yaml"))
+	require.NoError(t, gc.Save())
+
+	back, err := LoadGlobal(gc.ConfigPath())
+	require.NoError(t, err)
+	assert.Equal(t, "local", back.Embedding.Provider)
+	assert.Equal(t, "jina_code", back.Embedding.Variant)
+}

--- a/internal/embedding/api.go
+++ b/internal/embedding/api.go
@@ -134,10 +134,25 @@ func (p *APIProvider) Embed(ctx context.Context, text string) ([]float32, error)
 }
 
 func (p *APIProvider) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	var (
+		vecs [][]float32
+		err  error
+	)
 	if p.format == formatOllama {
-		return p.embedOllama(ctx, texts)
+		vecs, err = p.embedOllama(ctx, texts)
+	} else {
+		vecs, err = p.embedOpenAI(ctx, texts)
 	}
-	return p.embedOpenAI(ctx, texts)
+	if err != nil {
+		return nil, err
+	}
+	// Width is learned lazily from the response (dims 0), so validate the count,
+	// reject empty vectors, and check the batch is internally consistent without
+	// asserting an absolute width.
+	if err := validateBatch("api", texts, vecs, 0); err != nil {
+		return nil, err
+	}
+	return vecs, nil
 }
 
 func (p *APIProvider) Dimensions() int { return p.dims }

--- a/internal/embedding/gomlx.go
+++ b/internal/embedding/gomlx.go
@@ -90,6 +90,9 @@ func (p *GoMLXProvider) EmbedBatch(ctx context.Context, texts []string) ([][]flo
 	if err != nil {
 		return nil, fmt.Errorf("gomlx run: %w", err)
 	}
+	if err := validateBatch("gomlx", texts, output.Embeddings, p.dims); err != nil {
+		return nil, err
+	}
 	return output.Embeddings, nil
 }
 

--- a/internal/embedding/gomlx.go
+++ b/internal/embedding/gomlx.go
@@ -20,10 +20,11 @@ const gomlxModelName = "sentence-transformers/all-MiniLM-L6-v2"
 // GoMLXProvider uses Hugot with the XLA/GoMLX backend for transformer embeddings.
 // XLA/PJRT plugin auto-downloads on first use (~100MB).
 type GoMLXProvider struct {
-	session  *hugot.Session
-	pipeline *pipelines.FeatureExtractionPipeline
-	dims     int
-	mu       sync.Mutex
+	session   *hugot.Session
+	pipeline  *pipelines.FeatureExtractionPipeline
+	dims      int
+	truncator *tokenTruncator
+	mu        sync.Mutex
 }
 
 func newGoMLXProvider() (Provider, error) {
@@ -52,10 +53,19 @@ func newGoMLXProvider() (Provider, error) {
 		return nil, fmt.Errorf("gomlx pipeline: %w", err)
 	}
 
+	// Belt-and-suspenders token truncation: the XLA path's Rust tokenizer
+	// already truncates, but keeping the client-side cap here matches the
+	// pure-Go provider and covers a degraded tokenizer. See hugot.go.
+	truncator, terr := newTokenTruncator(modelPath)
+	if terr != nil {
+		fmt.Fprintf(os.Stderr, "[gortex embedding] %v\n", terr)
+	}
+
 	return &GoMLXProvider{
-		session:  session,
-		pipeline: pipeline,
-		dims:     384,
+		session:   session,
+		pipeline:  pipeline,
+		dims:      384,
+		truncator: truncator,
 	}, nil
 }
 
@@ -73,6 +83,8 @@ func (p *GoMLXProvider) Embed(ctx context.Context, text string) ([]float32, erro
 func (p *GoMLXProvider) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+
+	texts = p.truncator.TruncateAll(texts)
 
 	output, err := p.pipeline.RunPipeline(ctx, texts)
 	if err != nil {

--- a/internal/embedding/gomlx_stub.go
+++ b/internal/embedding/gomlx_stub.go
@@ -2,8 +2,8 @@
 
 package embedding
 
-import "errors"
+import "fmt"
 
 func newGoMLXProvider() (Provider, error) {
-	return nil, errors.New("GoMLX provider not compiled in (build with -tags embeddings_gomlx)")
+	return nil, fmt.Errorf("GoMLX provider not compiled in (build with -tags \"embeddings_gomlx XLA\"): %w", ErrBackendNotCompiled)
 }

--- a/internal/embedding/hugot.go
+++ b/internal/embedding/hugot.go
@@ -170,6 +170,9 @@ func (p *HugotProvider) EmbedBatch(ctx context.Context, texts []string) ([][]flo
 	if err != nil {
 		return nil, fmt.Errorf("hugot run: %w", err)
 	}
+	if err := validateBatch("hugot", texts, output.Embeddings, p.dims); err != nil {
+		return nil, err
+	}
 	return output.Embeddings, nil
 }
 

--- a/internal/embedding/hugot.go
+++ b/internal/embedding/hugot.go
@@ -23,10 +23,11 @@ const miniLMRepo = "sentence-transformers/all-MiniLM-L6-v2"
 // HugotProvider uses Hugot with the pure Go backend for offline transformer embeddings.
 // Model auto-downloads from Hugging Face on first use.
 type HugotProvider struct {
-	session  *hugot.Session
-	pipeline *pipelines.FeatureExtractionPipeline
-	dims     int
-	mu       sync.Mutex
+	session   *hugot.Session
+	pipeline  *pipelines.FeatureExtractionPipeline
+	dims      int
+	truncator *tokenTruncator
+	mu        sync.Mutex
 }
 
 // DefaultHugotVariant is the short name of the variant newHugotProvider
@@ -128,10 +129,23 @@ func newHugotProviderWithSpec(spec HugotVariant) (Provider, error) {
 	if dims == 0 {
 		dims = 384 // conservative fallback
 	}
+
+	// Cap inputs at the model's positional budget before they reach the
+	// pipeline. The pure-Go tokenizer path does not honour
+	// max_position_embeddings, so an over-long text would otherwise abort the
+	// whole vector index with a tensor shape mismatch. A degraded truncator
+	// (missing config.json / corrupt tokenizer.json) still works via a rune
+	// clamp, so we warn and continue rather than fail the provider.
+	truncator, terr := newTokenTruncator(modelPath)
+	if terr != nil {
+		fmt.Fprintf(os.Stderr, "[gortex embedding] %v\n", terr)
+	}
+
 	return &HugotProvider{
-		session:  session,
-		pipeline: pipeline,
-		dims:     dims,
+		session:   session,
+		pipeline:  pipeline,
+		dims:      dims,
+		truncator: truncator,
 	}, nil
 }
 
@@ -149,6 +163,8 @@ func (p *HugotProvider) Embed(ctx context.Context, text string) ([]float32, erro
 func (p *HugotProvider) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+
+	texts = p.truncator.TruncateAll(texts)
 
 	output, err := p.pipeline.RunPipeline(ctx, texts)
 	if err != nil {

--- a/internal/embedding/onnx.go
+++ b/internal/embedding/onnx.go
@@ -46,7 +46,7 @@ type ONNXProvider struct {
 func newONNXProvider() (Provider, error) {
 	modelDir := findONNXModelDir()
 	if modelDir == "" {
-		return nil, fmt.Errorf("ONNX model not found; place model.onnx + vocab.txt in ~/.gortex/models/gte-small/")
+		return nil, fmt.Errorf("ONNX model not found; this backend never auto-downloads — manually place model.onnx + vocab.txt in ~/.gortex/models/gte-small/ (plus `brew install onnxruntime` or the distro equivalent); see docs/semantic-search.md")
 	}
 
 	modelPath := filepath.Join(modelDir, "model.onnx")

--- a/internal/embedding/onnx_stub.go
+++ b/internal/embedding/onnx_stub.go
@@ -2,8 +2,8 @@
 
 package embedding
 
-import "errors"
+import "fmt"
 
 func newONNXProvider() (Provider, error) {
-	return nil, errors.New("ONNX provider not compiled in (build with -tags embeddings_onnx)")
+	return nil, fmt.Errorf("ONNX provider not compiled in (build with -tags embeddings_onnx): %w", ErrBackendNotCompiled)
 }

--- a/internal/embedding/provider.go
+++ b/internal/embedding/provider.go
@@ -14,8 +14,15 @@ package embedding
 
 import (
 	"context"
+	"errors"
 	"fmt"
 )
+
+// ErrBackendNotCompiled marks a local-backend factory that failed only because
+// its build tag was not set (the onnx/gomlx stubs). Such a failure is benign
+// noise in a default build — callers use errors.Is to log it at debug rather
+// than warn even when the chain degrades to the static fallback.
+var ErrBackendNotCompiled = errors.New("embedding backend not compiled in")
 
 // Provider generates embedding vectors from text.
 type Provider interface {

--- a/internal/embedding/provider.go
+++ b/internal/embedding/provider.go
@@ -109,23 +109,88 @@ func NewProviderFromConfig(cfg ProviderConfig) (Provider, error) {
 	}
 }
 
-// NewLocalProvider returns the best available local embedding provider.
-// Preference order: ONNX (fastest, requires libonnxruntime) → GoMLX (XLA) →
-// Hugot (pure Go, always compiled in) → Static (GloVe word vectors fallback).
-func NewLocalProvider() (Provider, error) {
-	// Opt-in transformer backends (compiled in via build tags), then the
-	// default Hugot pure-Go ONNX runtime which auto-downloads MiniLM-L6-v2
-	// to ~/.gortex/models/ on first use.
-	factories := []func() (Provider, error){
-		newONNXProvider,
-		newGoMLXProvider,
-		newHugotProvider,
-	}
-	for _, factory := range factories {
-		if p, err := factory(); err == nil {
-			return p, nil
+// NewProviderFromConfigWithReport is NewProviderFromConfig plus a SelectionReport
+// for the auto-selected local backend (Provider "local" with no pinned Variant),
+// so the caller can log which backend was constructed and which were skipped.
+// For every other provider the report is empty.
+func NewProviderFromConfigWithReport(cfg ProviderConfig) (Provider, SelectionReport, error) {
+	if cfg.Provider == "local" && cfg.Variant == "" {
+		p, report := NewLocalProviderWithReport()
+		if p == nil {
+			err := fmt.Errorf("no embedding provider available")
+			if n := len(report.Attempts); n > 0 {
+				err = report.Attempts[n-1].Err
+			}
+			return nil, report, err
 		}
+		return p, report, nil
+	}
+	p, err := NewProviderFromConfig(cfg)
+	return p, SelectionReport{}, err
+}
+
+// SelectionAttempt records one backend the local-provider chain tried and the
+// error that made it fall through. It exists so a silent degradation to the
+// static GloVe fallback becomes observable to the caller.
+type SelectionAttempt struct {
+	Backend string
+	Err     error
+}
+
+// SelectionReport describes how NewLocalProviderWithReport chose a backend: the
+// backend actually constructed, its dimension, and every rejected attempt.
+// Chosen is the backend name (e.g. "hugot", "static"); it is "static" when the
+// chain fell all the way through to the GloVe fallback.
+type SelectionReport struct {
+	Chosen   string
+	Dims     int
+	Attempts []SelectionAttempt
+}
+
+// NewLocalProviderWithReport returns the best available local embedding provider
+// along with a report of every backend it tried. Preference order: ONNX
+// (fastest, requires libonnxruntime) → GoMLX (XLA) → Hugot (pure Go, always
+// compiled in) → Static (GloVe word vectors fallback). A nil provider means even
+// the static fallback failed to construct (its error is the last attempt).
+func NewLocalProviderWithReport() (Provider, SelectionReport) {
+	factories := []struct {
+		name    string
+		factory func() (Provider, error)
+	}{
+		{"onnx", newONNXProvider},
+		{"gomlx", newGoMLXProvider},
+		{"hugot", newHugotProvider},
+	}
+	var report SelectionReport
+	for _, nf := range factories {
+		p, err := nf.factory()
+		if err == nil {
+			report.Chosen = nf.name
+			report.Dims = p.Dimensions()
+			return p, report
+		}
+		report.Attempts = append(report.Attempts, SelectionAttempt{Backend: nf.name, Err: err})
 	}
 	// Fallback: static word vectors (always available, no network).
-	return NewStaticProvider()
+	p, err := NewStaticProvider()
+	if err != nil {
+		report.Attempts = append(report.Attempts, SelectionAttempt{Backend: "static", Err: err})
+		return nil, report
+	}
+	report.Chosen = "static"
+	report.Dims = p.Dimensions()
+	return p, report
+}
+
+// NewLocalProvider returns the best available local embedding provider,
+// discarding the selection report. See NewLocalProviderWithReport.
+func NewLocalProvider() (Provider, error) {
+	p, report := NewLocalProviderWithReport()
+	if p == nil {
+		if n := len(report.Attempts); n > 0 {
+			return nil, report.Attempts[n-1].Err
+		}
+		return nil, fmt.Errorf("no embedding provider available")
+	}
+	return p, nil
 }

--- a/internal/embedding/truncate.go
+++ b/internal/embedding/truncate.go
@@ -22,11 +22,14 @@ const (
 	// truncation budget is max_position_embeddings minus this.
 	specialTokenReserve = 2
 
-	// runeClampFactor bounds the rune-clamp fallback when no real tokenizer is
-	// available: a WordPiece token spans at least one rune, so clamping to
-	// factor*budget runes is a loose-but-safe cap that keeps a corrupt tokenizer.json
-	// from letting an over-long text through to the pipeline.
-	runeClampFactor = 4
+	// runeClampBudgetFactor caps the rune-clamp fallback at budget runes. A
+	// WordPiece token spans at least one rune, so token_count <= rune_count;
+	// clamping to budget runes therefore guarantees token_count <= budget. A
+	// looser cap (e.g. 4*budget) would NOT bound the token count and could let a
+	// token-dense input (CJK, single-char words) overflow the window it is meant
+	// to protect. Recall loss in this rare fallback is an acceptable price for a
+	// hard safety bound.
+	runeClampBudgetFactor = 1
 )
 
 // tokenTruncator caps input texts at a model's positional budget before they reach
@@ -57,7 +60,7 @@ type tokenTruncator struct {
 // be loaded) so the caller can warn without disabling the provider.
 func newTokenTruncator(modelDir string) (*tokenTruncator, error) {
 	budget, budgetErr := readTokenBudget(modelDir)
-	t := &tokenTruncator{budget: budget, clamp: budget * runeClampFactor}
+	t := &tokenTruncator{budget: budget, clamp: budget * runeClampBudgetFactor}
 
 	tkBytes, err := os.ReadFile(filepath.Join(modelDir, "tokenizer.json"))
 	if err != nil {
@@ -87,9 +90,12 @@ func (t *tokenTruncator) Truncate(text string) string {
 	if t == nil || t.budget <= 0 || text == "" {
 		return text
 	}
-	// Fast path (DD-3): a WordPiece token spans at least one rune, so a rune count
+	// Fast path: a WordPiece/subword token spans at least one rune (true for every
+	// registered variant — MiniLM/BGE/Jina are all WordPiece), so a rune count
 	// within budget guarantees the token count is too. Only longer texts pay for the
-	// extra tokenizer pass; tokenization is µs–ms while inference dominates.
+	// extra tokenizer pass; tokenization is µs–ms while inference dominates. (A
+	// byte-level-BPE variant, where one rune can yield several tokens, would need
+	// this invariant revisited — but the exact-tokenize path below is always correct.)
 	if utf8.RuneCountInString(text) <= t.budget {
 		return text
 	}
@@ -105,7 +111,11 @@ func (t *tokenTruncator) Truncate(text string) string {
 		return clampRunes(text, t.clamp)
 	}
 	cut := enc.Spans[t.budget-1].End
-	if cut <= 0 || cut > len(text) {
+	// cut must land strictly inside the text: we only reach here with more than
+	// budget tokens, so the budget-th token ends before the end. cut == len(text)
+	// means a degenerate (zero-width) later span — fall back to the rune clamp
+	// rather than returning the full over-budget text.
+	if cut <= 0 || cut >= len(text) {
 		return clampRunes(text, t.clamp)
 	}
 	// Defensive: token spans already align to rune boundaries, but never hand back a

--- a/internal/embedding/truncate.go
+++ b/internal/embedding/truncate.go
@@ -1,0 +1,178 @@
+package embedding
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"unicode/utf8"
+
+	"github.com/gomlx/go-huggingface/tokenizers/api"
+	"github.com/gomlx/go-huggingface/tokenizers/hftokenizer"
+)
+
+const (
+	// fallbackTokenBudget is the token budget used when a model directory has no
+	// parseable config.json to read max_position_embeddings from. 512 - 2 = 510,
+	// matching the classic BERT/MiniLM context window minus the two special tokens.
+	fallbackTokenBudget = 510
+
+	// specialTokenReserve is the number of positions the inference pipeline consumes
+	// for special tokens ([CLS]/[SEP]) appended after client-side truncation, so the
+	// truncation budget is max_position_embeddings minus this.
+	specialTokenReserve = 2
+
+	// runeClampFactor bounds the rune-clamp fallback when no real tokenizer is
+	// available: a WordPiece token spans at least one rune, so clamping to
+	// factor*budget runes is a loose-but-safe cap that keeps a corrupt tokenizer.json
+	// from letting an over-long text through to the pipeline.
+	runeClampFactor = 4
+)
+
+// tokenTruncator caps input texts at a model's positional budget before they reach
+// the inference pipeline.
+//
+// The pure-Go Hugot tokenizer path does not honour max_position_embeddings, so a
+// text longer than the model's context window reaches inference at full length and
+// produces a tensor shape mismatch that aborts the entire vector index. Truncating
+// client-side keeps that failure from ever occurring; because a transformer cannot
+// attend past its positional budget, cutting the tail is lossless by construction.
+//
+// A tokenTruncator returned by newTokenTruncator is always safe to use: if the real
+// tokenizer could not be loaded, tk is nil and Truncate degrades to a rune clamp
+// rather than disabling truncation (and the caller's local backend) entirely.
+type tokenTruncator struct {
+	tk     *hftokenizer.Tokenizer // nil ⇒ rune-clamp fallback
+	budget int                    // max token count before truncation (max_position_embeddings - 2)
+	clamp  int                    // rune cap used when tk == nil
+}
+
+// newTokenTruncator builds a truncator for the model cached under modelDir. It reads
+// <modelDir>/tokenizer.json (the same file hugot loads) and derives the token budget
+// from <modelDir>/config.json's max_position_embeddings.
+//
+// The returned truncator is always non-nil and usable. A non-nil error is
+// informational: it reports a degraded state (a fallback budget because config.json
+// was missing/unparseable, or rune-clamp-only mode because tokenizer.json could not
+// be loaded) so the caller can warn without disabling the provider.
+func newTokenTruncator(modelDir string) (*tokenTruncator, error) {
+	budget, budgetErr := readTokenBudget(modelDir)
+	t := &tokenTruncator{budget: budget, clamp: budget * runeClampFactor}
+
+	tkBytes, err := os.ReadFile(filepath.Join(modelDir, "tokenizer.json"))
+	if err != nil {
+		return t, fmt.Errorf("token truncation degraded to rune clamp: read tokenizer.json: %w", err)
+	}
+	tk, err := hftokenizer.NewFromContent(nil, tkBytes)
+	if err != nil {
+		return t, fmt.Errorf("token truncation degraded to rune clamp: parse tokenizer.json: %w", err)
+	}
+	// Encode without special tokens so every returned span is a real byte span into
+	// the original text; the two reserved positions cover the [CLS]/[SEP] the pipeline
+	// adds later. IncludeSpans is required for EncodeWithAnnotations to populate Spans.
+	if err := tk.With(api.EncodeOptions{IncludeSpans: true, AddSpecialTokens: false}); err != nil {
+		return t, fmt.Errorf("token truncation degraded to rune clamp: configure tokenizer: %w", err)
+	}
+	t.tk = tk
+
+	if budgetErr != nil {
+		return t, fmt.Errorf("using fallback token budget %d: %w", budget, budgetErr)
+	}
+	return t, nil
+}
+
+// Truncate returns text unchanged when it fits the token budget, otherwise the
+// longest prefix that stays within budget, cut on a token (and rune) boundary.
+func (t *tokenTruncator) Truncate(text string) string {
+	if t == nil || t.budget <= 0 || text == "" {
+		return text
+	}
+	// Fast path (DD-3): a WordPiece token spans at least one rune, so a rune count
+	// within budget guarantees the token count is too. Only longer texts pay for the
+	// extra tokenizer pass; tokenization is µs–ms while inference dominates.
+	if utf8.RuneCountInString(text) <= t.budget {
+		return text
+	}
+	if t.tk == nil {
+		return clampRunes(text, t.clamp)
+	}
+	enc := t.tk.EncodeWithAnnotations(text)
+	if len(enc.IDs) <= t.budget {
+		return text
+	}
+	if len(enc.Spans) < t.budget {
+		// Spans unexpectedly short (tokenizer without span support) — degrade safely.
+		return clampRunes(text, t.clamp)
+	}
+	cut := enc.Spans[t.budget-1].End
+	if cut <= 0 || cut > len(text) {
+		return clampRunes(text, t.clamp)
+	}
+	// Defensive: token spans already align to rune boundaries, but never hand back a
+	// string split mid-rune.
+	for cut < len(text) && !utf8.RuneStart(text[cut]) {
+		cut--
+	}
+	return text[:cut]
+}
+
+// TruncateAll applies Truncate to every text. It returns the input slice
+// unchanged (no allocation) when nothing needed truncating — the common case on
+// this hot path — and otherwise a copy with the over-budget entries shortened.
+func (t *tokenTruncator) TruncateAll(texts []string) []string {
+	if t == nil || t.budget <= 0 {
+		return texts
+	}
+	var out []string
+	for i, s := range texts {
+		cut := t.Truncate(s)
+		if len(cut) == len(s) { // Truncate only ever returns s or a strict prefix.
+			continue
+		}
+		if out == nil {
+			out = make([]string, len(texts))
+			copy(out, texts)
+		}
+		out[i] = cut
+	}
+	if out == nil {
+		return texts
+	}
+	return out
+}
+
+// readTokenBudget derives the truncation budget from <modelDir>/config.json's
+// max_position_embeddings. It returns the fallback budget with a non-nil error when
+// the file is missing, unparseable, or carries an implausible value — never failing.
+func readTokenBudget(modelDir string) (int, error) {
+	raw, err := os.ReadFile(filepath.Join(modelDir, "config.json"))
+	if err != nil {
+		return fallbackTokenBudget, fmt.Errorf("read config.json: %w", err)
+	}
+	var cfg struct {
+		MaxPositionEmbeddings int `json:"max_position_embeddings"`
+	}
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return fallbackTokenBudget, fmt.Errorf("parse config.json: %w", err)
+	}
+	if cfg.MaxPositionEmbeddings <= specialTokenReserve {
+		return fallbackTokenBudget, fmt.Errorf("config.json max_position_embeddings=%d is implausible", cfg.MaxPositionEmbeddings)
+	}
+	return cfg.MaxPositionEmbeddings - specialTokenReserve, nil
+}
+
+// clampRunes returns the longest prefix of text with at most maxRunes runes, always
+// cutting on a rune boundary.
+func clampRunes(text string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return ""
+	}
+	count := 0
+	for i := range text {
+		if count == maxRunes {
+			return text[:i]
+		}
+		count++
+	}
+	return text
+}

--- a/internal/embedding/truncate_test.go
+++ b/internal/embedding/truncate_test.go
@@ -1,9 +1,11 @@
 package embedding
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"unicode/utf8"
 )
@@ -186,6 +188,52 @@ func TestClampRunes(t *testing.T) {
 				t.Fatalf("result not valid UTF-8: %q", got)
 			}
 		})
+	}
+}
+
+// TestHugotProvider_LiveTruncatesOverBudgetInput is the end-to-end regression
+// for the shape-mismatch crash: an input well past MiniLM's 512-token window
+// used to abort the pipeline. With truncation it must embed to a real 384-dim
+// vector. Gated on a real cached model — set GORTEX_TEST_LIVE_MODELS=1.
+func TestHugotProvider_LiveTruncatesOverBudgetInput(t *testing.T) {
+	if os.Getenv("GORTEX_TEST_LIVE_MODELS") != "1" {
+		t.Skip("set GORTEX_TEST_LIVE_MODELS=1 to run against the real MiniLM model")
+	}
+	prov, err := newHugotProvider()
+	if err != nil {
+		t.Skipf("MiniLM model unavailable: %v", err)
+	}
+	defer prov.Close()
+
+	// ~120 repetitions of a 9-token sentence ≈ 1000+ tokens — comfortably past
+	// the 512-token window that used to crash the GO tokenizer path.
+	over := strings.Repeat("the quick brown fox jumps over the lazy dog ", 120)
+
+	vec, err := prov.Embed(context.Background(), over)
+	if err != nil {
+		t.Fatalf("embedding an over-budget input failed (truncation regression): %v", err)
+	}
+	if len(vec) != prov.Dimensions() {
+		t.Fatalf("got a %d-dim vector, want %d", len(vec), prov.Dimensions())
+	}
+	nonZero := false
+	for _, v := range vec {
+		if v != 0 {
+			nonZero = true
+			break
+		}
+	}
+	if !nonZero {
+		t.Fatal("embedding vector is all zeros")
+	}
+
+	// A batch mixing an over-budget input with a short one must also succeed.
+	vecs, err := prov.EmbedBatch(context.Background(), []string{over, "short input"})
+	if err != nil {
+		t.Fatalf("mixed batch failed: %v", err)
+	}
+	if len(vecs) != 2 || len(vecs[0]) != prov.Dimensions() || len(vecs[1]) != prov.Dimensions() {
+		t.Fatalf("mixed batch produced wrong shapes: %d vectors", len(vecs))
 	}
 }
 

--- a/internal/embedding/truncate_test.go
+++ b/internal/embedding/truncate_test.go
@@ -133,6 +133,35 @@ func TestTokenTruncator_OverBudgetCutAtSpanBoundary(t *testing.T) {
 	}
 }
 
+// TestTokenTruncator_TruncateAll covers the batch API actually wired into every
+// provider's EmbedBatch: over-budget entries are shortened, in-budget entries are
+// returned untouched, and an all-fits batch returns the input slice unmodified.
+func TestTokenTruncator_TruncateAll(t *testing.T) {
+	dir := writeModelDir(t, 7) // budget 5
+	tr, err := newTokenTruncator(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const over = "hello world test the a is this" // 7 tokens > budget 5
+
+	out := tr.TruncateAll([]string{over, "hello", "hello world"})
+	if len(out) != 3 {
+		t.Fatalf("got %d results, want 3", len(out))
+	}
+	if len(tr.tk.EncodeWithAnnotations(out[0]).IDs) > tr.budget {
+		t.Fatalf("over-budget entry not truncated: %q", out[0])
+	}
+	if out[1] != "hello" || out[2] != "hello world" {
+		t.Fatalf("in-budget entries changed: %q, %q", out[1], out[2])
+	}
+
+	// Nothing over budget -> the exact same slice is returned (no allocation).
+	fits := []string{"hello", "world"}
+	if got := tr.TruncateAll(fits); &got[0] != &fits[0] {
+		t.Fatal("TruncateAll should return the input slice when nothing needs truncating")
+	}
+}
+
 func TestReadTokenBudget(t *testing.T) {
 	cases := []struct {
 		name       string
@@ -255,8 +284,10 @@ func TestNewTokenTruncator_CorruptTokenizerRuneClamp(t *testing.T) {
 	if tr.tk != nil {
 		t.Fatal("tk must be nil in rune-clamp mode")
 	}
-	if tr.budget != 10 || tr.clamp != 40 {
-		t.Fatalf("budget=%d clamp=%d, want 10/40", tr.budget, tr.clamp)
+	// clamp must equal the budget (not a multiple): a token spans >= 1 rune, so
+	// budget runes bound the token count to budget — a looser cap would not.
+	if tr.budget != 10 || tr.clamp != 10 {
+		t.Fatalf("budget=%d clamp=%d, want 10/10", tr.budget, tr.clamp)
 	}
 	// A long multibyte text is clamped (not split mid-rune) rather than passed through.
 	long := ""

--- a/internal/embedding/truncate_test.go
+++ b/internal/embedding/truncate_test.go
@@ -1,0 +1,225 @@
+package embedding
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"unicode/utf8"
+)
+
+// tinyWordPieceTokenizer is a minimal handcrafted BERT-style WordPiece tokenizer.json
+// (lowercasing normalizer, whitespace pre-tokenizer, ~14-entry vocab). Each
+// whitespace-separated in-vocab word encodes to exactly one token, which makes the
+// truncation cut points deterministic without a real model download.
+const tinyWordPieceTokenizer = `{
+  "version": "1.0",
+  "truncation": null,
+  "padding": null,
+  "added_tokens": [
+    {"id": 0, "content": "[PAD]", "single_word": false, "lstrip": false, "rstrip": false, "normalized": false, "special": true},
+    {"id": 100, "content": "[UNK]", "single_word": false, "lstrip": false, "rstrip": false, "normalized": false, "special": true},
+    {"id": 101, "content": "[CLS]", "single_word": false, "lstrip": false, "rstrip": false, "normalized": false, "special": true},
+    {"id": 102, "content": "[SEP]", "single_word": false, "lstrip": false, "rstrip": false, "normalized": false, "special": true}
+  ],
+  "normalizer": {"type": "BertNormalizer", "lowercase": true},
+  "pre_tokenizer": {"type": "BertPreTokenizer"},
+  "post_processor": null,
+  "decoder": {"type": "WordPiece", "prefix": "##"},
+  "model": {
+    "type": "WordPiece",
+    "unk_token": "[UNK]",
+    "continuing_subword_prefix": "##",
+    "max_input_chars_per_word": 100,
+    "vocab": {
+      "[PAD]": 0,
+      "hello": 1,
+      "world": 2,
+      "test": 3,
+      "[UNK]": 100,
+      "[CLS]": 101,
+      "[SEP]": 102,
+      "the": 104,
+      "a": 105,
+      "is": 106,
+      "this": 107
+    }
+  }
+}`
+
+// writeModelDir creates a temp model directory containing tokenizer.json and,
+// optionally, a config.json declaring max_position_embeddings.
+func writeModelDir(t *testing.T, maxPos int) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "tokenizer.json"), []byte(tinyWordPieceTokenizer), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if maxPos > 0 {
+		cfg := fmt.Sprintf(`{"max_position_embeddings": %d}`, maxPos)
+		if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(cfg), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func TestNewTokenTruncator_BudgetFromConfig(t *testing.T) {
+	// max_position_embeddings 7 minus the two reserved special-token slots = budget 5.
+	dir := writeModelDir(t, 7)
+	tr, err := newTokenTruncator(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tr.tk == nil {
+		t.Fatal("expected a real tokenizer to load")
+	}
+	if tr.budget != 5 {
+		t.Fatalf("budget = %d, want 5", tr.budget)
+	}
+}
+
+func TestNewTokenTruncator_MissingConfigFallback(t *testing.T) {
+	dir := writeModelDir(t, 0) // no config.json
+	tr, err := newTokenTruncator(dir)
+	if err == nil {
+		t.Fatal("expected an informational error about the fallback budget")
+	}
+	if tr.tk == nil {
+		t.Fatal("tokenizer must still load even when config.json is missing")
+	}
+	if tr.budget != fallbackTokenBudget {
+		t.Fatalf("budget = %d, want fallback %d", tr.budget, fallbackTokenBudget)
+	}
+}
+
+func TestTokenTruncator_ShortTextUntouched(t *testing.T) {
+	dir := writeModelDir(t, 7) // budget 5
+	tr, err := newTokenTruncator(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 5 runes ≤ budget 5 → fast path returns the text verbatim.
+	if got := tr.Truncate("hello"); got != "hello" {
+		t.Fatalf("Truncate(hello) = %q, want unchanged", got)
+	}
+	// 11 runes > budget but only 2 tokens ≤ budget → token-count check returns verbatim.
+	if got := tr.Truncate("hello world"); got != "hello world" {
+		t.Fatalf("Truncate(hello world) = %q, want unchanged", got)
+	}
+}
+
+func TestTokenTruncator_OverBudgetCutAtSpanBoundary(t *testing.T) {
+	dir := writeModelDir(t, 7) // budget 5
+	tr, err := newTokenTruncator(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const input = "hello world test the a is this" // 7 in-vocab words → 7 tokens
+	if n := len(tr.tk.EncodeWithAnnotations(input).IDs); n <= tr.budget {
+		t.Fatalf("test precondition: input encodes to %d tokens, need > budget %d", n, tr.budget)
+	}
+	got := tr.Truncate(input)
+	if got != "hello world test the a" {
+		t.Fatalf("Truncate cut = %q, want %q", got, "hello world test the a")
+	}
+	if !utf8.ValidString(got) {
+		t.Fatalf("truncated text is not valid UTF-8: %q", got)
+	}
+	if n := len(tr.tk.EncodeWithAnnotations(got).IDs); n > tr.budget {
+		t.Fatalf("truncated text still encodes to %d tokens, over budget %d", n, tr.budget)
+	}
+}
+
+func TestReadTokenBudget(t *testing.T) {
+	cases := []struct {
+		name       string
+		configBody string // "" means no config.json
+		want       int
+		wantErr    bool
+	}{
+		{"bert-512", `{"max_position_embeddings": 512}`, 510, false},
+		{"jina-8192", `{"max_position_embeddings": 8192}`, 8190, false},
+		{"missing", "", fallbackTokenBudget, true},
+		{"unparseable", `{not json`, fallbackTokenBudget, true},
+		{"absent-field", `{"hidden_size": 384}`, fallbackTokenBudget, true},
+		{"implausible", `{"max_position_embeddings": 1}`, fallbackTokenBudget, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tc.configBody != "" {
+				if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(tc.configBody), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got, err := readTokenBudget(dir)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tc.wantErr)
+			}
+			if got != tc.want {
+				t.Fatalf("budget = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClampRunes(t *testing.T) {
+	cases := []struct {
+		name     string
+		text     string
+		maxRunes int
+		want     string
+	}{
+		{"multibyte not split", "héllo wörld", 3, "hél"},
+		{"under cap untouched", "abc", 10, "abc"},
+		{"zero cap", "abc", 0, ""},
+		{"exact cap", "abcd", 4, "abcd"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := clampRunes(tc.text, tc.maxRunes)
+			if got != tc.want {
+				t.Fatalf("clampRunes(%q, %d) = %q, want %q", tc.text, tc.maxRunes, got, tc.want)
+			}
+			if !utf8.ValidString(got) {
+				t.Fatalf("result not valid UTF-8: %q", got)
+			}
+		})
+	}
+}
+
+func TestNewTokenTruncator_CorruptTokenizerRuneClamp(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "tokenizer.json"), []byte("{ not a tokenizer"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(`{"max_position_embeddings": 12}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tr, err := newTokenTruncator(dir)
+	if err == nil {
+		t.Fatal("expected an error when tokenizer.json is corrupt")
+	}
+	if tr == nil {
+		t.Fatal("truncator must be non-nil even on tokenizer failure")
+	}
+	if tr.tk != nil {
+		t.Fatal("tk must be nil in rune-clamp mode")
+	}
+	if tr.budget != 10 || tr.clamp != 40 {
+		t.Fatalf("budget=%d clamp=%d, want 10/40", tr.budget, tr.clamp)
+	}
+	// A long multibyte text is clamped (not split mid-rune) rather than passed through.
+	long := ""
+	for i := 0; i < 100; i++ {
+		long += "café "
+	}
+	got := tr.Truncate(long)
+	if utf8.RuneCountInString(got) > tr.clamp {
+		t.Fatalf("clamped rune count %d exceeds clamp %d", utf8.RuneCountInString(got), tr.clamp)
+	}
+	if !utf8.ValidString(got) {
+		t.Fatalf("clamped text not valid UTF-8")
+	}
+}

--- a/internal/embedding/validate.go
+++ b/internal/embedding/validate.go
@@ -1,0 +1,35 @@
+package embedding
+
+import "fmt"
+
+// validateBatch checks that an embedding backend returned exactly one vector per
+// input, that no vector is empty, and that every vector has the expected width.
+//
+// dims is the expected width. Pass a provider's known dimension (e.g. a Hugot
+// model's 384) for a strict check; pass 0 when the width is not yet known — an
+// API provider learns its width lazily from the first response — and the width
+// is taken from the first returned vector so the batch is still checked for
+// internal consistency (a ragged batch) without asserting an absolute size.
+//
+// A violation returns a descriptive error naming the offending index so a
+// provider regression that returns nil, short, or mis-counted vectors surfaces
+// as a loud, attributable failure instead of a silently empty or mis-dimensioned
+// index.
+func validateBatch(name string, texts []string, vecs [][]float32, dims int) error {
+	if len(vecs) != len(texts) {
+		return fmt.Errorf("%s returned %d vectors for %d inputs", name, len(vecs), len(texts))
+	}
+	expected := dims
+	if expected <= 0 && len(vecs) > 0 {
+		expected = len(vecs[0])
+	}
+	for i, v := range vecs {
+		if len(v) == 0 {
+			return fmt.Errorf("%s returned an empty vector at index %d of %d", name, i, len(vecs))
+		}
+		if expected > 0 && len(v) != expected {
+			return fmt.Errorf("%s returned a width-%d vector at index %d, want %d", name, len(v), i, expected)
+		}
+	}
+	return nil
+}

--- a/internal/embedding/validate_test.go
+++ b/internal/embedding/validate_test.go
@@ -1,0 +1,33 @@
+package embedding
+
+import "testing"
+
+func TestValidateBatch(t *testing.T) {
+	vec := func(n int) []float32 { return make([]float32, n) }
+
+	cases := []struct {
+		name    string
+		texts   []string
+		vecs    [][]float32
+		dims    int
+		wantErr bool
+	}{
+		{"ok strict width", []string{"a", "b"}, [][]float32{vec(384), vec(384)}, 384, false},
+		{"ok empty batch", []string{}, [][]float32{}, 384, false},
+		{"ok lazy width consistent", []string{"a", "b"}, [][]float32{vec(768), vec(768)}, 0, false},
+		{"count mismatch short", []string{"a", "b"}, [][]float32{vec(384)}, 384, true},
+		{"count mismatch extra", []string{"a"}, [][]float32{vec(384), vec(384)}, 384, true},
+		{"nil vector", []string{"a", "b"}, [][]float32{vec(384), nil}, 384, true},
+		{"empty vector", []string{"a"}, [][]float32{{}}, 384, true},
+		{"wrong strict width", []string{"a"}, [][]float32{vec(100)}, 384, true},
+		{"ragged lazy width", []string{"a", "b"}, [][]float32{vec(768), vec(384)}, 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateBatch("test", tc.texts, tc.vecs, tc.dims)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("validateBatch err = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -3998,6 +3998,11 @@ func flattenEmbedResults(results [][][]float32) [][]float32 {
 // AllNodes() path because nodes there carry an empty RepoPrefix and
 // GetRepoNodes("") would miss them.
 func (idx *Indexer) buildSearchIndex() {
+	// Start every build from a clean vector-build error: the degraded vector
+	// paths below set it, and a successful build (or a benign skip / no embedder)
+	// leaves it nil, so LastVectorBuildError always reflects the current pass.
+	idx.lastVectorBuildErr = nil
+
 	// Code-only enumeration: content (data_class=content) sections live in
 	// the content index, never the symbol search or the vector store, so the
 	// FTS loop below and collectEmbedTexts both skip them anyway. Fetching
@@ -4038,10 +4043,6 @@ func (idx *Indexer) buildSearchIndex() {
 	if idx.skipVectorBuild {
 		return
 	}
-
-	// Fresh attempt: clear any failure recorded by a previous build so the
-	// LastVectorBuildError seam reflects only this pass.
-	idx.lastVectorBuildErr = nil
 
 	// Provisional dimensionality: trust the embedder's own report.
 	// A provider that can't state its width yet (an APIProvider before

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -236,6 +236,14 @@ type Indexer struct {
 	// inference mutex.
 	embedAPIConcurrency int
 
+	// lastVectorBuildErr records why the most recent buildSearchIndex pass
+	// shipped text-only instead of a vector index (chunk-embed failure,
+	// all-vectors-invalid, or the symbol-count guard). Nil after a build that
+	// produced a vector index. Read via LastVectorBuildError once a build has
+	// finished — it lets `gortex eval embedders` report the real cause instead
+	// of a bare "no vector data".
+	lastVectorBuildErr error
+
 	// semanticMgr is the optional semantic enrichment manager.
 	semanticMgr *semantic.Manager
 
@@ -1132,6 +1140,13 @@ func (idx *Indexer) SetEmbeddingMaxSymbols(n int) { idx.embedMaxSymbols = n }
 // in parallel against an API-backed embedder. Zero keeps the built-in
 // default. Has no effect on in-process embedders.
 func (idx *Indexer) SetEmbeddingAPIConcurrency(n int) { idx.embedAPIConcurrency = n }
+
+// LastVectorBuildError returns why the most recent index build produced no
+// vector index (chunk-embed failure, all vectors invalid, or the symbol-count
+// guard), or nil when a vector index was built or the embedder was unset. Read
+// it after an index build completes; it is not safe to call concurrently with
+// one.
+func (idx *Indexer) LastVectorBuildError() error { return idx.lastVectorBuildErr }
 
 // SetSemanticManager sets the semantic enrichment manager.
 // When set, the indexer runs semantic enrichment after resolution.
@@ -4024,6 +4039,10 @@ func (idx *Indexer) buildSearchIndex() {
 		return
 	}
 
+	// Fresh attempt: clear any failure recorded by a previous build so the
+	// LastVectorBuildError seam reflects only this pass.
+	idx.lastVectorBuildErr = nil
+
 	// Provisional dimensionality: trust the embedder's own report.
 	// A provider that can't state its width yet (an APIProvider before
 	// its first call returns 0) gets a neutral placeholder — the value
@@ -4098,6 +4117,7 @@ func (idx *Indexer) buildSearchIndex() {
 			zap.Int("texts", len(texts)),
 			zap.Int("threshold", embedMaxSymbols),
 			zap.String("hint", "BM25 text search remains active; raise embedding.max_symbols if you have memory headroom"))
+		idx.lastVectorBuildErr = fmt.Errorf("embedding text count %d exceeds threshold %d (raise embedding.max_symbols)", len(texts), embedMaxSymbols)
 		return
 	}
 
@@ -4150,6 +4170,7 @@ func (idx *Indexer) buildSearchIndex() {
 		// text-only search rather than ship an inconsistent hybrid
 		// backend.
 		idx.logger.Warn("vector index aborted on chunk failure", zap.Error(err))
+		idx.lastVectorBuildErr = fmt.Errorf("chunk embedding failed: %w", err)
 		return
 	}
 
@@ -4215,6 +4236,7 @@ func (idx *Indexer) buildSearchIndex() {
 			zap.Int("dropped", droppedVectors),
 			zap.Int("dimensions", dims),
 			zap.Strings("sample_ids", droppedSample))
+		idx.lastVectorBuildErr = fmt.Errorf("all %d embedding vectors were invalid (want width %d)", droppedVectors, dims)
 		return
 	}
 	if persistSink != nil && len(backendItems) > 0 {

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -4186,16 +4186,36 @@ func (idx *Indexer) buildSearchIndex() {
 	if persistSink != nil {
 		backendItems = make([]graph.VectorItem, 0, len(vectors))
 	}
+	// Add only well-formed vectors. A nil or wrong-width vector would poison
+	// the index — a mis-scored or panicking query — so drop it, count it, and
+	// keep a sample of offending node IDs for the log.
+	var droppedVectors int
+	var droppedSample []string
 	for i, vec := range vectors {
-		if vec != nil {
-			vecBackend.Add(ids[i], vec)
-			if persistSink != nil {
-				backendItems = append(backendItems, graph.VectorItem{
-					NodeID: ids[i],
-					Vec:    vec,
-				})
+		if len(vec) != dims {
+			droppedVectors++
+			if len(droppedSample) < 5 {
+				droppedSample = append(droppedSample, ids[i])
 			}
+			continue
 		}
+		vecBackend.Add(ids[i], vec)
+		if persistSink != nil {
+			backendItems = append(backendItems, graph.VectorItem{
+				NodeID: ids[i],
+				Vec:    vec,
+			})
+		}
+	}
+	// If every vector was invalid there is nothing to search on. Ship text-only
+	// rather than a silently empty vector index that mis-scores every query —
+	// the same all-or-nothing contract as the chunk-failure abort above.
+	if len(vectors) > 0 && vecBackend.Count() == 0 {
+		idx.logger.Warn("vector index aborted — all embeddings invalid",
+			zap.Int("dropped", droppedVectors),
+			zap.Int("dimensions", dims),
+			zap.Strings("sample_ids", droppedSample))
+		return
 	}
 	if persistSink != nil && len(backendItems) > 0 {
 		if err := persistSink.BulkUpsertEmbeddings(backendItems); err != nil {
@@ -4230,10 +4250,17 @@ func (idx *Indexer) buildSearchIndex() {
 		inner = hyb.TextBackend()
 	}
 	sw.Swap(search.NewHybrid(inner, vecBackend, idx.embedder))
+	if droppedVectors > 0 {
+		idx.logger.Warn("indexer: dropped invalid embedding vectors",
+			zap.Int("dropped", droppedVectors),
+			zap.Int("dimensions", dims),
+			zap.Strings("sample_ids", droppedSample))
+	}
 	fields := []zap.Field{
 		zap.Int("vectors", vecBackend.Count()),
 		zap.Int("chunk_vectors", len(chunkMap)),
 		zap.Int("dimensions", dims),
+		zap.Int("dropped", droppedVectors),
 	}
 	// Surface the actual token spend of a paid embedding pass when the
 	// backend reports usage (API providers do; in-process ones don't).

--- a/internal/indexer/vector_ingest_test.go
+++ b/internal/indexer/vector_ingest_test.go
@@ -1,0 +1,135 @@
+package indexer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+	"github.com/zzet/gortex/internal/search"
+)
+
+// mixedEmbedder returns a 4-dim vector for every third input (starting with the
+// first, so the width is detectable from index 0), a nil vector for the next,
+// and a wrong-width vector for the one after — a deterministic valid/nil/short
+// mix regardless of how the indexer batches the inputs.
+type mixedEmbedder struct {
+	mu   sync.Mutex
+	seen int
+	good int
+}
+
+func (m *mixedEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	v, err := m.EmbedBatch(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+	return v[0], nil
+}
+
+func (m *mixedEmbedder) EmbedBatch(_ context.Context, texts []string) ([][]float32, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([][]float32, len(texts))
+	for i := range texts {
+		switch (m.seen + i) % 3 {
+		case 1:
+			out[i] = nil // dropped: nil vector
+		case 2:
+			out[i] = []float32{1, 2} // dropped: wrong width (2 != 4)
+		default:
+			out[i] = []float32{float32(len(texts[i])), 0, 0, 0} // valid 4-dim
+			m.good++
+		}
+	}
+	m.seen += len(texts)
+	return out, nil
+}
+
+func (m *mixedEmbedder) Dimensions() int { return 4 }
+func (m *mixedEmbedder) Close() error    { return nil }
+
+// nilEmbedder returns nil for every input — an all-invalid batch.
+type nilEmbedder struct{}
+
+func (nilEmbedder) Embed(context.Context, string) ([]float32, error) { return nil, nil }
+func (nilEmbedder) EmbedBatch(_ context.Context, texts []string) ([][]float32, error) {
+	return make([][]float32, len(texts)), nil
+}
+func (nilEmbedder) Dimensions() int { return 4 }
+func (nilEmbedder) Close() error    { return nil }
+
+const vectorIngestFixture = `package main
+
+func Alpha() {}
+func Beta() {}
+func Gamma() {}
+func Delta() {}
+func Epsilon() {}
+func Zeta() {}
+`
+
+func indexWithEmbedder(t *testing.T, emb interface {
+	Embed(context.Context, string) ([]float32, error)
+	EmbedBatch(context.Context, []string) ([][]float32, error)
+	Dimensions() int
+	Close() error
+}) *Indexer {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte(vectorIngestFixture), 0o644))
+
+	g := graph.New()
+	reg := parser.NewRegistry()
+	reg.Register(languages.NewGoExtractor())
+
+	cfg := config.Default().Index
+	cfg.Workers = 1
+	cfg.SkipSearch = config.DefaultSkipSearch()
+
+	idx := New(g, reg, cfg, zap.NewNop())
+	idx.SetEmbedder(emb)
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+	return idx
+}
+
+// TestBuildSearchIndex_DropsInvalidVectors: a mix of valid/nil/short vectors
+// yields a vector index populated with only the valid ones — the bad vectors
+// are dropped rather than poisoning the index or aborting a viable build.
+func TestBuildSearchIndex_DropsInvalidVectors(t *testing.T) {
+	emb := &mixedEmbedder{}
+	idx := indexWithEmbedder(t, emb)
+
+	sw, ok := idx.Search().(*search.Swappable)
+	require.True(t, ok)
+	hybrid, ok := sw.Inner().(*search.HybridBackend)
+	require.True(t, ok, "a viable subset of vectors must still produce a HybridBackend")
+	require.NotNil(t, hybrid.VectorIndex())
+
+	require.Greater(t, emb.good, 0, "test precondition: some vectors were valid")
+	require.Less(t, emb.good, emb.seen, "test precondition: some vectors were dropped")
+	assert.Equal(t, emb.good, hybrid.VectorIndex().Count(),
+		"only the valid vectors should be in the index")
+}
+
+// TestBuildSearchIndex_AllInvalidAbortsToTextOnly: when every vector is invalid
+// the build must abort to text-only search, not ship a silently empty index.
+func TestBuildSearchIndex_AllInvalidAbortsToTextOnly(t *testing.T) {
+	idx := indexWithEmbedder(t, nilEmbedder{})
+
+	sw, ok := idx.Search().(*search.Swappable)
+	require.True(t, ok)
+	_, isHybrid := sw.Inner().(*search.HybridBackend)
+	assert.False(t, isHybrid,
+		"an all-invalid embedding pass must leave a text-only backend, not an empty vector index")
+}

--- a/internal/indexer/vector_ingest_test.go
+++ b/internal/indexer/vector_ingest_test.go
@@ -120,6 +120,8 @@ func TestBuildSearchIndex_DropsInvalidVectors(t *testing.T) {
 	require.Less(t, emb.good, emb.seen, "test precondition: some vectors were dropped")
 	assert.Equal(t, emb.good, hybrid.VectorIndex().Count(),
 		"only the valid vectors should be in the index")
+	assert.NoError(t, idx.LastVectorBuildError(),
+		"a partially-valid build is a success, not a recorded failure")
 }
 
 // TestBuildSearchIndex_AllInvalidAbortsToTextOnly: when every vector is invalid
@@ -132,4 +134,6 @@ func TestBuildSearchIndex_AllInvalidAbortsToTextOnly(t *testing.T) {
 	_, isHybrid := sw.Inner().(*search.HybridBackend)
 	assert.False(t, isHybrid,
 		"an all-invalid embedding pass must leave a text-only backend, not an empty vector index")
+	assert.Error(t, idx.LastVectorBuildError(),
+		"the vector-build failure must be recorded for eval to surface")
 }

--- a/internal/serverstack/embedder.go
+++ b/internal/serverstack/embedder.go
@@ -34,12 +34,14 @@ type EmbedderRequest struct {
 // enablement and the provider comes from the `embedding:` config; else
 // the config decides (default: semantic search ON with the zero-download
 // static GloVe provider). The returned string describes the decision for
-// logging ("" when no embedder was built); a non-nil error means an
-// embedder was requested but could not be constructed.
-func ResolveEmbedder(req EmbedderRequest, cfg *config.Config) (embedding.Provider, string, error) {
+// logging ("" when no embedder was built); the SelectionReport records every
+// backend the local auto-selection tried (empty for other providers) so a
+// silent degradation to static is observable; a non-nil error means an embedder
+// was requested but could not be constructed.
+func ResolveEmbedder(req EmbedderRequest, cfg *config.Config) (embedding.Provider, string, embedding.SelectionReport, error) {
 	if url := firstNonEmpty(req.FlagURL, os.Getenv("GORTEX_EMBEDDINGS_URL")); url != "" {
 		model := firstNonEmpty(req.FlagModel, os.Getenv("GORTEX_EMBEDDINGS_MODEL"))
-		return embedding.NewAPIProvider(url, model), fmt.Sprintf("api (%s)", url), nil
+		return embedding.NewAPIProvider(url, model), fmt.Sprintf("api (%s)", url), embedding.SelectionReport{}, nil
 	}
 
 	embCfg := config.EmbeddingConfig{}
@@ -50,7 +52,7 @@ func ResolveEmbedder(req EmbedderRequest, cfg *config.Config) (embedding.Provide
 	explicitEnabled, haveExplicit := explicitEmbeddingToggle(req)
 	if haveExplicit {
 		if !explicitEnabled {
-			return nil, "", nil
+			return nil, "", embedding.SelectionReport{}, nil
 		}
 		return buildConfiguredEmbedder(embCfg, "enabled by flag/env")
 	}
@@ -58,7 +60,7 @@ func ResolveEmbedder(req EmbedderRequest, cfg *config.Config) (embedding.Provide
 	// No explicit flag/env toggle. An explicit `embedding.enabled: false`
 	// still wins and disables the vector channel.
 	if embCfg.Enabled != nil && !*embCfg.Enabled {
-		return nil, "", nil
+		return nil, "", embedding.SelectionReport{}, nil
 	}
 	// An explicit `embedding.enabled: true` builds whatever provider is
 	// configured, including the baked static GloVe one.
@@ -75,7 +77,7 @@ func ResolveEmbedder(req EmbedderRequest, cfg *config.Config) (embedding.Provide
 	if isRealEmbedder(embCfg.EmbeddingProviderOrDefault()) {
 		return buildConfiguredEmbedder(embCfg, "real embedder configured")
 	}
-	return nil, "", nil
+	return nil, "", embedding.SelectionReport{}, nil
 }
 
 // isRealEmbedder reports whether the named provider is a model-backed
@@ -110,24 +112,33 @@ func explicitEmbeddingToggle(req EmbedderRequest) (enabled, haveExplicit bool) {
 }
 
 // buildConfiguredEmbedder constructs the provider named by the config
-// block (defaulting to the static GloVe provider).
-func buildConfiguredEmbedder(embCfg config.EmbeddingConfig, why string) (embedding.Provider, string, error) {
+// block (defaulting to the static GloVe provider). The returned description
+// names the backend actually constructed — "local (hugot)" for an
+// auto-selected local backend, or "local → static fallback" when the chain
+// degraded — so the startup log tells the truth rather than echoing the
+// configured name.
+func buildConfiguredEmbedder(embCfg config.EmbeddingConfig, why string) (embedding.Provider, string, embedding.SelectionReport, error) {
 	provider := embCfg.EmbeddingProviderOrDefault()
 	variant := firstNonEmpty(os.Getenv("GORTEX_EMBEDDINGS_VARIANT"), embCfg.Variant)
-	p, err := embedding.NewProviderFromConfig(embedding.ProviderConfig{
+	p, report, err := embedding.NewProviderFromConfigWithReport(embedding.ProviderConfig{
 		Provider: provider,
 		APIURL:   embCfg.APIURL,
 		APIModel: embCfg.APIModel,
 		Variant:  variant,
 	})
 	if err != nil {
-		return nil, "", err
+		return nil, "", report, err
 	}
 	desc := provider
-	if variant != "" && provider == "local" {
+	switch {
+	case variant != "" && provider == "local":
 		desc = fmt.Sprintf("%s/%s", provider, variant)
+	case provider == "local" && report.Chosen == "static":
+		desc = "local → static fallback"
+	case provider == "local" && report.Chosen != "":
+		desc = fmt.Sprintf("local (%s)", report.Chosen)
 	}
-	return p, fmt.Sprintf("%s — %s", desc, why), nil
+	return p, fmt.Sprintf("%s — %s", desc, why), report, nil
 }
 
 // EmbeddingChunkOptions translates the chunking knobs of an

--- a/internal/serverstack/embedder_selection_test.go
+++ b/internal/serverstack/embedder_selection_test.go
@@ -1,0 +1,94 @@
+package serverstack
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/embedding"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+// clearEmbeddingEnv neutralises the flag/env overrides so a test exercises the
+// config-driven ResolveEmbedder path deterministically.
+func clearEmbeddingEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{"GORTEX_EMBEDDINGS", "GORTEX_EMBEDDINGS_URL", "GORTEX_EMBEDDINGS_MODEL", "GORTEX_EMBEDDINGS_VARIANT"} {
+		t.Setenv(k, "")
+	}
+}
+
+func TestResolveEmbedder_StaticDescIsTruthful(t *testing.T) {
+	clearEmbeddingEnv(t)
+	cfg := &config.Config{Embedding: config.EmbeddingConfig{Enabled: boolPtr(true), Provider: "static"}}
+
+	p, desc, report, err := ResolveEmbedder(EmbedderRequest{}, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p == nil {
+		t.Fatal("expected a static provider")
+	}
+	defer p.Close()
+	if !strings.HasPrefix(desc, "static") {
+		t.Fatalf("desc = %q, want it to start with \"static\"", desc)
+	}
+	if len(report.Attempts) != 0 {
+		t.Fatalf("explicit static should record no selection attempts, got %d", len(report.Attempts))
+	}
+}
+
+func TestResolveEmbedder_APIDescIsTruthful(t *testing.T) {
+	clearEmbeddingEnv(t)
+	cfg := &config.Config{Embedding: config.EmbeddingConfig{
+		Enabled:  boolPtr(true),
+		Provider: "api",
+		APIURL:   "http://localhost:11434",
+	}}
+
+	p, desc, _, err := ResolveEmbedder(EmbedderRequest{}, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p == nil {
+		t.Fatal("expected an api provider")
+	}
+	defer p.Close()
+	if _, ok := p.(*embedding.APIProvider); !ok {
+		t.Fatalf("expected *embedding.APIProvider, got %T", p)
+	}
+	if !strings.HasPrefix(desc, "api") {
+		t.Fatalf("desc = %q, want it to start with \"api\"", desc)
+	}
+}
+
+// TestResolveEmbedder_LocalDegradesToStatic forces the local auto-selection to
+// fall all the way through to the static fallback (offline + an empty models
+// dir so no transformer can load) and asserts the description tells the truth
+// and the report records the degradation.
+func TestResolveEmbedder_LocalDegradesToStatic(t *testing.T) {
+	clearEmbeddingEnv(t)
+	t.Setenv("XDG_DATA_HOME", t.TempDir())     // absolute → uncached models dir
+	t.Setenv("GORTEX_EMBEDDING_OFFLINE", "1")  // no network download
+
+	cfg := &config.Config{Embedding: config.EmbeddingConfig{Enabled: boolPtr(true), Provider: "local"}}
+
+	p, desc, report, err := ResolveEmbedder(EmbedderRequest{}, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p == nil {
+		t.Fatal("expected the static fallback provider")
+	}
+	defer p.Close()
+	if report.Chosen != "static" {
+		t.Fatalf("report.Chosen = %q, want \"static\"", report.Chosen)
+	}
+	if len(report.Attempts) == 0 {
+		t.Fatal("expected the failed backend attempts to be recorded")
+	}
+	if !strings.Contains(desc, "static fallback") {
+		t.Fatalf("desc = %q, want it to mention the static fallback", desc)
+	}
+}

--- a/internal/serverstack/shared_server.go
+++ b/internal/serverstack/shared_server.go
@@ -424,6 +424,23 @@ func NewSharedServer(cfg SharedServerConfig) (*SharedServer, error) {
 			zap.Strings("lsp_auto_registered", autoRegistered))
 	}
 
+	// Layer the global ~/.gortex/config.yaml `embedding:` block under the
+	// repo-local one before resolving the embedder, so an `embedding:` block in
+	// the global file is honoured while any repo-local non-zero field still
+	// wins. Done here (not at the LLM merge below) so it precedes ResolveEmbedder
+	// and leaves its flag/env precedence untouched. Warn about any unrecognised
+	// top-level keys — most often an `embedding:` block written in the wrong file.
+	embGlobal := cfg.Global
+	if embGlobal == nil {
+		embGlobal, _ = config.LoadGlobal()
+	}
+	conf.Embedding = embGlobal.MergeEmbeddingInto(conf.Embedding)
+	if unknown := config.UnknownGlobalKeys(); len(unknown) > 0 {
+		logger.Warn("serverstack: ~/.gortex/config.yaml contains keys gortex does not recognize",
+			zap.Strings("keys", unknown),
+			zap.String("hint", "see docs/semantic-search.md for embedding config placement"))
+	}
+
 	// Embeddings: explicit flag/env > `embedding:` config > default (on,
 	// static GloVe).
 	embedder, embDesc, embReport, embErr := ResolveEmbedder(cfg.Embedder, conf)

--- a/internal/serverstack/shared_server.go
+++ b/internal/serverstack/shared_server.go
@@ -426,7 +426,7 @@ func NewSharedServer(cfg SharedServerConfig) (*SharedServer, error) {
 
 	// Embeddings: explicit flag/env > `embedding:` config > default (on,
 	// static GloVe).
-	embedder, embDesc, embErr := ResolveEmbedder(cfg.Embedder, conf)
+	embedder, embDesc, embReport, embErr := ResolveEmbedder(cfg.Embedder, conf)
 	// Probe API-backed providers up front so Dimensions() is truthful before
 	// we log it and — crucially — before EmbedderDims gates snapshot-vector
 	// reload. An APIProvider reports 0 until its first embed; without this the
@@ -445,6 +445,20 @@ func NewSharedServer(cfg SharedServerConfig) (*SharedServer, error) {
 			} else {
 				logger.Info("serverstack: embedding dimension probed", zap.Int("dim", dim))
 			}
+		}
+	}
+	// Surface every backend the local auto-selection tried. A degradation all
+	// the way to the static fallback is a real problem the user should see, so
+	// warn; the benign failures behind a successfully-chosen backend (e.g. the
+	// onnx/gomlx stubs in a default build) are only interesting when debugging.
+	degradedToStatic := embReport.Chosen == "static" && len(embReport.Attempts) > 0
+	for _, a := range embReport.Attempts {
+		if degradedToStatic {
+			logger.Warn("serverstack: embedding backend unavailable — degraded to static fallback",
+				zap.String("backend", a.Backend), zap.Error(a.Err))
+		} else {
+			logger.Debug("serverstack: embedding backend not available",
+				zap.String("backend", a.Backend), zap.Error(a.Err))
 		}
 	}
 	switch {

--- a/internal/serverstack/shared_server.go
+++ b/internal/serverstack/shared_server.go
@@ -2,6 +2,7 @@ package serverstack
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,6 +16,7 @@ import (
 	"github.com/zzet/gortex/internal/config"
 	"github.com/zzet/gortex/internal/contracts"
 	"github.com/zzet/gortex/internal/daemon"
+	"github.com/zzet/gortex/internal/embedding"
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/indexer"
 	gortexmcp "github.com/zzet/gortex/internal/mcp"
@@ -432,10 +434,22 @@ func NewSharedServer(cfg SharedServerConfig) (*SharedServer, error) {
 	// top-level keys — most often an `embedding:` block written in the wrong file.
 	embGlobal := cfg.Global
 	if embGlobal == nil {
-		embGlobal, _ = config.LoadGlobal()
+		var gerr error
+		if embGlobal, gerr = config.LoadGlobal(); gerr != nil {
+			// A malformed global file is otherwise silently ignored — exactly
+			// when its embedding/llm block would have taken effect.
+			logger.Warn("serverstack: global config could not be parsed — its embedding/llm block is ignored",
+				zap.Error(gerr))
+		}
 	}
 	conf.Embedding = embGlobal.MergeEmbeddingInto(conf.Embedding)
-	if unknown := config.UnknownGlobalKeys(); len(unknown) > 0 {
+	// Diagnose unknown keys in the file that was actually loaded (which may be an
+	// overridden path from cfg.Global), not always the default location.
+	globalPath := ""
+	if embGlobal != nil {
+		globalPath = embGlobal.ConfigPath()
+	}
+	if unknown := config.UnknownGlobalKeys(globalPath); len(unknown) > 0 {
 		logger.Warn("serverstack: ~/.gortex/config.yaml contains keys gortex does not recognize",
 			zap.Strings("keys", unknown),
 			zap.String("hint", "see docs/semantic-search.md for embedding config placement"))
@@ -464,13 +478,14 @@ func NewSharedServer(cfg SharedServerConfig) (*SharedServer, error) {
 			}
 		}
 	}
-	// Surface every backend the local auto-selection tried. A degradation all
-	// the way to the static fallback is a real problem the user should see, so
-	// warn; the benign failures behind a successfully-chosen backend (e.g. the
-	// onnx/gomlx stubs in a default build) are only interesting when debugging.
-	degradedToStatic := embReport.Chosen == "static" && len(embReport.Attempts) > 0
+	// Surface every backend the local auto-selection tried. Warn per backend
+	// only when the outcome was actually degraded (fell to the static fallback,
+	// or built nothing) AND the backend could really have worked — a backend
+	// that is simply not compiled into this build (the onnx/gomlx stubs) is
+	// benign noise and stays at debug even on a degradation.
+	outcomeDegraded := (embedder == nil || embReport.Chosen == "static") && len(embReport.Attempts) > 0
 	for _, a := range embReport.Attempts {
-		if degradedToStatic {
+		if outcomeDegraded && !errors.Is(a.Err, embedding.ErrBackendNotCompiled) {
 			logger.Warn("serverstack: embedding backend unavailable — degraded to static fallback",
 				zap.String("backend", a.Backend), zap.Error(a.Err))
 		} else {


### PR DESCRIPTION
## Summary

Makes `provider: local` survive a real repository. Today the zero-dependency local embedding path (pure-Go Hugot, MiniLM-L6-v2) dies on the first code chunk longer than 512 tokens — which every real repo has — and every failure along the chain is silent: the vector index is thrown away wholesale, the daemon logs a provider name that isn't what's running, and an `embedding:` block in the global config file disappears without a warning. The net effect (per #232) is that only `static` (GloVe-50d) and `api` work, with no way to see why.

This fixes the crash, isolates the remaining failure modes, and makes every layer of the chain tell the truth about what got constructed, what fell back, what was dropped, and why.

Fixes #232.

## Root cause

The pure-Go Hugot tokenizer path never applies `max_position_embeddings`, so any input past the model's context window reaches inference at full length and produces a tensor shape mismatch. The indexer's abort-on-any-error contract then throws away the **entire** vector index, dropping the daemon to text-only search — silently. ("Emits empty vectors" in the issue was a misdiagnosis; short texts embed fine.)

## What changed (one commit per fix)

- **Token-exact truncation** (`internal/embedding/truncate.go`) — reads the model's `tokenizer.json`/`config.json`, derives the budget from `max_position_embeddings − 2`, and cuts over-long inputs on a token (and rune) boundary before inference. A rune-count fast path skips the extra tokenizer pass for inputs that already fit; a degraded tokenizer falls back to a rune clamp with a warning instead of disabling the backend. Wired into both the Hugot and GoMLX providers.
- **Provider output validation** — every `EmbedBatch` now checks it returned one vector per input, none empty, each of the expected width; a violation is a loud, index-naming error instead of a silently empty/mis-dimensioned index.
- **Indexer vector-ingest hardening** — malformed vectors are dropped and counted (with a `dropped=` field and a sample of node IDs); an all-invalid build aborts to text-only rather than shipping an empty vector index.
- **Truthful selection + logging** — a `SelectionReport` records which local backend was constructed and which were skipped; the "embeddings enabled" line now reads `local (hugot/fp32), dim: 384` or `local → static fallback, dim: 50` instead of echoing the configured name. A genuine degradation to static warns per backend; benign misses (the onnx/gomlx stubs in a default build) stay at debug.
- **Global `embedding:` config** — `GlobalConfig` learns an `embedding:` block (merged under the repo-local one, repo values win), and unrecognised top-level keys in `~/.gortex/config.yaml` now warn at startup instead of vanishing.
- **GoMLX build tags** — the gomlx entry points move to `-tags "embeddings_gomlx XLA"` so the real XLA session is actually compiled (it was dead code before); CI compiles both the pair and `embeddings_gomlx` alone. Docs are honest that XLA runtime is experimental and the pure-Go backend is the reliable default.
- **`eval embedders` observability** — records the concrete vector-build failure (`LastVectorBuildError`) and reports it instead of a bare "no vector data", with a WARN-level logger so the indexer's warnings are visible.
- **Docs** — ONNX manual-setup honesty, truncation semantics, config placement/precedence, a per-build-tag backend matrix, and a troubleshooting section keyed on the actual log lines.

## Verification

- Unit tests for every fix (truncation span-cutting, budget derivation, output validation, the drop/all-invalid indexer paths, selection descriptions, the config merge + unknown-key detection, the eval note selection).
- **Live regression** (`GORTEX_TEST_LIVE_MODELS=1`): a ~1000-token input — the exact case that used to crash — embeds to a clean 384-dim vector through the real cached MiniLM model, as does a mixed over-budget/short batch.
- `go test -race` green on the touched packages; `golangci-lint` clean; the default, `embeddings_gomlx XLA`, and `embeddings_onnx` builds all compile with no system XLA/ONNX libraries (both are runtime dlopen).

The issue's three failure modes now each produce either working 384-dim vectors or a loud, documented, correctly-attributed log line — no silent static fallback remains reachable from a `local` config.
