### PR TITLE
fix: daemon memory bloat — speculative-edge flood, whole-graph scan bounds, store hygiene

### DIFF
--- a/cmd/gortex/daemon_compact.go
+++ b/cmd/gortex/daemon_compact.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/platform"
+)
+
+// Guarded one-time store compaction at daemon boot.
+//
+// Row-shedding maintenance (orphan-repo purges, the duplicate-collapse
+// migration, resolver cleanups) returns pages to SQLite's freelist, where new
+// writes reuse them — but only VACUUM returns them to the filesystem, and
+// nothing ran it: a live store carried 4.4 GB of freelist inside a 6.8 GB
+// file. This is not a correctness problem (freelist pages are fully
+// reusable), so the trigger is deliberately conservative: compaction runs
+// only when the dead fraction dominates the file AND is large in absolute
+// terms AND the filesystem can absorb VACUUM's temporary full copy. Anything
+// smaller is left to organic reuse.
+
+// storeCompactor is the optional store capability the boot-time compaction
+// probes for — implemented by the on-disk backend only, so a memory-mode
+// daemon skips the whole feature via the failed type assertion.
+type storeCompactor interface {
+	CompactStats() (freeBytes, totalBytes int64)
+	Compact() error
+	Path() string
+}
+
+const (
+	// compactMinFreeBytes is the absolute floor: below 1 GiB of reclaimable
+	// space a VACUUM (minutes of exclusive I/O on a store this size) costs
+	// more than the disk it returns.
+	compactMinFreeBytes = int64(1) << 30
+)
+
+// shouldCompactStore is the pure trigger predicate: compact only when the
+// freelist is BOTH the majority of the file (> 50% of pages — organic reuse
+// would take a long time to grow back into that much dead space) AND large in
+// absolute terms (> 1 GiB — a small file's majority is still cheap to leave
+// alone), AND the filesystem has room for VACUUM's transient full copy
+// (available > 1.5 × the current file, headroom over the worst case of the
+// rewrite temporarily doubling the footprint). Pure so the policy is
+// table-testable without a store or a filesystem.
+func shouldCompactStore(freeBytes, totalBytes int64, diskAvailBytes uint64) bool {
+	if totalBytes <= 0 || freeBytes <= 0 {
+		return false
+	}
+	if freeBytes*2 <= totalBytes { // freelist must exceed half the pages
+		return false
+	}
+	if freeBytes <= compactMinFreeBytes {
+		return false
+	}
+	need := uint64(totalBytes) + uint64(totalBytes)/2 // total × 1.5
+	return diskAvailBytes > need
+}
+
+// maybeCompactStore probes the store for the compaction capability and runs
+// a one-time VACUUM when shouldCompactStore says the file is mostly dead
+// space. Called from warmupDaemonState right after the orphan-prefix purge
+// (so the purge's freshly-freed pages are measured and reclaimed in the same
+// pass) and before the warmup re-index loop (whose writes would start
+// reusing freelist pages and whose readers would contend with VACUUM's
+// exclusive lock). Every failure path degrades to "skip": freelist pages
+// stay reusable, so a missed compaction costs disk, never correctness.
+func maybeCompactStore(g graph.Store, logger *zap.Logger) {
+	if os.Getenv("GORTEX_SKIP_STORE_COMPACT") == "1" {
+		logger.Debug("daemon: store compaction disabled (GORTEX_SKIP_STORE_COMPACT=1)")
+		return
+	}
+	c, ok := g.(storeCompactor)
+	if !ok {
+		return // memory-mode store: nothing on disk to compact
+	}
+	path := c.Path()
+	if path == "" {
+		return // no file backing — no filesystem to reason about
+	}
+	free, total := c.CompactStats()
+	avail, err := platform.DiskAvailBytes(filepath.Dir(path))
+	if err != nil {
+		// Unknown headroom means the ×1.5 guard cannot hold; VACUUM without it
+		// risks filling the volume mid-rewrite, so skip.
+		logger.Debug("daemon: store compaction skipped — disk headroom unknown",
+			zap.String("path", path), zap.Error(err))
+		return
+	}
+	if !shouldCompactStore(free, total, avail) {
+		logger.Debug("daemon: store compaction not warranted",
+			zap.Int64("reclaimable_bytes", free),
+			zap.Int64("store_bytes", total),
+			zap.Uint64("disk_avail_bytes", avail))
+		return
+	}
+	logger.Info("daemon: one-time store compaction starting — VACUUM may take minutes on a multi-GB store",
+		zap.Int64("reclaimable_bytes", free),
+		zap.Int64("store_bytes", total),
+		zap.Uint64("disk_avail_bytes", avail))
+	start := time.Now()
+	if err := c.Compact(); err != nil {
+		// Non-fatal by design: a failed VACUUM leaves the store exactly as it
+		// was (the freelist remains reusable), so boot continues.
+		logger.Warn("daemon: store compaction failed — continuing boot",
+			zap.Duration("elapsed", time.Since(start)), zap.Error(err))
+		return
+	}
+	_, after := c.CompactStats()
+	logger.Info("daemon: store compaction finished",
+		zap.Duration("elapsed", time.Since(start)),
+		zap.Int64("store_bytes", after),
+		zap.Int64("reclaimed_bytes", total-after))
+}

--- a/cmd/gortex/daemon_compact_test.go
+++ b/cmd/gortex/daemon_compact_test.go
@@ -1,0 +1,56 @@
+package main
+
+import "testing"
+
+// TestShouldCompactStore pins the boot-compaction trigger: all three gates
+// (majority-dead file, absolute reclaimable floor, disk headroom for the
+// VACUUM copy) must hold, and each boundary is exclusive — equality on any
+// gate means "don't". Pure-function table so the policy is exercised without
+// a store or a filesystem.
+func TestShouldCompactStore(t *testing.T) {
+	const (
+		gib = int64(1) << 30
+		tib = uint64(1) << 40
+	)
+	cases := []struct {
+		name  string
+		free  int64
+		total int64
+		avail uint64
+		want  bool
+	}{
+		{name: "all gates hold", free: 2 * gib, total: 3 * gib, avail: tib, want: true},
+		{name: "the observed live store shape (4.4/6.8 GB)", free: 4707074048, total: 7301444403, avail: tib, want: true},
+
+		// Fraction gate: freelist must be a strict MAJORITY of the file.
+		{name: "exactly half free — no", free: 2 * gib, total: 4 * gib, avail: tib, want: false},
+		{name: "just under half free — no", free: 2*gib - 1, total: 4 * gib, avail: tib, want: false},
+		{name: "just over half free — yes", free: 2*gib + 1, total: 4 * gib, avail: tib, want: true},
+
+		// Absolute floor: a small file's majority is still not worth minutes
+		// of exclusive I/O.
+		{name: "90% free but only 900 MiB — no", free: 900 << 20, total: 1 << 30, avail: tib, want: false},
+		{name: "exactly 1 GiB free — no (floor is exclusive)", free: gib, total: gib + 2, avail: tib, want: false},
+
+		// Headroom gate: available disk must strictly exceed total × 1.5,
+		// because VACUUM transiently needs up to a full extra copy.
+		{name: "avail exactly 1.5× — no", free: 2 * gib, total: 3 * gib, avail: uint64(3*gib) + uint64(3*gib)/2, want: false},
+		{name: "avail just over 1.5× — yes", free: 2 * gib, total: 3 * gib, avail: uint64(3*gib) + uint64(3*gib)/2 + 1, want: true},
+		{name: "tight disk — no", free: 2 * gib, total: 3 * gib, avail: uint64(3 * gib), want: false},
+
+		// Degenerate inputs: an unreadable store reports zeros; never fire.
+		{name: "zero stats", free: 0, total: 0, avail: tib, want: false},
+		{name: "zero free", free: 0, total: 4 * gib, avail: tib, want: false},
+		{name: "zero total", free: 2 * gib, total: 0, avail: tib, want: false},
+		{name: "negative total", free: 2 * gib, total: -1, avail: tib, want: false},
+		{name: "zero avail", free: 2 * gib, total: 3 * gib, avail: 0, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldCompactStore(tc.free, tc.total, tc.avail); got != tc.want {
+				t.Errorf("shouldCompactStore(free=%d, total=%d, avail=%d) = %v, want %v",
+					tc.free, tc.total, tc.avail, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/gortex/daemon_state.go
+++ b/cmd/gortex/daemon_state.go
@@ -326,6 +326,20 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 		}
 	}
 
+	// One-time store compaction, guarded (see daemon_compact.go). Placed HERE
+	// on purpose: after the orphan purge, so the pages it just freed are
+	// measured and reclaimed in the same pass; before the warmup re-index loop
+	// and the resolver/enrichment passes, whose writes would reuse freelist
+	// pages mid-measurement and whose readers would contend with VACUUM's
+	// exclusive lock. The socket is already listening (it opens before this
+	// goroutine by design), but at this point in boot the daemon's own
+	// workload is quiet and a rare early client query either finishes first or
+	// makes the VACUUM fail cleanly at busy_timeout — a skip, not a fault.
+	// Running before the socket opened instead would hold the daemon
+	// unreachable for the whole VACUUM, turning a compacting boot into an
+	// apparent hang.
+	maybeCompactStore(state.graph, logger)
+
 	// Register a per-repo resolver-time LSP helper for every
 	// tracked repo BEFORE the parallel warmup loop fires. The
 	// helpers are lazy: language servers are not spawned until the

--- a/cmd/gortex/daemon_state.go
+++ b/cmd/gortex/daemon_state.go
@@ -291,6 +291,41 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 
 	repos := state.configManager.Global().Repos
 
+	// Purge orphaned repo prefixes BEFORE the warmup loop re-registers the
+	// tracked repos, while the store still reflects the prior run's state. A
+	// repo removed from config (or untracked before the sidecar-aware purge
+	// existed) can leave its nodes+edges AND its fifteen repo_prefix-keyed
+	// sidecar tables (file_mtimes, *_enrichment, symbol_fts, content_fts, ...)
+	// behind — a long-lived store then carries thousands of rows for a repo
+	// gone long ago. Key the tracked repos through the same EffectiveRepoPrefix
+	// the warm mtime lookup + LSP-helper registry use (so the comparison
+	// matches what the indexer actually wrote), ask the store for any DISTINCT
+	// prefix outside that set, and PurgeRepo each. '' is never an orphan
+	// (shared global externals / solo data). Capability-probed, so only the
+	// sidecar-bearing on-disk store participates; the in-memory store skips it.
+	if orphaner, ok := state.graph.(interface {
+		OrphanRepoPrefixes(known []string) []string
+	}); ok {
+		if purger, ok := state.graph.(interface{ PurgeRepo(string) error }); ok {
+			known := make([]string, 0, len(repos))
+			for _, entry := range repos {
+				p := strings.TrimPrefix(indexer.EffectiveRepoPrefix(state.configManager, entry), "/")
+				if p != "" {
+					known = append(known, p)
+				}
+			}
+			for _, prefix := range orphaner.OrphanRepoPrefixes(known) {
+				if err := purger.PurgeRepo(prefix); err != nil {
+					logger.Warn("daemon: purging orphaned repo prefix failed",
+						zap.String("prefix", prefix), zap.Error(err))
+					continue
+				}
+				logger.Info("daemon: purged orphaned repo prefix (no tracked repo in config keys under it)",
+					zap.String("prefix", prefix))
+			}
+		}
+	}
+
 	// Register a per-repo resolver-time LSP helper for every
 	// tracked repo BEFORE the parallel warmup loop fires. The
 	// helpers are lazy: language servers are not spawned until the

--- a/internal/analysis/adjacency.go
+++ b/internal/analysis/adjacency.go
@@ -101,7 +101,9 @@ func BuildAdjacencySnapshot(g graph.Store) *AdjacencySnapshot {
 		w  float64
 	}
 	adj := make([][]link, len(ids))
-	for _, e := range g.AllEdges() {
+	// Meta-less kind-scoped scan (see LightEdgeScanner): the CSR build reads only
+	// e.Kind, endpoints, and graph.ProvenanceWeight.
+	for _, e := range graph.EdgesForKindsLight(g, graph.EdgeCalls, graph.EdgeReferences) {
 		if e == nil {
 			continue
 		}

--- a/internal/analysis/hits.go
+++ b/internal/analysis/hits.go
@@ -85,7 +85,9 @@ func ComputeHITS(g graph.Store) *HITSResult {
 	// ranking identical to the unweighted computation.
 	outLinks := make(map[string][]weightedLink)
 	inLinks := make(map[string][]weightedLink)
-	for _, e := range g.AllEdges() {
+	// Meta-less kind-scoped scan (see LightEdgeScanner): only e.Kind, endpoints,
+	// and graph.ProvenanceWeight are read here.
+	for _, e := range graph.EdgesForKindsLight(g, graph.EdgeCalls, graph.EdgeReferences) {
 		if e.Kind != graph.EdgeCalls && e.Kind != graph.EdgeReferences {
 			continue
 		}

--- a/internal/analysis/incremental_communities.go
+++ b/internal/analysis/incremental_communities.go
@@ -78,7 +78,11 @@ type leidenGraph struct {
 // partition.
 func buildLeidenGraph(g graph.Store) *leidenGraph {
 	nodes := g.AllNodes()
-	edges := g.AllEdges()
+	// Meta-less scan (see LightEdgeScanner): the Leiden weighting keys only off
+	// e.Kind (via edgeWeight) and endpoints. No kind argument — edgeWeight scores
+	// ~14 kinds, so the kind set is pushed down here rather than duplicated at the
+	// call, and a meta-less all-kinds scan still drops the per-edge blob decode.
+	edges := graph.EdgesForKindsLight(g)
 
 	symbolNodes := make(map[string]bool, len(nodes))
 	for _, n := range nodes {

--- a/internal/analysis/pagerank.go
+++ b/internal/analysis/pagerank.go
@@ -69,7 +69,10 @@ func ComputePageRank(g graph.Store) *PageRankResult {
 	// identical to the unweighted PageRank.
 	outWeight := make(map[string]float64, n)
 	inLinks := make(map[string][]weightedLink)
-	for _, e := range g.AllEdges() {
+	// Meta-less kind-scoped scan: this pass reads only e.Kind, endpoints, and
+	// graph.ProvenanceWeight — never arbitrary Meta — so it must not pay to decode
+	// every edge's meta blob on a warm-restart whole-graph run.
+	for _, e := range graph.EdgesForKindsLight(g, graph.EdgeCalls, graph.EdgeReferences) {
 		if e.Kind != graph.EdgeCalls && e.Kind != graph.EdgeReferences {
 			continue
 		}

--- a/internal/analysis/processes.go
+++ b/internal/analysis/processes.go
@@ -39,7 +39,9 @@ type ProcessResult struct {
 // DiscoverProcesses finds execution flows by identifying entry points and tracing forward.
 func DiscoverProcesses(g graph.Store) *ProcessResult {
 	nodes := g.AllNodes()
-	edges := g.AllEdges()
+	// Meta-less call-edge scan (see LightEdgeScanner): process discovery reads only
+	// endpoints off each call edge.
+	edges := graph.EdgesForKindsLight(g, graph.EdgeCalls)
 
 	// Build call graph adjacency (forward only)
 	callees := make(map[string][]string) // who does this function call?

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -1178,6 +1178,24 @@ func (g *Graph) EdgesWithUnresolvedTarget() iter.Seq[*Edge] {
 	}
 }
 
+// FnValuePlaceholderEdges implements graph.FnValuePlaceholderScanner: it yields
+// every edge whose To is a fn-value gate placeholder (both the bare and the
+// multi-repo COPY-rewrite forms) — the exact inverse of the exclusion
+// EdgesWithUnresolvedTarget applies. Full edges with Meta intact, since the gate
+// reads Meta["via"] and the captured fn_value_name off each one.
+func (g *Graph) FnValuePlaceholderEdges() iter.Seq[*Edge] {
+	return func(yield func(*Edge) bool) {
+		for _, e := range g.AllEdges() {
+			if e == nil || !IsFnValuePlaceholder(e.To) {
+				continue
+			}
+			if !yield(e) {
+				return
+			}
+		}
+	}
+}
+
 // DeadCodeCandidates is the in-memory reference implementation of
 // DeadCodeCandidator. Iterates the requested node kinds and filters
 // out anything whose incoming-edge bucket contains an allowlist match

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -1196,6 +1196,75 @@ func (g *Graph) FnValuePlaceholderEdges() iter.Seq[*Edge] {
 	}
 }
 
+// AllEdgesLight implements graph.LightEdgeScanner for the in-memory backend.
+// There is no separate meta blob to skip here — the edges are live structs — so
+// it returns the matching edges as-is, Meta present. Honouring the "Meta
+// absent" half of the contract would mean copying every edge to strip Meta,
+// doubling heap for zero benefit; the contract only promises Meta MAY be absent
+// and correct callers read only the promoted fields either way. An empty kinds
+// list returns every edge.
+func (g *Graph) AllEdgesLight(kinds ...EdgeKind) []*Edge {
+	all := g.AllEdges()
+	if len(kinds) == 0 {
+		return all
+	}
+	want := make(map[EdgeKind]struct{}, len(kinds))
+	for _, k := range kinds {
+		if k != "" {
+			want[k] = struct{}{}
+		}
+	}
+	if len(want) == 0 {
+		return nil
+	}
+	out := make([]*Edge, 0, len(all))
+	for _, e := range all {
+		if e != nil {
+			if _, ok := want[e.Kind]; ok {
+				out = append(out, e)
+			}
+		}
+	}
+	return out
+}
+
+// EdgesForKindsLight returns the edges of the given kinds (an empty kinds list
+// means every kind) for a whole-graph scan, preferring the meta-less
+// LightEdgeScanner capability when the store implements it (skips the per-edge
+// Meta decode on disk backends) and otherwise falling back to AllEdges() with a
+// Go-side kind filter. See LightEdgeScanner for the Meta-presence contract:
+// callers must read only the promoted edge fields, never arbitrary Meta.
+func EdgesForKindsLight(g Store, kinds ...EdgeKind) []*Edge {
+	if g == nil {
+		return nil
+	}
+	if sc, ok := g.(LightEdgeScanner); ok {
+		return sc.AllEdgesLight(kinds...)
+	}
+	all := g.AllEdges()
+	if len(kinds) == 0 {
+		return all
+	}
+	want := make(map[EdgeKind]struct{}, len(kinds))
+	for _, k := range kinds {
+		if k != "" {
+			want[k] = struct{}{}
+		}
+	}
+	if len(want) == 0 {
+		return nil
+	}
+	out := make([]*Edge, 0, len(all))
+	for _, e := range all {
+		if e != nil {
+			if _, ok := want[e.Kind]; ok {
+				out = append(out, e)
+			}
+		}
+	}
+	return out
+}
+
 // DeadCodeCandidates is the in-memory reference implementation of
 // DeadCodeCandidator. Iterates the requested node kinds and filters
 // out anything whose incoming-edge bucket contains an allowlist match

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -1151,7 +1151,11 @@ func (g *Graph) FindNodesByNames(names []string) map[string][]*Node {
 // EdgesWithUnresolvedTarget yields every edge whose To has the
 // "unresolved::" prefix — the resolver's main pending-edge filter.
 // In-memory iterates all edges and prefix-checks; disk backends back
-// it with a range scan on a to-keyed index.
+// it with a range scan on a to-keyed index. Gate-owned fn-value
+// placeholders (`unresolved::fnvalue::<name>`) are excluded: the master
+// resolver can never bind them, so surfacing them here only bloats the
+// pending set it reconciles every pass — the fn-value gate scans them
+// itself via EdgesByKind(references).
 func (g *Graph) EdgesWithUnresolvedTarget() iter.Seq[*Edge] {
 	return func(yield func(*Edge) bool) {
 		for _, e := range g.AllEdges() {
@@ -1163,7 +1167,8 @@ func (g *Graph) EdgesWithUnresolvedTarget() iter.Seq[*Edge] {
 			// form that the disk backend's bulk-load rewrite produces. A bare
 			// HasPrefix check silently skipped every prefixed stub, so the
 			// Go resolver never got a second pass at multi-repo edges.
-			if !IsUnresolvedTarget(e.To) {
+			// IsFnValuePlaceholder drops the gate-owned fnvalue sub-namespace.
+			if !IsUnresolvedTarget(e.To) || IsFnValuePlaceholder(e.To) {
 				continue
 			}
 			if !yield(e) {

--- a/internal/graph/store.go
+++ b/internal/graph/store.go
@@ -1070,6 +1070,35 @@ type LightNodeReader interface {
 	GetRepoNodesLight(repoPrefix string) []*Node
 }
 
+// LightEdgeScanner is an optional store capability: a kind-scoped edge scan
+// that skips decoding each row's opaque meta blob. AllEdgesLight returns the
+// edges whose Kind is in kinds (an empty kinds list means every kind), Meta
+// left nil, with only the struct columns plus the promoted edge fields
+// (Origin/Tier/Confidence/ConfidenceLabel/CrossRepo/Line) populated.
+//
+// The warm-restart centrality/analysis passes (PageRank, HITS, adjacency CSR,
+// process discovery, Leiden) each scan the whole call/reference edge set on
+// every run. On a large multi-repo graph AllEdges() materialises millions of
+// Meta maps those passes never read — the per-edge JSON decode + map
+// allocation dominates the scan and inflates warm-restart heap. This capability
+// serves the same rows without that cost.
+//
+// Contract drift, documented once: the ONE Meta key any of these passes still
+// consults sits inside graph.ProvenanceWeight, and only for legacy rows whose
+// Origin column is empty (it falls back to Meta["semantic_source"] to
+// reconstruct the origin). Rows written since the origin-column promotion carry
+// Origin directly, so ProvenanceWeight never touches Meta for them; on a
+// meta-less legacy row it degrades to the default AST-inferred weight. That
+// drift is accepted — the promotion is long-shipped and these passes produce
+// approximate rankings, not exact values. Callers MUST NOT rely on any other
+// Meta content from a light edge. The in-memory backend returns its live edges
+// as-is (Meta present) rather than copy every edge just to strip Meta — the
+// contract only promises Meta MAY be absent, so a correct caller reads only the
+// promoted fields regardless of backend.
+type LightEdgeScanner interface {
+	AllEdgesLight(kinds ...EdgeKind) []*Edge
+}
+
 // FnValuePlaceholderScanner is an optional store capability: a scan restricted
 // to the fn-value gate's placeholder namespace (FnValuePlaceholderMarker, both
 // the bare `unresolved::fnvalue::<name>` and the multi-repo

--- a/internal/graph/store.go
+++ b/internal/graph/store.go
@@ -1070,6 +1070,23 @@ type LightNodeReader interface {
 	GetRepoNodesLight(repoPrefix string) []*Node
 }
 
+// FnValuePlaceholderScanner is an optional store capability: a scan restricted
+// to the fn-value gate's placeholder namespace (FnValuePlaceholderMarker, both
+// the bare `unresolved::fnvalue::<name>` and the multi-repo
+// `<repoPrefix>::unresolved::fnvalue::<name>` COPY-rewrite forms). The gate
+// (resolver.ResolveFnValueCallbacks) is the sole consumer and needs only these
+// placeholders, but its generic path scans the entire EdgeReferences kind —
+// placeholders plus every real reference edge — and Go-filters by Meta["via"].
+// On a large multi-repo graph that materialises millions of reference edges on
+// every whole-graph synthesizer pass just to keep a handful of placeholders.
+// Backends that can range-scan the namespace on a to-keyed index implement
+// this; others are served by the gate's EdgesByKind(references) fallback. Meta
+// IS populated — the gate reads Meta["via"] and the captured fn_value_name off
+// each placeholder.
+type FnValuePlaceholderScanner interface {
+	FnValuePlaceholderEdges() iter.Seq[*Edge]
+}
+
 // EdgePersister is an optional capability backends MAY implement to
 // durably rewrite the mutable attribute columns (Confidence,
 // ConfidenceLabel, Origin, Tier, Meta) of an edge already present in the

--- a/internal/graph/store.go
+++ b/internal/graph/store.go
@@ -172,7 +172,9 @@ type Store interface {
 	// "unresolved::" prefix. The resolver's main loop calls this
 	// once per pass; on disk backends it should range-scan a
 	// to-keyed index over the single contiguous "unresolved::" slice
-	// rather than materialise the whole edges table.
+	// rather than materialise the whole edges table. Gate-owned fn-value
+	// placeholders (FnValuePlaceholderMarker) are excluded — the master
+	// resolver never binds them; the fn-value gate scans them itself by kind.
 	EdgesWithUnresolvedTarget() iter.Seq[*Edge]
 
 	// --- Batched point lookups -------------------------------------

--- a/internal/graph/store_sqlite/closed_store_test.go
+++ b/internal/graph/store_sqlite/closed_store_test.go
@@ -28,3 +28,42 @@ func TestClosedStoreReadsDoNotPanic(t *testing.T) {
 		assert.Empty(t, s.GetFileNodes("p/a.go"))
 	}, "reads after Close must degrade gracefully, not panic")
 }
+
+// TestClosedStoreAggregatorsDoNotPanic pins the aggregator teardown-race sweep:
+// each aggregator read runs its Query error through panicOnFatal, which
+// swallows the "database is closed" race — leaving rows == nil. Every such site
+// must early-return its empty value instead of dereferencing nil rows. The live
+// crash was NodeIDsByKinds (FindHotspots -> RunAnalysis at watch-start) SIGSEGV
+// on nil rows right after a long warmup. Each method is called with non-empty
+// args so it actually reaches the Query rather than an early argument guard.
+func TestClosedStoreAggregatorsDoNotPanic(t *testing.T) {
+	s := openTestStore(t)
+	s.AddNode(&graph.Node{ID: "p/a.go::Foo", Kind: graph.KindType, Name: "Foo", FilePath: "p/a.go"})
+	s.AddNode(&graph.Node{ID: "p/a.go::bar", Kind: graph.KindFunction, Name: "bar", FilePath: "p/a.go"})
+	s.AddEdge(&graph.Edge{From: "p/a.go::bar", To: "p/a.go::Foo", Kind: graph.EdgeReferences, FilePath: "p/a.go", Line: 1})
+	require.NoError(t, s.Close())
+
+	nodeKinds := []graph.NodeKind{graph.KindType, graph.KindFunction}
+	edgeKinds := []graph.EdgeKind{graph.EdgeReferences}
+	ids := []string{"p/a.go::Foo", "p/a.go::bar"}
+	assert.NotPanics(t, func() {
+		assert.Empty(t, s.InEdgeCountsByKind(edgeKinds))
+		assert.Empty(t, s.NodeIDsByKinds(nodeKinds))
+		assert.Empty(t, s.EdgeKindCounts())
+		assert.Empty(t, s.NodeDegreeByKinds(nodeKinds, ""))
+		assert.Empty(t, s.FileImportCounts(nil)) // exercises aggScanImportCounts
+		assert.Empty(t, s.InDegreeForNodes(ids))
+		assert.Empty(t, s.CrossRepoEdgeCounts())
+		assert.Empty(t, s.FileImporters("p/a.go"))
+		assert.Empty(t, s.FileSymbolNamesByPaths([]string{"p/a.go"}, nodeKinds))
+		assert.Empty(t, s.NodeDegreeCounts(ids, edgeKinds))
+		assert.Empty(t, s.NodeFanCounts(ids, edgeKinds, edgeKinds))
+		assert.Empty(t, s.CommunityCrossingsByKind(edgeKinds, map[string]string{"p/a.go::bar": "c0"}))
+		// Iterator-shaped: the Query runs inside the yield closure.
+		n := 0
+		for range s.EdgeAdjacencyForKinds(edgeKinds, nodeKinds) {
+			n++
+		}
+		assert.Zero(t, n)
+	}, "aggregator reads after Close must degrade to empty, not panic")
+}

--- a/internal/graph/store_sqlite/schema_upgrade_test.go
+++ b/internal/graph/store_sqlite/schema_upgrade_test.go
@@ -46,7 +46,8 @@ func TestOpenUpgradesPreDataClassStore(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "store.sqlite")
 
 	// 1. Create a current store and seed a row, then close. A fresh store is
-	//    stamped at the v1 baseline (currentSchemaVersion == 1).
+	//    stamped at the current schema version; step 2 knocks it back to the v1
+	//    baseline to simulate a store written before data_class existed.
 	s, err := Open(path)
 	require.NoError(t, err)
 	s.AddNode(&graph.Node{ID: "old1", Kind: graph.KindFunction, Name: "Legacy", FilePath: "f.go", RepoPrefix: "r"})
@@ -58,6 +59,12 @@ func TestOpenUpgradesPreDataClassStore(t *testing.T) {
 		_, err := db.Exec(`ALTER TABLE nodes DROP COLUMN data_class`)
 		require.NoError(t, err, "simulate a pre-data_class store")
 		require.False(t, hasNodeColumn(t, db, "data_class"), "data_class must be absent before the upgrade")
+
+		// A fresh Open stamps the current schema version; knock it back to the v1
+		// baseline so this genuinely simulates a pre-data_class store and the
+		// reopen exercises the in-place upgrade arm rather than a no-op.
+		_, err = db.Exec(`PRAGMA user_version = 1`)
+		require.NoError(t, err, "reset to the v1 baseline")
 
 		var v int
 		require.NoError(t, db.QueryRow(`PRAGMA user_version`).Scan(&v))

--- a/internal/graph/store_sqlite/schema_version.go
+++ b/internal/graph/store_sqlite/schema_version.go
@@ -32,7 +32,7 @@ import (
 // index changes in a way an old on-disk DB would not already have, and append a
 // matching schemaMigrations entry describing how to bring an older store
 // forward (in place, or by rebuild).
-const currentSchemaVersion = 1
+const currentSchemaVersion = 2
 
 // schemaMigration is one forward step. Exactly one strategy applies:
 //   - rebuild=true: the change introduces structure/data that can only come
@@ -49,12 +49,41 @@ type schemaMigration struct {
 	rebuild bool
 }
 
-// schemaMigrations is the ordered, forward-only registry. It is intentionally
-// empty at version 1: a v1 store is reconciled entirely by schemaSQL's
+// schemaMigrations is the ordered, forward-only registry. Version 1 is the
+// implicit baseline (no entry): a v1 store is reconciled entirely by schemaSQL's
 // idempotent CREATE ... IF NOT EXISTS plus ensureNodeColumns, so any
 // pre-versioning database baseline-stamps to v1 without a rebuild. Append
 // entries for version 2 and up as the schema evolves.
-var schemaMigrations []schemaMigration
+var schemaMigrations = []schemaMigration{
+	{version: 2, name: "dedupe fn-value placeholder edges", inPlace: dedupeFnValuePlaceholderEdges},
+}
+
+// dedupeFnValuePlaceholderEdges collapses duplicate function-as-value gate
+// placeholder edges (graph.FnValuePlaceholderMarker, `unresolved::fnvalue::
+// <name>`) to one row per (from_id, to_id), keeping the MIN(id) survivor. The
+// capture path now dedups per (from, name) before it emits, but stores written
+// earlier accumulated one placeholder per call site — a live store held
+// millions — and EdgesWithUnresolvedTarget plus the resolver's terminal
+// reconcile materialised every one on each warm restart, the dominant warmup
+// heap transient this step drains. The keep set is small (tens of thousands of
+// distinct pairs), so the NOT IN materialisation is cheap; the ph filter rides
+// the edges_by_to(to_id) range for the bare form and the is_unresolved index for
+// the multi-repo infix form. Idempotent: a second run finds no duplicates. Freed
+// pages return to the freelist and are reused by later writes; the file itself
+// shrinks only under a manual VACUUM, deliberately out of scope for a derived
+// cache that reclaims the space on its own.
+func dedupeFnValuePlaceholderEdges(tx *sql.Tx) error {
+	_, err := tx.Exec(`
+WITH ph AS (
+    SELECT id, from_id, to_id FROM edges
+    WHERE (to_id >= 'unresolved::fnvalue::' AND to_id < 'unresolved::fnvalue:;')
+       OR (is_unresolved = 1 AND to_id LIKE '%::unresolved::fnvalue::%')
+), keep AS (
+    SELECT MIN(id) AS id FROM ph GROUP BY from_id, to_id
+)
+DELETE FROM edges WHERE id IN (SELECT id FROM ph) AND id NOT IN (SELECT id FROM keep)`)
+	return err
+}
 
 // schemaPlan is the decision planSchemaMigration derives from the stored
 // PRAGMA user_version. It mutates nothing on its own.
@@ -77,15 +106,25 @@ func planSchemaMigrationWith(stored, current int, migrations []schemaMigration) 
 		// have changed under us. For a cache the safe move is to rebuild.
 		return schemaPlan{wipe: true, stamp: true}
 	case stored == 0:
-		// Fresh DB, or a pre-versioning store of unknown shape. When nothing is
-		// registered above the baseline, schemaSQL + ensureNodeColumns reconcile
-		// it to the current shape, so stamp it. Once any later migration exists,
-		// a store that skipped the versioning-introduction release could be
-		// missing migration-introduced structure, so rebuild instead.
-		if len(pendingBetween(0, current, migrations)) == 0 {
+		// Fresh DB, or a pre-versioning store of unknown shape. schemaSQL's
+		// idempotent CREATE ... IF NOT EXISTS plus ensureNodeColumns /
+		// ensureEdgeColumns reconcile the base shape either way, so a stored==0
+		// store needs a wipe only when a pending step is a REBUILD whose data can
+		// only come from re-indexing source. With nothing pending, stamp; with
+		// only in-place steps pending, run them and stamp — an in-place step is
+		// idempotent and mechanically derivable, so it upgrades a pre-versioning
+		// store in place (preserving its rows) exactly as it upgrades a known
+		// prior version. Wiping a stored==0 store on any migration instead would
+		// force every non-daemon Open (tests, read-only tools) to pass WithRebuild
+		// the moment the first migration ships.
+		pending := pendingBetween(0, current, migrations)
+		if len(pending) == 0 {
 			return schemaPlan{stamp: true}
 		}
-		return schemaPlan{wipe: true, stamp: true}
+		if anyRebuild(pending) {
+			return schemaPlan{wipe: true, stamp: true}
+		}
+		return schemaPlan{inPlace: pending, stamp: true}
 	default: // 0 < stored < current: a known prior version
 		pending := pendingBetween(stored, current, migrations)
 		if anyRebuild(pending) {

--- a/internal/graph/store_sqlite/schema_version_test.go
+++ b/internal/graph/store_sqlite/schema_version_test.go
@@ -175,7 +175,8 @@ func TestPlanSchemaMigration(t *testing.T) {
 		{"up to date", 1, 1, nil, false, false, 0},
 		{"fresh at v1 baseline-stamps", 0, 1, nil, false, true, 0},
 		{"newer DB rebuilds", 2, 1, nil, true, true, 0},
-		{"v0 skipping a later migration rebuilds", 0, 2, []schemaMigration{inPlace}, true, true, 0},
+		{"v0 with only in-place pending upgrades in place, no wipe", 0, 2, []schemaMigration{inPlace}, false, true, 1},
+		{"v0 with a pending rebuild wipes", 0, 2, []schemaMigration{rebuild}, true, true, 0},
 		{"v1->v2 in-place", 1, 2, []schemaMigration{inPlace}, false, true, 1},
 		{"v1->v2 rebuild", 1, 2, []schemaMigration{rebuild}, true, true, 0},
 	}
@@ -291,7 +292,9 @@ func TestOpenAtCurrentVersionIsNoOp(t *testing.T) {
 func TestOpenWithInPlaceMigration(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "store.sqlite")
 
-	// Create a v1 store with a row, then close.
+	// Create a store with a row, then knock it back to the v1 baseline so the
+	// openWith below drives the v1->v2 in-place arm (a fresh Open now stamps the
+	// current version, which is >= 2).
 	s, err := Open(path)
 	if err != nil {
 		t.Fatalf("first open: %v", err)
@@ -302,6 +305,11 @@ func TestOpenWithInPlaceMigration(t *testing.T) {
 	if err := s.Close(); err != nil {
 		t.Fatalf("close: %v", err)
 	}
+	withRawDB(t, path, func(db *sql.DB) {
+		if _, err := db.Exec(`PRAGMA user_version = 1`); err != nil {
+			t.Fatalf("reset to v1 baseline: %v", err)
+		}
+	})
 
 	// An in-place v2 step that depends on the base schema (an index on a
 	// nodes column) — proving it runs after schemaSQL/ensureNodeColumns.
@@ -340,13 +348,20 @@ func TestOpenWithInPlaceMigration(t *testing.T) {
 // retries the upgrade rather than treating it as done.
 func TestOpenWithInPlaceFailureDoesNotStamp(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "store.sqlite")
-	s, err := Open(path) // v1 store
+	s, err := Open(path)
 	if err != nil {
 		t.Fatalf("first open: %v", err)
 	}
 	if err := s.Close(); err != nil {
 		t.Fatalf("close: %v", err)
 	}
+	// A fresh Open now stamps the current version (>= 2); knock it back to the
+	// v1 baseline so openWith drives the v1->v2 arm and the failing step runs.
+	withRawDB(t, path, func(db *sql.DB) {
+		if _, err := db.Exec(`PRAGMA user_version = 1`); err != nil {
+			t.Fatalf("reset to v1 baseline: %v", err)
+		}
+	})
 
 	boom := schemaMigration{version: 2, name: "boom", inPlace: func(*sql.Tx) error {
 		return sql.ErrConnDone
@@ -437,5 +452,94 @@ func TestSchemaMigrationsWellFormed(t *testing.T) {
 		if err := validateSchemaMigrations(c.current, c.migs); err == nil {
 			t.Errorf("%s: expected a validation error, got nil", c.name)
 		}
+	}
+}
+
+// TestOpenDedupesFnValuePlaceholders drives the shipped v2 migration through the
+// real Open composition: a store knocked back to the v1 baseline with duplicate
+// fn-value placeholder edges is deduped in place on reopen — one survivor per
+// (from_id, to_id), the MIN(id) row kept — while a distinct placeholder, a
+// resolved edge, and an ordinary unresolved stub are untouched, and the version
+// stamps to current. Covers both the bare and the multi-repo COPY-rewrite form.
+func TestOpenDedupesFnValuePlaceholders(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "store.sqlite")
+
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+	// Seed edges by explicit id so the MIN(id) survivors are predictable. The
+	// is_unresolved column is generated, so it is omitted from the INSERT.
+	ins := `INSERT INTO edges (id, from_id, to_id, kind, file_path, line) VALUES (?,?,?,?,?,?)`
+	seed := []struct {
+		id       int
+		from, to string
+		kind     string
+		line     int
+	}{
+		// Duplicate bare placeholders: same (from,to), distinct lines. Keep id 1.
+		{1, "a", "unresolved::fnvalue::handler", "references", 10},
+		{2, "a", "unresolved::fnvalue::handler", "references", 20},
+		{3, "a", "unresolved::fnvalue::handler", "references", 30},
+		// A distinct placeholder (different name) — must survive untouched.
+		{4, "a", "unresolved::fnvalue::other", "references", 10},
+		// Duplicate multi-repo COPY-rewrite placeholders — exercises the
+		// is_unresolved infix branch of the migration. Keep id 5.
+		{5, "b", "r::unresolved::fnvalue::handler", "references", 10},
+		{6, "b", "r::unresolved::fnvalue::handler", "references", 20},
+		// A resolved edge and an ordinary unresolved stub — never touched.
+		{7, "a", "b", "calls", 1},
+		{8, "a", "unresolved::Foo", "calls", 1},
+	}
+	for _, r := range seed {
+		if _, err := s.db.Exec(ins, r.id, r.from, r.to, r.kind, "f.go", r.line); err != nil {
+			t.Fatalf("seed edge %d: %v", r.id, err)
+		}
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	// Knock the store back to the v1 baseline so the reopen runs the v2 dedup.
+	withRawDB(t, path, func(db *sql.DB) {
+		if _, err := db.Exec(`PRAGMA user_version = 1`); err != nil {
+			t.Fatalf("reset to v1 baseline: %v", err)
+		}
+	})
+
+	s2, err := Open(path)
+	if err != nil {
+		t.Fatalf("reopen for dedup: %v", err)
+	}
+	defer s2.Close()
+
+	if v, _ := readUserVersion(s2.db); v != currentSchemaVersion {
+		t.Fatalf("user_version after dedup = %d, want %d", v, currentSchemaVersion)
+	}
+
+	present := func(id int) bool {
+		var n int
+		if err := s2.db.QueryRow(`SELECT COUNT(*) FROM edges WHERE id = ?`, id).Scan(&n); err != nil {
+			t.Fatalf("count id %d: %v", id, err)
+		}
+		return n == 1
+	}
+	// Bare-form dedup keeps the MIN(id) survivor and drops the rest.
+	if !present(1) || present(2) || present(3) {
+		t.Fatalf("bare dedup wrong: want keep 1 / drop 2,3; got 1=%v 2=%v 3=%v", present(1), present(2), present(3))
+	}
+	// A distinct placeholder pair survives.
+	if !present(4) {
+		t.Fatal("distinct fn-value placeholder (id 4) was wrongly deleted")
+	}
+	// Multi-repo infix dedup keeps the MIN(id) survivor and drops the rest.
+	if !present(5) || present(6) {
+		t.Fatalf("multi-repo dedup wrong: want keep 5 / drop 6; got 5=%v 6=%v", present(5), present(6))
+	}
+	// A resolved edge and an ordinary unresolved stub must be untouched.
+	if !present(7) {
+		t.Fatal("resolved edge (id 7) must survive the placeholder dedup")
+	}
+	if !present(8) {
+		t.Fatal("ordinary unresolved stub (id 8) must survive the placeholder dedup")
 	}
 }

--- a/internal/graph/store_sqlite/store.go
+++ b/internal/graph/store_sqlite/store.go
@@ -1836,11 +1836,21 @@ func (s *Store) NodesByKind(kind graph.NodeKind) iter.Seq[*graph.Node] {
 // equivalent to_id-based OR query on a real 26-repo store (7.96s -> 2.95s for
 // the same 847,684-row result) because the boolean index's bookmark lookups
 // land in ascending rowid order, unlike a to_id-ordered index's.
+//
+// Gate-owned fn-value placeholders (graph.FnValuePlaceholderMarker,
+// `unresolved::fnvalue::<name>`) are excluded on top of is_unresolved: the
+// master resolver can never bind them, so they are pure pending-set bloat here
+// (a live store held millions). The bare form is dropped by the range predicate
+// — which rides edges_by_to(to_id) — using the ':;' range end from
+// isUnresolvedColumnDDL's idiom (';' == ':'+1); the multi-repo COPY-rewrite form
+// is dropped by the NOT LIKE, matching IsFnValuePlaceholder's infix shape.
 func (s *Store) EdgesWithUnresolvedTarget() iter.Seq[*graph.Edge] {
 	return func(yield func(*graph.Edge) bool) {
 		out := s.queryEdgesSQL(`
 SELECT from_id, to_id, kind, file_path, line, confidence, confidence_label, origin, tier, cross_repo, meta, resolve_terminal, resolve_terminal_reason
-FROM edges WHERE is_unresolved = 1`)
+FROM edges WHERE is_unresolved = 1
+  AND NOT (to_id >= 'unresolved::fnvalue::' AND to_id < 'unresolved::fnvalue:;')
+  AND to_id NOT LIKE '%::unresolved::fnvalue::%'`)
 		for _, e := range out {
 			if !yield(e) {
 				return

--- a/internal/graph/store_sqlite/store.go
+++ b/internal/graph/store_sqlite/store.go
@@ -343,9 +343,12 @@ func openWith(path string, current int, migrations []schemaMigration, allowRebui
 		return nil, fmt.Errorf("sqlite fts rowid backfill: %w", err)
 	}
 
-	// Apply any in-place migration steps (none on a fresh, baseline, or wiped
-	// DB), then stamp the current schema version. After a wipe the store is
-	// empty and the daemon's normal indexing repopulates it.
+	// Apply any in-place migration steps, then stamp the current schema version.
+	// Fresh and pre-versioning (stored==0) stores run the in-place steps too —
+	// they are idempotent and no-op on an empty or already-clean store — so the
+	// first in-place migration ships without forcing every non-daemon Open to
+	// pass WithRebuild. A wipe plan carries no in-place steps, and after a wipe
+	// the store is empty and the daemon's normal indexing repopulates it.
 	if plan.stamp {
 		if err := applyInPlaceMigrations(db, plan.inPlace); err != nil {
 			_ = db.Close()

--- a/internal/graph/store_sqlite/store.go
+++ b/internal/graph/store_sqlite/store.go
@@ -1756,6 +1756,14 @@ func (s *Store) AllRepoMemoryEstimates() map[string]graph.RepoMemoryEstimate {
 // callers stay quiet. The graph.Store interface deliberately does not
 // surface errors -- it mirrors the in-memory store's "everything
 // succeeds" contract -- so a fatal storage failure cannot be ignored.
+//
+// Caller contract: on a teardown-race error panicOnFatal RETURNS rather than
+// panicking, so a caller that keeps using the query result after it returns
+// MUST nil-check first. `rows, err := db.Query(...); panicOnFatal(err)` leaves
+// rows == nil on a swallowed error, and the subsequent rows.Close() /
+// rows.Next() would SIGSEGV — the aggregator reads early-return their empty
+// value on nil rows for exactly this reason. In one line: fatal panics; a
+// teardown-race read returns empty.
 func panicOnFatal(err error) {
 	if err == nil {
 		return

--- a/internal/graph/store_sqlite/store.go
+++ b/internal/graph/store_sqlite/store.go
@@ -541,7 +541,9 @@ func (s *Store) prepare() error {
 		`INSERT OR IGNORE INTO edges (`+edgeCols+`) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)`)
 	prep(&s.stmtOutEdges,
 		`SELECT `+edgeCols+` FROM edges WHERE from_id = ?`)
-	const edgeColsLight = `from_id, to_id, kind, file_path, line, confidence, confidence_label, origin, tier, cross_repo`
+	// edgeColsLight is the package-level meta-less projection (store_light_edges.go),
+	// shared with AllEdgesLight so this prepared statement and the whole-graph scan
+	// can never drift apart.
 	prep(&s.stmtOutEdgesLight,
 		`SELECT `+edgeColsLight+` FROM edges WHERE from_id = ?`)
 	prep(&s.stmtInEdges,

--- a/internal/graph/store_sqlite/store_aggregators.go
+++ b/internal/graph/store_sqlite/store_aggregators.go
@@ -83,6 +83,10 @@ func (s *Store) InEdgeCountsByKind(kinds []graph.EdgeKind) map[string]int {
 	q := `SELECT to_id, COUNT(*) FROM edges WHERE kind IN (` + inPlaceholders(len(args)) + `) GROUP BY to_id`
 	rows, err := s.db.Query(q, args...)
 	panicOnFatal(err)
+	if rows == nil {
+		// swallowed teardown-race error: read returns empty (see panicOnFatal)
+		return nil
+	}
 	defer rows.Close()
 	out := make(map[string]int)
 	for rows.Next() {
@@ -105,6 +109,10 @@ func (s *Store) NodeIDsByKinds(kinds []graph.NodeKind) []string {
 	q := `SELECT id FROM nodes WHERE kind IN (` + inPlaceholders(len(args)) + `) ORDER BY id`
 	rows, err := s.db.Query(q, args...)
 	panicOnFatal(err)
+	if rows == nil {
+		// swallowed teardown-race error: read returns empty (see panicOnFatal)
+		return nil
+	}
 	defer rows.Close()
 	var out []string
 	for rows.Next() {
@@ -121,6 +129,10 @@ func (s *Store) NodeIDsByKinds(kinds []graph.NodeKind) []string {
 func (s *Store) EdgeKindCounts() map[graph.EdgeKind]int {
 	rows, err := s.db.Query(`SELECT kind, COUNT(*) FROM edges GROUP BY kind`)
 	panicOnFatal(err)
+	if rows == nil {
+		// swallowed teardown-race error: read returns empty (see panicOnFatal)
+		return nil
+	}
 	defer rows.Close()
 	out := make(map[graph.EdgeKind]int)
 	for rows.Next() {
@@ -154,6 +166,10 @@ func (s *Store) NodeDegreeByKinds(kinds []graph.NodeKind, pathPrefix string) []g
 	q += ` ORDER BY n.id`
 	rows, err := s.db.Query(q, args...)
 	panicOnFatal(err)
+	if rows == nil {
+		// swallowed teardown-race error: read returns empty (see panicOnFatal)
+		return nil
+	}
 	defer rows.Close()
 	var out []graph.NodeDegreeRow
 	for rows.Next() {
@@ -227,6 +243,10 @@ func (s *Store) FileImportCounts(scope []string) []graph.FileImportCountRow {
 func aggScanImportCounts(s *Store, q string, args []any, acc map[string]int) {
 	rows, err := s.db.Query(q, args...)
 	panicOnFatal(err)
+	if rows == nil {
+		// swallowed teardown-race error: read returns empty (see panicOnFatal)
+		return
+	}
 	defer rows.Close()
 	for rows.Next() {
 		var path string
@@ -252,6 +272,10 @@ func (s *Store) InDegreeForNodes(ids []string) map[string]int {
 			inPlaceholders(len(chunk)) + `) GROUP BY to_id`
 		rows, err := s.db.Query(q, toAnyArgs(chunk)...)
 		panicOnFatal(err)
+		if rows == nil {
+			// swallowed teardown-race error: read returns empty (see panicOnFatal)
+			return out
+		}
 		for rows.Next() {
 			var id string
 			var n int
@@ -277,6 +301,10 @@ func (s *Store) CrossRepoEdgeCounts() []graph.CrossRepoEdgeRow {
 		GROUP BY e.kind, nf.repo_prefix, nt.repo_prefix`
 	rows, err := s.db.Query(q)
 	panicOnFatal(err)
+	if rows == nil {
+		// swallowed teardown-race error: read returns empty (see panicOnFatal)
+		return nil
+	}
 	defer rows.Close()
 	// Aggregate keyed by the edge's OWN kind (cross_repo_*), NOT the base.
 	// BaseKindForCrossRepo is used only as the recogniser that decides
@@ -322,6 +350,10 @@ func (s *Store) FileImporters(filePath string) []graph.FileImporterRow {
 		ORDER BY nf.file_path`
 	rows, err := s.db.Query(q, string(graph.EdgeImports), filePath, filePath)
 	panicOnFatal(err)
+	if rows == nil {
+		// swallowed teardown-race error: read returns empty (see panicOnFatal)
+		return nil
+	}
 	defer rows.Close()
 	var out []graph.FileImporterRow
 	for rows.Next() {
@@ -353,6 +385,10 @@ func (s *Store) FileSymbolNamesByPaths(paths []string, kinds []graph.NodeKind) [
 			inPlaceholders(len(chunk)) + `) AND kind IN (` + inPlaceholders(len(kindArgs)) + `)`
 		rows, err := s.db.Query(q, args...)
 		panicOnFatal(err)
+		if rows == nil {
+			// swallowed teardown-race error: read returns empty (see panicOnFatal)
+			return out
+		}
 		for rows.Next() {
 			var r graph.FileSymbolNameRow
 			panicOnFatal(rows.Scan(&r.FilePath, &r.Name))
@@ -444,6 +480,10 @@ func (s *Store) EdgeAdjacencyForKinds(edgeKinds []graph.EdgeKind, nodeKinds []gr
 			AND nt.kind IN (` + inPlaceholders(len(nArgs)) + `)`
 		rows, err := s.db.Query(q, args...)
 		panicOnFatal(err)
+		if rows == nil {
+			// swallowed teardown-race error: read returns empty (see panicOnFatal)
+			return
+		}
 		defer rows.Close()
 		for rows.Next() {
 			var from, to string
@@ -487,6 +527,10 @@ func (s *Store) NodeDegreeCounts(ids []string, usageKinds []graph.EdgeKind) []gr
 		args := append(append([]any(nil), usageInline...), toAnyArgs(chunk)...)
 		rows, err := s.db.Query(q, args...)
 		panicOnFatal(err)
+		if rows == nil {
+			// swallowed teardown-race error: read returns empty (see panicOnFatal)
+			return out
+		}
 		for rows.Next() {
 			var r graph.NodeDegreeRow
 			panicOnFatal(rows.Scan(&r.NodeID, &r.InCount, &r.OutCount, &r.UsageInCount))
@@ -537,6 +581,10 @@ func (s *Store) NodeFanCounts(ids []string, fanInKinds, fanOutKinds []graph.Edge
 		args = append(args, toAnyArgs(chunk)...)
 		rows, err := s.db.Query(q, args...)
 		panicOnFatal(err)
+		if rows == nil {
+			// swallowed teardown-race error: read returns empty (see panicOnFatal)
+			return out
+		}
 		for rows.Next() {
 			var r graph.NodeFanRow
 			panicOnFatal(rows.Scan(&r.NodeID, &r.FanIn, &r.FanOut))
@@ -562,6 +610,10 @@ func (s *Store) CommunityCrossingsByKind(kinds []graph.EdgeKind, nodeToComm map[
 	q := `SELECT from_id, to_id FROM edges WHERE kind IN (` + inPlaceholders(len(args)) + `)`
 	rows, err := s.db.Query(q, args...)
 	panicOnFatal(err)
+	if rows == nil {
+		// swallowed teardown-race error: read returns empty (see panicOnFatal)
+		return nil
+	}
 	defer rows.Close()
 	out := make(map[string]int)
 	for rows.Next() {

--- a/internal/graph/store_sqlite/store_compact.go
+++ b/internal/graph/store_sqlite/store_compact.go
@@ -1,0 +1,63 @@
+package store_sqlite
+
+// One-time boot compaction support.
+//
+// The graph store only ever grows on disk: deleted rows (a purged repo, the
+// duplicate-collapse migration, resolver cleanups) return their pages to
+// SQLite's freelist, where future writes reuse them — but nothing short of
+// VACUUM returns them to the filesystem. A long-lived store that shed a large
+// fraction of its rows can therefore pin gigabytes of dead file forever (a
+// live store sat at 64% freelist — 4.4 GB reclaimable in a 6.8 GB file).
+// These methods give the daemon the numbers to decide whether that one-time
+// rewrite is worth it, and the lever to run it. The policy (thresholds, disk
+// headroom, kill-switch) deliberately lives with the caller: the store cannot
+// know whether minutes of exclusive I/O are acceptable right now.
+
+// Path returns the on-disk database file path. Empty when the store was not
+// opened from a file — callers using it to reason about the underlying
+// filesystem (disk-headroom checks) must treat "" as "unknown, don't".
+func (s *Store) Path() string {
+	return s.dbPath
+}
+
+// CompactStats reports how much of the database file is reclaimable dead
+// space: freeBytes is the freelist (freelist_count × page_size), totalBytes
+// the whole main file (page_count × page_size). Zeros on any pragma error —
+// a read failing here is the same teardown race panicOnFatal swallows, and
+// "nothing reclaimable" is the answer that makes every caller do nothing.
+// The -wal file is excluded on purpose: the checkpoint loop already bounds
+// it, and VACUUM only rewrites the main file.
+func (s *Store) CompactStats() (freeBytes, totalBytes int64) {
+	var pageSize, pageCount, freePages int64
+	if err := s.db.QueryRow(`PRAGMA page_size`).Scan(&pageSize); err != nil {
+		return 0, 0
+	}
+	if err := s.db.QueryRow(`PRAGMA page_count`).Scan(&pageCount); err != nil {
+		return 0, 0
+	}
+	if err := s.db.QueryRow(`PRAGMA freelist_count`).Scan(&freePages); err != nil {
+		return 0, 0
+	}
+	return freePages * pageSize, pageCount * pageSize
+}
+
+// Compact rewrites the database file (VACUUM), returning freelist pages to
+// the filesystem, then drains the write-ahead log with a TRUNCATE checkpoint
+// so the rewrite's WAL traffic doesn't linger as a second oversized file.
+//
+// Cost model callers must respect: VACUUM copies the live content into a
+// temporary database (up to a full extra copy on the same filesystem) and
+// needs exclusive access — it blocks Go-side writers via writeMu here, and a
+// concurrent reader on another pooled connection makes SQLite wait out
+// busy_timeout and then fail. That failure is clean (the store is untouched,
+// freelist pages remain reusable), which is why the daemon treats a Compact
+// error as skip-and-continue rather than fatal.
+func (s *Store) Compact() error {
+	s.writeMu.Lock()
+	_, err := s.db.Exec(`VACUUM`)
+	s.writeMu.Unlock()
+	if err != nil {
+		return err
+	}
+	return s.CheckpointWAL()
+}

--- a/internal/graph/store_sqlite/store_compact_test.go
+++ b/internal/graph/store_sqlite/store_compact_test.go
@@ -1,0 +1,76 @@
+package store_sqlite_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// TestCompactReclaimsFreelist pins the boot-compaction capability end to end
+// on a real file: shedding most rows leaves the file full of freelist pages
+// (CompactStats must say so), Compact() must return them to the filesystem
+// (page_count shrinks), and the surviving rows must come through untouched.
+// Fractional assertions only — page size and per-row overhead are backend
+// details this test must not encode.
+func TestCompactReclaimsFreelist(t *testing.T) {
+	s := openTestStore(t)
+
+	// Seed 60 files × 50 nodes with ~2 KiB of meta each (~6 MiB of pages),
+	// then checkpoint so the rows land in the main file rather than the WAL —
+	// CompactStats deliberately measures only the main file.
+	const files, perFile = 60, 50
+	pad := strings.Repeat("x", 2048)
+	for f := 0; f < files; f++ {
+		nodes := make([]*graph.Node, 0, perFile)
+		path := fmt.Sprintf("p/f%03d.go", f)
+		for n := 0; n < perFile; n++ {
+			nodes = append(nodes, &graph.Node{
+				ID:       fmt.Sprintf("%s::N%d", path, n),
+				Kind:     graph.KindFunction,
+				Name:     fmt.Sprintf("N%d", n),
+				FilePath: path,
+				Meta:     map[string]any{"pad": pad},
+			})
+		}
+		s.AddBatch(nodes, nil)
+	}
+	require.NoError(t, s.CheckpointWAL())
+	_, totalSeeded := s.CompactStats()
+	require.Greater(t, totalSeeded, int64(3<<20), "sanity: seeding must produce a multi-MiB main file")
+
+	// Shed all but one file, checkpoint again so the deletions reach the main
+	// file's freelist.
+	for f := 1; f < files; f++ {
+		s.EvictFile(fmt.Sprintf("p/f%03d.go", f))
+	}
+	require.NoError(t, s.CheckpointWAL())
+
+	freeBefore, totalBefore := s.CompactStats()
+	assert.Greater(t, freeBefore*3, totalBefore,
+		"after shedding ~98%% of rows the freelist must dominate the file (free=%d total=%d)", freeBefore, totalBefore)
+	assert.Greater(t, freeBefore, int64(1<<20), "freelist must be at least MiB-scale to make the shrink observable")
+
+	require.NoError(t, s.Compact())
+
+	freeAfter, totalAfter := s.CompactStats()
+	assert.Less(t, totalAfter, totalBefore/2,
+		"VACUUM must return the dead majority to the filesystem (before=%d after=%d)", totalBefore, totalAfter)
+	assert.Less(t, freeAfter, totalBefore/10,
+		"post-VACUUM freelist must be near empty (free=%d)", freeAfter)
+
+	// Survivors intact, evicted rows gone.
+	assert.Equal(t, perFile, s.NodeCount(), "compaction must not change the row count")
+	kept := s.GetNode("p/f000.go::N0")
+	require.NotNil(t, kept, "kept row must survive VACUUM")
+	assert.Equal(t, pad, kept.Meta["pad"], "kept row's meta blob must round-trip through VACUUM")
+	assert.Nil(t, s.GetNode("p/f001.go::N0"), "evicted row must stay gone")
+
+	// The store stays fully writable after the rewrite.
+	s.AddNode(&graph.Node{ID: "p/new.go::After", Kind: graph.KindFunction, Name: "After", FilePath: "p/new.go"})
+	assert.NotNil(t, s.GetNode("p/new.go::After"))
+}

--- a/internal/graph/store_sqlite/store_content_fts.go
+++ b/internal/graph/store_sqlite/store_content_fts.go
@@ -48,6 +48,97 @@ func (s *Store) WipeContentFile(filePath string) error {
 	return err
 }
 
+// WipeContentFileInRepo removes ONE file's content rows scoped to a repo —
+// the crash-safe full-index sibling of WipeContentFile (which keys on
+// file_path alone and so would clobber a same-named file in another repo).
+// A full index streams content per file: delete this file's prior rows,
+// then AppendContent its fresh sections — so a mid-parse kill leaves a mix
+// of old+new content per file rather than the empty table a repo-wide
+// pre-wipe would leave behind. Empty filePath is a no-op.
+func (s *Store) WipeContentFileInRepo(repoPrefix, filePath string) error {
+	if filePath == "" {
+		return nil
+	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	_, err := s.db.Exec(`DELETE FROM content_fts WHERE repo_prefix = ? AND file_path = ?`, repoPrefix, filePath)
+	return err
+}
+
+// DeleteContentFilesForRepoNotIn sweeps a repo's content rows down to keep —
+// every content row whose file_path is absent from keep is deleted. keep is
+// the set of files that actually STREAMED content sections in the walk just
+// completed (each recorded as the same file_path form AppendContent wrote),
+// NOT the set of files that merely survive on disk: a file can still exist
+// yet stop producing content (doc emptied, classification changed), and a
+// disk-based keep would protect its stale rows forever. Run once at the end
+// of a successful full index (right after the authoritative mtime replace),
+// it reaps vanished files and content->no-content transitions in one scan;
+// the per-file WipeContentFileInRepo + AppendContent streaming build
+// refreshes the files that still produce content. Together they replace the
+// old repo-wide pre-wipe: a mid-parse kill no longer empties the content
+// index, and stale rows are reaped only on the next clean completion.
+// Empty keep is a deliberate no-op safety net — never wipe a whole repo from
+// an empty set; a caller that legitimately ends a walk with zero content
+// files calls WipeContent explicitly instead.
+func (s *Store) DeleteContentFilesForRepoNotIn(repoPrefix string, keep map[string]struct{}) error {
+	if len(keep) == 0 {
+		return nil
+	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	// Enumerate the repo's content file paths, then delete only those not in
+	// keep. Content files are a small subset (docs / PDFs / office), so the
+	// DISTINCT scan + targeted deletes stay cheap and dodge a giant NOT IN
+	// (...) bound-variable list. Rows are drained + closed before the delete
+	// tx opens (no open read cursor while writing on the same connection).
+	rows, err := s.db.Query(`SELECT DISTINCT file_path FROM content_fts WHERE repo_prefix = ?`, repoPrefix)
+	if err != nil {
+		return err
+	}
+	var vanished []string
+	for rows.Next() {
+		var fp string
+		if err := rows.Scan(&fp); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		if _, ok := keep[fp]; !ok {
+			vanished = append(vanished, fp)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return err
+	}
+	_ = rows.Close()
+	if len(vanished) == 0 {
+		return nil
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck // rollback after Commit is a no-op
+	const chunk = 900
+	for start := 0; start < len(vanished); start += chunk {
+		end := minInt(start+chunk, len(vanished))
+		batch := vanished[start:end]
+		placeholders := strings.TrimSuffix(strings.Repeat("?,", len(batch)), ",")
+		args := make([]any, 0, len(batch)+1)
+		args = append(args, repoPrefix)
+		for _, fp := range batch {
+			args = append(args, fp)
+		}
+		if _, err := tx.Exec(`DELETE FROM content_fts WHERE repo_prefix = ? AND file_path IN (`+placeholders+`)`, args...); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
 // AppendContent inserts content rows for repoPrefix without wiping — the
 // streamed per-file build path. Callers wipe (whole repo or one file)
 // first. Rows with an empty NodeID are skipped.

--- a/internal/graph/store_sqlite/store_fnvalue.go
+++ b/internal/graph/store_sqlite/store_fnvalue.go
@@ -1,0 +1,38 @@
+package store_sqlite
+
+import (
+	"iter"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Compile-time assertion: *Store serves the fn-value placeholder scan.
+var _ graph.FnValuePlaceholderScanner = (*Store)(nil)
+
+// FnValuePlaceholderEdges implements graph.FnValuePlaceholderScanner: it yields
+// only the fn-value gate's placeholder edges, the exact inverse of the
+// fn-value exclusion EdgesWithUnresolvedTarget applies. The predicate is the
+// SAME two-form filter the v2 migration's dedupeFnValuePlaceholderEdges uses:
+// the bare `unresolved::fnvalue::` range rides edges_by_to(to_id) (the ':;'
+// range end is ':'+1, one past the marker); the multi-repo COPY-rewrite infix
+// form is caught by is_unresolved = 1 + LIKE. Full column set incl. meta — the
+// gate reads Meta["via"] and the captured fn_value_name off each placeholder.
+//
+// The whole point is that the gate no longer has to scan the entire
+// EdgeReferences kind (placeholders + every real reference) and Go-filter on
+// every whole-graph synthesizer pass; it pulls the handful of placeholders
+// straight off the index instead.
+func (s *Store) FnValuePlaceholderEdges() iter.Seq[*graph.Edge] {
+	return func(yield func(*graph.Edge) bool) {
+		out := s.queryEdgesSQL(`
+SELECT from_id, to_id, kind, file_path, line, confidence, confidence_label, origin, tier, cross_repo, meta, resolve_terminal, resolve_terminal_reason
+FROM edges
+WHERE (to_id >= 'unresolved::fnvalue::' AND to_id < 'unresolved::fnvalue:;')
+   OR (is_unresolved = 1 AND to_id LIKE '%::unresolved::fnvalue::%')`)
+		for _, e := range out {
+			if !yield(e) {
+				return
+			}
+		}
+	}
+}

--- a/internal/graph/store_sqlite/store_light_edges.go
+++ b/internal/graph/store_sqlite/store_light_edges.go
@@ -1,0 +1,54 @@
+package store_sqlite
+
+import "github.com/zzet/gortex/internal/graph"
+
+// Compile-time assertion: *Store serves the meta-less kind-scoped edge scan.
+var _ graph.LightEdgeScanner = (*Store)(nil)
+
+// edgeColsLight is the meta-less edge column projection: the promoted struct
+// columns WITHOUT the meta blob (and without resolve_terminal, which lives in
+// Meta). It is exactly the ten columns scanEdgeLight scans, and is shared with
+// the stmtOutEdgesLight prepared statement so the projection can never drift
+// from the scanner. Adding meta back here would defeat the whole point — the
+// per-row JSON decode this projection exists to skip.
+const edgeColsLight = `from_id, to_id, kind, file_path, line, confidence, confidence_label, origin, tier, cross_repo`
+
+// AllEdgesLight implements graph.LightEdgeScanner: a kind-scoped edge scan that
+// never decodes the meta blob. An empty kinds list scans every edge; supplying
+// only empty-string kinds matches nothing (parity with the aggregators). The
+// edges_by_kind index serves the IN filter. Meta is left nil; only the promoted
+// fields (origin/tier/confidence/confidence_label/cross_repo/line) are hydrated.
+func (s *Store) AllEdgesLight(kinds ...graph.EdgeKind) []*graph.Edge {
+	_, args := aggDedupeEdgeKinds(kinds)
+	if len(args) == 0 {
+		if len(kinds) > 0 {
+			return nil // caller passed only empty kinds — nothing matches
+		}
+		return s.queryEdgesLightSQL(`SELECT ` + edgeColsLight + ` FROM edges ORDER BY id`)
+	}
+	q := `SELECT ` + edgeColsLight + ` FROM edges WHERE kind IN (` +
+		inPlaceholders(len(args)) + `) ORDER BY id`
+	return s.queryEdgesLightSQL(q, args...)
+}
+
+// queryEdgesLightSQL is the meta-less sibling of queryEdgesSQL: it materialises
+// the rows into a slice and closes the cursor before returning (releasing the
+// single pooled connection), but scans through scanEdgeLight so the meta column
+// is never transferred or decoded. Returns nil on any query error, matching
+// queryEdgesSQL — a teardown-race read degrades to empty rather than panicking.
+func (s *Store) queryEdgesLightSQL(q string, args ...any) []*graph.Edge {
+	rows, err := s.db.Query(q, args...)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+	var out []*graph.Edge
+	for rows.Next() {
+		e, err := scanEdgeLight(rows)
+		if err != nil || e == nil {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}

--- a/internal/graph/store_sqlite/store_light_edges_test.go
+++ b/internal/graph/store_sqlite/store_light_edges_test.go
@@ -1,0 +1,54 @@
+package store_sqlite_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// TestAllEdgesLightIsMetaless pins the disk backend's graph.LightEdgeScanner:
+// the scan must skip the meta blob (Meta == nil) — the per-edge JSON decode the
+// warm-restart analysis passes exist to avoid — while every promoted field
+// still equals what the full AllEdges() scan returns.
+func TestAllEdgesLightIsMetaless(t *testing.T) {
+	s := openTestStore(t)
+	s.AddNode(&graph.Node{ID: "p/a.go::A", Kind: graph.KindFunction, Name: "A", FilePath: "p/a.go"})
+	s.AddNode(&graph.Node{ID: "p/a.go::B", Kind: graph.KindFunction, Name: "B", FilePath: "p/a.go"})
+	s.AddEdge(&graph.Edge{
+		From: "p/a.go::A", To: "p/a.go::B", Kind: graph.EdgeCalls,
+		FilePath: "p/a.go", Line: 11, Confidence: 0.75, ConfidenceLabel: "high",
+		Origin: graph.OriginLSPResolved, Tier: "lsp", CrossRepo: true,
+		Meta: map[string]any{"via": "direct", "blob_only": "x"},
+	})
+	// A second kind to prove the IN filter really scopes.
+	s.AddEdge(&graph.Edge{From: "p/a.go::A", To: "p/a.go::B", Kind: graph.EdgeImports, FilePath: "p/a.go", Line: 1})
+
+	light := s.AllEdgesLight(graph.EdgeCalls)
+	require.Len(t, light, 1, "kind filter must exclude the imports edge")
+	e := light[0]
+	assert.Nil(t, e.Meta, "AllEdgesLight must not decode the meta blob")
+
+	var full *graph.Edge
+	for _, fe := range s.AllEdges() {
+		if fe.Kind == graph.EdgeCalls {
+			full = fe
+		}
+	}
+	require.NotNil(t, full)
+	assert.NotNil(t, full.Meta, "sanity: the full scan DOES decode meta")
+	assert.Equal(t, full.From, e.From)
+	assert.Equal(t, full.To, e.To)
+	assert.Equal(t, full.Kind, e.Kind)
+	assert.Equal(t, full.Line, e.Line)
+	assert.Equal(t, full.Confidence, e.Confidence)
+	assert.Equal(t, full.ConfidenceLabel, e.ConfidenceLabel)
+	assert.Equal(t, full.Origin, e.Origin)
+	assert.Equal(t, full.Tier, e.Tier)
+	assert.Equal(t, full.CrossRepo, e.CrossRepo)
+
+	// Empty kinds means every edge.
+	assert.Len(t, s.AllEdgesLight(), 2)
+}

--- a/internal/graph/store_sqlite/store_purge.go
+++ b/internal/graph/store_sqlite/store_purge.go
@@ -1,0 +1,310 @@
+package store_sqlite
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+// This file adds the repo-scoped store hygiene the base eviction path lacks.
+// EvictRepo (store.go) deletes ONLY nodes+edges, but a repo owns fifteen
+// other repo_prefix-keyed sidecar tables (file_mtimes, repo_index_state,
+// enrichment_state, clone_shingles, constant_values, files, ref_facts,
+// vectors, churn/coverage/release/blame_enrichment, symbol_fts,
+// symbol_fts_rowid, content_fts — see schema.go). Untracking a repo through
+// EvictRepo leaks every one of them, so a long-lived store accumulates
+// sidecar rows for repos removed from config long ago. PurgeRepo clears a
+// repo whole; OrphanRepoPrefixes finds prefixes that outlived their config
+// entry; RekeyRepoPrefix moves a lone repo's residue when it earns a prefix.
+//
+// INVARIANT — the empty repo_prefix is NEVER purged. In a live multi-repo
+// store repo_prefix='' identifies SYNTHETIC GLOBAL EXTERNALS (external_call
+// ::dep:* / builtin:: / module:: nodes shared across every repo) and, in a
+// single-repo store, the sole repo's live data. Deleting '' rows would strip
+// the shared externals out from under every repo, or wipe the lone repo.
+// Every method here refuses or excludes ''.
+
+// purgeSidecarTables are the repo_prefix-keyed sidecar tables PurgeRepo
+// clears for a prefix, alongside nodes+edges. Each carries a repo_prefix
+// column a plain `DELETE ... WHERE repo_prefix = ?` keys on. The two FTS5
+// vtables (symbol_fts, content_fts) carry repo_prefix UNINDEXED, so their
+// delete is a full scan — acceptable for a purge (a rare, whole-repo op),
+// unlike the per-edit hot path. `vectors` is deliberately absent: it has NO
+// repo_prefix column (keyed by node_id alone), so PurgeRepo deletes its rows
+// by node-id membership instead (see deleteByIDColumnsTx below).
+var purgeSidecarTables = []string{
+	"file_mtimes",
+	"repo_index_state",
+	"enrichment_state",
+	"clone_shingles",
+	"constant_values",
+	"files",
+	"ref_facts",
+	"churn_enrichment",
+	"coverage_enrichment",
+	"release_enrichment",
+	"blame_enrichment",
+	"symbol_fts",
+	"symbol_fts_rowid",
+	"content_fts",
+}
+
+// PurgeRepo deletes EVERY row a repo owns — nodes, edges, and all fifteen
+// repo_prefix-keyed sidecar tables (purgeSidecarTables + vectors) — in one
+// transaction. It is the complete form of EvictRepo (which drops only
+// nodes+edges), wired into UntrackRepo so removing a repo from config leaves
+// no residue. Refuses prefix=="" (shared global externals / solo-mode live
+// data — see the file-level INVARIANT).
+func (s *Store) PurgeRepo(prefix string) error {
+	if prefix == "" {
+		return fmt.Errorf("store_sqlite: PurgeRepo refuses empty repo prefix (would delete shared global externals / solo-repo data)")
+	}
+
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck // rollback after Commit is a no-op
+
+	// Collect this repo's node IDs first: edges and vectors are keyed off
+	// them (edges by from_id/to_id, vectors by node_id — neither carries a
+	// repo_prefix column). Edge deletion semantics mirror evictByScopeLocked
+	// (store.go): delete every edge touching one of these nodes, then the
+	// nodes themselves.
+	ids, err := repoNodeIDsTx(tx, prefix)
+	if err != nil {
+		return err
+	}
+	if err := deleteByIDColumnsTx(tx, "edges", []string{"from_id", "to_id"}, ids); err != nil {
+		return fmt.Errorf("store_sqlite: PurgeRepo edges: %w", err)
+	}
+	if err := deleteByIDColumnsTx(tx, "vectors", []string{"node_id"}, ids); err != nil {
+		return fmt.Errorf("store_sqlite: PurgeRepo vectors: %w", err)
+	}
+
+	for _, table := range purgeSidecarTables {
+		if _, err := tx.Exec(`DELETE FROM `+table+` WHERE repo_prefix = ?`, prefix); err != nil {
+			return fmt.Errorf("store_sqlite: PurgeRepo %s: %w", table, err)
+		}
+	}
+
+	if _, err := tx.Exec(`DELETE FROM nodes WHERE repo_prefix = ?`, prefix); err != nil {
+		return fmt.Errorf("store_sqlite: PurgeRepo nodes: %w", err)
+	}
+
+	return tx.Commit()
+}
+
+// orphanScanTables are the tables OrphanRepoPrefixes unions DISTINCT
+// repo_prefix over. These five span the residue space: nodes (the primary
+// keyed store), file_mtimes + repo_index_state (the warm-restart provenance
+// that lingers when nodes are gone but sidecars survive — the exact shape a
+// leaked untrack leaves), enrichment_state (per-provider provenance), and
+// files (per-file metadata). A prefix whose nodes are gone but whose
+// sidecars remain is invisible to a nodes-only scan, which is why the
+// sidecar tables are unioned in; scanning still more tables would only
+// rediscover the same prefixes at higher cost.
+var orphanScanTables = []string{
+	"nodes",
+	"file_mtimes",
+	"repo_index_state",
+	"enrichment_state",
+	"files",
+}
+
+// OrphanRepoPrefixes returns every repo_prefix present in the store but
+// absent from known — repos whose rows outlived their config entry (an
+// untrack that predated PurgeRepo, or a repo dropped straight from config
+// with no untrack at all). The empty prefix is NEVER reported (shared global
+// externals / solo data). known is matched case-insensitively as a safety
+// net, so a case-only spelling drift on a case-insensitive filesystem can
+// never flag a still-tracked repo as an orphan (the #270 failure mode).
+// Startup warmup feeds the result to PurgeRepo.
+func (s *Store) OrphanRepoPrefixes(known []string) []string {
+	knownFold := make(map[string]struct{}, len(known))
+	for _, k := range known {
+		if k == "" {
+			continue
+		}
+		knownFold[strings.ToLower(k)] = struct{}{}
+	}
+
+	seen := make(map[string]struct{})
+	var out []string
+	for _, table := range orphanScanTables {
+		// WHERE repo_prefix <> '' both excludes the protected empty prefix
+		// and lets the nodes scan ride the partial nodes_by_repo index
+		// (defined WHERE repo_prefix <> ''). A table absent on an older
+		// schema simply contributes nothing.
+		rows, err := s.db.Query(`SELECT DISTINCT repo_prefix FROM ` + table + ` WHERE repo_prefix <> ''`)
+		if err != nil {
+			continue
+		}
+		for rows.Next() {
+			var p string
+			if err := rows.Scan(&p); err != nil {
+				break
+			}
+			if p == "" {
+				continue
+			}
+			if _, ok := knownFold[strings.ToLower(p)]; ok {
+				continue
+			}
+			if _, dup := seen[p]; dup {
+				continue
+			}
+			seen[p] = struct{}{}
+			out = append(out, p)
+		}
+		_ = rows.Close()
+	}
+	return out
+}
+
+// rekeyMoveTables are the sidecar tables RekeyRepoPrefix relabels from old
+// to new. Every one is keyed by repo_prefix (+ file_path or provider), NOT
+// by node_id, so its row content survives a node-id change: file_mtimes /
+// files by (repo_prefix, file_path); repo_index_state / enrichment_state by
+// repo_prefix (+ provider). At a solo->multi migration every '' row in these
+// belongs to the one migrating repo — global externals live in the NODES
+// table and hold NO rows here — so moving them wholesale is safe. UPDATE OR
+// REPLACE folds any row the re-mint re-index already wrote under new
+// (identical content: same files, same mtimes, same commit) instead of
+// tripping the primary-key conflict a plain UPDATE would.
+var rekeyMoveTables = []string{
+	"file_mtimes",
+	"files",
+	"repo_index_state",
+	"enrichment_state",
+}
+
+// rekeyDropTables are the sidecar tables RekeyRepoPrefix DROPS (rather than
+// relabels) for old. Every one is keyed by node_id, and the solo->multi
+// re-mint changes every node id (unprefixed `pkg::X` -> `<new>::pkg::X`), so
+// these old-id rows are already dangling against the evicted unprefixed
+// nodes. Relabeling their repo_prefix would just move dangling rows under
+// new — and let, e.g., the clone reseed load a shingle set for a node that
+// no longer exists. Dropping them is correct: the re-mint re-index rewrites
+// the index-time sidecars (constant_values, ref_facts, clone_shingles) under
+// the new node ids, and the enrichment sidecars (churn/coverage/release/
+// blame) must re-run for the new ids regardless. The FTS vtables sit here
+// too — their rows carry the old node ids, and UPDATE over an FTS5 UNINDEXED
+// column is awkward, so delete-then-reindex is the clean path.
+var rekeyDropTables = []string{
+	"clone_shingles",
+	"constant_values",
+	"ref_facts",
+	"churn_enrichment",
+	"coverage_enrichment",
+	"release_enrichment",
+	"blame_enrichment",
+	"symbol_fts",
+	"symbol_fts_rowid",
+	"content_fts",
+}
+
+// RekeyRepoPrefix moves a repo's sidecar residue from old to new the moment a
+// solo (unprefixed) repo earns a real prefix because a second repo joined —
+// the migrateLoneUnprefixedRepoCtx path. The prefix/path-keyed provenance
+// tables (rekeyMoveTables) are relabeled so warm restart finds the repo's
+// mtimes + freshness under new instead of full-re-tracking it; the
+// node_id-keyed tables (rekeyDropTables) are dropped because the re-mint
+// changed every node id out from under them (see the two table lists for the
+// per-table rationale).
+//
+// Refuses new=="" (cannot rekey INTO the protected empty prefix). old=="" IS
+// allowed — that is the whole point, since solo repos index unprefixed — and
+// is safe here because this method touches SIDECAR tables ONLY; the synthetic
+// global externals that also carry repo_prefix='' live in the NODES table,
+// which RekeyRepoPrefix never writes.
+func (s *Store) RekeyRepoPrefix(oldPrefix, newPrefix string) error {
+	if newPrefix == "" {
+		return fmt.Errorf("store_sqlite: RekeyRepoPrefix refuses empty destination prefix")
+	}
+	if oldPrefix == newPrefix {
+		return nil
+	}
+
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck // rollback after Commit is a no-op
+
+	for _, table := range rekeyMoveTables {
+		if _, err := tx.Exec(`UPDATE OR REPLACE `+table+` SET repo_prefix = ? WHERE repo_prefix = ?`, newPrefix, oldPrefix); err != nil {
+			return fmt.Errorf("store_sqlite: RekeyRepoPrefix move %s: %w", table, err)
+		}
+	}
+	for _, table := range rekeyDropTables {
+		if _, err := tx.Exec(`DELETE FROM `+table+` WHERE repo_prefix = ?`, oldPrefix); err != nil {
+			return fmt.Errorf("store_sqlite: RekeyRepoPrefix drop %s: %w", table, err)
+		}
+	}
+	// vectors is intentionally omitted: it has NO repo_prefix column (keyed
+	// by node_id alone), so it cannot be addressed here by prefix. Any ''
+	// embeddings are node_id-keyed against now-evicted unprefixed ids —
+	// dangling, and absent in the common case (embeddings are opt-in). They
+	// are left to a node-membership vector GC rather than guessed at here.
+
+	return tx.Commit()
+}
+
+// repoNodeIDsTx returns every node id in repoPrefix, read inside tx. The
+// caller holds writeMu. Rows are fully drained + closed before the caller
+// issues writes on the same tx — SQLite forbids an open read cursor while
+// writing on the same connection.
+func repoNodeIDsTx(tx *sql.Tx, repoPrefix string) ([]string, error) {
+	rows, err := tx.Query(`SELECT id FROM nodes WHERE repo_prefix = ?`, repoPrefix)
+	if err != nil {
+		return nil, err
+	}
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, err
+	}
+	_ = rows.Close()
+	return ids, nil
+}
+
+// deleteByIDColumnsTx deletes rows from table where ANY of cols matches one
+// of ids, chunked so each statement stays under SQLite's 999 bound-variable
+// limit. Mirrors evictByScopeLocked's chunked from_id/to_id edge delete
+// (store.go) — the semantics source for edge eviction. Empty ids is a no-op.
+func deleteByIDColumnsTx(tx *sql.Tx, table string, cols, ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	const chunk = 900
+	for _, col := range cols {
+		for start := 0; start < len(ids); start += chunk {
+			end := minInt(start+chunk, len(ids))
+			batch := ids[start:end]
+			placeholders := strings.TrimSuffix(strings.Repeat("?,", len(batch)), ",")
+			args := make([]any, len(batch))
+			for i, id := range batch {
+				args[i] = id
+			}
+			if _, err := tx.Exec(`DELETE FROM `+table+` WHERE `+col+` IN (`+placeholders+`)`, args...); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/internal/graph/store_sqlite/store_purge_test.go
+++ b/internal/graph/store_sqlite/store_purge_test.go
@@ -1,0 +1,174 @@
+package store_sqlite
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// openPurgeStore opens a throwaway on-disk store for the hygiene tests.
+func openPurgeStore(t *testing.T) *Store {
+	t.Helper()
+	s, err := Open(filepath.Join(t.TempDir(), "purge.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+// seedRepoRows inserts exactly one row keyed to prefix into nodes, edges,
+// vectors, and every repo_prefix-keyed sidecar table, so a PurgeRepo /
+// RekeyRepoPrefix test can assert each table is cleared/moved. Node/vector
+// ids embed the prefix (`<prefix>::a.go::X`) so the node-id-keyed vectors +
+// edges land in the prefix's scope. Uses raw SQL for exhaustiveness: some
+// tables have no public setter.
+func seedRepoRows(t *testing.T, db *sql.DB, prefix string) {
+	t.Helper()
+	nodeID := prefix + "::a.go::X"
+	exec := func(q string, args ...any) {
+		t.Helper()
+		_, err := db.Exec(q, args...)
+		require.NoError(t, err, q)
+	}
+	exec(`INSERT INTO nodes (id, kind, name, file_path, repo_prefix) VALUES (?, 'function', 'X', 'a.go', ?)`, nodeID, prefix)
+	// An edge from the repo's node to a shared '' global external: PurgeRepo
+	// must delete this edge (its from_id is a repo node) but NEVER the ''
+	// target node.
+	exec(`INSERT INTO edges (from_id, to_id, kind) VALUES (?, 'external_call::dep:shared', 'calls')`, nodeID)
+	exec(`INSERT INTO vectors (node_id, dims, vec) VALUES (?, 1, X'00')`, nodeID)
+
+	exec(`INSERT INTO file_mtimes (repo_prefix, file_path, mtime_ns) VALUES (?, 'a.go', 123)`, prefix)
+	exec(`INSERT INTO repo_index_state (repo_prefix, indexed_sha) VALUES (?, 'sha')`, prefix)
+	exec(`INSERT INTO enrichment_state (repo_prefix, provider) VALUES (?, 'lsp')`, prefix)
+	exec(`INSERT INTO clone_shingles (node_id, repo_prefix, shingles) VALUES (?, ?, X'00')`, nodeID, prefix)
+	exec(`INSERT INTO constant_values (node_id, repo_prefix, file_path, value) VALUES (?, ?, 'a.go', 'v')`, nodeID, prefix)
+	exec(`INSERT INTO files (repo_prefix, file_path, content_hash) VALUES (?, 'a.go', 'h')`, prefix)
+	exec(`INSERT INTO ref_facts (repo_prefix, from_id, to_id, kind, line) VALUES (?, ?, 'a.go::Y', 'ref', 1)`, prefix, nodeID)
+	exec(`INSERT INTO churn_enrichment (node_id, repo_prefix, commit_count) VALUES (?, ?, 3)`, nodeID, prefix)
+	exec(`INSERT INTO coverage_enrichment (node_id, repo_prefix, coverage_pct) VALUES (?, ?, 0.5)`, nodeID, prefix)
+	exec(`INSERT INTO release_enrichment (node_id, repo_prefix, added_in) VALUES (?, ?, 'v1')`, nodeID, prefix)
+	exec(`INSERT INTO blame_enrichment (node_id, repo_prefix, email) VALUES (?, ?, 'a@b')`, nodeID, prefix)
+	exec(`INSERT INTO symbol_fts (node_id, repo_prefix, tokens) VALUES (?, ?, 'x')`, nodeID, prefix)
+	exec(`INSERT INTO symbol_fts_rowid (node_id, repo_prefix, fts_rowid) VALUES (?, ?, 1)`, nodeID, prefix)
+	exec(`INSERT INTO content_fts (node_id, repo_prefix, file_path, ordinal, body) VALUES (?, ?, 'a.go', 0, 'body')`, nodeID, prefix)
+}
+
+// countByPrefix reports how many rows a repo_prefix-keyed table holds for
+// prefix. nodes and every sidecar carry a repo_prefix column.
+func countByPrefix(t *testing.T, db *sql.DB, table, prefix string) int {
+	t.Helper()
+	var n int
+	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM `+table+` WHERE repo_prefix = ?`, prefix).Scan(&n))
+	return n
+}
+
+// countByNodeIDLike reports how many rows a node_id-keyed table (vectors)
+// holds whose node_id starts with `<prefix>::`.
+func countByNodeIDLike(t *testing.T, db *sql.DB, table, prefix string) int {
+	t.Helper()
+	var n int
+	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM `+table+` WHERE node_id LIKE ?`, prefix+"::%").Scan(&n))
+	return n
+}
+
+// prefixKeyedTables is every repo_prefix-keyed table PurgeRepo/Rekey touch,
+// minus nodes (asserted separately) — used to loop assertions.
+var prefixKeyedTables = []string{
+	"file_mtimes", "repo_index_state", "enrichment_state", "clone_shingles",
+	"constant_values", "files", "ref_facts", "churn_enrichment",
+	"coverage_enrichment", "release_enrichment", "blame_enrichment",
+	"symbol_fts", "symbol_fts_rowid", "content_fts",
+}
+
+func TestPurgeRepo_ClearsEveryTable_LeavesOthersAndGlobals(t *testing.T) {
+	s := openPurgeStore(t)
+	// Two real repos plus a shared '' global-external node the purge must
+	// never touch.
+	seedRepoRows(t, s.db, "repoA")
+	seedRepoRows(t, s.db, "repoB")
+	_, err := s.db.Exec(`INSERT INTO nodes (id, kind, name, file_path, repo_prefix) VALUES ('external_call::dep:shared', 'external', 'shared', '', '')`)
+	require.NoError(t, err)
+
+	require.NoError(t, s.PurgeRepo("repoA"))
+
+	// repoA: nodes, edges, vectors, and every sidecar cleared.
+	assert.Equal(t, 0, countByPrefix(t, s.db, "nodes", "repoA"), "repoA nodes gone")
+	assert.Equal(t, 0, countByNodeIDLike(t, s.db, "vectors", "repoA"), "repoA vectors gone")
+	for _, tbl := range prefixKeyedTables {
+		assert.Equal(t, 0, countByPrefix(t, s.db, tbl, "repoA"), "repoA %s cleared", tbl)
+	}
+	var edgesFromA int
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM edges WHERE from_id LIKE 'repoA::%'`).Scan(&edgesFromA))
+	assert.Equal(t, 0, edgesFromA, "repoA edges gone")
+
+	// repoB untouched across the board.
+	assert.Equal(t, 1, countByPrefix(t, s.db, "nodes", "repoB"), "repoB nodes intact")
+	assert.Equal(t, 1, countByNodeIDLike(t, s.db, "vectors", "repoB"), "repoB vectors intact")
+	for _, tbl := range prefixKeyedTables {
+		assert.Equal(t, 1, countByPrefix(t, s.db, tbl, "repoB"), "repoB %s intact", tbl)
+	}
+
+	// The shared '' global external survives — nothing may purge ''.
+	assert.Equal(t, 1, countByPrefix(t, s.db, "nodes", ""), "'' global external survives")
+}
+
+func TestPurgeRepo_RefusesEmptyPrefix(t *testing.T) {
+	s := openPurgeStore(t)
+	seedRepoRows(t, s.db, "")
+	require.Error(t, s.PurgeRepo(""), "PurgeRepo must refuse the empty prefix (global externals / solo data)")
+	// The '' rows are still there.
+	assert.Equal(t, 1, countByPrefix(t, s.db, "file_mtimes", ""), "'' file_mtimes untouched by refused purge")
+}
+
+func TestOrphanRepoPrefixes_SidecarOnlyResidue(t *testing.T) {
+	s := openPurgeStore(t)
+	// gone: a repo whose NODES were evicted but whose sidecars linger — the
+	// exact leaked-untrack shape (residue in file_mtimes + repo_index_state,
+	// no nodes). live: a fully-present tracked repo.
+	_, err := s.db.Exec(`INSERT INTO file_mtimes (repo_prefix, file_path, mtime_ns) VALUES ('gone', 'x.go', 1)`)
+	require.NoError(t, err)
+	_, err = s.db.Exec(`INSERT INTO repo_index_state (repo_prefix) VALUES ('gone')`)
+	require.NoError(t, err)
+	seedRepoRows(t, s.db, "live")
+	// A '' row must never be reported as an orphan.
+	_, err = s.db.Exec(`INSERT INTO file_mtimes (repo_prefix, file_path, mtime_ns) VALUES ('', 'g.go', 1)`)
+	require.NoError(t, err)
+
+	orphans := s.OrphanRepoPrefixes([]string{"live"})
+	assert.Equal(t, []string{"gone"}, orphans, "only the nodes-less residue prefix is an orphan")
+
+	// Case-fold safety net: a case-only spelling drift of a tracked repo is
+	// NOT an orphan.
+	assert.Empty(t, s.OrphanRepoPrefixes([]string{"LIVE", "GONE"}), "case-insensitive known set covers both prefixes")
+}
+
+func TestRekeyRepoPrefix_MovesProvenanceDropsNodeIDKeyed(t *testing.T) {
+	s := openPurgeStore(t)
+	seedRepoRows(t, s.db, "") // solo repo: everything under ''
+
+	require.NoError(t, s.RekeyRepoPrefix("", "drools"))
+
+	// Prefix/path-keyed provenance MOVED '' -> drools (so warm restart finds
+	// the repo's mtimes under the new prefix instead of full-re-tracking).
+	moveTables := []string{"file_mtimes", "files", "repo_index_state", "enrichment_state"}
+	for _, tbl := range moveTables {
+		assert.Equal(t, 0, countByPrefix(t, s.db, tbl, ""), "%s '' rows moved out", tbl)
+		assert.Equal(t, 1, countByPrefix(t, s.db, tbl, "drools"), "%s rows now under new prefix", tbl)
+	}
+
+	// node_id-keyed tables DROPPED (their old ids are dangling after the
+	// re-mint) — the FTS decision included.
+	dropTables := []string{
+		"clone_shingles", "constant_values", "ref_facts", "churn_enrichment",
+		"coverage_enrichment", "release_enrichment", "blame_enrichment",
+		"symbol_fts", "symbol_fts_rowid", "content_fts",
+	}
+	for _, tbl := range dropTables {
+		assert.Equal(t, 0, countByPrefix(t, s.db, tbl, ""), "%s '' rows dropped", tbl)
+		assert.Equal(t, 0, countByPrefix(t, s.db, tbl, "drools"), "%s NOT relabeled to new prefix", tbl)
+	}
+
+	assert.Error(t, s.RekeyRepoPrefix("repoA", ""), "rekey INTO the empty prefix is refused")
+}

--- a/internal/graph/store_sqlite/store_purge_test.go
+++ b/internal/graph/store_sqlite/store_purge_test.go
@@ -2,6 +2,7 @@ package store_sqlite
 
 import (
 	"database/sql"
+	"github.com/zzet/gortex/internal/graph"
 	"path/filepath"
 	"testing"
 
@@ -171,4 +172,51 @@ func TestRekeyRepoPrefix_MovesProvenanceDropsNodeIDKeyed(t *testing.T) {
 	}
 
 	assert.Error(t, s.RekeyRepoPrefix("repoA", ""), "rekey INTO the empty prefix is refused")
+}
+
+// TestContentCrashWindow simulates the D4 kill-window at the store level:
+// per-file delete+append leaves a mix of old+new content instead of an empty
+// table, and the end-of-track sweep (keep = files that STREAMED content this
+// run) reaps both files that vanished from disk and files that still exist
+// but no longer yield content sections.
+func TestContentCrashWindow(t *testing.T) {
+	s := openPurgeStore(t)
+	item := func(id, file, body string) graph.ContentFTSItem {
+		return graph.ContentFTSItem{NodeID: id, FilePath: file, Ordinal: 0, Body: body}
+	}
+	// Prior full index: three content files present.
+	require.NoError(t, s.AppendContent("r", []graph.ContentFTSItem{item("r::f1", "f1.md", "old one")}))
+	require.NoError(t, s.AppendContent("r", []graph.ContentFTSItem{item("r::f2", "f2.md", "old two")}))
+	require.NoError(t, s.AppendContent("r", []graph.ContentFTSItem{item("r::f3", "f3.md", "old three")}))
+
+	// A new full index re-streams only f1 (crash before it reached the
+	// rest): delete f1's rows then re-append. The other files' OLD rows must
+	// survive — no empty-table window.
+	require.NoError(t, s.WipeContentFileInRepo("r", "f1.md"))
+	require.NoError(t, s.AppendContent("r", []graph.ContentFTSItem{item("r::f1", "f1.md", "new one")}))
+
+	countFile := func(file string) int {
+		var n int
+		require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM content_fts WHERE repo_prefix='r' AND file_path=?`, file).Scan(&n))
+		return n
+	}
+	assert.Equal(t, 1, countFile("f1.md"), "f1 refreshed (delete+append, not doubled)")
+	assert.Equal(t, 1, countFile("f2.md"), "f2's old rows survive the mid-parse kill (no empty table)")
+	assert.Equal(t, 1, countFile("f3.md"), "f3's old rows survive the mid-parse kill (no empty table)")
+
+	// The next SUCCESSFUL completion: f2 was deleted from the repo, and f3
+	// STILL EXISTS on disk but was emptied — it streamed no content sections
+	// this run, so it is absent from the streamed set. The sweep keeps
+	// exactly the streamed set {f1}, reaping both the vanished file and the
+	// content->no-content transition (a disk-survival keep would have
+	// protected f3's stale rows forever).
+	require.NoError(t, s.DeleteContentFilesForRepoNotIn("r", map[string]struct{}{"f1.md": {}}))
+	assert.Equal(t, 1, countFile("f1.md"), "still-streaming file kept")
+	assert.Equal(t, 0, countFile("f2.md"), "vanished file swept")
+	assert.Equal(t, 0, countFile("f3.md"), "content->no-content transition swept despite surviving on disk")
+
+	// Empty keep is a deliberate no-op (the never-wipe-from-empty safety
+	// net; a zero-content walk routes to WipeContent instead).
+	require.NoError(t, s.DeleteContentFilesForRepoNotIn("r", nil))
+	assert.Equal(t, 1, countFile("f1.md"), "empty keep never wipes")
 }

--- a/internal/graph/storetest/storetest.go
+++ b/internal/graph/storetest/storetest.go
@@ -67,6 +67,7 @@ func RunConformance(t *testing.T, factory Factory) {
 	t.Run("EdgesByKind", func(t *testing.T) { testEdgesByKind(t, factory) })
 	t.Run("NodesByKind", func(t *testing.T) { testNodesByKind(t, factory) })
 	t.Run("EdgesWithUnresolvedTarget", func(t *testing.T) { testEdgesWithUnresolvedTarget(t, factory) })
+	t.Run("FnValuePlaceholderEdges", func(t *testing.T) { testFnValuePlaceholderEdges(t, factory) })
 	t.Run("GetNodesByIDs", func(t *testing.T) { testGetNodesByIDs(t, factory) })
 	t.Run("FindNodesByNames", func(t *testing.T) { testFindNodesByNames(t, factory) })
 	t.Run("GetEdgesByNodeIDs", func(t *testing.T) { testGetEdgesByNodeIDs(t, factory) })
@@ -983,6 +984,47 @@ func testEdgesWithUnresolvedTarget(t *testing.T, factory Factory) {
 	}
 	if !gotPrefixed {
 		t.Fatalf("EdgesWithUnresolvedTarget did not yield the multi-repo prefixed stub gortex::unresolved::Baz")
+	}
+}
+
+// testFnValuePlaceholderEdges pins graph.FnValuePlaceholderScanner: the scan
+// must return EXACTLY the fn-value gate placeholders (both the bare and the
+// multi-repo COPY-rewrite forms) and nothing else — not real references, not
+// non-fnvalue unresolved stubs, not resolved edges. It is the mirror image of
+// testEdgesWithUnresolvedTarget's exclusion.
+func testFnValuePlaceholderEdges(t *testing.T, factory Factory) {
+	t.Helper()
+	s := factory(t)
+	sc, ok := s.(graph.FnValuePlaceholderScanner)
+	if !ok {
+		t.Skip("backend does not implement FnValuePlaceholderScanner")
+	}
+	s.AddNode(mkNode("a", "A", "x.go", graph.KindFunction))
+	s.AddEdge(mkEdge("a", "b", graph.EdgeReferences))          // real reference — not a placeholder
+	s.AddEdge(mkEdge("a", "unresolved::Foo", graph.EdgeCalls)) // unresolved, but not fn-value
+	s.AddEdge(mkEdge("a", "resolved", graph.EdgeReferences))   // resolved
+	ph1 := mkEdge("a", "unresolved::fnvalue::handler", graph.EdgeReferences)
+	ph1.Line = 6
+	ph2 := mkEdge("a", "gortex::unresolved::fnvalue::handler", graph.EdgeReferences)
+	ph2.Line = 7
+	s.AddEdge(ph1)
+	s.AddEdge(ph2)
+
+	seen := map[string]bool{}
+	for e := range sc.FnValuePlaceholderEdges() {
+		if !graph.IsFnValuePlaceholder(e.To) {
+			t.Fatalf("FnValuePlaceholderEdges yielded a non-placeholder To: %s", e.To)
+		}
+		seen[e.To] = true
+	}
+	if len(seen) != 2 {
+		t.Fatalf("FnValuePlaceholderEdges yielded %d distinct placeholders, want 2 (bare + multi-repo forms only); got %v", len(seen), seen)
+	}
+	if !seen["unresolved::fnvalue::handler"] {
+		t.Fatalf("FnValuePlaceholderEdges missed the bare form; got %v", seen)
+	}
+	if !seen["gortex::unresolved::fnvalue::handler"] {
+		t.Fatalf("FnValuePlaceholderEdges missed the multi-repo COPY-rewrite form; got %v", seen)
 	}
 }
 

--- a/internal/graph/storetest/storetest.go
+++ b/internal/graph/storetest/storetest.go
@@ -68,6 +68,7 @@ func RunConformance(t *testing.T, factory Factory) {
 	t.Run("NodesByKind", func(t *testing.T) { testNodesByKind(t, factory) })
 	t.Run("EdgesWithUnresolvedTarget", func(t *testing.T) { testEdgesWithUnresolvedTarget(t, factory) })
 	t.Run("FnValuePlaceholderEdges", func(t *testing.T) { testFnValuePlaceholderEdges(t, factory) })
+	t.Run("LightEdgeScanner", func(t *testing.T) { testLightEdgeScanner(t, factory) })
 	t.Run("GetNodesByIDs", func(t *testing.T) { testGetNodesByIDs(t, factory) })
 	t.Run("FindNodesByNames", func(t *testing.T) { testFindNodesByNames(t, factory) })
 	t.Run("GetEdgesByNodeIDs", func(t *testing.T) { testGetEdgesByNodeIDs(t, factory) })
@@ -1000,7 +1001,7 @@ func testFnValuePlaceholderEdges(t *testing.T, factory Factory) {
 		t.Skip("backend does not implement FnValuePlaceholderScanner")
 	}
 	s.AddNode(mkNode("a", "A", "x.go", graph.KindFunction))
-	s.AddEdge(mkEdge("a", "b", graph.EdgeReferences))          // real reference — not a placeholder
+	s.AddEdge(mkEdge("a", "b", graph.EdgeReferences))         // real reference — not a placeholder
 	s.AddEdge(mkEdge("a", "unresolved::Foo", graph.EdgeCalls)) // unresolved, but not fn-value
 	s.AddEdge(mkEdge("a", "resolved", graph.EdgeReferences))   // resolved
 	ph1 := mkEdge("a", "unresolved::fnvalue::handler", graph.EdgeReferences)
@@ -1025,6 +1026,59 @@ func testFnValuePlaceholderEdges(t *testing.T, factory Factory) {
 	}
 	if !seen["gortex::unresolved::fnvalue::handler"] {
 		t.Fatalf("FnValuePlaceholderEdges missed the multi-repo COPY-rewrite form; got %v", seen)
+	}
+}
+
+// testLightEdgeScanner pins graph.LightEdgeScanner: the kind filter must scope
+// to the requested kinds (empty means all), and every promoted field must
+// survive the meta-less scan intact and equal the values written. (The
+// backend-specific Meta-is-nil guarantee is asserted where it holds — the disk
+// backend's own test — since the in-memory backend legitimately keeps Meta.)
+func testLightEdgeScanner(t *testing.T, factory Factory) {
+	t.Helper()
+	s := factory(t)
+	sc, ok := s.(graph.LightEdgeScanner)
+	if !ok {
+		t.Skip("backend does not implement LightEdgeScanner")
+	}
+	s.AddNode(mkNode("a", "A", "x.go", graph.KindFunction))
+	s.AddNode(mkNode("b", "B", "x.go", graph.KindFunction))
+	call := mkEdge("a", "b", graph.EdgeCalls)
+	call.Line, call.Confidence, call.Origin, call.Tier, call.CrossRepo = 11, 0.75, graph.OriginLSPResolved, "lsp", true
+	call.Meta = map[string]any{"via": "direct", "blob_only": "x"}
+	ref := mkEdge("a", "b", graph.EdgeReferences)
+	ref.Line = 22
+	imp := mkEdge("a", "b", graph.EdgeImports)
+	imp.Line = 33
+	s.AddEdge(call)
+	s.AddEdge(ref)
+	s.AddEdge(imp)
+
+	// Kind filter: calls + references, imports excluded.
+	got := sc.AllEdgesLight(graph.EdgeCalls, graph.EdgeReferences)
+	kinds := map[graph.EdgeKind]int{}
+	var lightCall *graph.Edge
+	for _, e := range got {
+		kinds[e.Kind]++
+		if e.Kind == graph.EdgeCalls {
+			lightCall = e
+		}
+	}
+	if len(got) != 2 || kinds[graph.EdgeCalls] != 1 || kinds[graph.EdgeReferences] != 1 || kinds[graph.EdgeImports] != 0 {
+		t.Fatalf("AllEdgesLight(calls,references) kind filter wrong: got %d edges %v, want {calls:1, references:1}", len(got), kinds)
+	}
+	// Empty kinds means every edge.
+	if all := sc.AllEdgesLight(); len(all) != 3 {
+		t.Fatalf("AllEdgesLight() with no kinds = %d, want 3 (all edges)", len(all))
+	}
+	// Promoted fields survive the meta-less scan.
+	if lightCall == nil {
+		t.Fatal("AllEdgesLight did not return the call edge")
+	}
+	if lightCall.Line != 11 || lightCall.Confidence != 0.75 || lightCall.Origin != graph.OriginLSPResolved ||
+		lightCall.Tier != "lsp" || !lightCall.CrossRepo {
+		t.Fatalf("AllEdgesLight dropped/altered a promoted field: line=%d conf=%v origin=%q tier=%q crossRepo=%v",
+			lightCall.Line, lightCall.Confidence, lightCall.Origin, lightCall.Tier, lightCall.CrossRepo)
 	}
 }
 

--- a/internal/graph/storetest/storetest.go
+++ b/internal/graph/storetest/storetest.go
@@ -944,23 +944,38 @@ func testEdgesWithUnresolvedTarget(t *testing.T, factory Factory) {
 	// the canonical matcher for both encodings.
 	e5 := mkEdge("a", "gortex::unresolved::Baz", graph.EdgeCalls)
 	e5.Line = 5
+	// Gate-owned fn-value placeholders: a captured function value parks at
+	// `unresolved::fnvalue::<name>` (bare and multi-repo forms) until the
+	// callback gate binds it. is_unresolved is 1 for them (they live in the
+	// unresolved space), but the master resolver can never bind them, so the
+	// pending scan MUST exclude both forms — otherwise they are pure bloat on
+	// the set the resolver reconciles every pass.
+	e6 := mkEdge("a", "unresolved::fnvalue::handler", graph.EdgeReferences)
+	e6.Line = 6
+	e7 := mkEdge("a", "gortex::unresolved::fnvalue::handler", graph.EdgeReferences)
+	e7.Line = 7
 	s.AddEdge(e1)
 	s.AddEdge(e2)
 	s.AddEdge(e3)
 	s.AddEdge(e4)
 	s.AddEdge(e5)
+	s.AddEdge(e6)
+	s.AddEdge(e7)
 
 	var unres []*graph.Edge
 	for e := range s.EdgesWithUnresolvedTarget() {
 		unres = append(unres, e)
 	}
 	if len(unres) != 3 {
-		t.Fatalf("EdgesWithUnresolvedTarget yielded %d, want 3 (unresolved::Foo, unresolved::Bar, gortex::unresolved::Baz)", len(unres))
+		t.Fatalf("EdgesWithUnresolvedTarget yielded %d, want 3 (unresolved::Foo, unresolved::Bar, gortex::unresolved::Baz); fn-value placeholders must be excluded", len(unres))
 	}
 	gotPrefixed := false
 	for _, e := range unres {
 		if !graph.IsUnresolvedTarget(e.To) {
 			t.Fatalf("yielded edge has non-unresolved To: %s", e.To)
+		}
+		if graph.IsFnValuePlaceholder(e.To) {
+			t.Fatalf("EdgesWithUnresolvedTarget yielded a gate-owned fn-value placeholder %q: the resolver pending scan must exclude both the bare and multi-repo forms", e.To)
 		}
 		if e.To == "gortex::unresolved::Baz" {
 			gotPrefixed = true

--- a/internal/graph/stub.go
+++ b/internal/graph/stub.go
@@ -141,6 +141,16 @@ func StubRest(id string) string {
 // data-flow tracker) don't have to know the encoding.
 const UnresolvedMarker = "unresolved::"
 
+// FnValuePlaceholderMarker is the sub-namespace the function-as-value capture
+// gate (parser/languages/fn_value_capture.go) owns inside the unresolved
+// space: a captured function value parks at `unresolved::fnvalue::<name>` until
+// resolver.ResolveFnValueCallbacks binds it to a same-file definition. These
+// placeholders are scaffolding for that gate alone — the master name resolver
+// can never bind them — so the resolver pending scan (EdgesWithUnresolvedTarget)
+// excludes the namespace via IsFnValuePlaceholder; the gate finds them itself
+// by walking EdgesByKind(references).
+const FnValuePlaceholderMarker = UnresolvedMarker + "fnvalue::"
+
 // IsUnresolvedTarget reports whether id names an unresolved
 // extractor stub in either the bare or the multi-repo form.
 func IsUnresolvedTarget(id string) bool {
@@ -151,6 +161,21 @@ func IsUnresolvedTarget(id string) bool {
 		return true
 	}
 	return strings.Contains(id, "::"+UnresolvedMarker)
+}
+
+// IsFnValuePlaceholder reports whether id is a fn-value gate placeholder in
+// either the bare `unresolved::fnvalue::<name>` form or the multi-repo
+// `<repoPrefix>::unresolved::fnvalue::<name>` COPY-rewrite form — mirroring
+// IsUnresolvedTarget's two shapes. The fn-value gate owns this namespace; the
+// resolver pending scan excludes it.
+func IsFnValuePlaceholder(id string) bool {
+	if id == "" {
+		return false
+	}
+	if strings.HasPrefix(id, FnValuePlaceholderMarker) {
+		return true
+	}
+	return strings.Contains(id, "::"+FnValuePlaceholderMarker)
 }
 
 // UnresolvedName returns the bare symbol name encoded in an

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -2521,12 +2521,43 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 		}
 	}
 
-	// Clear this repo's prior content rows before the per-file streaming
-	// appends below, so a full reindex (cold or warm) rebuilds the content
-	// index from a clean slate instead of accumulating stale sections.
-	// No-op on a cold store; cheap per-repo DELETE on a warm one.
+	// Content-index rebuild strategy. The crash-safe path (on-disk store)
+	// deletes each file's prior content rows as that file re-streams
+	// (contentWipeFile, invoked at the per-file AddBatch sites below) and
+	// sweeps every OTHER content row after the authoritative mtime replace —
+	// so a mid-parse kill leaves a mix of old+new content per file instead of
+	// the empty table a repo-wide pre-wipe would leave. contentStreamedFiles
+	// records which files actually streamed content this walk (the wipe's own
+	// argument, i.e. the node FilePath content_fts carries); the end sweep
+	// keeps exactly that set, so files that vanished from disk AND files that
+	// still exist but no longer yield content sections (doc emptied,
+	// classification changed) are both reaped in one scan — the transitions
+	// the old repo-wide pre-wipe used to cover. Backends without the per-file
+	// capability keep that old behaviour: one repo-wide wipe up front (a
+	// cold-store no-op; a cheap per-repo DELETE on a warm one).
+	var (
+		contentWipeFile      func(filePath string)
+		contentStreamedMu    sync.Mutex
+		contentStreamedFiles map[string]struct{}
+	)
 	if cs := idx.contentSearcher(); cs != nil {
-		if err := cs.WipeContent(idx.RepoPrefix()); err != nil {
+		if w, ok := cs.(interface {
+			WipeContentFileInRepo(repoPrefix, filePath string) error
+		}); ok {
+			repoPrefix := idx.RepoPrefix()
+			contentStreamedFiles = make(map[string]struct{})
+			contentWipeFile = func(filePath string) {
+				if filePath == "" {
+					return
+				}
+				contentStreamedMu.Lock()
+				contentStreamedFiles[filePath] = struct{}{}
+				contentStreamedMu.Unlock()
+				if err := w.WipeContentFileInRepo(repoPrefix, filePath); err != nil {
+					idx.logger.Warn("indexer: per-file content wipe failed", zap.Error(err))
+				}
+			}
+		} else if err := cs.WipeContent(idx.RepoPrefix()); err != nil {
 			idx.logger.Warn("indexer: content index wipe failed", zap.Error(err))
 		}
 	}
@@ -2612,6 +2643,53 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 		return os.ReadFile(wf.path)
 	}
 
+	// recordStreamedMtime persists a file's mtime incrementally, in batches,
+	// as its nodes land on disk during a full track — so a first-ever index
+	// killed mid-parse RESUMES on the next boot (the flushed files reconcile
+	// clean, the remainder re-parses) instead of re-tracking a large repo
+	// from scratch every time it dies under memory pressure.
+	//
+	// INVARIANT: an mtime row must land only AFTER its file's nodes are
+	// durably in the store, or a fresh mtime would falsely imply indexed
+	// nodes. The `idx.graph.(graph.FileMtimeWriter)` assertion is what
+	// enforces it: it succeeds ONLY on the direct-to-disk path, where
+	// idx.graph is the on-disk store and AddBatch has already made the
+	// file's nodes durable. On the whole-repo in-memory shadow and the
+	// streaming-flush per-chunk shadow, idx.graph is a plain graph.Graph
+	// (no FileMtimeWriter) whose nodes reach disk only at a later drain, so
+	// this self-skips and those paths persist at their own drain points (the
+	// final ReplaceFileMtimes / the streaming-flush per-chunk persist). The
+	// final ReplaceFileMtimes still runs and is authoritative — it also
+	// prunes deleted files — so these batches only bound the work a crash
+	// can waste; the leftover under-threshold tail rides that final replace.
+	var (
+		streamMtimeMu sync.Mutex
+		streamMtimes  = make(map[string]int64, mtimeStreamPersistEvery)
+	)
+	recordStreamedMtime := func(absPath string, mtimeNano int64) {
+		if mtimeNano <= 0 {
+			return
+		}
+		w, ok := idx.graph.(graph.FileMtimeWriter)
+		if !ok {
+			return
+		}
+		var flush map[string]int64
+		streamMtimeMu.Lock()
+		streamMtimes[idx.relKey(absPath)] = mtimeNano
+		if len(streamMtimes) >= mtimeStreamPersistEvery {
+			flush = streamMtimes
+			streamMtimes = make(map[string]int64, mtimeStreamPersistEvery)
+		}
+		streamMtimeMu.Unlock()
+		if flush != nil {
+			if err := w.BulkSetFileMtimes(idx.repoPrefix, flush); err != nil {
+				idx.logger.Warn("indexer: incremental mtime batch persist failed",
+					zap.String("repo", idx.repoPrefix), zap.Error(err))
+			}
+		}
+	}
+
 	// parseChunk runs the per-file worker pool over the supplied
 	// slice. Closure over outer state (errors, counters, contract
 	// registry, parsePool, quarantine) so it can be called multiple
@@ -2668,9 +2746,13 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 								continue
 							}
 							idx.applyRepoPrefix(result.Nodes, result.Edges)
+							if contentWipeFile != nil {
+								contentWipeFile(firstContentFilePath(result.Nodes))
+							}
 							idx.streamContentSections(result.Nodes)
 							idx.graph.AddBatch(result.Nodes, result.Edges)
 							idx.persistConstValues(result)
+							recordStreamedMtime(path, wf.mtimeNano)
 							continue
 						}
 					}
@@ -2785,6 +2867,9 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 					// nodes to a snippet BEFORE AddBatch, so the bulk text
 					// never enters the graph, the symbol search, or the
 					// materialising code passes.
+					if contentWipeFile != nil {
+						contentWipeFile(firstContentFilePath(result.Nodes))
+					}
 					idx.streamContentSections(result.Nodes)
 
 					// Batch the per-file insert into one shard-grouped pass
@@ -2795,6 +2880,7 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 					idx.graph.AddBatch(result.Nodes, result.Edges)
 					idx.persistConstValues(result)
 					idx.persistFileMeta(relPath, src, result)
+					recordStreamedMtime(path, wf.mtimeNano)
 
 					if !skipped && fileGraphPath != "" {
 						exts := contractExtractorsByLang[lang]
@@ -2879,6 +2965,27 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 			streamingDisk.AddBatch(chunkShadow.AllNodes(), chunkShadow.AllEdges())
 			if err := bl.FlushBulk(); err != nil {
 				return nil, fmt.Errorf("indexer: streaming-flush chunk %d..%d: %w", chunkStart, chunkEnd, err)
+			}
+			// This chunk's nodes are durable on disk now, so persist its
+			// files' mtimes — a kill mid-track then resumes from this chunk
+			// boundary instead of re-tracking the whole large first index
+			// from scratch. The in-worker recordStreamedMtime is a no-op on
+			// this path (idx.graph was the throwaway per-chunk shadow, not a
+			// FileMtimeWriter); the persist happens here, after the drain,
+			// keeping the "fresh mtime implies durable nodes" invariant.
+			if w, ok := streamingDisk.(graph.FileMtimeWriter); ok {
+				batch := make(map[string]int64, chunkEnd-chunkStart)
+				for _, f := range files[chunkStart:chunkEnd] {
+					if f.mtimeNano > 0 {
+						batch[idx.relKey(f.path)] = f.mtimeNano
+					}
+				}
+				if len(batch) > 0 {
+					if err := w.BulkSetFileMtimes(idx.repoPrefix, batch); err != nil {
+						idx.logger.Warn("indexer: streaming-flush chunk mtime persist failed",
+							zap.String("repo", idx.repoPrefix), zap.Error(err))
+					}
+				}
 			}
 		}
 		// After all chunks, idx.graph points at the disk store so
@@ -2967,6 +3074,40 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 				idx.logger.Info("persisted file mtimes",
 					zap.String("repo", idx.repoPrefix),
 					zap.Int("count", len(mtimeSnapshot)))
+			}
+		}
+
+		// Crash-safe content path: reap every content row this walk did NOT
+		// re-stream. keep is contentStreamedFiles — the files that actually
+		// produced content sections this run — NOT the surviving-file mtime
+		// set: a file can survive on disk yet stop yielding content (doc
+		// emptied, classification changed), and keying keep off mtimes would
+		// protect its stale rows forever. Recorded keys are the wipe's own
+		// argument (the node FilePath content_fts carries), so the comparison
+		// matches the stored rows in single- and multi-repo form alike. A walk
+		// that streamed NO content falls back to the repo-wide wipe: the repo
+		// has zero content files now, and the sweep's empty-keep guard (a
+		// never-wipe-from-empty safety net) would otherwise no-op and leave
+		// every stale row behind. Only when the per-file wipe path is active;
+		// on the repo-wide-wipe fallback the up-front pre-wipe already cleared
+		// both transitions. Runs only under the completed-walk guard above
+		// (len(mtimeSnapshot) > 0), so a killed parse never triggers it.
+		if contentWipeFile != nil {
+			contentStreamedMu.Lock()
+			keep := contentStreamedFiles
+			contentStreamedMu.Unlock()
+			if len(keep) == 0 {
+				if cs := idx.contentSearcher(); cs != nil {
+					if err := cs.WipeContent(idx.RepoPrefix()); err != nil {
+						idx.logger.Warn("indexer: content wipe of contentless repo failed", zap.Error(err))
+					}
+				}
+			} else if sw, ok := idx.contentSearcher().(interface {
+				DeleteContentFilesForRepoNotIn(repoPrefix string, keep map[string]struct{}) error
+			}); ok {
+				if err := sw.DeleteContentFilesForRepoNotIn(idx.repoPrefix, keep); err != nil {
+					idx.logger.Warn("indexer: content sweep of stale files failed", zap.Error(err))
+				}
 			}
 		}
 	}

--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -1191,6 +1191,27 @@ func (mi *MultiIndexer) migrateLoneUnprefixedRepoCtx(ctx context.Context) {
 		mi.graph.EvictFile(path)
 	}
 
+	// EvictFile clears only nodes+edges; the solo repo's sidecar rows
+	// (file_mtimes, repo_index_state, enrichment_state, ...) were written
+	// under the empty prefix and would otherwise be orphaned — the very next
+	// warm restart would look for mtimes under the new prefix, find zero, and
+	// full-re-track a repo that never changed. Re-key the '' sidecar residue
+	// onto the new prefix. The re-mint re-index above already wrote fresh
+	// new-prefix rows; RekeyRepoPrefix folds the prefix/path-keyed ones and
+	// drops the node_id-keyed ones (whose ids changed under the re-mint) —
+	// see its per-table rationale. Safe on '': the store is still single-repo
+	// here, so '' holds only this repo's data (the synthetic global externals
+	// a multi-repo graph parks under '' live in NODES, which the rekey — a
+	// sidecar-only operation — never touches).
+	if rk, ok := mi.graph.(interface {
+		RekeyRepoPrefix(oldPrefix, newPrefix string) error
+	}); ok {
+		if err := rk.RekeyRepoPrefix("", oldPrefix); err != nil {
+			mi.logger.Warn("re-keying lone repo sidecar rows failed; orphaned '' rows remain until purge",
+				zap.String("prefix", oldPrefix), zap.Error(err))
+		}
+	}
+
 	mi.mu.Lock()
 	mi.repos[oldPrefix] = &RepoMetadata{
 		RepoPrefix:    oldPrefix,
@@ -2083,7 +2104,24 @@ func (mi *MultiIndexer) UntrackRepo(repoPrefix string) (int, int) {
 			nodesRemoved += n
 			edgesRemoved += e
 		}
+	} else if purger, ok := mi.graph.(interface{ PurgeRepo(string) error }); ok {
+		// Prefer the full sidecar-aware purge. EvictRepo drops only
+		// nodes+edges and leaves fifteen repo_prefix-keyed sidecar tables
+		// (file_mtimes, *_enrichment, symbol_fts, content_fts, ...) behind,
+		// which accumulate across untrack/retrack cycles until they dominate
+		// a long-lived store. PurgeRepo clears them in one transaction. It
+		// returns no counts, so report the repo's last-index metadata as the
+		// removed estimate; fall back to EvictRepo (real counts) on error.
+		if err := purger.PurgeRepo(repoPrefix); err != nil {
+			mi.logger.Warn("purge repo failed; falling back to node/edge eviction",
+				zap.String("prefix", repoPrefix), zap.Error(err))
+			nodesRemoved, edgesRemoved = mi.graph.EvictRepo(repoPrefix)
+		} else {
+			nodesRemoved, edgesRemoved = meta.NodeCount, meta.EdgeCount
+		}
 	} else {
+		// Backends without the purge capability (the in-memory store has no
+		// sidecars, so EvictRepo is already complete there).
 		nodesRemoved, edgesRemoved = mi.graph.EvictRepo(repoPrefix)
 	}
 

--- a/internal/indexer/shadow_threshold.go
+++ b/internal/indexer/shadow_threshold.go
@@ -25,6 +25,16 @@ const defaultShadowMaxFileCount = 50000
 // RAM even on 8GB build agents.
 const defaultStreamingChunkSize = 5000
 
+// mtimeStreamPersistEvery is how many files' mtimes the direct-to-disk
+// full-index path buffers before flushing them to the store's FileMtime
+// sidecar (see recordStreamedMtime in IndexCtx). It makes a first-ever
+// track crash-resumable: a kill after some batches have flushed re-parses
+// only the tail on the next boot, instead of re-tracking the whole repo
+// from scratch every time it dies under memory pressure. A var, not a
+// const, so a test can lower it to observe the incremental flush without
+// staging thousands of fixture files.
+var mtimeStreamPersistEvery = 500
+
 // shadowMaxFileCount returns the active file-count ceiling for the
 // IndexCtx in-memory shadow swap. GORTEX_SHADOW_MAX_FILES overrides
 // the default; setting it to 0 disables the shadow entirely (always

--- a/internal/indexer/store_hygiene_indexer_test.go
+++ b/internal/indexer/store_hygiene_indexer_test.go
@@ -2,7 +2,11 @@ package indexer
 
 import (
 	"context"
+	"fmt"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -102,4 +106,104 @@ type mtimeCountingStore struct {
 func (m *mtimeCountingStore) BulkSetFileMtimes(prefix string, mtimes map[string]int64) error {
 	m.bulkCalls.Add(1)
 	return m.Store.BulkSetFileMtimes(prefix, mtimes)
+}
+
+// D5: on the direct-to-disk full-index path, mtimes are flushed in batches as
+// files land, so a kill mid-track resumes instead of re-tracking from
+// scratch. Proven by counting the incremental BulkSetFileMtimes flushes.
+func TestFullIndex_PersistsMtimesIncrementallyOnDiskPath(t *testing.T) {
+	// Force the direct-to-disk path (no in-memory shadow) and a small flush
+	// batch so a handful of files triggers several flushes.
+	t.Setenv("GORTEX_SHADOW_MAX_FILES", "0")
+	prev := mtimeStreamPersistEvery
+	mtimeStreamPersistEvery = 2
+	t.Cleanup(func() { mtimeStreamPersistEvery = prev })
+
+	dir := t.TempDir()
+	const nFiles = 6
+	for i := 0; i < nFiles; i++ {
+		writeFile(t, filepath.Join(dir, fmt.Sprintf("f%d.go", i)),
+			fmt.Sprintf("package main\n\nfunc F%d() {}\n", i))
+	}
+
+	base, err := store_sqlite.Open(filepath.Join(t.TempDir(), "store.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = base.Close() })
+	s := &mtimeCountingStore{Store: base}
+
+	idx := New(graph.Store(s), newTestRegistry(), config.Default().Index, zap.NewNop())
+	idx.SetRootPath(dir)
+	_, err = idx.IndexCtx(context.Background(), dir)
+	require.NoError(t, err)
+
+	// nFiles files flushed every 2 => the incremental path fired at least
+	// twice DURING the parse (the final replace uses ReplaceFileMtimes, which
+	// this counter does not see).
+	assert.GreaterOrEqual(t, s.bulkCalls.Load(), int64(2),
+		"disk-path full index must persist mtimes incrementally via BulkSetFileMtimes")
+
+	// Every file's mtime is durable at the end (final authoritative replace).
+	got := base.LoadFileMtimes("")
+	for i := 0; i < nFiles; i++ {
+		assert.Contains(t, got, fmt.Sprintf("f%d.go", i), "every file's mtime persisted")
+	}
+}
+
+// D4: the end-of-track content sweep keeps only the files that STREAMED
+// content sections this walk — so a file that still exists on disk but
+// stopped yielding content (doc emptied) loses its stale rows, and a walk
+// that ends with zero content files wipes the repo's content outright. A
+// keep-set derived from surviving files would protect both leaks forever.
+func TestContentSweep_ReapsEmptiedFilesAndContentlessRepo(t *testing.T) {
+	// Force the direct-to-disk path — the crash-relevant one the per-file
+	// wipe + end sweep were built for (mirrors content_split's disk_path).
+	t.Setenv("GORTEX_SHADOW_MAX_BYTES", "1")
+
+	dir := t.TempDir()
+	body := strings.Repeat("searchable prose for the content splitter ", 40)
+	writeFile(t, filepath.Join(dir, "main.go"), "package main\n\nfunc Keep() {}\n")
+	writeFile(t, filepath.Join(dir, "doc1.txt"), body)
+	writeFile(t, filepath.Join(dir, "doc2.txt"), body)
+
+	store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "store.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	reg := parser.NewRegistry()
+	languages.RegisterAll(reg)
+	cfg := config.Default().Index
+	cfg.Workers = 2
+	_, err = New(graph.Store(store), reg, cfg, zap.NewNop()).IndexCtx(context.Background(), dir)
+	require.NoError(t, err)
+
+	contentFiles := func() map[string]bool {
+		got := map[string]bool{}
+		require.NoError(t, store.ScanContent("", func(_, filePath, _ string) bool {
+			got[filePath] = true
+			return true
+		}))
+		return got
+	}
+	first := contentFiles()
+	require.True(t, first["doc1.txt"], "doc1 content indexed on the first walk")
+	require.True(t, first["doc2.txt"], "doc2 content indexed on the first walk")
+
+	// doc2 is emptied but SURVIVES on disk: the next full walk streams no
+	// sections for it, so it is absent from the streamed set and the sweep
+	// reaps its stale rows, while doc1's re-streamed rows survive.
+	writeFile(t, filepath.Join(dir, "doc2.txt"), "")
+	_, err = New(graph.Store(store), reg, cfg, zap.NewNop()).IndexCtx(context.Background(), dir)
+	require.NoError(t, err)
+
+	second := contentFiles()
+	assert.True(t, second["doc1.txt"], "still-content file keeps its rows")
+	assert.False(t, second["doc2.txt"], "emptied file's stale rows reaped despite surviving on disk")
+
+	// Both docs emptied: the walk streams zero content, so the zero-content
+	// branch fires the repo-wide wipe (the sweep's empty-keep no-op guard
+	// alone would leak doc1's stale rows).
+	writeFile(t, filepath.Join(dir, "doc1.txt"), "")
+	_, err = New(graph.Store(store), reg, cfg, zap.NewNop()).IndexCtx(context.Background(), dir)
+	require.NoError(t, err)
+	assert.Empty(t, contentFiles(), "contentless repo ends with an empty content index")
 }

--- a/internal/indexer/store_hygiene_indexer_test.go
+++ b/internal/indexer/store_hygiene_indexer_test.go
@@ -1,0 +1,105 @@
+package indexer
+
+import (
+	"context"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/search"
+)
+
+// newSqliteMultiIndexer builds a MultiIndexer over a real on-disk sqlite
+// store (the only backend with sidecar tables) for the two repos in repos.
+// Returns the indexer and the store so a test can read the persisted
+// sidecars directly.
+func newSqliteMultiIndexer(t *testing.T, repos []config.RepoEntry) (*MultiIndexer, *store_sqlite.Store) {
+	t.Helper()
+	tmpCfg := filepath.Join(t.TempDir(), "config.yaml")
+	gc := &config.GlobalConfig{Repos: repos}
+	gc.SetConfigPath(tmpCfg)
+	require.NoError(t, gc.Save())
+	cm, err := config.NewConfigManager(tmpCfg)
+	require.NoError(t, err)
+
+	s, err := store_sqlite.Open(filepath.Join(t.TempDir(), "store.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	mi := NewMultiIndexer(graph.Store(s), newTestRegistry(), search.NewBM25(), cm, zap.NewNop())
+	return mi, s
+}
+
+// D1: untracking a prefixed repo must take the capability path (PurgeRepo)
+// and clear its sidecar rows, not just nodes+edges — otherwise a store
+// accumulates file_mtimes/etc. residue across untrack/retrack cycles.
+func TestUntrackRepo_PurgesSidecarRows(t *testing.T) {
+	repoA := setupRepoDir(t, "repo-a")
+	repoB := setupRepoDir(t, "repo-b")
+	mi, s := newSqliteMultiIndexer(t, []config.RepoEntry{
+		{Path: repoA, Name: "repo-a"},
+		{Path: repoB, Name: "repo-b"},
+	})
+	_, err := mi.IndexAll()
+	require.NoError(t, err)
+	require.True(t, mi.IsMultiRepo(), "two repos -> prefixed multi-repo mode")
+
+	require.NotEmpty(t, s.LoadFileMtimes("repo-a"), "repo-a mtimes persisted under its prefix")
+	require.NotEmpty(t, s.LoadFileMtimes("repo-b"), "repo-b mtimes persisted under its prefix")
+
+	mi.UntrackRepo("repo-a")
+
+	// PurgeRepo cleared repo-a's sidecar (EvictRepo alone would have leaked
+	// it); repo-b untouched.
+	assert.Empty(t, s.LoadFileMtimes("repo-a"), "untrack purged repo-a's file_mtimes sidecar")
+	assert.Empty(t, s.GetRepoNodes("repo-a"), "untrack evicted repo-a's nodes")
+	assert.NotEmpty(t, s.LoadFileMtimes("repo-b"), "repo-b sidecars intact")
+	assert.NotEmpty(t, s.GetRepoNodes("repo-b"), "repo-b nodes intact")
+}
+
+// D3: when a second repo joins a lone single-repo daemon, the first repo's
+// nodes are re-minted under its prefix — and its sidecar residue must move
+// with them, or the next warm restart finds zero mtimes under the new prefix
+// and full-re-tracks a repo that never changed.
+func TestMigrateLoneUnprefixed_ReKeysMtimesToNewPrefix(t *testing.T) {
+	repoA := setupRepoDir(t, "repo-a")
+	mi, s := newSqliteMultiIndexer(t, []config.RepoEntry{{Path: repoA, Name: "repo-a"}})
+	_, err := mi.IndexAll()
+	require.NoError(t, err)
+	require.False(t, mi.IsMultiRepo(), "one repo indexes unprefixed")
+
+	require.NotEmpty(t, s.LoadFileMtimes(""), "solo repo persists mtimes under ''")
+	require.Empty(t, s.LoadFileMtimes("repo-a"), "nothing under the basename prefix yet")
+
+	// Track a second repo -> migrateLoneUnprefixedRepoCtx fires.
+	repoB := setupRepoDir(t, "repo-b")
+	_, err = mi.TrackRepoCtx(context.Background(), config.RepoEntry{Path: repoB, Name: "repo-b"})
+	require.NoError(t, err)
+	require.True(t, mi.IsMultiRepo())
+
+	// The exact warm-restart bug: mtimes must now live under the new prefix,
+	// and '' must no longer carry the migrated repo's residue.
+	assert.NotEmpty(t, s.LoadFileMtimes("repo-a"), "migrated repo's mtimes now load under its prefix")
+	assert.Empty(t, s.LoadFileMtimes(""), "no '' file_mtimes residue survives the migration")
+}
+
+// mtimeCountingStore counts BulkSetFileMtimes calls so a test can prove the
+// full-index path persists mtimes INCREMENTALLY (before the final
+// authoritative ReplaceFileMtimes), not just at the end. Every other method
+// is the embedded on-disk store.
+type mtimeCountingStore struct {
+	*store_sqlite.Store
+	bulkCalls atomic.Int64
+}
+
+func (m *mtimeCountingStore) BulkSetFileMtimes(prefix string, mtimes map[string]int64) error {
+	m.bulkCalls.Add(1)
+	return m.Store.BulkSetFileMtimes(prefix, mtimes)
+}

--- a/internal/llm/config.go
+++ b/internal/llm/config.go
@@ -169,6 +169,11 @@ type LocalConfig struct {
 	// Template is the chat-template family: "chatml" (Qwen2.5,
 	// Hermes-3) or "llama3" (Llama-3.x native). Defaults to "chatml".
 	Template string `mapstructure:"template" yaml:"template,omitempty"`
+	// IdleTTL is the idle window after which the loaded model is unloaded to
+	// reclaim its (V)RAM — a Go duration string ("10m", the default when
+	// empty). "0"/"off"/"none" keeps the model resident once loaded. The
+	// GORTEX_LLM_IDLE_TTL env var overrides this at runtime (env wins).
+	IdleTTL string `mapstructure:"idle_ttl" yaml:"idle_ttl,omitempty"`
 }
 
 // RemoteConfig is the sub-block shared by the HTTP API providers

--- a/internal/llm/provider/local/gate.go
+++ b/internal/llm/provider/local/gate.go
@@ -22,14 +22,21 @@ var errGateClosed = errors.New("local: provider closed")
 // unloaded when GORTEX_LLM_IDLE_TTL is unset.
 const defaultIdleTTL = 10 * time.Minute
 
-// idleTTLFromEnv resolves the idle-unload TTL from GORTEX_LLM_IDLE_TTL.
-// The value is a verbatim Go duration (e.g. "5m"); "0" / "off" / "none"
-// disables idle unloading (the model, once loaded, stays resident); an
-// unset or unparseable value falls back to defaultIdleTTL. Parsed the
-// same way the enrichment timeout override is (see
+// idleTTLFromEnv resolves the idle-unload TTL. Precedence: the
+// GORTEX_LLM_IDLE_TTL env var wins when set (non-empty); otherwise the
+// llm.local.idle_ttl config value (configTTL); otherwise defaultIdleTTL. In
+// either source the value is a verbatim Go duration ("5m"); "0" / "off" /
+// "none" disables idle unloading (the model, once loaded, stays resident); an
+// unset or unparseable value falls back to defaultIdleTTL. Env wins so an
+// operator can override a checked-in config at runtime without editing the
+// file. Parsed the same way the enrichment timeout override is (see
 // semantic.enrichRepoTimeout).
-func idleTTLFromEnv() time.Duration {
-	switch v := strings.TrimSpace(os.Getenv("GORTEX_LLM_IDLE_TTL")); v {
+func idleTTLFromEnv(configTTL string) time.Duration {
+	v := strings.TrimSpace(os.Getenv("GORTEX_LLM_IDLE_TTL"))
+	if v == "" {
+		v = strings.TrimSpace(configTTL)
+	}
+	switch v {
 	case "":
 		return defaultIdleTTL
 	case "0", "off", "none":

--- a/internal/llm/provider/local/gate_test.go
+++ b/internal/llm/provider/local/gate_test.go
@@ -333,28 +333,44 @@ func TestIdleTicker_StopIsIdempotent(t *testing.T) {
 
 func TestIdleTTLFromEnv(t *testing.T) {
 	cases := []struct {
-		val  string
-		set  bool
+		name string
+		val  string // GORTEX_LLM_IDLE_TTL value
+		set  bool   // whether the env var is set at all
+		cfg  string // llm.local.idle_ttl config fallback
 		want time.Duration
 	}{
-		{set: false, want: defaultIdleTTL},
-		{val: "", set: true, want: defaultIdleTTL},
-		{val: "5m", set: true, want: 5 * time.Minute},
-		{val: "30s", set: true, want: 30 * time.Second},
-		{val: "0", set: true, want: 0},
-		{val: "off", set: true, want: 0},
-		{val: "none", set: true, want: 0},
-		{val: "garbage", set: true, want: defaultIdleTTL},
+		// Env-only (no config): the original behaviour is preserved.
+		{name: "env unset, no config", set: false, want: defaultIdleTTL},
+		{name: "env empty, no config", val: "", set: true, want: defaultIdleTTL},
+		{name: "env 5m", val: "5m", set: true, want: 5 * time.Minute},
+		{name: "env 30s", val: "30s", set: true, want: 30 * time.Second},
+		{name: "env 0 disables", val: "0", set: true, want: 0},
+		{name: "env off disables", val: "off", set: true, want: 0},
+		{name: "env none disables", val: "none", set: true, want: 0},
+		{name: "env garbage -> default", val: "garbage", set: true, want: defaultIdleTTL},
+		// Config fallback: consulted only when the env var is unset.
+		{name: "config 15m, env unset", set: false, cfg: "15m", want: 15 * time.Minute},
+		{name: "config off, env unset", set: false, cfg: "off", want: 0},
+		{name: "config garbage, env unset", set: false, cfg: "garbage", want: defaultIdleTTL},
+		{name: "config empty, env unset", set: false, cfg: "", want: defaultIdleTTL},
+		// Precedence: a set env var wins over any config value.
+		{name: "env 5m beats config 15m", val: "5m", set: true, cfg: "15m", want: 5 * time.Minute},
+		{name: "env off beats config 15m", val: "off", set: true, cfg: "15m", want: 0},
+		// An explicitly-empty env var does NOT count as set, so config wins.
+		{name: "env empty falls through to config", val: "", set: true, cfg: "15m", want: 15 * time.Minute},
 	}
 	for _, tc := range cases {
-		if tc.set {
-			t.Setenv("GORTEX_LLM_IDLE_TTL", tc.val)
-		} else {
-			_ = os.Unsetenv("GORTEX_LLM_IDLE_TTL")
-		}
-		if got := idleTTLFromEnv(); got != tc.want {
-			t.Errorf("idleTTLFromEnv(%q,set=%v) = %s, want %s", tc.val, tc.set, got, tc.want)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv("GORTEX_LLM_IDLE_TTL", tc.val)
+			} else {
+				_ = os.Unsetenv("GORTEX_LLM_IDLE_TTL")
+			}
+			if got := idleTTLFromEnv(tc.cfg); got != tc.want {
+				t.Errorf("idleTTLFromEnv(cfg=%q) with env(%q,set=%v) = %s, want %s",
+					tc.cfg, tc.val, tc.set, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/llm/provider/local/local.go
+++ b/internal/llm/provider/local/local.go
@@ -102,7 +102,7 @@ func New(cfg llm.LocalConfig) (llm.Provider, error) {
 	if cfg.Ctx <= 0 {
 		cfg.Ctx = 4096
 	}
-	p := &Provider{cfg: cfg, tmpl: tmpl, ttl: idleTTLFromEnv()}
+	p := &Provider{cfg: cfg, tmpl: tmpl, ttl: idleTTLFromEnv(cfg.IdleTTL)}
 	p.gate = newIdleGate(p.loadResources, p.unloadResources)
 	// The idle reaper only runs when a TTL is configured; a disabled TTL
 	// (GORTEX_LLM_IDLE_TTL=0/off/none) keeps the model resident once

--- a/internal/mcp/diagnostics.go
+++ b/internal/mcp/diagnostics.go
@@ -102,11 +102,26 @@ func (b *diagnosticsBroadcaster) publish(specName, absPath string, diags []lsp.D
 	hash := hashDiagnostics(diags)
 
 	b.mu.Lock()
-	if b.lastHash[absPath] == hash {
-		b.mu.Unlock()
-		return
+	prev, had := b.lastHash[absPath]
+	if len(diags) == 0 {
+		// A cleared file. Suppress unless it was previously non-empty:
+		// a file that never had (or already dropped) diagnostics must
+		// not emit a spurious clear. Drop the key on the clear so
+		// lastHash only ever holds live non-empty fingerprints — that,
+		// not an "empty" entry accumulated per file the server ever
+		// touched, is what keeps the map bounded.
+		if !had {
+			b.mu.Unlock()
+			return
+		}
+		delete(b.lastHash, absPath)
+	} else {
+		if prev == hash {
+			b.mu.Unlock()
+			return
+		}
+		b.lastHash[absPath] = hash
 	}
-	b.lastHash[absPath] = hash
 	subs := make([]*diagnosticsSubscriber, 0, len(b.subscribers))
 	for _, s := range b.subscribers {
 		subs = append(subs, s)
@@ -114,8 +129,8 @@ func (b *diagnosticsBroadcaster) publish(specName, absPath string, diags []lsp.D
 	b.mu.Unlock()
 
 	if len(subs) == 0 {
-		// Hash already updated above — late subscribers won't see a
-		// stale replay of this payload during their initial snapshot.
+		// Hash state already updated above — late subscribers won't see
+		// a stale replay of this payload during their initial snapshot.
 		return
 	}
 

--- a/internal/mcp/diagnostics_test.go
+++ b/internal/mcp/diagnostics_test.go
@@ -107,6 +107,51 @@ func TestDiagnosticsBroadcaster_DeltaFilter(t *testing.T) {
 	require.Len(t, fake.snapshot(), 2, "exactly two deliveries after delta filter")
 }
 
+// TestDiagnosticsBroadcaster_ClearPrunesHash — a file clearing its
+// diagnostics broadcasts the clear exactly once (only when it was
+// previously non-empty) and drops its lastHash key, so the map doesn't
+// retain an entry per file the server ever touched.
+func TestDiagnosticsBroadcaster_ClearPrunesHash(t *testing.T) {
+	fake := &fakeSpecificSender{}
+	b := newDiagnosticsBroadcaster(fake, noSnapshot, zap.NewNop())
+	b.subscribe("session-A", subscribeOptions{})
+
+	const path = "/work/main.go"
+	b.publish("gopls", path, []lsp.Diagnostic{{Message: "boom", Severity: 1}}) // non-empty
+	b.publish("gopls", path, nil)                                              // cleared
+	b.publish("gopls", path, nil)                                              // still empty — suppressed
+
+	calls := fake.snapshot()
+	require.Len(t, calls, 2, "one non-empty publish + one clear; the second clear is suppressed")
+
+	// The clear delivery carries an empty diagnostics list.
+	clear, _ := calls[1].params["diagnostics"].([]map[string]any)
+	assert.Empty(t, clear, "clear broadcast carries no diagnostics")
+
+	// The key is pruned, so lastHash doesn't grow one entry per touched file.
+	b.mu.RLock()
+	_, present := b.lastHash[path]
+	b.mu.RUnlock()
+	assert.False(t, present, "lastHash key removed after clear")
+}
+
+// TestDiagnosticsBroadcaster_ClearWithoutPriorSuppressed — an empty
+// publish for a file that never had diagnostics is not broadcast (no
+// spurious clear) and leaves no lastHash entry.
+func TestDiagnosticsBroadcaster_ClearWithoutPriorSuppressed(t *testing.T) {
+	fake := &fakeSpecificSender{}
+	b := newDiagnosticsBroadcaster(fake, noSnapshot, zap.NewNop())
+	b.subscribe("session-A", subscribeOptions{})
+
+	b.publish("gopls", "/work/clean.go", nil)
+
+	assert.Empty(t, fake.snapshot(), "no prior diagnostics — clear suppressed")
+	b.mu.RLock()
+	_, present := b.lastHash["/work/clean.go"]
+	b.mu.RUnlock()
+	assert.False(t, present)
+}
+
 // TestDiagnosticsBroadcaster_PayloadShape — payload carries the
 // expected fields and the wire-form diagnostics list.
 func TestDiagnosticsBroadcaster_PayloadShape(t *testing.T) {

--- a/internal/mcp/feedback.go
+++ b/internal/mcp/feedback.go
@@ -7,6 +7,29 @@ import (
 	"github.com/zzet/gortex/internal/persistence"
 )
 
+// feedbackMaxEntries bounds the in-memory feedback log. Aggregation
+// scans every entry and the store is reloaded in full on startup, so an
+// unbounded log grows the daemon's heap and slows every AggregatedStats
+// call for the life of the repo. The disk store is separately capped in
+// persistence.SaveFeedback, but that trim only runs when a cache dir is
+// configured; this cap also holds for the dir-less (embedded) manager
+// and defends against an oversized store loaded from disk. Aggregation
+// degrades gracefully — recent feedback dominates the signal, so the
+// oldest entries age out first.
+const feedbackMaxEntries = 4096
+
+// trimFeedbackEntries keeps only the newest feedbackMaxEntries entries,
+// copying into a fresh slice so the trimmed history is released rather
+// than pinned by a shared backing array.
+func trimFeedbackEntries(entries []persistence.FeedbackEntry) []persistence.FeedbackEntry {
+	if len(entries) <= feedbackMaxEntries {
+		return entries
+	}
+	trimmed := make([]persistence.FeedbackEntry, feedbackMaxEntries)
+	copy(trimmed, entries[len(entries)-feedbackMaxEntries:])
+	return trimmed
+}
+
 // feedbackManager provides thread-safe access to agent feedback data
 // and handles persistence across server restarts.
 type feedbackManager struct {
@@ -27,6 +50,7 @@ func newFeedbackManager(cacheDir, repoPath string) *feedbackManager {
 	loaded, err := persistence.LoadFeedback(dir)
 	if err == nil && loaded != nil {
 		fm.store = *loaded
+		fm.store.Entries = trimFeedbackEntries(fm.store.Entries)
 	}
 	return fm
 }
@@ -43,6 +67,7 @@ func (fm *feedbackManager) Record(entry persistence.FeedbackEntry) error {
 		entry.Keywords = keywordTokens(entry.Task)
 	}
 	fm.store.Entries = append(fm.store.Entries, entry)
+	fm.store.Entries = trimFeedbackEntries(fm.store.Entries)
 
 	if fm.dir == "" {
 		return nil

--- a/internal/mcp/feedback_test.go
+++ b/internal/mcp/feedback_test.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -152,4 +153,25 @@ func TestFeedbackManager_FilterByToolSource(t *testing.T) {
 	// All sources.
 	stats = fm.AggregatedStats("all", 10)
 	assert.Equal(t, 2, stats["total_entries"])
+}
+
+func TestFeedbackManager_EntriesBounded(t *testing.T) {
+	fm := &feedbackManager{} // dir="" — no disk trim, exercises the in-memory cap
+
+	total := feedbackMaxEntries + 128
+	for i := 0; i < total; i++ {
+		require.NoError(t, fm.Record(persistence.FeedbackEntry{
+			Task:   "task",
+			Useful: []string{fmt.Sprintf("sym-%d", i)},
+			Source: "smart_context",
+		}))
+	}
+
+	require.Len(t, fm.store.Entries, feedbackMaxEntries, "in-memory log capped")
+
+	// Newest retained, oldest aged out.
+	last := fm.store.Entries[len(fm.store.Entries)-1]
+	assert.Equal(t, []string{fmt.Sprintf("sym-%d", total-1)}, last.Useful, "newest entry retained")
+	first := fm.store.Entries[0]
+	assert.Equal(t, []string{fmt.Sprintf("sym-%d", total-feedbackMaxEntries)}, first.Useful, "oldest surviving entry")
 }

--- a/internal/mcp/pack_delta.go
+++ b/internal/mcp/pack_delta.go
@@ -5,7 +5,9 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -255,25 +257,91 @@ func shortHash(s string) string {
 	return hex.EncodeToString(sum[:8])
 }
 
+// packCacheDefaultMaxBytes bounds the total memory the pack cache may
+// retain across all cached views. A count ceiling alone is unsafe: each
+// entry is a full smart_context pack whose symbols carry their source,
+// so a handful of large packs reach hundreds of MB even under the
+// 32-entry cap. Override with GORTEX_PACK_CACHE_MAX_MB.
+const packCacheDefaultMaxBytes = 32 << 20 // 32 MiB
+
+const (
+	// packEntryOverhead is a conservative fixed charge per cached symbol
+	// (struct headers, map bucket, slice growth) added on top of its
+	// retained string bytes.
+	packEntryOverhead = 64
+	// packFieldOverhead is the same fixed charge for one non-string
+	// entry field. Deliberately generous — an over-estimate only makes
+	// the cache evict sooner, it never overshoots the budget.
+	packFieldOverhead = 16
+)
+
 // packDeltaCache is a bounded LRU of pack views keyed by pack root, so a
 // later smart_context call with delta_from=<root> can diff against the
 // pack the agent already received. Content-addressed (the key is the
 // pack root), so it is safe to share across sessions: an identical pack
 // produced by two sessions resolves to the same entry.
+//
+// Bounded on two axes — a distinct-entry ceiling (cap) and a memory
+// budget (maxBytes) — because a single pack's retained bytes vary by
+// orders of magnitude with the working set's source size.
 type packDeltaCache struct {
-	mu  sync.Mutex
-	ll  *list.List
-	m   map[string]*list.Element
-	cap int
+	mu       sync.Mutex
+	ll       *list.List
+	m        map[string]*list.Element
+	cap      int   // max distinct packs retained (secondary ceiling)
+	maxBytes int64 // memory budget across all retained views
+	curBytes int64 // running sum of entry.bytes
 }
 
 type packCacheEntry struct {
-	root string
-	view packView
+	root  string
+	view  packView
+	bytes int64 // estimated retained size, for the byte budget
 }
 
+// newPackDeltaCache builds the cache with the default budgets. The
+// memory budget is overridable with GORTEX_PACK_CACHE_MAX_MB=<n>
+// (0 or negative keeps the default).
 func newPackDeltaCache() *packDeltaCache {
-	return &packDeltaCache{ll: list.New(), m: make(map[string]*list.Element), cap: 32}
+	c := &packDeltaCache{
+		ll:       list.New(),
+		m:        make(map[string]*list.Element),
+		cap:      32,
+		maxBytes: packCacheDefaultMaxBytes,
+	}
+	if v := strings.TrimSpace(os.Getenv("GORTEX_PACK_CACHE_MAX_MB")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			c.maxBytes = int64(n) << 20
+		}
+	}
+	return c
+}
+
+// packViewBytes conservatively estimates a cached view's retained heap
+// footprint for the byte budget. Dominated by each symbol's full entry
+// (which carries the symbol's source); identity fields and edge / file
+// keys are counted too. Computed once at insert time so eviction is a
+// cheap scalar comparison.
+func packViewBytes(v packView) int64 {
+	var n int64
+	for _, s := range v.Symbols {
+		n += int64(len(s.ID) + len(s.SourceHash) + packEntryOverhead)
+		for k, val := range s.Entry {
+			n += int64(len(k))
+			if str, ok := val.(string); ok {
+				n += int64(len(str))
+			} else {
+				n += packFieldOverhead
+			}
+		}
+	}
+	for _, f := range v.Files {
+		n += int64(len(f))
+	}
+	for _, e := range v.Edges {
+		n += int64(len(e))
+	}
+	return n
 }
 
 func (c *packDeltaCache) get(root string) (packView, bool) {
@@ -294,21 +362,36 @@ func (c *packDeltaCache) put(root string, v packView) {
 	if c == nil || root == "" {
 		return
 	}
+	sz := packViewBytes(v)
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if el, ok := c.m[root]; ok {
-		el.Value.(*packCacheEntry).view = v
+		e := el.Value.(*packCacheEntry)
+		c.curBytes += sz - e.bytes
+		e.view = v
+		e.bytes = sz
 		c.ll.MoveToFront(el)
+		c.evictLocked()
 		return
 	}
-	el := c.ll.PushFront(&packCacheEntry{root: root, view: v})
+	el := c.ll.PushFront(&packCacheEntry{root: root, view: v, bytes: sz})
 	c.m[root] = el
-	for c.ll.Len() > c.cap {
+	c.curBytes += sz
+	c.evictLocked()
+}
+
+// evictLocked drops least-recently-used entries until the cache is
+// within both its byte budget and its entry-count ceiling. The caller
+// holds c.mu.
+func (c *packDeltaCache) evictLocked() {
+	for c.ll.Len() > 0 && (c.curBytes > c.maxBytes || c.ll.Len() > c.cap) {
 		back := c.ll.Back()
 		if back == nil {
 			break
 		}
+		e := back.Value.(*packCacheEntry)
 		c.ll.Remove(back)
-		delete(c.m, back.Value.(*packCacheEntry).root)
+		delete(c.m, e.root)
+		c.curBytes -= e.bytes
 	}
 }

--- a/internal/mcp/pack_delta_test.go
+++ b/internal/mcp/pack_delta_test.go
@@ -1,6 +1,9 @@
 package mcp
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func symEntry(id string, line int, source string) map[string]any {
 	return map[string]any{"id": id, "start_line": line, "source": source, "name": id}
@@ -93,6 +96,33 @@ func TestPackDeltaCacheLRU(t *testing.T) {
 	}
 	if _, ok := c.get("r1"); !ok {
 		t.Fatal("r1 should survive")
+	}
+}
+
+// TestPackDeltaCacheByteBudget — with a high count ceiling but a small
+// byte budget, the memory budget is the binding limit: big entries
+// evict older ones even though the entry count stays well under cap.
+func TestPackDeltaCacheByteBudget(t *testing.T) {
+	c := newPackDeltaCache()
+	c.cap = 1000        // high, so the byte budget binds instead
+	c.maxBytes = 25_000 // ~2 of the 10 KB entries below fit
+
+	big := strings.Repeat("x", 10_000) // ~10 KB of source per entry
+	for _, root := range []string{"r1", "r2", "r3", "r4", "r5"} {
+		c.put(root, extractPackView(packResult(symEntry(root+".go::F", 1, big)), true))
+	}
+
+	if c.ll.Len() > 3 {
+		t.Fatalf("byte budget should keep the cache small; got %d entries", c.ll.Len())
+	}
+	if c.curBytes > c.maxBytes {
+		t.Fatalf("curBytes %d exceeds budget %d", c.curBytes, c.maxBytes)
+	}
+	if _, ok := c.get("r5"); !ok {
+		t.Fatal("newest entry r5 should survive")
+	}
+	if _, ok := c.get("r1"); ok {
+		t.Fatal("oldest entry r1 should have been evicted by the byte budget")
 	}
 }
 

--- a/internal/mcp/refs_confirmed_test.go
+++ b/internal/mcp/refs_confirmed_test.go
@@ -1,0 +1,28 @@
+package mcp
+
+import "testing"
+
+// TestResetConfirmedRefs asserts the lazy-enrichment ledger is emptied
+// when the graph is rebuilt so it stays scoped to one analysis epoch
+// instead of growing for the daemon's lifetime.
+func TestResetConfirmedRefs(t *testing.T) {
+	s := &Server{}
+	for _, id := range []string{"a.go::A", "b.go::B", "c.go::C"} {
+		s.refsConfirmed.Store(id, struct{}{})
+	}
+
+	s.resetConfirmedRefs()
+
+	n := 0
+	s.refsConfirmed.Range(func(_, _ any) bool { n++; return true })
+	if n != 0 {
+		t.Fatalf("refsConfirmed has %d entries after reset, want 0", n)
+	}
+
+	// Reusable after clearing: a later store is cleared by a second reset.
+	s.refsConfirmed.Store("d.go::D", struct{}{})
+	s.resetConfirmedRefs()
+	if _, ok := s.refsConfirmed.Load("d.go::D"); ok {
+		t.Fatal("entry stored after reset should be cleared by a second reset")
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -2199,6 +2199,16 @@ func (s *Server) RunAnalysis() {
 	s.hotspots = analysis.FindHotspots(s.graph, communities, 0)
 	s.analysisMu.Unlock()
 
+	// The graph was just rebuilt, so the lazy-enrichment ledger — symbol
+	// IDs whose incoming refs were confirmed against the *previous* graph
+	// — is both potentially stale (a reindex can re-mint those IDs) and
+	// unbounded across a long daemon session. Reset it so re-confirmation
+	// runs against the new graph and the ledger stays scoped to one
+	// analysis epoch. Kept outside analysisMu: refsConfirmed carries its
+	// own synchronisation and a racing reader just re-confirms, which is
+	// idempotent.
+	s.resetConfirmedRefs()
+
 	// Bootstrap-resource payloads (graph_stats, index_health, etc.)
 	// can change after re-warm even when the analysis itself didn't
 	// — node counts move on every reindex. Fire updates regardless.
@@ -2209,6 +2219,18 @@ func (s *Server) RunAnalysis() {
 	if s.graphInvalidatedBroadcaster != nil && s.graph != nil {
 		s.graphInvalidatedBroadcaster.broadcast(s.graph.NodeCount(), s.graph.EdgeCount(), "reanalysis")
 	}
+}
+
+// resetConfirmedRefs clears the lazy-enrichment ledger (see the
+// refsConfirmed field). sync.Map has no clear-all, so this ranges and
+// deletes; it is safe against concurrent confirmSymbolRefsOnDemand
+// readers because a racing miss just re-confirms the symbol, which is
+// idempotent — it re-lands the same lsp_resolved edges.
+func (s *Server) resetConfirmedRefs() {
+	s.refsConfirmed.Range(func(k, _ any) bool {
+		s.refsConfirmed.Delete(k)
+		return true
+	})
 }
 
 func (s *Server) getCommunities() *analysis.CommunityResult {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1476,6 +1476,16 @@ func (s *Server) SetLLMService(service *svc.Service) {
 	s.registerLLMTools()
 }
 
+// LLMService returns the attached LLM service, or nil when none was configured
+// (no provider, or provider construction failed). The daemon's shared-server
+// wiring uses it to register the service's Close in the process cleanup chain —
+// honouring the "caller owns Close" lifecycle noted on SetLLMService — so a
+// graceful shutdown unloads the loaded model instead of leaning on the idle
+// reaper as the only unload path.
+func (s *Server) LLMService() *svc.Service {
+	return s.llmService
+}
+
 // SetupLLM is the convenience constructor used by daemon entrypoints.
 // It builds an in-process backend wired to this server's engine +
 // contract registry, constructs the service from cfg, and attaches

--- a/internal/parser/languages/c_cmdtable_test.go
+++ b/internal/parser/languages/c_cmdtable_test.go
@@ -1,6 +1,8 @@
 package languages
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -115,4 +117,138 @@ func TestCExtractor_CommandTableErrorRecovery(t *testing.T) {
 	}
 	assert.True(t, cands["getCommand"], "the cleanly-parsed row before the error survives")
 	assert.True(t, cands["strlenCommand"], "the handler still in an arg list after the missing paren survives recovery")
+}
+
+// TestCExtractor_LexerLookaheadFilteredAndDeduped pins the generated-lexer flood
+// shape. An uninitialised local (`int32_t lookahead;`) compared on ==/!= across
+// many lines is a local, never a function address, so it yields no candidate; a
+// genuinely-undeclared free name compared the same way collapses to exactly one
+// candidate regardless of how many lines mention it (the per-name dedup).
+func TestCExtractor_LexerLookaheadFilteredAndDeduped(t *testing.T) {
+	src := "" +
+		"void lexScan(void) {\n" + // line 1
+		"  int32_t lookahead;\n" + // line 2: uninitialised local
+		"  if (lookahead == 65) return;\n" + // 3
+		"  if (lookahead != 66) return;\n" + // 4
+		"  if (lookahead == 67) return;\n" + // 5
+		"  if (externScanHook == 68) return;\n" + // 6: undeclared free name
+		"  if (externScanHook != 69) return;\n" + // 7
+		"  if (externScanHook == 70) return;\n" + // 8
+		"}\n"
+	r, err := NewCExtractor().Extract("lexer.c", []byte(src))
+	require.NoError(t, err)
+
+	counts := map[string]int{}
+	for _, e := range r.Edges {
+		if e.Meta == nil {
+			continue
+		}
+		if v, _ := e.Meta["via"].(string); v != "callback_candidate" {
+			continue
+		}
+		if name, _ := e.Meta["fn_value_name"].(string); name != "" {
+			counts[name]++
+		}
+	}
+	assert.Zero(t, counts["lookahead"], "an uninitialised local compared on ==/!= is never a function-address candidate")
+	assert.Equal(t, 1, counts["externScanHook"], "an undeclared free name on N comparison lines collapses to one candidate")
+}
+
+// TestCExtractor_EnumMembersNotCaptured pins the generated-parser enum flood: an
+// in-file anonymous enum's members, referenced from a designated-initializer
+// action table, are compile-time constants — never function addresses — so none
+// becomes a candidate, while a genuine cross-TU handler in the same table does.
+func TestCExtractor_EnumMembersNotCaptured(t *testing.T) {
+	src := "" +
+		"enum { sym_alpha, sym_beta, sym_gamma };\n" + // line 1
+		"void *actionTable[] = {\n" + // line 2
+		"  [0] = sym_alpha,\n" + // 3
+		"  [1] = sym_beta,\n" + // 4
+		"  [2] = sym_gamma,\n" + // 5
+		"  [3] = reduceAction,\n" + // 6: a real cross-TU handler
+		"};\n"
+	cands := cValueRefCandidates(t, "parser.c", src)
+
+	assert.NotContains(t, cands, "sym_alpha", "an in-file enum member is not a function reference")
+	assert.NotContains(t, cands, "sym_beta", "an in-file enum member is not a function reference")
+	assert.NotContains(t, cands, "sym_gamma", "an in-file enum member is not a function reference")
+	assert.Contains(t, cands, "reduceAction", "a genuine handler in the same table is still captured")
+}
+
+// TestCExtractor_PerFileCandidateFuse pins the per-file fuse: a pathological
+// generated file with more distinct value-position handlers than the cap emits
+// exactly the cap — the bound that stops a generated dispatch table from
+// exploding the placeholder set.
+func TestCExtractor_PerFileCandidateFuse(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("void *bigDispatch[] = {\n")
+	for i := 0; i < cFnAddressMaxPerFile+200; i++ {
+		fmt.Fprintf(&b, "  handlerFn%05d,\n", i)
+	}
+	b.WriteString("};\n")
+
+	r, err := NewCExtractor().Extract("generated.c", []byte(b.String()))
+	require.NoError(t, err)
+
+	n := 0
+	for _, e := range r.Edges {
+		if e.Meta == nil {
+			continue
+		}
+		if v, _ := e.Meta["via"].(string); v == "callback_candidate" {
+			n++
+		}
+	}
+	assert.Equal(t, cFnAddressMaxPerFile, n, "the per-file fuse caps emitted candidates at the const bound")
+}
+
+// TestCExtractor_DispatchTableCandidateFields pins the candidate metadata a
+// realistic cross-TU dispatch table produces: each handler is captured exactly
+// once (dedup), marked ungated so the resolver binds it cross-translation-unit,
+// tagged with the capturing grammar, and carries no address-of form (a plain
+// value slot).
+func TestCExtractor_DispatchTableCandidateFields(t *testing.T) {
+	src := "" +
+		"struct cmd table[] = {\n" + // line 1
+		"{ \"get\", getCommand, 2 },\n" + // 2
+		"{ \"set\", setCommand, 3 },\n" + // 3
+		"};\n"
+	r, err := NewCExtractor().Extract("dispatch.c", []byte(src))
+	require.NoError(t, err)
+
+	type capture struct {
+		count   int
+		ungated bool
+		form    string
+		lang    string
+	}
+	got := map[string]capture{}
+	for _, e := range r.Edges {
+		if e.Meta == nil {
+			continue
+		}
+		if v, _ := e.Meta["via"].(string); v != "callback_candidate" {
+			continue
+		}
+		name, _ := e.Meta["fn_value_name"].(string)
+		if name == "" {
+			continue
+		}
+		c := got[name]
+		c.count++
+		if u, _ := e.Meta["fn_value_ungated"].(bool); u {
+			c.ungated = true
+		}
+		c.form, _ = e.Meta["fn_ref_form"].(string)
+		c.lang, _ = e.Meta["fn_ref_lang"].(string)
+		got[name] = c
+	}
+
+	for _, name := range []string{"getCommand", "setCommand"} {
+		c := got[name]
+		assert.Equal(t, 1, c.count, "%s is captured exactly once", name)
+		assert.True(t, c.ungated, "%s is ungated for cross-TU binding", name)
+		assert.Equal(t, "", c.form, "%s sits in a plain value position (no address-of form)", name)
+		assert.Equal(t, "c", c.lang, "%s is tagged with the capturing grammar", name)
+	}
 }

--- a/internal/parser/languages/c_fnaddr.go
+++ b/internal/parser/languages/c_fnaddr.go
@@ -1,12 +1,18 @@
 package languages
 
 import (
-	"strconv"
-
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/parser"
 	sitter "github.com/zzet/gortex/internal/parser/tsitter"
 )
+
+// cFnAddressMaxPerFile fuses the per-file candidate count. A generated parser
+// (a tree-sitter lexer, a bytecode dispatch table) presents tens of thousands
+// of distinct value-position identifiers; unbounded, each becomes a
+// speculative placeholder edge and the set explodes. A hand-written dispatch
+// table sits far below this cap, so the fuse trips only on machine-generated
+// input. Candidates are taken in walk order, so the cut is deterministic.
+const cFnAddressMaxPerFile = 1024
 
 // C cross-file function-address references.
 //
@@ -26,10 +32,19 @@ import (
 // shared pass it attributes a file-scope reference (a command table lives
 // outside any function) to the file node, so a table entry becomes a usage.
 //
-// Flood control: value-position-only, plus dropping any name the file declares
-// (functions handled by the gated pass, variables / constants / types) or that
-// is a parameter / local. What survives is the small set of free identifiers a
-// gate lookup can turn into a real cross-TU function edge.
+// Flood control matters most on generated C (a tree-sitter lexer, a bytecode
+// dispatch table), where naive capture explodes. Bounds keep the pass to the
+// small set of free identifiers a gate lookup can turn into a real cross-TU
+// function edge:
+//
+//   - value-position-only, and never a name the file declares (functions go to
+//     the gated pass; variables / constants / types resolve locally) or a
+//     parameter / local / uninitialised declaration / in-file enum member;
+//   - one candidate per (enclosing symbol or file, name): a function address
+//     binds by name repo-wide, so the same free identifier on N lines of a
+//     generated ==/!= lexer is one reference, not N;
+//   - a per-file fuse (cFnAddressMaxPerFile) bounds a pathological generated
+//     file; a hand-written dispatch table sits far below it.
 func captureCFnAddressRefs(result *parser.ExtractionResult, root *sitter.Node, filePath, fileID string, src []byte) {
 	if root == nil || result == nil {
 		return
@@ -53,6 +68,9 @@ func captureCFnAddressRefs(result *parser.ExtractionResult, root *sitter.Node, f
 	seen := map[string]bool{}
 	var cands []FnValueCandidate
 	walkNodes(root, func(n *sitter.Node) {
+		if len(cands) >= cFnAddressMaxPerFile {
+			return // per-file fuse: bound a pathological generated file
+		}
 		if n.Type() != "identifier" {
 			return
 		}
@@ -81,7 +99,12 @@ func captureCFnAddressRefs(result *parser.ExtractionResult, root *sitter.Node, f
 		if from == "" {
 			from = fileID // file-scope reference (command / dispatch table)
 		}
-		key := from + "\x00" + name + "\x00" + strconv.Itoa(line)
+		// One candidate per (enclosing symbol or file, name): a function
+		// address binds by name repo-wide, so the same free identifier on N
+		// lines of a generated ==/!= lexer collapses to a single reference.
+		// First occurrence by walk order wins; mirrors the shared
+		// captureFnValueCandidates key shape.
+		key := from + "\x00" + name
 		if seen[key] {
 			return
 		}
@@ -149,10 +172,24 @@ func isFieldChild(p *sitter.Node, field string, n *sitter.Node) bool {
 	return c != nil && c.StartByte() == n.StartByte() && c.EndByte() == n.EndByte()
 }
 
-// cCollectLocalNames gathers parameter and initialised-local declarator names
-// across the file. A function address is never a parameter or local, so these
-// names are dropped from the cross-file candidate set — the dominant flood
-// source (every call passes locals / params by value).
+// cCollectLocalNames gathers the file's parameter, local, uninitialised-
+// declaration, and in-file enum-member names — every declared name that can
+// never denote a cross-TU function address and so must be dropped from the
+// candidate set. It spans four declaration shapes:
+//
+//   - parameters and initialised locals (`f(int x)`, `Handler h = g`) — the
+//     dominant flood source, since a call passes locals / params by value into
+//     the very positions this pass scans;
+//   - uninitialised declarations (`int32_t lookahead;`) — a generated lexer
+//     compares such a local on ==/!= across tens of thousands of lines, and the
+//     identifier is only ever that local, never a function address;
+//   - in-file enum members (`enum { sym_a, sym_b }`) — a generated parser
+//     declares its token / symbol enum in-file, then floods designated-
+//     initializer tables with the members, none of which is a function.
+//
+// A same-file function prototype is deliberately NOT collected: a declaration
+// whose declarator is (or wraps) a function_declarator names a function, left
+// bindable for the resolver gate, not shadowed here.
 func cCollectLocalNames(root *sitter.Node, src []byte) map[string]bool {
 	out := map[string]bool{}
 	walkNodes(root, func(n *sitter.Node) {
@@ -167,9 +204,54 @@ func cCollectLocalNames(root *sitter.Node, src []byte) map[string]bool {
 			if name := cDeclName(n.ChildByFieldName("declarator"), src); name != "" {
 				out[name] = true
 			}
+		case "declaration":
+			// An uninitialised declaration's declarators sit directly under it
+			// (an initialised one is wrapped in init_declarator, handled above).
+			// A declaration may carry several (`int a, *b, c[3];`), so every
+			// declarator-field child is unwrapped to its variable name.
+			for i := 0; i < int(n.ChildCount()); i++ {
+				if n.FieldNameForChild(i) != "declarator" {
+					continue
+				}
+				if name := cUninitDeclName(n.Child(i), src); name != "" {
+					out[name] = true
+				}
+			}
+		case "enumerator":
+			if d := n.ChildByFieldName("name"); d != nil {
+				if name := d.Content(src); name != "" {
+					out[name] = true
+				}
+			}
 		}
 	})
 	return out
+}
+
+// cUninitDeclName unwraps the pointer / array / parenthesized wrappers of an
+// uninitialised declaration's declarator to its variable name. It returns "" for
+// a function_declarator — a prototype names a function, which must stay a
+// bindable candidate rather than a shadowing local — and for any other
+// unexpected shape. Unlike cDeclName it never descends through a
+// function_declarator, so `int *foo(int);` (a pointer-returning prototype)
+// contributes no name.
+func cUninitDeclName(decl *sitter.Node, src []byte) string {
+	for decl != nil {
+		switch decl.Type() {
+		case "identifier", "field_identifier":
+			return decl.Content(src)
+		case "pointer_declarator", "array_declarator":
+			decl = decl.ChildByFieldName("declarator")
+		case "parenthesized_declarator":
+			if decl.NamedChildCount() == 0 {
+				return ""
+			}
+			decl = decl.NamedChild(0)
+		default:
+			return ""
+		}
+	}
+	return ""
 }
 
 // isCFnAddressNonTarget reports whether a name is a C literal / keyword /

--- a/internal/parser/languages/fn_value_capture.go
+++ b/internal/parser/languages/fn_value_capture.go
@@ -24,9 +24,12 @@ import (
 // top of this skeleton.
 
 // fnValueUnresolvedPrefix is the synthetic-target namespace a captured
-// function value occupies until the gate binds it. Kept human-readable
-// (the bare name is appended) to match Gortex's navigable-ID convention.
-const fnValueUnresolvedPrefix = "unresolved::fnvalue::"
+// function value occupies until the gate binds it — the graph-owned
+// graph.FnValuePlaceholderMarker, aliased here so the emit sites read locally
+// and the resolver's pending-scan exclusion keys off the same constant. Kept
+// human-readable (the bare name is appended) to match Gortex's navigable-ID
+// convention.
+const fnValueUnresolvedPrefix = graph.FnValuePlaceholderMarker
 
 // fnValueCandidateVia marks a placeholder edge as awaiting the callback gate.
 // It mirrors the resolver-side constant of the same value; the two packages

--- a/internal/platform/disk_unix.go
+++ b/internal/platform/disk_unix.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+package platform
+
+import "golang.org/x/sys/unix"
+
+// DiskAvailBytes reports the bytes available to an unprivileged caller on the
+// filesystem holding path (statfs f_bavail × f_bsize — the root-reserved
+// blocks are deliberately excluded, since the daemon does not run as root).
+// Callers gate disk-hungry maintenance (the store VACUUM needs up to a full
+// temporary copy of the database) on this number.
+func DiskAvailBytes(path string) (uint64, error) {
+	var st unix.Statfs_t
+	if err := unix.Statfs(path, &st); err != nil {
+		return 0, err
+	}
+	return uint64(st.Bavail) * uint64(st.Bsize), nil
+}

--- a/internal/platform/disk_windows.go
+++ b/internal/platform/disk_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package platform
+
+import "golang.org/x/sys/windows"
+
+// DiskAvailBytes reports the bytes available to the calling user on the
+// volume holding path (GetDiskFreeSpaceEx's caller-quota figure, so per-user
+// quotas are respected). Callers gate disk-hungry maintenance (the store
+// VACUUM needs up to a full temporary copy of the database) on this number.
+func DiskAvailBytes(path string) (uint64, error) {
+	p, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, err
+	}
+	var availToCaller, total, totalFree uint64
+	if err := windows.GetDiskFreeSpaceEx(p, &availToCaller, &total, &totalFree); err != nil {
+		return 0, err
+	}
+	return availToCaller, nil
+}

--- a/internal/resolver/cross_repo_edges.go
+++ b/internal/resolver/cross_repo_edges.go
@@ -90,7 +90,11 @@ func crossRepoCandidates(g graph.Store) []graph.CrossRepoCandidateRow {
 		kset[k] = struct{}{}
 	}
 	var out []graph.CrossRepoCandidateRow
-	for _, e := range g.AllEdges() {
+	// Meta-less kind-scoped scan (see LightEdgeScanner): this fallback only runs
+	// for a store without the CrossRepoCandidates capability, and reads just
+	// e.Kind and endpoints — the emitted row propagates e but its consumer
+	// (DetectCrossRepoEdges) touches only promoted fields, never Meta.
+	for _, e := range graph.EdgesForKindsLight(g, baseKinds...) {
 		if e == nil {
 			continue
 		}

--- a/internal/resolver/fn_value_gate.go
+++ b/internal/resolver/fn_value_gate.go
@@ -63,12 +63,20 @@ func ResolveFnValueCallbacks(g graph.Store) int {
 		fileNodes[filePath] = ns
 		return ns
 	}
-	// Every callback-candidate placeholder EmitFnValueCandidates emits is a
-	// graph.EdgeReferences edge (see languages.EmitFnValueCandidates), so a
-	// kind-scoped scan sees the same candidates as AllEdges() without paying
-	// to decode the graph's other edge kinds (calls, arg_of, member_of, ...) —
-	// several times the size of references alone on a large multi-repo graph.
-	for e := range g.EdgesByKind(graph.EdgeReferences) {
+	// The gate needs only the placeholders parked in the fn-value namespace,
+	// not every reference edge. When the backend can range-scan that namespace
+	// (FnValuePlaceholderScanner) use it: the generic EdgesByKind(references)
+	// path materialises the whole placeholders-plus-real-references set on every
+	// whole-graph synthesizer pass — several times the size of the placeholder
+	// slice on a large multi-repo graph. Both iterators are iter.Seq[*Edge], so
+	// the loop body is identical; the Meta["via"] == callback_candidate filter
+	// below STAYS on both paths — a non-candidate edge can be parked in the
+	// namespace (e.g. an already-bound registration) and must never be gated.
+	edges := g.EdgesByKind(graph.EdgeReferences)
+	if fp, ok := g.(graph.FnValuePlaceholderScanner); ok {
+		edges = fp.FnValuePlaceholderEdges()
+	}
+	for e := range edges {
 		if e == nil || e.Meta == nil {
 			continue
 		}

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -62,10 +62,17 @@ type Provider struct {
 	client *Client
 
 	// sourceCache holds file contents read by openDocument so the
-	// per-symbol column-resolution lookups don't reread the file
-	// for every hover / references / implementation query. Keyed
-	// by absolute path. Eviction is not implemented — the cache
-	// lives only for the duration of one Enrich pass.
+	// per-symbol column-resolution lookups don't reread the file for
+	// every hover / references / implementation query. Keyed by
+	// absolute path. closeDocument drops a file's entry and
+	// resetForReconnect clears the whole map, so a long-lived
+	// interactive session — where hover / definition traffic keeps the
+	// provider's lastUsed fresh and the router never reaps it — does
+	// not retain every navigated file's bytes for the daemon's
+	// lifetime. Accessed lock-free (see getSource, which tolerates a
+	// miss by falling back to col=0): the interactive
+	// open→lookup→close sequence is serialized per file, so it needs
+	// no docMu.
 	sourceCache map[string][]byte
 
 	// docMu guards docVersions / openDocs / lastDiag so concurrent
@@ -1674,6 +1681,12 @@ func (p *Provider) resetForReconnect() {
 	p.openDocs = map[string]bool{}
 	p.lastDiag = map[string][]Diagnostic{}
 	p.docMu.Unlock()
+	// sourceCache is the unsynchronised interactive-navigation cache
+	// (written lock-free by openDocument); drop it on reconnect so a
+	// long-lived provider doesn't carry the dead session's file bytes.
+	// nil is the freed state — openDocument lazily re-creates it and
+	// getSource nil-checks before reading.
+	p.sourceCache = nil
 }
 
 // dialOrSpawn builds the LSP client according to the provider's spec.
@@ -2470,6 +2483,11 @@ func (p *Provider) closeDocument(absPath string) error {
 	delete(p.openDocs, absPath)
 	delete(p.docVersions, absPath)
 	p.docMu.Unlock()
+	// Drop this file's cached bytes too. getSource tolerates a miss
+	// (falls back to col=0) and the next openDocument repopulates, so
+	// without this an interactive session that navigates thousands of
+	// files would pin every one's contents until the daemon exits.
+	delete(p.sourceCache, absPath)
 	return p.client.Notify("textDocument/didClose", DidCloseTextDocumentParams{
 		TextDocument: TextDocumentIdentifier{URI: pathToURI(absPath)},
 	})

--- a/internal/semantic/lsp/provider_cache_test.go
+++ b/internal/semantic/lsp/provider_cache_test.go
@@ -1,0 +1,57 @@
+package lsp
+
+import "testing"
+
+// discardWriteCloser is a no-op transport write-end so closeDocument's
+// didClose notification can be "sent" without a live LSP server.
+type discardWriteCloser struct{}
+
+func (discardWriteCloser) Write(p []byte) (int, error) { return len(p), nil }
+func (discardWriteCloser) Close() error                { return nil }
+
+// TestCloseDocument_DropsSourceCache asserts closeDocument frees the
+// file's cached bytes. Without this an interactive session that keeps
+// the provider warm (hover / definition traffic) retains every
+// navigated file's contents for the daemon's lifetime.
+func TestCloseDocument_DropsSourceCache(t *testing.T) {
+	const abs = "/work/main.go"
+	p := &Provider{
+		openDocs:    map[string]bool{abs: true},
+		docVersions: map[string]int{abs: 1},
+		lastDiag:    map[string][]Diagnostic{},
+		sourceCache: map[string][]byte{abs: []byte("package main")},
+		client:      &Client{stdin: discardWriteCloser{}},
+	}
+
+	if err := p.closeDocument(abs); err != nil {
+		t.Fatalf("closeDocument: %v", err)
+	}
+	if _, ok := p.sourceCache[abs]; ok {
+		t.Fatalf("sourceCache still holds %q after closeDocument", abs)
+	}
+	if p.openDocs[abs] {
+		t.Fatalf("openDocs still marks %q open after closeDocument", abs)
+	}
+}
+
+// TestResetForReconnect_ClearsSourceCache asserts a reconnect frees
+// every cached file's bytes, not just the doc-version / open-doc
+// bookkeeping. A nil client makes resetForReconnect skip the LSP
+// shutdown handshake.
+func TestResetForReconnect_ClearsSourceCache(t *testing.T) {
+	p := &Provider{
+		openDocs:    map[string]bool{"/a": true},
+		docVersions: map[string]int{"/a": 1},
+		lastDiag:    map[string][]Diagnostic{"/a": nil},
+		sourceCache: map[string][]byte{"/a": []byte("x"), "/b": []byte("y")},
+	}
+
+	p.resetForReconnect()
+
+	if len(p.sourceCache) != 0 {
+		t.Fatalf("sourceCache = %d entries after resetForReconnect, want 0", len(p.sourceCache))
+	}
+	if len(p.openDocs) != 0 {
+		t.Fatalf("openDocs = %d entries after resetForReconnect, want 0", len(p.openDocs))
+	}
+}

--- a/internal/serverstack/shared_server.go
+++ b/internal/serverstack/shared_server.go
@@ -664,6 +664,14 @@ func NewSharedServer(cfg SharedServerConfig) (*SharedServer, error) {
 	}
 	if global != nil {
 		srv.SetupLLM(global.MergeLLMInto(conf.LLM))
+		// SetupLLM constructs the LLM service lazily and attaches it; nothing
+		// else frees it, so a graceful shutdown would leave a loaded local
+		// model resident (only the idle reaper unloads at runtime). Register
+		// its Close in the cleanup chain — the "caller owns Close" contract
+		// SetLLMService documents.
+		if llmSvc := srv.LLMService(); llmSvc != nil {
+			s.cleanup = append(s.cleanup, func() { _ = llmSvc.Close() })
+		}
 	}
 
 	return s, nil


### PR DESCRIPTION
## Problem

The daemon's memory footprint grew to ~20 GB (2.4 GB resident + compressed) with sustained ~200% CPU, and restarts made it worse: each boot ground through a 40+ minute "resolving references" warmup with heap-sys peaking above 11 GiB (post-GC alloc ~700 MB), and one observed boot died on a SIGSEGV seconds after finishing warmup — launchd respawned it and the whole churn repeated. Live forensics against the running daemon and its 6.8 GB store identified a chain of compounding causes; this PR fixes each link.

## Root causes (measured on a live store)

1. **Speculative edge flood.** The C function-address capture deduped per *line*, so generated C files (tree-sitter-style `parser.c` lexers/tables in a tracked repo vendoring ~60 grammars) emitted one placeholder reference edge per occurrence: 5,768,821 edges collapsing to 69,860 distinct (from,to) pairs in one repo (82×), 199,143 edges for 800 pairs in a 7-file grammar repo (249×). Edges + their four indexes were ~6.1 GB of the 6.7 GB store.
2. **Placeholders poisoned every whole-graph pass.** The fn-value placeholders live in the unresolved namespace, so the resolver's pending scan materialized all of them per restart; they evade the resolve scope filter (bare targets) and never earn terminal stamps (scoped passes don't stamp). The gate that owns them scanned *every* reference edge to find them. PageRank/HITS/Leiden/adjacency each re-materialized the full edge table with decoded meta.
3. **Full re-track loop.** A first-ever track of a 1.2 GB repo killed mid-parse leaves zero mtime rows (persistence was end-of-parse only), so every subsequent boot re-tracked the whole repo from scratch — observed as a 276 s re-track of an unchanged repo, feeding the churn that gets daemons killed in the first place.
4. **Store never garbage-collects.** Untrack/EvictRepo deleted only nodes+edges, leaking 14 sidecar tables; a repo removed from config weeks ago still had 1,214 mtime rows. No startup reconciliation existed. A lone repo that later earns a prefix orphaned all its `''`-keyed sidecar rows (→ cause 3 again, deterministically).
5. **Teardown-race SIGSEGV.** `panicOnFatal` swallows closed-DB/closed-statement errors so shutdown-race reads "return empty" — but the aggregator reads then dereferenced the nil `rows`. Observed live: `NodeIDsByKinds` → `FindHotspots` → `RunAnalysis` crashed the daemon right after its 44-minute warmup.
6. **Unbounded caches.** The interactive LSP `sourceCache` retained full file bytes forever (didClose never dropped them); the pack cache was count-capped only (each entry holds full symbol sources); the confirmed-refs ledger, feedback log, and diagnostics fingerprints only ever grew.
7. **Content-index crash window.** A full track wiped the repo's content search up front and rebuilt file-by-file — a mid-parse kill left content search empty.

## Fixes (one commit per fix)

**Stop generating the flood**
- `fix(parser)`: C fn-address capture — per-(symbol,name) dedupe, uninitialized-declaration + enum-member filtering, per-file fuse (1024).

**Stop paying for it**
- `fix(graph)`: fn-value placeholders excluded from the resolver pending scan (both backends, SQL-level on sqlite).
- `perf(resolver)`: the fn-value gate range-scans its own namespace (new store capability) instead of materializing every reference edge.
- `perf(analysis)`: PageRank/HITS/adjacency/processes/Leiden/cross-repo fallback use a meta-less kind-scoped edge scan (`LightEdgeScanner`, kind filter pushed into SQL).

**Drain existing stores**
- `fix(store)`: schema v2 in-place migration dedupes legacy placeholder rows (keep MIN(id) per pair). Dry-run against a copy of the live 6.8 GB store: see numbers below. Also fixes a latent planner rule that would have failed every fresh-DB `Open` once the first migration shipped.
- `feat(daemon)`: guarded one-time boot compaction (VACUUM) when the freelist dominates the file (>50% and >1 GiB, with disk-headroom check; `GORTEX_SKIP_STORE_COMPACT=1` opt-out).

**Make restarts survivable**
- `fix(indexer)`: killed full tracks resume — mtimes persist per parsed batch on the disk path (a row lands only after its file's nodes are durable); content search rebuilds per file with an end-of-walk sweep keyed on the files that actually streamed content (covers vanished files *and* content→no-content transitions), so a kill never empties it.
- `fix(store)`: teardown-race reads return empty instead of SIGSEGV (nil-rows guards across all thirteen aggregator reads + documented caller contract; closed-store test drives every method).

**Complete the repo lifecycle**
- `fix(store)`: `PurgeRepo` clears nodes, edges, vectors, and all sidecar tables in one transaction; untrack prefers it; warmup purges prefixes absent from config; solo→multi migration re-keys the prefix/path-keyed sidecar rows (so the repo's next warm restart finds its mtimes) and drops the node-id-keyed ones invalidated by the re-mint. The empty prefix (shared synthetic externals / solo-mode data) is refused everywhere.

**Bound the caches**
- `fix(lsp)`: `sourceCache` freed on didClose and reconnect.
- `fix(mcp)`: pack cache byte budget (32 MiB default, `GORTEX_PACK_CACHE_MAX_MB`); confirmed-refs ledger reset when analysis rebuilds; feedback log capped (4096, fresh-slice trim); diagnostics fingerprints pruned on clear.

**LLM lifecycle**
- `fix(llm)`: the in-process model is freed on graceful shutdown (Close wired into the cleanup chain); idle-unload TTL configurable via `llm.local.idle_ttl` (env `GORTEX_LLM_IDLE_TTL` still wins).

## Verification

- `go build ./...`; `go test -race` on every touched package (parser/languages, graph, storetest conformance on both backends, store_sqlite, resolver, analysis, indexer, mcp, semantic/lsp, serverstack, llm/*, cmd/gortex incl. the wire-contract golden).
- Migration + compaction dry run against a byte-copy of the live 6.8 GB store: the v2 DELETE removed 409,426 duplicate placeholder rows in 65 s (2.59M → 2.18M edges; this store's resolver had already collapsed part of the historical flood — stores caught mid-explosion heal proportionally more), and the follow-up VACUUM took 81 s, shrinking the file from 6.8 GB to 2.06 GB.
- New tests: generated-lexer flood shapes, both placeholder forms in the shared store suite, migration dedupe through real `Open`, closed-store aggregator crash test, purge/orphan/re-key coverage for every sidecar table, content kill-window + emptied-file sweep, incremental mtime flush on the disk path, cache-bound unit tests, TTL precedence.

## Operator notes

- First boot after upgrade runs the v2 migration (a few seconds to ~a minute on multi-GB stores) and may then run the one-time compaction (logged up front; minutes on multi-GB stores; `GORTEX_SKIP_STORE_COMPACT=1` to skip).
- New knobs: `GORTEX_PACK_CACHE_MAX_MB`, `llm.local.idle_ttl`, `GORTEX_SKIP_STORE_COMPACT`.
