### PR TITLE
fix(windows): hide daemon background subprocesses

### DIFF
--- a/internal/cochange/cochange.go
+++ b/internal/cochange/cochange.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/platform"
 )
 
 // Tuning defaults for a history scan.
@@ -94,6 +95,7 @@ func Mine(ctx context.Context, root string, opts Options) Result {
 	// the file lists, grouped per commit by the NUL separator.
 	cmd := exec.CommandContext(ctx, "git", "-C", root, "log", "--no-merges", //nolint:gosec // root is daemon-internal
 		"-n", strconv.Itoa(opts.MaxCommits), "--name-only", "--format=%x00")
+	platform.ConfigureBackgroundCommand(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		return empty

--- a/internal/gitcmd/gitcmd.go
+++ b/internal/gitcmd/gitcmd.go
@@ -24,6 +24,7 @@ import (
 	"runtime"
 	"sync"
 
+	"github.com/zzet/gortex/internal/platform"
 	"golang.org/x/sync/semaphore"
 )
 
@@ -97,6 +98,7 @@ func Run(ctx context.Context, dir string, args ...string) ([]byte, error) {
 		full = append([]string{"-C", dir}, args...)
 	}
 	cmd := exec.CommandContext(ctx, "git", full...)
+	platform.ConfigureBackgroundCommand(cmd)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/internal/indexer/identity.go
+++ b/internal/indexer/identity.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/platform"
 )
 
 // RepoIdentity holds the canonical identity of a repository.
@@ -52,6 +53,7 @@ func DetectIdentity(repoPath string) (*RepoIdentity, error) {
 // gitRemoteOrigin runs `git -C <path> remote get-url origin` and returns the URL.
 func gitRemoteOrigin(repoPath string) (string, error) {
 	cmd := exec.Command("git", "-C", repoPath, "remote", "get-url", "origin")
+	platform.ConfigureBackgroundCommand(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		return "", err

--- a/internal/indexer/transform.go
+++ b/internal/indexer/transform.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/platform"
 )
 
 // defaultTransformTimeout bounds a transform subprocess when the rule
@@ -265,6 +266,7 @@ func (c *commandTransform) apply(_ string, src []byte) ([]byte, error) {
 	defer cancel()
 	// argv is operator-declared config, not user-derived input.
 	cmd := exec.CommandContext(ctx, c.argv[0], c.argv[1:]...) //nolint:gosec
+	platform.ConfigureBackgroundCommand(cmd)
 	cmd.Stdin = bytes.NewReader(src)
 	var out, errBuf bytes.Buffer
 	cmd.Stdout = &out

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -14,6 +14,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/zzet/gortex/internal/platform"
 )
 
 // Severity is the normalized severity of a diagnostic across linters.
@@ -155,6 +157,7 @@ func runOne(ctx context.Context, l Linter, absPath string, timeout time.Duration
 		args[i] = strings.ReplaceAll(a, "{file}", absPath)
 	}
 	cmd := exec.CommandContext(cctx, l.Bin, args...)
+	platform.ConfigureBackgroundCommand(cmd)
 	cmd.Dir = filepath.Dir(absPath) // so per-project linter config is discovered
 
 	var stdout, stderr bytes.Buffer

--- a/internal/llm/daemon_backend.go
+++ b/internal/llm/daemon_backend.go
@@ -10,6 +10,8 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+
+	"github.com/zzet/gortex/internal/platform"
 )
 
 // DaemonBackend speaks MCP over stdio to a long-running `gortex mcp`
@@ -41,6 +43,7 @@ func NewDaemonBackend(gortexBin string, extraEnv []string) (*DaemonBackend, erro
 		gortexBin = "gortex"
 	}
 	cmd := exec.Command(gortexBin, "mcp")
+	platform.ConfigureBackgroundCommand(cmd)
 	cmd.Env = append(os.Environ(), extraEnv...)
 
 	stdin, err := cmd.StdinPipe()

--- a/internal/llm/provider/agentcli/agentcli.go
+++ b/internal/llm/provider/agentcli/agentcli.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/zzet/gortex/internal/llm"
+	"github.com/zzet/gortex/internal/platform"
 )
 
 // DefaultTimeout caps one Complete call when the Spec leaves Timeout
@@ -152,6 +153,7 @@ func (p *Provider) Complete(ctx context.Context, req llm.CompletionRequest) (llm
 	}
 
 	cmd := exec.CommandContext(runCtx, p.spec.Binary, args...)
+	platform.ConfigureBackgroundCommand(cmd)
 	if stdin != nil {
 		cmd.Stdin = stdin
 	}

--- a/internal/llm/provider/claudecli/claudecli.go
+++ b/internal/llm/provider/claudecli/claudecli.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/zzet/gortex/internal/llm"
+	"github.com/zzet/gortex/internal/platform"
 )
 
 // defaultTimeout caps one Complete call when the user hasn't set
@@ -116,6 +117,7 @@ func (p *Provider) Complete(ctx context.Context, req llm.CompletionRequest) (llm
 	}
 
 	cmd := exec.CommandContext(runCtx, p.binary, args...)
+	platform.ConfigureBackgroundCommand(cmd)
 	cmd.Stdin = strings.NewReader(prompt)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/internal/llm/provider/codex/codex.go
+++ b/internal/llm/provider/codex/codex.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	"github.com/zzet/gortex/internal/llm"
+	"github.com/zzet/gortex/internal/platform"
 )
 
 // defaultTimeout caps one Complete call when the user hasn't set
@@ -134,6 +135,7 @@ func (p *Provider) Complete(ctx context.Context, req llm.CompletionRequest) (llm
 	}
 
 	cmd := exec.CommandContext(runCtx, p.binary, args...)
+	platform.ConfigureBackgroundCommand(cmd)
 	cmd.Stdin = strings.NewReader(prompt)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/internal/mcp/tools_analyze_history.go
+++ b/internal/mcp/tools_analyze_history.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/platform"
 )
 
 // fixSubjectRe matches a commit subject that describes a bug fix:
@@ -39,6 +40,7 @@ func mineFixCommits(ctx context.Context, root string, maxScan int) []fixCommit {
 	// line; --name-only appends the changed files below it.
 	cmd := exec.CommandContext(ctx, "git", "-C", root, "log", "--no-merges", //nolint:gosec // root is daemon-internal
 		"-n", strconv.Itoa(maxScan), "--name-only", "--format=%x00%s")
+	platform.ConfigureBackgroundCommand(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		return nil

--- a/internal/parser/crashpool/pool.go
+++ b/internal/parser/crashpool/pool.go
@@ -13,6 +13,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/zzet/gortex/internal/platform"
 	"github.com/zzet/gortex/internal/procio"
 )
 
@@ -106,6 +107,7 @@ func (p *Pool) Stats() (spawns, crashes int64) {
 func (p *Pool) spawn() (*procWorker, error) {
 	p.spawns.Add(1)
 	cmd := exec.Command(p.cfg.Argv[0], p.cfg.Argv[1:]...) //nolint:gosec // argv is internal, not user-derived
+	platform.ConfigureBackgroundCommand(cmd)
 	if len(p.cfg.Env) > 0 {
 		cmd.Env = append(os.Environ(), p.cfg.Env...)
 	}

--- a/internal/parser/languages/extractor_plugin.go
+++ b/internal/parser/languages/extractor_plugin.go
@@ -15,6 +15,7 @@ import (
 	"github.com/zzet/gortex/internal/config"
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/platform"
 )
 
 // defaultExtractorPluginTimeout bounds a plugin subprocess when the
@@ -126,6 +127,7 @@ func (e *SubprocessExtractor) Extract(filePath string, src []byte) (*parser.Extr
 
 	// command/args are operator-declared config, not user-derived input.
 	cmd := exec.CommandContext(ctx, e.command, e.args...) //nolint:gosec
+	platform.ConfigureBackgroundCommand(cmd)
 	cmd.Stdin = bytes.NewReader(src)
 	cmd.Env = append(os.Environ(), "GORTEX_FILE_PATH="+filePath)
 	var out, errBuf bytes.Buffer

--- a/internal/platform/background_command_unix.go
+++ b/internal/platform/background_command_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package platform
+
+import "os/exec"
+
+// ConfigureBackgroundCommand is a no-op on Unix. Daemon-owned subprocesses
+// inherit the daemon's detached session without allocating a separate window.
+func ConfigureBackgroundCommand(_ *exec.Cmd) {}

--- a/internal/platform/background_command_windows.go
+++ b/internal/platform/background_command_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package platform
+
+import (
+	"os/exec"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// ConfigureBackgroundCommand prevents a daemon-owned, non-interactive child
+// process from allocating or showing a console window. CREATE_NO_WINDOW is
+// incompatible with DETACHED_PROCESS and CREATE_NEW_CONSOLE, so remove those
+// flags while preserving any other caller-supplied process attributes.
+func ConfigureBackgroundCommand(cmd *exec.Cmd) {
+	if cmd == nil {
+		return
+	}
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.HideWindow = true
+	cmd.SysProcAttr.CreationFlags &^= windows.DETACHED_PROCESS | windows.CREATE_NEW_CONSOLE
+	cmd.SysProcAttr.CreationFlags |= windows.CREATE_NO_WINDOW
+}

--- a/internal/platform/background_command_windows_test.go
+++ b/internal/platform/background_command_windows_test.go
@@ -1,0 +1,59 @@
+//go:build windows
+
+package platform
+
+import (
+	"os/exec"
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestConfigureBackgroundCommandHidesWindowsConsole(t *testing.T) {
+	cmd := exec.Command("cmd.exe")
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: windows.CREATE_NEW_PROCESS_GROUP | windows.DETACHED_PROCESS | windows.CREATE_NEW_CONSOLE,
+	}
+
+	ConfigureBackgroundCommand(cmd)
+
+	if cmd.SysProcAttr == nil {
+		t.Fatal("ConfigureBackgroundCommand left SysProcAttr nil")
+	}
+	if !cmd.SysProcAttr.HideWindow {
+		t.Error("ConfigureBackgroundCommand left HideWindow disabled")
+	}
+	if cmd.SysProcAttr.CreationFlags&windows.CREATE_NO_WINDOW == 0 {
+		t.Error("ConfigureBackgroundCommand did not set CREATE_NO_WINDOW")
+	}
+	if cmd.SysProcAttr.CreationFlags&windows.CREATE_NEW_PROCESS_GROUP == 0 {
+		t.Error("ConfigureBackgroundCommand discarded existing creation flags")
+	}
+	if cmd.SysProcAttr.CreationFlags&windows.DETACHED_PROCESS != 0 {
+		t.Error("ConfigureBackgroundCommand must not combine CREATE_NO_WINDOW with DETACHED_PROCESS")
+	}
+	if cmd.SysProcAttr.CreationFlags&windows.CREATE_NEW_CONSOLE != 0 {
+		t.Error("ConfigureBackgroundCommand must not combine CREATE_NO_WINDOW with CREATE_NEW_CONSOLE")
+	}
+}
+
+func TestConfigureBackgroundCommandNilIsSafe(t *testing.T) {
+	ConfigureBackgroundCommand(nil)
+}
+
+func TestConfigureBackgroundCommandCreatesWindowsAttributes(t *testing.T) {
+	cmd := exec.Command("cmd.exe")
+
+	ConfigureBackgroundCommand(cmd)
+
+	if cmd.SysProcAttr == nil {
+		t.Fatal("ConfigureBackgroundCommand left SysProcAttr nil")
+	}
+	if !cmd.SysProcAttr.HideWindow {
+		t.Error("ConfigureBackgroundCommand left HideWindow disabled")
+	}
+	if cmd.SysProcAttr.CreationFlags != windows.CREATE_NO_WINDOW {
+		t.Errorf("CreationFlags = %#x, want CREATE_NO_WINDOW", cmd.SysProcAttr.CreationFlags)
+	}
+}

--- a/internal/semantic/lsp/client.go
+++ b/internal/semantic/lsp/client.go
@@ -16,6 +16,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/zzet/gortex/internal/platform"
 	"github.com/zzet/gortex/internal/procio"
 )
 
@@ -111,6 +112,7 @@ type SpawnTransport struct {
 // or crash backtrace can't flood the daemon's log with raw text.
 func (s *SpawnTransport) Start() (io.WriteCloser, io.Reader, error) {
 	cmd := exec.Command(s.Command, s.Args...)
+	platform.ConfigureBackgroundCommand(cmd)
 	cmd.Dir = s.WorkspaceRoot
 	if len(s.Env) > 0 {
 		cmd.Env = append(os.Environ(), s.Env...)

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/lspuri"
+	"github.com/zzet/gortex/internal/platform"
 	"github.com/zzet/gortex/internal/semantic"
 )
 
@@ -2100,6 +2101,7 @@ func (p *Provider) maybeCSharpPreRestore(workspaceRoot string) {
 	ctx, cancel := context.WithTimeout(context.Background(), csharpRestoreTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "dotnet", "restore", "-p:NuGetAudit=false")
+	platform.ConfigureBackgroundCommand(cmd)
 	cmd.Dir = workspaceRoot
 	cmd.Env = append(os.Environ(), p.env...)
 	if out, err := cmd.CombinedOutput(); err != nil {

--- a/internal/semantic/scip/provider.go
+++ b/internal/semantic/scip/provider.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/platform"
 	"github.com/zzet/gortex/internal/semantic"
 )
 
@@ -138,6 +139,7 @@ func (p *Provider) runIndexerContext(ctx context.Context, repoRoot string) (stri
 	args = append(args, "--output", outputPath)
 
 	cmd := exec.CommandContext(ctx, p.command, args...)
+	platform.ConfigureBackgroundCommand(cmd)
 	cmd.Dir = repoRoot
 	cmd.Env = append(os.Environ(), "SCIP_OUTPUT="+outputPath)
 


### PR DESCRIPTION
## Summary

Prevent daemon-owned, non-interactive subprocesses from allocating or showing a Windows console window.

Addresses #217. The issue should remain open until the reporter or maintainer confirms the visual flicker is gone on Windows Terminal.

## Root-cause hypothesis

The daemon bootstrap is detached on Windows, but later child processes were created with ordinary `exec.Command` / `exec.CommandContext`. A console child launched by a console-less daemon can allocate a visible console window. This matches the intermittent pop-up/focus symptom more closely than stderr routing alone.

## Changes

- add a build-tagged `platform.ConfigureBackgroundCommand` helper
- set `HideWindow` and `CREATE_NO_WINDOW` on Windows while preserving compatible caller flags
- keep Unix behavior unchanged with a no-op implementation
- apply the helper to the shared Git command path, spawned LSP servers, and parser crash workers
- cover the additional daemon subprocesses identified in review:
  - co-change and fix-history Git commands
  - repository identity detection
  - configured source transforms and extractor plugins
  - linters and SCIP indexers
  - C# pre-restore
  - Codex, Claude CLI, Copilot/Cursor/OpenCode providers, and the long-running MCP daemon backend
- add Windows-specific coverage for default, existing-attribute, incompatible-flag, and nil-command cases

Interactive CLI and evaluation subprocesses are intentionally unchanged.

## Verification

- `go test ./internal/platform -run '^TestConfigureBackgroundCommand' -count=1` (Windows) — PASS
- `go test ./internal/cochange ./internal/lint -count=1` (Windows) — PASS
- focused tests for all touched packages (Go 1.26 Linux/CGO container) — PASS
- `go vet` for all touched packages (Go 1.26 Linux/CGO container) — PASS
- `git diff --check` — PASS

GitHub Actions will rerun against the updated head.

## Manual QA

Automated tests can assert the Windows process attributes and build the native paths, but they cannot reliably observe terminal focus/flicker. Final closure of #217 should include a `gortex daemon start --detach` check in Windows Terminal that exercises repository reconciliation, Git history analysis, an LSP/SCIP spawn, and a configured external subprocess if available.