### PR TITLE
fix(store): tolerate reindex writer-gate timeout instead of crashing daemon

### DIFF
--- a/internal/graph/store_sqlite/reindex_set.go
+++ b/internal/graph/store_sqlite/reindex_set.go
@@ -76,7 +76,11 @@ func (s *Store) reindexEdgesSetOriented(batch []graph.EdgeReindex) (sqliteReinde
 	gateErr := s.writeMu.LockContext(gateCtx)
 	cancelGate()
 	if gateErr != nil {
-		return stats, fmt.Errorf("store_sqlite: reindex writer gate: %w", gateErr)
+		// Wrap the recoverable sentinel so ReindexEdges can tell a contended
+		// gate (drop the batch, rebind later) apart from a fatal store error
+		// (panic). gateErr stays wrapped too, so callers still see the
+		// underlying context.DeadlineExceeded / Canceled.
+		return stats, fmt.Errorf("%w: %w", errReindexWriterGateContended, gateErr)
 	}
 	defer s.writeMu.Unlock()
 

--- a/internal/graph/store_sqlite/store.go
+++ b/internal/graph/store_sqlite/store.go
@@ -1499,6 +1499,17 @@ func (s *Store) ReindexEdge(e *graph.Edge, oldTo string) {
 // mutations.
 const reindexChunkSize = 5000
 
+// errReindexWriterGateContended marks a reindex abandoned because the writer
+// gate stayed contended past its bounded window (see reindexEdgesSetOriented).
+// It is recoverable by design -- the batch is dropped and its edges are rebound
+// by a later resolve pass -- so ReindexEdges swallows it instead of escalating
+// through panicOnFatal. The bounded gate exists precisely so a mandatory
+// reindex cannot block the store indefinitely; turning that liveness signal
+// into a daemon-killing panic (which it did during warmup, when a checkpoint or
+// a sibling mutation held writeMu past the window) is strictly worse than
+// leaving a few edges unresolved until the next pass.
+var errReindexWriterGateContended = errors.New("store_sqlite: reindex writer gate contended")
+
 // ReindexEdges applies resolver re-binds through bounded VALUES relations.
 // Each bounded transaction prefetches only the relevant identities through
 // variable-safe VALUES relations, simulates the prior ordered DELETE + INSERT
@@ -1510,6 +1521,10 @@ func (s *Store) ReindexEdges(batch []graph.EdgeReindex) {
 		}
 	}
 	if _, err := s.reindexEdgesSetOriented(batch); err != nil {
+		if errors.Is(err, errReindexWriterGateContended) {
+			log.Printf("store_sqlite: reindex writer gate contended, dropping %d rebind(s) — a later resolve pass rebinds them: %v", len(batch), err)
+			return
+		}
 		panicOnFatal(err)
 	}
 }


### PR DESCRIPTION
## Problem

The daemon panics during warmup:

```
panic: store_sqlite: store_sqlite: reindex writer gate: context deadline exceeded
  ...ReindexEdges -> persistAttributionReindexes -> ResolveAll -> RunPreEnrichResolve -> warmupDaemonState
```

## Root cause

The writer gate in `reindexEdgesSetOriented` is **bounded on purpose** — `TestReindexWriterGateWaitHonorsContext` pins the contract: a mandatory reindex must not block the store indefinitely, so under sustained `writeMu` contention it returns `context.DeadlineExceeded` and abandons the batch (those edges stay unresolved until a later pass).

`ReindexEdges` routed **every** error from that call through `panicOnFatal`, which only swallows `ErrNoRows` / `ErrConnDone` / store-closed — not `DeadlineExceeded`. So when a warmup WAL checkpoint (or a sibling mutation from the deferred-enrichment pool) held `writeMu` past the gate window, the recoverable lock-wait was escalated into a whole-daemon crash.

## Fix

Keep the bounded gate exactly as-is (its `DeadlineExceeded` contract is unchanged and still tested). Wrap the gate timeout in a recoverable sentinel `errReindexWriterGateContended`, and have `ReindexEdges` **log-and-drop** the batch on that sentinel instead of panicking. The dropped rebinds are re-applied by a later resolve pass — the same benign degradation the bounded gate already accepts — rather than taking the daemon down over a recoverable lock-wait.

Only the gate-contention timeout is swallowed; genuine fatal store errors (and `SQLITE_BUSY` exhaustion) still panic as before.

## Verification

- `go build ./...` and `go vet ./internal/graph/store_sqlite/` clean.
- Full `internal/graph/store_sqlite` package passes with `-race`, including `TestReindexWriterGateWaitHonorsContext` and the busy / checkpoint / reindex-receipt suites.

## Supersedes

Replaces the earlier attempt in #328, which made the gate unbounded — that violated the intentional bounded-gate contract and deadlocked `TestReindexWriterGateWaitHonorsContext` (20-minute CI timeout).
