### PR TITLE
test(ci): run agent integrations on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,9 @@ jobs:
   build-windows:
     # CGO build smoke-test on native Windows. tree-sitter needs a C/C++
     # compiler — the GitHub windows runner ships mingw-w64 on PATH, so no
-    # extra toolchain setup is required. Build-only: `go build ./...`
-    # compiles every production package without pulling in the
-    # platform-specific test files a full `go test` would.
+    # extra toolchain setup is required. `go build ./...` compiles every
+    # production package; the focused agents test also exercises Windows-only
+    # integration paths without opting into the unsupported full test suite.
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -52,6 +52,9 @@ jobs:
 
       - name: Build all packages
         run: go build ./...
+
+      - name: Test Windows agent integrations
+        run: go test -timeout=5m -count=1 ./internal/agents
 
   lint:
     runs-on: ubuntu-latest

--- a/internal/agents/instructions_test.go
+++ b/internal/agents/instructions_test.go
@@ -185,11 +185,12 @@ func TestBashInstructionsBodyUsesOnlyExplicitCLIMirror(t *testing.T) {
 func TestGlobalPointerBody_ShapeAndSentinel(t *testing.T) {
 	const dir = "/home/user/.gortex/instructions"
 	body := GlobalPointerBody(dir)
+	activePath := filepath.Join(dir, "active.md")
 
 	if !strings.Contains(body, InstructionsSentinel) {
 		t.Error("pointer block lost the idempotency sentinel heading")
 	}
-	if !strings.Contains(body, "@"+dir+"/active.md") {
+	if !strings.Contains(body, "@"+activePath) {
 		t.Errorf("pointer block does not @-include the active profile: %q", body)
 	}
 	if !strings.Contains(body, "gortex instructions switch") {


### PR DESCRIPTION
## Summary

- make `TestGlobalPointerBody_ShapeAndSentinel` assert the OS-native path emitted by `filepath.Join`
- run the focused `internal/agents` test package in the existing native Windows CI job
- keep the broader Windows suite out of scope because it still pulls platform-specific parser/CGO test surfaces

## Why

The Windows job currently compiles production packages but does not execute platform-specific tests. That leaves regressions such as the Windows atomic-write sharing-violation coverage in `internal/agents/writer_windows_test.go` dependent on local/on-demand verification.

Running `go test ./internal/agents -count=1` on Windows exposed one portability false-failure before the Windows-only writer tests could be promoted to CI: `TestGlobalPointerBody_ShapeAndSentinel` hard-coded `/active.md`, while `GlobalPointerBody` intentionally emits the result of `filepath.Join` (`\active.md` on Windows).

This PR fixes that assertion and adds only the package-level test that now has a clean, bounded Windows responsibility.

## Verification

- fail-first on Windows: `go test ./internal/agents -count=1` failed at `TestGlobalPointerBody_ShapeAndSentinel` with the OS-native `@\home\user\.gortex\instructions\active.md` output
- `gofmt -w internal/agents/instructions_test.go`
- `git diff --check`
- the new `windows-latest` CI step is the authoritative post-fix Windows verification

## Scope

No production behavior changes. No attempt to enable `go test ./...` on Windows.