### PR TITLE
Emit call edges for C# null-conditional invocations

### DIFF
--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -77,6 +77,12 @@ const qCSharpAll = `
       expression: (_) @callm.receiver
       name: (identifier) @callm.method)) @callm.expr
 
+  (invocation_expression
+    function: (conditional_access_expression
+      condition: (_) @callm.receiver
+      (member_binding_expression
+        name: (identifier) @callm.method))) @callm.expr
+
   (local_declaration_statement
     (variable_declaration
       type: (_) @lvar.type

--- a/internal/parser/languages/csharp_nullcond_test.go
+++ b/internal/parser/languages/csharp_nullcond_test.go
@@ -1,0 +1,53 @@
+package languages
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Regression: `recv?.M(x)` parses as an invocation_expression whose
+// `function` field is a conditional_access_expression, not a
+// member_access_expression. While the query alternation covered only the
+// latter, every null-conditional call site was dropped silently, so a
+// method reached only through `?.` — the dominant idiom for optional
+// module/service dispatch — looked callerless and read as dead code.
+func TestCSharpExtractor_NullConditionalInvocationCallEdge(t *testing.T) {
+	src := []byte(`public class Alpha {
+    public void Target(int x) { }
+    public void Plain() {
+        var a = new Alpha();
+        a.Target(1);
+    }
+    public void NullConditional() {
+        var a = new Alpha();
+        a?.Target(2);
+    }
+    public void CastNullConditional(object o) {
+        (o as Alpha)?.Target(3);
+    }
+}`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("Alpha.cs", src)
+	require.NoError(t, err)
+
+	callers := map[string]bool{}
+	for _, ed := range result.Edges {
+		if ed.Kind != graph.EdgeCalls {
+			continue
+		}
+		if strings.HasSuffix(ed.To, ".Target") {
+			callers[ed.From] = true
+		}
+	}
+
+	assert.True(t, callers["Alpha.cs::Alpha.Plain"],
+		"plain member call must mint a calls edge (control)")
+	assert.True(t, callers["Alpha.cs::Alpha.NullConditional"],
+		"`a?.Target(2)` must mint a calls edge")
+	assert.True(t, callers["Alpha.cs::Alpha.CastNullConditional"],
+		"`(o as Alpha)?.Target(3)` must mint a calls edge")
+}


### PR DESCRIPTION
## Summary

The C# extractor emits no `calls` edge for a null-conditional invocation, so any method reached only through `recv?.M(...)` has no callers in the graph and reads as dead code. Details and measurements in #366.

`recv?.M(x)` parses as an `invocation_expression` whose `function` field is a `conditional_access_expression`. The alternation in `qCSharpAll` matched only `function: (identifier)` and `function: (member_access_expression)`, so the call site was dropped silently.

On a 3.8k-file C# repository, counting only call sites whose target method is defined in the same repository: `?.M(` had 5/1154 sites with a `calls` edge (0.4%) against 400/1132 (35.3%) for plain `.M(`.

Fixes #366

## Changes

- One added alternation in `qCSharpAll` for `function: (conditional_access_expression condition: (_) (member_binding_expression name: (identifier)))`.

It reuses the existing `@callm.receiver` / `@callm.method` / `@callm.expr` captures, so the deferred member-call buffer, receiver-type resolution and return-usage classification are untouched — only the set of matched invocation shapes grows. Per tree-sitter-c-sharp v0.23.5 `node-types.json`, `invocation_expression.function` already lists `conditional_access_expression`, and `member_binding_expression` carries field `name`.

Chained forms split by where the `?` sits, and only one of the two was already covered:

| form | before | after |
|---|---|---|
| `a?.b.M()` — conditional access in the receiver, invocation on a `member_access_expression` | edge | edge |
| `a?.M()` | none | edge |
| `a.b?.M()` — conditional access at the invocation | none | edge |

## Testing

- [x] `go test ./internal/parser/languages/` — full package green
- [x] New tests added for new functionality
- [ ] Benchmarks run if performance-relevant — not performance-relevant: one more alternation in the single existing tree walk, no extra pass

`TestCSharpExtractor_NullConditionalInvocationCallEdge` covers `a.M()` (control), `a?.M()` and `(o as T)?.M()` against the same target method. Verified red before the change — the control passes, both `?.` assertions fail — and green after.

Also verified end to end: a patched binary indexing the same fixture produces `calls` edges at all three lines, where stock produces only the plain-call one.

## Checklist

- [x] Code follows existing patterns in the codebase
- [x] No unnecessary abstractions added
- [ ] Language extractor includes `Meta["methods"]` for interfaces — n/a, no change to interface extraction
- [ ] Methods have `EdgeMemberOf` edges to their containing type — n/a, unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
