### PR TITLE
fix(mcp): let the analysis generation pass the store's validation

### DIFF
--- a/internal/mcp/analysis_generation.go
+++ b/internal/mcp/analysis_generation.go
@@ -33,6 +33,7 @@ type analysisGenerationInput struct {
 	adjacency      analysis.AdjacencyPersistenceSnapshot
 	communities    []graph.AnalysisCommunitySummary
 	processes      []graph.AnalysisProcessSummary
+	processSteps   map[string][]graph.AnalysisProcessStep
 	concepts       []graph.AnalysisConcept
 	conceptRelated map[string][]string
 }
@@ -66,6 +67,35 @@ func normalizePersistedAnalysis(candidate *persistedAnalysis) {
 	}
 }
 
+// sanitizeAnalysisFiles drops empty and duplicate paths from a community /
+// process file list and returns it sorted.
+//
+// Communities and processes are keyed on nodes, and a node need not have a
+// file: synthetic, external, and stub nodes carry an empty FilePath, and two
+// nodes routinely share one. The store validates these lists as non-empty and
+// unique and rejects the entire generation on the first violation, so an
+// unfiltered list makes every analysis save fail — which silently costs both
+// the warm-start cache and the header-only residency the save enables.
+func sanitizeAnalysisFiles(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	seen := make(map[string]struct{}, len(in))
+	for _, file := range in {
+		if file == "" {
+			continue
+		}
+		if _, duplicate := seen[file]; duplicate {
+			continue
+		}
+		seen[file] = struct{}{}
+		out = append(out, file)
+	}
+	sort.Strings(out)
+	return out
+}
+
 func prepareAnalysisGeneration(candidate persistedAnalysis, revision uint64) (analysisGenerationInput, error) {
 	normalizePersistedAnalysis(&candidate)
 	if candidate.communities == nil || candidate.leiden == nil || candidate.processes == nil ||
@@ -76,8 +106,7 @@ func prepareAnalysisGeneration(candidate persistedAnalysis, revision uint64) (an
 	adjacency := candidate.adjacency.PersistenceSnapshot()
 	communities := make([]graph.AnalysisCommunitySummary, 0, len(candidate.communities.Communities))
 	for _, community := range candidate.communities.Communities {
-		files := append([]string(nil), community.Files...)
-		sort.Strings(files)
+		files := sanitizeAnalysisFiles(community.Files)
 		communities = append(communities, graph.AnalysisCommunitySummary{
 			ID: community.ID, Label: community.Label, Hub: community.Hub, ParentID: community.ParentID,
 			Size: community.Size, Cohesion: community.Cohesion, Files: files,
@@ -85,13 +114,35 @@ func prepareAnalysisGeneration(candidate persistedAnalysis, revision uint64) (an
 	}
 	sort.Slice(communities, func(i, j int) bool { return communities[i].ID < communities[j].ID })
 
+	// A process step can point at a node this generation does not carry:
+	// BuildAdjacencySnapshot deliberately skips unresolved and dangling
+	// endpoints to keep its dense index consistent, so analysis_nodes has no
+	// row for them while DiscoverProcesses still walks them. The step insert
+	// resolves node_rowid through analysis_nodes and rejects the generation
+	// when it finds none. Drop those steps here, renumber the survivors so
+	// ordinals stay contiguous, and report the surviving count as StepCount —
+	// the store validates step_count against the persisted step rows.
+	generationNodes := make(map[string]struct{}, len(adjacency.IDs))
+	for _, nodeID := range adjacency.IDs {
+		generationNodes[nodeID] = struct{}{}
+	}
+	processSteps := make(map[string][]graph.AnalysisProcessStep, len(candidate.processes.Processes))
 	processes := make([]graph.AnalysisProcessSummary, 0, len(candidate.processes.Processes))
 	for _, process := range candidate.processes.Processes {
-		files := append([]string(nil), process.Files...)
-		sort.Strings(files)
+		files := sanitizeAnalysisFiles(process.Files)
+		steps := make([]graph.AnalysisProcessStep, 0, len(process.Steps))
+		for _, step := range process.Steps {
+			if _, known := generationNodes[step.ID]; !known {
+				continue
+			}
+			steps = append(steps, graph.AnalysisProcessStep{
+				ProcessID: process.ID, NodeID: step.ID, Ordinal: len(steps), Depth: step.Depth,
+			})
+		}
+		processSteps[process.ID] = steps
 		processes = append(processes, graph.AnalysisProcessSummary{
 			ID: process.ID, Name: process.Name, EntryPoint: process.EntryPoint,
-			StepCount: process.StepCount, Score: process.Score, Truncated: process.Truncated, Files: files,
+			StepCount: len(steps), Score: process.Score, Truncated: process.Truncated, Files: files,
 		})
 	}
 	sort.Slice(processes, func(i, j int) bool { return processes[i].ID < processes[j].ID })
@@ -133,7 +184,7 @@ func prepareAnalysisGeneration(candidate persistedAnalysis, revision uint64) (an
 			ProcessesTruncated:        candidate.processes.Truncated,
 			ProcessesTruncationReason: candidate.processes.TruncationReason,
 		},
-		adjacency: adjacency, communities: communities, processes: processes,
+		adjacency: adjacency, communities: communities, processes: processes, processSteps: processSteps,
 		concepts: concepts, conceptRelated: conceptSnapshot.Related,
 	}, nil
 }
@@ -197,16 +248,11 @@ func persistAnalysisGeneration(
 			return graph.AnalysisGenerationHeader{}, accepted, err
 		}
 	}
-	for _, process := range candidate.processes.Processes {
-		for start := 0; start < len(process.Steps); start += analysisGenerationWriteChunk {
-			end := min(start+analysisGenerationWriteChunk, len(process.Steps))
-			steps := make([]graph.AnalysisProcessStep, 0, end-start)
-			for ordinal, step := range process.Steps[start:end] {
-				steps = append(steps, graph.AnalysisProcessStep{
-					ProcessID: process.ID, NodeID: step.ID, Ordinal: start + ordinal, Depth: step.Depth,
-				})
-			}
-			accepted, err = writer.AppendAnalysisProcesses(expectedRevision, generationID, nil, steps)
+	for _, process := range input.processes {
+		steps := input.processSteps[process.ID]
+		for start := 0; start < len(steps); start += analysisGenerationWriteChunk {
+			end := min(start+analysisGenerationWriteChunk, len(steps))
+			accepted, err = writer.AppendAnalysisProcesses(expectedRevision, generationID, nil, steps[start:end])
 			if err != nil || !accepted {
 				return graph.AnalysisGenerationHeader{}, accepted, err
 			}

--- a/internal/mcp/analysis_generation_validation_test.go
+++ b/internal/mcp/analysis_generation_validation_test.go
@@ -1,0 +1,120 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/analysis"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/search"
+)
+
+// The store validates a generation as it writes it and rejects the whole
+// thing on the first violation — a rejection that only ever surfaced as a
+// warn, leaving the daemon to fall back to holding the analysis in memory
+// and recomputing it on every restart. These tests pin the three producer
+// invariants the store enforces.
+
+func testAnalysisCandidate(t *testing.T) persistedAnalysis {
+	t.Helper()
+	g := graph.New()
+	nodes := []*graph.Node{
+		{ID: "pkg/a.go::Alpha", Kind: graph.KindFunction, Name: "Alpha", FilePath: "pkg/a.go", Language: "go"},
+		{ID: "pkg/b.go::Beta", Kind: graph.KindFunction, Name: "Beta", FilePath: "pkg/b.go", Language: "go"},
+		{ID: "pkg/c.go::Gamma", Kind: graph.KindFunction, Name: "Gamma", FilePath: "pkg/c.go", Language: "go"},
+	}
+	edges := []*graph.Edge{
+		{From: "pkg/a.go::Alpha", To: "pkg/b.go::Beta", Kind: graph.EdgeCalls},
+		{From: "pkg/b.go::Beta", To: "pkg/c.go::Gamma", Kind: graph.EdgeCalls},
+	}
+	g.AddBatch(nodes, edges)
+
+	communities, leiden, _ := analysis.DetectCommunitiesLeidenIncremental(g, nil)
+	candidate := persistedAnalysis{
+		communities:  communities,
+		leiden:       leiden,
+		processes:    analysis.DiscoverProcesses(g),
+		pageRank:     analysis.ComputePageRank(g),
+		adjacency:    analysis.BuildAdjacencySnapshot(g),
+		autoConcepts: search.BuildAutoConcepts(g),
+		hits:         analysis.ComputeHITS(g),
+	}
+	require.NotNil(t, candidate.communities)
+	require.NotNil(t, candidate.adjacency)
+	require.NotEmpty(t, candidate.communities.Communities, "need at least one community to mutate")
+	return candidate
+}
+
+func TestSanitizeAnalysisFiles(t *testing.T) {
+	// Nodes without a file (synthetic / external / stub) contribute an
+	// empty path, and two nodes routinely share one file.
+	got := sanitizeAnalysisFiles([]string{"z.go", "", "a.go", "z.go", ""})
+	require.Equal(t, []string{"a.go", "z.go"}, got)
+
+	require.Nil(t, sanitizeAnalysisFiles(nil))
+	require.Nil(t, sanitizeAnalysisFiles([]string{}))
+	require.Empty(t, sanitizeAnalysisFiles([]string{"", ""}), "an all-empty list must not yield an empty-string row")
+}
+
+func TestPrepareAnalysisGenerationDropsEmptyAndDuplicateCommunityFiles(t *testing.T) {
+	candidate := testAnalysisCandidate(t)
+	candidate.communities.Communities[0].Files = []string{"pkg/a.go", "", "pkg/a.go"}
+
+	input, err := prepareAnalysisGeneration(candidate, 1)
+	require.NoError(t, err)
+
+	for _, community := range input.communities {
+		for _, file := range community.Files {
+			require.NotEmpty(t, file, "community %q kept an empty file path", community.ID)
+		}
+		seen := map[string]struct{}{}
+		for _, file := range community.Files {
+			_, dup := seen[file]
+			require.False(t, dup, "community %q repeats file %q", community.ID, file)
+			seen[file] = struct{}{}
+		}
+	}
+}
+
+func TestPrepareAnalysisGenerationDropsStepsForNodesNotInGeneration(t *testing.T) {
+	candidate := testAnalysisCandidate(t)
+	known := candidate.adjacency.PersistenceSnapshot().IDs
+	require.NotEmpty(t, known)
+
+	// BuildAdjacencySnapshot skips unresolved / dangling endpoints, so a
+	// process step naming one has no analysis_nodes row to join against.
+	candidate.processes.Processes = []analysis.Process{{
+		ID:         "process-0",
+		Name:       "test",
+		EntryPoint: known[0],
+		Steps: []analysis.Step{
+			{ID: known[0], Depth: 0},
+			{ID: "unresolved::ACCEPT_TOKEN", Depth: 1},
+			{ID: known[len(known)-1], Depth: 1},
+		},
+		StepCount: 3,
+		Files:     []string{"pkg/a.go"},
+	}}
+
+	input, err := prepareAnalysisGeneration(candidate, 1)
+	require.NoError(t, err)
+	require.Len(t, input.processes, 1)
+
+	steps := input.processSteps["process-0"]
+	for _, step := range steps {
+		require.NotEqual(t, "unresolved::ACCEPT_TOKEN", step.NodeID,
+			"a step naming a node absent from the generation must be dropped")
+	}
+
+	// The store validates analysis_processes.step_count against the number
+	// of persisted step rows, so the summary must count survivors only.
+	require.Equal(t, len(steps), input.processes[0].StepCount)
+
+	// Ordinals form the step primary key and drive keyset paging, so they
+	// must stay contiguous after filtering.
+	for i, step := range steps {
+		require.Equal(t, i, step.Ordinal)
+		require.Equal(t, "process-0", step.ProcessID)
+	}
+}


### PR DESCRIPTION
## Problem

`populateAnalysisLocked` writes the analysis snapshot to SQLite so the daemon can serve it header-only (`installHeader` nils all seven fields) and skip recomputing on the next start. **That save has never succeeded on a real workspace.**

On a daemon tracking 20 repos:

```
analysis_active_generation  → EMPTY
analysis_generations        → every row state=2 (analysisGenerationStale, i.e. aborted)
every "analysis pass complete" in the whole log → cache_hit:false
```

The store validates a generation as it writes it and rejects the whole thing on the first violation. The rejection surfaces only as a `warn`, after which `install` runs with `generationReady=false` and retains the full snapshot in memory. Two costs follow: the analyzer output stays resident, and every start recomputes it — **79s to 366s per pass** in the observed logs (Leiden alone 29–174s), 13+ passes in one file.

## Three independent rejections, each masking the next

| Store error | Cause |
|---|---|
| `community "community-107" has empty file` | Communities and processes are keyed on nodes and carry a file list the store requires non-empty **and** unique. A node need not have a file — synthetic, external and stub nodes have an empty `FilePath` — and two nodes routinely share one. The list was passed through verbatim. |
| `process step process-0[3] references unknown node "unresolved::ACCEPT_TOKEN"` | Steps insert by resolving `node_rowid` through `analysis_nodes`, whose rows come from the adjacency snapshot — which deliberately skips unresolved/dangling endpoints to keep its dense index consistent, while process discovery still walks them. |
| `29 process step counts are incomplete` | The store checks `analysis_processes.step_count` against the persisted step rows, so filtering steps requires the summary to count survivors. |

## Fix

- `sanitizeAnalysisFiles` drops empty and duplicate paths and sorts, applied to both community and process file lists.
- Process steps are filtered to nodes the generation actually carries (`adjacency.IDs`), with ordinals renumbered contiguously — they form the step primary key and drive keyset paging.
- `StepCount` is computed from the filtered list, and the filtered steps travel through `analysisGenerationInput.processSteps` so preparation and writing cannot disagree.

Dropping unresolved steps is the right side of the trade: an unresolved target is not a real graph node, has no metrics row, and cannot be navigated to. The alternative in effect today is discarding the entire generation.

## Verification

- `go build ./...`, `go vet`, `golangci-lint` — clean (0 issues)
- `go test -race ./internal/mcp/ ./internal/graph/store_sqlite/` — pass (94s / 391s)
- Against a live 20-repo daemon, `cache_save` goes **0.07s → 33.7s** — it now writes the full ~500K-row node set instead of aborting in the first chunk — and all three validation errors stop appearing.

Note on the tests: they are compile-coupled to the new helpers, so reverting the fix makes the package fail to build rather than the assertions go red. The evidence that the old path was broken is the production log above, not a synthetic red-green.

## Not fixed here

Activation is still blocked by a separate issue: `BeginAnalysisGeneration` rejects when the graph revision moves during the run. Analysis takes 60–260s, so on a busy daemon with continuous enrichment the window is rarely quiet, and the result cannot be tied to a stable revision ("fail closed"). That needs its own change — these three fixes are a prerequisite either way, and are correct independently.