### PR TITLE
feat(cli): upgrade/uninstall self-maintenance (fixes #281, refs #298)

### DIFF
--- a/cmd/gortex/daemon_service.go
+++ b/cmd/gortex/daemon_service.go
@@ -154,6 +154,8 @@ func runDaemonInstallService(cmd *cobra.Command, _ []string) error {
 		return installLaunchd(w, exe)
 	case "linux":
 		return installSystemd(w, exe)
+	case "windows":
+		return installWindowsTask(w, exe)
 	default:
 		return fmt.Errorf("service install is not supported on %s — run 'gortex daemon start --detach' to keep the daemon running in the background", runtime.GOOS)
 	}
@@ -166,6 +168,8 @@ func runDaemonUninstallService(cmd *cobra.Command, _ []string) error {
 		return uninstallLaunchd(w)
 	case "linux":
 		return uninstallSystemd(w)
+	case "windows":
+		return uninstallWindowsTask(w)
 	default:
 		return fmt.Errorf("service uninstall not supported on %s", runtime.GOOS)
 	}
@@ -178,6 +182,8 @@ func runDaemonServiceStatus(cmd *cobra.Command, _ []string) error {
 		return statusLaunchd(w)
 	case "linux":
 		return statusSystemd(w)
+	case "windows":
+		return statusWindowsTask(w)
 	default:
 		return fmt.Errorf("service status not supported on %s", runtime.GOOS)
 	}
@@ -466,4 +472,76 @@ func runCmd(w io.Writer, name string, args ...string) error {
 	c.Stdout = w
 	c.Stderr = w
 	return c.Run()
+}
+
+// --- Task Scheduler (Windows) --------------------------------------------
+//
+// Windows has no user-level unit file the way launchd / systemd --user do,
+// and a true Windows Service would require admin rights plus Service Control
+// Manager integration in the daemon. The per-user analogue that keeps the
+// no-admin, autostart-at-login contract is a Task Scheduler logon task, driven
+// through schtasks: it runs `gortex daemon start` at each logon under the
+// current limited user. (schtasks' CLI flags don't expose restart-on-failure —
+// that's a Task-Scheduler-XML-only setting — so crash-restart parity with
+// launchd KeepAlive / systemd Restart=on-failure is a follow-up.)
+
+// windowsTaskName is the Task Scheduler task that autostarts the daemon at
+// logon on Windows.
+const windowsTaskName = "GortexDaemon"
+
+// windowsTaskCreateArgs builds the schtasks argv that registers the logon
+// autostart task. Split out so the arg vector is unit-testable without a
+// Windows host: the task runs `"<exe>" daemon start` at each logon (ONLOGON)
+// under the current limited user (RL LIMITED), replacing any existing task (F).
+func windowsTaskCreateArgs(taskName, exe string) []string {
+	return []string{
+		"/Create",
+		"/TN", taskName,
+		"/TR", fmt.Sprintf(`"%s" daemon start`, exe),
+		"/SC", "ONLOGON",
+		"/RL", "LIMITED",
+		"/F",
+	}
+}
+
+func installWindowsTask(w io.Writer, exe string) error {
+	if err := runCmd(w, "schtasks", windowsTaskCreateArgs(windowsTaskName, exe)...); err != nil {
+		return fmt.Errorf("schtasks create: %w", err)
+	}
+	// Start it now so the user gets a running daemon in one command — the
+	// Windows analogue of systemd `enable --now` / launchd RunAtLoad.
+	_ = runCmd(w, "schtasks", "/Run", "/TN", windowsTaskName)
+	fmt.Fprintf(w, "[gortex daemon] logon task installed (%s)\n", windowsTaskName)
+	fmt.Fprintf(w, "  logs: %s\n", daemon.LogFilePath())
+	fmt.Fprintf(w, "  check: gortex daemon service-status\n")
+	return nil
+}
+
+func uninstallWindowsTask(w io.Writer) error {
+	// End a running instance, then delete the task. Both are swallowed so
+	// uninstall is idempotent on a host where the task was never installed
+	// (schtasks exits non-zero for an unknown task).
+	_ = runCmd(w, "schtasks", "/End", "/TN", windowsTaskName)
+	_ = runCmd(w, "schtasks", "/Delete", "/TN", windowsTaskName, "/F")
+	fmt.Fprintln(w, "[gortex daemon] logon task uninstalled")
+	return nil
+}
+
+func statusWindowsTask(w io.Writer) error {
+	// `schtasks /Query /TN <name>` exits 0 when the task exists, non-zero
+	// otherwise.
+	out, err := exec.Command("schtasks", "/Query", "/TN", windowsTaskName).CombinedOutput()
+	if err != nil {
+		fmt.Fprintf(w, "windows task: not installed (%s)\n", windowsTaskName)
+		return nil
+	}
+	fmt.Fprintf(w, "windows task: installed (%s)\n", windowsTaskName)
+	// Surface the Status column if schtasks printed one.
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "Status:") {
+			fmt.Fprintln(w, "  "+line)
+		}
+	}
+	return nil
 }

--- a/cmd/gortex/daemon_service_test.go
+++ b/cmd/gortex/daemon_service_test.go
@@ -195,14 +195,31 @@ func TestSystemdUnitPath_ResolvesUnderHome(t *testing.T) {
 }
 
 // TestServiceCommands_RejectUnsupportedOS keeps the guard
-// runDaemonInstallService uses from silently succeeding on Windows or
-// other platforms we haven't wired.
+// runDaemonInstallService uses from silently succeeding on a platform we
+// haven't wired (darwin/linux/windows are now all supported).
 func TestServiceCommands_RejectUnsupportedOS(t *testing.T) {
-	if runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
+	if runtime.GOOS == "darwin" || runtime.GOOS == "linux" || runtime.GOOS == "windows" {
 		t.Skip("this test only runs on unsupported platforms")
 	}
 	err := runDaemonInstallService(daemonInstallServiceCmd, nil)
 	require.Error(t, err)
 	assert.True(t, strings.Contains(err.Error(), "not supported"),
 		"install must refuse on unsupported OS: %v", err)
+}
+
+// TestWindowsTaskCreateArgs pins the schtasks command that registers the
+// Windows logon autostart task: a per-user (LIMITED) ONLOGON task running the
+// quoted binary with `daemon start`, force-replacing any existing task.
+func TestWindowsTaskCreateArgs(t *testing.T) {
+	args := windowsTaskCreateArgs("GortexDaemon", `C:\Users\x\scoop\apps\gortex\current\gortex.exe`)
+	require.Equal(t, "/Create", args[0])
+
+	joined := strings.Join(args, " ")
+	assert.Contains(t, joined, "/TN GortexDaemon")
+	assert.Contains(t, joined, "/SC ONLOGON")
+	assert.Contains(t, joined, "/RL LIMITED")
+	assert.Contains(t, joined, "/F")
+	// The run action quotes the exe (so a Program Files path with spaces is one
+	// token) and appends the daemon subcommand.
+	assert.Contains(t, joined, `"C:\Users\x\scoop\apps\gortex\current\gortex.exe" daemon start`)
 }

--- a/cmd/gortex/uninstall.go
+++ b/cmd/gortex/uninstall.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/zzet/gortex/internal/agents"
 	"github.com/zzet/gortex/internal/agents/claudecode"
+	"github.com/zzet/gortex/internal/daemon"
 	"github.com/zzet/gortex/internal/progress"
 	"github.com/zzet/gortex/internal/tui"
 )
@@ -19,6 +20,7 @@ import (
 var (
 	uninstallYes             bool
 	uninstallGlobal          bool
+	uninstallPurge           bool
 	uninstallClaudeConfigDir string
 )
 
@@ -43,6 +45,13 @@ config, permission allowlist, hooks, the CLAUDE.md rule block, and the
 gortex skills / commands / sub-agents). --global honors
 $CLAUDE_CONFIG_DIR; target a specific profile with --claude-config-dir.
 
+Pass --purge to additionally tear down the machine-level runtime: stop the
+daemon, remove its OS service unit (launchd / systemd / Task Scheduler),
+and delete the unified ~/.gortex data/cache/config tree — plus the binary
+when it was dropped by the installer script (package-manager installs are
+left to the manager). --purge is orthogonal to per-repo cleanup and can be
+combined with --global.
+
 Destructive by design: the interactive run shows a confirm wizard listing
 every file before any deletion. Non-TTY callers must pass --yes to bypass
 the wizard — that gate is intentional, the safer default is to refuse and
@@ -56,6 +65,7 @@ docs / scripts / muscle memory still work.`,
 func init() {
 	uninstallCmd.Flags().BoolVarP(&uninstallYes, "yes", "y", false, "skip the confirmation prompt (required when stdin is not a TTY)")
 	uninstallCmd.Flags().BoolVar(&uninstallGlobal, "global", false, "also remove the machine-level Claude Code footprint (user MCP config, settings, CLAUDE.md rule block, skills/commands/agents) installed by `gortex install`")
+	uninstallCmd.Flags().BoolVar(&uninstallPurge, "purge", false, "also tear down the machine-level runtime: stop the daemon, remove its OS service unit, and delete the ~/.gortex data/cache/config tree (and the binary, for an installer-script install)")
 	uninstallCmd.Flags().StringVar(&uninstallClaudeConfigDir, "claude-config-dir", "", "Claude Code config root to clean (implies --global); overrides $CLAUDE_CONFIG_DIR, defaults to ~/.claude")
 	uninstallCmd.Flags().StringVar(&uninstallClaudeConfigDir, "config-root", "", "alias for --claude-config-dir")
 	rootCmd.AddCommand(uninstallCmd)
@@ -116,7 +126,20 @@ func runUninstall(cmd *cobra.Command, _ []string) error {
 		globalItems = claudecode.GlobalArtifacts(home)
 	}
 
-	totalPresent := len(presentFiles) + len(presentDirs) + len(globalItems)
+	// --purge extends the removal to the machine-level runtime that `gortex
+	// install` / the daemon created: the OS service unit, the unified
+	// ~/.gortex data/cache/config tree, and (installer-script method) the
+	// binary. Computed up front so the wizard previews the full blast radius.
+	var (
+		purge      purgePlan
+		purgeItems []string
+	)
+	if uninstallPurge {
+		purge = computePurgePlan()
+		purgeItems = purgeWizardItems(purge, daemon.IsRunning())
+	}
+
+	totalPresent := len(presentFiles) + len(presentDirs) + len(globalItems) + len(purgeItems)
 	if totalPresent == 0 {
 		emitUninstallNothingTodo(w)
 		return nil
@@ -129,7 +152,7 @@ func runUninstall(cmd *cobra.Command, _ []string) error {
 		if !progress.IsTTY(w) || noProgress {
 			return fmt.Errorf("`gortex uninstall` is destructive; pass --yes to confirm (or run with a TTY for the interactive prompt)")
 		}
-		accepted, err := runUninstallConfirmWizard(w, presentFiles, presentDirs, globalItems)
+		accepted, err := runUninstallConfirmWizard(w, presentFiles, presentDirs, globalItems, purgeItems)
 		if err != nil {
 			return err
 		}
@@ -152,6 +175,17 @@ func runUninstall(cmd *cobra.Command, _ []string) error {
 		removed += gRemoved
 		failures = append(failures, gFailures...)
 		globalCleaned = true
+	}
+
+	// Machine-level teardown last, so a failure here still reports the
+	// per-repo / global files already removed above.
+	if uninstallPurge {
+		pRemoved, pFailures := executePurge(cmd, purge)
+		removed += pRemoved
+		failures = append(failures, pFailures...)
+		if note := purgeBinaryNote(purge); note != "" {
+			fmt.Fprintln(w, note)
+		}
 	}
 
 	emitUninstallSummary(w, removed, failures, totalPresent, globalCleaned)
@@ -179,8 +213,8 @@ func filterPresentUninstallTargets() ([]string, []string) {
 // runUninstallConfirmWizard renders a confirm wizard listing every target
 // that would be removed, then waits for the user to accept or cancel.
 // Returns accepted=true only on an explicit yes.
-func runUninstallConfirmWizard(w io.Writer, files, dirs, global []string) (bool, error) {
-	items := make([]string, 0, len(files)+len(dirs)+len(global))
+func runUninstallConfirmWizard(w io.Writer, files, dirs, global, purge []string) (bool, error) {
+	items := make([]string, 0, len(files)+len(dirs)+len(global)+len(purge))
 	for _, f := range files {
 		items = append(items, f+"  "+progress.StyleHint.Render("(file)"))
 	}
@@ -190,9 +224,15 @@ func runUninstallConfirmWizard(w io.Writer, files, dirs, global []string) (bool,
 	for _, g := range global {
 		items = append(items, g+"  "+progress.StyleHint.Render("(user-level)"))
 	}
+	for _, p := range purge {
+		items = append(items, p+"  "+progress.StyleHint.Render("(machine-level)"))
+	}
 
 	subtitle := "Remove all Gortex-generated config from this repo."
-	if len(global) > 0 {
+	switch {
+	case len(purge) > 0:
+		subtitle = "Remove Gortex config and tear down the machine-level runtime (daemon, service, ~/.gortex)."
+	case len(global) > 0:
 		subtitle = "Remove Gortex config from this repo and the user-level Claude Code profile."
 	}
 	m := tui.NewConfirmModel(
@@ -200,6 +240,9 @@ func runUninstallConfirmWizard(w io.Writer, files, dirs, global []string) (bool,
 		subtitle,
 	)
 	m.Warning = "This cannot be undone — re-run `gortex init` to restore."
+	if len(purge) > 0 {
+		m.Warning = "This cannot be undone — --purge deletes the daemon's data/cache/config tree."
+	}
 	m.Items = items
 	m.YesLabel = "yes, remove " + strconv.Itoa(len(items)) + " item(s)"
 	m.NoLabel = "no, keep them"

--- a/cmd/gortex/uninstall_purge.go
+++ b/cmd/gortex/uninstall_purge.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"runtime"
 
 	"github.com/spf13/cobra"
@@ -74,6 +75,9 @@ func serviceUnitPresent() bool {
 		path, err = launchdPlistPath()
 	case "linux":
 		path, err = systemdUnitPath()
+	case "windows":
+		// No unit file — the logon task lives in Task Scheduler; query it.
+		return exec.Command("schtasks", "/Query", "/TN", windowsTaskName).Run() == nil
 	default:
 		return false
 	}

--- a/cmd/gortex/uninstall_purge.go
+++ b/cmd/gortex/uninstall_purge.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+
+	"github.com/spf13/cobra"
+
+	"github.com/zzet/gortex/internal/daemon"
+	"github.com/zzet/gortex/internal/platform"
+)
+
+// --purge extends `gortex uninstall` from per-repo / integration cleanup to a
+// full machine-level teardown: stop the daemon, remove its OS service unit,
+// delete the unified ~/.gortex data/cache/config tree, and — for the
+// installer-script install — remove the binary. Package-manager installs
+// (brew/scoop/go) leave the binary to the manager and only get advice, so its
+// metadata stays consistent.
+
+// purgePlan is the machine-scope footprint --purge removes, computed up front
+// so the confirm wizard can preview every path before anything is deleted.
+type purgePlan struct {
+	dirs           []string      // existing data/cache/config dirs to delete
+	binary         string        // the running executable
+	binMethod      InstallMethod // how it was installed
+	servicePresent bool          // an OS service unit file exists
+}
+
+// computePurgePlan collects the machine-scope removal targets that actually
+// exist, de-duplicating the data/cache/config dirs (they collapse to one
+// ~/.gortex tree unless an XDG override splits a category out).
+func computePurgePlan() purgePlan {
+	var p purgePlan
+
+	seen := map[string]bool{}
+	for _, d := range []string{platform.ConfigDir(), platform.DataDir(), platform.CacheDir(), platform.Home()} {
+		if d == "" || seen[d] {
+			continue
+		}
+		seen[d] = true
+		if _, err := os.Stat(d); err == nil {
+			p.dirs = append(p.dirs, d)
+		}
+	}
+
+	if exe, err := os.Executable(); err == nil {
+		p.binary = exe
+		p.binMethod = detectInstallMethod(exe, goBinDir(), homeDirOrEmpty())
+	}
+
+	p.servicePresent = serviceUnitPresent()
+	return p
+}
+
+// binaryRemovable reports whether --purge should delete the binary itself.
+// Only the installer-script method drops a plain file we own; package-manager
+// installs must be removed through the manager (we advise instead — see
+// purgeBinaryNote).
+func (p purgePlan) binaryRemovable() bool {
+	return p.binMethod == InstallScript && p.binary != ""
+}
+
+// serviceUnitPresent reports whether an OS service unit file for the daemon
+// exists, so --purge can preview and remove it even when it isn't currently
+// active.
+func serviceUnitPresent() bool {
+	var (
+		path string
+		err  error
+	)
+	switch runtime.GOOS {
+	case "darwin":
+		path, err = launchdPlistPath()
+	case "linux":
+		path, err = systemdUnitPath()
+	default:
+		return false
+	}
+	if err != nil {
+		return false
+	}
+	_, statErr := os.Stat(path)
+	return statErr == nil
+}
+
+// purgeWizardItems renders the machine-scope targets for the confirm wizard so
+// --purge shows the daemon / service / data-tree / binary blast radius
+// alongside the per-repo files before any deletion. daemonRunning is passed in
+// (not probed here) so the preview stays deterministic and testable.
+func purgeWizardItems(p purgePlan, daemonRunning bool) []string {
+	var items []string
+	if daemonRunning {
+		items = append(items, "stop the running daemon")
+	}
+	if p.servicePresent {
+		items = append(items, "remove the daemon OS service unit")
+	}
+	for _, d := range p.dirs {
+		items = append(items, d+"/  (data/cache/config)")
+	}
+	if p.binaryRemovable() {
+		items = append(items, p.binary+"  (binary)")
+	}
+	return items
+}
+
+// executePurge performs the machine-scope teardown after confirmation: stop
+// the daemon, remove its service unit, delete the data/cache/config tree, and
+// (installer-script method) delete the binary. Failures are collected as
+// warnings so a partial teardown still reports what it removed; the returned
+// count tallies each successful action.
+func executePurge(cmd *cobra.Command, p purgePlan) (removed int, failures []string) {
+	// Stop a manually started daemon; a supervised one is stopped when its
+	// unit is removed just below.
+	if daemon.IsRunning() && !serviceActive() {
+		if err := runDaemonStop(cmd, nil); err != nil {
+			failures = append(failures, fmt.Sprintf("stop daemon: %v", err))
+		} else {
+			removed++
+		}
+	}
+
+	// Remove the OS service unit (idempotent; also stops a supervised daemon).
+	if p.servicePresent {
+		if err := runDaemonUninstallService(cmd, nil); err != nil {
+			failures = append(failures, fmt.Sprintf("remove service: %v", err))
+		} else {
+			removed++
+		}
+	}
+
+	// Delete the data/cache/config directories.
+	for _, d := range p.dirs {
+		if err := os.RemoveAll(d); err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", d, err))
+			continue
+		}
+		removed++
+	}
+
+	// Remove the binary only for the installer-script method. Unlinking the
+	// running executable is safe on Unix — the inode survives until this
+	// process exits.
+	if p.binaryRemovable() {
+		if err := os.Remove(p.binary); err != nil {
+			failures = append(failures, fmt.Sprintf("remove binary %s: %v", p.binary, err))
+		} else {
+			removed++
+		}
+	}
+
+	return removed, failures
+}
+
+// purgeBinaryNote returns guidance for removing the binary when --purge can't
+// (or shouldn't) do it automatically — every method except the installer
+// script, which purge deletes directly.
+func purgeBinaryNote(p purgePlan) string {
+	if p.binary == "" || p.binMethod == InstallScript {
+		return ""
+	}
+	switch p.binMethod {
+	case InstallBrew:
+		return "Binary left in place — remove it with `brew uninstall gortex`."
+	case InstallScoop:
+		return "Binary left in place — remove it with `scoop uninstall gortex`."
+	case InstallGoInstall:
+		return fmt.Sprintf("Binary left in place — delete it with `rm %s`.", p.binary)
+	default:
+		return fmt.Sprintf("Binary left in place at %s — delete it manually.", p.binary)
+	}
+}

--- a/cmd/gortex/uninstall_purge_test.go
+++ b/cmd/gortex/uninstall_purge_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestComputePurgePlanCollectsExistingDataDirs proves --purge targets the
+// unified ~/.gortex tree when it exists, de-duplicated across the
+// config/data/cache/home categories that collapse to it.
+func TestComputePurgePlanCollectsExistingDataDirs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Neutralise XDG overrides so the categories collapse into ~/.gortex.
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_CACHE_HOME", "")
+
+	gortexHome := filepath.Join(home, ".gortex")
+	require.NoError(t, os.MkdirAll(filepath.Join(gortexHome, "cache"), 0o755))
+
+	p := computePurgePlan()
+	assert.Contains(t, p.dirs, gortexHome, "the unified ~/.gortex tree must be a purge target")
+
+	seen := map[string]bool{}
+	for _, d := range p.dirs {
+		assert.Falsef(t, seen[d], "duplicate purge dir %q", d)
+		seen[d] = true
+	}
+}
+
+// TestComputePurgePlanEmptyWhenNothingInstalled asserts a clean host yields no
+// data dirs to remove.
+func TestComputePurgePlanEmptyWhenNothingInstalled(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_CACHE_HOME", "")
+
+	p := computePurgePlan()
+	assert.Empty(t, p.dirs)
+}
+
+// TestBinaryRemovableOnlyForScript proves purge auto-deletes the binary only
+// for the installer-script method (a plain file we own).
+func TestBinaryRemovableOnlyForScript(t *testing.T) {
+	assert.True(t, purgePlan{binary: "/x/gortex", binMethod: InstallScript}.binaryRemovable())
+	assert.False(t, purgePlan{binary: "/x/gortex", binMethod: InstallBrew}.binaryRemovable())
+	assert.False(t, purgePlan{binary: "/x/gortex", binMethod: InstallGoInstall}.binaryRemovable())
+	assert.False(t, purgePlan{binary: "", binMethod: InstallScript}.binaryRemovable())
+}
+
+// TestPurgeBinaryNoteByMethod pins the per-method binary guidance: the
+// installer-script binary is deleted by purge (no note), everything else gets
+// method-appropriate advice.
+func TestPurgeBinaryNoteByMethod(t *testing.T) {
+	assert.Equal(t, "", purgeBinaryNote(purgePlan{binary: "/x/gortex", binMethod: InstallScript}))
+	assert.Contains(t, purgeBinaryNote(purgePlan{binary: "/x/gortex", binMethod: InstallBrew}), "brew uninstall")
+	assert.Contains(t, purgeBinaryNote(purgePlan{binary: "/x/gortex", binMethod: InstallScoop}), "scoop uninstall")
+	assert.Contains(t, purgeBinaryNote(purgePlan{binary: "/x/gortex", binMethod: InstallGoInstall}), "/x/gortex")
+	assert.Contains(t, purgeBinaryNote(purgePlan{binary: "/x/gortex", binMethod: InstallUnknown}), "manually")
+	assert.Equal(t, "", purgeBinaryNote(purgePlan{binary: "", binMethod: InstallBrew}))
+}
+
+// TestPurgeWizardItems proves the preview lists the daemon stop, the service
+// unit, each data dir, and the binary (script method only) — and omits each
+// when it doesn't apply.
+func TestPurgeWizardItems(t *testing.T) {
+	full := purgePlan{
+		dirs:           []string{"/home/u/.gortex"},
+		binary:         "/home/u/.local/bin/gortex",
+		binMethod:      InstallScript,
+		servicePresent: true,
+	}
+	items := strings.Join(purgeWizardItems(full, true), "\n")
+	assert.Contains(t, items, "stop the running daemon")
+	assert.Contains(t, items, "service unit")
+	assert.Contains(t, items, "/home/u/.gortex")
+	assert.Contains(t, items, "/home/u/.local/bin/gortex")
+
+	// Not running, no service, package-manager binary → only the data dir.
+	lean := purgePlan{dirs: []string{"/home/u/.gortex"}, binary: "/opt/gortex", binMethod: InstallBrew}
+	leanItems := strings.Join(purgeWizardItems(lean, false), "\n")
+	assert.NotContains(t, leanItems, "stop the running daemon")
+	assert.NotContains(t, leanItems, "service unit")
+	assert.NotContains(t, leanItems, "/opt/gortex")
+	assert.Contains(t, leanItems, "/home/u/.gortex")
+}

--- a/cmd/gortex/upgrade.go
+++ b/cmd/gortex/upgrade.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -196,9 +197,8 @@ func runUpgrade(cmd *cobra.Command, args []string) error {
 	if !upgradeRun {
 		fmt.Fprintf(out, "Run:\n  %s\n", command)
 	} else {
-		parts := strings.Fields(command)
 		fmt.Fprintf(out, "$ %s\n", command)
-		ex := exec.CommandContext(cmd.Context(), parts[0], parts[1:]...) //nolint:gosec // command is one of the fixed install-method templates
+		ex := upgradeExecCommand(cmd.Context(), command)
 		ex.Stdout, ex.Stderr, ex.Stdin = out, cmd.ErrOrStderr(), os.Stdin
 		if rerr := ex.Run(); rerr != nil {
 			return fmt.Errorf("upgrade command failed: %w", rerr)
@@ -210,6 +210,26 @@ func runUpgrade(cmd *cobra.Command, args []string) error {
 	// reindexed. F2 enriches this with the exact stale languages per repo.
 	fmt.Fprintln(out, "\nAfter upgrading, reindex so the graph picks up any extractor changes:\n  gortex index .")
 	return nil
+}
+
+// upgradeExecCommand builds the command that --run executes. The installer
+// script is a shell pipeline (`curl … | sh`), so it must run through `sh -c`;
+// splitting it on whitespace would hand `|` and `sh` to curl as extra
+// hostnames (issue #281). Plain-argv methods (go install / brew / scoop) keep
+// direct execution so no shell is spawned when one isn't needed.
+func upgradeExecCommand(ctx context.Context, command string) *exec.Cmd {
+	if upgradeCommandNeedsShell(command) {
+		return exec.CommandContext(ctx, "sh", "-c", command) //nolint:gosec // fixed installer template, needs shell for pipe
+	}
+	parts := strings.Fields(command)
+	return exec.CommandContext(ctx, parts[0], parts[1:]...) //nolint:gosec // command is one of the fixed install-method templates
+}
+
+// upgradeCommandNeedsShell reports whether the command contains shell
+// metacharacters that only a shell interprets (a pipe, redirection, expansion,
+// quoting) — the signal that it must not be split into a raw argv vector.
+func upgradeCommandNeedsShell(command string) bool {
+	return strings.ContainsAny(command, "|&;<>()$`\\\"'")
 }
 
 // goBinDir returns the directory `go install` drops binaries into — $GOBIN, or

--- a/cmd/gortex/upgrade.go
+++ b/cmd/gortex/upgrade.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -12,6 +13,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"golang.org/x/mod/semver"
+
+	"github.com/zzet/gortex/internal/daemon"
 )
 
 // InstallMethod is how this gortex binary was installed, inferred from where it
@@ -198,9 +201,12 @@ func runUpgrade(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(out, "Run:\n  %s\n", command)
 	} else {
 		fmt.Fprintf(out, "$ %s\n", command)
-		ex := upgradeExecCommand(cmd.Context(), command)
-		ex.Stdout, ex.Stderr, ex.Stdin = out, cmd.ErrOrStderr(), os.Stdin
-		if rerr := ex.Run(); rerr != nil {
+		run := func() error {
+			ex := upgradeExecCommand(cmd.Context(), command)
+			ex.Stdout, ex.Stderr, ex.Stdin = out, cmd.ErrOrStderr(), os.Stdin
+			return ex.Run()
+		}
+		if rerr := runUpgradeCommand(out, cmd.ErrOrStderr(), defaultUpgradeDaemonOps(cmd), run); rerr != nil {
 			return fmt.Errorf("upgrade command failed: %w", rerr)
 		}
 	}
@@ -230,6 +236,77 @@ func upgradeExecCommand(ctx context.Context, command string) *exec.Cmd {
 // quoting) — the signal that it must not be split into a raw argv vector.
 func upgradeCommandNeedsShell(command string) bool {
 	return strings.ContainsAny(command, "|&;<>()$`\\\"'")
+}
+
+// upgradeDaemonOps captures the daemon-lifecycle hooks runUpgradeCommand uses
+// to bounce the daemon around the binary swap. Defaults wire to the real
+// daemon; tests substitute fakes to assert the stop→swap→restart ordering
+// without a live daemon or an OS supervisor.
+type upgradeDaemonOps struct {
+	isRunning    func() bool
+	supervised   func() bool
+	stop         func() error
+	start        func() error
+	superRestart func(io.Writer) error
+}
+
+// defaultUpgradeDaemonOps wires upgradeDaemonOps to the real daemon lifecycle.
+func defaultUpgradeDaemonOps(cmd *cobra.Command) upgradeDaemonOps {
+	return upgradeDaemonOps{
+		isRunning:  daemon.IsRunning,
+		supervised: serviceActive,
+		stop: func() error {
+			// Suppress the stop-intent marker (as `daemon restart` does) so a
+			// failed upgrade can't leave autostart permanently disabled.
+			daemonRestartActive = true
+			defer func() { daemonRestartActive = false }()
+			return runDaemonStop(cmd, nil)
+		},
+		start: func() error {
+			daemonDetach = true
+			return runDaemonStart(cmd, nil)
+		},
+		superRestart: serviceRestart,
+	}
+}
+
+// runUpgradeCommand executes the install command (run) with the daemon bounced
+// around it, so the upgraded binary is what serves afterwards and the old
+// process isn't holding the store lock during an in-place replace. A daemon
+// owned by an OS supervisor is bounced THROUGH the supervisor (keeping its
+// ownership): the binary is swapped in place first — the running daemon keeps
+// the old inode — then the supervisor re-execs the new binary. A manually
+// started daemon is stopped before the swap and restarted after. The daemon is
+// always brought back, even when the install command fails, so a failed
+// upgrade never leaves the user with the daemon down.
+func runUpgradeCommand(out, errw io.Writer, ops upgradeDaemonOps, run func() error) error {
+	running := ops.isRunning()
+	supervised := running && ops.supervised()
+
+	switch {
+	case supervised:
+		if err := run(); err != nil {
+			return err
+		}
+		fmt.Fprintln(out, "Restarting daemon via service supervisor…")
+		if err := ops.superRestart(errw); err != nil {
+			fmt.Fprintf(errw, "warning: upgrade succeeded but service restart failed: %v\n", err)
+		}
+		return nil
+	case running:
+		fmt.Fprintln(out, "Stopping daemon before upgrade…")
+		if err := ops.stop(); err != nil {
+			return fmt.Errorf("stop daemon before upgrade: %w", err)
+		}
+		runErr := run()
+		fmt.Fprintln(out, "Restarting daemon…")
+		if err := ops.start(); err != nil {
+			fmt.Fprintf(errw, "warning: daemon restart after upgrade failed: %v\n", err)
+		}
+		return runErr
+	default:
+		return run()
+	}
 }
 
 // goBinDir returns the directory `go install` drops binaries into — $GOBIN, or

--- a/cmd/gortex/upgrade_test.go
+++ b/cmd/gortex/upgrade_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 // TestUpgradeInstallMethodDetection proves the path-math that maps a binary's
 // location to its install method — so `gortex upgrade` updates the way the user
@@ -43,6 +46,31 @@ func TestUpgradeInstallMethodDetection(t *testing.T) {
 	// A version pin flows into the go-install target.
 	if cmd, _ := upgradeInstructions(InstallGoInstall, "v0.49.0"); cmd != "go install github.com/zzet/gortex/cmd/gortex@v0.49.0" {
 		t.Errorf("pinned go install cmd = %q", cmd)
+	}
+}
+
+// TestUpgradeRunCommandUsesShellOnlyForPipelines proves --run routes the
+// installer-script pipeline through `sh -c` (so the pipe is interpreted rather
+// than split into raw curl args — issue #281) while plain-argv methods still
+// exec directly with no shell in the way.
+func TestUpgradeRunCommandUsesShellOnlyForPipelines(t *testing.T) {
+	ctx := context.Background()
+	cmd := upgradeExecCommand(ctx, "curl -fsSL https://get.gortex.dev | sh")
+	// Assert on Args[0], not Path: exec.Command resolves a bare name through
+	// LookPath, so Path becomes /bin/sh once sh is on $PATH — Args[0] stays "sh".
+	if got := cmd.Args[0]; got != "sh" {
+		t.Fatalf("script installer should run through sh, got %q args %v", got, cmd.Args)
+	}
+	if len(cmd.Args) != 3 || cmd.Args[1] != "-c" || cmd.Args[2] != "curl -fsSL https://get.gortex.dev | sh" {
+		t.Fatalf("script installer command args = %#v", cmd.Args)
+	}
+
+	cmd = upgradeExecCommand(ctx, "go install github.com/zzet/gortex/cmd/gortex@latest")
+	if got := cmd.Args[0]; got != "go" {
+		t.Fatalf("plain argv command should exec directly, got %q args %v", got, cmd.Args)
+	}
+	if len(cmd.Args) != 3 || cmd.Args[1] != "install" || cmd.Args[2] != "github.com/zzet/gortex/cmd/gortex@latest" {
+		t.Fatalf("go install command args = %#v", cmd.Args)
 	}
 }
 

--- a/cmd/gortex/upgrade_test.go
+++ b/cmd/gortex/upgrade_test.go
@@ -2,7 +2,12 @@ package main
 
 import (
 	"context"
+	"errors"
+	"io"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestUpgradeInstallMethodDetection proves the path-math that maps a binary's
@@ -72,6 +77,62 @@ func TestUpgradeRunCommandUsesShellOnlyForPipelines(t *testing.T) {
 	if len(cmd.Args) != 3 || cmd.Args[1] != "install" || cmd.Args[2] != "github.com/zzet/gortex/cmd/gortex@latest" {
 		t.Fatalf("go install command args = %#v", cmd.Args)
 	}
+}
+
+// TestRunUpgradeCommandDaemonBounce proves --run bounces the daemon around the
+// binary swap: a manually started daemon is stopped before and restarted after
+// (in that order), a supervised daemon is bounced through its supervisor
+// without a manual stop/start, an idle host just runs the command, and a failed
+// install still brings the daemon back so the host isn't left with it down.
+func TestRunUpgradeCommandDaemonBounce(t *testing.T) {
+	newOps := func(log *[]string, running, supervised bool, stopErr error) upgradeDaemonOps {
+		return upgradeDaemonOps{
+			isRunning:    func() bool { return running },
+			supervised:   func() bool { return supervised },
+			stop:         func() error { *log = append(*log, "stop"); return stopErr },
+			start:        func() error { *log = append(*log, "start"); return nil },
+			superRestart: func(io.Writer) error { *log = append(*log, "superRestart"); return nil },
+		}
+	}
+	runFn := func(log *[]string, err error) func() error {
+		return func() error { *log = append(*log, "run"); return err }
+	}
+
+	t.Run("idle host runs the command only", func(t *testing.T) {
+		var log []string
+		err := runUpgradeCommand(io.Discard, io.Discard, newOps(&log, false, false, nil), runFn(&log, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []string{"run"}, log)
+	})
+
+	t.Run("manual daemon: stop then run then start", func(t *testing.T) {
+		var log []string
+		err := runUpgradeCommand(io.Discard, io.Discard, newOps(&log, true, false, nil), runFn(&log, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []string{"stop", "run", "start"}, log)
+	})
+
+	t.Run("supervised daemon: run then supervisor restart", func(t *testing.T) {
+		var log []string
+		err := runUpgradeCommand(io.Discard, io.Discard, newOps(&log, true, true, nil), runFn(&log, nil))
+		require.NoError(t, err)
+		assert.Equal(t, []string{"run", "superRestart"}, log)
+	})
+
+	t.Run("failed install still restarts the manual daemon", func(t *testing.T) {
+		var log []string
+		boom := errors.New("boom")
+		err := runUpgradeCommand(io.Discard, io.Discard, newOps(&log, true, false, nil), runFn(&log, boom))
+		require.ErrorIs(t, err, boom)
+		assert.Equal(t, []string{"stop", "run", "start"}, log)
+	})
+
+	t.Run("stop failure aborts before the install runs", func(t *testing.T) {
+		var log []string
+		err := runUpgradeCommand(io.Discard, io.Discard, newOps(&log, true, false, errors.New("stopfail")), runFn(&log, nil))
+		require.Error(t, err)
+		assert.Equal(t, []string{"stop"}, log)
+	})
 }
 
 // TestUpgradeReleaseTagParse covers the /releases/latest redirect tag parse.


### PR DESCRIPTION
## Summary

Two related threads of `gortex` self-maintenance:

1. **Fix #281** — `gortex upgrade --run` exec'd the installer pipeline as raw argv, so `curl … | sh` split `|`/`sh` into curl hostnames (`curl: (6) Could not resolve host: |`).
2. **Refs #298** — extend the existing `upgrade` / `uninstall` / service commands toward the self-maintenance workflow that issue asks for.

## Commits

| Commit | What |
|---|---|
| `fix(upgrade): run script installer pipeline via shell` | #281 — route commands with shell metacharacters through `sh -c`; keep plain argv for `go install`/brew/scoop. Co-authored with @zerone0x (see below). |
| `feat(upgrade): bounce the daemon around --run installs` | Stop the daemon before the swap (releasing the store lock) and restart it after on the new binary; a supervised daemon is bounced **through** launchd/systemd. Always brought back — even on a failed install. Config untouched. |
| `feat(uninstall): add --purge for machine-level teardown` | `gortex uninstall --purge` also stops the daemon, removes its OS service unit, deletes the `~/.gortex` data/cache/config tree, and (installer-script install) removes the binary. Package-manager installs get method-specific advice. Confirm wizard previews the full blast radius. |
| `feat(daemon): add Windows service management via a logon task` | `install-service`/`uninstall-service`/`service-status` now work on Windows via a per-user Task Scheduler logon task — the no-admin analogue of the launchd/systemd `--user` units. |

## What #298 asks for, and what this does

`gortex install` / `uninstall` / `upgrade` already exist; #298 is really about filling gaps, so this addresses the daemon-lifecycle and Windows-parity parts:

- ✅ Upgrade stops → swaps → restarts the daemon; config preserved.
- ✅ Uninstall can stop the daemon, remove the service, and purge data/cache/config (+ the installer-script binary).
- ✅ Windows daemon autostart (Task Scheduler logon task) + uninstall + status.

Deliberately **out of scope** here (noted so the issue can track them):

- Full self-downloading updater with checksum/signature verification and rollback — the current design **delegates to the install method** (brew/scoop/`go install`/the verifying installer script), which already preserves cosign + SHA256 verification. A parallel download-and-verify path is a larger change with its own trade-offs.
- Windows crash-restart parity (schtasks' CLI flags don't expose restart-on-failure — a Task-Scheduler-XML-only setting) and `winget` / "Apps & Features" / Start Menu registration — those are installer-packaging concerns, not CLI code.

## Validation

- `go build ./cmd/gortex/`, `go vet ./cmd/gortex/` — clean.
- `go test ./cmd/gortex/` — passes, including new coverage: daemon-bounce ordering (stop→swap→restart, supervised path, failed-install-still-restarts), purge target/dedup/binary-advice, and the Windows schtasks arg vector.
- The Windows service functions carry no build tags, so they compile and type-check on every platform (a CGO/tree-sitter cross-compile to Windows isn't available locally); they are selected only when `GOOS=windows`.

## Attribution

The #281 pipeline fix carries forward @zerone0x's PR #292 (credited as co-author on that commit); it corrects two bugs in that PR's never-run test (`cmd.Path` vs `cmd.Args[0]` under `LookPath`, and a `nil`-context panic). The #298 feature commits are new work.