### PR TITLE
Default Go enrichment to in-process go-types instead of gopls-over-LSP

### DIFF
--- a/internal/semantic/goanalysis/provider.go
+++ b/internal/semantic/goanalysis/provider.go
@@ -346,52 +346,91 @@ func (p *Provider) EnrichRepo(g graph.Store, repoPrefix, repoRoot string) (*sema
 	result.EdgesConfirmed += p.enrichImplements(g, pkgs, objToNode)
 	result.EdgesAdded += p.addMissingImplements(g, pkgs, objToNode, absRoot)
 
-	// Phase 4: Enrich node metadata with type info.
-	// EnrichNodeMeta mutates Node.Meta in place; on disk backends the
-	// node is a per-call GetNode reconstruction, so collect every stamped
-	// node and round-trip it through the store at the end (one AddBatch)
-	// or the semantic_type / return_type stamps are silently discarded on
-	// the disk backend. See semantic.EnrichNodeMeta.
-	var stampedNodes []*graph.Node
+	// Phase 4: node-driven type stamping. go/types has a Def — hence an exact
+	// type — for every function, method, field, parameter and local variable.
+	// The bottleneck is attaching each Def to its graph node. Phase 1 maps a
+	// Def with MatchNodeByFileLine, which returns the innermost node whose
+	// RANGE contains the ident line, so a function's params and locals collapse
+	// onto the enclosing function node and never receive their own type — that
+	// is why the old Defs→node stamping reached only ~20% of locals and ~24% of
+	// params. Here we index every named Def by (file, name) and, for each graph
+	// node, pick the same-named Def whose ident sits closest to the node's own
+	// declaration line (within its range). That attaches a local/param to ITS
+	// node rather than its enclosing function, lifting coverage to what go/types
+	// actually knows (every named symbol).
+	//
+	// EnrichNodeMeta mutates Node.Meta in place; on disk backends the node is a
+	// per-call GetNode reconstruction, so collect every stamped node and
+	// round-trip it through the store at the end (one AddBatch) or the
+	// semantic_type / return_type stamps are silently discarded. See
+	// semantic.EnrichNodeMeta.
+	type defEntry struct {
+		line int
+		obj  types.Object
+	}
+	defsByName := make(map[string][]defEntry) // key: rel \x00 name
+	relSet := make(map[string]struct{})
 	for _, pkg := range pkgs {
 		if pkg.TypesInfo == nil {
 			continue
 		}
 		for ident, obj := range pkg.TypesInfo.Defs {
-			if obj == nil {
+			if obj == nil || ident.Pos() == token.NoPos || ident.Name == "" || ident.Name == "_" {
 				continue
 			}
-			nodeID, ok := objToNode[obj]
-			if !ok {
+			pos := fset.Position(ident.Pos())
+			rel := relativePath(pos.Filename, absRoot)
+			if rel == "" {
 				continue
 			}
-			node := g.GetNode(nodeID)
-			if node == nil {
+			defsByName[rel+"\x00"+ident.Name] = append(defsByName[rel+"\x00"+ident.Name], defEntry{pos.Line, obj})
+			relSet[rel] = struct{}{}
+		}
+	}
+	var stampedNodes []*graph.Node
+	for rel := range relSet {
+		for _, node := range g.GetFileNodes(rel) {
+			if node.Kind == graph.KindFile || node.Kind == graph.KindImport || node.Name == "" {
+				continue
+			}
+			// Among same-named Defs in this file, pick the one whose ident line
+			// is closest to the node's start line and falls within its range —
+			// this distinguishes two locals of the same name in one function.
+			best := types.Object(nil)
+			bestDist := 1 << 30
+			for _, e := range defsByName[rel+"\x00"+node.Name] {
+				if e.line < node.StartLine-1 || e.line > node.EndLine+1 {
+					continue
+				}
+				d := e.line - node.StartLine
+				if d < 0 {
+					d = -d
+				}
+				if d < bestDist {
+					bestDist = d
+					best = e.obj
+				}
+			}
+			if best == nil {
 				continue
 			}
 
 			didStamp := false
-			typeStr := types.TypeString(obj.Type(), nil)
-			if typeStr != "" && typeStr != "invalid type" {
+			if typeStr := types.TypeString(best.Type(), nil); typeStr != "" && typeStr != "invalid type" {
 				semantic.EnrichNodeMeta(node, "semantic_type", typeStr, p.Name())
 				result.NodesEnriched++
 				didStamp = true
 			}
-
 			// Add return type for functions.
-			if fn, ok := obj.(*types.Func); ok {
-				sig, ok := fn.Type().(*types.Signature)
-				if ok && sig.Results().Len() > 0 {
-					retType := types.TypeString(sig.Results(), nil)
-					semantic.EnrichNodeMeta(node, "return_type", retType, p.Name())
+			if fn, ok := best.(*types.Func); ok {
+				if sig, ok := fn.Type().(*types.Signature); ok && sig.Results().Len() > 0 {
+					semantic.EnrichNodeMeta(node, "return_type", types.TypeString(sig.Results(), nil), p.Name())
 					didStamp = true
 				}
 			}
 			if didStamp {
 				stampedNodes = append(stampedNodes, node)
 			}
-
-			_ = ident // used in range
 		}
 	}
 	if len(stampedNodes) > 0 {

--- a/internal/serverstack/shared_server.go
+++ b/internal/serverstack/shared_server.go
@@ -332,13 +332,16 @@ func NewSharedServer(cfg SharedServerConfig) (*SharedServer, error) {
 			goMode = goanalysis.ModeCallGraph
 		}
 		goProvider := goanalysis.NewProvider(goMode, goTypesIncludeTests(), logger)
-		// The go/packages "go-types" provider is a full `go list ./...` +
-		// go/types pass over the module on every index — tens of seconds per
-		// Go module per warmup, and on an already-resolved graph it routinely
-		// confirms zero new edges (the always-on go-ast-types tree-sitter
-		// floor already covers Go). Keep it as the contracts binding resolver,
-		// but only register it for enrichment when explicitly opted in.
-		if goTypesEnrichEnabled(conf.Semantic) {
+		// The go/packages "go-types" provider owns Go enrichment when the
+		// toolchain is present: it type-checks the module once in-process and
+		// stamps every symbol's exact type plus resolves stdlib/dep calls to
+		// real nodes, in a fraction of the time the per-request gopls LSP pass
+		// takes (which additionally leaves external calls as dead stubs). As an
+		// eager provider it claims the "go" language slot, so the LSP router's
+		// gopls spec is skipped as a gap-filler and never spawns. Registration
+		// is gated on Available() (a `go` toolchain on PATH): without it the
+		// slot stays open and gopls / the tree-sitter floor serve Go instead.
+		if goTypesEnrichEnabled(conf.Semantic) && goProvider.Available() {
 			semMgr.RegisterProvider(goProvider)
 		}
 		contracts.SetBindingResolver(goProvider)
@@ -665,15 +668,20 @@ func NewSharedServer(cfg SharedServerConfig) (*SharedServer, error) {
 	return s, nil
 }
 
-// goTypesEnrichEnabled reports whether the heavyweight go/packages
-// "go-types" enrichment provider should be registered. Default OFF — the
-// always-on go-ast-types tree-sitter floor serves Go resolution at a
-// fraction of the cost. GORTEX_GO_TYPES=1/0 overrides the config key.
+// goTypesEnrichEnabled reports whether the in-process go/packages "go-types"
+// enrichment provider should be registered for Go. Default ON: it is both
+// faster and more complete than driving gopls over LSP (see the registration
+// site), and registration is separately gated on the toolchain being present.
+// Precedence: GORTEX_GO_TYPES=1/0 wins, then an explicit semantic.go_types
+// config value, then the on-by-default.
 func goTypesEnrichEnabled(sem config.SemanticConfig) bool {
 	if v := os.Getenv("GORTEX_GO_TYPES"); v != "" {
 		return v == "1" || strings.EqualFold(v, "true")
 	}
-	return sem.GoTypesEnabledOrDefault()
+	if sem.GoTypes != nil {
+		return *sem.GoTypes
+	}
+	return true
 }
 
 // goTypesIncludeTests reports whether the go-types provider should load

--- a/internal/serverstack/shared_server.go
+++ b/internal/serverstack/shared_server.go
@@ -331,7 +331,7 @@ func NewSharedServer(cfg SharedServerConfig) (*SharedServer, error) {
 		if cfg.SemanticMode == "callgraph" {
 			goMode = goanalysis.ModeCallGraph
 		}
-		goProvider := goanalysis.NewProvider(goMode, false, logger)
+		goProvider := goanalysis.NewProvider(goMode, goTypesIncludeTests(), logger)
 		// The go/packages "go-types" provider is a full `go list ./...` +
 		// go/types pass over the module on every index — tens of seconds per
 		// Go module per warmup, and on an already-resolved graph it routinely
@@ -674,4 +674,14 @@ func goTypesEnrichEnabled(sem config.SemanticConfig) bool {
 		return v == "1" || strings.EqualFold(v, "true")
 	}
 	return sem.GoTypesEnabledOrDefault()
+}
+
+// goTypesIncludeTests reports whether the go-types provider should load
+// _test.go files (and each package's external test variant). Loading them
+// roughly doubles the go/packages work per module, so it is OFF by default;
+// GORTEX_GO_TYPES_TESTS=1 opts in to stamp test-file symbols too (LSP hover
+// covers them, so the opt-in closes that coverage gap when it matters).
+func goTypesIncludeTests() bool {
+	return os.Getenv("GORTEX_GO_TYPES_TESTS") == "1" ||
+		strings.EqualFold(os.Getenv("GORTEX_GO_TYPES_TESTS"), "true")
 }


### PR DESCRIPTION
## Default Go enrichment to in-process go-types instead of gopls-over-LSP

Profiling a real multi-repo cold index showed **LSP semantic enrichment is the dominant cost — ~3.4 h across 24 repos**, and `lsp-gopls` alone was **6,951s (57%)**. The cause is structural: driving gopls over the LSP protocol re-type-checks the module **per request** — one `hover` per symbol, one `textDocument/references` per ambiguous edge, one call-hierarchy per function — hundreds of thousands of round-trips.

Gortex already ships the fast path: the **`go-types` provider** (`go/packages` + `go/types`) type-checks a module **once, in-process**. It was disabled by default, so gopls filled the vacuum. This PR makes go-types the default and closes the one gap it had.

### What go-types produces that gopls does *not*

A with/without benchmark on a 24k-node Go repo — go-types uniquely resolves **stdlib/dep calls to real graph nodes**:

| | tree-sitter floor | go-types | gopls (LSP) |
|---|--:|--:|--:|
| `ext::` external nodes | 0 | **392** | 0 |
| edges resolved to external nodes | 0 | **8,786** | 0 |
| stdlib/dep calls left as dead stubs | 15,874 | **6,567** | 15,874 |

gopls leaves every `fmt.Println`/`errors.New`-style call an unnavigable stub; go-types turns 8,786 of them into real nodes. (Interface `implements` edges are equal across all three — the resolver's structural pass already produces them, so that is *not* a type-checker differentiator.)

### Three commits

1. **Node-driven type stamping.** Phase 4 stamped only the Defs that a containment matcher mapped, collapsing a function's params/locals onto the enclosing node — go-types stamped ~20% of locals. Indexing every named Def by `(file, name)` and attaching each graph node to the closest same-named Def lifts non-test coverage **5,674 → 7,065**, now matching the gopls hover pass (6,851) it replaces, with byte-correct types.
2. **`GORTEX_GO_TYPES_TESTS=1`.** go-types skips `_test.go` by default (loading test variants ~doubles the pass). Opt in to stamp test-file symbols too — with it go-types stamps **16,644**, exceeding gopls everywhere while still finishing faster end-to-end.
3. **The flip.** go-types defaults on (env `GORTEX_GO_TYPES` / `semantic.go_types` still win). As an eager provider it claims the Go slot, so the LSP router's gopls spec is skipped and never spawns. Registration is gated on the `go` toolchain being present — without it the slot stays open for gopls / the tree-sitter floor.

### Verified (default config, gopls installed)

| 24k-node Go repo | gopls (before) | go-types (after) |
|---|--:|--:|
| index-to-settled | 942s | **157s (6×)** |
| gopls subprocess | ran (864s) | **never spawned** |
| Go type stamps | 6,851 | **7,065** |
| external-node edges | 0 | **8,779** |

- Build `GOWORK=off go build ./...`; `go test -race ./internal/semantic/... ./internal/serverstack/ ./internal/indexer/` green.
- Isolated cold-index runs on a fresh `HOME`; the live daemon untouched.

### Notes / trade-offs
- go-types needs the module to **build** (`go/packages`). Partial builds still enrich the packages that type-check; a total load failure leaves Go at parse+resolve (no type stamps) — the toolchain gate + eager-slot mean gopls is not a fallback in that case.
- It holds the type-checked program in memory (~1–2 GB/large module), already bounded by an idle stash TTL + count ceiling.
