### PR TITLE
fix: stop reporting a negative document count in daemon status

### DIFF
--- a/cmd/gortex/daemon.go
+++ b/cmd/gortex/daemon.go
@@ -1189,11 +1189,21 @@ func renderDaemonHeader(w io.Writer, st daemon.StatusResponse) {
 		t.AppendRow(table.Row{"memory", formatBytes(st.MemoryBytes)})
 	}
 	if sb := st.SearchBackend; sb.Name != "" {
+		// formatSearchDocs renders the trailing-space "docs=N  " fragment,
+		// or nothing when the backend cannot report a real count. Backends
+		// whose only figure is a since-construction Add/Remove delta must
+		// print nothing rather than pass the delta off as a corpus size.
+		formatSearchDocs := func(sb daemon.SearchBackendStats) string {
+			if !sb.DocCountKnown {
+				return ""
+			}
+			return fmt.Sprintf("docs=%d  ", sb.DocCount)
+		}
 		switch {
 		case sb.DiskPath != "":
 			t.AppendRow(table.Row{"search", fmt.Sprintf(
-				"%s  docs=%d  heap=%s  disk=%s  path=%s",
-				sb.Name, sb.DocCount, formatBytes(sb.Bytes),
+				"%s  %sheap=%s  disk=%s  path=%s",
+				sb.Name, formatSearchDocs(sb), formatBytes(sb.Bytes),
 				formatBytes(sb.DiskBytes), sb.DiskPath)})
 		case sb.DiskResident:
 			// No heap footprint to report — the index lives inside the
@@ -1201,11 +1211,11 @@ func renderDaemonHeader(w io.Writer, st daemon.StatusResponse) {
 			// structure. Printing "heap=0 B" here would read as "this
 			// backend costs nothing", which is false.
 			t.AppendRow(table.Row{"search", fmt.Sprintf(
-				"%s  docs=%d  disk-resident (indexed in the graph store)",
-				sb.Name, sb.DocCount)})
+				"%s  %sdisk-resident (indexed in the graph store)",
+				sb.Name, formatSearchDocs(sb))})
 		default:
 			t.AppendRow(table.Row{"search", fmt.Sprintf(
-				"%s  docs=%d  heap=%s", sb.Name, sb.DocCount, formatBytes(sb.Bytes))})
+				"%s  %sheap=%s", sb.Name, formatSearchDocs(sb), formatBytes(sb.Bytes))})
 		}
 	}
 	rt := st.Runtime

--- a/cmd/gortex/daemon_controller.go
+++ b/cmd/gortex/daemon_controller.go
@@ -615,24 +615,32 @@ func resolveSearchBackend(b search.Backend) searchBackendInfo {
 			out.Name = "bleve-memory"
 		}
 		out.DocCount = back.Count()
+		out.DocCountKnown = true
 		out.Bytes = back.SizeBytes()
 	case *search.BM25Backend:
 		out.Name = "bm25"
 		out.DocCount = back.Count()
+		out.DocCountKnown = true
 		out.Bytes = back.SizeBytes()
 	case *search.SymbolSearcherBackend:
 		// The FTS5 index lives inside the graph store's own file, not a
 		// separate in-memory structure — there is no honest byte count
-		// to report here (Count() is only a since-construction delta,
-		// documented as non-authoritative on the adapter itself). Report
-		// the backend truthfully as disk-resident instead of printing a
-		// fabricated "heap=0 B".
+		// to report here. Report the backend truthfully as disk-resident
+		// instead of printing a fabricated "heap=0 B".
+		//
+		// The document count comes from the index itself, never from
+		// Count(): that is a since-construction Add/Remove delta, which
+		// is not a corpus size and goes negative as soon as an eviction
+		// path drops more than the admit predicate ever added. When the
+		// index cannot answer, the figure is omitted rather than filled
+		// in with the delta.
 		out.Name = "sqlite-fts5"
-		out.DocCount = back.Count()
 		out.DiskResident = true
+		out.DocCount, out.DocCountKnown = back.DocCount()
 	default:
 		out.Name = "unknown"
 		out.DocCount = b.Count()
+		out.DocCountKnown = true
 		out.Bytes = search.BackendSize(b)
 	}
 	return out

--- a/cmd/gortex/daemon_search_backend_test.go
+++ b/cmd/gortex/daemon_search_backend_test.go
@@ -21,6 +21,15 @@ func (fakeSymbolSearcher) BulkUpsertSymbolFTS(string, []graph.SymbolFTSItem) err
 func (fakeSymbolSearcher) BuildSymbolIndex() error                                 { return nil }
 func (fakeSymbolSearcher) SearchSymbols(string, int) ([]graph.SymbolHit, error)    { return nil, nil }
 
+// countingSymbolSearcher is a store that can answer the authoritative
+// document count, as the real SQLite store does.
+type countingSymbolSearcher struct {
+	fakeSymbolSearcher
+	count int
+}
+
+func (c countingSymbolSearcher) SymbolFTSCount() (int, error) { return c.count, nil }
+
 func TestResolveSearchBackend_SymbolSearcherBackend(t *testing.T) {
 	b := search.NewSymbolSearcherBackend(fakeSymbolSearcher{})
 	b.Add("node-1")
@@ -29,9 +38,29 @@ func TestResolveSearchBackend_SymbolSearcherBackend(t *testing.T) {
 	info := resolveSearchBackend(b)
 
 	assert.Equal(t, "sqlite-fts5", info.Name)
-	assert.Equal(t, 2, info.DocCount, "DocCount should come from the adapter's Count()")
 	assert.True(t, info.DiskResident, "the FTS5 index lives inside the graph store, not in-process heap")
 	assert.Zero(t, info.Bytes, "no fabricated byte count for a disk-resident backend")
+	// Count() is a since-construction Add/Remove delta, not a corpus size —
+	// it goes negative as soon as an eviction path drops more than the admit
+	// predicate ever added. A store that cannot answer the real count must
+	// leave the figure unreported rather than have the delta stand in for it.
+	assert.False(t, info.DocCountKnown, "the delta must never be reported as a document count")
+	assert.Zero(t, info.DocCount)
+}
+
+func TestResolveSearchBackend_SymbolSearcherBackend_CountFromIndex(t *testing.T) {
+	// Adds and removes move the adapter's delta; the reported figure must
+	// still be the index's own count, not that delta.
+	b := search.NewSymbolSearcherBackend(countingSymbolSearcher{count: 48572})
+	b.Add("node-1")
+	b.Remove("node-2")
+	b.Remove("node-3")
+	assert.Negative(t, b.Count(), "precondition: the delta is negative here")
+
+	info := resolveSearchBackend(b)
+
+	assert.True(t, info.DocCountKnown)
+	assert.Equal(t, 48572, info.DocCount, "DocCount must come from the index, not the adapter delta")
 }
 
 func TestResolveSearchBackend_SymbolSearcherBackend_ThroughSwappable(t *testing.T) {
@@ -47,9 +76,10 @@ func TestResolveSearchBackend_SymbolSearcherBackend_ThroughSwappable(t *testing.
 func TestRenderDaemonHeader_SearchBackendRow_SymbolSearcher(t *testing.T) {
 	st := sampleStatus()
 	st.SearchBackend = daemon.SearchBackendStats{
-		Name:         "sqlite-fts5",
-		DocCount:     48572,
-		DiskResident: true,
+		Name:          "sqlite-fts5",
+		DocCount:      48572,
+		DocCountKnown: true,
+		DiskResident:  true,
 	}
 	var buf bytes.Buffer
 	renderDaemonHeader(&buf, st)
@@ -58,4 +88,19 @@ func TestRenderDaemonHeader_SearchBackendRow_SymbolSearcher(t *testing.T) {
 	assert.Contains(t, out, "48572")
 	assert.Contains(t, out, "disk-resident")
 	assert.NotContains(t, out, "heap=0 B", "must not print a fabricated zero heap size")
+}
+
+func TestRenderDaemonHeader_OmitsUnknownDocCount(t *testing.T) {
+	st := sampleStatus()
+	st.SearchBackend = daemon.SearchBackendStats{
+		Name:         "sqlite-fts5",
+		DiskResident: true,
+	}
+	var buf bytes.Buffer
+	renderDaemonHeader(&buf, st)
+	out := buf.String()
+	assert.Contains(t, out, "sqlite-fts5")
+	assert.Contains(t, out, "disk-resident")
+	assert.NotContains(t, out, "docs=",
+		"a backend with no real count must omit the figure, not print docs=0 or a delta")
 }

--- a/cmd/gortex/daemon_status_render_test.go
+++ b/cmd/gortex/daemon_status_render_test.go
@@ -98,8 +98,9 @@ func TestRenderDaemonRepos_NoDiskColumnInMemoryMode(t *testing.T) {
 func TestRenderDaemonHeader_SearchBackendRow(t *testing.T) {
 	st := sampleStatus()
 	st.SearchBackend = daemon.SearchBackendStats{
-		Name:      "bleve-disk",
-		DocCount:  65000,
+		Name:          "bleve-disk",
+		DocCount:      65000,
+		DocCountKnown: true,
 		Bytes:     200 * 1024 * 1024,
 		DiskPath:  "/tmp/gortex/bleve.scorch",
 		DiskBytes: 800 * 1024 * 1024,

--- a/cmd/gortex/daemon_status_tui.go
+++ b/cmd/gortex/daemon_status_tui.go
@@ -330,12 +330,21 @@ func (m statusTUI) headerRightCol() string {
 		state,
 		tuiSub.Render("up " + humanizeDur(time.Duration(st.UptimeSeconds)*time.Second)),
 	}, tuiHint.Render(" · "))
-	row3 := strings.Join([]string{
+	row3Cells := []string{
 		tuiKey.Render(humanizeBytes(st.Runtime.Alloc)) + tuiSub.Render(" alloc"),
-		tuiKey.Render(humanizeInt(st.SearchBackend.DocCount)) + tuiSub.Render(" docs"),
-		tuiKey.Render(fmt.Sprintf("%d", st.Sessions)) + tuiSub.Render(" sessions"),
-		tuiKey.Render(fmt.Sprintf("%d", st.Runtime.NumGoroutine)) + tuiSub.Render(" goroutines"),
-	}, tuiHint.Render(" · "))
+	}
+	// Omitted entirely when the backend has no real count to report —
+	// its only figure would be a since-construction Add/Remove delta,
+	// which is not a document count and can be negative.
+	if st.SearchBackend.DocCountKnown {
+		row3Cells = append(row3Cells,
+			tuiKey.Render(humanizeInt(st.SearchBackend.DocCount))+tuiSub.Render(" docs"))
+	}
+	row3Cells = append(row3Cells,
+		tuiKey.Render(fmt.Sprintf("%d", st.Sessions))+tuiSub.Render(" sessions"),
+		tuiKey.Render(fmt.Sprintf("%d", st.Runtime.NumGoroutine))+tuiSub.Render(" goroutines"),
+	)
+	row3 := strings.Join(row3Cells, tuiHint.Render(" · "))
 	return lipgloss.JoinVertical(lipgloss.Left, row1, "", row2, row3)
 }
 

--- a/internal/daemon/proto.go
+++ b/internal/daemon/proto.go
@@ -318,6 +318,12 @@ type RuntimeStats struct {
 type SearchBackendStats struct {
 	Name      string `json:"name"`                 // "bm25" | "bleve-memory" | "bleve-disk" | "sqlite-fts5"
 	DocCount  int    `json:"doc_count"`            // indexed documents across all repos
+	// DocCountKnown distinguishes "the index holds zero documents" from
+	// "this backend cannot report a document count". Backends whose only
+	// available figure is a since-construction Add/Remove delta leave it
+	// false so renderers omit the number instead of presenting the delta
+	// as a corpus size.
+	DocCountKnown bool `json:"doc_count_known,omitempty"`
 	Bytes     uint64 `json:"bytes"`                // approximate heap footprint
 	DiskPath  string `json:"disk_path,omitempty"`  // set only when Name == "bleve-disk"
 	DiskBytes uint64 `json:"disk_bytes,omitempty"` // current on-disk size for "bleve-disk"

--- a/internal/graph/store.go
+++ b/internal/graph/store.go
@@ -554,6 +554,15 @@ type SymbolSearcher interface {
 	SearchSymbols(query string, limit int) ([]SymbolHit, error)
 }
 
+// SymbolFTSCounter is the optional authoritative document count. The
+// search.Backend Count() contract reports a since-construction delta of the
+// indexer's Add/Remove calls, which is not a corpus size and can legitimately
+// be negative; anything that wants to report how many documents are actually
+// indexed must ask the store instead of the adapter.
+type SymbolFTSCounter interface {
+	SymbolFTSCount() (int, error)
+}
+
 // SymbolFTSBatchUpserter is the optional incremental fast path. It is kept
 // separate from SymbolSearcher so alternate search implementations and test
 // doubles retain source compatibility. Indexing paths use this capability as

--- a/internal/graph/store_sqlite/store_fts.go
+++ b/internal/graph/store_sqlite/store_fts.go
@@ -77,6 +77,20 @@ func (s *Store) UpsertSymbolFTS(nodeID, tokens string) error {
 	return s.BatchUpsertSymbolFTS([]graph.SymbolFTSItem{{NodeID: nodeID, Tokens: tokens}})
 }
 
+// SymbolFTSCount reports how many symbols are actually indexed. It counts the
+// symbol_fts_rowid ownership sidecar rather than the FTS5 vtable: the sidecar
+// carries exactly one row per indexed node, is WITHOUT ROWID so the primary
+// key index is the table, and counting it avoids making the vtable resolve
+// every document. One row per document is the invariant the delete path
+// maintains, so this is the corpus size.
+func (s *Store) SymbolFTSCount() (int, error) {
+	var count int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM symbol_fts_rowid`).Scan(&count); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
 // symbolFTSBatchStats records the actual bounded SQL statements executed by
 // one incremental batch. It is returned by the internal implementation so
 // tests can enforce that statement count grows by chunks, never by symbols.

--- a/internal/indexer/incremental_batch.go
+++ b/internal/indexer/incremental_batch.go
@@ -725,9 +725,7 @@ func (idx *Indexer) commitStructuralIncrementalBatch(
 				continue
 			}
 			oldNodeIDs = append(oldNodeIDs, node.ID)
-			if node.Kind != graph.KindFile && node.Kind != graph.KindImport {
-				idx.search.Remove(node.ID)
-			}
+			idx.removeFromSearch(node)
 			if node.Kind == graph.KindFunction || node.Kind == graph.KindMethod {
 				oldFuncIDs = append(oldFuncIDs, node.ID)
 			}
@@ -1388,9 +1386,7 @@ func (idx *Indexer) evictDeletedFilesBatched(deleted []string, plan *DerivedInva
 					continue
 				}
 				nodeIDs = append(nodeIDs, node.ID)
-				if node.Kind != graph.KindFile && node.Kind != graph.KindImport {
-					idx.search.Remove(node.ID)
-				}
+				idx.removeFromSearch(node)
 			}
 			_ = i
 		}

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -723,6 +723,32 @@ func (idx *Indexer) shouldIndexForSearch(n *graph.Node) bool {
 	return true
 }
 
+// removeFromSearch drops a node from the symbol index, gated on the same
+// predicate that admits it. Every eviction path must go through this rather
+// than its own Kind check.
+//
+// The backend's Remove is an unconditional decrement with no membership set,
+// so evicting on a broader predicate than Add uses does not just miscount by
+// a constant: it subtracts the difference set on every reconcile of the same
+// file and never adds it back. KindLocal dominates that set — those bindings
+// are persisted only to satisfy dataflow FK constraints, so they are present
+// in the prior-node list of every Go file, while shouldIndexForSearch has
+// always refused to index them.
+//
+// Safe on nodes read back from the store: every input the predicate reads
+// (Kind, Language, Stub, Origin, data_class) is a persisted column, so it
+// evaluates the same on a stored node as on the freshly extracted one that
+// was admitted.
+func (idx *Indexer) removeFromSearch(n *graph.Node) {
+	if idx == nil || idx.search == nil || n == nil {
+		return
+	}
+	if !idx.shouldIndexForSearch(n) {
+		return
+	}
+	idx.search.Remove(n.ID)
+}
+
 // upgradeSearchToBleve constructs a Bleve backend from the current graph
 // and atomically swaps it in. Designed to run in a background goroutine
 // triggered by IndexCtx after the initial index completes. Does nothing
@@ -3806,9 +3832,7 @@ func (idx *Indexer) indexFile(
 	var oldFuncIDs []string
 	evictExisting := func() {
 		for _, n := range idx.graph.GetFileNodes(graphPath) {
-			if n.Kind != graph.KindFile && n.Kind != graph.KindImport {
-				idx.search.Remove(n.ID)
-			}
+			idx.removeFromSearch(n)
 			if n.Kind == graph.KindFunction || n.Kind == graph.KindMethod {
 				oldFuncIDs = append(oldFuncIDs, n.ID)
 			}
@@ -4355,9 +4379,7 @@ func (idx *Indexer) EvictFile(filePath string) (int, int) {
 	graphPath := idx.prefixPath(relPath)
 	// Remove from search index.
 	for _, n := range idx.graph.GetFileNodes(graphPath) {
-		if n.Kind != graph.KindFile && n.Kind != graph.KindImport {
-			idx.search.Remove(n.ID)
-		}
+		idx.removeFromSearch(n)
 	}
 	idx.restubIncomingRefs(graphPath)
 	idx.evictEnrichment(graphPath)

--- a/internal/indexer/search_count_symmetry_test.go
+++ b/internal/indexer/search_count_symmetry_test.go
@@ -1,0 +1,95 @@
+package indexer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/search"
+)
+
+// countingSearch records Add/Remove calls so a test can assert that a node
+// admitted by shouldIndexForSearch is the only kind ever removed. The real
+// backend's Remove is an unconditional decrement, so an eviction predicate
+// broader than the admit predicate silently corrupts its count.
+type countingSearch struct {
+	added   []string
+	removed []string
+}
+
+func (c *countingSearch) Add(id string, fields ...string)          { c.added = append(c.added, id) }
+func (c *countingSearch) Remove(id string)                         { c.removed = append(c.removed, id) }
+func (c *countingSearch) Search(string, int) []search.SearchResult { return nil }
+func (c *countingSearch) Count() int                               { return len(c.added) - len(c.removed) }
+func (c *countingSearch) SizeBytes() int                           { return 0 }
+func (c *countingSearch) Close()                                   {}
+
+func TestRemoveFromSearchOnlyEvictsWhatWouldBeIndexed(t *testing.T) {
+	spy := &countingSearch{}
+	idx := &Indexer{search: spy, config: config.IndexConfig{}}
+
+	// Kinds shouldIndexForSearch refuses. KindLocal is the important one:
+	// those bindings are persisted purely to satisfy dataflow FK
+	// constraints, so they appear in the prior-node set of every Go file
+	// and were being removed on every single reconcile.
+	rejected := []*graph.Node{
+		{ID: "f", Kind: graph.KindFile},
+		{ID: "i", Kind: graph.KindImport},
+		{ID: "l", Kind: graph.KindLocal},
+		{ID: "b", Kind: graph.KindBuiltin},
+	}
+	for _, n := range rejected {
+		require.False(t, idx.shouldIndexForSearch(n), "%s should not be indexable", n.ID)
+		idx.removeFromSearch(n)
+	}
+	require.Empty(t, spy.removed,
+		"a node the admit predicate rejects must never reach Remove — the backend decrements unconditionally")
+
+	admitted := &graph.Node{ID: "pkg/a.go::Fn", Kind: graph.KindFunction, Name: "Fn", Language: "go"}
+	require.True(t, idx.shouldIndexForSearch(admitted))
+	idx.removeFromSearch(admitted)
+	require.Equal(t, []string{"pkg/a.go::Fn"}, spy.removed)
+}
+
+// The count only stays honest if the two predicates agree. Simulating a
+// reconcile — evict the prior nodes, re-add the fresh ones — must be
+// count-neutral for an unchanged file.
+func TestReconcileOfUnchangedFileIsCountNeutral(t *testing.T) {
+	spy := &countingSearch{}
+	idx := &Indexer{search: spy, config: config.IndexConfig{}}
+
+	nodes := []*graph.Node{
+		{ID: "pkg/a.go", Kind: graph.KindFile},
+		{ID: "pkg/a.go::Fn", Kind: graph.KindFunction, Name: "Fn", Language: "go"},
+		{ID: "pkg/a.go::Fn::err", Kind: graph.KindLocal, Name: "err", Language: "go"},
+		{ID: "pkg/a.go::Fn::data", Kind: graph.KindLocal, Name: "data", Language: "go"},
+		{ID: "pkg/a.go::T", Kind: graph.KindType, Name: "T", Language: "go"},
+	}
+
+	// Admit pass — what the indexer would have added.
+	for _, n := range nodes {
+		if idx.shouldIndexForSearch(n) {
+			spy.Add(n.ID)
+		}
+	}
+	afterIndex := spy.Count()
+	require.Equal(t, 2, afterIndex, "only Fn and T are searchable")
+
+	// Ten reconciles of an unchanged file: evict prior, re-add fresh.
+	for range 10 {
+		for _, n := range nodes {
+			idx.removeFromSearch(n)
+		}
+		for _, n := range nodes {
+			if idx.shouldIndexForSearch(n) {
+				spy.Add(n.ID)
+			}
+		}
+	}
+
+	require.Equal(t, afterIndex, spy.Count(),
+		"re-indexing an unchanged file must not move the count; a broader evict predicate drains it by the difference set each pass")
+	require.GreaterOrEqual(t, spy.Count(), 0, "a document count must never go negative")
+}

--- a/internal/search/symbolsearcher_backend.go
+++ b/internal/search/symbolsearcher_backend.go
@@ -154,6 +154,28 @@ func (b *SymbolSearcherBackend) Count() int {
 	return int(b.count.Load())
 }
 
+// DocCount returns the authoritative number of indexed documents, straight
+// from the underlying index, and reports whether it could be obtained.
+//
+// Count() must not be used for this: it is a delta of the indexer's Add and
+// Remove calls since construction, so it is not a corpus size and can be
+// negative. Anything user-facing asks here and omits the figure when the
+// answer is unavailable, rather than printing the delta.
+func (b *SymbolSearcherBackend) DocCount() (int, bool) {
+	if b == nil || b.s == nil {
+		return 0, false
+	}
+	counter, ok := b.s.(graph.SymbolFTSCounter)
+	if !ok {
+		return 0, false
+	}
+	count, err := counter.SymbolFTSCount()
+	if err != nil || count < 0 {
+		return 0, false
+	}
+	return count, true
+}
+
 // Close is a no-op. The wrapped SymbolSearcher is owned by the
 // graph.Store; closing it from the search adapter would race the
 // indexer's own lifecycle.


### PR DESCRIPTION
## Symptom

```
search    sqlite-fts5  docs=-1690  disk-resident (indexed in the graph store)
```

Observed on a 20-repo daemon: **−233 → −306 → −1569 → −1690**, descending within a single boot (−121 over 27 minutes). It resets to 0 at each start and re-descends, so it is not persisted corruption.

Two independent defects, fixed in one commit each.

## 1. The evict predicate is broader than the admit predicate

`SymbolSearcherBackend.Remove` is an unconditional decrement — no membership set, no floor:

```go
func (b *SymbolSearcherBackend) Remove(id string) {
	if b == nil || id == "" { return }
	b.count.Add(-1)
}
```

Four eviction sites removed on an ad-hoc check while every add went through `shouldIndexForSearch`:

```go
// evict                                        // add
if node.Kind != graph.KindFile &&               if !idx.shouldIndexForSearch(node) {
   node.Kind != graph.KindImport {                  continue
    idx.search.Remove(node.ID)                  }
}
```

`shouldIndexForSearch` additionally rejects proxy nodes, `KindLocal`, `KindBuiltin`, content nodes, `KindDoc` without prose indexing, and configured `SkipSearch` pairs. So each reconcile of the *same file* subtracts the difference set and never adds it back. **`KindLocal` dominates** — those bindings exist only to satisfy dataflow FK constraints, so they are in the prior-node set of every Go file while never being indexed. Two of the four sites (`evictDeletedFilesBatched`, `EvictFile`) are pure-deletion paths with no paired add at all.

All four now route through one `removeFromSearch` helper so the predicates cannot drift apart again — the shape `file_delta.go` already used, and which does not leak. Safe on store-read nodes: every input the predicate reads (`Kind`, `Language`, `Stub`, `Origin`, `data_class`) is a persisted column.

## 2. A delta was being rendered as a count

The field's own doc comment already said what it is:

> `Count` returns the running **delta-since-construction** … **never as a load-bearing decision input**. The authoritative size lives in the disk FTS index.

…and `resolveSearchBackend` assigned it straight to `DocCount`, which the renderers print as `docs=%d`. Defect 1 made it negative; this made it visible.

The count now comes from the index — `SymbolFTSCounter`, an optional store capability matching the existing `SymbolFTSBatchUpserter` / `SymbolFTSRepoResetter` pattern, over the `symbol_fts_rowid` ownership sidecar (one row per indexed node, `WITHOUT ROWID` so the PK index *is* the table). When a backend cannot supply a real count the figure is **omitted** rather than filled in, so `DocCount` gains a `DocCountKnown` companion distinguishing "zero documents" from "cannot say". Both renderers honour it.

`Count()` is deliberately **not** floored at zero: flooring would have hidden this bug rather than surfaced it, and no caller treats it as authoritative.

## Verification

- `go build ./...`, `go vet`, `golangci-lint` — clean (0 issues)
- `go test -race ./internal/indexer/ ./internal/search/ ./internal/graph/store_sqlite/ ./cmd/gortex/` — pass (124s / 1s / 388s / 36s)
- **Negative control:** with the new tests in place and only the helper's predicate reverted to the old broad check, both regression tests fail with the intended messages ("a node the admit predicate rejects must never reach Remove", "re-indexing an unchanged file must not move the count"). Red-green confirmed, not just green.

## Test changes worth a reviewer's eye

`TestResolveSearchBackend_SymbolSearcherBackend` asserted `DocCount == 2` with the comment *"DocCount should come from the adapter's Count()"* — that assertion encoded the defect, so it is inverted rather than adjusted, and a companion case now pins that the figure comes from the index even while the adapter's delta is negative. The other two changes are struct literals that need the new `DocCountKnown` field; no production site constructs `SearchBackendStats` literally, so nothing silently loses a count.

Independent of #340 and #343 — touches different files.