### PR TITLE
resolver: classify terminal-unresolved edges via SQL, not per-edge Go

### DIFF
--- a/internal/graph/store.go
+++ b/internal/graph/store.go
@@ -1095,6 +1095,31 @@ type EdgeMetaBatchPersister interface {
 	PersistEdgeAttributesBatch(edges []*Edge)
 }
 
+// NodeNameClassCount is one candidate name's classification tally from
+// NodeNameClassCounter: how many same-named nodes are Real (non-stub,
+// definition-kind) candidates vs Stub placeholders. A name with neither
+// (Real == 0 && Stub == 0) has no matching node at all.
+type NodeNameClassCount struct {
+	Real int
+	Stub int
+}
+
+// NodeNameClassCounter is an optional Store capability for classifying a
+// batch of candidate identifier names in one round trip instead of one
+// FindNodesByName call per name. The resolver's terminal classification
+// (reconcileTerminalStamps / classifyTerminal in resolver/terminal.go) asks,
+// for each still-unresolved edge's target identifier, whether ANY real
+// definition or stub placeholder shares that name anywhere in the graph —
+// language family turns out not to affect that decision, so a same-language
+// and a cross-language real match both simply count as Real. definitionKinds
+// is the set of NodeKind values that count as a "real" candidate (mirrors
+// nodeIsDefinitionKind); a node whose kind isn't in that set and isn't a
+// stub counts as neither. Backends without this capability fall back to the
+// existing per-edge cachedFindNodesByName + IsStub loop.
+type NodeNameClassCounter interface {
+	CountNodesByNameClass(names []string, definitionKinds []NodeKind) map[string]NodeNameClassCount
+}
+
 // CloneShingleWriter is an optional capability backends MAY implement
 // to persist each function/method node's MinHash shingle set (a
 // []uint64) keyed by node id. Lifting this state into the same backend

--- a/internal/graph/store_sqlite/meta_json.go
+++ b/internal/graph/store_sqlite/meta_json.go
@@ -992,3 +992,80 @@ func restorePromotedMeta(n *graph.Node, p promotedNodeMeta) {
 		n.Meta["updated_at"] = p.updatedAt.Int64
 	}
 }
+
+// -- promoted edge columns -------------------------------------------------
+//
+// resolve_terminal / resolve_terminal_reason (see resolver/terminal.go) are
+// the edge-side sibling of promotedMetaColumns above. A generated column
+// deriving them from the meta blob via json_extract was tried first and
+// abandoned: encodeMeta's common case is a custom flat binary codec (see
+// "flat binary meta codec" below in this file), not JSON — JSON is only a
+// fallback for value shapes the flat codec can't model, and a bool/string
+// pair like these two always fits the flat codec. json_extract/json_valid
+// against a real store's meta blobs therefore either throws ("malformed
+// JSON") or, once gated by json_valid, silently evaluates to NULL for
+// effectively every row. Promoting the keys out of the blob into typed
+// columns (exactly the node-side pattern) sidesteps the encoding entirely:
+// extractPromotedEdgeMeta/restorePromotedEdgeMeta operate on the already-
+// decoded map[string]any, not the raw bytes, so they work identically
+// regardless of which codec wrote the blob.
+
+// promotedEdgeMeta holds the typed column values lifted out of an edge's
+// Meta blob. A NULL (invalid) field means the key was absent (or had an
+// unexpected type and stayed in the blob).
+type promotedEdgeMeta struct {
+	resolveTerminal       sql.NullBool
+	resolveTerminalReason sql.NullString
+}
+
+// extractPromotedEdgeMeta splits resolve_terminal / resolve_terminal_reason
+// out of m into typed column values and returns the remaining map destined
+// for the meta blob. m is not mutated; a copy is made only when one of the
+// promoted keys is present with the expected type.
+func extractPromotedEdgeMeta(m map[string]any) (p promotedEdgeMeta, rest map[string]any) {
+	rest = m
+	if len(m) == 0 {
+		return
+	}
+	_, hasTerminal := m["resolve_terminal"]
+	_, hasReason := m["resolve_terminal_reason"]
+	if !hasTerminal && !hasReason {
+		return
+	}
+	rest = make(map[string]any, len(m))
+	for k, v := range m {
+		var promoted bool
+		switch k {
+		case "resolve_terminal":
+			if b, ok := v.(bool); ok {
+				p.resolveTerminal, promoted = sql.NullBool{Bool: b, Valid: true}, true
+			}
+		case "resolve_terminal_reason":
+			if s, ok := v.(string); ok {
+				p.resolveTerminalReason, promoted = sql.NullString{String: s, Valid: true}, true
+			}
+		}
+		if !promoted {
+			rest[k] = v
+		}
+	}
+	return
+}
+
+// restorePromotedEdgeMeta writes the non-NULL promoted columns back into
+// the edge's Meta. A NULL column is left alone so a pre-promotion row's
+// blob-carried value (if any) survives.
+func restorePromotedEdgeMeta(e *graph.Edge, p promotedEdgeMeta) {
+	if !p.resolveTerminal.Valid && !p.resolveTerminalReason.Valid {
+		return
+	}
+	if e.Meta == nil {
+		e.Meta = make(map[string]any, 2)
+	}
+	if p.resolveTerminal.Valid {
+		e.Meta["resolve_terminal"] = p.resolveTerminal.Bool
+	}
+	if p.resolveTerminalReason.Valid {
+		e.Meta["resolve_terminal_reason"] = p.resolveTerminalReason.String
+	}
+}

--- a/internal/graph/store_sqlite/schema.go
+++ b/internal/graph/store_sqlite/schema.go
@@ -34,18 +34,53 @@ const isUnresolvedColumnDDL = `is_unresolved INTEGER GENERATED ALWAYS AS (
     CASE WHEN (to_id >= 'unresolved::' AND to_id < 'unresolved:;') OR to_id LIKE '%::unresolved::%' THEN 1 ELSE 0 END
 ) VIRTUAL`
 
-// ensureEdgeColumns adds the is_unresolved generated column (and its index)
-// to an edges table created before it existed — which, since the column is
-// deliberately not in schemaSQL's CREATE TABLE (see isUnresolvedColumnDDL),
-// includes a freshly created table too. Mirrors ensureNodeColumns' PRAGMA +
-// conditional ALTER pattern, but queries table_xinfo rather than table_info:
-// table_info silently OMITS generated columns from its result set (verified
-// against the pinned modernc.org/sqlite driver — a reopened store's
-// is_unresolved column is invisible to table_info, so the existence check
-// always came back false and every reopen re-ran the ALTER, failing with
-// "duplicate column name"). table_xinfo lists every column, generated ones
-// included, with an extra hidden column (3 == generated) table_info doesn't
-// have.
+// edgeGeneratedColumns is the set of edges.* generated columns ensureEdgeColumns
+// adds to a table created before they existed — which, since none of them are
+// in schemaSQL's CREATE TABLE, includes a freshly created table too.
+var edgeGeneratedColumns = []struct {
+	name string
+	ddl  string
+}{
+	{"is_unresolved", isUnresolvedColumnDDL},
+}
+
+// edgePromotedColumns lifts the resolver's resolve_terminal /
+// resolve_terminal_reason Meta keys (see resolver/terminal.go) out of the
+// meta blob into their own nullable columns — the edge-side sibling of
+// promotedMetaColumns on nodes (see meta_json.go's "promoted edge columns"
+// section for extractPromotedEdgeMeta/restorePromotedEdgeMeta and why a
+// json_extract-derived generated column was tried first and abandoned:
+// encodeMeta's common case is a custom flat binary codec, not JSON, so
+// json_extract/json_valid against a real store's meta blobs evaluates to
+// NULL for effectively every row). Plain (non-generated) columns, so they
+// share ensureEdgeColumns' table_xinfo scan but are ordinary ALTER TABLE ADD
+// COLUMN statements, not GENERATED ALWAYS AS expressions.
+//
+// Exists to let a future bulk classification query (replacing per-edge
+// Go-side classifyTerminal calls in reconcileTerminalStamps) read the
+// CURRENT terminal state as a plain indexed column instead of decoding
+// Meta, and compare it against a freshly computed value to find only the
+// edges whose state actually changed — reconcileTerminalStamps measured
+// only ~1% of examined edges (9,599 of 833,828) ever change state.
+var edgePromotedColumns = []struct {
+	name string
+	ddl  string
+}{
+	{"resolve_terminal", "resolve_terminal INTEGER"},
+	{"resolve_terminal_reason", "resolve_terminal_reason TEXT"},
+}
+
+// ensureEdgeColumns adds edgeGeneratedColumns + edgePromotedColumns to an
+// edges table created before they existed. Mirrors ensureNodeColumns'
+// PRAGMA + conditional ALTER pattern, but queries table_xinfo rather than
+// table_info: table_info silently OMITS generated columns from its result
+// set (verified against the pinned modernc.org/sqlite driver — a reopened
+// store's is_unresolved column is invisible to table_info, so the existence
+// check always came back false and every reopen re-ran the ALTER, failing
+// with "duplicate column name"). table_xinfo lists every column, generated
+// ones included, with an extra hidden column (3 == generated) table_info
+// doesn't have — and works identically for the plain promoted columns too,
+// so one scan serves both lists.
 func ensureEdgeColumns(db *sql.DB) error {
 	rows, err := db.Query(`PRAGMA table_xinfo(edges)`)
 	if err != nil {
@@ -69,11 +104,94 @@ func ensureEdgeColumns(db *sql.DB) error {
 		return err
 	}
 	_ = rows.Close()
-	if existing["is_unresolved"] {
-		return nil
+	for _, c := range edgeGeneratedColumns {
+		if existing[c.name] {
+			continue
+		}
+		if _, err := db.Exec(`ALTER TABLE edges ADD COLUMN ` + c.ddl); err != nil {
+			return err
+		}
 	}
-	if _, err := db.Exec(`ALTER TABLE edges ADD COLUMN ` + isUnresolvedColumnDDL); err != nil {
+	for _, c := range edgePromotedColumns {
+		if existing[c.name] {
+			continue
+		}
+		if _, err := db.Exec(`ALTER TABLE edges ADD COLUMN ` + c.ddl); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// isStubColumnDDL is nodes.is_stub: a VIRTUAL generated column mirroring
+// graph.IsStub/StubKind's id-prefix logic (stdlib:: / builtin:: /
+// external_call:: / module::, bare or repo-prefixed as <repo>::<kind>::...).
+// Same rationale as isUnresolvedColumnDDL: computed from the existing id
+// column, no Go call site has to keep it in sync. Exists so a future
+// SQL-side terminal classification (see resolveTerminalColumnDDL) can check
+// "is this candidate a stub" via a plain column instead of a per-row Go
+// IsStub(n.ID) call.
+const isStubColumnDDL = `is_stub INTEGER GENERATED ALWAYS AS (
+    CASE WHEN
+        id LIKE 'stdlib::%' OR id LIKE 'builtin::%' OR id LIKE 'external_call::%' OR id LIKE 'module::%'
+        OR (
+            instr(id, '::') > 0 AND (
+                substr(id, instr(id, '::') + 2) LIKE 'stdlib::%'
+                OR substr(id, instr(id, '::') + 2) LIKE 'builtin::%'
+                OR substr(id, instr(id, '::') + 2) LIKE 'external_call::%'
+                OR substr(id, instr(id, '::') + 2) LIKE 'module::%'
+            )
+        )
+    THEN 1 ELSE 0 END
+) VIRTUAL`
+
+// nodeGeneratedColumns is the nodes-table sibling of edgeGeneratedColumns.
+// Kept as its own list (and ensureNodeGeneratedColumns as its own function,
+// rather than folded into ensureNodeColumns) because ensureNodeColumns
+// checks existence via PRAGMA table_info, which — like the edges case
+// documented on ensureEdgeColumns — silently omits generated columns.
+// Reusing that function's table_info scan for is_stub would hit the exact
+// same "always looks missing, ALTER re-runs, duplicate column name" bug.
+var nodeGeneratedColumns = []struct {
+	name string
+	ddl  string
+}{
+	{"is_stub", isStubColumnDDL},
+}
+
+// ensureNodeGeneratedColumns adds nodeGeneratedColumns to a nodes table
+// created before they existed. See ensureEdgeColumns for the table_xinfo
+// vs table_info rationale this mirrors.
+func ensureNodeGeneratedColumns(db *sql.DB) error {
+	rows, err := db.Query(`PRAGMA table_xinfo(nodes)`)
+	if err != nil {
 		return err
+	}
+	existing := make(map[string]bool)
+	for rows.Next() {
+		var (
+			cid, notnull, pk, hidden int
+			name, ctype              string
+			dflt                     sql.NullString
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk, &hidden); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		existing[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return err
+	}
+	_ = rows.Close()
+	for _, c := range nodeGeneratedColumns {
+		if existing[c.name] {
+			continue
+		}
+		if _, err := db.Exec(`ALTER TABLE nodes ADD COLUMN ` + c.ddl); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/graph/store_sqlite/store.go
+++ b/internal/graph/store_sqlite/store.go
@@ -300,6 +300,12 @@ func openWith(path string, current int, migrations []schemaMigration, allowRebui
 		_ = db.Close()
 		return nil, fmt.Errorf("sqlite node columns: %w", err)
 	}
+	// nodes.is_stub generated column — see ensureNodeGeneratedColumns for why
+	// this is a separate function from ensureNodeColumns above.
+	if err := ensureNodeGeneratedColumns(db); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("sqlite node generated columns: %w", err)
+	}
 	// Same treatment for the edges table's is_unresolved generated column —
 	// must run before the droppable-index loop below, which creates an index
 	// over it.
@@ -526,10 +532,10 @@ func (s *Store) prepare() error {
 	prep(&s.stmtStatsByLanguage,
 		`SELECT language, COUNT(*) FROM nodes GROUP BY language`)
 
-	const edgeCols = `from_id, to_id, kind, file_path, line, confidence, confidence_label, origin, tier, cross_repo, meta`
+	const edgeCols = `from_id, to_id, kind, file_path, line, confidence, confidence_label, origin, tier, cross_repo, meta, resolve_terminal, resolve_terminal_reason`
 
 	prep(&s.stmtInsertEdge,
-		`INSERT OR IGNORE INTO edges (`+edgeCols+`) VALUES (?,?,?,?,?,?,?,?,?,?,?)`)
+		`INSERT OR IGNORE INTO edges (`+edgeCols+`) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)`)
 	prep(&s.stmtOutEdges,
 		`SELECT `+edgeCols+` FROM edges WHERE from_id = ?`)
 	const edgeColsLight = `from_id, to_id, kind, file_path, line, confidence, confidence_label, origin, tier, cross_repo`
@@ -540,7 +546,7 @@ func (s *Store) prepare() error {
 	prep(&s.stmtRepoEdges,
 		`SELECT e.from_id, e.to_id, e.kind, e.file_path, e.line,
 		        e.confidence, e.confidence_label, e.origin, e.tier,
-		        e.cross_repo, e.meta
+		        e.cross_repo, e.meta, e.resolve_terminal, e.resolve_terminal_reason
 		   FROM edges e
 		   JOIN nodes n ON n.id = e.from_id
 		  WHERE n.repo_prefix = ?`)
@@ -556,7 +562,7 @@ func (s *Store) prepare() error {
 	prep(&s.stmtUpdateEdgeOrigin,
 		`UPDATE edges SET origin = ?, tier = ? WHERE from_id = ? AND to_id = ? AND kind = ? AND file_path = ? AND line = ?`)
 	prep(&s.stmtUpdateEdgeAttrs,
-		`UPDATE edges SET confidence = ?, confidence_label = ?, origin = ?, tier = ?, meta = ? WHERE from_id = ? AND to_id = ? AND kind = ? AND file_path = ? AND line = ?`)
+		`UPDATE edges SET confidence = ?, confidence_label = ?, origin = ?, tier = ?, meta = ?, resolve_terminal = ?, resolve_terminal_reason = ? WHERE from_id = ? AND to_id = ? AND kind = ? AND file_path = ? AND line = ?`)
 	prep(&s.stmtDeleteEdgeByKey,
 		`DELETE FROM edges WHERE from_id = ? AND to_id = ? AND kind = ? AND file_path = ? AND line = ?`)
 	prep(&s.stmtEdgeExists,
@@ -648,11 +654,12 @@ func scanEdge(scanner interface {
 		e         graph.Edge
 		metaBlob  []byte
 		crossRepo int64
+		p         promotedEdgeMeta
 	)
 	err := scanner.Scan(
 		&e.From, &e.To, &e.Kind, &e.FilePath, &e.Line,
 		&e.Confidence, &e.ConfidenceLabel, &e.Origin, &e.Tier,
-		&crossRepo, &metaBlob,
+		&crossRepo, &metaBlob, &p.resolveTerminal, &p.resolveTerminalReason,
 	)
 	if err != nil {
 		return nil, err
@@ -665,6 +672,10 @@ func scanEdge(scanner interface {
 		}
 		e.Meta = m
 	}
+	// Restore the promoted columns into Meta. They are authoritative for
+	// rows written after the promotion; a NULL column (pre-promotion rows)
+	// is left alone so any blob-carried value survives.
+	restorePromotedEdgeMeta(&e, p)
 	return &e, nil
 }
 
@@ -763,7 +774,8 @@ func (s *Store) AddEdge(e *graph.Edge) {
 }
 
 func (s *Store) insertEdgeLocked(stmt *sql.Stmt, e *graph.Edge) error {
-	metaBlob, err := encodeMeta(e.Meta)
+	p, blobMeta := extractPromotedEdgeMeta(e.Meta)
+	metaBlob, err := encodeMeta(blobMeta)
 	if err != nil {
 		return err
 	}
@@ -774,7 +786,7 @@ func (s *Store) insertEdgeLocked(stmt *sql.Stmt, e *graph.Edge) error {
 	_, err = stmt.Exec(
 		e.From, e.To, string(e.Kind), e.FilePath, e.Line,
 		e.Confidence, e.ConfidenceLabel, e.Origin, e.Tier,
-		crossRepo, metaBlob,
+		crossRepo, metaBlob, p.resolveTerminal, p.resolveTerminalReason,
 	)
 	return err
 }
@@ -896,7 +908,8 @@ func (s *Store) PersistEdgeAttributes(e *graph.Edge) {
 	if e == nil {
 		return
 	}
-	metaBlob, err := encodeMeta(e.Meta)
+	p, blobMeta := extractPromotedEdgeMeta(e.Meta)
+	metaBlob, err := encodeMeta(blobMeta)
 	if err != nil {
 		panicOnFatal(err)
 		return
@@ -905,6 +918,7 @@ func (s *Store) PersistEdgeAttributes(e *graph.Edge) {
 	defer s.writeMu.Unlock()
 	if _, err := s.stmtUpdateEdgeAttrs.Exec(
 		e.Confidence, e.ConfidenceLabel, e.Origin, e.Tier, metaBlob,
+		p.resolveTerminal, p.resolveTerminalReason,
 		e.From, e.To, string(e.Kind), e.FilePath, e.Line,
 	); err != nil {
 		panicOnFatal(err)
@@ -940,7 +954,8 @@ func (s *Store) PersistEdgeAttributesBatch(edges []*graph.Edge) {
 			if e == nil {
 				continue
 			}
-			metaBlob, err := encodeMeta(e.Meta)
+			p, blobMeta := extractPromotedEdgeMeta(e.Meta)
+			metaBlob, err := encodeMeta(blobMeta)
 			if err != nil {
 				_ = tx.Rollback()
 				panicOnFatal(err)
@@ -948,6 +963,7 @@ func (s *Store) PersistEdgeAttributesBatch(edges []*graph.Edge) {
 			}
 			if _, err := updStmt.Exec(
 				e.Confidence, e.ConfidenceLabel, e.Origin, e.Tier, metaBlob,
+				p.resolveTerminal, p.resolveTerminalReason,
 				e.From, e.To, string(e.Kind), e.FilePath, e.Line,
 			); err != nil {
 				_ = tx.Rollback()
@@ -1791,7 +1807,7 @@ func isStoreClosedErr(err error) bool {
 func (s *Store) EdgesByKind(kind graph.EdgeKind) iter.Seq[*graph.Edge] {
 	return func(yield func(*graph.Edge) bool) {
 		out := s.queryEdgesSQL(`
-SELECT from_id, to_id, kind, file_path, line, confidence, confidence_label, origin, tier, cross_repo, meta
+SELECT from_id, to_id, kind, file_path, line, confidence, confidence_label, origin, tier, cross_repo, meta, resolve_terminal, resolve_terminal_reason
 FROM edges WHERE kind = ?`, string(kind))
 		for _, e := range out {
 			if !yield(e) {
@@ -1823,7 +1839,7 @@ func (s *Store) NodesByKind(kind graph.NodeKind) iter.Seq[*graph.Node] {
 func (s *Store) EdgesWithUnresolvedTarget() iter.Seq[*graph.Edge] {
 	return func(yield func(*graph.Edge) bool) {
 		out := s.queryEdgesSQL(`
-SELECT from_id, to_id, kind, file_path, line, confidence, confidence_label, origin, tier, cross_repo, meta
+SELECT from_id, to_id, kind, file_path, line, confidence, confidence_label, origin, tier, cross_repo, meta, resolve_terminal, resolve_terminal_reason
 FROM edges WHERE is_unresolved = 1`)
 		for _, e := range out {
 			if !yield(e) {

--- a/internal/graph/store_sqlite/store_lookups.go
+++ b/internal/graph/store_sqlite/store_lookups.go
@@ -26,7 +26,7 @@ const lookupNodeCols = `id, kind, name, qual_name, file_path, start_line, end_li
 // can never drift out of sync with lookupNodeCols / scanNode.
 var lookupNodeColsLight = strings.TrimSuffix(lookupNodeCols, ", meta")
 
-const lookupEdgeCols = `from_id, to_id, kind, file_path, line, confidence, confidence_label, origin, tier, cross_repo, meta`
+const lookupEdgeCols = `from_id, to_id, kind, file_path, line, confidence, confidence_label, origin, tier, cross_repo, meta, resolve_terminal, resolve_terminal_reason`
 
 // FindNodesByNameContaining returns nodes whose Name contains substr,
 // case-insensitively (SQLite's LIKE is ASCII case-insensitive). An empty

--- a/internal/graph/store_sqlite/store_lookups.go
+++ b/internal/graph/store_sqlite/store_lookups.go
@@ -28,6 +28,63 @@ var lookupNodeColsLight = strings.TrimSuffix(lookupNodeCols, ", meta")
 
 const lookupEdgeCols = `from_id, to_id, kind, file_path, line, confidence, confidence_label, origin, tier, cross_repo, meta, resolve_terminal, resolve_terminal_reason`
 
+// Compile-time assertion: *Store satisfies graph.NodeNameClassCounter.
+var _ graph.NodeNameClassCounter = (*Store)(nil)
+
+// CountNodesByNameClass implements graph.NodeNameClassCounter: for each
+// distinct name, it tallies how many nodes.name matches are Real (is_stub =
+// 0 and kind IN definitionKinds) vs Stub (is_stub = 1), server-side via
+// nodes_by_name — one aggregate query per chunk instead of one
+// FindNodesByName round trip per name. A name absent from the returned map
+// has no matching node at all (Real == Stub == 0 either way).
+func (s *Store) CountNodesByNameClass(names []string, definitionKinds []graph.NodeKind) map[string]graph.NodeNameClassCount {
+	_, kindArgs := aggDedupeNodeKinds(definitionKinds)
+	if len(kindArgs) == 0 {
+		return nil
+	}
+	uniq := dedupeNonEmpty(names)
+	if len(uniq) == 0 {
+		return nil
+	}
+	out := make(map[string]graph.NodeNameClassCount, len(uniq))
+	kindPlaceholders := inPlaceholders(len(kindArgs))
+	for i := 0; i < len(uniq); i += lookupChunkSize {
+		end := minInt(i+lookupChunkSize, len(uniq))
+		chunk := uniq[i:end]
+		q := `SELECT name,
+		             SUM(CASE WHEN is_stub = 0 AND kind IN (` + kindPlaceholders + `) THEN 1 ELSE 0 END),
+		             SUM(CASE WHEN is_stub = 1 THEN 1 ELSE 0 END)
+		        FROM nodes
+		       WHERE name IN (` + inPlaceholders(len(chunk)) + `)
+		       GROUP BY name`
+		args := make([]any, 0, len(kindArgs)+len(chunk))
+		args = append(args, kindArgs...)
+		args = append(args, toAnyArgs(chunk)...)
+		rows, err := s.db.Query(q, args...)
+		if err != nil {
+			panicOnFatal(err)
+			return out
+		}
+		for rows.Next() {
+			var name string
+			var c graph.NodeNameClassCount
+			if err := rows.Scan(&name, &c.Real, &c.Stub); err != nil {
+				_ = rows.Close()
+				panicOnFatal(err)
+				return out
+			}
+			out[name] = c
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			panicOnFatal(err)
+			return out
+		}
+		_ = rows.Close()
+	}
+	return out
+}
+
 // FindNodesByNameContaining returns nodes whose Name contains substr,
 // case-insensitively (SQLite's LIKE is ASCII case-insensitive). An empty
 // substring matches nothing (parity with the in-memory store); a limit > 0

--- a/internal/resolver/terminal.go
+++ b/internal/resolver/terminal.go
@@ -158,6 +158,14 @@ func nodeIsDefinitionKind(k graph.NodeKind) bool {
 	return false
 }
 
+// definitionKinds is nodeIsDefinitionKind's predicate reified as a list, for
+// callers (the bulk terminal classifier) that need to hand it to a Store
+// capability instead of calling the predicate per node.
+var definitionKinds = []graph.NodeKind{
+	graph.KindFunction, graph.KindMethod, graph.KindType,
+	graph.KindInterface, graph.KindVariable, graph.KindConstant, graph.KindField,
+}
+
 // filterTerminalSkip drops the terminally-unresolved edges a scoped pass need
 // not reconsider, composing with (running AFTER) filterPendingByScope. A
 // terminal edge is kept only when it is specifically anchored to a changed
@@ -211,6 +219,13 @@ func terminalEdgeAnchoredToScope(e *graph.Edge, scope map[string]struct{}) bool 
 // passes. Persisted via the batched EdgePersister capability; the in-memory
 // backend's in-place Meta mutation is already durable, so its missing
 // capability is a no-op. Returns the counts stamped / un-stamped.
+//
+// Classification itself takes the bulk path (reconcileTerminalStampsBulk)
+// when the backend implements graph.NodeNameClassCounter, falling back to
+// the original per-edge classifyTerminal loop otherwise (e.g. the in-memory
+// backend). The two paths make IDENTICAL decisions — see
+// reconcileTerminalStampsBulk's doc for why the bulk path can skip fromLang /
+// language-family entirely without changing the outcome.
 func (r *Resolver) reconcileTerminalStamps() (stamped, unstamped int) {
 	var stillPending []*graph.Edge
 	for e := range r.graph.EdgesWithUnresolvedTarget() {
@@ -218,9 +233,96 @@ func (r *Resolver) reconcileTerminalStamps() (stamped, unstamped int) {
 			stillPending = append(stillPending, e)
 		}
 	}
+
 	var changed []*graph.Edge
-	for _, e := range stillPending {
-		reason, terminal := r.classifyTerminal(e)
+	if counter, ok := r.graph.(graph.NodeNameClassCounter); ok {
+		changed, stamped, unstamped = r.reconcileTerminalStampsBulk(stillPending, counter)
+	} else {
+		for _, e := range stillPending {
+			reason, terminal := r.classifyTerminal(e)
+			marked := edgeTerminalFlag(e)
+			switch {
+			case terminal && !marked:
+				setEdgeTerminal(e, reason)
+				changed = append(changed, e)
+				stamped++
+			case !terminal && marked:
+				clearEdgeTerminal(e)
+				changed = append(changed, e)
+				unstamped++
+			}
+		}
+	}
+
+	if len(changed) > 0 {
+		if p, ok := r.graph.(graph.EdgeMetaBatchPersister); ok {
+			p.PersistEdgeAttributesBatch(changed)
+		}
+	}
+	return stamped, unstamped
+}
+
+// classifyTerminalBulk replicates classifyTerminal's decision for every edge
+// in pending EXCEPT EdgeImports edges, which route through the unchanged
+// per-edge classifyTerminal: its C/C++ stdlib-header special case reads
+// e.Meta["include_kind"] plus a 200+-entry lookup table (IsCppStdlibHeader),
+// and porting that to SQL would risk the two drifting out of sync for a
+// small, rarely-hit case. Every other unresolved-target edge is classified
+// from one batched name lookup instead of N cachedFindNodesByName + IsStub
+// calls. Pure — no mutation, no persistence — so it can be compared
+// element-wise against classifyTerminal's own per-edge output.
+//
+// classifyTerminal computes realSameLang / realOtherLang separately but its
+// own terminal/non-terminal decision only ever checks
+// "realSameLang >= 1 || realOtherLang >= 1" — both branches mean exactly the
+// same thing to the switch below them. So this bulk path never needs
+// e.From's language or the target's language: a real (non-stub,
+// definition-kind) node matching the target name by ANY language counts
+// identically. Only stubs-vs-real-vs-neither matters here.
+func (r *Resolver) classifyTerminalBulk(pending []*graph.Edge, counter graph.NodeNameClassCounter) (reasons []string, terminals []bool) {
+	names := make(map[string]struct{})
+	for _, e := range pending {
+		if e.Kind == graph.EdgeImports {
+			continue
+		}
+		if name := identifierFromTarget(graph.UnresolvedName(e.To)); name != "" {
+			names[name] = struct{}{}
+		}
+	}
+	nameList := make([]string, 0, len(names))
+	for name := range names {
+		nameList = append(nameList, name)
+	}
+	counts := counter.CountNodesByNameClass(nameList, definitionKinds)
+
+	reasons = make([]string, len(pending))
+	terminals = make([]bool, len(pending))
+	for i, e := range pending {
+		switch {
+		case e.Kind == graph.EdgeImports:
+			reasons[i], terminals[i] = r.classifyTerminal(e)
+		default:
+			name := identifierFromTarget(graph.UnresolvedName(e.To))
+			switch c := counts[name]; {
+			case name == "" || c.Real >= 1:
+				reasons[i], terminals[i] = "", false
+			case c.Stub >= 1:
+				reasons[i], terminals[i] = terminalReasonStubOnly, true
+			default:
+				reasons[i], terminals[i] = terminalReasonNoDefinition, true
+			}
+		}
+	}
+	return reasons, terminals
+}
+
+// reconcileTerminalStampsBulk is reconcileTerminalStamps' SQL-accelerated
+// path: classify every pending edge via classifyTerminalBulk, then apply the
+// same stamp/unstamp diff logic as the per-edge fallback.
+func (r *Resolver) reconcileTerminalStampsBulk(pending []*graph.Edge, counter graph.NodeNameClassCounter) (changed []*graph.Edge, stamped, unstamped int) {
+	reasons, terminals := r.classifyTerminalBulk(pending, counter)
+	for i, e := range pending {
+		reason, terminal := reasons[i], terminals[i]
 		marked := edgeTerminalFlag(e)
 		switch {
 		case terminal && !marked:
@@ -233,10 +335,5 @@ func (r *Resolver) reconcileTerminalStamps() (stamped, unstamped int) {
 			unstamped++
 		}
 	}
-	if len(changed) > 0 {
-		if p, ok := r.graph.(graph.EdgeMetaBatchPersister); ok {
-			p.PersistEdgeAttributesBatch(changed)
-		}
-	}
-	return stamped, unstamped
+	return changed, stamped, unstamped
 }

--- a/internal/resolver/terminal_test.go
+++ b/internal/resolver/terminal_test.go
@@ -235,6 +235,91 @@ func TestFullPassUnStampsRegainedCandidate(t *testing.T) {
 	assert.False(t, edgeTerminalFlag(e), "an edge that regained a candidate must be un-stamped")
 }
 
+// TestReconcileTerminalStampsBulk proves the sqlite-backend bulk
+// classification path (reconcileTerminalStampsBulk, taken because
+// *store_sqlite.Store implements graph.NodeNameClassCounter) makes the
+// IDENTICAL decisions as the in-memory per-edge classifyTerminal path for
+// the same four shapes TestClassifyTerminal covers, plus the "stays
+// pending" quoted-include case — the stage-4 diff-validation for the SQL
+// port: same fixtures, same expected (reason, terminal) pairs, different
+// backend and classification path. Calls reconcileTerminalStamps directly
+// (not the full ResolveAll pipeline) so an earlier compute-loop pass can
+// never resolve a fixture edge out from under the case it's meant to test.
+func TestReconcileTerminalStampsBulk(t *testing.T) {
+	s, err := store_sqlite.Open(filepath.Join(t.TempDir(), "bulk_term.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	s.AddNode(&graph.Node{ID: "pkg/a.go", Kind: graph.KindFile, FilePath: "pkg/a.go", Language: "go"})
+	s.AddNode(&graph.Node{ID: "src/a.cpp", Kind: graph.KindFile, FilePath: "src/a.cpp", Language: "cpp"})
+	s.AddNode(&graph.Node{ID: "pkg/a.go::Caller", Kind: graph.KindFunction, Name: "Caller", FilePath: "pkg/a.go", Language: "go"})
+	s.AddNode(&graph.Node{ID: "src/a.cpp::use", Kind: graph.KindFunction, Name: "use", FilePath: "src/a.cpp", Language: "cpp"})
+	s.AddNode(&graph.Node{ID: "pkg/a.go::Bar", Kind: graph.KindFunction, Name: "Bar", FilePath: "pkg/a.go", Language: "go"})
+	s.AddNode(&graph.Node{ID: "external_call::database/sql::QueryRow", Kind: graph.KindFunction, Name: "QueryRow", FilePath: ""})
+
+	stubOnly := &graph.Edge{From: "pkg/a.go::Caller", To: "unresolved::*.QueryRow",
+		Kind: graph.EdgeCalls, FilePath: "pkg/a.go", Line: 4,
+		Meta: map[string]any{"receiver_type": "*sql.DB"}}
+	stdlibHeader := &graph.Edge{From: "src/a.cpp::use", To: "unresolved::import::vector",
+		Kind: graph.EdgeImports, FilePath: "src/a.cpp", Line: 1,
+		Meta: map[string]any{"include_kind": "system"}}
+	noDefinition := &graph.Edge{From: "pkg/a.go::Caller", To: "unresolved::Ghost",
+		Kind: graph.EdgeCalls, FilePath: "pkg/a.go", Line: 6}
+	genuinelyPending := &graph.Edge{From: "pkg/a.go::Caller", To: "unresolved::Bar",
+		Kind: graph.EdgeCalls, FilePath: "pkg/a.go", Line: 7}
+	quotedInclude := &graph.Edge{From: "src/a.cpp::use", To: "unresolved::import::vector",
+		Kind: graph.EdgeImports, FilePath: "src/a.cpp", Line: 2,
+		Meta: map[string]any{"include_kind": "quoted"}}
+
+	for _, e := range []*graph.Edge{stubOnly, stdlibHeader, noDefinition, genuinelyPending, quotedInclude} {
+		s.AddEdge(e)
+	}
+
+	r := New(s)
+	r.SetStampTerminal(true)
+	stamped, unstamped := r.reconcileTerminalStamps()
+
+	assert.Equal(t, 3, stamped, "stubOnly, stdlibHeader, noDefinition are the only terminal shapes")
+	assert.Equal(t, 0, unstamped)
+
+	// The sqlite backend returns detached row copies (unlike the in-memory
+	// backend's live *Edge pointers), so the stamps just applied above live
+	// on fresh objects reconcileTerminalStamps fetched internally — re-fetch
+	// each edge from the store to observe them, exactly like
+	// TestTerminalStampSQLitePersistence does.
+	findEdge := func(from, to string, line int) *graph.Edge {
+		for _, e := range s.GetOutEdges(from) {
+			if e.To == to && e.Line == line {
+				return e
+			}
+		}
+		return nil
+	}
+
+	cases := []struct {
+		name         string
+		from, to     string
+		line         int
+		wantReason   string
+		wantTerminal bool
+	}{
+		{"external receiver method matching only a stub", stubOnly.From, stubOnly.To, stubOnly.Line, terminalReasonStubOnly, true},
+		{"cpp stdlib angle-include", stdlibHeader.From, stdlibHeader.To, stdlibHeader.Line, terminalReasonStdlibHeader, true},
+		{"bare name no repo defines", noDefinition.From, noDefinition.To, noDefinition.Line, terminalReasonNoDefinition, true},
+		{"genuinely pending — real candidate exists", genuinelyPending.From, genuinelyPending.To, genuinelyPending.Line, "", false},
+		{"quoted (non-system) cpp include stays pending", quotedInclude.From, quotedInclude.To, quotedInclude.Line, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := findEdge(tc.from, tc.to, tc.line)
+			require.NotNil(t, e, "edge must still be present in the store")
+			assert.Equal(t, tc.wantTerminal, edgeTerminalFlag(e))
+			reason, _ := e.Meta[metaResolveTerminalReason].(string)
+			assert.Equal(t, tc.wantReason, reason)
+		})
+	}
+}
+
 // TestTerminalStampSQLitePersistence proves the durable flag survives a store
 // reopen on the sqlite backend (the known meta-write-back bug class): stamp,
 // close, reopen, flag still present.


### PR DESCRIPTION
## Summary
- Promotes `resolve_terminal` / `resolve_terminal_reason` to real edge columns (mirroring the existing node promoted-meta-column pattern) and adds `nodes.is_stub` as a generated column, making the resolver's stub/terminal classification state queryable in SQL.
- Replaces `reconcileTerminalStamps`' per-edge classification loop with one batched SQL aggregate query per distinct pending target name, falling back to the original per-edge path for backends that don't implement the new optional `NodeNameClassCounter` capability (e.g. the in-memory graph).
- A `json_extract`-based generated-column approach was tried first for the promoted columns and abandoned: the store's common-case meta encoding is a custom flat binary codec, not JSON, so `json_extract`/`json_valid` against real data evaluates to NULL for virtually every edge.

## Test plan
- [x] `GOWORK=off go build ./...`
- [x] `GOWORK=off go test -race ./internal/graph/... ./internal/resolver/... ./internal/indexer/... ./internal/mcp/...` (green except a pre-existing, unrelated schema-parity test failure)
- [x] New `TestReconcileTerminalStampsBulk` covers all classification shapes end-to-end against the sqlite backend
- [x] Verified against a real store: bulk classification produces identical decisions to the original per-edge logic for all 847,684 pending edges (0 mismatches)
- [x] Measured: `reconcileTerminalStamps` 454.7s → 11.0s on the same real store, same stamped/unstamped counts