### PR TITLE
fix(store): render Windows drive-letter store paths as file:///C:/... DSNs

### DIFF
--- a/internal/graph/store_sqlite/sqlite_connections.go
+++ b/internal/graph/store_sqlite/sqlite_connections.go
@@ -86,7 +86,16 @@ func sqliteDSN(path, rawQuery string) string {
 	if absolute, err := filepath.Abs(path); err == nil {
 		path = absolute
 	}
-	escaped := &url.URL{Scheme: "file", Path: filepath.ToSlash(path), RawQuery: rawQuery}
+	slashed := filepath.ToSlash(path)
+	if !strings.HasPrefix(slashed, "/") {
+		// A Windows drive-letter path ("C:/...") must become the URI path
+		// "/C:/..." so url.URL renders file:///C:/... — without the leading
+		// slash it renders file:C:/... and SQLite reads "C:" as a URI
+		// authority ("invalid uri authority: C:"), so the daemon cannot open
+		// a fresh store on Windows at all.
+		slashed = "/" + slashed
+	}
+	escaped := &url.URL{Scheme: "file", Path: slashed, RawQuery: rawQuery}
 	return escaped.String()
 }
 

--- a/internal/graph/store_sqlite/sqlite_connections_windows_test.go
+++ b/internal/graph/store_sqlite/sqlite_connections_windows_test.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package store_sqlite
+
+import (
+	"strings"
+	"testing"
+)
+
+// A Windows drive-letter path must render as file:///C:/... — commit
+// 1ba5c8b's url.URL construction emitted file:C:/..., which SQLite rejects
+// with "invalid uri authority: C:", so a daemon with a fresh default store
+// could not start on Windows at all.
+func TestSqliteDSNWindowsDriveLetterPath(t *testing.T) {
+	dsn := sqliteDSN(`C:\tmp\gortex-test\store.sqlite`, "mode=ro")
+	if !strings.HasPrefix(dsn, "file:///") {
+		t.Fatalf("windows drive-letter DSN must start with file:/// (got %q)", dsn)
+	}
+	if strings.Contains(dsn, "file:C:") || strings.Contains(dsn, "file://C:") {
+		t.Fatalf("drive letter leaked into URI authority position: %q", dsn)
+	}
+}


### PR DESCRIPTION
Fixes #314.

## Problem

Since 1ba5c8b, a daemon with a fresh default store cannot start on Windows:

```
open sqlite store at "C:\...\store.sqlite": sqlite read schema version:
SQL logic error: invalid uri authority: C: (1)
```

`sqliteDSN` builds `url.URL{Scheme: "file", Path: filepath.ToSlash(path)}`.
On Windows the slashed path (`C:/...`) has no leading slash, so `URL.String()`
renders `file:C:/...` instead of `file:///C:/...`, and SQLite parses the
drive letter as a URI authority. Bisect: v0.60.0 (dd3bb30) starts fine on the
same machine/home; the first failing commit is 1ba5c8b, the only change to
`sqlite_connections.go` in that range.

## Fix

Prefix a leading slash when the slashed path lacks one, so the URL renders as
`file:///C:/...`. POSIX absolute paths already start with `/` and are
byte-for-byte unchanged.

## Verification (Windows 11, mingw-w64 UCRT gcc 16.1, CGO_ENABLED=1)

- Before: `gortex daemon start` on an empty `~/.gortex` exits 1 with the
  URI-authority error above.
- After: the daemon starts, `track` indexes a fixture repo, and
  `search_symbols` returns the expected symbol at the correct line.
- Added a `//go:build windows` unit test pinning the `file:///C:/...` DSN
  shape (passes on the native CGO build).

Note on CI: the windows job compiles `go build ./...` but never boots a
daemon against a default store, which is how this shipped green — a
daemon-start smoke step on the windows runner would catch this class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
