### PR TITLE
TS/JS: make barrel re-export bindings queryable nodes

### DIFF
--- a/internal/graph/node.go
+++ b/internal/graph/node.go
@@ -347,6 +347,21 @@ type Node struct {
 	FetchedAt time.Time `json:"fetched_at,omitempty"`
 }
 
+// IsReExportNode reports whether n is a barrel re-export binding — a node
+// minted at an `export { X } from './mod'` site that forwards another module's
+// declaration under the exported (post-alias) name. Marked with
+// Meta["reexport"]==true by the JS/TS extractor. These nodes are transparent
+// aliases: call resolution skips them (a call binds to the forwarded
+// declaration, not the façade), while find_usages delegates their usage set to
+// the canonical target.
+func IsReExportNode(n *Node) bool {
+	if n == nil || n.Meta == nil {
+		return false
+	}
+	v, ok := n.Meta["reexport"].(bool)
+	return ok && v
+}
+
 // Brief returns a compact representation with only the fields needed for listing.
 func (n *Node) Brief() map[string]any {
 	b := map[string]any{

--- a/internal/mcp/reexport_barrel.go
+++ b/internal/mcp/reexport_barrel.go
@@ -2,9 +2,11 @@ package mcp
 
 import (
 	"path"
+	"strconv"
 	"strings"
 
 	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/query"
 )
 
 // Barrel re-export resolve-through for find_usages.
@@ -140,4 +142,94 @@ func hasJSTSExt(file string) bool {
 		}
 	}
 	return false
+}
+
+// isReExportNode reports whether a node is a barrel re-export binding minted
+// at an `export { X } from './mod'` site. Thin alias over graph.IsReExportNode
+// so the find_usages delegation reads at the call site.
+func isReExportNode(n *graph.Node) bool { return graph.IsReExportNode(n) }
+
+// reExportNodeCanonical follows a barrel re-export node's outgoing
+// EdgeReExports edge(s) to the terminal canonical declaration it forwards.
+// It walks the resolved graph — the node→canonical edge the extractor mints is
+// rewritten from `unresolved::import::…` onto the declaration id by the
+// resolver — so a chain of barrels (index → middleware → persist) resolves hop
+// by hop until a non-re-export node is reached. Returns "" when the node has no
+// resolved forward edge (e.g. a bare-package re-export the resolver left
+// unresolved). Distinct from reExportBindingCanonical, which walks a FILE's
+// out-edges on the pre-resolution unresolved targets.
+func reExportNodeCanonical(g graph.Store, id string, depth int) string {
+	if g == nil || depth > maxReExportChainDepth {
+		return ""
+	}
+	for _, e := range g.GetOutEdges(id) {
+		if e == nil || e.Kind != graph.EdgeReExports {
+			continue
+		}
+		to := e.To
+		if to == "" || to == id || graph.IsUnresolvedTarget(to) {
+			continue // unresolved / self — nothing to delegate to
+		}
+		tn := g.GetNode(to)
+		if tn == nil {
+			continue
+		}
+		if isReExportNode(tn) {
+			if canon := reExportNodeCanonical(g, to, depth+1); canon != "" {
+				return canon
+			}
+			// An intermediate barrel whose own forward edge didn't resolve
+			// still stands in as the best delegation target.
+			return to
+		}
+		return to
+	}
+	return ""
+}
+
+// mergeUsageSubGraph folds src's usage rows into dst, deduping nodes by id and
+// edges by (from,to,kind,line), and refreshes the totals. Used by find_usages
+// to union a barrel binding's own refs with its canonical declaration's usages.
+func mergeUsageSubGraph(dst, src *query.SubGraph) {
+	if dst == nil || src == nil {
+		return
+	}
+	haveNode := make(map[string]struct{}, len(dst.Nodes))
+	for _, n := range dst.Nodes {
+		if n != nil {
+			haveNode[n.ID] = struct{}{}
+		}
+	}
+	for _, n := range src.Nodes {
+		if n == nil {
+			continue
+		}
+		if _, dup := haveNode[n.ID]; dup {
+			continue
+		}
+		haveNode[n.ID] = struct{}{}
+		dst.Nodes = append(dst.Nodes, n)
+	}
+	edgeKey := func(e *graph.Edge) string {
+		return e.From + "\x00" + e.To + "\x00" + string(e.Kind) + "\x00" + strconv.Itoa(e.Line)
+	}
+	haveEdge := make(map[string]struct{}, len(dst.Edges))
+	for _, e := range dst.Edges {
+		if e != nil {
+			haveEdge[edgeKey(e)] = struct{}{}
+		}
+	}
+	for _, e := range src.Edges {
+		if e == nil {
+			continue
+		}
+		k := edgeKey(e)
+		if _, dup := haveEdge[k]; dup {
+			continue
+		}
+		haveEdge[k] = struct{}{}
+		dst.Edges = append(dst.Edges, e)
+	}
+	dst.TotalNodes = len(dst.Nodes)
+	dst.TotalEdges = len(dst.Edges)
 }

--- a/internal/mcp/reexport_barrel_integration_test.go
+++ b/internal/mcp/reexport_barrel_integration_test.go
@@ -1,0 +1,121 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+	"github.com/zzet/gortex/internal/query"
+)
+
+// buildBarrelIndex indexes a three-file barrel fixture through the real
+// extractor + resolver pipeline: a canonical module, a barrel that forwards it,
+// and a consumer that imports through the barrel and calls the function.
+func buildBarrelIndex(t *testing.T) graph.Store {
+	t.Helper()
+	dir := t.TempDir()
+	write := func(rel, src string) {
+		p := filepath.Join(dir, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+		require.NoError(t, os.WriteFile(p, []byte(src), 0o644))
+	}
+	write("src/middleware/persist.ts", "export function persist(config: unknown): unknown {\n  return config;\n}\n")
+	write("src/middleware.ts", "export { persist } from './middleware/persist';\n")
+	write("src/consumer.ts", "import { persist } from './middleware';\n\nexport function useStore(): unknown {\n  return persist({ name: 'x' });\n}\n")
+
+	g := graph.New()
+	reg := parser.NewRegistry()
+	languages.RegisterAll(reg)
+	cfg := config.Default()
+	idx := indexer.New(g, reg, cfg.Index, zap.NewNop())
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+	idx.ResolveAll()
+	return g
+}
+
+func usageFroms(sg *query.SubGraph) map[string]bool {
+	out := map[string]bool{}
+	for _, e := range sg.Edges {
+		out[e.From] = true
+	}
+	return out
+}
+
+func edgeKeys(sg *query.SubGraph) map[string]bool {
+	out := map[string]bool{}
+	for _, e := range sg.Edges {
+		out[e.From+"->"+e.To+":"+string(e.Kind)] = true
+	}
+	return out
+}
+
+// TestBarrelReExport_ResolvesAsNodeWithDelegatedUsages is the end-to-end
+// acceptance: the barrel binding resolves as a real node, find_usages on it
+// returns the consumer's sites (its own import plus the canonical
+// declaration's call via delegation), and the canonical declaration's own
+// usages are a strict superset of what they were before the re-export node
+// existed (the consumer call stays on canonical; a node-level re-export edge is
+// added).
+func TestBarrelReExport_ResolvesAsNodeWithDelegatedUsages(t *testing.T) {
+	g := buildBarrelIndex(t)
+
+	const (
+		barrel     = "src/middleware.ts::persist"
+		barrelFile = "src/middleware.ts"
+		canonical  = "src/middleware/persist.ts::persist"
+		consumer   = "src/consumer.ts"
+		consumerFn = "src/consumer.ts::useStore"
+	)
+
+	// (a) The public façade binding resolves as a real node carrying the marker.
+	bn := g.GetNode(barrel)
+	require.NotNil(t, bn, "barrel re-export node %q must exist", barrel)
+	require.True(t, isReExportNode(bn), "barrel node must carry the reexport marker")
+	require.Equal(t, graph.KindVariable, bn.Kind)
+	require.NotNil(t, g.GetNode(canonical), "canonical declaration must exist")
+
+	// The node → canonical forward edge resolves through the import machinery.
+	require.Equal(t, canonical, reExportNodeCanonical(g, barrel, 0),
+		"barrel node must forward to the canonical declaration")
+
+	eng := query.NewEngine(g)
+
+	// Baseline: the canonical declaration's usages before any delegation. The
+	// consumer's *call* binds to the canonical function (the barrel hop keeps
+	// import evidence), so this set already contains it.
+	canonUsages := eng.FindUsages(canonical)
+	require.True(t, usageFroms(canonUsages)[consumerFn],
+		"canonical usages must retain the consumer's call site (no regression)")
+	// The node-level re-export edge is additive on canonical — a superset.
+	require.True(t, edgeKeys(canonUsages)[barrel+"->"+canonical+":"+string(graph.EdgeReExports)],
+		"canonical usages must gain the node-level re-export edge")
+
+	// (b) find_usages on the barrel node: its own direct refs — the consumer's
+	// per-binding import binds here — merged with the canonical's usages via
+	// delegation, exactly as the handler does.
+	barrelUsages := eng.FindUsages(barrel)
+	require.True(t, usageFroms(barrelUsages)[consumer],
+		"barrel node's direct usages must include the consumer's import site")
+	require.Equal(t, canonical, reExportNodeCanonical(g, barrel, 0))
+	mergeUsageSubGraph(barrelUsages, eng.FindUsages(canonical))
+
+	froms := usageFroms(barrelUsages)
+	require.True(t, froms[consumer], "merged usages must include the consumer import site")
+	require.True(t, froms[consumerFn], "merged usages must include the consumer call site (delegated)")
+
+	// (c) Delegation is complete: every canonical usage is present in the
+	// barrel's merged usage set.
+	merged := edgeKeys(barrelUsages)
+	for k := range edgeKeys(canonUsages) {
+		require.True(t, merged[k], "merged barrel usages missing canonical usage %q", k)
+	}
+}

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -2482,24 +2482,38 @@ func (s *Server) handleFindUsages(ctx context.Context, req mcp.CallToolRequest) 
 	}
 	eng := s.engineFor(ctx)
 	// Barrel re-export resolve-through: a public import path that names a
-	// forwarded binding (`src/middleware.ts::persist`) has no node of its own —
-	// map it to the canonical declaration so find_usages answers with the real
-	// usages instead of not_found. Gated on the id not already being a node, so
-	// a real symbol's result is never altered.
-	if eng.GetSymbol(id) == nil {
+	// forwarded binding (`src/middleware.ts::persist`) may have no node of its
+	// own (an unresolved / over-cap / wildcard barrel) — map it to the
+	// canonical declaration so find_usages answers with the real usages instead
+	// of not_found. Gated on the id not already being a node, so a real
+	// symbol's result is never altered.
+	node := eng.GetSymbol(id)
+	if node == nil {
 		if canon := reExportBindingCanonical(s.graph, id, 0); canon != "" {
 			id = canon
+			node = eng.GetSymbol(id)
 		}
 	}
-	if node := eng.GetSymbol(id); node != nil && !resolvedScopeAllowsNode(resolved, node) {
+	if node != nil && !resolvedScopeAllowsNode(resolved, node) {
 		return symbolNotFoundGuidance(id), nil
 	}
-	sg := eng.FindUsagesScoped(id, query.QueryOptions{
+	opts := query.QueryOptions{
 		WorkspaceID:  resolved.WorkspaceID,
 		ProjectID:    resolved.ProjectID,
 		RepoAllow:    resolved.RepoAllow,
 		ExcludeTests: req.GetBool("exclude_tests", false),
-	})
+	}
+	sg := eng.FindUsagesScoped(id, opts)
+	// Barrel re-export binding: a query on the public façade node
+	// (`src/middleware.ts::persist`) returns its own direct refs — consumer
+	// imports that bind to it — plus the canonical declaration's usages,
+	// deduped. So the façade an agent actually imports answers with the full
+	// usage set instead of only the forwarding site.
+	if isReExportNode(node) {
+		if canon := reExportNodeCanonical(s.graph, id, 0); canon != "" && canon != id {
+			mergeUsageSubGraph(sg, eng.FindUsagesScoped(canon, opts))
+		}
+	}
 
 	sg = filterSubGraphByResolvedScope(sg, resolved)
 	sg.FilterByMinTier(minTier)

--- a/internal/parser/languages/helpers_jsimports.go
+++ b/internal/parser/languages/helpers_jsimports.go
@@ -101,7 +101,17 @@ func emitJSPerBindingImports(importNode *sitter.Node, importPath, fileID, filePa
 //     collapses to a single module-level re-export edge.
 //   - namespace `export * as ns from "mod"` — one module-level edge, Alias "ns".
 //   - wildcard `export * from "mod"` — one module-level edge, no Alias.
-func emitJSReExport(exportNode *sitter.Node, importPath, fileID, filePath string, src []byte, result *parser.ExtractionResult) {
+//
+// For each named (value) specifier within the cap it also mints a queryable
+// node at the barrel site under the exported (post-alias) name, so the public
+// façade a consumer imports (`import { persist } from 'zustand/middleware'`)
+// resolves as a real symbol whose id follows the standard `<file>::<name>`
+// scheme. The node carries a `reexport` marker and a node→canonical
+// EdgeReExports edge (resolved through the same import machinery as the
+// file-level edge) so find_usages can delegate to the canonical declaration's
+// usages. Type-only specifiers are left as reference edges by
+// emitTSTypeOnlyExportRefs and never mint a value node here.
+func emitJSReExport(exportNode *sitter.Node, importPath, fileID, filePath, lang string, src []byte, result *parser.ExtractionResult) {
 	line := int(exportNode.StartPoint().Row) + 1
 
 	if clause := findChildByType(exportNode, "export_clause"); clause != nil {
@@ -113,19 +123,71 @@ func emitJSReExport(exportNode *sitter.Node, importPath, fileID, filePath string
 			})
 			return
 		}
+		stmtTypeOnly := tsExportStatementTypeOnly(exportNode, src)
+		mintedNode := map[string]bool{}
 		for _, sp := range specs {
 			orig, alias := jsSpecifierNames(sp, src)
 			if orig == "" {
 				continue
 			}
+			specLine := int(sp.StartPoint().Row) + 1
 			edge := &graph.Edge{
 				From: fileID, To: "unresolved::import::" + importPath + "::" + orig,
-				Kind: graph.EdgeReExports, FilePath: filePath, Line: int(sp.StartPoint().Row) + 1,
+				Kind: graph.EdgeReExports, FilePath: filePath, Line: specLine,
 			}
 			if alias != "" && alias != orig {
 				edge.Alias = alias
 			}
 			result.Edges = append(result.Edges, edge)
+
+			// A type-only re-export (`export type { X } from` or
+			// `export { type X } from`) names a type, not a value — it is
+			// forwarded as a reference edge by emitTSTypeOnlyExportRefs, so
+			// no value node is minted for it.
+			if stmtTypeOnly || tsSpecifierTypeOnly(sp, src) {
+				continue
+			}
+			// The public binding name is the alias when renamed, else the
+			// original — that is the name a consumer imports.
+			publicName := orig
+			if alias != "" {
+				publicName = alias
+			}
+			nodeID := fileID + "::" + publicName
+			if mintedNode[nodeID] {
+				continue
+			}
+			mintedNode[nodeID] = true
+			meta := map[string]any{
+				"reexport":        true,
+				"reexport_source": importPath,
+			}
+			if publicName != orig {
+				meta["reexport_original"] = orig
+			}
+			result.Nodes = append(result.Nodes, &graph.Node{
+				ID: nodeID, Kind: graph.KindVariable, Name: publicName,
+				FilePath: filePath, StartLine: specLine, EndLine: specLine,
+				Language: lang, Meta: meta,
+			})
+			// File → binding: EdgeDefines attaches the binding to the barrel
+			// file (get_file_summary and friends walk defines/contains).
+			result.Edges = append(result.Edges, &graph.Edge{
+				From: fileID, To: nodeID, Kind: graph.EdgeDefines,
+				FilePath: filePath, Line: specLine,
+			})
+			// Binding → canonical: a second EdgeReExports edge, this one
+			// sourced from the node, gives the barrel binding a direct link
+			// to the declaration it forwards once the resolver rewrites the
+			// unresolved target. find_usages walks it to delegate.
+			forward := &graph.Edge{
+				From: nodeID, To: "unresolved::import::" + importPath + "::" + orig,
+				Kind: graph.EdgeReExports, FilePath: filePath, Line: specLine,
+			}
+			if publicName != orig {
+				forward.Alias = publicName
+			}
+			result.Edges = append(result.Edges, forward)
 		}
 		return
 	}

--- a/internal/parser/languages/javascript.go
+++ b/internal/parser/languages/javascript.go
@@ -812,7 +812,7 @@ func (e *JavaScriptExtractor) emitReExport(m parser.QueryResult, filePath, fileI
 		return
 	}
 	importPath := m.Captures["reexport.path"].Text
-	emitJSReExport(def.Node, importPath, fileID, filePath, src, result)
+	emitJSReExport(def.Node, importPath, fileID, filePath, "javascript", src, result)
 }
 
 func (e *JavaScriptExtractor) emitRequire(m parser.QueryResult, filePath, fileID string, result *parser.ExtractionResult) {

--- a/internal/parser/languages/reexport_nodes_test.go
+++ b/internal/parser/languages/reexport_nodes_test.go
@@ -1,0 +1,178 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+)
+
+// findNode returns the node with the given id, or nil.
+func findResultNode(res *parser.ExtractionResult, id string) *graph.Node {
+	for _, n := range res.Nodes {
+		if n.ID == id {
+			return n
+		}
+	}
+	return nil
+}
+
+// edgeFromTo returns the edge of the given kind with the exact From and To,
+// or nil.
+func edgeFromTo(res *parser.ExtractionResult, kind graph.EdgeKind, from, to string) *graph.Edge {
+	for _, e := range res.Edges {
+		if e.Kind == kind && e.From == from && e.To == to {
+			return e
+		}
+	}
+	return nil
+}
+
+// barrelFixture models zustand's src/middleware.ts: named function re-exports
+// forwarded from sibling modules, one of them aliased.
+const barrelFixture = `export { persist } from './middleware/persist';
+export { devtools, redux } from './middleware/devtools';
+export { ssrSafe as unstable_ssrSafe } from './ssr';
+`
+
+func assertBarrelReExportNodes(t *testing.T, res *parser.ExtractionResult, file, lang string) {
+	t.Helper()
+
+	// Named re-export mints a queryable node under the standard <file>::<name>
+	// scheme so `middleware.ts::persist` resolves.
+	persist := findResultNode(res, file+"::persist")
+	if persist == nil {
+		t.Fatalf("no re-export node minted for persist (%s)", file+"::persist")
+	}
+	if persist.Kind != graph.KindVariable {
+		t.Errorf("persist node kind = %q, want %q", persist.Kind, graph.KindVariable)
+	}
+	if persist.Name != "persist" {
+		t.Errorf("persist node name = %q, want persist", persist.Name)
+	}
+	if persist.Language != lang {
+		t.Errorf("persist node language = %q, want %q", persist.Language, lang)
+	}
+	if v, _ := persist.Meta["reexport"].(bool); !v {
+		t.Errorf("persist node missing reexport marker: %#v", persist.Meta)
+	}
+	if persist.StartLine != 1 {
+		t.Errorf("persist node start line = %d, want 1", persist.StartLine)
+	}
+
+	// The node → canonical link (via the unresolved import machinery) and the
+	// file → node defines edge both ride the same specifier line.
+	if edgeFromTo(res, graph.EdgeReExports, file+"::persist", "unresolved::import::./middleware/persist::persist") == nil {
+		t.Error("missing node→canonical re-export edge for persist")
+	}
+	if edgeFromTo(res, graph.EdgeDefines, file, file+"::persist") == nil {
+		t.Error("missing file→node defines edge for persist")
+	}
+
+	// A multi-specifier statement mints one node per binding.
+	if findResultNode(res, file+"::devtools") == nil {
+		t.Error("no re-export node minted for devtools")
+	}
+	if findResultNode(res, file+"::redux") == nil {
+		t.Error("no re-export node minted for redux")
+	}
+
+	// Aliased re-export mints under the ALIAS name, not the original.
+	alias := findResultNode(res, file+"::unstable_ssrSafe")
+	if alias == nil {
+		t.Fatalf("no re-export node minted for alias unstable_ssrSafe")
+	}
+	if alias.Name != "unstable_ssrSafe" {
+		t.Errorf("alias node name = %q, want unstable_ssrSafe", alias.Name)
+	}
+	if orig, _ := alias.Meta["reexport_original"].(string); orig != "ssrSafe" {
+		t.Errorf("alias node reexport_original = %q, want ssrSafe", orig)
+	}
+	if alias.StartLine != 3 {
+		t.Errorf("alias node start line = %d, want 3", alias.StartLine)
+	}
+	if findResultNode(res, file+"::ssrSafe") != nil {
+		t.Error("aliased re-export must NOT mint a node under the original name ssrSafe")
+	}
+	// The aliased node's forward edge still points at the ORIGINAL name and
+	// carries the alias.
+	fwd := edgeFromTo(res, graph.EdgeReExports, file+"::unstable_ssrSafe", "unresolved::import::./ssr::ssrSafe")
+	if fwd == nil {
+		t.Fatal("missing node→canonical re-export edge for the alias")
+	}
+	if fwd.Alias != "unstable_ssrSafe" {
+		t.Errorf("alias forward edge alias = %q, want unstable_ssrSafe", fwd.Alias)
+	}
+
+	// The existing file-level per-specifier re-export edges are untouched.
+	if importEdge(res, graph.EdgeReExports, "unresolved::import::./middleware/persist::persist") == nil {
+		t.Error("file-level per-specifier re-export edge for persist was dropped")
+	}
+}
+
+func TestTSExtractor_BarrelReExportNodes(t *testing.T) {
+	res, err := NewTypeScriptExtractor().Extract("middleware.ts", []byte(barrelFixture))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertBarrelReExportNodes(t, res, "middleware.ts", "typescript")
+}
+
+func TestJSExtractor_BarrelReExportNodes(t *testing.T) {
+	res, err := NewJavaScriptExtractor().Extract("middleware.js", []byte(barrelFixture))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertBarrelReExportNodes(t, res, "middleware.js", "javascript")
+}
+
+// TestTSExtractor_TypeOnlyReExportMintsNoValueNode guards the value/type split:
+// a type-only re-export names a type, handled as a reference edge elsewhere, so
+// it must not mint a value binding node.
+func TestTSExtractor_TypeOnlyReExportMintsNoValueNode(t *testing.T) {
+	src := `export type { Config } from './types';
+export { type Options, run } from './run';
+`
+	res, err := NewTypeScriptExtractor().Extract("types_barrel.ts", []byte(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if findResultNode(res, "types_barrel.ts::Config") != nil {
+		t.Error("type-only re-export `export type { Config }` must not mint a value node")
+	}
+	if findResultNode(res, "types_barrel.ts::Options") != nil {
+		t.Error("inline type-only specifier `{ type Options }` must not mint a value node")
+	}
+	// The value specifier alongside the inline type-only one still mints.
+	if findResultNode(res, "types_barrel.ts::run") == nil {
+		t.Error("value re-export `run` alongside a type-only specifier should still mint a node")
+	}
+}
+
+// TestTSExtractor_ReExportVolumeGuardMintsNoNodes verifies a barrel past the
+// binding cap collapses to the module edge and mints no per-binding nodes.
+func TestTSExtractor_ReExportVolumeGuardMintsNoNodes(t *testing.T) {
+	var b []byte
+	b = append(b, []byte("export { ")...)
+	for i := 0; i < jsImportBindingCap+5; i++ {
+		if i > 0 {
+			b = append(b, ", "...)
+		}
+		b = append(b, []byte("n")...)
+		b = append(b, []byte{byte('0' + i%10)}...)
+		b = append(b, []byte{byte('a' + byte(i/10))}...)
+	}
+	b = append(b, []byte(" } from './big';\n")...)
+	res, err := NewTypeScriptExtractor().Extract("big_barrel.ts", b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, n := range res.Nodes {
+		if v, _ := n.Meta["reexport"].(bool); v {
+			t.Fatalf("re-export node %q minted past the volume guard", n.ID)
+		}
+	}
+	if importEdge(res, graph.EdgeReExports, "unresolved::import::./big") == nil {
+		t.Error("module-level re-export edge dropped under the volume guard")
+	}
+}

--- a/internal/parser/languages/typescript.go
+++ b/internal/parser/languages/typescript.go
@@ -1257,7 +1257,7 @@ func (e *TypeScriptExtractor) emitReExport(m parser.QueryResult, filePath, fileI
 		return
 	}
 	importPath := strings.Trim(m.Captures["reexport.path"].Text, `"'`+"`")
-	emitJSReExport(def.Node, importPath, fileID, filePath, src, result)
+	emitJSReExport(def.Node, importPath, fileID, filePath, "typescript", src, result)
 }
 
 // emitMethod is called once per method_definition captured at root

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -2178,7 +2178,7 @@ func (r *Resolver) resolveImport(e *graph.Edge, importPath string, stats *Resolv
 
 func (r *Resolver) resolveFunctionCall(e *graph.Edge, funcName string, stats *ResolveStats) {
 	callerRepo := r.callerRepoPrefix(e)
-	candidates := r.cachedFindNodesByNameInRepo(funcName, callerRepo)
+	candidates := withoutReExportForwarders(r.cachedFindNodesByNameInRepo(funcName, callerRepo))
 	if len(candidates) == 0 {
 		// No same-repo candidate. A genuine cross-repo callee is left
 		// unresolved here for CrossRepoResolver — which alone carries the
@@ -2338,6 +2338,34 @@ func (r *Resolver) resolveFunctionCall(e *graph.Edge, funcName string, stats *Re
 	}
 
 	stats.Unresolved++
+}
+
+// withoutReExportForwarders drops barrel re-export binding nodes from a
+// call-resolution candidate set. A re-export node (`export { X } from './mod'`)
+// is a transparent forwarder, never a callee — the call binds to the
+// declaration it forwards, which is a separate same-named candidate. Leaving
+// the forwarder in only adds a phantom candidate that turns an otherwise-clean
+// import-evidence / value-callee pick into a refused ambiguity. Returns the
+// input unchanged when it holds no forwarders (the common case), so non-JS/TS
+// and non-barrel resolution pays nothing.
+func withoutReExportForwarders(candidates []*graph.Node) []*graph.Node {
+	has := false
+	for _, c := range candidates {
+		if graph.IsReExportNode(c) {
+			has = true
+			break
+		}
+	}
+	if !has {
+		return candidates
+	}
+	out := make([]*graph.Node, 0, len(candidates))
+	for _, c := range candidates {
+		if !graph.IsReExportNode(c) {
+			out = append(out, c)
+		}
+	}
+	return out
 }
 
 // pickTopLevelValueCallee returns the variable/constant candidate a JS/TS


### PR DESCRIPTION
A JS/TS barrel (`export { X } from './mod'`, optionally aliased) is the public API a consumer imports — but the extractor recorded re-exports only as file-level edges and minted no node for the forwarded binding, so querying the façade path an agent actually knows (`src/middleware.ts::persist`) returned a silent zero.

The extractor now mints a node at the barrel site under the exported (post-alias) name for each named value specifier within the cap, marked with a reexport flag plus a node→canonical forward edge resolved through the existing import machinery. find_usages on a re-export node returns its own direct refs (consumer imports binding to it) merged with the canonical declaration's usages by walking the forward edge, so the façade answers with the full usage set. Aliased re-exports mint under the alias; type-only re-exports stay reference edges and mint no value node; call resolution treats the node as a transparent forwarder.