### PR TITLE
fix(init): layer the repo's .gitignore into the init index walk

### DIFF
--- a/cmd/gortex/init.go
+++ b/cmd/gortex/init.go
@@ -409,6 +409,38 @@ func toEnvSkills(src []genskills.GeneratedSkill) []agents.GeneratedSkill {
 	return out
 }
 
+// initRepoConfig resolves the layered per-repo config for root exactly the way
+// the daemon does — builtin baseline, the repo's own `.gitignore` (unless
+// `respect_gitignore: false`), global config, and workspace excludes — and
+// returns it with Index.Exclude populated.
+//
+// init previously loaded the config with an empty *config file* path, which
+// carries no repo, so the `.gitignore` layer never ran. indexer.New then saw an
+// empty Index.Exclude and fell back to excludes.Builtin alone, so the init walk
+// admitted gitignored trees (nested worktrees under an ignored directory,
+// generated output) that the daemon's indexer prunes (#324).
+//
+// globalPath is empty in production (the default ~/.gortex/config.yaml); tests
+// pass a temp path so they never read the developer's real global config.
+func initRepoConfig(globalPath, root string, logger *zap.Logger) *config.Config {
+	cm, err := config.NewConfigManager(globalPath)
+	if err != nil {
+		// Preserve the previous best-effort behaviour: an unreadable global
+		// config should not block indexing outright.
+		cfg, loadErr := config.Load("")
+		if loadErr != nil {
+			return &config.Config{}
+		}
+		return cfg
+	}
+	if logger != nil {
+		cm.SetLogger(logger)
+	}
+	prefix := config.ResolvePrefix(config.RepoEntry{Path: root})
+	cm.LoadWorkspaceConfig(prefix, root)
+	return cm.GetRepoConfig(prefix)
+}
+
 // indexRepoForInit runs a one-shot index of the repo. Kept inside
 // cmd/gortex (not an adapter) because the indexer pulls in many
 // gortex-internal packages we'd rather not leak into internal/agents.
@@ -431,10 +463,7 @@ func indexRepoForInit(ctx context.Context, root string, logger *zap.Logger) (gra
 	}
 	defer func() { _ = logger.Sync() }()
 
-	cfg, err := config.Load("")
-	if err != nil {
-		cfg = &config.Config{}
-	}
+	cfg := initRepoConfig("", root, logger)
 
 	tmpDir, err := os.MkdirTemp("", "gortex-init-store-*")
 	if err != nil {

--- a/cmd/gortex/init_gitignore_test.go
+++ b/cmd/gortex/init_gitignore_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/zzet/gortex/internal/excludes"
+)
+
+// TestInitRepoConfigLayersRepoGitignore pins #324. `gortex init` resolved its
+// config without a repo path, so the repo's own .gitignore never reached
+// indexer.New; the init walk then admitted gitignored trees (nested worktrees
+// under an ignored directory, generated output) that the daemon's indexer
+// prunes. Builtin-only exclusion is not enough — it covers node_modules/ and
+// .next/ but not repo-specific ignores.
+func TestInitRepoConfigLayersRepoGitignore(t *testing.T) {
+	root := t.TempDir()
+	writeInitConfigFile(t, filepath.Join(root, ".gitignore"), "tmp/\n/generated-out/\n")
+	globalPath := filepath.Join(t.TempDir(), "config.yaml")
+	writeInitConfigFile(t, globalPath, "")
+
+	cfg := initRepoConfig(globalPath, root, nil)
+	matcher := excludes.New(cfg.Index.Exclude)
+
+	for _, dir := range []string{"tmp", "generated-out"} {
+		if !matcher.MatchAbsDir(filepath.Join(root, dir), root, true) {
+			t.Errorf("gitignored %q must be excluded from the init walk; Index.Exclude=%v",
+				dir, cfg.Index.Exclude)
+		}
+	}
+	// A tracked directory must still be walked, so the fix cannot be
+	// "exclude everything".
+	if matcher.MatchAbsDir(filepath.Join(root, "internal"), root, true) {
+		t.Errorf("tracked directory must not be excluded; Index.Exclude=%v", cfg.Index.Exclude)
+	}
+}
+
+// TestInitRepoConfigHonoursRespectGitignoreOptOut keeps the documented escape
+// hatch working: a repo that opts out must still have its ignored trees walked.
+func TestInitRepoConfigHonoursRespectGitignoreOptOut(t *testing.T) {
+	root := t.TempDir()
+	writeInitConfigFile(t, filepath.Join(root, ".gitignore"), "tmp/\n")
+	writeInitConfigFile(t, filepath.Join(root, ".gortex.yaml"), "respect_gitignore: false\n")
+	globalPath := filepath.Join(t.TempDir(), "config.yaml")
+	writeInitConfigFile(t, globalPath, "")
+
+	cfg := initRepoConfig(globalPath, root, nil)
+	if excludes.New(cfg.Index.Exclude).MatchAbsDir(filepath.Join(root, "tmp"), root, true) {
+		t.Errorf("respect_gitignore: false must not layer .gitignore; Index.Exclude=%v",
+			cfg.Index.Exclude)
+	}
+}
+
+func writeInitConfigFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
Fixes #324.

## Root cause

`indexRepoForInit` resolved its config with:

```go
cfg, err := config.Load("")
```

`config.Load` takes a **config file** path, not a repo path, so the per-repo
layering never ran and `cfg.Index.Exclude` came back empty. `indexer.New` then
hit its own documented fallback:

```go
patterns := idx.config.Exclude
// A nil/empty list from upstream means "no layering was applied"
// (e.g. a direct caller of indexer.New without ConfigManager).
if len(patterns) == 0 {
    patterns = excludes.Builtin
}
```

`cmd/gortex/init.go` is exactly that direct caller, so the init walk ran on
`excludes.Builtin` alone and admitted every gitignored tree that does not happen
to match a builtin pattern. Only the daemon reached the layered list, via
`ConfigManager.GetRepoConfig` → `EffectiveExclude`.

The admission path never consults `.gitignore` on its own either —
`dirIgnoreFiles` is `{".gortexignore", ".ignore", ".rgignore"}` — so the
`.gitignore` layer exists solely in `internal/config`.

## Why this is a bug rather than a design choice

`RespectGitignore` is documented as defaulting to true. The promise held for the
daemon and silently did not hold for `init`.

## Symptom (from #324)

On a repo whose `.gitignore` excludes `tmp/` (holding four linked worktrees) and
a generated output directory:

| | files |
|---|---|
| tracked set | 2,693 |
| queued by `init` | **15,496** (5.7×) |

Still parsing at 18m46s. `node_modules/` (29.7k) and `.next/` (5.1k) were
correctly skipped because they match builtin patterns — which is what made the
failure look inconsistent rather than absent.

Note for #324 readers: the issue guessed that nested git worktrees were being
treated as admissible repos. That turned out to be a red herring —
`LinkedWorktreeRoots` only reports already-tracked repos. The worktrees under
`tmp/` were swallowed simply because `tmp/` was never pruned.

## Fix

Resolve the config for the actual root through the same path the daemon uses.
The new `initRepoConfig` helper:

- keeps the previous best-effort fallback when the global config cannot be read,
  so an unreadable `~/.gortex/config.yaml` still does not block indexing;
- takes an explicit global path so tests never read the developer's real global
  config.

## Tests

`cmd/gortex/init_gitignore_test.go`:

- `TestInitRepoConfigLayersRepoGitignore` — gitignored dirs are excluded, and a
  tracked dir is still walked (so the fix cannot be "exclude everything").
- `TestInitRepoConfigHonoursRespectGitignoreOptOut` — `respect_gitignore: false`
  still walks ignored trees.

Sabotage-verified: reverting the helper to the old `config.Load("")` behaviour
makes `TestInitRepoConfigLayersRepoGitignore` fail; restoring it passes.

## Verification

`gofmt`, `go vet` and `go build` clean.

Full-package runs on Windows show six failures — `TestReviewCLI_AudienceAgent`
(path separators), `TestComputePurgePlan*` and `TestDefaultGlobalConfigPath_*`
(they read the real `HOME` rather than the temp one), and `TestMatchRepo_SuffixMatch`
(needs a running daemon). I confirmed all six fail identically on the base commit
`7de88fb` without this change, so they are pre-existing environment coupling and
not introduced here.