### PR TITLE
fix(goanalysis): run go/packages in the module's own directory

### DIFF
--- a/internal/semantic/goanalysis/module_gate.go
+++ b/internal/semantic/goanalysis/module_gate.go
@@ -33,24 +33,63 @@ var moduleProbeSkippedDirs = map[string]struct{}{
 // falls back to a GOPATH-mode scan of the entire repository, which on a
 // non-Go tree costs minutes and yields nothing.
 func goModulePresent(root string) bool {
+	return len(goModuleRoots(root)) > 0
+}
+
+// goModuleRoots returns every directory — root itself, or one at most two
+// levels below it — that carries a go.mod or go.work, shallowest first and
+// otherwise in directory order.
+//
+// goModulePresent only answers whether a manifest is in reach. Returning the
+// locations is what lets the caller run go/packages in the directory that
+// actually owns the module. A repository whose Go code lives in a
+// subdirectory (services/foo, backend/, src/go/) is a healthy module; only
+// "./..." evaluated from the repository root is meaningless for it, and that
+// is an argument about where to run, not about whether the module resolves.
+//
+// The walk shares moduleProbeBudget with the boolean form, so the cost stays
+// bounded on a pathological tree.
+func goModuleRoots(root string) []string {
+	var roots []string
 	if hasGoManifest(root) {
-		return true
+		roots = append(roots, root)
 	}
 	budget := moduleProbeBudget
 	level1 := listProbeSubdirs(root, &budget)
 	for _, dir := range level1 {
 		if hasGoManifest(dir) {
-			return true
+			roots = append(roots, dir)
 		}
 	}
 	for _, dir := range level1 {
 		for _, sub := range listProbeSubdirs(dir, &budget) {
 			if hasGoManifest(sub) {
-				return true
+				roots = append(roots, sub)
 			}
 		}
 	}
-	return false
+	return roots
+}
+
+// goLoadDir reports the directory go/packages must run in for root, and how
+// many module roots were found.
+//
+// A manifest at the repository root keeps the historical behaviour exactly.
+// Otherwise the single module below the root is the only directory in which
+// "./..." names that module's packages. When several modules sit below the
+// root and none is at it there is no single correct directory, so the caller
+// degrades — as it already did, but now for a reason that names the shape
+// instead of reporting the module as unloadable.
+func goLoadDir(root string) (dir string, moduleRoots int) {
+	roots := goModuleRoots(root)
+	switch {
+	case len(roots) == 0:
+		return root, 0
+	case hasGoManifest(root), len(roots) == 1:
+		return roots[0], len(roots)
+	default:
+		return root, len(roots)
+	}
 }
 
 func hasGoManifest(dir string) bool {

--- a/internal/semantic/goanalysis/module_gate_test.go
+++ b/internal/semantic/goanalysis/module_gate_test.go
@@ -153,3 +153,105 @@ func TestProbeGoPackagesLoadableHonorsInjectedLoader(t *testing.T) {
 		t.Fatalf("all-errored load must not be loadable: loadable=%v real=%d errored=%d", loadable, real, errored)
 	}
 }
+
+func writeGoModule(t *testing.T, dir, path string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"),
+		[]byte("module "+path+"\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.go"),
+		[]byte("package main\n\nfunc main() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGoModuleRoots(t *testing.T) {
+	t.Run("no manifest", func(t *testing.T) {
+		if roots := goModuleRoots(t.TempDir()); len(roots) != 0 {
+			t.Fatalf("want no roots, got %v", roots)
+		}
+	})
+	t.Run("root manifest is first", func(t *testing.T) {
+		root := t.TempDir()
+		writeProbeFile(t, filepath.Join(root, "go.mod"))
+		writeProbeFile(t, filepath.Join(root, "services", "api", "go.mod"))
+		roots := goModuleRoots(root)
+		if len(roots) != 2 || roots[0] != root {
+			t.Fatalf("root manifest must sort first, got %v", roots)
+		}
+	})
+	t.Run("depth-two module is located, not just detected", func(t *testing.T) {
+		root := t.TempDir()
+		want := filepath.Join(root, "services", "domain-core")
+		writeProbeFile(t, filepath.Join(want, "go.mod"))
+		roots := goModuleRoots(root)
+		if len(roots) != 1 || roots[0] != want {
+			t.Fatalf("want [%s], got %v", want, roots)
+		}
+	})
+}
+
+func TestGoLoadDir(t *testing.T) {
+	t.Run("root manifest keeps the root", func(t *testing.T) {
+		root := t.TempDir()
+		writeProbeFile(t, filepath.Join(root, "go.mod"))
+		writeProbeFile(t, filepath.Join(root, "tools", "go.mod"))
+		dir, n := goLoadDir(root)
+		if dir != root || n != 2 {
+			t.Fatalf("want root dir with 2 roots, got dir=%s n=%d", dir, n)
+		}
+	})
+	t.Run("single nested module becomes the load dir", func(t *testing.T) {
+		root := t.TempDir()
+		want := filepath.Join(root, "backend")
+		writeProbeFile(t, filepath.Join(want, "go.mod"))
+		dir, n := goLoadDir(root)
+		if dir != want || n != 1 {
+			t.Fatalf("want %s with 1 root, got dir=%s n=%d", want, dir, n)
+		}
+	})
+	t.Run("several nested modules stay ambiguous", func(t *testing.T) {
+		root := t.TempDir()
+		writeProbeFile(t, filepath.Join(root, "a", "go.mod"))
+		writeProbeFile(t, filepath.Join(root, "b", "go.mod"))
+		dir, n := goLoadDir(root)
+		if dir != root || n != 2 {
+			t.Fatalf("ambiguous layout must not pick one: dir=%s n=%d", dir, n)
+		}
+	})
+	t.Run("no module reports zero", func(t *testing.T) {
+		root := t.TempDir()
+		if dir, n := goLoadDir(root); dir != root || n != 0 {
+			t.Fatalf("want root/0, got dir=%s n=%d", dir, n)
+		}
+	})
+}
+
+func TestProbeGoPackagesLoadableSubdirModuleLoadsAtItsOwnDir(t *testing.T) {
+	// Same fixture as TestProbeGoPackagesLoadableSubdirModuleRootFailsClosed:
+	// the module lives under backend/. Probed at the ROOT it fails closed,
+	// which is correct — `./...` there is out-of-module. Probed at the
+	// directory that owns the module it loads cleanly, which is the point:
+	// the module is healthy, only the directory was wrong.
+	root := t.TempDir()
+	backend := filepath.Join(root, "backend")
+	writeGoModule(t, backend, "example.com/backend")
+
+	p := &Provider{}
+	if loadable, real, _ := p.probeGoPackagesLoadable(context.Background(), root); loadable || real != 0 {
+		t.Fatalf("root probe must still fail closed: loadable=%v real=%d", loadable, real)
+	}
+
+	dir, n := goLoadDir(root)
+	if dir != backend || n != 1 {
+		t.Fatalf("goLoadDir must select the module dir: dir=%s n=%d", dir, n)
+	}
+	loadable, real, errored := p.probeGoPackagesLoadable(context.Background(), dir)
+	if !loadable || real < 1 {
+		t.Fatalf("module dir must load cleanly: loadable=%v real=%d errored=%d", loadable, real, errored)
+	}
+}

--- a/internal/semantic/goanalysis/provider.go
+++ b/internal/semantic/goanalysis/provider.go
@@ -307,12 +307,27 @@ func (p *Provider) enrichRepoContext(ctx context.Context, g graph.Store, repoPre
 	// whole (possibly non-Go) repository — measured minutes on a Rust tree —
 	// and the pass would additionally hold the serialized gate for that whole
 	// time, stalling every genuine Go repo queued behind it.
-	if !goModulePresent(absRoot) {
+	loadDir, moduleRoots := goLoadDir(absRoot)
+	if moduleRoots == 0 {
 		return &semantic.EnrichResult{
 			Provider:       p.Name(),
 			Language:       "go",
 			Degraded:       true,
 			DegradedReason: "no go.mod/go.work within two directory levels; go/packages not attempted",
+		}, nil
+	}
+	// Several modules below the root and none at it: there is no single
+	// directory in which "./..." names all of them, so this pass has nothing
+	// correct to load. Report the shape rather than letting the loadability
+	// probe below call the modules unloadable, which they are not.
+	if loadDir == absRoot && !hasGoManifest(absRoot) {
+		return &semantic.EnrichResult{
+			Provider: p.Name(),
+			Language: "go",
+			Degraded: true,
+			DegradedReason: fmt.Sprintf(
+				"%d Go modules below the repository root and none at it; go/packages needs a single module directory",
+				moduleRoots),
 		}, nil
 	}
 
@@ -328,11 +343,12 @@ func (p *Provider) enrichRepoContext(ctx context.Context, g graph.Store, repoPre
 	// normally and paying a second metadata enumeration on every healthy repo
 	// is a measured per-repo tax with no yield.
 	if !hasGoManifest(absRoot) {
-		if loadable, realPkgs, erroredPkgs := p.probeGoPackagesLoadable(ctx, absRoot); !loadable {
+		if loadable, realPkgs, erroredPkgs := p.probeGoPackagesLoadable(ctx, loadDir); !loadable {
 			if p.logger != nil {
 				p.logger.Info("go-types: skipping unloadable module before heavy load",
 					zap.String("repo_prefix", repoPrefix),
 					zap.String("root", absRoot),
+					zap.String("module_dir", loadDir),
 					zap.Int("real_packages", realPkgs),
 					zap.Int("errored_packages", erroredPkgs))
 			}
@@ -354,7 +370,7 @@ func (p *Provider) enrichRepoContext(ctx context.Context, g graph.Store, repoPre
 	if !goTypesNeedDepsClosure() {
 		depIndexStart := time.Now()
 		var depErr error
-		depIndex, depErr = p.loadDepModuleIndex(ctx, absRoot)
+		depIndex, depErr = p.loadDepModuleIndex(ctx, loadDir)
 		if depErr != nil && p.logger != nil {
 			p.logger.Warn("go-types: dependency metadata index failed; external classification degraded for this pass",
 				zap.String("repo_prefix", repoPrefix),
@@ -389,9 +405,12 @@ func (p *Provider) enrichRepoContext(ctx context.Context, g graph.Store, repoPre
 	if p.logger != nil {
 		p.logger.Info("go-types: package load starting",
 			zap.String("repo_prefix", repoPrefix),
-			zap.String("root", absRoot))
+			zap.String("root", absRoot),
+			zap.String("module_dir", loadDir))
 	}
-	pkgs, fset, err := p.loadPackagesContext(ctx, absRoot, "./...")
+	// absRoot stays the relativization base for every graph path below; only
+	// the directory go/packages runs in follows the module.
+	pkgs, fset, err := p.loadPackagesContext(ctx, loadDir, "./...")
 	if err != nil {
 		return nil, fmt.Errorf("load packages: %w", err)
 	}
@@ -919,7 +938,12 @@ func (p *Provider) EnrichFilesContext(ctx context.Context, g graph.Store, repoPr
 		}
 		patterns = append(patterns, "file="+filepath.Join(absRoot, filepath.FromSlash(relPath)))
 	}
-	pkgs, fset, err := p.loadPackagesContext(ctx, absRoot, patterns...)
+	// The file= patterns are absolute, but Dir still selects the module whose
+	// build list resolves them: a repository whose module lives in a
+	// subdirectory resolves nothing from the root. absRoot remains the
+	// relativization base for graph paths.
+	fileLoadDir, _ := goLoadDir(absRoot)
+	pkgs, fset, err := p.loadPackagesContext(ctx, fileLoadDir, patterns...)
 	if err != nil {
 		return nil, fmt.Errorf("load packages for %d files: %w", len(requestedFiles), err)
 	}


### PR DESCRIPTION
## The bug

A repository whose Go module lives in a subdirectory gets **no type enrichment at all, silently**.

`goModulePresent` admits it — the two-level walk finds the manifest — but every `go/packages` call then runs with `Dir` set to the repository root, where `./...` is out-of-module. `probeGoPackagesLoadable` sees a clean load failure and returns `loadable=false`, so the full typecheck is skipped with `"go/packages loadability probe found no cleanly-loading packages"`.

The probe is right that `./...` from the root resolves nothing. It is wrong to conclude the module is doomed — the module is healthy, and the only problem is which directory `go/packages` runs in.

## Measured

On a monorepo whose module sits at `services/domain-core`:

```
$ go list ./...                       # from repo root — what the probe does
pattern ./...: directory prefix . does not contain main module or its selected dependencies

$ cd services/domain-core && go list ./... | wc -l
90
```

And through the provider itself:

```
goLoadDir         -> dir=<repo>/services/domain-core  moduleRoots=1
probe(repo root)     loadable=false  packages=0
probe(module dir)    loadable=true   packages=90
```

What the index reports for that repo today:

```
health_score: 100
semantic_enrichment_ok: true
lsp_resolved_edges_by_language:  go: 0   python: 0   typescript: 0
go-types: degraded — "go/packages loadability probe found no cleanly-loading packages"
          coverage_percent: 0   symbols_total: 0   edges_added: 0
```

Every Go edge comes from the AST pass, and nothing in the health signal says the type layer never ran. That combination — `health_score: 100` next to zero resolved edges — is what makes this expensive to notice.

## The change

Teach the gate to report *where* the module is, not just that one exists.

- **`goModuleRoots`** returns the manifest directories from the existing two-level walk, sharing `moduleProbeBudget` so the cost is unchanged. `goModulePresent` becomes its boolean form.
- **`goLoadDir`** picks the directory `go/packages` must run in: the repository root when it carries a manifest — historical behaviour, byte for byte — otherwise the single module below it.
- The probe, `loadDepModuleIndex` and both `loadPackagesContext` call sites use that directory.
- **`absRoot` stays the relativization base for every graph path**, so node identities are unaffected. Only the `Dir` handed to `go/packages` follows the module.
- Several modules below the root with none at it stays degraded — there genuinely is no single correct directory — but the reason now names the shape instead of calling the modules unloadable.

## Tests

- `TestGoModuleRoots` — the walk locates the module rather than only detecting it; a root manifest sorts first.
- `TestGoLoadDir` — each branch: root manifest, single nested module, several nested modules, none.
- `TestProbeGoPackagesLoadableSubdirModuleLoadsAtItsOwnDir` — the fixture from `TestProbeGoPackagesLoadableSubdirModuleRootFailsClosed`, probed at both directories: still fails closed at the root, loads cleanly at the module directory.

`TestProbeGoPackagesLoadableSubdirModuleRootFailsClosed` is **unchanged and still passes** — the probe's own contract did not move, only the caller's choice of directory.

`go build`, `go vet` and the full `./internal/semantic/goanalysis/` suite pass.

## Separate, not fixed here

When this provider degrades, the surfaced recommendation asks for `compile_commands.json` via `cmake`/`bear`/`meson`. That is C/C++ advice and cannot help a Go repository. Happy to send it as its own PR if you'd like it changed.
