### PR TITLE
fix(hooks): make Codex hooks effective (PostToolUse socket, alternation-aware Grep, per-turn UserPromptSubmit)

### DIFF
--- a/cmd/gortex/hook.go
+++ b/cmd/gortex/hook.go
@@ -35,8 +35,8 @@ var hookCmd = &cobra.Command{
 			hooks.RunPi(hookPort, hooks.ParseMode(hookMode))
 			return
 		case "codex":
-			// Codex support is intentionally soft-only for now: the adapter
-			// installs Bash PreToolUse/PostToolUse hooks that emit
+			// Codex support is intentionally soft-only: the adapter installs
+			// Bash PreToolUse/PostToolUse plus a UserPromptSubmit hook that emit
 			// additionalContext without ever denying the tool call.
 			hooks.RunCodex(hookPort)
 			return
@@ -62,6 +62,6 @@ func init() {
 	hookCmd.Flags().StringVar(&hookMode, "mode", "deny",
 		"hook posture: 'deny' (redirect Grep/Glob/Read of indexed source), 'enrich' (never deny; PostToolUse appends graph context), 'consult-unlock' (deny fallback reads until the graph is queried once this session), or 'nudge' (soft-deny once per burst of non-symbolic calls)")
 	hookCmd.Flags().StringVar(&hookAgent, "agent", "",
-		"hook wire protocol: empty/'claude' (Claude Code PreToolUse/UserPromptSubmit), 'codex' (Codex Bash PreToolUse/PostToolUse soft context), 'kimi' (Kimi Code CLI UserPromptSubmit/PreToolUse/Stop/SubagentStart; plain-stdout context, permissionDecision deny for indexed reads), 'hermes' (NousResearch hermes-agent pre_tool_call/pre_llm_call), 'pi' (earendil-works/pi extension bridge — normalized PiEvent envelope in, PiDecision out), or 'gemini'/'antigravity' (emits hookSpecificOutput.additionalContext). Default (empty) is the Claude Code format.")
+		"hook wire protocol: empty/'claude' (Claude Code PreToolUse/UserPromptSubmit), 'codex' (Codex Bash PreToolUse/PostToolUse + UserPromptSubmit soft context), 'kimi' (Kimi Code CLI UserPromptSubmit/PreToolUse/Stop/SubagentStart; plain-stdout context, permissionDecision deny for indexed reads), 'hermes' (NousResearch hermes-agent pre_tool_call/pre_llm_call), 'pi' (earendil-works/pi extension bridge — normalized PiEvent envelope in, PiDecision out), or 'gemini'/'antigravity' (emits hookSpecificOutput.additionalContext). Default (empty) is the Claude Code format.")
 	rootCmd.AddCommand(hookCmd)
 }

--- a/internal/agents/codex/adapter.go
+++ b/internal/agents/codex/adapter.go
@@ -156,6 +156,10 @@ func upsertPostToolUseHook(root map[string]any, env agents.Env, opts agents.Appl
 	return upsertCodexHook(root, "PostToolUse", codexHookEntryIsGortexPostToolUse, codexPostToolUseHookEntry(env), opts)
 }
 
+func upsertUserPromptSubmitHook(root map[string]any, env agents.Env, opts agents.ApplyOpts) bool {
+	return upsertCodexHook(root, "UserPromptSubmit", codexHookEntryIsGortexUserPromptSubmit, codexUserPromptSubmitHookEntry(env), opts)
+}
+
 // InstallHooksOnly refreshes the Codex lifecycle hooks in configPath without
 // touching MCP server entries, AGENTS.md, or any other Codex adapter surface.
 func InstallHooksOnly(w io.Writer, configPath string, env agents.Env, opts agents.ApplyOpts) (agents.FileAction, error) {
@@ -175,7 +179,8 @@ func upsertCodexHooks(root map[string]any, env agents.Env, opts agents.ApplyOpts
 	sessionChanged := upsertSessionStartHook(root, opts)
 	preChanged := upsertPreToolUseHook(root, env, opts)
 	postChanged := upsertPostToolUseHook(root, env, opts)
-	return sessionChanged || preChanged || postChanged
+	promptChanged := upsertUserPromptSubmitHook(root, env, opts)
+	return sessionChanged || preChanged || postChanged || promptChanged
 }
 
 func upsertCodexHook(root map[string]any, event string, isGortex func(any) bool, desired map[string]any, opts agents.ApplyOpts) bool {
@@ -323,6 +328,10 @@ func codexHookEntryIsGortexPostToolUse(entry any) bool {
 	return codexHookEntryInvokesCodexHook(entry)
 }
 
+func codexHookEntryIsGortexUserPromptSubmit(entry any) bool {
+	return codexHookEntryInvokesCodexHook(entry)
+}
+
 func codexHookEntryInvokesCodexHook(entry any) bool {
 	group, ok := entry.(map[string]any)
 	if !ok {
@@ -408,6 +417,24 @@ func codexPostToolUseHookEntry(env agents.Env) map[string]any {
 				"command":       codexHookCommand(env),
 				"timeout":       codexHookTimeoutSeconds,
 				"statusMessage": "Loading Gortex Bash output context...",
+			},
+		},
+	}
+}
+
+// codexUserPromptSubmitHookEntry fires on every user turn — Codex's
+// UserPromptSubmit event takes no matcher (it can't filter by tool name), so
+// the entry omits one. The handler probes the graph for symbols relevant to
+// the prompt and injects them as additionalContext, re-surfacing Gortex on
+// every turn instead of relying on the SessionStart orientation to persist.
+func codexUserPromptSubmitHookEntry(env agents.Env) map[string]any {
+	return map[string]any{
+		"hooks": []any{
+			map[string]any{
+				"type":          "command",
+				"command":       codexHookCommand(env),
+				"timeout":       codexHookTimeoutSeconds,
+				"statusMessage": "Surfacing Gortex graph context for your prompt...",
 			},
 		},
 	}

--- a/internal/agents/codex/adapter_test.go
+++ b/internal/agents/codex/adapter_test.go
@@ -173,6 +173,45 @@ func TestCodexInstallsPostToolUseHook(t *testing.T) {
 	}
 }
 
+func TestCodexInstallsUserPromptSubmitHook(t *testing.T) {
+	env := codexGlobalEnv(t)
+	a := New()
+
+	res, err := a.Apply(env, agents.ApplyOpts{})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionCreate: 1})
+
+	cfg := readCodexConfig(t, env)
+	entries := userPromptSubmitEntries(t, cfg)
+	if len(entries) != 1 {
+		t.Fatalf("UserPromptSubmit entries=%d want 1: %#v", len(entries), entries)
+	}
+	entry := entries[0].(map[string]any)
+	// UserPromptSubmit takes no matcher — Codex can't filter it by tool name.
+	if _, hasMatcher := entry["matcher"]; hasMatcher {
+		t.Fatalf("UserPromptSubmit entry should carry no matcher: %#v", entry)
+	}
+	handlers, ok := codexHookList(entry["hooks"])
+	if !ok || len(handlers) != 1 {
+		t.Fatalf("handlers=%#v", entry["hooks"])
+	}
+	handler := handlers[0].(map[string]any)
+	if handler["type"] != "command" {
+		t.Errorf("hook type=%v want command", handler["type"])
+	}
+	if handler["command"] != testCodexHookCommand {
+		t.Errorf("command=%v want %q", handler["command"], testCodexHookCommand)
+	}
+	if handler["timeout"] != int64(codexHookTimeoutSeconds) {
+		t.Errorf("timeout=%v want %d", handler["timeout"], codexHookTimeoutSeconds)
+	}
+	if count := gortexUserPromptSubmitHookCount(t, cfg); count != 1 {
+		t.Fatalf("Gortex UserPromptSubmit hooks=%d want 1", count)
+	}
+}
+
 func TestCodexInstallHooksOnlyCreatesOnlyHooks(t *testing.T) {
 	env := codexGlobalEnv(t)
 	path := codexConfigPath(env)
@@ -618,6 +657,11 @@ func postToolUseEntries(t *testing.T, cfg map[string]any) []any {
 	return hookEntries(t, cfg, "PostToolUse")
 }
 
+func userPromptSubmitEntries(t *testing.T, cfg map[string]any) []any {
+	t.Helper()
+	return hookEntries(t, cfg, "UserPromptSubmit")
+}
+
 func hookEntries(t *testing.T, cfg map[string]any, event string) []any {
 	t.Helper()
 	hooks, ok := cfg["hooks"].(map[string]any)
@@ -671,6 +715,17 @@ func gortexPostToolUseHookCount(t *testing.T, cfg map[string]any) int {
 	count := 0
 	for _, entry := range postToolUseEntries(t, cfg) {
 		if codexHookEntryIsGortexPostToolUse(entry) {
+			count++
+		}
+	}
+	return count
+}
+
+func gortexUserPromptSubmitHookCount(t *testing.T, cfg map[string]any) int {
+	t.Helper()
+	count := 0
+	for _, entry := range userPromptSubmitEntries(t, cfg) {
+		if codexHookEntryIsGortexUserPromptSubmit(entry) {
 			count++
 		}
 	}

--- a/internal/hooks/alternation_test.go
+++ b/internal/hooks/alternation_test.go
@@ -1,0 +1,109 @@
+package hooks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSplitAlternation(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"foo", []string{"foo"}},
+		{"place_edges|location_edge|normalize", []string{"place_edges", "location_edge", "normalize"}},
+		{"a | b | c", []string{"a", "b", "c"}},
+		{"foo|", []string{"foo"}},
+		{"|foo", []string{"foo"}},
+		{`a\|b`, []string{`a\|b`}}, // escaped pipe stays literal → single segment
+		{"||", []string{"||"}},     // degenerate: no usable segments → whole pattern
+	}
+	for _, c := range cases {
+		got := splitAlternation(c.in)
+		if len(got) != len(c.want) {
+			t.Errorf("splitAlternation(%q) = %v, want %v", c.in, got, c.want)
+			continue
+		}
+		for i := range c.want {
+			if got[i] != c.want[i] {
+				t.Errorf("splitAlternation(%q)[%d] = %q, want %q", c.in, i, got[i], c.want[i])
+			}
+		}
+	}
+}
+
+// TestEnrichGrep_Alternation_ProbesEachSegment covers the Codex-style
+// multi-keyword grep pattern: every identifier-shaped alternative is probed
+// and a hit on any of them denies with the aggregated matches.
+func TestEnrichGrep_Alternation_ProbesEachSegment(t *testing.T) {
+	logPath := redirectTelemetry(t)
+	hits := []grepSymbolHit{{Name: "placeEdges", Kind: "function", FilePath: "internal/a.go", Line: 5}}
+	rec := stubProbe(t, hits, nil)
+
+	result := enrichGrep(map[string]any{"pattern": "place_edges|location_edge|normalize"}, 0)
+	if !result.deny {
+		t.Fatalf("alternation with symbol hits should deny, got context=%q", result.context)
+	}
+	if len(rec.calls) != 3 {
+		t.Errorf("expected 3 segment probes, got %v", rec.calls)
+	}
+	recs := readDecisions(t, logPath)
+	if len(recs) != 1 || recs[0].Decision != DecisionProbedHit {
+		t.Fatalf("expected one probed_hit, got %+v", recs)
+	}
+}
+
+// TestEnrichGrep_Alternation_MixedProbesOnlySymbolSegments verifies that only
+// the identifier-shaped alternatives are probed — hyphenated / spaced keywords
+// are skipped.
+func TestEnrichGrep_Alternation_MixedProbesOnlySymbolSegments(t *testing.T) {
+	hits := []grepSymbolHit{{Name: "entity_links", Kind: "type", FilePath: "internal/e.go", Line: 9}}
+	rec := stubProbe(t, hits, nil)
+
+	result := enrichGrep(map[string]any{"pattern": "ai-redesign|entity_links|world-map"}, 0)
+	if !result.deny {
+		t.Fatalf("expected deny when one segment is a real symbol, got %q", result.context)
+	}
+	if len(rec.calls) != 1 || rec.calls[0] != "entity_links" {
+		t.Errorf("expected only the identifier segment probed, got %v", rec.calls)
+	}
+}
+
+// TestEnrichGrep_Alternation_PureTextSkips covers a multi-keyword pattern with
+// no identifier-shaped alternative: it must not probe and must steer the agent
+// toward search_text.
+func TestEnrichGrep_Alternation_PureTextSkips(t *testing.T) {
+	logPath := redirectTelemetry(t)
+	rec := stubProbe(t, nil, nil)
+
+	result := enrichGrep(map[string]any{"pattern": "Phase 5|world-map"}, 0)
+	if result.deny {
+		t.Fatal("pure-text alternation should not deny")
+	}
+	if !strings.Contains(result.context, "search_text") {
+		t.Errorf("guidance should point at search_text: %q", result.context)
+	}
+	if len(rec.calls) != 0 {
+		t.Errorf("pure-text alternation should not probe, got %v", rec.calls)
+	}
+	recs := readDecisions(t, logPath)
+	if len(recs) != 1 || recs[0].Decision != DecisionSkippedNonSymbol {
+		t.Fatalf("expected skipped_non_symbol, got %+v", recs)
+	}
+}
+
+// TestEnrichGrep_Alternation_DaemonUnreachableNoTelemetry checks that a fully
+// unreachable daemon during an alternation probe stays quiet rather than
+// logging a false miss.
+func TestEnrichGrep_Alternation_DaemonUnreachableNoTelemetry(t *testing.T) {
+	logPath := redirectTelemetry(t)
+	stubProbe(t, nil, errDaemonUnreachable)
+
+	result := enrichGrep(map[string]any{"pattern": "foo_a|foo_b"}, 0)
+	if result.deny {
+		t.Fatal("unreachable daemon should not deny")
+	}
+	if recs := readDecisions(t, logPath); len(recs) != 0 {
+		t.Errorf("unreachable daemon (alternation) should emit no telemetry, got %+v", recs)
+	}
+}

--- a/internal/hooks/codex.go
+++ b/internal/hooks/codex.go
@@ -7,8 +7,9 @@ import (
 )
 
 // RunCodex handles the Codex hook wire shape. Codex support is deliberately
-// soft-only: PreToolUse is forced through ModeEnrich, and PostToolUse only
-// emits additionalContext.
+// soft-only: PreToolUse is forced through ModeEnrich, PostToolUse only emits
+// additionalContext, and UserPromptSubmit re-surfaces prompt-relevant graph
+// symbols on every turn. No branch ever denies a tool call.
 func RunCodex(port int) {
 	data, err := io.ReadAll(os.Stdin)
 	if err != nil {
@@ -32,7 +33,14 @@ func runCodex(data []byte, port int) {
 	case peek.HookEventName == "PreToolUse" && codexMCPReadPreToolUseTool(peek.ToolName):
 		runCodexMCPReadPreToolUse(data)
 	case peek.HookEventName == "PostToolUse" && peek.ToolName == "Bash":
-		runCodexPostToolUse(data, port)
+		runCodexPostToolUse(data)
+	case peek.HookEventName == "UserPromptSubmit":
+		// Re-surface graph symbols relevant to the prompt on every turn.
+		// Codex forgets MCP tools as context grows, so a SessionStart
+		// orientation alone fades; this lands a fresh, prompt-specific
+		// nudge at the top of each turn (the wire shape is shared with
+		// Claude Code — hookSpecificOutput.additionalContext).
+		runUserPromptSubmit(data)
 	}
 }
 
@@ -66,7 +74,7 @@ func runCodexMCPReadPreToolUse(data []byte) {
 	})
 }
 
-func runCodexPostToolUse(data []byte, port int) {
+func runCodexPostToolUse(data []byte) {
 	var input postHookInput
 	if err := json.Unmarshal(data, &input); err != nil {
 		return
@@ -102,5 +110,5 @@ func runCodexPostToolUse(data []byte, port int) {
 	if err != nil {
 		return
 	}
-	runPostToolUse(normalized, port)
+	runPostToolUse(normalized)
 }

--- a/internal/hooks/codex_test.go
+++ b/internal/hooks/codex_test.go
@@ -261,8 +261,8 @@ func TestRunCodexPostToolUseBashReadSourceAdditionalContext(t *testing.T) {
 			if !strings.Contains(hso.AdditionalContext, "3 indexed symbol(s)") {
 				t.Fatalf("additionalContext missing symbol count: %q", hso.AdditionalContext)
 			}
-			if !strings.Contains(hso.AdditionalContext, "2 unique external caller(s)") {
-				t.Fatalf("additionalContext missing caller count: %q", hso.AdditionalContext)
+			if !strings.Contains(hso.AdditionalContext, "2 file(s) import this one") {
+				t.Fatalf("additionalContext missing importer count: %q", hso.AdditionalContext)
 			}
 			if hso.PermissionDecision != "" || hso.PermissionDecisionReason != "" {
 				t.Fatalf("Codex PostToolUse enrichment must not deny: %#v", hso)
@@ -434,9 +434,52 @@ func TestRunCodexPostToolUseIgnoresNonBash(t *testing.T) {
 }
 
 func TestRunCodexPostToolUseMalformedJSONNoop(t *testing.T) {
-	out := captureStdout(t, func() { runCodexPostToolUse([]byte(`{`), 0) })
+	out := captureStdout(t, func() { runCodexPostToolUse([]byte(`{`)) })
 	if out != "" {
 		t.Fatalf("malformed JSON should be silent, got %q", out)
+	}
+}
+
+func TestRunCodexUserPromptSubmitInjectsGraphContext(t *testing.T) {
+	prev := userPromptProbe
+	userPromptProbe = func(string, time.Duration) ([]grepSymbolHit, error) {
+		return []grepSymbolHit{
+			{Name: "AuthMiddleware", Kind: "function", FilePath: "internal/auth.go", Line: 12},
+		}, nil
+	}
+	t.Cleanup(func() { userPromptProbe = prev })
+
+	data := []byte(`{"hook_event_name":"UserPromptSubmit","session_id":"codex-shape","prompt":"where is the auth middleware wired"}`)
+	out := captureStdout(t, func() { runCodex(data, 0) })
+	if out == "" {
+		t.Fatal("expected Codex UserPromptSubmit injection, got empty output")
+	}
+	hso := decodeHookOutput(t, out).HookSpecificOutput
+	if hso == nil {
+		t.Fatalf("missing hookSpecificOutput: %s", out)
+	}
+	if hso.HookEventName != "UserPromptSubmit" {
+		t.Fatalf("hookEventName=%q want UserPromptSubmit", hso.HookEventName)
+	}
+	if !strings.Contains(hso.AdditionalContext, "AuthMiddleware") {
+		t.Fatalf("additionalContext missing probed symbol: %q", hso.AdditionalContext)
+	}
+	if hso.PermissionDecision != "" || hso.PermissionDecisionReason != "" {
+		t.Fatalf("Codex UserPromptSubmit injection must not deny: %#v", hso)
+	}
+}
+
+func TestRunCodexUserPromptSubmitSilentWhenNoHits(t *testing.T) {
+	prev := userPromptProbe
+	userPromptProbe = func(string, time.Duration) ([]grepSymbolHit, error) {
+		return nil, nil
+	}
+	t.Cleanup(func() { userPromptProbe = prev })
+
+	data := []byte(`{"hook_event_name":"UserPromptSubmit","session_id":"codex-shape","prompt":"refactor the parser"}`)
+	out := captureStdout(t, func() { runCodex(data, 0) })
+	if out != "" {
+		t.Fatalf("expected silent no-op when probe returns no hits, got %q", out)
 	}
 }
 

--- a/internal/hooks/dispatch.go
+++ b/internal/hooks/dispatch.go
@@ -113,7 +113,7 @@ func Run(port int, mode Mode) {
 		captureModelHint(data)
 		runPreToolUse(data, port, mode)
 	case "PostToolUse":
-		runPostToolUse(data, port)
+		runPostToolUse(data)
 	case "PreCompact":
 		runPreCompact(data, port)
 	case "Stop":

--- a/internal/hooks/main_test.go
+++ b/internal/hooks/main_test.go
@@ -15,10 +15,11 @@ func TestMain(m *testing.M) {
 		_ = os.Setenv("GORTEX_HOOK_LOG", filepath.Join(dir, "hook-decisions.jsonl"))
 		defer func() { _ = os.RemoveAll(dir) }()
 	}
-	// Default the file-indexed probe to "not indexed" so no test dials a
-	// real daemon. Tests needing an indexed verdict stub fileIndexedFn
-	// (fakeIndexedBridge / newIndexedBridge / stubBridge) and restore this
-	// default on cleanup.
+	// Default the file-indexed / file-summary probes to "not indexed" so no
+	// test dials a real daemon. Tests needing an indexed verdict stub
+	// fileIndexedFn / fileSummaryFn (fakeIndexedBridge / newIndexedBridge /
+	// stubBridge) and restore these defaults on cleanup.
 	fileIndexedFn = func(_, _ string) (bool, int) { return false, 0 }
+	fileSummaryFn = func(_, _ string) (*hookFileSummary, bool) { return nil, false }
 	os.Exit(m.Run())
 }

--- a/internal/hooks/posttooluse.go
+++ b/internal/hooks/posttooluse.go
@@ -3,7 +3,6 @@ package hooks
 import (
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"regexp"
 	"sort"
 	"strconv"
@@ -31,14 +30,20 @@ type postHookInput struct {
 //
 // The handler is shape-aware:
 //   - Grep: parse "path:line:text" lines, look up the enclosing symbol
-//     in the graph for the first few hits, append name + kind + caller
-//     count so the agent sees graph-grade follow-ups inline.
+//     in the graph for the first few hits, append name + kind so the
+//     agent sees graph-grade follow-ups inline.
 //   - Glob: count the matched files, look up symbol counts per file,
 //     append a short summary so the agent can pick the right one without
 //     a follow-up tool call.
-//   - Read: look up the file's symbol count, top callers, and community
-//     so the agent knows where the file lives before deciding to act.
-func runPostToolUse(data []byte, port int) {
+//   - Read: look up the file's symbol count and importer count so the
+//     agent knows where the file lives before deciding to act.
+//
+// Every graph lookup goes over the daemon's AF_UNIX MCP socket (see
+// fileSummaryViaDaemon), the same channel the PreToolUse file-indexed
+// probe uses. An earlier revision hit an HTTP :8765 /api/graph/* API that
+// was removed when the web surface migrated to the daemon, so these
+// lookups silently returned nothing regardless of configuration (#241).
+func runPostToolUse(data []byte) {
 	var input postHookInput
 	if err := json.Unmarshal(data, &input); err != nil {
 		return
@@ -50,11 +55,11 @@ func runPostToolUse(data []byte, port int) {
 	var ctx string
 	switch input.ToolName {
 	case "Grep":
-		ctx = postGrep(input, port)
+		ctx = postGrep(input)
 	case "Glob":
-		ctx = postGlob(input, port)
+		ctx = postGlob(input)
 	case "Read":
-		ctx = postRead(input, port)
+		ctx = postRead(input)
 	}
 	if ctx == "" {
 		return
@@ -81,8 +86,9 @@ var grepHitLineRe = regexp.MustCompile(`^([^:]+):(\d+):`)
 
 // postGrep parses ripgrep-style match lines from tool_response and adds
 // "enclosing symbol" lookups for the first few hits so the agent doesn't
-// have to follow up with find_usages / get_callers manually.
-func postGrep(input postHookInput, port int) string {
+// have to follow up with find_usages / get_callers manually. Summaries
+// are memoised per file so several hits in one file cost one socket call.
+func postGrep(input postHookInput) string {
 	body := responseText(input.ToolResponse)
 	if body == "" {
 		return ""
@@ -93,16 +99,31 @@ func postGrep(input postHookInput, port int) string {
 	}
 
 	const maxLookup = 5
+	// Cache summaries (including misses, cached as nil) so repeated hits
+	// in the same file don't re-dial the daemon.
+	cache := make(map[string]*hookFileSummary)
 	enriched := make([]string, 0, maxLookup)
 	for _, h := range hits {
 		if len(enriched) >= maxLookup {
 			break
 		}
-		sym := lookupEnclosingSymbol(port, h.path, h.line)
-		if sym == "" {
+		summary, seen := cache[h.path]
+		if !seen {
+			summary, _ = fileSummaryFn(input.CWD, h.path)
+			cache[h.path] = summary
+		}
+		if summary == nil {
 			continue
 		}
-		enriched = append(enriched, fmt.Sprintf("  %s:%d → %s", h.path, h.line, sym))
+		n := enclosingNode(summary.Symbols, h.line)
+		if n == nil {
+			continue
+		}
+		label := n.Name
+		if n.Kind != "" {
+			label = n.Kind + " " + n.Name
+		}
+		enriched = append(enriched, fmt.Sprintf("  %s:%d → %s", h.path, h.line, label))
 	}
 	if len(enriched) == 0 {
 		return ""
@@ -121,7 +142,7 @@ func postGrep(input postHookInput, port int) string {
 // so the agent can rank them by relevance without another Read/Grep
 // roundtrip. Files that aren't indexed are still counted but only
 // reported in aggregate ("12 indexed / 3 unindexed").
-func postGlob(input postHookInput, port int) string {
+func postGlob(input postHookInput) string {
 	body := responseText(input.ToolResponse)
 	if body == "" {
 		return ""
@@ -139,13 +160,13 @@ func postGlob(input postHookInput, port int) string {
 	indexed := make([]fileSummary, 0, maxFiles)
 	unindexed := 0
 	for _, p := range paths {
-		ok, n := queryFileIndexed(input.CWD, p)
-		if !ok {
+		summary, ok := fileSummaryFn(input.CWD, p)
+		if !ok || summary == nil || len(summary.Symbols) == 0 {
 			unindexed++
 			continue
 		}
 		if len(indexed) < maxFiles {
-			indexed = append(indexed, fileSummary{path: p, symbols: n})
+			indexed = append(indexed, fileSummary{path: p, symbols: len(summary.Symbols)})
 		}
 	}
 	if len(indexed) == 0 {
@@ -169,26 +190,24 @@ func postGlob(input postHookInput, port int) string {
 }
 
 // postRead enriches a Read by reporting the file's graph footprint —
-// symbol count, top community, top callers — so the agent sees where
-// the file sits in the codebase. Files outside the graph are silently
-// skipped.
-func postRead(input postHookInput, port int) string {
+// symbol count and how many other files import it — so the agent sees
+// where the file sits in the codebase. Files outside the graph are
+// silently skipped.
+func postRead(input postHookInput) string {
 	filePath, _ := input.ToolInput["file_path"].(string)
 	if filePath == "" {
 		return ""
 	}
-	ok, symbolCount := queryFileIndexed(input.CWD, filePath)
-	if !ok {
+	summary, ok := fileSummaryFn(input.CWD, filePath)
+	if !ok || summary == nil || len(summary.Symbols) == 0 {
 		return ""
 	}
 
-	callers := lookupFileCallerCount(port, filePath)
-
 	var b strings.Builder
 	fmt.Fprintf(&b, "[Gortex] Graph footprint for %s:\n", filePath)
-	fmt.Fprintf(&b, "  %d indexed symbol(s)\n", symbolCount)
-	if callers > 0 {
-		fmt.Fprintf(&b, "  %d unique external caller(s)\n", callers)
+	fmt.Fprintf(&b, "  %d indexed symbol(s)\n", len(summary.Symbols))
+	if summary.Dependents > 0 {
+		fmt.Fprintf(&b, "  %d file(s) import this one\n", summary.Dependents)
 	}
 	b.WriteString("Follow-up: `get_file_summary` / `get_editing_context` returns the same info plus signatures, no re-Read needed.\n")
 	return b.String()
@@ -272,54 +291,104 @@ func parseGlobPaths(body string) []string {
 }
 
 // ---------------------------------------------------------------------------
-// Graph lookups
+// Graph lookups (over the daemon AF_UNIX MCP socket)
 // ---------------------------------------------------------------------------
 
-// lookupEnclosingSymbol asks the daemon for the symbol containing the
-// given path:line position. Returns a one-line label suitable for
-// inclusion in additionalContext, or "" on any failure / miss. Failures
-// are silent — PostToolUse must never block the agent.
-func lookupEnclosingSymbol(port int, path string, line int) string {
-	q := fmt.Sprintf("/api/graph/symbol-at?path=%s&line=%d",
-		url.QueryEscape(path), line)
-	resp, err := queryGortex(port, q)
-	if err != nil || resp == "" {
-		return ""
-	}
-	var result struct {
-		ID   string `json:"id"`
-		Name string `json:"name"`
-		Kind string `json:"kind"`
-	}
-	if err := json.Unmarshal([]byte(resp), &result); err != nil {
-		return ""
-	}
-	if result.Name == "" {
-		return ""
-	}
-	if result.Kind == "" {
-		return result.Name
-	}
-	return fmt.Sprintf("%s %s", result.Kind, result.Name)
+// summaryNode is the subset of a get_file_summary node the PostToolUse
+// enrichment consumes: name/kind for the label, and the line span so the
+// enclosing symbol for a grep hit can be resolved client-side.
+type summaryNode struct {
+	Name      string `json:"name"`
+	Kind      string `json:"kind"`
+	StartLine int    `json:"start_line"`
+	EndLine   int    `json:"end_line"`
 }
 
-// lookupFileCallerCount asks the daemon how many unique callers
-// reference symbols in the given file from outside the file. Used by
-// postRead to surface "this file is load-bearing — N external callers"
-// without forcing the agent into a follow-up get_dependents call. A
-// zero / error result returns 0; postRead then omits the line.
-func lookupFileCallerCount(port int, filePath string) int {
-	q := "/api/graph/file-callers?path=" + url.QueryEscape(filePath)
-	resp, err := queryGortex(port, q)
-	if err != nil || resp == "" {
-		return 0
-	}
-	var result struct {
-		Count int `json:"count"`
-	}
-	if err := json.Unmarshal([]byte(resp), &result); err != nil {
-		return 0
-	}
-	return result.Count
+// hookFileSummary is the parsed shape the PostToolUse handlers need from a
+// get_file_summary response: the file's definition symbols plus a count of
+// the files that import it.
+type hookFileSummary struct {
+	Symbols    []summaryNode
+	Dependents int
 }
 
+// fileSummaryFn is the seam tests stub; production routes through the
+// daemon's MCP socket (fileSummaryViaDaemon). A false / nil return is the
+// "no signal" case — daemon unreachable, malformed response, or the file
+// genuinely not indexed; callers treat all three the same (no enrichment).
+var fileSummaryFn = fileSummaryViaDaemon
+
+// fileSummaryViaDaemon fetches get_file_summary for filePath over the
+// daemon socket and parses out the definition symbols + importer count.
+// Shares daemonFileSummaryRaw (dial + path resolution + frame exchange)
+// with the PreToolUse file-indexed probe so both stay on one transport.
+func fileSummaryViaDaemon(cwd, filePath string) (*hookFileSummary, bool) {
+	resp, ok := daemonFileSummaryRaw(cwd, filePath)
+	if !ok {
+		return nil, false
+	}
+	syms, dependents, ok := parseFileSummary(resp)
+	if !ok {
+		return nil, false
+	}
+	return &hookFileSummary{Symbols: syms, Dependents: dependents}, true
+}
+
+// parseFileSummary unwraps a get_file_summary tools/call response —
+// JSON-RPC envelope → first content block (the JSON payload as text) →
+// {nodes, dependents}. get_file_summary strips the file/import nodes, so
+// nodes is the definition-symbol list; a not-indexed file comes back as a
+// tool error / guidance text, which fails the parse → ok=false.
+func parseFileSummary(resp []byte) (nodes []summaryNode, dependents int, ok bool) {
+	var rpc struct {
+		Result struct {
+			Content []struct {
+				Text string `json:"text"`
+			} `json:"content"`
+			IsError bool `json:"isError"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(resp, &rpc); err != nil {
+		return nil, 0, false
+	}
+	if rpc.Result.IsError || len(rpc.Result.Content) == 0 {
+		return nil, 0, false
+	}
+	var summary struct {
+		Nodes      []summaryNode     `json:"nodes"`
+		Dependents []json.RawMessage `json:"dependents"`
+	}
+	if err := json.Unmarshal([]byte(rpc.Result.Content[0].Text), &summary); err != nil {
+		return nil, 0, false
+	}
+	if len(summary.Nodes) == 0 {
+		return nil, 0, false
+	}
+	return summary.Nodes, len(summary.Dependents), true
+}
+
+// enclosingNode returns the innermost definition node whose [start,end]
+// line span contains line, or nil when no node covers it. Ties break to
+// the smallest span so a method wins over the type/file that also spans
+// the line. Nodes without an end line are treated as single-line spans.
+func enclosingNode(nodes []summaryNode, line int) *summaryNode {
+	var best *summaryNode
+	bestSpan := int(^uint(0) >> 1) // max int
+	for i := range nodes {
+		n := &nodes[i]
+		if n.StartLine <= 0 {
+			continue
+		}
+		end := n.EndLine
+		if end < n.StartLine {
+			end = n.StartLine
+		}
+		if line < n.StartLine || line > end {
+			continue
+		}
+		if span := end - n.StartLine; best == nil || span < bestSpan {
+			best, bestSpan = n, span
+		}
+	}
+	return best
+}

--- a/internal/hooks/posttooluse_test.go
+++ b/internal/hooks/posttooluse_test.go
@@ -3,85 +3,83 @@ package hooks
 import (
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
 	"strconv"
 	"strings"
 	"testing"
 )
 
-// stubBridge starts a httptest server that answers the three
-// /api/graph/* endpoints the PostToolUse handler consults:
+// stubBridge stubs the daemon file-summary seam (fileSummaryFn) the
+// PostToolUse handlers consult, translating the three legacy test maps into
+// per-file hookFileSummary values:
 //
-//   - /api/graph/file?path=...        → {"nodes": [...]} with len-1 == file
-//                                       node + symbolCount entries
-//   - /api/graph/symbol-at?path=...&line=N → {id, name, kind} when (path,N)
-//                                       is in `enclosing` (else 404)
-//   - /api/graph/file-callers?path=...   → {"count": N} when path is in
-//                                       `callers` (else {"count": 0})
+//   - indexed:   path → symbol count. Padded with generic single-line nodes.
+//   - enclosing: "path:line" → {ID, Name, Kind}. Materialised as a node with a
+//     [line,line] span so enclosingNode resolves it exactly.
+//   - callers:   path → importer count (hookFileSummary.Dependents).
 //
-// Returns the port the server is listening on plus a cleanup func.
+// Returns 0 — the port is vestigial (the lookups moved off HTTP onto the
+// daemon socket, #241) but callers still thread a port into runCodex.
 func stubBridge(
 	t *testing.T,
 	indexed map[string]int, // path → symbol count
 	enclosing map[string]struct{ ID, Name, Kind string }, // "path:line" → symbol
-	callers map[string]int, // path → external-caller count
+	callers map[string]int, // path → importer count
 ) int {
 	t.Helper()
 
-	// The file-indexed check now routes through the daemon socket probe
-	// (fileIndexedFn), not the HTTP bridge; stub it from the same `indexed`
-	// map. callers / symbol-at still go over HTTP below (via the port).
-	prevIndexed := fileIndexedFn
-	t.Cleanup(func() { fileIndexedFn = prevIndexed })
-	fileIndexedFn = func(_, filePath string) (bool, int) {
-		n, ok := indexed[filePath]
-		return ok && n > 0, n
+	summaries := make(map[string]*hookFileSummary)
+	ensure := func(path string) *hookFileSummary {
+		s := summaries[path]
+		if s == nil {
+			s = &hookFileSummary{}
+			summaries[path] = s
+		}
+		return s
 	}
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("/api/graph/file", func(w http.ResponseWriter, r *http.Request) {
-		p := r.URL.Query().Get("path")
-		count, ok := indexed[p]
-		if !ok {
-			_, _ = io.WriteString(w, `{"nodes":[]}`)
-			return
-		}
-		nodes := make([]any, 0, count+1)
-		nodes = append(nodes, map[string]any{"id": p, "kind": "file"})
-		for i := range count {
-			nodes = append(nodes, map[string]any{"id": fmt.Sprintf("%s::Sym%d", p, i)})
-		}
-		_ = json.NewEncoder(w).Encode(map[string]any{"nodes": nodes})
-	})
-	mux.HandleFunc("/api/graph/symbol-at", func(w http.ResponseWriter, r *http.Request) {
-		p := r.URL.Query().Get("path")
-		line := r.URL.Query().Get("line")
-		key := p + ":" + line
-		sym, ok := enclosing[key]
-		if !ok {
-			http.NotFound(w, r)
-			return
-		}
-		_ = json.NewEncoder(w).Encode(sym)
-	})
-	mux.HandleFunc("/api/graph/file-callers", func(w http.ResponseWriter, r *http.Request) {
-		p := r.URL.Query().Get("path")
-		_ = json.NewEncoder(w).Encode(map[string]int{"count": callers[p]})
-	})
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
-	u, err := url.Parse(srv.URL)
-	if err != nil {
-		t.Fatalf("parse stub url: %v", err)
+	for key, sym := range enclosing {
+		path, line := splitKeyLine(t, key)
+		s := ensure(path)
+		s.Symbols = append(s.Symbols, summaryNode{
+			Name: sym.Name, Kind: sym.Kind, StartLine: line, EndLine: line,
+		})
 	}
-	port, err := strconv.Atoi(u.Port())
-	if err != nil {
-		t.Fatalf("port: %v", err)
+	for path, count := range indexed {
+		s := ensure(path)
+		for len(s.Symbols) < count {
+			ln := len(s.Symbols) + 1
+			s.Symbols = append(s.Symbols, summaryNode{
+				Name: fmt.Sprintf("Sym%d", ln), Kind: "symbol", StartLine: ln, EndLine: ln,
+			})
+		}
 	}
-	return port
+	for path, n := range callers {
+		ensure(path).Dependents = n
+	}
+
+	prev := fileSummaryFn
+	t.Cleanup(func() { fileSummaryFn = prev })
+	fileSummaryFn = func(_, path string) (*hookFileSummary, bool) {
+		s, ok := summaries[path]
+		if !ok || len(s.Symbols) == 0 {
+			return nil, false
+		}
+		return s, true
+	}
+	return 0
+}
+
+func splitKeyLine(t *testing.T, key string) (string, int) {
+	t.Helper()
+	idx := strings.LastIndex(key, ":")
+	if idx < 0 {
+		t.Fatalf("bad enclosing key %q (want path:line)", key)
+	}
+	line, err := strconv.Atoi(key[idx+1:])
+	if err != nil {
+		t.Fatalf("bad line in enclosing key %q: %v", key, err)
+	}
+	return key[:idx], line
 }
 
 // ---------------------------------------------------------------------------
@@ -125,11 +123,114 @@ internal/util/x.go
 }
 
 // ---------------------------------------------------------------------------
+// enclosingNode — line-range resolution (pure)
+// ---------------------------------------------------------------------------
+
+func TestEnclosingNode(t *testing.T) {
+	nodes := []summaryNode{
+		{Name: "File", Kind: "type", StartLine: 1, EndLine: 100}, // widest span
+		{Name: "Method", Kind: "method", StartLine: 40, EndLine: 60},
+		{Name: "Nested", Kind: "func", StartLine: 45, EndLine: 50}, // innermost
+		{Name: "Later", Kind: "func", StartLine: 70, EndLine: 80},
+	}
+	cases := []struct {
+		line int
+		want string
+	}{
+		{48, "Nested"}, // innermost span wins over Method + File
+		{55, "Method"}, // inside Method but not Nested
+		{90, "File"},   // only the wide span covers it
+		{75, "Later"},
+		{200, ""}, // no node covers it
+	}
+	for _, c := range cases {
+		got := enclosingNode(nodes, c.line)
+		name := ""
+		if got != nil {
+			name = got.Name
+		}
+		if name != c.want {
+			t.Errorf("enclosingNode(line=%d) = %q, want %q", c.line, name, c.want)
+		}
+	}
+
+	// A node with no end line is treated as a single-line span.
+	single := []summaryNode{{Name: "Const", Kind: "const", StartLine: 7}}
+	if got := enclosingNode(single, 7); got == nil || got.Name != "Const" {
+		t.Errorf("single-line span: got %+v, want Const", got)
+	}
+	if got := enclosingNode(single, 8); got != nil {
+		t.Errorf("single-line span should not cover line 8: %+v", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseFileSummary — JSON-RPC envelope → nodes + importer count
+// ---------------------------------------------------------------------------
+
+func TestParseFileSummary(t *testing.T) {
+	payload := map[string]any{
+		"nodes": []map[string]any{
+			{"name": "Bar", "kind": "function", "start_line": 10, "end_line": 20},
+			{"name": "Baz", "kind": "type", "start_line": 22, "end_line": 30},
+		},
+		"dependents":  []string{"pkg/a.go", "pkg/b.go", "pkg/c.go"},
+		"total_nodes": 2,
+	}
+	text, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	rpc, err := json.Marshal(map[string]any{
+		"result": map[string]any{
+			"content": []map[string]any{{"type": "text", "text": string(text)}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal rpc: %v", err)
+	}
+
+	nodes, deps, ok := parseFileSummary(rpc)
+	if !ok {
+		t.Fatal("expected ok parse")
+	}
+	if len(nodes) != 2 {
+		t.Fatalf("nodes=%d want 2", len(nodes))
+	}
+	if nodes[0].Name != "Bar" || nodes[0].Kind != "function" || nodes[0].StartLine != 10 || nodes[0].EndLine != 20 {
+		t.Errorf("nodes[0] = %+v", nodes[0])
+	}
+	if deps != 3 {
+		t.Errorf("dependents=%d want 3", deps)
+	}
+}
+
+func TestParseFileSummaryRejectsErrorsAndEmpty(t *testing.T) {
+	cases := []struct {
+		name string
+		resp string
+	}{
+		{"tool error", `{"result":{"isError":true,"content":[{"text":"not indexed"}]}}`},
+		{"no content", `{"result":{"content":[]}}`},
+		{"empty nodes", `{"result":{"content":[{"text":"{\"nodes\":[]}"}]}}`},
+		{"malformed envelope", `not json`},
+		{"non-json content text", `{"result":{"content":[{"text":"file not indexed"}]}}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, _, ok := parseFileSummary([]byte(c.resp)); ok {
+				t.Errorf("expected ok=false for %s", c.name)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
 // postGrep — graph context for ripgrep-style match output
 // ---------------------------------------------------------------------------
 
 func TestPostGrep_EnrichesWithEnclosingSymbols(t *testing.T) {
-	port := stubBridge(t, nil,
+	stubBridge(t, nil,
 		map[string]struct{ ID, Name, Kind string }{
 			"pkg/foo.go:42": {ID: "pkg/foo.go::Bar", Name: "Bar", Kind: "function"},
 			"pkg/baz.go:7":  {ID: "pkg/baz.go::Quux", Name: "Quux", Kind: "type"},
@@ -140,7 +241,7 @@ func TestPostGrep_EnrichesWithEnclosingSymbols(t *testing.T) {
 		ToolResponse: "pkg/foo.go:42:func Bar() {\n" +
 			"pkg/baz.go:7:type Quux struct{}\n",
 	}
-	out := postGrep(input, port)
+	out := postGrep(input)
 	if out == "" {
 		t.Fatal("expected enrichment context, got empty")
 	}
@@ -153,12 +254,12 @@ func TestPostGrep_EnrichesWithEnclosingSymbols(t *testing.T) {
 }
 
 func TestPostGrep_EmptyWhenNoEnclosingSymbol(t *testing.T) {
-	port := stubBridge(t, nil, nil, nil) // no enclosing for any hit
+	stubBridge(t, nil, nil, nil) // no summary for any hit
 	input := postHookInput{
 		ToolName:     "Grep",
 		ToolResponse: "pkg/foo.go:42:something\n",
 	}
-	out := postGrep(input, port)
+	out := postGrep(input)
 	if out != "" {
 		t.Errorf("expected empty context when no symbols resolve, got:\n%s", out)
 	}
@@ -173,13 +274,13 @@ func TestPostGlob_RanksByIndexedSymbolCount(t *testing.T) {
 		"src/big.go":   42,
 		"src/small.go": 3,
 	}
-	port := stubBridge(t, indexed, nil, nil)
+	stubBridge(t, indexed, nil, nil)
 
 	input := postHookInput{
 		ToolName:     "Glob",
 		ToolResponse: "src/big.go\nsrc/small.go\nsrc/empty.go\n", // empty.go not indexed
 	}
-	out := postGlob(input, port)
+	out := postGlob(input)
 	if out == "" {
 		t.Fatal("expected enrichment, got empty")
 	}
@@ -204,12 +305,12 @@ func TestPostGlob_RanksByIndexedSymbolCount(t *testing.T) {
 }
 
 func TestPostGlob_AllUnindexedReturnsEmpty(t *testing.T) {
-	port := stubBridge(t, nil, nil, nil)
+	stubBridge(t, nil, nil, nil)
 	input := postHookInput{
 		ToolName:     "Glob",
 		ToolResponse: "vendor/some.go\n",
 	}
-	out := postGlob(input, port)
+	out := postGlob(input)
 	if out != "" {
 		t.Errorf("expected empty context when nothing is indexed, got:\n%s", out)
 	}
@@ -219,34 +320,34 @@ func TestPostGlob_AllUnindexedReturnsEmpty(t *testing.T) {
 // postRead — file footprint
 // ---------------------------------------------------------------------------
 
-func TestPostRead_IncludesSymbolAndCallerCounts(t *testing.T) {
+func TestPostRead_IncludesSymbolAndDependentCounts(t *testing.T) {
 	indexed := map[string]int{"pkg/handler.go": 12}
 	callers := map[string]int{"pkg/handler.go": 8}
-	port := stubBridge(t, indexed, nil, callers)
+	stubBridge(t, indexed, nil, callers)
 
 	input := postHookInput{
 		ToolName:  "Read",
 		ToolInput: map[string]any{"file_path": "pkg/handler.go"},
 	}
-	out := postRead(input, port)
+	out := postRead(input)
 	if out == "" {
 		t.Fatal("expected enrichment for indexed file, got empty")
 	}
 	if !strings.Contains(out, "12 indexed symbol(s)") {
 		t.Errorf("missing symbol count in:\n%s", out)
 	}
-	if !strings.Contains(out, "8 unique external caller(s)") {
-		t.Errorf("missing caller count in:\n%s", out)
+	if !strings.Contains(out, "8 file(s) import this one") {
+		t.Errorf("missing importer count in:\n%s", out)
 	}
 }
 
 func TestPostRead_SkipsUnindexedFiles(t *testing.T) {
-	port := stubBridge(t, nil, nil, nil)
+	stubBridge(t, nil, nil, nil)
 	input := postHookInput{
 		ToolName:  "Read",
 		ToolInput: map[string]any{"file_path": "README.md"},
 	}
-	out := postRead(input, port)
+	out := postRead(input)
 	if out != "" {
 		t.Errorf("expected empty for unindexed file, got:\n%s", out)
 	}
@@ -258,10 +359,10 @@ func TestPostRead_SkipsUnindexedFiles(t *testing.T) {
 
 func TestRunPostToolUse_DispatchesByToolName(t *testing.T) {
 	indexed := map[string]int{"pkg/handler.go": 5}
-	port := stubBridge(t, indexed, nil, nil)
+	stubBridge(t, indexed, nil, nil)
 
 	payload := []byte(`{"hook_event_name":"PostToolUse","tool_name":"Read","tool_input":{"file_path":"pkg/handler.go"}}`)
-	out := captureStdout(t, func() { runPostToolUse(payload, port) })
+	out := captureStdout(t, func() { runPostToolUse(payload) })
 	if out == "" {
 		t.Fatal("expected JSON output from dispatcher")
 	}
@@ -281,9 +382,9 @@ func TestRunPostToolUse_DispatchesByToolName(t *testing.T) {
 }
 
 func TestRunPostToolUse_SilentForUnsupportedTool(t *testing.T) {
-	port := stubBridge(t, nil, nil, nil)
+	stubBridge(t, nil, nil, nil)
 	payload := []byte(`{"hook_event_name":"PostToolUse","tool_name":"Bash","tool_input":{"command":"echo hi"}}`)
-	out := captureStdout(t, func() { runPostToolUse(payload, port) })
+	out := captureStdout(t, func() { runPostToolUse(payload) })
 	if out != "" {
 		t.Errorf("expected silent no-op for Bash, got:\n%s", out)
 	}
@@ -291,7 +392,7 @@ func TestRunPostToolUse_SilentForUnsupportedTool(t *testing.T) {
 
 func TestRunPostToolUse_SilentOnNonPostToolUseEvent(t *testing.T) {
 	payload := []byte(`{"hook_event_name":"PreToolUse","tool_name":"Read","tool_input":{"file_path":"x.go"}}`)
-	out := captureStdout(t, func() { runPostToolUse(payload, 0) })
+	out := captureStdout(t, func() { runPostToolUse(payload) })
 	if out != "" {
 		t.Errorf("expected silent no-op for non-PostToolUse event, got:\n%s", out)
 	}
@@ -303,11 +404,11 @@ func TestRunPostToolUse_SilentOnNonPostToolUseEvent(t *testing.T) {
 
 func TestDispatchRoutesPostToolUseEvent(t *testing.T) {
 	indexed := map[string]int{"pkg/x.go": 3}
-	port := stubBridge(t, indexed, nil, nil)
+	stubBridge(t, indexed, nil, nil)
 
 	data := []byte(`{"hook_event_name":"PostToolUse","tool_name":"Read","tool_input":{"file_path":"pkg/x.go"}}`)
 	withStdin(t, data, func() {
-		out := captureStdout(t, func() { Run(port, ModeEnrich) })
+		out := captureStdout(t, func() { Run(0, ModeEnrich) })
 		if out == "" {
 			t.Fatal("dispatcher dropped PostToolUse silently")
 		}

--- a/internal/hooks/pretooluse.go
+++ b/internal/hooks/pretooluse.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -443,16 +442,75 @@ func enrichGrep(toolInput map[string]any, _ int) enrichResult {
 	return probeSymbolPattern("Grep", pattern, defaultGrepGuidance())
 }
 
+// maxAlternationProbes caps how many identifier-shaped alternatives of a
+// multi-keyword grep pattern (grep 'a|b|c') the hook probes, so a long
+// alternation can't fan out into an unbounded number of daemon round-trips.
+const maxAlternationProbes = 5
+
 // probeSymbolPattern is the shared body of enrichGrep and the grep-/find-like
 // branches of enrichBash. Given a pattern, it gates on symbol-shape, probes
 // the daemon, and returns deny-with-hits or soft guidance. Telemetry is
 // attributed to the `tool` label so Grep- vs Bash-sourced probes stay
 // distinguishable in `hook-decisions.jsonl`.
+//
+// Alternation patterns (grep 'a|b|c') get split first: agents that wrap grep
+// in Bash — Codex especially — routinely batch several keywords behind `|`,
+// so the whole pattern is never a bare identifier even when the individual
+// alternatives are. Each identifier-shaped alternative is probed and the hits
+// aggregated; a pure-text alternation (phrases, hyphenated words) falls
+// through to guidance that points at search_text.
 func probeSymbolPattern(tool, pattern, guidance string) enrichResult {
 	if pattern == "" {
 		return enrichResult{}
 	}
 
+	segments := splitAlternation(pattern)
+	if len(segments) == 1 {
+		return probeSinglePattern(tool, segments[0], guidance)
+	}
+
+	var symbolSegs []string
+	for _, s := range segments {
+		if classifyGrepPattern(s) == GrepPatternSymbol {
+			symbolSegs = append(symbolSegs, s)
+			if len(symbolSegs) >= maxAlternationProbes {
+				break
+			}
+		}
+	}
+	if len(symbolSegs) == 0 {
+		// Pure text search — phrases, hyphenated words, numeric literals.
+		// search_text (surfaced in the guidance) is the graph equivalent.
+		if len(pattern) > 2 {
+			logHookDecision(tool, pattern, DecisionSkippedNonSymbol, 0, 0)
+			return enrichResult{context: guidance}
+		}
+		return enrichResult{}
+	}
+
+	start := time.Now()
+	hits, reached := probeSegments(symbolSegs)
+	dur := time.Since(start)
+	if len(hits) == 0 {
+		// Only record a miss when the daemon actually answered — a fully
+		// unreachable daemon is "no signal", not a miss (matches the
+		// single-pattern path).
+		if reached {
+			logHookDecision(tool, pattern, DecisionProbedMiss, 0, dur)
+		}
+		return enrichResult{context: guidance}
+	}
+	logHookDecision(tool, pattern, DecisionProbedHit, len(hits), dur)
+	return enrichResult{
+		deny:   true,
+		reason: formatGrepDeny(pattern, hits),
+	}
+}
+
+// probeSinglePattern gates a single (non-alternation) pattern on symbol-shape
+// and probes the daemon's search_symbols endpoint, returning deny-with-hits on
+// a match or soft guidance on miss/timeout/non-symbol.
+func probeSinglePattern(tool, pattern, guidance string) enrichResult {
 	if classifyGrepPattern(pattern) != GrepPatternSymbol {
 		if len(pattern) > 2 {
 			logHookDecision(tool, pattern, DecisionSkippedNonSymbol, 0, 0)
@@ -489,6 +547,71 @@ func probeSymbolPattern(tool, pattern, guidance string) enrichResult {
 	}
 }
 
+// probeSegments probes each alternation segment and returns the deduplicated
+// union of hits plus whether the daemon answered at least once. A per-segment
+// error (timeout, decode) drops that segment silently — one bad alternative
+// shouldn't sink the whole redirect — and an unreachable daemon leaves
+// reached=false so the caller can stay quiet instead of logging a false miss.
+func probeSegments(segs []string) (hits []grepSymbolHit, reached bool) {
+	seen := make(map[string]bool)
+	for _, s := range segs {
+		found, err := grepProbe(s, grepProbeTimeout)
+		if errors.Is(err, errDaemonUnreachable) {
+			continue
+		}
+		reached = true
+		if err != nil {
+			continue
+		}
+		for _, h := range found {
+			key := fmt.Sprintf("%s:%d:%s", h.FilePath, h.Line, h.Name)
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			hits = append(hits, h)
+		}
+	}
+	return hits, reached
+}
+
+// splitAlternation splits a grep pattern on top-level '|' alternation so a
+// multi-keyword search like "place_edges|location_edge|normalize" can be
+// probed as individual identifiers. A backslash-escaped `\|` is kept literal
+// and does not split. Empty segments are dropped; a pattern with no usable
+// '|' returns a single-element slice (the fast path).
+func splitAlternation(pattern string) []string {
+	if !strings.Contains(pattern, "|") {
+		return []string{pattern}
+	}
+	var out []string
+	var cur strings.Builder
+	for i := 0; i < len(pattern); i++ {
+		c := pattern[i]
+		if c == '\\' && i+1 < len(pattern) {
+			cur.WriteByte(c)
+			cur.WriteByte(pattern[i+1])
+			i++
+			continue
+		}
+		if c == '|' {
+			if seg := strings.TrimSpace(cur.String()); seg != "" {
+				out = append(out, seg)
+			}
+			cur.Reset()
+			continue
+		}
+		cur.WriteByte(c)
+	}
+	if seg := strings.TrimSpace(cur.String()); seg != "" {
+		out = append(out, seg)
+	}
+	if len(out) == 0 {
+		return []string{pattern}
+	}
+	return out
+}
+
 func defaultGrepGuidance() string {
 	var b strings.Builder
 	b.WriteString("[Gortex] PREFER graph tools over Grep:\n")
@@ -496,6 +619,7 @@ func defaultGrepGuidance() string {
 	b.WriteString("  - To find all references: use `find_usages` (zero false positives)\n")
 	b.WriteString("  - To find callers: use `get_callers`\n")
 	b.WriteString("  - To find implementations: use `find_implementations`\n")
+	b.WriteString("  - For literal / multi-keyword text (phrases, `foo|bar|baz`, hyphenated or other non-identifier strings): use `search_text` (trigram literal / regex search)\n")
 	b.WriteString("  - For TODO / FIXME / HACK / XXX / NOTE patterns: use `analyze kind=todos` (filter by tag/assignee/ticket)\n")
 	b.WriteString("  - For HTTP route / handler patterns (e.g. `app.get`, `func.*Handler`, `@RequestMapping`): use `contracts` (action=list to enumerate, action=check to match cross-repo)\n")
 	b.WriteString(gcxTip)
@@ -558,21 +682,41 @@ var fileIndexedFn = fileIndexedViaDaemon
 // hot path — is the next optimisation. Deferred so the test seam
 // (fileIndexedFn) stays a simple per-file func; left to the maintainer.
 func fileIndexedViaDaemon(cwd, filePath string) (bool, int) {
+	resp, ok := daemonFileSummaryRaw(cwd, filePath)
+	if !ok {
+		return false, 0
+	}
+	return parseFileSummaryIndexed(resp)
+}
+
+// daemonFileSummaryRaw resolves filePath to its tracked-repo root, asks the
+// daemon's get_file_summary tool over the AF_UNIX MCP channel, and returns
+// the raw tools/call response frame. ok=false on any failure (relative path
+// with no cwd, outside every tracked repo, daemon unreachable, socket error).
+// The graph keys files by their repo-relative path, so the absolute path is
+// resolved against its tracked-repo root and the root-relative path is what
+// gets queried (with the handshake CWD set to that root for scoping).
+//
+// Shared by the PreToolUse file-indexed probe (fileIndexedViaDaemon) and the
+// PostToolUse enrichment (fileSummaryViaDaemon) so both stay on the daemon
+// socket — the HTTP :8765 /api/graph/* API they used to hit was removed when
+// the web surface migrated to the daemon (#241).
+func daemonFileSummaryRaw(cwd, filePath string) ([]byte, bool) {
 	abs := filePath
 	if !filepath.IsAbs(abs) {
 		if cwd == "" {
-			return false, 0
+			return nil, false
 		}
 		abs = filepath.Join(cwd, abs)
 	}
 
 	root := repoRootForFile(abs)
 	if root == "" {
-		return false, 0 // outside every tracked repo → not indexed
+		return nil, false // outside every tracked repo → not indexed
 	}
 	rel, err := filepath.Rel(root, abs)
 	if err != nil {
-		return false, 0
+		return nil, false
 	}
 
 	client, err := daemon.Dial(daemon.Handshake{
@@ -581,7 +725,7 @@ func fileIndexedViaDaemon(cwd, filePath string) (bool, int) {
 		CWD:        root,
 	})
 	if err != nil {
-		return false, 0
+		return nil, false
 	}
 	defer client.Close()
 	_ = client.Conn.SetDeadline(time.Now().Add(fileIndexedTimeout))
@@ -596,16 +740,16 @@ func fileIndexedViaDaemon(cwd, filePath string) (bool, int) {
 		},
 	})
 	if err != nil {
-		return false, 0
+		return nil, false
 	}
 	if err := client.WriteMCPFrame(frame); err != nil {
-		return false, 0
+		return nil, false
 	}
 	resp, err := client.ReadMCPFrame()
 	if err != nil {
-		return false, 0
+		return nil, false
 	}
-	return parseFileSummaryIndexed(resp)
+	return resp, true
 }
 
 // daemonStatusCacheTTL bounds how long a fetched tracked-repo list is reused
@@ -824,25 +968,6 @@ func isGreedySourceGlob(pattern string) bool {
 	stem := last[:dot]
 	// Bare wildcard stems indicate "all files of this extension".
 	return stem == "*" || stem == "**"
-}
-
-func queryGortex(port int, path string) (string, error) {
-	client := &http.Client{Timeout: 2 * time.Second}
-	resp, err := client.Get(fmt.Sprintf("http://localhost:%d%s", port, path))
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("status %d", resp.StatusCode)
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-	return string(body), nil
 }
 
 // editBlockingEnvVar gates Edit/Write enforcement. We ship behind a


### PR DESCRIPTION
Codex's hooks fired correctly but delivered almost no graph value. The investigation confirmed all three reported gaps and one was worse than diagnosed — the PostToolUse HTTP endpoint doesn't just fail on an occupied port, it **no longer exists**. This PR closes all three, cross-referenced against the [official Codex hooks spec](https://developers.openai.com/codex/hooks).

## 1. PostToolUse enrichment reached a removed HTTP API (root cause)

`lookupEnclosingSymbol` / `lookupFileCallerCount` queried `http://localhost:<port>/api/graph/symbol-at` and `/api/graph/file-callers`. Those routes were retired when the web surface migrated onto the daemon — the daemon's HTTP surface (only with `--http-addr`) serves `/v1/*` + `/mcp`, never `/api/graph/*`. So every lookup silently returned nothing **regardless of port or configuration**, and since Codex runs in soft `enrich` mode where PostToolUse carries the value, Codex got ~zero enrichment.

The PreToolUse twin was already migrated to the AF_UNIX daemon socket (commit that "route[d] file-indexed probe through daemon socket"); PostToolUse was left behind. This routes both through one shared `daemonFileSummaryRaw` helper (`get_file_summary` over the socket), computes the enclosing symbol from node line-spans client-side, and reports importer count from the file's `dependents`. Deletes `queryGortex` and the `net/http` dependency.

> The pre-existing `posttooluse_test.go` was green because it stubbed an httptest `/api/graph/*` bridge that production never provided — the tests are re-seamed to the socket (`fileSummaryFn`) so they now exercise the real path.

## 2. PreToolUse skipped Codex's multi-keyword Grep patterns

Codex wraps grep in Bash and batches keywords behind `|` (e.g. `place_edges|location_edge|normalize`), so the whole pattern is never a bare identifier and `classifyGrepPattern` skipped it — **91% of probes were `skipped_non_symbol`**. Now alternation patterns are split and each identifier-shaped alternative is probed (hits aggregated + deduped); pure-text patterns (phrases, hyphenated words) are steered toward `search_text`, the correct graph equivalent for literal search. The single-pattern fast path is unchanged.

## 3. Codex had no per-turn reinforcement

A SessionStart orientation fades as context grows and Codex forgets MCP tools — the core adoption concern in the issue thread. This wires a Codex `UserPromptSubmit` hook (the event Codex supports without a matcher, per the spec) that re-surfaces prompt-relevant graph symbols on every turn, reusing the existing `buildUserPromptSubmitContext` path already shared with Claude Code and Kimi.

## Tests
- New unit tests: `enclosingNode` (line-span resolution), `parseFileSummary`, `splitAlternation`, alternation probing (hit / mixed / pure-text / unreachable), Codex `UserPromptSubmit` install + dispatch.
- `go build ./...`, `go test -race ./internal/hooks/... ./internal/agents/codex/...`, and `go test ./cmd/gortex/...` all pass.

## Notes / follow-ups (not in this PR)
- **Binary freshness** (issue side-note): packaging timing, not a code issue.
- **`--port` flag** is now vestigial (kept for backward compatibility with existing hook configs).
- Per the spec, Codex PreToolUse also fires for `apply_patch` and MCP tools — an edit-redirect for `apply_patch` is a plausible future addition but stays out of scope (edit-blocking is env-gated/experimental).
- The existing SessionStart hook uses `command_windows`; the spec's TOML example shows `commandWindows`. Flagged for separate Windows-only verification — untouched here.
- If Codex's `UserPromptSubmit` payload omits a `prompt` field, the new hook degrades to a silent no-op.