### PR TITLE
fix(init): refuse to index the filesystem root or $HOME

### DIFF
--- a/cmd/gortex/init.go
+++ b/cmd/gortex/init.go
@@ -108,7 +108,7 @@ func init() {
 	initCmd.Flags().BoolVar(&initJSON, "json", false, "emit a structured JSON report on stdout")
 	initCmd.Flags().BoolVar(&initDryRun, "dry-run", false, "plan writes without modifying disk")
 	initCmd.Flags().BoolVar(&initDryRunIntake, "dry-run-intake", false, "emit a privacy-safe corpus intake manifest and exit before parsing or writing")
-	initCmd.Flags().BoolVar(&initForce, "force", false, "overwrite keys we would otherwise preserve during a merge")
+	initCmd.Flags().BoolVar(&initForce, "force", false, "overwrite keys we would otherwise preserve during a merge; also bypasses the filesystem-root/home-directory safety check")
 
 	rootCmd.AddCommand(initCmd)
 }
@@ -147,6 +147,16 @@ func runInit(cmd *cobra.Command, args []string) (err error) {
 		root = args[0]
 	}
 
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return err
+	}
+	if !initForce {
+		if reason := indexer.UnsafeIndexRootReason(absRoot); reason != "" {
+			return fmt.Errorf("%s; pass --force to init it anyway", reason)
+		}
+	}
+
 	if initNoHooks {
 		initInstallHooks = false
 	}
@@ -183,10 +193,6 @@ func runInit(cmd *cobra.Command, args []string) (err error) {
 		}
 	}
 
-	absRoot, err := filepath.Abs(root)
-	if err != nil {
-		return err
-	}
 	if initDryRunIntake {
 		return emitInitDryRunIntake(cmd, absRoot)
 	}

--- a/cmd/gortex/init_integration_test.go
+++ b/cmd/gortex/init_integration_test.go
@@ -229,6 +229,84 @@ func TestInitDryRunSkipsProjectMarker(t *testing.T) {
 	}
 }
 
+// TestInitRefusesHomeDirectory pins the safety guard in runInit:
+// pointing gortex init directly at $HOME must be refused before any
+// indexing or file writes happen, since that would crawl every
+// project and dotfile under it.
+func TestInitRefusesHomeDirectory(t *testing.T) {
+	saved := struct {
+		yes, dryRun, json, force bool
+		agents                   string
+	}{initYes, initDryRun, initJSON, initForce, initAgents}
+	t.Cleanup(func() {
+		initYes, initDryRun, initJSON, initForce = saved.yes, saved.dryRun, saved.json, saved.force
+		initAgents = saved.agents
+	})
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	initYes = true
+	initDryRun = false
+	initJSON = false
+	initForce = false
+	initAgents = "claude-code"
+
+	var stdout, stderr bytes.Buffer
+	initCmd.SetOut(&stdout)
+	initCmd.SetErr(&stderr)
+	t.Cleanup(func() {
+		initCmd.SetOut(nil)
+		initCmd.SetErr(nil)
+	})
+
+	err := runInit(initCmd, []string{home})
+	if err == nil {
+		t.Fatal("expected runInit to refuse indexing $HOME, got nil error")
+	}
+	if !strings.Contains(err.Error(), "home directory") || !strings.Contains(err.Error(), "--force") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+
+	if _, statErr := os.Stat(filepath.Join(home, ".gortex")); statErr == nil {
+		t.Fatal("refused init still wrote .gortex/ into $HOME")
+	}
+}
+
+// TestInitForceBypassesHomeDirectoryGuard confirms --force is the
+// documented escape hatch for the guard above.
+func TestInitForceBypassesHomeDirectoryGuard(t *testing.T) {
+	saved := struct {
+		yes, dryRun, json, force bool
+		agents                   string
+	}{initYes, initDryRun, initJSON, initForce, initAgents}
+	t.Cleanup(func() {
+		initYes, initDryRun, initJSON, initForce = saved.yes, saved.dryRun, saved.json, saved.force
+		initAgents = saved.agents
+	})
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	initYes = true
+	initDryRun = true // planning-only: keeps the forced run from writing into $HOME during the test
+	initJSON = false
+	initForce = true
+	initAgents = "claude-code"
+
+	var stdout, stderr bytes.Buffer
+	initCmd.SetOut(&stdout)
+	initCmd.SetErr(&stderr)
+	t.Cleanup(func() {
+		initCmd.SetOut(nil)
+		initCmd.SetErr(nil)
+	})
+
+	if err := runInit(initCmd, []string{home}); err != nil {
+		t.Fatalf("runInit with --force: %v\nstderr: %s", err, stderr.String())
+	}
+}
+
 func TestInitHooksOnlyRefreshesClaudeAndCodexHooks(t *testing.T) {
 	restore := saveInitGlobals(t)
 	defer restore()


### PR DESCRIPTION
## Summary

`gortex init` had no guard against being pointed at a dangerous root — running it against `$HOME` (or `/`) walks the entire tree by default, since `--skills` defaults to on. `gortex track` already refused these paths via `indexer.UnsafeIndexRootReason`; `init` never called it. This wires the same guard into `init`, checked before the wizard, any indexing, or any file writes.

## Changes

- `cmd/gortex/init.go`: `runInit` now resolves `absRoot` immediately after parsing the `[path]` arg and, unless `--force` is set, calls `indexer.UnsafeIndexRootReason(absRoot)` before doing anything else (wizard, indexing, or writes). Refuses with the reason plus `; pass --force to init it anyway` when the target is the filesystem root, a Windows drive root, or exactly `$HOME`. Removed the now-redundant later `filepath.Abs(root)` recomputation. Updated the `--force` flag help text to mention the new bypass.
- `cmd/gortex/init_integration_test.go`: added `TestInitRefusesHomeDirectory` (asserts the refusal, its error message, and that no `.gortex/` marker is written) and `TestInitForceBypassesHomeDirectoryGuard` (asserts `--force` still proceeds).

## Testing

- [x] New tests added for new functionality (`TestInitRefusesHomeDirectory`, `TestInitForceBypassesHomeDirectoryGuard`)
- [x] `go test ./cmd/gortex/... -run TestInit` — all init/init-wizard tests pass
- [x] `go build ./cmd/gortex/...`
- [x] Manually verified with a built binary: `gortex init "$HOME" --yes` refuses with the home-directory message; `gortex init "$HOME" --yes --force` proceeds
- [ ] Full `go test -race ./...` not run (scoped to the touched package; happy to run the full suite before merge if wanted)
- [ ] Benchmarks — not performance-relevant

## Checklist

- [x] Code follows existing patterns in the codebase (mirrors the `unsafeRootBlocked`/`pass force to track it anyway` convention already used by `gortex track`)
- [x] No unnecessary abstractions added
- [ ] Language extractor includes `Meta["methods"]` for interfaces (not applicable)
- [ ] Methods have `EdgeMemberOf` edges to their containing type (not applicable)