### PR TITLE
resolver: stop framework synthesizers from full-scanning the graph

### DIFF
--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -953,6 +953,9 @@ func (mi *MultiIndexer) RunGlobalGraphPasses(ctx context.Context) {
 	mi.logger.Info("global pass: framework dispatch synthesis",
 		zap.Int("edges", fwRep.Total),
 		zap.Any("per_synthesizer", fwRep.Per),
+		zap.Int64("gate_ms", fwRep.GateMillis),
+		zap.Int64("claim_ms", fwRep.ClaimMillis),
+		zap.Int64("demote_ms", fwRep.DemoteMillis),
 		zap.Duration("elapsed", time.Since(fwStart)))
 	// External-call placeholder synthesis (opt-in). Runs after the
 	// stub passes so only genuinely un-indexed external targets are

--- a/internal/resolver/chain_factory.go
+++ b/internal/resolver/chain_factory.go
@@ -28,11 +28,11 @@ func ResolveFactoryChains(g graph.Store) int {
 	}
 	resolved := 0
 	var batch []graph.EdgeReindex
-	for _, e := range g.AllEdges() {
+	// Scoped to the two kinds this pass ever acts on (below), instead of
+	// AllEdges() decoding every kind in the graph — calls+references is a
+	// fraction of the total edge count on a large multi-repo graph.
+	for e := range edgesByKinds(g, []graph.EdgeKind{graph.EdgeCalls, graph.EdgeReferences}) {
 		if e == nil || e.Meta == nil {
-			continue
-		}
-		if e.Kind != graph.EdgeCalls && e.Kind != graph.EdgeReferences {
 			continue
 		}
 		if !graph.IsUnresolvedTarget(e.To) {

--- a/internal/resolver/fn_value_gate.go
+++ b/internal/resolver/fn_value_gate.go
@@ -48,7 +48,27 @@ func ResolveFnValueCallbacks(g graph.Store) int {
 		return 0
 	}
 	var landed []*graph.Edge
-	for _, e := range g.AllEdges() {
+	// Candidates sharing a file each want the same GetFileNodes(filePath)
+	// result. Fetching it fresh per candidate is a per-candidate SQL
+	// round-trip regardless of how few nodes the file has — a generated file
+	// with a large candidate count (a tree-sitter parser.c, an ORM-generated
+	// Go file) turns into hundreds of thousands of redundant queries against
+	// a handful of nodes. Cache per file for the life of this pass.
+	fileNodes := map[string][]*graph.Node{}
+	getFileNodes := func(filePath string) []*graph.Node {
+		if ns, ok := fileNodes[filePath]; ok {
+			return ns
+		}
+		ns := g.GetFileNodes(filePath)
+		fileNodes[filePath] = ns
+		return ns
+	}
+	// Every callback-candidate placeholder EmitFnValueCandidates emits is a
+	// graph.EdgeReferences edge (see languages.EmitFnValueCandidates), so a
+	// kind-scoped scan sees the same candidates as AllEdges() without paying
+	// to decode the graph's other edge kinds (calls, arg_of, member_of, ...) —
+	// several times the size of references alone on a large multi-repo graph.
+	for e := range g.EdgesByKind(graph.EdgeReferences) {
 		if e == nil || e.Meta == nil {
 			continue
 		}
@@ -86,7 +106,7 @@ func ResolveFnValueCallbacks(g graph.Store) int {
 			if target = resolveFnValueSelfMember(g, e.From, name); target != "" {
 				conf, origin = 0.85, graph.OriginASTResolved
 			} else {
-				target = resolveFnValueName(g, e.FilePath, name)
+				target = resolveFnValueName(getFileNodes(e.FilePath), name)
 			}
 		case recvHint != "":
 			if target = resolveMemberByType(g, recvHint, name); target != "" {
@@ -96,7 +116,7 @@ func ResolveFnValueCallbacks(g graph.Store) int {
 				conf = 0.45
 			}
 		default:
-			target = resolveFnValueName(g, e.FilePath, name)
+			target = resolveFnValueName(getFileNodes(e.FilePath), name)
 			if target == "" && ungated {
 				target = resolveFnValueCrossModule(g, name)
 				conf = 0.45
@@ -135,15 +155,16 @@ func ResolveFnValueCallbacks(g graph.Store) int {
 	return len(landed)
 }
 
-// resolveFnValueName returns the ID of a same-file function or method named
-// name, or "" when none exists. Same-file scope is the conservative default;
-// per-language capture extends the gate with imported-symbol and C-family
-// file-scope rules on top of this skeleton.
-func resolveFnValueName(g graph.Store, filePath, name string) string {
-	if filePath == "" || name == "" {
+// resolveFnValueName returns the ID of a function or method named name among
+// fileNodes (the caller's already-fetched same-file node list), or "" when
+// none exists. Same-file scope is the conservative default; per-language
+// capture extends the gate with imported-symbol and C-family file-scope
+// rules on top of this skeleton.
+func resolveFnValueName(fileNodes []*graph.Node, name string) string {
+	if name == "" {
 		return ""
 	}
-	for _, n := range g.GetFileNodes(filePath) {
+	for _, n := range fileNodes {
 		if n == nil {
 			continue
 		}

--- a/internal/resolver/framework_synth.go
+++ b/internal/resolver/framework_synth.go
@@ -1,6 +1,10 @@
 package resolver
 
-import "github.com/zzet/gortex/internal/graph"
+import (
+	"time"
+
+	"github.com/zzet/gortex/internal/graph"
+)
 
 // Framework-dispatch synthesizer engine.
 //
@@ -317,6 +321,11 @@ func defaultFrameworkSynthesizers() []FrameworkSynthesizer {
 type SynthCount struct {
 	Name  string `json:"name"`
 	Edges int    `json:"edges"`
+	// Millis is how long this synthesizer's Synthesize call took. Named
+	// passes that land 0 edges are not free — many scan a shared edge/node
+	// kind across the whole graph before concluding there is nothing to
+	// bind — so this rides on every row, not just the ones with edges.
+	Millis int64 `json:"ms,omitempty"`
 }
 
 // FrameworkSynthReport is the aggregate result of one
@@ -332,6 +341,12 @@ type FrameworkSynthReport struct {
 	// tier because they attach to a same-named member of a type unrelated to
 	// the edge's receiver_type.
 	ReceiverGated int `json:"receiver_type_gated,omitempty"`
+	// GateMillis/ClaimMillis/DemoteMillis time the three tail passes that
+	// run once (not per-synthesizer) after the main loop, so a slow one
+	// doesn't hide behind the loop's aggregate elapsed.
+	GateMillis   int64 `json:"gate_ms,omitempty"`
+	ClaimMillis  int64 `json:"claim_ms,omitempty"`
+	DemoteMillis int64 `json:"demote_ms,omitempty"`
 }
 
 // RunFrameworkSynthesizers runs every registered framework synthesizer
@@ -343,19 +358,24 @@ func RunFrameworkSynthesizers(g graph.Store) FrameworkSynthReport {
 		return rep
 	}
 	for _, s := range defaultFrameworkSynthesizers() {
+		start := time.Now()
 		n := s.Synthesize(g)
-		rep.Per = append(rep.Per, SynthCount{Name: s.Name(), Edges: n})
+		rep.Per = append(rep.Per, SynthCount{Name: s.Name(), Edges: n, Millis: time.Since(start).Milliseconds()})
 		rep.Total += n
 	}
 	// Drop coincidental cross-language-family reference/import results before
 	// the claiming resolvers run, so a gated edge cannot be mistaken for a
 	// resolved placeholder downstream. Bridge synthesizers are exempt.
+	gateStart := time.Now()
 	rep.Gated = applyFrameworkFamilyGate(g)
+	rep.GateMillis = time.Since(gateStart).Milliseconds()
 	// Claiming resolvers run last — after every framework synthesizer has
 	// had its chance to consume a pre-stamped placeholder, but before
 	// external-call synthesis classifies the residual unresolved refs as
 	// external. Reported in registration order for determinism.
+	claimStart := time.Now()
 	claimed := RunClaimingResolvers(g)
+	rep.ClaimMillis = time.Since(claimStart).Milliseconds()
 	for _, r := range defaultClaimingResolvers() {
 		n := claimed[r.Name()]
 		rep.Per = append(rep.Per, SynthCount{Name: r.Name(), Edges: n})
@@ -363,7 +383,9 @@ func RunFrameworkSynthesizers(g graph.Store) FrameworkSynthReport {
 	}
 	// Receiver-type gate runs last: it corrects (demotes) already-bound C#
 	// member calls, so it must see the settled call graph.
+	demoteStart := time.Now()
 	rep.ReceiverGated = demoteCSharpMisattributedMemberCalls(g)
+	rep.DemoteMillis = time.Since(demoteStart).Milliseconds()
 	return rep
 }
 


### PR DESCRIPTION
## Summary

- On a real 26-repo daemon, the `framework dispatch synthesis` global pass took **9,667.76s (161 min) — 97.6% of the 165-minute post-resolve settle phase**, with most of the ~46 registered synthesizers landing zero edges on this corpus.
- Root cause: two synthesizers (`ResolveFnValueCallbacks`, `ResolveFactoryChains`) scanned **every edge in the graph** via `AllEdges()` and filtered by kind in Go, instead of using the existing kind-scoped `EdgesByKind`/`edgesByKinds` helpers every other synthesizer already uses (which push the filter into SQL).
- `ResolveFnValueCallbacks` additionally re-issued a fresh `GetFileNodes` SQL round-trip **per candidate edge**, not per file — on this real graph, 522,679 candidate placeholder edges triggered that many round-trips, with a single generated file (`tree-sitter-swift/src/parser.c`) alone responsible for 199,117 of them against a file holding only 24 nodes.
- Added per-synthesizer and per-tail-pass elapsed-time logging to `RunFrameworkSynthesizers` so a regression like this shows up directly in the existing log line instead of hiding behind one aggregate duration.

## Measured

Isolated before/after against a `.backup`'d snapshot of the real 26-repo store (live daemon untouched throughout):

| synthesizer | before | after | edges (before → after) |
|---|---|---|---|
| fn-value-callback | >51 min (killed, still running) | 5m19.6s | — → 15,950 (daemon log showed 15,947 pre-fix) |
| factory-chain | 17.0s | 8.5s | 0 → 0 |

Same resolution results (edge counts match within noise), dramatically faster.

## Test plan

- [x] `GOWORK=off go build ./...`
- [x] `GOWORK=off go vet ./internal/resolver/... ./internal/indexer/...`
- [x] `GOWORK=off go test ./internal/resolver/... ./internal/indexer/...`
- [x] `GOWORK=off go test -race ./internal/resolver/... ./internal/indexer/...`