### PR TITLE
search: hybrid ranking — code-embedding rerank, bounded diversification, per-class blends

### DIFF
--- a/internal/embedding/potion.go
+++ b/internal/embedding/potion.go
@@ -179,8 +179,8 @@ func f16ToF32(h uint16) float32 {
 	sign := uint32(h>>15) << 31
 	exp := uint32(h>>10) & 0x1f
 	man := uint32(h) & 0x3ff
-	switch {
-	case exp == 0:
+	switch exp {
+	case 0:
 		if man == 0 {
 			return math.Float32frombits(sign)
 		}
@@ -192,7 +192,7 @@ func f16ToF32(h uint16) float32 {
 		}
 		man &= 0x3ff
 		return math.Float32frombits(sign | e<<23 | man<<13)
-	case exp == 0x1f:
+	case 0x1f:
 		return math.Float32frombits(sign | 0xff<<23 | man<<13)
 	default:
 		return math.Float32frombits(sign | (exp+112)<<23 | man<<13)

--- a/internal/embedding/potion.go
+++ b/internal/embedding/potion.go
@@ -1,0 +1,315 @@
+package embedding
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/zzet/gortex/internal/platform"
+)
+
+// PotionProvider embeds text with a Model2Vec static embedding model —
+// a WordPiece tokenizer plus a single [vocab × dims] embedding matrix.
+// Inference is: tokenize → gather the token rows → mean-pool →
+// L2-normalise (the model config's `normalize: true` convention, matching
+// the reference implementations). No transformer, no positional limit —
+// a 50-candidate rerank batch embeds in well under a millisecond.
+//
+// The bundled model is minishlab/potion-code-16M-v2 (MIT): 256-dim
+// vectors over a ~63.5k-token code-mined vocabulary, distilled from a
+// code-retrieval teacher. It replaces the older averaged word-vector
+// channel for the rerank's semantic-cosine signal.
+type PotionProvider struct {
+	tok  *wordPieceTokenizer
+	mat  []float32 // row-major [vocab][dims]
+	dims int
+}
+
+// Potion model pin. The revision and checksums identify the exact
+// artifacts the loader accepts; a mismatched download is discarded.
+const (
+	potionModelName = "potion-code-16M-v2"
+	potionRevision  = "d3daf3e31f36d78f75913030b8bdf4a505d5b833"
+	potionBaseURL   = "https://huggingface.co/minishlab/" + potionModelName + "/resolve/" + potionRevision
+
+	potionWeightsFile   = "model.safetensors"
+	potionTokenizerFile = "tokenizer.json"
+
+	potionWeightsSHA256   = "75cf7a6c2171b230ad19b1e7d8e0b1aee86da5a02af8e7cacedd9921d227623c"
+	potionTokenizerSHA256 = "107bbdcbad4bff1d299b7a4c3a2fb17c52890688b7dd0e4c9deab79d3c4f3d45"
+)
+
+// maxPotionTokens caps how many tokens of one text feed the mean-pool.
+// The model is static (no sequence limit), but the rerank only ever
+// embeds short name+signature+doc fragments; the cap bounds the cost of
+// a pathological input.
+const maxPotionTokens = 512
+
+// NewPotionProviderFromDir loads the model from a directory holding
+// model.safetensors and tokenizer.json.
+func NewPotionProviderFromDir(dir string) (*PotionProvider, error) {
+	tok, err := loadWordPieceTokenizer(filepath.Join(dir, potionTokenizerFile))
+	if err != nil {
+		return nil, err
+	}
+	mat, dims, err := loadSafetensorsF16(filepath.Join(dir, potionWeightsFile))
+	if err != nil {
+		return nil, err
+	}
+	return &PotionProvider{tok: tok, mat: mat, dims: dims}, nil
+}
+
+func (p *PotionProvider) Dimensions() int { return p.dims }
+func (p *PotionProvider) Close() error    { return nil }
+
+func (p *PotionProvider) Embed(_ context.Context, text string) ([]float32, error) {
+	return p.embed(text), nil
+}
+
+func (p *PotionProvider) EmbedBatch(_ context.Context, texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i, t := range texts {
+		out[i] = p.embed(t)
+	}
+	return out, nil
+}
+
+func (p *PotionProvider) embed(text string) []float32 {
+	ids := p.tok.Encode(text)
+	if len(ids) > maxPotionTokens {
+		ids = ids[:maxPotionTokens]
+	}
+	vec := make([]float32, p.dims)
+	if len(ids) == 0 {
+		return vec
+	}
+	rows := len(p.mat) / p.dims
+	n := 0
+	for _, id := range ids {
+		if id < 0 || id >= rows {
+			continue
+		}
+		row := p.mat[id*p.dims : (id+1)*p.dims]
+		for i, v := range row {
+			vec[i] += v
+		}
+		n++
+	}
+	if n == 0 {
+		return vec
+	}
+	inv := 1.0 / float32(n)
+	var norm float64
+	for i := range vec {
+		vec[i] *= inv
+		norm += float64(vec[i]) * float64(vec[i])
+	}
+	// L2-normalise (model config `normalize: true`).
+	if norm > 0 {
+		s := float32(1.0 / math.Sqrt(norm))
+		for i := range vec {
+			vec[i] *= s
+		}
+	}
+	return vec
+}
+
+// loadSafetensorsF16 reads a single-tensor safetensors file holding an
+// F16 "embeddings" matrix and returns it as row-major float32.
+func loadSafetensorsF16(path string) ([]float32, int, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, 0, fmt.Errorf("read weights: %w", err)
+	}
+	if len(raw) < 8 {
+		return nil, 0, fmt.Errorf("weights file too short")
+	}
+	hlen := binary.LittleEndian.Uint64(raw[:8])
+	if hlen == 0 || 8+hlen > uint64(len(raw)) {
+		return nil, 0, fmt.Errorf("weights header out of range")
+	}
+	var header map[string]json.RawMessage
+	if err := json.Unmarshal(raw[8:8+hlen], &header); err != nil {
+		return nil, 0, fmt.Errorf("parse weights header: %w", err)
+	}
+	var info struct {
+		Dtype       string `json:"dtype"`
+		Shape       []int  `json:"shape"`
+		DataOffsets []int  `json:"data_offsets"`
+	}
+	entry, ok := header["embeddings"]
+	if !ok {
+		return nil, 0, fmt.Errorf("weights file has no 'embeddings' tensor")
+	}
+	if err := json.Unmarshal(entry, &info); err != nil {
+		return nil, 0, fmt.Errorf("parse tensor info: %w", err)
+	}
+	if info.Dtype != "F16" {
+		return nil, 0, fmt.Errorf("unsupported tensor dtype %q (want F16)", info.Dtype)
+	}
+	if len(info.Shape) != 2 || len(info.DataOffsets) != 2 {
+		return nil, 0, fmt.Errorf("unexpected tensor shape/offsets")
+	}
+	rows, dims := info.Shape[0], info.Shape[1]
+	start := 8 + int(hlen) + info.DataOffsets[0]
+	end := 8 + int(hlen) + info.DataOffsets[1]
+	if start < 0 || end > len(raw) || end-start != rows*dims*2 {
+		return nil, 0, fmt.Errorf("tensor data out of range")
+	}
+	data := raw[start:end]
+	mat := make([]float32, rows*dims)
+	for i := range mat {
+		mat[i] = f16ToF32(binary.LittleEndian.Uint16(data[i*2 : i*2+2]))
+	}
+	return mat, dims, nil
+}
+
+// f16ToF32 converts an IEEE-754 half-precision value to float32.
+func f16ToF32(h uint16) float32 {
+	sign := uint32(h>>15) << 31
+	exp := uint32(h>>10) & 0x1f
+	man := uint32(h) & 0x3ff
+	switch {
+	case exp == 0:
+		if man == 0 {
+			return math.Float32frombits(sign)
+		}
+		// Subnormal half: renormalise into a normal float32.
+		e := uint32(113) // 127 - 14
+		for man&0x400 == 0 {
+			man <<= 1
+			e--
+		}
+		man &= 0x3ff
+		return math.Float32frombits(sign | e<<23 | man<<13)
+	case exp == 0x1f:
+		return math.Float32frombits(sign | 0xff<<23 | man<<13)
+	default:
+		return math.Float32frombits(sign | (exp+112)<<23 | man<<13)
+	}
+}
+
+// resolvePotionDir returns the first directory that holds both model
+// files, probing in order:
+//
+//  1. $GORTEX_POTION_DIR — explicit override.
+//  2. <executable dir>/models/<model> — the release/bench sidecar. A
+//     packaged install ships the model next to the binary, so it is
+//     fully offline after install.
+//  3. <gortex home>/models/<model> — the per-user cache the first-use
+//     download fills.
+//
+// Returns "" when none has the files.
+func resolvePotionDir() string {
+	var candidates []string
+	if d := os.Getenv("GORTEX_POTION_DIR"); d != "" {
+		candidates = append(candidates, d)
+	}
+	if exe, err := os.Executable(); err == nil {
+		candidates = append(candidates, filepath.Join(filepath.Dir(exe), "models", potionModelName))
+	}
+	candidates = append(candidates, filepath.Join(platform.ModelsDir(), potionModelName))
+	for _, dir := range candidates {
+		if hasPotionFiles(dir) {
+			return dir
+		}
+	}
+	return ""
+}
+
+func hasPotionFiles(dir string) bool {
+	for _, f := range []string{potionWeightsFile, potionTokenizerFile} {
+		if st, err := os.Stat(filepath.Join(dir, f)); err != nil || st.IsDir() {
+			return false
+		}
+	}
+	return true
+}
+
+// downloadPotion fetches the pinned model revision into the per-user
+// models dir, verifying each file's SHA-256 before moving it into
+// place. Returns the directory on success. Disabled entirely when
+// GORTEX_POTION_DOWNLOAD=0 (offline installs ship the sidecar instead).
+func downloadPotion() (string, error) {
+	if v := strings.TrimSpace(os.Getenv("GORTEX_POTION_DOWNLOAD")); v == "0" || strings.EqualFold(v, "false") || strings.EqualFold(v, "off") {
+		return "", fmt.Errorf("model download disabled by GORTEX_POTION_DOWNLOAD")
+	}
+	dir := filepath.Join(platform.ModelsDir(), potionModelName)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	client := &http.Client{Timeout: 120 * time.Second}
+	files := []struct{ name, sum string }{
+		{potionWeightsFile, potionWeightsSHA256},
+		{potionTokenizerFile, potionTokenizerSHA256},
+	}
+	for _, f := range files {
+		dst := filepath.Join(dir, f.name)
+		if st, err := os.Stat(dst); err == nil && !st.IsDir() {
+			if ok, _ := fileSHA256Matches(dst, f.sum); ok {
+				continue
+			}
+		}
+		if err := downloadVerified(client, potionBaseURL+"/"+f.name, dst, f.sum); err != nil {
+			return "", fmt.Errorf("fetch %s: %w", f.name, err)
+		}
+	}
+	return dir, nil
+}
+
+// downloadVerified streams url into dst.partial, verifies the SHA-256,
+// and renames into place atomically.
+func downloadVerified(client *http.Client, url, dst, wantSHA string) error {
+	resp, err := client.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	tmp := dst + ".partial"
+	out, err := os.Create(tmp)
+	if err != nil {
+		return err
+	}
+	h := sha256.New()
+	_, cpErr := io.Copy(io.MultiWriter(out, h), resp.Body)
+	closeErr := out.Close()
+	if cpErr != nil {
+		os.Remove(tmp)
+		return cpErr
+	}
+	if closeErr != nil {
+		os.Remove(tmp)
+		return closeErr
+	}
+	if got := hex.EncodeToString(h.Sum(nil)); got != wantSHA {
+		os.Remove(tmp)
+		return fmt.Errorf("checksum mismatch: got %s want %s", got, wantSHA)
+	}
+	return os.Rename(tmp, dst)
+}
+
+func fileSHA256Matches(path, want string) (bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return false, err
+	}
+	return hex.EncodeToString(h.Sum(nil)) == want, nil
+}

--- a/internal/embedding/potion.go
+++ b/internal/embedding/potion.go
@@ -244,6 +244,12 @@ func downloadPotion() (string, error) {
 	if v := strings.TrimSpace(os.Getenv("GORTEX_POTION_DOWNLOAD")); v == "0" || strings.EqualFold(v, "false") || strings.EqualFold(v, "off") {
 		return "", fmt.Errorf("model download disabled by GORTEX_POTION_DOWNLOAD")
 	}
+	// Test binaries never reach the network: a `go test` run that
+	// exercises a search path must stay hermetic and fall back to the
+	// baked vectors instead of pulling 32MB mid-suite.
+	if strings.HasSuffix(os.Args[0], ".test") {
+		return "", fmt.Errorf("model download disabled in test binaries")
+	}
 	dir := filepath.Join(platform.ModelsDir(), potionModelName)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return "", err

--- a/internal/embedding/potion_test.go
+++ b/internal/embedding/potion_test.go
@@ -1,0 +1,214 @@
+package embedding
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTestTokenizer(t *testing.T, dir string, vocab map[string]int) {
+	t.Helper()
+	tj := map[string]any{
+		"normalizer": map[string]any{
+			"type": "BertNormalizer", "clean_text": true,
+			"handle_chinese_chars": true, "strip_accents": nil, "lowercase": true,
+		},
+		"pre_tokenizer": map[string]any{"type": "BertPreTokenizer"},
+		"model": map[string]any{
+			"type": "WordPiece", "unk_token": "[UNK]",
+			"continuing_subword_prefix": "##", "max_input_chars_per_word": 100,
+			"vocab": vocab,
+		},
+	}
+	raw, err := json.Marshal(tj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, potionTokenizerFile), raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// f32ToF16 converts float32 → IEEE half for fixture building. Handles
+// the normal range the fixtures use; no rounding subtleties needed.
+func f32ToF16(f float32) uint16 {
+	bits := math.Float32bits(f)
+	sign := uint16(bits>>16) & 0x8000
+	exp := int32(bits>>23&0xff) - 127 + 15
+	man := bits >> 13 & 0x3ff
+	if exp <= 0 {
+		return sign
+	}
+	if exp >= 0x1f {
+		return sign | 0x7c00
+	}
+	return sign | uint16(exp)<<10 | uint16(man)
+}
+
+func writeTestWeights(t *testing.T, dir string, rows [][]float32) {
+	t.Helper()
+	dims := len(rows[0])
+	header := map[string]any{
+		"embeddings": map[string]any{
+			"dtype": "F16", "shape": []int{len(rows), dims},
+			"data_offsets": []int{0, len(rows) * dims * 2},
+		},
+	}
+	hj, err := json.Marshal(header)
+	if err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 8, 8+len(hj)+len(rows)*dims*2)
+	binary.LittleEndian.PutUint64(buf, uint64(len(hj)))
+	buf = append(buf, hj...)
+	for _, row := range rows {
+		for _, v := range row {
+			var b [2]byte
+			binary.LittleEndian.PutUint16(b[:], f32ToF16(v))
+			buf = append(buf, b[:]...)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, potionWeightsFile), buf, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWordPiece_BertSchemeHermetic(t *testing.T) {
+	dir := t.TempDir()
+	vocab := map[string]int{
+		"[PAD]": 0, "[UNK]": 1,
+		"bind": 2, "##body": 3, "body": 4, "(": 5, ")": 6, "*": 7,
+		"client": 8, "func": 9, ".": 10, "go": 11,
+	}
+	writeTestTokenizer(t, dir, vocab)
+	tok, err := loadWordPieceTokenizer(filepath.Join(dir, potionTokenizerFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		text string
+		want []int
+	}{
+		// camel-cased word lowercased then greedily split
+		{"BindBody", []int{2, 3}},
+		// punctuation isolated; unknown word → UNK
+		{"func (c *Client)", []int{9, 5, 1, 7, 8, 6}},
+		// dot split as punctuation
+		{"bind.go", []int{2, 10, 11}},
+		// whitespace collapse + empty
+		{"   ", nil},
+		// no matching piece anywhere → whole-word UNK
+		{"zzzqqq", []int{1}},
+	}
+	for _, c := range cases {
+		got := tok.Encode(c.text)
+		if len(got) != len(c.want) {
+			t.Fatalf("Encode(%q) = %v, want %v", c.text, got, c.want)
+		}
+		for i := range got {
+			if got[i] != c.want[i] {
+				t.Fatalf("Encode(%q) = %v, want %v", c.text, got, c.want)
+			}
+		}
+	}
+}
+
+func TestPotionProvider_MeanPoolAndNormalize(t *testing.T) {
+	dir := t.TempDir()
+	vocab := map[string]int{"[PAD]": 0, "[UNK]": 1, "bind": 2, "##body": 3}
+	writeTestTokenizer(t, dir, vocab)
+	writeTestWeights(t, dir, [][]float32{
+		{0, 0, 0, 0},  // PAD
+		{1, 0, 0, 0},  // UNK
+		{0, 2, 0, 0},  // bind
+		{0, 0, 2, 0},  // ##body
+	})
+	p, err := NewPotionProviderFromDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Dimensions() != 4 {
+		t.Fatalf("dims = %d, want 4", p.Dimensions())
+	}
+	vec, err := p.Embed(context.Background(), "BindBody")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// mean of (0,2,0,0) and (0,0,2,0) = (0,1,1,0); L2-normalised.
+	want := []float32{0, float32(1 / math.Sqrt2), float32(1 / math.Sqrt2), 0}
+	for i := range want {
+		if math.Abs(float64(vec[i]-want[i])) > 1e-3 {
+			t.Fatalf("vec = %v, want %v", vec, want)
+		}
+	}
+	// Unknown-only text embeds the UNK row, not a zero vector.
+	vec2, _ := p.Embed(context.Background(), "zzzqqq")
+	if vec2[0] < 0.99 {
+		t.Fatalf("UNK-only embed = %v, want unit x-axis", vec2)
+	}
+	// Empty text → zero vector (signal reads it as no evidence).
+	vec3, _ := p.Embed(context.Background(), "")
+	for _, v := range vec3 {
+		if v != 0 {
+			t.Fatalf("empty embed should be zero vector, got %v", vec3)
+		}
+	}
+}
+
+// TestPotionProvider_GoldenAgainstReference verifies the pure-Go
+// tokenizer + pooling against reference outputs captured from the
+// upstream tokenizers + numpy implementation for the real model.
+// Skipped when the model files are not installed on this machine.
+func TestPotionProvider_GoldenAgainstReference(t *testing.T) {
+	dir := resolvePotionDir()
+	if dir == "" {
+		t.Skip("potion model files not installed; run with GORTEX_POTION_DIR pointing at the model")
+	}
+	p, err := NewPotionProviderFromDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden := []struct {
+		text  string
+		ids   []int
+		head8 []float32
+	}{
+		{
+			"BindBody bsonBinding.BindBody binding/bson.go",
+			[]int{13190, 22687, 30716, 7431, 3670, 15, 13190, 22687, 7034, 16, 30716, 15, 1178},
+			[]float32{0.034474, 0.018522, -0.13514, 0.084147, 0.232714, -0.36536, 0.193378, 0.139676},
+		},
+		{
+			"decode bson request body",
+			[]int{29631, 30716, 4230, 1306},
+			[]float32{-0.07553, -0.022155, -0.119157, 0.177616, 0.124399, -0.224746, 0.050767, 0.065148},
+		},
+		{
+			"func (c *Client) Do(req *Request) (*Response, error)",
+			[]int{29527, 9, 42, 11, 6399, 10, 1082, 9, 29556, 11, 4230, 10, 9, 11, 2436, 13, 6564, 10},
+			[]float32{-0.087694, 0.013899, -0.003767, 0.109125, -0.006322, 0.076795, 0.031422, 0.040902},
+		},
+	}
+	for _, g := range golden {
+		ids := p.tok.Encode(g.text)
+		if len(ids) != len(g.ids) {
+			t.Fatalf("Encode(%q) ids = %v, want %v", g.text, ids, g.ids)
+		}
+		for i := range ids {
+			if ids[i] != g.ids[i] {
+				t.Fatalf("Encode(%q) ids = %v, want %v", g.text, ids, g.ids)
+			}
+		}
+		vec, _ := p.Embed(context.Background(), g.text)
+		for i, w := range g.head8 {
+			if math.Abs(float64(vec[i]-w)) > 2e-3 {
+				t.Fatalf("Embed(%q)[%d] = %.6f, want %.6f", g.text, i, vec[i], w)
+			}
+		}
+	}
+}

--- a/internal/embedding/shared.go
+++ b/internal/embedding/shared.go
@@ -1,0 +1,46 @@
+package embedding
+
+import (
+	"context"
+	"sync"
+)
+
+// sharedStatic memoises a single process-wide StaticProvider. The baked
+// GloVe vectors are ~3.7MB compressed and decompress into a ~20k-entry
+// map that is safe for concurrent reads, so one instance serves every
+// rerank call. Constructed lazily on first use.
+var (
+	sharedStaticOnce sync.Once
+	sharedStaticInst *StaticProvider
+)
+
+// SharedStatic returns the process-wide static word-vector provider,
+// constructing it on first call. Returns nil only when the baked
+// vectors fail to load (a corrupt build); callers treat nil as "no
+// semantic-cosine channel". Safe for concurrent use.
+func SharedStatic() *StaticProvider {
+	sharedStaticOnce.Do(func() {
+		p, err := NewStaticProvider()
+		if err != nil {
+			return
+		}
+		sharedStaticInst = p
+	})
+	return sharedStaticInst
+}
+
+// EmbedTextFunc adapts a provider into the plain func the rerank
+// Context wants: text -> normalised vector, errors and nil providers
+// collapsing to a nil result the signal reads as "cannot embed".
+func EmbedTextFunc(p Provider) func(string) []float32 {
+	if p == nil {
+		return nil
+	}
+	return func(text string) []float32 {
+		vec, err := p.Embed(context.Background(), text)
+		if err != nil {
+			return nil
+		}
+		return vec
+	}
+}

--- a/internal/embedding/shared.go
+++ b/internal/embedding/shared.go
@@ -2,6 +2,8 @@ package embedding
 
 import (
 	"context"
+	"os"
+	"strings"
 	"sync"
 )
 
@@ -43,4 +45,52 @@ func EmbedTextFunc(p Provider) func(string) []float32 {
 		}
 		return vec
 	}
+}
+
+// sharedCode memoises the process-wide code-embedding provider used by
+// the rerank's semantic-cosine channel: the bundled static code model
+// (potion) when its files resolve — explicit dir, exec-adjacent
+// sidecar, per-user models dir, or a checksum-verified first-use
+// download — and the baked GloVe word vectors otherwise, so an offline
+// install without the sidecar still gets a semantic channel.
+var (
+	sharedCodeOnce sync.Once
+	sharedCodeInst Provider
+)
+
+// SharedCodeEmbedder returns the process-wide code embedder for the
+// rerank's semantic-cosine channel. Never returns an error — the
+// fallback chain ends at the baked static provider; nil only when even
+// that failed to load. Safe for concurrent use. GORTEX_POTION=0 pins
+// the GloVe fallback (diagnostic escape hatch).
+func SharedCodeEmbedder() Provider {
+	sharedCodeOnce.Do(func() {
+		if v := strings.TrimSpace(os.Getenv("GORTEX_POTION")); v == "0" || strings.EqualFold(v, "false") || strings.EqualFold(v, "off") {
+			sharedCodeInst = staticOrNil()
+			return
+		}
+		dir := resolvePotionDir()
+		if dir == "" {
+			if d, err := downloadPotion(); err == nil {
+				dir = d
+			}
+		}
+		if dir != "" {
+			if p, err := NewPotionProviderFromDir(dir); err == nil {
+				sharedCodeInst = p
+				return
+			}
+		}
+		sharedCodeInst = staticOrNil()
+	})
+	return sharedCodeInst
+}
+
+// staticOrNil adapts SharedStatic's concrete return into the Provider
+// interface without wrapping a typed nil.
+func staticOrNil() Provider {
+	if p := SharedStatic(); p != nil {
+		return p
+	}
+	return nil
 }

--- a/internal/embedding/wordpiece.go
+++ b/internal/embedding/wordpiece.go
@@ -1,0 +1,271 @@
+package embedding
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"unicode"
+
+	"golang.org/x/text/unicode/norm"
+)
+
+// wordPieceTokenizer is a minimal, dependency-free implementation of the
+// HuggingFace fast-tokenizer trio used by BERT-style vocabularies:
+// BertNormalizer → BertPreTokenizer → WordPiece. It loads the standard
+// tokenizer.json and reproduces the exact token-ID sequences of the
+// reference implementation for that configuration (verified by golden
+// tests against the upstream tokenizer).
+//
+// Scope: only the configuration the bundled static code-embedding model
+// uses — BertNormalizer{clean_text, handle_chinese_chars, lowercase,
+// strip_accents:null} + BertPreTokenizer + WordPiece{"##"} — is
+// implemented. Loading a tokenizer.json with a different model type
+// fails loudly rather than mis-tokenizing quietly.
+type wordPieceTokenizer struct {
+	vocab            map[string]int
+	unkID            int
+	contPrefix       string
+	maxWordChars     int
+	lowercase        bool
+	stripAccents     bool
+	cleanText        bool
+	handleCJK        bool
+}
+
+// tokenizerJSON mirrors just the fields of tokenizer.json this
+// implementation consumes.
+type tokenizerJSON struct {
+	Normalizer *struct {
+		Type         string `json:"type"`
+		CleanText    *bool  `json:"clean_text"`
+		HandleCJK    *bool  `json:"handle_chinese_chars"`
+		StripAccents *bool  `json:"strip_accents"`
+		Lowercase    *bool  `json:"lowercase"`
+	} `json:"normalizer"`
+	PreTokenizer *struct {
+		Type string `json:"type"`
+	} `json:"pre_tokenizer"`
+	Model struct {
+		Type                    string         `json:"type"`
+		UnkToken                string         `json:"unk_token"`
+		ContinuingSubwordPrefix string         `json:"continuing_subword_prefix"`
+		MaxInputCharsPerWord    *int           `json:"max_input_chars_per_word"`
+		Vocab                   map[string]int `json:"vocab"`
+	} `json:"model"`
+}
+
+// loadWordPieceTokenizer parses a tokenizer.json from disk.
+func loadWordPieceTokenizer(path string) (*wordPieceTokenizer, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read tokenizer: %w", err)
+	}
+	var tj tokenizerJSON
+	if err := json.Unmarshal(raw, &tj); err != nil {
+		return nil, fmt.Errorf("parse tokenizer: %w", err)
+	}
+	if tj.Model.Type != "WordPiece" {
+		return nil, fmt.Errorf("unsupported tokenizer model %q (want WordPiece)", tj.Model.Type)
+	}
+	if len(tj.Model.Vocab) == 0 {
+		return nil, fmt.Errorf("tokenizer vocab is empty")
+	}
+	t := &wordPieceTokenizer{
+		vocab:        tj.Model.Vocab,
+		contPrefix:   tj.Model.ContinuingSubwordPrefix,
+		maxWordChars: 100,
+		// BertNormalizer defaults per the reference implementation.
+		cleanText: true,
+		handleCJK: true,
+	}
+	if t.contPrefix == "" {
+		t.contPrefix = "##"
+	}
+	if tj.Model.MaxInputCharsPerWord != nil && *tj.Model.MaxInputCharsPerWord > 0 {
+		t.maxWordChars = *tj.Model.MaxInputCharsPerWord
+	}
+	unk := tj.Model.UnkToken
+	if unk == "" {
+		unk = "[UNK]"
+	}
+	id, ok := t.vocab[unk]
+	if !ok {
+		return nil, fmt.Errorf("unk token %q not in vocab", unk)
+	}
+	t.unkID = id
+	if n := tj.Normalizer; n != nil {
+		if n.CleanText != nil {
+			t.cleanText = *n.CleanText
+		}
+		if n.HandleCJK != nil {
+			t.handleCJK = *n.HandleCJK
+		}
+		if n.Lowercase != nil {
+			t.lowercase = *n.Lowercase
+		}
+		// strip_accents:null means "follow lowercase" in the reference
+		// implementation; an explicit value wins.
+		if n.StripAccents != nil {
+			t.stripAccents = *n.StripAccents
+		} else {
+			t.stripAccents = t.lowercase
+		}
+	}
+	return t, nil
+}
+
+// Encode returns the WordPiece token IDs for text. No special tokens
+// are added (the model's post_processor is null).
+func (t *wordPieceTokenizer) Encode(text string) []int {
+	var ids []int
+	for _, word := range t.preTokenize(t.normalize(text)) {
+		ids = t.wordPiece(word, ids)
+	}
+	return ids
+}
+
+// normalize applies BertNormalizer: control-char cleanup, CJK padding,
+// accent stripping (NFD, drop Mn), lowercasing.
+func (t *wordPieceTokenizer) normalize(s string) string {
+	var b strings.Builder
+	b.Grow(len(s) + 8)
+	for _, r := range s {
+		if t.cleanText {
+			if r == 0 || r == 0xFFFD || isBertControl(r) {
+				continue
+			}
+			if isBertWhitespace(r) {
+				b.WriteByte(' ')
+				continue
+			}
+		}
+		if t.handleCJK && isCJK(r) {
+			b.WriteByte(' ')
+			b.WriteRune(r)
+			b.WriteByte(' ')
+			continue
+		}
+		b.WriteRune(r)
+	}
+	out := b.String()
+	if t.stripAccents {
+		decomposed := norm.NFD.String(out)
+		var sb strings.Builder
+		sb.Grow(len(decomposed))
+		for _, r := range decomposed {
+			if unicode.Is(unicode.Mn, r) {
+				continue
+			}
+			sb.WriteRune(r)
+		}
+		out = sb.String()
+	}
+	if t.lowercase {
+		out = strings.ToLower(out)
+	}
+	return out
+}
+
+// preTokenize applies BertPreTokenizer: split on whitespace, then
+// isolate each punctuation rune as its own token.
+func (t *wordPieceTokenizer) preTokenize(s string) []string {
+	var words []string
+	var cur strings.Builder
+	flush := func() {
+		if cur.Len() > 0 {
+			words = append(words, cur.String())
+			cur.Reset()
+		}
+	}
+	for _, r := range s {
+		switch {
+		case isBertWhitespace(r):
+			flush()
+		case isBertPunct(r):
+			flush()
+			words = append(words, string(r))
+		default:
+			cur.WriteRune(r)
+		}
+	}
+	flush()
+	return words
+}
+
+// wordPiece runs the greedy longest-match-first sub-word split for one
+// word, appending IDs to dst.
+func (t *wordPieceTokenizer) wordPiece(word string, dst []int) []int {
+	runes := []rune(word)
+	if len(runes) > t.maxWordChars {
+		return append(dst, t.unkID)
+	}
+	start := 0
+	var pieces []int
+	for start < len(runes) {
+		end := len(runes)
+		id := -1
+		for end > start {
+			sub := string(runes[start:end])
+			if start > 0 {
+				sub = t.contPrefix + sub
+			}
+			if v, ok := t.vocab[sub]; ok {
+				id = v
+				break
+			}
+			end--
+		}
+		if id < 0 {
+			// No piece matched: the whole word becomes UNK, per the
+			// reference implementation.
+			return append(dst, t.unkID)
+		}
+		pieces = append(pieces, id)
+		start = end
+	}
+	return append(dst, pieces...)
+}
+
+// isBertControl mirrors the reference _is_control: category Cc/Cf,
+// except tab / newline / carriage-return which count as whitespace.
+func isBertControl(r rune) bool {
+	if r == '\t' || r == '\n' || r == '\r' {
+		return false
+	}
+	return unicode.Is(unicode.Cc, r) || unicode.Is(unicode.Cf, r)
+}
+
+// isBertWhitespace mirrors the reference _is_whitespace.
+func isBertWhitespace(r rune) bool {
+	switch r {
+	case ' ', '\t', '\n', '\r':
+		return true
+	}
+	return unicode.Is(unicode.Zs, r)
+}
+
+// isBertPunct mirrors the reference _is_punctuation: the four ASCII
+// symbol ranges plus every Unicode P* category rune.
+func isBertPunct(r rune) bool {
+	if (r >= 33 && r <= 47) || (r >= 58 && r <= 64) || (r >= 91 && r <= 96) || (r >= 123 && r <= 126) {
+		return true
+	}
+	return unicode.IsPunct(r)
+}
+
+// isCJK mirrors the reference _is_chinese_char CJK block test.
+func isCJK(r rune) bool {
+	switch {
+	case r >= 0x4E00 && r <= 0x9FFF,
+		r >= 0x3400 && r <= 0x4DBF,
+		r >= 0x20000 && r <= 0x2A6DF,
+		r >= 0x2A700 && r <= 0x2B73F,
+		r >= 0x2B740 && r <= 0x2B81F,
+		r >= 0x2B820 && r <= 0x2CEAF,
+		r >= 0xF900 && r <= 0xFAFF,
+		r >= 0x2F800 && r <= 0x2FA1F:
+		return true
+	}
+	return false
+}

--- a/internal/mcp/rerank_context.go
+++ b/internal/mcp/rerank_context.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 
+	"github.com/zzet/gortex/internal/embedding"
 	"github.com/zzet/gortex/internal/search/rerank"
 )
 
@@ -114,6 +115,22 @@ func (s *Server) buildRerankContext(ctx context.Context, query string) *rerank.C
 	// from an enriched snapshot). Until then the signal sits at 0.
 	if s.hasCoChangeData() {
 		rctx.CoChangeOf = s.coChangeScores
+	}
+
+	// Semantic-cosine channel: the always-available in-process static
+	// word-vector provider (baked GloVe) re-scores the BM25 top-N
+	// against the query with no ANN index and no index-time vector
+	// build. Wired unconditionally — the per-class weight table damps
+	// it hard on identifier / path queries so it earns its keep only on
+	// natural-language intent queries, where BM25 alone cannot bridge
+	// "decode bson body" to BindBody. An empty query vector (no known
+	// words) leaves the signal at 0, so a pure-identifier query is
+	// unaffected even before the class damping.
+	if emb := embedding.SharedStatic(); emb != nil {
+		rctx.EmbedText = embedding.EmbedTextFunc(emb)
+		if qv, err := emb.Embed(ctx, query); err == nil {
+			rctx.QueryVec = qv
+		}
 	}
 
 	return rctx

--- a/internal/mcp/rerank_context.go
+++ b/internal/mcp/rerank_context.go
@@ -117,16 +117,16 @@ func (s *Server) buildRerankContext(ctx context.Context, query string) *rerank.C
 		rctx.CoChangeOf = s.coChangeScores
 	}
 
-	// Semantic-cosine channel: the always-available in-process static
-	// word-vector provider (baked GloVe) re-scores the BM25 top-N
-	// against the query with no ANN index and no index-time vector
-	// build. Wired unconditionally — the per-class weight table damps
-	// it hard on identifier / path queries so it earns its keep only on
-	// natural-language intent queries, where BM25 alone cannot bridge
-	// "decode bson body" to BindBody. An empty query vector (no known
-	// words) leaves the signal at 0, so a pure-identifier query is
-	// unaffected even before the class damping.
-	if emb := embedding.SharedStatic(); emb != nil {
+	// Semantic-cosine channel: the in-process static code-embedding
+	// model (with the baked GloVe word vectors as offline fallback)
+	// re-scores the BM25 top-N against the query with no ANN index and
+	// no index-time vector build. Wired unconditionally — the per-class
+	// weight table damps it hard on identifier / path queries so it
+	// earns its keep only on natural-language intent queries, where
+	// BM25 alone cannot bridge "decode bson body" to BindBody. An empty
+	// query vector leaves the signal at 0, so a pure-identifier query
+	// is unaffected even before the class damping.
+	if emb := embedding.SharedCodeEmbedder(); emb != nil {
 		rctx.EmbedText = embedding.EmbedTextFunc(emb)
 		if qv, err := emb.Embed(ctx, query); err == nil {
 			rctx.QueryVec = qv

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -1502,6 +1502,18 @@ func (s *Server) handleSearchSymbols(ctx context.Context, req mcp.CallToolReques
 		// in/out edge pair through the bundle phase. Tighten to
 		// +5 so the post-filter slack still leaves a full page.
 		fetchLimit = offset + limit + 5
+	} else {
+		// Concept / degraded-identifier query with no LLM assist: the
+		// always-on semantic-cosine rerank still runs, so widen the BM25
+		// head to a full rerank pool. A natural-language intent query
+		// ("decode bson request body") often has its target sitting past
+		// the default +10 over-fetch; the semantic channel can only lift
+		// a candidate it actually sees, so this pool is what turns a
+		// BM25-rank-15 file hit into a top-5 result. Cheap: ~40 extra
+		// FTS rows and their edge pairs, well inside the latency budget.
+		if want := offset + limit + semanticRerankPool; want > fetchLimit {
+			fetchLimit = want
+		}
 	}
 
 	// Expansion terms feeding the BM25 OR-merge: LLM-derived synonyms

--- a/internal/mcp/tools_search_assist.go
+++ b/internal/mcp/tools_search_assist.go
@@ -435,6 +435,14 @@ func graphReaderFromEngine(eng *query.Engine) (namesReader, bool) {
 // after the reranked head.
 const rerankCap = 20
 
+// semanticRerankPool is the BM25 over-fetch width for a concept /
+// degraded-identifier query that will be reranked by the always-on
+// in-process semantic-cosine channel (no LLM assist). Wide enough that
+// an intent query's target, which BM25 alone ranks past the default
+// over-fetch, still enters the candidate pool the semantic rerank can
+// reorder into the top-5.
+const semanticRerankPool = 40
+
 // prioritizeCallables stably re-orders nodes so functions and methods
 // come first, preserving BM25 order within each bucket. Everything
 // non-callable (fields, params, variables, constants, types, files,

--- a/internal/search/rerank/context.go
+++ b/internal/search/rerank/context.go
@@ -88,6 +88,23 @@ type Context struct {
 	// treated as 1.0 everywhere.
 	ComboBoostOf func(nodeID string) float64
 
+	// EmbedText returns a normalised embedding vector for arbitrary
+	// text, or nil when it cannot embed. It is the substrate for the
+	// on-the-fly SemanticCosineSignal: the signal assembles a compact
+	// text for each candidate (name + qualname + path + signature) and
+	// embeds it here, then cosines the result against QueryVec. Wired by
+	// the MCP server to the always-available in-process static provider;
+	// nil disables the semantic-cosine channel (it then sits at 0). The
+	// closure must be safe for concurrent use.
+	EmbedText func(text string) []float32
+
+	// QueryVec is the pre-computed embedding of the raw query, produced
+	// once per request with the same provider EmbedText wraps. Empty
+	// disables the semantic-cosine channel. Kept on the Context so the
+	// per-candidate signal pays only for one candidate embed + one dot
+	// product, never a second query embed.
+	QueryVec []float32
+
 	// Centrality runs a Random-Walk-with-Restart (Personalized
 	// PageRank) from the given seed node IDs and returns each reachable
 	// node's proximity score. It is the data source for ProximitySignal.

--- a/internal/search/rerank/context.go
+++ b/internal/search/rerank/context.go
@@ -2,6 +2,7 @@ package rerank
 
 import (
 	"math"
+	"strings"
 	"time"
 
 	"github.com/zzet/gortex/internal/graph"
@@ -159,6 +160,13 @@ type Context struct {
 	// MinHash uses it to only count similarity edges that point to
 	// other candidates in the same batch (cluster-cohesion signal).
 	candidateIDs map[string]struct{}
+
+	// nameGroupCount maps a lowercased candidate name → how many
+	// candidates in the batch share it. OverloadProminenceSignal reads
+	// it to fire only on a genuine same-name collision (an ambiguous
+	// query where several symbols answer to the same identifier), so
+	// non-colliding candidates are never perturbed.
+	nameGroupCount map[string]int
 
 	// fileGroups maps each file path → candidates from that file in
 	// batch order. The file-coherence signal reads this to detect
@@ -344,6 +352,7 @@ func (c *Context) prepare(cands []*Candidate) {
 	c.communityCount = make(map[string]int, len(cands))
 	c.maxCommunityCount = 0
 	c.candidateIDs = make(map[string]struct{}, len(cands))
+	c.nameGroupCount = make(map[string]int, len(cands))
 	c.fanInMax = 0
 	c.fanOutMax = 0
 	c.churnMax = 0
@@ -369,6 +378,10 @@ func (c *Context) prepare(cands []*Candidate) {
 		}
 		c.candidateIDs[cand.Node.ID] = struct{}{}
 		ids = append(ids, cand.Node.ID)
+
+		if nm := strings.ToLower(cand.Node.Name); nm != "" {
+			c.nameGroupCount[nm]++
+		}
 
 		if c.CommunityOf != nil {
 			com := c.CommunityOf(cand.Node.ID)

--- a/internal/search/rerank/pipeline.go
+++ b/internal/search/rerank/pipeline.go
@@ -193,6 +193,7 @@ func DefaultSignals() []Signal {
 	return []Signal{
 		BM25Signal{},
 		SemanticSignal{},
+		SemanticCosineSignal{},
 		FanInSignal{},
 		HITSSignal{},
 		FanOutSignal{},
@@ -230,6 +231,7 @@ func DefaultWeights() map[string]float64 {
 	return map[string]float64{
 		SignalBM25:           1.00,
 		SignalSemantic:       0.80,
+		SignalSemanticCosine: 0.70,
 		SignalFanIn:          0.60,
 		SignalHITS:           0.40,
 		SignalFanOut:         0.20,
@@ -255,6 +257,7 @@ func DefaultWeights() map[string]float64 {
 const (
 	SignalBM25           = "bm25"
 	SignalSemantic       = "semantic"
+	SignalSemanticCosine = "semantic_cosine"
 	SignalFanIn          = "fan_in"
 	SignalHITS           = "hits"
 	SignalFanOut         = "fan_out"
@@ -280,6 +283,7 @@ func AllSignalNames() []string {
 	return []string{
 		SignalBM25,
 		SignalSemantic,
+		SignalSemanticCosine,
 		SignalFanIn,
 		SignalHITS,
 		SignalFanOut,

--- a/internal/search/rerank/pipeline.go
+++ b/internal/search/rerank/pipeline.go
@@ -236,7 +236,7 @@ func DefaultWeights() map[string]float64 {
 	return map[string]float64{
 		SignalBM25:           1.00,
 		SignalSemantic:       0.80,
-		SignalSemanticCosine: 0.70,
+		SignalSemanticCosine: 1.30,
 		SignalFanIn:          0.60,
 		SignalHITS:           0.40,
 		SignalFanOut:         0.20,

--- a/internal/search/rerank/pipeline.go
+++ b/internal/search/rerank/pipeline.go
@@ -167,7 +167,76 @@ func (p *Pipeline) Rerank(query string, cands []*Candidate, ctx *Context) []*Can
 		}
 		return cands[i].Node.ID < cands[j].Node.ID
 	})
+	// Bounded file diversification, concept queries only: an intent
+	// query answered by one big file's symbols crowds every other file
+	// out of the head. Each file keeps its two best rows untouched;
+	// from the third on, a row is pushed down by a bounded positional
+	// penalty so a fresh file's best candidate can enter the head.
+	// Identifier / path queries are exempt — an exact-token query that
+	// legitimately resolves to many rows of one file (overloads in one
+	// implementation file) must keep its literal order.
+	if ctx.QueryClass == QueryClassConcept {
+		applyFileDiversity(cands)
+	}
 	return cands
+}
+
+// fileDiversityAllowed is how many rows one file keeps un-demoted at
+// the head of the ranking; fileDiversityStep is the positional penalty
+// each further same-file row accrues. Both tuned on the discovery
+// evaluation corpus with one tier per repo held out: allowed=2 with
+// step=3 lifted the held-out intent tier's file-hit without moving any
+// exact-identifier metric, while step>=4 began trading away symbol-level
+// hits for file coverage.
+const (
+	fileDiversityAllowed = 2
+	fileDiversityStep    = 3
+)
+
+// applyFileDiversity re-orders a score-sorted candidate slice by
+// effective rank: a candidate whose file already holds
+// fileDiversityAllowed higher-ranked candidates is demoted by
+// fileDiversityStep positions per extra same-file row above it
+// (xQuAD-lite — bounded, not a full round-robin, so the strongest
+// same-file rows keep their positions and symbol-level hits are
+// preserved). In-place, stable for untouched rows.
+func applyFileDiversity(cands []*Candidate) {
+	if len(cands) < 3 {
+		return
+	}
+	seen := make(map[string]int, len(cands))
+	eff := make([]int, len(cands))
+	demoted := false
+	for i, c := range cands {
+		eff[i] = i
+		if c == nil || c.Node == nil || c.Node.FilePath == "" {
+			continue
+		}
+		above := seen[c.Node.FilePath]
+		seen[c.Node.FilePath] = above + 1
+		if above >= fileDiversityAllowed {
+			eff[i] = i + fileDiversityStep*(above-fileDiversityAllowed+1)
+			demoted = true
+		}
+	}
+	if !demoted {
+		return
+	}
+	idx := make([]int, len(cands))
+	for i := range idx {
+		idx[i] = i
+	}
+	sort.SliceStable(idx, func(a, b int) bool {
+		if eff[idx[a]] != eff[idx[b]] {
+			return eff[idx[a]] < eff[idx[b]]
+		}
+		return idx[a] < idx[b]
+	})
+	out := make([]*Candidate, len(cands))
+	for i, j := range idx {
+		out[i] = cands[j]
+	}
+	copy(cands, out)
 }
 
 // sameSliceHeader reports whether a and b alias the same underlying

--- a/internal/search/rerank/pipeline.go
+++ b/internal/search/rerank/pipeline.go
@@ -305,7 +305,7 @@ func DefaultWeights() map[string]float64 {
 	return map[string]float64{
 		SignalBM25:           1.00,
 		SignalSemantic:       0.80,
-		SignalSemanticCosine: 1.30,
+		SignalSemanticCosine: 2.00,
 		SignalFanIn:          0.60,
 		SignalHITS:           0.40,
 		SignalFanOut:         0.20,

--- a/internal/search/rerank/pipeline.go
+++ b/internal/search/rerank/pipeline.go
@@ -143,7 +143,11 @@ func (p *Pipeline) Rerank(query string, cands []*Candidate, ctx *Context) []*Can
 			}
 			total += w * classMult * raw
 		}
-		c.Score = total
+		// Multiplicative supporting-cast demotion, applied after the
+		// additive signal sum: a test file that out-scores the real
+		// implementation on shared vocabulary is pushed below it rather
+		// than merely nudged. 1.0 (no-op) for every non-test candidate.
+		c.Score = total * supportFileDemotion(c, ctx)
 	}
 
 	sort.SliceStable(cands, func(i, j int) bool {

--- a/internal/search/rerank/pipeline.go
+++ b/internal/search/rerank/pipeline.go
@@ -215,6 +215,7 @@ func DefaultSignals() []Signal {
 		SourceBiasSignal{},
 		ProvenanceSignal{},
 		ProximitySignal{},
+		OverloadProminenceSignal{},
 	}
 }
 
@@ -253,6 +254,7 @@ func DefaultWeights() map[string]float64 {
 		SignalSourceBias:     0.25,
 		SignalProvenance:     0.15,
 		SignalProximity:      0.45,
+		SignalOverload:       0.35,
 	}
 }
 
@@ -279,6 +281,7 @@ const (
 	SignalSourceBias     = "source_bias"
 	SignalProvenance     = "provenance"
 	SignalProximity      = "proximity"
+	SignalOverload       = "overload"
 )
 
 // AllSignalNames lists every canonical signal name. Useful for config
@@ -305,5 +308,6 @@ func AllSignalNames() []string {
 		SignalSourceBias,
 		SignalProvenance,
 		SignalProximity,
+		SignalOverload,
 	}
 }

--- a/internal/search/rerank/query_kind.go
+++ b/internal/search/rerank/query_kind.go
@@ -414,7 +414,7 @@ func ClassWeightMultiplier(c QueryClass, signal string) float64 {
 	switch signal {
 	case SignalBM25:
 		return cw.bm25
-	case SignalSemantic:
+	case SignalSemantic, SignalSemanticCosine:
 		return cw.semantic
 	case SignalProximity:
 		if cw.proximity == 0 {
@@ -445,6 +445,7 @@ func ClassWeightMultiplier(c QueryClass, signal string) float64 {
 var proseWeightTable = map[string]float64{
 	SignalBM25:           1.25,
 	SignalSemantic:       1.30,
+	SignalSemanticCosine: 1.30,
 	SignalAPISignature:   0.0,
 	SignalTypeSignature:  0.0,
 	SignalDefinitionBias: 0.0,
@@ -489,7 +490,7 @@ func continuousClassMultiplier(alpha float64, signal string) float64 {
 	switch signal {
 	case SignalBM25:
 		return 1.0 + frac*(maxBM25-1.0)
-	case SignalSemantic:
+	case SignalSemantic, SignalSemanticCosine:
 		return 1.0 - frac*(1.0-minSem)
 	case SignalProximity:
 		// Interpolate proximity from the concept (NL) anchor down to

--- a/internal/search/rerank/ranking_regression_test.go
+++ b/internal/search/rerank/ranking_regression_test.go
@@ -123,6 +123,40 @@ func TestOverloadProminence_FiresOnlyOnCollision(t *testing.T) {
 	}
 }
 
+func TestApplyFileDiversity_BoundedDemotion(t *testing.T) {
+	mk := func(id, fp string) *Candidate {
+		return &Candidate{Node: &graph.Node{ID: id, FilePath: fp}}
+	}
+	// Five rows from big.go crowd the head; small.go sits at rank 5.
+	cands := []*Candidate{
+		mk("b1", "big.go"), mk("b2", "big.go"), mk("b3", "big.go"),
+		mk("b4", "big.go"), mk("b5", "big.go"), mk("s1", "small.go"),
+	}
+	applyFileDiversity(cands)
+	// The first two big.go rows are untouched; the third-and-later are
+	// demoted so small.go's best row enters the head.
+	if cands[0].Node.ID != "b1" || cands[1].Node.ID != "b2" {
+		t.Fatalf("top-2 of the crowding file must keep their rank, got %s,%s",
+			cands[0].Node.ID, cands[1].Node.ID)
+	}
+	pos := map[string]int{}
+	for i, c := range cands {
+		pos[c.Node.ID] = i
+	}
+	if pos["s1"] >= pos["b4"] {
+		t.Fatalf("fresh file's best row must outrank the 4th crowding row: %v", pos)
+	}
+	// A list with no file holding 3+ rows is untouched.
+	orig := []*Candidate{mk("a", "x.go"), mk("b", "y.go"), mk("c", "x.go"), mk("d", "y.go")}
+	want := []string{"a", "b", "c", "d"}
+	applyFileDiversity(orig)
+	for i, c := range orig {
+		if c.Node.ID != want[i] {
+			t.Fatalf("no-crowding list must be stable, got %v at %d", c.Node.ID, i)
+		}
+	}
+}
+
 // TestPipeline_SemanticLiftsConceptTarget locks in the end-to-end
 // behaviour: with the semantic channel wired, a concept query lifts the
 // semantically-related candidate above a lexically-adjacent but unrelated

--- a/internal/search/rerank/ranking_regression_test.go
+++ b/internal/search/rerank/ranking_regression_test.go
@@ -20,7 +20,7 @@ func bagEmbed(vocab []string) func(string) []float32 {
 	return func(text string) []float32 {
 		v := make([]float32, len(vocab))
 		for _, tok := range strings.FieldsFunc(strings.ToLower(text), func(r rune) bool {
-			return !(r >= 'a' && r <= 'z')
+			return r < 'a' || r > 'z'
 		}) {
 			if i, ok := idx[tok]; ok {
 				v[i] += 1

--- a/internal/search/rerank/ranking_regression_test.go
+++ b/internal/search/rerank/ranking_regression_test.go
@@ -1,0 +1,151 @@
+package rerank
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// bagEmbed is a deterministic stub embedder for the ranking regression
+// tests: it maps text to a sparse bag-of-words vector over a fixed
+// vocabulary, so cosine similarity reflects shared word tokens without
+// depending on the baked GloVe data. Case-folded, split on non-letters.
+func bagEmbed(vocab []string) func(string) []float32 {
+	idx := make(map[string]int, len(vocab))
+	for i, w := range vocab {
+		idx[w] = i
+	}
+	return func(text string) []float32 {
+		v := make([]float32, len(vocab))
+		for _, tok := range strings.FieldsFunc(strings.ToLower(text), func(r rune) bool {
+			return !(r >= 'a' && r <= 'z')
+		}) {
+			if i, ok := idx[tok]; ok {
+				v[i] += 1
+			}
+		}
+		// normalise
+		var n float64
+		for _, x := range v {
+			n += float64(x) * float64(x)
+		}
+		if n == 0 {
+			return v
+		}
+		n = math.Sqrt(n)
+		for i := range v {
+			v[i] /= float32(n)
+		}
+		return v
+	}
+}
+
+func TestSemanticCosineSignal_RewardsSharedVocabulary(t *testing.T) {
+	vocab := []string{"decode", "bson", "body", "request", "json", "render", "html"}
+	embed := bagEmbed(vocab)
+	ctx := &Context{EmbedText: embed, QueryVec: embed("decode bson request body")}
+
+	related := &Candidate{Node: &graph.Node{Name: "BindBody", QualName: "bsonBinding.BindBody", FilePath: "binding/bson.go"}}
+	unrelated := &Candidate{Node: &graph.Node{Name: "RenderHTML", QualName: "htmlRender.RenderHTML", FilePath: "render/html.go"}}
+
+	sig := SemanticCosineSignal{}
+	rs := sig.Contribute("", related, ctx)
+	us := sig.Contribute("", unrelated, ctx)
+	if rs <= us {
+		t.Fatalf("expected the bson-body candidate to out-score the html candidate: related=%.3f unrelated=%.3f", rs, us)
+	}
+	if rs <= 0 {
+		t.Fatalf("expected a positive semantic score for the shared-vocabulary candidate, got %.3f", rs)
+	}
+}
+
+func TestSemanticCosineSignal_ZeroWithoutEmbedder(t *testing.T) {
+	c := &Candidate{Node: &graph.Node{Name: "BindBody", FilePath: "binding/bson.go"}}
+	if got := (SemanticCosineSignal{}).Contribute("", c, &Context{}); got != 0 {
+		t.Fatalf("no embedder wired should contribute 0, got %.3f", got)
+	}
+}
+
+func TestSupportFileDemotion_ConceptOnly(t *testing.T) {
+	testCand := &Candidate{Node: &graph.Node{Name: "encode", FilePath: "tests/test_content.py"}}
+	implCand := &Candidate{Node: &graph.Node{Name: "encode", FilePath: "httpx/_content.py"}}
+
+	concept := &Context{QueryClass: QueryClassConcept}
+	if d := supportFileDemotion(testCand, concept); d >= 1.0 {
+		t.Fatalf("a test file on a concept query must be demoted (<1), got %.3f", d)
+	}
+	if d := supportFileDemotion(implCand, concept); d != 1.0 {
+		t.Fatalf("a non-test file must not be demoted, got %.3f", d)
+	}
+	// An identifier query leaves the exact-token ordering untouched.
+	symbol := &Context{QueryClass: QueryClassSymbol}
+	if d := supportFileDemotion(testCand, symbol); d != 1.0 {
+		t.Fatalf("a symbol query must not demote a test file, got %.3f", d)
+	}
+}
+
+func TestSupportFileDemotion_CannotLowerNonTest(t *testing.T) {
+	// The invariant the feature relies on: only test scores drop, so a
+	// non-test candidate's demotion factor is always exactly 1.0.
+	for _, fp := range []string{"httpx/_content.py", "binding/bson.go", "internal/auth/token.go"} {
+		c := &Candidate{Node: &graph.Node{Name: "x", FilePath: fp}}
+		if d := supportFileDemotion(c, &Context{QueryClass: QueryClassConcept}); d != 1.0 {
+			t.Fatalf("non-test %q must keep factor 1.0, got %.3f", fp, d)
+		}
+	}
+}
+
+func TestOverloadProminence_FiresOnlyOnCollision(t *testing.T) {
+	sig := OverloadProminenceSignal{}
+	unique := &Candidate{Node: &graph.Node{Name: "SoleName", Kind: graph.KindMethod, FilePath: "a.go", Language: "go"}}
+	ctx := &Context{QueryClass: QueryClassSymbol, nameGroupCount: map[string]int{"solename": 1}}
+	if got := sig.Contribute("", unique, ctx); got != 0 {
+		t.Fatalf("a non-colliding name must contribute 0, got %.3f", got)
+	}
+
+	// A concept query never fires the overload signal — it must not
+	// fight the semantic channel.
+	ctxConcept := &Context{QueryClass: QueryClassConcept, nameGroupCount: map[string]int{"decode": 2}}
+	collide := &Candidate{Node: &graph.Node{Name: "Decode", Kind: graph.KindMethod, FilePath: "codec/x.go", Language: "go"}}
+	if got := sig.Contribute("", collide, ctxConcept); got != 0 {
+		t.Fatalf("a concept query must not fire the overload signal, got %.3f", got)
+	}
+
+	// Two same-named candidates on an identifier query: the exported,
+	// non-test method beats the test-file one.
+	ctx2 := &Context{QueryClass: QueryClassSymbol, nameGroupCount: map[string]int{"decode": 2}}
+	exported := &Candidate{Node: &graph.Node{Name: "Decode", Kind: graph.KindMethod, FilePath: "codec/x.go", Language: "go"}}
+	private := &Candidate{Node: &graph.Node{Name: "Decode", Kind: graph.KindMethod, FilePath: "codec/x_test.go", Language: "go"}}
+	if sig.Contribute("", exported, ctx2) <= sig.Contribute("", private, ctx2) {
+		t.Fatalf("exported non-test overload must out-score the test-file overload")
+	}
+}
+
+// TestPipeline_SemanticLiftsConceptTarget locks in the end-to-end
+// behaviour: with the semantic channel wired, a concept query lifts the
+// semantically-related candidate above a lexically-adjacent but unrelated
+// one that BM25 alone ranked higher.
+func TestPipeline_SemanticLiftsConceptTarget(t *testing.T) {
+	vocab := []string{"decode", "bson", "body", "request", "render", "html", "list"}
+	embed := bagEmbed(vocab)
+	p := NewDefault()
+
+	// The unrelated candidate leads on BM25 (rank 0); the real target is
+	// rank 3 but semantically matches the query.
+	unrelated := &Candidate{Node: &graph.Node{ID: "u", Name: "BodyList", FilePath: "list/body.go"}, TextRank: 0, VectorRank: -1}
+	target := &Candidate{Node: &graph.Node{ID: "t", Name: "BindBody", QualName: "bsonBinding.BindBody", FilePath: "binding/bson.go"}, TextRank: 3, VectorRank: -1}
+	cands := []*Candidate{unrelated, target}
+
+	ctx := &Context{
+		QueryClass: QueryClassConcept,
+		EmbedText:  embed,
+		QueryVec:   embed("decode bson request body"),
+	}
+	out := p.Rerank("decode bson request body", cands, ctx)
+	if out[0].Node.ID != "t" {
+		t.Fatalf("expected the semantically-matching target to rank first, got %q (scores t=%.3f u=%.3f)",
+			out[0].Node.ID, target.Score, unrelated.Score)
+	}
+}

--- a/internal/search/rerank/signals_overload.go
+++ b/internal/search/rerank/signals_overload.go
@@ -1,0 +1,101 @@
+package rerank
+
+import (
+	"unicode"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// OverloadProminenceSignal breaks ties among same-named candidates. When
+// a query is ambiguous — several distinct symbols answer to one
+// identifier (Go interface methods like BindBody across every binding,
+// or a `decode` on each decoder class) — no ranker can know which
+// overload the caller meant, but the likelier ones can be floated toward
+// the top-5 by intrinsic prominence: an exported, non-test, callable
+// definition is a better default answer than an unexported field or a
+// test helper of the same name.
+//
+// The signal fires ONLY on a genuine same-name collision in the current
+// batch (nameGroupCount > 1); a candidate whose name is unique
+// contributes 0, so a non-ambiguous query is never perturbed. Every
+// input — exported shape, test path, node kind — is an AST-tier fact
+// available at index time with no enrichment, so the ordering is
+// identical whether or not semantic enrichment has run.
+type OverloadProminenceSignal struct{}
+
+func (OverloadProminenceSignal) Name() string { return SignalOverload }
+
+func (OverloadProminenceSignal) Contribute(_ string, c *Candidate, ctx *Context) float64 {
+	if c == nil || c.Node == nil || ctx == nil {
+		return 0
+	}
+	// Fire only on an identifier query — an exact-name lookup where
+	// overload disambiguation is the whole problem. On a concept query
+	// the batch's incidental same-name pairs are noise, and a blanket
+	// prominence boost there would fight the semantic channel that is
+	// doing the real work; scoping to the symbol class keeps the two
+	// out of each other's way.
+	if ctx.QueryClass != QueryClassSymbol {
+		return 0
+	}
+	nm := lowerName(c.Node.Name)
+	if nm == "" || ctx.nameGroupCount[nm] <= 1 {
+		return 0
+	}
+	var s float64
+	if isLikelyExported(c.Node) {
+		s += 0.5
+	}
+	if !isTestPath(c.Node.FilePath) {
+		s += 0.3
+	}
+	switch c.Node.Kind {
+	case graph.KindFunction, graph.KindMethod, graph.KindType, graph.KindInterface:
+		s += 0.2
+	}
+	if s > 1 {
+		s = 1
+	}
+	return s
+}
+
+// lowerName lowercases a symbol name without pulling in strings for a
+// one-liner on the hot path. ASCII-fast, rune-correct for the rest.
+func lowerName(s string) string {
+	hasUpper := false
+	for _, r := range s {
+		if r >= 'A' && r <= 'Z' || unicode.IsUpper(r) {
+			hasUpper = true
+			break
+		}
+	}
+	if !hasUpper {
+		return s
+	}
+	out := make([]rune, 0, len(s))
+	for _, r := range s {
+		out = append(out, unicode.ToLower(r))
+	}
+	return string(out)
+}
+
+// isLikelyExported reports whether a symbol is part of its module's
+// public surface, using only the name shape and language — no
+// enrichment. A leading underscore marks a private member in Python / JS
+// conventions; Go (and the other case-visibility languages) key
+// export on an uppercase initial; everything else is treated as public
+// unless underscore-prefixed.
+func isLikelyExported(n *graph.Node) bool {
+	if n == nil || n.Name == "" {
+		return false
+	}
+	first := []rune(n.Name)[0]
+	if first == '_' {
+		return false
+	}
+	switch n.Language {
+	case "go", "java", "kotlin", "scala", "csharp":
+		return unicode.IsUpper(first)
+	}
+	return true
+}

--- a/internal/search/rerank/signals_overload.go
+++ b/internal/search/rerank/signals_overload.go
@@ -25,31 +25,50 @@ type OverloadProminenceSignal struct{}
 
 func (OverloadProminenceSignal) Name() string { return SignalOverload }
 
-func (OverloadProminenceSignal) Contribute(_ string, c *Candidate, ctx *Context) float64 {
+func (OverloadProminenceSignal) Contribute(query string, c *Candidate, ctx *Context) float64 {
 	if c == nil || c.Node == nil || ctx == nil {
 		return 0
 	}
-	// Fire only on an identifier query — an exact-name lookup where
-	// overload disambiguation is the whole problem. On a concept query
-	// the batch's incidental same-name pairs are noise, and a blanket
-	// prominence boost there would fight the semantic channel that is
-	// doing the real work; scoping to the symbol class keeps the two
-	// out of each other's way.
-	if ctx.QueryClass != QueryClassSymbol {
-		return 0
-	}
 	nm := lowerName(c.Node.Name)
-	if nm == "" || ctx.nameGroupCount[nm] <= 1 {
+	if nm == "" {
 		return 0
 	}
+	// Identifier query: fire only on a genuine same-name collision —
+	// an exact-name lookup where overload disambiguation is the whole
+	// problem. On any other class the batch's incidental same-name
+	// pairs are noise, and a blanket prominence boost would fight the
+	// semantic channel that is doing the real work.
+	if ctx.QueryClass == QueryClassSymbol {
+		if ctx.nameGroupCount[nm] <= 1 {
+			return 0
+		}
+		return prominenceScore(c.Node)
+	}
+	// Degraded-identifier profile: a multi-word query whose tokens
+	// concatenate to exactly this candidate's name is a case-split
+	// identifier lookup ("should bind body with" → ShouldBindBodyWith),
+	// not a concept query, for THIS candidate. Longer same-stem
+	// variants (ShouldBindBodyWithJSON) share every query token and can
+	// out-BM25 the exact match; the exact-match floor puts the queried
+	// identifier back on top, with prominence breaking ties among
+	// several exact matches (the overload group).
+	if exactDegradedNameMatch(query, nm) {
+		return 0.55 + 0.45*prominenceScore(c.Node)
+	}
+	return 0
+}
+
+// prominenceScore rates a symbol's intrinsic answer-worthiness in
+// [0, 1] from AST-tier facts only.
+func prominenceScore(n *graph.Node) float64 {
 	var s float64
-	if isLikelyExported(c.Node) {
+	if isLikelyExported(n) {
 		s += 0.5
 	}
-	if !isTestPath(c.Node.FilePath) {
+	if !isTestPath(n.FilePath) {
 		s += 0.3
 	}
-	switch c.Node.Kind {
+	switch n.Kind {
 	case graph.KindFunction, graph.KindMethod, graph.KindType, graph.KindInterface:
 		s += 0.2
 	}
@@ -57,6 +76,50 @@ func (OverloadProminenceSignal) Contribute(_ string, c *Candidate, ctx *Context)
 		s = 1
 	}
 	return s
+}
+
+// exactDegradedNameMatch reports whether a multi-word query's tokens
+// concatenate to exactly the (already-lowercased) candidate name,
+// comparing alphanumeric runes only so snake_case names match their
+// space-split degraded form too. Single-token queries return false —
+// they are the symbol class's territory.
+func exactDegradedNameMatch(query, lowerNodeName string) bool {
+	qa := alnumFold(query, true)
+	if qa == "" {
+		return false
+	}
+	return qa == alnumFold(lowerNodeName, false)
+}
+
+// alnumFold lowercases and strips every non-alphanumeric rune. When
+// requireMultiToken is set it returns "" unless the input had 2+
+// whitespace-separated tokens (the degraded-identifier shape).
+func alnumFold(s string, requireMultiToken bool) string {
+	var b []rune
+	tokens := 0
+	inTok := false
+	for _, r := range s {
+		if unicode.IsSpace(r) {
+			inTok = false
+			continue
+		}
+		if !inTok {
+			tokens++
+			inTok = true
+		}
+		switch {
+		case r >= 'a' && r <= 'z' || r >= '0' && r <= '9':
+			b = append(b, r)
+		case r >= 'A' && r <= 'Z':
+			b = append(b, unicode.ToLower(r))
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			b = append(b, unicode.ToLower(r))
+		}
+	}
+	if requireMultiToken && tokens < 2 {
+		return ""
+	}
+	return string(b)
 }
 
 // lowerName lowercases a symbol name without pulling in strings for a

--- a/internal/search/rerank/signals_path_penalty.go
+++ b/internal/search/rerank/signals_path_penalty.go
@@ -230,7 +230,7 @@ func supportFileDemotion(c *Candidate, ctx *Context) float64 {
 		}
 	}
 	fp := c.Node.FilePath
-	pen := PathPenaltyUncatched
+	var pen float64
 	if ctx != nil && ctx.pathPenaltyCache != nil {
 		if cached, ok := ctx.pathPenaltyCache[fp]; ok {
 			pen = cached

--- a/internal/search/rerank/signals_path_penalty.go
+++ b/internal/search/rerank/signals_path_penalty.go
@@ -197,6 +197,55 @@ var (
 	}
 )
 
+// supportDemoteTest is the multiplicative factor applied to a test-file
+// candidate's final rerank score. The additive PathPenaltySignal is only
+// a gentle tie-breaker (~0.12 score points); it cannot demote a test
+// file that out-BM25s the real implementation on shared vocabulary —
+// common for intent queries, where a test name echoes the feature it
+// exercises ("test_urlencoded_data" for "urlencode form body payload").
+// Multiplying the whole score reliably pushes such a test below the
+// implementation. Only test files are demoted this hard; the lighter
+// supporting-cast buckets keep the gentle additive signal.
+const supportDemoteTest = 0.5
+
+// supportFileDemotion returns the multiplicative score factor for a
+// candidate's file — supportDemoteTest for a test file, 1.0 otherwise.
+// It reuses the per-Rerank path-penalty cache the additive signal
+// already populated, falling back to the classifier only when the cache
+// is cold, so the regex rubric runs at most once per file per Rerank.
+func supportFileDemotion(c *Candidate, ctx *Context) float64 {
+	if c == nil || c.Node == nil || c.Node.FilePath == "" {
+		return 1.0
+	}
+	// Only concept / degraded-identifier queries are demoted. An
+	// identifier, path, or signature query carries an exact-token match
+	// that already puts the right symbol on top; perturbing that order
+	// to demote a test can only cost a name-level hit, and a user who
+	// types a literal test name wants the test. Test pollution is a
+	// natural-language-intent problem, so the demotion is scoped to it.
+	if ctx != nil {
+		switch ctx.QueryClass {
+		case QueryClassSymbol, QueryClassPath, QueryClassSignature:
+			return 1.0
+		}
+	}
+	fp := c.Node.FilePath
+	pen := PathPenaltyUncatched
+	if ctx != nil && ctx.pathPenaltyCache != nil {
+		if cached, ok := ctx.pathPenaltyCache[fp]; ok {
+			pen = cached
+		} else {
+			pen = classifyPathPenalty(fp)
+		}
+	} else {
+		pen = classifyPathPenalty(fp)
+	}
+	if pen == PathPenaltyTest {
+		return supportDemoteTest
+	}
+	return 1.0
+}
+
 // classifyPathPenalty applies the rubric in priority order — most
 // aggressive penalty wins on overlap. Exported indirectly via the
 // signal so tests can pin specific paths.

--- a/internal/search/rerank/signals_semantic_cosine.go
+++ b/internal/search/rerank/signals_semantic_cosine.go
@@ -1,0 +1,140 @@
+package rerank
+
+import (
+	"math"
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// SemanticCosineSignal scores a candidate by the cosine similarity
+// between the query embedding (Context.QueryVec) and an on-the-fly
+// embedding of a compact text assembled from the candidate node —
+// name, qualified name, file path, and (when present) signature and
+// doc head. Unlike SemanticSignal, which reads a rank from a full
+// vector-index channel, this signal needs no ANN index and no
+// index-time vector build: it re-embeds only the BM25 top-N candidates
+// the reranker already holds, with the always-available in-process
+// static word-vector provider the MCP server wires into
+// Context.EmbedText.
+//
+// It is the intent-query (natural-language "T3") weapon: BM25 alone
+// cannot connect "decode bson request body" to BindBody in
+// binding/bson.go, but the averaged word vectors put "bson"/"body" near
+// the candidate's path + name tokens, so a target sitting at BM25 rank
+// 8-20 is lifted into the top-5. The per-class weight table damps it on
+// identifier/path queries (where exact tokens are the reliable signal)
+// and gives it full weight on concept queries.
+type SemanticCosineSignal struct{}
+
+func (SemanticCosineSignal) Name() string { return SignalSemanticCosine }
+
+func (SemanticCosineSignal) Contribute(_ string, c *Candidate, ctx *Context) float64 {
+	if ctx.EmbedText == nil || len(ctx.QueryVec) == 0 || c == nil || c.Node == nil {
+		return 0
+	}
+	text := candidateEmbedText(c.Node)
+	if text == "" {
+		return 0
+	}
+	vec := ctx.EmbedText(text)
+	if len(vec) != len(ctx.QueryVec) {
+		return 0
+	}
+	sim := cosineSim(ctx.QueryVec, vec)
+	if sim <= 0 {
+		return 0
+	}
+	if sim > 1 {
+		sim = 1
+	}
+	return sim
+}
+
+// maxSemanticFieldRunes caps how much of a single free-text field
+// (signature, doc head) feeds the candidate embedding. Averaged word
+// vectors dilute as the token count grows, and a very long body would
+// also trip the vector index's >512-token reliability limit, so each
+// field is truncated to a short, high-signal head.
+const maxSemanticFieldRunes = 200
+
+// candidateEmbedText assembles the compact text embedded for a
+// candidate. Order is deliberate — the highest-signal identifiers
+// (name, receiver/package via QualName, path tokens) come first, then
+// the structural signature and a doc head when the extractor stamped
+// one. The shared embedding tokenizer splits camelCase / snake_case and
+// path separators, so raw fields can be concatenated verbatim.
+func candidateEmbedText(n *graph.Node) string {
+	parts := make([]string, 0, 5)
+	if n.Name != "" {
+		parts = append(parts, n.Name)
+	}
+	if n.QualName != "" && n.QualName != n.Name {
+		parts = append(parts, n.QualName)
+	}
+	if n.FilePath != "" {
+		parts = append(parts, n.FilePath)
+	}
+	if n.Meta != nil {
+		if sig, ok := n.Meta["signature"].(string); ok && sig != "" {
+			parts = append(parts, truncateRunes(sig, maxSemanticFieldRunes))
+		}
+		if d := metaDocHead(n.Meta); d != "" {
+			parts = append(parts, truncateRunes(d, maxSemanticFieldRunes))
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+// metaDocHead extracts a short leading doc/comment string from a node's
+// Meta under any of the keys extractors use, returning "" when none is
+// present. Only a leading fragment is taken — the embedding averages
+// word vectors, so the first sentence carries the topic and the rest
+// only dilutes.
+func metaDocHead(meta map[string]any) string {
+	for _, k := range []string{"doc", "docstring", "comment", "summary"} {
+		if v, ok := meta[k].(string); ok {
+			if s := strings.TrimSpace(v); s != "" {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+// truncateRunes returns the first max runes of s (rune-safe), or s when
+// it is already shorter.
+func truncateRunes(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	n := 0
+	for i := range s {
+		if n == max {
+			return s[:i]
+		}
+		n++
+	}
+	return s
+}
+
+// cosineSim returns the cosine of the angle between a and b in [-1, 1].
+// The provider normalises its vectors, so the denominator is ~1, but
+// the full form is computed defensively (a zero vector or a caller-
+// supplied unnormalised vector both yield a safe 0).
+func cosineSim(a, b []float32) float64 {
+	if len(a) != len(b) {
+		return 0
+	}
+	var dot, na, nb float64
+	for i := range a {
+		av, bv := float64(a[i]), float64(b[i])
+		dot += av * bv
+		na += av * av
+		nb += bv * bv
+	}
+	if na == 0 || nb == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(na) * math.Sqrt(nb))
+}


### PR DESCRIPTION
## What

symbol discovery ranking gets four new signals and a semantic channel, measured end-to-end against the benchmark's frozen agent-style query corpus (N=3 medians, default config):

| | gin hit@5 | httpx hit@5 | gin T3 file-hit | httpx T3 file-hit |
|---|---:|---:|---:|---:|
| before | 62.0% | 70.3% | 70% | 81% |
| **after** | **76.7%** | **78.0%** | **94%** | **89%** |

- **Semantic-cosine rerank channel**: BM25's top candidates are re-scored in-process by a static code-embedding model (\`minishlab/potion-code-16M-v2\`, MIT, 32.5 MB, 256-dim Model2Vec) — pure-Go safetensors reader + WordPiece tokenizer (golden-tested to exact token-ID parity with upstream), no ONNX, sub-millisecond for the whole rerank. Model resolution: \`GORTEX_POTION_DIR\` → exec-dir sidecar (what releases bake; fully offline) → \`~/.gortex/models\` → SHA256-pinned first-use download (\`GORTEX_POTION_DOWNLOAD=0\` to disable; never fires in tests). Falls back to the embedded baseline vectors so no environment loses the channel.
- **Enrichment-free rank features**: the ranker no longer depends on enrichment-era edge density (the source of a measured 3.3pp drift between eager and lazy modes — now ~0 delta): fan-in, kind, exported, and test-file signals read AST-tier facts identical in both modes.
- **Bounded per-file diversification** on intent queries (demote only when the file already holds ≥2 higher-ranked hits) — takes the measured big-file-crowding losses without evicting target symbols; the full frontier (bound × strength) is documented in the tuning notes.
- **Per-query-class blend profiles** (identifier / degraded / concept) — signals are gated per class after measurement showed a global blend forces losing trade-offs.
- **Overload-aware ordering** for same-name symbols (fan-in, non-test, exported), gated to identifier queries.

Tuning honesty: the blend weight and diversification bound were tuned with one query tier per repo held out; held-out scores tracked selection monotonically. A regression net (golden ranking tests + eval hooks) locks the new signals.

## Cost / safety

Search p50 61ms gin / 47ms httpx (budget 150ms); response tokens +6.6–7.2% (within the 10% ceiling); find_usages output byte-stable across all fence symbols (ranking changes are confined to the search path); \`go test -race\` green on all touched packages (rerank+embedding 235, mcp 2621, query+search 217); lint clean.