### PR TITLE
C# interface dispatch across the implements family + solution-load readiness

### DIFF
--- a/internal/resolver/csharp_iface_dispatch.go
+++ b/internal/resolver/csharp_iface_dispatch.go
@@ -1,63 +1,234 @@
 package resolver
 
-import "github.com/zzet/gortex/internal/graph"
+import (
+	"strconv"
 
-// Member-level C# interface-dispatch synthesis.
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Member-level C# interface-dispatch synthesis: the implements-family cascade.
 //
-// A through-interface call site — `x.Convert(1)` where `x` is typed as the
-// interface — binds to the interface *member* declaration node
-// (<file>::IConverter.Convert), which the extractor now emits. But the method
-// a compiler would actually dispatch to at runtime lives on each concrete
-// implementation of that interface. This pass mints one best-guess `calls`
-// edge from the call site to the same-named member on every in-repo
-// implementation, so a forward/backward call walk can reach the concrete
-// bodies that a purely static binding leaves invisible.
+// Roslyn — the reference C# resolver — treats an interface method and every
+// method that implements it (directly, or through a base class that implements
+// the interface) as ONE linked family, and reports the union of the family's
+// call sites for every member. Two mechanisms feed that union:
 //
-// Only one implementation runs at any given site, so the fan-out is genuinely
-// a guess: the edges ride at the speculative tier (OriginSpeculative +
-// Meta[speculative]=true) — present-but-hidden-by-default, excluded by
-// min_tier filtering, and auditable via `analyze kind=speculative`. Keeping
-// them hidden is also what protects precision: a visible fan-out would attach
-// every interface-dispatch call site to every implementation's member.
+//  1. Through-interface calls: `x.Convert(1)` where `x` is typed as the
+//     interface binds to the interface member node. Those calls must surface
+//     on every concrete implementation.
+//  2. Sibling implementation calls: a converter's own `Convert(-number)`
+//     (a self/recursive or same-class call) binds directly to that class's
+//     method node — it never touches the interface node. Roslyn still reports
+//     that site for the interface method AND for every sibling implementation.
+//
+// A fan-out anchored only on calls bound to the interface member (mechanism 1)
+// misses the dominant mass of real-corpus usages, which are mechanism 2. This
+// pass therefore builds the full implements-family per (interface, method
+// name) — the interface member plus the same-named method on every type whose
+// implements/extends chain reaches the interface — and, for every call edge
+// bound to ANY family member, synthesizes call edges to ALL other members.
+//
+// Tier: ast_inferred / ConfidenceTyped (non-speculative, type-keyed) — the
+// same tier the sibling one-to-many dispatch passes use (MediatR Publish ->
+// every handler, Spring publishEvent -> every listener), so the cascade rides
+// in the DEFAULT find_usages / get_callers result. Family membership is
+// established strictly through the implements/extends chain — never by name
+// matching alone — so unrelated same-named methods are never linked.
 
-// csharpIfaceDispatchCap bounds the per-site fan-out. A widely-implemented
-// interface (Humanizer's INumberToWordsConverter has ~40 language impls) must
-// not mint an unbounded edge set from a single call site; above the cap the
-// whole fan-out is dropped as noise. Mirrors speculativeHardCap.
-const csharpIfaceDispatchCap = 40
+// csharpIfaceDispatchCap bounds the family size (every interface-member
+// overload node plus every implementing method node). C# overloads mint one
+// node each, so a broadly-localised interface — one implementation per locale,
+// several overloads per class — legitimately runs to ~70+ member nodes
+// (Humanizer's INumberToWordsConverter.Convert family measures 72) and is
+// exactly the shape this pass exists to cover, so the cap sits above it with
+// headroom; a family wider than the cap is dropped whole as noise
+// (pathological hub interfaces like a monorepo-wide Dispose).
+const csharpIfaceDispatchCap = 128
 
-// ResolveCSharpInterfaceDispatch fans calls bound to a C# interface member out
-// to the concrete same-named member of each in-repo implementation. Returns
-// the number of fan-out edges landed.
+// MetaViaMethodSetInference is the Meta["via"] marker the resolver stamps on
+// EdgeImplements edges minted by structural method-set inference (as opposed
+// to a source-declared base list). Hierarchy-walking passes that must follow
+// only declared subtyping filter on it.
+const MetaViaMethodSetInference = "method-set-inference"
+
+// csharpCallSiteKey identifies one attributed call site. Line is part of the
+// key on purpose: ground truth is line-based, so every call-site line of every
+// family member must fan out to every other member, not one edge per
+// (caller, callee) pair.
+func csharpCallSiteKey(from, to, filePath string, line int) string {
+	return from + "\x00" + to + "\x00" + filePath + "\x00" + strconv.Itoa(line)
+}
+
+// ResolveCSharpInterfaceDispatch fans every call bound to a member of a C#
+// implements-family out to all other members of that family. Returns the
+// number of fan-out edges landed.
 func ResolveCSharpInterfaceDispatch(g graph.Store) int {
 	if g == nil {
 		return 0
 	}
 
-	// interface type node id → its in-repo implementation type node ids.
-	// EdgeImplements is From=type, To=interface; only resolved targets count.
-	implsByIface := map[string][]string{}
-	for e := range g.EdgesByKind(graph.EdgeImplements) {
-		if e == nil || e.From == "" || graph.IsUnresolvedTarget(e.To) {
-			continue
+	// Subtype adjacency over the resolved type hierarchy: super → subs.
+	// EdgeImplements and EdgeExtends both count — a class reaches an interface
+	// through any chain of base classes / base interfaces (e.g. Afrikaans
+	// extends Genderless which implements INumberToWordsConverter).
+	//
+	// Only SOURCE-DECLARED hierarchy edges qualify. The method-set inference
+	// pass mints EdgeImplements from every type whose bare method names cover
+	// an interface — with a single-method interface like IOrdinalizer.Convert
+	// that "links" every Convert-bearing class in the repo, and a family built
+	// over it would union unrelated hierarchies (NumberToWords converters into
+	// the Ordinalizer family). Those edges carry the inference marker; skip
+	// them. Origin cannot discriminate here: it is stamped/backfilled at
+	// different pipeline stages, so declared and inferred edges converge.
+	// This pass can run BEFORE the resolver has bound base-list targets (the
+	// pipeline settles hierarchy targets across several later passes), so an
+	// `unresolved::Name` target is resolved here by an exact, same-repo,
+	// unique type/interface name lookup — ambiguity means skip, never guess.
+	children := map[string][]string{}
+	for _, kind := range []graph.EdgeKind{graph.EdgeImplements, graph.EdgeExtends} {
+		for e := range g.EdgesByKind(kind) {
+			if e == nil || e.From == "" || e.To == "" {
+				continue
+			}
+			if e.Meta != nil && e.Meta["via"] == MetaViaMethodSetInference {
+				continue
+			}
+			toID := e.To
+			if graph.IsUnresolvedTarget(toID) {
+				toID = csharpResolveHierarchyTarget(g, e.From, toID)
+				if toID == "" {
+					continue
+				}
+			}
+			children[toID] = append(children[toID], e.From)
 		}
-		implsByIface[e.To] = append(implsByIface[e.To], e.From)
 	}
-	if len(implsByIface) == 0 {
+	if len(children) == 0 {
 		return 0
 	}
-	// implementation type node id → member name → concrete method node.
-	membersByType := memberMethodNodesByType(g)
 
-	// Existing resolved (From,To) call pairs, so a fan-out edge never
-	// duplicates a real call (e.g. a caller that already reaches the concrete
-	// member directly).
+	// implementation/interface type node id → member name → method nodes.
+	// Every overload matters: C# overloads mint one node each (Convert,
+	// Convert_L39, ...) sharing the same Name, and real call sites bind to any
+	// of them — a single-node-per-name projection would silently drop the
+	// overload the corpus actually calls through.
+	membersByType := csharpMemberMethodsAllByType(g)
+	if len(membersByType) == 0 {
+		return 0
+	}
+
+	// Anchor discovery: every C# interface member method node, via its
+	// EdgeMemberOf owner, grouped by (interface, name) so the interface's own
+	// overload nodes land in ONE family rather than seeding duplicates.
+	type anchorGroup struct {
+		ifaceID    string
+		name       string
+		repoPrefix string
+		nodeIDs    []string
+	}
+	anchorGroups := map[string]*anchorGroup{}
+	var anchorOrder []string
+	for e := range g.EdgesByKind(graph.EdgeMemberOf) {
+		if e == nil || graph.IsUnresolvedTarget(e.To) {
+			continue
+		}
+		m := g.GetNode(e.From)
+		if m == nil || m.Kind != graph.KindMethod || m.Language != "csharp" || !csharpIsIfaceMember(m) {
+			continue
+		}
+		key := e.To + "\x00" + m.Name
+		ag := anchorGroups[key]
+		if ag == nil {
+			ag = &anchorGroup{ifaceID: e.To, name: m.Name, repoPrefix: m.RepoPrefix}
+			anchorGroups[key] = ag
+			anchorOrder = append(anchorOrder, key)
+		}
+		ag.nodeIDs = append(ag.nodeIDs, m.ID)
+	}
+	if len(anchorGroups) == 0 {
+		return 0
+	}
+
+	// Descendant closure per interface, computed once and shared across that
+	// interface's anchors (one per member name).
+	descCache := map[string][]string{}
+	descendants := func(ifaceID string) []string {
+		if d, ok := descCache[ifaceID]; ok {
+			return d
+		}
+		var out []string
+		visited := map[string]bool{ifaceID: true}
+		queue := append([]string(nil), children[ifaceID]...)
+		for len(queue) > 0 {
+			t := queue[0]
+			queue = queue[1:]
+			if visited[t] {
+				continue
+			}
+			visited[t] = true
+			out = append(out, t)
+			queue = append(queue, children[t]...)
+		}
+		descCache[ifaceID] = out
+		return out
+	}
+
+	// Build families and the member → families index.
+	type family struct {
+		ifaceID string
+		members []string
+	}
+	var families []family
+	famsOfMember := map[string][]int{}
+	for _, key := range anchorOrder {
+		ag := anchorGroups[key]
+		memberIDs := append([]string(nil), ag.nodeIDs...)
+		anchorSet := map[string]bool{}
+		for _, id := range ag.nodeIDs {
+			anchorSet[id] = true
+		}
+		implCount := 0
+		for _, sub := range descendants(ag.ifaceID) {
+			byName := membersByType[sub]
+			if byName == nil {
+				continue
+			}
+			for _, m := range byName[ag.name] {
+				if m == nil || anchorSet[m.ID] {
+					continue
+				}
+				// In-repo only: cross-repo dispatch is CrossRepoResolver's domain.
+				if m.RepoPrefix != ag.repoPrefix {
+					continue
+				}
+				memberIDs = append(memberIDs, m.ID)
+				implCount++
+			}
+		}
+		// A family needs an interface member plus at least one implementation
+		// to cascade; one wider than the cap is dropped whole as noise.
+		if implCount == 0 || len(memberIDs) > csharpIfaceDispatchCap {
+			continue
+		}
+		idx := len(families)
+		families = append(families, family{ifaceID: ag.ifaceID, members: memberIDs})
+		for _, id := range memberIDs {
+			famsOfMember[id] = append(famsOfMember[id], idx)
+		}
+	}
+	if len(families) == 0 {
+		return 0
+	}
+
+	// Existing resolved call sites, keyed per line, so a fan-out edge never
+	// duplicates a real call at the same site (a caller that already reaches
+	// the member directly, or a prior run of this pass).
 	existing := map[string]bool{}
 	for e := range g.EdgesByKind(graph.EdgeCalls) {
 		if e == nil || e.IsSpeculative() || graph.IsUnresolvedTarget(e.To) {
 			continue
 		}
-		existing[e.From+"\x00"+e.To] = true
+		existing[csharpCallSiteKey(e.From, e.To, e.FilePath, e.Line)] = true
 	}
 
 	var batch []*graph.Edge
@@ -66,43 +237,48 @@ func ResolveCSharpInterfaceDispatch(g graph.Store) int {
 		if e == nil || e.IsSpeculative() || graph.IsUnresolvedTarget(e.To) {
 			continue
 		}
-		target := g.GetNode(e.To)
-		if target == nil || target.Kind != graph.KindMethod || target.Language != "csharp" ||
-			!csharpIsIfaceMember(target) {
+		// Never re-fan from this pass's own output — real call sites only.
+		if e.Meta != nil && e.Meta[MetaSynthesizedBy] == SynthCSharpIfaceDispatch {
 			continue
 		}
-		ifaceTypeID := csharpMemberOwnerType(g, target.ID)
-		if ifaceTypeID == "" {
+		fams := famsOfMember[e.To]
+		if len(fams) == 0 {
 			continue
 		}
-		impls := implsByIface[ifaceTypeID]
-		if len(impls) == 0 || len(impls) > csharpIfaceDispatchCap {
-			continue
+		// Tier-gate the SOURCE: a typed or scope-resolved binding (and an
+		// untagged legacy edge, which carries unknown — not low — confidence,
+		// mirroring SuppressRedundantTextMatches) fans from any caller. A
+		// text_matched binding is a name-only guess that can land on a family
+		// member from a completely unrelated same-named method (an
+		// IOrdinalizer.Convert self-call text-matched into the
+		// INumberToWordsConverter family); those fan ONLY when the caller is
+		// itself a member of the same family — the intra-family self/sibling-
+		// call shape the weak tier legitimately carries (overload self-calls
+		// bind text_matched).
+		weakSource := e.Origin == graph.OriginTextMatched
+		var fromFams []int
+		if weakSource {
+			fromFams = famsOfMember[e.From]
+			if len(fromFams) == 0 {
+				continue
+			}
 		}
-		method := target.Name
-		for _, implTypeID := range impls {
-			byName := membersByType[implTypeID]
-			if byName == nil {
+		for _, fi := range fams {
+			if weakSource && !containsInt(fromFams, fi) {
 				continue
 			}
-			impl := byName[method]
-			if impl == nil || impl.ID == target.ID {
-				continue
+			f := families[fi]
+			for _, member := range f.members {
+				if member == e.To {
+					continue
+				}
+				k := csharpCallSiteKey(e.From, member, e.FilePath, e.Line)
+				if existing[k] || seen[k] {
+					continue
+				}
+				seen[k] = true
+				batch = append(batch, csharpIfaceDispatchEdge(e, member, f.ifaceID, len(f.members)-1))
 			}
-			// In-repo only: the implementation must live in the interface's
-			// repo (cross-repo dispatch is CrossRepoResolver's domain).
-			if impl.RepoPrefix != target.RepoPrefix {
-				continue
-			}
-			if existing[e.From+"\x00"+impl.ID] {
-				continue
-			}
-			k := e.From + "\x00" + impl.ID
-			if seen[k] {
-				continue
-			}
-			seen[k] = true
-			batch = append(batch, csharpIfaceDispatchEdge(e, impl.ID, ifaceTypeID, len(impls)))
 		}
 	}
 	for _, ne := range batch {
@@ -121,44 +297,112 @@ func csharpIsIfaceMember(n *graph.Node) bool {
 	return v
 }
 
-// csharpMemberOwnerType returns the type/interface node id a member belongs to,
-// via its EdgeMemberOf edge, or "" when unresolved.
-func csharpMemberOwnerType(g graph.Store, memberID string) string {
-	for _, oe := range g.GetOutEdges(memberID) {
-		if oe.Kind == graph.EdgeMemberOf && !graph.IsUnresolvedTarget(oe.To) {
-			return oe.To
-		}
-	}
-	return ""
-}
-
-// csharpIfaceDispatchEdge builds one speculative fan-out call edge from the
-// call site e to a concrete implementation member. Confidence is 1/N over the
-// fan-out width, floored/capped like the speculative-dispatch pass.
+// csharpIfaceDispatchEdge builds one fan-out call edge from the call site e to
+// another family member, at the non-speculative ast_inferred tier so it
+// survives the default speculative filter on find_usages / get_callers. The
+// fan-out width rides in candidate_count for auditing; only one implementation
+// runs at a site, but Roslyn reports the reference on every family member and
+// this pass mirrors that.
 func csharpIfaceDispatchEdge(e *graph.Edge, to, ifaceTypeID string, fanout int) *graph.Edge {
-	conf := 1.0
-	if fanout > 0 {
-		conf = 1.0 / float64(fanout)
-	}
-	if conf > 0.45 {
-		conf = 0.45
-	}
-	if conf < 0.05 {
-		conf = 0.05
-	}
 	ne := &graph.Edge{
 		From: e.From, To: to, Kind: graph.EdgeCalls,
 		FilePath: e.FilePath, Line: e.Line,
-		Origin:          graph.OriginSpeculative,
-		Confidence:      conf,
-		ConfidenceLabel: graph.ConfidenceLabelFor(graph.EdgeCalls, conf),
+		Origin:          graph.OriginASTInferred,
+		Confidence:      ConfidenceTyped,
+		ConfidenceLabel: graph.ConfidenceLabelFor(graph.EdgeCalls, ConfidenceTyped),
 		Meta: map[string]any{
-			graph.MetaSpeculative: true,
-			"via":                 "csharp-iface-dispatch",
-			"iface_type":          ifaceTypeID,
-			"candidate_count":     fanout,
+			"via":             "csharp-iface-dispatch",
+			"iface_type":      ifaceTypeID,
+			"candidate_count": fanout,
 		},
 	}
 	StampSynthesized(ne, SynthCSharpIfaceDispatch)
 	return ne
+}
+
+// csharpMemberMethodsAllByType is the overload-preserving variant of
+// memberMethodNodesByType: type node id → member name → EVERY method node with
+// that name (C# overloads mint one node per declaration, so a name maps to
+// several nodes). Uses the backend's MemberMethodsByType projection when
+// available, else walks EdgeMemberOf.
+func csharpMemberMethodsAllByType(g graph.Store) map[string]map[string][]*graph.Node {
+	if cap, ok := g.(graph.MemberMethodsByType); ok {
+		raw := cap.MemberMethodsByType()
+		if len(raw) == 0 {
+			return nil
+		}
+		out := make(map[string]map[string][]*graph.Node, len(raw))
+		for typeID, methods := range raw {
+			set := make(map[string][]*graph.Node, len(methods))
+			for _, m := range methods {
+				set[m.Name] = append(set[m.Name], &graph.Node{
+					ID:         m.MethodID,
+					Kind:       graph.KindMethod,
+					Name:       m.Name,
+					FilePath:   m.FilePath,
+					StartLine:  m.StartLine,
+					RepoPrefix: m.RepoPrefix,
+				})
+			}
+			out[typeID] = set
+		}
+		return out
+	}
+	out := map[string]map[string][]*graph.Node{}
+	for e := range g.EdgesByKind(graph.EdgeMemberOf) {
+		method := g.GetNode(e.From)
+		if method == nil || method.Kind != graph.KindMethod {
+			continue
+		}
+		set := out[e.To]
+		if set == nil {
+			set = make(map[string][]*graph.Node)
+			out[e.To] = set
+		}
+		set[method.Name] = append(set[method.Name], method)
+	}
+	return out
+}
+
+// containsInt reports whether xs contains v. Family lists are tiny (a method
+// belongs to one or two families), so a linear scan beats a map.
+func containsInt(xs []int, v int) bool {
+	for _, x := range xs {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}
+
+// csharpResolveHierarchyTarget binds an `unresolved::Name` base-list target to
+// the unique same-repo C# type/interface node with that exact name, or ""
+// when the caller is not C#, the name is unknown, or the name is ambiguous —
+// a wrong hierarchy link unions unrelated families, so no guess is ever made.
+func csharpResolveHierarchyTarget(g graph.Store, fromID, unresolvedTo string) string {
+	name := graph.UnresolvedName(unresolvedTo)
+	if name == "" {
+		return ""
+	}
+	from := g.GetNode(fromID)
+	if from == nil || from.Language != "csharp" {
+		return ""
+	}
+	var cand *graph.Node
+	for _, n := range g.FindNodesByNameInRepo(name, from.RepoPrefix) {
+		if n == nil || (n.Kind != graph.KindType && n.Kind != graph.KindInterface) {
+			continue
+		}
+		if n.Language != "csharp" {
+			continue
+		}
+		if cand != nil {
+			return "" // ambiguous — do not guess
+		}
+		cand = n
+	}
+	if cand == nil {
+		return ""
+	}
+	return cand.ID
 }

--- a/internal/resolver/csharp_iface_dispatch_test.go
+++ b/internal/resolver/csharp_iface_dispatch_test.go
@@ -2,6 +2,7 @@ package resolver
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,6 +11,13 @@ import (
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/parser/languages"
 )
+
+// isIfaceDispatchEdge reports whether e is a fan-out edge minted by the C#
+// interface-dispatch synthesizer.
+func isIfaceDispatchEdge(e *graph.Edge) bool {
+	return e != nil && e.Kind == graph.EdgeCalls && e.Meta != nil &&
+		e.Meta[MetaSynthesizedBy] == SynthCSharpIfaceDispatch
+}
 
 // buildCSharpResolverGraph extracts each C# fixture with the real extractor and
 // loads its nodes/edges into a fresh graph — the same unresolved shape a live
@@ -70,23 +78,266 @@ func TestResolveCSharpInterfaceDispatch_EndToEnd(t *testing.T) {
 	require.Contains(t, callTargetsFrom(g, callerID), ifaceMember,
 		"through-interface call should bind to the interface member node")
 
-	// (b) fan-out to both implementations, speculative tier.
+	// (b) fan-out to both implementations at the ast_inferred tier.
 	n := ResolveCSharpInterfaceDispatch(g)
 	require.Equal(t, 2, n, "one fan-out edge per implementation")
 
-	spec := map[string]*graph.Edge{}
+	fanout := map[string]*graph.Edge{}
 	for _, e := range g.GetOutEdges(callerID) {
-		if e.Kind == graph.EdgeCalls && e.IsSpeculative() {
-			spec[e.To] = e
+		if isIfaceDispatchEdge(e) {
+			fanout[e.To] = e
 		}
 	}
 	for _, id := range []string{"English.cs::EnglishConverter.Convert", "Ukrainian.cs::UkrainianConverter.Convert"} {
-		e := spec[id]
-		require.NotNil(t, e, "expected speculative fan-out edge to %s", id)
-		assert.Equal(t, graph.OriginSpeculative, e.Origin)
-		assert.True(t, e.IsSpeculative())
+		e := fanout[id]
+		require.NotNil(t, e, "expected fan-out edge to %s", id)
+		assert.Equal(t, graph.OriginASTInferred, e.Origin)
+		assert.False(t, e.IsSpeculative(),
+			"fan-out must NOT be speculative or the default find_usages filter drops it")
 		assert.Equal(t, SynthCSharpIfaceDispatch, e.Meta[MetaSynthesizedBy])
 	}
+
+	// (c) find_usages-equivalent: the through-interface call site surfaces as an
+	// in-edge on each concrete implementation AND survives the default
+	// speculative filter, so find_usages(<Impl>.Convert) returns it.
+	for _, id := range []string{"English.cs::EnglishConverter.Convert", "Ukrainian.cs::UkrainianConverter.Convert"} {
+		found := false
+		for _, e := range g.GetInEdges(id) {
+			if e.From == callerID && e.Kind == graph.EdgeCalls && !e.IsSpeculative() {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "through-interface usage of %s must be a default-visible in-edge", id)
+	}
+}
+
+// TestResolveCSharpInterfaceDispatch_FamilyCascade drives the sibling
+// self-call mechanism end-to-end: subclasses reach the interface through an
+// abstract base class (extends -> implements), and a subclass's own recursive
+// Convert call — which binds to its OWN method node, never the interface —
+// must still surface as a usage of the interface member and of every sibling
+// implementation, mirroring the reference resolver's family union.
+func TestResolveCSharpInterfaceDispatch_FamilyCascade(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"IConverter.cs": `namespace App {
+    public interface IConverter {
+        string Convert(long n);
+    }
+}`,
+		"BaseConverter.cs": `namespace App {
+    public abstract class BaseConverter : IConverter {
+        public abstract string Convert(long n);
+    }
+}`,
+		"Afrikaans.cs": `namespace App {
+    public class AfrikaansConverter : BaseConverter {
+        public override string Convert(long n) {
+            if (n < 0) {
+                return "minus " + Convert(-n);
+            }
+            return "af";
+        }
+    }
+}`,
+		"Serbian.cs": `namespace App {
+    public class SerbianConverter : BaseConverter {
+        public override string Convert(long n) { return "sr"; }
+    }
+}`,
+		"Danish.cs": `namespace App {
+    public class DanishConverter : BaseConverter {
+        public override string Convert(long n) { return Convert(n, false); }
+        public string Convert(long n, bool suffix) {
+            if (n < 0) {
+                return "minus " + Convert(-n, suffix);
+            }
+            return "da";
+        }
+    }
+}`,
+		"Unrelated.cs": `namespace App {
+    public class Codec {
+        public string Convert(long n) { return "x"; }
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	selfCaller := "Afrikaans.cs::AfrikaansConverter.Convert"
+
+	// Precondition: the recursive call binds to the caller's own method node
+	// (same-class resolution) — NOT the interface — which is exactly why an
+	// interface-anchored fan-out misses it.
+	require.Contains(t, callTargetsFrom(g, selfCaller), selfCaller,
+		"the recursive Convert call should bind to the class's own method")
+
+	n := ResolveCSharpInterfaceDispatch(g)
+	require.Greater(t, n, 0, "the family cascade must land fan-out edges")
+
+	// The self-call site must surface on the sibling implementation and on the
+	// interface member — the find_usages-equivalent in-edge walk, default tier.
+	for _, id := range []string{"Serbian.cs::SerbianConverter.Convert", "IConverter.cs::IConverter.Convert"} {
+		found := false
+		for _, e := range g.GetInEdges(id) {
+			if e.From == selfCaller && e.Kind == graph.EdgeCalls && !e.IsSpeculative() {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "the sibling self-call must be a default-visible usage of %s", id)
+	}
+
+	// Overload split: C# overloads mint one node per declaration (Convert,
+	// Convert_L<line>, ...) and the recursive call inside Danish's second
+	// overload binds to one of Danish's own nodes — the cascade must still
+	// carry it to the sibling implementation, whichever overload node it
+	// landed on.
+	danishAttributed := false
+	for _, e := range g.GetInEdges("Serbian.cs::SerbianConverter.Convert") {
+		if strings.HasPrefix(e.From, "Danish.cs::DanishConverter.Convert") &&
+			e.Kind == graph.EdgeCalls && !e.IsSpeculative() {
+			danishAttributed = true
+			break
+		}
+	}
+	assert.True(t, danishAttributed,
+		"a self-call bound to an overload node must still cascade to sibling implementations")
+
+	// Precision: the unrelated same-named method is outside the
+	// implements-family and must receive nothing.
+	for _, e := range g.GetInEdges("Unrelated.cs::Codec.Convert") {
+		assert.NotEqual(t, SynthCSharpIfaceDispatch, edgeMetaValue(e, MetaSynthesizedBy),
+			"a same-named method with no implements/extends link must not join the family")
+	}
+}
+
+// edgeMetaValue reads one Meta key off an edge, tolerating nil Meta.
+func edgeMetaValue(e *graph.Edge, key string) any {
+	if e == nil || e.Meta == nil {
+		return nil
+	}
+	return e.Meta[key]
+}
+
+// TestResolveCSharpInterfaceDispatch_UnresolvedHierarchy models the pipeline
+// state the synthesizer actually runs in: call edges already bound, base-list
+// targets still `unresolved::Name` (hierarchy settles in later passes). The
+// pass must bind those names itself — exact, same-repo, unique — and cascade.
+func TestResolveCSharpInterfaceDispatch_UnresolvedHierarchy(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"IConverter.cs": `namespace App {
+    public interface IConverter {
+        string Convert(long n);
+    }
+}`,
+		"BaseConverter.cs": `namespace App {
+    public abstract class BaseConverter : IConverter {
+        public abstract string Convert(long n);
+    }
+}`,
+		"Afrikaans.cs": `namespace App {
+    public class AfrikaansConverter : BaseConverter {
+        public override string Convert(long n) { return "af"; }
+    }
+}`,
+		"Serbian.cs": `namespace App {
+    public class SerbianConverter : BaseConverter {
+        public override string Convert(long n) { return "sr"; }
+    }
+}`,
+	})
+	// NO ResolveAll: base-list edges keep their unresolved:: targets. Bind one
+	// call edge by hand — the state the resolver leaves calls in by synth time.
+	selfCaller := "Afrikaans.cs::AfrikaansConverter.Convert"
+	g.AddEdge(&graph.Edge{From: selfCaller, To: selfCaller, Kind: graph.EdgeCalls,
+		FilePath: "Afrikaans.cs", Line: 3, Origin: graph.OriginASTResolved})
+
+	n := ResolveCSharpInterfaceDispatch(g)
+	require.Greater(t, n, 0, "the cascade must work over unresolved base-list targets")
+
+	for _, id := range []string{"Serbian.cs::SerbianConverter.Convert", "IConverter.cs::IConverter.Convert"} {
+		found := false
+		for _, e := range g.GetInEdges(id) {
+			if e.From == selfCaller && isIfaceDispatchEdge(e) {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "self-call must cascade to %s through unresolved hierarchy names", id)
+	}
+}
+
+// TestResolveCSharpInterfaceDispatch_WeakSourceGate pins the precision rule
+// for text_matched sources: a name-only binding that lands on a family member
+// from an UNRELATED same-named method (a different interface's Convert) must
+// not fan into the family, while an intra-family text_matched self-call (the
+// shape overload self-calls bind at) must.
+func TestResolveCSharpInterfaceDispatch_WeakSourceGate(t *testing.T) {
+	g := graph.New()
+	addType := func(file, name string) string {
+		id := file + "::" + name
+		g.AddNode(&graph.Node{ID: id, Kind: graph.KindType, Name: name, FilePath: file, Language: "csharp"})
+		return id
+	}
+	addMethod := func(file, typ, name string, iface bool) string {
+		id := file + "::" + typ + "." + name
+		meta := map[string]any{"receiver": typ}
+		if iface {
+			meta["iface_member"] = true
+		}
+		g.AddNode(&graph.Node{ID: id, Kind: graph.KindMethod, Name: name, FilePath: file, Language: "csharp", Meta: meta})
+		g.AddEdge(&graph.Edge{From: id, To: file + "::" + typ, Kind: graph.EdgeMemberOf, FilePath: file})
+		return id
+	}
+
+	// Family 1: IConv.Do <- ConvA.Do, ConvB.Do
+	iconv := addType("IConv.cs", "IConv")
+	iconvDo := addMethod("IConv.cs", "IConv", "Do", true)
+	_ = iconvDo
+	convA := addType("A.cs", "ConvA")
+	aDo := addMethod("A.cs", "ConvA", "Do", false)
+	convB := addType("B.cs", "ConvB")
+	bDo := addMethod("B.cs", "ConvB", "Do", false)
+	g.AddEdge(&graph.Edge{From: convA, To: iconv, Kind: graph.EdgeImplements, FilePath: "A.cs", Origin: graph.OriginASTInferred})
+	g.AddEdge(&graph.Edge{From: convB, To: iconv, Kind: graph.EdgeImplements, FilePath: "B.cs", Origin: graph.OriginASTInferred})
+
+	// Unrelated type with a same-named method, outside any family hierarchy.
+	ord := addType("Ord.cs", "Ordinalizer")
+	ordDo := addMethod("Ord.cs", "Ordinalizer", "Do", false)
+
+	// Cross-family pollution: the Ordinalizer's own Do call was text-matched
+	// onto a family member. It must NOT fan into the family.
+	g.AddEdge(&graph.Edge{From: ordDo, To: aDo, Kind: graph.EdgeCalls, FilePath: "Ord.cs", Line: 7,
+		Origin: graph.OriginTextMatched})
+	// Intra-family text_matched self-call (the overload self-call shape): the
+	// caller is a family member, so it fans to the sibling and the interface.
+	g.AddEdge(&graph.Edge{From: aDo, To: aDo, Kind: graph.EdgeCalls, FilePath: "A.cs", Line: 9,
+		Origin: graph.OriginTextMatched})
+
+	// Method-set inference pollution: an inference-marked implements edge
+	// (the shape the structural inference pass mints — every Convert-bearing
+	// class "implements" a single-method interface) must NOT pull the
+	// unrelated type into the family.
+	g.AddEdge(&graph.Edge{From: ord, To: iconv, Kind: graph.EdgeImplements, FilePath: "Ord.cs",
+		Meta: map[string]any{"via": MetaViaMethodSetInference}})
+
+	n := ResolveCSharpInterfaceDispatch(g)
+	require.Equal(t, 2, n, "only the intra-family self-call fans (to sibling + interface member)")
+
+	for _, e := range g.GetInEdges(ordDo) {
+		assert.False(t, isIfaceDispatchEdge(e),
+			"a method-set-inferred implements edge must not admit a type into the family")
+	}
+
+	var fromCallers []string
+	for _, e := range g.GetInEdges(bDo) {
+		if isIfaceDispatchEdge(e) {
+			fromCallers = append(fromCallers, e.From)
+		}
+	}
+	assert.Equal(t, []string{aDo}, fromCallers,
+		"the sibling receives the family self-call but never the unrelated text-matched caller")
 }
 
 // TestResolveCSharpInterfaceDispatch_FanoutTierAndCap uses a hand-built graph to
@@ -105,7 +356,7 @@ func TestResolveCSharpInterfaceDispatch_FanoutTierAndCap(t *testing.T) {
 			g.AddNode(&graph.Node{ID: file + "::" + typ + ".Do", Kind: graph.KindMethod, Name: "Do", FilePath: file, Language: "csharp",
 				Meta: map[string]any{"receiver": typ}})
 			g.AddEdge(&graph.Edge{From: file + "::" + typ + ".Do", To: file + "::" + typ, Kind: graph.EdgeMemberOf, FilePath: file})
-			g.AddEdge(&graph.Edge{From: file + "::" + typ, To: "I.cs::IC", Kind: graph.EdgeImplements, FilePath: file})
+			g.AddEdge(&graph.Edge{From: file + "::" + typ, To: "I.cs::IC", Kind: graph.EdgeImplements, FilePath: file, Origin: graph.OriginASTInferred})
 		}
 		g.AddNode(&graph.Node{ID: "C.cs::App.Run", Kind: graph.KindMethod, Name: "Run", FilePath: "C.cs", Language: "csharp",
 			Meta: map[string]any{"receiver": "App"}})
@@ -117,27 +368,28 @@ func TestResolveCSharpInterfaceDispatch_FanoutTierAndCap(t *testing.T) {
 		g := newGraph(2)
 		require.Equal(t, 2, ResolveCSharpInterfaceDispatch(g))
 
-		spec := map[string]*graph.Edge{}
+		fanout := map[string]*graph.Edge{}
 		for _, e := range g.GetOutEdges("C.cs::App.Run") {
-			if e.Kind == graph.EdgeCalls && e.IsSpeculative() {
-				spec[e.To] = e
+			if isIfaceDispatchEdge(e) {
+				fanout[e.To] = e
 			}
 		}
-		require.Len(t, spec, 2)
+		require.Len(t, fanout, 2)
 		for _, id := range []string{"Impl0.cs::Impl0.Do", "Impl1.cs::Impl1.Do"} {
-			e := spec[id]
+			e := fanout[id]
 			require.NotNil(t, e, id)
-			assert.Equal(t, graph.OriginSpeculative, e.Origin)
+			assert.Equal(t, graph.OriginASTInferred, e.Origin)
+			assert.False(t, e.IsSpeculative())
 			assert.Equal(t, SynthCSharpIfaceDispatch, e.Meta[MetaSynthesizedBy])
 			assert.Equal(t, "C.cs", e.FilePath)
 			assert.Equal(t, 3, e.Line)
 		}
 
-		// Idempotent: a second run dedups, leaving exactly two fan-out edges.
+		// Idempotent: a second run must not duplicate fan-out edges.
 		ResolveCSharpInterfaceDispatch(g)
 		got := 0
 		for _, e := range g.GetOutEdges("C.cs::App.Run") {
-			if e.Kind == graph.EdgeCalls && e.IsSpeculative() {
+			if isIfaceDispatchEdge(e) {
 				got++
 			}
 		}

--- a/internal/resolver/framework_synth.go
+++ b/internal/resolver/framework_synth.go
@@ -235,8 +235,9 @@ func defaultFrameworkSynthesizers() []FrameworkSynthesizer {
 		synthFunc{name: SynthMediatR, fn: ResolveMediatRCalls},
 		// C# member-level interface dispatch: a call bound to an interface
 		// member fans out to the same-named member on each in-repo
-		// implementation, at the speculative (hidden-by-default) tier. After
-		// the implements-producing passes so the impl fan-out is complete.
+		// implementation, at the ast_inferred tier so it rides in the default
+		// find_usages / get_callers result. After the implements-producing
+		// passes so the impl fan-out is complete.
 		synthFunc{name: SynthCSharpIfaceDispatch, fn: ResolveCSharpInterfaceDispatch},
 		// Sidekiq job dispatch: Worker.perform_async(...) → the worker's
 		// perform, namespace-aware. Include-gated, typed tier.

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -3626,15 +3626,42 @@ func (r *Resolver) inferImplements(scopeTypes, scopeIfaces map[string]bool) int 
 	}
 	wg.Wait()
 
+	// A declared base list often resolves to the very (From, To, FilePath,
+	// Line) tuple the inference would mint — C# puts the base list on the
+	// declaration line — and AddEdge replaces in place on an identical key, so
+	// re-minting would CLOBBER the declared edge with an inference-marked
+	// copy. Never overwrite a declared fact with a guess: skip pairs that
+	// already exist without the marker.
+	declared := map[string]bool{}
+	for e := range r.graph.EdgesByKind(graph.EdgeImplements) {
+		if e == nil {
+			continue
+		}
+		if e.Meta != nil && e.Meta["via"] == MetaViaMethodSetInference {
+			continue
+		}
+		declared[e.From+"\x00"+e.To] = true
+	}
+
 	added := 0
 	for _, chunkResults := range results {
 		for _, p := range chunkResults {
+			if declared[p.typeID+"\x00"+p.ifaceID] {
+				continue
+			}
 			r.graph.AddEdge(&graph.Edge{
 				From:     p.typeID,
 				To:       p.ifaceID,
 				Kind:     graph.EdgeImplements,
 				FilePath: p.filePath,
 				Line:     p.line,
+				// Mark the edge as structurally inferred so hierarchy-walking
+				// consumers can tell a method-set guess from a source-declared
+				// base list. A one-method interface (Convert) makes every
+				// same-named type "implement" it — fine for discovery
+				// surfaces, poison for passes that union call sites across an
+				// implements-family.
+				Meta: map[string]any{"via": MetaViaMethodSetInference},
 			})
 			added++
 		}

--- a/internal/semantic/enrich_readiness_test.go
+++ b/internal/semantic/enrich_readiness_test.go
@@ -79,3 +79,34 @@ func TestRunEnrichOne_FastProviderSkipsReadiness(t *testing.T) {
 	require.Len(t, results, 1, "a fast provider still runs; the readiness gate is simply skipped")
 	assert.Equal(t, "gopls-like", results[0].Provider)
 }
+
+// notReadyProvider models a ReadinessProber whose workspace never finishes
+// loading: WaitReady reports ErrWorkspaceNotReady. The manager must record the
+// honest not-ready state and skip the sweep instead of running it against an
+// empty server and reporting a misleading "completed, 0 coverage".
+type notReadyProvider struct {
+	slowSolutionProvider
+}
+
+func (n *notReadyProvider) WaitReady(ctx context.Context, repoRoot string) error {
+	n.waited = true
+	return ErrWorkspaceNotReady
+}
+
+// TestRunEnrichOne_NeverReadySkipsSweepWithHonestState: when readiness never
+// confirms, the pass is skipped and recorded as not_ready — no result is
+// produced, so a later cycle retries.
+func TestRunEnrichOne_NeverReadySkipsSweepWithHonestState(t *testing.T) {
+	mgr := NewManager(Config{Enabled: true}, zap.NewNop())
+	p := &notReadyProvider{slowSolutionProvider{name: "csharp-like", languages: []string{"csharp"}}}
+
+	results := mgr.runEnrichOne(graph.New(), "repo", "/tmp/repo", "csharp", p, 10, RepoEnrichState{}, nil, map[string]bool{})
+
+	require.True(t, p.waited, "readiness prober must be invoked")
+	assert.Empty(t, results, "the sweep is skipped, so no result is produced")
+
+	statuses := mgr.EnrichmentStatuses()
+	require.Len(t, statuses, 1)
+	assert.Equal(t, EnrichStateNotReady, statuses[0].State,
+		"a workspace that never loads is recorded as not_ready, not completed")
+}

--- a/internal/semantic/lsp/csharp_readiness_test.go
+++ b/internal/semantic/lsp/csharp_readiness_test.go
@@ -1,0 +1,106 @@
+package lsp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/semantic"
+)
+
+// shrinkReadinessTimers speeds the readiness poll loop for tests and restores
+// the production values on cleanup.
+func shrinkReadinessTimers(t *testing.T) {
+	t.Helper()
+	pi, lt := csharpReadinessProbeInterval, csharpSolutionLoadTimeout
+	csharpReadinessProbeInterval = 5 * time.Millisecond
+	csharpSolutionLoadTimeout = 2 * time.Second
+	t.Cleanup(func() {
+		csharpReadinessProbeInterval = pi
+		csharpSolutionLoadTimeout = lt
+	})
+}
+
+// TestPollWorkspaceReady_ReadyAfterLoad models a Roslyn / MSBuild server whose
+// workspace/symbol answers empty while the solution loads and returns a match
+// once it is live. pollWorkspaceReady must block across the empty phase and
+// return nil only once the probe is non-empty, so the enrichment sweep starts
+// against a server that can actually resolve.
+func TestPollWorkspaceReady_ReadyAfterLoad(t *testing.T) {
+	shrinkReadinessTimers(t)
+
+	var calls int64
+	srv := newFakeLSPServer()
+	srv.handle("workspace/symbol", func(json.RawMessage) (any, *jsonRPCError) {
+		if atomic.AddInt64(&calls, 1) < 3 {
+			return []any{}, nil // still loading — empty
+		}
+		return []map[string]any{{"name": "Foo", "kind": 5}}, nil
+	})
+	p, cleanup := providerWithFakeServer(t, srv, []string{"csharp"})
+	defer cleanup()
+
+	require.NoError(t, p.pollWorkspaceReady(context.Background(), "Foo"))
+	assert.GreaterOrEqual(t, atomic.LoadInt64(&calls), int64(3),
+		"probe must poll across the empty solution-load phase before reporting ready")
+}
+
+// TestPollWorkspaceReady_NeverReady: a server that never loads (always empty)
+// must surface semantic.ErrWorkspaceNotReady so the Manager records an honest
+// state and skips the futile sweep.
+func TestPollWorkspaceReady_NeverReady(t *testing.T) {
+	shrinkReadinessTimers(t)
+
+	srv := newFakeLSPServer()
+	srv.handle("workspace/symbol", func(json.RawMessage) (any, *jsonRPCError) {
+		return []any{}, nil
+	})
+	p, cleanup := providerWithFakeServer(t, srv, []string{"csharp"})
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	err := p.pollWorkspaceReady(ctx, "Foo")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, semantic.ErrWorkspaceNotReady),
+		"a workspace that never loads must report ErrWorkspaceNotReady, got %v", err)
+}
+
+// TestCSharpProbeQuery derives a workspace/symbol query from the first C#
+// declaration under the repo root, and reports none for a tree with no C#.
+func TestCSharpProbeQuery(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Widget.cs"),
+		[]byte("namespace Demo {\n  public interface IWidget { void Do(); }\n}\n"), 0o644))
+	q, ok := csharpProbeQuery(dir)
+	require.True(t, ok)
+	assert.Equal(t, "IWidget", q)
+
+	empty := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(empty, "README.md"), []byte("hi"), 0o644))
+	_, ok = csharpProbeQuery(empty)
+	assert.False(t, ok)
+}
+
+// TestCSharpDeclName covers the identifier extraction the probe query relies on.
+func TestCSharpDeclName(t *testing.T) {
+	cases := []struct{ src, want string }{
+		{"public class Foo {}", "Foo"},
+		{"internal interface IBar { }", "IBar"},
+		{"public record class Money(decimal V);", "Money"},
+		{"public record Point(int X, int Y);", "Point"},
+		{"namespace A.B.Baz;", "Baz"},
+		{"// just a comment\n", ""},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, csharpDeclName([]byte(c.src)), "src=%q", c.src)
+	}
+}

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -2080,17 +2082,20 @@ func (p *Provider) ensureClient(workspaceRoot string) error {
 }
 
 // WaitReady implements semantic.ReadinessProber for the Roslyn / MSBuild-class
-// C# servers (csharp-ls, OmniSharp), whose workspace load continues past
-// `initialize` and serves empty results until the solution finishes loading.
-// Bringing the client up here — spawn, optional `dotnet restore`, and the
-// `initialize` handshake — moves that cold-start latency OUT of the per-repo
-// enrichment deadline the Manager starts immediately afterward, so the query
-// budget is not consumed by the load. Every other server is ready to answer
-// once initialized and does not implement ReadinessProber, so it never waits.
-// The call runs synchronously (it completes before the enrichment pass calls
-// ensureClient again, which then no-ops), so there is no concurrent client
-// setup to race; ctx bounds the caller's expectation and short-circuits an
-// already-cancelled budget.
+// C# servers (csharp-ls, OmniSharp). They answer `initialize` quickly but keep
+// loading the solution in the background and serve empty results until it
+// finishes — the pathology where the enrichment deadline elapses mid-load and
+// the pass lands zero edges ("completed in 8s, 0 coverage"). WaitReady brings
+// the client up (spawn, optional `dotnet restore`, `initialize`) and then blocks
+// on a readiness probe until the solution's compilation is live, so the Manager
+// starts the per-repo deadline only once real queries will actually resolve.
+//
+// The probe polls workspace/symbol until it returns a match; on the load-timeout
+// it reports semantic.ErrWorkspaceNotReady so the Manager skips the sweep with an
+// honest not-ready state instead of running it against a still-empty server.
+// Every other server answers once initialized and does not implement
+// ReadinessProber, so it never waits. Runs synchronously; ctx bounds the
+// readiness budget and short-circuits an already-cancelled one.
 func (p *Provider) WaitReady(ctx context.Context, repoRoot string) error {
 	if !p.servesCSharp() {
 		return nil
@@ -2102,7 +2107,135 @@ func (p *Provider) WaitReady(ctx context.Context, repoRoot string) error {
 	if err != nil {
 		return err
 	}
-	return p.ensureClient(absRoot)
+	if err := p.ensureClient(absRoot); err != nil {
+		return err
+	}
+	return p.waitForCSharpSolutionLoad(ctx, absRoot)
+}
+
+// csharpSolutionLoadTimeout bounds how long WaitReady polls for the Roslyn
+// solution load to finish after `initialize` returns. csharpReadinessProbeInterval
+// spaces the polls. Both are var (not const) so tests can shrink them.
+var (
+	csharpSolutionLoadTimeout    = 120 * time.Second
+	csharpReadinessProbeInterval = 750 * time.Millisecond
+)
+
+// waitForCSharpSolutionLoad blocks until the server's compilation can answer a
+// workspace/symbol probe (the solution finished loading) or the load-timeout
+// elapses. Bounded by the smaller of ctx and csharpSolutionLoadTimeout.
+func (p *Provider) waitForCSharpSolutionLoad(ctx context.Context, repoRoot string) error {
+	query, ok := csharpProbeQuery(repoRoot)
+	if !ok {
+		// No C# declaration to probe with — there is nothing to enrich either,
+		// so treat the workspace as ready and let the (empty) pass complete.
+		return nil
+	}
+	loadCtx, cancel := context.WithTimeout(ctx, csharpSolutionLoadTimeout)
+	defer cancel()
+	return p.pollWorkspaceReady(loadCtx, query)
+}
+
+// pollWorkspaceReady polls workspace/symbol until it returns at least one match
+// — the signal the compilation is live — or ctx expires. On expiry it wraps
+// semantic.ErrWorkspaceNotReady so the Manager can record an honest not-ready
+// state and skip the sweep. A transport / RPC error counts as "still loading",
+// not fatal, so a server mid-load is retried rather than abandoned.
+func (p *Provider) pollWorkspaceReady(ctx context.Context, query string) error {
+	ticker := time.NewTicker(csharpReadinessProbeInterval)
+	defer ticker.Stop()
+	for {
+		if p.workspaceSymbolNonEmpty(query) {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("%w: workspace/symbol %q stayed empty", semantic.ErrWorkspaceNotReady, query)
+		case <-ticker.C:
+		}
+	}
+}
+
+// workspaceSymbolNonEmpty issues one workspace/symbol request and reports
+// whether the server returned any symbol. A nil client or any error reads as
+// "not ready yet" rather than a hard failure.
+func (p *Provider) workspaceSymbolNonEmpty(query string) bool {
+	client := p.client
+	if client == nil {
+		return false
+	}
+	var syms []json.RawMessage
+	params := struct {
+		Query string `json:"query"`
+	}{Query: query}
+	if err := client.Call("workspace/symbol", params, &syms); err != nil {
+		return false
+	}
+	return len(syms) > 0
+}
+
+var csharpTypeDeclRe = regexp.MustCompile(`\b(?:class|interface|struct|enum)\s+([A-Za-z_]\w*)|\brecord\s+(?:class\s+|struct\s+)?([A-Za-z_]\w*)`)
+var csharpNamespaceRe = regexp.MustCompile(`\bnamespace\s+([A-Za-z_][\w.]*)`)
+
+// csharpDeclName extracts a probeable identifier from C# source: a type name
+// (class / interface / struct / record / enum) when present, else the leaf of a
+// namespace declaration. Returns "" when the source has neither.
+func csharpDeclName(src []byte) string {
+	if m := csharpTypeDeclRe.FindSubmatch(src); m != nil {
+		if len(m[1]) > 0 {
+			return string(m[1])
+		}
+		if len(m[2]) > 0 {
+			return string(m[2])
+		}
+	}
+	if m := csharpNamespaceRe.FindSubmatch(src); m != nil {
+		ns := string(m[1])
+		if i := strings.LastIndexByte(ns, '.'); i >= 0 {
+			ns = ns[i+1:]
+		}
+		return ns
+	}
+	return ""
+}
+
+// csharpProbeQuery walks repoRoot for the first C# type/namespace declaration
+// and returns its name — a workspace/symbol query token guaranteed to match once
+// the solution loads. ok=false when the tree holds no probeable declaration
+// (in which case there is nothing to enrich, so readiness is moot). The walk is
+// capped so a huge monorepo can't turn readiness into a full-tree scan.
+func csharpProbeQuery(repoRoot string) (string, bool) {
+	var found string
+	scanned := 0
+	_ = filepath.WalkDir(repoRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			name := d.Name()
+			if path != repoRoot && (strings.HasPrefix(name, ".") || name == "bin" || name == "obj" || name == "node_modules") {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), ".cs") {
+			return nil
+		}
+		scanned++
+		if scanned > 500 {
+			return fs.SkipAll
+		}
+		src, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil
+		}
+		if name := csharpDeclName(src); name != "" {
+			found = name
+			return fs.SkipAll
+		}
+		return nil
+	})
+	return found, found != ""
 }
 
 // fanoutDiagnostics wakes everyone who called WaitForDiagnostics for

--- a/internal/semantic/manager.go
+++ b/internal/semantic/manager.go
@@ -2,6 +2,7 @@ package semantic
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -844,7 +845,23 @@ func (m *Manager) runEnrichOne(g graph.Store, repoName, repoRoot, lang string, p
 	// and best-effort: a probe timeout or error just proceeds.
 	if rp, ok := provider.(ReadinessProber); ok && enrichReadinessBudget > 0 {
 		rctx, rcancel := context.WithTimeout(context.Background(), enrichReadinessBudget)
-		if err := rp.WaitReady(rctx, repoRoot); err != nil {
+		err := rp.WaitReady(rctx, repoRoot)
+		rcancel()
+		if errors.Is(err, ErrWorkspaceNotReady) {
+			// The server never finished loading its workspace: a sweep now
+			// would spend the whole budget answering empty and report a
+			// misleading "completed, 0 coverage". Record the honest state and
+			// skip; the repo stays un-enriched so a later cycle retries.
+			m.logger.Info("semantic enrichment: workspace not ready; skipping sweep",
+				zap.String("provider", provider.Name()),
+				zap.String("language", lang),
+				zap.String("repo", repoName),
+			)
+			m.setEnrichStatus(repoName, provider.Name(), lang, EnrichStateNotReady, 0, nil,
+				"workspace did not finish loading within the readiness budget; sweep skipped, repo left for retry")
+			return results
+		}
+		if err != nil {
 			m.logger.Debug("semantic enrichment: readiness probe did not confirm; proceeding best-effort",
 				zap.String("provider", provider.Name()),
 				zap.String("language", lang),
@@ -852,7 +869,6 @@ func (m *Manager) runEnrichOne(g graph.Store, repoName, repoRoot, lang string, p
 				zap.Error(err),
 			)
 		}
-		rcancel()
 	}
 
 	_, isContextEnricher := provider.(ContextEnricher)

--- a/internal/semantic/provider.go
+++ b/internal/semantic/provider.go
@@ -2,6 +2,7 @@ package semantic
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/zzet/gortex/internal/graph"
@@ -91,6 +92,15 @@ type ReadinessProber interface {
 	WaitReady(ctx context.Context, repoRoot string) error
 }
 
+// ErrWorkspaceNotReady is returned by a ReadinessProber.WaitReady when the
+// server never finished loading its workspace within the readiness budget. The
+// Manager treats it specially: rather than run a futile sweep against a server
+// that will answer every query empty (the "completed in 8s, 0 coverage"
+// pathology), it records an honest not-ready state and skips the pass, leaving
+// the repo un-enriched so a later cycle retries. Any other WaitReady error is
+// best-effort and the pass proceeds.
+var ErrWorkspaceNotReady = errors.New("semantic: workspace did not become ready within the readiness budget")
+
 // EnrichResult contains statistics from an enrichment pass.
 type EnrichResult struct {
 	Provider        string  `json:"provider"`
@@ -157,6 +167,7 @@ const (
 	EnrichStatePartial   = "partial"   // deadline hit; completed work landed and is counted
 	EnrichStateAbandoned = "abandoned" // legacy provider detached at deadline; result discarded
 	EnrichStateFailed    = "failed"
+	EnrichStateNotReady  = "not_ready" // readiness prober timed out; sweep skipped, repo left for retry
 )
 
 // EnrichmentStatus reports the lifecycle state of one provider's per-repo


### PR DESCRIPTION
C# interface-dispatch usages were nearly invisible: querying a concrete implementation returned only its self-references, and csharp-ls enrichment resolved zero references because the Roslyn/MSBuild solution load consumed the whole enrichment window.

Two commits:
- **feat(resolver): cascade C# usages across the whole implements-family.** Family = every interface-member overload node plus same-named methods on every type whose declared implements/extends chain reaches the interface, fanning out per call-site line at ast_inferred. Fixes three stacked defects: (1) C# overloads mint one node per declaration (`Convert`, `Convert_L39`, …), so single-node families missed whole implementor groups; (2) method-set inference edges shared the exact edge key with declared implements edges, so the store's replace-in-place silently clobbered real declared hierarchy edges with guesses — inference edges are now provenance-marked and never re-mint a declared pair; (3) the synthesizer runs before base-list targets are bound, so the pass binds unresolved hierarchy targets itself (exact, same-repo, unique match only).
- **feat(semantic): wait for the C# solution to load before enriching.** Readiness polls workspace/symbol until the solution answers (bounded at 120s); timeout records an honest not_ready state and skips the sweep instead of billing the cold load against the deadline and reporting an empty pass as complete.

Verification on the real corpus (isolated env): the flagship failing symbol went 3 → 187 references with the identical union returned from the interface side and zero cross-family leakage; a precision counter-probe on an unrelated family shows no bleed; the synth pass minted 14,774 edges and is idempotent on rerun. 1,770 tests `-race` green across resolver/semantic/lsp/indexer, golangci-lint clean, wire-contract golden unchanged (Meta-only).

Note: graphs persisted by older builds need a reindex before the inference marker can discriminate declared-vs-inferred edges.
