### PR TITLE
feat(lsp): default rust-analyzer to the full enrichment sweep

### DIFF
--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -225,7 +225,14 @@ Resolution precedence, highest first:
    it where you launch `gortex daemon` / `gortex server` to dial one run without
    editing config.
 2. The `.gortex.yaml` key `semantic.lsp_sweep` (same values).
-3. The `demand` default.
+3. A per-server default. Most servers have none and fall through to the global
+   default; **rust-analyzer defaults to `full`**. Rust method calls bind
+   overwhelmingly to standard-library receiver types the graph never indexes, so
+   static confirmation leaves rust-analyzer's net-new call-hierarchy edges on the
+   table — its recall lives in the full sweep. Either operator source above
+   overrides it, so `semantic.lsp_sweep: demand` (or the env) puts rust-analyzer
+   back on the demand gate.
+4. The `demand` default.
 
 An unrecognised value at any level is ignored and the next source applies.
 

--- a/internal/semantic/lsp/registry.go
+++ b/internal/semantic/lsp/registry.go
@@ -89,6 +89,16 @@ type ServerSpec struct {
 	// degrades to reference confirmation: it skips the sweep and header
 	// files and warns with the remediation.
 	NeedsCompileDB bool
+	// DefaultSweepMode overrides the global demand-gated default of the
+	// per-file hover / call-hierarchy sweep for this server. Empty keeps
+	// the "demand" default; "full" makes the server sweep every file
+	// unless the operator sets an explicit sweep mode (config or the
+	// GORTEX_LSP_SWEEP env), both of which still win. Set for a server
+	// whose net-new edges come mostly from call hierarchy the demand gate
+	// skips — rust-analyzer, whose ambiguous receivers resolve through
+	// std-library types the graph never indexes, so its recall lives in
+	// the full sweep rather than in cheaper static confirmation.
+	DefaultSweepMode string
 }
 
 // ConnectSpec carries the transport coordinates for passive LSP attach
@@ -337,6 +347,12 @@ var Servers = []ServerSpec{
 		Priority:    5,
 		Daemon:      true,
 		MaxParallel: 8,
+		// Rust method calls bind overwhelmingly to standard-library
+		// receiver types the graph never indexes, so static confirmation
+		// leaves rust-analyzer's net-new call-hierarchy edges on the table;
+		// its recall lives in the full sweep. Default to it (operator config
+		// / GORTEX_LSP_SWEEP still override).
+		DefaultSweepMode: sweepModeFull,
 	},
 	{
 		Name:    "clangd",

--- a/internal/semantic/lsp/sweep.go
+++ b/internal/semantic/lsp/sweep.go
@@ -59,23 +59,35 @@ func normalizeSweepMode(v string) string {
 }
 
 // resolveSweepMode picks the effective per-file sweep mode by precedence:
-// the GORTEX_LSP_SWEEP env override wins over the configured value, which
-// wins over the demand-gated default. An unrecognised value at any level
-// is ignored (falls through) rather than failing the pass.
-func resolveSweepMode(configured string) string {
+// the GORTEX_LSP_SWEEP env override wins over the operator-configured value,
+// which wins over the per-server spec default, which wins over the global
+// demand-gated default. Only the two operator-set sources (env, config) can
+// override a server's own default, so a server that needs the full sweep
+// gets it out of the box while an operator retains the last word. An
+// unrecognised value at any level is ignored (falls through) rather than
+// failing the pass.
+func resolveSweepMode(configured, specDefault string) string {
 	if env := normalizeSweepMode(os.Getenv(SweepEnv)); env != "" {
 		return env
 	}
 	if cfg := normalizeSweepMode(configured); cfg != "" {
 		return cfg
 	}
+	if sd := normalizeSweepMode(specDefault); sd != "" {
+		return sd
+	}
 	return sweepModeDemand
 }
 
 // effectiveSweepMode resolves the sweep mode for this provider, honouring
-// the GORTEX_LSP_SWEEP env override over the router-configured field.
+// the GORTEX_LSP_SWEEP env override over the router-configured field over
+// the server spec's own DefaultSweepMode.
 func (p *Provider) effectiveSweepMode() string {
-	return resolveSweepMode(p.sweepMode)
+	specDefault := ""
+	if p.spec != nil {
+		specDefault = p.spec.DefaultSweepMode
+	}
+	return resolveSweepMode(p.sweepMode, specDefault)
 }
 
 // sweepFile reports whether the per-file hover / call-hierarchy sweep should

--- a/internal/semantic/lsp/sweep_test.go
+++ b/internal/semantic/lsp/sweep_test.go
@@ -33,27 +33,46 @@ func TestNormalizeSweepMode(t *testing.T) {
 }
 
 func TestResolveSweepMode_EnvWinsOverConfig(t *testing.T) {
-	// No env, no config → demand default.
+	// No env, no config, no spec default → demand default.
 	t.Setenv(SweepEnv, "")
-	assert.Equal(t, sweepModeDemand, resolveSweepMode(""), "empty env + empty config resolves to the demand default")
+	assert.Equal(t, sweepModeDemand, resolveSweepMode("", ""), "empty env + empty config + empty spec default resolves to the demand default")
 
 	// Config alone is honoured when the env is unset.
-	assert.Equal(t, sweepModeFull, resolveSweepMode("full"), "configured value is used when env is unset")
-	assert.Equal(t, sweepModeOff, resolveSweepMode("off"))
+	assert.Equal(t, sweepModeFull, resolveSweepMode("full", ""), "configured value is used when env is unset")
+	assert.Equal(t, sweepModeOff, resolveSweepMode("off", ""))
 
 	// An unrecognised config value falls back to the default rather than failing.
-	assert.Equal(t, sweepModeDemand, resolveSweepMode("bogus"))
+	assert.Equal(t, sweepModeDemand, resolveSweepMode("bogus", ""))
 
 	// Env wins over config in both directions.
 	t.Setenv(SweepEnv, "full")
-	assert.Equal(t, sweepModeFull, resolveSweepMode("off"), "env override must win over a configured off")
+	assert.Equal(t, sweepModeFull, resolveSweepMode("off", ""), "env override must win over a configured off")
 	t.Setenv(SweepEnv, "off")
-	assert.Equal(t, sweepModeOff, resolveSweepMode("full"), "env override must win over a configured full")
+	assert.Equal(t, sweepModeOff, resolveSweepMode("full", ""), "env override must win over a configured full")
 
 	// An unrecognised env value is ignored — config (then default) takes over.
 	t.Setenv(SweepEnv, "garbage")
-	assert.Equal(t, sweepModeFull, resolveSweepMode("full"), "an unrecognised env value falls through to config")
-	assert.Equal(t, sweepModeDemand, resolveSweepMode(""), "an unrecognised env value with no config falls through to the default")
+	assert.Equal(t, sweepModeFull, resolveSweepMode("full", ""), "an unrecognised env value falls through to config")
+	assert.Equal(t, sweepModeDemand, resolveSweepMode("", ""), "an unrecognised env value with no config falls through to the default")
+}
+
+func TestResolveSweepMode_SpecDefault(t *testing.T) {
+	t.Setenv(SweepEnv, "")
+
+	// A spec default is used when neither env nor config is set.
+	assert.Equal(t, sweepModeFull, resolveSweepMode("", sweepModeFull), "spec default is used when env + config are unset")
+
+	// Operator config outranks the spec default in both directions.
+	assert.Equal(t, sweepModeDemand, resolveSweepMode("demand", sweepModeFull), "configured value wins over a full spec default")
+	assert.Equal(t, sweepModeOff, resolveSweepMode("off", sweepModeFull), "configured off wins over a full spec default")
+
+	// The env override outranks both config and the spec default.
+	t.Setenv(SweepEnv, "demand")
+	assert.Equal(t, sweepModeDemand, resolveSweepMode("", sweepModeFull), "env wins over a full spec default")
+
+	// An unrecognised spec default is ignored — falls through to the demand default.
+	t.Setenv(SweepEnv, "")
+	assert.Equal(t, sweepModeDemand, resolveSweepMode("", "bogus"), "an unrecognised spec default falls through to the demand default")
 }
 
 func TestSweepFile(t *testing.T) {
@@ -101,6 +120,21 @@ func TestEffectiveSweepMode(t *testing.T) {
 	empty := &Provider{}
 	t.Setenv(SweepEnv, "")
 	assert.Equal(t, sweepModeDemand, empty.effectiveSweepMode(), "an unset field and unset env resolve to the demand default")
+
+	// A server spec's DefaultSweepMode is honoured when neither env nor the
+	// router field is set — and both still override it.
+	specFull := &Provider{spec: &ServerSpec{DefaultSweepMode: sweepModeFull}}
+	assert.Equal(t, sweepModeFull, specFull.effectiveSweepMode(), "the spec default is used when env + field are unset")
+	specWithField := &Provider{sweepMode: "demand", spec: &ServerSpec{DefaultSweepMode: sweepModeFull}}
+	assert.Equal(t, sweepModeDemand, specWithField.effectiveSweepMode(), "the router-configured field wins over the spec default")
+	t.Setenv(SweepEnv, "off")
+	assert.Equal(t, sweepModeOff, specFull.effectiveSweepMode(), "the env override wins over the spec default")
+
+	// The rust-analyzer registry spec ships a full-sweep default.
+	t.Setenv(SweepEnv, "")
+	ra := &Provider{spec: SpecByName("rust-analyzer")}
+	require.NotNil(t, ra.spec)
+	assert.Equal(t, sweepModeFull, ra.effectiveSweepMode(), "rust-analyzer defaults to the full sweep out of the box")
 }
 
 // enrichCapturingResult runs a full enrichment pass and returns its result,


### PR DESCRIPTION
## What

Adds a per-server `DefaultSweepMode` to `ServerSpec` and sets it to `full` for **rust-analyzer**, so Rust gets the full enrichment sweep out of the box while every other language keeps the demand-gated default.

New sweep-mode precedence (highest first): `GORTEX_LSP_SWEEP` env → `semantic.lsp_sweep` config → **per-server spec default** → global `demand`. Both operator sources still win, so `semantic.lsp_sweep: demand` (or the env) puts rust-analyzer back on the demand gate.

## Why

The demand gate skips a file whose declarations are already statically resolved, on the premise that its call edges are recoverable without the language server. That premise holds for Go / TS / Python but not Rust: measured on ripgrep, Rust's method calls bind overwhelmingly to standard-library receiver types (`Vec`/`String`/`Option`/`&[u8]`) that the graph never indexes, so static resolution can't recover them and rust-analyzer's net-new call-hierarchy edges come precisely from the sweep the demand gate skips.

Concretely, across a language matrix (baseline vs demand vs full):
- Go / TS / Python: demand mode trims a negligible-to-small share of net-new edges (−3% / −2% / −10%) for a 1.5–2.4× enrichment speedup — demand is the right default.
- **Rust: demand mode trims ~23% of rust-analyzer's net-new call edges while saving only ~5% wall time** (rust-analyzer's cost is dominated by reference/hover volume the gate doesn't reduce, not the incoming calls it gates). So Rust pays the most recall for the least speed under demand — `full` is the better default.

A separate investigation confirmed this gap is not closable by improving Gortex's native Rust resolution: the residual ambiguity is standard-library-shaped, which is inherently language-server territory. So defaulting rust-analyzer to `full` is the right lever.

## Tests

- `resolveSweepMode` precedence including the new spec-default level (env > config > spec default > demand); unrecognised spec default falls through.
- `effectiveSweepMode`: a spec `DefaultSweepMode` is honoured, the router field and env both override it, and the real rust-analyzer registry spec resolves to `full`.
- `go build`, `go test -race ./internal/semantic/lsp/`, `golangci-lint` all green. `docs/lsp.md` updated with the new precedence and rust-analyzer note.
