### PR TITLE
Retry AtomicWriteFile's rename past transient Windows sharing violations

### DIFF
--- a/internal/agents/writer.go
+++ b/internal/agents/writer.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 )
 
 // writer.go centralises every write `gortex init` performs. Going
@@ -144,11 +145,42 @@ func AtomicWriteFile(path string, data []byte, perm os.FileMode) error {
 		cleanup()
 		return fmt.Errorf("close %s: %w", tmpPath, err)
 	}
-	if err := os.Rename(tmpPath, path); err != nil {
+	if err := renameWithRetry(tmpPath, path); err != nil {
 		cleanup()
 		return fmt.Errorf("rename %s -> %s: %w", tmpPath, path, err)
 	}
 	return nil
+}
+
+// renameWithRetry renames oldPath onto newPath, retrying briefly when the
+// failure is a transient, Windows-specific sharing violation (see
+// isRetryableRenameErr). On POSIX the predicate is always false, so this
+// collapses to a single os.Rename with no added latency.
+//
+// os.Rename maps to MoveFileEx(MOVEFILE_REPLACE_EXISTING) on Windows,
+// which fails with ERROR_SHARING_VIOLATION / ERROR_ACCESS_DENIED when
+// another process still holds the destination open without
+// FILE_SHARE_DELETE — an editor's language server, antivirus, a search
+// indexer, or Gortex's own file watcher re-indexing the file we just
+// wrote. Those holders release the handle within milliseconds, so a
+// short bounded retry turns a spurious "file is being used by another
+// process" error into the atomic replace the caller asked for. Worst
+// case is ~225ms of backoff, imperceptible for an interactive write.
+func renameWithRetry(oldPath, newPath string) error {
+	const attempts = 10
+	var err error
+	for attempt := range attempts {
+		if err = os.Rename(oldPath, newPath); err == nil {
+			return nil
+		}
+		if !isRetryableRenameErr(err) {
+			return err
+		}
+		if attempt < attempts-1 {
+			time.Sleep(time.Duration(attempt+1) * 5 * time.Millisecond)
+		}
+	}
+	return err
 }
 
 // MergeJSON reads path (if present), parses it as a JSON object,

--- a/internal/agents/writer_other.go
+++ b/internal/agents/writer_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package agents
+
+// isRetryableRenameErr is always false off Windows: a POSIX rename
+// atomically replaces the destination even while another process holds it
+// open, so a failed rename there is a genuine, non-transient error (e.g.
+// an EXDEV cross-device link) that retrying would not fix.
+func isRetryableRenameErr(error) bool { return false }

--- a/internal/agents/writer_test.go
+++ b/internal/agents/writer_test.go
@@ -284,3 +284,47 @@ func names(as []Adapter) []string {
 	}
 	return out
 }
+
+// TestAtomicWriteFileCreatesAndOverwrites guards the core write path every
+// MCP file tool funnels through (write_file, edit_file, move, ...): a
+// fresh write lands the content and a second write atomically replaces it,
+// leaving no stray *.gortex.tmp-* file behind. This is also the
+// no-contention happy path for renameWithRetry — its retry loop must be
+// transparent when the rename succeeds first try.
+func TestAtomicWriteFileCreatesAndOverwrites(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sub", "file.txt")
+
+	if err := AtomicWriteFile(path, []byte("first"), 0o644); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if got, _ := os.ReadFile(path); string(got) != "first" {
+		t.Fatalf("content: got %q want %q", got, "first")
+	}
+
+	// Overwrite must replace, not append or corrupt.
+	if err := AtomicWriteFile(path, []byte("second"), 0o644); err != nil {
+		t.Fatalf("overwrite: %v", err)
+	}
+	if got, _ := os.ReadFile(path); string(got) != "second" {
+		t.Fatalf("overwrite content: got %q want %q", got, "second")
+	}
+
+	// Success must not leave the sibling temp file behind.
+	if leftovers, _ := filepath.Glob(filepath.Join(filepath.Dir(path), "*.gortex.tmp-*")); len(leftovers) != 0 {
+		t.Fatalf("leftover temp files: %v", leftovers)
+	}
+}
+
+// TestRenameWithRetryReturnsNonRetryableErr checks that a rename failure
+// which isn't a transient sharing violation (here: a missing source) is
+// surfaced immediately rather than retried — the retry budget is reserved
+// for the Windows lock race, not for masking genuine errors. On every
+// platform ERROR_FILE_NOT_FOUND / ENOENT is non-retryable, so this holds
+// cross-platform.
+func TestRenameWithRetryReturnsNonRetryableErr(t *testing.T) {
+	dir := t.TempDir()
+	if err := renameWithRetry(filepath.Join(dir, "does-not-exist"), filepath.Join(dir, "dest")); err == nil {
+		t.Fatal("expected an error renaming a missing source, got nil")
+	}
+}

--- a/internal/agents/writer_windows.go
+++ b/internal/agents/writer_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package agents
+
+import (
+	"errors"
+	"syscall"
+)
+
+// Windows system error codes returned by MoveFileEx (which os.Rename
+// wraps) when the destination path is transiently held open by another
+// process without FILE_SHARE_DELETE — an editor's language server,
+// antivirus, a search indexer, or Gortex's own file watcher re-indexing
+// the file we just wrote. Unlike POSIX, Windows refuses to replace a file
+// while such a handle is open. The holder releases within milliseconds,
+// so these are safe to retry.
+const (
+	errSharingViolation syscall.Errno = 32 // ERROR_SHARING_VIOLATION
+	errLockViolation    syscall.Errno = 33 // ERROR_LOCK_VIOLATION
+	errAccessDenied     syscall.Errno = 5  // ERROR_ACCESS_DENIED
+)
+
+// isRetryableRenameErr reports whether a failed os.Rename is a transient
+// Windows sharing/lock violation worth retrying. os.Rename returns a
+// *os.LinkError whose Err unwraps to a syscall.Errno.
+func isRetryableRenameErr(err error) bool {
+	return errors.Is(err, errSharingViolation) ||
+		errors.Is(err, errLockViolation) ||
+		errors.Is(err, errAccessDenied)
+}

--- a/internal/agents/writer_windows_test.go
+++ b/internal/agents/writer_windows_test.go
@@ -1,0 +1,96 @@
+//go:build windows
+
+package agents
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// openExclusiveNoDelete opens path with a share mode that omits
+// FILE_SHARE_DELETE, reproducing the handle an editor's language server,
+// antivirus, a search indexer, or Gortex's own file watcher holds while
+// touching a file. MoveFileEx — and therefore os.Rename — cannot replace
+// a destination held this way and fails with ERROR_SHARING_VIOLATION.
+func openExclusiveNoDelete(t *testing.T, path string) syscall.Handle {
+	t.Helper()
+	p, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		t.Fatalf("utf16 %s: %v", path, err)
+	}
+	h, err := syscall.CreateFile(p,
+		syscall.GENERIC_READ,
+		syscall.FILE_SHARE_READ, // deliberately no FILE_SHARE_DELETE / WRITE
+		nil,
+		syscall.OPEN_EXISTING,
+		syscall.FILE_ATTRIBUTE_NORMAL,
+		0)
+	if err != nil {
+		t.Fatalf("CreateFile %s: %v", path, err)
+	}
+	return h
+}
+
+// TestAtomicWriteFileRetriesPastSharingViolation is the Windows regression
+// test for the "The process cannot access the file because it is being
+// used by another process" failures: when the destination is transiently
+// held open without FILE_SHARE_DELETE, AtomicWriteFile must retry the
+// rename and succeed once the holder releases the handle, instead of
+// surfacing the spurious error.
+//
+// CI's Windows job is build-only (see .github/workflows/ci.yml), so this
+// runs locally / on demand, not in the cross-platform test matrix.
+func TestAtomicWriteFileRetriesPastSharingViolation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "held.txt")
+	if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	h := openExclusiveNoDelete(t, path)
+
+	// Release the handle within the retry budget (~225ms) so a rename that
+	// first fails with a sharing violation later succeeds.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(40 * time.Millisecond)
+		_ = syscall.CloseHandle(h)
+	}()
+
+	if err := AtomicWriteFile(path, []byte("new"), 0o644); err != nil {
+		t.Fatalf("AtomicWriteFile should retry past a transient hold, got: %v", err)
+	}
+	wg.Wait()
+
+	if got, _ := os.ReadFile(path); string(got) != "new" {
+		t.Fatalf("content after retry: got %q want %q", got, "new")
+	}
+}
+
+// TestAtomicWriteFileFailsWhenHeldThroughout bounds the retry: a
+// destination held open for longer than the whole retry budget must make
+// AtomicWriteFile give up and return an error — not hang forever — and
+// must leave the original file intact.
+func TestAtomicWriteFileFailsWhenHeldThroughout(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "locked.txt")
+	if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	h := openExclusiveNoDelete(t, path)
+	defer syscall.CloseHandle(h)
+
+	if err := AtomicWriteFile(path, []byte("new"), 0o644); err == nil {
+		t.Fatal("expected AtomicWriteFile to fail while the file is held open throughout")
+	}
+	if got, _ := os.ReadFile(path); string(got) != "old" {
+		t.Fatalf("a failed write must not corrupt the destination: got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

On Windows, `os.Rename` — which `AtomicWriteFile` uses for its temp→dest replace — maps to `MoveFileEx(MOVEFILE_REPLACE_EXISTING)`, which fails with `ERROR_SHARING_VIOLATION` / `ERROR_ACCESS_DENIED` when the destination is briefly held open **without `FILE_SHARE_DELETE`** by another process: an editor's language server, antivirus, a search indexer, or **Gortex's own file watcher re-indexing the file we just wrote**.

Because `AtomicWriteFile` is the single choke point for every MCP file mutation (`write_file`, `edit_file`, `move`, safe-delete, overlay-branch), this surfaces to coding agents as spurious errors like:

```
rename ...\entry.cs.gortex.tmp-3024971810 -> ...\entry.cs: The process cannot access the file because it is being used by another process.
```

on rapid successive edits to the same file — the second write races the reindex the first write triggered. Retrying the same edit typically succeeds, confirming a transient lock rather than a real error.

POSIX renames replace an open destination atomically, so this never happens off Windows.

## Changes

- `internal/agents/writer.go`: route the temp→dest rename through a new `renameWithRetry` — a bounded retry (10 attempts, ~225 ms total backoff) that retries **only** when the failure is a transient Windows sharing/lock violation and returns every other error immediately.
- `internal/agents/writer_windows.go` (new, `//go:build windows`): `isRetryableRenameErr` matching `ERROR_SHARING_VIOLATION` (32), `ERROR_LOCK_VIOLATION` (33), `ERROR_ACCESS_DENIED` (5) via `errors.Is` on the `*os.LinkError` chain.
- `internal/agents/writer_other.go` (new, `//go:build !windows`): the predicate is always `false`, so the loop collapses to a single `os.Rename` with no added latency on POSIX.

The build-tag split mirrors the vendored `renameio` package's existing Windows/non-Windows layout. No behavior change off Windows; on Windows the only change is that a transient sharing violation is retried instead of surfaced.

## Testing

- [x] New `internal/agents/writer_windows_test.go` reproduces the exact failure: it opens the destination without `FILE_SHARE_DELETE`, then asserts `AtomicWriteFile` retries and succeeds once the handle releases. A second test bounds the retry (destination held throughout → gives up and returns the error, leaving the original file intact).
- [x] Portable `writer_test.go` coverage: create/overwrite happy path (asserts no leftover `*.gortex.tmp-*`) and non-retryable errors fast-fail.
- [x] `go test ./internal/agents/` passes on Windows (all four new tests); `gofmt -l` and `go vet` clean; `GOOS=linux CGO_ENABLED=0 go build ./internal/agents/` succeeds.

> Note: the `test` job runs on ubuntu/macos only and the `build-windows` job is build-only (per `.github/workflows/ci.yml`), so the Windows regression tests are validated locally / on-demand rather than in the CI matrix.

## Checklist

- [x] Code follows existing patterns in the codebase
- [x] No unnecessary abstractions added
- [ ] Language extractor includes `Meta["methods"]` for interfaces (n/a)
- [ ] Methods have `EdgeMemberOf` edges to their containing type (n/a)
