### PR TITLE
savings: price the model generation the dashboard actually sees

### DIFF
--- a/cmd/gortex/savings.go
+++ b/cmd/gortex/savings.go
@@ -311,20 +311,36 @@ func emitSavingsDashboard(snap savings.File, buckets []savings.Bucket, modelTota
 				nameWidth = l
 			}
 		}
+		unpriced := 0
 		for _, m := range modelTotals {
 			adj := tokens.ScaleFromCL100K(m.Name, m.TokensSaved)
+			priced := savings.ModelRate(m.Name) > 0
+			if !priced {
+				unpriced++
+			}
 			if tty {
-				cost := savings.CostAvoided(adj, m.Name)
+				tone := progress.StatGood
+				if !priced {
+					tone = progress.StatNeutral
+				}
 				stats := []string{
-					progress.Stat(formatUSD(cost), "", progress.StatGood),
+					progress.Stat(formatModelCost(adj, m.Name), "", tone),
 					progress.Stat(humanInt(m.CallsCounted), "calls", progress.StatNeutral),
 					progress.Stat(humanInt(adj), "tokens saved", progress.StatNeutral),
 				}
 				fmt.Printf("     %-*s  %s\n", nameWidth, m.Name, progress.StatStrip(stats...))
 			} else {
 				fmt.Printf("  %-*s %s   (%s calls · %s tokens saved)\n",
-					nameWidth, m.Name, formatUSD(savings.CostAvoided(adj, m.Name)),
+					nameWidth, m.Name, formatModelCost(adj, m.Name),
 					humanInt(m.CallsCounted), humanInt(adj))
+			}
+		}
+		if unpriced > 0 {
+			hint := fmt.Sprintf("%d model(s) have no list price on file — set GORTEX_MODEL_PRICING_JSON to price them.", unpriced)
+			if tty {
+				fmt.Println("     " + progress.Caption(hint))
+			} else {
+				fmt.Println("  " + hint)
 			}
 		}
 	}
@@ -457,6 +473,18 @@ func formatUSD(usd float64) string {
 		return fmt.Sprintf("$%.2f", usd)
 	}
 	return fmt.Sprintf("$%.4f", usd)
+}
+
+// formatModelCost renders one model's cost avoided, separating "no list
+// price on file" from "this model avoided nothing". Both used to print
+// $0.0000, so a model the pricing table has never heard of — a newly
+// released id, or a provider whose rates we don't carry — read as a real
+// zero sitting next to millions of tokens saved.
+func formatModelCost(tokensSaved int64, model string) string {
+	if savings.ModelRate(model) <= 0 {
+		return "unpriced"
+	}
+	return formatUSD(savings.CostAvoided(tokensSaved, model))
 }
 
 // printBucket renders a sorted breakdown of name → Totals. Skipped when

--- a/cmd/gortex/savings_test.go
+++ b/cmd/gortex/savings_test.go
@@ -202,3 +202,32 @@ func TestEmitSavingsDashboard_EmptyTotals(t *testing.T) {
 		t.Errorf("empty ledger must not print a tracking-since line, got:\n%s", out)
 	}
 }
+
+// TestDefaultHeadlineModelIsPriced pins the invariant behind the dashboard's
+// headline figure. pickHeadlineCost falls back to the highest-value entry
+// when defaultHeadlineModel isn't in the pricing table, so an unpriced
+// headline model silently re-denominates every headline number against a
+// different model instead of failing.
+func TestDefaultHeadlineModelIsPriced(t *testing.T) {
+	if rate := savings.ModelRate(defaultHeadlineModel); rate <= 0 {
+		t.Fatalf("defaultHeadlineModel %q has no pricing row (rate %.4f) — the headline "+
+			"cost would silently re-denominate against another model", defaultHeadlineModel, rate)
+	}
+}
+
+// TestFormatModelCostSeparatesUnpricedFromZero is the fix for a model with
+// millions of tokens saved rendering as $0.0000 purely because the pricing
+// table had never heard of its id.
+func TestFormatModelCostSeparatesUnpricedFromZero(t *testing.T) {
+	if got := formatModelCost(20_676_506, "claude-opus-5"); got != "$103.38" {
+		t.Errorf("formatModelCost(20.68M, claude-opus-5) = %q, want $103.38", got)
+	}
+	if got := formatModelCost(5_000_000, "some-unreleased-model"); got != "unpriced" {
+		t.Errorf("formatModelCost(5M, unknown model) = %q, want \"unpriced\"", got)
+	}
+	// A priced model that genuinely saved nothing still reads as a dollar
+	// amount — that is a real zero, not a missing rate.
+	if got := formatModelCost(0, "claude-opus-5"); got != "$0.0000" {
+		t.Errorf("formatModelCost(0, claude-opus-5) = %q, want $0.0000", got)
+	}
+}

--- a/internal/savings/pricing.go
+++ b/internal/savings/pricing.go
@@ -23,15 +23,26 @@ type Price struct {
 // the input rate. Users can override the whole table via
 // GORTEX_MODEL_PRICING_JSON='[{"model":"...","usd_per_m_input":N},...]'.
 var defaultPricing = []Price{
-	// Anthropic — claude-opus-4-8 is the headline default (see savings.go);
-	// claude-mythos-preview is the current preview flagship.
+	// Anthropic — claude-opus-4-8 is the headline default (see savings.go).
+	// Keep the current generation listed first: findPrice resolves an exact
+	// match before any substring match, so a missing row is what turns a live
+	// model's cost avoided into a silent $0.00.
+	{"claude-fable-5", 10.00},
+	{"claude-mythos-5", 10.00},
 	{"claude-mythos-preview", 10.00},
+	{"claude-opus-5", 5.00},
 	{"claude-opus-4-8", 5.00},
 	{"claude-opus-4-7", 5.00},
 	{"claude-opus-4-6", 5.00},
+	{"claude-sonnet-5", 3.00},
 	{"claude-sonnet-4-6", 3.00},
 	{"claude-haiku-4-5", 1.00},
-	// OpenAI (also reachable via Azure).
+	// OpenAI (also reachable via Azure). The gpt-5.6 tiers are the slugs the
+	// codex CLI reports, so they show up in savings attribution even though
+	// gortex never calls them directly.
+	{"gpt-5.6-sol", 5.00},
+	{"gpt-5.6-terra", 2.50},
+	{"gpt-5.6-luna", 1.00},
 	{"gpt-5.5", 5.00},
 	{"gpt-5.4", 2.50},
 	{"gpt-5.4-mini", 0.75},

--- a/internal/savings/pricing_test.go
+++ b/internal/savings/pricing_test.go
@@ -78,3 +78,89 @@ func TestPricing_EnvUnsetUsesDefaults(t *testing.T) {
 		t.Errorf("unset env should use defaults, got %d", len(got))
 	}
 }
+
+// TestDefaultPricingCoversCurrentGeneration pins list prices for the model
+// generation gortex's own clients actually run on. A missing row here is not
+// a cosmetic gap: findPrice returns nil for an unknown id and CostAvoided
+// then reports $0.00 next to millions of tokens saved, which reads as "this
+// model avoided nothing" rather than "we have no rate for it".
+func TestDefaultPricingCoversCurrentGeneration(t *testing.T) {
+	// USD per 1M input tokens.
+	want := map[string]float64{
+		"claude-fable-5":    10.00,
+		"claude-mythos-5":   10.00,
+		"claude-opus-5":     5.00,
+		"claude-opus-4-8":   5.00,
+		"claude-sonnet-5":   3.00,
+		"claude-sonnet-4-6": 3.00,
+		"claude-haiku-4-5":  1.00,
+		// OpenAI slugs the codex CLI reports into savings attribution.
+		"gpt-5.6-sol":   5.00,
+		"gpt-5.6-terra": 2.50,
+		"gpt-5.6-luna":  1.00,
+	}
+	for model, rate := range want {
+		got := ModelRate(model)
+		if got == 0 {
+			t.Errorf("ModelRate(%q) = 0 — model missing from the pricing table, so its "+
+				"cost avoided renders as $0.00", model)
+			continue
+		}
+		if got != rate {
+			t.Errorf("ModelRate(%q) = %.2f, want %.2f", model, got, rate)
+		}
+	}
+}
+
+// TestPricingExactMatchBeatsSubstring guards the resolution order that keeps
+// same-family ids from stealing each other's rate — claude-opus-5 must not
+// resolve against claude-opus-4-8, and claude-sonnet-5 must not resolve
+// against claude-sonnet-4-6.
+func TestPricingExactMatchBeatsSubstring(t *testing.T) {
+	if got := CostAvoided(1_000_000, "claude-opus-5"); got != 5.00 {
+		t.Errorf("CostAvoided(1M, claude-opus-5) = %.4f, want 5.00", got)
+	}
+	if got := CostAvoided(1_000_000, "claude-sonnet-5"); got != 3.00 {
+		t.Errorf("CostAvoided(1M, claude-sonnet-5) = %.4f, want 3.00", got)
+	}
+	if got := CostAvoided(1_000_000, "claude-fable-5"); got != 10.00 {
+		t.Errorf("CostAvoided(1M, claude-fable-5) = %.4f, want 10.00", got)
+	}
+}
+
+// TestModelRateReportsUnknownAsZero is the contract formatModelCost relies on
+// to tell "unpriced" apart from "avoided nothing".
+func TestModelRateReportsUnknownAsZero(t *testing.T) {
+	if got := ModelRate("totally-unknown-model-xyz"); got != 0 {
+		t.Errorf("ModelRate(unknown) = %.4f, want 0", got)
+	}
+	if got := ModelRate(""); got != 0 {
+		t.Errorf("ModelRate(\"\") = %.4f, want 0", got)
+	}
+}
+
+// TestPricingGPT56TierDoesNotCollideWithGPT55 guards the substring resolver:
+// the gpt-5.6 tiers and gpt-5.5 are distinct rows, and neither may resolve
+// against the other. gpt-5.6-sol and gpt-5.5 happen to share a rate, so
+// assert on the resolved row rather than only on the dollar figure.
+func TestPricingGPT56TierDoesNotCollideWithGPT55(t *testing.T) {
+	for _, tc := range []struct {
+		model string
+		want  float64
+	}{
+		{"gpt-5.6-sol", 5.00},
+		{"gpt-5.6-terra", 2.50},
+		{"gpt-5.6-luna", 1.00},
+		{"gpt-5.5", 5.00},
+		{"gpt-5.4", 2.50},
+	} {
+		if got := ModelRate(tc.model); got != tc.want {
+			t.Errorf("ModelRate(%q) = %.2f, want %.2f", tc.model, got, tc.want)
+		}
+	}
+	// The tiers must not be interchangeable — terra and luna are cheaper
+	// than sol, so a collision would silently misprice a third of a bill.
+	if ModelRate("gpt-5.6-terra") == ModelRate("gpt-5.6-sol") {
+		t.Error("gpt-5.6-terra resolved to the same rate as gpt-5.6-sol — substring collision")
+	}
+}


### PR DESCRIPTION
## What's wrong

`gortex savings` reports **$0.0000** cost avoided for models that have saved tens of millions of tokens:

```
claude-opus-4-8  $211.65  ·  2,662 calls  ·  42,330,989 tokens saved
claude-opus-5    $0.0000  ·    964 calls  ·  20,676,506 tokens saved   <-- 
gpt-5.6-sol      $0.0000  ·     87 calls  ·   5,840,292 tokens saved   <-- 
claude-fable-5   $0.0000  ·    351 calls  ·   5,235,052 tokens saved   <-- 
```

The tokens are counted correctly — the **rate** is missing. `defaultPricing` stopped at the previous generation, `findPrice` returns no row for the ids clients now report, and `CostAvoided` turns that miss into a zero.

The per-client / per-repo / per-language sections looked fine throughout, which is what made this read as a data bug rather than a missing row. Those bill every token at `defaultHeadlineModel`'s rate rather than each model's own — `$430.61 / 86,121,916 tokens = exactly $5.00/M`, `claude-opus-4-8`'s rate. Only the per-model section resolves each id individually, so only it exposed the gap.

## Fix

**Add the missing rows.** Prices are list input rates (tokens saved are input that never got sent, so `Price.USDPerMInput` is the right column):

| model | input $/1M |
|---|---:|
| `claude-fable-5`, `claude-mythos-5` | 10.00 |
| `claude-opus-5` | 5.00 |
| `claude-sonnet-5` | 3.00 |
| `gpt-5.6-sol` | 5.00 |
| `gpt-5.6-terra` | 2.50 |
| `gpt-5.6-luna` | 1.00 |

The gpt-5.6 tiers are the slugs the `codex` CLI reports, so they reach savings attribution even though gortex never calls them. All three are listed rather than just the one in use — `findPrice` falls back to a substring match, so a lone `gpt-5.6-sol` row would let a `terra`/`luna` session silently resolve onto the flagship's higher rate.

**Render a miss as `unpriced`, not `$0.0000`.** These printed identically, so "we don't carry a rate for this id" was indistinguishable from "this model avoided nothing" — sitting next to millions of tokens saved. A trailing line names `GORTEX_MODEL_PRICING_JSON` for rates we don't ship.

After, against a real sidecar:

```
claude-opus-4-8 $211.65   (2,662 calls · 42,330,989 tokens saved)
claude-opus-5   $107.93   (993 calls · 21,585,961 tokens saved)
gpt-5.6-sol     $44.94    (286 calls · 8,988,194 tokens saved)
claude-fable-5  $52.35    (351 calls · 5,235,052 tokens saved)
```

## Tests

The regression is a missing row, not wrong arithmetic, so the tests pin coverage rather than a formula. All fail on `main` and pass with the fix:

- `TestDefaultPricingCoversCurrentGeneration` — every current id resolves to its expected rate; the failure message says a missing row renders as $0.00 so the next person doesn't have to re-derive it
- `TestPricingExactMatchBeatsSubstring` — `claude-opus-5` must not resolve against `claude-opus-4-8`, nor `claude-sonnet-5` against `claude-sonnet-4-6`
- `TestPricingGPT56TierDoesNotCollideWithGPT55` — asserts the tiers resolve to *distinct* rates. `gpt-5.6-sol` and `gpt-5.5` happen to share $5.00, so a collision between them is invisible in the dollar figure alone
- `TestModelRateReportsUnknownAsZero` — the contract `formatModelCost` relies on
- `TestDefaultHeadlineModelIsPriced` — `pickHeadlineCost` falls back to the highest-value entry when the headline model isn't priced, silently re-denominating every headline figure against a different model instead of failing
- `TestFormatModelCostSeparatesUnpricedFromZero` — a priced model that genuinely saved nothing still prints a dollar amount

`go build ./...`, `go vet`, `gofmt` clean; `go test -race` green on `internal/savings` and the `cmd/gortex` savings tests.

## Known limitation, deliberately not addressed

OpenAI prices requests over 272K input tokens at 2× input for the whole request. Gortex applies one flat rate per model, so long-context sessions are slightly under-counted. That simplification already applies to every other row in the table, so this PR doesn't special-case it.

## Separate defect found while investigating — not fixed here

The per-model section is also **mis-attributed**, independently of pricing. MCP never transmits the calling model, so it's inferred from a filesystem hint (`internal/modelhint`, 12h TTL) written by the hook layer. Until `62ec0a7d` only Claude Code wrote hints, so Codex sessions inherited whichever model Claude Code last announced for that cwd — and recorded nothing once it aged out. In one real sidecar that's 3,397 borrowed `claude-*` rows plus 2,443 blanks (33% of all tokens saved).

`62ec0a7d` fixes attribution going forward. Two things remain, both out of scope here:

1. Blank-model rows are dropped by `savingsDimTotals`' `WHERE <col> <> ''`, so the section can't reconcile against the headline and shows no `(unattributed)` remainder. Same filter feeds `graph_stats`' `per_model_actual` and `gortex savings --json`, so surfacing it changes the JSON shape.
2. The Codex hint writer fires only on SessionStart/UserPromptSubmit, so a session running >12h on one prompt can still age out its own hint.
