### PR TITLE
Cut LSP semantic-enrichment cost on cold index

### DIFF
--- a/internal/semantic/lsp/enrich_confirm.go
+++ b/internal/semantic/lsp/enrich_confirm.go
@@ -21,6 +21,46 @@ type enrichTarget struct {
 	edge *graph.Edge
 }
 
+// confirmableEdgeKind reports whether the reference-confirm pass and its
+// definition-rebind fallback can meaningfully adjudicate an edge kind.
+//
+// The pass matches an edge's SITE line against the reference list of its target
+// declaration, and on a miss asks the server what the site resolves to and
+// rebinds. That is meaningful for every edge that anchors a use / reference /
+// flow site the server can resolve:
+//
+//   - use sites: calls, references, field reads/writes, type instantiations;
+//   - type positions: typed_as / returns — when a concrete impl and the
+//     interface it satisfies share a name the resolver may pick the wrong one,
+//     and the server's definition rebinds to the declared type (measured: it
+//     binds a param / return typed as an interface to the interface, not an
+//     implementation);
+//   - dataflow through a call: arg_of / value_flow / returns_to — the server
+//     disambiguates the callee the value flows into (measured: it rebinds an
+//     arg_of from the wrong same-named method onto the one the call actually
+//     resolves to, e.g. Pool.EnqueueJob rather than Client.EnqueueJob).
+//
+// It is NOT meaningful for STRUCTURAL CONTAINMENT — a declaration's fixed
+// relationship to the structure that encloses it: a method to its type
+// (member_of), a symbol to its definer (defines) or container (contains), a
+// param to its function (param_of), a file to an imported package (imports), a
+// closure to a captured variable (captures). These are AST-deterministic and
+// carry no distinct use site, so the reference match wastes a round-trip and,
+// on a miss, can feed a correct edge into the definition-rebind fallback and
+// mutate its target (observed: a local variable's member_of edge rebound onto
+// an unrelated same-named method). member_of alone is the single largest
+// confidence<1.0 kind, so skipping this family removes a large slice of the
+// confirm round-trips while, if anything, improving correctness.
+func confirmableEdgeKind(k graph.EdgeKind) bool {
+	switch k {
+	case graph.EdgeMemberOf, graph.EdgeDefines, graph.EdgeContains,
+		graph.EdgeParamOf, graph.EdgeImports, graph.EdgeCaptures:
+		return false
+	default:
+		return true
+	}
+}
+
 // confirmGroup is the confirm pass's per-file work unit: every ambiguous
 // target whose referent declaration lives in rel. Grouping lets one didOpen of
 // rel serve all its targets' reference queries.

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -671,6 +671,15 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 		if e.Confidence >= 1.0 {
 			continue
 		}
+		// Skip structural-containment edges (member_of, defines, contains,
+		// param_of, imports, captures): they anchor no use site a reference
+		// lookup can adjudicate, so confirming them wastes a round-trip and can
+		// feed a correct edge into the definition-rebind fallback and mutate its
+		// target. Use-site, type-position and dataflow edges stay confirmable.
+		// See confirmableEdgeKind.
+		if !confirmableEdgeKind(e.Kind) {
+			continue
+		}
 		if from, ok := langAllByID[e.From]; ok {
 			targets = append(targets, enrichTarget{node: from, edge: e})
 		}

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -904,6 +904,23 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 					return
 				}
 				defer release()
+				// findReferences is positioned on the TARGET declaration, not the
+				// call site, so every ambiguous edge in this group that points at
+				// the same referent asks the server for the identical reference
+				// list — measured ~9x fan-in for calls, ~8x for references, since
+				// an overloaded / hot declaration draws many candidate edges.
+				// confirmRefMatchesSite still filters that shared list per edge,
+				// so caching it by target node turns N identical round-trips into
+				// one with byte-identical confirm/refute decisions. A target's
+				// file is unique to one group, so every edge to it lands here —
+				// the per-group cache captures all of its redundancy. ok=false
+				// records a server error so repeat targets skip exactly as the
+				// un-cached path did (error → skip, no fallback).
+				type cachedRefs struct {
+					refs []Location
+					ok   bool
+				}
+				refsByTarget := make(map[string]cachedRefs, len(grp.targets))
 				for _, t := range grp.targets {
 					if targetedCtx.Err() != nil {
 						return
@@ -916,12 +933,17 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 					if !ok {
 						continue
 					}
-					col := identifierColumn(content, toNode.StartLine, toNode.Name)
-					refs, err := p.findReferences(absRoot, grp.rel, line, col)
-					if err != nil {
+					cr, seen := refsByTarget[t.edge.To]
+					if !seen {
+						col := identifierColumn(content, toNode.StartLine, toNode.Name)
+						refs, err := p.findReferences(absRoot, grp.rel, line, col)
+						cr = cachedRefs{refs: refs, ok: err == nil}
+						refsByTarget[t.edge.To] = cr
+					}
+					if !cr.ok {
 						continue
 					}
-					if p.confirmRefMatchesSite(refs, absRoot, repoPrefix, t) {
+					if p.confirmRefMatchesSite(cr.refs, absRoot, repoPrefix, t) {
 						rmu.Lock()
 						semantic.ConfirmEdge(t.edge, p.Name())
 						semantic.PersistEdge(g, t.edge)


### PR DESCRIPTION
## Cut LSP semantic-enrichment cost on cold index

Profiling a real multi-repo cold index showed the wall-time is dominated by **LSP semantic enrichment**, not resolve. Two gopls/pyright passes alone accounted for ~28 min:

| pass | duration | enriched | what it spent |
|---|--:|--:|---|
| gopls (go) | 905s | 11,338 | 52,571 `textDocument/references` |
| pyright (python) | 774s | 3 | 26,059 `textDocument/references` |

`references` requests dominate every enrichment pass. They come from the **reference-confirm pass**, which promotes/refutes each ambiguous (`confidence < 1.0`) edge by asking the server for the target declaration's references and checking the edge's site is among them. Two inefficiencies made that pass issue far more round-trips than it needs.

### 1. Cache the reference list per target declaration

`findReferences` is positioned on the edge's **target declaration**, not its call site, so every ambiguous edge pointing at the same overloaded/hot declaration re-issued the **identical** query. Measured fan-in is **4.7×–9.4×** for call/reference edges. The list is now fetched once per target within a confirm group and the per-edge site match filters the shared list — byte-identical confirm/refute decisions, far fewer round-trips.

**Clean A/B, cold gopls pass on a small Go repo:** duration **230s → 108s (2.1×)**, `req_references` **6,475 → 2,199**, with identical `confirmed`/`added`/`nodes_enriched`.

### 2. Skip structural-containment edges

The confirm target set was *every* `confidence < 1.0` edge — with no kind filter. So it also issued a reference round-trip for **structural-containment** edges (`member_of`, `defines`, `contains`, `param_of`, `imports`, `captures`) — a third of the target set, `member_of` alone being the single largest kind. Those anchor a declaration's fixed relationship to its enclosing structure; they carry no use site a reference list can adjudicate, and on a miss the definition-rebind fallback can **mutate a correct edge's target**.

The confirm targets are now confined to edges that anchor a use / type-position / dataflow site the server can actually resolve. **Use-site** (`calls`, `references`, `reads`, `writes`, `instantiates`), **type-position** (`typed_as`, `returns`) and **dataflow** (`arg_of`, `value_flow`, `returns_to`) edges stay confirmable, so their LSP disambiguation is preserved.

**Verified by a full store diff (dedup vs +filter, same repo):**
- Every kept kind is **byte-identical** — including the `arg_of` rebind onto the call's actual `Pool.EnqueueJob` overload (confirmed against source) and the `typed_as`/`returns` binds to an interface rather than a concrete impl.
- The **only** edge that changes is one `member_of` on a local variable that the fallback had mis-rebound onto an unrelated same-named method; skipping it restores the resolver's correct bind.

Net: **0 regressions, 1 misbind fixed**, and `req_references` drops a further **~35%** on top of the per-target cache.

### Verification
- `GOWORK=off go build ./...`
- `GOWORK=off go test -race ./internal/semantic/lsp/ ./internal/resolver/ ./internal/indexer/ ./internal/mcp/` — green
- Isolated cold-index A/B on a fresh `HOME` (the live daemon untouched); byte-level store diff for the correctness proof above.

### At-scale A/B (23k-node Go repo, warm gopls cache — isolates the confirm pass)

| | before | after (both commits) |
|---|--:|--:|
| gopls enrichment | 556s | **205s (−63%, 2.7×)** |
| `req_references` | 53,455 | **11,518 (−78%)** |
| `nodes_enriched` | 11,272 | **11,272 (identical)** |
| `added` | 984 | **984 (identical)** |

`confirmed` drops 37,323 → 28,722 — that is the structural-containment kinds no longer being promoted to the lsp tier; their **targets are unchanged** (proven by the byte-level store diff on the smaller repo, and the mechanism is repo-independent). Cold, the same before-pass ran **>17 min without completing**.
