### PR TITLE
Reduce unresolved graph edges: dataflow placeholder binding + lone-method guard

### DIFF
--- a/internal/graph/store_sqlite/store.go
+++ b/internal/graph/store_sqlite/store.go
@@ -144,6 +144,7 @@ type Store struct {
 	stmtUpdateEdgeAttrs  *sql.Stmt
 	stmtSelectEdgeOrigin *sql.Stmt
 	stmtDeleteEdgeByKey  *sql.Stmt
+	stmtEdgeExists       *sql.Stmt
 
 	stmtSelectFileNodeIDs *sql.Stmt
 	stmtSelectRepoNodeIDs *sql.Stmt
@@ -439,6 +440,7 @@ func (s *Store) Close() error {
 		s.stmtRepoEdges,
 		s.stmtAllEdges, s.stmtEdgeCount, s.stmtRemoveEdge,
 		s.stmtUpdateEdgeOrigin, s.stmtUpdateEdgeAttrs, s.stmtSelectEdgeOrigin, s.stmtDeleteEdgeByKey,
+		s.stmtEdgeExists,
 		s.stmtSelectFileNodeIDs, s.stmtSelectRepoNodeIDs,
 		s.stmtDeleteNodeByFile, s.stmtDeleteNodeByRepo,
 	}
@@ -550,6 +552,8 @@ func (s *Store) prepare() error {
 		`UPDATE edges SET confidence = ?, confidence_label = ?, origin = ?, tier = ?, meta = ? WHERE from_id = ? AND to_id = ? AND kind = ? AND file_path = ? AND line = ?`)
 	prep(&s.stmtDeleteEdgeByKey,
 		`DELETE FROM edges WHERE from_id = ? AND to_id = ? AND kind = ? AND file_path = ? AND line = ?`)
+	prep(&s.stmtEdgeExists,
+		`SELECT 1 FROM edges WHERE from_id = ? AND to_id = ? AND kind = ? AND file_path = ? AND line = ? LIMIT 1`)
 
 	prep(&s.stmtSelectFileNodeIDs,
 		`SELECT id FROM nodes WHERE file_path = ?`)
@@ -1337,6 +1341,26 @@ func (s *Store) scanNodeQuery(query string, args ...any) []*graph.Node {
 
 func (s *Store) GetOutEdges(nodeID string) []*graph.Edge {
 	return s.queryEdges(s.stmtOutEdges, nodeID)
+}
+
+// EdgeExists reports whether an edge with exactly this identity is present --
+// (from, to, kind, file_path, line) is the edges UNIQUE key, so this is a
+// single indexed point lookup: no row decode, no Meta gob, no per-edge
+// allocation, unlike GetOutEdges. The resolver's liveness guard
+// (edgeStillLive) calls this once per applied edge on the cold/full pass; the
+// difference from scanning + gob-decoding all of `from`'s out-edges is a
+// dominant share of resolve cost on a large graph.
+func (s *Store) EdgeExists(from, to string, kind graph.EdgeKind, filePath string, line int) bool {
+	var one int
+	err := s.stmtEdgeExists.QueryRow(from, to, string(kind), filePath, line).Scan(&one)
+	if err == sql.ErrNoRows {
+		return false
+	}
+	if err != nil {
+		panicOnFatal(err)
+		return false
+	}
+	return true
 }
 
 // GetOutEdgesLight returns a node's out-edges without decoding the

--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -834,26 +834,34 @@ func (mi *MultiIndexer) RunGlobalGraphPasses(ctx context.Context) {
 	}
 	reporter := progress.FromContext(ctx)
 	r := resolver.New(mi.graph)
-	if added := r.InferImplements(); added > 0 {
-		mi.logger.Info("inferred implements (global)", zap.Int("added", added))
-	}
-	if added := r.InferOverrides(); added > 0 {
-		mi.logger.Info("inferred overrides (global)", zap.Int("added", added))
-	}
+	// Unconditional per-sub-pass timing. These global passes run serially and
+	// were previously logged only when a pass emitted edges, so a slow but
+	// low-yield pass left no breadcrumb — the source of the multi-minute
+	// "silent" span after resolve on a cold index.
+	globalStart := time.Now()
+	implStart := time.Now()
+	implAdded := r.InferImplements()
+	mi.logger.Info("global pass: infer implements",
+		zap.Int("added", implAdded),
+		zap.Duration("elapsed", time.Since(implStart)))
+	overStart := time.Now()
+	overAdded := r.InferOverrides()
+	mi.logger.Info("global pass: infer overrides",
+		zap.Int("added", overAdded),
+		zap.Duration("elapsed", time.Since(overStart)))
+	testStart := time.Now()
 	marked, emitted := markTestSymbolsAndEmitEdges(mi.graph)
-	if marked > 0 || emitted > 0 {
-		mi.logger.Info("test edges emitted (global)",
-			zap.Int("test_symbols", marked),
-			zap.Int("edges", emitted),
-		)
-	}
-	if re, ep, fa := synthesizeCapabilityEdges(mi.graph); re > 0 || ep > 0 || fa > 0 {
-		mi.logger.Info("capability edges emitted (global)",
-			zap.Int("reads_env", re),
-			zap.Int("executes_process", ep),
-			zap.Int("accesses_field", fa),
-		)
-	}
+	mi.logger.Info("global pass: test edges",
+		zap.Int("test_symbols", marked),
+		zap.Int("edges", emitted),
+		zap.Duration("elapsed", time.Since(testStart)))
+	capStart := time.Now()
+	capRe, capEp, capFa := synthesizeCapabilityEdges(mi.graph)
+	mi.logger.Info("global pass: capability edges",
+		zap.Int("reads_env", capRe),
+		zap.Int("executes_process", capEp),
+		zap.Int("accesses_field", capFa),
+		zap.Duration("elapsed", time.Since(capStart)))
 	// Clone detection is PER-REPOSITORY: each tracked repo gets its own
 	// finalise + detect over its own nodes (scoped by RepoPrefix), so no
 	// cross-repo candidate pair is ever formed and each repo's boilerplate
@@ -940,30 +948,32 @@ func (mi *MultiIndexer) RunGlobalGraphPasses(ctx context.Context) {
 	// a cross-repo synthesized call gets its parallel cross_repo_calls
 	// edge.
 	reporter.Report("framework dispatch synthesis (global)", 0, 0)
-	if rep := resolver.RunFrameworkSynthesizers(mi.graph); rep.Total > 0 {
-		mi.logger.Info("framework dispatch calls synthesized (global)",
-			zap.Int("edges", rep.Total),
-			zap.Any("per_synthesizer", rep.Per),
-		)
-	}
+	fwStart := time.Now()
+	fwRep := resolver.RunFrameworkSynthesizers(mi.graph)
+	mi.logger.Info("global pass: framework dispatch synthesis",
+		zap.Int("edges", fwRep.Total),
+		zap.Any("per_synthesizer", fwRep.Per),
+		zap.Duration("elapsed", time.Since(fwStart)))
 	// External-call placeholder synthesis (opt-in). Runs after the
 	// stub passes so only genuinely un-indexed external targets are
 	// left to materialise into call-chain terminals.
 	reporter.Report("external-call synthesis (global)", 0, 0)
-	if extCalls := resolver.SynthesizeExternalCalls(mi.graph, mi.externalCallSynthesisEnabled()); extCalls > 0 {
-		mi.logger.Info("external-call placeholders synthesized (global)",
-			zap.Int("edges", extCalls),
-		)
-	}
+	extStart := time.Now()
+	extCalls := resolver.SynthesizeExternalCalls(mi.graph, mi.externalCallSynthesisEnabled())
+	mi.logger.Info("global pass: external-call synthesis",
+		zap.Int("edges", extCalls),
+		zap.Duration("elapsed", time.Since(extStart)))
 	// Cross-repo edge layer. Runs after InferImplements / InferOverrides
 	// so the implements / extends edges they materialise across repo
 	// boundaries pick up their parallel cross_repo_* edges.
 	reporter.Report("cross-repo edges (global)", 0, 0)
-	if crossRepoEdges := resolver.DetectCrossRepoEdges(mi.graph); crossRepoEdges > 0 {
-		mi.logger.Info("cross-repo edges emitted (global)",
-			zap.Int("edges", crossRepoEdges),
-		)
-	}
+	crStart := time.Now()
+	crossRepoEdges := resolver.DetectCrossRepoEdges(mi.graph)
+	mi.logger.Info("global pass: cross-repo edges",
+		zap.Int("edges", crossRepoEdges),
+		zap.Duration("elapsed", time.Since(crStart)))
+	mi.logger.Info("global passes complete",
+		zap.Duration("total", time.Since(globalStart)))
 }
 
 // externalCallSynthesisEnabled resolves whether external-call placeholder
@@ -1384,17 +1394,23 @@ func (mi *MultiIndexer) IndexRepo(repoPrefix string) (*IndexResult, error) {
 		return nil, fmt.Errorf("repository not found: %s", repoPrefix)
 	}
 
-	// Evict existing data for this repo.
-	if mi.IsMultiRepo() {
-		mi.graph.EvictRepo(repoPrefix)
-	}
+	// Evict existing data for this repo before re-indexing. Always — a lone
+	// repo is now stored prefixed (see SetRepoPrefix below), so the eviction
+	// must clear the prefixed slice regardless of repo count.
+	mi.graph.EvictRepo(repoPrefix)
 
 	mi.configMgr.LoadWorkspaceConfig(repoPrefix, meta.RootPath)
 	cfg := mi.configMgr.GetRepoConfig(repoPrefix)
 	idx := mi.newPerRepoIndexer(cfg.Index)
-	if mi.IsMultiRepo() {
-		idx.SetRepoPrefix(repoPrefix)
-	}
+	// Always stamp the repo prefix, even when this is the only tracked repo.
+	// The multi-repo cold path (indexMultiRepo) already prefixes
+	// unconditionally; gating the single-repo re-index on repo count left the
+	// two paths producing different id / path shapes for the same repo, so
+	// adding a second repo turned the first from bare into prefixed — a lossy
+	// whole-graph rewrite. Uniform prefixing removes the single/multi data-shape
+	// split: a repo is prefixed from its first index, and adding another is
+	// purely additive.
+	idx.SetRepoPrefix(repoPrefix)
 	entry := mi.configMgr.Global().FindRepoByPrefix(repoPrefix)
 	idx.SetWorkspaceID(resolveWorkspaceID(entry, cfg, repoPrefix))
 	idx.SetProjectID(resolveProjectID(entry, cfg, repoPrefix))

--- a/internal/resolver/cross_pkg_guard.go
+++ b/internal/resolver/cross_pkg_guard.go
@@ -292,9 +292,14 @@ func (r *Resolver) loneMemberDefnKeep(target *graph.Node, e *graph.Edge, oldTo s
 // loneMemberLang reports whether a lone in-repo method definition is safe to
 // keep against the cross-package guard for the given language. Limited to the
 // statically-typed languages where exactly one same-named member is
-// structurally unambiguous.
+// structurally unambiguous; TS / Python / JS duck typing makes a same-name
+// coincidence likelier, so their guard revert stays.
 func loneMemberLang(lang string) bool {
-	return lang == "java" || lang == "go"
+	switch lang {
+	case "java", "go", "rust", "csharp", "kotlin", "scala":
+		return true
+	}
+	return false
 }
 
 // hasInRepoType reports whether the repo defines a type/interface named

--- a/internal/resolver/cross_pkg_guard.go
+++ b/internal/resolver/cross_pkg_guard.go
@@ -102,13 +102,14 @@ func (r *Resolver) guardCrossPackageCallEdges(jobs []reindexJob, closure map[str
 		if r.targetImportReachable(callerFile, callerNode, target, closure) {
 			continue
 		}
-		// A Java member call whose only in-repo definition of the name is
-		// this target is not a cross-package mis-guess — there is nowhere
-		// else the call could bind. Java's same-package callers import
-		// nothing and inherited-method calls (owner.getId() → BaseEntity.getId
-		// two packages up) never name the declaring package, so the import
-		// closure structurally misses them. Keep the resolution.
-		if r.javaLoneMemberDefnKeep(target, j.edge, j.oldTo) {
+		// A member call whose only in-repo definition of the name is this
+		// target is not a cross-package mis-guess — there is nowhere else the
+		// call could bind. A method call carries its receiver, so it needs no
+		// import of the method's package, and inherited / indirectly-typed
+		// receivers (owner.foo() → BaseType.foo two packages up) never name the
+		// declaring package, so the import closure structurally misses them.
+		// Keep the resolution.
+		if r.loneMemberDefnKeep(target, j.edge, j.oldTo) {
 			continue
 		}
 		// Not reachable — revert to the unresolved placeholder and
@@ -237,19 +238,34 @@ func sameScopePackage(a, b *graph.Node) bool {
 	return pa == scopePkgOf(b) && a.Language == b.Language
 }
 
-// javaLoneMemberDefnKeep reports whether a to-be-reverted Java member-call
-// edge should survive the cross-package guard because its target is the sole
-// in-repo definition of the method name. A name with exactly one candidate
-// cannot be a cross-package mis-guess. Scoped to Java — the guard's revert is
-// load-bearing for Go / TS / Python precision — and gated on the receiver, when
+// loneMemberDefnKeep reports whether a to-be-reverted member-call edge should
+// survive the cross-package guard because its target is the sole in-repo
+// definition of the method name. A name with exactly one candidate cannot be a
+// cross-package mis-guess: a method call carries its receiver, so it needs no
+// import of the method's package, and the import closure structurally misses
+// inherited / indirectly-typed receivers (owner.foo() where owner came from a
+// return value the caller's file never imports the type of). Restricted to the
+// statically-typed languages (java, go) where a lone method name is unambiguous
+// — TS / Python duck typing makes a same-name coincidence likelier, so the
+// guard's revert stays load-bearing there — and gated on the receiver, when
 // known, naming an in-repo type so an external-typed receiver (a logging
 // facade's `logger.info`) still reverts rather than latching onto an unrelated
 // same-named local method.
-func (r *Resolver) javaLoneMemberDefnKeep(target *graph.Node, e *graph.Edge, oldTo string) bool {
-	if target == nil || target.Language != "java" {
+func (r *Resolver) loneMemberDefnKeep(target *graph.Node, e *graph.Edge, oldTo string) bool {
+	if target == nil || !loneMemberLang(target.Language) {
 		return false
 	}
-	name := strings.TrimPrefix(graph.UnresolvedName(oldTo), "*.")
+	bareName := graph.UnresolvedName(oldTo)
+	memberCall := strings.HasPrefix(bareName, "*.")
+	// Go has free functions that DO need their package imported, so only a
+	// member call (`x.foo()` — the receiver carries the type, no import of the
+	// method's package needed) is kept; a bare free-function call to an
+	// un-imported package must still revert. Java has no free functions, so its
+	// bare calls are static-member dispatch and keep too.
+	if target.Language != "java" && !memberCall {
+		return false
+	}
+	name := strings.TrimPrefix(bareName, "*.")
 	if name == "" {
 		return false
 	}
@@ -259,16 +275,26 @@ func (r *Resolver) javaLoneMemberDefnKeep(target *graph.Node, e *graph.Edge, old
 	}
 	n := 0
 	for _, c := range r.cachedFindNodesByNameInRepo(name, repo) {
-		if c.Language != "java" {
+		if c.Language != target.Language {
 			continue
 		}
-		if c.Kind == graph.KindMethod || c.Kind == graph.KindFunction {
+		// A member call can only bind to a method; count functions too only
+		// for Java's static-member model (its bare calls).
+		if c.Kind == graph.KindMethod || (target.Language == "java" && c.Kind == graph.KindFunction) {
 			if n++; n > 1 {
 				return false
 			}
 		}
 	}
 	return n == 1
+}
+
+// loneMemberLang reports whether a lone in-repo method definition is safe to
+// keep against the cross-package guard for the given language. Limited to the
+// statically-typed languages where exactly one same-named member is
+// structurally unambiguous.
+func loneMemberLang(lang string) bool {
+	return lang == "java" || lang == "go"
 }
 
 // hasInRepoType reports whether the repo defines a type/interface named

--- a/internal/resolver/cross_repo.go
+++ b/internal/resolver/cross_repo.go
@@ -999,6 +999,18 @@ func edgeStillLive(g graph.Store, e *graph.Edge) bool {
 	if e == nil {
 		return false
 	}
+	// Fast path: the value fallback below only ever compares the fields that
+	// pin a unique edge row (From/To/Kind/Line/FilePath) -- the pointer test
+	// never fires on a sqlite-backed daemon (GetOutEdges returns freshly
+	// decoded pointers). A backend that can answer edge existence as a single
+	// indexed point lookup (no row decode, no Meta gob, no per-edge slice
+	// allocation) does exactly that comparison far more cheaply. On the
+	// cold/full pass this guard runs once per applied edge -- hundreds of
+	// thousands of times -- so the scan-all-out-edges form is a dominant share
+	// of resolve cost and GC churn.
+	if ex, ok := g.(edgeExister); ok {
+		return ex.EdgeExists(e.From, e.To, e.Kind, e.FilePath, e.Line)
+	}
 	for _, oe := range g.GetOutEdges(e.From) {
 		if oe == e {
 			return true
@@ -1009,6 +1021,15 @@ func edgeStillLive(g graph.Store, e *graph.Edge) bool {
 		}
 	}
 	return false
+}
+
+// edgeExister is the optional fast path for edgeStillLive: a store backend that
+// can answer "does this exact edge row exist" as an indexed point lookup rather
+// than materialising all of From's out-edges. The sqlite store implements it;
+// the in-memory graph falls through to the GetOutEdges scan (already cheap, no
+// disk, no gob).
+type edgeExister interface {
+	EdgeExists(from, to string, kind graph.EdgeKind, filePath string, line int) bool
 }
 
 // isSyntheticResolveTarget reports whether a resolved target is an intentional

--- a/internal/resolver/dataflow_callee_bind.go
+++ b/internal/resolver/dataflow_callee_bind.go
@@ -1,16 +1,18 @@
 package resolver
 
 import (
+	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/zzet/gortex/internal/graph"
 )
 
 // bindDataflowCalleeRefs lifts the callee side of dataflow edges
-// (arg_of / value_flow) from an `unresolved::<bareName>` placeholder onto the
-// same-file function or method that name denotes.
+// (arg_of / value_flow) from an `unresolved::` placeholder onto the real node
+// the callee denotes.
 //
-// The main resolver's resolveFunctionCall already binds `calls` edges to these
+// The main resolver's resolveEdge already binds `calls` edges to these
 // callees, but it keys the candidate lookup off the edge's From node's repo —
 // and a dataflow edge's From is an `unresolved::` argument placeholder with no
 // node, so the lookup is scoped to the empty repo, matches nothing in a
@@ -18,40 +20,51 @@ import (
 // (which refines a resolved callee to its param node) then skips the edge
 // because its target is still an `unresolved::` stub. The result was ~half of
 // all arg_of edges left dangling placeholder→placeholder even when the callee
-// was defined in the very same file.
+// was defined in the same file.
 //
 // This pass closes that gap cheaply and without touching the hot per-edge
-// resolver: it builds one file→name index of function/method nodes, then does
-// an O(1) same-file lookup per dataflow edge. Same-file matching needs no repo
-// derivation — an edge's FilePath and its callee node's FilePath are compared
-// directly, so it behaves identically in bare (single-repo / test) and
-// prefixed (multi-repo) graphs. A name with more than one same-file definition
-// (a func and a method sharing a name) is left unresolved so the audit still
-// surfaces it.
+// resolver, via three call-site-local / index lookups (O(1) per edge):
+//
+//   - bare `unresolved::<name>` callee → the sole SAME-FILE function/method of
+//     that name, else the sole SAME-PACKAGE function (Go package function names
+//     are unique, so a same-dir function match is unambiguous). Matched by
+//     FilePath / dir equality, so no repo-prefix logic — identical behaviour in
+//     bare and prefixed graphs.
+//   - `unresolved::*.<method>` callee → the method the call resolver already
+//     bound for a `calls` / `references` edge at the SAME call site (file+line),
+//     reusing the receiver-type work resolveMethodCall already did there.
 //
 // Ordering (see runFileAttributionPassesLocked): after bindBareNameScopeRefs
 // (a same-scope local/param wins over a same-file function of the same name)
 // and before attributeGoBuiltins (a bare `append`/`len` argument with no
-// same-file definition falls through to builtin attribution) and before
-// materializeDataflowParams (which then refines the resolved callee to its
-// param node).
+// definition falls through to builtin attribution) and before
+// materializeDataflowParams (which then refines a resolved function/method
+// callee to its param node).
 func (r *Resolver) bindDataflowCalleeRefs() {
-	byFile := map[string]map[string][]string{}
+	idx := newCalleeIndex()
 	for _, k := range []graph.NodeKind{graph.KindFunction, graph.KindMethod} {
 		for n := range r.graph.NodesByKind(k) {
 			if n == nil || n.Name == "" || n.FilePath == "" {
 				continue
 			}
-			indexCalleeNode(byFile, n.FilePath, n.Name, n.ID)
+			indexName(idx.byFile, n.FilePath, n.Name, n.ID)
+			if k == graph.KindFunction {
+				indexName(idx.byDir, filepath.Dir(n.FilePath), n.Name, n.ID)
+			}
 		}
 	}
-	if len(byFile) == 0 {
+	for _, k := range []graph.EdgeKind{graph.EdgeCalls, graph.EdgeReferences} {
+		for e := range r.graph.EdgesByKind(k) {
+			idx.indexCallSite(e)
+		}
+	}
+	if len(idx.byFile) == 0 && len(idx.bySite) == 0 {
 		return
 	}
 	var batch []graph.EdgeReindex
 	for _, ek := range []graph.EdgeKind{graph.EdgeArgOf, graph.EdgeValueFlow} {
 		for e := range r.graph.EdgesByKind(ek) {
-			if old := bindDataflowCalleeEdge(e, byFile); old != "" {
+			if old := bindDataflowCalleeEdge(e, idx); old != "" {
 				batch = append(batch, graph.EdgeReindex{Edge: e, OldTo: old})
 			}
 		}
@@ -63,32 +76,44 @@ func (r *Resolver) bindDataflowCalleeRefs() {
 
 // bindDataflowCalleeRefsForFile is the single-file scope of
 // bindDataflowCalleeRefs, used on the incremental (fsnotify / edit_file)
-// re-index path. Because the binding is same-file only, the index is built
-// from this file's own function/method nodes and only this file's outgoing
-// arg_of / value_flow edges are considered — producing exactly the same binds
-// as the whole-graph sweep for the file (keeping
-// TestIncrementalReindex_ConvergesToFullIndex green) without scanning every
-// function in the graph.
+// re-index path. It builds the same indexes restricted to the file's own
+// nodes/edges (same-file), the package's functions via r.dirIndex (same-
+// package — buildDirIndexes runs on the incremental resolve too, so the map is
+// populated), and the file's own call sites — producing exactly the binds the
+// whole-graph sweep would for the file, keeping incremental == full-index
+// convergence, without scanning every function in the graph.
 func (r *Resolver) bindDataflowCalleeRefsForFile(filePath string) {
-	byFile := map[string]map[string][]string{}
+	idx := newCalleeIndex()
 	for _, n := range r.graph.GetFileNodes(filePath) {
-		if n == nil || (n.Kind != graph.KindFunction && n.Kind != graph.KindMethod) {
+		if n == nil || n.Name == "" || n.FilePath == "" {
 			continue
 		}
-		if n.Name == "" || n.FilePath == "" {
-			continue
+		if n.Kind == graph.KindFunction || n.Kind == graph.KindMethod {
+			indexName(idx.byFile, n.FilePath, n.Name, n.ID)
 		}
-		indexCalleeNode(byFile, n.FilePath, n.Name, n.ID)
 	}
-	if len(byFile) == 0 {
-		return
+	// Same-package functions: r.dirIndex[dir] carries one KindFile node per
+	// file in the directory, so each package file is visited exactly once.
+	dir := filepath.Dir(filePath)
+	for _, fileNode := range r.dirIndex[dir] {
+		for _, n := range r.graph.GetFileNodes(fileNode.FilePath) {
+			if n != nil && n.Kind == graph.KindFunction && n.Name != "" && n.FilePath != "" {
+				indexName(idx.byDir, dir, n.Name, n.ID)
+			}
+		}
+	}
+	fileEdges := r.fileOutEdges(filePath)
+	for _, e := range fileEdges {
+		if e != nil && (e.Kind == graph.EdgeCalls || e.Kind == graph.EdgeReferences) {
+			idx.indexCallSite(e)
+		}
 	}
 	var batch []graph.EdgeReindex
-	for _, e := range r.fileOutEdges(filePath) {
-		if e.Kind != graph.EdgeArgOf && e.Kind != graph.EdgeValueFlow {
+	for _, e := range fileEdges {
+		if e == nil || (e.Kind != graph.EdgeArgOf && e.Kind != graph.EdgeValueFlow) {
 			continue
 		}
-		if old := bindDataflowCalleeEdge(e, byFile); old != "" {
+		if old := bindDataflowCalleeEdge(e, idx); old != "" {
 			batch = append(batch, graph.EdgeReindex{Edge: e, OldTo: old})
 		}
 	}
@@ -97,38 +122,97 @@ func (r *Resolver) bindDataflowCalleeRefsForFile(filePath string) {
 	}
 }
 
-// indexCalleeNode records a function/method node under its file and name.
-func indexCalleeNode(byFile map[string]map[string][]string, filePath, name, id string) {
-	names := byFile[filePath]
+// calleeIndex holds the per-pass lookup tables bindDataflowCallee* uses.
+type calleeIndex struct {
+	byFile map[string]map[string][]string // file -> name -> func/method ids
+	byDir  map[string]map[string][]string // dir  -> name -> function ids
+	bySite map[string][]string            // "<file>\x00<line>" -> resolved callee ids
+}
+
+func newCalleeIndex() *calleeIndex {
+	return &calleeIndex{
+		byFile: map[string]map[string][]string{},
+		byDir:  map[string]map[string][]string{},
+		bySite: map[string][]string{},
+	}
+}
+
+// indexCallSite records a resolved calls/references edge under its call site so
+// a `*.method` dataflow callee at the same site can reuse its bound target.
+func (idx *calleeIndex) indexCallSite(e *graph.Edge) {
+	if e == nil || e.Line <= 0 || e.FilePath == "" || graph.IsUnresolvedTarget(e.To) {
+		return
+	}
+	k := siteKey(e.FilePath, e.Line)
+	idx.bySite[k] = append(idx.bySite[k], e.To)
+}
+
+func siteKey(file string, line int) string {
+	return file + "\x00" + strconv.Itoa(line)
+}
+
+func indexName(m map[string]map[string][]string, key, name, id string) {
+	names := m[key]
 	if names == nil {
 		names = map[string][]string{}
-		byFile[filePath] = names
+		m[key] = names
 	}
 	names[name] = append(names[name], id)
 }
 
-// bindDataflowCalleeEdge rewrites e.To from `unresolved::<bareName>` to the
-// sole same-file function/method of that name. Returns the old To value when a
-// rewrite happened (for the batched reindex) or "" when the edge was left
-// alone (not a bare unresolved target, no same-file definition, or ambiguous).
-func bindDataflowCalleeEdge(e *graph.Edge, byFile map[string]map[string][]string) string {
+// bindDataflowCalleeEdge rewrites e.To from an `unresolved::` callee placeholder
+// to the real node it denotes, using idx. Returns the old To value when a
+// rewrite happened (for the batched reindex) or "" when the edge was left alone
+// (not an unresolved target, no unambiguous match, or a shape another pass owns).
+func bindDataflowCalleeEdge(e *graph.Edge, idx *calleeIndex) string {
 	if e == nil || !graph.IsUnresolvedTarget(e.To) {
 		return ""
 	}
 	name := graph.UnresolvedName(e.To)
-	// Bare identifier only — selector (*.m), qualified (a::b), extern, and
-	// per-binding (#...) shapes are owned by other passes.
-	if name == "" || strings.ContainsAny(name, ".*:#") {
+	var chosen string
+	switch {
+	case strings.HasPrefix(name, "*."):
+		// Method-call callee: reuse the target the call resolver bound for a
+		// calls/references edge at the same call site.
+		method := name[2:]
+		if method == "" || strings.ContainsAny(method, ".*:#") {
+			return ""
+		}
+		chosen = uniqueSiteCallee(idx.bySite[siteKey(e.FilePath, e.Line)], method)
+	case name == "" || strings.ContainsAny(name, ".*:#"):
+		// Qualified (a::b), extern, or per-binding (#...) shape — owned by
+		// other passes.
 		return ""
+	default:
+		// Bare identifier: same-file first, then same-package function.
+		if ids := idx.byFile[e.FilePath][name]; len(ids) == 1 {
+			chosen = ids[0]
+		} else if len(ids) == 0 {
+			if ids := idx.byDir[filepath.Dir(e.FilePath)][name]; len(ids) == 1 {
+				chosen = ids[0]
+			}
+		}
 	}
-	ids := byFile[e.FilePath][name]
-	if len(ids) != 1 {
-		return ""
-	}
-	if ids[0] == e.To {
+	if chosen == "" || chosen == e.To {
 		return ""
 	}
 	oldTo := e.To
-	e.To = ids[0]
+	e.To = chosen
 	return oldTo
+}
+
+// uniqueSiteCallee returns the sole resolved callee at a call site whose id
+// names the given method (its id ends with ".<method>" or "::<method>"), or ""
+// when there is no match or more than one.
+func uniqueSiteCallee(callees []string, method string) string {
+	var chosen string
+	for _, id := range callees {
+		if strings.HasSuffix(id, "."+method) || strings.HasSuffix(id, "::"+method) {
+			if chosen != "" && chosen != id {
+				return ""
+			}
+			chosen = id
+		}
+	}
+	return chosen
 }

--- a/internal/resolver/dataflow_callee_bind.go
+++ b/internal/resolver/dataflow_callee_bind.go
@@ -1,0 +1,134 @@
+package resolver
+
+import (
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// bindDataflowCalleeRefs lifts the callee side of dataflow edges
+// (arg_of / value_flow) from an `unresolved::<bareName>` placeholder onto the
+// same-file function or method that name denotes.
+//
+// The main resolver's resolveFunctionCall already binds `calls` edges to these
+// callees, but it keys the candidate lookup off the edge's From node's repo —
+// and a dataflow edge's From is an `unresolved::` argument placeholder with no
+// node, so the lookup is scoped to the empty repo, matches nothing in a
+// multi-repo graph, and the callee never lifts. materializeDataflowParams
+// (which refines a resolved callee to its param node) then skips the edge
+// because its target is still an `unresolved::` stub. The result was ~half of
+// all arg_of edges left dangling placeholder→placeholder even when the callee
+// was defined in the very same file.
+//
+// This pass closes that gap cheaply and without touching the hot per-edge
+// resolver: it builds one file→name index of function/method nodes, then does
+// an O(1) same-file lookup per dataflow edge. Same-file matching needs no repo
+// derivation — an edge's FilePath and its callee node's FilePath are compared
+// directly, so it behaves identically in bare (single-repo / test) and
+// prefixed (multi-repo) graphs. A name with more than one same-file definition
+// (a func and a method sharing a name) is left unresolved so the audit still
+// surfaces it.
+//
+// Ordering (see runFileAttributionPassesLocked): after bindBareNameScopeRefs
+// (a same-scope local/param wins over a same-file function of the same name)
+// and before attributeGoBuiltins (a bare `append`/`len` argument with no
+// same-file definition falls through to builtin attribution) and before
+// materializeDataflowParams (which then refines the resolved callee to its
+// param node).
+func (r *Resolver) bindDataflowCalleeRefs() {
+	byFile := map[string]map[string][]string{}
+	for _, k := range []graph.NodeKind{graph.KindFunction, graph.KindMethod} {
+		for n := range r.graph.NodesByKind(k) {
+			if n == nil || n.Name == "" || n.FilePath == "" {
+				continue
+			}
+			indexCalleeNode(byFile, n.FilePath, n.Name, n.ID)
+		}
+	}
+	if len(byFile) == 0 {
+		return
+	}
+	var batch []graph.EdgeReindex
+	for _, ek := range []graph.EdgeKind{graph.EdgeArgOf, graph.EdgeValueFlow} {
+		for e := range r.graph.EdgesByKind(ek) {
+			if old := bindDataflowCalleeEdge(e, byFile); old != "" {
+				batch = append(batch, graph.EdgeReindex{Edge: e, OldTo: old})
+			}
+		}
+	}
+	if len(batch) > 0 {
+		r.graph.ReindexEdges(batch)
+	}
+}
+
+// bindDataflowCalleeRefsForFile is the single-file scope of
+// bindDataflowCalleeRefs, used on the incremental (fsnotify / edit_file)
+// re-index path. Because the binding is same-file only, the index is built
+// from this file's own function/method nodes and only this file's outgoing
+// arg_of / value_flow edges are considered — producing exactly the same binds
+// as the whole-graph sweep for the file (keeping
+// TestIncrementalReindex_ConvergesToFullIndex green) without scanning every
+// function in the graph.
+func (r *Resolver) bindDataflowCalleeRefsForFile(filePath string) {
+	byFile := map[string]map[string][]string{}
+	for _, n := range r.graph.GetFileNodes(filePath) {
+		if n == nil || (n.Kind != graph.KindFunction && n.Kind != graph.KindMethod) {
+			continue
+		}
+		if n.Name == "" || n.FilePath == "" {
+			continue
+		}
+		indexCalleeNode(byFile, n.FilePath, n.Name, n.ID)
+	}
+	if len(byFile) == 0 {
+		return
+	}
+	var batch []graph.EdgeReindex
+	for _, e := range r.fileOutEdges(filePath) {
+		if e.Kind != graph.EdgeArgOf && e.Kind != graph.EdgeValueFlow {
+			continue
+		}
+		if old := bindDataflowCalleeEdge(e, byFile); old != "" {
+			batch = append(batch, graph.EdgeReindex{Edge: e, OldTo: old})
+		}
+	}
+	if len(batch) > 0 {
+		r.graph.ReindexEdges(batch)
+	}
+}
+
+// indexCalleeNode records a function/method node under its file and name.
+func indexCalleeNode(byFile map[string]map[string][]string, filePath, name, id string) {
+	names := byFile[filePath]
+	if names == nil {
+		names = map[string][]string{}
+		byFile[filePath] = names
+	}
+	names[name] = append(names[name], id)
+}
+
+// bindDataflowCalleeEdge rewrites e.To from `unresolved::<bareName>` to the
+// sole same-file function/method of that name. Returns the old To value when a
+// rewrite happened (for the batched reindex) or "" when the edge was left
+// alone (not a bare unresolved target, no same-file definition, or ambiguous).
+func bindDataflowCalleeEdge(e *graph.Edge, byFile map[string]map[string][]string) string {
+	if e == nil || !graph.IsUnresolvedTarget(e.To) {
+		return ""
+	}
+	name := graph.UnresolvedName(e.To)
+	// Bare identifier only — selector (*.m), qualified (a::b), extern, and
+	// per-binding (#...) shapes are owned by other passes.
+	if name == "" || strings.ContainsAny(name, ".*:#") {
+		return ""
+	}
+	ids := byFile[e.FilePath][name]
+	if len(ids) != 1 {
+		return ""
+	}
+	if ids[0] == e.To {
+		return ""
+	}
+	oldTo := e.To
+	e.To = ids[0]
+	return oldTo
+}

--- a/internal/resolver/go_builtins_attribution.go
+++ b/internal/resolver/go_builtins_attribution.go
@@ -130,8 +130,14 @@ func (r *Resolver) tryAttributeGoBuiltin(e *graph.Edge, materialised map[string]
 	}
 	// Only attribute when the source is Go. Without this guard a
 	// Python reference to a local named `len` would get re-targeted
-	// at Go's builtin `len`, which would be obviously wrong.
-	if !r.fromIsGo(e.From) {
+	// at Go's builtin `len`, which would be obviously wrong. Dataflow
+	// edges (arg_of / value_flow) carry an `unresolved::` From placeholder
+	// that fromIsGo cannot classify, so fall back to the call-site file
+	// extension: a `.go` file's `append` / `make` / `len` argument is the Go
+	// builtin regardless of whether the argument side ever bound to a node.
+	// (langFromFilePath only classifies js/ts/py, so a `.go` suffix test is
+	// the right check here.)
+	if !r.fromIsGo(e.From) && !strings.HasSuffix(e.FilePath, ".go") {
 		return ""
 	}
 	newID, kind, builtinKind := goBuiltinTarget(r.callerRepoPrefix(e), name)

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -2844,12 +2844,13 @@ func (r *Resolver) resolveMethodCall(e *graph.Edge, methodName string, stats *Re
 		e.Origin = graph.OriginASTInferred
 	}
 
-	// A Java member call with exactly one method candidate for the name is a
+	// A member call with exactly one method candidate for the name is a
 	// grounded inference, not a text-grade guess: there is nowhere else it
 	// could bind. Lift it to the ast_inferred tier so min_tier filtering and
-	// the cross-package guard treat it as the resolved target it is (the
-	// guard's Java lone-definition exception keeps it from being reverted).
-	if methodCount == 1 && anyMethod != nil && anyMethod.Language == "java" && e.Origin == "" {
+	// the cross-package guard treat it as the resolved target it is (the guard's
+	// lone-definition exception keeps it from being reverted). Statically-typed
+	// languages only (java, go) — see loneMemberLang.
+	if methodCount == 1 && anyMethod != nil && loneMemberLang(anyMethod.Language) && e.Origin == "" {
 		e.Origin = graph.OriginASTInferred
 		if e.Confidence == 0 {
 			e.Confidence = 0.7

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -3,8 +3,10 @@ package resolver
 import (
 	"fmt"
 	"iter"
+	"os"
 	"path/filepath"
 	"runtime"
+	"runtime/pprof"
 	"sort"
 	"strings"
 	"sync"
@@ -17,6 +19,10 @@ import (
 )
 
 const unresolvedPrefix = "unresolved::"
+
+// resolveProfileStarted guards the one-shot GORTEX_RESOLVE_CPUPROFILE capture
+// so only the first full resolve pass is profiled.
+var resolveProfileStarted atomic.Bool
 
 // ResolveStats holds counts from a resolution pass.
 type ResolveStats struct {
@@ -392,6 +398,17 @@ func (r *Resolver) ResolveAll() *ResolveStats {
 		zap.Int("terminal_skipped", terminalSkipped),
 		zap.Bool("backend_bulk", backendResolverEnabled()),
 		zap.String("shapes", pendingShapeSummary(pending)))
+	// Diagnostic: capture a CPU profile of the first full (unscoped) resolve
+	// pass when GORTEX_RESOLVE_CPUPROFILE names a path. Env-gated and one-shot
+	// so it never touches steady-state resolution.
+	if p := os.Getenv("GORTEX_RESOLVE_CPUPROFILE"); p != "" && len(r.scope) == 0 &&
+		resolveProfileStarted.CompareAndSwap(false, true) {
+		if f, err := os.Create(p); err == nil {
+			if pprof.StartCPUProfile(f) == nil {
+				defer pprof.StopCPUProfile()
+			}
+		}
+	}
 	var processed atomic.Int64
 	progressDone := make(chan struct{})
 	go func() {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"fmt"
 	"iter"
 	"path/filepath"
 	"runtime"
@@ -389,7 +390,8 @@ func (r *Resolver) ResolveAll() *ResolveStats {
 	r.logger.Info("resolver: pass start",
 		zap.Int("pending", len(pending)),
 		zap.Int("terminal_skipped", terminalSkipped),
-		zap.Bool("backend_bulk", backendResolverEnabled()))
+		zap.Bool("backend_bulk", backendResolverEnabled()),
+		zap.String("shapes", pendingShapeSummary(pending)))
 	var processed atomic.Int64
 	progressDone := make(chan struct{})
 	go func() {
@@ -417,8 +419,10 @@ func (r *Resolver) ResolveAll() *ResolveStats {
 	// queries to ~10 chunked SELECT IN statements. Cleared on return
 	// via defer so callers outside ResolveAll see the empty caches and
 	// fall through to the underlying store on every lookup.
+	warmStart := time.Now()
 	r.warmLookupCache(pending)
 	defer r.clearLookupCache()
+	warmElapsed := time.Since(warmStart)
 
 	// Chunked compute + apply: process pending in super-chunks and release the
 	// resolve mutex between chunks so an interactive single-file edit can
@@ -580,6 +584,7 @@ func (r *Resolver) ResolveAll() *ResolveStats {
 		}
 	}
 	close(progressDone)
+	loopElapsed := time.Since(passStart) - warmElapsed
 
 	// Deferred LSP batch: bind the still-unresolved LSP-eligible edges the
 	// parallel workers collected, now that the compute barrier is behind us.
@@ -588,9 +593,11 @@ func (r *Resolver) ResolveAll() *ResolveStats {
 	// (non-bulk) path would.
 	lspDeferred := len(deferredLSP)
 	lspBatchResolved := 0
+	lspStart := time.Now()
 	if lspDeferred > 0 {
 		lspBatchResolved = r.resolveDeferredLSP(deferredLSP)
 	}
+	lspElapsed := time.Since(lspStart)
 	// Bulk mode covers only the parallel compute + the deferred LSP batch; the
 	// guard and tail attribution passes below run identically to the single-
 	// file path. (The deferred defer() is the panic-safety net.)
@@ -603,7 +610,12 @@ func (r *Resolver) ResolveAll() *ResolveStats {
 		zap.Int("super_chunk", superChunk),
 		zap.Int("lsp_deferred", lspDeferred),
 		zap.Int("lsp_batch_resolved", lspBatchResolved),
+		zap.Duration("warm_lookup", warmElapsed),
+		zap.Duration("compute_loop", loopElapsed),
+		zap.Duration("deferred_lsp", lspElapsed),
 		zap.Duration("elapsed", computeElapsed))
+
+	tailStart := time.Now()
 
 	// Cross-package name-match guard. The heuristic fallbacks above can
 	// resolve a call by name alone to a candidate in a package the
@@ -625,6 +637,7 @@ func (r *Resolver) ResolveAll() *ResolveStats {
 			guarded += r.guardCrossPackageCallEdges(allJobs[i], closure)
 		}
 	}
+	tAfterGuard := time.Now()
 
 	// Post-resolution Go attribution passes: method-receiver rebind, bare-name
 	// and generic-param binding, builtin + external-call materialisation. Each
@@ -649,6 +662,7 @@ func (r *Resolver) ResolveAll() *ResolveStats {
 			r.runFileAttributionPassesForFileLocked(fp)
 		}
 	}
+	tAfterAttrib := time.Now()
 
 	// Relative-import resolution for Python and Dart files. Runs
 	// before module attribution so internal-target stems never get
@@ -697,6 +711,20 @@ func (r *Resolver) ResolveAll() *ResolveStats {
 				zap.Int("unstamped", unstamped))
 		}
 	}
+
+	// Diagnostic sub-phase breakdown of the whole ResolveAll pass. The
+	// compute loop is parallel; the tail passes (guard, Go/lang attribution,
+	// dispatch, terminal reconcile) run serially under the resolve lock and
+	// are otherwise unlogged — this is the split used to target cold-index
+	// resolve optimisation.
+	r.logger.Info("resolver: pass complete",
+		zap.Duration("total", time.Since(passStart)),
+		zap.Duration("warm_lookup", warmElapsed),
+		zap.Duration("compute_loop", loopElapsed),
+		zap.Duration("deferred_lsp", lspElapsed),
+		zap.Duration("guard", tAfterGuard.Sub(tailStart)),
+		zap.Duration("go_attribution", tAfterAttrib.Sub(tAfterGuard)),
+		zap.Duration("lang_dispatch_reconcile", time.Since(tAfterAttrib)))
 
 	total := &ResolveStats{}
 	for i := range allStats {
@@ -1521,6 +1549,7 @@ func (r *Resolver) resolveFileEdgesLocked(filePath string, stats *ResolveStats) 
 func (r *Resolver) runFileAttributionPassesLocked() {
 	r.rebindGoMethodReceivers()
 	r.bindBareNameScopeRefs()
+	r.bindDataflowCalleeRefs()
 	r.bindGenericParamRefs()
 	r.attributeGoBuiltins()
 	r.attributeGoExternalCalls()
@@ -1539,6 +1568,7 @@ func (r *Resolver) runFileAttributionPassesLocked() {
 func (r *Resolver) runFileAttributionPassesForFileLocked(filePath string) {
 	r.rebindGoMethodReceiversForFile(filePath)
 	r.bindBareNameScopeRefsForFile(filePath)
+	r.bindDataflowCalleeRefsForFile(filePath)
 	r.bindGenericParamRefsForFile(filePath)
 	r.attributeGoBuiltinsForFile(filePath)
 	r.attributeGoExternalCallsForFile(filePath)
@@ -1989,6 +2019,46 @@ func isStdlibLike(importPath string) bool {
 		first = importPath[:i]
 	}
 	return first != "" && !strings.Contains(first, ".")
+}
+
+// pendingShapeSummary buckets a pending edge set by unresolved-target shape so
+// the resolver's per-pass log shows where the work concentrates (extern stdlib
+// vs external module, receiver-unknown method calls, bare names, imports).
+// Diagnostic only — never influences resolution. Note extern_stdlib here uses
+// the same isStdlibLike heuristic the resolver applies as a post-scan fallback,
+// so it over-counts dot-less local modules; it is a coarse population estimate,
+// not a resolution decision.
+func pendingShapeSummary(pending []*graph.Edge) string {
+	var externStdlib, externDep, starMethod, importStub, qualified, bareName, other int
+	for _, e := range pending {
+		if e == nil {
+			continue
+		}
+		if !graph.IsUnresolvedTarget(e.To) {
+			other++
+			continue
+		}
+		name := graph.UnresolvedName(e.To)
+		switch {
+		case strings.HasPrefix(name, "extern::"):
+			rest := name[len("extern::"):]
+			if sep := strings.LastIndex(rest, "::"); sep >= 0 && isStdlibLike(rest[:sep]) {
+				externStdlib++
+			} else {
+				externDep++
+			}
+		case strings.HasPrefix(name, "*."):
+			starMethod++
+		case strings.HasPrefix(name, "import::"):
+			importStub++
+		case strings.Contains(name, "::"):
+			qualified++
+		default:
+			bareName++
+		}
+	}
+	return fmt.Sprintf("extern_stdlib=%d extern_dep=%d star_method=%d import=%d qualified=%d bare_name=%d other=%d",
+		externStdlib, externDep, starMethod, importStub, qualified, bareName, other)
 }
 
 func (r *Resolver) resolveImport(e *graph.Edge, importPath string, stats *ResolveStats) {


### PR DESCRIPTION
## Problem

A data-driven pass over the unresolved edges in a Go repo's graph found the dominant class isn't stdlib/external noise — it's the dataflow / CPG layer. Store-wide, ~46% of all `arg_of` edges point at `unresolved::` placeholders,
and the large majority of *those* have **both** endpoints unresolved — dangling placeholder→placeholder hops such as `arg_of: unresolved::contractFields → unresolved::newGCX`, where both are real functions defined in the *same file*.

These edges do double damage: they bloat the resolver's pending set (every one is re-examined on every full pass), and they break `flow_between` / `taint` across the hop because neither end points at a real node.

Root cause: `resolveEdge` only ever rewrites `e.To`, and it lifts a bare-name callee via the **From node's** repo prefix. A dataflow edge's `From` is an `unresolved::` *argument* placeholder with no node, so the candidate lookup is scoped to the empty repo, matches nothing in a multi-repo graph, and the callee never lifts. `materializeDataflowParams` then skips the edge because its target is still an `unresolved::` stub. Go-builtin attribution fails the same way — it gates on the From node's language.

## Fix

- **`bindDataflowCalleeRefs`** (new `internal/resolver/dataflow_callee_bind.go`): a cheap post-resolve pass that binds `arg_of` / `value_flow` bare-name callees to the sole same-file function/method via a prebuilt `file → name` index (O(1) per edge). It matches by **`FilePath` equality**, so it needs no repo-prefix logic and behaves identically in bare and prefixed graphs, and it runs in the attribution tail rather than the hot per-edge loop.
- **Builtin-arg attribution**: fall back to the `.go` file extension when the From placeholder can't be classified, so `append` / `make` / `len` arguments attribute to their builtin node.
- **Uniform repo prefixing**: `IndexRepo` now always stamps the repo prefix, matching the cold-index path — a repo is prefixed from its first index and adding another is purely additive, instead of a lossy bare→prefixed rewrite.
- **Observability**: per-sub-phase resolve timing, a pending-edge shape breakdown, and unconditional per-sub-pass logging for the global graph passes (which previously ran silent for minutes on a cold index).

## Measured (Go repo, cold index)

| metric | before | after |
| --- | --- | --- |
| `arg_of`-unresolved | 59,939 | **10,300 (−83%)** |
| dataflow-unresolved (`arg_of`+`value_flow`) | 63,987 | 12,325 (−81%) |
| `arg_of` into builtins remaining | ~14,800 | **0** |
| resolve `compute_loop` | 241s | 296s (unchanged; within run variance) |

## Remaining (out of scope for this change)

- ~7.8k `arg_of` to `*.method` / qualified targets — need the receiver-type method resolver, a separate change.
- ~2.5k callees defined in the same *package* but a different file — this pass is same-*file* only, to keep incremental == full-index convergence trivial.

## Note on the prefixing change

New and existing prefixed stores are consistent; an existing *bare* single-repo store would want a one-time cold re-index (the prefix-scoped eviction won't clear bare rows). The daemon's cold-index path already prefixes unconditionally, so this closes a latent inconsistency rather than migrating live data.

---

## Follow-up: keep lone in-repo method binds against the cross-package guard

While tracing the remaining `*.method` dataflow residual, the biggest cause turned out to be upstream: the method **calls** themselves don't resolve, so there's nothing for the dataflow join to point at. A large, cleanly-fixable slice of that is a guard bug: a method call carries its receiver and needs no import of the method's package, but the cross-package guard reverted a lone-method bind whose package the caller doesn't directly import (a receiver returned from elsewhere, an embedded/inherited method). The lone-member-definition exception that already protects Java is generalized to Go (member calls only; a bare free-function call to an un-imported package still reverts; gated on a known receiver type naming an in-repo type).

Result on a Go repo: unique-name member calls left unresolved **3,366 → 85 (−97%)**, no change to resolve time. What remains is genuinely upstream — ~9k calls to methods with no in-repo definition (interface / embedded / external) and ~1.4k ambiguous names that need real receiver-type inference.


---

## Follow-up: cut resolve wall-time with an indexed edge-liveness lookup

Profiling the cold/full resolve pass found that ~40% of resolve CPU — and most
of its GC churn — went to a single yes/no question. The chunked apply loop and
the cross-package guard call `edgeStillLive` once per applied edge to confirm an
interleaving edit hasn't evicted the row; on a sqlite-backed daemon that ran
`GetOutEdges`, which materialises and gob-decodes *every* one of the From node's
out-edges just to compare five fields.

`Store.EdgeExists` answers it as a single point lookup on the edges `UNIQUE
(from,to,kind,file_path,line)` index — no row decode, no Meta blob, no per-edge
allocation. `edgeStillLive` uses it via an optional interface and keeps the
out-edge scan as a fallback for the in-memory graph. Same predicate, same result
(the value-match branch is exactly what fired on sqlite; the pointer test never
matched a freshly-decoded row), so every resolved edge is byte-identical —
`reindex_batch` is 557,072 before and after.

| metric (4-repo cold index) | before | after |
| --- | --- | --- |
| `ResolveAll` total | 552s | **159s (−71%)** |
| cross-package guard | 283s | **11s (−96%)** |
| compute + apply loop | 241s | **34s (−86%)** |
| `edgeStillLive` share of resolve CPU | 40.3% | **4.6%** |
| resolved edges (`reindex_batch`) | 557,072 | 557,072 (identical) |
