### PR TITLE
graph/store_sqlite: index unresolved edges via a generated column

### DIFF
--- a/internal/graph/store_sqlite/bulk_load.go
+++ b/internal/graph/store_sqlite/bulk_load.go
@@ -50,6 +50,14 @@ var bulkDroppableIndexes = []bulkDroppableIndex{
 	{"edges_by_from", `CREATE INDEX IF NOT EXISTS edges_by_from ON edges(from_id, kind)`},
 	{"edges_by_to", `CREATE INDEX IF NOT EXISTS edges_by_to ON edges(to_id, kind)`},
 	{"edges_by_kind", `CREATE INDEX IF NOT EXISTS edges_by_kind ON edges(kind)`},
+	// Backs EdgesWithUnresolvedTarget — the resolver's main pending-edge
+	// collector, called on every full resolve. is_unresolved is a VIRTUAL
+	// generated column (see isUnresolvedColumnDDL); indexing it turns a
+	// full-table scan (the prior to_id-based OR query forced SQLite to
+	// abandon its index) into an index search whose bookmark lookups land
+	// in ascending rowid order (see isUnresolvedColumnDDL's doc comment for
+	// why that beats an equivalent-looking to_id-based index).
+	{"edges_by_unresolved", `CREATE INDEX IF NOT EXISTS edges_by_unresolved ON edges(is_unresolved)`},
 	// Partial index over exactly the not-yet-semantically-stamped nodes per
 	// repo. Stays small in steady state (most nodes end up stamped), so a
 	// future "unstamped nodes in this repo" query is an index scan over the

--- a/internal/graph/store_sqlite/schema.go
+++ b/internal/graph/store_sqlite/schema.go
@@ -1,5 +1,83 @@
 package store_sqlite
 
+import "database/sql"
+
+// isUnresolvedColumnDDL is the edges.is_unresolved generated column: a
+// VIRTUAL, indexed boolean mirroring graph.IsUnresolvedTarget's two shapes
+// (the bare `unresolved::Name` prefix and the multi-repo COPY-rewrite
+// `<repoPrefix>::unresolved::Name` infix), computed by SQLite itself from
+// to_id — no Go call site has to remember to keep it in sync. VIRTUAL, not
+// STORED: SQLite refuses `ALTER TABLE ADD COLUMN ... STORED` on a non-empty
+// table ("cannot add a STORED column"), which every real installed store is.
+// VIRTUAL has no such restriction and is just as fast here — the read path
+// always goes through the index below, and an index always stores its own
+// materialised key values regardless of whether the underlying column is
+// virtual or stored. Added via ensureEdgeColumns (ALTER TABLE) rather than
+// baked into schemaSQL's CREATE TABLE so one code path handles both a fresh
+// DB (column missing right after CREATE TABLE) and an existing one (column
+// missing from before this was introduced) identically — see
+// ensureNodeColumns for the same pattern on the nodes table.
+//
+// Measured on a real 26-repo store (2.57M edges, 847,684 unresolved, ~33%
+// selectivity): replacing the OR'd `to_id` range/LIKE query with
+// `is_unresolved = 1` cut EdgesWithUnresolvedTarget from 7.96s to 2.95s
+// (2.7x). The prior approach of splitting the OR into two to_id-based
+// queries (one indexed range, one LIKE) was WORSE (13.49s) despite a
+// better-looking EXPLAIN QUERY PLAN: at ~33% selectivity the to_id index's
+// matching rows are ordered by string value, so the mandatory per-row
+// bookmark lookup back into the main table is effectively random I/O. The
+// boolean column's matching rows are all rowid-tie-broken (identical index
+// key), so its bookmark lookups land in ascending rowid order — sequential,
+// not random. Same "SEARCH ... USING INDEX" in EXPLAIN QUERY PLAN either way;
+// only real measurement told them apart.
+const isUnresolvedColumnDDL = `is_unresolved INTEGER GENERATED ALWAYS AS (
+    CASE WHEN (to_id >= 'unresolved::' AND to_id < 'unresolved:;') OR to_id LIKE '%::unresolved::%' THEN 1 ELSE 0 END
+) VIRTUAL`
+
+// ensureEdgeColumns adds the is_unresolved generated column (and its index)
+// to an edges table created before it existed — which, since the column is
+// deliberately not in schemaSQL's CREATE TABLE (see isUnresolvedColumnDDL),
+// includes a freshly created table too. Mirrors ensureNodeColumns' PRAGMA +
+// conditional ALTER pattern, but queries table_xinfo rather than table_info:
+// table_info silently OMITS generated columns from its result set (verified
+// against the pinned modernc.org/sqlite driver — a reopened store's
+// is_unresolved column is invisible to table_info, so the existence check
+// always came back false and every reopen re-ran the ALTER, failing with
+// "duplicate column name"). table_xinfo lists every column, generated ones
+// included, with an extra hidden column (3 == generated) table_info doesn't
+// have.
+func ensureEdgeColumns(db *sql.DB) error {
+	rows, err := db.Query(`PRAGMA table_xinfo(edges)`)
+	if err != nil {
+		return err
+	}
+	existing := make(map[string]bool)
+	for rows.Next() {
+		var (
+			cid, notnull, pk, hidden int
+			name, ctype              string
+			dflt                     sql.NullString
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk, &hidden); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		existing[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return err
+	}
+	_ = rows.Close()
+	if existing["is_unresolved"] {
+		return nil
+	}
+	if _, err := db.Exec(`ALTER TABLE edges ADD COLUMN ` + isUnresolvedColumnDDL); err != nil {
+		return err
+	}
+	return nil
+}
+
 // schemaSQL is the canonical DDL applied on Open. Statements are
 // idempotent (IF NOT EXISTS) so they run cleanly against a fresh DB
 // and against an existing one.

--- a/internal/graph/store_sqlite/store.go
+++ b/internal/graph/store_sqlite/store.go
@@ -300,6 +300,13 @@ func openWith(path string, current int, migrations []schemaMigration, allowRebui
 		_ = db.Close()
 		return nil, fmt.Errorf("sqlite node columns: %w", err)
 	}
+	// Same treatment for the edges table's is_unresolved generated column —
+	// must run before the droppable-index loop below, which creates an index
+	// over it.
+	if err := ensureEdgeColumns(db); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("sqlite edge columns: %w", err)
+	}
 	// Create the droppable secondary indexes from the shared set so their
 	// initial-creation DDL is byte-identical to the DDL the bulk-load fast
 	// path rebuilds them with (BeginBulkLoad drops these, FlushBulk
@@ -1806,17 +1813,18 @@ func (s *Store) NodesByKind(kind graph.NodeKind) iter.Seq[*graph.Node] {
 	}
 }
 
-// EdgesWithUnresolvedTarget yields edges whose target is an unresolved
-// stub in EITHER form: the bare `unresolved::X` (a half-open range scan
-// that seeks directly to the contiguous slice via the to_id b-tree) or
-// the multi-repo `<repo>::unresolved::X` rewrite (an infix LIKE — the
-// unresolved set is small, so the scan is cheap). Mirrors
-// graph.IsUnresolvedTarget over both shapes.
+// EdgesWithUnresolvedTarget yields edges whose target is an unresolved stub
+// in either form graph.IsUnresolvedTarget recognises. Filters on the
+// is_unresolved generated column (see isUnresolvedColumnDDL) rather than
+// re-deriving the to_id pattern match in SQL: measured 2.7x faster than the
+// equivalent to_id-based OR query on a real 26-repo store (7.96s -> 2.95s for
+// the same 847,684-row result) because the boolean index's bookmark lookups
+// land in ascending rowid order, unlike a to_id-ordered index's.
 func (s *Store) EdgesWithUnresolvedTarget() iter.Seq[*graph.Edge] {
 	return func(yield func(*graph.Edge) bool) {
 		out := s.queryEdgesSQL(`
 SELECT from_id, to_id, kind, file_path, line, confidence, confidence_label, origin, tier, cross_repo, meta
-FROM edges WHERE (to_id >= 'unresolved::' AND to_id < 'unresolved:;') OR to_id LIKE '%::unresolved::%'`)
+FROM edges WHERE is_unresolved = 1`)
 		for _, e := range out {
 			if !yield(e) {
 				return


### PR DESCRIPTION
## Summary

`EdgesWithUnresolvedTarget` — the resolver's main pending-edge collector, called on every full resolve — matched `to_id` against a single OR'd condition (a bare-prefix range plus an infix `LIKE` for the multi-repo COPY-rewrite shape). `EXPLAIN QUERY PLAN` showed the OR forces SQLite to abandon the `to_id` index for the whole query (full `SCAN edges`), even though the dominant branch alone would use it.

Adds `edges.is_unresolved`: a `VIRTUAL` generated column computed by SQLite itself from `to_id` (both unresolved shapes), indexed, and queried in place of re-deriving the pattern match in SQL. No Go call site needs to keep it in sync — SQLite recomputes it on every insert/update to `to_id` automatically (verified against the pinned `modernc.org/sqlite` driver, including that an `UPDATE` to `to_id` correctly flips it).

`VIRTUAL` rather than `STORED`: SQLite refuses `ALTER TABLE ADD COLUMN ... STORED` on a non-empty table ("cannot add a STORED column") — which every already-installed store is. `VIRTUAL` has no such restriction and performs identically for this read path, since the query always goes through the index, and an index always materialises its own key values regardless of the underlying column's storage class.

## Measured

Isolated, same store copy, same Go code path (not just `EXPLAIN QUERY PLAN`):

| approach | time (847,684-row result) |
|---|---|
| current (`to_id` range OR infix LIKE) | 7.96s |
| split into two `to_id`-based queries (range + LIKE) | 13.49s — **worse**, reverted, not in this PR |
| `is_unresolved = 1` (indexed) | **2.95s** |

The split-query attempt is a recorded gotcha in the column's doc comment: at ~33% selectivity, a `to_id`-ordered index's bookmark lookups back into the main table are effectively random I/O (matching rows ordered by string value), while the boolean column's are rowid-ordered — every matching row shares the same index key, so ties break on rowid, landing lookups in ascending (sequential) order. Same `SEARCH ... USING INDEX` in the query plan either way; only real measurement told them apart.

Also caught before shipping: `PRAGMA table_info` silently omits generated columns (a real, reproducible quirk against the pinned driver), so the existing-database migration path originally used it, detected the column as always-missing, and re-ran the `ALTER TABLE` on every reopen — failing with "duplicate column name". Switched to `PRAGMA table_xinfo`, which does report generated columns.

## Test plan

- [x] `GOWORK=off go build ./...`
- [x] `GOWORK=off go vet ./...`
- [x] `GOWORK=off go test -race ./internal/graph/store_sqlite/... ./internal/resolver/... ./internal/indexer/... ./internal/mcp/...`
- [x] Verified end-to-end against a fresh copy of a real 26-repo store, including the one-time migration path on an already-populated database (7.3s one-time `ALTER TABLE` + index build on 2.57M rows).