### PR TITLE
fix(store): acquire reindex writer gate unbounded to stop warmup crash

### DIFF
--- a/internal/graph/store_sqlite/reindex_set.go
+++ b/internal/graph/store_sqlite/reindex_set.go
@@ -72,12 +72,22 @@ func (s *Store) reindexEdgesSetOriented(batch []graph.EdgeReindex) (sqliteReinde
 		return stats, nil
 	}
 
-	gateCtx, cancelGate := context.WithTimeout(context.Background(), s.sqliteBusyRetryWindow())
-	gateErr := s.writeMu.LockContext(gateCtx)
-	cancelGate()
-	if gateErr != nil {
-		return stats, fmt.Errorf("store_sqlite: reindex writer gate: %w", gateErr)
-	}
+	// A resolver reindex is a mandatory graph mutation: the graph.Store
+	// interface has no error channel (it mirrors the in-memory store's
+	// "everything succeeds" contract), so ReindexEdges routes any failure here
+	// through panicOnFatal. Acquire the writer gate with an UNBOUNDED Lock,
+	// exactly like the single-edge ReindexEdge and the sibling
+	// setEdgeProvenanceBatchSetOriented. A bounded LockContext(sqliteBusyRetryWindow)
+	// abandons the batch when a sibling writer -- a warmup checkpoint, or a
+	// deferred-enrich mutation -- holds writeMu past the window; that surfaces as
+	// context.DeadlineExceeded, which is NOT one of panicOnFatal's swallowed
+	// teardown races, so it crashes the whole daemon over a recoverable
+	// lock-wait. The gate is only ever held by short sibling writers plus
+	// context-bounded maintenance (Compact's unbounded VACUUM is a dedicated
+	// daemon path, never concurrent with warmup resolve), so waiting cannot
+	// hang. Per-transaction SQLITE_BUSY contention is still bounded by
+	// withSQLiteBusyRetry below.
+	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
 
 	for txStart := 0; txStart < len(batch); txStart += reindexChunkSize {


### PR DESCRIPTION
## Problem

The daemon panics during warmup:

```
panic: store_sqlite: store_sqlite: reindex writer gate: context deadline exceeded
  ...store_sqlite.(*Store).ReindexEdges
  ...resolver.(*Resolver).persistAttributionReindexes
  ...resolver.(*Resolver).bindDataflowCalleeRefsForFile
  ...resolver.(*Resolver).ResolveAll
  ...indexer.(*MultiIndexer).RunPreEnrichResolve
  ...main.warmupDaemonState
```

## Root cause

`reindexEdgesSetOriented` acquired `writeMu` with a **bounded** `LockContext(sqliteBusyRetryWindow)` — 15s by default. A resolver reindex is a mandatory `graph.Store` mutation with no error channel (the interface mirrors the in-memory store's "everything succeeds" contract), so `ReindexEdges` routes any failure through `panicOnFatal`, which only swallows `ErrNoRows` / `ErrConnDone` / store-closed — **not** `context.DeadlineExceeded`.

When a sibling writer (a warmup WAL checkpoint, or a mutation from the deferred-enrichment pool started ahead of the resolve) held `writeMu` past the 15s window, the gate timed out and the recoverable lock-wait was escalated into a whole-daemon panic.

`reindexEdgesSetOriented` was the only mandatory-write path using a bounded gate; the siblings `ReindexEdge`, `setEdgeProvenanceBatchSetOriented`, and `RemoveEdge` all use a plain unbounded `writeMu.Lock()`.

## Fix

Acquire the gate with a plain unbounded `Lock()`, matching the sibling mandatory-write paths. A mandatory graph mutation must wait for the writer gate, not abandon the batch and crash.

Waiting cannot hang:
- `beginWriteContext` never re-locks `writeMu`;
- the only unbounded `writeMu` holder — `Compact`'s VACUUM — runs sequentially before the warmup resolve in the same goroutine, never concurrent;
- lock order is always resolver mutex → `writeMu`, no inversion (the siblings already prove unbounded `Lock` is safe from these resolver contexts).

Per-transaction `SQLITE_BUSY` contention remains bounded by `withSQLiteBusyRetry`. The checkpoint's bounded `LockContext` is left untouched — a checkpoint is retryable maintenance whose caller treats failure as skip-and-continue.

## Verification

- `go build ./...` and `go vet ./internal/graph/store_sqlite/` clean.
- `store_sqlite` busy / reindex / checkpoint / provenance tests pass with `-race` and without: `TestCheckpointSerializesBehindWriterGate`, `TestReindexEdgesRetriesWholeTransactionAfterBusy`, `TestReindexEdgesPersistentBusySurfacesAndRollsBack`, `TestLongWALReaderDoesNotBlockReindexWriter`. No test asserted the gate-timeout path, so behavior is unchanged for covered cases.
