### PR TITLE
fix(mcp): run graph analysis on demand instead of eagerly

### DIFF
--- a/cmd/gortex/daemon.go
+++ b/cmd/gortex/daemon.go
@@ -594,19 +594,17 @@ func runDaemonStart(cmd *cobra.Command, _ []string) error {
 		if v1EventHub != nil && mw != nil {
 			go v1EventHub.Run(mw.Events())
 		}
-		// Community detection and process discovery only run when a
-		// repo is tracked or indexed via MCP — a daemon coming up off
-		// a snapshot never triggers them. Fire once here so
-		// get_communities / get_processes / dashboards reflect the
-		// loaded graph instead of returning "run index_repository
-		// first" against a fully populated state.
+		// Community detection and process discovery are a whole-graph pass
+		// costing minutes on a large workspace, and most sessions never ask
+		// for them. Running it here delayed readiness and kept the result
+		// resident for every daemon whether or not anything read it, so the
+		// pass is now started by the first consumer that needs it: those
+		// tools answer with a retry hint while it runs in the background
+		// instead of the old "run index_repository first", which was
+		// misleading against a fully populated graph.
 		if state.mcpServer != nil {
-			analysisStart := time.Now()
-			publishReadinessPhase(state, "analysis", true, nil)
-			state.mcpServer.RunAnalysis()
-			warmup.analysis = time.Since(analysisStart)
-			publishReadinessPhase(state, "analysis_done", true, map[string]any{
-				"elapsed_ms": warmup.analysis.Milliseconds(),
+			publishReadinessPhase(state, "analysis_deferred", true, map[string]any{
+				"reason": "analysis runs on first use",
 			})
 			// Co-change pre-warm: fire the git-history mine in the
 			// background so the first user-visible

--- a/cmd/gortex/mcp.go
+++ b/cmd/gortex/mcp.go
@@ -382,12 +382,8 @@ func runMCP(cmd *cobra.Command, args []string) error {
 			eventHub := hub.New()
 			go eventHub.Run(watcher.Events())
 
-			srv.WatchForReanalysis(eventHub, 500)
 			fmt.Fprintf(os.Stderr, "[gortex] watch mode active\n")
 		}
-
-		// Run initial analysis.
-		srv.RunAnalysis()
 	}()
 
 	// Handle graceful shutdown.

--- a/internal/mcp/analysis_generation.go
+++ b/internal/mcp/analysis_generation.go
@@ -33,6 +33,7 @@ type analysisGenerationInput struct {
 	adjacency      analysis.AdjacencyPersistenceSnapshot
 	communities    []graph.AnalysisCommunitySummary
 	processes      []graph.AnalysisProcessSummary
+	processSteps   map[string][]graph.AnalysisProcessStep
 	concepts       []graph.AnalysisConcept
 	conceptRelated map[string][]string
 }
@@ -66,6 +67,35 @@ func normalizePersistedAnalysis(candidate *persistedAnalysis) {
 	}
 }
 
+// sanitizeAnalysisFiles drops empty and duplicate paths from a community /
+// process file list and returns it sorted.
+//
+// Communities and processes are keyed on nodes, and a node need not have a
+// file: synthetic, external, and stub nodes carry an empty FilePath, and two
+// nodes routinely share one. The store validates these lists as non-empty and
+// unique and rejects the entire generation on the first violation, so an
+// unfiltered list makes every analysis save fail — which silently costs both
+// the warm-start cache and the header-only residency the save enables.
+func sanitizeAnalysisFiles(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	seen := make(map[string]struct{}, len(in))
+	for _, file := range in {
+		if file == "" {
+			continue
+		}
+		if _, duplicate := seen[file]; duplicate {
+			continue
+		}
+		seen[file] = struct{}{}
+		out = append(out, file)
+	}
+	sort.Strings(out)
+	return out
+}
+
 func prepareAnalysisGeneration(candidate persistedAnalysis, revision uint64) (analysisGenerationInput, error) {
 	normalizePersistedAnalysis(&candidate)
 	if candidate.communities == nil || candidate.leiden == nil || candidate.processes == nil ||
@@ -76,8 +106,7 @@ func prepareAnalysisGeneration(candidate persistedAnalysis, revision uint64) (an
 	adjacency := candidate.adjacency.PersistenceSnapshot()
 	communities := make([]graph.AnalysisCommunitySummary, 0, len(candidate.communities.Communities))
 	for _, community := range candidate.communities.Communities {
-		files := append([]string(nil), community.Files...)
-		sort.Strings(files)
+		files := sanitizeAnalysisFiles(community.Files)
 		communities = append(communities, graph.AnalysisCommunitySummary{
 			ID: community.ID, Label: community.Label, Hub: community.Hub, ParentID: community.ParentID,
 			Size: community.Size, Cohesion: community.Cohesion, Files: files,
@@ -85,13 +114,35 @@ func prepareAnalysisGeneration(candidate persistedAnalysis, revision uint64) (an
 	}
 	sort.Slice(communities, func(i, j int) bool { return communities[i].ID < communities[j].ID })
 
+	// A process step can point at a node this generation does not carry:
+	// BuildAdjacencySnapshot deliberately skips unresolved and dangling
+	// endpoints to keep its dense index consistent, so analysis_nodes has no
+	// row for them while DiscoverProcesses still walks them. The step insert
+	// resolves node_rowid through analysis_nodes and rejects the generation
+	// when it finds none. Drop those steps here, renumber the survivors so
+	// ordinals stay contiguous, and report the surviving count as StepCount —
+	// the store validates step_count against the persisted step rows.
+	generationNodes := make(map[string]struct{}, len(adjacency.IDs))
+	for _, nodeID := range adjacency.IDs {
+		generationNodes[nodeID] = struct{}{}
+	}
+	processSteps := make(map[string][]graph.AnalysisProcessStep, len(candidate.processes.Processes))
 	processes := make([]graph.AnalysisProcessSummary, 0, len(candidate.processes.Processes))
 	for _, process := range candidate.processes.Processes {
-		files := append([]string(nil), process.Files...)
-		sort.Strings(files)
+		files := sanitizeAnalysisFiles(process.Files)
+		steps := make([]graph.AnalysisProcessStep, 0, len(process.Steps))
+		for _, step := range process.Steps {
+			if _, known := generationNodes[step.ID]; !known {
+				continue
+			}
+			steps = append(steps, graph.AnalysisProcessStep{
+				ProcessID: process.ID, NodeID: step.ID, Ordinal: len(steps), Depth: step.Depth,
+			})
+		}
+		processSteps[process.ID] = steps
 		processes = append(processes, graph.AnalysisProcessSummary{
 			ID: process.ID, Name: process.Name, EntryPoint: process.EntryPoint,
-			StepCount: process.StepCount, Score: process.Score, Truncated: process.Truncated, Files: files,
+			StepCount: len(steps), Score: process.Score, Truncated: process.Truncated, Files: files,
 		})
 	}
 	sort.Slice(processes, func(i, j int) bool { return processes[i].ID < processes[j].ID })
@@ -133,7 +184,7 @@ func prepareAnalysisGeneration(candidate persistedAnalysis, revision uint64) (an
 			ProcessesTruncated:        candidate.processes.Truncated,
 			ProcessesTruncationReason: candidate.processes.TruncationReason,
 		},
-		adjacency: adjacency, communities: communities, processes: processes,
+		adjacency: adjacency, communities: communities, processes: processes, processSteps: processSteps,
 		concepts: concepts, conceptRelated: conceptSnapshot.Related,
 	}, nil
 }
@@ -197,16 +248,11 @@ func persistAnalysisGeneration(
 			return graph.AnalysisGenerationHeader{}, accepted, err
 		}
 	}
-	for _, process := range candidate.processes.Processes {
-		for start := 0; start < len(process.Steps); start += analysisGenerationWriteChunk {
-			end := min(start+analysisGenerationWriteChunk, len(process.Steps))
-			steps := make([]graph.AnalysisProcessStep, 0, end-start)
-			for ordinal, step := range process.Steps[start:end] {
-				steps = append(steps, graph.AnalysisProcessStep{
-					ProcessID: process.ID, NodeID: step.ID, Ordinal: start + ordinal, Depth: step.Depth,
-				})
-			}
-			accepted, err = writer.AppendAnalysisProcesses(expectedRevision, generationID, nil, steps)
+	for _, process := range input.processes {
+		steps := input.processSteps[process.ID]
+		for start := 0; start < len(steps); start += analysisGenerationWriteChunk {
+			end := min(start+analysisGenerationWriteChunk, len(steps))
+			accepted, err = writer.AppendAnalysisProcesses(expectedRevision, generationID, nil, steps[start:end])
 			if err != nil || !accepted {
 				return graph.AnalysisGenerationHeader{}, accepted, err
 			}

--- a/internal/mcp/analysis_generation_validation_test.go
+++ b/internal/mcp/analysis_generation_validation_test.go
@@ -1,0 +1,120 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/analysis"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/search"
+)
+
+// The store validates a generation as it writes it and rejects the whole
+// thing on the first violation — a rejection that only ever surfaced as a
+// warn, leaving the daemon to fall back to holding the analysis in memory
+// and recomputing it on every restart. These tests pin the three producer
+// invariants the store enforces.
+
+func testAnalysisCandidate(t *testing.T) persistedAnalysis {
+	t.Helper()
+	g := graph.New()
+	nodes := []*graph.Node{
+		{ID: "pkg/a.go::Alpha", Kind: graph.KindFunction, Name: "Alpha", FilePath: "pkg/a.go", Language: "go"},
+		{ID: "pkg/b.go::Beta", Kind: graph.KindFunction, Name: "Beta", FilePath: "pkg/b.go", Language: "go"},
+		{ID: "pkg/c.go::Gamma", Kind: graph.KindFunction, Name: "Gamma", FilePath: "pkg/c.go", Language: "go"},
+	}
+	edges := []*graph.Edge{
+		{From: "pkg/a.go::Alpha", To: "pkg/b.go::Beta", Kind: graph.EdgeCalls},
+		{From: "pkg/b.go::Beta", To: "pkg/c.go::Gamma", Kind: graph.EdgeCalls},
+	}
+	g.AddBatch(nodes, edges)
+
+	communities, leiden, _ := analysis.DetectCommunitiesLeidenIncremental(g, nil)
+	candidate := persistedAnalysis{
+		communities:  communities,
+		leiden:       leiden,
+		processes:    analysis.DiscoverProcesses(g),
+		pageRank:     analysis.ComputePageRank(g),
+		adjacency:    analysis.BuildAdjacencySnapshot(g),
+		autoConcepts: search.BuildAutoConcepts(g),
+		hits:         analysis.ComputeHITS(g),
+	}
+	require.NotNil(t, candidate.communities)
+	require.NotNil(t, candidate.adjacency)
+	require.NotEmpty(t, candidate.communities.Communities, "need at least one community to mutate")
+	return candidate
+}
+
+func TestSanitizeAnalysisFiles(t *testing.T) {
+	// Nodes without a file (synthetic / external / stub) contribute an
+	// empty path, and two nodes routinely share one file.
+	got := sanitizeAnalysisFiles([]string{"z.go", "", "a.go", "z.go", ""})
+	require.Equal(t, []string{"a.go", "z.go"}, got)
+
+	require.Nil(t, sanitizeAnalysisFiles(nil))
+	require.Nil(t, sanitizeAnalysisFiles([]string{}))
+	require.Empty(t, sanitizeAnalysisFiles([]string{"", ""}), "an all-empty list must not yield an empty-string row")
+}
+
+func TestPrepareAnalysisGenerationDropsEmptyAndDuplicateCommunityFiles(t *testing.T) {
+	candidate := testAnalysisCandidate(t)
+	candidate.communities.Communities[0].Files = []string{"pkg/a.go", "", "pkg/a.go"}
+
+	input, err := prepareAnalysisGeneration(candidate, 1)
+	require.NoError(t, err)
+
+	for _, community := range input.communities {
+		for _, file := range community.Files {
+			require.NotEmpty(t, file, "community %q kept an empty file path", community.ID)
+		}
+		seen := map[string]struct{}{}
+		for _, file := range community.Files {
+			_, dup := seen[file]
+			require.False(t, dup, "community %q repeats file %q", community.ID, file)
+			seen[file] = struct{}{}
+		}
+	}
+}
+
+func TestPrepareAnalysisGenerationDropsStepsForNodesNotInGeneration(t *testing.T) {
+	candidate := testAnalysisCandidate(t)
+	known := candidate.adjacency.PersistenceSnapshot().IDs
+	require.NotEmpty(t, known)
+
+	// BuildAdjacencySnapshot skips unresolved / dangling endpoints, so a
+	// process step naming one has no analysis_nodes row to join against.
+	candidate.processes.Processes = []analysis.Process{{
+		ID:         "process-0",
+		Name:       "test",
+		EntryPoint: known[0],
+		Steps: []analysis.Step{
+			{ID: known[0], Depth: 0},
+			{ID: "unresolved::ACCEPT_TOKEN", Depth: 1},
+			{ID: known[len(known)-1], Depth: 1},
+		},
+		StepCount: 3,
+		Files:     []string{"pkg/a.go"},
+	}}
+
+	input, err := prepareAnalysisGeneration(candidate, 1)
+	require.NoError(t, err)
+	require.Len(t, input.processes, 1)
+
+	steps := input.processSteps["process-0"]
+	for _, step := range steps {
+		require.NotEqual(t, "unresolved::ACCEPT_TOKEN", step.NodeID,
+			"a step naming a node absent from the generation must be dropped")
+	}
+
+	// The store validates analysis_processes.step_count against the number
+	// of persisted step rows, so the summary must count survivors only.
+	require.Equal(t, len(steps), input.processes[0].StepCount)
+
+	// Ordinals form the step primary key and drive keyset paging, so they
+	// must stay contiguous after filtering.
+	for i, step := range steps {
+		require.Equal(t, i, step.Ordinal)
+		require.Equal(t, "process-0", step.ProcessID)
+	}
+}

--- a/internal/mcp/analysis_lazy.go
+++ b/internal/mcp/analysis_lazy.go
@@ -143,7 +143,14 @@ func (s *Server) analysisProcessesForNodes(nodeIDs []string) ([]graph.AnalysisPr
 // generation receipt and graph tokens remain published, so the next request can
 // query bounded rows without a whole-graph recomputation.
 func (s *Server) releaseTransientAnalysisIfIdle() bool {
-	s.analysisMu.Lock()
+	// This runs on the tail of every tool call while an analysis pass holds
+	// analysisMu for its whole multi-minute run, so taking the lock
+	// unconditionally stalls every request — including ones that never touch
+	// analysis — behind that pass. The release is pure opportunistic
+	// housekeeping, so a contended lock defers it to the next call.
+	if !s.analysisMu.TryLock() {
+		return false
+	}
 	defer s.analysisMu.Unlock()
 	if !s.analysisGenerationReady {
 		return false

--- a/internal/mcp/analysis_ondemand.go
+++ b/internal/mcp/analysis_ondemand.go
@@ -1,0 +1,139 @@
+package mcp
+
+import (
+	"fmt"
+	"sync/atomic"
+	"time"
+)
+
+// Analysis is a whole-graph pass — six analyzers over the full node and edge
+// corpus — that takes minutes on a large workspace. It must therefore never
+// run inline on a tool call: an agent's tool budget is far shorter than the
+// pass, so blocking would guarantee a timeout with nothing to show for it.
+//
+// Instead a consumer that finds the snapshot missing starts the pass in the
+// background and gets back a retry hint, so it can come back once the pass
+// has had time to finish rather than hanging or being told to run something
+// it has already run.
+const (
+	// analysisRetryFloor keeps a hint from suggesting a busy-poll.
+	analysisRetryFloor = 10 * time.Second
+	// analysisRetryCeiling keeps one hint inside a plausible agent budget;
+	// a longer pass simply asks the caller back more than once.
+	analysisRetryCeiling = 55 * time.Second
+	// analysisRetryUnknown is the hint used before any pass has completed
+	// and left a duration to extrapolate from.
+	analysisRetryUnknown = 30 * time.Second
+)
+
+// analysisRunState tracks the background pass so concurrent callers start at
+// most one and can be told how long it has left.
+type analysisRunState struct {
+	running   atomic.Bool
+	startedAt atomic.Int64 // unix nanos of the in-flight pass
+	lastTook  atomic.Int64 // nanos the previous pass took, 0 until one completes
+}
+
+// AnalysisAvailability is what a consumer needs to decide between answering
+// now and asking the caller to come back.
+type AnalysisAvailability struct {
+	// Ready reports that the snapshot is current and can be read.
+	Ready bool
+	// Running reports that a pass is in flight — either one this call
+	// started or one already under way.
+	Running bool
+	// RetryAfter is how long the caller should wait before asking again.
+	// Zero when Ready.
+	RetryAfter time.Duration
+}
+
+// Message renders the availability as an agent-facing sentence. Empty when
+// the snapshot is ready.
+func (a AnalysisAvailability) Message() string {
+	if a.Ready {
+		return ""
+	}
+	secs := int(a.RetryAfter.Round(time.Second) / time.Second)
+	if !a.Running {
+		return "graph analysis is unavailable and could not be started; retry later"
+	}
+	return fmt.Sprintf(
+		"graph analysis is running in the background — retry this call in ~%ds. "+
+			"It is a whole-graph pass, so it takes minutes on a large workspace; "+
+			"there is nothing to re-index and no other action to take.", secs)
+}
+
+// retryHint converts the observed pass duration into a wait the caller can
+// act on: how much of the previous pass's runtime is left, clamped so a hint
+// is never a busy-poll and never outlives a plausible tool budget.
+func (s *analysisRunState) retryHint() time.Duration {
+	last := time.Duration(s.lastTook.Load())
+	if last <= 0 {
+		return analysisRetryUnknown
+	}
+	remaining := last
+	if started := s.startedAt.Load(); started > 0 {
+		if elapsed := time.Since(time.Unix(0, started)); elapsed < last {
+			remaining = last - elapsed
+		} else {
+			// The pass is already past its previous runtime; it should
+			// land soon, so ask for the floor rather than a stale estimate.
+			remaining = analysisRetryFloor
+		}
+	}
+	return min(max(remaining, analysisRetryFloor), analysisRetryCeiling)
+}
+
+// analysisPendingPayload is the body a consumer returns while the pass runs.
+// The empty collection under its own key keeps the response shape identical
+// to a successful call, so a caller that just iterates results sees "none
+// yet" rather than a decode error, while status/retry_after_seconds carry
+// the actionable part.
+func analysisPendingPayload(a AnalysisAvailability, collection string) map[string]any {
+	return map[string]any{
+		collection:            []any{},
+		"status":              "analysis_pending",
+		"retry_after_seconds": int(a.RetryAfter.Round(time.Second) / time.Second),
+		"message":             a.Message(),
+	}
+}
+
+// ensureAnalysis reports whether the analysis snapshot can be read right now,
+// starting a background pass when it cannot. It never blocks on the pass.
+//
+// The daemon deliberately does not compute analysis at startup: it is minutes
+// of whole-graph work that most sessions never look at, and computing it
+// eagerly both delays readiness and keeps the result resident. This is the
+// path that replaces that eager pass.
+func (s *Server) ensureAnalysis() AnalysisAvailability {
+	// RunAnalysis holds analysisMu for the whole pass, so a plain RLock here
+	// would queue behind it and block the caller for minutes — the exact
+	// failure this path exists to prevent. Failing to take the lock is
+	// itself the answer: a writer holds it, so a pass is in flight.
+	if !s.analysisMu.TryRLock() {
+		return AnalysisAvailability{Running: true, RetryAfter: s.analysisRun.retryHint()}
+	}
+	ready := s.analysisSnapshotCurrentLocked()
+	s.analysisMu.RUnlock()
+	if ready {
+		return AnalysisAvailability{Ready: true}
+	}
+
+	// Exactly one caller starts the pass; the rest join the same wait.
+	if s.analysisRun.running.CompareAndSwap(false, true) {
+		s.analysisRun.startedAt.Store(time.Now().UnixNano())
+		go func() {
+			started := time.Now()
+			defer func() {
+				s.analysisRun.lastTook.Store(int64(time.Since(started)))
+				s.analysisRun.startedAt.Store(0)
+				s.analysisRun.running.Store(false)
+			}()
+			if s.logger != nil {
+				s.logger.Info("analysis: starting on-demand pass")
+			}
+			s.RunAnalysis()
+		}()
+	}
+	return AnalysisAvailability{Running: true, RetryAfter: s.analysisRun.retryHint()}
+}

--- a/internal/mcp/analysis_ondemand_test.go
+++ b/internal/mcp/analysis_ondemand_test.go
@@ -1,0 +1,60 @@
+package mcp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnalysisRetryHintWithoutAPriorPass(t *testing.T) {
+	var state analysisRunState
+	require.Equal(t, analysisRetryUnknown, state.retryHint(),
+		"with no completed pass to extrapolate from the hint must be the unknown default")
+}
+
+func TestAnalysisRetryHintCountsDownThePass(t *testing.T) {
+	var state analysisRunState
+	state.lastTook.Store(int64(40 * time.Second))
+	state.startedAt.Store(time.Now().Add(-10 * time.Second).UnixNano())
+
+	hint := state.retryHint()
+	require.Less(t, hint, 40*time.Second, "the hint must shrink as the pass progresses")
+	require.Greater(t, hint, analysisRetryFloor, "30s of a 40s pass remains, well above the floor")
+}
+
+func TestAnalysisRetryHintIsClamped(t *testing.T) {
+	// A pass that already overran its previous runtime should land soon.
+	var overrun analysisRunState
+	overrun.lastTook.Store(int64(40 * time.Second))
+	overrun.startedAt.Store(time.Now().Add(-2 * time.Minute).UnixNano())
+	require.Equal(t, analysisRetryFloor, overrun.retryHint())
+
+	// A pass far longer than any tool budget still yields one actionable
+	// wait; the caller simply comes back more than once.
+	var long analysisRunState
+	long.lastTook.Store(int64(6 * time.Minute))
+	require.Equal(t, analysisRetryCeiling, long.retryHint(),
+		"a hint must never exceed a plausible tool budget")
+}
+
+func TestAnalysisPendingPayloadKeepsResponseShape(t *testing.T) {
+	payload := analysisPendingPayload(
+		AnalysisAvailability{Running: true, RetryAfter: 25 * time.Second}, "communities")
+
+	// A caller that just iterates the collection must not hit a decode
+	// error or a missing key while the pass runs.
+	collection, ok := payload["communities"].([]any)
+	require.True(t, ok, "the collection key must be present and correctly typed")
+	require.Empty(t, collection)
+
+	require.Equal(t, "analysis_pending", payload["status"])
+	require.Equal(t, 25, payload["retry_after_seconds"])
+	require.Contains(t, payload["message"], "retry this call in ~25s")
+	require.NotContains(t, payload["message"], "index_repository",
+		"a populated graph must not be told to re-index")
+}
+
+func TestAnalysisAvailabilityMessageIsEmptyWhenReady(t *testing.T) {
+	require.Empty(t, AnalysisAvailability{Ready: true}.Message())
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -35,7 +35,6 @@ import (
 	"github.com/zzet/gortex/internal/savings"
 	"github.com/zzet/gortex/internal/search"
 	"github.com/zzet/gortex/internal/semantic"
-	"github.com/zzet/gortex/internal/server/hub"
 	"github.com/zzet/gortex/internal/telemetry"
 	"github.com/zzet/gortex/internal/tokens"
 )
@@ -204,6 +203,10 @@ type Server struct {
 	hotspotsReady   bool
 	hotspotsBuildMu sync.Mutex
 	analysisEpoch   uint64
+	// analysisRun tracks the background on-demand analysis pass so a tool
+	// call can report "running, retry in Ns" instead of blocking for
+	// minutes on a whole-graph computation.
+	analysisRun analysisRunState
 	// hotspotsFn is a test seam for deterministic concurrency/invalidation
 	// tests. Production leaves it nil and uses analysis.FindHotspots.
 	hotspotsFn func(graph.Store, *analysis.CommunityResult, float64) []analysis.HotspotEntry
@@ -2658,31 +2661,13 @@ func (s *Server) SetEventRules(rules []config.EventRule) {
 	s.eventRules = rules
 }
 
-// WatchForReanalysis subscribes to hub events and re-runs analysis after
-// a debounce period of inactivity. It runs in a background goroutine.
-func (s *Server) WatchForReanalysis(h *hub.Hub, debounceMs int) {
-	subID, events := h.Subscribe()
-	debounce := time.Duration(debounceMs) * time.Millisecond
-
-	go func() {
-		var timer *time.Timer
-		for ev := range events {
-			_ = ev // any event triggers reanalysis
-			if timer != nil {
-				timer.Stop()
-			}
-			timer = time.AfterFunc(debounce, func() {
-				s.logger.Info("re-running analysis after graph change")
-				s.RunAnalysis()
-			})
-		}
-		// Channel closed — hub is shutting down.
-		if timer != nil {
-			timer.Stop()
-		}
-		_ = subID
-	}()
-}
+// Analysis deliberately has no watcher-driven trigger. Re-running it on every
+// graph change was self-defeating: the pass is minutes of whole-graph work
+// started by a change, so it ran while further changes landed and could never
+// be published against a stable revision. Nothing has to replace it — the
+// currency token is derived from graph state, so a change already makes the
+// snapshot non-current, and the next consumer starts a fresh pass through
+// ensureAnalysis.
 
 // ServeStdio starts the MCP server on stdin/stdout.
 func (s *Server) ServeStdio() error {

--- a/internal/mcp/tools_analysis.go
+++ b/internal/mcp/tools_analysis.go
@@ -71,6 +71,9 @@ func (s *Server) registerAnalysisTools() {
 }
 
 func (s *Server) handleGetCommunities(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	if pending := s.ensureAnalysis(); !pending.Ready {
+		return s.respondJSONOrTOON(ctx, req, analysisPendingPayload(pending, "communities"))
+	}
 	comms := s.getCommunities()
 
 	// If id is provided, return the single community in detail.
@@ -129,6 +132,9 @@ func (s *Server) handleGetCommunities(ctx context.Context, req mcp.CallToolReque
 }
 
 func (s *Server) handleGetProcesses(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	if pending := s.ensureAnalysis(); !pending.Ready {
+		return s.respondJSONOrTOON(ctx, req, analysisPendingPayload(pending, "processes"))
+	}
 	procs := s.getProcesses()
 
 	// If id is provided, return the single process in detail.


### PR DESCRIPTION
Stacked on #340 — review that first; this branch targets it, not `main`.

## Problem

The analysis pass (six whole-graph analyzers) took **79s–366s** on a 20-repo workspace and ran twice over: once at daemon startup, then again after *every* graph change (`WatchForReanalysis`, 500ms debounce, `// any event triggers reanalysis`).

That was self-defeating. The pass is *triggered by* a graph mutation, then runs for minutes while more mutations land, so it can never be published against a stable revision. Combined with the validation bugs in #340, **no generation had ever activated** — `analysis_active_generation` was empty across the daemon's entire history, `cache_hit:false` on every pass. The daemon recomputed the same snapshot on every start and discarded it, while the ~400 MB result stayed resident.

## Change

Analysis starts when a consumer first needs it. Nothing is lost by dropping the eager pass: the currency token is derived from graph state, so a mutation already makes the snapshot non-current — the watcher only has to stop recomputing.

Since the pass far exceeds any agent's tool budget, a consumer that finds the snapshot missing **does not block**. It starts the pass in the background and returns the collection empty plus `retry_after_seconds`, derived from the previous pass's runtime and clamped so a hint is neither a busy-poll nor longer than a plausible budget:

```json
{
  "communities": [],
  "status": "analysis_pending",
  "retry_after_seconds": 30,
  "message": "graph analysis is running in the background — retry this call in ~30s. ..."
}
```

The empty collection keeps the response shape identical to success, so a caller that just iterates sees "none yet" rather than a decode error. This replaces `"run index_repository first"`, which was misleading against a fully populated graph.

**Two lock fixes make it safe.** `ensureAnalysis` uses `TryRLock` — a plain `RLock` queues behind the running pass and blocks for minutes, the exact failure it exists to prevent. And `releaseTransientAnalysisIfIdle`, which runs on the tail of **every** tool call, now uses `TryLock`: taking it unconditionally stalled every request — including ones that never touch analysis — behind a background pass.

## Measured on a live 20-repo daemon

| | Before | After |
|---|---|---|
| Time to `ready` | 2m21s – 11m29s | **21s** |
| `tool not found` reply during a pass | 66s | **3.5s** |
| `search_symbols` during a pass | — | **3.5s** |
| Active generation | never, in the daemon's whole history | **generation 10, state=ready** |
| Analysis pass on restart | `cache_hit:false`, 79–366s | **`cache_hit:true`, 0.19s** |
| `daemon status memory` | 507 MiB | **135.6 MiB** |
| Retained heap (pprof `?gc=1`) | 497 MB | **141 MB** |

The analyzer structures are now absent from the heap profile entirely — `columnText` 186 MB, Leiden 128.67 MB, adjacency 98.85 MB, HITS 86.64 MB, PageRank 82.37 MB all gone, served from SQLite instead. `get_communities` returns all 3,251 communities from the durable generation.

Note this needed no new residency mechanism: `releaseTransientAnalysisIfIdle` already drops the seven in-memory views once a generation is published. It simply never fired, because publication never succeeded.

## Deliberately not included

I also tried removing the `DELETE FROM analysis_active_generation` in `invalidateAnalysisGenerationTx`, on the theory that marking the generation stale was sufficient. **It is not, and the tests caught it:** `LoadActiveAnalysisHeader` treats an active pointer aimed at a non-ready generation as *corruption*, not as a cache miss. The invariant is "an active pointer must point at a ready generation," and the `DELETE` is how invalidation maintains it. Reverted; `store_sqlite` is green.

## Verification

- `go build ./...`, `go vet`, `golangci-lint` — clean (0 issues)
- `go test -race ./internal/mcp/ ./internal/graph/store_sqlite/` — pass (92s / 395s)
- Unit tests cover the retry-hint countdown, both clamps, the unknown-duration default, and the pending payload's response shape