### PR TITLE
fix(mcp): preserve recovery for concrete path anchors

### DIFF
--- a/internal/mcp/localization_recovery_test.go
+++ b/internal/mcp/localization_recovery_test.go
@@ -63,7 +63,7 @@ func TestWeakReadAllowsOneBoundedSearchRecoveryThenTerminates(t *testing.T) {
 	}
 }
 
-func TestRecoveryRejectsSearchAnchorUnrelatedToTaskBeforeHandler(t *testing.T) {
+func TestRecoveryRejectsUnrelatedAnchorWithoutConsumingAllowance(t *testing.T) {
 	server := setupPresetServer(t, ToolPolicyConfig{Preset: "core", Mode: "defer"})
 	ctx := WithSessionID(context.Background(), "unrelated_recovery_anchor")
 	terminal := server.localizationFor(ctx)
@@ -76,19 +76,54 @@ func TestRecoveryRejectsSearchAnchorUnrelatedToTaskBeforeHandler(t *testing.T) {
 	calls := 0
 	server.facades.capture(mcpgo.NewTool(searchSpec.Legacy), func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 		calls++
-		return mcpgo.NewToolResultText(`{"matches":[{"text":"fn sink_matched"}]}`), nil
+		return mcpgo.NewToolResultText(`{"matches":[{"text":"replace output"}]}`), nil
 	})
 
 	result, err := server.handleFacade(ctx, "search", localizationRecoveryRequest("search", "text", map[string]any{
 		"query": "fn sink_matched",
 	}))
-	if err != nil {
-		t.Fatalf("unrelated recovery returned transport error: %v", err)
+	if err != nil || result == nil || !result.IsError {
+		t.Fatalf("unrelated recovery = (%#v, %v), want corrective tool error", result, err)
 	}
-	requireLocalizationTerminalError(t, result, "search", "text")
+	text, ok := singleTextContent(result)
+	if !ok {
+		t.Fatalf("corrective result content = %#v, want one text block", result.Content)
+	}
+	var corrective struct {
+		ErrorCode ErrorCode `json:"error_code"`
+		Retriable bool      `json:"retriable"`
+		Data      struct {
+			Contract localizationTerminalContract `json:"contract"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(text), &corrective); err != nil {
+		t.Fatalf("decode corrective error %q: %v", text, err)
+	}
+	if corrective.ErrorCode != ErrCodeLocalizationComplete || !corrective.Retriable {
+		t.Fatalf("corrective error = %#v", corrective)
+	}
+	if corrective.Data.Contract.Terminal ||
+		corrective.Data.Contract.Completion.State != localizationStateNeedsRecovery ||
+		corrective.Data.Contract.Completion.AllowedToolCalls != 1 {
+		t.Fatalf("corrective contract = %#v", corrective.Data.Contract)
+	}
+	terminal.mu.Lock()
+	stored := terminal.completionLocked()
+	terminal.mu.Unlock()
+	if stored.State != localizationStateNeedsRecovery || stored.AllowedToolCalls != 1 {
+		t.Fatalf("stored recovery after rejected anchor = %#v", stored)
+	}
 	if calls != 0 {
 		t.Fatalf("unrelated recovery reached handler: calls=%d", calls)
 	}
+
+	retry, err := server.handleFacade(ctx, "search", localizationRecoveryRequest("search", "text", map[string]any{
+		"query": "--replace",
+	}))
+	if err != nil || retry == nil || retry.IsError || calls != 1 {
+		t.Fatalf("corrected recovery = (%#v, %v), calls=%d", retry, err, calls)
+	}
+	requireLocalizationResultStateEqual(t, terminal, retry, localizationStateAnswerReady, true, 0)
 }
 
 func TestRecoveryAcceptsTaskAlignedIdentifierAndCompactLiteralAnchors(t *testing.T) {
@@ -100,6 +135,7 @@ func TestRecoveryAcceptsTaskAlignedIdentifierAndCompactLiteralAnchors(t *testing
 		{name: "identifier segment", task: "find candidate resolution", query: "resolveCandidate"},
 		{name: "flag", task: "--multiline with --replace duplicates output", query: "--replace"},
 		{name: "compact literal", task: `register the locale code "ku"`, query: "ku"},
+		{name: "specific VCS path", task: "confirm the completed VCS default exclusion change", query: `".jj/"`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/mcp/localization_terminal.go
+++ b/internal/mcp/localization_terminal.go
@@ -465,6 +465,12 @@ func (s *localizationTerminalState) interceptAnswerReady(facade, operation strin
 			// invalid request must never consume a newly committed task's recovery.
 			return nil, s.generation
 		}
+		if localizationRecoveryAllows(facade, operation, arguments) {
+			// A concrete search with a weak task correlation has not spent the
+			// bounded recovery call. Let the caller correct the anchor once it has
+			// better evidence instead of terminalizing the localization session.
+			return localizationRecoveryMisalignedResult(s.completionLocked(), facade, operation), 0
+		}
 		s.state = localizationStateAnswerReady
 		s.recoveryRetriesRemaining = 0
 		return localizationRecoveryRejectedResult(s.completionLocked(), facade, operation), 0
@@ -536,7 +542,20 @@ func localizationRecoveryQueryAligned(task, query string) bool {
 			return true
 		}
 	}
-	return false
+	return localizationRecoverySpecificAnchor(query)
+}
+
+// localizationRecoverySpecificAnchor admits compact path-like literals that
+// are sufficiently concrete to bound a recovery search on their own. This
+// covers metadata paths such as `".jj/"` whose semantic class (VCS state) may
+// appear in the task without the literal directory name. Generic declaration
+// fragments remain subject to task-term alignment.
+func localizationRecoverySpecificAnchor(query string) bool {
+	anchor := strings.Trim(strings.TrimSpace(query), "`'\"")
+	if len(anchor) < 2 || strings.ContainsAny(anchor, " \t\r\n") {
+		return false
+	}
+	return strings.ContainsAny(anchor, "/\\") || strings.HasPrefix(anchor, ".")
 }
 
 func localizationRecoveryOperationAllowed(facade, operation string) bool {
@@ -560,6 +579,20 @@ func (s *localizationTerminalState) consumeInvalidRecovery(facade, operation str
 	s.state = localizationStateAnswerReady
 	s.recoveryRetriesRemaining = 0
 	return s.completionLocked(), true
+}
+
+func localizationRecoveryMisalignedResult(completion localizationCompletion, facade, operation string) *mcpgo.CallToolResult {
+	return newStructuredErrorResult(StructuredError{
+		ErrorCode: ErrCodeLocalizationComplete,
+		Message:   "the recovery search query is not specific to the localization task; use a task term or a concrete path/literal anchor; the recovery allowance is still available",
+		Retriable: true,
+		Data: map[string]any{
+			"contract":           localizationContractFor(completion),
+			"facade":             facade,
+			"operation":          operation,
+			"allowed_operations": append([]string(nil), localizationRecoveryOperations...),
+		},
+	}, true)
 }
 
 func localizationRecoveryRejectedResult(completion localizationCompletion, facade, operation string) *mcpgo.CallToolResult {
@@ -701,6 +734,9 @@ func (s *localizationTerminalState) authorizeWithToken(facade, operation string,
 		if s.localizationRecoveryAllowsLocked(facade, operation, arguments) {
 			s.state = localizationStateRecoveryInFlight
 			return nil, s.beginReadReservationLocked()
+		}
+		if localizationRecoveryAllows(facade, operation, arguments) {
+			return localizationRecoveryMisalignedResult(s.completionLocked(), facade, operation), 0
 		}
 		s.state = localizationStateAnswerReady
 		s.recoveryRetriesRemaining = 0


### PR DESCRIPTION
Summary:
- accept concrete path-like recovery anchors such as quoted .jj/ even when the task uses only the broader VCS term
- keep needs_recovery active after a task-alignment rejection so the bounded allowance can be corrected
- preserve terminal behavior for malformed or unsupported recovery calls
- add regression coverage for the reported VCS/.jj flow and corrected-query retry

Tests:
- go test -race ./internal/mcp
- git diff --check