### PR TITLE
fix: case-insensitive tracked-repo path identity on macOS and Windows

### DIFF
--- a/cmd/gortex/cli_daemon.go
+++ b/cmd/gortex/cli_daemon.go
@@ -6,9 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/zzet/gortex/internal/daemon"
+	"github.com/zzet/gortex/internal/pathkey"
 )
 
 // ErrNoExecutor signals that no warm daemon owns the repo and no explicit
@@ -158,7 +158,7 @@ func daemonOwnsRepo(abs string) bool {
 		if repo.Path == "" {
 			continue
 		}
-		if abs == repo.Path || strings.HasPrefix(abs, repo.Path+string(filepath.Separator)) {
+		if pathkey.HasPathPrefix(abs, repo.Path) {
 			return true
 		}
 	}

--- a/cmd/gortex/daemon_controller.go
+++ b/cmd/gortex/daemon_controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/zzet/gortex/internal/daemon"
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/pathkey"
 	"github.com/zzet/gortex/internal/releases"
 	"github.com/zzet/gortex/internal/search"
 	"github.com/zzet/gortex/internal/semantic"
@@ -396,10 +397,17 @@ func (c *realController) Untrack(_ context.Context, p daemon.UntrackParams) (jso
 	}
 
 	prefix := p.PathOrPrefix
-	// Resolve path → prefix if an absolute or relative path was given.
+	// Resolve path → prefix if an absolute path was given. Absolutise (to
+	// Clean) and compare with fold-aware EqualPaths so a case-variant
+	// spelling of a tracked root on a case-insensitive filesystem still
+	// resolves to the right prefix.
 	if filepath.IsAbs(p.PathOrPrefix) {
+		abs, err := filepath.Abs(p.PathOrPrefix)
+		if err != nil {
+			abs = p.PathOrPrefix
+		}
 		for pfx, meta := range c.multiIndexer.AllMetadata() {
-			if meta.RootPath == p.PathOrPrefix {
+			if pathkey.EqualPaths(meta.RootPath, abs) {
 				prefix = pfx
 				break
 			}

--- a/cmd/gortex/daemon_heal_repos_test.go
+++ b/cmd/gortex/daemon_heal_repos_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+)
+
+func TestHealDuplicateRepos_DropsCaseVariantAndPersists(t *testing.T) {
+	forceCaseInsensitivePaths(t, true)
+
+	base := t.TempDir()
+	upper := filepath.Join(base, "MyRepo")
+	lower := filepath.Join(base, "myrepo")
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	gc := &config.GlobalConfig{Repos: []config.RepoEntry{
+		{Path: upper, Name: "first"},
+		{Path: lower, Name: "dup"},
+	}}
+	gc.SetConfigPath(cfgPath)
+	require.NoError(t, gc.Save())
+
+	removed := healDuplicateRepos(gc, zap.NewNop())
+	assert.Equal(t, 1, removed)
+	require.Len(t, gc.Repos, 1)
+	assert.Equal(t, upper, gc.Repos[0].Path, "first (oldest) spelling must survive")
+
+	// Persisted: reloading the config yields the single healed entry.
+	reloaded, err := config.LoadGlobal(cfgPath)
+	require.NoError(t, err)
+	require.Len(t, reloaded.Repos, 1)
+	assert.Equal(t, upper, reloaded.Repos[0].Path)
+}
+
+func TestHealDuplicateRepos_NoDuplicatesNoOp(t *testing.T) {
+	forceCaseInsensitivePaths(t, true)
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	gc := &config.GlobalConfig{Repos: []config.RepoEntry{
+		{Path: filepath.Join(t.TempDir(), "a")},
+		{Path: filepath.Join(t.TempDir(), "b")},
+	}}
+	gc.SetConfigPath(cfgPath)
+	require.NoError(t, gc.Save())
+
+	assert.Equal(t, 0, healDuplicateRepos(gc, zap.NewNop()))
+	assert.Len(t, gc.Repos, 2)
+}
+
+func TestHealDuplicateRepos_NilConfig(t *testing.T) {
+	assert.Equal(t, 0, healDuplicateRepos(nil, zap.NewNop()))
+}

--- a/cmd/gortex/daemon_mcp.go
+++ b/cmd/gortex/daemon_mcp.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"path/filepath"
-	"strings"
+	"sort"
+	"sync"
 	"sync/atomic"
 
 	"go.uber.org/zap"
@@ -13,6 +13,7 @@ import (
 	"github.com/zzet/gortex/internal/daemon"
 	"github.com/zzet/gortex/internal/indexer"
 	gortexmcp "github.com/zzet/gortex/internal/mcp"
+	"github.com/zzet/gortex/internal/pathkey"
 )
 
 // mcpDispatcher routes MCP JSON-RPC frames from daemon sessions to the
@@ -34,6 +35,10 @@ type mcpDispatcher struct {
 	// decision is the shared peek→route→outcome helper; it reads the
 	// router through the atomic accessor so a live swap is reflected.
 	decision *daemon.ProxyDecision
+	// loggedUntracked records session IDs for which the "cwd not covered"
+	// diagnostic has already been emitted, so it fires once per session
+	// rather than on every frame. Cleared in SessionEnded.
+	loggedUntracked sync.Map
 }
 
 func newMCPDispatcher(srv *gortexmcp.Server, mi *indexer.MultiIndexer, logger *zap.Logger) *mcpDispatcher {
@@ -87,6 +92,9 @@ func (d *mcpDispatcher) Dispatch(ctx context.Context, sess *daemon.Session, fram
 	// connection-poisoning errored initialize. Only tools/call is refused (with
 	// the structured not-tracked error the agent can act on).
 	untracked := sess.CWD != "" && !d.cwdReachable(sess.CWD)
+	if untracked {
+		d.logUncoveredCWDOnce(sess)
+	}
 	if untracked && peekFrameMethod(frame) == "tools/call" {
 		return d.notTrackedError(sess, frame), nil
 	}
@@ -160,7 +168,7 @@ func (d *mcpDispatcher) Dispatch(ctx context.Context, sess *daemon.Session, fram
 	// response into its inactive variant: the agent gets the actionable
 	// "run gortex track" instructions and an empty track-only tool list.
 	if untracked {
-		out = rewriteUntrackedResponse(peekFrameMethod(frame), out, sess.CWD)
+		out = rewriteUntrackedResponse(peekFrameMethod(frame), out, sess.CWD, d.trackedRoots())
 	}
 	return out, nil
 }
@@ -197,7 +205,7 @@ func peekFrameToolName(frame []byte) string {
 // so the handshake completes gracefully instead of erroring. Non-initialize /
 // non-tools/list frames, error responses, and unparseable bodies pass through
 // unchanged.
-func rewriteUntrackedResponse(method string, out []byte, cwd string) []byte {
+func rewriteUntrackedResponse(method string, out []byte, cwd string, roots []string) []byte {
 	if len(out) == 0 {
 		return out
 	}
@@ -211,7 +219,7 @@ func rewriteUntrackedResponse(method string, out []byte, cwd string) []byte {
 	}
 	switch method {
 	case "initialize":
-		result["instructions"] = gortexmcp.ServerInstructionsUntracked(cwd)
+		result["instructions"] = gortexmcp.ServerInstructionsUntracked(cwd, roots...)
 	case "tools/list":
 		result["tools"] = []any{}
 	default:
@@ -228,9 +236,13 @@ func rewriteUntrackedResponse(method string, out []byte, cwd string) []byte {
 // disconnects, drop its entry from the MCP server's session map so idle
 // per-session state doesn't accumulate for the daemon's lifetime.
 func (d *mcpDispatcher) SessionEnded(sess *daemon.Session) {
-	if d.srv != nil && sess != nil {
+	if sess == nil {
+		return
+	}
+	if d.srv != nil {
 		d.srv.ReleaseSession(sess.ID)
 	}
+	d.loggedUntracked.Delete(sess.ID)
 }
 
 // cwdReachable reports whether a session cwd has any chance of
@@ -285,17 +297,52 @@ func (d *mcpDispatcher) isCWDTracked(cwd string) bool {
 	if d.multiIndexer == nil {
 		return true
 	}
-	cwd = filepath.Clean(cwd)
+	// Fold-aware containment: on a case-insensitive filesystem (macOS,
+	// Windows) the cwd the editor hands us can differ from the stored
+	// root only in letter case or drive-letter case (e.g. VS Code's
+	// `c:\repo` vs the config's `C:\repo`). A byte compare would reject
+	// it and publish zero tools; HasPathPrefix folds both first (#277).
 	for _, meta := range d.multiIndexer.AllMetadata() {
-		root := filepath.Clean(meta.RootPath)
-		if cwd == root {
-			return true
-		}
-		if strings.HasPrefix(cwd, root+string(filepath.Separator)) {
+		if pathkey.HasPathPrefix(cwd, meta.RootPath) {
 			return true
 		}
 	}
 	return false
+}
+
+// logUncoveredCWDOnce emits, at most once per session, a diagnostic that
+// names the session cwd and every tracked repo root — so an operator
+// looking at an INACTIVE session (zero tools published) can immediately
+// see the cwd the daemon was handed and the roots it was compared
+// against. The mismatch is most often a path-case or drive-letter
+// difference (#277).
+func (d *mcpDispatcher) logUncoveredCWDOnce(sess *daemon.Session) {
+	if sess == nil || sess.ID == "" {
+		return
+	}
+	if _, loaded := d.loggedUntracked.LoadOrStore(sess.ID, struct{}{}); loaded {
+		return
+	}
+	d.logger.Info("mcp session cwd is not covered by any tracked repo",
+		zap.String("session_id", sess.ID),
+		zap.String("cwd", sess.CWD),
+		zap.Strings("tracked_roots", d.trackedRoots()))
+}
+
+// trackedRoots returns the sorted absolute root of every locally tracked
+// repo, for the INACTIVE diagnostics.
+func (d *mcpDispatcher) trackedRoots() []string {
+	if d.multiIndexer == nil {
+		return nil
+	}
+	var roots []string
+	for _, meta := range d.multiIndexer.AllMetadata() {
+		if meta != nil && meta.RootPath != "" {
+			roots = append(roots, meta.RootPath)
+		}
+	}
+	sort.Strings(roots)
+	return roots
 }
 
 // tryProxyToolCall inspects a JSON-RPC frame and, if it's a

--- a/cmd/gortex/daemon_mcp_case_identity_test.go
+++ b/cmd/gortex/daemon_mcp_case_identity_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/daemon"
+	"github.com/zzet/gortex/internal/pathkey"
+)
+
+// forceCaseInsensitivePaths flips the process-global
+// pathkey.CaseInsensitivePaths for the test and restores it afterwards.
+// Tests using it must not run in parallel.
+func forceCaseInsensitivePaths(t *testing.T, v bool) {
+	t.Helper()
+	prev := pathkey.CaseInsensitivePaths
+	pathkey.CaseInsensitivePaths = v
+	t.Cleanup(func() { pathkey.CaseInsensitivePaths = prev })
+}
+
+// toggleBaseCase returns p with the case of every ASCII letter inverted,
+// so it names the same directory on a case-insensitive filesystem while
+// differing byte-wise. Toggling the whole path (not just the final
+// component) guarantees a byte difference even when the final component is
+// all digits, as t.TempDir's "001" suffix is.
+func toggleBaseCase(p string) string {
+	b := []byte(p)
+	for i := range b {
+		switch {
+		case b[i] >= 'a' && b[i] <= 'z':
+			b[i] -= 32
+		case b[i] >= 'A' && b[i] <= 'Z':
+			b[i] += 32
+		}
+	}
+	return string(b)
+}
+
+// A case-variant cwd of a tracked root must be recognised as tracked on a
+// case-insensitive filesystem. This is the #277 Windows / macOS 0-tools
+// fix at the MCP dispatcher boundary (isCWDTracked is pure folding, no
+// stat, so it is deterministic on every platform once folding is forced).
+func TestDispatcher_CaseMismatchedCWD_Tracked(t *testing.T) {
+	forceCaseInsensitivePaths(t, true)
+	tracked := t.TempDir()
+	d, _ := trackedPathMCPSetup(t, tracked)
+
+	variant := toggleBaseCase(tracked)
+	require.NotEqual(t, tracked, variant, "temp dir base must contain letters to toggle")
+	assert.True(t, d.isCWDTracked(variant),
+		"case-variant of tracked root must be recognised as tracked")
+	assert.True(t, d.isCWDTracked(filepath.Join(variant, "internal", "auth")),
+		"case-variant subdirectory must be recognised as tracked")
+}
+
+// With case-sensitive comparison forced, a byte-different variant must be
+// rejected — the fold must not over-merge on genuinely case-sensitive
+// volumes.
+func TestDispatcher_CaseSensitiveCWD_RejectsVariant(t *testing.T) {
+	forceCaseInsensitivePaths(t, false)
+	tracked := t.TempDir()
+	d, _ := trackedPathMCPSetup(t, tracked)
+
+	variant := toggleBaseCase(tracked)
+	require.NotEqual(t, tracked, variant)
+	assert.False(t, d.isCWDTracked(variant),
+		"case-sensitive: byte-different variant must not be recognised as tracked")
+}
+
+// The INACTIVE initialize instructions must name the tracked roots so the
+// mismatch is self-diagnosing (#277 explicit ask).
+func TestDispatcher_UntrackedInstructions_IncludeTrackedRoots(t *testing.T) {
+	tracked := t.TempDir()
+	untracked := t.TempDir()
+	d, _ := trackedPathMCPSetup(t, tracked)
+
+	sess := &daemon.Session{ID: "sess_roots", CWD: untracked}
+	frame := []byte(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`)
+	reply, err := d.Dispatch(context.Background(), sess, frame)
+	require.NoError(t, err)
+	require.NotNil(t, reply)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(reply, &parsed))
+	result, ok := parsed["result"].(map[string]any)
+	require.True(t, ok, "initialize must return a result: %v", parsed)
+	instr, ok := result["instructions"].(string)
+	require.True(t, ok, "initialize result must carry instructions")
+
+	assert.Contains(t, instr, "INACTIVE")
+	assert.Contains(t, instr, "Tracked repository roots",
+		"instructions must list tracked roots for self-diagnosis")
+	assert.Contains(t, instr, tracked,
+		"instructions must name the actual tracked root path")
+}

--- a/cmd/gortex/daemon_state.go
+++ b/cmd/gortex/daemon_state.go
@@ -20,6 +20,7 @@ import (
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/indexer"
 	gortexmcp "github.com/zzet/gortex/internal/mcp"
+	"github.com/zzet/gortex/internal/pathkey"
 	"github.com/zzet/gortex/internal/platform"
 	"github.com/zzet/gortex/internal/progress"
 	"github.com/zzet/gortex/internal/semantic/lsp"
@@ -225,6 +226,43 @@ type warmupTimings struct {
 // — so the daemon reports ready as soon as find_usages / get_callers return
 // complete results, not after enrichment finishes. The returned *warmupTimings
 // is never nil — daemon.go uses it to emit a one-line warmup summary.
+// healDuplicateRepos drops tracked-repo entries that name the same
+// directory as an earlier entry under a different path spelling — letter
+// case or Unicode normalisation on a case-insensitive filesystem — logs
+// each drop, and persists the cleaned config. Returns the number of
+// entries removed. It is the startup / load-time repair for configs that
+// accumulated a duplicate before folding was applied (#270): a duplicate
+// reaching the warmup loop would flip the daemon into multi-repo mode and
+// desync the graph. The FIRST (oldest) spelling of each directory is kept.
+func healDuplicateRepos(gc *config.GlobalConfig, logger *zap.Logger) int {
+	if gc == nil {
+		return 0
+	}
+	removed := gc.DedupeRepos()
+	if len(removed) == 0 {
+		return 0
+	}
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	for _, r := range removed {
+		kept := r.Path
+		for _, k := range gc.Repos {
+			if pathkey.SamePathIdentity(k.Path, r.Path) {
+				kept = k.Path
+				break
+			}
+		}
+		logger.Warn("dropping duplicate tracked-repo entry (same directory, different path spelling)",
+			zap.String("dropped", r.Path),
+			zap.String("kept", kept))
+	}
+	if err := gc.Save(); err != nil {
+		logger.Warn("persisting deduped repo config failed", zap.Error(err))
+	}
+	return len(removed)
+}
+
 func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func()) (*indexer.MultiWatcher, *warmupTimings) {
 	timings := &warmupTimings{}
 	if state.multiIndexer == nil || state.configManager == nil {
@@ -243,6 +281,13 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 	// per-repo passes serially before the global resolve. Without this
 	// batch wrapper, a 100+ repo warmup is O(R · global_size).
 	state.multiIndexer.BeginParallelBatch()
+
+	// Heal any duplicate tracked-repo entries that name the same directory
+	// under a different path spelling (case, or Unicode normalisation)
+	// BEFORE the warmup loop registers them. Two spellings of one directory
+	// would otherwise both reach the indexer and flip the daemon into
+	// multi-repo mode, desyncing the unprefixed graph (#270).
+	healDuplicateRepos(state.configManager.Global(), logger)
 
 	repos := state.configManager.Global().Repos
 

--- a/cmd/gortex/install.go
+++ b/cmd/gortex/install.go
@@ -14,6 +14,7 @@ import (
 	"github.com/zzet/gortex/internal/agents"
 	"github.com/zzet/gortex/internal/agents/claudecode"
 	"github.com/zzet/gortex/internal/daemon"
+	"github.com/zzet/gortex/internal/pathkey"
 	"github.com/zzet/gortex/internal/platform"
 	"github.com/zzet/gortex/internal/progress"
 	"github.com/zzet/gortex/internal/telemetry"
@@ -303,7 +304,10 @@ func runInstallFollowUps(cmd *cobra.Command) error {
 	}
 
 	if installTrackRepo {
-		abs := mustAbs(installTrackPath)
+		// Normalise the volume for this NEW tracked path so a Windows drive
+		// letter converges with os.Getwd's upper-case convention before the
+		// daemon stores it. No-op on POSIX; never touches the basename.
+		abs := pathkey.NormalizeVolume(mustAbs(installTrackPath))
 		if !daemon.IsRunning() {
 			fmt.Fprintln(w, "[gortex install] ⚠ skipping --track: daemon is not running (try `gortex daemon start`)")
 		} else {

--- a/cmd/gortex/track.go
+++ b/cmd/gortex/track.go
@@ -82,11 +82,15 @@ func runTrack(cmd *cobra.Command, args []string) error {
 	rawPath := args[0]
 	w := cmd.ErrOrStderr()
 
-	// Resolve to absolute path.
+	// Resolve to absolute path. Normalise the volume (upper-case a Windows
+	// drive letter) for this NEW entry so it converges with os.Getwd's
+	// convention — the volume is never part of a repo basename, so this is
+	// cosmetic and cannot rotate a repo prefix. No-op on POSIX.
 	absPath, err := filepath.Abs(rawPath)
 	if err != nil {
 		return fmt.Errorf("resolving path %s: %w", rawPath, err)
 	}
+	absPath = pathkey.NormalizeVolume(absPath)
 
 	// Validate path exists and is a directory.
 	info, err := os.Stat(absPath)

--- a/cmd/gortex/track.go
+++ b/cmd/gortex/track.go
@@ -13,6 +13,7 @@ import (
 	"github.com/zzet/gortex/internal/config"
 	"github.com/zzet/gortex/internal/daemon"
 	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/pathkey"
 	"github.com/zzet/gortex/internal/progress"
 	"github.com/zzet/gortex/internal/tui"
 )
@@ -108,7 +109,7 @@ func runTrack(cmd *cobra.Command, args []string) error {
 	}
 	already := false
 	for _, existing := range gc.Repos {
-		if existingAbs, _ := filepath.Abs(existing.Path); existingAbs == absPath {
+		if existingAbs, _ := filepath.Abs(existing.Path); pathkey.SamePathIdentity(existingAbs, absPath) {
 			already = true
 			break
 		}
@@ -175,7 +176,7 @@ func runTrack(cmd *cobra.Command, args []string) error {
 // daemon status, or -1 if the daemon has not registered the repo yet.
 func repoNodeCount(st daemon.StatusResponse, absPath string) int {
 	for _, r := range st.TrackedRepos {
-		if ra, err := filepath.Abs(r.Path); err == nil && ra == absPath {
+		if ra, err := filepath.Abs(r.Path); err == nil && pathkey.EqualPaths(ra, absPath) {
 			return r.Nodes
 		}
 	}
@@ -343,6 +344,14 @@ func runUntrack(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("resolving path %s: %w", rawPath, err)
 		}
 		target = abs
+	} else if info, statErr := os.Stat(rawPath); statErr == nil && info.IsDir() {
+		// A relative arg that names an existing directory (e.g. `foo/bar`
+		// from cwd) is a path, not a prefix — absolutise it so it resolves
+		// against the tracked roots. A bare prefix that names no directory
+		// keeps its as-is behaviour.
+		if abs, err := filepath.Abs(rawPath); err == nil {
+			target = abs
+		}
 	}
 
 	emitUntrackBanner(w, target, daemon.IsRunning())

--- a/cmd/gortex/track.go
+++ b/cmd/gortex/track.go
@@ -111,6 +111,9 @@ func runTrack(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("loading global config: %w", err)
 	}
+	// Heal any pre-existing duplicate case-variant entries so the track
+	// path (and the persisted config) sees a clean list (#270).
+	healDuplicateRepos(gc, nil)
 	already := false
 	for _, existing := range gc.Repos {
 		if existingAbs, _ := filepath.Abs(existing.Path); pathkey.SamePathIdentity(existingAbs, absPath) {

--- a/cmd/gortex/workspace_cmd.go
+++ b/cmd/gortex/workspace_cmd.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/pathkey"
 	"github.com/zzet/gortex/internal/progress"
 	"github.com/zzet/gortex/internal/tui"
 )
@@ -181,12 +182,12 @@ func matchRepo(repos []config.RepoEntry, target string) (int, error) {
 			return i, nil
 		}
 		ra, _ := filepath.Abs(r.Path)
-		if ra == abs {
+		if pathkey.EqualPaths(ra, abs) {
 			return i, nil
 		}
 		// Allow short suffix matches like "tuck-api" against
 		// "/Users/x/code/work/tuck-api".
-		if strings.HasSuffix(r.Path, "/"+target) {
+		if strings.HasSuffix(r.Path, string(filepath.Separator)+target) {
 			return i, nil
 		}
 	}

--- a/cmd/gortex/workspace_match_case_test.go
+++ b/cmd/gortex/workspace_match_case_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/config"
+)
+
+func TestMatchRepo_CaseVariantAbsPath(t *testing.T) {
+	forceCaseInsensitivePaths(t, true)
+	repos := []config.RepoEntry{
+		{Name: "alpha", Path: "/Users/me/Projects/Alpha"},
+		{Name: "beta", Path: "/Users/me/Projects/Beta"},
+	}
+	i, err := matchRepo(repos, "/users/me/projects/alpha")
+	require.NoError(t, err)
+	assert.Equal(t, 0, i, "case-variant abs path must resolve to the right repo")
+}
+
+func TestMatchRepo_CaseSensitiveRejectsVariant(t *testing.T) {
+	forceCaseInsensitivePaths(t, false)
+	repos := []config.RepoEntry{{Name: "alpha", Path: "/Users/me/Projects/Alpha"}}
+	_, err := matchRepo(repos, "/users/me/projects/alpha")
+	require.Error(t, err, "case-sensitive: byte-different abs path must not match")
+}
+
+func TestMatchRepo_NameMatch(t *testing.T) {
+	repos := []config.RepoEntry{{Name: "alpha", Path: "/Users/me/Projects/Alpha"}}
+	i, err := matchRepo(repos, "alpha")
+	require.NoError(t, err)
+	assert.Equal(t, 0, i)
+}
+
+func TestMatchRepo_SuffixMatch(t *testing.T) {
+	// Exercises the separator-aware suffix fallback (was a hardcoded "/").
+	repos := []config.RepoEntry{{Name: "x", Path: "/Users/x/code/work/tuck-api"}}
+	i, err := matchRepo(repos, "tuck-api")
+	require.NoError(t, err)
+	assert.Equal(t, 0, i)
+}

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/zzet/gortex/internal/llm"
+	"github.com/zzet/gortex/internal/pathkey"
 	"github.com/zzet/gortex/internal/platform"
 )
 
@@ -425,10 +426,14 @@ func (gc *GlobalConfig) AddRepo(entry RepoEntry) error {
 	}
 	entry.Path = absPath
 
-	// Check for duplicate path.
+	// Check for duplicate path. Compare on folded identity so a
+	// case-only or Unicode-normalisation variant of an already-tracked
+	// directory on a case-insensitive filesystem is recognised as the
+	// same repo. The existing entry's stored Path spelling is preserved
+	// as the identity anchor — we never append a second entry for it.
 	for _, existing := range gc.Repos {
 		existingAbs := normalizePath(existing.Path)
-		if existingAbs == absPath {
+		if pathkey.SamePathIdentity(existingAbs, absPath) {
 			return nil // already tracked, skip
 		}
 	}
@@ -447,13 +452,53 @@ func (gc *GlobalConfig) RemoveRepo(path string) error {
 
 	for i, entry := range gc.Repos {
 		entryAbs := normalizePath(entry.Path)
-		if entryAbs == absPath {
+		if pathkey.SamePathIdentity(entryAbs, absPath) {
 			gc.Repos = append(gc.Repos[:i], gc.Repos[i+1:]...)
 			return nil
 		}
 	}
 
 	return fmt.Errorf("repository not found: %s", path)
+}
+
+// DedupeRepos removes tracked-repo entries that name the same directory as
+// an earlier entry but differ only in path spelling — letter case or
+// Unicode normalisation — on a case-insensitive filesystem. It is the
+// startup-healing pass for configs that already accumulated a duplicate
+// (issue #270): before folding was applied, two casings of one directory
+// could each become a tracked entry, flipping the daemon into multi-repo
+// mode and desyncing the graph.
+//
+// The FIRST entry for each directory is kept: it is the oldest and the one
+// whose repo prefix most likely already owns the indexed graph. Later
+// duplicates are returned so the caller can log which spelling was dropped
+// and persist the cleaned list. A surviving entry's stored Path is never
+// rewritten — its spelling is identity-bearing.
+func (gc *GlobalConfig) DedupeRepos() (removed []RepoEntry) {
+	if len(gc.Repos) < 2 {
+		return nil
+	}
+	kept := make([]RepoEntry, 0, len(gc.Repos))
+	for _, entry := range gc.Repos {
+		entryAbs := normalizePath(entry.Path)
+		dup := false
+		for _, k := range kept {
+			if pathkey.SamePathIdentity(normalizePath(k.Path), entryAbs) {
+				dup = true
+				break
+			}
+		}
+		if dup {
+			removed = append(removed, entry)
+			continue
+		}
+		kept = append(kept, entry)
+	}
+	if len(removed) == 0 {
+		return nil
+	}
+	gc.Repos = kept
+	return removed
 }
 
 // ResolveRepos returns the effective repo list for a given project name.

--- a/internal/config/global_dedup_test.go
+++ b/internal/config/global_dedup_test.go
@@ -1,0 +1,117 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/zzet/gortex/internal/pathkey"
+)
+
+// forceCaseInsensitive flips pathkey.CaseInsensitivePaths for the test and
+// restores it afterwards. Tests using it must not run in parallel because
+// the flag is process-global.
+func forceCaseInsensitive(t *testing.T, v bool) {
+	t.Helper()
+	prev := pathkey.CaseInsensitivePaths
+	pathkey.CaseInsensitivePaths = v
+	t.Cleanup(func() { pathkey.CaseInsensitivePaths = prev })
+}
+
+// caseVariantPaths returns two absolute, non-existent paths under a fresh
+// temp dir that differ only by the case of their final component, so a
+// fold treats them as the same directory while os.Stat fails (letting
+// SamePathIdentity trust the fold regardless of the host filesystem).
+func caseVariantPaths(t *testing.T) (upper, lower string) {
+	t.Helper()
+	base := t.TempDir()
+	return filepath.Join(base, "MyRepo"), filepath.Join(base, "myrepo")
+}
+
+func TestAddRepo_DedupesCaseVariant(t *testing.T) {
+	forceCaseInsensitive(t, true)
+	upper, lower := caseVariantPaths(t)
+
+	gc := &GlobalConfig{}
+	if err := gc.AddRepo(RepoEntry{Path: upper}); err != nil {
+		t.Fatalf("AddRepo(upper): %v", err)
+	}
+	if err := gc.AddRepo(RepoEntry{Path: lower}); err != nil {
+		t.Fatalf("AddRepo(lower): %v", err)
+	}
+	if len(gc.Repos) != 1 {
+		t.Fatalf("case variant should not add a second entry: got %d entries", len(gc.Repos))
+	}
+	// The first spelling is the identity anchor and must be preserved.
+	if gc.Repos[0].Path != upper {
+		t.Fatalf("stored spelling rewritten: got %q want %q", gc.Repos[0].Path, upper)
+	}
+}
+
+func TestAddRepo_CaseSensitiveKeepsBoth(t *testing.T) {
+	forceCaseInsensitive(t, false)
+	upper, lower := caseVariantPaths(t)
+
+	gc := &GlobalConfig{}
+	if err := gc.AddRepo(RepoEntry{Path: upper}); err != nil {
+		t.Fatalf("AddRepo(upper): %v", err)
+	}
+	if err := gc.AddRepo(RepoEntry{Path: lower}); err != nil {
+		t.Fatalf("AddRepo(lower): %v", err)
+	}
+	if len(gc.Repos) != 2 {
+		t.Fatalf("case-sensitive: distinct casings should both be tracked: got %d", len(gc.Repos))
+	}
+}
+
+func TestRemoveRepo_MatchesCaseVariant(t *testing.T) {
+	forceCaseInsensitive(t, true)
+	upper, lower := caseVariantPaths(t)
+
+	gc := &GlobalConfig{Repos: []RepoEntry{{Path: upper}}}
+	if err := gc.RemoveRepo(lower); err != nil {
+		t.Fatalf("RemoveRepo(lower) should match the upper entry: %v", err)
+	}
+	if len(gc.Repos) != 0 {
+		t.Fatalf("entry not removed: %d remain", len(gc.Repos))
+	}
+}
+
+func TestDedupeRepos_KeepsFirstReturnsRemoved(t *testing.T) {
+	forceCaseInsensitive(t, true)
+	upper, lower := caseVariantPaths(t)
+	other := filepath.Join(t.TempDir(), "distinct")
+
+	gc := &GlobalConfig{Repos: []RepoEntry{
+		{Path: upper, Name: "first"},
+		{Path: other, Name: "other"},
+		{Path: lower, Name: "dup"},
+	}}
+	removed := gc.DedupeRepos()
+
+	if len(removed) != 1 {
+		t.Fatalf("expected 1 removed entry, got %d", len(removed))
+	}
+	if removed[0].Path != lower {
+		t.Fatalf("wrong entry removed: got %q want %q", removed[0].Path, lower)
+	}
+	if len(gc.Repos) != 2 {
+		t.Fatalf("expected 2 surviving entries, got %d", len(gc.Repos))
+	}
+	// The first (oldest) spelling of the duplicated directory survives.
+	if gc.Repos[0].Path != upper || gc.Repos[0].Name != "first" {
+		t.Fatalf("first entry not preserved: %+v", gc.Repos[0])
+	}
+}
+
+func TestDedupeRepos_NoDuplicatesNoOp(t *testing.T) {
+	forceCaseInsensitive(t, true)
+	a := filepath.Join(t.TempDir(), "a")
+	b := filepath.Join(t.TempDir(), "b")
+	gc := &GlobalConfig{Repos: []RepoEntry{{Path: a}, {Path: b}}}
+	if removed := gc.DedupeRepos(); removed != nil {
+		t.Fatalf("expected no removals, got %v", removed)
+	}
+	if len(gc.Repos) != 2 {
+		t.Fatalf("clean list must be untouched: got %d", len(gc.Repos))
+	}
+}

--- a/internal/hooks/classifycwd_case_test.go
+++ b/internal/hooks/classifycwd_case_test.go
@@ -1,0 +1,42 @@
+package hooks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/daemon"
+	"github.com/zzet/gortex/internal/pathkey"
+)
+
+func forceHooksCaseInsensitive(t *testing.T, v bool) {
+	t.Helper()
+	prev := pathkey.CaseInsensitivePaths
+	pathkey.CaseInsensitivePaths = v
+	t.Cleanup(func() { pathkey.CaseInsensitivePaths = prev })
+}
+
+func TestClassifyCwd_CaseMismatchedExact(t *testing.T) {
+	forceHooksCaseInsensitive(t, true)
+	repos := []daemon.TrackedRepoStatus{{Path: "/Users/me/Repo"}}
+	exact, contained := classifyCwd("/users/me/repo", repos)
+	require.NotNil(t, exact, "case-variant cwd must match the tracked repo exactly")
+	assert.Empty(t, contained)
+}
+
+func TestClassifyCwd_CaseMismatchedContained(t *testing.T) {
+	forceHooksCaseInsensitive(t, true)
+	repos := []daemon.TrackedRepoStatus{{Path: "/Users/me/Workspace/Repo"}}
+	exact, contained := classifyCwd("/users/me/workspace", repos)
+	assert.Nil(t, exact)
+	require.Len(t, contained, 1, "a repo under a case-variant workspace cwd must be contained")
+}
+
+func TestClassifyCwd_CaseSensitiveNoMatch(t *testing.T) {
+	forceHooksCaseInsensitive(t, false)
+	repos := []daemon.TrackedRepoStatus{{Path: "/Users/me/Repo"}}
+	exact, contained := classifyCwd("/users/me/repo", repos)
+	assert.Nil(t, exact, "case-sensitive: byte-different cwd must not match")
+	assert.Empty(t, contained)
+}

--- a/internal/hooks/sessionstart.go
+++ b/internal/hooks/sessionstart.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/zzet/gortex/internal/daemon"
+	"github.com/zzet/gortex/internal/pathkey"
 	"github.com/zzet/gortex/internal/toolref"
 )
 
@@ -213,7 +214,7 @@ func classifyCwd(cwd string, repos []daemon.TrackedRepoStatus) (exact *daemon.Tr
 	for i := range repos {
 		repo := repos[i]
 		repoPath := filepath.Clean(repo.Path)
-		if repoPath == cwd {
+		if pathkey.EqualPaths(repoPath, cwd) {
 			exact = &repos[i]
 			continue
 		}
@@ -224,18 +225,13 @@ func classifyCwd(cwd string, repos []daemon.TrackedRepoStatus) (exact *daemon.Tr
 	return exact, contained
 }
 
-// hasPathPrefix reports whether path is rooted at prefix. Filepath
-// equality alone is wrong (`/foo/barbaz` would match `/foo/bar`) so
-// we require either equality or that the next char after prefix is
-// a separator.
+// hasPathPrefix reports whether path is rooted at prefix. It delegates to
+// pathkey.HasPathPrefix, which handles component boundaries (`/foo/barbaz`
+// must not match `/foo/bar`), the separator-root edge, and — on a
+// case-insensitive filesystem — case-only differences between the cwd and
+// a tracked root (#277).
 func hasPathPrefix(path, prefix string) bool {
-	if path == prefix {
-		return true
-	}
-	if !strings.HasPrefix(path, prefix) {
-		return false
-	}
-	return len(path) > len(prefix) && (path[len(prefix)] == filepath.Separator || prefix == string(filepath.Separator))
+	return pathkey.HasPathPrefix(path, prefix)
 }
 
 // rulePreamble is the short, always-present rule restatement. The

--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -19,6 +19,7 @@ import (
 	"github.com/zzet/gortex/internal/embedding"
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/pathkey"
 	"github.com/zzet/gortex/internal/progress"
 	"github.com/zzet/gortex/internal/resolver"
 	"github.com/zzet/gortex/internal/search"
@@ -1167,7 +1168,7 @@ func (mi *MultiIndexer) migrateLoneUnprefixedRepoCtx(ctx context.Context) {
 	entry := config.RepoEntry{Path: oldMeta.RootPath, Name: oldPrefix}
 	if mi.configMgr != nil {
 		for _, e := range mi.configMgr.Global().Repos {
-			if e.Path == oldMeta.RootPath {
+			if pathkey.EqualPaths(e.Path, oldMeta.RootPath) {
 				entry = e
 				break
 			}
@@ -1563,7 +1564,7 @@ func (mi *MultiIndexer) resolveTrackPrefix(entry *config.RepoEntry, absPath stri
 	mi.mu.RLock()
 	existing, ok := mi.repos[prefix]
 	mi.mu.RUnlock()
-	if ok && existing != nil && existing.RootPath != absPath {
+	if ok && existing != nil && !pathkey.SamePathIdentity(existing.RootPath, absPath) {
 		prefix = name + "-" + shortPathHash(absPath)
 	}
 
@@ -1600,6 +1601,36 @@ func EffectiveRepoPrefix(cm *config.ConfigManager, entry config.RepoEntry) strin
 	}
 	name, _ := WorktreeInstanceName(absPath, base, declaredWS, entry.AsWorktree)
 	return name
+}
+
+// foldDistinctRepoCount counts configured repos by folded path identity,
+// so two entries that name the same directory under different spellings
+// (case or Unicode normalisation on a case-insensitive filesystem) count
+// once. It backstops the willBeMultiRepo decision: startup healing already
+// prunes such duplicates, but a not-yet-pruned config must not be allowed
+// to flip the graph into prefixed-ID mode for what is really one repo.
+func foldDistinctRepoCount(repos []config.RepoEntry) int {
+	n := 0
+	seen := make([]string, 0, len(repos))
+	for _, e := range repos {
+		abs, err := filepath.Abs(e.Path)
+		if err != nil {
+			abs = e.Path
+		}
+		dup := false
+		for _, s := range seen {
+			if pathkey.EqualPaths(s, abs) {
+				dup = true
+				break
+			}
+		}
+		if dup {
+			continue
+		}
+		seen = append(seen, abs)
+		n++
+	}
+	return n
 }
 
 // TrackRepoCtx is TrackRepo with a context, allowing callers to pipe progress
@@ -1640,11 +1671,22 @@ func (mi *MultiIndexer) TrackRepoCtx(ctx context.Context, entry config.RepoEntry
 	// matching impossible to express).
 	prefix, cfg := mi.resolveTrackPrefix(&entry, absPath, identity)
 
-	// Check if already tracked.
+	// Check if already tracked. The prefix-keyed check catches the common
+	// case; the path scan additionally catches a case-only or Unicode
+	// spelling variant of an already-tracked directory on a
+	// case-insensitive filesystem (which resolves to a different derived
+	// prefix and would otherwise be minted as a bogus second instance —
+	// the very thing that flips the daemon into multi-repo mode, #270).
 	mi.mu.RLock()
 	if _, exists := mi.repos[prefix]; exists {
 		mi.mu.RUnlock()
 		return nil, nil // already tracked
+	}
+	for _, meta := range mi.repos {
+		if meta != nil && pathkey.SamePathIdentity(meta.RootPath, absPath) {
+			mi.mu.RUnlock()
+			return nil, nil // same directory, different path spelling
+		}
 	}
 	hook := mi.onRepoTracked
 	mi.mu.RUnlock()
@@ -1662,7 +1704,7 @@ func (mi *MultiIndexer) TrackRepoCtx(ctx context.Context, entry config.RepoEntry
 	// the same graph and halving cross-file edge density.
 	totalConfigured := 1 // ourselves
 	if mi.configMgr != nil {
-		totalConfigured = len(mi.configMgr.Global().Repos)
+		totalConfigured = foldDistinctRepoCount(mi.configMgr.Global().Repos)
 	}
 	willBeMultiRepo := len(mi.repos)+1 >= 2 || totalConfigured >= 2
 
@@ -1786,7 +1828,7 @@ func (mi *MultiIndexer) ReconcileRepoCtx(ctx context.Context, entry config.RepoE
 
 	totalConfigured := 1
 	if mi.configMgr != nil {
-		totalConfigured = len(mi.configMgr.Global().Repos)
+		totalConfigured = foldDistinctRepoCount(mi.configMgr.Global().Repos)
 	}
 	willBeMultiRepo := len(mi.repos)+1 >= 2 || totalConfigured >= 2
 
@@ -2157,7 +2199,12 @@ func (mi *MultiIndexer) RepoForFile(filePath string) string {
 	var bestLen int
 
 	for prefix, meta := range mi.repos {
-		if strings.HasPrefix(absPath, meta.RootPath+string(filepath.Separator)) || absPath == meta.RootPath {
+		// Fold-aware containment so a case-variant file path still maps
+		// to its repo on a case-insensitive filesystem. Longest-root-wins
+		// breaks ties by nesting depth; nested roots share a prefix, so
+		// the raw RootPath length orders them the same as their folded
+		// forms would.
+		if pathkey.HasPathPrefix(absPath, meta.RootPath) {
 			if len(meta.RootPath) > bestLen {
 				bestLen = len(meta.RootPath)
 				bestPrefix = prefix

--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -1640,6 +1640,11 @@ func (mi *MultiIndexer) TrackRepoCtx(ctx context.Context, entry config.RepoEntry
 	if err != nil {
 		return nil, fmt.Errorf("resolving path %s: %w", entry.Path, err)
 	}
+	// Normalise the volume (upper-case a Windows drive letter) so a newly
+	// tracked path converges with os.Getwd's convention. The volume is
+	// never part of a repo basename, so this cannot rotate a repo prefix;
+	// no-op on POSIX.
+	absPath = pathkey.NormalizeVolume(absPath)
 
 	// Validate path exists and is a directory.
 	info, err := os.Stat(absPath)
@@ -1789,6 +1794,9 @@ func (mi *MultiIndexer) ReconcileRepoCtx(ctx context.Context, entry config.RepoE
 	if err != nil {
 		return nil, fmt.Errorf("resolving path %s: %w", entry.Path, err)
 	}
+	// Normalise the volume (upper-case a Windows drive letter) to converge
+	// with os.Getwd's convention. Cosmetic; never touches the basename.
+	absPath = pathkey.NormalizeVolume(absPath)
 	info, err := os.Stat(absPath)
 	if err != nil {
 		return nil, fmt.Errorf("path does not exist: %s", absPath)

--- a/internal/indexer/multi_case_identity_test.go
+++ b/internal/indexer/multi_case_identity_test.go
@@ -1,0 +1,114 @@
+package indexer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/pathkey"
+)
+
+// forceCaseInsensitive flips the process-global pathkey.CaseInsensitivePaths
+// for the test and restores it afterwards. Tests using it must not run in
+// parallel because the flag is process-global.
+func forceCaseInsensitive(t *testing.T, v bool) {
+	t.Helper()
+	prev := pathkey.CaseInsensitivePaths
+	pathkey.CaseInsensitivePaths = v
+	t.Cleanup(func() { pathkey.CaseInsensitivePaths = prev })
+}
+
+// caseVariantOf returns p with the case of its final path component
+// toggled, so it names the same directory on a case-insensitive
+// filesystem while differing byte-wise.
+func caseVariantOf(p string) string {
+	return filepath.Join(filepath.Dir(p), swapCaseASCII(filepath.Base(p)))
+}
+
+func swapCaseASCII(s string) string {
+	b := []byte(s)
+	for i := range b {
+		switch {
+		case b[i] >= 'a' && b[i] <= 'z':
+			b[i] -= 32
+		case b[i] >= 'A' && b[i] <= 'Z':
+			b[i] += 32
+		}
+	}
+	return string(b)
+}
+
+// Tracking a case-only variant of an already-tracked directory must be a
+// no-op: no second entry, the repo count stays 1, and the daemon stays in
+// single-repo (unprefixed) mode. This is the #270 macOS regression.
+func TestTrackRepoCtx_CaseVariantIsNoOp(t *testing.T) {
+	forceCaseInsensitive(t, true)
+	mi, dir := indexSingleRepoForTest(t)
+	require.False(t, mi.IsMultiRepo())
+
+	variant := caseVariantOf(dir)
+	if _, err := os.Stat(variant); err != nil {
+		t.Skipf("host filesystem is case-sensitive; %q does not resolve", variant)
+	}
+
+	res, err := mi.TrackRepoCtx(context.Background(), config.RepoEntry{Path: variant})
+	require.NoError(t, err)
+	require.Nil(t, res, "tracking a case variant of an already-tracked dir must be a no-op")
+
+	assert.Len(t, mi.AllMetadata(), 1, "repo count must stay 1")
+	assert.False(t, mi.IsMultiRepo(), "mode must stay single-repo")
+}
+
+// ScopeForCWD is pure string folding (no stat), so a case-mismatched cwd
+// resolves to the tracked repo on any platform once folding is forced on.
+// This is the #277 Windows 0-tools scenario at the workspace layer.
+func TestScopeForCWD_CaseMismatchedCwd(t *testing.T) {
+	forceCaseInsensitive(t, true)
+	mi, dir := indexSingleRepoForTest(t)
+
+	variant := caseVariantOf(dir)
+	_, _, prefix, ok := mi.ScopeForCWD(variant)
+	require.True(t, ok, "case-variant cwd must resolve to the tracked repo")
+	assert.Equal(t, "myrepo", prefix)
+
+	// A sub-path with mismatched case resolves too.
+	_, _, prefix, ok = mi.ScopeForCWD(filepath.Join(variant, "pkg", "file.go"))
+	require.True(t, ok)
+	assert.Equal(t, "myrepo", prefix)
+}
+
+// ScopeForCWD must NOT resolve a genuinely unrelated cwd.
+func TestScopeForCWD_UnrelatedCwdMisses(t *testing.T) {
+	forceCaseInsensitive(t, true)
+	mi, dir := indexSingleRepoForTest(t)
+	_, _, _, ok := mi.ScopeForCWD(filepath.Join(filepath.Dir(dir), "somewhere-else"))
+	assert.False(t, ok)
+}
+
+func TestFoldDistinctRepoCount(t *testing.T) {
+	forceCaseInsensitive(t, true)
+	repos := []config.RepoEntry{
+		{Path: "/Users/me/Repo"},
+		{Path: "/Users/me/repo"}, // case variant of the first
+		{Path: "/Users/me/other"},
+	}
+	if got := foldDistinctRepoCount(repos); got != 2 {
+		t.Fatalf("foldDistinctRepoCount = %d, want 2 (case variants fold to one)", got)
+	}
+}
+
+func TestFoldDistinctRepoCount_CaseSensitive(t *testing.T) {
+	forceCaseInsensitive(t, false)
+	repos := []config.RepoEntry{
+		{Path: "/Users/me/Repo"},
+		{Path: "/Users/me/repo"},
+	}
+	if got := foldDistinctRepoCount(repos); got != 2 {
+		t.Fatalf("case-sensitive foldDistinctRepoCount = %d, want 2", got)
+	}
+}

--- a/internal/indexer/workspace_resolve.go
+++ b/internal/indexer/workspace_resolve.go
@@ -2,10 +2,10 @@ package indexer
 
 import (
 	"path/filepath"
-	"strings"
 
 	"github.com/zzet/gortex/internal/config"
 	"github.com/zzet/gortex/internal/contracts"
+	"github.com/zzet/gortex/internal/pathkey"
 	"github.com/zzet/gortex/internal/resolver"
 )
 
@@ -95,7 +95,7 @@ func (mi *MultiIndexer) ScopeForCWD(cwd string) (workspaceID, projectID, repoPre
 		if root == "" || root == "." {
 			continue
 		}
-		if cwd == root || strings.HasPrefix(cwd, root+string(filepath.Separator)) {
+		if pathkey.HasPathPrefix(cwd, root) {
 			if len(root) > len(bestRoot) {
 				bestRoot, bestPrefix = root, prefix
 			}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1113,16 +1113,28 @@ const serverInstructions = `Gortex is a code-intelligence graph server — it in
 // poisoning the connection with an errored initialize, the handshake succeeds
 // and the response tells the agent exactly how to activate the server — the
 // actionable affordance codegraph's silent empty-list lacks.
-func ServerInstructionsUntracked(cwd string) string {
+func ServerInstructionsUntracked(cwd string, roots ...string) string {
 	target := cwd
 	if strings.TrimSpace(target) == "" {
 		target = "."
 	}
-	return fmt.Sprintf("Gortex is connected but INACTIVE for this directory: %q is not covered by any tracked repository, "+
+	msg := fmt.Sprintf("Gortex is connected but INACTIVE for this directory: %q is not covered by any tracked repository, "+
 		"so the graph tools have nothing to answer with yet.\n\n"+
 		"To activate: run `gortex track %s`, then reconnect — the full tool catalogue and the "+
 		"graph become available.\n\n"+
 		"Until then tools/list is intentionally empty; fall back to your own file reads and text search.", target, target)
+	// Append the tracked roots so the mismatch is self-diagnosing: a
+	// case-only or drive-letter difference between the cwd above and one
+	// of these roots is the usual cause of an INACTIVE session (#277).
+	if len(roots) > 0 {
+		quoted := make([]string, len(roots))
+		for i, r := range roots {
+			quoted[i] = fmt.Sprintf("%q", r)
+		}
+		msg += fmt.Sprintf("\n\nTracked repository roots: [%s]. If one of these is the same directory as %q "+
+			"under a different letter case, that is the mismatch.", strings.Join(quoted, ", "), target)
+	}
+	return msg
 }
 
 // afterInitializeInstructions is the server's OnAfterInitialize hook: it
@@ -1142,10 +1154,26 @@ func (s *Server) afterInitializeInstructions(ctx context.Context, _ any, _ *mcp.
 // activation affordance (shared with the F4 handshake path); a covered cwd —
 // or a single-repo / cwd-less control client — gets the base guidance plus a
 // live-facts block describing the workspace and warmup state.
+// trackedRepoRoots returns the sorted absolute root of every tracked repo,
+// for the self-diagnosing INACTIVE instructions.
+func (s *Server) trackedRepoRoots() []string {
+	if s.multiIndexer == nil {
+		return nil
+	}
+	var roots []string
+	for _, meta := range s.multiIndexer.AllMetadata() {
+		if meta != nil && meta.RootPath != "" {
+			roots = append(roots, meta.RootPath)
+		}
+	}
+	sort.Strings(roots)
+	return roots
+}
+
 func (s *Server) stateAwareInstructions(cwd string) string {
 	if s.multiIndexer != nil && strings.TrimSpace(cwd) != "" {
 		if _, _, _, ok := s.multiIndexer.ScopeForCWD(cwd); !ok {
-			return ServerInstructionsUntracked(cwd)
+			return ServerInstructionsUntracked(cwd, s.trackedRepoRoots()...)
 		}
 	}
 	if facts := s.liveInstructionFacts(cwd); facts != "" {

--- a/internal/pathkey/identity.go
+++ b/internal/pathkey/identity.go
@@ -1,0 +1,185 @@
+package pathkey
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// CaseInsensitivePaths reports whether path identity comparisons should
+// ignore letter case. The default is chosen for the host filesystem:
+// true on Windows and macOS (whose default NTFS / APFS volumes are
+// case-insensitive), false on Linux.
+//
+// The environment override GORTEX_CASE_SENSITIVE_PATHS lets an operator
+// correct the default for an unusual mount:
+//
+//   - =1 (or true/yes) forces case-SENSITIVE comparisons — for a
+//     case-sensitive APFS or NTFS volume on macOS / Windows.
+//   - =0 (or false/no) forces case-INSENSITIVE comparisons — for a
+//     case-insensitive mount (e.g. an exFAT / SMB share) on Linux.
+//
+// It is a settable package variable rather than a constant so that
+// higher-layer tests can flip it deterministically on any CI platform.
+// A test that flips it MUST restore it via t.Cleanup and MUST NOT call
+// t.Parallel — the variable is process-global.
+var CaseInsensitivePaths bool
+
+func init() {
+	CaseInsensitivePaths = defaultCaseInsensitive()
+}
+
+// defaultCaseInsensitive resolves the initial value of CaseInsensitivePaths
+// from the environment override, falling back to the host GOOS default.
+func defaultCaseInsensitive() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("GORTEX_CASE_SENSITIVE_PATHS"))) {
+	case "1", "true", "yes", "on":
+		return false
+	case "0", "false", "no", "off":
+		return true
+	}
+	return runtime.GOOS == "windows" || runtime.GOOS == "darwin"
+}
+
+// foldPath reduces p to a canonical identity key: filepath.Clean removes
+// redundant separators and dot segments, Normalize folds Unicode to NFC,
+// the Windows-style volume component (drive letter or UNC root) is
+// upper-cased so "c:" and "C:" agree, and — when ci is true — the
+// remainder is lower-cased so a case-insensitive filesystem treats
+// "Documents" and "documents" as one path.
+//
+// It is a pure function of (string, bool): the volume is detected with
+// host-independent semantics (see volumeNameLen) so Windows and macOS
+// folding can be table-tested on a Linux CI runner. It never touches the
+// filesystem and never resolves symlinks — identity is lexical.
+func foldPath(p string, ci bool) string {
+	p = filepath.Clean(p)
+	p = Normalize(p)
+	vl := volumeNameLen(p)
+	vol := strings.ToUpper(p[:vl])
+	rest := p[vl:]
+	if ci {
+		rest = strings.ToLower(rest)
+	}
+	return vol + rest
+}
+
+// EqualPaths reports whether two absolute paths identify the same
+// location once folded. A byte-equal fast path mirrors Equal so the
+// common case allocates nothing.
+func EqualPaths(a, b string) bool {
+	if a == b {
+		return true
+	}
+	return foldPath(a, CaseInsensitivePaths) == foldPath(b, CaseInsensitivePaths)
+}
+
+// HasPathPrefix reports whether path is root itself or lies beneath it,
+// comparing on folded identity and respecting path-component boundaries:
+// "/Users/me/Doc" is not under "/Users/me/Documents". The volume root
+// ("/" on POSIX, "C:\" on Windows) already ends in a separator after
+// filepath.Clean, which the trailing-separator branch handles.
+func HasPathPrefix(path, root string) bool {
+	fp := foldPath(path, CaseInsensitivePaths)
+	fr := foldPath(root, CaseInsensitivePaths)
+	if fp == fr {
+		return true
+	}
+	sep := string(filepath.Separator)
+	if strings.HasSuffix(fr, sep) {
+		return strings.HasPrefix(fp, fr)
+	}
+	return strings.HasPrefix(fp, fr+sep)
+}
+
+// NormalizeVolume returns p with its Windows-style volume component
+// (drive letter or UNC root) upper-cased, e.g. "c:\x" -> "C:\x". It is a
+// no-op when there is no volume component (every POSIX path) and when the
+// volume is already upper-cased, so it never allocates on the common path.
+//
+// It is applied at store time to NEW tracked-repo entries only, to
+// converge cosmetically with os.Getwd's convention (which upper-cases the
+// drive letter on Windows). The volume is never part of a repo basename,
+// so re-casing it cannot rotate a repo prefix or node IDs. It must never
+// be applied to an already-stored path.
+func NormalizeVolume(p string) string {
+	vl := volumeNameLen(p)
+	if vl == 0 {
+		return p
+	}
+	up := strings.ToUpper(p[:vl])
+	if up == p[:vl] {
+		return p
+	}
+	return up + p[vl:]
+}
+
+// SamePathIdentity is the store-time dedup predicate. It treats a and b
+// as the same repo when they fold equal AND, when they differ byte-wise
+// but both stat cleanly, os.SameFile confirms they resolve to the same
+// directory — so two genuinely distinct directories on a case-sensitive
+// volume are never merged. If either path fails to stat, the fold is
+// trusted: a path that cannot be stat'd cannot be a distinct live repo.
+//
+// It stats the filesystem, so it must never be called on a per-request
+// hot path — only when adding, removing, or deduping a tracked entry.
+func SamePathIdentity(a, b string) bool {
+	if a == b {
+		return true
+	}
+	if !EqualPaths(a, b) {
+		return false
+	}
+	ai, aerr := os.Stat(a)
+	bi, berr := os.Stat(b)
+	if aerr != nil || berr != nil {
+		return true
+	}
+	return os.SameFile(ai, bi)
+}
+
+// volumeNameLen returns the length of the leading Windows-style volume
+// component of p — a drive letter ("c:") or a UNC root ("\\host\share").
+// It uses Windows semantics regardless of the host OS so that path
+// folding is deterministic and testable on every platform; a POSIX path
+// (which begins with "/") has no volume and yields 0. Both '\\' and '/'
+// are accepted as separators because a Windows path may arrive with
+// either.
+func volumeNameLen(p string) int {
+	if len(p) < 2 {
+		return 0
+	}
+	// Drive letter, e.g. "c:".
+	if p[1] == ':' && isDriveLetter(p[0]) {
+		return 2
+	}
+	// UNC root, e.g. "\\host\share" or "//host/share".
+	if isAnySeparator(p[0]) && isAnySeparator(p[1]) {
+		n := len(p)
+		i := 2
+		host := i
+		for i < n && !isAnySeparator(p[i]) {
+			i++
+		}
+		if i == host {
+			return 0 // "\\" with no host is not a UNC volume
+		}
+		if i < n {
+			i++ // consume the separator before the share name
+		}
+		for i < n && !isAnySeparator(p[i]) {
+			i++
+		}
+		return i
+	}
+	return 0
+}
+
+func isDriveLetter(c byte) bool {
+	return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z')
+}
+
+func isAnySeparator(c byte) bool {
+	return c == '\\' || c == '/'
+}

--- a/internal/pathkey/identity_test.go
+++ b/internal/pathkey/identity_test.go
@@ -173,6 +173,18 @@ func TestNormalizeVolume(t *testing.T) {
 	}
 }
 
+// TestNormalizeVolume_Idempotent proves store-time volume normalization is
+// stable: applying it in the CLI (runTrack / install) and again in the
+// daemon's TrackRepoCtx / ReconcileRepoCtx never drifts the stored path.
+func TestNormalizeVolume_Idempotent(t *testing.T) {
+	for _, in := range []string{`c:\x`, `C:\x`, `\\srv\share\dir`, "/Users/me/p", "relative/p", ""} {
+		once := NormalizeVolume(in)
+		if twice := NormalizeVolume(once); twice != once {
+			t.Errorf("NormalizeVolume not idempotent for %q: once=%q twice=%q", in, once, twice)
+		}
+	}
+}
+
 func TestVolumeNameLen(t *testing.T) {
 	cases := []struct {
 		in   string

--- a/internal/pathkey/identity_test.go
+++ b/internal/pathkey/identity_test.go
@@ -1,0 +1,256 @@
+package pathkey
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// withCaseInsensitive flips the process-global CaseInsensitivePaths for
+// the duration of a test and restores it on cleanup. Tests that call it
+// must not run in parallel.
+func withCaseInsensitive(t *testing.T, v bool) {
+	t.Helper()
+	prev := CaseInsensitivePaths
+	CaseInsensitivePaths = v
+	t.Cleanup(func() { CaseInsensitivePaths = prev })
+}
+
+func TestFoldPath_CaseInsensitiveLowersRemainder(t *testing.T) {
+	// With ci=true, two casings of the same path fold to one key.
+	a := foldPath("/Users/me/Documents/Project", true)
+	b := foldPath("/Users/me/documents/project", true)
+	if a != b {
+		t.Fatalf("foldPath ci=true did not converge: %q vs %q", a, b)
+	}
+}
+
+func TestFoldPath_CaseSensitiveKeepsRemainder(t *testing.T) {
+	// With ci=false, differing casings stay distinct.
+	a := foldPath("/Users/me/Documents", false)
+	b := foldPath("/Users/me/documents", false)
+	if a == b {
+		t.Fatalf("foldPath ci=false collapsed distinct casings: both %q", a)
+	}
+}
+
+func TestFoldPath_UppercasesDriveLetter(t *testing.T) {
+	// Windows drive letters fold identically regardless of case, even
+	// when the rest of the path is compared case-sensitively.
+	for _, ci := range []bool{false, true} {
+		a := foldPath(`c:\work\git\myrepo`, ci)
+		b := foldPath(`C:\work\git\myrepo`, ci)
+		if a != b {
+			t.Fatalf("foldPath ci=%v did not fold drive-letter case: %q vs %q", ci, a, b)
+		}
+	}
+}
+
+func TestFoldPath_CleansRedundantSegments(t *testing.T) {
+	got := foldPath("/Users/me/./project/../project", false)
+	want := "/Users/me/project"
+	if got != want {
+		t.Fatalf("foldPath did not clean: got %q want %q", got, want)
+	}
+}
+
+func TestFoldPath_FoldsNFDBeforeCasing(t *testing.T) {
+	// The NFC fold runs before case folding, so an NFD macOS spelling
+	// and an NFC git spelling of the same accented path converge.
+	a := foldPath("/x/"+cafeNFD, true)
+	b := foldPath("/x/"+cafeNFC, true)
+	if a != b {
+		t.Fatalf("foldPath did not reconcile NFD vs NFC: %q vs %q", a, b)
+	}
+}
+
+func TestEqualPaths_CaseVariants(t *testing.T) {
+	withCaseInsensitive(t, true)
+	if !EqualPaths("/Users/me/Documents/Project", "/Users/me/documents/project") {
+		t.Fatal("EqualPaths should treat case variants as equal when case-insensitive")
+	}
+}
+
+func TestEqualPaths_CaseSensitiveRejects(t *testing.T) {
+	withCaseInsensitive(t, false)
+	if EqualPaths("/Users/me/Documents", "/Users/me/documents") {
+		t.Fatal("EqualPaths must keep case variants distinct when case-sensitive")
+	}
+}
+
+func TestEqualPaths_ByteEqualFastPath(t *testing.T) {
+	withCaseInsensitive(t, false)
+	if !EqualPaths("/a/b/c", "/a/b/c") {
+		t.Fatal("EqualPaths byte-equal fast path failed")
+	}
+}
+
+func TestEqualPaths_DistinctPaths(t *testing.T) {
+	withCaseInsensitive(t, true)
+	if EqualPaths("/Users/me/alpha", "/Users/me/beta") {
+		t.Fatal("EqualPaths reported genuinely distinct paths as equal")
+	}
+}
+
+func TestHasPathPrefix_RootItself(t *testing.T) {
+	withCaseInsensitive(t, true)
+	if !HasPathPrefix("/Users/me/Repo", "/Users/me/repo") {
+		t.Fatal("a path is a prefix of itself (case-insensitive)")
+	}
+}
+
+func TestHasPathPrefix_ChildUnderRoot(t *testing.T) {
+	withCaseInsensitive(t, true)
+	if !HasPathPrefix("/Users/me/Repo/pkg/file.go", "/Users/me/repo") {
+		t.Fatal("child path should be under root regardless of case")
+	}
+}
+
+func TestHasPathPrefix_ComponentBoundary(t *testing.T) {
+	withCaseInsensitive(t, false)
+	// A shared textual prefix that is not a path-component prefix must
+	// not match: "/Users/me/Doc" is NOT under "/Users/me/Documents".
+	if HasPathPrefix("/Users/me/Documents", "/Users/me/Doc") {
+		t.Fatal("prefix-but-not-component must not match")
+	}
+	if HasPathPrefix("/Users/me/Doc", "/Users/me/Documents") {
+		t.Fatal("shorter sibling must not be under longer sibling")
+	}
+}
+
+func TestHasPathPrefix_PosixRoot(t *testing.T) {
+	withCaseInsensitive(t, false)
+	if !HasPathPrefix("/anything/here", "/") {
+		t.Fatal("everything is under the POSIX root")
+	}
+	if !HasPathPrefix("/", "/") {
+		t.Fatal("root is a prefix of itself")
+	}
+}
+
+func TestHasPathPrefix_TrailingSeparatorRoot(t *testing.T) {
+	withCaseInsensitive(t, true)
+	// A root passed with a trailing separator is cleaned; the child
+	// still matches.
+	if !HasPathPrefix("/Users/me/Repo/x", "/Users/me/repo/") {
+		t.Fatal("trailing-separator root should still match its children")
+	}
+}
+
+func TestHasPathPrefix_WindowsDriveRoot(t *testing.T) {
+	withCaseInsensitive(t, true)
+	// The drive-letter fold — the #277 fix — is exercised by the
+	// root-equals-cwd path (VS Code passes "c:\..." for a config-stored
+	// "C:\..."). This holds with either separator on any host OS.
+	if !HasPathPrefix(`C:\work\git\myrepo`, `c:\work\git\myrepo`) {
+		t.Fatal("Windows drive-letter case must not defeat the coverage check")
+	}
+	// The child-under-root branch relies on filepath.Separator, so use a
+	// forward-slash Windows path (also accepted by Windows) so the
+	// component boundary is verifiable on a POSIX CI runner too.
+	if !HasPathPrefix(`c:/work/git/myrepo/pkg`, `C:/work/git/myrepo`) {
+		t.Fatal("child under a drive-letter root must match despite case")
+	}
+}
+
+func TestNormalizeVolume(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{`c:\x`, `C:\x`},
+		{`C:\x`, `C:\x`},
+		{`\\srv\share`, `\\SRV\SHARE`},
+		{`\\Srv\Share\dir`, `\\SRV\SHARE\dir`},
+		{"/Users/me/project", "/Users/me/project"}, // no volume: no-op
+		{"relative/path", "relative/path"},         // no volume: no-op
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := NormalizeVolume(c.in); got != c.want {
+			t.Errorf("NormalizeVolume(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestVolumeNameLen(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"/Users/me", 0},
+		{"relative", 0},
+		{`c:\x`, 2},
+		{`C:`, 2},
+		{`\\srv\share`, len(`\\srv\share`)},
+		{`\\srv\share\dir`, len(`\\srv\share`)},
+		{`\\`, 0},
+		{"", 0},
+		{"a", 0},
+	}
+	for _, c := range cases {
+		if got := volumeNameLen(c.in); got != c.want {
+			t.Errorf("volumeNameLen(%q) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+func TestSamePathIdentity_DistinctDirsNotMerged(t *testing.T) {
+	// Two genuinely distinct directories must never be merged, even
+	// when the fold is forced case-insensitive.
+	withCaseInsensitive(t, true)
+	a := t.TempDir()
+	b := t.TempDir()
+	if SamePathIdentity(a, b) {
+		t.Fatalf("distinct dirs %q and %q must not be identified", a, b)
+	}
+}
+
+func TestSamePathIdentity_CaseVariantOfSameDir(t *testing.T) {
+	// On this host's default FS, a case variant of a real directory
+	// resolves to the same inode. Only assert the merge when the host
+	// filesystem is actually case-insensitive (so the variant exists).
+	withCaseInsensitive(t, true)
+	dir := t.TempDir()
+	base := filepath.Base(dir)
+	variant := filepath.Join(filepath.Dir(dir), swapCase(base))
+	if _, err := os.Stat(variant); err != nil {
+		t.Skipf("host filesystem is case-sensitive; %q does not resolve", variant)
+	}
+	if !SamePathIdentity(dir, variant) {
+		t.Fatalf("case variant %q of %q should identify as the same dir", variant, dir)
+	}
+}
+
+func TestSamePathIdentity_MissingPathTrustsFold(t *testing.T) {
+	// When a path cannot be stat'd, the fold is trusted rather than
+	// treating the pair as distinct.
+	withCaseInsensitive(t, true)
+	a := "/nonexistent/gortex/Repo"
+	b := "/nonexistent/gortex/repo"
+	if !SamePathIdentity(a, b) {
+		t.Fatal("fold-equal missing paths should be identified")
+	}
+}
+
+func TestSamePathIdentity_ByteEqualFastPath(t *testing.T) {
+	withCaseInsensitive(t, false)
+	if !SamePathIdentity("/x/y", "/x/y") {
+		t.Fatal("byte-equal fast path failed")
+	}
+}
+
+// swapCase toggles the case of ASCII letters so a case-variant directory
+// name can be constructed deterministically.
+func swapCase(s string) string {
+	b := []byte(s)
+	for i := range b {
+		switch {
+		case b[i] >= 'a' && b[i] <= 'z':
+			b[i] -= 32
+		case b[i] >= 'A' && b[i] <= 'Z':
+			b[i] += 32
+		}
+	}
+	return string(b)
+}


### PR DESCRIPTION
## Problem

Tracked-repo paths were compared byte-for-byte everywhere, so on case-insensitive filesystems the same directory could present under two spellings and break repo identity:

- **macOS (#270):** `~/Documents/project` and `~/documents/project` are the same directory but were tracked as two config entries. That flipped the daemon into multi-repo mode, desynced the unprefixed graph, and made `gortex` report "does not track" from one casing.
- **Windows (#277, a duplicate of #270):** `gortex init`/`install` store `C:\work\git\myrepo` (from `os.Getwd`), while VS Code launches the MCP server with cwd `c:\work\git\myrepo`. The coverage check byte-compared the two → the session was marked INACTIVE and `tools/list` returned `[]`.

Both are the same root cause: byte-wise path comparison where the filesystem is case-insensitive.

## What changed

- **Fold-aware identity helpers** in `internal/pathkey` (`EqualPaths`, `HasPathPrefix`, `NormalizeVolume`, `SamePathIdentity`, and a settable `CaseInsensitivePaths` flag defaulting to Windows/macOS, overridable via `GORTEX_CASE_SENSITIVE_PATHS`). Folding is lexical only — `filepath.Clean` + NFC + drive-letter upper-case + case-fold; it never resolves symlinks.
- **Compare-time folding** at every mapped call site: MCP session cwd coverage (`isCWDTracked` — the Windows 0-tools fix), workspace scope resolution (`ScopeForCWD`), file→repo mapping (`RepoForFile`), the SessionStart hook (`classifyCwd`/`hasPathPrefix`), and the `daemonOwnsRepo` / `matchRepo` / `repoNodeCount` / controller `Untrack` CLI paths.
- **Write-time dedup** so no new duplicate can form: `AddRepo`/`RemoveRepo`/`DedupeRepos` in config, the already-tracked scan and worktree collision guard in `TrackRepoCtx`/`resolveTrackPrefix`, and a fold-distinct count backstopping the single- vs multi-repo decision.
- **Startup healing** for configs that already accumulated a duplicate: the daemon warmup and the `track` CLI both run `DedupeRepos` before the repo list is used, log which spelling was dropped, and persist the cleaned config.
- **INACTIVE diagnostics** (#277 ask): the daemon logs the session cwd and the tracked roots once per uncovered session, and the client-visible INACTIVE instructions now list the tracked roots so a case/drive-letter mismatch is self-diagnosing.
- **Cosmetic volume normalization** for new entries only (upper-case a Windows drive letter to converge with `os.Getwd`); a no-op on POSIX.

## What deliberately did NOT change

Stored path spellings, repo prefixes, and node IDs are never rewritten. The stored basename is identity-bearing — it seeds node IDs, the sqlite `repo_prefix`, workspace slugs, and (via the full path) the snapshot cache key — so rewriting it would orphan the indexed graph. This fix folds at compare time and dedupes at write time, keeping the first (oldest) spelling as the identity anchor; it never persists a folded/lowercased path and never calls `EvalSymlinks` on an identity path.

## Tests

New coverage (previously zero on these functions): `internal/pathkey` table tests for folding, prefix component boundaries, POSIX/Windows/UNC roots, NFD+case combos, and `SamePathIdentity` with real temp dirs (distinct dirs must not merge); config `AddRepo`/`RemoveRepo`/`DedupeRepos` dedup; indexer fold-aware already-tracked + `ScopeForCWD` + fold-distinct count; daemon `isCWDTracked` case-variant match + roots in the INACTIVE instructions; CLI `matchRepo` and hooks `classifyCwd`; and the startup healing wiring. All touched packages pass `go test -race`; verified end-to-end on case-insensitive APFS (track → re-track via a case variant is a no-op keeping one entry → graph query works from the variant cwd → untrack via the variant path).

Fixes #270
Fixes #277
