### PR TITLE
fix(indexer): evict present-but-excluded files on reindex

### DIFF
--- a/internal/indexer/incremental_reindex_test.go
+++ b/internal/indexer/incremental_reindex_test.go
@@ -17,12 +17,11 @@ import (
 	"github.com/zzet/gortex/internal/graph"
 )
 
-// TestIncrementalReindex_PreservesExcludedFiles is the regression test for
-// the deletion-classification bug: a file that's tracked in fileMtimes but
-// absent from the discovery walk must NOT be purged unless it's truly gone
-// from disk. Otherwise an exclude-list change between passes silently
-// destroys legitimate graph state.
-func TestIncrementalReindex_PreservesExcludedFiles(t *testing.T) {
+// TestIncrementalReindex_EvictsExcludedFiles is the regression for #321:
+// when a previously-indexed file becomes excluded, IncrementalReindex must
+// purge its nodes even though the file still exists on disk. Otherwise
+// file_count drops while node_count/search keep serving orphans.
+func TestIncrementalReindex_EvictsExcludedFiles(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "keep.go"), `package main
 
@@ -40,18 +39,18 @@ func Dropped() {}
 	require.NotEmpty(t, g.FindNodesByName("Kept"))
 	require.NotEmpty(t, g.FindNodesByName("Dropped"))
 
-	// Mid-flight exclusion change: future discoveries will not visit
-	// drop.go, but it's still on disk. The old code would treat it as
-	// deleted and purge its nodes; the new code stats it and preserves.
+	// Mid-flight exclusion: drop.go remains on disk but must leave the graph.
 	idx.config.Exclude = append(append([]string{}, excludes.Builtin...), "drop.go")
 	idx.excludes = nil
 	idx.excludeOnce = sync.Once{}
 
-	_, err = idx.IncrementalReindex(dir)
+	res, err := idx.IncrementalReindex(dir)
 	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, 1, res.DeletedFileCount, "excluded-but-present file must count as deleted")
 
 	assert.NotEmpty(t, g.FindNodesByName("Kept"), "kept.go was not excluded; nodes must survive")
-	assert.NotEmpty(t, g.FindNodesByName("Dropped"), "drop.go was excluded but still on disk; nodes must be preserved")
+	assert.Empty(t, g.FindNodesByName("Dropped"), "drop.go is excluded; nodes must be evicted")
 }
 
 // TestIncrementalReindex_EvictsTrulyDeletedFiles is the control case: a

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -5509,6 +5509,10 @@ func (idx *Indexer) incrementalReindexPaths(
 			absPath := filepath.Join(absRoot, filepath.FromSlash(relPath))
 			_, statErr := os.Stat(absPath)
 			if statErr == nil {
+				// Present-but-excluded must be purged (same as full IncrementalReindex).
+				if idx.shouldExclude(absPath, absRoot, false) {
+					deletedFiles = append(deletedFiles, relPath)
+				}
 				continue
 			}
 			if errors.Is(statErr, os.ErrNotExist) {
@@ -5671,23 +5675,17 @@ func (idx *Indexer) IncrementalReindex(root string) (*IndexResult, error) {
 
 	// Detect deleted files. A file that's tracked in fileMtimes but
 	// absent from the current discovery walk is a candidate, but
-	// "absent from discovery" is not the same as "absent from disk":
+	// "absent from discovery" is not always "absent from disk":
 	//
-	//   - The exclude list (.gortex.yaml, builtin, workspace) may have
-	//     grown since the last index — every newly-excluded file would
-	//     be classified as deleted.
-	//   - A language extractor's Extensions() may have changed across
-	//     versions — files whose ext is no longer detected would be
-	//     classified as deleted.
+	//   - Newly excluded (user/config intent): treat as deleted so the
+	//     graph does not retain permanent orphans (#321).
+	//   - Language extractor Extensions() shrank: file still on disk and
+	//     not excluded — preserve graph state.
 	//   - WalkDir swallowed a transient error (EACCES, EIO, NFS hiccup,
-	//     ELOOP) — the file is unreachable this pass but still on disk.
+	//     ELOOP) — preserve on non-ENOENT stat failures.
 	//
-	// All three would purge legitimate graph state on every daemon
-	// restart. Stat the candidate first: only treat ENOENT/ENOTDIR as
-	// deletion; preserve on success (file exists, just not discovered)
-	// and on transient errors. The cost is one extra stat per
-	// previously-indexed-but-not-discovered file, which is bounded by
-	// the size of the exclusion delta.
+	// Stat the candidate: ENOENT => deleted; exists+excluded => deleted;
+	// exists+not-excluded => preserve; other errors => preserve.
 	idx.mtimeMu.RLock()
 	var candidates []string
 	for relPath := range idx.fileMtimes {
@@ -5702,8 +5700,15 @@ func (idx *Indexer) IncrementalReindex(root string) (*IndexResult, error) {
 		absPath := filepath.Join(absRoot, relPath)
 		_, err := os.Stat(absPath)
 		if err == nil {
-			// File exists on disk; it was excluded or its extension is
-			// no longer detected. Preserve.
+			// File still exists on disk but was not admitted by this walk.
+			// If the admission set now excludes it, treat it like a deletion
+			// so exclude-list refinements do not leave permanent orphans
+			// (file_count drops while node_count/search stay stale). See #321.
+			// If it is not excluded (e.g. extension no longer detected),
+			// preserve graph state.
+			if idx.shouldExclude(absPath, absRoot, false) {
+				deletedFiles = append(deletedFiles, relPath)
+			}
 			continue
 		}
 		if errors.Is(err, os.ErrNotExist) {


### PR DESCRIPTION
## Summary
Fixes #321.

When exclude patterns grow, the discovery walk correctly skips those paths (`file_count` drops), but `IncrementalReindex` only treated `ENOENT` as deletion. Present-but-excluded files kept their graph nodes/edges forever until `untrack` + `track`.

## Change
- If a previously indexed path is missing from the walk but still on disk **and** `shouldExclude` is true → treat as deleted and run the normal eviction path
- If it is on disk and **not** excluded (e.g. language extension set shrank) → still preserve
- Transient stat errors still preserve
- Same rule on scoped deletion detection
- Regression: `TestIncrementalReindex_EvictsExcludedFiles` (replaces the old preserve-excluded test that encoded the opposite policy)

## Test plan
- [ ] CI: `go test ./internal/indexer/ -run EvictsExcluded|EvictsTrulyDeleted`
- Local Go toolchain not available on the contributor machine for this session; logic mirrors existing deletion path after classification.

## Notes
This is a deliberate policy shift from "preserve all present-but-undiscovered files" to "exclude list is admission intent." Non-exclude undiscovered files remain preserved.