### PR TITLE
fix(upgrade): run script installer pipeline via shell

### DIFF
--- a/cmd/gortex/upgrade.go
+++ b/cmd/gortex/upgrade.go
@@ -196,9 +196,8 @@ func runUpgrade(cmd *cobra.Command, args []string) error {
 	if !upgradeRun {
 		fmt.Fprintf(out, "Run:\n  %s\n", command)
 	} else {
-		parts := strings.Fields(command)
 		fmt.Fprintf(out, "$ %s\n", command)
-		ex := exec.CommandContext(cmd.Context(), parts[0], parts[1:]...) //nolint:gosec // command is one of the fixed install-method templates
+		ex := upgradeExecCommand(cmd, command)
 		ex.Stdout, ex.Stderr, ex.Stdin = out, cmd.ErrOrStderr(), os.Stdin
 		if rerr := ex.Run(); rerr != nil {
 			return fmt.Errorf("upgrade command failed: %w", rerr)
@@ -210,6 +209,18 @@ func runUpgrade(cmd *cobra.Command, args []string) error {
 	// reindexed. F2 enriches this with the exact stale languages per repo.
 	fmt.Fprintln(out, "\nAfter upgrading, reindex so the graph picks up any extractor changes:\n  gortex index .")
 	return nil
+}
+
+func upgradeExecCommand(cmd *cobra.Command, command string) *exec.Cmd {
+	if upgradeCommandNeedsShell(command) {
+		return exec.CommandContext(cmd.Context(), "sh", "-c", command) //nolint:gosec // fixed installer template, needs shell for pipe
+	}
+	parts := strings.Fields(command)
+	return exec.CommandContext(cmd.Context(), parts[0], parts[1:]...) //nolint:gosec // command is one of the fixed install-method templates
+}
+
+func upgradeCommandNeedsShell(command string) bool {
+	return strings.ContainsAny(command, "|&;<>()$`\\\"'")
 }
 
 // goBinDir returns the directory `go install` drops binaries into — $GOBIN, or

--- a/cmd/gortex/upgrade_test.go
+++ b/cmd/gortex/upgrade_test.go
@@ -46,6 +46,24 @@ func TestUpgradeInstallMethodDetection(t *testing.T) {
 	}
 }
 
+func TestUpgradeRunCommandUsesShellOnlyForPipelines(t *testing.T) {
+	cmd := upgradeExecCommand(rootCmd, "curl -fsSL https://get.gortex.dev | sh")
+	if got := cmd.Path; got != "sh" {
+		t.Fatalf("script installer should run through sh, got path %q args %v", got, cmd.Args)
+	}
+	if len(cmd.Args) != 3 || cmd.Args[1] != "-c" || cmd.Args[2] != "curl -fsSL https://get.gortex.dev | sh" {
+		t.Fatalf("script installer command args = %#v", cmd.Args)
+	}
+
+	cmd = upgradeExecCommand(rootCmd, "go install github.com/zzet/gortex/cmd/gortex@latest")
+	if got := cmd.Path; got != "go" {
+		t.Fatalf("plain argv command should exec directly, got path %q args %v", got, cmd.Args)
+	}
+	if len(cmd.Args) != 3 || cmd.Args[1] != "install" || cmd.Args[2] != "github.com/zzet/gortex/cmd/gortex@latest" {
+		t.Fatalf("go install command args = %#v", cmd.Args)
+	}
+}
+
 // TestUpgradeReleaseTagParse covers the /releases/latest redirect tag parse.
 func TestUpgradeReleaseTagParse(t *testing.T) {
 	cases := map[string]string{


### PR DESCRIPTION
## Summary

Fixes #281

`gortex upgrade --run` now executes the installer-script command through `sh -c`, so the documented installer pipeline is interpreted by a shell instead of being split into raw curl arguments.

## Changes

- Add `upgradeExecCommand` to choose shell execution only for commands with shell metacharacters
- Keep plain argv execution for commands such as `go install ...`
- Add regression coverage for the script pipeline and plain `go install` path

## Validation

- `gofmt -w cmd/gortex/upgrade.go cmd/gortex/upgrade_test.go` — blocked: this runner does not have `gofmt`/Go installed
- Static diff review only in this environment; change is limited to fixed upgrade command templates and tests
