### PR TITLE
Link linux release binaries statically so they run on any distro

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,56 @@ jobs:
       - name: Test Windows agent integrations
         run: go test -timeout=5m -count=1 ./internal/agents
 
+  build-linux-static:
+    # The linux release ships a statically linked binary so it runs on any
+    # distro (see .goreleaser.yml). That only holds while the code stays
+    # link-clean under -static + netgo/osusergo — a new cgo dependency, or a
+    # dep that needs a runtime dlopen, breaks it. The release-time build hook
+    # catches that at tag time; this catches it on the PR that introduces it.
+    #
+    # ubuntu-latest is the same Ubuntu 24.04 / GCC 13 generation as the
+    # goreleaser-cross image, so it reproduces the same GLIBCXX floor the
+    # dynamic build used to inherit — without pulling that multi-GB image.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Build with the release link flags
+        env:
+          CGO_ENABLED: "1"
+        run: |
+          go build -tags netgo,osusergo,static_link \
+            -ldflags '-s -w -extldflags "-static"' \
+            -o gortex-static ./cmd/gortex/
+
+      - name: Verify the binary is self-contained
+        run: |
+          file gortex-static
+          sh scripts/verify-static-elf.sh gortex-static
+
+      # The static-only code path (custom grammars declining instead of
+      # dlopen'ing) is compiled out of every other job, so it needs its tests
+      # run under the tag or they never execute anywhere.
+      - name: Test the static-only code paths
+        run: go test -count=1 -tags netgo,osusergo,static_link ./internal/parser/languages/
+
+      - name: Run it where the dynamic build could not
+        # debian:11 (glibc 2.31 / GLIBCXX_3.4.28) is the userland that reported
+        # `GLIBCXX_3.4.32 not found`; alpine has no glibc at all. Exercise a
+        # command that resolves the user's home dir and touches the net stack,
+        # so a missing netgo/osusergo tag fails here rather than for a user.
+        run: |
+          set -euo pipefail
+          for img in debian:11 alpine:3; do
+            echo "== $img"
+            docker run --rm -v "$PWD/gortex-static:/gortex:ro" "$img" /gortex version
+            docker run --rm -v "$PWD/gortex-static:/gortex:ro" "$img" /gortex daemon status || true
+          done
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,6 +243,35 @@ jobs:
       - name: Reclaim ownership of dist/ from Docker
         run: sudo chown -R "$(id -u):$(id -g)" dist
 
+      # The goreleaser build hook already refused to archive a dynamically
+      # linked binary (scripts/verify-static-elf.sh). Re-assert it on the
+      # packaged artifacts, then prove it by execution on the exact userlands
+      # the dynamic build broke on: debian:11 is glibc 2.31 / GLIBCXX_3.4.28
+      # — the reported failure class — and alpine has no glibc at all. A
+      # correctly static binary runs unchanged on both. Only amd64 can execute
+      # on this runner; arm64 is covered by the ELF assertions.
+      - name: Verify linux binaries are self-contained
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          for tgz in dist/gortex_linux_*.tar.gz; do
+            workdir="$(mktemp -d)"
+            tar -xzf "$tgz" -C "$workdir" gortex
+            echo "== $(basename "$tgz")"
+            file "$workdir/gortex"
+            sh scripts/verify-static-elf.sh "$workdir/gortex"
+            rm -rf "$workdir"
+          done
+
+          workdir="$(mktemp -d)"
+          tar -xzf dist/gortex_linux_amd64.tar.gz -C "$workdir" gortex
+          chmod +x "$workdir/gortex"
+          for img in debian:11 alpine:3; do
+            echo "== runtime smoke on $img"
+            docker run --rm -v "$workdir/gortex:/gortex:ro" "$img" /gortex version
+          done
+          rm -rf "$workdir"
+
       # Now that goreleaser's --clean has run, fold the darwin tarballs in
       # alongside the linux ones so the notarize / cosign / checksum / upload
       # steps below treat all platforms uniformly.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,13 +23,51 @@ builds:
   - id: main
     main: ./cmd/gortex/
     binary: gortex
+    # A statically linked glibc cannot dlopen anything on a host whose glibc
+    # differs from the build host's — and it does not fail cleanly, it SEGVs
+    # inside the loader. These three tags remove every dlopen from the binary:
+    #   netgo      — resolver reads /etc/resolv.conf instead of getaddrinfo
+    #   osusergo   — user lookup reads /etc/passwd instead of getpwuid
+    #   static_link — custom tree-sitter grammars decline up front instead of
+    #                 crashing the daemon (internal/parser/languages)
+    # Without them -static would produce a binary that starts everywhere and
+    # then dies on first use.
+    tags:
+      - netgo
+      - osusergo
+      - static_link
     ldflags:
       # main.version + main.commit get parsed at startup into a SemVer 2.0.0
       # Version (see internal/version). Commit lands in the +build slot so
       # `gortex version` output round-trips as canonical semver.
       - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
+      # Link the C/C++ runtime in, the same way release.yml does for the
+      # windows .exe. The C++ stdlib is in the link at all because some
+      # tree-sitter grammars carry C++ external scanners; linking it
+      # dynamically stamped the binary with the goreleaser-cross image's
+      # GLIBCXX/GLIBC floor (Ubuntu 24.04, GCC 13.3 -> GLIBCXX_3.4.32 +
+      # GLIBC_2.34), so it refused to start on any older distro:
+      #
+      #   gortex: /lib/x86_64-linux-gnu/libstdc++.so.6:
+      #           version `GLIBCXX_3.4.32' not found (required by gortex)
+      #
+      # Debian 12 and Ubuntu 22.04 top out at GLIBCXX_3.4.30/3.4.29, so the
+      # dynamic build only ran on Ubuntu 24.04+/Debian 13+. Static linking
+      # removes the floor entirely and makes the README's "single static
+      # binary, no dependency chain" claim true on linux. The
+      # "Verify linux binaries are self-contained" step in release.yml is the
+      # gate that keeps it that way.
+      - -extldflags "-static"
     env:
       - CGO_ENABLED=1
+    hooks:
+      # Run per built binary, before anything is archived or published, so a
+      # link that quietly went dynamic again aborts the release instead of
+      # shipping. `goreleaser release` creates the GitHub release as part of
+      # the same run, so this has to be a build hook — a workflow step after
+      # it would only ever be a post-mortem.
+      post:
+        - cmd: sh scripts/verify-static-elf.sh "{{ .Path }}"
     goos:
       - linux
     goarch:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -97,6 +97,34 @@ xattr -d com.apple.quarantine /usr/local/bin/gortex
 gortex version
 ```
 
+## System requirements
+
+Every published binary is self-contained — there is no runtime dependency to
+install, and no minimum glibc or `libstdc++` version.
+
+| Platform | Requirement |
+|---|---|
+| Linux (amd64 / arm64) | Any kernel ≥ 3.7. Statically linked — runs unchanged on glibc distros of any vintage (Debian 11, Ubuntu 20.04, RHEL 8, Astra …) and on musl distros like Alpine. |
+| macOS (amd64 / arm64) | macOS 11+. Links only against system frameworks. |
+| Windows (amd64) | Windows 10+. The mingw C/C++ runtime is linked in, so no DLLs to ship. |
+
+Linux builds up to and including v0.61.4 were dynamically linked and so
+inherited the build host's `GLIBCXX`/`GLIBC` floor — on anything older than
+Ubuntu 24.04 / Debian 13 they failed at startup with:
+
+```
+gortex: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.32' not found
+```
+
+If you hit that, upgrade to a later release; no workaround is needed.
+
+**One caveat to the static linux build:** custom tree-sitter grammars
+(`index.grammars` in `.gortex.yaml`) load a shared object at runtime, which a
+static binary cannot do. Gortex logs a warning and skips those entries — the
+257 built-in grammars are unaffected. If you need a custom grammar on Linux,
+[build from source](#from-source); that build is dynamically linked and
+supports them.
+
 ## Verifying releases (supply-chain security)
 
 Every GitHub release is:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -902,6 +902,12 @@ type EventBusBoundarySpec struct {
 // grammar must be a compiled shared library (.so / .dylib / .dll)
 // exporting the standard tree-sitter `tree_sitter_<language>` entry
 // point, built against a compatible tree-sitter ABI.
+//
+// Loading one needs a runtime dynamic loader, so the statically linked
+// linux release binary declines and logs a warning per entry (see
+// internal/parser/languages/grammar_load_static.go); a source build is
+// dynamically linked and supports them. macOS and Windows releases are
+// unaffected.
 type GrammarSpec struct {
 	// Language is the name the extractor registers under. A name that
 	// collides with a built-in extractor is skipped — built-ins win.

--- a/internal/parser/languages/grammar_load_static.go
+++ b/internal/parser/languages/grammar_load_static.go
@@ -1,0 +1,31 @@
+//go:build !windows && static_link
+
+package languages
+
+import (
+	"errors"
+	"unsafe"
+)
+
+// errNoDlopen explains why a statically linked build cannot load a custom
+// grammar, and what to do about it. RegisterCustomGrammars logs this as a
+// warning and skips the grammar, so an unusable `grammars:` entry degrades to
+// "that one language isn't indexed" rather than taking the daemon down.
+var errNoDlopen = errors.New(
+	"custom tree-sitter grammars need dlopen, which the statically linked release binary does not have; " +
+		"build gortex from source (go build ./cmd/gortex/) to use them, or use one of the built-in grammars")
+
+// loadGrammarLanguage refuses to load a custom grammar in a static build.
+//
+// The linux release links -static so it runs on any distro (see
+// .goreleaser.yml). glibc's dlopen is the one thing that does not survive that:
+// it needs the shared libc that the binary was linked against to be present at
+// runtime, and when the host's glibc differs it does not fail cleanly — the
+// process SEGVs inside the loader. That would turn an opt-in config entry into
+// a daemon crash, so the static build declines up front instead. The dynamic
+// implementation is in grammar_load_unix.go and is what every source build
+// gets; windows is unaffected because it loads grammars through LoadDLL, an OS
+// API rather than a libc one.
+func loadGrammarLanguage(_, _ string) (unsafe.Pointer, error) {
+	return nil, errNoDlopen
+}

--- a/internal/parser/languages/grammar_load_static_test.go
+++ b/internal/parser/languages/grammar_load_static_test.go
@@ -1,0 +1,40 @@
+//go:build !windows && static_link
+
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/parser"
+)
+
+// The static build must DECLINE a custom grammar, not attempt the load. A
+// statically linked glibc SEGVs inside the loader when it dlopen's on a host
+// whose glibc differs from the build host's, so "returns an error" is the
+// invariant that keeps an opt-in config entry from taking the daemon down.
+func TestLoadGrammarLanguage_DeclinesInStaticBuild(t *testing.T) {
+	ptr, err := loadGrammarLanguage("/any/libtree-sitter-thing.so", "tree_sitter_thing")
+	require.Error(t, err)
+	assert.Nil(t, ptr)
+	assert.ErrorIs(t, err, errNoDlopen)
+	// The message has to tell the user what to do instead — this is the only
+	// place they learn the release binary can't load their grammar.
+	assert.Contains(t, err.Error(), "build gortex from source")
+}
+
+// End to end through the caller: a declared grammar is skipped with a warning
+// and never registered, exactly as a missing library already behaves.
+func TestRegisterCustomGrammars_SkippedInStaticBuild(t *testing.T) {
+	reg := parser.NewRegistry()
+	assert.NotPanics(t, func() {
+		RegisterCustomGrammars(reg, []config.GrammarSpec{
+			{Language: "fictional", Library: "/any/libtree-sitter-fictional.so", Extensions: []string{".fic"}},
+		}, nil)
+	})
+	_, ok := reg.GetByLanguage("fictional")
+	assert.False(t, ok)
+}

--- a/internal/parser/languages/grammar_load_unix.go
+++ b/internal/parser/languages/grammar_load_unix.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !static_link
 
 package languages
 

--- a/scripts/verify-static-elf.sh
+++ b/scripts/verify-static-elf.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+# Guard for the linux "not actually a static binary" regression.
+#
+# README promises a "single static binary ... no dependency chain", but the
+# linux builds linked libstdc++/libgcc/libc dynamically. That stamped them with
+# the goreleaser-cross image's symbol-version floor (Ubuntu 24.04, GCC 13.3 ->
+# GLIBCXX_3.4.32 and GLIBC_2.34), so the binary refused to even start anywhere
+# older:
+#
+#   gortex: /lib/x86_64-linux-gnu/libstdc++.so.6:
+#           version `GLIBCXX_3.4.32' not found (required by gortex)
+#
+# Debian 12 caps at GLIBCXX_3.4.30 and Ubuntu 22.04 at 3.4.29, so in practice
+# the release only ran on Ubuntu 24.04+/Debian 13+. libstdc++ is in the link at
+# all because some tree-sitter grammars ship C++ external scanners.
+#
+# .goreleaser.yml now links -static (with the netgo/osusergo tags so nothing
+# needs a runtime dlopen of libnss_*). This script is the gate that keeps it
+# that way: it runs as a goreleaser build post-hook, before any artifact is
+# archived or published, and in CI on every change.
+#
+# Usage: verify-static-elf.sh <elf-binary>
+set -eu
+
+bin="${1:?usage: verify-static-elf.sh <elf-binary>}"
+[ -f "$bin" ] || { echo "FATAL: $bin does not exist" >&2; exit 1; }
+
+# GNU readelf reads foreign-architecture ELF fine, so one host readelf covers
+# both the amd64 and the cross-linked arm64 binary. Never skip the check when
+# it is missing — silently skipping is exactly how the broken shape shipped.
+readelf=""
+for cand in readelf llvm-readelf eu-readelf; do
+	if command -v "$cand" >/dev/null 2>&1; then readelf="$cand"; break; fi
+done
+[ -n "$readelf" ] || { echo "FATAL: no readelf available to verify $bin" >&2; exit 1; }
+
+fail=0
+
+# 1. A statically linked binary has no DT_NEEDED entries at all.
+needed="$("$readelf" -d "$bin" 2>/dev/null | grep NEEDED || true)"
+if [ -n "$needed" ]; then
+	echo "FATAL: $bin links shared libraries — static link incomplete:" >&2
+	echo "$needed" >&2
+	fail=1
+fi
+
+# 2. ... and no PT_INTERP segment, i.e. no dynamic loader is invoked. A binary
+#    can lose its NEEDED entries and still be dynamically loaded.
+if "$readelf" -l "$bin" 2>/dev/null | grep -q INTERP; then
+	echo "FATAL: $bin has a PT_INTERP segment — it is not statically linked" >&2
+	fail=1
+fi
+
+# 3. ... and requires no versioned symbols. This is the check that maps
+#    directly to the reported failure: a partially static link can drop the
+#    NEEDED entry while still versioning symbols against the build host.
+vers="$("$readelf" -V "$bin" 2>/dev/null | grep -oE 'GLIBCXX_[0-9.]+|GLIBC_[0-9.]+|CXXABI_[0-9.]+' | sort -u || true)"
+if [ -n "$vers" ]; then
+	echo "FATAL: $bin carries symbol-version requirements (a distro floor):" >&2
+	echo "$vers" | sed 's/^/       /' >&2
+	fail=1
+fi
+
+[ "$fail" -eq 0 ] || exit 1
+
+echo "ok: $bin is statically linked (no NEEDED, no PT_INTERP, no glibc/libstdc++ floor)"


### PR DESCRIPTION
## The bug

`gortex_linux_amd64` is **dynamically linked**, despite the README promising a "single static binary … no dependency chain". Confirmed against the published v0.61.4 artifact:

```
NEEDED:  libc.so.6, libgcc_s.so.1, libstdc++.so.6
interp:  /lib64/ld-linux-x86-64.so.2
floors:  GLIBCXX_3.4.32 (GCC 13.2+)  ·  GLIBC_2.34
```

The release builds inside `goreleaser-cross:v1.26` = Ubuntu 24.04 / GCC 13.3, so binaries inherit that host's floor. Debian 12 caps at GLIBCXX_3.4.30 and Ubuntu 22.04 at 3.4.29 — meaning the linux release only ever ran on **Ubuntu 24.04+/Debian 13+**. Everyone else got a binary that never started:

```
gortex: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.32' not found (required by gortex)
```

libstdc++ is in the link at all because some tree-sitter grammars ship C++ external scanners. Windows already linked `-static`; only linux was left dynamic.

## The fix

Link linux `-static` with `netgo,osusergo,static_link`, matching what Windows already did.

**The non-obvious part.** In a statically linked glibc binary, `dlopen` does *not* fail cleanly on a host whose glibc differs from the build host's — it **SEGVs inside the loader**. Verified: a static binary built on glibc 2.39, run under glibc 2.31, crashes with exit 2. On the *same* glibc it works, so a naive test passes.

gortex `dlopen`s user-declared custom grammars, and `RegisterCustomGrammars` assumes `loadGrammarLanguage` returns an error and warn-skips. Plain `-static` would have converted an opt-in `index.grammars` entry into a **daemon crash**. The new `static_link` tag selects an implementation that declines up front with an actionable error. Windows is unaffected — it loads grammars via `LoadDLL`, an OS API rather than a libc one.

## Where the gate lives

`goreleaser release` builds **and publishes** in one run, so a verification step after it is only a post-mortem on an already-published artifact. `scripts/verify-static-elf.sh` therefore runs as a goreleaser `builds[].hooks.post`, before anything is archived. It asserts no `DT_NEEDED`, no `PT_INTERP`, and no symbol-version requirements.

A new `build-linux-static` CI job runs the same assertion on every change, so this fails on the PR rather than at tag time, and executes the result on debian:11 and alpine so a missing tag surfaces in CI instead of for a user.

## Verification

Built in the real release image (native arm64, 2m51s) → 287 MB binary, **0 NEEDED, 0 PT_INTERP, no symbol-version floor, 0 dlopen link warnings**.

Full daemon start → track → index cycle (Go + Python, 9 nodes / 13 edges) on:

| Userland | glibc | Result |
|---|---|---|
| debian:11 | 2.31 | works |
| ubuntu:22.04 | 2.35 | works |
| alpine:3 | musl (none) | works |

All three refuse to run the current release. `goreleaser check` and `actionlint` clean; languages package green both tagged (1858) and untagged (1856).

## Trade-off to review

Custom tree-sitter grammars (`index.grammars`) stop working on the official linux binary — warn-and-skip, with the 257 built-in grammars unaffected and source builds still supporting them. Documented in `docs/installation.md`.

The alternative was static-libstdc++-only, which fixes the reported error but leaves a `GLIBC_2.34` floor that still breaks Ubuntu 20.04, Debian 11, and RHEL 8. Full-static was chosen because it makes the README's claim true and matches the windows build.
