### PR TITLE
fix(watcher): treat an external file replace as a modify, not a delete

### DIFF
--- a/internal/indexer/external_revert_reindex_test.go
+++ b/internal/indexer/external_revert_reindex_test.go
@@ -1,0 +1,162 @@
+package indexer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/search"
+)
+
+// setupRevertWatcher indexes a two-file Go repo where caller.go::Use calls
+// debug.go::IsDebugging across files, stamps that resolved caller edge
+// lsp_resolved (the tier the semantic-enrichment pass mints once), and returns
+// the watcher driving the live patch path plus the definition-file path and its
+// stable node ID.
+//
+// It mirrors the external staleness probe: a definition with a cross-file
+// caller, fully resolved before any live edit arrives.
+func setupRevertWatcher(t *testing.T) (w *Watcher, g graph.Store, defPath, defID string) {
+	t.Helper()
+	dir := t.TempDir()
+	defPath = filepath.Join(dir, "debug.go")
+	callerPath := filepath.Join(dir, "caller.go")
+	writeFile(t, defPath, "package p\n\nfunc IsDebugging() {}\n")
+	writeFile(t, callerPath, "package p\n\nfunc Use() { IsDebugging() }\n")
+
+	g = newSqliteGraph(t)
+	idx := New(g, newTestRegistry(), config.IndexConfig{Workers: 1}, zap.NewNop())
+	idx.search = search.NewBM25()
+	idx.SetRootPath(dir)
+	_, err := idx.IndexCtx(testCtx(), dir)
+	require.NoError(t, err)
+
+	defID = fnNodeID(t, g, "debug.go", "IsDebugging")
+	useID := fnNodeID(t, g, "caller.go", "Use")
+	require.Equal(t, defID, callTargetFrom(t, g, useID),
+		"cross-file caller must resolve to the definition before the revert")
+	stampLSP(t, g, callEdgeFrom(t, g, useID))
+
+	w, err = NewWatcher(idx, config.WatchConfig{Enabled: true, DebounceMs: 10}, zap.NewNop())
+	require.NoError(t, err)
+	return w, g, defPath, defID
+}
+
+// assertCrossFileCallerHealthy asserts the definition node still resolves and
+// its single surviving incoming caller edge (caller.go::Use) is bound to it
+// with its lsp tier intact — i.e. find_usages on the definition would return
+// the cross-file caller, not a silent zero.
+func assertCrossFileCallerHealthy(t *testing.T, g graph.Store, defID string) {
+	t.Helper()
+	require.NotNilf(t, g.GetNode(defID),
+		"definition node %s must still resolve after the external revert", defID)
+	incoming := incomingCallEdges(t, g, defID)
+	require.Lenf(t, incoming, 1,
+		"the cross-file caller edge must be restored, not stubbed/dropped (got %d incoming call edges)", len(incoming))
+	assert.Falsef(t, graph.IsUnresolvedTarget(incoming[0].To),
+		"restored incoming caller edge must not be a stub")
+	assert.Equalf(t, defID, incoming[0].To,
+		"restored incoming caller edge must resolve back to the definition")
+	assert.Equalf(t, graph.OriginLSPResolved, incoming[0].Origin,
+		"restored incoming caller edge must keep its lsp tier (a demotion reads as a find_usages zero)")
+}
+
+// TestPatchGraph_ExternalAdd_InPlaceWrite_KeepsCrossFileCaller locks in the
+// external-ADD path (an in-place open(truncate)+write that keeps the inode):
+// the watcher classifies it as ChangeModified, and the parse-then-swap +
+// incoming re-resolve must keep the cross-file caller edge resolved while
+// adding the new probe call site. This must not regress.
+func TestPatchGraph_ExternalAdd_InPlaceWrite_KeepsCrossFileCaller(t *testing.T) {
+	w, g, defPath, defID := setupRevertWatcher(t)
+
+	// In-place truncate+write: append a compilable probe that also calls
+	// the definition. Same inode; the watcher sees a bare modify.
+	writeFile(t, defPath, "package p\n\nfunc IsDebugging() {}\n\nfunc _probe() { IsDebugging() }\n")
+	w.patchGraph(defPath, ChangeModified)
+
+	require.NotNil(t, g.GetNode(defID), "IsDebugging survives the in-place ADD")
+	// Two callers now: cross-file Use and intra-file _probe.
+	require.Len(t, incomingCallEdges(t, g, defID), 2,
+		"both the cross-file and the new intra-file caller must resolve after the ADD")
+	// The cross-file caller specifically must keep its lsp tier.
+	useID := fnNodeID(t, g, "caller.go", "Use")
+	useEdge := callEdgeFrom(t, g, useID)
+	assert.False(t, graph.IsUnresolvedTarget(useEdge.To), "cross-file caller stays resolved after ADD")
+	assert.Equal(t, graph.OriginLSPResolved, useEdge.Origin, "cross-file caller keeps its lsp tier after ADD")
+}
+
+// TestPatchGraph_ExternalRevert_RenameOver_KeepsCrossFileCaller reproduces the
+// git-checkout revert shape: git writes a sibling temp file and os.Renames it
+// over the target, so the worktree file gets a NEW inode. FSEvents accumulates
+// ItemRemoved|ItemCreated|ItemModified flags for the path, and pickKind — which
+// ranks Remove/Rename above Modify — reduces that to ChangeDeleted. So the live
+// watcher delivers patchGraph(path, ChangeDeleted) even though a file is right
+// back at the same path. Pre-fix that hard-evicts the definition and stubs its
+// cross-file callers with nothing to rebind them: find_usages goes silently to
+// zero. The file's on-disk presence at patch time must reclassify this as a
+// modify so the definition and its callers are restored.
+func TestPatchGraph_ExternalRevert_RenameOver_KeepsCrossFileCaller(t *testing.T) {
+	w, g, defPath, defID := setupRevertWatcher(t)
+	dir := filepath.Dir(defPath)
+
+	// ADD first (in-place), so the revert has something to undo.
+	writeFile(t, defPath, "package p\n\nfunc IsDebugging() {}\n\nfunc _probe() { IsDebugging() }\n")
+	w.patchGraph(defPath, ChangeModified)
+	require.Len(t, incomingCallEdges(t, g, defID), 2, "sanity: two callers after ADD")
+
+	// REVERT via rename-over: new inode, file present at the same path.
+	tmp := filepath.Join(dir, "debug.go.tmp")
+	writeFile(t, tmp, "package p\n\nfunc IsDebugging() {}\n")
+	require.NoError(t, os.Rename(tmp, defPath))
+	w.patchGraph(defPath, ChangeDeleted)
+
+	// The probe caller is gone with the revert; the cross-file caller must
+	// survive with its lsp tier.
+	assertCrossFileCallerHealthy(t, g, defID)
+}
+
+// TestPatchGraph_ExternalRevert_UnlinkRecreate_KeepsCrossFileCaller is the
+// unlink+recreate variant of the same revert: git removes the worktree file
+// and writes a fresh one at the same path (also a new inode). FSEvents shows
+// ItemRemoved|ItemRenamed|ItemCreated; pickKind may reduce it to
+// ChangeRenamed. The live watcher then delivers patchGraph(path, ChangeRenamed)
+// for a path that exists on disk. Same requirement: reclassify as a modify and
+// restore the definition + its cross-file callers.
+func TestPatchGraph_ExternalRevert_UnlinkRecreate_KeepsCrossFileCaller(t *testing.T) {
+	w, g, defPath, defID := setupRevertWatcher(t)
+
+	// ADD first (in-place).
+	writeFile(t, defPath, "package p\n\nfunc IsDebugging() {}\n\nfunc _probe() { IsDebugging() }\n")
+	w.patchGraph(defPath, ChangeModified)
+	require.Len(t, incomingCallEdges(t, g, defID), 2, "sanity: two callers after ADD")
+
+	// REVERT via unlink + recreate.
+	require.NoError(t, os.Remove(defPath))
+	writeFile(t, defPath, "package p\n\nfunc IsDebugging() {}\n")
+	w.patchGraph(defPath, ChangeRenamed)
+
+	assertCrossFileCallerHealthy(t, g, defID)
+}
+
+// TestPatchGraph_TrueDelete_StillEvicts guards the reconciliation: a genuine
+// deletion (the file is gone from disk) must still evict the definition and
+// drop its incoming callers to stubs. The disk-existence check must not turn a
+// real delete into a no-op modify.
+func TestPatchGraph_TrueDelete_StillEvicts(t *testing.T) {
+	w, g, defPath, defID := setupRevertWatcher(t)
+
+	require.NoError(t, os.Remove(defPath))
+	w.patchGraph(defPath, ChangeDeleted)
+
+	assert.Nil(t, g.GetNode(defID), "a genuine delete must evict the definition")
+	for _, e := range incomingCallEdges(t, g, defID) {
+		assert.True(t, graph.IsUnresolvedTarget(e.To),
+			"a genuine delete must leave its former callers on unresolved stubs")
+	}
+}

--- a/internal/indexer/watcher.go
+++ b/internal/indexer/watcher.go
@@ -927,6 +927,9 @@ func (w *Watcher) drainStorm() {
 // / index dispatch, but without per-file resolver work. The caller is
 // responsible for running indexer.ResolveAll() after the batch.
 func (w *Watcher) patchGraphNoResolve(path string, kind ChangeKind) {
+	// Same disk-truth reconciliation as patchGraph: a storm-batched
+	// replace must not be evicted as a delete when the file is present.
+	kind = w.reconcileKindWithDisk(path, kind)
 	switch kind {
 	case ChangeCreated, ChangeModified:
 		if err := w.indexer.IndexFileNoResolve(path); err != nil {
@@ -938,9 +941,44 @@ func (w *Watcher) patchGraphNoResolve(path string, kind ChangeKind) {
 	}
 }
 
+// reconcileKindWithDisk corrects an event kind against the file's actual
+// on-disk state at patch time. FSEvents accumulates flags per path, so an
+// atomic replace — git checkout writing a temp file and renaming it over the
+// target, or an unlink + recreate — surfaces with ItemRemoved / ItemRenamed
+// set even though a file is right back at the same path with a new inode.
+// pickKind ranks Remove and Rename above Modify, so it classifies that replace
+// as a deletion; the delete branch then EvictFiles the definition and stubs
+// its cross-file callers with nothing to rebind them, and find_usages goes
+// silently to zero. By the time the debounced patch runs the filesystem has
+// settled, so the path's existence is authoritative: a delete/rename whose
+// path is still a regular file is really a modify (re-parse + rebind incoming
+// refs), and a create/modify whose path has vanished is really a delete. An
+// in-place write (same inode) is already a bare Modify, so it is unaffected.
+func (w *Watcher) reconcileKindWithDisk(path string, kind ChangeKind) ChangeKind {
+	info, err := os.Stat(path)
+	exists := err == nil && info.Mode().IsRegular()
+	switch kind {
+	case ChangeDeleted, ChangeRenamed:
+		if exists {
+			return ChangeModified
+		}
+	case ChangeCreated, ChangeModified:
+		if !exists {
+			return ChangeDeleted
+		}
+	}
+	return kind
+}
+
 func (w *Watcher) patchGraph(path string, kind ChangeKind) {
 	w.patchMu.Lock()
 	defer w.patchMu.Unlock()
+	// A replace/revert (rename-over or unlink+recreate) reaches us as a
+	// delete/rename even though a file is right back at the same path;
+	// reconcile against disk so it takes the parse-then-swap + incoming-
+	// rebind modify path instead of a hard evict that would silently zero
+	// the definition's callers. A vanished create/modify becomes a delete.
+	kind = w.reconcileKindWithDisk(path, kind)
 	start := time.Now()
 	var nodesAdded, nodesRemoved, edgesAdded, edgesRemoved int
 


### PR DESCRIPTION
## Problem

A file that is atomically replaced on disk — `git checkout -- <file>` writing a temp file and renaming it over the target, or an unlink+recreate — reaches the fsnotify watcher with the accumulated remove/rename flags set even though a file is right back at the same path with a new inode. `pickKind` ranks remove and rename above modify, so it classified the replace as a deletion. The delete branch then hard-evicted the file's definitions and restubbed their cross-file callers with nothing to rebind them:

- `find_usages` on the reverted symbol collapsed to 0 nodes and 0 edges — a persistent silent zero, including cross-file call sites;
- a persisted store served the wrong answer stably across a warm restart.

An in-place truncate+write (same inode) surfaces as a bare modify and was already handled correctly by the parse-then-swap path — that asymmetry (external ADD fine, external REVERT broken) was the tell. The synchronous `edit_file` path was always correct.

## Fix

`internal/indexer/watcher.go`: new `reconcileKindWithDisk` reconciles the event kind against the file's actual on-disk state at patch time, when the debounce has fired and the filesystem has settled:

- a delete/rename whose path is still a regular file is really a **modify** → takes the parse-then-swap + scoped incoming re-resolve path, restoring the definition and its callers with their resolved tier intact;
- a create/modify whose path has vanished is really a **delete**;
- a genuine deletion still evicts and stubs callers.

Applied to both the debounced patch (`patchGraph`) and the storm-batched patch (`patchGraphNoResolve`). `pickKind` is unchanged.

## Tests

New `internal/indexer/external_revert_reindex_test.go` (real two-file Go repo, sqlite backend, cross-file caller edge stamped `lsp_resolved`, driven through the live patch path):

- `TestPatchGraph_ExternalRevert_RenameOver_KeepsCrossFileCaller` — rename-over replace delivered as a delete; **failed pre-fix**, passes now.
- `TestPatchGraph_ExternalRevert_UnlinkRecreate_KeepsCrossFileCaller` — unlink+recreate delivered as a rename; **failed pre-fix**, passes now.
- `TestPatchGraph_ExternalAdd_InPlaceWrite_KeepsCrossFileCaller` — locks in the working in-place ADD path.
- `TestPatchGraph_TrueDelete_StillEvicts` — a genuine delete still evicts and leaves callers on stubs.

Verification: `go build ./cmd/gortex/` green; `go test -race ./internal/indexer/` 816/816 passing; `golangci-lint run internal/indexer/...` clean.