### PR TITLE
fix(indexer): ignore VCS metadata directories by default

### DIFF
--- a/internal/excludes/builtin.go
+++ b/internal/excludes/builtin.go
@@ -12,9 +12,16 @@ package excludes
 // Users can re-include an entry by listing "!pattern" in global,
 // RepoEntry, or workspace config.
 var Builtin = []string{
+	// Version-control metadata can contain huge object stores and working-copy
+	// state. Prune all common VCS directories before the walker descends.
 	".git/",
+	".jj/",
 	".hg/",
 	".svn/",
+	".bzr/",
+	"_darcs/",
+	".pijul/",
+	".fossil-settings/",
 	".terraform/",
 	".gortex-cache/",
 	".gortex/", // Gortex's per-repo state dir (quarantine, merkle tree)

--- a/internal/excludes/builtin_test.go
+++ b/internal/excludes/builtin_test.go
@@ -1,0 +1,40 @@
+package excludes
+
+import "testing"
+
+func TestBuiltinExcludesVersionControlMetadata(t *testing.T) {
+	t.Parallel()
+
+	matcher := New(Builtin)
+	for _, path := range []string{
+		".git/objects/pack/pack.data",
+		".jj/repo/store/type",
+		".hg/store/data/file.i",
+		".svn/pristine/00/file.svn-base",
+		".bzr/repository/pack-names",
+		"_darcs/inventories/000000",
+		".pijul/changes/ABC.change",
+		".fossil-settings/ignore-glob",
+		"nested/.jj/repo/store/type",
+	} {
+		if !matcher.MatchRel(path) {
+			t.Errorf("Builtin should exclude VCS metadata path %q", path)
+		}
+	}
+}
+
+func TestBuiltinDoesNotExcludeSimilarSourcePaths(t *testing.T) {
+	t.Parallel()
+
+	matcher := New(Builtin)
+	for _, path := range []string{
+		"jj/repository.go",
+		"pijul/client.go",
+		"fossil-settings/parser.go",
+		"darcs/model.go",
+	} {
+		if matcher.MatchRel(path) {
+			t.Errorf("Builtin unexpectedly excludes source path %q", path)
+		}
+	}
+}


### PR DESCRIPTION
Summary:
- exclude Jujutsu metadata directories from indexing and watching
- cover additional unambiguous VCS metadata directories for Bazaar, Darcs, Pijul, and Fossil
- add regression coverage for nested metadata and similarly named source paths

Tests:
- go test -race ./internal/excludes
- git diff --check