### PR TITLE
fix(index_health): a degraded pass that landed nothing is not ok

### DIFF
--- a/internal/mcp/index_health_enrichment_test.go
+++ b/internal/mcp/index_health_enrichment_test.go
@@ -18,12 +18,21 @@ import (
 type fakeSemProvider struct {
 	name   string
 	result *semantic.EnrichResult
+	// langs overrides the declared languages. The manager dispatches on
+	// provider.Languages()[0], not on ProviderConfig.Languages, so a test that
+	// cares which language a status carries must set this. Empty means Go.
+	langs []string
 }
 
-func (f *fakeSemProvider) Name() string        { return f.name }
-func (f *fakeSemProvider) Languages() []string { return []string{"go"} }
-func (f *fakeSemProvider) Available() bool     { return true }
-func (f *fakeSemProvider) Close() error        { return nil }
+func (f *fakeSemProvider) Name() string { return f.name }
+func (f *fakeSemProvider) Languages() []string {
+	if len(f.langs) > 0 {
+		return f.langs
+	}
+	return []string{"go"}
+}
+func (f *fakeSemProvider) Available() bool { return true }
+func (f *fakeSemProvider) Close() error    { return nil }
 func (f *fakeSemProvider) Enrich(g graph.Store, repoRoot string) (*semantic.EnrichResult, error) {
 	return f.result, nil
 }
@@ -155,4 +164,84 @@ func TestIndexHealth_SurfacesDegradedEnrichment(t *testing.T) {
 	assert.True(t, strings.Contains(rec, "degraded") && strings.Contains(rec, "compile_commands.json"),
 		"a degraded pass must recommend generating a compile database, got: %q", rec)
 	assert.Contains(t, rec, "lsp-clangd in repo-a", "the recommendation should name the repo/provider")
+}
+
+// A degraded pass that landed NOTHING is not a partial success: for that
+// language the semantic tier does not exist. It must not report as ok, and it
+// must report its own reason rather than the compile-database remediation.
+func TestIndexHealth_InertDegradedEnrichmentIsNotOK(t *testing.T) {
+	srv, _ := setupTestServer(t) // indexes a main.go, so the graph has Go nodes
+
+	mgr := semantic.NewManager(semantic.Config{
+		Enabled: true,
+		Providers: []semantic.ProviderConfig{
+			{Name: "go-types", Languages: []string{"go"}, Priority: 1, Enabled: true},
+		},
+	}, zap.NewNop())
+	mgr.RegisterProvider(&fakeSemProvider{
+		name: "go-types",
+		result: &semantic.EnrichResult{
+			Provider:       "go-types",
+			Language:       "go",
+			Degraded:       true,
+			DegradedReason: "go/packages loadability probe found no cleanly-loading packages; full typecheck skipped",
+		},
+	})
+	_, _, err := mgr.EnrichAll(srv.graph, map[string]string{"repo-a": t.TempDir()}, semantic.EnrichOptions{})
+	require.NoError(t, err)
+	srv.SetSemanticManager(mgr)
+
+	payload := srv.buildIndexHealthPayload()
+	require.NotNil(t, payload)
+
+	okFlag, ok := payload["semantic_enrichment_ok"].(bool)
+	require.True(t, ok)
+	assert.False(t, okFlag,
+		"a degraded pass that produced no edges, nodes or symbols must not report as ok")
+
+	rec, _ := payload["recommendation"].(string)
+	assert.Contains(t, rec, "produced nothing", "the recommendation must say the pass produced nothing, got: %q", rec)
+	assert.Contains(t, rec, "go-types in repo-a", "the recommendation should name the repo/provider")
+	assert.Contains(t, rec, "loadability probe", "the provider's own reason must be surfaced")
+	assert.NotContains(t, rec, "compile_commands.json",
+		"a Go pass must not be handed a C/C++ compilation-database remediation")
+}
+
+// A provider that degrades for a language the graph does not contain is
+// correct and expected — the Go pass on a Rust tree. It must not lower the
+// enrichment signal, or every polyglot repo would report a false alarm.
+func TestIndexHealth_InertDegradedForAbsentLanguageStaysOK(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	mgr := semantic.NewManager(semantic.Config{
+		Enabled: true,
+		Providers: []semantic.ProviderConfig{
+			{Name: "rust-analyzer", Languages: []string{"rust"}, Priority: 1, Enabled: true},
+		},
+	}, zap.NewNop())
+	mgr.RegisterProvider(&fakeSemProvider{
+		name:  "rust-analyzer",
+		langs: []string{"rust"},
+		result: &semantic.EnrichResult{
+			Provider:       "rust-analyzer",
+			Language:       "rust",
+			Degraded:       true,
+			DegradedReason: "no Cargo.toml within two directory levels",
+		},
+	})
+	_, _, err := mgr.EnrichAll(srv.graph, map[string]string{"repo-a": t.TempDir()}, semantic.EnrichOptions{})
+	require.NoError(t, err)
+	srv.SetSemanticManager(mgr)
+
+	payload := srv.buildIndexHealthPayload()
+	require.NotNil(t, payload)
+
+	okFlag, ok := payload["semantic_enrichment_ok"].(bool)
+	require.True(t, ok)
+	assert.True(t, okFlag,
+		"a language absent from the graph cannot be under-enriched and must not lower the signal")
+
+	rec, _ := payload["recommendation"].(string)
+	assert.NotContains(t, rec, "produced nothing",
+		"an absent language must not raise the inert-enrichment alarm, got: %q", rec)
 }

--- a/internal/mcp/tools_enhancements.go
+++ b/internal/mcp/tools_enhancements.go
@@ -3087,18 +3087,55 @@ func (s *Server) buildIndexHealthPayload() map[string]any {
 		}
 	}
 
-	// Compile-database-degraded providers: a clangd pass with no
-	// compile_commands.json intentionally runs reference confirmation only (no
-	// hover / hierarchy sweep). This is not a failure — semantic_enrichment_ok
-	// stays true — but the missing tiers are worth flagging with the remediation.
-	var degradedProviders []string
+	// Degraded providers split by whether the pass still landed work.
+	//
+	// REDUCED is the shape this concept was written for: a clangd pass with no
+	// compile_commands.json runs reference confirmation only. Edges still land,
+	// so it is a genuine partial success — semantic_enrichment_ok stays true
+	// and the remediation points at the compilation database.
+	//
+	// INERT is different in kind: the provider degraded and landed nothing at
+	// all — no edges, no nodes, no symbols. For that language the semantic tier
+	// does not exist, and calling that healthy is how a repository sits at
+	// health_score 100 with lsp_resolved_edges_by_language 0 for a language it
+	// is full of. It counts as incomplete, and it reports the provider's own
+	// reason rather than a canned compilation-database remediation that may not
+	// even name the right toolchain.
+	var reducedProviders, inertProviders, inertReasons []string
 	for _, st := range enrichStatuses {
-		if st.Degraded {
-			degradedProviders = append(degradedProviders, st.Provider+" in "+st.Repo)
+		if !st.Degraded {
+			continue
+		}
+		label := st.Provider + " in " + st.Repo
+		landed := st.EdgesConfirmed + st.EdgesAdded + st.NodesEnriched + st.SymbolsCovered
+		// A provider that degrades for a language the graph does not contain is
+		// correct and expected — the Go pass on a Rust tree is the case the
+		// module gate exists to skip cheaply. Only a language actually present
+		// in the graph can be under-enriched, so only that can lower health.
+		presentInGraph := st.Language != "" && stats.ByLanguage[st.Language] > 0
+		if landed == 0 && presentInGraph {
+			inertProviders = append(inertProviders, label)
+			if st.DegradedReason != "" {
+				inertReasons = append(inertReasons, label+": "+st.DegradedReason)
+			}
+			continue
+		}
+		reducedProviders = append(reducedProviders, label)
+	}
+	if len(reducedProviders) > 0 {
+		msg := "Semantic enrichment ran in degraded (reference-confirmation-only) mode for " + strings.Join(reducedProviders, ", ") + " because no compilation database was found — hover types and call/type-hierarchy edges were skipped. Generate compile_commands.json (cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON, bear -- make, or meson) at the repo root, then reindex_repository."
+		if recommendation == "" {
+			recommendation = msg
+		} else {
+			recommendation = msg + " " + recommendation
 		}
 	}
-	if len(degradedProviders) > 0 {
-		msg := "Semantic enrichment ran in degraded (reference-confirmation-only) mode for " + strings.Join(degradedProviders, ", ") + " because no compilation database was found — hover types and call/type-hierarchy edges were skipped. Generate compile_commands.json (cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON, bear -- make, or meson) at the repo root, then reindex_repository."
+	if len(inertProviders) > 0 {
+		enrichmentIncomplete = true
+		msg := "Semantic enrichment produced nothing for " + strings.Join(inertProviders, ", ") + ", so no LSP-tier edges exist for those languages: tier-filtered queries (min_tier=lsp_resolved) return nothing there rather than under-reporting, and every edge you do see came from the AST pass."
+		if len(inertReasons) > 0 {
+			msg += " Reported reason — " + strings.Join(inertReasons, "; ") + "."
+		}
 		if recommendation == "" {
 			recommendation = msg
 		} else {

--- a/internal/semantic/provider.go
+++ b/internal/semantic/provider.go
@@ -232,10 +232,15 @@ type EnrichmentStatus struct {
 	// textDocument/references (no call hierarchy) — the intelephense-style
 	// add mode. Distinguishes it from the call-hierarchy add mode.
 	ReferencesAddPass bool `json:"references_add_pass,omitempty"`
-	// Degraded marks that this provider ran in reference-confirmation-only
-	// mode because a needed compilation database was missing. Not a failure —
-	// State stays "completed" — but hover / hierarchy edges are absent, so
-	// index_health can flag it with the remediation. DegradedReason says why.
+	// Degraded marks that this provider could not run its full pass — e.g. a
+	// clangd sweep with no compilation database, or a language toolchain that
+	// would not load. State stays "completed"; DegradedReason says why.
+	//
+	// Degraded alone does not say whether anything landed, and the difference
+	// matters to index_health: a pass that still confirmed edges is a partial
+	// success, while one whose counters are all zero means the semantic tier
+	// does not exist for that language at all. index_health separates the two
+	// and only the second lowers semantic_enrichment_ok.
 	Degraded       bool   `json:"degraded,omitempty"`
 	DegradedReason string `json:"degraded_reason,omitempty"`
 	Detail         string `json:"detail,omitempty"`


### PR DESCRIPTION
## The gap

`index_health` treats every degraded provider as a partial success. That is right for the case the concept was written for — a clangd pass with no `compile_commands.json` still confirms references — but wrong when the provider degraded and **landed nothing at all**.

Measured on a monorepo whose Go module sits in a subdirectory:

```
health_score: 100                    semantic_enrichment_ok: true
lsp_resolved_edges_by_language:      go: 0   python: 0   typescript: 0
go-types: degraded=true  coverage_percent=0  symbols_total=0  edges_added=0  edges_confirmed=0
```

Every Go edge in that graph came from the AST pass, and nothing in the surface says so. An agent filtering `min_tier=lsp_resolved` gets an empty result and reads it as *"no usages"* rather than *"this tier was never built"*. That is the expensive failure mode: a confident wrong answer.

**`health_score` is not the misleading part.** It is `successfully_indexed / total_detected`, and `100` is the honest truth about file indexing. `semantic_enrichment_ok` is the field that claims something it never checked — so that is the field this changes, and `health_score` is left alone.

## The change

Split degraded by whether the pass landed work:

| Shape | Condition | Behaviour |
|---|---|---|
| **Reduced** | edges, nodes or symbols landed | **unchanged** — `ok` stays true, remediation still points at the compilation database |
| **Inert** | every counter is zero | counts as incomplete → `semantic_enrichment_ok: false`, and the recommendation carries the provider's **own** `DegradedReason` |

The second half of the inert case also fixes a smaller wrong: today a degraded Go or TypeScript pass is handed *"Generate compile_commands.json (cmake … bear … meson)"*, which is C/C++ advice that cannot help those toolchains.

**False-alarm guard.** A provider that degrades for a language the graph does not contain is correct and expected — the Go pass on a Rust tree is exactly what the module gate exists to skip cheaply. So the inert path only fires when `stats.ByLanguage` actually carries nodes for that language. Without that, every polyglot repository would raise a false alarm.

## What is deliberately untouched

`TestIndexHealth_SurfacesDegradedEnrichment` — the clangd contract, `EdgesConfirmed: 3` — is **unchanged and still passes**, keeping `ok=true` and the `compile_commands.json` remediation. If this PR had broken the shape the feature was designed for, that test would say so.

## Tests

- `TestIndexHealth_InertDegradedEnrichmentIsNotOK` — an inert pass flips `ok` false, names the provider and its own reason, and must **not** print the compile-database remediation.
- `TestIndexHealth_InertDegradedForAbsentLanguageStaysOK` — an inert pass for a language absent from the graph leaves the signal alone.

**Sabotage-verified**: disabling the inert branch (`if false && …`) turns the first test red, so the assertion binds on the new behaviour rather than being satisfied by the surrounding payload.

`gofmt` clean, `go build ./...` and `go vet ./internal/mcp/` pass, and the four pre-existing `TestIndexHealth_*` enrichment tests pass.

*(`internal/semantic/lsp` fails on this machine, but it fails identically on a clean stashed tree — pre-existing here, unrelated to this change.)*

## Small test-fixture change

`fakeSemProvider` gains an optional `langs` field. The manager dispatches on `provider.Languages()[0]`, not `ProviderConfig.Languages`, so a test that cares which language a status carries could not express it before — the fake always reported Go. Existing users leave it empty and keep Go.

## Related

Companion to #338, which fixes the underlying reason that Go pass produced nothing. They are independent: #338 stops this particular repo shape from going inert, this one stops *any* inert pass from reporting as healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
