### PR TITLE
Windows: fix slash-path duplicate indexing and orphaned atomic-write temp files

### DIFF
--- a/internal/agents/writer.go
+++ b/internal/agents/writer.go
@@ -112,15 +112,22 @@ func WriteOwnedFile(w io.Writer, path, content string, opts ApplyOpts) (FileActi
 // either sees the old file or the fully-written new file — never a
 // half-written state.
 //
-// The temp file uses a deterministic prefix so a crash leaves
-// "<name>.gortex.tmp-<pid>.<rand>" files that are easy to identify
-// and clean up manually.
+// The temp file carries a distinctive ".gortex.tmp-" infix, so a crash
+// between CreateTemp and the rename leaves an identifiable
+// "<name>.gortex.tmp-<rand>" orphan. Those orphans are not left to
+// accumulate: every AtomicWriteFile first sweeps its target directory
+// for stale ones via cleanStaleTempFiles.
 func AtomicWriteFile(path string, data []byte, perm os.FileMode) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("mkdir %s: %w", dir, err)
 	}
-	f, err := os.CreateTemp(dir, filepath.Base(path)+".gortex.tmp-*")
+	// Reap temp files an earlier write orphaned here before adding our
+	// own: a crash (or kill) between CreateTemp and the rename below
+	// strands the temp on disk, and the success path only ever consumes
+	// THIS write's temp, so without an opportunistic sweep they pile up.
+	cleanStaleTempFiles(dir)
+	f, err := os.CreateTemp(dir, filepath.Base(path)+tempInfix+"*")
 	if err != nil {
 		return fmt.Errorf("create temp in %s: %w", dir, err)
 	}
@@ -150,6 +157,48 @@ func AtomicWriteFile(path string, data []byte, perm os.FileMode) error {
 		return fmt.Errorf("rename %s -> %s: %w", tmpPath, path, err)
 	}
 	return nil
+}
+
+// tempInfix is the distinctive, Gortex-branded marker in every temp
+// file AtomicWriteFile writes: os.CreateTemp expands the pattern
+// "<base>.gortex.tmp-*" into "<base>.gortex.tmp-<random>". Sharing one
+// const between the writer and the reaper keeps the sweep from ever
+// drifting out of sync with the names it is meant to match.
+const tempInfix = ".gortex.tmp-"
+
+// staleTempAge is how long an orphaned temp must sit untouched before a
+// later write reaps it. It only has to exceed the lifetime of one
+// in-flight AtomicWriteFile — a data write plus renameWithRetry's
+// ~225ms worst-case backoff — so an hour is orders of magnitude of
+// headroom and guarantees a concurrent write's fresh temp is never
+// mistaken for debris.
+const staleTempAge = time.Hour
+
+// cleanStaleTempFiles best-effort removes temp files an earlier
+// AtomicWriteFile orphaned in dir when its process died between
+// CreateTemp and the rename. Only files that carry our own tempInfix
+// AND have gone untouched for longer than staleTempAge are removed, so
+// a temp another writer is still filling in (or about to rename) is
+// never disturbed. Every error is swallowed: this is directory hygiene,
+// not a load-bearing step — a write must never fail because a leftover
+// could not be reaped, and a dir we cannot read simply has nothing to
+// sweep from this caller's point of view.
+func cleanStaleTempFiles(dir string) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	cutoff := time.Now().Add(-staleTempAge)
+	for _, e := range entries {
+		if e.IsDir() || !strings.Contains(e.Name(), tempInfix) {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil || !info.ModTime().Before(cutoff) {
+			continue
+		}
+		_ = os.Remove(filepath.Join(dir, e.Name()))
+	}
 }
 
 // renameWithRetry renames oldPath onto newPath, retrying briefly when the

--- a/internal/agents/writer_test.go
+++ b/internal/agents/writer_test.go
@@ -331,7 +331,7 @@ func TestRenameWithRetryReturnsNonRetryableErr(t *testing.T) {
 }
 
 // TestAtomicWriteFileReapsStaleTempOrphans guards the cleanup of temp
-// files a crashed write orphaned ("历史临时文件未清理"): a *.gortex.tmp-*
+// files a crashed write orphaned ("not cleared"): a *.gortex.tmp-*
 // stranded when a process died between CreateTemp and the rename must be
 // reaped by a later AtomicWriteFile — but a temp still in flight (fresh
 // mtime) and any unrelated file must be left untouched.

--- a/internal/agents/writer_test.go
+++ b/internal/agents/writer_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // TestWriteIfNotExistsCreatesAndSkips covers both the create and
@@ -326,5 +327,55 @@ func TestRenameWithRetryReturnsNonRetryableErr(t *testing.T) {
 	dir := t.TempDir()
 	if err := renameWithRetry(filepath.Join(dir, "does-not-exist"), filepath.Join(dir, "dest")); err == nil {
 		t.Fatal("expected an error renaming a missing source, got nil")
+	}
+}
+
+// TestAtomicWriteFileReapsStaleTempOrphans guards the cleanup of temp
+// files a crashed write orphaned ("历史临时文件未清理"): a *.gortex.tmp-*
+// stranded when a process died between CreateTemp and the rename must be
+// reaped by a later AtomicWriteFile — but a temp still in flight (fresh
+// mtime) and any unrelated file must be left untouched.
+func TestAtomicWriteFileReapsStaleTempOrphans(t *testing.T) {
+	dir := t.TempDir()
+
+	// A stale orphan from a write that crashed long ago.
+	stale := filepath.Join(dir, "config.json"+tempInfix+"123456")
+	if err := os.WriteFile(stale, []byte("half-written"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-2 * staleTempAge)
+	if err := os.Chtimes(stale, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	// A temp another write is still filling in — fresh mtime, must survive.
+	fresh := filepath.Join(dir, "other.json"+tempInfix+"987654")
+	if err := os.WriteFile(fresh, []byte("in flight"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A real, unrelated file must never be swept.
+	keep := filepath.Join(dir, "keep.txt")
+	if err := os.WriteFile(keep, []byte("keep me"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Any AtomicWriteFile into the directory sweeps it first.
+	target := filepath.Join(dir, "config.json")
+	if err := AtomicWriteFile(target, []byte("new content"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Errorf("stale temp orphan must be reaped (stat err=%v)", err)
+	}
+	if _, err := os.Stat(fresh); err != nil {
+		t.Errorf("in-flight temp (fresh mtime) must be preserved: %v", err)
+	}
+	if _, err := os.Stat(keep); err != nil {
+		t.Errorf("unrelated file must be untouched: %v", err)
+	}
+	if got, _ := os.ReadFile(target); string(got) != "new content" {
+		t.Errorf("target content: got %q want %q", got, "new content")
 	}
 }

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -1282,6 +1282,27 @@ func (idx *Indexer) relKey(absPath string) string {
 	return pathkey.Normalize(filepath.ToSlash(rel))
 }
 
+// graphRelKey reduces an absolute path to the key the GRAPH stores a
+// file's nodes under: repo-relative, OS-native separators (the exact
+// form the bulk-walk extractor stamps on node IDs / FilePaths),
+// NFC-folded. It is the graph-node analogue of relKey — relKey
+// slash-normalises for the mtime map, graphRelKey keeps the OS-native
+// separators so an incremental re-index's evict lookup actually matches
+// the nodes the cold walk created (graph.GetFileNodes / EvictFile key on
+// the exact string, with no separator folding). On POSIX the two are
+// identical (filepath.Rel already yields '/'); they diverge only on
+// Windows, where relKey's ToSlash would key the lookup as
+// "repo/a/b.go" while the cold walk stored "repo/a\b.go" — the miss
+// leaves the stale nodes un-evicted and the re-parse leaks a duplicate
+// set on every save (issue: slash-path duplicate indexing).
+func (idx *Indexer) graphRelKey(absPath string) string {
+	rel, err := filepath.Rel(idx.rootPath, absPath)
+	if err != nil {
+		return pathkey.Normalize(absPath)
+	}
+	return pathkey.Normalize(rel)
+}
+
 // RelKey exposes relKey to in-package collaborators (the watcher) that
 // hold an absolute filesystem path and need the canonical repo-relative
 // graph key for it — e.g. to look up a file's nodes before and after a
@@ -1446,7 +1467,7 @@ func (idx *Indexer) graphFilePaths(files []string) []string {
 		if !filepath.IsAbs(abs) && idx.rootPath != "" {
 			abs = filepath.Join(idx.rootPath, f)
 		}
-		out = append(out, idx.prefixPath(idx.relKey(abs)))
+		out = append(out, idx.prefixPath(idx.graphRelKey(abs)))
 	}
 	return out
 }
@@ -2258,7 +2279,7 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 			skippedBytes += info.Size()
 			rel, _ := filepath.Rel(absRoot, path)
 			skippedBySize = append(skippedBySize, skippedFile{
-				relPath: filepath.ToSlash(rel), lang: lang, size: info.Size(),
+				relPath: pathkey.Normalize(rel), lang: lang, size: info.Size(),
 			})
 			return nil
 		}
@@ -2266,7 +2287,7 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 			skippedContentBytes += info.Size()
 			rel, _ := filepath.Rel(absRoot, path)
 			skippedByContent = append(skippedByContent, skippedFile{
-				relPath: filepath.ToSlash(rel), lang: lang, size: info.Size(), reason: reason,
+				relPath: pathkey.Normalize(rel), lang: lang, size: info.Size(), reason: reason,
 			})
 			return nil
 		}
@@ -2274,7 +2295,7 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 			skippedContentBytes += info.Size()
 			rel, _ := filepath.Rel(absRoot, path)
 			skippedByContent = append(skippedByContent, skippedFile{
-				relPath: filepath.ToSlash(rel), lang: lang, size: info.Size(), reason: reason,
+				relPath: pathkey.Normalize(rel), lang: lang, size: info.Size(), reason: reason,
 			})
 			return nil
 		}
@@ -3444,12 +3465,19 @@ func (idx *Indexer) indexFile(filePath string, resolve bool) error {
 		return err
 	}
 
-	// relKey gives the canonical key (slash form, Unicode NFC). Using
-	// it here keeps an incremental re-index — which may be driven by a
-	// git-watcher path in NFC or an FSEvents path in NFD — landing on
-	// the exact graph key the bulk walk created, so the evict below
-	// finds the file's existing nodes instead of leaking a duplicate.
-	relPath := idx.relKey(absPath)
+	// Two keys for the same file, deliberately distinct on Windows.
+	// mtimeKey (relKey: slash form + NFC) is the fileMtimes map key.
+	// relPath (graphRelKey: OS-native separators + NFC) is what the
+	// graph stores a file's nodes under — the exact form the cold bulk
+	// walk stamped on their IDs / FilePaths. The evict below MUST use
+	// the graph form: a slash-keyed lookup misses the backslash-keyed
+	// cold nodes on Windows, so the re-parse would leak a duplicate node
+	// set on every save. On POSIX the two keys are identical
+	// (filepath.Rel already yields '/'), so this split is a Windows-only
+	// correction. Both drive an FSEvents-NFD / git-watcher-NFC path onto
+	// the same NFC key so a re-index still lands on the bulk-walk key.
+	mtimeKey := idx.relKey(absPath)
+	relPath := idx.graphRelKey(absPath)
 
 	// In multi-repo mode, the graph stores prefixed file paths.
 	graphPath := idx.prefixPath(relPath)
@@ -3501,7 +3529,7 @@ func (idx *Indexer) indexFile(filePath string, resolve bool) error {
 	// prior state and installs the synthetic node, same as before.
 	if maxSize := idx.config.MaxFileSize; maxSize > 0 && int64(len(src)) > maxSize {
 		n := sizeSkipNode(skippedFile{
-			relPath: filepath.ToSlash(relPath), lang: lang, size: int64(len(src)),
+			relPath: relPath, lang: lang, size: int64(len(src)),
 		}, maxSize)
 		idx.applyRepoPrefix([]*graph.Node{n}, nil)
 		evictExisting()
@@ -3515,7 +3543,7 @@ func (idx *Indexer) indexFile(filePath string, resolve bool) error {
 	// — same synthetic-skip-node treatment as the size cap above.
 	if reason, skip := idx.newContentAdmissionGate().skip(lang, int64(len(src))); skip {
 		n := contentSkipNode(skippedFile{
-			relPath: filepath.ToSlash(relPath), lang: lang, size: int64(len(src)), reason: reason,
+			relPath: relPath, lang: lang, size: int64(len(src)), reason: reason,
 		})
 		idx.applyRepoPrefix([]*graph.Node{n}, nil)
 		evictExisting()
@@ -3554,7 +3582,7 @@ func (idx *Indexer) indexFile(filePath string, resolve bool) error {
 		// from perpetually seeing this one unparseable file as "the
 		// repo changed" and routing the whole repo through the
 		// expensive shadow re-track path on every restart.
-		idx.recordFileMtime(relPath, absPath)
+		idx.recordFileMtime(mtimeKey, absPath)
 		return err
 	}
 
@@ -3745,10 +3773,11 @@ func (idx *Indexer) indexFile(filePath string, resolve bool) error {
 		}
 	}
 
-	// Update mtime for this file. relPath is already the canonical
-	// key (relKey applied slash + NFC), so the mtime entry lines up
-	// with the graph file-node key and with the bulk-walk mtimes.
-	idx.recordFileMtime(relPath, absPath)
+	// Update mtime for this file, keyed by mtimeKey (the relKey slash
+	// form), NOT relPath — relPath is the OS-native graph key, whereas
+	// the fileMtimes map and IsStale / TrackedFileState all key on the
+	// slash form.
+	idx.recordFileMtime(mtimeKey, absPath)
 
 	return nil
 }
@@ -3909,7 +3938,10 @@ func (idx *Indexer) EvictFile(filePath string) (int, int) {
 	if !filepath.IsAbs(absPath) {
 		absPath = filepath.Join(idx.rootPath, filePath)
 	}
-	relPath := idx.relKey(absPath)
+	// graphRelKey (OS-native + NFC), not relKey (slash + NFC): the graph
+	// stores nodes under OS-native separators, so a slash-form lookup
+	// would miss them on Windows and leave a stale subtree behind.
+	relPath := idx.graphRelKey(absPath)
 	// In multi-repo mode, the graph stores prefixed file paths.
 	graphPath := idx.prefixPath(relPath)
 	// Remove from search index.
@@ -3937,7 +3969,10 @@ func (idx *Indexer) ReresolveFileScoped(filePath string) error {
 	if !filepath.IsAbs(absPath) {
 		absPath = filepath.Join(idx.rootPath, filePath)
 	}
-	graphPath := idx.prefixPath(idx.relKey(absPath))
+	// graphRelKey (OS-native + NFC): the graph keys nodes under OS-native
+	// separators, so a relKey slash-form graphPath would miss them on
+	// Windows and wrongly report the file as evicted.
+	graphPath := idx.prefixPath(idx.graphRelKey(absPath))
 	if len(idx.graph.GetFileNodes(graphPath)) == 0 {
 		return nil // file gone / evicted; nothing to re-resolve
 	}
@@ -5016,7 +5051,11 @@ func (idx *Indexer) IncrementalReindexPaths(root string, paths []string) (*Index
 	}
 
 	for _, relPath := range deletedFiles {
-		graphPath := idx.prefixPath(relPath)
+		// relPath is a fileMtimes key (relKey: slash + NFC); the graph
+		// keys nodes under OS-native separators, so convert before the
+		// evict or a deleted file's nodes leak on Windows. FromSlash is
+		// a no-op on POSIX.
+		graphPath := idx.prefixPath(filepath.FromSlash(relPath))
 		idx.restubIncomingRefs(graphPath)
 		idx.evictEnrichment(graphPath)
 		idx.graph.EvictFile(graphPath)
@@ -5247,7 +5286,11 @@ func (idx *Indexer) IncrementalReindex(root string) (*IndexResult, error) {
 
 	// Evict only files that are truly absent from disk.
 	for _, relPath := range deletedFiles {
-		graphPath := idx.prefixPath(relPath)
+		// relPath is a fileMtimes key (relKey: slash + NFC); the graph
+		// keys nodes under OS-native separators, so convert before the
+		// evict or a deleted file's nodes leak on Windows. FromSlash is
+		// a no-op on POSIX.
+		graphPath := idx.prefixPath(filepath.FromSlash(relPath))
 		idx.restubIncomingRefs(graphPath)
 		idx.evictEnrichment(graphPath)
 		idx.graph.EvictFile(graphPath)

--- a/internal/indexer/realtime_reliability_test.go
+++ b/internal/indexer/realtime_reliability_test.go
@@ -450,7 +450,12 @@ func TestWatcher_NewSubdirScanIndexesPreWatchFile(t *testing.T) {
 	require.NoError(t, os.MkdirAll(subdir, 0o755))
 	ext.setFuncs("Buried")
 	writeFile(t, filepath.Join(subdir, "buried.fk"), "buried body")
-	require.Empty(t, g.GetFileNodes("pkg/buried.fk"),
+	// The graph keys file nodes under OS-native separators (see
+	// graphRelKey), so build the expected key with filepath.Join instead
+	// of a hard-coded "pkg/buried.fk" — the slash form only matches on
+	// POSIX and would spuriously fail this test on Windows.
+	buriedKey := filepath.Join("pkg", "buried.fk")
+	require.Empty(t, g.GetFileNodes(buriedKey),
 		"the pre-watch file must be absent before the directory scan")
 
 	w.handleEvent(fswatcher.WatchEvent{
@@ -459,7 +464,7 @@ func TestWatcher_NewSubdirScanIndexesPreWatchFile(t *testing.T) {
 	})
 
 	require.Eventually(t, func() bool {
-		return len(g.GetFileNodes("pkg/buried.fk")) > 0
+		return len(g.GetFileNodes(buriedKey)) > 0
 	}, 5*time.Second, 10*time.Millisecond,
 		"the new-directory create must trigger a scoped scan that indexes the pre-watch file")
 }

--- a/internal/indexer/slash_path_test.go
+++ b/internal/indexer/slash_path_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // TestIncrementalReindex_NestedFileNoDuplicate guards the
-// "斜杠路径重复索引" (slash-path duplicate indexing) regression on Windows.
+// slash-path duplicate indexing regression on Windows.
 //
 // The cold bulk walk keys a nested file's graph nodes under OS-native
 // separators — "myrepo/pkg\sub\thing.go" on Windows. The incremental

--- a/internal/indexer/slash_path_test.go
+++ b/internal/indexer/slash_path_test.go
@@ -1,0 +1,67 @@
+package indexer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// TestIncrementalReindex_NestedFileNoDuplicate guards the
+// "斜杠路径重复索引" (slash-path duplicate indexing) regression on Windows.
+//
+// The cold bulk walk keys a nested file's graph nodes under OS-native
+// separators — "myrepo/pkg\sub\thing.go" on Windows. The incremental
+// re-index must evict via the SAME OS-native key (graphRelKey), not the
+// relKey slash form; otherwise graph.GetFileNodes / EvictFile (which
+// match the key byte-for-byte, with no separator folding) miss the cold
+// nodes, the stale set survives, and the re-parse appends a second,
+// forward-slash-keyed copy — a duplicate that grows on every save.
+//
+// On POSIX filepath.Rel already yields '/', so the two key forms
+// coincide and this is a Windows-only correction; the assertions below
+// hold on every platform (before the fix they failed only on Windows).
+func TestIncrementalReindex_NestedFileNoDuplicate(t *testing.T) {
+	dir := t.TempDir()
+	nested := filepath.Join(dir, "pkg", "sub", "thing.go")
+	require.NoError(t, os.MkdirAll(filepath.Dir(nested), 0o755))
+	const content = "package sub\n\nfunc Thing() {}\n"
+	writeFile(t, nested, content)
+
+	g := graph.New()
+	idx := newTestIndexer(g)
+	idx.SetRepoPrefix("myrepo")
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+
+	// Cold index established exactly one node named Thing.
+	cold := g.FindNodesByName("Thing")
+	require.Len(t, cold, 1, "cold index should define Thing exactly once")
+	coldFilePath := cold[0].FilePath
+
+	// A scoped incremental re-index of the same file must REPLACE its
+	// node set, not leak a second copy under a different separator form.
+	bumpMtime(t, nested, content)
+	_, err = idx.IncrementalReindexPaths(dir, []string{nested})
+	require.NoError(t, err)
+
+	things := g.FindNodesByName("Thing")
+	require.Len(t, things, 1,
+		"incremental re-index must replace the nested file's nodes, not duplicate them")
+
+	// The re-indexed node must land on the SAME key the cold walk used,
+	// so the graph stays internally consistent and runtime lookups (which
+	// build OS-native graph paths) still resolve it after a save.
+	assert.Equal(t, coldFilePath, things[0].FilePath,
+		"incremental node FilePath must match the cold-walk key form")
+
+	// And the whole file's node set must be reachable under that one key
+	// — never split across a slash and a backslash spelling.
+	nodesUnderColdKey := g.GetFileNodes(idx.prefixPath(idx.graphRelKey(nested)))
+	assert.NotEmpty(t, nodesUnderColdKey,
+		"the file's nodes must be retrievable under the graph key form")
+}

--- a/internal/indexer/watcher.go
+++ b/internal/indexer/watcher.go
@@ -1006,15 +1006,20 @@ func (w *Watcher) patchGraph(path string, kind ChangeKind) {
 	start := time.Now()
 	var nodesAdded, nodesRemoved, edgesAdded, edgesRemoved int
 
-	// Compute the relative path for snapshotting old symbols. RelKey
-	// folds it to the canonical key (slash form, Unicode NFC) so the
-	// GetFileNodes / snapshotSymbols lookups below hit the same graph
-	// key the indexer stored — a watcher event for a non-ASCII-named
-	// file arrives in the filesystem's Unicode form (NFD on macOS),
-	// which would otherwise miss an NFC-keyed node.
+	// Two keys for this file. relPath (RelKey: slash form + NFC) is the
+	// mtime-forget / change-callback key. graphKey (graphRelKey:
+	// OS-native separators + NFC, repo-prefixed) is what the graph
+	// stores the file's nodes under, so the GetFileNodes /
+	// snapshotSymbols lookups below MUST use it — a slash-form key
+	// misses the backslash-keyed nodes on Windows and would report every
+	// symbol as added/removed. Both fold an NFD (macOS) event path to
+	// NFC so a non-ASCII name still hits the indexed node. On POSIX the
+	// two keys coincide.
 	relPath := path
+	graphKey := path
 	if w.indexer.rootPath != "" {
 		relPath = w.indexer.RelKey(path)
+		graphKey = w.indexer.prefixPath(w.indexer.graphRelKey(path))
 	}
 
 	switch kind {
@@ -1023,7 +1028,7 @@ func (w *Watcher) patchGraph(path string, kind ChangeKind) {
 			w.logger.Warn("index file failed", zap.String("path", path), zap.Error(err))
 			return
 		}
-		newSymbols := w.indexer.graph.GetFileNodes(relPath)
+		newSymbols := w.indexer.graph.GetFileNodes(graphKey)
 		nodesAdded = len(newSymbols)
 		edgesAdded = w.countFileEdges(newSymbols)
 
@@ -1037,7 +1042,7 @@ func (w *Watcher) patchGraph(path string, kind ChangeKind) {
 
 	case ChangeModified:
 		// Snapshot old symbols before eviction.
-		oldSymbols := w.snapshotSymbols(relPath)
+		oldSymbols := w.snapshotSymbols(graphKey)
 
 		// Content-aware skip: if the saved file's structural symbols
 		// are byte-for-byte identical to the ones already in the
@@ -1065,7 +1070,7 @@ func (w *Watcher) patchGraph(path string, kind ChangeKind) {
 		// count first (still present pre-swap) so removed/added telemetry
 		// stays gross: a rename removes one node and adds one even though
 		// the net node delta is zero.
-		priorNodes := w.indexer.graph.GetFileNodes(relPath)
+		priorNodes := w.indexer.graph.GetFileNodes(graphKey)
 		fileEdgesBefore := w.countFileEdges(priorNodes)
 		resolvedBefore := w.countResolvedFileEdges(priorNodes)
 		incomingBeforeByID := w.resolvedIncomingByNode(priorNodes)
@@ -1074,7 +1079,7 @@ func (w *Watcher) patchGraph(path string, kind ChangeKind) {
 			return
 		}
 		nodesRemoved = len(priorNodes)
-		newSymbols := w.indexer.graph.GetFileNodes(relPath)
+		newSymbols := w.indexer.graph.GetFileNodes(graphKey)
 		nodesAdded = len(newSymbols)
 		// Edge churn scoped to this file's nodes. A graph-wide
 		// EdgeCount delta would also pick up edges landed by whatever
@@ -1103,7 +1108,7 @@ func (w *Watcher) patchGraph(path string, kind ChangeKind) {
 
 	case ChangeDeleted, ChangeRenamed:
 		// Snapshot old symbols before eviction.
-		oldSymbols := w.snapshotSymbols(relPath)
+		oldSymbols := w.snapshotSymbols(graphKey)
 
 		nr, er := w.indexer.EvictFile(path)
 		nodesRemoved = nr
@@ -1437,8 +1442,8 @@ func (w *Watcher) recordInertModify(path, relPath string, symbols []*graph.Node,
 
 // snapshotSymbols returns a deep copy of the symbols for a file, preserving
 // their signatures in Meta so they can be compared after re-indexing.
-func (w *Watcher) snapshotSymbols(relPath string) []*graph.Node {
-	nodes := w.indexer.graph.GetFileNodes(relPath)
+func (w *Watcher) snapshotSymbols(graphKey string) []*graph.Node {
+	nodes := w.indexer.graph.GetFileNodes(graphKey)
 	snapshot := make([]*graph.Node, 0, len(nodes))
 	for _, n := range nodes {
 		// Skip file and import nodes — we only track code symbols.


### PR DESCRIPTION
## Windows robustness: fix slash-path duplicate indexing and orphaned temp files

Two self-defects surfaced while hardening the Windows atomic-write path, plus the rename-retry that this branch already carried.

### 1. Slash-path duplicate indexing (Windows)

The graph keys a file's nodes under **OS-native separators** — the cold bulk walk stamps `repo/pkg\sub\x.go` on Windows (`filepath.Rel`, no `ToSlash`), and every runtime file→node lookup produces the same form. But the **incremental** re-index path derived its graph lookup/eviction key with `relKey`, which slash-normalises to `repo/pkg/sub/x.go`.

`graph.GetFileNodes` / `graph.EvictFile` match the key **byte-for-byte with no separator folding**, so on Windows:

- an incremental re-index **missed** the backslash-keyed cold nodes → the evict was a no-op → the re-parse appended a **second, forward-slash-keyed copy**. A duplicate node set grew on every save.
- deleted files leaked their nodes the same way (the deletion loops built the evict key from the slash-form mtime map).
- the watcher's change-detection reported **every symbol as added/removed** (its `GetFileNodes` used the slash key too).

On POSIX the two key forms coincide (`filepath.Rel` already yields `/`), so this only ever bit Windows — which is why it hid behind a green Linux CI.

**Fix:** introduce `graphRelKey` (OS-native separators + NFC) as the single graph-node key, and keep `relKey` (slash + NFC) for the `fileMtimes` map only. Every graph-key derivation now routes through `graphRelKey`: `indexFile` (evict + new-node form), `EvictFile`, `ReresolveFileScoped`, `graphFilePaths`, the scoped-deletion loops (via `filepath.FromSlash` on the mtime key), the cold-walk size/content skip nodes, and the watcher's `GetFileNodes` / `snapshotSymbols`. The mtime map, `IsStale`, and staleness detection are deliberately untouched.

This also fixes the pre-existing `TestIncrementalReindexPaths_EvictsDeletedFileInScope` and `TestIncrementalReindex_ConvergesToFullIndex` failures on Windows. New regression guard: `TestIncrementalReindex_NestedFileNoDuplicate` (verified to fail without the fix).

### 2. Orphaned atomic-write temp files never cleaned up

`AtomicWriteFile` writes through a `<name>.gortex.tmp-<rand>` temp file and renames it into place. A crash (or kill) between `CreateTemp` and the rename strands that temp on disk **forever** — the success path only removes its own temp — so orphans accumulate wherever Gortex writes agent config. The doc comment literally told users to "clean up manually".

**Fix:** every `AtomicWriteFile` now calls `cleanStaleTempFiles(dir)` first, reaping files that carry the `.gortex.tmp-` infix and have been untouched for over an hour. The age gate sits far above a single write's lifetime (data write + `renameWithRetry`'s ~225 ms worst case), so a temp another writer is still filling in is never touched. Best-effort and error-swallowing — a write never fails because a leftover couldn't be removed. New test: `TestAtomicWriteFileReapsStaleTempOrphans`.

### Verification

- `go build ./...` and `go vet` on the touched packages pass.
- `internal/indexer` full package: **zero new test failures** vs. the base branch (compared by test name), and the two reindex failures above now pass. The remaining failures reproduce on an unmodified checkout (pre-existing Windows-environment issues, unrelated to this change).
- Both regression tests were confirmed to fail when the fix is reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
