### PR TITLE
fix(daemon): quiet handshake log for bare liveness probes

### DIFF
--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -376,7 +376,17 @@ func (s *Server) handle(conn net.Conn) {
 	reader := bufio.NewReader(conn)
 	sess, err := s.handshake(conn, reader)
 	if err != nil {
-		s.Logger.Warn("daemon: handshake failed", zap.Error(err))
+		if errors.Is(err, io.EOF) {
+			// Liveness probe (daemon.IsRunningAt and friends): the peer
+			// dialed the socket and closed it without sending a handshake
+			// frame, so the first read returns a clean EOF. This is an
+			// expected "is the socket accepting?" knock, not a fault —
+			// keep it at Debug. A partially-written frame yields
+			// io.ErrUnexpectedEOF instead and still warns below.
+			s.Logger.Debug("daemon: connection closed before handshake", zap.Error(err))
+		} else {
+			s.Logger.Warn("daemon: handshake failed", zap.Error(err))
+		}
 		return
 	}
 


### PR DESCRIPTION
## Problem

The daemon log fills with bursts of:

```
warn  daemon/server.go:379  daemon: handshake failed  error="read handshake: EOF"
```

These are **not** faults. The daemon's liveness check, `daemon.IsRunningAt` (`internal/daemon/client.go:201`), dials the Unix socket and closes it immediately to test whether the socket is accepting — it never sends a handshake frame:

```go
conn, err := d.Dial("unix", socketPath)
if err != nil { return false }
_ = conn.Close()   // connect-and-close; no handshake
return true
```

On the daemon side, the first `reader.ReadBytes('\n')` then returns a clean `io.EOF`, `handshake` wraps it, and `handle` logged it at Warn. `IsRunningAt` has ~19 CLI/hook callers (`gortex status`, `track`/`untrack`, all `enrich *`, proxy-apply, daemon stop/reload, …), so every such invocation emits a warning — hence the bursts.

## Fix

Branch the error handling in `handle`: demote the `io.EOF` case to Debug (an expected "is the socket up?" knock), keep everything else at Warn.

The distinction is precise:
- **Bare connect-and-close** → clean `io.EOF` → Debug.
- **Malformed JSON / protocol-version mismatch / unsupported mode** → still Warn.
- **Half-written handshake frame** → `io.ErrUnexpectedEOF`, which `errors.Is(err, io.EOF)` does **not** match → still Warn.

No behavior change beyond log level. `errors` and `io` were already imported.

## Test

`go build ./internal/daemon/` passes.