### PR TITLE
feat(rust): infer let types from Self-returning associated constructors

### DIFF
--- a/internal/parser/languages/rust.go
+++ b/internal/parser/languages/rust.go
@@ -1338,15 +1338,62 @@ func lookupRustRecvType(paramsByFunc map[string]map[string]string, tenv typeEnv,
 	return t, ok
 }
 
+// rustConcreteTypeName reports whether name can seed the local type
+// environment from an associated-constructor qualifier as a resolvable,
+// concrete type. It must be UpperCamelCase and name a real type, so a single
+// uppercase letter (a generic parameter such as T/E/K, which owns no methods
+// in the graph) and the `Self` placeholder (which names no node) are both
+// rejected. A struct literal cannot name a generic parameter and so is guarded
+// more loosely above; only here — the qualifier of a `T::ctor()` call — may a
+// bare single letter really be a generic parameter, so the single-letter form
+// is refused to keep an inferred receiver from ever pointing at a non-type.
+func rustConcreteTypeName(name string) bool {
+	if len(name) < 2 || name == "Self" {
+		return false
+	}
+	return name[0] >= 'A' && name[0] <= 'Z'
+}
+
+// rustSelfReturningCtor reports whether an associated-function name is one of
+// the conventional constructors that yields a value of the type it hangs off.
+// Binding a let's inferred type to that qualifier is safe because idiomatic
+// Rust reserves these names for constructors that return the owning type itself,
+// unwrapped: `T::from`/`T::default` implement the From / Default traits
+// (`fn(..) -> Self`), and `new`/`with_capacity`/`with_config`/`empty` are the
+// near-universal inherent-constructor convention, each returning `Self`.
+//
+// Only names whose result IS the qualifier type belong here. Constructors that
+// return a *wrapper* around Self are deliberately excluded: `from_str` and
+// `open` yield a `Result<Self>` and `builder` a separate builder struct, so the
+// binding's real type is that wrapper — not the qualifier. The downstream
+// owner-match cannot recover from admitting them: it refuses to bind to a method
+// the qualifier type does NOT own, but a wrapper-returning constructor whose
+// qualifier happens to own a same-named method (a getter shadowing a builder's
+// setter, say) would bind that call to the wrong owner rather than fall through
+// to unresolved. Confining the list to genuinely Self-returning names is what
+// keeps every seeded receiver pointing at the value actually in hand.
+func rustSelfReturningCtor(method string) bool {
+	switch method {
+	case "new", "default", "from", "with_capacity", "with_config", "empty":
+		return true
+	}
+	return false
+}
+
 // inferTypeFromRustExpr inspects a tree-sitter expression node to infer
 // the type of a let declaration's RHS.
 func inferTypeFromRustExpr(node *sitter.Node, src []byte) string {
 	switch node.Type() {
 	case "struct_expression":
-		// Config { port: 8080 } — first named child is the type name.
+		// Config { port: 8080 } — first named child is the type name. The
+		// literal constructs a value of exactly that type, so a selector call
+		// on the binding resolves against it. A struct literal can never name a
+		// generic parameter (Rust forbids `T { .. }`), so even a single-letter
+		// UpperCamelCase name is a concrete type here and is trusted — the
+		// single-letter rejection only guards the associated-call arm below,
+		// where the qualifier may instead be a generic parameter.
 		if node.NamedChildCount() > 0 {
-			typeNode := node.NamedChild(0)
-			name := typeNode.Content(src)
+			name := node.NamedChild(0).Content(src)
 			// Strip module path.
 			if idx := strings.LastIndex(name, "::"); idx >= 0 {
 				name = name[idx+2:]
@@ -1357,20 +1404,27 @@ func inferTypeFromRustExpr(node *sitter.Node, src []byte) string {
 		}
 
 	case "call_expression":
-		// Type::new() — scoped_identifier with path containing ::new
+		// Type::<ctor>(..) — a scoped associated call whose qualifier names the
+		// constructed type. Only the conventional Self-returning constructors are
+		// trusted, and the qualifier must be a bare concrete type name, so the
+		// seeded binding can only point at the value the constructor produces —
+		// never at a lowercase module function, `Self`, or a generic parameter.
 		if node.NamedChildCount() > 0 {
 			funcNode := node.NamedChild(0)
 			if funcNode.Type() == "scoped_identifier" {
 				funcText := funcNode.Content(src)
-				// e.g. "Config::new" or "module::Config::new"
-				if strings.HasSuffix(funcText, "::new") {
-					typePart := strings.TrimSuffix(funcText, "::new")
-					// Take last segment.
-					if idx := strings.LastIndex(typePart, "::"); idx >= 0 {
-						typePart = typePart[idx+2:]
-					}
-					if len(typePart) > 0 && typePart[0] >= 'A' && typePart[0] <= 'Z' {
-						return typePart
+				// e.g. "Config::from" or "module::Config::with_capacity".
+				if idx := strings.LastIndex(funcText, "::"); idx > 0 {
+					method := funcText[idx+2:]
+					if rustSelfReturningCtor(method) {
+						typePart := funcText[:idx]
+						// Take last path segment as the type name.
+						if j := strings.LastIndex(typePart, "::"); j >= 0 {
+							typePart = typePart[j+2:]
+						}
+						if rustConcreteTypeName(typePart) {
+							return typePart
+						}
 					}
 				}
 			}

--- a/internal/parser/languages/rust_recvtype_test.go
+++ b/internal/parser/languages/rust_recvtype_test.go
@@ -47,6 +47,58 @@ impl Foo {
 	assert.Equal(t, "Foo", recvTypeOfCall(result.Edges, "foo.rs::Foo.a"))
 }
 
+// recvTypeForMethod returns the receiver_type stamped on the selector-call
+// edge from `from` whose method is `method` (To == "unresolved::*.<method>"),
+// so a test can assert the inferred type for one specific call among several.
+func recvTypeForMethod(edges []*graph.Edge, from, method string) (string, bool) {
+	for _, ed := range edges {
+		if ed.Kind == graph.EdgeCalls && ed.From == from && ed.To == "unresolved::*."+method {
+			rt, _ := ed.Meta["receiver_type"].(string)
+			return rt, true
+		}
+	}
+	return "", false
+}
+
+// A let bound to a Self-returning associated constructor (default/with_capacity
+// /from) seeds the local's type, so a later selector call on it stamps
+// receiver_type for the resolver. A lowercase module function and a
+// single-letter generic qualifier must NOT seed a type — the constructor
+// returns a value of an unknown concrete type there, so guessing would risk a
+// wrong-owner bind.
+func TestRsExtractor_ConstructorReceiverType(t *testing.T) {
+	src := []byte(`
+struct Config {}
+struct Buf {}
+struct Matcher {}
+fn run() {
+    let c = Config::default();
+    c.tune();
+    let b = Buf::with_capacity(8);
+    b.push(1);
+    let m = Matcher::from(pattern);
+    m.find();
+    let g = thing::from(x);
+    g.walk();
+    let t = T::from(x);
+    t.step();
+}
+`)
+	e := NewRustExtractor()
+	result, err := e.Extract("main.rs", src)
+	require.NoError(t, err)
+
+	got := func(method string) string {
+		rt, _ := recvTypeForMethod(result.Edges, "main.rs::run", method)
+		return rt
+	}
+	assert.Equal(t, "Config", got("tune"), "Config::default() should seed tenv[c]=Config")
+	assert.Equal(t, "Buf", got("push"), "Buf::with_capacity() should seed tenv[b]=Buf")
+	assert.Equal(t, "Matcher", got("find"), "Matcher::from() should seed tenv[m]=Matcher")
+	assert.Equal(t, "", got("walk"), "lowercase module qualifier must not seed a type")
+	assert.Equal(t, "", got("step"), "single-letter generic qualifier must not seed a type")
+}
+
 // A parameter shadows a same-named file-wide let binding at call resolution.
 func TestRsExtractor_ParamShadowsLet(t *testing.T) {
 	src := []byte(`struct A {}

--- a/internal/resolver/rust_scope_test.go
+++ b/internal/resolver/rust_scope_test.go
@@ -210,6 +210,41 @@ fn run() {
 	}
 }
 
+// TestRustScope_ConstructorReceiverBind: a `let c = Config::default()` local
+// seeds tenv[c]=Config in the extractor, so the selector call `c.tune()` binds
+// to Config.tune end to end through the receiver_type path. A same-named method
+// on a different type must NOT be picked — the inferred owner is exact.
+func TestRustScope_ConstructorReceiverBind(t *testing.T) {
+	src := `
+struct Config {}
+
+impl Config {
+    fn default() -> Config { Config {} }
+    fn tune(&self) {}
+}
+
+struct Other {}
+
+impl Other {
+    fn tune(&self) {}
+}
+
+fn run() {
+    let c = Config::default();
+    c.tune();
+}
+`
+	g := buildRustGraph(t, map[string]string{"lib.rs": src})
+
+	ResolveRustScopeCalls(g)
+
+	targets := callTargetsFromRust(g, "lib.rs::run")
+	require.Contains(t, targets, "lib.rs::Config.tune",
+		"c.tune() where c = Config::default() should bind to Config.tune, got %v", targets)
+	require.NotContains(t, targets, "lib.rs::Other.tune",
+		"the same-named method on Other must not be picked")
+}
+
 // TestRustScope_Idempotent: a second run does not change the resolved
 // state nor produce additional rebindings.
 func TestRustScope_Idempotent(t *testing.T) {


### PR DESCRIPTION
## What

Extends the Rust extractor's local type environment: a `let x = Type::new(..)` already seeded `x`'s type so a later `x.method()` selector call resolves against `Type`. This generalizes that seeding to the other conventional value constructors idiomatic Rust reserves for returning the owning type — `from`, `default`, `with_capacity`, `with_config`, `empty` — so `let x = Matcher::from(cfg); x.find()` binds `find` to `Matcher::find`.

Precision is preserved by two guards: (1) the inferred name must be a bare UpperCamelCase type, so a lowercase module function, `Self`, or a single-letter generic parameter is never seeded; (2) the resolver still refuses to bind unless that type genuinely owns the called method, so a misfit inference falls through to unresolved rather than to a wrong owner. Wrapper-returning constructors are deliberately excluded — `from_str`/`open` yield `Result<Self>` and `builder` a distinct struct, so their binding's real type is the wrapper, not the qualifier (admitting them was a latent wrong-owner risk this PR also removes).

## Measured impact — honest

On ripgrep (native resolution, rust-analyzer off), this produces **zero change** in resolved-vs-unresolved edges: ripgrep's residual ambiguous method calls are dominated by common names (`push`/`len`/`map`/`is_empty`) on **standard-library** receiver types (`Vec`/`String`/`Option`/`&[u8]`) whose owner types aren't graph nodes, so no amount of native qualifier/receiver inference can bind them — that is inherently language-server territory. This change is a **correctness/completeness improvement to the extractor** (it infers more local types, and fixes the wrapper-constructor precision hole) that helps codebases with richer internal polymorphism than ripgrep; it is not expected to move recall on std-heavy repos.

## Tests

- Extractor tests: `Config::default()` / `Buf::with_capacity()` / `Matcher::from()` seed the local type; `thing::from` (lowercase) and `T::from` (generic) do not.
- Resolver test: end-to-end bind of a constructor-bound local's method to the correct owner, refusing a same-named method on another type.
- `go build`, `go test -race ./internal/parser/... ./internal/resolver/...`, `golangci-lint` all green.
