### PR TITLE
fix(mcp): keep source-literal recall assertions off the wall clock

### DIFF
--- a/internal/mcp/explore_source_literal.go
+++ b/internal/mcp/explore_source_literal.go
@@ -24,6 +24,17 @@ const (
 	exploreSourceLiteralRecallMaxFilesPerTerm  = 2
 )
 
+// sourceLiteralRecallBudget is the wall-clock slice one anchor of the bounded
+// source-literal recall may spend. Everything the recall reports — which
+// owners it mapped, and the reason it stopped — is a function of this slice,
+// so tests pin it rather than racing the default against a loaded machine.
+func (s *Server) sourceLiteralRecallBudget() time.Duration {
+	if s != nil && s.sourceLiteralRecallBudgetOverride > 0 {
+		return s.sourceLiteralRecallBudgetOverride
+	}
+	return exploreSourceLiteralRecallBudget
+}
+
 type exploreSourceLiteralHit struct {
 	nodeID    string
 	rank      int
@@ -228,8 +239,9 @@ func (s *Server) gatherExploreSourceLiteralRecall(
 		return exploreSourceLiteralRecall{}
 	}
 
+	recallBudget := s.sourceLiteralRecallBudget()
 	started := time.Now()
-	boundedCtx, cancelBounded := context.WithTimeout(ctx, 2*exploreSourceLiteralRecallBudget)
+	boundedCtx, cancelBounded := context.WithTimeout(ctx, 2*recallBudget)
 	defer cancelBounded()
 	type literalAttempt struct {
 		term       string
@@ -245,7 +257,7 @@ func (s *Server) gatherExploreSourceLiteralRecall(
 		}
 		attemptCtx, cancelAttempt := context.WithTimeout(boundedCtx, budget)
 		defer cancelAttempt()
-		searchBudget := exploreSourceLiteralRecallBudget
+		searchBudget := recallBudget
 		if budget < searchBudget {
 			searchBudget = budget
 		}
@@ -308,9 +320,9 @@ func (s *Server) gatherExploreSourceLiteralRecall(
 		return result
 	}
 
-	attemptBudget := 2 * exploreSourceLiteralRecallBudget
+	attemptBudget := 2 * recallBudget
 	if len(attemptTerms) > 1 {
-		attemptBudget = exploreSourceLiteralRecallBudget
+		attemptBudget = recallBudget
 	}
 	for index, term := range attemptTerms {
 		if boundedCtx.Err() != nil {
@@ -325,7 +337,7 @@ func (s *Server) gatherExploreSourceLiteralRecall(
 		primary := results[0]
 		if fallback := exploreSourceLiteralFallback(terms, primary.term); fallback != "" &&
 			(len(primary.recall.hits) == 0 || primary.recall.ambiguous || primary.search.incomplete) {
-			run(fallback, 1, exploreSourceLiteralRecallBudget)
+			run(fallback, 1, recallBudget)
 		}
 	}
 	for _, term := range terms {
@@ -421,7 +433,7 @@ func (s *Server) mapDiscoveredExploreSourceLiteralMatches(
 	scope query.QueryOptions,
 	discoveryErr error,
 ) (exploreSourceLiteralRecall, error) {
-	mappingCtx, cancelMapping := context.WithTimeout(ctx, exploreSourceLiteralRecallBudget)
+	mappingCtx, cancelMapping := context.WithTimeout(ctx, s.sourceLiteralRecallBudget())
 	recall := s.mapExploreSourceLiteralMatchesContext(mappingCtx, term, search.matches, scope)
 	mappingErr := mappingCtx.Err()
 	cancelMapping()

--- a/internal/mcp/explore_source_literal_test.go
+++ b/internal/mcp/explore_source_literal_test.go
@@ -91,6 +91,21 @@ func newExploreSourceLiteralServer(t testing.TB, nodes []*graph.Node) *Server {
 	return &Server{graph: store}
 }
 
+// pinExploreSourceLiteralRecallBudget takes the bounded source-literal recall
+// off the wall clock. In production the recall gets a 75ms slice per anchor
+// and reports a deadline when it runs out, which is the right trade for a
+// best-effort fallback. Mapping a two-file fixture costs single-digit
+// milliseconds, but a loaded CI runner can deschedule it past that slice, and
+// a test asserting which owners were mapped then fails against a recall that
+// behaved correctly. Tests that assert what the recall finds pin a slice they
+// cannot miss; the ones that assert what it does when the slice runs out —
+// TestGatherExploreSourceLiteralRecallBoundsMappingByRequestDeadline — keep
+// the production default.
+func pinExploreSourceLiteralRecallBudget(s *Server) *Server {
+	s.sourceLiteralRecallBudgetOverride = 30 * time.Second
+	return s
+}
+
 func newExploreSourceLiteralGraphServer(
 	t testing.TB,
 	nodes []*graph.Node,
@@ -595,7 +610,9 @@ func TestGatherExploreSourceLiteralRecallAggregatesCompactAnchorsAcrossLanguages
 			second.Language = fixture.language
 			store.AddBatch([]*graph.Node{first, second}, nil)
 			counting := &exploreSourceLiteralCountingStore{Store: store}
-			server := &Server{graph: counting, indexer: idx, logger: zap.NewNop()}
+			server := pinExploreSourceLiteralRecallBudget(
+				&Server{graph: counting, indexer: idx, logger: zap.NewNop()},
+			)
 
 			recall := server.gatherExploreSourceLiteralRecall(
 				context.Background(), []string{"aa", "bb"}, "", query.QueryOptions{},
@@ -691,17 +708,20 @@ func TestGatherExploreSourceLiteralRecallKeepsMultiAnchorOwnerUnderNearCapCompet
 	idx.SetFileMtimes(map[string]int64{competitorRel: 1, targetRel: 1})
 	store.AddBatch(nodes, nil)
 	counting := &exploreSourceLiteralCountingStore{Store: store}
-	server := &Server{graph: counting, indexer: idx, logger: zap.NewNop()}
+	// What this test pins down is the retention rule — a second-file owner
+	// must survive an anchor page crowded with same-file competitors — so
+	// take it off the wall clock.
+	server := pinExploreSourceLiteralRecallBudget(
+		&Server{graph: counting, indexer: idx, logger: zap.NewNop()},
+	)
 	scope := query.QueryOptions{RepoAllow: map[string]bool{"demo": true}}
 
-	started := time.Now()
 	recall := server.gatherExploreSourceLiteralRecall(context.Background(), []string{"pl", "ku"}, "", scope)
-	require.Less(t, time.Since(started), 500*time.Millisecond, "near-cap two-anchor recall must honor the shared deadline")
 	require.Len(t, recall.diagnostics, 2)
 	for _, diagnostic := range recall.diagnostics {
 		// Bounded grep collapses repeated lines to one hit per file. The large
 		// competitor body still exercises production parsing and both per-anchor
-		// deadlines without multiplying retained owners.
+		// mapping passes without multiplying retained owners.
 		require.Equal(t, 2, diagnostic.rawHits)
 		require.Equal(t, 2, diagnostic.mappedOwners)
 		require.Equal(t, 2, diagnostic.retainedOwners)
@@ -738,7 +758,8 @@ func TestGatherExploreSourceLiteralRecallKeepsMultiAnchorOwnerUnderNearCapCompet
 }
 
 func TestGatherExploreSourceLiteralRecallRecordsTermCapDiagnostic(t *testing.T) {
-	server := &Server{logger: zap.NewNop()}
+	// "cc" must be reported as term_cap, not as a deadline the runner caused.
+	server := pinExploreSourceLiteralRecallBudget(&Server{logger: zap.NewNop()})
 	recall := server.gatherExploreSourceLiteralRecall(
 		context.Background(), []string{"aa", "bb", "cc"}, "demo", query.QueryOptions{},
 	)
@@ -771,7 +792,9 @@ func TestGatherExploreSourceLiteralRecallMapsParsedCSharpConstructor(t *testing.
 	require.NotEmpty(t, constructors)
 	require.NotEmpty(t, callees)
 	counting := &exploreSourceLiteralCountingStore{Store: store}
-	server := &Server{graph: counting, indexer: idx, logger: zap.NewNop()}
+	server := pinExploreSourceLiteralRecallBudget(
+		&Server{graph: counting, indexer: idx, logger: zap.NewNop()},
+	)
 
 	recall := server.gatherExploreSourceLiteralRecall(
 		context.Background(), []string{"ku"}, "", query.QueryOptions{},
@@ -792,7 +815,9 @@ func TestGatherExploreSourceLiteralRecallMapsParsedCSharpConstructor(t *testing.
 		"long parenthesized issue prose must use concept retrieval without losing its unique literal proof")
 	engine := query.NewEngine(counting)
 	engine.SetSearchProvider(idx.Search)
-	fullServer := NewServer(engine, counting, idx, nil, zap.NewNop(), nil)
+	fullServer := pinExploreSourceLiteralRecallBudget(
+		NewServer(engine, counting, idx, nil, zap.NewNop(), nil),
+	)
 	req := mcpgo.CallToolRequest{}
 	req.Params.Arguments = map[string]any{
 		"task": task, "localize": true, "max_symbols": 10,
@@ -884,7 +909,9 @@ func TestExploreCompactLiteralIgnoresTestMetadataAndPrefersSpecificProductionCal
 	_, err = idx.IndexCtx(context.Background(), root)
 	require.NoError(t, err)
 	counting := &exploreSourceLiteralCountingStore{Store: store}
-	server := &Server{graph: counting, indexer: idx, logger: zap.NewNop()}
+	server := pinExploreSourceLiteralRecallBudget(
+		&Server{graph: counting, indexer: idx, logger: zap.NewNop()},
+	)
 
 	task := `CultureNotFoundException for culture "ku" (Kurdish) thrown when code enumerates or references all supported cultures, e.g. in number-to-words or collection initialization; find where "ku" locale/culture is registered or iterated causing crash on platforms lacking that culture.`
 	testNodes := store.FindNodesByName("ToOrdinalWordsKurdish")
@@ -907,7 +934,9 @@ func TestExploreCompactLiteralIgnoresTestMetadataAndPrefersSpecificProductionCal
 
 	engine := query.NewEngine(counting)
 	engine.SetSearchProvider(idx.Search)
-	fullServer := NewServer(engine, counting, idx, nil, zap.NewNop(), nil)
+	fullServer := pinExploreSourceLiteralRecallBudget(
+		NewServer(engine, counting, idx, nil, zap.NewNop(), nil),
+	)
 	req := mcpgo.CallToolRequest{}
 	req.Params.Arguments = map[string]any{
 		"task": task, "localize": true, "max_symbols": 6,

--- a/internal/mcp/localization_evidence_policy_test.go
+++ b/internal/mcp/localization_evidence_policy_test.go
@@ -71,7 +71,9 @@ func TestLocalizationEvidencePolicyRejectsWeakFindLocaliserOwnerFromSQLiteCSharp
 	}
 	require.NotNil(t, owner)
 
-	server := &Server{graph: store, indexer: idx, logger: zap.NewNop()}
+	server := pinExploreSourceLiteralRecallBudget(
+		&Server{graph: store, indexer: idx, logger: zap.NewNop()},
+	)
 	recall := server.gatherExploreSourceLiteralRecall(
 		context.Background(), []string{"ku"}, "", query.QueryOptions{},
 	)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -447,6 +447,15 @@ type Server struct {
 	// USD estimate from a stubbed usage seam.
 	reviewPricingOverride *llm.ProviderPricing
 
+	// sourceLiteralRecallBudgetOverride replaces the per-anchor wall-clock
+	// slice the bounded source-literal recall may spend. Test-only:
+	// production leaves it zero and gets exploreSourceLiteralRecallBudget.
+	// A test that asserts which owners the recall maps widens the slice so
+	// the answer cannot depend on how loaded the machine is; the tests that
+	// assert deadline behaviour leave it zero. See
+	// pinExploreSourceLiteralRecallBudget.
+	sourceLiteralRecallBudgetOverride time.Duration
+
 	// critiqueLLMGenOverride substitutes the critique_review tool's LLM seam.
 	// Test-only: production leaves it nil and the handler builds the closure
 	// over llmService.Generate. A non-nil override stands in for the real


### PR DESCRIPTION
## What failed

`TestGatherExploreSourceLiteralRecallKeepsMultiAnchorOwnerUnderNearCapCompetitors` failed on `test (macos-latest, 1.26)`:

```
explore_source_literal_test.go:706
Error: Not equal:
       expected: 2
       actual  : 0
```

Line 706 is `require.Equal(t, 2, diagnostic.mappedOwners)`. The preceding `rawHits` assertion passed — the grep found both files and then nothing was mapped.

## Why

`gatherExploreSourceLiteralRecall` gives each anchor a 75ms wall-clock slice and maps the raw hits to owners inside it. Instrumenting the path shows the split: discovery costs ~0.1ms, mapping ~6ms. Both fit the slice with room to spare on an idle machine.

Under CPU oversubscription the mapping goroutine gets descheduled past the slice. `mapExploreSourceLiteralMatchesContext` then returns empty at its `ctx.Err()` guard, and the recall reports:

```
literal="ku" raw=2 mapped=0 retained=0 files=0 reason="mapping_deadline"
```

That is the recall behaving as designed — it is a best-effort fallback and `reason` exists to say why it gave up. The defect is in the test: it binds a retention invariant (a second-file owner must survive an anchor page crowded with same-file competitors) to a clock it does not control. Every sibling test that asserts mapped-owner counts or mapped-hit provenance carries the same exposure.

## The fix

`Server` gains a test-only `sourceLiteralRecallBudgetOverride`; the recall reads it through `sourceLiteralRecallBudget()` and falls back to `exploreSourceLiteralRecallBudget`. Production is unchanged — the field stays zero and the same 75ms constant is read.

Tests that assert *what the recall finds* widen the slice via `pinExploreSourceLiteralRecallBudget`. Tests that assert *what it does when the slice runs out* keep the production default, so `TestGatherExploreSourceLiteralRecallBoundsMappingByRequestDeadline` still covers the deadline path against its blocking store. The now-meaningless `require.Less(..., 500*time.Millisecond)` in the near-cap test is dropped rather than left to assert a pinned budget against itself.

## Verification

Reproduced against a `-race` binary under 3x CPU oversubscription:

| | before | after |
|---|---|---|
| near-cap test, 12 runs | 2 failures at line 706 | — |
| affected tests, 15 runs | — | 0 failures |

`go build ./...`, `go vet ./internal/mcp/` and `go test -race ./internal/mcp/` all pass.

## Separate finding, not addressed here

`TestHandleExplorePromotesDivergentDefaultOwnerFromSQLitePHPIndex` also flakes under the same oversubscription — 3/8 on `main` without any change from this PR, failing at both line 428 and line 415. Line 415 is a synchronous `promoteExploreDivergentDefaultOwner` call with no deadline in its path, so it is a different cause. It did not fail in the reported CI job. I have not diagnosed it and deliberately left it out rather than ship a speculative pin: an experimental budget pin there moved it 3/8 -> 4/8, i.e. no effect. Worth a separate issue.