### PR TITLE
Fix search_text returning zero results below the repo root on Windows

### DIFF
--- a/internal/mcp/tools_search_text.go
+++ b/internal/mcp/tools_search_text.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -184,6 +185,16 @@ func (s *Server) filterTextMatchesByResolvedScope(matches []trigram.Match, resol
 			continue
 		}
 		n := s.graph.GetNode(m.Path)
+		if n == nil {
+			// A trigram match path is always forward-slash, but node IDs
+			// keep the repo-relative remainder in the OS separator. The two
+			// spellings agree only for a file at the repo root, so on
+			// Windows every match below the root failed attribution here and
+			// the fail-closed drop below emptied the entire result set.
+			if key := graphMatchPathKey(m.Path, knownRepo); key != m.Path {
+				n = s.graph.GetNode(key)
+			}
+		}
 		if n == nil && knownRepo {
 			// GrepTextForRepos stamps the registry prefix onto every
 			// match path, but a repo indexed in single-repo mode minted
@@ -192,6 +203,11 @@ func (s *Server) filterTextMatchesByResolvedScope(matches []trigram.Match, resol
 			// stripped so attribution works in a lone-repo daemon.
 			if meta := s.multiIndexer.GetMetadata(repo); meta != nil && meta.Unprefixed {
 				n = s.graph.GetNode(rest)
+				if n == nil {
+					if key := graphMatchPathKey(rest, false); key != rest {
+						n = s.graph.GetNode(key)
+					}
+				}
 			}
 		}
 		if n == nil || !opts.ScopeAllows(n) {
@@ -202,19 +218,51 @@ func (s *Server) filterTextMatchesByResolvedScope(matches []trigram.Match, resol
 	return out
 }
 
+// graphMatchPathKey spells a trigram match path the way graph node IDs
+// spell it. Match paths are always forward-slash; a node ID joins the repo
+// prefix with "/" but keeps the repo-relative remainder in the OS separator,
+// so the two forms diverge on Windows for every file below the repo root.
+// repoPrefixed says whether the first segment names a tracked repo rather
+// than an ordinary directory. Returns path unchanged where the separators
+// already agree, so POSIX callers pay nothing.
+func graphMatchPathKey(path string, repoPrefixed bool) string {
+	if filepath.Separator == '/' {
+		return path
+	}
+	if repoPrefixed {
+		if repo, rest, ok := strings.Cut(path, "/"); ok {
+			return repo + "/" + filepath.FromSlash(rest)
+		}
+	}
+	return filepath.FromSlash(path)
+}
+
 // enrichTextMatches decorates every trigram match with its enclosing
 // graph symbol. It builds one per-file symbol index for the set of
 // matched files, then resolves each match's line through it.
+//
+// The index is queried under both path spellings: file nodes are fetched
+// and keyed by the graph's own FilePath, which on Windows is not the
+// forward-slash path the match carries.
 func (s *Server) enrichTextMatches(matches []trigram.Match) []enrichedTextMatch {
 	out := make([]enrichedTextMatch, 0, len(matches))
 	paths := make(map[string]struct{}, len(matches))
 	for _, m := range matches {
 		paths[m.Path] = struct{}{}
+		if key := graphMatchPathKey(m.Path, true); key != m.Path {
+			paths[key] = struct{}{}
+		}
 	}
 	idx := s.buildFileSymbolIndexForPaths(paths)
 	for _, m := range matches {
 		em := enrichedTextMatch{Path: m.Path, Line: m.Line, Text: m.Text}
-		if fi := idx[m.Path]; fi != nil {
+		fi := idx[m.Path]
+		if fi == nil {
+			if key := graphMatchPathKey(m.Path, true); key != m.Path {
+				fi = idx[key]
+			}
+		}
+		if fi != nil {
 			em.SymbolID, em.SymbolName = fi.find(m.Line)
 		}
 		out = append(out, em)

--- a/internal/mcp/tools_search_text_pathsep_test.go
+++ b/internal/mcp/tools_search_text_pathsep_test.go
@@ -1,0 +1,120 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+	"github.com/zzet/gortex/internal/query"
+	"github.com/zzet/gortex/internal/search"
+	"github.com/zzet/gortex/internal/search/trigram"
+)
+
+// TestGraphMatchPathKey pins the two spellings apart: a trigram match path
+// is always forward-slash, while a graph node ID joins the repo prefix with
+// "/" and keeps the repo-relative remainder in the OS separator.
+func TestGraphMatchPathKey(t *testing.T) {
+	require.Equal(t, "beta/"+filepath.FromSlash("pkg/sub/main.go"),
+		graphMatchPathKey("beta/pkg/sub/main.go", true),
+		"a repo-prefixed match keeps the prefix separator and OS-spells the remainder")
+	require.Equal(t, filepath.FromSlash("pkg/sub/main.go"),
+		graphMatchPathKey("pkg/sub/main.go", false),
+		"an unprefixed match is OS-spelled whole")
+	require.Equal(t, "beta/main.go", graphMatchPathKey("beta/main.go", true),
+		"a repo-root file has one spelling on every platform")
+}
+
+// setupNestedRepo writes a repo whose only source file sits below the root,
+// which is where the match-path and node-ID spellings diverge.
+func setupNestedRepo(t *testing.T, name, workspace, body string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), name)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "pkg", "sub"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".gortex.yaml"),
+		[]byte("workspace: "+workspace+"\nproject: backend\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "pkg", "sub", "main.go"),
+		[]byte(body), 0o644))
+	return dir
+}
+
+func nestedRepoServer(t *testing.T, entries []config.RepoEntry) (*Server, *graph.Graph) {
+	t.Helper()
+	tmpCfg := filepath.Join(t.TempDir(), "config.yaml")
+	gc := &config.GlobalConfig{Repos: entries}
+	gc.SetConfigPath(tmpCfg)
+	require.NoError(t, gc.Save())
+	cm, err := config.NewConfigManager(tmpCfg)
+	require.NoError(t, err)
+
+	reg := parser.NewRegistry()
+	reg.Register(languages.NewGoExtractor())
+	g := graph.New()
+	mi := indexer.NewMultiIndexer(g, reg, search.NewBM25(), cm, zap.NewNop())
+	_, err = mi.IndexAll()
+	require.NoError(t, err)
+
+	srv := NewServer(query.NewEngine(g), g, nil, nil, zap.NewNop(), nil, MultiRepoOptions{
+		ConfigManager: cm,
+		MultiIndexer:  mi,
+	})
+	return srv, g
+}
+
+// TestFilterTextMatchesByResolvedScope_BelowRepoRoot is the regression for
+// search_text returning zero results on Windows. Scope narrowing attributes
+// every match to a graph node and fails closed when it cannot. The lookup
+// key was the raw forward-slash match path, which equals the node ID only
+// for a file at the repo root — so on Windows every match below the root was
+// silently dropped and a repo-wide search reported no hits at all.
+//
+// The existing fail-closed fixture uses a root-level file, where the two
+// spellings coincide on every platform; these put the file in a
+// subdirectory, and cover both node-ID shapes: prefixed (several tracked
+// repos) and unprefixed (a lone repo, where the stamped prefix is stripped
+// before the retry).
+func TestFilterTextMatchesByResolvedScope_BelowRepoRoot(t *testing.T) {
+	t.Run("prefixed node ids", func(t *testing.T) {
+		alpha := setupNestedRepo(t, "alpha", "shared", "package sub\n\n// marker\nfunc A() {}\n")
+		beta := setupNestedRepo(t, "beta", "shared", "package sub\n\n// marker\nfunc B() {}\n")
+		srv, g := nestedRepoServer(t, []config.RepoEntry{
+			{Path: alpha, Name: "alpha", Project: "backend"},
+			{Path: beta, Name: "beta", Project: "backend"},
+		})
+
+		nodeKey := "beta/" + filepath.FromSlash("pkg/sub/main.go")
+		require.NotNil(t, g.GetNode(nodeKey),
+			"fixture invariant: several tracked repos mint prefixed node ids")
+
+		got := srv.filterTextMatchesByResolvedScope(
+			[]trigram.Match{{Path: "beta/pkg/sub/main.go", Line: 3, Text: "// marker"}},
+			ResolvedScope{WorkspaceID: "shared", RepoAllow: map[string]bool{"beta": true}},
+		)
+		require.Len(t, got, 1,
+			"a node-backed match below the repo root must survive narrowing on every platform")
+	})
+
+	t.Run("unprefixed node ids", func(t *testing.T) {
+		solo := setupNestedRepo(t, "solo", "shared", "package sub\n\n// marker\nfunc S() {}\n")
+		srv, g := nestedRepoServer(t, []config.RepoEntry{
+			{Path: solo, Name: "solo", Project: "backend"},
+		})
+
+		require.NotNil(t, g.GetNode(filepath.FromSlash("pkg/sub/main.go")),
+			"fixture invariant: a lone repo mints unprefixed node ids")
+
+		got := srv.filterTextMatchesByResolvedScope(
+			[]trigram.Match{{Path: "solo/pkg/sub/main.go", Line: 3, Text: "// marker"}},
+			ResolvedScope{WorkspaceID: "shared", RepoAllow: map[string]bool{"solo": true}},
+		)
+		require.Len(t, got, 1,
+			"the unprefixed retry must also cross the separator gap")
+	})
+}


### PR DESCRIPTION
## Summary

`search_text` returns `count: 0` for every query on Windows unless the match happens to land in a file at the repository root. This is #310 — the reason every known-positive control in that report came back zero is that real code lives in subdirectories.

The root cause is a path-**spelling** mismatch, not the repo-identity mismatch #310 hypothesised.

`trigram.Match.Path` is forward-slash by contract (`trigram.Build` calls `filepath.ToSlash`). A graph node ID joins the repo prefix with `/` but keeps the repo-relative remainder in the OS separator — on Windows, `beta/pkg\sub\main.go`. `filterTextMatchesByResolvedScope` attributes every match with `s.graph.GetNode(m.Path)` and **fails closed** when that lookup misses, so under any active narrowing each match below the repo root is dropped silently. A file at the repo root has the same spelling on both sides, which is why the symptom reads as "zero for everything" rather than "some results missing".

`repo:"*"` cannot help: widening changes which repos are searched, not how the surviving matches are attributed. That is also why the `scope_note` hint is actively misleading here.

Minimal discriminator — fresh 2-file repo, one file at the root and one in `src/`, gortex v0.61.4, Windows 11:

| query | file | stock | patched |
|---|---|---|---|
| `UNIQUEMARKER_ABC123` | `README.md` (repo root) | 1 | 1 |
| `namespace Probe` | `src/Alpha.cs` (subdirectory) | **0** | 1 |
| `覆盖点` | `src/Alpha.cs` (subdirectory) | **0** | 4 |

Fixes #310

## Changes

- `graphMatchPathKey` spells a forward-slash match path the way node IDs spell it: repo prefix by `/`, remainder by the OS separator. It is identity on POSIX, so nothing changes there.
- `filterTextMatchesByResolvedScope` retries the node lookup under that spelling, in both the prefixed branch and the unprefixed (`RepoMetadata.Unprefixed`, lone-repo) branch.
- `enrichTextMatches` seeds and queries the enclosing-symbol index under both spellings — `buildFileSymbolIndexForPaths` keys its result by the graph's own `FilePath`, so symbol enrichment missed for the same reason.

## Testing

- [x] `go test ./internal/mcp/ ./internal/parser/languages/` — new tests green, no new failures (two pre-existing Windows failures, see below)
- [x] New tests added for new functionality
- [ ] Benchmarks run if performance-relevant — not performance-relevant: one extra map lookup, only on the miss path

New tests:

- `TestGraphMatchPathKey` — pins the two spellings apart; platform-agnostic.
- `TestFilterTextMatchesByResolvedScope_BelowRepoRoot` — a node-backed match below the repo root must survive narrowing, covering both node-ID shapes: prefixed (several tracked repos) and unprefixed (lone repo). Verified red on Windows before the change (both subtests) and green after. The existing `TestFilterTextMatchesByResolvedScope_FailsClosed` fixture uses a repo-root file, where the two spellings coincide on every platform — which is why it never caught this.

Also verified end to end: a patched binary running as an isolated daemon returns nested-file matches for both ASCII and non-ASCII queries, with repo-root behaviour unchanged.

Two `internal/mcp` tests fail on Windows **both before and after** this change, so they are out of scope here:

- `TestOverlayBranch_BackwardCompat` — unrelated.
- `TestGetFileSummary_MultiRepoRelativePath` — same separator class, different handler (`graphRelPath`): `alpha/svc/a.go` misses the `alpha/svc\a.go` node and the tool answers `file_not_indexed`. Happy to follow up with one shared normalisation across the MCP path resolvers if you would prefer that over the local retry used here.

## Checklist

- [x] Code follows existing patterns in the codebase
- [x] No unnecessary abstractions added
- [ ] Language extractor includes `Meta["methods"]` for interfaces — n/a
- [ ] Methods have `EdgeMemberOf` edges to their containing type — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)
