### PR TITLE
fix(indexer): release tree-sitter parse trees on the incremental index paths

### DIFF
--- a/internal/indexer/file_delta.go
+++ b/internal/indexer/file_delta.go
@@ -101,6 +101,16 @@ func (idx *Indexer) prepareFileDelta(filePath string) (fileDeltaProbe, bool) {
 	if quarantine != nil && quarantine.Len() > 0 {
 		_ = quarantine.Save()
 	}
+	// Ownership of the result's tree-sitter tree — C memory the Go GC
+	// cannot reclaim — passes to idx.prepared only on the success path
+	// at the bottom. Every early return below drops the result on the
+	// floor, so release the tree unless it was stored.
+	stored := false
+	defer func() {
+		if !stored {
+			result.ReleaseTree()
+		}
+	}()
 	if result == nil || skipped || err != nil {
 		return probe, false
 	}
@@ -124,6 +134,10 @@ func (idx *Indexer) prepareFileDelta(filePath string) (fileDeltaProbe, bool) {
 	if idx.prepared == nil {
 		idx.prepared = make(map[string]*preparedExtraction)
 	}
+	// A second prepare for the same path before the first was consumed
+	// displaces the earlier entry; it owns a tree that nothing else can
+	// reach once the map slot is overwritten.
+	displaced := idx.prepared[absPath]
 	idx.prepared[absPath] = &preparedExtraction{
 		absPath:     absPath,
 		relPath:     relPath,
@@ -133,8 +147,21 @@ func (idx *Indexer) prepareFileDelta(filePath string) (fileDeltaProbe, bool) {
 		readVersion: readVersion,
 	}
 	idx.preparedMu.Unlock()
+	// Released outside the lock: Release closes the tree through cgo.
+	displaced.releaseTree()
+	stored = true
 	probe.readVersion = readVersion
 	return probe, true
+}
+
+// releaseTree drops the prepared extraction's parse tree. Nil-safe on
+// the entry and on the result, so a caller that took a map slot which
+// may or may not have been occupied can call it unconditionally.
+func (p *preparedExtraction) releaseTree() {
+	if p == nil {
+		return
+	}
+	p.result.ReleaseTree()
 }
 
 func (idx *Indexer) takePreparedExtraction(absPath, relPath, lang string, src []byte) (*parser.ExtractionResult, bool) {
@@ -143,6 +170,9 @@ func (idx *Indexer) takePreparedExtraction(absPath, relPath, lang string, src []
 	delete(idx.prepared, absPath)
 	idx.preparedMu.Unlock()
 	if prepared == nil || prepared.relPath != relPath || prepared.lang != lang || !bytes.Equal(prepared.src, src) {
+		// The entry is already out of the map and the caller gets
+		// nothing, so this is the last reference to its tree.
+		prepared.releaseTree()
 		return nil, false
 	}
 	return prepared.result, true
@@ -162,10 +192,14 @@ func (idx *Indexer) takePreparedRefresh(filePath string) (*preparedExtraction, b
 	}
 	current, readVersion, err := readFileWithVersion(absPath)
 	if err != nil {
+		prepared.releaseTree()
 		return nil, false
 	}
 	current = idx.transforms.run(prepared.relPath, current)
 	if !bytes.Equal(current, prepared.src) {
+		// The file moved on since the speculative parse; the entry is
+		// already out of the map, so drop its tree with it.
+		prepared.releaseTree()
 		return nil, false
 	}
 	prepared.readVersion = readVersion
@@ -178,8 +212,11 @@ func (idx *Indexer) discardPreparedExtraction(filePath string) {
 		return
 	}
 	idx.preparedMu.Lock()
+	discarded := idx.prepared[absPath]
 	delete(idx.prepared, absPath)
 	idx.preparedMu.Unlock()
+	// Released outside the lock: Release closes the tree through cgo.
+	discarded.releaseTree()
 }
 
 type fingerprintMode uint8
@@ -655,6 +692,11 @@ func (idx *Indexer) applyPreparedMetadataRefresh(filePath string, priorNodes []*
 		return nil, false, false
 	}
 	result := prepared.result
+	// takePreparedRefresh already removed the entry from idx.prepared,
+	// so this function owns the tree. Only Nodes/Edges are read from
+	// here on, and every shape-mismatch check below returns early —
+	// release on all of them.
+	defer result.ReleaseTree()
 	idx.applyRepoPrefix(result.Nodes, result.Edges)
 	graphPath := idx.prefixPath(prepared.relPath)
 

--- a/internal/indexer/incremental_batch.go
+++ b/internal/indexer/incremental_batch.go
@@ -142,6 +142,17 @@ func (idx *Indexer) reindexIncrementalChunk(
 	priorByFile := idx.graph.GetFileNodesByPaths(graphPaths)
 
 	stages := make([]*incrementalBatchStage, 0, len(files))
+	// Each staged result carries the tree-sitter tree its extraction
+	// produced — C memory the Go GC cannot reclaim. Nothing downstream
+	// of staging reads the tree (the commit works off Nodes/Edges), so
+	// release the batch's trees on every exit, committed or not.
+	defer func() {
+		for _, stage := range stages {
+			if stage != nil {
+				stage.result.ReleaseTree()
+			}
+		}
+	}()
 	fallbacks := make([]incrementalFallback, 0)
 	receipts := make([]fileReadReceipt, 0, len(files))
 	nodeCount, edgeCount := 0, 0

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -3208,8 +3208,11 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 					// Release the parse tree now that the per-file
 					// contract pass is done. Post-passes that need a
 					// tree for this file (cross-file handler resolution)
-					// re-parse on demand. Nil-safe.
-					result.Tree.Release()
+					// re-parse on demand. Nil-safe. Deliberately not a
+					// defer: this is a per-file loop body inside a
+					// long-lived worker goroutine, so a defer would pin
+					// every tree in the chunk until the worker exits.
+					result.ReleaseTree()
 					atomic.AddInt64(&fileCount, 1)
 				}
 				if len(localContracts) > 0 {
@@ -3882,6 +3885,12 @@ func (idx *Indexer) indexFile(
 			_ = quarantine.Save()
 		}
 	}
+	// The tree-sitter tree behind result.Tree is C memory the Go GC
+	// cannot reclaim, and this function has many early returns below.
+	// Release it on every exit path — nothing after this point reads
+	// the tree (the incremental contract pass parses its own), so the
+	// defer is the whole lifetime.
+	defer result.ReleaseTree()
 	if result == nil {
 		// No usable parse result (transient parse failure, quarantine,
 		// timeout). Do NOT evict — the file's prior nodes/edges/search
@@ -4258,6 +4267,11 @@ func (idx *Indexer) StructuralSymbols(filePath string) ([]*graph.Node, bool) {
 	if quarantine != nil && quarantine.Len() > 0 {
 		_ = quarantine.Save()
 	}
+	// This probe only ever reads result.Nodes, so the parse tree is
+	// dead the moment extraction returns. Release it on both exits —
+	// the inertness probe runs on every watcher event, so a retained
+	// tree here leaks C memory at save frequency.
+	defer result.ReleaseTree()
 	// A skipped (quarantined / timed-out) file produces only a
 	// synthetic node — not the real symbol set — so inertness cannot
 	// be proven and the caller must reindex normally.

--- a/internal/indexer/parse_tree_release_test.go
+++ b/internal/indexer/parse_tree_release_test.go
@@ -1,0 +1,186 @@
+package indexer
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+// The Go extractor is the only one that hands its tree-sitter tree back
+// on the ExtractionResult, and that tree is C memory the Go GC cannot
+// reclaim. Every incremental path that takes an extraction must release
+// it, or a long-lived daemon accumulates one leaked parse tree per
+// re-indexed Go file. These tests pin each of those paths.
+//
+// A released ParseTree reports a nil Tree(), which is the observable
+// stand-in for "the underlying C tree was freed".
+
+func newParseTreeReleaseIndexer(t *testing.T, dir string) *Indexer {
+	t.Helper()
+	registry := parser.NewRegistry()
+	registry.Register(languages.NewGoExtractor())
+	cfg := config.Default()
+	cfg.Index.Workers = 1
+	idx := New(graph.New(), registry, cfg.Index, zap.NewNop())
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+	return idx
+}
+
+// preparedTree returns the live ParseTree the prepared extraction for
+// path is holding, failing the test if there is not exactly one.
+func preparedTree(t *testing.T, idx *Indexer, path string) *parser.ParseTree {
+	t.Helper()
+	abs, err := filepath.Abs(path)
+	require.NoError(t, err)
+	idx.preparedMu.Lock()
+	defer idx.preparedMu.Unlock()
+	entry := idx.prepared[abs]
+	require.NotNil(t, entry, "expected a prepared extraction for %s", path)
+	require.NotNil(t, entry.result, "prepared extraction has no result")
+	require.NotNil(t, entry.result.Tree, "Go extraction should carry a parse tree")
+	require.NotNil(t, entry.result.Tree.Tree(), "parse tree should still be live")
+	return entry.result.Tree
+}
+
+func TestDiscardPreparedExtractionReleasesParseTree(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.go")
+	writeTestFile(t, path, "package main\n\nfunc Value() int { return 0 }\n")
+	idx := newParseTreeReleaseIndexer(t, dir)
+
+	writeTestFile(t, path, "package main\n\nfunc Value() int { return 1 }\n")
+	_, ok := idx.prepareFileDelta(path)
+	require.True(t, ok)
+	tree := preparedTree(t, idx, path)
+
+	idx.discardPreparedExtraction(path)
+	require.Nil(t, tree.Tree(), "discarding a prepared extraction must release its parse tree")
+}
+
+func TestPrepareFileDeltaReleasesDisplacedParseTree(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.go")
+	writeTestFile(t, path, "package main\n\nfunc Value() int { return 0 }\n")
+	idx := newParseTreeReleaseIndexer(t, dir)
+
+	writeTestFile(t, path, "package main\n\nfunc Value() int { return 1 }\n")
+	_, ok := idx.prepareFileDelta(path)
+	require.True(t, ok)
+	first := preparedTree(t, idx, path)
+
+	// A second prepare for the same path before the first is consumed
+	// overwrites the map slot; the displaced entry's tree is otherwise
+	// unreachable.
+	writeTestFile(t, path, "package main\n\nfunc Value() int { return 2 }\n")
+	_, ok = idx.prepareFileDelta(path)
+	require.True(t, ok)
+	second := preparedTree(t, idx, path)
+
+	require.NotSame(t, first, second)
+	require.Nil(t, first.Tree(), "displaced prepared extraction must release its parse tree")
+	require.NotNil(t, second.Tree(), "the current prepared extraction must keep its tree")
+
+	idx.discardPreparedExtraction(path)
+	require.Nil(t, second.Tree())
+}
+
+func TestTakePreparedExtractionReleasesParseTreeOnMismatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.go")
+	writeTestFile(t, path, "package main\n\nfunc Value() int { return 0 }\n")
+	idx := newParseTreeReleaseIndexer(t, dir)
+
+	writeTestFile(t, path, "package main\n\nfunc Value() int { return 1 }\n")
+	_, ok := idx.prepareFileDelta(path)
+	require.True(t, ok)
+	tree := preparedTree(t, idx, path)
+
+	abs, err := filepath.Abs(path)
+	require.NoError(t, err)
+	// Source bytes that don't match what was prepared: the entry is
+	// dropped rather than handed to the caller.
+	result, taken := idx.takePreparedExtraction(
+		abs, idx.relKey(abs), "go", []byte("package main\n\nfunc Other() {}\n"),
+	)
+	require.False(t, taken)
+	require.Nil(t, result)
+	require.Nil(t, tree.Tree(), "a rejected prepared extraction must release its parse tree")
+}
+
+func TestIndexFileReleasesPreparedParseTree(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.go")
+	writeTestFile(t, path, "package main\n\nfunc Value() int { return 0 }\n")
+	idx := newParseTreeReleaseIndexer(t, dir)
+
+	writeTestFile(t, path, "package main\n\nfunc Value() int { return 1 }\n")
+	_, ok := idx.prepareFileDelta(path)
+	require.True(t, ok)
+	tree := preparedTree(t, idx, path)
+
+	require.NoError(t, idx.indexFile(path, true))
+	require.Nil(t, tree.Tree(), "indexFile must release the parse tree it consumed")
+}
+
+func TestIndexFileReleasesParseTreeWithoutPrepare(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.go")
+	writeTestFile(t, path, "package main\n\nfunc Value() int { return 0 }\n")
+	idx := newParseTreeReleaseIndexer(t, dir)
+
+	// No prepare: indexFile extracts for itself, so it owns the tree.
+	// Observed indirectly — the prepared map must stay empty and the
+	// re-index must still succeed without retaining anything.
+	writeTestFile(t, path, "package main\n\nfunc Value() int { return 1 }\n")
+	require.NoError(t, idx.indexFile(path, true))
+
+	idx.preparedMu.Lock()
+	remaining := len(idx.prepared)
+	idx.preparedMu.Unlock()
+	require.Zero(t, remaining)
+}
+
+func TestApplyPreparedMetadataRefreshReleasesParseTree(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.go")
+	writeTestFile(t, path, "package main\n\nfunc Value() int { return 0 }\n")
+	idx := newParseTreeReleaseIndexer(t, dir)
+
+	// A comment-only edit keeps the node shape identical, which is the
+	// case the metadata-refresh fast path is built for.
+	writeTestFile(t, path, "package main\n\n// Value returns a number.\nfunc Value() int { return 0 }\n")
+	_, ok := idx.prepareFileDelta(path)
+	require.True(t, ok)
+	tree := preparedTree(t, idx, path)
+
+	prior := idx.graph.GetFileNodes(idx.graphRelKey(path))
+	idx.applyPreparedMetadataRefresh(path, prior)
+	require.Nil(t, tree.Tree(), "the metadata refresh must release the tree it took")
+}
+
+func TestStructuralSymbolsReleasesParseTree(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.go")
+	writeTestFile(t, path, "package main\n\nfunc Value() int { return 0 }\n")
+	idx := newParseTreeReleaseIndexer(t, dir)
+
+	// StructuralSymbols owns its extraction end to end, so the tree is
+	// unobservable from outside; assert it returns the symbols it
+	// promises and leaves nothing prepared behind.
+	syms, ok := idx.StructuralSymbols(path)
+	require.True(t, ok)
+	require.NotEmpty(t, syms)
+
+	idx.preparedMu.Lock()
+	remaining := len(idx.prepared)
+	idx.preparedMu.Unlock()
+	require.Zero(t, remaining)
+}

--- a/internal/parser/parsetree.go
+++ b/internal/parser/parsetree.go
@@ -92,6 +92,27 @@ func (pt *ParseTree) Close() {
 	pt.Release()
 }
 
+// ReleaseTree drops the result's reference to its parse tree, if it
+// holds one. Nil-safe on the result, on the handle, and on repeat
+// calls, so every path that consumes an ExtractionResult can
+// unconditionally `defer result.ReleaseTree()` right after extraction
+// without first knowing whether this language's extractor retains a
+// tree (only the Go extractor does today) or whether the extraction
+// even succeeded.
+//
+// Clearing the field before releasing is what makes the repeat call
+// safe: a second ReleaseTree must not decrement a count the caller no
+// longer owns, which would close the tree out from under a consumer
+// that legitimately holds its own Acquire'd reference.
+func (r *ExtractionResult) ReleaseTree() {
+	if r == nil || r.Tree == nil {
+		return
+	}
+	tree := r.Tree
+	r.Tree = nil
+	tree.Release()
+}
+
 // HasParseErrors reports whether the underlying tree contains any
 // ERROR or MISSING nodes. Returns false for a nil ParseTree so
 // language extractors that drop their tree (most non-Go languages)

--- a/internal/parser/parsetree_release_test.go
+++ b/internal/parser/parsetree_release_test.go
@@ -1,0 +1,55 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	gosrc "github.com/zzet/gortex/internal/parser/tsitter/golang"
+)
+
+func newTestParseTree(t *testing.T) *ParseTree {
+	t.Helper()
+	src := []byte("package main\n\nfunc Value() int { return 0 }\n")
+	tree, err := ParseFile(src, gosrc.GetLanguage())
+	require.NoError(t, err)
+	require.NotNil(t, tree)
+	return NewParseTree(tree, src, "go")
+}
+
+func TestExtractionResultReleaseTree(t *testing.T) {
+	pt := newTestParseTree(t)
+	result := &ExtractionResult{Tree: pt}
+	require.NotNil(t, pt.Tree())
+
+	result.ReleaseTree()
+	require.Nil(t, result.Tree, "ReleaseTree must clear the field")
+	require.Nil(t, pt.Tree(), "ReleaseTree must close the underlying tree")
+}
+
+// Callers defer ReleaseTree on paths that may also release explicitly,
+// so a repeat call must be a no-op rather than a second decrement — a
+// second decrement would close a tree another holder still owns.
+func TestExtractionResultReleaseTreeIsIdempotent(t *testing.T) {
+	pt := newTestParseTree(t)
+	// A consumer that retains the handle across calls.
+	pt.Acquire()
+	result := &ExtractionResult{Tree: pt}
+
+	result.ReleaseTree()
+	result.ReleaseTree()
+	result.ReleaseTree()
+
+	require.NotNil(t, pt.Tree(), "the retained Acquire must still hold the tree open")
+	pt.Release()
+	require.Nil(t, pt.Tree(), "the last Release must close the tree")
+}
+
+func TestExtractionResultReleaseTreeNilSafe(t *testing.T) {
+	var nilResult *ExtractionResult
+	require.NotPanics(t, func() { nilResult.ReleaseTree() })
+
+	// The common case: an extractor that never retains a tree.
+	empty := &ExtractionResult{}
+	require.NotPanics(t, func() { empty.ReleaseTree() })
+}


### PR DESCRIPTION
## Problem

A daemon that had been up ~3 days was holding a **6.99 GB physical footprint** while reporting `memory 3.1 GiB` in `gortex daemon status`. The gap is entirely in the **C heap**: 2.77 GB across 27.7M live allocations at 1% fragmentation, so retained rather than fragmented.

Those allocations are tree-sitter parse trees. tree-sitter sizes every node as `ts_subtree_alloc_size(child_count) = sizeof(SubtreeHeapData) + child_count*sizeof(Subtree)` = `80 + 8n` bytes; rounded to the allocator's 16-byte granularity that predicts buckets 80/96/112/128/160/192/256, and every populated bucket in the process heap histogram was a member of that family — 2.76 of the 2.77 GB.

`golang.go` is the only extractor that hands its tree back on `ExtractionResult.Tree`, and `ParseTree` carries no finalizer. Of the four `extractFile` consumers, only the bulk walk released it. Everything incremental dropped the result on the floor, so each Go file re-indexed after a save leaked ~1 MB of C memory permanently. The full index was clean, which is why this only shows up on a long-lived daemon.

Measured on the affected process: touching 3 Go files added **31,051 allocations / 3.13 MB**, still elevated 45 s later. Touching 4 non-Go files added 32 allocations / 10 KB — a 416x per-file difference, matching the static finding that only the Go extractor retains a tree.

## Fix

`ExtractionResult.ReleaseTree()` — nil-safe on the result, the handle, and repeat calls — so any consumer can `defer result.ReleaseTree()` right after extraction without knowing whether that language retains a tree or whether extraction succeeded. It clears the field before releasing so a repeat call can't decrement a count the caller no longer owns.

Release added on every path that ends an extraction's life:

| Path | Leak |
|---|---|
| `indexFile` | consumed a prepared or fresh extraction, never released |
| `StructuralSymbols` | inertness probe, reads only `result.Nodes` |
| `prepareFileDelta` | early return on skip/failure and on fingerprint miss |
| `prepareFileDelta` | a second prepare displaced the first map entry |
| `takePreparedExtraction` | entry dropped when the guard rejected it |
| `takePreparedRefresh` | entry dropped when the file changed underneath |
| `discardPreparedExtraction` | the explicit discard path deleted the slot and nothing else |
| `applyPreparedMetadataRefresh` | took the entry, returned early on each shape-mismatch check |
| `reindexIncrementalChunk` | staged results never released after commit |

Nothing downstream of these reads the tree — the incremental contract pass parses its own, and the staged commit works off `Nodes`/`Edges`. Displaced and discarded entries are released outside `preparedMu` because `Release` closes through cgo. The bulk-walk site stays a plain statement rather than a defer: it is a per-file loop body inside a long-lived worker goroutine, where a defer would pin every tree in the chunk until the worker exits.

I audited the other nine `ParseTree` producers (`ParseTreeForLang` / `buildClientLibTree` callers) — all of them already release correctly, so no changes there.

## Deliberately not included

An auto-closing finalizer on `ParseTree` would be the obvious backstop, but it is unsafe here: `Tree()`, `Inner()`, and `RootNode()` hand out raw `*sitter.Tree` / `*sitter.Node` pointers into the tree, and the GC can collect the handle while a walk is still holding them. That turns a leak into a use-after-free. Explicit release at each ownership boundary is the correct shape.

## Verification

- `go build ./...`, `go vet`, `golangci-lint` — clean (0 issues)
- `go test -race ./internal/indexer/ ./internal/parser/... ./internal/contracts/` — all pass (indexer suite 123 s under `-race`)
- **Negative control:** with the new tests in place and only the call-site changes reverted, 5 of the 7 regression tests fail. The 2 that still pass cover paths that own their extraction end to end and cannot observe the tree from outside; they assert the weaker property that nothing is left parked in the prepared map.

To reproduce the original measurement on a running daemon: `heap <pid>` before and after touching a Go file in a tracked repo, and compare against a non-Go file.

## Note

`gortex daemon status` reports Go `alloc` only, so it under-reported this process by 2.25x and would not show the leak at all. Worth surfacing the C-heap side separately; out of scope here.