### PR TITLE
perf(store_sqlite): promote semantic_type/semantic_source to real node columns

### DIFF
--- a/internal/graph/store.go
+++ b/internal/graph/store.go
@@ -1054,6 +1054,20 @@ type EnrichmentStateStore interface {
 	SetEnrichmentState(state EnrichmentState) error
 }
 
+// LightNodeReader is an optional store capability: a repo-scoped node scan
+// that skips decoding each row's opaque meta blob, populating only struct
+// columns and the already-promoted meta keys (signature/visibility/doc/
+// external/return_type/.../semantic_type/semantic_source) into Meta. Safe
+// for read-only structural use (file path, kind, position, the promoted
+// stamp check) — a node fetched this way must NEVER be round-tripped back
+// through AddNode/AddBatch, since any non-promoted meta content still
+// living in the row's blob would be silently discarded on write. Backends
+// with no separate blob (nothing to skip) need not implement it — callers
+// fall back to the full scan.
+type LightNodeReader interface {
+	GetRepoNodesLight(repoPrefix string) []*Node
+}
+
 // EdgePersister is an optional capability backends MAY implement to
 // durably rewrite the mutable attribute columns (Confidence,
 // ConfidenceLabel, Origin, Tier, Meta) of an edge already present in the

--- a/internal/graph/store_sqlite/bulk_load.go
+++ b/internal/graph/store_sqlite/bulk_load.go
@@ -50,6 +50,11 @@ var bulkDroppableIndexes = []bulkDroppableIndex{
 	{"edges_by_from", `CREATE INDEX IF NOT EXISTS edges_by_from ON edges(from_id, kind)`},
 	{"edges_by_to", `CREATE INDEX IF NOT EXISTS edges_by_to ON edges(to_id, kind)`},
 	{"edges_by_kind", `CREATE INDEX IF NOT EXISTS edges_by_kind ON edges(kind)`},
+	// Partial index over exactly the not-yet-semantically-stamped nodes per
+	// repo. Stays small in steady state (most nodes end up stamped), so a
+	// future "unstamped nodes in this repo" query is an index scan over the
+	// residual few instead of a full-table decode of every node's meta.
+	{"nodes_semantic_pending", `CREATE INDEX IF NOT EXISTS nodes_semantic_pending ON nodes(repo_prefix) WHERE semantic_type IS NULL`},
 }
 
 // bulkCacheSizeKiB is the page cache the fast path requests on its pinned

--- a/internal/graph/store_sqlite/light_node_reader_test.go
+++ b/internal/graph/store_sqlite/light_node_reader_test.go
@@ -1,0 +1,76 @@
+package store_sqlite
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// TestGetRepoNodesLight verifies the graph.LightNodeReader fast path
+// matches GetRepoNodes on IDs and promoted-field values, stays scoped to
+// repo_prefix, and never surfaces non-promoted meta content — the
+// invariant the enrichment hover-candidate refetch depends on for
+// correctness (see EnrichRepoContext's use of repoScopedNodesLight).
+func TestGetRepoNodesLight(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "light.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	s.AddNode(&graph.Node{
+		ID: "repoA/f.go::Stamped", Kind: graph.KindFunction, Name: "Stamped",
+		FilePath: "repoA/f.go", RepoPrefix: "repoA",
+		Meta: map[string]any{
+			"semantic_type":   "string",
+			"semantic_source": "lsp-gopls",
+			"doc":             "docs",
+			"complexity":      7, // non-promoted
+		},
+	})
+	s.AddNode(&graph.Node{
+		ID: "repoA/f.go::Unstamped", Kind: graph.KindFunction, Name: "Unstamped",
+		FilePath: "repoA/f.go", RepoPrefix: "repoA",
+	})
+	s.AddNode(&graph.Node{
+		ID: "repoB/g.go::Other", Kind: graph.KindFunction, Name: "Other",
+		FilePath: "repoB/g.go", RepoPrefix: "repoB",
+	})
+
+	var _ graph.LightNodeReader = s // compile-time capability check
+
+	full := s.GetRepoNodes("repoA")
+	light := s.GetRepoNodesLight("repoA")
+	if len(light) != len(full) {
+		t.Fatalf("light returned %d nodes, full returned %d", len(light), len(full))
+	}
+
+	byID := make(map[string]*graph.Node, len(light))
+	for _, n := range light {
+		byID[n.ID] = n
+	}
+
+	stamped, ok := byID["repoA/f.go::Stamped"]
+	if !ok {
+		t.Fatal("light scan missing the stamped node")
+	}
+	assertType[string](t, stamped.Meta, "semantic_type", "string")
+	assertType[string](t, stamped.Meta, "semantic_source", "lsp-gopls")
+	assertType[string](t, stamped.Meta, "doc", "docs")
+	if _, ok := stamped.Meta["complexity"]; ok {
+		t.Errorf("light scan must not surface non-promoted meta, got complexity=%v", stamped.Meta["complexity"])
+	}
+
+	unstamped, ok := byID["repoA/f.go::Unstamped"]
+	if !ok {
+		t.Fatal("light scan missing the unstamped node")
+	}
+	if _, ok := unstamped.Meta["semantic_type"]; ok {
+		t.Error("unstamped node must not carry a semantic_type key")
+	}
+
+	if _, ok := byID["repoB/g.go::Other"]; ok {
+		t.Error("light scan crossed repo_prefix scope")
+	}
+}

--- a/internal/graph/store_sqlite/meta_json.go
+++ b/internal/graph/store_sqlite/meta_json.go
@@ -752,6 +752,8 @@ var promotedMetaColumns = []struct {
 	{"is_exported", "is_exported INTEGER"},
 	{"updated_at", "updated_at INTEGER"},
 	{"data_class", "data_class TEXT"},
+	{"semantic_type", "semantic_type TEXT"},
+	{"semantic_source", "semantic_source TEXT"},
 }
 
 // structNodeColumns are typed nodes columns read and written directly from
@@ -771,6 +773,7 @@ var structNodeColumns = []struct {
 // type and stayed in the blob).
 type promotedNodeMeta struct {
 	sig, vis, doc, returnType, dataClass                sql.NullString
+	semanticType, semanticSource                        sql.NullString
 	external, isAsync, isStatic, isAbstract, isExported sql.NullBool
 	updatedAt                                           sql.NullInt64
 }
@@ -876,6 +879,14 @@ func extractPromotedMeta(m map[string]any) (p promotedNodeMeta, rest map[string]
 			if nv, ok := str(v); ok {
 				p.dataClass, promoted = nv, true
 			}
+		case "semantic_type":
+			if nv, ok := str(v); ok {
+				p.semanticType, promoted = nv, true
+			}
+		case "semantic_source":
+			if nv, ok := str(v); ok {
+				p.semanticSource, promoted = nv, true
+			}
 		case "external":
 			if nv, ok := boolean(v); ok {
 				p.external, promoted = nv, true
@@ -932,7 +943,8 @@ func metaToInt64(v any) (int64, bool) {
 // survives.
 func restorePromotedMeta(n *graph.Node, p promotedNodeMeta) {
 	if !p.sig.Valid && !p.vis.Valid && !p.doc.Valid && !p.returnType.Valid &&
-		!p.dataClass.Valid && !p.external.Valid && !p.isAsync.Valid &&
+		!p.dataClass.Valid && !p.semanticType.Valid && !p.semanticSource.Valid &&
+		!p.external.Valid && !p.isAsync.Valid &&
 		!p.isStatic.Valid && !p.isAbstract.Valid && !p.isExported.Valid &&
 		!p.updatedAt.Valid {
 		return
@@ -954,6 +966,12 @@ func restorePromotedMeta(n *graph.Node, p promotedNodeMeta) {
 	}
 	if p.dataClass.Valid {
 		n.Meta["data_class"] = p.dataClass.String
+	}
+	if p.semanticType.Valid {
+		n.Meta["semantic_type"] = p.semanticType.String
+	}
+	if p.semanticSource.Valid {
+		n.Meta["semantic_source"] = p.semanticSource.String
 	}
 	if p.external.Valid {
 		n.Meta["external"] = p.external.Bool

--- a/internal/graph/store_sqlite/meta_promoted_test.go
+++ b/internal/graph/store_sqlite/meta_promoted_test.go
@@ -140,6 +140,57 @@ func TestPromotedColumns_NewColumns(t *testing.T) {
 	}
 }
 
+// TestPromotedColumns_SemanticType verifies semantic_type/semantic_source —
+// promoted alongside signature/visibility/etc. so enrichment can query the
+// unstamped subset by column instead of decoding every node's meta blob —
+// round-trip through their columns and out of the JSON blob.
+func TestPromotedColumns_SemanticType(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "p.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	s.AddNode(&graph.Node{
+		ID: "f.go::T", Kind: graph.KindFunction, Name: "T", FilePath: "f.go",
+		Meta: map[string]any{
+			"semantic_type":   "string",
+			"semantic_source": "lsp-gopls",
+			"complexity":      5, // non-promoted — must stay in the blob
+		},
+	})
+
+	n := s.GetNode("f.go::T")
+	if n == nil {
+		t.Fatal("GetNode returned nil")
+	}
+	assertType[string](t, n.Meta, "semantic_type", "string")
+	assertType[string](t, n.Meta, "semantic_source", "lsp-gopls")
+	assertType[int](t, n.Meta, "complexity", 5)
+
+	var st, ss sql.NullString
+	var blob []byte
+	row := s.db.QueryRow(`SELECT semantic_type, semantic_source, meta FROM nodes WHERE id=?`, "f.go::T")
+	if err := row.Scan(&st, &ss, &blob); err != nil {
+		t.Fatal(err)
+	}
+	if !st.Valid || st.String != "string" {
+		t.Errorf("semantic_type column = %+v", st)
+	}
+	if !ss.Valid || ss.String != "lsp-gopls" {
+		t.Errorf("semantic_source column = %+v", ss)
+	}
+	blobStr := string(blob)
+	for _, k := range []string{"semantic_type", "semantic_source"} {
+		if strings.Contains(blobStr, k) {
+			t.Errorf("blob still contains promoted key %q: %s", k, blobStr)
+		}
+	}
+	if !strings.Contains(blobStr, "complexity") {
+		t.Errorf("blob missing non-promoted key complexity: %s", blobStr)
+	}
+}
+
 // TestPromotedColumns_ExternalFalse guards the NULL-vs-false distinction:
 // a stored false must round-trip as false, not vanish.
 func TestPromotedColumns_ExternalFalse(t *testing.T) {

--- a/internal/graph/store_sqlite/store.go
+++ b/internal/graph/store_sqlite/store.go
@@ -601,6 +601,35 @@ func scanNode(scanner interface {
 	return &n, nil
 }
 
+// scanNodeLight scans the same columns as scanNode minus the trailing meta
+// blob — no decodeMeta call, so no JSON/gob parse per row. Promoted columns
+// still restore into Meta via restorePromotedMeta, so any caller that only
+// reads a promoted key (signature, visibility, ..., semantic_type) sees the
+// exact values scanNode would produce; only non-promoted content still
+// living in the row's blob is absent. See graph.LightNodeReader: a node
+// from this scan must never be round-tripped back through AddNode/AddBatch.
+func scanNodeLight(scanner interface {
+	Scan(...any) error
+}) (*graph.Node, error) {
+	var (
+		n graph.Node
+		p promotedNodeMeta
+	)
+	err := scanner.Scan(
+		&n.ID, &n.Kind, &n.Name, &n.QualName, &n.FilePath,
+		&n.StartLine, &n.EndLine, &n.StartColumn, &n.EndColumn, &n.Language,
+		&n.RepoPrefix, &n.WorkspaceID, &n.ProjectID,
+		&p.sig, &p.vis, &p.doc, &p.external, &p.returnType,
+		&p.isAsync, &p.isStatic, &p.isAbstract, &p.isExported, &p.updatedAt,
+		&p.dataClass, &p.semanticType, &p.semanticSource,
+	)
+	if err != nil {
+		return nil, err
+	}
+	restorePromotedMeta(&n, p)
+	return &n, nil
+}
+
 func scanEdge(scanner interface {
 	Scan(...any) error
 }) (*graph.Edge, error) {
@@ -1258,6 +1287,30 @@ func (s *Store) GetRepoNonContentNodes(repoPrefix string) []*graph.Node {
 		return s.scanNodeQuery(`SELECT ` + lookupNodeCols + ` FROM nodes WHERE ` + filter)
 	}
 	return s.scanNodeQuery(`SELECT `+lookupNodeCols+` FROM nodes WHERE repo_prefix = ? AND `+filter, repoPrefix)
+}
+
+// GetRepoNodesLight is the graph.LightNodeReader fast path: repo_prefix
+// still uses the nodes_by_repo index, but the meta column is left out of
+// the projection entirely, so a repo's already-enriched majority never
+// crosses the driver boundary as a blob to decode. See LightNodeReader's
+// doc for the read-only-use invariant this projection depends on.
+func (s *Store) GetRepoNodesLight(repoPrefix string) []*graph.Node {
+	rows, err := s.db.Query(`SELECT `+lookupNodeColsLight+` FROM nodes WHERE repo_prefix = ?`, repoPrefix)
+	if err != nil {
+		panicOnFatal(err)
+		return nil
+	}
+	defer rows.Close()
+	var out []*graph.Node
+	for rows.Next() {
+		n, err := scanNodeLight(rows)
+		if err != nil {
+			panicOnFatal(err)
+			return out
+		}
+		out = append(out, n)
+	}
+	return out
 }
 
 // scanNodeQuery runs an ad-hoc node SELECT (columns = lookupNodeCols) and

--- a/internal/graph/store_sqlite/store.go
+++ b/internal/graph/store_sqlite/store.go
@@ -290,6 +290,15 @@ func openWith(path string, current int, migrations []schemaMigration, allowRebui
 		_ = db.Close()
 		return nil, fmt.Errorf("sqlite schema: %w", err)
 	}
+	// Add the promoted node columns to databases created before they
+	// existed (CREATE TABLE IF NOT EXISTS won't alter an existing table).
+	// Must run before the droppable-index loop below — nodes_semantic_pending
+	// references a promoted column — and before prepare(), whose node INSERT
+	// references them too.
+	if err := ensureNodeColumns(db); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("sqlite node columns: %w", err)
+	}
 	// Create the droppable secondary indexes from the shared set so their
 	// initial-creation DDL is byte-identical to the DDL the bulk-load fast
 	// path rebuilds them with (BeginBulkLoad drops these, FlushBulk
@@ -311,14 +320,6 @@ func openWith(path string, current int, migrations []schemaMigration, allowRebui
 		_ = db.Close()
 		return nil, fmt.Errorf("sqlite edges_external index: %w", err)
 	}
-	// Add the promoted node columns to databases created before they
-	// existed (CREATE TABLE IF NOT EXISTS won't alter an existing table).
-	// Must run before prepare(), whose node INSERT references them.
-	if err := ensureNodeColumns(db); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("sqlite node columns: %w", err)
-	}
-
 	// Backfill the FTS rowid sidecar for databases built before it existed,
 	// so the first incremental UpsertSymbolFTS on an already-indexed symbol
 	// can do its O(log n) docid delete instead of leaking a duplicate row.
@@ -467,7 +468,7 @@ func (s *Store) prepare() error {
 	const nodeCols = lookupNodeCols
 
 	prep(&s.stmtInsertNode,
-		`INSERT OR REPLACE INTO nodes (`+nodeCols+`) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`)
+		`INSERT OR REPLACE INTO nodes (`+nodeCols+`) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`)
 	prep(&s.stmtGetNode,
 		`SELECT `+nodeCols+` FROM nodes WHERE id = ?`)
 	prep(&s.stmtGetNodeByQual,
@@ -581,7 +582,7 @@ func scanNode(scanner interface {
 		&n.RepoPrefix, &n.WorkspaceID, &n.ProjectID,
 		&p.sig, &p.vis, &p.doc, &p.external, &p.returnType,
 		&p.isAsync, &p.isStatic, &p.isAbstract, &p.isExported, &p.updatedAt,
-		&p.dataClass, &metaBlob,
+		&p.dataClass, &p.semanticType, &p.semanticSource, &metaBlob,
 	)
 	if err != nil {
 		return nil, err
@@ -691,7 +692,7 @@ func (s *Store) insertNodeLocked(stmt *sql.Stmt, n *graph.Node) error {
 		n.RepoPrefix, n.WorkspaceID, n.ProjectID,
 		p.sig, p.vis, p.doc, p.external, p.returnType,
 		p.isAsync, p.isStatic, p.isAbstract, p.isExported, p.updatedAt,
-		p.dataClass, metaBlob,
+		p.dataClass, p.semanticType, p.semanticSource, metaBlob,
 	)
 	return err
 }

--- a/internal/graph/store_sqlite/store_lookups.go
+++ b/internal/graph/store_sqlite/store_lookups.go
@@ -19,6 +19,13 @@ import (
 // return_type/is_async/is_static/is_abstract/is_exported/updated_at/
 // data_class/semantic_type/semantic_source) precede meta.
 const lookupNodeCols = `id, kind, name, qual_name, file_path, start_line, end_line, start_column, end_column, language, repo_prefix, workspace_id, project_id, signature, visibility, doc, external, return_type, is_async, is_static, is_abstract, is_exported, updated_at, data_class, semantic_type, semantic_source, meta`
+
+// lookupNodeColsLight is lookupNodeCols without the trailing meta column —
+// the projection GetRepoNodesLight uses so a repo-scoped scan never
+// transfers or decodes a single blob. Derived, not hand-duplicated, so it
+// can never drift out of sync with lookupNodeCols / scanNode.
+var lookupNodeColsLight = strings.TrimSuffix(lookupNodeCols, ", meta")
+
 const lookupEdgeCols = `from_id, to_id, kind, file_path, line, confidence, confidence_label, origin, tier, cross_repo, meta`
 
 // FindNodesByNameContaining returns nodes whose Name contains substr,

--- a/internal/graph/store_sqlite/store_lookups.go
+++ b/internal/graph/store_sqlite/store_lookups.go
@@ -17,8 +17,8 @@ import (
 // scanNode. The struct columns (start_column/end_column) sit with the line
 // range; the promoted meta columns (signature/visibility/doc/external/
 // return_type/is_async/is_static/is_abstract/is_exported/updated_at/
-// data_class) precede meta.
-const lookupNodeCols = `id, kind, name, qual_name, file_path, start_line, end_line, start_column, end_column, language, repo_prefix, workspace_id, project_id, signature, visibility, doc, external, return_type, is_async, is_static, is_abstract, is_exported, updated_at, data_class, meta`
+// data_class/semantic_type/semantic_source) precede meta.
+const lookupNodeCols = `id, kind, name, qual_name, file_path, start_line, end_line, start_column, end_column, language, repo_prefix, workspace_id, project_id, signature, visibility, doc, external, return_type, is_async, is_static, is_abstract, is_exported, updated_at, data_class, semantic_type, semantic_source, meta`
 const lookupEdgeCols = `from_id, to_id, kind, file_path, line, confidence, confidence_label, origin, tier, cross_repo, meta`
 
 // FindNodesByNameContaining returns nodes whose Name contains substr,

--- a/internal/semantic/lsp/enrich_light_scan_test.go
+++ b/internal/semantic/lsp/enrich_light_scan_test.go
@@ -1,0 +1,100 @@
+package lsp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/semantic"
+)
+
+// TestLSP_Provider_SkipsAlreadyStampedNodes_LightScan mirrors
+// TestLSP_Provider_SkipsAlreadyStampedNodes but backs the graph with a real
+// sqlite Store, which implements graph.LightNodeReader — exercising the
+// repoScopedNodesLight branch the in-memory-graph test never reaches. The
+// critical extra assertion: a non-promoted meta key present on the fresh
+// node before enrichment must survive the light-scan → candidate refetch
+// (GetNodesByIDs) → hover-stamp → AddBatch round trip. Losing it would mean
+// the light scan's stripped-down Meta got persisted back in place of the
+// full one — silently discarding whatever else the graph had recorded for
+// that node.
+func TestLSP_Provider_SkipsAlreadyStampedNodes_LightScan(t *testing.T) {
+	t.Setenv("GORTEX_LSP_SWEEP", "full")
+	repoRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repoRoot, "main.go"),
+		[]byte("package main\n\nfunc F() string { return \"hi\" }\n\nfunc G() int { return 0 }\n"),
+		0o644,
+	))
+
+	var hoverCalls atomic.Int64
+	server := newFakeLSPServer()
+	server.handle("textDocument/hover", func(params json.RawMessage) (any, *jsonRPCError) {
+		hoverCalls.Add(1)
+		return map[string]any{
+			"contents": map[string]any{"kind": "plaintext", "value": "func G() int"},
+		}, nil
+	})
+
+	p, cleanup := providerWithFakeServer(t, server, []string{"go"})
+	defer cleanup()
+
+	g, err := store_sqlite.Open(filepath.Join(t.TempDir(), "enrich.sqlite"))
+	require.NoError(t, err)
+	defer g.Close()
+	var _ graph.LightNodeReader = g // the branch this test targets
+
+	// F is already stamped by a prior pass — must not be re-hovered.
+	g.AddNode(&graph.Node{
+		ID: "main.go::F", Kind: graph.KindFunction, Name: "F",
+		FilePath: "main.go", StartLine: 3, EndLine: 3, Language: "go",
+		Meta: map[string]any{"semantic_type": "func F() string", "semantic_source": "lsp-prior"},
+	})
+	// G is fresh — must be hovered and stamped. Carries a non-promoted meta
+	// key that has nothing to do with enrichment, standing in for whatever
+	// else the graph recorded for this node (e.g. a DI-contract tag).
+	g.AddNode(&graph.Node{
+		ID: "main.go::G", Kind: graph.KindFunction, Name: "G",
+		FilePath: "main.go", StartLine: 5, EndLine: 5, Language: "go",
+		Meta: map[string]any{"unrelated_tag": "keep-me"},
+	})
+
+	done := make(chan *semantic.EnrichResult, 1)
+	go func() {
+		res, err := p.Enrich(g, repoRoot)
+		require.NoError(t, err)
+		done <- res
+	}()
+	var res *semantic.EnrichResult
+	select {
+	case res = <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Enrich timed out")
+	}
+
+	assert.Equal(t, int64(1), hoverCalls.Load(), "only the fresh node is hovered")
+	assert.Equal(t, 1, res.HoverCandidates, "post-filter candidate count excludes the stamped node")
+	assert.Equal(t, 2, res.SymbolsTotal)
+	assert.Equal(t, 2, res.SymbolsCovered)
+
+	// F keeps its prior stamp (a re-hover would have overwritten it).
+	fNode := g.GetNode("main.go::F")
+	assert.Equal(t, "func F() string", fNode.Meta["semantic_type"])
+	assert.Equal(t, "lsp-prior", fNode.Meta["semantic_source"])
+
+	// G is now stamped by this pass, AND its pre-existing non-promoted meta
+	// key survived the light-scan candidate's full refetch + AddBatch.
+	gNode := g.GetNode("main.go::G")
+	assert.Equal(t, "func G() int", gNode.Meta["semantic_type"])
+	assert.Equal(t, "lsp-fake-lsp", gNode.Meta["semantic_source"])
+	assert.Equal(t, "keep-me", gNode.Meta["unrelated_tag"],
+		"non-promoted meta present before enrichment must survive the light-scan round trip")
+}

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -606,9 +606,20 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 	//     original ambiguous-edge target scan matched any repo+language source
 	//     node (file/import edges like EdgeImports included), so the
 	//     references-confirm pass must keep matching those too.
-	repoNodes := p.repoScopedNodes(g, repoPrefix)
+	//
+	// repoNodes is fetched via repoScopedNodesLight: on a backend with the
+	// optional LightNodeReader fast path (sqlite), the meta blob is never
+	// decoded for the repo's already-stamped majority. langAllByID only
+	// ever needs structural fields (file path, kind, position) for the
+	// confirm pass below, so it's built directly from whatever repoNodes
+	// holds. langNodes' candidates, in contrast, get round-tripped through
+	// AddBatch once hovered (see flushFile), so on a light scan a candidate
+	// is never added there directly — its ID is queued and the FULL node
+	// (with any non-promoted meta intact) is re-fetched afterward.
+	repoNodes, lightScan := p.repoScopedNodesLight(g, repoPrefix)
 	langAllByID := make(map[string]*graph.Node, len(repoNodes))
 	langNodes := make([]*graph.Node, 0, len(repoNodes))
+	var candidateIDs []string
 	// Count symbol nodes a prior pass already stamped with a semantic type.
 	// Stamps persist in node Meta across restarts, so on a warm restart of an
 	// unchanged repo — or a changed repo where only a few files moved — most
@@ -635,7 +646,19 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 			skippedAlreadyStamped++
 			continue
 		}
+		if lightScan {
+			candidateIDs = append(candidateIDs, n.ID)
+			continue
+		}
 		langNodes = append(langNodes, n)
+	}
+	if len(candidateIDs) > 0 {
+		full := g.GetNodesByIDs(candidateIDs)
+		for _, id := range candidateIDs {
+			if n := full[id]; n != nil {
+				langNodes = append(langNodes, n)
+			}
+		}
 	}
 
 	// Collect AMBIGUOUS edges (confidence < 1.0) whose source is one of this
@@ -3097,6 +3120,20 @@ func (p *Provider) repoScopedNodes(g graph.Store, repoPrefix string) []*graph.No
 		return g.AllNodes()
 	}
 	return nodes
+}
+
+// repoScopedNodesLight fetches this repo's nodes via the store's optional
+// LightNodeReader fast path when available — skipping the meta-blob decode
+// for the majority of nodes that are already fully enriched — falling back
+// to the full repoScopedNodes scan otherwise. The bool result reports
+// whether the light path was taken: when true, the returned nodes must not
+// be round-tripped back through AddBatch as-is (see graph.LightNodeReader);
+// the caller re-fetches in full whatever subset it intends to stamp.
+func (p *Provider) repoScopedNodesLight(g graph.Store, repoPrefix string) ([]*graph.Node, bool) {
+	if lr, ok := g.(graph.LightNodeReader); ok {
+		return lr.GetRepoNodesLight(repoPrefix), true
+	}
+	return p.repoScopedNodes(g, repoPrefix), false
 }
 
 // repoScopedEdges returns the edges whose source node belongs to


### PR DESCRIPTION
## Summary

**Commit 1 — promote the column:**
- Promotes the `semantic_type` / `semantic_source` node-meta keys to real, indexed sqlite columns, following the existing promoted-column pattern used for `signature`/`visibility`/`doc`/`external`/`return_type`/etc.
- Adds a partial index (`nodes_semantic_pending ON nodes(repo_prefix) WHERE semantic_type IS NULL`).
- Fixes an ordering bug found while testing: `ensureNodeColumns` ran *after* the droppable-index creation loop in `openWith`, so the new index failed with "no such column" on a fresh database. Moved it earlier.
- `Node.Meta["semantic_type"]` reads/writes are unchanged — sqlite backend storage only, not the `Store` interface or any caller.

**Commit 2 — use the column to load way less data:**
- `EnrichRepoContext` (the LSP hover-enrichment pass) previously decoded every repo node's meta blob just to filter down to the handful needing a hover — on a large, mostly-already-enriched repo that's ~90% wasted decode work every warm restart.
- Adds `graph.LightNodeReader`, an optional store capability (sqlite only, mirroring the existing `NonContentNodeReader` pattern) that scans a repo's nodes with the meta column left out of the projection entirely.
- `langAllByID` (read-only file-path/position lookups for the reference-confirm pass) is built directly from the light scan — safe, since it's never written back.
- `langNodes`' candidates are different: they get round-tripped through `AddBatch` once hovered, so a light node is never added there as-is (that would silently discard any non-promoted meta content on write-back) — its ID is queued and the full node is re-fetched via the existing batched `GetNodesByIDs` before entering `langNodes`.
- Backends without the capability (the in-memory graph) take the unchanged full-scan path byte-for-byte — zero behavior or perf change there.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/graph/... ./internal/semantic/... ./internal/indexer/...`
- [x] `go test ./internal/graph/... ./internal/semantic/... ./internal/indexer/... -count=1` (2589 passed)
- [x] `go test -race ./internal/graph/... ./internal/semantic/... ./internal/indexer/... -count=1` (1796 passed)
- [x] New `TestGetRepoNodesLight`: light scan matches full scan on IDs/promoted fields, never surfaces non-promoted meta, stays scoped to `repo_prefix`
- [x] New `TestLSP_Provider_SkipsAlreadyStampedNodes_LightScan`: end-to-end enrichment against a real sqlite store, asserting a non-promoted meta key on the hover candidate survives the light-scan → refetch → `AddBatch` round trip