### PR TITLE
fix(mcp): preserve causal localization evidence

### DIFF
--- a/internal/agents/claudecode/adapter.go
+++ b/internal/agents/claudecode/adapter.go
@@ -487,7 +487,7 @@ func removeGlobalHooks(w io.Writer, settingsPath string, opts agents.ApplyOpts) 
 			return false, nil
 		}
 		removed := 0
-		for _, event := range []string{"PreToolUse", "PreCompact", "PostToolUse", "Stop", "SessionStart", "UserPromptSubmit"} {
+		for _, event := range []string{"PreToolUse", "PreCompact", "PostToolUse", "Stop", "SessionStart", "UserPromptSubmit", "SubagentStart", "SubagentStop"} {
 			removed += removeGortexHookEntries(hooks, event)
 		}
 		if removed == 0 {

--- a/internal/agents/claudecode/adapter_test.go
+++ b/internal/agents/claudecode/adapter_test.go
@@ -53,7 +53,7 @@ func TestInstallPermissionsMigratesWildcardButPreservesCustomPolicy(t *testing.T
 // a fresh project gets:
 //   - .mcp.json with our server stanza
 //   - .claude/settings.json with MCP permissions
-//   - .claude/settings.local.json with the three hook events
+//   - .claude/settings.local.json with the lifecycle and tool hook events
 //   - CLAUDE.md with the marker-guarded communities block (since
 //     the test env seeds SkillsRouting)
 //   - .claude/skills/generated/<DirName>/SKILL.md (one per

--- a/internal/agents/claudecode/hooks.go
+++ b/internal/agents/claudecode/hooks.go
@@ -20,9 +20,10 @@ import (
 // upgradeGortexMatcher rewrites those in place. Edit and Write are
 // included so the hook can redirect whole-file rewrites of indexed
 // source to the Gortex MCP edit tools (gated by GORTEX_HOOK_BLOCK_EDIT
-// in the hook itself). The compact mcp__gortex__read tool is included so the
-// hook can also enforce read shaping after the client has entered Gortex.
-const CurrentPreToolUseMatcher = "Read|Grep|Glob|Task|Bash|Edit|Write|mcp__gortex__read"
+// in the hook itself). The native "*" match-all sentinel lets a local,
+// constant-time terminal marker stop any tool after answer_ready without the
+// host evaluating a regular expression for every call.
+const CurrentPreToolUseMatcher = "*"
 
 // v060PreToolUseMatcher fingerprints the exact matcher shipped by gortex
 // v0.60.0. The concrete retirement gate is documented in docs/versioning.md.
@@ -172,7 +173,7 @@ func HookCommandPathIsEphemeral(cmd string) bool {
 // entries whose path is healthy are also left alone.
 func healStaleHookCommands(hooks map[string]any, newCommand string) int {
 	healed := 0
-	for _, event := range []string{"PreToolUse", "PreCompact", "Stop", "SessionStart", "UserPromptSubmit"} {
+	for _, event := range []string{"PreToolUse", "PreCompact", "Stop", "SessionStart", "UserPromptSubmit", "SubagentStart", "SubagentStop"} {
 		list, ok := hooks[event].([]any)
 		if !ok {
 			continue
@@ -180,6 +181,9 @@ func healStaleHookCommands(hooks map[string]any, newCommand string) int {
 		for _, h := range list {
 			hm, ok := h.(map[string]any)
 			if !ok {
+				continue
+			}
+			if (event == "PreToolUse" || event == "PostToolUse") && !managedGortexHookGroup(hm, event) {
 				continue
 			}
 			inner, ok := hm["hooks"].([]any)
@@ -224,6 +228,7 @@ func upgradeGortexMatcher(hooks map[string]any) bool {
 		return false
 	}
 	supersededMatchers := map[string]bool{
+		".*":                                  true,
 		"Read|Grep":                           true,
 		"Read|Grep|Glob":                      true,
 		"Read|Grep|Glob|Task":                 true,
@@ -235,6 +240,9 @@ func upgradeGortexMatcher(hooks map[string]any) bool {
 	for _, h := range pre {
 		hm, ok := h.(map[string]any)
 		if !ok {
+			continue
+		}
+		if !managedGortexHookGroup(hm, "PreToolUse") {
 			continue
 		}
 		matcher, _ := hm["matcher"].(string)
@@ -328,7 +336,7 @@ func commandInvokesGortexHook(cmd string) bool {
 // rewritten entries.
 func rewriteGortexHookMode(hooks map[string]any, newCommand string) int {
 	rewritten := 0
-	for _, event := range []string{"PreToolUse", "PostToolUse", "PreCompact", "Stop", "SessionStart", "UserPromptSubmit"} {
+	for _, event := range []string{"PreToolUse", "PostToolUse", "PreCompact", "Stop", "SessionStart", "UserPromptSubmit", "SubagentStart", "SubagentStop"} {
 		list, ok := hooks[event].([]any)
 		if !ok {
 			continue
@@ -336,6 +344,9 @@ func rewriteGortexHookMode(hooks map[string]any, newCommand string) int {
 		for _, h := range list {
 			hm, ok := h.(map[string]any)
 			if !ok {
+				continue
+			}
+			if (event == "PreToolUse" || event == "PostToolUse") && !managedGortexHookGroup(hm, event) {
 				continue
 			}
 			inner, ok := hm["hooks"].([]any)
@@ -381,6 +392,9 @@ func rewriteGortexPreToolUseStatus(hooks map[string]any, mode string) int {
 	for _, h := range list {
 		hm, ok := h.(map[string]any)
 		if !ok {
+			continue
+		}
+		if !managedGortexHookGroup(hm, "PreToolUse") {
 			continue
 		}
 		inner, ok := hm["hooks"].([]any)
@@ -472,7 +486,8 @@ func hasGortexHookEntry(hooks map[string]any, event string) bool {
 // match the current Gortex config" operation. It reads the file,
 // heals stale commands, upgrades old matchers, dedupes repeat
 // entries, then installs any missing Gortex hooks (PreToolUse,
-// PreCompact, Stop, SessionStart, and — in enrich mode — PostToolUse).
+// PreCompact, Stop, SessionStart, UserPromptSubmit, SubagentStart,
+// SubagentStop, and PostToolUse).
 // Writes back atomically via the shared helper.
 //
 // This function intentionally accepts a plain filesystem path
@@ -485,13 +500,11 @@ func InstallHook(w io.Writer, settingsPath string, opts agents.ApplyOpts) (agent
 	return InstallHookWithMode(w, settingsPath, HookModeDeny, opts)
 }
 
-// InstallHookWithMode is the mode-aware variant. mode is one of
-// HookModeDeny (default — install PreToolUse with deny behavior, no
-// PostToolUse) or HookModeEnrich (install PreToolUse in soft-context
-// mode plus a PostToolUse entry that augments tool output with graph
-// context). Switching modes between installs rewrites the existing
-// Gortex hook command in place and adds or removes the PostToolUse
-// entry to match.
+// InstallHookWithMode is the mode-aware variant. HookModeDeny installs the
+// blocking access posture; HookModeEnrich installs soft context. Both retain
+// the PostToolUse terminal observer, while enrich additionally observes native
+// read-shaped tools for graph augmentation. Switching modes rewrites only
+// installer-owned groups in place.
 func InstallHookWithMode(w io.Writer, settingsPath string, mode string, opts agents.ApplyOpts) (agents.FileAction, error) {
 	mode = normalizeHookMode(mode)
 	var settings map[string]any
@@ -517,33 +530,35 @@ func InstallHookWithMode(w io.Writer, settingsPath string, mode string, opts age
 
 	healedCount := healStaleHookCommands(hooks, hookCommand)
 	matcherUpgraded := upgradeGortexMatcher(hooks)
+	preToolMatcherRewriteCount := rewriteGortexEventMatcher(hooks, "PreToolUse", localizationPreToolUseMatcher)
 	modeRewriteCount := rewriteGortexHookMode(hooks, hookCommand)
 	statusRewriteCount := rewriteGortexPreToolUseStatus(hooks, mode)
-	dedupedCount := dedupGortexEntries(hooks, "PreToolUse") +
+	dedupedCount := dedupManagedGortexEntries(hooks, "PreToolUse") +
 		dedupGortexEntries(hooks, "PreCompact") +
-		dedupGortexEntries(hooks, "PostToolUse") +
+		dedupManagedGortexEntries(hooks, "PostToolUse") +
 		dedupGortexEntries(hooks, "Stop") +
 		dedupGortexEntries(hooks, "SessionStart") +
-		dedupGortexEntries(hooks, "UserPromptSubmit")
+		dedupGortexEntries(hooks, "UserPromptSubmit") +
+		dedupGortexEntries(hooks, "SubagentStart") +
+		dedupGortexEntries(hooks, "SubagentStop")
 
-	// PostToolUse is only present when mode=enrich. Removing it on a
-	// switch to any other posture keeps settings.json clean — agents
-	// won't fire a no-op hook on every Read/Grep response.
-	postToolUseRemoved := 0
-	if mode != HookModeEnrich {
-		postToolUseRemoved = removeGortexHookEntries(hooks, "PostToolUse")
-	}
+	// PostToolUse is always present for the terminal-contract observer. In
+	// enrich mode it additionally retains the native Read/Grep/Glob matchers.
+	postToolMatcherRewriteCount := rewriteGortexEventMatcher(hooks, "PostToolUse", desiredPostToolUseMatcher(mode))
+	postToolStatusRewriteCount := rewriteGortexPostToolUseStatus(hooks, mode)
 
-	preToolUseInstalled := hasGortexHookEntry(hooks, "PreToolUse")
+	preToolUseInstalled := hasManagedGortexHookEntry(hooks, "PreToolUse")
 	preCompactInstalled := hasGortexHookEntry(hooks, "PreCompact")
 	stopInstalled := hasGortexHookEntry(hooks, "Stop")
 	sessionStartInstalled := hasGortexHookEntry(hooks, "SessionStart")
 	userPromptSubmitInstalled := hasGortexHookEntry(hooks, "UserPromptSubmit")
-	postToolUseInstalled := hasGortexHookEntry(hooks, "PostToolUse")
+	subagentStartInstalled := hasGortexHookEntry(hooks, "SubagentStart")
+	subagentStopInstalled := hasGortexHookEntry(hooks, "SubagentStop")
+	postToolUseInstalled := hasManagedGortexHookEntry(hooks, "PostToolUse")
 
 	if !preToolUseInstalled {
 		appendHookEntry(hooks, "PreToolUse", map[string]any{
-			"matcher": CurrentPreToolUseMatcher,
+			"matcher": localizationPreToolUseMatcher,
 			"hooks": []any{
 				map[string]any{
 					"type":          "command",
@@ -610,20 +625,43 @@ func InstallHookWithMode(w io.Writer, settingsPath string, mode string, opts age
 			},
 		})
 	}
-	// PostToolUse is only installed in enrich mode. It augments
-	// Grep / Glob / Read responses with graph context (enclosing
-	// symbols, file footprints) so the agent sees the graph value
-	// adjacent to the raw output instead of via a deny redirect.
-	postToolUseAdded := false
-	if mode == HookModeEnrich && !postToolUseInstalled {
-		appendHookEntry(hooks, "PostToolUse", map[string]any{
-			"matcher": CurrentPostToolUseMatcher,
+	if !subagentStartInstalled {
+		appendHookEntry(hooks, "SubagentStart", map[string]any{
 			"hooks": []any{
 				map[string]any{
 					"type":          "command",
 					"command":       hookCommand,
 					"timeout":       3000,
-					"statusMessage": "Layering Gortex graph context onto tool output...",
+					"statusMessage": "Starting an isolated Gortex subagent turn...",
+				},
+			},
+		})
+	}
+	if !subagentStopInstalled {
+		appendHookEntry(hooks, "SubagentStop", map[string]any{
+			"hooks": []any{
+				map[string]any{
+					"type":          "command",
+					"command":       hookCommand,
+					"timeout":       3000,
+					"statusMessage": "Clearing Gortex subagent turn state...",
+				},
+			},
+		})
+	}
+	// PostToolUse always watches Gortex navigation results for the exact
+	// enforceable localization terminal contract. Enrich mode also augments
+	// native Grep / Glob / Read responses with graph context.
+	postToolUseAdded := false
+	if !postToolUseInstalled {
+		appendHookEntry(hooks, "PostToolUse", map[string]any{
+			"matcher": desiredPostToolUseMatcher(mode),
+			"hooks": []any{
+				map[string]any{
+					"type":          "command",
+					"command":       hookCommand,
+					"timeout":       3000,
+					"statusMessage": desiredPostToolUseStatus(mode),
 				},
 			},
 		})
@@ -631,9 +669,10 @@ func InstallHookWithMode(w io.Writer, settingsPath string, mode string, opts age
 	}
 
 	allPresent := preToolUseInstalled && preCompactInstalled && stopInstalled && sessionStartInstalled &&
-		userPromptSubmitInstalled && (mode != HookModeEnrich || postToolUseInstalled)
+		userPromptSubmitInstalled && subagentStartInstalled && subagentStopInstalled && postToolUseInstalled
 	noChanges := allPresent && !matcherUpgraded && dedupedCount == 0 && healedCount == 0 &&
-		modeRewriteCount == 0 && statusRewriteCount == 0 && postToolUseRemoved == 0 && !postToolUseAdded
+		modeRewriteCount == 0 && statusRewriteCount == 0 && preToolMatcherRewriteCount == 0 &&
+		postToolMatcherRewriteCount == 0 && postToolStatusRewriteCount == 0 && !postToolUseAdded
 	if noChanges {
 		if w != nil {
 			fmt.Fprintf(w, "[gortex init] all hooks already present in %s\n", settingsPath)
@@ -663,6 +702,15 @@ func InstallHookWithMode(w io.Writer, settingsPath string, mode string, opts age
 	if matcherUpgraded {
 		changes = append(changes, "upgraded PreToolUse matcher")
 	}
+	if preToolMatcherRewriteCount > 0 {
+		changes = append(changes, "enabled all-tool terminal gate")
+	}
+	if postToolMatcherRewriteCount > 0 {
+		changes = append(changes, "updated PostToolUse terminal observer")
+	}
+	if postToolStatusRewriteCount > 0 {
+		changes = append(changes, "updated PostToolUse status")
+	}
 	if dedupedCount > 0 {
 		changes = append(changes, fmt.Sprintf("removed %d duplicate entries", dedupedCount))
 	}
@@ -684,11 +732,14 @@ func InstallHookWithMode(w io.Writer, settingsPath string, mode string, opts age
 	if !userPromptSubmitInstalled {
 		changes = append(changes, "installed UserPromptSubmit")
 	}
-	if postToolUseAdded {
-		changes = append(changes, "installed PostToolUse (enrich mode)")
+	if !subagentStartInstalled {
+		changes = append(changes, "installed SubagentStart")
 	}
-	if postToolUseRemoved > 0 {
-		changes = append(changes, fmt.Sprintf("removed PostToolUse (switched to %s mode)", mode))
+	if !subagentStopInstalled {
+		changes = append(changes, "installed SubagentStop")
+	}
+	if postToolUseAdded {
+		changes = append(changes, "installed PostToolUse terminal observer")
 	}
 	if modeRewriteCount > 0 {
 		changes = append(changes, fmt.Sprintf("rewrote %d hook command(s) for mode=%s", modeRewriteCount, mode))

--- a/internal/agents/claudecode/hooks_status_test.go
+++ b/internal/agents/claudecode/hooks_status_test.go
@@ -21,7 +21,7 @@ func TestPreToolUseStatusMessageReflectsMode(t *testing.T) {
 	}
 }
 
-func TestRewriteGortexPreToolUseStatusPreservesCustomMessage(t *testing.T) {
+func TestRewriteGortexPreToolUseStatusPreservesMixedGroup(t *testing.T) {
 	generated := map[string]any{
 		"command":       "/opt/gortex hook --mode=enrich",
 		"statusMessage": preToolUseStatusEnrich,
@@ -34,14 +34,30 @@ func TestRewriteGortexPreToolUseStatusPreservesCustomMessage(t *testing.T) {
 		"PreToolUse": []any{map[string]any{"hooks": []any{generated, custom}}},
 	}
 
+	if got := rewriteGortexPreToolUseStatus(hooks, HookModeDeny); got != 0 {
+		t.Fatalf("rewritten count = %d, want 0 for mixed-ownership group", got)
+	}
+	if got := generated["statusMessage"]; got != preToolUseStatusEnrich {
+		t.Fatalf("generated message changed inside mixed group: %#v", got)
+	}
+	if got := custom["statusMessage"]; got != "custom user-set message" {
+		t.Fatalf("custom message changed: %#v", got)
+	}
+}
+
+func TestRewriteGortexPreToolUseStatusRewritesPureManagedGroup(t *testing.T) {
+	generated := map[string]any{
+		"command":       "/opt/gortex hook --mode=enrich",
+		"statusMessage": preToolUseStatusEnrich,
+	}
+	hooks := map[string]any{
+		"PreToolUse": []any{map[string]any{"hooks": []any{generated}}},
+	}
 	if got := rewriteGortexPreToolUseStatus(hooks, HookModeDeny); got != 1 {
 		t.Fatalf("rewritten count = %d, want 1", got)
 	}
 	if got := generated["statusMessage"]; got != preToolUseStatusDeny {
 		t.Fatalf("generated message = %#v, want %q", got, preToolUseStatusDeny)
-	}
-	if got := custom["statusMessage"]; got != "custom user-set message" {
-		t.Fatalf("custom message changed: %#v", got)
 	}
 }
 

--- a/internal/agents/claudecode/hooks_test.go
+++ b/internal/agents/claudecode/hooks_test.go
@@ -334,7 +334,7 @@ func TestRemoveGortexHookEntries_NoOpOnMissingEvent(t *testing.T) {
 // rewriteGortexHookMode — switches mode without touching user fields
 // ---------------------------------------------------------------------------
 
-func TestRewriteGortexHookMode_UpdatesCommandPreservingMeta(t *testing.T) {
+func TestRewriteGortexHookMode_PreservesCustomGortexGroup(t *testing.T) {
 	hooks := map[string]any{
 		"PreToolUse": []any{
 			map[string]any{
@@ -351,12 +351,12 @@ func TestRewriteGortexHookMode_UpdatesCommandPreservingMeta(t *testing.T) {
 		},
 	}
 	rewritten := rewriteGortexHookMode(hooks, "/opt/gortex hook --mode=enrich")
-	assert.Equal(t, 1, rewritten)
+	assert.Equal(t, 0, rewritten)
 	list := hooks["PreToolUse"].([]any)
 	em := list[0].(map[string]any)["hooks"].([]any)[0].(map[string]any)
-	assert.Equal(t, "/opt/gortex hook --mode=enrich", em["command"])
+	assert.Equal(t, "/opt/gortex hook", em["command"])
 	assert.Equal(t, "custom user-set message", em["statusMessage"],
-		"rewrite must preserve user-added fields like statusMessage")
+		"installer must not claim ownership of a custom Gortex hook group")
 }
 
 func TestRewriteGortexHookMode_NoOpOnIdenticalCommand(t *testing.T) {
@@ -382,19 +382,18 @@ func TestRewriteGortexHookMode_IgnoresNonGortexEntries(t *testing.T) {
 // nudge starts firing without the user touching settings.json.
 func TestUpgradeGortexMatcher_RewritesPreviousCurrent(t *testing.T) {
 	hooks := map[string]any{
-		"PreToolUse": []any{makeHookEntry("Read|Grep|Glob|Task|Bash|Edit|Write", "/opt/gortex hook")},
+		"PreToolUse": []any{managedTestHookEntry("Read|Grep|Glob|Task|Bash|Edit|Write", "/opt/gortex hook", preToolUseStatusDeny)},
 	}
 	assert.True(t, upgradeGortexMatcher(hooks), "previous-current matcher should upgrade")
 	got := hooks["PreToolUse"].([]any)[0].(map[string]any)["matcher"].(string)
 	assert.Equal(t, CurrentPreToolUseMatcher, got)
-	assert.Contains(t, got, "mcp__gortex__read",
-		"upgraded matcher must include the compact gortex read tool")
-	assert.NotContains(t, got, "mcp__gortex__read_file")
+	assert.Equal(t, "*", got,
+		"the terminal gate must observe every tool without enumerating host-specific names")
 }
 
 func TestUpgradeGortexMatcher_RewritesV060MCPReadMatcher(t *testing.T) {
 	hooks := map[string]any{
-		"PreToolUse": []any{makeHookEntry(v060PreToolUseMatcher, "/opt/gortex hook")},
+		"PreToolUse": []any{managedTestHookEntry(v060PreToolUseMatcher, "/opt/gortex hook", preToolUseStatusDeny)},
 	}
 	assert.True(t, upgradeGortexMatcher(hooks))
 	got := hooks["PreToolUse"].([]any)[0].(map[string]any)["matcher"].(string)
@@ -428,14 +427,18 @@ func TestInstallHookWithMode_DenyMode(t *testing.T) {
 	require.NoError(t, err)
 
 	hooks := readSettingsHooks(t, settingsPath)
-	assert.NotContains(t, hooks, "PostToolUse",
-		"deny mode must NOT install a PostToolUse entry")
+	require.Contains(t, hooks, "PostToolUse",
+		"terminal observation is independent of the source-access mode")
+	post := hooks["PostToolUse"].([]any)[0].(map[string]any)
+	assert.Equal(t, localizationPostToolUseMatcher, post["matcher"])
 	cmd := extractCmd(t, hooks, "PreToolUse", 0)
 	assert.Equal(t, "gortex hook", cmd,
 		"deny mode keeps the bare command — no --mode flag")
+	pre := hooks["PreToolUse"].([]any)[0].(map[string]any)
+	assert.Equal(t, localizationPreToolUseMatcher, pre["matcher"])
 }
 
-func TestInstallHook_InstallsUserPromptSubmit(t *testing.T) {
+func TestInstallHook_InstallsTurnLifecycleHooks(t *testing.T) {
 	dir := t.TempDir()
 	settingsPath := filepath.Join(dir, "settings.local.json")
 	t.Setenv("PATH", t.TempDir()) // force fallback to bare "gortex hook"
@@ -444,10 +447,10 @@ func TestInstallHook_InstallsUserPromptSubmit(t *testing.T) {
 	require.NoError(t, err)
 
 	hooks := readSettingsHooks(t, settingsPath)
-	require.Contains(t, hooks, "UserPromptSubmit",
-		"UserPromptSubmit hook must be installed for per-turn context injection")
-	cmd := extractCmd(t, hooks, "UserPromptSubmit", 0)
-	assert.Equal(t, "gortex hook", cmd)
+	for _, event := range []string{"UserPromptSubmit", "SubagentStart", "SubagentStop"} {
+		require.Contains(t, hooks, event, "%s hook must be installed for turn isolation", event)
+		assert.Equal(t, "gortex hook", extractCmd(t, hooks, event, 0))
+	}
 }
 
 func TestInstallHookWithMode_EnrichMode(t *testing.T) {
@@ -467,9 +470,10 @@ func TestInstallHookWithMode_EnrichMode(t *testing.T) {
 	assert.Equal(t, "gortex hook --mode=enrich", preCmd,
 		"PreToolUse must use the same --mode=enrich command so it falls back to soft-context")
 
-	// PostToolUse uses the matcher restricted to read-shaped tools.
+	// Enrich keeps the native read-shaped tools and adds the six terminal
+	// contract producers.
 	post := hooks["PostToolUse"].([]any)[0].(map[string]any)
-	assert.Equal(t, CurrentPostToolUseMatcher, post["matcher"])
+	assert.Equal(t, desiredPostToolUseMatcher(HookModeEnrich), post["matcher"])
 }
 
 func TestInstallHookWithMode_DenyToEnrichRoundTrip(t *testing.T) {
@@ -481,7 +485,9 @@ func TestInstallHookWithMode_DenyToEnrichRoundTrip(t *testing.T) {
 	_, err := InstallHookWithMode(io.Discard, settingsPath, HookModeDeny, agentsApplyOptsZero())
 	require.NoError(t, err)
 	hooks := readSettingsHooks(t, settingsPath)
-	require.NotContains(t, hooks, "PostToolUse")
+	require.Contains(t, hooks, "PostToolUse")
+	assert.Equal(t, localizationPostToolUseMatcher,
+		hooks["PostToolUse"].([]any)[0].(map[string]any)["matcher"])
 	assert.Equal(t, "gortex hook", extractCmd(t, hooks, "PreToolUse", 0))
 
 	// Switch to enrich.
@@ -493,13 +499,18 @@ func TestInstallHookWithMode_DenyToEnrichRoundTrip(t *testing.T) {
 		"PreToolUse command must be rewritten on mode switch")
 	assert.Equal(t, "gortex hook --mode=enrich", extractCmd(t, hooks, "PostToolUse", 0))
 
-	// Switch back to deny — PostToolUse must be removed, PreToolUse rewritten.
+	// Switch back to deny — terminal observation remains, while native
+	// post-read enrichment is removed and commands return to deny mode.
 	_, err = InstallHookWithMode(io.Discard, settingsPath, HookModeDeny, agentsApplyOptsZero())
 	require.NoError(t, err)
 	hooks = readSettingsHooks(t, settingsPath)
-	assert.NotContains(t, hooks, "PostToolUse", "switch back to deny must drop PostToolUse")
+	require.Contains(t, hooks, "PostToolUse")
+	assert.Equal(t, localizationPostToolUseMatcher,
+		hooks["PostToolUse"].([]any)[0].(map[string]any)["matcher"])
 	assert.Equal(t, "gortex hook", extractCmd(t, hooks, "PreToolUse", 0),
 		"switch back to deny must restore bare command on PreToolUse")
+	assert.Equal(t, "gortex hook", extractCmd(t, hooks, "PostToolUse", 0),
+		"switch back to deny must restore bare command on PostToolUse")
 }
 
 func TestInstallHookWithMode_EnrichIdempotent(t *testing.T) {
@@ -518,7 +529,8 @@ func TestInstallHookWithMode_EnrichIdempotent(t *testing.T) {
 	assert.Len(t, post, 1, "repeated install must not duplicate the PostToolUse entry")
 }
 
-// InstallHook (the back-compat wrapper) must default to deny mode.
+// InstallHook (the back-compat wrapper) defaults to deny mode while retaining
+// the mode-independent terminal observer.
 func TestInstallHook_DefaultsToDeny(t *testing.T) {
 	dir := t.TempDir()
 	settingsPath := filepath.Join(dir, "settings.local.json")
@@ -527,6 +539,7 @@ func TestInstallHook_DefaultsToDeny(t *testing.T) {
 	_, err := InstallHook(io.Discard, settingsPath, agentsApplyOptsZero())
 	require.NoError(t, err)
 	hooks := readSettingsHooks(t, settingsPath)
-	assert.NotContains(t, hooks, "PostToolUse",
-		"InstallHook (no mode) must behave as deny — no PostToolUse entry")
+	require.Contains(t, hooks, "PostToolUse")
+	post := hooks["PostToolUse"].([]any)[0].(map[string]any)
+	assert.Equal(t, localizationPostToolUseMatcher, post["matcher"])
 }

--- a/internal/agents/claudecode/localization_terminal_hooks.go
+++ b/internal/agents/claudecode/localization_terminal_hooks.go
@@ -1,0 +1,265 @@
+package claudecode
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const (
+	// Claude Code treats "*" as its native match-all sentinel. Using it keeps
+	// the terminal gate host-wide without paying regex matching cost for ".*".
+	localizationPreToolUseMatcher  = "*"
+	localizationPostToolUseMatcher = "mcp__gortex__explore|mcp__gortex__search|mcp__gortex__read|" +
+		"mcp__gortex__relations|mcp__gortex__trace|mcp__gortex__analyze|" +
+		"mcp__plugin_gortex_gortex__explore|mcp__plugin_gortex_gortex__search|mcp__plugin_gortex_gortex__read|" +
+		"mcp__plugin_gortex_gortex__relations|mcp__plugin_gortex_gortex__trace|mcp__plugin_gortex_gortex__analyze"
+)
+
+func desiredPostToolUseMatcher(mode string) string {
+	if mode != HookModeEnrich {
+		return localizationPostToolUseMatcher
+	}
+	return joinHookMatchers(CurrentPostToolUseMatcher, localizationPostToolUseMatcher)
+}
+
+func desiredPostToolUseStatus(mode string) string {
+	if mode == HookModeEnrich {
+		return "Layering Gortex graph context and watching localization completion..."
+	}
+	return "Watching for Gortex localization completion..."
+}
+
+func joinHookMatchers(matchers ...string) string {
+	seen := make(map[string]struct{}, len(matchers))
+	parts := make([]string, 0, len(matchers))
+	for _, matcher := range matchers {
+		for _, part := range strings.Split(matcher, "|") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			if _, ok := seen[part]; ok {
+				continue
+			}
+			seen[part] = struct{}{}
+			parts = append(parts, part)
+		}
+	}
+	return strings.Join(parts, "|")
+}
+
+func rewriteGortexEventMatcher(hooks map[string]any, event, matcher string) int {
+	groups, ok := hooks[event].([]any)
+	if !ok {
+		return 0
+	}
+	changed := 0
+	for _, rawGroup := range groups {
+		group, ok := rawGroup.(map[string]any)
+		if !ok || !managedGortexHookGroup(group, event) {
+			continue
+		}
+		if current, _ := group["matcher"].(string); current == matcher {
+			continue
+		}
+		group["matcher"] = matcher
+		changed++
+	}
+	return changed
+}
+
+func rewriteGortexPostToolUseStatus(hooks map[string]any, mode string) int {
+	groups, ok := hooks["PostToolUse"].([]any)
+	if !ok {
+		return 0
+	}
+	desired := desiredPostToolUseStatus(mode)
+	changed := 0
+	for _, rawGroup := range groups {
+		group, ok := rawGroup.(map[string]any)
+		if !ok || !managedGortexHookGroup(group, "PostToolUse") {
+			continue
+		}
+		entries, _ := group["hooks"].([]any)
+		for _, rawEntry := range entries {
+			entry, ok := rawEntry.(map[string]any)
+			if !ok {
+				continue
+			}
+			if current, _ := entry["statusMessage"].(string); current == desired {
+				continue
+			}
+			entry["statusMessage"] = desired
+			changed++
+		}
+	}
+	return changed
+}
+
+func managedGortexHookGroup(group map[string]any, event string) bool {
+	entries, ok := group["hooks"].([]any)
+	if !ok || len(entries) == 0 {
+		return false
+	}
+	for _, rawEntry := range entries {
+		entry, ok := rawEntry.(map[string]any)
+		if !ok || !managedGortexHookHandler(entry, event) {
+			return false
+		}
+	}
+	return true
+}
+
+// managedGortexHookHandler identifies ownership on one handler, never by
+// pairing a Gortex command from one handler with a generated status message
+// from another. A group is mutable only when every handler is managed.
+func managedGortexHookHandler(entry map[string]any, event string) bool {
+	command, _ := entry["command"].(string)
+	if !handlerInvokesGortex(command) {
+		return false
+	}
+	status, _ := entry["statusMessage"].(string)
+	return managedGortexHookStatus(event, status)
+}
+
+func managedGortexHookStatus(event, status string) bool {
+	switch event {
+	case "PreToolUse":
+		return status == preToolUseStatusDeny ||
+			status == preToolUseStatusEnrich ||
+			status == preToolUseStatusConsultUnlock ||
+			status == preToolUseStatusNudge
+	case "PostToolUse":
+		return status == "Layering Gortex graph context onto tool output..." ||
+			status == desiredPostToolUseStatus(HookModeDeny) ||
+			status == desiredPostToolUseStatus(HookModeEnrich)
+	default:
+		return false
+	}
+}
+
+func hasManagedGortexHookEntry(hooks map[string]any, event string) bool {
+	groups, ok := hooks[event].([]any)
+	if !ok {
+		return false
+	}
+	for _, rawGroup := range groups {
+		group, ok := rawGroup.(map[string]any)
+		if ok && managedGortexHookGroup(group, event) {
+			return true
+		}
+	}
+	return false
+}
+
+func dedupManagedGortexEntries(hooks map[string]any, event string) int {
+	groups, ok := hooks[event].([]any)
+	if !ok {
+		return 0
+	}
+	seen := false
+	removed := 0
+	kept := make([]any, 0, len(groups))
+	for _, rawGroup := range groups {
+		group, ok := rawGroup.(map[string]any)
+		if !ok || !managedGortexHookGroup(group, event) {
+			kept = append(kept, rawGroup)
+			continue
+		}
+		if seen {
+			removed++
+			continue
+		}
+		seen = true
+		kept = append(kept, rawGroup)
+	}
+	if removed > 0 {
+		hooks[event] = kept
+	}
+	return removed
+}
+
+func hookGroupInvokesGortex(group map[string]any) bool {
+	entries, ok := group["hooks"].([]any)
+	if !ok {
+		return false
+	}
+	for _, rawEntry := range entries {
+		entry, ok := rawEntry.(map[string]any)
+		if !ok {
+			continue
+		}
+		command, _ := entry["command"].(string)
+		if handlerInvokesGortex(command) {
+			return true
+		}
+	}
+	return false
+}
+
+func handlerInvokesGortex(command string) bool {
+	return commandInvokesGortexHook(command) || strings.Contains(command, "gortex-hook")
+}
+
+func pluginHooksWithLocalizationTerminality(data []byte) ([]byte, error) {
+	var root map[string]any
+	if err := json.Unmarshal(data, &root); err != nil {
+		return nil, fmt.Errorf("parse generated plugin hooks: %w", err)
+	}
+	hooks, ok := root["hooks"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("generated plugin hooks: hooks object is missing")
+	}
+
+	preGroups, ok := hooks["PreToolUse"].([]any)
+	if !ok {
+		return nil, fmt.Errorf("generated plugin hooks: PreToolUse is missing")
+	}
+	var prototype map[string]any
+	for _, rawGroup := range preGroups {
+		group, ok := rawGroup.(map[string]any)
+		if !ok || !hookGroupInvokesGortex(group) {
+			continue
+		}
+		group["matcher"] = localizationPreToolUseMatcher
+		if prototype == nil {
+			prototype = group
+		}
+	}
+	if prototype == nil {
+		return nil, fmt.Errorf("generated plugin hooks: Gortex PreToolUse entry is missing")
+	}
+
+	postGroups, _ := hooks["PostToolUse"].([]any)
+	postFound := false
+	for _, rawGroup := range postGroups {
+		group, ok := rawGroup.(map[string]any)
+		if !ok || !hookGroupInvokesGortex(group) {
+			continue
+		}
+		current, _ := group["matcher"].(string)
+		group["matcher"] = joinHookMatchers(current, localizationPostToolUseMatcher)
+		postFound = true
+	}
+	if !postFound {
+		encoded, err := json.Marshal(prototype)
+		if err != nil {
+			return nil, err
+		}
+		var group map[string]any
+		if err := json.Unmarshal(encoded, &group); err != nil {
+			return nil, err
+		}
+		group["matcher"] = localizationPostToolUseMatcher
+		for _, rawEntry := range group["hooks"].([]any) {
+			if entry, ok := rawEntry.(map[string]any); ok {
+				entry["statusMessage"] = desiredPostToolUseStatus(HookModeDeny)
+			}
+		}
+		postGroups = append(postGroups, group)
+		hooks["PostToolUse"] = postGroups
+	}
+
+	return json.MarshalIndent(root, "", "  ")
+}

--- a/internal/agents/claudecode/localization_terminal_hooks_test.go
+++ b/internal/agents/claudecode/localization_terminal_hooks_test.go
@@ -1,0 +1,140 @@
+package claudecode
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRewriteGortexEventMatcherPreservesUserHook(t *testing.T) {
+	hooks := map[string]any{
+		"PreToolUse": []any{
+			managedTestHookEntry("Read", "gortex hook", preToolUseStatusDeny),
+			makeHookEntry("Bash", "/usr/bin/user-hook"),
+		},
+	}
+	assert.Equal(t, 1, rewriteGortexEventMatcher(hooks, "PreToolUse", localizationPreToolUseMatcher))
+	groups := hooks["PreToolUse"].([]any)
+	assert.Equal(t, localizationPreToolUseMatcher, groups[0].(map[string]any)["matcher"])
+	assert.Equal(t, "Bash", groups[1].(map[string]any)["matcher"],
+		"terminal matcher healing must not rewrite user hooks")
+}
+
+func TestInstallHookWithModeHealsTerminalMatchersAndPreservesUserHooks(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.local.json")
+	t.Setenv("PATH", t.TempDir())
+	settings := map[string]any{
+		"hooks": map[string]any{
+			"PreToolUse": []any{
+				managedTestHookEntry("Read|Grep", "gortex hook", preToolUseStatusDeny),
+				managedTestHookEntry("Read|Grep", "gortex hook", "my custom Gortex pre hook"),
+				makeHookEntry("Bash", "/usr/bin/user-pre-hook"),
+			},
+			"PostToolUse": []any{
+				managedTestHookEntry("Read|Grep|Glob", "gortex hook --mode=enrich", "Layering Gortex graph context onto tool output..."),
+				managedTestHookEntry("CustomTool", "gortex hook", "my custom Gortex post hook"),
+				makeHookEntry("Write", "/usr/bin/user-post-hook"),
+			},
+		},
+	}
+	data, err := json.Marshal(settings)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(settingsPath, data, 0o644))
+
+	_, err = InstallHookWithMode(io.Discard, settingsPath, HookModeDeny, agentsApplyOptsZero())
+	require.NoError(t, err)
+	hooks := readSettingsHooks(t, settingsPath)
+	pre := hooks["PreToolUse"].([]any)
+	post := hooks["PostToolUse"].([]any)
+	require.Len(t, pre, 3)
+	require.Len(t, post, 3)
+	assert.Equal(t, localizationPreToolUseMatcher, pre[0].(map[string]any)["matcher"])
+	assert.Equal(t, "Read|Grep", pre[1].(map[string]any)["matcher"])
+	assert.Equal(t, "my custom Gortex pre hook", hookStatus(t, pre[1]))
+	assert.Equal(t, "Bash", pre[2].(map[string]any)["matcher"])
+	assert.Equal(t, localizationPostToolUseMatcher, post[0].(map[string]any)["matcher"])
+	assert.Equal(t, "CustomTool", post[1].(map[string]any)["matcher"])
+	assert.Equal(t, "my custom Gortex post hook", hookStatus(t, post[1]))
+	assert.Equal(t, "Write", post[2].(map[string]any)["matcher"])
+	assert.Equal(t, "/usr/bin/user-pre-hook", extractCmd(t, hooks, "PreToolUse", 2))
+	assert.Equal(t, "/usr/bin/user-post-hook", extractCmd(t, hooks, "PostToolUse", 2))
+}
+
+func managedTestHookEntry(matcher, command, status string) map[string]any {
+	entry := makeHookEntry(matcher, command)
+	hook := entry["hooks"].([]any)[0].(map[string]any)
+	hook["statusMessage"] = status
+	return entry
+}
+
+func hookStatus(t *testing.T, rawGroup any) string {
+	t.Helper()
+	group := rawGroup.(map[string]any)
+	entry := group["hooks"].([]any)[0].(map[string]any)
+	status, _ := entry["statusMessage"].(string)
+	return status
+}
+
+func TestDesiredPostToolUseMatcherIsModeSpecific(t *testing.T) {
+	assert.Equal(t, localizationPostToolUseMatcher, desiredPostToolUseMatcher(HookModeDeny))
+	enrich := desiredPostToolUseMatcher(HookModeEnrich)
+	assert.Contains(t, enrich, CurrentPostToolUseMatcher)
+	for _, tool := range []string{"explore", "search", "read", "relations", "trace", "analyze"} {
+		assert.Contains(t, enrich, "mcp__gortex__"+tool)
+		assert.Contains(t, enrich, "mcp__plugin_gortex_gortex__"+tool)
+	}
+}
+
+func TestManagedGortexHookGroupRequiresHandlerLocalPureOwnership(t *testing.T) {
+	crossPaired := map[string]any{
+		"matcher": "Read|Grep",
+		"hooks": []any{
+			map[string]any{"type": "command", "command": "gortex hook", "statusMessage": "custom"},
+			map[string]any{"type": "command", "command": "/usr/bin/user-hook", "statusMessage": preToolUseStatusDeny},
+		},
+	}
+	if managedGortexHookGroup(crossPaired, "PreToolUse") {
+		t.Fatal("command and managed status from different handlers must not establish ownership")
+	}
+
+	mixed := map[string]any{
+		"matcher": "Read|Grep",
+		"hooks": []any{
+			map[string]any{"type": "command", "command": "gortex hook", "statusMessage": preToolUseStatusDeny},
+			map[string]any{"type": "command", "command": "/usr/bin/user-hook", "statusMessage": "custom"},
+		},
+	}
+	if managedGortexHookGroup(mixed, "PreToolUse") {
+		t.Fatal("a mixed managed/user group must be preserved as user-owned")
+	}
+	hooks := map[string]any{"PreToolUse": []any{crossPaired, mixed}}
+	if got := rewriteGortexEventMatcher(hooks, "PreToolUse", localizationPreToolUseMatcher); got != 0 {
+		t.Fatalf("rewrote %d mixed/cross-paired groups", got)
+	}
+}
+
+func TestDedupManagedGortexEntriesOnlyRemovesPureDuplicates(t *testing.T) {
+	pureOne := managedTestHookEntry("Read", "gortex hook", preToolUseStatusDeny)
+	pureTwo := managedTestHookEntry("Read|Grep", "gortex hook", preToolUseStatusEnrich)
+	mixed := map[string]any{
+		"matcher": "CustomTool",
+		"hooks": []any{
+			map[string]any{"type": "command", "command": "gortex hook", "statusMessage": preToolUseStatusDeny},
+			map[string]any{"type": "command", "command": "/usr/bin/user-hook", "statusMessage": "custom"},
+		},
+	}
+	hooks := map[string]any{"PreToolUse": []any{pureOne, mixed, pureTwo}}
+	if got := dedupManagedGortexEntries(hooks, "PreToolUse"); got != 1 {
+		t.Fatalf("removed = %d, want 1 pure duplicate", got)
+	}
+	groups := hooks["PreToolUse"].([]any)
+	require.Len(t, groups, 2)
+	assert.Equal(t, pureOne, groups[0])
+	assert.Equal(t, mixed, groups[1], "mixed group must survive dedup")
+}

--- a/internal/agents/claudecode/plugin.go
+++ b/internal/agents/claudecode/plugin.go
@@ -69,8 +69,9 @@ const pluginMCPJSON = `{
 `
 
 // pluginHooksJSON is the hooks/hooks.json content for the
-// marketplace plugin. Four event bindings (PreToolUse, PreCompact,
-// Stop, SessionStart) all dispatch through ${CLAUDE_PLUGIN_ROOT}/hooks-handlers/gortex-hook.sh
+// marketplace plugin. Seven event bindings (PreToolUse, UserPromptSubmit,
+// SubagentStart, SubagentStop, PreCompact, Stop, SessionStart) all dispatch
+// through ${CLAUDE_PLUGIN_ROOT}/hooks-handlers/gortex-hook.sh
 // — a thin wrapper that locates the gortex binary and invokes
 // `gortex hook`. The wrapper's job is:
 //
@@ -84,7 +85,7 @@ const pluginMCPJSON = `{
 // The %s is filled with CurrentPreToolUseMatcher at emit time so the
 // marketplace plugin and the `gortex init` settings.json never drift.
 const pluginHooksJSON = `{
-  "description": "Gortex graph-aware hooks: PreToolUse routing, PreCompact orientation, post-task diagnostics, SessionStart cold briefing.",
+  "description": "Gortex graph-aware hooks: parent and subagent turn state, PreToolUse routing, PreCompact orientation, post-task diagnostics, SessionStart cold briefing.",
   "hooks": {
     "PreToolUse": [
       {
@@ -95,6 +96,42 @@ const pluginHooksJSON = `{
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks-handlers/gortex-hook.sh\"",
             "timeout": 3000,
             "statusMessage": "Enforcing Gortex graph access policy..."
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks-handlers/gortex-hook.sh\"",
+            "timeout": 3000,
+            "statusMessage": "Starting a fresh Gortex turn..."
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks-handlers/gortex-hook.sh\"",
+            "timeout": 3000,
+            "statusMessage": "Starting an isolated Gortex subagent turn..."
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks-handlers/gortex-hook.sh\"",
+            "timeout": 3000,
+            "statusMessage": "Clearing Gortex subagent turn state..."
           }
         ]
       }
@@ -189,7 +226,7 @@ installs to ` + "`~/.local/bin`" + ` (or ` + "`/usr/local/bin`" + `), and runs `
 | **MCP server** | 21 tools over stdio via ` + "`gortex mcp`" + `: begin with ` + "`explore`" + `, inspect with ` + "`search`" + ` / ` + "`read`" + ` / ` + "`relations`" + ` / ` + "`trace`" + `, assess with ` + "`analyze`" + ` / ` + "`change`" + ` / ` + "`review`" + `, and mutate with ` + "`edit`" + ` / ` + "`refactor`" + `. ` + "`capabilities`" + ` returns an operation's exact schema on demand. |
 | **Slash commands** | Discovery: ` + "`/gortex-guide`" + `, ` + "`/gortex-explore`" + `, ` + "`/gortex-debug`" + `, ` + "`/gortex-impact`" + `, ` + "`/gortex-dataflow-trace`" + `, ` + "`/gortex-cross-repo-usage`" + `, ` + "`/gortex-co-change`" + `, ` + "`/gortex-onboarding`" + ` · Edit & refactor: ` + "`/gortex-refactor`" + `, ` + "`/gortex-safe-edit`" + `, ` + "`/gortex-rename`" + `, ` + "`/gortex-extract-function`" + `, ` + "`/gortex-fix-all`" + `, ` + "`/gortex-add-test`" + ` · Review & operate: ` + "`/gortex-pr-review`" + `, ` + "`/gortex-pr-review-agent`" + `, ` + "`/gortex-architecture-review`" + `, ` + "`/gortex-quality-audit`" + `, ` + "`/gortex-incident-investigation`" + `, ` + "`/gortex-episode-replay`" + ` |
 | **Skills** | Twenty model-invoked, task-shaped workflows require callable native MCP, start with ` + "`explore`" + `, gate mutations with ` + "`change`" + `, write through ` + "`edit`" + ` / ` + "`refactor`" + `, and verify the result. The separate CLI skill mirrors those names through ` + "`gortex call`" + ` only for a harness with no MCP transport by design. |
-| **Hooks** | PreToolUse graph routing, PreCompact orientation, Stop post-task diagnostics, and SessionStart briefing. Hook guidance uses the same public MCP tool names. |
+| **Hooks** | UserPromptSubmit parent-turn isolation, SubagentStart/SubagentStop agent isolation, PreToolUse graph routing, PreCompact orientation, Stop post-task diagnostics, and SessionStart briefing. Hook guidance uses the same public MCP tool names. |
 
 ## First run
 
@@ -325,7 +362,11 @@ func EmitPluginBundle(spec PluginBundleSpec) ([]string, error) {
 	}
 
 	// 8. hooks/hooks.json + hooks-handlers/gortex-hook.sh
-	if err := write("hooks/hooks.json", fmt.Appendf(nil, pluginHooksJSON, CurrentPreToolUseMatcher), 0o644); err != nil {
+	pluginHooks, err := pluginHooksWithLocalizationTerminality(fmt.Appendf(nil, pluginHooksJSON, CurrentPreToolUseMatcher))
+	if err != nil {
+		return nil, err
+	}
+	if err := write("hooks/hooks.json", pluginHooks, 0o644); err != nil {
 		return nil, err
 	}
 	if err := write("hooks-handlers/gortex-hook.sh", []byte(pluginHookHandler), 0o755); err != nil {

--- a/internal/agents/claudecode/plugin_test.go
+++ b/internal/agents/claudecode/plugin_test.go
@@ -175,9 +175,9 @@ func TestEmitPluginBundle_HooksShape(t *testing.T) {
 		t.Fatalf("hooks.json: missing top-level 'hooks' object: %v", doc)
 	}
 
-	// All four event kinds must be present; each must reference the
+	// All seven lifecycle/tool event kinds must be present; each must reference the
 	// hooks-handlers script via ${CLAUDE_PLUGIN_ROOT}.
-	for _, event := range []string{"PreToolUse", "PreCompact", "Stop", "SessionStart"} {
+	for _, event := range []string{"PreToolUse", "UserPromptSubmit", "SubagentStart", "SubagentStop", "PreCompact", "Stop", "SessionStart"} {
 		entries, ok := hooks[event].([]any)
 		if !ok || len(entries) == 0 {
 			t.Errorf("hooks.json: event %s missing or empty", event)
@@ -204,6 +204,13 @@ func TestEmitPluginBundle_HooksShape(t *testing.T) {
 	matcher, _ := pre[0].(map[string]any)["matcher"].(string)
 	if matcher != CurrentPreToolUseMatcher {
 		t.Errorf("hooks.json: PreToolUse matcher = %q, want %q", matcher, CurrentPreToolUseMatcher)
+	}
+	post := hooks["PostToolUse"].([]any)
+	postMatcher, _ := post[0].(map[string]any)["matcher"].(string)
+	for _, want := range []string{"mcp__gortex__explore", "mcp__plugin_gortex_gortex__explore"} {
+		if !strings.Contains(postMatcher, want) {
+			t.Errorf("hooks.json: PostToolUse matcher %q missing %q", postMatcher, want)
+		}
 	}
 }
 

--- a/internal/graph/store.go
+++ b/internal/graph/store.go
@@ -154,10 +154,11 @@ type Store interface {
 
 	// GetNodesByQualNames returns a map qualName→*Node (first match per
 	// qual_name) for the whole batch — the qual-name twin of
-	// FindNodesByNames. It pre-warms the resolver's import resolution:
-	// qual_name is unindexed on the disk backend, so the per-edge
-	// GetNodeByQualName in resolveImport is a full node scan per import
-	// edge; one batched IN-scan collapses that to a single query.
+	// FindNodesByNames. It pre-warms the resolver's import resolution so
+	// per-edge point lookups become one batched probe; both the batch and
+	// the point lookup ride the partial nodes_by_qual index (their SQL
+	// restates the index predicate literally, which is what makes a
+	// partial index usable against bound parameters).
 	GetNodesByQualNames(qualNames []string) map[string]*Node
 
 	// --- Name + scope queries --------------------------------------

--- a/internal/graph/store_sqlite/bulk_load.go
+++ b/internal/graph/store_sqlite/bulk_load.go
@@ -130,6 +130,14 @@ var bulkDroppableIndexes = []bulkDroppableIndex{
 	// sort the full edge corpus; the partial index preserves rowid ordering while
 	// shrinking rebuild and steady-state maintenance to the pending frontier.
 	{"edges_by_unresolved", `CREATE INDEX IF NOT EXISTS edges_by_unresolved ON edges(is_unresolved) WHERE is_unresolved = 1`},
+	// The repo-prefixed fn-value placeholder namespace is read once per
+	// framework-synthesis pass through a leading-wildcard LIKE that no
+	// general index can serve — without this partial index the reader
+	// walked every unresolved edge. The reader states the predicate
+	// verbatim as its only WHERE clause (the OR-arm implication prover
+	// will not bind it otherwise). Near-empty at rest; populated only
+	// mid-pass while placeholders await the fn-value gate.
+	{"edges_fnvalue_prefixed", `CREATE INDEX IF NOT EXISTS edges_fnvalue_prefixed ON edges(to_id) WHERE to_id LIKE '%::unresolved::fnvalue::%'`},
 	// Canonical Go receiver types remain indexed for the SQLite-native repair.
 	// The edge side reuses edges_by_kind for its one global cold pass; scoped
 	// warm/partial passes continue to seek member_of edges through edges_by_from.

--- a/internal/graph/store_sqlite/derived_contract_replace.go
+++ b/internal/graph/store_sqlite/derived_contract_replace.go
@@ -49,16 +49,7 @@ func (s *Store) ReplaceDerivedContracts(replacement graph.DerivedContractReplace
 			values.WriteString("(?,?,?,?,?)")
 			args = append(args, edge.From, edge.To, string(edge.Kind), edge.FilePath, edge.Line)
 		}
-		removed, execErr := tx.Exec(`WITH wanted(from_id, to_id, kind, file_path, line) AS (VALUES `+values.String()+`)
-DELETE FROM edges
-WHERE EXISTS (
-    SELECT 1 FROM wanted AS w
-    WHERE w.from_id = edges.from_id
-      AND w.to_id = edges.to_id
-      AND w.kind = edges.kind
-      AND w.file_path = edges.file_path
-      AND w.line = edges.line
-)`, args...)
+		removed, execErr := tx.Exec(edgeExactDeleteByIdentitySQL(values.String()), args...)
 		if execErr != nil {
 			return graph.DerivedContractReplaceResult{}, execErr
 		}

--- a/internal/graph/store_sqlite/edge_remove_batch.go
+++ b/internal/graph/store_sqlite/edge_remove_batch.go
@@ -6,6 +6,26 @@ import (
 	"github.com/zzet/gortex/internal/graph"
 )
 
+// edgeExactDeleteByIdentitySQL deletes edges matching a VALUES list of
+// full identities. The IN-over-JOIN shape is load-bearing: a correlated
+// WHERE EXISTS against a constant VALUES table cannot be inverted by the
+// planner and scans the whole edges table per chunk; driving the join
+// from the VALUES side probes the edges primary key per identity.
+func edgeExactDeleteByIdentitySQL(values string) string {
+	return `WITH wanted(from_id, to_id, kind, file_path, line) AS (VALUES ` + values + `)
+DELETE FROM edges
+WHERE id IN (
+    SELECT e.id
+    FROM edges AS e
+    JOIN wanted AS w
+      ON e.from_id = w.from_id
+     AND e.to_id = w.to_id
+     AND e.kind = w.kind
+     AND e.file_path = w.file_path
+     AND e.line = w.line
+)`
+}
+
 const exactEdgeRemoveChunkSize = 160 // 160 * 5 = 800 bound parameters.
 
 // RemoveEdgesExact deletes complete logical edge identities through bounded
@@ -66,16 +86,7 @@ func (s *Store) RemoveEdgesExact(edges []*graph.Edge) int {
 			values.WriteString("(?,?,?,?,?)")
 			args = append(args, k.from, k.to, k.kind, k.file, k.line)
 		}
-		result, execErr := tx.Exec(`WITH wanted(from_id, to_id, kind, file_path, line) AS (VALUES `+values.String()+`)
-DELETE FROM edges
-WHERE EXISTS (
-    SELECT 1 FROM wanted AS w
-    WHERE w.from_id = edges.from_id
-      AND w.to_id = edges.to_id
-      AND w.kind = edges.kind
-      AND w.file_path = edges.file_path
-      AND w.line = edges.line
-)`, args...)
+		result, execErr := tx.Exec(edgeExactDeleteByIdentitySQL(values.String()), args...)
 		if execErr != nil {
 			panicOnFatal(execErr)
 			return 0

--- a/internal/graph/store_sqlite/lsp_projection.go
+++ b/internal/graph/store_sqlite/lsp_projection.go
@@ -77,9 +77,10 @@ WITH requested_languages(language) AS (
 )
 SELECT `+qualifiedNodeColumns("n", lookupNodeColsLight)+`
 FROM requested_files AS f
-JOIN nodes AS n ON n.file_path = f.file_path
+CROSS JOIN nodes AS n
 JOIN requested_languages AS l ON l.language = n.language
-WHERE n.repo_prefix = ?
+WHERE n.file_path = f.file_path
+  AND +n.repo_prefix = ?
   AND n.kind NOT IN (?, ?)`+predicate+`
 ORDER BY n.file_path, n.id`, languagesJSON, filesJSON, repoPrefix, string(graph.KindFile), string(graph.KindImport))
 	if err != nil {
@@ -128,10 +129,12 @@ WITH requested_languages(language) AS (
 )
 SELECT `+lookupQualifiedEdgeCols+`
 FROM requested_files AS f
-JOIN nodes AS n ON n.file_path = f.file_path
+CROSS JOIN nodes AS n
 JOIN requested_languages AS l ON l.language = n.language
-JOIN edges AS e ON e.from_id = n.id
-WHERE n.repo_prefix = ?
+CROSS JOIN edges AS e
+WHERE n.file_path = f.file_path
+  AND e.from_id = n.id
+  AND +n.repo_prefix = ?
   AND e.kind NOT IN (?, ?, ?, ?, ?, ?)`+confidencePredicate+`
 ORDER BY e.from_id, e.to_id, e.kind, e.file_path, e.line`, languagesJSON, filesJSON, repoPrefix,
 		string(graph.EdgeMemberOf), string(graph.EdgeDefines), string(graph.EdgeContains),
@@ -189,11 +192,13 @@ WITH requested_languages(language) AS (
 )
 SELECT `+lookupQualifiedEdgeCols+`
 FROM requested_files AS f
-JOIN nodes AS n ON n.file_path = f.file_path
+CROSS JOIN nodes AS n
 JOIN requested_languages AS l ON l.language = n.language
-JOIN edges AS e ON e.from_id = n.id
+CROSS JOIN edges AS e
 JOIN requested_kinds AS k ON k.kind = e.kind
-WHERE n.repo_prefix = ?
+WHERE n.file_path = f.file_path
+  AND e.from_id = n.id
+  AND +n.repo_prefix = ?
 ORDER BY e.from_id, e.to_id, e.kind, e.file_path, e.line`, languagesJSON, filesJSON, kindsJSON, repoPrefix)
 	if err != nil {
 		panicOnFatal(err)

--- a/internal/graph/store_sqlite/method_receiver_rebind_batch.go
+++ b/internal/graph/store_sqlite/method_receiver_rebind_batch.go
@@ -12,17 +12,18 @@ const goMethodReceiverFileTableSQL = `CREATE TEMP TABLE IF NOT EXISTS go_receive
 
 const goMethodReceiverCandidatesForFilesSQL = `
 SELECT e.id, MIN(c.id)
-FROM nodes AS m INDEXED BY nodes_by_file
-JOIN temp.go_receiver_rebind_files AS f ON f.file_path = m.file_path
-JOIN edges AS e INDEXED BY edges_by_from
-  ON e.from_id = m.id
- AND e.kind = 'member_of'
+FROM temp.go_receiver_rebind_files AS f
+CROSS JOIN nodes AS m INDEXED BY nodes_by_file
+CROSS JOIN edges AS e INDEXED BY edges_by_from
 LEFT JOIN nodes AS t ON t.id = e.to_id
 JOIN nodes AS c INDEXED BY nodes_go_receiver_type
   ON c.repo_prefix = m.repo_prefix
  AND c.file_dir = e.member_receiver_dir
  AND c.name = e.member_receiver
-WHERE m.language = 'go'
+WHERE m.file_path = f.file_path
+  AND e.from_id = m.id
+  AND e.kind = 'member_of'
+  AND m.language = 'go'
   AND m.kind = 'method'
   AND e.member_receiver IS NOT NULL
   AND e.member_receiver_dir IS NOT NULL

--- a/internal/graph/store_sqlite/plan_lock_v1_test.go
+++ b/internal/graph/store_sqlite/plan_lock_v1_test.go
@@ -1,0 +1,178 @@
+package store_sqlite
+
+import (
+	"strings"
+	"testing"
+)
+
+// Plan locks for the shapes the production-scale SQL sweep found misplanning.
+// Each query text mirrors its production site (kept in sync by hand — the
+// access path lives in the FROM/WHERE text, and drifting a production query
+// without updating its lock is exactly the failure these tests exist to
+// catch). Properties, not index names, wherever two indexes would be equally
+// correct.
+func TestSweepPlanLocks(t *testing.T) {
+	s := newPlanLockFixture(t)
+
+	cases := []struct {
+		name   string
+		query  string
+		args   int
+		want   []string
+		forbid []string
+	}{
+		{
+			// store.go stmtGetNodeByQual: the literal qual_name <> ''
+			// conjunct is what admits the partial nodes_by_qual index; a
+			// bound parameter alone cannot be proven non-empty and the
+			// statement scans all nodes (measured on a production store).
+			name:   "get_node_by_qual",
+			query:  `SELECT ` + lookupNodeCols + ` FROM nodes WHERE qual_name = ? AND qual_name <> '' LIMIT 1`,
+			args:   1,
+			want:   []string{"nodes_by_qual (qual_name=?)"},
+			forbid: []string{"SCAN nodes"},
+		},
+		{
+			// edgeExactDeleteByIdentitySQL: the IN-over-JOIN shape drives
+			// from the VALUES list into the edges primary key. The prior
+			// correlated EXISTS scanned all edges per chunk.
+			name:  "edge_exact_identity_delete",
+			query: edgeExactDeleteByIdentitySQL("(?,?,?,?,?),(?,?,?,?,?),(?,?,?,?,?)"),
+			args:  15,
+			want: []string{
+				"SEARCH e USING COVERING INDEX sqlite_autoindex_edges_1 (from_id=? AND to_id=? AND kind=? AND file_path=? AND line=?)",
+			},
+			forbid: []string{"SCAN edges", "SCAN e"},
+		},
+		{
+			// lsp_projection ProjectFileNodes: requested_files must drive
+			// nodes_by_file; the repo predicate is demoted so the planner
+			// cannot read the whole repo per changed-file batch.
+			name: "lsp_project_file_nodes",
+			query: `
+WITH requested_languages(language) AS (
+    SELECT CAST(value AS TEXT) FROM json_each(?)
+), requested_files(file_path) AS (
+    SELECT CAST(value AS TEXT) FROM json_each(?)
+)
+SELECT ` + qualifiedNodeColumns("n", lookupNodeColsLight) + `
+FROM requested_files AS f
+CROSS JOIN nodes AS n
+JOIN requested_languages AS l ON l.language = n.language
+WHERE n.file_path = f.file_path
+  AND +n.repo_prefix = ?
+  AND n.kind NOT IN (?, ?)
+ORDER BY n.file_path, n.id`,
+			args:   5,
+			want:   []string{"SEARCH n USING INDEX nodes_by_file (file_path=?)"},
+			forbid: []string{"nodes_by_repo", "SCAN n"},
+		},
+		{
+			// lsp_projection ProjectFileEdges: files drive nodes, nodes
+			// drive edges_by_from — never a whole-repo read.
+			name: "lsp_project_file_edges",
+			query: `
+WITH requested_languages(language) AS (
+    SELECT CAST(value AS TEXT) FROM json_each(?)
+), requested_files(file_path) AS (
+    SELECT CAST(value AS TEXT) FROM json_each(?)
+)
+SELECT ` + lookupQualifiedEdgeCols + `
+FROM requested_files AS f
+CROSS JOIN nodes AS n
+JOIN requested_languages AS l ON l.language = n.language
+CROSS JOIN edges AS e
+WHERE n.file_path = f.file_path
+  AND e.from_id = n.id
+  AND +n.repo_prefix = ?
+  AND e.kind NOT IN (?, ?, ?, ?, ?, ?)
+ORDER BY e.from_id, e.to_id, e.kind, e.file_path, e.line`,
+			args: 9,
+			want: []string{
+				"SEARCH n USING INDEX nodes_by_file (file_path=?)",
+				"SEARCH e USING INDEX edges_by_from", "(from_id=?",
+			},
+			forbid: []string{"nodes_by_repo", "SCAN n", "SCAN e"},
+		},
+		{
+			name: "lsp_project_file_edges_by_kinds",
+			query: `
+WITH requested_languages(language) AS (
+    SELECT CAST(value AS TEXT) FROM json_each(?)
+), requested_files(file_path) AS (
+    SELECT CAST(value AS TEXT) FROM json_each(?)
+), requested_kinds(kind) AS (
+    SELECT CAST(value AS TEXT) FROM json_each(?)
+)
+SELECT ` + lookupQualifiedEdgeCols + `
+FROM requested_files AS f
+CROSS JOIN nodes AS n
+JOIN requested_languages AS l ON l.language = n.language
+CROSS JOIN edges AS e
+JOIN requested_kinds AS k ON k.kind = e.kind
+WHERE n.file_path = f.file_path
+  AND e.from_id = n.id
+  AND +n.repo_prefix = ?
+ORDER BY e.from_id, e.to_id, e.kind, e.file_path, e.line`,
+			args: 4,
+			want: []string{
+				"SEARCH n USING INDEX nodes_by_file (file_path=?)",
+				"SEARCH e USING INDEX edges_by_from", "(from_id=?",
+			},
+			forbid: []string{"nodes_by_repo", "SCAN n", "SCAN e"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := explainQueryPlan(t, s, tc.query, tc.args)
+			joined := strings.Join(plan, "\n")
+			for _, want := range tc.want {
+				if !strings.Contains(joined, want) {
+					t.Fatalf("plan missing %q:\n%s", want, joined)
+				}
+			}
+			for _, forbid := range tc.forbid {
+				if strings.Contains(joined, forbid) {
+					t.Fatalf("plan contains forbidden %q:\n%s", forbid, joined)
+				}
+			}
+		})
+	}
+}
+
+// The receiver-rebind batch drives from the TEMP file table (CROSS JOIN pin);
+// the temp table is connection-local, so this lock provisions it through the
+// same writer path production uses.
+func TestSweepPlanLockReceiverRebindBatch(t *testing.T) {
+	s := newPlanLockFixture(t)
+	conn, err := s.writerDB.Conn(t.Context())
+	if err != nil {
+		t.Fatalf("writer conn: %v", err)
+	}
+	defer conn.Close()
+	if _, err := conn.ExecContext(t.Context(), goMethodReceiverFileTableSQL); err != nil {
+		t.Fatalf("create temp table: %v", err)
+	}
+	rows, err := conn.QueryContext(t.Context(), "EXPLAIN QUERY PLAN "+goMethodReceiverCandidatesForFilesSQL)
+	if err != nil {
+		t.Fatalf("explain: %v", err)
+	}
+	defer rows.Close()
+	var plan []string
+	for rows.Next() {
+		var id, parent, notused int
+		var detail string
+		if err := rows.Scan(&id, &parent, &notused, &detail); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		plan = append(plan, detail)
+	}
+	joined := strings.Join(plan, "\n")
+	if !strings.Contains(joined, "SCAN f") && !strings.Contains(joined, "go_receiver_rebind_files") {
+		t.Fatalf("plan must drive from the temp file table:\n%s", joined)
+	}
+	if !strings.Contains(joined, "nodes_by_file (file_path=?)") {
+		t.Fatalf("plan must probe nodes_by_file per requested file:\n%s", joined)
+	}
+}

--- a/internal/graph/store_sqlite/plan_lock_v1_test.go
+++ b/internal/graph/store_sqlite/plan_lock_v1_test.go
@@ -141,6 +141,31 @@ ORDER BY e.from_id, e.to_id, e.kind, e.file_path, e.line`,
 	}
 }
 
+// explainPlanTolerant mirrors explainQueryPlan but accepts empty plans:
+// prepared DML like a bare INSERT legitimately has no plan rows.
+func explainPlanTolerant(t *testing.T, s *Store, query string) []string {
+	t.Helper()
+	args := make([]any, strings.Count(query, "?"))
+	for i := range args {
+		args[i] = ""
+	}
+	rows, err := s.db.Query("EXPLAIN QUERY PLAN "+query, args...)
+	if err != nil {
+		t.Fatalf("explain %.60s: %v", query, err)
+	}
+	defer rows.Close()
+	var plan []string
+	for rows.Next() {
+		var id, parent, notused int
+		var detail string
+		if err := rows.Scan(&id, &parent, &notused, &detail); err != nil {
+			t.Fatalf("scan plan row: %v", err)
+		}
+		plan = append(plan, detail)
+	}
+	return plan
+}
+
 // The receiver-rebind batch drives from the TEMP file table (CROSS JOIN pin);
 // the temp table is connection-local, so this lock provisions it through the
 // same writer path production uses.
@@ -174,5 +199,72 @@ func TestSweepPlanLockReceiverRebindBatch(t *testing.T) {
 	}
 	if !strings.Contains(joined, "nodes_by_file (file_path=?)") {
 		t.Fatalf("plan must probe nodes_by_file per requested file:\n%s", joined)
+	}
+}
+
+// TestPreparedStatementPlansNeverScanBigTables is the mechanical form of the
+// partial-index convention: every statement prepared at Open is EXPLAINed
+// and any full scan of the nodes or edges tables fails the build, unless the
+// statement is on the explicit allowlist of intentional whole-table reads.
+// A future prepared statement that trips the partial-index-vs-bound-parameter
+// trap (or any other misplan) fails here without anyone remembering a rule.
+func TestPreparedStatementPlansNeverScanBigTables(t *testing.T) {
+	s := newPlanLockFixture(t)
+	// Intentional whole-table reads, and statements the tiny fixture plans
+	// as a scan but a production-scale store verifiably serves from an
+	// index (regime flips — each entry names its verification). Adding an
+	// entry here is a reviewed decision, not a remembered convention.
+	allowlist := []string{
+		"COUNT(*)", // whole-table counts are whole-table by intent
+		// WHERE repo_prefix = ?: SEARCH nodes_by_repo_kind (repo_prefix=?)
+		// on the production snapshot; the 1.2k-row fixture prefers a scan.
+		`FROM nodes WHERE repo_prefix = ?`,
+		// Repo edges via LIST SUBQUERY + edges_by_from_line probe on the
+		// production snapshot; fixture-size regime flip.
+		`FROM edges e`,
+	}
+	if len(s.preparedSQL) == 0 {
+		t.Fatal("prepared-statement registry is empty; the fence covers nothing")
+	}
+	bareScan := func(plan []string) string {
+		for _, detail := range plan {
+			trimmed := strings.TrimSpace(detail)
+			if !strings.HasPrefix(trimmed, "SCAN nodes") && !strings.HasPrefix(trimmed, "SCAN edges") {
+				continue
+			}
+			// A covering-index scan is an index-only read (DISTINCT over a
+			// partial index, for example) — only bare table scans fail.
+			if strings.Contains(trimmed, "USING") {
+				continue
+			}
+			return trimmed
+		}
+		return ""
+	}
+	for _, query := range s.preparedSQL {
+		name := query
+		if len(name) > 70 {
+			name = name[:70]
+		}
+		allowed := false
+		for _, allow := range allowlist {
+			if strings.Contains(query, allow) {
+				allowed = true
+				break
+			}
+		}
+		// The bare AllNodes/AllEdges exports are whole-table by intent —
+		// matched by exact suffix so nothing with a WHERE clause rides along.
+		if strings.HasSuffix(query, "FROM nodes") || strings.HasSuffix(query, "FROM edges") {
+			allowed = true
+		}
+		if allowed {
+			continue
+		}
+		plan := explainPlanTolerant(t, s, query)
+		if offender := bareScan(plan); offender != "" {
+			t.Errorf("prepared statement scans a big table (%s):\n  %s\nplan:\n%s",
+				offender, name, strings.Join(plan, "\n"))
+		}
 	}
 }

--- a/internal/graph/store_sqlite/plan_lock_v1_test.go
+++ b/internal/graph/store_sqlite/plan_lock_v1_test.go
@@ -268,3 +268,56 @@ func TestPreparedStatementPlansNeverScanBigTables(t *testing.T) {
 		}
 	}
 }
+
+// The WARN-class shapes from the sweep, post-fix: enrichment repo readers
+// ride their partial indexes via the literal predicate, and each fn-value
+// placeholder arm rides its own index standalone (the OR form defeated the
+// partial-index prover).
+func TestSweepWarnPlanLocks(t *testing.T) {
+	s := newPlanLockFixture(t)
+	cases := []struct {
+		name   string
+		query  string
+		args   int
+		want   []string
+		forbid []string
+	}{
+		{
+			name:   "blame_enrichment_by_repo",
+			query:  "SELECT node_id FROM blame_enrichment WHERE repo_prefix = ? AND repo_prefix <> \x27\x27",
+			args:   1,
+			want:   []string{"blame_by_repo (repo_prefix=?)"},
+			forbid: []string{"SCAN blame_enrichment"},
+		},
+		{
+			name:   "fnvalue_bare_range",
+			query:  "SELECT id FROM edges WHERE to_id >= \x27unresolved::fnvalue::\x27 AND to_id < \x27unresolved::fnvalue:;\x27",
+			args:   0,
+			want:   []string{"edges_by_to (to_id>? AND to_id<?)"},
+			forbid: []string{"SCAN edges USING COVERING INDEX edges_by_unresolved"},
+		},
+		{
+			name:   "fnvalue_prefixed_partial",
+			query:  "SELECT id FROM edges WHERE to_id LIKE \x27%::unresolved::fnvalue::%\x27",
+			args:   0,
+			want:   []string{"edges_fnvalue_prefixed"},
+			forbid: []string{"edges_by_unresolved"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := explainPlanTolerant(t, s, tc.query)
+			joined := strings.Join(plan, "\n")
+			for _, want := range tc.want {
+				if !strings.Contains(joined, want) {
+					t.Fatalf("plan missing %q:\n%s", want, joined)
+				}
+			}
+			for _, forbid := range tc.forbid {
+				if strings.Contains(joined, forbid) {
+					t.Fatalf("plan contains forbidden %q:\n%s", forbid, joined)
+				}
+			}
+		})
+	}
+}

--- a/internal/graph/store_sqlite/store.go
+++ b/internal/graph/store_sqlite/store.go
@@ -734,8 +734,13 @@ func (s *Store) prepare() error {
 		`INSERT INTO nodes (`+nodeCols+`) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`+nodeUpsertClause)
 	prep(&s.stmtGetNode,
 		`SELECT `+nodeCols+` FROM nodes WHERE id = ?`)
+	// The literal qual_name <> '' conjunct is what makes the partial
+	// nodes_by_qual index usable: SQLite cannot prove a bound parameter is
+	// non-empty, so without it this statement is a full node scan per call
+	// on resolver hot paths (measured against a production store). Every
+	// reader of a partial index must restate its predicate literally.
 	prep(&s.stmtGetNodeByQual,
-		`SELECT `+nodeCols+` FROM nodes WHERE qual_name = ? LIMIT 1`)
+		`SELECT `+nodeCols+` FROM nodes WHERE qual_name = ? AND qual_name <> '' LIMIT 1`)
 	prep(&s.stmtFindByName,
 		`SELECT `+nodeCols+` FROM nodes WHERE name = ?`)
 	prep(&s.stmtFindByNameInRepo,

--- a/internal/graph/store_sqlite/store.go
+++ b/internal/graph/store_sqlite/store.go
@@ -65,6 +65,11 @@ type Store struct {
 	// re-indexes don't re-upsert identical stubs on every batch.
 	builtinSeen sync.Map
 
+	// preparedSQL registers every statement prepared at Open so the plan
+	// fence can EXPLAIN the entire prepared surface against a fixture and
+	// reject big-table scans mechanically.
+	preparedSQL []string
+
 	// writeMu serialises every mutation. SQLite serialises writers
 	// internally; doing the same on the Go side turns SQLITE_BUSY
 	// contention into clean lock-wait and keeps the conformance
@@ -719,8 +724,20 @@ func (s *Store) prepare() error {
 		}
 		*out = st
 	}
-	prep := func(out **sql.Stmt, q string) { prepOn(s.db, out, q) }
-	prepWrite := func(out **sql.Stmt, q string) { prepOn(s.writerDB, out, q) }
+	// Every prepared statement is also recorded so the plan fence
+	// (TestPreparedStatementPlansNeverScanBigTables) can EXPLAIN the whole
+	// prepared surface mechanically. Partial-index misuse against bound
+	// parameters slipped through review three independent times as a
+	// "convention"; the registry turns the convention into a gate that
+	// covers every future statement automatically.
+	prep := func(out **sql.Stmt, q string) {
+		s.preparedSQL = append(s.preparedSQL, q)
+		prepOn(s.db, out, q)
+	}
+	prepWrite := func(out **sql.Stmt, q string) {
+		s.preparedSQL = append(s.preparedSQL, q)
+		prepOn(s.writerDB, out, q)
+	}
 
 	const nodeCols = nodeInsertColumns
 

--- a/internal/graph/store_sqlite/store_blame_enrichment.go
+++ b/internal/graph/store_sqlite/store_blame_enrichment.go
@@ -109,7 +109,7 @@ func (s *Store) BlameRows(repoPrefix string) []graph.BlameEnrichment {
 	if repoPrefix == "" {
 		rows, err = s.db.Query(`SELECT ` + blameCols + ` FROM blame_enrichment`)
 	} else {
-		rows, err = s.db.Query(`SELECT `+blameCols+` FROM blame_enrichment WHERE repo_prefix = ?`, repoPrefix)
+		rows, err = s.db.Query(`SELECT `+blameCols+` FROM blame_enrichment WHERE repo_prefix = ? AND repo_prefix <> ''`, repoPrefix)
 	}
 	if err != nil {
 		return nil

--- a/internal/graph/store_sqlite/store_churn_enrichment.go
+++ b/internal/graph/store_sqlite/store_churn_enrichment.go
@@ -132,7 +132,7 @@ func (s *Store) ChurnRows(repoPrefix string) []graph.ChurnEnrichment {
 	if repoPrefix == "" {
 		rows, err = s.db.Query(`SELECT ` + churnCols + ` FROM churn_enrichment`)
 	} else {
-		rows, err = s.db.Query(`SELECT `+churnCols+` FROM churn_enrichment WHERE repo_prefix = ?`, repoPrefix)
+		rows, err = s.db.Query(`SELECT `+churnCols+` FROM churn_enrichment WHERE repo_prefix = ? AND repo_prefix <> ''`, repoPrefix)
 	}
 	if err != nil {
 		return nil

--- a/internal/graph/store_sqlite/store_coverage_enrichment.go
+++ b/internal/graph/store_sqlite/store_coverage_enrichment.go
@@ -121,7 +121,7 @@ func (s *Store) CoverageRows(repoPrefix string) []graph.CoverageEnrichment {
 	if repoPrefix == "" {
 		rows, err = s.db.Query(`SELECT ` + coverageCols + ` FROM coverage_enrichment`)
 	} else {
-		rows, err = s.db.Query(`SELECT `+coverageCols+` FROM coverage_enrichment WHERE repo_prefix = ?`, repoPrefix)
+		rows, err = s.db.Query(`SELECT `+coverageCols+` FROM coverage_enrichment WHERE repo_prefix = ? AND repo_prefix <> ''`, repoPrefix)
 	}
 	if err != nil {
 		return nil

--- a/internal/graph/store_sqlite/store_fnvalue.go
+++ b/internal/graph/store_sqlite/store_fnvalue.go
@@ -22,13 +22,26 @@ var _ graph.FnValuePlaceholderScanner = (*Store)(nil)
 // EdgeReferences kind (placeholders + every real reference) and Go-filter on
 // every whole-graph synthesizer pass; it pulls the handful of placeholders
 // straight off the index instead.
+// The two forms run as SEPARATE queries: inside an OR, the planner's
+// implication prover would not bind the partial edges_fnvalue_prefixed
+// index to the infix arm and walked every unresolved edge instead
+// (measured against a production store). Standalone, each arm rides its
+// own index; the namespaces are disjoint (the bare form starts at the
+// marker, the infix form requires a repo prefix before it), so no dedupe.
 func (s *Store) FnValuePlaceholderEdges() iter.Seq[*graph.Edge] {
 	return func(yield func(*graph.Edge) bool) {
-		out := s.queryEdgesSQL(`SELECT ` + lookupEdgeCols + `
+		bare := s.queryEdgesSQL(`SELECT ` + lookupEdgeCols + `
 FROM edges
-WHERE (to_id >= 'unresolved::fnvalue::' AND to_id < 'unresolved::fnvalue:;')
-   OR (is_unresolved = 1 AND to_id LIKE '%::unresolved::fnvalue::%')`)
-		for _, e := range out {
+WHERE to_id >= 'unresolved::fnvalue::' AND to_id < 'unresolved::fnvalue:;'`)
+		for _, e := range bare {
+			if !yield(e) {
+				return
+			}
+		}
+		prefixed := s.queryEdgesSQL(`SELECT ` + lookupEdgeCols + `
+FROM edges
+WHERE to_id LIKE '%::unresolved::fnvalue::%'`)
+		for _, e := range prefixed {
 			if !yield(e) {
 				return
 			}

--- a/internal/graph/store_sqlite/store_release_enrichment.go
+++ b/internal/graph/store_sqlite/store_release_enrichment.go
@@ -118,7 +118,7 @@ func (s *Store) ReleaseRows(repoPrefix string) []graph.ReleaseEnrichment {
 	if repoPrefix == "" {
 		rows, err = s.db.Query(`SELECT ` + releaseCols + ` FROM release_enrichment`)
 	} else {
-		rows, err = s.db.Query(`SELECT `+releaseCols+` FROM release_enrichment WHERE repo_prefix = ?`, repoPrefix)
+		rows, err = s.db.Query(`SELECT `+releaseCols+` FROM release_enrichment WHERE repo_prefix = ? AND repo_prefix <> ''`, repoPrefix)
 	}
 	if err != nil {
 		return nil

--- a/internal/hooks/dispatch.go
+++ b/internal/hooks/dispatch.go
@@ -126,6 +126,10 @@ func Run(port int, mode Mode) {
 		runSessionStart(data)
 	case "UserPromptSubmit":
 		runUserPromptSubmit(data)
+	case "SubagentStart":
+		runSubagentStart(data)
+	case "SubagentStop":
+		runSubagentStop(data)
 	}
 }
 

--- a/internal/hooks/gortex_read.go
+++ b/internal/hooks/gortex_read.go
@@ -73,11 +73,11 @@ func gortexReadNudge(toolName string, toolInput map[string]any) string {
 func normalizeGortexReadInput(toolName string, input map[string]any) (path string, options, output map[string]any, wholeFile bool) {
 	options = map[string]any{}
 	output = map[string]any{}
-	switch strings.TrimSpace(toolName) {
-	case gortexReadFileTool, gortexEditingContextTool, "read_file", "get_editing_context":
+	switch shortGortexToolName(strings.TrimSpace(toolName)) {
+	case "read_file", "get_editing_context":
 		path, _ = input["path"].(string)
 		return path, input, output, true
-	case gortexCompactReadTool, "read":
+	case "read":
 		operation, _ := input["operation"].(string)
 		operation = strings.ReplaceAll(strings.ToLower(strings.TrimSpace(operation)), "-", "_")
 		target, _ := input["target"].(map[string]any)
@@ -128,10 +128,12 @@ func gortexReadAdvisory(toolName, path string) string {
 	return b.String()
 }
 
-// shortGortexToolName strips the mcp__gortex__ namespace so the advisory
-// reads "read_file" rather than the fully-qualified tool name.
+// shortGortexToolName strips either Claude Code namespace: direct MCP config
+// uses mcp__gortex__, while marketplace plugins use
+// mcp__plugin_gortex_gortex__. The advisory should display only the operation.
 func shortGortexToolName(toolName string) string {
-	return strings.TrimPrefix(toolName, gortexMCPToolPrefix)
+	toolName = strings.TrimPrefix(toolName, gortexMCPToolPrefix)
+	return strings.TrimPrefix(toolName, gortexPluginMCPToolPrefix)
 }
 
 // hasReadSizeCap reports whether the read already bounds its output via a

--- a/internal/hooks/localization_terminal.go
+++ b/internal/hooks/localization_terminal.go
@@ -1,0 +1,794 @@
+package hooks
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	localizationTerminalMarkerVersion   = 3
+	localizationTerminalContractV2      = 2
+	localizationTerminalHostMetaVersion = 1
+	localizationTerminalMarkerTTL       = 24 * time.Hour
+	localizationTerminalPruneLimit      = 256
+	localizationTerminalSessionHardCap  = 128
+	localizationTerminalAgentHardCap    = 64
+	localizationTerminalJanitorDeletes  = 32
+
+	localizationTerminalContext    = "Gortex localization is complete. Respond to the user now; do not call another tool in this turn."
+	localizationTerminalDenyReason = "[Gortex] Localization is complete. Respond to the user now; no further tool calls are allowed in this turn."
+	gortexPluginMCPToolPrefix      = "mcp__plugin_gortex_gortex__"
+	localizationHostMetaKey        = "gortex/localization"
+)
+
+var localizationNavigationOperations = map[string]struct{}{
+	"explore":   {},
+	"search":    {},
+	"read":      {},
+	"relations": {},
+	"trace":     {},
+	"analyze":   {},
+}
+
+var preToolUsePolicyTools = map[string]struct{}{
+	"Read":  {},
+	"Grep":  {},
+	"Glob":  {},
+	"Task":  {},
+	"Bash":  {},
+	"Edit":  {},
+	"Write": {},
+}
+
+type localizationTerminalBase struct {
+	SessionID string `json:"session_id"`
+	AgentID   string `json:"agent_id,omitempty"`
+	CWD       string `json:"cwd"`
+}
+
+type localizationTerminalIdentity struct {
+	SessionID string `json:"session_id"`
+	PromptID  string `json:"prompt_id,omitempty"`
+	AgentID   string `json:"agent_id,omitempty"`
+	CWD       string `json:"cwd"`
+	TurnToken string `json:"turn_token"`
+}
+
+type localizationTurnState struct {
+	Version         int                          `json:"version"`
+	Identity        localizationTerminalIdentity `json:"identity"`
+	CreatedUnixNano int64                        `json:"created_unix_nano"`
+}
+
+type localizationToolSnapshot struct {
+	Version         int                          `json:"version"`
+	ToolUseID       string                       `json:"tool_use_id"`
+	ToolName        string                       `json:"tool_name"`
+	Identity        localizationTerminalIdentity `json:"identity"`
+	CreatedUnixNano int64                        `json:"created_unix_nano"`
+}
+
+type localizationTerminalMarker struct {
+	Version          int                          `json:"version"`
+	ContractVersion  int                          `json:"contract_version"`
+	Identity         localizationTerminalIdentity `json:"identity"`
+	ObservedUnixNano int64                        `json:"observed_unix_nano"`
+}
+
+type localizationTerminalHookInput struct {
+	HookEventName string          `json:"hook_event_name"`
+	ToolName      string          `json:"tool_name"`
+	ToolUseID     string          `json:"tool_use_id"`
+	SessionID     string          `json:"session_id"`
+	PromptID      string          `json:"prompt_id"`
+	AgentID       string          `json:"agent_id"`
+	CWD           string          `json:"cwd"`
+	ToolResponse  json.RawMessage `json:"tool_response"`
+}
+
+type localizationTerminalCompletion struct {
+	State            string `json:"state"`
+	Scope            string `json:"scope"`
+	RequiredAction   string `json:"required_action"`
+	AllowedToolCalls *int   `json:"allowed_tool_calls"`
+	ContractVersion  int    `json:"contract_version"`
+	Enforceable      bool   `json:"enforceable"`
+}
+
+type localizationTerminalContract struct {
+	Completion localizationTerminalCompletion `json:"completion"`
+	Terminal   bool                           `json:"terminal"`
+}
+
+type localizationToolResponse struct {
+	IsError                bool                       `json:"isError"`
+	IsErrorSnake           bool                       `json:"is_error"`
+	StructuredContent      json.RawMessage            `json:"structuredContent"`
+	StructuredContentSnake json.RawMessage            `json:"structured_content"`
+	Content                json.RawMessage            `json:"content"`
+	Meta                   map[string]json.RawMessage `json:"_meta"`
+}
+
+type localizationTextBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type localizationHostEnvelope struct {
+	Version  int                          `json:"version"`
+	Contract localizationTerminalContract `json:"contract"`
+	Evidence json.RawMessage              `json:"evidence"`
+}
+
+func observeLocalizationTerminal(data []byte) (localizationTerminalHookInput, bool) {
+	var input localizationTerminalHookInput
+	if err := json.Unmarshal(data, &input); err != nil || input.HookEventName != "PostToolUse" {
+		return localizationTerminalHookInput{}, false
+	}
+	if !localizationNavigationTool(input.ToolName) {
+		return localizationTerminalHookInput{}, false
+	}
+	identity, ok := consumeLocalizationToolSnapshot(input)
+	if !ok {
+		return localizationTerminalHookInput{}, false
+	}
+	contract, ok := exactLocalizationTerminalContract(input.ToolResponse)
+	if !ok || !enforceableLocalizationTerminalContract(contract) {
+		return localizationTerminalHookInput{}, false
+	}
+	if !markLocalizationTerminal(identity, contract.Completion.ContractVersion) {
+		return localizationTerminalHookInput{}, false
+	}
+	return input, true
+}
+
+// exactLocalizationTerminalContract accepts only a server-owned host envelope
+// paired with the same contract in structuredContent or in one exact JSON text
+// block. The authoritative metadata prevents repository text from arming the
+// host gate; prefixes, extra blocks, and visible/metadata mismatches fail open.
+func exactLocalizationTerminalContract(raw json.RawMessage) (localizationTerminalContract, bool) {
+	raw, ok := unwrapJSONString(raw)
+	if !ok {
+		return localizationTerminalContract{}, false
+	}
+	var response localizationToolResponse
+	if err := json.Unmarshal(raw, &response); err != nil || response.IsError || response.IsErrorSnake {
+		return localizationTerminalContract{}, false
+	}
+	visible := response.StructuredContent
+	if len(visible) == 0 {
+		visible = response.StructuredContentSnake
+	}
+	if len(visible) > 0 {
+		visible, ok = unwrapJSONString(visible)
+	} else {
+		visible, ok = exactLocalizationContractContent(response.Content)
+	}
+	if !ok || len(visible) == 0 {
+		return localizationTerminalContract{}, false
+	}
+	var contract localizationTerminalContract
+	if err := json.Unmarshal(visible, &contract); err != nil {
+		return localizationTerminalContract{}, false
+	}
+	hostContract, ok := localizationHostContract(response.Meta)
+	if !ok || !sameLocalizationTerminalContract(contract, hostContract) {
+		return localizationTerminalContract{}, false
+	}
+	return contract, true
+}
+
+func localizationHostContract(meta map[string]json.RawMessage) (localizationTerminalContract, bool) {
+	raw, ok := meta[localizationHostMetaKey]
+	if !ok {
+		return localizationTerminalContract{}, false
+	}
+	raw, ok = unwrapJSONString(raw)
+	if !ok {
+		return localizationTerminalContract{}, false
+	}
+	var envelope localizationHostEnvelope
+	if err := json.Unmarshal(raw, &envelope); err != nil || envelope.Version != localizationTerminalHostMetaVersion {
+		return localizationTerminalContract{}, false
+	}
+	if !enforceableLocalizationTerminalContract(envelope.Contract) {
+		return localizationTerminalContract{}, false
+	}
+	return envelope.Contract, true
+}
+
+func exactLocalizationContractContent(raw json.RawMessage) (json.RawMessage, bool) {
+	raw, ok := unwrapJSONString(raw)
+	if !ok || len(raw) == 0 {
+		return nil, false
+	}
+	if raw[0] == '{' {
+		var block localizationTextBlock
+		if err := json.Unmarshal(raw, &block); err != nil || block.Type != "text" {
+			return nil, false
+		}
+		return exactLocalizationContractText(block.Text)
+	}
+	if raw[0] != '[' {
+		return nil, false
+	}
+	var blocks []localizationTextBlock
+	if err := json.Unmarshal(raw, &blocks); err != nil || len(blocks) != 1 || blocks[0].Type != "text" {
+		return nil, false
+	}
+	return exactLocalizationContractText(blocks[0].Text)
+}
+
+func exactLocalizationContractText(text string) (json.RawMessage, bool) {
+	text = strings.TrimSpace(text)
+	if text == "" || text[0] != '{' || !json.Valid([]byte(text)) {
+		return nil, false
+	}
+	return json.RawMessage(text), true
+}
+
+func sameLocalizationTerminalContract(left, right localizationTerminalContract) bool {
+	if left.Terminal != right.Terminal {
+		return false
+	}
+	lc, rc := left.Completion, right.Completion
+	if lc.AllowedToolCalls == nil || rc.AllowedToolCalls == nil {
+		return lc.AllowedToolCalls == nil && rc.AllowedToolCalls == nil &&
+			lc.State == rc.State && lc.Scope == rc.Scope && lc.RequiredAction == rc.RequiredAction &&
+			lc.ContractVersion == rc.ContractVersion && lc.Enforceable == rc.Enforceable
+	}
+	return lc.State == rc.State && lc.Scope == rc.Scope && lc.RequiredAction == rc.RequiredAction &&
+		*lc.AllowedToolCalls == *rc.AllowedToolCalls && lc.ContractVersion == rc.ContractVersion &&
+		lc.Enforceable == rc.Enforceable
+}
+
+func unwrapJSONString(raw json.RawMessage) (json.RawMessage, bool) {
+	raw = json.RawMessage(strings.TrimSpace(string(raw)))
+	if len(raw) == 0 {
+		return nil, false
+	}
+	for raw[0] == '"' {
+		var text string
+		if err := json.Unmarshal(raw, &text); err != nil {
+			return nil, false
+		}
+		raw = json.RawMessage(strings.TrimSpace(text))
+		if len(raw) == 0 {
+			return nil, false
+		}
+	}
+	return raw, true
+}
+
+func enforceableLocalizationTerminalContract(contract localizationTerminalContract) bool {
+	completion := contract.Completion
+	return contract.Terminal &&
+		completion.State == "answer_ready" &&
+		completion.Scope == "localization" &&
+		completion.RequiredAction == "respond" &&
+		completion.AllowedToolCalls != nil && *completion.AllowedToolCalls == 0 &&
+		completion.ContractVersion >= localizationTerminalContractV2 &&
+		completion.Enforceable
+}
+
+func localizationNavigationTool(tool string) bool {
+	operation := shortGortexToolName(tool)
+	if operation == tool {
+		return false
+	}
+	_, ok := localizationNavigationOperations[operation]
+	return ok
+}
+
+func isGortexMCPToolName(tool string) bool {
+	return strings.HasPrefix(tool, gortexMCPToolPrefix) || strings.HasPrefix(tool, gortexPluginMCPToolPrefix)
+}
+
+func preToolUsePolicyTool(tool string) bool {
+	if isGortexMCPToolName(tool) {
+		return true
+	}
+	_, ok := preToolUsePolicyTools[tool]
+	return ok
+}
+
+func localizationTerminalBaseFor(sessionID, agentID, cwd string) (localizationTerminalBase, bool) {
+	base := localizationTerminalBase{
+		SessionID: strings.TrimSpace(sessionID),
+		AgentID:   strings.TrimSpace(agentID),
+		CWD:       canonicalLocalizationTerminalCWD(cwd),
+	}
+	return base, base.SessionID != "" && base.CWD != ""
+}
+
+func localizationTerminalRoot() string {
+	dir := sessionStateDir()
+	if dir == "" {
+		return ""
+	}
+	return filepath.Join(dir, "localization-terminal-v3")
+}
+
+func localizationStateHash(value any) string {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func localizationSessionStateDir(base localizationTerminalBase) string {
+	root := localizationTerminalRoot()
+	key := struct {
+		SessionID string `json:"session_id"`
+		CWD       string `json:"cwd"`
+	}{base.SessionID, base.CWD}
+	digest := localizationStateHash(key)
+	if root == "" || digest == "" {
+		return ""
+	}
+	return filepath.Join(root, "sessions", digest)
+}
+
+func localizationAgentStateDir(base localizationTerminalBase) string {
+	sessionDir := localizationSessionStateDir(base)
+	digest := localizationStateHash(struct {
+		AgentID string `json:"agent_id"`
+	}{base.AgentID})
+	if sessionDir == "" || digest == "" {
+		return ""
+	}
+	return filepath.Join(sessionDir, "agents", digest)
+}
+
+func localizationTurnPath(base localizationTerminalBase) string {
+	agentDir := localizationAgentStateDir(base)
+	if agentDir == "" {
+		return ""
+	}
+	return filepath.Join(agentDir, "turn.json")
+}
+
+func localizationSnapshotPath(base localizationTerminalBase, toolUseID string) string {
+	agentDir := localizationAgentStateDir(base)
+	toolUseID = strings.TrimSpace(toolUseID)
+	digest := localizationStateHash(toolUseID)
+	if agentDir == "" || toolUseID == "" || digest == "" {
+		return ""
+	}
+	return filepath.Join(agentDir, "snapshots", digest+".json")
+}
+
+func localizationTerminalMarkerPath(identity localizationTerminalIdentity) string {
+	base, ok := localizationTerminalBaseFor(identity.SessionID, identity.AgentID, identity.CWD)
+	if !ok {
+		return ""
+	}
+	agentDir := localizationAgentStateDir(base)
+	digest := localizationStateHash(identity)
+	if agentDir == "" || digest == "" {
+		return ""
+	}
+	return filepath.Join(agentDir, "markers", digest+".json")
+}
+
+func beginLocalizationTurn(sessionID, promptID, agentID, cwd string) (localizationTerminalIdentity, bool) {
+	base, ok := localizationTerminalBaseFor(sessionID, agentID, cwd)
+	if !ok {
+		return localizationTerminalIdentity{}, false
+	}
+	var tokenBytes [16]byte
+	if _, err := rand.Read(tokenBytes[:]); err != nil {
+		return localizationTerminalIdentity{}, false
+	}
+	identity := localizationTerminalIdentity{
+		SessionID: base.SessionID,
+		PromptID:  strings.TrimSpace(promptID),
+		AgentID:   base.AgentID,
+		CWD:       base.CWD,
+		TurnToken: hex.EncodeToString(tokenBytes[:]),
+	}
+	state := localizationTurnState{
+		Version:         localizationTerminalMarkerVersion,
+		Identity:        identity,
+		CreatedUnixNano: time.Now().UnixNano(),
+	}
+	if !writeLocalizationState(localizationTurnPath(base), state) {
+		return localizationTerminalIdentity{}, false
+	}
+	maintainLocalizationState(base)
+	return identity, true
+}
+
+func currentLocalizationTurn(sessionID, promptID, agentID, cwd string) (localizationTerminalIdentity, bool) {
+	base, ok := localizationTerminalBaseFor(sessionID, agentID, cwd)
+	if !ok {
+		return localizationTerminalIdentity{}, false
+	}
+	var state localizationTurnState
+	path := localizationTurnPath(base)
+	if !readLocalizationState(path, &state) || !freshLocalizationTimestamp(path, state.CreatedUnixNano) ||
+		state.Version != localizationTerminalMarkerVersion ||
+		state.Identity.SessionID != base.SessionID || state.Identity.AgentID != base.AgentID || state.Identity.CWD != base.CWD ||
+		strings.TrimSpace(state.Identity.TurnToken) == "" {
+		return localizationTerminalIdentity{}, false
+	}
+	promptID = strings.TrimSpace(promptID)
+	if promptID != "" && promptID != state.Identity.PromptID {
+		return localizationTerminalIdentity{}, false
+	}
+	return state.Identity, true
+}
+
+func snapshotLocalizationToolUse(input HookInput, identity localizationTerminalIdentity) bool {
+	if !localizationNavigationTool(input.ToolName) || strings.TrimSpace(input.ToolUseID) == "" {
+		return false
+	}
+	base, ok := localizationTerminalBaseFor(input.SessionID, input.AgentID, input.CWD)
+	if !ok {
+		return false
+	}
+	snapshot := localizationToolSnapshot{
+		Version:         localizationTerminalMarkerVersion,
+		ToolUseID:       strings.TrimSpace(input.ToolUseID),
+		ToolName:        input.ToolName,
+		Identity:        identity,
+		CreatedUnixNano: time.Now().UnixNano(),
+	}
+	return writeBoundedLocalizationState(localizationSnapshotPath(base, input.ToolUseID), snapshot)
+}
+
+func consumeLocalizationToolSnapshot(input localizationTerminalHookInput) (localizationTerminalIdentity, bool) {
+	base, ok := localizationTerminalBaseFor(input.SessionID, input.AgentID, input.CWD)
+	if !ok || strings.TrimSpace(input.ToolUseID) == "" {
+		return localizationTerminalIdentity{}, false
+	}
+	path := localizationSnapshotPath(base, input.ToolUseID)
+	var snapshot localizationToolSnapshot
+	if !readLocalizationState(path, &snapshot) || !freshLocalizationTimestamp(path, snapshot.CreatedUnixNano) ||
+		snapshot.Version != localizationTerminalMarkerVersion ||
+		snapshot.ToolUseID != strings.TrimSpace(input.ToolUseID) || snapshot.ToolName != input.ToolName ||
+		snapshot.Identity.SessionID != base.SessionID || snapshot.Identity.AgentID != base.AgentID || snapshot.Identity.CWD != base.CWD {
+		return localizationTerminalIdentity{}, false
+	}
+	_ = os.Remove(path)
+	if promptID := strings.TrimSpace(input.PromptID); promptID != "" && promptID != snapshot.Identity.PromptID {
+		return localizationTerminalIdentity{}, false
+	}
+	return snapshot.Identity, true
+}
+
+func markLocalizationTerminal(identity localizationTerminalIdentity, contractVersion int) bool {
+	if identity.SessionID == "" || identity.CWD == "" || identity.TurnToken == "" ||
+		contractVersion < localizationTerminalContractV2 {
+		return false
+	}
+	marker := localizationTerminalMarker{
+		Version:          localizationTerminalMarkerVersion,
+		ContractVersion:  contractVersion,
+		Identity:         identity,
+		ObservedUnixNano: time.Now().UnixNano(),
+	}
+	return writeBoundedLocalizationState(localizationTerminalMarkerPath(identity), marker)
+}
+
+func hasLocalizationTerminal(identity localizationTerminalIdentity) bool {
+	var marker localizationTerminalMarker
+	path := localizationTerminalMarkerPath(identity)
+	if !readLocalizationState(path, &marker) || !freshLocalizationTimestamp(path, marker.ObservedUnixNano) ||
+		marker.Version != localizationTerminalMarkerVersion ||
+		marker.ContractVersion < localizationTerminalContractV2 || marker.Identity != identity {
+		return false
+	}
+	return true
+}
+
+func writeLocalizationState(path string, value any) bool {
+	if path == "" {
+		return false
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return false
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return false
+	}
+	tmp, err := os.CreateTemp(dir, ".localization-terminal-*")
+	if err != nil {
+		return false
+	}
+	tmpPath := tmp.Name()
+	committed := false
+	defer func() {
+		_ = tmp.Close()
+		if !committed {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := tmp.Chmod(0o600); err != nil {
+		return false
+	}
+	if _, err := tmp.Write(data); err != nil {
+		return false
+	}
+	if err := tmp.Sync(); err != nil {
+		return false
+	}
+	if err := tmp.Close(); err != nil {
+		return false
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return false
+	}
+	committed = true
+	return true
+}
+
+// writeBoundedLocalizationState keeps transient marker/snapshot storage
+// bounded within one session+agent namespace. Lifecycle rotation removes the
+// entire namespace; this cap also handles missing PostToolUse/Stop callbacks.
+func writeBoundedLocalizationState(path string, value any) bool {
+	if !writeLocalizationState(path, value) {
+		return false
+	}
+	trimLocalizationStateDir(filepath.Dir(path), path)
+	return true
+}
+
+func trimLocalizationStateDir(dir, preserve string) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	type stateFile struct {
+		path    string
+		modTime time.Time
+	}
+	files := make([]stateFile, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		age := time.Since(info.ModTime())
+		if age < 0 || age > localizationTerminalMarkerTTL {
+			_ = os.Remove(path)
+			continue
+		}
+		files = append(files, stateFile{path: path, modTime: info.ModTime()})
+	}
+	if len(files) <= localizationTerminalPruneLimit {
+		return
+	}
+	sort.Slice(files, func(i, j int) bool {
+		if files[i].modTime.Equal(files[j].modTime) {
+			return files[i].path < files[j].path
+		}
+		return files[i].modTime.Before(files[j].modTime)
+	})
+	remove := len(files) - localizationTerminalPruneLimit
+	for _, file := range files {
+		if remove == 0 {
+			break
+		}
+		if file.path == preserve {
+			continue
+		}
+		if os.Remove(file.path) == nil {
+			remove--
+		}
+	}
+}
+
+// maintainLocalizationState bounds abandoned lifecycle namespaces in addition
+// to the transient files bounded above. The current session and agent are
+// always preserved. Under normal operation each creation can exceed a cap by
+// at most one, so one bounded janitor pass restores the hard cap immediately;
+// a pre-existing oversized cache converges by a fixed deletion budget.
+func maintainLocalizationState(base localizationTerminalBase) {
+	sessionDir := localizationSessionStateDir(base)
+	agentDir := localizationAgentStateDir(base)
+	if sessionDir == "" || agentDir == "" {
+		return
+	}
+	now := time.Now()
+	_ = os.Chtimes(sessionDir, now, now)
+	_ = os.Chtimes(agentDir, now, now)
+	pruneLocalizationTreeDir(filepath.Join(localizationTerminalRoot(), "sessions"), sessionDir, localizationTerminalSessionHardCap)
+	pruneLocalizationTreeDir(filepath.Join(sessionDir, "agents"), agentDir, localizationTerminalAgentHardCap)
+}
+
+func pruneLocalizationTreeDir(dir, preserve string, hardCap int) {
+	entries, err := os.ReadDir(dir)
+	if err != nil || hardCap < 1 {
+		return
+	}
+	trees := make([]os.DirEntry, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			trees = append(trees, entry)
+		}
+	}
+	if len(trees) == 0 {
+		return
+	}
+	scanLimit := hardCap + localizationTerminalJanitorDeletes + 1
+	if len(trees) < scanLimit {
+		scanLimit = len(trees)
+	}
+	type stateTree struct {
+		path    string
+		modTime time.Time
+	}
+	fresh := make([]stateTree, 0, scanLimit)
+	deleted := 0
+	now := time.Now()
+	for _, entry := range trees[:scanLimit] {
+		path := filepath.Join(dir, entry.Name())
+		if filepath.Clean(path) == filepath.Clean(preserve) {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		if now.Sub(info.ModTime()) > localizationTerminalMarkerTTL && deleted < localizationTerminalJanitorDeletes {
+			if os.RemoveAll(path) == nil {
+				deleted++
+			}
+			continue
+		}
+		fresh = append(fresh, stateTree{path: path, modTime: info.ModTime()})
+	}
+	overCap := len(trees) - deleted - hardCap
+	if overCap <= 0 || deleted >= localizationTerminalJanitorDeletes {
+		return
+	}
+	sort.Slice(fresh, func(i, j int) bool {
+		if fresh[i].modTime.Equal(fresh[j].modTime) {
+			return fresh[i].path < fresh[j].path
+		}
+		return fresh[i].modTime.Before(fresh[j].modTime)
+	})
+	for _, tree := range fresh {
+		if overCap == 0 || deleted >= localizationTerminalJanitorDeletes {
+			break
+		}
+		if os.RemoveAll(tree.path) == nil {
+			deleted++
+			overCap--
+		}
+	}
+}
+
+func readLocalizationState(path string, value any) bool {
+	if path == "" {
+		return false
+	}
+	data, err := os.ReadFile(path)
+	return err == nil && json.Unmarshal(data, value) == nil
+}
+
+func freshLocalizationTimestamp(path string, timestamp int64) bool {
+	if timestamp <= 0 {
+		return false
+	}
+	age := time.Since(time.Unix(0, timestamp))
+	if age < 0 || age > localizationTerminalMarkerTTL {
+		_ = os.Remove(path)
+		return false
+	}
+	return true
+}
+
+func clearLocalizationTerminalFromHook(data []byte) bool {
+	var input localizationTerminalHookInput
+	if err := json.Unmarshal(data, &input); err != nil {
+		return false
+	}
+	base, ok := localizationTerminalBaseFor(input.SessionID, input.AgentID, input.CWD)
+	if !ok {
+		return false
+	}
+	switch input.HookEventName {
+	case "UserPromptSubmit":
+		if strings.TrimSpace(input.AgentID) != "" {
+			return false
+		}
+		removed, _ := discardLocalizationStateTree(localizationAgentStateDir(base))
+		_, _ = beginLocalizationTurn(input.SessionID, input.PromptID, input.AgentID, input.CWD)
+		return removed
+	case "SessionStart":
+		path := localizationAgentStateDir(base)
+		if input.AgentID == "" {
+			path = localizationSessionStateDir(base)
+		}
+		removed, _ := discardLocalizationStateTree(path)
+		return removed
+	default:
+		return false
+	}
+}
+
+func beginLocalizationSubagentFromHook(data []byte) bool {
+	var input localizationTerminalHookInput
+	if err := json.Unmarshal(data, &input); err != nil || input.HookEventName != "SubagentStart" ||
+		strings.TrimSpace(input.SessionID) == "" || strings.TrimSpace(input.AgentID) == "" || strings.TrimSpace(input.CWD) == "" {
+		return false
+	}
+	base, ok := localizationTerminalBaseFor(input.SessionID, input.AgentID, input.CWD)
+	if !ok {
+		return false
+	}
+	_, _ = discardLocalizationStateTree(localizationAgentStateDir(base))
+	_, ok = beginLocalizationTurn(input.SessionID, input.PromptID, input.AgentID, input.CWD)
+	return ok
+}
+
+func endLocalizationSubagentFromHook(data []byte) bool {
+	var input localizationTerminalHookInput
+	if err := json.Unmarshal(data, &input); err != nil || input.HookEventName != "SubagentStop" ||
+		strings.TrimSpace(input.SessionID) == "" || strings.TrimSpace(input.AgentID) == "" || strings.TrimSpace(input.CWD) == "" {
+		return false
+	}
+	base, ok := localizationTerminalBaseFor(input.SessionID, input.AgentID, input.CWD)
+	if !ok {
+		return false
+	}
+	current, ok := currentLocalizationTurn(input.SessionID, input.PromptID, input.AgentID, input.CWD)
+	if !ok || current.PromptID != strings.TrimSpace(input.PromptID) {
+		return false
+	}
+	_, ok = discardLocalizationStateTree(localizationAgentStateDir(base))
+	return ok
+}
+
+// discardLocalizationStateTree removes one exact session or agent namespace.
+// Hash-derived paths make this both bounded and collision-resistant: cleanup
+// never scans unrelated sessions and cannot starve behind an arbitrary entry
+// limit. The bools report whether state existed and whether removal succeeded.
+func discardLocalizationStateTree(path string) (bool, bool) {
+	if path == "" {
+		return false, false
+	}
+	_, err := os.Stat(path)
+	existed := err == nil
+	if err != nil && !os.IsNotExist(err) {
+		return false, false
+	}
+	if err := os.RemoveAll(path); err != nil {
+		return existed, false
+	}
+	return existed, true
+}
+
+func canonicalLocalizationTerminalCWD(cwd string) string {
+	cwd = strings.TrimSpace(cwd)
+	if cwd == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(cwd)
+	if err != nil {
+		return filepath.Clean(cwd)
+	}
+	return filepath.Clean(abs)
+}
+
+func localizationTerminalTelemetry(event string, emitted bool, started time.Time) {
+	logHookEffectivenessUnknown(fmt.Sprintf("LocalizationTerminal.%s", event), emitted, 0, time.Since(started))
+}

--- a/internal/hooks/localization_terminal_test.go
+++ b/internal/hooks/localization_terminal_test.go
@@ -1,0 +1,821 @@
+package hooks
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestObserveLocalizationTerminalAcceptsDirectAndPluginNavigationFacades(t *testing.T) {
+	configureLocalizationTerminalTestHome(t)
+	prefixes := []string{gortexMCPToolPrefix, gortexPluginMCPToolPrefix}
+	operations := []string{"explore", "search", "read", "relations", "trace", "analyze"}
+	for _, prefix := range prefixes {
+		for _, operation := range operations {
+			tool := prefix + operation
+			t.Run(tool, func(t *testing.T) {
+				sessionID := strings.NewReplacer("/", "-", "_", "-").Replace(t.Name())
+				cwd := t.TempDir()
+				identity := beginTestLocalizationTurn(t, sessionID, "prompt-1", cwd)
+				toolUseID := "tool-1"
+				snapshotTestLocalizationTool(t, identity, tool, toolUseID)
+				data := localizationPostToolPayload(t, tool, toolUseID, identity, terminalToolResponse(t, terminalContractMap(), true, false))
+				if _, observed := observeLocalizationTerminal(data); !observed {
+					t.Fatalf("expected %s terminal contract to be observed", tool)
+				}
+			})
+		}
+	}
+}
+
+func TestObserveLocalizationTerminalRequiresExactEnforceableV2Contract(t *testing.T) {
+	configureLocalizationTerminalTestHome(t)
+	valid := terminalContractMap()
+	tests := []struct {
+		name   string
+		mutate func(map[string]any)
+	}{
+		{name: "v1", mutate: func(root map[string]any) { completionMap(root)["contract_version"] = 1 }},
+		{name: "advisory", mutate: func(root map[string]any) { completionMap(root)["enforceable"] = false }},
+		{name: "needs refinement", mutate: func(root map[string]any) { completionMap(root)["state"] = "needs_refinement" }},
+		{name: "wrong scope", mutate: func(root map[string]any) { completionMap(root)["scope"] = "diagnosis" }},
+		{name: "tool allowed", mutate: func(root map[string]any) { completionMap(root)["allowed_tool_calls"] = 1 }},
+		{name: "not terminal", mutate: func(root map[string]any) { root["terminal"] = false }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := cloneMap(t, valid)
+			tt.mutate(root)
+			identity := beginTestLocalizationTurn(t, t.Name(), "prompt", t.TempDir())
+			snapshotTestLocalizationTool(t, identity, gortexMCPToolPrefix+"read", "tool")
+			data := localizationPostToolPayload(t, gortexMCPToolPrefix+"read", "tool", identity, terminalToolResponse(t, root, true, false))
+			if _, observed := observeLocalizationTerminal(data); observed {
+				t.Fatal("unexpected terminal observation")
+			}
+		})
+	}
+}
+
+func TestObserveLocalizationTerminalRequiresMatchingAuthoritativeMeta(t *testing.T) {
+	configureLocalizationTerminalTestHome(t)
+	tests := []struct {
+		name     string
+		response func(*testing.T) map[string]any
+		want     bool
+	}{
+		{
+			name: "structured and matching meta",
+			response: func(t *testing.T) map[string]any {
+				return terminalToolResponse(t, terminalContractMap(), true, false)
+			},
+			want: true,
+		},
+		{
+			name: "exact text and matching meta",
+			response: func(t *testing.T) map[string]any {
+				return terminalToolResponse(t, terminalContractMap(), true, true)
+			},
+			want: true,
+		},
+		{
+			name: "meta stripped",
+			response: func(t *testing.T) map[string]any {
+				return terminalToolResponse(t, terminalContractMap(), false, false)
+			},
+		},
+		{
+			name: "repository text spoof",
+			response: func(t *testing.T) map[string]any {
+				contract := mustJSON(t, terminalContractMap())
+				return map[string]any{"content": []any{map[string]any{"type": "text", "text": string(contract)}}}
+			},
+		},
+		{
+			name: "prefixed text despite meta",
+			response: func(t *testing.T) map[string]any {
+				response := terminalToolResponse(t, terminalContractMap(), true, true)
+				blocks := response["content"].([]any)
+				blocks[0].(map[string]any)["text"] = "source prefix " + blocks[0].(map[string]any)["text"].(string)
+				return response
+			},
+		},
+		{
+			name: "meta mismatch",
+			response: func(t *testing.T) map[string]any {
+				response := terminalToolResponse(t, terminalContractMap(), true, false)
+				meta := response["_meta"].(map[string]any)
+				envelope := meta[localizationHostMetaKey].(map[string]any)
+				mismatched := cloneMap(t, terminalContractMap())
+				completionMap(mismatched)["allowed_tool_calls"] = 1
+				envelope["contract"] = mismatched
+				return response
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			identity := beginTestLocalizationTurn(t, t.Name(), "prompt", t.TempDir())
+			snapshotTestLocalizationTool(t, identity, gortexMCPToolPrefix+"read", "tool")
+			data := localizationPostToolPayload(t, gortexMCPToolPrefix+"read", "tool", identity, tt.response(t))
+			_, observed := observeLocalizationTerminal(data)
+			if observed != tt.want {
+				t.Fatalf("observed = %v, want %v", observed, tt.want)
+			}
+		})
+	}
+}
+
+func TestLocalizationTerminalHookFlowDeniesThenPromptRotatesTurn(t *testing.T) {
+	configureLocalizationTerminalTestHome(t)
+	sessionID := "terminal-flow"
+	cwd := t.TempDir()
+	identity := beginTestLocalizationTurn(t, sessionID, "prompt-1", cwd)
+	snapshotTestLocalizationTool(t, identity, gortexMCPToolPrefix+"read", "tool-1")
+
+	post := localizationPostToolPayload(t, gortexMCPToolPrefix+"read", "tool-1", identity, terminalToolResponse(t, terminalContractMap(), true, false))
+	postOutput := captureHookStdout(t, func() { runPostToolUse(post) })
+	if !strings.Contains(postOutput, localizationTerminalContext) {
+		t.Fatalf("PostToolUse output %q does not contain fixed terminal context", postOutput)
+	}
+
+	pre := preToolPayload(t, "WebSearch", "", identity, nil)
+	preOutput := captureHookStdout(t, func() { runPreToolUse(pre, 0, ModeDeny) })
+	var output HookOutput
+	if err := json.Unmarshal([]byte(preOutput), &output); err != nil {
+		t.Fatalf("decode PreToolUse output %q: %v", preOutput, err)
+	}
+	if output.HookSpecificOutput == nil || output.HookSpecificOutput.PermissionDecision != "deny" {
+		t.Fatalf("expected all-tool terminal deny, got %#v", output)
+	}
+
+	beginTestLocalizationTurn(t, sessionID, "prompt-2", cwd)
+	newTurn := currentTestLocalizationTurn(t, sessionID, "prompt-2", "", cwd)
+	newPre := preToolPayload(t, "WebSearch", "", newTurn, nil)
+	if got := captureHookStdout(t, func() { runPreToolUse(newPre, 0, ModeDeny) }); got != "" {
+		t.Fatalf("new prompt inherited terminal deny: %q", got)
+	}
+}
+
+func TestLocalizationTerminalDelayedPostCannotPoisonNewTurn(t *testing.T) {
+	configureLocalizationTerminalTestHome(t)
+	sessionID := "delayed-post"
+	cwd := t.TempDir()
+	oldTurn := beginTestLocalizationTurn(t, sessionID, "prompt-old", cwd)
+	snapshotTestLocalizationTool(t, oldTurn, gortexMCPToolPrefix+"explore", "old-tool")
+	newTurn := beginTestLocalizationTurn(t, sessionID, "prompt-new", cwd)
+
+	oldPost := localizationPostToolPayload(t, gortexMCPToolPrefix+"explore", "old-tool", oldTurn, terminalToolResponse(t, terminalContractMap(), true, true))
+	if _, observed := observeLocalizationTerminal(oldPost); observed {
+		t.Fatal("a snapshot cleared at the next UserPromptSubmit must not be consumed")
+	}
+	// Even if a PostToolUse process had already loaded its old snapshot before
+	// the prompt rotated, the marker key remains bound to the old turn token.
+	if !markLocalizationTerminal(oldTurn, localizationTerminalContractV2) {
+		t.Fatal("mark old turn")
+	}
+	if hasLocalizationTerminal(newTurn) {
+		t.Fatal("old-turn marker poisoned the new turn")
+	}
+	if got := captureHookStdout(t, func() {
+		runPreToolUse(preToolPayload(t, "WebSearch", "", newTurn, nil), 0, ModeDeny)
+	}); got != "" {
+		t.Fatalf("new turn was denied by delayed old PostToolUse: %q", got)
+	}
+}
+
+func TestLocalizationTerminalSeparatesParentAndSubagent(t *testing.T) {
+	configureLocalizationTerminalTestHome(t)
+	sessionID := "shared-session"
+	cwd := t.TempDir()
+	parent := beginTestLocalizationTurn(t, sessionID, "parent-prompt", cwd)
+	start := subagentLifecyclePayload(t, "SubagentStart", sessionID, "agent-7", cwd)
+	runSubagentStart(start)
+	subagent := currentTestLocalizationTurn(t, sessionID, "", "agent-7", cwd)
+	if !markLocalizationTerminal(parent, localizationTerminalContractV2) {
+		t.Fatal("mark parent")
+	}
+	if hasLocalizationTerminal(subagent) {
+		t.Fatal("parent marker leaked into subagent")
+	}
+	if got := captureHookStdout(t, func() {
+		runPreToolUse(preToolPayload(t, "WebSearch", "", subagent, nil), 0, ModeDeny)
+	}); got != "" {
+		t.Fatalf("subagent was denied by parent marker: %q", got)
+	}
+	if got := captureHookStdout(t, func() {
+		runPreToolUse(preToolPayload(t, "WebSearch", "", parent, nil), 0, ModeDeny)
+	}); !strings.Contains(got, `"permissionDecision":"deny"`) {
+		t.Fatalf("parent marker did not deny parent tool: %q", got)
+	}
+}
+
+func TestLocalizationTerminalSubagentLifecycleDelayedPostAndAgentIDReuse(t *testing.T) {
+	configureLocalizationTerminalTestHome(t)
+	sessionID := "subagent-reuse"
+	agentID := "agent-7"
+	cwd := t.TempDir()
+	start := subagentLifecyclePayload(t, "SubagentStart", sessionID, agentID, cwd)
+	stop := subagentLifecyclePayload(t, "SubagentStop", sessionID, agentID, cwd)
+	runSubagentStart(start)
+	oldTurn := currentTestLocalizationTurn(t, sessionID, "", agentID, cwd)
+	snapshotTestLocalizationTool(t, oldTurn, gortexMCPToolPrefix+"explore", "old-tool")
+
+	runSubagentStop(stop)
+	if _, ok := currentLocalizationTurn(sessionID, "", agentID, cwd); ok {
+		t.Fatal("SubagentStop retained the old agent turn")
+	}
+	runSubagentStart(start)
+	newTurn := currentTestLocalizationTurn(t, sessionID, "", agentID, cwd)
+	if newTurn.TurnToken == oldTurn.TurnToken {
+		t.Fatal("reused agent_id did not receive a fresh turn token")
+	}
+
+	oldPost := localizationPostToolPayload(t, gortexMCPToolPrefix+"explore", "old-tool", oldTurn, terminalToolResponse(t, terminalContractMap(), true, false))
+	if _, observed := observeLocalizationTerminal(oldPost); observed {
+		t.Fatal("delayed PostToolUse consumed state from the prior agent lifetime")
+	}
+	// A PostToolUse that loaded its snapshot just before Stop can still finish,
+	// but its old token must remain inert after agent_id reuse.
+	if !markLocalizationTerminal(oldTurn, localizationTerminalContractV2) {
+		t.Fatal("simulate delayed old marker")
+	}
+	if hasLocalizationTerminal(newTurn) {
+		t.Fatal("old agent-lifetime marker poisoned reused agent_id")
+	}
+}
+
+func TestLocalizationTerminalSubagentPromptIDFlowsThroughStartPrePostStop(t *testing.T) {
+	configureLocalizationTerminalTestHome(t)
+	sessionID := "subagent-prompt"
+	agentID := "agent-prompt"
+	promptID := "prompt-42"
+	cwd := t.TempDir()
+	start := subagentLifecyclePayloadWithPrompt(t, "SubagentStart", sessionID, agentID, promptID, cwd)
+	runSubagentStart(start)
+	identity := currentTestLocalizationTurn(t, sessionID, promptID, agentID, cwd)
+	if identity.PromptID != promptID {
+		t.Fatalf("stored prompt_id = %q, want %q", identity.PromptID, promptID)
+	}
+
+	tool := gortexPluginMCPToolPrefix + "read"
+	toolUseID := "prompt-tool"
+	pre := preToolPayload(t, tool, toolUseID, identity, map[string]any{
+		"operation": "summary",
+		"target":    map[string]any{"file": "internal/hooks/pretooluse.go"},
+	})
+	_ = captureHookStdout(t, func() { runPreToolUse(pre, 0, ModeDeny) })
+	post := localizationPostToolPayload(t, tool, toolUseID, identity, terminalToolResponse(t, terminalContractMap(), true, false))
+	if got := captureHookStdout(t, func() { runPostToolUse(post) }); !strings.Contains(got, localizationTerminalContext) {
+		t.Fatalf("PostToolUse did not observe prompt-scoped terminal result: %q", got)
+	}
+	if !hasLocalizationTerminal(identity) {
+		t.Fatal("prompt-scoped terminal marker was not persisted")
+	}
+
+	stop := subagentLifecyclePayloadWithPrompt(t, "SubagentStop", sessionID, agentID, promptID, cwd)
+	runSubagentStop(stop)
+	if _, ok := currentLocalizationTurn(sessionID, promptID, agentID, cwd); ok {
+		t.Fatal("SubagentStop retained prompt-scoped state")
+	}
+}
+
+func TestLocalizationTerminalDelayedSubagentStopCannotDeleteNewPrompt(t *testing.T) {
+	configureLocalizationTerminalTestHome(t)
+	sessionID := "subagent-delayed-stop"
+	agentID := "reused-agent"
+	cwd := t.TempDir()
+
+	oldPromptID := "prompt-old"
+	runSubagentStart(subagentLifecyclePayloadWithPrompt(t, "SubagentStart", sessionID, agentID, oldPromptID, cwd))
+	oldIdentity := currentTestLocalizationTurn(t, sessionID, oldPromptID, agentID, cwd)
+
+	newPromptID := "prompt-new"
+	runSubagentStart(subagentLifecyclePayloadWithPrompt(t, "SubagentStart", sessionID, agentID, newPromptID, cwd))
+	newIdentity := currentTestLocalizationTurn(t, sessionID, newPromptID, agentID, cwd)
+	if oldIdentity.TurnToken == newIdentity.TurnToken {
+		t.Fatal("reused agent retained the prior prompt turn token")
+	}
+
+	runSubagentStop(subagentLifecyclePayloadWithPrompt(t, "SubagentStop", sessionID, agentID, oldPromptID, cwd))
+	current := currentTestLocalizationTurn(t, sessionID, newPromptID, agentID, cwd)
+	if current.TurnToken != newIdentity.TurnToken {
+		t.Fatalf("delayed SubagentStop changed current turn token: got %q, want %q", current.TurnToken, newIdentity.TurnToken)
+	}
+}
+
+func TestLocalizationSubagentLifecycleRequiresFullIdentity(t *testing.T) {
+	configureLocalizationTerminalTestHome(t)
+	for _, event := range []string{"SubagentStart", "SubagentStop"} {
+		for _, missing := range []string{"session_id", "agent_id", "cwd"} {
+			t.Run(event+"/missing_"+missing, func(t *testing.T) {
+				payload := map[string]any{
+					"hook_event_name": event,
+					"session_id":      "session",
+					"agent_id":        "agent",
+					"cwd":             t.TempDir(),
+				}
+				delete(payload, missing)
+				data := mustJSON(t, payload)
+				if event == "SubagentStart" && beginLocalizationSubagentFromHook(data) {
+					t.Fatal("incomplete SubagentStart identity was accepted")
+				}
+				if event == "SubagentStop" && endLocalizationSubagentFromHook(data) {
+					t.Fatal("incomplete SubagentStop identity was accepted")
+				}
+			})
+		}
+	}
+}
+
+func TestLocalizationUserPromptSubmitCannotFabricateSubagentTurn(t *testing.T) {
+	configureLocalizationTerminalTestHome(t)
+	cwd := t.TempDir()
+	payload := mustJSON(t, map[string]any{
+		"hook_event_name": "UserPromptSubmit",
+		"session_id":      "session",
+		"agent_id":        "agent",
+		"cwd":             cwd,
+		"prompt":          "not a real subagent lifecycle event",
+	})
+	if clearLocalizationTerminalFromHook(payload) {
+		t.Fatal("UserPromptSubmit with agent_id must not initialize subagent state")
+	}
+	if _, ok := currentLocalizationTurn("session", "", "agent", cwd); ok {
+		t.Fatal("fabricated UserPromptSubmit initialized subagent state")
+	}
+}
+
+func TestLocalizationStateIsBoundedAndResetPerAgent(t *testing.T) {
+	configureLocalizationTerminalTestHome(t)
+	sessionID := "bounded-state"
+	agentID := "agent-a"
+	cwd := t.TempDir()
+	start := subagentLifecyclePayload(t, "SubagentStart", sessionID, agentID, cwd)
+	if !beginLocalizationSubagentFromHook(start) {
+		t.Fatal("SubagentStart failed")
+	}
+	turn := currentTestLocalizationTurn(t, sessionID, "", agentID, cwd)
+	base, ok := localizationTerminalBaseFor(sessionID, agentID, cwd)
+	if !ok {
+		t.Fatal("base")
+	}
+	snapshotDir := filepath.Join(localizationAgentStateDir(base), "snapshots")
+	for i := 0; i < localizationTerminalPruneLimit+32; i++ {
+		path := filepath.Join(snapshotDir, fmt.Sprintf("%064x.json", i))
+		if !writeLocalizationState(path, localizationToolSnapshot{
+			Version: localizationTerminalMarkerVersion, Identity: turn, CreatedUnixNano: time.Now().UnixNano(),
+		}) {
+			t.Fatalf("seed snapshot %d", i)
+		}
+	}
+	preserved := filepath.Join(snapshotDir, strings.Repeat("f", sha256HexLength)+".json")
+	if !writeBoundedLocalizationState(preserved, localizationToolSnapshot{
+		Version: localizationTerminalMarkerVersion, Identity: turn, CreatedUnixNano: time.Now().UnixNano(),
+	}) {
+		t.Fatal("bounded write")
+	}
+	entries, err := os.ReadDir(snapshotDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) > localizationTerminalPruneLimit {
+		t.Fatalf("snapshot state remained unbounded: %d", len(entries))
+	}
+	if _, err := os.Stat(preserved); err != nil {
+		t.Fatalf("current snapshot was not preserved: %v", err)
+	}
+
+	if !beginLocalizationSubagentFromHook(start) {
+		t.Fatal("agent reset failed")
+	}
+	if _, err := os.Stat(snapshotDir); !os.IsNotExist(err) {
+		t.Fatalf("agent reset did not remove all per-agent snapshots: %v", err)
+	}
+}
+
+func TestLocalizationStateJanitorCleansAbandonedSessionsAndMissingStops(t *testing.T) {
+	configureLocalizationTerminalTestHome(t)
+	cwd := t.TempDir()
+
+	// Session A leaves agent-1 behind without SubagentStop. A later lifecycle
+	// creation in the same session must remove the stale agent tree.
+	beginTestLocalizationSubagentTurn(t, "session-a", "agent-1", cwd)
+	baseA1, _ := localizationTerminalBaseFor("session-a", "agent-1", cwd)
+	agentA1 := localizationAgentStateDir(baseA1)
+	stale := time.Now().Add(-localizationTerminalMarkerTTL - time.Minute)
+	if err := os.Chtimes(agentA1, stale, stale); err != nil {
+		t.Fatal(err)
+	}
+	beginTestLocalizationSubagentTurn(t, "session-a", "agent-2", cwd)
+	if _, err := os.Stat(agentA1); !os.IsNotExist(err) {
+		t.Fatalf("missing-Stop agent tree survived TTL janitor: %v", err)
+	}
+
+	// Keep an independent session live, then age the whole abandoned session.
+	liveB := beginTestLocalizationTurn(t, "session-b", "prompt-b", cwd)
+	sessionA := localizationSessionStateDir(baseA1)
+	if err := os.Chtimes(sessionA, stale, stale); err != nil {
+		t.Fatal(err)
+	}
+	beginTestLocalizationTurn(t, "session-c", "prompt-c", cwd)
+	if _, err := os.Stat(sessionA); !os.IsNotExist(err) {
+		t.Fatalf("abandoned session tree survived global TTL janitor: %v", err)
+	}
+	if current, ok := currentLocalizationTurn(liveB.SessionID, liveB.PromptID, liveB.AgentID, liveB.CWD); !ok || current != liveB {
+		t.Fatal("global janitor removed an independent live session")
+	}
+}
+
+func TestLocalizationStateJanitorEnforcesSessionAndAgentHardCaps(t *testing.T) {
+	configureLocalizationTerminalTestHome(t)
+	cwd := t.TempDir()
+	identity := beginTestLocalizationTurn(t, "cap-session", "prompt", cwd)
+	base, _ := localizationTerminalBaseFor(identity.SessionID, identity.AgentID, identity.CWD)
+
+	sessionsDir := filepath.Join(localizationTerminalRoot(), "sessions")
+	for i := 0; i < localizationTerminalSessionHardCap+5; i++ {
+		if err := os.MkdirAll(filepath.Join(sessionsDir, fmt.Sprintf("dummy-session-%03d", i)), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	maintainLocalizationState(base)
+	if got := countStateTreeDirs(t, sessionsDir); got > localizationTerminalSessionHardCap {
+		t.Fatalf("session trees = %d, hard cap = %d", got, localizationTerminalSessionHardCap)
+	}
+
+	agentsDir := filepath.Join(localizationSessionStateDir(base), "agents")
+	for i := 0; i < localizationTerminalAgentHardCap+5; i++ {
+		if err := os.MkdirAll(filepath.Join(agentsDir, fmt.Sprintf("dummy-agent-%03d", i)), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	maintainLocalizationState(base)
+	if got := countStateTreeDirs(t, agentsDir); got > localizationTerminalAgentHardCap {
+		t.Fatalf("agent trees = %d, hard cap = %d", got, localizationTerminalAgentHardCap)
+	}
+}
+
+func TestLocalizationTerminalMissingTurnOrToolUseIDFailsOpen(t *testing.T) {
+	configureLocalizationTerminalTestHome(t)
+	cwd := t.TempDir()
+	identity := localizationTerminalIdentity{SessionID: "missing", CWD: cwd, TurnToken: "not-installed"}
+	if got := captureHookStdout(t, func() {
+		runPreToolUse(preToolPayload(t, "WebSearch", "", identity, nil), 0, ModeDeny)
+	}); got != "" {
+		t.Fatalf("missing UserPromptSubmit must not deny: %q", got)
+	}
+	post := localizationPostToolPayload(t, gortexMCPToolPrefix+"read", "", identity, terminalToolResponse(t, terminalContractMap(), true, false))
+	if _, observed := observeLocalizationTerminal(post); observed {
+		t.Fatal("PostToolUse without tool_use_id snapshot must fail open")
+	}
+}
+
+func TestRunPreToolUseSnapshotsDocumentedToolUseID(t *testing.T) {
+	configureLocalizationTerminalTestHome(t)
+	identity := beginTestLocalizationTurn(t, "pre-snapshot", "", t.TempDir())
+	tool := gortexPluginMCPToolPrefix + "read"
+	pre := preToolPayload(t, tool, "tool-use-1", identity, map[string]any{
+		"operation": "summary",
+		"target":    map[string]any{"file": "internal/hooks/pretooluse.go"},
+	})
+	_ = captureHookStdout(t, func() { runPreToolUse(pre, 0, ModeDeny) })
+	post := localizationPostToolPayload(t, tool, "tool-use-1", identity, terminalToolResponse(t, terminalContractMap(), true, false))
+	if _, observed := observeLocalizationTerminal(post); !observed {
+		t.Fatal("production PreToolUse did not persist the tool_use_id snapshot")
+	}
+}
+
+func TestPreToolUseUnrelatedToolWithoutTurnIsStrictLocalNoOp(t *testing.T) {
+	configureLocalizationTerminalTestHome(t)
+	originalReachable := daemonReachableFn
+	probes := 0
+	daemonReachableFn = func() bool {
+		probes++
+		return true
+	}
+	t.Cleanup(func() { daemonReachableFn = originalReachable })
+
+	identity := localizationTerminalIdentity{SessionID: "no-marker", CWD: t.TempDir()}
+	output := captureHookStdout(t, func() {
+		runPreToolUse(preToolPayload(t, "WebSearch", "", identity, nil), 0, ModeDeny)
+	})
+	if output != "" {
+		t.Fatalf("unrelated marker-absent tool emitted %q", output)
+	}
+	if probes != 0 {
+		t.Fatalf("unrelated marker-absent tool made %d daemon reachability probe(s)", probes)
+	}
+}
+
+func TestLocalizationTerminalMarkerUsesFullHashAndAtomicConcurrentWrites(t *testing.T) {
+	configureLocalizationTerminalTestHome(t)
+	identity := beginTestLocalizationSubagentTurn(t, "terminal-race", "agent", t.TempDir())
+	base := strings.TrimSuffix(filepath.Base(localizationTerminalMarkerPath(identity)), ".json")
+	if len(base) != sha256HexLength || strings.Trim(base, "0123456789abcdef") != "" {
+		t.Fatalf("marker basename is not a full SHA-256 hex digest: %q", base)
+	}
+
+	const workers = 32
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if !markLocalizationTerminal(identity, localizationTerminalContractV2) {
+				t.Errorf("markLocalizationTerminal failed")
+			}
+			_ = hasLocalizationTerminal(identity)
+		}()
+	}
+	wg.Wait()
+	if !hasLocalizationTerminal(identity) {
+		t.Fatal("expected a complete marker after concurrent writers")
+	}
+}
+
+func TestLocalizationTerminalMarkerRejectsStaleAndWrongIdentity(t *testing.T) {
+	configureLocalizationTerminalTestHome(t)
+	identity := beginTestLocalizationSubagentTurn(t, "terminal-stale", "agent-a", t.TempDir())
+	if !markLocalizationTerminal(identity, localizationTerminalContractV2) {
+		t.Fatal("markLocalizationTerminal failed")
+	}
+	wrong := identity
+	wrong.AgentID = "agent-b"
+	if hasLocalizationTerminal(wrong) {
+		t.Fatal("marker must be scoped to the full identity")
+	}
+
+	path := localizationTerminalMarkerPath(identity)
+	marker := localizationTerminalMarker{
+		Version:          localizationTerminalMarkerVersion,
+		ContractVersion:  localizationTerminalContractV2,
+		Identity:         identity,
+		ObservedUnixNano: time.Now().Add(-localizationTerminalMarkerTTL - time.Minute).UnixNano(),
+	}
+	if !writeLocalizationState(path, marker) {
+		t.Fatal("write stale marker")
+	}
+	if hasLocalizationTerminal(identity) {
+		t.Fatal("stale marker must fail open")
+	}
+}
+
+func TestLocalizationTerminalTelemetryEventsReachProductionLog(t *testing.T) {
+	configureLocalizationTerminalTestHome(t)
+	path := filepath.Join(t.TempDir(), "effectiveness.jsonl")
+	t.Setenv("GORTEX_HOOK_EFFECTIVENESS_LOG", path)
+	want := []string{"observed", "denied", "cleared_prompt", "cleared_session"}
+	for _, event := range want {
+		localizationTerminalTelemetry(event, true, time.Now())
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != len(want) {
+		t.Fatalf("telemetry records = %d, want %d: %q", len(lines), len(want), data)
+	}
+	for i, line := range lines {
+		var record hookEffectiveness
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("record %d: %v", i, err)
+		}
+		if record.Event != "LocalizationTerminal."+want[i] {
+			t.Fatalf("record %d event = %q", i, record.Event)
+		}
+		var raw map[string]any
+		if err := json.Unmarshal([]byte(line), &raw); err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := raw["daemon_reachable"]; ok {
+			t.Fatalf("record %d falsely reported daemon reachability: %s", i, line)
+		}
+	}
+}
+
+func BenchmarkPreToolUseUnrelatedWithoutTurn(b *testing.B) {
+	home := b.TempDir()
+	b.Setenv("HOME", home)
+	b.Setenv("XDG_CACHE_HOME", home)
+	identity := localizationTerminalIdentity{SessionID: "benchmark", CWD: home}
+	data := preToolPayloadB(b, "WebSearch", "", identity, nil)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		runPreToolUse(data, 0, ModeDeny)
+	}
+}
+
+const sha256HexLength = 64
+
+func beginTestLocalizationTurn(t *testing.T, sessionID, promptID, cwd string) localizationTerminalIdentity {
+	t.Helper()
+	payload := mustJSON(t, map[string]any{
+		"hook_event_name": "UserPromptSubmit",
+		"session_id":      sessionID,
+		"prompt_id":       promptID,
+		"cwd":             cwd,
+		"prompt":          "test prompt",
+	})
+	_ = clearLocalizationTerminalFromHook(payload)
+	return currentTestLocalizationTurn(t, sessionID, promptID, "", cwd)
+}
+
+func beginTestLocalizationSubagentTurn(t *testing.T, sessionID, agentID, cwd string) localizationTerminalIdentity {
+	t.Helper()
+	if !beginLocalizationSubagentFromHook(subagentLifecyclePayload(t, "SubagentStart", sessionID, agentID, cwd)) {
+		t.Fatal("SubagentStart failed")
+	}
+	return currentTestLocalizationTurn(t, sessionID, "", agentID, cwd)
+}
+
+func subagentLifecyclePayload(t *testing.T, event, sessionID, agentID, cwd string) []byte {
+	t.Helper()
+	return subagentLifecyclePayloadWithPrompt(t, event, sessionID, agentID, "", cwd)
+}
+
+func subagentLifecyclePayloadWithPrompt(t *testing.T, event, sessionID, agentID, promptID, cwd string) []byte {
+	t.Helper()
+	return mustJSON(t, map[string]any{
+		"hook_event_name": event,
+		"session_id":      sessionID,
+		"agent_id":        agentID,
+		"prompt_id":       promptID,
+		"cwd":             cwd,
+	})
+}
+
+func countStateTreeDirs(t *testing.T, dir string) int {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	count := 0
+	for _, entry := range entries {
+		if entry.IsDir() {
+			count++
+		}
+	}
+	return count
+}
+
+func currentTestLocalizationTurn(t *testing.T, sessionID, promptID, agentID, cwd string) localizationTerminalIdentity {
+	t.Helper()
+	identity, ok := currentLocalizationTurn(sessionID, promptID, agentID, cwd)
+	if !ok {
+		t.Fatal("currentLocalizationTurn failed")
+	}
+	return identity
+}
+
+func snapshotTestLocalizationTool(t *testing.T, identity localizationTerminalIdentity, tool, toolUseID string) {
+	t.Helper()
+	if !snapshotLocalizationToolUse(HookInput{
+		HookEventName: "PreToolUse",
+		ToolName:      tool,
+		ToolUseID:     toolUseID,
+		SessionID:     identity.SessionID,
+		PromptID:      identity.PromptID,
+		AgentID:       identity.AgentID,
+		CWD:           identity.CWD,
+	}, identity) {
+		t.Fatal("snapshotLocalizationToolUse failed")
+	}
+}
+
+func localizationPostToolPayload(t *testing.T, tool, toolUseID string, identity localizationTerminalIdentity, response map[string]any) []byte {
+	t.Helper()
+	return mustJSON(t, map[string]any{
+		"hook_event_name": "PostToolUse",
+		"tool_name":       tool,
+		"tool_use_id":     toolUseID,
+		"session_id":      identity.SessionID,
+		"prompt_id":       identity.PromptID,
+		"agent_id":        identity.AgentID,
+		"cwd":             identity.CWD,
+		"tool_response":   response,
+	})
+}
+
+func terminalToolResponse(t *testing.T, contract map[string]any, withMeta, text bool) map[string]any {
+	t.Helper()
+	response := make(map[string]any)
+	if text {
+		response["content"] = []any{map[string]any{"type": "text", "text": string(mustJSON(t, contract))}}
+	} else {
+		response["structuredContent"] = contract
+	}
+	if withMeta {
+		response["_meta"] = map[string]any{
+			localizationHostMetaKey: map[string]any{
+				"version":  localizationTerminalHostMetaVersion,
+				"contract": cloneMap(t, contract),
+				"evidence": []any{map[string]any{"file": "repo/source.go", "id": "repo/source.go::Target"}},
+			},
+		}
+	}
+	return response
+}
+
+func preToolPayload(t *testing.T, tool, toolUseID string, identity localizationTerminalIdentity, input map[string]any) []byte {
+	t.Helper()
+	return preToolPayloadB(t, tool, toolUseID, identity, input)
+}
+
+type jsonTestHelper interface {
+	Helper()
+	Fatal(...any)
+}
+
+func preToolPayloadB(tb jsonTestHelper, tool, toolUseID string, identity localizationTerminalIdentity, input map[string]any) []byte {
+	tb.Helper()
+	if input == nil {
+		input = map[string]any{}
+	}
+	data, err := json.Marshal(map[string]any{
+		"hook_event_name": "PreToolUse",
+		"tool_name":       tool,
+		"tool_use_id":     toolUseID,
+		"tool_input":      input,
+		"session_id":      identity.SessionID,
+		"prompt_id":       identity.PromptID,
+		"agent_id":        identity.AgentID,
+		"cwd":             identity.CWD,
+	})
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return data
+}
+
+func terminalContractMap() map[string]any {
+	return map[string]any{
+		"completion": map[string]any{
+			"state":              "answer_ready",
+			"scope":              "localization",
+			"required_action":    "respond",
+			"allowed_tool_calls": 0,
+			"contract_version":   localizationTerminalContractV2,
+			"enforceable":        true,
+		},
+		"terminal": true,
+	}
+}
+
+func completionMap(root map[string]any) map[string]any {
+	return root["completion"].(map[string]any)
+}
+
+func cloneMap(t *testing.T, in map[string]any) map[string]any {
+	t.Helper()
+	data := mustJSON(t, in)
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+func mustJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func configureLocalizationTerminalTestHome(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CACHE_HOME", home)
+}
+
+func captureHookStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	original := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = writer
+	defer func() { os.Stdout = original }()
+	fn()
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}

--- a/internal/hooks/posttooluse.go
+++ b/internal/hooks/posttooluse.go
@@ -54,9 +54,21 @@ func runPostToolUse(data []byte) {
 		return
 	}
 	emitted := false
+	terminalObserved := false
 	defer func() {
+		if terminalObserved {
+			localizationTerminalTelemetry("observed", emitted, started)
+			return
+		}
 		logHookEffectiveness("PostToolUse", emitted, daemonReachableFn(), 0, time.Since(started))
 	}()
+
+	if _, observed := observeLocalizationTerminal(data); observed {
+		terminalObserved = true
+		emitted = true
+		emitPostToolContext(localizationTerminalContext, false)
+		return
+	}
 
 	ctx := postToolContext(input)
 	if ctx == "" {

--- a/internal/hooks/pretooluse.go
+++ b/internal/hooks/pretooluse.go
@@ -21,10 +21,18 @@ type HookInput struct {
 	HookEventName string         `json:"hook_event_name"`
 	ToolName      string         `json:"tool_name"`
 	ToolInput     map[string]any `json:"tool_input"`
+	ToolUseID     string         `json:"tool_use_id"`
 	CWD           string         `json:"cwd"`
 	// SessionID identifies the Claude Code session. Used to key the
 	// per-session state store (consult-unlock marker, nudge streak).
 	SessionID string `json:"session_id"`
+	// PromptID is accepted when a host supplies it. Current Claude Code hook
+	// schemas guarantee tool_use_id instead, so terminal state primarily uses
+	// the per-turn token correlated through that field.
+	PromptID string `json:"prompt_id"`
+	// AgentID is present inside subagents and isolates their terminal state from
+	// the parent agent sharing the same Claude session.
+	AgentID string `json:"agent_id"`
 	// PermissionMode is the host's active permission posture
 	// ("default" / "acceptEdits" / "plan" / "bypassPermissions" / "auto").
 	// Drives the auto-approve branch for Gortex's own MCP tools.
@@ -91,12 +99,41 @@ func runPreToolUse(data []byte, gortexPort int, mode Mode) {
 	if input.HookEventName != "PreToolUse" {
 		return
 	}
+
+	// Terminal enforcement is deliberately the first policy branch. It is a
+	// local marker lookup, so it neither waits for the daemon nor gets bypassed
+	// by permissive permission modes. A new user prompt clears the marker.
+	terminalIdentity, terminalTurnReady := currentLocalizationTurn(input.SessionID, input.PromptID, input.AgentID, input.CWD)
+	if terminalTurnReady && hasLocalizationTerminal(terminalIdentity) {
+		emitPreToolUse(HookOutput{HookSpecificOutput: &HookSpecificOutput{
+			HookEventName:            "PreToolUse",
+			PermissionDecision:       "deny",
+			PermissionDecisionReason: localizationTerminalDenyReason,
+		}})
+		localizationTerminalTelemetry("denied", true, started)
+		return
+	}
+	if terminalTurnReady {
+		// Correlate the current turn with this exact tool invocation. PostToolUse
+		// consumes the snapshot, so a delayed result from a previous turn cannot
+		// arm the new turn's marker.
+		_ = snapshotLocalizationToolUse(input, terminalIdentity)
+	}
+
+	// The installed matcher is deliberately broad so terminal state can stop
+	// any tool. With no marker, tools outside the historical access-policy
+	// matcher must be an immediate no-op: no daemon probe, classification,
+	// enrichment, or telemetry I/O.
+	if !preToolUsePolicyTool(input.ToolName) {
+		return
+	}
+
 	emitted := false
 	defer func() {
 		logHookEffectiveness("PreToolUse", emitted, daemonReachableFn(), hookAlternationSegmentCount(input), time.Since(started))
 	}()
 
-	isGortexMCP := strings.HasPrefix(input.ToolName, gortexMCPToolPrefix)
+	isGortexMCP := isGortexMCPToolName(input.ToolName)
 
 	// Auto-approve: under a permissive permission mode the host has
 	// already granted blanket approval, so Gortex's own MCP tools

--- a/internal/hooks/sessionstart.go
+++ b/internal/hooks/sessionstart.go
@@ -45,9 +45,13 @@ func runSessionStart(data []byte) {
 	if input.HookEventName != "SessionStart" {
 		return
 	}
+	clearedTerminal := clearLocalizationTerminalFromHook(data)
 	emitted := false
 	defer func() {
 		logHookEffectiveness("SessionStart", emitted, daemonReachableFn(), 0, time.Since(started))
+		if clearedTerminal {
+			localizationTerminalTelemetry("cleared_session", true, started)
+		}
 	}()
 
 	ctx := buildSessionStartBriefing(input.CWD)

--- a/internal/hooks/sessionstart.go
+++ b/internal/hooks/sessionstart.go
@@ -293,8 +293,13 @@ func hasPathPrefix(path, prefix string) bool {
 // — this is just enough that an agent in the very first turn knows
 // to reach for graph tools first.
 func rulePreamble() string {
-	return "**Rule:** Call `explore` first for every code task. Inspect indexed code with `search`, `read`, `relations`, or `trace`. Use native read, search, or edit tools only when Gortex performance or integration is bad. " +
-		"Before mutation call `change(operation:\"impact\")`; for a signature change also call `change(operation:\"verify\")` with the proposed signature. Mutate with `edit` or `refactor`. After mutation call `change(operation:\"detect\")`; use the returned symbol IDs with `change` operations `tests`, `guards`, and `contract`. " +
+	return "**Rule:** Call `explore` first for every code task (you're not oblicated to call `explore` if the given task is not related to the code). " +
+		"Inspect indexed code with `search`, `read`, `relations`, or `trace`. " +
+		"Use native read, search, or edit tools only when Gortex performance or integration is bad. " +
+		"Before mutation call `change(operation:\"impact\")`; " +
+		"for a signature change also call `change(operation:\"verify\")` with the proposed signature. " +
+		"Mutate with `edit` or `refactor`. After mutation call `change(operation:\"detect\")`; " +
+		"use the returned symbol IDs with `change` operations `tests`, `guards`, and `contract`. " +
 		"Call `capabilities` only when exact operation fields are unknown.\n" +
 		toolref.MCPRequiredLine()
 }

--- a/internal/hooks/subagent_lifecycle.go
+++ b/internal/hooks/subagent_lifecycle.go
@@ -1,0 +1,21 @@
+package hooks
+
+import "time"
+
+// runSubagentStart establishes an agent-scoped turn. Claude subagents do not
+// receive UserPromptSubmit, so this lifecycle hook is their authoritative turn
+// boundary. Missing identity fields fail open and emit no hook output.
+func runSubagentStart(data []byte) {
+	started := time.Now()
+	_ = beginLocalizationSubagentFromHook(data)
+	logHookEffectivenessUnknown("SubagentStart", false, 0, time.Since(started))
+}
+
+// runSubagentStop removes the exact agent namespace. A delayed PostToolUse may
+// still finish afterward, but its old token cannot match a future reused
+// agent_id, whose SubagentStart always rotates the namespace first.
+func runSubagentStop(data []byte) {
+	started := time.Now()
+	_ = endLocalizationSubagentFromHook(data)
+	logHookEffectivenessUnknown("SubagentStop", false, 0, time.Since(started))
+}

--- a/internal/hooks/telemetry.go
+++ b/internal/hooks/telemetry.go
@@ -38,21 +38,25 @@ type hookEffectiveness struct {
 	Timestamp           string `json:"ts"`
 	Event               string `json:"event"`
 	EmittedContext      bool   `json:"emitted_context"`
-	DaemonReachable     bool   `json:"daemon_reachable"`
+	DaemonReachable     *bool  `json:"daemon_reachable,omitempty"`
 	AlternationSegments int    `json:"alternation_segments"`
 	DurationMS          int64  `json:"duration_ms"`
 }
 
 var hookEffectivenessEvents = map[string]bool{
-	"PostToolUse":      true,
-	"PreToolUse":       true,
-	"SessionStart":     true,
-	"UserPromptSubmit": true,
-	"PreCompact":       true,
-	"PostCompact":      true,
-	"Stop":             true,
-	"SubagentStart":    true,
-	"SubagentStop":     true,
+	"PostToolUse":                          true,
+	"PreToolUse":                           true,
+	"SessionStart":                         true,
+	"UserPromptSubmit":                     true,
+	"PreCompact":                           true,
+	"PostCompact":                          true,
+	"Stop":                                 true,
+	"SubagentStart":                        true,
+	"SubagentStop":                         true,
+	"LocalizationTerminal.observed":        true,
+	"LocalizationTerminal.denied":          true,
+	"LocalizationTerminal.cleared_prompt":  true,
+	"LocalizationTerminal.cleared_session": true,
 }
 
 // hookDecisionsPath returns the telemetry file path. Respects GORTEX_HOOK_LOG
@@ -106,6 +110,17 @@ func logHookDecision(tool, _ string, decision DecisionKind, hits int, dur time.D
 // capped to prevent an adversarial regex from becoming a high-cardinality
 // metric; values above the probe ceiling share the same overflow bucket.
 func logHookEffectiveness(event string, emitted, reachable bool, alternationSegments int, dur time.Duration) {
+	logHookEffectivenessReachability(event, emitted, &reachable, alternationSegments, dur)
+}
+
+// logHookEffectivenessUnknown records hooks that deliberately perform no
+// daemon I/O. Omitting reachability avoids turning local lifecycle/terminal
+// decisions into false daemon-down samples.
+func logHookEffectivenessUnknown(event string, emitted bool, alternationSegments int, dur time.Duration) {
+	logHookEffectivenessReachability(event, emitted, nil, alternationSegments, dur)
+}
+
+func logHookEffectivenessReachability(event string, emitted bool, reachable *bool, alternationSegments int, dur time.Duration) {
 	if !hookEffectivenessEvents[event] {
 		return
 	}

--- a/internal/hooks/telemetry_effectiveness_test.go
+++ b/internal/hooks/telemetry_effectiveness_test.go
@@ -37,10 +37,10 @@ func TestHookEffectivenessRecordsSkippedDenominatorAndAlternation(t *testing.T) 
 	if json.Unmarshal([]byte(lines[0]), &first) != nil || json.Unmarshal([]byte(lines[1]), &second) != nil {
 		t.Fatalf("invalid effectiveness JSONL: %s", data)
 	}
-	if first.Event != "PreToolUse" || !first.EmittedContext || !first.DaemonReachable || first.AlternationSegments != 3 {
+	if first.Event != "PreToolUse" || !first.EmittedContext || first.DaemonReachable == nil || !*first.DaemonReachable || first.AlternationSegments != 3 {
 		t.Fatalf("first record=%+v", first)
 	}
-	if second.Event != "PreToolUse" || second.EmittedContext || !second.DaemonReachable || second.AlternationSegments != 0 {
+	if second.Event != "PreToolUse" || second.EmittedContext || second.DaemonReachable == nil || !*second.DaemonReachable || second.AlternationSegments != 0 {
 		t.Fatalf("second record=%+v", second)
 	}
 }
@@ -61,7 +61,7 @@ func TestHookEffectivenessRejectsUnknownEventsAndCapsSegments(t *testing.T) {
 	if json.Unmarshal([]byte(strings.TrimSpace(string(data))), &record) != nil {
 		t.Fatalf("invalid record: %s", data)
 	}
-	if record.AlternationSegments != maxAlternationProbes+1 || record.DaemonReachable {
+	if record.AlternationSegments != maxAlternationProbes+1 || record.DaemonReachable == nil || *record.DaemonReachable {
 		t.Fatalf("record=%+v", record)
 	}
 }

--- a/internal/hooks/userpromptsubmit.go
+++ b/internal/hooks/userpromptsubmit.go
@@ -45,9 +45,16 @@ func runUserPromptSubmit(data []byte) {
 	if input.HookEventName != "UserPromptSubmit" {
 		return
 	}
+	// The user prompt is the authoritative turn boundary. Clear terminal
+	// enforcement before any daemon-backed enrichment so a down daemon cannot
+	// leave the previous turn's marker active.
+	clearedTerminal := clearLocalizationTerminalFromHook(data)
 	emitted := false
 	defer func() {
 		logHookEffectiveness("UserPromptSubmit", emitted, daemonReachableFn(), 0, time.Since(started))
+		if clearedTerminal {
+			localizationTerminalTelemetry("cleared_prompt", true, started)
+		}
 	}()
 	block := buildUserPromptSubmitContext(input.HookEventName, input.Prompt)
 	if block == "" {

--- a/internal/indexer/extractor_version.go
+++ b/internal/indexer/extractor_version.go
@@ -26,6 +26,7 @@ var extractorVersions = map[string]int{
 	// Languages default to version 1 (no salt). Raise an entry here in
 	// the same change that alters a language's extraction logic, e.g.
 	//   "go": 2,
+	"php": 2, // class/interface inheritance now emits typed structural edges
 }
 
 // extractorSaltExtLang maps a lower-case file extension to the language

--- a/internal/indexer/extractor_version_test.go
+++ b/internal/indexer/extractor_version_test.go
@@ -39,10 +39,16 @@ func TestStaleLangsDetection(t *testing.T) {
 		if got := ExtractorVersionStaleLangs("not json"); got != nil {
 			t.Errorf("bad json = %v, want nil", got)
 		}
-		// Against the live extractor versions (all baseline 1), a stored go@1
+		// Against the live extractor versions, an unchanged baseline language
 		// is not stale.
 		if got := ExtractorVersionStaleLangs(`{"go":1}`); len(got) != 0 {
 			t.Errorf("stored at current = %v, want empty", got)
+		}
+		if got := ExtractorVersionStaleLangs(`{"go":1,"php":1}`); !reflect.DeepEqual(got, []string{"php"}) {
+			t.Errorf("stored PHP structural-edge version = %v, want [php]", got)
+		}
+		if got := merkleSaltFor("src/Handler.php"); got != "php@2" {
+			t.Errorf("PHP extractor salt = %q, want php@2", got)
 		}
 	})
 

--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -759,8 +759,12 @@ func (mi *MultiIndexer) runMasterResolveHooked(scope map[string]struct{}, useLSP
 		zap.Bool("scoped", scoped),
 		zap.Bool("lsp_enabled", useLSP && mi.resolverLSPHelper != nil),
 		zap.Int("scope_repos", len(scope)),
-		zap.Int("pending_before", stats.PendingBefore),
-		zap.Int("pending_after", stats.PendingAfter))
+		// Scanned vs admitted, NOT residual-after-resolution: PendingAfter
+		// counts the rows that survived scope/terminal filtering into the
+		// pass (see ResolveStats). A 666k-conversion pass with these two
+		// nearly equal is a pass that admitted nearly everything it scanned.
+		zap.Int("pending_scanned", stats.PendingBefore),
+		zap.Int("pending_admitted", stats.PendingAfter))
 }
 
 func (mi *MultiIndexer) runMasterResolveFiles(files []string, useLSP bool) {
@@ -774,8 +778,8 @@ func (mi *MultiIndexer) runMasterResolveFiles(files []string, useLSP bool) {
 		zap.Duration("elapsed", time.Since(mt)),
 		zap.Bool("lsp_enabled", useLSP && mi.resolverLSPHelper != nil),
 		zap.Int("files", len(files)),
-		zap.Int("pending_before", stats.PendingBefore),
-		zap.Int("pending_after", stats.PendingAfter))
+		zap.Int("pending_scanned", stats.PendingBefore),
+		zap.Int("pending_admitted", stats.PendingAfter))
 }
 
 // RunPreEnrichResolve runs the resolution stage that makes references queryable

--- a/internal/mcp/analysis_lazy.go
+++ b/internal/mcp/analysis_lazy.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/zzet/gortex/internal/analysis"
 	"github.com/zzet/gortex/internal/graph"
-	"github.com/zzet/gortex/internal/runtimeactivity"
 	"go.uber.org/zap"
 )
 
@@ -144,14 +143,17 @@ func (s *Server) analysisProcessesForNodes(nodeIDs []string) ([]graph.AnalysisPr
 // generation receipt and graph tokens remain published, so the next request can
 // query bounded rows without a whole-graph recomputation.
 func (s *Server) releaseTransientAnalysisIfIdle() bool {
-	if runtimeactivity.Current().Active != 0 {
-		return false
-	}
 	s.analysisMu.Lock()
 	defer s.analysisMu.Unlock()
 	if !s.analysisGenerationReady {
 		return false
 	}
+	// The durable generation is the source of truth once published. Dropping
+	// these compatibility views is safe even while requests are active: a
+	// request that already copied a pointer keeps that object alive, while new
+	// requests materialize bounded rows from the generation store. Waiting for
+	// process-wide idleness can retain the entire analysis corpus forever when
+	// a cancelled MCP handler ignores its context.
 	s.communities = nil
 	s.leidenCache = nil
 	s.processes = nil

--- a/internal/mcp/analysis_lazy_release_test.go
+++ b/internal/mcp/analysis_lazy_release_test.go
@@ -1,0 +1,37 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/analysis"
+)
+
+func TestReleaseTransientAnalysisDropsPublishedCompatibilityViews(t *testing.T) {
+	s := &Server{
+		analysisGenerationReady: true,
+		communities:             &analysis.CommunityResult{},
+		processes:               &analysis.ProcessResult{},
+		hotspots:                []analysis.HotspotEntry{{ID: "hot"}},
+		hotspotsReady:           true,
+	}
+
+	if !s.releaseTransientAnalysisIfIdle() {
+		t.Fatal("expected published transient analysis to be released")
+	}
+	if s.communities != nil || s.processes != nil || s.hotspots != nil || s.hotspotsReady {
+		t.Fatalf("transient analysis retained: communities=%v processes=%v hotspots=%v ready=%v",
+			s.communities != nil, s.processes != nil, s.hotspots != nil, s.hotspotsReady)
+	}
+}
+
+func TestReleaseTransientAnalysisKeepsUnpublishedCompatibilityViews(t *testing.T) {
+	communities := &analysis.CommunityResult{}
+	s := &Server{communities: communities}
+
+	if s.releaseTransientAnalysisIfIdle() {
+		t.Fatal("unpublished transient analysis must remain available")
+	}
+	if s.communities != communities {
+		t.Fatal("unpublished compatibility view was dropped")
+	}
+}

--- a/internal/mcp/analyze_admission.go
+++ b/internal/mcp/analyze_admission.go
@@ -1,0 +1,49 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+)
+
+const maxConcurrentExpensiveAnalyses = 1
+
+var (
+	errAnalysisBusy        = errors.New("expensive analysis already running; retry after it completes")
+	errAnalysisWarmup      = errors.New("expensive analysis unavailable while graph warmup is running; retry after workspace readiness")
+	expensiveAnalysisSlots = make(chan struct{}, maxConcurrentExpensiveAnalyses)
+)
+
+// expensiveAnalyzeKinds identifies operations that scan or materialize a
+// substantial fraction of the graph. They have dedicated admission so editor
+// background audits cannot consume every general MCP dispatcher slot.
+var expensiveAnalyzeKinds = map[string]struct{}{
+	"bottlenecks": {},
+	"clusters":    {},
+	"components":  {},
+	"cycles":      {},
+	"dead_code":   {},
+	"hotspots":    {},
+	"kcore":       {},
+	"louvain":     {},
+	"pagerank":    {},
+	"scc":         {},
+	"wcc":         {},
+}
+
+func (s *Server) acquireAnalyzeAdmission(ctx context.Context, kind string) (func(), error) {
+	if _, expensive := expensiveAnalyzeKinds[kind]; !expensive {
+		return func() {}, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if s != nil && s.warmupSnapshot().warming() {
+		return nil, errAnalysisWarmup
+	}
+	select {
+	case expensiveAnalysisSlots <- struct{}{}:
+		return func() { <-expensiveAnalysisSlots }, nil
+	default:
+		return nil, errAnalysisBusy
+	}
+}

--- a/internal/mcp/analyze_admission_test.go
+++ b/internal/mcp/analyze_admission_test.go
@@ -1,0 +1,61 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func resetExpensiveAnalysisSlots(t *testing.T) {
+	t.Helper()
+	for {
+		select {
+		case <-expensiveAnalysisSlots:
+		default:
+			return
+		}
+	}
+}
+
+func TestAcquireAnalyzeAdmissionRejectsConcurrentExpensiveWork(t *testing.T) {
+	resetExpensiveAnalysisSlots(t)
+	t.Cleanup(func() { resetExpensiveAnalysisSlots(t) })
+
+	s := &Server{}
+	release, err := s.acquireAnalyzeAdmission(context.Background(), "dead_code")
+	if err != nil {
+		t.Fatalf("first admission: %v", err)
+	}
+	defer release()
+
+	if _, err := s.acquireAnalyzeAdmission(context.Background(), "cycles"); !errors.Is(err, errAnalysisBusy) {
+		t.Fatalf("second expensive admission error = %v, want %v", err, errAnalysisBusy)
+	}
+}
+
+func TestAcquireAnalyzeAdmissionDoesNotGateLightweightKinds(t *testing.T) {
+	resetExpensiveAnalysisSlots(t)
+	t.Cleanup(func() { resetExpensiveAnalysisSlots(t) })
+
+	s := &Server{}
+	release, err := s.acquireAnalyzeAdmission(context.Background(), "dead_code")
+	if err != nil {
+		t.Fatalf("expensive admission: %v", err)
+	}
+	defer release()
+
+	lightRelease, err := s.acquireAnalyzeAdmission(context.Background(), "todos")
+	if err != nil {
+		t.Fatalf("lightweight admission: %v", err)
+	}
+	lightRelease()
+}
+
+func TestAcquireAnalyzeAdmissionHonorsCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := (&Server{}).acquireAnalyzeAdmission(ctx, "dead_code"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("admission error = %v, want %v", err, context.Canceled)
+	}
+}

--- a/internal/mcp/errors.go
+++ b/internal/mcp/errors.go
@@ -98,6 +98,13 @@ const (
 	// already produced its terminal evidence. The caller must respond, or make
 	// the one exact read named by data.completion when that state is returned.
 	ErrCodeLocalizationComplete ErrorCode = "localization_complete"
+
+	// ErrCodeLocalizationTerminal — a localization contract is already in its
+	// terminal answer_ready state. The original successful response contains
+	// the evidence; retrying navigation cannot add evidence and is not
+	// retriable. This is distinct from LocalizationComplete, which also covers
+	// non-terminal refinement and in-flight states.
+	ErrCodeLocalizationTerminal ErrorCode = "localization_terminal"
 )
 
 // StructuredError is the JSON shape encoded into the TextContent
@@ -116,13 +123,38 @@ type StructuredError struct {
 // Use this from any MCP handler that wants to surface a typed
 // failure instead of a free-form string.
 func NewStructuredErrorResult(err StructuredError) *mcp.CallToolResult {
+	return newStructuredErrorResult(err, false)
+}
+
+// newStructuredErrorResult preserves the exported constructor's historical
+// wire shape while allowing protocol contracts that require an explicit
+// retriable boolean to opt in locally.
+func newStructuredErrorResult(err StructuredError, explicitRetriable bool) *mcp.CallToolResult {
 	if err.ErrorCode == "" {
 		err.ErrorCode = ErrCodeInvalidArgument
 	}
 	if err.Message == "" {
 		err.Message = string(err.ErrorCode)
 	}
-	body, mErr := json.Marshal(err)
+	var (
+		body []byte
+		mErr error
+	)
+	if explicitRetriable {
+		body, mErr = json.Marshal(struct {
+			ErrorCode ErrorCode      `json:"error_code"`
+			Message   string         `json:"message"`
+			Retriable bool           `json:"retriable"`
+			Data      map[string]any `json:"data,omitempty"`
+		}{
+			ErrorCode: err.ErrorCode,
+			Message:   err.Message,
+			Retriable: err.Retriable,
+			Data:      err.Data,
+		})
+	} else {
+		body, mErr = json.Marshal(err)
+	}
 	if mErr != nil {
 		// Fallback to plain text — never let a marshal failure mask
 		// the actual error.

--- a/internal/mcp/explore_divergent_default_owner.go
+++ b/internal/mcp/explore_divergent_default_owner.go
@@ -1,0 +1,1074 @@
+package mcp
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+const (
+	exploreDefaultSignatureCap     = 1024
+	exploreDefaultParamCap         = 16
+	exploreDefaultSourceCap        = 32 * 1024
+	exploreDefaultOwnerBaseCap     = 3
+	exploreDefaultOwnerEdgeCap     = 16
+	exploreDefaultOwnerEndpointCap = 32
+	exploreDefaultOwnerFileCap     = 3
+	exploreDefaultOwnerFileNodeCap = 64
+	exploreDefaultOwnerTotalCap    = 96
+	exploreDefaultOwnerFallbackSLO = 25 * time.Millisecond
+)
+
+type exploreParameterDefault struct {
+	name  string
+	value string
+}
+
+type exploreDivergentDefaultOwner struct {
+	constructor *graph.Node
+	owner       *graph.Node
+	baseCtor    *graph.Node
+	baseOwner   *graph.Node
+	parameter   string
+	consumerID  string
+}
+
+type exploreDivergentDefaultBase struct {
+	constructor *graph.Node
+	owner       *graph.Node
+	defaults    []exploreParameterDefault
+	consumerID  string
+}
+
+type exploreDivergentDefaultProjection struct {
+	callers   map[string][]string
+	extenders map[string][]string
+	nodes     map[string]*graph.Node
+}
+
+// promoteExploreDivergentDefaultOwner recognizes one high-confidence causal
+// shape through a bounded, exact-ID projection from the graph store:
+//
+//	child constructor --calls--> base constructor
+//	child type        --extends-> base type
+//
+// Both constructors must expose the same query-relevant parameter, with a
+// neutral base default and a concrete child default. The projection starts only
+// from already-ranked base constructor/type pairs, performs one batched inbound
+// lookup and one batched node hydration, and fails closed at every cap. A unique
+// match replaces its represented base pair before being moved to the head, so
+// promotion never evicts an unrelated protected candidate.
+func promoteExploreDivergentDefaultOwner(task string, targets []exploreTarget, store graph.Store, maxSymbols int, readSource func(*graph.Node) string) []exploreTarget {
+	if store == nil || readSource == nil || len(targets) == 0 || !exploreQueryIsConceptTask(task) {
+		return targets
+	}
+	taskTerms := exploreTerminalTerms(task)
+	bases, ok := exploreDivergentDefaultBases(taskTerms, targets)
+	if !ok {
+		return targets
+	}
+	if len(bases) == 0 {
+		deadline := time.Now().Add(exploreDefaultOwnerFallbackSLO)
+		bases, ok = exploreDivergentDefaultBasesFromRankedCallables(taskTerms, targets, store, deadline)
+		if !ok || len(bases) == 0 {
+			return targets
+		}
+	}
+	projection, ok := projectExploreDivergentDefaultOwners(store, bases)
+	if !ok {
+		return targets
+	}
+	match, ok := findExploreDivergentDefaultOwner(bases, projection)
+	if !ok {
+		return targets
+	}
+
+	constructor, _ := exploreTargetByID(targets, match.constructor.ID)
+	constructor.node = match.constructor
+	constructor.divergentDefaultOwner = true
+	if constructor.source == "" {
+		constructor.source = readSource(match.constructor)
+	}
+	if !exploreConstructorForwardsParameter(constructor.source, match.parameter, match.baseOwner.Name) {
+		return targets
+	}
+	owner, _ := exploreTargetByID(targets, match.owner.ID)
+	owner.node = match.owner
+	owner.divergentDefaultType = true
+	if len(constructor.callees) == 0 {
+		constructor.callees = []*graph.Node{match.baseCtor}
+	}
+	if len(owner.callees) == 0 {
+		owner.callees = []*graph.Node{match.baseOwner}
+	}
+
+	replaced, ok := placeExploreDivergentDefaultOwner(task, targets, match, constructor, owner, maxSymbols)
+	if !ok {
+		return targets
+	}
+	return prioritizeExploreTargetPair(replaced, match.constructor.ID, match.owner.ID)
+}
+
+// placeExploreDivergentDefaultOwner keeps every ranked consumer intact. When
+// the base constructor/type pair was ranked, the proven child pair replaces
+// it. The callable-owner fallback may discover an unranked base pair; when the
+// result is already at capacity it admits the proof only by evicting the
+// lowest-ranked unprotected candidates. The consuming callable, explicit and
+// literal anchors, artifacts (kept outside this slice), and implementation
+// evidence are never sacrificed.
+func placeExploreDivergentDefaultOwner(task string, targets []exploreTarget, match exploreDivergentDefaultOwner, constructor, owner exploreTarget, maxSymbols int) ([]exploreTarget, bool) {
+	if maxSymbols <= 0 {
+		maxSymbols = len(targets)
+	}
+	missing := 0
+	if exploreTargetIndex(targets, match.constructor.ID) < 0 && exploreTargetIndex(targets, match.baseCtor.ID) < 0 {
+		missing++
+	}
+	if exploreTargetIndex(targets, match.owner.ID) < 0 && exploreTargetIndex(targets, match.baseOwner.ID) < 0 {
+		missing++
+	}
+	overflow := len(targets) + missing - maxSymbols
+	if overflow < 0 {
+		overflow = 0
+	}
+	evict := make(map[int]struct{}, overflow)
+	for index := len(targets) - 1; index >= 0 && len(evict) < overflow; index-- {
+		if exploreDivergentDefaultAdmissionProtected(task, targets[index], match) {
+			continue
+		}
+		evict[index] = struct{}{}
+	}
+	if len(evict) != overflow {
+		return nil, false
+	}
+
+	replaced := make([]exploreTarget, 0, len(targets)-len(evict)+missing)
+	for index, target := range targets {
+		if _, drop := evict[index]; !drop {
+			replaced = append(replaced, target)
+		}
+	}
+	place := func(candidate exploreTarget, candidateID, baseID string) {
+		if index := exploreTargetIndex(replaced, candidateID); index >= 0 {
+			replaced[index] = candidate
+			return
+		}
+		if index := exploreTargetIndex(replaced, baseID); index >= 0 {
+			replaced[index] = candidate
+			return
+		}
+		replaced = append(replaced, candidate)
+	}
+	place(constructor, match.constructor.ID, match.baseCtor.ID)
+	place(owner, match.owner.ID, match.baseOwner.ID)
+	return replaced, true
+}
+
+func exploreDivergentDefaultAdmissionProtected(task string, target exploreTarget, match exploreDivergentDefaultOwner) bool {
+	if target.node == nil {
+		return true
+	}
+	id := target.node.ID
+	if id == match.consumerID || id == match.constructor.ID || id == match.owner.ID ||
+		id == match.baseCtor.ID || id == match.baseOwner.ID {
+		return true
+	}
+	return target.divergentDefaultOwner || target.divergentDefaultType || target.conceptImplementation ||
+		target.exactContent || target.exactContentAmbiguous || target.sourceLiteral ||
+		exploreLocalizationExplicitAnchor(task, target.node)
+}
+
+func preserveExploreDivergentDefaultOrder(targets []exploreTarget) []exploreTarget {
+	constructorID, ownerID := "", ""
+	for _, target := range targets {
+		if target.node == nil {
+			continue
+		}
+		if target.divergentDefaultOwner {
+			constructorID = target.node.ID
+		}
+		if target.divergentDefaultType {
+			ownerID = target.node.ID
+		}
+	}
+	if constructorID == "" || ownerID == "" {
+		return targets
+	}
+	return prioritizeExploreTargetPair(targets, constructorID, ownerID)
+}
+
+func exploreDivergentDefaultOwnerSymbol(targets []exploreTarget) string {
+	for _, target := range targets {
+		if target.divergentDefaultOwner && target.node != nil {
+			return target.node.ID
+		}
+	}
+	return ""
+}
+
+func prioritizeExploreTargetPair(targets []exploreTarget, firstID, secondID string) []exploreTarget {
+	first, firstFound := exploreTargetByID(targets, firstID)
+	second, secondFound := exploreTargetByID(targets, secondID)
+	if !firstFound || !secondFound {
+		return targets
+	}
+	ordered := make([]exploreTarget, 0, len(targets))
+	ordered = append(ordered, first, second)
+	for _, target := range targets {
+		if target.node == nil || target.node.ID == firstID || target.node.ID == secondID {
+			continue
+		}
+		ordered = append(ordered, target)
+	}
+	if len(ordered) != len(targets) {
+		return targets
+	}
+	return ordered
+}
+
+func exploreTargetByID(targets []exploreTarget, id string) (exploreTarget, bool) {
+	if index := exploreTargetIndex(targets, id); index >= 0 {
+		return targets[index], true
+	}
+	return exploreTarget{}, false
+}
+
+func exploreTargetIndex(targets []exploreTarget, id string) int {
+	for index, target := range targets {
+		if target.node != nil && target.node.ID == id {
+			return index
+		}
+	}
+	return -1
+}
+
+// exploreConstructorForwardsParameter confirms that the changed child default
+// actually reaches the base constructor. The caller edge proves which symbol
+// is invoked; this bounded lexical check proves that the shared parameter is
+// present in that base/super call rather than merely declared independently by
+// both constructors.
+func exploreConstructorForwardsParameter(source, parameter, baseOwner string) bool {
+	if source == "" || parameter == "" || len(source) > exploreDefaultSourceCap {
+		return false
+	}
+	code := exploreMaskNonCode(source)
+	for open := 0; open < len(code); open++ {
+		if code[open] != '(' {
+			continue
+		}
+		callee := exploreCallCalleeBefore(code, open)
+		if !exploreBaseConstructorCallee(callee, baseOwner) {
+			continue
+		}
+		close, ok := exploreMatchingParen(code, open)
+		if !ok {
+			return false
+		}
+		if exploreContainsIdentifier(code[open+1:close], parameter) {
+			return true
+		}
+		open = close
+	}
+	return false
+}
+
+// exploreMaskNonCode preserves byte offsets while blanking comments and string
+// literals. Forwarding evidence must come from executable arguments of the
+// proven base-constructor call; examples in comments, exception text, and
+// string interpolation are not data-flow evidence.
+func exploreMaskNonCode(source string) string {
+	masked := []byte(source)
+	mask := func(start, end int) {
+		if end > len(masked) {
+			end = len(masked)
+		}
+		for index := start; index < end; index++ {
+			if masked[index] != '\n' && masked[index] != '\r' {
+				masked[index] = ' '
+			}
+		}
+	}
+	for index := 0; index < len(source); {
+		switch {
+		case index+1 < len(source) && source[index] == '/' && source[index+1] == '/':
+			end := index + 2
+			for end < len(source) && source[end] != '\n' && source[end] != '\r' {
+				end++
+			}
+			mask(index, end)
+			index = end
+		case index+1 < len(source) && source[index] == '/' && source[index+1] == '*':
+			end := index + 2
+			for end+1 < len(source) && (source[end] != '*' || source[end+1] != '/') {
+				end++
+			}
+			if end+1 < len(source) {
+				end += 2
+			} else {
+				end = len(source)
+			}
+			mask(index, end)
+			index = end
+		case source[index] == '#' && (index+1 >= len(source) || source[index+1] != '['):
+			end := index + 1
+			for end < len(source) && source[end] != '\n' && source[end] != '\r' {
+				end++
+			}
+			mask(index, end)
+			index = end
+		case source[index] == '\'' || source[index] == '"' || source[index] == '`':
+			quote := source[index]
+			end := index + 1
+			escaped := false
+			for end < len(source) {
+				char := source[end]
+				end++
+				if escaped {
+					escaped = false
+					continue
+				}
+				if char == '\\' {
+					escaped = true
+					continue
+				}
+				if char == quote {
+					break
+				}
+			}
+			mask(index, end)
+			index = end
+		default:
+			index++
+		}
+	}
+	return string(masked)
+}
+
+func exploreCallCalleeBefore(source string, open int) string {
+	end := open
+	for end > 0 && unicode.IsSpace(rune(source[end-1])) {
+		end--
+	}
+	start := end
+	for start > 0 {
+		char := source[start-1]
+		if char == '_' || char == '.' || char == ':' || char == '$' || char == '(' || char == ')' ||
+			char >= 'a' && char <= 'z' || char >= 'A' && char <= 'Z' || char >= '0' && char <= '9' {
+			start--
+			continue
+		}
+		break
+	}
+	callee := strings.ToLower(source[start:end])
+	callee = strings.ReplaceAll(callee, "()", "")
+	return strings.Trim(callee, ".:$")
+}
+
+func exploreBaseConstructorCallee(callee, baseOwner string) bool {
+	callee = strings.TrimSpace(callee)
+	base := strings.ToLower(strings.TrimSpace(baseOwner))
+	switch callee {
+	case "parent::__construct", "super.__init__", "super.init", "super", "base":
+		return true
+	}
+	return base != "" && (callee == base || strings.HasSuffix(callee, "."+base) || strings.HasSuffix(callee, "::"+base))
+}
+
+func exploreMatchingParen(source string, open int) (int, bool) {
+	depth := 0
+	quote := byte(0)
+	escaped := false
+	for index := open; index < len(source); index++ {
+		char := source[index]
+		if quote != 0 {
+			if escaped {
+				escaped = false
+				continue
+			}
+			if char == '\\' {
+				escaped = true
+				continue
+			}
+			if char == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch char {
+		case '\'', '"', '`':
+			quote = char
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return index, true
+			}
+		}
+	}
+	return 0, false
+}
+
+func exploreContainsIdentifier(source, identifier string) bool {
+	for offset := 0; offset < len(source); {
+		index := strings.Index(strings.ToLower(source[offset:]), strings.ToLower(identifier))
+		if index < 0 {
+			return false
+		}
+		index += offset
+		end := index + len(identifier)
+		before := index == 0 || !exploreIdentifierByte(source[index-1])
+		after := end == len(source) || !exploreIdentifierByte(source[end])
+		if before && after {
+			return true
+		}
+		offset = index + 1
+	}
+	return false
+}
+
+func exploreIdentifierByte(value byte) bool {
+	return value == '_' || value >= 'a' && value <= 'z' || value >= 'A' && value <= 'Z' || value >= '0' && value <= '9'
+}
+
+func exploreDivergentDefaultBases(taskTerms map[string]struct{}, targets []exploreTarget) ([]exploreDivergentDefaultBase, bool) {
+	direct := make(map[string]exploreTarget, len(targets))
+	for _, target := range targets {
+		if target.node != nil && target.node.ID != "" {
+			direct[target.node.ID] = target
+		}
+	}
+	bases := make([]exploreDivergentDefaultBase, 0, exploreDefaultOwnerBaseCap)
+	seen := make(map[string]struct{}, exploreDefaultOwnerBaseCap)
+	for _, target := range targets {
+		baseCtor := target.node
+		if !exploreConstructorNode(baseCtor) {
+			continue
+		}
+		baseOwnerID, _ := graph.EnclosingFromID(baseCtor.ID, baseCtor.Kind)
+		baseOwnerTarget, found := direct[baseOwnerID]
+		if !found || baseOwnerTarget.node == nil || baseOwnerTarget.node.Kind != graph.KindType {
+			continue
+		}
+		defaults := parseExploreParameterDefaults(baseCtor.RetrievalMetadata().Signature)
+		relevant := defaults[:0]
+		for _, candidate := range defaults {
+			if isNeutralExploreDefault(candidate.value) && exploreDefaultParameterRelevantTerms(taskTerms, candidate.name) {
+				relevant = append(relevant, candidate)
+			}
+		}
+		if len(relevant) == 0 {
+			continue
+		}
+		if _, duplicate := seen[baseCtor.ID]; duplicate {
+			continue
+		}
+		seen[baseCtor.ID] = struct{}{}
+		bases = append(bases, exploreDivergentDefaultBase{
+			constructor: baseCtor,
+			owner:       baseOwnerTarget.node,
+			defaults:    relevant,
+		})
+		if len(bases) > exploreDefaultOwnerBaseCap {
+			return nil, false
+		}
+	}
+	return bases, true
+}
+
+type exploreRankedCallableOwner struct {
+	callable *graph.Node
+	ownerID  string
+	owner    *graph.Node
+}
+
+// exploreDivergentDefaultBasesFromRankedCallables is the strictly bounded
+// recovery path for a common ranking gap: the consuming method is present but
+// its constructor/type pair is not. It follows only the callable's exact
+// enclosing owner, hydrates those owners in one batch, and reads only their
+// indexed file-node sets in one batch. It never scans a repository or source
+// tree, and ambiguous/oversized projections are rejected.
+func exploreDivergentDefaultBasesFromRankedCallables(taskTerms map[string]struct{}, targets []exploreTarget, store graph.Store, deadline time.Time) ([]exploreDivergentDefaultBase, bool) {
+	if store == nil || len(taskTerms) == 0 || time.Now().After(deadline) {
+		return nil, false
+	}
+	owners := make([]exploreRankedCallableOwner, 0, exploreDefaultOwnerFileCap)
+	seenOwners := make(map[string]struct{}, exploreDefaultOwnerFileCap)
+	for _, target := range targets {
+		callable := target.node
+		if callable == nil || (callable.Kind != graph.KindMethod && callable.Kind != graph.KindFunction) ||
+			exploreConstructorNode(callable) || exploreDraftIsTestNode(callable) {
+			continue
+		}
+		ownerID, _ := graph.EnclosingFromID(callable.ID, callable.Kind)
+		if ownerID == "" {
+			continue
+		}
+		overlap, longest := exploreDraftTermOverlap(taskTerms, callable)
+		relevant := overlap >= 2 || overlap == 1 && longest >= 5
+		if !relevant {
+			continue
+		}
+		if _, duplicate := seenOwners[ownerID]; duplicate {
+			continue
+		}
+		seenOwners[ownerID] = struct{}{}
+		owners = append(owners, exploreRankedCallableOwner{callable: callable, ownerID: ownerID})
+		if len(owners) > exploreDefaultOwnerFileCap {
+			return nil, false
+		}
+	}
+	if len(owners) == 0 {
+		return nil, true
+	}
+
+	ownerIDs := make([]string, 0, len(owners))
+	for _, candidate := range owners {
+		ownerIDs = append(ownerIDs, candidate.ownerID)
+	}
+	hydrated := store.GetNodesByIDs(ownerIDs)
+	if time.Now().After(deadline) || len(hydrated) != len(ownerIDs) {
+		return nil, false
+	}
+	filePaths := make([]string, 0, len(owners))
+	seenFiles := make(map[string]struct{}, len(owners))
+	coherent := owners[:0]
+	for _, candidate := range owners {
+		candidate.owner = hydrated[candidate.ownerID]
+		if !exploreRankedCallableOwnerCoherent(candidate.callable, candidate.owner) {
+			continue
+		}
+		coherent = append(coherent, candidate)
+		if _, duplicate := seenFiles[candidate.owner.FilePath]; duplicate {
+			continue
+		}
+		seenFiles[candidate.owner.FilePath] = struct{}{}
+		filePaths = append(filePaths, candidate.owner.FilePath)
+	}
+	if len(coherent) == 0 || len(filePaths) == 0 || len(filePaths) > exploreDefaultOwnerFileCap {
+		return nil, len(coherent) == 0
+	}
+
+	fileNodes := store.GetFileNodesByPaths(filePaths)
+	if time.Now().After(deadline) {
+		return nil, false
+	}
+	total := 0
+	for _, path := range filePaths {
+		nodes := fileNodes[path]
+		if len(nodes) > exploreDefaultOwnerFileNodeCap {
+			return nil, false
+		}
+		total += len(nodes)
+		if total > exploreDefaultOwnerTotalCap {
+			return nil, false
+		}
+	}
+
+	bases := make([]exploreDivergentDefaultBase, 0, len(coherent))
+	for _, candidate := range coherent {
+		var viable []exploreDivergentDefaultBase
+		for _, node := range fileNodes[candidate.owner.FilePath] {
+			if !exploreConstructorNode(node) || exploreDraftIsTestNode(node) {
+				continue
+			}
+			ownerID, _ := graph.EnclosingFromID(node.ID, node.Kind)
+			if ownerID != candidate.owner.ID || !exploreRankedOwnerConstructorCoherent(candidate.callable, candidate.owner, node) {
+				continue
+			}
+			defaults := parseExploreParameterDefaults(node.RetrievalMetadata().Signature)
+			relevantDefaults := make([]exploreParameterDefault, 0, len(defaults))
+			for _, parameter := range defaults {
+				if isNeutralExploreDefault(parameter.value) && exploreDefaultParameterRelevantTerms(taskTerms, parameter.name) {
+					relevantDefaults = append(relevantDefaults, parameter)
+				}
+			}
+			if len(relevantDefaults) > 0 {
+				viable = append(viable, exploreDivergentDefaultBase{
+					constructor: node,
+					owner:       candidate.owner,
+					defaults:    relevantDefaults,
+					consumerID:  candidate.callable.ID,
+				})
+			}
+		}
+		if len(viable) > 1 {
+			return nil, false
+		}
+		if len(viable) == 1 {
+			bases = append(bases, viable[0])
+			if len(bases) > exploreDefaultOwnerBaseCap {
+				return nil, false
+			}
+		}
+	}
+	return bases, true
+}
+
+func exploreRankedCallableOwnerCoherent(callable, owner *graph.Node) bool {
+	if callable == nil || owner == nil || owner.Kind != graph.KindType || owner.ID == "" ||
+		callable.FilePath == "" || callable.FilePath != owner.FilePath ||
+		exploreDraftIsTestNode(callable) || exploreDraftIsTestNode(owner) {
+		return false
+	}
+	ownerID, _ := graph.EnclosingFromID(callable.ID, callable.Kind)
+	return ownerID == owner.ID && exploreNodesShareExactScope(callable, owner)
+}
+
+func exploreRankedOwnerConstructorCoherent(callable, owner, constructor *graph.Node) bool {
+	return exploreRankedCallableOwnerCoherent(callable, owner) && constructor != nil &&
+		constructor.FilePath == owner.FilePath && exploreNodesShareExactScope(owner, constructor)
+}
+
+func exploreNodesShareExactScope(left, right *graph.Node) bool {
+	if left == nil || right == nil || left.RepoPrefix != right.RepoPrefix ||
+		left.WorkspaceID != right.WorkspaceID || left.ProjectID != right.ProjectID {
+		return false
+	}
+	return left.Language == "" || right.Language == "" || strings.EqualFold(left.Language, right.Language)
+}
+
+// projectExploreDivergentDefaultOwners reads only direct inbound adjacency for
+// the bounded ranked seed set. Unlike query.Engine.GetCallers, graph.Store
+// preserves the relationship kind and full node metadata needed by this proof.
+// Any oversized or partially hydrated projection is rejected rather than
+// interpreted as evidence that no competing child exists.
+func projectExploreDivergentDefaultOwners(store graph.Store, bases []exploreDivergentDefaultBase) (exploreDivergentDefaultProjection, bool) {
+	if store == nil || len(bases) == 0 || len(bases) > exploreDefaultOwnerBaseCap {
+		return exploreDivergentDefaultProjection{}, false
+	}
+	seedIDs := make([]string, 0, len(bases)*2)
+	for _, base := range bases {
+		seedIDs = append(seedIDs, base.constructor.ID, base.owner.ID)
+	}
+	incoming := store.GetInEdgesByNodeIDs(seedIDs)
+	projection := exploreDivergentDefaultProjection{
+		callers:   make(map[string][]string, len(bases)),
+		extenders: make(map[string][]string, len(bases)),
+	}
+	endpointIDs := make(map[string]struct{})
+	appendEndpoint := func(targetID string, edge *graph.Edge, kind graph.EdgeKind, destinations map[string][]string) bool {
+		if edge == nil || edge.Kind != kind || edge.To != targetID || edge.From == "" {
+			return true
+		}
+		for _, existing := range destinations[targetID] {
+			if existing == edge.From {
+				return true
+			}
+		}
+		destinations[targetID] = append(destinations[targetID], edge.From)
+		if len(destinations[targetID]) > exploreDefaultOwnerEdgeCap {
+			return false
+		}
+		endpointIDs[edge.From] = struct{}{}
+		return len(endpointIDs) <= exploreDefaultOwnerEndpointCap
+	}
+	for _, base := range bases {
+		for _, edge := range incoming[base.constructor.ID] {
+			if !appendEndpoint(base.constructor.ID, edge, graph.EdgeCalls, projection.callers) {
+				return exploreDivergentDefaultProjection{}, false
+			}
+		}
+		for _, edge := range incoming[base.owner.ID] {
+			if !appendEndpoint(base.owner.ID, edge, graph.EdgeExtends, projection.extenders) {
+				return exploreDivergentDefaultProjection{}, false
+			}
+		}
+	}
+	ids := make([]string, 0, len(endpointIDs))
+	for id := range endpointIDs {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	projection.nodes = store.GetNodesByIDs(ids)
+	if len(projection.nodes) != len(ids) {
+		return exploreDivergentDefaultProjection{}, false
+	}
+	return projection, true
+}
+
+func findExploreDivergentDefaultOwner(bases []exploreDivergentDefaultBase, projection exploreDivergentDefaultProjection) (exploreDivergentDefaultOwner, bool) {
+
+	matches := make([]exploreDivergentDefaultOwner, 0, 1)
+	seen := make(map[string]struct{})
+	childDefaults := make(map[string][]exploreParameterDefault)
+	for _, base := range bases {
+		for _, childCtorID := range projection.callers[base.constructor.ID] {
+			childCtor := projection.nodes[childCtorID]
+			if !exploreConstructorNode(childCtor) {
+				continue
+			}
+			childOwnerID, _ := graph.EnclosingFromID(childCtor.ID, childCtor.Kind)
+			if !exploreStringSliceContains(projection.extenders[base.owner.ID], childOwnerID) {
+				continue
+			}
+			childOwner := projection.nodes[childOwnerID]
+			if childOwner == nil || childOwner.Kind != graph.KindType ||
+				!exploreDefaultOwnerNodesCoherent(base.constructor, childCtor, base.owner, childOwner) {
+				continue
+			}
+			defaults, parsed := childDefaults[childCtor.ID]
+			if !parsed {
+				defaults = parseExploreParameterDefaults(childCtor.RetrievalMetadata().Signature)
+				childDefaults[childCtor.ID] = defaults
+			}
+			for _, baseDefault := range base.defaults {
+				childDefault, found := exploreParameterDefaultByName(defaults, baseDefault.name)
+				if !found || !isConcreteExploreDefault(childDefault.value) {
+					continue
+				}
+				key := childCtor.ID + "\x00" + childOwner.ID + "\x00" + strings.ToLower(baseDefault.name)
+				if _, duplicate := seen[key]; duplicate {
+					continue
+				}
+				seen[key] = struct{}{}
+				matches = append(matches, exploreDivergentDefaultOwner{
+					constructor: childCtor,
+					owner:       childOwner,
+					baseCtor:    base.constructor,
+					baseOwner:   base.owner,
+					parameter:   baseDefault.name,
+					consumerID:  base.consumerID,
+				})
+			}
+		}
+	}
+	if len(matches) != 1 {
+		return exploreDivergentDefaultOwner{}, false
+	}
+	return matches[0], true
+}
+
+func exploreStringSliceContains(values []string, value string) bool {
+	for _, candidate := range values {
+		if candidate == value {
+			return true
+		}
+	}
+	return false
+}
+
+func exploreDefaultOwnerNodesCoherent(baseCtor, childCtor, baseOwner, childOwner *graph.Node) bool {
+	if baseCtor == nil || childCtor == nil || baseOwner == nil || childOwner == nil ||
+		childCtor.FilePath == "" || childCtor.FilePath != childOwner.FilePath ||
+		baseCtor.FilePath == "" || baseCtor.FilePath != baseOwner.FilePath ||
+		childOwner.ID == baseOwner.ID || exploreDraftIsTestNode(childCtor) || exploreDraftIsTestNode(childOwner) {
+		return false
+	}
+	if baseCtor.RepoPrefix != childCtor.RepoPrefix || baseCtor.WorkspaceID != childCtor.WorkspaceID || baseCtor.ProjectID != childCtor.ProjectID ||
+		baseCtor.RepoPrefix != baseOwner.RepoPrefix || baseCtor.WorkspaceID != baseOwner.WorkspaceID || baseCtor.ProjectID != baseOwner.ProjectID ||
+		childCtor.RepoPrefix != childOwner.RepoPrefix || childCtor.WorkspaceID != childOwner.WorkspaceID || childCtor.ProjectID != childOwner.ProjectID {
+		return false
+	}
+	for _, node := range []*graph.Node{baseOwner, childCtor, childOwner} {
+		if baseCtor.Language != "" && node.Language != "" && !strings.EqualFold(baseCtor.Language, node.Language) {
+			return false
+		}
+	}
+	return true
+}
+
+func exploreConstructorNode(node *graph.Node) bool {
+	if node == nil || (node.Kind != graph.KindMethod && node.Kind != graph.KindFunction) {
+		return false
+	}
+	_, ownerName := graph.EnclosingFromID(node.ID, node.Kind)
+	if ownerName == "" {
+		return false
+	}
+	name := strings.ToLower(strings.TrimSpace(node.Name))
+	switch name {
+	case "__construct", "__init__", "constructor", "init", "initialize", "<init>":
+		return true
+	}
+	return strings.EqualFold(exploreDefaultIdentifier(name), exploreDefaultIdentifier(ownerName))
+}
+
+func parseExploreParameterDefaults(signature string) []exploreParameterDefault {
+	if len(signature) == 0 || len(signature) > exploreDefaultSignatureCap {
+		return nil
+	}
+	parameters, ok := exploreOuterParameterList(signature)
+	if !ok {
+		return nil
+	}
+	parts, ok := splitExploreParameters(parameters)
+	if !ok || len(parts) > exploreDefaultParamCap {
+		return nil
+	}
+	defaults := make([]exploreParameterDefault, 0, len(parts))
+	for _, parameter := range parts {
+		assignment := exploreTopLevelAssignment(parameter)
+		if assignment < 0 {
+			continue
+		}
+		name := exploreParameterName(parameter[:assignment])
+		value := strings.TrimSpace(parameter[assignment+1:])
+		if name == "" || value == "" {
+			continue
+		}
+		defaults = append(defaults, exploreParameterDefault{name: name, value: value})
+	}
+	return defaults
+}
+
+func exploreOuterParameterList(signature string) (string, bool) {
+	open := strings.IndexByte(signature, '(')
+	if open < 0 {
+		return "", false
+	}
+	depth := 0
+	quote := rune(0)
+	escaped := false
+	for offset, r := range signature[open:] {
+		if quote != 0 {
+			if escaped {
+				escaped = false
+				continue
+			}
+			if r == '\\' {
+				escaped = true
+				continue
+			}
+			if r == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch r {
+		case '\'', '"', '`':
+			quote = r
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return signature[open+1 : open+offset], true
+			}
+			if depth < 0 {
+				return "", false
+			}
+		}
+	}
+	return "", false
+}
+
+func splitExploreParameters(parameters string) ([]string, bool) {
+	parts := make([]string, 0, 8)
+	start := 0
+	depth := 0
+	quote := rune(0)
+	escaped := false
+	for offset, r := range parameters {
+		if quote != 0 {
+			if escaped {
+				escaped = false
+				continue
+			}
+			if r == '\\' {
+				escaped = true
+				continue
+			}
+			if r == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch r {
+		case '\'', '"', '`':
+			quote = r
+		case '(', '[', '{', '<':
+			depth++
+		case ')', ']', '}', '>':
+			depth--
+			if depth < 0 {
+				return nil, false
+			}
+		case ',':
+			if depth == 0 {
+				parts = append(parts, strings.TrimSpace(parameters[start:offset]))
+				start = offset + 1
+			}
+		}
+	}
+	if quote != 0 || depth != 0 {
+		return nil, false
+	}
+	if tail := strings.TrimSpace(parameters[start:]); tail != "" {
+		parts = append(parts, tail)
+	}
+	return parts, true
+}
+
+func exploreTopLevelAssignment(parameter string) int {
+	depth := 0
+	quote := byte(0)
+	escaped := false
+	for index := 0; index < len(parameter); index++ {
+		char := parameter[index]
+		if quote != 0 {
+			if escaped {
+				escaped = false
+				continue
+			}
+			if char == '\\' {
+				escaped = true
+				continue
+			}
+			if char == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch char {
+		case '\'', '"', '`':
+			quote = char
+		case '(', '[', '{', '<':
+			depth++
+		case ')', ']', '}', '>':
+			if depth > 0 {
+				depth--
+			}
+		case '=':
+			if depth == 0 && (index+1 >= len(parameter) || parameter[index+1] != '>') &&
+				(index == 0 || (parameter[index-1] != '=' && parameter[index-1] != '!' && parameter[index-1] != '<' && parameter[index-1] != '>')) {
+				return index
+			}
+		}
+	}
+	return -1
+}
+
+func exploreParameterName(declaration string) string {
+	declaration = strings.TrimSpace(declaration)
+	if colon := exploreParameterTypeColon(declaration); colon >= 0 {
+		declaration = strings.TrimSpace(declaration[:colon])
+	}
+	fields := strings.Fields(declaration)
+	if len(fields) == 0 {
+		return ""
+	}
+	name := strings.Trim(fields[len(fields)-1], "*$&?!.[]{}()")
+	name = strings.TrimPrefix(name, "...")
+	name = strings.TrimPrefix(name, "$")
+	var b strings.Builder
+	for _, r := range name {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func exploreParameterTypeColon(declaration string) int {
+	for index := len(declaration) - 1; index >= 0; index-- {
+		if declaration[index] != ':' || (index > 0 && declaration[index-1] == ':') || (index+1 < len(declaration) && declaration[index+1] == ':') {
+			continue
+		}
+		return index
+	}
+	return -1
+}
+
+func exploreDefaultIdentifier(value string) string {
+	var b strings.Builder
+	for _, r := range value {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' {
+			b.WriteRune(unicode.ToLower(r))
+		}
+	}
+	return b.String()
+}
+
+func exploreParameterDefaultByName(defaults []exploreParameterDefault, name string) (exploreParameterDefault, bool) {
+	for _, candidate := range defaults {
+		if strings.EqualFold(candidate.name, name) {
+			return candidate, true
+		}
+	}
+	return exploreParameterDefault{}, false
+}
+
+func isNeutralExploreDefault(value string) bool {
+	value = strings.ToLower(strings.TrimSpace(value))
+	for len(value) >= 2 && value[0] == '(' && value[len(value)-1] == ')' {
+		value = strings.TrimSpace(value[1 : len(value)-1])
+	}
+	switch value {
+	case "null", "none", "nil", "undefined", "false", "''", "\"\"", "[]", "{}", "()", "array()":
+		return true
+	default:
+		return false
+	}
+}
+
+func isConcreteExploreDefault(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" || isNeutralExploreDefault(value) {
+		return false
+	}
+	lower := strings.ToLower(value)
+	if lower == "true" {
+		return true
+	}
+	if len(value) >= 2 && ((value[0] == '\'' && value[len(value)-1] == '\'') || (value[0] == '"' && value[len(value)-1] == '"')) {
+		return strings.TrimSpace(value[1:len(value)-1]) != ""
+	}
+	number := strings.ReplaceAll(value, "_", "")
+	parsed, err := strconv.ParseInt(number, 0, 64)
+	return err == nil && parsed != 0
+}
+
+func exploreDefaultParameterRelevantTerms(terms map[string]struct{}, name string) bool {
+	for _, term := range exploreDefaultIdentifierTerms(name) {
+		if len(term) < 4 || exploreGenericDefaultParameterTerm(term) {
+			continue
+		}
+		if _, found := terms[term]; found {
+			return true
+		}
+		if strings.HasSuffix(term, "s") {
+			if _, found := terms[strings.TrimSuffix(term, "s")]; found {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func exploreDefaultIdentifierTerms(name string) []string {
+	var terms []string
+	var token []rune
+	flush := func() {
+		if len(token) == 0 {
+			return
+		}
+		terms = append(terms, strings.ToLower(string(token)))
+		token = token[:0]
+	}
+	for _, r := range name {
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) {
+			flush()
+			continue
+		}
+		if len(token) > 0 && unicode.IsUpper(r) && unicode.IsLower(token[len(token)-1]) {
+			flush()
+		}
+		token = append(token, r)
+	}
+	flush()
+	return terms
+}
+
+func exploreGenericDefaultParameterTerm(term string) bool {
+	switch term {
+	case "arg", "argument", "config", "data", "default", "file", "option", "param", "parameter", "setting", "value":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/mcp/explore_divergent_default_owner_test.go
+++ b/internal/mcp/explore_divergent_default_owner_test.go
@@ -417,7 +417,8 @@ func TestHandleExplorePromotesDivergentDefaultOwnerFromSQLitePHPIndex(t *testing
 	req := mcpgo.CallToolRequest{}
 	req.Params.Name = "explore"
 	req.Params.Arguments = map[string]any{"task": task, "localize": true, "max_symbols": 30, "token_budget": 2400}
-	result, err := server.handleExplore(context.Background(), req)
+	ctx := WithSessionID(context.Background(), "php_divergent_default_contract")
+	result, err := server.handleExplore(ctx, req)
 	require.NoError(t, err)
 	require.False(t, result.IsError)
 	body, ok := singleTextContent(result)
@@ -429,6 +430,47 @@ func TestHandleExplorePromotesDivergentDefaultOwnerFromSQLitePHPIndex(t *testing
 	require.Equal(t, childType.ID, envelope.Symbols[1], body)
 	require.NotEmpty(t, envelope.Files)
 	require.True(t, strings.HasSuffix(filepath.ToSlash(envelope.Files[0]), "RotatingFileHandler.php"), body)
+	require.Equal(t, envelope.Completion.State == localizationStateAnswerReady, envelope.Terminal)
+	provenance := make(map[string]string, len(envelope.Evidence))
+	for _, row := range envelope.Evidence {
+		provenance[row.ID] = row.Provenance
+	}
+	require.Equal(t, localizationProvenanceDivergentDefault, provenance[childCtor.ID])
+	require.Equal(t, localizationProvenanceDivergentDefaultType, provenance[childType.ID])
+	requireLocalizationHostContractMatchesVisible(t, result, envelope)
+
+	switch envelope.Completion.State {
+	case localizationStateAnswerReady:
+		require.True(t, envelope.Terminal)
+		require.True(t, envelope.Completion.Enforceable)
+	case localizationStateNeedsExactRead:
+		require.False(t, envelope.Terminal)
+		require.False(t, envelope.Completion.Enforceable)
+		require.Equal(t, childCtor.ID, envelope.Completion.ExactSymbol)
+		readRequest := mcpgo.CallToolRequest{Params: mcpgo.CallToolParams{
+			Name: "read",
+			Arguments: map[string]any{
+				"operation": "source",
+				"target":    map[string]any{"symbol": childCtor.ID},
+			},
+		}}
+		readResult, readErr := server.handleFacade(ctx, "read", readRequest)
+		require.NoError(t, readErr)
+		require.NotNil(t, readResult)
+		require.False(t, readResult.IsError)
+		readBody, readOK := singleTextContent(readResult)
+		require.True(t, readOK)
+		require.Contains(t, readBody, `"state":"answer_ready"`)
+		require.Contains(t, readBody, `"terminal":true`)
+		require.Contains(t, readBody, `"enforceable":true`)
+		require.NotNil(t, readResult.Meta)
+		readHost, readHostOK := readResult.Meta.AdditionalFields[localizationHostMetaKey].(localizationHostEnvelope)
+		require.True(t, readHostOK)
+		require.True(t, readHost.Contract.Terminal)
+		require.True(t, readHost.Contract.Completion.Enforceable)
+	default:
+		t.Fatalf("divergent-default proof returned unexpected completion: %#v", envelope.Completion)
+	}
 }
 
 func newPHPDivergentDefaultServer(t *testing.T) (*Server, graph.Store) {

--- a/internal/mcp/explore_divergent_default_owner_test.go
+++ b/internal/mcp/explore_divergent_default_owner_test.go
@@ -1,0 +1,539 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/query"
+	"github.com/zzet/gortex/internal/search/rerank"
+)
+
+const monologForwardingConstructorSource = `public function __construct($filename, $maxFiles = 0, $filePermission = 0644) { parent::__construct($filename, $filePermission); }`
+
+type divergentDefaultFixture struct {
+	store                     graph.Store
+	targets                   []exploreTarget
+	write, baseType, baseCtor *graph.Node
+	childType, childCtor      *graph.Node
+}
+
+type countingDivergentDefaultStore struct {
+	graph.Store
+	nodeBatchCalls int
+	fileBatchCalls int
+	inBatchCalls   int
+	nodeBatchDelay time.Duration
+}
+
+func (s *countingDivergentDefaultStore) GetNodesByIDs(ids []string) map[string]*graph.Node {
+	s.nodeBatchCalls++
+	if s.nodeBatchDelay > 0 {
+		time.Sleep(s.nodeBatchDelay)
+	}
+	return s.Store.GetNodesByIDs(ids)
+}
+
+func (s *countingDivergentDefaultStore) GetFileNodesByPaths(paths []string) map[string][]*graph.Node {
+	s.fileBatchCalls++
+	return s.Store.GetFileNodesByPaths(paths)
+}
+
+func (s *countingDivergentDefaultStore) GetInEdgesByNodeIDs(ids []string) map[string][]*graph.Edge {
+	s.inBatchCalls++
+	return s.Store.GetInEdgesByNodeIDs(ids)
+}
+
+func divergentDefaultTestSource(node *graph.Node) string {
+	if node != nil && node.Name == "__construct" {
+		return monologForwardingConstructorSource
+	}
+	return ""
+}
+
+func divergentDefaultTestNode(id string, kind graph.NodeKind, name, path, signature string) *graph.Node {
+	meta := map[string]any{}
+	if signature != "" {
+		meta["signature"] = signature
+	}
+	return &graph.Node{
+		ID: id, Kind: kind, Name: name, QualName: strings.TrimPrefix(id[strings.LastIndex(id, "::")+2:], "."), FilePath: path,
+		Language: "php", RepoPrefix: "repo", WorkspaceID: "workspace", ProjectID: "project", Meta: meta,
+	}
+}
+
+func monologDivergentDefaultFixture() divergentDefaultFixture {
+	basePath := "src/Monolog/Handler/StreamHandler.php"
+	childPath := "src/Monolog/Handler/RotatingFileHandler.php"
+	write := divergentDefaultTestNode(basePath+"::StreamHandler.write", graph.KindMethod, "write", basePath, "protected function write(array $record)")
+	baseType := divergentDefaultTestNode(basePath+"::StreamHandler", graph.KindType, "StreamHandler", basePath, "class StreamHandler")
+	baseCtor := divergentDefaultTestNode(basePath+"::StreamHandler.__construct", graph.KindMethod, "__construct", basePath,
+		"public function __construct($stream, $level = null, $bubble = true, $filePermission = null)")
+	childType := divergentDefaultTestNode(childPath+"::RotatingFileHandler", graph.KindType, "RotatingFileHandler", childPath,
+		"class RotatingFileHandler extends StreamHandler")
+	childCtor := divergentDefaultTestNode(childPath+"::RotatingFileHandler.__construct", graph.KindMethod, "__construct", childPath,
+		"public function __construct($filename, $maxFiles = 0, $level = null, $bubble = true, $filePermission = 0644)")
+	store := graph.New()
+	store.AddBatch(
+		[]*graph.Node{write, baseType, baseCtor, childType, childCtor},
+		[]*graph.Edge{
+			{From: childCtor.ID, To: baseCtor.ID, Kind: graph.EdgeCalls},
+			{From: childType.ID, To: baseType.ID, Kind: graph.EdgeExtends},
+		},
+	)
+	return divergentDefaultFixture{
+		store: store,
+		targets: []exploreTarget{
+			{node: write, source: `fopen($this->url, 'a'); chmod($this->url, $this->filePermission);`, sourceLiteral: true},
+			{node: baseType},
+			{node: baseCtor},
+		},
+		write: write, baseType: baseType, baseCtor: baseCtor, childType: childType, childCtor: childCtor,
+	}
+}
+
+func TestDivergentDefaultOwnerPromotesFromStoreProjectionWithoutEviction(t *testing.T) {
+	task := `StreamHandler::write throws UnexpectedValueException "could not be opened: Permission denied" after upgrade, likely due to chmod and file permission handling`
+	fixture := monologDivergentDefaultFixture()
+	if got := rerank.ClassifyQuery(shapeExploreQuery(task)); got != rerank.QueryClassConcept {
+		t.Fatalf("Monolog issue classified as %q, want concept", got)
+	}
+	protected := divergentDefaultTestNode("src/Protected.php::Protected.run", graph.KindMethod, "run", "src/Protected.php", "function run()")
+	fixture.targets = append(fixture.targets, exploreTarget{node: protected, conceptImplementation: true})
+	originalCount := len(fixture.targets)
+	reads := 0
+	promoted := promoteExploreDivergentDefaultOwner(task, fixture.targets, fixture.store, len(fixture.targets), func(node *graph.Node) string {
+		reads++
+		require.Equal(t, fixture.childCtor.ID, node.ID)
+		return monologForwardingConstructorSource
+	})
+	require.Len(t, promoted, originalCount, "promotion must replace the represented base pair, not append and truncate")
+	require.Equal(t, fixture.childCtor.ID, promoted[0].node.ID)
+	require.True(t, promoted[0].divergentDefaultOwner)
+	require.Equal(t, fixture.childType.ID, promoted[1].node.ID)
+	require.True(t, promoted[1].divergentDefaultType)
+	require.Equal(t, fixture.write.ID, promoted[2].node.ID)
+	require.Equal(t, protected.ID, promoted[3].node.ID, "unrelated protected candidate was evicted")
+	require.Equal(t, 1, reads)
+	require.Equal(t, fixture.childCtor.ID, explorePreferredRefinementSymbol(task, promoted))
+
+	promoted = materializeExploreStructuralSourceWithReader(
+		context.Background(), task, promoted,
+		query.QueryOptions{WorkspaceID: "workspace", ProjectID: "project", RepoAllow: map[string]bool{"repo": true}},
+		func(_ context.Context, _ *graph.Node) string {
+			reads++
+			return "unexpected second read"
+		},
+	)
+	require.Equal(t, 1, reads, "proof source must be reused by materialization")
+
+	completion := newLocalizationRefinementCompletion(fixture.childCtor.ID)
+	result, _, _ := buildLocalizationExploreResultForTask(completion, task, promoted, exploreDefaultBudgetTokens)
+	body, ok := singleTextContent(result)
+	require.True(t, ok)
+	var envelope localizationExploreEnvelope
+	require.NoError(t, json.Unmarshal([]byte(body), &envelope))
+	require.GreaterOrEqual(t, len(envelope.Files), 2)
+	require.Equal(t, fixture.childCtor.FilePath, envelope.Files[0])
+	require.Equal(t, fixture.write.FilePath, envelope.Files[1])
+	require.GreaterOrEqual(t, len(envelope.Symbols), 3)
+	require.Equal(t, []string{fixture.childCtor.ID, fixture.childType.ID, fixture.write.ID}, envelope.Symbols[:3])
+}
+
+func TestDivergentDefaultOwnerRecoversBasePairFromRankedCallableOwner(t *testing.T) {
+	task := `StreamHandler::write reports "could not be opened: Permission denied" after a rotating handler applies chmod; find the divergent filePermission default and owning type`
+	fixture := monologDivergentDefaultFixture()
+	fixture.targets = fixture.targets[:1]
+	counted := &countingDivergentDefaultStore{Store: fixture.store}
+	reads := 0
+	promoted := promoteExploreDivergentDefaultOwner(task, fixture.targets, counted, 3, func(node *graph.Node) string {
+		reads++
+		require.Equal(t, fixture.childCtor.ID, node.ID)
+		return monologForwardingConstructorSource
+	})
+	require.Len(t, promoted, 3)
+	require.Equal(t, []string{fixture.childCtor.ID, fixture.childType.ID, fixture.write.ID}, []string{
+		promoted[0].node.ID, promoted[1].node.ID, promoted[2].node.ID,
+	})
+	require.Equal(t, 2, counted.nodeBatchCalls, "owner discovery and endpoint hydration must each be batched")
+	require.Equal(t, 1, counted.fileBatchCalls)
+	require.Equal(t, 1, counted.inBatchCalls)
+	require.Equal(t, 1, reads)
+}
+
+func TestDivergentDefaultOwnerAdmissionAtCapacityEvictsOnlyUnprotectedTail(t *testing.T) {
+	task := `StreamHandler::write reports "could not be opened: Permission denied" after a rotating handler applies chmod; find the divergent filePermission default and owning type`
+	fixture := monologDivergentDefaultFixture()
+	distractorOne := divergentDefaultTestNode("src/Noise.php::Noise.one", graph.KindMethod, "one", "src/Noise.php", "function one()")
+	distractorTwo := divergentDefaultTestNode("src/Noise.php::Noise.two", graph.KindMethod, "two", "src/Noise.php", "function two()")
+	fixture.targets = []exploreTarget{{node: fixture.write}, {node: distractorOne}, {node: distractorTwo}}
+
+	promoted := promoteExploreDivergentDefaultOwner(task, fixture.targets, fixture.store, len(fixture.targets), divergentDefaultTestSource)
+	require.Len(t, promoted, len(fixture.targets))
+	require.Equal(t, []string{fixture.childCtor.ID, fixture.childType.ID, fixture.write.ID}, []string{
+		promoted[0].node.ID, promoted[1].node.ID, promoted[2].node.ID,
+	})
+
+	protectedLiteral := exploreTarget{node: distractorOne, sourceLiteral: true}
+	protectedImplementation := exploreTarget{node: distractorTwo, conceptImplementation: true}
+	fixture.targets = []exploreTarget{{node: fixture.write}, protectedLiteral, protectedImplementation}
+	unchanged := promoteExploreDivergentDefaultOwner(task, fixture.targets, fixture.store, len(fixture.targets), divergentDefaultTestSource)
+	require.Equal(t, []string{fixture.write.ID, distractorOne.ID, distractorTwo.ID}, []string{
+		unchanged[0].node.ID, unchanged[1].node.ID, unchanged[2].node.ID,
+	})
+	require.True(t, unchanged[1].sourceLiteral)
+	require.True(t, unchanged[2].conceptImplementation)
+}
+
+func TestDivergentDefaultOwnerCallableFallbackFailsClosed(t *testing.T) {
+	task := `StreamHandler::write reports "could not be opened: Permission denied" after a rotating handler applies chmod; find the divergent filePermission default and owning type`
+	t.Run("no output capacity", func(t *testing.T) {
+		fixture := monologDivergentDefaultFixture()
+		fixture.targets = fixture.targets[:1]
+		got := promoteExploreDivergentDefaultOwner(task, fixture.targets, fixture.store, 2, divergentDefaultTestSource)
+		require.Equal(t, []exploreTarget{fixture.targets[0]}, got)
+	})
+	t.Run("irrelevant ranked callable", func(t *testing.T) {
+		fixture := monologDivergentDefaultFixture()
+		fixture.targets = fixture.targets[:1]
+		got := promoteExploreDivergentDefaultOwner("Investigate queue retry scheduling and backoff policy", fixture.targets, fixture.store, 3, divergentDefaultTestSource)
+		require.Equal(t, fixture.write.ID, got[0].node.ID)
+		require.Len(t, got, 1)
+	})
+	t.Run("ambiguous constructors for exact owner", func(t *testing.T) {
+		fixture := monologDivergentDefaultFixture()
+		fixture.targets = fixture.targets[:1]
+		alternate := divergentDefaultTestNode(
+			fixture.baseType.FilePath+"::StreamHandler.StreamHandler",
+			graph.KindMethod,
+			"StreamHandler",
+			fixture.baseType.FilePath,
+			`function StreamHandler($filePermission = null)`,
+		)
+		fixture.store.AddNode(alternate)
+		got := promoteExploreDivergentDefaultOwner(task, fixture.targets, fixture.store, 3, divergentDefaultTestSource)
+		require.Equal(t, fixture.write.ID, got[0].node.ID)
+		require.Len(t, got, 1)
+	})
+	t.Run("oversized owner file", func(t *testing.T) {
+		fixture := monologDivergentDefaultFixture()
+		fixture.targets = fixture.targets[:1]
+		for index := 0; index < exploreDefaultOwnerFileNodeCap; index++ {
+			fixture.store.AddNode(divergentDefaultTestNode(
+				fmt.Sprintf("%s::StreamHandler.helper%02d", fixture.baseType.FilePath, index),
+				graph.KindMethod,
+				fmt.Sprintf("helper%02d", index),
+				fixture.baseType.FilePath,
+				"function helper()",
+			))
+		}
+		got := promoteExploreDivergentDefaultOwner(task, fixture.targets, fixture.store, 3, divergentDefaultTestSource)
+		require.Equal(t, fixture.write.ID, got[0].node.ID)
+		require.Len(t, got, 1)
+	})
+	t.Run("owner hydration exceeds admission budget", func(t *testing.T) {
+		fixture := monologDivergentDefaultFixture()
+		fixture.targets = fixture.targets[:1]
+		counted := &countingDivergentDefaultStore{Store: fixture.store, nodeBatchDelay: exploreDefaultOwnerFallbackSLO + time.Millisecond}
+		got := promoteExploreDivergentDefaultOwner(task, fixture.targets, counted, 3, divergentDefaultTestSource)
+		require.Equal(t, fixture.write.ID, got[0].node.ID)
+		require.Len(t, got, 1)
+		require.Equal(t, 1, counted.nodeBatchCalls)
+		require.Zero(t, counted.fileBatchCalls)
+	})
+}
+
+func TestDivergentDefaultOwnerFailsClosedOnMissingOrInvalidStoreEvidence(t *testing.T) {
+	task := "permission denied after the rotating file handler changed its default permission"
+	tests := []struct {
+		name   string
+		mutate func(divergentDefaultFixture)
+	}{
+		{"missing call edge", func(f divergentDefaultFixture) { f.store.RemoveEdge(f.childCtor.ID, f.baseCtor.ID, graph.EdgeCalls) }},
+		{"missing extends edge", func(f divergentDefaultFixture) { f.store.RemoveEdge(f.childType.ID, f.baseType.ID, graph.EdgeExtends) }},
+		{"neutral child default", func(f divergentDefaultFixture) {
+			f.childCtor.Meta["signature"] = `function __construct($filePermission = null)`
+		}},
+		{"irrelevant parameter", func(f divergentDefaultFixture) {
+			f.baseCtor.Meta["signature"] = `function __construct($retryCount = null)`
+			f.childCtor.Meta["signature"] = `function __construct($retryCount = 3)`
+		}},
+		{"concrete base default", func(f divergentDefaultFixture) {
+			f.baseCtor.Meta["signature"] = `function __construct($filePermission = 0600)`
+		}},
+		{"cross-repository child", func(f divergentDefaultFixture) {
+			f.childCtor.RepoPrefix = "other"
+			f.childType.RepoPrefix = "other"
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := monologDivergentDefaultFixture()
+			test.mutate(fixture)
+			got := promoteExploreDivergentDefaultOwner(task, fixture.targets, fixture.store, len(fixture.targets), divergentDefaultTestSource)
+			require.Equal(t, fixture.write.ID, got[0].node.ID)
+			require.False(t, got[0].divergentDefaultOwner)
+		})
+	}
+}
+
+func TestDivergentDefaultOwnerRejectsAmbiguousOrOversizedInboundProjection(t *testing.T) {
+	task := "permission denied after the rotating file handler changed its default permission"
+	t.Run("ambiguous", func(t *testing.T) {
+		fixture := monologDivergentDefaultFixture()
+		secondType := divergentDefaultTestNode("src/Weekly.php::WeeklyFileHandler", graph.KindType, "WeeklyFileHandler", "src/Weekly.php", "class WeeklyFileHandler extends StreamHandler")
+		secondCtor := divergentDefaultTestNode("src/Weekly.php::WeeklyFileHandler.__construct", graph.KindMethod, "__construct", secondType.FilePath, `function __construct($filePermission = 0660)`)
+		fixture.store.AddBatch([]*graph.Node{secondType, secondCtor}, []*graph.Edge{
+			{From: secondCtor.ID, To: fixture.baseCtor.ID, Kind: graph.EdgeCalls},
+			{From: secondType.ID, To: fixture.baseType.ID, Kind: graph.EdgeExtends},
+		})
+		got := promoteExploreDivergentDefaultOwner(task, fixture.targets, fixture.store, len(fixture.targets), divergentDefaultTestSource)
+		require.Equal(t, fixture.write.ID, got[0].node.ID)
+	})
+	t.Run("edge cap", func(t *testing.T) {
+		fixture := monologDivergentDefaultFixture()
+		nodes := make([]*graph.Node, 0, exploreDefaultOwnerEdgeCap)
+		edges := make([]*graph.Edge, 0, exploreDefaultOwnerEdgeCap)
+		for index := 0; index < exploreDefaultOwnerEdgeCap; index++ {
+			node := divergentDefaultTestNode(fmt.Sprintf("src/Extra%02d.php::Extra%02d.__construct", index, index), graph.KindMethod, "__construct", fmt.Sprintf("src/Extra%02d.php", index), `function __construct($filePermission = 0600)`)
+			nodes = append(nodes, node)
+			edges = append(edges, &graph.Edge{From: node.ID, To: fixture.baseCtor.ID, Kind: graph.EdgeCalls})
+		}
+		fixture.store.AddBatch(nodes, edges)
+		got := promoteExploreDivergentDefaultOwner(task, fixture.targets, fixture.store, len(fixture.targets), divergentDefaultTestSource)
+		require.Equal(t, fixture.write.ID, got[0].node.ID)
+	})
+}
+
+func TestDivergentDefaultOrderSurvivesOwnerFolding(t *testing.T) {
+	fixture := monologDivergentDefaultFixture()
+	targets := []exploreTarget{
+		{node: fixture.childType, divergentDefaultType: true},
+		{node: fixture.write},
+		{node: fixture.childCtor, divergentDefaultOwner: true},
+	}
+	got := preserveExploreDivergentDefaultOrder(targets)
+	require.Equal(t, []string{fixture.childCtor.ID, fixture.childType.ID, fixture.write.ID}, []string{got[0].node.ID, got[1].node.ID, got[2].node.ID})
+}
+
+func TestParseExploreParameterDefaultsAcrossLanguages(t *testing.T) {
+	tests := []struct {
+		name, signature, parameter, value string
+		neutral                           bool
+	}{
+		{"php", `function __construct($filePermission = null)`, "filePermission", "null", true},
+		{"python", `def __init__(self, file_permission: int | None = None)`, "file_permission", "None", true},
+		{"typescript", `constructor(filePermission: number | null = 0o644)`, "filePermission", "0o644", false},
+		{"csharp", `Handler(int? filePermission = 420)`, "filePermission", "420", false},
+		{"kotlin", `constructor(filePermission: Int? = null)`, "filePermission", "null", true},
+		{"ruby", `def initialize(file_permission = 0o644)`, "file_permission", "0o644", false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			defaults := parseExploreParameterDefaults(test.signature)
+			got, found := exploreParameterDefaultByName(defaults, test.parameter)
+			require.True(t, found)
+			require.Equal(t, test.value, got.value)
+			require.Equal(t, test.neutral, isNeutralExploreDefault(got.value))
+			require.NotEqual(t, test.neutral, isConcreteExploreDefault(got.value))
+		})
+	}
+}
+
+func TestDivergentDefaultOwnerRequiresExecutableForwardingIntoProvenBaseCall(t *testing.T) {
+	task := "permission denied after the rotating file handler changed its default permission"
+	negative := []string{
+		`function __construct($filePermission = 0644) { $this->filePermission = $filePermission; parent::__construct($filename); }`,
+		`function __construct($filePermission = 0644) { helper($filePermission); parent::__construct($filename); }`,
+		`function __construct($filePermission = 0644) { /* parent::__construct($filePermission); */ parent::__construct($filename); }`,
+		`function __construct($filePermission = 0644) { throw new Exception("parent::__construct($filePermission)"); }`,
+		`function __construct($filePermission = 0644) { parent::__construct($filename, "$filePermission"); }`,
+		`function __construct($filePermission = 0644) { parent::__construct($filename /* $filePermission */); }`,
+		"",
+	}
+	for _, source := range negative {
+		fixture := monologDivergentDefaultFixture()
+		got := promoteExploreDivergentDefaultOwner(task, fixture.targets, fixture.store, len(fixture.targets), func(*graph.Node) string { return source })
+		require.Equal(t, fixture.write.ID, got[0].node.ID, "non-executable forwarding was accepted: %q", source)
+	}
+}
+
+func TestConstructorForwardingProofAcrossLanguages(t *testing.T) {
+	tests := []struct{ name, source, parameter, base string }{
+		{"php", `parent::__construct($path, $filePermission);`, "filePermission", "StreamHandler"},
+		{"python", `super().__init__(path, file_permission)`, "file_permission", "StreamHandler"},
+		{"typescript", `super(path, filePermission);`, "filePermission", "StreamHandler"},
+		{"csharp", `RotatingHandler(string path, int permission = 420) : base(path, permission) {}`, "permission", "StreamHandler"},
+		{"kotlin", `class Rotating(path: String, permission: Int = 420) : StreamHandler(path, permission)`, "permission", "StreamHandler"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.True(t, exploreConstructorForwardsParameter(test.source, test.parameter, test.base))
+		})
+	}
+}
+
+func TestHandleExplorePromotesDivergentDefaultOwnerFromSQLitePHPIndex(t *testing.T) {
+	server, store := newPHPDivergentDefaultServer(t)
+	write := requirePHPFixtureNode(t, store, "StreamHandler.php", "write", graph.KindMethod)
+	baseType := requirePHPFixtureNode(t, store, "StreamHandler.php", "StreamHandler", graph.KindType)
+	baseCtor := requirePHPFixtureNode(t, store, "StreamHandler.php", "__construct", graph.KindMethod)
+	childType := requirePHPFixtureNode(t, store, "RotatingFileHandler.php", "RotatingFileHandler", graph.KindType)
+	childCtor := requirePHPFixtureNode(t, store, "RotatingFileHandler.php", "__construct", graph.KindMethod)
+	baseContract := requirePHPFixtureNode(t, store, "StreamHandler.php", "BaseContract", graph.KindInterface)
+	childContract := requirePHPFixtureNode(t, store, "StreamHandler.php", "ChildContract", graph.KindInterface)
+	serializableContract := requirePHPFixtureNode(t, store, "StreamHandler.php", "SerializableContract", graph.KindInterface)
+	statusType := requirePHPFixtureNode(t, store, "StreamHandler.php", "HandlerStatus", graph.KindType)
+	require.Contains(t, baseCtor.RetrievalMetadata().Signature, "filePermission")
+	require.Contains(t, childCtor.RetrievalMetadata().Signature, "0644")
+	require.True(t, hasFixtureEdge(store.GetInEdges(baseCtor.ID), childCtor.ID, baseCtor.ID, graph.EdgeCalls), "PHP index must resolve child ctor -> base ctor")
+	require.True(t, hasFixtureEdge(store.GetInEdges(baseType.ID), childType.ID, baseType.ID, graph.EdgeExtends), "PHP index must resolve child type -> base type; child out=%v base in=%v", fixtureEdgeStrings(store.GetOutEdges(childType.ID)), fixtureEdgeStrings(store.GetInEdges(baseType.ID)))
+	require.True(t, hasFixtureEdge(store.GetInEdges(baseContract.ID), childContract.ID, baseContract.ID, graph.EdgeExtends), "PHP index must resolve interface inheritance")
+	require.True(t, hasFixtureEdge(store.GetInEdges(serializableContract.ID), statusType.ID, serializableContract.ID, graph.EdgeImplements), "PHP index must resolve enum conformance")
+
+	task := `StreamHandler::write reports "could not be opened: Permission denied" after a rotating handler applies chmod; find the divergent filePermission default and owning type`
+	direct := promoteExploreDivergentDefaultOwner(task, []exploreTarget{{node: write}, {node: baseType}, {node: baseCtor}}, store, 3, func(node *graph.Node) string {
+		return server.manifestSymbolSource(context.Background(), node)
+	})
+	require.Equal(t, childCtor.ID, direct[0].node.ID, "real store projection did not promote child constructor")
+	fallback := promoteExploreDivergentDefaultOwner(task, []exploreTarget{{node: write}}, store, 3, func(node *graph.Node) string {
+		return server.manifestSymbolSource(context.Background(), node)
+	})
+	require.Equal(t, childCtor.ID, fallback[0].node.ID, "real store callable-owner fallback did not promote child constructor")
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Name = "explore"
+	req.Params.Arguments = map[string]any{"task": task, "localize": true, "max_symbols": 30, "token_budget": 2400}
+	result, err := server.handleExplore(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	body, ok := singleTextContent(result)
+	require.True(t, ok)
+	var envelope localizationExploreEnvelope
+	require.NoError(t, json.Unmarshal([]byte(body), &envelope), body)
+	require.GreaterOrEqual(t, len(envelope.Symbols), 2, body)
+	require.Equal(t, childCtor.ID, envelope.Symbols[0], body)
+	require.Equal(t, childType.ID, envelope.Symbols[1], body)
+	require.NotEmpty(t, envelope.Files)
+	require.True(t, strings.HasSuffix(filepath.ToSlash(envelope.Files[0]), "RotatingFileHandler.php"), body)
+}
+
+func newPHPDivergentDefaultServer(t *testing.T) (*Server, graph.Store) {
+	t.Helper()
+	root := t.TempDir()
+	handlerDir := filepath.Join(root, "src", "Monolog", "Handler")
+	require.NoError(t, os.MkdirAll(handlerDir, 0o755))
+	stream := `<?php
+namespace Monolog\Handler;
+interface BaseContract {}
+interface ChildContract extends BaseContract {}
+interface SerializableContract {}
+enum HandlerStatus implements SerializableContract { case Ready; }
+/** Stream handler that opens files and applies the configured file permission. */
+class StreamHandler {
+    /** Configure the neutral file permission default later consumed by write. */
+    public function __construct($stream, $level = null, $bubble = true, $filePermission = null) {}
+    protected function write(array $record): void {
+        chmod($record['path'], $this->filePermission);
+        throw new \UnexpectedValueException('could not be opened: Permission denied');
+    }
+}
+`
+	rotating := `<?php
+namespace Monolog\Handler;
+/** Rotating handler with a concrete file permission constructor default. */
+class RotatingFileHandler extends StreamHandler {
+    /** Forward the concrete file permission default into the stream handler. */
+    public function __construct($filename, $maxFiles = 0, $level = null, $bubble = true, $filePermission = 0644) {
+        parent::__construct($filename, $level, $bubble, $filePermission);
+    }
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(handlerDir, "StreamHandler.php"), []byte(stream), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(handlerDir, "RotatingFileHandler.php"), []byte(rotating), 0o644))
+	store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "graph.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	cfg := config.Default()
+	idx := indexer.New(store, testRegistry(), cfg.Index, zap.NewNop())
+	_, err = idx.Index(root)
+	require.NoError(t, err)
+	server := NewServer(query.NewEngine(store), store, idx, nil, zap.NewNop(), nil)
+	return server, store
+}
+
+func requirePHPFixtureNode(t *testing.T, store graph.Store, fileSuffix, name string, kind graph.NodeKind) *graph.Node {
+	t.Helper()
+	for _, node := range store.FindNodesByName(name) {
+		if node != nil && node.Kind == kind && strings.HasSuffix(filepath.ToSlash(node.FilePath), fileSuffix) {
+			return node
+		}
+	}
+	t.Fatalf("missing PHP fixture node %s %s in %s", kind, name, fileSuffix)
+	return nil
+}
+
+func hasFixtureEdge(edges []*graph.Edge, from, to string, kind graph.EdgeKind) bool {
+	for _, edge := range edges {
+		if edge != nil && edge.From == from && edge.To == to && edge.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func fixtureEdgeStrings(edges []*graph.Edge) []string {
+	result := make([]string, 0, len(edges))
+	for _, edge := range edges {
+		if edge != nil {
+			result = append(result, fmt.Sprintf("%s --%s--> %s", edge.From, edge.Kind, edge.To))
+		}
+	}
+	return result
+}
+
+func BenchmarkPromoteExploreDivergentDefaultOwner24(b *testing.B) {
+	fixture := monologDivergentDefaultFixture()
+	for index := len(fixture.targets); index < 24; index++ {
+		node := divergentDefaultTestNode(fmt.Sprintf("src/Distractor%02d.php::Distractor%02d.run", index, index), graph.KindMethod, "run", fmt.Sprintf("src/Distractor%02d.php", index), "function run($value = null)")
+		fixture.targets = append(fixture.targets, exploreTarget{node: node})
+	}
+	task := "permission denied after the rotating file handler changed its default permission"
+	b.ReportAllocs()
+	b.ResetTimer()
+	for index := 0; index < b.N; index++ {
+		if got := promoteExploreDivergentDefaultOwner(task, fixture.targets, fixture.store, len(fixture.targets), divergentDefaultTestSource); !got[0].divergentDefaultOwner {
+			b.Fatal("expected promotion")
+		}
+	}
+}
+
+func BenchmarkPromoteExploreDivergentDefaultOwnerFromCallable24(b *testing.B) {
+	fixture := monologDivergentDefaultFixture()
+	fixture.targets = fixture.targets[:1]
+	for index := len(fixture.targets); index < 24; index++ {
+		node := divergentDefaultTestNode(fmt.Sprintf("src/Distractor%02d.php::Distractor%02d.run", index, index), graph.KindMethod, "run", fmt.Sprintf("src/Distractor%02d.php", index), "function run($value = null)")
+		fixture.targets = append(fixture.targets, exploreTarget{node: node})
+	}
+	task := `StreamHandler::write reports "could not be opened: Permission denied" after a rotating handler applies chmod; find the divergent filePermission default and owning type`
+	b.ReportAllocs()
+	b.ResetTimer()
+	for index := 0; index < b.N; index++ {
+		if got := promoteExploreDivergentDefaultOwner(task, fixture.targets, fixture.store, 26, divergentDefaultTestSource); !got[0].divergentDefaultOwner {
+			b.Fatal("expected promotion")
+		}
+	}
+}

--- a/internal/mcp/explore_implementation_intent.go
+++ b/internal/mcp/explore_implementation_intent.go
@@ -1,0 +1,204 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"unicode"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Implementation-intent localization.
+//
+// A query asking where something is IMPLEMENTED must return the concrete
+// code that changes, not only the interface that names it. Ranking cannot
+// guarantee that: an interface declaration legitimately dominates the text
+// and centrality signals for its own name, so the concrete members that a
+// fix actually edits can fall below the envelope cut. When the query
+// expresses implementation intent, strong interface/abstract seeds in the
+// ranked head expand through bounded implements/overrides relations, and a
+// result whose head is exclusively abstract declarations refuses to declare
+// answer_ready.
+//
+// Every rule here is generic: intent detection is plain English vocabulary,
+// expansion walks graph relations, and nothing names a repository, an
+// issue, or benchmark vocabulary.
+
+const (
+	// exploreImplSeedScan bounds how deep into the ranked head seeds are
+	// considered; expansion never reorders the head above this line.
+	exploreImplSeedScan = 5
+	// exploreImplPerSeed bounds implementors admitted per abstract seed.
+	exploreImplPerSeed = 4
+	// exploreImplFileReserve is the number of DISTINCT implementation files
+	// the expansion reserves in the final candidate set.
+	exploreImplFileReserve = 3
+)
+
+var exploreImplementationIntentTerms = []string{
+	"implementation", "implementations", "implement", "implements",
+	"implemented", "implementing", "implementor", "implementors",
+	"implementer", "implementers", "concrete", "override", "overrides",
+	"overriding", "overridden", "subclass", "subclasses",
+}
+
+// exploreImplementationIntent reports whether the task text asks for the
+// implementing/concrete side of an abstraction. Deliberately a plain word
+// scan: the terminal-terms shaping drops or restems exactly the vocabulary
+// this must detect.
+func exploreImplementationIntent(task string) bool {
+	for _, field := range strings.FieldsFunc(strings.ToLower(task), func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	}) {
+		for _, intent := range exploreImplementationIntentTerms {
+			if field == intent {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// exploreAbstractSeed reports whether a ranked node is an abstract
+// declaration an implementation-intent query must expand: an interface, or
+// an interface member (owner resolved through member_of).
+func exploreAbstractSeed(getOut func(string) []*graph.Edge, getNode func(string) *graph.Node, n *graph.Node) (owner *graph.Node, abstract bool) {
+	if n == nil {
+		return nil, false
+	}
+	if n.Kind == graph.KindInterface {
+		return n, true
+	}
+	if n.Kind != graph.KindMethod && n.Kind != graph.KindFunction {
+		return nil, false
+	}
+	for _, e := range getOut(n.ID) {
+		if e == nil || e.Kind != graph.EdgeMemberOf {
+			continue
+		}
+		if ownerNode := getNode(e.To); ownerNode != nil && ownerNode.Kind == graph.KindInterface {
+			return ownerNode, true
+		}
+	}
+	return nil, false
+}
+
+// expandImplementationTargets inserts concrete implementors after abstract
+// seeds in the ranked head. Interface seeds admit their implementing types;
+// interface-member seeds admit the same-name members of those implementors.
+// The abstract seed is never evicted, admitted implementors cover at most
+// exploreImplFileReserve distinct new files, and every walk is one bounded
+// relation hop — no transitive traversal.
+func (s *Server) expandImplementationTargets(ctx context.Context, targets []exploreTarget) []exploreTarget {
+	eng := s.engineFor(ctx)
+	if eng == nil || len(targets) == 0 {
+		return targets
+	}
+	present := make(map[string]struct{}, len(targets))
+	presentFiles := make(map[string]struct{}, len(targets))
+	for _, t := range targets {
+		if t.node != nil {
+			present[t.node.ID] = struct{}{}
+			presentFiles[t.node.FilePath] = struct{}{}
+		}
+	}
+
+	newFiles := make(map[string]struct{}, exploreImplFileReserve)
+	admit := func(n *graph.Node) bool {
+		if n == nil || n.ID == "" {
+			return false
+		}
+		if _, dup := present[n.ID]; dup {
+			return false
+		}
+		if _, known := presentFiles[n.FilePath]; !known {
+			if len(newFiles) >= exploreImplFileReserve {
+				return false
+			}
+			newFiles[n.FilePath] = struct{}{}
+		}
+		present[n.ID] = struct{}{}
+		return true
+	}
+
+	implementorsOf := func(ownerID string) []*graph.Node {
+		var out []*graph.Node
+		for _, e := range eng.GetInEdges(ownerID) {
+			if e == nil || (e.Kind != graph.EdgeImplements && e.Kind != graph.EdgeExtends) {
+				continue
+			}
+			if impl := eng.GetSymbol(e.From); impl != nil {
+				out = append(out, impl)
+				if len(out) == exploreImplPerSeed {
+					break
+				}
+			}
+		}
+		return out
+	}
+	memberOf := func(typeID, name string) *graph.Node {
+		for _, e := range eng.GetInEdges(typeID) {
+			if e == nil || e.Kind != graph.EdgeMemberOf {
+				continue
+			}
+			if member := eng.GetSymbol(e.From); member != nil && member.Name == name {
+				return member
+			}
+		}
+		return nil
+	}
+
+	expanded := make([]exploreTarget, 0, len(targets)+exploreImplPerSeed)
+	for index, t := range targets {
+		expanded = append(expanded, t)
+		if index >= exploreImplSeedScan || t.node == nil {
+			continue
+		}
+		owner, abstract := exploreAbstractSeed(eng.GetOutEdges, eng.GetSymbol, t.node)
+		if !abstract {
+			continue
+		}
+		memberName := ""
+		if owner.ID != t.node.ID {
+			memberName = t.node.Name
+		}
+		for _, impl := range implementorsOf(owner.ID) {
+			concrete := impl
+			if memberName != "" {
+				if member := memberOf(impl.ID, memberName); member != nil {
+					concrete = member
+				}
+			}
+			if !admit(concrete) {
+				continue
+			}
+			expanded = append(expanded, exploreTarget{
+				node:  concrete,
+				score: t.score * 0.98,
+			})
+		}
+	}
+	return expanded
+}
+
+// exploreImplementationAnswerBlocked refuses answer_ready when an
+// implementation-intent query's visible head holds only abstract
+// declarations: the concrete code the query asks for is not in evidence.
+func exploreImplementationAnswerBlocked(task string, targets []exploreTarget, getOut func(string) []*graph.Edge, getNode func(string) *graph.Node) bool {
+	if !exploreImplementationIntent(task) {
+		return false
+	}
+	scanned := 0
+	for _, t := range targets {
+		if t.node == nil {
+			continue
+		}
+		if scanned++; scanned > exploreImplSeedScan {
+			break
+		}
+		if _, abstract := exploreAbstractSeed(getOut, getNode, t.node); !abstract {
+			return false
+		}
+	}
+	return scanned > 0
+}

--- a/internal/mcp/explore_implementation_intent_test.go
+++ b/internal/mcp/explore_implementation_intent_test.go
@@ -1,0 +1,104 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/query"
+)
+
+// Neutral fixture: Storage.load is declared by an interface and implemented
+// by DiskStorage and CloudStorage in separate files.
+func newStorageFixtureServer(t *testing.T) (*Server, *graph.Graph) {
+	t.Helper()
+	g := graph.New()
+	nodes := []*graph.Node{
+		{ID: "repo/storage/storage.go::Storage", Kind: graph.KindInterface, Name: "Storage", FilePath: "repo/storage/storage.go", Language: "go"},
+		{ID: "repo/storage/storage.go::Storage.load", Kind: graph.KindMethod, Name: "load", FilePath: "repo/storage/storage.go", Language: "go"},
+		{ID: "repo/storage/disk.go::DiskStorage", Kind: graph.KindType, Name: "DiskStorage", FilePath: "repo/storage/disk.go", Language: "go"},
+		{ID: "repo/storage/disk.go::DiskStorage.load", Kind: graph.KindMethod, Name: "load", FilePath: "repo/storage/disk.go", Language: "go"},
+		{ID: "repo/storage/cloud.go::CloudStorage", Kind: graph.KindType, Name: "CloudStorage", FilePath: "repo/storage/cloud.go", Language: "go"},
+		{ID: "repo/storage/cloud.go::CloudStorage.load", Kind: graph.KindMethod, Name: "load", FilePath: "repo/storage/cloud.go", Language: "go"},
+	}
+	edges := []*graph.Edge{
+		{From: "repo/storage/storage.go::Storage.load", To: "repo/storage/storage.go::Storage", Kind: graph.EdgeMemberOf},
+		{From: "repo/storage/disk.go::DiskStorage", To: "repo/storage/storage.go::Storage", Kind: graph.EdgeImplements},
+		{From: "repo/storage/cloud.go::CloudStorage", To: "repo/storage/storage.go::Storage", Kind: graph.EdgeImplements},
+		{From: "repo/storage/disk.go::DiskStorage.load", To: "repo/storage/disk.go::DiskStorage", Kind: graph.EdgeMemberOf},
+		{From: "repo/storage/cloud.go::CloudStorage.load", To: "repo/storage/cloud.go::CloudStorage", Kind: graph.EdgeMemberOf},
+	}
+	g.AddBatch(nodes, edges)
+	return NewServer(query.NewEngine(g), g, nil, nil, zap.NewNop(), nil), g
+}
+
+func TestExploreImplementationIntentVocabulary(t *testing.T) {
+	positives := []string{
+		"where is the concrete implementation of Storage.load",
+		"find the classes that implement Storage",
+		"which subclasses override load",
+	}
+	for _, task := range positives {
+		if !exploreImplementationIntent(task) {
+			t.Fatalf("intent not detected: %q", task)
+		}
+	}
+	if exploreImplementationIntent("where is Storage.load declared") {
+		t.Fatal("declaration query must not carry implementation intent")
+	}
+}
+
+// An interface seed expands to its implementing types; an interface-member
+// seed expands to the same-name concrete members. The abstract seed is never
+// evicted and new files are bounded.
+func TestExpandImplementationTargets(t *testing.T) {
+	s, g := newStorageFixtureServer(t)
+	seed := exploreTarget{node: g.GetNode("repo/storage/storage.go::Storage.load"), score: 1.0}
+
+	expanded := s.expandImplementationTargets(context.Background(), []exploreTarget{seed})
+	if expanded[0].node.ID != "repo/storage/storage.go::Storage.load" {
+		t.Fatal("abstract seed must stay at its rank")
+	}
+	got := map[string]bool{}
+	for _, tgt := range expanded[1:] {
+		got[tgt.node.ID] = true
+	}
+	if !got["repo/storage/disk.go::DiskStorage.load"] || !got["repo/storage/cloud.go::CloudStorage.load"] {
+		t.Fatalf("member seed must expand to same-name concrete members, got %v", got)
+	}
+
+	ifaceSeed := exploreTarget{node: g.GetNode("repo/storage/storage.go::Storage"), score: 1.0}
+	expanded = s.expandImplementationTargets(context.Background(), []exploreTarget{ifaceSeed})
+	got = map[string]bool{}
+	for _, tgt := range expanded[1:] {
+		got[tgt.node.ID] = true
+	}
+	if !got["repo/storage/disk.go::DiskStorage"] || !got["repo/storage/cloud.go::CloudStorage"] {
+		t.Fatalf("interface seed must expand to implementing types, got %v", got)
+	}
+}
+
+// Only-abstract evidence blocks answer_ready for implementation intent;
+// the presence of one concrete implementor unblocks it, and non-intent
+// queries are never touched.
+func TestImplementationAnswerBlockedOnAbstractOnlyHead(t *testing.T) {
+	s, g := newStorageFixtureServer(t)
+	eng := s.engineFor(context.Background())
+	task := "find the concrete implementation of Storage.load"
+	abstractOnly := []exploreTarget{
+		{node: g.GetNode("repo/storage/storage.go::Storage.load")},
+		{node: g.GetNode("repo/storage/storage.go::Storage")},
+	}
+	if !exploreImplementationAnswerBlocked(task, abstractOnly, eng.GetOutEdges, eng.GetSymbol) {
+		t.Fatal("abstract-only head must block answer_ready for implementation intent")
+	}
+	withConcrete := append(abstractOnly, exploreTarget{node: g.GetNode("repo/storage/disk.go::DiskStorage.load")})
+	if exploreImplementationAnswerBlocked(task, withConcrete, eng.GetOutEdges, eng.GetSymbol) {
+		t.Fatal("a concrete implementor in the head must unblock answer_ready")
+	}
+	if exploreImplementationAnswerBlocked("where is Storage.load declared", abstractOnly, eng.GetOutEdges, eng.GetSymbol) {
+		t.Fatal("non-intent queries must be untouched")
+	}
+}

--- a/internal/mcp/explore_literal_provenance.go
+++ b/internal/mcp/explore_literal_provenance.go
@@ -1,0 +1,55 @@
+package mcp
+
+import (
+	"strings"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+)
+
+// Terminal-confidence provenance.
+//
+// A quoted-literal match may make localization terminal, but terminal
+// confidence must be supported by evidence the agent can actually see: if
+// the envelope sheds the matching source body under its byte budget, the
+// session is told "answer now" while holding no visible trace of the very
+// evidence that justified stopping. Literal-driven terminality therefore
+// requires the serialized envelope to contain the literal; otherwise the
+// contract downgrades to the ordinary bounded refinement read.
+
+// exploreAnswerReadyViaLiteralOnly reports whether a terminal verdict rests
+// solely on the exact-content rung: with the head's literal flags stripped,
+// the same targets would not be terminal. Callers invoke it only after
+// exploreAnswerReady returned true.
+func exploreAnswerReadyViaLiteralOnly(task string, targets []exploreTarget) bool {
+	if len(targets) == 0 || !targets[0].exactContent {
+		return false
+	}
+	stripped := append([]exploreTarget(nil), targets...)
+	stripped[0].exactContent = false
+	stripped[0].exactContentAmbiguous = false
+	return !exploreAnswerReady(task, stripped)
+}
+
+// exploreResultCitesTaskLiteral reports whether the serialized localization
+// result visibly contains one of the task's quoted literals. Case-exact for
+// double-quoted content evidence; a task without quoted literals passes
+// vacuously (the gate only arms on literal-driven terminality).
+func exploreResultCitesTaskLiteral(result *mcpgo.CallToolResult, task string) bool {
+	literals := exploreQuotedRecallTerms(task)
+	if len(literals) == 0 {
+		return true
+	}
+	if result == nil || len(result.Content) == 0 {
+		return false
+	}
+	text, ok := result.Content[0].(mcpgo.TextContent)
+	if !ok {
+		return false
+	}
+	for _, literal := range literals {
+		if literal != "" && strings.Contains(text.Text, literal) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/mcp/explore_literal_provenance_test.go
+++ b/internal/mcp/explore_literal_provenance_test.go
@@ -1,0 +1,47 @@
+package mcp
+
+import (
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestAnswerReadyViaLiteralOnly(t *testing.T) {
+	task := `unsupported locale "ku"`
+	head := exploreTarget{node: &graph.Node{
+		ID: "repo/locale/registry.go::registerLocale", Kind: graph.KindFunction,
+		Name: "registerLocale", FilePath: "repo/locale/registry.go",
+	}, exactContent: true}
+	if !exploreAnswerReady(task, []exploreTarget{head}) {
+		t.Fatal("fixture must be terminal via the literal rung")
+	}
+	if !exploreAnswerReadyViaLiteralOnly(task, []exploreTarget{head}) {
+		t.Fatal("terminality resting on exactContent must report literal-only")
+	}
+
+	anchorTask := "repo/locale/registry.go"
+	anchorHead := exploreTarget{node: head.node, exactContent: true}
+	if !exploreAnswerReady(anchorTask, []exploreTarget{anchorHead}) {
+		t.Fatal("fixture must be terminal via the path anchor")
+	}
+	if exploreAnswerReadyViaLiteralOnly(anchorTask, []exploreTarget{anchorHead}) {
+		t.Fatal("anchor-driven terminality must not report literal-only")
+	}
+}
+
+func TestResultCitesTaskLiteral(t *testing.T) {
+	task := `find the handler for "connection reset by peer"`
+	with := mcpgo.NewToolResultText(`{"evidence":[{"source":"return errors.New(\"connection reset by peer\")"}]}`)
+	if !exploreResultCitesTaskLiteral(with, task) {
+		t.Fatal("envelope containing the literal must pass")
+	}
+	without := mcpgo.NewToolResultText(`{"evidence":[{"name":"handleReset"}]}`)
+	if exploreResultCitesTaskLiteral(without, task) {
+		t.Fatal("envelope without the literal must fail the provenance gate")
+	}
+	if !exploreResultCitesTaskLiteral(without, "no quoted literal here") {
+		t.Fatal("tasks without literals pass vacuously")
+	}
+}

--- a/internal/mcp/explore_owner_folding.go
+++ b/internal/mcp/explore_owner_folding.go
@@ -2,6 +2,8 @@ package mcp
 
 import (
 	"context"
+	"strings"
+	"unicode"
 
 	"github.com/zzet/gortex/internal/graph"
 )
@@ -103,7 +105,7 @@ func (s *Server) foldMemberOwners(ctx context.Context, targets []exploreTarget) 
 			kept = append(kept, t)
 		}
 		if !found {
-			ownerTarget = exploreTarget{node: g.owner}
+			ownerTarget = exploreTarget{node: g.owner, foldedOwner: true}
 		}
 		insertAt := g.firstMember
 		if insertAt > len(kept) {
@@ -122,4 +124,214 @@ func (s *Server) foldMemberOwners(ctx context.Context, targets []exploreTarget) 
 		}
 	}
 	return targets
+}
+
+// exploreFoldedDraftSelection returns the current targets selected by the same
+// bounded draft planner used for the terminal envelope. A synthetic owner may
+// displace direct evidence only when the planner selected that owner and there
+// are enough non-mandatory, draft-rejected direct rows to absorb the overflow.
+// Raw caller/callee adjacency is deliberately insufficient: noisy graph
+// neighbors must not turn an optional summary into mandatory evidence.
+func exploreFoldedDraftSelection(
+	task string,
+	targets []exploreTarget,
+	limit int,
+	reserved map[string]struct{},
+) map[string]struct{} {
+	if strings.TrimSpace(task) == "" || limit <= 0 || len(targets) <= limit {
+		return nil
+	}
+	targetIDs := make(map[string]struct{}, len(targets))
+	for _, target := range targets {
+		if target.node != nil {
+			targetIDs[target.node.ID] = struct{}{}
+		}
+	}
+	draft := exploreAnswerDraft(task, targets)
+	planned := localizationEvidenceTargetsFromDraft(task, "", targets, draft)
+	selected := make(map[string]struct{}, min(limit, len(planned)))
+	for index, target := range planned {
+		if index >= limit {
+			break
+		}
+		if target.node == nil {
+			continue
+		}
+		if _, direct := targetIDs[target.node.ID]; direct {
+			selected[target.node.ID] = struct{}{}
+		}
+	}
+
+	selectedOwners, unselectedOwners, victims := 0, 0, 0
+	for _, target := range targets {
+		if target.node == nil {
+			continue
+		}
+		_, chosen := selected[target.node.ID]
+		if target.foldedOwner {
+			if chosen && exploreFoldedOwnerTaskAligned(task, target.node) {
+				selectedOwners++
+			} else {
+				delete(selected, target.node.ID)
+				unselectedOwners++
+			}
+			continue
+		}
+		if !chosen && !exploreFoldedTargetMandatory(target, reserved) {
+			victims++
+		}
+	}
+	if selectedOwners == 0 {
+		return nil
+	}
+	neededVictims := len(targets) - limit - unselectedOwners
+	if neededVictims < 0 {
+		neededVictims = 0
+	}
+	if victims < neededVictims {
+		return nil
+	}
+	return selected
+}
+
+func exploreFoldedOwnerTaskAligned(task string, owner *graph.Node) bool {
+	if owner == nil {
+		return false
+	}
+	if exploreFoldedOwnerIdentityMentioned(task, owner.Name) ||
+		exploreFoldedOwnerIdentityMentioned(task, owner.QualName) ||
+		exploreFoldedOwnerIdentityMentioned(task, owner.ID) {
+		return true
+	}
+	queryTerms := exploreTerminalTerms(task)
+	ownerTerms := exploreTerminalTerms(owner.Name)
+	if len(ownerTerms) == 0 {
+		return false
+	}
+	genericOwnerTerms := map[string]struct{}{
+		"class": {}, "config": {}, "configuration": {}, "configur": {},
+		"impl": {}, "implement": {}, "implementation": {},
+		"interface": {}, "interfac": {}, "manager": {}, "management": {}, "manag": {},
+		"option": {}, "registration": {}, "registry": {}, "registrie": {}, "registri": {},
+		"schema": {}, "service": {}, "servic": {}, "state": {}, "struct": {}, "type": {},
+	}
+	distinctive := false
+	for term := range ownerTerms {
+		if _, matched := queryTerms[term]; !matched {
+			return false
+		}
+		if _, generic := genericOwnerTerms[term]; !generic {
+			distinctive = true
+		}
+	}
+	return distinctive
+}
+
+func exploreFoldedOwnerIdentityMentioned(task, identity string) bool {
+	taskRunes := []rune(strings.ToLower(task))
+	identityRunes := []rune(strings.ToLower(strings.TrimSpace(identity)))
+	if len(taskRunes) == 0 || len(identityRunes) == 0 || len(identityRunes) > len(taskRunes) {
+		return false
+	}
+	for start := 0; start+len(identityRunes) <= len(taskRunes); start++ {
+		if start > 0 && exploreFoldedOwnerIdentityRune(taskRunes[start-1]) {
+			continue
+		}
+		matched := true
+		for index := range identityRunes {
+			if taskRunes[start+index] != identityRunes[index] {
+				matched = false
+				break
+			}
+		}
+		if !matched {
+			continue
+		}
+		after := start + len(identityRunes)
+		if after == len(taskRunes) || !exploreFoldedOwnerIdentityRune(taskRunes[after]) {
+			return true
+		}
+	}
+	return false
+}
+
+func exploreFoldedOwnerIdentityRune(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_'
+}
+
+// exploreFoldedTargetMandatory is the single definition of direct evidence
+// that an optional synthetic owner may not displace. Callers add contextual
+// reservations (including the retrieval head) through reserved; evidence-role
+// flags remain centralized here so selection and eviction cannot drift.
+func exploreFoldedTargetMandatory(target exploreTarget, reserved map[string]struct{}) bool {
+	if target.node == nil {
+		return false
+	}
+	if _, keep := reserved[target.node.ID]; keep {
+		return true
+	}
+	return target.sourceLiteral || target.sourceLiteralCallee || target.exactContent ||
+		target.conceptImplementation || target.typedAnchorProjection ||
+		target.divergentDefaultOwner || target.divergentDefaultType
+}
+
+// limitExploreFoldedTargets restores the request's symbol cap after owner
+// folding inserts a synthetic type. Folding is a post-selection summary:
+// synthetic owners are the first overflow victims unless the final draft
+// planner selected them and identified weaker direct evidence to displace.
+// The ordinary unprotected-tail fallback is retained only as a fail-safe for
+// malformed input whose overflow was not produced by folding.
+func limitExploreFoldedTargets(task string, targets []exploreTarget, limit int, reserved map[string]struct{}) []exploreTarget {
+	if limit <= 0 || len(targets) <= limit {
+		return targets
+	}
+	protected := make(map[string]struct{}, len(reserved)+1)
+	for id := range reserved {
+		protected[id] = struct{}{}
+	}
+	if targets[0].node != nil && !targets[0].foldedOwner {
+		protected[targets[0].node.ID] = struct{}{}
+	}
+	draftSelected := exploreFoldedDraftSelection(task, targets, limit, protected)
+
+	bounded := append([]exploreTarget(nil), targets...)
+	for len(bounded) > limit {
+		remove := -1
+		for index := len(bounded) - 1; index >= 0; index-- {
+			target := bounded[index]
+			if target.node == nil || !target.foldedOwner {
+				continue
+			}
+			if _, chosen := draftSelected[target.node.ID]; chosen {
+				continue
+			}
+			// The tag proves this row was added after the direct window. External
+			// reservations cannot preserve it; only the task-aware draft above can.
+			remove = index
+			break
+		}
+		if remove >= 0 {
+			bounded = append(bounded[:remove], bounded[remove+1:]...)
+			continue
+		}
+		for index := len(bounded) - 1; index >= 0; index-- {
+			target := bounded[index]
+			if target.node == nil {
+				remove = index
+				break
+			}
+			if _, chosen := draftSelected[target.node.ID]; chosen {
+				continue
+			}
+			if !exploreFoldedTargetMandatory(target, protected) {
+				remove = index
+				break
+			}
+		}
+		if remove < 0 {
+			return targets
+		}
+		bounded = append(bounded[:remove], bounded[remove+1:]...)
+	}
+	return bounded
 }

--- a/internal/mcp/explore_owner_folding.go
+++ b/internal/mcp/explore_owner_folding.go
@@ -1,0 +1,125 @@
+package mcp
+
+import (
+	"context"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Owner folding.
+//
+// Concept queries about a capability often rank several members of one type
+// above the type itself: each member carries the query vocabulary and its
+// own fan-in, while the owner splits the same evidence. The benchmark shape
+// is a middleware/persist module whose expected answer is the option/state
+// TYPES, yet the emitted symbols were the value-level members. When two or
+// more top candidates share one owner type, the owner is promoted directly
+// ahead of its first member — members stay as evidence, nothing is evicted.
+//
+// Implementation-intent queries are exempt: they ask for the concrete
+// members, and Q2's expansion exists to surface exactly those.
+
+const (
+	exploreOwnerFoldScan = 8
+	exploreOwnerFoldMax  = 2
+)
+
+// foldMemberOwners promotes an owner type above its members when at least
+// two of the scanned top candidates belong to it. The owner node is pulled
+// from the candidate list when it is already present (its later occurrence
+// is removed), or fetched by one bounded member_of hop otherwise.
+func (s *Server) foldMemberOwners(ctx context.Context, targets []exploreTarget) []exploreTarget {
+	eng := s.engineFor(ctx)
+	if eng == nil || len(targets) < 2 {
+		return targets
+	}
+	ownerOf := func(n *graph.Node) *graph.Node {
+		if n == nil || (n.Kind != graph.KindMethod && n.Kind != graph.KindFunction && n.Kind != graph.KindField) {
+			return nil
+		}
+		for _, e := range eng.GetOutEdges(n.ID) {
+			if e == nil || e.Kind != graph.EdgeMemberOf {
+				continue
+			}
+			if owner := eng.GetSymbol(e.To); owner != nil &&
+				(owner.Kind == graph.KindType || owner.Kind == graph.KindInterface) {
+				return owner
+			}
+		}
+		return nil
+	}
+
+	type ownerGroup struct {
+		owner       *graph.Node
+		firstMember int
+		members     int
+	}
+	groups := map[string]*ownerGroup{}
+	order := make([]string, 0, exploreOwnerFoldScan)
+	rankOf := map[string]int{}
+	for index, t := range targets {
+		if t.node != nil {
+			rankOf[t.node.ID] = index
+		}
+		if index >= exploreOwnerFoldScan || t.node == nil {
+			continue
+		}
+		owner := ownerOf(t.node)
+		if owner == nil {
+			continue
+		}
+		g, ok := groups[owner.ID]
+		if !ok {
+			g = &ownerGroup{owner: owner, firstMember: index}
+			groups[owner.ID] = g
+			order = append(order, owner.ID)
+		}
+		g.members++
+	}
+
+	folded := 0
+	for _, ownerID := range order {
+		if folded >= exploreOwnerFoldMax {
+			break
+		}
+		g := groups[ownerID]
+		if g.members < 2 {
+			continue
+		}
+		if existing, present := rankOf[ownerID]; present && existing <= g.firstMember {
+			continue // the owner already leads its members
+		}
+		// Remove a lower-ranked occurrence of the owner, then insert it
+		// directly ahead of its first member.
+		kept := make([]exploreTarget, 0, len(targets)+1)
+		var ownerTarget exploreTarget
+		found := false
+		for _, t := range targets {
+			if t.node != nil && t.node.ID == ownerID {
+				ownerTarget = t
+				found = true
+				continue
+			}
+			kept = append(kept, t)
+		}
+		if !found {
+			ownerTarget = exploreTarget{node: g.owner}
+		}
+		insertAt := g.firstMember
+		if insertAt > len(kept) {
+			insertAt = len(kept)
+		}
+		if insertAt < len(kept) {
+			ownerTarget.score = kept[insertAt].score
+		}
+		targets = append(kept[:insertAt:insertAt], append([]exploreTarget{ownerTarget}, kept[insertAt:]...)...)
+		folded++
+		rankOf = map[string]int{}
+		for index, t := range targets {
+			if t.node != nil {
+				rankOf[t.node.ID] = index
+			}
+		}
+	}
+	return targets
+}

--- a/internal/mcp/explore_owner_folding_test.go
+++ b/internal/mcp/explore_owner_folding_test.go
@@ -64,3 +64,29 @@ func TestFoldMemberOwnersPromotesSharedOwner(t *testing.T) {
 		t.Fatalf("leading owner must be untouched, got %d entries head=%s", len(same), same[0].node.ID)
 	}
 }
+
+// A same-file helper named in a wrapper body is promotable into the answer
+// draft as a callee of the ranked wrapper — the generic wrapper-to-helper
+// shape. Verified covered by the existing draft promotion; pinned so
+// selection work cannot regress it.
+func TestDraftPromotesWrapperHelperCallee(t *testing.T) {
+	task := "case insensitive path lookup returns the wrong file"
+	wrapper := &graph.Node{ID: "repo/fs/path.go::findCaseInsensitivePath", Kind: graph.KindFunction,
+		Name: "findCaseInsensitivePath", FilePath: "repo/fs/path.go"}
+	helper := &graph.Node{ID: "repo/fs/path.go::findCaseInsensitivePathRec", Kind: graph.KindFunction,
+		Name: "findCaseInsensitivePathRec", FilePath: "repo/fs/path.go"}
+	targets := []exploreTarget{{
+		node: wrapper, score: 1.0,
+		source:  "func findCaseInsensitivePath(p string) string { return findCaseInsensitivePathRec(p, 0) }",
+		callees: []*graph.Node{helper},
+	}}
+	found := false
+	for _, entry := range exploreAnswerDraft(task, targets) {
+		if entry.node != nil && entry.node.ID == helper.ID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("wrapper body helper must be promotable into the answer draft")
+	}
+}

--- a/internal/mcp/explore_owner_folding_test.go
+++ b/internal/mcp/explore_owner_folding_test.go
@@ -1,0 +1,66 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/query"
+)
+
+// Neutral persist-middleware shape: several members of one options type rank
+// above the type itself; folding promotes the owner ahead of its first
+// member without evicting anything.
+func newOwnerFoldFixture(t *testing.T) (*Server, *graph.Graph) {
+	t.Helper()
+	g := graph.New()
+	g.AddBatch([]*graph.Node{
+		{ID: "repo/mw/persist.ts::PersistOptions", Kind: graph.KindType, Name: "PersistOptions", FilePath: "repo/mw/persist.ts", Language: "typescript"},
+		{ID: "repo/mw/persist.ts::PersistOptions.serialize", Kind: graph.KindMethod, Name: "serialize", FilePath: "repo/mw/persist.ts", Language: "typescript"},
+		{ID: "repo/mw/persist.ts::PersistOptions.hydrate", Kind: graph.KindMethod, Name: "hydrate", FilePath: "repo/mw/persist.ts", Language: "typescript"},
+		{ID: "repo/mw/other.ts::unrelated", Kind: graph.KindFunction, Name: "unrelated", FilePath: "repo/mw/other.ts", Language: "typescript"},
+	}, []*graph.Edge{
+		{From: "repo/mw/persist.ts::PersistOptions.serialize", To: "repo/mw/persist.ts::PersistOptions", Kind: graph.EdgeMemberOf},
+		{From: "repo/mw/persist.ts::PersistOptions.hydrate", To: "repo/mw/persist.ts::PersistOptions", Kind: graph.EdgeMemberOf},
+	})
+	return NewServer(query.NewEngine(g), g, nil, nil, zap.NewNop(), nil), g
+}
+
+func TestFoldMemberOwnersPromotesSharedOwner(t *testing.T) {
+	s, g := newOwnerFoldFixture(t)
+	targets := []exploreTarget{
+		{node: g.GetNode("repo/mw/persist.ts::PersistOptions.serialize"), score: 1.0},
+		{node: g.GetNode("repo/mw/other.ts::unrelated"), score: 0.9},
+		{node: g.GetNode("repo/mw/persist.ts::PersistOptions.hydrate"), score: 0.8},
+	}
+	folded := s.foldMemberOwners(context.Background(), targets)
+	if folded[0].node.ID != "repo/mw/persist.ts::PersistOptions" {
+		t.Fatalf("owner not promoted ahead of first member: head=%s", folded[0].node.ID)
+	}
+	if len(folded) != len(targets)+1 {
+		t.Fatalf("folding must not evict members: len=%d", len(folded))
+	}
+
+	// One member alone must not fold its owner.
+	single := []exploreTarget{
+		{node: g.GetNode("repo/mw/persist.ts::PersistOptions.serialize"), score: 1.0},
+		{node: g.GetNode("repo/mw/other.ts::unrelated"), score: 0.9},
+	}
+	unfolded := s.foldMemberOwners(context.Background(), single)
+	if unfolded[0].node.ID != "repo/mw/persist.ts::PersistOptions.serialize" {
+		t.Fatal("a lone member must not trigger folding")
+	}
+
+	// An owner already leading its members stays put; no duplicate appears.
+	led := []exploreTarget{
+		{node: g.GetNode("repo/mw/persist.ts::PersistOptions"), score: 1.0},
+		{node: g.GetNode("repo/mw/persist.ts::PersistOptions.serialize"), score: 0.9},
+		{node: g.GetNode("repo/mw/persist.ts::PersistOptions.hydrate"), score: 0.8},
+	}
+	same := s.foldMemberOwners(context.Background(), led)
+	if len(same) != 3 || same[0].node.ID != "repo/mw/persist.ts::PersistOptions" {
+		t.Fatalf("leading owner must be untouched, got %d entries head=%s", len(same), same[0].node.ID)
+	}
+}

--- a/internal/mcp/explore_owner_folding_test.go
+++ b/internal/mcp/explore_owner_folding_test.go
@@ -65,6 +65,214 @@ func TestFoldMemberOwnersPromotesSharedOwner(t *testing.T) {
 	}
 }
 
+func TestLimitExploreFoldedTargetsPreservesReservationsAndCap(t *testing.T) {
+	s, g := newOwnerFoldFixture(t)
+	targets := []exploreTarget{
+		{node: g.GetNode("repo/mw/persist.ts::PersistOptions.serialize"), score: 1.0, typedAnchorProjection: true},
+		{node: g.GetNode("repo/mw/other.ts::unrelated"), score: 0.9},
+		{node: g.GetNode("repo/mw/persist.ts::PersistOptions.hydrate"), score: 0.8, sourceLiteral: true},
+	}
+	folded := s.foldMemberOwners(context.Background(), targets)
+	bounded := limitExploreFoldedTargets("", folded, len(targets), map[string]struct{}{
+		targets[0].node.ID: {},
+		targets[2].node.ID: {},
+	})
+	if len(bounded) != len(targets) {
+		t.Fatalf("bounded owner fold = %d targets, want %d", len(bounded), len(targets))
+	}
+	for _, id := range []string{targets[0].node.ID, targets[2].node.ID} {
+		found := false
+		for _, target := range bounded {
+			found = found || target.node != nil && target.node.ID == id
+		}
+		if !found {
+			t.Fatalf("owner fold cap evicted reserved target %s", id)
+		}
+	}
+}
+
+func TestLimitExploreFoldedTargetsDropsSyntheticOwnerWhenEveryDirectTargetIsReserved(t *testing.T) {
+	s, g := newOwnerFoldFixture(t)
+	targets := []exploreTarget{
+		{node: g.GetNode("repo/mw/persist.ts::PersistOptions.serialize"), score: 1.0, typedAnchorProjection: true},
+		{node: g.GetNode("repo/mw/other.ts::unrelated"), score: 0.9, sourceLiteral: true},
+		{node: g.GetNode("repo/mw/persist.ts::PersistOptions.hydrate"), score: 0.8, typedAnchorProjection: true},
+	}
+	reserved := make(map[string]struct{}, len(targets))
+	for _, target := range targets {
+		reserved[target.node.ID] = struct{}{}
+	}
+	folded := s.foldMemberOwners(context.Background(), targets)
+	if len(folded) != len(targets)+1 || !folded[0].foldedOwner {
+		t.Fatalf("fixture did not insert a tagged synthetic owner: %#v", folded)
+	}
+	bounded := limitExploreFoldedTargets(
+		"Find the PersistOptions type that owns serialize and hydrate behavior.",
+		folded,
+		len(targets),
+		reserved,
+	)
+	if len(bounded) != len(targets) {
+		t.Fatalf("all-protected fold returned %d targets, want %d", len(bounded), len(targets))
+	}
+	for _, target := range bounded {
+		if target.foldedOwner {
+			t.Fatal("synthetic owner survived when every direct target was reserved")
+		}
+	}
+}
+
+func TestLimitExploreFoldedTargetsNeverEvictsDirectWindowForSyntheticOwner(t *testing.T) {
+	s, g := newOwnerFoldFixture(t)
+	direct := []exploreTarget{
+		{node: g.GetNode("repo/mw/persist.ts::PersistOptions.serialize"), score: 1.0},
+		{node: g.GetNode("repo/mw/other.ts::unrelated"), score: 0.9},
+		{node: g.GetNode("repo/mw/persist.ts::PersistOptions.hydrate"), score: 0.8},
+	}
+	folded := s.foldMemberOwners(context.Background(), direct)
+	if len(folded) != len(direct)+1 || !folded[0].foldedOwner {
+		t.Fatalf("fixture did not insert a tagged synthetic owner: %#v", folded)
+	}
+	bounded := limitExploreFoldedTargets("", folded, len(direct), map[string]struct{}{
+		folded[0].node.ID: {}, // even a stale reservation cannot displace direct evidence
+	})
+	if len(bounded) != len(direct) {
+		t.Fatalf("bounded owner fold = %d targets, want %d", len(bounded), len(direct))
+	}
+	want := make(map[string]struct{}, len(direct))
+	for _, target := range direct {
+		want[target.node.ID] = struct{}{}
+	}
+	for _, target := range bounded {
+		if target.foldedOwner {
+			t.Fatal("post-selection synthetic owner displaced a direct candidate")
+		}
+		delete(want, target.node.ID)
+	}
+	if len(want) != 0 {
+		t.Fatalf("direct candidate window was not preserved: missing %v", want)
+	}
+}
+
+func TestLimitExploreFoldedTargetsRetainsDraftSelectedTypeOwnerAtCap(t *testing.T) {
+	s, g := newOwnerFoldFixture(t)
+	direct := []exploreTarget{
+		{node: g.GetNode("repo/mw/persist.ts::PersistOptions.serialize"), score: 1.0},
+		{node: g.GetNode("repo/mw/other.ts::unrelated"), score: 0.9},
+		{node: g.GetNode("repo/mw/persist.ts::PersistOptions.hydrate"), score: 0.8},
+	}
+	folded := s.foldMemberOwners(context.Background(), direct)
+	bounded := limitExploreFoldedTargets(
+		"Find the persist middleware options type that owns serialize and hydrate behavior.",
+		folded,
+		len(direct),
+		nil,
+	)
+	if len(bounded) != len(direct) {
+		t.Fatalf("bounded owner fold = %d targets, want %d", len(bounded), len(direct))
+	}
+	want := map[string]struct{}{
+		"repo/mw/persist.ts::PersistOptions":           {},
+		"repo/mw/persist.ts::PersistOptions.serialize": {},
+		"repo/mw/persist.ts::PersistOptions.hydrate":   {},
+	}
+	for _, target := range bounded {
+		if target.node != nil {
+			delete(want, target.node.ID)
+		}
+	}
+	if len(want) != 0 {
+		t.Fatalf("draft-selected type route was not retained: missing %v; got %#v", want, bounded)
+	}
+	for _, target := range bounded {
+		if target.node != nil && target.node.ID == "repo/mw/other.ts::unrelated" {
+			t.Fatal("draft-rejected unrelated row survived ahead of selected owner route")
+		}
+	}
+}
+
+func TestExploreFoldedOwnerTaskAlignedRequiresOwnerIdentity(t *testing.T) {
+	tests := []struct {
+		name  string
+		task  string
+		owner string
+		want  bool
+	}{
+		{
+			name:  "compound identity",
+			task:  "Find the persist middleware options type that owns hydration.",
+			owner: "PersistOptions",
+			want:  true,
+		},
+		{
+			name:  "single exact identity",
+			task:  "Find the callable that matches ancestor ignore rules.",
+			owner: "Ignore",
+			want:  true,
+		},
+		{
+			name:  "generic declaration words",
+			task:  "Find the configuration options type that owns this behavior.",
+			owner: "ConfigurationOptions",
+			want:  false,
+		},
+		{
+			name:  "literal generic compound identity",
+			task:  "Find ConfigurationOptions and explain its behavior.",
+			owner: "ConfigurationOptions",
+			want:  true,
+		},
+		{
+			name:  "partial compound identity",
+			task:  "Find number-to-words registration for a locale.",
+			owner: "NumberToWordsConverterRegistry",
+			want:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owner := &graph.Node{Name: tt.owner, Kind: graph.KindType}
+			if got := exploreFoldedOwnerTaskAligned(tt.task, owner); got != tt.want {
+				t.Fatalf("owner alignment = %v, want %v for task %q and owner %q", got, tt.want, tt.task, tt.owner)
+			}
+		})
+	}
+}
+
+func TestLimitExploreFoldedTargetsGenericTypeWordsDoNotRetainUnrelatedOwner(t *testing.T) {
+	s, g := newOwnerFoldFixture(t)
+	direct := []exploreTarget{
+		{node: g.GetNode("repo/mw/persist.ts::PersistOptions.serialize"), score: 1.0},
+		{node: g.GetNode("repo/mw/other.ts::unrelated"), score: 0.9},
+		{node: g.GetNode("repo/mw/persist.ts::PersistOptions.hydrate"), score: 0.8},
+	}
+	folded := s.foldMemberOwners(context.Background(), direct)
+	bounded := limitExploreFoldedTargets(
+		"Find the type config options that own this behavior.",
+		folded,
+		len(direct),
+		nil,
+	)
+	if len(bounded) != len(direct) {
+		t.Fatalf("bounded owner fold = %d targets, want %d", len(bounded), len(direct))
+	}
+	want := make(map[string]struct{}, len(direct))
+	for _, target := range direct {
+		want[target.node.ID] = struct{}{}
+	}
+	for _, target := range bounded {
+		if target.foldedOwner {
+			t.Fatal("generic type/config/options wording retained an unrelated synthetic owner")
+		}
+		if target.node != nil {
+			delete(want, target.node.ID)
+		}
+	}
+	if len(want) != 0 {
+		t.Fatalf("generic owner wording displaced direct candidates: missing %v", want)
+	}
+}
+
 // A same-file helper named in a wrapper body is promotable into the answer
 // draft as a callee of the ranked wrapper — the generic wrapper-to-helper
 // shape. Verified covered by the existing draft promotion; pinned so

--- a/internal/mcp/explore_refinement_ladder_test.go
+++ b/internal/mcp/explore_refinement_ladder_test.go
@@ -1,0 +1,42 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// The single permitted refinement read must follow the answer-draft ladder,
+// not raw rank: a generic rank-one type that shares no vocabulary with the
+// query must not consume the read while an aligned callable sits lower in
+// the same envelope.
+func TestRefinementLadderPrefersAlignedCallableOverGenericHead(t *testing.T) {
+	task := "replace trailing context lines in the printed output"
+	genericHead := exploreTarget{node: &graph.Node{
+		ID: "repo/printer/builder.go::OutputBuilder", Kind: graph.KindType, Name: "OutputBuilder", FilePath: "repo/printer/builder.go",
+	}, score: 1.0}
+	alignedFn := exploreTarget{node: &graph.Node{
+		ID: "repo/printer/util.go::replace_with_context", Kind: graph.KindFunction, Name: "replace_with_context", FilePath: "repo/printer/util.go",
+	}, score: 0.7}
+
+	got := explorePreferredRefinementSymbol(task, []exploreTarget{genericHead, alignedFn})
+	if got != alignedFn.node.ID {
+		t.Fatalf("ladder picked %q, want the aligned callable", got)
+	}
+
+	literal := exploreTarget{node: &graph.Node{
+		ID: "repo/printer/other.go::helper", Kind: graph.KindFunction, Name: "helper", FilePath: "repo/printer/other.go",
+	}, score: 0.4, sourceLiteral: true}
+	got = explorePreferredRefinementSymbol(task, []exploreTarget{genericHead, alignedFn, literal})
+	if got != literal.node.ID {
+		t.Fatalf("ladder picked %q, want the source-literal target", got)
+	}
+
+	unrelated := exploreTarget{node: &graph.Node{
+		ID: "repo/other/thing.go::Widget", Kind: graph.KindType, Name: "Widget", FilePath: "repo/other/thing.go",
+	}, score: 1.0}
+	got = explorePreferredRefinementSymbol(task, []exploreTarget{unrelated})
+	if got != unrelated.node.ID {
+		t.Fatalf("ladder picked %q, want the raw head when nothing aligns", got)
+	}
+}

--- a/internal/mcp/explore_refinement_ladder_test.go
+++ b/internal/mcp/explore_refinement_ladder_test.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/zzet/gortex/internal/graph"
@@ -24,12 +25,20 @@ func TestRefinementLadderPrefersAlignedCallableOverGenericHead(t *testing.T) {
 		t.Fatalf("ladder picked %q, want the aligned callable", got)
 	}
 
-	literal := exploreTarget{node: &graph.Node{
-		ID: "repo/printer/other.go::helper", Kind: graph.KindFunction, Name: "helper", FilePath: "repo/printer/other.go",
+	literalDistractor := exploreTarget{node: &graph.Node{
+		ID: "repo/errors.go::NoMatchFoundException", Kind: graph.KindType, Name: "NoMatchFoundException", FilePath: "repo/errors.go",
+	}, score: 0.4, sourceLiteral: true, source: `const locale = "ku"`}
+	got = explorePreferredRefinementSymbol(task, []exploreTarget{genericHead, alignedFn, literalDistractor})
+	if got != alignedFn.node.ID {
+		t.Fatalf("ladder picked unrelated literal %q, want aligned callable %q", got, alignedFn.node.ID)
+	}
+
+	alignedLiteral := exploreTarget{node: &graph.Node{
+		ID: "repo/printer/literal.go::replace_context", Kind: graph.KindFunction, Name: "replace_context", FilePath: "repo/printer/literal.go",
 	}, score: 0.4, sourceLiteral: true}
-	got = explorePreferredRefinementSymbol(task, []exploreTarget{genericHead, alignedFn, literal})
-	if got != literal.node.ID {
-		t.Fatalf("ladder picked %q, want the source-literal target", got)
+	got = explorePreferredRefinementSymbol(task, []exploreTarget{genericHead, alignedFn, alignedLiteral})
+	if got != alignedLiteral.node.ID {
+		t.Fatalf("ladder picked %q, want semantically tied source-literal target", got)
 	}
 
 	unrelated := exploreTarget{node: &graph.Node{
@@ -38,5 +47,102 @@ func TestRefinementLadderPrefersAlignedCallableOverGenericHead(t *testing.T) {
 	got = explorePreferredRefinementSymbol(task, []exploreTarget{unrelated})
 	if got != unrelated.node.ID {
 		t.Fatalf("ladder picked %q, want the raw head when nothing aligns", got)
+	}
+}
+
+func TestRefinementLadderPrefersLexicallyAlignedDefaultOwnerOverFieldConsumer(t *testing.T) {
+	task := "the rotating handler uses the wrong default file permission in its constructor"
+	consumer := exploreTarget{node: &graph.Node{
+		ID: "repo/Handler.php::StreamHandler.write", Kind: graph.KindMethod,
+		Name: "write", QualName: "StreamHandler.write", FilePath: "repo/Handler.php",
+	}, source: `chmod($url, $this->filePermission);`}
+	owner := exploreTarget{node: &graph.Node{
+		ID: "repo/RotatingFileHandler.php::RotatingFileHandler.__construct", Kind: graph.KindMethod,
+		Name: "__construct", QualName: "RotatingFileHandler.__construct", FilePath: "repo/RotatingFileHandler.php",
+	}, source: `function __construct($filename, $maxFiles = 0, $level = Logger::DEBUG, $bubble = true, $filePermission = null) {}`}
+
+	got := explorePreferredRefinementSymbol(task, []exploreTarget{consumer, owner})
+	if got != owner.node.ID {
+		t.Fatalf("refinement selected field consumer %q, want default-setting owner %q", got, owner.node.ID)
+	}
+}
+
+func TestRefinementLadderPrefersCallableOverEquallyAlignedContainer(t *testing.T) {
+	task := "replace trailing context lines"
+	container := exploreTarget{node: &graph.Node{
+		ID: "repo/printer/util.go::ReplacementContext", Kind: graph.KindType,
+		Name: "ReplacementContext", FilePath: "repo/printer/util.go",
+	}, sourceLiteral: true}
+	callable := exploreTarget{node: &graph.Node{
+		ID: "repo/printer/util.go::replace_context", Kind: graph.KindFunction,
+		Name: "replace_context", FilePath: "repo/printer/util.go",
+	}}
+
+	got := explorePreferredRefinementSymbol(task, []exploreTarget{container, callable})
+	if got != callable.node.ID {
+		t.Fatalf("refinement selected enclosing container %q, want callable %q", got, callable.node.ID)
+	}
+}
+
+func TestRefinementLadderKeepsVerifiedLiteralWhenCallableHasNoAlignment(t *testing.T) {
+	literalOwner := exploreTarget{node: &graph.Node{
+		ID: "repo/registry.go::LocaleRegistry", Kind: graph.KindType,
+		Name: "LocaleRegistry", FilePath: "repo/registry.go",
+	}, sourceLiteral: true}
+	unrelatedCallable := exploreTarget{node: &graph.Node{
+		ID: "repo/worker.go::Run", Kind: graph.KindFunction,
+		Name: "Run", FilePath: "repo/worker.go",
+	}}
+
+	got := explorePreferredRefinementSymbol(`"xy"`, []exploreTarget{unrelatedCallable, literalOwner})
+	if got != literalOwner.node.ID {
+		t.Fatalf("refinement selected zero-alignment callable %q, want verified literal owner %q", got, literalOwner.node.ID)
+	}
+}
+
+func TestLocalizationBuilderLeadsWithRequiredSymbolAndItsFileUnderTightBudget(t *testing.T) {
+	task := "replace trailing context lines in the printed output"
+	head := exploreTarget{node: &graph.Node{
+		ID: "repo/printer/builder.go::OutputBuilder", Kind: graph.KindType,
+		Name: "OutputBuilder", FilePath: "repo/printer/builder.go",
+	}}
+	preferred := exploreTarget{node: &graph.Node{
+		ID: "repo/printer/util.go::replace_with_context", Kind: graph.KindFunction,
+		Name: "replace_with_context", FilePath: "repo/printer/util.go",
+	}}
+	completion := newLocalizationRefinementCompletion(preferred.node.ID)
+	const budget = 256
+	result, returnedSymbols, digest := buildLocalizationExploreResultForTask(
+		completion, task, []exploreTarget{head, preferred}, budget,
+	)
+	if result == nil || result.IsError {
+		t.Fatalf("builder result = %#v, want successful localization envelope", result)
+	}
+	body, ok := singleTextContent(result)
+	if !ok {
+		t.Fatalf("builder result has no text content: %#v", result)
+	}
+	if len(body) > budget*localizationEnvelopeBytesPerToken {
+		t.Fatalf("envelope bytes = %d, want <= %d", len(body), budget*localizationEnvelopeBytesPerToken)
+	}
+	var envelope localizationExploreEnvelope
+	if err := json.Unmarshal([]byte(body), &envelope); err != nil {
+		t.Fatalf("decode localization envelope: %v", err)
+	}
+	if len(envelope.Evidence) < 2 || len(envelope.Files) < 2 || len(envelope.Symbols) < 2 {
+		t.Fatalf("tight envelope lost required/primary evidence: %#v", envelope)
+	}
+	if envelope.Completion.RequiredAction != completion.RequiredAction || envelope.Evidence[0].ID != preferred.node.ID ||
+		envelope.Files[0] != preferred.node.FilePath || envelope.Symbols[0] != preferred.node.ID {
+		t.Fatalf("required action and leading evidence diverged: completion=%#v envelope=%#v", completion, envelope)
+	}
+	if envelope.Evidence[1].ID != head.node.ID || envelope.Files[1] != head.node.FilePath || envelope.Symbols[1] != head.node.ID {
+		t.Fatalf("original retrieval head was not retained immediately after refinement target: %#v", envelope)
+	}
+	if len(returnedSymbols) < 2 || returnedSymbols[0] != preferred.node.ID || returnedSymbols[1] != head.node.ID {
+		t.Fatalf("authorization symbols diverged from envelope: %#v", returnedSymbols)
+	}
+	if digest == nil || len(digest.Evidence) < 2 || digest.Evidence[0].ID != preferred.node.ID || digest.Evidence[1].ID != head.node.ID {
+		t.Fatalf("terminal digest diverged from serialized evidence: %#v", digest)
 	}
 }

--- a/internal/mcp/explore_refinement_route_test.go
+++ b/internal/mcp/explore_refinement_route_test.go
@@ -1,0 +1,278 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestExploreRefinementRoutesPreferConcreteForwardedImplementation(t *testing.T) {
+	wrapper := &graph.Node{
+		ID: "repo/src/replace.rs::Replacer.replace", Name: "replace",
+		Kind: graph.KindMethod, FilePath: "src/replace.rs",
+	}
+	implementation := &graph.Node{
+		ID: "repo/src/replace.rs::Replacer.replace_all", Name: "replace_all",
+		Kind: graph.KindMethod, FilePath: "src/replace.rs",
+	}
+	targets := []exploreTarget{
+		{
+			node:                  wrapper,
+			directCalleesComplete: true,
+			source: `fn replace(&self, haystack: &str) -> String {
+				self.replace_all(haystack)
+			}`,
+			callees: []*graph.Node{implementation},
+		},
+		{
+			node: implementation,
+			source: `fn replace_all(&self, haystack: &str) -> String {
+				for capture in self.captures(haystack) { output.push_str(capture); }
+				output
+			}`,
+		},
+	}
+
+	routes := exploreLocalizationRefinementRoutes(targets)
+	if got := routes[wrapper.ID].implementationSymbol; got != implementation.ID {
+		t.Fatalf("wrapper implementation route = %q, want %q", got, implementation.ID)
+	}
+	if route, ok := routes[implementation.ID]; !ok || route.implementationSymbol != "" {
+		t.Fatalf("concrete implementation route = %#v, present=%v", route, ok)
+	}
+	if got := explorePreferredRoutedRefinementSymbol(wrapper.ID, targets, routes); got != implementation.ID {
+		t.Fatalf("preferred routed symbol = %q, want concrete %q", got, implementation.ID)
+	}
+}
+
+func TestExploreRefinementRoutesRejectAmbiguousGenericForwarder(t *testing.T) {
+	wrapper := &graph.Node{ID: "repo/wrapper", Name: "replace", Kind: graph.KindMethod, FilePath: "src/wrapper.rs"}
+	first := &graph.Node{ID: "repo/first", Name: "replace_all", Kind: graph.KindMethod, FilePath: "src/first.rs"}
+	second := &graph.Node{ID: "repo/second", Name: "replace_one", Kind: graph.KindMethod, FilePath: "src/second.rs"}
+	concreteSource := `fn replace_value(&self) { for value in self.values() { consume(value); } }`
+	targets := []exploreTarget{
+		{
+			node:                  wrapper,
+			directCalleesComplete: true,
+			source:                `fn replace(&self) { self.delegate.replace() }`,
+			callees:               []*graph.Node{first, second},
+		},
+		{node: first, source: concreteSource},
+		{node: second, source: concreteSource},
+	}
+
+	routes := exploreLocalizationRefinementRoutes(targets)
+	if _, authorized := routes[wrapper.ID]; authorized {
+		t.Fatal("ambiguous generic forwarder was authorized")
+	}
+}
+
+func TestExplorePreferredRouteFallsBackToFirstRankedConcreteCandidate(t *testing.T) {
+	invalid := &graph.Node{ID: "repo/invalid", Name: "replace", Kind: graph.KindMethod, FilePath: "src/wrapper.rs"}
+	firstConcrete := &graph.Node{ID: "repo/first", Name: "replace_all", Kind: graph.KindMethod, FilePath: "src/first.rs"}
+	secondConcrete := &graph.Node{ID: "repo/second", Name: "replace_one", Kind: graph.KindMethod, FilePath: "src/second.rs"}
+	targets := []exploreTarget{
+		{node: invalid, source: `fn replace(&self) { self.delegate.replace() }`},
+		{node: firstConcrete, source: `fn replace_all(&self) { execute_all(); }`},
+		{node: secondConcrete, source: `fn replace_one(&self) { execute_one(); }`},
+	}
+	routes := exploreLocalizationRefinementRoutes(targets)
+	if _, authorized := routes[invalid.ID]; authorized {
+		t.Fatal("generic preferred with incomplete direct projection was authorized")
+	}
+	if got := explorePreferredRoutedRefinementSymbol(invalid.ID, targets, routes); got != firstConcrete.ID {
+		t.Fatalf("fallback preferred = %q, want first ranked concrete %q", got, firstConcrete.ID)
+	}
+}
+
+func TestExploreRefinementRoutesRejectSaturatedDirectCalleeProjection(t *testing.T) {
+	wrapper := &graph.Node{ID: "repo/wrapper", Name: "replace", Kind: graph.KindMethod, FilePath: "src/wrapper.rs"}
+	raw := make([]*graph.Node, 0, exploreRingCap+1)
+	targets := []exploreTarget{{
+		node:   wrapper,
+		source: `fn replace(&self) { self.delegate.replace() }`,
+	}}
+	for i := 0; i < exploreRingCap+1; i++ {
+		callee := &graph.Node{
+			ID: fmt.Sprintf("repo/callee-%d", i), Name: fmt.Sprintf("replace_%d", i),
+			Kind: graph.KindMethod, FilePath: "src/replace.rs",
+		}
+		raw = append(raw, callee)
+		targets = append(targets, exploreTarget{node: callee, source: `fn concrete(&self) { execute(); }`})
+	}
+	projected, complete := ringNeighborsProjection(raw, wrapper.ID, exploreRingCap)
+	if complete || len(projected) != exploreRingCap {
+		t.Fatalf("saturated projection = (%d, complete=%v), want (%d, false)", len(projected), complete, exploreRingCap)
+	}
+	targets[0].callees = projected
+	targets[0].directCalleesComplete = complete
+	if _, authorized := exploreLocalizationRefinementRoutes(targets)[wrapper.ID]; authorized {
+		t.Fatal("generic wrapper was authorized from saturated direct-callee evidence")
+	}
+}
+
+func TestExploreRefinementRoutesRequireHydratedProductionCallable(t *testing.T) {
+	hydrated := &graph.Node{ID: "repo/hydrated", Name: "run", Kind: graph.KindFunction, FilePath: "src/run.go"}
+	unhydrated := &graph.Node{ID: "repo/unhydrated", Name: "run", Kind: graph.KindMethod, FilePath: "src/run.go"}
+	nonCallable := &graph.Node{ID: "repo/type", Name: "Runner", Kind: graph.KindType, FilePath: "src/run.go"}
+	testCallable := &graph.Node{
+		ID: "repo/test", Name: "testRun", Kind: graph.KindFunction, FilePath: "src/run_test.go",
+		Meta: map[string]any{"is_test": true},
+	}
+	routes := exploreLocalizationRefinementRoutes([]exploreTarget{
+		{node: hydrated, source: `func run() { executeWork() }`},
+		{node: unhydrated},
+		{node: nonCallable, source: `type Runner struct{}`},
+		{node: testCallable, source: `func testRun() { run() }`},
+	})
+	if _, ok := routes[hydrated.ID]; !ok {
+		t.Fatal("hydrated production callable was not authorized")
+	}
+	for _, rejected := range []string{unhydrated.ID, nonCallable.ID, testCallable.ID} {
+		if _, ok := routes[rejected]; ok {
+			t.Fatalf("ineligible candidate %q was authorized", rejected)
+		}
+	}
+}
+
+func TestExploreRefinementRoutesTreatEveryPlausibleCallableAsAmbiguity(t *testing.T) {
+	wrapper := &graph.Node{ID: "repo/wrapper", Name: "replace", Kind: graph.KindMethod, FilePath: "src/wrapper.rs"}
+	concrete := &graph.Node{ID: "repo/concrete", Name: "replace_all", Kind: graph.KindMethod, FilePath: "src/replace.rs"}
+	unresolved := &graph.Node{ID: "repo/unresolved", Name: "replace_one", Kind: graph.KindMethod, FilePath: "src/missing.rs"}
+	unhydrated := &graph.Node{ID: "repo/unhydrated", Name: "replace_some", Kind: graph.KindMethod, FilePath: "src/replace.rs"}
+	wrapperSource := `fn replace(&self) { self.delegate.replace() }`
+	concreteSource := `fn replace_all(&self) { for value in self.values() { consume(value); } }`
+
+	for name, extraTargets := range map[string][]exploreTarget{
+		"unresolved": nil,
+		"unhydrated": {{node: unhydrated}},
+	} {
+		extraCallee := unresolved
+		if name == "unhydrated" {
+			extraCallee = unhydrated
+		}
+		targets := []exploreTarget{
+			{node: wrapper, source: wrapperSource, callees: []*graph.Node{concrete, extraCallee}, directCalleesComplete: true},
+			{node: concrete, source: concreteSource},
+		}
+		targets = append(targets, extraTargets...)
+		if _, ok := exploreLocalizationRefinementRoutes(targets)[wrapper.ID]; ok {
+			t.Fatalf("generic wrapper with %s callable callee was authorized", name)
+		}
+	}
+}
+
+func TestBuildLocalizationRefinementResultKeepsWireAndStateAuthorizationEqual(t *testing.T) {
+	preferred := &graph.Node{ID: "repo/concrete", Name: "replace_all", Kind: graph.KindMethod, FilePath: "src/replace.rs"}
+	alternate := &graph.Node{ID: "repo/alternate", Name: "replace_one", Kind: graph.KindMethod, FilePath: "src/replace.rs"}
+	targets := []exploreTarget{
+		{node: preferred, source: `fn replace_all(&self) { execute_all(); }`},
+		{node: alternate, source: `fn replace_one(&self) { execute_one(); }`},
+	}
+	routes := exploreLocalizationRefinementRoutes(targets)
+	result, completion, bounded, digest := buildLocalizationRefinementResultForTask(
+		preferred.ID, "find the replace implementation", targets, exploreDefaultBudgetTokens, routes,
+	)
+	if completion.State != localizationStateNeedsRefinement {
+		t.Fatalf("completion state = %q, want %q", completion.State, localizationStateNeedsRefinement)
+	}
+	state := &localizationTerminalState{}
+	state.armRefinementRoutesForTask(
+		"find the replace implementation", completion.refinementSymbol,
+		completion.AllowedSymbols, bounded, digest,
+	)
+	text, ok := singleTextContent(result)
+	if !ok {
+		t.Fatal("localization refinement result has no single text payload")
+	}
+	var envelope localizationExploreEnvelope
+	if err := json.Unmarshal([]byte(text), &envelope); err != nil {
+		t.Fatalf("decode localization envelope: %v", err)
+	}
+	stateCompletion := state.completionLocked()
+	if !reflect.DeepEqual(envelope.Completion.AllowedSymbols, stateCompletion.AllowedSymbols) {
+		t.Fatalf("wire allowed symbols = %v, state allowed symbols = %v", envelope.Completion.AllowedSymbols, stateCompletion.AllowedSymbols)
+	}
+	if envelope.Completion.refinementSymbol != "" || len(envelope.Completion.refinementRoutes) != 0 {
+		t.Fatalf("wire decoded private routing state: %#v", envelope.Completion)
+	}
+}
+
+func TestBuildLocalizationRefinementResultStaysOpenWithoutValidPreferredRoute(t *testing.T) {
+	unhydrated := &graph.Node{ID: "repo/unhydrated", Name: "replace", Kind: graph.KindMethod, FilePath: "src/replace.rs"}
+	targets := []exploreTarget{{node: unhydrated}}
+	result, completion, bounded, _ := buildLocalizationRefinementResultForTask(
+		unhydrated.ID, "find the replace implementation", targets, exploreDefaultBudgetTokens,
+		exploreLocalizationRefinementRoutes(targets),
+	)
+	if completion.State != localizationStateInactive || completion.RequiredAction != "continue" || completion.AllowedToolCalls != 0 {
+		t.Fatalf("invalid preferred route completion = %#v, want explicit open contract", completion)
+	}
+	if len(bounded) != 0 {
+		t.Fatalf("invalid preferred route retained authorization: %v", bounded)
+	}
+	text, ok := singleTextContent(result)
+	if !ok {
+		t.Fatal("open localization result has no single text payload")
+	}
+	var envelope localizationExploreEnvelope
+	if err := json.Unmarshal([]byte(text), &envelope); err != nil {
+		t.Fatalf("decode open localization envelope: %v", err)
+	}
+	if envelope.Completion.State != localizationStateInactive || envelope.Completion.RequiredAction != "continue" || len(envelope.Completion.AllowedSymbols) != 0 {
+		t.Fatalf("wire completion = %#v, want open without authorization", envelope.Completion)
+	}
+}
+
+func TestBoundedLocalizationRefinementRoutesCapsWireSetAndKeepsPreferred(t *testing.T) {
+	symbols := make([]string, 10)
+	routes := make(map[string]localizationRefinementRoute, len(symbols))
+	for i := range symbols {
+		symbols[i] = fmt.Sprintf("repo/internal/localization/package%02d/file.go::Resolver.Method%02d", i, i)
+		routes[symbols[i]] = localizationRefinementRoute{}
+	}
+	preferred := symbols[9]
+	authorized, bounded := boundedLocalizationRefinementRoutes(symbols, routes, preferred)
+	if len(authorized) != localizationRefinementAllowedSymbolCap || len(bounded) != localizationRefinementAllowedSymbolCap {
+		t.Fatalf("bounded authorization sizes = (%d, %d), want (%d, %d)", len(authorized), len(bounded), localizationRefinementAllowedSymbolCap, localizationRefinementAllowedSymbolCap)
+	}
+	if authorized[0] != preferred {
+		t.Fatalf("preferred symbol = %q at index 0, want %q", authorized[0], preferred)
+	}
+	if _, rankSevenRetained := bounded[symbols[6]]; !rankSevenRetained {
+		t.Fatalf("rank-seven recovery symbol %q was dropped: %v", symbols[6], authorized)
+	}
+	completion := newLocalizationRefinementCompletionForSymbols(preferred, authorized)
+	wire, err := json.Marshal(completion)
+	if err != nil {
+		t.Fatalf("marshal bounded completion: %v", err)
+	}
+	if len(wire) > 2048 {
+		t.Fatalf("bounded completion = %d bytes, want <= 2048: %s", len(wire), wire)
+	}
+	state := &localizationTerminalState{}
+	state.armRefinementRoutesForTask("find implementation", preferred, authorized, bounded, nil)
+	if got := state.completionLocked().AllowedSymbols; !reflect.DeepEqual(got, authorized) {
+		t.Fatalf("state allowed symbols = %v, wire set = %v", got, authorized)
+	}
+}
+
+func TestBoundedLocalizationRefinementRoutesRequiresVisibleImplementation(t *testing.T) {
+	routes := map[string]localizationRefinementRoute{
+		"wrapper":        {implementationSymbol: "implementation"},
+		"implementation": {},
+	}
+
+	authorized, bounded := boundedLocalizationRefinementRoutes([]string{"wrapper"}, routes, "wrapper")
+	if len(authorized) != 0 || len(bounded) != 0 {
+		t.Fatalf("hidden implementation retained route: symbols=%v routes=%v", authorized, bounded)
+	}
+
+	authorized, bounded = boundedLocalizationRefinementRoutes([]string{"wrapper", "implementation"}, routes, "wrapper")
+	if len(authorized) != 2 || bounded["wrapper"].implementationSymbol != "implementation" {
+		t.Fatalf("visible implementation route = symbols:%v routes:%v", authorized, bounded)
+	}
+}

--- a/internal/mcp/explore_refinement_route_test.go
+++ b/internal/mcp/explore_refinement_route_test.go
@@ -210,29 +210,29 @@ func TestBuildLocalizationRefinementResultKeepsWireAndStateAuthorizationEqual(t 
 	}
 }
 
-func TestBuildLocalizationRefinementResultStaysOpenWithoutValidPreferredRoute(t *testing.T) {
+func TestBuildLocalizationRefinementResultOffersRecoveryWithoutValidPreferredRoute(t *testing.T) {
 	unhydrated := &graph.Node{ID: "repo/unhydrated", Name: "replace", Kind: graph.KindMethod, FilePath: "src/replace.rs"}
 	targets := []exploreTarget{{node: unhydrated}}
 	result, completion, bounded, _ := buildLocalizationRefinementResultForTask(
 		unhydrated.ID, "find the replace implementation", targets, exploreDefaultBudgetTokens,
 		exploreLocalizationRefinementRoutes(targets),
 	)
-	if completion.State != localizationStateInactive || completion.RequiredAction != "continue" || completion.AllowedToolCalls != 0 {
-		t.Fatalf("invalid preferred route completion = %#v, want explicit open contract", completion)
+	if completion.State != localizationStateNeedsRecovery || completion.RequiredAction != "recover_once" || completion.AllowedToolCalls != 1 {
+		t.Fatalf("invalid preferred route completion = %#v, want bounded recovery contract", completion)
 	}
 	if len(bounded) != 0 {
 		t.Fatalf("invalid preferred route retained authorization: %v", bounded)
 	}
 	text, ok := singleTextContent(result)
 	if !ok {
-		t.Fatal("open localization result has no single text payload")
+		t.Fatal("recovery localization result has no single text payload")
 	}
 	var envelope localizationExploreEnvelope
 	if err := json.Unmarshal([]byte(text), &envelope); err != nil {
-		t.Fatalf("decode open localization envelope: %v", err)
+		t.Fatalf("decode recovery localization envelope: %v", err)
 	}
-	if envelope.Completion.State != localizationStateInactive || envelope.Completion.RequiredAction != "continue" || len(envelope.Completion.AllowedSymbols) != 0 {
-		t.Fatalf("wire completion = %#v, want open without authorization", envelope.Completion)
+	if envelope.Completion.State != localizationStateNeedsRecovery || envelope.Completion.RequiredAction != "recover_once" || len(envelope.Completion.AllowedSymbols) != 0 {
+		t.Fatalf("wire completion = %#v, want bounded recovery without a prevalidated route", envelope.Completion)
 	}
 }
 

--- a/internal/mcp/explore_refinement_route_test.go
+++ b/internal/mcp/explore_refinement_route_test.go
@@ -40,8 +40,17 @@ func TestExploreRefinementRoutesPreferConcreteForwardedImplementation(t *testing
 	if got := routes[wrapper.ID].implementationSymbol; got != implementation.ID {
 		t.Fatalf("wrapper implementation route = %q, want %q", got, implementation.ID)
 	}
+	if !routes[wrapper.ID].enforceable {
+		t.Fatal("unique complete wrapper-to-implementation route must retain strong provenance")
+	}
 	if route, ok := routes[implementation.ID]; !ok || route.implementationSymbol != "" {
 		t.Fatalf("concrete implementation route = %#v, present=%v", route, ok)
+	} else if !route.enforceable || route.proofSymbol != wrapper.ID {
+		t.Fatalf("proven concrete route = %#v, want wrapper proof %q", route, wrapper.ID)
+	}
+	ordinary := exploreLocalizationRefinementRoutes([]exploreTarget{targets[1]})
+	if ordinary[implementation.ID].enforceable || ordinary[implementation.ID].proofSymbol != "" {
+		t.Fatalf("ordinary concrete hydration became enforceable: %#v", ordinary[implementation.ID])
 	}
 	if got := explorePreferredRoutedRefinementSymbol(wrapper.ID, targets, routes); got != implementation.ID {
 		t.Fatalf("preferred routed symbol = %q, want concrete %q", got, implementation.ID)

--- a/internal/mcp/explore_source_literal.go
+++ b/internal/mcp/explore_source_literal.go
@@ -10,6 +10,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/query"
 	"github.com/zzet/gortex/internal/search/trigram"
 )
@@ -486,9 +487,24 @@ func (s *Server) mapExploreSourceLiteralMatchesContext(
 		}
 	}
 	indexes := s.buildFileSymbolIndexForOrderedPathsContext(ctx, orderedPaths)
-	seen := make(map[string]struct{}, len(matches))
-	hits := make([]exploreSourceLiteralHit, 0, len(matches))
-	ownerFiles := make(map[string]string, len(matches))
+	type mappedLiteralOwner struct {
+		owner    *graph.Node
+		match    trigram.Match
+		rank     int
+		callName string
+	}
+	mapped := make([]mappedLiteralOwner, 0, len(matches))
+	ownerIDs := make([]string, 0, len(matches))
+	seenOwners := make(map[string]struct{}, len(matches))
+	calleeIDs := make([]string, 0, len(matches))
+	seenCallees := make(map[string]struct{}, len(matches))
+	ownerEdges := make(map[string][]*graph.Edge)
+
+	// First map each exact line to its smallest enclosing declaration. When
+	// the literal is syntactically inside one call on that line, retain the
+	// call name as a conservative hint; graph edges remain authoritative.
+	// This parser is deliberately line-bounded, so multiline or otherwise
+	// uncertain shapes keep the enclosing declaration instead of guessing.
 	for rank, match := range matches {
 		if !exploreTextHasExactLiteral(match.Text, term) {
 			continue
@@ -500,15 +516,72 @@ func (s *Server) mapExploreSourceLiteralMatchesContext(
 		if index == nil {
 			continue
 		}
-		node := index.smallestEnclosing(match.Line)
-		if node == nil || node.ID == "" || !scope.ScopeAllows(node) {
+		owner := index.smallestEnclosing(match.Line)
+		if owner == nil || owner.ID == "" || !scope.ScopeAllows(owner) {
 			continue
+		}
+		callName, _ := exploreSourceLiteralCallName(match.Text, term)
+		mapped = append(mapped, mappedLiteralOwner{owner: owner, match: match, rank: rank, callName: callName})
+		if callName != "" {
+			if _, duplicate := seenOwners[owner.ID]; duplicate {
+				continue
+			}
+			seenOwners[owner.ID] = struct{}{}
+			ownerIDs = append(ownerIDs, owner.ID)
+		}
+	}
+
+	if len(ownerIDs) > 0 {
+		ownerEdges = s.graph.GetOutEdgesByNodeIDs(ownerIDs)
+		for _, item := range mapped {
+			if item.callName == "" {
+				continue
+			}
+			for _, edge := range ownerEdges[item.owner.ID] {
+				if edge == nil || edge.Kind != graph.EdgeCalls || edge.Line != item.match.Line || edge.To == "" {
+					continue
+				}
+				if _, duplicate := seenCallees[edge.To]; duplicate {
+					continue
+				}
+				seenCallees[edge.To] = struct{}{}
+				calleeIDs = append(calleeIDs, edge.To)
+			}
+		}
+	}
+	calleeNodes := map[string]*graph.Node{}
+	if len(calleeIDs) > 0 {
+		calleeNodes = s.graph.GetNodesByIDs(calleeIDs)
+	}
+
+	seen := make(map[string]struct{}, len(mapped))
+	hits := make([]exploreSourceLiteralHit, 0, len(matches))
+	ownerFiles := make(map[string]string, len(matches))
+	for _, item := range mapped {
+		node := item.owner
+		if item.callName != "" {
+			resolved := make(map[string]*graph.Node)
+			for _, edge := range ownerEdges[item.owner.ID] {
+				if edge == nil || edge.Kind != graph.EdgeCalls || edge.Line != item.match.Line {
+					continue
+				}
+				callee := calleeNodes[edge.To]
+				if !exploreSourceLiteralLocalCallee(item.owner, callee, item.callName, scope) {
+					continue
+				}
+				resolved[callee.ID] = callee
+			}
+			if len(resolved) == 1 {
+				for _, callee := range resolved {
+					node = callee
+				}
+			}
 		}
 		if _, duplicate := seen[node.ID]; duplicate {
 			continue
 		}
 		seen[node.ID] = struct{}{}
-		hits = append(hits, exploreSourceLiteralHit{nodeID: node.ID, rank: rank})
+		hits = append(hits, exploreSourceLiteralHit{nodeID: node.ID, rank: item.rank})
 		ownerFiles[node.ID] = node.FilePath
 	}
 	return exploreSourceLiteralRecall{
@@ -516,6 +589,152 @@ func (s *Server) mapExploreSourceLiteralMatchesContext(
 		ambiguous:  saturated || len(hits) > 1,
 		ownerFiles: ownerFiles,
 	}
+}
+
+type exploreSourceLiteralSpan struct {
+	start int
+	end   int
+}
+
+// exploreSourceLiteralCallName returns the one direct call containing every
+// exact quoted occurrence of term on a source line. It intentionally declines
+// multiline calls, assignments, control-flow parentheses, and lines where the
+// literal participates in multiple calls. Those shapes retain the enclosing
+// callable and never receive callee promotion.
+func exploreSourceLiteralCallName(line, term string) (string, bool) {
+	spans := exploreSourceLiteralQuotedSpans(line, term)
+	if len(spans) == 0 {
+		return "", false
+	}
+	pairs := exploreSourceLiteralParenPairs(line)
+	names := make(map[string]string, len(spans))
+	for _, span := range spans {
+		bestOpen := -1
+		for _, pair := range pairs {
+			if pair.start < span.start && pair.end > span.end && pair.start > bestOpen {
+				bestOpen = pair.start
+			}
+		}
+		if bestOpen < 0 {
+			return "", false
+		}
+		name := exploreSourceLiteralIdentifierBefore(line, bestOpen)
+		if name == "" || exploreSourceLiteralControlWord(name) {
+			return "", false
+		}
+		names[strings.ToLower(name)] = name
+	}
+	if len(names) != 1 {
+		return "", false
+	}
+	for _, name := range names {
+		return name, true
+	}
+	return "", false
+}
+
+func exploreSourceLiteralQuotedSpans(line, term string) []exploreSourceLiteralSpan {
+	spans := make([]exploreSourceLiteralSpan, 0, 1)
+	for index := 0; index < len(line); {
+		quote := line[index]
+		if quote != '\'' && quote != '"' && quote != '`' {
+			index++
+			continue
+		}
+		start := index
+		index++
+		contentStart := index
+		for index < len(line) {
+			if line[index] == '\\' {
+				index += 2
+				continue
+			}
+			if line[index] == quote {
+				if line[contentStart:index] == term {
+					spans = append(spans, exploreSourceLiteralSpan{start: start, end: index})
+				}
+				index++
+				break
+			}
+			index++
+		}
+	}
+	return spans
+}
+
+func exploreSourceLiteralParenPairs(line string) []exploreSourceLiteralSpan {
+	stack := make([]int, 0, 4)
+	pairs := make([]exploreSourceLiteralSpan, 0, 4)
+	for index := 0; index < len(line); index++ {
+		switch line[index] {
+		case '\'', '"', '`':
+			quote := line[index]
+			for index++; index < len(line); index++ {
+				if line[index] == '\\' {
+					index++
+					continue
+				}
+				if line[index] == quote {
+					break
+				}
+			}
+		case '(':
+			stack = append(stack, index)
+		case ')':
+			if len(stack) == 0 {
+				continue
+			}
+			open := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			pairs = append(pairs, exploreSourceLiteralSpan{start: open, end: index})
+		}
+	}
+	return pairs
+}
+
+func exploreSourceLiteralIdentifierBefore(line string, end int) string {
+	for end > 0 {
+		r, size := utf8.DecodeLastRuneInString(line[:end])
+		if !unicode.IsSpace(r) {
+			break
+		}
+		end -= size
+	}
+	start := end
+	for start > 0 {
+		r, size := utf8.DecodeLastRuneInString(line[:start])
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' && r != '$' {
+			break
+		}
+		start -= size
+	}
+	return line[start:end]
+}
+
+func exploreSourceLiteralControlWord(name string) bool {
+	switch strings.ToLower(name) {
+	case "catch", "do", "for", "foreach", "if", "match", "new", "return", "sizeof", "switch", "typeof", "while", "with":
+		return true
+	default:
+		return false
+	}
+}
+
+func exploreSourceLiteralLocalCallee(owner, callee *graph.Node, callName string, scope query.QueryOptions) bool {
+	if owner == nil || callee == nil || callee.ID == "" || callee.ID == owner.ID || callee.FilePath == "" || !scope.ScopeAllows(callee) {
+		return false
+	}
+	if callee.Kind != graph.KindFunction && callee.Kind != graph.KindMethod {
+		return false
+	}
+	if callee.RepoPrefix != owner.RepoPrefix {
+		return false
+	}
+	name := callee.Name
+	if separator := strings.LastIndexAny(name, ".:#/"); separator >= 0 {
+		name = name[separator+1:]
+	}
+	return strings.EqualFold(name, callName)
 }
 
 func exploreSourceLiteralSingleRepoPrefix(scope query.QueryOptions) string {

--- a/internal/mcp/explore_source_literal.go
+++ b/internal/mcp/explore_source_literal.go
@@ -15,19 +15,35 @@ import (
 )
 
 const (
-	exploreSourceLiteralRecallMaxHits  = 24
-	exploreSourceLiteralRecallMaxFiles = 0
-	exploreSourceLiteralRecallBudget   = 75 * time.Millisecond
+	exploreSourceLiteralRecallMaxHits          = 24
+	exploreSourceLiteralRecallMaxFiles         = 0
+	exploreSourceLiteralRecallBudget           = 75 * time.Millisecond
+	exploreSourceLiteralRecallMaxTerms         = 2
+	exploreSourceLiteralRecallMaxOwnersPerTerm = 3
+	exploreSourceLiteralRecallMaxFilesPerTerm  = 2
 )
 
 type exploreSourceLiteralHit struct {
-	nodeID string
-	rank   int
+	nodeID    string
+	rank      int
+	anchor    int
+	ambiguous bool
+}
+
+type exploreSourceLiteralDiagnostic struct {
+	literal        string
+	rawHits        int
+	mappedOwners   int
+	retainedOwners int
+	retainedFiles  int
+	reason         string
 }
 
 type exploreSourceLiteralRecall struct {
-	hits      []exploreSourceLiteralHit
-	ambiguous bool
+	hits        []exploreSourceLiteralHit
+	ambiguous   bool
+	ownerFiles  map[string]string
+	diagnostics []exploreSourceLiteralDiagnostic
 }
 
 type exploreSourceLiteralSearch struct {
@@ -96,11 +112,101 @@ func exploreSourceLiteralFallback(terms []string, primary string) string {
 	return best
 }
 
+func exploreCompactSourceLiteralTerms(terms []string) []string {
+	out := make([]string, 0, min(len(terms), exploreSourceLiteralRecallMaxTerms))
+	seen := make(map[string]struct{}, len(terms))
+	for _, term := range terms {
+		if !exploreCompactSourceLiteral(term, utf8.RuneCountInString(term)) {
+			continue
+		}
+		key := strings.ToLower(term)
+		if _, duplicate := seen[key]; duplicate {
+			continue
+		}
+		seen[key] = struct{}{}
+		if len(out) < exploreSourceLiteralRecallMaxTerms {
+			out = append(out, term)
+		}
+	}
+	return out
+}
+
+// retainExploreSourceLiteralOwners keeps file diversity before filling the
+// remaining declaration slots. This prevents the first file's sibling methods
+// from evicting an equally exact owner in a second file while retaining fixed
+// per-term work and response bounds.
+func retainExploreSourceLiteralOwners(recall exploreSourceLiteralRecall) (hits []exploreSourceLiteralHit, files int, reason string) {
+	if len(recall.hits) == 0 {
+		return nil, 0, "no_mapped_owner"
+	}
+	seenOwners := make(map[string]struct{}, min(len(recall.hits), exploreSourceLiteralRecallMaxOwnersPerTerm))
+	seenFiles := make(map[string]struct{}, exploreSourceLiteralRecallMaxFilesPerTerm)
+	selected := make([]bool, len(recall.hits))
+	add := func(index int) {
+		hit := recall.hits[index]
+		if _, duplicate := seenOwners[hit.nodeID]; duplicate {
+			return
+		}
+		seenOwners[hit.nodeID] = struct{}{}
+		if file := recall.ownerFiles[hit.nodeID]; file != "" {
+			seenFiles[file] = struct{}{}
+		}
+		selected[index] = true
+		hits = append(hits, hit)
+	}
+
+	// First pass: one declaration from each distinct file.
+	for index, hit := range recall.hits {
+		if len(hits) >= exploreSourceLiteralRecallMaxOwnersPerTerm || len(seenFiles) >= exploreSourceLiteralRecallMaxFilesPerTerm {
+			break
+		}
+		file := recall.ownerFiles[hit.nodeID]
+		if file == "" {
+			continue
+		}
+		if _, exists := seenFiles[file]; exists {
+			continue
+		}
+		add(index)
+	}
+	// Second pass: fill remaining owner slots from already-admitted files.
+	for index, hit := range recall.hits {
+		if len(hits) >= exploreSourceLiteralRecallMaxOwnersPerTerm {
+			break
+		}
+		if selected[index] {
+			continue
+		}
+		file := recall.ownerFiles[hit.nodeID]
+		if file != "" {
+			if _, admitted := seenFiles[file]; !admitted && len(seenFiles) >= exploreSourceLiteralRecallMaxFilesPerTerm {
+				continue
+			}
+		}
+		add(index)
+	}
+
+	if len(hits) < len(recall.hits) {
+		mappedFiles := make(map[string]struct{}, len(recall.hits))
+		for _, hit := range recall.hits {
+			if file := recall.ownerFiles[hit.nodeID]; file != "" {
+				mappedFiles[file] = struct{}{}
+			}
+		}
+		if len(mappedFiles) > exploreSourceLiteralRecallMaxFilesPerTerm {
+			reason = "file_cap"
+		} else {
+			reason = "owner_cap"
+		}
+	}
+	return hits, len(seenFiles), reason
+}
+
 // gatherExploreSourceLiteralRecall reuses the bounded raw-text path behind
 // search(operation:"text") only when content_fts could not produce an exact
-// symbol candidate. It searches one repository and one literal, maps each
-// 1-based line hit to the smallest enclosing code symbol, and returns IDs for
-// the caller's existing single batch graph hydration.
+// symbol candidates. It searches one repository and at most two compact
+// literals, maps 1-based hits to their smallest enclosing declarations, and
+// returns a file-diverse owner set for the caller's existing batch hydration.
 func (s *Server) gatherExploreSourceLiteralRecall(
 	ctx context.Context,
 	terms []string,
@@ -110,14 +216,16 @@ func (s *Server) gatherExploreSourceLiteralRecall(
 	if s == nil || ctx.Err() != nil {
 		return exploreSourceLiteralRecall{}
 	}
-	primary := explorePreferredSourceLiteral(terms)
-	if primary == "" {
+	attemptTerms := exploreCompactSourceLiteralTerms(terms)
+	if len(attemptTerms) == 0 {
+		if primary := explorePreferredSourceLiteral(terms); primary != "" {
+			attemptTerms = append(attemptTerms, primary)
+		}
+	}
+	if len(attemptTerms) == 0 {
 		return exploreSourceLiteralRecall{}
 	}
 
-	// Search and symbol mapping historically had one 75 ms phase each. Keep the
-	// same 150 ms end-to-end ceiling while allowing a fast, saturated compact-key
-	// lookup to spend only the remaining time on one more-selective fallback.
 	started := time.Now()
 	boundedCtx, cancelBounded := context.WithTimeout(ctx, 2*exploreSourceLiteralRecallBudget)
 	defer cancelBounded()
@@ -128,12 +236,21 @@ func (s *Server) gatherExploreSourceLiteralRecall(
 		searchErr  error
 		mappingErr error
 	}
-	attempt := func(term string) literalAttempt {
+	attempt := func(term string, budget time.Duration) literalAttempt {
 		result := literalAttempt{term: term}
 		if term == "" || boundedCtx.Err() != nil {
 			return result
 		}
-		searchCtx, cancelSearch := context.WithTimeout(boundedCtx, exploreSourceLiteralRecallBudget)
+		attemptCtx, cancelAttempt := context.WithTimeout(boundedCtx, budget)
+		defer cancelAttempt()
+		searchBudget := exploreSourceLiteralRecallBudget
+		if budget < searchBudget {
+			searchBudget = budget
+		}
+		// Two-anchor recall gives each discovery the full per-anchor slice.
+		// Mapping still shares attemptCtx, so the two attempts remain inside the
+		// fixed 150ms request budget without silently halving grep time again.
+		searchCtx, cancelSearch := context.WithTimeout(attemptCtx, searchBudget)
 		result.search = s.searchExploreSourceLiteral(searchCtx, term, repoPrefix, scope)
 		result.searchErr = searchCtx.Err()
 		cancelSearch()
@@ -141,67 +258,158 @@ func (s *Server) gatherExploreSourceLiteralRecall(
 			return result
 		}
 		result.recall, result.mappingErr = s.mapDiscoveredExploreSourceLiteralMatches(
-			boundedCtx, term, result.search, scope, result.searchErr,
+			attemptCtx, term, result.search, scope, result.searchErr,
 		)
 		return result
 	}
 
-	chosen := attempt(primary)
-	fallbackAttempted := false
-	fallback := exploreSourceLiteralFallback(terms, primary)
-	primaryCompact := exploreCompactSourceLiteral(primary, utf8.RuneCountInString(primary))
-	if primaryCompact && fallback != "" && boundedCtx.Err() == nil &&
-		(len(chosen.recall.hits) == 0 || chosen.recall.ambiguous || chosen.search.incomplete) {
-		fallbackAttempted = true
-		candidate := attempt(fallback)
-		// Preserve a useful compact-key result unless the longer term is the only
-		// mapped result or resolves the compact lookup's ambiguity.
-		if len(candidate.recall.hits) > 0 &&
-			(len(chosen.recall.hits) == 0 || !candidate.recall.ambiguous) {
-			chosen = candidate
+	aggregate := exploreSourceLiteralRecall{ownerFiles: make(map[string]string)}
+	attempted := make(map[string]struct{}, len(attemptTerms)+1)
+	results := make([]literalAttempt, 0, len(attemptTerms)+1)
+	run := func(term string, anchor int, budget time.Duration) literalAttempt {
+		result := attempt(term, budget)
+		attempted[strings.ToLower(term)] = struct{}{}
+		retained, retainedFiles, capReason := retainExploreSourceLiteralOwners(result.recall)
+		reason := capReason
+		switch {
+		case result.searchErr != nil:
+			reason = "search_deadline"
+		case result.mappingErr != nil:
+			reason = "mapping_deadline"
+		case result.search.backend == "none" || !result.search.owned && len(result.search.matches) == 0:
+			reason = "backend_unavailable"
+		case len(result.search.matches) == 0:
+			reason = "no_match"
+		case len(result.recall.hits) == 0:
+			reason = "no_mapped_owner"
+		case reason == "" && result.search.incomplete:
+			reason = "search_cap"
 		}
+		aggregate.diagnostics = append(aggregate.diagnostics, exploreSourceLiteralDiagnostic{
+			literal:        term,
+			rawHits:        len(result.search.matches),
+			mappedOwners:   len(result.recall.hits),
+			retainedOwners: len(retained),
+			retainedFiles:  retainedFiles,
+			reason:         reason,
+		})
+		for _, hit := range retained {
+			hit.anchor = anchor
+			hit.ambiguous = result.recall.ambiguous
+			aggregate.hits = append(aggregate.hits, hit)
+			if file := result.recall.ownerFiles[hit.nodeID]; file != "" {
+				aggregate.ownerFiles[hit.nodeID] = file
+			}
+		}
+		aggregate.ambiguous = aggregate.ambiguous || result.recall.ambiguous
+		results = append(results, result)
+		return result
+	}
+
+	attemptBudget := 2 * exploreSourceLiteralRecallBudget
+	if len(attemptTerms) > 1 {
+		attemptBudget = exploreSourceLiteralRecallBudget
+	}
+	for index, term := range attemptTerms {
+		if boundedCtx.Err() != nil {
+			break
+		}
+		run(term, index, attemptBudget)
+	}
+	// Preserve the existing selective fallback when there is only one compact
+	// anchor and it produces no settled owner. Two compact anchors already spend
+	// the entire bounded term budget and are aggregated directly.
+	if len(attemptTerms) == 1 && len(results) == 1 && boundedCtx.Err() == nil {
+		primary := results[0]
+		if fallback := exploreSourceLiteralFallback(terms, primary.term); fallback != "" &&
+			(len(primary.recall.hits) == 0 || primary.recall.ambiguous || primary.search.incomplete) {
+			run(fallback, 1, exploreSourceLiteralRecallBudget)
+		}
+	}
+	for _, term := range terms {
+		if _, ok := attempted[strings.ToLower(term)]; ok {
+			continue
+		}
+		reason := "not_compact"
+		if exploreCompactSourceLiteral(term, utf8.RuneCountInString(term)) {
+			reason = "term_cap"
+			if boundedCtx.Err() != nil {
+				reason = "request_deadline"
+			}
+		}
+		aggregate.diagnostics = append(aggregate.diagnostics, exploreSourceLiteralDiagnostic{
+			literal: term,
+			reason:  reason,
+		})
 	}
 	if ctx.Err() != nil {
 		return exploreSourceLiteralRecall{}
 	}
 
 	if s.logger != nil {
-		contextError := ""
-		if chosen.searchErr != nil {
-			contextError = "search: " + chosen.searchErr.Error()
-		}
-		if chosen.mappingErr != nil {
-			if contextError != "" {
-				contextError += "; "
+		rawHits, mappedOwners, retainedOwners := 0, 0, 0
+		reasons := make(map[string]struct{})
+		for _, diagnostic := range aggregate.diagnostics {
+			rawHits += diagnostic.rawHits
+			mappedOwners += diagnostic.mappedOwners
+			retainedOwners += diagnostic.retainedOwners
+			if diagnostic.reason != "" {
+				reasons[diagnostic.reason] = struct{}{}
 			}
-			contextError += "mapping: " + chosen.mappingErr.Error()
 		}
+		reasonKeys := make([]string, 0, len(reasons))
+		for reason := range reasons {
+			reasonKeys = append(reasonKeys, reason)
+		}
+		sort.Strings(reasonKeys)
+		termRunes := 0
+		backend := "none"
+		owned := false
+		lookupRepoPrefix := ""
 		firstMatchPath := ""
-		if len(chosen.search.matches) > 0 {
-			firstMatchPath = chosen.search.matches[0].Path
+		contextError := ""
+		if len(results) > 0 {
+			termRunes = utf8.RuneCountInString(results[0].term)
+			backend = results[0].search.backend
+			owned = results[0].search.owned
+			lookupRepoPrefix = results[0].search.lookupRepoPrefix
+			if len(results[0].search.matches) > 0 {
+				firstMatchPath = results[0].search.matches[0].Path
+			}
+			if results[0].searchErr != nil {
+				contextError = "search: " + results[0].searchErr.Error()
+			}
+			if results[0].mappingErr != nil {
+				if contextError != "" {
+					contextError += "; "
+				}
+				contextError += "mapping: " + results[0].mappingErr.Error()
+			}
 		}
 		fields := []zap.Field{
-			zap.Int("term_runes", utf8.RuneCountInString(chosen.term)),
-			zap.Bool("fallback_attempted", fallbackAttempted),
-			zap.Bool("fallback_selected", chosen.term != primary),
+			zap.Int("term_runes", termRunes),
+			zap.Int("attempted_terms", len(results)),
+			zap.Int("diagnostic_terms", len(aggregate.diagnostics)),
+			zap.String("reasons", strings.Join(reasonKeys, ",")),
 			zap.String("requested_repo_prefix", repoPrefix),
-			zap.String("lookup_repo_prefix", chosen.search.lookupRepoPrefix),
+			zap.String("lookup_repo_prefix", lookupRepoPrefix),
 			zap.String("first_match_path", firstMatchPath),
-			zap.String("backend", chosen.search.backend),
-			zap.Bool("owned", chosen.search.owned),
-			zap.Int("raw_matches", len(chosen.search.matches)),
-			zap.Int("mapped_symbols", len(chosen.recall.hits)),
-			zap.Bool("incomplete", chosen.search.incomplete),
+			zap.String("backend", backend),
+			zap.Bool("owned", owned),
+			zap.Int("raw_matches", rawHits),
+			zap.Int("mapped_symbols", mappedOwners),
+			zap.Int("retained_symbols", retainedOwners),
+			zap.Bool("incomplete", aggregate.ambiguous),
 			zap.String("context_error", contextError),
 			zap.Duration("elapsed", time.Since(started)),
 		}
-		if len(chosen.recall.hits) == 0 || chosen.search.incomplete || contextError != "" {
+		if len(aggregate.hits) == 0 || aggregate.ambiguous || contextError != "" {
 			s.logger.Info("mcp: explore source literal recall incomplete", fields...)
 		} else {
 			s.logger.Debug("mcp: explore source literal recall", fields...)
 		}
 	}
-	return chosen.recall
+	return aggregate
 }
 
 func (s *Server) mapDiscoveredExploreSourceLiteralMatches(
@@ -280,6 +488,7 @@ func (s *Server) mapExploreSourceLiteralMatchesContext(
 	indexes := s.buildFileSymbolIndexForOrderedPathsContext(ctx, orderedPaths)
 	seen := make(map[string]struct{}, len(matches))
 	hits := make([]exploreSourceLiteralHit, 0, len(matches))
+	ownerFiles := make(map[string]string, len(matches))
 	for rank, match := range matches {
 		if !exploreTextHasExactLiteral(match.Text, term) {
 			continue
@@ -300,10 +509,12 @@ func (s *Server) mapExploreSourceLiteralMatchesContext(
 		}
 		seen[node.ID] = struct{}{}
 		hits = append(hits, exploreSourceLiteralHit{nodeID: node.ID, rank: rank})
+		ownerFiles[node.ID] = node.FilePath
 	}
 	return exploreSourceLiteralRecall{
-		hits:      hits,
-		ambiguous: saturated || len(hits) > 1,
+		hits:       hits,
+		ambiguous:  saturated || len(hits) > 1,
+		ownerFiles: ownerFiles,
 	}
 }
 

--- a/internal/mcp/explore_source_literal.go
+++ b/internal/mcp/explore_source_literal.go
@@ -29,6 +29,7 @@ type exploreSourceLiteralHit struct {
 	rank      int
 	anchor    int
 	ambiguous bool
+	callee    bool
 }
 
 type exploreSourceLiteralDiagnostic struct {
@@ -554,11 +555,12 @@ func (s *Server) mapExploreSourceLiteralMatchesContext(
 		calleeNodes = s.graph.GetNodesByIDs(calleeIDs)
 	}
 
-	seen := make(map[string]struct{}, len(mapped))
+	seen := make(map[string]int, len(mapped))
 	hits := make([]exploreSourceLiteralHit, 0, len(matches))
 	ownerFiles := make(map[string]string, len(matches))
 	for _, item := range mapped {
 		node := item.owner
+		calleeResolved := false
 		if item.callName != "" {
 			resolved := make(map[string]*graph.Node)
 			for _, edge := range ownerEdges[item.owner.ID] {
@@ -574,14 +576,18 @@ func (s *Server) mapExploreSourceLiteralMatchesContext(
 			if len(resolved) == 1 {
 				for _, callee := range resolved {
 					node = callee
+					calleeResolved = true
 				}
 			}
 		}
-		if _, duplicate := seen[node.ID]; duplicate {
+		if existing, duplicate := seen[node.ID]; duplicate {
+			if calleeResolved {
+				hits[existing].callee = true
+			}
 			continue
 		}
-		seen[node.ID] = struct{}{}
-		hits = append(hits, exploreSourceLiteralHit{nodeID: node.ID, rank: item.rank})
+		seen[node.ID] = len(hits)
+		hits = append(hits, exploreSourceLiteralHit{nodeID: node.ID, rank: item.rank, callee: calleeResolved})
 		ownerFiles[node.ID] = node.FilePath
 	}
 	return exploreSourceLiteralRecall{

--- a/internal/mcp/explore_source_literal.go
+++ b/internal/mcp/explore_source_literal.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
 	"unicode/utf8"
 
 	"go.uber.org/zap"
@@ -37,14 +38,57 @@ type exploreSourceLiteralSearch struct {
 	lookupRepoPrefix string
 }
 
-// exploreHighestInformationQuotedLiteral picks one deterministic source-search
-// key. Quoted terms have already passed the noise filter; rune length is a
-// language-neutral proxy for selectivity and avoids multiplying repository
-// scans when a task contains several literals.
-func exploreHighestInformationQuotedLiteral(terms []string) string {
+// explorePreferredSourceLiteral picks one deterministic source-search key.
+// Quoted terms have already passed the noise filter. Compact alphabetic values
+// (locale/protocol/config keys) are reserved before longer prose because their
+// registration sites are otherwise invisible to symbol metadata. A saturated
+// compact lookup may fall back to the longest remaining term inside the same
+// fixed end-to-end deadline.
+func explorePreferredSourceLiteral(terms []string) string {
+	best := ""
+	bestLen := 0
+	bestCompact := false
+	for _, term := range terms {
+		n := utf8.RuneCountInString(term)
+		compact := exploreCompactSourceLiteral(term, n)
+		if best == "" || compact && !bestCompact || compact == bestCompact && n > bestLen {
+			best, bestLen, bestCompact = term, n, compact
+		}
+	}
+	return best
+}
+
+func exploreCompactSourceLiteral(term string, runeCount int) bool {
+	// Reserve priority only for two-letter alphabetic codes. Three- and
+	// four-letter lowercase values are indistinguishable from common prose
+	// ("test", "file", "true") and must compete by information length. They
+	// remain searchable when they are the only quoted term.
+	if runeCount != 2 {
+		return false
+	}
+	lower := strings.ToLower(term)
+	if _, stop := assistStopWords[lower]; stop {
+		return false
+	}
+	switch lower {
+	case "am", "an", "as", "at", "be", "by", "do", "go", "he", "hi", "if", "in", "is", "it", "me", "my", "no", "of", "oh", "ok", "on", "or", "so", "to", "up", "us", "we":
+		return false
+	}
+	for _, r := range term {
+		if !unicode.IsLetter(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func exploreSourceLiteralFallback(terms []string, primary string) string {
 	best := ""
 	bestLen := 0
 	for _, term := range terms {
+		if strings.EqualFold(term, primary) {
+			continue
+		}
 		if n := utf8.RuneCountInString(term); n > bestLen {
 			best, bestLen = term, n
 		}
@@ -66,63 +110,98 @@ func (s *Server) gatherExploreSourceLiteralRecall(
 	if s == nil || ctx.Err() != nil {
 		return exploreSourceLiteralRecall{}
 	}
-	term := exploreHighestInformationQuotedLiteral(terms)
-	if term == "" {
+	primary := explorePreferredSourceLiteral(terms)
+	if primary == "" {
 		return exploreSourceLiteralRecall{}
 	}
 
+	// Search and symbol mapping historically had one 75 ms phase each. Keep the
+	// same 150 ms end-to-end ceiling while allowing a fast, saturated compact-key
+	// lookup to spend only the remaining time on one more-selective fallback.
 	started := time.Now()
-	searchCtx, cancelSearch := context.WithTimeout(ctx, exploreSourceLiteralRecallBudget)
-	search := s.searchExploreSourceLiteral(searchCtx, term, repoPrefix, scope)
-	searchErr := searchCtx.Err()
-	cancelSearch()
+	boundedCtx, cancelBounded := context.WithTimeout(ctx, 2*exploreSourceLiteralRecallBudget)
+	defer cancelBounded()
+	type literalAttempt struct {
+		term       string
+		search     exploreSourceLiteralSearch
+		recall     exploreSourceLiteralRecall
+		searchErr  error
+		mappingErr error
+	}
+	attempt := func(term string) literalAttempt {
+		result := literalAttempt{term: term}
+		if term == "" || boundedCtx.Err() != nil {
+			return result
+		}
+		searchCtx, cancelSearch := context.WithTimeout(boundedCtx, exploreSourceLiteralRecallBudget)
+		result.search = s.searchExploreSourceLiteral(searchCtx, term, repoPrefix, scope)
+		result.searchErr = searchCtx.Err()
+		cancelSearch()
+		if ctx.Err() != nil {
+			return result
+		}
+		result.recall, result.mappingErr = s.mapDiscoveredExploreSourceLiteralMatches(
+			boundedCtx, term, result.search, scope, result.searchErr,
+		)
+		return result
+	}
+
+	chosen := attempt(primary)
+	fallbackAttempted := false
+	fallback := exploreSourceLiteralFallback(terms, primary)
+	primaryCompact := exploreCompactSourceLiteral(primary, utf8.RuneCountInString(primary))
+	if primaryCompact && fallback != "" && boundedCtx.Err() == nil &&
+		(len(chosen.recall.hits) == 0 || chosen.recall.ambiguous || chosen.search.incomplete) {
+		fallbackAttempted = true
+		candidate := attempt(fallback)
+		// Preserve a useful compact-key result unless the longer term is the only
+		// mapped result or resolves the compact lookup's ambiguity.
+		if len(candidate.recall.hits) > 0 &&
+			(len(chosen.recall.hits) == 0 || !candidate.recall.ambiguous) {
+			chosen = candidate
+		}
+	}
 	if ctx.Err() != nil {
 		return exploreSourceLiteralRecall{}
 	}
 
-	// Discovery and graph mapping have independent bounded phases. A backend
-	// may return useful partial matches as its deadline expires; reusing that
-	// expired context would discard those matches before they can be mapped to
-	// enclosing symbols. The request context remains the parent bound, while
-	// each phase gets the same small local budget.
-	recall, mappingErr := s.mapDiscoveredExploreSourceLiteralMatches(
-		ctx, term, search, scope, searchErr,
-	)
 	if s.logger != nil {
 		contextError := ""
-		if searchErr != nil {
-			contextError = "search: " + searchErr.Error()
+		if chosen.searchErr != nil {
+			contextError = "search: " + chosen.searchErr.Error()
 		}
-		if mappingErr != nil {
+		if chosen.mappingErr != nil {
 			if contextError != "" {
 				contextError += "; "
 			}
-			contextError += "mapping: " + mappingErr.Error()
+			contextError += "mapping: " + chosen.mappingErr.Error()
 		}
 		firstMatchPath := ""
-		if len(search.matches) > 0 {
-			firstMatchPath = search.matches[0].Path
+		if len(chosen.search.matches) > 0 {
+			firstMatchPath = chosen.search.matches[0].Path
 		}
 		fields := []zap.Field{
-			zap.Int("term_runes", utf8.RuneCountInString(term)),
+			zap.Int("term_runes", utf8.RuneCountInString(chosen.term)),
+			zap.Bool("fallback_attempted", fallbackAttempted),
+			zap.Bool("fallback_selected", chosen.term != primary),
 			zap.String("requested_repo_prefix", repoPrefix),
-			zap.String("lookup_repo_prefix", search.lookupRepoPrefix),
+			zap.String("lookup_repo_prefix", chosen.search.lookupRepoPrefix),
 			zap.String("first_match_path", firstMatchPath),
-			zap.String("backend", search.backend),
-			zap.Bool("owned", search.owned),
-			zap.Int("raw_matches", len(search.matches)),
-			zap.Int("mapped_symbols", len(recall.hits)),
-			zap.Bool("incomplete", search.incomplete),
+			zap.String("backend", chosen.search.backend),
+			zap.Bool("owned", chosen.search.owned),
+			zap.Int("raw_matches", len(chosen.search.matches)),
+			zap.Int("mapped_symbols", len(chosen.recall.hits)),
+			zap.Bool("incomplete", chosen.search.incomplete),
 			zap.String("context_error", contextError),
 			zap.Duration("elapsed", time.Since(started)),
 		}
-		if len(recall.hits) == 0 || search.incomplete || contextError != "" {
+		if len(chosen.recall.hits) == 0 || chosen.search.incomplete || contextError != "" {
 			s.logger.Info("mcp: explore source literal recall incomplete", fields...)
 		} else {
 			s.logger.Debug("mcp: explore source literal recall", fields...)
 		}
 	}
-	return recall
+	return chosen.recall
 }
 
 func (s *Server) mapDiscoveredExploreSourceLiteralMatches(

--- a/internal/mcp/explore_source_literal_test.go
+++ b/internal/mcp/explore_source_literal_test.go
@@ -237,9 +237,24 @@ func TestMapDiscoveredExploreSourceLiteralMatchesPreservesHitsAfterDiscoveryDead
 	require.True(t, recall.ambiguous, "deadline-truncated discovery must remain non-terminal")
 }
 
-func TestExploreHighestInformationQuotedLiteral(t *testing.T) {
-	require.Equal(t, "registration-key", exploreHighestInformationQuotedLiteral([]string{"ku", "日本", "registration-key"}))
-	require.Empty(t, exploreHighestInformationQuotedLiteral(nil))
+func TestExplorePreferredSourceLiteralReservesCompactValue(t *testing.T) {
+	require.Equal(t, "ku", explorePreferredSourceLiteral([]string{"registration-key", "ku", "日本"}))
+	require.Equal(t, "日本", explorePreferredSourceLiteral([]string{"registration-key", "日本"}))
+	require.Empty(t, explorePreferredSourceLiteral(nil))
+}
+
+func TestExplorePreferredSourceLiteralRejectsCompactNoise(t *testing.T) {
+	for _, noise := range []string{"it", "x-1", "test", "file", "true"} {
+		require.Equal(t, "registration-key", explorePreferredSourceLiteral([]string{noise, "registration-key"}), noise)
+	}
+	// A short prose value remains searchable when it is the only literal; it
+	// simply no longer displaces a more selective term.
+	require.Equal(t, "test", explorePreferredSourceLiteral([]string{"test"}))
+}
+
+func TestExploreSourceLiteralFallbackUsesLongestRemainingTerm(t *testing.T) {
+	require.Equal(t, "registration-key", exploreSourceLiteralFallback([]string{"ku", "name", "registration-key"}, "ku"))
+	require.Empty(t, exploreSourceLiteralFallback([]string{"ku", "KU"}, "ku"))
 }
 
 func TestGatherExploreQuotedContentCandidatesMergesSourceLiteralWithExactContentNode(t *testing.T) {
@@ -279,6 +294,36 @@ func TestGatherExploreQuotedContentCandidatesMergesSourceLiteralWithExactContent
 
 	require.NotNil(t, candidateByID(candidates, document.ID), "exact content evidence must be retained")
 	require.NotNil(t, candidateByID(candidates, constructor.ID), "an exact non-source content hit must not suppress bounded source recall")
+}
+
+func TestGatherExploreQuotedContentCandidatesKeepsMissingCompactLiteralBesideExactPeer(t *testing.T) {
+	root := t.TempDir()
+	rel := "src/Registry.cs"
+	path := filepath.Join(root, filepath.FromSlash(rel))
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte("public sealed class Registry {\n    public void Configure() {\n        Register(\"xy\");\n    }\n}\n"), 0o644))
+
+	store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "graph.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	idx := indexer.New(store, parser.NewRegistry(), config.IndexConfig{}, zap.NewNop())
+	_, err = idx.IndexCtx(context.Background(), root)
+	require.NoError(t, err)
+	idx.SetFileMtimes(map[string]int64{rel: 1})
+
+	exactPeer := sourceLiteralNode("demo/src/VisibleType.cs::VisibleType", "VisibleType", "src/VisibleType.cs", graph.KindType, 1, 2)
+	configure := sourceLiteralNode("demo/src/Registry.cs::Registry.Configure", "Registry.Configure", rel, graph.KindMethod, 2, 4)
+	store.AddBatch([]*graph.Node{exactPeer, configure}, nil)
+	server := &Server{graph: store, indexer: idx, logger: zap.NewNop()}
+
+	candidates := server.gatherExploreQuotedContentCandidates(
+		context.Background(), `locate where "xy" is registered; "VisibleType" is contextual`,
+		[]*rerank.Candidate{{Node: exactPeer, TextRank: 0, VectorRank: -1}}, 20,
+		query.QueryOptions{RepoAllow: map[string]bool{"demo": true}},
+	)
+
+	require.NotNil(t, candidateByID(candidates, configure.ID),
+		"an exact metadata peer for one term must not suppress source recall for another quoted value")
 }
 
 func TestGatherExploreQuotedContentCandidatesSkipsSourceScanForExactOrdinaryCandidate(t *testing.T) {

--- a/internal/mcp/explore_source_literal_test.go
+++ b/internal/mcp/explore_source_literal_test.go
@@ -321,8 +321,8 @@ func TestExplorePreferredRefinementSymbolPrefersSourceLiteral(t *testing.T) {
 	source := &graph.Node{ID: "repo/source.go::source"}
 	targets := []exploreTarget{{node: ordinary}, {node: source, sourceLiteral: true}}
 
-	require.Equal(t, source.ID, explorePreferredRefinementSymbol(targets))
-	require.Equal(t, ordinary.ID, explorePreferredRefinementSymbol(targets[:1]))
+	require.Equal(t, source.ID, explorePreferredRefinementSymbol("locate the helper", targets))
+	require.Equal(t, ordinary.ID, explorePreferredRefinementSymbol("locate the helper", targets[:1]))
 }
 
 func TestGatherExploreSourceLiteralRecallMapsParsedCSharpConstructor(t *testing.T) {

--- a/internal/mcp/explore_source_literal_test.go
+++ b/internal/mcp/explore_source_literal_test.go
@@ -370,6 +370,236 @@ func TestExplorePreferredRefinementSymbolPrefersSourceLiteral(t *testing.T) {
 	require.Equal(t, ordinary.ID, explorePreferredRefinementSymbol("locate the helper", targets[:1]))
 }
 
+func TestRetainExploreSourceLiteralOwnersDiversifiesFilesWithinCaps(t *testing.T) {
+	recall := exploreSourceLiteralRecall{
+		hits: []exploreSourceLiteralHit{
+			{nodeID: "first-a", rank: 0},
+			{nodeID: "first-b", rank: 1},
+			{nodeID: "second", rank: 2},
+			{nodeID: "third", rank: 3},
+		},
+		ownerFiles: map[string]string{
+			"first-a": "src/first.go",
+			"first-b": "src/first.go",
+			"second":  "src/second.go",
+			"third":   "src/third.go",
+		},
+	}
+
+	hits, files, reason := retainExploreSourceLiteralOwners(recall)
+
+	require.Equal(t, []string{"first-a", "second", "first-b"}, []string{
+		hits[0].nodeID, hits[1].nodeID, hits[2].nodeID,
+	})
+	require.Equal(t, exploreSourceLiteralRecallMaxFilesPerTerm, files)
+	require.Equal(t, "file_cap", reason)
+}
+
+func TestGatherExploreSourceLiteralRecallAggregatesCompactAnchorsAcrossLanguages(t *testing.T) {
+	fixtures := []struct {
+		name     string
+		language string
+		ext      string
+		first    string
+		second   string
+	}{
+		{
+			name: "csharp", language: "csharp", ext: ".cs",
+			first:  "public void First() {\n    Register(\"aa\");\n}\n",
+			second: "public void Second() {\n    Register(\"aa\");\n    Register(\"bb\");\n}\n",
+		},
+		{
+			name: "rust", language: "rust", ext: ".rs",
+			first:  "fn first() {\n    register(\"aa\");\n}\n",
+			second: "fn second() {\n    register(\"aa\");\n    register(\"bb\");\n}\n",
+		},
+		{
+			name: "typescript", language: "typescript", ext: ".ts",
+			first:  "function first() {\n    register(\"aa\");\n}\n",
+			second: "function second() {\n    register(\"aa\");\n    register(\"bb\");\n}\n",
+		},
+	}
+	for _, fixture := range fixtures {
+		t.Run(fixture.name, func(t *testing.T) {
+			root := t.TempDir()
+			firstRel := "src/first" + fixture.ext
+			secondRel := "src/second" + fixture.ext
+			for rel, source := range map[string]string{firstRel: fixture.first, secondRel: fixture.second} {
+				path := filepath.Join(root, filepath.FromSlash(rel))
+				require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+				require.NoError(t, os.WriteFile(path, []byte(source), 0o644))
+			}
+
+			store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "graph.sqlite"))
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, store.Close()) })
+			idx := indexer.New(store, parser.NewRegistry(), config.IndexConfig{}, zap.NewNop())
+			_, err = idx.IndexCtx(context.Background(), root)
+			require.NoError(t, err)
+			idx.SetFileMtimes(map[string]int64{firstRel: 1, secondRel: 1})
+
+			first := sourceLiteralNode("demo/first::owner", "first", firstRel, graph.KindFunction, 1, 3)
+			second := sourceLiteralNode("demo/second::owner", "second", secondRel, graph.KindFunction, 1, 4)
+			first.Language = fixture.language
+			second.Language = fixture.language
+			store.AddBatch([]*graph.Node{first, second}, nil)
+			counting := &exploreSourceLiteralCountingStore{Store: store}
+			server := &Server{graph: counting, indexer: idx, logger: zap.NewNop()}
+
+			recall := server.gatherExploreSourceLiteralRecall(
+				context.Background(), []string{"aa", "bb"}, "", query.QueryOptions{},
+			)
+			coverage := make(map[string]map[int]struct{})
+			for _, hit := range recall.hits {
+				if coverage[hit.nodeID] == nil {
+					coverage[hit.nodeID] = make(map[int]struct{})
+				}
+				coverage[hit.nodeID][hit.anchor] = struct{}{}
+			}
+			require.Len(t, coverage[first.ID], 1)
+			require.Len(t, coverage[second.ID], 2)
+			require.Len(t, recall.diagnostics, 2)
+			require.Equal(t, []string{"aa", "bb"}, []string{
+				recall.diagnostics[0].literal, recall.diagnostics[1].literal,
+			})
+			require.Equal(t, 2, recall.diagnostics[0].rawHits)
+			require.Equal(t, 2, recall.diagnostics[0].mappedOwners)
+			require.Equal(t, 2, recall.diagnostics[0].retainedOwners)
+			require.Equal(t, 2, recall.diagnostics[0].retainedFiles)
+			require.Empty(t, recall.diagnostics[0].reason)
+			require.Equal(t, 1, recall.diagnostics[1].rawHits)
+			require.Equal(t, 1, recall.diagnostics[1].mappedOwners)
+			require.Equal(t, 1, recall.diagnostics[1].retainedOwners)
+			require.Equal(t, 1, recall.diagnostics[1].retainedFiles)
+			require.Empty(t, recall.diagnostics[1].reason)
+			require.Zero(t, counting.allNodesCalls, "anchor aggregation must remain file-bounded")
+
+			candidates := server.gatherExploreQuotedContentCandidates(
+				context.Background(), `locate registrations for "aa" and "bb"`, nil, 20,
+				query.QueryOptions{RepoAllow: map[string]bool{"demo": true}},
+			)
+			firstCandidate := candidateByID(candidates, first.ID)
+			secondCandidate := candidateByID(candidates, second.ID)
+			require.NotNil(t, firstCandidate)
+			require.NotNil(t, secondCandidate)
+			require.Equal(t, float64(1), firstCandidate.Signals[exploreSourceLiteralCoverageSignal])
+			require.Equal(t, float64(2), secondCandidate.Signals[exploreSourceLiteralCoverageSignal])
+			require.Positive(t, firstCandidate.Signals[exploreContentRecallAmbiguousSignal])
+			require.Zero(t, secondCandidate.Signals[exploreContentRecallAmbiguousSignal])
+		})
+	}
+}
+
+func TestGatherExploreSourceLiteralRecallKeepsMultiAnchorOwnerUnderNearCapCompetitors(t *testing.T) {
+	root := t.TempDir()
+	competitorRel := "src/00_CompetingDefaults.cs"
+	targetRel := "src/99_FormatterRegistry.cs"
+	competitorSource := "public sealed class CompetingDefaults {\n"
+	nodes := make([]*graph.Node, 0, 45)
+	line := 2
+	for i := 0; i < 44; i++ {
+		term := "pl"
+		if i%2 == 1 {
+			term = "ku"
+		}
+		name := fmt.Sprintf("Candidate%02d", i)
+		competitorSource += fmt.Sprintf("    public void %s() {\n        Register(\"%s\");\n    }\n", name, term)
+		node := sourceLiteralNode("demo/competitors::"+name, name, competitorRel, graph.KindMethod, line, line+2)
+		node.Language = "csharp"
+		nodes = append(nodes, node)
+		line += 3
+	}
+	competitorSource += "}\n"
+	targetSource := "public sealed class FormatterRegistry {\n" +
+		"    public void RegisterDefaultFormatter() {\n" +
+		"        Register(\"pl\");\n" +
+		"        Register(\"ku\");\n" +
+		"    }\n" +
+		"}\n"
+	target := sourceLiteralNode(
+		"demo/formatter::RegisterDefaultFormatter", "RegisterDefaultFormatter",
+		targetRel, graph.KindMethod, 2, 5,
+	)
+	target.Language = "csharp"
+	nodes = append(nodes, target)
+	for rel, source := range map[string]string{
+		competitorRel: competitorSource,
+		targetRel:     targetSource,
+	} {
+		path := filepath.Join(root, filepath.FromSlash(rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(source), 0o644))
+	}
+
+	store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "graph.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	idx := indexer.New(store, parser.NewRegistry(), config.IndexConfig{}, zap.NewNop())
+	_, err = idx.IndexCtx(context.Background(), root)
+	require.NoError(t, err)
+	idx.SetFileMtimes(map[string]int64{competitorRel: 1, targetRel: 1})
+	store.AddBatch(nodes, nil)
+	counting := &exploreSourceLiteralCountingStore{Store: store}
+	server := &Server{graph: counting, indexer: idx, logger: zap.NewNop()}
+	scope := query.QueryOptions{RepoAllow: map[string]bool{"demo": true}}
+
+	started := time.Now()
+	recall := server.gatherExploreSourceLiteralRecall(context.Background(), []string{"pl", "ku"}, "", scope)
+	require.Less(t, time.Since(started), 500*time.Millisecond, "near-cap two-anchor recall must honor the shared deadline")
+	require.Len(t, recall.diagnostics, 2)
+	for _, diagnostic := range recall.diagnostics {
+		// Bounded grep collapses repeated lines to one hit per file. The large
+		// competitor body still exercises production parsing and both per-anchor
+		// deadlines without multiplying retained owners.
+		require.Equal(t, 2, diagnostic.rawHits)
+		require.Equal(t, 2, diagnostic.mappedOwners)
+		require.Equal(t, 2, diagnostic.retainedOwners)
+		require.Equal(t, 2, diagnostic.retainedFiles)
+		require.Empty(t, diagnostic.reason)
+	}
+	coverage := make(map[int]struct{})
+	for _, hit := range recall.hits {
+		if hit.nodeID == target.ID {
+			coverage[hit.anchor] = struct{}{}
+		}
+	}
+	require.Len(t, coverage, 2, "the second-file owner must survive both collision-heavy anchor pages")
+	require.Zero(t, counting.allNodesCalls, "near-cap recall must remain file-bounded")
+
+	sourceCandidates := server.gatherExploreQuotedContentCandidates(
+		context.Background(), `locate default formatter registrations for "pl" and "ku"`, nil, 20, scope,
+	)
+	targetCandidate := candidateByID(sourceCandidates, target.ID)
+	require.NotNil(t, targetCandidate)
+	require.Equal(t, float64(2), targetCandidate.Signals[exploreSourceLiteralCoverageSignal])
+	require.Positive(t, targetCandidate.Signals[exploreContentRecallAmbiguousSignal])
+	ordinary := []*rerank.Candidate{
+		sourcePreservationCandidate("semantic-0", 0, 0),
+		sourcePreservationCandidate("semantic-1", 1, 0),
+		sourcePreservationCandidate("semantic-2", 2, 0),
+	}
+	selected := selectFinalExploreCandidates(
+		mergeExploreCandidates(ordinary, sourceCandidates, len(ordinary)), nil, 3,
+	)
+	require.NotNil(t, candidateByID(selected, target.ID), "multi-anchor owner must survive global pruning")
+	require.NotNil(t, candidateByID(selected, "semantic-0"))
+	require.NotNil(t, candidateByID(selected, "semantic-1"), "ambiguous single-anchor competitors must not consume the second reserve slot")
+}
+
+func TestGatherExploreSourceLiteralRecallRecordsTermCapDiagnostic(t *testing.T) {
+	server := &Server{logger: zap.NewNop()}
+	recall := server.gatherExploreSourceLiteralRecall(
+		context.Background(), []string{"aa", "bb", "cc"}, "demo", query.QueryOptions{},
+	)
+
+	require.Len(t, recall.diagnostics, 3)
+	byLiteral := make(map[string]exploreSourceLiteralDiagnostic, len(recall.diagnostics))
+	for _, diagnostic := range recall.diagnostics {
+		byLiteral[diagnostic.literal] = diagnostic
+	}
+	require.Equal(t, "term_cap", byLiteral["cc"].reason)
+}
+
 func TestGatherExploreSourceLiteralRecallMapsParsedCSharpConstructor(t *testing.T) {
 	root := t.TempDir()
 	rel := "src/Humanizer/Configuration/FormatterRegistry.cs"

--- a/internal/mcp/explore_source_literal_test.go
+++ b/internal/mcp/explore_source_literal_test.go
@@ -164,7 +164,7 @@ func TestMapExploreSourceLiteralMatchesPromotesUniqueDirectCalleeAcrossLanguages
 				Path: path, Line: 3, Text: test.line,
 			}}, query.QueryOptions{RepoAllow: map[string]bool{"demo": true}})
 
-			require.Equal(t, []exploreSourceLiteralHit{{nodeID: callee.ID, rank: 0}}, recall.hits)
+			require.Equal(t, []exploreSourceLiteralHit{{nodeID: callee.ID, rank: 0, callee: true}}, recall.hits)
 			require.Equal(t, callee.FilePath, recall.ownerFiles[callee.ID])
 			require.Zero(t, counting.allNodesCalls, "callee promotion must remain batch- and file-bounded")
 			require.Equal(t, 1, counting.outEdgeBatchCalls)
@@ -782,6 +782,7 @@ func TestGatherExploreSourceLiteralRecallMapsParsedCSharpConstructor(t *testing.
 		node := store.GetNode(hit.nodeID)
 		if node != nil && node.FilePath == rel && node.Name == "RegisterDefaultFormatter" {
 			found = true
+			require.True(t, hit.callee, "unique call-edge promotion must retain strong provenance")
 		}
 	}
 	require.True(t, found, "literal callsite must promote the uniquely resolved invoked method")
@@ -804,10 +805,17 @@ func TestGatherExploreSourceLiteralRecallMapsParsedCSharpConstructor(t *testing.
 	require.NoError(t, json.Unmarshal([]byte(text.Text), &envelope))
 	require.NotEmpty(t, envelope.Evidence)
 	require.Equal(t, "RegisterDefaultFormatter", envelope.Evidence[0].Name, "invoked source evidence must lead the final localization envelope")
-	if envelope.Completion.State == localizationStateNeedsRefinement {
-		require.Contains(t, envelope.Completion.AllowedSymbols, callees[0].ID)
-		require.Contains(t, envelope.Completion.RequiredAction, envelope.Evidence[0].ID)
-	}
+	require.Equal(t, localizationProvenanceSourceLiteralCallee, envelope.Evidence[0].Provenance)
+	require.Equal(t, localizationStateAnswerReady, envelope.Completion.State)
+	require.True(t, envelope.Terminal)
+	require.True(t, envelope.Completion.Enforceable)
+	require.NotNil(t, result.Meta)
+	host, ok := result.Meta.AdditionalFields[localizationHostMetaKey].(localizationHostEnvelope)
+	require.True(t, ok, "initial explore must attach an authoritative host envelope")
+	require.Equal(t, localizationContractFor(envelope.Completion), host.Contract)
+	require.NotNil(t, host.Evidence)
+	require.NotEmpty(t, host.Evidence.Evidence)
+	require.Equal(t, localizationProvenanceSourceLiteralCallee, host.Evidence.Evidence[0].Provenance)
 	require.Zero(t, counting.allNodesCalls, "literal mapping must stay bounded to matched files")
 }
 

--- a/internal/mcp/explore_source_literal_test.go
+++ b/internal/mcp/explore_source_literal_test.go
@@ -819,6 +819,119 @@ func TestGatherExploreSourceLiteralRecallMapsParsedCSharpConstructor(t *testing.
 	require.Zero(t, counting.allNodesCalls, "literal mapping must stay bounded to matched files")
 }
 
+func TestExploreQuotedRecallCompactMetadataUsesDeclarationEvidenceOnly(t *testing.T) {
+	scope := query.QueryOptions{}
+	compactName := &graph.Node{
+		ID: "src/locale.rs::KU", Name: "KU", QualName: "locale.KU",
+		Kind: graph.KindFunction, FilePath: "src/locale.rs", Language: "rust",
+	}
+	require.True(t, exploreQuotedRecallHasExactSourceNode(`find locale "ku"`, []string{"ku"}, compactName, scope))
+
+	pathOnly := &graph.Node{
+		ID: "src/locales/ku/registry.rs::register", Name: "register", QualName: "locales.ku.register",
+		Kind: graph.KindFunction, FilePath: "src/locales/ku/registry.rs", Language: "rust",
+	}
+	require.False(t, exploreQuotedRecallHasExactSourceNode(`find locale "ku"`, []string{"ku"}, pathOnly, scope),
+		"a path-derived qualified name must not suppress bounded source recall")
+}
+
+func TestExploreQuotedRecallTestMetadataRequiresTestIntent(t *testing.T) {
+	testNode := &graph.Node{
+		ID: "pkg/locale_test.go::TestKurdish", Name: "TestKurdish", QualName: "tests.ku.TestKurdish",
+		Kind: graph.KindFunction, FilePath: "pkg/locale_test.go", Language: "go",
+		Meta: map[string]any{"is_test": true, "signature": `func TestKurdish() // "ku"`},
+	}
+	require.False(t, exploreQuotedRecallHasExactSourceNode(`find where locale "ku" is registered`, []string{"ku"}, testNode, query.QueryOptions{}))
+	require.True(t, exploreQuotedRecallHasExactSourceNode(`find the test for locale "ku"`, []string{"ku"}, testNode, query.QueryOptions{}))
+}
+
+func TestExploreCompactLiteralIgnoresTestMetadataAndPrefersSpecificProductionCallee(t *testing.T) {
+	root := t.TempDir()
+	files := map[string]string{
+		"src/Humanizer/Configuration/FormatterRegistry.cs": `namespace Humanizer.Configuration {
+    internal class FormatterRegistry {
+        public FormatterRegistry() { RegisterDefaultFormatter("ku"); }
+        private void RegisterDefaultFormatter(string localeCode) { var formatter = new DefaultFormatter(localeCode); }
+    }
+    internal class DefaultFormatter { public DefaultFormatter(string localeCode) { } }
+}`,
+		"src/Humanizer/Configuration/NumberToWordsConverterRegistry.cs": `namespace Humanizer.Configuration {
+    internal class NumberToWordsConverterRegistry {
+        public NumberToWordsConverterRegistry() { Register("ku"); }
+        private void Register(string localeCode) { }
+    }
+}`,
+		"src/Humanizer.Tests.Shared/Localisation/ku/NumberToWordsTests.cs": `namespace Humanizer.Tests.Localisation.ku {
+    [UseCulture("ku")]
+    public class NumberToWordsTests {
+        public void ToOrdinalWordsKurdish() { }
+    }
+}`,
+	}
+	for rel, source := range files {
+		path := filepath.Join(root, filepath.FromSlash(rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(source), 0o644))
+	}
+
+	store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "graph.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	registry := parser.NewRegistry()
+	languages.RegisterAll(registry)
+	idx := indexer.New(store, registry, config.IndexConfig{}, zap.NewNop())
+	_, err = idx.IndexCtx(context.Background(), root)
+	require.NoError(t, err)
+	counting := &exploreSourceLiteralCountingStore{Store: store}
+	server := &Server{graph: counting, indexer: idx, logger: zap.NewNop()}
+
+	task := `CultureNotFoundException for culture "ku" (Kurdish) thrown when code enumerates or references all supported cultures, e.g. in number-to-words or collection initialization; find where "ku" locale/culture is registered or iterated causing crash on platforms lacking that culture.`
+	testNodes := store.FindNodesByName("ToOrdinalWordsKurdish")
+	require.NotEmpty(t, testNodes)
+	candidates := server.gatherExploreQuotedContentCandidates(
+		context.Background(), task,
+		[]*rerank.Candidate{{Node: testNodes[0], TextRank: 0, VectorRank: -1}},
+		20, query.QueryOptions{},
+	)
+	specificID := "src/Humanizer/Configuration/FormatterRegistry.cs::FormatterRegistry.RegisterDefaultFormatter"
+	genericID := "src/Humanizer/Configuration/NumberToWordsConverterRegistry.cs::NumberToWordsConverterRegistry.Register"
+	specificCandidate := candidateByID(candidates, specificID)
+	genericCandidate := candidateByID(candidates, genericID)
+	require.NotNil(t, specificCandidate, "test metadata must not suppress production literal recall")
+	require.NotNil(t, genericCandidate, "both production direct callees must remain available")
+	require.Equal(t, 1.0, specificCandidate.Signals[exploreSourceLiteralTaskAlignSignal],
+		"construction intent must align with the exact owner that instantiates a value")
+	require.Zero(t, genericCandidate.Signals[exploreSourceLiteralTaskAlignSignal],
+		"a generic registration helper must not gain construction alignment")
+
+	engine := query.NewEngine(counting)
+	engine.SetSearchProvider(idx.Search)
+	fullServer := NewServer(engine, counting, idx, nil, zap.NewNop(), nil)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"task": task, "localize": true, "max_symbols": 6,
+	}
+	result, err := fullServer.handleExplore(context.Background(), req)
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Content)
+	text, ok := result.Content[0].(mcpgo.TextContent)
+	require.True(t, ok)
+	var envelope localizationExploreEnvelope
+	require.NoError(t, json.Unmarshal([]byte(text.Text), &envelope))
+
+	specificRank := -1
+	for rank, evidence := range envelope.Evidence {
+		if evidence.ID == specificID {
+			specificRank = rank
+		}
+	}
+	require.NotEqual(t, -1, specificRank, "construction-aligned source evidence must survive final packing")
+	require.Equal(t, localizationStateNeedsRefinement, envelope.Completion.State)
+	require.False(t, envelope.Terminal)
+	require.False(t, envelope.Completion.Enforceable, "ambiguous production literal sites remain advisory")
+	require.Contains(t, envelope.Completion.AllowedSymbols, specificID)
+}
+
 func TestGatherExploreSourceLiteralRecallBoundsMappingByRequestDeadline(t *testing.T) {
 	root := t.TempDir()
 	rel := "src/Registry.cs"

--- a/internal/mcp/explore_source_literal_test.go
+++ b/internal/mcp/explore_source_literal_test.go
@@ -28,12 +28,24 @@ import (
 
 type exploreSourceLiteralCountingStore struct {
 	graph.Store
-	allNodesCalls int
+	allNodesCalls     int
+	outEdgeBatchCalls int
+	nodeLookupBatches int
 }
 
 func (s *exploreSourceLiteralCountingStore) AllNodes() []*graph.Node {
 	s.allNodesCalls++
 	return s.Store.AllNodes()
+}
+
+func (s *exploreSourceLiteralCountingStore) GetOutEdgesByNodeIDs(ids []string) map[string][]*graph.Edge {
+	s.outEdgeBatchCalls++
+	return s.Store.GetOutEdgesByNodeIDs(ids)
+}
+
+func (s *exploreSourceLiteralCountingStore) GetNodesByIDs(ids []string) map[string]*graph.Node {
+	s.nodeLookupBatches++
+	return s.Store.GetNodesByIDs(ids)
 }
 
 type exploreSourceLiteralBlockingStore struct {
@@ -66,6 +78,10 @@ func (s *exploreSourceLiteralOrderedStore) GetFileNodesContext(ctx context.Conte
 	return s.nodesByPath[path]
 }
 
+func (s *exploreSourceLiteralOrderedStore) GetOutEdgesByNodeIDs([]string) map[string][]*graph.Edge {
+	return nil
+}
+
 func newExploreSourceLiteralServer(t testing.TB, nodes []*graph.Node) *Server {
 	t.Helper()
 	store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "graph.sqlite"))
@@ -75,12 +91,147 @@ func newExploreSourceLiteralServer(t testing.TB, nodes []*graph.Node) *Server {
 	return &Server{graph: store}
 }
 
+func newExploreSourceLiteralGraphServer(
+	t testing.TB,
+	nodes []*graph.Node,
+	edges []*graph.Edge,
+) (*Server, *exploreSourceLiteralCountingStore) {
+	t.Helper()
+	store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "graph.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	store.AddBatch(nodes, edges)
+	counting := &exploreSourceLiteralCountingStore{Store: store}
+	return &Server{graph: counting}, counting
+}
+
 func sourceLiteralNode(id, name, path string, kind graph.NodeKind, start, end int) *graph.Node {
 	return &graph.Node{
 		ID: id, Name: name, QualName: id, Kind: kind,
 		FilePath: path, RepoPrefix: "demo", Language: "csharp",
 		StartLine: start, EndLine: end,
 	}
+}
+
+func TestExploreSourceLiteralCallNameAcrossLanguages(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want string
+		ok   bool
+	}{
+		{name: "csharp", line: `RegisterDefaultFormatter("ku", formatter);`, want: "RegisterDefaultFormatter", ok: true},
+		{name: "rust", line: `register_default_formatter("ku", formatter);`, want: "register_default_formatter", ok: true},
+		{name: "typescript member", line: `registry.registerDefaultFormatter('ku', formatter);`, want: "registerDefaultFormatter", ok: true},
+		{name: "nested", line: `install(resolve("ku"));`, want: "resolve", ok: true},
+		{name: "assignment", line: `const locale = "ku";`},
+		{name: "control expression", line: `if (locale == "ku") { register(); }`},
+		{name: "ambiguous calls", line: `left("ku"); right("ku");`},
+		{name: "multiline is conservative", line: `RegisterDefaultFormatter(`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := exploreSourceLiteralCallName(test.line, "ku")
+			require.Equal(t, test.ok, ok)
+			require.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestMapExploreSourceLiteralMatchesPromotesUniqueDirectCalleeAcrossLanguages(t *testing.T) {
+	tests := []struct {
+		name     string
+		language string
+		line     string
+		callee   string
+	}{
+		{name: "csharp", language: "csharp", line: `RegisterDefaultFormatter("ku");`, callee: "RegisterDefaultFormatter"},
+		{name: "rust", language: "rust", line: `register_default_formatter("ku");`, callee: "register_default_formatter"},
+		{name: "typescript", language: "typescript", line: `registry.registerDefaultFormatter('ku');`, callee: "registerDefaultFormatter"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := "demo/src/registry"
+			owner := sourceLiteralNode(path+"::configure", "configure", path, graph.KindMethod, 1, 5)
+			callee := sourceLiteralNode(path+"::"+test.callee, test.callee, path, graph.KindMethod, 7, 9)
+			owner.Language = test.language
+			callee.Language = test.language
+			server, counting := newExploreSourceLiteralGraphServer(t, []*graph.Node{owner, callee}, []*graph.Edge{{
+				From: owner.ID, To: callee.ID, Kind: graph.EdgeCalls, FilePath: path, Line: 3,
+			}})
+
+			recall := server.mapExploreSourceLiteralMatches("ku", []trigram.Match{{
+				Path: path, Line: 3, Text: test.line,
+			}}, query.QueryOptions{RepoAllow: map[string]bool{"demo": true}})
+
+			require.Equal(t, []exploreSourceLiteralHit{{nodeID: callee.ID, rank: 0}}, recall.hits)
+			require.Equal(t, callee.FilePath, recall.ownerFiles[callee.ID])
+			require.Zero(t, counting.allNodesCalls, "callee promotion must remain batch- and file-bounded")
+			require.Equal(t, 1, counting.outEdgeBatchCalls)
+			require.Equal(t, 1, counting.nodeLookupBatches)
+		})
+	}
+}
+
+func TestMapExploreSourceLiteralMatchesDoesNotPromoteAmbiguousCallee(t *testing.T) {
+	path := "demo/src/registry.cs"
+	owner := sourceLiteralNode(path+"::configure", "configure", path, graph.KindMethod, 1, 5)
+	first := sourceLiteralNode(path+"::register-string", "RegisterDefaultFormatter", path, graph.KindMethod, 7, 9)
+	second := sourceLiteralNode(path+"::register-provider", "RegisterDefaultFormatter", path, graph.KindMethod, 11, 13)
+	server, _ := newExploreSourceLiteralGraphServer(t, []*graph.Node{owner, first, second}, []*graph.Edge{
+		{From: owner.ID, To: first.ID, Kind: graph.EdgeCalls, FilePath: path, Line: 3},
+		{From: owner.ID, To: second.ID, Kind: graph.EdgeCalls, FilePath: path, Line: 3},
+	})
+
+	recall := server.mapExploreSourceLiteralMatches("ku", []trigram.Match{{
+		Path: path, Line: 3, Text: `RegisterDefaultFormatter("ku");`,
+	}}, query.QueryOptions{RepoAllow: map[string]bool{"demo": true}})
+
+	require.Equal(t, []exploreSourceLiteralHit{{nodeID: owner.ID, rank: 0}}, recall.hits)
+}
+
+func TestMapExploreSourceLiteralMatchesDoesNotPromoteAssignment(t *testing.T) {
+	path := "demo/src/registry.cs"
+	owner := sourceLiteralNode(path+"::configure", "configure", path, graph.KindMethod, 1, 5)
+	callee := sourceLiteralNode(path+"::register", "RegisterDefaultFormatter", path, graph.KindMethod, 7, 9)
+	server, counting := newExploreSourceLiteralGraphServer(t, []*graph.Node{owner, callee}, []*graph.Edge{{
+		From: owner.ID, To: callee.ID, Kind: graph.EdgeCalls, FilePath: path, Line: 3,
+	}})
+
+	recall := server.mapExploreSourceLiteralMatches("ku", []trigram.Match{{
+		Path: path, Line: 3, Text: `const locale = "ku";`,
+	}}, query.QueryOptions{RepoAllow: map[string]bool{"demo": true}})
+
+	require.Equal(t, []exploreSourceLiteralHit{{nodeID: owner.ID, rank: 0}}, recall.hits,
+		"an unrelated same-line edge must not turn an assignment into a callsite")
+	require.Zero(t, counting.outEdgeBatchCalls, "non-call literal hits must not query graph adjacency")
+	require.Zero(t, counting.nodeLookupBatches, "non-call literal hits must not query callee nodes")
+}
+
+func TestExploreSourceLiteralLocalCalleeRejectsCrossRepositoryTarget(t *testing.T) {
+	owner := sourceLiteralNode("demo/registry.cs::configure", "configure", "demo/registry.cs", graph.KindMethod, 1, 5)
+	callee := sourceLiteralNode("other/registry.cs::register", "RegisterDefaultFormatter", "other/registry.cs", graph.KindMethod, 7, 9)
+	callee.RepoPrefix = "other"
+	require.False(t, exploreSourceLiteralLocalCallee(owner, callee, "RegisterDefaultFormatter", query.QueryOptions{}))
+}
+
+func TestSourceLiteralCalleeRemainsAuthorizedForRefinement(t *testing.T) {
+	task := `find where culture "ku" is registered`
+	owner := sourceLiteralNode("demo/registry.cs::configure", "configure", "demo/registry.cs", graph.KindMethod, 1, 5)
+	callee := sourceLiteralNode("demo/registry.cs::RegisterDefaultFormatter", "RegisterDefaultFormatter", "demo/registry.cs", graph.KindMethod, 7, 10)
+	targets := []exploreTarget{
+		{node: owner, source: `void configure() { ... }`},
+		{node: callee, source: `void RegisterDefaultFormatter(string culture) { ... }`, sourceLiteral: true},
+	}
+	preferred := explorePreferredRefinementSymbol(task, targets)
+	require.Equal(t, callee.ID, preferred)
+
+	_, completion, _, _ := buildLocalizationRefinementResultForTask(
+		preferred, task, targets, exploreDefaultBudgetTokens, exploreLocalizationRefinementRoutes(targets),
+	)
+	require.Equal(t, localizationStateNeedsRefinement, completion.State)
+	require.Contains(t, completion.AllowedSymbols, callee.ID)
+	require.Contains(t, completion.RequiredAction, callee.ID)
 }
 
 func TestMapExploreSourceLiteralMatchesFindsCSharpConstructor(t *testing.T) {
@@ -605,7 +756,7 @@ func TestGatherExploreSourceLiteralRecallMapsParsedCSharpConstructor(t *testing.
 	rel := "src/Humanizer/Configuration/FormatterRegistry.cs"
 	path := filepath.Join(root, filepath.FromSlash(rel))
 	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
-	require.NoError(t, os.WriteFile(path, []byte("public sealed class FormatterRegistry {\n    public FormatterRegistry() {\n        RegisterDefaultFormatter(\"ku\");\n    }\n}\n"), 0o644))
+	require.NoError(t, os.WriteFile(path, []byte("public sealed class FormatterRegistry {\n    public FormatterRegistry() {\n        RegisterDefaultFormatter(\"ku\");\n    }\n\n    private void RegisterDefaultFormatter(string culture) {\n    }\n}\n"), 0o644))
 
 	store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "graph.sqlite"))
 	require.NoError(t, err)
@@ -615,6 +766,10 @@ func TestGatherExploreSourceLiteralRecallMapsParsedCSharpConstructor(t *testing.
 	idx := indexer.New(store, registry, config.IndexConfig{}, zap.NewNop())
 	_, err = idx.IndexCtx(context.Background(), root)
 	require.NoError(t, err)
+	constructors := store.FindNodesByName("FormatterRegistry.<init>")
+	callees := store.FindNodesByName("RegisterDefaultFormatter")
+	require.NotEmpty(t, constructors)
+	require.NotEmpty(t, callees)
 	counting := &exploreSourceLiteralCountingStore{Store: store}
 	server := &Server{graph: counting, indexer: idx, logger: zap.NewNop()}
 
@@ -625,11 +780,11 @@ func TestGatherExploreSourceLiteralRecallMapsParsedCSharpConstructor(t *testing.
 	found := false
 	for _, hit := range recall.hits {
 		node := store.GetNode(hit.nodeID)
-		if node != nil && node.FilePath == rel && node.Name == "FormatterRegistry.<init>" {
+		if node != nil && node.FilePath == rel && node.Name == "RegisterDefaultFormatter" {
 			found = true
 		}
 	}
-	require.True(t, found, "literal line must map to the parsed enclosing constructor")
+	require.True(t, found, "literal callsite must promote the uniquely resolved invoked method")
 
 	task := `CultureNotFoundException for "ku" culture - code adds/uses "ku" (Kurdish) CultureInfo which is not supported on Xamarin.Android, causing crash. Find where "ku" culture is registered/used in fallback resolution logic.`
 	require.NotEqual(t, rerank.QueryClassConcept, rerank.ClassifyQuery(shapeExploreQuery(task)), "regression requires the non-concept retrieval branch")
@@ -648,8 +803,9 @@ func TestGatherExploreSourceLiteralRecallMapsParsedCSharpConstructor(t *testing.
 	var envelope localizationExploreEnvelope
 	require.NoError(t, json.Unmarshal([]byte(text.Text), &envelope))
 	require.NotEmpty(t, envelope.Evidence)
-	require.Equal(t, "FormatterRegistry.<init>", envelope.Evidence[0].Name, "source evidence must lead the final localization envelope")
+	require.Equal(t, "RegisterDefaultFormatter", envelope.Evidence[0].Name, "invoked source evidence must lead the final localization envelope")
 	if envelope.Completion.State == localizationStateNeedsRefinement {
+		require.Contains(t, envelope.Completion.AllowedSymbols, callees[0].ID)
 		require.Contains(t, envelope.Completion.RequiredAction, envelope.Evidence[0].ID)
 	}
 	require.Zero(t, counting.allNodesCalls, "literal mapping must stay bounded to matched files")

--- a/internal/mcp/explore_source_literal_test.go
+++ b/internal/mcp/explore_source_literal_test.go
@@ -788,7 +788,8 @@ func TestGatherExploreSourceLiteralRecallMapsParsedCSharpConstructor(t *testing.
 	require.True(t, found, "literal callsite must promote the uniquely resolved invoked method")
 
 	task := `CultureNotFoundException for "ku" culture - code adds/uses "ku" (Kurdish) CultureInfo which is not supported on Xamarin.Android, causing crash. Find where "ku" culture is registered/used in fallback resolution logic.`
-	require.NotEqual(t, rerank.QueryClassConcept, rerank.ClassifyQuery(shapeExploreQuery(task)), "regression requires the non-concept retrieval branch")
+	require.Equal(t, rerank.QueryClassConcept, exploreQueryClass(shapeExploreQuery(task)),
+		"long parenthesized issue prose must use concept retrieval without losing its unique literal proof")
 	engine := query.NewEngine(counting)
 	engine.SetSearchProvider(idx.Search)
 	fullServer := NewServer(engine, counting, idx, nil, zap.NewNop(), nil)

--- a/internal/mcp/explore_syntactic_anchor.go
+++ b/internal/mcp/explore_syntactic_anchor.go
@@ -1,0 +1,610 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/query"
+	"github.com/zzet/gortex/internal/search/rerank"
+)
+
+const (
+	exploreSyntacticAnchorMaxTerms = 3
+	exploreSyntacticAnchorFetch    = 10
+)
+
+// exploreSyntacticAnchor is a bounded, implementation-shaped clue copied
+// directly from the task. CLI flags and identifier-shaped tokens survive
+// prose query shaping poorly, but often name the missing implementation more
+// precisely than the surrounding natural language.
+type exploreSyntacticAnchor struct {
+	query   string
+	source  string
+	terms   []string
+	compact string
+}
+
+// exploreSyntacticAnchors extracts only syntactically strong, unquoted clues.
+// Flags lead because they are explicit user-facing identifiers; snake/camel/
+// qualified identifiers follow in first-seen order. Prefix-equivalent forms
+// collapse into one anchor, so --replace, replace_all, and Replacer consume a
+// single bounded retrieval lane rather than three.
+func exploreSyntacticAnchors(task string) []exploreSyntacticAnchor {
+	out := make([]exploreSyntacticAnchor, 0, exploreSyntacticAnchorMaxTerms)
+	tokens := exploreUnquotedCodeTokens(task)
+	add := func(raw string) {
+		anchor, ok := newExploreSyntacticAnchor(raw)
+		if !ok {
+			return
+		}
+		for _, existing := range out {
+			if exploreSyntacticAnchorEquivalent(existing, anchor) {
+				return
+			}
+		}
+		out = append(out, anchor)
+	}
+
+	for _, token := range tokens {
+		if !strings.HasPrefix(token, "--") || len(token) <= 2 {
+			continue
+		}
+		add(strings.TrimLeft(token, "-"))
+		if len(out) == exploreSyntacticAnchorMaxTerms {
+			return out
+		}
+	}
+
+	for _, token := range tokens {
+		if strings.HasPrefix(token, "--") {
+			continue
+		}
+		if !exploreCodeShapedToken(token) {
+			continue
+		}
+		add(token)
+		if len(out) == exploreSyntacticAnchorMaxTerms {
+			break
+		}
+	}
+	return out
+}
+
+func newExploreSyntacticAnchor(raw string) (exploreSyntacticAnchor, bool) {
+	raw = strings.Trim(raw, " \t\r\n()[]{}<>,.;:'\"")
+	if raw == "" {
+		return exploreSyntacticAnchor{}, false
+	}
+	seen := make(map[string]struct{})
+	terms := make([]string, 0, 4)
+	for _, token := range rerank.Tokenize(raw) {
+		term := strings.ToLower(strings.TrimSpace(token))
+		if len(term) < 3 {
+			continue
+		}
+		if _, duplicate := seen[term]; duplicate {
+			continue
+		}
+		seen[term] = struct{}{}
+		terms = append(terms, term)
+	}
+	if len(terms) == 0 {
+		return exploreSyntacticAnchor{}, false
+	}
+	compact := strings.Join(terms, "")
+	if len(compact) < 4 || exploreSyntacticAnchorNoise(compact) {
+		return exploreSyntacticAnchor{}, false
+	}
+	queryTerms := append([]string(nil), terms...)
+	if len(terms) > 1 {
+		queryTerms = append(queryTerms, strings.Join(terms, "_"), compact)
+	}
+	return exploreSyntacticAnchor{
+		query:   strings.Join(queryTerms, " "),
+		source:  strings.ToLower(raw),
+		terms:   terms,
+		compact: compact,
+	}, true
+}
+
+func exploreSyntacticAnchorNoise(compact string) bool {
+	switch compact {
+	case "csharp", "debug", "default", "dotnet", "example", "file", "files", "github", "gitlab", "golang", "help", "javascript", "kotlin", "linux", "macos", "option", "options", "path", "python", "rust", "test", "tests", "typescript", "verbose", "version", "windows":
+		return true
+	default:
+		return false
+	}
+}
+
+func exploreSyntacticAnchorEquivalent(left, right exploreSyntacticAnchor) bool {
+	if left.compact == right.compact {
+		return true
+	}
+	shorter, longer := left.compact, right.compact
+	if len(shorter) > len(longer) {
+		shorter, longer = longer, shorter
+	}
+	return len(shorter) >= 5 && strings.HasPrefix(longer, shorter)
+}
+
+func exploreUnquotedCodeTokens(task string) []string {
+	var masked strings.Builder
+	masked.Grow(len(task))
+	var quote rune
+	escaped := false
+	for _, r := range task {
+		if quote != 0 {
+			if escaped {
+				escaped = false
+				masked.WriteRune(' ')
+				continue
+			}
+			if r == '\\' && quote == '"' {
+				escaped = true
+				masked.WriteRune(' ')
+				continue
+			}
+			if r == quote {
+				quote = 0
+			}
+			masked.WriteRune(' ')
+			continue
+		}
+		if r == '"' || r == '`' {
+			quote = r
+			masked.WriteRune(' ')
+			continue
+		}
+		masked.WriteRune(r)
+	}
+	return strings.FieldsFunc(masked.String(), func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' && r != '.' && r != ':' && r != '-'
+	})
+}
+
+func exploreCodeShapedToken(token string) bool {
+	token = strings.Trim(token, "-_.:")
+	first, _ := utf8.DecodeRuneInString(token)
+	if token == "" || len(token) > 128 || (!unicode.IsLetter(first) && first != '_') {
+		return false
+	}
+	lower := strings.ToLower(token)
+	for _, suffix := range []string{".ai", ".com", ".dev", ".io", ".net", ".org"} {
+		if strings.HasSuffix(lower, suffix) {
+			return false
+		}
+	}
+	if strings.Contains(token, "_") || strings.Contains(token, "::") || strings.Contains(token, ".") {
+		return true
+	}
+	var previous rune
+	for _, r := range token {
+		if previous != 0 && (unicode.IsLower(previous) || unicode.IsDigit(previous)) && unicode.IsUpper(r) {
+			return true
+		}
+		previous = r
+	}
+	return false
+}
+
+func exploreSyntacticAnchorMatchesNode(anchor exploreSyntacticAnchor, node *graph.Node) bool {
+	if node == nil {
+		return false
+	}
+	return exploreSyntacticAnchorMatchesIdentifier(anchor, node.Name) ||
+		exploreSyntacticAnchorMatchesIdentifier(anchor, node.QualName)
+}
+
+func exploreSyntacticAnchorMatchesIdentifier(anchor exploreSyntacticAnchor, identifier string) bool {
+	identifierTerms := rerank.Tokenize(identifier)
+	if len(identifierTerms) == 0 {
+		return false
+	}
+	compact := strings.ToLower(strings.Join(identifierTerms, ""))
+	if strings.HasPrefix(compact, anchor.compact) ||
+		(len(compact) >= 5 && strings.HasPrefix(anchor.compact, compact)) {
+		return true
+	}
+	for _, anchorTerm := range anchor.terms {
+		matched := false
+		for _, identifierTerm := range identifierTerms {
+			identifierTerm = strings.ToLower(identifierTerm)
+			if strings.HasPrefix(identifierTerm, anchorTerm) ||
+				(len(identifierTerm) >= 4 && strings.HasPrefix(anchorTerm, identifierTerm)) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	return true
+}
+
+func exploreSyntacticAnchorEligibleNode(node *graph.Node) bool {
+	if node == nil {
+		return false
+	}
+	if isTest, _ := node.Meta["is_test"].(bool); isTest {
+		return false
+	}
+	switch node.Kind {
+	case graph.KindFunction, graph.KindMethod, graph.KindType, graph.KindMacro:
+		return true
+	default:
+		return false
+	}
+}
+
+func exploreSyntacticAnchorNodeStrength(anchor exploreSyntacticAnchor, node *graph.Node) int {
+	if !exploreSyntacticAnchorEligibleNode(node) || !exploreSyntacticAnchorMatchesNode(anchor, node) {
+		return 0
+	}
+	identifierTerms := rerank.Tokenize(node.Name)
+	strength := 0
+	for _, anchorTerm := range anchor.terms {
+		best := 0
+		for _, rawIdentifierTerm := range identifierTerms {
+			identifierTerm := strings.ToLower(rawIdentifierTerm)
+			switch {
+			case identifierTerm == anchorTerm:
+				best = max(best, 3)
+			case strings.HasPrefix(identifierTerm, anchorTerm):
+				suffix := strings.TrimPrefix(identifierTerm, anchorTerm)
+				if suffix == "r" || suffix == "er" || suffix == "or" || suffix == "impl" {
+					best = max(best, 2)
+				} else {
+					best = max(best, 1)
+				}
+			case len(identifierTerm) >= 4 && strings.HasPrefix(anchorTerm, identifierTerm):
+				best = max(best, 1)
+			}
+		}
+		strength += best
+	}
+	switch node.Kind {
+	case graph.KindFunction, graph.KindMethod:
+		strength += 3
+	case graph.KindMacro:
+		strength += 2
+	case graph.KindType:
+		strength++
+	}
+	if len(identifierTerms) > 1 {
+		strength++
+	}
+	return strength
+}
+
+func exploreSyntacticAnchorCandidate(
+	anchor exploreSyntacticAnchor,
+	candidates []*rerank.Candidate,
+	scope query.QueryOptions,
+	usedIDs, usedFiles map[string]struct{},
+) *rerank.Candidate {
+	var best *rerank.Candidate
+	bestStrength := 0
+	bestDiverse := false
+	for _, candidate := range candidates {
+		if candidate == nil || !exploreSyntacticAnchorEligibleNode(candidate.Node) ||
+			!scope.ScopeAllows(candidate.Node) || !exploreSyntacticAnchorMatchesNode(anchor, candidate.Node) {
+			continue
+		}
+		if _, used := usedIDs[candidate.Node.ID]; used {
+			continue
+		}
+		strength := exploreSyntacticAnchorNodeStrength(anchor, candidate.Node)
+		_, repeatedFile := usedFiles[candidate.Node.FilePath]
+		diverse := !repeatedFile
+		if best == nil || strength > bestStrength || (strength == bestStrength && diverse && !bestDiverse) {
+			best = candidate
+			bestStrength = strength
+			bestDiverse = diverse
+		}
+	}
+	return best
+}
+
+func exploreSyntacticAnchorReusesProtected(
+	anchor exploreSyntacticAnchor,
+	candidates []*rerank.Candidate,
+	usedIDs map[string]struct{},
+) string {
+	for _, candidate := range candidates {
+		if candidate == nil || candidate.Node == nil {
+			continue
+		}
+		if _, used := usedIDs[candidate.Node.ID]; used && exploreSyntacticAnchorMatchesNode(anchor, candidate.Node) {
+			return candidate.Node.ID
+		}
+	}
+	return ""
+}
+
+// gatherExploreSyntacticAnchorCandidates performs a tiny lexical retrieval for
+// each anchor not represented by the ordinary over-fetch pool. Only after that
+// identifier lane misses do we invoke the existing request-local source scan.
+// One diverse node per anchor is retained; no source body is persisted.
+func (s *Server) gatherExploreSyntacticAnchorCandidates(
+	ctx context.Context,
+	task string,
+	ordinary []*rerank.Candidate,
+	eng *query.Engine,
+	scope query.QueryOptions,
+	rctx *rerank.Context,
+) ([]*rerank.Candidate, map[int]string) {
+	anchors := exploreSyntacticAnchors(task)
+	if s == nil || s.graph == nil || eng == nil || len(anchors) == 0 || ctx.Err() != nil {
+		return nil, nil
+	}
+
+	protected := make(map[int]string, len(anchors))
+	usedIDs := make(map[string]struct{}, len(anchors))
+	usedFiles := make(map[string]struct{}, len(anchors))
+	addProtected := func(index int, candidate *rerank.Candidate) {
+		protected[index] = candidate.Node.ID
+		usedIDs[candidate.Node.ID] = struct{}{}
+		if candidate.Node.FilePath != "" {
+			usedFiles[candidate.Node.FilePath] = struct{}{}
+		}
+	}
+
+	additions := make([]*rerank.Candidate, 0, len(anchors))
+	missed := make([]int, 0, len(anchors))
+	anchorOpts := scope
+	anchorOpts.SkipInnerRerank = true
+	anchorOpts.SkipVectorChannel = true
+	for index, anchor := range anchors {
+		if ctx.Err() != nil {
+			break
+		}
+		reused := exploreSyntacticAnchorReusesProtected(anchor, ordinary, usedIDs)
+		if reused == "" {
+			reused = exploreSyntacticAnchorReusesProtected(anchor, additions, usedIDs)
+		}
+		if reused != "" {
+			protected[index] = reused
+			continue
+		}
+		ordinaryCandidate := exploreSyntacticAnchorCandidate(anchor, ordinary, scope, usedIDs, usedFiles)
+		if ordinaryCandidate != nil && exploreSyntacticAnchorNodeStrength(anchor, ordinaryCandidate.Node) >= 4 {
+			addProtected(index, ordinaryCandidate)
+			continue
+		}
+		rows := eng.GatherSymbolCandidates(anchor.query, exploreSyntacticAnchorFetch, anchorOpts, rctx)
+		combined := rows
+		if ordinaryCandidate != nil {
+			combined = append([]*rerank.Candidate{ordinaryCandidate}, rows...)
+		}
+		candidate := exploreSyntacticAnchorCandidate(anchor, combined, scope, usedIDs, usedFiles)
+		if candidate == nil {
+			missed = append(missed, index)
+			continue
+		}
+		alreadyOrdinary := false
+		for _, existing := range ordinary {
+			if existing != nil && existing.Node != nil && existing.Node.ID == candidate.Node.ID {
+				alreadyOrdinary = true
+				break
+			}
+		}
+		if !alreadyOrdinary {
+			additions = append(additions, candidate)
+		}
+		addProtected(index, candidate)
+	}
+	if len(missed) == 0 || ctx.Err() != nil {
+		return additions, protected
+	}
+
+	repoPrefix := ""
+	if len(scope.RepoAllow) == 1 {
+		for prefix, allowed := range scope.RepoAllow {
+			if allowed {
+				repoPrefix = prefix
+			}
+		}
+	}
+	if repoPrefix == "" {
+		repoPrefix, _ = s.sessionLocality(ctx)
+	}
+	sourceTerms := make([]string, 0, len(missed))
+	for _, index := range missed {
+		anchor := anchors[index]
+		sourceTerms = append(sourceTerms, anchor.source)
+	}
+	recall := s.gatherExploreSourceLiteralRecall(ctx, sourceTerms, repoPrefix, scope)
+	if len(recall.hits) == 0 {
+		return additions, protected
+	}
+	ids := make([]string, 0, len(recall.hits))
+	for _, hit := range recall.hits {
+		ids = append(ids, hit.nodeID)
+	}
+	nodes := s.graph.GetNodesByIDs(ids)
+	for localIndex, anchorIndex := range missed {
+		var fallback *graph.Node
+		var selected *graph.Node
+		selectedRank := 0
+		for _, hit := range recall.hits {
+			if hit.anchor != localIndex {
+				continue
+			}
+			node := nodes[hit.nodeID]
+			if !exploreSyntacticAnchorEligibleNode(node) || !scope.ScopeAllows(node) {
+				continue
+			}
+			if _, used := usedIDs[node.ID]; used {
+				continue
+			}
+			if fallback == nil {
+				fallback = node
+				selectedRank = hit.rank
+			}
+			if _, repeatedFile := usedFiles[node.FilePath]; !repeatedFile {
+				selected = node
+				selectedRank = hit.rank
+				break
+			}
+		}
+		if selected == nil {
+			selected = fallback
+		}
+		if selected == nil {
+			continue
+		}
+		sourceRank := 1.0
+		if selectedRank > 0 {
+			sourceRank = 1 / float64(selectedRank+1)
+		}
+		candidate := &rerank.Candidate{
+			Node: selected, TextRank: selectedRank, VectorRank: -1,
+			Signals: map[string]float64{
+				exploreSourceLiteralSignal:         sourceRank,
+				exploreSourceLiteralCoverageSignal: 1,
+			},
+		}
+		additions = append(additions, candidate)
+		addProtected(anchorIndex, candidate)
+	}
+	return additions, protected
+}
+
+// reserveExploreSyntacticAnchorCandidates keeps every discovered anchor owner
+// inside the final window while preserving the semantic head and the relative
+// order of all candidates that do not need promotion.
+func reserveExploreSyntacticAnchorCandidates(
+	task string,
+	candidates []*rerank.Candidate,
+	protected map[int]string,
+	maxSymbols int,
+) []*rerank.Candidate {
+	anchors := exploreSyntacticAnchors(task)
+	if len(anchors) == 0 || len(candidates) == 0 || maxSymbols <= 0 {
+		return candidates
+	}
+	if maxSymbols > len(candidates) {
+		maxSymbols = len(candidates)
+	}
+
+	usedIDs := make(map[string]struct{}, len(anchors))
+	usedFiles := make(map[string]struct{}, len(anchors))
+	reservationIDs := make([]string, 0, len(anchors))
+	for index, anchor := range anchors {
+		id := protected[index]
+		if id == "" {
+			if candidate := exploreSyntacticAnchorCandidate(anchor, candidates, query.QueryOptions{}, usedIDs, usedFiles); candidate != nil {
+				id = candidate.Node.ID
+			}
+		}
+		if id == "" {
+			continue
+		}
+		for _, candidate := range candidates {
+			if candidate == nil || candidate.Node == nil || candidate.Node.ID != id {
+				continue
+			}
+			usedIDs[id] = struct{}{}
+			usedFiles[candidate.Node.FilePath] = struct{}{}
+			reservationIDs = append(reservationIDs, id)
+			break
+		}
+	}
+	if len(reservationIDs) == 0 {
+		return candidates
+	}
+
+	// Rebuild only the order, never the candidate objects: semantic head first,
+	// then one owner per anchor, then every unreserved row in original order.
+	// This is simpler and safer than repeated in-place moves, where promoting a
+	// later anchor can shift an earlier reservation back outside the window.
+	result := make([]*rerank.Candidate, 0, len(candidates))
+	admitted := make(map[string]struct{}, len(reservationIDs)+1)
+	appendCandidate := func(candidate *rerank.Candidate) {
+		if candidate == nil || candidate.Node == nil {
+			return
+		}
+		if _, duplicate := admitted[candidate.Node.ID]; duplicate {
+			return
+		}
+		admitted[candidate.Node.ID] = struct{}{}
+		result = append(result, candidate)
+	}
+	appendCandidate(candidates[0])
+	for _, id := range reservationIDs {
+		if len(result) >= maxSymbols {
+			break
+		}
+		for _, candidate := range candidates {
+			if candidate != nil && candidate.Node != nil && candidate.Node.ID == id {
+				appendCandidate(candidate)
+				break
+			}
+		}
+	}
+	for _, candidate := range candidates {
+		appendCandidate(candidate)
+	}
+	return result
+}
+
+func exploreSyntacticAnchorMatchesTargetSource(anchor exploreSyntacticAnchor, target exploreTarget, lowerSource string) bool {
+	if exploreSyntacticAnchorMatchesNode(anchor, target.node) {
+		return true
+	}
+	for _, term := range anchor.terms {
+		if !strings.Contains(lowerSource, term) {
+			return false
+		}
+	}
+	return true
+}
+
+// exploreSyntacticAnchorEvidenceReady prevents a broad semantic neighbor from
+// terminating localization while a distinctive implementation clue is absent.
+// Every retained anchor needs one production declaration with hydrated source;
+// fields, tests, abstract declarations, and metadata-only hits cannot prove it.
+func exploreSyntacticAnchorEvidenceReady(task string, targets []exploreTarget) bool {
+	anchors := exploreSyntacticAnchors(task)
+	covered := make([]bool, len(anchors))
+	remaining := len(anchors)
+	for _, target := range targets {
+		if !exploreSyntacticAnchorEligibleNode(target.node) || strings.TrimSpace(target.source) == "" {
+			continue
+		}
+		declaration := strings.ToLower(target.source)
+		for index, anchor := range anchors {
+			if covered[index] || !exploreSyntacticAnchorMatchesTargetSource(anchor, target, declaration) {
+				continue
+			}
+			if target.node.Kind == graph.KindType &&
+				(strings.Contains(declaration, "interface ") || strings.Contains(declaration, "trait ") || strings.Contains(declaration, "protocol ")) {
+				continue
+			}
+			covered[index] = true
+			remaining--
+		}
+		if remaining == 0 {
+			return true
+		}
+	}
+	return remaining == 0
+}
+
+func exploreSyntacticAnchorTargetMatchesAnchors(anchors []exploreSyntacticAnchor, target exploreTarget) int {
+	if !exploreSyntacticAnchorEligibleNode(target.node) || strings.TrimSpace(target.source) == "" {
+		return 0
+	}
+	lowerSource := strings.ToLower(target.source)
+	matched := 0
+	for _, anchor := range anchors {
+		if exploreSyntacticAnchorMatchesTargetSource(anchor, target, lowerSource) {
+			matched++
+		}
+	}
+	return matched
+}

--- a/internal/mcp/explore_syntactic_anchor_test.go
+++ b/internal/mcp/explore_syntactic_anchor_test.go
@@ -1,0 +1,166 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/query"
+	"github.com/zzet/gortex/internal/search/rerank"
+)
+
+func TestExploreSyntacticAnchorsNormalizeFlagsAndIdentifiers(t *testing.T) {
+	anchors := exploreSyntacticAnchors("replacement breaks when --replace --only-matching use replace_all through DevtoolsOptions; ignore `quoted_name`")
+	require.Len(t, anchors, 3)
+	require.Equal(t, "replace", anchors[0].compact)
+	require.Equal(t, "onlymatching", anchors[1].compact)
+	require.Equal(t, "devtoolsoptions", anchors[2].compact)
+}
+
+func TestExploreSyntacticAnchorIdentifierPrefixMorphology(t *testing.T) {
+	anchors := exploreSyntacticAnchors("the --replace path fails")
+	require.Len(t, anchors, 1)
+	anchor := anchors[0]
+	for _, identifier := range []string{"Replacer", "replace_all", "replaceAll"} {
+		require.True(t, exploreSyntacticAnchorMatchesIdentifier(anchor, identifier), identifier)
+	}
+	require.False(t, exploreSyntacticAnchorMatchesIdentifier(anchor, "configure_context"))
+}
+
+func TestReserveExploreSyntacticAnchorCandidatesPreservesHeadAndDiversity(t *testing.T) {
+	makeCandidate := func(id, name, file string) *rerank.Candidate {
+		return &rerank.Candidate{Node: &graph.Node{
+			ID: id, Name: name, QualName: name, Kind: graph.KindFunction, FilePath: file,
+		}}
+	}
+	candidates := []*rerank.Candidate{
+		makeCandidate("semantic", "search_execution", "search.rs"),
+		makeCandidate("noise-a", "configure_output", "args.rs"),
+		makeCandidate("noise-b", "print_match", "printer.rs"),
+		makeCandidate("replace", "replace_all", "util.rs"),
+		makeCandidate("only", "only_matching", "config.rs"),
+	}
+
+	got := reserveExploreSyntacticAnchorCandidates(
+		"interaction between --replace and --only-matching",
+		candidates,
+		map[int]string{0: "replace", 1: "only"},
+		3,
+	)
+	require.Equal(t, "semantic", got[0].Node.ID)
+	window := map[string]bool{}
+	for _, candidate := range got[:3] {
+		window[candidate.Node.ID] = true
+	}
+	require.True(t, window["replace"])
+	require.True(t, window["only"])
+}
+
+func TestExploreSyntacticAnchorCandidatePrefersCallableExactStem(t *testing.T) {
+	anchor := exploreSyntacticAnchors("failure in --replace")[0]
+	candidates := []*rerank.Candidate{
+		{Node: &graph.Node{ID: "replacement", Name: "Replacement", Kind: graph.KindType, FilePath: "args.rs"}},
+		{Node: &graph.Node{ID: "replacer", Name: "Replacer", Kind: graph.KindType, FilePath: "replacer.rs"}},
+		{Node: &graph.Node{ID: "replace-all", Name: "replace_all", Kind: graph.KindMethod, FilePath: "util.rs"}},
+	}
+
+	got := exploreSyntacticAnchorCandidate(anchor, candidates, query.QueryOptions{}, map[string]struct{}{}, map[string]struct{}{})
+	require.NotNil(t, got)
+	require.Equal(t, "replace-all", got.Node.ID)
+}
+
+func TestExploreSyntacticAnchorEvidenceBlocksMissingImplementation(t *testing.T) {
+	target := exploreTarget{
+		node: &graph.Node{
+			ID: "repo/config.rs::multi_line", Name: "multi_line", QualName: "Config.multi_line",
+			Kind: graph.KindMethod, FilePath: "repo/config.rs",
+		},
+		source:                "fn multi_line(&mut self, yes: bool) { if yes { self.multi_line = true; } }",
+		conceptImplementation: true,
+	}
+	require.False(t, exploreSyntacticAnchorEvidenceReady("replacement fails with --replace and --multiline", []exploreTarget{target}))
+}
+
+func TestExploreAnswerReadyRequiresAllSyntacticAnchors(t *testing.T) {
+	target := exploreTarget{
+		node: &graph.Node{
+			ID: "repo/util.rs::replace_multiline", Name: "replace_multiline", QualName: "util.replace_multiline",
+			Kind: graph.KindFunction, FilePath: "repo/util.rs",
+		},
+		source: `fn replace_multiline(input: &str) -> String {
+		if input.contains('\n') { perform_replacement(input) } else { input.to_owned() }
+	}`,
+		conceptImplementation: true,
+	}
+	require.True(t, exploreAnswerReady("replacement behavior for --replace and --multiline", []exploreTarget{target}))
+
+	missing := target
+	missing.node = &graph.Node{
+		ID: "repo/config.rs::multi_line", Name: "multi_line", QualName: "Config.multi_line",
+		Kind: graph.KindMethod, FilePath: "repo/config.rs",
+	}
+	missing.source = "fn multi_line(&mut self, yes: bool) { if yes { self.multi_line = true; } }"
+	require.False(t, exploreAnswerReady("replacement behavior for --replace and --multiline", []exploreTarget{missing}))
+}
+
+func TestExploreDraftGenericCandidateRecognizesOneStepForwarders(t *testing.T) {
+	fixtures := []struct {
+		name   string
+		source string
+	}{
+		{
+			name: "rust tail expression",
+			source: `fn replace_with_captures_at(&self, caps: &Captures, dst: &mut Vec<u8>, at: usize) {
+				(*self).replace_with_captures_at(caps, dst, at)
+			}`,
+		},
+		{name: "csharp expression body", source: "string Replace(string value) => inner.Replace(value);"},
+		{name: "kotlin expression body", source: "fun replace(value: String) = delegate.replace(value)"},
+	}
+	for _, fixture := range fixtures {
+		t.Run(fixture.name, func(t *testing.T) {
+			node := &graph.Node{ID: fixture.name, Name: "replace_with_captures_at", Kind: graph.KindMethod}
+			require.True(t, exploreDraftGenericCandidate(node, fixture.source))
+		})
+	}
+}
+
+func TestExploreAnswerReadyRejectsGenericAnchorForwarder(t *testing.T) {
+	target := exploreTarget{
+		node: &graph.Node{
+			ID: "repo/replacer.rs::replace_with_captures_at", Name: "replace_with_captures_at",
+			QualName: "ReplacerRef.replace_with_captures_at", Kind: graph.KindMethod, FilePath: "repo/replacer.rs",
+		},
+		source: `fn replace_with_captures_at(&self, caps: &Captures, dst: &mut Vec<u8>, at: usize) {
+			(*self).replace_with_captures_at(caps, dst, at)
+		}`,
+		conceptImplementation: true,
+	}
+	require.False(t, exploreAnswerReady("locate replacement implementation for --replace", []exploreTarget{target}))
+}
+
+func TestRefinementPrefersConcreteAnchorOwnerOverForwarder(t *testing.T) {
+	wrapper := exploreTarget{
+		node: &graph.Node{
+			ID: "repo/replacer.rs::ref_forwarder", Name: "replace_with_captures_at",
+			QualName: "ReplacerRef.replace_with_captures_at", Kind: graph.KindMethod, FilePath: "repo/replacer.rs",
+		},
+		source: `fn replace_with_captures_at(&self, caps: &Captures, dst: &mut Vec<u8>, at: usize) {
+			(*self).replace_with_captures_at(caps, dst, at)
+		}`,
+	}
+	implementation := exploreTarget{
+		node: &graph.Node{
+			ID: "repo/util.rs::Replacer.replace_all", Name: "replace_all",
+			QualName: "Replacer.replace_all", Kind: graph.KindMethod, FilePath: "repo/util.rs",
+		},
+		source: `fn replace_all(&self, haystack: &[u8], dst: &mut Vec<u8>) {
+			for captures in self.captures_iter(haystack) { self.append(captures, dst); }
+		}`,
+	}
+
+	require.Equal(t, implementation.node.ID, explorePreferredRefinementSymbol(
+		"replacement implementation for --replace", []exploreTarget{wrapper, implementation},
+	))
+}

--- a/internal/mcp/explore_typed_anchor_projection.go
+++ b/internal/mcp/explore_typed_anchor_projection.go
@@ -1,0 +1,793 @@
+package mcp
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/query"
+	"github.com/zzet/gortex/internal/search/rerank"
+)
+
+const (
+	exploreTypedAnchorFieldLimit         = 2
+	exploreTypedAnchorFieldRelationLimit = 8
+	exploreTypedAnchorConsumerLimit      = 12
+	exploreTypedAnchorOwnerMemberLimit   = 48
+	exploreTypedAnchorCallLimit          = 64
+	exploreTypedAnchorMemberOwnerLimit   = 4
+	exploreTypedAnchorProjectionSignal   = "typed_anchor_projection"
+)
+
+// exploreTypedAnchorBatchReader deliberately exposes only batched graph reads.
+// The SQLite implementation turns each stage into one bounded IN query, while
+// query overlays preserve request-local edits. A point-reader interface here
+// previously amplified one projection into dozens of SQLite round trips.
+type exploreTypedAnchorBatchReader interface {
+	GetNodesByIDs([]string) map[string]*graph.Node
+	GetInEdgesByNodeIDs([]string) map[string][]*graph.Edge
+	GetOutEdgesByNodeIDs([]string) map[string][]*graph.Edge
+}
+
+type exploreTypedAnchorField struct {
+	candidate     *rerank.Candidate
+	anchorIndexes []int
+	field         *graph.Node
+	owner         *graph.Node
+	typedIDs      map[string]struct{}
+	canonicalType string
+}
+
+type exploreTypedAnchorConsumer struct {
+	field         *exploreTypedAnchorField
+	node          *graph.Node
+	direct        bool
+	anchorMatches int
+}
+
+type exploreTypedAnchorCall struct {
+	consumer *exploreTypedAnchorConsumer
+	memberID string
+}
+
+type exploreTypedAnchorProjection struct {
+	field           *exploreTypedAnchorField
+	consumer        *graph.Node
+	member          *graph.Node
+	memberMatches   int
+	consumerMatches int
+	directFieldUse  bool
+	exactType       bool
+}
+
+// projectExploreTypedAnchorCandidates repairs a narrow blind spot in the
+// ordinary localization window. A distinctive syntactic anchor can retain a
+// typed field without the behavior that consumes it. One consumer/member pair
+// is admitted only when the graph proves all of:
+//
+//	field --member_of--> owner <--member_of-- consumer --calls--> member
+//	member --member_of--> the field's declared type
+//
+// A direct field-use edge proves the consumer. Without one, the owner member
+// itself must match the same active task anchor. Every graph stage is batched,
+// canonically ordered, and structurally capped. Cap overflow, incomplete
+// hydration, ambiguous strongest proofs, and request cancellation are all
+// conservative no-ops; wall-clock scheduling never changes correctness.
+func projectExploreTypedAnchorCandidates(
+	ctx context.Context,
+	task string,
+	candidates []*rerank.Candidate,
+	reader exploreTypedAnchorBatchReader,
+	scope query.QueryOptions,
+	maxSymbols int,
+	protectedAnchors map[int]string,
+	protectedImplementationID string,
+) []*rerank.Candidate {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if reader == nil || ctx.Err() != nil || len(candidates) == 0 || maxSymbols < 3 || len(protectedAnchors) == 0 {
+		return candidates
+	}
+	projection, ok := findExploreTypedAnchorProjection(ctx, task, candidates, reader, scope, protectedAnchors)
+	if !ok {
+		return candidates
+	}
+	reserved := exploreTypedAnchorReservedCandidateIDs(candidates, protectedAnchors, protectedImplementationID)
+	return reserveExploreTypedAnchorProjection(candidates, projection, reserved, maxSymbols)
+}
+
+func findExploreTypedAnchorProjection(
+	ctx context.Context,
+	task string,
+	candidates []*rerank.Candidate,
+	reader exploreTypedAnchorBatchReader,
+	scope query.QueryOptions,
+	protected map[int]string,
+) (exploreTypedAnchorProjection, bool) {
+	anchors := exploreSyntacticAnchors(task)
+	active := exploreTypedAnchorActiveIndexes(anchors, protected)
+	if len(active) == 0 || ctx.Err() != nil {
+		return exploreTypedAnchorProjection{}, false
+	}
+
+	fields := make([]*exploreTypedAnchorField, 0, exploreTypedAnchorFieldLimit)
+	for _, candidate := range candidates {
+		if candidate == nil || candidate.Node == nil || candidate.Node.Kind != graph.KindField {
+			continue
+		}
+		indexes := exploreTypedAnchorMatchingIndexes(
+			anchors, active, candidate.Node, exploreTypedAnchorFieldType(candidate.Node),
+		)
+		if len(indexes) == 0 {
+			continue
+		}
+		if len(fields) == exploreTypedAnchorFieldLimit {
+			return exploreTypedAnchorProjection{}, false
+		}
+		fields = append(fields, &exploreTypedAnchorField{
+			candidate: candidate, anchorIndexes: indexes, field: candidate.Node,
+			canonicalType: exploreTypedAnchorCanonicalType(exploreTypedAnchorFieldType(candidate.Node)),
+		})
+	}
+	if len(fields) == 0 || !hydrateExploreTypedAnchorFields(ctx, fields, reader, scope) {
+		return exploreTypedAnchorProjection{}, false
+	}
+
+	consumers, ok := hydrateExploreTypedAnchorConsumers(ctx, fields, reader, scope, anchors)
+	if !ok || len(consumers) == 0 {
+		return exploreTypedAnchorProjection{}, false
+	}
+	projections, ok := hydrateExploreTypedAnchorCalls(ctx, consumers, reader, scope, anchors)
+	if !ok || len(projections) == 0 {
+		return exploreTypedAnchorProjection{}, false
+	}
+	return uniqueStrongestExploreTypedAnchorProjection(projections)
+}
+
+func exploreTypedAnchorActiveIndexes(anchors []exploreSyntacticAnchor, protected map[int]string) []int {
+	indexes := make([]int, 0, len(protected))
+	for index, id := range protected {
+		if id != "" && index >= 0 && index < len(anchors) {
+			indexes = append(indexes, index)
+		}
+	}
+	sort.Ints(indexes)
+	return indexes
+}
+
+func hydrateExploreTypedAnchorFields(
+	ctx context.Context,
+	fields []*exploreTypedAnchorField,
+	reader exploreTypedAnchorBatchReader,
+	scope query.QueryOptions,
+) bool {
+	fieldIDs := make([]string, 0, len(fields))
+	for _, field := range fields {
+		fieldIDs = append(fieldIDs, field.field.ID)
+	}
+	out := reader.GetOutEdgesByNodeIDs(exploreTypedAnchorSortedIDs(fieldIDs))
+	if ctx.Err() != nil {
+		return false
+	}
+
+	relations := make(map[string][]*graph.Edge, len(fields))
+	endpointIDs := make([]string, 0, len(fields)*2)
+	for _, field := range fields {
+		edges, overflow := exploreTypedAnchorBoundedEdges(
+			out[field.field.ID], exploreTypedAnchorFieldRelationLimit, graph.EdgeMemberOf, graph.EdgeTypedAs,
+		)
+		if overflow {
+			return false
+		}
+		relations[field.field.ID] = edges
+		for _, edge := range edges {
+			endpointIDs = append(endpointIDs, edge.To)
+		}
+	}
+	nodes := reader.GetNodesByIDs(exploreTypedAnchorSortedIDs(endpointIDs))
+	if ctx.Err() != nil {
+		return false
+	}
+
+	kept := fields[:0]
+	for _, field := range fields {
+		owners := make(map[string]*graph.Node)
+		field.typedIDs = make(map[string]struct{})
+		complete := true
+		for _, edge := range relations[field.field.ID] {
+			node := nodes[edge.To]
+			if node == nil {
+				complete = false
+				break
+			}
+			if !exploreNodeWithinQueryScope(node, scope) {
+				continue
+			}
+			switch edge.Kind {
+			case graph.EdgeMemberOf:
+				if exploreTypedAnchorTypeNode(node) {
+					owners[node.ID] = node
+				}
+			case graph.EdgeTypedAs:
+				if exploreTypedAnchorTypeNode(node) {
+					field.typedIDs[node.ID] = struct{}{}
+				}
+			}
+		}
+		if !complete || len(owners) != 1 || (len(field.typedIDs) == 0 && field.canonicalType == "") {
+			continue
+		}
+		for _, owner := range owners {
+			field.owner = owner
+		}
+		kept = append(kept, field)
+	}
+	for index := len(kept); index < len(fields); index++ {
+		fields[index] = nil
+	}
+	return len(kept) > 0
+}
+
+func hydrateExploreTypedAnchorConsumers(
+	ctx context.Context,
+	fields []*exploreTypedAnchorField,
+	reader exploreTypedAnchorBatchReader,
+	scope query.QueryOptions,
+	anchors []exploreSyntacticAnchor,
+) ([]*exploreTypedAnchorConsumer, bool) {
+	// hydrateExploreTypedAnchorFields filters in place but cannot resize its
+	// caller's slice. Ignore any cleared or unhydrated seed here.
+	queryIDs := make([]string, 0, len(fields)*2)
+	for _, field := range fields {
+		if field == nil || field.owner == nil {
+			continue
+		}
+		queryIDs = append(queryIDs, field.field.ID, field.owner.ID)
+	}
+	if len(queryIDs) == 0 {
+		return nil, false
+	}
+	in := reader.GetInEdgesByNodeIDs(exploreTypedAnchorSortedIDs(queryIDs))
+	if ctx.Err() != nil {
+		return nil, false
+	}
+
+	type rawConsumer struct {
+		id     string
+		direct bool
+	}
+	rawByField := make(map[string]map[string]rawConsumer, len(fields))
+	consumerIDs := make([]string, 0, len(fields)*exploreTypedAnchorConsumerLimit)
+	for _, field := range fields {
+		if field == nil || field.owner == nil {
+			continue
+		}
+		direct, overflow := exploreTypedAnchorBoundedEdges(
+			in[field.field.ID], exploreTypedAnchorConsumerLimit,
+			graph.EdgeReads, graph.EdgeWrites, graph.EdgeAccessesField,
+		)
+		if overflow {
+			return nil, false
+		}
+		members, overflow := exploreTypedAnchorBoundedEdges(
+			in[field.owner.ID], exploreTypedAnchorOwnerMemberLimit, graph.EdgeMemberOf,
+		)
+		if overflow {
+			return nil, false
+		}
+		byID := make(map[string]rawConsumer, len(direct)+len(members))
+		for _, edge := range members {
+			byID[edge.From] = rawConsumer{id: edge.From}
+		}
+		for _, edge := range direct {
+			consumer, member := byID[edge.From]
+			if !member {
+				// A field read outside the owning type does not prove the
+				// field→owner←consumer leg required by this projection.
+				continue
+			}
+			consumer.direct = true
+			byID[edge.From] = consumer
+		}
+		rawByField[field.field.ID] = byID
+		for id := range byID {
+			consumerIDs = append(consumerIDs, id)
+		}
+	}
+	nodes := reader.GetNodesByIDs(exploreTypedAnchorSortedIDs(consumerIDs))
+	if ctx.Err() != nil {
+		return nil, false
+	}
+
+	consumers := make([]*exploreTypedAnchorConsumer, 0, len(consumerIDs))
+	for _, field := range fields {
+		if field == nil || field.owner == nil {
+			continue
+		}
+		local := make([]*exploreTypedAnchorConsumer, 0, len(rawByField[field.field.ID]))
+		for _, raw := range rawByField[field.field.ID] {
+			node := nodes[raw.id]
+			if node == nil {
+				return nil, false
+			}
+			if !exploreTypedAnchorCallable(node, scope) {
+				continue
+			}
+			matches := exploreTypedAnchorMatchCount(anchors, field.anchorIndexes, node, "")
+			if !raw.direct && matches == 0 {
+				continue
+			}
+			local = append(local, &exploreTypedAnchorConsumer{
+				field: field, node: node, direct: raw.direct, anchorMatches: matches,
+			})
+		}
+		sort.SliceStable(local, func(i, j int) bool {
+			if local[i].direct != local[j].direct {
+				return local[i].direct
+			}
+			if local[i].anchorMatches != local[j].anchorMatches {
+				return local[i].anchorMatches > local[j].anchorMatches
+			}
+			return local[i].node.ID < local[j].node.ID
+		})
+		if len(local) > exploreTypedAnchorConsumerLimit {
+			return nil, false
+		}
+		consumers = append(consumers, local...)
+	}
+	return consumers, true
+}
+
+func hydrateExploreTypedAnchorCalls(
+	ctx context.Context,
+	consumers []*exploreTypedAnchorConsumer,
+	reader exploreTypedAnchorBatchReader,
+	scope query.QueryOptions,
+	anchors []exploreSyntacticAnchor,
+) ([]exploreTypedAnchorProjection, bool) {
+	consumerIDs := make([]string, 0, len(consumers))
+	consumerByID := make(map[string][]*exploreTypedAnchorConsumer, len(consumers))
+	for _, consumer := range consumers {
+		consumerIDs = append(consumerIDs, consumer.node.ID)
+		consumerByID[consumer.node.ID] = append(consumerByID[consumer.node.ID], consumer)
+	}
+	out := reader.GetOutEdgesByNodeIDs(exploreTypedAnchorSortedIDs(consumerIDs))
+	if ctx.Err() != nil {
+		return nil, false
+	}
+
+	calls := make([]exploreTypedAnchorCall, 0, exploreTypedAnchorCallLimit)
+	seenCalls := make(map[string]struct{})
+	for _, consumerID := range exploreTypedAnchorSortedIDs(consumerIDs) {
+		edges, overflow := exploreTypedAnchorBoundedEdges(out[consumerID], exploreTypedAnchorCallLimit, graph.EdgeCalls)
+		if overflow || len(calls)+len(edges)*len(consumerByID[consumerID]) > exploreTypedAnchorCallLimit {
+			return nil, false
+		}
+		for _, consumer := range consumerByID[consumerID] {
+			for _, edge := range edges {
+				key := consumer.field.field.ID + "\x00" + consumer.node.ID + "\x00" + edge.To
+				if _, duplicate := seenCalls[key]; duplicate {
+					continue
+				}
+				seenCalls[key] = struct{}{}
+				calls = append(calls, exploreTypedAnchorCall{consumer: consumer, memberID: edge.To})
+			}
+		}
+	}
+	if len(calls) == 0 {
+		return nil, true
+	}
+
+	memberIDs := make([]string, 0, len(calls))
+	for _, call := range calls {
+		memberIDs = append(memberIDs, call.memberID)
+	}
+	memberOut := reader.GetOutEdgesByNodeIDs(exploreTypedAnchorSortedIDs(memberIDs))
+	if ctx.Err() != nil {
+		return nil, false
+	}
+	memberRelations := make(map[string][]*graph.Edge)
+	ownerIDs := make([]string, 0, len(memberIDs))
+	for _, memberID := range exploreTypedAnchorSortedIDs(memberIDs) {
+		edges, overflow := exploreTypedAnchorBoundedEdges(
+			memberOut[memberID], exploreTypedAnchorMemberOwnerLimit, graph.EdgeMemberOf,
+		)
+		if overflow {
+			return nil, false
+		}
+		memberRelations[memberID] = edges
+		for _, edge := range edges {
+			ownerIDs = append(ownerIDs, edge.To)
+		}
+	}
+	hydrationIDs := append(exploreTypedAnchorSortedIDs(memberIDs), ownerIDs...)
+	nodes := reader.GetNodesByIDs(exploreTypedAnchorSortedIDs(hydrationIDs))
+	if ctx.Err() != nil {
+		return nil, false
+	}
+
+	projections := make([]exploreTypedAnchorProjection, 0, len(calls))
+	for _, call := range calls {
+		member := nodes[call.memberID]
+		if member == nil {
+			return nil, false
+		}
+		if !exploreTypedAnchorCallable(member, scope) {
+			continue
+		}
+		memberMatches := exploreTypedAnchorMatchCount(
+			anchors, call.consumer.field.anchorIndexes, member, "",
+		)
+		if memberMatches == 0 {
+			continue
+		}
+		exactType, typeMatches, complete := exploreTypedAnchorMemberTypeProof(
+			call.consumer.field, memberRelations[member.ID], nodes, scope,
+		)
+		if !complete {
+			return nil, false
+		}
+		if !typeMatches {
+			continue
+		}
+		projections = append(projections, exploreTypedAnchorProjection{
+			field: call.consumer.field, consumer: call.consumer.node, member: member,
+			memberMatches: memberMatches, consumerMatches: call.consumer.anchorMatches,
+			directFieldUse: call.consumer.direct, exactType: exactType,
+		})
+	}
+	return projections, true
+}
+
+func exploreTypedAnchorMemberTypeProof(
+	field *exploreTypedAnchorField,
+	edges []*graph.Edge,
+	nodes map[string]*graph.Node,
+	scope query.QueryOptions,
+) (exact, matches, complete bool) {
+	complete = true
+	for _, edge := range edges {
+		owner := nodes[edge.To]
+		if owner == nil {
+			return false, false, false
+		}
+		if !exploreTypedAnchorTypeNode(owner) || !exploreNodeWithinQueryScope(owner, scope) {
+			continue
+		}
+		if len(field.typedIDs) > 0 {
+			if _, ok := field.typedIDs[owner.ID]; ok {
+				return true, true, true
+			}
+			continue
+		}
+		if field.canonicalType != "" && exploreTypedAnchorCanonicalTypeMatches(field.canonicalType, owner) {
+			return false, true, true
+		}
+	}
+	return false, false, complete
+}
+
+func uniqueStrongestExploreTypedAnchorProjection(projections []exploreTypedAnchorProjection) (exploreTypedAnchorProjection, bool) {
+	if len(projections) == 0 {
+		return exploreTypedAnchorProjection{}, false
+	}
+	best := projections[0]
+	ambiguous := false
+	for _, projection := range projections[1:] {
+		switch exploreTypedAnchorProjectionCompare(projection, best) {
+		case 1:
+			best = projection
+			ambiguous = false
+		case 0:
+			if projection.consumer.ID != best.consumer.ID || projection.member.ID != best.member.ID {
+				ambiguous = true
+			}
+		}
+	}
+	return best, !ambiguous
+}
+
+func exploreTypedAnchorProjectionCompare(left, right exploreTypedAnchorProjection) int {
+	leftStrength := []int{
+		boolInt(left.exactType), boolInt(left.directFieldUse), left.memberMatches, left.consumerMatches,
+	}
+	rightStrength := []int{
+		boolInt(right.exactType), boolInt(right.directFieldUse), right.memberMatches, right.consumerMatches,
+	}
+	for index := range leftStrength {
+		if leftStrength[index] > rightStrength[index] {
+			return 1
+		}
+		if leftStrength[index] < rightStrength[index] {
+			return -1
+		}
+	}
+	return 0
+}
+
+func boolInt(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
+}
+
+func exploreTypedAnchorMatchingIndexes(
+	anchors []exploreSyntacticAnchor,
+	indexes []int,
+	node *graph.Node,
+	extra string,
+) []int {
+	matched := make([]int, 0, len(indexes))
+	for _, index := range indexes {
+		if index < 0 || index >= len(anchors) {
+			continue
+		}
+		anchor := anchors[index]
+		if exploreSyntacticAnchorMatchesNode(anchor, node) ||
+			(extra != "" && exploreSyntacticAnchorMatchesIdentifier(anchor, extra)) {
+			matched = append(matched, index)
+		}
+	}
+	return matched
+}
+
+func exploreTypedAnchorMatchCount(anchors []exploreSyntacticAnchor, indexes []int, node *graph.Node, extra string) int {
+	return len(exploreTypedAnchorMatchingIndexes(anchors, indexes, node, extra))
+}
+
+func exploreTypedAnchorCallable(node *graph.Node, scope query.QueryOptions) bool {
+	if node == nil || (node.Kind != graph.KindFunction && node.Kind != graph.KindMethod) || !exploreNodeWithinQueryScope(node, scope) {
+		return false
+	}
+	isTest, _ := node.Meta["is_test"].(bool)
+	return !isTest
+}
+
+func exploreTypedAnchorTypeNode(node *graph.Node) bool {
+	return node != nil && (node.Kind == graph.KindType || node.Kind == graph.KindInterface)
+}
+
+func exploreTypedAnchorFieldType(field *graph.Node) string {
+	if field == nil || field.Meta == nil {
+		return ""
+	}
+	value, _ := field.Meta["field_type"].(string)
+	return strings.TrimSpace(value)
+}
+
+// exploreTypedAnchorCanonicalType extracts one exact outer type identity. It
+// strips references, array/nullable suffixes and generic arguments, retaining
+// at most the final namespace/module qualifier. It deliberately does not accept
+// shared component words or peer wrapper contents. If the graph cannot provide
+// typed_as, false positives are more damaging than a conservative no-op.
+func exploreTypedAnchorCanonicalType(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if index := strings.IndexByte(value, '<'); index >= 0 {
+		value = value[:index]
+	}
+	value = strings.TrimSpace(strings.TrimRight(value, "?[]*& "))
+	fields := strings.Fields(value)
+	if len(fields) == 0 {
+		return ""
+	}
+	value = fields[len(fields)-1]
+	parts := strings.FieldsFunc(value, func(r rune) bool {
+		return r == ':' || r == '.' || r == '/' || r == '\\'
+	})
+	identities := make([]string, 0, 2)
+	for _, part := range parts {
+		tokens := rerank.Tokenize(part)
+		if len(tokens) == 0 {
+			continue
+		}
+		identities = append(identities, strings.ToLower(strings.TrimSpace(tokens[len(tokens)-1])))
+	}
+	if len(identities) > 2 {
+		identities = identities[len(identities)-2:]
+	}
+	return strings.Join(identities, ".")
+}
+
+func exploreTypedAnchorCanonicalTypeMatches(fieldIdentity string, owner *graph.Node) bool {
+	if fieldIdentity == "" || owner == nil {
+		return false
+	}
+	if !strings.Contains(fieldIdentity, ".") {
+		return fieldIdentity == exploreTypedAnchorCanonicalType(owner.Name)
+	}
+	return fieldIdentity == exploreTypedAnchorCanonicalType(owner.QualName)
+}
+
+func exploreTypedAnchorBoundedEdges(edges []*graph.Edge, limit int, kinds ...graph.EdgeKind) ([]*graph.Edge, bool) {
+	if limit < 1 || len(edges) == 0 || len(kinds) == 0 {
+		return nil, false
+	}
+	allowed := make(map[graph.EdgeKind]struct{}, len(kinds))
+	for _, kind := range kinds {
+		allowed[kind] = struct{}{}
+	}
+	bounded := make([]*graph.Edge, 0, min(limit+1, len(edges)))
+	for _, edge := range edges {
+		if edge == nil {
+			continue
+		}
+		if _, ok := allowed[edge.Kind]; ok {
+			bounded = append(bounded, edge)
+		}
+	}
+	sort.SliceStable(bounded, func(i, j int) bool {
+		left, right := bounded[i], bounded[j]
+		if left.Kind != right.Kind {
+			return left.Kind < right.Kind
+		}
+		if left.From != right.From {
+			return left.From < right.From
+		}
+		if left.To != right.To {
+			return left.To < right.To
+		}
+		if left.FilePath != right.FilePath {
+			return left.FilePath < right.FilePath
+		}
+		if left.Line != right.Line {
+			return left.Line < right.Line
+		}
+		return left.Origin < right.Origin
+	})
+	if len(bounded) > limit {
+		return nil, true
+	}
+	return bounded, false
+}
+
+func exploreTypedAnchorSortedIDs(ids []string) []string {
+	if len(ids) == 0 {
+		return nil
+	}
+	unique := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if id != "" {
+			unique[id] = struct{}{}
+		}
+	}
+	result := make([]string, 0, len(unique))
+	for id := range unique {
+		result = append(result, id)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func exploreTypedAnchorReservedCandidateIDs(
+	candidates []*rerank.Candidate,
+	protectedAnchors map[int]string,
+	protectedImplementationID string,
+) map[string]struct{} {
+	reserved := make(map[string]struct{}, len(protectedAnchors)+4)
+	if len(candidates) > 0 && candidates[0] != nil && candidates[0].Node != nil {
+		reserved[candidates[0].Node.ID] = struct{}{}
+	}
+	for _, id := range protectedAnchors {
+		if id != "" {
+			reserved[id] = struct{}{}
+		}
+	}
+	if protectedImplementationID != "" {
+		reserved[protectedImplementationID] = struct{}{}
+	}
+	for _, candidate := range candidates {
+		if candidate == nil || candidate.Node == nil || candidate.Signals == nil {
+			continue
+		}
+		if candidate.Signals[exploreContentRecallExactSignal] > 0 ||
+			candidate.Signals[exploreSourceLiteralSignal] > 0 ||
+			candidate.Signals[exploreSourceLiteralCalleeSignal] > 0 ||
+			candidate.Signals[exploreTypedAnchorProjectionSignal] > 0 {
+			reserved[candidate.Node.ID] = struct{}{}
+		}
+	}
+	return reserved
+}
+
+func reserveExploreTypedAnchorProjection(
+	candidates []*rerank.Candidate,
+	projection exploreTypedAnchorProjection,
+	reserved map[string]struct{},
+	maxSymbols int,
+) []*rerank.Candidate {
+	if projection.field == nil || projection.field.candidate == nil || projection.field.field == nil ||
+		projection.consumer == nil || projection.member == nil {
+		return candidates
+	}
+	mustKeep := make(map[string]struct{}, len(reserved)+3)
+	for id := range reserved {
+		mustKeep[id] = struct{}{}
+	}
+	mustKeep[projection.field.field.ID] = struct{}{}
+	mustKeep[projection.consumer.ID] = struct{}{}
+	mustKeep[projection.member.ID] = struct{}{}
+	if len(mustKeep) > maxSymbols {
+		return candidates
+	}
+
+	existing := make(map[string]struct{}, len(candidates))
+	marked := make([]*rerank.Candidate, 0, len(candidates)+2)
+	for _, candidate := range candidates {
+		if candidate == nil || candidate.Node == nil {
+			marked = append(marked, candidate)
+			continue
+		}
+		id := candidate.Node.ID
+		if _, duplicate := existing[id]; duplicate {
+			continue
+		}
+		existing[id] = struct{}{}
+		if id == projection.consumer.ID || id == projection.member.ID {
+			candidate = exploreTypedAnchorMarkedCandidate(candidate)
+		}
+		marked = append(marked, candidate)
+	}
+
+	additions := make([]*rerank.Candidate, 0, 2)
+	for _, node := range []*graph.Node{projection.consumer, projection.member} {
+		if _, present := existing[node.ID]; present {
+			continue
+		}
+		existing[node.ID] = struct{}{}
+		additions = append(additions, exploreTypedAnchorProjectedCandidate(node, projection.field.candidate.Score))
+	}
+	expanded := make([]*rerank.Candidate, 0, len(marked)+len(additions))
+	inserted := false
+	for _, candidate := range marked {
+		expanded = append(expanded, candidate)
+		if candidate != nil && candidate.Node != nil && candidate.Node.ID == projection.field.field.ID {
+			expanded = append(expanded, additions...)
+			inserted = true
+		}
+	}
+	if !inserted {
+		return candidates
+	}
+	for len(expanded) > maxSymbols {
+		remove := -1
+		for index := len(expanded) - 1; index >= 0; index-- {
+			candidate := expanded[index]
+			if candidate == nil || candidate.Node == nil {
+				remove = index
+				break
+			}
+			if _, keep := mustKeep[candidate.Node.ID]; !keep {
+				remove = index
+				break
+			}
+		}
+		if remove < 0 {
+			return candidates
+		}
+		expanded = append(expanded[:remove], expanded[remove+1:]...)
+	}
+	return expanded
+}
+
+func exploreTypedAnchorMarkedCandidate(candidate *rerank.Candidate) *rerank.Candidate {
+	clone := *candidate
+	clone.Signals = make(map[string]float64, len(candidate.Signals)+1)
+	for key, value := range candidate.Signals {
+		clone.Signals[key] = value
+	}
+	clone.Signals[exploreTypedAnchorProjectionSignal] = 1
+	return &clone
+}
+
+func exploreTypedAnchorProjectedCandidate(node *graph.Node, score float64) *rerank.Candidate {
+	return &rerank.Candidate{
+		Node: node, TextRank: -1, VectorRank: -1, Score: score,
+		Signals: map[string]float64{exploreTypedAnchorProjectionSignal: 1},
+	}
+}

--- a/internal/mcp/explore_typed_anchor_projection_test.go
+++ b/internal/mcp/explore_typed_anchor_projection_test.go
@@ -1,0 +1,507 @@
+package mcp
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/query"
+	"github.com/zzet/gortex/internal/search/rerank"
+)
+
+type exploreTypedAnchorTestReader struct {
+	nodes       map[string]*graph.Node
+	in          map[string][]*graph.Edge
+	out         map[string][]*graph.Edge
+	delay       time.Duration
+	nodeBatches int
+	inBatches   int
+	outBatches  int
+}
+
+func newExploreTypedAnchorTestReader(nodes ...*graph.Node) *exploreTypedAnchorTestReader {
+	reader := &exploreTypedAnchorTestReader{
+		nodes: make(map[string]*graph.Node, len(nodes)),
+		in:    make(map[string][]*graph.Edge),
+		out:   make(map[string][]*graph.Edge),
+	}
+	for _, node := range nodes {
+		reader.nodes[node.ID] = node
+	}
+	return reader
+}
+
+func (r *exploreTypedAnchorTestReader) addEdge(from, to string, kind graph.EdgeKind) {
+	edge := &graph.Edge{From: from, To: to, Kind: kind}
+	r.out[from] = append(r.out[from], edge)
+	r.in[to] = append(r.in[to], edge)
+}
+
+func (r *exploreTypedAnchorTestReader) GetNodesByIDs(ids []string) map[string]*graph.Node {
+	r.nodeBatches++
+	time.Sleep(r.delay)
+	result := make(map[string]*graph.Node, len(ids))
+	for _, id := range ids {
+		if node := r.nodes[id]; node != nil {
+			result[id] = node
+		}
+	}
+	return result
+}
+
+func (r *exploreTypedAnchorTestReader) GetInEdgesByNodeIDs(ids []string) map[string][]*graph.Edge {
+	r.inBatches++
+	time.Sleep(r.delay)
+	result := make(map[string][]*graph.Edge, len(ids))
+	for _, id := range ids {
+		result[id] = r.in[id]
+	}
+	return result
+}
+
+func (r *exploreTypedAnchorTestReader) GetOutEdgesByNodeIDs(ids []string) map[string][]*graph.Edge {
+	r.outBatches++
+	time.Sleep(r.delay)
+	result := make(map[string][]*graph.Edge, len(ids))
+	for _, id := range ids {
+		result[id] = r.out[id]
+	}
+	return result
+}
+
+func removeExploreTypedAnchorTestEdge(edges []*graph.Edge, from, to string, kind graph.EdgeKind) []*graph.Edge {
+	kept := edges[:0]
+	for _, edge := range edges {
+		if edge.From == from && edge.To == to && edge.Kind == kind {
+			continue
+		}
+		kept = append(kept, edge)
+	}
+	return kept
+}
+
+func exploreTypedAnchorCandidateIDs(candidates []*rerank.Candidate) []string {
+	ids := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate != nil && candidate.Node != nil {
+			ids = append(ids, candidate.Node.ID)
+		}
+	}
+	return ids
+}
+
+type exploreTypedAnchorFixture struct {
+	task       string
+	reader     *exploreTypedAnchorTestReader
+	candidates []*rerank.Candidate
+	protected  map[int]string
+	field      *graph.Node
+	consumer   *graph.Node
+	member     *graph.Node
+	wrongType  *graph.Node
+}
+
+func exploreTypedAnchorNode(id, name, path, language string, kind graph.NodeKind) *graph.Node {
+	return &graph.Node{
+		ID: id, Name: name, QualName: name, Kind: kind,
+		FilePath: path, Language: language,
+		WorkspaceID: "workspace", ProjectID: "project", RepoPrefix: "repo",
+	}
+}
+
+func newExploreTypedAnchorFixture(language, task, fieldName, fieldType, consumerName, memberName string, typedAs bool) exploreTypedAnchorFixture {
+	owner := exploreTypedAnchorNode(language+"-owner", "ResponseSink", "sink."+language, language, graph.KindType)
+	field := exploreTypedAnchorNode(language+"-field", fieldName, "sink."+language, language, graph.KindField)
+	field.Meta = map[string]any{"field_type": fieldType}
+	consumer := exploreTypedAnchorNode(language+"-consumer", consumerName, "sink."+language, language, graph.KindMethod)
+	targetType := exploreTypedAnchorNode(language+"-target-type", fieldType, "codec."+language, language, graph.KindType)
+	member := exploreTypedAnchorNode(language+"-member", memberName, "codec."+language, language, graph.KindMethod)
+	wrongType := exploreTypedAnchorNode(language+"-wrong-type", "OutputBuffer", "buffer."+language, language, graph.KindType)
+	wrongMember := exploreTypedAnchorNode(language+"-wrong-member", memberName, "buffer."+language, language, graph.KindMethod)
+	wrongConsumer := exploreTypedAnchorNode(language+"-wrong-consumer", memberName, "sink."+language, language, graph.KindMethod)
+	anchorDistractor := exploreTypedAnchorNode(language+"-anchor-distractor", memberName+"_bytes", "config."+language, language, graph.KindFunction)
+	noiseB := exploreTypedAnchorNode(language+"-noise-b", "print_output", "print."+language, language, graph.KindFunction)
+	noiseC := exploreTypedAnchorNode(language+"-noise-c", "parse_output", "parse."+language, language, graph.KindFunction)
+	noiseD := exploreTypedAnchorNode(language+"-noise-d", "write_output", "write."+language, language, graph.KindFunction)
+
+	reader := newExploreTypedAnchorTestReader(
+		owner, field, consumer, targetType, member, wrongType, wrongMember, wrongConsumer,
+		anchorDistractor, noiseB, noiseC, noiseD,
+	)
+	reader.addEdge(field.ID, owner.ID, graph.EdgeMemberOf)
+	reader.addEdge(consumer.ID, owner.ID, graph.EdgeMemberOf)
+	reader.addEdge(wrongConsumer.ID, owner.ID, graph.EdgeMemberOf)
+	reader.addEdge(consumer.ID, field.ID, graph.EdgeReads)
+	reader.addEdge(consumer.ID, member.ID, graph.EdgeCalls)
+	reader.addEdge(member.ID, targetType.ID, graph.EdgeMemberOf)
+	reader.addEdge(wrongConsumer.ID, wrongMember.ID, graph.EdgeCalls)
+	reader.addEdge(wrongMember.ID, wrongType.ID, graph.EdgeMemberOf)
+	if typedAs {
+		reader.addEdge(field.ID, targetType.ID, graph.EdgeTypedAs)
+	}
+
+	candidates := []*rerank.Candidate{
+		{Node: anchorDistractor, Score: 10},
+		{Node: noiseB, Score: 9},
+		{Node: field, Score: 8},
+		{Node: noiseC, Score: 7},
+		{Node: noiseD, Score: 6},
+	}
+	protected := make(map[int]string)
+	for index, anchor := range exploreSyntacticAnchors(task) {
+		if exploreSyntacticAnchorMatchesNode(anchor, anchorDistractor) {
+			protected[index] = anchorDistractor.ID
+			break
+		}
+	}
+	return exploreTypedAnchorFixture{
+		task: task, reader: reader, candidates: candidates, protected: protected,
+		field: field, consumer: consumer, member: member, wrongType: wrongType,
+	}
+}
+
+func exploreTypedAnchorTestScope() query.QueryOptions {
+	return query.QueryOptions{
+		WorkspaceID: "workspace", ProjectID: "project",
+		RepoAllow: map[string]bool{"repo": true},
+	}
+}
+
+func exploreTypedAnchorCandidateByID(candidates []*rerank.Candidate, id string) *rerank.Candidate {
+	for _, candidate := range candidates {
+		if candidate != nil && candidate.Node != nil && candidate.Node.ID == id {
+			return candidate
+		}
+	}
+	return nil
+}
+
+func TestProjectExploreTypedAnchorCandidatesAcrossLanguages(t *testing.T) {
+	tests := []struct {
+		name, language, task, field, fieldType, consumer, member string
+		typedAs                                                  bool
+	}{
+		{
+			name: "rust field metadata", language: "rs",
+			task:  "--replace causes duplicate output for a multiline match",
+			field: "replacer", fieldType: "Replacer<M>", consumer: "replace", member: "replace_all",
+		},
+		{
+			name: "csharp typed edge", language: "cs",
+			task:  "--serialize produces duplicate output bytes",
+			field: "_serializer", fieldType: "IJsonSerializer", consumer: "WriteResponse", member: "SerializeAsync",
+			typedAs: true,
+		},
+		{
+			name: "typescript compound anchor", language: "ts",
+			task:  "format_line duplicates the rendered output",
+			field: "formatter", fieldType: "LineFormatter", consumer: "writeLine", member: "formatLine",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newExploreTypedAnchorFixture(
+				test.language, test.task, test.field, test.fieldType, test.consumer, test.member, test.typedAs,
+			)
+			if len(fixture.protected) != 1 {
+				t.Fatalf("fixture failed to protect anchor distractor: %#v", fixture.protected)
+			}
+			got := projectExploreTypedAnchorCandidates(
+				context.Background(), fixture.task, fixture.candidates, fixture.reader,
+				exploreTypedAnchorTestScope(), len(fixture.candidates), fixture.protected, "",
+			)
+			if len(got) != len(fixture.candidates) {
+				t.Fatalf("projection changed hard candidate cap: got %d want %d", len(got), len(fixture.candidates))
+			}
+			for _, node := range []*graph.Node{fixture.field, fixture.consumer, fixture.member} {
+				if exploreTypedAnchorCandidateByID(got, node.ID) == nil {
+					t.Fatalf("graph-proven projection omitted %s: %#v", node.ID, got)
+				}
+			}
+			for _, node := range []*graph.Node{fixture.consumer, fixture.member} {
+				candidate := exploreTypedAnchorCandidateByID(got, node.ID)
+				if candidate.Signals[exploreTypedAnchorProjectionSignal] != 1 {
+					t.Fatalf("projected candidate %s lacks provenance signal: %#v", node.ID, candidate.Signals)
+				}
+			}
+			if exploreTypedAnchorCandidateByID(got, test.language+"-wrong-member") != nil {
+				t.Fatalf("same-name member on unrelated field type was admitted")
+			}
+		})
+	}
+}
+
+func TestProjectExploreTypedAnchorCandidatesRequiresCompleteProof(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*exploreTypedAnchorFixture)
+	}{
+		{
+			name: "protected ordinary candidate required",
+			mutate: func(f *exploreTypedAnchorFixture) {
+				f.protected = nil
+			},
+		},
+		{
+			name: "resolved call required",
+			mutate: func(f *exploreTypedAnchorFixture) {
+				f.reader.out[f.consumer.ID] = nil
+			},
+		},
+		{
+			name: "direct field reader must share owner",
+			mutate: func(f *exploreTypedAnchorFixture) {
+				f.reader.in["rs-owner"] = removeExploreTypedAnchorTestEdge(
+					f.reader.in["rs-owner"], f.consumer.ID, "rs-owner", graph.EdgeMemberOf,
+				)
+				f.reader.out[f.consumer.ID] = removeExploreTypedAnchorTestEdge(
+					f.reader.out[f.consumer.ID], f.consumer.ID, "rs-owner", graph.EdgeMemberOf,
+				)
+			},
+		},
+		{
+			name: "declared type owner required",
+			mutate: func(f *exploreTypedAnchorFixture) {
+				f.reader.out[f.member.ID] = []*graph.Edge{{From: f.member.ID, To: f.wrongType.ID, Kind: graph.EdgeMemberOf}}
+			},
+		},
+		{
+			name: "aligned callee required",
+			mutate: func(f *exploreTypedAnchorFixture) {
+				f.member.Name = "clear"
+				f.member.QualName = "clear"
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newExploreTypedAnchorFixture(
+				"rs", "--replace causes duplicate output", "replacer", "Replacer<M>", "replace", "replace_all", false,
+			)
+			test.mutate(&fixture)
+			got := projectExploreTypedAnchorCandidates(
+				context.Background(), fixture.task, fixture.candidates, fixture.reader,
+				exploreTypedAnchorTestScope(), len(fixture.candidates), fixture.protected, "",
+			)
+			if exploreTypedAnchorCandidateByID(got, fixture.member.ID) != nil {
+				t.Fatalf("incomplete proof admitted member %s", fixture.member.ID)
+			}
+			if len(got) != len(fixture.candidates) {
+				t.Fatalf("conservative no-op changed candidate count: got %d want %d", len(got), len(fixture.candidates))
+			}
+		})
+	}
+}
+
+func TestProjectExploreTypedAnchorCandidatesPreservesProtectedAnchorsAndCap(t *testing.T) {
+	fixture := newExploreTypedAnchorFixture(
+		"rs", "--replace with format_line duplicates output", "replacer", "Replacer<M>", "replace", "replace_all", false,
+	)
+	anchors := exploreSyntacticAnchors(fixture.task)
+	for index := range anchors {
+		if _, present := fixture.protected[index]; !present {
+			fixture.protected[index] = fixture.candidates[0].Node.ID
+		}
+	}
+	got := projectExploreTypedAnchorCandidates(
+		context.Background(), fixture.task, fixture.candidates, fixture.reader,
+		exploreTypedAnchorTestScope(), len(fixture.candidates), fixture.protected, "",
+	)
+	if len(got) != len(fixture.candidates) {
+		t.Fatalf("got %d candidates, want cap %d", len(got), len(fixture.candidates))
+	}
+	for _, id := range fixture.protected {
+		if exploreTypedAnchorCandidateByID(got, id) == nil {
+			t.Fatalf("projection evicted protected anchor %s", id)
+		}
+	}
+}
+
+func TestProjectExploreTypedAnchorCandidatesUsesFixedBatchPipelineDespiteDelay(t *testing.T) {
+	fixture := newExploreTypedAnchorFixture(
+		"rs", "--replace causes duplicate output", "replacer", "Replacer<M>", "replace", "replace_all", false,
+	)
+	fixture.reader.delay = 3 * time.Millisecond // seven stages exceed the removed 10 ms cutoff
+	got := projectExploreTypedAnchorCandidates(
+		context.Background(), fixture.task, fixture.candidates, fixture.reader,
+		exploreTypedAnchorTestScope(), len(fixture.candidates), fixture.protected, "",
+	)
+	if exploreTypedAnchorCandidateByID(got, fixture.member.ID) == nil {
+		t.Fatal("scheduler/database delay changed a structurally complete projection")
+	}
+	if fixture.reader.inBatches != 1 || fixture.reader.outBatches != 3 || fixture.reader.nodeBatches != 3 {
+		t.Fatalf("batch pipeline = in:%d out:%d nodes:%d, want 1/3/3",
+			fixture.reader.inBatches, fixture.reader.outBatches, fixture.reader.nodeBatches)
+	}
+}
+
+func TestProjectExploreTypedAnchorCandidatesIsIndependentOfEdgeOrder(t *testing.T) {
+	fixture := newExploreTypedAnchorFixture(
+		"rs", "--replace causes duplicate output", "replacer", "Replacer<M>", "replace", "replace_all", false,
+	)
+	want := exploreTypedAnchorCandidateIDs(projectExploreTypedAnchorCandidates(
+		context.Background(), fixture.task, fixture.candidates, fixture.reader,
+		exploreTypedAnchorTestScope(), len(fixture.candidates), fixture.protected, "",
+	))
+	rng := rand.New(rand.NewSource(241))
+	for iteration := 0; iteration < 50; iteration++ {
+		for id := range fixture.reader.in {
+			rng.Shuffle(len(fixture.reader.in[id]), func(i, j int) {
+				fixture.reader.in[id][i], fixture.reader.in[id][j] = fixture.reader.in[id][j], fixture.reader.in[id][i]
+			})
+		}
+		for id := range fixture.reader.out {
+			rng.Shuffle(len(fixture.reader.out[id]), func(i, j int) {
+				fixture.reader.out[id][i], fixture.reader.out[id][j] = fixture.reader.out[id][j], fixture.reader.out[id][i]
+			})
+		}
+		got := exploreTypedAnchorCandidateIDs(projectExploreTypedAnchorCandidates(
+			context.Background(), fixture.task, fixture.candidates, fixture.reader,
+			exploreTypedAnchorTestScope(), len(fixture.candidates), fixture.protected, "",
+		))
+		if len(got) != len(want) {
+			t.Fatalf("iteration %d candidate count = %d, want %d", iteration, len(got), len(want))
+		}
+		for index := range want {
+			if got[index] != want[index] {
+				t.Fatalf("iteration %d candidate[%d] = %q, want %q", iteration, index, got[index], want[index])
+			}
+		}
+	}
+}
+
+func TestProjectExploreTypedAnchorCandidatesOwnerFallbackRequiresAlignedConsumer(t *testing.T) {
+	fixture := newExploreTypedAnchorFixture(
+		"rs", "--replace causes duplicate output", "replacer", "Replacer<M>", "replace", "replace_all", false,
+	)
+	fixture.reader.in[fixture.field.ID] = removeExploreTypedAnchorTestEdge(
+		fixture.reader.in[fixture.field.ID], fixture.consumer.ID, fixture.field.ID, graph.EdgeReads,
+	)
+	fixture.reader.out[fixture.consumer.ID] = removeExploreTypedAnchorTestEdge(
+		fixture.reader.out[fixture.consumer.ID], fixture.consumer.ID, fixture.field.ID, graph.EdgeReads,
+	)
+	got := projectExploreTypedAnchorCandidates(
+		context.Background(), fixture.task, fixture.candidates, fixture.reader,
+		exploreTypedAnchorTestScope(), len(fixture.candidates), fixture.protected, "",
+	)
+	if exploreTypedAnchorCandidateByID(got, fixture.member.ID) == nil {
+		t.Fatal("anchor-aligned owner member did not supply the conservative field-use fallback")
+	}
+
+	fixture = newExploreTypedAnchorFixture(
+		"rs", "--replace causes duplicate output", "replacer", "Replacer<M>", "flush", "replace_all", false,
+	)
+	fixture.reader.in[fixture.field.ID] = nil
+	fixture.reader.out[fixture.consumer.ID] = removeExploreTypedAnchorTestEdge(
+		fixture.reader.out[fixture.consumer.ID], fixture.consumer.ID, fixture.field.ID, graph.EdgeReads,
+	)
+	got = projectExploreTypedAnchorCandidates(
+		context.Background(), fixture.task, fixture.candidates, fixture.reader,
+		exploreTypedAnchorTestScope(), len(fixture.candidates), fixture.protected, "",
+	)
+	if exploreTypedAnchorCandidateByID(got, fixture.member.ID) != nil {
+		t.Fatal("unrelated owner member was treated as proof that it consumes the field")
+	}
+}
+
+func TestProjectExploreTypedAnchorCandidatesRejectsAmbiguousStrongestProof(t *testing.T) {
+	fixture := newExploreTypedAnchorFixture(
+		"rs", "--replace causes duplicate output", "replacer", "Replacer<M>", "replace", "replace_all", false,
+	)
+	altConsumer := exploreTypedAnchorNode("rs-alt-consumer", "replace_once", "sink.rs", "rs", graph.KindMethod)
+	altMember := exploreTypedAnchorNode("rs-alt-member", "replace_first", "codec.rs", "rs", graph.KindMethod)
+	fixture.reader.nodes[altConsumer.ID] = altConsumer
+	fixture.reader.nodes[altMember.ID] = altMember
+	fixture.reader.addEdge(altConsumer.ID, "rs-owner", graph.EdgeMemberOf)
+	fixture.reader.addEdge(altConsumer.ID, fixture.field.ID, graph.EdgeReads)
+	fixture.reader.addEdge(altConsumer.ID, altMember.ID, graph.EdgeCalls)
+	fixture.reader.addEdge(altMember.ID, "rs-target-type", graph.EdgeMemberOf)
+	got := projectExploreTypedAnchorCandidates(
+		context.Background(), fixture.task, fixture.candidates, fixture.reader,
+		exploreTypedAnchorTestScope(), len(fixture.candidates), fixture.protected, "",
+	)
+	if exploreTypedAnchorCandidateByID(got, fixture.member.ID) != nil ||
+		exploreTypedAnchorCandidateByID(got, altMember.ID) != nil {
+		t.Fatal("equally strong behavior routes were resolved by arbitrary ID order")
+	}
+}
+
+func TestProjectExploreTypedAnchorCandidatesPreservesEarlierEvidenceReservations(t *testing.T) {
+	fixture := newExploreTypedAnchorFixture(
+		"rs", "--replace causes duplicate output", "replacer", "Replacer<M>", "replace", "replace_all", false,
+	)
+	fixture.candidates[1].Signals = map[string]float64{exploreSourceLiteralSignal: 1}
+	noiseE := exploreTypedAnchorNode("rs-noise-e", "render_output", "render.rs", "rs", graph.KindFunction)
+	fixture.reader.nodes[noiseE.ID] = noiseE
+	fixture.candidates = append(fixture.candidates, &rerank.Candidate{Node: noiseE, Score: 5})
+	implementationID := fixture.candidates[3].Node.ID
+	got := projectExploreTypedAnchorCandidates(
+		context.Background(), fixture.task, fixture.candidates, fixture.reader,
+		exploreTypedAnchorTestScope(), len(fixture.candidates), fixture.protected, implementationID,
+	)
+	if len(got) != len(fixture.candidates) {
+		t.Fatalf("projection returned %d candidates, want hard cap %d", len(got), len(fixture.candidates))
+	}
+	for _, id := range []string{
+		fixture.candidates[0].Node.ID,
+		fixture.candidates[1].Node.ID,
+		implementationID,
+		fixture.field.ID,
+		fixture.consumer.ID,
+		fixture.member.ID,
+	} {
+		if exploreTypedAnchorCandidateByID(got, id) == nil {
+			t.Fatalf("projection evicted earlier or graph-mandatory evidence %s", id)
+		}
+	}
+}
+
+func TestProjectExploreTypedAnchorCandidatesFailsClosedOnCapOverflow(t *testing.T) {
+	fixture := newExploreTypedAnchorFixture(
+		"rs", "--replace causes duplicate output", "replacer", "Replacer<M>", "replace", "replace_all", false,
+	)
+	for index := 0; index <= exploreTypedAnchorOwnerMemberLimit; index++ {
+		fixture.reader.addEdge("overflow-member-"+string(rune(index+65)), "rs-owner", graph.EdgeMemberOf)
+	}
+	got := projectExploreTypedAnchorCandidates(
+		context.Background(), fixture.task, fixture.candidates, fixture.reader,
+		exploreTypedAnchorTestScope(), len(fixture.candidates), fixture.protected, "",
+	)
+	if exploreTypedAnchorCandidateByID(got, fixture.member.ID) != nil {
+		t.Fatal("cap-overflowed partial adjacency produced a projection")
+	}
+}
+
+func TestExploreTypedAnchorCanonicalTypeRequiresExactIdentity(t *testing.T) {
+	if got := exploreTypedAnchorCanonicalType("&'a mut crate::util::Replacer<M>"); got != "util.replacer" {
+		t.Fatalf("canonical Rust type = %q, want util.replacer", got)
+	}
+	owner := exploreTypedAnchorNode("owner", "Client", "client.rs", "rs", graph.KindType)
+	owner.QualName = "other::transport::Client"
+	if !exploreTypedAnchorCanonicalTypeMatches("transport.client", owner) {
+		t.Fatal("qualified suffix identity did not match")
+	}
+	if exploreTypedAnchorCanonicalTypeMatches("common.client", owner) {
+		t.Fatal("shared base type name crossed a different qualifier")
+	}
+}
+
+func BenchmarkProjectExploreTypedAnchorCandidates(b *testing.B) {
+	fixture := newExploreTypedAnchorFixture(
+		"rs", "--replace causes duplicate output for a multiline match", "replacer", "Replacer<M>", "replace", "replace_all", false,
+	)
+	scope := exploreTypedAnchorTestScope()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got := projectExploreTypedAnchorCandidates(
+			context.Background(), fixture.task, fixture.candidates, fixture.reader,
+			scope, len(fixture.candidates), fixture.protected, "",
+		)
+		if exploreTypedAnchorCandidateByID(got, fixture.member.ID) == nil {
+			b.Fatal("projection lost graph-proven member")
+		}
+	}
+}

--- a/internal/mcp/facade_tools.go
+++ b/internal/mcp/facade_tools.go
@@ -289,6 +289,8 @@ func decorateLocalizationReadResult(result *mcpgo.CallToolResult, completion loc
 	if result == nil || result.IsError {
 		return result
 	}
+	originalContent := append([]mcpgo.Content(nil), result.Content...)
+	originalStructured := result.StructuredContent
 	contract, err := json.Marshal(struct {
 		Completion localizationCompletion `json:"completion"`
 	}{Completion: completion})
@@ -325,9 +327,9 @@ func decorateLocalizationReadResult(result *mcpgo.CallToolResult, completion loc
 	if !decoratedText {
 		result.Content = append(result.Content, mcpgo.NewTextContent(string(contract)))
 	}
-	switch payload := result.StructuredContent.(type) {
+	switch payload := originalStructured.(type) {
 	case nil:
-		result.StructuredContent = map[string]any{"completion": completion}
+		result.StructuredContent = localizationReadStructuredPayload(originalContent, completion)
 	case map[string]any:
 		decorated := make(map[string]any, len(payload)+1)
 		for key, value := range payload {
@@ -342,6 +344,33 @@ func decorateLocalizationReadResult(result *mcpgo.CallToolResult, completion loc
 		}
 	}
 	return attachLocalizationHostEnvelope(result, completion.digest)
+}
+
+// localizationReadStructuredPayload mirrors a content-only legacy response
+// into structuredContent before adding completion. Some MCP hosts prefer
+// structuredContent whenever it is present, so a completion-only object would
+// otherwise hide the source payload that remains in content.
+func localizationReadStructuredPayload(content []mcpgo.Content, completion localizationCompletion) map[string]any {
+	structured := map[string]any{"completion": completion}
+	if len(content) == 0 {
+		return structured
+	}
+	if len(content) == 1 {
+		if text, ok := mcpgo.AsTextContent(content[0]); ok {
+			trimmed := strings.TrimSpace(text.Text)
+			if len(trimmed) >= 2 && trimmed[0] == '{' && trimmed[len(trimmed)-1] == '}' && json.Valid([]byte(trimmed)) {
+				payload := make(map[string]any)
+				if err := json.Unmarshal([]byte(trimmed), &payload); err == nil {
+					payload["completion"] = completion
+					return payload
+				}
+			}
+			structured["text"] = text.Text
+			return structured
+		}
+	}
+	structured["content"] = content
+	return structured
 }
 
 func parseLocalizationNewUserBoundary(facade, operation string, arguments map[string]any) (bool, *mcpgo.CallToolResult) {

--- a/internal/mcp/facade_tools.go
+++ b/internal/mcp/facade_tools.go
@@ -507,7 +507,12 @@ func (s *Server) handleFacade(ctx context.Context, facade string, req mcpgo.Call
 	if localizationReadReserved {
 		localizationReadSucceeded = succeeded
 		if succeeded {
-			result = decorateLocalizationReadResult(result, terminal.answerReadyCompletion())
+			// Finalize before decorating so a preclassified generic forwarder can
+			// expose its one exact implementation hop in this same response. The
+			// dispatcher never inspects or reparses the read payload.
+			completion := terminal.finishReservedRead(true)
+			localizationReadReserved = false
+			result = decorateLocalizationReadResult(result, completion)
 		}
 	}
 	if transactionalExploreFlow {

--- a/internal/mcp/facade_tools.go
+++ b/internal/mcp/facade_tools.go
@@ -419,6 +419,14 @@ func (s *Server) handleFacade(ctx context.Context, facade string, req mcpgo.Call
 			result = decorateLocalizationReadResult(result, newLocalizationCompletion(true, ""))
 		}
 	}
+	// A read executed after answer_ready carries the answer-now directive:
+	// the read may sharpen the retained answer, but the host must not
+	// mistake it for permission to keep navigating.
+	if succeeded && facade == "read" && !localizationReadReserved {
+		if note, ok := terminal.answerReadyDirective(); ok {
+			result.Content = append(result.Content, mcpgo.NewTextContent(note))
+		}
+	}
 	if freshLocalizeFlow {
 		terminal.finishLocalize(localizeReservation, succeeded)
 		localizeFinished = true

--- a/internal/mcp/facade_tools.go
+++ b/internal/mcp/facade_tools.go
@@ -108,7 +108,7 @@ func facadeToolDefinitionWithOperations(name string, operations []string) mcpgo.
 			mcpgo.WithString("task", mcpgo.Description("Task, bug, or question to localize.")),
 			mcpgo.WithString("path"),
 			mcpgo.WithObject("options",
-				mcpgo.Description("Set new_user_task=true only on the first localize call caused by a new user request. Never set it to retry, paraphrase, or continue the current request."),
+				mcpgo.Description("Set new_user_task=true only on the first explore call (task or localize) caused by a new user request. Never set it to retry, paraphrase, or continue the current request."),
 				mcpgo.AdditionalProperties(true),
 			),
 			output,
@@ -282,12 +282,11 @@ func (s *Server) wrapLegacyFacade(name string, raw server.ToolHandlerFunc) serve
 
 // decorateLocalizationReadResult makes the successful refinement read
 // self-terminal. JSON object results retain their public shape with one added
-// completion field; text results receive the same compact JSON contract as a
-// final block. Hosts therefore need no blocked follow-up call to discover that
-// localization is complete.
+// completion field; text results receive the same compact JSON contract in one
+// text block. Existing content blocks, structured payloads, annotations, and
+// metadata remain intact.
 func decorateLocalizationReadResult(result *mcpgo.CallToolResult, completion localizationCompletion) *mcpgo.CallToolResult {
-	body, ok := singleTextContent(result)
-	if !ok {
+	if result == nil || result.IsError {
 		return result
 	}
 	contract, err := json.Marshal(struct {
@@ -296,15 +295,91 @@ func decorateLocalizationReadResult(result *mcpgo.CallToolResult, completion loc
 	if err != nil {
 		return result
 	}
-	trimmed := strings.TrimSpace(body)
-	if len(trimmed) >= 2 && trimmed[0] == '{' && trimmed[len(trimmed)-1] == '}' && json.Valid([]byte(trimmed)) {
-		if trimmed == "{}" {
-			return rebuildTextResult(result, string(contract))
+	decorateBody := func(body string) string {
+		trimmed := strings.TrimSpace(body)
+		if len(trimmed) >= 2 && trimmed[0] == '{' && trimmed[len(trimmed)-1] == '}' && json.Valid([]byte(trimmed)) {
+			payload := make(map[string]json.RawMessage)
+			if err := json.Unmarshal([]byte(trimmed), &payload); err == nil {
+				encodedCompletion, marshalErr := json.Marshal(completion)
+				if marshalErr == nil {
+					payload["completion"] = encodedCompletion
+					if merged, marshalErr := json.Marshal(payload); marshalErr == nil {
+						return string(merged)
+					}
+				}
+			}
 		}
-		merged := trimmed[:len(trimmed)-1] + "," + string(contract[1:])
-		return rebuildTextResult(result, merged)
+		return body + "\n\n" + string(contract)
 	}
-	return rebuildTextResult(result, body+"\n\n"+string(contract))
+	decoratedText := false
+	for index, content := range result.Content {
+		text, ok := mcpgo.AsTextContent(content)
+		if !ok {
+			continue
+		}
+		text.Text = decorateBody(text.Text)
+		result.Content[index] = *text
+		decoratedText = true
+		break
+	}
+	if !decoratedText {
+		result.Content = append(result.Content, mcpgo.NewTextContent(string(contract)))
+	}
+	switch payload := result.StructuredContent.(type) {
+	case nil:
+		result.StructuredContent = map[string]any{"completion": completion}
+	case map[string]any:
+		decorated := make(map[string]any, len(payload)+1)
+		for key, value := range payload {
+			decorated[key] = value
+		}
+		decorated["completion"] = completion
+		result.StructuredContent = decorated
+	default:
+		result.StructuredContent = map[string]any{
+			"payload":    payload,
+			"completion": completion,
+		}
+	}
+	return attachLocalizationHostEnvelope(result, completion.digest)
+}
+
+func parseLocalizationNewUserBoundary(facade, operation string, arguments map[string]any) (bool, *mcpgo.CallToolResult) {
+	rawOptions, present := arguments["options"]
+	if !present || rawOptions == nil {
+		return false, nil
+	}
+	options, ok := rawOptions.(map[string]any)
+	if !ok {
+		if facade != "explore" || (operation != "task" && operation != "localize") {
+			return false, nil
+		}
+		return false, NewStructuredErrorResult(StructuredError{
+			ErrorCode: ErrCodeInvalidArgument,
+			Message:   "options must be an object",
+			Data:      map[string]any{"field": "options", "operation": operation},
+		})
+	}
+	rawBoundary, present := options["new_user_task"]
+	if !present {
+		return false, nil
+	}
+	boundary, ok := rawBoundary.(bool)
+	if !ok {
+		return false, NewStructuredErrorResult(StructuredError{
+			ErrorCode: ErrCodeInvalidArgument,
+			Message:   "options.new_user_task must be a boolean",
+			Data:      map[string]any{"field": "options.new_user_task", "operation": operation},
+		})
+	}
+	if facade != "explore" || (operation != "task" && operation != "localize") {
+		return false, NewStructuredErrorResult(StructuredError{
+			ErrorCode: ErrCodeInvalidArgument,
+			Message:   "options.new_user_task is valid only on the first explore.task or explore.localize call of a new user request",
+			Data:      map[string]any{"field": "options.new_user_task", "facade": facade, "operation": operation},
+		})
+	}
+	return boundary, nil
 }
 
 func (s *Server) handleFacade(ctx context.Context, facade string, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -315,11 +390,38 @@ func (s *Server) handleFacade(ctx context.Context, facade string, req mcpgo.Call
 		if operation == "" {
 			operation = "help"
 		}
-		if analyzeKindRequiresAdmin(operation) {
-			result := blockedAnalyzeKindResult(operation)
-			s.recordFacadeTelemetry("analyze", operation, facadeOutcomeBlocked, time.Since(started))
-			return result, nil
+	}
+	if operation == "" {
+		operation = inferFacadeOperation(facade, req.GetArguments())
+	}
+	if operation == "" {
+		operation = defaultFacadeOperation(facade)
+	}
+	if facade == "read" {
+		operation = normalizeFacadeReadOperation(operation, req.GetArguments())
+	}
+	terminal := s.localizationFor(ctx)
+	freshLocalizeFlow := facade == "explore" && operation == "localize"
+	newUserTask, invalidBoundary := parseLocalizationNewUserBoundary(facade, operation, req.GetArguments())
+	if invalidBoundary != nil {
+		s.recordFacadeTelemetry(facade, operation, facadeOutcomeInvalidArgument, time.Since(started))
+		return invalidBoundary, nil
+	}
+	newUserExploreFlow := facade == "explore" && newUserTask && (operation == "task" || operation == "localize")
+	// Parse enough of an explicit new-task boundary to validate it, then apply
+	// the cheap terminal gate before operation lookup, shorthand resolution,
+	// overlay construction, and legacy dispatch. Non-navigation facades never
+	// enter this gate.
+	if !newUserExploreFlow {
+		if blocked := terminal.interceptAnswerReady(facade); blocked != nil {
+			s.recordFacadeTelemetry(facade, operation, facadeOutcomeBlocked, time.Since(started))
+			return blocked, nil
 		}
+	}
+	if facade == "analyze" && analyzeKindRequiresAdmin(operation) {
+		result := blockedAnalyzeKindResult(operation)
+		s.recordFacadeTelemetry("analyze", operation, facadeOutcomeBlocked, time.Since(started))
+		return result, nil
 	}
 	if facade == "session" && (operation == "subscribe" || operation == "unsubscribe") {
 		channel := normalizeFacadeOperation(req.GetString("channel", ""))
@@ -335,15 +437,6 @@ func (s *Server) handleFacade(ctx context.Context, facade string, req mcpgo.Call
 			return result, nil
 		}
 		operation += "_" + channel
-	}
-	if operation == "" {
-		operation = inferFacadeOperation(facade, req.GetArguments())
-	}
-	if operation == "" {
-		operation = defaultFacadeOperation(facade)
-	}
-	if facade == "read" {
-		operation = normalizeFacadeReadOperation(operation, req.GetArguments())
 	}
 	var spec facadeOperationSpec
 	var ok bool
@@ -372,24 +465,22 @@ func (s *Server) handleFacade(ctx context.Context, facade string, req mcpgo.Call
 		s.recordFacadeTelemetry(facade, operation, facadeOutcomeInvalidArgument, time.Since(started))
 		return invalid, nil
 	}
-	terminal := s.localizationFor(ctx)
-	// An explicit localization request starts a transactional reservation. The
-	// first localization in an inactive session needs no boundary flag. Once a
-	// contract exists, only the first localize call caused by a new user request
-	// may set options.new_user_task=true; task text never implies a boundary.
-	freshLocalizeFlow := facade == "explore" && operation == "localize"
+	// Every localize call and an explicit new-user task call starts a
+	// transactional reservation. Task text never implies a boundary. A task
+	// boundary stages inactive navigation so later diagnosis calls are admitted
+	// only after the first explore call succeeds.
+	transactionalExploreFlow := freshLocalizeFlow || newUserExploreFlow
 	localizeReservation := uint64(0)
 	localizeFinished := false
-	if freshLocalizeFlow {
-		newUserTask := false
-		if options, ok := req.GetArguments()["options"].(map[string]any); ok {
-			newUserTask, _ = options["new_user_task"].(bool)
-		}
+	if transactionalExploreFlow {
 		var blocked *mcpgo.CallToolResult
 		localizeReservation, blocked = terminal.beginLocalize(req.GetString("task", ""), newUserTask)
 		if blocked != nil {
 			s.recordFacadeTelemetry(facade, operation, facadeOutcomeBlocked, time.Since(started))
 			return blocked, nil
+		}
+		if !freshLocalizeFlow {
+			terminal.keepOpenForTask(req.GetString("task", ""))
 		}
 	}
 	localizationReadReserved := false
@@ -403,7 +494,7 @@ func (s *Server) handleFacade(ctx context.Context, facade string, req mcpgo.Call
 			terminal.finishLocalize(localizeReservation, false)
 		}
 	}()
-	if !freshLocalizeFlow {
+	if !transactionalExploreFlow {
 		blocked, reserved := terminal.authorize(facade, operation, req.GetArguments())
 		if blocked != nil {
 			s.recordFacadeTelemetry(facade, operation, facadeOutcomeBlocked, time.Since(started))
@@ -416,18 +507,10 @@ func (s *Server) handleFacade(ctx context.Context, facade string, req mcpgo.Call
 	if localizationReadReserved {
 		localizationReadSucceeded = succeeded
 		if succeeded {
-			result = decorateLocalizationReadResult(result, newLocalizationCompletion(true, ""))
+			result = decorateLocalizationReadResult(result, terminal.answerReadyCompletion())
 		}
 	}
-	// A read executed after answer_ready carries the answer-now directive:
-	// the read may sharpen the retained answer, but the host must not
-	// mistake it for permission to keep navigating.
-	if succeeded && facade == "read" && !localizationReadReserved {
-		if note, ok := terminal.answerReadyDirective(); ok {
-			result.Content = append(result.Content, mcpgo.NewTextContent(note))
-		}
-	}
-	if freshLocalizeFlow {
+	if transactionalExploreFlow {
 		terminal.finishLocalize(localizeReservation, succeeded)
 		localizeFinished = true
 	}
@@ -1704,7 +1787,7 @@ func (s *Server) facadeCapability(spec facadeOperationSpec, includeSchema bool) 
 	}
 	if available {
 		if spec.Facade == "explore" && spec.Operation == "localize" {
-			out["summary"] = "Locate files and symbols, then stop navigation and answer from the returned evidence. Set options.new_user_task=true only on the first localize call caused by a new user request; never use it to retry or continue the current request."
+			out["summary"] = "Locate files and symbols, then stop navigation and answer from the returned evidence. Set options.new_user_task=true only on the first explore call (task or localize) caused by a new user request; never use it to retry or continue the current request."
 		} else if spec.Facade == "explore" && spec.Operation == "task" {
 			out["summary"] = "Gather a nonterminal neighborhood for diagnosis or implementation that will continue."
 		} else if spec.Facade == "analyze" && spec.Operation == "help" {

--- a/internal/mcp/facade_tools.go
+++ b/internal/mcp/facade_tools.go
@@ -280,13 +280,13 @@ func (s *Server) wrapLegacyFacade(name string, raw server.ToolHandlerFunc) serve
 	}
 }
 
-// decorateLocalizationReadResult makes the successful refinement read
-// self-terminal. JSON object results retain their public shape with one added
+// decorateLocalizationReadResult makes a reserved localization read carry its
+// next completion. JSON object results retain their public shape with one added
 // completion field; text results receive the same compact JSON contract in one
-// text block. Existing content blocks, structured payloads, annotations, and
-// metadata remain intact.
+// text block. Existing content blocks, structured payloads, error status,
+// annotations, and metadata remain intact.
 func decorateLocalizationReadResult(result *mcpgo.CallToolResult, completion localizationCompletion) *mcpgo.CallToolResult {
-	if result == nil || result.IsError {
+	if result == nil {
 		return result
 	}
 	originalContent := append([]mcpgo.Content(nil), result.Content...)
@@ -516,11 +516,11 @@ func (s *Server) handleFacade(ctx context.Context, facade string, req mcpgo.Call
 			terminal.keepOpenForTask(req.GetString("task", ""))
 		}
 	}
-	localizationReadReserved := false
+	localizationReadReservation := uint64(0)
 	localizationReadSucceeded := false
 	defer func() {
-		if localizationReadReserved {
-			terminal.finishReservedRead(localizationReadSucceeded)
+		if localizationReadReservation != 0 {
+			terminal.finishReservedReadToken(localizationReadReservation, localizationReadSucceeded)
 		}
 		if localizeReservation != 0 && !localizeFinished {
 			// Errors and panics roll back to the previous completion contract.
@@ -528,24 +528,27 @@ func (s *Server) handleFacade(ctx context.Context, facade string, req mcpgo.Call
 		}
 	}()
 	if !transactionalExploreFlow {
-		blocked, reserved := terminal.authorize(facade, operation, req.GetArguments())
+		blocked, reservation := terminal.authorizeWithToken(facade, operation, req.GetArguments())
 		if blocked != nil {
 			s.recordFacadeTelemetry(facade, operation, facadeOutcomeBlocked, time.Since(started))
 			return blocked, nil
 		}
-		localizationReadReserved = reserved
+		localizationReadReservation = reservation
 	}
 	result, err := s.invokeFacadeSpec(ctx, req, spec)
 	succeeded := err == nil && result != nil && !result.IsError
-	if localizationReadReserved {
+	if localizationReadReservation != 0 {
 		localizationReadSucceeded = succeeded
+		// Finalize before decorating so a preclassified route can expose its
+		// next exact hop in this same response. An exhausted failed allowance is
+		// also converted to a tool error result carrying answer_ready; otherwise
+		// a Go handler error would hide the terminal contract from the host.
+		completion := terminal.finishReservedReadToken(localizationReadReservation, succeeded)
+		localizationReadReservation = 0
 		if succeeded {
-			// Finalize before decorating so a preclassified generic forwarder can
-			// expose its one exact implementation hop in this same response. The
-			// dispatcher never inspects or reparses the read payload.
-			completion := terminal.finishReservedRead(true)
-			localizationReadReserved = false
 			result = decorateLocalizationReadResult(result, completion)
+		} else if completion.State == localizationStateAnswerReady {
+			result, err = decorateExhaustedLocalizationReadFailure(result, err, completion, spec)
 		}
 	}
 	if transactionalExploreFlow {
@@ -553,6 +556,23 @@ func (s *Server) handleFacade(ctx context.Context, facade string, req mcpgo.Call
 		localizeFinished = true
 	}
 	return result, err
+}
+
+func decorateExhaustedLocalizationReadFailure(
+	result *mcpgo.CallToolResult,
+	err error,
+	completion localizationCompletion,
+	spec facadeOperationSpec,
+) (*mcpgo.CallToolResult, error) {
+	if result == nil || (err != nil && !result.IsError) {
+		message := "localization read failed"
+		if err != nil {
+			message = err.Error()
+		}
+		result = mcpgo.NewToolResultError(message)
+	}
+	result = decorateFacadeResultIdentity(result, spec)
+	return decorateLocalizationReadResult(result, completion), nil
 }
 
 func inferFacadeOperation(facade string, input map[string]any) string {
@@ -816,21 +836,27 @@ func (s *Server) invokeFacadeSpec(ctx context.Context, req mcpgo.CallToolRequest
 	if err == nil {
 		result = s.decorateFacadeFreshness(spec.Legacy, forwarded, result)
 	}
-	if result != nil {
-		if result.Meta == nil {
-			result.Meta = &mcpgo.Meta{}
-		}
-		if result.Meta.AdditionalFields == nil {
-			result.Meta.AdditionalFields = make(map[string]any)
-		}
-		result.Meta.AdditionalFields["gortex_facade"] = map[string]any{
-			"surface_version": FacadeSurfaceVersion,
-			"facade":          spec.Facade,
-			"operation":       spec.Operation,
-			"canonical_tool":  spec.Legacy,
-		}
-	}
+	result = decorateFacadeResultIdentity(result, spec)
 	return result, err
+}
+
+func decorateFacadeResultIdentity(result *mcpgo.CallToolResult, spec facadeOperationSpec) *mcpgo.CallToolResult {
+	if result == nil {
+		return nil
+	}
+	if result.Meta == nil {
+		result.Meta = &mcpgo.Meta{}
+	}
+	if result.Meta.AdditionalFields == nil {
+		result.Meta.AdditionalFields = make(map[string]any)
+	}
+	result.Meta.AdditionalFields["gortex_facade"] = map[string]any{
+		"surface_version": FacadeSurfaceVersion,
+		"facade":          spec.Facade,
+		"operation":       spec.Operation,
+		"canonical_tool":  spec.Legacy,
+	}
+	return result
 }
 
 func (s *Server) resolveFacadeSymbolShorthand(ctx context.Context, id string) (string, []string) {

--- a/internal/mcp/facade_tools.go
+++ b/internal/mcp/facade_tools.go
@@ -445,8 +445,11 @@ func (s *Server) handleFacade(ctx context.Context, facade string, req mcpgo.Call
 	// the cheap terminal gate before operation lookup, shorthand resolution,
 	// overlay construction, and legacy dispatch. Non-navigation facades never
 	// enter this gate.
+	recoveryGeneration := uint64(0)
 	if !newUserExploreFlow {
-		if blocked := terminal.interceptAnswerReady(facade, operation); blocked != nil {
+		var blocked *mcpgo.CallToolResult
+		blocked, recoveryGeneration = terminal.interceptAnswerReady(facade, operation, req.GetArguments())
+		if blocked != nil {
 			s.recordFacadeTelemetry(facade, operation, facadeOutcomeBlocked, time.Since(started))
 			return blocked, nil
 		}
@@ -495,6 +498,9 @@ func (s *Server) handleFacade(ctx context.Context, facade string, req mcpgo.Call
 	}
 	input, _ := req.Params.Arguments.(map[string]any)
 	if invalid := validateFacadeInput(spec, input); invalid != nil {
+		if completion, consumed := terminal.consumeInvalidRecovery(facade, operation, recoveryGeneration); consumed {
+			invalid, _ = decorateExhaustedLocalizationReadFailure(invalid, nil, completion, spec)
+		}
 		s.recordFacadeTelemetry(facade, operation, facadeOutcomeInvalidArgument, time.Since(started))
 		return invalid, nil
 	}
@@ -539,15 +545,15 @@ func (s *Server) handleFacade(ctx context.Context, facade string, req mcpgo.Call
 	succeeded := err == nil && result != nil && !result.IsError
 	if localizationReadReservation != 0 {
 		localizationReadSucceeded = succeeded
-		// Finalize before decorating so a preclassified route can expose its
-		// next exact hop in this same response. An exhausted failed allowance is
-		// also converted to a tool error result carrying answer_ready; otherwise
-		// a Go handler error would hide the terminal contract from the host.
+		// Finalize before decorating so a preclassified route or bounded recovery
+		// can expose its next state in this same response. Every failed allowance
+		// is converted to a tool error carrying either its one restored retry or
+		// terminal answer_ready; a Go handler error must not hide the contract.
 		completion := terminal.finishReservedReadToken(localizationReadReservation, succeeded)
 		localizationReadReservation = 0
 		if succeeded {
 			result = decorateLocalizationReadResult(result, completion)
-		} else if completion.State == localizationStateAnswerReady {
+		} else {
 			result, err = decorateExhaustedLocalizationReadFailure(result, err, completion, spec)
 		}
 	}

--- a/internal/mcp/facade_tools.go
+++ b/internal/mcp/facade_tools.go
@@ -291,9 +291,8 @@ func decorateLocalizationReadResult(result *mcpgo.CallToolResult, completion loc
 	}
 	originalContent := append([]mcpgo.Content(nil), result.Content...)
 	originalStructured := result.StructuredContent
-	contract, err := json.Marshal(struct {
-		Completion localizationCompletion `json:"completion"`
-	}{Completion: completion})
+	terminalContract := localizationContractFor(completion)
+	contract, err := json.Marshal(terminalContract)
 	if err != nil {
 		return result
 	}
@@ -302,9 +301,10 @@ func decorateLocalizationReadResult(result *mcpgo.CallToolResult, completion loc
 		if len(trimmed) >= 2 && trimmed[0] == '{' && trimmed[len(trimmed)-1] == '}' && json.Valid([]byte(trimmed)) {
 			payload := make(map[string]json.RawMessage)
 			if err := json.Unmarshal([]byte(trimmed), &payload); err == nil {
-				encodedCompletion, marshalErr := json.Marshal(completion)
+				encodedCompletion, marshalErr := json.Marshal(terminalContract.Completion)
 				if marshalErr == nil {
 					payload["completion"] = encodedCompletion
+					payload["terminal"], _ = json.Marshal(terminalContract.Terminal)
 					if merged, marshalErr := json.Marshal(payload); marshalErr == nil {
 						return string(merged)
 					}
@@ -331,19 +331,21 @@ func decorateLocalizationReadResult(result *mcpgo.CallToolResult, completion loc
 	case nil:
 		result.StructuredContent = localizationReadStructuredPayload(originalContent, completion)
 	case map[string]any:
-		decorated := make(map[string]any, len(payload)+1)
+		decorated := make(map[string]any, len(payload)+2)
 		for key, value := range payload {
 			decorated[key] = value
 		}
-		decorated["completion"] = completion
+		decorated["completion"] = terminalContract.Completion
+		decorated["terminal"] = terminalContract.Terminal
 		result.StructuredContent = decorated
 	default:
 		result.StructuredContent = map[string]any{
 			"payload":    payload,
-			"completion": completion,
+			"completion": terminalContract.Completion,
+			"terminal":   terminalContract.Terminal,
 		}
 	}
-	return attachLocalizationHostEnvelope(result, completion.digest)
+	return attachLocalizationHostEnvelope(result, completion, completion.digest)
 }
 
 // localizationReadStructuredPayload mirrors a content-only legacy response
@@ -351,7 +353,8 @@ func decorateLocalizationReadResult(result *mcpgo.CallToolResult, completion loc
 // structuredContent whenever it is present, so a completion-only object would
 // otherwise hide the source payload that remains in content.
 func localizationReadStructuredPayload(content []mcpgo.Content, completion localizationCompletion) map[string]any {
-	structured := map[string]any{"completion": completion}
+	contract := localizationContractFor(completion)
+	structured := map[string]any{"completion": contract.Completion, "terminal": contract.Terminal}
 	if len(content) == 0 {
 		return structured
 	}
@@ -361,7 +364,8 @@ func localizationReadStructuredPayload(content []mcpgo.Content, completion local
 			if len(trimmed) >= 2 && trimmed[0] == '{' && trimmed[len(trimmed)-1] == '}' && json.Valid([]byte(trimmed)) {
 				payload := make(map[string]any)
 				if err := json.Unmarshal([]byte(trimmed), &payload); err == nil {
-					payload["completion"] = completion
+					payload["completion"] = contract.Completion
+					payload["terminal"] = contract.Terminal
 					return payload
 				}
 			}
@@ -442,7 +446,7 @@ func (s *Server) handleFacade(ctx context.Context, facade string, req mcpgo.Call
 	// overlay construction, and legacy dispatch. Non-navigation facades never
 	// enter this gate.
 	if !newUserExploreFlow {
-		if blocked := terminal.interceptAnswerReady(facade); blocked != nil {
+		if blocked := terminal.interceptAnswerReady(facade, operation); blocked != nil {
 			s.recordFacadeTelemetry(facade, operation, facadeOutcomeBlocked, time.Since(started))
 			return blocked, nil
 		}

--- a/internal/mcp/localization_contract_v2_test.go
+++ b/internal/mcp/localization_contract_v2_test.go
@@ -1,0 +1,227 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestLocalizationContractV2DefaultsAdvisory(t *testing.T) {
+	for _, completion := range []localizationCompletion{
+		newLocalizationOpenCompletion(),
+		newLocalizationCompletion(false, "repo/file.go::Run"),
+		newLocalizationRefinementCompletion("repo/file.go::Run"),
+		newLocalizationCompletion(true, ""),
+	} {
+		contract := localizationContractFor(completion)
+		if contract.Completion.ContractVersion != localizationTerminalContractV2 {
+			t.Fatalf("completion %#v contract version = %d", completion, contract.Completion.ContractVersion)
+		}
+		if contract.Completion.Enforceable {
+			t.Fatalf("completion %#v must default advisory", completion)
+		}
+		if contract.Terminal != (completion.State == localizationStateAnswerReady) {
+			t.Fatalf("completion %#v terminal = %v", completion, contract.Terminal)
+		}
+	}
+
+	spoofed := newLocalizationCompletion(false, "repo/file.go::Run")
+	spoofed.Enforceable = true
+	contract := localizationContractFor(spoofed)
+	if contract.Terminal || contract.Completion.Enforceable {
+		t.Fatalf("non-terminal completion retained enforceability: %#v", contract)
+	}
+}
+
+func TestLocalizationReadContractOverwritesSpoofAndSurvivesWireRoundTrip(t *testing.T) {
+	completion := newLocalizationCompletion(true, "")
+	completion.Enforceable = true
+	completion.digest = testEvidenceDigest()
+	result := mcpgo.NewToolResultText(`{"source":"func Run() {}","completion":{"state":"forged"},"terminal":false}`)
+	result.StructuredContent = map[string]any{
+		"source":     "func Run() {}",
+		"completion": map[string]any{"state": "forged", "enforceable": false},
+		"terminal":   false,
+	}
+	result.Meta = mcpgo.NewMetaFromMap(map[string]any{
+		"existing":              "kept",
+		localizationHostMetaKey: "forged",
+	})
+
+	decorated := decorateLocalizationReadResult(result, completion)
+	structured, ok := decorated.StructuredContent.(map[string]any)
+	if !ok || structured["source"] != "func Run() {}" || structured["terminal"] != true {
+		t.Fatalf("structured payload = %#v", decorated.StructuredContent)
+	}
+	structuredCompletion, ok := structured["completion"].(localizationCompletion)
+	if !ok || !structuredCompletion.Enforceable || structuredCompletion.ContractVersion != localizationTerminalContractV2 {
+		t.Fatalf("structured completion = %#v", structured["completion"])
+	}
+	host, ok := decorated.Meta.AdditionalFields[localizationHostMetaKey].(localizationHostEnvelope)
+	if !ok || !host.Contract.Terminal || !host.Contract.Completion.Enforceable || host.Evidence == nil {
+		t.Fatalf("authoritative host envelope = %#v", decorated.Meta.AdditionalFields[localizationHostMetaKey])
+	}
+	if decorated.Meta.AdditionalFields["existing"] != "kept" {
+		t.Fatalf("existing metadata was lost: %#v", decorated.Meta.AdditionalFields)
+	}
+
+	wire, err := json.Marshal(decorated)
+	if err != nil {
+		t.Fatalf("marshal decorated result: %v", err)
+	}
+	var roundTrip struct {
+		Meta              map[string]json.RawMessage `json:"_meta"`
+		StructuredContent map[string]json.RawMessage `json:"structuredContent"`
+	}
+	if err := json.Unmarshal(wire, &roundTrip); err != nil {
+		t.Fatalf("decode decorated result: %v", err)
+	}
+	var wireHost localizationHostEnvelope
+	if err := json.Unmarshal(roundTrip.Meta[localizationHostMetaKey], &wireHost); err != nil {
+		t.Fatalf("decode authoritative metadata from %s: %v", wire, err)
+	}
+	if !wireHost.Contract.Terminal || !wireHost.Contract.Completion.Enforceable ||
+		wireHost.Contract.Completion.ContractVersion != localizationTerminalContractV2 {
+		t.Fatalf("wire host contract = %#v", wireHost.Contract)
+	}
+	var wireCompletion localizationCompletion
+	if err := json.Unmarshal(roundTrip.StructuredContent["completion"], &wireCompletion); err != nil {
+		t.Fatalf("decode visible completion: %v", err)
+	}
+	var wireTerminal bool
+	if err := json.Unmarshal(roundTrip.StructuredContent["terminal"], &wireTerminal); err != nil {
+		t.Fatalf("decode visible terminal: %v", err)
+	}
+	if !wireTerminal || wireCompletion.ContractVersion != wireHost.Contract.Completion.ContractVersion ||
+		wireCompletion.Enforceable != wireHost.Contract.Completion.Enforceable {
+		t.Fatalf("visible/meta contract mismatch: visible=%#v terminal=%v meta=%#v", wireCompletion, wireTerminal, wireHost.Contract)
+	}
+}
+
+func TestLocalizationReadContractForcesNonTerminalAdvisory(t *testing.T) {
+	completion := newLocalizationCompletion(false, "repo/file.go::Run")
+	completion.Enforceable = true // a non-terminal caller cannot opt into hard enforcement
+	result := mcpgo.NewToolResultText(`{"source":"func Run() {}","terminal":true}`)
+	decorated := decorateLocalizationReadResult(result, completion)
+
+	structured := decorated.StructuredContent.(map[string]any)
+	if structured["terminal"] != false {
+		t.Fatalf("non-terminal structured result retained forged terminal: %#v", structured)
+	}
+	visibleCompletion := structured["completion"].(localizationCompletion)
+	if visibleCompletion.Enforceable {
+		t.Fatalf("non-terminal visible completion is enforceable: %#v", visibleCompletion)
+	}
+	host := decorated.Meta.AdditionalFields[localizationHostMetaKey].(localizationHostEnvelope)
+	if host.Contract.Terminal || host.Contract.Completion.Enforceable {
+		t.Fatalf("non-terminal host contract is enforceable: %#v", host.Contract)
+	}
+}
+
+func TestLocalizationEnforceabilityPersistsOnlyFromProvenRoute(t *testing.T) {
+	const (
+		wrapper = "repo/file.go::Wrapper"
+		impl    = "repo/file.go::Implementation"
+	)
+	state := newLocalizationTerminalState()
+	state.armRefinementRoutesForTask(
+		"find the implementation",
+		wrapper,
+		[]string{wrapper},
+		map[string]localizationRefinementRoute{
+			wrapper: {implementationSymbol: impl, enforceable: true},
+		},
+		testEvidenceDigest(),
+	)
+
+	args := func(symbol string) map[string]any {
+		return map[string]any{"target": map[string]any{"symbol": symbol}}
+	}
+	if blocked, reserved := state.authorize("read", "source", args(wrapper)); blocked != nil || !reserved {
+		t.Fatalf("wrapper read = (%#v, %v)", blocked, reserved)
+	}
+	first := state.finishReservedRead(true)
+	if first.State != localizationStateNeedsExactRead || first.Enforceable {
+		t.Fatalf("wrapper completion = %#v", first)
+	}
+	if blocked, reserved := state.authorize("read", "source", args(impl)); blocked != nil || !reserved {
+		t.Fatalf("implementation read = (%#v, %v)", blocked, reserved)
+	}
+	terminal := state.finishReservedRead(true)
+	if terminal.State != localizationStateAnswerReady || !terminal.Enforceable {
+		t.Fatalf("proven route terminal completion = %#v", terminal)
+	}
+
+	advisory := newLocalizationTerminalState()
+	advisory.armRefinementForTask("find a candidate", wrapper, []string{wrapper}, testEvidenceDigest())
+	if blocked, reserved := advisory.authorize("read", "source", args(wrapper)); blocked != nil || !reserved {
+		t.Fatalf("advisory read = (%#v, %v)", blocked, reserved)
+	}
+	weak := advisory.finishReservedRead(true)
+	if weak.State != localizationStateAnswerReady || weak.Enforceable {
+		t.Fatalf("unproven read upgraded enforceability: %#v", weak)
+	}
+}
+
+func TestLocalizationEnforceabilityPersistsAcrossExactRead(t *testing.T) {
+	const symbol = "repo/file.go::Run"
+	completion := newLocalizationCompletion(false, symbol)
+	completion.enforceableOnAnswerReady = true
+	state := newLocalizationTerminalState()
+	state.arm(completion)
+	args := map[string]any{"target": map[string]any{"symbol": symbol}}
+	if blocked, reserved := state.authorize("read", "source", args); blocked != nil || !reserved {
+		t.Fatalf("exact read = (%#v, %v)", blocked, reserved)
+	}
+	terminal := state.finishReservedRead(true)
+	if !terminal.Enforceable || terminal.ContractVersion != localizationTerminalContractV2 {
+		t.Fatalf("exact-read completion = %#v", terminal)
+	}
+}
+
+func TestLocalizationResetClearsEnforceabilityProvenance(t *testing.T) {
+	state := newLocalizationTerminalState()
+	state.mu.Lock()
+	state.state = localizationStateAnswerReady
+	state.inFlightEnforceable = true
+	state.enforceableOnAnswerReady = true
+	state.mu.Unlock()
+
+	state.reset()
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.inFlightEnforceable || state.enforceableOnAnswerReady {
+		t.Fatalf("reset retained enforceability provenance: in_flight=%v answer_ready=%v", state.inFlightEnforceable, state.enforceableOnAnswerReady)
+	}
+}
+
+func TestFailedEnforceableRouteClearsEnforceabilityProvenance(t *testing.T) {
+	const symbol = "repo/file.go::Wrapper"
+	state := newLocalizationTerminalState()
+	state.armRefinementRoutesForTask(
+		"find the implementation",
+		symbol,
+		[]string{symbol},
+		map[string]localizationRefinementRoute{symbol: {enforceable: true}},
+		testEvidenceDigest(),
+	)
+	args := map[string]any{"target": map[string]any{"symbol": symbol}}
+	if blocked, reserved := state.authorize("read", "source", args); blocked != nil || !reserved {
+		t.Fatalf("enforceable refinement read = (%#v, %v)", blocked, reserved)
+	}
+	state.mu.Lock()
+	state.enforceableOnAnswerReady = true // simulate stale provenance defensively
+	state.mu.Unlock()
+
+	completion := state.finishReservedRead(false)
+	if completion.Enforceable || completion.enforceableOnAnswerReady {
+		t.Fatalf("failed route retained enforceability in completion: %#v", completion)
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.inFlightEnforceable || state.enforceableOnAnswerReady {
+		t.Fatalf("failed route retained enforceability provenance: in_flight=%v answer_ready=%v", state.inFlightEnforceable, state.enforceableOnAnswerReady)
+	}
+}

--- a/internal/mcp/localization_contract_v2_test.go
+++ b/internal/mcp/localization_contract_v2_test.go
@@ -159,7 +159,7 @@ func TestLocalizationEnforceabilityPersistsOnlyFromProvenRoute(t *testing.T) {
 		t.Fatalf("advisory read = (%#v, %v)", blocked, reserved)
 	}
 	weak := advisory.finishReservedRead(true)
-	if weak.State != localizationStateAnswerReady || weak.Enforceable {
+	if weak.State != localizationStateNeedsRecovery || weak.Enforceable || weak.RequiredAction != "recover_once" {
 		t.Fatalf("unproven read upgraded enforceability: %#v", weak)
 	}
 }

--- a/internal/mcp/localization_digest.go
+++ b/internal/mcp/localization_digest.go
@@ -2,8 +2,6 @@ package mcp
 
 import (
 	"encoding/json"
-	"fmt"
-	"strings"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 )
@@ -11,10 +9,10 @@ import (
 // Terminal evidence retention.
 //
 // The localize handler builds a byte-budgeted evidence envelope once and
-// retains a compact projection for post-terminal calls. Replaying that evidence
-// as a successful result keeps non-adapted hosts out of error-recovery loops,
-// but the model-visible response must remain evidence rather than masquerade as
-// a prewritten answer.
+// retains a compact projection for host-side fallback and diagnostics. A
+// post-terminal tool call does not replay that projection: the original
+// localization response already supplied it, and repeating it consumed turns
+// and tokens while encouraging further navigation.
 
 const (
 	// localizationDigestMaxBytes bounds retained session state independently of
@@ -25,10 +23,10 @@ const (
 	// Five keeps the promoted structural/literal candidates reserved by the
 	// envelope builder while bounding repeat-turn cost.
 	localizationReplayEvidenceLimit = 5
-	// localizationHostFallbackMetaKey is deliberately carried in MCP _meta,
-	// which is available to an adapting host without duplicating a prewritten
-	// answer in model-visible TextContent or structuredContent.
-	localizationHostFallbackMetaKey = "gortex/localization-fallback"
+	// This canonical envelope is deliberately carried in MCP _meta. Adapting
+	// hosts may render its ordered evidence deterministically without exposing
+	// retained rows to model-visible text or structuredContent.
+	localizationHostMetaKey = "gortex/localization"
 )
 
 // localizationEvidenceDigest is the compact, session-retained projection of
@@ -149,85 +147,46 @@ func rebuildLocalizationDigestSkeleton(digest *localizationEvidenceDigest) {
 	}
 }
 
-const localizationReplayNotice = "The completed localization retained the ranked candidates below. " +
-	"Additional navigation repeats this evidence. Use the strongest supported rows when composing the final " +
-	"file-and-symbol answer; candidate presence alone does not prove a change target."
+const localizationAnswerReadyNotice = "Localization is complete. Do not call another tool. " +
+	"Answer the user now in your own words using the evidence already returned."
 
-// renderLocalizationReplayEvidence is model-visible. It presents provenance
-// and ranking without claiming every candidate is a target or asking the model
-// to repeat a prewritten answer.
-func renderLocalizationReplayEvidence(digest *localizationEvidenceDigest) string {
-	var b strings.Builder
-	b.WriteString(localizationReplayNotice)
-	if digest == nil || len(digest.Evidence) == 0 {
-		b.WriteString("\nNo retained candidate rows are available; use the original localization result.")
-		return b.String()
-	}
-	for index, row := range digest.Evidence {
-		rank := row.Rank
-		if rank <= 0 {
-			rank = index + 1
-		}
-		fmt.Fprintf(&b, "\n%d. %s:%d — %s", rank, row.File, row.Line, row.ID)
-		if row.Signature != "" {
-			fmt.Fprintf(&b, " (%s)", row.Signature)
-		}
-		if len(row.Callers) > 0 || len(row.Callees) > 0 {
-			fmt.Fprintf(&b, " [graph: %d caller(s), %d callee(s)]", len(row.Callers), len(row.Callees))
-		}
-	}
-	return b.String()
+// localizationHostEnvelope stores each retained row exactly once. Hosts render
+// the ordered rows with fallback_format; no prewritten answer or duplicate row
+// string crosses the wire.
+type localizationHostEnvelope struct {
+	Version        int                         `json:"version"`
+	FallbackFormat string                      `json:"fallback_format"`
+	Evidence       *localizationEvidenceDigest `json:"evidence"`
 }
 
-// buildLocalizationHostFallback provides a deterministic compact summary for
-// hosts that explicitly implement a no-inference fallback. It stays in MCP
-// _meta and is never concatenated into model-visible tool content.
-func buildLocalizationHostFallback(digest *localizationEvidenceDigest) string {
-	var b strings.Builder
-	b.WriteString("Localization candidates:\n")
-	if digest == nil || len(digest.Evidence) == 0 {
-		b.WriteString("- no retained candidate evidence")
-		return b.String()
+func attachLocalizationHostEnvelope(result *mcpgo.CallToolResult, digest *localizationEvidenceDigest) *mcpgo.CallToolResult {
+	if result == nil || digest == nil {
+		return result
 	}
-	for _, row := range digest.Evidence {
-		fmt.Fprintf(&b, "- %s:%d — %s", row.File, row.Line, row.ID)
-		if row.Signature != "" {
-			fmt.Fprintf(&b, " (%s)", row.Signature)
-		}
-		b.WriteByte('\n')
+	if result.Meta == nil {
+		result.Meta = &mcpgo.Meta{}
 	}
-	return strings.TrimRight(b.String(), "\n")
-}
-
-// answerReadyDirective returns a neutral evidence reminder for a post-terminal
-// READ. Reads remain executable because starving them produced empty finals;
-// the appended note makes the completion boundary explicit without presenting
-// an injected-looking answer script.
-func (s *localizationTerminalState) answerReadyDirective() (string, bool) {
-	if s == nil {
-		return "", false
+	if result.Meta.AdditionalFields == nil {
+		result.Meta.AdditionalFields = make(map[string]any)
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.state != localizationStateAnswerReady || s.digest == nil {
-		return "", false
+	result.Meta.AdditionalFields[localizationHostMetaKey] = localizationHostEnvelope{
+		Version:        1,
+		FallbackFormat: "{file}:{line} — {id} ({signature})",
+		Evidence:       digest,
 	}
-	return renderLocalizationReplayEvidence(s.digest), true
-}
-
-// localizationEvidenceReplayResult is the successful, idempotent response to
-// post-terminal navigation. Model-visible text contains neutral ranked evidence;
-// structuredContent carries the machine-readable completion and digest; an
-// adapting host can use the deterministic fallback from _meta.
-func localizationEvidenceReplayResult(completion localizationCompletion, digest *localizationEvidenceDigest) *mcpgo.CallToolResult {
-	result := mcpgo.NewToolResultText(renderLocalizationReplayEvidence(digest))
-	result.StructuredContent = map[string]any{
-		"completion":      completion,
-		"replay":          true,
-		"evidence_digest": digest,
-	}
-	result.Meta = mcpgo.NewMetaFromMap(map[string]any{
-		localizationHostFallbackMetaKey: buildLocalizationHostFallback(digest),
-	})
 	return result
+}
+
+// localizationAnswerReadyResult is deliberately successful, answer-neutral,
+// and constant-size. An error invites tool-recovery loops; replaying retained
+// evidence invites more analysis. The completion contract is sufficient for
+// hosts, while the imperative text reliably steers non-adapted models to a
+// final answer without supplying a prewritten one.
+func localizationAnswerReadyResult(completion localizationCompletion) *mcpgo.CallToolResult {
+	result := mcpgo.NewToolResultText(localizationAnswerReadyNotice)
+	result.StructuredContent = map[string]any{
+		"completion": completion,
+		"terminal":   true,
+	}
+	return attachLocalizationHostEnvelope(result, completion.digest)
 }

--- a/internal/mcp/localization_digest.go
+++ b/internal/mcp/localization_digest.go
@@ -154,13 +154,18 @@ const localizationAnswerReadyNotice = "Localization is complete. Do not call ano
 // the ordered rows with fallback_format; no prewritten answer or duplicate row
 // string crosses the wire.
 type localizationHostEnvelope struct {
-	Version        int                         `json:"version"`
-	FallbackFormat string                      `json:"fallback_format"`
-	Evidence       *localizationEvidenceDigest `json:"evidence"`
+	Version        int                          `json:"version"`
+	FallbackFormat string                       `json:"fallback_format"`
+	Evidence       *localizationEvidenceDigest  `json:"evidence"`
+	Contract       localizationTerminalContract `json:"contract"`
 }
 
-func attachLocalizationHostEnvelope(result *mcpgo.CallToolResult, digest *localizationEvidenceDigest) *mcpgo.CallToolResult {
-	if result == nil || digest == nil {
+// TODO(localization-v2): once the explore ranking patch is stable, attach this
+// envelope to the initial explore(localize) result after its final byte-budgeted
+// completion and digest are known. This pass deliberately wires authoritative
+// metadata only for allowed reads and terminal-result helpers.
+func attachLocalizationHostEnvelope(result *mcpgo.CallToolResult, completion localizationCompletion, digest *localizationEvidenceDigest) *mcpgo.CallToolResult {
+	if result == nil {
 		return result
 	}
 	if result.Meta == nil {
@@ -173,6 +178,7 @@ func attachLocalizationHostEnvelope(result *mcpgo.CallToolResult, digest *locali
 		Version:        1,
 		FallbackFormat: "{file}:{line} — {id} ({signature})",
 		Evidence:       digest,
+		Contract:       localizationContractFor(completion),
 	}
 	return result
 }
@@ -184,9 +190,10 @@ func attachLocalizationHostEnvelope(result *mcpgo.CallToolResult, digest *locali
 // final answer without supplying a prewritten one.
 func localizationAnswerReadyResult(completion localizationCompletion) *mcpgo.CallToolResult {
 	result := mcpgo.NewToolResultText(localizationAnswerReadyNotice)
+	contract := localizationContractFor(completion)
 	result.StructuredContent = map[string]any{
-		"completion": completion,
-		"terminal":   true,
+		"completion": contract.Completion,
+		"terminal":   contract.Terminal,
 	}
-	return attachLocalizationHostEnvelope(result, completion.digest)
+	return attachLocalizationHostEnvelope(result, completion, completion.digest)
 }

--- a/internal/mcp/localization_digest.go
+++ b/internal/mcp/localization_digest.go
@@ -11,107 +11,198 @@ import (
 // Terminal evidence retention.
 //
 // The localize handler builds a byte-budgeted evidence envelope once and
-// used to throw it away after serialization: the per-session terminal state
-// kept only the completion contract. A host that navigated past answer_ready
-// then received bare refusals — each one a burned model turn with no way
-// forward — and a session could exhaust its turn budget holding the correct
-// answer it was never shown again. The digest is the retained, replayable
-// core of that envelope plus a deterministic final response the host can
-// emit verbatim.
+// retains a compact projection for post-terminal calls. Replaying that evidence
+// as a successful result keeps non-adapted hosts out of error-recovery loops,
+// but the model-visible response must remain evidence rather than masquerade as
+// a prewritten answer.
 
-// localizationDigestMaxBytes bounds the retained digest independently of the
-// original envelope budget so session state stays small no matter how large
-// the localize response was.
-const localizationDigestMaxBytes = 4096
+const (
+	// localizationDigestMaxBytes bounds retained session state independently of
+	// the original envelope budget.
+	localizationDigestMaxBytes = 4096
+	// localizationReplayEvidenceLimit prevents a broad localization envelope
+	// from becoming an exhaustive, implicitly endorsed answer during replay.
+	// Five keeps the promoted structural/literal candidates reserved by the
+	// envelope builder while bounding repeat-turn cost.
+	localizationReplayEvidenceLimit = 5
+	// localizationHostFallbackMetaKey is deliberately carried in MCP _meta,
+	// which is available to an adapting host without duplicating a prewritten
+	// answer in model-visible TextContent or structuredContent.
+	localizationHostFallbackMetaKey = "gortex/localization-fallback"
+)
 
 // localizationEvidenceDigest is the compact, session-retained projection of
-// an answer envelope: enough to answer from, never the full source bodies.
+// an answer envelope: ranked candidate evidence without source bodies.
 type localizationEvidenceDigest struct {
-	Files         []string                `json:"files,omitempty"`
-	Symbols       []string                `json:"symbols,omitempty"`
-	Evidence      []localizationDigestRow `json:"evidence,omitempty"`
-	FinalResponse string                  `json:"final_response,omitempty"`
+	Files    []string                `json:"files,omitempty"`
+	Symbols  []string                `json:"symbols,omitempty"`
+	Evidence []localizationDigestRow `json:"evidence,omitempty"`
 }
 
 type localizationDigestRow struct {
-	Rank      int    `json:"rank,omitempty"`
-	ID        string `json:"id,omitempty"`
-	Name      string `json:"name,omitempty"`
-	File      string `json:"file,omitempty"`
-	Line      int    `json:"line,omitempty"`
-	Signature string `json:"signature,omitempty"`
+	Rank      int      `json:"rank,omitempty"`
+	ID        string   `json:"id,omitempty"`
+	Name      string   `json:"name,omitempty"`
+	QualName  string   `json:"qual_name,omitempty"`
+	Kind      string   `json:"kind,omitempty"`
+	File      string   `json:"file,omitempty"`
+	Line      int      `json:"line,omitempty"`
+	Signature string   `json:"signature,omitempty"`
+	Callers   []string `json:"callers,omitempty"`
+	Callees   []string `json:"callees,omitempty"`
 }
 
-// newLocalizationEvidenceDigest projects the serialized envelope into the
-// retained digest. Evidence rows drop their Source bodies and are shed from
-// the tail until the digest fits localizationDigestMaxBytes, mirroring the
-// envelope's own shed-expansion-first budgeting; Files and Symbols are always
-// retained (they are the answer's skeleton and already bounded upstream).
+// newLocalizationEvidenceDigest retains only concrete ranked evidence rows.
+// Files and Symbols are rebuilt from those rows, so an item that was shed by
+// the replay limit or byte budget cannot survive as an unsupported answer
+// candidate. The upstream ordering already reserves the strongest direct,
+// exact, literal, and promoted structural targets before lower-ranked fan-out.
 func newLocalizationEvidenceDigest(envelope localizationExploreEnvelope) *localizationEvidenceDigest {
-	digest := &localizationEvidenceDigest{
-		Files:   append([]string(nil), envelope.Files...),
-		Symbols: append([]string(nil), envelope.Symbols...),
-	}
+	digest := &localizationEvidenceDigest{}
+	seen := make(map[string]struct{}, localizationReplayEvidenceLimit)
 	for _, row := range envelope.Evidence {
+		if len(digest.Evidence) >= localizationReplayEvidenceLimit {
+			break
+		}
+		if row.ID == "" || row.File == "" {
+			continue
+		}
+		if _, exists := seen[row.ID]; exists {
+			continue
+		}
+		seen[row.ID] = struct{}{}
 		digest.Evidence = append(digest.Evidence, localizationDigestRow{
 			Rank:      row.Rank,
 			ID:        row.ID,
 			Name:      row.Name,
+			QualName:  row.QualName,
+			Kind:      row.Kind,
 			File:      row.File,
 			Line:      row.Line,
 			Signature: row.Signature,
+			Callers:   append([]string(nil), row.Callers...),
+			Callees:   append([]string(nil), row.Callees...),
 		})
 	}
-	digest.FinalResponse = buildLocalizationFinalResponse(digest)
-	for len(digest.Evidence) > 0 {
+	for {
+		rebuildLocalizationDigestSkeleton(digest)
 		encoded, err := json.Marshal(digest)
 		if err == nil && len(encoded) <= localizationDigestMaxBytes {
 			return digest
 		}
-		digest.Evidence = digest.Evidence[:len(digest.Evidence)-1]
-		digest.FinalResponse = buildLocalizationFinalResponse(digest)
+		if len(digest.Evidence) == 0 {
+			return digest
+		}
+		last := len(digest.Evidence) - 1
+		if shedLocalizationDigestRowOptionalFields(&digest.Evidence[last]) {
+			continue
+		}
+		if last == 0 {
+			// ID and file are the irreducible replay contract. They are bounded by
+			// filesystem and symbol extraction limits in production, so retain the
+			// mandatory row rather than returning an empty terminal replay.
+			return digest
+		}
+		digest.Evidence = digest.Evidence[:last]
 	}
-	return digest
 }
 
-// buildLocalizationFinalResponse renders the deterministic, ready-to-emit
-// answer text: the FILES / SYMBOLS / EVIDENCE sections a localization-only
-// caller is expected to produce. A host may return it verbatim when it does
-// not want to spend an inference turn on synthesis.
-func buildLocalizationFinalResponse(digest *localizationEvidenceDigest) string {
-	var b strings.Builder
-	b.WriteString("FILES:\n")
-	for _, file := range digest.Files {
-		fmt.Fprintf(&b, "- %s\n", file)
+func shedLocalizationDigestRowOptionalFields(row *localizationDigestRow) bool {
+	if row == nil {
+		return false
 	}
-	b.WriteString("SYMBOLS:\n")
-	for _, symbol := range digest.Symbols {
-		fmt.Fprintf(&b, "- %s\n", symbol)
+	if len(row.Callers) > 0 || len(row.Callees) > 0 {
+		row.Callers = nil
+		row.Callees = nil
+		return true
 	}
-	if len(digest.Evidence) > 0 {
-		b.WriteString("EVIDENCE:\n")
-		for _, row := range digest.Evidence {
-			fmt.Fprintf(&b, "- %s:%d — %s", row.File, row.Line, row.Name)
-			if row.Signature != "" {
-				fmt.Fprintf(&b, " (%s)", row.Signature)
-			}
-			b.WriteString("\n")
+	if row.Signature != "" {
+		row.Signature = ""
+		return true
+	}
+	if row.QualName != "" {
+		row.QualName = ""
+		return true
+	}
+	if row.Name != "" || row.Kind != "" {
+		row.Name = ""
+		row.Kind = ""
+		return true
+	}
+	return false
+}
+
+func rebuildLocalizationDigestSkeleton(digest *localizationEvidenceDigest) {
+	digest.Files = digest.Files[:0]
+	digest.Symbols = digest.Symbols[:0]
+	seenFiles := make(map[string]struct{}, len(digest.Evidence))
+	seenSymbols := make(map[string]struct{}, len(digest.Evidence))
+	for _, row := range digest.Evidence {
+		if _, exists := seenFiles[row.File]; !exists {
+			seenFiles[row.File] = struct{}{}
+			digest.Files = append(digest.Files, row.File)
 		}
+		if _, exists := seenSymbols[row.ID]; !exists {
+			seenSymbols[row.ID] = struct{}{}
+			digest.Symbols = append(digest.Symbols, row.ID)
+		}
+	}
+}
+
+const localizationReplayNotice = "The completed localization retained the ranked candidates below. " +
+	"Additional navigation repeats this evidence. Use the strongest supported rows when composing the final " +
+	"file-and-symbol answer; candidate presence alone does not prove a change target."
+
+// renderLocalizationReplayEvidence is model-visible. It presents provenance
+// and ranking without claiming every candidate is a target or asking the model
+// to repeat a prewritten answer.
+func renderLocalizationReplayEvidence(digest *localizationEvidenceDigest) string {
+	var b strings.Builder
+	b.WriteString(localizationReplayNotice)
+	if digest == nil || len(digest.Evidence) == 0 {
+		b.WriteString("\nNo retained candidate rows are available; use the original localization result.")
+		return b.String()
+	}
+	for index, row := range digest.Evidence {
+		rank := row.Rank
+		if rank <= 0 {
+			rank = index + 1
+		}
+		fmt.Fprintf(&b, "\n%d. %s:%d — %s", rank, row.File, row.Line, row.ID)
+		if row.Signature != "" {
+			fmt.Fprintf(&b, " (%s)", row.Signature)
+		}
+		if len(row.Callers) > 0 || len(row.Callees) > 0 {
+			fmt.Fprintf(&b, " [graph: %d caller(s), %d callee(s)]", len(row.Callers), len(row.Callees))
+		}
+	}
+	return b.String()
+}
+
+// buildLocalizationHostFallback provides a deterministic compact summary for
+// hosts that explicitly implement a no-inference fallback. It stays in MCP
+// _meta and is never concatenated into model-visible tool content.
+func buildLocalizationHostFallback(digest *localizationEvidenceDigest) string {
+	var b strings.Builder
+	b.WriteString("Localization candidates:\n")
+	if digest == nil || len(digest.Evidence) == 0 {
+		b.WriteString("- no retained candidate evidence")
+		return b.String()
+	}
+	for _, row := range digest.Evidence {
+		fmt.Fprintf(&b, "- %s:%d — %s", row.File, row.Line, row.ID)
+		if row.Signature != "" {
+			fmt.Fprintf(&b, " (%s)", row.Signature)
+		}
+		b.WriteByte('\n')
 	}
 	return strings.TrimRight(b.String(), "\n")
 }
 
-// localizationReplayDirective is the actionable half of a post-terminal
-// replay: the same "answer NOW" instruction the momentum escalation uses,
-// phrased for the terminal case.
-const localizationReplayDirective = "You already hold the localization answer — respond NOW using the evidence " +
-	"below: name the files and symbols, citing the locations already returned. Further Gortex navigation " +
-	"returns this same evidence; a confident answer beats an exhausted turn budget with no answer."
-
-// answerReadyDirective returns the answer-now note a post-terminal READ
-// result carries: reads execute after answer_ready (starving them produced
-// empty finals), but every such result reminds the host it already holds
-// the answer and repeats the deterministic final response.
+// answerReadyDirective returns a neutral evidence reminder for a post-terminal
+// READ. Reads remain executable because starving them produced empty finals;
+// the appended note makes the completion boundary explicit without presenting
+// an injected-looking answer script.
 func (s *localizationTerminalState) answerReadyDirective() (string, bool) {
 	if s == nil {
 		return "", false
@@ -121,29 +212,22 @@ func (s *localizationTerminalState) answerReadyDirective() (string, bool) {
 	if s.state != localizationStateAnswerReady || s.digest == nil {
 		return "", false
 	}
-	return localizationReplayDirective + "\n\n" + s.digest.FinalResponse, true
+	return renderLocalizationReplayEvidence(s.digest), true
 }
 
 // localizationEvidenceReplayResult is the successful, idempotent response to
-// any post-terminal navigation call. It is deliberately NOT an error: error
-// results push non-adapted hosts into error-recovery loops and count as
-// failed calls, while a success result is actionable on the very next model
-// turn. Every subsequent call returns the byte-identical payload — the
-// refused call's facade/operation is deliberately absent, because the answer
-// does not depend on which navigation was attempted.
+// post-terminal navigation. Model-visible text contains neutral ranked evidence;
+// structuredContent carries the machine-readable completion and digest; an
+// adapting host can use the deterministic fallback from _meta.
 func localizationEvidenceReplayResult(completion localizationCompletion, digest *localizationEvidenceDigest) *mcpgo.CallToolResult {
-	payload := map[string]any{
+	result := mcpgo.NewToolResultText(renderLocalizationReplayEvidence(digest))
+	result.StructuredContent = map[string]any{
 		"completion":      completion,
 		"replay":          true,
-		"directive":       localizationReplayDirective,
 		"evidence_digest": digest,
-		"final_response":  digest.FinalResponse,
 	}
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return mcpgo.NewToolResultText(localizationReplayDirective + "\n\n" + digest.FinalResponse)
-	}
-	result := mcpgo.NewToolResultText(localizationReplayDirective + "\n\n" + digest.FinalResponse + "\n\n" + string(body))
-	result.StructuredContent = json.RawMessage(body)
+	result.Meta = mcpgo.NewMetaFromMap(map[string]any{
+		localizationHostFallbackMetaKey: buildLocalizationHostFallback(digest),
+	})
 	return result
 }

--- a/internal/mcp/localization_digest.go
+++ b/internal/mcp/localization_digest.go
@@ -38,16 +38,17 @@ type localizationEvidenceDigest struct {
 }
 
 type localizationDigestRow struct {
-	Rank      int      `json:"rank,omitempty"`
-	ID        string   `json:"id,omitempty"`
-	Name      string   `json:"name,omitempty"`
-	QualName  string   `json:"qual_name,omitempty"`
-	Kind      string   `json:"kind,omitempty"`
-	File      string   `json:"file,omitempty"`
-	Line      int      `json:"line,omitempty"`
-	Signature string   `json:"signature,omitempty"`
-	Callers   []string `json:"callers,omitempty"`
-	Callees   []string `json:"callees,omitempty"`
+	Rank       int      `json:"rank,omitempty"`
+	ID         string   `json:"id,omitempty"`
+	Name       string   `json:"name,omitempty"`
+	QualName   string   `json:"qual_name,omitempty"`
+	Kind       string   `json:"kind,omitempty"`
+	File       string   `json:"file,omitempty"`
+	Line       int      `json:"line,omitempty"`
+	Signature  string   `json:"signature,omitempty"`
+	Callers    []string `json:"callers,omitempty"`
+	Callees    []string `json:"callees,omitempty"`
+	Provenance string   `json:"provenance,omitempty"`
 }
 
 // newLocalizationEvidenceDigest retains only concrete ranked evidence rows.
@@ -70,16 +71,17 @@ func newLocalizationEvidenceDigest(envelope localizationExploreEnvelope) *locali
 		}
 		seen[row.ID] = struct{}{}
 		digest.Evidence = append(digest.Evidence, localizationDigestRow{
-			Rank:      row.Rank,
-			ID:        row.ID,
-			Name:      row.Name,
-			QualName:  row.QualName,
-			Kind:      row.Kind,
-			File:      row.File,
-			Line:      row.Line,
-			Signature: row.Signature,
-			Callers:   append([]string(nil), row.Callers...),
-			Callees:   append([]string(nil), row.Callees...),
+			Rank:       row.Rank,
+			ID:         row.ID,
+			Name:       row.Name,
+			QualName:   row.QualName,
+			Kind:       row.Kind,
+			File:       row.File,
+			Line:       row.Line,
+			Signature:  row.Signature,
+			Callers:    append([]string(nil), row.Callers...),
+			Callees:    append([]string(nil), row.Callees...),
+			Provenance: row.Provenance,
 		})
 	}
 	for {
@@ -160,10 +162,9 @@ type localizationHostEnvelope struct {
 	Contract       localizationTerminalContract `json:"contract"`
 }
 
-// TODO(localization-v2): once the explore ranking patch is stable, attach this
-// envelope to the initial explore(localize) result after its final byte-budgeted
-// completion and digest are known. This pass deliberately wires authoritative
-// metadata only for allowed reads and terminal-result helpers.
+// Initial localization and authorized reads call this only after byte-budget
+// packing and evidence-policy finalization, so visible and authoritative host
+// contracts always describe the same completion.
 func attachLocalizationHostEnvelope(result *mcpgo.CallToolResult, completion localizationCompletion, digest *localizationEvidenceDigest) *mcpgo.CallToolResult {
 	if result == nil {
 		return result

--- a/internal/mcp/localization_digest.go
+++ b/internal/mcp/localization_digest.go
@@ -1,0 +1,133 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+)
+
+// Terminal evidence retention.
+//
+// The localize handler builds a byte-budgeted evidence envelope once and
+// used to throw it away after serialization: the per-session terminal state
+// kept only the completion contract. A host that navigated past answer_ready
+// then received bare refusals — each one a burned model turn with no way
+// forward — and a session could exhaust its turn budget holding the correct
+// answer it was never shown again. The digest is the retained, replayable
+// core of that envelope plus a deterministic final response the host can
+// emit verbatim.
+
+// localizationDigestMaxBytes bounds the retained digest independently of the
+// original envelope budget so session state stays small no matter how large
+// the localize response was.
+const localizationDigestMaxBytes = 4096
+
+// localizationEvidenceDigest is the compact, session-retained projection of
+// an answer envelope: enough to answer from, never the full source bodies.
+type localizationEvidenceDigest struct {
+	Files         []string                `json:"files,omitempty"`
+	Symbols       []string                `json:"symbols,omitempty"`
+	Evidence      []localizationDigestRow `json:"evidence,omitempty"`
+	FinalResponse string                  `json:"final_response,omitempty"`
+}
+
+type localizationDigestRow struct {
+	Rank      int    `json:"rank,omitempty"`
+	ID        string `json:"id,omitempty"`
+	Name      string `json:"name,omitempty"`
+	File      string `json:"file,omitempty"`
+	Line      int    `json:"line,omitempty"`
+	Signature string `json:"signature,omitempty"`
+}
+
+// newLocalizationEvidenceDigest projects the serialized envelope into the
+// retained digest. Evidence rows drop their Source bodies and are shed from
+// the tail until the digest fits localizationDigestMaxBytes, mirroring the
+// envelope's own shed-expansion-first budgeting; Files and Symbols are always
+// retained (they are the answer's skeleton and already bounded upstream).
+func newLocalizationEvidenceDigest(envelope localizationExploreEnvelope) *localizationEvidenceDigest {
+	digest := &localizationEvidenceDigest{
+		Files:   append([]string(nil), envelope.Files...),
+		Symbols: append([]string(nil), envelope.Symbols...),
+	}
+	for _, row := range envelope.Evidence {
+		digest.Evidence = append(digest.Evidence, localizationDigestRow{
+			Rank:      row.Rank,
+			ID:        row.ID,
+			Name:      row.Name,
+			File:      row.File,
+			Line:      row.Line,
+			Signature: row.Signature,
+		})
+	}
+	digest.FinalResponse = buildLocalizationFinalResponse(digest)
+	for len(digest.Evidence) > 0 {
+		encoded, err := json.Marshal(digest)
+		if err == nil && len(encoded) <= localizationDigestMaxBytes {
+			return digest
+		}
+		digest.Evidence = digest.Evidence[:len(digest.Evidence)-1]
+		digest.FinalResponse = buildLocalizationFinalResponse(digest)
+	}
+	return digest
+}
+
+// buildLocalizationFinalResponse renders the deterministic, ready-to-emit
+// answer text: the FILES / SYMBOLS / EVIDENCE sections a localization-only
+// caller is expected to produce. A host may return it verbatim when it does
+// not want to spend an inference turn on synthesis.
+func buildLocalizationFinalResponse(digest *localizationEvidenceDigest) string {
+	var b strings.Builder
+	b.WriteString("FILES:\n")
+	for _, file := range digest.Files {
+		fmt.Fprintf(&b, "- %s\n", file)
+	}
+	b.WriteString("SYMBOLS:\n")
+	for _, symbol := range digest.Symbols {
+		fmt.Fprintf(&b, "- %s\n", symbol)
+	}
+	if len(digest.Evidence) > 0 {
+		b.WriteString("EVIDENCE:\n")
+		for _, row := range digest.Evidence {
+			fmt.Fprintf(&b, "- %s:%d — %s", row.File, row.Line, row.Name)
+			if row.Signature != "" {
+				fmt.Fprintf(&b, " (%s)", row.Signature)
+			}
+			b.WriteString("\n")
+		}
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// localizationReplayDirective is the actionable half of a post-terminal
+// replay: the same "answer NOW" instruction the momentum escalation uses,
+// phrased for the terminal case.
+const localizationReplayDirective = "You already hold the localization answer — respond NOW using the evidence " +
+	"below: name the files and symbols, citing the locations already returned. Further Gortex navigation " +
+	"returns this same evidence; a confident answer beats an exhausted turn budget with no answer."
+
+// localizationEvidenceReplayResult is the successful, idempotent response to
+// any post-terminal navigation call. It is deliberately NOT an error: error
+// results push non-adapted hosts into error-recovery loops and count as
+// failed calls, while a success result is actionable on the very next model
+// turn. Every subsequent call returns the byte-identical payload — the
+// refused call's facade/operation is deliberately absent, because the answer
+// does not depend on which navigation was attempted.
+func localizationEvidenceReplayResult(completion localizationCompletion, digest *localizationEvidenceDigest) *mcpgo.CallToolResult {
+	payload := map[string]any{
+		"completion":      completion,
+		"replay":          true,
+		"directive":       localizationReplayDirective,
+		"evidence_digest": digest,
+		"final_response":  digest.FinalResponse,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return mcpgo.NewToolResultText(localizationReplayDirective + "\n\n" + digest.FinalResponse)
+	}
+	result := mcpgo.NewToolResultText(localizationReplayDirective + "\n\n" + digest.FinalResponse + "\n\n" + string(body))
+	result.StructuredContent = json.RawMessage(body)
+	return result
+}

--- a/internal/mcp/localization_digest.go
+++ b/internal/mcp/localization_digest.go
@@ -108,6 +108,22 @@ const localizationReplayDirective = "You already hold the localization answer â€
 	"below: name the files and symbols, citing the locations already returned. Further Gortex navigation " +
 	"returns this same evidence; a confident answer beats an exhausted turn budget with no answer."
 
+// answerReadyDirective returns the answer-now note a post-terminal READ
+// result carries: reads execute after answer_ready (starving them produced
+// empty finals), but every such result reminds the host it already holds
+// the answer and repeats the deterministic final response.
+func (s *localizationTerminalState) answerReadyDirective() (string, bool) {
+	if s == nil {
+		return "", false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.state != localizationStateAnswerReady || s.digest == nil {
+		return "", false
+	}
+	return localizationReplayDirective + "\n\n" + s.digest.FinalResponse, true
+}
+
 // localizationEvidenceReplayResult is the successful, idempotent response to
 // any post-terminal navigation call. It is deliberately NOT an error: error
 // results push non-adapted hosts into error-recovery loops and count as

--- a/internal/mcp/localization_digest_test.go
+++ b/internal/mcp/localization_digest_test.go
@@ -22,7 +22,51 @@ func testEvidenceDigest() *localizationEvidenceDigest {
 	})
 }
 
-func TestPostTerminalNavigationReturnsCompactHostBackedSuccess(t *testing.T) {
+func requireLocalizationTerminalError(t *testing.T, result *mcpgo.CallToolResult, facade, operation string) localizationTerminalContract {
+	t.Helper()
+	if result == nil || !result.IsError {
+		t.Fatalf("terminal result = %#v, want typed MCP error", result)
+	}
+	text, ok := singleTextContent(result)
+	if !ok {
+		t.Fatalf("terminal result content = %#v, want one text block", result.Content)
+	}
+	var payload struct {
+		ErrorCode ErrorCode `json:"error_code"`
+		Message   string    `json:"message"`
+		Retriable bool      `json:"retriable"`
+		Data      struct {
+			Contract  localizationTerminalContract `json:"contract"`
+			Facade    string                       `json:"facade"`
+			Operation string                       `json:"operation"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(text), &payload); err != nil {
+		t.Fatalf("decode terminal error %q: %v", text, err)
+	}
+	var wire map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(text), &wire); err != nil {
+		t.Fatalf("decode terminal error wire %q: %v", text, err)
+	}
+	if raw, exists := wire["retriable"]; !exists || string(raw) != "false" {
+		t.Fatalf("terminal error must explicitly encode retriable=false: %s", text)
+	}
+	if payload.ErrorCode != ErrCodeLocalizationTerminal || payload.Message == "" || payload.Retriable {
+		t.Fatalf("terminal error = %#v", payload)
+	}
+	if payload.Data.Facade != facade || payload.Data.Operation != operation {
+		t.Fatalf("terminal error route = %q/%q, want %q/%q", payload.Data.Facade, payload.Data.Operation, facade, operation)
+	}
+	contract := payload.Data.Contract
+	if !contract.Terminal || contract.Completion.State != localizationStateAnswerReady ||
+		contract.Completion.ContractVersion != localizationTerminalContractV2 ||
+		contract.Completion.AllowedToolCalls != 0 {
+		t.Fatalf("terminal contract = %#v", contract)
+	}
+	return contract
+}
+
+func TestPostTerminalNavigationReturnsCompactTypedError(t *testing.T) {
 	state := &localizationTerminalState{}
 	completion := newLocalizationCompletion(true, "")
 	completion.digest = testEvidenceDigest()
@@ -34,17 +78,11 @@ func TestPostTerminalNavigationReturnsCompactHostBackedSuccess(t *testing.T) {
 			if reserved {
 				t.Fatalf("%s repeat %d reserved a handler call", facade, repeat)
 			}
-			if result == nil || result.IsError {
-				t.Fatalf("%s repeat %d = %+v, want successful terminal result", facade, repeat, result)
+			contract := requireLocalizationTerminalError(t, result, facade, "any_operation")
+			if contract.Completion.Enforceable {
+				t.Fatalf("%s repeat %d unexpectedly upgraded advisory evidence", facade, repeat)
 			}
-			text, ok := singleTextContent(result)
-			if !ok || text != localizationAnswerReadyNotice {
-				t.Fatalf("%s repeat %d text = %q, want constant terminal notice", facade, repeat, text)
-			}
-			visible, err := json.Marshal(struct {
-				Content    []mcpgo.Content `json:"content"`
-				Structured any             `json:"structuredContent"`
-			}{Content: result.Content, Structured: result.StructuredContent})
+			visible, err := json.Marshal(result)
 			if err != nil {
 				t.Fatalf("marshal %s result: %v", facade, err)
 			}
@@ -53,16 +91,6 @@ func TestPostTerminalNavigationReturnsCompactHostBackedSuccess(t *testing.T) {
 			}
 			if strings.Contains(string(visible), "repo/storage") {
 				t.Fatalf("%s visible terminal result replayed retained evidence: %s", facade, visible)
-			}
-			if result.Meta == nil || result.Meta.AdditionalFields == nil {
-				t.Fatalf("%s terminal result omitted host-only fallback metadata", facade)
-			}
-			host, ok := result.Meta.AdditionalFields[localizationHostMetaKey].(localizationHostEnvelope)
-			if !ok || host.Evidence == nil || host.FallbackFormat == "" || len(host.Evidence.Evidence) == 0 {
-				t.Fatalf("%s host fallback envelope = %#v", facade, result.Meta.AdditionalFields[localizationHostMetaKey])
-			}
-			if host.Evidence.Evidence[0].File != "repo/storage/disk.go" {
-				t.Fatalf("%s host evidence = %#v", facade, host.Evidence.Evidence)
 			}
 		}
 	}
@@ -83,13 +111,7 @@ func TestRepeatLocalizeAgainstTerminalContractReturnsCompactStop(t *testing.T) {
 	if token != 0 {
 		t.Fatal("repeat localize must not reserve the handler slot")
 	}
-	if blocked == nil || blocked.IsError {
-		t.Fatalf("repeat localize = %+v, want successful terminal result", blocked)
-	}
-	text, _ := singleTextContent(blocked)
-	if text != localizationAnswerReadyNotice {
-		t.Fatalf("repeat localize text = %q, want compact terminal notice", text)
-	}
+	requireLocalizationTerminalError(t, blocked, "explore", "localize")
 }
 
 func TestRefinementPromotionRetainsDigestForReplay(t *testing.T) {
@@ -104,12 +126,13 @@ func TestRefinementPromotionRetainsDigestForReplay(t *testing.T) {
 	state.finishReservedRead(true)
 
 	terminal, reserved := state.authorize("search", "symbols", nil)
-	if reserved || terminal == nil || terminal.IsError {
-		t.Fatalf("post-promotion navigation = (%+v, %v), want successful terminal result", terminal, reserved)
+	if reserved {
+		t.Fatal("post-promotion navigation reserved a handler")
 	}
-	text, _ := singleTextContent(terminal)
-	if text != localizationAnswerReadyNotice || strings.Contains(text, "repo/storage/cloud.go") {
-		t.Fatalf("promotion must stop without replaying the retained digest: %q", text)
+	requireLocalizationTerminalError(t, terminal, "search", "symbols")
+	encoded, err := json.Marshal(terminal)
+	if err != nil || strings.Contains(string(encoded), "repo/storage/cloud.go") {
+		t.Fatalf("promotion must stop without replaying the retained digest: %s (%v)", encoded, err)
 	}
 }
 
@@ -128,8 +151,10 @@ func TestRefinementAllowsOneAlternateRankedCandidateRead(t *testing.T) {
 		t.Fatalf("alternate ranked candidate read = (%v, %v), want reservation", blocked, reserved)
 	}
 	state.finishReservedRead(true)
-	if result, reserved := state.authorize("read", "source", args); reserved || result == nil || result.IsError {
-		t.Fatalf("second read = (%v, %v), want successful terminal interception", result, reserved)
+	if result, reserved := state.authorize("read", "source", args); reserved {
+		t.Fatal("second read reserved a handler")
+	} else {
+		requireLocalizationTerminalError(t, result, "read", "source")
 	}
 }
 
@@ -149,9 +174,7 @@ func TestDigestLifecycleAndLegacyFallback(t *testing.T) {
 	withoutDigest := &localizationTerminalState{}
 	withoutDigest.armForTask(newLocalizationCompletion(true, ""), "task without digest")
 	blocked, _ := withoutDigest.authorize("search", "symbols", nil)
-	if blocked == nil || blocked.IsError {
-		t.Fatal("answer_ready without a digest must return the successful terminal contract")
-	}
+	requireLocalizationTerminalError(t, blocked, "search", "symbols")
 }
 
 func TestDigestByteCapShedsEvidenceTail(t *testing.T) {
@@ -225,11 +248,13 @@ func TestPostTerminalReadsAreIntercepted(t *testing.T) {
 	completion.digest = testEvidenceDigest()
 	state.armForTask(completion, "find the storage load implementations")
 
-	if blocked, reserved := state.authorize("read", "source", map[string]any{
+	blocked, reserved := state.authorize("read", "source", map[string]any{
 		"target": map[string]any{"symbol": "repo/storage/disk.go::DiskStorage.Load"},
-	}); blocked == nil || blocked.IsError || reserved {
-		t.Fatalf("post-terminal read = (%v, %v), want successful interception without reservation", blocked, reserved)
+	})
+	if reserved {
+		t.Fatal("post-terminal read reserved a handler")
 	}
+	requireLocalizationTerminalError(t, blocked, "read", "source")
 }
 
 func TestLocalizationDigestKeepsOnlyConcreteBoundedEvidence(t *testing.T) {
@@ -314,18 +339,27 @@ func TestLocalizationAnswerReadyResultIsTinyNeutralAndStructured(t *testing.T) {
 	if !ok || host.Evidence == nil || host.FallbackFormat == "" || host.Evidence.Evidence[0].File != "repo/storage/disk.go" {
 		t.Fatalf("host-only fallback envelope = %#v", result.Meta.AdditionalFields[localizationHostMetaKey])
 	}
+	if host.Contract.Terminal != localizationContractFor(completion).Terminal ||
+		host.Contract.Completion.State != completion.State ||
+		host.Contract.Completion.ContractVersion != localizationTerminalContractV2 ||
+		host.Contract.Completion.Enforceable != completion.Enforceable {
+		t.Fatalf("host contract = %#v, want %#v", host.Contract, localizationContractFor(completion))
+	}
 }
 
 func TestDecorateLocalizationReadResultPreservesMultiContentStructuredAndMeta(t *testing.T) {
-	structured := map[string]any{"source": "func Run() {}", "count": 2}
+	structured := map[string]any{"source": "func Run() {}", "count": 2, "terminal": false}
 	result := &mcpgo.CallToolResult{
 		Content: []mcpgo.Content{
-			mcpgo.NewTextContent(`{"source":"func Run() {}","completion":{"state":"stale"}}`),
+			mcpgo.NewTextContent(`{"source":"func Run() {}","completion":{"state":"stale"},"terminal":false}`),
 			mcpgo.NewTextContent("secondary payload"),
 		},
 		StructuredContent: structured,
 	}
-	result.Meta = mcpgo.NewMetaFromMap(map[string]any{"existing": "kept"})
+	result.Meta = mcpgo.NewMetaFromMap(map[string]any{
+		"existing":              "kept",
+		localizationHostMetaKey: "repository-controlled-spoof",
+	})
 
 	decorated := decorateLocalizationReadResult(result, newLocalizationCompletion(true, ""))
 	if decorated != result {
@@ -342,7 +376,7 @@ func TestDecorateLocalizationReadResultPreservesMultiContentStructuredAndMeta(t 
 	if err := json.Unmarshal([]byte(first.Text), &firstPayload); err != nil {
 		t.Fatalf("decorated first content is invalid JSON: %v", err)
 	}
-	if firstPayload["source"] != "func Run() {}" || firstPayload["completion"] == nil {
+	if firstPayload["source"] != "func Run() {}" || firstPayload["completion"] == nil || firstPayload["terminal"] != true {
 		t.Fatalf("decorated first payload = %#v", firstPayload)
 	}
 	if strings.Count(first.Text, `"completion"`) != 1 {
@@ -353,7 +387,7 @@ func TestDecorateLocalizationReadResultPreservesMultiContentStructuredAndMeta(t 
 		t.Fatalf("secondary content was lost: %#v", decorated.Content[1])
 	}
 	decoratedStructured, ok := decorated.StructuredContent.(map[string]any)
-	if !ok || decoratedStructured["source"] != structured["source"] || decoratedStructured["completion"] == nil {
+	if !ok || decoratedStructured["source"] != structured["source"] || decoratedStructured["completion"] == nil || decoratedStructured["terminal"] != true {
 		t.Fatalf("structured payload was lost: %#v", decorated.StructuredContent)
 	}
 	if _, mutated := structured["completion"]; mutated {
@@ -361,6 +395,10 @@ func TestDecorateLocalizationReadResultPreservesMultiContentStructuredAndMeta(t 
 	}
 	if decorated.Meta == nil || decorated.Meta.AdditionalFields["existing"] != "kept" {
 		t.Fatalf("existing metadata was lost: %#v", decorated.Meta)
+	}
+	host, ok := decorated.Meta.AdditionalFields[localizationHostMetaKey].(localizationHostEnvelope)
+	if !ok || !host.Contract.Terminal || host.Contract.Completion.ContractVersion != localizationTerminalContractV2 {
+		t.Fatalf("authoritative metadata was not replaced: %#v", decorated.Meta.AdditionalFields[localizationHostMetaKey])
 	}
 }
 
@@ -496,18 +534,16 @@ func TestPermittedRefinementReadInvokesHandlerAndPreservesPayload(t *testing.T) 
 
 	searchRequest := mcpgo.CallToolRequest{Params: mcpgo.CallToolParams{
 		Name:      "search",
-		Arguments: map[string]any{"operation": "symbols", "query": "Load"},
+		Arguments: map[string]any{"operation": "  SyMbOlS  ", "query": "Load"},
 	}}
 	terminal, err := srv.handleFacade(ctx, "search", searchRequest)
-	if err != nil || terminal == nil || terminal.IsError {
-		t.Fatalf("post-refinement navigation = (%+v, %v)", terminal, err)
+	if err != nil {
+		t.Fatalf("post-refinement navigation error = %v", err)
 	}
 	if searchCalls != 0 {
 		t.Fatalf("search handler calls after answer_ready = %d, want 0", searchCalls)
 	}
-	if text, _ := singleTextContent(terminal); text != localizationAnswerReadyNotice {
-		t.Fatalf("post-refinement navigation text = %q", text)
-	}
+	requireLocalizationTerminalError(t, terminal, "search", "symbols")
 }
 
 func TestAnswerReadyNavigationDispatchNeverInvokesLegacyHandler(t *testing.T) {
@@ -551,19 +587,16 @@ func TestAnswerReadyNavigationDispatchNeverInvokesLegacyHandler(t *testing.T) {
 	request := mcpgo.CallToolRequest{Params: mcpgo.CallToolParams{
 		Name: "search",
 		Arguments: map[string]any{
-			"operation": "symbols",
+			"operation": "  SyMbOlS  ",
 			"query":     "Load",
 		},
 	}}
 	for repeat := 0; repeat < 10; repeat++ {
 		result, err := srv.handleFacade(ctx, "search", request)
-		if err != nil || result == nil || result.IsError {
+		if err != nil {
 			t.Fatalf("repeat %d result = (%+v, %v)", repeat, result, err)
 		}
-		text, _ := singleTextContent(result)
-		if text != localizationAnswerReadyNotice {
-			t.Fatalf("repeat %d text = %q", repeat, text)
-		}
+		requireLocalizationTerminalError(t, result, "search", "symbols")
 	}
 	if handlerCalls != 0 {
 		t.Fatalf("legacy handler invoked %d times after answer_ready", handlerCalls)
@@ -576,12 +609,10 @@ func TestAnswerReadyNavigationDispatchNeverInvokesLegacyHandler(t *testing.T) {
 		},
 	}}
 	readResult, err := srv.handleFacade(ctx, "read", readRequest)
-	if err != nil || readResult == nil || readResult.IsError {
+	if err != nil {
 		t.Fatalf("post-terminal read = (%+v, %v)", readResult, err)
 	}
-	if text, _ := singleTextContent(readResult); text != localizationAnswerReadyNotice {
-		t.Fatalf("post-terminal read text = %q", text)
-	}
+	requireLocalizationTerminalError(t, readResult, "read", "source")
 	if handlerCalls != 0 {
 		t.Fatalf("read handler invoked %d times after answer_ready", handlerCalls)
 	}
@@ -590,12 +621,10 @@ func TestAnswerReadyNavigationDispatchNeverInvokesLegacyHandler(t *testing.T) {
 	// of spending a turn on schema errors.
 	request.Params.Arguments = map[string]any{"operation": "not_an_operation"}
 	result, err := srv.handleFacade(ctx, "search", request)
-	if err != nil || result == nil || result.IsError {
+	if err != nil {
 		t.Fatalf("malformed post-terminal request = (%+v, %v)", result, err)
 	}
-	if text, _ := singleTextContent(result); text != localizationAnswerReadyNotice {
-		t.Fatalf("malformed post-terminal text = %q", text)
-	}
+	requireLocalizationTerminalError(t, result, "search", "not_an_operation")
 
 	changeRequest := mcpgo.CallToolRequest{Params: mcpgo.CallToolParams{
 		Name:      "change",

--- a/internal/mcp/localization_digest_test.go
+++ b/internal/mcp/localization_digest_test.go
@@ -382,6 +382,134 @@ func TestDecorateLocalizationReadResultPreservesStructuredOnlyPayload(t *testing
 	}
 }
 
+func TestDecorateLocalizationReadResultMirrorsContentOnlyPayloadForHosts(t *testing.T) {
+	completion := newLocalizationCompletion(true, "")
+
+	plain := mcpgo.NewToolResultText("func Load() {}")
+	decoratedPlain := decorateLocalizationReadResult(plain, completion)
+	plainStructured, ok := decoratedPlain.StructuredContent.(map[string]any)
+	if !ok || plainStructured["text"] != "func Load() {}" || plainStructured["completion"] == nil {
+		t.Fatalf("plain content was not mirrored for structured-first hosts: %#v", decoratedPlain.StructuredContent)
+	}
+	plainText, ok := singleTextContent(decoratedPlain)
+	if !ok || !strings.Contains(plainText, "func Load() {}") {
+		t.Fatalf("plain content block was lost: %#v", decoratedPlain.Content)
+	}
+
+	multi := &mcpgo.CallToolResult{Content: []mcpgo.Content{
+		mcpgo.NewTextContent("primary"),
+		mcpgo.NewTextContent("secondary"),
+	}}
+	decoratedMulti := decorateLocalizationReadResult(multi, completion)
+	multiStructured, ok := decoratedMulti.StructuredContent.(map[string]any)
+	mirrored, mirroredOK := multiStructured["content"].([]mcpgo.Content)
+	if !ok || !mirroredOK || len(mirrored) != 2 || multiStructured["completion"] == nil {
+		t.Fatalf("multi-content payload was not mirrored: %#v", decoratedMulti.StructuredContent)
+	}
+	if len(decoratedMulti.Content) != 2 {
+		t.Fatalf("multi-content blocks = %d, want 2", len(decoratedMulti.Content))
+	}
+}
+
+func TestPermittedRefinementReadInvokesHandlerAndPreservesPayload(t *testing.T) {
+	srv := setupPresetServer(t, ToolPolicyConfig{Preset: "core", Mode: "defer"})
+	ctx := WithSessionID(context.Background(), "refinement_read_payload")
+	initFrame := []byte(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"codex","version":"1.0"}}}`)
+	if reply := srv.MCPServer().HandleMessage(ctx, initFrame); reply == nil {
+		t.Fatal("initialize returned nil")
+	}
+
+	readSpec, ok := srv.facades.operation("read", "source")
+	if !ok {
+		t.Fatal("read.source facade operation is missing")
+	}
+	searchSpec, ok := srv.facades.operation("search", "symbols")
+	if !ok {
+		t.Fatal("search.symbols facade operation is missing")
+	}
+
+	const symbol = "repo/storage/disk.go::DiskStorage.Load"
+	readCalls := 0
+	searchCalls := 0
+	srv.facades.capture(mcpgo.NewTool(readSpec.Legacy), func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		readCalls++
+		result := mcpgo.NewToolResultText(`{"source":"func (s *DiskStorage) Load() {}","language":"go"}`)
+		result.Meta = mcpgo.NewMetaFromMap(map[string]any{"handler": "kept"})
+		return result, nil
+	})
+	srv.facades.capture(mcpgo.NewTool(searchSpec.Legacy), func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		searchCalls++
+		return mcpgo.NewToolResultText("unexpected search result"), nil
+	})
+	srv.localizationFor(ctx).armRefinementForTask(
+		"find the storage load implementation",
+		symbol,
+		[]string{symbol},
+		testEvidenceDigest(),
+	)
+
+	readRequest := mcpgo.CallToolRequest{Params: mcpgo.CallToolParams{
+		Name: "read",
+		Arguments: map[string]any{
+			"operation": "source",
+			"target":    map[string]any{"symbol": symbol},
+		},
+	}}
+	result, err := srv.handleFacade(ctx, "read", readRequest)
+	if err != nil || result == nil || result.IsError {
+		t.Fatalf("permitted refinement read = (%+v, %v)", result, err)
+	}
+	if readCalls != 1 {
+		t.Fatalf("read handler calls = %d, want 1", readCalls)
+	}
+	if len(result.Content) != 1 {
+		t.Fatalf("content blocks = %d, want 1", len(result.Content))
+	}
+	first, ok := mcpgo.AsTextContent(result.Content[0])
+	if !ok || !strings.Contains(first.Text, `"source":"func (s *DiskStorage) Load() {}"`) ||
+		!strings.Contains(first.Text, `"state":"answer_ready"`) {
+		t.Fatalf("decorated first payload = %#v", result.Content[0])
+	}
+	structured, ok := result.StructuredContent.(map[string]any)
+	if !ok || structured["source"] != "func (s *DiskStorage) Load() {}" ||
+		structured["language"] != "go" || structured["completion"] == nil {
+		t.Fatalf("structured source payload was lost: %#v", result.StructuredContent)
+	}
+	if result.Meta == nil || result.Meta.AdditionalFields["handler"] != "kept" {
+		t.Fatalf("handler metadata was lost: %#v", result.Meta)
+	}
+	wire, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal MCP result: %v", err)
+	}
+	var roundTrip struct {
+		Content           []map[string]any `json:"content"`
+		StructuredContent map[string]any   `json:"structuredContent"`
+	}
+	if err := json.Unmarshal(wire, &roundTrip); err != nil {
+		t.Fatalf("unmarshal MCP result: %v", err)
+	}
+	if len(roundTrip.Content) != 1 || roundTrip.StructuredContent["source"] != "func (s *DiskStorage) Load() {}" ||
+		roundTrip.StructuredContent["language"] != "go" || roundTrip.StructuredContent["completion"] == nil {
+		t.Fatalf("wire result lost source payload: %s", wire)
+	}
+
+	searchRequest := mcpgo.CallToolRequest{Params: mcpgo.CallToolParams{
+		Name:      "search",
+		Arguments: map[string]any{"operation": "symbols", "query": "Load"},
+	}}
+	terminal, err := srv.handleFacade(ctx, "search", searchRequest)
+	if err != nil || terminal == nil || terminal.IsError {
+		t.Fatalf("post-refinement navigation = (%+v, %v)", terminal, err)
+	}
+	if searchCalls != 0 {
+		t.Fatalf("search handler calls after answer_ready = %d, want 0", searchCalls)
+	}
+	if text, _ := singleTextContent(terminal); text != localizationAnswerReadyNotice {
+		t.Fatalf("post-refinement navigation text = %q", text)
+	}
+}
+
 func TestAnswerReadyNavigationDispatchNeverInvokesLegacyHandler(t *testing.T) {
 	srv := setupPresetServer(t, ToolPolicyConfig{Preset: "core", Mode: "defer"})
 	ctx := WithSessionID(context.Background(), "terminal_handler_intercept")

--- a/internal/mcp/localization_digest_test.go
+++ b/internal/mcp/localization_digest_test.go
@@ -140,7 +140,16 @@ func TestRefinementAllowsOneAlternateRankedCandidateRead(t *testing.T) {
 	state := &localizationTerminalState{}
 	preferred := "repo/storage/disk.go::DiskStorage.Load"
 	alternate := "repo/storage/cloud.go::CloudStorage.Load"
-	state.armRefinementForTask("find the storage load implementations", preferred, []string{preferred, alternate}, testEvidenceDigest())
+	state.armRefinementRoutesForTask(
+		"find the storage load implementations",
+		preferred,
+		[]string{preferred, alternate},
+		map[string]localizationRefinementRoute{
+			preferred: {enforceable: true},
+			alternate: {enforceable: true},
+		},
+		testEvidenceDigest(),
+	)
 
 	if completion := state.completionLocked(); !strings.Contains(completion.RequiredAction, "recommended") ||
 		!strings.Contains(completion.RequiredAction, "any returned candidate") {
@@ -479,10 +488,11 @@ func TestPermittedRefinementReadInvokesHandlerAndPreservesPayload(t *testing.T) 
 		searchCalls++
 		return mcpgo.NewToolResultText("unexpected search result"), nil
 	})
-	srv.localizationFor(ctx).armRefinementForTask(
+	srv.localizationFor(ctx).armRefinementRoutesForTask(
 		"find the storage load implementation",
 		symbol,
 		[]string{symbol},
+		map[string]localizationRefinementRoute{symbol: {enforceable: true}},
 		testEvidenceDigest(),
 	)
 

--- a/internal/mcp/localization_digest_test.go
+++ b/internal/mcp/localization_digest_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -18,9 +19,6 @@ func testEvidenceDigest() *localizationEvidenceDigest {
 	})
 }
 
-// The core terminality guarantee: a navigation call after answer_ready gets
-// the retained answer back as a SUCCESSFUL, idempotent replay — never a bare
-// refusal that burns a model turn with no way forward.
 func TestPostTerminalNavigationReplaysEvidenceAsSuccess(t *testing.T) {
 	state := &localizationTerminalState{}
 	completion := newLocalizationCompletion(true, "")
@@ -38,11 +36,11 @@ func TestPostTerminalNavigationReplaysEvidenceAsSuccess(t *testing.T) {
 	if !ok {
 		t.Fatal("replay result must carry text content")
 	}
-	if !strings.Contains(text, localizationReplayDirective) {
-		t.Fatal("replay must carry the answer-now directive")
+	if !strings.Contains(text, localizationReplayNotice) || !strings.Contains(text, "repo/storage/disk.go") {
+		t.Fatalf("replay must carry neutral retained evidence: %q", text)
 	}
-	if !strings.Contains(text, "repo/storage/disk.go") || !strings.Contains(text, "FILES:") {
-		t.Fatal("replay must carry the deterministic final response")
+	if strings.Contains(text, "answer NOW") || strings.Contains(text, "FILES:") {
+		t.Fatalf("replay must not carry an injected-looking answer: %q", text)
 	}
 
 	second, _ := state.authorize("relations", "usages", nil)
@@ -53,8 +51,6 @@ func TestPostTerminalNavigationReplaysEvidenceAsSuccess(t *testing.T) {
 	}
 }
 
-// A repeat localize against a terminal contract is the non-adapted host's
-// signature move; it must receive the evidence again, not error recovery.
 func TestRepeatLocalizeAgainstTerminalContractReplaysEvidence(t *testing.T) {
 	state := &localizationTerminalState{}
 	completion := newLocalizationCompletion(true, "")
@@ -69,13 +65,11 @@ func TestRepeatLocalizeAgainstTerminalContractReplaysEvidence(t *testing.T) {
 		t.Fatalf("repeat localize = %+v, want successful replay", blocked)
 	}
 	text, _ := singleTextContent(blocked)
-	if !strings.Contains(text, "final_response") && !strings.Contains(text, "FILES:") {
-		t.Fatal("repeat localize replay must carry the final response")
+	if !strings.Contains(text, "repo/storage/disk.go") || strings.Contains(text, "final_response") {
+		t.Fatalf("repeat localize must replay neutral retained evidence: %q", text)
 	}
 }
 
-// The evidence is stashed when the refinement contract is armed, so the
-// promotion to answer_ready after the one permitted read replays it.
 func TestRefinementPromotionRetainsDigestForReplay(t *testing.T) {
 	state := &localizationTerminalState{}
 	candidate := "repo/storage/disk.go::DiskStorage.Load"
@@ -97,8 +91,6 @@ func TestRefinementPromotionRetainsDigestForReplay(t *testing.T) {
 	}
 }
 
-// Digest lifecycle: an inactive commit clears it, and answer_ready without a
-// digest (legacy contracts) keeps the original error semantics.
 func TestDigestLifecycleAndLegacyFallback(t *testing.T) {
 	state := &localizationTerminalState{}
 	completion := newLocalizationCompletion(true, "")
@@ -120,20 +112,16 @@ func TestDigestLifecycleAndLegacyFallback(t *testing.T) {
 	}
 }
 
-// The retained digest is bounded regardless of envelope size: evidence rows
-// shed from the tail, the files/symbols skeleton always survives.
 func TestDigestByteCapShedsEvidenceTail(t *testing.T) {
-	envelope := localizationExploreEnvelope{
-		Files:   []string{"repo/big/file.go"},
-		Symbols: []string{"repo/big/file.go::Sym"},
-	}
+	envelope := localizationExploreEnvelope{}
 	for i := 0; i < 400; i++ {
 		envelope.Evidence = append(envelope.Evidence, localizationEvidence{
-			Rank: i + 1,
-			ID:   fmt.Sprintf("repo/big/file.go::Sym%03d", i),
-			Name: strings.Repeat("n", 40),
-			File: "repo/big/file.go",
-			Line: i,
+			Rank:      i + 1,
+			ID:        fmt.Sprintf("repo/big/file.go::Sym%03d", i),
+			Name:      strings.Repeat("n", 40),
+			File:      "repo/big/file.go",
+			Line:      i,
+			Signature: strings.Repeat("s", 2000),
 		})
 	}
 	digest := newLocalizationEvidenceDigest(envelope)
@@ -144,20 +132,51 @@ func TestDigestByteCapShedsEvidenceTail(t *testing.T) {
 	if len(encoded) > localizationDigestMaxBytes {
 		t.Fatalf("digest = %d bytes, want <= %d", len(encoded), localizationDigestMaxBytes)
 	}
-	if len(digest.Files) != 1 || len(digest.Symbols) != 1 {
-		t.Fatal("files/symbols skeleton must survive the cap")
+	if len(digest.Evidence) == 0 || len(digest.Evidence) >= localizationReplayEvidenceLimit {
+		t.Fatalf("byte cap retained %d rows, want a non-empty shed prefix", len(digest.Evidence))
 	}
-	if len(digest.Evidence) == 0 {
-		t.Fatal("cap should shed the tail, not everything")
+	if !reflect.DeepEqual(digest.Files, []string{"repo/big/file.go"}) {
+		t.Fatalf("files were not rebuilt from retained evidence: %#v", digest.Files)
 	}
-	if !strings.Contains(digest.FinalResponse, "FILES:") {
-		t.Fatal("final response must be rebuilt after shedding")
+	if len(digest.Symbols) != len(digest.Evidence) {
+		t.Fatalf("symbols=%d evidence=%d, want one supported symbol per row", len(digest.Symbols), len(digest.Evidence))
 	}
 }
 
-// Post-terminal reads execute (with the directive attached by dispatch)
-// instead of being replayed: starving reads produced empty finals in
-// sessions that held the correct file and asked to read it.
+func TestDigestByteCapRetainsSingleMandatoryRowAfterSheddingOptionalFields(t *testing.T) {
+	envelope := localizationExploreEnvelope{Evidence: []localizationEvidence{{
+		Rank:      1,
+		ID:        "repo/registry.go::Registry.Configure",
+		Name:      strings.Repeat("n", 1000),
+		QualName:  strings.Repeat("q", 3000),
+		Kind:      "method",
+		File:      "repo/registry.go",
+		Line:      17,
+		Signature: strings.Repeat("s", 8000),
+		Callers:   []string{strings.Repeat("caller", 1000)},
+		Callees:   []string{strings.Repeat("callee", 1000)},
+	}}}
+
+	digest := newLocalizationEvidenceDigest(envelope)
+	if len(digest.Evidence) != 1 {
+		t.Fatalf("mandatory evidence rows = %d, want 1", len(digest.Evidence))
+	}
+	row := digest.Evidence[0]
+	if row.ID != envelope.Evidence[0].ID || row.File != envelope.Evidence[0].File || row.Line != envelope.Evidence[0].Line {
+		t.Fatalf("mandatory row identity changed while shedding: %#v", row)
+	}
+	if row.Signature != "" || row.QualName != "" || len(row.Callers) != 0 || len(row.Callees) != 0 {
+		t.Fatalf("largest optional fields were retained after the digest fit: %#v", row)
+	}
+	encoded, err := json.Marshal(digest)
+	if err != nil {
+		t.Fatalf("marshal digest: %v", err)
+	}
+	if len(encoded) > localizationDigestMaxBytes {
+		t.Fatalf("shed digest = %d bytes, want <= %d", len(encoded), localizationDigestMaxBytes)
+	}
+}
+
 func TestPostTerminalReadsExecuteWhileNavigationReplays(t *testing.T) {
 	state := &localizationTerminalState{}
 	completion := newLocalizationCompletion(true, "")
@@ -172,7 +191,119 @@ func TestPostTerminalReadsExecuteWhileNavigationReplays(t *testing.T) {
 	if replay, _ := state.authorize("search", "symbols", nil); replay == nil || replay.IsError {
 		t.Fatal("post-terminal navigation must still replay")
 	}
-	if note, ok := state.answerReadyDirective(); !ok || !strings.Contains(note, "FILES:") {
-		t.Fatalf("directive must carry the final response, got %q ok=%v", note, ok)
+	if note, ok := state.answerReadyDirective(); !ok || !strings.Contains(note, "repo/storage/disk.go") || strings.Contains(note, "FILES:") {
+		t.Fatalf("post-terminal read note must carry neutral retained evidence, got %q ok=%v", note, ok)
+	}
+}
+
+func TestLocalizationDigestKeepsOnlyConcreteBoundedEvidence(t *testing.T) {
+	envelope := localizationExploreEnvelope{
+		Files:   []string{"pkg/unsupported.go", "pkg/a.go", "pkg/b.go", "pkg/c.go", "pkg/d.go", "pkg/e.go", "pkg/f.go"},
+		Symbols: []string{"repo/pkg/unsupported.go::Unsupported", "repo/pkg/a.go::A", "repo/pkg/b.go::B", "repo/pkg/c.go::C", "repo/pkg/d.go::D", "repo/pkg/e.go::E", "repo/pkg/f.go::F"},
+		Evidence: []localizationEvidence{
+			{Rank: 1, ID: "repo/pkg/a.go::A", Name: "A", Kind: "function", File: "pkg/a.go", Line: 10, Callers: []string{"repo/pkg/caller.go::CallA"}},
+			{Rank: 2, ID: "repo/pkg/b.go::B", Name: "B", Kind: "method", File: "pkg/b.go", Line: 20},
+			{Rank: 3, ID: "repo/pkg/c.go::C", Name: "C", Kind: "method", File: "pkg/c.go", Line: 30},
+			{Rank: 4, ID: "repo/pkg/d.go::D", Name: "D", Kind: "method", File: "pkg/d.go", Line: 40},
+			{Rank: 5, ID: "repo/pkg/e.go::E", Name: "E", Kind: "method", File: "pkg/e.go", Line: 50},
+			{Rank: 6, ID: "repo/pkg/f.go::F", Name: "F", Kind: "method", File: "pkg/f.go", Line: 60},
+			{Rank: 7, ID: "repo/pkg/missing.go::Missing", Name: "Missing"},
+		},
+	}
+
+	digest := newLocalizationEvidenceDigest(envelope)
+	if len(digest.Evidence) != localizationReplayEvidenceLimit {
+		t.Fatalf("retained evidence = %d, want %d", len(digest.Evidence), localizationReplayEvidenceLimit)
+	}
+	wantFiles := []string{"pkg/a.go", "pkg/b.go", "pkg/c.go", "pkg/d.go", "pkg/e.go"}
+	wantSymbols := []string{"repo/pkg/a.go::A", "repo/pkg/b.go::B", "repo/pkg/c.go::C", "repo/pkg/d.go::D", "repo/pkg/e.go::E"}
+	if !reflect.DeepEqual(digest.Files, wantFiles) {
+		t.Fatalf("digest files = %#v, want %#v", digest.Files, wantFiles)
+	}
+	if !reflect.DeepEqual(digest.Symbols, wantSymbols) {
+		t.Fatalf("digest symbols = %#v, want %#v", digest.Symbols, wantSymbols)
+	}
+	if got := digest.Evidence[0].Callers; !reflect.DeepEqual(got, []string{"repo/pkg/caller.go::CallA"}) {
+		t.Fatalf("causal provenance was dropped: %#v", got)
+	}
+	encoded, err := json.Marshal(digest)
+	if err != nil {
+		t.Fatalf("marshal digest: %v", err)
+	}
+	if strings.Contains(string(encoded), "final_response") || strings.Contains(string(encoded), "unsupported") {
+		t.Fatalf("digest retained an unsupported or prewritten answer field: %s", encoded)
+	}
+}
+
+func TestLocalizationEvidenceReplaySeparatesVisibleEvidenceFromHostFallback(t *testing.T) {
+	digest := &localizationEvidenceDigest{
+		Files:   []string{"pkg/handler.go", "pkg/rotating.go"},
+		Symbols: []string{"repo/pkg/handler.go::Handler.Write", "repo/pkg/rotating.go::RotatingHandler"},
+		Evidence: []localizationDigestRow{
+			{Rank: 1, ID: "repo/pkg/handler.go::Handler.Write", File: "pkg/handler.go", Line: 42, Signature: "func (h *Handler) Write(record Record)"},
+			{Rank: 2, ID: "repo/pkg/rotating.go::RotatingHandler", File: "pkg/rotating.go", Line: 17, Callers: []string{"repo/pkg/factory.go::NewHandler"}},
+		},
+	}
+	result := localizationEvidenceReplayResult(newLocalizationCompletion(true, ""), digest)
+	if result == nil || result.IsError || len(result.Content) != 1 {
+		t.Fatalf("replay result = %#v, want one successful visible evidence block", result)
+	}
+	visible, ok := singleTextContent(result)
+	if !ok {
+		t.Fatalf("replay has no text content: %#v", result)
+	}
+	for _, forbidden := range []string{"answer NOW", "verbatim", "final_response", `"directive"`, "FILES:\n", "SYMBOLS:\n"} {
+		if strings.Contains(visible, forbidden) {
+			t.Fatalf("model-visible replay contains %q: %s", forbidden, visible)
+		}
+	}
+	for _, required := range []string{"ranked candidates", "candidate presence alone does not prove a change target", "pkg/rotating.go:17", "repo/pkg/rotating.go::RotatingHandler"} {
+		if !strings.Contains(visible, required) {
+			t.Fatalf("model-visible replay omitted %q: %s", required, visible)
+		}
+	}
+
+	structured, ok := result.StructuredContent.(map[string]any)
+	if !ok {
+		t.Fatalf("structured content type = %T, want map", result.StructuredContent)
+	}
+	if structured["replay"] != true || structured["completion"] == nil || structured["evidence_digest"] != digest {
+		t.Fatalf("structured replay contract is incomplete: %#v", structured)
+	}
+	if _, exists := structured["directive"]; exists {
+		t.Fatalf("structured content retained a directive: %#v", structured)
+	}
+	if _, exists := structured["final_response"]; exists {
+		t.Fatalf("structured content exposed the host fallback: %#v", structured)
+	}
+
+	if result.Meta == nil {
+		t.Fatal("replay omitted host metadata")
+	}
+	fallback, ok := result.Meta.AdditionalFields[localizationHostFallbackMetaKey].(string)
+	if !ok || fallback == "" {
+		t.Fatalf("host fallback metadata = %#v", result.Meta.AdditionalFields)
+	}
+	if !strings.Contains(fallback, "pkg/rotating.go:17") || strings.Contains(fallback, "answer NOW") || strings.Contains(fallback, "verbatim") {
+		t.Fatalf("host fallback is missing evidence or retained coercive wording: %q", fallback)
+	}
+}
+
+func TestAnswerReadyDirectiveUsesNeutralRetainedEvidence(t *testing.T) {
+	digest := &localizationEvidenceDigest{Evidence: []localizationDigestRow{{
+		Rank: 1, ID: "repo/pkg/file.go::Run", File: "pkg/file.go", Line: 12,
+	}}}
+	state := &localizationTerminalState{state: localizationStateAnswerReady, digest: digest}
+	note, ok := state.answerReadyDirective()
+	if !ok {
+		t.Fatal("answer-ready state did not return retained evidence")
+	}
+	if !strings.Contains(note, "pkg/file.go:12") || !strings.Contains(note, "candidate presence alone does not prove a change target") {
+		t.Fatalf("answer-ready note omitted neutral evidence: %q", note)
+	}
+	for _, forbidden := range []string{"answer NOW", "verbatim", "final_response", "FILES:", "SYMBOLS:"} {
+		if strings.Contains(note, forbidden) {
+			t.Fatalf("answer-ready note contains %q: %s", forbidden, note)
+		}
 	}
 }

--- a/internal/mcp/localization_digest_test.go
+++ b/internal/mcp/localization_digest_test.go
@@ -154,3 +154,25 @@ func TestDigestByteCapShedsEvidenceTail(t *testing.T) {
 		t.Fatal("final response must be rebuilt after shedding")
 	}
 }
+
+// Post-terminal reads execute (with the directive attached by dispatch)
+// instead of being replayed: starving reads produced empty finals in
+// sessions that held the correct file and asked to read it.
+func TestPostTerminalReadsExecuteWhileNavigationReplays(t *testing.T) {
+	state := &localizationTerminalState{}
+	completion := newLocalizationCompletion(true, "")
+	completion.digest = testEvidenceDigest()
+	state.armForTask(completion, "find the storage load implementations")
+
+	if blocked, reserved := state.authorize("read", "source", map[string]any{
+		"target": map[string]any{"symbol": "repo/storage/disk.go::DiskStorage.Load"},
+	}); blocked != nil || reserved {
+		t.Fatalf("post-terminal read = (%v, %v), want allowed without reservation", blocked, reserved)
+	}
+	if replay, _ := state.authorize("search", "symbols", nil); replay == nil || replay.IsError {
+		t.Fatal("post-terminal navigation must still replay")
+	}
+	if note, ok := state.answerReadyDirective(); !ok || !strings.Contains(note, "FILES:") {
+		t.Fatalf("directive must carry the final response, got %q ok=%v", note, ok)
+	}
+}

--- a/internal/mcp/localization_digest_test.go
+++ b/internal/mcp/localization_digest_test.go
@@ -1,0 +1,156 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func testEvidenceDigest() *localizationEvidenceDigest {
+	return newLocalizationEvidenceDigest(localizationExploreEnvelope{
+		Files:   []string{"repo/storage/disk.go", "repo/storage/cloud.go"},
+		Symbols: []string{"repo/storage/disk.go::DiskStorage.Load", "repo/storage/cloud.go::CloudStorage.Load"},
+		Evidence: []localizationEvidence{
+			{Rank: 1, ID: "repo/storage/disk.go::DiskStorage.Load", Name: "Load", File: "repo/storage/disk.go", Line: 42, Signature: "func (s *DiskStorage) Load(key string) ([]byte, error)"},
+			{Rank: 2, ID: "repo/storage/cloud.go::CloudStorage.Load", Name: "Load", File: "repo/storage/cloud.go", Line: 17},
+		},
+	})
+}
+
+// The core terminality guarantee: a navigation call after answer_ready gets
+// the retained answer back as a SUCCESSFUL, idempotent replay — never a bare
+// refusal that burns a model turn with no way forward.
+func TestPostTerminalNavigationReplaysEvidenceAsSuccess(t *testing.T) {
+	state := &localizationTerminalState{}
+	completion := newLocalizationCompletion(true, "")
+	completion.digest = testEvidenceDigest()
+	state.armForTask(completion, "find the storage load implementations")
+
+	first, reserved := state.authorize("search", "symbols", nil)
+	if reserved {
+		t.Fatal("post-terminal navigation must not reserve a read")
+	}
+	if first == nil || first.IsError {
+		t.Fatalf("post-terminal navigation = %+v, want successful replay", first)
+	}
+	text, ok := singleTextContent(first)
+	if !ok {
+		t.Fatal("replay result must carry text content")
+	}
+	if !strings.Contains(text, localizationReplayDirective) {
+		t.Fatal("replay must carry the answer-now directive")
+	}
+	if !strings.Contains(text, "repo/storage/disk.go") || !strings.Contains(text, "FILES:") {
+		t.Fatal("replay must carry the deterministic final response")
+	}
+
+	second, _ := state.authorize("relations", "usages", nil)
+	firstText, _ := singleTextContent(first)
+	secondText, _ := singleTextContent(second)
+	if firstText != secondText {
+		t.Fatal("post-terminal replay must be idempotent across calls and facades")
+	}
+}
+
+// A repeat localize against a terminal contract is the non-adapted host's
+// signature move; it must receive the evidence again, not error recovery.
+func TestRepeatLocalizeAgainstTerminalContractReplaysEvidence(t *testing.T) {
+	state := &localizationTerminalState{}
+	completion := newLocalizationCompletion(true, "")
+	completion.digest = testEvidenceDigest()
+	state.armForTask(completion, "find the storage load implementations")
+
+	token, blocked := state.beginLocalize("find the storage load implementations again", false)
+	if token != 0 {
+		t.Fatal("repeat localize must not reserve the handler slot")
+	}
+	if blocked == nil || blocked.IsError {
+		t.Fatalf("repeat localize = %+v, want successful replay", blocked)
+	}
+	text, _ := singleTextContent(blocked)
+	if !strings.Contains(text, "final_response") && !strings.Contains(text, "FILES:") {
+		t.Fatal("repeat localize replay must carry the final response")
+	}
+}
+
+// The evidence is stashed when the refinement contract is armed, so the
+// promotion to answer_ready after the one permitted read replays it.
+func TestRefinementPromotionRetainsDigestForReplay(t *testing.T) {
+	state := &localizationTerminalState{}
+	candidate := "repo/storage/disk.go::DiskStorage.Load"
+	state.armRefinementForTask("find the storage load implementations", candidate, []string{candidate}, testEvidenceDigest())
+
+	args := map[string]any{"target": map[string]any{"symbol": candidate}}
+	if blocked, reserved := state.authorize("read", "source", args); blocked != nil || !reserved {
+		t.Fatalf("permitted refinement read = (%v, %v), want reservation", blocked, reserved)
+	}
+	state.finishReservedRead(true)
+
+	replay, reserved := state.authorize("search", "symbols", nil)
+	if reserved || replay == nil || replay.IsError {
+		t.Fatalf("post-promotion navigation = (%+v, %v), want successful replay", replay, reserved)
+	}
+	text, _ := singleTextContent(replay)
+	if !strings.Contains(text, "repo/storage/cloud.go") {
+		t.Fatal("promotion must replay the digest stashed at refinement arm time")
+	}
+}
+
+// Digest lifecycle: an inactive commit clears it, and answer_ready without a
+// digest (legacy contracts) keeps the original error semantics.
+func TestDigestLifecycleAndLegacyFallback(t *testing.T) {
+	state := &localizationTerminalState{}
+	completion := newLocalizationCompletion(true, "")
+	completion.digest = testEvidenceDigest()
+	state.armForTask(completion, "find the storage load implementations")
+	state.keepOpenForTask("new unrelated work")
+	if blocked, _ := state.authorize("search", "symbols", nil); blocked != nil {
+		t.Fatalf("inactive state must not block, got %+v", blocked)
+	}
+	if state.digest != nil {
+		t.Fatal("keepOpenForTask must clear the retained digest")
+	}
+
+	legacy := &localizationTerminalState{}
+	legacy.armForTask(newLocalizationCompletion(true, ""), "task without digest")
+	blocked, _ := legacy.authorize("search", "symbols", nil)
+	if blocked == nil || !blocked.IsError {
+		t.Fatal("answer_ready without a digest must keep the error contract")
+	}
+}
+
+// The retained digest is bounded regardless of envelope size: evidence rows
+// shed from the tail, the files/symbols skeleton always survives.
+func TestDigestByteCapShedsEvidenceTail(t *testing.T) {
+	envelope := localizationExploreEnvelope{
+		Files:   []string{"repo/big/file.go"},
+		Symbols: []string{"repo/big/file.go::Sym"},
+	}
+	for i := 0; i < 400; i++ {
+		envelope.Evidence = append(envelope.Evidence, localizationEvidence{
+			Rank: i + 1,
+			ID:   fmt.Sprintf("repo/big/file.go::Sym%03d", i),
+			Name: strings.Repeat("n", 40),
+			File: "repo/big/file.go",
+			Line: i,
+		})
+	}
+	digest := newLocalizationEvidenceDigest(envelope)
+	encoded, err := json.Marshal(digest)
+	if err != nil {
+		t.Fatalf("marshal digest: %v", err)
+	}
+	if len(encoded) > localizationDigestMaxBytes {
+		t.Fatalf("digest = %d bytes, want <= %d", len(encoded), localizationDigestMaxBytes)
+	}
+	if len(digest.Files) != 1 || len(digest.Symbols) != 1 {
+		t.Fatal("files/symbols skeleton must survive the cap")
+	}
+	if len(digest.Evidence) == 0 {
+		t.Fatal("cap should shed the tail, not everything")
+	}
+	if !strings.Contains(digest.FinalResponse, "FILES:") {
+		t.Fatal("final response must be rebuilt after shedding")
+	}
+}

--- a/internal/mcp/localization_digest_test.go
+++ b/internal/mcp/localization_digest_test.go
@@ -1,11 +1,14 @@
 package mcp
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
 	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
 )
 
 func testEvidenceDigest() *localizationEvidenceDigest {
@@ -19,39 +22,58 @@ func testEvidenceDigest() *localizationEvidenceDigest {
 	})
 }
 
-func TestPostTerminalNavigationReplaysEvidenceAsSuccess(t *testing.T) {
+func TestPostTerminalNavigationReturnsCompactHostBackedSuccess(t *testing.T) {
 	state := &localizationTerminalState{}
 	completion := newLocalizationCompletion(true, "")
 	completion.digest = testEvidenceDigest()
 	state.armForTask(completion, "find the storage load implementations")
 
-	first, reserved := state.authorize("search", "symbols", nil)
-	if reserved {
-		t.Fatal("post-terminal navigation must not reserve a read")
+	for _, facade := range []string{"explore", "search", "read", "relations", "trace", "analyze"} {
+		for repeat := 0; repeat < 3; repeat++ {
+			result, reserved := state.authorize(facade, "any_operation", nil)
+			if reserved {
+				t.Fatalf("%s repeat %d reserved a handler call", facade, repeat)
+			}
+			if result == nil || result.IsError {
+				t.Fatalf("%s repeat %d = %+v, want successful terminal result", facade, repeat, result)
+			}
+			text, ok := singleTextContent(result)
+			if !ok || text != localizationAnswerReadyNotice {
+				t.Fatalf("%s repeat %d text = %q, want constant terminal notice", facade, repeat, text)
+			}
+			visible, err := json.Marshal(struct {
+				Content    []mcpgo.Content `json:"content"`
+				Structured any             `json:"structuredContent"`
+			}{Content: result.Content, Structured: result.StructuredContent})
+			if err != nil {
+				t.Fatalf("marshal %s result: %v", facade, err)
+			}
+			if len(visible) > 512 {
+				t.Fatalf("%s visible terminal result = %d bytes, want <= 512", facade, len(visible))
+			}
+			if strings.Contains(string(visible), "repo/storage") {
+				t.Fatalf("%s visible terminal result replayed retained evidence: %s", facade, visible)
+			}
+			if result.Meta == nil || result.Meta.AdditionalFields == nil {
+				t.Fatalf("%s terminal result omitted host-only fallback metadata", facade)
+			}
+			host, ok := result.Meta.AdditionalFields[localizationHostMetaKey].(localizationHostEnvelope)
+			if !ok || host.Evidence == nil || host.FallbackFormat == "" || len(host.Evidence.Evidence) == 0 {
+				t.Fatalf("%s host fallback envelope = %#v", facade, result.Meta.AdditionalFields[localizationHostMetaKey])
+			}
+			if host.Evidence.Evidence[0].File != "repo/storage/disk.go" {
+				t.Fatalf("%s host evidence = %#v", facade, host.Evidence.Evidence)
+			}
+		}
 	}
-	if first == nil || first.IsError {
-		t.Fatalf("post-terminal navigation = %+v, want successful replay", first)
-	}
-	text, ok := singleTextContent(first)
-	if !ok {
-		t.Fatal("replay result must carry text content")
-	}
-	if !strings.Contains(text, localizationReplayNotice) || !strings.Contains(text, "repo/storage/disk.go") {
-		t.Fatalf("replay must carry neutral retained evidence: %q", text)
-	}
-	if strings.Contains(text, "answer NOW") || strings.Contains(text, "FILES:") {
-		t.Fatalf("replay must not carry an injected-looking answer: %q", text)
-	}
-
-	second, _ := state.authorize("relations", "usages", nil)
-	firstText, _ := singleTextContent(first)
-	secondText, _ := singleTextContent(second)
-	if firstText != secondText {
-		t.Fatal("post-terminal replay must be idempotent across calls and facades")
+	for _, facade := range []string{"change", "edit", "refactor", "workspace", "session", "recall", "remember", "capabilities"} {
+		if result, reserved := state.authorize(facade, "any_operation", nil); result != nil || reserved {
+			t.Fatalf("%s must remain dispatchable after answer_ready: result=%#v reserved=%v", facade, result, reserved)
+		}
 	}
 }
 
-func TestRepeatLocalizeAgainstTerminalContractReplaysEvidence(t *testing.T) {
+func TestRepeatLocalizeAgainstTerminalContractReturnsCompactStop(t *testing.T) {
 	state := &localizationTerminalState{}
 	completion := newLocalizationCompletion(true, "")
 	completion.digest = testEvidenceDigest()
@@ -62,11 +84,11 @@ func TestRepeatLocalizeAgainstTerminalContractReplaysEvidence(t *testing.T) {
 		t.Fatal("repeat localize must not reserve the handler slot")
 	}
 	if blocked == nil || blocked.IsError {
-		t.Fatalf("repeat localize = %+v, want successful replay", blocked)
+		t.Fatalf("repeat localize = %+v, want successful terminal result", blocked)
 	}
 	text, _ := singleTextContent(blocked)
-	if !strings.Contains(text, "repo/storage/disk.go") || strings.Contains(text, "final_response") {
-		t.Fatalf("repeat localize must replay neutral retained evidence: %q", text)
+	if text != localizationAnswerReadyNotice {
+		t.Fatalf("repeat localize text = %q, want compact terminal notice", text)
 	}
 }
 
@@ -81,13 +103,33 @@ func TestRefinementPromotionRetainsDigestForReplay(t *testing.T) {
 	}
 	state.finishReservedRead(true)
 
-	replay, reserved := state.authorize("search", "symbols", nil)
-	if reserved || replay == nil || replay.IsError {
-		t.Fatalf("post-promotion navigation = (%+v, %v), want successful replay", replay, reserved)
+	terminal, reserved := state.authorize("search", "symbols", nil)
+	if reserved || terminal == nil || terminal.IsError {
+		t.Fatalf("post-promotion navigation = (%+v, %v), want successful terminal result", terminal, reserved)
 	}
-	text, _ := singleTextContent(replay)
-	if !strings.Contains(text, "repo/storage/cloud.go") {
-		t.Fatal("promotion must replay the digest stashed at refinement arm time")
+	text, _ := singleTextContent(terminal)
+	if text != localizationAnswerReadyNotice || strings.Contains(text, "repo/storage/cloud.go") {
+		t.Fatalf("promotion must stop without replaying the retained digest: %q", text)
+	}
+}
+
+func TestRefinementAllowsOneAlternateRankedCandidateRead(t *testing.T) {
+	state := &localizationTerminalState{}
+	preferred := "repo/storage/disk.go::DiskStorage.Load"
+	alternate := "repo/storage/cloud.go::CloudStorage.Load"
+	state.armRefinementForTask("find the storage load implementations", preferred, []string{preferred, alternate}, testEvidenceDigest())
+
+	if completion := state.completionLocked(); !strings.Contains(completion.RequiredAction, "recommended") ||
+		!strings.Contains(completion.RequiredAction, "any returned candidate") {
+		t.Fatalf("required action does not explain alternate candidate authorization: %q", completion.RequiredAction)
+	}
+	args := map[string]any{"target": map[string]any{"symbol": alternate}}
+	if blocked, reserved := state.authorize("read", "source", args); blocked != nil || !reserved {
+		t.Fatalf("alternate ranked candidate read = (%v, %v), want reservation", blocked, reserved)
+	}
+	state.finishReservedRead(true)
+	if result, reserved := state.authorize("read", "source", args); reserved || result == nil || result.IsError {
+		t.Fatalf("second read = (%v, %v), want successful terminal interception", result, reserved)
 	}
 }
 
@@ -104,11 +146,11 @@ func TestDigestLifecycleAndLegacyFallback(t *testing.T) {
 		t.Fatal("keepOpenForTask must clear the retained digest")
 	}
 
-	legacy := &localizationTerminalState{}
-	legacy.armForTask(newLocalizationCompletion(true, ""), "task without digest")
-	blocked, _ := legacy.authorize("search", "symbols", nil)
-	if blocked == nil || !blocked.IsError {
-		t.Fatal("answer_ready without a digest must keep the error contract")
+	withoutDigest := &localizationTerminalState{}
+	withoutDigest.armForTask(newLocalizationCompletion(true, ""), "task without digest")
+	blocked, _ := withoutDigest.authorize("search", "symbols", nil)
+	if blocked == nil || blocked.IsError {
+		t.Fatal("answer_ready without a digest must return the successful terminal contract")
 	}
 }
 
@@ -177,7 +219,7 @@ func TestDigestByteCapRetainsSingleMandatoryRowAfterSheddingOptionalFields(t *te
 	}
 }
 
-func TestPostTerminalReadsExecuteWhileNavigationReplays(t *testing.T) {
+func TestPostTerminalReadsAreIntercepted(t *testing.T) {
 	state := &localizationTerminalState{}
 	completion := newLocalizationCompletion(true, "")
 	completion.digest = testEvidenceDigest()
@@ -185,14 +227,8 @@ func TestPostTerminalReadsExecuteWhileNavigationReplays(t *testing.T) {
 
 	if blocked, reserved := state.authorize("read", "source", map[string]any{
 		"target": map[string]any{"symbol": "repo/storage/disk.go::DiskStorage.Load"},
-	}); blocked != nil || reserved {
-		t.Fatalf("post-terminal read = (%v, %v), want allowed without reservation", blocked, reserved)
-	}
-	if replay, _ := state.authorize("search", "symbols", nil); replay == nil || replay.IsError {
-		t.Fatal("post-terminal navigation must still replay")
-	}
-	if note, ok := state.answerReadyDirective(); !ok || !strings.Contains(note, "repo/storage/disk.go") || strings.Contains(note, "FILES:") {
-		t.Fatalf("post-terminal read note must carry neutral retained evidence, got %q ok=%v", note, ok)
+	}); blocked == nil || blocked.IsError || reserved {
+		t.Fatalf("post-terminal read = (%v, %v), want successful interception without reservation", blocked, reserved)
 	}
 }
 
@@ -235,75 +271,233 @@ func TestLocalizationDigestKeepsOnlyConcreteBoundedEvidence(t *testing.T) {
 	}
 }
 
-func TestLocalizationEvidenceReplaySeparatesVisibleEvidenceFromHostFallback(t *testing.T) {
-	digest := &localizationEvidenceDigest{
-		Files:   []string{"pkg/handler.go", "pkg/rotating.go"},
-		Symbols: []string{"repo/pkg/handler.go::Handler.Write", "repo/pkg/rotating.go::RotatingHandler"},
-		Evidence: []localizationDigestRow{
-			{Rank: 1, ID: "repo/pkg/handler.go::Handler.Write", File: "pkg/handler.go", Line: 42, Signature: "func (h *Handler) Write(record Record)"},
-			{Rank: 2, ID: "repo/pkg/rotating.go::RotatingHandler", File: "pkg/rotating.go", Line: 17, Callers: []string{"repo/pkg/factory.go::NewHandler"}},
-		},
-	}
-	result := localizationEvidenceReplayResult(newLocalizationCompletion(true, ""), digest)
+func TestLocalizationAnswerReadyResultIsTinyNeutralAndStructured(t *testing.T) {
+	completion := newLocalizationCompletion(true, "")
+	completion.digest = testEvidenceDigest()
+	result := localizationAnswerReadyResult(completion)
 	if result == nil || result.IsError || len(result.Content) != 1 {
-		t.Fatalf("replay result = %#v, want one successful visible evidence block", result)
+		t.Fatalf("terminal result = %#v, want one successful text block", result)
 	}
 	visible, ok := singleTextContent(result)
-	if !ok {
-		t.Fatalf("replay has no text content: %#v", result)
+	if !ok || visible != localizationAnswerReadyNotice {
+		t.Fatalf("terminal result text = %q", visible)
 	}
-	for _, forbidden := range []string{"answer NOW", "verbatim", "final_response", `"directive"`, "FILES:\n", "SYMBOLS:\n"} {
+	for _, forbidden := range []string{"verbatim", "final_response", `"directive"`, "FILES:", "SYMBOLS:", "pkg/"} {
 		if strings.Contains(visible, forbidden) {
-			t.Fatalf("model-visible replay contains %q: %s", forbidden, visible)
+			t.Fatalf("terminal result contains %q: %s", forbidden, visible)
 		}
 	}
-	for _, required := range []string{"ranked candidates", "candidate presence alone does not prove a change target", "pkg/rotating.go:17", "repo/pkg/rotating.go::RotatingHandler"} {
-		if !strings.Contains(visible, required) {
-			t.Fatalf("model-visible replay omitted %q: %s", required, visible)
-		}
-	}
-
 	structured, ok := result.StructuredContent.(map[string]any)
-	if !ok {
-		t.Fatalf("structured content type = %T, want map", result.StructuredContent)
+	if !ok || structured["terminal"] != true || structured["completion"] == nil {
+		t.Fatalf("structured terminal contract = %#v", result.StructuredContent)
 	}
-	if structured["replay"] != true || structured["completion"] == nil || structured["evidence_digest"] != digest {
-		t.Fatalf("structured replay contract is incomplete: %#v", structured)
+	if _, exists := structured["evidence_digest"]; exists {
+		t.Fatalf("terminal contract replayed evidence: %#v", structured)
 	}
-	if _, exists := structured["directive"]; exists {
-		t.Fatalf("structured content retained a directive: %#v", structured)
+	visibleEncoded, err := json.Marshal(struct {
+		Content    []mcpgo.Content `json:"content"`
+		Structured any             `json:"structuredContent"`
+	}{Content: result.Content, Structured: result.StructuredContent})
+	if err != nil {
+		t.Fatalf("marshal terminal result: %v", err)
 	}
-	if _, exists := structured["final_response"]; exists {
-		t.Fatalf("structured content exposed the host fallback: %#v", structured)
+	if len(visibleEncoded) > 512 {
+		t.Fatalf("visible terminal result = %d bytes, want <= 512", len(visibleEncoded))
 	}
-
-	if result.Meta == nil {
-		t.Fatal("replay omitted host metadata")
+	if strings.Contains(string(visibleEncoded), "repo/storage") {
+		t.Fatalf("retained evidence escaped into visible terminal result: %s", visibleEncoded)
 	}
-	fallback, ok := result.Meta.AdditionalFields[localizationHostFallbackMetaKey].(string)
-	if !ok || fallback == "" {
-		t.Fatalf("host fallback metadata = %#v", result.Meta.AdditionalFields)
+	if result.Meta == nil || result.Meta.AdditionalFields == nil {
+		t.Fatal("terminal result omitted host-only metadata")
 	}
-	if !strings.Contains(fallback, "pkg/rotating.go:17") || strings.Contains(fallback, "answer NOW") || strings.Contains(fallback, "verbatim") {
-		t.Fatalf("host fallback is missing evidence or retained coercive wording: %q", fallback)
+	host, ok := result.Meta.AdditionalFields[localizationHostMetaKey].(localizationHostEnvelope)
+	if !ok || host.Evidence == nil || host.FallbackFormat == "" || host.Evidence.Evidence[0].File != "repo/storage/disk.go" {
+		t.Fatalf("host-only fallback envelope = %#v", result.Meta.AdditionalFields[localizationHostMetaKey])
 	}
 }
 
-func TestAnswerReadyDirectiveUsesNeutralRetainedEvidence(t *testing.T) {
-	digest := &localizationEvidenceDigest{Evidence: []localizationDigestRow{{
-		Rank: 1, ID: "repo/pkg/file.go::Run", File: "pkg/file.go", Line: 12,
-	}}}
-	state := &localizationTerminalState{state: localizationStateAnswerReady, digest: digest}
-	note, ok := state.answerReadyDirective()
+func TestDecorateLocalizationReadResultPreservesMultiContentStructuredAndMeta(t *testing.T) {
+	structured := map[string]any{"source": "func Run() {}", "count": 2}
+	result := &mcpgo.CallToolResult{
+		Content: []mcpgo.Content{
+			mcpgo.NewTextContent(`{"source":"func Run() {}","completion":{"state":"stale"}}`),
+			mcpgo.NewTextContent("secondary payload"),
+		},
+		StructuredContent: structured,
+	}
+	result.Meta = mcpgo.NewMetaFromMap(map[string]any{"existing": "kept"})
+
+	decorated := decorateLocalizationReadResult(result, newLocalizationCompletion(true, ""))
+	if decorated != result {
+		t.Fatal("decorator must preserve the result object and its non-text payload")
+	}
+	if len(decorated.Content) != 2 {
+		t.Fatalf("content blocks = %d, want 2", len(decorated.Content))
+	}
+	first, ok := mcpgo.AsTextContent(decorated.Content[0])
 	if !ok {
-		t.Fatal("answer-ready state did not return retained evidence")
+		t.Fatal("first content block stopped being text")
 	}
-	if !strings.Contains(note, "pkg/file.go:12") || !strings.Contains(note, "candidate presence alone does not prove a change target") {
-		t.Fatalf("answer-ready note omitted neutral evidence: %q", note)
+	var firstPayload map[string]any
+	if err := json.Unmarshal([]byte(first.Text), &firstPayload); err != nil {
+		t.Fatalf("decorated first content is invalid JSON: %v", err)
 	}
-	for _, forbidden := range []string{"answer NOW", "verbatim", "final_response", "FILES:", "SYMBOLS:"} {
-		if strings.Contains(note, forbidden) {
-			t.Fatalf("answer-ready note contains %q: %s", forbidden, note)
+	if firstPayload["source"] != "func Run() {}" || firstPayload["completion"] == nil {
+		t.Fatalf("decorated first payload = %#v", firstPayload)
+	}
+	if strings.Count(first.Text, `"completion"`) != 1 {
+		t.Fatalf("decorated first payload contains duplicate completion keys: %s", first.Text)
+	}
+	second, ok := mcpgo.AsTextContent(decorated.Content[1])
+	if !ok || second.Text != "secondary payload" {
+		t.Fatalf("secondary content was lost: %#v", decorated.Content[1])
+	}
+	decoratedStructured, ok := decorated.StructuredContent.(map[string]any)
+	if !ok || decoratedStructured["source"] != structured["source"] || decoratedStructured["completion"] == nil {
+		t.Fatalf("structured payload was lost: %#v", decorated.StructuredContent)
+	}
+	if _, mutated := structured["completion"]; mutated {
+		t.Fatal("decorator mutated the handler's structured map")
+	}
+	if decorated.Meta == nil || decorated.Meta.AdditionalFields["existing"] != "kept" {
+		t.Fatalf("existing metadata was lost: %#v", decorated.Meta)
+	}
+}
+
+func TestDecorateLocalizationReadResultPreservesStructuredOnlyPayload(t *testing.T) {
+	payload := []any{"first", map[string]any{"second": true}}
+	result := &mcpgo.CallToolResult{StructuredContent: payload}
+
+	decorated := decorateLocalizationReadResult(result, newLocalizationCompletion(true, ""))
+	if len(decorated.Content) != 1 {
+		t.Fatalf("completion content blocks = %d, want 1", len(decorated.Content))
+	}
+	completionText, ok := mcpgo.AsTextContent(decorated.Content[0])
+	if !ok || !strings.Contains(completionText.Text, `"state":"answer_ready"`) {
+		t.Fatalf("structured-only result omitted visible completion: %#v", decorated.Content)
+	}
+	wrapped, ok := decorated.StructuredContent.(map[string]any)
+	if !ok || !reflect.DeepEqual(wrapped["payload"], payload) || wrapped["completion"] == nil {
+		t.Fatalf("structured-only payload was lost: %#v", decorated.StructuredContent)
+	}
+}
+
+func TestAnswerReadyNavigationDispatchNeverInvokesLegacyHandler(t *testing.T) {
+	srv := setupPresetServer(t, ToolPolicyConfig{Preset: "core", Mode: "defer"})
+	ctx := WithSessionID(context.Background(), "terminal_handler_intercept")
+	initFrame := []byte(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"codex","version":"1.0"}}}`)
+	if reply := srv.MCPServer().HandleMessage(ctx, initFrame); reply == nil {
+		t.Fatal("initialize returned nil")
+	}
+
+	spec, ok := srv.facades.operation("search", "symbols")
+	if !ok {
+		t.Fatal("search.symbols facade operation is missing")
+	}
+	readSpec, ok := srv.facades.operation("read", "source")
+	if !ok {
+		t.Fatal("read.source facade operation is missing")
+	}
+	changeSpec, ok := srv.facades.operation("change", "detect")
+	if !ok {
+		t.Fatal("change.detect facade operation is missing")
+	}
+	handlerCalls := 0
+	changeCalls := 0
+	srv.facades.capture(mcpgo.NewTool(spec.Legacy), func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		handlerCalls++
+		return mcpgo.NewToolResultText(strings.Repeat("expensive", 10_000)), nil
+	})
+	srv.facades.capture(mcpgo.NewTool(readSpec.Legacy), func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		handlerCalls++
+		return mcpgo.NewToolResultText(strings.Repeat("source", 10_000)), nil
+	})
+	srv.facades.capture(mcpgo.NewTool(changeSpec.Legacy), func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		changeCalls++
+		return mcpgo.NewToolResultText(`{"changed":[]}`), nil
+	})
+	completion := newLocalizationCompletion(true, "")
+	completion.digest = testEvidenceDigest()
+	srv.localizationFor(ctx).armForTask(completion, "find the storage load implementations")
+
+	request := mcpgo.CallToolRequest{Params: mcpgo.CallToolParams{
+		Name: "search",
+		Arguments: map[string]any{
+			"operation": "symbols",
+			"query":     "Load",
+		},
+	}}
+	for repeat := 0; repeat < 10; repeat++ {
+		result, err := srv.handleFacade(ctx, "search", request)
+		if err != nil || result == nil || result.IsError {
+			t.Fatalf("repeat %d result = (%+v, %v)", repeat, result, err)
 		}
+		text, _ := singleTextContent(result)
+		if text != localizationAnswerReadyNotice {
+			t.Fatalf("repeat %d text = %q", repeat, text)
+		}
+	}
+	if handlerCalls != 0 {
+		t.Fatalf("legacy handler invoked %d times after answer_ready", handlerCalls)
+	}
+	readRequest := mcpgo.CallToolRequest{Params: mcpgo.CallToolParams{
+		Name: "read",
+		Arguments: map[string]any{
+			"operation": "source",
+			"target":    map[string]any{"symbol": "repo/storage/disk.go::DiskStorage.Load"},
+		},
+	}}
+	readResult, err := srv.handleFacade(ctx, "read", readRequest)
+	if err != nil || readResult == nil || readResult.IsError {
+		t.Fatalf("post-terminal read = (%+v, %v)", readResult, err)
+	}
+	if text, _ := singleTextContent(readResult); text != localizationAnswerReadyNotice {
+		t.Fatalf("post-terminal read text = %q", text)
+	}
+	if handlerCalls != 0 {
+		t.Fatalf("read handler invoked %d times after answer_ready", handlerCalls)
+	}
+
+	// The pre-validation gate also catches malformed recovery attempts instead
+	// of spending a turn on schema errors.
+	request.Params.Arguments = map[string]any{"operation": "not_an_operation"}
+	result, err := srv.handleFacade(ctx, "search", request)
+	if err != nil || result == nil || result.IsError {
+		t.Fatalf("malformed post-terminal request = (%+v, %v)", result, err)
+	}
+	if text, _ := singleTextContent(result); text != localizationAnswerReadyNotice {
+		t.Fatalf("malformed post-terminal text = %q", text)
+	}
+
+	changeRequest := mcpgo.CallToolRequest{Params: mcpgo.CallToolParams{
+		Name:      "change",
+		Arguments: map[string]any{"operation": "detect"},
+	}}
+	changeResult, err := srv.handleFacade(ctx, "change", changeRequest)
+	if err != nil || changeResult == nil || changeResult.IsError || changeCalls != 1 {
+		t.Fatalf("post-terminal change.detect = (%+v, %v), calls=%d", changeResult, err, changeCalls)
+	}
+	if text, _ := singleTextContent(changeResult); text == localizationAnswerReadyNotice {
+		t.Fatal("post-terminal change.detect was incorrectly intercepted")
+	}
+
+	// Capabilities has a dedicated handler and remains usable after localization.
+	capabilitiesFrame := []byte(`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"capabilities","arguments":{}}}`)
+	raw, err := json.Marshal(srv.MCPServer().HandleMessage(ctx, capabilitiesFrame))
+	if err != nil {
+		t.Fatalf("marshal capabilities response: %v", err)
+	}
+	var called struct {
+		Error  any                   `json:"error"`
+		Result *mcpgo.CallToolResult `json:"result"`
+	}
+	if err := json.Unmarshal(raw, &called); err != nil {
+		t.Fatalf("decode capabilities response: %v", err)
+	}
+	if called.Error != nil || called.Result == nil || called.Result.IsError {
+		t.Fatalf("terminal capabilities response = error %#v result %#v", called.Error, called.Result)
+	}
+	if text, _ := singleTextContent(called.Result); text == localizationAnswerReadyNotice {
+		t.Fatalf("capabilities was incorrectly intercepted: %q", text)
 	}
 }

--- a/internal/mcp/localization_evidence_policy.go
+++ b/internal/mcp/localization_evidence_policy.go
@@ -1,0 +1,212 @@
+package mcp
+
+import "github.com/zzet/gortex/internal/graph"
+
+// Hard terminal enforcement is deliberately narrower than answer readiness.
+// The latter is a ranking decision; the former requires one of these bounded,
+// production-proven evidence shapes and must survive final response packing.
+const (
+	localizationProvenanceSourceLiteralCallee  = "source_literal_callee"
+	localizationProvenanceDivergentDefault     = "divergent_default_owner"
+	localizationProvenanceDivergentDefaultType = "divergent_default_type"
+	localizationProvenanceImplementationRoute  = "implementation_route"
+	localizationProvenanceImplementationTarget = "implementation_target"
+)
+
+type localizationEvidenceProof struct {
+	provenance string
+	primary    string
+	support    []string
+}
+
+func localizationStrongSourceLiteralCallee(target exploreTarget) bool {
+	return target.sourceLiteral && target.sourceLiteralCallee && target.exactContent &&
+		!target.exactContentAmbiguous && exploreHydratedProductionCallable(target)
+}
+
+func localizationStrongImplementationRoute(wrapper, implementation exploreTarget) bool {
+	if !wrapper.directCalleesComplete ||
+		!exploreHydratedProductionCallable(wrapper) ||
+		!exploreHydratedProductionCallable(implementation) ||
+		!exploreDraftGenericCandidate(wrapper.node, wrapper.source) ||
+		exploreDraftGenericCandidate(implementation.node, implementation.source) {
+		return false
+	}
+	matched := false
+	for _, callee := range wrapper.callees {
+		if callee == nil || callee.ID == "" || callee.ID == wrapper.node.ID ||
+			exploreDraftIsTestNode(callee) ||
+			(callee.Kind != graph.KindFunction && callee.Kind != graph.KindMethod) {
+			continue
+		}
+		if callee.ID != implementation.node.ID {
+			return false
+		}
+		matched = true
+	}
+	return matched
+}
+
+func localizationStrongEvidenceForCompletion(completion localizationCompletion, targets []exploreTarget) localizationEvidenceProof {
+	if completion.State != localizationStateAnswerReady && completion.State != localizationStateNeedsExactRead {
+		return localizationEvidenceProof{}
+	}
+
+	ownerID, ownerIndex := "", -1
+	typeID := ""
+	for index, target := range targets {
+		if target.node == nil || target.node.ID == "" {
+			continue
+		}
+		if target.divergentDefaultOwner && exploreHydratedProductionCallable(target) {
+			ownerID, ownerIndex = target.node.ID, index
+		}
+		if target.divergentDefaultType {
+			typeID = target.node.ID
+		}
+	}
+	if ownerID != "" && typeID != "" &&
+		((completion.ExactSymbol == "" && ownerIndex == 0) || completion.ExactSymbol == ownerID) {
+		return localizationEvidenceProof{
+			provenance: localizationProvenanceDivergentDefault,
+			primary:    ownerID,
+			support:    []string{typeID},
+		}
+	}
+
+	selected := -1
+	if completion.ExactSymbol != "" {
+		for index, target := range targets {
+			if target.node != nil && target.node.ID == completion.ExactSymbol {
+				selected = index
+				break
+			}
+		}
+	} else if len(targets) > 0 {
+		selected = 0
+	}
+	if selected >= 0 && localizationStrongSourceLiteralCallee(targets[selected]) {
+		return localizationEvidenceProof{
+			provenance: localizationProvenanceSourceLiteralCallee,
+			primary:    targets[selected].node.ID,
+		}
+	}
+	return localizationEvidenceProof{}
+}
+
+func localizationFinalizeCompletionEvidence(
+	completion localizationCompletion,
+	targets []exploreTarget,
+	envelope localizationExploreEnvelope,
+) localizationCompletion {
+	// Never trust an upstream or caller-supplied verdict. The policy is the
+	// sole producer of enforceability for initial localization responses.
+	completion.Enforceable = false
+	completion.enforceableOnAnswerReady = false
+	proof := localizationStrongEvidenceForCompletion(completion, targets)
+	if !localizationEvidenceProofVisible(proof, envelope) {
+		return completion
+	}
+	switch completion.State {
+	case localizationStateAnswerReady:
+		completion.Enforceable = true
+	case localizationStateNeedsExactRead:
+		completion.enforceableOnAnswerReady = true
+	}
+	return completion
+}
+
+func localizationBoundRouteEvidence(
+	routes map[string]localizationRefinementRoute,
+	envelope localizationExploreEnvelope,
+) map[string]localizationRefinementRoute {
+	for symbol, route := range routes {
+		if !route.enforceable {
+			continue
+		}
+		proof := localizationEvidenceProof{
+			provenance: localizationProvenanceSourceLiteralCallee,
+			primary:    symbol,
+		}
+		switch {
+		case route.proofSymbol != "":
+			proof.provenance = localizationProvenanceImplementationRoute
+			proof.primary = route.proofSymbol
+			proof.support = []string{symbol}
+		case route.implementationSymbol != "":
+			proof.provenance = localizationProvenanceImplementationRoute
+			proof.support = []string{route.implementationSymbol}
+		}
+		if !localizationEvidenceProofVisible(proof, envelope) {
+			route.enforceable = false
+			routes[symbol] = route
+		}
+	}
+	return routes
+}
+
+func localizationEvidenceProofVisible(proof localizationEvidenceProof, envelope localizationExploreEnvelope) bool {
+	if proof.provenance == "" || proof.primary == "" {
+		return false
+	}
+	visible := make(map[string]string, len(envelope.Evidence))
+	for _, evidence := range envelope.Evidence {
+		if evidence.ID != "" {
+			visible[evidence.ID] = evidence.Provenance
+		}
+	}
+	if visible[proof.primary] != proof.provenance {
+		return false
+	}
+	for _, support := range proof.support {
+		expected := ""
+		switch proof.provenance {
+		case localizationProvenanceDivergentDefault:
+			expected = localizationProvenanceDivergentDefaultType
+		case localizationProvenanceImplementationRoute:
+			expected = localizationProvenanceImplementationTarget
+		}
+		if support == "" || visible[support] != expected {
+			return false
+		}
+	}
+	return true
+}
+
+func localizationTargetProvenance(completion localizationCompletion, target exploreTarget) string {
+	if target.divergentDefaultOwner {
+		return localizationProvenanceDivergentDefault
+	}
+	if target.divergentDefaultType {
+		return localizationProvenanceDivergentDefaultType
+	}
+	if target.node == nil {
+		return ""
+	}
+	// Refinement routes need both distinct role markers on the packed wire.
+	// Give that paired proof priority over any independent literal role the
+	// same target may also carry.
+	for symbol, route := range completion.refinementRoutes {
+		if !route.enforceable {
+			continue
+		}
+		if route.proofSymbol != "" {
+			if target.node.ID == route.proofSymbol {
+				return localizationProvenanceImplementationRoute
+			}
+			if target.node.ID == symbol {
+				return localizationProvenanceImplementationTarget
+			}
+		}
+		if target.node.ID == symbol && route.implementationSymbol != "" {
+			return localizationProvenanceImplementationRoute
+		}
+		if target.node.ID == route.implementationSymbol {
+			return localizationProvenanceImplementationTarget
+		}
+	}
+	if localizationStrongSourceLiteralCallee(target) {
+		return localizationProvenanceSourceLiteralCallee
+	}
+	return ""
+}

--- a/internal/mcp/localization_evidence_policy.go
+++ b/internal/mcp/localization_evidence_policy.go
@@ -105,6 +105,12 @@ func localizationFinalizeCompletionEvidence(
 	completion.enforceableOnAnswerReady = false
 	proof := localizationStrongEvidenceForCompletion(completion, targets)
 	if !localizationEvidenceProofVisible(proof, envelope) {
+		if completion.State == localizationStateAnswerReady &&
+			(len(envelope.Evidence) > 0 || len(envelope.Symbols) > 0) {
+			recovery := newLocalizationRecoveryCompletion()
+			recovery.digest = completion.digest
+			return recovery
+		}
 		return completion
 	}
 	switch completion.State {

--- a/internal/mcp/localization_evidence_policy.go
+++ b/internal/mcp/localization_evidence_policy.go
@@ -6,11 +6,12 @@ import "github.com/zzet/gortex/internal/graph"
 // The latter is a ranking decision; the former requires one of these bounded,
 // production-proven evidence shapes and must survive final response packing.
 const (
-	localizationProvenanceSourceLiteralCallee  = "source_literal_callee"
-	localizationProvenanceDivergentDefault     = "divergent_default_owner"
-	localizationProvenanceDivergentDefaultType = "divergent_default_type"
-	localizationProvenanceImplementationRoute  = "implementation_route"
-	localizationProvenanceImplementationTarget = "implementation_target"
+	localizationProvenanceSourceLiteralCallee   = "source_literal_callee"
+	localizationProvenanceDivergentDefault      = "divergent_default_owner"
+	localizationProvenanceDivergentDefaultType  = "divergent_default_type"
+	localizationProvenanceImplementationRoute   = "implementation_route"
+	localizationProvenanceImplementationTarget  = "implementation_target"
+	localizationProvenanceTypedAnchorProjection = "typed_anchor_projection"
 )
 
 type localizationEvidenceProof struct {
@@ -213,6 +214,9 @@ func localizationTargetProvenance(completion localizationCompletion, target expl
 	}
 	if localizationStrongSourceLiteralCallee(target) {
 		return localizationProvenanceSourceLiteralCallee
+	}
+	if target.typedAnchorProjection {
+		return localizationProvenanceTypedAnchorProjection
 	}
 	return ""
 }

--- a/internal/mcp/localization_evidence_policy_test.go
+++ b/internal/mcp/localization_evidence_policy_test.go
@@ -1,0 +1,285 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+	"github.com/zzet/gortex/internal/query"
+)
+
+func requireLocalizationHostContractMatchesVisible(
+	t *testing.T,
+	result *mcpgo.CallToolResult,
+	envelope localizationExploreEnvelope,
+) localizationHostEnvelope {
+	t.Helper()
+	require.NotNil(t, result)
+	require.NotNil(t, result.Meta)
+	host, ok := result.Meta.AdditionalFields[localizationHostMetaKey].(localizationHostEnvelope)
+	require.True(t, ok, "authoritative localization metadata is missing")
+	visible := localizationTerminalContract{Completion: envelope.Completion, Terminal: envelope.Terminal}
+	visibleJSON, err := json.Marshal(visible)
+	require.NoError(t, err)
+	hostJSON, err := json.Marshal(host.Contract)
+	require.NoError(t, err)
+	require.JSONEq(t, string(visibleJSON), string(hostJSON))
+	return host
+}
+
+func TestLocalizationEvidencePolicyRejectsWeakFindLocaliserOwnerFromSQLiteCSharpIndex(t *testing.T) {
+	root := t.TempDir()
+	rel := "src/Humanizer/Localisation/Localiser.cs"
+	path := filepath.Join(root, filepath.FromSlash(rel))
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(`public sealed class Localiser {
+    public string FindLocaliser(string culture) {
+        return culture == "ku" ? "fallback" : culture;
+    }
+}
+`), 0o644))
+
+	store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "graph.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	registry := parser.NewRegistry()
+	languages.RegisterAll(registry)
+	idx := indexer.New(store, registry, config.IndexConfig{}, zap.NewNop())
+	_, err = idx.IndexCtx(context.Background(), root)
+	require.NoError(t, err)
+
+	owners := store.FindNodesByName("FindLocaliser")
+	require.NotEmpty(t, owners)
+	var owner *graph.Node
+	for _, candidate := range owners {
+		if candidate != nil && candidate.FilePath == rel && candidate.Kind == graph.KindMethod {
+			owner = candidate
+			break
+		}
+	}
+	require.NotNil(t, owner)
+
+	server := &Server{graph: store, indexer: idx, logger: zap.NewNop()}
+	recall := server.gatherExploreSourceLiteralRecall(
+		context.Background(), []string{"ku"}, "", query.QueryOptions{},
+	)
+	var hit *exploreSourceLiteralHit
+	for index := range recall.hits {
+		if recall.hits[index].nodeID == owner.ID {
+			hit = &recall.hits[index]
+			break
+		}
+	}
+	require.NotNil(t, hit)
+	require.False(t, hit.callee, "an enclosing owner without a resolved call edge is advisory")
+
+	target := exploreTarget{
+		node:          owner,
+		source:        server.manifestSymbolSource(context.Background(), owner),
+		exactContent:  true,
+		sourceLiteral: true,
+	}
+	result, _, _, completion := buildLocalizationExploreResultForTaskFinalized(
+		newLocalizationCompletion(true, ""), `FindLocaliser handles the literal "ku"`,
+		[]exploreTarget{target}, exploreDefaultBudgetTokens,
+	)
+	require.Equal(t, localizationStateAnswerReady, completion.State)
+	require.False(t, completion.Enforceable)
+
+	body, ok := singleTextContent(result)
+	require.True(t, ok)
+	var envelope localizationExploreEnvelope
+	require.NoError(t, json.Unmarshal([]byte(body), &envelope))
+	require.True(t, envelope.Terminal)
+	require.False(t, envelope.Completion.Enforceable)
+	require.Len(t, envelope.Evidence, 1)
+	require.Empty(t, envelope.Evidence[0].Provenance)
+
+	wire, err := json.Marshal(result)
+	require.NoError(t, err)
+	var roundTrip struct {
+		Meta map[string]json.RawMessage `json:"_meta"`
+	}
+	require.NoError(t, json.Unmarshal(wire, &roundTrip))
+	var host localizationHostEnvelope
+	require.NoError(t, json.Unmarshal(roundTrip.Meta[localizationHostMetaKey], &host))
+	require.Equal(t, localizationContractFor(envelope.Completion), host.Contract)
+}
+
+func TestLocalizationEvidencePolicyKeepsCompleteImplementationRouteAfterPacking(t *testing.T) {
+	wrapper := &graph.Node{
+		ID: "repo/src/replace.rs::Replacer.replace", Name: "replace",
+		Kind: graph.KindMethod, FilePath: "src/replace.rs",
+	}
+	implementation := &graph.Node{
+		ID: "repo/src/replace.rs::Replacer.replace_all", Name: "replace_all",
+		Kind: graph.KindMethod, FilePath: "src/replace.rs",
+	}
+	targets := []exploreTarget{
+		{
+			node: wrapper, directCalleesComplete: true,
+			source:  "fn replace(&self, text: &str) -> String { self.replace_all(text) }",
+			callees: []*graph.Node{implementation},
+		},
+		{
+			node: implementation,
+			source: `fn replace_all(&self, text: &str) -> String {
+				for capture in self.captures(text) { output.push_str(capture); }
+				output
+			}`,
+		},
+	}
+	routes := exploreLocalizationRefinementRoutes(targets)
+	result, completion, bounded, _ := buildLocalizationRefinementResultForTask(
+		implementation.ID, "find the replacement implementation", targets,
+		exploreDefaultBudgetTokens, routes,
+	)
+	require.Equal(t, localizationStateNeedsRefinement, completion.State)
+	require.True(t, bounded[wrapper.ID].enforceable)
+	require.True(t, bounded[implementation.ID].enforceable)
+	require.Equal(t, wrapper.ID, bounded[implementation.ID].proofSymbol)
+
+	state := &localizationTerminalState{}
+	state.armRefinementRoutesForTask(
+		"find the replacement implementation", completion.refinementSymbol,
+		completion.AllowedSymbols, bounded, nil,
+	)
+	blocked, allowed := state.authorize("read", "source", map[string]any{
+		"target": map[string]any{"symbol": implementation.ID},
+	})
+	require.Nil(t, blocked)
+	require.True(t, allowed)
+	finished := state.finishReservedRead(true)
+	require.Equal(t, localizationStateAnswerReady, finished.State)
+	require.True(t, finished.Enforceable)
+
+	body, ok := singleTextContent(result)
+	require.True(t, ok)
+	var envelope localizationExploreEnvelope
+	require.NoError(t, json.Unmarshal([]byte(body), &envelope))
+	require.False(t, envelope.Terminal)
+	require.False(t, envelope.Completion.Enforceable)
+	provenance := make(map[string]string, len(envelope.Evidence))
+	for _, row := range envelope.Evidence {
+		provenance[row.ID] = row.Provenance
+	}
+	require.Equal(t, localizationProvenanceImplementationRoute, provenance[wrapper.ID])
+	require.Equal(t, localizationProvenanceImplementationTarget, provenance[implementation.ID])
+	requireLocalizationHostContractMatchesVisible(t, result, envelope)
+}
+
+func TestLocalizationEvidencePolicyPrefersImplementationRouteForMixedStrongProofs(t *testing.T) {
+	wrapper := &graph.Node{
+		ID: "repo/src/replace.rs::Replacer.replace", Name: "replace",
+		Kind: graph.KindMethod, FilePath: "src/replace.rs",
+	}
+	implementation := &graph.Node{
+		ID: "repo/src/replace.rs::Replacer.replace_all", Name: "replace_all",
+		Kind: graph.KindMethod, FilePath: "src/replace.rs",
+	}
+	targets := []exploreTarget{
+		{
+			node: wrapper, directCalleesComplete: true,
+			source:  "fn replace(&self, text: &str) -> String { self.replace_all(text) }",
+			callees: []*graph.Node{implementation},
+		},
+		{
+			node: implementation,
+			source: `fn replace_all(&self, text: &str) -> String {
+				for capture in self.captures(text) { output.push_str(capture); }
+				output
+			}`,
+			sourceLiteral:       true,
+			sourceLiteralCallee: true,
+			exactContent:        true,
+		},
+	}
+	routes := exploreLocalizationRefinementRoutes(targets)
+	require.True(t, routes[implementation.ID].enforceable)
+	require.Equal(t, wrapper.ID, routes[implementation.ID].proofSymbol)
+
+	result, completion, bounded, _ := buildLocalizationRefinementResultForTask(
+		implementation.ID, "find the replacement implementation", targets,
+		exploreDefaultBudgetTokens, routes,
+	)
+	require.True(t, bounded[implementation.ID].enforceable)
+	body, ok := singleTextContent(result)
+	require.True(t, ok)
+	var envelope localizationExploreEnvelope
+	require.NoError(t, json.Unmarshal([]byte(body), &envelope))
+	provenance := make(map[string]string, len(envelope.Evidence))
+	for _, row := range envelope.Evidence {
+		provenance[row.ID] = row.Provenance
+	}
+	require.Equal(t, localizationProvenanceImplementationRoute, provenance[wrapper.ID])
+	require.Equal(t, localizationProvenanceImplementationTarget, provenance[implementation.ID])
+
+	state := &localizationTerminalState{}
+	state.armRefinementRoutesForTask(
+		"find the replacement implementation", completion.refinementSymbol,
+		completion.AllowedSymbols, bounded, nil,
+	)
+	blocked, allowed := state.authorize("read", "source", map[string]any{
+		"target": map[string]any{"symbol": implementation.ID},
+	})
+	require.Nil(t, blocked)
+	require.True(t, allowed)
+	finished := state.finishReservedRead(true)
+	require.Equal(t, localizationStateAnswerReady, finished.State)
+	require.True(t, finished.Enforceable)
+}
+
+func TestLocalizationEvidencePolicyRequiresEveryPackedProofRole(t *testing.T) {
+	owner := &graph.Node{
+		ID: "repo/RotatingFileHandler.php::__construct", Name: "__construct",
+		Kind: graph.KindMethod, FilePath: "src/RotatingFileHandler.php",
+	}
+	ownerTarget := exploreTarget{
+		node: owner, source: "public function __construct($filePermission = 0644) {}",
+		divergentDefaultOwner: true,
+	}
+	typeNode := &graph.Node{
+		ID: "repo/RotatingFileHandler.php::RotatingFileHandler", Name: "RotatingFileHandler",
+		Kind: graph.KindType, FilePath: "src/RotatingFileHandler.php",
+	}
+	typeTarget := exploreTarget{node: typeNode, divergentDefaultType: true}
+	targets := []exploreTarget{ownerTarget, typeTarget}
+	completion := newLocalizationCompletion(false, owner.ID)
+
+	completeEnvelope := localizationExploreEnvelope{Evidence: []localizationEvidence{
+		{ID: owner.ID, Provenance: localizationProvenanceDivergentDefault},
+		{ID: typeNode.ID, Provenance: localizationProvenanceDivergentDefaultType},
+	}}
+	complete := localizationFinalizeCompletionEvidence(completion, targets, completeEnvelope)
+	require.True(t, complete.enforceableOnAnswerReady)
+
+	missingSupport := completeEnvelope
+	missingSupport.Evidence = missingSupport.Evidence[:1]
+	incomplete := localizationFinalizeCompletionEvidence(completion, targets, missingSupport)
+	require.False(t, incomplete.enforceableOnAnswerReady)
+
+	ready := newLocalizationCompletion(true, "")
+	ready = localizationFinalizeCompletionEvidence(ready, targets, completeEnvelope)
+	require.True(t, ready.Enforceable)
+
+	spoofed := newLocalizationCompletion(true, "")
+	spoofed.Enforceable = true
+	spoofed.enforceableOnAnswerReady = true
+	weak := localizationFinalizeCompletionEvidence(spoofed, []exploreTarget{{
+		node: owner, source: ownerTarget.source, sourceLiteral: true, exactContent: true,
+	}}, localizationExploreEnvelope{Evidence: []localizationEvidence{{ID: owner.ID}}})
+	require.False(t, weak.Enforceable)
+	require.False(t, weak.enforceableOnAnswerReady)
+}

--- a/internal/mcp/localization_evidence_policy_test.go
+++ b/internal/mcp/localization_evidence_policy_test.go
@@ -95,14 +95,17 @@ func TestLocalizationEvidencePolicyRejectsWeakFindLocaliserOwnerFromSQLiteCSharp
 		newLocalizationCompletion(true, ""), `FindLocaliser handles the literal "ku"`,
 		[]exploreTarget{target}, exploreDefaultBudgetTokens,
 	)
-	require.Equal(t, localizationStateAnswerReady, completion.State)
+	require.Equal(t, localizationStateNeedsRecovery, completion.State)
 	require.False(t, completion.Enforceable)
+	require.Equal(t, "recover_once", completion.RequiredAction)
+	require.Equal(t, localizationRecoveryOperations, completion.AllowedOperations)
 
 	body, ok := singleTextContent(result)
 	require.True(t, ok)
 	var envelope localizationExploreEnvelope
 	require.NoError(t, json.Unmarshal([]byte(body), &envelope))
-	require.True(t, envelope.Terminal)
+	require.False(t, envelope.Terminal)
+	require.Equal(t, localizationStateNeedsRecovery, envelope.Completion.State)
 	require.False(t, envelope.Completion.Enforceable)
 	require.Len(t, envelope.Evidence, 1)
 	require.Empty(t, envelope.Evidence[0].Provenance)

--- a/internal/mcp/localization_evidence_policy_test.go
+++ b/internal/mcp/localization_evidence_policy_test.go
@@ -244,6 +244,29 @@ func TestLocalizationEvidencePolicyPrefersImplementationRouteForMixedStrongProof
 	require.True(t, finished.Enforceable)
 }
 
+func TestTypedAnchorProvenanceDoesNotOverrideStrongerEvidenceRoles(t *testing.T) {
+	node := &graph.Node{
+		ID: "repo/src/replace.rs::Replacer.replace_all", Name: "replace_all",
+		Kind: graph.KindMethod, FilePath: "src/replace.rs",
+	}
+	target := exploreTarget{
+		node: node, source: "fn replace_all() {}",
+		typedAnchorProjection: true,
+		sourceLiteral:         true, sourceLiteralCallee: true, exactContent: true,
+	}
+	if got := localizationTargetProvenance(newLocalizationCompletion(true, ""), target); got != localizationProvenanceSourceLiteralCallee {
+		t.Fatalf("source-literal provenance = %q, want %q", got, localizationProvenanceSourceLiteralCallee)
+	}
+
+	completion := newLocalizationRefinementCompletionForSymbols(node.ID, []string{node.ID})
+	completion.refinementRoutes = map[string]localizationRefinementRoute{
+		node.ID: {enforceable: true, implementationSymbol: "repo/src/replace.rs::Replacer.replace_impl"},
+	}
+	if got := localizationTargetProvenance(completion, target); got != localizationProvenanceImplementationRoute {
+		t.Fatalf("implementation-route provenance = %q, want %q", got, localizationProvenanceImplementationRoute)
+	}
+}
+
 func TestLocalizationEvidencePolicyRequiresEveryPackedProofRole(t *testing.T) {
 	owner := &graph.Node{
 		ID: "repo/RotatingFileHandler.php::__construct", Name: "__construct",

--- a/internal/mcp/localization_recovery_test.go
+++ b/internal/mcp/localization_recovery_test.go
@@ -1,0 +1,329 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestWeakReadAllowsOneBoundedSearchRecoveryThenTerminates(t *testing.T) {
+	server := setupPresetServer(t, ToolPolicyConfig{Preset: "core", Mode: "defer"})
+	ctx := WithSessionID(context.Background(), "weak_read_search_recovery")
+	terminal := server.localizationFor(ctx)
+	preferred := "repo/search.go::findCandidate"
+	terminal.armRefinementForTask("find candidate resolution", preferred, []string{preferred}, nil)
+
+	readSpec, ok := server.facades.operation("read", "source")
+	if !ok {
+		t.Fatal("read.source facade operation is missing")
+	}
+	searchSpec, ok := server.facades.operation("search", "text")
+	if !ok {
+		t.Fatal("search.text facade operation is missing")
+	}
+	readCalls := 0
+	searchCalls := 0
+	server.facades.capture(mcpgo.NewTool(readSpec.Legacy), func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		readCalls++
+		return mcpgo.NewToolResultText(`{"source":"func findCandidate() {}"}`), nil
+	})
+	server.facades.capture(mcpgo.NewTool(searchSpec.Legacy), func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		searchCalls++
+		return mcpgo.NewToolResultText(`{"matches":[{"symbol":"repo/search.go::resolveCandidate"}]}`), nil
+	})
+
+	readResult, err := server.handleFacade(ctx, "read", localizationRecoveryRequest("read", "source", map[string]any{
+		"target": map[string]any{"symbol": preferred},
+	}))
+	if err != nil || readResult == nil || readResult.IsError || readCalls != 1 {
+		t.Fatalf("weak preferred read = (%#v, %v), calls=%d", readResult, err, readCalls)
+	}
+	requireLocalizationResultStateEqual(t, terminal, readResult, localizationStateNeedsRecovery, false, 1)
+
+	searchResult, err := server.handleFacade(ctx, "search", localizationRecoveryRequest("search", "text", map[string]any{
+		"query": "resolveCandidate",
+	}))
+	if err != nil || searchResult == nil || searchResult.IsError || searchCalls != 1 {
+		t.Fatalf("bounded recovery search = (%#v, %v), calls=%d", searchResult, err, searchCalls)
+	}
+	requireLocalizationResultStateEqual(t, terminal, searchResult, localizationStateAnswerReady, true, 0)
+
+	extra, err := server.handleFacade(ctx, "search", localizationRecoveryRequest("search", "text", map[string]any{
+		"query": "another anchor",
+	}))
+	if err != nil {
+		t.Fatalf("post-recovery call returned transport error: %v", err)
+	}
+	requireLocalizationTerminalError(t, extra, "search", "text")
+	if searchCalls != 1 {
+		t.Fatalf("post-recovery search reached handler: calls=%d", searchCalls)
+	}
+}
+
+func TestRecoveryFailureRestoresOnceAndTerminalizesSameResponse(t *testing.T) {
+	server := setupPresetServer(t, ToolPolicyConfig{Preset: "core", Mode: "defer"})
+	ctx := WithSessionID(context.Background(), "weak_recovery_failure")
+	terminal := server.localizationFor(ctx)
+	terminal.armForTask(newLocalizationRecoveryCompletion(), "find candidate resolution")
+
+	searchSpec, ok := server.facades.operation("search", "symbols")
+	if !ok {
+		t.Fatal("search.symbols facade operation is missing")
+	}
+	calls := 0
+	server.facades.capture(mcpgo.NewTool(searchSpec.Legacy), func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		calls++
+		return nil, errors.New("recovery backend unavailable")
+	})
+	request := localizationRecoveryRequest("search", "symbols", map[string]any{"query": "resolveCandidate"})
+
+	first, err := server.handleFacade(ctx, "search", request)
+	if err != nil || first == nil || !first.IsError || calls != 1 {
+		t.Fatalf("first failed recovery = (%#v, %v), calls=%d", first, err, calls)
+	}
+	requireLocalizationResultStateEqual(t, terminal, first, localizationStateNeedsRecovery, false, 1)
+
+	second, err := server.handleFacade(ctx, "search", request)
+	if err != nil || second == nil || !second.IsError || calls != 2 {
+		t.Fatalf("second failed recovery = (%#v, %v), calls=%d", second, err, calls)
+	}
+	requireLocalizationResultStateEqual(t, terminal, second, localizationStateAnswerReady, true, 0)
+
+	third, err := server.handleFacade(ctx, "search", request)
+	if err != nil {
+		t.Fatalf("post-exhaustion search returned transport error: %v", err)
+	}
+	requireLocalizationTerminalError(t, third, "search", "symbols")
+	if calls != 2 {
+		t.Fatalf("recovery allowance restored more than once: calls=%d", calls)
+	}
+}
+
+func TestEnforceableAnswerReadyLocksBeforeHandler(t *testing.T) {
+	server := setupPresetServer(t, ToolPolicyConfig{Preset: "core", Mode: "defer"})
+	ctx := WithSessionID(context.Background(), "strong_answer_ready_lock")
+	completion := newLocalizationCompletion(true, "")
+	completion.Enforceable = true
+	server.localizationFor(ctx).armForTask(completion, "find candidate resolution")
+
+	searchSpec, ok := server.facades.operation("search", "text")
+	if !ok {
+		t.Fatal("search.text facade operation is missing")
+	}
+	calls := 0
+	server.facades.capture(mcpgo.NewTool(searchSpec.Legacy), func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		calls++
+		return mcpgo.NewToolResultText("unexpected"), nil
+	})
+
+	result, err := server.handleFacade(ctx, "search", localizationRecoveryRequest("search", "text", map[string]any{
+		"query": "resolveCandidate",
+	}))
+	if err != nil {
+		t.Fatalf("strong terminal search returned transport error: %v", err)
+	}
+	requireLocalizationTerminalError(t, result, "search", "text")
+	if calls != 0 {
+		t.Fatalf("enforceable answer_ready reached handler: calls=%d", calls)
+	}
+}
+
+func TestUnsupportedRecoveryAttemptTerminatesBeforeSchemaDispatch(t *testing.T) {
+	server := setupPresetServer(t, ToolPolicyConfig{Preset: "core", Mode: "defer"})
+	ctx := WithSessionID(context.Background(), "unsupported_recovery")
+	server.localizationFor(ctx).armForTask(newLocalizationRecoveryCompletion(), "find candidate resolution")
+
+	result, err := server.handleFacade(ctx, "search", localizationRecoveryRequest("search", "not_an_operation", map[string]any{
+		"query": "resolveCandidate",
+	}))
+	if err != nil || result == nil || !result.IsError {
+		t.Fatalf("unsupported recovery = (%#v, %v), want terminal tool error", result, err)
+	}
+	requireLocalizationTerminalError(t, result, "search", "not_an_operation")
+
+	valid, err := server.handleFacade(ctx, "search", localizationRecoveryRequest("search", "text", map[string]any{
+		"query": "resolveCandidate",
+	}))
+	if err != nil {
+		t.Fatalf("post-rejection recovery returned transport error: %v", err)
+	}
+	requireLocalizationTerminalError(t, valid, "search", "text")
+}
+
+func TestSchemaInvalidAllowedRecoveryTerminatesBeforeHandler(t *testing.T) {
+	server := setupPresetServer(t, ToolPolicyConfig{Preset: "core", Mode: "defer"})
+	ctx := WithSessionID(context.Background(), "schema_invalid_recovery")
+	terminal := server.localizationFor(ctx)
+	terminal.armForTask(newLocalizationRecoveryCompletion(), "find candidate resolution")
+
+	searchSpec, ok := server.facades.operation("search", "text")
+	if !ok {
+		t.Fatal("search.text facade operation is missing")
+	}
+	calls := 0
+	server.facades.capture(mcpgo.NewTool(searchSpec.Legacy), func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		calls++
+		return mcpgo.NewToolResultText("unexpected"), nil
+	})
+	invalid, err := server.handleFacade(ctx, "search", localizationRecoveryRequest("search", "text", map[string]any{
+		"query":   "resolveCandidate",
+		"options": "not-an-object",
+	}))
+	if err != nil || invalid == nil || !invalid.IsError {
+		t.Fatalf("schema-invalid recovery = (%#v, %v), want terminal tool error", invalid, err)
+	}
+	requireLocalizationResultStateEqual(t, terminal, invalid, localizationStateAnswerReady, true, 0)
+	if calls != 0 {
+		t.Fatalf("schema-invalid recovery reached handler: calls=%d", calls)
+	}
+
+	valid, err := server.handleFacade(ctx, "search", localizationRecoveryRequest("search", "text", map[string]any{
+		"query": "resolveCandidate",
+	}))
+	if err != nil {
+		t.Fatalf("post-invalid recovery returned transport error: %v", err)
+	}
+	requireLocalizationTerminalError(t, valid, "search", "text")
+	if calls != 0 {
+		t.Fatalf("recovery allowance survived invalid schema: calls=%d", calls)
+	}
+}
+
+func TestStaleInvalidRecoveryTicketCannotConsumeNewTaskState(t *testing.T) {
+	state := &localizationTerminalState{}
+	state.armForTask(newLocalizationRecoveryCompletion(), "old task")
+	blocked, oldGeneration := state.interceptAnswerReady("search", "text", map[string]any{"query": "old anchor"})
+	if blocked != nil || oldGeneration == 0 {
+		t.Fatalf("old invalid-recovery preflight = (%#v, %d)", blocked, oldGeneration)
+	}
+
+	state.armForTask(newLocalizationRecoveryCompletion(), "new task")
+	if completion, consumed := state.consumeInvalidRecovery("search", "text", oldGeneration); consumed {
+		t.Fatalf("stale invalid request consumed new task: %#v", completion)
+	}
+	state.mu.Lock()
+	stored := state.completionLocked()
+	state.mu.Unlock()
+	if stored.State != localizationStateNeedsRecovery || stored.AllowedToolCalls != 1 {
+		t.Fatalf("new task completion after stale invalid request = %#v", stored)
+	}
+
+	blocked, newGeneration := state.interceptAnswerReady("search", "text", map[string]any{"query": "new anchor"})
+	if blocked != nil || newGeneration == 0 || newGeneration == oldGeneration {
+		t.Fatalf("new invalid-recovery preflight = (%#v, %d), old generation=%d", blocked, newGeneration, oldGeneration)
+	}
+	completion, consumed := state.consumeInvalidRecovery("search", "text", newGeneration)
+	if !consumed || completion.State != localizationStateAnswerReady {
+		t.Fatalf("current invalid request consumption = (%#v, %v)", completion, consumed)
+	}
+}
+
+func TestStaleRecoveryCannotConsumeNewTaskState(t *testing.T) {
+	state := &localizationTerminalState{}
+	state.armForTask(newLocalizationRecoveryCompletion(), "old task")
+	blocked, token := state.authorizeWithToken("search", "text", map[string]any{"query": "old anchor"})
+	if blocked != nil || token == 0 {
+		t.Fatalf("old recovery reservation = (%#v, %d)", blocked, token)
+	}
+
+	state.reset()
+	strong := newLocalizationCompletion(true, "")
+	strong.Enforceable = true
+	state.armForTask(strong, "new task")
+	stale := state.finishReservedReadToken(token, true)
+	if stale.State != localizationStateInactive {
+		t.Fatalf("stale finisher completion = %#v, want inactive", stale)
+	}
+	if blocked, reserved := state.authorize("search", "text", map[string]any{"query": "new anchor"}); reserved {
+		t.Fatal("new strong task reserved a recovery call")
+	} else {
+		requireLocalizationTerminalError(t, blocked, "search", "text")
+	}
+}
+
+func localizationRecoveryRequest(facade, operation string, arguments map[string]any) mcpgo.CallToolRequest {
+	arguments["operation"] = operation
+	return mcpgo.CallToolRequest{Params: mcpgo.CallToolParams{Name: facade, Arguments: arguments}}
+}
+
+func requireLocalizationResultStateEqual(
+	t *testing.T,
+	state *localizationTerminalState,
+	result *mcpgo.CallToolResult,
+	wantState string,
+	wantTerminal bool,
+	wantAllowed int,
+) {
+	t.Helper()
+	if result == nil {
+		t.Fatal("localization result is nil")
+	}
+	payload, ok := result.StructuredContent.(map[string]any)
+	if !ok {
+		t.Fatalf("structured content = %T, want map", result.StructuredContent)
+	}
+	wire := decodeLocalizationCompletion(t, payload["completion"])
+	terminal, ok := payload["terminal"].(bool)
+	if !ok || terminal != wantTerminal {
+		t.Fatalf("structured terminal = %#v, want %v", payload["terminal"], wantTerminal)
+	}
+	if wire.State != wantState || wire.AllowedToolCalls != wantAllowed {
+		t.Fatalf("wire completion = %#v, want state=%q allowed=%d", wire, wantState, wantAllowed)
+	}
+	if wantState == localizationStateNeedsRecovery {
+		if wire.RequiredAction != "recover_once" || len(wire.AllowedOperations) != len(localizationRecoveryOperations) {
+			t.Fatalf("recovery completion is not directional/machine-readable: %#v", wire)
+		}
+		wantInstruction := `Make exactly one bounded Gortex recovery call: search(operation:"text" or "symbols", query:<specific anchor>) or read(operation:"source", target:{symbol:<exact id>}); then respond from the returned evidence.`
+		if wire.Instruction != wantInstruction {
+			t.Fatalf("recovery instruction = %q, want %q", wire.Instruction, wantInstruction)
+		}
+	}
+
+	if result.Meta == nil || result.Meta.AdditionalFields == nil {
+		t.Fatal("localization host metadata is missing")
+	}
+	host, ok := result.Meta.AdditionalFields[localizationHostMetaKey].(localizationHostEnvelope)
+	if !ok {
+		t.Fatalf("localization host metadata = %T, want localizationHostEnvelope", result.Meta.AdditionalFields[localizationHostMetaKey])
+	}
+	state.mu.Lock()
+	stored := state.completionLocked()
+	state.mu.Unlock()
+	requireLocalizationCompletionJSONEqual(t, wire, host.Contract.Completion, "wire/meta")
+	requireLocalizationCompletionJSONEqual(t, wire, stored, "wire/state")
+	if host.Contract.Terminal != wantTerminal {
+		t.Fatalf("host terminal = %v, want %v", host.Contract.Terminal, wantTerminal)
+	}
+}
+
+func decodeLocalizationCompletion(t *testing.T, value any) localizationCompletion {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal completion: %v", err)
+	}
+	var completion localizationCompletion
+	if err := json.Unmarshal(encoded, &completion); err != nil {
+		t.Fatalf("decode completion: %v", err)
+	}
+	return completion
+}
+
+func requireLocalizationCompletionJSONEqual(t *testing.T, left, right localizationCompletion, label string) {
+	t.Helper()
+	leftJSON, err := json.Marshal(left)
+	if err != nil {
+		t.Fatalf("marshal left %s completion: %v", label, err)
+	}
+	rightJSON, err := json.Marshal(right)
+	if err != nil {
+		t.Fatalf("marshal right %s completion: %v", label, err)
+	}
+	if string(leftJSON) != string(rightJSON) {
+		t.Fatalf("%s completion mismatch:\nwire=%s\nother=%s", label, leftJSON, rightJSON)
+	}
+}

--- a/internal/mcp/localization_recovery_test.go
+++ b/internal/mcp/localization_recovery_test.go
@@ -63,6 +63,56 @@ func TestWeakReadAllowsOneBoundedSearchRecoveryThenTerminates(t *testing.T) {
 	}
 }
 
+func TestRecoveryRejectsSearchAnchorUnrelatedToTaskBeforeHandler(t *testing.T) {
+	server := setupPresetServer(t, ToolPolicyConfig{Preset: "core", Mode: "defer"})
+	ctx := WithSessionID(context.Background(), "unrelated_recovery_anchor")
+	terminal := server.localizationFor(ctx)
+	terminal.armForTask(newLocalizationRecoveryCompletion(), "--multiline with --replace duplicates printer output")
+
+	searchSpec, ok := server.facades.operation("search", "text")
+	if !ok {
+		t.Fatal("search.text facade operation is missing")
+	}
+	calls := 0
+	server.facades.capture(mcpgo.NewTool(searchSpec.Legacy), func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		calls++
+		return mcpgo.NewToolResultText(`{"matches":[{"text":"fn sink_matched"}]}`), nil
+	})
+
+	result, err := server.handleFacade(ctx, "search", localizationRecoveryRequest("search", "text", map[string]any{
+		"query": "fn sink_matched",
+	}))
+	if err != nil {
+		t.Fatalf("unrelated recovery returned transport error: %v", err)
+	}
+	requireLocalizationTerminalError(t, result, "search", "text")
+	if calls != 0 {
+		t.Fatalf("unrelated recovery reached handler: calls=%d", calls)
+	}
+}
+
+func TestRecoveryAcceptsTaskAlignedIdentifierAndCompactLiteralAnchors(t *testing.T) {
+	tests := []struct {
+		name  string
+		task  string
+		query string
+	}{
+		{name: "identifier segment", task: "find candidate resolution", query: "resolveCandidate"},
+		{name: "flag", task: "--multiline with --replace duplicates output", query: "--replace"},
+		{name: "compact literal", task: `register the locale code "ku"`, query: "ku"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !localizationRecoveryQueryAligned(tt.task, tt.query) {
+				t.Fatalf("query %q should align with task %q", tt.query, tt.task)
+			}
+		})
+	}
+	if localizationRecoveryQueryAligned("--multiline with --replace duplicates output", "fn sink_matched") {
+		t.Fatal("generic adjacent declaration unexpectedly aligned with task")
+	}
+}
+
 func TestRecoveryFailureRestoresOnceAndTerminalizesSameResponse(t *testing.T) {
 	server := setupPresetServer(t, ToolPolicyConfig{Preset: "core", Mode: "defer"})
 	ctx := WithSessionID(context.Background(), "weak_recovery_failure")
@@ -194,13 +244,13 @@ func TestSchemaInvalidAllowedRecoveryTerminatesBeforeHandler(t *testing.T) {
 
 func TestStaleInvalidRecoveryTicketCannotConsumeNewTaskState(t *testing.T) {
 	state := &localizationTerminalState{}
-	state.armForTask(newLocalizationRecoveryCompletion(), "old task")
+	state.armForTask(newLocalizationRecoveryCompletion(), "old anchor task")
 	blocked, oldGeneration := state.interceptAnswerReady("search", "text", map[string]any{"query": "old anchor"})
 	if blocked != nil || oldGeneration == 0 {
 		t.Fatalf("old invalid-recovery preflight = (%#v, %d)", blocked, oldGeneration)
 	}
 
-	state.armForTask(newLocalizationRecoveryCompletion(), "new task")
+	state.armForTask(newLocalizationRecoveryCompletion(), "new anchor task")
 	if completion, consumed := state.consumeInvalidRecovery("search", "text", oldGeneration); consumed {
 		t.Fatalf("stale invalid request consumed new task: %#v", completion)
 	}
@@ -223,7 +273,7 @@ func TestStaleInvalidRecoveryTicketCannotConsumeNewTaskState(t *testing.T) {
 
 func TestStaleRecoveryCannotConsumeNewTaskState(t *testing.T) {
 	state := &localizationTerminalState{}
-	state.armForTask(newLocalizationRecoveryCompletion(), "old task")
+	state.armForTask(newLocalizationRecoveryCompletion(), "old anchor task")
 	blocked, token := state.authorizeWithToken("search", "text", map[string]any{"query": "old anchor"})
 	if blocked != nil || token == 0 {
 		t.Fatalf("old recovery reservation = (%#v, %d)", blocked, token)
@@ -277,7 +327,7 @@ func requireLocalizationResultStateEqual(
 		if wire.RequiredAction != "recover_once" || len(wire.AllowedOperations) != len(localizationRecoveryOperations) {
 			t.Fatalf("recovery completion is not directional/machine-readable: %#v", wire)
 		}
-		wantInstruction := `Make exactly one bounded Gortex recovery call: search(operation:"text" or "symbols", query:<specific anchor>) or read(operation:"source", target:{symbol:<exact id>}); then respond from the returned evidence.`
+		wantInstruction := `Make exactly one bounded Gortex recovery call: search(operation:"text" or "symbols", query:<specific task anchor>) or read(operation:"source", target:{symbol:<exact id>}); then respond from the returned evidence.`
 		if wire.Instruction != wantInstruction {
 			t.Fatalf("recovery instruction = %q, want %q", wire.Instruction, wantInstruction)
 		}

--- a/internal/mcp/localization_recovery_test.go
+++ b/internal/mcp/localization_recovery_test.go
@@ -113,6 +113,28 @@ func TestRecoveryAcceptsTaskAlignedIdentifierAndCompactLiteralAnchors(t *testing
 	}
 }
 
+func TestRecoveryRejectsDigestOnlyTermFromRG2095Incident(t *testing.T) {
+	terminal := newLocalizationTerminalState()
+	task := "--multiline with --replace causes duplicate output when a match spans multiple lines"
+	digest := &localizationEvidenceDigest{Evidence: []localizationDigestRow{{
+		ID:       "ripgrep/crates/printer/src/standard.rs::StandardSink.replacer",
+		Name:     "replacer",
+		QualName: "StandardSink.replacer",
+		File:     "crates/printer/src/standard.rs",
+	}}}
+	completion := newLocalizationRecoveryCompletion()
+	completion.digest = digest
+	terminal.armForTask(completion, task)
+
+	blocked, reserved := terminal.authorize("search", "text", map[string]any{"query": "fn sink_matched"})
+	if blocked == nil {
+		t.Fatal("digest-only generic sink term re-admitted the RG2095 recovery failure")
+	}
+	if reserved {
+		t.Fatal("rejected recovery unexpectedly reserved the one-shot allowance")
+	}
+}
+
 func TestRecoveryFailureRestoresOnceAndTerminalizesSameResponse(t *testing.T) {
 	server := setupPresetServer(t, ToolPolicyConfig{Preset: "core", Mode: "defer"})
 	ctx := WithSessionID(context.Background(), "weak_recovery_failure")

--- a/internal/mcp/localization_refinement_contract.go
+++ b/internal/mcp/localization_refinement_contract.go
@@ -1,3 +1,3 @@
 package mcp
 
-const localizationRefinementRequiredActionFormat = `Call Gortex MCP read(operation:"source", target:{symbol:%q}); do not call a host file-read tool.`
+const localizationRefinementRequiredActionFormat = `Call Gortex MCP read(operation:"source", target:{symbol:%q}); the named symbol is recommended; any returned candidate is permitted only when its ID appears in completion.allowed_symbols; do not call a host file-read tool.`

--- a/internal/mcp/localization_refinement_contract_test.go
+++ b/internal/mcp/localization_refinement_contract_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestLocalizationRefinementRequiredActionNamesFacadeReadSelector(t *testing.T) {
 	const symbol = "repo/pkg/file.go::Resolver.Run"
-	const want = `Call Gortex MCP read(operation:"source", target:{symbol:"repo/pkg/file.go::Resolver.Run"}); do not call a host file-read tool.`
+	const want = `Call Gortex MCP read(operation:"source", target:{symbol:"repo/pkg/file.go::Resolver.Run"}); do not call a host file-read tool. The named symbol is recommended; one source read of any returned candidate symbol is permitted.`
 	completion := newLocalizationRefinementCompletion(symbol)
 	if got := completion.RequiredAction; got != want {
 		t.Fatalf("refinement action = %q, want %q", got, want)

--- a/internal/mcp/localization_refinement_contract_test.go
+++ b/internal/mcp/localization_refinement_contract_test.go
@@ -2,18 +2,22 @@ package mcp
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 )
 
 func TestLocalizationRefinementRequiredActionNamesFacadeReadSelector(t *testing.T) {
 	const symbol = "repo/pkg/file.go::Resolver.Run"
-	const want = `Call Gortex MCP read(operation:"source", target:{symbol:"repo/pkg/file.go::Resolver.Run"}); do not call a host file-read tool. The named symbol is recommended; one source read of any returned candidate symbol is permitted.`
+	want := fmt.Sprintf(localizationRefinementRequiredActionFormat, symbol)
 	completion := newLocalizationRefinementCompletion(symbol)
 	if got := completion.RequiredAction; got != want {
 		t.Fatalf("refinement action = %q, want %q", got, want)
 	}
 	if completion.refinementSymbol != symbol {
 		t.Fatalf("refinement symbol = %q, want %q", completion.refinementSymbol, symbol)
+	}
+	if len(completion.AllowedSymbols) != 1 || completion.AllowedSymbols[0] != symbol {
+		t.Fatalf("allowed symbols = %v, want [%q]", completion.AllowedSymbols, symbol)
 	}
 	if completion.ExactSymbol != "" {
 		t.Fatalf("uncertain refinement falsely advertised exact symbol %q", completion.ExactSymbol)

--- a/internal/mcp/localization_refinement_route_test.go
+++ b/internal/mcp/localization_refinement_route_test.go
@@ -14,7 +14,7 @@ func TestRefinementRouteConcreteReadCompletesInOneCall(t *testing.T) {
 		"find the replace implementation",
 		concrete,
 		[]string{concrete},
-		map[string]localizationRefinementRoute{concrete: {}},
+		map[string]localizationRefinementRoute{concrete: {enforceable: true}},
 		nil,
 	)
 
@@ -346,7 +346,7 @@ func TestGenericCorrectionSharesOneRetryAcrossRouteHops(t *testing.T) {
 	}
 }
 
-func TestWeakPreferredReadWithoutPrevalidatedAlternateTerminates(t *testing.T) {
+func TestWeakPreferredReadWithoutPrevalidatedAlternateOffersRecovery(t *testing.T) {
 	state := &localizationTerminalState{}
 	preferred := "repo/search.go::findCandidate"
 	unproven := "repo/search.go::validateCandidate"
@@ -354,7 +354,10 @@ func TestWeakPreferredReadWithoutPrevalidatedAlternateTerminates(t *testing.T) {
 
 	requireRefinementSourceReservation(t, state, preferred)
 	completion := state.finishReservedRead(true)
-	requireRefinementCompletion(t, completion, localizationStateAnswerReady, "", 0)
+	requireRefinementCompletion(t, completion, localizationStateNeedsRecovery, "", 1)
+	if completion.RequiredAction != "recover_once" {
+		t.Fatalf("weak preferred completion action = %q, want recover_once", completion.RequiredAction)
+	}
 }
 
 func TestInitialRefinementFailureRestoresOnlyOnce(t *testing.T) {

--- a/internal/mcp/localization_refinement_route_test.go
+++ b/internal/mcp/localization_refinement_route_test.go
@@ -1,0 +1,170 @@
+package mcp
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestRefinementRouteConcreteReadCompletesInOneCall(t *testing.T) {
+	state := &localizationTerminalState{}
+	concrete := "repo/replace.go::replaceAll"
+	state.armRefinementRoutesForTask(
+		"find the replace implementation",
+		concrete,
+		[]string{concrete},
+		map[string]localizationRefinementRoute{concrete: {}},
+		nil,
+	)
+
+	requireRefinementSourceReservation(t, state, concrete)
+	completion := state.finishReservedRead(true)
+	requireRefinementCompletion(t, completion, localizationStateAnswerReady, "", 0)
+
+	result, reserved := state.authorize("read", "source", refinementSourceArgs(concrete))
+	if reserved || result == nil || result.IsError {
+		t.Fatalf("read after concrete completion = (%+v, %v), want successful terminal interception", result, reserved)
+	}
+}
+
+func TestRefinementRouteUsesActuallySelectedAlternateGenericCandidate(t *testing.T) {
+	state := &localizationTerminalState{}
+	preferred := "repo/replace.go::replaceAll"
+	generic := "repo/replacer.go::Replacer.Replace"
+	implementation := "repo/replacer.go::Replacer.replaceAll"
+	routes := map[string]localizationRefinementRoute{
+		preferred: {},
+		generic:   {implementationSymbol: implementation},
+	}
+	state.armRefinementRoutesForTask(
+		"find the replace implementation",
+		preferred,
+		[]string{preferred, generic},
+		routes,
+		nil,
+	)
+
+	requireRefinementSourceReservation(t, state, generic)
+	completion := state.finishReservedRead(true)
+	requireRefinementCompletion(t, completion, localizationStateNeedsExactRead, implementation, 1)
+
+	requireRefinementSourceReservation(t, state, implementation)
+	completion = state.finishReservedRead(true)
+	requireRefinementCompletion(t, completion, localizationStateAnswerReady, "", 0)
+
+	result, reserved := state.authorize("read", "source", refinementSourceArgs(implementation))
+	if reserved || result == nil || result.IsError {
+		t.Fatalf("third read = (%+v, %v), want successful terminal interception", result, reserved)
+	}
+}
+
+func TestRefinementRouteGenericReadFailureRestoresFirstAllowance(t *testing.T) {
+	state := &localizationTerminalState{}
+	generic := "repo/replacer.go::Replacer.Replace"
+	implementation := "repo/replacer.go::Replacer.replaceAll"
+	state.armRefinementRoutesForTask(
+		"find the replace implementation",
+		generic,
+		[]string{generic},
+		map[string]localizationRefinementRoute{
+			generic: {implementationSymbol: implementation},
+		},
+		nil,
+	)
+
+	requireRefinementSourceReservation(t, state, generic)
+	completion := state.finishReservedRead(false)
+	requireRefinementCompletion(t, completion, localizationStateNeedsRefinement, "", 1)
+
+	requireRefinementSourceReservation(t, state, generic)
+	state.finishReservedRead(false)
+}
+
+func TestRefinementRouteExactHopFailureRestoresExactAllowance(t *testing.T) {
+	state := &localizationTerminalState{}
+	generic := "repo/replacer.go::Replacer.Replace"
+	implementation := "repo/replacer.go::Replacer.replaceAll"
+	state.armRefinementRoutesForTask(
+		"find the replace implementation",
+		generic,
+		[]string{generic},
+		map[string]localizationRefinementRoute{
+			generic: {implementationSymbol: implementation},
+		},
+		nil,
+	)
+
+	requireRefinementSourceReservation(t, state, generic)
+	completion := state.finishReservedRead(true)
+	requireRefinementCompletion(t, completion, localizationStateNeedsExactRead, implementation, 1)
+
+	requireRefinementSourceReservation(t, state, implementation)
+	completion = state.finishReservedRead(false)
+	requireRefinementCompletion(t, completion, localizationStateNeedsExactRead, implementation, 1)
+
+	requireRefinementSourceReservation(t, state, implementation)
+	state.finishReservedRead(true)
+}
+
+func TestRefinementAllowedSymbolsMirrorSessionAuthorization(t *testing.T) {
+	state := &localizationTerminalState{}
+	preferred := "repo/replace.go::replaceAll"
+	generic := "repo/replacer.go::Replacer.Replace"
+	implementation := "repo/replacer.go::Replacer.replaceAll"
+	state.armRefinementRoutesForTask(
+		"find the replace implementation",
+		preferred,
+		[]string{preferred, generic},
+		map[string]localizationRefinementRoute{
+			preferred: {},
+			generic:   {implementationSymbol: implementation},
+		},
+		nil,
+	)
+
+	wire, err := json.Marshal(state.completionLocked())
+	if err != nil {
+		t.Fatalf("marshal localization completion: %v", err)
+	}
+	var completion localizationCompletion
+	if err := json.Unmarshal(wire, &completion); err != nil {
+		t.Fatalf("unmarshal localization completion: %v", err)
+	}
+	if !reflect.DeepEqual(completion.AllowedSymbols, state.refinementSymbols) {
+		t.Fatalf("wire allowed symbols = %v, state authorization = %v", completion.AllowedSymbols, state.refinementSymbols)
+	}
+	if !strings.Contains(completion.RequiredAction, "completion.allowed_symbols") {
+		t.Fatalf("required action does not name the authorization field: %q", completion.RequiredAction)
+	}
+	if strings.Contains(string(wire), implementation) {
+		t.Fatalf("serialized completion leaks session-only implementation hop %q: %s", implementation, wire)
+	}
+}
+
+func refinementSourceArgs(symbol string) map[string]any {
+	return map[string]any{"target": map[string]any{"symbol": symbol}}
+}
+
+func requireRefinementSourceReservation(t *testing.T, state *localizationTerminalState, symbol string) {
+	t.Helper()
+	blocked, reserved := state.authorize("read", "source", refinementSourceArgs(symbol))
+	if blocked != nil || !reserved {
+		t.Fatalf("source read reservation for %q = (%+v, %v), want reservation", symbol, blocked, reserved)
+	}
+}
+
+func requireRefinementCompletion(t *testing.T, completion localizationCompletion, state, exactSymbol string, allowed int) {
+	t.Helper()
+	if completion.State != state || completion.ExactSymbol != exactSymbol || completion.AllowedToolCalls != allowed {
+		t.Fatalf(
+			"completion = {state:%q exact:%q allowed:%d}, want {state:%q exact:%q allowed:%d}",
+			completion.State,
+			completion.ExactSymbol,
+			completion.AllowedToolCalls,
+			state,
+			exactSymbol,
+			allowed,
+		)
+	}
+}

--- a/internal/mcp/localization_refinement_route_test.go
+++ b/internal/mcp/localization_refinement_route_test.go
@@ -144,6 +144,325 @@ func TestRefinementAllowedSymbolsMirrorSessionAuthorization(t *testing.T) {
 	}
 }
 
+func TestWeakPreferredReadOffersOnePrecomputedCorrection(t *testing.T) {
+	state := &localizationTerminalState{}
+	preferred := "repo/localize.go::FindLocaliser"
+	alternate := "repo/format.go::RegisterDefaultFormatter"
+	third := "repo/format.go::Register"
+	state.armRefinementRoutesForTask(
+		"find where the short culture formatter is registered",
+		preferred,
+		[]string{preferred, alternate, third},
+		map[string]localizationRefinementRoute{
+			preferred: {},
+			alternate: {enforceable: true},
+			third:     {},
+		},
+		nil,
+	)
+
+	blocked, token := state.authorizeWithToken("read", "source", refinementSourceArgs(preferred))
+	if blocked != nil || token == 0 {
+		t.Fatalf("preferred weak read = (%+v, %d), want reservation", blocked, token)
+	}
+	completion := state.finishReservedReadToken(token, true)
+	requireRefinementCompletion(t, completion, localizationStateNeedsExactRead, alternate, 1)
+	if completion.Enforceable {
+		t.Fatal("weak correction completion became enforceable")
+	}
+	if completion.RequiredAction != "read_exact" ||
+		!strings.Contains(completion.Instruction, alternate) ||
+		!strings.Contains(completion.Instruction, `read(operation:"source"`) ||
+		!strings.Contains(completion.Instruction, "only permitted corrective read") {
+		t.Fatalf("correction contract is not machine-readable and directional: %#v", completion)
+	}
+
+	if result, reserved := state.authorize("read", "source", refinementSourceArgs(third)); reserved || result == nil {
+		t.Fatalf("wrong correction read = (%+v, %v), want blocked", result, reserved)
+	}
+	blocked, token = state.authorizeWithToken("read", "source", refinementSourceArgs(alternate))
+	if blocked != nil || token == 0 {
+		t.Fatalf("exact correction read = (%+v, %d), want reservation", blocked, token)
+	}
+	completion = state.finishReservedReadToken(token, true)
+	requireRefinementCompletion(t, completion, localizationStateAnswerReady, "", 0)
+	if !completion.Enforceable {
+		t.Fatal("prevalidated correction lost enforceability")
+	}
+
+	if result, reserved := state.authorize("read", "source", refinementSourceArgs(third)); reserved {
+		t.Fatal("third read reserved a handler")
+	} else {
+		requireLocalizationTerminalError(t, result, "read", "source")
+	}
+}
+
+func TestStrongPreferredReadRemainsOneReadTerminal(t *testing.T) {
+	state := &localizationTerminalState{}
+	preferred := "repo/replacer.go::Replacer.replaceAll"
+	alternate := "repo/replacer.go::Replacer.Replace"
+	state.armRefinementRoutesForTask(
+		"find the exact replacement implementation",
+		preferred,
+		[]string{preferred, alternate},
+		map[string]localizationRefinementRoute{
+			preferred: {enforceable: true},
+			alternate: {},
+		},
+		nil,
+	)
+
+	blocked, token := state.authorizeWithToken("read", "source", refinementSourceArgs(preferred))
+	if blocked != nil || token == 0 {
+		t.Fatalf("strong preferred read = (%+v, %d), want reservation", blocked, token)
+	}
+	completion := state.finishReservedReadToken(token, true)
+	requireRefinementCompletion(t, completion, localizationStateAnswerReady, "", 0)
+	if !completion.Enforceable {
+		t.Fatal("strong completion lost enforceability")
+	}
+	if result, reserved := state.authorize("read", "source", refinementSourceArgs(alternate)); reserved {
+		t.Fatal("strong route opened a corrective read")
+	} else {
+		requireLocalizationTerminalError(t, result, "read", "source")
+	}
+}
+
+func TestWeakPreferredReadExecutesGenericCorrectionRoute(t *testing.T) {
+	state := &localizationTerminalState{}
+	preferred := "repo/search.rs::find_candidate"
+	generic := "repo/replacer.rs::Replacer::replace"
+	implementation := "repo/replacer.rs::Replacer::replace_all"
+	route := localizationRefinementRoute{
+		implementationSymbol: implementation,
+		proofSymbol:          "repo/replacer.rs::Replacer",
+		enforceable:          true,
+	}
+	state.armRefinementRoutesForTask(
+		"find the replacement implementation",
+		preferred,
+		[]string{preferred, generic, implementation},
+		map[string]localizationRefinementRoute{
+			preferred:      {},
+			generic:        route,
+			implementation: {enforceable: true},
+		},
+		nil,
+	)
+
+	blocked, token := state.authorizeWithToken("read", "source", refinementSourceArgs(preferred))
+	if blocked != nil || token == 0 {
+		t.Fatalf("preferred weak read = (%+v, %d), want reservation", blocked, token)
+	}
+	completion := state.finishReservedReadToken(token, true)
+	requireRefinementCompletion(t, completion, localizationStateNeedsExactRead, generic, 1)
+	if state.exactReadRoute != route {
+		t.Fatalf("stored correction route = %#v, want %#v", state.exactReadRoute, route)
+	}
+
+	blocked, token = state.authorizeWithToken("read", "source", refinementSourceArgs(generic))
+	if blocked != nil || token == 0 {
+		t.Fatalf("generic correction read = (%+v, %d), want reservation", blocked, token)
+	}
+	completion = state.finishReservedReadToken(token, true)
+	requireRefinementCompletion(t, completion, localizationStateNeedsExactRead, implementation, 1)
+
+	blocked, token = state.authorizeWithToken("read", "source", refinementSourceArgs(implementation))
+	if blocked != nil || token == 0 {
+		t.Fatalf("implementation correction read = (%+v, %d), want reservation", blocked, token)
+	}
+	completion = state.finishReservedReadToken(token, true)
+	requireRefinementCompletion(t, completion, localizationStateAnswerReady, "", 0)
+	if !completion.Enforceable {
+		t.Fatal("proven generic correction route lost enforceability")
+	}
+	if result, reserved := state.authorize("read", "source", refinementSourceArgs(generic)); reserved {
+		t.Fatal("fourth route read reserved a handler")
+	} else {
+		requireLocalizationTerminalError(t, result, "read", "source")
+	}
+}
+
+func TestWeakPreferredReadSkipsUnprovenAlternate(t *testing.T) {
+	state := &localizationTerminalState{}
+	preferred := "repo/search.go::findCandidate"
+	unproven := "repo/search.go::validateCandidate"
+	prevalidated := "repo/search.go::resolveCandidate"
+	state.armRefinementRoutesForTask(
+		"find candidate resolution",
+		preferred,
+		[]string{preferred, unproven, prevalidated},
+		map[string]localizationRefinementRoute{
+			preferred:    {},
+			unproven:     {},
+			prevalidated: {enforceable: true},
+		},
+		nil,
+	)
+
+	requireRefinementSourceReservation(t, state, preferred)
+	completion := state.finishReservedRead(true)
+	requireRefinementCompletion(t, completion, localizationStateNeedsExactRead, prevalidated, 1)
+}
+
+func TestGenericCorrectionSharesOneRetryAcrossRouteHops(t *testing.T) {
+	state := &localizationTerminalState{}
+	preferred := "repo/search.rs::find_candidate"
+	generic := "repo/replacer.rs::Replacer::replace"
+	implementation := "repo/replacer.rs::Replacer::replace_all"
+	state.armRefinementRoutesForTask(
+		"find the replacement implementation",
+		preferred,
+		[]string{preferred, generic, implementation},
+		map[string]localizationRefinementRoute{
+			preferred: {},
+			generic:   {implementationSymbol: implementation, enforceable: true},
+			implementation: {
+				enforceable: true,
+			},
+		},
+		nil,
+	)
+
+	requireRefinementSourceReservation(t, state, preferred)
+	completion := state.finishReservedRead(true)
+	requireRefinementCompletion(t, completion, localizationStateNeedsExactRead, generic, 1)
+
+	requireRefinementSourceReservation(t, state, generic)
+	completion = state.finishReservedRead(false)
+	requireRefinementCompletion(t, completion, localizationStateNeedsExactRead, generic, 1)
+
+	requireRefinementSourceReservation(t, state, generic)
+	completion = state.finishReservedRead(true)
+	requireRefinementCompletion(t, completion, localizationStateNeedsExactRead, implementation, 1)
+
+	requireRefinementSourceReservation(t, state, implementation)
+	completion = state.finishReservedRead(false)
+	requireRefinementCompletion(t, completion, localizationStateAnswerReady, "", 0)
+	if result, reserved := state.authorize("read", "source", refinementSourceArgs(implementation)); reserved {
+		t.Fatal("implementation hop received a second route-level retry")
+	} else {
+		requireLocalizationTerminalError(t, result, "read", "source")
+	}
+}
+
+func TestWeakPreferredReadWithoutPrevalidatedAlternateTerminates(t *testing.T) {
+	state := &localizationTerminalState{}
+	preferred := "repo/search.go::findCandidate"
+	unproven := "repo/search.go::validateCandidate"
+	state.armRefinementForTask("find candidate resolution", preferred, []string{preferred, unproven}, nil)
+
+	requireRefinementSourceReservation(t, state, preferred)
+	completion := state.finishReservedRead(true)
+	requireRefinementCompletion(t, completion, localizationStateAnswerReady, "", 0)
+}
+
+func TestInitialRefinementFailureRestoresOnlyOnce(t *testing.T) {
+	state := &localizationTerminalState{}
+	preferred := "repo/search.go::findCandidate"
+	state.armRefinementForTask("find candidate resolution", preferred, []string{preferred}, nil)
+
+	requireRefinementSourceReservation(t, state, preferred)
+	completion := state.finishReservedRead(false)
+	requireRefinementCompletion(t, completion, localizationStateNeedsRefinement, "", 1)
+
+	requireRefinementSourceReservation(t, state, preferred)
+	completion = state.finishReservedRead(false)
+	requireRefinementCompletion(t, completion, localizationStateAnswerReady, "", 0)
+	if result, reserved := state.authorize("read", "source", refinementSourceArgs(preferred)); reserved {
+		t.Fatal("initial refinement failure restored more than once")
+	} else {
+		requireLocalizationTerminalError(t, result, "read", "source")
+	}
+}
+
+func TestWeakCorrectionFailureRestoresOnlyOnce(t *testing.T) {
+	state := &localizationTerminalState{}
+	preferred := "repo/localize.go::FindLocaliser"
+	alternate := "repo/format.go::RegisterDefaultFormatter"
+	state.armRefinementRoutesForTask(
+		"find the formatter registration",
+		preferred,
+		[]string{preferred, alternate},
+		map[string]localizationRefinementRoute{
+			preferred: {},
+			alternate: {enforceable: true},
+		},
+		nil,
+	)
+
+	blocked, token := state.authorizeWithToken("read", "source", refinementSourceArgs(preferred))
+	if blocked != nil || token == 0 {
+		t.Fatalf("preferred read = (%+v, %d), want reservation", blocked, token)
+	}
+	completion := state.finishReservedReadToken(token, false)
+	requireRefinementCompletion(t, completion, localizationStateNeedsRefinement, "", 1)
+
+	blocked, token = state.authorizeWithToken("read", "source", refinementSourceArgs(preferred))
+	if blocked != nil || token == 0 {
+		t.Fatalf("restored preferred read = (%+v, %d), want reservation", blocked, token)
+	}
+	completion = state.finishReservedReadToken(token, true)
+	requireRefinementCompletion(t, completion, localizationStateNeedsExactRead, alternate, 1)
+
+	blocked, token = state.authorizeWithToken("read", "source", refinementSourceArgs(alternate))
+	if blocked != nil || token == 0 {
+		t.Fatalf("correction read = (%+v, %d), want reservation", blocked, token)
+	}
+	completion = state.finishReservedReadToken(token, false)
+	requireRefinementCompletion(t, completion, localizationStateNeedsExactRead, alternate, 1)
+
+	blocked, token = state.authorizeWithToken("read", "source", refinementSourceArgs(alternate))
+	if blocked != nil || token == 0 {
+		t.Fatalf("restored correction read = (%+v, %d), want reservation", blocked, token)
+	}
+	completion = state.finishReservedReadToken(token, false)
+	requireRefinementCompletion(t, completion, localizationStateAnswerReady, "", 0)
+	if result, reserved := state.authorize("read", "source", refinementSourceArgs(alternate)); reserved {
+		t.Fatal("correction was restored more than once")
+	} else {
+		requireLocalizationTerminalError(t, result, "read", "source")
+	}
+}
+
+func TestStaleWeakReadCannotConsumeNewTaskCorrection(t *testing.T) {
+	state := &localizationTerminalState{}
+	oldPreferred := "repo/old.go::Find"
+	oldAlternate := "repo/old.go::Register"
+	state.armRefinementRoutesForTask(
+		"old task",
+		oldPreferred,
+		[]string{oldPreferred, oldAlternate},
+		map[string]localizationRefinementRoute{oldPreferred: {}, oldAlternate: {enforceable: true}},
+		nil,
+	)
+	blocked, oldToken := state.authorizeWithToken("read", "source", refinementSourceArgs(oldPreferred))
+	if blocked != nil || oldToken == 0 {
+		t.Fatalf("old read = (%+v, %d), want reservation", blocked, oldToken)
+	}
+
+	state.reset()
+	newPreferred := "repo/new.go::Find"
+	newAlternate := "repo/new.go::Register"
+	state.armRefinementRoutesForTask(
+		"new task",
+		newPreferred,
+		[]string{newPreferred, newAlternate},
+		map[string]localizationRefinementRoute{newPreferred: {}, newAlternate: {enforceable: true}},
+		nil,
+	)
+	blocked, newToken := state.authorizeWithToken("read", "source", refinementSourceArgs(newPreferred))
+	if blocked != nil || newToken == 0 || newToken == oldToken {
+		t.Fatalf("new read = (%+v, %d), old token %d", blocked, newToken, oldToken)
+	}
+
+	if stale := state.finishReservedReadToken(oldToken, true); stale.State != localizationStateInactive {
+		t.Fatalf("stale completion state = %q, want inactive", stale.State)
+	}
+	completion := state.finishReservedReadToken(newToken, true)
+	requireRefinementCompletion(t, completion, localizationStateNeedsExactRead, newAlternate, 1)
+}
+
 func refinementSourceArgs(symbol string) map[string]any {
 	return map[string]any{"target": map[string]any{"symbol": symbol}}
 }

--- a/internal/mcp/localization_refinement_route_test.go
+++ b/internal/mcp/localization_refinement_route_test.go
@@ -23,9 +23,10 @@ func TestRefinementRouteConcreteReadCompletesInOneCall(t *testing.T) {
 	requireRefinementCompletion(t, completion, localizationStateAnswerReady, "", 0)
 
 	result, reserved := state.authorize("read", "source", refinementSourceArgs(concrete))
-	if reserved || result == nil || result.IsError {
-		t.Fatalf("read after concrete completion = (%+v, %v), want successful terminal interception", result, reserved)
+	if reserved {
+		t.Fatal("read after concrete completion reserved a handler")
 	}
+	requireLocalizationTerminalError(t, result, "read", "source")
 }
 
 func TestRefinementRouteUsesActuallySelectedAlternateGenericCandidate(t *testing.T) {
@@ -54,9 +55,10 @@ func TestRefinementRouteUsesActuallySelectedAlternateGenericCandidate(t *testing
 	requireRefinementCompletion(t, completion, localizationStateAnswerReady, "", 0)
 
 	result, reserved := state.authorize("read", "source", refinementSourceArgs(implementation))
-	if reserved || result == nil || result.IsError {
-		t.Fatalf("third read = (%+v, %v), want successful terminal interception", result, reserved)
+	if reserved {
+		t.Fatal("third read reserved a handler")
 	}
+	requireLocalizationTerminalError(t, result, "read", "source")
 }
 
 func TestRefinementRouteGenericReadFailureRestoresFirstAllowance(t *testing.T) {

--- a/internal/mcp/localization_terminal.go
+++ b/internal/mcp/localization_terminal.go
@@ -23,18 +23,18 @@ const (
 // the server also enforces it for later Gortex navigation calls in the same
 // MCP session.
 type localizationCompletion struct {
-	State            string `json:"state"`
-	Scope            string `json:"scope"`
-	RequiredAction   string `json:"required_action"`
-	AllowedToolCalls int    `json:"allowed_tool_calls"`
-	ExactSymbol      string `json:"exact_symbol,omitempty"`
+	State            string   `json:"state"`
+	Scope            string   `json:"scope"`
+	RequiredAction   string   `json:"required_action"`
+	AllowedToolCalls int      `json:"allowed_tool_calls"`
+	ExactSymbol      string   `json:"exact_symbol,omitempty"`
+	AllowedSymbols   []string `json:"allowed_symbols,omitempty"`
 
-	// Refinement routing is session-only authorization state. Candidate IDs are
-	// already present once in the envelope's symbols field, so they are not
-	// serialized again. The concrete preferred ID remains in required_action;
-	// exact_symbol is reserved for the semantically exact-read state.
+	// Route hops stay session-only, while AllowedSymbols exposes the exact
+	// bounded authorization set carried by the wire contract.
 	refinementSymbol  string
 	refinementSymbols []string
+	refinementRoutes  map[string]localizationRefinementRoute
 
 	// digest is the bounded evidence projection carried session-only through
 	// reservation staging (see localization_digest.go). Post-terminal results
@@ -42,6 +42,13 @@ type localizationCompletion struct {
 	// completion through reservation staging into commitLocalizationLocked,
 	// which covers the direct-arm and facade finishLocalize paths alike.
 	digest *localizationEvidenceDigest
+}
+
+// localizationRefinementRoute is session-only. A zero implementation symbol
+// marks a concrete refinement candidate; a non-empty symbol is the one exact
+// concrete hop prevalidated for a generic forwarder.
+type localizationRefinementRoute struct {
+	implementationSymbol string
 }
 
 func newLocalizationCompletion(answerReady bool, exactSymbol string) localizationCompletion {
@@ -62,19 +69,33 @@ func newLocalizationCompletion(answerReady bool, exactSymbol string) localizatio
 	}
 }
 
+func newLocalizationOpenCompletion() localizationCompletion {
+	return localizationCompletion{
+		State:            localizationStateInactive,
+		Scope:            "localization",
+		RequiredAction:   "continue",
+		AllowedToolCalls: 0,
+	}
+}
+
 // newLocalizationRefinementCompletion keeps uncertain localization successful
 // and bounded. The ranked evidence remains usable, while the server permits
-// exactly one source read of a returned candidate instead of allowing another
-// broad exploration loop.
+// exactly one source read selected from the explicit wire authorization set.
 func newLocalizationRefinementCompletion(preferredSymbol string) localizationCompletion {
+	return newLocalizationRefinementCompletionForSymbols(preferredSymbol, []string{preferredSymbol})
+}
+
+func newLocalizationRefinementCompletionForSymbols(preferredSymbol string, allowedSymbols []string) localizationCompletion {
 	preferredSymbol = strings.TrimSpace(preferredSymbol)
+	allowedSymbols = append([]string(nil), allowedSymbols...)
 	return localizationCompletion{
-		State: localizationStateNeedsRefinement,
-		Scope: "localization",
-		RequiredAction: fmt.Sprintf(localizationRefinementRequiredActionFormat, preferredSymbol) +
-			" The named symbol is recommended; one source read of any returned candidate symbol is permitted.",
-		AllowedToolCalls: 1,
-		refinementSymbol: preferredSymbol,
+		State:             localizationStateNeedsRefinement,
+		Scope:             "localization",
+		RequiredAction:    fmt.Sprintf(localizationRefinementRequiredActionFormat, preferredSymbol),
+		AllowedToolCalls:  1,
+		AllowedSymbols:    allowedSymbols,
+		refinementSymbol:  preferredSymbol,
+		refinementSymbols: append([]string(nil), allowedSymbols...),
 	}
 }
 
@@ -87,10 +108,15 @@ type localizationTerminalState struct {
 	exactSymbol       string
 	refinementSymbol  string
 	refinementSymbols []string
-	taskFingerprint   string
-	generation        uint64
-	nextReservation   uint64
-	reservation       *localizationReservation
+	refinementRoutes  map[string]localizationRefinementRoute
+	// inFlightImplementationSymbol is selected from refinementRoutes when the
+	// actual requested candidate is authorized. It is never inferred from the
+	// read result.
+	inFlightImplementationSymbol string
+	taskFingerprint              string
+	generation                   uint64
+	nextReservation              uint64
+	reservation                  *localizationReservation
 	// digest is the evidence retained for the live contract; nil when the
 	// contract is inactive or predates digest capture. Promotions through
 	// finishReservedRead keep it — the evidence was stashed when the
@@ -120,6 +146,8 @@ func (s *localizationTerminalState) reset() {
 	s.exactSymbol = ""
 	s.refinementSymbol = ""
 	s.refinementSymbols = nil
+	s.refinementRoutes = nil
+	s.inFlightImplementationSymbol = ""
 	s.taskFingerprint = ""
 	s.digest = nil
 	// Keep an in-flight reservation until its owner finishes. Its captured
@@ -157,12 +185,37 @@ func (s *localizationTerminalState) keepOpenForTask(task string) {
 }
 
 func (s *localizationTerminalState) armRefinementForTask(task, preferredSymbol string, symbols []string, digest *localizationEvidenceDigest) {
+	routes := make(map[string]localizationRefinementRoute, len(symbols))
+	for _, symbol := range symbols {
+		symbol = strings.TrimSpace(symbol)
+		if symbol != "" {
+			routes[symbol] = localizationRefinementRoute{}
+		}
+	}
+	s.armRefinementRoutesForTask(task, preferredSymbol, symbols, routes, digest)
+}
+
+func (s *localizationTerminalState) armRefinementRoutesForTask(
+	task, preferredSymbol string,
+	symbols []string,
+	routes map[string]localizationRefinementRoute,
+	digest *localizationEvidenceDigest,
+) {
 	preferredSymbol = strings.TrimSpace(preferredSymbol)
-	seen := make(map[string]struct{}, min(len(symbols), 12))
-	refinementSymbols := make([]string, 0, min(len(symbols), 12))
+	seen := make(map[string]struct{}, min(len(symbols), localizationRefinementAllowedSymbolCap))
+	refinementSymbols := make([]string, 0, min(len(symbols), localizationRefinementAllowedSymbolCap))
+	refinementRoutes := make(map[string]localizationRefinementRoute, min(len(symbols), localizationRefinementAllowedSymbolCap))
 	for _, symbol := range symbols {
 		symbol = strings.TrimSpace(symbol)
 		if symbol == "" {
+			continue
+		}
+		route, authorized := routes[symbol]
+		if !authorized {
+			continue
+		}
+		route.implementationSymbol = strings.TrimSpace(route.implementationSymbol)
+		if route.implementationSymbol == symbol {
 			continue
 		}
 		if _, duplicate := seen[symbol]; duplicate {
@@ -170,7 +223,8 @@ func (s *localizationTerminalState) armRefinementForTask(task, preferredSymbol s
 		}
 		seen[symbol] = struct{}{}
 		refinementSymbols = append(refinementSymbols, symbol)
-		if len(refinementSymbols) == 12 {
+		refinementRoutes[symbol] = route
+		if len(refinementSymbols) == localizationRefinementAllowedSymbolCap {
 			break
 		}
 	}
@@ -179,10 +233,11 @@ func (s *localizationTerminalState) armRefinementForTask(task, preferredSymbol s
 		return
 	}
 	if _, exists := seen[preferredSymbol]; !exists {
-		preferredSymbol = refinementSymbols[0]
+		s.keepOpenForTask(task)
+		return
 	}
-	completion := newLocalizationRefinementCompletion(preferredSymbol)
-	completion.refinementSymbols = refinementSymbols
+	completion := newLocalizationRefinementCompletionForSymbols(preferredSymbol, refinementSymbols)
+	completion.refinementRoutes = refinementRoutes
 	// Stashed now, not at promotion: when the permitted read succeeds,
 	// finishReservedRead flips this contract to answer_ready and the
 	// evidence must already be retained for replay.
@@ -196,9 +251,12 @@ func (s *localizationTerminalState) commitLocalizationLocked(completion localiza
 	s.exactSymbol = completion.ExactSymbol
 	s.refinementSymbol = ""
 	s.refinementSymbols = nil
+	s.refinementRoutes = nil
+	s.inFlightImplementationSymbol = ""
 	if completion.State == localizationStateNeedsRefinement {
 		s.refinementSymbol = completion.refinementSymbol
 		s.refinementSymbols = append([]string(nil), completion.refinementSymbols...)
+		s.refinementRoutes = cloneLocalizationRefinementRoutes(completion.refinementRoutes)
 	}
 	s.taskFingerprint = fingerprint
 	// The digest follows the contract: an inactive commit (keepOpenForTask)
@@ -210,7 +268,8 @@ func (s *localizationTerminalState) completionLocked() localizationCompletion {
 	var completion localizationCompletion
 	switch s.state {
 	case localizationStateNeedsRefinement, localizationStateRefineInFlight:
-		completion = newLocalizationRefinementCompletion(s.refinementSymbol)
+		completion = newLocalizationRefinementCompletionForSymbols(s.refinementSymbol, s.refinementSymbols)
+		completion.refinementRoutes = cloneLocalizationRefinementRoutes(s.refinementRoutes)
 		if s.state == localizationStateRefineInFlight {
 			completion.State = localizationStateRefineInFlight
 			completion.AllowedToolCalls = 0
@@ -220,17 +279,6 @@ func (s *localizationTerminalState) completionLocked() localizationCompletion {
 	default:
 		completion = newLocalizationCompletion(true, "")
 	}
-	completion.digest = s.digest
-	return completion
-}
-
-func (s *localizationTerminalState) answerReadyCompletion() localizationCompletion {
-	completion := newLocalizationCompletion(true, "")
-	if s == nil {
-		return completion
-	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	completion.digest = s.digest
 	return completion
 }
@@ -254,12 +302,8 @@ func (s *localizationTerminalState) refinementAllowsLocked(symbol string) bool {
 	if symbol == "" {
 		return false
 	}
-	for _, candidate := range s.refinementSymbols {
-		if symbol == candidate {
-			return true
-		}
-	}
-	return false
+	_, authorized := s.refinementRoutes[symbol]
+	return authorized
 }
 
 // beginLocalize reserves the only localization handler slot for this session.
@@ -376,7 +420,9 @@ func (s *localizationTerminalState) authorize(facade, operation string, argument
 		s.state = localizationStateExactReadInFlight
 		return nil, true
 	}
-	if s.state == localizationStateNeedsRefinement && facade == "read" && operation == "source" && s.refinementAllowsLocked(exactLocalizationSymbol(arguments)) {
+	refinementSymbol := exactLocalizationSymbol(arguments)
+	if s.state == localizationStateNeedsRefinement && facade == "read" && operation == "source" && s.refinementAllowsLocked(refinementSymbol) {
+		s.inFlightImplementationSymbol = s.refinementRoutes[refinementSymbol].implementationSymbol
 		s.state = localizationStateRefineInFlight
 		return nil, true
 	}
@@ -404,9 +450,9 @@ func (s *localizationTerminalState) authorize(facade, operation string, argument
 	}), false
 }
 
-func (s *localizationTerminalState) finishReservedRead(success bool) {
+func (s *localizationTerminalState) finishReservedRead(success bool) localizationCompletion {
 	if s == nil {
-		return
+		return newLocalizationCompletion(true, "")
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -415,18 +461,40 @@ func (s *localizationTerminalState) finishReservedRead(success bool) {
 		if success {
 			s.state = localizationStateAnswerReady
 			s.exactSymbol = ""
-			return
+			s.inFlightImplementationSymbol = ""
+			return s.completionLocked()
 		}
 		s.state = localizationStateNeedsExactRead
 	case localizationStateRefineInFlight:
 		if success {
-			s.state = localizationStateAnswerReady
+			implementationSymbol := s.inFlightImplementationSymbol
+			s.inFlightImplementationSymbol = ""
 			s.refinementSymbol = ""
 			s.refinementSymbols = nil
-			return
+			s.refinementRoutes = nil
+			if implementationSymbol != "" {
+				s.state = localizationStateNeedsExactRead
+				s.exactSymbol = implementationSymbol
+				return s.completionLocked()
+			}
+			s.state = localizationStateAnswerReady
+			return s.completionLocked()
 		}
+		s.inFlightImplementationSymbol = ""
 		s.state = localizationStateNeedsRefinement
 	}
+	return s.completionLocked()
+}
+
+func cloneLocalizationRefinementRoutes(routes map[string]localizationRefinementRoute) map[string]localizationRefinementRoute {
+	if len(routes) == 0 {
+		return nil
+	}
+	cloned := make(map[string]localizationRefinementRoute, len(routes))
+	for symbol, route := range routes {
+		cloned[symbol] = route
+	}
+	return cloned
 }
 
 // block is retained for direct state checks; production dispatch uses

--- a/internal/mcp/localization_terminal.go
+++ b/internal/mcp/localization_terminal.go
@@ -103,7 +103,7 @@ func newLocalizationRecoveryCompletion() localizationCompletion {
 		State:             localizationStateNeedsRecovery,
 		Scope:             "localization",
 		RequiredAction:    "recover_once",
-		Instruction:       `Make exactly one bounded Gortex recovery call: search(operation:"text" or "symbols", query:<specific anchor>) or read(operation:"source", target:{symbol:<exact id>}); then respond from the returned evidence.`,
+		Instruction:       `Make exactly one bounded Gortex recovery call: search(operation:"text" or "symbols", query:<specific task anchor>) or read(operation:"source", target:{symbol:<exact id>}); then respond from the returned evidence.`,
 		AllowedToolCalls:  1,
 		ContractVersion:   localizationTerminalContractV2,
 		AllowedOperations: append([]string(nil), localizationRecoveryOperations...),
@@ -460,7 +460,7 @@ func (s *localizationTerminalState) interceptAnswerReady(facade, operation strin
 	case localizationStateAnswerReady:
 		return localizationTerminalResult(s.completionLocked(), facade, operation), 0
 	case localizationStateNeedsRecovery:
-		if localizationRecoveryAllows(facade, operation, arguments) {
+		if s.localizationRecoveryAllowsLocked(facade, operation, arguments) {
 			// Carry the task generation through later schema validation. A stale
 			// invalid request must never consume a newly committed task's recovery.
 			return nil, s.generation
@@ -493,6 +493,52 @@ func localizationRecoveryAllows(facade, operation string, arguments map[string]a
 	}
 }
 
+// localizationRecoveryAllowsLocked keeps the one-shot correction anchored to
+// the user request. Without this check an agent can invent a nearby generic
+// declaration name, receive valid-but-unrelated text hits, and mistake their
+// existence for causal evidence. Exact source reads remain available because
+// their symbol identity is itself a bounded declaration target.
+//
+// s.mu must be held by the caller.
+func (s *localizationTerminalState) localizationRecoveryAllowsLocked(facade, operation string, arguments map[string]any) bool {
+	if !localizationRecoveryAllows(facade, operation, arguments) {
+		return false
+	}
+	if facade != "search" {
+		return true
+	}
+	query, _ := arguments["query"].(string)
+	return localizationRecoveryQueryAligned(s.taskFingerprint, query)
+}
+
+func localizationRecoveryQueryAligned(task, query string) bool {
+	task = strings.TrimSpace(task)
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return false
+	}
+	if task == "" {
+		// Empty task fingerprints occur only in direct state tests and older
+		// sessions. Production recovery is always armed with a localize task.
+		return true
+	}
+	lowerTask := strings.ToLower(task)
+	lowerQuery := strings.ToLower(query)
+	// Preserve compact quoted literals and command-line flags that are too
+	// short for identifier tokenization but occur verbatim in the request.
+	trimmedAnchor := strings.Trim(lowerQuery, " \t\r\n`'\"")
+	if len(trimmedAnchor) >= 2 && strings.Contains(lowerTask, trimmedAnchor) {
+		return true
+	}
+	taskTerms := exploreTerminalTerms(task)
+	for term := range exploreTerminalTerms(query) {
+		if _, aligned := taskTerms[term]; aligned {
+			return true
+		}
+	}
+	return false
+}
+
 func localizationRecoveryOperationAllowed(facade, operation string) bool {
 	switch facade + "." + operation {
 	case "search.text", "search.symbols", "read.source":
@@ -519,7 +565,7 @@ func (s *localizationTerminalState) consumeInvalidRecovery(facade, operation str
 func localizationRecoveryRejectedResult(completion localizationCompletion, facade, operation string) *mcpgo.CallToolResult {
 	return newStructuredErrorResult(StructuredError{
 		ErrorCode: ErrCodeLocalizationTerminal,
-		Message:   "the one bounded localization recovery call must be search.text, search.symbols, or read.source with a concrete query or symbol; localization is now terminal",
+		Message:   "the one bounded localization recovery call must be search.text or search.symbols with a task-aligned query, or read.source with a concrete symbol; localization is now terminal",
 		Retriable: false,
 		Data: map[string]any{
 			"contract":           localizationContractFor(completion),
@@ -652,7 +698,7 @@ func (s *localizationTerminalState) authorizeWithToken(facade, operation string,
 		return localizationTerminalResult(s.completionLocked(), facade, operation), 0
 	}
 	if s.state == localizationStateNeedsRecovery {
-		if localizationRecoveryAllows(facade, operation, arguments) {
+		if s.localizationRecoveryAllowsLocked(facade, operation, arguments) {
 			s.state = localizationStateRecoveryInFlight
 			return nil, s.beginReadReservationLocked()
 		}

--- a/internal/mcp/localization_terminal.go
+++ b/internal/mcp/localization_terminal.go
@@ -27,6 +27,7 @@ type localizationCompletion struct {
 	State            string   `json:"state"`
 	Scope            string   `json:"scope"`
 	RequiredAction   string   `json:"required_action"`
+	Instruction      string   `json:"instruction,omitempty"`
 	AllowedToolCalls int      `json:"allowed_tool_calls"`
 	ContractVersion  int      `json:"contract_version"`
 	Enforceable      bool     `json:"enforceable"`
@@ -38,6 +39,11 @@ type localizationCompletion struct {
 	refinementSymbol  string
 	refinementSymbols []string
 	refinementRoutes  map[string]localizationRefinementRoute
+	// correctionSymbol is the one ranked alternate fixed when the contract is
+	// armed. It is session-only: after a successful advisory read the wire
+	// contract exposes it as ExactSymbol instead of opening another search.
+	correctionSymbol string
+	correctionRoute  localizationRefinementRoute
 	// enforceableOnAnswerReady is session-only provenance. A non-terminal
 	// completion may carry a prevalidated future verdict through its one
 	// authorized read without claiming that the current response is terminal.
@@ -97,10 +103,19 @@ func newLocalizationCompletion(answerReady bool, exactSymbol string) localizatio
 			ContractVersion:  localizationTerminalContractV2,
 		}
 	}
+	return newLocalizationExactReadCompletion(exactSymbol, false)
+}
+
+func newLocalizationExactReadCompletion(exactSymbol string, correction bool) localizationCompletion {
+	instruction := fmt.Sprintf(`Call Gortex MCP read(operation:"source", target:{symbol:%q}); then respond.`, exactSymbol)
+	if correction {
+		instruction = fmt.Sprintf(`Call Gortex MCP read(operation:"source", target:{symbol:%q}); this is the only permitted corrective read; then follow the returned completion.`, exactSymbol)
+	}
 	return localizationCompletion{
 		State:            localizationStateNeedsExactRead,
 		Scope:            "localization",
 		RequiredAction:   "read_exact",
+		Instruction:      instruction,
 		AllowedToolCalls: 1,
 		ContractVersion:  localizationTerminalContractV2,
 		ExactSymbol:      exactSymbol,
@@ -139,6 +154,25 @@ func newLocalizationRefinementCompletionForSymbols(preferredSymbol string, allow
 	}
 }
 
+func localizationRankedCorrection(
+	preferredSymbol string,
+	symbols []string,
+	routes map[string]localizationRefinementRoute,
+) (string, localizationRefinementRoute) {
+	for _, symbol := range symbols {
+		symbol = strings.TrimSpace(symbol)
+		if symbol == "" || symbol == preferredSymbol {
+			continue
+		}
+		route, authorized := routes[symbol]
+		if !authorized || (!route.enforceable && route.implementationSymbol == "") {
+			continue
+		}
+		return symbol, route
+	}
+	return "", localizationRefinementRoute{}
+}
+
 // localizationTerminalState is intentionally session-local. It bounds only
 // localization navigation; mutation, workspace, session, memory, and
 // capability tools remain usable after answer_ready and across later work.
@@ -149,11 +183,24 @@ type localizationTerminalState struct {
 	refinementSymbol  string
 	refinementSymbols []string
 	refinementRoutes  map[string]localizationRefinementRoute
+	correctionSymbol  string
+	correctionRoute   localizationRefinementRoute
 	// inFlightImplementationSymbol is selected from refinementRoutes when the
 	// actual requested candidate is authorized. It is never inferred from the
 	// read result.
 	inFlightImplementationSymbol string
 	inFlightEnforceable          bool
+	inFlightCorrectionSymbol     string
+	exactReadIsCorrection        bool
+	exactReadRoute               localizationRefinementRoute
+	correctionRetriesRemaining   uint8
+	refinementRetriesRemaining   uint8
+	// Read reservations are tokenized independently of localization calls. A
+	// reset or newly armed task invalidates an old token, so a late read cannot
+	// finish (or decorate itself with) a newer task's contract.
+	nextReadReservation  uint64
+	readReservationToken uint64
+	readReservationGen   uint64
 	// enforceableOnAnswerReady persists a proven verdict across an authorized
 	// exact/refinement read. Its zero value is deliberately advisory.
 	enforceableOnAnswerReady bool
@@ -191,8 +238,17 @@ func (s *localizationTerminalState) reset() {
 	s.refinementSymbol = ""
 	s.refinementSymbols = nil
 	s.refinementRoutes = nil
+	s.correctionSymbol = ""
+	s.correctionRoute = localizationRefinementRoute{}
 	s.inFlightImplementationSymbol = ""
 	s.inFlightEnforceable = false
+	s.inFlightCorrectionSymbol = ""
+	s.exactReadIsCorrection = false
+	s.exactReadRoute = localizationRefinementRoute{}
+	s.correctionRetriesRemaining = 0
+	s.refinementRetriesRemaining = 0
+	s.readReservationToken = 0
+	s.readReservationGen = 0
 	s.enforceableOnAnswerReady = false
 	s.taskFingerprint = ""
 	s.digest = nil
@@ -284,6 +340,11 @@ func (s *localizationTerminalState) armRefinementRoutesForTask(
 	}
 	completion := newLocalizationRefinementCompletionForSymbols(preferredSymbol, refinementSymbols)
 	completion.refinementRoutes = refinementRoutes
+	completion.correctionSymbol, completion.correctionRoute = localizationRankedCorrection(
+		preferredSymbol,
+		refinementSymbols,
+		refinementRoutes,
+	)
 	// Stashed now, not at promotion: when the permitted read succeeds,
 	// finishReservedRead flips this contract to answer_ready and the
 	// evidence must already be retained for replay.
@@ -300,6 +361,13 @@ func (s *localizationTerminalState) commitLocalizationLocked(completion localiza
 	s.refinementRoutes = nil
 	s.inFlightImplementationSymbol = ""
 	s.inFlightEnforceable = false
+	s.inFlightCorrectionSymbol = ""
+	s.exactReadIsCorrection = false
+	s.exactReadRoute = localizationRefinementRoute{}
+	s.correctionRetriesRemaining = 0
+	s.refinementRetriesRemaining = 0
+	s.readReservationToken = 0
+	s.readReservationGen = 0
 	s.enforceableOnAnswerReady = completion.enforceableOnAnswerReady
 	if completion.State == localizationStateAnswerReady {
 		s.enforceableOnAnswerReady = completion.Enforceable
@@ -308,6 +376,12 @@ func (s *localizationTerminalState) commitLocalizationLocked(completion localiza
 		s.refinementSymbol = completion.refinementSymbol
 		s.refinementSymbols = append([]string(nil), completion.refinementSymbols...)
 		s.refinementRoutes = cloneLocalizationRefinementRoutes(completion.refinementRoutes)
+		s.correctionSymbol = completion.correctionSymbol
+		s.correctionRoute = completion.correctionRoute
+		s.refinementRetriesRemaining = 1
+	} else {
+		s.correctionSymbol = ""
+		s.correctionRoute = localizationRefinementRoute{}
 	}
 	s.taskFingerprint = fingerprint
 	// The digest follows the contract: an inactive commit (keepOpenForTask)
@@ -326,7 +400,9 @@ func (s *localizationTerminalState) completionLocked() localizationCompletion {
 			completion.AllowedToolCalls = 0
 		}
 	case localizationStateNeedsExactRead, localizationStateExactReadInFlight:
-		completion = newLocalizationCompletion(false, s.exactSymbol)
+		completion = newLocalizationExactReadCompletion(s.exactSymbol, s.exactReadIsCorrection)
+	case localizationStateInactive:
+		completion = newLocalizationOpenCompletion()
 	default:
 		completion = newLocalizationCompletion(true, "")
 	}
@@ -454,35 +530,46 @@ func localizationTaskFingerprint(task string) string {
 // after invocation so a failed read restores the allowance instead of silently
 // consuming it.
 func (s *localizationTerminalState) authorize(facade, operation string, arguments map[string]any) (*mcpgo.CallToolResult, bool) {
+	blocked, token := s.authorizeWithToken(facade, operation, arguments)
+	return blocked, token != 0
+}
+
+func (s *localizationTerminalState) authorizeWithToken(facade, operation string, arguments map[string]any) (*mcpgo.CallToolResult, uint64) {
 	if s == nil || !localizationNavigationFacade(facade) {
-		return nil, false
+		return nil, 0
 	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.reservation != nil {
-		return localizationInProgressResult(), false
+		return localizationInProgressResult(), 0
 	}
 	if s.state == localizationStateInactive {
-		return nil, false
+		return nil, 0
 	}
 	// answer_ready terminates only localization navigation. Catch those facades
 	// before their handlers can run and return a compact typed instruction;
 	// unrelated work remains dispatchable through the early return above.
 	if s.state == localizationStateAnswerReady {
-		return localizationTerminalResult(s.completionLocked(), facade, operation), false
+		return localizationTerminalResult(s.completionLocked(), facade, operation), 0
 	}
 	if s.state == localizationStateNeedsExactRead && facade == "read" && operation == "source" && exactLocalizationSymbol(arguments) == s.exactSymbol {
+		s.inFlightImplementationSymbol = s.exactReadRoute.implementationSymbol
+		s.inFlightEnforceable = s.exactReadRoute.enforceable
 		s.state = localizationStateExactReadInFlight
-		return nil, true
+		return nil, s.beginReadReservationLocked()
 	}
 	refinementSymbol := exactLocalizationSymbol(arguments)
 	if s.state == localizationStateNeedsRefinement && facade == "read" && operation == "source" && s.refinementAllowsLocked(refinementSymbol) {
 		route := s.refinementRoutes[refinementSymbol]
 		s.inFlightImplementationSymbol = route.implementationSymbol
 		s.inFlightEnforceable = route.enforceable
+		s.inFlightCorrectionSymbol = ""
+		if refinementSymbol == s.refinementSymbol && !route.enforceable && route.implementationSymbol == "" && s.correctionSymbol != "" {
+			s.inFlightCorrectionSymbol = s.correctionSymbol
+		}
 		s.state = localizationStateRefineInFlight
-		return nil, true
+		return nil, s.beginReadReservationLocked()
 	}
 
 	completion := s.completionLocked()
@@ -497,48 +584,123 @@ func (s *localizationTerminalState) authorize(facade, operation string, argument
 	case localizationStateRefineInFlight:
 		message = "the permitted localization refinement read is already in progress"
 	}
-	return NewStructuredErrorResult(StructuredError{
+	return newStructuredErrorResult(StructuredError{
 		ErrorCode: ErrCodeLocalizationComplete,
 		Message:   message,
+		Retriable: false,
 		Data: map[string]any{
 			"completion": completion,
 			"facade":     facade,
 			"operation":  operation,
 		},
-	}), false
+	}, true), 0
 }
 
+func (s *localizationTerminalState) beginReadReservationLocked() uint64 {
+	s.nextReadReservation++
+	if s.nextReadReservation == 0 {
+		s.nextReadReservation++
+	}
+	s.readReservationToken = s.nextReadReservation
+	s.readReservationGen = s.generation
+	return s.readReservationToken
+}
+
+// finishReservedRead is retained for direct state tests. Production dispatch
+// carries the exact token returned by authorizeWithToken so a stale finisher
+// can never consume a later task's read.
 func (s *localizationTerminalState) finishReservedRead(success bool) localizationCompletion {
 	if s == nil {
 		return newLocalizationCompletion(true, "")
 	}
 	s.mu.Lock()
+	token := s.readReservationToken
+	s.mu.Unlock()
+	return s.finishReservedReadToken(token, success)
+}
+
+func (s *localizationTerminalState) finishReservedReadToken(token uint64, success bool) localizationCompletion {
+	if s == nil {
+		return newLocalizationOpenCompletion()
+	}
+	s.mu.Lock()
 	defer s.mu.Unlock()
+	if token == 0 || token != s.readReservationToken || s.readReservationGen != s.generation {
+		return newLocalizationOpenCompletion()
+	}
+	s.readReservationToken = 0
+	s.readReservationGen = 0
 	switch s.state {
 	case localizationStateExactReadInFlight:
-		if success {
-			s.state = localizationStateAnswerReady
-			s.exactSymbol = ""
-			s.inFlightImplementationSymbol = ""
-			return s.completionLocked()
-		}
+		implementationSymbol := s.inFlightImplementationSymbol
+		routeEnforceable := s.inFlightEnforceable
 		s.inFlightImplementationSymbol = ""
 		s.inFlightEnforceable = false
+		s.inFlightCorrectionSymbol = ""
+		if success {
+			if routeEnforceable {
+				s.enforceableOnAnswerReady = true
+			}
+			if s.exactReadIsCorrection && implementationSymbol != "" {
+				s.state = localizationStateNeedsExactRead
+				s.exactSymbol = implementationSymbol
+				s.exactReadRoute = localizationRefinementRoute{enforceable: routeEnforceable}
+				return s.completionLocked()
+			}
+			s.state = localizationStateAnswerReady
+			s.exactSymbol = ""
+			s.correctionSymbol = ""
+			s.correctionRoute = localizationRefinementRoute{}
+			s.exactReadIsCorrection = false
+			s.exactReadRoute = localizationRefinementRoute{}
+			s.correctionRetriesRemaining = 0
+			return s.completionLocked()
+		}
 		s.enforceableOnAnswerReady = false
+		if s.exactReadIsCorrection {
+			if s.correctionRetriesRemaining > 0 {
+				s.correctionRetriesRemaining--
+				s.state = localizationStateNeedsExactRead
+				return s.completionLocked()
+			}
+			s.state = localizationStateAnswerReady
+			s.exactSymbol = ""
+			s.exactReadIsCorrection = false
+			s.exactReadRoute = localizationRefinementRoute{}
+			s.correctionRetriesRemaining = 0
+			return s.completionLocked()
+		}
 		s.state = localizationStateNeedsExactRead
 	case localizationStateRefineInFlight:
 		if success {
 			implementationSymbol := s.inFlightImplementationSymbol
 			enforceable := s.inFlightEnforceable
+			correctionSymbol := s.inFlightCorrectionSymbol
+			correctionRoute := s.correctionRoute
 			s.inFlightImplementationSymbol = ""
 			s.inFlightEnforceable = false
+			s.inFlightCorrectionSymbol = ""
 			s.enforceableOnAnswerReady = enforceable
 			s.refinementSymbol = ""
 			s.refinementSymbols = nil
 			s.refinementRoutes = nil
+			s.correctionSymbol = ""
+			s.correctionRoute = localizationRefinementRoute{}
+			s.refinementRetriesRemaining = 0
 			if implementationSymbol != "" {
 				s.state = localizationStateNeedsExactRead
 				s.exactSymbol = implementationSymbol
+				s.exactReadIsCorrection = true
+				s.exactReadRoute = localizationRefinementRoute{enforceable: enforceable}
+				s.correctionRetriesRemaining = 1
+				return s.completionLocked()
+			}
+			if correctionSymbol != "" {
+				s.state = localizationStateNeedsExactRead
+				s.exactSymbol = correctionSymbol
+				s.exactReadIsCorrection = true
+				s.exactReadRoute = correctionRoute
+				s.correctionRetriesRemaining = 1
 				return s.completionLocked()
 			}
 			s.state = localizationStateAnswerReady
@@ -546,8 +708,19 @@ func (s *localizationTerminalState) finishReservedRead(success bool) localizatio
 		}
 		s.inFlightImplementationSymbol = ""
 		s.inFlightEnforceable = false
+		s.inFlightCorrectionSymbol = ""
 		s.enforceableOnAnswerReady = false
-		s.state = localizationStateNeedsRefinement
+		if s.refinementRetriesRemaining > 0 {
+			s.refinementRetriesRemaining--
+			s.state = localizationStateNeedsRefinement
+			return s.completionLocked()
+		}
+		s.state = localizationStateAnswerReady
+		s.refinementSymbol = ""
+		s.refinementSymbols = nil
+		s.refinementRoutes = nil
+		s.correctionSymbol = ""
+		s.correctionRoute = localizationRefinementRoute{}
 	}
 	return s.completionLocked()
 }

--- a/internal/mcp/localization_terminal.go
+++ b/internal/mcp/localization_terminal.go
@@ -16,6 +16,7 @@ const (
 	localizationStateRefineInFlight    = "refinement_in_flight"
 	localizationStateExactReadInFlight = "exact_read_in_flight"
 	localizationStateAnswerReady       = "answer_ready"
+	localizationTerminalContractV2     = 2
 )
 
 // localizationCompletion is the host-neutral terminality contract returned by
@@ -27,6 +28,8 @@ type localizationCompletion struct {
 	Scope            string   `json:"scope"`
 	RequiredAction   string   `json:"required_action"`
 	AllowedToolCalls int      `json:"allowed_tool_calls"`
+	ContractVersion  int      `json:"contract_version"`
+	Enforceable      bool     `json:"enforceable"`
 	ExactSymbol      string   `json:"exact_symbol,omitempty"`
 	AllowedSymbols   []string `json:"allowed_symbols,omitempty"`
 
@@ -35,6 +38,11 @@ type localizationCompletion struct {
 	refinementSymbol  string
 	refinementSymbols []string
 	refinementRoutes  map[string]localizationRefinementRoute
+	// enforceableOnAnswerReady is session-only provenance. A non-terminal
+	// completion may carry a prevalidated future verdict through its one
+	// authorized read without claiming that the current response is terminal.
+	// It defaults false until the evidence policy explicitly opts in.
+	enforceableOnAnswerReady bool
 
 	// digest is the bounded evidence projection carried session-only through
 	// reservation staging (see localization_digest.go). Post-terminal results
@@ -49,6 +57,30 @@ type localizationCompletion struct {
 // concrete hop prevalidated for a generic forwarder.
 type localizationRefinementRoute struct {
 	implementationSymbol string
+	// enforceable is set only by the centralized evidence policy after it has
+	// proved the entire route. A successful read alone never upgrades trust.
+	enforceable bool
+}
+
+// localizationTerminalContract is the single wire shape used in visible MCP
+// payloads and authoritative host-only metadata. Hosts must treat _meta as the
+// authority; the visible copy remains useful to agents and legacy harnesses.
+type localizationTerminalContract struct {
+	Completion localizationCompletion `json:"completion"`
+	Terminal   bool                   `json:"terminal"`
+}
+
+func localizationContractFor(completion localizationCompletion) localizationTerminalContract {
+	if completion.ContractVersion == 0 {
+		completion.ContractVersion = localizationTerminalContractV2
+	}
+	if completion.State != localizationStateAnswerReady {
+		completion.Enforceable = false
+	}
+	return localizationTerminalContract{
+		Completion: completion,
+		Terminal:   completion.State == localizationStateAnswerReady,
+	}
 }
 
 func newLocalizationCompletion(answerReady bool, exactSymbol string) localizationCompletion {
@@ -58,6 +90,7 @@ func newLocalizationCompletion(answerReady bool, exactSymbol string) localizatio
 			Scope:            "localization",
 			RequiredAction:   "respond",
 			AllowedToolCalls: 0,
+			ContractVersion:  localizationTerminalContractV2,
 		}
 	}
 	return localizationCompletion{
@@ -65,6 +98,7 @@ func newLocalizationCompletion(answerReady bool, exactSymbol string) localizatio
 		Scope:            "localization",
 		RequiredAction:   "read_exact",
 		AllowedToolCalls: 1,
+		ContractVersion:  localizationTerminalContractV2,
 		ExactSymbol:      exactSymbol,
 	}
 }
@@ -75,6 +109,7 @@ func newLocalizationOpenCompletion() localizationCompletion {
 		Scope:            "localization",
 		RequiredAction:   "continue",
 		AllowedToolCalls: 0,
+		ContractVersion:  localizationTerminalContractV2,
 	}
 }
 
@@ -93,6 +128,7 @@ func newLocalizationRefinementCompletionForSymbols(preferredSymbol string, allow
 		Scope:             "localization",
 		RequiredAction:    fmt.Sprintf(localizationRefinementRequiredActionFormat, preferredSymbol),
 		AllowedToolCalls:  1,
+		ContractVersion:   localizationTerminalContractV2,
 		AllowedSymbols:    allowedSymbols,
 		refinementSymbol:  preferredSymbol,
 		refinementSymbols: append([]string(nil), allowedSymbols...),
@@ -113,10 +149,14 @@ type localizationTerminalState struct {
 	// actual requested candidate is authorized. It is never inferred from the
 	// read result.
 	inFlightImplementationSymbol string
-	taskFingerprint              string
-	generation                   uint64
-	nextReservation              uint64
-	reservation                  *localizationReservation
+	inFlightEnforceable          bool
+	// enforceableOnAnswerReady persists a proven verdict across an authorized
+	// exact/refinement read. Its zero value is deliberately advisory.
+	enforceableOnAnswerReady bool
+	taskFingerprint          string
+	generation               uint64
+	nextReservation          uint64
+	reservation              *localizationReservation
 	// digest is the evidence retained for the live contract; nil when the
 	// contract is inactive or predates digest capture. Promotions through
 	// finishReservedRead keep it — the evidence was stashed when the
@@ -148,6 +188,8 @@ func (s *localizationTerminalState) reset() {
 	s.refinementSymbols = nil
 	s.refinementRoutes = nil
 	s.inFlightImplementationSymbol = ""
+	s.inFlightEnforceable = false
+	s.enforceableOnAnswerReady = false
 	s.taskFingerprint = ""
 	s.digest = nil
 	// Keep an in-flight reservation until its owner finishes. Its captured
@@ -181,7 +223,7 @@ func (s *localizationTerminalState) armForTask(completion localizationCompletion
 // staged until the localization response succeeds; direct handlers commit it
 // immediately.
 func (s *localizationTerminalState) keepOpenForTask(task string) {
-	s.armForTask(localizationCompletion{State: localizationStateInactive}, task)
+	s.armForTask(newLocalizationOpenCompletion(), task)
 }
 
 func (s *localizationTerminalState) armRefinementForTask(task, preferredSymbol string, symbols []string, digest *localizationEvidenceDigest) {
@@ -253,6 +295,11 @@ func (s *localizationTerminalState) commitLocalizationLocked(completion localiza
 	s.refinementSymbols = nil
 	s.refinementRoutes = nil
 	s.inFlightImplementationSymbol = ""
+	s.inFlightEnforceable = false
+	s.enforceableOnAnswerReady = completion.enforceableOnAnswerReady
+	if completion.State == localizationStateAnswerReady {
+		s.enforceableOnAnswerReady = completion.Enforceable
+	}
 	if completion.State == localizationStateNeedsRefinement {
 		s.refinementSymbol = completion.refinementSymbol
 		s.refinementSymbols = append([]string(nil), completion.refinementSymbols...)
@@ -279,6 +326,10 @@ func (s *localizationTerminalState) completionLocked() localizationCompletion {
 	default:
 		completion = newLocalizationCompletion(true, "")
 	}
+	completion.enforceableOnAnswerReady = s.enforceableOnAnswerReady
+	if completion.State == localizationStateAnswerReady {
+		completion.Enforceable = s.enforceableOnAnswerReady
+	}
 	completion.digest = s.digest
 	return completion
 }
@@ -286,7 +337,7 @@ func (s *localizationTerminalState) completionLocked() localizationCompletion {
 // interceptAnswerReady is the cheap pre-validation gate used by facade
 // dispatch. It makes localization terminality independent of operation
 // validity while deliberately leaving non-navigation facades untouched.
-func (s *localizationTerminalState) interceptAnswerReady(facade string) *mcpgo.CallToolResult {
+func (s *localizationTerminalState) interceptAnswerReady(facade, operation string) *mcpgo.CallToolResult {
 	if s == nil || !localizationNavigationFacade(facade) {
 		return nil
 	}
@@ -295,7 +346,7 @@ func (s *localizationTerminalState) interceptAnswerReady(facade string) *mcpgo.C
 	if s.state != localizationStateAnswerReady {
 		return nil
 	}
-	return localizationAnswerReadyResult(s.completionLocked())
+	return localizationTerminalResult(s.completionLocked(), facade, operation)
 }
 
 func (s *localizationTerminalState) refinementAllowsLocked(symbol string) bool {
@@ -328,11 +379,10 @@ func (s *localizationTerminalState) beginLocalize(task string, newUserTask bool)
 	if s.state != localizationStateInactive && !newUserTask {
 		completion := s.completionLocked()
 		// A repeat localize against a terminal contract gets the same compact,
-		// successful stop signal as every other post-terminal facade call.
-		// Returning an error invites recovery loops; replaying evidence invites
-		// more analysis. The original localization result already holds it.
+		// typed non-retriable signal as every other post-terminal navigation
+		// call. The original successful result already holds the evidence.
 		if s.state == localizationStateAnswerReady {
-			return 0, localizationAnswerReadyResult(completion)
+			return 0, localizationTerminalResult(completion, "explore", "localize")
 		}
 		return 0, NewStructuredErrorResult(StructuredError{
 			ErrorCode: ErrCodeLocalizationComplete,
@@ -383,6 +433,8 @@ func localizationInProgressResult() *mcpgo.CallToolResult {
 			"completion": map[string]any{
 				"state": "localization_in_progress", "scope": "localization",
 				"required_action": "wait", "allowed_tool_calls": 0,
+				"contract_version": localizationTerminalContractV2,
+				"enforceable":      false,
 			},
 			"facade": "explore", "operation": "localize",
 		},
@@ -411,10 +463,10 @@ func (s *localizationTerminalState) authorize(facade, operation string, argument
 		return nil, false
 	}
 	// answer_ready terminates only localization navigation. Catch those facades
-	// before their handlers can run and return a compact successful instruction;
+	// before their handlers can run and return a compact typed instruction;
 	// unrelated work remains dispatchable through the early return above.
 	if s.state == localizationStateAnswerReady {
-		return localizationAnswerReadyResult(s.completionLocked()), false
+		return localizationTerminalResult(s.completionLocked(), facade, operation), false
 	}
 	if s.state == localizationStateNeedsExactRead && facade == "read" && operation == "source" && exactLocalizationSymbol(arguments) == s.exactSymbol {
 		s.state = localizationStateExactReadInFlight
@@ -422,7 +474,9 @@ func (s *localizationTerminalState) authorize(facade, operation string, argument
 	}
 	refinementSymbol := exactLocalizationSymbol(arguments)
 	if s.state == localizationStateNeedsRefinement && facade == "read" && operation == "source" && s.refinementAllowsLocked(refinementSymbol) {
-		s.inFlightImplementationSymbol = s.refinementRoutes[refinementSymbol].implementationSymbol
+		route := s.refinementRoutes[refinementSymbol]
+		s.inFlightImplementationSymbol = route.implementationSymbol
+		s.inFlightEnforceable = route.enforceable
 		s.state = localizationStateRefineInFlight
 		return nil, true
 	}
@@ -464,11 +518,17 @@ func (s *localizationTerminalState) finishReservedRead(success bool) localizatio
 			s.inFlightImplementationSymbol = ""
 			return s.completionLocked()
 		}
+		s.inFlightImplementationSymbol = ""
+		s.inFlightEnforceable = false
+		s.enforceableOnAnswerReady = false
 		s.state = localizationStateNeedsExactRead
 	case localizationStateRefineInFlight:
 		if success {
 			implementationSymbol := s.inFlightImplementationSymbol
+			enforceable := s.inFlightEnforceable
 			s.inFlightImplementationSymbol = ""
+			s.inFlightEnforceable = false
+			s.enforceableOnAnswerReady = enforceable
 			s.refinementSymbol = ""
 			s.refinementSymbols = nil
 			s.refinementRoutes = nil
@@ -481,9 +541,30 @@ func (s *localizationTerminalState) finishReservedRead(success bool) localizatio
 			return s.completionLocked()
 		}
 		s.inFlightImplementationSymbol = ""
+		s.inFlightEnforceable = false
+		s.enforceableOnAnswerReady = false
 		s.state = localizationStateNeedsRefinement
 	}
 	return s.completionLocked()
+}
+
+// localizationTerminalResult is the compact, typed suppression returned only
+// after a successful localization response established answer_ready. It never
+// replays evidence and is non-retriable by default.
+func localizationTerminalResult(completion localizationCompletion, facade, operation string) *mcpgo.CallToolResult {
+	data := map[string]any{"contract": localizationContractFor(completion)}
+	if facade != "" {
+		data["facade"] = facade
+	}
+	if operation != "" {
+		data["operation"] = operation
+	}
+	return newStructuredErrorResult(StructuredError{
+		ErrorCode: ErrCodeLocalizationTerminal,
+		Message:   "localization is terminal for this user request; respond using the evidence already returned",
+		Retriable: false,
+		Data:      data,
+	}, true)
 }
 
 func cloneLocalizationRefinementRoutes(routes map[string]localizationRefinementRoute) map[string]localizationRefinementRoute {

--- a/internal/mcp/localization_terminal.go
+++ b/internal/mcp/localization_terminal.go
@@ -35,6 +35,13 @@ type localizationCompletion struct {
 	// exact_symbol is reserved for the semantically exact-read state.
 	refinementSymbol  string
 	refinementSymbols []string
+
+	// digest is the retained evidence projection for this contract, carried
+	// session-only so a post-terminal navigation call can replay the answer
+	// instead of refusing it (see localization_digest.go). It rides the
+	// completion through reservation staging into commitLocalizationLocked,
+	// which covers the direct-arm and facade finishLocalize paths alike.
+	digest *localizationEvidenceDigest
 }
 
 func newLocalizationCompletion(answerReady bool, exactSymbol string) localizationCompletion {
@@ -83,6 +90,11 @@ type localizationTerminalState struct {
 	generation        uint64
 	nextReservation   uint64
 	reservation       *localizationReservation
+	// digest is the evidence retained for the live contract; nil when the
+	// contract is inactive or predates digest capture. Promotions through
+	// finishReservedRead keep it — the evidence was stashed when the
+	// contract was armed, before the permitted read ran.
+	digest *localizationEvidenceDigest
 }
 
 type localizationReservation struct {
@@ -108,6 +120,7 @@ func (s *localizationTerminalState) reset() {
 	s.refinementSymbol = ""
 	s.refinementSymbols = nil
 	s.taskFingerprint = ""
+	s.digest = nil
 	// Keep an in-flight reservation until its owner finishes. Its captured
 	// generation is now stale, so finishLocalize cannot commit it, while a
 	// second localization cannot race ahead of the still-running handler.
@@ -142,7 +155,7 @@ func (s *localizationTerminalState) keepOpenForTask(task string) {
 	s.armForTask(localizationCompletion{State: localizationStateInactive}, task)
 }
 
-func (s *localizationTerminalState) armRefinementForTask(task, preferredSymbol string, symbols []string) {
+func (s *localizationTerminalState) armRefinementForTask(task, preferredSymbol string, symbols []string, digest *localizationEvidenceDigest) {
 	preferredSymbol = strings.TrimSpace(preferredSymbol)
 	seen := make(map[string]struct{}, min(len(symbols), 12))
 	refinementSymbols := make([]string, 0, min(len(symbols), 12))
@@ -169,6 +182,10 @@ func (s *localizationTerminalState) armRefinementForTask(task, preferredSymbol s
 	}
 	completion := newLocalizationRefinementCompletion(preferredSymbol)
 	completion.refinementSymbols = refinementSymbols
+	// Stashed now, not at promotion: when the permitted read succeeds,
+	// finishReservedRead flips this contract to answer_ready and the
+	// evidence must already be retained for replay.
+	completion.digest = digest
 	s.armForTask(completion, task)
 }
 
@@ -183,6 +200,9 @@ func (s *localizationTerminalState) commitLocalizationLocked(completion localiza
 		s.refinementSymbols = append([]string(nil), completion.refinementSymbols...)
 	}
 	s.taskFingerprint = fingerprint
+	// The digest follows the contract: an inactive commit (keepOpenForTask)
+	// carries nil and clears it; every localize commit replaces it.
+	s.digest = completion.digest
 }
 
 func (s *localizationTerminalState) completionLocked() localizationCompletion {
@@ -233,6 +253,12 @@ func (s *localizationTerminalState) beginLocalize(task string, newUserTask bool)
 	}
 	if s.state != localizationStateInactive && !newUserTask {
 		completion := s.completionLocked()
+		// A repeat localize against a terminal contract gets the same
+		// successful evidence replay as any other post-terminal navigation:
+		// re-localizing hosts want the evidence again, not error recovery.
+		if s.state == localizationStateAnswerReady && s.digest != nil {
+			return 0, localizationEvidenceReplayResult(completion, s.digest)
+		}
 		return 0, NewStructuredErrorResult(StructuredError{
 			ErrorCode: ErrCodeLocalizationComplete,
 			Message:   "this user request already has a localization completion contract; follow it instead of starting another localize call",
@@ -319,6 +345,14 @@ func (s *localizationTerminalState) authorize(facade, operation string, argument
 	}
 
 	completion := s.completionLocked()
+	// Terminal contract with retained evidence: replay the answer as a
+	// SUCCESSFUL idempotent result instead of a refusal. An error here sends
+	// non-adapted hosts into error-recovery loops — a burned turn per call
+	// with the correct answer already in hand; the replay is actionable on
+	// the very next turn and identical on every subsequent call.
+	if s.state == localizationStateAnswerReady && s.digest != nil {
+		return localizationEvidenceReplayResult(completion, s.digest), false
+	}
 	message := "localization is complete; return the existing evidence without another Gortex navigation call"
 	switch s.state {
 	case localizationStateNeedsExactRead:

--- a/internal/mcp/localization_terminal.go
+++ b/internal/mcp/localization_terminal.go
@@ -57,6 +57,10 @@ type localizationCompletion struct {
 // concrete hop prevalidated for a generic forwarder.
 type localizationRefinementRoute struct {
 	implementationSymbol string
+	// proofSymbol names the generic wrapper that uniquely and completely
+	// resolved to this concrete target. It is empty for ordinary concrete
+	// hydration and for the wrapper side of the same route.
+	proofSymbol string
 	// enforceable is set only by the centralized evidence policy after it has
 	// proved the entire route. A successful read alone never upgrades trust.
 	enforceable bool

--- a/internal/mcp/localization_terminal.go
+++ b/internal/mcp/localization_terminal.go
@@ -36,9 +36,9 @@ type localizationCompletion struct {
 	refinementSymbol  string
 	refinementSymbols []string
 
-	// digest is the retained evidence projection for this contract, carried
-	// session-only so a post-terminal navigation call can replay the answer
-	// instead of refusing it (see localization_digest.go). It rides the
+	// digest is the bounded evidence projection carried session-only through
+	// reservation staging (see localization_digest.go). Post-terminal results
+	// expose it only through host-only MCP _meta. It rides the
 	// completion through reservation staging into commitLocalizationLocked,
 	// which covers the direct-arm and facade finishLocalize paths alike.
 	digest *localizationEvidenceDigest
@@ -69,17 +69,18 @@ func newLocalizationCompletion(answerReady bool, exactSymbol string) localizatio
 func newLocalizationRefinementCompletion(preferredSymbol string) localizationCompletion {
 	preferredSymbol = strings.TrimSpace(preferredSymbol)
 	return localizationCompletion{
-		State:            localizationStateNeedsRefinement,
-		Scope:            "localization",
-		RequiredAction:   fmt.Sprintf(localizationRefinementRequiredActionFormat, preferredSymbol),
+		State: localizationStateNeedsRefinement,
+		Scope: "localization",
+		RequiredAction: fmt.Sprintf(localizationRefinementRequiredActionFormat, preferredSymbol) +
+			" The named symbol is recommended; one source read of any returned candidate symbol is permitted.",
 		AllowedToolCalls: 1,
 		refinementSymbol: preferredSymbol,
 	}
 }
 
-// localizationTerminalState is intentionally session-local. It never affects
-// mutation, analysis, workspace, or memory tools; it only prevents an agent
-// from reopening localization after an explicit localization-only request.
+// localizationTerminalState is intentionally session-local. It bounds only
+// localization navigation; mutation, workspace, session, memory, and
+// capability tools remain usable after answer_ready and across later work.
 type localizationTerminalState struct {
 	mu                sync.Mutex
 	state             string
@@ -206,23 +207,51 @@ func (s *localizationTerminalState) commitLocalizationLocked(completion localiza
 }
 
 func (s *localizationTerminalState) completionLocked() localizationCompletion {
+	var completion localizationCompletion
 	switch s.state {
 	case localizationStateNeedsRefinement, localizationStateRefineInFlight:
-		completion := newLocalizationRefinementCompletion(s.refinementSymbol)
+		completion = newLocalizationRefinementCompletion(s.refinementSymbol)
 		if s.state == localizationStateRefineInFlight {
 			completion.State = localizationStateRefineInFlight
 			completion.AllowedToolCalls = 0
 		}
-		return completion
 	case localizationStateNeedsExactRead, localizationStateExactReadInFlight:
-		return newLocalizationCompletion(false, s.exactSymbol)
+		completion = newLocalizationCompletion(false, s.exactSymbol)
 	default:
-		return newLocalizationCompletion(true, "")
+		completion = newLocalizationCompletion(true, "")
 	}
+	completion.digest = s.digest
+	return completion
+}
+
+func (s *localizationTerminalState) answerReadyCompletion() localizationCompletion {
+	completion := newLocalizationCompletion(true, "")
+	if s == nil {
+		return completion
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	completion.digest = s.digest
+	return completion
+}
+
+// interceptAnswerReady is the cheap pre-validation gate used by facade
+// dispatch. It makes localization terminality independent of operation
+// validity while deliberately leaving non-navigation facades untouched.
+func (s *localizationTerminalState) interceptAnswerReady(facade string) *mcpgo.CallToolResult {
+	if s == nil || !localizationNavigationFacade(facade) {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.state != localizationStateAnswerReady {
+		return nil
+	}
+	return localizationAnswerReadyResult(s.completionLocked())
 }
 
 func (s *localizationTerminalState) refinementAllowsLocked(symbol string) bool {
-	if symbol == "" || (s.refinementSymbol != "" && symbol != s.refinementSymbol) {
+	if symbol == "" {
 		return false
 	}
 	for _, candidate := range s.refinementSymbols {
@@ -235,8 +264,9 @@ func (s *localizationTerminalState) refinementAllowsLocked(symbol string) bool {
 
 // beginLocalize reserves the only localization handler slot for this session.
 // An inactive session admits its first localization without a boundary flag.
-// Once a contract exists, only the first localize call for a genuinely new user
-// request may cross it, and the caller must say so explicitly. The old contract
+// Once a contract exists, only the first explore call for a genuinely new user
+// request may cross it, and the caller must say so explicitly. Localize stages
+// its returned completion; task stages inactive navigation. The old contract
 // remains live until finishLocalize commits the successful replacement.
 func (s *localizationTerminalState) beginLocalize(task string, newUserTask bool) (uint64, *mcpgo.CallToolResult) {
 	if s == nil {
@@ -253,11 +283,12 @@ func (s *localizationTerminalState) beginLocalize(task string, newUserTask bool)
 	}
 	if s.state != localizationStateInactive && !newUserTask {
 		completion := s.completionLocked()
-		// A repeat localize against a terminal contract gets the same
-		// successful evidence replay as any other post-terminal navigation:
-		// re-localizing hosts want the evidence again, not error recovery.
-		if s.state == localizationStateAnswerReady && s.digest != nil {
-			return 0, localizationEvidenceReplayResult(completion, s.digest)
+		// A repeat localize against a terminal contract gets the same compact,
+		// successful stop signal as every other post-terminal facade call.
+		// Returning an error invites recovery loops; replaying evidence invites
+		// more analysis. The original localization result already holds it.
+		if s.state == localizationStateAnswerReady {
+			return 0, localizationAnswerReadyResult(completion)
 		}
 		return 0, NewStructuredErrorResult(StructuredError{
 			ErrorCode: ErrCodeLocalizationComplete,
@@ -335,6 +366,12 @@ func (s *localizationTerminalState) authorize(facade, operation string, argument
 	if s.state == localizationStateInactive {
 		return nil, false
 	}
+	// answer_ready terminates only localization navigation. Catch those facades
+	// before their handlers can run and return a compact successful instruction;
+	// unrelated work remains dispatchable through the early return above.
+	if s.state == localizationStateAnswerReady {
+		return localizationAnswerReadyResult(s.completionLocked()), false
+	}
 	if s.state == localizationStateNeedsExactRead && facade == "read" && operation == "source" && exactLocalizationSymbol(arguments) == s.exactSymbol {
 		s.state = localizationStateExactReadInFlight
 		return nil, true
@@ -345,24 +382,6 @@ func (s *localizationTerminalState) authorize(facade, operation string, argument
 	}
 
 	completion := s.completionLocked()
-	// Terminal contract with retained evidence: replay the answer as a
-	// SUCCESSFUL idempotent result instead of a refusal. An error here sends
-	// non-adapted hosts into error-recovery loops — a burned turn per call
-	// with the correct answer already in hand; the replay is actionable on
-	// the very next turn and identical on every subsequent call.
-	//
-	// Reads are exempt from the replay: a post-terminal source read can only
-	// sharpen the answer the session already owns, and replaying it starves
-	// a non-adapted host into an empty final (observed: a session holding
-	// the correct file asked to read it twice, received the replay twice,
-	// and exhausted its turns with no answer). The read executes and the
-	// dispatcher attaches the answer-now directive to its result.
-	if s.state == localizationStateAnswerReady && s.digest != nil {
-		if facade == "read" {
-			return nil, false
-		}
-		return localizationEvidenceReplayResult(completion, s.digest), false
-	}
 	message := "localization is complete; return the existing evidence without another Gortex navigation call"
 	switch s.state {
 	case localizationStateNeedsExactRead:

--- a/internal/mcp/localization_terminal.go
+++ b/internal/mcp/localization_terminal.go
@@ -350,7 +350,17 @@ func (s *localizationTerminalState) authorize(facade, operation string, argument
 	// non-adapted hosts into error-recovery loops — a burned turn per call
 	// with the correct answer already in hand; the replay is actionable on
 	// the very next turn and identical on every subsequent call.
+	//
+	// Reads are exempt from the replay: a post-terminal source read can only
+	// sharpen the answer the session already owns, and replaying it starves
+	// a non-adapted host into an empty final (observed: a session holding
+	// the correct file asked to read it twice, received the replay twice,
+	// and exhausted its turns with no answer). The read executes and the
+	// dispatcher attaches the answer-now directive to its result.
 	if s.state == localizationStateAnswerReady && s.digest != nil {
+		if facade == "read" {
+			return nil, false
+		}
 		return localizationEvidenceReplayResult(completion, s.digest), false
 	}
 	message := "localization is complete; return the existing evidence without another Gortex navigation call"

--- a/internal/mcp/localization_terminal.go
+++ b/internal/mcp/localization_terminal.go
@@ -13,26 +13,31 @@ const (
 	localizationStateInactive          = ""
 	localizationStateNeedsExactRead    = "needs_exact_read"
 	localizationStateNeedsRefinement   = "needs_refinement"
+	localizationStateNeedsRecovery     = "needs_recovery"
 	localizationStateRefineInFlight    = "refinement_in_flight"
 	localizationStateExactReadInFlight = "exact_read_in_flight"
+	localizationStateRecoveryInFlight  = "recovery_in_flight"
 	localizationStateAnswerReady       = "answer_ready"
 	localizationTerminalContractV2     = 2
 )
+
+var localizationRecoveryOperations = []string{"search.text", "search.symbols", "read.source"}
 
 // localizationCompletion is the host-neutral terminality contract returned by
 // explore(operation:"localize"). Hosts may stop the turn from this payload;
 // the server also enforces it for later Gortex navigation calls in the same
 // MCP session.
 type localizationCompletion struct {
-	State            string   `json:"state"`
-	Scope            string   `json:"scope"`
-	RequiredAction   string   `json:"required_action"`
-	Instruction      string   `json:"instruction,omitempty"`
-	AllowedToolCalls int      `json:"allowed_tool_calls"`
-	ContractVersion  int      `json:"contract_version"`
-	Enforceable      bool     `json:"enforceable"`
-	ExactSymbol      string   `json:"exact_symbol,omitempty"`
-	AllowedSymbols   []string `json:"allowed_symbols,omitempty"`
+	State             string   `json:"state"`
+	Scope             string   `json:"scope"`
+	RequiredAction    string   `json:"required_action"`
+	Instruction       string   `json:"instruction,omitempty"`
+	AllowedToolCalls  int      `json:"allowed_tool_calls"`
+	ContractVersion   int      `json:"contract_version"`
+	Enforceable       bool     `json:"enforceable"`
+	ExactSymbol       string   `json:"exact_symbol,omitempty"`
+	AllowedSymbols    []string `json:"allowed_symbols,omitempty"`
+	AllowedOperations []string `json:"allowed_operations,omitempty"`
 
 	// Route hops stay session-only, while AllowedSymbols exposes the exact
 	// bounded authorization set carried by the wire contract.
@@ -90,6 +95,18 @@ func localizationContractFor(completion localizationCompletion) localizationTerm
 	return localizationTerminalContract{
 		Completion: completion,
 		Terminal:   completion.State == localizationStateAnswerReady,
+	}
+}
+
+func newLocalizationRecoveryCompletion() localizationCompletion {
+	return localizationCompletion{
+		State:             localizationStateNeedsRecovery,
+		Scope:             "localization",
+		RequiredAction:    "recover_once",
+		Instruction:       `Make exactly one bounded Gortex recovery call: search(operation:"text" or "symbols", query:<specific anchor>) or read(operation:"source", target:{symbol:<exact id>}); then respond from the returned evidence.`,
+		AllowedToolCalls:  1,
+		ContractVersion:   localizationTerminalContractV2,
+		AllowedOperations: append([]string(nil), localizationRecoveryOperations...),
 	}
 }
 
@@ -195,6 +212,7 @@ type localizationTerminalState struct {
 	exactReadRoute               localizationRefinementRoute
 	correctionRetriesRemaining   uint8
 	refinementRetriesRemaining   uint8
+	recoveryRetriesRemaining     uint8
 	// Read reservations are tokenized independently of localization calls. A
 	// reset or newly armed task invalidates an old token, so a late read cannot
 	// finish (or decorate itself with) a newer task's contract.
@@ -247,6 +265,7 @@ func (s *localizationTerminalState) reset() {
 	s.exactReadRoute = localizationRefinementRoute{}
 	s.correctionRetriesRemaining = 0
 	s.refinementRetriesRemaining = 0
+	s.recoveryRetriesRemaining = 0
 	s.readReservationToken = 0
 	s.readReservationGen = 0
 	s.enforceableOnAnswerReady = false
@@ -366,6 +385,7 @@ func (s *localizationTerminalState) commitLocalizationLocked(completion localiza
 	s.exactReadRoute = localizationRefinementRoute{}
 	s.correctionRetriesRemaining = 0
 	s.refinementRetriesRemaining = 0
+	s.recoveryRetriesRemaining = 0
 	s.readReservationToken = 0
 	s.readReservationGen = 0
 	s.enforceableOnAnswerReady = completion.enforceableOnAnswerReady
@@ -382,6 +402,9 @@ func (s *localizationTerminalState) commitLocalizationLocked(completion localiza
 	} else {
 		s.correctionSymbol = ""
 		s.correctionRoute = localizationRefinementRoute{}
+	}
+	if completion.State == localizationStateNeedsRecovery {
+		s.recoveryRetriesRemaining = 1
 	}
 	s.taskFingerprint = fingerprint
 	// The digest follows the contract: an inactive commit (keepOpenForTask)
@@ -401,6 +424,14 @@ func (s *localizationTerminalState) completionLocked() localizationCompletion {
 		}
 	case localizationStateNeedsExactRead, localizationStateExactReadInFlight:
 		completion = newLocalizationExactReadCompletion(s.exactSymbol, s.exactReadIsCorrection)
+	case localizationStateNeedsRecovery, localizationStateRecoveryInFlight:
+		completion = newLocalizationRecoveryCompletion()
+		if s.state == localizationStateRecoveryInFlight {
+			completion.State = localizationStateRecoveryInFlight
+			completion.RequiredAction = "wait"
+			completion.Instruction = "The bounded Gortex recovery call is already in progress."
+			completion.AllowedToolCalls = 0
+		}
 	case localizationStateInactive:
 		completion = newLocalizationOpenCompletion()
 	default:
@@ -416,17 +447,30 @@ func (s *localizationTerminalState) completionLocked() localizationCompletion {
 
 // interceptAnswerReady is the cheap pre-validation gate used by facade
 // dispatch. It makes localization terminality independent of operation
-// validity while deliberately leaving non-navigation facades untouched.
-func (s *localizationTerminalState) interceptAnswerReady(facade, operation string) *mcpgo.CallToolResult {
+// validity, and consumes an unsupported advisory recovery attempt before a
+// schema error can create an unbounded retry loop. Non-navigation facades stay
+// untouched.
+func (s *localizationTerminalState) interceptAnswerReady(facade, operation string, arguments map[string]any) (*mcpgo.CallToolResult, uint64) {
 	if s == nil || !localizationNavigationFacade(facade) {
-		return nil
+		return nil, 0
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.state != localizationStateAnswerReady {
-		return nil
+	switch s.state {
+	case localizationStateAnswerReady:
+		return localizationTerminalResult(s.completionLocked(), facade, operation), 0
+	case localizationStateNeedsRecovery:
+		if localizationRecoveryAllows(facade, operation, arguments) {
+			// Carry the task generation through later schema validation. A stale
+			// invalid request must never consume a newly committed task's recovery.
+			return nil, s.generation
+		}
+		s.state = localizationStateAnswerReady
+		s.recoveryRetriesRemaining = 0
+		return localizationRecoveryRejectedResult(s.completionLocked(), facade, operation), 0
+	default:
+		return nil, 0
 	}
-	return localizationTerminalResult(s.completionLocked(), facade, operation)
 }
 
 func (s *localizationTerminalState) refinementAllowsLocked(symbol string) bool {
@@ -435,6 +479,55 @@ func (s *localizationTerminalState) refinementAllowsLocked(symbol string) bool {
 	}
 	_, authorized := s.refinementRoutes[symbol]
 	return authorized
+}
+
+func localizationRecoveryAllows(facade, operation string, arguments map[string]any) bool {
+	switch facade + "." + operation {
+	case "search.text", "search.symbols":
+		query, _ := arguments["query"].(string)
+		return strings.TrimSpace(query) != ""
+	case "read.source":
+		return exactLocalizationSymbol(arguments) != ""
+	default:
+		return false
+	}
+}
+
+func localizationRecoveryOperationAllowed(facade, operation string) bool {
+	switch facade + "." + operation {
+	case "search.text", "search.symbols", "read.source":
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *localizationTerminalState) consumeInvalidRecovery(facade, operation string, generation uint64) (localizationCompletion, bool) {
+	if s == nil || generation == 0 || !localizationRecoveryOperationAllowed(facade, operation) {
+		return newLocalizationOpenCompletion(), false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.state != localizationStateNeedsRecovery || s.generation != generation {
+		return newLocalizationOpenCompletion(), false
+	}
+	s.state = localizationStateAnswerReady
+	s.recoveryRetriesRemaining = 0
+	return s.completionLocked(), true
+}
+
+func localizationRecoveryRejectedResult(completion localizationCompletion, facade, operation string) *mcpgo.CallToolResult {
+	return newStructuredErrorResult(StructuredError{
+		ErrorCode: ErrCodeLocalizationTerminal,
+		Message:   "the one bounded localization recovery call must be search.text, search.symbols, or read.source with a concrete query or symbol; localization is now terminal",
+		Retriable: false,
+		Data: map[string]any{
+			"contract":           localizationContractFor(completion),
+			"facade":             facade,
+			"operation":          operation,
+			"allowed_operations": append([]string(nil), localizationRecoveryOperations...),
+		},
+	}, true)
 }
 
 // beginLocalize reserves the only localization handler slot for this session.
@@ -458,6 +551,11 @@ func (s *localizationTerminalState) beginLocalize(task string, newUserTask bool)
 	}
 	if s.state != localizationStateInactive && !newUserTask {
 		completion := s.completionLocked()
+		if s.state == localizationStateNeedsRecovery {
+			s.state = localizationStateAnswerReady
+			s.recoveryRetriesRemaining = 0
+			return 0, localizationRecoveryRejectedResult(s.completionLocked(), "explore", "localize")
+		}
 		// A repeat localize against a terminal contract gets the same compact,
 		// typed non-retriable signal as every other post-terminal navigation
 		// call. The original successful result already holds the evidence.
@@ -553,6 +651,15 @@ func (s *localizationTerminalState) authorizeWithToken(facade, operation string,
 	if s.state == localizationStateAnswerReady {
 		return localizationTerminalResult(s.completionLocked(), facade, operation), 0
 	}
+	if s.state == localizationStateNeedsRecovery {
+		if localizationRecoveryAllows(facade, operation, arguments) {
+			s.state = localizationStateRecoveryInFlight
+			return nil, s.beginReadReservationLocked()
+		}
+		s.state = localizationStateAnswerReady
+		s.recoveryRetriesRemaining = 0
+		return localizationRecoveryRejectedResult(s.completionLocked(), facade, operation), 0
+	}
 	if s.state == localizationStateNeedsExactRead && facade == "read" && operation == "source" && exactLocalizationSymbol(arguments) == s.exactSymbol {
 		s.inFlightImplementationSymbol = s.exactReadRoute.implementationSymbol
 		s.inFlightEnforceable = s.exactReadRoute.enforceable
@@ -583,6 +690,8 @@ func (s *localizationTerminalState) authorizeWithToken(facade, operation string,
 		message = fmt.Sprintf("localization permits exactly one read(operation:\"source\") for %q; other navigation calls are blocked", s.refinementSymbol)
 	case localizationStateRefineInFlight:
 		message = "the permitted localization refinement read is already in progress"
+	case localizationStateRecoveryInFlight:
+		message = "the bounded localization recovery call is already in progress"
 	}
 	return newStructuredErrorResult(StructuredError{
 		ErrorCode: ErrCodeLocalizationComplete,
@@ -631,9 +740,23 @@ func (s *localizationTerminalState) finishReservedReadToken(token uint64, succes
 	s.readReservationToken = 0
 	s.readReservationGen = 0
 	switch s.state {
+	case localizationStateRecoveryInFlight:
+		if success {
+			s.state = localizationStateAnswerReady
+			s.recoveryRetriesRemaining = 0
+			return s.completionLocked()
+		}
+		if s.recoveryRetriesRemaining > 0 {
+			s.recoveryRetriesRemaining--
+			s.state = localizationStateNeedsRecovery
+			return s.completionLocked()
+		}
+		s.state = localizationStateAnswerReady
+		return s.completionLocked()
 	case localizationStateExactReadInFlight:
 		implementationSymbol := s.inFlightImplementationSymbol
 		routeEnforceable := s.inFlightEnforceable
+		wasCorrection := s.exactReadIsCorrection
 		s.inFlightImplementationSymbol = ""
 		s.inFlightEnforceable = false
 		s.inFlightCorrectionSymbol = ""
@@ -641,19 +764,24 @@ func (s *localizationTerminalState) finishReservedReadToken(token uint64, succes
 			if routeEnforceable {
 				s.enforceableOnAnswerReady = true
 			}
-			if s.exactReadIsCorrection && implementationSymbol != "" {
+			if wasCorrection && implementationSymbol != "" {
 				s.state = localizationStateNeedsExactRead
 				s.exactSymbol = implementationSymbol
 				s.exactReadRoute = localizationRefinementRoute{enforceable: routeEnforceable}
 				return s.completionLocked()
 			}
-			s.state = localizationStateAnswerReady
 			s.exactSymbol = ""
 			s.correctionSymbol = ""
 			s.correctionRoute = localizationRefinementRoute{}
 			s.exactReadIsCorrection = false
 			s.exactReadRoute = localizationRefinementRoute{}
 			s.correctionRetriesRemaining = 0
+			if !wasCorrection && !s.enforceableOnAnswerReady {
+				s.state = localizationStateNeedsRecovery
+				s.recoveryRetriesRemaining = 1
+				return s.completionLocked()
+			}
+			s.state = localizationStateAnswerReady
 			return s.completionLocked()
 		}
 		s.enforceableOnAnswerReady = false
@@ -701,6 +829,11 @@ func (s *localizationTerminalState) finishReservedReadToken(token uint64, succes
 				s.exactReadIsCorrection = true
 				s.exactReadRoute = correctionRoute
 				s.correctionRetriesRemaining = 1
+				return s.completionLocked()
+			}
+			if !enforceable {
+				s.state = localizationStateNeedsRecovery
+				s.recoveryRetriesRemaining = 1
 				return s.completionLocked()
 			}
 			s.state = localizationStateAnswerReady

--- a/internal/mcp/localization_terminal_test.go
+++ b/internal/mcp/localization_terminal_test.go
@@ -151,20 +151,20 @@ func TestCompleteEmptyLocalizationReplacesPriorContract(t *testing.T) {
 	if !ok {
 		t.Fatalf("completion = %#v, want object", envelope["completion"])
 	}
-	if state, _ := completion["state"].(string); state != localizationStateInactive {
-		t.Fatalf("empty completion state = %q, want inactive", state)
+	if state, _ := completion["state"].(string); state != localizationStateAnswerReady {
+		t.Fatalf("empty completion state = %q, want advisory answer_ready", state)
 	}
-	if action, _ := completion["required_action"].(string); action != "continue" {
-		t.Fatalf("empty completion action = %q, want continue", action)
+	if action, _ := completion["required_action"].(string); action != "respond" {
+		t.Fatalf("empty completion action = %q, want respond", action)
 	}
 	terminal.mu.Lock()
 	state, exact := terminal.state, terminal.exactSymbol
 	terminal.mu.Unlock()
-	if state != localizationStateInactive || exact != "" {
+	if state != localizationStateAnswerReady || exact != "" {
 		t.Fatalf("empty localization armed terminal state=%q exact=%q", state, exact)
 	}
-	if blocked := terminal.block("search", "symbols", map[string]any{"query": "better anchor"}); blocked != nil {
-		t.Fatalf("empty localization blocked continued investigation: %v", blocked)
+	if blocked := terminal.block("search", "symbols", map[string]any{"query": "better anchor"}); blocked == nil {
+		t.Fatal("zero-candidate advisory completion did not stop repeated localization")
 	}
 }
 
@@ -205,7 +205,7 @@ func TestLocalizationCompletionEnvelope(t *testing.T) {
 	if err := json.Unmarshal([]byte(text), &envelope); err != nil {
 		t.Fatalf("decode completion envelope: %v\n%s", err, text)
 	}
-	if envelope.Completion.State != localizationStateAnswerReady || envelope.Completion.RequiredAction != "respond" || envelope.Completion.AllowedToolCalls != 0 {
+	if envelope.Completion.State != localizationStateNeedsRecovery || envelope.Completion.RequiredAction != "recover_once" || envelope.Completion.AllowedToolCalls != 1 {
 		t.Fatalf("unexpected completion: %#v", envelope.Completion)
 	}
 	if len(envelope.Files) != 1 || len(envelope.Symbols) != 1 || envelope.Symbols[0] != "repo/pkg/file.go::Run" || len(envelope.Evidence) != 1 {
@@ -253,7 +253,16 @@ func TestLocalizationRefinementAllowsExactlyOneCandidateRead(t *testing.T) {
 	state := newLocalizationTerminalState()
 	candidate := "repo/pkg/file.go::Resolver.Run"
 	other := "repo/pkg/other.go::Other"
-	state.armRefinementForTask("locate resolver behavior", candidate, []string{candidate, other}, nil)
+	state.armRefinementRoutesForTask(
+		"locate resolver behavior",
+		candidate,
+		[]string{candidate, other},
+		map[string]localizationRefinementRoute{
+			candidate: {enforceable: true},
+			other:     {enforceable: true},
+		},
+		nil,
+	)
 
 	wrong := map[string]any{"target": map[string]any{"symbol": "repo/pkg/wrong.go::Wrong"}}
 	if blocked, reserved := state.authorize("read", "source", wrong); blocked == nil || reserved {
@@ -299,7 +308,13 @@ func TestHandleFacadeRefinementReadReturnsAnswerReadyCompletion(t *testing.T) {
 	})
 	server := &Server{facades: registry, localization: newLocalizationTerminalState(), sessions: newSessionMap()}
 	ctx := WithSessionID(context.Background(), "refinement-read-completion")
-	server.localizationFor(ctx).armRefinementForTask("locate resolver behavior", candidate, []string{candidate}, testEvidenceDigest())
+	server.localizationFor(ctx).armRefinementRoutesForTask(
+		"locate resolver behavior",
+		candidate,
+		[]string{candidate},
+		map[string]localizationRefinementRoute{candidate: {enforceable: true}},
+		testEvidenceDigest(),
+	)
 
 	req := mcpgo.CallToolRequest{}
 	req.Params.Name = "read"
@@ -488,7 +503,9 @@ func TestHandleFacadeExactReadCommitsOnlyOnSuccess(t *testing.T) {
 	})
 	server := &Server{facades: registry, localization: newLocalizationTerminalState(), sessions: newSessionMap()}
 	ctx := WithSessionID(context.Background(), "exact-read")
-	server.localizationFor(ctx).armForTask(newLocalizationCompletion(false, "repo/pkg/file.go::Run"), "locate Run")
+	exactCompletion := newLocalizationCompletion(false, "repo/pkg/file.go::Run")
+	exactCompletion.enforceableOnAnswerReady = true
+	server.localizationFor(ctx).armForTask(exactCompletion, "locate Run")
 	req := mcpgo.CallToolRequest{}
 	req.Params.Name = "read"
 	req.Params.Arguments = map[string]any{
@@ -504,15 +521,19 @@ func TestHandleFacadeExactReadCommitsOnlyOnSuccess(t *testing.T) {
 		t.Fatalf("retry should retain and consume the allowance on success: result=%#v err=%v", second, err)
 	}
 	body, ok := singleTextContent(second)
-	if !ok || !strings.Contains(body, `"state":"answer_ready"`) ||
-		!strings.Contains(body, `"contract_version":2`) || !strings.Contains(body, `"terminal":true`) {
-		t.Fatalf("successful exact read omitted terminal completion: %q", body)
+	if !ok || !strings.Contains(body, `"state":"needs_recovery"`) ||
+		!strings.Contains(body, `"required_action":"recover_once"`) || !strings.Contains(body, `"terminal":false`) {
+		t.Fatalf("successful unproven exact-read retry omitted recovery completion: %q", body)
 	}
 	third, err := server.handleFacade(ctx, "read", req)
-	if err != nil || calls != 2 {
-		t.Fatalf("successful exact read must make later navigation terminal: result=%#v err=%v calls=%d", third, err, calls)
+	if err != nil || third == nil || third.IsError || calls != 3 {
+		t.Fatalf("bounded exact-read recovery = result=%#v err=%v calls=%d", third, err, calls)
 	}
-	requireLocalizationTerminalError(t, third, "read", "source")
+	fourth, err := server.handleFacade(ctx, "read", req)
+	if err != nil || calls != 3 {
+		t.Fatalf("post-recovery exact read = result=%#v err=%v calls=%d", fourth, err, calls)
+	}
+	requireLocalizationTerminalError(t, fourth, "read", "source")
 }
 
 func TestHandleFacadeExhaustedCorrectionFailureCarriesTerminalCompletion(t *testing.T) {
@@ -835,7 +856,9 @@ func TestHandleFacadeExactReadPanicRestoresReservation(t *testing.T) {
 	ctx := WithSessionID(context.Background(), "exact-read-panic")
 	terminal := server.localizationFor(ctx)
 	const symbol = "repo/internal/file.go::Target"
-	terminal.armForTask(newLocalizationCompletion(false, symbol), "Locate Target")
+	exactCompletion := newLocalizationCompletion(false, symbol)
+	exactCompletion.enforceableOnAnswerReady = true
+	terminal.armForTask(exactCompletion, "Locate Target")
 
 	args := map[string]any{
 		"operation": "source",
@@ -857,12 +880,16 @@ func TestHandleFacadeExactReadPanicRestoresReservation(t *testing.T) {
 		t.Fatalf("exact read retry = (%v, %v), want success", result, err)
 	}
 	third, err := server.handleFacade(ctx, "read", req)
-	if err != nil {
-		t.Fatalf("third exact read = (%v, %v), want terminal block", third, err)
+	if err != nil || third == nil || third.IsError {
+		t.Fatalf("third exact read recovery = (%v, %v), want success", third, err)
 	}
-	requireLocalizationTerminalError(t, third, "read", "source")
-	if calls != 2 {
-		t.Fatalf("legacy source calls = %d, want 2", calls)
+	fourth, err := server.handleFacade(ctx, "read", req)
+	if err != nil {
+		t.Fatalf("fourth exact read = (%v, %v), want terminal block", fourth, err)
+	}
+	requireLocalizationTerminalError(t, fourth, "read", "source")
+	if calls != 3 {
+		t.Fatalf("legacy source calls = %d, want 3", calls)
 	}
 }
 

--- a/internal/mcp/localization_terminal_test.go
+++ b/internal/mcp/localization_terminal_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -512,6 +513,126 @@ func TestHandleFacadeExactReadCommitsOnlyOnSuccess(t *testing.T) {
 		t.Fatalf("successful exact read must make later navigation terminal: result=%#v err=%v calls=%d", third, err, calls)
 	}
 	requireLocalizationTerminalError(t, third, "read", "source")
+}
+
+func TestHandleFacadeExhaustedCorrectionFailureCarriesTerminalCompletion(t *testing.T) {
+	registry := newFacadeRegistry()
+	preferred := "repo/pkg/find.go::Find"
+	alternate := "repo/pkg/resolve.go::Resolve"
+	alternateCalls := 0
+	registry.capture(mcpgo.NewTool("get_symbol_source", mcpgo.WithString("id", mcpgo.Required())), func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		if req.GetString("id", "") == preferred {
+			return mcpgo.NewToolResultText("func Find() {}"), nil
+		}
+		alternateCalls++
+		if alternateCalls == 1 {
+			return mcpgo.NewToolResultError("transient correction failure"), nil
+		}
+		return nil, errors.New("persistent correction failure")
+	})
+	server := &Server{facades: registry, localization: newLocalizationTerminalState(), sessions: newSessionMap()}
+	ctx := WithSessionID(context.Background(), "exhausted-correction")
+	server.localizationFor(ctx).armRefinementRoutesForTask(
+		"locate resolver behavior",
+		preferred,
+		[]string{preferred, alternate},
+		map[string]localizationRefinementRoute{
+			preferred: {},
+			alternate: {enforceable: true},
+		},
+		testEvidenceDigest(),
+	)
+
+	read := func(symbol string) (*mcpgo.CallToolResult, error) {
+		req := mcpgo.CallToolRequest{}
+		req.Params.Name = "read"
+		req.Params.Arguments = map[string]any{
+			"operation": "source",
+			"target":    map[string]any{"symbol": symbol},
+		}
+		return server.handleFacade(ctx, "read", req)
+	}
+	first, err := read(preferred)
+	if err != nil || first == nil || first.IsError {
+		t.Fatalf("preferred read = (%#v, %v), want success", first, err)
+	}
+	firstBody, _ := singleTextContent(first)
+	if !strings.Contains(firstBody, `"state":"needs_exact_read"`) ||
+		!strings.Contains(firstBody, `"required_action":"read_exact"`) ||
+		!strings.Contains(firstBody, alternate) {
+		t.Fatalf("preferred read omitted correction contract: %q", firstBody)
+	}
+
+	second, err := read(alternate)
+	if err != nil || second == nil || !second.IsError {
+		t.Fatalf("first correction failure = (%#v, %v), want tool error", second, err)
+	}
+	third, err := read(alternate)
+	if err != nil || third == nil || !third.IsError {
+		t.Fatalf("exhausted correction failure = (%#v, %v), want observable tool error", third, err)
+	}
+	thirdBody, _ := singleTextContent(third)
+	if !strings.Contains(thirdBody, "persistent correction failure") ||
+		!strings.Contains(thirdBody, `"state":"answer_ready"`) ||
+		!strings.Contains(thirdBody, `"required_action":"respond"`) ||
+		!strings.Contains(thirdBody, `"terminal":true`) {
+		t.Fatalf("exhausted failure omitted terminal completion: %q", thirdBody)
+	}
+	requireFacadeIdentity(t, third, facadeOperationSpec{Facade: "read", Operation: "source", Legacy: "get_symbol_source"})
+	if blocked, err := read(alternate); err != nil {
+		t.Fatalf("post-terminal read returned transport error: %v", err)
+	} else {
+		requireLocalizationTerminalError(t, blocked, "read", "source")
+	}
+}
+
+func TestDecorateExhaustedLocalizationReadFailureKeepsErrorAndFacadeIdentity(t *testing.T) {
+	spec := facadeOperationSpec{Facade: "read", Operation: "source", Legacy: "get_symbol_source"}
+	completion := newLocalizationCompletion(true, "")
+
+	t.Run("transport error overrides success-shaped result", func(t *testing.T) {
+		result, err := decorateExhaustedLocalizationReadFailure(
+			mcpgo.NewToolResultText("stale success payload"),
+			errors.New("transport read failure"),
+			completion,
+			spec,
+		)
+		if err != nil || result == nil || !result.IsError {
+			t.Fatalf("decorated transport failure = (%#v, %v), want tool error", result, err)
+		}
+		body, _ := singleTextContent(result)
+		if !strings.Contains(body, "transport read failure") || strings.Contains(body, "stale success payload") ||
+			!strings.Contains(body, `"state":"answer_ready"`) {
+			t.Fatalf("transport failure payload = %q", body)
+		}
+		requireFacadeIdentity(t, result, spec)
+	})
+
+	t.Run("existing tool error metadata is preserved", func(t *testing.T) {
+		original := mcpgo.NewToolResultError("tool read failure")
+		original.Meta = mcpgo.NewMetaFromMap(map[string]any{"handler": "kept"})
+		result, err := decorateExhaustedLocalizationReadFailure(original, nil, completion, spec)
+		if err != nil || result == nil || !result.IsError {
+			t.Fatalf("decorated tool failure = (%#v, %v), want tool error", result, err)
+		}
+		if result.Meta.AdditionalFields["handler"] != "kept" {
+			t.Fatalf("existing handler metadata lost: %#v", result.Meta)
+		}
+		requireFacadeIdentity(t, result, spec)
+	})
+}
+
+func requireFacadeIdentity(t *testing.T, result *mcpgo.CallToolResult, spec facadeOperationSpec) {
+	t.Helper()
+	if result == nil || result.Meta == nil || result.Meta.AdditionalFields == nil {
+		t.Fatalf("facade result has no metadata: %#v", result)
+	}
+	identity, ok := result.Meta.AdditionalFields["gortex_facade"].(map[string]any)
+	if !ok || identity["surface_version"] != FacadeSurfaceVersion ||
+		identity["facade"] != spec.Facade || identity["operation"] != spec.Operation ||
+		identity["canonical_tool"] != spec.Legacy {
+		t.Fatalf("facade identity = %#v, want %#v", identity, spec)
+	}
 }
 
 func TestHandleFacadeFailedDifferentLocalizePreservesTerminalState(t *testing.T) {

--- a/internal/mcp/localization_terminal_test.go
+++ b/internal/mcp/localization_terminal_test.go
@@ -38,12 +38,11 @@ func TestHandleFacadeRejectsLocalizationBypassesWithoutClearingState(t *testing.
 			req.Params.Name = "explore"
 			req.Params.Arguments = request.args
 			result, err := server.handleFacade(ctx, "explore", req)
-			if err != nil || result == nil || result.IsError {
-				t.Fatalf("handleFacade() = (%v, %v), want successful terminal result", result, err)
+			if err != nil {
+				t.Fatalf("handleFacade() transport error = %v", err)
 			}
-			if text, _ := singleTextContent(result); text != localizationAnswerReadyNotice {
-				t.Fatalf("handleFacade() text = %q, want terminal notice", text)
-			}
+			operation, _ := request.args["operation"].(string)
+			requireLocalizationTerminalError(t, result, "explore", normalizeFacadeOperation(operation))
 			if blocked := terminal.block("search", "symbols", nil); blocked == nil {
 				t.Fatal("invalid localization request cleared terminal state")
 			}
@@ -224,13 +223,7 @@ func TestLocalizationTerminalStateInterceptsOnlyNavigation(t *testing.T) {
 	state.arm(newLocalizationCompletion(true, ""))
 	for _, facade := range []string{"explore", "search", "read", "relations", "trace", "analyze"} {
 		blocked := state.block(facade, "anything", nil)
-		if blocked == nil || blocked.IsError {
-			t.Fatalf("%s should return a successful terminal interception", facade)
-		}
-		text, _ := singleTextContent(blocked)
-		if text != localizationAnswerReadyNotice {
-			t.Fatalf("%s returned the wrong terminal notice: %s", facade, text)
-		}
+		requireLocalizationTerminalError(t, blocked, facade, "anything")
 	}
 	for _, facade := range []string{"change", "edit", "refactor", "workspace", "session", "recall", "remember", "capabilities"} {
 		if blocked := state.block(facade, "anything", nil); blocked != nil {
@@ -285,8 +278,10 @@ func TestLocalizationRefinementAllowsExactlyOneCandidateRead(t *testing.T) {
 		t.Fatalf("failed refinement did not restore allowance: blocked=%#v reserved=%v", blocked, reserved)
 	}
 	state.finishReservedRead(true)
-	if blocked, reserved := state.authorize("read", "source", read); blocked == nil || blocked.IsError || reserved {
-		t.Fatalf("second successful refinement read was not terminally intercepted: blocked=%#v reserved=%v", blocked, reserved)
+	if blocked, reserved := state.authorize("read", "source", read); reserved {
+		t.Fatal("second successful refinement read reserved a handler")
+	} else {
+		requireLocalizationTerminalError(t, blocked, "read", "source")
 	}
 }
 
@@ -351,15 +346,9 @@ func TestHandleFacadeRefinementReadReturnsAnswerReadyCompletion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("terminal analyze returned transport error: %v", err)
 	}
-	if blockedAnalyze == nil || blockedAnalyze.IsError {
-		t.Fatalf("terminal analyze did not return a successful interception: %#v", blockedAnalyze)
-	}
+	requireLocalizationTerminalError(t, blockedAnalyze, "analyze", "why")
 	if analyzeCalls != 0 {
 		t.Fatalf("terminal analyze reached its legacy handler %d time(s)", analyzeCalls)
-	}
-	text, _ := singleTextContent(blockedAnalyze)
-	if text != localizationAnswerReadyNotice {
-		t.Fatalf("terminal analyze returned the wrong notice: %s", text)
 	}
 }
 
@@ -405,13 +394,10 @@ func TestHandleFacadeTaskCannotEscapeTerminalState(t *testing.T) {
 		req.Params.Name = "explore"
 		req.Params.Arguments = map[string]any{"operation": "task", "task": task}
 		result, err := server.handleFacade(ctx, "explore", req)
-		if err != nil || result == nil || result.IsError {
+		if err != nil {
 			t.Fatalf("ordinary task escaped terminal state: result=%#v err=%v", result, err)
 		}
-		text, _ := singleTextContent(result)
-		if text != localizationAnswerReadyNotice {
-			t.Fatalf("ordinary task returned wrong terminal notice: %s", text)
-		}
+		requireLocalizationTerminalError(t, result, "explore", "task")
 	}
 	if called {
 		t.Fatal("ordinary explore(task) dispatched after localization completed")
@@ -517,16 +503,15 @@ func TestHandleFacadeExactReadCommitsOnlyOnSuccess(t *testing.T) {
 		t.Fatalf("retry should retain and consume the allowance on success: result=%#v err=%v", second, err)
 	}
 	body, ok := singleTextContent(second)
-	if !ok || !strings.Contains(body, `{"completion":{"state":"answer_ready","scope":"localization","required_action":"respond","allowed_tool_calls":0}}`) {
+	if !ok || !strings.Contains(body, `"state":"answer_ready"`) ||
+		!strings.Contains(body, `"contract_version":2`) || !strings.Contains(body, `"terminal":true`) {
 		t.Fatalf("successful exact read omitted terminal completion: %q", body)
 	}
 	third, err := server.handleFacade(ctx, "read", req)
-	if err != nil || third == nil || third.IsError || calls != 2 {
+	if err != nil || calls != 2 {
 		t.Fatalf("successful exact read must make later navigation terminal: result=%#v err=%v calls=%d", third, err, calls)
 	}
-	if text, _ := singleTextContent(third); text != localizationAnswerReadyNotice {
-		t.Fatalf("third exact read returned wrong terminal notice: %q", text)
-	}
+	requireLocalizationTerminalError(t, third, "read", "source")
 }
 
 func TestHandleFacadeFailedDifferentLocalizePreservesTerminalState(t *testing.T) {
@@ -595,12 +580,10 @@ func TestHandleFacadeExplicitNewUserTaskCommitsOnSuccess(t *testing.T) {
 
 	req.Params.Arguments = map[string]any{"operation": "localize", "task": "Locate Baz"}
 	blocked, err := server.handleFacade(ctx, "explore", req)
-	if err != nil || blocked == nil || blocked.IsError || calls != 1 {
+	if err != nil || calls != 1 {
 		t.Fatalf("later localize without boundary escaped: result=%#v err=%v calls=%d", blocked, err, calls)
 	}
-	if text, _ := singleTextContent(blocked); text != localizationAnswerReadyNotice {
-		t.Fatalf("later localize returned wrong terminal notice: %q", text)
-	}
+	requireLocalizationTerminalError(t, blocked, "explore", "localize")
 }
 
 func TestHandleFacadeNewUserTaskPanicRollsBack(t *testing.T) {
@@ -753,12 +736,10 @@ func TestHandleFacadeExactReadPanicRestoresReservation(t *testing.T) {
 		t.Fatalf("exact read retry = (%v, %v), want success", result, err)
 	}
 	third, err := server.handleFacade(ctx, "read", req)
-	if err != nil || third == nil || third.IsError {
+	if err != nil {
 		t.Fatalf("third exact read = (%v, %v), want terminal block", third, err)
 	}
-	if text, _ := singleTextContent(third); text != localizationAnswerReadyNotice {
-		t.Fatalf("third exact read returned wrong terminal notice: %q", text)
-	}
+	requireLocalizationTerminalError(t, third, "read", "source")
 	if calls != 2 {
 		t.Fatalf("legacy source calls = %d, want 2", calls)
 	}
@@ -785,12 +766,10 @@ func TestHandleFacadeLocalizeBlocksParaphrasesWithoutBoundary(t *testing.T) {
 		req.Params.Name = "explore"
 		req.Params.Arguments = map[string]any{"operation": "localize", "task": task}
 		result, err := server.handleFacade(ctx, "explore", req)
-		if err != nil || result == nil || result.IsError {
+		if err != nil {
 			t.Fatalf("localize(%q) bypassed active contract: result=%#v err=%v", task, result, err)
 		}
-		if text, _ := singleTextContent(result); text != localizationAnswerReadyNotice {
-			t.Fatalf("localize(%q) returned wrong terminal notice: %q", task, text)
-		}
+		requireLocalizationTerminalError(t, result, "explore", "localize")
 	}
 	if calls != 0 {
 		t.Fatalf("blocked localize calls dispatched %d legacy request(s)", calls)

--- a/internal/mcp/localization_terminal_test.go
+++ b/internal/mcp/localization_terminal_test.go
@@ -187,7 +187,7 @@ func TestLocalizationRefinementAllowsExactlyOneCandidateRead(t *testing.T) {
 	state := newLocalizationTerminalState()
 	candidate := "repo/pkg/file.go::Resolver.Run"
 	other := "repo/pkg/other.go::Other"
-	state.armRefinementForTask("locate resolver behavior", candidate, []string{candidate, other})
+	state.armRefinementForTask("locate resolver behavior", candidate, []string{candidate, other}, nil)
 
 	wrong := map[string]any{"target": map[string]any{"symbol": "repo/pkg/wrong.go::Wrong"}}
 	if blocked, reserved := state.authorize("read", "source", wrong); blocked == nil || reserved {
@@ -234,7 +234,7 @@ func TestHandleFacadeRefinementReadReturnsAnswerReadyCompletion(t *testing.T) {
 	})
 	server := &Server{facades: registry, localization: newLocalizationTerminalState(), sessions: newSessionMap()}
 	ctx := WithSessionID(context.Background(), "refinement-read-completion")
-	server.localizationFor(ctx).armRefinementForTask("locate resolver behavior", candidate, []string{candidate})
+	server.localizationFor(ctx).armRefinementForTask("locate resolver behavior", candidate, []string{candidate}, nil)
 
 	req := mcpgo.CallToolRequest{}
 	req.Params.Name = "read"

--- a/internal/mcp/localization_terminal_test.go
+++ b/internal/mcp/localization_terminal_test.go
@@ -31,7 +31,6 @@ func TestHandleFacadeRejectsLocalizationBypassesWithoutClearingState(t *testing.
 		{name: "task nested override", args: map[string]any{"operation": "task", "task": "Locate Bar", "options": map[string]any{"localize": true}}},
 		{name: "empty localize", args: map[string]any{"operation": "localize", "task": ""}},
 		{name: "nested localize task", args: map[string]any{"operation": "localize", "options": map[string]any{"task": "Locate Bar"}}},
-		{name: "malformed different localize", args: map[string]any{"operation": "localize", "task": "Locate Bar", "options": "bad"}},
 	}
 	for _, request := range requests {
 		t.Run(request.name, func(t *testing.T) {
@@ -39,8 +38,11 @@ func TestHandleFacadeRejectsLocalizationBypassesWithoutClearingState(t *testing.
 			req.Params.Name = "explore"
 			req.Params.Arguments = request.args
 			result, err := server.handleFacade(ctx, "explore", req)
-			if err != nil || result == nil || !result.IsError {
-				t.Fatalf("handleFacade() = (%v, %v), want invalid argument result", result, err)
+			if err != nil || result == nil || result.IsError {
+				t.Fatalf("handleFacade() = (%v, %v), want successful terminal result", result, err)
+			}
+			if text, _ := singleTextContent(result); text != localizationAnswerReadyNotice {
+				t.Fatalf("handleFacade() text = %q, want terminal notice", text)
 			}
 			if blocked := terminal.block("search", "symbols", nil); blocked == nil {
 				t.Fatal("invalid localization request cleared terminal state")
@@ -49,6 +51,76 @@ func TestHandleFacadeRejectsLocalizationBypassesWithoutClearingState(t *testing.
 	}
 	if calls != 0 {
 		t.Fatalf("legacy explore calls = %d, want 0", calls)
+	}
+}
+
+func TestHandleFacadeValidatesMalformedExplicitNewUserBoundary(t *testing.T) {
+	registry := newFacadeRegistry()
+	calls := 0
+	registry.capture(mcpgo.NewTool("explore"), func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		calls++
+		return mcpgo.NewToolResultText("unexpected"), nil
+	})
+	server := &Server{facades: registry, localization: &localizationTerminalState{}}
+	ctx := WithSessionID(context.Background(), "malformed-new-task-boundary")
+	terminal := server.localizationFor(ctx)
+	terminal.armForTask(newLocalizationCompletion(true, ""), "Locate Foo")
+
+	tests := []struct {
+		name   string
+		facade string
+		args   map[string]any
+		want   string
+	}{
+		{
+			name: "options not object",
+			args: map[string]any{"operation": "localize", "task": "Locate Bar", "options": "true"},
+			want: "options must be an object",
+		},
+		{
+			name: "boundary not boolean",
+			args: map[string]any{"operation": "localize", "task": "Locate Bar", "options": map[string]any{"new_user_task": "true"}},
+			want: "options.new_user_task must be a boolean",
+		},
+		{
+			name: "boundary on unsupported explore operation",
+			args: map[string]any{"operation": "outline", "task": "Locate Bar", "options": map[string]any{"new_user_task": true}},
+			want: "valid only on the first explore.task or explore.localize",
+		},
+		{
+			name:   "boundary on another facade",
+			facade: "search",
+			args:   map[string]any{"operation": "symbols", "query": "Run", "options": map[string]any{"new_user_task": true}},
+			want:   "valid only on the first explore.task or explore.localize",
+		},
+		{
+			name: "boundary without task",
+			args: map[string]any{"operation": "localize", "task": "", "options": map[string]any{"new_user_task": true}},
+			want: "explore.localize requires task",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			facade := test.facade
+			if facade == "" {
+				facade = "explore"
+			}
+			req := mcpgo.CallToolRequest{Params: mcpgo.CallToolParams{Name: "explore", Arguments: test.args}}
+			result, err := server.handleFacade(ctx, facade, req)
+			if err != nil || result == nil || !result.IsError {
+				t.Fatalf("malformed boundary = (%#v, %v), want validation error", result, err)
+			}
+			text, _ := singleTextContent(result)
+			if !strings.Contains(text, test.want) {
+				t.Fatalf("validation text = %q, want %q", text, test.want)
+			}
+			if blocked := terminal.block("search", "symbols", nil); blocked == nil {
+				t.Fatal("malformed boundary cleared the prior terminal contract")
+			}
+		})
+	}
+	if calls != 0 {
+		t.Fatalf("malformed boundary dispatched %d legacy call(s)", calls)
 	}
 }
 
@@ -147,22 +219,22 @@ func TestLocalizationCompletionEnvelope(t *testing.T) {
 	}
 }
 
-func TestLocalizationTerminalStateBlocksOnlyNavigation(t *testing.T) {
+func TestLocalizationTerminalStateInterceptsOnlyNavigation(t *testing.T) {
 	state := newLocalizationTerminalState()
 	state.arm(newLocalizationCompletion(true, ""))
 	for _, facade := range []string{"explore", "search", "read", "relations", "trace", "analyze"} {
 		blocked := state.block(facade, "anything", nil)
-		if blocked == nil || !blocked.IsError {
-			t.Fatalf("%s should be terminally blocked", facade)
+		if blocked == nil || blocked.IsError {
+			t.Fatalf("%s should return a successful terminal interception", facade)
 		}
 		text, _ := singleTextContent(blocked)
-		if !strings.Contains(text, string(ErrCodeLocalizationComplete)) {
-			t.Fatalf("%s returned the wrong error: %s", facade, text)
+		if text != localizationAnswerReadyNotice {
+			t.Fatalf("%s returned the wrong terminal notice: %s", facade, text)
 		}
 	}
-	for _, facade := range []string{"change", "edit", "refactor", "workspace", "recall", "remember"} {
+	for _, facade := range []string{"change", "edit", "refactor", "workspace", "session", "recall", "remember", "capabilities"} {
 		if blocked := state.block(facade, "anything", nil); blocked != nil {
-			t.Fatalf("%s must remain available after localization: %#v", facade, blocked)
+			t.Fatalf("%s must remain dispatchable after answer_ready: %#v", facade, blocked)
 		}
 	}
 }
@@ -193,10 +265,6 @@ func TestLocalizationRefinementAllowsExactlyOneCandidateRead(t *testing.T) {
 	if blocked, reserved := state.authorize("read", "source", wrong); blocked == nil || reserved {
 		t.Fatalf("unreturned refinement target was admitted: blocked=%#v reserved=%v", blocked, reserved)
 	}
-	alternate := map[string]any{"target": map[string]any{"symbol": other}}
-	if blocked, reserved := state.authorize("read", "source", alternate); blocked == nil || reserved {
-		t.Fatalf("non-preferred refinement target was admitted: blocked=%#v reserved=%v", blocked, reserved)
-	}
 	if blocked, reserved := state.authorize("search", "text", map[string]any{"query": "Run"}); blocked == nil || reserved {
 		t.Fatalf("broad refinement search was admitted: blocked=%#v reserved=%v", blocked, reserved)
 	}
@@ -204,20 +272,21 @@ func TestLocalizationRefinementAllowsExactlyOneCandidateRead(t *testing.T) {
 		t.Fatalf("non-navigation tool was blocked: blocked=%#v reserved=%v", blocked, reserved)
 	}
 
-	read := map[string]any{"target": map[string]any{"symbol": candidate}}
-	if blocked, reserved := state.authorize("read", "source", read); blocked != nil || !reserved {
-		t.Fatalf("candidate refinement read was not reserved: blocked=%#v reserved=%v", blocked, reserved)
+	alternate := map[string]any{"target": map[string]any{"symbol": other}}
+	if blocked, reserved := state.authorize("read", "source", alternate); blocked != nil || !reserved {
+		t.Fatalf("alternate returned candidate was not reserved: blocked=%#v reserved=%v", blocked, reserved)
 	}
-	if blocked, reserved := state.authorize("read", "source", read); blocked == nil || reserved {
+	if blocked, reserved := state.authorize("read", "source", alternate); blocked == nil || reserved {
 		t.Fatalf("concurrent refinement read was admitted: blocked=%#v reserved=%v", blocked, reserved)
 	}
 	state.finishReservedRead(false)
+	read := map[string]any{"target": map[string]any{"symbol": candidate}}
 	if blocked, reserved := state.authorize("read", "source", read); blocked != nil || !reserved {
 		t.Fatalf("failed refinement did not restore allowance: blocked=%#v reserved=%v", blocked, reserved)
 	}
 	state.finishReservedRead(true)
-	if blocked, reserved := state.authorize("read", "source", read); blocked == nil || reserved {
-		t.Fatalf("second successful refinement read was admitted: blocked=%#v reserved=%v", blocked, reserved)
+	if blocked, reserved := state.authorize("read", "source", read); blocked == nil || blocked.IsError || reserved {
+		t.Fatalf("second successful refinement read was not terminally intercepted: blocked=%#v reserved=%v", blocked, reserved)
 	}
 }
 
@@ -234,7 +303,7 @@ func TestHandleFacadeRefinementReadReturnsAnswerReadyCompletion(t *testing.T) {
 	})
 	server := &Server{facades: registry, localization: newLocalizationTerminalState(), sessions: newSessionMap()}
 	ctx := WithSessionID(context.Background(), "refinement-read-completion")
-	server.localizationFor(ctx).armRefinementForTask("locate resolver behavior", candidate, []string{candidate}, nil)
+	server.localizationFor(ctx).armRefinementForTask("locate resolver behavior", candidate, []string{candidate}, testEvidenceDigest())
 
 	req := mcpgo.CallToolRequest{}
 	req.Params.Name = "read"
@@ -261,6 +330,13 @@ func TestHandleFacadeRefinementReadReturnsAnswerReadyCompletion(t *testing.T) {
 	if !ok || completion["state"] != localizationStateAnswerReady || completion["required_action"] != "respond" || completion["allowed_tool_calls"] != float64(0) {
 		t.Fatalf("refinement response omitted answer-ready completion: %#v", payload["completion"])
 	}
+	if result.Meta == nil || result.Meta.AdditionalFields == nil {
+		t.Fatal("first terminal read omitted host-only fallback metadata")
+	}
+	host, ok := result.Meta.AdditionalFields[localizationHostMetaKey].(localizationHostEnvelope)
+	if !ok || host.Evidence == nil || len(host.Evidence.Evidence) == 0 || host.Evidence.Evidence[0].File != "repo/storage/disk.go" {
+		t.Fatalf("first terminal read fallback envelope = %#v", result.Meta.AdditionalFields[localizationHostMetaKey])
+	}
 	if blocked := server.localizationFor(ctx).block("explore", "localize", nil); blocked == nil {
 		t.Fatal("successful refinement read did not commit terminal state")
 	}
@@ -275,15 +351,15 @@ func TestHandleFacadeRefinementReadReturnsAnswerReadyCompletion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("terminal analyze returned transport error: %v", err)
 	}
-	if blockedAnalyze == nil || !blockedAnalyze.IsError {
-		t.Fatalf("terminal analyze was not blocked: %#v", blockedAnalyze)
+	if blockedAnalyze == nil || blockedAnalyze.IsError {
+		t.Fatalf("terminal analyze did not return a successful interception: %#v", blockedAnalyze)
 	}
 	if analyzeCalls != 0 {
 		t.Fatalf("terminal analyze reached its legacy handler %d time(s)", analyzeCalls)
 	}
 	text, _ := singleTextContent(blockedAnalyze)
-	if !strings.Contains(text, string(ErrCodeLocalizationComplete)) {
-		t.Fatalf("terminal analyze returned the wrong error: %s", text)
+	if text != localizationAnswerReadyNotice {
+		t.Fatalf("terminal analyze returned the wrong notice: %s", text)
 	}
 }
 
@@ -329,12 +405,12 @@ func TestHandleFacadeTaskCannotEscapeTerminalState(t *testing.T) {
 		req.Params.Name = "explore"
 		req.Params.Arguments = map[string]any{"operation": "task", "task": task}
 		result, err := server.handleFacade(ctx, "explore", req)
-		if err != nil || result == nil || !result.IsError {
+		if err != nil || result == nil || result.IsError {
 			t.Fatalf("ordinary task escaped terminal state: result=%#v err=%v", result, err)
 		}
 		text, _ := singleTextContent(result)
-		if !strings.Contains(text, string(ErrCodeLocalizationComplete)) {
-			t.Fatalf("ordinary task returned wrong terminal error: %s", text)
+		if text != localizationAnswerReadyNotice {
+			t.Fatalf("ordinary task returned wrong terminal notice: %s", text)
 		}
 	}
 	if called {
@@ -373,6 +449,46 @@ func TestHandleFacadeTaskRunsWhenTerminalInactive(t *testing.T) {
 	}
 }
 
+func TestHandleFacadeExplicitNewUserTaskCrossesTerminalBoundary(t *testing.T) {
+	registry := newFacadeRegistry()
+	calls := 0
+	registry.capture(mcpgo.NewTool("explore", mcpgo.WithString("task", mcpgo.Required())), func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		calls++
+		if req.GetString("task", "") != "Diagnose Bar" {
+			t.Fatalf("legacy task = %q, want Diagnose Bar", req.GetString("task", ""))
+		}
+		return mcpgo.NewToolResultText("diagnostic neighborhood"), nil
+	})
+	server := &Server{facades: registry, localization: newLocalizationTerminalState(), sessions: newSessionMap()}
+	ctx := WithSessionID(context.Background(), "explicit-task-boundary")
+	terminal := server.localizationFor(ctx)
+	terminal.armForTask(newLocalizationCompletion(true, ""), "Locate Foo")
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Name = "explore"
+	req.Params.Arguments = map[string]any{
+		"operation": "task",
+		"task":      "Diagnose Bar",
+		"options":   map[string]any{"new_user_task": true},
+	}
+	result, err := server.handleFacade(ctx, "explore", req)
+	if err != nil || result == nil || result.IsError || calls != 1 {
+		t.Fatalf("explicit task boundary = (%#v, %v), calls=%d", result, err, calls)
+	}
+	if text, _ := singleTextContent(result); text != "diagnostic neighborhood" {
+		t.Fatalf("explicit task boundary text = %q", text)
+	}
+	if blocked := terminal.block("search", "symbols", nil); blocked != nil {
+		t.Fatalf("successful diagnostic task retained prior terminal state: %#v", blocked)
+	}
+	terminal.mu.Lock()
+	fingerprint := terminal.taskFingerprint
+	terminal.mu.Unlock()
+	if fingerprint != "Diagnose Bar" {
+		t.Fatalf("successful diagnostic task committed fingerprint %q", fingerprint)
+	}
+}
+
 func TestHandleFacadeExactReadCommitsOnlyOnSuccess(t *testing.T) {
 	registry := newFacadeRegistry()
 	calls := 0
@@ -405,8 +521,11 @@ func TestHandleFacadeExactReadCommitsOnlyOnSuccess(t *testing.T) {
 		t.Fatalf("successful exact read omitted terminal completion: %q", body)
 	}
 	third, err := server.handleFacade(ctx, "read", req)
-	if err != nil || third == nil || !third.IsError || calls != 2 {
+	if err != nil || third == nil || third.IsError || calls != 2 {
 		t.Fatalf("successful exact read must make later navigation terminal: result=%#v err=%v calls=%d", third, err, calls)
+	}
+	if text, _ := singleTextContent(third); text != localizationAnswerReadyNotice {
+		t.Fatalf("third exact read returned wrong terminal notice: %q", text)
 	}
 }
 
@@ -476,8 +595,11 @@ func TestHandleFacadeExplicitNewUserTaskCommitsOnSuccess(t *testing.T) {
 
 	req.Params.Arguments = map[string]any{"operation": "localize", "task": "Locate Baz"}
 	blocked, err := server.handleFacade(ctx, "explore", req)
-	if err != nil || blocked == nil || !blocked.IsError || calls != 1 {
+	if err != nil || blocked == nil || blocked.IsError || calls != 1 {
 		t.Fatalf("later localize without boundary escaped: result=%#v err=%v calls=%d", blocked, err, calls)
+	}
+	if text, _ := singleTextContent(blocked); text != localizationAnswerReadyNotice {
+		t.Fatalf("later localize returned wrong terminal notice: %q", text)
 	}
 }
 
@@ -631,8 +753,11 @@ func TestHandleFacadeExactReadPanicRestoresReservation(t *testing.T) {
 		t.Fatalf("exact read retry = (%v, %v), want success", result, err)
 	}
 	third, err := server.handleFacade(ctx, "read", req)
-	if err != nil || third == nil || !third.IsError {
+	if err != nil || third == nil || third.IsError {
 		t.Fatalf("third exact read = (%v, %v), want terminal block", third, err)
+	}
+	if text, _ := singleTextContent(third); text != localizationAnswerReadyNotice {
+		t.Fatalf("third exact read returned wrong terminal notice: %q", text)
 	}
 	if calls != 2 {
 		t.Fatalf("legacy source calls = %d, want 2", calls)
@@ -660,8 +785,11 @@ func TestHandleFacadeLocalizeBlocksParaphrasesWithoutBoundary(t *testing.T) {
 		req.Params.Name = "explore"
 		req.Params.Arguments = map[string]any{"operation": "localize", "task": task}
 		result, err := server.handleFacade(ctx, "explore", req)
-		if err != nil || result == nil || !result.IsError {
+		if err != nil || result == nil || result.IsError {
 			t.Fatalf("localize(%q) bypassed active contract: result=%#v err=%v", task, result, err)
+		}
+		if text, _ := singleTextContent(result); text != localizationAnswerReadyNotice {
+			t.Fatalf("localize(%q) returned wrong terminal notice: %q", task, text)
 		}
 	}
 	if calls != 0 {

--- a/internal/mcp/tools_enhancements.go
+++ b/internal/mcp/tools_enhancements.go
@@ -775,6 +775,12 @@ func (s *Server) handleAnalyze(ctx context.Context, req mcp.CallToolRequest) (*m
 		return mcp.NewToolResultText(analyzeHelpResult()), nil
 	}
 
+	releaseAnalysis, admissionErr := s.acquireAnalyzeAdmission(ctx, kind)
+	if admissionErr != nil {
+		return mcp.NewToolResultError(admissionErr.Error()), nil
+	}
+	defer releaseAnalysis()
+
 	// Uniform repo/project/workspace/scope narrowing, clamped to the
 	// session workspace. A few kinds own one of the uniform arg names as
 	// a kind-specific filter, so strip those from the scope-resolution

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -92,6 +92,8 @@ type exploreTarget struct {
 	exactContentAmbiguous bool   // exact evidence has visible or possibly truncated peers
 	sourceLiteral         bool   // exact source-body hit that must survive final envelope packing
 	sourceLiteralCallee   bool   // exact source callsite uniquely resolved to this invoked callable
+	typedAnchorProjection bool   // bounded field-owner-call proof promoted from a task-aligned typed field
+	foldedOwner           bool   // synthetic owner inserted by concept member folding
 }
 
 type exploreCausalNeighbor struct {
@@ -2055,6 +2057,20 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 		}
 		cands = anchorPool
 	}
+	if queryClass == rerank.QueryClassConcept && len(protectedSyntacticAnchors) > 0 {
+		// A protected anchor can leave a matching typed field in the final window
+		// without its behavioral owner. Admit one graph-proven field-owner
+		// consumer and its anchor-aligned typed member before source hydration.
+		// The projection uses a fixed batch pipeline with deterministic fanout
+		// bounds and is a no-op unless every structural link is resolved.
+		cands = projectExploreTypedAnchorCandidates(
+			ctx, task, cands, eng.Reader(), opts, maxSymbols,
+			protectedSyntacticAnchors, protectedImplementationID,
+		)
+	}
+	protectedFinalCandidateIDs := exploreTypedAnchorReservedCandidateIDs(
+		cands, protectedSyntacticAnchors, protectedImplementationID,
+	)
 	if len(cands) == 0 && len(artifactLane.targets) == 0 {
 		if req.GetBool("localize", false) {
 			return s.completeEmptyLocalization(ctx, task, budget), nil
@@ -2099,6 +2115,7 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 			t.exactContentAmbiguous = c.Signals[exploreContentRecallAmbiguousSignal] > 0
 			t.sourceLiteral = c.Signals[exploreSourceLiteralSignal] > 0
 			t.sourceLiteralCallee = c.Signals[exploreSourceLiteralCalleeSignal] > 0
+			t.typedAnchorProjection = c.Signals[exploreTypedAnchorProjectionSignal] > 0
 		}
 		t.source = s.manifestSymbolSource(ctx, n)
 		if callers := eng.GetCallers(n.ID, ringOpts); callers != nil {
@@ -2183,6 +2200,11 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 		// so terminality is judged against the same strongest evidence that the
 		// final envelope exposes, rather than against a synthetic owner row.
 		symbolTargets = promoteExploreStrongSourceLiteralTarget(symbolTargets)
+		// Owner folding may insert a type above two retained members. Preserve the
+		// fold without violating the request's max_symbols contract: evict only an
+		// unreserved tail target, or the inserted owner itself when every direct
+		// candidate is protected by an earlier evidence lane.
+		symbolTargets = limitExploreFoldedTargets(task, symbolTargets, maxSymbols, protectedFinalCandidateIDs)
 		targets = append(targets[:len(artifactTargets):len(artifactTargets)], symbolTargets...)
 	}
 	answerReady := exploreAnswerReady(task, symbolTargets) || artifactLane.ready
@@ -2697,6 +2719,15 @@ func localizationEvidenceTargetsFromDraft(task, exactID string, targets []explor
 			break
 		}
 	}
+	// A typed-field projection is admitted only after a complete bounded
+	// field→owner←consumer→member proof. Reserve its consumer/member pair before
+	// ordinary draft expansion, but behind pre-existing exact and source-literal
+	// contracts so the new lane cannot demote stronger evidence.
+	for _, target := range targets {
+		if target.typedAnchorProjection {
+			appendTarget(target)
+		}
+	}
 	appendEntry := func(entry exploreDraftEntry) {
 		if entry.node == nil {
 			return
@@ -2874,6 +2905,9 @@ func buildLocalizationExploreResultForTaskFinalized(
 	}
 	for index, target := range targets {
 		if (target.divergentDefaultOwner || target.divergentDefaultType) && index+1 > mandatoryCount {
+			mandatoryCount = index + 1
+		}
+		if target.typedAnchorProjection && index+1 > mandatoryCount {
 			mandatoryCount = index + 1
 		}
 	}

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -3574,6 +3574,7 @@ const (
 	exploreSourceLiteralSignal          = "explore_source_literal"
 	exploreSourceLiteralCalleeSignal    = "explore_source_literal_callee"
 	exploreSourceLiteralCoverageSignal  = "explore_source_literal_coverage"
+	exploreSourceLiteralTaskAlignSignal = "explore_source_literal_task_alignment"
 	exploreSourceLiteralReservationMax  = 2
 	exploreQuotedRecallMaxTerms         = 3
 	exploreQuotedRecallMaxPerTerm       = 12
@@ -3697,16 +3698,50 @@ func exploreQuotedRecallHasExactSourceNode(
 		!exploreLocalizableKind(node.Kind) || !exploreCodeDefinitionKind(node.Kind) {
 		return false
 	}
+	if exploreDraftIsTestNode(node) && !exploreQueryHasTestIntent(task) {
+		return false
+	}
 	if exploreLocalizationExplicitAnchor(task, node) {
 		return true
 	}
 	retrieval := node.RetrievalMetadata()
-	fields := [...]string{node.Name, retrieval.QualName, retrieval.Signature}
 	for _, term := range terms {
-		for _, field := range fields {
+		// Compact values such as locale and protocol codes are usually source
+		// literals, not declaration identities. Trust an exact declaration name
+		// or signature, but never a path-derived qualified name such as a test
+		// namespace ending in `.ku`.
+		fields := [...]string{node.Name, retrieval.Signature, retrieval.QualName}
+		fieldCount := len(fields)
+		if exploreCompactSourceLiteral(term, utf8.RuneCountInString(term)) {
+			fieldCount--
+		}
+		for _, field := range fields[:fieldCount] {
 			if exploreTextHasExactLiteral(field, term) {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+func exploreQueryHasTestIntent(task string) bool {
+	for _, token := range rerank.Tokenize(task) {
+		switch strings.ToLower(token) {
+		case "test", "tests", "testing", "spec", "specs", "fixture", "fixtures":
+			return true
+		}
+	}
+	return false
+}
+
+func exploreSourceLiteralConstructionIntent(task string) bool {
+	for _, token := range rerank.Tokenize(task) {
+		switch strings.ToLower(token) {
+		case "construct", "constructed", "constructing", "construction", "constructor", "constructors",
+			"initialise", "initialised", "initialises", "initialising", "initialisation",
+			"initialize", "initialized", "initializes", "initializing", "initialization",
+			"instantiate", "instantiated", "instantiates", "instantiating", "instantiation":
+			return true
 		}
 	}
 	return false
@@ -3812,6 +3847,7 @@ func (s *Server) gatherExploreQuotedContentCandidates(
 	sourceLiteralAmbiguous := make(map[string]bool)
 	sourceLiteralSettled := make(map[string]bool)
 	sourceLiteralCallee := make(map[string]bool)
+	sourceLiteralTaskAligned := make(map[string]bool)
 	for _, page := range pages {
 		seenForTerm := make(map[string]struct{}, len(page.hits))
 		exactIDs := make(map[string]struct{})
@@ -3922,6 +3958,29 @@ func (s *Server) gatherExploreQuotedContentCandidates(
 				nodes[id] = node
 			}
 		}
+		// A collision-heavy literal alone cannot justify replacing two semantic
+		// candidates. When the task explicitly asks about construction, however,
+		// an exact callsite whose resolved callable instantiates a value is a
+		// language-neutral causal discriminator. One batched edge lookup covers
+		// the already-bounded owner set; no source body or recursive walk is added.
+		if exploreSourceLiteralConstructionIntent(task) {
+			calleeIDs := make([]string, 0, len(sourceLiteralCallee))
+			for id, callee := range sourceLiteralCallee {
+				if callee {
+					calleeIDs = append(calleeIDs, id)
+				}
+			}
+			if len(calleeIDs) > 0 {
+				for id, edges := range s.graph.GetOutEdgesByNodeIDs(calleeIDs) {
+					for _, edge := range edges {
+						if edge != nil && edge.Kind == graph.EdgeInstantiates {
+							sourceLiteralTaskAligned[id] = true
+							break
+						}
+					}
+				}
+			}
+		}
 	}
 	if len(order) == 0 {
 		return nil
@@ -3948,6 +4007,9 @@ func (s *Server) gatherExploreQuotedContentCandidates(
 			signals[exploreSourceLiteralCoverageSignal] = float64(len(sourceLiteralAnchors[id]))
 			if sourceLiteralCallee[id] {
 				signals[exploreSourceLiteralCalleeSignal] = 1
+			}
+			if sourceLiteralTaskAligned[id] {
+				signals[exploreSourceLiteralTaskAlignSignal] = 1
 			}
 		}
 		candidates = append(candidates, &rerank.Candidate{
@@ -4253,12 +4315,28 @@ func reserveExploreSourceLiteralCandidate(candidates, bounded []*rerank.Candidat
 	}
 
 	sources := make([]*rerank.Candidate, 0, exploreSourceLiteralReservationMax)
+	seenSourceIDs := make(map[string]struct{}, exploreSourceLiteralReservationMax)
 	for _, candidate := range candidates {
-		if candidate == nil || candidate.Node == nil || candidate.Signals == nil ||
+		if candidate == nil || candidate.Node == nil || candidate.Node.ID == "" || candidate.Signals == nil ||
 			candidate.Signals[exploreSourceLiteralSignal] <= 0 {
 			continue
 		}
+		if _, duplicate := seenSourceIDs[candidate.Node.ID]; duplicate {
+			continue
+		}
+		seenSourceIDs[candidate.Node.ID] = struct{}{}
 		sources = append(sources, candidate)
+	}
+	directProductionCallee := func(candidate *rerank.Candidate) bool {
+		return candidate != nil && candidate.Node != nil && candidate.Signals != nil &&
+			candidate.Signals[exploreSourceLiteralCalleeSignal] > 0 &&
+			!exploreDraftIsTestNode(candidate.Node)
+	}
+	callableSpecificity := func(candidate *rerank.Candidate) int {
+		if !directProductionCallee(candidate) {
+			return 0
+		}
+		return exploreIdentifierSegmentCountBounded(candidate.Node.Name)
 	}
 	sort.SliceStable(sources, func(i, j int) bool {
 		leftCoverage := sources[i].Signals[exploreSourceLiteralCoverageSignal]
@@ -4266,7 +4344,27 @@ func reserveExploreSourceLiteralCandidate(candidates, bounded []*rerank.Candidat
 		if leftCoverage != rightCoverage {
 			return leftCoverage > rightCoverage
 		}
-		return sources[i].Signals[exploreSourceLiteralSignal] > sources[j].Signals[exploreSourceLiteralSignal]
+		leftSettled := sources[i].Signals[exploreContentRecallAmbiguousSignal] <= 0
+		rightSettled := sources[j].Signals[exploreContentRecallAmbiguousSignal] <= 0
+		if leftSettled != rightSettled {
+			return leftSettled
+		}
+		leftDirect := directProductionCallee(sources[i])
+		rightDirect := directProductionCallee(sources[j])
+		if leftDirect != rightDirect {
+			return leftDirect
+		}
+		leftAligned := sources[i].Signals[exploreSourceLiteralTaskAlignSignal] > 0
+		rightAligned := sources[j].Signals[exploreSourceLiteralTaskAlignSignal] > 0
+		if leftAligned != rightAligned {
+			return leftAligned
+		}
+		leftRank := sources[i].Signals[exploreSourceLiteralSignal]
+		rightRank := sources[j].Signals[exploreSourceLiteralSignal]
+		if leftRank != rightRank {
+			return leftRank > rightRank
+		}
+		return callableSpecificity(sources[i]) > callableSpecificity(sources[j])
 	})
 	selectedSources := sources[:0]
 	for _, source := range sources {

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -1862,6 +1862,19 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 	// too, whose success promotes to answer_ready with the evidence already
 	// stashed.
 	result, _, digest := buildLocalizationExploreResultForTask(completion, task, targets, budget)
+	// Literal-driven terminality must show its evidence: when the verdict
+	// rests on a quoted-literal match but the budgeted envelope shed the
+	// literal, downgrade to the bounded refinement read instead of telling
+	// the host to answer from evidence it cannot see.
+	if answerReady && exactSymbol == "" &&
+		exploreAnswerReadyViaLiteralOnly(task, symbolTargets) &&
+		!exploreResultCitesTaskLiteral(result, task) {
+		preferredSymbol := explorePreferredRefinementSymbol(task, symbolTargets)
+		refinement := newLocalizationRefinementCompletion(preferredSymbol)
+		refined, returnedSymbols, refinedDigest := buildLocalizationExploreResultForTask(refinement, task, targets, budget)
+		s.localizationFor(ctx).armRefinementForTask(task, preferredSymbol, returnedSymbols, refinedDigest)
+		return refined, nil
+	}
 	completion.digest = digest
 	s.localizationFor(ctx).armForTask(completion, task)
 	return result, nil

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -85,6 +85,8 @@ type exploreTarget struct {
 	directCalleesComplete bool // false when the direct projection was truncated, bounded, or otherwise lower-bound
 	causalCallees         []exploreCausalNeighbor
 	source                string // full body (may be empty for non-source kinds)
+	divergentDefaultOwner bool   // unique child constructor whose concrete default causes the queried behavior
+	divergentDefaultType  bool   // owning type paired with divergentDefaultOwner for coherent file/symbol output
 	conceptImplementation bool   // one identifier-backed callable protected from final truncation
 	exactContent          bool   // verified full quoted-literal hit from content_fts
 	exactContentAmbiguous bool   // exact evidence has visible or possibly truncated peers
@@ -2016,6 +2018,12 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 		}
 		targets = append(targets, t)
 	}
+	if exploreQueryIsConceptTask(task) && len(targets) > len(artifactTargets) {
+		symbolTargets := promoteExploreDivergentDefaultOwner(task, targets[len(artifactTargets):], s.graph, maxSymbols, func(node *graph.Node) string {
+			return s.manifestSymbolSource(ctx, node)
+		})
+		targets = append(targets[:len(artifactTargets):len(artifactTargets)], symbolTargets...)
+	}
 	// Direct retrieval owns the ranked head. Once graph promotion has selected
 	// a cross-file boundary, materialize exactly that one node so both text and
 	// structured responses can reserve a source body without a broad read.
@@ -2035,7 +2043,7 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 		// Concept answers prefer the owning type when several of its members
 		// rank together; implementation-intent queries are exempt because
 		// they ask for exactly those members.
-		symbolTargets = s.foldMemberOwners(ctx, symbolTargets)
+		symbolTargets = preserveExploreDivergentDefaultOrder(s.foldMemberOwners(ctx, symbolTargets))
 		targets = append(targets[:len(artifactTargets):len(artifactTargets)], symbolTargets...)
 	}
 	answerReady := exploreAnswerReady(task, symbolTargets) || artifactLane.ready
@@ -2051,6 +2059,13 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 	// File evidence can make localization answer-ready, but it never becomes a
 	// synthetic exact-symbol read. Exact reads remain declaration-only.
 	exactSymbol := exploreLocalizationExplicitTarget(task, symbolTargets)
+	// A unique graph + default-flow proof identifies the upstream cause behind
+	// an issue author's downstream symbol anchor. Read that proven constructor,
+	// while retaining the explicitly named consumer immediately after it in the
+	// evidence projection.
+	if causalSymbol := exploreDivergentDefaultOwnerSymbol(symbolTargets); causalSymbol != "" {
+		exactSymbol = causalSymbol
+	}
 	if !answerReady && exactSymbol == "" {
 		// Uncertain localization is still useful evidence. Returning it as an
 		// MCP error makes hosts discard the ranked candidates and restart broad
@@ -2232,6 +2247,14 @@ func materializeExploreStructuralSourceWithReader(
 	if len(targets) == 0 || !exploreAllowsStructuralBody(task) || ctx.Err() != nil || readSource == nil {
 		return targets
 	}
+	// Promotion already spent this request's single structural read proving the
+	// child forwards its divergent default. Reuse that source and never open a
+	// second boundary merely for presentation.
+	for _, target := range targets {
+		if target.divergentDefaultOwner {
+			return targets
+		}
+	}
 	draft := exploreAnswerDraft(task, targets)
 	present := make(map[string]struct{}, len(targets))
 	for _, target := range targets {
@@ -2371,6 +2394,12 @@ func explorePreferredRefinementSymbol(task string, targets []exploreTarget) stri
 		return candidate.identifierOverlap + body
 	}
 	better := func(left, right refinementCandidate) bool {
+		// A divergent-default owner is promoted only after a unique constructor
+		// call + inheritance proof over complete bounded projections. That causal
+		// proof supersedes an issue author's downstream symbol guess.
+		if left.target.divergentDefaultOwner != right.target.divergentDefaultOwner {
+			return left.target.divergentDefaultOwner
+		}
 		if left.explicit != right.explicit {
 			return left.explicit
 		}
@@ -2484,10 +2513,25 @@ func localizationEvidenceTargetsFromDraft(task, exactID string, targets []explor
 	if draft == nil && strings.TrimSpace(task) != "" {
 		draft = exploreAnswerDraft(task, targets)
 	}
-	// Primary retrieval evidence leads exact-read and answer-ready envelopes;
-	// both it and the exact target are contractual under tight budgets. A
-	// needs-refinement caller may move its authorized target ahead afterward,
-	// without changing this stable answer-draft projection.
+	// A graph-proven causal constructor and its owning type outrank the
+	// downstream retrieval seed. Their explicit admission metadata survives
+	// draft ranking, owner folding, and byte-budget packing, so this ordering is
+	// evidence-driven rather than a late symbol-name sort.
+	for _, target := range targets {
+		if target.divergentDefaultOwner {
+			appendTarget(target)
+			break
+		}
+	}
+	for _, target := range targets {
+		if target.divergentDefaultType {
+			appendTarget(target)
+			break
+		}
+	}
+	// Primary retrieval evidence remains contractual under tight budgets and
+	// follows the causal pair as its supporting consumer. A needs-refinement
+	// caller may move its authorized target ahead afterward.
 	appendTarget(targets[0])
 	if exactID != "" {
 		for _, target := range targets {
@@ -2651,6 +2695,11 @@ func buildLocalizationExploreResultForTask(
 	mandatoryCount := 0
 	if len(targets) > 0 {
 		mandatoryCount = 1
+	}
+	for index, target := range targets {
+		if (target.divergentDefaultOwner || target.divergentDefaultType) && index+1 > mandatoryCount {
+			mandatoryCount = index + 1
+		}
 	}
 	// Primary retrieval evidence and the authorized exact/refinement symbol are
 	// both mandatory regardless of which one leads the serialized projection.

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -2114,7 +2114,8 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 			preferredSymbol, task, targets, budget, routes,
 		)
 		if refinement.State != localizationStateNeedsRefinement {
-			s.localizationFor(ctx).keepOpenForTask(task)
+			refinement.digest = digest
+			s.localizationFor(ctx).armForTask(refinement, task)
 			return result, nil
 		}
 		// Wire and server authorization are derived from the same finalized
@@ -2146,7 +2147,8 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 			preferredSymbol, task, targets, budget, routes,
 		)
 		if refinement.State != localizationStateNeedsRefinement {
-			s.localizationFor(ctx).keepOpenForTask(task)
+			refinement.digest = refinedDigest
+			s.localizationFor(ctx).armForTask(refinement, task)
 			return refined, nil
 		}
 		s.localizationFor(ctx).armRefinementRoutesForTask(
@@ -2187,12 +2189,16 @@ type localizationEvidence struct {
 }
 
 func (s *Server) completeEmptyLocalization(ctx context.Context, task string, budget int) *mcp.CallToolResult {
-	completion := newLocalizationOpenCompletion()
-	// An empty result supersedes any previous task contract but must not arm
-	// answer-ready or an exact-read allowance. Stage the open state so facade
-	// dispatch commits it only after the successful response.
-	s.localizationFor(ctx).keepOpenForTask(task)
-	return newLocalizationExploreResult(completion, []exploreTarget{}, budget)
+	// No bounded source read can improve an empty projection. Return a compact,
+	// advisory terminal contract so the host gets a final response instead of
+	// an unbounded navigation loop with an eventually empty final.
+	completion := newLocalizationCompletion(true, "")
+	result, _, digest, completion := buildLocalizationExploreResultForTaskFinalized(
+		completion, task, nil, budget,
+	)
+	completion.digest = digest
+	s.localizationFor(ctx).armForTask(completion, task)
+	return result
 }
 
 // exploreAllowsStructuralBody keeps graph-expanded source reads exclusive to
@@ -2668,16 +2674,30 @@ func buildLocalizationRefinementResultForTask(
 	budget int,
 	routes map[string]localizationRefinementRoute,
 ) (*mcp.CallToolResult, localizationCompletion, map[string]localizationRefinementRoute, *localizationEvidenceDigest) {
-	open := newLocalizationOpenCompletion()
-	candidateSymbols := exploreLocalizationTargetSymbols(targets)
-	preauthorized, prebounded := boundedLocalizationRefinementRoutes(candidateSymbols, routes, preferredSymbol)
-	if preferredSymbol == "" {
-		result, _, digest, _ := buildLocalizationExploreResultForTaskFinalized(open, task, targets, budget)
-		return result, open, nil, digest
+	choosePreferred := func(symbols []string, requested string) (string, []string, map[string]localizationRefinementRoute) {
+		authorized, bounded := boundedLocalizationRefinementRoutes(symbols, routes, requested)
+		if requested != "" {
+			if _, ok := bounded[requested]; ok {
+				return requested, authorized, bounded
+			}
+		}
+		authorized, bounded = boundedLocalizationRefinementRoutes(symbols, routes, "")
+		for _, symbol := range symbols {
+			if _, ok := bounded[symbol]; !ok {
+				continue
+			}
+			authorized, bounded = boundedLocalizationRefinementRoutes(symbols, routes, symbol)
+			return symbol, authorized, bounded
+		}
+		return "", nil, nil
 	}
-	if _, preferredAuthorized := prebounded[preferredSymbol]; !preferredAuthorized {
-		result, _, digest, _ := buildLocalizationExploreResultForTaskFinalized(open, task, targets, budget)
-		return result, open, nil, digest
+
+	candidateSymbols := exploreLocalizationTargetSymbols(targets)
+	preferredSymbol, preauthorized, prebounded := choosePreferred(candidateSymbols, preferredSymbol)
+	if preferredSymbol == "" {
+		advisory := newLocalizationCompletion(true, "")
+		result, _, digest, packedCompletion := buildLocalizationExploreResultForTaskFinalized(advisory, task, targets, budget)
+		return result, packedCompletion, nil, digest
 	}
 
 	// Budget against the largest completion this envelope can expose. The final
@@ -2685,24 +2705,22 @@ func buildLocalizationRefinementResultForTask(
 	// so replacing this provisional contract cannot invalidate the byte cap.
 	budgetCompletion := newLocalizationRefinementCompletionForSymbols(preferredSymbol, preauthorized)
 	budgetCompletion.refinementRoutes = prebounded
-	finalCompletion := open
 	var finalRoutes map[string]localizationRefinementRoute
 	result, _, digest, packedCompletion := buildLocalizationExploreResultForTaskFinalized(
 		budgetCompletion, task, targets, budget,
 		func(packed localizationExploreEnvelope) localizationCompletion {
-			allowedSymbols, bounded := boundedLocalizationRefinementRoutes(packed.Symbols, routes, preferredSymbol)
-			if _, preferredAuthorized := bounded[preferredSymbol]; !preferredAuthorized {
+			packedPreferred, allowedSymbols, bounded := choosePreferred(packed.Symbols, preferredSymbol)
+			if packedPreferred == "" {
 				finalRoutes = nil
-				return open
+				return newLocalizationCompletion(true, "")
 			}
 			finalRoutes = localizationBoundRouteEvidence(bounded, packed)
-			finalCompletion = newLocalizationRefinementCompletionForSymbols(preferredSymbol, allowedSymbols)
-			finalCompletion.refinementRoutes = finalRoutes
-			return finalCompletion
+			completion := newLocalizationRefinementCompletionForSymbols(packedPreferred, allowedSymbols)
+			completion.refinementRoutes = finalRoutes
+			return completion
 		},
 	)
-	finalCompletion = packedCompletion
-	return result, finalCompletion, finalRoutes, digest
+	return result, packedCompletion, finalRoutes, digest
 }
 
 // The finalized variant additionally returns the exact completion used by both

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -1820,7 +1820,23 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 		return mcp.NewToolResultText(s.renderExplore(task, targets, budget)), nil
 	}
 	symbolTargets := targets[len(artifactTargets):]
+	// An implementation-intent query expands abstract seeds into their
+	// concrete implementors before terminality is judged, so the envelope
+	// carries the code that changes and answer_ready can see it.
+	if exploreImplementationIntent(task) {
+		symbolTargets = s.expandImplementationTargets(ctx, symbolTargets)
+		targets = append(targets[:len(artifactTargets):len(artifactTargets)], symbolTargets...)
+	}
 	answerReady := exploreAnswerReady(task, symbolTargets) || artifactLane.ready
+	if answerReady && !artifactLane.ready {
+		eng := s.engineFor(ctx)
+		if eng != nil && exploreImplementationAnswerBlocked(task, symbolTargets, eng.GetOutEdges, eng.GetSymbol) {
+			// Only abstract declarations in evidence for an implementation
+			// question: stay nonterminal so the permitted refinement read
+			// can reach the concrete side.
+			answerReady = false
+		}
+	}
 	// File evidence can make localization answer-ready, but it never becomes a
 	// synthetic exact-symbol read. Exact reads remain declaration-only.
 	exactSymbol := exploreLocalizationExplicitTarget(task, symbolTargets)

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -101,7 +101,7 @@ type exploreCausalNeighbor struct {
 
 const (
 	exploreCausalSeedLimit       = 3
-	exploreCausalDepth           = 4
+	exploreCausalDepth           = 2
 	exploreCausalAdmissionBudget = 10 * time.Millisecond
 	exploreDraftPrimaryLimit     = 3
 	exploreDraftTotalLimit       = 5
@@ -196,6 +196,18 @@ func exploreQueryIsConceptTask(query string) bool {
 	return plain >= 6 && plain*2 >= len(fields) && codeShaped*2 < len(fields)
 }
 
+// exploreQueryClass applies the prose-aware concept decision consistently.
+// The generic classifier intentionally treats compact parentheses and paths as
+// signatures/lookups; long issue paraphrases may contain those shapes as small
+// embedded examples and must remain concept localization everywhere.
+func exploreQueryClass(query string) rerank.QueryClass {
+	class := rerank.ClassifyQuery(query)
+	if class != rerank.QueryClassConcept && exploreQueryIsConceptTask(query) {
+		return rerank.QueryClassConcept
+	}
+	return class
+}
+
 func exploreQueryHasCallAnchor(query, name string) bool {
 	name = strings.TrimSpace(name)
 	if name == "" {
@@ -252,10 +264,6 @@ func exploreQueryHasPathSymbolAnchor(query string, n *graph.Node) bool {
 	return false
 }
 
-func exploreAdmitCausalSeed(conceptTask, explicit, strong bool, admitted int, elapsed time.Duration) bool {
-	return conceptTask && !explicit && strong && admitted < exploreCausalSeedLimit && elapsed < exploreCausalAdmissionBudget
-}
-
 func exploreStrongCausalSeed(query string, target exploreTarget) bool {
 	n := target.node
 	if n == nil || (n.Kind != graph.KindFunction && n.Kind != graph.KindMethod) || exploreDraftIsTestNode(n) || exploreIdentifierSegmentCount(n.Name) < 2 {
@@ -265,6 +273,98 @@ func exploreStrongCausalSeed(query string, target exploreTarget) bool {
 	overlap, longest := exploreDraftTermOverlap(queryTerms, n)
 	bodyOverlap := exploreDraftTermSetOverlap(queryTerms, exploreTerminalTerms(target.source))
 	return overlap >= 2 || bodyOverlap >= 2 || (overlap == 1 && longest >= 5)
+}
+
+type exploreCausalSeedMetric struct {
+	index             int
+	crossFileCallees  int
+	callableCallees   int
+	identifierOverlap int
+	bodyOverlap       int
+	longest           int
+	generic           bool
+}
+
+// selectExploreCausalSeeds spends the fixed depth-2 budget only after every
+// final candidate has received the same source and depth-1 hydration. Selection
+// is therefore evidence-based rather than arrival-order based: task-aligned
+// production callables that cross a file boundary lead, while leaf accessors
+// and configuration gates remain eligible only when stronger routes are absent.
+func selectExploreCausalSeeds(query string, targets []exploreTarget, conceptTask, explicit bool) []int {
+	if !conceptTask || explicit || len(targets) == 0 {
+		return nil
+	}
+	queryTerms := exploreTerminalTerms(query)
+	metrics := make([]exploreCausalSeedMetric, 0, len(targets))
+	for index, target := range targets {
+		if !exploreHydratedProductionCallable(target) || !exploreStrongCausalSeed(query, target) {
+			continue
+		}
+		identifierOverlap, longest := exploreDraftTermOverlap(queryTerms, target.node)
+		metric := exploreCausalSeedMetric{
+			index:             index,
+			identifierOverlap: identifierOverlap,
+			bodyOverlap:       exploreDraftTermSetOverlap(queryTerms, exploreTerminalTerms(target.source)),
+			longest:           longest,
+			generic:           exploreDraftGenericCandidate(target.node, target.source),
+		}
+		seedPath := exploreNormalizedPath(nodeDisplayPath(target.node))
+		for _, callee := range target.callees {
+			if callee == nil || callee.ID == "" || exploreDraftIsTestNode(callee) ||
+				(callee.Kind != graph.KindFunction && callee.Kind != graph.KindMethod) {
+				continue
+			}
+			metric.callableCallees++
+			calleePath := exploreNormalizedPath(nodeDisplayPath(callee))
+			if seedPath != "" && calleePath != "" && calleePath != seedPath {
+				metric.crossFileCallees++
+			}
+		}
+		metrics = append(metrics, metric)
+	}
+	if len(metrics) == 0 {
+		return nil
+	}
+	alignment := func(metric exploreCausalSeedMetric) int {
+		body := metric.bodyOverlap
+		if body > 2 {
+			body = 2
+		}
+		return metric.identifierOverlap + body
+	}
+	sort.SliceStable(metrics, func(i, j int) bool {
+		a, b := metrics[i], metrics[j]
+		if (a.crossFileCallees > 0) != (b.crossFileCallees > 0) {
+			return a.crossFileCallees > 0
+		}
+		if a.crossFileCallees != b.crossFileCallees {
+			return a.crossFileCallees > b.crossFileCallees
+		}
+		if (a.callableCallees > 0) != (b.callableCallees > 0) {
+			return a.callableCallees > 0
+		}
+		if a.generic != b.generic {
+			return !a.generic
+		}
+		if alignment(a) != alignment(b) {
+			return alignment(a) > alignment(b)
+		}
+		if a.identifierOverlap != b.identifierOverlap {
+			return a.identifierOverlap > b.identifierOverlap
+		}
+		if a.longest != b.longest {
+			return a.longest > b.longest
+		}
+		return a.index < b.index
+	})
+	if len(metrics) > exploreCausalSeedLimit {
+		metrics = metrics[:exploreCausalSeedLimit]
+	}
+	selected := make([]int, len(metrics))
+	for index, metric := range metrics {
+		selected[index] = metric.index
+	}
+	return selected
 }
 
 // minimumExploreCausalHops derives a deterministic, bounded reachable set from
@@ -781,7 +881,7 @@ func exploreDraftGenericCandidate(n *graph.Node, source string) bool {
 	nameTerms := rerank.Tokenize(n.Name)
 	if len(nameTerms) > 0 && len(nameTerms) <= 3 {
 		switch strings.ToLower(nameTerms[0]) {
-		case "get", "set", "is", "has":
+		case "get", "set", "is", "has", "no":
 			return true
 		}
 	}
@@ -1087,7 +1187,7 @@ func exploreAnswerReady(task string, targets []exploreTarget) bool {
 		return false
 	}
 	query := shapeExploreQuery(task)
-	class := rerank.ClassifyQuery(query)
+	class := exploreQueryClass(query)
 	if class == rerank.QueryClassConcept {
 		query = stripLeadingExploreDirective(query)
 	}
@@ -1112,8 +1212,9 @@ func exploreAnswerReady(task string, targets []exploreTarget) bool {
 	matchedNode := func(node *graph.Node) int { return matchedNodeFor(node, queryTerms) }
 	head := targets[0]
 	headMatches := matchedNode(head.node)
+	strongSourceLiteral := head.sourceLiteral && head.sourceLiteralCallee && !head.exactContentAmbiguous
 	if class == rerank.QueryClassConcept && !exploreLocalizationExplicitAnchor(query, head.node) &&
-		!exploreSyntacticAnchorEvidenceReady(task, targets) {
+		!exploreSyntacticAnchorEvidenceReady(task, targets) && !strongSourceLiteral {
 		return false
 	}
 
@@ -1333,7 +1434,7 @@ func exploreLocalizationExplicitAnchor(query string, n *graph.Node) bool {
 		return true
 	}
 
-	class := rerank.ClassifyQuery(query)
+	class := exploreQueryClass(query)
 	if class == rerank.QueryClassSignature {
 		signature := exploreNormalizedAnchor(retrieval.Signature)
 		return signature != "" && strings.Contains(normalizedQuery, " "+signature+" ")
@@ -1349,7 +1450,7 @@ func exploreLocalizationExplicitAnchor(query string, n *graph.Node) bool {
 // allowed post-localization source read.
 func exploreLocalizationExplicitTarget(task string, targets []exploreTarget) string {
 	query := shapeExploreQuery(task)
-	if rerank.ClassifyQuery(query) == rerank.QueryClassConcept {
+	if exploreQueryClass(query) == rerank.QueryClassConcept {
 		query = stripLeadingExploreDirective(query)
 	}
 	for _, target := range targets {
@@ -1370,7 +1471,7 @@ func exploreLocalizationExplicitTarget(task string, targets []exploreTarget) str
 // stable final tie-breaker.
 func exploreLocalizationExactTarget(task string, targets []exploreTarget) string {
 	query := shapeExploreQuery(task)
-	class := rerank.ClassifyQuery(query)
+	class := exploreQueryClass(query)
 	if class == rerank.QueryClassConcept {
 		query = stripLeadingExploreDirective(query)
 	}
@@ -1805,7 +1906,7 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 	// untouched. The original task is still shown in the header so the agent
 	// sees what it asked.
 	searchQuery := shapeExploreQuery(task)
-	queryClass := rerank.ClassifyQuery(searchQuery)
+	queryClass := exploreQueryClass(searchQuery)
 	if queryClass == rerank.QueryClassConcept {
 		searchQuery = stripLeadingExploreDirective(searchQuery)
 	}
@@ -1979,8 +2080,6 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 			}
 		}
 	}
-	causalAdmitted := 0
-	var causalElapsed time.Duration
 	artifactTargets := artifactLane.targets
 	targets := make([]exploreTarget, 0, len(artifactTargets)+len(cands))
 	// Artifact evidence leads only when the strong classifier activated its
@@ -2006,51 +2105,52 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 			t.callers = ringNeighbors(callers.Nodes, n.ID, exploreRingCap)
 		}
 
-		calleeOpts := ringOpts
-		expanded := exploreAdmitCausalSeed(
-			queryClass == rerank.QueryClassConcept,
-			explicitTarget,
-			exploreStrongCausalSeed(searchQuery, t),
-			causalAdmitted,
-			causalElapsed,
-		)
-		if expanded {
-			calleeOpts.Depth = exploreCausalDepth
-			causalAdmitted++
-		}
-		started := time.Now()
-		callees := eng.GetCallChain(n.ID, calleeOpts)
-		if expanded {
-			causalElapsed += time.Since(started)
-		}
+		callees := eng.GetCallChain(n.ID, ringOpts)
 		if callees != nil {
 			t.directCalleesComplete = !callees.Truncated && !callees.BudgetHit && !callees.LowerBound
-			if expanded {
-				neighbors := minimumExploreCausalHops(n.ID, callees, opts, exploreCausalDepth, ringOpts.Limit)
-				direct := make([]*graph.Node, 0, exploreRingCap)
-				for _, neighbor := range neighbors {
-					if neighbor.hop == 1 {
-						direct = append(direct, neighbor.node)
-					} else {
-						t.causalCallees = append(t.causalCallees, neighbor)
-					}
-				}
-				if len(neighbors) > 0 {
-					var projectionComplete bool
-					t.callees, projectionComplete = ringNeighborsProjection(direct, n.ID, exploreRingCap)
-					t.directCalleesComplete = t.directCalleesComplete && projectionComplete
-				} else {
-					var projectionComplete bool
-					t.callees, projectionComplete = ringNeighborsProjection(callees.Nodes, n.ID, exploreRingCap)
-					t.directCalleesComplete = t.directCalleesComplete && projectionComplete
-				}
-			} else {
-				var projectionComplete bool
-				t.callees, projectionComplete = ringNeighborsProjection(callees.Nodes, n.ID, exploreRingCap)
-				t.directCalleesComplete = t.directCalleesComplete && projectionComplete
-			}
+			var projectionComplete bool
+			t.callees, projectionComplete = ringNeighborsProjection(callees.Nodes, n.ID, exploreRingCap)
+			t.directCalleesComplete = t.directCalleesComplete && projectionComplete
 		}
 		targets = append(targets, t)
+	}
+
+	// Every final symbol now has equally-bounded depth-1 evidence. Spend the
+	// deeper budget in a second pass so a strong route ranked fourth cannot be
+	// starved by three earlier leaf/accessor collisions.
+	symbolTargets := targets[len(artifactTargets):]
+	var causalElapsed time.Duration
+	for _, index := range selectExploreCausalSeeds(
+		searchQuery, symbolTargets, queryClass == rerank.QueryClassConcept, explicitTarget,
+	) {
+		if causalElapsed >= exploreCausalAdmissionBudget {
+			break
+		}
+		target := &symbolTargets[index]
+		calleeOpts := ringOpts
+		calleeOpts.Depth = exploreCausalDepth
+		started := time.Now()
+		callees := eng.GetCallChain(target.node.ID, calleeOpts)
+		causalElapsed += time.Since(started)
+		if callees == nil {
+			continue
+		}
+		target.directCalleesComplete = !callees.Truncated && !callees.BudgetHit && !callees.LowerBound
+		neighbors := minimumExploreCausalHops(target.node.ID, callees, opts, exploreCausalDepth, ringOpts.Limit)
+		direct := make([]*graph.Node, 0, exploreRingCap)
+		target.causalCallees = target.causalCallees[:0]
+		for _, neighbor := range neighbors {
+			if neighbor.hop == 1 {
+				direct = append(direct, neighbor.node)
+			} else {
+				target.causalCallees = append(target.causalCallees, neighbor)
+			}
+		}
+		if len(neighbors) > 0 {
+			var projectionComplete bool
+			target.callees, projectionComplete = ringNeighborsProjection(direct, target.node.ID, exploreRingCap)
+			target.directCalleesComplete = target.directCalleesComplete && projectionComplete
+		}
 	}
 	if exploreQueryIsConceptTask(task) && len(targets) > len(artifactTargets) {
 		symbolTargets := promoteExploreDivergentDefaultOwner(task, targets[len(artifactTargets):], s.graph, maxSymbols, func(node *graph.Node) string {
@@ -2066,7 +2166,7 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 	if !req.GetBool("localize", false) {
 		return mcp.NewToolResultText(s.renderExplore(task, targets, budget)), nil
 	}
-	symbolTargets := targets[len(artifactTargets):]
+	symbolTargets = targets[len(artifactTargets):]
 	// An implementation-intent query expands abstract seeds into their
 	// concrete implementors before terminality is judged, so the envelope
 	// carries the code that changes and answer_ready can see it.
@@ -2078,6 +2178,11 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 		// rank together; implementation-intent queries are exempt because
 		// they ask for exactly those members.
 		symbolTargets = preserveExploreDivergentDefaultOrder(s.foldMemberOwners(ctx, symbolTargets))
+		// Owner folding is weaker than a unique source-literal callsite whose
+		// callee was resolved and hydrated. Re-promote that proof after folding
+		// so terminality is judged against the same strongest evidence that the
+		// final envelope exposes, rather than against a synthetic owner row.
+		symbolTargets = promoteExploreStrongSourceLiteralTarget(symbolTargets)
 		targets = append(targets[:len(artifactTargets):len(artifactTargets)], symbolTargets...)
 	}
 	answerReady := exploreAnswerReady(task, symbolTargets) || artifactLane.ready
@@ -2207,7 +2312,7 @@ func (s *Server) completeEmptyLocalization(ctx context.Context, task string, bud
 // literal symbol and signature queries retain their direct-only behavior.
 func exploreAllowsStructuralBody(task string) bool {
 	shaped := shapeExploreQuery(task)
-	class := rerank.ClassifyQuery(shaped)
+	class := exploreQueryClass(shaped)
 	_, directoryQualified := exploreQueryPathAnchors(shaped)
 	return !directoryQualified && class != rerank.QueryClassSymbol && class != rerank.QueryClassSignature
 }
@@ -3390,6 +3495,10 @@ const (
 	// be worth repeating — below it the "clause" is a sentence fragment
 	// whose repetition would over-weight one or two words.
 	shapeInlineMinLeadChars = 20
+	// A long single-line paraphrase with sentence structure is report-like even
+	// when it contains no flags or hashes. Short focused queries stay byte-for-
+	// byte unchanged.
+	shapeInlineLongQueryChars = 180
 	// shaMinHexLen / shaMaxHexLen bound a commit-SHA-shaped token: git
 	// abbreviates to >=7 hex chars; a full SHA-1 is 40.
 	shaMinHexLen = 7
@@ -3417,11 +3526,17 @@ var (
 // shapeExploreQuery: drop provably-inert tokens and weight the lead
 // clause, gated on structural noise so a clean query is untouched.
 func shapeInlineQuery(task string) string {
-	if !hasInlineNoise(task) {
+	noisy := hasInlineNoise(task)
+	lead := inlineLeadClause(task)
+	if !noisy && (len(task) < shapeInlineLongQueryChars || lead == "") {
 		return task
 	}
-	cleaned := dropInertTokens(task)
-	if lead := inlineLeadClause(cleaned); lead != "" {
+	cleaned := task
+	if noisy {
+		cleaned = dropInertTokens(task)
+		lead = inlineLeadClause(cleaned)
+	}
+	if lead != "" {
 		cleaned += " " + lead
 	}
 	return cleaned
@@ -3568,6 +3683,13 @@ func inlineLeadClause(task string) string {
 			// "ignore::WalkBuilder" does not.
 			if i > 0 && t[i-1] != ':' && t[i-1] != ' ' && i+1 < len(t) && t[i+1] == ' ' {
 				end = i
+			}
+		case '.', '?', '!':
+			// A sentence boundary in a long single-line report is the inline
+			// equivalent of a title newline. Requiring following whitespace
+			// avoids splitting .ignore, dotted identifiers, and quoted ".".
+			if i+1 < len(t) && (t[i+1] == ' ' || t[i+1] == '\t') {
+				end = i + 1
 			}
 		}
 		if end >= 0 {
@@ -4040,13 +4162,63 @@ func (s *Server) gatherExploreQuotedContentCandidates(
 	return candidates
 }
 
+// exploreConceptTermPresent recognizes a bounded family of inflectional forms
+// when concept prose and source identifiers use different grammatical forms
+// (for example matching versus matched_ignore). It never uses a raw stem
+// substring: that would incorrectly equate building with Builder.
+func exploreConceptTermPresent(text, term string) bool {
+	if strings.Contains(text, term) {
+		return true
+	}
+	for _, suffix := range [...]string{"ing", "ed"} {
+		if !strings.HasSuffix(term, suffix) {
+			continue
+		}
+		stem := strings.TrimSuffix(term, suffix)
+		if len(stem) < 5 {
+			continue
+		}
+		alternate := stem + "ing"
+		if suffix == "ing" {
+			alternate = stem + "ed"
+		}
+		if exploreConceptFormAtBoundary(text, alternate, false) ||
+			exploreConceptFormAtBoundary(text, stem, true) {
+			return true
+		}
+	}
+	return false
+}
+
+func exploreConceptFormAtBoundary(text, form string, requireEnd bool) bool {
+	for offset := 0; offset < len(text); {
+		index := strings.Index(text[offset:], form)
+		if index < 0 {
+			return false
+		}
+		index += offset
+		startOK := index == 0 || !exploreASCIIAlphaNumeric(text[index-1])
+		end := index + len(form)
+		endOK := !requireEnd || end == len(text) || !exploreASCIIAlphaNumeric(text[end])
+		if startOK && endOK {
+			return true
+		}
+		offset = index + 1
+	}
+	return false
+}
+
+func exploreASCIIAlphaNumeric(value byte) bool {
+	return value >= 'a' && value <= 'z' || value >= '0' && value <= '9'
+}
+
 // rerankExploreConceptCoverage corrects the principal weakness of prefix-OR
 // symbol retrieval: one rare identifier can otherwise outrank an implementation
 // whose metadata covers several independent task concepts. Explicit anchors and
 // bounded exact body-literal hits remain strongest. Vector-backed candidates
 // retain their semantic ordering; coverage only reorders lexical-only rows.
 func rerankExploreConceptCoverage(query string, candidates []*rerank.Candidate) []*rerank.Candidate {
-	if rerank.ClassifyQuery(query) != rerank.QueryClassConcept || len(candidates) < 2 {
+	if exploreQueryClass(query) != rerank.QueryClassConcept || len(candidates) < 2 {
 		return candidates
 	}
 	queryTerms := exploreTerminalTerms(query)
@@ -4054,14 +4226,19 @@ func rerankExploreConceptCoverage(query string, candidates []*rerank.Candidate) 
 		return candidates
 	}
 	type evidence struct {
+		text           string
 		explicit       bool
 		exactContent   bool
 		ambiguousExact bool
+		callable       bool
+		generic        bool
 		overlap        int
 		contentTerms   float64
 		contentRank    float64
 	}
 	metrics := make(map[*rerank.Candidate]evidence, len(candidates))
+	termFrequency := make(map[string]int, len(queryTerms))
+	candidateCount := 0
 	for _, candidate := range candidates {
 		if candidate == nil || candidate.Node == nil {
 			continue
@@ -4071,22 +4248,41 @@ func rerankExploreConceptCoverage(query string, candidates []*rerank.Candidate) 
 		if len(doc) > 768 {
 			doc = doc[:768]
 		}
-		// Candidate-side token maps are disproportionately expensive on the
-		// 80-row over-fetch window. Query terms are already normalized and at
-		// least three bytes long; a lowercase retrieval projection plus bounded
-		// substring checks preserves camelCase/path matching with no per-term
-		// allocations.
 		text := strings.ToLower(strings.Join([]string{
 			candidate.Node.Name, retrieval.QualName, nodeDisplayPath(candidate.Node),
 			retrieval.Signature, doc,
 		}, " "))
+		metrics[candidate] = evidence{text: text}
+		candidateCount++
+		for term := range queryTerms {
+			if exploreConceptTermPresent(text, term) {
+				termFrequency[term]++
+			}
+		}
+	}
+	// A task noun shared by more than a third of the retrieval window (path is
+	// the common case) carries no discriminating evidence. Counting it as a
+	// second concept turns every path wrapper into a strong semantic peer and
+	// freezes the upstream rank order. Frequency is computed only inside the
+	// already-bounded window, so this adds no graph or index work.
+	maxFrequency := max(1, candidateCount/3)
+	for _, candidate := range candidates {
+		if candidate == nil || candidate.Node == nil {
+			continue
+		}
+		metric := metrics[candidate]
+		text := metric.text
 		overlap := 0
 		for term := range queryTerms {
-			if strings.Contains(text, term) {
+			if frequency := termFrequency[term]; frequency > 0 && frequency <= maxFrequency &&
+				exploreConceptTermPresent(text, term) {
 				overlap++
 			}
 		}
-		metric := evidence{explicit: exploreLocalizationExplicitAnchor(query, candidate.Node), overlap: overlap}
+		metric.explicit = exploreLocalizationExplicitAnchor(query, candidate.Node)
+		metric.callable = candidate.Node.Kind == graph.KindFunction || candidate.Node.Kind == graph.KindMethod
+		metric.generic = exploreDraftGenericCandidate(candidate.Node, "")
+		metric.overlap = overlap
 		if candidate.Signals != nil {
 			metric.contentTerms = candidate.Signals[exploreContentRecallTermSignal]
 			metric.contentRank = candidate.Signals[exploreContentRecallRankSignal]
@@ -4120,20 +4316,33 @@ func rerankExploreConceptCoverage(query string, candidates []*rerank.Candidate) 
 			return 0
 		}
 	}
+	strongConjunctive := func(candidate *rerank.Candidate) bool {
+		metric := metrics[candidate]
+		return metric.callable && !metric.generic && metric.overlap >= 2
+	}
+	weakCollision := func(candidate *rerank.Candidate) bool {
+		metric := metrics[candidate]
+		return metric.generic || metric.overlap <= 1
+	}
 	// Explicit anchors and verified full quoted literals may cross semantic
 	// candidates. Unique exact evidence leads ambiguous pages; ambiguous exact
-	// peers use task coverage before content-channel rank. All other evidence
-	// only reorders lexical-only slots, preserving vector ordering.
+	// peers use task coverage before content-channel rank. Outside those proof
+	// tiers, one concrete callable covering two independent concepts may cross a
+	// generic one-token exact/vector collision, but never another multi-concept
+	// semantic candidate.
 	sort.SliceStable(candidates, func(i, j int) bool {
 		a, b := candidates[i], candidates[j]
 		at, bt := priorityTier(a), priorityTier(b)
 		if at != bt {
 			return at > bt
 		}
+		am, bm := metrics[a], metrics[b]
+		if at == 0 {
+			return false
+		}
 		if at != 1 {
 			return false
 		}
-		am, bm := metrics[a], metrics[b]
 		ac, bc := coverageTier(am.overlap), coverageTier(bm.overlap)
 		if ac != bc {
 			return ac > bc
@@ -4146,6 +4355,24 @@ func rerankExploreConceptCoverage(query string, candidates []*rerank.Candidate) 
 		}
 		return am.contentRank > bm.contentRank
 	})
+	// Within the ordinary evidence tier, promote a strong conjunctive callable
+	// only across adjacent weak collisions. A multi-concept non-callable is a
+	// barrier: crossing it would violate the promise that semantic peers retain
+	// their upstream order. Expressing that barrier relation inside sort.Less is
+	// non-transitive (strong~medium, medium~weak, strong<weak), so use this
+	// explicit stable insertion pass instead.
+	for index := 1; index < len(candidates); index++ {
+		candidate := candidates[index]
+		if priorityTier(candidate) != 0 || !strongConjunctive(candidate) {
+			continue
+		}
+		insert := index
+		for insert > 0 && priorityTier(candidates[insert-1]) == 0 && weakCollision(candidates[insert-1]) {
+			candidates[insert] = candidates[insert-1]
+			insert--
+		}
+		candidates[insert] = candidate
+	}
 	priorityEnd := 0
 	for priorityEnd < len(candidates) && priorityTier(candidates[priorityEnd]) > 0 {
 		priorityEnd++
@@ -4475,6 +4702,40 @@ func promoteExploreSourceLiteralCandidate(candidates []*rerank.Candidate) []*rer
 	return promoted
 }
 
+// promoteExploreStrongSourceLiteralTarget keeps terminality aligned with the
+// final evidence projection after concept owner folding. A unique, hydrated
+// source-literal callee is direct implementation proof; an owner inserted from
+// member_of metadata must not displace it. Ambiguous or incomplete literal
+// hits deliberately retain their established order.
+func promoteExploreStrongSourceLiteralTarget(targets []exploreTarget) []exploreTarget {
+	hasDivergentOwner, hasDivergentType := false, false
+	for _, target := range targets {
+		hasDivergentOwner = hasDivergentOwner || target.divergentDefaultOwner
+		hasDivergentType = hasDivergentType || target.divergentDefaultType
+	}
+	if hasDivergentOwner && hasDivergentType {
+		// The paired constructor/default-flow proof identifies why behavior
+		// diverges, while a literal callee identifies only where the literal is
+		// consumed. Preserve the stronger causal ordering.
+		return targets
+	}
+	best := -1
+	for index, target := range targets {
+		if localizationStrongSourceLiteralCallee(target) {
+			best = index
+			break
+		}
+	}
+	if best <= 0 {
+		return targets
+	}
+	promoted := append([]exploreTarget(nil), targets...)
+	target := promoted[best]
+	copy(promoted[1:best+1], promoted[:best])
+	promoted[0] = target
+	return promoted
+}
+
 // selectFinalExploreCandidates applies the source-literal reservation at the
 // last production boundary, after every reranker and concept reservation has
 // settled candidate order. The source hit replaces the weakest bounded
@@ -4505,24 +4766,108 @@ func selectFinalExploreCandidates(prod, test []*rerank.Candidate, maxSymbols int
 // first-seen order for the ordinary concept recall channel. The same generic
 // and stopword filter used by answer-readiness keeps agent verbs and task
 // boilerplate from consuming the bounded expansion bag.
+func exploreConceptRecallTokenStream(text string) []string {
+	fields := strings.FieldsFunc(text, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_'
+	})
+	tokens := make([]string, 0, len(fields))
+	for _, field := range fields {
+		tokens = append(tokens, rerank.Tokenize(field)...)
+	}
+	return tokens
+}
+
 func exploreConceptRecallTerms(text string) []string {
-	const maxTerms = 12
+	const (
+		maxTerms     = 12
+		frequentCap  = 8
+		lateMinChars = 6
+	)
 	allowed := exploreTerminalTerms(text)
-	seen := make(map[string]struct{}, len(allowed))
-	out := make([]string, 0, min(len(allowed), maxTerms))
-	for _, raw := range rerank.Tokenize(text) {
+	type termStat struct {
+		term        string
+		first, last int
+		count       int
+	}
+	stats := make([]termStat, 0, len(allowed))
+	byTerm := make(map[string]int, len(allowed))
+	weightedTokens := exploreConceptRecallTokenStream(text)
+	for position, raw := range weightedTokens {
 		term := exploreTerminalTermRoot(strings.ToLower(strings.TrimSpace(raw)))
 		if _, ok := allowed[term]; !ok {
 			continue
 		}
-		if _, ok := seen[term]; ok {
+		if index, ok := byTerm[term]; ok {
+			stats[index].count++
+			stats[index].last = position
 			continue
 		}
-		seen[term] = struct{}{}
-		out = append(out, term)
-		if len(out) >= maxTerms {
+		byTerm[term] = len(stats)
+		stats = append(stats, termStat{term: term, first: position, last: position, count: 1})
+	}
+	if len(stats) <= maxTerms {
+		out := make([]string, len(stats))
+		for index := range stats {
+			out[index] = stats[index].term
+		}
+		return out
+	}
+
+	// Repetition captures the weighted lead; length breaks ties toward more
+	// informative concepts. Reserve the remaining slots by scanning the
+	// original tail so late technical constraints survive the fixed bag even
+	// when the lead was deliberately repeated for primary retrieval.
+	ranked := append([]termStat(nil), stats...)
+	sort.SliceStable(ranked, func(i, j int) bool {
+		if ranked[i].count != ranked[j].count {
+			return ranked[i].count > ranked[j].count
+		}
+		if len(ranked[i].term) != len(ranked[j].term) {
+			return len(ranked[i].term) > len(ranked[j].term)
+		}
+		return ranked[i].first < ranked[j].first
+	})
+	selected := make(map[string]struct{}, maxTerms)
+	for _, stat := range ranked {
+		if len(selected) >= frequentCap {
 			break
 		}
+		selected[stat.term] = struct{}{}
+	}
+	baseText := strings.TrimSpace(text)
+	if lead := inlineLeadClause(baseText); lead != "" {
+		suffix := " " + lead
+		if strings.HasSuffix(baseText, suffix) {
+			baseText = strings.TrimSpace(strings.TrimSuffix(baseText, suffix))
+		}
+	}
+	baseTokens := exploreConceptRecallTokenStream(baseText)
+	for index := len(baseTokens) - 1; index >= 0 && len(selected) < maxTerms; index-- {
+		term := exploreTerminalTermRoot(strings.ToLower(strings.TrimSpace(baseTokens[index])))
+		if len(term) < lateMinChars {
+			continue
+		}
+		if _, ok := allowed[term]; !ok {
+			continue
+		}
+		selected[term] = struct{}{}
+	}
+	for _, stat := range ranked {
+		if len(selected) >= maxTerms {
+			break
+		}
+		selected[stat.term] = struct{}{}
+	}
+	chosen := make([]termStat, 0, len(selected))
+	for _, stat := range stats {
+		if _, ok := selected[stat.term]; ok {
+			chosen = append(chosen, stat)
+		}
+	}
+	sort.SliceStable(chosen, func(i, j int) bool { return chosen[i].first < chosen[j].first })
+	out := make([]string, len(chosen))
+	for index := range chosen {
+		out[index] = chosen[index].term
 	}
 	return out
 }

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -1826,6 +1826,12 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 	if exploreImplementationIntent(task) {
 		symbolTargets = s.expandImplementationTargets(ctx, symbolTargets)
 		targets = append(targets[:len(artifactTargets):len(artifactTargets)], symbolTargets...)
+	} else if queryClass == rerank.QueryClassConcept {
+		// Concept answers prefer the owning type when several of its members
+		// rank together; implementation-intent queries are exempt because
+		// they ask for exactly those members.
+		symbolTargets = s.foldMemberOwners(ctx, symbolTargets)
+		targets = append(targets[:len(artifactTargets):len(artifactTargets)], symbolTargets...)
 	}
 	answerReady := exploreAnswerReady(task, symbolTargets) || artifactLane.ready
 	if answerReady && !artifactLane.ready {

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -1846,7 +1846,7 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 		// exploration, multiplying turns and payloads. Name one concrete ranked
 		// target for the only permitted refinement read; source-literal evidence
 		// wins because it is absent from ordinary symbol metadata.
-		preferredSymbol := explorePreferredRefinementSymbol(symbolTargets)
+		preferredSymbol := explorePreferredRefinementSymbol(task, symbolTargets)
 		completion := newLocalizationRefinementCompletion(preferredSymbol)
 		result, returnedSymbols, digest := buildLocalizationExploreResultForTask(completion, task, targets, budget)
 		// Authorization is derived from the exact serialized projection, not
@@ -2049,10 +2049,48 @@ func exploreNodeWithinQueryScope(n *graph.Node, scope query.QueryOptions) bool {
 // one concrete, bounded follow-up. Exact source-literal evidence wins because
 // ordinary symbol metadata cannot represent it; otherwise the ranked head is
 // the deterministic refinement target.
-func explorePreferredRefinementSymbol(targets []exploreTarget) string {
-	for _, target := range targets {
-		if target.sourceLiteral && target.node != nil && target.node.ID != "" {
-			return target.node.ID
+// explorePreferredRefinementSymbol picks the single permitted refinement
+// read with the same preference ladder the answer draft uses, instead of the
+// raw rank-one symbol. A generic head (a builder type that shares no term
+// with the query) must not consume the only read while a query-aligned
+// candidate sits lower in the same envelope:
+//
+//	1. verified source-literal evidence
+//	2. explicit path / qualified-symbol / call anchor
+//	3. query-aligned non-generic callable
+//	4. protected concept implementation
+//	5. aligned candidate of any definition kind
+//	6. raw head only when nothing aligned exists
+func explorePreferredRefinementSymbol(task string, targets []exploreTarget) string {
+	query := shapeExploreQuery(task)
+	if exploreQueryIsConceptTask(query) {
+		query = stripLeadingExploreDirective(query)
+	}
+	queryTerms := exploreTerminalTerms(query)
+	aligned := func(t exploreTarget) bool {
+		overlap, _ := exploreDraftTermOverlap(queryTerms, t.node)
+		return overlap > 0
+	}
+	callable := func(n *graph.Node) bool {
+		return n != nil && (n.Kind == graph.KindFunction || n.Kind == graph.KindMethod)
+	}
+	rungs := []func(exploreTarget) bool{
+		func(t exploreTarget) bool { return t.sourceLiteral },
+		func(t exploreTarget) bool { return exploreLocalizationExplicitAnchor(query, t.node) },
+		func(t exploreTarget) bool {
+			return callable(t.node) && aligned(t) && !exploreDraftGenericCandidate(t.node, t.source)
+		},
+		func(t exploreTarget) bool { return t.conceptImplementation },
+		aligned,
+	}
+	for _, rung := range rungs {
+		for _, target := range targets {
+			if target.node == nil || target.node.ID == "" {
+				continue
+			}
+			if rung(target) {
+				return target.node.ID
+			}
 		}
 	}
 	for _, target := range targets {

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -91,6 +91,7 @@ type exploreTarget struct {
 	exactContent          bool   // verified full quoted-literal hit from content_fts
 	exactContentAmbiguous bool   // exact evidence has visible or possibly truncated peers
 	sourceLiteral         bool   // exact source-body hit that must survive final envelope packing
+	sourceLiteralCallee   bool   // exact source callsite uniquely resolved to this invoked callable
 }
 
 type exploreCausalNeighbor struct {
@@ -863,7 +864,9 @@ func exploreLocalizationRefinementRoutes(targets []exploreTarget) map[string]loc
 			continue
 		}
 		if !exploreDraftGenericCandidate(target.node, target.source) {
-			routes[target.node.ID] = localizationRefinementRoute{}
+			routes[target.node.ID] = localizationRefinementRoute{
+				enforceable: localizationStrongSourceLiteralCallee(target),
+			}
 			continue
 		}
 		if !target.directCalleesComplete {
@@ -894,8 +897,33 @@ func exploreLocalizationRefinementRoutes(targets []exploreTarget) map[string]loc
 			}
 		}
 		if implementationSymbol != "" && !ambiguous {
-			routes[target.node.ID] = localizationRefinementRoute{implementationSymbol: implementationSymbol}
+			implementation := byID[implementationSymbol]
+			routes[target.node.ID] = localizationRefinementRoute{
+				implementationSymbol: implementationSymbol,
+				enforceable:          localizationStrongImplementationRoute(target, implementation),
+			}
 		}
+	}
+	// The recommended read is normally the concrete implementation, not its
+	// generic wrapper. Carry the wrapper's proof onto that exact route so the
+	// one-read fast path preserves trust; ordinary concrete hydration remains
+	// advisory. Ranked target order deterministically chooses among equivalent
+	// proven wrappers.
+	for _, target := range targets {
+		if target.node == nil {
+			continue
+		}
+		wrapperRoute, ok := routes[target.node.ID]
+		if !ok || !wrapperRoute.enforceable || wrapperRoute.implementationSymbol == "" {
+			continue
+		}
+		implementationRoute, ok := routes[wrapperRoute.implementationSymbol]
+		if !ok || implementationRoute.implementationSymbol != "" || implementationRoute.proofSymbol != "" {
+			continue
+		}
+		implementationRoute.enforceable = true
+		implementationRoute.proofSymbol = target.node.ID
+		routes[wrapperRoute.implementationSymbol] = implementationRoute
 	}
 	return routes
 }
@@ -964,6 +992,11 @@ func boundedLocalizationRefinementRoutes(
 		}
 		if route.implementationSymbol != "" {
 			if _, implementationVisible := visible[route.implementationSymbol]; !implementationVisible {
+				return
+			}
+		}
+		if route.proofSymbol != "" {
+			if _, proofVisible := visible[route.proofSymbol]; !proofVisible {
 				return
 			}
 		}
@@ -1966,6 +1999,7 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 			t.exactContent = c.Signals[exploreContentRecallExactSignal] > 0
 			t.exactContentAmbiguous = c.Signals[exploreContentRecallAmbiguousSignal] > 0
 			t.sourceLiteral = c.Signals[exploreSourceLiteralSignal] > 0
+			t.sourceLiteralCallee = c.Signals[exploreSourceLiteralCalleeSignal] > 0
 		}
 		t.source = s.manifestSymbolSource(ctx, n)
 		if callers := eng.GetCallers(n.ID, ringOpts); callers != nil {
@@ -2096,13 +2130,13 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 	// and is retained for post-terminal replay — for the exact-read contract
 	// too, whose success promotes to answer_ready with the evidence already
 	// stashed.
-	result, _, digest := buildLocalizationExploreResultForTask(completion, task, targets, budget)
+	result, _, digest, completion := buildLocalizationExploreResultForTaskFinalized(completion, task, targets, budget)
 	// Literal-driven terminality must show its evidence: when the verdict
 	// rests on a quoted-literal match but the budgeted envelope shed the
 	// literal, downgrade to the bounded refinement read instead of telling
 	// the host to answer from evidence it cannot see.
 	if answerReady && exactSymbol == "" &&
-		exploreAnswerReadyViaLiteralOnly(task, symbolTargets) &&
+		exploreAnswerReadyViaLiteralOnly(task, symbolTargets) && !completion.Enforceable &&
 		!exploreResultCitesTaskLiteral(result, task) {
 		routes := exploreLocalizationRefinementRoutes(symbolTargets)
 		preferredSymbol := explorePreferredRoutedRefinementSymbol(
@@ -2130,24 +2164,26 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 // human-oriented legacy rendering; localize does not duplicate it.
 type localizationExploreEnvelope struct {
 	Completion localizationCompletion `json:"completion"`
+	Terminal   bool                   `json:"terminal"`
 	Files      []string               `json:"files"`
 	Symbols    []string               `json:"symbols"`
 	Evidence   []localizationEvidence `json:"evidence"`
 }
 
 type localizationEvidence struct {
-	Rank      int      `json:"rank"`
-	ID        string   `json:"id"`
-	Name      string   `json:"name"`
-	QualName  string   `json:"qual_name,omitempty"`
-	Kind      string   `json:"kind"`
-	File      string   `json:"file"`
-	Line      int      `json:"line"`
-	EndLine   int      `json:"end_line,omitempty"`
-	Signature string   `json:"signature,omitempty"`
-	Callers   []string `json:"callers,omitempty"`
-	Callees   []string `json:"callees,omitempty"`
-	Source    string   `json:"source,omitempty"`
+	Rank       int      `json:"rank"`
+	ID         string   `json:"id"`
+	Name       string   `json:"name"`
+	QualName   string   `json:"qual_name,omitempty"`
+	Kind       string   `json:"kind"`
+	File       string   `json:"file"`
+	Line       int      `json:"line"`
+	EndLine    int      `json:"end_line,omitempty"`
+	Signature  string   `json:"signature,omitempty"`
+	Callers    []string `json:"callers,omitempty"`
+	Callees    []string `json:"callees,omitempty"`
+	Provenance string   `json:"provenance,omitempty"`
+	Source     string   `json:"source,omitempty"`
 }
 
 func (s *Server) completeEmptyLocalization(ctx context.Context, task string, budget int) *mcp.CallToolResult {
@@ -2608,8 +2644,23 @@ func newLocalizationExploreResultForTask(completion localizationCompletion, task
 	return result
 }
 
-// buildLocalizationExploreResultForTask returns both the result and the exact
-type localizationCompletionFinalizer func([]string) localizationCompletion
+// buildLocalizationExploreResultForTask returns the packed result and the exact
+// bounded symbol projection serialized into it. Callers that also need the
+// post-budget completion use buildLocalizationExploreResultForTaskFinalized.
+func buildLocalizationExploreResultForTask(
+	completion localizationCompletion,
+	task string,
+	targets []exploreTarget,
+	budget int,
+	finalize ...localizationCompletionFinalizer,
+) (*mcp.CallToolResult, []string, *localizationEvidenceDigest) {
+	result, symbols, digest, _ := buildLocalizationExploreResultForTaskFinalized(
+		completion, task, targets, budget, finalize...,
+	)
+	return result, symbols, digest
+}
+
+type localizationCompletionFinalizer func(localizationExploreEnvelope) localizationCompletion
 
 func buildLocalizationRefinementResultForTask(
 	preferredSymbol, task string,
@@ -2621,11 +2672,11 @@ func buildLocalizationRefinementResultForTask(
 	candidateSymbols := exploreLocalizationTargetSymbols(targets)
 	preauthorized, prebounded := boundedLocalizationRefinementRoutes(candidateSymbols, routes, preferredSymbol)
 	if preferredSymbol == "" {
-		result, _, digest := buildLocalizationExploreResultForTask(open, task, targets, budget)
+		result, _, digest, _ := buildLocalizationExploreResultForTaskFinalized(open, task, targets, budget)
 		return result, open, nil, digest
 	}
 	if _, preferredAuthorized := prebounded[preferredSymbol]; !preferredAuthorized {
-		result, _, digest := buildLocalizationExploreResultForTask(open, task, targets, budget)
+		result, _, digest, _ := buildLocalizationExploreResultForTaskFinalized(open, task, targets, budget)
 		return result, open, nil, digest
 	}
 
@@ -2636,33 +2687,33 @@ func buildLocalizationRefinementResultForTask(
 	budgetCompletion.refinementRoutes = prebounded
 	finalCompletion := open
 	var finalRoutes map[string]localizationRefinementRoute
-	result, _, digest := buildLocalizationExploreResultForTask(
+	result, _, digest, packedCompletion := buildLocalizationExploreResultForTaskFinalized(
 		budgetCompletion, task, targets, budget,
-		func(returnedSymbols []string) localizationCompletion {
-			allowedSymbols, bounded := boundedLocalizationRefinementRoutes(returnedSymbols, routes, preferredSymbol)
+		func(packed localizationExploreEnvelope) localizationCompletion {
+			allowedSymbols, bounded := boundedLocalizationRefinementRoutes(packed.Symbols, routes, preferredSymbol)
 			if _, preferredAuthorized := bounded[preferredSymbol]; !preferredAuthorized {
 				finalRoutes = nil
 				return open
 			}
-			finalRoutes = bounded
+			finalRoutes = localizationBoundRouteEvidence(bounded, packed)
 			finalCompletion = newLocalizationRefinementCompletionForSymbols(preferredSymbol, allowedSymbols)
-			finalCompletion.refinementRoutes = bounded
+			finalCompletion.refinementRoutes = finalRoutes
 			return finalCompletion
 		},
 	)
+	finalCompletion = packedCompletion
 	return result, finalCompletion, finalRoutes, digest
 }
 
-// bounded symbol projection serialized into it. Refinement authorization uses
-// this projection so every authorized ID is visible and every visible evidence
-// target is authorized without a second ranking or budgeting pass.
-func buildLocalizationExploreResultForTask(
+// The finalized variant additionally returns the exact completion used by both
+// visible text and authoritative host metadata after byte-budget packing.
+func buildLocalizationExploreResultForTaskFinalized(
 	completion localizationCompletion,
 	task string,
 	targets []exploreTarget,
 	budget int,
 	finalize ...localizationCompletionFinalizer,
-) (*mcp.CallToolResult, []string, *localizationEvidenceDigest) {
+) (*mcp.CallToolResult, []string, *localizationEvidenceDigest, localizationCompletion) {
 	var draft []exploreDraftEntry
 	if strings.TrimSpace(task) != "" {
 		draft = exploreAnswerDraft(task, targets)
@@ -2681,8 +2732,10 @@ func buildLocalizationExploreResultForTask(
 	if refinementFirst {
 		targets = prioritizeLocalizationEvidenceTarget(requiredSymbol, targets)
 	}
+	contract := localizationContractFor(completion)
 	envelope := localizationExploreEnvelope{
-		Completion: completion,
+		Completion: contract.Completion,
+		Terminal:   contract.Terminal,
 		Files:      make([]string, 0),
 		Symbols:    make([]string, 0),
 		Evidence:   make([]localizationEvidence, 0),
@@ -2706,8 +2759,13 @@ func buildLocalizationExploreResultForTask(
 	// A generic preferred candidate also reserves its one prevalidated concrete
 	// hop, because the route is invalid unless both IDs are visible on the wire.
 	mandatoryIDs := []string{primarySymbol, requiredSymbol}
-	if route, routed := completion.refinementRoutes[requiredSymbol]; routed && route.implementationSymbol != "" {
-		mandatoryIDs = append(mandatoryIDs, route.implementationSymbol)
+	if route, routed := completion.refinementRoutes[requiredSymbol]; routed {
+		if route.implementationSymbol != "" {
+			mandatoryIDs = append(mandatoryIDs, route.implementationSymbol)
+		}
+		if route.proofSymbol != "" {
+			mandatoryIDs = append(mandatoryIDs, route.proofSymbol)
+		}
 	}
 	// Packing operates on a prefix, so retain through the latest mandatory ID.
 	for _, mandatoryID := range mandatoryIDs {
@@ -2742,10 +2800,11 @@ func buildLocalizationExploreResultForTask(
 			Name: compactLocalizationField(n.Name, localizationMaxNameRunes),
 			Kind: string(n.Kind), File: path,
 			Line: n.StartLine, EndLine: n.EndLine,
-			QualName:  compactLocalizationField(retrieval.QualName, localizationMaxQualNameRunes),
-			Signature: compactLocalizationField(retrieval.Signature, localizationMaxSignatureRunes),
-			Callers:   boundedLocalizationNeighborIDs(target.callers, localizationMaxNeighborIDs),
-			Callees:   boundedLocalizationNeighborIDs(target.callees, localizationMaxNeighborIDs),
+			QualName:   compactLocalizationField(retrieval.QualName, localizationMaxQualNameRunes),
+			Signature:  compactLocalizationField(retrieval.Signature, localizationMaxSignatureRunes),
+			Callers:    boundedLocalizationNeighborIDs(target.callers, localizationMaxNeighborIDs),
+			Callees:    boundedLocalizationNeighborIDs(target.callees, localizationMaxNeighborIDs),
+			Provenance: localizationTargetProvenance(completion, target),
 		}
 
 		candidate := envelope
@@ -2821,13 +2880,22 @@ func buildLocalizationExploreResultForTask(
 	}
 
 	if len(finalize) > 0 && finalize[0] != nil {
-		envelope.Completion = finalize[0](append([]string(nil), envelope.Symbols...))
+		envelope.Completion = finalize[0](envelope)
 	}
+	// Strong enforcement is derived only from proof rows that survived final
+	// byte-budget packing. Visible text, retained state, and host metadata then
+	// share this one normalized completion value.
+	envelope.Completion = localizationFinalizeCompletionEvidence(envelope.Completion, acceptedTargets, envelope)
+	contract = localizationContractFor(envelope.Completion)
+	envelope.Completion = contract.Completion
+	envelope.Terminal = contract.Terminal
 	body, err := json.Marshal(envelope)
 	if err != nil {
-		return mcp.NewToolResultError("encode localization result: " + err.Error()), nil, nil
+		return mcp.NewToolResultError("encode localization result: " + err.Error()), nil, nil, envelope.Completion
 	}
-	return mcp.NewToolResultText(string(body)), append([]string(nil), envelope.Symbols...), newLocalizationEvidenceDigest(envelope)
+	digest := newLocalizationEvidenceDigest(envelope)
+	result := attachLocalizationHostEnvelope(mcp.NewToolResultText(string(body)), envelope.Completion, digest)
+	return result, append([]string(nil), envelope.Symbols...), digest, envelope.Completion
 }
 
 func boundedLocalizationNeighborIDs(nodes []*graph.Node, limit int) []string {
@@ -3504,6 +3572,7 @@ const (
 	exploreContentRecallExactSignal     = "explore_content_exact"
 	exploreContentRecallAmbiguousSignal = "explore_content_exact_ambiguous"
 	exploreSourceLiteralSignal          = "explore_source_literal"
+	exploreSourceLiteralCalleeSignal    = "explore_source_literal_callee"
 	exploreSourceLiteralCoverageSignal  = "explore_source_literal_coverage"
 	exploreSourceLiteralReservationMax  = 2
 	exploreQuotedRecallMaxTerms         = 3
@@ -3742,6 +3811,7 @@ func (s *Server) gatherExploreQuotedContentCandidates(
 	sourceLiteralAnchors := make(map[string]map[int]struct{})
 	sourceLiteralAmbiguous := make(map[string]bool)
 	sourceLiteralSettled := make(map[string]bool)
+	sourceLiteralCallee := make(map[string]bool)
 	for _, page := range pages {
 		seenForTerm := make(map[string]struct{}, len(page.hits))
 		exactIDs := make(map[string]struct{})
@@ -3831,6 +3901,9 @@ func (s *Server) gatherExploreQuotedContentCandidates(
 			if sourceRank > sourceLiteralHit[hit.nodeID] {
 				sourceLiteralHit[hit.nodeID] = sourceRank
 			}
+			if hit.callee {
+				sourceLiteralCallee[hit.nodeID] = true
+			}
 			if hit.ambiguous {
 				sourceLiteralAmbiguous[hit.nodeID] = true
 			} else {
@@ -3873,6 +3946,9 @@ func (s *Server) gatherExploreQuotedContentCandidates(
 		if sourceRank := sourceLiteralHit[id]; sourceRank > 0 {
 			signals[exploreSourceLiteralSignal] = sourceRank
 			signals[exploreSourceLiteralCoverageSignal] = float64(len(sourceLiteralAnchors[id]))
+			if sourceLiteralCallee[id] {
+				signals[exploreSourceLiteralCalleeSignal] = 1
+			}
 		}
 		candidates = append(candidates, &rerank.Candidate{
 			Node:       node,
@@ -4067,6 +4143,7 @@ func mergeExploreCandidates(primary, expanded []*rerank.Candidate, expansionRank
 				exploreContentRecallExactSignal,
 				exploreContentRecallAmbiguousSignal,
 				exploreSourceLiteralSignal,
+				exploreSourceLiteralCalleeSignal,
 				exploreSourceLiteralCoverageSignal,
 			} {
 				if clone.Signals == nil || clone.Signals[key] <= current.Signals[key] {

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -817,11 +817,29 @@ func exploreDraftGenericCandidate(n *graph.Node, source string) bool {
 		}
 	}
 	// Receiver syntax varies, but trivial implementations consistently contain
-	// a member access plus either one return/call or one field assignment.
-	hasMemberAccess := strings.Contains(code, ".")
-	hasOneStepReturn := strings.Contains(code, " return ") && strings.Contains(code, "(")
-	hasAccessorAssignment := strings.Contains(code, "=")
-	return hasMemberAccess && (hasOneStepReturn || hasAccessorAssignment)
+	// a member access plus one return/call or one field assignment. Inspect the
+	// body separately so Rust tail expressions and C#/Kotlin expression bodies
+	// are recognized even though they omit an explicit return keyword.
+	body := code
+	if open := strings.IndexByte(body, '{'); open >= 0 {
+		body = body[open+1:]
+		if close := strings.LastIndexByte(body, '}'); close >= 0 {
+			body = body[:close]
+		}
+	}
+	body = strings.TrimSpace(body)
+	hasMemberAccess := strings.Contains(body, ".") || strings.Contains(body, "::")
+	hasCall := strings.Contains(body, "(") && strings.Contains(body, ")")
+	hasOneStepReturn := strings.Contains(" "+body+" ", " return ") && hasCall
+	hasAccessorAssignment := strings.Contains(body, "=")
+	hasExpressionBody := strings.Contains(body, "=>") && hasCall
+	// A tail forwarder is one member call with no statement-level work around
+	// it. One optional trailing semicolon covers Rust and expression-bodied
+	// languages without classifying small control-flow implementations as shims.
+	tail := strings.TrimSpace(strings.TrimSuffix(body, ";"))
+	hasTailForwarder := hasCall && hasMemberAccess && !strings.Contains(tail, ";") &&
+		!strings.Contains(tail, "{") && !strings.Contains(tail, "}")
+	return hasMemberAccess && (hasOneStepReturn || hasAccessorAssignment || hasExpressionBody || hasTailForwarder)
 }
 
 func exploreDraftExactAnchor(query string, n *graph.Node) bool {
@@ -914,6 +932,10 @@ func exploreAnswerReady(task string, targets []exploreTarget) bool {
 	matchedNode := func(node *graph.Node) int { return matchedNodeFor(node, queryTerms) }
 	head := targets[0]
 	headMatches := matchedNode(head.node)
+	if class == rerank.QueryClassConcept && !exploreLocalizationExplicitAnchor(query, head.node) &&
+		!exploreSyntacticAnchorEvidenceReady(task, targets) {
+		return false
+	}
 
 	// Paths, signatures, and identifier-shaped queries carry explicit anchors.
 	// A shared token is not enough: the ranked head must cover the complete
@@ -983,11 +1005,13 @@ func exploreAnswerReady(task string, targets []exploreTarget) bool {
 	// declarations remain useful evidence, but cannot terminate navigation.
 	var implementation *exploreTarget
 	if class == rerank.QueryClassConcept {
+		hasSyntacticAnchors := len(exploreSyntacticAnchors(task)) > 0
 		for i := range targets {
 			target := &targets[i]
 			callable := target.node != nil &&
 				(target.node.Kind == graph.KindFunction || target.node.Kind == graph.KindMethod)
-			if target.conceptImplementation && callable && strings.TrimSpace(target.source) != "" {
+			if target.conceptImplementation && callable && strings.TrimSpace(target.source) != "" &&
+				(!hasSyntacticAnchors || !exploreDraftGenericCandidate(target.node, target.source)) {
 				implementation = target
 				break
 			}
@@ -1656,6 +1680,21 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 			ranked = limitExploreCandidatesPreservingSourceLiteral(ranked, fetch*2)
 		}
 	}
+	// Distinctive CLI and identifier-shaped anchors get one bounded lexical
+	// owner each. This runs after the ordinary ranking pass so it only spends
+	// work on uncovered anchors and cannot perturb the semantic channel. The
+	// existing source scanner is the final fallback, never a persistent body
+	// index.
+	var protectedSyntacticAnchors map[int]string
+	if queryClass == rerank.QueryClassConcept {
+		anchorCandidates, protected := s.gatherExploreSyntacticAnchorCandidates(
+			ctx, task, ranked, eng, opts, rctx,
+		)
+		protectedSyntacticAnchors = protected
+		if len(anchorCandidates) > 0 {
+			ranked = mergeExploreCandidates(ranked, anchorCandidates, fetch)
+		}
+	}
 	// Resilience ladder: a warm-restarted daemon can transiently return an
 	// empty scoped ranked result (workspace stamps not yet backfilled, or
 	// search bundles served before their node payloads re-materialise)
@@ -1721,6 +1760,18 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 	}
 	prod, protectedImplementationID := reserveExploreConceptImplementation(searchQuery, queryClass, prod, maxSymbols)
 	cands := selectFinalExploreCandidates(prod, test, maxSymbols)
+	if len(protectedSyntacticAnchors) > 0 {
+		// Source-literal selection owns its own final-slot guarantees. Re-union
+		// that selected window with production candidates, then enforce anchor
+		// reservations against the actual final pool while retaining the selected
+		// order for every remaining slot.
+		anchorPool := mergeExploreCandidates(cands, prod, 0)
+		anchorPool = reserveExploreSyntacticAnchorCandidates(task, anchorPool, protectedSyntacticAnchors, maxSymbols)
+		if len(anchorPool) > maxSymbols {
+			anchorPool = anchorPool[:maxSymbols]
+		}
+		cands = anchorPool
+	}
 	if len(cands) == 0 && len(artifactLane.targets) == 0 {
 		if req.GetBool("localize", false) {
 			return s.completeEmptyLocalization(ctx, task, budget), nil
@@ -2084,6 +2135,7 @@ func explorePreferredRefinementSymbol(task string, targets []exploreTarget) stri
 		return ""
 	}
 	query := shapeExploreQuery(task)
+	syntacticAnchors := exploreSyntacticAnchors(task)
 	if exploreQueryIsConceptTask(query) {
 		query = stripLeadingExploreDirective(query)
 	}
@@ -2110,6 +2162,7 @@ func explorePreferredRefinementSymbol(task string, targets []exploreTarget) stri
 		identifierOverlap int
 		bodyOverlap       int
 		longest           int
+		anchorMatches     int
 		explicit          bool
 		callable          bool
 		generic           bool
@@ -2133,6 +2186,7 @@ func explorePreferredRefinementSymbol(task string, targets []exploreTarget) stri
 			identifierOverlap: identifierOverlap,
 			bodyOverlap:       bodyOverlap,
 			longest:           longest,
+			anchorMatches:     exploreSyntacticAnchorTargetMatchesAnchors(syntacticAnchors, target),
 			explicit:          exploreLocalizationExplicitAnchor(query, target.node),
 			callable:          callable,
 			generic:           exploreDraftGenericCandidate(target.node, target.source),
@@ -2151,6 +2205,12 @@ func explorePreferredRefinementSymbol(task string, targets []exploreTarget) stri
 	better := func(left, right refinementCandidate) bool {
 		if left.explicit != right.explicit {
 			return left.explicit
+		}
+		if left.anchorMatches != right.anchorMatches {
+			return left.anchorMatches > right.anchorMatches
+		}
+		if left.anchorMatches > 0 && left.generic != right.generic {
+			return !left.generic
 		}
 		leftAlignment, rightAlignment := alignment(left), alignment(right)
 		if leftAlignment != rightAlignment {
@@ -3155,6 +3215,8 @@ const (
 	exploreContentRecallExactSignal     = "explore_content_exact"
 	exploreContentRecallAmbiguousSignal = "explore_content_exact_ambiguous"
 	exploreSourceLiteralSignal          = "explore_source_literal"
+	exploreSourceLiteralCoverageSignal  = "explore_source_literal_coverage"
+	exploreSourceLiteralReservationMax  = 2
 	exploreQuotedRecallMaxTerms         = 3
 	exploreQuotedRecallMaxPerTerm       = 12
 	exploreQuotedRecallRetryMaxRows     = 24
@@ -3346,6 +3408,9 @@ func (s *Server) gatherExploreQuotedContentCandidates(
 	uniqueExact := make(map[string]bool, len(pages)*perTerm)
 	ambiguousExact := make(map[string]bool, len(pages)*perTerm)
 	sourceLiteralHit := make(map[string]float64)
+	sourceLiteralAnchors := make(map[string]map[int]struct{})
+	sourceLiteralAmbiguous := make(map[string]bool)
+	sourceLiteralSettled := make(map[string]bool)
 	for _, page := range pages {
 		seenForTerm := make(map[string]struct{}, len(page.hits))
 		exactIDs := make(map[string]struct{})
@@ -3418,8 +3483,14 @@ func (s *Server) gatherExploreQuotedContentCandidates(
 			} else if hit.rank < previous {
 				bestRank[hit.nodeID] = hit.rank
 			}
-			if termCount[hit.nodeID] == 0 {
-				termCount[hit.nodeID] = 1
+			anchors := sourceLiteralAnchors[hit.nodeID]
+			if anchors == nil {
+				anchors = make(map[int]struct{}, exploreSourceLiteralRecallMaxTerms)
+				sourceLiteralAnchors[hit.nodeID] = anchors
+			}
+			anchors[hit.anchor] = struct{}{}
+			if termCount[hit.nodeID] < len(anchors) {
+				termCount[hit.nodeID] = len(anchors)
 			}
 			exactHit[hit.nodeID] = true
 			sourceRank := 1.0
@@ -3429,10 +3500,17 @@ func (s *Server) gatherExploreQuotedContentCandidates(
 			if sourceRank > sourceLiteralHit[hit.nodeID] {
 				sourceLiteralHit[hit.nodeID] = sourceRank
 			}
-			if sourceRecall.ambiguous {
-				ambiguousExact[hit.nodeID] = true
+			if hit.ambiguous {
+				sourceLiteralAmbiguous[hit.nodeID] = true
 			} else {
-				uniqueExact[hit.nodeID] = true
+				sourceLiteralSettled[hit.nodeID] = true
+			}
+		}
+		for id := range sourceLiteralAnchors {
+			if sourceLiteralAmbiguous[id] && !sourceLiteralSettled[id] {
+				ambiguousExact[id] = true
+			} else {
+				uniqueExact[id] = true
 			}
 		}
 		if len(missingNodes) > 0 {
@@ -3463,6 +3541,7 @@ func (s *Server) gatherExploreQuotedContentCandidates(
 		}
 		if sourceRank := sourceLiteralHit[id]; sourceRank > 0 {
 			signals[exploreSourceLiteralSignal] = sourceRank
+			signals[exploreSourceLiteralCoverageSignal] = float64(len(sourceLiteralAnchors[id]))
 		}
 		candidates = append(candidates, &rerank.Candidate{
 			Node:       node,
@@ -3657,6 +3736,7 @@ func mergeExploreCandidates(primary, expanded []*rerank.Candidate, expansionRank
 				exploreContentRecallExactSignal,
 				exploreContentRecallAmbiguousSignal,
 				exploreSourceLiteralSignal,
+				exploreSourceLiteralCoverageSignal,
 			} {
 				if clone.Signals == nil || clone.Signals[key] <= current.Signals[key] {
 					continue
@@ -3737,9 +3817,10 @@ func limitExploreCandidates(candidates []*rerank.Candidate, limit int) []*rerank
 }
 
 // limitExploreCandidatesPreservingSourceLiteral reserves one slot for the best
-// request-local raw-source literal hit after the ordinary retrieval union is
-// full. The reservation replaces the weakest bounded candidate; it never grows
-// the candidate set or performs another graph lookup.
+// request-local raw-source literal owners after the ordinary retrieval union is
+// full. The bounded reservation prefers multi-anchor owners, preserves one
+// semantic candidate, and never grows the candidate set or performs another
+// graph lookup.
 func limitExploreCandidatesPreservingSourceLiteral(candidates []*rerank.Candidate, limit int) []*rerank.Candidate {
 	bounded := limitExploreCandidates(candidates, limit)
 	if limit <= 0 || len(candidates) <= limit || len(bounded) == 0 {
@@ -3748,35 +3829,93 @@ func limitExploreCandidatesPreservingSourceLiteral(candidates []*rerank.Candidat
 	return reserveExploreSourceLiteralCandidate(candidates, bounded)
 }
 
-// reserveExploreSourceLiteralCandidate inserts the strongest source-literal
-// candidate into an already-selected window. It deliberately leaves the
-// window's established order untouched unless a replacement is required.
+// reserveExploreSourceLiteralCandidate inserts up to two bounded source-literal
+// owners into an already-selected window, preferring owners that cover multiple
+// anchors while preserving at least one semantic candidate. It leaves the
+// established order untouched unless replacement is required.
 func reserveExploreSourceLiteralCandidate(candidates, bounded []*rerank.Candidate) []*rerank.Candidate {
 	if len(bounded) == 0 || len(candidates) <= len(bounded) {
 		return bounded
 	}
-	var best *rerank.Candidate
-	bestSignal := 0.0
-	for _, candidate := range candidates {
-		if candidate == nil || candidate.Node == nil || candidate.Signals == nil {
-			continue
-		}
-		if signal := candidate.Signals[exploreSourceLiteralSignal]; signal > bestSignal {
-			best = candidate
-			bestSignal = signal
-		}
-	}
-	if best == nil {
+	// A source-body fallback may occupy at most the slots after the ranked
+	// semantic head. This remains true even for a one-slot response.
+	reservationLimit := min(exploreSourceLiteralReservationMax, len(bounded)-1)
+	if reservationLimit <= 0 {
 		return bounded
 	}
-	for _, candidate := range bounded {
-		if candidate != nil && candidate.Node != nil && candidate.Node.ID == best.Node.ID {
-			return bounded
+
+	sources := make([]*rerank.Candidate, 0, exploreSourceLiteralReservationMax)
+	for _, candidate := range candidates {
+		if candidate == nil || candidate.Node == nil || candidate.Signals == nil ||
+			candidate.Signals[exploreSourceLiteralSignal] <= 0 {
+			continue
+		}
+		sources = append(sources, candidate)
+	}
+	sort.SliceStable(sources, func(i, j int) bool {
+		leftCoverage := sources[i].Signals[exploreSourceLiteralCoverageSignal]
+		rightCoverage := sources[j].Signals[exploreSourceLiteralCoverageSignal]
+		if leftCoverage != rightCoverage {
+			return leftCoverage > rightCoverage
+		}
+		return sources[i].Signals[exploreSourceLiteralSignal] > sources[j].Signals[exploreSourceLiteralSignal]
+	})
+	selectedSources := sources[:0]
+	for _, source := range sources {
+		coverage := source.Signals[exploreSourceLiteralCoverageSignal]
+		settled := source.Signals[exploreContentRecallAmbiguousSignal] <= 0
+		// One ambiguous single-anchor owner may preserve recall, but allowing a
+		// second would spend most of a three-slot answer on collision evidence.
+		// Multi-anchor corroboration is strong enough to keep despite ambiguity.
+		if len(selectedSources) > 0 && coverage < 2 && !settled {
+			continue
+		}
+		selectedSources = append(selectedSources, source)
+		if len(selectedSources) == reservationLimit {
+			break
 		}
 	}
+	sources = selectedSources
+	if len(sources) == 0 {
+		return bounded
+	}
 
+	desired := make(map[string]struct{}, len(sources))
+	present := make(map[string]struct{}, len(bounded))
+	for _, candidate := range sources {
+		desired[candidate.Node.ID] = struct{}{}
+	}
+	for _, candidate := range bounded {
+		if candidate != nil && candidate.Node != nil {
+			present[candidate.Node.ID] = struct{}{}
+		}
+	}
 	reserved := append([]*rerank.Candidate(nil), bounded...)
-	reserved[len(reserved)-1] = best
+	for _, source := range sources {
+		if _, exists := present[source.Node.ID]; exists {
+			continue
+		}
+		replace := -1
+		for index := len(reserved) - 1; index >= 1; index-- {
+			candidate := reserved[index]
+			if candidate == nil || candidate.Node == nil {
+				replace = index
+				break
+			}
+			if _, protected := desired[candidate.Node.ID]; !protected {
+				replace = index
+				break
+			}
+		}
+		if replace < 0 {
+			break
+		}
+		if previous := reserved[replace]; previous != nil && previous.Node != nil {
+			delete(present, previous.Node.ID)
+		}
+		reserved[replace] = source
+		present[source.Node.ID] = struct{}{}
+	}
 	return reserved
 }
 
@@ -3786,14 +3925,18 @@ func reserveExploreSourceLiteralCandidate(candidates, bounded []*rerank.Candidat
 // the ordinary retrieval head.
 func promoteExploreSourceLiteralCandidate(candidates []*rerank.Candidate) []*rerank.Candidate {
 	bestIndex := -1
+	bestCoverage := 0.0
 	bestSignal := 0.0
 	for index, candidate := range candidates {
 		if candidate == nil || candidate.Node == nil || candidate.Signals == nil ||
 			candidate.Signals[exploreContentRecallAmbiguousSignal] > 0 {
 			continue
 		}
-		if signal := candidate.Signals[exploreSourceLiteralSignal]; signal > bestSignal {
+		coverage := candidate.Signals[exploreSourceLiteralCoverageSignal]
+		signal := candidate.Signals[exploreSourceLiteralSignal]
+		if signal > 0 && (coverage > bestCoverage || coverage == bestCoverage && signal > bestSignal) {
 			bestIndex = index
+			bestCoverage = coverage
 			bestSignal = signal
 		}
 	}

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -1479,8 +1479,10 @@ func reserveExploreConceptImplementation(
 		queryTerms = append(queryTerms, term)
 	}
 	var frequencyStorage [64]int
-	frequency := frequencyStorage[:len(queryTerms)]
-	if len(queryTerms) > len(frequencyStorage) {
+	var frequency []int
+	if len(queryTerms) <= len(frequencyStorage) {
+		frequency = frequencyStorage[:len(queryTerms)]
+	} else {
 		frequency = make([]int, len(queryTerms))
 	}
 	var metricStorage [80]exploreConceptImplementationMetric

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -92,6 +92,7 @@ type exploreTarget struct {
 	exactContentAmbiguous bool   // exact evidence has visible or possibly truncated peers
 	sourceLiteral         bool   // exact source-body hit that must survive final envelope packing
 	sourceLiteralCallee   bool   // exact source callsite uniquely resolved to this invoked callable
+	sourceLiteralAligned  bool   // source-literal callee that instantiates the task's value; strongest literal owner
 	typedAnchorProjection bool   // bounded field-owner-call proof promoted from a task-aligned typed field
 	foldedOwner           bool   // synthetic owner inserted by concept member folding
 }
@@ -828,6 +829,18 @@ func exploreDraftIsTestNode(n *graph.Node) bool {
 	for _, dir := range []string{"/__tests__/", "/spec/", "/specs/", "/test/", "/tests/"} {
 		if strings.Contains(segmented, dir) {
 			return true
+		}
+	}
+	// .NET/JVM test assemblies name their directory with a dotted token, e.g.
+	// `Humanizer.Tests.Shared` — a real path segment that the slash-delimited
+	// check above cannot see. Treat a dot-delimited test/spec token inside any
+	// segment as test code so test metadata never suppresses production recall.
+	for _, segment := range strings.Split(strings.Trim(path, "/"), "/") {
+		for _, token := range strings.Split(segment, ".") {
+			switch token {
+			case "test", "tests", "spec", "specs":
+				return true
+			}
 		}
 	}
 	base := path
@@ -2115,6 +2128,7 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 			t.exactContentAmbiguous = c.Signals[exploreContentRecallAmbiguousSignal] > 0
 			t.sourceLiteral = c.Signals[exploreSourceLiteralSignal] > 0
 			t.sourceLiteralCallee = c.Signals[exploreSourceLiteralCalleeSignal] > 0
+			t.sourceLiteralAligned = c.Signals[exploreSourceLiteralTaskAlignSignal] > 0
 			t.typedAnchorProjection = c.Signals[exploreTypedAnchorProjectionSignal] > 0
 		}
 		t.source = s.manifestSymbolSource(ctx, n)
@@ -2713,6 +2727,16 @@ func localizationEvidenceTargetsFromDraft(task, exactID string, targets []explor
 	// A source-body literal is the only direct evidence that can identify an
 	// implementation absent from symbol metadata. Reserve the strongest one
 	// before draft promotion and byte-budget packing can consume every slot.
+	// A construction-aligned callee — one that instantiates the task's value —
+	// is the strongest literal owner; reserve it ahead of a generic literal
+	// callee that merely leads primary retrieval, so it is never the sacrificial
+	// tail when the projection is at the max_symbols boundary.
+	for _, target := range targets {
+		if target.sourceLiteral && target.sourceLiteralAligned {
+			appendTarget(target)
+			break
+		}
+	}
 	for _, target := range targets {
 		if target.sourceLiteral {
 			appendTarget(target)
@@ -2938,6 +2962,15 @@ func buildLocalizationExploreResultForTaskFinalized(
 	}
 	for index, target := range targets {
 		if target.sourceLiteral && index+1 > mandatoryCount {
+			mandatoryCount = index + 1
+			break
+		}
+	}
+	// The construction-aligned literal owner is reserved evidence: guarantee its
+	// identifier survives byte-budget packing even when a generic literal callee
+	// leads the projection and holds the first source-literal slot.
+	for index, target := range targets {
+		if target.sourceLiteral && target.sourceLiteralAligned && index+1 > mandatoryCount {
 			mandatoryCount = index + 1
 			break
 		}
@@ -4486,6 +4519,7 @@ func mergeExploreCandidates(primary, expanded []*rerank.Candidate, expansionRank
 				exploreSourceLiteralSignal,
 				exploreSourceLiteralCalleeSignal,
 				exploreSourceLiteralCoverageSignal,
+				exploreSourceLiteralTaskAlignSignal,
 			} {
 				if clone.Signals == nil || clone.Signals[key] <= current.Signals[key] {
 					continue

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -3500,6 +3500,9 @@ func exploreQuotedRecallTerms(task string) []string {
 		if len(literal) < 2 || len(literal) > 128 || quotedLiteralIsNoise(literal) {
 			continue
 		}
+		if exploreTwoLetterQuotedAnchor(literal) && !exploreAllowsTwoLetterQuotedAnchor(task) {
+			continue
+		}
 		key := strings.ToLower(literal)
 		if _, duplicate := seen[key]; duplicate {
 			continue
@@ -3511,6 +3514,45 @@ func exploreQuotedRecallTerms(task string) []string {
 		}
 	}
 	return out
+}
+
+func exploreTwoLetterQuotedAnchor(literal string) bool {
+	if utf8.RuneCountInString(literal) != 2 {
+		return false
+	}
+	for _, r := range literal {
+		if !unicode.IsLetter(r) {
+			return false
+		}
+	}
+	return true
+}
+
+// exploreAllowsTwoLetterQuotedAnchor keeps exceptionally collision-prone
+// literals out of fallback source scans unless the request identifies them as
+// a culture, locale, language, registry, protocol, or configuration value.
+// This is task-class gating rather than a vocabulary of specific codes, so it
+// applies equally to future repositories and languages.
+func exploreAllowsTwoLetterQuotedAnchor(task string) bool {
+	lower := strings.ToLower(task)
+	for _, phrase := range []string{
+		"configuration key", "config key", "country code", "culture code",
+		"language code", "language tag", "locale code", "protocol code",
+		"region code", "status code",
+	} {
+		if strings.Contains(lower, phrase) {
+			return true
+		}
+	}
+	for _, token := range strings.FieldsFunc(lower, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_'
+	}) {
+		switch token {
+		case "bcp47", "charset", "culture", "cultureinfo", "cultures", "currency", "encoding", "ietf", "iso", "locale", "locales", "register", "registered", "registering", "registration", "registrations", "registry":
+			return true
+		}
+	}
+	return false
 }
 
 func exploreQuotedRecallHasExactSourceCandidate(

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -2074,50 +2074,130 @@ func exploreNodeWithinQueryScope(n *graph.Node, scope query.QueryOptions) bool {
 // with the query) must not consume the only read while a query-aligned
 // candidate sits lower in the same envelope:
 //
-//	1. verified source-literal evidence
-//	2. explicit path / qualified-symbol / call anchor
-//	3. query-aligned non-generic callable
-//	4. protected concept implementation
-//	5. aligned candidate of any definition kind
-//	6. raw head only when nothing aligned exists
+//  1. explicit path / qualified-symbol / call anchor
+//  2. strongest non-literal semantic coverage across declaration and body
+//  3. smallest actionable callable, then verified literal provenance
+//  4. protected concept implementation and non-generic declaration quality
+//  5. answer-draft rank and raw rank as deterministic final tie-breaks
 func explorePreferredRefinementSymbol(task string, targets []exploreTarget) string {
+	if len(targets) == 0 {
+		return ""
+	}
 	query := shapeExploreQuery(task)
 	if exploreQueryIsConceptTask(query) {
 		query = stripLeadingExploreDirective(query)
 	}
-	queryTerms := exploreTerminalTerms(query)
-	aligned := func(t exploreTarget) bool {
-		overlap, _ := exploreDraftTermOverlap(queryTerms, t.node)
-		return overlap > 0
-	}
-	callable := func(n *graph.Node) bool {
-		return n != nil && (n.Kind == graph.KindFunction || n.Kind == graph.KindMethod)
-	}
-	rungs := []func(exploreTarget) bool{
-		func(t exploreTarget) bool { return t.sourceLiteral },
-		func(t exploreTarget) bool { return exploreLocalizationExplicitAnchor(query, t.node) },
-		func(t exploreTarget) bool {
-			return callable(t.node) && aligned(t) && !exploreDraftGenericCandidate(t.node, t.source)
-		},
-		func(t exploreTarget) bool { return t.conceptImplementation },
-		aligned,
-	}
-	for _, rung := range rungs {
-		for _, target := range targets {
-			if target.node == nil || target.node.ID == "" {
-				continue
-			}
-			if rung(target) {
-				return target.node.ID
-			}
+	semanticTerms := exploreTerminalTerms(query)
+	for _, literal := range exploreQuotedRecallTerms(task) {
+		for term := range exploreTerminalTerms(literal) {
+			delete(semanticTerms, term)
 		}
 	}
-	for _, target := range targets {
-		if target.node != nil && target.node.ID != "" {
-			return target.node.ID
+
+	// The answer-draft order already incorporates rare-term density and generic
+	// declaration demotion. Retain it as the final deterministic tie-break while
+	// comparing all direct targets on their non-literal semantic evidence.
+	draftRank := make(map[string]int, len(targets))
+	for index, entry := range exploreAnswerDraft(task, targets) {
+		if entry.node != nil {
+			draftRank[exploreDraftNodeKey(entry.node)] = index
 		}
 	}
-	return ""
+	type refinementCandidate struct {
+		target            exploreTarget
+		index             int
+		draftRank         int
+		identifierOverlap int
+		bodyOverlap       int
+		longest           int
+		explicit          bool
+		callable          bool
+		generic           bool
+	}
+	candidates := make([]refinementCandidate, 0, len(targets))
+	for index, target := range targets {
+		if target.node == nil || target.node.ID == "" {
+			continue
+		}
+		identifierOverlap, longest := exploreDraftTermOverlap(semanticTerms, target.node)
+		bodyOverlap := exploreDraftTermSetOverlap(semanticTerms, exploreTerminalTerms(target.source))
+		rank, ranked := draftRank[exploreDraftNodeKey(target.node)]
+		if !ranked {
+			rank = len(targets) + index
+		}
+		callable := target.node.Kind == graph.KindFunction || target.node.Kind == graph.KindMethod
+		candidates = append(candidates, refinementCandidate{
+			target:            target,
+			index:             index,
+			draftRank:         rank,
+			identifierOverlap: identifierOverlap,
+			bodyOverlap:       bodyOverlap,
+			longest:           longest,
+			explicit:          exploreLocalizationExplicitAnchor(query, target.node),
+			callable:          callable,
+			generic:           exploreDraftGenericCandidate(target.node, target.source),
+		})
+	}
+	if len(candidates) == 0 {
+		return ""
+	}
+	alignment := func(candidate refinementCandidate) int {
+		body := candidate.bodyOverlap
+		if body > 2 {
+			body = 2
+		}
+		return candidate.identifierOverlap + body
+	}
+	better := func(left, right refinementCandidate) bool {
+		if left.explicit != right.explicit {
+			return left.explicit
+		}
+		leftAlignment, rightAlignment := alignment(left), alignment(right)
+		if leftAlignment != rightAlignment {
+			return leftAlignment > rightAlignment
+		}
+		if left.identifierOverlap != right.identifierOverlap {
+			return left.identifierOverlap > right.identifierOverlap
+		}
+		if left.bodyOverlap != right.bodyOverlap {
+			return left.bodyOverlap > right.bodyOverlap
+		}
+		// With no semantic alignment, verified source provenance is the only
+		// concrete evidence. Do not let an arbitrary callable beat the exact
+		// literal merely because the literal maps to a type or field owner.
+		if leftAlignment == 0 && left.target.sourceLiteral != right.target.sourceLiteral {
+			return left.target.sourceLiteral
+		}
+		// Once both candidates cover task concepts, prefer the smallest
+		// actionable declaration before provenance: a literal mapped to an
+		// enclosing type/file must not outrank an aligned callable.
+		if left.callable != right.callable {
+			return left.callable
+		}
+		if left.target.sourceLiteral != right.target.sourceLiteral {
+			return left.target.sourceLiteral
+		}
+		if left.target.conceptImplementation != right.target.conceptImplementation {
+			return left.target.conceptImplementation
+		}
+		if left.generic != right.generic {
+			return !left.generic
+		}
+		if left.longest != right.longest {
+			return left.longest > right.longest
+		}
+		if left.draftRank != right.draftRank {
+			return left.draftRank < right.draftRank
+		}
+		return left.index < right.index
+	}
+	best := candidates[0]
+	for _, candidate := range candidates[1:] {
+		if better(candidate, best) {
+			best = candidate
+		}
+	}
+	return best.target.node.ID
 }
 
 // localizationEvidenceTargets projects the same bounded answer-draft evidence
@@ -2126,6 +2206,27 @@ func explorePreferredRefinementSymbol(task string, targets []exploreTarget) stri
 // the response cardinality. Direct targets retain their source and neighbors.
 func localizationEvidenceTargets(task, exactID string, targets []exploreTarget) []exploreTarget {
 	return localizationEvidenceTargetsFromDraft(task, exactID, targets, nil)
+}
+
+func prioritizeLocalizationEvidenceTarget(requiredID string, targets []exploreTarget) []exploreTarget {
+	if requiredID == "" || len(targets) < 2 {
+		return targets
+	}
+	requiredIndex := -1
+	for index, target := range targets {
+		if target.node != nil && target.node.ID == requiredID {
+			requiredIndex = index
+			break
+		}
+	}
+	if requiredIndex <= 0 {
+		return targets
+	}
+	ordered := make([]exploreTarget, 0, len(targets))
+	ordered = append(ordered, targets[requiredIndex])
+	ordered = append(ordered, targets[:requiredIndex]...)
+	ordered = append(ordered, targets[requiredIndex+1:]...)
+	return ordered
 }
 
 func localizationEvidenceTargetsFromDraft(task, exactID string, targets []exploreTarget, draft []exploreDraftEntry) []exploreTarget {
@@ -2155,10 +2256,11 @@ func localizationEvidenceTargetsFromDraft(task, exactID string, targets []explor
 	if draft == nil && strings.TrimSpace(task) != "" {
 		draft = exploreAnswerDraft(task, targets)
 	}
+	// Primary retrieval evidence leads exact-read and answer-ready envelopes;
+	// both it and the exact target are contractual under tight budgets. A
+	// needs-refinement caller may move its authorized target ahead afterward,
+	// without changing this stable answer-draft projection.
 	appendTarget(targets[0])
-	// The completion contract names the exact refinement target. Reserve it
-	// before promoted structural neighbors so a tight evidence limit cannot
-	// advertise an exact_symbol that is absent from files/symbols/evidence.
 	if exactID != "" {
 		for _, target := range targets {
 			if target.node != nil && target.node.ID == exactID {
@@ -2244,11 +2346,19 @@ func buildLocalizationExploreResultForTask(completion localizationCompletion, ta
 		draft = exploreAnswerDraft(task, targets)
 	}
 	preferredBodyIDs := explorePreferredFullBodyIDs(task, targets, draft, exploreFullBodyLimit)
+	primarySymbol := ""
+	if len(targets) > 0 && targets[0].node != nil {
+		primarySymbol = targets[0].node.ID
+	}
 	requiredSymbol := completion.ExactSymbol
-	if completion.State == localizationStateNeedsRefinement {
+	refinementFirst := completion.State == localizationStateNeedsRefinement
+	if refinementFirst {
 		requiredSymbol = completion.refinementSymbol
 	}
 	targets = localizationEvidenceTargetsFromDraft(task, requiredSymbol, targets, draft)
+	if refinementFirst {
+		targets = prioritizeLocalizationEvidenceTarget(requiredSymbol, targets)
+	}
 	envelope := localizationExploreEnvelope{
 		Completion: completion,
 		Files:      make([]string, 0),
@@ -2264,9 +2374,15 @@ func buildLocalizationExploreResultForTask(completion localizationCompletion, ta
 	if len(targets) > 0 {
 		mandatoryCount = 1
 	}
-	if requiredSymbol != "" {
+	// Primary retrieval evidence and the authorized exact/refinement symbol are
+	// both mandatory regardless of which one leads the serialized projection.
+	// Packing operates on a prefix, so retain through the later of the two.
+	for _, mandatoryID := range []string{primarySymbol, requiredSymbol} {
+		if mandatoryID == "" {
+			continue
+		}
 		for index, target := range targets {
-			if target.node != nil && target.node.ID == requiredSymbol && index+1 > mandatoryCount {
+			if target.node != nil && target.node.ID == mandatoryID && index+1 > mandatoryCount {
 				mandatoryCount = index + 1
 				break
 			}
@@ -3266,22 +3382,33 @@ func (s *Server) gatherExploreQuotedContentCandidates(
 	if len(order) > 0 {
 		nodes = s.graph.GetNodesByIDs(order)
 	}
-	exactSourceFound := exploreQuotedRecallHasExactSourceCandidate(task, terms, ordinary, scope)
-	if !exactSourceFound {
-		for _, id := range order {
-			if exploreQuotedRecallHasExactSourceNode(task, terms, nodes[id], scope) {
-				exactSourceFound = true
-				break
+	// Decide source coverage per quoted term. An exact metadata hit for one
+	// symbol-like term must not suppress a different compact value whose only
+	// useful evidence is inside a registration body. The selected missing term
+	// still feeds one bounded source scan, so this preserves the fixed I/O cap.
+	sourceRecallTerms := make([]string, 0, len(terms))
+	for _, term := range terms {
+		oneTerm := []string{term}
+		exactSourceFound := exploreQuotedRecallHasExactSourceCandidate(task, oneTerm, ordinary, scope)
+		if !exactSourceFound {
+			for _, id := range order {
+				if exploreQuotedRecallHasExactSourceNode(task, oneTerm, nodes[id], scope) {
+					exactSourceFound = true
+					break
+				}
 			}
+		}
+		if !exactSourceFound {
+			sourceRecallTerms = append(sourceRecallTerms, term)
 		}
 	}
 
 	// content_fts stores content-class nodes rather than ordinary source bodies.
 	// An exact document hit therefore does not prove that the source declaration
-	// containing the literal is represented. Only a miss across both ordinary
-	// retrieval and hydrated content symbols activates the bounded source scan.
-	if ctx.Err() == nil && !exactSourceFound {
-		sourceRecall := s.gatherExploreSourceLiteralRecall(ctx, terms, repoPrefix, scope)
+	// containing the literal is represented. Only a per-term miss across both
+	// ordinary retrieval and hydrated content symbols activates the bounded scan.
+	if ctx.Err() == nil && len(sourceRecallTerms) > 0 {
+		sourceRecall := s.gatherExploreSourceLiteralRecall(ctx, sourceRecallTerms, repoPrefix, scope)
 		missingNodes := make([]string, 0, len(sourceRecall.hits))
 		for _, hit := range sourceRecall.hits {
 			if previous, exists := bestRank[hit.nodeID]; !exists {

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -38,13 +38,14 @@ const exploreToolDescription = "Start here for any task, bug report, or " +
 // corpus, query vocabulary, or benchmark. The verb takes arbitrary free
 // text; nothing here is derived from a fixed task set.
 const (
-	exploreDefaultBudgetTokens = 1600
-	exploreMinBudgetTokens     = 1000
-	exploreMaxBudgetTokens     = 24000
-	exploreDefaultMaxSymbols   = 10
-	exploreMaxMaxSymbols       = 30
-	exploreRingCap             = 5 // callers / callees shown per target
-	exploreCharsPerToken       = 4 // coarse token estimate for budgeting
+	exploreDefaultBudgetTokens             = 1600
+	exploreMinBudgetTokens                 = 1000
+	exploreMaxBudgetTokens                 = 24000
+	exploreDefaultMaxSymbols               = 10
+	exploreMaxMaxSymbols                   = 30
+	exploreRingCap                         = 5 // callers / callees shown per target
+	localizationRefinementAllowedSymbolCap = 8 // preferred plus ranked alternates; preserves rank seven
+	exploreCharsPerToken                   = 4 // coarse token estimate for budgeting
 	// Full bodies are the largest repeated-context cost. Candidate headers,
 	// locations, signatures, and graph rings preserve recall for the whole
 	// neighborhood; only the top targets need full source to make the first
@@ -81,6 +82,7 @@ type exploreTarget struct {
 	score                 float64
 	callers               []*graph.Node
 	callees               []*graph.Node
+	directCalleesComplete bool // false when the direct projection was truncated, bounded, or otherwise lower-bound
 	causalCallees         []exploreCausalNeighbor
 	source                string // full body (may be empty for non-source kinds)
 	conceptImplementation bool   // one identifier-backed callable protected from final truncation
@@ -840,6 +842,149 @@ func exploreDraftGenericCandidate(n *graph.Node, source string) bool {
 	hasTailForwarder := hasCall && hasMemberAccess && !strings.Contains(tail, ";") &&
 		!strings.Contains(tail, "{") && !strings.Contains(tail, "}")
 	return hasMemberAccess && (hasOneStepReturn || hasAccessorAssignment || hasExpressionBody || hasTailForwarder)
+}
+
+// exploreLocalizationRefinementRoutes classifies the already-hydrated,
+// bounded localization targets once. Every authorized candidate is a hydrated
+// production callable. A known generic forwarder is authorized only when every
+// plausible direct callable callee resolves to the same hydrated concrete target.
+func exploreLocalizationRefinementRoutes(targets []exploreTarget) map[string]localizationRefinementRoute {
+	byID := make(map[string]exploreTarget, len(targets))
+	for _, target := range targets {
+		if target.node != nil && target.node.ID != "" {
+			byID[target.node.ID] = target
+		}
+	}
+	routes := make(map[string]localizationRefinementRoute, len(byID))
+	for _, target := range targets {
+		if !exploreHydratedProductionCallable(target) {
+			continue
+		}
+		if !exploreDraftGenericCandidate(target.node, target.source) {
+			routes[target.node.ID] = localizationRefinementRoute{}
+			continue
+		}
+		if !target.directCalleesComplete {
+			continue
+		}
+
+		implementationSymbol := ""
+		ambiguous := false
+		for _, callee := range target.callees {
+			if callee == nil || callee.ID == "" || callee.ID == target.node.ID ||
+				exploreDraftIsTestNode(callee) ||
+				(callee.Kind != graph.KindFunction && callee.Kind != graph.KindMethod) {
+				continue
+			}
+			candidate, visible := byID[callee.ID]
+			if !visible || !exploreHydratedProductionCallable(candidate) ||
+				exploreDraftGenericCandidate(candidate.node, candidate.source) {
+				ambiguous = true
+				break
+			}
+			if implementationSymbol == "" {
+				implementationSymbol = candidate.node.ID
+				continue
+			}
+			if implementationSymbol != candidate.node.ID {
+				ambiguous = true
+				break
+			}
+		}
+		if implementationSymbol != "" && !ambiguous {
+			routes[target.node.ID] = localizationRefinementRoute{implementationSymbol: implementationSymbol}
+		}
+	}
+	return routes
+}
+
+func exploreHydratedProductionCallable(target exploreTarget) bool {
+	if target.node == nil || target.node.ID == "" || exploreDraftIsTestNode(target.node) {
+		return false
+	}
+	if target.node.Kind != graph.KindFunction && target.node.Kind != graph.KindMethod {
+		return false
+	}
+	return strings.TrimSpace(target.source) != ""
+}
+
+func explorePreferredRoutedRefinementSymbol(
+	preferred string,
+	targets []exploreTarget,
+	routes map[string]localizationRefinementRoute,
+) string {
+	if route, authorized := routes[preferred]; authorized {
+		if route.implementationSymbol == "" {
+			return preferred
+		}
+		if implementationRoute, implementationAuthorized := routes[route.implementationSymbol]; implementationAuthorized && implementationRoute.implementationSymbol == "" {
+			return route.implementationSymbol
+		}
+	}
+	// The semantic preferred target can be generic, ambiguous, or unhydrated.
+	// Fall back deterministically to the first ranked concrete authorized target;
+	// a generic wrapper is never recommended even when it is a valid alternate.
+	for _, target := range targets {
+		if target.node == nil {
+			continue
+		}
+		if route, authorized := routes[target.node.ID]; authorized && route.implementationSymbol == "" {
+			return target.node.ID
+		}
+	}
+	return ""
+}
+
+// boundedLocalizationRefinementRoutes intersects precomputed routes with the
+// symbols that survived envelope budgeting. A generic route is retained only
+// when its concrete hop is visible in the same envelope.
+func boundedLocalizationRefinementRoutes(
+	symbols []string,
+	routes map[string]localizationRefinementRoute,
+	preferredSymbol string,
+) ([]string, map[string]localizationRefinementRoute) {
+	visible := make(map[string]struct{}, len(symbols))
+	for _, symbol := range symbols {
+		visible[symbol] = struct{}{}
+	}
+	authorized := make([]string, 0, min(len(symbols), localizationRefinementAllowedSymbolCap))
+	bounded := make(map[string]localizationRefinementRoute, min(len(symbols), localizationRefinementAllowedSymbolCap))
+	appendAuthorized := func(symbol string) {
+		if symbol == "" || len(authorized) >= localizationRefinementAllowedSymbolCap {
+			return
+		}
+		if _, duplicate := bounded[symbol]; duplicate {
+			return
+		}
+		route, ok := routes[symbol]
+		if !ok {
+			return
+		}
+		if route.implementationSymbol != "" {
+			if _, implementationVisible := visible[route.implementationSymbol]; !implementationVisible {
+				return
+			}
+		}
+		authorized = append(authorized, symbol)
+		bounded[symbol] = route
+	}
+	// The recommendation must stay visible and authorized even when ranking
+	// places it after the alternate recovery window.
+	appendAuthorized(preferredSymbol)
+	for _, symbol := range symbols {
+		appendAuthorized(symbol)
+	}
+	return authorized, bounded
+}
+
+func exploreLocalizationTargetSymbols(targets []exploreTarget) []string {
+	symbols := make([]string, 0, len(targets))
+	for _, target := range targets {
+		if target.node != nil && target.node.ID != "" {
+			symbols = append(symbols, target.node.ID)
+		}
+	}
+	return symbols
 }
 
 func exploreDraftExactAnchor(query string, n *graph.Node) bool {
@@ -1841,6 +1986,7 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 			causalElapsed += time.Since(started)
 		}
 		if callees != nil {
+			t.directCalleesComplete = !callees.Truncated && !callees.BudgetHit && !callees.LowerBound
 			if expanded {
 				neighbors := minimumExploreCausalHops(n.ID, callees, opts, exploreCausalDepth, ringOpts.Limit)
 				direct := make([]*graph.Node, 0, exploreRingCap)
@@ -1852,12 +1998,18 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 					}
 				}
 				if len(neighbors) > 0 {
-					t.callees = ringNeighbors(direct, n.ID, exploreRingCap)
+					var projectionComplete bool
+					t.callees, projectionComplete = ringNeighborsProjection(direct, n.ID, exploreRingCap)
+					t.directCalleesComplete = t.directCalleesComplete && projectionComplete
 				} else {
-					t.callees = ringNeighbors(callees.Nodes, n.ID, exploreRingCap)
+					var projectionComplete bool
+					t.callees, projectionComplete = ringNeighborsProjection(callees.Nodes, n.ID, exploreRingCap)
+					t.directCalleesComplete = t.directCalleesComplete && projectionComplete
 				}
 			} else {
-				t.callees = ringNeighbors(callees.Nodes, n.ID, exploreRingCap)
+				var projectionComplete bool
+				t.callees, projectionComplete = ringNeighborsProjection(callees.Nodes, n.ID, exploreRingCap)
+				t.directCalleesComplete = t.directCalleesComplete && projectionComplete
 			}
 		}
 		targets = append(targets, t)
@@ -1903,14 +2055,23 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 		// exploration, multiplying turns and payloads. Name one concrete ranked
 		// target for the only permitted refinement read; source-literal evidence
 		// wins because it is absent from ordinary symbol metadata.
-		preferredSymbol := explorePreferredRefinementSymbol(task, symbolTargets)
-		completion := newLocalizationRefinementCompletion(preferredSymbol)
-		result, returnedSymbols, digest := buildLocalizationExploreResultForTask(completion, task, targets, budget)
-		// Authorization is derived from the exact serialized projection, not
-		// the larger pre-budget candidate set. The preferred symbol is mandatory
-		// in that projection and is the only candidate accepted by the session
-		// guard, so the instruction and enforcement cannot diverge.
-		s.localizationFor(ctx).armRefinementForTask(task, preferredSymbol, returnedSymbols, digest)
+		routes := exploreLocalizationRefinementRoutes(symbolTargets)
+		preferredSymbol := explorePreferredRoutedRefinementSymbol(
+			explorePreferredRefinementSymbol(task, symbolTargets), symbolTargets, routes,
+		)
+		result, refinement, boundedRoutes, digest := buildLocalizationRefinementResultForTask(
+			preferredSymbol, task, targets, budget, routes,
+		)
+		if refinement.State != localizationStateNeedsRefinement {
+			s.localizationFor(ctx).keepOpenForTask(task)
+			return result, nil
+		}
+		// Wire and server authorization are derived from the same finalized
+		// post-budget set. Known generic wrappers without a visible, unique
+		// concrete hop remain evidence but are never authorized.
+		s.localizationFor(ctx).armRefinementRoutesForTask(
+			task, refinement.refinementSymbol, refinement.AllowedSymbols, boundedRoutes, digest,
+		)
 		return result, nil
 	}
 	completion := newLocalizationCompletion(answerReady, exactSymbol)
@@ -1926,10 +2087,20 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 	if answerReady && exactSymbol == "" &&
 		exploreAnswerReadyViaLiteralOnly(task, symbolTargets) &&
 		!exploreResultCitesTaskLiteral(result, task) {
-		preferredSymbol := explorePreferredRefinementSymbol(task, symbolTargets)
-		refinement := newLocalizationRefinementCompletion(preferredSymbol)
-		refined, returnedSymbols, refinedDigest := buildLocalizationExploreResultForTask(refinement, task, targets, budget)
-		s.localizationFor(ctx).armRefinementForTask(task, preferredSymbol, returnedSymbols, refinedDigest)
+		routes := exploreLocalizationRefinementRoutes(symbolTargets)
+		preferredSymbol := explorePreferredRoutedRefinementSymbol(
+			explorePreferredRefinementSymbol(task, symbolTargets), symbolTargets, routes,
+		)
+		refined, refinement, boundedRoutes, refinedDigest := buildLocalizationRefinementResultForTask(
+			preferredSymbol, task, targets, budget, routes,
+		)
+		if refinement.State != localizationStateNeedsRefinement {
+			s.localizationFor(ctx).keepOpenForTask(task)
+			return refined, nil
+		}
+		s.localizationFor(ctx).armRefinementRoutesForTask(
+			task, refinement.refinementSymbol, refinement.AllowedSymbols, boundedRoutes, refinedDigest,
+		)
 		return refined, nil
 	}
 	completion.digest = digest
@@ -1963,12 +2134,7 @@ type localizationEvidence struct {
 }
 
 func (s *Server) completeEmptyLocalization(ctx context.Context, task string, budget int) *mcp.CallToolResult {
-	completion := localizationCompletion{
-		State:            localizationStateInactive,
-		Scope:            "localization",
-		RequiredAction:   "continue",
-		AllowedToolCalls: 0,
-	}
+	completion := newLocalizationOpenCompletion()
 	// An empty result supersedes any previous task contract but must not arm
 	// answer-ready or an exact-read allowance. Stage the open state so facade
 	// dispatch commits it only after the successful response.
@@ -2397,10 +2563,60 @@ func newLocalizationExploreResultForTask(completion localizationCompletion, task
 }
 
 // buildLocalizationExploreResultForTask returns both the result and the exact
+type localizationCompletionFinalizer func([]string) localizationCompletion
+
+func buildLocalizationRefinementResultForTask(
+	preferredSymbol, task string,
+	targets []exploreTarget,
+	budget int,
+	routes map[string]localizationRefinementRoute,
+) (*mcp.CallToolResult, localizationCompletion, map[string]localizationRefinementRoute, *localizationEvidenceDigest) {
+	open := newLocalizationOpenCompletion()
+	candidateSymbols := exploreLocalizationTargetSymbols(targets)
+	preauthorized, prebounded := boundedLocalizationRefinementRoutes(candidateSymbols, routes, preferredSymbol)
+	if preferredSymbol == "" {
+		result, _, digest := buildLocalizationExploreResultForTask(open, task, targets, budget)
+		return result, open, nil, digest
+	}
+	if _, preferredAuthorized := prebounded[preferredSymbol]; !preferredAuthorized {
+		result, _, digest := buildLocalizationExploreResultForTask(open, task, targets, budget)
+		return result, open, nil, digest
+	}
+
+	// Budget against the largest completion this envelope can expose. The final
+	// allowed set is an equal or smaller intersection with serialized symbols,
+	// so replacing this provisional contract cannot invalidate the byte cap.
+	budgetCompletion := newLocalizationRefinementCompletionForSymbols(preferredSymbol, preauthorized)
+	budgetCompletion.refinementRoutes = prebounded
+	finalCompletion := open
+	var finalRoutes map[string]localizationRefinementRoute
+	result, _, digest := buildLocalizationExploreResultForTask(
+		budgetCompletion, task, targets, budget,
+		func(returnedSymbols []string) localizationCompletion {
+			allowedSymbols, bounded := boundedLocalizationRefinementRoutes(returnedSymbols, routes, preferredSymbol)
+			if _, preferredAuthorized := bounded[preferredSymbol]; !preferredAuthorized {
+				finalRoutes = nil
+				return open
+			}
+			finalRoutes = bounded
+			finalCompletion = newLocalizationRefinementCompletionForSymbols(preferredSymbol, allowedSymbols)
+			finalCompletion.refinementRoutes = bounded
+			return finalCompletion
+		},
+	)
+	return result, finalCompletion, finalRoutes, digest
+}
+
 // bounded symbol projection serialized into it. Refinement authorization uses
 // this projection so every authorized ID is visible and every visible evidence
 // target is authorized without a second ranking or budgeting pass.
-func buildLocalizationExploreResultForTask(completion localizationCompletion, task string, targets []exploreTarget, budget int) (*mcp.CallToolResult, []string, *localizationEvidenceDigest) {
+func buildLocalizationExploreResultForTask(
+	completion localizationCompletion,
+	task string,
+	targets []exploreTarget,
+	budget int,
+	finalize ...localizationCompletionFinalizer,
+) (*mcp.CallToolResult, []string, *localizationEvidenceDigest) {
 	var draft []exploreDraftEntry
 	if strings.TrimSpace(task) != "" {
 		draft = exploreAnswerDraft(task, targets)
@@ -2436,8 +2652,14 @@ func buildLocalizationExploreResultForTask(completion localizationCompletion, ta
 	}
 	// Primary retrieval evidence and the authorized exact/refinement symbol are
 	// both mandatory regardless of which one leads the serialized projection.
-	// Packing operates on a prefix, so retain through the later of the two.
-	for _, mandatoryID := range []string{primarySymbol, requiredSymbol} {
+	// A generic preferred candidate also reserves its one prevalidated concrete
+	// hop, because the route is invalid unless both IDs are visible on the wire.
+	mandatoryIDs := []string{primarySymbol, requiredSymbol}
+	if route, routed := completion.refinementRoutes[requiredSymbol]; routed && route.implementationSymbol != "" {
+		mandatoryIDs = append(mandatoryIDs, route.implementationSymbol)
+	}
+	// Packing operates on a prefix, so retain through the latest mandatory ID.
+	for _, mandatoryID := range mandatoryIDs {
 		if mandatoryID == "" {
 			continue
 		}
@@ -2547,6 +2769,9 @@ func buildLocalizationExploreResultForTask(completion localizationCompletion, ta
 		}
 	}
 
+	if len(finalize) > 0 && finalize[0] != nil {
+		envelope.Completion = finalize[0](append([]string(nil), envelope.Symbols...))
+	}
 	body, err := json.Marshal(envelope)
 	if err != nil {
 		return mcp.NewToolResultError("encode localization result: " + err.Error()), nil, nil
@@ -2772,17 +2997,30 @@ func exploreLocalizableKind(k graph.NodeKind) bool {
 // ringNeighbors filters a traversal result's nodes to real neighbors (not
 // the focus node itself, not param/local/import noise), capped.
 func ringNeighbors(nodes []*graph.Node, selfID string, cap int) []*graph.Node {
+	out, _ := ringNeighborsProjection(nodes, selfID, cap)
+	return out
+}
+
+// ringNeighborsProjection also reports whether every eligible neighbor fit in
+// the projection. Callers can reject uniqueness claims made from a saturated
+// ring without issuing another graph query.
+func ringNeighborsProjection(nodes []*graph.Node, selfID string, cap int) ([]*graph.Node, bool) {
+	if cap < 1 {
+		return nil, false
+	}
 	out := make([]*graph.Node, 0, cap)
+	complete := true
 	for _, n := range nodes {
 		if n == nil || n.ID == selfID || !exploreLocalizableKind(n.Kind) {
 			continue
 		}
-		out = append(out, n)
 		if len(out) >= cap {
-			break
+			complete = false
+			continue
 		}
+		out = append(out, n)
 	}
-	return out
+	return out, complete
 }
 
 // joinNeighbors renders a neighbor ring as "name (path:line), name (path:line)".

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -1832,17 +1832,23 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 		// wins because it is absent from ordinary symbol metadata.
 		preferredSymbol := explorePreferredRefinementSymbol(symbolTargets)
 		completion := newLocalizationRefinementCompletion(preferredSymbol)
-		result, returnedSymbols := buildLocalizationExploreResultForTask(completion, task, targets, budget)
+		result, returnedSymbols, digest := buildLocalizationExploreResultForTask(completion, task, targets, budget)
 		// Authorization is derived from the exact serialized projection, not
 		// the larger pre-budget candidate set. The preferred symbol is mandatory
 		// in that projection and is the only candidate accepted by the session
 		// guard, so the instruction and enforcement cannot diverge.
-		s.localizationFor(ctx).armRefinementForTask(task, preferredSymbol, returnedSymbols)
+		s.localizationFor(ctx).armRefinementForTask(task, preferredSymbol, returnedSymbols, digest)
 		return result, nil
 	}
 	completion := newLocalizationCompletion(answerReady, exactSymbol)
+	// The digest derives from the same serialized projection the host sees,
+	// and is retained for post-terminal replay — for the exact-read contract
+	// too, whose success promotes to answer_ready with the evidence already
+	// stashed.
+	result, _, digest := buildLocalizationExploreResultForTask(completion, task, targets, budget)
+	completion.digest = digest
 	s.localizationFor(ctx).armForTask(completion, task)
-	return newLocalizationExploreResultForTask(completion, task, targets, budget), nil
+	return result, nil
 }
 
 // localizationExploreEnvelope is the compact, machine-readable result for an
@@ -2151,7 +2157,7 @@ func localizationEnvelopeFits(envelope localizationExploreEnvelope, maxBytes int
 }
 
 func newLocalizationExploreResultForTask(completion localizationCompletion, task string, targets []exploreTarget, budget int) *mcp.CallToolResult {
-	result, _ := buildLocalizationExploreResultForTask(completion, task, targets, budget)
+	result, _, _ := buildLocalizationExploreResultForTask(completion, task, targets, budget)
 	return result
 }
 
@@ -2159,7 +2165,7 @@ func newLocalizationExploreResultForTask(completion localizationCompletion, task
 // bounded symbol projection serialized into it. Refinement authorization uses
 // this projection so every authorized ID is visible and every visible evidence
 // target is authorized without a second ranking or budgeting pass.
-func buildLocalizationExploreResultForTask(completion localizationCompletion, task string, targets []exploreTarget, budget int) (*mcp.CallToolResult, []string) {
+func buildLocalizationExploreResultForTask(completion localizationCompletion, task string, targets []exploreTarget, budget int) (*mcp.CallToolResult, []string, *localizationEvidenceDigest) {
 	var draft []exploreDraftEntry
 	if strings.TrimSpace(task) != "" {
 		draft = exploreAnswerDraft(task, targets)
@@ -2294,9 +2300,9 @@ func buildLocalizationExploreResultForTask(completion localizationCompletion, ta
 
 	body, err := json.Marshal(envelope)
 	if err != nil {
-		return mcp.NewToolResultError("encode localization result: " + err.Error()), nil
+		return mcp.NewToolResultError("encode localization result: " + err.Error()), nil, nil
 	}
-	return mcp.NewToolResultText(string(body)), append([]string(nil), envelope.Symbols...)
+	return mcp.NewToolResultText(string(body)), append([]string(nil), envelope.Symbols...), newLocalizationEvidenceDigest(envelope)
 }
 
 func boundedLocalizationNeighborIDs(nodes []*graph.Node, limit int) []string {

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -2786,7 +2786,7 @@ func buildLocalizationRefinementResultForTask(
 				return requested, authorized, bounded
 			}
 		}
-		authorized, bounded = boundedLocalizationRefinementRoutes(symbols, routes, "")
+		_, bounded = boundedLocalizationRefinementRoutes(symbols, routes, "")
 		for _, symbol := range symbols {
 			if _, ok := bounded[symbol]; !ok {
 				continue

--- a/internal/mcp/tools_explore_causal_test.go
+++ b/internal/mcp/tools_explore_causal_test.go
@@ -3,7 +3,6 @@ package mcp
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/query"
@@ -150,27 +149,51 @@ func TestExploreStrongCausalSeedRejectsWeakAndTestParents(t *testing.T) {
 	}
 }
 
-func TestExploreAdmitCausalSeedEnforcesExplicitLimitAndBudget(t *testing.T) {
-	cases := []struct {
-		name                      string
-		concept, explicit, strong bool
-		admitted                  int
-		elapsed                   time.Duration
-		want                      bool
-	}{
-		{name: "admit", concept: true, strong: true, want: true},
-		{name: "explicit", concept: true, explicit: true, strong: true},
-		{name: "non-concept", strong: true},
-		{name: "weak", concept: true},
-		{name: "seed limit", concept: true, strong: true, admitted: exploreCausalSeedLimit},
-		{name: "budget", concept: true, strong: true, elapsed: exploreCausalAdmissionBudget},
+func TestSelectExploreCausalSeedsUsesEvidenceInsteadOfArrivalOrder(t *testing.T) {
+	query := "replacement match sink line terminator"
+	leaves := []exploreTarget{
+		{node: exploreCausalTestNode("path", "configure_replacement_path", "config.rs"), source: "fn configure_replacement_path() { replacement match line terminator }"},
+		{node: exploreCausalTestNode("flag", "select_replacement_match", "flags.rs"), source: "fn select_replacement_match() { replacement match line terminator }"},
+		{node: exploreCausalTestNode("setting", "prepare_replacement_sink", "settings.rs"), source: "fn prepare_replacement_sink() { replacement sink line terminator }"},
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := exploreAdmitCausalSeed(tc.concept, tc.explicit, tc.strong, tc.admitted, tc.elapsed); got != tc.want {
-				t.Fatalf("got %v, want %v", got, tc.want)
-			}
-		})
+	fromMatch := exploreCausalTestNode("from-match", "from_match", "matcher.rs")
+	sunk := exploreCausalTestNode("sunk", "from_sink_match", "sink.rs")
+	targets := append(leaves, exploreTarget{
+		node:    fromMatch,
+		source:  "fn from_match() { if replacement_matches() { Sunk::from_sink_match() } }",
+		callees: []*graph.Node{sunk},
+	})
+
+	selected := selectExploreCausalSeeds(query, targets, true, false)
+	if len(selected) == 0 || selected[0] != len(leaves) {
+		t.Fatalf("cross-file callable route was starved by earlier leaves: selected=%v", selected)
+	}
+	if len(selected) > exploreCausalSeedLimit {
+		t.Fatalf("selected %d seeds, want cap %d", len(selected), exploreCausalSeedLimit)
+	}
+	if got := selectExploreCausalSeeds(query, targets, false, false); len(got) != 0 {
+		t.Fatalf("non-concept task selected causal seeds: %v", got)
+	}
+	if got := selectExploreCausalSeeds(query, targets, true, true); len(got) != 0 {
+		t.Fatalf("explicit target selected causal seeds: %v", got)
+	}
+}
+
+func TestExploreCausalTwoPassReachesSecondHopReplacementImplementation(t *testing.T) {
+	fromMatch := exploreCausalTestNode("from-match", "from_match", "matcher.rs")
+	sunk := exploreCausalTestNode("sunk", "from_sink_match", "sink.rs")
+	replaceAll := exploreCausalTestNode("replace-all", "replace_all", "replacer.rs")
+	sg := &query.SubGraph{
+		Nodes: []*graph.Node{fromMatch, sunk, replaceAll},
+		Edges: []*graph.Edge{
+			{From: fromMatch.ID, To: sunk.ID, Kind: graph.EdgeCalls},
+			{From: sunk.ID, To: replaceAll.ID, Kind: graph.EdgeCalls},
+		},
+	}
+
+	got := causalHopMap(minimumExploreCausalHops(fromMatch.ID, sg, exploreCausalTestScope(), exploreCausalDepth, 15))
+	if got[sunk.ID] != 1 || got[replaceAll.ID] != 2 {
+		t.Fatalf("two-pass causal projection lost replacement route: %v", got)
 	}
 }
 

--- a/internal/mcp/tools_explore_quality_test.go
+++ b/internal/mcp/tools_explore_quality_test.go
@@ -224,14 +224,15 @@ func TestHandleExploreRecallsExactQuotedLiteralFromSQLiteContentFTS(t *testing.T
 	require.True(t, api < 0 || registry < api, "exact body-literal candidate must lead ordinary metadata: %s", text)
 }
 
-func TestHandleExploreLocalizeKeepsEmptyResultNonTerminal(t *testing.T) {
+func TestHandleExploreLocalizeTerminatesEmptyResultAdvisory(t *testing.T) {
 	server := newExploreQualityServer(t)
 	result, text := callExploreQuality(t, server, "find request validation and message routing behavior", true)
 	require.False(t, result.IsError, text)
-	require.Contains(t, text, `"state":""`)
-	require.Contains(t, text, `"required_action":"continue"`)
+	require.Contains(t, text, `"state":"answer_ready"`)
+	require.Contains(t, text, `"required_action":"respond"`)
+	require.Contains(t, text, `"terminal":true`)
 	require.Contains(t, text, `"evidence":[]`)
-	require.Nil(t, server.localization.block("search", "symbols", map[string]any{"query": "better anchor"}))
+	require.NotNil(t, server.localization.block("search", "symbols", map[string]any{"query": "better anchor"}))
 }
 
 func TestHandleExploreLocalizeReturnsBoundedEvidenceWhenConfidenceIsLow(t *testing.T) {
@@ -249,11 +250,13 @@ func TestHandleExploreLocalizeReturnsBoundedEvidenceWhenConfidenceIsLow(t *testi
 	require.False(t, result.IsError, text)
 	var envelope localizationExploreEnvelope
 	require.NoError(t, json.Unmarshal([]byte(text), &envelope))
-	require.Equal(t, localizationStateInactive, envelope.Completion.State)
+	require.Equal(t, localizationStateNeedsRecovery, envelope.Completion.State)
 	require.Empty(t, envelope.Completion.ExactSymbol)
-	require.Equal(t, "continue", envelope.Completion.RequiredAction)
-	require.Zero(t, envelope.Completion.AllowedToolCalls)
+	require.Equal(t, "recover_once", envelope.Completion.RequiredAction)
+	require.Equal(t, 1, envelope.Completion.AllowedToolCalls)
+	require.Equal(t, localizationRecoveryOperations, envelope.Completion.AllowedOperations)
 	require.Empty(t, envelope.Completion.AllowedSymbols)
+	require.False(t, envelope.Terminal)
 	require.NotEmpty(t, envelope.Evidence)
 	require.NotEmpty(t, envelope.Symbols)
 
@@ -263,13 +266,16 @@ func TestHandleExploreLocalizeReturnsBoundedEvidenceWhenConfidenceIsLow(t *testi
 	preferred := terminal.refinementSymbol
 	authorized := append([]string(nil), terminal.refinementSymbols...)
 	terminal.mu.Unlock()
-	require.Equal(t, localizationStateInactive, state)
+	require.Equal(t, localizationStateNeedsRecovery, state)
 	require.Empty(t, preferred)
 	require.Empty(t, authorized)
-	require.Nil(t, terminal.block("search", "symbols", map[string]any{"query": "locale formatter"}))
-	candidateRead := map[string]any{"target": map[string]any{"symbol": envelope.Symbols[0]}}
-	blocked, reserved := terminal.authorize("read", "source", candidateRead)
+	blocked, reserved := terminal.authorize("search", "symbols", map[string]any{"query": "locale formatter"})
 	require.Nil(t, blocked)
+	require.True(t, reserved)
+	require.Equal(t, localizationStateAnswerReady, terminal.finishReservedRead(true).State)
+	candidateRead := map[string]any{"target": map[string]any{"symbol": envelope.Symbols[0]}}
+	blocked, reserved = terminal.authorize("read", "source", candidateRead)
+	require.NotNil(t, blocked)
 	require.False(t, reserved)
 }
 

--- a/internal/mcp/tools_explore_quality_test.go
+++ b/internal/mcp/tools_explore_quality_test.go
@@ -392,7 +392,7 @@ func TestHandleExploreLocalizeReturnsBoundedEvidenceWhenConfidenceIsLow(t *testi
 	require.Equal(t, localizationStateNeedsRecovery, state)
 	require.Empty(t, preferred)
 	require.Empty(t, authorized)
-	blocked, reserved := terminal.authorize("search", "symbols", map[string]any{"query": "locale formatter"})
+	blocked, reserved := terminal.authorize("search", "symbols", map[string]any{"query": "culture route"})
 	require.Nil(t, blocked)
 	require.True(t, reserved)
 	require.Equal(t, localizationStateAnswerReady, terminal.finishReservedRead(true).State)

--- a/internal/mcp/tools_explore_quality_test.go
+++ b/internal/mcp/tools_explore_quality_test.go
@@ -60,6 +60,129 @@ func TestRerankExploreConceptCoveragePromotesConjunctiveImplementation(t *testin
 	}
 }
 
+func TestRerankExploreConceptCoverageCrossesGenericVectorPathCollision(t *testing.T) {
+	pathSetter := &rerank.Candidate{
+		Node: &graph.Node{
+			ID: "builder-path", Name: "path", QualName: "StandardBuilder.path",
+			Kind: graph.KindMethod, FilePath: "src/builder.rs",
+			Meta: map[string]any{"signature": "fn path(&mut self, path: &Path)"},
+		},
+		TextRank: 0, VectorRank: 0, Score: 9,
+	}
+	matchedIgnore := &rerank.Candidate{
+		Node: &graph.Node{
+			ID: "matched-ignore", Name: "matched_ignore", QualName: "Ignore.matched_ignore",
+			Kind: graph.KindMethod, FilePath: "src/dir.rs",
+			Meta: map[string]any{"signature": "fn matched_ignore(&self, path: &Path)"},
+		},
+		TextRank: 9, VectorRank: 7, Score: 1,
+	}
+	got := rerankExploreConceptCoverage(shapeExploreQuery(exploreLongIgnoreTask), []*rerank.Candidate{pathSetter, matchedIgnore})
+	require.Same(t, matchedIgnore, got[0], "two-concept callable must cross a generic one-token vector collision")
+}
+
+func TestExploreConceptTermPresentUsesBoundedInflections(t *testing.T) {
+	require.True(t, exploreConceptTermPresent("ignore.matched_ignore", "matching"),
+		"query prose and declaration tense should align")
+	require.True(t, exploreConceptTermPresent("matcher matching rules", "matched"),
+		"the inverse tense should align as well")
+	require.False(t, exploreConceptTermPresent("tree.Builder", "building"),
+		"a raw grammatical stem must not match a longer unrelated identifier")
+}
+
+func TestDiversifyRepeatedExploreNamesPreservesLegitimateShortCallables(t *testing.T) {
+	readA := &rerank.Candidate{Node: &graph.Node{ID: "reader-a", Name: "read", Kind: graph.KindMethod}}
+	readB := &rerank.Candidate{Node: &graph.Node{ID: "reader-b", Name: "read", Kind: graph.KindMethod}}
+	emitA := &rerank.Candidate{Node: &graph.Node{ID: "emitter-a", Name: "emit", Kind: graph.KindMethod}}
+	emitB := &rerank.Candidate{Node: &graph.Node{ID: "emitter-b", Name: "emit", Kind: graph.KindMethod}}
+	other := &rerank.Candidate{Node: &graph.Node{ID: "other", Name: "dispatch", Kind: graph.KindMethod}}
+	input := []*rerank.Candidate{readA, readB, emitA, emitB, other}
+
+	got := diversifyRepeatedExploreNames(append([]*rerank.Candidate(nil), input...), rerank.QueryClassConcept)
+	require.Equal(t, input, got, "identifier length alone must not demote valid overload or receiver families")
+}
+
+func TestStrongSourceLiteralPromotionPreservesDivergentDefaultProof(t *testing.T) {
+	owner := exploreTarget{
+		node:                  &graph.Node{ID: "child.cs::.ctor", Name: ".ctor", Kind: graph.KindMethod, FilePath: "child.cs"},
+		source:                "Child() { mode = Disabled; }",
+		divergentDefaultOwner: true,
+	}
+	typeEvidence := exploreTarget{
+		node:                 &graph.Node{ID: "child.cs::Child", Name: "Child", Kind: graph.KindType, FilePath: "child.cs"},
+		divergentDefaultType: true,
+	}
+	literal := exploreTarget{
+		node:                &graph.Node{ID: "registry.cs::Register", Name: "Register", Kind: graph.KindMethod, FilePath: "registry.cs"},
+		source:              "void Register() { Add(\"value\"); }",
+		exactContent:        true,
+		sourceLiteral:       true,
+		sourceLiteralCallee: true,
+	}
+	input := []exploreTarget{owner, typeEvidence, literal}
+
+	got := promoteExploreStrongSourceLiteralTarget(input)
+	require.Equal(t, input, got, "a literal consumer must not displace a proven divergent-default cause")
+}
+
+func TestRerankExploreConceptCoverageDropsTermsPresentInMoreThanOneThird(t *testing.T) {
+	decoy := &rerank.Candidate{
+		Node: &graph.Node{
+			ID: "path-dispatch", Name: "path_dispatch", Kind: graph.KindMethod,
+			Meta: map[string]any{"doc": "Dispatch ownership for a path."},
+		},
+		TextRank: 0, VectorRank: 0, Score: 9,
+	}
+	implementation := &rerank.Candidate{
+		Node: &graph.Node{
+			ID: "matched-rule", Name: "matched_rule", Kind: graph.KindMethod,
+			Meta: map[string]any{
+				"signature": "fn matched_rule(path: &Path)",
+				"doc":       "Match ancestor ownership rules.",
+			},
+		},
+		TextRank: 7, VectorRank: 7, Score: 1,
+	}
+	fillerA := &rerank.Candidate{Node: &graph.Node{ID: "cache", Name: "cache", Kind: graph.KindType}, TextRank: 8, VectorRank: 8}
+	fillerB := &rerank.Candidate{Node: &graph.Node{ID: "clock", Name: "clock", Kind: graph.KindType}, TextRank: 9, VectorRank: 9}
+
+	got := rerankExploreConceptCoverage(
+		"where does the path matching ancestor rule ownership behavior live",
+		[]*rerank.Candidate{decoy, implementation, fillerA, fillerB},
+	)
+	require.Same(t, implementation, got[0], "a term present in two of four candidates must not manufacture a second decoy concept")
+}
+
+func TestRerankExploreConceptCoverageRespectsSemanticBarriers(t *testing.T) {
+	weak := &rerank.Candidate{
+		Node:     &graph.Node{ID: "weak", Name: "request", Kind: graph.KindVariable},
+		TextRank: 0, VectorRank: 0,
+	}
+	medium := &rerank.Candidate{
+		Node:     &graph.Node{ID: "medium", Name: "DispatchRouting", Kind: graph.KindType},
+		TextRank: 1, VectorRank: 1,
+	}
+	strong := &rerank.Candidate{
+		Node: &graph.Node{
+			ID: "strong", Name: "routeRequest", Kind: graph.KindMethod,
+			Meta: map[string]any{"doc": "Dispatch and route each request."},
+		},
+		TextRank: 2, VectorRank: 2,
+	}
+	fillerA := &rerank.Candidate{Node: &graph.Node{ID: "clock", Name: "clock", Kind: graph.KindType}, TextRank: 3, VectorRank: 3}
+	fillerB := &rerank.Candidate{Node: &graph.Node{ID: "cache", Name: "cache", Kind: graph.KindType}, TextRank: 4, VectorRank: 4}
+	fillerC := &rerank.Candidate{Node: &graph.Node{ID: "queue", Name: "queue", Kind: graph.KindType}, TextRank: 5, VectorRank: 5}
+	query := "where does the request dispatch routing behavior happen in code"
+
+	barrier := rerankExploreConceptCoverage(query, []*rerank.Candidate{weak, medium, strong, fillerA, fillerB, fillerC})
+	require.Equal(t, []*rerank.Candidate{weak, medium, strong}, barrier[:3],
+		"a conjunctive callable must not cross a multi-concept semantic peer")
+
+	adjacent := rerankExploreConceptCoverage(query, []*rerank.Candidate{medium, weak, strong, fillerA, fillerB, fillerC})
+	require.Equal(t, []*rerank.Candidate{medium, strong, weak}, adjacent[:3],
+		"a conjunctive callable may cross an adjacent one-concept collision")
+}
+
 func TestRerankExploreConceptCoveragePromotesBoundedBodyLiteral(t *testing.T) {
 	metadataHit := &rerank.Candidate{
 		Node:     &graph.Node{ID: "api", Name: "convert", Kind: graph.KindMethod, FilePath: "api.go"},

--- a/internal/mcp/tools_explore_quality_test.go
+++ b/internal/mcp/tools_explore_quality_test.go
@@ -240,32 +240,28 @@ func TestHandleExploreLocalizeReturnsBoundedEvidenceWhenConfidenceIsLow(t *testi
 	require.False(t, result.IsError, text)
 	var envelope localizationExploreEnvelope
 	require.NoError(t, json.Unmarshal([]byte(text), &envelope))
-	require.Equal(t, localizationStateNeedsRefinement, envelope.Completion.State)
+	require.Equal(t, localizationStateInactive, envelope.Completion.State)
 	require.Empty(t, envelope.Completion.ExactSymbol)
-	require.NotContains(t, envelope.Completion.RequiredAction, "<candidate.id>")
-	require.Equal(t, 1, envelope.Completion.AllowedToolCalls)
+	require.Equal(t, "continue", envelope.Completion.RequiredAction)
+	require.Zero(t, envelope.Completion.AllowedToolCalls)
+	require.Empty(t, envelope.Completion.AllowedSymbols)
 	require.NotEmpty(t, envelope.Evidence)
 	require.NotEmpty(t, envelope.Symbols)
-	for _, evidence := range envelope.Evidence {
-		require.Empty(t, evidence.Source, "refinement evidence must not duplicate the authorized source read")
-	}
 
 	terminal := server.localizationFor(context.Background())
 	terminal.mu.Lock()
+	state := terminal.state
 	preferred := terminal.refinementSymbol
 	authorized := append([]string(nil), terminal.refinementSymbols...)
 	terminal.mu.Unlock()
-	require.NotEmpty(t, preferred)
-	require.Contains(t, envelope.Symbols, preferred)
-	require.Contains(t, envelope.Completion.RequiredAction, preferred)
-	require.Equal(t, envelope.Symbols, authorized, "only serialized evidence IDs may be refined")
-	require.NotNil(t, terminal.block("search", "symbols", map[string]any{"query": "locale formatter"}))
-	candidateRead := map[string]any{"target": map[string]any{"symbol": preferred}}
+	require.Equal(t, localizationStateInactive, state)
+	require.Empty(t, preferred)
+	require.Empty(t, authorized)
+	require.Nil(t, terminal.block("search", "symbols", map[string]any{"query": "locale formatter"}))
+	candidateRead := map[string]any{"target": map[string]any{"symbol": envelope.Symbols[0]}}
 	blocked, reserved := terminal.authorize("read", "source", candidateRead)
 	require.Nil(t, blocked)
-	require.True(t, reserved)
-	terminal.finishReservedRead(true)
-	require.NotNil(t, terminal.block("search", "symbols", map[string]any{"query": "another search"}))
+	require.False(t, reserved)
 }
 
 func TestHandleExploreLocalizeAcceptsVerifiedLiteralAndExplicitSymbol(t *testing.T) {

--- a/internal/mcp/tools_explore_quality_test.go
+++ b/internal/mcp/tools_explore_quality_test.go
@@ -32,6 +32,15 @@ func TestExploreQuotedRecallTermsPreservesShortSignalAndDropsPatterns(t *testing
 	}
 }
 
+func TestExploreQuotedRecallTermsGatesTwoLetterAnchorsByIntent(t *testing.T) {
+	require.Equal(t, []string{"ku"}, exploreQuotedRecallTerms(`find where culture "ku" is registered`))
+	require.Equal(t, []string{"go"}, exploreQuotedRecallTerms(`find the language code "go" fallback`))
+	require.Empty(t, exploreQuotedRecallTerms(`fix wording around "ku" in this comment`))
+	require.Empty(t, exploreQuotedRecallTerms(`find a mention of "it"`))
+	require.Equal(t, []string{"tenant-code"}, exploreQuotedRecallTerms(`find "tenant-code"`),
+		"longer explicit literals must remain independent of the short-anchor gate")
+}
+
 func TestRerankExploreConceptCoveragePromotesConjunctiveImplementation(t *testing.T) {
 	generic := &rerank.Candidate{
 		Node:     &graph.Node{ID: "generic", Name: "validate", Kind: graph.KindVariable, FilePath: "config.go"},
@@ -235,7 +244,7 @@ func TestHandleExploreLocalizeReturnsBoundedEvidenceWhenConfidenceIsLow(t *testi
 	}}))
 	require.NoError(t, store.BuildContentIndex())
 
-	result, text := callExploreQuality(t, server, `find "ku" behavior`, true)
+	result, text := callExploreQuality(t, server, `find culture "ku" behavior`, true)
 
 	require.False(t, result.IsError, text)
 	var envelope localizationExploreEnvelope

--- a/internal/mcp/tools_explore_rust_quality_test.go
+++ b/internal/mcp/tools_explore_rust_quality_test.go
@@ -1,0 +1,137 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+	"github.com/zzet/gortex/internal/query"
+)
+
+func newIndexedRustLocalizationServer(t *testing.T) func() *Server {
+	t.Helper()
+
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "src"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "src", "dir.rs"), []byte(`
+pub struct Ignore;
+impl Ignore {
+    pub fn matched_ignore(&self, path: &Path) -> bool {
+        if path == Path::new(".") {
+            return self.match_path(path);
+        }
+        self.match_path(path) || self.add_parents(path)
+    }
+
+    fn match_path(&self, path: &Path) -> bool { path.is_relative() }
+    fn add_parents(&self, path: &Path) -> bool { path.parent().is_some() }
+}
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "src", "builder.rs"), []byte(`
+pub struct StandardBuilder;
+pub struct SummaryBuilder;
+pub struct WalkBuilder;
+
+impl StandardBuilder { pub fn path(&self, path: &Path) -> bool { path.exists() } }
+impl SummaryBuilder { pub fn path(&self, path: &Path) -> bool { path.exists() } }
+impl WalkBuilder {
+    pub fn path(&self, path: &Path) -> bool { self.parents(path) }
+    fn parents(&self, path: &Path) -> bool { self.ancestors(path) }
+    fn ancestors(&self, path: &Path) -> bool { path.parent().is_some() }
+}
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "src", "paths.rs"), []byte(`
+pub struct Paths;
+pub struct HiArgs;
+
+impl Paths {
+    pub fn path(&self, path: &Path) -> bool { path.exists() }
+    pub fn has_implicit_path(&self) -> bool { false }
+    pub fn from_patterns(&self, patterns: &[String]) -> bool { !patterns.is_empty() }
+}
+impl HiArgs {
+    pub fn no_ignore_files(&self) -> bool { false }
+    pub fn no_ignore_exclude(&self) -> bool { false }
+    pub fn explicit_path(&self, path: &Path) -> bool { path.exists() }
+}
+`), 0o644))
+
+	store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "graph.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	registry := parser.NewRegistry()
+	registry.Register(languages.NewRustExtractor())
+	idx := indexer.New(store, registry, config.IndexConfig{Workers: 1}, zap.NewNop())
+	idx.SetRepoPrefix("rust-fixture")
+	idx.SetWorkspaceID("rust-fixture")
+	idx.SetProjectID("rust-fixture")
+	_, err = idx.IndexCtx(context.Background(), root)
+	require.NoError(t, err)
+
+	return func() *Server {
+		engine := query.NewEngine(store)
+		engine.SetSearchProvider(idx.Search)
+		return NewServer(engine, store, idx, nil, zap.NewNop(), nil)
+	}
+}
+
+func callIndexedRustLocalization(t *testing.T, server *Server, task string) localizationExploreEnvelope {
+	t.Helper()
+
+	request := mcpgo.CallToolRequest{}
+	request.Params.Arguments = map[string]any{
+		"task":          task,
+		"localize":      true,
+		"max_symbols":   5,
+		"token_budget":  1600,
+		"repository_id": "rust-fixture",
+	}
+	result, err := server.handleExplore(context.Background(), request)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.NotEmpty(t, result.Content)
+
+	text, ok := result.Content[0].(mcpgo.TextContent)
+	require.True(t, ok)
+	var envelope localizationExploreEnvelope
+	require.NoError(t, json.Unmarshal([]byte(text.Text), &envelope))
+	return envelope
+}
+
+func TestIndexedRustLocalizationRetainsMatchedIgnoreForShortAndLongParaphrases(t *testing.T) {
+	newServer := newIndexedRustLocalizationServer(t)
+	tests := []struct {
+		name string
+		task string
+	}{
+		{name: "short", task: "Find the callable that matches ancestor ignore rules for an explicit dot path."},
+		{name: "long", task: exploreLongIgnoreTask},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			envelope := callIndexedRustLocalization(t, newServer(), tt.task)
+			found := false
+			for _, evidence := range envelope.Evidence {
+				if evidence.Name == "matched_ignore" && filepath.Base(evidence.File) == "dir.rs" {
+					found = true
+					break
+				}
+			}
+			require.True(t, found, "expected matched_ignore in dir.rs, got %#v", envelope.Evidence)
+			require.NotEqual(t, "continue", envelope.Completion.RequiredAction)
+		})
+	}
+}

--- a/internal/mcp/tools_explore_rust_quality_test.go
+++ b/internal/mcp/tools_explore_rust_quality_test.go
@@ -123,6 +123,7 @@ func TestIndexedRustLocalizationRetainsMatchedIgnoreForShortAndLongParaphrases(t
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			envelope := callIndexedRustLocalization(t, newServer(), tt.task)
+			require.LessOrEqual(t, len(envelope.Evidence), 5, "max_symbols must bound owner-folded evidence")
 			found := false
 			for _, evidence := range envelope.Evidence {
 				if evidence.Name == "matched_ignore" && filepath.Base(evidence.File) == "dir.rs" {

--- a/internal/mcp/tools_explore_rust_typed_anchor_e2e_test.go
+++ b/internal/mcp/tools_explore_rust_typed_anchor_e2e_test.go
@@ -1,0 +1,174 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+	"github.com/zzet/gortex/internal/query"
+)
+
+func newIndexedRustTypedAnchorLocalizationServer(t *testing.T) *Server {
+	t.Helper()
+
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "src"), 0o755))
+	files := map[string]string{
+		"lib.rs": `
+pub mod duplicate_output;
+pub mod line_buffer;
+pub mod multiline_printer;
+pub mod repeated_match;
+pub mod replacement_span;
+pub mod same_match;
+pub mod standard;
+pub mod util;
+`,
+		"util.rs": `
+pub struct Replacer<M> {
+    matcher: M,
+}
+
+impl<M> Replacer<M> {
+    pub fn replace_all(&mut self, haystack: &[u8], replacement: &[u8]) -> Vec<u8> {
+        let _ = (&self.matcher, replacement);
+        haystack.to_vec()
+    }
+}
+`,
+		"standard.rs": `
+use crate::util::Replacer;
+
+pub struct DefaultMatcher;
+pub struct StandardSink {
+    /// Applies one replacement to a multiline match without duplicate output.
+    replacer: Replacer<DefaultMatcher>,
+    replacement: Vec<u8>,
+}
+
+impl StandardSink {
+    pub fn replace(&mut self, bytes: &[u8]) -> Vec<u8> {
+        self.replacer.replace_all(bytes, &self.replacement)
+    }
+
+    pub fn print_match(&self, bytes: &[u8]) -> bool {
+        !bytes.is_empty()
+    }
+}
+`,
+		"line_buffer.rs": `
+pub fn replace_bytes(bytes: &[u8]) -> Vec<u8> { bytes.to_vec() }
+pub fn multiline_match(bytes: &[u8]) -> bool { bytes.contains(&b'\n') }
+pub fn print_matching_line(bytes: &[u8]) -> bool { !bytes.is_empty() }
+pub fn duplicate_match(bytes: &[u8]) -> Vec<u8> { bytes.to_vec() }
+pub fn replacement_for_match(bytes: &[u8]) -> Vec<u8> { bytes.to_vec() }
+pub fn match_across_lines(bytes: &[u8]) -> bool { bytes.windows(2).any(|w| w == b"\n\n") }
+`,
+		"duplicate_output.rs": `
+pub fn prevent_duplicate_output_for_multiline_match(bytes: &[u8]) -> bool { !bytes.is_empty() }
+`,
+		"multiline_printer.rs": `
+pub fn print_multiline_match_once(bytes: &[u8]) -> bool { !bytes.is_empty() }
+`,
+		"repeated_match.rs": `
+pub fn avoid_printing_same_match_multiple_times(bytes: &[u8]) -> bool { !bytes.is_empty() }
+`,
+		"replacement_span.rs": `
+pub fn replace_match_spanning_multiple_lines(bytes: &[u8]) -> Vec<u8> { bytes.to_vec() }
+`,
+		"same_match.rs": `
+pub fn printer_repeats_same_match(bytes: &[u8]) -> bool { !bytes.is_empty() }
+`,
+	}
+	for name, content := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(root, "src", name), []byte(content), 0o644))
+	}
+
+	store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "graph.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	registry := parser.NewRegistry()
+	registry.Register(languages.NewRustExtractor())
+	idx := indexer.New(store, registry, config.IndexConfig{Workers: 1}, zap.NewNop())
+	idx.SetRepoPrefix("rust-fixture")
+	idx.SetWorkspaceID("rust-fixture")
+	idx.SetProjectID("rust-fixture")
+	_, err = idx.IndexCtx(context.Background(), root)
+	require.NoError(t, err)
+
+	engine := query.NewEngine(store)
+	engine.SetSearchProvider(idx.Search)
+	return NewServer(engine, store, idx, nil, zap.NewNop(), nil)
+}
+
+func callIndexedRustTypedAnchorLocalization(t *testing.T, server *Server, task string, maxSymbols int) localizationExploreEnvelope {
+	t.Helper()
+
+	request := mcpgo.CallToolRequest{}
+	request.Params.Arguments = map[string]any{
+		"task":          task,
+		"localize":      true,
+		"max_symbols":   maxSymbols,
+		"token_budget":  1600,
+		"repository_id": "rust-fixture",
+	}
+	result, err := server.handleExplore(context.Background(), request)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.NotEmpty(t, result.Content)
+
+	text, ok := result.Content[0].(mcpgo.TextContent)
+	require.True(t, ok)
+	var envelope localizationExploreEnvelope
+	require.NoError(t, json.Unmarshal([]byte(text.Text), &envelope))
+	return envelope
+}
+
+func TestIndexedRustLocalizationProjectsTypedAnchorThroughFinalEnvelope(t *testing.T) {
+	const (
+		maxSymbols = 10
+		task       = "--multiline with --replace causes duplicate output when a match spans multiple lines and printer prints the same match multiple times"
+	)
+	server := newIndexedRustTypedAnchorLocalizationServer(t)
+	const (
+		memberID = "rust-fixture/src/util.rs::Replacer<M>.replace_all"
+		ownerID  = "rust-fixture/src/util.rs::Replacer"
+	)
+	var memberOfTargets []string
+	for _, edge := range server.graph.GetOutEdges(memberID) {
+		if edge.Kind == graph.EdgeMemberOf {
+			memberOfTargets = append(memberOfTargets, edge.To)
+		}
+	}
+	require.Equal(t, []string{ownerID}, memberOfTargets)
+	require.NotNil(t, server.graph.GetNode(ownerID), "generic impl member_of target must resolve to the bare declaration")
+
+	envelope := callIndexedRustTypedAnchorLocalization(t, server, task, maxSymbols)
+
+	require.LessOrEqual(t, len(envelope.Evidence), maxSymbols, "max_symbols must bound the packed evidence: %#v", envelope.Evidence)
+	require.LessOrEqual(t, len(envelope.Symbols), maxSymbols, "max_symbols must bound the symbol projection: %#v", envelope.Symbols)
+
+	found := false
+	for _, evidence := range envelope.Evidence {
+		if filepath.Base(evidence.File) != "util.rs" || evidence.Name != "replace_all" {
+			continue
+		}
+		found = true
+		require.Equal(t, localizationProvenanceTypedAnchorProjection, evidence.Provenance, "expected projected evidence, got %#v", envelope.Evidence)
+		break
+	}
+	require.True(t, found, "expected typed-anchor projection to retain util.rs::replace_all, got %#v", envelope.Evidence)
+}

--- a/internal/mcp/tools_explore_shape_test.go
+++ b/internal/mcp/tools_explore_shape_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 )
 
+const exploreLongIgnoreTask = `Hidden files whitelisted by an ancestor .ignore file are not searched when "." is passed as the directory argument to ripgrep (but are found when no argument is given, or "./." is given). This relates to how paths are canonicalized/parsed and how the ignore/ancestor-parent logic determines the "root" for computing ancestor .ignore whitelist rules, likely in the ignore crate's directory traversal or the path argument handling in core (hiargs/paths). Need the exact file/function responsible for treating "." specially versus other paths when building parents/ancestors for gitignore matching.`
+
 // TestShapeExploreQuery_DistilsReport locks the report-distillation behavior:
 // a pasted issue (a title, then a body of repro commands, template prompts and
 // an environment table) is reduced to its retrieval signal — the lead weighted,
@@ -52,6 +54,24 @@ func TestShapeExploreQuery_PassThrough(t *testing.T) {
 	} {
 		if got := shapeExploreQuery(q); got != q {
 			t.Errorf("focused query altered:\n in:  %q\n out: %q", q, got)
+		}
+	}
+}
+
+func TestShapeExploreQueryWeightsLongSingleLineAndRetainsLateConcepts(t *testing.T) {
+	got := shapeExploreQuery(exploreLongIgnoreTask)
+	lead := inlineLeadClause(exploreLongIgnoreTask)
+	if lead == "" || strings.Count(got, lead) != 2 {
+		t.Fatalf("long inline lead not weighted exactly once: lead=%q query=%q", lead, got)
+	}
+	terms := exploreConceptRecallTerms(got)
+	seen := make(map[string]bool, len(terms))
+	for _, term := range terms {
+		seen[term] = true
+	}
+	for _, term := range []string{"ignore", "path", "parent", "gitignore", "matching"} {
+		if !seen[term] {
+			t.Fatalf("late/repeated concept %q was lost from bounded terms %v", term, terms)
 		}
 	}
 }

--- a/internal/mcp/tools_explore_source_preservation_test.go
+++ b/internal/mcp/tools_explore_source_preservation_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -183,6 +184,39 @@ func TestMergeExploreCandidatesPreservesSourceLiteralSignalThroughDedupe(t *test
 	require.Equal(t, float64(2), merged[0].Signals[exploreSourceLiteralCoverageSignal])
 	require.Zero(t, primarySignals[exploreSourceLiteralSignal], "request-local evidence must not mutate an input candidate")
 	require.Zero(t, primarySignals[exploreSourceLiteralCoverageSignal], "coverage evidence must remain request-local")
+}
+
+func TestReserveExploreConceptImplementationHandlesMoreThanInlineTermCapacity(t *testing.T) {
+	terms := make([]string, 65)
+	for i := range terms {
+		terms[i] = fmt.Sprintf("term%c%c", 'a'+rune(i/26), 'a'+rune(i%26))
+	}
+	primary := sourcePreservationCandidate("primary", 0, 0)
+	targetName := terms[0] + "_" + terms[1]
+	target := &rerank.Candidate{Node: &graph.Node{
+		ID:       "demo/worker.go::" + targetName,
+		Name:     targetName,
+		QualName: "demo." + targetName,
+		Kind:     graph.KindFunction,
+		FilePath: "demo/worker.go",
+	}}
+	candidates := []*rerank.Candidate{
+		primary,
+		sourcePreservationCandidate("secondary", 1, 0),
+		target,
+	}
+
+	got, protected := reserveExploreConceptImplementation(
+		strings.Join(terms, " "),
+		rerank.QueryClassConcept,
+		candidates,
+		2,
+	)
+
+	require.Len(t, got, len(candidates))
+	require.Same(t, primary, got[0], "reservation must preserve the semantic head")
+	require.Same(t, target, got[1], "the callable matching long-query terms must be reserved")
+	require.Equal(t, target.Node.ID, protected)
 }
 
 func TestExploreAnswerReadyKeepsQuotedNonExactConceptNonTerminal(t *testing.T) {

--- a/internal/mcp/tools_explore_source_preservation_test.go
+++ b/internal/mcp/tools_explore_source_preservation_test.go
@@ -37,6 +37,70 @@ func TestLimitExploreCandidatesPreservingSourceLiteralReservesOneFullCapSlot(t *
 	require.NotNil(t, candidateByID(bounded, "source"))
 }
 
+func TestLimitExploreCandidatesPreservingSourceLiteralPrefersMultiAnchorOwner(t *testing.T) {
+	multi := sourcePreservationCandidate("multi-anchor", 90, 0.25)
+	multi.Signals[exploreSourceLiteralCoverageSignal] = 2
+	single := sourcePreservationCandidate("single-anchor", 80, 1)
+	single.Signals[exploreSourceLiteralCoverageSignal] = 1
+	candidates := []*rerank.Candidate{
+		sourcePreservationCandidate("primary-0", 0, 0),
+		sourcePreservationCandidate("primary-1", 1, 0),
+		single,
+		multi,
+	}
+
+	bounded := limitExploreCandidatesPreservingSourceLiteral(candidates, 2)
+
+	require.Len(t, bounded, 2)
+	require.NotNil(t, candidateByID(bounded, multi.Node.ID))
+	require.Nil(t, candidateByID(bounded, single.Node.ID), "a two-slot window preserves its semantic head plus the multi-anchor owner")
+}
+
+func TestSelectFinalExploreCandidatesReservesOnlyOneAmbiguousSingleAnchorOwner(t *testing.T) {
+	first := sourcePreservationCandidate("ambiguous-a", 80, 1)
+	first.Signals[exploreSourceLiteralCoverageSignal] = 1
+	first.Signals[exploreContentRecallAmbiguousSignal] = 1
+	second := sourcePreservationCandidate("ambiguous-b", 90, 0.5)
+	second.Signals[exploreSourceLiteralCoverageSignal] = 1
+	second.Signals[exploreContentRecallAmbiguousSignal] = 1
+	prod := []*rerank.Candidate{
+		sourcePreservationCandidate("primary-0", 0, 0),
+		sourcePreservationCandidate("primary-1", 1, 0),
+		sourcePreservationCandidate("primary-2", 2, 0),
+		first,
+		second,
+	}
+
+	selected := selectFinalExploreCandidates(prod, nil, 3)
+
+	require.Len(t, selected, 3)
+	require.Equal(t, "primary-0", selected[0].Node.ID)
+	require.NotNil(t, candidateByID(selected, first.Node.ID))
+	require.Nil(t, candidateByID(selected, second.Node.ID))
+	require.NotNil(t, candidateByID(selected, "primary-1"), "ambiguous collision evidence must not consume both reserve slots")
+}
+
+func TestSelectFinalExploreCandidatesReservesTwoSourceOwnersWhenCapacityAllows(t *testing.T) {
+	multi := sourcePreservationCandidate("multi-anchor", 90, 0.25)
+	multi.Signals[exploreSourceLiteralCoverageSignal] = 2
+	single := sourcePreservationCandidate("single-anchor", 80, 1)
+	single.Signals[exploreSourceLiteralCoverageSignal] = 1
+	prod := []*rerank.Candidate{
+		sourcePreservationCandidate("primary-0", 0, 0),
+		sourcePreservationCandidate("primary-1", 1, 0),
+		sourcePreservationCandidate("primary-2", 2, 0),
+		single,
+		multi,
+	}
+
+	selected := selectFinalExploreCandidates(prod, nil, 3)
+
+	require.Len(t, selected, 3)
+	require.Equal(t, multi.Node.ID, selected[0].Node.ID)
+	require.NotNil(t, candidateByID(selected, single.Node.ID))
+	require.NotNil(t, candidateByID(selected, "primary-0"), "bounded reservation must retain the semantic head")
+}
+
 func TestSelectFinalExploreCandidatesPreservesSourceLiteralAfterRerank(t *testing.T) {
 	prod := []*rerank.Candidate{
 		sourcePreservationCandidate("primary-0", 0, 0),
@@ -108,13 +172,17 @@ func TestMergeExploreCandidatesPreservesSourceLiteralSignalThroughDedupe(t *test
 	primarySignals := map[string]float64{"ordinary": 1}
 	merged := mergeExploreCandidates(
 		[]*rerank.Candidate{{Node: node, TextRank: 0, VectorRank: -1, Signals: primarySignals}},
-		[]*rerank.Candidate{{Node: node, TextRank: 9, VectorRank: -1, Signals: map[string]float64{exploreSourceLiteralSignal: 0.5}}},
+		[]*rerank.Candidate{{Node: node, TextRank: 9, VectorRank: -1, Signals: map[string]float64{
+			exploreSourceLiteralSignal: 0.5, exploreSourceLiteralCoverageSignal: 2,
+		}}},
 		20,
 	)
 
 	require.Len(t, merged, 1)
 	require.Equal(t, 0.5, merged[0].Signals[exploreSourceLiteralSignal])
+	require.Equal(t, float64(2), merged[0].Signals[exploreSourceLiteralCoverageSignal])
 	require.Zero(t, primarySignals[exploreSourceLiteralSignal], "request-local evidence must not mutate an input candidate")
+	require.Zero(t, primarySignals[exploreSourceLiteralCoverageSignal], "coverage evidence must remain request-local")
 }
 
 func TestExploreAnswerReadyKeepsQuotedNonExactConceptNonTerminal(t *testing.T) {

--- a/internal/mcp/tools_explore_source_preservation_test.go
+++ b/internal/mcp/tools_explore_source_preservation_test.go
@@ -81,6 +81,69 @@ func TestSelectFinalExploreCandidatesReservesOnlyOneAmbiguousSingleAnchorOwner(t
 	require.NotNil(t, candidateByID(selected, "primary-1"), "ambiguous collision evidence must not consume both reserve slots")
 }
 
+func TestSelectFinalExploreCandidatesPrefersTaskAlignedAmbiguousCallee(t *testing.T) {
+	generic := sourcePreservationCandidate("generic-register", 10, 1)
+	generic.Node.Name = "Register"
+	generic.Signals[exploreSourceLiteralCoverageSignal] = 1
+	generic.Signals[exploreContentRecallAmbiguousSignal] = 1
+	generic.Signals[exploreSourceLiteralCalleeSignal] = 1
+	specific := sourcePreservationCandidate("specific-register", 20, 0.5)
+	specific.Node.Name = "RegisterDefaultFormatter"
+	specific.Node.Language = "rust"
+	specific.Node.FilePath = "src/registry.rs"
+	specific.Signals[exploreSourceLiteralCoverageSignal] = 1
+	specific.Signals[exploreContentRecallAmbiguousSignal] = 1
+	specific.Signals[exploreSourceLiteralCalleeSignal] = 1
+	specific.Signals[exploreSourceLiteralTaskAlignSignal] = 1
+	third := sourcePreservationCandidate("third-register", 30, 0.25)
+	third.Signals[exploreSourceLiteralCoverageSignal] = 1
+	third.Signals[exploreContentRecallAmbiguousSignal] = 1
+	third.Signals[exploreSourceLiteralCalleeSignal] = 1
+	prod := []*rerank.Candidate{
+		sourcePreservationCandidate("primary-0", 0, 0),
+		sourcePreservationCandidate("primary-1", 1, 0),
+		sourcePreservationCandidate("primary-2", 2, 0),
+		generic,
+		specific,
+		third,
+	}
+
+	selected := selectFinalExploreCandidates(prod, nil, 3)
+
+	require.Len(t, selected, 3)
+	require.Equal(t, "primary-0", selected[0].Node.ID, "source reservation must preserve the semantic head")
+	require.NotNil(t, candidateByID(selected, specific.Node.ID))
+	require.Nil(t, candidateByID(selected, generic.Node.ID), "one compact collision may reserve only one owner")
+	require.Nil(t, candidateByID(selected, third.Node.ID), "three-way collision noise must stay outside the bounded answer")
+}
+
+func TestSelectFinalExploreCandidatesDeduplicatesSourceOwnersAndHonorsSmallLimits(t *testing.T) {
+	head := sourcePreservationCandidate("head", 0, 0)
+	source := sourcePreservationCandidate("aligned-source", 8, 0.5)
+	source.Signals[exploreSourceLiteralCoverageSignal] = 1
+	source.Signals[exploreContentRecallAmbiguousSignal] = 1
+	source.Signals[exploreSourceLiteralCalleeSignal] = 1
+	source.Signals[exploreSourceLiteralTaskAlignSignal] = 1
+	duplicate := *source
+	duplicate.Signals = map[string]float64{
+		exploreSourceLiteralSignal:          0.5,
+		exploreSourceLiteralCoverageSignal:  1,
+		exploreContentRecallAmbiguousSignal: 1,
+		exploreSourceLiteralCalleeSignal:    1,
+		exploreSourceLiteralTaskAlignSignal: 1,
+	}
+	prod := []*rerank.Candidate{head, sourcePreservationCandidate("tail", 1, 0), source, &duplicate}
+
+	require.Nil(t, selectFinalExploreCandidates(prod, nil, 0))
+	one := selectFinalExploreCandidates(prod, nil, 1)
+	require.Len(t, one, 1)
+	require.Equal(t, "head", one[0].Node.ID)
+	two := selectFinalExploreCandidates(prod, nil, 2)
+	require.Len(t, two, 2)
+	require.Equal(t, "head", two[0].Node.ID)
+	require.Equal(t, "aligned-source", two[1].Node.ID)
+}
+
 func TestSelectFinalExploreCandidatesReservesTwoSourceOwnersWhenCapacityAllows(t *testing.T) {
 	multi := sourcePreservationCandidate("multi-anchor", 90, 0.25)
 	multi.Signals[exploreSourceLiteralCoverageSignal] = 2

--- a/internal/mcp/tools_explore_test.go
+++ b/internal/mcp/tools_explore_test.go
@@ -586,12 +586,20 @@ func TestExploreDraftExactAnchorUsesTokenBoundaries(t *testing.T) {
 
 func TestExploreBroadWellAlignedNeighborhoodGetsExplicitAnswerReadyContract(t *testing.T) {
 	targets := []exploreTarget{{
-		node:  &graph.Node{ID: "internal/mcp/facade_tools.go::registerFacadeTools", Name: "registerFacadeTools", Kind: graph.KindMethod, FilePath: "internal/mcp/facade_tools.go"},
-		score: 1.2,
+		node:                  &graph.Node{ID: "internal/mcp/facade_tools.go::registerFacadeTools", Name: "registerFacadeTools", Kind: graph.KindMethod, FilePath: "internal/mcp/facade_tools.go"},
+		score:                 1.2,
+		conceptImplementation: true,
+		source:                "func registerFacadeTools() { registerRoutingSchema() }",
 	}}
 	task := "investigate mcp facade tool routing schema registration operation dispatch surface architecture integration behavior"
 	if !exploreAnswerReady(task, targets) {
-		t.Fatal("well-aligned ranked head should produce answer_ready for explore(localize)")
+		t.Fatal("well-aligned hydrated implementation should produce answer_ready for explore(localize)")
+	}
+	metadataOnly := targets[0]
+	metadataOnly.conceptImplementation = false
+	metadataOnly.source = ""
+	if exploreAnswerReady(task, []exploreTarget{metadataOnly}) {
+		t.Fatal("metadata alignment without a hydrated implementation must remain nonterminal")
 	}
 	out := (&Server{}).renderExplore(task, targets, 1600)
 	if !strings.Contains(out, "RANKED LOCALIZATION:") || strings.Contains(out, "LOCALIZATION COMPLETE:") {

--- a/internal/mcp/tools_explore_test.go
+++ b/internal/mcp/tools_explore_test.go
@@ -1152,7 +1152,7 @@ func TestRefinementEnvelopeAuthorizesSerializedEvidenceAndOmitsSource(t *testing
 		{node: buildParallel, source: "fn build_parallel(&self) {}", callees: []*graph.Node{unrelated, buildWithCWD}},
 		{node: &graph.Node{ID: "crates/ignore/src/walk.rs::WalkParallel", Name: "WalkParallel", Kind: graph.KindType, FilePath: "crates/ignore/src/walk.rs"}, source: "struct WalkParallel;"},
 	}
-	result, authorized := buildLocalizationExploreResultForTask(
+	result, authorized, _ := buildLocalizationExploreResultForTask(
 		newLocalizationRefinementCompletion(buildParallel.ID),
 		"nondeterministic WalkBuilder parallel multi-root walk build_parallel",
 		targets,

--- a/internal/parser/languages/php_refform_test.go
+++ b/internal/parser/languages/php_refform_test.go
@@ -67,8 +67,8 @@ class Svc {
 }
 
 // TestPHPRefForm_Inheritance verifies `class X extends Base implements I, J`
-// emits one EdgeReferences (ref_context "inherit") per base / interface name,
-// attributed to the declaring class node.
+// emits typed structural edges per base / interface name, attributed to the
+// declaring class node, without a duplicate generic reference edge.
 func TestPHPRefForm_Inheritance(t *testing.T) {
 	src := []byte(`<?php
 class Derived extends BaseSvc implements HandlerInterface, Countable {
@@ -80,11 +80,99 @@ class Derived extends BaseSvc implements HandlerInterface, Countable {
 	}
 	const typeID = "p/Derived.php::Derived"
 
-	for _, tgt := range []string{"BaseSvc", "HandlerInterface", "Countable"} {
-		if !hasPHPRefEdge(result.Edges, typeID, tgt, graph.EdgeReferences, graph.RefContextInherit) {
-			t.Errorf("expected EdgeReferences (inherit) %s -> %s", typeID, tgt)
+	if !hasPHPRefEdge(result.Edges, typeID, "BaseSvc", graph.EdgeExtends, graph.RefContextInherit) {
+		t.Errorf("expected EdgeExtends (inherit) %s -> BaseSvc", typeID)
+	}
+	for _, tgt := range []string{"HandlerInterface", "Countable"} {
+		if !hasPHPRefEdge(result.Edges, typeID, tgt, graph.EdgeImplements, graph.RefContextInherit) {
+			t.Errorf("expected EdgeImplements (inherit) %s -> %s", typeID, tgt)
 		}
 	}
+	for _, edge := range result.Edges {
+		if edge.From == typeID && edge.Kind == graph.EdgeReferences && edge.Meta["ref_context"] == graph.RefContextInherit {
+			t.Errorf("inheritance must not retain duplicate generic reference edge: %#v", edge)
+		}
+	}
+}
+
+// TestPHPRefForm_InheritanceParserSpellings covers only extractor spelling:
+// fully-qualified names reduce to their leaf while an imported alias remains
+// the alias token. Import-aware target resolution is a separate resolver step.
+func TestPHPRefForm_InheritanceParserSpellings(t *testing.T) {
+	src := []byte(`<?php
+namespace App;
+use Vendor\Framework\BaseService as ParentService;
+class Qualified extends \Vendor\Framework\BaseService implements \Vendor\Contracts\Handler {}
+class Aliased extends ParentService {}
+`)
+	result, err := NewPHPExtractor().Extract("p/Qualified.php", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasPHPRefEdge(result.Edges, "p/Qualified.php::Qualified", "BaseService", graph.EdgeExtends, graph.RefContextInherit) {
+		t.Error("fully-qualified base must emit EdgeExtends to the extractor's canonical leaf")
+	}
+	if !hasPHPRefEdge(result.Edges, "p/Qualified.php::Qualified", "Handler", graph.EdgeImplements, graph.RefContextInherit) {
+		t.Error("fully-qualified interface must emit EdgeImplements to canonical leaf")
+	}
+	if !hasPHPRefEdge(result.Edges, "p/Qualified.php::Aliased", "ParentService", graph.EdgeExtends, graph.RefContextInherit) {
+		t.Error("alias must remain in its parsed spelling for later resolver processing")
+	}
+}
+
+func TestPHPRefForm_InterfaceExtendsUsesTypedStructuralEdges(t *testing.T) {
+	src := []byte(`<?php
+interface ChildHandler extends ParentHandler, Countable {}
+`)
+	result, err := NewPHPExtractor().Extract("p/ChildHandler.php", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const typeID = "p/ChildHandler.php::ChildHandler"
+	for _, target := range []string{"ParentHandler", "Countable"} {
+		if !hasPHPRefEdge(result.Edges, typeID, target, graph.EdgeExtends, graph.RefContextInherit) {
+			t.Errorf("expected interface EdgeExtends %s -> %s", typeID, target)
+		}
+	}
+}
+
+func TestPHPRefForm_EnumImplementsUsesTypedStructuralEdges(t *testing.T) {
+	src := []byte(`<?php
+enum Status implements JsonSerializable, Stringable {
+    case Ready;
+}
+`)
+	result, err := NewPHPExtractor().Extract("p/Status.php", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const typeID = "p/Status.php::Status"
+	for _, target := range []string{"JsonSerializable", "Stringable"} {
+		if !hasPHPRefEdge(result.Edges, typeID, target, graph.EdgeImplements, graph.RefContextInherit) {
+			t.Errorf("expected enum EdgeImplements %s -> %s", typeID, target)
+		}
+	}
+}
+
+func TestPHPRefForm_TraitUseRemainsCompositionExtendsEdge(t *testing.T) {
+	src := []byte(`<?php
+trait LogsFailures {}
+class Handler {
+    use LogsFailures;
+}
+`)
+	result, err := NewPHPExtractor().Extract("p/Handler.php", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const typeID = "p/Handler.php::Handler"
+	for _, edge := range result.Edges {
+		if edge != nil && edge.From == typeID && edge.To == "unresolved::LogsFailures" &&
+			edge.Kind == graph.EdgeExtends && edge.Meta["via"] == "trait" {
+			return
+		}
+	}
+	t.Fatal("trait use must retain EdgeExtends with via=trait")
 }
 
 // TestPHPRefForm_Instanceof verifies `$x instanceof Foo` emits an
@@ -167,8 +255,8 @@ class Svc {
 
 // TestPHPRefForm_OriginASTResolved verifies every reference-form edge rides
 // OriginASTResolved — the load-bearing tier that keeps the cross-package
-// guard from reverting the structural EdgeReferences edges to their
-// unresolved placeholder.
+// guard from reverting typed structural and reference-form edges to generic
+// unresolved placeholders.
 func TestPHPRefForm_OriginASTResolved(t *testing.T) {
 	src := []byte(`<?php
 class Svc extends BaseSvc {
@@ -191,7 +279,7 @@ class Svc extends BaseSvc {
 		kind     graph.EdgeKind
 		refctx   string
 	}{
-		{typeID, "BaseSvc", graph.EdgeReferences, graph.RefContextInherit},
+		{typeID, "BaseSvc", graph.EdgeExtends, graph.RefContextInherit},
 		{methodID, "RestClient", graph.EdgeInstantiates, ""},
 		{methodID, "Response", graph.EdgeReferences, graph.RefContextCast},
 		{methodID, "Status", graph.EdgeReferences, graph.RefContextStaticAccess},

--- a/internal/parser/languages/php_reffrm.go
+++ b/internal/parser/languages/php_reffrm.go
@@ -18,7 +18,7 @@ import (
 //     type is a Capitalized name / qualified_name → EdgeInstantiates
 //   - INHERITANCE     `class X extends Base` (base_clause) /
 //     `class X implements I, J` (class_interface_clause)
-//     → EdgeReferences, Meta["ref_context"]="inherit"
+//     → EdgeExtends / EdgeImplements, Meta["ref_context"]="inherit"
 //   - TYPE-TEST       `$x instanceof Foo` (binary_expression with the
 //     `instanceof` operator) → EdgeReferences, Meta["ref_context"]="cast"
 //   - STATIC / CONST  `Foo::CONST` / `Foo::class`
@@ -28,12 +28,11 @@ import (
 //   - ATTRIBUTE       `#[Foo]` / `#[Foo(...)]` (attribute, PHP 8) names the
 //     attribute type Foo → EdgeReferences, Meta["ref_context"]="static_access"
 //
-// The inheritance forms are emitted here as EdgeReferences (ref_context
-// "inherit") rather than EdgeExtends / EdgeImplements: #143's
-// extractPhpTraitUse already owns trait composition (EdgeExtends via:trait),
-// and scope_parent on the class node carries the single base class for the
-// scope resolver. These ref edges give find_usages a "used as a base /
-// conformed interface" surface without changing the inheritance modelling.
+// Inheritance forms use their structural edge kinds. The earlier generic
+// EdgeReferences representation made hierarchy consumers unable to distinguish
+// inheritance from ordinary type mentions even though the parser has exact
+// syntax. #143's extractPhpTraitUse separately owns trait composition
+// (EdgeExtends via:trait); this path covers class/interface declarations.
 //
 // Each expression-site edge attributes to the enclosing function / method
 // (file node when nothing encloses the line); each inheritance edge
@@ -125,20 +124,22 @@ func emitPHPReferenceForms(root *sitter.Node, src []byte, filePath, fileID strin
 			}
 
 		case "base_clause":
-			// `class X extends Base` — emit one inherit reference per base
+			// `class X extends Base` / `interface X extends A, B` — emit one
+			// structural inheritance edge per base
 			// name (PHP single inheritance for classes, but interfaces may
 			// extend several). Attributed to the enclosing class node.
 			owner := ownerFor(line)
 			for _, name := range phpClauseTypeNames(n, src) {
-				emit(name, int(n.StartPoint().Row)+1, owner, graph.EdgeReferences, graph.RefContextInherit)
+				emit(name, int(n.StartPoint().Row)+1, owner, graph.EdgeExtends, graph.RefContextInherit)
 			}
 
 		case "class_interface_clause":
 			// `class X implements I, J` / `interface X extends A, B` — one
-			// inherit reference per named interface.
+			// conformance edge per named interface. tree-sitter-php represents
+			// interface-to-interface extends with base_clause, handled above.
 			owner := ownerFor(line)
 			for _, name := range phpClauseTypeNames(n, src) {
-				emit(name, int(n.StartPoint().Row)+1, owner, graph.EdgeReferences, graph.RefContextInherit)
+				emit(name, int(n.StartPoint().Row)+1, owner, graph.EdgeImplements, graph.RefContextInherit)
 			}
 
 		case "binary_expression":

--- a/internal/parser/languages/rust.go
+++ b/internal/parser/languages/rust.go
@@ -246,6 +246,7 @@ func (e *RustExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 			})
 		}
 	})
+	rebindRustLocalGenericMemberOwners(filePath, result)
 
 	// Stamp trait method names onto trait nodes' Meta["methods"]. Some
 	// trait nodes were emitted before their function_signature_item
@@ -519,6 +520,53 @@ func (e *RustExtractor) emitFunction(m parser.QueryResult, filePath, fileID stri
 	emitRustAnnotationEdges(rustCollectAttributes(def.Node), id, filePath, src, result, annotationSeen)
 	emitRustThrowsEdges(def.Node, src, id, filePath, startLine1, result)
 	emitRustFunctionShape(id, def.Node, src, filePath, startLine1, result)
+}
+
+// rebindRustLocalGenericMemberOwners repairs generic inherent/trait impl
+// ownership only when the extractor can prove the bare declaration exists in
+// this file. Method IDs and receiver metadata retain the instantiated spelling
+// (`Replacer<M>.replace_all`), while member_of targets the declaration node
+// (`Replacer`). Qualified targets such as `std::vec::Vec<T>` and cross-module
+// impls remain unresolved: stripping their qualifier could falsely attach them
+// to an unrelated same-file type with the same basename.
+func rebindRustLocalGenericMemberOwners(filePath string, result *parser.ExtractionResult) {
+	if result == nil {
+		return
+	}
+	prefix := filePath + "::"
+	localTypes := make(map[string]struct{})
+	methods := make(map[string]struct{})
+	for _, node := range result.Nodes {
+		if node == nil {
+			continue
+		}
+		if node.Kind == graph.KindMethod {
+			methods[node.ID] = struct{}{}
+		}
+		if node.FilePath == filePath && (node.Kind == graph.KindType || node.Kind == graph.KindInterface) {
+			localTypes[node.ID] = struct{}{}
+		}
+	}
+	for _, edge := range result.Edges {
+		if edge == nil || edge.Kind != graph.EdgeMemberOf {
+			continue
+		}
+		if _, method := methods[edge.From]; !method || !strings.HasPrefix(edge.To, prefix) {
+			continue
+		}
+		owner := strings.TrimPrefix(edge.To, prefix)
+		if !strings.Contains(owner, "<") || strings.Contains(owner, "::") {
+			continue
+		}
+		base := rustTraitPathBaseName(owner)
+		if base == "" {
+			continue
+		}
+		target := prefix + base
+		if _, local := localTypes[target]; local {
+			edge.To = target
+		}
+	}
 }
 
 // rustTypeParams reads the `type_parameters` child of a Rust item

--- a/internal/parser/languages/rust_test.go
+++ b/internal/parser/languages/rust_test.go
@@ -167,6 +167,70 @@ impl Server {
 	assert.Len(t, funcs, 0)
 }
 
+func TestRsExtractor_GenericImplMemberOfTargetsBareType(t *testing.T) {
+	src := []byte(`
+struct Replacer<M> { matcher: M }
+
+impl<M> Replacer<M> {
+    fn replace_all(&self) {}
+}
+`)
+	result, err := NewRustExtractor().Extract("util.rs", src)
+	require.NoError(t, err)
+
+	methodID := "util.rs::Replacer<M>.replace_all"
+	typeID := "util.rs::Replacer"
+	var method *graph.Node
+	var owner *graph.Node
+	for _, node := range result.Nodes {
+		if node.ID == methodID {
+			method = node
+		}
+		if node.ID == typeID {
+			owner = node
+		}
+	}
+	require.NotNil(t, method, "generic impl method must retain its instantiated receiver ID")
+	assert.Equal(t, "Replacer<M>", method.Meta["receiver"])
+	require.NotNil(t, owner, "bare owner target must name a real type node")
+
+	found := false
+	for _, edge := range edgesOfKind(result.Edges, graph.EdgeMemberOf) {
+		if edge.From == methodID {
+			found = true
+			assert.Equal(t, typeID, edge.To, "member_of must target the type declaration's bare ID")
+			assert.NotEqual(t, "util.rs::Replacer<M>", edge.To, "generic owner aliases must not remain dangling")
+		}
+	}
+	assert.True(t, found, "generic impl method must have a member_of edge")
+}
+
+func TestRsExtractor_GenericScopedImplDoesNotBindSameFileBasename(t *testing.T) {
+	src := []byte(`
+struct Vec;
+trait LocalTrait { fn inspect(&self); }
+
+impl<T> LocalTrait for std::vec::Vec<T> {
+    fn inspect(&self) {}
+}
+`)
+	result, err := NewRustExtractor().Extract("scoped.rs", src)
+	require.NoError(t, err)
+
+	methodID := "scoped.rs::std::vec::Vec<T>.inspect"
+	localTypeID := "scoped.rs::Vec"
+	found := false
+	for _, edge := range edgesOfKind(result.Edges, graph.EdgeMemberOf) {
+		if edge.From != methodID {
+			continue
+		}
+		found = true
+		assert.NotEqual(t, localTypeID, edge.To, "qualified external impl must not bind a same-file basename")
+		assert.Equal(t, "scoped.rs::std::vec::Vec<T>", edge.To)
+	}
+	assert.True(t, found, "scoped generic impl method must retain an unresolved owner edge")
+}
+
 func TestRsExtractor_ImplMethodMeta(t *testing.T) {
 	src := []byte(`struct Foo {}
 

--- a/internal/parser/languages/typescript_test.go
+++ b/internal/parser/languages/typescript_test.go
@@ -1065,3 +1065,39 @@ func TestTemplateExprCallMining(t *testing.T) {
 	assert.True(t, callTag, "a tagged-template tag is a call")
 	assert.False(t, fnvalTag, "a tagged-template tag is NOT a function-as-value candidate")
 }
+
+// Curried const-arrow middleware with generics — the store-middleware shape:
+// the const binding extracts as a function with its parameters, exported type
+// aliases extract as types, and a nested const-arrow helper inside the body
+// extracts too. Pinned so selection-layer work can rely on these symbols
+// existing; the historical miss on this shape was emission, not extraction.
+func TestTypeScriptCurriedConstArrowMiddlewareExtraction(t *testing.T) {
+	src := []byte(`export type StoreSetStateWithAction<T> = (state: T, replace?: boolean, action?: string) => void
+
+const middlewareImpl: MiddlewareImpl =
+  (fn, middlewareOptions = {}) =>
+  (set, get, api) => {
+    const setStateTracked: SetStateTracked = (...a) => set(...a)
+    return fn(setStateTracked, get, api)
+  }
+`)
+	e := NewTypeScriptExtractor()
+	result, err := e.Extract("mw/middleware.ts", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ids := map[string]string{}
+	for _, n := range result.Nodes {
+		ids[n.ID] = string(n.Kind)
+	}
+	for id, kind := range map[string]string{
+		"mw/middleware.ts::StoreSetStateWithAction":              "type",
+		"mw/middleware.ts::middlewareImpl":                       "function",
+		"mw/middleware.ts::middlewareImpl#param:middlewareOptions@1": "param",
+		"mw/middleware.ts::setStateTracked":                      "function",
+	} {
+		if ids[id] != kind {
+			t.Fatalf("%s = %q, want %q (all: %v)", id, ids[id], kind, ids)
+		}
+	}
+}

--- a/internal/query/engine.go
+++ b/internal/query/engine.go
@@ -966,19 +966,20 @@ func (e *Engine) searchSubstring(query string, limit int) []*graph.Node {
 		results = append(results, scored{n, 0})
 	}
 
+	// Fold-matching instead of lowering every candidate: ToLower on both the
+	// name and the ID of every node allocated two strings per node per query
+	// — a quarter-million allocations per call on a mid-size graph, on the
+	// degraded-mode path a stale search index falls back to.
 	allNodes := e.g.AllNodes()
 	for _, n := range allNodes {
 		if seen[n.ID] || n.Kind == graph.KindFile || n.Kind == graph.KindImport {
 			continue
 		}
-		nameLower := strings.ToLower(n.Name)
-		idLower := strings.ToLower(n.ID)
-
-		if strings.HasPrefix(nameLower, lower) {
+		if hasPrefixFold(n.Name, lower) {
 			results = append(results, scored{n, 1})
-		} else if strings.Contains(nameLower, lower) {
+		} else if containsFold(n.Name, lower) {
 			results = append(results, scored{n, 2})
-		} else if strings.Contains(idLower, lower) {
+		} else if containsFold(n.ID, lower) {
 			results = append(results, scored{n, 3})
 		} else {
 			continue
@@ -1677,4 +1678,24 @@ func dedup(edges []*graph.Edge) []*graph.Edge {
 		out = append(out, e)
 	}
 	return out
+}
+
+// hasPrefixFold reports whether s begins with prefix under simple case
+// folding, without allocating. prefix is already lowercased by the caller.
+func hasPrefixFold(s, prefix string) bool {
+	return len(s) >= len(prefix) && strings.EqualFold(s[:len(prefix)], prefix)
+}
+
+// containsFold reports whether sub occurs in s under simple case folding,
+// without allocating. sub is already lowercased by the caller.
+func containsFold(s, sub string) bool {
+	if len(sub) == 0 {
+		return true
+	}
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if strings.EqualFold(s[i:i+len(sub)], sub) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/query/engine.go
+++ b/internal/query/engine.go
@@ -1688,11 +1688,24 @@ func hasPrefixFold(s, prefix string) bool {
 
 // containsFold reports whether sub occurs in s under simple case folding,
 // without allocating. sub is already lowercased by the caller.
+//
+// The window loop only pays an EqualFold where the first byte can actually
+// fold-match: an ASCII byte is prechecked with |0x20 case-folding, and any
+// non-ASCII byte always takes the EqualFold path. Known limitation shared by
+// every byte-windowed fold: length-changing Unicode foldings (the three-byte
+// Kelvin sign folding to a one-byte k) cannot match, because the window is
+// sized in bytes. Identifiers do not contain those; the degraded-mode
+// fallback accepts the trade, and production search uses the indexed
+// backend.
 func containsFold(s, sub string) bool {
 	if len(sub) == 0 {
 		return true
 	}
+	c := sub[0] | 0x20
 	for i := 0; i+len(sub) <= len(s); i++ {
+		if b := s[i]; b < 0x80 && b|0x20 != c {
+			continue
+		}
 		if strings.EqualFold(s[i:i+len(sub)], sub) {
 			return true
 		}

--- a/internal/query/fold_semantics_test.go
+++ b/internal/query/fold_semantics_test.go
@@ -1,0 +1,28 @@
+package query
+
+import "testing"
+
+func TestContainsFoldSemantics(t *testing.T) {
+	cases := []struct {
+		s, sub string
+		want   bool
+	}{
+		{"HandleServerRequest", "server", true},
+		{"handleserverrequest", "server", true},
+		{"HANDLESERVERREQUEST", "server", true},
+		{"handle", "server", false},
+		{"srv", "server", false},
+		{"", "server", false},
+		{"anything", "", true},
+		{"pkg/a.go::HandleServer", "server", true},
+		// Length-changing Unicode foldings (the Kelvin sign folding to a
+		// one-byte k) are a documented non-goal of the byte-windowed fold —
+		// see containsFold.
+		{"caféServer", "server", true},
+	}
+	for _, tc := range cases {
+		if got := containsFold(tc.s, tc.sub); got != tc.want {
+			t.Errorf("containsFold(%q, %q) = %v, want %v", tc.s, tc.sub, got, tc.want)
+		}
+	}
+}

--- a/internal/resolver/chain_factory.go
+++ b/internal/resolver/chain_factory.go
@@ -23,15 +23,30 @@ import (
 // overridden. Runs in the framework-synthesizer settle window, after the
 // implements/extends edges exist, so the conformance walk sees them.
 func ResolveFactoryChains(g graph.Store) int {
+	return resolveFactoryChains(g, nil)
+}
+
+// resolveFactoryChains is the census-multiplexed form: cands, when non-nil,
+// replaces the calls+references decode with the shared walk's pre-matched
+// candidates (calls first, then references — each edge's resolution is
+// independent, so the interleaving of the combined kind scan is not
+// load-bearing).
+func resolveFactoryChains(g graph.Store, cands *frameworkPassCandidates) int {
 	if g == nil {
 		return 0
 	}
-	resolved := 0
-	var batch []graph.EdgeReindex
 	// Scoped to the two kinds this pass ever acts on (below), instead of
 	// AllEdges() decoding every kind in the graph — calls+references is a
 	// fraction of the total edge count on a large multi-repo graph.
-	for e := range edgesByKinds(g, []graph.EdgeKind{graph.EdgeCalls, graph.EdgeReferences}) {
+	stream := edgesByKinds(g, []graph.EdgeKind{graph.EdgeCalls, graph.EdgeReferences})
+	if cands != nil {
+		merged := refetchFrameworkCandidates(g, cands.calls)
+		merged = append(merged, refetchFrameworkCandidates(g, cands.refs)...)
+		stream = frameworkEdgeSeq(merged)
+	}
+	resolved := 0
+	var batch []graph.EdgeReindex
+	for e := range stream {
 		if e == nil || e.Meta == nil {
 			continue
 		}

--- a/internal/resolver/cross_repo.go
+++ b/internal/resolver/cross_repo.go
@@ -93,10 +93,10 @@ type CrossRepoResolver struct {
 	// placeholder_sources.go). Reset at pass start.
 	placeholderSrcIdx placeholderSourceIndex
 	nodesByName       map[string][]*graph.Node
-	nodesByNameRepo map[string]map[string][]*graph.Node
-	nodesByQualName map[string]*graph.Node
-	dirIndex        map[string][]*graph.Node
-	lastDirIndex    map[string][]*graph.Node
+	nodesByNameRepo   map[string]map[string][]*graph.Node
+	nodesByQualName   map[string]*graph.Node
+	dirIndex          map[string][]*graph.Node
+	lastDirIndex      map[string][]*graph.Node
 	// reachableReposByFile maps a caller file's ID to the set of repo
 	// prefixes that file imports (derived from resolved EdgeImports
 	// edges). It is the import-reachability evidence gate: a name-only
@@ -335,7 +335,7 @@ func (cr *CrossRepoResolver) ResolveAll() *CrossRepoStats {
 	defer cr.clearReachableReposIndex()
 
 	if resolveHotCacheEnabled() {
-		cr.hotCache = newResolveHotCache(resolveHotCacheBudgetBytes())
+		cr.hotCache = newResolveHotCache(resolveHotCacheBudgetBytes(), len(pending))
 		defer func() {
 			if c := cr.hotCache; c != nil {
 				cr.logger.Info("cross-repo resolve: hot cache stats",

--- a/internal/resolver/fastapi_resolve.go
+++ b/internal/resolver/fastapi_resolve.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"iter"
 	"strings"
 
 	"github.com/zzet/gortex/internal/graph"
@@ -26,13 +27,26 @@ var (
 // references to their definitions by directory convention. Returns the count
 // bound.
 func ResolveFastAPIDeps(g graph.Store) int {
+	return resolveFastAPIDeps(g, nil)
+}
+
+// resolveFastAPIDeps is the census-multiplexed form: cands, when non-nil,
+// replaces both whole-stream decodes with the shared walk's pre-matched
+// candidates.
+func resolveFastAPIDeps(g graph.Store, cands *frameworkPassCandidates) int {
 	if g == nil {
 		return 0
 	}
+	callsStream := g.EdgesByKind(graph.EdgeCalls)
+	refsStream := g.EdgesByKind(graph.EdgeReferences)
+	if cands != nil {
+		callsStream = frameworkEdgeSeq(refetchFrameworkCandidates(g, cands.calls))
+		refsStream = frameworkEdgeSeq(refetchFrameworkCandidates(g, cands.refs))
+	}
 	resolved := 0
 	var reindex []graph.EdgeReindex
-	for _, kind := range []graph.EdgeKind{graph.EdgeCalls, graph.EdgeReferences} {
-		for e := range g.EdgesByKind(kind) {
+	for _, stream := range []iter.Seq[*graph.Edge]{callsStream, refsStream} {
+		for e := range stream {
 			if e == nil || e.Meta == nil || !graph.IsUnresolvedTarget(e.To) {
 				continue
 			}

--- a/internal/resolver/fn_pointer_dispatch.go
+++ b/internal/resolver/fn_pointer_dispatch.go
@@ -34,6 +34,14 @@ const (
 //
 // Returns the number of dispatcher → function edges synthesized.
 func ResolveFnPointerDispatch(g graph.Store) int {
+	return resolveFnPointerDispatch(g, nil)
+}
+
+// resolveFnPointerDispatch is the census-multiplexed form: cands, when
+// non-nil, replaces both whole-stream decodes — the EdgeReferences
+// registration arm and the EdgeCalls dispatch arm — with the shared walk's
+// pre-matched candidates.
+func resolveFnPointerDispatch(g graph.Store, cands *frameworkPassCandidates) int {
 	if g == nil {
 		return 0
 	}
@@ -50,8 +58,12 @@ func ResolveFnPointerDispatch(g graph.Store) int {
 	type copyEdge struct{ to, from string }
 	var copies []copyEdge
 
+	regStream := g.EdgesByKind(graph.EdgeReferences)
+	if cands != nil {
+		regStream = frameworkEdgeSeq(refetchFrameworkCandidates(g, cands.refs))
+	}
 	var regReindex []graph.EdgeReindex
-	for e := range g.EdgesByKind(graph.EdgeReferences) {
+	for e := range regStream {
 		if e == nil || e.Meta == nil {
 			continue
 		}
@@ -111,10 +123,14 @@ func ResolveFnPointerDispatch(g graph.Store) int {
 		}
 	}
 
+	dispatchStream := g.EdgesByKind(graph.EdgeCalls)
+	if cands != nil {
+		dispatchStream = frameworkEdgeSeq(refetchFrameworkCandidates(g, cands.calls))
+	}
 	resolved := 0
 	var reindex []graph.EdgeReindex
 	var batch []*graph.Edge
-	for e := range g.EdgesByKind(graph.EdgeCalls) {
+	for e := range dispatchStream {
 		if e == nil || e.Meta == nil {
 			continue
 		}

--- a/internal/resolver/framework_census_probe_test.go
+++ b/internal/resolver/framework_census_probe_test.go
@@ -46,7 +46,7 @@ func TestFrameworkCensusProbe(t *testing.T) {
 	t.Logf("EdgesByKind(calls) full stream: %d rows (%d with meta) in %s", calls, withMeta, time.Since(t1))
 
 	t2 := time.Now()
-	census := collectFrameworkEdgeCensus(s)
+	census := collectFrameworkEdgeCensus(s, nil)
 	t.Logf("collectFrameworkEdgeCensus: %s (via markers=%d)", time.Since(t2), len(census.via))
 
 	t3 := time.Now()
@@ -85,4 +85,7 @@ func TestFrameworkSynthesisScopedProbe(t *testing.T) {
 		loopMs += p.Millis
 	}
 	t.Logf("loop total: %dms across %d entries", loopMs, len(rep.Per))
+	for _, p := range rep.Per {
+		t.Logf("per: %-24s edges=%-8d ms=%d", p.Name, p.Edges, p.Millis)
+	}
 }

--- a/internal/resolver/framework_edge_batch.go
+++ b/internal/resolver/framework_edge_batch.go
@@ -85,6 +85,20 @@ func runLegacyFrameworkSynth(store graph.Store, fn func(graph.Store) int) int {
 	return count
 }
 
+// stagedEdgesMatching returns the edges THIS pass has staged so far, in
+// insertion order, filtered by pred — the overlay a fresh kind stream would
+// surface for a pass re-reading its own uncommitted additions. Used by the
+// shared-stream forms, whose candidate slices predate the pass's own adds.
+func (s *frameworkEdgeBatchStore) stagedEdgesMatching(pred func(*graph.Edge) bool) []*graph.Edge {
+	var out []*graph.Edge
+	for _, key := range s.order {
+		if edge := s.staged[key]; edge != nil && pred(edge) {
+			out = append(out, edge)
+		}
+	}
+	return out
+}
+
 func (s *frameworkEdgeBatchStore) GetOutEdges(id string) []*graph.Edge {
 	return s.mergeEdges(s.Store.GetOutEdges(id), func(edge *graph.Edge) bool {
 		return edge.From == id

--- a/internal/resolver/framework_stream_mux.go
+++ b/internal/resolver/framework_stream_mux.go
@@ -1,0 +1,426 @@
+package resolver
+
+import (
+	"iter"
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Shared-stream candidate multiplexer for the framework synthesizers.
+//
+// On a cold / full-coverage run, the admission census already decodes the
+// entire EdgeCalls stream once. Historically each via-gated synthesizer then
+// re-decoded that same stream for itself — EdgeCalls was walked with full
+// Meta decoding by eight-plus passes and EdgeReferences by four more, every
+// walk discarding all but a tiny predicate-matched slice. The multiplexer
+// collects each pass's candidate edges DURING the census walk instead: one
+// decoded walk per edge kind feeds every consumer, and each pass receives
+// its pre-matched slice at its own turn in the (unchanged) registry order.
+//
+// Only candidate COLLECTION is multiplexed. Pass logic, write ordering, and
+// the sequential registry loop are untouched: a pass re-reads its collected
+// candidates in their CURRENT store form before acting (see
+// refetchFrameworkCandidates), so an edge retargeted by an earlier pass in
+// the same run drops out exactly as it would vanish from a fresh stream walk.
+
+// frameworkPassCandidates is the per-synthesizer bundle handed to a
+// converted pass in place of its own whole-stream scans.
+type frameworkPassCandidates struct {
+	// calls / refs hold the pass's EdgeCalls / EdgeReferences candidates in
+	// census stream order. They are census-time reads: consult them through
+	// refetchFrameworkCandidates so mutations by earlier passes are honoured.
+	calls []*graph.Edge
+	refs  []*graph.Edge
+	// annotated holds the temporal-tagged EdgeAnnotated edges (temporal
+	// only). No pass mutates annotation edges, so they are used directly.
+	annotated []*graph.Edge
+	// nodes is the run-wide shared node snapshot (one decoded walk per node
+	// kind for the whole synthesizer loop).
+	nodes *frameworkNodeSnapshot
+}
+
+// frameworkNodeSnapshot caches one materialised NodesByKind walk per node
+// kind for the duration of a synthesizer run. Consumers that historically
+// issued their own per-kind scans (temporal, rust, store-factory, macro)
+// read the cached slice instead; single-kind order is preserved exactly, so
+// each consumer sees the same nodes in the same order its own scan yielded.
+type frameworkNodeSnapshot struct {
+	byKind map[graph.NodeKind][]*graph.Node
+}
+
+// kind returns the cached slice for one node kind, materialising it on
+// first use. Lazy per kind: a run whose admitted passes never consume a
+// kind never pays its walk.
+func (s *frameworkNodeSnapshot) kind(g graph.Store, kind graph.NodeKind) []*graph.Node {
+	if s.byKind == nil {
+		s.byKind = map[graph.NodeKind][]*graph.Node{}
+	}
+	if nodes, ok := s.byKind[kind]; ok {
+		return nodes
+	}
+	var nodes []*graph.Node
+	for n := range g.NodesByKind(kind) {
+		if n != nil {
+			nodes = append(nodes, n)
+		}
+	}
+	s.byKind[kind] = nodes
+	return nodes
+}
+
+// frameworkKindNodes returns a pass's node input for one kind: the shared
+// snapshot slice when the pass runs in shared-stream form, else one direct
+// kind scan (the legacy shape, kept for scoped runs and focused tests).
+func frameworkKindNodes(g graph.Store, snap *frameworkNodeSnapshot, kind graph.NodeKind) []*graph.Node {
+	if snap != nil {
+		return snap.kind(g, kind)
+	}
+	var nodes []*graph.Node
+	for n := range g.NodesByKind(kind) {
+		if n != nil {
+			nodes = append(nodes, n)
+		}
+	}
+	return nodes
+}
+
+// frameworkStreamCandidates owns the armed collectors and the per-pass
+// buffers for one full-census run.
+type frameworkStreamCandidates struct {
+	perPass map[string]*frameworkPassCandidates
+	nodes   *frameworkNodeSnapshot
+
+	// macroNames / macroIDs pre-filter the macro-expansion use-site arm.
+	// Built from the node snapshot's Macro slice at construction (macro is
+	// the one collector whose predicate needs node knowledge); a name-only
+	// superset of the pass's own index, so it can only over-collect.
+	macroNames map[string]struct{}
+	macroIDs   map[string]struct{}
+
+	callsCollectors []frameworkCandidateCollector
+	refsCollectors  []frameworkCandidateCollector
+	wantAnnotated   bool
+}
+
+// frameworkCandidateCollector pairs a pass with the cheap edge-only
+// predicate mirroring that pass's own stream filter. A predicate is a
+// necessary-condition superset: the pass re-applies its full filter over
+// the (re-fetched) candidates, so over-collection is safe and
+// under-collection is the only bug class.
+type frameworkCandidateCollector struct {
+	name string
+	pred func(*graph.Edge) bool
+}
+
+// newFrameworkStreamCandidates arms a collector for every convertible pass
+// whose family / node-marker gates pass on the census the light node walk
+// just produced. Edge-preflight gates are census-derived and not yet known
+// here; they can only narrow admission further, so the armed set is a
+// superset of the passes that will run — an unconsumed buffer costs memory,
+// never correctness.
+func newFrameworkStreamCandidates(g graph.Store, present, markers map[string]int) *frameworkStreamCandidates {
+	sc := &frameworkStreamCandidates{
+		perPass: map[string]*frameworkPassCandidates{},
+		nodes:   &frameworkNodeSnapshot{},
+	}
+	armed := func(name string) bool {
+		return frameworkSynthNodeGatesPass(name, present, markers)
+	}
+	addCalls := func(name string, pred func(*graph.Edge) bool) {
+		sc.callsCollectors = append(sc.callsCollectors, frameworkCandidateCollector{name: name, pred: pred})
+	}
+	addRefs := func(name string, pred func(*graph.Edge) bool) {
+		sc.refsCollectors = append(sc.refsCollectors, frameworkCandidateCollector{name: name, pred: pred})
+	}
+
+	if armed(SynthGRPCStub) {
+		addCalls(SynthGRPCStub, grpcCandidateEdge)
+	}
+	if armed(SynthTemporalStub) {
+		addCalls(SynthTemporalStub, temporalCandidateEdge)
+		sc.wantAnnotated = true
+	}
+	if armed(SynthStoreFactory) {
+		addCalls(SynthStoreFactory, storeFactoryCandidateEdge)
+	}
+	if armed(SynthFnPointerDispatch) {
+		addCalls(SynthFnPointerDispatch, fnPtrDispatchCandidateEdge)
+		addRefs(SynthFnPointerDispatch, fnPtrRegCandidateEdge)
+	}
+	if armed(SynthMacroExpansion) {
+		// The macro use-site predicate needs the function-like macro name
+		// vocabulary; macros are a tiny kind, so warming the snapshot here
+		// is the same walk the pass itself would have paid, done once.
+		sc.macroNames = map[string]struct{}{}
+		sc.macroIDs = map[string]struct{}{}
+		for _, n := range sc.nodes.kind(g, graph.KindMacro) {
+			if n == nil || n.Meta == nil || n.Name == "" {
+				continue
+			}
+			if k, _ := n.Meta["macro_kind"].(string); k != macroFunctionKindMeta {
+				continue
+			}
+			sc.macroNames[n.Name] = struct{}{}
+			sc.macroIDs[n.ID] = struct{}{}
+		}
+		if len(sc.macroNames) > 0 {
+			addCalls(SynthMacroExpansion, sc.macroCandidateEdge)
+		}
+	}
+	if armed(SynthRailsResolve) {
+		addCalls(SynthRailsResolve, railsCandidateEdge)
+	}
+	if armed(SynthReactResolve) {
+		addCalls(SynthReactResolve, reactCandidateEdge)
+		addRefs(SynthReactResolve, reactCandidateEdge)
+	}
+	if armed(SynthFastAPIResolve) {
+		addCalls(SynthFastAPIResolve, fastapiCandidateEdge)
+		addRefs(SynthFastAPIResolve, fastapiCandidateEdge)
+	}
+	if armed(SynthFactoryChain) {
+		addCalls(SynthFactoryChain, factoryChainCandidateEdge)
+		addRefs(SynthFactoryChain, factoryChainCandidateEdge)
+	}
+	if armed(SynthRustScope) {
+		addCalls(SynthRustScope, rustCandidateEdge)
+	}
+
+	for _, c := range sc.callsCollectors {
+		sc.ensurePass(c.name)
+	}
+	for _, c := range sc.refsCollectors {
+		sc.ensurePass(c.name)
+	}
+	if sc.wantAnnotated {
+		sc.ensurePass(SynthTemporalStub)
+	}
+	return sc
+}
+
+func (sc *frameworkStreamCandidates) ensurePass(name string) *frameworkPassCandidates {
+	pc := sc.perPass[name]
+	if pc == nil {
+		pc = &frameworkPassCandidates{nodes: sc.nodes}
+		sc.perPass[name] = pc
+	}
+	return pc
+}
+
+// passStreams returns the bundle for one pass, or nil when its collectors
+// were not armed (the pass then runs its legacy whole-stream form).
+func (sc *frameworkStreamCandidates) passStreams(name string) *frameworkPassCandidates {
+	if sc == nil {
+		return nil
+	}
+	return sc.perPass[name]
+}
+
+// collectCalls hands one census-walk EdgeCalls edge to every armed
+// collector. Edges without a source node are skipped: no pass can act on a
+// degenerate edge and the current-form re-read below is keyed by source.
+func (sc *frameworkStreamCandidates) collectCalls(e *graph.Edge) {
+	if sc == nil || e == nil || e.From == "" {
+		return
+	}
+	for _, c := range sc.callsCollectors {
+		if c.pred(e) {
+			pc := sc.perPass[c.name]
+			pc.calls = append(pc.calls, e)
+		}
+	}
+}
+
+// collectRefs is collectCalls for the EdgeReferences walk.
+func (sc *frameworkStreamCandidates) collectRefs(e *graph.Edge) {
+	if sc == nil || e == nil || e.From == "" {
+		return
+	}
+	for _, c := range sc.refsCollectors {
+		if c.pred(e) {
+			pc := sc.perPass[c.name]
+			pc.refs = append(pc.refs, e)
+		}
+	}
+}
+
+func (sc *frameworkStreamCandidates) wantsRefs() bool {
+	return sc != nil && len(sc.refsCollectors) > 0
+}
+
+func (sc *frameworkStreamCandidates) wantsAnnotated() bool {
+	return sc != nil && sc.wantAnnotated
+}
+
+func (sc *frameworkStreamCandidates) addAnnotated(e *graph.Edge) {
+	pc := sc.perPass[SynthTemporalStub]
+	pc.annotated = append(pc.annotated, e)
+}
+
+func (sc *frameworkStreamCandidates) annotatedCount() int {
+	if sc == nil {
+		return 0
+	}
+	if pc := sc.perPass[SynthTemporalStub]; pc != nil {
+		return len(pc.annotated)
+	}
+	return 0
+}
+
+// refetchFrameworkCandidates re-reads the CURRENT form of the collected
+// candidates, in collection order, through the pass's own store view. A
+// candidate whose (from, to, kind, file, line) identity no longer exists —
+// retargeted or removed by an earlier pass — is dropped, exactly as it
+// would no longer match a fresh predicate walk; one that survives is
+// returned in its live form (staged-overlay and Meta-current), so the
+// pass's own loop filters see the same state a fresh stream would yield.
+// One batched out-edge read replaces a whole-kind decode.
+func refetchFrameworkCandidates(g graph.Store, cands []*graph.Edge) []*graph.Edge {
+	if len(cands) == 0 {
+		return nil
+	}
+	fromIDs := make([]string, 0, len(cands))
+	for _, e := range cands {
+		fromIDs = append(fromIDs, e.From)
+	}
+	byKey := map[string]*graph.Edge{}
+	for _, edges := range g.GetOutEdgesByNodeIDs(dedupeFrameworkIDs(fromIDs)) {
+		for _, e := range edges {
+			if e != nil {
+				byKey[frameworkScopedEdgeKey(e)] = e
+			}
+		}
+	}
+	out := make([]*graph.Edge, 0, len(cands))
+	for _, c := range cands {
+		if e := byKey[frameworkScopedEdgeKey(c)]; e != nil {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// frameworkEdgeSeq adapts a candidate slice to the iterator shape a kind
+// stream yields, so a pass's loop body is identical across the legacy and
+// shared-stream forms.
+func frameworkEdgeSeq(edges []*graph.Edge) iter.Seq[*graph.Edge] {
+	return func(yield func(*graph.Edge) bool) {
+		for _, e := range edges {
+			if !yield(e) {
+				return
+			}
+		}
+	}
+}
+
+// --- per-pass candidate predicates -------------------------------------
+//
+// Each predicate is a verbatim copy of the cheap edge-only prefix of its
+// pass's own stream filter. Conditions needing graph reads (source-file
+// language, node lookups, index membership) stay in the pass, which
+// re-applies its full filter over the re-fetched candidates.
+
+func grpcCandidateEdge(e *graph.Edge) bool {
+	if e.Meta == nil {
+		return false
+	}
+	// Both arms of the pass read EdgeCalls: the stub arm keys on the via,
+	// the handler-index arm on the registration marker.
+	if v, _ := e.Meta["via"].(string); v == "grpc.stub" {
+		return true
+	}
+	svc, _ := e.Meta["grpc_register_service"].(string)
+	return svc != ""
+}
+
+func temporalCandidateEdge(e *graph.Edge) bool {
+	if e.Meta == nil {
+		return false
+	}
+	// The prefix covers every phase input: register / stub / start for the
+	// sweep, executor-field markers for the pre-pass, handler edges for the
+	// cross-language join — mirroring the pass's own presence probe.
+	v, _ := e.Meta["via"].(string)
+	return strings.HasPrefix(v, "temporal.")
+}
+
+func storeFactoryCandidateEdge(e *graph.Edge) bool {
+	if e.Meta == nil {
+		return false
+	}
+	v, _ := e.Meta["via"].(string)
+	return v == storeFactoryVia
+}
+
+func fnPtrDispatchCandidateEdge(e *graph.Edge) bool {
+	if e.Meta == nil {
+		return false
+	}
+	v, _ := e.Meta["via"].(string)
+	return v == fnPtrDispatchVia
+}
+
+func fnPtrRegCandidateEdge(e *graph.Edge) bool {
+	if e.Meta == nil {
+		return false
+	}
+	v, _ := e.Meta["via"].(string)
+	return v == fnPtrRegVia
+}
+
+func (sc *frameworkStreamCandidates) macroCandidateEdge(e *graph.Edge) bool {
+	if e.To == "" {
+		return false
+	}
+	if graph.IsUnresolvedTarget(e.To) {
+		_, ok := sc.macroNames[graph.UnresolvedName(e.To)]
+		return ok
+	}
+	_, ok := sc.macroIDs[e.To]
+	return ok
+}
+
+func railsCandidateEdge(e *graph.Edge) bool {
+	if e.Meta == nil || !graph.IsUnresolvedTarget(e.To) {
+		return false
+	}
+	recv, _ := e.Meta["recv_const"].(string)
+	return recv != ""
+}
+
+func reactCandidateEdge(e *graph.Edge) bool {
+	if !graph.IsUnresolvedTarget(e.To) {
+		return false
+	}
+	head := graph.UnresolvedName(e.To)
+	if i := strings.IndexByte(head, '.'); i >= 0 {
+		head = head[:i]
+	}
+	via, _ := e.Meta["via"].(string)
+	_, _, ok := reactResolveShape(head, via)
+	return ok
+}
+
+func fastapiCandidateEdge(e *graph.Edge) bool {
+	if e.Meta == nil || !graph.IsUnresolvedTarget(e.To) {
+		return false
+	}
+	switch v, _ := e.Meta["via"].(string); v {
+	case "fastapi.Depends", "fastapi.router":
+		return true
+	}
+	return false
+}
+
+func factoryChainCandidateEdge(e *graph.Edge) bool {
+	if e.Meta == nil || !graph.IsUnresolvedTarget(e.To) {
+		return false
+	}
+	expr, _ := e.Meta["receiver_expr"].(string)
+	return expr != ""
+}
+
+func rustCandidateEdge(e *graph.Edge) bool {
+	return graph.IsUnresolvedTarget(e.To) && rustScopeEdgeCandidate(e)
+}

--- a/internal/resolver/framework_synth.go
+++ b/internal/resolver/framework_synth.go
@@ -187,6 +187,11 @@ type synthFunc struct {
 	name     string
 	fn       func(graph.Store) int
 	scopedFn func(graph.Store, map[string]bool) int
+	// candFn is the shared-stream form: the pass consumes the candidate
+	// buffers the census dispatcher collected instead of re-decoding whole
+	// edge kinds. Used only when a full-census run armed the pass's
+	// collectors; every other invocation keeps fn / scopedFn.
+	candFn func(graph.Store, *frameworkPassCandidates) int
 }
 
 func (s synthFunc) Name() string                 { return s.name }
@@ -264,6 +269,10 @@ type frameworkCandidateSummary struct {
 	// Absence-proof gates (edge census, family/receiver tails) may only
 	// trust counts from a full walk; a partial summary cannot prove absence.
 	fullCensus bool
+	// streams carries the shared-stream candidate buffers the census edge
+	// walks collected for the converted synthesizers. Full-census runs only;
+	// nil on a partial run, where every pass keeps its own scoped scans.
+	streams *frameworkStreamCandidates
 }
 
 // frameworkDistinctNames counts distinct non-empty names, saturating at two.
@@ -326,12 +335,18 @@ type frameworkEdgeCensus struct {
 // frameworkSynthEdgePreflights. Every flag is a necessary condition copied
 // verbatim from the consuming pass's own loop filter, so a missed flag can
 // only keep a pass enabled, never skip one that could land an edge.
-func collectFrameworkEdgeCensus(g graph.Store) frameworkEdgeCensus {
+//
+// The same decoded walk doubles as the shared-stream candidate dispatcher:
+// when streams is non-nil, every edge is also offered to the armed per-pass
+// collectors, and the (smaller) EdgeAnnotated and EdgeReferences kinds are
+// walked once here for their consumers instead of once per pass.
+func collectFrameworkEdgeCensus(g graph.Store, streams *frameworkStreamCandidates) frameworkEdgeCensus {
 	census := frameworkEdgeCensus{valid: true, via: map[string]bool{}}
 	for e := range g.EdgesByKind(graph.EdgeCalls) {
 		if e == nil {
 			continue
 		}
+		streams.collectCalls(e)
 		if isSetStateTarget(e.To) {
 			census.setStateTarget = true
 		}
@@ -365,7 +380,23 @@ func collectFrameworkEdgeCensus(g graph.Store) frameworkEdgeCensus {
 			}
 		}
 	}
-	if !census.temporalVia {
+	if streams.wantsAnnotated() {
+		// The temporal pass consumes the matched annotation edges
+		// themselves, so the presence probe's break-on-first-hit walk
+		// becomes one full collection walk of this small kind — replacing
+		// the pass's own EdgeAnnotated scan.
+		for e := range g.EdgesByKind(graph.EdgeAnnotated) {
+			if e == nil {
+				continue
+			}
+			if role, member := temporalRoleForJavaAnnotation(e.To); role != "" || member != "" {
+				streams.addAnnotated(e)
+			}
+		}
+		if !census.temporalVia {
+			census.temporalAnnotation = streams.annotatedCount() > 0
+		}
+	} else if !census.temporalVia {
 		for e := range g.EdgesByKind(graph.EdgeAnnotated) {
 			if e == nil {
 				continue
@@ -374,6 +405,14 @@ func collectFrameworkEdgeCensus(g graph.Store) frameworkEdgeCensus {
 				census.temporalAnnotation = true
 				break
 			}
+		}
+	}
+	if streams.wantsRefs() {
+		for e := range g.EdgesByKind(graph.EdgeReferences) {
+			if e == nil {
+				continue
+			}
+			streams.collectRefs(e)
 		}
 	}
 	return census
@@ -530,7 +569,17 @@ func summarizeFrameworkCandidatesCensus(
 		}
 	}
 	if fullCensus {
-		summary.edges = collectFrameworkEdgeCensus(g)
+		// Arm the shared-stream collectors with the family / node-marker
+		// verdicts the light walk just produced (the census-derived edge
+		// preflights are decided by the walk below and can only narrow
+		// admission further), then run the census edge walks as the single
+		// candidate dispatcher for every armed pass.
+		present, markers := summary.all, summary.allMarkers
+		if scope != nil {
+			present, markers = summary.scoped, summary.scopedMarkers
+		}
+		summary.streams = newFrameworkStreamCandidates(g, present, markers)
+		summary.edges = collectFrameworkEdgeCensus(g, summary.streams)
 	}
 	return summary
 }
@@ -786,7 +835,25 @@ func shouldRunFrameworkSynthesizer(s FrameworkSynthesizer, scope map[string]bool
 		present = summary.scoped
 		markers = summary.scopedMarkers
 	}
-	if families := frameworkSynthLanguageFamilies[s.Name()]; len(families) > 0 {
+	if !frameworkSynthNodeGatesPass(s.Name(), present, markers) {
+		return false
+	}
+	if summary.edges.valid {
+		if preflight := frameworkSynthEdgePreflights[s.Name()]; preflight != nil && !preflight(summary.edges) {
+			return false
+		}
+	}
+	return true
+}
+
+// frameworkSynthNodeGatesPass evaluates the family / conjunction /
+// node-marker gates for one pass against the chosen census maps — the
+// sub-verdict of shouldRunFrameworkSynthesizer that is already known after
+// the light node walk, before the edge census runs. The shared-stream
+// dispatcher arms a pass's candidate collectors on exactly this verdict, so
+// its armed set is a superset of the passes the full gate will admit.
+func frameworkSynthNodeGatesPass(name string, present, markers map[string]int) bool {
+	if families := frameworkSynthLanguageFamilies[name]; len(families) > 0 {
 		found := false
 		for _, family := range families {
 			if present[family] > 0 {
@@ -798,7 +865,7 @@ func shouldRunFrameworkSynthesizer(s FrameworkSynthesizer, scope map[string]bool
 			return false
 		}
 	}
-	for _, groups := range frameworkSynthFamilyConjunctions[s.Name()] {
+	for _, groups := range frameworkSynthFamilyConjunctions[name] {
 		found := false
 		for _, family := range groups {
 			if present[family] > 0 {
@@ -810,13 +877,8 @@ func shouldRunFrameworkSynthesizer(s FrameworkSynthesizer, scope map[string]bool
 			return false
 		}
 	}
-	for _, marker := range frameworkSynthNodePreflights[s.Name()] {
+	for _, marker := range frameworkSynthNodePreflights[name] {
 		if markers[marker] == 0 {
-			return false
-		}
-	}
-	if summary.edges.valid {
-		if preflight := frameworkSynthEdgePreflights[s.Name()]; preflight != nil && !preflight(summary.edges) {
 			return false
 		}
 	}
@@ -1087,7 +1149,15 @@ func runFrameworkSynthesizersScoped(
 		var n int
 		if shouldRunFrameworkSynthesizer(s, scope, candidates) {
 			if sf, ok := s.(synthFunc); ok {
+				bundle := candidates.streams.passStreams(sf.name)
 				switch {
+				case sf.candFn != nil && bundle != nil:
+					// Shared-stream form. streams exist only on a full-census
+					// run, where the execution store is the raw g for both
+					// the nil-scope and the attested full-coverage shapes.
+					n = runLegacyFrameworkSynth(g, func(store graph.Store) int {
+						return sf.candFn(store, bundle)
+					})
 				case scope == nil:
 					n = runLegacyFrameworkSynth(g, sf.fn)
 				case sf.scopedFn != nil:

--- a/internal/resolver/framework_synth.go
+++ b/internal/resolver/framework_synth.go
@@ -893,8 +893,8 @@ func frameworkSynthNodeGatesPass(name string, present, markers map[string]int) b
 // Native-bridge resolvers append to this slice.
 func defaultFrameworkSynthesizers() []FrameworkSynthesizer {
 	return []FrameworkSynthesizer{
-		synthFunc{name: SynthGRPCStub, fn: ResolveGRPCStubCalls},
-		synthFunc{name: SynthTemporalStub, fn: ResolveTemporalCalls},
+		synthFunc{name: SynthGRPCStub, fn: ResolveGRPCStubCalls, candFn: resolveGRPCStubCalls},
+		synthFunc{name: SynthTemporalStub, fn: ResolveTemporalCalls, candFn: resolveTemporalCalls},
 		synthFunc{name: SynthEventChannel, fn: ResolveEventChannelCalls},
 		synthFunc{name: SynthSwiftObjC, fn: ResolveSwiftObjCBridge},
 		synthFunc{name: SynthReactNative, fn: ResolveReactNativeBridge},
@@ -910,7 +910,7 @@ func defaultFrameworkSynthesizers() []FrameworkSynthesizer {
 		synthFunc{name: SynthSQLCallsite, fn: ResolveSQLCallsites},
 		// Store-factory (Zustand/Redux/Pinia/MobX) indirect action calls —
 		// binds getState()-chain and destructured calls to the action node.
-		synthFunc{name: SynthStoreFactory, fn: ResolveStoreFactoryCalls},
+		synthFunc{name: SynthStoreFactory, fn: ResolveStoreFactoryCalls, candFn: resolveStoreFactoryCalls},
 		// Redux Toolkit createAsyncThunk dispatch chains: a thunk →
 		// each action/thunk it dispatches from its payload-creator body.
 		// After store-factory so its action nodes are indexed for the
@@ -954,12 +954,12 @@ func defaultFrameworkSynthesizers() []FrameworkSynthesizer {
 		// C/C++ function-pointer dispatch: a fn registered into a struct's
 		// fn-pointer field → the indirect recv->field() call, keyed by
 		// (struct type, field) with a field-copy fixpoint.
-		synthFunc{name: SynthFnPointerDispatch, fn: ResolveFnPointerDispatch},
+		synthFunc{name: SynthFnPointerDispatch, fn: ResolveFnPointerDispatch, candFn: resolveFnPointerDispatch},
 		// C/C++ function-like macro expansion: a macro invocation
 		// `CALL_M(o)` → each call hidden in the macro's replacement list,
 		// attributed to the use-site line so a forward call walk shows the
 		// call where the macro is invoked, not at its `#define`.
-		synthFunc{name: SynthMacroExpansion, fn: ResolveMacroExpansionCalls},
+		synthFunc{name: SynthMacroExpansion, fn: ResolveMacroExpansionCalls, candFn: resolveMacroExpansionCalls},
 		// Gin middleware-chain dispatcher → registered handlers. Bridges the
 		// `c.handlers[idx](c)` indirection so ServeHTTP→handler reachability
 		// flows; repo-scoped, gated on a dispatcher existing.
@@ -970,16 +970,16 @@ func defaultFrameworkSynthesizers() []FrameworkSynthesizer {
 		// React custom-hook / context resolution: a `useAuth()` call binds to
 		// its /hooks/ definition; a `*Context`/`*Provider` reference binds to
 		// /context/ or /providers/, with the suffix-strip fallback.
-		synthFunc{name: SynthReactResolve, fn: ResolveReactHooksContext},
+		synthFunc{name: SynthReactResolve, fn: ResolveReactHooksContext, candFn: resolveReactHooksContext},
 		// FastAPI dependency / router fallback: a residual `Depends(get_db)`
 		// binds to a /dependencies/ provider, an `include_router(api_router)`
 		// to a /routers/ definition — only when reference resolution left the
 		// target unresolved.
-		synthFunc{name: SynthFastAPIResolve, fn: ResolveFastAPIDeps},
+		synthFunc{name: SynthFastAPIResolve, fn: ResolveFastAPIDeps, candFn: resolveFastAPIDeps},
 		// Rails receiver-constant resolution: a `UserService.perform` /
 		// `User.find` / `ApplicationHelper.fmt` call binds to the directory-
 		// located service / model / helper definition named by its receiver.
-		synthFunc{name: SynthRailsResolve, fn: ResolveRailsRefs},
+		synthFunc{name: SynthRailsResolve, fn: ResolveRailsRefs, candFn: resolveRailsRefs},
 		// SwiftUI directory-convention fallback: a residual `*View` /
 		// `*ViewModel` / `*Store` / `*Manager` / PascalCase-model reference
 		// binds to its /Views/ /ViewModels/ /Stores/ /Models/ definition.
@@ -1002,10 +1002,10 @@ func defaultFrameworkSynthesizers() []FrameworkSynthesizer {
 		// completion. Runs in the same settle window so residual
 		// unresolved Rust calls land before external-call synthesis
 		// classifies the rest as external.
-		synthFunc{name: SynthRustScope, fn: ResolveRustScopeCalls},
+		synthFunc{name: SynthRustScope, fn: ResolveRustScopeCalls, candFn: resolveRustScopeCalls},
 		// After rust-scope and the implements/extends-producing passes so the
 		// cross-file factory-chain walk + conformance hop see settled edges.
-		synthFunc{name: SynthFactoryChain, fn: ResolveFactoryChains},
+		synthFunc{name: SynthFactoryChain, fn: ResolveFactoryChains, candFn: resolveFactoryChains},
 		// Function-as-value callback registration — binds each captured
 		// value-position function identifier to its same-file definition and
 		// drops unbound candidates. The per-language capture feeds it via

--- a/internal/resolver/grpc_stub_calls.go
+++ b/internal/resolver/grpc_stub_calls.go
@@ -51,8 +51,23 @@ const grpcStubPrefix = unresolvedPrefix + "grpc::"
 // Returns the number of grpc.stub edges pointing at a resolved handler
 // after the pass.
 func ResolveGRPCStubCalls(g graph.Store) int {
+	return resolveGRPCStubCalls(g, nil)
+}
+
+// resolveGRPCStubCalls is the census-multiplexed form: cands, when non-nil,
+// carries the pass's pre-matched EdgeCalls candidates (stubs AND
+// registration carriers) from the shared full-census walk, replacing both
+// of this pass's own whole-stream decodes.
+func resolveGRPCStubCalls(g graph.Store, cands *frameworkPassCandidates) int {
 	if g == nil {
 		return 0
+	}
+
+	callsStream := g.EdgesByKind(graph.EdgeCalls)
+	var sharedCalls []*graph.Edge
+	if cands != nil {
+		sharedCalls = refetchFrameworkCandidates(g, cands.calls)
+		callsStream = frameworkEdgeSeq(sharedCalls)
 	}
 
 	resolved := 0
@@ -71,7 +86,7 @@ func ResolveGRPCStubCalls(g graph.Store) int {
 	}
 	var stubs []stubEdge
 	fromIDs := make(map[string]struct{})
-	for e := range g.EdgesByKind(graph.EdgeCalls) {
+	for e := range callsStream {
 		if e == nil || e.Meta == nil {
 			continue
 		}
@@ -96,7 +111,7 @@ func ResolveGRPCStubCalls(g graph.Store) int {
 		fromList = append(fromList, id)
 	}
 	callerNodes := g.GetNodesByIDs(fromList)
-	idx := buildGRPCHandlerIndex(g)
+	idx := buildGRPCHandlerIndex(g, cands != nil, sharedCalls)
 
 	for _, s := range stubs {
 		e := s.edge
@@ -172,8 +187,10 @@ func (idx *grpcHandlerIndex) lookup(service, method, callerRepo string) (id, ori
 }
 
 // buildGRPCHandlerIndex walks the graph once and indexes server-side
-// gRPC handler methods by service, via both discovery signals.
-func buildGRPCHandlerIndex(g graph.Store) *grpcHandlerIndex {
+// gRPC handler methods by service, via both discovery signals. When shared
+// is set, sharedCalls carries the registration-carrier candidates from the
+// census dispatcher and the index's own EdgeCalls decode is skipped.
+func buildGRPCHandlerIndex(g graph.Store, shared bool, sharedCalls []*graph.Edge) *grpcHandlerIndex {
 	typesByName := map[string][]*graph.Node{}
 	ifacesByName := map[string][]*graph.Node{}
 	typeAndIfaceNodes := nodesByKindsOrAll(g, graph.KindType, graph.KindInterface)
@@ -217,7 +234,11 @@ func buildGRPCHandlerIndex(g graph.Store) *grpcHandlerIndex {
 		}
 		implementorsByIface[e.To] = append(implementorsByIface[e.To], e.From)
 	}
-	for e := range g.EdgesByKind(graph.EdgeCalls) {
+	registrationStream := g.EdgesByKind(graph.EdgeCalls)
+	if shared {
+		registrationStream = frameworkEdgeSeq(sharedCalls)
+	}
+	for e := range registrationStream {
 		if e == nil || e.Meta == nil {
 			continue
 		}

--- a/internal/resolver/macro_expansion_calls.go
+++ b/internal/resolver/macro_expansion_calls.go
@@ -58,6 +58,17 @@ const macroFunctionKindMeta = "function"
 //
 // Returns the number of use-site call edges the pass owns after this run.
 func ResolveMacroExpansionCalls(g graph.Store) int {
+	return resolveMacroExpansionCalls(g, nil)
+}
+
+// resolveMacroExpansionCalls is the census-multiplexed form: cands, when
+// non-nil, supplies the shared macro-node snapshot and the pre-matched
+// use-site candidates (edges naming a function-like macro), replacing the
+// pass's own whole-kind node scan and EdgeCalls decode. The candidate
+// vocabulary is a name-only superset of the index built here (it skips the
+// recovered-callee requirement), so the loop's own byKey / macroByID
+// filters remain the deciding gate.
+func resolveMacroExpansionCalls(g graph.Store, cands *frameworkPassCandidates) int {
 	if g == nil {
 		return 0
 	}
@@ -75,9 +86,15 @@ func ResolveMacroExpansionCalls(g graph.Store) int {
 	macroNames := map[string]struct{}{}
 	macroKey := func(repo, name string) string { return repo + "\x00" + name }
 
+	var macroNodes []*graph.Node
+	if cands != nil {
+		macroNodes = cands.nodes.kind(g, graph.KindMacro)
+	} else {
+		macroNodes = nodesByKindsOrAll(g, graph.KindMacro)
+	}
 	var macros []*graph.Node
 	var macroIDs []string
-	for _, n := range nodesByKindsOrAll(g, graph.KindMacro) {
+	for _, n := range macroNodes {
 		if n == nil || n.Meta == nil || n.Name == "" {
 			continue
 		}
@@ -121,10 +138,14 @@ func ResolveMacroExpansionCalls(g graph.Store) int {
 		line   int
 		entry  *macroEntry
 	}
+	useSiteStream := g.EdgesByKind(graph.EdgeCalls)
+	if cands != nil {
+		useSiteStream = frameworkEdgeSeq(refetchFrameworkCandidates(g, cands.calls))
+	}
 	var callEdges []*graph.Edge
 	var candidateCallerIDs []string
 	callerSeen := make(map[string]struct{})
-	for e := range g.EdgesByKind(graph.EdgeCalls) {
+	for e := range useSiteStream {
 		if e == nil || e.From == "" || e.To == "" {
 			continue
 		}

--- a/internal/resolver/rails_resolve.go
+++ b/internal/resolver/rails_resolve.go
@@ -34,14 +34,33 @@ var (
 // ResolveRailsRefs binds residual unresolved Ruby `Const.method` calls to
 // their Rails definitions by directory convention. Returns the count bound.
 func ResolveRailsRefs(g graph.Store) int {
+	return resolveRailsRefs(g, nil)
+}
+
+// resolveRailsRefs is the census-multiplexed form: cands, when non-nil,
+// replaces the whole EdgeCalls decode with the shared walk's pre-matched
+// recv_const candidates. The class/method node index keeps its own
+// combined-kind scan: its first-wins name map depends on the multi-kind
+// scan's row order, which per-kind snapshot slices cannot reproduce.
+func resolveRailsRefs(g graph.Store, cands *frameworkPassCandidates) int {
 	if g == nil {
 		return 0
+	}
+	stream := g.EdgesByKind(graph.EdgeCalls)
+	if cands != nil {
+		refetched := refetchFrameworkCandidates(g, cands.calls)
+		if len(refetched) == 0 {
+			// The convention indexes below are pure reads consumed only by
+			// the loop; with no candidates the pass provably lands nothing.
+			return 0
+		}
+		stream = frameworkEdgeSeq(refetched)
 	}
 	models := railsModelClassSet(g)
 	methodsByClass := railsClassMethodIndex(g)
 	resolved := 0
 	var reindex []graph.EdgeReindex
-	for e := range g.EdgesByKind(graph.EdgeCalls) {
+	for e := range stream {
 		if e == nil || e.Meta == nil || !graph.IsUnresolvedTarget(e.To) {
 			continue
 		}

--- a/internal/resolver/react_resolve.go
+++ b/internal/resolver/react_resolve.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"iter"
 	"regexp"
 	"strings"
 
@@ -39,13 +40,27 @@ var (
 // references to their definitions by directory convention. Returns the count
 // bound.
 func ResolveReactHooksContext(g graph.Store) int {
+	return resolveReactHooksContext(g, nil)
+}
+
+// resolveReactHooksContext is the census-multiplexed form: cands, when
+// non-nil, replaces the EdgeCalls and EdgeReferences decodes with the
+// shared walk's pre-matched candidates. The (small) EdgeRendersChild kind
+// keeps its own stream in both forms.
+func resolveReactHooksContext(g graph.Store, cands *frameworkPassCandidates) int {
 	if g == nil {
 		return 0
 	}
+	callsStream := g.EdgesByKind(graph.EdgeCalls)
+	refsStream := g.EdgesByKind(graph.EdgeReferences)
+	if cands != nil {
+		callsStream = frameworkEdgeSeq(refetchFrameworkCandidates(g, cands.calls))
+		refsStream = frameworkEdgeSeq(refetchFrameworkCandidates(g, cands.refs))
+	}
 	resolved := 0
 	var reindex []graph.EdgeReindex
-	for _, kind := range []graph.EdgeKind{graph.EdgeCalls, graph.EdgeReferences, graph.EdgeRendersChild} {
-		for e := range g.EdgesByKind(kind) {
+	for _, stream := range []iter.Seq[*graph.Edge]{callsStream, refsStream, g.EdgesByKind(graph.EdgeRendersChild)} {
+		for e := range stream {
 			if e == nil || !graph.IsUnresolvedTarget(e.To) {
 				continue
 			}

--- a/internal/resolver/resolve_guard_spool.go
+++ b/internal/resolver/resolve_guard_spool.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/gob"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"sort"
@@ -13,10 +14,10 @@ import (
 )
 
 // resolveGuardRecord is the compact, pointer-free subset of reindexJob needed
-// by the post-pass cross-package guard. Records are spooled to a temporary
-// file so even a pathological pass where every pending edge changes keeps
-// cross-page state out of the Go heap. Live edges are recovered later through
-// one batched source-site query per page.
+// by the post-pass cross-package guard. One bounded page stays inline; larger
+// corpora spill to a temporary file so a pathological pass where every pending
+// edge changes still keeps cross-page state out of the Go heap. Live edges are
+// recovered later through one batched source-site query per page.
 type resolveGuardRecord struct {
 	From       string
 	CurrentTo  string
@@ -31,6 +32,9 @@ type resolveGuardRecord struct {
 }
 
 type resolveGuardSpool struct {
+	records []resolveGuardRecord
+	readAt  int
+	bytes   int
 	file    *os.File
 	writer  *bufio.Writer
 	encoder *gob.Encoder
@@ -38,23 +42,30 @@ type resolveGuardSpool struct {
 	count   int
 }
 
+// A resolveGuardRecord occupies 280 bytes on 64-bit Go before the bytes
+// referenced by its strings and Meta slice. Keep additional per-record
+// headroom so the inline byte limit remains conservative across allocator
+// alignment and small representation changes.
+const resolveGuardRecordFixedBytes = 320
+
 func newResolveGuardSpool() (*resolveGuardSpool, error) {
-	file, err := os.CreateTemp("", "gortex-resolve-guard-*")
-	if err != nil {
-		return nil, err
-	}
-	writer := bufio.NewWriterSize(file, 256<<10)
-	return &resolveGuardSpool{file: file, writer: writer, encoder: gob.NewEncoder(writer)}, nil
+	return &resolveGuardSpool{}, nil
 }
 
 func (s *resolveGuardSpool) close() {
-	if s == nil || s.file == nil {
+	if s == nil {
 		return
 	}
-	_ = s.writer.Flush()
-	name := s.file.Name()
-	_ = s.file.Close()
-	_ = os.Remove(name)
+	s.records = nil
+	if s.file != nil {
+		if s.writer != nil {
+			_ = s.writer.Flush()
+		}
+		name := s.file.Name()
+		_ = s.file.Close()
+		_ = os.Remove(name)
+		s.file = nil
+	}
 }
 
 func (s *resolveGuardSpool) appendJobs(groups [][]reindexJob) error {
@@ -71,12 +82,57 @@ func (s *resolveGuardSpool) appendJobs(groups [][]reindexJob) error {
 				CrossRepo: job.crossRepo, Confidence: job.confidence, Origin: job.origin,
 				Payload: payload,
 			}
-			if err := s.encoder.Encode(&record); err != nil {
+			if err := s.append(record); err != nil {
 				return err
 			}
-			s.count++
 		}
 	}
+	return nil
+}
+
+func resolveGuardRecordSize(record resolveGuardRecord) int {
+	payload := record.Payload
+	return resolveGuardRecordFixedBytes + len(record.From) + len(record.CurrentTo) + len(record.OldTo) +
+		len(record.Kind) + len(record.FilePath) + len(record.Origin) +
+		len(payload.From) + len(payload.To) + len(payload.Kind) + len(payload.FilePath) +
+		len(payload.ConfidenceLabel) + len(payload.Origin) + len(payload.Tier) + len(payload.Meta)
+}
+
+func (s *resolveGuardSpool) append(record resolveGuardRecord) error {
+	recordBytes := resolveGuardRecordSize(record)
+	if s.file == nil && len(s.records) < resolvePendingPageRows && s.bytes+recordBytes <= resolveSpoolInlineBytes {
+		s.records = append(s.records, record)
+		s.bytes += recordBytes
+		s.count++
+		return nil
+	}
+	if s.file == nil {
+		if err := s.spill(); err != nil {
+			return err
+		}
+	}
+	if err := s.encoder.Encode(&record); err != nil {
+		return err
+	}
+	s.count++
+	return nil
+}
+
+func (s *resolveGuardSpool) spill() error {
+	file, err := os.CreateTemp("", "gortex-resolve-guard-*")
+	if err != nil {
+		return err
+	}
+	s.file = file
+	s.writer = bufio.NewWriterSize(file, resolveSpoolBufferBytes)
+	s.encoder = gob.NewEncoder(s.writer)
+	for i := range s.records {
+		if err := s.encoder.Encode(&s.records[i]); err != nil {
+			return err
+		}
+	}
+	s.records = nil
+	s.bytes = 0
 	return nil
 }
 
@@ -92,18 +148,21 @@ func guardCandidateJob(job *reindexJob) bool {
 }
 
 func (s *resolveGuardSpool) beginRead() error {
+	if s.file == nil {
+		return nil
+	}
 	if err := s.writer.Flush(); err != nil {
 		return err
 	}
 	if _, err := s.file.Seek(0, io.SeekStart); err != nil {
 		return err
 	}
-	s.decoder = gob.NewDecoder(bufio.NewReaderSize(s.file, 256<<10))
+	s.decoder = gob.NewDecoder(bufio.NewReaderSize(s.file, resolveSpoolBufferBytes))
 	return nil
 }
 
 func (s *resolveGuardSpool) nextPage(limit int) ([]resolveGuardRecord, bool, error) {
-	if s.decoder == nil {
+	if s.file != nil && s.decoder == nil {
 		if err := s.beginRead(); err != nil {
 			return nil, false, err
 		}
@@ -111,18 +170,29 @@ func (s *resolveGuardSpool) nextPage(limit int) ([]resolveGuardRecord, bool, err
 	if limit <= 0 {
 		limit = resolvePendingPageRows
 	}
-	records := make([]resolveGuardRecord, 0, limit)
-	for len(records) < limit {
+	if s.readAt >= s.count {
+		return nil, true, nil
+	}
+	if s.file == nil {
+		start := s.readAt
+		s.readAt = min(s.readAt+limit, len(s.records))
+		return s.records[start:s.readAt], s.readAt == s.count, nil
+	}
+	remaining := s.count - s.readAt
+	targetRows := min(limit, remaining)
+	records := make([]resolveGuardRecord, 0, targetRows)
+	for len(records) < targetRows {
 		var record resolveGuardRecord
 		if err := s.decoder.Decode(&record); err != nil {
 			if errors.Is(err, io.EOF) {
-				return records, true, nil
+				return nil, false, fmt.Errorf("resolve guard spool ended after %d of %d records: %w", s.readAt+len(records), s.count, io.ErrUnexpectedEOF)
 			}
 			return nil, false, err
 		}
 		records = append(records, record)
 	}
-	return records, false, nil
+	s.readAt += len(records)
+	return records, s.readAt == s.count, nil
 }
 
 func guardJobsFromRecords(store graph.Store, records []resolveGuardRecord) []reindexJob {

--- a/internal/resolver/resolve_hot_cache.go
+++ b/internal/resolver/resolve_hot_cache.go
@@ -82,28 +82,39 @@ type hotNodeGen struct {
 	bytes int64
 }
 
-func newHotNodeGen() *hotNodeGen {
+func newHotNodeGen(pendingHint int) *hotNodeGen {
+	if pendingHint <= 0 {
+		return &hotNodeGen{}
+	}
+	nameHint := min(pendingHint, 4096)
+	nodeHint := 4096
+	if pendingHint <= 2048 {
+		nodeHint = pendingHint * 2
+	}
 	return &hotNodeGen{
-		nodes: make(map[string]*graph.Node, 4096),
-		names: make(map[string][]*graph.Node, 4096),
+		nodes: make(map[string]*graph.Node, nodeHint),
+		names: make(map[string][]*graph.Node, nameHint),
 	}
 }
 
 // resolveHotCache is used only while the owning Resolver holds its resolve
 // mutex; it needs no locking of its own.
 type resolveHotCache struct {
-	cur, prev *hotNodeGen
-	budget    int64
+	cur, prev   *hotNodeGen
+	budget      int64
+	pendingHint int
 
 	nodeHits, nodeMisses int64
 	nameHits, nameMisses int64
 }
 
-func newResolveHotCache(budget int64) *resolveHotCache {
+func newResolveHotCache(budget int64, pendingHint int) *resolveHotCache {
 	if budget <= 0 {
 		budget = int64(defaultResolveHotCacheMB) << 20
 	}
-	return &resolveHotCache{cur: newHotNodeGen(), prev: newHotNodeGen(), budget: budget}
+	return &resolveHotCache{
+		cur: newHotNodeGen(pendingHint), budget: budget, pendingHint: pendingHint,
+	}
 }
 
 func (c *resolveHotCache) rotateIfNeeded() {
@@ -111,15 +122,15 @@ func (c *resolveHotCache) rotateIfNeeded() {
 		return
 	}
 	c.prev = c.cur
-	c.cur = newHotNodeGen()
+	c.cur = newHotNodeGen(c.pendingHint)
 }
 
 func (c *resolveHotCache) flush() {
 	if c == nil {
 		return
 	}
-	c.cur = newHotNodeGen()
-	c.prev = newHotNodeGen()
+	c.cur = newHotNodeGen(c.pendingHint)
+	c.prev = nil
 }
 
 func (c *resolveHotCache) getNode(id string) (*graph.Node, bool) {
@@ -127,12 +138,17 @@ func (c *resolveHotCache) getNode(id string) (*graph.Node, bool) {
 		c.nodeHits++
 		return n, true
 	}
-	if n, ok := c.prev.nodes[id]; ok {
-		// Promote so a hot entry survives the next rotation.
-		c.cur.nodes[id] = n
-		c.cur.bytes += approxResolveNodeBytes(n)
-		c.nodeHits++
-		return n, true
+	if c.prev != nil {
+		if n, ok := c.prev.nodes[id]; ok {
+			// Promote so a hot entry survives the next rotation.
+			if c.cur.nodes == nil {
+				c.cur.nodes = make(map[string]*graph.Node)
+			}
+			c.cur.nodes[id] = n
+			c.cur.bytes += approxResolveNodeBytes(n)
+			c.nodeHits++
+			return n, true
+		}
 	}
 	c.nodeMisses++
 	return nil, false
@@ -146,6 +162,9 @@ func (c *resolveHotCache) putNode(n *graph.Node) {
 	}
 	if _, exists := c.cur.nodes[n.ID]; exists {
 		return
+	}
+	if c.cur.nodes == nil {
+		c.cur.nodes = make(map[string]*graph.Node)
 	}
 	c.cur.nodes[n.ID] = n
 	c.cur.bytes += approxResolveNodeBytes(n)
@@ -163,13 +182,18 @@ func (c *resolveHotCache) getNames(key string) ([]*graph.Node, bool) {
 		c.nameHits++
 		return hits, true
 	}
-	if hits, ok := c.prev.names[key]; ok {
-		c.cur.names[key] = hits
-		for _, n := range hits {
-			c.cur.bytes += approxResolveNodeBytes(n)
+	if c.prev != nil {
+		if hits, ok := c.prev.names[key]; ok {
+			if c.cur.names == nil {
+				c.cur.names = make(map[string][]*graph.Node)
+			}
+			c.cur.names[key] = hits
+			for _, n := range hits {
+				c.cur.bytes += approxResolveNodeBytes(n)
+			}
+			c.nameHits++
+			return hits, true
 		}
-		c.nameHits++
-		return hits, true
 	}
 	c.nameMisses++
 	return nil, false
@@ -181,6 +205,9 @@ func (c *resolveHotCache) getNames(key string) ([]*graph.Node, bool) {
 func (c *resolveHotCache) putNames(key string, hits []*graph.Node) {
 	if _, exists := c.cur.names[key]; exists {
 		return
+	}
+	if c.cur.names == nil {
+		c.cur.names = make(map[string][]*graph.Node)
 	}
 	c.cur.names[key] = hits
 	c.cur.bytes += int64(len(key)) + 48

--- a/internal/resolver/resolve_hot_cache_test.go
+++ b/internal/resolver/resolve_hot_cache_test.go
@@ -20,7 +20,7 @@ func hotCacheTestNode(id, name, repo string) *graph.Node {
 
 func TestResolveHotCacheRotationBoundsBytes(t *testing.T) {
 	budget := int64(64 << 10) // tiny budget forces rotation
-	c := newResolveHotCache(budget)
+	c := newResolveHotCache(budget, 4096)
 	for i := 0; i < 4096; i++ {
 		c.putNode(hotCacheTestNode(fmt.Sprintf("repo::fn::%05d", i), fmt.Sprintf("fn%05d", i), "repo"))
 	}
@@ -37,7 +37,7 @@ func TestResolveHotCacheRotationBoundsBytes(t *testing.T) {
 }
 
 func TestResolveHotCacheNegativeNameGroupsAreCached(t *testing.T) {
-	c := newResolveHotCache(1 << 20)
+	c := newResolveHotCache(1<<20, 1)
 	key := hotNameKey("repo", "language:go", "definitelyMissing")
 	if _, ok := c.getNames(key); ok {
 		t.Fatal("unexpected hit before put")
@@ -52,6 +52,23 @@ func TestResolveHotCacheNegativeNameGroupsAreCached(t *testing.T) {
 	}
 }
 
+func TestResolveHotCacheStartsWithOneFrontierSizedGeneration(t *testing.T) {
+	c := newResolveHotCache(1<<20, 2)
+	if c.cur == nil {
+		t.Fatal("current generation is nil")
+	}
+	if c.prev != nil {
+		t.Fatal("unused previous generation was allocated eagerly")
+	}
+	if len(c.cur.nodes) != 0 || len(c.cur.names) != 0 {
+		t.Fatal("new cache generation is not empty")
+	}
+	c.flush()
+	if c.prev != nil {
+		t.Fatal("flush allocated an unused previous generation")
+	}
+}
+
 func TestCachedParallelGetNodesByIDsServesRepeatsFromCache(t *testing.T) {
 	g := graph.New()
 	n1 := hotCacheTestNode("repo::fn::a", "a", "repo")
@@ -59,8 +76,8 @@ func TestCachedParallelGetNodesByIDsServesRepeatsFromCache(t *testing.T) {
 	g.AddNode(n1)
 	g.AddNode(n2)
 
-	r := &Resolver{graph: g, hotCache: newResolveHotCache(1 << 20)}
 	ids := []string{"repo::fn::a", "repo::fn::b", "repo::fn::missing"}
+	r := &Resolver{graph: g, hotCache: newResolveHotCache(1<<20, len(ids))}
 
 	first := r.cachedParallelGetNodesByIDs(ids)
 	if first["repo::fn::a"] == nil || first["repo::fn::b"] == nil {
@@ -99,7 +116,7 @@ func TestWarmRepoLanguageNameCacheReusesHotGroupsAcrossPages(t *testing.T) {
 		Kind: graph.EdgeCalls,
 	}}
 
-	r := &Resolver{graph: g, hotCache: newResolveHotCache(1 << 20)}
+	r := &Resolver{graph: g, hotCache: newResolveHotCache(1<<20, len(page))}
 	// Production order: warmLookupCacheWithSources installs the source-node
 	// ID cache before the name warm derives repo/language scopes from it.
 	r.nodeByID = map[string]*graph.Node{src.ID: src}

--- a/internal/resolver/resolve_stream_test.go
+++ b/internal/resolver/resolve_stream_test.go
@@ -3,9 +3,81 @@ package resolver
 import (
 	"fmt"
 	"testing"
+	"unsafe"
 
 	"github.com/zzet/gortex/internal/graph"
 )
+
+func TestResolveGuardRecordSizeCoversFixedMemory(t *testing.T) {
+	fixed := resolveGuardRecordSize(resolveGuardRecord{})
+	structBytes := int(unsafe.Sizeof(resolveGuardRecord{}))
+	if fixed < structBytes+32 {
+		t.Fatalf("fixed record accounting=%d, want at least %d-byte struct + 32 bytes headroom", fixed, structBytes)
+	}
+}
+
+func TestResolveGuardSpoolHonorsInlineByteLimit(t *testing.T) {
+	spool, err := newResolveGuardSpool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer spool.close()
+
+	record := resolveGuardRecord{Payload: persistedEdgeSpoolSnapshot{Meta: make([]byte, 32<<10)}}
+	recordBytes := resolveGuardRecordSize(record)
+	inlineRecords := resolveSpoolInlineBytes / recordBytes
+	if inlineRecords == 0 || inlineRecords >= resolvePendingPageRows {
+		t.Fatalf("invalid byte-boundary fixture: records=%d bytes=%d", inlineRecords, recordBytes)
+	}
+	for i := 0; i < inlineRecords; i++ {
+		record.Payload.Meta = make([]byte, 32<<10)
+		if err := spool.append(record); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if spool.file != nil {
+		t.Fatal("guard spool spilled before reaching the inline byte limit")
+	}
+	record.Payload.Meta = make([]byte, 32<<10)
+	if err := spool.append(record); err != nil {
+		t.Fatal(err)
+	}
+	if spool.file == nil {
+		t.Fatal("guard spool did not spill after crossing the inline byte limit")
+	}
+}
+
+func TestUnresolvedEdgeStreamKeepsSmallLegacyCorpusInline(t *testing.T) {
+	store := graph.New()
+	edges := make([]*graph.Edge, 0, 8)
+	for i := 0; i < cap(edges); i++ {
+		edges = append(edges, &graph.Edge{
+			From: fmt.Sprintf("source-%d", i), To: fmt.Sprintf("unresolved::target-%d", i),
+			Kind: graph.EdgeCalls, FilePath: "x.go", Line: i + 1,
+		})
+	}
+	store.AddBatch(nil, edges)
+
+	stream := newUnresolvedEdgeStream(store)
+	defer stream.close()
+	if stream.legacy == nil {
+		t.Fatal("in-memory graph unexpectedly selected the native pager")
+	}
+	if stream.legacy.file != nil || stream.legacy.decoder != nil {
+		t.Fatal("small legacy frontier opened a disk spool")
+	}
+	if len(stream.legacy.records) != len(edges) {
+		t.Fatalf("inline records = %d, want %d", len(stream.legacy.records), len(edges))
+	}
+
+	page, done, err := stream.nextPage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !done || len(page) != len(edges) {
+		t.Fatalf("inline replay len=%d done=%v, want %d/true", len(page), done, len(edges))
+	}
+}
 
 func TestUnresolvedEdgeStreamBoundsLegacyCorpus(t *testing.T) {
 	store := graph.New()
@@ -20,6 +92,9 @@ func TestUnresolvedEdgeStreamBoundsLegacyCorpus(t *testing.T) {
 
 	stream := newUnresolvedEdgeStream(store)
 	defer stream.close()
+	if stream.legacy == nil || stream.legacy.file == nil {
+		t.Fatal("large legacy frontier did not spill to disk")
+	}
 	total, peak := 0, 0
 	for {
 		page, done, err := stream.nextPage()
@@ -42,6 +117,35 @@ func TestUnresolvedEdgeStreamBoundsLegacyCorpus(t *testing.T) {
 	}
 }
 
+func TestResolveGuardSpoolKeepsSmallCorpusInline(t *testing.T) {
+	spool, err := newResolveGuardSpool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer spool.close()
+	edge := &graph.Edge{From: "repo::source", FilePath: "x.go", Line: 1}
+	job := reindexJob{
+		edge: edge, oldTo: "unresolved::target", newTo: "repo::target",
+		kind: graph.EdgeCalls, confidence: 0.5, origin: graph.OriginTextMatched,
+	}
+	if err := spool.appendJobs([][]reindexJob{{job}}); err != nil {
+		t.Fatal(err)
+	}
+	if spool.file != nil || spool.decoder != nil {
+		t.Fatal("small guard corpus opened a disk spool")
+	}
+	if len(spool.records) != 1 {
+		t.Fatalf("inline guard records = %d, want 1", len(spool.records))
+	}
+	records, done, err := spool.nextPage(16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !done || len(records) != 1 {
+		t.Fatalf("inline guard replay len=%d done=%v, want 1/true", len(records), done)
+	}
+}
+
 func TestResolveGuardSpoolPagesBoundChangedJobs(t *testing.T) {
 	spool, err := newResolveGuardSpool()
 	if err != nil {
@@ -60,6 +164,9 @@ func TestResolveGuardSpoolPagesBoundChangedJobs(t *testing.T) {
 	}
 	if err := spool.appendJobs([][]reindexJob{jobs}); err != nil {
 		t.Fatal(err)
+	}
+	if spool.file == nil {
+		t.Fatal("large guard corpus did not spill to disk")
 	}
 	if spool.count != len(jobs) {
 		t.Fatalf("spooled %d jobs, want %d", spool.count, len(jobs))

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -602,7 +602,7 @@ func (r *Resolver) ResolveAll() *ResolveStats {
 	// down with the pass; see resolve_hot_cache.go for the immutability and
 	// flush rules that make this safe.
 	if resolveHotCacheEnabled() {
-		r.hotCache = newResolveHotCache(resolveHotCacheBudgetBytes())
+		r.hotCache = newResolveHotCache(resolveHotCacheBudgetBytes(), len(pending))
 		defer func() {
 			if c := r.hotCache; c != nil {
 				r.logger.Info("resolver: hot cache stats",

--- a/internal/resolver/rust_bounds_test.go
+++ b/internal/resolver/rust_bounds_test.go
@@ -202,7 +202,7 @@ func TestRustInheritedMethodsKeepQualifiedOwnerAliases(t *testing.T) {
 			{From: bChild.ID, To: bParent.ID, Kind: graph.EdgeExtends},
 		},
 	)
-	idx, changed := buildRustScopeIndex(g)
+	idx, changed := buildRustScopeIndex(g, nil)
 	if changed != 0 || idx == nil {
 		t.Fatalf("buildRustScopeIndex() = (%v, %d), want non-nil, 0", idx, changed)
 	}

--- a/internal/resolver/rust_scope.go
+++ b/internal/resolver/rust_scope.go
@@ -60,6 +60,15 @@ import (
 // Returns the number of Rust module-import, supertrait, override, and call
 // edges this pass landed on concrete nodes.
 func ResolveRustScopeCalls(g graph.Store) int {
+	return resolveRustScopeCalls(g, nil)
+}
+
+// resolveRustScopeCalls is the census-multiplexed form: cands, when
+// non-nil, supplies the pre-matched unresolved-call candidates and the
+// shared node snapshot for the scope index's method / function / param
+// sweeps. The module-import, trait-override, alias, and field scans keep
+// their own streams — their kinds are not part of the shared walks.
+func resolveRustScopeCalls(g graph.Store, cands *frameworkPassCandidates) int {
 	if g == nil {
 		return 0
 	}
@@ -69,7 +78,11 @@ func ResolveRustScopeCalls(g graph.Store) int {
 	// graph has no unresolved Rust call edges.
 	bound := resolveRustModuleImports(g)
 
-	idx, extendsResolved := buildRustScopeIndex(g)
+	var snap *frameworkNodeSnapshot
+	if cands != nil {
+		snap = cands.nodes
+	}
+	idx, extendsResolved := buildRustScopeIndex(g, snap)
 	bound += extendsResolved
 	if idx == nil {
 		return bound
@@ -86,9 +99,13 @@ func ResolveRustScopeCalls(g graph.Store) int {
 	type candEdge struct {
 		edge *graph.Edge
 	}
-	var cands []candEdge
+	var callCands []candEdge
 	fromIDs := make(map[string]struct{})
-	for e := range g.EdgesByKind(graph.EdgeCalls) {
+	callStream := g.EdgesByKind(graph.EdgeCalls)
+	if cands != nil {
+		callStream = frameworkEdgeSeq(refetchFrameworkCandidates(g, cands.calls))
+	}
+	for e := range callStream {
 		if e == nil {
 			continue
 		}
@@ -98,12 +115,12 @@ func ResolveRustScopeCalls(g graph.Store) int {
 		if !rustScopeEdgeCandidate(e) {
 			continue
 		}
-		cands = append(cands, candEdge{edge: e})
+		callCands = append(callCands, candEdge{edge: e})
 		if e.From != "" {
 			fromIDs[e.From] = struct{}{}
 		}
 	}
-	if len(cands) == 0 {
+	if len(callCands) == 0 {
 		return bound + resolved
 	}
 
@@ -113,7 +130,7 @@ func ResolveRustScopeCalls(g graph.Store) int {
 	}
 	callerNodes := g.GetNodesByIDs(fromList)
 
-	for _, c := range cands {
+	for _, c := range callCands {
 		e := c.edge
 		caller := callerNodes[e.From]
 		if caller == nil || caller.Language != "rust" {
@@ -286,8 +303,10 @@ type rustFieldKey struct {
 // buildRustScopeIndex walks the graph once and indexes Rust method
 // owners, free functions, and caller params. Supertrait edges are resolved
 // before the method/function early-out; the returned count includes those
-// rewrites even when the graph contains marker traits only.
-func buildRustScopeIndex(g graph.Store) (*rustScopeIndex, int) {
+// rewrites even when the graph contains marker traits only. A non-nil snap
+// feeds the method / function / param sweeps from the run-wide shared node
+// snapshot instead of this pass's own kind scans.
+func buildRustScopeIndex(g graph.Store, snap *frameworkNodeSnapshot) (*rustScopeIndex, int) {
 	typeAliases := newRustTypeAliasIndex(g)
 	traitTargets := newRustTraitTargetIndex(g)
 	extendsResolved := resolveRustTraitExtendsWithIndex(g, traitTargets, typeAliases)
@@ -301,7 +320,7 @@ func buildRustScopeIndex(g graph.Store) (*rustScopeIndex, int) {
 		fieldTypesByOwner: map[rustFieldKey]string{},
 	}
 	any := false
-	for n := range g.NodesByKind(graph.KindMethod) {
+	for _, n := range frameworkKindNodes(g, snap, graph.KindMethod) {
 		if n == nil || n.Language != "rust" {
 			continue
 		}
@@ -336,7 +355,7 @@ func buildRustScopeIndex(g graph.Store) (*rustScopeIndex, int) {
 		}
 		any = true
 	}
-	for n := range g.NodesByKind(graph.KindFunction) {
+	for _, n := range frameworkKindNodes(g, snap, graph.KindFunction) {
 		if n == nil || n.Language != "rust" {
 			continue
 		}
@@ -349,7 +368,7 @@ func buildRustScopeIndex(g graph.Store) (*rustScopeIndex, int) {
 	}
 	// Params are read lazily-but-once: index every Rust param by its
 	// enclosing function/method ID for the shadow check.
-	for n := range g.NodesByKind(graph.KindParam) {
+	for _, n := range frameworkKindNodes(g, snap, graph.KindParam) {
 		if n == nil || n.Language != "rust" {
 			continue
 		}

--- a/internal/resolver/store_factory_calls.go
+++ b/internal/resolver/store_factory_calls.go
@@ -22,13 +22,27 @@ const storeFactoryVia = "store-factory"
 // pass prefers the candidate in the caller's file (then a unique binding match,
 // then a singleton). Returns the number of call edges landed on an action.
 func ResolveStoreFactoryCalls(g graph.Store) int {
+	return resolveStoreFactoryCalls(g, nil)
+}
+
+// resolveStoreFactoryCalls is the census-multiplexed form: cands, when
+// non-nil, supplies the pre-matched via=store-factory EdgeCalls candidates
+// and the shared function-node snapshot, replacing this pass's own
+// whole-stream decode and whole-kind node scan.
+func resolveStoreFactoryCalls(g graph.Store, cands *frameworkPassCandidates) int {
 	if g == nil {
 		return 0
+	}
+	var functionNodes []*graph.Node
+	if cands != nil {
+		functionNodes = cands.nodes.kind(g, graph.KindFunction)
+	} else {
+		functionNodes = nodesByKindsOrAll(g, graph.KindFunction)
 	}
 	// index: binding → member → action nodes (multiple files may reuse the
 	// same binding name, hence a slice).
 	index := map[string]map[string][]*graph.Node{}
-	for _, n := range nodesByKindsOrAll(g, graph.KindFunction) {
+	for _, n := range functionNodes {
 		if n == nil || n.Meta == nil {
 			continue
 		}
@@ -49,9 +63,13 @@ func ResolveStoreFactoryCalls(g graph.Store) int {
 		return 0
 	}
 
+	stream := g.EdgesByKind(graph.EdgeCalls)
+	if cands != nil {
+		stream = frameworkEdgeSeq(refetchFrameworkCandidates(g, cands.calls))
+	}
 	resolved := 0
 	var reindex []graph.EdgeReindex
-	for e := range g.EdgesByKind(graph.EdgeCalls) {
+	for e := range stream {
 		if e == nil || e.Meta == nil {
 			continue
 		}

--- a/internal/resolver/temporal_calls.go
+++ b/internal/resolver/temporal_calls.go
@@ -187,10 +187,15 @@ func temporalWrapperStubExists(g graph.Store, from, kind, name string) bool {
 //	extract the arg at the wrapper's param position, emit a new stub
 //
 // KEYWORDS — wrapper-following, temporal.stub, arg_names, single-level
-// resolveTemporalWrapperCalls returns the number of fresh wrapper-stub edges
-// it synthesised, so the caller can iterate the pass to a fixpoint and follow
-// multi-hop (depth>1) wrapper chains.
-func resolveTemporalWrapperCalls(g graph.Store) int {
+// resolveTemporalWrapperCalls returns the fresh wrapper-stub edges it
+// synthesised, so the caller can iterate the pass to a fixpoint and follow
+// multi-hop (depth>1) wrapper chains. When shared is set, seed carries the
+// stub edges to discover wrappers among (the census candidates plus the
+// stubs earlier iterations emitted) in place of this function's own
+// whole-stream decode; the caller scan that finds each wrapper's invokers
+// keeps its stream — it matches arbitrary call edges, not a via-tagged
+// subset — and runs only when a wrapper actually exists.
+func resolveTemporalWrapperCalls(g graph.Store, seed []*graph.Edge, shared bool) []*graph.Edge {
 	type wrapper struct {
 		id, kind, name string
 		pos            int
@@ -198,7 +203,11 @@ func resolveTemporalWrapperCalls(g graph.Store) int {
 	byID := map[string]wrapper{}
 	byName := map[string][]wrapper{}
 
-	for e := range g.EdgesByKind(graph.EdgeCalls) {
+	stubStream := g.EdgesByKind(graph.EdgeCalls)
+	if shared {
+		stubStream = frameworkEdgeSeq(seed)
+	}
+	for e := range stubStream {
 		if e == nil || e.Meta == nil || e.From == "" {
 			continue
 		}
@@ -232,7 +241,7 @@ func resolveTemporalWrapperCalls(g graph.Store) int {
 		}
 	}
 	if len(byID) == 0 {
-		return 0
+		return nil
 	}
 
 	type pending struct {
@@ -292,7 +301,7 @@ func resolveTemporalWrapperCalls(g graph.Store) int {
 		}
 	}
 
-	added := 0
+	var added []*graph.Edge
 	for _, p := range out {
 		if temporalWrapperStubExists(g, p.from, p.kind, p.name) {
 			continue
@@ -309,17 +318,29 @@ func resolveTemporalWrapperCalls(g graph.Store) int {
 		if p.fwdParam != "" {
 			meta["temporal_name_param"] = p.fwdParam
 		}
-		g.AddEdge(&graph.Edge{
+		stub := &graph.Edge{
 			From: p.from, To: temporalStubPlaceholder(p.kind, p.name),
 			Kind: graph.EdgeCalls, FilePath: p.file, Line: p.line,
 			Meta: meta,
-		})
-		added++
+		}
+		g.AddEdge(stub)
+		added = append(added, stub)
 	}
 	return added
 }
 
 func ResolveTemporalCalls(g graph.Store) int {
+	return resolveTemporalCalls(g, nil)
+}
+
+// resolveTemporalCalls is the census-multiplexed form of the pass: cands,
+// when non-nil, carries every temporal.* EdgeCalls edge and every temporal
+// annotation edge the shared full-census walk collected, replacing this
+// pass's own presence probe and per-phase whole-stream decodes. The wrapper
+// fixpoint's caller scan and the cross-language node sweeps keep their own
+// streams: the former discovers arbitrary callers of wrapper functions, the
+// latter must observe the temporal_role stamps this very run writes.
+func resolveTemporalCalls(g graph.Store, cands *frameworkPassCandidates) int {
 	if g == nil {
 		return 0
 	}
@@ -332,29 +353,37 @@ func ResolveTemporalCalls(g graph.Store) int {
 	// and previously still paid the fixpoint's own full calls-scans
 	// (measured 43.9s for nothing on a temporal-free 28-repo workspace).
 	// Break-on-first-hit keeps temporal-using workspaces at ~zero extra cost.
-	temporalPresent := false
-	for e := range g.EdgesByKind(graph.EdgeCalls) {
-		if e == nil || e.Meta == nil {
-			continue
+	// On the multiplexed path the census already answered the same two
+	// predicates: the collected buffers ARE the probe.
+	if cands != nil {
+		if len(cands.calls) == 0 && len(cands.annotated) == 0 {
+			return 0
 		}
-		if v, _ := e.Meta["via"].(string); strings.HasPrefix(v, "temporal.") {
-			temporalPresent = true
-			break
-		}
-	}
-	if !temporalPresent {
-		for e := range g.EdgesByKind(graph.EdgeAnnotated) {
-			if e == nil {
+	} else {
+		temporalPresent := false
+		for e := range g.EdgesByKind(graph.EdgeCalls) {
+			if e == nil || e.Meta == nil {
 				continue
 			}
-			if r, m := temporalRoleForJavaAnnotation(e.To); r != "" || m != "" {
+			if v, _ := e.Meta["via"].(string); strings.HasPrefix(v, "temporal.") {
 				temporalPresent = true
 				break
 			}
 		}
-	}
-	if !temporalPresent {
-		return 0
+		if !temporalPresent {
+			for e := range g.EdgesByKind(graph.EdgeAnnotated) {
+				if e == nil {
+					continue
+				}
+				if r, m := temporalRoleForJavaAnnotation(e.To); r != "" || m != "" {
+					temporalPresent = true
+					break
+				}
+			}
+		}
+		if !temporalPresent {
+			return 0
+		}
 	}
 	// Serialise against other graph-wide passes that mutate Node.Meta
 	// (markTestSymbolsAndEmitEdges, detectClonesAndEmitEdges,
@@ -376,16 +405,36 @@ func ResolveTemporalCalls(g graph.Store) int {
 	// idempotent (temporalWrapperStubExists guards re-emission), so it
 	// terminates once no fresh stub is added; the bound caps pathological
 	// chains.
+	// On the multiplexed path each phase re-reads the collected candidates
+	// in their CURRENT store form — one batched read per phase in place of
+	// one whole-stream decode per phase, with the same per-phase object
+	// isolation a fresh scan gives each backend.
+	shared := cands != nil
+	var wrapperSeed []*graph.Edge
+	if shared {
+		wrapperSeed = refetchFrameworkCandidates(g, cands.calls)
+	}
 	for i := 0; i < 16; i++ {
-		if resolveTemporalWrapperCalls(g) == 0 {
+		added := resolveTemporalWrapperCalls(g, wrapperSeed, shared)
+		if len(added) == 0 {
 			break
+		}
+		if shared {
+			// The next iteration discovers transitive wrappers among the
+			// stubs this one just emitted; grow the seed instead of
+			// re-scanning the stream for them.
+			wrapperSeed = append(wrapperSeed, added...)
 		}
 	}
 
 	// Executor-field pre-pass: rewrite struct-field dispatch stubs to the
 	// literal name supplied at the executor's construction site. Also runs
 	// before the sweep so the rewritten stubs resolve below.
-	resolveTemporalExecutorFields(g)
+	if shared {
+		resolveTemporalExecutorFields(g, refetchFrameworkCandidates(g, cands.calls), true)
+	} else {
+		resolveTemporalExecutorFields(g, nil, false)
+	}
 
 	// Single sweep over EdgeCalls — the largest edge class — collecting
 	// both the temporal.register edges (index inputs) and the
@@ -399,7 +448,23 @@ func ResolveTemporalCalls(g graph.Store) int {
 	var stubs []stubEdge
 	var registerEdges []*graph.Edge
 	fromIDSet := map[string]struct{}{}
-	for e := range g.EdgesByKind(graph.EdgeCalls) {
+	sweepStream := g.EdgesByKind(graph.EdgeCalls)
+	if shared {
+		// The census candidates plus this pass's own staged wrapper stubs
+		// are exactly the overlay a fresh stream walk would surface here.
+		sweep := refetchFrameworkCandidates(g, cands.calls)
+		if bs, ok := g.(*frameworkEdgeBatchStore); ok {
+			sweep = append(sweep, bs.stagedEdgesMatching(func(e *graph.Edge) bool {
+				if e.Kind != graph.EdgeCalls || e.Meta == nil {
+					return false
+				}
+				v, _ := e.Meta["via"].(string)
+				return strings.HasPrefix(v, "temporal.")
+			})...)
+		}
+		sweepStream = frameworkEdgeSeq(sweep)
+	}
+	for e := range sweepStream {
 		if e == nil || e.Meta == nil {
 			continue
 		}
@@ -424,16 +489,22 @@ func ResolveTemporalCalls(g graph.Store) int {
 		}
 	}
 
-	// Probe the (smaller) annotation class for Java temporal tags.
+	// Probe the (smaller) annotation class for Java temporal tags. The
+	// census walk already collected the matching edges on the multiplexed
+	// path; no pass mutates annotation edges, so they are used directly.
 	var annotatedEdges []*graph.Edge
-	for e := range g.EdgesByKind(graph.EdgeAnnotated) {
-		if e == nil {
-			continue
+	if shared {
+		annotatedEdges = cands.annotated
+	} else {
+		for e := range g.EdgesByKind(graph.EdgeAnnotated) {
+			if e == nil {
+				continue
+			}
+			if r, m := temporalRoleForJavaAnnotation(e.To); r == "" && m == "" {
+				continue
+			}
+			annotatedEdges = append(annotatedEdges, e)
 		}
-		if r, m := temporalRoleForJavaAnnotation(e.To); r == "" && m == "" {
-			continue
-		}
-		annotatedEdges = append(annotatedEdges, e)
 	}
 
 	// Early-out: a graph with no Temporal register / stub / annotation
@@ -444,7 +515,11 @@ func ResolveTemporalCalls(g graph.Store) int {
 		return 0
 	}
 
-	idx := buildTemporalIndex(g, registerEdges, annotatedEdges)
+	var snap *frameworkNodeSnapshot
+	if shared {
+		snap = cands.nodes
+	}
+	idx := buildTemporalIndex(g, registerEdges, annotatedEdges, snap)
 	resolved := 0
 	var reindexBatch []graph.EdgeReindex
 	fromList := make([]string, 0, len(fromIDSet))
@@ -666,7 +741,11 @@ func ResolveTemporalCalls(g graph.Store) int {
 	// last: it reads temporal_role / temporal_name meta stamped by the
 	// sweep above and the via=temporal.handler edges emitted by the Go
 	// extractor. Additive — graph.AddEdge dedupes.
-	resolveTemporalCrossLanguage(g)
+	if shared {
+		resolveTemporalCrossLanguage(g, refetchFrameworkCandidates(g, cands.calls), true)
+	} else {
+		resolveTemporalCrossLanguage(g, nil, false)
+	}
 	return resolved
 }
 
@@ -691,7 +770,13 @@ func temporalStubPlaceholder(kind, name string) string {
 // All edges carry cross_language=true and are emitted at the inferred
 // tier (the link is by string name across the type-system boundary).
 // graph.AddEdge dedupes → idempotent.
-func resolveTemporalCrossLanguage(g graph.Store) {
+//
+// When shared is set, sharedCalls carries the pass's temporal.* candidates
+// in their current form and replaces the temporal.handler stream decode.
+// The four node sweeps keep their own streams deliberately: they read the
+// temporal_role / temporal_name stamps THIS run's earlier phases wrote, and
+// a census-time snapshot predates those stamps on disk-backed stores.
+func resolveTemporalCrossLanguage(g graph.Store, sharedCalls []*graph.Edge, shared bool) {
 	// Go provider indexes, by name.
 	goWorkflow := map[string][]string{}
 	goSignalWf := map[string][]string{}
@@ -718,7 +803,11 @@ func resolveTemporalCrossLanguage(g graph.Store) {
 	for n := range g.NodesByKind(graph.KindMethod) {
 		addGoWorkflow(n)
 	}
-	for e := range g.EdgesByKind(graph.EdgeCalls) {
+	handlerStream := g.EdgesByKind(graph.EdgeCalls)
+	if shared {
+		handlerStream = frameworkEdgeSeq(sharedCalls)
+	}
+	for e := range handlerStream {
 		if e == nil || e.Meta == nil || e.From == "" {
 			continue
 		}
@@ -1047,7 +1136,10 @@ func (idx *temporalIndex) lookupExactSig(kind, name, callerRepo string) string {
 // collected by the single ResolveTemporalCalls sweep — passing them in
 // avoids re-scanning the (largest) EdgeCalls class and the EdgeAnnotated
 // class a second time.
-func buildTemporalIndex(g graph.Store, registerEdges, annotatedEdges []*graph.Edge) *temporalIndex {
+// A non-nil snap feeds the function / method sweep from the run-wide shared
+// node snapshot instead of this pass's own kind scans; the sweep reads only
+// names and extractor-stamped signature meta, which no synthesizer mutates.
+func buildTemporalIndex(g graph.Store, registerEdges, annotatedEdges []*graph.Edge, snap *frameworkNodeSnapshot) *temporalIndex {
 	idx := &temporalIndex{
 		byKindName: map[string][]*graph.Node{},
 		funcExact:  map[string][]*graph.Node{},
@@ -1094,10 +1186,10 @@ func buildTemporalIndex(g graph.Store, registerEdges, annotatedEdges []*graph.Ed
 		indexExactFunc(n)
 		indexConventionFunc(n)
 	}
-	for n := range g.NodesByKind(graph.KindFunction) {
+	for _, n := range frameworkKindNodes(g, snap, graph.KindFunction) {
 		indexFuncNode(n)
 	}
-	for n := range g.NodesByKind(graph.KindMethod) {
+	for _, n := range frameworkKindNodes(g, snap, graph.KindMethod) {
 		indexFuncNode(n)
 	}
 
@@ -1862,14 +1954,21 @@ func methodsOfJavaTypeFromIndex(t *graph.Node, methodsByReceiver map[string][]*g
 // recvType::field with conflicting construction-site literals is left
 // unresolved — same unique-or-nothing policy as the const-deref join.
 // KEYWORDS — temporal, executor-field, resolver
-func resolveTemporalExecutorFields(g graph.Store) {
+// When shared is set, sharedCalls carries the pass's temporal.* candidates
+// in their current form and replaces both phases' whole-stream decodes (the
+// two phases filter disjoint via tags, so one slice serves both).
+func resolveTemporalExecutorFields(g graph.Store, sharedCalls []*graph.Edge, shared bool) {
 	// Phase 1: collect the method-stub edges that read a receiver field,
 	// grouped by `recvType::field`.
 	type dispatch struct {
 		stubs []*graph.Edge
 	}
 	byField := map[string]*dispatch{}
-	for e := range g.EdgesByKind(graph.EdgeCalls) {
+	stubStream := g.EdgesByKind(graph.EdgeCalls)
+	if shared {
+		stubStream = frameworkEdgeSeq(sharedCalls)
+	}
+	for e := range stubStream {
 		if e == nil || e.Meta == nil {
 			continue
 		}
@@ -1899,7 +1998,11 @@ func resolveTemporalExecutorFields(g graph.Store) {
 	// values across construction sites is ambiguous and dropped.
 	valByField := map[string]string{}
 	ambiguous := map[string]struct{}{}
-	for e := range g.EdgesByKind(graph.EdgeCalls) {
+	markerStream := g.EdgesByKind(graph.EdgeCalls)
+	if shared {
+		markerStream = frameworkEdgeSeq(sharedCalls)
+	}
+	for e := range markerStream {
 		if e == nil || e.Meta == nil || e.From == "" {
 			continue
 		}

--- a/internal/resolver/unresolved_legacy_spool.go
+++ b/internal/resolver/unresolved_legacy_spool.go
@@ -4,10 +4,19 @@ import (
 	"bufio"
 	"encoding/gob"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 
 	"github.com/zzet/gortex/internal/graph"
+)
+
+const (
+	// Keep at most one compact replay page in memory. Larger legacy frontiers
+	// spill behind the same identity boundary instead of paying temp-file and
+	// gob setup for every small in-memory graph.
+	resolveSpoolBufferBytes = 256 << 10
+	resolveSpoolInlineBytes = 256 << 10
 )
 
 type unresolvedEdgeRecord struct {
@@ -21,9 +30,13 @@ type unresolvedEdgeRecord struct {
 // unresolvedLegacySpool gives stores without a native high-water pager the
 // same stable pass boundary without a pointer snapshot. The initial predicate
 // iterator is drained into compact identities before mutations begin; replay
-// rehydrates each bounded page with one batched site lookup.
+// rehydrates each bounded page with one batched site lookup. One bounded page
+// stays inline; larger frontiers spill to disk before resolution starts.
 type unresolvedLegacySpool struct {
 	store   graph.Store
+	records []unresolvedEdgeRecord
+	readAt  int
+	bytes   int
 	file    *os.File
 	writer  *bufio.Writer
 	encoder *gob.Encoder
@@ -32,14 +45,7 @@ type unresolvedLegacySpool struct {
 }
 
 func newUnresolvedLegacySpool(store graph.Store) (*unresolvedLegacySpool, error) {
-	file, err := os.CreateTemp("", "gortex-unresolved-*")
-	if err != nil {
-		return nil, err
-	}
-	writer := bufio.NewWriterSize(file, 256<<10)
-	spool := &unresolvedLegacySpool{
-		store: store, file: file, writer: writer, encoder: gob.NewEncoder(writer),
-	}
+	spool := &unresolvedLegacySpool{store: store}
 	for edge := range store.EdgesWithUnresolvedTarget() {
 		if edge == nil {
 			continue
@@ -48,33 +54,87 @@ func newUnresolvedLegacySpool(store graph.Store) (*unresolvedLegacySpool, error)
 			From: edge.From, To: edge.To, Kind: edge.Kind,
 			FilePath: edge.FilePath, Line: edge.Line,
 		}
-		if err := spool.encoder.Encode(&record); err != nil {
+		if err := spool.append(record); err != nil {
 			spool.close()
 			return nil, err
 		}
-		spool.count++
 	}
-	if err := spool.writer.Flush(); err != nil {
-		spool.close()
-		return nil, err
+	if spool.file != nil {
+		if err := spool.beginRead(); err != nil {
+			spool.close()
+			return nil, err
+		}
 	}
-	if _, err := spool.file.Seek(0, io.SeekStart); err != nil {
-		spool.close()
-		return nil, err
-	}
-	spool.decoder = gob.NewDecoder(bufio.NewReaderSize(spool.file, 256<<10))
 	return spool, nil
 }
 
+func unresolvedEdgeRecordSize(record unresolvedEdgeRecord) int {
+	return 96 + len(record.From) + len(record.To) + len(record.Kind) + len(record.FilePath)
+}
+
+func (s *unresolvedLegacySpool) append(record unresolvedEdgeRecord) error {
+	recordBytes := unresolvedEdgeRecordSize(record)
+	if s.file == nil && len(s.records) < resolvePendingPageRows && s.bytes+recordBytes <= resolveSpoolInlineBytes {
+		s.records = append(s.records, record)
+		s.bytes += recordBytes
+		s.count++
+		return nil
+	}
+	if s.file == nil {
+		if err := s.spill(); err != nil {
+			return err
+		}
+	}
+	if err := s.encoder.Encode(&record); err != nil {
+		return err
+	}
+	s.count++
+	return nil
+}
+
+func (s *unresolvedLegacySpool) spill() error {
+	file, err := os.CreateTemp("", "gortex-unresolved-*")
+	if err != nil {
+		return err
+	}
+	s.file = file
+	s.writer = bufio.NewWriterSize(file, resolveSpoolBufferBytes)
+	s.encoder = gob.NewEncoder(s.writer)
+	for i := range s.records {
+		if err := s.encoder.Encode(&s.records[i]); err != nil {
+			return err
+		}
+	}
+	s.records = nil
+	s.bytes = 0
+	return nil
+}
+
+func (s *unresolvedLegacySpool) beginRead() error {
+	if err := s.writer.Flush(); err != nil {
+		return err
+	}
+	if _, err := s.file.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	s.decoder = gob.NewDecoder(bufio.NewReaderSize(s.file, resolveSpoolBufferBytes))
+	return nil
+}
+
 func (s *unresolvedLegacySpool) close() {
-	if s == nil || s.file == nil {
+	if s == nil {
 		return
 	}
-	_ = s.writer.Flush()
-	name := s.file.Name()
-	_ = s.file.Close()
-	_ = os.Remove(name)
-	s.file = nil
+	s.records = nil
+	if s.file != nil {
+		if s.writer != nil {
+			_ = s.writer.Flush()
+		}
+		name := s.file.Name()
+		_ = s.file.Close()
+		_ = os.Remove(name)
+		s.file = nil
+	}
 }
 
 func (s *unresolvedLegacySpool) nextPage(maxRows, maxBytes int) ([]*graph.Edge, bool, error) {
@@ -84,24 +144,38 @@ func (s *unresolvedLegacySpool) nextPage(maxRows, maxBytes int) ([]*graph.Edge, 
 	if maxBytes <= 0 {
 		maxBytes = resolvePendingPageBytes
 	}
-	records := make([]unresolvedEdgeRecord, 0, maxRows)
+	if s.readAt >= s.count {
+		return nil, true, nil
+	}
+	if s.file == nil {
+		start := s.readAt
+		bytesUsed := 0
+		for s.readAt < len(s.records) && s.readAt-start < maxRows && (s.readAt == start || bytesUsed < maxBytes) {
+			bytesUsed += unresolvedEdgeRecordSize(s.records[s.readAt])
+			s.readAt++
+		}
+		return s.rehydrate(s.records[start:s.readAt]), s.readAt == s.count, nil
+	}
+	remaining := s.count - s.readAt
+	targetRows := min(maxRows, remaining)
+	records := make([]unresolvedEdgeRecord, 0, targetRows)
 	bytesUsed := 0
-	exhausted := false
-	for len(records) < maxRows && bytesUsed < maxBytes {
+	for len(records) < targetRows && bytesUsed < maxBytes {
 		var record unresolvedEdgeRecord
 		if err := s.decoder.Decode(&record); err != nil {
 			if errors.Is(err, io.EOF) {
-				exhausted = true
-				break
+				return nil, false, fmt.Errorf("unresolved edge spool ended after %d of %d records: %w", s.readAt+len(records), s.count, io.ErrUnexpectedEOF)
 			}
 			return nil, false, err
 		}
 		records = append(records, record)
-		bytesUsed += 96 + len(record.From) + len(record.To) + len(record.Kind) + len(record.FilePath)
+		bytesUsed += unresolvedEdgeRecordSize(record)
 	}
-	if len(records) == 0 {
-		return nil, exhausted, nil
-	}
+	s.readAt += len(records)
+	return s.rehydrate(records), s.readAt == s.count, nil
+}
+
+func (s *unresolvedLegacySpool) rehydrate(records []unresolvedEdgeRecord) []*graph.Edge {
 	sites := make([]graph.EdgeSite, 0, len(records))
 	for _, record := range records {
 		sites = append(sites, graph.EdgeSite{From: record.From, Line: record.Line, Kind: record.Kind})
@@ -116,5 +190,5 @@ func (s *unresolvedLegacySpool) nextPage(maxRows, maxBytes int) ([]*graph.Edge, 
 			}
 		}
 	}
-	return edges, exhausted, nil
+	return edges
 }


### PR DESCRIPTION
Follow-up to #290. This change closes the localization-quality gaps found in the 28-session facade transcript audit without adding repository-specific rules.

## What changed

- keep deterministic fallback in MCP metadata and expose only neutral, bounded ranked evidence to the model
- preserve zero-empty-final terminal steering without prompt-injection-like `answer NOW` or `verbatim` text
- evaluate quoted-source coverage per term, retaining compact locale/protocol keys beside unrelated exact metadata matches
- keep raw-source fallback bounded to one repository, 24 hits, and a shared 150 ms ceiling
- choose refinement reads from semantic declaration/body alignment while preserving verified literal evidence
- keep required symbol/file coherence without violating primary/exact evidence ordering or serialization budgets
- retain at least one mandatory digest row by shedding optional metadata before evidence

## Validation

- `go test ./internal/mcp`
- `go test -race ./internal/mcp`
- `go test ./internal/indexer ./internal/search/trigram`
- `golangci-lint run --timeout=10m` with sandbox-safe caches: 0 issues
- cold-index regression guard: 3/3 isolated runs pass
- Gortex post-change mapping: 9/9 changed production symbols covered; no configured guard violations

The full `go test ./...` run passed every package except one cold-index wall-clock sample under suite-wide contention; three immediate isolated reruns passed. A fresh 28-session N=1 localization campaign is in progress and will be added before this draft is marked ready.

## Measurement integrity

Canonical benchmark output remains unchanged. A separate audited-label rescore corrects five hunk-header/context defects found by comparing the corpus to the actual merged PR declarations; audited results will not overwrite or be presented as canonical scores.
