### PR TITLE
fix(cli): let the completion command reach cobra's generator

### DIFF
--- a/cmd/gortex/root.go
+++ b/cmd/gortex/root.go
@@ -167,6 +167,9 @@ func newLogger() *zap.Logger {
 
 func execute() {
 	assignCommandGroups()
+	// Cobra only adds its own `help` and `completion` commands from inside
+	// Execute, so register them before anything below reads the command tree.
+	primeBuiltinCommands(os.Args[1:])
 	// Recover the `gortex <tool>` misuse (issue #259) before cobra prints a
 	// bare "unknown command": point the user at `gortex call <tool> --arg …`.
 	if maybeToolInvocationHint(os.Stderr, os.Args[1:]) {

--- a/cmd/gortex/tool_did_you_mean.go
+++ b/cmd/gortex/tool_did_you_mean.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/spf13/cobra"
 	gortexmcp "github.com/zzet/gortex/internal/mcp"
 	"github.com/zzet/gortex/internal/toolref"
 )
@@ -149,10 +150,37 @@ func firstPositionalArg(args []string) string {
 	return ""
 }
 
+// primeBuiltinCommands registers the two commands cobra otherwise only adds
+// from inside Execute: `help` and `completion` (with its per-shell
+// subcommands). Until they exist the command tree is incomplete, so
+// isKnownRootCommand — which decides whether a verb is real by walking that
+// tree — reports a built-in as unknown and the tool hint shadows it. That is
+// how `gortex completion zsh` came to answer with a `graph_completion_search`
+// suggestion instead of the script, which in turn broke the completions
+// Homebrew generates by running the binary at install time.
+//
+// Both initializers are idempotent, so cobra's own calls during Execute become
+// no-ops. args is the command line below the binary name — cobra reads it to
+// decide whether a root whose only subcommand would be `completion` is
+// actually being asked for it, and it is threaded through a parameter rather
+// than read from os.Args so tests can drive it.
+func primeBuiltinCommands(args []string) {
+	rootCmd.InitDefaultHelpCmd()
+	rootCmd.InitDefaultCompletionCmd(args...)
+}
+
 // isKnownRootCommand reports whether name matches a registered top-level cobra
 // command or one of its aliases. No daemon, no tool registry — a plain walk of
-// the already-registered command tree.
+// the command tree, which primeBuiltinCommands has topped up with cobra's
+// lazily-added built-ins.
 func isKnownRootCommand(name string) bool {
+	// Cobra adds the shell-completion protocol commands from an unexported
+	// initializer that priming cannot reach, so they never appear in the walk
+	// below. They carry every completion request a generated script makes, and
+	// a hint printed in their place would land in the shell's candidate list.
+	if name == cobra.ShellCompRequestCmd || name == cobra.ShellCompNoDescRequestCmd {
+		return true
+	}
 	for _, c := range rootCmd.Commands() {
 		if c.Name() == name {
 			return true

--- a/cmd/gortex/tool_did_you_mean_test.go
+++ b/cmd/gortex/tool_did_you_mean_test.go
@@ -4,9 +4,15 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestMaybeToolInvocationHint(t *testing.T) {
+	// Mirror execute(): cobra's own `help` and `completion` commands are on
+	// the tree before the hint ever inspects it.
+	primeBuiltinCommands(nil)
+
 	cases := []struct {
 		name     string
 		args     []string
@@ -87,6 +93,30 @@ func TestMaybeToolInvocationHint(t *testing.T) {
 			args:     []string{"--help"},
 			wantHint: false,
 		},
+		// Cobra registers these itself, late. Shadowing `completion` sent
+		// `gortex completion zsh` a graph_completion_search suggestion instead
+		// of the script, which also broke the completions a packager generates
+		// by running the binary at install time.
+		{
+			name:     "completion command reaches cobra's generator",
+			args:     []string{"completion", "zsh"},
+			wantHint: false,
+		},
+		{
+			name:     "help command reaches cobra",
+			args:     []string{"help"},
+			wantHint: false,
+		},
+		{
+			name:     "shell completion protocol command is never hinted",
+			args:     []string{cobra.ShellCompRequestCmd, "completion", ""},
+			wantHint: false,
+		},
+		{
+			name:     "descriptionless completion protocol command is never hinted",
+			args:     []string{cobra.ShellCompNoDescRequestCmd, ""},
+			wantHint: false,
+		},
 	}
 
 	for _, tc := range cases {
@@ -118,6 +148,39 @@ func TestMaybeToolInvocationHint(t *testing.T) {
 				t.Errorf("hint must teach the `gortex call` shape:\n%s", out)
 			}
 		})
+	}
+}
+
+// TestPrimeBuiltinCommandsRegistersBuiltins asserts the commands cobra would
+// otherwise only add from inside Execute are on the tree beforehand — the
+// precondition isKnownRootCommand depends on — and that priming stays
+// idempotent, since cobra runs the same initializers again during Execute.
+func TestPrimeBuiltinCommandsRegistersBuiltins(t *testing.T) {
+	primeBuiltinCommands(nil)
+
+	for _, name := range []string{"completion", "help"} {
+		if !isKnownRootCommand(name) {
+			t.Errorf("built-in %q is not a known root command after priming", name)
+		}
+	}
+
+	// The per-shell subcommands must resolve too: these are what a packager
+	// runs to generate completion scripts at install time.
+	for _, shell := range []string{"bash", "zsh", "fish", "powershell"} {
+		cmd, _, err := rootCmd.Find([]string{"completion", shell})
+		if err != nil {
+			t.Errorf("completion %s does not resolve: %v", shell, err)
+			continue
+		}
+		if cmd.Name() != shell {
+			t.Errorf("completion %s resolved to %q, want %q", shell, cmd.Name(), shell)
+		}
+	}
+
+	before := len(rootCmd.Commands())
+	primeBuiltinCommands(nil)
+	if after := len(rootCmd.Commands()); after != before {
+		t.Errorf("primeBuiltinCommands not idempotent: commands %d -> %d", before, after)
 	}
 }
 


### PR DESCRIPTION
Fixes #339.

## What happened

`gortex completion <shell>` stopped working, so the completions a cask generates by running the binary at install time failed for all four shells:

```
$ gortex completion zsh
gortex: unknown command "completion". The closest Gortex MCP tools:
  gortex call capabilities --arg domain='search' --arg operation='completion' --arg detail=schema
```

Cobra does not register `help` and `completion` when a command is declared — it adds them inside `Execute`, at `ExecuteC` time. `execute()` runs the bare-tool-name hint (the `gortex <tool>` → `gortex call <tool>` recovery added for #259) *before* that, and the hint decides whether a verb is real via `isKnownRootCommand`, which walks the command tree. At that moment the tree has no `completion` on it.

So the verb fell through to the fuzzy tool match, which found `completion` as an underscore-delimited token of `graph_completion_search`, printed a suggestion, and exited 1. The command existed the whole time — `gortex --help` listed it, because `--help` goes through `Execute` and gets the real tree — it was simply unreachable.

`help` was exposed to the same shadowing and survived only because no registered tool name fuzzy-matches it.

## The fix

Register cobra's built-ins before the hint inspects the tree. Both initializers are idempotent, so cobra's own calls during `Execute` become no-ops.

The two shell-completion protocol commands (`__complete`, `__completeNoDesc`) come from an unexported initializer that priming cannot reach, so they are name-matched directly. They carry every completion request a generated script makes, and a hint printed in their place would land in the shell's candidate list.

The recovery behaviour the hint exists for is unchanged — exact tool names, legacy names, and fuzzy truncations still get their `gortex call` line.

## Verification

All four shells generate, and the generated scripts parse:

```
$ for sh in bash zsh fish powershell; do gortex completion $sh >/dev/null; echo "$sh rc=$?"; done
bash rc=0
zsh rc=0
fish rc=0
powershell rc=0

$ gortex completion zsh | zsh -n /dev/stdin && echo ok
ok
```

- `go test -race ./cmd/gortex/` — 720 pass
- `gofmt` clean, `go vet` clean
- Reverting the source fix while keeping the tests fails 3 of them, including the `completion zsh` case, so they are real guards rather than restatements of current behaviour. The two protocol-command cases pass either way today and are marked in the test commit as forward-looking.

Existing installs stay broken until they upgrade — the binary is what generates the scripts.
