### PR TITLE
install: slim the generated agent guidance to a policy core, move reference to gortex://guide

### DIFF
--- a/cmd/gortex/guide.go
+++ b/cmd/gortex/guide.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/zzet/gortex/internal/mcp"
+)
+
+// guideCmd prints the Gortex reference guide — the same content served by the
+// `gortex://guide` MCP resource, for harnesses without MCP-resource support or
+// for shell use. The installed CLAUDE.md carries only the mandatory policy
+// core and points here for everything else.
+var guideCmd = &cobra.Command{
+	Use:   "guide [topic]",
+	Short: "Print the Gortex reference guide (providers, capabilities, tokens, analyze, search_ast, resources, workflow)",
+	Long: `Prints the Gortex reference guide — the on-demand home for detail that is
+not pre-paid in the installed CLAUDE.md: the LLM-provider matrix, the
+non-obvious capabilities catalog, the token-economy deep-dive, the MCP
+resources list, and the analyze / search_ast catalogs.
+
+With no argument the full guide is printed with a topic index. Pass a topic
+to print just that section:
+
+  gortex guide providers
+  gortex guide capabilities
+  gortex guide tokens
+  gortex guide analyze
+  gortex guide search_ast
+  gortex guide resources
+  gortex guide workflow
+
+The same content is served by the ` + "`gortex://guide`" + ` MCP resource
+(section-addressable at ` + "`gortex://guide/{topic}`" + `).`,
+	Args:      cobra.MaximumNArgs(1),
+	ValidArgs: mcp.GuideTopics(),
+	Run: func(cmd *cobra.Command, args []string) {
+		topic := ""
+		if len(args) == 1 {
+			topic = args[0]
+		}
+		fmt.Fprint(cmd.OutOrStdout(), strings.TrimRight(mcp.GuideText(topic), "\n")+"\n")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(guideCmd)
+}

--- a/cmd/gortex/guide_test.go
+++ b/cmd/gortex/guide_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestGuideCmd_PrintsRelocatedReference verifies the `gortex guide` verb
+// returns the relocated reference content — the CLI path for harnesses
+// without MCP-resource support.
+func TestGuideCmd_PrintsRelocatedReference(t *testing.T) {
+	run := func(args ...string) string {
+		var buf bytes.Buffer
+		guideCmd.SetOut(&buf)
+		guideCmd.SetErr(&buf)
+		guideCmd.Run(guideCmd, args)
+		return buf.String()
+	}
+
+	full := run()
+	if !strings.Contains(full, "# Gortex Guide") {
+		t.Error("full guide missing header")
+	}
+	if !strings.Contains(full, "bedrock` / `deepseek`") {
+		t.Error("full guide missing the provider matrix")
+	}
+
+	providers := run("providers")
+	if !strings.Contains(providers, "AWS Bedrock Converse") {
+		t.Error("`gortex guide providers` missing provider detail")
+	}
+
+	analyze := run("analyze")
+	if !strings.Contains(analyze, "analyze") {
+		t.Error("`gortex guide analyze` missing the analyze catalog")
+	}
+}

--- a/cmd/gortex/testdata/agent-render/hermes.txt
+++ b/cmd/gortex/testdata/agent-render/hermes.txt
@@ -10,7 +10,7 @@ platform_toolsets:
 === home/.hermes/skills/analysis/gortex-architecture-review/SKILL.md ===
 ---
 name: gortex-architecture-review
-description: "Use when the user wants a graph-grounded architectural read — what the architecture actually looks like, where the design is under stress, what to refactor before it breaks. Distinct from quality-audit (punch list) — this produces a narrative. Enforces get_repo_outline / get_communities / get_processes / analyze components|routes|models|k8s_resources|images|hotspots|cycles|cross_repo|pubsub|channel_ops|race_writes|stale_code|ownership / contracts list+check / get_class_hierarchy / get_dependencies+dependents at community level / export_context. Examples: \"Review the architecture of this repo\", \"Where is this design under stress?\", \"Map the de facto modules and processes\""
+description: "Graph-grounded architectural read of a repo."
 version: 1.0.0
 metadata:
   hermes:
@@ -118,7 +118,7 @@ The packet rides the same surface as `/gortex-quality-audit` but is structured a
 === home/.hermes/skills/analysis/gortex-co-change/SKILL.md ===
 ---
 name: gortex-co-change
-description: "Use when the user asks what tends to change together — for refactor planning, ownership decisions, ADR rationale, or to find hidden coupling the graph's static edges don't capture. Enforces gortex enrich blame all / get_recent_changes / get_symbol_history / analyze blame|ownership|hotspots / get_dependents / find_clones / detect_changes. Examples: \"What changes together with X?\", \"Find hidden coupling in this package\", \"Which files should I refactor together?\""
+description: "Find what changes together and hidden coupling."
 version: 1.0.0
 metadata:
   hermes:
@@ -193,7 +193,7 @@ When the anchor lives in a multi-repo project (`get_active_project` shows >1 mem
 === home/.hermes/skills/analysis/gortex-episode-replay/SKILL.md ===
 ---
 name: gortex-episode-replay
-description: "Use when the user wants to reconstruct what happened in a window — for a postmortem, a release-boundary diff, a 'what did Alice change last week', or a 'what did this PR actually change beyond the diff'. Enforces gortex enrich blame all / analyze releases|blame|ownership / get_recent_changes / detect_changes / diff_context / explain_change_impact per symbol / query_notes|query_memories / export_context. Examples: \"What shipped in v1.3?\", \"Walk me through last week's changes\", \"Build a postmortem from this incident window\""
+description: "Reconstruct what changed in a window (postmortem, release, PR)."
 version: 1.0.0
 metadata:
   hermes:
@@ -269,7 +269,7 @@ These two surfaces are how a postmortem reads as a story rather than a list of f
 === home/.hermes/skills/analysis/gortex-impact/SKILL.md ===
 ---
 name: gortex-impact
-description: "Use when the user wants to know what will break if they change something, or needs safety analysis before editing code. Examples: \"Is it safe to change X?\", \"What depends on this?\", \"What will break?\""
+description: "Assess what breaks if you change X before editing it."
 version: 1.0.0
 metadata:
   hermes:
@@ -326,7 +326,7 @@ metadata:
 === home/.hermes/skills/analysis/gortex-pr-review-agent/SKILL.md ===
 ---
 name: gortex-pr-review-agent
-description: "Use when you are a coding agent that needs a graph-grounded review verdict on a pending change without hand-walking the review gates. Shell the review verb once — gortex review --audience agent (add --format json for structured output) — and act on the terse one-line verdict + compact file:line findings + cost. Block means fix every critical/error finding and re-run until it clears. Examples: \"Review my change and tell me if it's safe to merge\", \"Run the review verb and act on the findings\", \"Get a terse review verdict for this diff\""
+description: "Coding-agent review verdict via the gortex review verb."
 version: 1.0.0
 metadata:
   hermes:
@@ -397,7 +397,7 @@ When you want the full reasoning behind a verdict (per-file risk, contracts, gua
 === home/.hermes/skills/analysis/gortex-pr-review/SKILL.md ===
 ---
 name: gortex-pr-review
-description: "Use when the user wants a code-review pass on a pending change — local staged diff, a branch about to merge, or a PR they're reading. Walks the diff through the graph so comments are grounded in real callers / contracts / coverage / guards, not style nitpicks. Enforces detect_changes / diff_context / explain_change_impact / verify_change / contracts check / check_guards / analyze would_create_cycle|coverage_gaps / get_test_targets / find_clones dead_only / preview_edit on high-risk changes / surface_memories on touched symbols / export_context. Examples: \"Review this PR\", \"What does this staged diff break?\", \"Do a graph-grounded review of this change\""
+description: "Graph-grounded review of a pending change or PR."
 version: 1.0.0
 metadata:
   hermes:
@@ -519,7 +519,7 @@ If the diff is in the working tree (or a feature branch checked out), `detect_ch
 === home/.hermes/skills/analysis/gortex-quality-audit/SKILL.md ===
 ---
 name: gortex-quality-audit
-description: "Use when the user wants a structured pass over a repo / directory looking for code-quality issues at scale — dead code, hotspots, cycles, churn, todos, coverage gaps, clones, anti-patterns, config drift. Enforces gortex enrich / analyze dead_code|hotspots|cycles|todos|stale_code|stale_flags|coverage_*|error_surface|field_writers|race_writes|unclosed_channels|orphan_tables / find_clones dead_only / search_ast detectors / audit_agent_config / contracts check / export_context. Examples: \"Audit this repo for quality issues\", \"Find code smells in this package\", \"Run a quality scan and rank by priority\""
+description: "Repo-scale quality scan — dead code, hotspots, clones."
 version: 1.0.0
 metadata:
   hermes:
@@ -639,7 +639,7 @@ The output of a quality audit is a prioritised markdown packet, not a one-line "
 === home/.hermes/skills/code-intelligence/gortex-cli/SKILL.md ===
 ---
 name: gortex-cli
-description: "Use to drive Gortex from the shell via the gortex CLI without mounting the MCP tool surface — when MCP is unavailable or impractical, in a CI job, or to keep baseline context low. Examples: \"use gortex from the CLI\", \"run the gortex safety workflow without MCP\", \"query the graph with the gortex command\""
+description: "Drive Gortex from the shell via the gortex CLI, no MCP surface."
 version: 1.0.0
 metadata:
   hermes:
@@ -867,7 +867,7 @@ After edits, call `verify_change` (broken callers + interface implementors, cros
 === home/.hermes/skills/debugging/gortex-debug/SKILL.md ===
 ---
 name: gortex-debug
-description: "Use when the user is debugging a bug, tracing an error, or asking why something fails. Examples: \"Why is X failing?\", \"Where does this error come from?\", \"Trace this bug\""
+description: "Debug a bug, trace an error, or find why something fails."
 version: 1.0.0
 metadata:
   hermes:
@@ -915,7 +915,7 @@ metadata:
 === home/.hermes/skills/debugging/gortex-incident-investigation/SKILL.md ===
 ---
 name: gortex-incident-investigation
-description: "Use when an alert fired, a deploy regressed, or production is misbehaving and the user needs to walk from symptom (log line, error, broken endpoint, failing CI) back to root cause. Enforces surface_memories / search_symbols / get_recent_changes / analyze error_surface|event_emitters / get_callers / flow_between / taint_paths / explain_change_impact / store_memory(kind:incident). Examples: \"Why did this alert fire?\", \"What broke in the last deploy?\", \"Trace this production error to its root cause\""
+description: "Walk a production symptom back to its root cause."
 version: 1.0.0
 metadata:
   hermes:
@@ -996,7 +996,7 @@ After root-cause is found and the fix is shipped:
 === home/.hermes/skills/navigation/gortex-cross-repo-usage/SKILL.md ===
 ---
 name: gortex-cross-repo-usage
-description: "Use when the user needs to see who uses a symbol across consumer repos, not just the current one. Enforces get_active_project / track_repository / find_usages partitioned by repo / analyze cross_repo. Examples: \"Who calls this across all our repos?\", \"What other services consume this API?\", \"Cross-repo blast radius\""
+description: "Find who uses a symbol across all consumer repos."
 version: 1.0.0
 metadata:
   hermes:
@@ -1067,7 +1067,7 @@ If a known consumer is missing from the tracked-repo list:
 === home/.hermes/skills/navigation/gortex-dataflow-trace/SKILL.md ===
 ---
 name: gortex-dataflow-trace
-description: "Use when the user wants to trace where a value flows — through assignments, function args, returns, channels, or pub/sub topics. Enforces search_symbols / flow_between / taint_paths / analyze pubsub|channel_ops. Examples: \"Where does this value end up?\", \"Trace the taint from input to sink\", \"Find every flow from X to Y\""
+description: "Trace where a value flows through the code."
 version: 1.0.0
 metadata:
   hermes:
@@ -1141,7 +1141,7 @@ Each row from `flow_between` is a sequence of edges with the kind annotated (`va
 === home/.hermes/skills/navigation/gortex-explore/SKILL.md ===
 ---
 name: gortex-explore
-description: "Use when the user asks how code works, wants to understand architecture, trace execution flows, or explore unfamiliar parts of the codebase. Examples: \"How does X work?\", \"What calls this function?\", \"Show me the auth flow\""
+description: "Understand how code works or trace an execution flow."
 version: 1.0.0
 metadata:
   hermes:
@@ -1180,7 +1180,7 @@ metadata:
 === home/.hermes/skills/navigation/gortex-onboarding/SKILL.md ===
 ---
 name: gortex-onboarding
-description: "Use when the user is new to a repo (or returning cold) and wants a structured tour — where to read first, what the architecture is, who owns what, where to safely make a first edit. Enforces graph_stats / get_active_project / get_repo_outline / surface_memories / distill_session / get_communities / get_processes / analyze hotspots|components|routes|models|ownership / contracts list / audit_agent_config / export_context. Examples: \"Give me a tour of this repo\", \"I'm new here, where do I start?\", \"Onboard me on this codebase\""
+description: "Structured tour of an unfamiliar repo."
 version: 1.0.0
 metadata:
   hermes:
@@ -1283,7 +1283,7 @@ Hand that to the user; they can paste it into their notes / wiki / agent memory.
 === home/.hermes/skills/refactoring/gortex-extract-function/SKILL.md ===
 ---
 name: gortex-extract-function
-description: "Use when the user wants to extract code into a new function / method / variable via the language server's refactor actions (not a manual rewrite). Enforces get_editing_context / get_code_actions(kind=refactor.extract) / preview_edit / apply_code_action. Examples: \"Extract these lines into a helper\", \"Pull this into its own method\", \"Refactor this block into a function\""
+description: "Extract code into a function or method via LSP refactor."
 version: 1.0.0
 metadata:
   hermes:
@@ -1349,7 +1349,7 @@ Some servers (yaml-language-server, json-language-server, bash-language-server) 
 === home/.hermes/skills/refactoring/gortex-fix-all/SKILL.md ===
 ---
 name: gortex-fix-all
-description: "Use when the user wants to clear LSP diagnostics — a single error, a file's worth of warnings, or the whole project's source.fixAll bundle. Enforces subscribe_diagnostics / get_code_actions / apply_code_action / fix_all_in_file in order. Examples: \"Fix the diagnostics in this file\", \"Run source.fixAll\", \"Apply quick-fixes for these errors\""
+description: "Clear LSP diagnostics — one error, a file, or source.fixAll."
 version: 1.0.0
 metadata:
   hermes:
@@ -1412,7 +1412,7 @@ If `get_code_actions` returns an empty menu, the server doesn't know how to fix 
 === home/.hermes/skills/refactoring/gortex-refactor/SKILL.md ===
 ---
 name: gortex-refactor
-description: "Use when the user wants to rename, extract, split, move, or restructure code safely. Examples: \"Rename this function\", \"Extract this into a module\", \"Refactor this class\""
+description: "Rename, extract, split, or restructure code safely."
 version: 1.0.0
 metadata:
   hermes:
@@ -1479,7 +1479,7 @@ metadata:
 === home/.hermes/skills/refactoring/gortex-rename/SKILL.md ===
 ---
 name: gortex-rename
-description: "Use when the user wants to rename a symbol and have every reference (definition + callers + tests + cross-repo consumers) updated atomically. Enforces search_symbols / verify_change / rename_symbol / batch_edit / check_guards in order. Examples: \"Rename Foo to Bar everywhere\", \"Rename this method\", \"Change the package name\""
+description: "Rename a symbol and update every reference atomically."
 version: 1.0.0
 metadata:
   hermes:
@@ -1543,7 +1543,7 @@ If the renamed symbol is part of an interface contract:
 === home/.hermes/skills/refactoring/gortex-safe-edit/SKILL.md ===
 ---
 name: gortex-safe-edit
-description: "Use when the user is about to edit source code and wants the edit to be safe — speculative preview, broken-callers / blast-radius check, then on-disk apply. Enforces preview_edit / simulate_chain before batch_edit. Examples: \"Change the signature of X safely\", \"Apply this WorkspaceEdit but verify first\", \"Speculate this edit before writing\""
+description: "Preview an edit's blast radius on the shadow graph before writing."
 version: 1.0.0
 metadata:
   hermes:
@@ -1607,7 +1607,7 @@ Use this **before** you touch `edit_file` / `edit_symbol` / `batch_edit` / `Edit
 === home/.hermes/skills/testing/gortex-add-test/SKILL.md ===
 ---
 name: gortex-add-test
-description: "Use when the user wants to add tests for under-tested code — coverage gaps, untested symbols, regression repro. Enforces analyze coverage_gaps / get_untested_symbols / suggest_pattern / scaffold / get_test_targets. Examples: \"Add tests for X\", \"Cover the gaps in this package\", \"Write a test for this bug\""
+description: "Add tests for under-tested code and coverage gaps."
 version: 1.0.0
 metadata:
   hermes:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -30,6 +30,7 @@ gortex export [path]         Export the graph to Cypher, GraphML, or Mermaid (--
 gortex githook <sub>         install / uninstall / status — manage the post-commit hook
 gortex clean                 Remove Gortex files from a project
 gortex telemetry <sub>       on / off / status — control anonymous, opt-in usage telemetry (off by default; honours DO_NOT_TRACK)
+gortex guide [topic]         Print the reference guide (providers, capabilities, tokens, analyze, search_ast, resources, workflow) — same content as the gortex://guide resource
 gortex version               Print version
 ```
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,6 +1,6 @@
 # MCP surface
 
-Gortex exposes a knowledge-graph query surface over the [Model Context Protocol](https://modelcontextprotocol.io): **100+ tools, 16 resources, 3 prompts**. Agents call the same surface from stdio, the daemon Unix socket, or the MCP 2026 Streamable HTTP endpoint.
+Gortex exposes a knowledge-graph query surface over the [Model Context Protocol](https://modelcontextprotocol.io): **100+ tools, 18 resources, 3 prompts**. Agents call the same surface from stdio, the daemon Unix socket, or the MCP 2026 Streamable HTTP endpoint.
 
 - [Tool discovery (lazy mode)](#tool-discovery-lazy-mode)
 - [Restricting the tool surface (presets)](#restricting-the-tool-surface-presets)
@@ -22,7 +22,7 @@ Gortex exposes a knowledge-graph query surface over the [Model Context Protocol]
 - [Multi-repo management](#multi-repo-management)
 - [Live editor buffers (overlay sessions)](#live-editor-buffers-overlay-sessions)
 - [Speculative execution](#speculative-execution)
-- [MCP resources (16)](#mcp-resources-16)
+- [MCP resources (18)](#mcp-resources-18)
 - [MCP prompts (3)](#mcp-prompts-3)
 
 ## Tool discovery (lazy mode)
@@ -357,7 +357,7 @@ Built on the same shadow-graph substrate, `preview_edit` and `simulate_chain` an
 | `preview_edit` | Single-shot WorkspaceEdit → impact report. Optional `diagnostics: false` skips the LSP round-trip. `inherit_overlay: true` layers on top of the caller's current overlay |
 | `simulate_chain` | Ordered sequence of WorkspaceEdits applied in order with per-step impact + cumulative rollup + per-step diagnostics delta. `stop_on_error: true` (default) aborts on the first new ERROR-severity diagnostic. `keep: true` promotes the final simulated state into a real overlay session bound to the caller |
 
-## MCP resources (16)
+## MCP resources (18)
 
 Read-only, URI-addressable, no args. Clients that speak resources can `resources/subscribe` once and receive `notifications/resources/updated` after each graph re-warm — no polling.
 
@@ -366,6 +366,8 @@ Read-only, URI-addressable, no args. Clients that speak resources can `resources
 | `gortex://session` | Current session state and activity |
 | `gortex://stats` | Graph statistics (node/edge counts) |
 | `gortex://schema` | Graph schema reference |
+| `gortex://guide` | On-demand reference: LLM-provider matrix, capabilities, token-economy, analyze/search_ast catalogs, workflow |
+| `gortex://guide/{topic}` | One guide section by topic (providers, capabilities, tokens, analyze, search_ast, resources, workflow) |
 | `gortex://index-health` | Health score, parse failures, stale files |
 | `gortex://workspace` | Workspace identity and discovered member set |
 | `gortex://repos` | Tracked repo / project list |

--- a/internal/agents/claudecode/content.go
+++ b/internal/agents/claudecode/content.go
@@ -99,121 +99,121 @@ var SlashCommands = map[string]string{
 var GlobalSkills = map[string]string{
 	"gortex-guide": `---
 name: gortex-guide
-description: "Use when the user asks about Gortex — available tools, graph schema, or workflow reference. Examples: \"What Gortex tools are available?\", \"How do I use Gortex?\""
+description: "Gortex reference: available tools, graph schema, and workflow."
 ---
 ` + commandGuide,
 
 	"gortex-explore": `---
 name: gortex-explore
-description: "Use when the user asks how code works, wants to understand architecture, trace execution flows, or explore unfamiliar parts of the codebase. Examples: \"How does X work?\", \"What calls this function?\", \"Show me the auth flow\""
+description: "Understand how code works or trace an execution flow."
 ---
 ` + commandExplore,
 
 	"gortex-debug": `---
 name: gortex-debug
-description: "Use when the user is debugging a bug, tracing an error, or asking why something fails. Examples: \"Why is X failing?\", \"Where does this error come from?\", \"Trace this bug\""
+description: "Debug a bug, trace an error, or find why something fails."
 ---
 ` + commandDebug,
 
 	"gortex-impact": `---
 name: gortex-impact
-description: "Use when the user wants to know what will break if they change something, or needs safety analysis before editing code. Examples: \"Is it safe to change X?\", \"What depends on this?\", \"What will break?\""
+description: "Assess what breaks if you change X before editing it."
 ---
 ` + commandImpact,
 
 	"gortex-refactor": `---
 name: gortex-refactor
-description: "Use when the user wants to rename, extract, split, move, or restructure code safely. Examples: \"Rename this function\", \"Extract this into a module\", \"Refactor this class\""
+description: "Rename, extract, split, or restructure code safely."
 ---
 ` + commandRefactor,
 
 	"gortex-safe-edit": `---
 name: gortex-safe-edit
-description: "Use when the user is about to edit source code and wants the edit to be safe — speculative preview, broken-callers / blast-radius check, then on-disk apply. Enforces preview_edit / simulate_chain before batch_edit. Examples: \"Change the signature of X safely\", \"Apply this WorkspaceEdit but verify first\", \"Speculate this edit before writing\""
+description: "Preview an edit's blast radius on the shadow graph before writing."
 ---
 ` + commandSafeEdit,
 
 	"gortex-fix-all": `---
 name: gortex-fix-all
-description: "Use when the user wants to clear LSP diagnostics — a single error, a file's worth of warnings, or the whole project's source.fixAll bundle. Enforces subscribe_diagnostics / get_code_actions / apply_code_action / fix_all_in_file in order. Examples: \"Fix the diagnostics in this file\", \"Run source.fixAll\", \"Apply quick-fixes for these errors\""
+description: "Clear LSP diagnostics — one error, a file, or source.fixAll."
 ---
 ` + commandFixAll,
 
 	"gortex-extract-function": `---
 name: gortex-extract-function
-description: "Use when the user wants to extract code into a new function / method / variable via the language server's refactor actions (not a manual rewrite). Enforces get_editing_context / get_code_actions(kind=refactor.extract) / preview_edit / apply_code_action. Examples: \"Extract these lines into a helper\", \"Pull this into its own method\", \"Refactor this block into a function\""
+description: "Extract code into a function or method via LSP refactor."
 ---
 ` + commandExtractFunction,
 
 	"gortex-rename": `---
 name: gortex-rename
-description: "Use when the user wants to rename a symbol and have every reference (definition + callers + tests + cross-repo consumers) updated atomically. Enforces search_symbols / verify_change / rename_symbol / batch_edit / check_guards in order. Examples: \"Rename Foo to Bar everywhere\", \"Rename this method\", \"Change the package name\""
+description: "Rename a symbol and update every reference atomically."
 ---
 ` + commandRename,
 
 	"gortex-cross-repo-usage": `---
 name: gortex-cross-repo-usage
-description: "Use when the user needs to see who uses a symbol across consumer repos, not just the current one. Enforces get_active_project / track_repository / find_usages partitioned by repo / analyze cross_repo. Examples: \"Who calls this across all our repos?\", \"What other services consume this API?\", \"Cross-repo blast radius\""
+description: "Find who uses a symbol across all consumer repos."
 ---
 ` + commandCrossRepoUsage,
 
 	"gortex-dataflow-trace": `---
 name: gortex-dataflow-trace
-description: "Use when the user wants to trace where a value flows — through assignments, function args, returns, channels, or pub/sub topics. Enforces search_symbols / flow_between / taint_paths / analyze pubsub|channel_ops. Examples: \"Where does this value end up?\", \"Trace the taint from input to sink\", \"Find every flow from X to Y\""
+description: "Trace where a value flows through the code."
 ---
 ` + commandDataflowTrace,
 
 	"gortex-add-test": `---
 name: gortex-add-test
-description: "Use when the user wants to add tests for under-tested code — coverage gaps, untested symbols, regression repro. Enforces analyze coverage_gaps / get_untested_symbols / suggest_pattern / scaffold / get_test_targets. Examples: \"Add tests for X\", \"Cover the gaps in this package\", \"Write a test for this bug\""
+description: "Add tests for under-tested code and coverage gaps."
 ---
 ` + commandAddTest,
 
 	"gortex-incident-investigation": `---
 name: gortex-incident-investigation
-description: "Use when an alert fired, a deploy regressed, or production is misbehaving and the user needs to walk from symptom (log line, error, broken endpoint, failing CI) back to root cause. Enforces surface_memories / search_symbols / get_recent_changes / analyze error_surface|event_emitters / get_callers / flow_between / taint_paths / explain_change_impact / store_memory(kind:incident). Examples: \"Why did this alert fire?\", \"What broke in the last deploy?\", \"Trace this production error to its root cause\""
+description: "Walk a production symptom back to its root cause."
 ---
 ` + commandIncidentInvestigation,
 
 	"gortex-episode-replay": `---
 name: gortex-episode-replay
-description: "Use when the user wants to reconstruct what happened in a window — for a postmortem, a release-boundary diff, a 'what did Alice change last week', or a 'what did this PR actually change beyond the diff'. Enforces gortex enrich blame all / analyze releases|blame|ownership / get_recent_changes / detect_changes / diff_context / explain_change_impact per symbol / query_notes|query_memories / export_context. Examples: \"What shipped in v1.3?\", \"Walk me through last week's changes\", \"Build a postmortem from this incident window\""
+description: "Reconstruct what changed in a window (postmortem, release, PR)."
 ---
 ` + commandEpisodeReplay,
 
 	"gortex-co-change": `---
 name: gortex-co-change
-description: "Use when the user asks what tends to change together — for refactor planning, ownership decisions, ADR rationale, or to find hidden coupling the graph's static edges don't capture. Enforces gortex enrich blame all / get_recent_changes / get_symbol_history / analyze blame|ownership|hotspots / get_dependents / find_clones / detect_changes. Examples: \"What changes together with X?\", \"Find hidden coupling in this package\", \"Which files should I refactor together?\""
+description: "Find what changes together and hidden coupling."
 ---
 ` + commandCoChange,
 
 	"gortex-onboarding": `---
 name: gortex-onboarding
-description: "Use when the user is new to a repo (or returning cold) and wants a structured tour — where to read first, what the architecture is, who owns what, where to safely make a first edit. Enforces graph_stats / get_active_project / get_repo_outline / surface_memories / distill_session / get_communities / get_processes / analyze hotspots|components|routes|models|ownership / contracts list / audit_agent_config / export_context. Examples: \"Give me a tour of this repo\", \"I'm new here, where do I start?\", \"Onboard me on this codebase\""
+description: "Structured tour of an unfamiliar repo."
 ---
 ` + commandOnboarding,
 
 	"gortex-quality-audit": `---
 name: gortex-quality-audit
-description: "Use when the user wants a structured pass over a repo / directory looking for code-quality issues at scale — dead code, hotspots, cycles, churn, todos, coverage gaps, clones, anti-patterns, config drift. Enforces gortex enrich / analyze dead_code|hotspots|cycles|todos|stale_code|stale_flags|coverage_*|error_surface|field_writers|race_writes|unclosed_channels|orphan_tables / find_clones dead_only / search_ast detectors / audit_agent_config / contracts check / export_context. Examples: \"Audit this repo for quality issues\", \"Find code smells in this package\", \"Run a quality scan and rank by priority\""
+description: "Repo-scale quality scan — dead code, hotspots, clones."
 ---
 ` + commandQualityAudit,
 
 	"gortex-architecture-review": `---
 name: gortex-architecture-review
-description: "Use when the user wants a graph-grounded architectural read — what the architecture actually looks like, where the design is under stress, what to refactor before it breaks. Distinct from quality-audit (punch list) — this produces a narrative. Enforces get_repo_outline / get_communities / get_processes / analyze components|routes|models|k8s_resources|images|hotspots|cycles|cross_repo|pubsub|channel_ops|race_writes|stale_code|ownership / contracts list+check / get_class_hierarchy / get_dependencies+dependents at community level / export_context. Examples: \"Review the architecture of this repo\", \"Where is this design under stress?\", \"Map the de facto modules and processes\""
+description: "Graph-grounded architectural read of a repo."
 ---
 ` + commandArchitectureReview,
 
 	"gortex-pr-review": `---
 name: gortex-pr-review
-description: "Use when the user wants a code-review pass on a pending change — local staged diff, a branch about to merge, or a PR they're reading. Walks the diff through the graph so comments are grounded in real callers / contracts / coverage / guards, not style nitpicks. Enforces detect_changes / diff_context / explain_change_impact / verify_change / contracts check / check_guards / analyze would_create_cycle|coverage_gaps / get_test_targets / find_clones dead_only / preview_edit on high-risk changes / surface_memories on touched symbols / export_context. Examples: \"Review this PR\", \"What does this staged diff break?\", \"Do a graph-grounded review of this change\""
+description: "Graph-grounded review of a pending change or PR."
 ---
 ` + commandPRReview,
 
 	"gortex-pr-review-agent": `---
 name: gortex-pr-review-agent
-description: "Use when you are a coding agent that needs a graph-grounded review verdict on a pending change without hand-walking the review gates. Shell the review verb once — gortex review --audience agent (add --format json for structured output) — and act on the terse one-line verdict + compact file:line findings + cost. Block means fix every critical/error finding and re-run until it clears. Examples: \"Review my change and tell me if it's safe to merge\", \"Run the review verb and act on the findings\", \"Get a terse review verdict for this diff\""
+description: "Coding-agent review verdict via the gortex review verb."
 ---
 ` + commandPRReviewAgent,
 
@@ -1769,7 +1769,7 @@ When you want the full reasoning behind a verdict (per-file risk, contracts, gua
 // the sub-agents' `tools:` allowlist — scoping the skill to the gortex binary.
 const skillGortexCLI = `---
 name: gortex-cli
-description: "Use to drive Gortex from the shell via the gortex CLI without mounting the MCP tool surface — when MCP is unavailable or impractical, in a CI job, or to keep baseline context low. Examples: \"use gortex from the CLI\", \"run the gortex safety workflow without MCP\", \"query the graph with the gortex command\""
+description: "Drive Gortex from the shell via the gortex CLI, no MCP surface."
 allowed-tools: Bash(gortex:*)
 ---
 

--- a/internal/agents/claudecode/install_diet_test.go
+++ b/internal/agents/claudecode/install_diet_test.go
@@ -1,0 +1,139 @@
+package claudecode
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/agents/agentstest"
+)
+
+// Byte ceilings for the installed ambient layer. Approximated at ~4.4 B/token:
+//   - 6.5 KiB global section ≈ 1.5k tokens
+//   - 2.5 KiB skills-eager total ≈ 0.57k tokens
+// Blowing either (a future rule-block or description balloon) fails loudly
+// instead of silently re-inflating the per-session tax.
+const (
+	globalSectionByteCeiling = 6656 // 6.5 KiB
+	skillsEagerByteCeiling   = 2560 // 2.5 KiB
+)
+
+// frontmatterOf returns the YAML frontmatter block (--- … ---) of a skill /
+// sub-agent definition — the part a client loads eagerly to route. Empty when
+// the body has no leading frontmatter.
+func frontmatterOf(s string) string {
+	s = strings.TrimLeft(s, "\n")
+	if !strings.HasPrefix(s, "---\n") {
+		return ""
+	}
+	rest := s[len("---\n"):]
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return ""
+	}
+	return "---\n" + rest[:end+len("\n---")]
+}
+
+// TestInstalledAmbientByteCeilings is the permanent measurement gate: it prints
+// the byte cost of the installed ambient layer and asserts the global rule
+// block and the skills-eager total stay inside their ceilings.
+func TestInstalledAmbientByteCeilings(t *testing.T) {
+	global := len(agents.GlobalInstructionsBody)
+
+	skillsFM := 0
+	for _, body := range GlobalSkills {
+		skillsFM += len(frontmatterOf(body))
+	}
+	subFM := 0
+	for _, body := range SubAgents {
+		subFM += len(frontmatterOf(body))
+	}
+
+	t.Logf("installed ambient byte cost:")
+	t.Logf("  global CLAUDE.md section : %d bytes  (ceiling %d)", global, globalSectionByteCeiling)
+	t.Logf("  skills eager frontmatter : %d bytes  (ceiling %d, %d skills)", skillsFM, skillsEagerByteCeiling, len(GlobalSkills))
+	t.Logf("  sub-agent eager frontmatter: %d bytes  (%d agents)", subFM, len(SubAgents))
+	t.Logf("  projected installed eager: %d bytes", global+skillsFM+subFM)
+
+	if global > globalSectionByteCeiling {
+		t.Errorf("global CLAUDE.md section is %d bytes, over the %d ceiling", global, globalSectionByteCeiling)
+	}
+	if skillsFM > skillsEagerByteCeiling {
+		t.Errorf("skills eager frontmatter is %d bytes, over the %d ceiling", skillsFM, skillsEagerByteCeiling)
+	}
+}
+
+// TestGlobalInstall_FatToSlimReplacement is the migration gate: a user
+// upgrading from a fat pre-diet rule block gets the slim one on re-install,
+// with the user's own prose around the marker block preserved and no duplicate
+// block. Exercises the marker-fenced merge on the real install path.
+func TestGlobalInstall_FatToSlimReplacement(t *testing.T) {
+	env, _ := agentstest.NewEnv(t)
+	env.Mode = agents.ModeGlobal
+	env.InstallGlobalInstructions = true
+
+	claudeMd := filepath.Join(env.Home, ".claude", "CLAUDE.md")
+	if err := os.MkdirAll(filepath.Dir(claudeMd), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Seed a realistic pre-diet file: user prose, then a FAT marker block
+	// carrying content the diet relocates (provider matrix, capabilities
+	// catalog), then more user prose.
+	const userAbove = "# My machine notes\n\nAlways run tests with -race.\n"
+	const userBelow = "\n## My other tooling\n\nUse ripgrep for logs.\n"
+	fatBlock := agents.GlobalRulesStartMarker + "\n" +
+		"## MANDATORY: Use Gortex MCP tools instead of Read/Grep/Glob\n\n" +
+		"### LLM provider\n" +
+		"one of `local` / `anthropic` / `openai` / `azure` / `ollama` / `claudecli` / `codex` / `copilot` / `cursor` / `opencode` / `gemini` / `bedrock` / `deepseek`\n\n" +
+		"### Non-obvious capabilities worth knowing\n" +
+		"- analyze is a 61-kind dispatcher: dead_code, hotspots, cycles via Tarjan's SCC…\n" +
+		"- TOON tabular text is a compact tabular text, lossy fallback\n" +
+		agents.GlobalRulesEndMarker + "\n"
+	seed := userAbove + "\n" + fatBlock + userBelow
+	if err := os.WriteFile(claudeMd, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	got, err := os.ReadFile(claudeMd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(got)
+
+	// User prose around the block survives verbatim.
+	if !strings.Contains(text, userAbove) {
+		t.Error("user content above the block was clobbered")
+	}
+	if !strings.Contains(text, strings.TrimLeft(userBelow, "\n")) {
+		t.Error("user content below the block was clobbered")
+	}
+
+	// Exactly one marker block — the fat one was replaced in place, not
+	// appended alongside.
+	if n := strings.Count(text, agents.GlobalRulesStartMarker); n != 1 {
+		t.Errorf("expected exactly 1 rule block, found %d", n)
+	}
+
+	// The block now carries the slim policy core…
+	if !strings.Contains(text, "gortex://guide") || !strings.Contains(text, "distill_session") {
+		t.Error("re-installed block is missing the slim policy core (guide pointer / memory triggers)")
+	}
+	// …and the relocated fat content is gone.
+	for _, gone := range []string{
+		"Non-obvious capabilities worth knowing",
+		"61-kind dispatcher",
+		"compact tabular text, lossy",
+		"`local` / `anthropic` / `openai` / `azure` / `ollama` / `claudecli` / `codex` / `copilot` / `cursor` / `opencode` / `gemini` / `bedrock` / `deepseek`",
+	} {
+		if strings.Contains(text, gone) {
+			t.Errorf("re-installed block still carries relocated fat content %q", gone)
+		}
+	}
+}

--- a/internal/agents/claudecode/subagents.go
+++ b/internal/agents/claudecode/subagents.go
@@ -53,7 +53,7 @@ func SubAgentTools(def string) []string {
 // no Grep, no Glob escape.
 const subagentSearch = `---
 name: gortex-search
-description: "Use to locate code, trace call paths, or explore architecture without polluting the parent context. The sub-agent runs gortex graph queries in a fresh context and returns a summary. Examples: \"Where is X defined?\", \"Find every implementation of Y\", \"Trace the request flow from handler to database\", \"Map the auth boundary\""
+description: "Locate code, trace call paths, or map architecture in a fresh context."
 tools: mcp__gortex__smart_context, mcp__gortex__surface_memories, mcp__gortex__search_symbols, mcp__gortex__search_text, mcp__gortex__get_symbol_source, mcp__gortex__get_editing_context, mcp__gortex__get_file_summary, mcp__gortex__find_usages, mcp__gortex__get_callers, mcp__gortex__get_call_chain, mcp__gortex__get_dependencies, mcp__gortex__get_dependents, mcp__gortex__get_repo_outline, mcp__gortex__get_architecture, mcp__gortex__graph_stats, mcp__gortex__get_symbol, mcp__gortex__read_file
 ---
 
@@ -79,7 +79,7 @@ When you reply to the parent: give the answer first (symbol IDs, file:line, the 
 // would otherwise blow up the parent's context.
 const subagentImpact = `---
 name: gortex-impact
-description: "Use to assess the blast radius of a proposed change before editing — broken callers, interface implementors, contract violations, test targets. The sub-agent runs gortex verification in a fresh context and returns a short impact report. Examples: \"What breaks if I change X's signature?\", \"Is it safe to delete Y?\", \"Who depends on this contract?\""
+description: "Assess a change's blast radius — broken callers, contracts, tests."
 tools: mcp__gortex__smart_context, mcp__gortex__surface_memories, mcp__gortex__search_symbols, mcp__gortex__get_symbol_source, mcp__gortex__find_usages, mcp__gortex__get_callers, mcp__gortex__get_call_chain, mcp__gortex__get_dependents, mcp__gortex__verify_change, mcp__gortex__explain_change_impact, mcp__gortex__analyze, mcp__gortex__simulate_chain, mcp__gortex__preview_edit, mcp__gortex__check_guards, mcp__gortex__get_test_targets, mcp__gortex__contracts, mcp__gortex__read_file
 ---
 

--- a/internal/agents/instructions.go
+++ b/internal/agents/instructions.go
@@ -57,185 +57,39 @@ const (
 // per-repo CLAUDE.md.
 const GlobalInstructionsBody = `## MANDATORY: Use Gortex MCP tools instead of Read/Grep/Glob
 
-A Gortex daemon is configured machine-wide via the ` + "`gortex` MCP server" + `. Whenever you are operating on indexed source code (any repo registered with the daemon — check ` + "`gortex daemon status`" + `), you MUST prefer graph queries over file reads. PreToolUse hooks deny ` + "`Read`" + ` / ` + "`Grep`" + ` / ` + "`Glob`" + ` against indexed source — the deny message names the right tool.
+A Gortex daemon is configured machine-wide via the ` + "`" + `gortex` + "`" + ` MCP server. Whenever you operate on indexed source (any repo the daemon tracks — check ` + "`" + `gortex daemon status` + "`" + `), you MUST prefer graph queries over file reads. PreToolUse hooks deny ` + "`" + `Read` + "`" + ` / ` + "`" + `Grep` + "`" + ` / ` + "`" + `Glob` + "`" + ` against indexed source — the deny message names the right tool.
 
-### Optional: delegate research to a local agent
+| Instead of...                       | Use...                                   |
+|-------------------------------------|------------------------------------------|
+| ` + "`" + `Grep` + "`" + ` / ` + "`" + `grep` + "`" + ` / ` + "`" + `rg` + "`" + ` for a symbol | ` + "`" + `search_symbols` + "`" + ` (BM25 + camelCase-aware) |
+| ` + "`" + `Grep` + "`" + ` for references               | ` + "`" + `find_usages` + "`" + ` (zero false positives)     |
+| Reading / grepping to find callers  | ` + "`" + `get_callers` + "`" + ` / ` + "`" + `get_call_chain` + "`" + `         |
+| ` + "`" + `Glob` + "`" + ` over source files            | ` + "`" + `get_repo_outline` + "`" + ` / ` + "`" + `search_symbols` + "`" + `    |
+| ` + "`" + `Read` + "`" + ` a file for one symbol        | ` + "`" + `get_symbol_source` + "`" + ` (` + "`" + `compress_bodies:true` + "`" + ` for the signature only) |
+| ` + "`" + `Read` + "`" + ` to understand a file         | ` + "`" + `get_file_summary` + "`" + ` / ` + "`" + `get_editing_context` + "`" + ` |
+| ` + "`" + `Read` + "`" + ` a non-indexed / raw file     | ` + "`" + `read_file` + "`" + `                              |
+| Multiple reads to explore a task    | ` + "`" + `smart_context` + "`" + ` (one call)               |
+| ` + "`" + `Edit` + "`" + ` / ` + "`" + `Write` + "`" + ` source             | ` + "`" + `edit_file` + "`" + ` / ` + "`" + `write_file` + "`" + ` / ` + "`" + `edit_symbol` + "`" + ` / ` + "`" + `rename_symbol` + "`" + ` / ` + "`" + `batch_edit` + "`" + ` |
 
-When ` + "`llm.provider`" + ` is configured (one of ` + "`local`" + ` / ` + "`anthropic`" + ` / ` + "`openai`" + ` / ` + "`azure`" + ` / ` + "`ollama`" + ` / ` + "`claudecli`" + ` / ` + "`codex`" + ` / ` + "`copilot`" + ` / ` + "`cursor`" + ` / ` + "`opencode`" + ` / ` + "`gemini`" + ` / ` + "`bedrock`" + ` / ` + "`deepseek`" + ` — pick one in ` + "`.gortex.yaml`" + ` or ` + "`~/.gortex/config.yaml`" + `, or via ` + "`GORTEX_LLM_PROVIDER`" + ` / ` + "`GORTEX_LLM_MODEL`" + `), the ` + "`ask`" + ` MCP tool is registered. It runs a grammar-constrained agent that uses gortex tools to research one question and returns a synthesized answer — useful when you'd otherwise issue many ` + "`search_symbols`" + ` / ` + "`get_callers`" + ` / ` + "`contracts`" + ` calls. Only the ` + "`local`" + ` provider requires a ` + "`-tags llama`" + ` build; the others are pure-Go HTTP / subprocess adapters available in every binary.
+Graph queries *narrow scope*; they do not replace reading the implementation. For the symbol you are about to change or depend on — especially behavior-critical code (migrations, retry / fallback / error-recovery paths, concurrency, compatibility shims) — read the real body with ` + "`" + `get_symbol_source` + "`" + ` and do NOT pass ` + "`" + `compress_bodies:true` + "`" + `, which elides the branches that carry the risk. ` + "`" + `format:"gcx"` + "`" + ` (compact wire, ~27% fewer tokens) and ` + "`" + `compress_bodies:true` + "`" + ` (body-eliding) exist on the read / list tools; the parameter legend is in the MCP server instructions.
 
-| When you'd otherwise...               | Consider...                              |
-|---------------------------------------|------------------------------------------|
-| Run many calls to answer one open-ended question | ` + "`ask`" + ` (one call, ~5-30s, ~200-400 token answer) |
-| Trace a request across repos (consumer → contract → handler → downstream) | ` + "`ask`" + ` with ` + "`chain: true`" + ` |
-| Look up a single known fact | Skip ` + "`ask`" + ` — direct tools are faster |
+## MANDATORY: Session + development memory
 
-If ` + "`ask`" + ` isn't in ` + "`tools/list`" + `, no provider could construct (missing model / API key, ` + "`local`" + ` without ` + "`-tags llama`" + `, ` + "`claudecli`" + ` without ` + "`claude`" + ` on ` + "`$PATH`" + `, ` + "`bedrock`" + ` without AWS credentials). Fall through to direct tools.
+The graph remembers code; these tools remember **why you made a call**. They are behavior-critical — run each at its trigger, not "optionally":
 
-### Search and Navigation
+- **Session start / after a compaction** — call ` + "`" + `distill_session` + "`" + ` first: prior top symbols, pinned notes, decisions, recent excerpts. Seed your mental model before reading any file.
+- **Immediately after ` + "`" + `smart_context` + "`" + `** — call ` + "`" + `surface_memories task:"<task>" symbol_ids:"<top hits>"` + "`" + `: cross-session invariants / gotchas / decisions anchored to your working set. If it returns nothing, don't probe further.
+- **At every decision** — pick an approach, reject an alternative, hit a non-obvious constraint, or commit to an invariant → ` + "`" + `save_note tags:"decision" body:"<what+why>"` + "`" + `. Mention symbol IDs (` + "`" + `pkg/foo.go::Bar` + "`" + `) in the body for auto-linking; ` + "`" + `pinned:true` + "`" + ` for load-bearing notes.
+- **When you learn a durable fact worth teaching the team** — ` + "`" + `store_memory kind:"<invariant|gotcha|convention|decision|constraint|incident>" body:"<what+why>" symbol_ids:"<id>" importance:5` + "`" + `. ` + "`" + `save_note` + "`" + ` is the per-session scratchpad; ` + "`" + `store_memory` + "`" + ` is the workspace-wide store every future agent inherits. Supersede a stale memory with ` + "`" + `supersedes:"<old-id>"` + "`" + `.
+- **Before editing a symbol you've touched before** — ` + "`" + `query_notes symbol_id:"<id>"` + "`" + ` / ` + "`" + `query_memories symbol_id:"<id>"` + "`" + ` surface prior decisions and "do not change this without …" warnings.
 
-| Instead of...                         | You MUST use...                          |
-|---------------------------------------|------------------------------------------|
-| ` + "`Grep`" + ` / ` + "`grep`" + ` / ` + "`rg`" + ` for a symbol      | ` + "`search_symbols`" + ` (BM25 + camelCase-aware)|
-| ` + "`Grep`" + ` for references                 | ` + "`find_usages`" + ` (zero false positives)     |
-| ` + "`Grep`" + ` to find callers                | ` + "`get_callers`" + ` / ` + "`get_call_chain`" + `         |
-| ` + "`Glob`" + ` over source files (` + "`**/*.go`" + `)  | ` + "`get_repo_outline`" + ` / ` + "`search_symbols`" + `    |
-| Multiple ` + "`Read`" + ` calls to explore      | ` + "`smart_context`" + ` (one call)               |
+**Save / store:** decisions, non-obvious constraints, invariants, follow-ups, incident learnings, bug reproductions. **Skip:** play-by-play the diff already shows, anything derivable from the graph, content already in CLAUDE.md.
 
-### Reading Source
+## Reference and discovery
 
-| Instead of...                         | You MUST use...                          |
-|---------------------------------------|------------------------------------------|
-| ` + "`Read`" + ` whole file for one function    | ` + "`get_symbol_source`" + ` (80% fewer tokens; add ` + "`compress_bodies: true`" + ` when you only need the surface signature) |
-| ` + "`Read`" + ` to understand a file           | ` + "`get_file_summary`" + ` / ` + "`get_editing_context`" + ` (the latter emits ` + "`source_compressed`" + ` when ` + "`compress_bodies: true`" + `) |
-| ` + "`Read`" + ` to check a signature           | ` + "`get_symbol`" + ` (signature in ` + "`meta.signature`" + `) |
-| ` + "`Read`" + ` to trace calls                 | ` + "`get_call_chain`" + ` / ` + "`get_callers`" + `         |
-| ` + "`Read`" + ` on a non-indexed / raw file    | ` + "`read_file`" + ` (atomic, honours editor-buffer overlays; ` + "`compress_bodies: true`" + ` elides function bodies for ~30-40% of original tokens) |
-
-### Editing and Refactoring
-
-| Instead of...                         | You MUST use...                          |
-|---------------------------------------|------------------------------------------|
-| ` + "`Edit`" + ` whole file by string match    | ` + "`edit_file`" + ` (Gortex MCP — no pre-Read required, atomic write, auto-reindex; pass ` + "`dry_run`" + ` to preview) |
-| ` + "`Write`" + ` a new file or full rewrite   | ` + "`write_file`" + ` (no pre-Read required; creates parent dirs; pass ` + "`dry_run`" + ` to preview) |
-| Read→Edit roundtrip for one symbol    | ` + "`edit_symbol`" + ` (edit by ID)               |
-| Manual find-and-replace for renames   | ` + "`rename_symbol`" + ` (cross-file refs)        |
-| Sequencing multi-file edits yourself  | ` + "`batch_edit`" + ` (dependency-ordered)        |
-
-### Dataflow (CPG-lite)
-
-The ` + "`flow_between`" + ` and ` + "`taint_paths`" + ` MCP tools answer **"where does this value flow?"** by walking the new dataflow edges (` + "`value_flow`" + ` intra-procedural; ` + "`arg_of`" + ` caller-arg→callee-param; ` + "`returns_to`" + ` callee→assignment).
-
-| Instead of...                         | You MUST use...                          |
-|---------------------------------------|------------------------------------------|
-| Tracing a value through helpers by hand | ` + "`flow_between(source_id, sink_id, max_depth=8)`" + ` — ranked dataflow paths between two symbols |
-| Grepping for sources / sinks         | ` + "`taint_paths(source_pattern, sink_pattern)`" + ` — pattern-driven sweep. Patterns: bare token = name substring; ` + "`exact:Foo`" + `; ` + "`path:dir/`" + `; ` + "`kind:method`" + `. Sinks auto-expand functions to their params. |
-| Asking "can A reach B?" over the call graph | ` + "`trace_path(source_id, sink_id)`" + ` — shortest A→B call path (bidirectional BFS); on no-path returns a why-unreachable diagnosis naming the dynamic-dispatch / external boundary where the chain breaks. CLI: ` + "`gortex trace <from> <to>`" + `. |
-
-### Structural Code Search
-
-` + "`search_ast`" + ` answers "find every code site whose AST matches this shape" — the missing primitive between ` + "`search_symbols`" + ` (name-based) and ` + "`find_usages`" + ` (target-required). Cross-language; every match enriched with the enclosing function's ` + "`symbol_id`" + `.
-
-| Instead of...                            | You MUST use...                          |
-|------------------------------------------|------------------------------------------|
-| Grep for an anti-pattern across the repo | ` + "`search_ast`" + ` with a bundled ` + "`detector`" + ` (` + "`error-not-wrapped`" + `, ` + "`sql-string-concat`" + `, ` + "`weak-crypto`" + `, ` + "`panic-in-library`" + `, ` + "`goroutine-without-recover`" + `, ` + "`http-client-no-timeout`" + `, ` + "`hardcoded-secret`" + `, ` + "`empty-catch`" + `, ` + "`java-string-equality`" + `, ` + "`python-mutable-default-arg`" + `). |
-| Grep for a code shape (e.g. ` + "`.Get(_, nil)`" + `) | ` + "`search_ast`" + ` with ` + "`pattern: \"...\"`" + ` (raw tree-sitter S-expression) + ` + "`language`" + `. Capture nodes with ` + "`@name`" + `, anchor with ` + "`@match`" + `, predicates ` + "`(#eq? @x \"…\")`" + ` / ` + "`(#match? @x \"…\")`" + `. |
-| Scoping the audit to load-bearing code   | Pass ` + "`min_fan_in_of_enclosing_func: <N>`" + ` — drops matches in functions with fewer than N callers. |
-
-### Clone Detection
-
-` + "`find_clones`" + ` surfaces near-duplicate function/method clusters from the ` + "`similar_to`" + ` graph layer — a MinHash + LSH pass over normalised tokens that catches copy-paste and renamed-variable (Type-1/Type-2) clones.
-
-| Instead of...                            | You MUST use...                          |
-|------------------------------------------|------------------------------------------|
-| Eyeballing the repo for copy-paste       | ` + "`find_clones`" + ` — near-duplicate clusters; filter with ` + "`min_similarity`" + ` / ` + "`path_prefix`" + ` / ` + "`repo`" + `. |
-| Hunting safe-to-delete duplicates        | ` + "`find_clones`" + ` with ` + "`dead_only: true`" + ` — clusters containing a dead symbol: "dead duplicates of live code". |
-
-### Code Quality and Analysis
-
-The ` + "`analyze`" + ` MCP tool is a unified dispatcher. Pass ` + "`kind: \"<name>\"`" + ` for one of:
-
-- Structural: ` + "`dead_code`" + `, ` + "`hotspots`" + `, ` + "`cycles`" + `, ` + "`would_create_cycle`" + `
-- Comments / churn: ` + "`todos`" + `, ` + "`stale_code`" + `, ` + "`ownership`" + `
-- Coverage / releases: ` + "`coverage`" + `, ` + "`coverage_gaps`" + `, ` + "`coverage_summary`" + `, ` + "`releases`" + `, ` + "`blame`" + `
-- Schema: ` + "`orphan_tables`" + `, ` + "`unreferenced_tables`" + `
-- Flags / interop: ` + "`stale_flags`" + `, ` + "`cgo_users`" + `, ` + "`wasm_users`" + `
-- Edge-driven: ` + "`channel_ops`" + `, ` + "`goroutine_spawns`" + `, ` + "`field_writers`" + `, ` + "`annotation_users`" + `, ` + "`config_readers`" + `, ` + "`event_emitters`" + `, ` + "`error_surface`" + `, ` + "`external_calls`" + `
-- Framework layer: ` + "`routes`" + ` (handler ↔ HTTP/gRPC/WS/GraphQL/topic), ` + "`models`" + ` (ORM class ↔ DB table), ` + "`components`" + ` (parent → child JSX)
-- Infrastructure: ` + "`k8s_resources`" + ` (KindResource fan-out by kind/namespace), ` + "`images`" + ` (KindImage with consumer count), ` + "`kustomize`" + ` (KindKustomization overlay tree)
-- Data transformation: ` + "`dbt_models`" + ` (dbt / SQLMesh models, seeds, snapshots, sources with column counts + lineage fan-in/out)
-- Multi-repo: ` + "`cross_repo`" + ` (repo-boundary-crossing calls / implements / extends grouped by source → target repo)
-
-The ` + "`gortex enrich blame|coverage|releases|all`" + ` CLI hydrates the graph with the metadata that the ` + "`stale_*`" + `, ` + "`coverage*`" + `, ` + "`ownership`" + `, and ` + "`releases`" + ` analyzers need.
-
-### PR / Change Review
-
-Review a diff through the graph instead of hand-walking each gate. ` + "`analyze`" + ` with ` + "`kind: \"review\"`" + ` runs the idiomatic / correctness rulepack (NPE, thread-safety check-then-act, N+1, logic-error; Go + Python) with a graph-grounded false-positive-reduction pass. The ` + "`review`" + ` / ` + "`review_pack`" + ` MCP tools (or ` + "`gortex review [--diff|--base <ref>] [--audience agent|human]`" + `) return one fused packet — verdict + ` + "`file:line`" + ` findings + cost. For a queue of open PRs, ` + "`list_prs`" + ` / ` + "`triage_prs`" + ` / ` + "`pr_risk`" + ` / ` + "`get_pr_impact`" + ` / ` + "`suggest_reviewers`" + ` (or ` + "`gortex prs --triage`" + `) rank by graph-derived blast radius and route reviewers.
-
-### Token Economy
-
-For list-shaped responses (` + "`search_symbols`" + `, ` + "`find_usages`" + `, ` + "`analyze`" + `, ` + "`batch_symbols`" + `, ` + "`get_callers`" + `, ` + "`get_call_chain`" + `, ` + "`get_dependencies`" + `, ` + "`get_dependents`" + `, ` + "`find_implementations`" + `, ` + "`get_file_summary`" + `, ` + "`get_editing_context`" + `, ` + "`smart_context`" + `, ` + "`contracts`" + `), pick a wire format. Order of preference: **gcx > toon > json**.
-
-- ` + "`format: \"gcx\"`" + ` — GCX1 compact wire format. Round-trippable, ~27% fewer tokens. Decode with ` + "`@gortex/wire`" + ` (npm) or ` + "`github.com/gortexhq/gcx-go`" + ` (Go). **Default for known clients (claude-code, cursor, vscode, zed, aider, kilocode, opencode, openclaw, codex, omp-coding-agent)** when the request omits ` + "`format`" + `.
-- ` + "`format: \"toon\"`" + ` — TOON tabular text. Lossy but compact; useful for clients without a GCX decoder.
-- ` + "`format: \"json\"`" + ` — verbose legacy default. Falls back automatically for unknown clients.
-
-Explicit ` + "`format`" + ` arg always overrides the session default in either direction.
-
-### Token Economy (content compression)
-
-` + "`compress_bodies: true`" + ` is an orthogonal axis: GCX1 shrinks the response *shape*; ` + "`compress_bodies`" + ` shrinks the response *content*. **Compose them** for stacked savings.
-
-The flag replaces every function/method body in the returned source with a ` + "`{ /* N lines elided */ }`" + ` stub (Python: ` + "`...  # N lines elided`" + `, Ruby: ` + "`# N lines elided`" + `, Elixir: ` + "`do\\n  # N lines elided\\nend`" + `). Signatures, doc-comments, imports, top-level constants/types, and structure stay intact. A 200-line file lands at ≤ 60 lines (~30-40% of original tokens). Wired in 16 languages: go, typescript, tsx, javascript, python, rust, java, c, cpp, csharp, kotlin, scala, php, ruby, bash, elixir.
-
-| Instead of...                                          | You MUST use...                          |
-|--------------------------------------------------------|------------------------------------------|
-| Reading a whole 2k-line file to learn the surface      | ` + "`read_file`" + ` with ` + "`compress_bodies: true`" + ` |
-| Pulling a class's full source to see its method shapes | ` + "`get_symbol_source`" + ` with ` + "`compress_bodies: true`" + ` |
-| Calling ` + "`get_editing_context`" + ` then fetching every neighbour's source for signatures | ` + "`get_editing_context`" + ` with ` + "`compress_bodies: true`" + ` — emits ` + "`source_compressed`" + ` alongside the structural sections |
-
-When the language has no grammar binding or tree-sitter can't parse the input, the flag is a no-op — raw source comes back and the response's ` + "`bodies_elided`" + ` flag stays absent. Safe to set unconditionally.
-
-### Reuse and freshness (don't re-fetch)
-
-Gortex exists to *save* tokens — treat what you fetch as cached for the task.
-
-- **Don't re-fetch what you already have.** Re-reading the same file or re-running the same query within a task is the most common avoidable cost — keep the earlier result and consult it again instead of re-calling.
-- **Re-validate cheaply with etags.** ` + "`read_file`" + ` / ` + "`get_symbol_source`" + ` / ` + "`get_file_summary`" + ` / ` + "`get_editing_context`" + ` / ` + "`smart_context`" + ` return an ` + "`etag`" + ` and accept ` + "`if_none_match`" + ` — an unchanged target comes back as ` + "`not_modified`" + ` at ~0 tokens. Use it to confirm freshness after an edit instead of re-reading the whole thing.
-- **A warming index is not an empty repo.** A ` + "`count: 0`" + ` / empty result while the daemon is still warming up (a ` + "`warming`" + ` block on the response, or ` + "`index_health`" + ` not yet ready) means *not indexed yet*, not *absent* — re-run shortly or check ` + "`index_health`" + `; don't conclude the symbol is missing and fall back to grep.
-
-### Pagination, sparse fieldsets, and graceful degradation
-
-Every list-shaped tool runs through a per-response budget by default — the agent harness's spill-to-disk fallback is a true edge case, not the routine outcome on real-world payloads. When a response would exceed the budget, the server runs a priority-aware cascade:
-
-1. **Strip verbose meta** (` + "`doc`" + `, raw ` + "`meta`" + ` blobs) — cheapest cut, never drops rows.
-2. **Drop tier-3 rows** — params, closures, generic params, ` + "`param_of`" + ` / ` + "`typed_as`" + ` / ` + "`value_flow`" + ` edges, low-confidence (` + "`text_matched`" + `) edges. High-noise rows agents almost never need on the first response.
-3. **Drop tier-2 rows** — fields, constants, variables, references, instantiates, etc.
-4. **Last-resort tail-trim** of the longest remaining tier-1 list.
-
-Each escape adds metadata: ` + "`_meta_stripped`" + `, ` + "`_dropped_tier_<N>_<list>`" + `, ` + "`_truncated_by_budget`" + `, ` + "`_max_returned_<list>`" + `, ` + "`_original_count_<list>`" + `. Use them to decide whether to narrow the filter, raise ` + "`max_bytes`" + `, or paginate.
-
-Knobs you can pull when you need something different:
-
-- **Pagination** — ` + "`search_symbols`" + `, ` + "`winnow_symbols`" + `, ` + "`prefetch_context`" + `, and ` + "`contracts`" + ` (action=list) accept ` + "`cursor`" + ` (opaque token from a previous ` + "`next_cursor`" + `). Don't parse the cursor; round-trip what the server gave you.
-- **Explicit budget** — pass ` + "`max_bytes: <N>`" + ` to override the project default. Pass ` + "`max_bytes: 0`" + ` to opt OUT of budgeting entirely — full result inline, transport spills if oversized. Use the opt-out only when you genuinely need every row (security audits, exhaustive enumeration).
-- **Sparse fieldsets** — pass ` + "`fields: \"id,line\"`" + ` (comma-separated) to drop columns at the row level. Pure size win, no priority drops.
-- **Limit defaults** — most tools default to 20–50 rows; raise ` + "`limit`" + ` only when a single page is too small. Pagination is preferred over a giant ` + "`limit`" + `.
-
-### MCP Resources
-
-Bootstrap-state tools (` + "`graph_stats`" + ` / ` + "`index_health`" + ` / ` + "`workspace_info`" + ` / ` + "`list_repos`" + ` / ` + "`get_active_project`" + `) are also exposed as MCP resources at ` + "`gortex://stats`" + ` / ` + "`gortex://index-health`" + ` / ` + "`gortex://workspace`" + ` / ` + "`gortex://repos`" + ` / ` + "`gortex://active-project`" + `. Subscribe via ` + "`resources/subscribe`" + ` to receive ` + "`notifications/resources/updated`" + ` after each graph re-warm — no polling. Tools stay registered for clients that don't speak resources.
-
-Analyzer rollups (read-only summaries of the current indexed state): ` + "`gortex://report`" + ` (orientation), ` + "`gortex://god-nodes`" + ` (top hotspots), ` + "`gortex://surprises`" + ` (cycles + dead code + hubs), ` + "`gortex://audit`" + ` (CLAUDE.md drift), ` + "`gortex://questions`" + ` (TODOs).
-
-### Session Memory (save_note / query_notes / distill_session)
-
-Gortex remembers code; this triplet remembers **why you made a call**. Notes persist per-repo across daemon restarts and context compactions, scoped to the session's workspace, auto-linked to symbols mentioned in the body.
-
-| Trigger                                                  | You MUST call                                                                 |
-|----------------------------------------------------------|-------------------------------------------------------------------------------|
-| Session start in a touched repo (after a compaction or on a fresh run) | ` + "`distill_session`" + ` — top symbols, pinned notes, decisions, recent excerpts. Seed your mental model before reading any file. |
-| Making a decision, rejecting an alternative, hitting a non-obvious constraint, committing to an invariant | ` + "`save_note tags:\"decision\" body:\"<what+why>\"`" + ` — mention symbol IDs in the body for auto-linking; pin (` + "`pinned:true`" + `) anything load-bearing. |
-| Before editing a symbol you've touched before            | ` + "`query_notes symbol_id:\"<id>\"`" + ` — prior decisions and warnings ride on each symbol. |
-
-**Save:** decisions, non-obvious constraints, follow-ups, bug reproductions, surprising graph findings, partial-progress hand-offs. **Skip:** play-by-play (the diff says it), patterns derivable from the graph, anything already in CLAUDE.md. Canonical tags: ` + "`decision`" + `, ` + "`bug`" + `, ` + "`follow-up`" + `, ` + "`gotcha`" + `, ` + "`invariant`" + ` — ` + "`decision`" + ` gets its own section in ` + "`distill_session`" + `.
-
-### Development Memories (store_memory / query_memories / surface_memories)
-
-` + "`save_note`" + ` is a **per-session scratchpad**; ` + "`store_memory`" + ` is the **workspace-wide durable knowledge base**. Memories outlive sessions, agents, and teammates — every future agent in the workspace inherits them.
-
-| Trigger                                                  | You MUST call                                                                 |
-|----------------------------------------------------------|-------------------------------------------------------------------------------|
-| Immediately after ` + "`smart_context`" + ` (every new task)            | ` + "`surface_memories task:\"<task>\" symbol_ids:\"<top hits>\"`" + ` — ranked memories anchored to your working set. Each hit carries ` + "`match_reasons`" + ` so you know *why* it surfaced. |
-| You discover a durable invariant / gotcha / decision worth teaching the team | ` + "`store_memory kind:\"<invariant|gotcha|convention|decision|constraint|incident>\" body:\"<what+why>\" symbol_ids:\"<id>\" importance:5`" + ` — pin load-bearing memories. |
-| You discover a memory is no longer true                  | ` + "`store_memory body:\"<corrected>\" supersedes:\"<old-id>\"`" + ` — preserves audit trail; the old memory is hidden from ` + "`surface_memories`" + ` by default. |
-
-**Store:** invariants (violating them breaks the system), conventions (this package never X), incident learnings, API contracts not enforced by types, debugging traps, cross-cutting decisions. **Skip:** anything derivable from code, session-local play-by-play (use ` + "`save_note`" + ` instead), CLAUDE.md content. Canonical kinds: ` + "`invariant`" + `, ` + "`constraint`" + `, ` + "`convention`" + `, ` + "`gotcha`" + `, ` + "`decision`" + `, ` + "`incident`" + `, ` + "`reference`" + `.
-
-### Session Start
-
-The SessionStart hook injects daemon status (tracked repos, cwd coverage, ready/warmup state). If you see "daemon is not running" — run ` + "`gortex daemon start --detach`" + ` and re-run the task. If you see "cwd is not covered by any tracked repo" — graph tools won't be available for that directory.
-
-Once the daemon is up, **call** ` + "`distill_session`" + ` next — surfaces decisions / pinned notes / recent excerpts saved in prior sessions in this workspace so a context compaction or a fresh process doesn't erase what was already learned.
+- **` + "`" + `gortex://guide` + "`" + ` resource** (or the ` + "`" + `gortex guide [topic]` + "`" + ` CLI) is the full reference: LLM-provider matrix, capabilities catalog, analyze / search_ast catalogs, token-economy detail, MCP resources, session-start checklist. Read it on demand — it is not pre-paid here.
+- **` + "`" + `tools_search` + "`" + `** — the server publishes a lean tool preset eagerly and defers the rest; call ` + "`" + `tools_search` + "`" + ` to discover and load any tool by keyword (every tool stays callable by name).
+- The SessionStart hook injects daemon status. "daemon is not running" → run ` + "`" + `gortex daemon start --detach` + "`" + `; "cwd is not covered by any tracked repo" → graph tools are unavailable there.
 `
 
 // InstructionsBody is the shared rule block every adapter writes to
@@ -245,350 +99,24 @@ Once the daemon is up, **call** ` + "`distill_session`" + ` next — surfaces de
 // we keep one body rather than branch by agent.
 const InstructionsBody = `## MANDATORY: Use Gortex MCP tools instead of Read/Grep
 
-Gortex is running as an MCP server. You MUST use graph queries instead of file reads whenever possible. This saves thousands of tokens per task.
-
-### Optional: delegate research to a local agent
-
-When ` + "`llm.provider`" + ` is configured (one of ` + "`local`" + ` / ` + "`anthropic`" + ` / ` + "`openai`" + ` / ` + "`azure`" + ` / ` + "`ollama`" + ` / ` + "`claudecli`" + ` / ` + "`codex`" + ` / ` + "`copilot`" + ` / ` + "`cursor`" + ` / ` + "`opencode`" + ` / ` + "`gemini`" + ` / ` + "`bedrock`" + ` / ` + "`deepseek`" + ` — pick one in ` + "`.gortex.yaml`" + ` or ` + "`~/.gortex/config.yaml`" + `, or via ` + "`GORTEX_LLM_PROVIDER`" + ` / ` + "`GORTEX_LLM_MODEL`" + `), the ` + "`ask`" + ` MCP tool is registered. It runs a grammar-constrained agent that uses gortex tools to research one question and returns a synthesized answer — useful when you'd otherwise issue many ` + "`search_symbols`" + ` / ` + "`get_callers`" + ` / ` + "`contracts`" + ` calls. Only the ` + "`local`" + ` provider requires a ` + "`-tags llama`" + ` build; the others are pure-Go HTTP / subprocess adapters available in every binary.
-
-| When you'd otherwise...               | Consider...                              |
-|---------------------------------------|------------------------------------------|
-| Run many calls to answer one open-ended question | ` + "`ask`" + ` (one call, ~5-30s, ~200-400 token answer) |
-| Trace a request across repos (consumer → contract → handler → downstream) | ` + "`ask`" + ` with ` + "`chain: true`" + ` |
-| Look up a single known fact | Skip ` + "`ask`" + ` — direct tools are faster |
-
-If ` + "`ask`" + ` isn't in ` + "`tools/list`" + `, no provider could construct (missing model / API key, ` + "`local`" + ` without ` + "`-tags llama`" + `, ` + "`claudecli`" + ` without ` + "`claude`" + ` on ` + "`$PATH`" + `, ` + "`bedrock`" + ` without AWS credentials). Fall through to direct tools.
-
-### Navigation and Reading
-
-| Instead of...                         | You MUST use...                          |
-|---------------------------------------|------------------------------------------|
-| ` + "`Read`" + ` a whole file for one function  | ` + "`get_symbol_source`" + ` with ` + "`id: \"path/to/file.go::SymbolName\"`" + ` (80% fewer tokens; add ` + "`compress_bodies: true`" + ` to drop the implementation body and keep only the signature) — use ` + "`get_file_summary`" + ` first if you don't know the symbol name |
-| ` + "`Read`" + ` to find a function             | ` + "`get_symbol`" + ` or ` + "`get_editing_context`" + `    |
-| Multiple ` + "`get_symbol`" + ` calls           | ` + "`batch_symbols`" + ` (one call for N symbols) |
-| ` + "`Grep`" + ` for references                 | ` + "`find_usages`" + ` (zero false positives)     |
-| ` + "`Grep`" + ` to find a symbol by name       | ` + "`search_symbols`" + ` (BM25 + camelCase-aware)|
-| Filtering ` + "`search_symbols`" + ` by hand    | ` + "`winnow_symbols`" + ` — structured constraint chain (kind, language, community, path_prefix, min_fan_in, min_churn) with per-axis score contributions |
-| ` + "`Read`" + ` to understand a file           | ` + "`get_file_summary`" + ` or ` + "`get_editing_context`" + ` (pass ` + "`compress_bodies: true`" + ` to ` + "`get_editing_context`" + ` to also receive a ` + "`source_compressed`" + ` view of the file) |
-| ` + "`Read`" + ` on a non-indexed / raw file    | ` + "`read_file`" + ` (honours editor-buffer overlays, etag-aware; ` + "`compress_bodies: true`" + ` elides function bodies for ~30-40% of original tokens) |
-| ` + "`Read`" + ` multiple files to trace calls  | ` + "`get_call_chain`" + ` / ` + "`get_callers`" + `         |
-| Walking up/down an inheritance chain  | ` + "`get_class_hierarchy`" + ` — multi-hop EdgeExtends + EdgeImplements + EdgeComposes (type nodes) and EdgeOverrides (method nodes); ` + "`direction`" + ` ∈ up/down/both, ` + "`include_methods`" + ` pulls members + their override chain |
-| Guessing an import path               | ` + "`find_import_path`" + `                       |
-| ` + "`Read`" + ` to check a function signature  | ` + "`get_symbol`" + ` (signature is in ` + "`meta.signature`" + `) |
-| 5-10 calls to explore for a task      | ` + "`smart_context`" + ` (one call)               |
-
-### Token Economy (wire format)
-
-Order of preference: **gcx > toon > json**. For known clients (claude-code, cursor, vscode, zed, aider, kilocode, opencode, openclaw, codex, omp-coding-agent) Gortex serves ` + "`gcx`" + ` automatically when a request omits the ` + "`format`" + ` arg — explicit ` + "`format`" + ` always wins.
-
-| Instead of...                         | You MUST use...                          |
-|---------------------------------------|------------------------------------------|
-| Default JSON on multi-row responses   | Rely on the per-session default (gcx) for known clients, or pass ` + "`format: \"gcx\"`" + ` explicitly on ` + "`search_symbols`" + `, ` + "`find_usages`" + `, ` + "`analyze`" + `, ` + "`contracts`" + `, ` + "`batch_symbols`" + `, ` + "`get_callers`" + ` / ` + "`get_call_chain`" + ` / ` + "`get_dependencies`" + ` / ` + "`get_dependents`" + ` / ` + "`find_implementations`" + ` / ` + "`find_overrides`" + ` / ` + "`get_class_hierarchy`" + `, ` + "`get_file_summary`" + `, ` + "`get_editing_context`" + `, ` + "`smart_context`" + ` |
-| GCX-blind tooling needing tabular text| Pass ` + "`format: \"toon\"`" + ` — TOON is the second-tier fallback (lossy but ~10–15% smaller than JSON) |
-| Parsing compact text output           | Use ` + "`@gortex/wire`" + ` (npm) or the Go ` + "`github.com/gortexhq/gcx-go`" + ` package (MIT) — both decode GCX back to structured rows |
-| Reading ` + "`compact: true`" + ` output        | Prefer ` + "`format: \"gcx\"`" + ` — lossy text is being phased out; GCX is round-trippable and tokenizer-optimised |
-
-### Token Economy (content compression)
-
-` + "`compress_bodies: true`" + ` is orthogonal to GCX1 — GCX1 compresses the response *shape*, ` + "`compress_bodies`" + ` compresses the response *content*. **Compose them** for stacked savings.
-
-When set on ` + "`get_symbol_source`" + ` / ` + "`get_editing_context`" + ` / ` + "`read_file`" + `, every function/method body in the returned source is replaced by a ` + "`{ /* N lines elided */ }`" + ` stub (Python: ` + "`...  # N lines elided`" + `; Ruby: ` + "`# N lines elided`" + `; Elixir: ` + "`do\\n  # N lines elided\\nend`" + `). Signatures, doc-comments, imports, top-level constants/types, and structure stay intact. A 200-line file lands at ≤ 60 lines (~30-40% of original tokens). Wired in 16 languages: go, typescript, tsx, javascript, python, rust, java, c, cpp, csharp, kotlin, scala, php, ruby, bash, elixir.
-
-| Instead of...                                          | You MUST use...                          |
-|--------------------------------------------------------|------------------------------------------|
-| Reading a whole 2k-line file just to learn its surface | ` + "`read_file`" + ` with ` + "`compress_bodies: true`" + ` |
-| Pulling a class's full source for method signatures    | ` + "`get_symbol_source`" + ` with ` + "`compress_bodies: true`" + ` |
-| Calling ` + "`get_editing_context`" + ` then fetching every neighbour's source for signatures | ` + "`get_editing_context`" + ` with ` + "`compress_bodies: true`" + ` — emits ` + "`source_compressed`" + ` alongside the structural sections |
-
-When the language has no grammar binding or tree-sitter can't parse the input, the flag is a no-op — raw source comes back and the response's ` + "`bodies_elided`" + ` flag stays absent. Safe to set unconditionally.
-
-### Reuse and freshness (don't re-fetch)
-
-Gortex exists to *save* tokens — treat what you fetch as cached for the task.
-
-- **Don't re-fetch what you already have.** Re-reading the same file or re-running the same query within a task is the most common avoidable cost — keep the earlier result and consult it again instead of re-calling.
-- **Re-validate cheaply with etags.** ` + "`read_file`" + ` / ` + "`get_symbol_source`" + ` / ` + "`get_file_summary`" + ` / ` + "`get_editing_context`" + ` / ` + "`smart_context`" + ` return an ` + "`etag`" + ` and accept ` + "`if_none_match`" + ` — an unchanged target comes back as ` + "`not_modified`" + ` at ~0 tokens. Use it to confirm freshness after an edit instead of re-reading the whole thing.
-- **A warming index is not an empty repo.** A ` + "`count: 0`" + ` / empty result while the daemon is still warming up (a ` + "`warming`" + ` block on the response, or ` + "`index_health`" + ` not yet ready) means *not indexed yet*, not *absent* — re-run shortly or check ` + "`index_health`" + `; don't conclude the symbol is missing and fall back to grep.
-
-### Pagination, sparse fieldsets, and opt-in budget
-
-Tools default to "return what you have" — full result inline, MCP transport spills to a side file if your harness cap fires. Three opt-in knobs let you trade rows for staying inline:
-
-| Instead of...                         | You MUST use...                          |
-|---------------------------------------|------------------------------------------|
-| Walking thousands of results in one call | Pass ` + "`cursor`" + ` (opaque token from a previous ` + "`next_cursor`" + `) on ` + "`search_symbols`" + ` / ` + "`winnow_symbols`" + ` / ` + "`prefetch_context`" + ` / ` + "`contracts`" + `; set ` + "`paginate: true`" + ` to also cap each page at the project default budget |
-| Returning every column on every row   | Pass ` + "`fields: \"id,line\"`" + ` (comma-separated) to drop verbose ` + "`meta`" + ` / ` + "`doc`" + ` / signature columns. Pure size win, no truncation |
-| Asking for a giant ` + "`limit`" + `              | Use the default page size and paginate; or pass ` + "`max_bytes: <N>`" + ` to cap the response (longest list is trimmed; truncation metadata rides on the response) |
-
-### Impact Analysis and Safety
-
-| Instead of...                         | You MUST use...                          |
-|---------------------------------------|------------------------------------------|
-| Reading files to assess change scope  | ` + "`explain_change_impact`" + ` (includes cross-community warnings) |
-| Guessing which tests to run           | ` + "`get_test_targets`" + `                       |
-| Manual dependency ordering            | ` + "`get_edit_plan`" + `                          |
-| Hoping signature changes are safe     | ` + "`verify_change`" + ` — checks callers and interface implementors |
-| Manually checking team conventions    | ` + "`check_guards`" + ` — evaluates guard rules from .gortex.yaml |
-| Wondering if a new dep creates a cycle| ` + "`analyze`" + ` with ` + "`kind: \"would_create_cycle\"`" + ` — checks before you add it |
-
-### Diagnostics and Code Actions
-
-Wired to every running language server (gopls / tsserver / pyright / rust-analyzer / clangd / jdtls / kotlin-language-server / omnisharp / ruby-lsp / phpactor / lua-language-server / sourcekit-lsp / haskell-language-server / elixir-ls / ocamllsp / zls / terraform-ls / yaml-language-server / json-language-server / bash-language-server). One unified surface across all of them:
-
-| Instead of...                            | You MUST use...                          |
-|------------------------------------------|------------------------------------------|
-| Polling for diagnostics after every edit | ` + "`subscribe_diagnostics`" + ` — opt the session into push ` + "`notifications/diagnostics`" + `. Initial state replays immediately as ` + "`initial_replay: true`" + `; thereafter only delta-changed files are pushed (hash-suppressed). Filter with ` + "`min_severity`" + ` (1=error, 2=warning, 3=info, 4=hint) or ` + "`path_prefix`" + ` (absolute prefix). |
-| Manual diagnostics fetch                 | ` + "`get_diagnostics`" + ` — latest stored ` + "`publishDiagnostics`" + ` for a file. Pass ` + "`wait: true`" + ` + ` + "`timeout_ms`" + ` to block on the first publish (e.g. right after a fresh ` + "`didOpen`" + `). |
-| Forgetting to opt back out               | ` + "`unsubscribe_diagnostics`" + ` — idempotent, also fires automatically on session disconnect. |
-| Hand-applying compiler suggestions       | ` + "`get_code_actions`" + ` for a file (and optional range), then ` + "`apply_code_action`" + ` on the chosen one. Atomic temp+rename, both legacy ` + "`changes`" + ` and modern ` + "`documentChanges`" + `, UTF-16 column math. |
-| Walking the whole file to apply every fix | ` + "`fix_all_in_file`" + ` — runs ` + "`source.fixAll`" + ` over the whole file in one round-trip. |
-
-### Structural Code Search
-
-` + "`search_ast`" + ` answers "find every code site whose AST matches this shape" — the missing primitive between ` + "`search_symbols`" + ` (name-based) and ` + "`find_usages`" + ` (target-required). Cross-language, graph-aware, every match enriched with the enclosing function's ` + "`symbol_id`" + `.
-
-| Instead of...                            | You MUST use...                          |
-|------------------------------------------|------------------------------------------|
-| Grep for an anti-pattern across the repo | ` + "`search_ast`" + ` with a bundled ` + "`detector`" + `: ` + "`error-not-wrapped`" + ` / ` + "`sql-string-concat`" + ` / ` + "`weak-crypto`" + ` / ` + "`panic-in-library`" + ` / ` + "`goroutine-without-recover`" + ` / ` + "`http-client-no-timeout`" + ` / ` + "`hardcoded-secret`" + ` / ` + "`empty-catch`" + ` / ` + "`java-string-equality`" + ` / ` + "`python-mutable-default-arg`" + `. |
-| Grep for a code shape (e.g. every ` + "`.Get(_, nil)`" + ` call) | ` + "`search_ast`" + ` with ` + "`pattern: \"...\"`" + ` (raw tree-sitter S-expression) + ` + "`language: \"...\"`" + `. Capture nodes with ` + "`@name`" + `, anchor the match span with ` + "`@match`" + `, predicates: ` + "`(#eq? @x \"literal\")`" + ` / ` + "`(#match? @x \"regex\")`" + `. |
-| Scoping the audit to load-bearing code   | Pass ` + "`min_fan_in_of_enclosing_func: <N>`" + ` — drops matches in functions with fewer than N callers. Combine with ` + "`path_prefix`" + ` / ` + "`repo`" + ` / ` + "`project`" + ` / ` + "`ref`" + ` to narrow further. |
-
-### Code Quality and Analysis
-
-The ` + "`analyze`" + ` MCP tool is a unified dispatcher. Supported ` + "`kind`" + ` values:
-
-| Instead of...                         | You MUST use...                          |
-|---------------------------------------|------------------------------------------|
-| Manually hunting unused code          | ` + "`analyze`" + ` with ` + "`kind: \"dead_code\"`" + ` — zero incoming edges (excludes entry points, tests, exports) |
-| Guessing which symbols are over-coupled| ` + "`analyze`" + ` with ` + "`kind: \"hotspots\"`" + ` — ranks by fan-in, fan-out, community crossings |
-| Manually scanning for circular deps   | ` + "`analyze`" + ` with ` + "`kind: \"cycles\"`" + ` — Tarjan's SCC with severity classification |
-| Wondering if a new dep creates a cycle| ` + "`analyze`" + ` with ` + "`kind: \"would_create_cycle\"`" + ` — checks before you add it |
-| Grepping for TODO / FIXME             | ` + "`analyze`" + ` with ` + "`kind: \"todos\"`" + ` — KindTodo nodes, filter by tag/assignee/ticket |
-| Walking blame by hand                 | ` + "`analyze`" + ` with ` + "`kind: \"blame\"`" + ` — stamps meta.last_authored from git blame |
-| Reading a cover.out profile manually  | ` + "`analyze`" + ` with ` + "`kind: \"coverage\"`" + ` — stamps meta.coverage_pct on executable symbols |
-| Hunting symbols nobody touches        | ` + "`analyze`" + ` with ` + "`kind: \"stale_code\"`" + ` — symbols older than ` + "`older_than`" + ` days |
-| Asking who owns a package             | ` + "`analyze`" + ` with ` + "`kind: \"ownership\"`" + ` — author rollup with symbol/file counts |
-| Finding undertested symbols           | ` + "`analyze`" + ` with ` + "`kind: \"coverage_gaps\"`" + ` — symbols inside [min_pct, max_pct) |
-| Per-package coverage rollup           | ` + "`analyze`" + ` with ` + "`kind: \"coverage_summary\"`" + ` — directory-level avg/covered/partial/uncovered |
-| Stale feature flags                   | ` + "`analyze`" + ` with ` + "`kind: \"stale_flags\"`" + ` — flag callers untouched for ` + "`older_than`" + ` days |
-| Walking git tags by hand              | ` + "`analyze`" + ` with ` + "`kind: \"releases\"`" + ` — stamps meta.added_in on file nodes |
-| Surveying cgo / wasm boundaries       | ` + "`analyze`" + ` with ` + "`kind: \"cgo_users\"`" + ` or ` + "`kind: \"wasm_users\"`" + ` — files crossing the FFI boundary |
-| Finding tables without migrations     | ` + "`analyze`" + ` with ` + "`kind: \"orphan_tables\"`" + ` — queried tables missing EdgeProvides |
-| Finding migrations without users      | ` + "`analyze`" + ` with ` + "`kind: \"unreferenced_tables\"`" + ` — provided tables with zero EdgeQueries |
-| Spotting channel send/recv mismatches | ` + "`analyze`" + ` with ` + "`kind: \"channel_ops\"`" + ` — channels grouped by sends/recvs |
-| Finding goroutine spawn hotspots      | ` + "`analyze`" + ` with ` + "`kind: \"goroutine_spawns\"`" + ` — EdgeSpawns grouped by target + mode |
-| Finding mutability hotspots           | ` + "`analyze`" + ` with ` + "`kind: \"field_writers\"`" + ` — fields ranked by EdgeWrites; pass ` + "`id`" + ` for one field |
-| Listing every @Deprecated use         | ` + "`analyze`" + ` with ` + "`kind: \"annotation_users\"`" + ` — pass ` + "`id`" + ` or ` + "`name`" + ` for one annotation |
-| Tracing config-key readers            | ` + "`analyze`" + ` with ` + "`kind: \"config_readers\"`" + ` — config_key nodes grouped by EdgeReadsConfig |
-| Tracing event/log emitters            | ` + "`analyze`" + ` with ` + "`kind: \"event_emitters\"`" + ` — events grouped by EdgeEmits, ` + "`level`" + ` filter optional |
-| Mapping event pub/sub topics          | ` + "`analyze`" + ` with ` + "`kind: \"pubsub\"`" + ` — pub/sub topics with publishers (EdgeEmits) + subscribers (EdgeListensOn) from NATS / Kafka / RabbitMQ / Redis / EventEmitter / Socket.IO; ` + "`transport`" + ` / ` + "`name`" + ` / ` + "`role`" + ` filters |
-| Mapping the error surface             | ` + "`analyze`" + ` with ` + "`kind: \"error_surface\"`" + ` — function/method nodes with their EdgeThrows targets |
-| Surveying stdlib / module-cache reach | ` + "`analyze`" + ` with ` + "`kind: \"external_calls\"`" + ` — KindModule nodes grouped by call/symbol counts; pass ` + "`id`" + ` for per-symbol detail, ` + "`module_kind`" + ` for stdlib/module_cache filter |
-| Listing every HTTP/gRPC/WS route      | ` + "`analyze`" + ` with ` + "`kind: \"routes\"`" + ` — handler→route pairs from the EdgeHandlesRoute graph layer; ` + "`method`" + `, ` + "`path`" + `, ` + "`type`" + ` filters (` + "`type`" + ` ∈ http/grpc/ws/graphql/topic) |
-| Mapping ORM models to tables          | ` + "`analyze`" + ` with ` + "`kind: \"models\"`" + ` — class→table edges from EdgeModelsTable across gorm / SQLAlchemy / Django / ActiveRecord / JPA / TypeORM / Ecto; ` + "`orm`" + `, ` + "`table`" + `, ` + "`model`" + ` filters |
-| Walking the component tree            | ` + "`analyze`" + ` with ` + "`kind: \"components\"`" + ` — parent↔child fan-in/out from EdgeRendersChild (JSX/TSX + Phoenix HEEx); pass ` + "`id`" + ` for per-component child list |
-| Surveying K8s manifests in the repo   | ` + "`analyze`" + ` with ` + "`kind: \"k8s_resources\"`" + ` — every KindResource with infra-edge fan-out (depends_on / configures / mounts / exposes / uses_env); ` + "`k8s_kind`" + `, ` + "`namespace`" + `, ` + "`name`" + ` filters |
-| Listing container images in use       | ` + "`analyze`" + ` with ` + "`kind: \"images\"`" + ` — every KindImage (Dockerfile FROM target or K8s container.image) with consumer count; ` + "`role`" + ` (base/stage), ` + "`ref`" + `, ` + "`tag`" + ` filters |
-| Mapping the Kustomize overlay tree    | ` + "`analyze`" + ` with ` + "`kind: \"kustomize\"`" + ` — every KindKustomization with base / resource fan-out; ` + "`dir`" + ` filter |
-| Auditing what crosses repo boundaries | ` + "`analyze`" + ` with ` + "`kind: \"cross_repo\"`" + ` — calls / implements / extends edges whose endpoints live in different repos, grouped by (source repo → target repo, relation); ` + "`repo`" + `, ` + "`base_kind`" + `, ` + "`path_prefix`" + ` filters |
-| Surveying dbt / SQLMesh models        | ` + "`analyze`" + ` with ` + "`kind: \"dbt_models\"`" + ` — dbt / SQLMesh models, seeds, snapshots, sources with column count + EdgeDependsOn lineage fan-in/out; ` + "`framework`" + `, ` + "`type`" + `, ` + "`materialized`" + `, ` + "`name`" + ` filters |
-| Checking if the index is stale        | ` + "`index_health`" + ` — health score, parse failures, stale files |
-| Wondering what changed this session   | ` + "`get_symbol_history`" + ` — modification counts, flags churning (3+ edits) |
-| Hydrating blame / coverage / releases | ` + "`gortex enrich blame|coverage|releases|all`" + ` (CLI) — bulk-stamps the graph for the ` + "`stale_*`" + `, ` + "`coverage_*`" + `, ` + "`ownership`" + `, and ` + "`releases`" + ` analyzers |
-
-### Code Generation and Editing
-
-| Instead of...                         | You MUST use...                          |
-|---------------------------------------|------------------------------------------|
-| Reading files to learn a pattern      | ` + "`suggest_pattern`" + `                        |
-| Manually scaffolding from a pattern   | ` + "`scaffold`" + ` — generates code, wiring, and test stubs from an example |
-| Read→Edit roundtrip for one symbol    | ` + "`edit_symbol`" + ` — edit source by ID, no Read needed |
-| Read→Edit roundtrip for any file      | ` + "`edit_file`" + ` — string-replace any file by absolute or repo-relative path; atomic write, auto-reindex; pass ` + "`dry_run`" + ` to preview |
-| Read→Write roundtrip for new files    | ` + "`write_file`" + ` — create or overwrite any file with given content; creates parent dirs; pass ` + "`dry_run`" + ` to preview |
-| Manual find-and-replace for renames   | ` + "`rename_symbol`" + ` — coordinated rename across all references |
-| Sequencing multi-file edits yourself  | ` + "`batch_edit`" + ` — applies edits in dependency order, re-indexes between steps |
-| Reading a diff without graph context  | ` + "`diff_context`" + ` — enriches git diff with callers, callees, community, risk |
-| Guessing what context you need next   | ` + "`prefetch_context`" + ` — predicts needed symbols from task + recent activity |
-
-### API Contracts
-
-| Instead of...                         | You MUST use...                          |
-|---------------------------------------|------------------------------------------|
-| Manually tracking API routes/services | ` + "`contracts`" + ` (default ` + "`action: \"list\"`" + `) — lists HTTP, gRPC, GraphQL, topic, WebSocket, env, OpenAPI; filter by ` + "`repo`" + `, ` + "`project`" + `, or ` + "`ref`" + ` |
-| Guessing if APIs match across repos   | ` + "`contracts`" + ` with ` + "`action: \"check\"`" + ` — detects orphan providers/consumers and mismatches; scope with ` + "`repo`" + ` / ` + "`project`" + ` / ` + "`ref`" + ` |
-| Assessing what breaks before editing a route handler | ` + "`api_impact(route|file)`" + ` — one fused report: response shape, consumers + accessed fields, response-shape mismatches, middleware, execution flows, blast radius (callers + tests to run), fused risk |
-
-### PR / Change Review
-
-A graph-grounded change-review surface walks a diff (staged / branch / pasted patch / PR) through the graph so findings ride on real callers / contracts / coverage / guards, not style nits — instead of hand-walking each gate yourself.
-
-| Instead of...                         | You MUST use...                          |
-|---------------------------------------|------------------------------------------|
-| Eyeballing a diff for correctness bugs | ` + "`analyze`" + ` with ` + "`kind: \"review\"`" + ` — idiomatic / correctness rulepack (NPE, thread-safety check-then-act, N+1, logic-error; Go + Python) with a graph-grounded false-positive-reduction pass |
-| Hand-walking detect_changes / diff_context / verify_change / contracts / check_guards one call at a time | ` + "`review`" + ` / ` + "`review_pack`" + ` (MCP) — one fused review packet (verdict + ` + "`file:line`" + ` findings + cost), or the ` + "`gortex review [--diff|--base <ref>] [--audience agent|human] [--post]`" + ` CLI for a terse machine-first verdict |
-| Triaging which open PRs need attention | ` + "`list_prs`" + ` / ` + "`triage_prs`" + ` / ` + "`pr_risk`" + ` / ` + "`get_pr_impact`" + ` / ` + "`conflicts_prs`" + ` / ` + "`suggest_reviewers`" + ` (MCP), or the ` + "`gortex prs`" + ` CLI (` + "`--triage`" + ` / ` + "`--conflicts`" + ` / ` + "`--worktrees`" + `) — graph-ranked PR queue, blast radius, reviewer routing |
-
-### CPG-lite Dataflow
-
-The ` + "`flow_between`" + ` and ` + "`taint_paths`" + ` MCP tools answer **"where does this value flow?"** by walking three new edge kinds — ` + "`value_flow`" + ` (intra-procedural), ` + "`arg_of`" + ` (caller arg → callee param), and ` + "`returns_to`" + ` (callee → assignment).
-
-| Instead of...                         | You MUST use...                          |
-|---------------------------------------|------------------------------------------|
-| Hand-tracing a value through helper functions | ` + "`flow_between`" + ` — ranked dataflow paths between two symbol IDs; pass ` + "`max_depth`" + ` (default 8) and ` + "`max_paths`" + ` (default 10); supports ` + "`format: \"gcx\"`" + ` |
-| Grepping for sources / sinks         | ` + "`taint_paths`" + ` — pattern-driven sweep returning every flow from a matching source to a matching sink. Pattern syntax: bare token = case-insensitive substring on name; ` + "`exact:Foo`" + ` = exact match; ` + "`path:dir/`" + ` = file-path prefix; ` + "`kind:method`" + ` = node-kind filter; combine clauses with spaces (AND). Sinks expand functions to their params automatically. |
-| Reading callers to verify a refactor | ` + "`flow_between`" + ` from the changed return symbol to a downstream consumer's param to find every consumer site, including those reached through helper functions. |
-
-### Clone Detection
-
-` + "`find_clones`" + ` materialises the ` + "`similar_to`" + ` graph layer — a MinHash + LSH pass that hashes every function/method body into a 64-slot signature, LSH-bands the signatures into candidate pairs, and keeps the pairs whose estimated Jaccard similarity crosses the index-time threshold. Catches copy-paste and renamed-variable (Type-1/Type-2) clones.
-
-| Instead of...                         | You MUST use...                          |
-|---------------------------------------|------------------------------------------|
-| Eyeballing the repo for copy-paste    | ` + "`find_clones`" + ` — near-duplicate function/method clusters; pass ` + "`min_similarity`" + ` / ` + "`path_prefix`" + ` / ` + "`repo`" + ` / ` + "`limit`" + ` to scope |
-| Finding safe-to-delete duplicates     | ` + "`find_clones`" + ` with ` + "`dead_only: true`" + ` — clusters containing a dead-code symbol ("dead duplicates of live code"); each member is also flagged ` + "`is_dead`" + ` in the default view |
-
-### Multi-Repo Management
-
-| Instead of...                         | You MUST use...                          |
-|---------------------------------------|------------------------------------------|
-| Manually adding a repo to config      | ` + "`track_repository`" + ` — indexes immediately, persists to config |
-| Manually removing a repo from config  | ` + "`untrack_repository`" + ` — evicts nodes/edges, persists to config |
-| Refreshing the graph after edits      | ` + "`reindex_repository`" + ` — incremental re-index of changed files only; pass ` + "`paths`" + ` to scope to specific files / directories |
-| Wondering which project is active     | ` + "`get_active_project`" + ` — returns project name and repo list |
-| Switching project context             | ` + "`set_active_project`" + ` — re-scopes all subsequent queries |
-| Scoping a query to one repo           | Pass ` + "`repo`" + ` param to ` + "`search_symbols`" + `, ` + "`find_usages`" + `, etc. |
-| Scoping a query to a project          | Pass ` + "`project`" + ` param to any query tool |
-| Filtering by reference tag            | Pass ` + "`ref`" + ` param to any query tool |
-
-### Live Editor Buffers (Shadow-Graph Overlay Sessions)
-
-Editor extensions push in-flight (unsaved) buffers as **overlays**. Gortex composes a per-request **shadow view** on top of the immutable base graph and threads it through the tool dispatch context. After ` + "`overlay_register`" + ` and one or more ` + "`overlay_push`" + ` calls, every subsequent ` + "`tools/call`" + ` from the same MCP session reads through the shadow view — graph-walking tools (` + "`find_usages`" + `, ` + "`get_call_chain`" + `, ` + "`get_file_summary`" + `, …) and source-reading tools (` + "`get_symbol_source`" + `, ` + "`get_editing_context`" + `, …) all see the overlay.
-
-**Load-bearing invariant: base is never mutated by overlay flow.** Concurrent sessions (A1 / A2 / B) each see their own view; the file watcher's reindex passes don't race with overlay queries; cross-file edges from non-overlaid files into overlaid symbols are preserved because base's edges are untouched.
-
-| Instead of...                         | You MUST use...                          |
-|---------------------------------------|------------------------------------------|
-| Asking the user to save before a query | ` + "`overlay_register`" + ` then ` + "`overlay_push`" + ` — pushes one editor buffer; subsequent tool calls see the overlay |
-| Listing what an extension has staged   | ` + "`overlay_list`" + ` — path / size / deleted / base SHA for the current session |
-| Cancelling a single overlay           | ` + "`overlay_delete`" + ` with ` + "`path`" + ` — saved-buffer view returns for that path |
-| Tearing down an overlay session       | ` + "`overlay_drop`" + ` — discards every overlay attached to the session in one call |
-| Previewing impact of an unsaved edit  | ` + "`compare_with_overlay`" + ` with ` + "`kind: find_usages / get_callers / get_call_chain / get_dependencies / get_dependents`" + ` — runs the query against base and overlay simultaneously, returns added / removed / common ID sets |
-
-Pass an editor-captured git blob SHA as ` + "`base_sha`" + ` on ` + "`overlay_push`" + ` to enable drift detection: when the next tool call needs that path, Gortex compares ` + "`base_sha`" + ` to the on-disk hash and returns ` + "`overlay base SHA mismatch`" + ` if they disagree, so the client knows to re-read and resubmit. Push with ` + "`deleted: true`" + ` to model a tombstone — the file's symbols vanish from the shadow view (but are untouched in base).
-
-**Lifecycle.** Overlays are bound to the MCP session that registered them — when the MCP session ends, the overlay is dropped synchronously. Idle TTL (default 30 min, configurable via ` + "`GORTEX_OVERLAY_IDLE_TTL`" + `) is a fail-safe for missed disconnects; every tool call against a live overlay refreshes it. Use ` + "`overlay_keepalive`" + ` for genuine idle gaps without re-pushing content. ` + "`overlay_list`" + ` returns ` + "`expires_at`" + ` / ` + "`idle_seconds`" + ` so extensions can schedule keepalives proactively.
-
-HTTP transport mirrors the surface at ` + "`/v1/overlay/sessions/*`" + `; the ` + "`/v1/tools/<name>`" + ` entry reads the active session from ` + "`Mcp-Session-Id`" + ` / ` + "`X-Gortex-Overlay-Session`" + ` / ` + "`?session_id=`" + `.
-
-### MCP 2026 Streamable HTTP transport (` + "`/mcp`" + `)
-
-` + "`gortex daemon --http-addr <addr>`" + ` exposes the **MCP 2026 Streamable HTTP transport** on` + "`POST /mcp`" + `, ` + "`GET /mcp`" + ` (SSE upstream for server-initiated notifications), ` + "`DELETE /mcp`" + ` (session termination), ` + "`OPTIONS /mcp`" + ` (CORS preflight). One endpoint, one wire format — the spec the June 2026 MCP release locks in. Stateless per request: every POST carries ` + "`Mcp-Session-Id`" + ` and the transport replays state out of a ` + "`streamable.SessionStore`" + ` (in-memory by default, TTL-evicted; swap in a shared backend like Redis to run multiple workers behind a load balancer). ` + "`initialize`" + ` mints the id and returns it on the response header; an unknown id replies with a JSON-RPC ` + "`-32001 session not found`" + ` envelope. JSON-RPC batches preserve order; notification-only batches return HTTP 202. ` + "`tools/call`" + ` frames flow through the same multi-server router that serves ` + "`/v1/tools/<name>`" + `, so workspace scoping carries over unchanged. ` + "`gortex daemon`" + ` enables it via ` + "`--http-addr 127.0.0.1:7411 [--http-auth-token <token>]`" + `; non-localhost binds require an auth token (or ` + "`$GORTEX_DAEMON_HTTP_TOKEN`" + `). ` + "`/healthz`" + ` is exempt from auth so liveness probes work. When ` + "`--http-addr`" + ` is set the daemon serves both ` + "`/mcp`" + ` and the ` + "`/v1/*`" + ` REST surface on one listener.
-
-### Speculative Execution (Simulation Sessions)
-
-Built on the same shadow-graph substrate, ` + "`preview_edit`" + ` and ` + "`simulate_chain`" + ` answer **"what would change if I applied this WorkspaceEdit?"** — graph diff, broken callers/implementors, blast-radius impact, suggested test targets, and (when an LSP is configured) round-trip diagnostics — all without ever mutating the base graph or writing to disk. The input is a standard LSP ` + "`WorkspaceEdit`" + ` (` + "`{changes}`" + ` or ` + "`{documentChanges}`" + `), so any agent that already produces WorkspaceEdits for code actions can speculate on them directly.
-
-| Instead of...                                       | You MUST use...                          |
-|-----------------------------------------------------|------------------------------------------|
-| Writing the file then running tests to see breakage | ` + "`preview_edit`" + ` with ` + "`workspace_edit: <LSP WorkspaceEdit JSON>`" + ` — single-shot impact report (touched files, broken callers, broken implementors, impact rollup, test targets, optional LSP diagnostics). Disk untouched. |
-| Sequencing multiple speculative edits manually      | ` + "`simulate_chain`" + ` with ` + "`steps: [<WorkspaceEdit>, ...]`" + ` — applies steps in order, returns per-step impact + cumulative rollup + per-step diagnostics delta. Pass ` + "`stop_on_error: true`" + ` (default) to abort on the first new ERROR-severity diagnostic. |
-| Discarding the simulation when it actually worked   | ` + "`simulate_chain`" + ` with ` + "`keep: true`" + ` — promotes the final simulated state into a real overlay session bound to the calling MCP session; the response carries ` + "`overlay_session_id`" + `. From there, the editor can commit, ` + "`overlay_drop`" + `, or ` + "`compare_with_overlay`" + ` further. |
-| Speculating on top of unsaved buffer state          | Either tool with ` + "`inherit_overlay: true`" + ` — layers the simulation on top of the calling session's existing overlay instead of pristine base. |
-
-**Rename heuristic.** When a base symbol disappears from the overlay and exactly one overlay symbol matches its kind + non-trivial signature (after name stripping), the simulator pairs them as a ` + "`symbols_renamed`" + ` entry rather than flagging the change as ` + "`symbols_removed`" + ` + ` + "`symbols_added`" + `. Trivial signatures (parameterless void functions) are intentionally NOT paired — too many false positives. ` + "`Encode(payload []byte) []byte`" + ` → ` + "`Marshal(payload []byte) []byte`" + ` surfaces as a rename; a wholesale rewrite surfaces as removed + added.
-
-**Diagnostics restoration.** The diagnostics pass opens each touched file on the relevant LSP server, sends a ` + "`didChange`" + ` with the simulated content, waits for ` + "`publishDiagnostics`" + `, then sends a second ` + "`didChange`" + ` restoring the on-disk bytes — so concurrent sessions on the same daemon never observe the simulated state as authoritative. Set ` + "`diagnostics: false`" + ` to skip the LSP round-trip when only the graph delta matters.
-
-### Session Memory (save_note / query_notes / distill_session)
-
-Gortex remembers code; this triplet remembers **why you made a call**. Notes persist per-repo across daemon restarts and context compactions, are scoped to the session's workspace, and are auto-linked to symbols mentioned in the body (` + "`pkg/foo.go::Bar`" + ` IDs resolve directly; bare identifiers resolve via the graph's name index, ambiguous names dropped for precision). Use these on every meaningful task — not "optional."
-
-| Trigger                                                  | You MUST call                                                                 |
-|----------------------------------------------------------|-------------------------------------------------------------------------------|
-| At session start in any touched repo (after a compaction or on a fresh run) | ` + "`distill_session`" + ` — returns top symbols, pinned notes, decisions, recent excerpts from prior sessions. Seed your mental model with this before reading any file. |
-| You make a decision, reject an alternative, find a non-obvious constraint, or commit to an invariant | ` + "`save_note tags:\"decision\" body:\"<what+why>\"`" + ` — mention affected symbol IDs in the body for auto-linking; pin (` + "`pinned:true`" + `) anything load-bearing. |
-| Before editing a symbol you've touched before            | ` + "`query_notes symbol_id:\"<id>\"`" + ` — surfaces prior decisions, gotchas, "do not change this without …" warnings attached to that symbol. |
-| Mid-task discovery worth a follow-up                     | ` + "`save_note tags:\"follow-up\" body:\"<what to revisit and why>\"`" + ` — keeps the lead alive after compaction. |
-| Looking for what was tried in this area before           | ` + "`query_notes text:\"<keyword>\"`" + ` or ` + "`query_notes file_path:\"<path>\"`" + ` — full filter set: symbol_id, file_path, tag, text, session_id (` + "`all`" + ` for cross-session), since (RFC-3339), pinned_only. |
-
-**What to save:** decisions, non-obvious constraints, follow-ups ("revisit when …"), bug reproductions, surprising graph findings, partial-progress hand-offs.
-**What to skip:** play-by-play of what you just did (the diff says it), code patterns derivable from the graph, anything already in CLAUDE.md / AGENTS.md.
-
-Canonical tags: ` + "`decision`" + `, ` + "`bug`" + `, ` + "`follow-up`" + `, ` + "`gotcha`" + `, ` + "`invariant`" + `. The ` + "`decision`" + ` tag gets its own section in ` + "`distill_session`" + `.
-
-` + "`save_note`" + ` also accepts ` + "`id`" + ` (switches to update mode), ` + "`links`" + ` (comma-separated symbol IDs to attach explicitly), ` + "`no_autolink: true`" + ` (when the body intentionally mentions identifiers that should not be linked), and ` + "`file_path`" + ` (when the note is about a file, not a symbol). ` + "`distill_session`" + ` accepts ` + "`max_symbols`" + ` / ` + "`max_files`" + ` / ` + "`max_tags`" + ` / ` + "`max_recent`" + ` / ` + "`excerpt_chars`" + ` to tune digest size; default fits in ~1k tokens.
-
-### Development Memories (store_memory / query_memories / surface_memories)
-
-` + "`save_note`" + ` is a **per-session scratchpad**; ` + "`store_memory`" + ` is the **workspace-wide durable knowledge base**. Memories outlive sessions, agents, and teammates: every future agent in this workspace inherits them. Memories carry ` + "`kind`" + ` (` + "`invariant`" + ` / ` + "`constraint`" + ` / ` + "`convention`" + ` / ` + "`gotcha`" + ` / ` + "`decision`" + ` / ` + "`incident`" + ` / ` + "`reference`" + `), ` + "`importance`" + ` (1..5), ` + "`confidence`" + ` (0..1), and ` + "`supersedes`" + ` for evolution. Use these on every meaningful task — the memory store compounds the longer your team uses Gortex.
-
-| Trigger                                                  | You MUST call                                                                 |
-|----------------------------------------------------------|-------------------------------------------------------------------------------|
-| Immediately after ` + "`smart_context`" + ` (every new task)            | ` + "`surface_memories task:\"<task>\" symbol_ids:\"<top hits>\"`" + ` — returns memories ranked by anchor symbol overlap, file overlap, keyword hits, importance, pinning, recency, and confidence. Each hit carries ` + "`match_reasons`" + ` so you know *why* it surfaced. |
-| You discover a durable invariant / gotcha / decision worth teaching the team | ` + "`store_memory kind:\"<kind>\" body:\"<what+why>\" symbol_ids:\"<id>\" importance:5`" + ` — pin (` + "`pinned:true`" + `) anything load-bearing. ` + "`title:\"<one-liner>\"`" + ` becomes the headline. |
-| Before editing a symbol with a known history             | ` + "`query_memories symbol_id:\"<id>\"`" + ` — all memories anchored or auto-linked to that symbol. |
-| A memory is no longer true                                | ` + "`store_memory body:\"<corrected>\" supersedes:\"<old-id>\"`" + ` — old entry stays in the store (audit), hidden from ` + "`surface_memories`" + ` by default. Don't delete unless the original was wrong. |
-| Browsing all wisdom anchored to a file                    | ` + "`query_memories file_path:\"<path>\"`" + ` or ` + "`query_memories kind:\"invariant\"`" + ` to filter by kind. |
-
-**Store:** invariants ("Bar must hold the lock"), conventions ("this package never uses gob"), incident learnings, API contracts not enforced by types, debugging traps, cross-cutting decisions with non-obvious rationale.
-**Skip:** anything derivable from the code (the graph already knows), session-local play-by-play (use ` + "`save_note`" + ` instead), CLAUDE.md / AGENTS.md content (already loaded), one-off observations with no actionable consequence.
-
-### MCP Resources
-
-Bootstrap-state tools are also exposed as MCP resources (read-only, URI-addressable, no args). Subscribe via ` + "`resources/subscribe`" + ` once and receive ` + "`notifications/resources/updated`" + ` after each graph re-warm — no polling. Tools stay registered for back-compat with clients that don't speak resources; both surfaces share builder helpers so payloads match byte-for-byte.
-
-| Resource URI                                              | Same payload as tool          |
-|-----------------------------------------------------------|-------------------------------|
-| ` + "`gortex://stats`" + `                                          | ` + "`graph_stats`" + `                 |
-| ` + "`gortex://index-health`" + `                                   | ` + "`index_health`" + `                |
-| ` + "`gortex://workspace`" + `                                      | ` + "`workspace_info`" + `              |
-| ` + "`gortex://repos`" + `                                          | ` + "`list_repos`" + `                  |
-| ` + "`gortex://active-project`" + `                                 | ` + "`get_active_project`" + `          |
-| ` + "`gortex://schema`" + `                                         | (graph schema reference)      |
-| ` + "`gortex://session`" + `                                        | (recent activity replay)      |
-| ` + "`gortex://communities`" + ` / ` + "`gortex://community/{id}`" + `        | community detection rollups |
-| ` + "`gortex://processes`" + ` / ` + "`gortex://process/{id}`" + `            | process discovery rollups   |
-
-Analyzer-backed rollups (read-only summaries; the only "argument" is the current state of the indexed code):
-
-| Resource URI            | Synthesises                                              |
-|-------------------------|----------------------------------------------------------|
-| ` + "`gortex://report`" + `       | High-level orientation: graph size, top languages/kinds, hotspot count, dead-code count, todo count |
-| ` + "`gortex://god-nodes`" + `    | Top 20 hotspots (subset of ` + "`analyze kind:hotspots`" + `) |
-| ` + "`gortex://surprises`" + `    | Cycles + dead code + cross-community call hubs           |
-| ` + "`gortex://audit`" + `        | ` + "`audit_agent_config`" + ` with discovery defaults             |
-| ` + "`gortex://questions`" + `    | TODO/FIXME rollup grouped by tag and assignee            |
-
-## Session start (Gortex)
-
-1. Confirm Gortex is up with ` + "`index_health`" + ` (cheap liveness + scope). Call ` + "`graph_stats`" + ` only when you need node/edge counts or ` + "`per_repo`" + ` orientation — it's a heavy payload that can block during warmup.
-2. If ` + "`total_nodes`" + ` is 0, call ` + "`index_repository`" + ` with path ` + "`\".\"`" + `.
-3. Call ` + "`distill_session`" + ` to recover prior session memory for this workspace — decisions, pinned notes, recent excerpts. Use the digest to seed your mental model before reading any file.
-4. In multi-repo mode, call ` + "`get_active_project`" + ` to check scope. Use ` + "`set_active_project`" + ` to switch if needed.
-5. Open a non-trivial task with ` + "`smart_context`" + ` for orientation — for a single known symbol or file, go straight to ` + "`search_symbols`" + ` / ` + "`get_symbol_source`" + ` instead. After a smart_context call, call ` + "`surface_memories task:\"<task>\" symbol_ids:\"<top hits>\"`" + ` to pick up any cross-session invariants / gotchas / decisions anchored to your working set.
-6. For every file you are about to edit, call ` + "`get_editing_context`" + ` first. If you've touched the symbol before, also call ` + "`query_notes symbol_id:\"<id>\"`" + ` and ` + "`query_memories symbol_id:\"<id>\"`" + ` to surface prior notes and durable memories.
-7. Before changing a function signature, call ` + "`verify_change`" + ` to catch contract violations — checks callers across all repos.
-8. Before any refactor, call ` + "`get_edit_plan`" + ` for dependency-ordered file list. Use ` + "`batch_edit`" + ` to apply atomically.
-9. Verify with the project's real build/test. Reserve ` + "`check_guards`" + ` for guard-relevant changes and ` + "`get_test_targets`" + ` to find the tests covering a substantive change (includes cross-repo test files) — not mechanically after every edit.
-10. After making a meaningful decision or hitting a non-obvious constraint, call ` + "`save_note tags:\"decision\" body:\"<what+why>\"`" + ` so the next session can recover it.
-11. Before committing, call ` + "`detect_changes`" + ` to verify scope. Use ` + "`diff_context`" + ` for graph-enriched review.
-
-## Graph Schema (Gortex)
-
-**Node kinds** (filter ` + "`search_symbols`" + ` with ` + "`kind`" + `):
-- Code structure: ` + "`file`" + `, ` + "`package`" + `, ` + "`function`" + `, ` + "`method`" + `, ` + "`type`" + `, ` + "`interface`" + `, ` + "`field`" + `, ` + "`variable`" + `, ` + "`constant`" + `, ` + "`import`" + `, ` + "`contract`" + `, ` + "`param`" + `, ` + "`closure`" + `, ` + "`enum_member`" + `, ` + "`generic_param`" + `
-- Coverage extensions: ` + "`module`" + ` (ecosystem deps), ` + "`table`" + `/` + "`column`" + ` (db schema), ` + "`config_key`" + ` (env/viper), ` + "`flag`" + ` (feature flags), ` + "`event`" + ` (logs/metrics/spans), ` + "`migration`" + `, ` + "`fixture`" + ` (test data), ` + "`todo`" + ` (TODO/FIXME comments), ` + "`team`" + ` (CODEOWNERS), ` + "`license`" + `, ` + "`release`" + ` (tag boundaries)
-- Infrastructure: ` + "`resource`" + ` (K8s manifest — Deployment/Service/Ingress/ConfigMap/Secret/CronJob/…), ` + "`kustomization`" + ` (Kustomize overlay), ` + "`image`" + ` (Dockerfile FROM target or K8s ` + "`container.image`" + `)
-
-**Edge kinds** (used internally; pass kind name to ` + "`analyze`" + ` to query):
-- Calls / structure: ` + "`calls`" + `, ` + "`imports`" + `, ` + "`defines`" + `, ` + "`implements`" + `, ` + "`extends`" + `, ` + "`references`" + `, ` + "`member_of`" + `, ` + "`instantiates`" + `, ` + "`provides`" + `, ` + "`consumes`" + `, ` + "`composes`" + `, ` + "`aliases`" + `, ` + "`typed_as`" + `, ` + "`returns`" + `, ` + "`captures`" + `, ` + "`param_of`" + `
-- Concurrency: ` + "`spawns`" + ` (goroutine/async), ` + "`sends`" + ` / ` + "`recvs`" + ` (channels)
-- Mutation: ` + "`reads`" + ` / ` + "`writes`" + ` (fields), ` + "`reads_config`" + ` / ` + "`writes_config`" + `
-- Dataflow (CPG-lite, ` + "`flow_between`" + ` / ` + "`taint_paths`" + `): ` + "`value_flow`" + ` (intra-procedural assignment / return / range), ` + "`arg_of`" + ` (caller arg → callee param), ` + "`returns_to`" + ` (callee → assignment LHS)
-- Metadata: ` + "`annotated`" + ` (decorators), ` + "`emits`" + ` (events + pub/sub publish), ` + "`listens_on`" + ` (pub/sub subscribe), ` + "`throws`" + ` (errors), ` + "`queries`" + ` (SQL), ` + "`reads_col`" + ` / ` + "`writes_col`" + `, ` + "`toggles_flag`" + `, ` + "`depends_on_module`" + `, ` + "`matches`" + ` (fixtures), ` + "`generated_by`" + `, ` + "`tests`" + ` (test → tested symbol), ` + "`covered_by`" + `, ` + "`owns`" + ` (CODEOWNERS), ` + "`authored`" + `, ` + "`licensed_as`" + `
-- Infrastructure (K8s / Kustomize / Dockerfile): ` + "`configures`" + ` (workload → ConfigMap/Secret via env/envFrom), ` + "`mounts`" + ` (workload → volume source: ConfigMap/Secret/PVC), ` + "`exposes`" + ` (Resource/Image → ` + "`port::<proto>::<n>`" + `), ` + "`depends_on`" + ` (Ingress→Service / stage→base / overlay→base / Resource→Image), ` + "`uses_env`" + ` (Resource/Image → ` + "`cfg::env::<NAME>`" + ` config_key — shared ID with ` + "`os.Getenv`" + ` so the cross-ref between infra declaration and code-side reads is automatic)
-- Similarity (` + "`find_clones`" + `): ` + "`similar_to`" + ` (function/method near-duplicate — MinHash + LSH clone detection; symmetric; ` + "`Meta[\"similarity\"]`" + ` carries the estimated Jaccard score)
-- Cross-repo (` + "`analyze kind=cross_repo`" + `): ` + "`cross_repo_calls`" + ` / ` + "`cross_repo_implements`" + ` / ` + "`cross_repo_extends`" + ` (parallel edge emitted alongside a calls/implements/extends edge whose From and To nodes live in different repos; base edge also gets ` + "`Edge.CrossRepo`" + ` set)
+Gortex runs as an MCP server for this repository. You MUST prefer graph queries over file reads on every task — PreToolUse hooks deny ` + "`" + `Read` + "`" + ` / ` + "`" + `Grep` + "`" + ` / ` + "`" + `Glob` + "`" + ` against indexed source, and the deny message names the right tool.
+
+| Instead of...                       | Use...                                   |
+|-------------------------------------|------------------------------------------|
+| ` + "`" + `Grep` + "`" + ` for a symbol                 | ` + "`" + `search_symbols` + "`" + ` (BM25 + camelCase-aware) |
+| ` + "`" + `Grep` + "`" + ` for references               | ` + "`" + `find_usages` + "`" + ` (zero false positives)     |
+| Reading / grepping to find callers  | ` + "`" + `get_callers` + "`" + ` / ` + "`" + `get_call_chain` + "`" + `         |
+| ` + "`" + `Read` + "`" + ` a file for one symbol        | ` + "`" + `get_symbol_source` + "`" + ` (` + "`" + `compress_bodies:true` + "`" + ` for the signature only) |
+| ` + "`" + `Read` + "`" + ` to understand a file         | ` + "`" + `get_file_summary` + "`" + ` / ` + "`" + `get_editing_context` + "`" + ` |
+| ` + "`" + `Read` + "`" + ` a non-indexed / raw file     | ` + "`" + `read_file` + "`" + `                              |
+| 5-10 reads to explore a task        | ` + "`" + `smart_context` + "`" + ` (one call)               |
+| ` + "`" + `Edit` + "`" + ` / ` + "`" + `Write` + "`" + ` source             | ` + "`" + `edit_file` + "`" + ` / ` + "`" + `write_file` + "`" + ` / ` + "`" + `edit_symbol` + "`" + ` / ` + "`" + `rename_symbol` + "`" + ` / ` + "`" + `batch_edit` + "`" + ` |
+
+The graph narrows scope; read the real body with ` + "`" + `get_symbol_source` + "`" + ` before you change or depend on a symbol — especially behavior-critical code (migrations, retry / fallback, concurrency), where ` + "`" + `compress_bodies:true` + "`" + ` would elide the risky branches. ` + "`" + `format:"gcx"` + "`" + ` and ` + "`" + `compress_bodies:true` + "`" + ` exist on the read / list tools — the parameter legend is in the MCP server instructions.
+
+**Memory workflow** (behavior-critical; the full triggers live in the global ` + "`" + `~/.claude/CLAUDE.md` + "`" + ` policy and in ` + "`" + `gortex://guide` + "`" + `): ` + "`" + `distill_session` + "`" + ` at session start; ` + "`" + `surface_memories` + "`" + ` right after ` + "`" + `smart_context` + "`" + `; ` + "`" + `save_note tags:"decision"` + "`" + ` at each decision; ` + "`" + `store_memory` + "`" + ` for durable invariants / gotchas the team should inherit; ` + "`" + `query_notes` + "`" + ` / ` + "`" + `query_memories` + "`" + ` before re-touching a symbol.
+
+**Reference:** ` + "`" + `gortex://guide` + "`" + ` (or ` + "`" + `gortex guide [topic]` + "`" + `) carries the full detail — provider matrix, capabilities, analyze / search_ast catalogs, token-economy, MCP resources. The server publishes a lean tool preset eagerly; call ` + "`" + `tools_search` + "`" + ` to discover and load any other tool by keyword.
 `
 
 // AppendInstructions appends body to path, creating the file if

--- a/internal/agents/instructions_test.go
+++ b/internal/agents/instructions_test.go
@@ -126,70 +126,72 @@ func TestCursorMDCFrontmatter(t *testing.T) {
 	assert.Contains(t, out, "BODY")
 }
 
-// TestInstructionsBody_AdvertisesKeyTools is a smoke test: the shared
-// body is the one artefact every agent relies on. A regression that
-// silently emptied it (e.g. moving content into an unused variable)
-// would leave `gortex init` installing a doc block that says nothing
-// about preferring Gortex. We spot-check for tool names that anchor
-// the MANDATORY message.
-func TestInstructionsBody_AdvertisesKeyTools(t *testing.T) {
+// Single-home markers: content that must live in exactly one place. These
+// strings anchor the reference blocks that were relocated OUT of the CLAUDE.md
+// sections into the guide (provider matrix, analyze catalog) or the server
+// instructions (wire-format deep-dive). Their absence from the slim bodies is
+// the enforcement side of the single-home principle; their presence in the
+// guide / server-instructions is asserted in the mcp package.
+const (
+	providerMatrixMarker = "`local` / `anthropic` / `openai` / `azure` / `ollama` / `claudecli` / `codex` / `copilot` / `cursor` / `opencode` / `gemini` / `bedrock` / `deepseek`"
+	analyzeCatalogMarker = "Tarjan's SCC" // from the analyze `cycles` kind doc
+	formatDeepDiveMarker = "compact tabular text, lossy"
+)
+
+// TestInstructionsBody_PolicyCoreAndSingleHome smoke-tests the slim project
+// rule block: it keeps the mandatory graph-tools mapping + the memory-workflow
+// pointers, and it does NOT re-carry the relocated reference content.
+func TestInstructionsBody_PolicyCoreAndSingleHome(t *testing.T) {
 	for _, token := range []string{
-		"search_symbols", "smart_context", "get_editing_context",
-		"contracts", "find_usages", "graph_stats",
-		// CPG-lite dataflow surface (flow_between / taint_paths).
-		"flow_between", "taint_paths",
-		"value_flow", "arg_of", "returns_to",
-		// Infrastructure-as-graph surface (K8s / Kustomize / Dockerfile).
-		"k8s_resources", "images", "kustomize",
-		"uses_env", "configures", "mounts", "exposes", "depends_on",
-		// Push diagnostics + code actions surface.
-		"subscribe_diagnostics", "unsubscribe_diagnostics",
-		"get_diagnostics", "get_code_actions", "apply_code_action",
-		"fix_all_in_file", "notifications/diagnostics",
-		// Structural code search.
-		"search_ast", "error-not-wrapped", "sql-string-concat",
-		"weak-crypto", "panic-in-library", "hardcoded-secret",
-		"min_fan_in_of_enclosing_func",
-		// Content compression (K9): the read_file tool and the
-		// compress_bodies flag — the load-bearing tokens an agent
-		// needs to discover the surface-only read mode.
-		"read_file", "compress_bodies", "source_compressed",
-		// MCP resources surface (bootstrap + analyzer rollups).
-		"gortex://stats", "gortex://index-health", "gortex://workspace",
-		"gortex://repos", "gortex://active-project",
-		"gortex://report", "gortex://god-nodes", "gortex://surprises",
-		"gortex://audit", "gortex://questions",
-		"notifications/resources/updated",
+		// Graph-tools policy core.
+		"search_symbols", "find_usages", "get_callers",
+		"get_symbol_source", "get_editing_context", "get_file_summary",
+		"read_file", "smart_context", "edit_file", "compress_bodies",
+		// Memory workflow (pointer form).
+		"distill_session", "surface_memories", "save_note", "store_memory",
+		"query_notes", "query_memories",
+		// Discovery pointers.
+		"tools_search", "gortex://guide",
 	} {
 		if !strings.Contains(InstructionsBody, token) {
-			t.Errorf("InstructionsBody no longer mentions %q — a doc regression would ship to every adapter", token)
+			t.Errorf("InstructionsBody no longer mentions %q — policy core regression", token)
+		}
+	}
+	for _, banned := range []string{providerMatrixMarker, analyzeCatalogMarker, formatDeepDiveMarker} {
+		if strings.Contains(InstructionsBody, banned) {
+			t.Errorf("InstructionsBody re-carries relocated content %q — single-home violation", banned)
 		}
 	}
 }
 
-// TestGlobalInstructionsBody_AdvertisesKeyTools mirrors the smoke
-// test above for the global block written by `gortex install` into
-// ~/.claude/CLAUDE.md. It's the per-machine surface and gets the
-// shorter dataflow callout — verify both tool names ship.
-func TestGlobalInstructionsBody_AdvertisesKeyTools(t *testing.T) {
+// TestGlobalInstructionsBody_PolicyCoreAndSingleHome mirrors the check for the
+// per-machine block written by `gortex install` into ~/.claude/CLAUDE.md — the
+// single home for the full memory-workflow triggers.
+func TestGlobalInstructionsBody_PolicyCoreAndSingleHome(t *testing.T) {
 	for _, token := range []string{
-		"search_symbols", "smart_context", "get_editing_context",
-		"flow_between", "taint_paths",
-		// Infrastructure surface — also written into the per-machine
-		// block by `gortex install`.
-		"k8s_resources", "images", "kustomize",
-		// Structural code search — also in the per-machine block.
-		"search_ast", "error-not-wrapped",
-		// Content compression (K9): same load-bearing tokens as the
-		// per-project block.
-		"read_file", "compress_bodies", "source_compressed",
-		// MCP resources surface (bootstrap + analyzer rollups).
-		"gortex://stats", "gortex://index-health", "gortex://active-project",
-		"gortex://report", "gortex://god-nodes",
-		"notifications/resources/updated",
+		// Graph-tools policy core.
+		"search_symbols", "find_usages", "get_callers", "get_call_chain",
+		"get_symbol_source", "get_editing_context", "read_file",
+		"smart_context", "edit_file", "rename_symbol", "compress_bodies",
+		// Full memory triggers (the single home).
+		"distill_session", "surface_memories", "save_note", "store_memory",
+		"query_notes", "query_memories",
+		// Discovery pointers.
+		"tools_search", "gortex://guide", "gortex daemon start",
 	} {
 		if !strings.Contains(GlobalInstructionsBody, token) {
 			t.Errorf("GlobalInstructionsBody no longer mentions %q", token)
+		}
+	}
+	for _, banned := range []string{
+		providerMatrixMarker, analyzeCatalogMarker, formatDeepDiveMarker,
+		// Reference catalogs that relocated to the guide / schema resource.
+		// (A bare "search_ast" pointer is allowed; the DETECTOR catalog — named
+		// detectors like error-not-wrapped — must not be inlined.)
+		"k8s_resources", "error-not-wrapped", "gortex://report",
+	} {
+		if strings.Contains(GlobalInstructionsBody, banned) {
+			t.Errorf("GlobalInstructionsBody re-carries relocated content %q — single-home violation", banned)
 		}
 	}
 }

--- a/internal/mcp/guide.go
+++ b/internal/mcp/guide.go
@@ -1,0 +1,191 @@
+package mcp
+
+import (
+	"sort"
+	"strings"
+)
+
+// The guide is the single on-demand home for Gortex reference detail that
+// used to be pre-paid in the installed CLAUDE.md section: the LLM-provider
+// matrix, the non-obvious capabilities catalog, the token-economy deep-dive,
+// the MCP resources list, and pointers into the analyze / search_ast
+// catalogs (which live authoritatively in `kind:"help"` / `detector:"help"`
+// and the gortex://schema resource). Nothing here is deleted from the
+// product — it stops being ambient and becomes reachable via the
+// `gortex://guide` MCP resource and the `gortex guide [topic]` CLI verb.
+//
+// Single-home invariants enforced by tests:
+//   - the LLM-provider matrix lives ONLY here (not in the CLAUDE.md sections);
+//   - the analyze kind catalog lives in `kind:"help"` / gortex://schema and is
+//     rendered here from the same source — never re-inlined into CLAUDE.md;
+//   - the wire-FORMAT deep-dive lives ONLY in the server instructions
+//     (sharedParamLegend) — the guide points at it, it is not repeated here.
+
+// guideProviders is the LLM-provider matrix + the `ask` delegation surface,
+// relocated verbatim out of the installed rule block. The 13-provider
+// enumeration is the single-home marker asserted by the gates.
+const guideProviders = `## LLM providers (powers ` + "`ask`" + ` and ` + "`search_symbols assist:`" + ` modes)
+
+Selected via ` + "`llm.provider`" + ` in ` + "`.gortex.yaml`" + ` or ` + "`~/.gortex/config.yaml`" + `, or ` + "`GORTEX_LLM_PROVIDER`" + ` / ` + "`GORTEX_LLM_MODEL`" + `. One of:
+` + "`local`" + ` / ` + "`anthropic`" + ` / ` + "`openai`" + ` / ` + "`azure`" + ` / ` + "`ollama`" + ` / ` + "`claudecli`" + ` / ` + "`codex`" + ` / ` + "`copilot`" + ` / ` + "`cursor`" + ` / ` + "`opencode`" + ` / ` + "`gemini`" + ` / ` + "`bedrock`" + ` / ` + "`deepseek`" + `.
+Only ` + "`local`" + ` needs a ` + "`-tags llama`" + ` build; the HTTP and subprocess adapters are pure Go, available in every binary.
+
+| Provider | Backend | Requires |
+|---|---|---|
+| ` + "`local`" + ` (default) | in-process llama.cpp | ` + "`-tags llama`" + ` build + ` + "`llm.local.model`" + ` (a ` + "`.gguf`" + `) |
+| ` + "`anthropic`" + ` | Messages API | ` + "`llm.anthropic.model`" + ` + ` + "`ANTHROPIC_API_KEY`" + ` |
+| ` + "`openai`" + ` | Chat Completions | ` + "`llm.openai.model`" + ` + ` + "`OPENAI_API_KEY`" + ` |
+| ` + "`azure`" + ` | Azure OpenAI | ` + "`llm.azure.deployment`" + ` + endpoint + ` + "`AZURE_OPENAI_API_KEY`" + ` |
+| ` + "`ollama`" + ` | Ollama daemon | ` + "`llm.ollama.model`" + ` (+ ` + "`llm.ollama.host`" + `) |
+| ` + "`claudecli`" + ` / ` + "`codex`" + ` / ` + "`copilot`" + ` / ` + "`cursor`" + ` / ` + "`opencode`" + ` | CLI subprocess | the named CLI on ` + "`$PATH`" + ` (signed in once) |
+| ` + "`gemini`" + ` | Gemini ` + "`generateContent`" + ` | ` + "`llm.gemini.model`" + ` + ` + "`GEMINI_API_KEY`" + ` |
+| ` + "`bedrock`" + ` | AWS Bedrock Converse (SigV4) | ` + "`llm.bedrock.model_id`" + ` + AWS creds (region default ` + "`us-east-1`" + `) |
+| ` + "`deepseek`" + ` | DeepSeek Chat Completions | ` + "`llm.deepseek.model`" + ` + ` + "`DEEPSEEK_API_KEY`" + ` |
+
+Custom OpenAI-compatible endpoints register by name with ` + "`gortex provider add/list/show/remove`" + `. Anthropic accepts the tier sentinels ` + "`claude-haiku`" + ` / ` + "`claude-sonnet`" + ` / ` + "`claude-opus`" + ` and opt-in prompt caching / thinking / effort. ` + "`llm.routing`" + ` (off by default) routes ` + "`ask`" + ` to a cheaper or more capable model by graph-derived task complexity.
+
+### Delegate research to a local agent (` + "`ask`" + `)
+
+When a provider is configured the ` + "`ask`" + ` MCP tool is registered — a grammar-constrained agent that uses gortex tools to research one question and returns a synthesized answer. Reach for it when you'd otherwise issue many ` + "`search_symbols`" + ` / ` + "`get_callers`" + ` / ` + "`contracts`" + ` calls; pass ` + "`chain: true`" + ` to trace a request across repos. If ` + "`ask`" + ` isn't in ` + "`tools/list`" + `, no provider could construct — fall through to direct tools.
+
+### ` + "`search_symbols assist:`" + ` modes
+
+` + "`auto`" + ` (default — skips the LLM for identifier queries, expands NL queries), ` + "`on`" + ` (forces expansion+rerank), ` + "`off`" + ` (pure BM25), ` + "`deep`" + ` (adds a body-grounded verification pass; +1.5-4s; quality is model-dependent).`
+
+// guideCapabilities is the non-obvious capabilities tour, relocated from the
+// rule block. Reference material an agent reaches for on demand, not a
+// mid-session action list.
+const guideCapabilities = `## Non-obvious capabilities
+
+- **` + "`compress_bodies: true`" + `** on ` + "`read_file`" + ` / ` + "`get_symbol_source`" + ` / ` + "`get_editing_context`" + ` elides function bodies to stubs while keeping signatures + doc-comments + structure. ~30-40% of original tokens. Composes with ` + "`format:\"gcx\"`" + `; safe to set unconditionally (no-op on unparseable input).
+- **Overlay sessions** (` + "`overlay_push`" + ` / ` + "`overlay_list`" + ` / ` + "`overlay_drop`" + ` / ` + "`compare_with_overlay`" + `) let editor extensions push unsaved buffers as a per-session shadow graph — every subsequent tool call reads through it without mutating base. Idle TTL via ` + "`GORTEX_OVERLAY_IDLE_TTL`" + ` (default 30m).
+- **Speculative execution** (` + "`preview_edit`" + ` / ` + "`simulate_chain`" + `) takes an LSP ` + "`WorkspaceEdit`" + ` and returns the graph diff + broken callers/implementors + impact rollup + suggested tests + optional diagnostics — disk untouched. ` + "`simulate_chain keep:true`" + ` promotes the final state into a real overlay.
+- **Change-contract pipeline** (` + "`change_contract`" + ` / ` + "`symbols_for_ranges`" + `) lowers a WorkspaceEdit / diff range / symbol set / line-ranges into one verdict ` + "`{allow|warn|refuse}`" + ` with reasons, risk, a verification command, a stop condition, and an edit strategy. The pre-write **parse gate** on ` + "`edit_file`" + ` / ` + "`write_file`" + ` refuses edits that introduce new tree-sitter parse errors (override ` + "`allow_parse_errors`" + `).
+- **MCP 2026 Streamable HTTP** at ` + "`POST /mcp`" + ` — ` + "`gortex server`" + ` always mounts it; ` + "`gortex daemon --http-addr <addr>`" + ` opts the daemon in (non-localhost binds require ` + "`--http-auth-token`" + `).
+- **Artifacts** — non-code knowledge files (DB schemas, API specs, ADRs, infra configs) declared in ` + "`.gortex.yaml`" + ` ` + "`artifacts:`" + ` are indexed as ` + "`artifact`" + ` nodes; ` + "`search_artifacts`" + ` / ` + "`get_artifact`" + ` surface them.
+- **` + "`get_architecture`" + `** — one-call architectural snapshot (languages, communities, hotspots, processes); pass ` + "`resolution`" + ` for a symbol → file → package → service → system rollup.
+- **Capability edges** — ` + "`reads_env`" + ` / ` + "`executes_process`" + ` / ` + "`accesses_field`" + ` are first-class traversable edges for supply-chain / least-privilege audits ("what reads $AWS_SECRET", "what shells out", "what writes this field").
+- **PR review, end-to-end** — ` + "`gortex prs`" + ` triages open PRs from the graph; ` + "`gortex review [<base>|--diff] [--audience agent|human]`" + ` reviews a diff. MCP mirrors: ` + "`pr_risk`" + ` / ` + "`list_prs`" + ` / ` + "`triage_prs`" + ` / ` + "`review`" + ` / ` + "`review_pack`" + `.
+- **Broad ingest** — image + PDF nodes; first-class extractors for Terraform/HCL, Helm, Ansible, .NET ` + "`.sln`" + `/` + "`.csproj`" + `, MCP configs, Quarto, Luau, COBOL/JCL, C/C++ macros. ` + "`gortex db schema --postgres <dsn>`" + ` ingests a live DB schema.`
+
+// guideTokens is the token-economy deep-dive MINUS the wire-format section
+// (which lives authoritatively in the server instructions / sharedParamLegend
+// and is only pointed at here — the single-home invariant for format).
+const guideTokens = `## Token economy
+
+The wire-FORMAT knobs (` + "`format`" + ` = json/gcx/toon, ` + "`max_bytes`" + `, ` + "`cursor`" + `, ` + "`fields`" + `, ` + "`limit`" + `, ` + "`scope`" + `, ` + "`repo`" + `/` + "`project`" + `/` + "`workspace`" + `/` + "`ref`" + `) are documented once in the MCP server ` + "`instructions`" + ` (the shared-parameter legend emitted at initialize). Read them there; this section covers the orthogonal content knobs.
+
+### Content compression (` + "`compress_bodies`" + `)
+
+Replaces every function/method body in returned source with a ` + "`{ /* N lines elided */ }`" + ` stub (language-appropriate). Signatures, doc-comments, imports, top-level constants/types, and structure stay intact. A 200-line file lands at ≤ 60 lines. Wired in 16 languages. Composes with ` + "`format:\"gcx\"`" + ` for stacked savings.
+
+### Graceful degradation
+
+List-shaped tools run through a per-response budget. On overflow the server strips verbose meta, then drops tier-3 rows (params/closures/low-confidence edges), then tier-2 rows, then tail-trims the longest tier-1 list — each escape stamped (` + "`_meta_stripped`" + `, ` + "`_dropped_tier_<N>_<list>`" + `, ` + "`_truncated_by_budget`" + `). Use the metadata to decide whether to narrow the filter, raise ` + "`max_bytes`" + `, or paginate.
+
+### Reuse and freshness
+
+Treat what you fetch as cached for the task — don't re-run the same query. ` + "`read_file`" + ` / ` + "`get_symbol_source`" + ` / ` + "`get_file_summary`" + ` / ` + "`get_editing_context`" + ` / ` + "`smart_context`" + ` return an ` + "`etag`" + ` and accept ` + "`if_none_match`" + ` — an unchanged target comes back ` + "`not_modified`" + ` at ~0 tokens. A ` + "`count: 0`" + ` while the daemon is warming (a ` + "`warming`" + ` block, or ` + "`index_health`" + ` not ready) means *not indexed yet*, not *absent*.`
+
+// guideResources is the MCP resources catalog, relocated from the rule block.
+const guideResources = `## MCP resources
+
+Bootstrap-state tools are also exposed as read-only, URI-addressable resources — subscribe via ` + "`resources/subscribe`" + ` once and receive ` + "`notifications/resources/updated`" + ` after each graph re-warm (no polling).
+
+| Resource | Payload |
+|---|---|
+| ` + "`gortex://stats`" + ` | ` + "`graph_stats`" + ` |
+| ` + "`gortex://index-health`" + ` | ` + "`index_health`" + ` |
+| ` + "`gortex://workspace`" + ` | ` + "`workspace_info`" + ` |
+| ` + "`gortex://repos`" + ` | ` + "`list_repos`" + ` |
+| ` + "`gortex://active-project`" + ` | ` + "`get_active_project`" + ` |
+| ` + "`gortex://schema`" + ` | graph schema + analyze/search_ast catalogs |
+| ` + "`gortex://guide`" + ` | this reference |
+
+Analyzer rollups (read-only summaries of the indexed state): ` + "`gortex://report`" + ` (orientation), ` + "`gortex://god-nodes`" + ` (top hotspots), ` + "`gortex://surprises`" + ` (cycles + dead code + hubs), ` + "`gortex://audit`" + ` (CLAUDE.md drift), ` + "`gortex://questions`" + ` (TODOs), plus ` + "`gortex://communities`" + ` / ` + "`gortex://processes`" + ` templates.`
+
+// guideWorkflow is the full session-start checklist, relocated here so the
+// installed policy core keeps only the memory-trigger essentials.
+const guideWorkflow = `## Session-start checklist
+
+1. Confirm the daemon with ` + "`index_health`" + ` (cheap liveness + scope). Call ` + "`graph_stats`" + ` only when you need node/edge counts or ` + "`per_repo`" + ` orientation.
+2. If ` + "`total_nodes`" + ` is 0, ` + "`index_repository`" + ` with path ` + "`\".\"`" + ` before anything else.
+3. Call ` + "`distill_session`" + ` to recover prior-session memory (decisions, pinned notes, recent excerpts).
+4. In multi-repo mode, ` + "`get_active_project`" + ` to check scope; ` + "`set_active_project`" + ` to switch.
+5. Open a non-trivial task with ` + "`smart_context`" + `; then ` + "`surface_memories task:\"…\" symbol_ids:\"…\"`" + ` to pick up cross-session invariants.
+6. Before editing a file, ` + "`get_editing_context`" + `; if you've touched the symbol before, ` + "`query_notes`" + ` / ` + "`query_memories`" + ` by symbol_id.
+7. Before a signature change, ` + "`verify_change`" + `. For a refactor, ` + "`get_edit_plan`" + ` then ` + "`batch_edit`" + `.
+8. Verify with the project's real build/test. Reserve ` + "`check_guards`" + ` / ` + "`get_test_targets`" + ` for substantive changes.
+9. Before committing, ` + "`detect_changes`" + ` for scope + ` + "`diff_context`" + ` for graph-enriched review.
+
+The behavior-critical memory triggers (distill_session, surface_memories, save_note, store_memory) live in the installed policy core (~/.claude/CLAUDE.md). This checklist is the fuller reference.`
+
+// guideSection maps a topic keyword to its rendered section. Section bodies
+// that need a live catalog (analyze / search_ast) are rendered from the same
+// source functions that back kind:"help" / detector:"help", so the catalog
+// has a single source of truth.
+func guideSection(topic string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(topic)) {
+	case "providers", "provider", "llm", "ask":
+		return guideProviders, true
+	case "capabilities", "capability", "features", "feature":
+		return guideCapabilities, true
+	case "tokens", "token", "economy", "compress", "compress_bodies":
+		return guideTokens, true
+	case "resources", "resource":
+		return guideResources, true
+	case "workflow", "session", "checklist", "session-start":
+		return guideWorkflow, true
+	case "analyze", "analyzers", "kinds":
+		// Point at the single-source catalog rather than re-inlining it: the
+		// full per-kind reference lives in `analyze kind:"help"` and the
+		// gortex://schema resource.
+		return "## analyze\n\n" + analyzeGroupedSummary, true
+	case "search_ast", "ast", "detectors":
+		return "## search_ast\n\n" + buildSearchASTDescription() +
+			"\n\nFull detector catalog: `search_ast detector:\"help\"` or the gortex://schema resource.", true
+	default:
+		return "", false
+	}
+}
+
+// guideTopicOrder is the canonical section order for the full render and the
+// topic list.
+var guideTopicOrder = []string{"providers", "capabilities", "tokens", "analyze", "search_ast", "resources", "workflow"}
+
+// GuideTopics returns the addressable guide topic keywords, sorted.
+func GuideTopics() []string {
+	out := append([]string(nil), guideTopicOrder...)
+	sort.Strings(out)
+	return out
+}
+
+// GuideText renders the guide. An empty topic (or "all"/"index") returns the
+// full document with a table of contents; a known topic returns just that
+// section; an unknown topic returns the overview with the topic list so the
+// caller can retry.
+func GuideText(topic string) string {
+	t := strings.ToLower(strings.TrimSpace(topic))
+	if t != "" && t != "all" && t != "index" && t != "toc" {
+		if sec, ok := guideSection(t); ok {
+			return sec + "\n"
+		}
+		// Unknown topic: fall through to the overview so the reply is still
+		// useful and names the valid topics.
+	}
+
+	var b strings.Builder
+	b.WriteString("# Gortex Guide\n\n")
+	b.WriteString("On-demand reference for Gortex. The mandatory graph-tools policy and the memory workflow live in the installed CLAUDE.md; everything below is reachable via the `gortex://guide` resource or `gortex guide [topic]`.\n\n")
+	if t != "" && t != "all" && t != "index" && t != "toc" {
+		b.WriteString("(Unknown topic \"" + topic + "\" — showing the full guide. Topics: " + strings.Join(guideTopicOrder, ", ") + ".)\n\n")
+	} else {
+		b.WriteString("Topics: " + strings.Join(guideTopicOrder, ", ") + ". Address one with `gortex guide <topic>` or `gortex://guide/<topic>`.\n\n")
+	}
+	for _, name := range guideTopicOrder {
+		sec, _ := guideSection(name)
+		b.WriteString(sec)
+		b.WriteString("\n\n")
+	}
+	return b.String()
+}

--- a/internal/mcp/guide_test.go
+++ b/internal/mcp/guide_test.go
@@ -1,0 +1,93 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+// providerMatrixMarker is the 13-provider enumeration — the single-home
+// marker for the LLM-provider matrix. It must appear in the guide and NOWHERE
+// in the installed CLAUDE.md sections (asserted by the single-home gate).
+const providerMatrixMarker = "`local` / `anthropic` / `openai` / `azure` / `ollama` / `claudecli` / `codex` / `copilot` / `cursor` / `opencode` / `gemini` / `bedrock` / `deepseek`"
+
+// formatDeepDiveMarker is a phrase unique to the wire-format deep-dive in the
+// server instructions (sharedParamLegend). It is the single-home marker for
+// "format lives only in the instructions" — asserted absent from the guide
+// here and from the CLAUDE.md sections in the agents package.
+const formatDeepDiveMarker = "compact tabular text, lossy"
+
+// TestGuideText_TopicsAndContent verifies each relocated reference block is
+// reachable through GuideText, both in the full render and section-addressed.
+func TestGuideText_TopicsAndContent(t *testing.T) {
+	full := GuideText("")
+	require.Contains(t, full, "# Gortex Guide")
+	require.Contains(t, full, providerMatrixMarker, "provider matrix must live in the guide")
+	require.Contains(t, full, "Overlay sessions", "capabilities catalog must live in the guide")
+	require.Contains(t, full, "compress_bodies", "token-economy content must live in the guide")
+	require.Contains(t, full, "gortex://report", "resources list must live in the guide")
+
+	// Section addressing returns just that section.
+	require.Contains(t, GuideText("providers"), providerMatrixMarker)
+	require.NotContains(t, GuideText("providers"), "Overlay sessions",
+		"a section address must return only its section")
+	require.Contains(t, GuideText("capabilities"), "Speculative execution")
+	require.Contains(t, GuideText("resources"), "gortex://guide")
+
+	// The analyze / search_ast sections point at the single-source catalog
+	// (kind:"help" / detector:"help" / gortex://schema) rather than re-inlining
+	// it — the grouped summary + a pointer, not the full per-kind text.
+	analyze := GuideText("analyze")
+	require.Contains(t, analyze, "dead_code")
+	require.Contains(t, analyze, `kind:"help"`)
+	require.NotContains(t, analyze, analyzeCatalogText(),
+		"the guide points at the analyze catalog; it must not re-inline the full per-kind text")
+	searchAST := GuideText("search_ast")
+	require.Contains(t, searchAST, "detector")
+	require.Contains(t, searchAST, `detector:"help"`)
+
+	// Aliases resolve.
+	require.Equal(t, GuideText("llm"), GuideText("providers"))
+	require.Equal(t, GuideText("features"), GuideText("capabilities"))
+
+	// Unknown topic degrades to the full guide (still useful, names topics).
+	unknown := GuideText("does-not-exist")
+	require.Contains(t, unknown, "# Gortex Guide")
+	require.Contains(t, unknown, providerMatrixMarker)
+}
+
+// TestGuideText_FormatDeepDiveStaysInInstructions enforces that the wire-
+// FORMAT deep-dive is NOT re-inlined into the guide — it lives once in the
+// server instructions (sharedParamLegend). The guide only points at it.
+func TestGuideText_FormatDeepDiveStaysInInstructions(t *testing.T) {
+	require.Contains(t, sharedParamLegend, formatDeepDiveMarker,
+		"the wire-format deep-dive must live in the server instructions")
+	require.NotContains(t, GuideText(""), formatDeepDiveMarker,
+		"the guide must point at the server-instructions format legend, not repeat it")
+}
+
+// TestGuideResource_ReturnsContent drives the MCP resource handlers.
+func TestGuideResource_ReturnsContent(t *testing.T) {
+	s := &Server{}
+	got, err := s.handleResourceGuide(context.Background(), mcp.ReadResourceRequest{
+		Params: mcp.ReadResourceParams{URI: "gortex://guide"},
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	trc, ok := got[0].(mcp.TextResourceContents)
+	require.True(t, ok)
+	require.Contains(t, trc.Text, providerMatrixMarker)
+
+	sec, err := s.handleResourceGuideSection(context.Background(), mcp.ReadResourceRequest{
+		Params: mcp.ReadResourceParams{URI: "gortex://guide/capabilities"},
+	})
+	require.NoError(t, err)
+	require.Len(t, sec, 1)
+	secText := sec[0].(mcp.TextResourceContents).Text
+	require.Contains(t, secText, "Speculative execution")
+	require.False(t, strings.Contains(secText, providerMatrixMarker),
+		"the capabilities section must not carry the provider matrix")
+}

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -45,6 +45,31 @@ func (s *Server) registerResources() {
 		s.handleResourceSchema,
 	)
 
+	// Static resource: the on-demand reference guide. The single home for
+	// content that used to be pre-paid in the installed CLAUDE.md section —
+	// the LLM-provider matrix, capabilities catalog, token-economy detail,
+	// resources list, and pointers into the analyze / search_ast catalogs.
+	s.mcpServer.AddResource(
+		mcp.NewResource(
+			"gortex://guide",
+			"Gortex Guide",
+			mcp.WithResourceDescription("On-demand reference: LLM-provider matrix, capabilities catalog, token-economy deep-dive, MCP resources, analyze/search_ast catalogs, session-start checklist. Section-addressable via gortex://guide/{topic}."),
+			mcp.WithMIMEType("text/markdown"),
+		),
+		s.handleResourceGuide,
+	)
+
+	// Template resource: a single guide section by topic keyword.
+	s.mcpServer.AddResourceTemplate(
+		mcp.NewResourceTemplate(
+			"gortex://guide/{topic}",
+			"Gortex Guide Section",
+			mcp.WithTemplateDescription("One section of the guide by topic: providers, capabilities, tokens, analyze, search_ast, resources, workflow."),
+			mcp.WithTemplateMIMEType("text/markdown"),
+		),
+		s.handleResourceGuideSection,
+	)
+
 	// Bootstrap-state resources: read-only, no args, every session
 	// hits these at startup. Same payloads as the corresponding
 	// tools; tools stay registered for back-compat.
@@ -242,6 +267,27 @@ Temporal (with temporal_kind + temporal_name):
 			URI:      req.Params.URI,
 			MIMEType: "text/plain",
 			Text:     schema,
+		},
+	}, nil
+}
+
+func (s *Server) handleResourceGuide(_ context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+	return []mcp.ResourceContents{
+		mcp.TextResourceContents{
+			URI:      req.Params.URI,
+			MIMEType: "text/markdown",
+			Text:     GuideText(""),
+		},
+	}, nil
+}
+
+func (s *Server) handleResourceGuideSection(_ context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+	topic := extractURIParam(req.Params.URI, "gortex://guide/")
+	return []mcp.ResourceContents{
+		mcp.TextResourceContents{
+			URI:      req.Params.URI,
+			MIMEType: "text/markdown",
+			Text:     GuideText(topic),
 		},
 	}, nil
 }


### PR DESCRIPTION
## What

\`gortex install\` writes agent guidance (CLAUDE.md sections, skill/sub-agent frontmatters) that had accreted a paragraph per feature and re-stated facts the MCP schema and server instructions already carry. Every agent session pre-paid ~6.8k tokens for it. This PR gives every fact exactly one home:

- **New \`gortex://guide\` MCP resource + \`gortex guide [topic]\` CLI verb** — the on-demand home for reference content: the provider/\`ask\` delegation matrix, capabilities tour, token-economy deep-dive, MCP resources list, session-start checklist. Relocated verbatim, never deleted; the analyze/search_ast catalogs stay in \`kind:"help"\` / \`detector:"help"\` / \`gortex://schema\` and the guide points at them.
- **The generated CLAUDE.md section shrinks to the policy core**: the mandatory graph-tools mapping table + hooks note, the memory-workflow triggers (their only home), and pointer lines to the guide and \`tools_search\`. The global and project sections no longer duplicate each other — policy is global; the project block carries only project-specific facts.
- **Skill/sub-agent frontmatters trimmed to one line each** (bodies unchanged).
- **Idempotent migration**: re-running \`gortex install\` replaces the old fat section in place, preserving surrounding user content (fixture-tested).
- **Ceiling gates**: the generated section (≤6,656 B) and skills eager total (≤2,560 B) are asserted in tests, so the guidance cannot silently regrow — same pattern as the tools/list byte gates.

## Numbers (bytes; ~tokens at 4.4 B/tok)

| surface | before | after |
|---|---|---|
| global CLAUDE.md section | 18,791 B (~4.3k tok) | 4,308 B (~1.0k tok) |
| skills eager frontmatter (21) | 9,234 B | 2,147 B |
| sub-agent frontmatter (2) | 1,751 B | 1,203 B |
| project CLAUDE.md block | 44,773 B | 3,254 B |
| **installed eager total** | ~29.8 KB (~6.8k tok) | **~7.7 KB (~1.7k tok)** |

## Verification

Single-home spot-check tests (provider matrix only in the guide; catalogs only in help/schema; wire-format deep-dive only in server instructions); fat→slim migration fixture with user content preserved; render goldens regenerated; skill-drift check, golangci-lint, and \`go test -race\` green on all changed packages.

Note for reviewers: \`TestSchemaParityAudit\` (internal/graph) false-fails when run from a checkout under a \`/worktrees/\` path — its path filter skips the whole tree. It passes on a normal checkout; this branch touches no internal/graph files.