### PR TITLE
perf(lsp): bounded document session, demand-gated sweep, and compile-db preflight for enrichment

### DIFF
--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -52,6 +52,12 @@ language. `gopls` is `3` so it beats SCIP-based providers (`5`) for Go;
 `jdtls` is `6` so it's lower-priority than the SCIP-java path that
 ships separately.
 
+`clangd` is the one server that needs a compilation database for full
+enrichment. Point it at a `compile_commands.json` (or a `compile_flags.txt`
+/ `.clangd`) at the repo root; without one, gortex degrades that repository's
+enrichment to reference confirmation — see
+[Enrichment cost model](#enrichment-cost-model).
+
 ## Enabling a server
 
 Add it to `.gortex.yaml`:
@@ -155,6 +161,141 @@ These defaults suit a polyglot workspace where most languages are
 touched only intermittently. Override them by editing the
 `lsp.NewRouter(...).With...` chain in your build if you need a longer
 warm pool or a tighter memory bound.
+
+## Enrichment cost model
+
+The resolution path (use 1 at the top of this page) runs as a batch
+**enrichment pass** — one pass per (repository × language server) — that walks
+the repo's nodes for that language and upgrades edges the AST resolver left
+ambiguous. A pass runs up to five phases:
+
+1. **Interface pass** — for each interface / abstract declaration, asks the
+   server for its implementations (`textDocument/implementation`) and links the
+   dispatch edges.
+2. **Confirm pass** — for every ambiguous edge (one whose confidence the
+   resolver could not raise to certainty), asks for the referent's references
+   (`textDocument/references`) and confirms or refutes the edge. Grouped by
+   referent file so each file opens once.
+3. **Definition-rebind fallback** — for edges the confirm pass could not settle
+   from references alone, asks for the call site's definition
+   (`textDocument/definition`) and rebinds the edge to the concrete target.
+4. **References-add pass** — only for servers that expose references but not a
+   call hierarchy; recovers the caller edges a declaration's references imply.
+5. **Per-file sweep** — the whole-repo hover / hierarchy phase. Per function or
+   method it prepares a call hierarchy and reads outgoing (and, where it helps,
+   incoming) calls; per type or interface it reads the super/subtype hierarchy;
+   per symbol it hovers for a type string.
+
+Each phase opens the files it touches on the language server (`didOpen`) and
+closes them when done (`didClose`). The first four phases carry most of the
+precision gain; the sweep carries most of the cost — on a warm restart, where
+every node already reloads with its resolved edges and type stamp, the sweep is
+almost pure churn.
+
+### Bounded document session
+
+All five phases share one **document session** per pass. It opens each file on a
+server at most once while the file is in use, keeps recently-closed files warm
+in an LRU tail so a later phase reuses the open document instead of reopening
+it, and closes everything at pass end. The simultaneously-open ceiling is
+`2 × max_parallel` documents per server (floor 4): the pinned working set stays
+within `max_parallel` (bounded by the pass's file semaphore) and the extra
+headroom is the warm tail. `didOpen` / `didClose` stay paired per (file,
+server) — a file opened on a server that later dies still gets its close attempt
+on that server — while the server's open-document set stays bounded.
+
+This matters most for `clangd` without a compilation database: every `didOpen`
+triggers a full fallback-preamble + AST rebuild, so reopening the same file
+across phases multiplies that cost.
+
+### Sweep modes
+
+The per-file sweep (phase 5) is gated by a **sweep mode**:
+
+| Mode     | Behaviour                                                                                                                                                                                                                                                                                                                                                              |
+| -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `demand` | **Default.** Sweep a file only when its declarations still carry unresolved same-name call candidates (enrichment demand) or it declares a type / interface whose super/subtype hierarchy the sweep recovers. A file with neither signal is skipped, so a warm restart pays no sweep for it. Within a swept file, a node that already carries a `semantic_type` stamp from an earlier pass is not re-hovered. |
+| `full`   | Sweep every file of the language — maximal hover and hierarchy coverage, the right choice for a first cold index.                                                                                                                                                                                                                                                       |
+| `off`    | Skip the per-file sweep entirely. The confirm / rebind / references-add / interface passes still run, so edge tiers and recall are unaffected — only hover type strings and sweep-recovered hierarchy edges are dropped.                                                                                                                                                 |
+
+Resolution precedence, highest first:
+
+1. The `GORTEX_LSP_SWEEP` environment variable (`demand` / `full` / `off`, with
+   `none` accepted as an alias for `off`; case- and whitespace-insensitive). Set
+   it where you launch `gortex daemon` / `gortex server` to dial one run without
+   editing config.
+2. The `.gortex.yaml` key `semantic.lsp_sweep` (same values).
+3. The `demand` default.
+
+An unrecognised value at any level is ignored and the next source applies.
+
+```yaml
+semantic:
+  enabled: true
+  lsp_sweep: demand   # demand (default) | full | off
+```
+
+### Incoming-calls policy
+
+In the sweep's call-hierarchy step, outgoing calls are always fetched — the
+sweep visits every caller, so a declaration's outgoing hops alone reconstruct
+every intra-repo static call edge. Incoming calls are fetched only where the
+outgoing side is blind: a dispatch-relevant declaration (whose concrete callers
+land on the incoming side of an interface method, not its outgoing side) or one
+that still carries unresolved demand — or under `full` mode. Files are swept
+demand-first, so a declaration whose incoming calls are skipped at a deadline
+cut still loses no reachable edge. The count of declined round trips rides on
+the pass-complete log as `incoming_calls_skipped`.
+
+### Compile-database preflight (clangd)
+
+Before enriching a repository with a server that needs a compilation database
+(`clangd`), gortex checks the workspace root for one of:
+
+- `compile_commands.json` — canonical CMake / Bear output
+- `build*/compile_commands.json` — out-of-tree build directories
+- `compile_flags.txt` — clangd's flat-flags fallback
+- `.clangd` — a hand-written clangd config
+
+If none is present, clangd rebuilds a full fallback AST on every `didOpen`, and
+opening a header directly makes it a standalone translation unit with no
+cross-file signal to show for the cost. Rather than drive that churn, the pass
+**degrades to reference confirmation**: it runs the confirm and rebind passes
+(which work inside the fallback translation unit on fallback flags) and skips
+the interface pass, the references-add pass, the entire per-file sweep, and all
+header files. Edge tiers and confirmed / refuted edges are unaffected; hover
+type strings and call / type-hierarchy edges are absent for that pass.
+
+A degraded pass warns once with the remediation and marks its result
+`degraded`. `index_health` surfaces a recommendation naming the repository and
+provider:
+
+> generate compile_commands.json (cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON,
+> bear -- make, or meson) at the repo root, then reindex
+
+Degradation is deliberate, not a failure — `semantic_enrichment_ok` stays true.
+
+### Telemetry
+
+The pass-complete log line (`LSP enrich: hover phase complete`) carries the cost
+accounting for the pass:
+
+| Field | Meaning |
+| ----- | ------- |
+| `sweep_mode` | The effective sweep mode for the pass. |
+| `did_opens` | Total `didOpen` calls across every phase. |
+| `reopened_files` | Files opened more than once (a warm-tail miss). |
+| `doc_evictions` | LRU evictions — a `didClose` forced to make room. |
+| `peak_open_docs` | Peak simultaneously-open documents on any one server. |
+| `req_references`, `req_implementations`, `req_definitions`, `req_hovers` | Per-method request counts. |
+| `req_prepare_call_hierarchy`, `req_outgoing_calls`, `req_incoming_calls` | Call-hierarchy request counts. |
+| `incoming_calls_skipped` | Incoming-calls round trips the policy above declined. |
+| `req_prepare_type_hierarchy`, `req_supertypes`, `req_subtypes` | Type-hierarchy request counts. |
+| `skipped_already_stamped` | Nodes whose hover was skipped because they already carried a `semantic_type`. |
+
+A degraded pass logs `LSP enrich: degraded pass complete (reference
+confirmation only)` instead, with `degraded=true` and the document-open counters
+but no hover / hierarchy counts.
 
 ## Diagnostics
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -239,6 +239,17 @@ type SemanticConfig struct {
 	// matching any glob is not enriched and does not count toward a repo's
 	// present languages, so a language server is not spawned just to index it.
 	ExcludeGlobs []string `mapstructure:"exclude_globs" yaml:"exclude_globs,omitempty"`
+	// LSPSweep selects how much of the per-file LSP hover / call-hierarchy
+	// enrichment sweep runs. On an already-resolved graph that sweep re-opens
+	// and re-hovers every file to confirm zero new edges, so gating it cuts
+	// warm-restart churn:
+	//   - "demand" (DEFAULT / empty): sweep only files whose declarations
+	//     still carry unresolved same-name call candidates.
+	//   - "full": sweep every file of the language (pre-knob behaviour).
+	//   - "off": skip the per-file sweep; the tier-deciding confirm / add
+	//     passes still run.
+	// The GORTEX_LSP_SWEEP env override wins over this setting.
+	LSPSweep string `mapstructure:"lsp_sweep" yaml:"lsp_sweep,omitempty"`
 	// SkipEmbed lists (language, kind) combinations that should be
 	// indexed for graph queries but *not* embedded into the vector
 	// search. Design tokens (CSS custom properties), terraform

--- a/internal/mcp/index_health_enrichment_test.go
+++ b/internal/mcp/index_health_enrichment_test.go
@@ -108,3 +108,51 @@ func TestIndexHealth_SemanticEnrichmentCompletedIsGreen(t *testing.T) {
 	rec, _ := payload["recommendation"].(string)
 	assert.False(t, strings.Contains(rec, "Semantic enrichment"), "completed enrichment must not warn, got: %q", rec)
 }
+
+// TestIndexHealth_SurfacesDegradedEnrichment verifies a compile-db-degraded
+// pass (reference confirmation only) is not treated as a failure — ok stays
+// true — but surfaces the status flag, its reason as detail, and a
+// remediation recommendation.
+func TestIndexHealth_SurfacesDegradedEnrichment(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	mgr := semantic.NewManager(semantic.Config{
+		Enabled: true,
+		Providers: []semantic.ProviderConfig{
+			{Name: "lsp-clangd", Languages: []string{"c"}, Priority: 1, Enabled: true},
+		},
+	}, zap.NewNop())
+	mgr.RegisterProvider(&fakeSemProvider{
+		name: "lsp-clangd",
+		result: &semantic.EnrichResult{
+			Provider:       "lsp-clangd",
+			Language:       "c",
+			EdgesConfirmed: 3,
+			Degraded:       true,
+			DegradedReason: "no compilation database found; enrichment limited to reference confirmation",
+		},
+	})
+	_, err := mgr.EnrichAll(srv.graph, map[string]string{"repo-a": t.TempDir()})
+	require.NoError(t, err)
+	srv.SetSemanticManager(mgr)
+
+	payload := srv.buildIndexHealthPayload()
+	require.NotNil(t, payload)
+
+	statuses, ok := payload["semantic_enrichment"].([]semantic.EnrichmentStatus)
+	require.True(t, ok)
+	require.Len(t, statuses, 1)
+	assert.True(t, statuses[0].Degraded, "the status must carry the degraded flag")
+	assert.Equal(t, semantic.EnrichStateCompleted, statuses[0].State, "degradation is not a failure state")
+	assert.Contains(t, statuses[0].Detail, "compilation database", "the degraded reason should surface as detail")
+
+	// Degradation is intentional — it must not flip the ok flag.
+	okFlag, ok := payload["semantic_enrichment_ok"].(bool)
+	require.True(t, ok)
+	assert.True(t, okFlag, "a degraded pass is not a failure and must keep semantic_enrichment_ok true")
+
+	rec, _ := payload["recommendation"].(string)
+	assert.True(t, strings.Contains(rec, "degraded") && strings.Contains(rec, "compile_commands.json"),
+		"a degraded pass must recommend generating a compile database, got: %q", rec)
+	assert.Contains(t, rec, "lsp-clangd in repo-a", "the recommendation should name the repo/provider")
+}

--- a/internal/mcp/tools_enhancements.go
+++ b/internal/mcp/tools_enhancements.go
@@ -3069,6 +3069,25 @@ func (s *Server) buildIndexHealthPayload() map[string]any {
 		}
 	}
 
+	// Compile-database-degraded providers: a clangd pass with no
+	// compile_commands.json intentionally runs reference confirmation only (no
+	// hover / hierarchy sweep). This is not a failure — semantic_enrichment_ok
+	// stays true — but the missing tiers are worth flagging with the remediation.
+	var degradedProviders []string
+	for _, st := range enrichStatuses {
+		if st.Degraded {
+			degradedProviders = append(degradedProviders, st.Provider+" in "+st.Repo)
+		}
+	}
+	if len(degradedProviders) > 0 {
+		msg := "Semantic enrichment ran in degraded (reference-confirmation-only) mode for " + strings.Join(degradedProviders, ", ") + " because no compilation database was found — hover types and call/type-hierarchy edges were skipped. Generate compile_commands.json (cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON, bear -- make, or meson) at the repo root, then reindex_repository."
+		if recommendation == "" {
+			recommendation = msg
+		} else {
+			recommendation = msg + " " + recommendation
+		}
+	}
+
 	result := map[string]any{
 		"health_score":         healthScore,
 		"total_detected":       totalDetected,

--- a/internal/semantic/config.go
+++ b/internal/semantic/config.go
@@ -16,6 +16,11 @@ type Config struct {
 	// languages (so a language server is not spawned for a repo whose only
 	// files of that language are excluded).
 	ExcludeGlobs []string `mapstructure:"exclude_globs" yaml:"exclude_globs,omitempty"`
+	// LSPSweep mirrors config.SemanticConfig.LSPSweep — the per-file LSP
+	// enrichment sweep mode ("demand" default / "full" / "off"). Threaded to
+	// each spawned LSP provider via the router's WithEnrichSweepMode. The
+	// GORTEX_LSP_SWEEP env override wins over it at enrichment time.
+	LSPSweep string `mapstructure:"lsp_sweep" yaml:"lsp_sweep,omitempty"`
 }
 
 // ProviderConfig holds configuration for a single semantic provider.

--- a/internal/semantic/lsp/compiledb.go
+++ b/internal/semantic/lsp/compiledb.go
@@ -1,0 +1,54 @@
+package lsp
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// hasCompileDB reports whether root carries a clangd-usable compilation
+// database, or an explicit clangd configuration that means the user
+// wired the server up deliberately. Without one, clangd falls back to a
+// per-file preamble + AST rebuild on every didOpen — the churn the
+// degraded enrichment path exists to avoid.
+//
+// Probed, in order:
+//   - <root>/compile_commands.json        — the canonical CMake / Bear output
+//   - <root>/build*/compile_commands.json — out-of-tree build directories
+//   - <root>/compile_flags.txt            — clangd's flat-flags fallback
+//   - <root>/.clangd                      — user opted clangd in by hand
+//
+// This mirrors the indexer's compile-DB probe without importing it: the
+// import graph runs indexer→semantic only, so a helper both need must be
+// stdlib-only and live on this side of the boundary. No caching — one
+// stat set runs per enrichment pass.
+func hasCompileDB(root string) bool {
+	if root == "" {
+		return false
+	}
+	if fileExists(filepath.Join(root, "compile_commands.json")) {
+		return true
+	}
+	if matches, _ := filepath.Glob(filepath.Join(root, "build*", "compile_commands.json")); len(matches) > 0 {
+		return true
+	}
+	if fileExists(filepath.Join(root, "compile_flags.txt")) {
+		return true
+	}
+	if fileExists(filepath.Join(root, ".clangd")) {
+		return true
+	}
+	return false
+}
+
+// isCXXHeaderFile reports whether rel names a C / C++ header. A degraded
+// (no-compile-database) pass skips headers: opening one directly makes
+// clangd treat it as a standalone translation unit and rebuild a full
+// fallback AST for a file that, without a database, offers no cross-file
+// signal in return.
+func isCXXHeaderFile(rel string) bool {
+	switch strings.ToLower(filepath.Ext(rel)) {
+	case ".h", ".hh", ".hpp", ".hxx", ".h++":
+		return true
+	}
+	return false
+}

--- a/internal/semantic/lsp/compiledb_test.go
+++ b/internal/semantic/lsp/compiledb_test.go
@@ -1,0 +1,199 @@
+package lsp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// TestHasCompileDB pins the compile-database preflight: any of the canonical
+// clangd inputs (a root or out-of-tree database, a flat-flags file, or an
+// explicit .clangd) counts as configured; a bare directory does not.
+func TestHasCompileDB(t *testing.T) {
+	write := func(t *testing.T, path, body string) {
+		t.Helper()
+		require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
+	}
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, root string)
+		want  bool
+	}{
+		{"root database", func(t *testing.T, root string) {
+			write(t, filepath.Join(root, "compile_commands.json"), "[]")
+		}, true},
+		{"out-of-tree build database", func(t *testing.T, root string) {
+			require.NoError(t, os.MkdirAll(filepath.Join(root, "build-debug"), 0o755))
+			write(t, filepath.Join(root, "build-debug", "compile_commands.json"), "[]")
+		}, true},
+		{"flat compile_flags.txt", func(t *testing.T, root string) {
+			write(t, filepath.Join(root, "compile_flags.txt"), "-Iinclude\n")
+		}, true},
+		{"explicit .clangd config", func(t *testing.T, root string) {
+			write(t, filepath.Join(root, ".clangd"), "CompileFlags:\n  Add: [-std=c11]\n")
+		}, true},
+		{"nothing configured", func(t *testing.T, root string) {}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			tt.setup(t, root)
+			assert.Equal(t, tt.want, hasCompileDB(root))
+		})
+	}
+	// An empty root string is never a database.
+	assert.False(t, hasCompileDB(""))
+}
+
+// degradedFixture writes a two-file C repo (a translation unit plus a header
+// referent) and seeds an interface node, an ambiguous edge to the served .c
+// referent, and an ambiguous edge to the header referent. It returns the repo
+// root and graph so a compile-db-present / -absent pair of tests can share it.
+func degradedFixture(t *testing.T) (string, graph.Store) {
+	t.Helper()
+	repoRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "a.c"),
+		[]byte("int target(void) { return 0; }\nint caller(void) { return target(); }\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "b.h"),
+		[]byte("int htarget(void);\n"), 0o644))
+
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "a.c::target", Kind: graph.KindFunction, Name: "target",
+		FilePath: "a.c", StartLine: 1, EndLine: 1, Language: "c"})
+	g.AddNode(&graph.Node{ID: "a.c::caller", Kind: graph.KindFunction, Name: "caller",
+		FilePath: "a.c", StartLine: 2, EndLine: 2, Language: "c"})
+	g.AddNode(&graph.Node{ID: "b.h::htarget", Kind: graph.KindFunction, Name: "htarget",
+		FilePath: "b.h", StartLine: 1, EndLine: 1, Language: "c"})
+	// An interface node — proves the interface (implementations) pass is gated.
+	g.AddNode(&graph.Node{ID: "a.c::iface", Kind: graph.KindInterface, Name: "iface",
+		FilePath: "a.c", StartLine: 1, EndLine: 1, Language: "c"})
+	// Ambiguous edge to a served .c referent — the confirm pass must query it.
+	g.AddEdge(&graph.Edge{From: "a.c::caller", To: "a.c::target", Kind: graph.EdgeCalls,
+		FilePath: "a.c", Line: 2, Confidence: 0.7, ConfidenceLabel: "INFERRED", Origin: graph.OriginTextMatched})
+	// Ambiguous edge to a header referent — a degraded pass must skip it.
+	g.AddEdge(&graph.Edge{From: "a.c::caller", To: "b.h::htarget", Kind: graph.EdgeCalls,
+		FilePath: "a.c", Line: 2, Confidence: 0.7, ConfidenceLabel: "INFERRED", Origin: graph.OriginTextMatched})
+	return repoRoot, g
+}
+
+// clangdLikeSpec mirrors the registry's clangd spec closely enough to drive the
+// degraded gate: the C/C++ extension coverage plus NeedsCompileDB.
+func clangdLikeSpec() *ServerSpec {
+	return &ServerSpec{
+		Name:           "clangd",
+		Languages:      []string{"c", "cpp"},
+		Extensions:     []string{".c", ".h", ".cpp", ".hpp"},
+		NeedsCompileDB: true,
+	}
+}
+
+// TestLSP_Enrich_DegradesWithoutCompileDB pins the degraded path: with a
+// NeedsCompileDB server and no database, only the reference-confirm pass runs —
+// the hover / hierarchy sweep and interface pass are skipped, header referents
+// are never opened, and the result is flagged Degraded with a reason.
+func TestLSP_Enrich_DegradesWithoutCompileDB(t *testing.T) {
+	repoRoot, g := degradedFixture(t)
+	// No compile_commands.json — the degraded gate must trip.
+
+	server := newInstrumentedServer()
+	var hoverCalls, implCalls, prepCalls atomic.Int64
+	var refMu sync.Mutex
+	refURIs := map[string]bool{}
+	server.handle("textDocument/references", func(params json.RawMessage) (any, *jsonRPCError) {
+		var req struct {
+			TextDocument struct {
+				URI string `json:"uri"`
+			} `json:"textDocument"`
+		}
+		_ = json.Unmarshal(params, &req)
+		refMu.Lock()
+		refURIs[req.TextDocument.URI] = true
+		refMu.Unlock()
+		return []Location{}, nil
+	})
+	server.handle("textDocument/hover", func(params json.RawMessage) (any, *jsonRPCError) {
+		hoverCalls.Add(1)
+		return nil, nil
+	})
+	server.handle("textDocument/implementation", func(params json.RawMessage) (any, *jsonRPCError) {
+		implCalls.Add(1)
+		return []Location{}, nil
+	})
+	server.handle("textDocument/prepareCallHierarchy", func(params json.RawMessage) (any, *jsonRPCError) {
+		prepCalls.Add(1)
+		return []Location{}, nil
+	})
+
+	p, cleanup := providerWithInstrumentedServer(t, server, []string{"c", "cpp"}, 2)
+	defer cleanup()
+	p.spec = clangdLikeSpec()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	result, err := p.EnrichRepoContext(ctx, g, "", repoRoot)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.True(t, result.Degraded, "a missing compilation database must degrade the pass")
+	assert.NotEmpty(t, result.DegradedReason)
+
+	// The sweep and interface pass are skipped; only reference confirmation ran.
+	assert.Zero(t, hoverCalls.Load(), "the hover sweep must be skipped while degraded")
+	assert.Zero(t, prepCalls.Load(), "call hierarchy must be skipped while degraded")
+	assert.Zero(t, implCalls.Load(), "the interface pass must be skipped while degraded")
+
+	aURI := pathToURI(filepath.Join(repoRoot, "a.c"))
+	hURI := pathToURI(filepath.Join(repoRoot, "b.h"))
+	refMu.Lock()
+	assert.True(t, refURIs[aURI], "the served .c referent must still be queried")
+	assert.False(t, refURIs[hURI], "a header referent must be skipped while degraded")
+	refMu.Unlock()
+	assert.False(t, server.wasOpened(hURI), "a header must never be opened while degraded")
+}
+
+// TestLSP_Enrich_RunsFullPipelineWithCompileDB is the degraded gate's negative
+// control: the same fixture with a compile_commands.json present runs the full
+// pipeline, so the hover sweep fires and the result is not degraded.
+func TestLSP_Enrich_RunsFullPipelineWithCompileDB(t *testing.T) {
+	repoRoot, g := degradedFixture(t)
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "compile_commands.json"), []byte("[]"), 0o644))
+	// Force a full sweep so the assertion isolates the compile-db gate from the
+	// demand-driven sweep gating.
+	t.Setenv(SweepEnv, "full")
+
+	server := newInstrumentedServer()
+	var hoverCalls atomic.Int64
+	server.handle("textDocument/references", func(params json.RawMessage) (any, *jsonRPCError) {
+		return []Location{}, nil
+	})
+	server.handle("textDocument/definition", func(params json.RawMessage) (any, *jsonRPCError) {
+		return []Location{}, nil
+	})
+	server.handle("textDocument/hover", func(params json.RawMessage) (any, *jsonRPCError) {
+		hoverCalls.Add(1)
+		return nil, nil
+	})
+
+	p, cleanup := providerWithInstrumentedServer(t, server, []string{"c", "cpp"}, 2)
+	defer cleanup()
+	p.spec = clangdLikeSpec()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	result, err := p.EnrichRepoContext(ctx, g, "", repoRoot)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.False(t, result.Degraded, "a present compilation database must not degrade the pass")
+	assert.Positive(t, hoverCalls.Load(), "the hover sweep must run when a compilation database is present")
+}

--- a/internal/semantic/lsp/doc_session.go
+++ b/internal/semantic/lsp/doc_session.go
@@ -1,0 +1,187 @@
+package lsp
+
+import (
+	"container/list"
+	"os"
+	"sync"
+)
+
+// docSession shares one bounded set of open documents across every phase
+// of a single enrichment pass. It builds ONLY on the bare
+// enrichOpenDoc / enrichCloseDoc lifecycle (never the shared-state
+// openDocument / sourceCache tables) and owns its own per-entry content
+// cache, so a file read from disk once serves every phase that touches it
+// and no phase writes the provider's unsynchronised sourceCache.
+//
+// A file is didOpen'd at most once per (client, path) while its entry
+// lives; release unpins it and leaves it warm in an LRU tail so a later
+// phase reuses the already-open document instead of reopening it. When the
+// documents open on a client would exceed cap, acquire first didCloses the
+// oldest unpinned entries. Pinned entries are never in the LRU and so never
+// close, which means a fully-pinned working set may briefly exceed cap —
+// pin volume is bounded externally by fileSem, so the overshoot is small.
+type docSession struct {
+	p   *Provider
+	cap int // simultaneously-open ceiling per client
+
+	mu        sync.Mutex
+	perClient map[*Client]*clientDocs
+
+	// Telemetry, all guarded by mu.
+	didOpens   int
+	evictions  int
+	curOpen    int
+	peakOpen   int
+	openCounts map[string]int // absPath → number of didOpens across the pass
+}
+
+// clientDocs tracks the documents open on one client. lru holds the
+// refcount-0 (unpinned) entries with the oldest at the front, so eviction
+// pops the least-recently-released document first. The list element Value
+// is the entry's absPath.
+type clientDocs struct {
+	open map[string]*docEntry
+	lru  *list.List
+}
+
+// docEntry is one open document. refs counts the live acquire pins; when it
+// falls to zero the entry moves onto its client's lru and becomes
+// evictable. content is the file's bytes, read from disk once per entry.
+type docEntry struct {
+	refs    int
+	elem    *list.Element
+	content []byte
+}
+
+// newDocSession builds a session sized to hold 2*maxParallel documents
+// open per client (floor 4). The pinned working set is bounded by fileSem
+// at maxParallel, so the extra headroom is the warm LRU tail that carries
+// recently-released documents across phases.
+func newDocSession(p *Provider) *docSession {
+	cp := 2 * p.maxParallel
+	if cp < 4 {
+		cp = 4
+	}
+	return &docSession{
+		p:          p,
+		cap:        cp,
+		perClient:  map[*Client]*clientDocs{},
+		openCounts: map[string]int{},
+	}
+}
+
+// acquire pins absPath open on c, sending its didOpen once per entry
+// lifetime and reading its bytes from disk once. The returned release
+// unpins the entry; a refcount-0 entry stays open on the server (warm in
+// the lru) until it is evicted or closeAll runs. err is non-nil only when
+// the disk read or the didOpen notify failed — release is a no-op then.
+func (s *docSession) acquire(c *Client, absPath string) ([]byte, func(), error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cd := s.perClient[c]
+	if cd == nil {
+		cd = &clientDocs{open: map[string]*docEntry{}, lru: list.New()}
+		s.perClient[c] = cd
+	}
+
+	if e, ok := cd.open[absPath]; ok {
+		// Already open on this client — pin it, pulling it back off the
+		// lru if it was sitting there unpinned.
+		if e.refs == 0 && e.elem != nil {
+			cd.lru.Remove(e.elem)
+			e.elem = nil
+		}
+		e.refs++
+		return e.content, s.releaseFunc(c, absPath), nil
+	}
+
+	// Read the file before touching the server so a read error leaves no
+	// half-open entry behind.
+	content, err := os.ReadFile(absPath)
+	if err != nil {
+		return nil, func() {}, err
+	}
+
+	// Make room: didClose the oldest unpinned entries so this open keeps
+	// the client at or under cap. Evicting before the new didOpen keeps the
+	// server's open count from spiking above cap. A fully-pinned client has
+	// an empty lru and simply overshoots.
+	for len(cd.open) >= s.cap {
+		front := cd.lru.Front()
+		if front == nil {
+			break
+		}
+		evPath := front.Value.(string)
+		cd.lru.Remove(front)
+		delete(cd.open, evPath)
+		_ = s.p.enrichCloseDoc(c, evPath)
+		s.curOpen--
+		s.evictions++
+	}
+
+	if err := s.p.enrichOpenDoc(c, absPath, content); err != nil {
+		return nil, func() {}, err
+	}
+	cd.open[absPath] = &docEntry{refs: 1, content: content}
+	s.didOpens++
+	s.openCounts[absPath]++
+	s.curOpen++
+	if s.curOpen > s.peakOpen {
+		s.peakOpen = s.curOpen
+	}
+	return content, s.releaseFunc(c, absPath), nil
+}
+
+// releaseFunc returns a release closure for one pin on (c, absPath).
+// Callers defer it exactly once per successful acquire; a refcount-0 entry
+// re-joins the lru so a later acquire can reuse (or evict) it.
+func (s *docSession) releaseFunc(c *Client, absPath string) func() {
+	return func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		cd := s.perClient[c]
+		if cd == nil {
+			return
+		}
+		e := cd.open[absPath]
+		if e == nil || e.refs == 0 {
+			return
+		}
+		e.refs--
+		if e.refs == 0 {
+			e.elem = cd.lru.PushBack(absPath)
+		}
+	}
+}
+
+// closeAll didCloses every still-open document on every client,
+// best-effort (a doc opened on a client that later died still gets its
+// close attempt, error ignored). Deferred once at the end of the pass.
+func (s *docSession) closeAll() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for c, cd := range s.perClient {
+		for path := range cd.open {
+			_ = s.p.enrichCloseDoc(c, path)
+			s.curOpen--
+		}
+		cd.open = map[string]*docEntry{}
+		cd.lru.Init()
+	}
+}
+
+// stats returns the pass telemetry: total didOpens, the number of distinct
+// paths opened more than once, LRU evictions, and the peak simultaneously
+// open documents.
+func (s *docSession) stats() (didOpens, reopenedFiles, evictions, peakOpen int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	reopened := 0
+	for _, cnt := range s.openCounts {
+		if cnt > 1 {
+			reopened++
+		}
+	}
+	return s.didOpens, reopened, s.evictions, s.peakOpen
+}

--- a/internal/semantic/lsp/doc_session_test.go
+++ b/internal/semantic/lsp/doc_session_test.go
@@ -1,0 +1,242 @@
+package lsp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/semantic"
+)
+
+// A single file that feeds three phases — the interface pass (a KindInterface
+// node), the ambiguous-edge confirm pass (an edge whose referent lives in the
+// file), and the per-file hover sweep — must be didOpen'd exactly once: the
+// shared document session keeps it warm across phases instead of reopening it.
+func TestLSP_Enrich_SessionSharedAcrossPasses(t *testing.T) {
+	repoRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repoRoot, "shared.go"),
+		[]byte("package shared\n\ntype Greeter interface { Greet() string }\n\nfunc Hello() string { return \"\" }\n\nfunc Caller() { _ = Hello() }\n"),
+		0o644,
+	))
+
+	server := newInstrumentedServer()
+	server.handle("textDocument/hover", func(params json.RawMessage) (any, *jsonRPCError) { return nil, nil })
+
+	p, cleanup := providerWithInstrumentedServer(t, server, []string{"go"}, 4)
+	defer cleanup()
+	// Advertise call / type hierarchy so the sweep exercises the hierarchy
+	// path too; the instrumented server answers null, so no hops are added.
+	p.caps = ServerCapabilities{CallHierarchyProvider: true, TypeHierarchyProvider: true}
+
+	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID: "shared.go::Greeter", Kind: graph.KindInterface, Name: "Greeter",
+		FilePath: "shared.go", StartLine: 3, EndLine: 3, Language: "go",
+	})
+	g.AddNode(&graph.Node{
+		ID: "shared.go::Hello", Kind: graph.KindFunction, Name: "Hello",
+		FilePath: "shared.go", StartLine: 5, EndLine: 5, Language: "go",
+	})
+	g.AddNode(&graph.Node{
+		ID: "shared.go::Caller", Kind: graph.KindFunction, Name: "Caller",
+		FilePath: "shared.go", StartLine: 7, EndLine: 7, Language: "go",
+	})
+	// Ambiguous edge whose referent (Hello) lives in shared.go — drives the
+	// confirm pass to open shared.go.
+	g.AddEdge(&graph.Edge{
+		From: "shared.go::Caller", To: "shared.go::Hello", Kind: graph.EdgeCalls,
+		Confidence: 0.7, ConfidenceLabel: "INFERRED", Origin: graph.OriginASTInferred,
+	})
+
+	require.NoError(t, runEnrich(t, p, g, repoRoot, 10*time.Second))
+
+	require.Eventually(t, func() bool {
+		_, o, c := server.stats()
+		return o == 1 && c == 1
+	}, 3*time.Second, 5*time.Millisecond, "shared.go should be opened once and closed once")
+
+	_, opens, closes := server.stats()
+	assert.Equal(t, 1, opens, "shared.go opened exactly once across interface + confirm + sweep")
+	assert.Equal(t, opens, closes, "the single open must be paired with a single close")
+}
+
+// A caller with several misbound sites in one file must open that site file
+// once during the definition-rebind fallback, not once per site. Callers live
+// in a.go, the callee in b.go; references never match (forcing fallback) and
+// definition answers with the callee, so all sites confirm off one open of
+// a.go. Total didOpens stay at two files: a.go (fallback) and b.go (confirm).
+func TestLSP_Enrich_FallbackRebindOpensSiteFileOnce(t *testing.T) {
+	repoRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repoRoot, "a.go"),
+		[]byte("package main\nfunc c0() { callee() }\nfunc c1() { callee() }\nfunc c2() { callee() }\nfunc c3() { callee() }\nfunc c4() { callee() }\n"),
+		0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repoRoot, "b.go"),
+		[]byte("package main\nfunc callee() {}\n"),
+		0o644,
+	))
+
+	server := newInstrumentedServer()
+	server.handle("textDocument/hover", func(params json.RawMessage) (any, *jsonRPCError) { return nil, nil })
+	// No matching references → every ambiguous edge falls through to the
+	// definition-rebind fallback.
+	server.handle("textDocument/references", func(params json.RawMessage) (any, *jsonRPCError) {
+		return []Location{}, nil
+	})
+	// Definition resolves each site to the callee declaration in b.go.
+	server.handle("textDocument/definition", func(params json.RawMessage) (any, *jsonRPCError) {
+		return []Location{{
+			URI:   pathToURI(filepath.Join(repoRoot, "b.go")),
+			Range: Range{Start: Position{Line: 1, Character: 5}, End: Position{Line: 1, Character: 11}},
+		}}, nil
+	})
+
+	p, cleanup := providerWithInstrumentedServer(t, server, []string{"go"}, 4)
+	defer cleanup()
+	// Call hierarchy present (references-add pass off); type hierarchy present.
+	p.caps = ServerCapabilities{CallHierarchyProvider: true, TypeHierarchyProvider: true}
+
+	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID: "b.go::callee", Kind: graph.KindFunction, Name: "callee",
+		FilePath: "b.go", StartLine: 2, EndLine: 2, Language: "go",
+	})
+	for i := 0; i < 5; i++ {
+		caller := "c" + string(rune('0'+i))
+		siteLine := 2 + i
+		g.AddNode(&graph.Node{
+			ID: "a.go::" + caller, Kind: graph.KindFunction, Name: caller,
+			FilePath: "a.go", StartLine: siteLine, EndLine: siteLine, Language: "go",
+		})
+		// Misbound ambiguous edge anchored at the caller's call site in a.go.
+		g.AddEdge(&graph.Edge{
+			From: "a.go::" + caller, To: "b.go::callee", Kind: graph.EdgeCalls,
+			FilePath: "a.go", Line: siteLine,
+			Confidence: 0.7, ConfidenceLabel: "INFERRED", Origin: graph.OriginASTInferred,
+		})
+	}
+
+	var result *semantic.EnrichResult
+	done := make(chan error, 1)
+	go func() {
+		r, err := p.Enrich(g, repoRoot)
+		result = r
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("Enrich timed out")
+	}
+
+	require.Eventually(t, func() bool {
+		_, o, c := server.stats()
+		return o == 2 && o == c
+	}, 3*time.Second, 5*time.Millisecond, "a.go (fallback) and b.go (confirm) each opened once")
+
+	_, opens, closes := server.stats()
+	assert.Equal(t, 2, opens, "five fallback sites in a.go open it once, not once per site")
+	assert.Equal(t, opens, closes, "every open must be paired with a close")
+	require.NotNil(t, result)
+	assert.Equal(t, 5, result.EdgesConfirmed, "all five sites confirm off one open of a.go")
+}
+
+// A sequential acquire/release of three files under cap 2 evicts (didCloses)
+// the oldest released file when the third opens, keeps the open set within
+// cap, and pairs every open with a close after closeAll.
+func TestDocSession_LRUEvictsPairedAndBounded(t *testing.T) {
+	repoRoot := t.TempDir()
+	files := []string{"a.go", "b.go", "c.go"}
+	for _, f := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(repoRoot, f), []byte("package main\n"), 0o644))
+	}
+
+	server := newInstrumentedServer()
+	p, cleanup := providerWithInstrumentedServer(t, server, []string{"go"}, 1)
+	defer cleanup()
+
+	session := newDocSession(p)
+	session.cap = 2
+
+	for _, f := range files {
+		_, release, err := session.acquire(p.client, filepath.Join(repoRoot, f))
+		require.NoError(t, err)
+		release()
+	}
+
+	// Opening c.go (the third file) evicts the oldest refcount-0 entry
+	// (a.go), so by now exactly one didClose has been sent.
+	require.Eventually(t, func() bool {
+		_, o, c := server.stats()
+		return o == 3 && c == 1
+	}, 2*time.Second, 5*time.Millisecond, "third open evicts + closes exactly the oldest file")
+
+	peak, _, _ := server.stats()
+	assert.LessOrEqual(t, peak, session.cap,
+		"peak simultaneously-open docs (%d) must stay within cap (%d)", peak, session.cap)
+
+	session.closeAll()
+	require.Eventually(t, func() bool {
+		_, o, c := server.stats()
+		return o == 3 && o == c
+	}, 2*time.Second, 5*time.Millisecond, "closeAll closes every remaining open document")
+
+	_, opens, closes := server.stats()
+	assert.Equal(t, opens, closes, "opens (%d) must equal closes (%d) after closeAll", opens, closes)
+	assert.Equal(t, 3, opens, "each of the three files was opened once")
+}
+
+// Pinned entries are never evicted: holding refs on cap files and acquiring one
+// more overshoots cap (no didClose) rather than closing a pinned document.
+func TestDocSession_PinnedNeverEvicted(t *testing.T) {
+	repoRoot := t.TempDir()
+	files := []string{"a.go", "b.go", "c.go"}
+	for _, f := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(repoRoot, f), []byte("package main\n"), 0o644))
+	}
+
+	server := newInstrumentedServer()
+	p, cleanup := providerWithInstrumentedServer(t, server, []string{"go"}, 1)
+	defer cleanup()
+
+	session := newDocSession(p)
+	session.cap = 2
+
+	// Hold pins on cap (2) files, then acquire one more without releasing.
+	_, rel1, err := session.acquire(p.client, filepath.Join(repoRoot, "a.go"))
+	require.NoError(t, err)
+	_, rel2, err := session.acquire(p.client, filepath.Join(repoRoot, "b.go"))
+	require.NoError(t, err)
+	_, rel3, err := session.acquire(p.client, filepath.Join(repoRoot, "c.go"))
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		_, o, _ := server.stats()
+		return o == 3
+	}, 2*time.Second, 5*time.Millisecond, "all three files opened")
+
+	peak, opens, closes := server.stats()
+	assert.Equal(t, 3, opens, "three files opened")
+	assert.Equal(t, 0, closes, "a fully-pinned set is never evicted — no didClose before release")
+	assert.Equal(t, 3, peak, "the pinned set overshoots cap")
+
+	rel1()
+	rel2()
+	rel3()
+	session.closeAll()
+
+	require.Eventually(t, func() bool {
+		_, o, c := server.stats()
+		return o == 3 && o == c
+	}, 2*time.Second, 5*time.Millisecond, "closeAll pairs every open with a close after release")
+}

--- a/internal/semantic/lsp/doc_session_test.go
+++ b/internal/semantic/lsp/doc_session_test.go
@@ -19,6 +19,7 @@ import (
 // file), and the per-file hover sweep — must be didOpen'd exactly once: the
 // shared document session keeps it warm across phases instead of reopening it.
 func TestLSP_Enrich_SessionSharedAcrossPasses(t *testing.T) {
+	t.Setenv("GORTEX_LSP_SWEEP", "full") // keep the per-file sweep in play so it shares the warm document
 	repoRoot := t.TempDir()
 	require.NoError(t, os.WriteFile(
 		filepath.Join(repoRoot, "shared.go"),

--- a/internal/semantic/lsp/enrich_budget_test.go
+++ b/internal/semantic/lsp/enrich_budget_test.go
@@ -26,6 +26,7 @@ import (
 // deadline that a sequential confirm pass alone (8 files x 60ms = 480ms > 400ms
 // budget) would have exhausted.
 func TestLSP_Enrich_ConfirmDoesNotStarveAddPhase(t *testing.T) {
+	t.Setenv("GORTEX_LSP_SWEEP", "full") // exercise the full post-confirm sweep, not the demand-gated default
 	const n = 8
 	const refDelay = 60 * time.Millisecond
 

--- a/internal/semantic/lsp/enrich_confirm.go
+++ b/internal/semantic/lsp/enrich_confirm.go
@@ -36,7 +36,11 @@ type confirmGroup struct {
 // where a confirmation resolves the most tiers — have already run. Ordering is
 // deterministic (count desc, then path) so a resumed / replayed index is
 // stable.
-func (p *Provider) groupConfirmTargets(g graph.Store, targets []enrichTarget) []*confirmGroup {
+//
+// skipFile, when non-nil, drops any referent file the predicate rejects —
+// the compile-database-degraded pass passes it to keep clangd from opening
+// header translation units it cannot resolve without a database.
+func (p *Provider) groupConfirmTargets(g graph.Store, targets []enrichTarget, skipFile func(rel string) bool) []*confirmGroup {
 	byFile := map[string]*confirmGroup{}
 	var order []*confirmGroup
 	for _, t := range targets {
@@ -53,6 +57,9 @@ func (p *Provider) groupConfirmTargets(g graph.Store, targets []enrichTarget) []
 		}
 		if !p.servesFile(rel) {
 			continue // never open a referent file this server can't compile
+		}
+		if skipFile != nil && skipFile(rel) {
+			continue // degraded mode: never open this referent (e.g. a header)
 		}
 		grp := byFile[rel]
 		if grp == nil {

--- a/internal/semantic/lsp/enrich_crashloop_test.go
+++ b/internal/semantic/lsp/enrich_crashloop_test.go
@@ -17,6 +17,7 @@ import (
 // loop. After the per-pass cap the provider's enrichment is abandoned with an
 // error and a bounded reconnect count, and whatever landed earlier stays.
 func TestLSP_Enrich_CrashLoopGuardAbandonsPass(t *testing.T) {
+	t.Setenv("GORTEX_LSP_SWEEP", "full") // exercise the full per-file sweep, not the demand-gated default
 	repoRoot, g := seedRepo(t, 60)
 
 	server1 := newInstrumentedServer()

--- a/internal/semantic/lsp/enrich_hardening_test.go
+++ b/internal/semantic/lsp/enrich_hardening_test.go
@@ -18,6 +18,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/semantic"
 )
 
 // ---------------------------------------------------------------------------
@@ -35,14 +36,14 @@ import (
 type instrumentedServer struct {
 	handlers map[string]func(params json.RawMessage) (any, *jsonRPCError)
 
-	mu          sync.Mutex
-	openDocs    map[string]int  // uri → currently-open count
-	everOpened  map[string]bool // uri → ever received a didOpen
-	maxOpen     int             // peak simultaneous open docs
-	totalOpen   int
-	totalClose  int
-	notifLog    []string
-	outMu       sync.Mutex // serialises concurrent response writes
+	mu         sync.Mutex
+	openDocs   map[string]int  // uri → currently-open count
+	everOpened map[string]bool // uri → ever received a didOpen
+	maxOpen    int             // peak simultaneous open docs
+	totalOpen  int
+	totalClose int
+	notifLog   []string
+	outMu      sync.Mutex // serialises concurrent response writes
 }
 
 func newInstrumentedServer() *instrumentedServer {
@@ -316,8 +317,12 @@ func TestLSP_Enrich_DocLifecyclePairedAndBounded(t *testing.T) {
 	peak, opens, closes := server.stats()
 	assert.Equal(t, opens, closes, "every didOpen must be matched by a didClose (opens=%d closes=%d)", opens, closes)
 	assert.Equal(t, nFiles, opens, "expected one didOpen per distinct file")
-	assert.LessOrEqual(t, peak, maxParallel,
-		"peak simultaneously-open docs (%d) must not exceed maxParallel (%d)", peak, maxParallel)
+	// The shared document session keeps a warm LRU tail of recently-released
+	// files across phases, so up to 2*maxParallel docs can be open at once:
+	// maxParallel pinned by the in-flight file goroutines plus the tail. The
+	// session evicts (didCloses) down to that ceiling before each new open.
+	assert.LessOrEqual(t, peak, 2*maxParallel,
+		"peak simultaneously-open docs (%d) must not exceed the session cap 2*maxParallel (%d)", peak, 2*maxParallel)
 }
 
 // didClose must happen even when hover fails.
@@ -421,6 +426,82 @@ func TestLSP_Enrich_ReconnectsOnServerExit(t *testing.T) {
 	require.NoError(t, runEnrich(t, p, g, repoRoot, 15*time.Second))
 
 	assert.GreaterOrEqual(t, int(reconnects.Load()), 1, "expected at least one reconnect on server exit")
+}
+
+// TestLSP_Enrich_UsesRetriedHoverResult forces the single hover down the
+// recover-and-retry path and asserts the retried hover's payload is actually
+// recorded. The first (and only) hover kills its client and then parks, so the
+// goroutine observes "LSP server exited" — never a response — which makes the
+// reconnect-and-retry the ONLY path by which this node can be stamped. The
+// second server serves a real type payload; the node must end the pass carrying
+// that type.
+func TestLSP_Enrich_UsesRetriedHoverResult(t *testing.T) {
+	t.Setenv("GORTEX_LSP_SWEEP", "full") // exercise the full per-file sweep, not the demand-gated default
+	repoRoot, g := seedRepo(t, 1)
+
+	server1 := newInstrumentedServer()
+	p, cleanup := providerWithInstrumentedServer(t, server1, []string{"go"}, 1)
+	defer cleanup()
+	deadClient := p.client
+
+	// The parked handler never answers; releasing it at cleanup lets the
+	// leaked server goroutine unwind.
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	var killOnce sync.Once
+	server1.handle("textDocument/hover", func(params json.RawMessage) (any, *jsonRPCError) {
+		killOnce.Do(func() {
+			deadClient.mu.Lock()
+			if !deadClient.closed {
+				deadClient.closed = true
+				close(deadClient.done)
+			}
+			deadClient.mu.Unlock()
+		})
+		<-release // never reply: the goroutine must observe the server exit, not a response
+		return nil, &jsonRPCError{Code: -32603, Message: "dead"}
+	})
+
+	// Second server: healthy, serves a type payload extractTypeFromHover parses.
+	server2 := newInstrumentedServer()
+	server2.handle("textDocument/hover", func(params json.RawMessage) (any, *jsonRPCError) {
+		return map[string]any{"contents": map[string]any{"kind": "plaintext", "value": "func F0() string"}}, nil
+	})
+	var reconnects atomic.Int64
+	p.connectOnce = func(absRoot string) error {
+		reconnects.Add(1)
+		c2, in2, out2, cl2 := newPipedClient(t)
+		go server2.run(in2, out2)
+		t.Cleanup(cl2)
+		p.client = c2
+		return nil
+	}
+	p.dialBackoffStart = 1 * time.Millisecond
+	p.maxDialBackoff = 5 * time.Millisecond
+
+	var result *semantic.EnrichResult
+	var enrichErr error
+	done := make(chan struct{})
+	go func() {
+		result, enrichErr = p.Enrich(g, repoRoot)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("Enrich timed out")
+	}
+
+	require.NoError(t, enrichErr)
+	require.GreaterOrEqual(t, int(reconnects.Load()), 1, "the dead server must have forced a reconnect")
+	require.NotNil(t, result)
+	assert.Equal(t, 1, result.NodesEnriched, "the retried hover's result must be recorded, not discarded")
+
+	node := g.GetNode("main.go::F0")
+	require.NotNil(t, node)
+	require.NotNil(t, node.Meta)
+	assert.Equal(t, "func F0() string", node.Meta["semantic_type"],
+		"the node must carry the type from the retried hover")
 }
 
 // TestLSP_Enrich_SingleReconnectUnderConcurrency verifies that when many

--- a/internal/semantic/lsp/enrich_hardening_test.go
+++ b/internal/semantic/lsp/enrich_hardening_test.go
@@ -243,6 +243,7 @@ func runEnrich(t *testing.T, p *Provider, g graph.Store, repoRoot string, timeou
 // ---------------------------------------------------------------------------
 
 func TestLSP_Enrich_ConcurrencyBounded(t *testing.T) {
+	t.Setenv("GORTEX_LSP_SWEEP", "full") // exercise the full per-file sweep, not the demand-gated default
 	repoRoot, g := seedRepo(t, 50)
 
 	var inFlight atomic.Int64
@@ -278,6 +279,7 @@ func TestLSP_Enrich_ConcurrencyBounded(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestLSP_Enrich_DocLifecyclePairedAndBounded(t *testing.T) {
+	t.Setenv("GORTEX_LSP_SWEEP", "full") // exercise the full per-file sweep, not the demand-gated default
 	repoRoot := t.TempDir()
 	// Many distinct files so each node opens its own document.
 	g := graph.New()
@@ -327,6 +329,7 @@ func TestLSP_Enrich_DocLifecyclePairedAndBounded(t *testing.T) {
 
 // didClose must happen even when hover fails.
 func TestLSP_Enrich_DocClosedEvenOnHoverError(t *testing.T) {
+	t.Setenv("GORTEX_LSP_SWEEP", "full") // exercise the full per-file sweep, not the demand-gated default
 	repoRoot := t.TempDir()
 	g := graph.New()
 	const nFiles = 8
@@ -373,6 +376,7 @@ func TestLSP_Enrich_DocClosedEvenOnHoverError(t *testing.T) {
 // "LSP server exited" error, then verifies the provider reconnects (via the
 // connectOnce seam) and the enrichment completes without error.
 func TestLSP_Enrich_ReconnectsOnServerExit(t *testing.T) {
+	t.Setenv("GORTEX_LSP_SWEEP", "full") // exercise the full per-file sweep, not the demand-gated default
 	repoRoot, g := seedRepo(t, 12)
 
 	// First server: after the 3rd hover, it "dies" (we close its client's
@@ -508,6 +512,7 @@ func TestLSP_Enrich_UsesRetriedHoverResult(t *testing.T) {
 // goroutines observe server-exit simultaneously, only ONE reconnection is
 // performed (others wait and retry).
 func TestLSP_Enrich_SingleReconnectUnderConcurrency(t *testing.T) {
+	t.Setenv("GORTEX_LSP_SWEEP", "full") // exercise the full per-file sweep, not the demand-gated default
 	repoRoot, g := seedRepo(t, 40)
 
 	server1 := newInstrumentedServer()
@@ -559,6 +564,7 @@ func TestLSP_Enrich_SingleReconnectUnderConcurrency(t *testing.T) {
 // TestLSP_Enrich_AbortsWhenReconnectFails verifies that a permanently-dead
 // server causes Enrich to return an error after exhausting retries.
 func TestLSP_Enrich_AbortsWhenReconnectFails(t *testing.T) {
+	t.Setenv("GORTEX_LSP_SWEEP", "full") // exercise the full per-file sweep, not the demand-gated default
 	repoRoot, g := seedRepo(t, 6)
 
 	server1 := newInstrumentedServer()
@@ -598,7 +604,8 @@ func TestLSP_Enrich_AbortsWhenReconnectFails(t *testing.T) {
 // of the dead session's opens) rather than hovered against an assumed-open
 // doc. The new server must therefore receive a paired didOpen/didClose.
 func TestLSP_Enrich_ReopensDocsOnNewServerAfterReconnect(t *testing.T) {
-	repoRoot, g := seedRepo(t, 8) // 8 nodes, all in main.go
+	t.Setenv("GORTEX_LSP_SWEEP", "full") // exercise the full per-file sweep, not the demand-gated default
+	repoRoot, g := seedRepo(t, 8)        // 8 nodes, all in main.go
 
 	server1 := newInstrumentedServer()
 	p, cleanup := providerWithInstrumentedServer(t, server1, []string{"go"}, 8)

--- a/internal/semantic/lsp/enrich_incoming_test.go
+++ b/internal/semantic/lsp/enrich_incoming_test.go
@@ -1,0 +1,225 @@
+package lsp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestEnrichCallableIsDispatchRelevant(t *testing.T) {
+	// A concrete method whose declaring type implements an interface: the
+	// call to it may dispatch through the interface, so only its incoming
+	// side names the concrete callers.
+	implMethod := func() (graph.Store, *graph.Node) {
+		g := graph.New()
+		m := &graph.Node{ID: "s.go::Circle.Area", Kind: graph.KindMethod, Name: "Area"}
+		g.AddNode(m)
+		g.AddNode(&graph.Node{ID: "s.go::Circle", Kind: graph.KindType, Name: "Circle"})
+		g.AddNode(&graph.Node{ID: "s.go::Shape", Kind: graph.KindInterface, Name: "Shape"})
+		g.AddEdge(&graph.Edge{From: m.ID, To: "s.go::Circle", Kind: graph.EdgeMemberOf})
+		g.AddEdge(&graph.Edge{From: "s.go::Circle", To: "s.go::Shape", Kind: graph.EdgeImplements})
+		return g, m
+	}
+	// A method whose declaring type extends a base type.
+	extendMethod := func() (graph.Store, *graph.Node) {
+		g := graph.New()
+		m := &graph.Node{ID: "s.go::Dog.Speak", Kind: graph.KindMethod, Name: "Speak"}
+		g.AddNode(m)
+		g.AddNode(&graph.Node{ID: "s.go::Dog", Kind: graph.KindType, Name: "Dog"})
+		g.AddNode(&graph.Node{ID: "s.go::Animal", Kind: graph.KindType, Name: "Animal"})
+		g.AddEdge(&graph.Edge{From: m.ID, To: "s.go::Dog", Kind: graph.EdgeMemberOf})
+		g.AddEdge(&graph.Edge{From: "s.go::Dog", To: "s.go::Animal", Kind: graph.EdgeExtends})
+		return g, m
+	}
+	// A method carrying an explicit overrides edge.
+	overrideMethod := func() (graph.Store, *graph.Node) {
+		g := graph.New()
+		m := &graph.Node{ID: "s.go::Impl.Do", Kind: graph.KindMethod, Name: "Do"}
+		g.AddNode(m)
+		g.AddEdge(&graph.Edge{From: m.ID, To: "s.go::Base.Do", Kind: graph.EdgeOverrides})
+		return g, m
+	}
+	// A plain method on a type that neither implements nor extends anything.
+	plainMethod := func() (graph.Store, *graph.Node) {
+		g := graph.New()
+		m := &graph.Node{ID: "s.go::Box.Size", Kind: graph.KindMethod, Name: "Size"}
+		g.AddNode(m)
+		g.AddNode(&graph.Node{ID: "s.go::Box", Kind: graph.KindType, Name: "Box"})
+		g.AddEdge(&graph.Edge{From: m.ID, To: "s.go::Box", Kind: graph.EdgeMemberOf})
+		return g, m
+	}
+	// An abstract-marked method (e.g. an interface member) with no edges.
+	abstractMethod := func() (graph.Store, *graph.Node) {
+		g := graph.New()
+		m := &graph.Node{ID: "s.go::Shape.Area", Kind: graph.KindMethod, Name: "Area",
+			Meta: map[string]any{"iface_member": true}}
+		g.AddNode(m)
+		return g, m
+	}
+	// A plain free function with only unresolved-call demand — demand is a
+	// separate signal; dispatch-relevance alone must not fire for it.
+	demandFunc := func() (graph.Store, *graph.Node) {
+		g := graph.New()
+		f := &graph.Node{ID: "s.go::Free", Kind: graph.KindFunction, Name: "Free"}
+		g.AddNode(f)
+		g.AddEdge(&graph.Edge{From: "s.go::caller", To: graph.UnresolvedMarker + "*.Free", Kind: graph.EdgeCalls})
+		return g, f
+	}
+	// A type node is never a call-hierarchy subject.
+	typeNode := func() (graph.Store, *graph.Node) {
+		g := graph.New()
+		n := &graph.Node{ID: "s.go::Circle", Kind: graph.KindType, Name: "Circle"}
+		g.AddNode(n)
+		return g, n
+	}
+
+	cases := []struct {
+		name  string
+		build func() (graph.Store, *graph.Node)
+		want  bool
+	}{
+		{"nil", func() (graph.Store, *graph.Node) { return graph.New(), nil }, false},
+		{"impl method via type implements", implMethod, true},
+		{"method via type extends", extendMethod, true},
+		{"method with overrides edge", overrideMethod, true},
+		{"abstract-marked method", abstractMethod, true},
+		{"plain method on plain type", plainMethod, false},
+		{"function with demand only", demandFunc, false},
+		{"type node", typeNode, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g, n := tc.build()
+			assert.Equal(t, tc.want, enrichCallableIsDispatchRelevant(g, n))
+		})
+	}
+}
+
+// callHierarchyCounters registers prepare / outgoing / incoming handlers that
+// count invocations, so a test can assert exactly which call-hierarchy round
+// trips the sweep made. prepareCallHierarchy returns a single item pointing at
+// the queried position; outgoing / incoming return empty result sets.
+func callHierarchyCounters(server *fakeLSPServer, repoRoot string) (prepare, outgoing, incoming *atomic.Int64) {
+	prepare, outgoing, incoming = &atomic.Int64{}, &atomic.Int64{}, &atomic.Int64{}
+	server.handle("textDocument/hover", func(json.RawMessage) (any, *jsonRPCError) { return nil, nil })
+	server.handle("textDocument/prepareCallHierarchy", func(json.RawMessage) (any, *jsonRPCError) {
+		prepare.Add(1)
+		return []CallHierarchyItem{{
+			Name:           "target",
+			URI:            pathToURI(filepath.Join(repoRoot, "svc.go")),
+			SelectionRange: Range{Start: Position{Line: 0, Character: 0}, End: Position{Line: 0, Character: 1}},
+		}}, nil
+	})
+	server.handle("callHierarchy/outgoingCalls", func(json.RawMessage) (any, *jsonRPCError) {
+		outgoing.Add(1)
+		return []CallHierarchyOutgoingCall{}, nil
+	})
+	server.handle("callHierarchy/incomingCalls", func(json.RawMessage) (any, *jsonRPCError) {
+		incoming.Add(1)
+		return []CallHierarchyIncomingCall{}, nil
+	})
+	return prepare, outgoing, incoming
+}
+
+// Under the demand default the sweep interrogates a plain static function for
+// its outgoing calls but skips its incoming calls: every intra-repo static
+// call to it is already recoverable from its caller's outgoing hop, so the
+// incoming round trip buys no edge.
+func TestLSP_Enrich_IncomingSkippedForPlainStaticFunction(t *testing.T) {
+	t.Setenv(SweepEnv, "") // demand default
+
+	repoRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "svc.go"),
+		[]byte("package p\n\ntype Marker struct{}\n\nfunc Plain() {}\n"), 0o644))
+
+	server := newFakeLSPServer()
+	prepare, outgoing, incoming := callHierarchyCounters(server, repoRoot)
+
+	p, cleanup := providerWithFakeServer(t, server, []string{"go"})
+	defer cleanup()
+
+	g := graph.New()
+	// A type keeps the file in the demand-gated sweep (dispatch-relevant),
+	// isolating the incoming decision from the file-level sweep gate.
+	g.AddNode(&graph.Node{ID: "svc.go::Marker", Kind: graph.KindType, Name: "Marker",
+		FilePath: "svc.go", StartLine: 3, EndLine: 3, Language: "go"})
+	g.AddNode(&graph.Node{ID: "svc.go::Plain", Kind: graph.KindFunction, Name: "Plain",
+		FilePath: "svc.go", StartLine: 5, EndLine: 5, Language: "go"})
+
+	require.NoError(t, runEnrich(t, p, g, repoRoot, 3*time.Second))
+
+	assert.Positive(t, prepare.Load(), "the swept function must still be prepared for call hierarchy")
+	assert.Positive(t, outgoing.Load(), "outgoing calls are always fetched")
+	assert.Zero(t, incoming.Load(), "a plain static function's incoming calls must be skipped under the demand default")
+	assert.Positive(t, p.reqStats.incomingSkipped.Load(), "the skipped incoming round trip must be counted")
+}
+
+// An interface-implementing method is a dynamic-dispatch target: a call to it
+// may bind to the interface method, so only its incoming side names the
+// concrete callers. Both outgoing and incoming are fetched even under the
+// demand default.
+func TestLSP_Enrich_IncomingFetchedForDispatchMethod(t *testing.T) {
+	t.Setenv(SweepEnv, "") // demand default
+
+	repoRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "svc.go"),
+		[]byte("package p\n\ntype Shape interface{ Area() float64 }\n\ntype Circle struct{}\n\nfunc (c Circle) Area() float64 { return 0 }\n"), 0o644))
+
+	server := newFakeLSPServer()
+	prepare, outgoing, incoming := callHierarchyCounters(server, repoRoot)
+
+	p, cleanup := providerWithFakeServer(t, server, []string{"go"})
+	defer cleanup()
+
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "svc.go::Shape", Kind: graph.KindInterface, Name: "Shape",
+		FilePath: "svc.go", StartLine: 3, EndLine: 3, Language: "go"})
+	g.AddNode(&graph.Node{ID: "svc.go::Circle", Kind: graph.KindType, Name: "Circle",
+		FilePath: "svc.go", StartLine: 5, EndLine: 5, Language: "go"})
+	g.AddNode(&graph.Node{ID: "svc.go::Circle.Area", Kind: graph.KindMethod, Name: "Area",
+		FilePath: "svc.go", StartLine: 7, EndLine: 7, Language: "go"})
+	g.AddEdge(&graph.Edge{From: "svc.go::Circle.Area", To: "svc.go::Circle", Kind: graph.EdgeMemberOf})
+	g.AddEdge(&graph.Edge{From: "svc.go::Circle", To: "svc.go::Shape", Kind: graph.EdgeImplements})
+
+	require.NoError(t, runEnrich(t, p, g, repoRoot, 3*time.Second))
+
+	assert.Positive(t, prepare.Load())
+	assert.Positive(t, outgoing.Load(), "outgoing calls are always fetched")
+	assert.Positive(t, incoming.Load(), "a dispatch-relevant method must have its incoming callers fetched")
+	assert.Zero(t, p.reqStats.incomingSkipped.Load(), "no incoming round trip is skipped for a dispatch-relevant method")
+}
+
+// A full sweep fetches incoming calls unconditionally, even for a plain static
+// function the demand default would skip.
+func TestLSP_Enrich_IncomingFetchedInFullMode(t *testing.T) {
+	t.Setenv(SweepEnv, "full")
+
+	repoRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "svc.go"),
+		[]byte("package p\n\nfunc Plain() {}\n"), 0o644))
+
+	server := newFakeLSPServer()
+	prepare, outgoing, incoming := callHierarchyCounters(server, repoRoot)
+
+	p, cleanup := providerWithFakeServer(t, server, []string{"go"})
+	defer cleanup()
+
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "svc.go::Plain", Kind: graph.KindFunction, Name: "Plain",
+		FilePath: "svc.go", StartLine: 3, EndLine: 3, Language: "go"})
+
+	require.NoError(t, runEnrich(t, p, g, repoRoot, 3*time.Second))
+
+	assert.Positive(t, prepare.Load())
+	assert.Positive(t, outgoing.Load())
+	assert.Positive(t, incoming.Load(), "full mode must fetch incoming calls even for a plain function")
+	assert.Zero(t, p.reqStats.incomingSkipped.Load(), "full mode skips no incoming round trip")
+}

--- a/internal/semantic/lsp/enrich_partial_test.go
+++ b/internal/semantic/lsp/enrich_partial_test.go
@@ -42,6 +42,7 @@ func providerWithFakeServerParallel(t *testing.T, server *fakeLSPServer, languag
 // back Partial with no error. This is the regression test for the
 // deadline path that used to discard a fully-buffered pass wholesale.
 func TestLSP_Provider_PartialLandingOnCanceledContext(t *testing.T) {
+	t.Setenv("GORTEX_LSP_SWEEP", "full") // exercise the full per-file sweep, not the demand-gated default
 	repoRoot := t.TempDir()
 	require.NoError(t, os.WriteFile(
 		filepath.Join(repoRoot, "main.go"),
@@ -179,6 +180,7 @@ func TestLSP_Provider_PartialLandingOnCanceledContext(t *testing.T) {
 // rejects per request ("cannot unmarshal number -1 into ...
 // position.line of type uint32") — pure wasted round trips.
 func TestLSP_Provider_SkipsNodesWithoutPosition(t *testing.T) {
+	t.Setenv("GORTEX_LSP_SWEEP", "full") // exercise the full per-file sweep, not the demand-gated default
 	repoRoot := t.TempDir()
 	require.NoError(t, os.WriteFile(
 		filepath.Join(repoRoot, "main.go"),

--- a/internal/semantic/lsp/hierarchy_test.go
+++ b/internal/semantic/lsp/hierarchy_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestLSP_Provider_PromotesCallEdgeViaCallHierarchy(t *testing.T) {
+	t.Setenv("GORTEX_LSP_SWEEP", "full") // exercise the full per-file sweep, not the demand-gated default
 	repoRoot := t.TempDir()
 	require.NoError(t, os.WriteFile(
 		filepath.Join(repoRoot, "main.go"),
@@ -87,6 +88,7 @@ func TestLSP_Provider_PromotesCallEdgeViaCallHierarchy(t *testing.T) {
 }
 
 func TestLSP_Provider_AddsImplementsViaTypeHierarchy(t *testing.T) {
+	t.Setenv("GORTEX_LSP_SWEEP", "full") // exercise the full per-file sweep, not the demand-gated default
 	repoRoot := t.TempDir()
 	require.NoError(t, os.WriteFile(
 		filepath.Join(repoRoot, "shape.ts"),
@@ -155,6 +157,7 @@ func TestLSP_Provider_AddsImplementsViaTypeHierarchy(t *testing.T) {
 }
 
 func TestLSP_Provider_AddsExtendsViaTypeHierarchySupertypes(t *testing.T) {
+	t.Setenv("GORTEX_LSP_SWEEP", "full") // exercise the full per-file sweep, not the demand-gated default
 	repoRoot := t.TempDir()
 	require.NoError(t, os.WriteFile(
 		filepath.Join(repoRoot, "h.ts"),
@@ -223,6 +226,7 @@ func TestLSP_Provider_AddsExtendsViaTypeHierarchySupertypes(t *testing.T) {
 }
 
 func TestLSP_Provider_AddsMissingCallEdgeViaCallHierarchy(t *testing.T) {
+	t.Setenv("GORTEX_LSP_SWEEP", "full") // exercise the full per-file sweep, not the demand-gated default
 	repoRoot := t.TempDir()
 	require.NoError(t, os.WriteFile(
 		filepath.Join(repoRoot, "main.go"),
@@ -292,6 +296,7 @@ func TestLSP_Provider_AddsMissingCallEdgeViaCallHierarchy(t *testing.T) {
 // line — and (b) be stamped at the call-expression line the server
 // reported in fromRanges, not at the caller's declaration line.
 func TestLSP_Provider_IncomingCallStampsCallSiteNotDeclaration(t *testing.T) {
+	t.Setenv("GORTEX_LSP_SWEEP", "full") // exercise the full per-file sweep, not the demand-gated default
 	repoRoot := t.TempDir()
 	require.NoError(t, os.WriteFile(
 		filepath.Join(repoRoot, "q.go"),
@@ -386,6 +391,7 @@ func TestLSP_Provider_IncomingCallStampsCallSiteNotDeclaration(t *testing.T) {
 // method node — not `<callee>#param:<name>` — and the added edge must be
 // stamped at the call site inside the caller.
 func TestLSP_Provider_OutgoingCallMatchesCallableAndStampsCallSite(t *testing.T) {
+	t.Setenv("GORTEX_LSP_SWEEP", "full") // exercise the full per-file sweep, not the demand-gated default
 	repoRoot := t.TempDir()
 	require.NoError(t, os.WriteFile(
 		filepath.Join(repoRoot, "m.go"),
@@ -520,6 +526,7 @@ func TestIdentifierIndex(t *testing.T) {
 // precision filter then suppressed — silently costing recall on repeated
 // calls within one function.
 func TestLSP_Provider_PromotesEveryVerifiedCallSite(t *testing.T) {
+	t.Setenv("GORTEX_LSP_SWEEP", "full") // exercise the full per-file sweep, not the demand-gated default
 	repoRoot := t.TempDir()
 	require.NoError(t, os.WriteFile(
 		filepath.Join(repoRoot, "q.go"),

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -156,6 +156,10 @@ type requestStats struct {
 	prepareTypeHierarchy atomic.Int64
 	supertypes           atomic.Int64
 	subtypes             atomic.Int64
+	// incomingSkipped counts the callHierarchy/incomingCalls round trips the
+	// sweep declined to make because the declaration's callers are already
+	// recoverable from the outgoing side — a derived saving, not a request.
+	incomingSkipped atomic.Int64
 }
 
 // reset zeroes every counter at the start of an enrichment pass.
@@ -170,6 +174,7 @@ func (r *requestStats) reset() {
 	r.prepareTypeHierarchy.Store(0)
 	r.supertypes.Store(0)
 	r.subtypes.Store(0)
+	r.incomingSkipped.Store(0)
 }
 
 // Dial-retry constants for passive-attach reconnect. The window
@@ -326,6 +331,57 @@ func enrichNodeIsDispatchRelevant(n *graph.Node) bool {
 		return false
 	}
 	return n.Kind == graph.KindType || n.Kind == graph.KindInterface
+}
+
+// enrichCallableIsDispatchRelevant reports whether a function or method takes
+// part in dynamic dispatch, so its incoming callers name concrete targets the
+// outgoing side of the sweep cannot reach. Every intra-repo static call is
+// recoverable from its caller's outgoing hop — collected for every caller by
+// the file sweep — so a declaration's incoming callers only add signal when a
+// call to it dispatches through another declaration: a call through an
+// interface / abstract member lands the caller's outgoing edge on that member,
+// leaving the concrete implementation's real call sites visible only from its
+// incoming side. A declaration qualifies when it is itself an abstract /
+// interface / virtual member, when it overrides (or is overridden by) another
+// declaration, or when its declaring type implements or extends another type.
+func enrichCallableIsDispatchRelevant(g graph.Store, n *graph.Node) bool {
+	if n == nil || (n.Kind != graph.KindFunction && n.Kind != graph.KindMethod) {
+		return false
+	}
+	if isAbstractMarked(n) {
+		return true
+	}
+	var parentType string
+	for _, e := range g.GetOutEdges(n.ID) {
+		switch e.Kind {
+		case graph.EdgeOverrides:
+			return true
+		case graph.EdgeMemberOf:
+			parentType = e.To
+		}
+	}
+	for _, e := range g.GetInEdges(n.ID) {
+		if e.Kind == graph.EdgeOverrides {
+			return true
+		}
+	}
+	if parentType == "" {
+		return false
+	}
+	// The declaring type implementing / extending another type makes its
+	// methods dispatch targets: a call through the interface or base type
+	// binds elsewhere, so this method's callers surface only via incoming.
+	for _, e := range g.GetOutEdges(parentType) {
+		if e.Kind == graph.EdgeImplements || e.Kind == graph.EdgeExtends {
+			return true
+		}
+	}
+	for _, e := range g.GetInEdges(parentType) {
+		if e.Kind == graph.EdgeImplements || e.Kind == graph.EdgeExtends {
+			return true
+		}
+	}
+	return false
 }
 
 // nodeHasSemanticType reports whether a node already carries a non-empty
@@ -1149,11 +1205,28 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 						if err != nil {
 							continue
 						}
+						// Outgoing always: the file sweep visits every caller,
+						// so a declaration's outgoing hops alone reconstruct
+						// every intra-repo static call edge. Incoming only adds
+						// what the outgoing side is blind to — the concrete
+						// callers of a dynamic-dispatch target, and names the
+						// resolver still could not bind — so it is fetched only
+						// for a dispatch-relevant or demand-bearing declaration
+						// (or under a full sweep). Demand-first file ordering
+						// sweeps the demand-bearing callers before any deadline
+						// cut, so a skipped incoming costs no reachable edge.
+						wantIncoming := sweepMode == sweepModeFull ||
+							enrichCallableIsDispatchRelevant(g, n) ||
+							enrichNodeHasUnresolvedDemand(g, n)
 						for _, item := range items {
 							if outs, oerr := p.outgoingCalls(item); oerr == nil {
 								for _, oc := range outs {
 									cHops = append(cHops, callHop{n: n, other: oc.To, asOutgoing: true, fromRanges: oc.FromRanges})
 								}
+							}
+							if !wantIncoming {
+								p.reqStats.incomingSkipped.Add(1)
+								continue
 							}
 							if ins, ierr := p.incomingCalls(item); ierr == nil {
 								for _, ic := range ins {
@@ -1329,6 +1402,7 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 		zap.Int64("req_prepare_call_hierarchy", p.reqStats.prepareCallHierarchy.Load()),
 		zap.Int64("req_outgoing_calls", p.reqStats.outgoingCalls.Load()),
 		zap.Int64("req_incoming_calls", p.reqStats.incomingCalls.Load()),
+		zap.Int64("incoming_calls_skipped", p.reqStats.incomingSkipped.Load()),
 		zap.Int64("req_prepare_type_hierarchy", p.reqStats.prepareTypeHierarchy.Load()),
 		zap.Int64("req_supertypes", p.reqStats.supertypes.Load()),
 		zap.Int64("req_subtypes", p.reqStats.subtypes.Load()),

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -628,6 +628,27 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 		return result, nil
 	}
 
+	// Compile-database preflight: a server that needs a compilation database
+	// (clangd) but has none rebuilds a full fallback AST on every didOpen, so
+	// the hover / hierarchy sweep churns for little signal and a directly
+	// opened header becomes a standalone TU. Degrade to reference confirmation
+	// — the confirm / rebind passes work inside the fallback TU on fallback
+	// flags — and skip the sweep, the interface pass, and header files.
+	degraded := p.spec != nil && p.spec.NeedsCompileDB && !hasCompileDB(absRoot)
+	var degradedSkipFile func(rel string) bool
+	if degraded {
+		degradedSkipFile = isCXXHeaderFile
+		result.Degraded = true
+		result.DegradedReason = "no compilation database found; enrichment limited to reference confirmation (hover, hierarchy, and header translation units skipped)"
+		if p.logger != nil {
+			p.logger.Warn("LSP enrich: degrading to reference confirmation, compilation database missing",
+				zap.String("provider", p.Name()),
+				zap.String("repo_prefix", repoPrefix),
+				zap.String("remediation", "generate compile_commands.json (cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON, bear -- make, or meson), then re-index"),
+			)
+		}
+	}
+
 	// Start or reuse the client now that there is work to do.
 	if err := p.ensureClient(absRoot); err != nil {
 		return nil, fmt.Errorf("start LSP server: %w", err)
@@ -674,8 +695,10 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 	// targetedCtx caps the targeted-edge passes (implementations + confirm) at
 	// a fraction of the window, reserving the remainder for the sweep so both
 	// phases make progress. With no deadline (tests) it is the parent context.
+	// A degraded pass skips the sweep entirely, so there is nothing to reserve
+	// for — give the confirm pass the whole window.
 	targetedCtx := ctx
-	if dl, ok := ctx.Deadline(); ok {
+	if dl, ok := ctx.Deadline(); ok && !degraded {
 		window := dl.Sub(start)
 		reserve := time.Duration(float64(window) * enrichSweepReserveFraction)
 		if reserve > 0 && reserve < window {
@@ -685,8 +708,13 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 		}
 	}
 
-	// Query implementations for interface nodes.
+	// Query implementations for interface nodes. A degraded pass skips this:
+	// the query opens each interface's file, and a database-less clangd cannot
+	// resolve implementations across translation units regardless.
 	for _, n := range langNodes {
+		if degraded {
+			break
+		}
 		if targetedCtx.Err() != nil {
 			break
 		}
@@ -761,7 +789,7 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 	// fallback opens arbitrary call-site files, so it runs serially afterward
 	// over the targets the sweep left unconfirmed, keeping document open/close
 	// from overlapping across goroutines.
-	confirmGroups := p.groupConfirmTargets(g, targets)
+	confirmGroups := p.groupConfirmTargets(g, targets, degradedSkipFile)
 	var confirmMu sync.Mutex
 	var fallback []enrichTarget
 	{
@@ -874,6 +902,9 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 		if !p.servesFile(siteRel) {
 			continue // never open a call-site file this server can't compile
 		}
+		if degradedSkipFile != nil && degradedSkipFile(siteRel) {
+			continue // degraded mode: never open this call-site (e.g. a header)
+		}
 		// Hold one open document per run of same-file sites: acquire on the
 		// first site of a file, release when the file changes (and once more
 		// after the loop). A failed acquire yields nil content, which
@@ -917,6 +948,38 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 		}
 	}
 	releaseSite()
+
+	// Degraded finalisation: the interface pass, the references-add pass, and
+	// the per-file hover / hierarchy sweep are all skipped when a needed
+	// compilation database is missing — only the reference-confirm and
+	// definition-rebind passes ran, working inside the fallback translation
+	// unit. Finalise the result here, before the sweep machinery below.
+	if degraded {
+		if result.SymbolsTotal > 0 {
+			result.CoveragePercent = float64(result.SymbolsCovered) / float64(result.SymbolsTotal) * 100
+		}
+		result.DurationMs = time.Since(start).Milliseconds()
+		if ctx.Err() != nil {
+			result.Partial = true
+			result.AbortReason = ctx.Err().Error()
+		}
+		if p.logger != nil {
+			didOpens, reopenedFiles, docEvictions, peakOpenDocs := session.stats()
+			p.logger.Info("LSP enrich: degraded pass complete (reference confirmation only)",
+				zap.String("provider", p.Name()),
+				zap.String("repo_prefix", repoPrefix),
+				zap.Bool("degraded", true),
+				zap.Int("edges_confirmed", result.EdgesConfirmed),
+				zap.Int("did_opens", didOpens),
+				zap.Int("reopened_files", reopenedFiles),
+				zap.Int("doc_evictions", docEvictions),
+				zap.Int("peak_open_docs", peakOpenDocs),
+				zap.Int64("req_references", p.reqStats.references.Load()),
+				zap.Int64("req_definitions", p.reqStats.definitions.Load()),
+			)
+		}
+		return result, nil
+	}
 
 	// References-driven add pass: a server that enumerates references but has
 	// no call hierarchy (e.g. intelephense) never runs the per-file sweep's

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -39,6 +39,11 @@ type Provider struct {
 	// top of the built-in generated/vendored heuristic. Set by the router from
 	// config when the provider is spawned.
 	excludeGlobs []string
+	// sweepMode selects how much of the per-file hover / call-hierarchy sweep
+	// runs ("demand" default / "full" / "off"); see sweep.go. Set by the
+	// router from config when the provider is spawned. An empty value means
+	// the demand-gated default; the GORTEX_LSP_SWEEP env override wins over it.
+	sweepMode string
 	// spec is the ServerSpec this provider was built from (when the
 	// caller used NewProviderFromSpec). nil for legacy NewProvider
 	// invocations — those fall back to single-language routing.
@@ -306,6 +311,35 @@ func enrichNodeHasUnresolvedDemand(g graph.Store, n *graph.Node) bool {
 		return false
 	}
 	return len(g.GetInEdges(graph.UnresolvedMarker+"*."+n.Name)) > 0
+}
+
+// enrichNodeIsDispatchRelevant reports whether a declaration's super/subtype
+// hierarchy the per-file sweep must interrogate: a type or interface whose
+// extends / supertype / subtype edges the AST extractor commonly misses (they
+// are cross-file or resolved dynamically). Such declarations never contribute
+// unresolved-call demand — enrichNodeHasUnresolvedDemand only counts callables —
+// so a file whose only enrichable work is a type hierarchy would score zero
+// demand and be skipped under the demand default. Marking it dispatch-relevant
+// keeps that file in the sweep so its hierarchy edges are still recovered.
+func enrichNodeIsDispatchRelevant(n *graph.Node) bool {
+	if n == nil {
+		return false
+	}
+	return n.Kind == graph.KindType || n.Kind == graph.KindInterface
+}
+
+// nodeHasSemanticType reports whether a node already carries a non-empty
+// semantic_type stamp from an earlier enrichment. The per-file sweep skips
+// re-hovering such a node — the hover would only re-derive the identical type
+// string — which is what keeps a dispatch-relevant file (swept for its call /
+// type-hierarchy edges) from re-paying the whole-file hover cost on a warm
+// restart, where every node reloads with its prior stamp.
+func nodeHasSemanticType(n *graph.Node) bool {
+	if n == nil || n.Meta == nil {
+		return false
+	}
+	s, ok := n.Meta["semantic_type"].(string)
+	return ok && s != ""
 }
 
 // scopedPath re-attaches repoPrefix to a repo-relative path the language
@@ -857,7 +891,7 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 	enrichedNodes := make(map[string]bool)
 
 	// Race-safe metric counters for the concurrent hover phase.
-	var diagTotalNodes, diagHoverOK, diagHoverErr, diagHoverNil, diagTypeEmpty, diagEnriched, diagNoPosition atomic.Int64
+	var diagTotalNodes, diagHoverOK, diagHoverErr, diagHoverNil, diagTypeEmpty, diagEnriched, diagNoPosition, diagHoverSkipped atomic.Int64
 
 	// mu guards the cross-goroutine aggregation: per-file stamp buffers,
 	// enrichedNodes, the EnrichResult node counters, and the best-effort
@@ -931,9 +965,10 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 	// spans all of its symbols. Files keep encounter order; symbols keep
 	// their order within a file.
 	type fileTargets struct {
-		rel    string
-		nodes  []*graph.Node
-		demand int // declarations still carrying unresolved same-name candidates
+		rel      string
+		nodes    []*graph.Node
+		demand   int  // declarations still carrying unresolved same-name candidates
+		dispatch bool // carries a type / interface whose hierarchy the sweep interrogates
 	}
 	var fileList []*fileTargets
 	fileIndex := map[string]*fileTargets{}
@@ -952,6 +987,9 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 		if enrichNodeHasUnresolvedDemand(g, n) {
 			ft.demand++
 		}
+		if enrichNodeIsDispatchRelevant(n) {
+			ft.dispatch = true
+		}
 	}
 	// Demand-driven ordering: enrich the files whose declarations still carry
 	// unresolved same-name call candidates first. Under a per-repo deadline the
@@ -961,6 +999,17 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 	sort.SliceStable(fileList, func(i, j int) bool {
 		return fileList[i].demand > fileList[j].demand
 	})
+
+	// Sweep gate: the per-file hover / call-hierarchy sweep below is the
+	// whole-repo churn a warm restart pays to confirm zero new edges. The
+	// resolved mode (GORTEX_LSP_SWEEP env override > router-configured field
+	// > demand-gated default) decides which files it visits — sweepFile
+	// skips a file the mode excludes. "demand" (default) sweeps a file that
+	// still carries unresolved same-name candidates OR declares a type /
+	// interface whose super/subtype hierarchy only this sweep recovers,
+	// "full" sweeps every file, "off" skips the sweep entirely. The
+	// tier-deciding confirm / add / interface passes above are never gated.
+	sweepMode := p.effectiveSweepMode()
 
 	// Call- and type-hierarchy hops are collected per file (while the
 	// file is open) and applied in that file's flush below, so each
@@ -1031,6 +1080,9 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 	for _, ft := range fileList {
 		if aborted.Load() || ctx.Err() != nil {
 			break
+		}
+		if !sweepFile(sweepMode, ft.demand, ft.dispatch) {
+			continue // mode excludes this file from the per-file sweep
 		}
 		wg.Add(1)
 		fileSem <- struct{}{} // acquire — bounds simultaneously-open docs
@@ -1137,6 +1189,16 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 			for _, n := range ft.nodes {
 				if aborted.Load() || ctx.Err() != nil {
 					break
+				}
+				// Hover-skip: a node already carrying a semantic_type stamp
+				// (e.g. reloaded on a warm restart) gains nothing from another
+				// hover — the derived type string is unchanged. Skip it so a
+				// file swept for its call / type-hierarchy edges does not
+				// re-pay the whole-file hover cost; the hierarchy interrogation
+				// above already ran for every node regardless.
+				if nodeHasSemanticType(n) {
+					diagHoverSkipped.Add(1)
+					continue
 				}
 				line, ok := lspLine(n)
 				if !ok {
@@ -1246,6 +1308,7 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 	// per-method request volume that drove the pass.
 	didOpens, reopenedFiles, docEvictions, peakOpenDocs := session.stats()
 	p.logger.Info("LSP enrich: hover phase complete",
+		zap.String("sweep_mode", sweepMode),
 		zap.Int64("total_nodes", diagTotalNodes.Load()),
 		zap.Int64("hover_ok", diagHoverOK.Load()),
 		zap.Int64("hover_err", diagHoverErr.Load()),
@@ -1253,6 +1316,7 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 		zap.Int64("type_empty", diagTypeEmpty.Load()),
 		zap.Int64("enriched", diagEnriched.Load()),
 		zap.Int64("skipped_no_position", diagNoPosition.Load()),
+		zap.Int64("skipped_already_stamped", diagHoverSkipped.Load()),
 		zap.Int64("reconnect_attempts", p.reconnectAttempts.Load()),
 		zap.Int("did_opens", didOpens),
 		zap.Int("reopened_files", reopenedFiles),

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -130,6 +130,41 @@ type Provider struct {
 	// backoff). Defaults to ensureClient. Injected in tests to swap in an
 	// in-memory piped client instead of spawning a subprocess.
 	connectOnce func(absRoot string) error
+
+	// reqStats counts the LSP request methods issued during the current
+	// enrichment pass. Reset at pass start and surfaced in the end-of-pass
+	// telemetry so the round-trip volume per method is observable.
+	reqStats requestStats
+}
+
+// requestStats holds one atomic counter per LSP request method the
+// enrichment pass issues, so the pass-complete log can report where the
+// round trips went.
+type requestStats struct {
+	references           atomic.Int64
+	implementations      atomic.Int64
+	definitions          atomic.Int64
+	hovers               atomic.Int64
+	prepareCallHierarchy atomic.Int64
+	outgoingCalls        atomic.Int64
+	incomingCalls        atomic.Int64
+	prepareTypeHierarchy atomic.Int64
+	supertypes           atomic.Int64
+	subtypes             atomic.Int64
+}
+
+// reset zeroes every counter at the start of an enrichment pass.
+func (r *requestStats) reset() {
+	r.references.Store(0)
+	r.implementations.Store(0)
+	r.definitions.Store(0)
+	r.hovers.Store(0)
+	r.prepareCallHierarchy.Store(0)
+	r.outgoingCalls.Store(0)
+	r.incomingCalls.Store(0)
+	r.prepareTypeHierarchy.Store(0)
+	r.supertypes.Store(0)
+	r.subtypes.Store(0)
 }
 
 // Dial-retry constants for passive-attach reconnect. The window
@@ -188,17 +223,17 @@ func NewProviderFromSpec(spec *ServerSpec, logger *zap.Logger) *Provider {
 		maxParallel = 10
 	}
 	p := &Provider{
-		command:          cmd,
-		args:             args,
-		env:              spec.Env,
-		languages:        spec.Languages,
-		daemon:           spec.Daemon,
-		maxParallel:      maxParallel,
-		logger:           logger,
-		spec:             spec,
-		docVersions:      map[string]int{},
-		openDocs:         map[string]bool{},
-		lastDiag:         map[string][]Diagnostic{},
+		command:            cmd,
+		args:               args,
+		env:                spec.Env,
+		languages:          spec.Languages,
+		daemon:             spec.Daemon,
+		maxParallel:        maxParallel,
+		logger:             logger,
+		spec:               spec,
+		docVersions:        map[string]int{},
+		openDocs:           map[string]bool{},
+		lastDiag:           map[string][]Diagnostic{},
 		diagWaiters:        map[string][]chan []Diagnostic{},
 		dynamicCaps:        map[string]Registration{},
 		connect:            spec.Connect,
@@ -333,7 +368,12 @@ func edgeExistsAt(g graph.Store, from, to string, kind graph.EdgeKind, line int)
 //
 // cache memoises verdicts per (file, line, name) within one enrichment
 // pass; multiple ambiguous edges can share a call site.
-func (p *Provider) definitionNodeAtSite(g graph.Store, repoPrefix, absRoot, siteRel string, siteLine int, name string, cache map[string]*graph.Node) (*graph.Node, bool) {
+//
+// content is the site file's bytes, already opened on the server and read
+// from disk by the caller (via the shared document session). A nil content
+// yields a no-verdict, matching the pre-session behaviour when the site
+// file could not be opened.
+func (p *Provider) definitionNodeAtSite(g graph.Store, repoPrefix, absRoot, siteRel string, siteLine int, name string, content []byte, cache map[string]*graph.Node) (*graph.Node, bool) {
 	if siteRel == "" || siteLine <= 0 || name == "" {
 		return nil, false
 	}
@@ -341,12 +381,7 @@ func (p *Provider) definitionNodeAtSite(g graph.Store, repoPrefix, absRoot, site
 	if cached, ok := cache[key]; ok {
 		return cached, true
 	}
-	if err := p.openDocument(absRoot, siteRel); err != nil {
-		return nil, false
-	}
-	defer func() { _ = p.closeDocument(filepath.Join(absRoot, siteRel)) }()
-
-	col, found := identifierColumnStrict(p.getSource(absRoot, siteRel), siteLine, name)
+	col, found := identifierColumnStrict(content, siteLine, name)
 	if !found {
 		// The identifier is not on the recorded line — a definition
 		// request would return junk for whatever token sits there.
@@ -515,6 +550,16 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 	// Reset the cross-pass reconnect counter so the metrics log reflects
 	// only this Enrich invocation.
 	p.reconnectAttempts.Store(0)
+	// Reset the per-method request counters so the pass-complete log
+	// reports only this invocation's round trips.
+	p.reqStats.reset()
+
+	// One document session shared by every phase below: a file didOpen'd
+	// by the interface pass stays warm for the confirm pass and the sweep
+	// instead of being reopened, and every open is paired with a didClose
+	// (evicted under cap, or by closeAll here at pass end).
+	session := newDocSession(p)
+	defer session.closeAll()
 
 	// Total symbols scoped to repo + language — langNodes already excludes
 	// file / import nodes and is filtered to this provider's languages.
@@ -567,14 +612,16 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 		if !p.servesFile(rel) {
 			continue // never open a file this server can't compile
 		}
-		// Per-item doc lifecycle (no bulk pre-open): open this interface's
-		// file, query, close immediately so memory stays bounded.
-		if err := p.openDocument(absRoot, rel); err != nil {
+		// Open this interface's file through the shared session: the query
+		// runs while it is pinned, and release leaves it warm in the LRU so
+		// the confirm pass and sweep reuse it instead of reopening.
+		content, release, err := session.acquire(p.client, filepath.Join(absRoot, rel))
+		if err != nil {
 			continue
 		}
-		col := identifierColumn(p.getSource(absRoot, rel), n.StartLine, n.Name)
+		col := identifierColumn(content, n.StartLine, n.Name)
 		impls, err := p.findImplementations(absRoot, rel, line, col)
-		_ = p.closeDocument(filepath.Join(absRoot, rel))
+		release()
 		if err != nil || len(impls) == 0 {
 			continue
 		}
@@ -645,16 +692,14 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 					return
 				}
 				absPath := filepath.Join(absRoot, grp.rel)
-				content, err := os.ReadFile(absPath)
+				// The file is unique to this group, so no two goroutines open
+				// it; the session pins it for the group and leaves it warm for
+				// a later phase that shares the file.
+				content, release, err := session.acquire(p.client, absPath)
 				if err != nil {
 					return
 				}
-				// Per-goroutine didOpen against the shared client — the file
-				// is unique to this group, so no two goroutines open it.
-				if err := p.enrichOpenDoc(p.client, absPath, content); err != nil {
-					return
-				}
-				defer func() { _ = p.enrichCloseDoc(p.client, absPath) }()
+				defer release()
 				for _, t := range grp.targets {
 					if targetedCtx.Err() != nil {
 						return
@@ -703,7 +748,29 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 	// rebind the edge to the correct target instead of leaving a
 	// misattribution behind. Runs after the parallel sweep so arbitrary
 	// call-site document opens never overlap across goroutines.
+	//
+	// Sites are ordered by their call-site file so one session acquire
+	// serves every site in a file — a caller with many misbound sites in
+	// one file is opened once, not once per site. Stable so sites keep
+	// their relative order within a file.
+	sort.SliceStable(fallback, func(i, j int) bool {
+		return edgeSiteRelPath(fallback[i].edge, repoPrefix, nodeRelPath(fallback[i].node)) <
+			edgeSiteRelPath(fallback[j].edge, repoPrefix, nodeRelPath(fallback[j].node))
+	})
 	defSiteCache := map[string]*graph.Node{}
+	var (
+		curSiteRel string
+		curContent []byte
+		relSite    func()
+		siteOpen   bool
+	)
+	releaseSite := func() {
+		if siteOpen {
+			relSite()
+			siteOpen = false
+		}
+		curContent = nil
+	}
 	for _, t := range fallback {
 		if targetedCtx.Err() != nil {
 			break
@@ -717,8 +784,23 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 		if !p.servesFile(siteRel) {
 			continue // never open a call-site file this server can't compile
 		}
+		// Hold one open document per run of same-file sites: acquire on the
+		// first site of a file, release when the file changes (and once more
+		// after the loop). A failed acquire yields nil content, which
+		// definitionNodeAtSite treats as a no-verdict — the same outcome the
+		// per-site openDocument failure produced before.
+		if siteRel != curSiteRel {
+			releaseSite()
+			curSiteRel = siteRel
+			content, release, err := session.acquire(p.client, filepath.Join(absRoot, siteRel))
+			if err == nil {
+				curContent = content
+				relSite = release
+				siteOpen = true
+			}
+		}
 		siteLine := t.edge.Line
-		cand, ok := p.definitionNodeAtSite(g, repoPrefix, absRoot, siteRel, siteLine, toNode.Name, defSiteCache)
+		cand, ok := p.definitionNodeAtSite(g, repoPrefix, absRoot, siteRel, siteLine, toNode.Name, curContent, defSiteCache)
 		switch {
 		case !ok || cand == nil:
 			// No verdict — leave the edge at its heuristic tier so
@@ -744,6 +826,7 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 			result.EdgesConfirmed++
 		}
 	}
+	releaseSite()
 
 	// References-driven add pass: a server that enumerates references but has
 	// no call hierarchy (e.g. intelephense) never runs the per-file sweep's
@@ -752,7 +835,7 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 	// call edges. Runs under the targeted budget (before the hover sweep) so
 	// a deadline cut sheds hover work, not the recall-bearing add.
 	if p.Supports("textDocument/references") && !p.Supports("textDocument/prepareCallHierarchy") {
-		p.referencesAddPass(targetedCtx, g, repoPrefix, absRoot, langNodes, rmu, result)
+		p.referencesAddPass(targetedCtx, g, repoPrefix, absRoot, langNodes, rmu, session, result)
 	}
 
 	// Per-file document lifecycle + bounded concurrency. The original
@@ -961,53 +1044,22 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 			}
 
 			absPath := filepath.Join(absRoot, ft.rel)
-			content, err := os.ReadFile(absPath)
+
+			// Pin the file open on the active client through the shared
+			// session for the whole span of this file's hierarchy + hover
+			// work — exactly one didOpen per file on the happy path, and the
+			// content is read from disk once. The session dedupes per
+			// (client, path), so a hover goroutine that reconnects re-opens
+			// the file on the fresh client (once) without a second open on
+			// the client this pin holds; closeAll pairs every open with a
+			// didClose at pass end.
+			content, release, err := session.acquire(activeClient.Load(), absPath)
 			if err != nil {
-				p.logger.Debug("LSP enrich: read source failed",
-					zap.String("file", ft.rel), zap.Error(err))
-				return
-			}
-
-			// ensureOpen opens the file on client c at most once per client.
-			// Tracking per client makes reconnection strict: the fresh client
-			// from a mid-flight reconnect starts with an empty open-set, so the
-			// file is re-opened on the new session (once, under openStateMu)
-			// rather than hovered against a document the dead session held.
-			// Every client we opened on is closed exactly once when the file
-			// is done, so didOpen / didClose stay paired on every session.
-			var openStateMu sync.Mutex
-			openedClients := map[*Client]bool{}
-			ensureOpen := func(c *Client) error {
-				openStateMu.Lock()
-				defer openStateMu.Unlock()
-				if openedClients[c] {
-					return nil
-				}
-				if err := p.enrichOpenDoc(c, absPath, content); err != nil {
-					return err
-				}
-				openedClients[c] = true
-				return nil
-			}
-			defer func() {
-				openStateMu.Lock()
-				clients := make([]*Client, 0, len(openedClients))
-				for c := range openedClients {
-					clients = append(clients, c)
-				}
-				openStateMu.Unlock()
-				for _, c := range clients {
-					_ = p.enrichCloseDoc(c, absPath)
-				}
-			}()
-
-			// Open once up front so the file is held open for the whole hover
-			// fan-out below — exactly one didOpen per file on the happy path.
-			if err := ensureOpen(activeClient.Load()); err != nil {
 				p.logger.Debug("LSP enrich: didOpen failed",
 					zap.String("file", ft.rel), zap.Error(err))
 				return
 			}
+			defer release()
 
 			// Per-file result buffers, flushed into the graph when this
 			// file finishes (or is cut mid-file by cancellation) —
@@ -1106,11 +1158,17 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 					}
 
 					c := activeClient.Load()
-					if err := ensureOpen(c); err != nil {
+					// Ensure the doc is open on this goroutine's client. On
+					// the happy path this dedupes against the file goroutine's
+					// pin (no didOpen); when the active client was swapped by a
+					// concurrent reconnect it opens the file on the new client.
+					_, releaseHover, err := session.acquire(c, absPath)
+					if err != nil {
 						p.logger.Debug("LSP enrich: didOpen failed",
 							zap.String("file", n.FilePath), zap.Error(err))
 						return
 					}
+					defer releaseHover()
 
 					col := identifierColumn(content, n.StartLine, n.Name)
 					hoverResult, err := p.hoverWith(c, absRoot, nodeRelPath(n), line, col)
@@ -1118,18 +1176,21 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 						// Server died mid-flight — recover once and retry this
 						// node's hover against the fresh session. The new client
 						// has no record of our document, so re-open it there
-						// (ensureOpen dedupes the re-open across this file's
+						// (the session dedupes the re-open across this file's
 						// goroutines) before retrying.
 						newC, rerr := reconnect(c)
 						if rerr != nil {
 							return // aborted; wg.Wait + abort check below handles it
 						}
 						c = newC
-						if err := ensureOpen(c); err != nil {
+						var releaseNew func()
+						_, releaseNew, err = session.acquire(c, absPath)
+						if err != nil {
 							p.logger.Debug("LSP enrich: reopen after reconnect failed",
 								zap.String("file", n.FilePath), zap.Error(err))
 							return
 						}
+						defer releaseNew()
 						hoverResult, err = p.hoverWith(c, absRoot, nodeRelPath(n), line, col)
 					}
 					if err != nil {
@@ -1180,7 +1241,10 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 	}
 	wg.Wait()
 
-	// Enrichment metrics (acceptance criterion 6).
+	// Enrichment metrics (acceptance criterion 6): hover outcomes, the
+	// shared document session's open/reopen/eviction accounting, and the
+	// per-method request volume that drove the pass.
+	didOpens, reopenedFiles, docEvictions, peakOpenDocs := session.stats()
 	p.logger.Info("LSP enrich: hover phase complete",
 		zap.Int64("total_nodes", diagTotalNodes.Load()),
 		zap.Int64("hover_ok", diagHoverOK.Load()),
@@ -1190,6 +1254,20 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 		zap.Int64("enriched", diagEnriched.Load()),
 		zap.Int64("skipped_no_position", diagNoPosition.Load()),
 		zap.Int64("reconnect_attempts", p.reconnectAttempts.Load()),
+		zap.Int("did_opens", didOpens),
+		zap.Int("reopened_files", reopenedFiles),
+		zap.Int("doc_evictions", docEvictions),
+		zap.Int("peak_open_docs", peakOpenDocs),
+		zap.Int64("req_references", p.reqStats.references.Load()),
+		zap.Int64("req_implementations", p.reqStats.implementations.Load()),
+		zap.Int64("req_definitions", p.reqStats.definitions.Load()),
+		zap.Int64("req_hovers", p.reqStats.hovers.Load()),
+		zap.Int64("req_prepare_call_hierarchy", p.reqStats.prepareCallHierarchy.Load()),
+		zap.Int64("req_outgoing_calls", p.reqStats.outgoingCalls.Load()),
+		zap.Int64("req_incoming_calls", p.reqStats.incomingCalls.Load()),
+		zap.Int64("req_prepare_type_hierarchy", p.reqStats.prepareTypeHierarchy.Load()),
+		zap.Int64("req_supertypes", p.reqStats.supertypes.Load()),
+		zap.Int64("req_subtypes", p.reqStats.subtypes.Load()),
 		zap.String("first_hover_value", diagFirstHoverValue),
 		zap.String("first_hover_error", diagFirstHoverError),
 		zap.String("first_node_name", diagFirstNodeName),
@@ -2035,6 +2113,7 @@ func (p *Provider) hoverWith(c *Client, repoRoot, relPath string, line, col int)
 		},
 	}
 
+	p.reqStats.hovers.Add(1)
 	var result HoverResult
 	if err := c.Call("textDocument/hover", params, &result); err != nil {
 		return nil, err
@@ -2162,6 +2241,7 @@ func (p *Provider) findImplementations(repoRoot, relPath string, line, col int) 
 		},
 	}
 
+	p.reqStats.implementations.Add(1)
 	var locations []Location
 	if err := p.client.Call("textDocument/implementation", params, &locations); err != nil {
 		return nil, err
@@ -2258,6 +2338,7 @@ func (p *Provider) findReferences(repoRoot, relPath string, line, col int) ([]Lo
 		Context: ReferenceContext{IncludeDeclaration: false},
 	}
 
+	p.reqStats.references.Add(1)
 	var locations []Location
 	if err := p.client.Call("textDocument/references", params, &locations); err != nil {
 		return nil, err
@@ -2281,6 +2362,7 @@ func (p *Provider) FindDefinition(repoRoot, relPath string, line, col int, timeo
 		TextDocument: TextDocumentIdentifier{URI: pathToURI(absPath)},
 		Position:     Position{Line: line, Character: col},
 	}
+	p.reqStats.definitions.Add(1)
 
 	type result struct {
 		locations []Location
@@ -2644,6 +2726,7 @@ func (p *Provider) prepareCallHierarchy(repoRoot, relPath string, line, col int)
 			Position:     Position{Line: line, Character: col},
 		},
 	}
+	p.reqStats.prepareCallHierarchy.Add(1)
 	var items []CallHierarchyItem
 	if err := p.client.Call("textDocument/prepareCallHierarchy", params, &items); err != nil {
 		return nil, err
@@ -2653,6 +2736,7 @@ func (p *Provider) prepareCallHierarchy(repoRoot, relPath string, line, col int)
 
 // outgoingCalls queries callHierarchy/outgoingCalls for one item.
 func (p *Provider) outgoingCalls(item CallHierarchyItem) ([]CallHierarchyOutgoingCall, error) {
+	p.reqStats.outgoingCalls.Add(1)
 	var calls []CallHierarchyOutgoingCall
 	if err := p.client.Call("callHierarchy/outgoingCalls",
 		CallHierarchyOutgoingCallsParams{Item: item}, &calls); err != nil {
@@ -2663,6 +2747,7 @@ func (p *Provider) outgoingCalls(item CallHierarchyItem) ([]CallHierarchyOutgoin
 
 // incomingCalls queries callHierarchy/incomingCalls for one item.
 func (p *Provider) incomingCalls(item CallHierarchyItem) ([]CallHierarchyIncomingCall, error) {
+	p.reqStats.incomingCalls.Add(1)
 	var calls []CallHierarchyIncomingCall
 	if err := p.client.Call("callHierarchy/incomingCalls",
 		CallHierarchyIncomingCallsParams{Item: item}, &calls); err != nil {
@@ -2680,6 +2765,7 @@ func (p *Provider) prepareTypeHierarchy(repoRoot, relPath string, line, col int)
 			Position:     Position{Line: line, Character: col},
 		},
 	}
+	p.reqStats.prepareTypeHierarchy.Add(1)
 	var items []TypeHierarchyItem
 	if err := p.client.Call("textDocument/prepareTypeHierarchy", params, &items); err != nil {
 		return nil, err
@@ -2689,6 +2775,7 @@ func (p *Provider) prepareTypeHierarchy(repoRoot, relPath string, line, col int)
 
 // supertypes queries typeHierarchy/supertypes.
 func (p *Provider) supertypes(item TypeHierarchyItem) ([]TypeHierarchyItem, error) {
+	p.reqStats.supertypes.Add(1)
 	var items []TypeHierarchyItem
 	if err := p.client.Call("typeHierarchy/supertypes",
 		TypeHierarchySupertypesParams{Item: item}, &items); err != nil {
@@ -2699,6 +2786,7 @@ func (p *Provider) supertypes(item TypeHierarchyItem) ([]TypeHierarchyItem, erro
 
 // subtypes queries typeHierarchy/subtypes.
 func (p *Provider) subtypes(item TypeHierarchyItem) ([]TypeHierarchyItem, error) {
+	p.reqStats.subtypes.Add(1)
 	var items []TypeHierarchyItem
 	if err := p.client.Call("typeHierarchy/subtypes",
 		TypeHierarchySubtypesParams{Item: item}, &items); err != nil {

--- a/internal/semantic/lsp/provider_test.go
+++ b/internal/semantic/lsp/provider_test.go
@@ -135,6 +135,7 @@ func providerWithFakeServer(t *testing.T, server *fakeLSPServer, languages []str
 // ---------------------------------------------------------------------------
 
 func TestLSP_Provider_EnrichesNodeMetaFromHover(t *testing.T) {
+	t.Setenv("GORTEX_LSP_SWEEP", "full") // exercise the full per-file sweep, not the demand-gated default
 	repoRoot := t.TempDir()
 	require.NoError(t, os.WriteFile(
 		filepath.Join(repoRoot, "main.go"),
@@ -417,6 +418,7 @@ func TestLSP_Provider_FiltersByLanguage(t *testing.T) {
 }
 
 func TestLSP_Provider_OpensEachFileOnce(t *testing.T) {
+	t.Setenv("GORTEX_LSP_SWEEP", "full") // exercise the full per-file sweep, not the demand-gated default
 	repoRoot := t.TempDir()
 	require.NoError(t, os.WriteFile(
 		filepath.Join(repoRoot, "shared.go"),
@@ -542,6 +544,7 @@ func TestLSP_Provider_EnrichFileIsNoOp(t *testing.T) {
 }
 
 func TestLSP_Provider_EnrichSurvivesHoverFailures(t *testing.T) {
+	t.Setenv("GORTEX_LSP_SWEEP", "full") // exercise the full per-file sweep, not the demand-gated default
 	repoRoot := t.TempDir()
 	require.NoError(t, os.WriteFile(
 		filepath.Join(repoRoot, "main.go"),

--- a/internal/semantic/lsp/references_add.go
+++ b/internal/semantic/lsp/references_add.go
@@ -28,7 +28,7 @@ import (
 // rmu as soon as its references land, so a deadline cut loses only the
 // unvisited remainder. Runs under the caller's targeted context (the same
 // budget the confirm pass uses), before the per-file hover sweep.
-func (p *Provider) referencesAddPass(ctx context.Context, g graph.Store, repoPrefix, absRoot string, langNodes []*graph.Node, rmu sync.Locker, result *semantic.EnrichResult) {
+func (p *Provider) referencesAddPass(ctx context.Context, g graph.Store, repoPrefix, absRoot string, langNodes []*graph.Node, rmu sync.Locker, session *docSession, result *semantic.EnrichResult) {
 	targets := selectReferencesAddTargets(g, langNodes)
 	if len(targets) == 0 {
 		return
@@ -60,12 +60,16 @@ func (p *Provider) referencesAddPass(ctx context.Context, g graph.Store, repoPre
 		if !p.servesFile(rel) {
 			continue // never open a file this server can't compile
 		}
-		if err := p.openDocument(absRoot, rel); err != nil {
+		// Open the declaration file through the shared session so sibling
+		// declarations in the same file reuse one open document (the LRU
+		// absorbs the same-file repeats) instead of reopening per node.
+		content, release, err := session.acquire(p.client, filepath.Join(absRoot, rel))
+		if err != nil {
 			continue
 		}
-		col := identifierColumn(p.getSource(absRoot, rel), n.StartLine, n.Name)
+		col := identifierColumn(content, n.StartLine, n.Name)
 		refs, err := p.findReferences(absRoot, rel, line, col)
-		_ = p.closeDocument(filepath.Join(absRoot, rel))
+		release()
 		if err != nil || len(refs) == 0 {
 			continue
 		}

--- a/internal/semantic/lsp/registry.go
+++ b/internal/semantic/lsp/registry.go
@@ -79,6 +79,16 @@ type ServerSpec struct {
 	// for a "composed bundle" on spawn unless BUNDLE_GEMFILE is already set;
 	// pointing it at the project Gemfile skips that install for enrichment.
 	UseWorkspaceBundleGemfile bool
+	// NeedsCompileDB marks a server that cannot produce full semantic
+	// signal without a compilation database in the workspace. clangd is
+	// the case: with no compile_commands.json every didOpen becomes a
+	// header-less fallback translation unit — a full preamble + AST
+	// rebuild per file — so the hover / hierarchy sweep pays a per-file
+	// rebuild for little return, and opening a header directly makes it a
+	// standalone TU. When this is set and no database is found, enrichment
+	// degrades to reference confirmation: it skips the sweep and header
+	// files and warns with the remediation.
+	NeedsCompileDB bool
 }
 
 // ConnectSpec carries the transport coordinates for passive LSP attach
@@ -365,6 +375,11 @@ var Servers = []ServerSpec{
 		Priority:    5,
 		Daemon:      true,
 		MaxParallel: 6,
+		// clangd's hover / call- and type-hierarchy signal needs a
+		// compilation database; without one it rebuilds a fallback AST
+		// per didOpen, so the enrichment pass degrades to reference
+		// confirmation instead of driving that churn.
+		NeedsCompileDB: true,
 	},
 	{
 		Name:       "jdtls",

--- a/internal/semantic/lsp/router.go
+++ b/internal/semantic/lsp/router.go
@@ -68,6 +68,12 @@ type Router struct {
 	// enrichment, propagated to every spawned provider.
 	enrichExcludeGlobs []string
 
+	// enrichSweepMode is the configured per-file enrichment sweep mode
+	// ("demand" default / "full" / "off"), propagated to every spawned
+	// provider. Empty means the demand-gated default; the GORTEX_LSP_SWEEP
+	// env override wins over it at enrichment time.
+	enrichSweepMode string
+
 	mu        sync.Mutex
 	providers map[providerKey]*routedProvider // (spec.Name, workspace) → cached provider
 	enabled   map[string]*ServerSpec          // spec.Name → spec marked enabled by config (no spawn until For/ForSpec)
@@ -316,6 +322,15 @@ func (r *Router) WithEnrichExcludeGlobs(globs []string) *Router {
 	return r
 }
 
+// WithEnrichSweepMode sets the per-file enrichment sweep mode ("demand"
+// default / "full" / "off") propagated to every spawned provider. An empty
+// value keeps the demand-gated default; the GORTEX_LSP_SWEEP env override
+// still wins over whatever is set here. Builder-style.
+func (r *Router) WithEnrichSweepMode(mode string) *Router {
+	r.enrichSweepMode = mode
+	return r
+}
+
 // WithReaperInterval starts a background reaper that calls Reap() at
 // the given cadence. Idempotent — calling twice replaces the previous
 // reaper. A zero duration disables reaping.
@@ -434,6 +449,7 @@ func (r *Router) forSpecWorkspace(spec *ServerSpec, workspace string, pin bool) 
 	p := NewProviderFromSpec(spec, r.logger)
 	p.workspaceFolders = r.additionalWorkspaceFolders
 	p.excludeGlobs = r.enrichExcludeGlobs
+	p.sweepMode = r.enrichSweepMode
 	// ruby-lsp (and any spec opting in) runs a `bundle install` for a composed
 	// bundle on spawn unless BUNDLE_GEMFILE is set; point it at the workspace's
 	// own Gemfile when present so enrichment skips that install.

--- a/internal/semantic/lsp/sweep.go
+++ b/internal/semantic/lsp/sweep.go
@@ -1,0 +1,99 @@
+package lsp
+
+import (
+	"os"
+	"strings"
+)
+
+// SweepEnv is the environment variable that overrides the configured
+// per-file enrichment sweep mode. When set to a recognised value it wins
+// over the provider's configured mode (and therefore over .gortex.yaml),
+// so an operator can dial sweep intensity for one run without editing
+// config.
+const SweepEnv = "GORTEX_LSP_SWEEP"
+
+// Per-file enrichment sweep modes. The sweep is the whole-repo hover /
+// call-hierarchy phase that runs after the tier-deciding confirm and add
+// passes: it stamps hover type strings and interrogates the server for
+// call/type-hierarchy edges the AST extractor missed, file by file.
+//
+// On an already-resolved graph (a warm restart) that sweep is pure churn —
+// it re-opens and re-hovers every file to confirm zero new edges. The mode
+// gates how much of it runs:
+//
+//   - sweepModeDemand (DEFAULT): sweep a file when its declarations still
+//     carry unresolved same-name call candidates (enrichment demand) OR it
+//     declares a type / interface whose super/subtype hierarchy the sweep
+//     interrogates (dispatch-relevant). The dispatch disjunct is load-bearing:
+//     a type / interface never contributes call demand, yet the sweep is the
+//     only path that recovers its cross-file / dynamic extends / supertype
+//     edges, so gating on demand alone would silently drop them. A file with
+//     neither signal is skipped, so a warm restart pays no sweep for it while
+//     the already-enriched declarations that are swept skip their redundant
+//     hover.
+//   - sweepModeFull: sweep every file of the language — the pre-knob
+//     behaviour, kept for a cold index that wants maximal hover coverage.
+//   - sweepModeOff: skip the per-file sweep entirely. The confirm / add /
+//     interface passes still run, so tiers and recall are unaffected.
+const (
+	sweepModeDemand = "demand"
+	sweepModeFull   = "full"
+	sweepModeOff    = "off"
+)
+
+// normalizeSweepMode canonicalises a configured / env sweep-mode string.
+// Case- and whitespace-insensitive; "none" is accepted as an alias for
+// "off". An empty or unrecognised value returns "" so the caller can fall
+// through to the next precedence source (env → config → default).
+func normalizeSweepMode(v string) string {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case sweepModeDemand:
+		return sweepModeDemand
+	case sweepModeFull:
+		return sweepModeFull
+	case sweepModeOff, "none":
+		return sweepModeOff
+	default:
+		return ""
+	}
+}
+
+// resolveSweepMode picks the effective per-file sweep mode by precedence:
+// the GORTEX_LSP_SWEEP env override wins over the configured value, which
+// wins over the demand-gated default. An unrecognised value at any level
+// is ignored (falls through) rather than failing the pass.
+func resolveSweepMode(configured string) string {
+	if env := normalizeSweepMode(os.Getenv(SweepEnv)); env != "" {
+		return env
+	}
+	if cfg := normalizeSweepMode(configured); cfg != "" {
+		return cfg
+	}
+	return sweepModeDemand
+}
+
+// effectiveSweepMode resolves the sweep mode for this provider, honouring
+// the GORTEX_LSP_SWEEP env override over the router-configured field.
+func (p *Provider) effectiveSweepMode() string {
+	return resolveSweepMode(p.sweepMode)
+}
+
+// sweepFile reports whether the per-file hover / call-hierarchy sweep should
+// run for a file under mode, given its unresolved-demand count and whether it
+// carries a dispatch-relevant declaration. Under the demand default a file is
+// swept when at least one of its declarations still has unresolved same-name
+// call candidates (demand > 0) OR it declares a type / interface whose
+// super/subtype hierarchy the sweep interrogates (dispatch) — the latter never
+// surfaces as demand, so without this disjunct a type-only file would drop the
+// extends / supertype edges only this sweep recovers. "full" always sweeps,
+// "off" never does.
+func sweepFile(mode string, demand int, dispatch bool) bool {
+	switch mode {
+	case sweepModeOff:
+		return false
+	case sweepModeFull:
+		return true
+	default: // sweepModeDemand and any unrecognised residue
+		return demand > 0 || dispatch
+	}
+}

--- a/internal/semantic/lsp/sweep_test.go
+++ b/internal/semantic/lsp/sweep_test.go
@@ -1,0 +1,376 @@
+package lsp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/semantic"
+)
+
+func TestNormalizeSweepMode(t *testing.T) {
+	cases := map[string]string{
+		"demand":   sweepModeDemand,
+		"DEMAND":   sweepModeDemand,
+		"  full  ": sweepModeFull,
+		"Full":     sweepModeFull,
+		"off":      sweepModeOff,
+		"none":     sweepModeOff, // alias
+		"NONE":     sweepModeOff,
+		"":         "", // empty → no opinion, caller falls through
+		"bogus":    "", // unrecognised → no opinion
+	}
+	for in, want := range cases {
+		assert.Equalf(t, want, normalizeSweepMode(in), "normalizeSweepMode(%q)", in)
+	}
+}
+
+func TestResolveSweepMode_EnvWinsOverConfig(t *testing.T) {
+	// No env, no config → demand default.
+	t.Setenv(SweepEnv, "")
+	assert.Equal(t, sweepModeDemand, resolveSweepMode(""), "empty env + empty config resolves to the demand default")
+
+	// Config alone is honoured when the env is unset.
+	assert.Equal(t, sweepModeFull, resolveSweepMode("full"), "configured value is used when env is unset")
+	assert.Equal(t, sweepModeOff, resolveSweepMode("off"))
+
+	// An unrecognised config value falls back to the default rather than failing.
+	assert.Equal(t, sweepModeDemand, resolveSweepMode("bogus"))
+
+	// Env wins over config in both directions.
+	t.Setenv(SweepEnv, "full")
+	assert.Equal(t, sweepModeFull, resolveSweepMode("off"), "env override must win over a configured off")
+	t.Setenv(SweepEnv, "off")
+	assert.Equal(t, sweepModeOff, resolveSweepMode("full"), "env override must win over a configured full")
+
+	// An unrecognised env value is ignored — config (then default) takes over.
+	t.Setenv(SweepEnv, "garbage")
+	assert.Equal(t, sweepModeFull, resolveSweepMode("full"), "an unrecognised env value falls through to config")
+	assert.Equal(t, sweepModeDemand, resolveSweepMode(""), "an unrecognised env value with no config falls through to the default")
+}
+
+func TestSweepFile(t *testing.T) {
+	// off never sweeps, even a demand-bearing or dispatch-relevant file.
+	assert.False(t, sweepFile(sweepModeOff, 5, false))
+	assert.False(t, sweepFile(sweepModeOff, 0, true))
+	// full always sweeps regardless of demand / dispatch.
+	assert.True(t, sweepFile(sweepModeFull, 0, false))
+	assert.True(t, sweepFile(sweepModeFull, 3, false))
+	// demand default: swept on demand > 0 OR a dispatch-relevant declaration.
+	assert.True(t, sweepFile(sweepModeDemand, 1, false))
+	assert.False(t, sweepFile(sweepModeDemand, 0, false))
+	assert.True(t, sweepFile(sweepModeDemand, 0, true), "a dispatch-relevant file is swept even with zero demand")
+	assert.True(t, sweepFile(sweepModeDemand, 2, true))
+	// An unrecognised residue behaves like the demand default.
+	assert.True(t, sweepFile("bogus", 2, false))
+	assert.True(t, sweepFile("bogus", 0, true))
+	assert.False(t, sweepFile("bogus", 0, false))
+}
+
+func TestEnrichNodeIsDispatchRelevant(t *testing.T) {
+	assert.True(t, enrichNodeIsDispatchRelevant(&graph.Node{Kind: graph.KindType}))
+	assert.True(t, enrichNodeIsDispatchRelevant(&graph.Node{Kind: graph.KindInterface}))
+	assert.False(t, enrichNodeIsDispatchRelevant(&graph.Node{Kind: graph.KindFunction}))
+	assert.False(t, enrichNodeIsDispatchRelevant(&graph.Node{Kind: graph.KindMethod}))
+	assert.False(t, enrichNodeIsDispatchRelevant(nil))
+}
+
+func TestNodeHasSemanticType(t *testing.T) {
+	assert.False(t, nodeHasSemanticType(nil))
+	assert.False(t, nodeHasSemanticType(&graph.Node{}))
+	assert.False(t, nodeHasSemanticType(&graph.Node{Meta: map[string]any{"semantic_type": ""}}))
+	assert.False(t, nodeHasSemanticType(&graph.Node{Meta: map[string]any{"other": "x"}}))
+	assert.False(t, nodeHasSemanticType(&graph.Node{Meta: map[string]any{"semantic_type": 42}}))
+	assert.True(t, nodeHasSemanticType(&graph.Node{Meta: map[string]any{"semantic_type": "func()"}}))
+}
+
+func TestEffectiveSweepMode(t *testing.T) {
+	p := &Provider{sweepMode: "off"}
+	t.Setenv(SweepEnv, "")
+	assert.Equal(t, sweepModeOff, p.effectiveSweepMode(), "the router-configured field is honoured when env is unset")
+	t.Setenv(SweepEnv, "full")
+	assert.Equal(t, sweepModeFull, p.effectiveSweepMode(), "the env override wins over the configured field")
+
+	empty := &Provider{}
+	t.Setenv(SweepEnv, "")
+	assert.Equal(t, sweepModeDemand, empty.effectiveSweepMode(), "an unset field and unset env resolve to the demand default")
+}
+
+// enrichCapturingResult runs a full enrichment pass and returns its result,
+// guarding against a hang with a hard timeout.
+func enrichCapturingResult(t *testing.T, p *Provider, g graph.Store, repoRoot string) *semantic.EnrichResult {
+	t.Helper()
+	type out struct {
+		res *semantic.EnrichResult
+		err error
+	}
+	done := make(chan out, 1)
+	go func() {
+		res, err := p.Enrich(g, repoRoot)
+		done <- out{res, err}
+	}()
+	select {
+	case o := <-done:
+		require.NoError(t, o.err)
+		require.NotNil(t, o.res)
+		return o.res
+	case <-time.After(10 * time.Second):
+		t.Fatal("Enrich timed out")
+		return nil
+	}
+}
+
+// hoverURIRecorder registers a hover handler that records the base name of
+// each file the server is asked to hover, so a test can assert exactly which
+// files the per-file sweep visited. The returned map is final once Enrich
+// returns (every hover request is issued and awaited before the pass ends).
+func hoverURIRecorder(server *instrumentedServer) (*sync.Mutex, map[string]bool) {
+	var mu sync.Mutex
+	hovered := map[string]bool{}
+	server.handle("textDocument/hover", func(params json.RawMessage) (any, *jsonRPCError) {
+		var req struct {
+			TextDocument struct {
+				URI string `json:"uri"`
+			} `json:"textDocument"`
+		}
+		_ = json.Unmarshal(params, &req)
+		mu.Lock()
+		hovered[filepath.Base(uriToAbsPath(req.TextDocument.URI))] = true
+		mu.Unlock()
+		return map[string]any{"contents": map[string]any{"kind": "plaintext", "value": "func X()"}}, nil
+	})
+	return &mu, hovered
+}
+
+// seedDemand gives declName enrichment demand by minting the unresolved
+// same-name call stub the demand check looks for. Confidence 1.0 keeps the
+// stub edge out of the ambiguous-edge confirm target set, so the ONLY pass
+// that can touch the file is the per-file sweep under test.
+func seedDemand(g graph.Store, callerID, declName string) {
+	g.AddEdge(&graph.Edge{
+		From: callerID, To: graph.UnresolvedMarker + "*." + declName,
+		Kind: graph.EdgeCalls, Confidence: 1.0,
+	})
+}
+
+// Default mode is demand-gated: the per-file hover sweep visits only files
+// whose declarations still carry unresolved same-name candidates. A
+// fully-resolved file is skipped, so a warm restart pays no sweep.
+func TestLSP_Enrich_SweepDemandGatedByDefault(t *testing.T) {
+	t.Setenv(SweepEnv, "") // hermetic: no external override, no config → demand default
+
+	repoRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "plain.go"),
+		[]byte("package p\n\nfunc Plain() {}\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "hot.go"),
+		[]byte("package p\n\nfunc Hot() {}\nfunc caller() {}\n"), 0o644))
+
+	server := newInstrumentedServer()
+	mu, hovered := hoverURIRecorder(server)
+
+	p, cleanup := providerWithInstrumentedServer(t, server, []string{"go"}, 4)
+	defer cleanup()
+
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "plain.go::Plain", Kind: graph.KindFunction, Name: "Plain",
+		FilePath: "plain.go", StartLine: 3, EndLine: 3, Language: "go"})
+	g.AddNode(&graph.Node{ID: "hot.go::Hot", Kind: graph.KindFunction, Name: "Hot",
+		FilePath: "hot.go", StartLine: 3, EndLine: 3, Language: "go"})
+	g.AddNode(&graph.Node{ID: "hot.go::caller", Kind: graph.KindFunction, Name: "caller",
+		FilePath: "hot.go", StartLine: 4, EndLine: 4, Language: "go"})
+	seedDemand(g, "hot.go::caller", "Hot") // hot.go now carries demand; plain.go does not
+
+	res := enrichCapturingResult(t, p, g, repoRoot)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.True(t, hovered["hot.go"], "the demand-bearing file must be swept")
+	assert.False(t, hovered["plain.go"], "the fully-resolved file must be skipped under the demand default")
+	assert.Positive(t, res.NodesEnriched, "the swept file's hovers must land stamps")
+
+	require.Eventually(t, func() bool { return server.wasOpened(pathToURI(filepath.Join(repoRoot, "hot.go"))) },
+		2*time.Second, 5*time.Millisecond, "hot.go should be opened by the sweep")
+	assert.False(t, server.wasOpened(pathToURI(filepath.Join(repoRoot, "plain.go"))),
+		"plain.go must never be opened under the demand default")
+}
+
+// Under the demand default, a file whose only enrichable work is a type
+// hierarchy (a class with an extends clause — zero call demand) must still be
+// swept, or the extends / supertype edges only this sweep recovers are
+// silently dropped. Regression guard: enrichNodeHasUnresolvedDemand counts
+// callables only, so such a file scores demand == 0; the dispatch-relevant
+// disjunct is what keeps it in the sweep.
+func TestLSP_Enrich_SweepDispatchRelevantRecoversHierarchyByDefault(t *testing.T) {
+	t.Setenv(SweepEnv, "") // hermetic: exercise the demand default, not full
+
+	repoRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repoRoot, "h.ts"),
+		[]byte("class Animal {}\nclass Dog extends Animal {}\n"),
+		0o644,
+	))
+
+	server := newFakeLSPServer()
+	server.handle("textDocument/hover", func(_ json.RawMessage) (any, *jsonRPCError) { return nil, nil })
+	server.handle("textDocument/implementation", func(_ json.RawMessage) (any, *jsonRPCError) { return nil, nil })
+	server.handle("textDocument/prepareTypeHierarchy", func(_ json.RawMessage) (any, *jsonRPCError) {
+		return []TypeHierarchyItem{{
+			Name:           "Dog",
+			URI:            pathToURI(filepath.Join(repoRoot, "h.ts")),
+			SelectionRange: Range{Start: Position{Line: 1, Character: 6}, End: Position{Line: 1, Character: 9}},
+		}}, nil
+	})
+	server.handle("typeHierarchy/supertypes", func(_ json.RawMessage) (any, *jsonRPCError) {
+		return []TypeHierarchyItem{{
+			Name:           "Animal",
+			URI:            pathToURI(filepath.Join(repoRoot, "h.ts")),
+			SelectionRange: Range{Start: Position{Line: 0, Character: 6}, End: Position{Line: 0, Character: 12}},
+		}}, nil
+	})
+	server.handle("typeHierarchy/subtypes", func(_ json.RawMessage) (any, *jsonRPCError) { return nil, nil })
+
+	p, cleanup := providerWithFakeServer(t, server, []string{"typescript"})
+	defer cleanup()
+
+	g := graph.New()
+	// Only type declarations — no functions, so demand == 0 for this file.
+	g.AddNode(&graph.Node{ID: "h.ts::Animal", Kind: graph.KindType, Name: "Animal",
+		FilePath: "h.ts", StartLine: 1, EndLine: 1, Language: "typescript"})
+	g.AddNode(&graph.Node{ID: "h.ts::Dog", Kind: graph.KindType, Name: "Dog",
+		FilePath: "h.ts", StartLine: 2, EndLine: 2, Language: "typescript"})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := p.Enrich(g, repoRoot)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("Enrich timed out")
+	}
+
+	var ext *graph.Edge
+	for _, e := range g.GetOutEdges("h.ts::Dog") {
+		if e.Kind == graph.EdgeExtends && e.To == "h.ts::Animal" {
+			ext = e
+			break
+		}
+	}
+	require.NotNil(t, ext, "a type-only (zero-demand) file must still be swept under the demand default so its extends edge is recovered")
+}
+
+// A node that already carries a semantic_type stamp (e.g. reloaded on a warm
+// restart) must not be re-hovered by the sweep, while an unstamped node in the
+// same pass still is. The file is force-swept so the skip — not the gate — is
+// the only reason the stamped node is untouched.
+func TestLSP_Enrich_SweepSkipsHoverForAlreadyStampedNode(t *testing.T) {
+	t.Setenv(SweepEnv, "full") // force the sweep; isolate the hover-skip from the gate
+
+	repoRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "stamped.go"),
+		[]byte("package p\n\nfunc Stamped() {}\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "fresh.go"),
+		[]byte("package p\n\nfunc Fresh() {}\n"), 0o644))
+
+	server := newInstrumentedServer()
+	mu, hovered := hoverURIRecorder(server)
+
+	p, cleanup := providerWithInstrumentedServer(t, server, []string{"go"}, 4)
+	defer cleanup()
+
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "stamped.go::Stamped", Kind: graph.KindFunction, Name: "Stamped",
+		FilePath: "stamped.go", StartLine: 3, EndLine: 3, Language: "go",
+		Meta: map[string]any{"semantic_type": "func() original"}}) // already enriched
+	g.AddNode(&graph.Node{ID: "fresh.go::Fresh", Kind: graph.KindFunction, Name: "Fresh",
+		FilePath: "fresh.go", StartLine: 3, EndLine: 3, Language: "go"})
+
+	enrichCapturingResult(t, p, g, repoRoot)
+
+	mu.Lock()
+	assert.True(t, hovered["fresh.go"], "an unstamped node must be hovered under a full sweep")
+	assert.False(t, hovered["stamped.go"], "a node already carrying a semantic_type must not be re-hovered")
+	mu.Unlock()
+
+	assert.Equal(t, "func() original", g.GetNode("stamped.go::Stamped").Meta["semantic_type"],
+		"the skipped node keeps its prior stamp untouched")
+}
+
+// "full" (via the env override, winning over a configured "off") sweeps even
+// a file with no unresolved demand — the pre-knob behaviour for a cold index
+// that wants maximal hover coverage.
+func TestLSP_Enrich_SweepFullEnvSweepsNoDemandFile(t *testing.T) {
+	t.Setenv(SweepEnv, "full")
+
+	repoRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "plain.go"),
+		[]byte("package p\n\nfunc Plain() {}\n"), 0o644))
+
+	server := newInstrumentedServer()
+	mu, hovered := hoverURIRecorder(server)
+
+	p, cleanup := providerWithInstrumentedServer(t, server, []string{"go"}, 4)
+	defer cleanup()
+	p.sweepMode = "off" // env "full" must win over this configured mode
+
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "plain.go::Plain", Kind: graph.KindFunction, Name: "Plain",
+		FilePath: "plain.go", StartLine: 3, EndLine: 3, Language: "go"})
+
+	res := enrichCapturingResult(t, p, g, repoRoot)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.True(t, hovered["plain.go"], "full mode (env wins over configured off) must sweep a no-demand file")
+	assert.Positive(t, res.NodesEnriched)
+}
+
+// "off" skips the per-file sweep entirely — even a demand-bearing file is not
+// hovered. The tier-deciding passes still run, but nothing is stamped here.
+func TestLSP_Enrich_SweepOffSkipsEvenDemandFile(t *testing.T) {
+	t.Setenv(SweepEnv, "off")
+
+	repoRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "hot.go"),
+		[]byte("package p\n\nfunc Hot() {}\nfunc caller() {}\n"), 0o644))
+
+	server := newInstrumentedServer()
+	var hoverCalls int
+	var hmu sync.Mutex
+	server.handle("textDocument/hover", func(_ json.RawMessage) (any, *jsonRPCError) {
+		hmu.Lock()
+		hoverCalls++
+		hmu.Unlock()
+		return map[string]any{"contents": map[string]any{"kind": "plaintext", "value": "func X()"}}, nil
+	})
+
+	p, cleanup := providerWithInstrumentedServer(t, server, []string{"go"}, 4)
+	defer cleanup()
+
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "hot.go::Hot", Kind: graph.KindFunction, Name: "Hot",
+		FilePath: "hot.go", StartLine: 3, EndLine: 3, Language: "go"})
+	g.AddNode(&graph.Node{ID: "hot.go::caller", Kind: graph.KindFunction, Name: "caller",
+		FilePath: "hot.go", StartLine: 4, EndLine: 4, Language: "go"})
+	seedDemand(g, "hot.go::caller", "Hot")
+
+	res := enrichCapturingResult(t, p, g, repoRoot)
+
+	// Enrich returns only after every sweep goroutine finishes, so once we
+	// are here no further hover requests can be issued: the count is final.
+	hmu.Lock()
+	assert.Zero(t, hoverCalls, "off mode must issue no hover requests, even for a demand-bearing file")
+	hmu.Unlock()
+	assert.Zero(t, res.NodesEnriched, "off mode stamps nothing")
+	assert.False(t, server.wasOpened(pathToURI(filepath.Join(repoRoot, "hot.go"))),
+		"off mode must not open the file for the sweep")
+}

--- a/internal/semantic/manager.go
+++ b/internal/semantic/manager.go
@@ -527,6 +527,8 @@ func (m *Manager) setEnrichStatus(repo, provider, lang, state string, deadline t
 		}
 		st.BoundReason = result.BoundReason
 		st.ReferencesAddPass = result.ReferencesAddPass
+		st.Degraded = result.Degraded
+		st.DegradedReason = result.DegradedReason
 	}
 	m.mu.Lock()
 	m.enrichStatus[repo+"\x00"+provider] = st
@@ -733,7 +735,13 @@ func (m *Manager) runEnrichOne(g graph.Store, repoName, repoRoot, lang string, p
 		if result.Partial {
 			state = EnrichStatePartial
 		}
-		m.setEnrichStatus(repoName, provider.Name(), lang, state, d, result, result.AbortReason)
+		// A degraded (compile-db-missing) pass completes normally; surface its
+		// reason as the status detail when there is no abort reason to report.
+		detail := result.AbortReason
+		if detail == "" {
+			detail = result.DegradedReason
+		}
+		m.setEnrichStatus(repoName, provider.Name(), lang, state, d, result, detail)
 
 		m.logger.Info("semantic enrichment complete",
 			zap.String("provider", provider.Name()),

--- a/internal/semantic/provider.go
+++ b/internal/semantic/provider.go
@@ -103,6 +103,13 @@ type EnrichResult struct {
 	// server advertised references but no call hierarchy — e.g. intelephense.
 	// Lets index_health distinguish this add mode from the hierarchy mode.
 	ReferencesAddPass bool `json:"references_add_pass,omitempty"`
+	// Degraded reports that the pass ran in a reduced mode — reference
+	// confirmation only, no hover / hierarchy sweep — because a server that
+	// needs a compilation database (clangd) found none. It is an intentional
+	// degradation, not a failure: the confirmed edges are trustworthy, but
+	// hover types and hierarchy edges are absent. DegradedReason carries why.
+	Degraded       bool   `json:"degraded,omitempty"`
+	DegradedReason string `json:"degraded_reason,omitempty"`
 }
 
 // Bounding reasons for the enrichment add-phase (EnrichResult.BoundReason /
@@ -148,8 +155,14 @@ type EnrichmentStatus struct {
 	// ReferencesAddPass marks that this provider added edges via
 	// textDocument/references (no call hierarchy) — the intelephense-style
 	// add mode. Distinguishes it from the call-hierarchy add mode.
-	ReferencesAddPass bool   `json:"references_add_pass,omitempty"`
-	Detail            string `json:"detail,omitempty"`
+	ReferencesAddPass bool `json:"references_add_pass,omitempty"`
+	// Degraded marks that this provider ran in reference-confirmation-only
+	// mode because a needed compilation database was missing. Not a failure —
+	// State stays "completed" — but hover / hierarchy edges are absent, so
+	// index_health can flag it with the remediation. DegradedReason says why.
+	Degraded       bool   `json:"degraded,omitempty"`
+	DegradedReason string `json:"degraded_reason,omitempty"`
+	Detail         string `json:"detail,omitempty"`
 }
 
 // ProviderStatus represents the current state of a semantic provider.

--- a/internal/serverstack/shared_server.go
+++ b/internal/serverstack/shared_server.go
@@ -302,6 +302,7 @@ func NewSharedServer(cfg SharedServerConfig) (*SharedServer, error) {
 			WatchDebounceMs:   conf.Semantic.WatchDebounceMs,
 			RefuteUnconfirmed: conf.Semantic.RefuteUnconfirmed,
 			ExcludeGlobs:      conf.Semantic.ExcludeGlobs,
+			LSPSweep:          conf.Semantic.LSPSweep,
 		}
 		for _, pc := range conf.Semantic.Providers {
 			out := semantic.ProviderConfig{
@@ -360,7 +361,8 @@ func NewSharedServer(cfg SharedServerConfig) (*SharedServer, error) {
 			WithReaperInterval(time.Minute).
 			WithMaxAlive(6).
 			WithAdditionalWorkspaceFolders(conf.Semantic.AdditionalWorkspaceFolders).
-			WithEnrichExcludeGlobs(conf.Semantic.ExcludeGlobs)
+			WithEnrichExcludeGlobs(conf.Semantic.ExcludeGlobs).
+			WithEnrichSweepMode(semCfg.LSPSweep)
 		semMgr.SetLSPRouter(lspRouter)
 
 		for _, pc := range semCfg.Providers {


### PR DESCRIPTION
Fixes #226 (the clangd enrichment CPU churn; the resolver-side warmup delay mentioned in that issue's closing note is a separate track).

## Problem

LSP enrichment was round-trip bound and document-lifecycle wasteful. Each enrichment phase owned its own didOpen/didClose cycles: the interface pass opened per interface node, the definition-rebind fallback opened per call site, the references-add pass opened per declaration, and the sweep re-opened files earlier phases had just closed. Every function also paid `prepareCallHierarchy` + `outgoingCalls` + `incomingCalls` + `hover` — ~4 round trips per symbol — even on fully-resolved graphs where the sweep confirms zero new edges.

For clangd without a compilation database this is pathological: every didOpen is a from-scratch fallback preamble+AST rebuild, and headers opened directly become standalone TUs. The reporter of #226 measured 241 fallback AST builds of a single file in one pass.

## What changed

- **Shared bounded document session** (`docSession`): one LRU-bounded open-document set shared by every enrichment phase — a file is opened once per (client, path) while it stays warm, pinned while in use, evicted only unpinned, everything close-paired at pass end. The rebind fallback now sorts sites by file and holds one open per file run; `definitionNodeAtSite` takes already-open content. Simultaneously-open docs are capped at 2×maxParallel (the original bulk-open OOM bound stays).
- **Sweep-mode knob**: the whole-repo hover/call-hierarchy sweep is gated. `semantic.lsp_sweep: demand` (default) sweeps only files whose declarations still carry unresolved same-name candidates, `full` restores the previous behavior, `off` skips the sweep. `GORTEX_LSP_SWEEP` overrides. The tier-deciding confirm / rebind / interface / references-add passes are never gated.
- **incomingCalls only where the outgoing sweep is blind**: every intra-repo static call edge is recoverable from its caller's outgoing hop, so incoming is fetched only for dispatch-relevant or demand-bearing declarations (or under `full`).
- **Compile-database preflight**: a `NeedsCompileDB` server (clangd) with no `compile_commands.json` / `build*/compile_commands.json` / `compile_flags.txt` / `.clangd` degrades to reference-confirmation only — no hover/hierarchy sweep, no header TUs — with a one-shot warning naming the remediation (`cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON`, `bear -- make`, meson). Degradation is surfaced on `EnrichResult` / `EnrichmentStatus` and as an `index_health` recommendation; it is intentional, so `semantic_enrichment_ok` stays true.
- **Telemetry**: the pass-complete log now carries `did_opens`, `reopened_files`, `doc_evictions`, `peak_open_docs`, per-method `req_*` counters, `incoming_calls_skipped`, and `sweep_mode`, so regressions in request volume are visible.

## Measured (Redis, clangd 22, fixed 10-minute enrichment budget, isolated home per run)

| | baseline | this branch |
|---|---|---|
| **With compile db** — wall / clangd CPU | 6m27s / 924s | **2m08s / 438s** |
| edges_confirmed | 31,385 | **51,390** |
| hover coverage (nodes_enriched) | 52 | 52 (identical) |
| incomingCalls requests | ~12,897 | **6** (10,034 skipped, edge delta vs full sweep: 0.05%) |
| **No compile db** (the #226 setup) — wall / clangd CPU | 6m27s / 950s | **1m06s / 189s** |
| fallback AST builds | 3,874 | **0 wasted on sweep** (degraded: references+definitions only) |
| edges_confirmed | 17,036 | **32,520** |

Baseline burned ~950 CPU-seconds of clangd on database-less hovers that came back 99.7% empty. The branch confirms *more* edges in both scenarios because the confirm pass no longer competes with document churn for the deadline budget.

An attribution run with `GORTEX_LSP_SWEEP=full` shows the document session alone accounts for most of the wall/CPU win; demand-gating then removes ~5.4k hovers and ~12.9k incomingCalls with a 0.05% edge difference.

## Behavioral notes

- In the default `demand` mode, fully-static already-confident edges are no longer redundantly re-promoted to the `lsp_resolved` tier by the sweep; `min_tier: "lsp_resolved"` queries will surface fewer of those redundant confirmations. `lsp_sweep: full` restores the old behavior.
- `reopened_files` telemetry is nonzero on repos whose touched-file set exceeds the LRU cap — that is the bounded-memory tradeoff working as intended (peak open docs stays exactly at the cap; total opens on Redis still dropped ~2×).
- One latent bug fixed en route: the sweep's reconnect-retry path shadowed its error variable, so a successfully retried hover after a server crash was discarded; now covered by a dedicated test.

## Testing

- `go build ./...`, `go vet`, full `go test -race ./...` green; `golangci-lint` clean on all touched packages.
- New tests: session sharing across passes, LRU eviction pairing/bounds, pinned-entry protection, fallback single-open, demand/dispatch/full gating matrices, incomingCalls policy, compile-db preflight (degraded + non-degraded + header skip), degraded status/index_health surfacing, reconnect-retry hover result.
- End-to-end on Redis as above; evidence (daemon logs, index_health snapshots, clangd CPU samples) captured per run.
