### PR TITLE
Stop dropping C# reference forms for type names in caseless scripts

### DIFF
--- a/internal/indexer/extractor_version.go
+++ b/internal/indexer/extractor_version.go
@@ -26,7 +26,8 @@ var extractorVersions = map[string]int{
 	// Languages default to version 1 (no salt). Raise an entry here in
 	// the same change that alters a language's extraction logic, e.g.
 	//   "go": 2,
-	"php": 2, // class/interface inheritance now emits typed structural edges
+	"php":    2, // class/interface inheritance now emits typed structural edges
+	"csharp": 2, // null-conditional call edges; reference forms for caseless type names
 }
 
 // extractorSaltExtLang maps a lower-case file extension to the language

--- a/internal/parser/languages/csharp_caseless_typeuse_test.go
+++ b/internal/parser/languages/csharp_caseless_typeuse_test.go
@@ -1,0 +1,107 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// refTargets collects the reference-form edge targets of one kind, keyed by
+// target id, with the ref_context that produced them.
+func refTargets(edges []*graph.Edge, kind graph.EdgeKind) map[string]string {
+	out := map[string]string{}
+	for _, e := range edges {
+		if e.Kind != kind {
+			continue
+		}
+		ctx := ""
+		if e.Meta != nil {
+			if v, ok := e.Meta["ref_context"].(string); ok {
+				ctx = v
+			}
+		}
+		out[e.To] = ctx
+	}
+	return out
+}
+
+// A type named in a script without case — Chinese here, but Japanese, Korean,
+// Hebrew, Arabic and Thai are the same shape — can never be "Capitalized".
+// Gating the reference-form pass on capitalisation therefore did not merely
+// lose precision in such a codebase, it dropped every instantiation, cast and
+// static access in the repository.
+func TestCSharpTypeUse_CaselessScriptTypeNames(t *testing.T) {
+	src := []byte(`public class 消息工厂 {
+    public object 创建(object 输入) {
+        var 请求 = new 钓鱼点覆盖请求();
+        var 类型 = 消息类型.钓鱼点覆盖请求;
+        var 转换 = 输入 as 钓鱼点覆盖请求;
+        if (输入 is 钓鱼点列表响应) { }
+        return 请求;
+    }
+}`)
+	e := NewCSharpExtractor()
+	res, err := e.Extract("消息工厂.cs", src)
+	require.NoError(t, err)
+
+	inst := refTargets(res.Edges, graph.EdgeInstantiates)
+	require.Contains(t, inst, "unresolved::钓鱼点覆盖请求",
+		"`new 钓鱼点覆盖请求()` must mint an instantiates edge")
+
+	refs := refTargets(res.Edges, graph.EdgeReferences)
+	assert.Equal(t, "cast", refs["unresolved::钓鱼点覆盖请求"],
+		"`输入 as 钓鱼点覆盖请求` must mint a cast reference")
+	assert.Equal(t, "cast", refs["unresolved::钓鱼点列表响应"],
+		"`输入 is 钓鱼点列表响应` must mint a cast reference")
+	assert.Equal(t, "static_access", refs["unresolved::消息类型"],
+		"`消息类型.X` must mint a static_access reference to the enum type")
+}
+
+// The capitalisation gate stood in for "is this receiver a value?". Where a
+// script has no case the question is answered directly instead, so a local
+// that shares a name with a type must still not be read as a static access.
+func TestCSharpTypeUse_CaselessLocalReceiverIsNotStaticAccess(t *testing.T) {
+	src := []byte(`public class 处理器 {
+    public void 运行() {
+        var 消息 = 取消息();
+        var 值 = 消息.字段;
+    }
+    private object 取消息() { return null; }
+}`)
+	e := NewCSharpExtractor()
+	res, err := e.Extract("处理器.cs", src)
+	require.NoError(t, err)
+
+	refs := refTargets(res.Edges, graph.EdgeReferences)
+	assert.NotContains(t, refs, "unresolved::消息",
+		"a receiver the file declares as a local must not become a type reference")
+}
+
+// Cased-script behaviour is unchanged: an uppercase receiver is a static
+// access, a lowercase one is not, and primitives stay out.
+func TestCSharpTypeUse_CasedScriptUnchanged(t *testing.T) {
+	src := []byte(`public class Factory {
+    public object Build(object input) {
+        var local = Helper();
+        var dead = local.Field;
+        var color = Palette.Red;
+        var made = new Widget();
+        return made;
+    }
+    private object Helper() { return null; }
+}`)
+	e := NewCSharpExtractor()
+	res, err := e.Extract("Factory.cs", src)
+	require.NoError(t, err)
+
+	refs := refTargets(res.Edges, graph.EdgeReferences)
+	assert.Equal(t, "static_access", refs["unresolved::Palette"],
+		"an uppercase receiver is still a static access")
+	assert.NotContains(t, refs, "unresolved::local",
+		"a lowercase receiver is still rejected")
+
+	inst := refTargets(res.Edges, graph.EdgeInstantiates)
+	assert.Contains(t, inst, "unresolved::Widget")
+}

--- a/internal/parser/languages/csharp_typeuse.go
+++ b/internal/parser/languages/csharp_typeuse.go
@@ -3,6 +3,8 @@ package languages
 import (
 	"strconv"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/parser"
@@ -21,8 +23,7 @@ import (
 //     (is_pattern_expression), `x as Foo` (as_expression)
 //     → EdgeReferences, Meta["ref_context"]="cast"
 //   - STATIC ACCESS   `Foo.Const` / `Foo.Method()` (member_access_expression
-//     whose receiver is a bare Capitalized identifier),
-//     `typeof(Foo)`, `nameof(Foo)`
+//     whose receiver names a type), `typeof(Foo)`, `nameof(Foo)`
 //     → EdgeReferences, Meta["ref_context"]="static_access"
 //   - ATTRIBUTE TYPE  `[Foo]` / `[Foo(...)]` (attribute) names the type Foo
 //     → EdgeReferences, Meta["ref_context"]="attribute"
@@ -52,12 +53,14 @@ import (
 // the guard polices at all, but it carries the same origin for
 // consistency.
 //
-// Scope discipline keeps the graph clean: only Capitalized leaf type
-// names are emitted (lowercase locals / primitives are skipped via the
-// Capitalization gate + isCSharpPrimitive), and a member access only
-// counts when its receiver is a bare Capitalized identifier — `this.x`,
-// `local.Foo`, and chained `a.b.C` are all excluded so a field read on an
-// instance is never mistaken for a static type reference.
+// Scope discipline keeps the graph clean, but only where a heuristic is
+// actually needed. A name in a syntactically guaranteed type position
+// (`new T()`, `(T)x`, `x as T`, `x is T`, `typeof(T)`, `[T]`, `List<T>`) is
+// emitted on the grammar's authority alone; primitives are still skipped.
+// Type-ness is inferred only for a member-access receiver, where `Type.X` and
+// `local.X` are the same shape — see csharpStaticReceiverEligible, which
+// accepts an uppercase receiver outright and falls back to "is this name
+// bound to a value in this file" for scripts that have no case at all.
 func emitCSharpReferenceForms(root *sitter.Node, src []byte, filePath, fileID string, result *parser.ExtractionResult) {
 	if root == nil {
 		return
@@ -75,11 +78,27 @@ func emitCSharpReferenceForms(root *sitter.Node, src []byte, filePath, fileID st
 		return fileID
 	}
 
+	// Identifiers this file declares as VALUES. A member access whose
+	// receiver is one of them reads an instance, not a type — the thing the
+	// Capitalization gate stands in for. Collected once so the caseless-script
+	// path can ask the real question instead of the ASCII-shaped proxy.
+	valueIdents := csharpDeclaredValueIdents(root, src)
+
 	// emitRef appends an EdgeReferences (cast / static_access / attribute)
-	// or EdgeInstantiates edge for a single Capitalized, non-primitive type.
-	emit := func(rawType string, line int, kind graph.EdgeKind, refContext string) {
+	// or EdgeInstantiates edge for a single non-primitive type.
+	//
+	// typePosition says the grammar already guarantees the name is a type —
+	// `new T()`, `(T)x`, `x as T`, `x is T`, `typeof(T)`, `[T]`, `List<T>`.
+	// Those positions need no naming heuristic at all, and applying one there
+	// dropped every such reference in a codebase whose types are named in a
+	// script without case. A receiver read out of `T.Member` is the only
+	// position where type-ness must be inferred.
+	emit := func(rawType string, line int, kind graph.EdgeKind, refContext string, typePosition bool) {
 		canon := canonicalizeCSharpTypeRef(rawType)
-		if canon == "" || isCSharpPrimitive(canon) || !isCSharpTypeNameCapitalized(canon) {
+		if canon == "" || isCSharpPrimitive(canon) {
+			return
+		}
+		if !typePosition && !csharpStaticReceiverEligible(canon, valueIdents) {
 			return
 		}
 		owner := ownerFor(line)
@@ -114,61 +133,60 @@ func emitCSharpReferenceForms(root *sitter.Node, src []byte, filePath, fileID st
 			// named child (identifier / generic_name / qualified_name);
 			// implicit_object_creation (`new()`) has no type and is skipped.
 			if name := csharpCreationTypeName(n, src); name != "" {
-				emit(name, line, graph.EdgeInstantiates, "")
+				emit(name, line, graph.EdgeInstantiates, "", true)
 			}
 
 		case "array_creation_expression":
 			// `new Foo[3]` — the element type lives on the nested array_type.
 			if at := csharpFirstChildOfType(n, "array_type"); at != nil {
 				if name := csharpArrayElementTypeName(at, src); name != "" {
-					emit(name, line, graph.EdgeInstantiates, "")
+					emit(name, line, graph.EdgeInstantiates, "", true)
 				}
 			}
 
 		case "cast_expression":
 			// `(Foo)x` — the type is the `type` field (first named child).
 			if name := csharpCastTypeName(n, src); name != "" {
-				emit(name, line, graph.EdgeReferences, "cast")
+				emit(name, line, graph.EdgeReferences, "cast", true)
 			}
 
 		case "as_expression":
 			// `x as Foo` — binary form `value as Type`; the type is the
 			// second named child.
 			if name := csharpAsExpressionTypeName(n, src); name != "" {
-				emit(name, line, graph.EdgeReferences, "cast")
+				emit(name, line, graph.EdgeReferences, "cast", true)
 			}
 
 		case "is_pattern_expression":
 			// `x is Foo` (constant_pattern) / `x is Foo f` (declaration_pattern).
 			if name := csharpIsPatternTypeName(n, src); name != "" {
-				emit(name, line, graph.EdgeReferences, "cast")
+				emit(name, line, graph.EdgeReferences, "cast", true)
 			}
 
 		case "typeof_expression":
 			// `typeof(Foo)` — the type is the named child.
 			if name := csharpUnaryTypeArgName(n, src); name != "" {
-				emit(name, line, graph.EdgeReferences, "static_access")
+				emit(name, line, graph.EdgeReferences, "static_access", true)
 			}
 
 		case "member_access_expression":
-			// `Foo.Const` / `Foo.Method` — only when the receiver is a bare
-			// Capitalized identifier (a type), never `this.x` / `local.X` /
-			// chained `a.b.C`.
+			// `Foo.Const` / `Foo.Method` — only when the receiver names a
+			// type, never `this.x` / `local.X` / chained `a.b.C`.
 			if name := csharpStaticAccessReceiver(n, src); name != "" {
-				emit(name, line, graph.EdgeReferences, "static_access")
+				emit(name, line, graph.EdgeReferences, "static_access", false)
 			}
 
 		case "invocation_expression":
 			// `nameof(Foo)` parses as a plain invocation, not a dedicated
 			// node — special-case it so the referenced type surfaces.
 			if name := csharpNameofTypeArg(n, src); name != "" {
-				emit(name, line, graph.EdgeReferences, "static_access")
+				emit(name, line, graph.EdgeReferences, "static_access", false)
 			}
 
 		case "attribute":
 			// `[Foo]` / `[Foo(...)]` names the attribute type Foo.
 			if name := csharpAttributeTypeName(n, src); name != "" {
-				emit(name, line, graph.EdgeReferences, "attribute")
+				emit(name, line, graph.EdgeReferences, "attribute", true)
 			}
 
 		case "type_argument_list":
@@ -199,31 +217,78 @@ func emitCSharpReferenceForms(root *sitter.Node, src []byte, filePath, fileID st
 					// `List<Qux>` — its head names a type; the nested
 					// type_argument_list (<Qux>) is visited separately.
 					if head := csharpFirstChildOfType(arg, "identifier"); head != nil {
-						emit(strings.TrimSpace(head.Content(src)), line, graph.EdgeReferences, "generic_arg")
+						emit(strings.TrimSpace(head.Content(src)), line, graph.EdgeReferences, "generic_arg", true)
 					}
 				case "identifier", "qualified_name", "nullable_type", "array_type":
 					// `Foo`, `Ns.Foo`, `Foo?`, `Foo[]` — canonicalizeCSharpTypeRef
 					// (called inside emit) strips the namespace / nullable /
 					// array decoration down to the bare named type.
-					emit(strings.TrimSpace(arg.Content(src)), line, graph.EdgeReferences, "generic_arg")
+					emit(strings.TrimSpace(arg.Content(src)), line, graph.EdgeReferences, "generic_arg", true)
 				}
 			}
 		}
 	})
 }
 
-// isCSharpTypeNameCapitalized reports whether a canonicalized type name
-// begins with an uppercase ASCII letter — the Capitalization gate that
-// keeps lowercase locals, parameters, and keywords out of the reference
-// surface. canonicalizeCSharpTypeRef has already stripped generics,
-// nullable markers, arrays, and namespace qualification, so the first
-// rune of the bare name is the discriminator.
-func isCSharpTypeNameCapitalized(name string) bool {
+// csharpStaticReceiverEligible reports whether a bare member-access receiver
+// may be read as a type rather than as a value.
+//
+// An uppercase first rune is the C# convention and is accepted outright, so
+// nothing changes for a codebase written in a cased script. A script WITHOUT
+// case — Chinese, Japanese, Korean, Hebrew, Arabic, Thai — has no such
+// convention available: no identifier in it is ever "Capitalized", so gating
+// on capitalisation silently dropped every reference form in such a codebase
+// rather than merely being imprecise. For those names the question the gate
+// was really asking is answered directly instead: a receiver the file
+// declares as a value is an instance access, anything else may be a type.
+// A lowercase cased letter is still rejected, and so is anything that is not
+// a letter, which keeps `_field.X` and `local.X` out as before.
+func csharpStaticReceiverEligible(name string, valueIdents map[string]bool) bool {
 	if name == "" {
 		return false
 	}
-	c := name[0]
-	return c >= 'A' && c <= 'Z'
+	r, _ := utf8.DecodeRuneInString(name)
+	if r == utf8.RuneError {
+		return false
+	}
+	if unicode.IsUpper(r) {
+		return true
+	}
+	if unicode.IsLower(r) || !unicode.IsLetter(r) {
+		return false
+	}
+	return !valueIdents[name]
+}
+
+// csharpDeclaredValueIdents collects every identifier the file binds to a
+// VALUE: locals and fields (variable_declarator), parameters, foreach
+// variables, pattern designations (`x is Foo f`), and catch bindings. It is
+// deliberately file-scoped rather than block-scoped — a name bound as a value
+// anywhere in the file is treated as a value throughout, which errs toward
+// dropping a reference rather than inventing one.
+func csharpDeclaredValueIdents(root *sitter.Node, src []byte) map[string]bool {
+	out := map[string]bool{}
+	add := func(n *sitter.Node) {
+		if n == nil {
+			return
+		}
+		if name := strings.TrimSpace(n.Content(src)); name != "" {
+			out[name] = true
+		}
+	}
+	walkNodes(root, func(n *sitter.Node) {
+		switch n.Type() {
+		case "variable_declarator", "single_variable_designation":
+			add(csharpFirstChildOfType(n, "identifier"))
+		case "parameter", "catch_declaration", "foreach_statement":
+			if nameNode := n.ChildByFieldName("name"); nameNode != nil {
+				add(nameNode)
+			} else {
+				add(csharpFirstChildOfType(n, "identifier"))
+			}
+		}
+	})
+	return out
 }
 
 // csharpFirstChildOfType returns the first named child of node whose type


### PR DESCRIPTION
## Summary

`emitCSharpReferenceForms` gates every emission on `isCSharpTypeNameCapitalized`, which tests whether the **first byte** is in `'A'..'Z'`. A type named in a script without case — Chinese, Japanese, Korean, Hebrew, Arabic, Thai — can never satisfy that. In such a codebase the gate does not lose precision, it disables the pass: no instantiations, no casts, no `as` / `is`, no `typeof`, no attributes, no generic arguments, no static access.

Measured on a 2.1k-file C# repository whose identifiers are Chinese, gortex v0.61.4:

| | types/interfaces/enums | with an incoming `references` or `instantiates` edge |
|---|---|---|
| Han-initial names | 2003 | **0 (0.0%)** |
| ASCII-initial names | 2292 | 1128 (49.2%) |

All 6691 `instantiates` edges in that graph pointed at ASCII names, while the source contains 2609 `new <Han type>(` sites. A 170-line message-factory file — one `[Kind.X] = () => new X(),` entry per protocol message — carried 17 edges in total, all from its imports and its two declarations.

After this change, on the same repository: Han-initial 1858/2003 (**92.8%**), ASCII-initial 1132/2292 (49.4%, i.e. unchanged), `instantiates` targets 3682 Han-initial / 6712 ASCII.

## Changes

- A name in a **syntactically guaranteed type position** — `new T()`, `new T[]`, `(T)x`, `x as T`, `x is T`, `typeof(T)`, `[T]`, `List<T>` — is emitted on the grammar's authority. No naming heuristic is needed there at all; the capitalisation test was being applied to positions that never had to guess. Primitives are still skipped.
- Type-ness is inferred only for a **member-access receiver**, where `T.X` and `local.X` are genuinely the same shape. An uppercase receiver is accepted exactly as before, so cased-script behaviour is untouched. For a caseless name the question the gate was really asking — *is this receiver bound to a value?* — is answered from the file's own declarations (`csharpDeclaredValueIdents`: locals, fields, parameters, `foreach` variables, pattern designations, catch bindings) instead of from its spelling. The collection is file-scoped rather than block-scoped, which errs toward dropping a reference rather than inventing one.

`isCSharpTypeNameCapitalized` also becomes rune-aware rather than byte-aware, which is what it always meant.

## Testing

- [x] `go test ./internal/parser/languages/` — full package green, no regressions
- [x] New tests added for new functionality
- [ ] Benchmarks run if performance-relevant — one extra tree walk per C# file to collect declared value identifiers; the pass already walks the tree twice

New tests:

- `TestCSharpTypeUse_CaselessScriptTypeNames` — instantiation, `as`, `is` and static access on Han-named types all mint edges. Verified red before the change (every assertion) and green after.
- `TestCSharpTypeUse_CaselessLocalReceiverIsNotStaticAccess` — a caseless receiver the file declares as a local must not become a type reference; this is the case the capitalisation gate was standing in for.
- `TestCSharpTypeUse_CasedScriptUnchanged` — uppercase receiver still a static access, lowercase still rejected, `new Widget()` still an instantiation.

## Not included

Even with this fix, a reference to an enum **member** (`Kind.Value` read as a value) is recorded against the owning enum type, never the member: `references` targets in that repository's graph are `type`, `method`, `interface` and `param` only, so "is this enum value used?" answers nothing for all 2726 `enum_member` nodes. I prototyped emitting the member as `unresolved::*.<name>` and backed it out — the resolver does not bind that form for `references` edges, so it produced ~85k unresolved edges, delivered no member attribution, and measurably diluted resolution elsewhere (the ASCII column above dropped to 47.3% with it in, and returned to 49.4% with it out). Landing it properly looks like resolver work rather than extractor work, so I left it out rather than guess at your binding rules. Happy to open a separate issue with the measurements if it is useful.

## Checklist

- [x] Code follows existing patterns in the codebase
- [x] No unnecessary abstractions added
- [ ] Language extractor includes `Meta["methods"]` for interfaces — n/a
- [ ] Methods have `EdgeMemberOf` edges to their containing type — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)
