### PR TITLE
feat(kimi): full Kimi Code CLI hook support (PreToolUse deny, Stop, subagent briefing)

### DIFF
--- a/cmd/gortex/hook.go
+++ b/cmd/gortex/hook.go
@@ -41,10 +41,11 @@ var hookCmd = &cobra.Command{
 			hooks.RunCodex(hookPort)
 			return
 		case "kimi":
-			// Kimi Code CLI PR 1 supports only UserPromptSubmit. It expects
-			// prompt context via normal stdout rather than Claude's
-			// additionalContext field.
-			hooks.RunKimi()
+			// Kimi Code CLI: UserPromptSubmit / PreToolUse / Stop /
+			// SubagentStart. Soft guidance rides Kimi's plain-stdout context
+			// channel; an indexed whole-file read is blocked via the documented
+			// hookSpecificOutput.permissionDecision shape.
+			hooks.RunKimi(hookPort, hooks.ParseMode(hookMode))
 			return
 		case "", "claude":
 			// Claude Code — handled below.
@@ -61,6 +62,6 @@ func init() {
 	hookCmd.Flags().StringVar(&hookMode, "mode", "deny",
 		"hook posture: 'deny' (redirect Grep/Glob/Read of indexed source), 'enrich' (never deny; PostToolUse appends graph context), 'consult-unlock' (deny fallback reads until the graph is queried once this session), or 'nudge' (soft-deny once per burst of non-symbolic calls)")
 	hookCmd.Flags().StringVar(&hookAgent, "agent", "",
-		"hook wire protocol: empty/'claude' (Claude Code PreToolUse/UserPromptSubmit), 'codex' (Codex Bash PreToolUse/PostToolUse soft context), 'kimi' (Kimi Code CLI UserPromptSubmit plain stdout), 'hermes' (NousResearch hermes-agent pre_tool_call/pre_llm_call), 'pi' (earendil-works/pi extension bridge — normalized PiEvent envelope in, PiDecision out), or 'gemini'/'antigravity' (emits hookSpecificOutput.additionalContext). Default (empty) is the Claude Code format.")
+		"hook wire protocol: empty/'claude' (Claude Code PreToolUse/UserPromptSubmit), 'codex' (Codex Bash PreToolUse/PostToolUse soft context), 'kimi' (Kimi Code CLI UserPromptSubmit/PreToolUse/Stop/SubagentStart; plain-stdout context, permissionDecision deny for indexed reads), 'hermes' (NousResearch hermes-agent pre_tool_call/pre_llm_call), 'pi' (earendil-works/pi extension bridge — normalized PiEvent envelope in, PiDecision out), or 'gemini'/'antigravity' (emits hookSpecificOutput.additionalContext). Default (empty) is the Claude Code format.")
 	rootCmd.AddCommand(hookCmd)
 }

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -30,6 +30,7 @@ commands accept `--agents=<csv>` to constrain setup and
 | `gemini`        | `.gemini/settings.json` or `~/.gemini/settings.json`, `GEMINI.md` communities block             | both       | https://geminicli.com/docs/tools/mcp-server/                        |
 | `hermes`        | `~/.hermes/config.yaml` + `profiles/*/config.yaml` (`mcp_servers`), hooks, `~/.hermes/skills/gortex/SKILL.md` | user       | https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp  |
 | `kilocode`      | `mcp_settings.json` + `.kilocode/mcp.json`, `.kilocoderules` communities block                  | both       | https://kilo.ai/docs/features/mcp/using-mcp-in-kilo-code            |
+| `kimi`          | `.kimi-code/mcp.json` (project) or `~/.kimi-code/mcp.json` + `~/.kimi-code/config.toml` (`UserPromptSubmit` / `PreToolUse` / `Stop` / `SubagentStart` hooks) | both       | https://www.kimi.com/code/docs/en/kimi-code-cli/customization/hooks.html |
 | `kiro`          | `.kiro/settings/mcp.json` + steering/hooks or user-level                                        | both       | https://kiro.dev/docs/mcp/configuration                             |
 | `oh-my-pi`      | `.omp/mcp.json`                                                                                 | project    | https://github.com/can1357/oh-my-pi/blob/main/docs/mcp-config.md   |
 | `opencode`      | `opencode.json` (or existing `opencode.jsonc`), `AGENTS.md` communities block                   | project    | https://opencode.ai/docs/mcp                                        |
@@ -246,6 +247,33 @@ Kilo Code is a Cline fork with its own globalStorage key
 (`kilocode.kilo`). We write to every candidate globalStorage path
 (VS Code + Cursor + Insiders variants) plus `.kilocode/mcp.json`
 when a project-level directory exists.
+
+### kimi
+
+Kimi Code CLI keeps MCP servers in `.kimi-code/mcp.json` (project, via
+`gortex init`) or `~/.kimi-code/mcp.json` (user, via `gortex install`),
+and user-level lifecycle hooks in `~/.kimi-code/config.toml` as a
+`[[hooks]]` array. Kimi appends a hook's plain stdout to the model
+context on exit 0, so Gortex sends soft guidance as plain text and uses
+the documented `hookSpecificOutput.permissionDecision = "deny"` shape
+only to block an indexed whole-file read.
+
+Current Kimi hook coverage (all gated to Gortex-enabled projects so the
+machine-wide user hook stays inert elsewhere):
+
+| Surface | Coverage |
+| ------- | -------- |
+| `UserPromptSubmit` | Injects graph symbols relevant to the prompt before the model runs. |
+| `PreToolUse` | Redirects native `Read`/`Grep`/`Glob`/`Bash` to graph tools — a hard `deny` for an indexed whole-file read, soft plain-stdout guidance otherwise — plus the `read_file`/`get_editing_context` `compress_bodies` nudge. |
+| `Stop` | Runs post-turn diagnostics (changed symbols → test targets, guards, dead code, coverage, contracts) and feeds them back so the agent self-corrects before handoff. |
+| `SubagentStart` | Briefs a spawned subagent with `smart_context` results and the tool-swap table so it doesn't default to raw `Read`/`Grep`. |
+
+The diagnostics and briefing hooks reach the daemon over its unix
+socket (the hook port's HTTP surface is served only under
+`--http-addr`), and every path degrades to a silent no-op when the
+payload is malformed, the cwd is outside a Gortex project, or the
+daemon is unreachable — so normal Kimi flow is never blocked by the
+integration.
 
 ### kiro
 

--- a/internal/agents/kimi/adapter.go
+++ b/internal/agents/kimi/adapter.go
@@ -8,8 +8,9 @@
 //
 // Kimi's hooks are user-level today, so project-mode `gortex init` only writes
 // the repo-local MCP file. Machine-wide `gortex install` writes user MCP and,
-// when hooks are enabled, UserPromptSubmit and PreToolUse hooks that shell
-// `gortex hook --agent=kimi`.
+// when hooks are enabled, UserPromptSubmit / PreToolUse / Stop / SubagentStart
+// hooks that shell `gortex hook --agent=kimi` for pre-turn context injection,
+// graph-aware tool redirects, post-turn self-correction, and subagent briefing.
 //
 // Docs: https://www.kimi.com/code/docs/en/kimi-code-cli/customization/hooks.html
 package kimi
@@ -28,7 +29,15 @@ import (
 const Name = "kimi"
 const DocsURL = "https://www.kimi.com/code/docs/en/kimi-code-cli/customization/hooks.html"
 
-const kimiHookTimeoutSeconds = 5
+// Per-event hook timeouts (Kimi allows 1–600s). UserPromptSubmit and
+// PreToolUse sit on the turn's critical path, so they stay snappy; the Stop and
+// SubagentStart briefings fan out to several graph tools and run off the hot
+// path, so they get more headroom before Kimi's fail-open kill.
+const (
+	kimiHookTimeoutSeconds         = 5
+	kimiStopHookTimeoutSeconds     = 30
+	kimiSubagentHookTimeoutSeconds = 15
+)
 
 type Adapter struct{}
 
@@ -214,6 +223,8 @@ func kimiHooks(env agents.Env) []map[string]any {
 	return []map[string]any{
 		kimiUserPromptSubmitHook(env),
 		kimiPreToolUseHook(env),
+		kimiStopHook(env),
+		kimiSubagentStartHook(env),
 	}
 }
 
@@ -227,12 +238,35 @@ func kimiUserPromptSubmitHook(env agents.Env) map[string]any {
 
 func kimiPreToolUseHook(env agents.Env) map[string]any {
 	// Do not set matcher here: Kimi currently exposes MCP tool names as the
-	// underlying tool name without a documented server namespace. The dispatcher
-	// does the narrow Gortex read-tool filtering and silently ignores the rest.
+	// underlying tool name without a documented server namespace, and the
+	// native Read/Grep/Glob redirects want to see every tool call. The
+	// dispatcher does the filtering and silently ignores anything it doesn't
+	// enrich.
 	return map[string]any{
 		"event":   "PreToolUse",
 		"command": kimiHookCommand(env),
 		"timeout": kimiHookTimeoutSeconds,
+	}
+}
+
+// kimiStopHook runs the post-turn diagnostics (changed symbols → test targets,
+// guards, dead code, coverage, contracts) and feeds them back so the agent can
+// self-correct before handoff.
+func kimiStopHook(env agents.Env) map[string]any {
+	return map[string]any{
+		"event":   "Stop",
+		"command": kimiHookCommand(env),
+		"timeout": kimiStopHookTimeoutSeconds,
+	}
+}
+
+// kimiSubagentStartHook briefs a spawned subagent with task-scoped graph
+// context and the tool-swap table so it doesn't default to raw Read/Grep.
+func kimiSubagentStartHook(env agents.Env) map[string]any {
+	return map[string]any{
+		"event":   "SubagentStart",
+		"command": kimiHookCommand(env),
+		"timeout": kimiSubagentHookTimeoutSeconds,
 	}
 }
 
@@ -251,7 +285,7 @@ func kimiHookEntryInvokesKimi(entry any) (string, bool) {
 	}
 	event, _ := m["event"].(string)
 	switch event {
-	case "UserPromptSubmit", "PreToolUse":
+	case "UserPromptSubmit", "PreToolUse", "Stop", "SubagentStart":
 	default:
 		return "", false
 	}

--- a/internal/agents/kimi/adapter_test.go
+++ b/internal/agents/kimi/adapter_test.go
@@ -51,11 +51,10 @@ func TestKimiGlobalWritesMCPAndHooks(t *testing.T) {
 	}
 
 	hooks := readKimiHooks(t, env)
-	if len(hooks) != 2 {
-		t.Fatalf("hooks=%#v want 2", hooks)
+	if len(hooks) != 4 {
+		t.Fatalf("hooks=%#v want 4", hooks)
 	}
-	assertKimiHook(t, hooks[0], "UserPromptSubmit")
-	assertKimiHook(t, hooks[1], "PreToolUse")
+	assertKimiGortexHooks(t, hooks, 0)
 
 	agentstest.AssertIdempotent(t, a, env)
 }
@@ -107,18 +106,13 @@ timeout = 5
 		t.Fatalf("default_model was not preserved: %#v", cfg)
 	}
 	hooks := readKimiHooks(t, env)
-	if len(hooks) != 3 {
+	if len(hooks) != 5 {
 		t.Fatalf("hooks=%#v want user+gortex hooks", hooks)
 	}
 	if hooks[0]["event"] != "Notification" {
 		t.Fatalf("user hook was not preserved first: %#v", hooks)
 	}
-	if hooks[1]["event"] != "UserPromptSubmit" {
-		t.Fatalf("missing gortex UserPromptSubmit hook: %#v", hooks)
-	}
-	if hooks[2]["event"] != "PreToolUse" {
-		t.Fatalf("missing gortex PreToolUse hook: %#v", hooks)
-	}
+	assertKimiGortexHooks(t, hooks, 1)
 }
 
 func TestKimiForceReplacesOnlyGortexHook(t *testing.T) {
@@ -150,14 +144,13 @@ timeout = 30
 		t.Fatalf("apply force: %v", err)
 	}
 	hooks := readKimiHooks(t, env)
-	if len(hooks) != 3 {
+	if len(hooks) != 5 {
 		t.Fatalf("hooks=%#v want user+current gortex hooks", hooks)
 	}
 	if hooks[0]["command"] != "echo user" {
 		t.Fatalf("user hook was not preserved: %#v", hooks)
 	}
-	assertKimiHook(t, hooks[1], "UserPromptSubmit")
-	assertKimiHook(t, hooks[2], "PreToolUse")
+	assertKimiGortexHooks(t, hooks, 1)
 }
 
 func kimiTestEnv(t *testing.T) agents.Env {
@@ -205,7 +198,7 @@ func readKimiHooks(t *testing.T, env agents.Env) []map[string]any {
 	return out
 }
 
-func assertKimiHook(t *testing.T, hook map[string]any, event string) {
+func assertKimiHook(t *testing.T, hook map[string]any, event string, timeout int) {
 	t.Helper()
 	if hook["event"] != event {
 		t.Errorf("event=%v want %s", hook["event"], event)
@@ -213,10 +206,20 @@ func assertKimiHook(t *testing.T, hook map[string]any, event string) {
 	if hook["command"] != testKimiHookCommand {
 		t.Errorf("command=%v want %q", hook["command"], testKimiHookCommand)
 	}
-	if hook["timeout"] != int64(kimiHookTimeoutSeconds) {
-		t.Errorf("timeout=%v want %d", hook["timeout"], kimiHookTimeoutSeconds)
+	if hook["timeout"] != int64(timeout) {
+		t.Errorf("timeout=%v want %d", hook["timeout"], timeout)
 	}
 	if _, ok := hook["matcher"]; ok {
 		t.Errorf("%s hook should not write matcher: %#v", event, hook)
 	}
+}
+
+// assertKimiGortexHooks checks the four gortex-managed hooks appear, in order,
+// starting at hooks[offset].
+func assertKimiGortexHooks(t *testing.T, hooks []map[string]any, offset int) {
+	t.Helper()
+	assertKimiHook(t, hooks[offset+0], "UserPromptSubmit", kimiHookTimeoutSeconds)
+	assertKimiHook(t, hooks[offset+1], "PreToolUse", kimiHookTimeoutSeconds)
+	assertKimiHook(t, hooks[offset+2], "Stop", kimiStopHookTimeoutSeconds)
+	assertKimiHook(t, hooks[offset+3], "SubagentStart", kimiSubagentHookTimeoutSeconds)
 }

--- a/internal/hooks/daemon_tool.go
+++ b/internal/hooks/daemon_tool.go
@@ -1,0 +1,112 @@
+package hooks
+
+import (
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/zzet/gortex/internal/daemon"
+)
+
+// hookCWD carries the working directory of the in-flight hook invocation so the
+// daemon-socket fallback in callServerTool can scope its tools/call handshake to
+// the right workspace. A hook binary is single-shot — it reads one stdin
+// payload, handles one event, and exits — so a package-level value set once at
+// dispatch entry is race-free in production; tests set-and-restore it. The
+// mutex is only for tidiness under `go test -race`, where several dispatchers
+// run in one process.
+var (
+	hookCWDMu sync.RWMutex
+	hookCWD   string
+)
+
+// setHookCWD records the payload CWD for the current hook invocation. Pass ""
+// to clear it (dispatchers defer a clear so a value never leaks across the
+// sequential tests sharing one process).
+func setHookCWD(cwd string) {
+	hookCWDMu.Lock()
+	hookCWD = cwd
+	hookCWDMu.Unlock()
+}
+
+// loadHookCWD returns the CWD recorded for the current hook invocation, or ""
+// when none was set (the pure-HTTP unit tests, or a dispatcher that opted out
+// of the socket fallback).
+func loadHookCWD() string {
+	hookCWDMu.RLock()
+	defer hookCWDMu.RUnlock()
+	return hookCWD
+}
+
+// callServerToolDaemonFn is the seam production uses to reach the daemon over
+// its unix socket; tests swap it so a hook never touches a real daemon.
+var callServerToolDaemonFn = callServerToolViaDaemon
+
+// callServerToolTimeout bounds the whole daemon round-trip (dial + handshake +
+// tools/call) per call, so a wedged daemon can never stall a Stop / subagent
+// hook past the host's own hook timeout.
+const callServerToolTimeout = 5 * time.Second
+
+// callServerToolViaDaemon runs one MCP tools/call against the local daemon over
+// its AF_UNIX socket and returns the first text content block, or "" on any
+// error. cwd scopes the handshake to the caller's workspace so tools that read
+// the working tree (detect_changes) or the active project (analyze) resolve the
+// right repo. Mirrors fileIndexedViaDaemon's transport; kept separate so the
+// file-indexed probe stays a tight count-only path.
+func callServerToolViaDaemon(cwd, name string, args map[string]any) string {
+	if args == nil {
+		args = map[string]any{}
+	}
+	client, err := daemon.Dial(daemon.Handshake{
+		Mode:       daemon.ModeMCP,
+		ClientName: "gortex-hook",
+		CWD:        cwd,
+	})
+	if err != nil {
+		return ""
+	}
+	defer client.Close()
+	_ = client.Conn.SetDeadline(time.Now().Add(callServerToolTimeout))
+
+	frame, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      name,
+			"arguments": args,
+		},
+	})
+	if err != nil {
+		return ""
+	}
+	if err := client.WriteMCPFrame(frame); err != nil {
+		return ""
+	}
+	resp, err := client.ReadMCPFrame()
+	if err != nil {
+		return ""
+	}
+	return parseToolCallText(resp)
+}
+
+// parseToolCallText unwraps a tools/call JSON-RPC response to the first content
+// block's text. Returns "" on a tool error or a shape mismatch so the caller
+// treats it the same as an unreachable bridge.
+func parseToolCallText(resp []byte) string {
+	var rpc struct {
+		Result struct {
+			Content []struct {
+				Text string `json:"text"`
+			} `json:"content"`
+			IsError bool `json:"isError"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(resp, &rpc); err != nil {
+		return ""
+	}
+	if rpc.Result.IsError || len(rpc.Result.Content) == 0 {
+		return ""
+	}
+	return rpc.Result.Content[0].Text
+}

--- a/internal/hooks/daemon_tool_test.go
+++ b/internal/hooks/daemon_tool_test.go
@@ -1,0 +1,37 @@
+package hooks
+
+import "testing"
+
+// The daemon-socket fallback must only fire when a hook CWD has been recorded,
+// so the pure-HTTP unit tests (which never set one) keep their "no bridge"
+// semantics and never touch a real daemon.
+func TestCallServerToolDaemonFallbackGatedOnHookCWD(t *testing.T) {
+	var called int
+	old := callServerToolDaemonFn
+	callServerToolDaemonFn = func(_, name string, _ map[string]any) string {
+		called++
+		return "daemon:" + name
+	}
+	t.Cleanup(func() { callServerToolDaemonFn = old })
+
+	// No hook CWD → HTTP (port 0, unreachable) fails and the fallback is
+	// skipped, leaving the historical empty-string result.
+	setHookCWD("")
+	if got := callServerTool(0, "detect_changes", nil); got != "" {
+		t.Fatalf("want empty result without a hook CWD, got %q", got)
+	}
+	if called != 0 {
+		t.Fatalf("daemon fallback must not fire without a hook CWD, fired %d times", called)
+	}
+
+	// With a hook CWD set, an unreachable HTTP surface falls back to the
+	// daemon socket scoped to that CWD.
+	setHookCWD("/repo")
+	defer setHookCWD("")
+	if got := callServerTool(0, "detect_changes", nil); got != "daemon:detect_changes" {
+		t.Fatalf("want daemon fallback result, got %q", got)
+	}
+	if called != 1 {
+		t.Fatalf("daemon fallback should fire exactly once, fired %d times", called)
+	}
+}

--- a/internal/hooks/kimi.go
+++ b/internal/hooks/kimi.go
@@ -9,57 +9,236 @@ import (
 	"strings"
 )
 
-// RunKimi handles the Kimi Code CLI hook wire shape. Kimi consumes plain
-// stdout as hook-added context, so this dispatcher intentionally avoids
-// Claude-style structured additionalContext JSON.
-func RunKimi() {
+// RunKimi handles the Kimi Code CLI hook wire shape across its lifecycle
+// events. Kimi appends a hook's plain stdout to the model context on exit 0, so
+// soft guidance (UserPromptSubmit context, PreToolUse read nudges, the Stop
+// diagnostics briefing, and subagent briefings) is emitted as plain text rather
+// than Claude-style additionalContext JSON. A hard block uses the one JSON
+// shape Kimi documents — hookSpecificOutput.permissionDecision = "deny" — so
+// the PreToolUse redirect of indexed whole-file reads actually stops the call.
+//
+// Every path degrades to a silent no-op when the payload is malformed, the cwd
+// is not a Gortex-enabled project, or the daemon is unreachable, so normal Kimi
+// flow is never blocked by the integration.
+func RunKimi(port int, mode Mode) {
 	data, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		return
 	}
-	runKimi(data)
+	runKimi(data, port, mode)
 }
 
-func runKimi(data []byte) {
+func runKimi(data []byte, port int, mode Mode) {
+	var peek struct {
+		HookEventName string `json:"hook_event_name"`
+		CWD           string `json:"cwd"`
+	}
+	if err := json.Unmarshal(data, &peek); err != nil {
+		return
+	}
+	switch peek.HookEventName {
+	case "UserPromptSubmit", "PreToolUse", "Stop", "SubagentStart":
+	default:
+		return
+	}
+	// Only enrich turns taken inside a Gortex-enabled project. The user-level
+	// Kimi hook fires machine-wide, so this front gate keeps the graph tools
+	// out of unrelated repos before any daemon round-trip.
+	if !kimiGortexEnabledProject(peek.CWD) {
+		return
+	}
+
+	// Record the workspace for callServerTool's daemon-socket fallback (the
+	// HTTP surface the hook port names is not served unless the daemon runs
+	// with --http-addr). Cleared on return so it never leaks across the
+	// sequential tests that share one process.
+	setHookCWD(peek.CWD)
+	defer setHookCWD("")
+
+	switch peek.HookEventName {
+	case "UserPromptSubmit":
+		runKimiUserPromptSubmit(data)
+	case "PreToolUse":
+		runKimiPreToolUseEvent(data, port, mode)
+	case "Stop":
+		runKimiStop(data, port)
+	case "SubagentStart":
+		runKimiSubagentStart(data, port)
+	}
+}
+
+// runKimiUserPromptSubmit injects graph symbols relevant to the user's prompt
+// before the model runs, as plain stdout.
+func runKimiUserPromptSubmit(data []byte) {
 	var input struct {
-		HookEventName string         `json:"hook_event_name"`
-		CWD           string         `json:"cwd"`
-		ToolName      string         `json:"tool_name"`
-		ToolInput     map[string]any `json:"tool_input"`
-		Prompt        any            `json:"prompt"`
+		HookEventName string `json:"hook_event_name"`
+		Prompt        any    `json:"prompt"`
 	}
 	if err := json.Unmarshal(data, &input); err != nil {
 		return
 	}
-	switch input.HookEventName {
-	case "UserPromptSubmit", "PreToolUse":
-	default:
-		return
-	}
-	if !kimiGortexEnabledProject(input.CWD) {
-		return
-	}
-	switch input.HookEventName {
-	case "UserPromptSubmit":
-		ctx := buildUserPromptSubmitContext(input.HookEventName, kimiPromptText(input.Prompt))
-		if ctx == "" {
-			return
-		}
-		fmt.Print(ctx)
-	case "PreToolUse":
-		runKimiPreToolUse(input.ToolName, input.ToolInput)
-	}
-}
-
-func runKimiPreToolUse(toolName string, toolInput map[string]any) {
-	if !kimiGortexReadPreToolUseTool(toolName) {
-		return
-	}
-	ctx := gortexReadNudge(toolName, toolInput)
+	ctx := buildUserPromptSubmitContext(input.HookEventName, kimiPromptText(input.Prompt))
 	if ctx == "" {
 		return
 	}
 	fmt.Print(ctx)
+}
+
+// runKimiPreToolUseEvent parses the PreToolUse envelope and routes it through
+// the shared enrichment machinery, emitting results in Kimi's wire shape.
+func runKimiPreToolUseEvent(data []byte, port int, mode Mode) {
+	var input struct {
+		ToolName  string         `json:"tool_name"`
+		ToolInput map[string]any `json:"tool_input"`
+		SessionID string         `json:"session_id"`
+	}
+	if err := json.Unmarshal(data, &input); err != nil {
+		return
+	}
+	runKimiPreToolUse(input.ToolName, input.ToolInput, input.SessionID, port, mode)
+}
+
+// runKimiPreToolUse applies the graph-aware PreToolUse posture to one tool call.
+//
+//   - Gortex's own whole-file read tools (read_file / get_editing_context) keep
+//     the historical plain-stdout compress-bodies nudge, never a hard deny —
+//     matching Claude's soft posture for these and the established Kimi
+//     contract.
+//   - Native tools (Read / Grep / Glob / Bash) and Task subagent spawns run
+//     through the shared enrich + applyMode path: a deny of an indexed
+//     whole-file read becomes a Kimi permission-decision block; soft guidance
+//     is appended as plain-stdout context so the call still proceeds.
+func runKimiPreToolUse(toolName string, toolInput map[string]any, sessionID string, port int, mode Mode) {
+	if kimiGortexReadPreToolUseTool(toolName) {
+		if ctx := gortexReadNudge(toolName, toolInput); ctx != "" {
+			fmt.Print(ctx)
+		}
+		return
+	}
+
+	input := HookInput{
+		HookEventName: "PreToolUse",
+		ToolName:      toolName,
+		ToolInput:     toolInput,
+		CWD:           loadHookCWD(),
+		SessionID:     sessionID,
+	}
+	result := applyMode(input, false, mode, enrich(input, port))
+	if result.deny {
+		emitKimiDeny(result.reason)
+		return
+	}
+	if result.context != "" {
+		fmt.Print(result.context)
+	}
+}
+
+// runKimiStop runs the post-turn diagnostics on the changed working tree and
+// appends the findings as plain-stdout context so the agent can self-correct
+// before handoff. Reuses the shared briefing builder, so Kimi gets identical
+// diagnostics (test targets, guards, dead code, coverage, contracts) to Claude.
+// Skips when a Stop hook is already rerunning to avoid recursion.
+func runKimiStop(data []byte, port int) {
+	var input PostTaskInput
+	if err := json.Unmarshal(data, &input); err != nil {
+		return
+	}
+	if input.StopHookActive {
+		return
+	}
+	briefing := buildPostTaskBriefing(port)
+	if briefing == "" {
+		return
+	}
+	fmt.Print(briefing)
+}
+
+// runKimiSubagentStart gives a spawned subagent a task-scoped briefing (relevant
+// symbols + the tool-swap table) as plain stdout, so it reaches for the graph
+// tools instead of defaulting to raw Read/Grep on indexed source.
+func runKimiSubagentStart(data []byte, port int) {
+	briefing := buildKimiSubagentBriefing(port, kimiSubagentTask(data))
+	if briefing == "" {
+		return
+	}
+	fmt.Print(briefing)
+}
+
+// buildKimiSubagentBriefing prefers the full enrichTask briefing (graph stats +
+// smart_context over the subagent task + recent churn) when a task can be
+// derived and the daemon answers; otherwise it falls back to the static
+// tool-swap table, which needs no daemon round-trip, so a subagent is never
+// left without the redirect rules.
+func buildKimiSubagentBriefing(port int, task string) string {
+	if task != "" {
+		if r := enrichTask(map[string]any{"description": task}, port); r.context != "" {
+			return r.context
+		}
+	}
+	return kimiSubagentFallbackBriefing()
+}
+
+// kimiSubagentFallbackBriefing restates the Gortex tool-swap rules inline for a
+// subagent when no task text is available (or the bridge is down). Kept short —
+// it is pure guidance text, injected on every spawn.
+func kimiSubagentFallbackBriefing() string {
+	var sb strings.Builder
+	sb.WriteString("[Gortex] Subagent briefing — this repo has a Gortex MCP server.\n")
+	sb.WriteString("Subagents don't inherit project instructions, so the rules below are restated inline:\n\n")
+	sb.WriteString(gortexToolGuidance)
+	sb.WriteString("\n_First call: `smart_context` with your task. Before editing any file: `get_editing_context`. Never Read/Grep an indexed source file._\n")
+	return sb.String()
+}
+
+// kimiSubagentTask extracts the subagent's task description from a SubagentStart
+// payload. Kimi's documented base payload is thin (hook_event_name / session_id
+// / cwd) and the subagent-specific fields aren't pinned down, so several likely
+// shapes are probed; a miss yields "" and the fallback briefing.
+func kimiSubagentTask(data []byte) string {
+	var in struct {
+		Prompt      any    `json:"prompt"`
+		Description string `json:"description"`
+		Task        string `json:"task"`
+		ToolInput   struct {
+			Prompt      any    `json:"prompt"`
+			Description string `json:"description"`
+		} `json:"tool_input"`
+		Subagent struct {
+			Prompt      any    `json:"prompt"`
+			Description string `json:"description"`
+			Task        string `json:"task"`
+		} `json:"subagent"`
+	}
+	if err := json.Unmarshal(data, &in); err != nil {
+		return ""
+	}
+	for _, s := range []string{
+		kimiPromptText(in.Prompt), in.Description, in.Task,
+		kimiPromptText(in.ToolInput.Prompt), in.ToolInput.Description,
+		kimiPromptText(in.Subagent.Prompt), in.Subagent.Description, in.Subagent.Task,
+	} {
+		if strings.TrimSpace(s) != "" {
+			return strings.TrimSpace(s)
+		}
+	}
+	return ""
+}
+
+// emitKimiDeny writes the one JSON response shape Kimi documents for blocking a
+// tool call: hookSpecificOutput.permissionDecision = "deny" with a reason Kimi
+// feeds back into context so the model can pick the graph-aware alternative.
+func emitKimiDeny(reason string) {
+	out, err := json.Marshal(HookOutput{
+		HookSpecificOutput: &HookSpecificOutput{
+			HookEventName:            "PreToolUse",
+			PermissionDecision:       "deny",
+			PermissionDecisionReason: reason,
+		},
+	})
+	if err != nil {
+		return
+	}
+	fmt.Print(string(out))
 }
 
 func kimiGortexReadPreToolUseTool(toolName string) bool {

--- a/internal/hooks/kimi_events_test.go
+++ b/internal/hooks/kimi_events_test.go
@@ -1,0 +1,153 @@
+package hooks
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// stubDaemonTool routes callServerTool's daemon-socket fallback to a canned
+// response map, so hook handlers that fan out to graph tools are exercised over
+// the production transport without touching a real daemon. A missing tool name
+// yields "" (unreachable/no-signal), matching how the daemon degrades.
+func stubDaemonTool(t *testing.T, responses map[string]string) {
+	t.Helper()
+	old := callServerToolDaemonFn
+	callServerToolDaemonFn = func(_, name string, _ map[string]any) string {
+		return responses[name]
+	}
+	t.Cleanup(func() { callServerToolDaemonFn = old })
+}
+
+func TestRunKimiPreToolUseReadIndexedDenies(t *testing.T) {
+	cwd := writeGortexProjectMarker(t, t.TempDir())
+	old := fileIndexedFn
+	fileIndexedFn = func(_, _ string) (bool, int) { return true, 7 }
+	defer func() { fileIndexedFn = old }()
+
+	out := captureStdout(t, func() {
+		runKimi(kimiPreToolPayload(cwd, "Read", `{"file_path":"internal/auth/token.go"}`), 0, ModeDeny)
+	})
+	if !strings.Contains(out, `"permissionDecision":"deny"`) {
+		t.Fatalf("expected a Kimi permission-decision deny, got: %q", out)
+	}
+	if !strings.Contains(out, "get_symbol_source") {
+		t.Fatalf("deny reason should name graph tools, got: %q", out)
+	}
+	if strings.Contains(out, "additionalContext") {
+		t.Fatalf("a hard deny should not ride additionalContext, got: %q", out)
+	}
+}
+
+func TestRunKimiPreToolUseReadUnindexedSoftStdout(t *testing.T) {
+	cwd := writeGortexProjectMarker(t, t.TempDir())
+	old := fileIndexedFn
+	fileIndexedFn = func(_, _ string) (bool, int) { return false, 0 }
+	defer func() { fileIndexedFn = old }()
+
+	out := captureStdout(t, func() {
+		runKimi(kimiPreToolPayload(cwd, "Read", `{"file_path":"internal/new.go"}`), 0, ModeDeny)
+	})
+	if strings.Contains(out, "permissionDecision") || strings.Contains(out, "hookSpecificOutput") {
+		t.Fatalf("an unindexed Read should be soft plain-stdout guidance, not a deny: %q", out)
+	}
+	if !strings.Contains(out, "get_symbol_source") {
+		t.Fatalf("expected soft graph guidance, got: %q", out)
+	}
+}
+
+func TestRunKimiPreToolUseGrepSymbolDenies(t *testing.T) {
+	cwd := writeGortexProjectMarker(t, t.TempDir())
+	old := grepProbe
+	grepProbe = func(string, time.Duration) ([]grepSymbolHit, error) {
+		return []grepSymbolHit{
+			{Name: "ValidateToken", Kind: "function", FilePath: "internal/auth/token.go", Line: 42},
+		}, nil
+	}
+	defer func() { grepProbe = old }()
+
+	out := captureStdout(t, func() {
+		runKimi(kimiPreToolPayload(cwd, "Grep", `{"pattern":"ValidateToken"}`), 0, ModeDeny)
+	})
+	if !strings.Contains(out, `"permissionDecision":"deny"`) {
+		t.Fatalf("expected a Grep symbol-match deny, got: %q", out)
+	}
+	if !strings.Contains(out, "ValidateToken") {
+		t.Fatalf("deny reason should name the matched symbol, got: %q", out)
+	}
+}
+
+func TestRunKimiStopEmitsDiagnostics(t *testing.T) {
+	cwd := writeGortexProjectMarker(t, t.TempDir())
+	stubDaemonTool(t, map[string]string{
+		"detect_changes":   `{"changed_files":["internal/foo.go"],"changed_symbols":[{"id":"internal/foo.go::Foo","name":"Foo","kind":"function"}],"risk":"MEDIUM","summary":"1 symbol"}`,
+		"get_test_targets": "internal/foo_test.go::TestFoo",
+	})
+
+	out := captureStdout(t, func() {
+		runKimi([]byte(`{"hook_event_name":"Stop","cwd":`+strconv.Quote(cwd)+`,"stop_hook_active":false}`), 0, ModeDeny)
+	})
+	if strings.Contains(out, "hookSpecificOutput") {
+		t.Fatalf("Kimi Stop should append plain-stdout context, got JSON: %q", out)
+	}
+	if !strings.Contains(out, "Post-Task Diagnostics") || !strings.Contains(out, "TestFoo") {
+		t.Fatalf("expected the diagnostics briefing with test targets, got: %q", out)
+	}
+}
+
+func TestRunKimiStopSkipsWhenActive(t *testing.T) {
+	cwd := writeGortexProjectMarker(t, t.TempDir())
+	stubDaemonTool(t, map[string]string{
+		"detect_changes": `{"changed_files":["internal/foo.go"],"changed_symbols":[{"id":"internal/foo.go::Foo","name":"Foo","kind":"function"}],"risk":"LOW","summary":"1"}`,
+	})
+	out := captureStdout(t, func() {
+		runKimi([]byte(`{"hook_event_name":"Stop","cwd":`+strconv.Quote(cwd)+`,"stop_hook_active":true}`), 0, ModeDeny)
+	})
+	if out != "" {
+		t.Fatalf("expected silent no-op while a Stop hook is already rerunning, got: %q", out)
+	}
+}
+
+func TestRunKimiSubagentStartBriefsWithTask(t *testing.T) {
+	cwd := writeGortexProjectMarker(t, t.TempDir())
+	stubDaemonTool(t, map[string]string{
+		"graph_stats":   `{"total_nodes":100}`,
+		"smart_context": "FooHandler internal/foo.go:10",
+	})
+
+	out := captureStdout(t, func() {
+		runKimi([]byte(`{"hook_event_name":"SubagentStart","cwd":`+strconv.Quote(cwd)+`,"prompt":"refactor the auth handler"}`), 0, ModeDeny)
+	})
+	if strings.Contains(out, "hookSpecificOutput") {
+		t.Fatalf("subagent briefing must be plain stdout, got JSON: %q", out)
+	}
+	if !strings.Contains(out, "Use Gortex MCP tools") {
+		t.Fatalf("expected the tool-swap table, got: %q", out)
+	}
+	if !strings.Contains(out, "FooHandler") {
+		t.Fatalf("expected smart_context symbols in the briefing, got: %q", out)
+	}
+}
+
+func TestRunKimiSubagentStartFallbackWithoutTask(t *testing.T) {
+	cwd := writeGortexProjectMarker(t, t.TempDir())
+	stubDaemonTool(t, map[string]string{}) // bridge answers nothing
+
+	out := captureStdout(t, func() {
+		runKimi([]byte(`{"hook_event_name":"SubagentStart","cwd":`+strconv.Quote(cwd)+`}`), 0, ModeDeny)
+	})
+	if !strings.Contains(out, "Use Gortex MCP tools") {
+		t.Fatalf("expected the static tool-swap fallback briefing, got: %q", out)
+	}
+}
+
+func TestRunKimiSubagentStartOutsideProjectSilent(t *testing.T) {
+	stubDaemonTool(t, map[string]string{"graph_stats": `{"total_nodes":100}`})
+	out := captureStdout(t, func() {
+		runKimi([]byte(`{"hook_event_name":"SubagentStart","cwd":`+strconv.Quote(t.TempDir())+`,"prompt":"do work"}`), 0, ModeDeny)
+	})
+	if out != "" {
+		t.Fatalf("expected silent no-op outside a Gortex-enabled project, got: %q", out)
+	}
+}

--- a/internal/hooks/kimi_test.go
+++ b/internal/hooks/kimi_test.go
@@ -18,7 +18,7 @@ func TestRunKimiUserPromptSubmitPlainStdout(t *testing.T) {
 	defer restore()
 
 	out := captureStdout(t, func() {
-		runKimi(kimiPromptPayload(cwd, "fix auth token validation"))
+		runKimi(kimiPromptPayload(cwd, "fix auth token validation"), 0, ModeDeny)
 	})
 	if out == "" {
 		t.Fatal("expected Kimi prompt context, got empty output")
@@ -43,7 +43,7 @@ func TestRunKimiUserPromptSubmitContentParts(t *testing.T) {
 	defer restore()
 
 	out := captureStdout(t, func() {
-		runKimi([]byte(`{"hook_event_name":"UserPromptSubmit","cwd":` + strconv.Quote(cwd) + `,"prompt":[{"type":"text","text":"trace auth middleware"},{"type":"image","source":"ignored"}]}`))
+		runKimi([]byte(`{"hook_event_name":"UserPromptSubmit","cwd":`+strconv.Quote(cwd)+`,"prompt":[{"type":"text","text":"trace auth middleware"},{"type":"image","source":"ignored"}]}`), 0, ModeDeny)
 	})
 	if !strings.Contains(out, "AuthMiddleware") {
 		t.Fatalf("content-parts prompt did not produce context:\n%s", out)
@@ -74,7 +74,7 @@ func TestRunKimiPreToolUseGortexReadPlainStdout(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			out := captureStdout(t, func() {
-				runKimi(kimiPreToolPayload(cwd, tt.tool, `{"path":"internal/a.go"}`))
+				runKimi(kimiPreToolPayload(cwd, tt.tool, `{"path":"internal/a.go"}`), 0, ModeDeny)
 			})
 			if out == "" {
 				t.Fatal("expected Kimi MCP read PreToolUse guidance, got empty output")
@@ -137,7 +137,7 @@ func TestRunKimiPreToolUseGortexReadSilentShapes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			out := captureStdout(t, func() {
-				runKimi(kimiPreToolPayload(tt.cwd, tt.tool, tt.input))
+				runKimi(kimiPreToolPayload(tt.cwd, tt.tool, tt.input), 0, ModeDeny)
 			})
 			if out != "" {
 				t.Fatalf("expected silent no-op, got %q", out)
@@ -157,7 +157,7 @@ func TestRunKimiNoopShapes(t *testing.T) {
 		kimiPromptPayload(cwd, "/clear"),
 	}
 	for _, tc := range cases {
-		out := captureStdout(t, func() { runKimi(tc) })
+		out := captureStdout(t, func() { runKimi(tc, 0, ModeDeny) })
 		if out != "" {
 			t.Fatalf("expected no output for %s, got %q", tc, out)
 		}
@@ -175,7 +175,7 @@ func TestRunKimiNoopOutsideGortexProject(t *testing.T) {
 	defer restore()
 
 	out := captureStdout(t, func() {
-		runKimi(kimiPromptPayload(t.TempDir(), "fix auth token validation"))
+		runKimi(kimiPromptPayload(t.TempDir(), "fix auth token validation"), 0, ModeDeny)
 	})
 	if out != "" {
 		t.Fatalf("expected no output outside a Gortex-enabled project, got %q", out)

--- a/internal/hooks/precompact.go
+++ b/internal/hooks/precompact.go
@@ -177,11 +177,31 @@ func cappedLines(s string, max int) string {
 	return strings.Join(lines, "\n") + "\n"
 }
 
-// callServerTool issues a POST /v1/tools/{name} against the server and returns
-// the text content from the first response block. Returns empty string on any
-// error (server unreachable, non-200, missing content) so callers can degrade
-// silently.
+// callServerTool resolves a Gortex tool call for a hook handler. It first
+// tries the HTTP REST surface (POST /v1/tools/{name} on the given port, served
+// only when the daemon runs with --http-addr); when that yields nothing it
+// falls back to the daemon's AF_UNIX socket, scoped to the current hook's
+// working directory. Returns "" on any error so callers degrade silently.
+//
+// The socket fallback is gated on a set hookCWD (see setHookCWD): the pure-HTTP
+// unit tests never set it, so they keep their existing "no bridge" semantics,
+// while a live hook process — which sets hookCWD from the payload — reaches a
+// normally-running daemon that only listens on the socket.
 func callServerTool(port int, name string, args map[string]any) string {
+	if raw := callServerToolHTTP(port, name, args); raw != "" {
+		return raw
+	}
+	cwd := loadHookCWD()
+	if cwd == "" {
+		return ""
+	}
+	return callServerToolDaemonFn(cwd, name, args)
+}
+
+// callServerToolHTTP issues a POST /v1/tools/{name} against the server and
+// returns the text content from the first response block. Returns empty string
+// on any error (server unreachable, non-200, missing content).
+func callServerToolHTTP(port int, name string, args map[string]any) string {
 	if args == nil {
 		args = map[string]any{}
 	}


### PR DESCRIPTION
Closes #214.

Kimi Code CLI support was previously **UserPromptSubmit + a read-tool nudge** only. This brings it to parity with the Claude Code and Codex adapters, so weaker-instruction-following models get the full deterministic hook loop the issue asks for: context injection, tool redirection, and post-turn correction.

## What's added

| Event | Behavior |
| ----- | -------- |
| `UserPromptSubmit` | *(existing)* injects graph symbols relevant to the prompt before the model runs. |
| `PreToolUse` | **new** — native `Read`/`Grep`/`Glob`/`Bash` run through the shared enrich machinery: a hard `deny` for an indexed whole-file read, soft plain-stdout guidance otherwise; keeps the `read_file`/`get_editing_context` compress-bodies nudge. |
| `Stop` | **new** — post-turn diagnostics (changed symbols → test targets, guards, dead code, coverage, contracts), fed back so the agent self-corrects before handoff. |
| `SubagentStart` | **new** — briefs a spawned subagent with `smart_context` results and the tool-swap table so it doesn't default to raw `Read`/`Grep`. |

## Wire protocol

Kimi cloned Claude Code's hook schema, so a hard block uses the one JSON shape Kimi documents — `hookSpecificOutput.permissionDecision = "deny"` — and all soft guidance rides Kimi's plain-stdout context channel (matching the established Kimi contract). Every path stays gated to Gortex-enabled projects and degrades to a **silent no-op** when the payload is malformed, the cwd is outside a project, or the daemon is unreachable — so normal Kimi flow is never blocked by the integration.

## Transport fix (why the Stop path is non-vacuous)

`callServerTool` (used by the Stop and subagent diagnostics) only spoke the HTTP `:8765` surface, which the daemon serves **only under `--http-addr`** — so it was dead by default. It now falls back to the daemon's AF_UNIX socket, scoped to the hook cwd. The fallback is gated on a recorded cwd, so the pure-HTTP unit tests are unaffected and non-Kimi agents keep their current behavior.

## Not included

`SubagentStop` is intentionally left out — the `Stop` hook already covers end-of-turn diagnostics, and a per-subagent variant would mostly add noise. Easy to add later if it proves useful.

## Verification

- `go build ./...`, `go vet`, `gofmt`, `golangci-lint` — all clean.
- `go test -race ./internal/hooks/... ./internal/agents/...` — **527 pass** (new tests cover the native-tool deny JSON, soft-stdout guidance, Stop diagnostics, subagent briefing + fallback, project gating, and the transport fallback gating).
- `go test ./cmd/gortex/ -run 'AgentRender|Hook|Kimi|Install|Init'` — 29 pass.
- Docs: `docs/agents.md` adapter matrix + per-agent `### kimi` note added.