### PR TITLE
feat(index): index doc-comment summaries for intent search recall

### DIFF
--- a/internal/indexer/doc_index_test.go
+++ b/internal/indexer/doc_index_test.go
@@ -1,0 +1,102 @@
+package indexer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// TestDocSummary_FirstParagraphBounded locks the doc-summary extraction:
+// the leading paragraph is kept, later paragraphs (detail / examples) are
+// dropped, CRLF is normalised, and a runaway single paragraph is bounded.
+func TestDocSummary_FirstParagraphBounded(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"single line", "Union the two sequences.", "Union the two sequences."},
+		{
+			"drops later paragraphs",
+			"Performs matching on the ignore files.\n\n# Examples\n\nlet x = ignore();",
+			"Performs matching on the ignore files.",
+		},
+		{
+			"keeps multi-line first paragraph",
+			"Executes a replacement on the given haystack\nby replacing all matches.\n\nDetail here.",
+			"Executes a replacement on the given haystack\nby replacing all matches.",
+		},
+		{
+			"crlf blank line is a paragraph break",
+			"Summary line.\r\n\r\nRest of doc.",
+			"Summary line.",
+		},
+		{"whitespace trimmed", "  spaced summary  ", "spaced summary"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := docSummary(tc.in); got != tc.want {
+				t.Errorf("docSummary(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDocSummary_RuneBound proves a long single-paragraph doc is bounded to
+// docSummaryMaxRunes so it can't dominate the token bag / dilute the name.
+func TestDocSummary_RuneBound(t *testing.T) {
+	long := strings.Repeat("word ", 500) // ~2500 runes, one paragraph
+	got := docSummary(long)
+	if n := len([]rune(got)); n > docSummaryMaxRunes {
+		t.Fatalf("docSummary bound not applied: %d runes > %d", n, docSummaryMaxRunes)
+	}
+}
+
+// TestSearchIndexFields_IncludesDocSummary is the load-bearing regression
+// guard: a code symbol's doc comment reaches the BM25 document (the
+// task-intent recall fix), while a symbol without a doc indexes exactly as
+// before and a prose (KindDoc) node keeps its section-text path untouched.
+func TestSearchIndexFields_IncludesDocSummary(t *testing.T) {
+	withDoc := &graph.Node{
+		Kind: graph.KindFunction, Name: "union", FilePath: "crates/regex/src/literal.rs",
+		Meta: map[string]any{
+			"signature": "fn union(self, o: Seq) -> Seq",
+			"doc":       "Union the two sequences if the result would be within the configured limit.\n\n# Examples\nlet u = a.union(b);",
+		},
+	}
+	fields := searchIndexFields(withDoc, "")
+	joined := strings.Join(fields, " || ")
+	if !strings.Contains(joined, "Union the two sequences") {
+		t.Errorf("doc summary missing from index fields: %q", joined)
+	}
+	// The example block after the blank line must NOT be indexed.
+	if strings.Contains(joined, "let u = a.union") {
+		t.Errorf("doc detail past the summary leaked into index fields: %q", joined)
+	}
+
+	noDoc := &graph.Node{
+		Kind: graph.KindFunction, Name: "helper", FilePath: "x.rs",
+		Meta: map[string]any{"signature": "fn helper()"},
+	}
+	got := searchIndexFields(noDoc, "")
+	want := []string{"helper", "x.rs", "fn helper()", ""}
+	if len(got) != len(want) {
+		t.Fatalf("no-doc fields len = %d, want %d (%q)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("no-doc field[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+
+	prose := &graph.Node{
+		Kind: graph.KindDoc, Name: "Overview", FilePath: "README.md",
+		Meta: map[string]any{"section_text": "This project searches text."},
+	}
+	pf := searchIndexFields(prose, "")
+	if len(pf) != 3 || pf[2] != "This project searches text." {
+		t.Errorf("KindDoc fields path changed: %q", pf)
+	}
+}

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -493,7 +493,52 @@ func searchIndexFields(n *graph.Node, projectName string) []string {
 		return []string{n.Name, indexedPath, body}
 	}
 	sig, _ := n.Meta["signature"].(string)
-	return []string{n.Name, indexedPath, sig}
+	// A symbol's doc comment is the natural-language statement of what it
+	// does — precisely the vocabulary a task-intent query carries ("union
+	// the two sequences", "performs matching on the ignore files") when it
+	// names no identifier verbatim. The identifier and signature alone
+	// answer name lookups; the doc summary is what lets an intent query
+	// reach the definition at all. Only the leading summary is indexed
+	// (docSummary), so a long doc block's examples and edge-case prose
+	// can't dilute the name/signature tokens under BM25 length
+	// normalisation. Empty doc → empty field, dropped by the caller, so a
+	// symbol with no doc indexes exactly as before.
+	doc, _ := n.Meta["doc"].(string)
+	return []string{n.Name, indexedPath, sig, docSummary(doc)}
+}
+
+// docSummaryMaxRunes bounds how much of a doc comment enters the search
+// document. The leading summary is the highest-signal part; the rest of a
+// long doc — parameter lists, example code blocks, edge-case notes — is
+// lower-signal and, unbounded, would dominate the token bag and dilute the
+// identifier under BM25 length normalisation. The bound keeps the doc's
+// contribution on the order of a signature's. It is a generic document-size
+// budget, independent of any repository or corpus.
+const docSummaryMaxRunes = 280
+
+// docSummary returns the leading summary of a doc comment for the search
+// index: the first paragraph (up to the first blank line), trimmed and
+// bounded to docSummaryMaxRunes. Doc comments across languages put the
+// one-line / one-paragraph summary first and defer detail and examples to
+// later paragraphs, so the first paragraph is the highest-signal slice.
+// Empty in → empty out.
+func docSummary(doc string) string {
+	if doc == "" {
+		return ""
+	}
+	// Normalise CRLF so the blank-line cut is newline-style-agnostic.
+	if strings.Contains(doc, "\r") {
+		doc = strings.ReplaceAll(doc, "\r\n", "\n")
+		doc = strings.ReplaceAll(doc, "\r", "\n")
+	}
+	if i := strings.Index(doc, "\n\n"); i >= 0 {
+		doc = doc[:i]
+	}
+	doc = strings.TrimSpace(doc)
+	if r := []rune(doc); len(r) > docSummaryMaxRunes {
+		doc = strings.TrimSpace(string(r[:docSummaryMaxRunes]))
+	}
+	return doc
 }
 
 // vectorSearcherDelegate is the search.VectorDelegate-shaped


### PR DESCRIPTION
## What

The BM25 search document for a code symbol was `{name, path, signature}` — the doc comment is extracted and stored in node meta but was never indexed. Intent-shaped queries ("where is the code that does X") match a symbol's *description*, which lives exactly there. This adds the doc **summary** (first paragraph, rune-bounded so long docs can't dilute the identifier under BM25 length normalisation) to the search-index fields, flowing through both the FTS and Bleve document builders. Empty doc → no-op. Language-general.

## Measured (fresh index, benchmark-exact search_symbols, limit 10, file-hit@5)

| tier | ripgrep base→fix | gin base→fix |
|---|---|---|
| T1 exact | 90.0 → 90.0 | 93.6 → 93.6 |
| T3 intent | 58.2 → **62.0** | 62.7 → **66.9** |
| all | 79.2 → **80.4** | 80.4 → **81.5** |

Exact-identifier tiers untouched on both a Rust and a Go corpus; intent tier +3.8–4.2pt.

## Tests

`internal/indexer/doc_index_test.go` — summary extraction bounds, empty-doc no-op, field-builder wiring. `go build ./...` and `go test -race` green on the touched packages.