### PR TITLE
indexer: report the repo's file count, not the last batch's

### DIFF
--- a/internal/indexer/incremental_reindex_paths_test.go
+++ b/internal/indexer/incremental_reindex_paths_test.go
@@ -1,6 +1,7 @@
 package indexer
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -117,8 +118,9 @@ func TestIncrementalReindexPaths_ScopesToSingleFile(t *testing.T) {
 	res, err := idx.IncrementalReindexPaths(dir, []string{filepath.Join(dir, "one.go")})
 	require.NoError(t, err)
 	assert.Equal(t, 1, res.StaleFileCount)
-	assert.Equal(t, 1, res.FileCount,
-		"FileCount for a single-file scope is the one in-scope file")
+	assert.Equal(t, 2, res.FileCount,
+		"FileCount describes the repo — both files — not the one-file scope; "+
+			"the scope size is StaleFileCount")
 	assert.NotEmpty(t, g.FindNodesByName("OneEdited"))
 	assert.Empty(t, g.FindNodesByName("TwoEdited"),
 		"the unscoped file must not be re-indexed")
@@ -232,4 +234,74 @@ func TestIncrementalReindexPaths_ConvergesForScopedFile(t *testing.T) {
 	assert.Len(t, gA.FindNodesByName("helper"), len(gB.FindNodesByName("helper")))
 	assert.NotEmpty(t, gA.FindNodesByName("Other"),
 		"a scoped reindex must leave the untouched file's nodes intact")
+}
+
+// TestIncrementalReindexPathsReportsRepoFileCountNotScopeSize pins the
+// documented contract on IndexResult.FileCount: it is how big the repo
+// is, not how much work the pass did. A scoped pass walks only the
+// caller's paths, so reporting the size of that walk here used to make
+// `daemon status` show an actively-edited repo's file count as the size
+// of its last changed-file batch.
+func TestIncrementalReindexPathsReportsRepoFileCountNotScopeSize(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "pkg"), 0o755))
+	const total = 10
+	for i := range total {
+		name := filepath.Join(dir, fmt.Sprintf("f%d.go", i))
+		if i >= total/2 {
+			name = filepath.Join(dir, "pkg", fmt.Sprintf("f%d.go", i))
+		}
+		writeFile(t, name, fmt.Sprintf("package main\n\nfunc F%d() {}\n", i))
+	}
+
+	g := graph.New()
+	idx := newTestIndexer(g)
+	full, err := idx.Index(dir)
+	require.NoError(t, err)
+	require.Equal(t, total, full.FileCount, "baseline: a full pass counts the repo")
+
+	// Scope the pass to exactly one changed file.
+	one := filepath.Join(dir, "f0.go")
+	bumpMtime(t, one, "package main\n\nfunc F0() {}\n\nfunc F0Edited() {}\n")
+
+	res, err := idx.IncrementalReindexPaths(dir, []string{one})
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.StaleFileCount,
+		"the pass's work size belongs to StaleFileCount")
+	assert.Equal(t, total, res.FileCount,
+		"FileCount must stay the repo's size under a one-file scope")
+
+	// Same contract when the scope is a directory rather than one file.
+	sub := filepath.Join(dir, "pkg", "f5.go")
+	bumpMtime(t, sub, "package main\n\nfunc F5() {}\n\nfunc F5Edited() {}\n")
+
+	res, err = idx.IncrementalReindexPaths(dir, []string{filepath.Join(dir, "pkg")})
+	require.NoError(t, err)
+	assert.Equal(t, total, res.FileCount,
+		"FileCount must stay the repo's size under a directory scope")
+}
+
+// TestIncrementalReindexPathsFileCountTracksAddsAndDeletes verifies the
+// repo-wide count still moves when the repo itself changes size, so the
+// fix reports a live total rather than a frozen one.
+func TestIncrementalReindexPathsFileCountTracksAddsAndDeletes(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.go"), "package main\n\nfunc A() {}\n")
+	writeFile(t, filepath.Join(dir, "b.go"), "package main\n\nfunc B() {}\n")
+
+	g := graph.New()
+	idx := newTestIndexer(g)
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+
+	added := filepath.Join(dir, "c.go")
+	writeFile(t, added, "package main\n\nfunc C() {}\n")
+	res, err := idx.IncrementalReindexPaths(dir, []string{added})
+	require.NoError(t, err)
+	assert.Equal(t, 3, res.FileCount, "a new file grows the repo count")
+
+	require.NoError(t, os.Remove(added))
+	res, err = idx.IncrementalReindexPaths(dir, []string{added})
+	require.NoError(t, err)
+	assert.Equal(t, 2, res.FileCount, "a deleted file shrinks the repo count")
 }

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -5252,6 +5252,17 @@ func (idx *Indexer) FileMtimes() map[string]int64 {
 	return out
 }
 
+// trackedFileCount reports how many files this indexer currently holds
+// mtime records for — the repo's whole file set, independent of any one
+// pass's scope. A scoped pass adds and evicts its own files within scope
+// before reading this, so the count stays current. Kept separate from
+// FileMtimes() so callers that only need the size do not copy the map.
+func (idx *Indexer) trackedFileCount() int {
+	idx.mtimeMu.RLock()
+	defer idx.mtimeMu.RUnlock()
+	return len(idx.fileMtimes)
+}
+
 // RefreshFileMtime restamps the recorded modification time for a file
 // from its current on-disk mtime, without re-indexing it. The watcher
 // calls this when a save turned out to be structurally inert and the
@@ -5576,10 +5587,22 @@ func (idx *Indexer) incrementalReindexPaths(
 	}
 
 	nodes, edges := idx.repoNodeEdgeCount()
+	// FileCount must describe the repo, never this pass. diskFiles holds
+	// only the files under the caller's scope, so len(diskFiles) is the
+	// size of the batch — stamping that onto RepoMetadata is what made
+	// `daemon status` report an actively-edited repo's file count as the
+	// size of its last changed-file batch. How much work this pass did is
+	// already carried by StaleFileCount / DeletedFileCount.
+	fileCount := idx.trackedFileCount()
+	if fileCount == 0 {
+		// No prior full pass populated the mtime map (a virgin indexer
+		// reaching the scoped path). The scope is all we know about.
+		fileCount = len(diskFiles)
+	}
 	result := &IndexResult{
 		NodeCount:           nodes,
 		EdgeCount:           edges,
-		FileCount:           len(diskFiles),
+		FileCount:           fileCount,
 		StaleFileCount:      len(staleFiles),
 		DeletedFileCount:    len(deletedFiles),
 		FailedFiles:         failedFiles,

--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -2658,6 +2658,16 @@ func (mi *MultiIndexer) ReconcileAllCtx(ctx context.Context) map[string]*IndexRe
 		if m, ok := mi.repos[prefix]; ok && m != nil {
 			m.FileMtimes = idx.FileMtimes()
 			m.LastIndexTime = time.Now()
+			// This pass was whole-repo, so its counts describe the repo
+			// and are safe to stamp. Doing so also heals metadata that a
+			// scoped pass left describing only its own scope, so a daemon
+			// already reporting a wrong file count converges on its own
+			// instead of needing a restart.
+			if result != nil {
+				m.FileCount = result.FileCount
+				m.NodeCount = result.NodeCount
+				m.EdgeCount = result.EdgeCount
+			}
 		}
 		mi.mu.Unlock()
 	}

--- a/internal/indexer/multi_test.go
+++ b/internal/indexer/multi_test.go
@@ -940,3 +940,47 @@ func TestSingleToMultiRepoTransition(t *testing.T) {
 			"multi-repo node ID %q should start with %q", n.ID, prefix)
 	}
 }
+
+// TestScopedReindexPreservesRepoMetadataFileCount is the end-to-end
+// guard on the bug that made `gortex daemon status` report an
+// actively-edited repo's file count as the size of its last
+// changed-file batch. IncrementalReindexRepo is the door the git
+// watcher and the MCP reindex_repository tool both come through, and it
+// full-replaces RepoMetadata from the scoped IndexResult — so a scoped
+// pass must still carry the repo-wide count.
+func TestScopedReindexPreservesRepoMetadataFileCount(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "myrepo")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	const total = 6
+	for i := range total {
+		writeFile(t, filepath.Join(dir, fmt.Sprintf("f%d.go", i)),
+			fmt.Sprintf("package main\n\nfunc F%d() {}\n", i))
+	}
+
+	tmpCfg := filepath.Join(t.TempDir(), "config.yaml")
+	gc := &config.GlobalConfig{Repos: []config.RepoEntry{{Path: dir, Name: "myrepo"}}}
+	gc.SetConfigPath(tmpCfg)
+	require.NoError(t, gc.Save())
+	cm, err := config.NewConfigManager(tmpCfg)
+	require.NoError(t, err)
+
+	g := graph.New()
+	mi := NewMultiIndexer(g, newTestRegistry(), search.NewBM25(), cm, zap.NewNop())
+	_, err = mi.IndexAll()
+	require.NoError(t, err)
+
+	meta := mi.GetMetadata("myrepo")
+	require.NotNil(t, meta)
+	require.Equal(t, total, meta.FileCount, "baseline: the full pass counts the repo")
+
+	// The watcher's door: one changed file, scoped.
+	one := filepath.Join(dir, "f0.go")
+	writeFile(t, one, "package main\n\nfunc F0() {}\n\nfunc F0Edited() {}\n")
+	_, err = mi.IncrementalReindexRepo("myrepo", []string{one})
+	require.NoError(t, err)
+
+	meta = mi.GetMetadata("myrepo")
+	require.NotNil(t, meta)
+	assert.Equal(t, total, meta.FileCount,
+		"a scoped reindex must not overwrite the repo's file count with its batch size")
+}


### PR DESCRIPTION
## What's wrong

`gortex daemon status` reports an actively-edited repo's `files` as the size of its **most recent changed-file batch**. Measured against the live graph on a 20-repo daemon:


The `nodes` and `edges` beside them are correct, because they are re-read live from the graph. One rendered row mixes two epochs.

## Root cause

`incrementalReindexPaths` stamped `FileCount: len(diskFiles)`, and `diskFiles` is declared eleven lines earlier as *"the set of **in-scope** language files"*. That contradicts the field's own contract:

> `FileCount` is the total number of language files the indexer observed for this repo — i.e. how big the repo is on disk, **not how much work this pass did**.

The work size is already carried by `StaleFileCount` / `DeletedFileCount`.

Two writers full-replace `mi.repos[prefix]` from that scoped result — `ReconcileRepoCtx`'s scoped branch (warm restart) and `IncrementalReindexRepo` (the git-watcher, storm-drain and MCP `reindex_repository` door) — and nothing healed it afterwards. `daemon status` renders the field raw; it is the only column in that struct literal not backed by a live graph read, and its only reader anywhere.

Repos that stay idle never take the scoped route, which is why most rows looked right.

## Fix

- **`indexer.go`** — new `trackedFileCount()`; the scoped pass reports the repo-wide total, falling back to the scope size only on a virgin indexer whose mtime map no full pass has populated.
- **`multi.go`** — the janitor already ran a whole-repo pass and computed authoritative counts every tick, then discarded them, writing back only `FileMtimes` and `LastIndexTime`. It now stamps `FileCount` / `NodeCount` / `EdgeCount`, so a daemon already holding a wrong count converges on its own instead of needing a restart.

Deliberately **not** switching the column to a live `ByKind["file"]` read: that would drop `gortex-terminal-replay` from 1809 to 28 and hide that repo's separate under-indexing problem (~4 nodes/file vs ~79 here) behind a plausible-looking number. Worth its own investigation.

## Why it shipped

A test had codified the defect — asserting `FileCount == 1` for a one-file scope of a **two**-file repo, the opposite of the documented contract. Its stated intent (that the pass stays scoped) is already covered by `StaleFileCount` and the `OneEdited`/`TwoEdited` node assertions, so correcting it loses no coverage.

## Tests

Three new guards plus the corrected assertion. All four **fail on `main` and pass with the fix** (verified by reverting the production change and re-running):

- `TestIncrementalReindexPathsReportsRepoFileCountNotScopeSize` — 10-file repo stays 10 under both a one-file and a directory scope, while `StaleFileCount` is 1
- `TestIncrementalReindexPathsFileCountTracksAddsAndDeletes` — the repo-wide count still moves when the repo itself grows/shrinks, so it is a live total and not a frozen one
- `TestScopedReindexPreservesRepoMetadataFileCount` — end-to-end through `IncrementalReindexRepo`, the watcher's actual door, asserting `RepoMetadata.FileCount` survives a scoped pass

`go test -race ./internal/indexer/` green (201s); `go build ./...`, `go vet`, `gofmt` clean.

## Follow-up worth considering

`IncrementalReindexRepo` full-replaces the `RepoMetadata` struct, so any newly added field is one commit away from this same bug — it already bit `IsWorktree` / `Unprefixed`, which are carried forward by hand with a comment recording it. Mutating the existing struct instead would close the class.
