### PR TITLE
fix(mcp): answer a read operation named in the singular

### DIFF
--- a/internal/mcp/facade_operation_alias_test.go
+++ b/internal/mcp/facade_operation_alias_test.go
@@ -1,0 +1,47 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A caller that asks to read "symbol" can only have meant one symbol's source.
+// Refusing the singular costs it a whole turn — and a turn costs its entire
+// prompt again — to learn a plural.
+func TestReadingASymbolAcceptsTheSingularName(t *testing.T) {
+	for _, guess := range []string{"symbol", "symbol_source", "get_symbol_source"} {
+		require.Equal(t, "source", resolveFacadeOperationAlias("read", guess),
+			"read(operation:%q) must resolve to the one-symbol source operation", guess)
+	}
+}
+
+// The plural is a different operation, not a synonym: it serves the batch
+// handler. Aliasing must not quietly collapse the two.
+func TestTheBatchOperationKeepsItsOwnName(t *testing.T) {
+	require.Equal(t, "symbols", resolveFacadeOperationAlias("read", "symbols"))
+	require.NotEqual(t, resolveFacadeOperationAlias("read", "symbol"),
+		resolveFacadeOperationAlias("read", "symbols"),
+		"the singular and the batch form must stay distinct operations")
+}
+
+// Aliasing is scoped: a name that means something here must not be invented
+// for a facade that never defined it.
+func TestAliasesDoNotLeakAcrossFacades(t *testing.T) {
+	for _, facade := range []string{"search", "relations", "change", "explore", "analyze"} {
+		require.Equal(t, "symbol", resolveFacadeOperationAlias(facade, "symbol"),
+			"%s must keep rejecting an operation it never defined", facade)
+	}
+}
+
+// Real operation names pass through untouched, whatever the facade.
+func TestKnownOperationsAreUnchanged(t *testing.T) {
+	for facade, ops := range map[string][]string{
+		"read":      {"source", "file", "editing_context", "summary", "history", "artifact"},
+		"relations": {"usages", "callers", "dependents"},
+	} {
+		for _, op := range ops {
+			require.Equal(t, op, resolveFacadeOperationAlias(facade, op))
+		}
+	}
+}

--- a/internal/mcp/facade_registry.go
+++ b/internal/mcp/facade_registry.go
@@ -442,3 +442,28 @@ func normalizeFacadeOperation(value string) string {
 	value = strings.ReplaceAll(value, "-", "_")
 	return value
 }
+
+// facadeOperationAliases resolves the near-misses a caller can only have meant
+// one way. Refusing them is expensive out of proportion to the mistake: a
+// rejected operation costs a whole turn, and a turn costs the caller its entire
+// prompt again, so one guessed word is paid for in tens of thousands of tokens.
+//
+// Only unambiguous names belong here. `symbol` is the singular of the batch
+// form `symbols`, and one symbol's source is exactly `source` — a caller asking
+// to read "symbol" cannot have meant the batch handler.
+var facadeOperationAliases = map[string]map[string]string{
+	"read": {
+		"symbol":            "source",
+		"symbol_source":     "source",
+		"get_symbol_source": "source",
+	},
+}
+
+func resolveFacadeOperationAlias(facade, operation string) string {
+	if byFacade, exists := facadeOperationAliases[facade]; exists {
+		if target, aliased := byFacade[operation]; aliased {
+			return target
+		}
+	}
+	return operation
+}

--- a/internal/mcp/facade_tools.go
+++ b/internal/mcp/facade_tools.go
@@ -421,7 +421,7 @@ func (s *Server) handleFacade(ctx context.Context, facade string, req mcpgo.Call
 	started := time.Now()
 	input, _ := req.Params.Arguments.(map[string]any)
 	localizationAuthToken := localizationauth.TakeArgument(input)
-	operation := normalizeFacadeOperation(req.GetString("operation", ""))
+	operation := resolveFacadeOperationAlias(facade, normalizeFacadeOperation(req.GetString("operation", "")))
 	if facade == "analyze" {
 		operation = requestedAnalyzeKind(req.GetArguments())
 		if operation == "" {


### PR DESCRIPTION
## Summary

`read(operation:"symbol")` was refused with `invalid_argument` and a list of valid names. The caller then retried with `"symbols"` and succeeded.

That refusal is expensive out of proportion to the mistake. A rejected operation costs a whole turn, and a turn costs the caller its entire prompt again — measured on the localization suite, ~80% of a session's tokens are the conversation prefix being re-read once per turn. One guessed word is paid for in tens of thousands of tokens.

Resolve the singular to the one-symbol source operation, plus the legacy handler name a caller might reach for:

- `symbol` → `source`
- `symbol_source` → `source`
- `get_symbol_source` → `source`

## The singular and the plural are not synonyms

Worth stating explicitly, because the tempting one-line fix is wrong:

- `read.source` → `get_symbol_source` — one symbol
- `read.symbols` → `batch_symbols` — many

They look identical from a transcript only because the batch handler delegates when handed a single target. Aliasing `symbol` → `symbols` would quietly route every single-symbol read through the batch path. The caller's singular guess was the semantically correct one; the plural it fell back to was the batch form. A test pins that the two stay distinct operations.

## Scope

Aliases are per facade, so a name that means something for `read` is still refused by a facade that never defined it — `search(operation:"symbol")` continues to fail. A global table would invent operations for facades that never had them, and that is also pinned by a test.

## Validation

- `go test ./internal/mcp/` — green on current `main`
- `golangci-lint run ./internal/mcp/...` — 0 issues
- four fixtures: the singular resolves, the batch form keeps its own meaning, aliases do not leak across facades, and known operation names pass through untouched

## How this was found

Reading the p2 localization transcripts: of 27 `read` calls in the gortex arm, 24 were already symbol-scoped and one was this rejected singular followed by a successful retry. It is one wasted turn in 56 sessions — a cheap correctness fix, not a measurable token win on its own.
