### PR TITLE
fix(mcp): stop the stdio proxy gating tools/call in defer mode

### DIFF
--- a/cmd/gortex/proxy_filter.go
+++ b/cmd/gortex/proxy_filter.go
@@ -45,8 +45,11 @@ func proxyToolSurface() *gortexmcp.ToolSurface {
 // synthesized JSON-RPC error reply (to write back to the client) and
 // gated=true — the original frame must NOT reach the daemon, so a client
 // that hard-codes a hidden tool name cannot bypass the restriction.
+// Only hide mode gates calls: in defer mode the surface trims tools/list
+// but keeps every tool callable, mirroring the server-side defer
+// semantics where tools_search promotion makes deferred tools live.
 func gateToolCallFrame(line []byte, surface *gortexmcp.ToolSurface) (reply []byte, gated bool) {
-	if !surface.Active() {
+	if !surface.GateCalls() {
 		return nil, false
 	}
 	var msg struct {

--- a/cmd/gortex/proxy_filter_test.go
+++ b/cmd/gortex/proxy_filter_test.go
@@ -97,6 +97,18 @@ func TestGateToolCallFrame(t *testing.T) {
 	inactive := gortexmcp.NewToolSurface(gortexmcp.ToolPolicyConfig{}, zap.NewNop())
 	_, gated = gateToolCallFrame(blocked, inactive)
 	require.False(t, gated)
+
+	// Defer mode trims tools/list but never gates calls — non-listed
+	// tools stay reachable, mirroring server-side tools_search promotion.
+	deferred := gortexmcp.NewToolSurface(gortexmcp.ToolPolicyConfig{
+		Allow: []string{"search_symbols", "edit_file"}, Mode: "defer",
+	}, zap.NewNop())
+	require.True(t, deferred.Active())
+	require.False(t, deferred.GateCalls())
+	_, gated = gateToolCallFrame(blocked, deferred)
+	require.False(t, gated, "defer mode must not gate tools/call")
+	trimmed := filterToolsListFrame([]byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"analyze"},{"name":"edit_file"}]}}`+"\n"), deferred)
+	require.NotContains(t, string(trimmed), "analyze", "defer mode still trims tools/list")
 }
 
 func TestToolPolicyConfigFromFlags(t *testing.T) {

--- a/internal/mcp/tool_presets.go
+++ b/internal/mcp/tool_presets.go
@@ -374,6 +374,15 @@ func (s *ToolSurface) Allows(name string) bool {
 	return s.p.allows(name)
 }
 
+// GateCalls reports whether disallowed tools should be blocked at call
+// time. True only for an active surface in hide mode; defer mode keeps
+// non-listed tools reachable (the proxy analogue of the server keeping
+// deferred tools callable after a tools_search promotion). A nil or
+// inactive surface gates nothing.
+func (s *ToolSurface) GateCalls() bool {
+	return s != nil && s.p.hideMode()
+}
+
 // Preset returns the resolved preset label (full / readonly / edit / nav
 // / custom) for logging.
 func (s *ToolSurface) Preset() string {


### PR DESCRIPTION
## Summary

The stdio proxy (gortex mcp --tools / GORTEX_TOOLS) hard-blocked tools/call to any tool outside the configured surface regardless of --tools-mode, contradicting the flag's own help text ("defer (keep reachable via tools_search)"). In defer mode a client that calls tools_search gets its matches promoted server-side, but the proxy then synthesized a -32601 for every call to them — promotion worked, calling the promoted tool didn't.

Reproduced live: with GORTEX_TOOLS=core GORTEX_TOOLS_MODE=defer on the proxy, tools_search query:"select:taint_paths" promote:true succeeded, but the follow-up tools/call taint_paths came back tool "taint_paths" is not available in this client's tool set (gortex mcp --tools).

The fix mirrors the server-side defer semantics on the proxy: defer trims tools/list but never gates calls; hide (the default) keeps blocking both, unchanged.

## Changes

- internal/mcp/tool_presets.go: add ToolSurface.GateCalls() — true only for an active surface in hide mode; nil/inactive/defer surfaces gate nothing.
- cmd/gortex/proxy_filter.go: gateToolCallFrame now checks surface.GateCalls() instead of surface.Active(), so defer mode forwards every tools/call to the daemon while filterToolsListFrame still trims tools/list. Hide-mode behavior is byte-for-byte unchanged.
- cmd/gortex/proxy_filter_test.go: new defer-mode case in TestGateToolCallFrame — asserts a disallowed tool is not gated in defer mode and that tools/list is still trimmed.

## Testing

- [x] All tests pass (`go test -race ./...`)
- [x] New tests added for new functionality
- [ ] Benchmarks run if performance-relevant

## Checklist

- [x] Code follows existing patterns in the codebase
- [x] No unnecessary abstractions added
- [ ] Language extractor includes `Meta["methods"]` for interfaces (if applicable)
- [ ] Methods have `EdgeMemberOf` edges to their containing type (if applicable)
