### PR TITLE
feat(kimi): add PreToolUse soft nudge for MCP read tools

### DIFF
--- a/internal/agents/kimi/adapter.go
+++ b/internal/agents/kimi/adapter.go
@@ -8,8 +8,8 @@
 //
 // Kimi's hooks are user-level today, so project-mode `gortex init` only writes
 // the repo-local MCP file. Machine-wide `gortex install` writes user MCP and,
-// when hooks are enabled, a UserPromptSubmit hook that shells `gortex hook
-// --agent=kimi`.
+// when hooks are enabled, UserPromptSubmit and PreToolUse hooks that shell
+// `gortex hook --agent=kimi`.
 //
 // Docs: https://www.kimi.com/code/docs/en/kimi-code-cli/customization/hooks.html
 package kimi
@@ -128,7 +128,7 @@ func (a *Adapter) applyGlobal(env agents.Env, opts agents.ApplyOpts, res *agents
 
 	if env.InstallHooks {
 		hookAction, err := agents.MergeTOML(env.Stderr, filepath.Join(home, "config.toml"), func(root map[string]any, _ bool) (bool, error) {
-			return upsertUserPromptSubmitHook(root, env, opts), nil
+			return upsertKimiHooks(root, env, opts), nil
 		}, opts)
 		if err != nil {
 			return res, err
@@ -157,28 +157,38 @@ func kimiConfigRoot(env agents.Env) string {
 	return filepath.Join(env.Home, ".kimi-code")
 }
 
-func upsertUserPromptSubmitHook(root map[string]any, env agents.Env, opts agents.ApplyOpts) bool {
+func upsertKimiHooks(root map[string]any, env agents.Env, opts agents.ApplyOpts) bool {
 	existing, ok := kimiHookList(root["hooks"])
 	if !ok {
 		return false
 	}
 
-	found := false
-	kept := make([]any, 0, len(existing)+1)
+	found := make(map[string]bool)
+	kept := make([]any, 0, len(existing)+2)
 	for _, entry := range existing {
-		if kimiHookEntryInvokesKimi(entry) {
-			found = true
+		if event, ok := kimiHookEntryInvokesKimi(entry); ok {
+			found[event] = true
 			if opts.Force {
 				continue
 			}
 		}
 		kept = append(kept, entry)
 	}
-	if found && !opts.Force {
+
+	changed := false
+	for _, hook := range kimiHooks(env) {
+		event, _ := hook["event"].(string)
+		if found[event] && !opts.Force {
+			continue
+		}
+		kept = append(kept, hook)
+		changed = true
+	}
+	if !changed {
 		return false
 	}
 
-	root["hooks"] = append(kept, kimiUserPromptSubmitHook(env))
+	root["hooks"] = kept
 	return true
 }
 
@@ -200,9 +210,27 @@ func kimiHookList(v any) ([]any, bool) {
 	}
 }
 
+func kimiHooks(env agents.Env) []map[string]any {
+	return []map[string]any{
+		kimiUserPromptSubmitHook(env),
+		kimiPreToolUseHook(env),
+	}
+}
+
 func kimiUserPromptSubmitHook(env agents.Env) map[string]any {
 	return map[string]any{
 		"event":   "UserPromptSubmit",
+		"command": kimiHookCommand(env),
+		"timeout": kimiHookTimeoutSeconds,
+	}
+}
+
+func kimiPreToolUseHook(env agents.Env) map[string]any {
+	// Do not set matcher here: Kimi currently exposes MCP tool names as the
+	// underlying tool name without a documented server namespace. The dispatcher
+	// does the narrow Gortex read-tool filtering and silently ignores the rest.
+	return map[string]any{
+		"event":   "PreToolUse",
 		"command": kimiHookCommand(env),
 		"timeout": kimiHookTimeoutSeconds,
 	}
@@ -216,17 +244,19 @@ func kimiHookCommand(env agents.Env) string {
 	return base + " --agent=kimi"
 }
 
-func kimiHookEntryInvokesKimi(entry any) bool {
+func kimiHookEntryInvokesKimi(entry any) (string, bool) {
 	m, ok := entry.(map[string]any)
 	if !ok {
-		return false
+		return "", false
 	}
 	event, _ := m["event"].(string)
-	if event != "UserPromptSubmit" {
-		return false
+	switch event {
+	case "UserPromptSubmit", "PreToolUse":
+	default:
+		return "", false
 	}
 	cmd, _ := m["command"].(string)
-	return kimiCommandInvokesKimiHook(cmd)
+	return event, kimiCommandInvokesKimiHook(cmd)
 }
 
 func kimiCommandInvokesKimiHook(cmd string) bool {

--- a/internal/agents/kimi/adapter_test.go
+++ b/internal/agents/kimi/adapter_test.go
@@ -34,7 +34,7 @@ func TestKimiProjectWritesOnlyProjectMCP(t *testing.T) {
 	agentstest.AssertIdempotent(t, a, env)
 }
 
-func TestKimiGlobalWritesMCPAndUserPromptHook(t *testing.T) {
+func TestKimiGlobalWritesMCPAndHooks(t *testing.T) {
 	env := kimiTestEnv(t)
 	env.Mode = agents.ModeGlobal
 	a := New()
@@ -51,22 +51,11 @@ func TestKimiGlobalWritesMCPAndUserPromptHook(t *testing.T) {
 	}
 
 	hooks := readKimiHooks(t, env)
-	if len(hooks) != 1 {
-		t.Fatalf("hooks=%#v want 1", hooks)
+	if len(hooks) != 2 {
+		t.Fatalf("hooks=%#v want 2", hooks)
 	}
-	hook := hooks[0]
-	if hook["event"] != "UserPromptSubmit" {
-		t.Errorf("event=%v want UserPromptSubmit", hook["event"])
-	}
-	if hook["command"] != testKimiHookCommand {
-		t.Errorf("command=%v want %q", hook["command"], testKimiHookCommand)
-	}
-	if hook["timeout"] != int64(kimiHookTimeoutSeconds) {
-		t.Errorf("timeout=%v want %d", hook["timeout"], kimiHookTimeoutSeconds)
-	}
-	if _, ok := hook["matcher"]; ok {
-		t.Errorf("UserPromptSubmit hook should not write matcher: %#v", hook)
-	}
+	assertKimiHook(t, hooks[0], "UserPromptSubmit")
+	assertKimiHook(t, hooks[1], "PreToolUse")
 
 	agentstest.AssertIdempotent(t, a, env)
 }
@@ -118,14 +107,17 @@ timeout = 5
 		t.Fatalf("default_model was not preserved: %#v", cfg)
 	}
 	hooks := readKimiHooks(t, env)
-	if len(hooks) != 2 {
-		t.Fatalf("hooks=%#v want user+gortex", hooks)
+	if len(hooks) != 3 {
+		t.Fatalf("hooks=%#v want user+gortex hooks", hooks)
 	}
 	if hooks[0]["event"] != "Notification" {
 		t.Fatalf("user hook was not preserved first: %#v", hooks)
 	}
 	if hooks[1]["event"] != "UserPromptSubmit" {
 		t.Fatalf("missing gortex UserPromptSubmit hook: %#v", hooks)
+	}
+	if hooks[2]["event"] != "PreToolUse" {
+		t.Fatalf("missing gortex PreToolUse hook: %#v", hooks)
 	}
 }
 
@@ -144,6 +136,11 @@ command = "echo user"
 event = "UserPromptSubmit"
 command = "/tmp/old-gortex hook --agent=kimi"
 timeout = 30
+
+[[hooks]]
+event = "PreToolUse"
+command = "/tmp/old-gortex hook --agent=kimi"
+timeout = 30
 `
 	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
 		t.Fatal(err)
@@ -153,15 +150,14 @@ timeout = 30
 		t.Fatalf("apply force: %v", err)
 	}
 	hooks := readKimiHooks(t, env)
-	if len(hooks) != 2 {
-		t.Fatalf("hooks=%#v want user+current gortex", hooks)
+	if len(hooks) != 3 {
+		t.Fatalf("hooks=%#v want user+current gortex hooks", hooks)
 	}
 	if hooks[0]["command"] != "echo user" {
 		t.Fatalf("user hook was not preserved: %#v", hooks)
 	}
-	if hooks[1]["command"] != testKimiHookCommand {
-		t.Fatalf("gortex hook was not refreshed: %#v", hooks)
-	}
+	assertKimiHook(t, hooks[1], "UserPromptSubmit")
+	assertKimiHook(t, hooks[2], "PreToolUse")
 }
 
 func kimiTestEnv(t *testing.T) agents.Env {
@@ -207,4 +203,20 @@ func readKimiHooks(t *testing.T, env agents.Env) []map[string]any {
 		out = append(out, m)
 	}
 	return out
+}
+
+func assertKimiHook(t *testing.T, hook map[string]any, event string) {
+	t.Helper()
+	if hook["event"] != event {
+		t.Errorf("event=%v want %s", hook["event"], event)
+	}
+	if hook["command"] != testKimiHookCommand {
+		t.Errorf("command=%v want %q", hook["command"], testKimiHookCommand)
+	}
+	if hook["timeout"] != int64(kimiHookTimeoutSeconds) {
+		t.Errorf("timeout=%v want %d", hook["timeout"], kimiHookTimeoutSeconds)
+	}
+	if _, ok := hook["matcher"]; ok {
+		t.Errorf("%s hook should not write matcher: %#v", event, hook)
+	}
 }

--- a/internal/hooks/kimi.go
+++ b/internal/hooks/kimi.go
@@ -9,10 +9,9 @@ import (
 	"strings"
 )
 
-// RunKimi handles the Kimi Code CLI hook wire shape. PR 1 intentionally
-// supports only UserPromptSubmit: Kimi reliably appends normal stdout from that
-// event to the turn context, while PreToolUse/PostToolUse need separate
-// contract work.
+// RunKimi handles the Kimi Code CLI hook wire shape. Kimi consumes plain
+// stdout as hook-added context, so this dispatcher intentionally avoids
+// Claude-style structured additionalContext JSON.
 func RunKimi() {
 	data, err := io.ReadAll(os.Stdin)
 	if err != nil {
@@ -23,24 +22,53 @@ func RunKimi() {
 
 func runKimi(data []byte) {
 	var input struct {
-		HookEventName string `json:"hook_event_name"`
-		CWD           string `json:"cwd"`
-		Prompt        any    `json:"prompt"`
+		HookEventName string         `json:"hook_event_name"`
+		CWD           string         `json:"cwd"`
+		ToolName      string         `json:"tool_name"`
+		ToolInput     map[string]any `json:"tool_input"`
+		Prompt        any            `json:"prompt"`
 	}
 	if err := json.Unmarshal(data, &input); err != nil {
 		return
 	}
-	if input.HookEventName != "UserPromptSubmit" {
+	switch input.HookEventName {
+	case "UserPromptSubmit", "PreToolUse":
+	default:
 		return
 	}
 	if !kimiGortexEnabledProject(input.CWD) {
 		return
 	}
-	ctx := buildUserPromptSubmitContext(input.HookEventName, kimiPromptText(input.Prompt))
+	switch input.HookEventName {
+	case "UserPromptSubmit":
+		ctx := buildUserPromptSubmitContext(input.HookEventName, kimiPromptText(input.Prompt))
+		if ctx == "" {
+			return
+		}
+		fmt.Print(ctx)
+	case "PreToolUse":
+		runKimiPreToolUse(input.ToolName, input.ToolInput)
+	}
+}
+
+func runKimiPreToolUse(toolName string, toolInput map[string]any) {
+	if !kimiGortexReadPreToolUseTool(toolName) {
+		return
+	}
+	ctx := gortexReadNudge(toolName, toolInput)
 	if ctx == "" {
 		return
 	}
 	fmt.Print(ctx)
+}
+
+func kimiGortexReadPreToolUseTool(toolName string) bool {
+	switch strings.TrimSpace(toolName) {
+	case gortexReadFileTool, gortexEditingContextTool, "read_file", "get_editing_context":
+		return true
+	default:
+		return false
+	}
 }
 
 func kimiPromptText(v any) string {

--- a/internal/hooks/kimi_test.go
+++ b/internal/hooks/kimi_test.go
@@ -50,6 +50,102 @@ func TestRunKimiUserPromptSubmitContentParts(t *testing.T) {
 	}
 }
 
+func TestRunKimiPreToolUseGortexReadPlainStdout(t *testing.T) {
+	withForceCompress(t, true)
+	cwd := writeGortexProjectMarker(t, t.TempDir())
+	tests := []struct {
+		name string
+		tool string
+	}{
+		{
+			name: "kimi plain read_file",
+			tool: "read_file",
+		},
+		{
+			name: "kimi plain get_editing_context",
+			tool: "get_editing_context",
+		},
+		{
+			name: "prefixed read_file",
+			tool: gortexReadFileTool,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := captureStdout(t, func() {
+				runKimi(kimiPreToolPayload(cwd, tt.tool, `{"path":"internal/a.go"}`))
+			})
+			if out == "" {
+				t.Fatal("expected Kimi MCP read PreToolUse guidance, got empty output")
+			}
+			for _, want := range []string{"compress_bodies", "search_text", "keep"} {
+				if !strings.Contains(out, want) {
+					t.Fatalf("stdout guidance missing %q: %q", want, out)
+				}
+			}
+			for _, notWant := range []string{"hookSpecificOutput", "additionalContext", "permissionDecision"} {
+				if strings.Contains(out, notWant) {
+					t.Fatalf("Kimi PreToolUse nudge must stay plain stdout, got %q", out)
+				}
+			}
+		})
+	}
+}
+
+func TestRunKimiPreToolUseGortexReadSilentShapes(t *testing.T) {
+	withForceCompress(t, false)
+	cwd := writeGortexProjectMarker(t, t.TempDir())
+	tests := []struct {
+		name  string
+		cwd   string
+		tool  string
+		input string
+	}{
+		{
+			name:  "compressed",
+			cwd:   cwd,
+			tool:  "read_file",
+			input: `{"path":"internal/a.go","compress_bodies":true}`,
+		},
+		{
+			name:  "capped",
+			cwd:   cwd,
+			tool:  "read_file",
+			input: `{"path":"internal/a.go","max_lines":80}`,
+		},
+		{
+			name:  "non-source file",
+			cwd:   cwd,
+			tool:  "read_file",
+			input: `{"path":"README.md"}`,
+		},
+		{
+			name:  "other tool",
+			cwd:   cwd,
+			tool:  "search_text",
+			input: `{"query":"Foo"}`,
+		},
+		{
+			name:  "outside project",
+			cwd:   t.TempDir(),
+			tool:  "read_file",
+			input: `{"path":"internal/a.go"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := captureStdout(t, func() {
+				runKimi(kimiPreToolPayload(tt.cwd, tt.tool, tt.input))
+			})
+			if out != "" {
+				t.Fatalf("expected silent no-op, got %q", out)
+			}
+		})
+	}
+}
+
 func TestRunKimiNoopShapes(t *testing.T) {
 	cwd := writeGortexProjectMarker(t, t.TempDir())
 	restore := stubUserPromptProbe(t, nil, errors.New("should not be called"))
@@ -110,6 +206,10 @@ func TestKimiGortexEnabledProjectMarkers(t *testing.T) {
 
 func kimiPromptPayload(cwd, prompt string) []byte {
 	return []byte(`{"hook_event_name":"UserPromptSubmit","cwd":` + strconv.Quote(cwd) + `,"prompt":` + strconv.Quote(prompt) + `}`)
+}
+
+func kimiPreToolPayload(cwd, toolName, input string) []byte {
+	return []byte(`{"hook_event_name":"PreToolUse","cwd":` + strconv.Quote(cwd) + `,"tool_name":` + strconv.Quote(toolName) + `,"tool_input":` + input + `}`)
 }
 
 func writeGortexProjectMarker(t *testing.T, dir string) string {


### PR DESCRIPTION
## Summary

- Add Kimi `PreToolUse` hook installation for `gortex install --agents=kimi`.
- Reuse the existing Gortex MCP read-tool nudge for Kimi read-style MCP calls.
- Emit plain stdout guidance when a Kimi `PreToolUse` payload is about to call `read_file` or `get_editing_context` without `compress_bodies`.
- Keep Kimi advisory-only: no deny, no `permissionDecision`, no input rewrite, and no output suppression.
- Preserve existing `UserPromptSubmit` behavior.

## Design notes

- Kimi consumes hook stdout as contextual guidance, so this dispatcher emits plain text rather than Claude-style `hookSpecificOutput.additionalContext` JSON.
- The Kimi `PreToolUse` hook intentionally does not set `matcher`: Kimi documents matcher as optional, and current Kimi MCP tools are exposed as their underlying tool names without a stable server namespace.
- The dispatcher performs the narrow filtering instead and silently ignores unrelated tools.
- The nudge is pure local logic based on `tool_name` and `tool_input`; it does not call the daemon or query the graph.
- The user-level Kimi hook still no-ops outside Gortex-enabled projects before doing any advisory work.
- This PR handles both likely Kimi MCP tool names (`read_file`, `get_editing_context`) and the existing Gortex-prefixed names used by other integrations.
- Existing Claude, Codex, Gemini, and Antigravity behavior remains unchanged.

## Out of scope

- `PostToolUse` passive observation
- `Stop`
- subagent hooks
- deny / enforcement behavior
- permission decisions
- tool input rewrite
- output suppression
- resolver / indexer / daemon / graph / MCP tool changes

## Tests

- `go test ./internal/agents/kimi -count=1 -timeout=120s`
- `go test ./internal/hooks -count=1 -timeout=180s`
- `go test ./cmd/gortex -count=1 -timeout=300s`
- `go test ./internal/agents/... -count=1 -timeout=180s`
- `git diff --check -- internal/agents/kimi/adapter.go internal/agents/kimi/adapter_test.go internal/hooks/kimi.go internal/hooks/kimi_test.go`
- Added coverage for Kimi `PreToolUse` hook installation, plain stdout read-tool nudges, compressed/capped/non-source silent paths, unrelated tool silent paths, and project-outside no-op behavior.