### PR TITLE
Normalise graphRelPath to the graph's node-ID path spelling

### DIFF
--- a/internal/mcp/tools_fileops.go
+++ b/internal/mcp/tools_fileops.go
@@ -522,9 +522,24 @@ func (s *Server) resolveGraphPath(graphPath string) (string, error) {
 // prefixed nodes in multi-repo mode.
 func (s *Server) graphRelPath(fp string) string {
 	if _, rel, err := s.resolveFilePath(fp); err == nil && rel != "" {
-		return rel
+		return s.graphPathSpelling(rel)
 	}
 	return fp
+}
+
+// graphPathSpelling renders a repo-relative path the way graph node IDs
+// spell it: the repo prefix joined with "/", the repo-relative remainder in
+// the OS separator. resolveFilePath echoes a caller-supplied relative path
+// back verbatim, so without this a forward-slash path — the spelling every
+// agent writes — missed every node below the repo root on Windows and the
+// read tools answered file_not_indexed for an indexed file. Identity on
+// POSIX, where the two separators already agree.
+func (s *Server) graphPathSpelling(rel string) string {
+	prefixed := false
+	if s.multiIndexer != nil {
+		prefixed = matchedRepoPrefix(s.multiIndexer, rel) != ""
+	}
+	return graphMatchPathKey(rel, prefixed)
 }
 
 // fileAttributionNode synthesizes a node carrying just the repo prefix

--- a/internal/mcp/tools_search_text_pathsep_test.go
+++ b/internal/mcp/tools_search_text_pathsep_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	mcplib "github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
@@ -61,11 +62,35 @@ func nestedRepoServer(t *testing.T, entries []config.RepoEntry) (*Server, *graph
 	_, err = mi.IndexAll()
 	require.NoError(t, err)
 
-	srv := NewServer(query.NewEngine(g), g, nil, nil, zap.NewNop(), nil, MultiRepoOptions{
+	singleton := indexer.New(g, reg, config.IndexConfig{}, zap.NewNop())
+	srv := NewServer(query.NewEngine(g), g, singleton, nil, zap.NewNop(), nil, MultiRepoOptions{
 		ConfigManager: cm,
 		MultiIndexer:  mi,
 	})
 	return srv, g
+}
+
+// TestGraphRelPath_LoneRepoForwardSlash covers the read side of the same
+// separator gap. resolveFilePath echoes a caller-supplied relative path back
+// verbatim, so a forward-slash path — what agents write, and what every tool
+// description shows — reached the graph unchanged and missed the node below
+// the repo root on Windows: get_file_summary answered file_not_indexed for a
+// file that was indexed.
+func TestGraphRelPath_LoneRepoForwardSlash(t *testing.T) {
+	solo := setupNestedRepo(t, "solo", "shared", "package sub\n\nfunc SoloHandler() {}\n")
+	srv, g := nestedRepoServer(t, []config.RepoEntry{{Path: solo, Name: "solo", Project: "backend"}})
+
+	nodeKey := filepath.FromSlash("pkg/sub/main.go")
+	require.NotNil(t, g.GetNode(nodeKey), "fixture invariant: a lone repo mints unprefixed node ids")
+
+	require.Equal(t, nodeKey, srv.graphRelPath("pkg/sub/main.go"),
+		"a forward-slash path must be normalised to the graph's spelling")
+	require.Equal(t, nodeKey, srv.graphRelPath(nodeKey),
+		"an already OS-spelled path is unchanged (idempotent)")
+
+	res := callTool(t, srv, "get_file_summary", map[string]any{"path": "pkg/sub/main.go"})
+	require.False(t, res.IsError, "a forward-slash repo-relative path must resolve")
+	require.Contains(t, res.Content[0].(mcplib.TextContent).Text, "SoloHandler")
 }
 
 // TestFilterTextMatchesByResolvedScope_BelowRepoRoot is the regression for

--- a/internal/mcp/tools_search_text_test.go
+++ b/internal/mcp/tools_search_text_test.go
@@ -376,8 +376,10 @@ func TestGetFileSummary_MultiRepoRelativePath(t *testing.T) {
 		MultiIndexer:  mi,
 	})
 
-	// A repo-relative path unique to one repo anchors to that repo's prefix.
-	require.Equal(t, "alpha/svc/a.go", srv.graphRelPath("svc/a.go"))
+	// A repo-relative path unique to one repo anchors to that repo's prefix,
+	// spelled the way node IDs are: prefix by "/", remainder by the OS
+	// separator. On POSIX the two are the same string.
+	require.Equal(t, "alpha/"+filepath.FromSlash("svc/a.go"), srv.graphRelPath("svc/a.go"))
 
 	// get_file_summary with the repo-relative path now finds the symbols
 	// rather than returning a file_not_indexed miss.
@@ -386,7 +388,7 @@ func TestGetFileSummary_MultiRepoRelativePath(t *testing.T) {
 	require.Contains(t, res.Content[0].(mcplib.TextContent).Text, "AlphaHandler")
 
 	// An already-prefixed path keeps working (idempotent normalisation).
-	require.Equal(t, "beta/other/b.go", srv.graphRelPath("beta/other/b.go"))
+	require.Equal(t, "beta/"+filepath.FromSlash("other/b.go"), srv.graphRelPath("beta/other/b.go"))
 }
 
 // TestFilterTextMatchesByPath_RepoPrefixed pins the multi-repo path


### PR DESCRIPTION
## Summary

Follow-up to #365, closing the read-side half of the same separator gap — the one I flagged there as out of scope.

`graphRelPath`'s documented contract is "the repo-relative form the graph stores its nodes under", and every call site uses it exactly that way, immediately before `GetFileSymbols` / `FileEditingContext`. But `resolveFilePath` echoes a caller-supplied relative path back verbatim, so the forward-slash spelling every agent writes reached the graph unchanged. Node IDs join the repo prefix with `/` and keep the remainder in the OS separator, so on Windows the lookup missed every file below the repo root:

```
read operation:"summary" path="src/pkg/thing.cs"   -> file_not_indexed   (indexed file)
read operation:"summary" path="src\pkg\thing.cs"   -> the symbol table
```

Measured on a real 2.1k-file repo with v0.61.4: the first form fails for every file in a subdirectory, which is all of them.

## Changes

- `graphPathSpelling` renders a resolved repo-relative path the way node IDs spell it, reusing `graphMatchPathKey` from #365. `graphRelPath` runs its result through it. Identity on POSIX.
- Two assertions in `TestGetFileSummary_MultiRepoRelativePath` pinned the POSIX spelling as if it were platform-independent (`"alpha/svc/a.go"`); they are now platform-aware. That test's tool-level assertion has been failing on Windows and passes with this change.

## Testing

- [x] `go test ./internal/mcp/` — no regressions, one pre-existing Windows failure fixed (numbers below)
- [x] New tests added for new functionality
- [ ] Benchmarks run if performance-relevant — not performance-relevant

`TestGraphRelPath_LoneRepoForwardSlash` covers the lone-repo case (unprefixed node IDs), asserting both the normalisation and that `get_file_summary` resolves a forward-slash path end to end. Verified red before this change and green after.

Full-package comparison on Windows 11, Go 1.26.5, same machine and same run conditions:

| tree | `--- FAIL` count in `internal/mcp` |
|---|---|
| stock `main` (095ffba7) | 59 |
| this branch | 58 |

Set difference: no test fails here that does not already fail on `main`; the single test that stops failing is `TestGetFileSummary_MultiRepoRelativePath`.

**Correction to #365.** In that PR I wrote that two `internal/mcp` tests fail on Windows before and after the change. That number came from a truncated view of the test output and is wrong — the real pre-existing Windows failure count in this package is 59, spread across notebook / notes / memory / scope-store persistence, inline-symbol and move-symbol refactors, overlay, and several path helpers. #365's actual claim — no regressions — still holds: the comparison above was run against a tree carrying both #365's change and this one, and no test fails in it that does not already fail on stock `main`. Whether that Windows test debt is worth a tracking issue is your call; I did not open one.

## Checklist

- [x] Code follows existing patterns in the codebase
- [x] No unnecessary abstractions added
- [ ] Language extractor includes `Meta["methods"]` for interfaces — n/a
- [ ] Methods have `EdgeMemberOf` edges to their containing type — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)
