### PR TITLE
fix(agents): alias Pi tool names that collide with its built-ins

### DIFF
--- a/cmd/gortex/testdata/agent-render/pi.txt
+++ b/cmd/gortex/testdata/agent-render/pi.txt
@@ -64,11 +64,9 @@ const CLIENT_NAME = "pi";
 const CLIENT_VERSION = "1.0.0";
 const WIRE_FORMATS: string[] = ["gcx"];
 
-// Names of the Gortex tools registered into Pi — the daemon's bare tool
-// names (search_symbols, tools_search, ...). Registered unprefixed so
-// every name the server's tools_search reply cites is exactly a callable
-// Pi tool; on an (unlikely) collision with another extension's tool,
-// safeRegister leaves the existing registration standing.
+// Names the Gortex tools are registered under in Pi — usually the bare
+// daemon name, except for a few aliased to dodge Pi's built-ins (see
+// piAliasName). Tracks the post-alias name.
 const gortexToolNames = new Set<string>();
 
 // ---------------------------------------------------------------------------
@@ -433,15 +431,48 @@ interface ToolDescriptor {
   inputSchema?: unknown;
 }
 
-// safeRegister registers a Pi tool, tolerating a redundant registration —
-// a config reload can re-fire session_start without resetting the session's
-// tool registry, in which case the name is already live and Pi may throw.
-function safeRegister(pi: any, def: any): void {
+// Pi's reserved built-in names (mirrors toolNameMap's keys). Pi lets an
+// extension silently replace a built-in by reusing its name, but our
+// generic bridge doesn't match the built-in's result shape — breaking
+// Pi's own rendering and any extension hooked to the built-in (e.g. a
+// lint-on-edit plugin). Only "edit"/"read" collide today; checking all
+// seven guards against future facade additions too.
+const PI_RESERVED_TOOL_NAMES = new Set(Object.keys(toolNameMap));
+const PI_ALIAS_PREFIX = "gortex_";
+
+// piAliasName is unchanged unless name collides with a built-in above, in
+// which case it's registered under a `gortex_`-prefixed alias instead.
+function piAliasName(name: string): string {
+  return PI_RESERVED_TOOL_NAMES.has(name) ? PI_ALIAS_PREFIX + name : name;
+}
+
+// piAliasNote tells the model which tools got aliased this session, so it
+// can translate bare names in Gortex's own guidance. Pi-local by design —
+// not a fact any other agent needs.
+function piAliasNote(): string {
+  const aliased = Array.from(gortexToolNames).filter((n) => n.startsWith(PI_ALIAS_PREFIX));
+  if (aliased.length === 0) return "";
+  const pairs = aliased
+    .map((n) => `\`${n.slice(PI_ALIAS_PREFIX.length)}\` -> \`${n}\``)
+    .join(", ");
+  return (
+    `[Gortex] This session renamed these Gortex tools to avoid colliding with Pi's own built-ins ` +
+    `of the same name: ${pairs}. Wherever Gortex's guidance or tool descriptions mention the bare name, call the renamed one instead.`
+  );
+}
+
+// safeRegister registers under the alias name (piAliasName), tolerating a
+// redundant registration — a reload can re-fire session_start without
+// resetting the registry. Returns the name actually registered.
+function safeRegister(pi: any, def: any): string {
+  def.name = piAliasName(def.name);
+  def.label = def.name;
   try {
     pi.registerTool(def);
   } catch {
     // already live this session — the existing registration stands.
   }
+  return def.name;
 }
 
 // Lazily resolved TUI Text component, used only to collapse a gortex
@@ -474,8 +505,7 @@ try {
 function registerOneTool(pi: any, desc: ToolDescriptor): void {
   const name = desc.name;
   if (!name) return;
-  if (gortexToolNames.has(name)) return;
-  gortexToolNames.add(name);
+  if (gortexToolNames.has(piAliasName(name))) return;
   const parameters =
     desc.inputSchema && typeof desc.inputSchema === "object"
       ? desc.inputSchema
@@ -513,7 +543,7 @@ function registerOneTool(pi: any, desc: ToolDescriptor): void {
       return new TuiText!(text, 0, 0);
     };
   }
-  safeRegister(pi, def);
+  gortexToolNames.add(safeRegister(pi, def));
 }
 
 // registerGortexTools fetches the daemon's eager surface (tools/list —
@@ -621,6 +651,8 @@ export default function (pi: any) {
       bridgeError = "";
     }
     if (decision.orientation) parts.push(decision.orientation);
+    const aliasNote = piAliasNote();
+    if (aliasNote) parts.push(aliasNote);
     if (parts.length > 0) {
       pendingOrientation = parts.join("\n\n");
       orientationInjected = true;

--- a/internal/agents/pi/extension/index.ts
+++ b/internal/agents/pi/extension/index.ts
@@ -63,11 +63,9 @@ const CLIENT_NAME = "pi";
 const CLIENT_VERSION = "1.0.0";
 const WIRE_FORMATS: string[] = ["gcx"];
 
-// Names of the Gortex tools registered into Pi — the daemon's bare tool
-// names (search_symbols, tools_search, ...). Registered unprefixed so
-// every name the server's tools_search reply cites is exactly a callable
-// Pi tool; on an (unlikely) collision with another extension's tool,
-// safeRegister leaves the existing registration standing.
+// Names the Gortex tools are registered under in Pi — usually the bare
+// daemon name, except for a few aliased to dodge Pi's built-ins (see
+// piAliasName). Tracks the post-alias name.
 const gortexToolNames = new Set<string>();
 
 // ---------------------------------------------------------------------------
@@ -432,15 +430,48 @@ interface ToolDescriptor {
   inputSchema?: unknown;
 }
 
-// safeRegister registers a Pi tool, tolerating a redundant registration —
-// a config reload can re-fire session_start without resetting the session's
-// tool registry, in which case the name is already live and Pi may throw.
-function safeRegister(pi: any, def: any): void {
+// Pi's reserved built-in names (mirrors toolNameMap's keys). Pi lets an
+// extension silently replace a built-in by reusing its name, but our
+// generic bridge doesn't match the built-in's result shape — breaking
+// Pi's own rendering and any extension hooked to the built-in (e.g. a
+// lint-on-edit plugin). Only "edit"/"read" collide today; checking all
+// seven guards against future facade additions too.
+const PI_RESERVED_TOOL_NAMES = new Set(Object.keys(toolNameMap));
+const PI_ALIAS_PREFIX = "gortex_";
+
+// piAliasName is unchanged unless name collides with a built-in above, in
+// which case it's registered under a `gortex_`-prefixed alias instead.
+function piAliasName(name: string): string {
+  return PI_RESERVED_TOOL_NAMES.has(name) ? PI_ALIAS_PREFIX + name : name;
+}
+
+// piAliasNote tells the model which tools got aliased this session, so it
+// can translate bare names in Gortex's own guidance. Pi-local by design —
+// not a fact any other agent needs.
+function piAliasNote(): string {
+  const aliased = Array.from(gortexToolNames).filter((n) => n.startsWith(PI_ALIAS_PREFIX));
+  if (aliased.length === 0) return "";
+  const pairs = aliased
+    .map((n) => `\`${n.slice(PI_ALIAS_PREFIX.length)}\` -> \`${n}\``)
+    .join(", ");
+  return (
+    `[Gortex] This session renamed these Gortex tools to avoid colliding with Pi's own built-ins ` +
+    `of the same name: ${pairs}. Wherever Gortex's guidance or tool descriptions mention the bare name, call the renamed one instead.`
+  );
+}
+
+// safeRegister registers under the alias name (piAliasName), tolerating a
+// redundant registration — a reload can re-fire session_start without
+// resetting the registry. Returns the name actually registered.
+function safeRegister(pi: any, def: any): string {
+  def.name = piAliasName(def.name);
+  def.label = def.name;
   try {
     pi.registerTool(def);
   } catch {
     // already live this session — the existing registration stands.
   }
+  return def.name;
 }
 
 // Lazily resolved TUI Text component, used only to collapse a gortex
@@ -473,8 +504,7 @@ try {
 function registerOneTool(pi: any, desc: ToolDescriptor): void {
   const name = desc.name;
   if (!name) return;
-  if (gortexToolNames.has(name)) return;
-  gortexToolNames.add(name);
+  if (gortexToolNames.has(piAliasName(name))) return;
   const parameters =
     desc.inputSchema && typeof desc.inputSchema === "object"
       ? desc.inputSchema
@@ -512,7 +542,7 @@ function registerOneTool(pi: any, desc: ToolDescriptor): void {
       return new TuiText!(text, 0, 0);
     };
   }
-  safeRegister(pi, def);
+  gortexToolNames.add(safeRegister(pi, def));
 }
 
 // registerGortexTools fetches the daemon's eager surface (tools/list —
@@ -620,6 +650,8 @@ export default function (pi: any) {
       bridgeError = "";
     }
     if (decision.orientation) parts.push(decision.orientation);
+    const aliasNote = piAliasNote();
+    if (aliasNote) parts.push(aliasNote);
     if (parts.length > 0) {
       pendingOrientation = parts.join("\n\n");
       orientationInjected = true;


### PR DESCRIPTION
## Summary

Pi has no native MCP support — extensions register tools into a flat, unprefixed registry, and Pi lets a same-named registration silently override a built-in (`read`, `bash`, `edit`, `write`, `grep`, `find`, `ls`). Gortex's default facade-v1 surface includes `edit` and `read`, so the Pi bridge was overriding those two built-ins with a generic relay that doesn't match Pi's expected result shape — breaking the built-in's own rendering (edited filename showed as `"..."`) and any extension hooked to the built-in shape (e.g. a lint-on-edit plugin expecting the native `edit` tool).

## Changes

- Alias only the tools that actually collide with Pi's reserved built-in names (`gortex_edit`, `gortex_read` today) instead of prefixing every Gortex tool, since a blanket prefix has previously confused the model — Gortex's own guidance and tool descriptions reference bare names elsewhere.
- `safeRegister` now registers under the alias name and returns the name actually used; `registerOneTool` dedupes against the aliased name.
- Session orientation now appends a short Pi-local note listing any renamed tools this session, so the model knows to translate bare names it sees in Gortex's guidance into the aliased ones.
- This logic lives entirely in the Pi extension (`internal/agents/pi/extension/index.ts`) — no server-side/shared code changed, since the collision is specific to Pi's flat tool registry.
- Regenerated the golden extension snapshot (`cmd/gortex/testdata/agent-render/pi.txt`).

## Testing

- [x] All tests pass (`go test -race ./...`)
- [ ] New tests added for new functionality — covered by the existing golden-snapshot test (`TestAgentsRenderGolden`) for the embedded extension source; no separate unit test added
- [ ] Benchmarks run if performance-relevant — not applicable

## Checklist

- [x] Code follows existing patterns in the codebase
- [x] No unnecessary abstractions added
- [ ] Language extractor includes `Meta["methods"]` for interfaces (if applicable) — not applicable
- [ ] Methods have `EdgeMemberOf` edges to their containing type (if applicable) — not applicable
