### PR TITLE
fix(daemon): report live node/edge counts for a solo unprefixed repo

### DIFF
--- a/cmd/gortex/daemon_controller.go
+++ b/cmd/gortex/daemon_controller.go
@@ -738,6 +738,47 @@ func (c *realController) Status(_ context.Context) (daemon.StatusResponse, error
 			}
 		}
 
+		// One repo in a multi-repo workspace can still hold all its nodes
+		// under repo_prefix="" while its metadata says prefixed — the same
+		// desync as the sole-repo case but with a second repo present (it was
+		// indexed solo, then another repo joined while the daemon was down, so
+		// warmup stamped it prefixed without restamping its nodes; the
+		// migrateLoneUnprefixedRepoCtx guard needs len(repos)==1, which is
+		// false mid-warmup-loop). Its per-prefix bucket is then empty and it
+		// would under-count. Attribute the unaccounted ("") node pool to it —
+		// but only when exactly one tracked repo lacks a live bucket, because
+		// the "" pool is a single undifferentiated pool and more than one
+		// empty-bucket repo is ambiguous. The pool also carries a small number
+		// of synthetic cross-repo/global nodes (<1% of a real graph), so the
+		// attribution is approximate, not exact.
+		var orphanOwner string
+		orphanOwnerCount := 0
+		if !soleRepo {
+			for prefix, meta := range allMeta {
+				if meta == nil {
+					continue
+				}
+				if est, ok := memEstimates[prefix]; !ok || est.NodeCount == 0 {
+					orphanOwner = prefix
+					orphanOwnerCount++
+				}
+			}
+		}
+		orphanNodes, orphanEdges := 0, 0
+		if orphanOwnerCount == 1 && g != nil {
+			orphanNodes, orphanEdges = wholeStoreNodes, wholeStoreEdges
+			for _, est := range memEstimates {
+				orphanNodes -= est.NodeCount
+				orphanEdges -= est.EdgeCount
+			}
+			if orphanNodes < 0 {
+				orphanNodes = 0
+			}
+			if orphanEdges < 0 {
+				orphanEdges = 0
+			}
+		}
+
 		// Search and vector backends are process-wide (one shared index
 		// across all repos), so we compute the global size once and
 		// split it proportionally to each repo's node share. Not exact,
@@ -756,6 +797,7 @@ func (c *realController) Status(_ context.Context) (daemon.StatusResponse, error
 			for _, est := range memEstimates {
 				totalNodes += est.NodeCount
 			}
+			totalNodes += orphanNodes
 			if totalNodes == 0 {
 				for _, meta := range allMeta {
 					if meta != nil {
@@ -781,7 +823,16 @@ func (c *realController) Status(_ context.Context) (daemon.StatusResponse, error
 				nodes = wholeStoreNodes
 				edges = wholeStoreEdges
 			default:
-				if est, ok := memEstimates[prefix]; ok {
+				est, ok := memEstimates[prefix]
+				switch {
+				case orphanOwnerCount == 1 && prefix == orphanOwner:
+					// This repo's nodes are the unaccounted "" pool — see the
+					// note above. Approximate (includes a little synthetic
+					// cross-repo overhead), but far closer than the frozen
+					// near-empty RepoMetadata fallback.
+					nodes = orphanNodes
+					edges = orphanEdges
+				case ok:
 					nodes = est.NodeCount
 					edges = est.EdgeCount
 					mem.NodesBytes = est.NodeBytes

--- a/cmd/gortex/daemon_controller.go
+++ b/cmd/gortex/daemon_controller.go
@@ -668,15 +668,58 @@ func (c *realController) Status(_ context.Context) (daemon.StatusResponse, error
 		// AllRepoMemoryEstimates returns nothing (or a much smaller
 		// set), some path has cleared the per-repo counters without
 		// clearing the underlying nodes. The meta fallback below keeps
-		// the table usable in the meantime.
+		// the table usable in the meantime. A workspace with exactly
+		// one Unprefixed repo legitimately runs one bucket short —
+		// its nodes carry repo_prefix="" and AllRepoMemoryEstimates'
+		// GROUP BY excludes that key by design (handled separately
+		// below) — so that expected gap must not trip this warning.
 		if c.logger != nil {
 			tracked := len(c.multiIndexer.AllMetadata())
 			counted := len(memEstimates)
-			if tracked > 0 && counted < tracked {
+			expectedGap := 0
+			for _, meta := range c.multiIndexer.AllMetadata() {
+				if meta != nil && meta.Unprefixed {
+					expectedGap = 1
+					break
+				}
+			}
+			if tracked > 0 && counted < tracked-expectedGap {
 				c.logger.Warn("daemon: per-repo counters below tracked-repo count — graph mutation cleared per-repo index?",
 					zap.Int("tracked_repos", tracked),
 					zap.Int("counter_buckets", counted),
 					zap.Int("graph_total_nodes", c.graph.NodeCount()))
+			}
+		}
+
+		// A repo indexed while it was the workspace's sole tracked repo
+		// stamps its nodes with repo_prefix="" (RepoMetadata.Unprefixed) —
+		// see TrackRepoCtx/ReconcileRepoCtx's willBeMultiRepo gate. Neither
+		// backend's per-repo estimate is usable for that empty key: the
+		// in-memory shard counters intentionally skip nodes with no
+		// RepoPrefix (shard.repoNodeAdd is a deliberate no-op for them),
+		// and the SQLite GROUP BY excludes repo_prefix="" rows outright
+		// (stmtAllRepoCountsNodes: `WHERE repo_prefix <> ''`). So such a
+		// repo never gets a memEstimates[prefix] hit and would otherwise
+		// fall back to whatever RepoMetadata.NodeCount happened to be
+		// frozen at by the last reindex — stale as soon as a scoped,
+		// file-watcher-triggered incremental pass restamps it. A repo is
+		// only ever Unprefixed while it's the workspace's sole tracked
+		// repo (migrateLoneUnprefixedRepoCtx re-mints it with a real
+		// prefix the moment a second repo joins), so the whole store's
+		// live totals ARE this repo's totals — the same fallback
+		// Indexer.repoNodeEdgeCount uses internally to stamp
+		// IndexResult.NodeCount/EdgeCount in unprefixed mode. Byte
+		// estimates stay at their zero value here, same as the pre-fix
+		// miss case — they're advisory display detail, not the reported
+		// bug.
+		var unprefixed graph.RepoMemoryEstimate
+		if g != nil {
+			for _, meta := range c.multiIndexer.AllMetadata() {
+				if meta != nil && meta.Unprefixed {
+					unprefixed.NodeCount = g.NodeCount()
+					unprefixed.EdgeCount = g.EdgeCount()
+					break
+				}
 			}
 		}
 
@@ -690,6 +733,7 @@ func (c *realController) Status(_ context.Context) (daemon.StatusResponse, error
 		for _, est := range memEstimates {
 			totalNodes += est.NodeCount
 		}
+		totalNodes += unprefixed.NodeCount
 		// totalNodes drives the SearchBytes share split below. When
 		// the per-repo counters are empty for every prefix (the
 		// post-warmup-wipe case described above), fall back to summing
@@ -707,11 +751,19 @@ func (c *realController) Status(_ context.Context) (daemon.StatusResponse, error
 			nodes := meta.NodeCount
 			edges := meta.EdgeCount
 			var mem daemon.MemoryBreakdown
-			if est, ok := memEstimates[prefix]; ok {
-				nodes = est.NodeCount
-				edges = est.EdgeCount
-				mem.NodesBytes = est.NodeBytes
-				mem.EdgesBytes = est.EdgeBytes
+			switch {
+			case meta.Unprefixed:
+				nodes = unprefixed.NodeCount
+				edges = unprefixed.EdgeCount
+				mem.NodesBytes = unprefixed.NodeBytes
+				mem.EdgesBytes = unprefixed.EdgeBytes
+			default:
+				if est, ok := memEstimates[prefix]; ok {
+					nodes = est.NodeCount
+					edges = est.EdgeCount
+					mem.NodesBytes = est.NodeBytes
+					mem.EdgesBytes = est.EdgeBytes
+				}
 			}
 			if totalNodes > 0 && nodes > 0 {
 				share := float64(nodes) / float64(totalNodes)

--- a/cmd/gortex/daemon_controller.go
+++ b/cmd/gortex/daemon_controller.go
@@ -673,14 +673,61 @@ func (c *realController) Status(_ context.Context) (daemon.StatusResponse, error
 		// its nodes carry repo_prefix="" and AllRepoMemoryEstimates'
 		// GROUP BY excludes that key by design (handled separately
 		// below) — so that expected gap must not trip this warning.
+		// A workspace with a single tracked repo owns the entire store:
+		// every node and edge belongs to it, whether or not those nodes
+		// carry a repo prefix. g.NodeCount()/g.EdgeCount() is therefore the
+		// exact per-repo count, and reporting it keeps `daemon status` in
+		// agreement with `gortex query stats` (which reports the same
+		// whole-store totals — the inconsistency users report in #261/#270).
+		//
+		// This covers both ways a lone repo's nodes land under
+		// repo_prefix="", neither of which produces a usable per-prefix
+		// bucket (the in-memory shard counters skip empty-prefix nodes —
+		// shard.repoNodeAdd is a deliberate no-op — and the SQLite GROUP BY
+		// excludes repo_prefix="" rows via `WHERE repo_prefix <> ''`):
+		//   1. Indexed unprefixed (RepoMetadata.Unprefixed) while it was the
+		//      workspace's sole tracked repo — the willBeMultiRepo gate in
+		//      TrackRepoCtx/ReconcileRepoCtx.
+		//   2. Desynced to a prefixed metadata: a second config entry (e.g. a
+		//      macOS path-case duplicate) flips willBeMultiRepo true at the
+		//      next warm restart, so the metadata is stamped prefixed
+		//      (Unprefixed=false) but the existing repo_prefix="" nodes are
+		//      never restamped (migrateLoneUnprefixedRepoCtx's guard needs
+		//      len(repos)==1, which fails mid-warmup-loop) — leaving an empty
+		//      per-prefix bucket.
+		// Both used to fall back to the frozen RepoMetadata.NodeCount (stale,
+		// often ~1) and render the near-empty row of #261/#270. Byte
+		// estimates stay at their zero value here — advisory display detail,
+		// not the reported bug.
+		allMeta := c.multiIndexer.AllMetadata()
+		soleRepo := len(allMeta) == 1
+		var wholeStoreNodes, wholeStoreEdges int
+		if g != nil {
+			wholeStoreNodes = g.NodeCount()
+			wholeStoreEdges = g.EdgeCount()
+		}
+
+		// Diagnostic: when AllMetadata has tracked repos but
+		// AllRepoMemoryEstimates returns nothing (or a much smaller
+		// set), some path has cleared the per-repo counters without
+		// clearing the underlying nodes. The meta fallback below keeps
+		// the table usable in the meantime.
 		if c.logger != nil {
-			tracked := len(c.multiIndexer.AllMetadata())
+			tracked := len(allMeta)
 			counted := len(memEstimates)
+			// A sole tracked repo (or one indexed unprefixed) legitimately
+			// contributes no per-prefix bucket — its nodes carry
+			// repo_prefix="" — so the expected shortfall must not trip this
+			// warning; the whole-store attribution below covers it.
 			expectedGap := 0
-			for _, meta := range c.multiIndexer.AllMetadata() {
-				if meta != nil && meta.Unprefixed {
-					expectedGap = 1
-					break
+			if soleRepo {
+				expectedGap = 1
+			} else {
+				for _, meta := range allMeta {
+					if meta != nil && meta.Unprefixed {
+						expectedGap = 1
+						break
+					}
 				}
 			}
 			if tracked > 0 && counted < tracked-expectedGap {
@@ -691,38 +738,6 @@ func (c *realController) Status(_ context.Context) (daemon.StatusResponse, error
 			}
 		}
 
-		// A repo indexed while it was the workspace's sole tracked repo
-		// stamps its nodes with repo_prefix="" (RepoMetadata.Unprefixed) —
-		// see TrackRepoCtx/ReconcileRepoCtx's willBeMultiRepo gate. Neither
-		// backend's per-repo estimate is usable for that empty key: the
-		// in-memory shard counters intentionally skip nodes with no
-		// RepoPrefix (shard.repoNodeAdd is a deliberate no-op for them),
-		// and the SQLite GROUP BY excludes repo_prefix="" rows outright
-		// (stmtAllRepoCountsNodes: `WHERE repo_prefix <> ''`). So such a
-		// repo never gets a memEstimates[prefix] hit and would otherwise
-		// fall back to whatever RepoMetadata.NodeCount happened to be
-		// frozen at by the last reindex — stale as soon as a scoped,
-		// file-watcher-triggered incremental pass restamps it. A repo is
-		// only ever Unprefixed while it's the workspace's sole tracked
-		// repo (migrateLoneUnprefixedRepoCtx re-mints it with a real
-		// prefix the moment a second repo joins), so the whole store's
-		// live totals ARE this repo's totals — the same fallback
-		// Indexer.repoNodeEdgeCount uses internally to stamp
-		// IndexResult.NodeCount/EdgeCount in unprefixed mode. Byte
-		// estimates stay at their zero value here, same as the pre-fix
-		// miss case — they're advisory display detail, not the reported
-		// bug.
-		var unprefixed graph.RepoMemoryEstimate
-		if g != nil {
-			for _, meta := range c.multiIndexer.AllMetadata() {
-				if meta != nil && meta.Unprefixed {
-					unprefixed.NodeCount = g.NodeCount()
-					unprefixed.EdgeCount = g.EdgeCount()
-					break
-				}
-			}
-		}
-
 		// Search and vector backends are process-wide (one shared index
 		// across all repos), so we compute the global size once and
 		// split it proportionally to each repo's node share. Not exact,
@@ -730,33 +745,41 @@ func (c *realController) Status(_ context.Context) (daemon.StatusResponse, error
 		// per-repo which would double storage for the sake of a status
 		// breakdown.
 		backendStats := resolveSearchBackend(c.multiIndexer.Search())
-		for _, est := range memEstimates {
-			totalNodes += est.NodeCount
-		}
-		totalNodes += unprefixed.NodeCount
-		// totalNodes drives the SearchBytes share split below. When
-		// the per-repo counters are empty for every prefix (the
-		// post-warmup-wipe case described above), fall back to summing
-		// per-repo meta so the share denominator stays nonzero and the
-		// search budget gets attributed instead of falling on the floor.
-		if totalNodes == 0 {
-			for _, meta := range c.multiIndexer.AllMetadata() {
-				if meta != nil {
-					totalNodes += meta.NodeCount
+		// totalNodes drives the SearchBytes share split below. A sole repo
+		// owns the whole store; otherwise sum the per-prefix buckets and, if
+		// every counter is empty (the post-warmup-wipe case described above),
+		// fall back to per-repo meta so the share denominator stays nonzero
+		// and the search budget gets attributed instead of falling on the floor.
+		if soleRepo {
+			totalNodes = wholeStoreNodes
+		} else {
+			for _, est := range memEstimates {
+				totalNodes += est.NodeCount
+			}
+			if totalNodes == 0 {
+				for _, meta := range allMeta {
+					if meta != nil {
+						totalNodes += meta.NodeCount
+					}
 				}
 			}
 		}
 
-		for prefix, meta := range c.multiIndexer.AllMetadata() {
+		for prefix, meta := range allMeta {
 			nodes := meta.NodeCount
 			edges := meta.EdgeCount
 			var mem daemon.MemoryBreakdown
 			switch {
-			case meta.Unprefixed:
-				nodes = unprefixed.NodeCount
-				edges = unprefixed.EdgeCount
-				mem.NodesBytes = unprefixed.NodeBytes
-				mem.EdgesBytes = unprefixed.EdgeBytes
+			case soleRepo || meta.Unprefixed:
+				// The whole store is this repo's graph — see the note
+				// above. This keeps `daemon status` in agreement with
+				// `gortex query stats` for a single-repo workspace, and
+				// corrects the near-empty row when a lone repo's nodes
+				// carry repo_prefix="" (indexed unprefixed, or desynced to
+				// a prefixed metadata whose per-prefix bucket is empty).
+				// Byte estimates stay zero — advisory detail, not the bug.
+				nodes = wholeStoreNodes
+				edges = wholeStoreEdges
 			default:
 				if est, ok := memEstimates[prefix]; ok {
 					nodes = est.NodeCount

--- a/cmd/gortex/daemon_status_unprefixed_test.go
+++ b/cmd/gortex/daemon_status_unprefixed_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+	"github.com/zzet/gortex/internal/search"
+)
+
+// TestStatus_UnprefixedSoloRepo_ReportsLiveNodeCount is the regression for
+// issues #261/#270: a lone tracked repo indexes with RepoPrefix="" (see
+// TrackRepoCtx/ReconcileRepoCtx's willBeMultiRepo gate), and both graph
+// backends make that empty-prefix bucket invisible to a lookup keyed by the
+// repo's real prefix — AllRepoMemoryEstimates on the in-memory backend keys
+// its map by literal RepoPrefix (so a "" entry never matches the repo's
+// resolved prefix string), and the SQLite backend's GROUP BY excludes
+// repo_prefix="" rows outright. Either way, `gortex daemon status` used to
+// fall back to whatever RepoMetadata.NodeCount was frozen at by the last
+// operation that replaced the metadata entry, which goes stale the moment
+// the live graph changes out from under it without retouching mi.repos.
+func TestStatus_UnprefixedSoloRepo_ReportsLiveNodeCount(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "lib.go"),
+		[]byte("package lib\n\nfunc A() {}\n"), 0o644))
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	gc := &config.GlobalConfig{Repos: []config.RepoEntry{{Path: dir}}}
+	gc.SetConfigPath(cfgPath)
+	require.NoError(t, gc.Save())
+	cm, err := config.NewConfigManager(cfgPath)
+	require.NoError(t, err)
+
+	g := graph.New()
+	reg := parser.NewRegistry()
+	languages.RegisterAll(reg)
+	mi := indexer.NewMultiIndexer(g, reg, search.NewBM25(), cm, zap.NewNop())
+	_, err = mi.IndexAll()
+	require.NoError(t, err)
+
+	metas := mi.AllMetadata()
+	require.Len(t, metas, 1, "exactly one repo is configured")
+	var prefix string
+	var frozenNodes int
+	for p, m := range metas {
+		prefix = p
+		frozenNodes = m.NodeCount
+		require.True(t, m.Unprefixed, "a lone tracked repo must index unprefixed")
+	}
+
+	// Simulate the live graph growing out from under the frozen
+	// RepoMetadata snapshot — e.g. an LSP-enrichment or watcher-driven
+	// write that lands nodes without going through a path that re-stamps
+	// mi.repos[prefix]. A real node (not a bare struct) so both backends'
+	// per-shard/column bookkeeping picks it up identically.
+	g.AddNode(&graph.Node{
+		ID:       "unprefixed::Extra",
+		Kind:     graph.KindFunction,
+		Name:     "Extra",
+		FilePath: "extra.go",
+		Language: "go",
+	})
+
+	c := &realController{graph: g, multiIndexer: mi, configManager: cm, logger: zap.NewNop()}
+	resp, err := c.Status(context.Background())
+	require.NoError(t, err)
+	require.Len(t, resp.TrackedRepos, 1)
+
+	// Ground truth: the in-memory backend's per-repo shard counters
+	// intentionally skip nodes with no RepoPrefix (shard.repoNodeAdd),
+	// so RepoMemoryEstimate("") is always zero there — the whole
+	// store's NodeCount is the only accurate read for unprefixed mode,
+	// which is also what Indexer.repoNodeEdgeCount falls back to.
+	liveNodes := g.NodeCount()
+	require.Greater(t, liveNodes, frozenNodes,
+		"sanity: the live graph must have outgrown the frozen metadata snapshot for this test to be meaningful")
+	assert.Equal(t, liveNodes, resp.TrackedRepos[0].Nodes,
+		"a solo (unprefixed) tracked repo's status row must reflect the live graph count, not the frozen RepoMetadata snapshot")
+	assert.Equal(t, prefix, resp.TrackedRepos[0].Prefix)
+}

--- a/cmd/gortex/daemon_status_unprefixed_test.go
+++ b/cmd/gortex/daemon_status_unprefixed_test.go
@@ -88,3 +88,86 @@ func TestStatus_UnprefixedSoloRepo_ReportsLiveNodeCount(t *testing.T) {
 		"a solo (unprefixed) tracked repo's status row must reflect the live graph count, not the frozen RepoMetadata snapshot")
 	assert.Equal(t, prefix, resp.TrackedRepos[0].Prefix)
 }
+
+// TestStatus_SoleRepoDesyncedToPrefixed_ReportsWholeStore reproduces the
+// remaining #261/#270 case f8436fab did not cover: a lone repo indexed
+// unprefixed (nodes carry repo_prefix="") whose metadata later flips to
+// prefixed (Unprefixed=false) WITHOUT its nodes being restamped, leaving an
+// empty per-prefix bucket. This is what a macOS path-case duplicate does — a
+// second config entry makes willBeMultiRepo true at the next warm restart, but
+// migrateLoneUnprefixedRepoCtx's guard (len(repos)==1) is false mid-warmup-loop
+// so the "" nodes never migrate. `query stats` still reports the full store,
+// while `daemon status` used to fall back to the frozen ~0 RepoMetadata.NodeCount
+// and render the reported near-empty (nodes=1) row.
+func TestStatus_SoleRepoDesyncedToPrefixed_ReportsWholeStore(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "lib.go"),
+		[]byte("package lib\n\nfunc A() {}\nfunc B() { A() }\n"), 0o644))
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	gc := &config.GlobalConfig{Repos: []config.RepoEntry{{Path: dir}}}
+	gc.SetConfigPath(cfgPath)
+	require.NoError(t, gc.Save())
+	cm, err := config.NewConfigManager(cfgPath)
+	require.NoError(t, err)
+
+	reg := parser.NewRegistry()
+	languages.RegisterAll(reg)
+
+	// First index: sole configured repo → indexed unprefixed.
+	g := graph.New()
+	mi1 := indexer.NewMultiIndexer(g, reg, search.NewBM25(), cm, zap.NewNop())
+	_, err = mi1.IndexAll()
+	require.NoError(t, err)
+
+	var priorMtimes map[string]int64
+	for _, m := range mi1.AllMetadata() {
+		require.True(t, m.Unprefixed, "a lone tracked repo must index unprefixed")
+		priorMtimes = m.FileMtimes
+	}
+	require.NotEmpty(t, priorMtimes, "the first index must have recorded file mtimes to reconcile against")
+	fullNodes := g.NodeCount()
+	fullEdges := g.EdgeCount()
+	require.Greater(t, fullNodes, 1, "sanity: the repo must have produced a real graph")
+
+	// A second config entry (the macOS path-case duplicate) makes the next
+	// warm restart see a multi-repo config and flip the lone repo to prefixed
+	// metadata mode.
+	require.NoError(t, cm.Global().AddRepo(config.RepoEntry{Path: t.TempDir()}))
+	require.GreaterOrEqual(t, len(cm.Global().Repos), 2)
+
+	// Warm restart: a fresh MultiIndexer over the SAME graph store reconciles
+	// the repo from the persisted mtimes. mi2.repos is empty, so
+	// migrateLoneUnprefixedRepoCtx is a no-op (guard needs len(repos)==1);
+	// willBeMultiRepo is true, so the metadata is stamped prefixed — but with
+	// nothing stale to reindex, the existing repo_prefix="" nodes are never
+	// restamped, leaving an empty per-prefix bucket.
+	mi2 := indexer.NewMultiIndexer(g, reg, search.NewBM25(), cm, zap.NewNop())
+	_, err = mi2.ReconcileRepoCtx(context.Background(), config.RepoEntry{Path: dir}, priorMtimes)
+	require.NoError(t, err)
+
+	metas := mi2.AllMetadata()
+	require.Len(t, metas, 1, "the path-case duplicate collapses to one tracked repo identity")
+	var prefix string
+	for p, m := range metas {
+		prefix = p
+		require.False(t, m.Unprefixed, "the reconcile under a 2-entry config flips the repo to prefixed mode")
+	}
+	require.NotEmpty(t, prefix, "the desynced repo must carry a real (non-empty) prefix")
+
+	// The desync: the store still holds every node under repo_prefix="", so
+	// the prefixed bucket is empty — the exact condition that made the old
+	// per-prefix lookup miss and fall back to the near-empty frozen count.
+	require.Less(t, g.RepoMemoryEstimate(prefix).NodeCount, fullNodes,
+		"sanity: the prefixed bucket must be short of the store total — nodes still carry repo_prefix=''")
+
+	c := &realController{graph: g, multiIndexer: mi2, configManager: cm, logger: zap.NewNop()}
+	resp, err := c.Status(context.Background())
+	require.NoError(t, err)
+	require.Len(t, resp.TrackedRepos, 1)
+
+	assert.Equal(t, fullNodes, resp.TrackedRepos[0].Nodes,
+		"a sole tracked repo's status row must reflect the whole store even when its nodes are unprefixed but its metadata says prefixed")
+	assert.Equal(t, fullEdges, resp.TrackedRepos[0].Edges,
+		"edges must likewise reflect the whole store, matching `gortex query stats`")
+}

--- a/cmd/gortex/daemon_status_unprefixed_test.go
+++ b/cmd/gortex/daemon_status_unprefixed_test.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/daemon"
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/indexer"
 	"github.com/zzet/gortex/internal/parser"
@@ -170,4 +171,97 @@ func TestStatus_SoleRepoDesyncedToPrefixed_ReportsWholeStore(t *testing.T) {
 		"a sole tracked repo's status row must reflect the whole store even when its nodes are unprefixed but its metadata says prefixed")
 	assert.Equal(t, fullEdges, resp.TrackedRepos[0].Edges,
 		"edges must likewise reflect the whole store, matching `gortex query stats`")
+}
+
+// TestStatus_MultiRepoDesync_AttributesUnaccountedPool covers the multi-repo
+// variant: repo A is indexed solo (nodes under repo_prefix=""), then repo B is
+// added while the daemon is down. At the next warm restart A is reconciled
+// first with an empty mi.repos, so the lone-repo migration never fires and A's
+// metadata is stamped prefixed while its nodes stay unprefixed — leaving A's
+// per-prefix bucket empty. B indexes normally. Because exactly one tracked
+// repo lacks a live bucket, `daemon status` attributes the unaccounted (mostly
+// "") node pool to A instead of falling back to its near-empty frozen count.
+func TestStatus_MultiRepoDesync_AttributesUnaccountedPool(t *testing.T) {
+	dirA := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dirA, "a.go"),
+		[]byte("package a\n\nfunc A() {}\nfunc A2() { A() }\n"), 0o644))
+	dirB := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dirB, "b.go"),
+		[]byte("package b\n\nfunc B() {}\nfunc B2() { B() }\nfunc B3() { B2() }\n"), 0o644))
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	gc := &config.GlobalConfig{Repos: []config.RepoEntry{{Path: dirA}}}
+	gc.SetConfigPath(cfgPath)
+	require.NoError(t, gc.Save())
+	cm, err := config.NewConfigManager(cfgPath)
+	require.NoError(t, err)
+
+	reg := parser.NewRegistry()
+	languages.RegisterAll(reg)
+
+	// First index: A is the sole configured repo → indexed unprefixed.
+	g := graph.New()
+	mi1 := indexer.NewMultiIndexer(g, reg, search.NewBM25(), cm, zap.NewNop())
+	_, err = mi1.IndexAll()
+	require.NoError(t, err)
+	var priorA map[string]int64
+	for _, m := range mi1.AllMetadata() {
+		require.True(t, m.Unprefixed)
+		priorA = m.FileMtimes
+	}
+	require.NotEmpty(t, priorA)
+
+	// B is added to the config while the daemon is "down".
+	require.NoError(t, cm.Global().AddRepo(config.RepoEntry{Path: dirB}))
+
+	// Warm restart over the same graph store: reconcile A (from its persisted
+	// mtimes — stays unprefixed in the store), then track B fresh.
+	mi2 := indexer.NewMultiIndexer(g, reg, search.NewBM25(), cm, zap.NewNop())
+	_, err = mi2.ReconcileRepoCtx(context.Background(), config.RepoEntry{Path: dirA}, priorA)
+	require.NoError(t, err)
+	_, err = mi2.TrackRepoCtx(context.Background(), config.RepoEntry{Path: dirB})
+	require.NoError(t, err)
+
+	metas := mi2.AllMetadata()
+	require.Len(t, metas, 2)
+	var prefixA, prefixB string
+	for p, m := range metas {
+		if m.RootPath == dirA {
+			prefixA = p
+			require.False(t, m.Unprefixed, "A desynced to prefixed metadata")
+		} else {
+			prefixB = p
+		}
+	}
+	require.NotEmpty(t, prefixA)
+	require.NotEmpty(t, prefixB)
+
+	// A's bucket is empty (its nodes are still under ""); B's is populated.
+	bucketA := g.RepoMemoryEstimate(prefixA).NodeCount
+	bucketB := g.RepoMemoryEstimate(prefixB).NodeCount
+	require.Zero(t, bucketA, "A's per-prefix bucket must be empty — its nodes carry repo_prefix=''")
+	require.Positive(t, bucketB, "B must have a populated per-prefix bucket")
+
+	// Expected attribution: the unaccounted pool (whole store minus B's
+	// bucket) goes to A, the lone empty-bucket repo.
+	expectedA := g.NodeCount() - bucketB
+	require.Greater(t, expectedA, 1, "sanity: A must own a real (non-near-empty) node pool for this test to be meaningful")
+
+	c := &realController{graph: g, multiIndexer: mi2, configManager: cm, logger: zap.NewNop()}
+	resp, err := c.Status(context.Background())
+	require.NoError(t, err)
+	require.Len(t, resp.TrackedRepos, 2)
+
+	rows := map[string]daemon.TrackedRepoStatus{}
+	for _, r := range resp.TrackedRepos {
+		rows[r.Prefix] = r
+	}
+	assert.Equal(t, expectedA, rows[prefixA].Nodes,
+		"A's row must reflect the unaccounted node pool it owns, not the near-empty frozen count")
+	assert.Equal(t, bucketB, rows[prefixB].Nodes,
+		"B's row must keep reflecting its own live per-prefix bucket")
+	assert.Greater(t, rows[prefixA].Nodes, bucketA,
+		"A's attributed pool must beat its former near-empty per-prefix bucket count")
+	assert.Equal(t, g.NodeCount(), rows[prefixA].Nodes+rows[prefixB].Nodes,
+		"the two rows together must account for the whole store")
 }

--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -1486,6 +1486,15 @@ func (mi *MultiIndexer) IncrementalReindexRepo(repoPrefix string, paths []string
 		EdgeCount:     result.EdgeCount,
 		ParseErrors:   result.Errors,
 		FileMtimes:    idx.FileMtimes(),
+		// Carried over from the prior metadata: this pass doesn't
+		// change either property, and dropping them here (both zero
+		// value on a fresh struct literal) used to silently flip a
+		// worktree or an Unprefixed solo repo back to their false
+		// defaults on the very first watcher-triggered incremental
+		// update, defeating callers that key behaviour off them (see
+		// the Unprefixed branch in cmd/gortex daemon status).
+		IsWorktree: meta.IsWorktree,
+		Unprefixed: meta.Unprefixed,
 	}
 	mi.mu.Unlock()
 


### PR DESCRIPTION
## Summary
- A repo indexed while it's the workspace's *only* tracked repo stamps its nodes with `RepoPrefix=""` (the `willBeMultiRepo` gate in `TrackRepoCtx`/`ReconcileRepoCtx`). `gortex daemon status`'s per-repo count lookup is keyed by the repo's resolved prefix string, which never matches `""`, so it silently fell back to a one-time-frozen `RepoMetadata` snapshot that goes stale the moment the live graph changes — reproducing "healthy, queryable graph but `daemon status` shows near-zero nodes/edges".
- Also fixes `IncrementalReindexRepo` (the file-watcher's per-save update path), which was resetting `Unprefixed`/`IsWorktree` back to `false` on every call — that would have defeated the counter fix after the very first file save in a session.
- Fixes #261
- Related to #270.

## Test plan
- [x] New regression test `TestStatus_UnprefixedSoloRepo_ReportsLiveNodeCount` — builds a real solo-repo `MultiIndexer`, grows the live graph past the frozen metadata snapshot, asserts `Status()` reports the live count, not the stale one.
- [x] Verified the test fails without the fix (reports the stale count) and passes with it.
- [x] `go build ./...`
- [x] `go vet ./cmd/gortex/... ./internal/indexer/...`
- [x] `go test ./cmd/gortex/...` (601 passed)
- [x] `go test ./internal/indexer/...` (825 passed)
- [x] `go test -race` on the touched status/reload/daemon and incremental-reindex/unprefixed/track/reconcile tests