### PR TITLE
fix(indexer): bound the per-repo trigram searcher cache

### DIFF
--- a/internal/indexer/grep.go
+++ b/internal/indexer/grep.go
@@ -31,6 +31,12 @@ func (idx *Indexer) GrepText(query string, limit int) []trigram.Match {
 func (idx *Indexer) warmTrigramSearcher() *trigram.Searcher {
 	gen := idx.indexGen.Load()
 
+	// Announce the use before taking trigramMu: touch may evict OTHER
+	// repos' searchers, and each eviction takes that repo's trigramMu.
+	// Doing it here keeps this goroutine holding at most one trigramMu at
+	// a time, so two repos warming concurrently cannot deadlock.
+	defer idx.trigramBudget().touch(idx, idx.releaseTrigramSearcher)
+
 	idx.trigramMu.Lock()
 	defer idx.trigramMu.Unlock()
 	if idx.trigramSearcher != nil && idx.trigramGen == gen {
@@ -53,6 +59,30 @@ func (idx *Indexer) warmTrigramSearcher() *trigram.Searcher {
 	idx.trigramSearcher = trigram.Build(root, rels)
 	idx.trigramGen = gen
 	return idx.trigramSearcher
+}
+
+// trigramBudget returns the budget this Indexer participates in, defaulting
+// to the process-wide one so an Indexer built without wiring is still bounded.
+func (idx *Indexer) trigramBudget() *trigramBudget {
+	if idx.trigramBudgetOverride != nil {
+		return idx.trigramBudgetOverride
+	}
+	return processTrigramBudget
+}
+
+// releaseTrigramSearcher drops this repo's built trigram index. Called by the
+// budget when the repo has gone idle or has been pushed out by more recently
+// used repos. Safe to call when nothing is built; the next search rebuilds
+// from disk, which costs latency but never correctness — the searcher is only
+// a candidate filter over files Grep re-reads anyway.
+func (idx *Indexer) releaseTrigramSearcher() {
+	if idx == nil {
+		return
+	}
+	idx.trigramMu.Lock()
+	idx.trigramSearcher = nil
+	idx.trigramGen = 0
+	idx.trigramMu.Unlock()
 }
 
 // GrepRegexp runs a trigram-accelerated regular-expression search for

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -191,6 +191,9 @@ type Indexer struct {
 	trigramSearcher *trigram.Searcher
 	trigramGen      uint64
 	trigramMu       sync.Mutex
+	// trigramBudgetOverride scopes the idle/LRU eviction budget to one
+	// test rather than the process-wide default. Nil in production.
+	trigramBudgetOverride *trigramBudget
 
 	// repoPrefix is set in multi-repo mode to prefix all file paths and node IDs.
 	// When empty, the indexer operates in single-repo mode (backward compatible).

--- a/internal/indexer/trigram_budget.go
+++ b/internal/indexer/trigram_budget.go
@@ -1,0 +1,176 @@
+package indexer
+
+import (
+	"os"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// The trigram searcher is a lazily-built, in-memory inverted index over the
+// FULL TEXT of every indexed file in one repo. It is built on the first
+// text/regex search in that repo and, before this budget existed, was then
+// held for the daemon's lifetime with no ceiling — and one exists per repo,
+// so a daemon tracking twenty repos could accumulate twenty of them by doing
+// nothing more than one text search in each. Measured on a live daemon a
+// single repo's index retained ~190 MB and its build spiked the process
+// footprint past 2.6 GB.
+//
+// It is a cache: every entry is reconstructible from files on disk, and the
+// searcher is only a candidate filter — Grep re-reads and scans the files it
+// selects, so a cold rebuild costs latency, never correctness. Caches in a
+// long-lived process need a ceiling, so this bounds them two ways: drop what
+// has gone unused for a while, and never hold more than a few at once.
+const (
+	// defaultTrigramIdleTTL is how long an unused searcher is kept. A repo
+	// being actively grepped re-touches its entry on every query, so the TTL
+	// only reclaims repos that have gone quiet.
+	defaultTrigramIdleTTL = 10 * time.Minute
+	// defaultTrigramMaxLive caps how many repos may hold a built searcher at
+	// once, which is what actually bounds the worst case: without it, N repos
+	// searched inside one TTL window still means N live indexes.
+	defaultTrigramMaxLive = 3
+)
+
+// trigramBudget tracks which repos currently hold a built trigram searcher
+// and evicts by idle time and by count. It stores release callbacks rather
+// than the searchers themselves so the owning Indexer keeps sole ownership
+// of its field and its own mutex discipline.
+type trigramBudget struct {
+	mu      sync.Mutex
+	ttl     time.Duration
+	maxLive int
+	entries map[*Indexer]*trigramEntry
+	now     func() time.Time // swappable in tests
+}
+
+type trigramEntry struct {
+	lastUsed time.Time
+	release  func()
+}
+
+var processTrigramBudget = newTrigramBudget(trigramIdleTTLFromEnv(), trigramMaxLiveFromEnv())
+
+func newTrigramBudget(ttl time.Duration, maxLive int) *trigramBudget {
+	if ttl <= 0 {
+		ttl = defaultTrigramIdleTTL
+	}
+	if maxLive <= 0 {
+		maxLive = defaultTrigramMaxLive
+	}
+	return &trigramBudget{
+		ttl:     ttl,
+		maxLive: maxLive,
+		entries: make(map[*Indexer]*trigramEntry),
+		now:     time.Now,
+	}
+}
+
+// touch records that owner's searcher is live and just used, then evicts
+// everything that has aged out and, if still over the cap, the
+// least-recently-used entries until it fits.
+//
+// Release callbacks run after the budget's own lock is dropped: each one
+// takes its Indexer's trigramMu, and holding both locks in one order here
+// while a concurrent warm path takes them in the other order would be a
+// deadlock waiting for load.
+func (b *trigramBudget) touch(owner *Indexer, release func()) {
+	if b == nil || owner == nil {
+		return
+	}
+	var evictions []func()
+
+	b.mu.Lock()
+	now := b.now()
+	if entry, ok := b.entries[owner]; ok {
+		entry.lastUsed = now
+		if release != nil {
+			entry.release = release
+		}
+	} else if release != nil {
+		b.entries[owner] = &trigramEntry{lastUsed: now, release: release}
+	}
+
+	for other, entry := range b.entries {
+		if other == owner {
+			continue
+		}
+		if now.Sub(entry.lastUsed) >= b.ttl {
+			evictions = append(evictions, entry.release)
+			delete(b.entries, other)
+		}
+	}
+
+	for len(b.entries) > b.maxLive {
+		var oldest *Indexer
+		var oldestAt time.Time
+		for other, entry := range b.entries {
+			if other == owner {
+				// The caller is about to use this one; evicting it would
+				// discard the build that is being paid for right now.
+				continue
+			}
+			if oldest == nil || entry.lastUsed.Before(oldestAt) {
+				oldest, oldestAt = other, entry.lastUsed
+			}
+		}
+		if oldest == nil {
+			break
+		}
+		evictions = append(evictions, b.entries[oldest].release)
+		delete(b.entries, oldest)
+	}
+	b.mu.Unlock()
+
+	for _, release := range evictions {
+		if release != nil {
+			release()
+		}
+	}
+}
+
+// forget drops an owner without running its release callback. For an Indexer
+// that is discarding its searcher itself (a repo untrack, say), so the budget
+// does not later call back into a dead owner.
+func (b *trigramBudget) forget(owner *Indexer) {
+	if b == nil || owner == nil {
+		return
+	}
+	b.mu.Lock()
+	delete(b.entries, owner)
+	b.mu.Unlock()
+}
+
+// live reports how many owners currently hold a built searcher.
+func (b *trigramBudget) live() int {
+	if b == nil {
+		return 0
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.entries)
+}
+
+func trigramIdleTTLFromEnv() time.Duration {
+	raw := os.Getenv("GORTEX_TRIGRAM_IDLE_TTL")
+	if raw == "" {
+		return defaultTrigramIdleTTL
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		return defaultTrigramIdleTTL
+	}
+	return d
+}
+
+func trigramMaxLiveFromEnv() int {
+	raw := os.Getenv("GORTEX_TRIGRAM_MAX_LIVE")
+	if raw == "" {
+		return defaultTrigramMaxLive
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return defaultTrigramMaxLive
+	}
+	return n
+}

--- a/internal/indexer/trigram_budget_test.go
+++ b/internal/indexer/trigram_budget_test.go
@@ -1,0 +1,157 @@
+package indexer
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The trigram searcher is a full-text in-memory index built per repo and
+// previously never released. These pin the two ceilings: idle entries are
+// dropped, and no more than maxLive repos hold one at once.
+
+func newTestTrigramBudget(ttl time.Duration, maxLive int, clock *time.Time) *trigramBudget {
+	b := newTrigramBudget(ttl, maxLive)
+	b.now = func() time.Time { return *clock }
+	return b
+}
+
+func TestTrigramBudgetEvictsIdleOwners(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	b := newTestTrigramBudget(time.Minute, 10, &now)
+
+	idle, active := &Indexer{}, &Indexer{}
+	var released []string
+	b.touch(idle, func() { released = append(released, "idle") })
+	b.touch(active, func() { released = append(released, "active") })
+	require.Equal(t, 2, b.live())
+
+	// Only `active` keeps being used; `idle` ages past the TTL.
+	now = now.Add(90 * time.Second)
+	b.touch(active, func() { released = append(released, "active") })
+
+	require.Equal(t, []string{"idle"}, released, "the idle repo's index must be dropped")
+	require.Equal(t, 1, b.live())
+}
+
+func TestTrigramBudgetCapsLiveOwners(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	// A generous TTL so only the count ceiling can be doing the work here.
+	b := newTestTrigramBudget(time.Hour, 2, &now)
+
+	first, second, third := &Indexer{}, &Indexer{}, &Indexer{}
+	var released []string
+	b.touch(first, func() { released = append(released, "first") })
+	now = now.Add(time.Second)
+	b.touch(second, func() { released = append(released, "second") })
+	now = now.Add(time.Second)
+	b.touch(third, func() { released = append(released, "third") })
+
+	require.Equal(t, []string{"first"}, released,
+		"over the cap, the least recently used repo is evicted")
+	require.Equal(t, 2, b.live())
+}
+
+func TestTrigramBudgetNeverEvictsTheCallerBeingWarmed(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	b := newTestTrigramBudget(time.Nanosecond, 1, &now)
+
+	warming := &Indexer{}
+	var releasedSelf bool
+	b.touch(warming, func() { releasedSelf = true })
+	now = now.Add(time.Hour)
+	// Even with everything aged out and a cap of one, the repo whose search
+	// is being served right now must keep the index it just paid to build.
+	b.touch(warming, func() { releasedSelf = true })
+
+	require.False(t, releasedSelf, "the caller's own index must survive its own touch")
+	require.Equal(t, 1, b.live())
+}
+
+func TestTrigramBudgetForgetDoesNotCallBack(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	b := newTestTrigramBudget(time.Minute, 10, &now)
+
+	owner, other := &Indexer{}, &Indexer{}
+	var released bool
+	b.touch(owner, func() { released = true })
+	b.forget(owner)
+	require.Zero(t, b.live())
+
+	// Ageing everything out must not reach the forgotten owner.
+	now = now.Add(time.Hour)
+	b.touch(other, func() {})
+	require.False(t, released, "a forgotten owner must never have its release invoked")
+}
+
+// Release callbacks take the owning Indexer's trigramMu, so the budget must
+// not hold its own lock while running them. Under -race a re-entrant call
+// would deadlock rather than fail an assertion.
+func TestTrigramBudgetRunsReleaseOutsideItsLock(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	b := newTestTrigramBudget(time.Nanosecond, 1, &now)
+
+	stale, fresh := &Indexer{}, &Indexer{}
+	b.touch(stale, func() {
+		// Re-entering the budget from a release callback must not deadlock.
+		b.live()
+	})
+	now = now.Add(time.Hour)
+
+	done := make(chan struct{})
+	var once sync.Once
+	go func() {
+		b.touch(fresh, func() {})
+		once.Do(func() { close(done) })
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("touch deadlocked: release ran while the budget lock was held")
+	}
+}
+
+func TestReleaseTrigramSearcherIsSafeWhenNothingBuilt(t *testing.T) {
+	idx := &Indexer{}
+	require.NotPanics(t, idx.releaseTrigramSearcher)
+	require.Nil(t, idx.trigramSearcher)
+	require.Zero(t, idx.trigramGen, "a released searcher must not keep a generation that would look warm")
+}
+
+// End-to-end over the real warm path: building a searcher in one repo must
+// evict another repo's, so the number of live full-text indexes stays capped
+// no matter how many repos get searched.
+func TestWarmTrigramSearcherEvictsOtherReposOverCap(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	budget := newTestTrigramBudget(time.Hour, 1, &now)
+
+	newRepo := func(name string) *Indexer {
+		dir := t.TempDir()
+		writeTestFile(t, dir+"/main.go", "package main\n\nfunc "+name+"() int { return 0 }\n")
+		return &Indexer{
+			rootPath:              dir,
+			fileMtimes:            map[string]int64{"main.go": 1},
+			trigramBudgetOverride: budget,
+		}
+	}
+
+	first, second := newRepo("First"), newRepo("Second")
+
+	require.NotNil(t, first.warmTrigramSearcher())
+	require.NotNil(t, first.trigramSearcher, "the repo just searched holds its index")
+
+	now = now.Add(time.Second)
+	require.NotNil(t, second.warmTrigramSearcher())
+
+	require.NotNil(t, second.trigramSearcher, "the repo just searched holds its index")
+	require.Nil(t, first.trigramSearcher,
+		"over the cap, an earlier repo's full-text index must be released")
+	require.Equal(t, 1, budget.live())
+
+	// Evicted is not broken: the next search in that repo rebuilds it.
+	now = now.Add(time.Second)
+	require.NotNil(t, first.warmTrigramSearcher())
+	require.NotNil(t, first.trigramSearcher, "an evicted repo rebuilds on its next search")
+}


### PR DESCRIPTION
## Problem

`warmTrigramSearcher` builds an in-memory inverted index over the **full text of every indexed file** in a repo, on the first text or regex search. It was then held for the daemon's lifetime — no TTL, no cap, no release path. And there is **one per repo** (`MultiIndexer.indexers` is `repoPrefix → *Indexer`, and `trigramSearcher` is an `Indexer` field), so a daemon tracking 20 repos could accumulate 20 of them by doing nothing more than one text search in each.

Measured on a live 20-repo daemon, from a heap profile taken with `?gc=1`:

| | |
|---|---|
| `trigram.(*Index).Add` | 140.16 MB flat / **164.45 MB cum** |
| `trigram.trigrams` | 24.28 MB |
| Process footprint before the build | 288 MB |
| Peak during the build | **2622 MB** |

The spike is `trigram.Build` reading every indexed file's content off disk in a single pass:

```go
for i, rel := range relPaths {
    content, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(rel)))
    s.ix.Add(uint32(i), content)
}
```

## Why bounding it is safe

Nothing about this index needs to be permanent. Every entry is reconstructible from files on disk, and the searcher is only a **candidate filter** — `Grep` uses it to pick which files to open, then re-reads and scans each one:

```go
for _, docID := range s.ix.Candidates(query) {
    f, err := os.Open(...)
    scanner := bufio.NewScanner(f)
```

So eviction costs rebuild latency, never correctness or completeness.

## Change

Two ceilings, because either alone leaves a hole:

- **Idle TTL** (default 10m) — a repo being actively grepped re-touches its entry on every query, so this only reclaims repos that have gone quiet. Alone, it still permits N live indexes if N repos are searched inside one window.
- **Live cap** (default 3) — this is what actually bounds the worst case. Alone, it would keep three indexes alive forever on a daemon that has gone idle.

Tunable via `GORTEX_TRIGRAM_IDLE_TTL` / `GORTEX_TRIGRAM_MAX_LIVE`, mirroring the existing process-wide `shadowAdmissionBudget` idiom.

### Concurrency

The budget stores **release callbacks**, not searchers, so each `Indexer` keeps sole ownership of its field and its own mutex discipline. Two ordering rules matter, and both have tests:

1. Callbacks run **after** the budget's lock is dropped.
2. The warm path announces its use **before** taking its own `trigramMu`.

An eviction takes the *evicted* repo's `trigramMu`; holding both in one order here while a concurrent warm path takes them in the other is a deadlock. `TestTrigramBudgetRunsReleaseOutsideItsLock` fails by timeout rather than assertion if rule 1 regresses.

The repo whose search is being served is never evicted by its own `touch` — it just paid to build that index.

## Verification

- `go build ./...`, `go vet`, `golangci-lint` — clean (0 issues)
- `go test -race ./internal/indexer/` — full suite pass (127s)
- **Negative control:** with the tests in place and only the budget call removed from the warm path, `TestWarmTrigramSearcherEvictsOtherReposOverCap` fails with *"over the cap, an earlier repo's full-text index must be released"*. Red-green confirmed.

Tests cover idle eviction, the LRU cap, self-eviction immunity, `forget` not invoking callbacks, the lock-ordering rule, and an end-to-end pass over the real `warmTrigramSearcher` that also asserts an evicted repo **rebuilds** on its next search.

## Follow-up (not in this PR)

SQLite FTS5 ships a built-in `trigram` tokenizer, and I verified it works on the exact driver the store already uses (`modernc.org/sqlite v1.54.0`) — including a genuine mid-word substring `MATCH`. So this index could live beside the existing `symbol_fts` and `content_fts` tables instead of on the heap, removing it entirely and surviving restarts. That needs a size-on-disk and candidate-latency benchmark before it is worth proposing; this PR bounds the worst case today without schema work.