### PR TITLE
Prefer the native tsgo server for TypeScript LSP routing

### DIFF
--- a/cmd/gortex/daemon_state.go
+++ b/cmd/gortex/daemon_state.go
@@ -365,9 +365,9 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 			registered++
 			for _, spec := range specs {
 				switch spec {
-				case "typescript-language-server":
+				case "typescript-language-server", "tsgo":
 					tsRepos++
-				case "pyright":
+				case "pyright", "pyrefly":
 					pythonRepos++
 				}
 			}

--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -18,13 +18,13 @@ reaper at ten minutes, LRU eviction at six concurrent.
 
 ## Server registry
 
-Sixteen servers ship in the registry today
-(`internal/semantic/lsp/registry.go`):
+The core registry (`internal/semantic/lsp/registry.go`):
 
 | Spec name                    | Command                          | Languages                   | Default priority |
 | ---------------------------- | -------------------------------- | --------------------------- | ---------------- |
 | `gopls`                      | `gopls`                          | go                          | 3                |
-| `typescript-language-server` | `typescript-language-server`     | typescript, javascript      | 5                |
+| `tsgo`                       | `tsgo --lsp`                     | typescript, javascript      | 5                |
+| `typescript-language-server` | `typescript-language-server`     | typescript, javascript      | 6                |
 | `pyright`                    | `pyright-langserver`             | python                      | 5                |
 | `rust-analyzer`              | `rust-analyzer`                  | rust                        | 5                |
 | `clangd`                     | `clangd --background-index`      | c, c++, objc, objc++        | 5                |
@@ -51,6 +51,14 @@ Lower priority numbers win when more than one provider serves the same
 language. `gopls` is `3` so it beats SCIP-based providers (`5`) for Go;
 `jdtls` is `6` so it's lower-priority than the SCIP-java path that
 ships separately.
+
+When several specs cover the same file extension, routing prefers the
+highest-priority spec whose binary is actually installed. `tsgo` — the
+native-Go TypeScript compiler's LSP mode — is the default TS/JS winner
+when its binary is on `PATH` (one native process instead of a
+node + tsserver + typingsInstaller tree); `typescript-language-server`
+serves wherever `tsgo` is missing or fails to spawn. The same rule
+gives `.py` a `pyrefly` fallback when `pyright` is not installed.
 
 `clangd` is the one server that needs a compilation database for full
 enrichment. Point it at a `compile_commands.json` (or a `compile_flags.txt`
@@ -98,8 +106,9 @@ npm install -g pyright            # recommended
 pip install jedi-language-server  # alt
 pip install python-lsp-server     # alt (pylsp)
 
-# TypeScript / JavaScript
-npm install -g typescript typescript-language-server
+# TypeScript / JavaScript (pick one)
+npm install -g @typescript/native-preview          # ships tsgo (preferred)
+npm install -g typescript typescript-language-server  # node-based fallback
 
 # C / C++ / Objective-C
 brew install llvm                 # ships clangd

--- a/internal/semantic/lsp/registry.go
+++ b/internal/semantic/lsp/registry.go
@@ -4,8 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
+	"sync"
 
 	"github.com/zzet/gortex/internal/semantic"
 )
@@ -179,9 +182,10 @@ type ServerAlt struct {
 // route. Order is meaningful only for the seed config — the runtime
 // router uses the per-extension lookup table.
 //
-// Adding a new server: add the entry here and add its file extensions
-// to extToSpec at init time. The default config picks it up
-// automatically; users override priority / command via .gortex.yaml.
+// Adding a new server: add the entry here and its file extensions are
+// collected into the per-extension table at init time. The default
+// config picks it up automatically; users override priority / command
+// via .gortex.yaml.
 // JdtlsTrustBuildEnv, when set to a truthy value ("1" / "true"), opts jdtls
 // into build-backed resolution (Maven/Gradle import + autobuild) for the
 // indexed repository. OFF by default: import and autobuild RUN the indexed
@@ -278,17 +282,20 @@ var Servers = []ServerSpec{
 			".mjs": "javascript",
 			".cjs": "javascript",
 		},
-		Priority:     5,
+		// Fallback behind tsgo: serves TS/JS wherever the native
+		// compiler's binary is not installed. Raise its priority in
+		// .gortex.yaml to prefer it over tsgo again.
+		Priority:     6,
 		Daemon:       true,
 		MaxParallel:  10,
 		ProjectReady: tsProjectReady,
 	},
 	{
-		// tsgo is the native-Go TypeScript compiler (the
-		// @typescript/native-preview package). Its LSP mode is offered
-		// at a lower precedence than typescript-language-server so the
-		// default routing is unchanged for anyone who has both — a
-		// user opts in by raising its priority in .gortex.yaml.
+		// tsgo is the native-Go TypeScript compiler's LSP mode. It is
+		// the default TS/JS routing winner when its binary is on PATH:
+		// native process, no node/tsserver/typingsInstaller tree, much
+		// faster startup. typescript-language-server serves as the
+		// fallback when tsgo is not installed.
 		Name:      "tsgo",
 		Command:   "tsgo",
 		Args:      []string{"--lsp", "--stdio"},
@@ -307,7 +314,7 @@ var Servers = []ServerSpec{
 			".mjs": "javascript",
 			".cjs": "javascript",
 		},
-		Priority:     6,
+		Priority:     5,
 		Daemon:       true,
 		MaxParallel:  10,
 		ProjectReady: tsProjectReady,
@@ -632,29 +639,30 @@ var Servers = []ServerSpec{
 	},
 }
 
-// extToSpec resolves a file extension (with leading dot, lower case) to
-// its preferred LSP spec. Built once at init from `Servers`.
-var extToSpec map[string]*ServerSpec
+// extToSpecs resolves a file extension (with leading dot, lower case)
+// to every spec covering it, ordered by Priority (registration order
+// breaks ties). Built once at init from `Servers`.
+var extToSpecs map[string][]*ServerSpec
 
 // nameToSpec resolves a server name (e.g. "rust-analyzer") to its spec.
 var nameToSpec map[string]*ServerSpec
 
 func init() {
-	extToSpec = make(map[string]*ServerSpec, 64)
+	extToSpecs = make(map[string][]*ServerSpec, 64)
 	nameToSpec = make(map[string]*ServerSpec, len(Servers))
 	for i := range Servers {
 		spec := &Servers[i]
 		nameToSpec[spec.Name] = spec
 		for _, ext := range spec.Extensions {
 			lower := strings.ToLower(ext)
-			// First registration wins; entries earlier in `Servers`
-			// take precedence when extensions overlap. (Used to keep
-			// gopls authoritative for `.go` even if a future entry
-			// claims it.)
-			if _, exists := extToSpec[lower]; !exists {
-				extToSpec[lower] = spec
-			}
+			extToSpecs[lower] = append(extToSpecs[lower], spec)
 		}
+	}
+	// Priority orders the candidates per extension; the stable sort
+	// keeps registration order among equals (gopls stays authoritative
+	// for `.go` even if a future same-priority entry claims it).
+	for _, specs := range extToSpecs {
+		sort.SliceStable(specs, func(i, j int) bool { return specs[i].Priority < specs[j].Priority })
 	}
 
 	// Contribute every known LSP spec to semantic.DefaultConfig()
@@ -681,16 +689,97 @@ func init() {
 }
 
 // SpecForExtension returns the ServerSpec preferred for the given file
-// extension (with or without leading dot). Returns nil when no spec
-// covers the extension.
+// extension (with or without leading dot): the highest-priority spec
+// whose binary is actually installed. When several specs cover one
+// extension (tsgo / typescript-language-server, pyright / pyrefly) the
+// lower Priority number wins among the installed ones — `.ts` routes
+// to tsgo when its binary is on PATH and falls back to
+// typescript-language-server otherwise. When none of the covering
+// servers is installed the priority winner is returned unchanged, so
+// the spawn path reports the missing binary as before. Returns nil
+// when no spec covers the extension.
 func SpecForExtension(ext string) *ServerSpec {
+	specs := SpecsForExtension(ext)
+	if len(specs) == 0 {
+		return nil
+	}
+	for _, s := range specs {
+		if specCommandAvailable(s) {
+			return s
+		}
+	}
+	return specs[0]
+}
+
+// SpecsForExtension returns every ServerSpec covering the extension in
+// priority order (lower Priority number first), without consulting
+// binary availability. Callers that hold their own availability source
+// (e.g. the Router) walk this list and pick the first live entry.
+func SpecsForExtension(ext string) []*ServerSpec {
 	if ext == "" {
 		return nil
 	}
 	if !strings.HasPrefix(ext, ".") {
 		ext = "." + ext
 	}
-	return extToSpec[strings.ToLower(ext)]
+	return extToSpecs[strings.ToLower(ext)]
+}
+
+// lookPath is swappable in tests so extension-preference cases can
+// simulate which server binaries are installed.
+var lookPath = exec.LookPath
+
+var (
+	cmdAvailMu    sync.Mutex
+	cmdAvailCache map[string]bool
+)
+
+// specCommandAvailable reports whether the spec's command (or one of
+// its alternatives) resolves on PATH. Passive connect specs count as
+// available — they dial instead of spawn. Results are cached for the
+// process lifetime, matching Router.specAvailable: installing a server
+// mid-daemon takes a restart to notice.
+func specCommandAvailable(s *ServerSpec) bool {
+	if s == nil {
+		return false
+	}
+	if s.Connect != nil {
+		return s.Connect.Validate() == nil
+	}
+	if commandOnPath(s.Command) {
+		return true
+	}
+	for _, alt := range s.AlternativeCommands {
+		if commandOnPath(alt.Command) {
+			return true
+		}
+	}
+	return false
+}
+
+func commandOnPath(cmd string) bool {
+	if cmd == "" {
+		return false
+	}
+	cmdAvailMu.Lock()
+	defer cmdAvailMu.Unlock()
+	if v, ok := cmdAvailCache[cmd]; ok {
+		return v
+	}
+	if cmdAvailCache == nil {
+		cmdAvailCache = make(map[string]bool)
+	}
+	_, err := lookPath(cmd)
+	cmdAvailCache[cmd] = err == nil
+	return err == nil
+}
+
+// resetCommandAvailabilityCache clears the per-command PATH cache.
+// Test-only: pairs with swapping lookPath.
+func resetCommandAvailabilityCache() {
+	cmdAvailMu.Lock()
+	cmdAvailCache = nil
+	cmdAvailMu.Unlock()
 }
 
 // SpecForPath returns the ServerSpec covering the file's extension.

--- a/internal/semantic/lsp/registry_test.go
+++ b/internal/semantic/lsp/registry_test.go
@@ -1,22 +1,49 @@
 package lsp
 
 import (
+	"os/exec"
 	"strings"
 	"testing"
 
 	"github.com/zzet/gortex/internal/semantic"
 )
 
+// stubInstalledCommands swaps the registry's PATH lookup so tests can
+// simulate exactly which server binaries are installed. Restores the
+// real lookup (and clears the cache) on cleanup.
+func stubInstalledCommands(t *testing.T, installed ...string) {
+	t.Helper()
+	have := make(map[string]bool, len(installed))
+	for _, c := range installed {
+		have[c] = true
+	}
+	orig := lookPath
+	lookPath = func(cmd string) (string, error) {
+		if have[cmd] {
+			return "/stub/bin/" + cmd, nil
+		}
+		return "", exec.ErrNotFound
+	}
+	resetCommandAvailabilityCache()
+	t.Cleanup(func() {
+		lookPath = orig
+		resetCommandAvailabilityCache()
+	})
+}
+
 // TestSpecForExtension verifies the per-extension lookup table is
 // populated for every claimed extension and that case is normalised.
+// No binaries are "installed", so every extension reports its priority
+// winner.
 func TestSpecForExtension(t *testing.T) {
+	stubInstalledCommands(t)
 	cases := []struct {
 		ext      string
 		wantName string
 	}{
 		{".go", "gopls"},
-		{".ts", "typescript-language-server"},
-		{".tsx", "typescript-language-server"},
+		{".ts", "tsgo"},
+		{".tsx", "tsgo"},
 		{".py", "pyright"},
 		{".pyi", "pyright"},
 		{".rs", "rust-analyzer"},
@@ -137,8 +164,8 @@ func TestExtensionsCoverEverySpec(t *testing.T) {
 }
 
 // TestPyreflyAndTsgoSpecs verifies the pyrefly and tsgo LSP servers are
-// registered as first-class specs without disturbing the default
-// Python / TypeScript routing.
+// registered as first-class specs: tsgo is the default TypeScript
+// routing winner, pyrefly stays a fallback behind pyright.
 func TestPyreflyAndTsgoSpecs(t *testing.T) {
 	pyrefly := SpecByName("pyrefly")
 	if pyrefly == nil {
@@ -159,13 +186,15 @@ func TestPyreflyAndTsgoSpecs(t *testing.T) {
 		t.Errorf("tsgo invocation: %s %v", tsgo.Command, tsgo.Args)
 	}
 
-	// Default extension routing must be unchanged — the incumbents
-	// register earlier in Servers and keep .py / .ts.
-	if s := SpecForExtension(".py"); s == nil || s.Name != "pyright" {
-		t.Errorf(".py should still route to pyright, got %v", s)
+	// tsgo outranks typescript-language-server by default; pyright
+	// keeps outranking pyrefly.
+	tls := SpecByName("typescript-language-server")
+	if tls == nil || tsgo.Priority >= tls.Priority {
+		t.Errorf("tsgo (prio %d) must outrank typescript-language-server (%v)", tsgo.Priority, tls)
 	}
-	if s := SpecForExtension(".ts"); s == nil || s.Name != "typescript-language-server" {
-		t.Errorf(".ts should still route to typescript-language-server, got %v", s)
+	pyright := SpecByName("pyright")
+	if pyright == nil || pyright.Priority >= pyrefly.Priority {
+		t.Errorf("pyright (%v) must outrank pyrefly (prio %d)", pyright, pyrefly.Priority)
 	}
 
 	// Both must be contributed to the default provider list.
@@ -177,6 +206,48 @@ func TestPyreflyAndTsgoSpecs(t *testing.T) {
 	if !have["pyrefly"] || !have["tsgo"] {
 		t.Errorf("pyrefly/tsgo missing from DefaultConfig providers")
 	}
+}
+
+// TestSpecForExtensionPrefersInstalledPriorityWinner pins the
+// multi-spec extension ladder: the highest-priority spec whose binary
+// is installed wins, and the priority winner is reported when none is.
+func TestSpecForExtensionPrefersInstalledPriorityWinner(t *testing.T) {
+	t.Run("both TS servers installed → tsgo", func(t *testing.T) {
+		stubInstalledCommands(t, "tsgo", "typescript-language-server")
+		if s := SpecForExtension(".ts"); s == nil || s.Name != "tsgo" {
+			t.Errorf(".ts with both installed: got %v, want tsgo", s)
+		}
+	})
+	t.Run("only node server installed → fallback", func(t *testing.T) {
+		stubInstalledCommands(t, "typescript-language-server")
+		if s := SpecForExtension(".ts"); s == nil || s.Name != "typescript-language-server" {
+			t.Errorf(".ts without tsgo: got %v, want typescript-language-server", s)
+		}
+	})
+	t.Run("only tsgo installed → tsgo", func(t *testing.T) {
+		stubInstalledCommands(t, "tsgo")
+		if s := SpecForExtension(".tsx"); s == nil || s.Name != "tsgo" {
+			t.Errorf(".tsx with only tsgo: got %v, want tsgo", s)
+		}
+	})
+	t.Run("none installed → priority winner", func(t *testing.T) {
+		stubInstalledCommands(t)
+		if s := SpecForExtension(".ts"); s == nil || s.Name != "tsgo" {
+			t.Errorf(".ts with nothing installed: got %v, want priority winner tsgo", s)
+		}
+	})
+	t.Run("python default unchanged when both installed", func(t *testing.T) {
+		stubInstalledCommands(t, "pyright-langserver", "pyrefly")
+		if s := SpecForExtension(".py"); s == nil || s.Name != "pyright" {
+			t.Errorf(".py with both installed: got %v, want pyright", s)
+		}
+	})
+	t.Run("python falls back to pyrefly when pyright missing", func(t *testing.T) {
+		stubInstalledCommands(t, "pyrefly")
+		if s := SpecForExtension(".py"); s == nil || s.Name != "pyrefly" {
+			t.Errorf(".py with only pyrefly: got %v, want pyrefly", s)
+		}
+	})
 }
 
 // TestSpecWithOverrides verifies .gortex.yaml command / args / env

--- a/internal/semantic/lsp/router.go
+++ b/internal/semantic/lsp/router.go
@@ -431,12 +431,25 @@ func (r *Router) For(relPath string) (*Provider, error) {
 // preventing the multi-repo bug where Provider.EnsureClient (which is
 // idempotent) would otherwise leave every workspace pinned to the
 // rootURI of whichever request happened to spawn the server first.
+//
+// When several specs cover the extension the router walks them in
+// priority order and takes the first one its own availability cache
+// reports live — so a preferred server that is missing from PATH or
+// was downgraded by markSpawnFailed falls back to the next candidate
+// (tsgo → typescript-language-server) instead of erroring.
 func (r *Router) ForWorkspace(relPath, workspace string) (*Provider, error) {
-	spec := SpecForPath(relPath)
-	if spec == nil {
+	specs := SpecsForExtension(filepath.Ext(relPath))
+	if len(specs) == 0 {
 		return nil, fmt.Errorf("no LSP server registered for %s", filepath.Ext(relPath))
 	}
-	return r.ForSpecWorkspace(spec, workspace)
+	for _, spec := range specs {
+		if r.specAvailable(spec) {
+			return r.ForSpecWorkspace(spec, workspace)
+		}
+	}
+	// None available: route to the priority winner so the caller gets
+	// the same "not available on PATH" error shape as before.
+	return r.ForSpecWorkspace(specs[0], workspace)
 }
 
 // ForSpec returns the provider for a named spec under the router's

--- a/internal/serverstack/lsp.go
+++ b/internal/serverstack/lsp.go
@@ -142,8 +142,27 @@ func BuildResolverLSPHelperForRepo(router *lsp.Router, absRoot string, poolSize 
 		specs = append(specs, name)
 	}
 
-	add("typescript-language-server", RepoLikelyHasTypeScriptIntent(absRoot))
-	add("pyright", RepoLikelyHasPythonIntent(absRoot))
+	add(preferredSpecName(router.Available, ".ts"), RepoLikelyHasTypeScriptIntent(absRoot))
+	add(preferredSpecName(router.Available, ".py"), RepoLikelyHasPythonIntent(absRoot))
 
 	return lsp.NewResolverHelperMux(helpers...), specs
+}
+
+// preferredSpecName returns the name of the highest-priority registered
+// spec covering ext that the given availability check reports live, so
+// resolve-time helpers agree with the registry's routing preference
+// (tsgo over typescript-language-server, pyright over pyrefly). Falls
+// back to the priority winner when none is available — the caller
+// re-checks availability and skips registration anyway.
+func preferredSpecName(available func(*lsp.ServerSpec) bool, ext string) string {
+	specs := lsp.SpecsForExtension(ext)
+	for _, spec := range specs {
+		if available(spec) {
+			return spec.Name
+		}
+	}
+	if len(specs) > 0 {
+		return specs[0].Name
+	}
+	return ""
 }

--- a/internal/serverstack/lsp_test.go
+++ b/internal/serverstack/lsp_test.go
@@ -4,7 +4,38 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/zzet/gortex/internal/semantic/lsp"
 )
+
+// TestPreferredSpecName pins the resolve-time helper's server choice:
+// the highest-priority spec the router reports available wins, with
+// the node-based TypeScript server serving only when tsgo is absent.
+func TestPreferredSpecName(t *testing.T) {
+	availableSet := func(names ...string) func(*lsp.ServerSpec) bool {
+		have := make(map[string]bool, len(names))
+		for _, n := range names {
+			have[n] = true
+		}
+		return func(s *lsp.ServerSpec) bool { return s != nil && have[s.Name] }
+	}
+
+	if got := preferredSpecName(availableSet("tsgo", "typescript-language-server"), ".ts"); got != "tsgo" {
+		t.Errorf("both available: got %q, want tsgo", got)
+	}
+	if got := preferredSpecName(availableSet("typescript-language-server"), ".ts"); got != "typescript-language-server" {
+		t.Errorf("tsgo absent: got %q, want typescript-language-server", got)
+	}
+	if got := preferredSpecName(availableSet(), ".ts"); got != "tsgo" {
+		t.Errorf("none available: got %q, want priority winner tsgo", got)
+	}
+	if got := preferredSpecName(availableSet("pyright", "pyrefly"), ".py"); got != "pyright" {
+		t.Errorf("python default: got %q, want pyright", got)
+	}
+	if got := preferredSpecName(availableSet(), ".unknown_ext"); got != "" {
+		t.Errorf("unknown extension: got %q, want empty", got)
+	}
+}
 
 func TestRepoLikelyHasPythonIntent(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
## What

Routes TypeScript/JavaScript LSP work to `tsgo` (the native-Go TypeScript compiler's LSP mode) by default whenever its binary is installed, with `typescript-language-server` as the fallback.

## Why

- One native process per TS workspace instead of a 4-process node tree (wrapper + syntax tsserver + semantic tsserver + typingsInstaller) — on a 20-repo workspace the node fleet was 22 processes and ~1.5–2GB of mostly-swapped footprint.
- Faster spawn and lower memory for enrichment and resolve-time helpers.
- TypeScript 7.0 RC mainlined the Go-native compiler, so the LSP surface is now the primary supported path.

## How

- The per-extension registry table keeps every covering spec in priority order; routing returns the highest-priority spec whose binary is on PATH. With no covering binary installed, the priority winner is returned so the spawn path reports the missing binary exactly as before.
- `tsgo` now carries priority 5, `typescript-language-server` 6 (raise it in `.gortex.yaml` to prefer the node server again).
- `Router.ForWorkspace` walks the ladder against the router's own availability cache, so a server downgraded by `markSpawnFailed` falls back to the next candidate on the following call instead of erroring.
- Resolve-time helper registration (`preferredSpecName`) derives its pick from the same registry order instead of hardcoding server names; warmup counters recognise both servers per language.
- Same ladder gives `.py` a `pyrefly` fallback when `pyright` is missing (default pyright routing unchanged).

## Behavior matrix (.ts)

| Installed | Routed to |
|---|---|
| both | tsgo |
| only typescript-language-server | typescript-language-server |
| only tsgo | tsgo |
| neither | tsgo (spawn error names the missing binary) |

## Testing

- New: `TestSpecForExtensionPrefersInstalledPriorityWinner` (6 ladder cases via a stubbed PATH lookup), `TestPreferredSpecName` (serverstack), updated priority pins in `TestPyreflyAndTsgoSpecs`.
- Green: `internal/semantic/lsp`, `internal/serverstack`, `internal/semantic`, `internal/mcp`, `internal/resolver`, `internal/indexer`, `cmd/gortex`; golangci-lint 0 issues on touched packages.