### PR TITLE
fix(mcp): detach the track first-index from the request lifetime

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -146,6 +146,11 @@ type Server struct {
 	// changes with a reindex under a different exclude set, so
 	// daemon-lifetime caching is safe.
 	testIndexProbe sync.Map
+	// trackInFlight guards first-index runs by absolute repo path.
+	// track answers before the index finishes (#326), so without this a
+	// second call for the same path would start a duplicate full index:
+	// TrackRepoCtx's already-tracked check only sees repos that finished.
+	trackInFlight sync.Map
 	// scopeWorkspace / scopeProject default-scope every query at this
 	// server instance to a single (workspace, project) tuple. Set by
 	// `gortex server --workspace <slug> [--scope-project <slug>]`.

--- a/internal/mcp/tools_multi.go
+++ b/internal/mcp/tools_multi.go
@@ -6,12 +6,20 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"go.uber.org/zap"
 
 	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/indexer"
 )
+
+// trackAcceptedHeadroom is how long before the MCP request deadline the
+// track handler stops waiting for the first index and answers `accepted`.
+// Without the headroom the daemon aborts the request first and the caller
+// sees a bare timeout instead of a usable answer.
+const trackAcceptedHeadroom = 5 * time.Second
 
 // registerMultiRepoTools registers MCP tools for multi-repo management:
 // track_repository, untrack_repository, set_active_project, get_active_project.
@@ -99,39 +107,88 @@ func (s *Server) handleTrackRepository(ctx context.Context, req mcp.CallToolRequ
 		entry.Force = force
 	}
 
-	result, trackErr := s.multiIndexer.TrackRepoCtx(s.progressCtx(ctx, req), entry)
-	if trackErr != nil {
-		return mcp.NewToolResultError(trackErr.Error()), nil
+	// A fresh repo's first index routinely outruns the MCP request deadline,
+	// and registration only lands *after* TrackRepoCtx returns — so the
+	// cancelled index left the repo untracked and a retry just repeated the
+	// cycle (#326). Run the index on a context detached from the request and
+	// answer `accepted` before the deadline, so the work continues
+	// server-side the way boot indexing does.
+	absPath, absErr := filepath.Abs(path)
+	if absErr != nil {
+		absPath = path
+	}
+	if _, busy := s.trackInFlight.LoadOrStore(absPath, struct{}{}); busy {
+		return s.respondJSONOrTOON(ctx, req, map[string]any{
+			"status": "accepted",
+			"path":   path,
+			"detail": "an initial index for this path is already running; call track again later to read its result",
+		})
 	}
 
-	// Already tracked — TrackRepo returns nil result when repo exists.
-	if result == nil {
-		return mcp.NewToolResultText("repository already tracked"), nil
+	type trackOutcome struct {
+		result *indexer.IndexResult
+		err    error
 	}
-
-	// Persist updated config.
-	if s.configManager != nil {
-		if saveErr := s.configManager.Global().Save(); saveErr != nil {
-			s.logger.Warn("failed to persist config after tracking repo",
-				zap.String("path", path), zap.Error(saveErr))
+	done := make(chan trackOutcome, 1)
+	go func() {
+		defer s.trackInFlight.Delete(absPath)
+		// WithoutCancel keeps the request's values (progress token, session)
+		// while dropping its cancellation, so the daemon's request lifetime
+		// can no longer kill a half-written first index.
+		res, trackErr := s.multiIndexer.TrackRepoCtx(
+			s.progressCtx(context.WithoutCancel(ctx), req), entry)
+		if trackErr == nil && res != nil {
+			// Persist and refresh here rather than in the caller: the caller
+			// may already have answered `accepted` and returned.
+			if s.configManager != nil {
+				if saveErr := s.configManager.Global().Save(); saveErr != nil {
+					s.logger.Warn("failed to persist config after tracking repo",
+						zap.String("path", path), zap.Error(saveErr))
+				}
+			}
+			s.RunAnalysis()
 		}
+		done <- trackOutcome{result: res, err: trackErr}
+	}()
+
+	// A nil channel blocks forever, so a request with no deadline (CLI, tests)
+	// keeps today's fully synchronous contract.
+	var answerBy <-chan time.Time
+	if deadline, ok := ctx.Deadline(); ok {
+		wait := max(time.Until(deadline)-trackAcceptedHeadroom, 0)
+		timer := time.NewTimer(wait)
+		defer timer.Stop()
+		answerBy = timer.C
 	}
 
-	// Re-run analysis after adding a new repo.
-	s.RunAnalysis()
-
-	prefix := result.RepoPrefix
-	if prefix == "" {
-		prefix = config.ResolvePrefix(entry)
+	select {
+	case out := <-done:
+		if out.err != nil {
+			return mcp.NewToolResultError(out.err.Error()), nil
+		}
+		// Already tracked — TrackRepo returns nil result when repo exists.
+		if out.result == nil {
+			return mcp.NewToolResultText("repository already tracked"), nil
+		}
+		prefix := out.result.RepoPrefix
+		if prefix == "" {
+			prefix = config.ResolvePrefix(entry)
+		}
+		return s.respondJSONOrTOON(ctx, req, map[string]any{
+			"status":     "tracked",
+			"path":       path,
+			"prefix":     prefix,
+			"file_count": out.result.FileCount,
+			"node_count": out.result.NodeCount,
+			"edge_count": out.result.EdgeCount,
+		})
+	case <-answerBy:
+		return s.respondJSONOrTOON(ctx, req, map[string]any{
+			"status": "accepted",
+			"path":   path,
+			"detail": "initial index is still running server-side and is no longer bound to this request; call track again to read the tracked result",
+		})
 	}
-	return s.respondJSONOrTOON(ctx, req, map[string]any{
-		"status":     "tracked",
-		"path":       path,
-		"prefix":     prefix,
-		"file_count": result.FileCount,
-		"node_count": result.NodeCount,
-		"edge_count": result.EdgeCount,
-	})
 }
 
 // handleUntrackRepository removes a repo from the workspace and persists to GlobalConfig.

--- a/internal/mcp/tools_multi_track_deadline_test.go
+++ b/internal/mcp/tools_multi_track_deadline_test.go
@@ -1,0 +1,112 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTrackRepositoryDetachesFirstIndexFromRequestLifetime pins #326.
+//
+// The first index of a fresh repo ran inside the MCP request context and
+// registration only landed *after* it returned, so a request that hit the
+// daemon's 60s lifetime cancelled the index and left the repo untracked —
+// a retry then repeated the cycle. MCP-driven tracking therefore only ever
+// worked for repos that fully indexed inside the deadline.
+//
+// A already-cancelled request context reproduces that deterministically: with
+// the index bound to it, TrackRepoCtx fails immediately and nothing registers.
+func TestTrackRepositoryDetachesFirstIndexFromRequestLifetime(t *testing.T) {
+	srv, mi := newWorktreeMCPServer(t)
+	require.Empty(t, mi.AllMetadata(), "fixture must start with no tracked repo")
+
+	repo := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "lib.go"),
+		[]byte("package lib\n\nfunc Tracked() {}\n"), 0o644))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // the daemon ended the request lifetime
+
+	req := mcplib.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"path": repo}
+
+	res, err := srv.handleTrackRepository(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.False(t, res.IsError,
+		"a spent request context must not abort tracking: %+v", res.Content)
+
+	var payload struct {
+		Status string `json:"status"`
+		Prefix string `json:"prefix"`
+	}
+	require.NoError(t, json.Unmarshal(
+		[]byte(extractTextFromContent(t, res.Content)), &payload))
+	require.Equal(t, "tracked", payload.Status)
+	require.NotEmpty(t, payload.Prefix)
+
+	// The detached index must have registered the repo, so a later call finds
+	// it instead of starting over.
+	require.Len(t, mi.AllMetadata(), 1,
+		"the first index must register the repo even though the request was cancelled")
+
+	second, err := srv.handleTrackRepository(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, second.IsError)
+	require.Contains(t, extractTextFromContent(t, second.Content), "already tracked")
+}
+
+// TestTrackRepositoryAnswersBeforeTheRequestDeadline pins the second half of
+// #326: rather than letting the daemon abort the request, the handler answers
+// `accepted` while the index keeps running server-side. A deadline that has
+// already passed leaves no room to wait, so the answer must come back
+// immediately and must not be an error.
+func TestTrackRepositoryAnswersBeforeTheRequestDeadline(t *testing.T) {
+	srv, mi := newWorktreeMCPServer(t)
+
+	repo := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "lib.go"),
+		[]byte("package lib\n\nfunc Deadlined() {}\n"), 0o644))
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	req := mcplib.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"path": repo}
+
+	res, err := srv.handleTrackRepository(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.False(t, res.IsError,
+		"an expired deadline must yield an answer, not a failure: %+v", res.Content)
+
+	var payload struct {
+		Status string `json:"status"`
+	}
+	require.NoError(t, json.Unmarshal(
+		[]byte(extractTextFromContent(t, res.Content)), &payload))
+	// Either the index beat the (already spent) timer or the handler answered
+	// `accepted`; both are correct, and neither may be an error or a hang.
+	require.Contains(t, []string{"accepted", "tracked"}, payload.Status)
+
+	// Whichever branch answered, the work must still land — and this test must
+	// not return while the detached goroutine is still writing (it persists
+	// config and re-runs analysis after registering), or it would race the
+	// tests that follow. A second track call reports "already tracked" only
+	// once that goroutine released its in-flight guard, so polling it is both
+	// the assertion and the barrier.
+	require.Eventually(t, func() bool {
+		follow, followErr := srv.handleTrackRepository(context.Background(), req)
+		return followErr == nil && follow != nil && !follow.IsError &&
+			strings.Contains(extractTextFromContent(t, follow.Content), "already tracked")
+	}, 30*time.Second, 25*time.Millisecond,
+		"the detached first index must register the repo and finish cleanly")
+	require.Len(t, mi.AllMetadata(), 1)
+}


### PR DESCRIPTION
Fixes #326.

## Root cause

`handleTrackRepository` ran the first index inside the MCP request context, and
`TrackRepoCtx` only registers the repo **after** that index returns:

```go
result, err := idx.IndexCtx(ctx, absPath)     // bound to the MCP request
if err != nil { return nil, ... }             // ← returns here
mi.repos[prefix] = &RepoMetadata{...}         // registration is below
mi.configMgr.Global().AddRepo(entry)
```

So when the daemon's 60s request lifetime expired, the context cancelled, the
index failed, and registration was never reached. Nothing was rolled back — it
simply never ran, which is why the daemon logged `tracked_roots: []` and a retry
repeated the cycle. MCP-driven tracking only worked for repos that fully indexed
inside the deadline; CLI `gortex track` (no lifetime) was the only path that
worked.

## Fix

Following the first option in the issue — detach the initial index from the
request lifetime:

- run the index on `context.WithoutCancel(ctx)`, which keeps the request's
  values (progress token, session) while dropping its cancellation;
- move the config save and analysis refresh into the same goroutine, so they
  still happen once the caller has already been answered;
- answer `accepted` a short headroom before the deadline instead of letting the
  daemon abort the request. A request **without** a deadline (CLI, tests) keeps
  today's fully synchronous contract, because the timer channel stays nil and
  `select` waits only on completion.

Answering before the index finishes introduces a case the old code could not
hit: a second `track` for the same path arriving while the first is still
running. `TrackRepoCtx`'s already-tracked check only sees repos that finished,
so that would start a duplicate full index. Added a `sync.Map` in-flight guard
keyed by absolute path that reports `accepted` instead.

## Tests

`internal/mcp/tools_multi_track_deadline_test.go`:

- `TestTrackRepositoryDetachesFirstIndexFromRequestLifetime` — calls the handler
  with an **already-cancelled** context. That reproduces the bug
  deterministically: bound to the request, `TrackRepoCtx` fails immediately and
  nothing registers. The test asserts the repo is tracked anyway and that a
  follow-up call reports `already tracked`.
- `TestTrackRepositoryAnswersBeforeTheRequestDeadline` — an expired deadline must
  yield an answer rather than an error or a hang, and the work must still land.
  It polls a follow-up `track` until it reports `already tracked`, which doubles
  as a barrier so the detached goroutine cannot race the tests that follow.

Sabotage-verified: re-binding the index to `ctx` makes the first test fail on
`res.IsError`; restoring the detachment passes.

## Verification

`gofmt`, `go vet`, `go build` clean.

`internal/mcp` on Windows fails 63 tests both with and without this change
(path/URI, symlink and persistence round-trips that read the real `HOME`). Base
`7de88fb` and this branch each report **63**; the two sets differ only by a
2-for-2 swap inside the already-flaky `TestReviewPack_*` family plus
`TestSiblingDiffContext_GCXAndTOONAndBudget`, which passes in isolation on this
branch. A regression would add failures rather than exchange them, so I could
not attribute any of them to this change — but a Linux CI run is the better
check.