### PR TITLE
Skip LSP enrichment when a server's project is not analyzable

### DIFF
--- a/internal/semantic/lsp/project_ready.go
+++ b/internal/semantic/lsp/project_ready.go
@@ -1,0 +1,59 @@
+package lsp
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// tsProjectReady reports whether a TypeScript/JavaScript workspace has its
+// dependency tree installed. typescript-language-server (and tsgo) resolve
+// every import and cross-file type through node_modules; without it, a
+// project that has a tsconfig answers "no package metadata" to every request,
+// so a whole-repo hover / call-hierarchy sweep runs for minutes and enriches
+// nothing (observed: 627 .ts files, 1,703s, zero nodes enriched). The gate is
+// intentionally narrow: it only reports not-ready when the repo declares a
+// TypeScript project (a tsconfig.json) AND no node_modules exists anywhere in
+// it. A repo with loose .js and no tsconfig is left alone — tsserver's
+// inferred project still types same-file symbols there.
+//
+// The walk is directory-only and bounded (depth 5, skipping node_modules /
+// VCS / build output), so it is cheap even on a large tree, and it runs once
+// per repo per pass, not per file.
+func tsProjectReady(root string) (bool, string) {
+	if root == "" {
+		return true, ""
+	}
+	var hasTSConfig, hasNodeModules bool
+	rootDepth := strings.Count(filepath.Clean(root), string(os.PathSeparator))
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil //nolint:nilerr // unreadable entries just don't contribute evidence
+		}
+		if hasNodeModules && hasTSConfig {
+			return fs.SkipAll
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case "node_modules":
+				hasNodeModules = true
+				return fs.SkipDir
+			case ".git", ".hg", ".svn", "vendor", "dist", "build", ".next", "out", "target":
+				return fs.SkipDir
+			}
+			if strings.Count(filepath.Clean(path), string(os.PathSeparator))-rootDepth >= 5 {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if d.Name() == "tsconfig.json" {
+			hasTSConfig = true
+		}
+		return nil
+	})
+	if hasTSConfig && !hasNodeModules {
+		return false, "TypeScript project found but node_modules is absent; run `npm install` (or pnpm/yarn), then re-index"
+	}
+	return true, ""
+}

--- a/internal/semantic/lsp/project_ready_test.go
+++ b/internal/semantic/lsp/project_ready_test.go
@@ -1,0 +1,67 @@
+package lsp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTSProjectReady(t *testing.T) {
+	mk := func(t *testing.T, files, dirs []string) string {
+		t.Helper()
+		root := t.TempDir()
+		for _, d := range dirs {
+			if err := os.MkdirAll(filepath.Join(root, d), 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}
+		for _, f := range files {
+			p := filepath.Join(root, f)
+			if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(p, []byte("{}"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return root
+	}
+
+	t.Run("tsconfig without node_modules is not ready", func(t *testing.T) {
+		root := mk(t, []string{"frontend/tsconfig.json"}, nil)
+		ready, rem := tsProjectReady(root)
+		if ready {
+			t.Fatalf("want not ready, got ready")
+		}
+		if rem == "" {
+			t.Fatalf("want a remediation string")
+		}
+	})
+
+	t.Run("tsconfig with node_modules is ready", func(t *testing.T) {
+		root := mk(t, []string{"frontend/tsconfig.json"}, []string{"frontend/node_modules/react"})
+		if ready, _ := tsProjectReady(root); !ready {
+			t.Fatalf("want ready when node_modules present")
+		}
+	})
+
+	t.Run("no tsconfig is left alone (ready)", func(t *testing.T) {
+		root := mk(t, []string{"src/app.js"}, nil)
+		if ready, _ := tsProjectReady(root); !ready {
+			t.Fatalf("want ready when there is no tsconfig (loose JS)")
+		}
+	})
+
+	t.Run("node_modules deeper than tsconfig still counts", func(t *testing.T) {
+		root := mk(t, []string{"tsconfig.json"}, []string{"packages/web/node_modules/x"})
+		if ready, _ := tsProjectReady(root); !ready {
+			t.Fatalf("want ready when node_modules exists anywhere")
+		}
+	})
+
+	t.Run("empty root is ready", func(t *testing.T) {
+		if ready, _ := tsProjectReady(""); !ready {
+			t.Fatalf("want ready for empty root")
+		}
+	})
+}

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -702,6 +702,29 @@ func (p *Provider) EnrichRepoContext(ctx context.Context, g graph.Store, repoPre
 		return result, nil
 	}
 
+	// Project-readiness preflight: a server whose workspace lacks the project
+	// setup it needs (node_modules for tsserver) resolves nothing — every
+	// import / cross-file request returns "no package metadata" — yet still
+	// pays a full index + per-file hover / call-hierarchy sweep for minutes.
+	// Skip the pass entirely; the tree-sitter floor still covers these files,
+	// and the resolver's static edges are untouched. This is the general form
+	// of the compile-database degrade below, for a missing dependency tree
+	// rather than a missing compilation database.
+	if p.spec != nil && p.spec.ProjectReady != nil {
+		if ready, remediation := p.spec.ProjectReady(absRoot); !ready {
+			if p.logger != nil {
+				p.logger.Warn("LSP enrich: skipped, project not analyzable",
+					zap.String("provider", p.Name()),
+					zap.String("repo_prefix", repoPrefix),
+					zap.String("remediation", remediation),
+				)
+			}
+			result.DegradedReason = remediation
+			result.DurationMs = time.Since(start).Milliseconds()
+			return result, nil
+		}
+	}
+
 	// Compile-database preflight: a server that needs a compilation database
 	// (clangd) but has none rebuilds a full fallback AST on every didOpen, so
 	// the hover / hierarchy sweep churns for little signal and a directly

--- a/internal/semantic/lsp/registry.go
+++ b/internal/semantic/lsp/registry.go
@@ -99,6 +99,17 @@ type ServerSpec struct {
 	// std-library types the graph never indexes, so its recall lives in
 	// the full sweep rather than in cheaper static confirmation.
 	DefaultSweepMode string
+	// ProjectReady, when non-nil, reports whether a workspace has the
+	// project setup this server needs to resolve anything at all — e.g.
+	// node_modules for tsserver, whose every cross-file / import lookup
+	// returns "no package metadata" without it. When it returns
+	// (false, remediation) the enrichment pass is SKIPPED entirely (not
+	// merely degraded like NeedsCompileDB): such a server spends minutes
+	// indexing and hovering to produce zero semantic signal, and the
+	// tree-sitter floor still covers those files. This is the general form
+	// of NeedsCompileDB for servers whose failure is a missing dependency
+	// tree rather than a missing compilation database.
+	ProjectReady func(root string) (ready bool, remediation string)
 }
 
 // ConnectSpec carries the transport coordinates for passive LSP attach
@@ -267,9 +278,10 @@ var Servers = []ServerSpec{
 			".mjs": "javascript",
 			".cjs": "javascript",
 		},
-		Priority:    5,
-		Daemon:      true,
-		MaxParallel: 10,
+		Priority:     5,
+		Daemon:       true,
+		MaxParallel:  10,
+		ProjectReady: tsProjectReady,
 	},
 	{
 		// tsgo is the native-Go TypeScript compiler (the
@@ -295,9 +307,10 @@ var Servers = []ServerSpec{
 			".mjs": "javascript",
 			".cjs": "javascript",
 		},
-		Priority:    6,
-		Daemon:      true,
-		MaxParallel: 10,
+		Priority:     6,
+		Daemon:       true,
+		MaxParallel:  10,
+		ProjectReady: tsProjectReady,
 	},
 	{
 		Name:       "pyright",


### PR DESCRIPTION
## Skip LSP enrichment when a server's project is not analyzable

On a real multi-repo cold index, several heavy language-server passes ran for minutes and enriched **zero** nodes because the workspace lacked the setup the server needs. The worst: **tsserver on a 627-file TypeScript tree with no `node_modules` — 1,703s, 0 nodes enriched**, every import and cross-file request answered "no package metadata".

This generalizes the existing clangd `NeedsCompileDB` degrade into a per-spec **`ProjectReady`** predicate. When a server reports its project unusable, the pass is **skipped entirely** (not merely degraded) — the tree-sitter floor still covers those files and the resolver's static edges are untouched.

Wired for tsserver / tsgo: not-ready when the repo declares a `tsconfig.json` but has **no `node_modules`** anywhere (loose `.js` without a tsconfig is left alone — tsserver's inferred project still types same-file symbols there). The readiness walk is directory-only and bounded (depth 5, skipping `node_modules`/VCS/build output), runs once per repo per pass.

### Verified end-to-end
- TS project **without** `node_modules`: pass returns in **2ms** with the remediation logged (`run npm install, then re-index`), instead of 1,703s.
- Same project **with** `node_modules`: gate does not fire, tsserver runs unchanged.
- Unit tests cover the tsconfig-without / tsconfig-with / no-tsconfig / nested / empty-root cases; `go test -race ./internal/semantic/lsp/` green.

### Scope / follow-up
This covers the missing-dependency-tree failure (tsserver, the single biggest waste). The other zero-enrich passes (rust-analyzer / pyright returning `type_empty` on projects they can't resolve) fail differently and need a separate **circuit-breaker** that tracks both stamp *and* edge yield — because rust-analyzer's value is call-hierarchy edges, not type stamps, so an empty-*type* signal alone must not abort it. Left as a follow-up.
