### PR TITLE
instructions: switchable session profiles — one table drives body, tool preset, skills, hook tier

### DIFF
--- a/cmd/gortex/instructions.go
+++ b/cmd/gortex/instructions.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/agents/claudecode"
+	"github.com/zzet/gortex/internal/profiles"
+)
+
+// instructions.go is the `gortex instructions` command tree — the CLI
+// front end for instruction profiles (internal/profiles): named
+// bundles of instructions body + MCP tool preset + skills subset +
+// hook-verbosity tier, generated from one table. `switch` atomically
+// repoints the @-included active.md copy; agents pick the change up at
+// their next session start.
+
+var instructionsCmd = &cobra.Command{
+	Use:   "instructions",
+	Short: "Manage instruction profiles (guidance depth per machine)",
+	Long: "Manage the machine's instruction profiles. A profile bundles the " +
+		"agent-facing instructions body (@-included from the rules file), the " +
+		"MCP tool preset sessions default to, the installed skills subset, and " +
+		"the hook-verbosity tier — all generated from one table so they cannot " +
+		"drift. Switching applies to NEW sessions only: instructions, " +
+		"tools/list, and skills are all loaded at session start.",
+}
+
+var instructionsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List profiles and show which one is active",
+	Args:  cobra.NoArgs,
+	RunE:  runInstructionsList,
+}
+
+var instructionsShowCmd = &cobra.Command{
+	Use:   "show <profile>",
+	Short: "Print one profile's instructions body",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runInstructionsShow,
+}
+
+var instructionsSwitchCmd = &cobra.Command{
+	Use:   "switch <profile>",
+	Short: "Make a profile active (takes effect for new sessions)",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runInstructionsSwitch,
+}
+
+var instructionsRegenCmd = &cobra.Command{
+	Use:   "regen",
+	Short: "Regenerate the profile files from this binary (keeps the active selection)",
+	Args:  cobra.NoArgs,
+	RunE:  runInstructionsRegen,
+}
+
+func init() {
+	instructionsCmd.AddCommand(instructionsListCmd)
+	instructionsCmd.AddCommand(instructionsShowCmd)
+	instructionsCmd.AddCommand(instructionsSwitchCmd)
+	instructionsCmd.AddCommand(instructionsRegenCmd)
+	rootCmd.AddCommand(instructionsCmd)
+}
+
+func runInstructionsList(cmd *cobra.Command, _ []string) error {
+	dir := profiles.DefaultDir()
+	active := profiles.ActiveName(dir)
+	cmd.Printf("Instruction profiles (dir: %s)\n\n", dir)
+	for _, p := range profiles.Table() {
+		marker := " "
+		if p.Name == active {
+			marker = "*"
+		}
+		preset := p.ToolPreset
+		if preset == "" {
+			preset = "(client default)"
+		}
+		skills := "all"
+		if p.Skills != nil {
+			skills = fmt.Sprintf("%d", len(p.Skills))
+		}
+		cmd.Printf("%s %-13s %s\n", marker, p.Name, p.Summary)
+		cmd.Printf("    body: %4d bytes · tool preset: %s · skills: %s · hook tier: %s\n",
+			len(p.Body()), preset, skills, p.HookTier)
+	}
+	cmd.Printf("\n* = active. Switch with `gortex instructions switch <name>` — applies to NEW sessions only.\n")
+	return nil
+}
+
+func runInstructionsShow(cmd *cobra.Command, args []string) error {
+	name := strings.TrimSpace(args[0])
+	p, ok := profiles.ByName(name)
+	if !ok {
+		return fmt.Errorf("unknown instruction profile %q (known: %s)", name, strings.Join(profiles.Names(), ", "))
+	}
+	cmd.Print(p.Body())
+	return nil
+}
+
+func runInstructionsSwitch(cmd *cobra.Command, args []string) error {
+	name := strings.TrimSpace(args[0])
+	dir := profiles.DefaultDir()
+	p, err := profiles.Switch(dir, name)
+	if err != nil {
+		return err
+	}
+	cmd.Printf("Switched to the %q instruction profile (active copy: %s/%s).\n", p.Name, dir, profiles.ActiveFileName)
+
+	// Reconcile the installed skills with the profile's subset. Best
+	// effort: a missing home or an unwritable skills dir downgrades to
+	// a warning, the profile switch itself has already landed.
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		actions, err := claudecode.SyncGlobalSkills(cmd.ErrOrStderr(), home, p.Skills, agents.ApplyOpts{})
+		if err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "warning: skills sync incomplete: %v\n", err)
+		} else {
+			installed, removed := 0, 0
+			for _, a := range actions {
+				switch a.Action {
+				case agents.ActionCreate:
+					installed++
+				case agents.ActionDelete:
+					removed++
+				}
+			}
+			if installed+removed > 0 {
+				cmd.Printf("Skills reconciled: %d installed, %d removed.\n", installed, removed)
+			}
+		}
+		// Nudge when the pointer block was never installed — the
+		// profile only reaches agents through the @-include.
+		if md, err := os.ReadFile(claudecode.UserClaudeMdPath(home)); err != nil || !strings.Contains(string(md), agents.GlobalRulesStartMarker) {
+			cmd.Printf("Note: no Gortex rule block found in ~/.claude/CLAUDE.md — run `gortex install` to wire the @-include pointer.\n")
+		}
+	}
+
+	cmd.Printf("\nTakes effect for NEW sessions only: the instructions @-include, the MCP tools/list, and skills are all loaded at session start — running sessions keep their current surface.\n")
+	return nil
+}
+
+func runInstructionsRegen(cmd *cobra.Command, _ []string) error {
+	dir := profiles.DefaultDir()
+	if err := profiles.Generate(dir); err != nil {
+		return err
+	}
+	cmd.Printf("Regenerated %d profile(s) in %s (active: %s — unchanged).\n",
+		len(profiles.Table()), dir, profiles.ActiveName(dir))
+	return nil
+}

--- a/cmd/gortex/instructions_test.go
+++ b/cmd/gortex/instructions_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/zzet/gortex/internal/profiles"
+)
+
+// sandboxInstructionsEnv points the profile dir (XDG_DATA_HOME) and the
+// home dir (skills sync, pointer nudge) at temp dirs, and neutralises
+// the profile env override so on-disk state decides.
+func sandboxInstructionsEnv(t *testing.T) (home, dataDir string) {
+	t.Helper()
+	home = t.TempDir()
+	dataDir = t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", dataDir)
+	t.Setenv(profiles.ActiveEnv, "")
+	return home, dataDir
+}
+
+func captureCmd() (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+	cmd := &cobra.Command{}
+	out, errOut := &bytes.Buffer{}, &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetErr(errOut)
+	return cmd, out, errOut
+}
+
+func TestInstructionsSwitchListShowRegen(t *testing.T) {
+	_, _ = sandboxInstructionsEnv(t)
+	dir := profiles.DefaultDir()
+
+	// switch → files land, state recorded, caveat printed.
+	cmd, out, _ := captureCmd()
+	if err := runInstructionsSwitch(cmd, []string{"localization"}); err != nil {
+		t.Fatalf("switch: %v", err)
+	}
+	text := out.String()
+	if !strings.Contains(text, "NEW sessions only") {
+		t.Errorf("switch output must state the next-session caveat, got:\n%s", text)
+	}
+	if !strings.Contains(text, "gortex install") {
+		t.Errorf("switch on an uninstalled machine should nudge toward `gortex install`, got:\n%s", text)
+	}
+	active, err := os.ReadFile(filepath.Join(dir, profiles.ActiveFileName))
+	if err != nil {
+		t.Fatalf("active.md missing after switch: %v", err)
+	}
+	loc, _ := profiles.ByName("localization")
+	if string(active) != loc.Body() {
+		t.Error("active.md is not the switched profile body")
+	}
+
+	// list → active marker on the switched profile.
+	cmd, out, _ = captureCmd()
+	if err := runInstructionsList(cmd, nil); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if !strings.Contains(out.String(), "* localization") {
+		t.Errorf("list must mark the active profile, got:\n%s", out.String())
+	}
+
+	// show → exact body on stdout.
+	cmd, out, _ = captureCmd()
+	if err := runInstructionsShow(cmd, []string{"core"}); err != nil {
+		t.Fatalf("show: %v", err)
+	}
+	core, _ := profiles.ByName("core")
+	if out.String() != core.Body() {
+		t.Error("show did not print the exact profile body")
+	}
+	if err := runInstructionsShow(cmd, []string{"nope"}); err == nil {
+		t.Error("show of an unknown profile must error")
+	}
+
+	// regen → keeps the active selection.
+	cmd, out, _ = captureCmd()
+	if err := runInstructionsRegen(cmd, nil); err != nil {
+		t.Fatalf("regen: %v", err)
+	}
+	if !strings.Contains(out.String(), "active: localization") {
+		t.Errorf("regen must preserve the active selection, got:\n%s", out.String())
+	}
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -237,6 +237,25 @@ gortex memory store --kind invariant --importance 5 --symbols pkg/foo.go::Bar \
 gortex memory note --tags decision --body "chose token bucket over leaky bucket because of burst tolerance"
 ```
 
+### `gortex instructions …` — instruction profiles
+
+An **instruction profile** bundles four agent-facing surfaces, generated from one table so they cannot drift: the instructions body (`~/.gortex/instructions/<name>.md`, @-included into `~/.claude/CLAUDE.md` through an `active.md` byte copy), the MCP tool preset sessions default to, the installed skills subset, and the hook-verbosity tier. Three profiles ship: `core` (balanced default), `localization` (lean code-finding surface: ~2 KB body, ~10 read-only tools, 3 skills, lean hooks), `full` (maximum guidance: the ~34-tool dev-cycle preset eager).
+
+| Verb | Effect |
+|---|---|
+| `instructions list` | profiles with the active marker, body bytes, preset, skills count, hook tier |
+| `instructions show <name>` | print one profile's instructions body |
+| `instructions switch <name>` | atomically repoint `active.md`, record the state, reconcile installed skills |
+| `instructions regen` | re-derive the profile files from the running binary (selection unchanged) |
+
+Switching applies to **new sessions only** — the @-include, `tools/list`, and skills all load at session start. A forwarded `GORTEX_TOOLS` or an operator-pinned `mcp.tools` config always beats the profile's preset (see [`mcp.md`](mcp.md#restricting-the-tool-surface-presets)); `GORTEX_INSTRUCTIONS_PROFILE=<name>` pins the profile per process tree (benchmarks, CI).
+
+```bash
+gortex instructions list
+gortex instructions switch localization   # lean machine: diet body + 10-tool surface + lean hooks
+gortex instructions switch core           # back to the balanced default
+```
+
 ### `gortex analyze` — unified analysis dispatcher
 
 `gortex analyze --kind <k>` runs the daemon's `analyze` dispatcher. `gortex analyze kinds` lists the valid kinds (no daemon needed). Universal typed flags (`--limit`, `--compact`, `--path-prefix`, `--format json|gcx|toon|text`) cover the common parameters; kind-specific parameters ride on `--arg key=value` (same coercion as `call`, and a `--arg` pair overrides the matching typed flag).

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -54,7 +54,7 @@ Returned tools are auto-promoted (`promote:false` opts out) and the server fires
 
 The full ~180-tool surface is more than many agents need. A **tool preset** picks what the server publishes — the basis both for the lean shipped default and for a minimal, headless editing harness (an agent on a trusted box driving a remote daemon through a small, fixed tool set).
 
-Six built-in presets:
+Seven built-in presets:
 
 | Preset | Surface |
 |--------|---------|
@@ -64,10 +64,13 @@ Six built-in presets:
 | `readonly` | everything except the mutating tools (`edit_file`, `write_file`, `index_repository`, …) |
 | `edit` | the minimal headless editing set — orient + navigate + mutate + verify (`smart_context`, `search_symbols`, `find_files`, `edit_file`, `verify_change`, `get_test_targets`, …) |
 | `nav` | read-only navigation / exploration; no editors |
+| `localization` | the diet "where is the code that does X" set (~10 tools, read-only, compacted descriptions): `smart_context` + search + trace + read. The eager list is sourced from the instruction-profile table, so this surface and the `localization` profile's instructions body cannot drift. Aliases: `locate`, `find` |
 
 `tool_profile` and `tools_search` are always kept. Layer per-tool deltas on any preset with `allow` / `deny`.
 
 **Client-aware default.** With no `GORTEX_TOOLS` / config preset, the server picks the default per connection: a **known coding-agent client** (the same set that defaults the wire format to GCX — `claude-code`, `cursor`, `vscode`, `zed`, `aider`, `kilocode`, `opencode`, `openclaw`, `codex`, `omp-coding-agent`) gets `agent`; every other client keeps `core`. `GORTEX_TOOLS` always overrides. The `gortex mcp` proxy forwards its `GORTEX_TOOLS` / `--tools` to the daemon in the handshake, so a client's preset applies over the shared daemon (it can both narrow and widen the surface, not just subtract).
+
+**Instruction profiles.** The machine's active instruction profile (`gortex instructions switch <core|localization|full>` — see [`cli.md`](cli.md#gortex-instructions--instruction-profiles)) can carry a tool preset; sessions pick it up between the forwarded spec and the client-aware default. Full precedence: **forwarded spec (`GORTEX_TOOLS` / `--tools`) > operator-pinned `mcp.tools` config > active instruction profile > client-aware default > server default**. The shipped `core` profile carries no preset, so nothing changes until a machine explicitly switches; profile changes apply to new sessions only.
 
 **Two modes** (`mode`):
 

--- a/internal/agents/agents.go
+++ b/internal/agents/agents.go
@@ -94,6 +94,13 @@ type Env struct {
 	// install delivers full enforcement; set false by --no-claude-md.
 	InstallGlobalInstructions bool
 
+	// InstructionsDir overrides where the generated instruction
+	// profiles (internal/profiles) are materialised and where the
+	// CLAUDE.md pointer block resolves its @-include. Empty means
+	// the machine default (profiles.DefaultDir()); tests set a temp
+	// directory for hermeticity.
+	InstructionsDir string
+
 	// AnalyzeRepo is true when the caller wants a dynamic CLAUDE.md
 	// preamble built from a fresh index. Only Claude Code uses it.
 	AnalyzeRepo bool
@@ -162,8 +169,10 @@ const (
 	ActionCreate      ActionKind = "create"
 	ActionMerge       ActionKind = "merge"
 	ActionSkip        ActionKind = "skip"
+	ActionDelete      ActionKind = "delete"
 	ActionWouldCreate ActionKind = "would-create"
 	ActionWouldMerge  ActionKind = "would-merge"
+	ActionWouldDelete ActionKind = "would-delete"
 )
 
 // FileAction describes one file write (real or planned). Keys is the

--- a/internal/agents/agentstest/harness.go
+++ b/internal/agents/agentstest/harness.go
@@ -41,6 +41,10 @@ func NewEnv(t *testing.T) (agents.Env, *bytes.Buffer) {
 		HookCommand:  "/tmp/test-gortex hook",
 		Mode:         agents.ModeProject,
 		InstallHooks: true,
+		// Hermetic instruction-profile dir: global installs generate
+		// profile files and read the active profile from here instead
+		// of the developer's real ~/.gortex.
+		InstructionsDir: filepath.Join(home, ".gortex", "instructions"),
 		// SkillsRouting + GeneratedSkills are seeded so per-adapter
 		// tests exercise the community-routing write path — which
 		// is the only reason adapters touch per-repo instructions

--- a/internal/agents/claudecode/adapter.go
+++ b/internal/agents/claudecode/adapter.go
@@ -587,13 +587,6 @@ func installPermissions(w io.Writer, settingsPath string, opts agents.ApplyOpts)
 	}, opts)
 }
 
-// installGlobalSkills writes ~/.claude/skills/gortex-*/SKILL.md for
-// each skill defined in GlobalSkills, skipping any that already
-// exist (users may have customised their copy).
-func installGlobalSkills(w io.Writer, home string, opts agents.ApplyOpts) ([]agents.FileAction, error) {
-	return SyncGlobalSkills(w, home, nil, opts)
-}
-
 // instructionsDir resolves where the generated instruction profiles
 // live for this install run: the Env override (tests) or the machine
 // default shared with the daemon and the `gortex instructions` verb.

--- a/internal/agents/claudecode/adapter.go
+++ b/internal/agents/claudecode/adapter.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/profiles"
 )
 
 // Name is the stable identifier for this adapter, matching the
@@ -237,14 +238,28 @@ func (a *Adapter) applyGlobal(env agents.Env, opts agents.ApplyOpts, res *agents
 		res.Files = append(res.Files, hookAction)
 	}
 
-	// 4. ~/.claude/CLAUDE.md — merge the rule block. Without this,
-	// the rule only surfaces at deny-time (PreToolUse) which is
-	// late: the agent has already wasted a turn on a forbidden
-	// tool. The marker block keeps user content intact and is
-	// regeneratable on re-install.
+	// 4. Instruction profiles + ~/.claude/CLAUDE.md pointer block.
+	// The generated profiles live under the gortex home; CLAUDE.md
+	// carries only a thin marker-fenced block that @-includes the
+	// active profile, so `gortex instructions switch` changes
+	// guidance depth without ever rewriting CLAUDE.md. Without the
+	// block, the rule only surfaces at deny-time (PreToolUse) which
+	// is late: the agent has already wasted a turn on a forbidden
+	// tool.
+	insDir := instructionsDir(env)
 	if env.InstallGlobalInstructions {
+		insAction := agents.FileAction{Path: insDir, Action: agents.ActionMerge, Keys: []string{"instruction-profiles"}}
+		if opts.DryRun {
+			insAction.Action = agents.ActionWouldMerge
+			res.Files = append(res.Files, insAction)
+		} else if err := profiles.Generate(insDir); err != nil {
+			logWarn(w, "could not generate instruction profiles: %v", err)
+		} else {
+			logf(w, "[gortex install] wrote instruction profiles to %s", insDir)
+			res.Files = append(res.Files, insAction)
+		}
 		claudeMdPath := userClaudeMdPath(env.Home)
-		mdAction, err := agents.UpsertMarkedBlock(w, claudeMdPath, agents.GlobalInstructionsBody,
+		mdAction, err := agents.UpsertMarkedBlock(w, claudeMdPath, agents.GlobalPointerBody(insDir),
 			agents.GlobalRulesStartMarker, agents.GlobalRulesEndMarker, opts)
 		if err != nil {
 			logWarn(w, "could not install global CLAUDE.md: %v", err)
@@ -261,11 +276,11 @@ func (a *Adapter) applyGlobal(env agents.Env, opts agents.ApplyOpts, res *agents
 	}
 
 	// 3. ~/.claude/skills/gortex-*/SKILL.md — curated tool-usage
-	// skills (guide / explore / debug / impact / refactor). One
-	// source of truth per user rather than duplicated into every
-	// repo. Skipped when the files already exist so user edits
-	// survive.
-	skillActions, err := installGlobalSkills(w, env.Home, opts)
+	// skills, reconciled against the active instruction profile's
+	// subset (nil = all shipped skills). Existing files are never
+	// overwritten so user edits survive; out-of-profile skills are
+	// removed only when they still match a shipped body.
+	skillActions, err := SyncGlobalSkills(w, env.Home, profiles.Active(insDir).Skills, opts)
 	if err != nil {
 		logWarn(w, "could not install user-level skills: %v", err)
 	}
@@ -350,6 +365,20 @@ func (a *Adapter) RemoveGlobal(env agents.Env, opts agents.ApplyOpts) (removed i
 	ownedRemoved, ownedFailures := removeGlobalOwnedFiles(w, env.Home, opts)
 	removed += ownedRemoved
 	failures = append(failures, ownedFailures...)
+
+	// 6. Generated instruction profiles — gortex-owned generated
+	// files (plus the tiny active-state record), safe to delete.
+	insDir := instructionsDir(env)
+	if _, err := os.Stat(insDir); err == nil {
+		if opts.DryRun {
+			removed++
+		} else if err := profiles.Remove(insDir); err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", insDir, err))
+		} else {
+			logf(w, "[gortex] removed instruction profiles at %s", insDir)
+			removed++
+		}
+	}
 
 	return removed, failures
 }
@@ -562,11 +591,67 @@ func installPermissions(w io.Writer, settingsPath string, opts agents.ApplyOpts)
 // each skill defined in GlobalSkills, skipping any that already
 // exist (users may have customised their copy).
 func installGlobalSkills(w io.Writer, home string, opts agents.ApplyOpts) ([]agents.FileAction, error) {
+	return SyncGlobalSkills(w, home, nil, opts)
+}
+
+// instructionsDir resolves where the generated instruction profiles
+// live for this install run: the Env override (tests) or the machine
+// default shared with the daemon and the `gortex instructions` verb.
+func instructionsDir(env agents.Env) string {
+	if env.InstructionsDir != "" {
+		return env.InstructionsDir
+	}
+	return profiles.DefaultDir()
+}
+
+// SyncGlobalSkills reconciles ~/.claude/skills/gortex-* with the
+// allowed subset (nil = every shipped skill):
+//
+//   - allowed skills are installed when missing; an existing file is
+//     never overwritten, so user edits survive;
+//   - shipped skills OUTSIDE the subset are removed only when their
+//     on-disk SKILL.md is still byte-identical to the shipped body —
+//     a customised copy is kept (ActionSkip) with a warning, because
+//     deleting user work to enforce a profile is never worth it.
+//
+// Also used by `gortex instructions switch` to re-shape the installed
+// skill surface when the active profile changes.
+func SyncGlobalSkills(w io.Writer, home string, allowed []string, opts agents.ApplyOpts) ([]agents.FileAction, error) {
+	var allowedSet map[string]bool
+	if allowed != nil {
+		allowedSet = make(map[string]bool, len(allowed))
+		for _, name := range allowed {
+			allowedSet[name] = true
+		}
+	}
 	out := make([]agents.FileAction, 0, len(GlobalSkills))
 	skillsDir := filepath.Join(userClaudeConfigDir(home), "skills")
 	for name, content := range GlobalSkills {
 		dir := filepath.Join(skillsDir, name)
 		path := filepath.Join(dir, "SKILL.md")
+		if allowedSet != nil && !allowedSet[name] {
+			existing, err := os.ReadFile(path)
+			if err != nil {
+				// Not installed (or unreadable): nothing to prune.
+				out = append(out, agents.FileAction{Path: path, Action: agents.ActionSkip, Reason: "outside-profile"})
+				continue
+			}
+			if string(existing) != content {
+				logWarn(w, "keeping customised skill %s (outside the active profile)", path)
+				out = append(out, agents.FileAction{Path: path, Action: agents.ActionSkip, Reason: "customised"})
+				continue
+			}
+			if opts.DryRun {
+				out = append(out, agents.FileAction{Path: path, Action: agents.ActionWouldDelete, Keys: []string{"skill"}})
+				continue
+			}
+			if err := os.RemoveAll(dir); err != nil {
+				return out, err
+			}
+			logf(w, "[gortex] removed skill %s (outside the active profile)", path)
+			out = append(out, agents.FileAction{Path: path, Action: agents.ActionDelete, Keys: []string{"skill"}})
+			continue
+		}
 		action, err := agents.WriteIfNotExists(w, path, content, opts)
 		if err != nil {
 			return out, err

--- a/internal/agents/claudecode/install_diet_test.go
+++ b/internal/agents/claudecode/install_diet_test.go
@@ -8,13 +8,16 @@ import (
 
 	"github.com/zzet/gortex/internal/agents"
 	"github.com/zzet/gortex/internal/agents/agentstest"
+	"github.com/zzet/gortex/internal/profiles"
 )
 
 // Byte ceilings for the installed ambient layer. Approximated at ~4.4 B/token:
-//   - 6.5 KiB global section ≈ 1.5k tokens
+//   - 6.5 KiB global section (pointer block + the @-included default
+//     profile body) ≈ 1.5k tokens
 //   - 2.5 KiB skills-eager total ≈ 0.57k tokens
 // Blowing either (a future rule-block or description balloon) fails loudly
-// instead of silently re-inflating the per-session tax.
+// instead of silently re-inflating the per-session tax. Per-profile body
+// ceilings live in internal/profiles.
 const (
 	globalSectionByteCeiling = 6656 // 6.5 KiB
 	skillsEagerByteCeiling   = 2560 // 2.5 KiB
@@ -40,7 +43,11 @@ func frontmatterOf(s string) string {
 // the byte cost of the installed ambient layer and asserts the global rule
 // block and the skills-eager total stay inside their ceilings.
 func TestInstalledAmbientByteCeilings(t *testing.T) {
-	global := len(agents.GlobalInstructionsBody)
+	// What a session actually pays at the machine level: the pointer
+	// block in ~/.claude/CLAUDE.md plus the @-included active profile
+	// body (default profile on a fresh install).
+	def, _ := profiles.ByName(profiles.DefaultName)
+	global := len(agents.GlobalPointerBody("/home/user/.gortex/instructions")) + len(def.Body())
 
 	skillsFM := 0
 	for _, body := range GlobalSkills {
@@ -52,13 +59,13 @@ func TestInstalledAmbientByteCeilings(t *testing.T) {
 	}
 
 	t.Logf("installed ambient byte cost:")
-	t.Logf("  global CLAUDE.md section : %d bytes  (ceiling %d)", global, globalSectionByteCeiling)
+	t.Logf("  global section (pointer+default profile): %d bytes  (ceiling %d)", global, globalSectionByteCeiling)
 	t.Logf("  skills eager frontmatter : %d bytes  (ceiling %d, %d skills)", skillsFM, skillsEagerByteCeiling, len(GlobalSkills))
 	t.Logf("  sub-agent eager frontmatter: %d bytes  (%d agents)", subFM, len(SubAgents))
 	t.Logf("  projected installed eager: %d bytes", global+skillsFM+subFM)
 
 	if global > globalSectionByteCeiling {
-		t.Errorf("global CLAUDE.md section is %d bytes, over the %d ceiling", global, globalSectionByteCeiling)
+		t.Errorf("global section (pointer + default profile body) is %d bytes, over the %d ceiling", global, globalSectionByteCeiling)
 	}
 	if skillsFM > skillsEagerByteCeiling {
 		t.Errorf("skills eager frontmatter is %d bytes, over the %d ceiling", skillsFM, skillsEagerByteCeiling)
@@ -66,9 +73,11 @@ func TestInstalledAmbientByteCeilings(t *testing.T) {
 }
 
 // TestGlobalInstall_FatToSlimReplacement is the migration gate: a user
-// upgrading from a fat pre-diet rule block gets the slim one on re-install,
-// with the user's own prose around the marker block preserved and no duplicate
-// block. Exercises the marker-fenced merge on the real install path.
+// upgrading from a fat pre-diet rule block gets the thin pointer block
+// on re-install (the policy body moves to the @-included instruction
+// profile), with the user's own prose around the marker block preserved
+// and no duplicate block. Exercises the marker-fenced merge on the real
+// install path.
 func TestGlobalInstall_FatToSlimReplacement(t *testing.T) {
 	env, _ := agentstest.NewEnv(t)
 	env.Mode = agents.ModeGlobal
@@ -121,9 +130,24 @@ func TestGlobalInstall_FatToSlimReplacement(t *testing.T) {
 		t.Errorf("expected exactly 1 rule block, found %d", n)
 	}
 
-	// The block now carries the slim policy core…
-	if !strings.Contains(text, "gortex://guide") || !strings.Contains(text, "distill_session") {
-		t.Error("re-installed block is missing the slim policy core (guide pointer / memory triggers)")
+	// The block is now the thin pointer: it @-includes the active
+	// profile copy from the hermetic instructions dir…
+	activePath := filepath.Join(env.InstructionsDir, profiles.ActiveFileName)
+	if !strings.Contains(text, "@"+activePath) {
+		t.Errorf("re-installed block does not @-include the active profile (%s)", activePath)
+	}
+	if !strings.Contains(text, "gortex instructions switch") {
+		t.Error("re-installed block lost the switch verb")
+	}
+	// …and the slim policy core moved into the profile file itself.
+	activeBody, err := os.ReadFile(activePath)
+	if err != nil {
+		t.Fatalf("active profile copy was not generated: %v", err)
+	}
+	for _, token := range []string{"gortex://guide", "distill_session", "surface_memories", "smart_context"} {
+		if !strings.Contains(string(activeBody), token) {
+			t.Errorf("active profile body is missing the policy core token %q", token)
+		}
 	}
 	// …and the relocated fat content is gone.
 	for _, gone := range []string{

--- a/internal/agents/claudecode/install_diet_test.go
+++ b/internal/agents/claudecode/install_diet_test.go
@@ -15,6 +15,7 @@ import (
 //   - 6.5 KiB global section (pointer block + the @-included default
 //     profile body) ≈ 1.5k tokens
 //   - 2.5 KiB skills-eager total ≈ 0.57k tokens
+//
 // Blowing either (a future rule-block or description balloon) fails loudly
 // instead of silently re-inflating the per-session tax. Per-profile body
 // ceilings live in internal/profiles.

--- a/internal/agents/instructions.go
+++ b/internal/agents/instructions.go
@@ -18,6 +18,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/zzet/gortex/internal/profiles"
 )
 
 // InstructionsSentinel is the substring every doc-aware adapter checks
@@ -49,50 +51,20 @@ const (
 	GlobalRulesEndMarker   = "<!-- gortex:rules:end -->"
 )
 
-// GlobalInstructionsBody is the rule block written into the
-// user-level ~/.claude/CLAUDE.md by `gortex install`. Mirrors
-// InstructionsBody (the per-project rules) but trimmed to the
-// always-applicable parts — multi-repo specifics, project-skill
-// generation, and contracts hygiene are project-scoped and stay in
-// per-repo CLAUDE.md.
-const GlobalInstructionsBody = `## MANDATORY: Use Gortex MCP tools instead of Read/Grep/Glob
-
-A Gortex daemon is configured machine-wide via the ` + "`" + `gortex` + "`" + ` MCP server. Whenever you operate on indexed source (any repo the daemon tracks — check ` + "`" + `gortex daemon status` + "`" + `), you MUST prefer graph queries over file reads. PreToolUse hooks deny ` + "`" + `Read` + "`" + ` / ` + "`" + `Grep` + "`" + ` / ` + "`" + `Glob` + "`" + ` against indexed source — the deny message names the right tool.
-
-| Instead of...                       | Use...                                   |
-|-------------------------------------|------------------------------------------|
-| ` + "`" + `Grep` + "`" + ` / ` + "`" + `grep` + "`" + ` / ` + "`" + `rg` + "`" + ` for a symbol | ` + "`" + `search_symbols` + "`" + ` (BM25 + camelCase-aware) |
-| ` + "`" + `Grep` + "`" + ` for references               | ` + "`" + `find_usages` + "`" + ` (zero false positives)     |
-| Reading / grepping to find callers  | ` + "`" + `get_callers` + "`" + ` / ` + "`" + `get_call_chain` + "`" + `         |
-| ` + "`" + `Glob` + "`" + ` over source files            | ` + "`" + `get_repo_outline` + "`" + ` / ` + "`" + `search_symbols` + "`" + `    |
-| ` + "`" + `Read` + "`" + ` a file for one symbol        | ` + "`" + `get_symbol_source` + "`" + ` (` + "`" + `compress_bodies:true` + "`" + ` for the signature only) |
-| ` + "`" + `Read` + "`" + ` to understand a file         | ` + "`" + `get_file_summary` + "`" + ` / ` + "`" + `get_editing_context` + "`" + ` |
-| ` + "`" + `Read` + "`" + ` a non-indexed / raw file     | ` + "`" + `read_file` + "`" + `                              |
-| Multiple reads to explore a task    | ` + "`" + `smart_context` + "`" + ` (one call)               |
-| ` + "`" + `Edit` + "`" + ` / ` + "`" + `Write` + "`" + ` source             | ` + "`" + `edit_file` + "`" + ` / ` + "`" + `write_file` + "`" + ` / ` + "`" + `edit_symbol` + "`" + ` / ` + "`" + `rename_symbol` + "`" + ` / ` + "`" + `batch_edit` + "`" + ` |
-
-**CLI fallback (no MCP):** every tool above is reachable from a shell as ` + "`" + `gortex call <tool> --arg k=v` + "`" + ` (e.g. ` + "`" + `gortex call read_file --arg path=<file>` + "`" + `) — there is no bare ` + "`" + `gortex <tool>` + "`" + ` verb.
-
-Graph queries *narrow scope*; they do not replace reading the implementation. For the symbol you are about to change or depend on — especially behavior-critical code (migrations, retry / fallback / error-recovery paths, concurrency, compatibility shims) — read the real body with ` + "`" + `get_symbol_source` + "`" + ` and do NOT pass ` + "`" + `compress_bodies:true` + "`" + `, which elides the branches that carry the risk. ` + "`" + `format:"gcx"` + "`" + ` (compact wire, ~27% fewer tokens) and ` + "`" + `compress_bodies:true` + "`" + ` (body-eliding) exist on the read / list tools; the parameter legend is in the MCP server instructions.
-
-## MANDATORY: Session + development memory
-
-The graph remembers code; these tools remember **why you made a call**. They are behavior-critical — run each at its trigger, not "optionally":
-
-- **Session start / after a compaction** — call ` + "`" + `distill_session` + "`" + ` first: prior top symbols, pinned notes, decisions, recent excerpts. Seed your mental model before reading any file.
-- **Immediately after ` + "`" + `smart_context` + "`" + `** — call ` + "`" + `surface_memories task:"<task>" symbol_ids:"<top hits>"` + "`" + `: cross-session invariants / gotchas / decisions anchored to your working set. If it returns nothing, don't probe further.
-- **At every decision** — pick an approach, reject an alternative, hit a non-obvious constraint, or commit to an invariant → ` + "`" + `save_note tags:"decision" body:"<what+why>"` + "`" + `. Mention symbol IDs (` + "`" + `pkg/foo.go::Bar` + "`" + `) in the body for auto-linking; ` + "`" + `pinned:true` + "`" + ` for load-bearing notes.
-- **When you learn a durable fact worth teaching the team** — ` + "`" + `store_memory kind:"<invariant|gotcha|convention|decision|constraint|incident>" body:"<what+why>" symbol_ids:"<id>" importance:5` + "`" + `. ` + "`" + `save_note` + "`" + ` is the per-session scratchpad; ` + "`" + `store_memory` + "`" + ` is the workspace-wide store every future agent inherits. Supersede a stale memory with ` + "`" + `supersedes:"<old-id>"` + "`" + `.
-- **Before editing a symbol you've touched before** — ` + "`" + `query_notes symbol_id:"<id>"` + "`" + ` / ` + "`" + `query_memories symbol_id:"<id>"` + "`" + ` surface prior decisions and "do not change this without …" warnings.
-
-**Save / store:** decisions, non-obvious constraints, invariants, follow-ups, incident learnings, bug reproductions. **Skip:** play-by-play the diff already shows, anything derivable from the graph, content already in CLAUDE.md.
-
-## Reference and discovery
-
-- **` + "`" + `gortex://guide` + "`" + ` resource** (or the ` + "`" + `gortex guide [topic]` + "`" + ` CLI) is the full reference: LLM-provider matrix, capabilities catalog, analyze / search_ast catalogs, token-economy detail, MCP resources, session-start checklist. Read it on demand — it is not pre-paid here.
-- **` + "`" + `tools_search` + "`" + `** — the server publishes a lean tool preset eagerly and defers the rest; call ` + "`" + `tools_search` + "`" + ` to discover and load any tool by keyword (every tool stays callable by name).
-- The SessionStart hook injects daemon status. "daemon is not running" → run ` + "`" + `gortex daemon start --detach` + "`" + `; "cwd is not covered by any tracked repo" → graph tools are unavailable there.
-`
+// GlobalPointerBody renders the thin machine-level rule block
+// `gortex install` merges into ~/.claude/CLAUDE.md. The rule content
+// itself lives in <instructionsDir>/active.md — an atomic byte copy of
+// the selected instruction profile (internal/profiles) — and is pulled
+// in through an @-include, so switching guidance depth never rewrites
+// CLAUDE.md. The heading stays here as the idempotency sentinel and as
+// a functional minimum for readers that do not expand @-includes.
+func GlobalPointerBody(instructionsDir string) string {
+	active := filepath.Join(instructionsDir, profiles.ActiveFileName)
+	return "## MANDATORY: Use Gortex MCP tools instead of Read/Grep/Glob\n\n" +
+		"The machine-wide Gortex rules load from the active instruction profile, imported below:\n\n" +
+		"@" + active + "\n\n" +
+		"Switch guidance depth with `gortex instructions switch <core|localization|full>` (`list` shows all) — applies to NEW sessions only.\n"
+}
 
 // InstructionsBody is the shared rule block every adapter writes to
 // its agent's instructions file. Tool names in the tables (Read, Grep)

--- a/internal/agents/instructions_test.go
+++ b/internal/agents/instructions_test.go
@@ -164,34 +164,33 @@ func TestInstructionsBody_PolicyCoreAndSingleHome(t *testing.T) {
 	}
 }
 
-// TestGlobalInstructionsBody_PolicyCoreAndSingleHome mirrors the check for the
-// per-machine block written by `gortex install` into ~/.claude/CLAUDE.md — the
-// single home for the full memory-workflow triggers.
-func TestGlobalInstructionsBody_PolicyCoreAndSingleHome(t *testing.T) {
-	for _, token := range []string{
-		// Graph-tools policy core.
-		"search_symbols", "find_usages", "get_callers", "get_call_chain",
-		"get_symbol_source", "get_editing_context", "read_file",
-		"smart_context", "edit_file", "rename_symbol", "compress_bodies",
-		// Full memory triggers (the single home).
-		"distill_session", "surface_memories", "save_note", "store_memory",
-		"query_notes", "query_memories",
-		// Discovery pointers.
-		"tools_search", "gortex://guide", "gortex daemon start",
-	} {
-		if !strings.Contains(GlobalInstructionsBody, token) {
-			t.Errorf("GlobalInstructionsBody no longer mentions %q", token)
-		}
+// TestGlobalPointerBody_ShapeAndSentinel locks in the thin pointer
+// block `gortex install` writes into ~/.claude/CLAUDE.md: it must keep
+// the mandatory-rule heading (the cross-adapter idempotency sentinel),
+// @-include the active profile copy from the given directory, name the
+// switch verb with its next-session caveat, and stay tiny — the full
+// policy body lives in the profile file, not here.
+func TestGlobalPointerBody_ShapeAndSentinel(t *testing.T) {
+	const dir = "/home/user/.gortex/instructions"
+	body := GlobalPointerBody(dir)
+
+	if !strings.Contains(body, InstructionsSentinel) {
+		t.Error("pointer block lost the idempotency sentinel heading")
 	}
-	for _, banned := range []string{
-		providerMatrixMarker, analyzeCatalogMarker, formatDeepDiveMarker,
-		// Reference catalogs that relocated to the guide / schema resource.
-		// (A bare "search_ast" pointer is allowed; the DETECTOR catalog — named
-		// detectors like error-not-wrapped — must not be inlined.)
-		"k8s_resources", "error-not-wrapped", "gortex://report",
-	} {
-		if strings.Contains(GlobalInstructionsBody, banned) {
-			t.Errorf("GlobalInstructionsBody re-carries relocated content %q — single-home violation", banned)
-		}
+	if !strings.Contains(body, "@"+dir+"/active.md") {
+		t.Errorf("pointer block does not @-include the active profile: %q", body)
+	}
+	if !strings.Contains(body, "gortex instructions switch") {
+		t.Error("pointer block lost the switch verb")
+	}
+	if !strings.Contains(body, "NEW sessions only") {
+		t.Error("pointer block lost the next-session caveat")
+	}
+	if strings.Contains(body, "@~") {
+		t.Error("pointer block must embed a resolved path, not a ~ shorthand")
+	}
+	const pointerByteCeiling = 512
+	if len(body) > pointerByteCeiling {
+		t.Errorf("pointer block is %d bytes, over the %d ceiling — the body belongs in the profile file", len(body), pointerByteCeiling)
 	}
 }

--- a/internal/hooks/hook_tier_test.go
+++ b/internal/hooks/hook_tier_test.go
@@ -1,0 +1,103 @@
+package hooks
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/daemon"
+	"github.com/zzet/gortex/internal/profiles"
+)
+
+// withHookTier pins the hook-verbosity tier for one test.
+func withHookTier(t *testing.T, tier profiles.HookTier) {
+	t.Helper()
+	prev := activeHookTier
+	activeHookTier = func() profiles.HookTier { return tier }
+	t.Cleanup(func() { activeHookTier = prev })
+}
+
+func leanTestStatus() (*daemon.StatusResponse, error) {
+	return &daemon.StatusResponse{
+		Version:       "0.60.0",
+		UptimeSeconds: 3600,
+		Ready:         true,
+		TrackedRepos: []daemon.TrackedRepoStatus{
+			{Name: "gortex", Path: "/tmp/gortex", Workspace: "gortex", Nodes: 6604, Edges: 27403},
+		},
+		Workspaces: []daemon.WorkspaceSummary{{Slug: "gortex"}},
+	}, nil
+}
+
+// TestSessionStart_LeanTier_TrackedCwd: the lean tier compresses status
+// to one line but keeps every positioning cue and the enforcement
+// signal.
+func TestSessionStart_LeanTier_TrackedCwd(t *testing.T) {
+	withFakeStatus(t, leanTestStatus)
+	withHookTier(t, profiles.HookTierLean)
+
+	briefing := buildSessionStartBriefing("/tmp/gortex")
+
+	if !strings.Contains(briefing, "enforcement active") {
+		t.Errorf("lean briefing lost the enforcement signal:\n%s", briefing)
+	}
+	if !strings.Contains(briefing, "Rule:") || !strings.Contains(briefing, "search_symbols") {
+		t.Errorf("lean briefing lost the rule preamble cues:\n%s", briefing)
+	}
+	// The standard-tier status prose must be gone.
+	if strings.Contains(briefing, "workspace(s)") || strings.Contains(briefing, "uptime") {
+		t.Errorf("lean briefing still carries standard status prose:\n%s", briefing)
+	}
+	// And the lean rendering must actually be smaller.
+	withHookTier(t, profiles.HookTierStandard)
+	standard := buildSessionStartBriefing("/tmp/gortex")
+	if len(briefing) >= len(standard) {
+		t.Errorf("lean briefing (%d bytes) is not smaller than standard (%d bytes)", len(briefing), len(standard))
+	}
+}
+
+// TestSessionStart_LeanTier_KeepsUncoveredWarning: the actionable
+// not-covered warning survives the diet — it is a cue, not prose.
+func TestSessionStart_LeanTier_KeepsUncoveredWarning(t *testing.T) {
+	withFakeStatus(t, leanTestStatus)
+	withHookTier(t, profiles.HookTierLean)
+
+	briefing := buildSessionStartBriefing("/somewhere/else")
+	if !strings.Contains(briefing, "not covered by any tracked repo") {
+		t.Errorf("lean briefing lost the uncovered-cwd warning:\n%s", briefing)
+	}
+	if !strings.Contains(briefing, "gortex track") {
+		t.Errorf("lean briefing lost the fix-it command:\n%s", briefing)
+	}
+}
+
+// TestPromptInjection_LeanTier: fewer hits, shorter tail, cues kept.
+func TestPromptInjection_LeanTier(t *testing.T) {
+	hits := []grepSymbolHit{
+		{Name: "Alpha", Kind: "function", FilePath: "a.go", Line: 1},
+		{Name: "Beta", Kind: "function", FilePath: "b.go", Line: 2},
+		{Name: "Gamma", Kind: "function", FilePath: "c.go", Line: 3},
+		{Name: "Delta", Kind: "function", FilePath: "d.go", Line: 4},
+		{Name: "Epsilon", Kind: "function", FilePath: "e.go", Line: 5},
+	}
+
+	withHookTier(t, profiles.HookTierLean)
+	lean := buildPromptInjection(hits)
+	if strings.Contains(lean, "Delta") || strings.Contains(lean, "Epsilon") {
+		t.Errorf("lean tier must cap hits at %d:\n%s", maxInjectedHitsLean, lean)
+	}
+	if !strings.Contains(lean, "Alpha") {
+		t.Errorf("lean tier dropped the top hit:\n%s", lean)
+	}
+	if !strings.Contains(lean, "get_symbol_source") || !strings.Contains(lean, "smart_context") {
+		t.Errorf("lean tier lost the tool cues:\n%s", lean)
+	}
+
+	withHookTier(t, profiles.HookTierStandard)
+	standard := buildPromptInjection(hits)
+	if !strings.Contains(standard, "Epsilon") {
+		t.Errorf("standard tier should keep %d hits:\n%s", maxInjectedHits, standard)
+	}
+	if len(lean) >= len(standard) {
+		t.Errorf("lean injection (%d bytes) is not smaller than standard (%d bytes)", len(lean), len(standard))
+	}
+}

--- a/internal/hooks/main_test.go
+++ b/internal/hooks/main_test.go
@@ -4,12 +4,18 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/zzet/gortex/internal/profiles"
 )
 
 // TestMain ensures hook tests never write telemetry to the user's real
 // ~/.cache/gortex/hook-decisions.jsonl. Tests that want to inspect the
 // log redirect it again via t.Setenv to a per-test tmp file.
 func TestMain(m *testing.M) {
+	// Pin the instruction profile so a developer machine that ran
+	// `gortex instructions switch` cannot change hook-tier behavior
+	// in unrelated tests; tier tests stub activeHookTier directly.
+	_ = os.Setenv(profiles.ActiveEnv, profiles.DefaultName)
 	dir, err := os.MkdirTemp("", "gortex-hooks-test")
 	if err == nil {
 		_ = os.Setenv("GORTEX_HOOK_LOG", filepath.Join(dir, "hook-decisions.jsonl"))

--- a/internal/hooks/sessionstart.go
+++ b/internal/hooks/sessionstart.go
@@ -154,7 +154,8 @@ func renderLeanReadiness(cwd string, s *daemon.StatusResponse) string {
 	if !s.Ready {
 		state = "warming up — enforcement partial"
 	}
-	line := fmt.Sprintf("✓ Gortex %s (v%s): %d repo(s), %d nodes.", state, s.Version, len(s.TrackedRepos), totalNodes)
+	line := fmt.Sprintf("✓ Gortex %s (v%s): %d repo(s), %d nodes.",
+		state, strings.TrimPrefix(s.Version, "v"), len(s.TrackedRepos), totalNodes)
 
 	abs := cwd
 	if cwd != "" {

--- a/internal/hooks/sessionstart.go
+++ b/internal/hooks/sessionstart.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/zzet/gortex/internal/daemon"
+	"github.com/zzet/gortex/internal/profiles"
 	"github.com/zzet/gortex/internal/toolref"
 )
 
@@ -120,12 +121,55 @@ func buildSessionStartBriefing(cwd string) string {
 		return sb.String()
 	}
 
-	// Happy path: daemon is reachable.
-	sb.WriteString(renderDaemonReadiness(status))
-	sb.WriteString(renderCwdCoverage(cwd, status))
+	// Happy path: daemon is reachable. The lean hook tier (set by the
+	// active instruction profile) compresses the status prose to one
+	// line; the rule preamble — the positioning cues — survives every
+	// tier, and so does the actionable not-covered warning.
+	if activeHookTier() == profiles.HookTierLean {
+		sb.WriteString(renderLeanReadiness(cwd, status))
+	} else {
+		sb.WriteString(renderDaemonReadiness(status))
+		sb.WriteString(renderCwdCoverage(cwd, status))
+	}
 	sb.WriteString("\n")
 	sb.WriteString(rulePreamble())
 	return sb.String()
+}
+
+// activeHookTier reads the machine's hook-verbosity tier from the
+// active instruction profile. Package var so tests pin a tier without
+// touching machine state.
+var activeHookTier = profiles.ActiveHookTier
+
+// renderLeanReadiness is the one-line status the lean tier emits when
+// the cwd is a tracked repo. The workspace-root and not-covered cases
+// keep their full explanations in every tier — those are actionable
+// warnings, not status prose.
+func renderLeanReadiness(cwd string, s *daemon.StatusResponse) string {
+	var totalNodes int
+	for _, r := range s.TrackedRepos {
+		totalNodes += r.Nodes
+	}
+	state := "ready"
+	if !s.Ready {
+		state = "warming up — enforcement partial"
+	}
+	line := fmt.Sprintf("✓ Gortex %s (v%s): %d repo(s), %d nodes.", state, s.Version, len(s.TrackedRepos), totalNodes)
+
+	abs := cwd
+	if cwd != "" {
+		if a, err := filepath.Abs(cwd); err == nil {
+			abs = a
+		}
+	}
+	if abs != "" {
+		if exact, _ := classifyCwd(abs, s.TrackedRepos); exact != nil {
+			return fmt.Sprintf("%s cwd tracked as `%s` — enforcement active.\n", line, exact.Name)
+		}
+		// Workspace-root and not-covered explanations stay verbatim.
+		return line + "\n\n" + renderCwdCoverage(cwd, s)
+	}
+	return line + "\n"
 }
 
 // renderDaemonReadiness summarises the daemon's overall state in one

--- a/internal/hooks/userpromptsubmit.go
+++ b/internal/hooks/userpromptsubmit.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/zzet/gortex/internal/profiles"
 	"github.com/zzet/gortex/internal/toolref"
 )
 
@@ -92,17 +93,28 @@ func promptQuery(prompt string) string {
 	return ""
 }
 
+// maxInjectedHitsLean is the per-turn cap under the lean hook tier —
+// the block keeps its cues but stops paying for marginal hits.
+const maxInjectedHitsLean = 3
+
 // buildPromptInjection renders the additionalContext block from search hits.
 func buildPromptInjection(hits []grepSymbolHit) string {
 	if len(hits) == 0 {
 		return ""
 	}
-	if len(hits) > maxInjectedHits {
-		hits = hits[:maxInjectedHits]
+	lean := activeHookTier() == profiles.HookTierLean
+	limit := maxInjectedHits
+	if lean {
+		limit = maxInjectedHitsLean
+	}
+	if len(hits) > limit {
+		hits = hits[:limit]
 	}
 	var sb strings.Builder
 	sb.WriteString("## Gortex — relevant indexed symbols for your request\n\n")
-	sb.WriteString("Before reaching for grep/Read, these graph symbols look relevant to what you just asked:\n\n")
+	if !lean {
+		sb.WriteString("Before reaching for grep/Read, these graph symbols look relevant to what you just asked:\n\n")
+	}
 	for _, h := range hits {
 		kind := h.Kind
 		if kind == "" {
@@ -114,8 +126,12 @@ func buildPromptInjection(hits []grepSymbolHit) string {
 			fmt.Fprintf(&sb, "- `%s` (%s) — %s\n", h.Name, kind, h.FilePath)
 		}
 	}
-	sb.WriteString("\nRead any of them with `get_symbol_source`, trace with `find_usages` / `get_callers`, " +
-		"or call `smart_context` for the full working set. These are indexed graph facts — prefer them over grep/Read. " +
-		"Shell only (no MCP tools)? Reach any with `gortex call <tool> --arg k=v` (e.g. `" + toolref.CLIFallback("get_symbol_source") + "`).\n")
+	if lean {
+		sb.WriteString("\nIndexed graph facts — prefer them over grep/Read: `get_symbol_source` to read, `smart_context` for the full working set.\n")
+	} else {
+		sb.WriteString("\nRead any of them with `get_symbol_source`, trace with `find_usages` / `get_callers`, " +
+			"or call `smart_context` for the full working set. These are indexed graph facts — prefer them over grep/Read. " +
+			"Shell only (no MCP tools)? Reach any with `gortex call <tool> --arg k=v` (e.g. `" + toolref.CLIFallback("get_symbol_source") + "`).\n")
+	}
 	return sb.String()
 }

--- a/internal/mcp/instruction_profile_policy_test.go
+++ b/internal/mcp/instruction_profile_policy_test.go
@@ -1,0 +1,102 @@
+package mcp
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/profiles"
+)
+
+// TestMain pins the instruction-profile env override to the default
+// profile for the whole package: a developer machine that ran
+// `gortex instructions switch` must not change the behavior of
+// unrelated internal/mcp tests. Tests that exercise the profile path
+// stub activeInstructionPreset directly.
+func TestMain(m *testing.M) {
+	os.Setenv(profiles.ActiveEnv, profiles.DefaultName)
+	os.Exit(m.Run())
+}
+
+// stubActiveProfilePreset swaps the machine-state reader for the test.
+func stubActiveProfilePreset(t *testing.T, preset string) {
+	t.Helper()
+	prev := activeInstructionPreset
+	activeInstructionPreset = func() string { return preset }
+	t.Cleanup(func() { activeInstructionPreset = prev })
+}
+
+func TestInstructionProfilePolicy_AppliesOnDefaultConfig(t *testing.T) {
+	srv := setupPresetServer(t, ToolPolicyConfig{Preset: "core", Mode: "defer"})
+	stubActiveProfilePreset(t, "localization")
+
+	p := srv.instructionProfilePolicy()
+	require.NotNil(t, p, "shipped-default config must let the active profile refine the surface")
+	require.Equal(t, "localization", p.preset)
+	require.True(t, p.deferMode(), "profile policy inherits the server's defer mode")
+	require.True(t, p.allows("search_symbols"))
+	require.True(t, p.allows("smart_context"))
+	require.False(t, p.allows("edit_file"), "the localization surface is read-only")
+
+	// Session resolution: the profile beats the client-aware default…
+	sp := srv.resolveSessionPolicy("", "", "claude-code")
+	require.NotNil(t, sp)
+	require.Equal(t, "localization", sp.preset)
+
+	// …but a forwarded spec beats the profile.
+	sp = srv.resolveSessionPolicy("edit", "", "claude-code")
+	require.NotNil(t, sp)
+	require.Equal(t, "edit", sp.preset)
+}
+
+func TestInstructionProfilePolicy_DefaultProfileIsNoOp(t *testing.T) {
+	srv := setupPresetServer(t, ToolPolicyConfig{Preset: "core", Mode: "defer"})
+	stubActiveProfilePreset(t, "")
+	require.Nil(t, srv.instructionProfilePolicy(),
+		"the core profile carries no preset and must resolve exactly as before")
+}
+
+func TestInstructionProfilePolicy_OperatorPinWins(t *testing.T) {
+	srv := setupPresetServer(t, ToolPolicyConfig{Preset: "agent", Mode: "defer"})
+	stubActiveProfilePreset(t, "localization")
+	require.Nil(t, srv.instructionProfilePolicy(),
+		"an operator-pinned mcp.tools config must not be overridden by the profile")
+}
+
+func TestOperatorPinnedToolPolicy(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  ToolPolicyConfig
+		want bool
+	}{
+		{"zero config", ToolPolicyConfig{}, false},
+		{"shipped default", ToolPolicyConfig{Preset: "core", Mode: "defer"}, false},
+		{"default alias", ToolPolicyConfig{Preset: "default", Mode: "defer"}, false},
+		{"core in hide mode", ToolPolicyConfig{Preset: "core", Mode: "hide"}, true},
+		{"named preset", ToolPolicyConfig{Preset: "agent", Mode: "defer"}, true},
+		{"allow delta", ToolPolicyConfig{Preset: "core", Mode: "defer", Allow: []string{"analyze"}}, true},
+		{"deny delta", ToolPolicyConfig{Deny: []string{"edit_file"}}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, operatorPinnedToolPolicy(tc.cfg))
+		})
+	}
+}
+
+func TestOperatorPinnedToolPolicy_EnvPins(t *testing.T) {
+	t.Setenv(toolPresetEnv, "nav")
+	require.True(t, operatorPinnedToolPolicy(ToolPolicyConfig{Preset: "core", Mode: "defer"}))
+}
+
+// TestLocalizationPresetMatchesProfileTable is the cross-package
+// no-drift gate: the preset registered here must be exactly the eager
+// list the instruction-profile table declares.
+func TestLocalizationPresetMatchesProfileTable(t *testing.T) {
+	require.Equal(t, profiles.LocalizationEagerTools(), localizationPresetTools)
+	set, denyMutating, known := builtinToolPresetSet("localization")
+	require.True(t, known)
+	require.False(t, denyMutating)
+	require.Equal(t, toToolSet(profiles.LocalizationEagerTools()), set)
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -428,6 +428,11 @@ type Server struct {
 	// toolSurfaceFilter + checkToolGate and in defer mode by the lazy
 	// registry's eager predicate.
 	toolPolicy *toolPolicy
+	// toolPolicyOperatorPinned records whether the global policy came
+	// from a deliberate operator configuration (mcp.tools beyond the
+	// shipped default, or GORTEX_TOOLS) — when true, the active
+	// instruction profile does not adjust session tool surfaces.
+	toolPolicyOperatorPinned bool
 
 	// toolBudgetOnce / toolBudgetCached memoise the project-size-scaled
 	// exploration-call budget appended to navigation tools' descriptions
@@ -1338,7 +1343,9 @@ func NewServer(engine *query.Engine, g graph.Store, idx *indexer.Indexer, watche
 	// eager surface; hide mode is enforced later by toolSurfaceFilter /
 	// checkToolGate. Resolved before the register sweep so every
 	// addTool sees the policy.
-	s.toolPolicy = resolveToolPolicy(toolPolicyBaseFromOptions(opts), logger)
+	toolPolicyBase := toolPolicyBaseFromOptions(opts)
+	s.toolPolicyOperatorPinned = operatorPinnedToolPolicy(toolPolicyBase)
+	s.toolPolicy = resolveToolPolicy(toolPolicyBase, logger)
 	s.lazy = newLazyToolRegistry(lazyEnabledFromEnv() || s.toolPolicy.deferMode())
 	if s.toolPolicy.deferMode() {
 		s.lazy.SetEagerPredicate(s.toolPolicy.allows)

--- a/internal/mcp/tool_catalog.go
+++ b/internal/mcp/tool_catalog.go
@@ -94,6 +94,9 @@ func presetsContaining(name string) []string {
 	if toolSetContains(navPresetTools, name) {
 		presets = append(presets, "nav")
 	}
+	if toolSetContains(localizationPresetTools, name) {
+		presets = append(presets, "localization")
+	}
 	if !daemon.IsMutating(name) {
 		presets = append(presets, "readonly")
 	}

--- a/internal/mcp/tool_presets.go
+++ b/internal/mcp/tool_presets.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/zzet/gortex/internal/daemon"
+	"github.com/zzet/gortex/internal/profiles"
 )
 
 // ToolPolicyConfig is the operator-facing description of a restricted
@@ -142,6 +143,13 @@ var navPresetTools = []string{
 	"get_dependencies", "get_dependents", "get_repo_outline", "graph_stats",
 }
 
+// localizationPresetTools is the eager surface of the `localization`
+// preset — the lean "where is the code that does X" working set. The
+// list lives in internal/profiles (the instruction-profile table) so
+// the tool surface and the localization instructions body render from
+// the same slice and cannot drift.
+var localizationPresetTools = profiles.LocalizationEagerTools()
+
 // builtinToolPresetSet resolves a preset name to its explicit allow-set.
 // A nil set with denyMutating=false is the sentinel for "no explicit
 // restriction" (the full surface); `readonly` carries denyMutating=true
@@ -162,13 +170,15 @@ func builtinToolPresetSet(name string) (set map[string]bool, denyMutating, known
 		return toToolSet(editPresetTools), false, true
 	case "nav", "navigate", "explore":
 		return toToolSet(navPresetTools), false, true
+	case "localization", "locate", "find":
+		return toToolSet(localizationPresetTools), false, true
 	default:
 		return nil, false, false
 	}
 }
 
 // builtinPresetNames lists the recognised preset names for diagnostics.
-var builtinPresetNames = []string{"agent", "core", "full", "readonly", "edit", "nav"}
+var builtinPresetNames = []string{"agent", "core", "full", "readonly", "edit", "nav", "localization"}
 
 // toolPolicy is the resolved, in-memory restriction applied to the tool
 // surface by the lazy registry (defer mode) and toolSurfaceFilter /
@@ -240,6 +250,8 @@ func newToolPolicy(cfg ToolPolicyConfig, logger *zap.Logger) *toolPolicy {
 			label = "core"
 		case "coding-agent":
 			label = "agent"
+		case "locate", "find":
+			label = "localization"
 		}
 	} else {
 		// A typo'd preset fails open to the full surface (never strands
@@ -260,7 +272,7 @@ func newToolPolicy(cfg ToolPolicyConfig, logger *zap.Logger) *toolPolicy {
 		allow:        allow,
 		deny:         deny,
 		active:       active,
-		lean:         label == "agent",
+		lean:         label == "agent" || label == "localization",
 	}
 }
 
@@ -499,10 +511,61 @@ func (s *Server) resolveSessionPolicy(spec, mode, client string) *toolPolicy {
 		}
 		return newToolPolicy(cfg, s.logger)
 	}
+	if p := s.instructionProfilePolicy(); p != nil {
+		return p
+	}
 	if p := s.clientDefaultPolicy(client); p != nil {
 		return p
 	}
 	return nil
+}
+
+// activeInstructionPreset reads the machine's active instruction
+// profile and returns its tool preset ("" when the profile keeps the
+// defaults). Package var so tests can stub the machine state.
+var activeInstructionPreset = profiles.ActiveToolPreset
+
+// instructionProfilePolicy applies the active instruction profile's
+// tool preset to sessions that forwarded no explicit spec. Precedence:
+// a forwarded spec wins (checked by the caller before this), an
+// operator-pinned mcp.tools / GORTEX_TOOLS configuration wins, then
+// the profile, then the client-aware default. The default `core`
+// profile carries no preset, so machines that never ran
+// `gortex instructions switch` resolve exactly as before.
+func (s *Server) instructionProfilePolicy() *toolPolicy {
+	if s == nil || s.toolPolicyOperatorPinned {
+		return nil
+	}
+	preset := activeInstructionPreset()
+	if strings.TrimSpace(preset) == "" {
+		return nil
+	}
+	mode := toolPolicyModeDefer
+	if s.toolPolicy != nil && s.toolPolicy.mode != "" {
+		mode = s.toolPolicy.mode
+	}
+	return newToolPolicy(ToolPolicyConfig{Preset: preset, Mode: mode}, s.logger)
+}
+
+// operatorPinnedToolPolicy reports whether the base tool-policy config
+// expresses a deliberate operator choice rather than the shipped
+// default (`core` preset in defer mode, no deltas) — the active
+// instruction profile only refines the shipped default, never an
+// operator pin. GORTEX_TOOLS / GORTEX_TOOLS_MODE always pin.
+func operatorPinnedToolPolicy(base ToolPolicyConfig) bool {
+	if _, envSet := toolPolicyConfigFromEnv(); envSet {
+		return true
+	}
+	if len(base.Allow) > 0 || len(base.Deny) > 0 {
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(base.Preset)) {
+	case "", "core", "default", "classic":
+		// The shipped default preset. A mode is only a pin when it
+		// deviates from the shipped defer default.
+		return strings.TrimSpace(base.Mode) != "" && normalizeToolMode(base.Mode) != toolPolicyModeDefer
+	}
+	return true
 }
 
 // clientDefaultPolicy returns the preset a known client should get when it

--- a/internal/mcp/tools_list_budget_test.go
+++ b/internal/mcp/tools_list_budget_test.go
@@ -49,6 +49,12 @@ const (
 // this test loudly instead of silently regressing the schema tax.
 const agentPresetByteCeiling = 27000
 
+// localizationPresetByteCeiling is the hard budget for the diet
+// localization preset (the `localization` instruction profile's tool
+// surface). It must stay well under the agent floor — the profile
+// exists to cut the per-turn schema tax.
+const localizationPresetByteCeiling = 20000
+
 // TestToolsListByteCeilings is the permanent measurement gate: it prints the
 // cold tools/list byte cost of every preset and asserts the agent preset
 // stays inside its ceiling while core and full shrink below their pre-diet
@@ -57,14 +63,28 @@ func TestToolsListByteCeilings(t *testing.T) {
 	agentBytes, agentNames := serializeToolsList(t, "agent", "defer")
 	coreBytes, _ := serializeToolsList(t, "core", "defer")
 	fullBytes, _ := serializeToolsList(t, "full", "")
+	locBytes, locNames := serializeToolsList(t, "localization", "defer")
 
 	t.Logf("tools/list byte cost per preset (cold):")
 	t.Logf("  agent  mode=defer tools=%-3d bytes=%d  (ceiling %d)", len(agentNames), agentBytes, agentPresetByteCeiling)
+	t.Logf("  loc    mode=defer tools=%-3d bytes=%d  (ceiling %d)", len(locNames), locBytes, localizationPresetByteCeiling)
 	t.Logf("  core   mode=defer          bytes=%d  (baseline %d)", coreBytes, corePresetBaselineBytes)
 	t.Logf("  full                       bytes=%d  (baseline %d)", fullBytes, fullPresetBaselineBytes)
 
 	require.LessOrEqualf(t, agentBytes, agentPresetByteCeiling,
 		"agent preset cold tools/list is %d bytes, over the %d ceiling", agentBytes, agentPresetByteCeiling)
+	require.LessOrEqualf(t, locBytes, localizationPresetByteCeiling,
+		"localization preset cold tools/list is %d bytes, over the %d ceiling", locBytes, localizationPresetByteCeiling)
+	require.Lessf(t, locBytes, agentBytes,
+		"localization (%d bytes) must stay leaner than the agent floor (%d bytes)", locBytes, agentBytes)
+
+	locSet := map[string]bool{}
+	for _, n := range locNames {
+		locSet[n] = true
+	}
+	require.True(t, locSet["smart_context"], "the one-shot opener must ship eagerly in the localization surface")
+	require.True(t, locSet[LazyToolsSearchName], "tools_search must survive every preset")
+	require.False(t, locSet["edit_file"], "the localization surface is read-only")
 	require.Lessf(t, coreBytes, corePresetBaselineBytes,
 		"core preset must shrink below its pre-diet baseline (%d), got %d", corePresetBaselineBytes, coreBytes)
 	require.Lessf(t, fullBytes, fullPresetBaselineBytes,

--- a/internal/profiles/bodies.go
+++ b/internal/profiles/bodies.go
@@ -1,0 +1,191 @@
+package profiles
+
+import (
+	"fmt"
+	"strings"
+)
+
+// The instruction bodies are composed from the shared sections below —
+// no profile hand-authors its own copy of a section. Body text uses §
+// as a backtick placeholder (bt renders it) so markdown tables stay
+// readable inside Go string literals.
+
+// bt renders § as a backtick.
+func bt(s string) string { return strings.ReplaceAll(s, "§", "`") }
+
+// sectionHeader renders the mandatory-rule opener every profile
+// keeps: the MUST-prefer statement and the deny-hook warning are the
+// two positioning cues that buy tool adoption, so they survive even
+// the lean rendering — lean only condenses the prose around them. The
+// heading doubles as the idempotency sentinel other adapters check
+// (agents.InstructionsSentinel).
+func sectionHeader(lean bool) string {
+	if lean {
+		return bt(`## MANDATORY: Use Gortex MCP tools instead of Read/Grep/Glob
+
+A machine-wide §gortex§ MCP server indexes this code. You MUST prefer graph queries over file reads — PreToolUse hooks deny §Read§ / §Grep§ / §Glob§ on indexed source, and the deny message names the right tool.
+
+`)
+	}
+	return bt(`## MANDATORY: Use Gortex MCP tools instead of Read/Grep/Glob
+
+A Gortex daemon is configured machine-wide via the §gortex§ MCP server. Whenever you operate on indexed source (any repo the daemon tracks — check §gortex daemon status§), you MUST prefer graph queries over file reads. PreToolUse hooks deny §Read§ / §Grep§ / §Glob§ against indexed source — the deny message names the right tool.
+
+`)
+}
+
+// sectionFullRuleTable is the classic nine-row instead-of table used
+// by the core and full profiles.
+var sectionFullRuleTable = bt(`| Instead of...                       | Use...                                   |
+|-------------------------------------|------------------------------------------|
+| §Grep§ / §grep§ / §rg§ for a symbol | §search_symbols§ (BM25 + camelCase-aware) |
+| §Grep§ for references               | §find_usages§ (zero false positives)     |
+| Reading / grepping to find callers  | §get_callers§ / §get_call_chain§         |
+| §Glob§ over source files            | §get_repo_outline§ / §search_symbols§    |
+| §Read§ a file for one symbol        | §get_symbol_source§ (§compress_bodies:true§ for the signature only) |
+| §Read§ to understand a file         | §get_file_summary§ / §get_editing_context§ |
+| §Read§ a non-indexed / raw file     | §read_file§                              |
+| Multiple reads to explore a task    | §smart_context§ (one call)               |
+| §Edit§ / §Write§ source             | §edit_file§ / §write_file§ / §edit_symbol§ / §rename_symbol§ / §batch_edit§ |
+
+`)
+
+// sectionCLIFallback is the shell fallback line. Load-bearing for
+// harnesses that mount no MCP tools — present in every profile.
+var sectionCLIFallback = bt(`**CLI fallback (no MCP):** every tool above is reachable from a shell as §gortex call <tool> --arg k=v§ (e.g. §gortex call read_file --arg path=<file>§) — there is no bare §gortex <tool>§ verb.
+
+`)
+
+// sectionReadDiscipline is the scope-vs-fidelity paragraph.
+var sectionReadDiscipline = bt(`Graph queries *narrow scope*; they do not replace reading the implementation. For the symbol you are about to change or depend on — especially behavior-critical code (migrations, retry / fallback / error-recovery paths, concurrency, compatibility shims) — read the real body with §get_symbol_source§ and do NOT pass §compress_bodies:true§, which elides the branches that carry the risk. §format:"gcx"§ (compact wire, ~27% fewer tokens) and §compress_bodies:true§ (body-eliding) exist on the read / list tools; the parameter legend is in the MCP server instructions.
+
+`)
+
+// sectionMemoryFull is the full memory-workflow section (core / full).
+var sectionMemoryFull = bt(`## MANDATORY: Session + development memory
+
+The graph remembers code; these tools remember **why you made a call**. They are behavior-critical — run each at its trigger, not "optionally":
+
+- **Session start / after a compaction** — call §distill_session§ first: prior top symbols, pinned notes, decisions, recent excerpts. Seed your mental model before reading any file.
+- **Immediately after §smart_context§** — call §surface_memories task:"<task>" symbol_ids:"<top hits>"§: cross-session invariants / gotchas / decisions anchored to your working set. If it returns nothing, don't probe further.
+- **At every decision** — pick an approach, reject an alternative, hit a non-obvious constraint, or commit to an invariant → §save_note tags:"decision" body:"<what+why>"§. Mention symbol IDs (§pkg/foo.go::Bar§) in the body for auto-linking; §pinned:true§ for load-bearing notes.
+- **When you learn a durable fact worth teaching the team** — §store_memory kind:"<invariant|gotcha|convention|decision|constraint|incident>" body:"<what+why>" symbol_ids:"<id>" importance:5§. §save_note§ is the per-session scratchpad; §store_memory§ is the workspace-wide store every future agent inherits. Supersede a stale memory with §supersedes:"<old-id>"§.
+- **Before editing a symbol you've touched before** — §query_notes symbol_id:"<id>"§ / §query_memories symbol_id:"<id>"§ surface prior decisions and "do not change this without …" warnings.
+
+**Save / store:** decisions, non-obvious constraints, invariants, follow-ups, incident learnings, bug reproductions. **Skip:** play-by-play the diff already shows, anything derivable from the graph, content already in CLAUDE.md.
+
+`)
+
+// sectionMemoryLean is the one-paragraph memory trio for the lean
+// profile — the triggers survive, the elaboration moves to the guide.
+var sectionMemoryLean = bt(`**Memory (mandatory):** §distill_session§ at session start; §surface_memories task:"<task>"§ right after §smart_context§; §save_note tags:"decision" body:"<what+why>"§ at every decision; §store_memory§ for durable invariants / gotchas the team should inherit; §query_notes§ / §query_memories§ before re-touching a symbol.
+
+`)
+
+// switchBullet renders the instruction-profile discovery line — the
+// line every profile carries so a switched-down machine can always
+// find its way back. The lean rendering keeps the verb and the
+// next-session caveat, dropping only the roster prose.
+func switchBullet(active string, lean bool) string {
+	if lean {
+		return bt(fmt.Sprintf(`- **Profiles:** active §%s§. Broader guidance: §gortex instructions switch core§ (or §full§; §list§ shows all) — NEW sessions only.
+`, active))
+	}
+	return bt(fmt.Sprintf(`- **Instruction profiles** — this block is the active §%s§ profile. §gortex instructions list§ shows the others (§core§ balanced default · §localization§ lean · §full§ maximum guidance); switch with §gortex instructions switch <name>§ — applies to NEW sessions only (instructions, tools/list, and skills all load at session start).
+`, active))
+}
+
+// sectionDiscovery builds the reference-and-discovery section shared
+// by core and full; surfaceLine describes what ships eagerly.
+func sectionDiscovery(active, surfaceLine string) string {
+	return bt(`## Reference and discovery
+
+- **§gortex://guide§ resource** (or the §gortex guide [topic]§ CLI) is the full reference: LLM-provider matrix, capabilities catalog, analyze / search_ast catalogs, token-economy detail, MCP resources, session-start checklist. Read it on demand — it is not pre-paid here.
+- `) + surfaceLine + bt(`- The SessionStart hook injects daemon status. "daemon is not running" → run §gortex daemon start --detach§; "cwd is not covered by any tracked repo" → graph tools are unavailable there.
+`) + switchBullet(active, false)
+}
+
+var coreSurfaceLine = bt(`**§tools_search§** — the server publishes a lean tool preset eagerly and defers the rest; call §tools_search§ to discover and load any tool by keyword (every tool stays callable by name).
+`)
+
+var fullSurfaceLine = bt(`**§tools_search§** — under this profile the server publishes the full documented dev-cycle preset (~34 workhorse tools) eagerly; the long tail still loads by keyword via §tools_search§ (every tool stays callable by name).
+`)
+
+// coreBody is the balanced default: today's slim policy core plus the
+// profile-switch discovery line.
+func coreBody() string {
+	return sectionHeader(false) +
+		sectionFullRuleTable +
+		sectionCLIFallback +
+		sectionReadDiscipline +
+		sectionMemoryFull +
+		sectionDiscovery("core", coreSurfaceLine)
+}
+
+// fullBody differs from core only in the eager-surface description —
+// the ToolPreset column of the table is what actually widens the
+// surface.
+func fullBody() string {
+	return sectionHeader(false) +
+		sectionFullRuleTable +
+		sectionCLIFallback +
+		sectionReadDiscipline +
+		sectionMemoryFull +
+		sectionDiscovery("full", fullSurfaceLine)
+}
+
+// localizationRow maps an eager tool to its instead-of table row.
+// Tools cued outside the table (the one-shot opener and the liveness
+// check) are listed in localizationNonTableTools; the body test
+// asserts every eager tool is covered by one of the two so the preset
+// and the body cannot drift.
+type localizationRow struct {
+	tool, instead, use string
+}
+
+var localizationRows = []localizationRow{
+	{"search_symbols", "§Grep§ / §rg§ for a symbol", "§search_symbols§ (BM25 + camelCase-aware)"},
+	{"search_text", "§Grep§ for a literal / regex", "§search_text§ (trigram-indexed)"},
+	{"find_usages", "§Grep§ for references", "§find_usages§ (zero false positives)"},
+	{"get_callers", "Reading to find callers", "§get_callers§"},
+	{"find_implementations", "Hunting interface implementors", "§find_implementations§"},
+	{"get_symbol_source", "§Read§ a file for one symbol", "§get_symbol_source§"},
+	{"get_file_summary", "§Read§ to understand a file", "§get_file_summary§"},
+	{"read_file", "§Read§ a non-indexed / raw file", "§read_file§"},
+}
+
+// localizationNonTableTools are eager tools cued in prose rather than
+// table rows.
+var localizationNonTableTools = map[string]bool{
+	"smart_context": true, // the open-with-one-call cue
+	"index_health":  true, // the liveness line in discovery
+}
+
+func localizationTable() string {
+	var sb strings.Builder
+	sb.WriteString("| Instead of...                  | Use...                          |\n")
+	sb.WriteString("|--------------------------------|---------------------------------|\n")
+	for _, r := range localizationRows {
+		fmt.Fprintf(&sb, "| %s | %s |\n", bt(r.instead), bt(r.use))
+	}
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+// localizationBody is the lean profile: every positioning cue (MUST
+// rule, deny warning, one-shot opener, memory triggers, discovery /
+// switch-back path) survives; reference elaboration moves to
+// gortex://guide.
+func localizationBody() string {
+	return sectionHeader(true) +
+		bt(`**Open every localization task with one call:** §smart_context task:"<what you are looking for>"§ — candidate symbols, source, and callers in one shot. Go targeted from its results instead of re-searching.
+
+`) +
+		localizationTable() +
+		bt(`Read the real body (§get_symbol_source§, without §compress_bodies§) before you change or depend on a symbol. **No MCP mounted?** Any tool works from a shell: §gortex call <tool> --arg k=v§.
+
+`) +
+		sectionMemoryLean +
+		bt(`**Discovery:** lean §localization§ profile — the tools above plus §index_health§ (liveness) ship eagerly; anything else loads by name via §tools_search§. Full reference: §gortex://guide§.
+`) + switchBullet("localization", true)
+}

--- a/internal/profiles/bodies.go
+++ b/internal/profiles/bodies.go
@@ -150,6 +150,7 @@ var localizationRows = []localizationRow{
 	{"get_callers", "Reading to find callers", "§get_callers§"},
 	{"find_implementations", "Hunting interface implementors", "§find_implementations§"},
 	{"get_symbol_source", "§Read§ a file for one symbol", "§get_symbol_source§"},
+	{"batch_symbols", "Reading several symbols one by one", "§batch_symbols§ (one call, many bodies)"},
 	{"get_file_summary", "§Read§ to understand a file", "§get_file_summary§"},
 	{"read_file", "§Read§ a non-indexed / raw file", "§read_file§"},
 }

--- a/internal/profiles/profiles.go
+++ b/internal/profiles/profiles.go
@@ -1,0 +1,322 @@
+// Package profiles defines the instruction profiles a machine can run
+// Gortex under: named bundles of (a) an instructions body written to
+// ~/.gortex/instructions/<name>.md and @-included from the agent's
+// rules file, (b) a tool-surface preset for the MCP server, (c) a
+// skills subset for skill-aware agents, and (d) a hook-verbosity tier.
+//
+// The four surfaces are generated from ONE table (Table) so they
+// cannot drift: the localization preset's eager tool list is the same
+// slice the instructions body renders its rule table from, and the
+// hook tier rides on the same Profile row the installer materialises.
+//
+// The package is a leaf: internal/agents (install), internal/mcp
+// (session tool policy), internal/hooks (verbosity) and cmd/gortex
+// (the `gortex instructions` verb) all import it, never the reverse.
+package profiles
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/zzet/gortex/internal/platform"
+)
+
+// HookTier selects how much ambient text the lifecycle hooks inject
+// per session / per turn. Lean keeps every positioning cue (the
+// prefer-graph-tools rule, the deny-hook warning, the tool-name
+// mappings) and trims only status prose around them.
+type HookTier string
+
+const (
+	// HookTierStandard is today's hook output: full daemon readiness,
+	// cwd coverage, rule preamble, prompt-derived symbol injection.
+	HookTierStandard HookTier = "standard"
+	// HookTierLean compresses status blocks to one line and caps the
+	// per-turn prompt injection, keeping the rule cues intact.
+	HookTierLean HookTier = "lean"
+)
+
+// DefaultName is the profile installed and active when the user never
+// ran `gortex instructions switch`.
+const DefaultName = "core"
+
+// ActiveEnv overrides the on-disk active-profile state when set to a
+// known profile name — the seam benchmarks and CI use to pin a profile
+// per process tree without touching the user's machine state.
+const ActiveEnv = "GORTEX_INSTRUCTIONS_PROFILE"
+
+// Profile is one row of the single source-of-truth table.
+type Profile struct {
+	Name    string
+	Summary string
+	// ToolPreset is the MCP tool-surface preset sessions default to
+	// while this profile is active. Empty keeps the server's existing
+	// client-aware defaults (known coding agents get the `agent`
+	// floor, everyone else the server's global preset).
+	ToolPreset string
+	// EagerTools, when non-nil, is the eager allow-set of the preset
+	// named by ToolPreset. internal/mcp builds the preset from this
+	// slice and the instructions body renders its rule rows from it —
+	// one list, two surfaces.
+	EagerTools []string
+	// Skills is the subset of shipped gortex-* skills this profile
+	// keeps installed. Nil means all shipped skills.
+	Skills   []string
+	HookTier HookTier
+
+	body func() string
+}
+
+// localizationEagerTools is the lean "where is the code that does X"
+// surface: orient, search, trace, read. It is the single source for
+// both the `localization` tool preset (internal/mcp) and the rule
+// table in the localization instructions body.
+var localizationEagerTools = []string{
+	// orient
+	"smart_context", "index_health",
+	// search
+	"search_symbols", "search_text",
+	// trace
+	"find_usages", "get_callers", "find_implementations",
+	// read
+	"get_symbol_source", "get_file_summary", "read_file",
+}
+
+// Table returns the profile table. Callers must not mutate the
+// returned slices.
+func Table() []Profile {
+	return []Profile{
+		{
+			Name:     "core",
+			Summary:  "balanced default — full workflow guidance, client-aware tool surface",
+			HookTier: HookTierStandard,
+			body:     coreBody,
+		},
+		{
+			Name:       "localization",
+			Summary:    "lean code-finding surface — minimal ambient, ~12 eager tools",
+			ToolPreset: "localization",
+			EagerTools: localizationEagerTools,
+			Skills:     []string{"gortex-explore", "gortex-guide", "gortex-debug"},
+			HookTier:   HookTierLean,
+			body:       localizationBody,
+		},
+		{
+			Name:       "full",
+			Summary:    "maximum guidance — the whole documented dev-cycle surface eager",
+			ToolPreset: "core",
+			HookTier:   HookTierStandard,
+			body:       fullBody,
+		},
+	}
+}
+
+// Names lists the profile names in table order.
+func Names() []string {
+	t := Table()
+	out := make([]string, len(t))
+	for i, p := range t {
+		out[i] = p.Name
+	}
+	return out
+}
+
+// ByName resolves one profile row.
+func ByName(name string) (Profile, bool) {
+	for _, p := range Table() {
+		if p.Name == name {
+			return p, true
+		}
+	}
+	return Profile{}, false
+}
+
+// LocalizationEagerTools returns the eager allow-set of the
+// localization preset — the slice internal/mcp registers under the
+// preset name so the tool surface and the instructions body cannot
+// drift.
+func LocalizationEagerTools() []string {
+	return append([]string(nil), localizationEagerTools...)
+}
+
+// Body renders the profile's instructions markdown.
+func (p Profile) Body() string {
+	if p.body == nil {
+		return ""
+	}
+	return p.body()
+}
+
+// DefaultDir is where profile files and the active state live:
+// <gortex data dir>/instructions (default ~/.gortex/instructions).
+func DefaultDir() string {
+	return filepath.Join(platform.DataDir(), "instructions")
+}
+
+// ActiveFileName is the file agents @-include. It is always a byte
+// copy of the active profile's <name>.md — never a symlink (Windows
+// parity, and @-include resolution should never depend on link
+// support).
+const ActiveFileName = "active.md"
+
+const stateFileName = "active.json"
+
+type state struct {
+	Name       string `json:"name"`
+	SwitchedAt string `json:"switched_at,omitempty"`
+}
+
+// ActiveName reports which profile is active for dir: the ActiveEnv
+// override when it names a known profile, else the recorded state,
+// else DefaultName. Unknown or unreadable state degrades to
+// DefaultName — a missing file must behave exactly like a machine
+// that never switched.
+func ActiveName(dir string) string {
+	if v := strings.TrimSpace(os.Getenv(ActiveEnv)); v != "" {
+		if _, ok := ByName(v); ok {
+			return v
+		}
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, stateFileName))
+	if err != nil {
+		return DefaultName
+	}
+	var st state
+	if json.Unmarshal(raw, &st) != nil {
+		return DefaultName
+	}
+	if _, ok := ByName(st.Name); !ok {
+		return DefaultName
+	}
+	return st.Name
+}
+
+// Active resolves the active profile row for dir.
+func Active(dir string) Profile {
+	p, _ := ByName(ActiveName(dir))
+	return p
+}
+
+// ActiveToolPreset is the one-call convenience internal/mcp uses when
+// resolving a session's default tool surface.
+func ActiveToolPreset() string {
+	return Active(DefaultDir()).ToolPreset
+}
+
+// ActiveHookTier is the one-call convenience internal/hooks uses.
+func ActiveHookTier() HookTier {
+	return Active(DefaultDir()).HookTier
+}
+
+// Generate materialises every profile's <name>.md under dir and
+// refreshes ActiveFileName to a byte copy of the active profile.
+// Idempotent: unchanged files are not rewritten (no spurious mtime
+// bumps on re-install).
+func Generate(dir string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	for _, p := range Table() {
+		if err := writeIfChanged(filepath.Join(dir, p.Name+".md"), []byte(p.Body())); err != nil {
+			return fmt.Errorf("profile %s: %w", p.Name, err)
+		}
+	}
+	return refreshActiveCopy(dir, Active(dir))
+}
+
+// Switch makes name the active profile: regenerates the profile
+// files, atomically replaces ActiveFileName with a copy of
+// <name>.md, and records the state. It does NOT touch skills or any
+// agent config — the cmd layer orchestrates those so this package
+// stays a leaf. The change applies to NEW sessions only: instructions
+// files, tools/list, and skills are all loaded at session start.
+func Switch(dir, name string) (Profile, error) {
+	p, ok := ByName(name)
+	if !ok {
+		return Profile{}, fmt.Errorf("unknown instruction profile %q (known: %s)", name, strings.Join(Names(), ", "))
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return Profile{}, err
+	}
+	for _, q := range Table() {
+		if err := writeIfChanged(filepath.Join(dir, q.Name+".md"), []byte(q.Body())); err != nil {
+			return Profile{}, fmt.Errorf("profile %s: %w", q.Name, err)
+		}
+	}
+	if err := refreshActiveCopy(dir, p); err != nil {
+		return Profile{}, err
+	}
+	st, err := json.Marshal(state{Name: name, SwitchedAt: time.Now().UTC().Format(time.RFC3339)})
+	if err != nil {
+		return Profile{}, err
+	}
+	if err := atomicWrite(filepath.Join(dir, stateFileName), append(st, '\n')); err != nil {
+		return Profile{}, err
+	}
+	return p, nil
+}
+
+// refreshActiveCopy atomically replaces active.md with p's body.
+func refreshActiveCopy(dir string, p Profile) error {
+	return atomicWrite(filepath.Join(dir, ActiveFileName), []byte(p.Body()))
+}
+
+// writeIfChanged writes content to path unless it is already
+// byte-identical.
+func writeIfChanged(path string, content []byte) error {
+	if existing, err := os.ReadFile(path); err == nil && string(existing) == string(content) {
+		return nil
+	}
+	return atomicWrite(path, content)
+}
+
+// atomicWrite is temp-file + rename in path's directory.
+func atomicWrite(path string, content []byte) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(content); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	if err := os.Chmod(tmpName, 0o644); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	return nil
+}
+
+// Remove deletes the generated instructions directory. Used by
+// uninstall flows; missing dir is not an error.
+func Remove(dir string) error {
+	err := os.RemoveAll(dir)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+// SortedEagerTools is a display helper for `gortex instructions list`.
+func (p Profile) SortedEagerTools() []string {
+	out := append([]string(nil), p.EagerTools...)
+	sort.Strings(out)
+	return out
+}

--- a/internal/profiles/profiles.go
+++ b/internal/profiles/profiles.go
@@ -84,8 +84,11 @@ var localizationEagerTools = []string{
 	"search_symbols", "search_text",
 	// trace
 	"find_usages", "get_callers", "find_implementations",
-	// read
-	"get_symbol_source", "get_file_summary", "read_file",
+	// read — batch_symbols is load-bearing for turn economy: without a
+	// multi-symbol read, follow-ups on a localization neighborhood cost
+	// one turn per symbol (measured +1 median turn on the localization
+	// benchmark when it was left out of this surface).
+	"get_symbol_source", "batch_symbols", "get_file_summary", "read_file",
 }
 
 // Table returns the profile table. Callers must not mutate the

--- a/internal/profiles/profiles_test.go
+++ b/internal/profiles/profiles_test.go
@@ -221,3 +221,52 @@ func TestActiveEnvOverride(t *testing.T) {
 		t.Errorf("unknown env value must fall through to state, got %q", got)
 	}
 }
+
+// Single-home markers: content that relocated to gortex://guide and the
+// schema resources must never re-inflate an instruction body. Mirrors
+// the pre-profiles guard on the CLAUDE.md rule block (the profile file
+// is that block's new home).
+var relocatedContentMarkers = []string{
+	"`local` / `anthropic` / `openai` / `azure` / `ollama` / `claudecli` / `codex` / `copilot` / `cursor` / `opencode` / `gemini` / `bedrock` / `deepseek`", // provider matrix
+	"Tarjan's SCC",                // analyze catalog deep-dive
+	"compact tabular text, lossy", // wire-format deep-dive
+	"k8s_resources",               // analyze kind catalog
+	"error-not-wrapped",           // search_ast detector catalog
+	"gortex://report",             // analyzer rollup roster
+}
+
+// fullPolicyTokens is the policy core the standard-depth profiles must
+// carry — the machine-level single home for the full memory-workflow
+// triggers. The localization profile intentionally keeps only the
+// positioning cues (TestEveryProfileKeepsPositioningCues).
+var fullPolicyTokens = []string{
+	"search_symbols", "find_usages", "get_callers", "get_call_chain",
+	"get_symbol_source", "get_editing_context", "read_file",
+	"smart_context", "edit_file", "rename_symbol", "compress_bodies",
+	"distill_session", "surface_memories", "save_note", "store_memory",
+	"query_notes", "query_memories",
+	"tools_search", "gortex://guide", "gortex daemon start",
+}
+
+func TestBodies_PolicyCoreAndSingleHome(t *testing.T) {
+	for _, name := range []string{"core", "full"} {
+		p, ok := ByName(name)
+		if !ok {
+			t.Fatalf("profile %q missing", name)
+		}
+		body := p.Body()
+		for _, token := range fullPolicyTokens {
+			if !strings.Contains(body, token) {
+				t.Errorf("%s body no longer mentions %q — policy core regression", name, token)
+			}
+		}
+	}
+	for _, p := range Table() {
+		body := p.Body()
+		for _, banned := range relocatedContentMarkers {
+			if strings.Contains(body, banned) {
+				t.Errorf("%s body re-carries relocated content %q — single-home violation", p.Name, banned)
+			}
+		}
+	}
+}

--- a/internal/profiles/profiles_test.go
+++ b/internal/profiles/profiles_test.go
@@ -1,0 +1,223 @@
+package profiles
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Per-profile instruction-body byte ceilings. The body is re-read into
+// the model on every API call of every session (via the @-include), so
+// a ballooning body is a per-turn tax — blowing a ceiling fails loudly
+// instead of silently re-inflating the ambient prefix.
+//
+// core inherits the pre-profiles global-section ceiling (6.5 KiB); full
+// gets slack for its longer surface description only; localization is
+// the diet profile and must stay under 2 KiB (~0.45k tokens).
+var bodyByteCeilings = map[string]int{
+	"core":         6656,
+	"full":         6912,
+	"localization": 2048,
+}
+
+func TestProfileBodyByteCeilings(t *testing.T) {
+	for _, p := range Table() {
+		ceiling, ok := bodyByteCeilings[p.Name]
+		if !ok {
+			t.Errorf("profile %q has no body byte ceiling — add one to bodyByteCeilings", p.Name)
+			continue
+		}
+		got := len(p.Body())
+		t.Logf("profile %-13s body bytes=%d (ceiling %d)", p.Name, got, ceiling)
+		if got > ceiling {
+			t.Errorf("profile %q body is %d bytes, over the %d ceiling", p.Name, got, ceiling)
+		}
+		if got == 0 {
+			t.Errorf("profile %q renders an empty body", p.Name)
+		}
+	}
+}
+
+// positioningCues are the load-bearing fragments EVERY profile must
+// keep, lean ones included: the mandatory-rule sentinel, the deny-hook
+// warning, the one-shot opener, the memory triggers, the discovery
+// path, the CLI fallback, and the switch-back line. Trimming any of
+// these is what costs tool adoption — the diet only ever removes
+// elaboration around them.
+var positioningCues = []string{
+	"## MANDATORY: Use Gortex MCP tools", // idempotency sentinel + the rule itself
+	"MUST prefer graph queries",
+	"deny",
+	"smart_context",
+	"distill_session",
+	"surface_memories",
+	"save_note",
+	"store_memory",
+	"tools_search",
+	"gortex://guide",
+	"gortex call",
+	"gortex instructions switch",
+	"NEW sessions only",
+}
+
+func TestEveryProfileKeepsPositioningCues(t *testing.T) {
+	for _, p := range Table() {
+		body := p.Body()
+		for _, cue := range positioningCues {
+			if !strings.Contains(body, cue) {
+				t.Errorf("profile %q body lost the positioning cue %q", p.Name, cue)
+			}
+		}
+	}
+}
+
+// TestLocalizationEagerToolsAllCued is the no-drift gate between the
+// localization tool preset and the localization instructions body:
+// every eager tool must be documented (table row or prose cue), and
+// every table row must correspond to an eager tool.
+func TestLocalizationEagerToolsAllCued(t *testing.T) {
+	p, ok := ByName("localization")
+	if !ok {
+		t.Fatal("localization profile missing from the table")
+	}
+	body := p.Body()
+	rowTools := map[string]bool{}
+	for _, r := range localizationRows {
+		rowTools[r.tool] = true
+	}
+	for _, tool := range p.EagerTools {
+		if !rowTools[tool] && !localizationNonTableTools[tool] {
+			t.Errorf("eager tool %q has neither a table row nor a prose cue — add one", tool)
+		}
+		if !strings.Contains(body, tool) {
+			t.Errorf("eager tool %q does not appear in the localization body", tool)
+		}
+	}
+	eager := map[string]bool{}
+	for _, tool := range p.EagerTools {
+		eager[tool] = true
+	}
+	for _, r := range localizationRows {
+		if !eager[r.tool] {
+			t.Errorf("table row for %q has no matching eager tool — remove the row or add the tool", r.tool)
+		}
+	}
+	for tool := range localizationNonTableTools {
+		if !eager[tool] {
+			t.Errorf("prose cue for %q has no matching eager tool", tool)
+		}
+	}
+}
+
+func TestGenerateAndSwitch(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := Generate(dir); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	for _, p := range Table() {
+		raw, err := os.ReadFile(filepath.Join(dir, p.Name+".md"))
+		if err != nil {
+			t.Fatalf("profile file %s: %v", p.Name, err)
+		}
+		if string(raw) != p.Body() {
+			t.Errorf("profile file %s.md is not the rendered body", p.Name)
+		}
+	}
+
+	// Before any switch, the active copy is the default profile.
+	active, err := os.ReadFile(filepath.Join(dir, ActiveFileName))
+	if err != nil {
+		t.Fatalf("active.md: %v", err)
+	}
+	def, _ := ByName(DefaultName)
+	if string(active) != def.Body() {
+		t.Error("active.md is not a byte copy of the default profile before any switch")
+	}
+	if got := ActiveName(dir); got != DefaultName {
+		t.Errorf("ActiveName = %q before any switch, want %q", got, DefaultName)
+	}
+
+	// Switch to localization: active.md becomes a byte copy, state
+	// records the name, and it is never a symlink.
+	p, err := Switch(dir, "localization")
+	if err != nil {
+		t.Fatalf("switch: %v", err)
+	}
+	if p.Name != "localization" {
+		t.Errorf("switch returned profile %q", p.Name)
+	}
+	active, err = os.ReadFile(filepath.Join(dir, ActiveFileName))
+	if err != nil {
+		t.Fatalf("active.md after switch: %v", err)
+	}
+	loc, _ := ByName("localization")
+	if string(active) != loc.Body() {
+		t.Error("active.md is not a byte copy of the switched profile")
+	}
+	if fi, err := os.Lstat(filepath.Join(dir, ActiveFileName)); err != nil || fi.Mode()&os.ModeSymlink != 0 {
+		t.Errorf("active.md must be a regular file, got mode %v err %v", fi.Mode(), err)
+	}
+	if got := ActiveName(dir); got != "localization" {
+		t.Errorf("ActiveName = %q after switch, want localization", got)
+	}
+	if Active(dir).HookTier != HookTierLean {
+		t.Error("active profile did not carry the lean hook tier")
+	}
+
+	// Re-generate keeps the switched selection.
+	if err := Generate(dir); err != nil {
+		t.Fatalf("re-generate: %v", err)
+	}
+	active, _ = os.ReadFile(filepath.Join(dir, ActiveFileName))
+	if string(active) != loc.Body() {
+		t.Error("re-generate clobbered the active selection")
+	}
+
+	// Unknown profile is refused and changes nothing.
+	if _, err := Switch(dir, "nope"); err == nil {
+		t.Error("switch to unknown profile must error")
+	}
+	if got := ActiveName(dir); got != "localization" {
+		t.Errorf("failed switch mutated state: ActiveName = %q", got)
+	}
+}
+
+func TestActiveStateDegradesToDefault(t *testing.T) {
+	dir := t.TempDir()
+	// Missing state file.
+	if got := ActiveName(dir); got != DefaultName {
+		t.Errorf("missing state: ActiveName = %q, want %q", got, DefaultName)
+	}
+	// Corrupt state file.
+	if err := os.WriteFile(filepath.Join(dir, stateFileName), []byte("{nope"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := ActiveName(dir); got != DefaultName {
+		t.Errorf("corrupt state: ActiveName = %q, want %q", got, DefaultName)
+	}
+	// Unknown name in state file.
+	if err := os.WriteFile(filepath.Join(dir, stateFileName), []byte(`{"name":"gone"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := ActiveName(dir); got != DefaultName {
+		t.Errorf("unknown state name: ActiveName = %q, want %q", got, DefaultName)
+	}
+}
+
+func TestActiveEnvOverride(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := Switch(dir, "full"); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(ActiveEnv, "localization")
+	if got := ActiveName(dir); got != "localization" {
+		t.Errorf("env override ignored: ActiveName = %q", got)
+	}
+	// Unknown env value falls through to the recorded state.
+	t.Setenv(ActiveEnv, "not-a-profile")
+	if got := ActiveName(dir); got != "full" {
+		t.Errorf("unknown env value must fall through to state, got %q", got)
+	}
+}


### PR DESCRIPTION
## What

Agent sessions pay an ambient prefix on every API call (tool schemas + installed guidance + hook output). This PR makes that surface a first-class, switchable profile instead of a fixed cost:

- **`internal/profiles`**: one table defines each profile's instruction body, MCP tool preset, skills subset, and hook-verbosity tier — all four surfaces generate from the same source so they cannot drift (a no-drift test asserts every eagerly-listed tool is cued in the rendered body).
- **`gortex instructions list|show|switch|regen`**: switching atomically copies the profile body over \`~/.gortex/instructions/active.md\` (never a symlink; asserted). The installed CLAUDE.md section becomes a thin \`@\`-include pointer block — no commented-out alternatives, since inactive text still bills every turn. The switch output states explicitly that changes take effect for new sessions only.
- **\`localization\` profile**: a 13-tool task-focused surface (19.1KB cold tools/list vs the 25.9KB agent preset; 2.0KB body) with lean hook output. The default profile remains \`core\` — machines that never switch see zero behavior change. Preset precedence: forwarded spec > operator pin > profile > client default > server default.
- Per-profile byte-ceiling tests; migration gate rewrites the legacy fat block to the pointer on re-install; skills sync prunes only byte-identical shipped copies.

## Measured (localization benchmark, 28 real tasks)

The lean profile delivered exactly its byte math — per-turn tokens 25.0k → 22.0k — and adoption held at 100% (9/9 spot-check sessions, first-tool 100%). The first lean surface traded the savings back by dropping \`batch_symbols\` (multi-symbol follow-ups cost a turn each; median turns 5.5 → 6.5) — that tool is now part of the surface, and the lesson is recorded in the docs: an ambient diet is bounded by turn count, so every focused profile must keep a multi-symbol read.

## Notes for review

- Positioning cues and the memory-workflow triggers survive in every profile body (they have no other home).
- Non-Claude adapters keep their existing full-body writes; profile-izing those surfaces is follow-up scope.
- After the explore-verb PR merges, the localization profile gains that verb (opener text, eager set, ceiling 2048→2304) — the rebase is mechanical and documented in the session notes.