### PR TITLE
Forward the caller's flags to the detached daemon child

### DIFF
--- a/cmd/gortex/daemon.go
+++ b/cmd/gortex/daemon.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"go.uber.org/zap"
 
 	"github.com/zzet/gortex/internal/daemon"
@@ -70,10 +71,13 @@ If no daemon is running, ` + "`gortex mcp`" + ` still works standalone — the d
 is additive, not required.`,
 }
 
+// RunE is wired in init() rather than here: runDaemonStart reaches back for
+// daemonStartCmd's flag set (to know what the re-exec'd child accepts), and
+// naming runDaemonStart in this initializer would close an initialization
+// cycle the compiler rejects.
 var daemonStartCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Start the daemon",
-	RunE:  runDaemonStart,
 }
 
 var daemonStopCmd = &cobra.Command{
@@ -107,6 +111,7 @@ var daemonLogsCmd = &cobra.Command{
 }
 
 func init() {
+	daemonStartCmd.RunE = runDaemonStart
 	daemonStartCmd.Flags().BoolVar(&daemonDetach, "detach", false,
 		"fork to background after starting (logs to the daemon log file — see `gortex daemon logs`)")
 	daemonStartCmd.Flags().BoolVar(&daemonEmbeddings, "embeddings", false,
@@ -176,7 +181,7 @@ func runDaemonStart(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("daemon already running (pid %d) — stop it with `gortex daemon stop`, or use `gortex daemon restart`", pid)
 	}
 	if daemonDetach && os.Getenv("GORTEX_DAEMON_CHILD") != "1" {
-		return spawnDetachedDaemon()
+		return spawnDetachedDaemon(detachedDaemonArgs(cmd.Flags(), daemonStartAcceptedFlags()))
 	}
 	logger := newLogger()
 
@@ -197,8 +202,9 @@ func runDaemonStart(cmd *cobra.Command, _ []string) error {
 
 	// Record whether `--embeddings` was set explicitly so
 	// buildDaemonState can let it override the `embedding:` config
-	// block. With `--detach` the re-exec'd child sees no flags, so an
-	// explicit opt-in there must travel via GORTEX_EMBEDDINGS instead.
+	// block. `--detach` forwards the flag verbatim (including
+	// `--embeddings=false`), so the child sees the same explicit-ness
+	// the parent did.
 	daemonEmbeddingsChanged = cmd.Flags().Changed("embeddings")
 
 	// Fast path: snapshot load + indexer + MCP server wiring. The
@@ -742,15 +748,70 @@ func startPeriodicSnapshots(g *graph.Graph, mi *indexer.MultiIndexer, version st
 	return func() { close(stop) }
 }
 
+// daemonStartAcceptedFlags returns every flag the re-exec'd `daemon start`
+// can parse: its own, plus the persistent flags it inherits from the root
+// command. cobra only folds the inherited half into Flags() when the command
+// actually executes, so callers that reach the spawn from a *different*
+// command (`daemon restart`, `install --start`) have to ask for it explicitly
+// or --log-level / --config would look unrecognised and be dropped.
+func daemonStartAcceptedFlags() *pflag.FlagSet {
+	accepted := pflag.NewFlagSet("daemon start", pflag.ContinueOnError)
+	accepted.AddFlagSet(daemonStartCmd.Flags())
+	accepted.AddFlagSet(daemonStartCmd.InheritedFlags())
+	return accepted
+}
+
+// detachedDaemonArgs rebuilds the argv the detached child needs so a
+// `--detach` start behaves exactly like the same command without it.
+// Only flags the user actually set are emitted (pflag's Visit walks the
+// changed set), in `--name=value` form — there is no shell between us and
+// the child, so values that would need quoting are safe, and defaults stay
+// implicit so the child still resolves them from config the same way a
+// foreground start does.
+//
+// `changed` is the flag set of the command being run (cobra merges the
+// inherited persistent flags into it, so --log-level / --config ride along);
+// `accepted` is the child's `daemon start` flag set. A changed flag the child
+// wouldn't recognise is dropped rather than handed to a process that would
+// exit on "unknown flag" — that is what lets `daemon restart` and
+// `install --start` reuse this without leaking their own flags. --detach is
+// dropped too: the child *is* the detached daemon.
+func detachedDaemonArgs(changed, accepted *pflag.FlagSet) []string {
+	var out []string
+	if changed == nil {
+		return out
+	}
+	changed.Visit(func(f *pflag.Flag) {
+		if f.Name == "detach" {
+			return
+		}
+		if accepted != nil && accepted.Lookup(f.Name) == nil {
+			return
+		}
+		// Slice flags stringify as "[a,b]", which pflag can't parse back.
+		// Repeat the flag instead — the second Set appends.
+		if sv, ok := f.Value.(pflag.SliceValue); ok {
+			for _, v := range sv.GetSlice() {
+				out = append(out, "--"+f.Name+"="+v)
+			}
+			return
+		}
+		out = append(out, "--"+f.Name+"="+f.Value.String())
+	})
+	return out
+}
+
 // spawnDetachedDaemon re-invokes the binary with GORTEX_DAEMON_CHILD=1
 // set, the log redirected to the daemon log file, and the child
 // parented to init. Parent exits as soon as the child has the socket up.
+// childArgs (from detachedDaemonArgs) carries the caller's flags through
+// to the re-exec'd `daemon start`.
 //
 // On a TTY the parent shows a mesh-spinner banner and a styled "ready" card
 // once the socket is live. On a non-TTY (CI scripts, automation) we keep the
 // historical one-line "[gortex daemon] detached (pid X, log: Y)" message so
 // existing parsers don't break.
-func spawnDetachedDaemon() error {
+func spawnDetachedDaemon(childArgs []string) error {
 	exe, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("resolve executable: %w", err)
@@ -763,19 +824,13 @@ func spawnDetachedDaemon() error {
 	if err != nil {
 		return fmt.Errorf("open log file: %w", err)
 	}
-	child := exec.Command(exe, "daemon", "start")
-	childEnv := append(os.Environ(), "GORTEX_DAEMON_CHILD=1")
-	// --detach re-execs `daemon start` with no flags, so the tool-preset
-	// selection must travel to the child via env (the GORTEX_TOOLS
-	// override path), mirroring how --embeddings propagates. Appended
-	// last so an explicit flag wins over any inherited GORTEX_TOOLS.
-	if daemonTools != "" {
-		childEnv = append(childEnv, "GORTEX_TOOLS="+daemonTools)
-	}
-	if daemonToolsMode != "" {
-		childEnv = append(childEnv, "GORTEX_TOOLS_MODE="+daemonToolsMode)
-	}
-	child.Env = childEnv
+	child := exec.Command(exe, append([]string{"daemon", "start"}, childArgs...)...)
+	// The child re-parses the forwarded flags itself, so nothing has to
+	// travel by env any more except the marker that stops it detaching
+	// again (and stops it clearing a stop-intent written meanwhile).
+	// Inherited GORTEX_* overrides keep the precedence they have on a
+	// foreground start rather than being re-injected from a flag here.
+	child.Env = append(os.Environ(), "GORTEX_DAEMON_CHILD=1")
 	child.Stdout = logFile
 	child.Stderr = logFile
 	child.Stdin = nil

--- a/cmd/gortex/daemon_detach_args_test.go
+++ b/cmd/gortex/daemon_detach_args_test.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// newDetachTestFlags mirrors the shape of the real `daemon start` flag set —
+// a bool, strings, a uint and a repeatable slice — without touching the
+// package-level command, so the table below can set flags freely.
+func newDetachTestFlags() *pflag.FlagSet {
+	fs := pflag.NewFlagSet("daemon start", pflag.ContinueOnError)
+	fs.Bool("detach", false, "")
+	fs.Bool("embeddings", false, "")
+	fs.String("http-addr", "", "")
+	fs.String("http-auth-token", "", "")
+	fs.String("cors-origin", "*", "")
+	fs.String("tools", "", "")
+	fs.Uint64("backend-buffer-pool-mb", 0, "")
+	fs.StringSlice("conversation-host", nil, "")
+	return fs
+}
+
+func TestDetachedDaemonArgsForwardsChangedFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		argv []string
+		want []string
+	}{
+		{
+			name: "nothing set forwards nothing",
+			argv: nil,
+			want: nil,
+		},
+		{
+			// The reported bug: --http-addr vanished, so the port never listened.
+			name: "http addr survives",
+			argv: []string{"--detach", "--http-addr", "127.0.0.1:7411"},
+			want: []string{"--http-addr=127.0.0.1:7411"},
+		},
+		{
+			name: "detach itself is never forwarded",
+			argv: []string{"--detach"},
+			want: nil,
+		},
+		{
+			name: "bool flag keeps its explicit value",
+			argv: []string{"--embeddings=false"},
+			want: []string{"--embeddings=false"},
+		},
+		{
+			name: "non-default and defaulted-back values both forward",
+			argv: []string{"--cors-origin=*", "--backend-buffer-pool-mb=512"},
+			want: []string{"--backend-buffer-pool-mb=512", "--cors-origin=*"},
+		},
+		{
+			name: "slice flag repeats instead of stringifying as a list",
+			argv: []string{"--conversation-host=a.internal", "--conversation-host=b.internal"},
+			want: []string{"--conversation-host=a.internal", "--conversation-host=b.internal"},
+		},
+		{
+			// No shell sits between parent and child, so a value with spaces
+			// or a leading dash must survive intact in --name=value form.
+			name: "awkward values need no quoting",
+			argv: []string{"--http-auth-token=-tok en"},
+			want: []string{"--http-auth-token=-tok en"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := newDetachTestFlags()
+			if err := fs.Parse(tt.argv); err != nil {
+				t.Fatalf("parse %v: %v", tt.argv, err)
+			}
+			got := detachedDaemonArgs(fs, fs)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("detachedDaemonArgs() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// A flag the child's `daemon start` doesn't know must be dropped: `install`
+// and `daemon restart` reach the same spawn carrying their own flags, and a
+// child that exits on "unknown flag" is worse than the flag not travelling.
+func TestDetachedDaemonArgsDropsFlagsTheChildCannotParse(t *testing.T) {
+	caller := pflag.NewFlagSet("install", pflag.ContinueOnError)
+	caller.Bool("start", false, "")
+	caller.String("agents", "", "")
+	caller.String("log-level", "info", "")
+	if err := caller.Parse([]string{"--start", "--agents=claude", "--log-level=debug"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	accepted := newDetachTestFlags()
+	accepted.String("log-level", "info", "")
+
+	got := detachedDaemonArgs(caller, accepted)
+	want := []string{"--log-level=debug"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("detachedDaemonArgs() = %q, want %q", got, want)
+	}
+}
+
+func TestDetachedDaemonArgsNilCaller(t *testing.T) {
+	if got := detachedDaemonArgs(nil, newDetachTestFlags()); got != nil {
+		t.Errorf("detachedDaemonArgs(nil, ...) = %q, want nil", got)
+	}
+}
+
+// The accepted set is what the child will actually parse, so it has to cover
+// both halves: `daemon start`'s own flags and the root command's persistent
+// ones. cobra merges those lazily, and the install / restart paths reach the
+// spawn without `daemon start` ever having executed.
+func TestDaemonStartAcceptedFlagsCoversLocalAndInherited(t *testing.T) {
+	accepted := daemonStartAcceptedFlags()
+
+	for _, name := range []string{"http-addr", "tools", "backend", "detach"} {
+		if accepted.Lookup(name) == nil {
+			t.Errorf("accepted set is missing local flag --%s", name)
+		}
+	}
+	for _, name := range []string{"log-level", "config", "no-progress"} {
+		if accepted.Lookup(name) == nil {
+			t.Errorf("accepted set is missing inherited flag --%s", name)
+		}
+	}
+}
+
+// End-to-end through cobra: parsing a real `daemon start` invocation must
+// reproduce every flag on the child's command line.
+func TestDetachedDaemonArgsFromCobraInvocation(t *testing.T) {
+	root := &cobra.Command{Use: "gortex"}
+	root.PersistentFlags().String("log-level", "info", "")
+
+	var captured []string
+	start := &cobra.Command{
+		Use: "start",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			captured = detachedDaemonArgs(cmd.Flags(), cmd.Flags())
+			return nil
+		},
+	}
+	start.Flags().Bool("detach", false, "")
+	start.Flags().String("http-addr", "", "")
+	daemon := &cobra.Command{Use: "daemon"}
+	daemon.AddCommand(start)
+	root.AddCommand(daemon)
+
+	root.SetArgs([]string{"daemon", "start", "--detach", "--http-addr=127.0.0.1:7411", "--log-level=debug"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	want := []string{"--http-addr=127.0.0.1:7411", "--log-level=debug"}
+	if !reflect.DeepEqual(captured, want) {
+		t.Errorf("detachedDaemonArgs() = %q, want %q", captured, want)
+	}
+}

--- a/cmd/gortex/ensure_daemon.go
+++ b/cmd/gortex/ensure_daemon.go
@@ -35,9 +35,15 @@ const (
 // testable without a real daemon.
 var (
 	isDaemonRunning  = daemon.IsRunning
-	spawnDaemon      = spawnDetachedDaemon
+	spawnDaemon      = spawnBareDaemon
 	stopIntentActive = daemon.StopIntentActive
 )
+
+// spawnBareDaemon is the autostart default for spawnDaemon. Autostart has no
+// `daemon start` flags to forward — it is `gortex mcp` / `gortex track`
+// bringing up a default daemon, not a user-typed start — so the child argv
+// stays bare and the daemon resolves everything from config.
+func spawnBareDaemon() error { return spawnDetachedDaemon(nil) }
 
 // resolveDaemonDecision probes the socket and, when auto-start is enabled
 // and no daemon is up, single-flights a spawn. It never returns an error;

--- a/cmd/gortex/ensure_daemon_test.go
+++ b/cmd/gortex/ensure_daemon_test.go
@@ -13,7 +13,7 @@ import (
 
 func restoreSeams() {
 	isDaemonRunning = daemon.IsRunning
-	spawnDaemon = spawnDetachedDaemon
+	spawnDaemon = spawnBareDaemon
 	stopIntentActive = daemon.StopIntentActive
 }
 

--- a/cmd/gortex/install.go
+++ b/cmd/gortex/install.go
@@ -296,7 +296,7 @@ func runInstallFollowUps(cmd *cobra.Command) error {
 		if daemon.IsRunning() {
 			fmt.Fprintln(w, "[gortex install] daemon already running (skipped --start)")
 		} else {
-			if err := spawnDetachedDaemon(); err != nil {
+			if err := spawnDetachedDaemon(detachedDaemonArgs(cmd.Flags(), daemonStartAcceptedFlags())); err != nil {
 				return fmt.Errorf("start daemon: %w", err)
 			}
 			fmt.Fprintln(w, "[gortex install] daemon started (detached)")

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -43,6 +43,9 @@ gortex install --no-hooks           # skip user-level hook installation
 
 # Daemon lifecycle (also spawned by `gortex install --start`):
 gortex daemon start --detach        # spawn in background
+gortex daemon start --detach --http-addr 127.0.0.1:7411 --log-level debug
+                                    # --detach forwards every other flag to the background process,
+                                    # so a detached start behaves like the same command without it
 gortex daemon status                # PID, uptime, memory, tracked repos, sessions, server roster, search backend, warmup + enrichment progress
 gortex daemon stop                  # graceful shutdown + final snapshot
 gortex daemon restart               # stop + start


### PR DESCRIPTION
Fixes #376.

## The bug

`spawnDetachedDaemon` re-exec'd the binary as a bare `daemon start`, so every flag on the original command line was silently discarded:

```
gortex daemon start --detach --http-addr 127.0.0.1:7411
```

…gave a running daemon, nothing listening on 7411, and no warning. `--backend`, `--backend-path`, `--cors-origin`, `--log-level` and the rest went the same way. Only `--tools` / `--tools-mode` survived, hand-propagated as `GORTEX_TOOLS` env vars.

## The fix

Rebuild the child's argv from the flags the caller actually set. `detachedDaemonArgs` walks pflag's *changed* set and emits `--name=value` pairs:

- No shell sits between parent and child, so values needing quotes are safe as-is.
- Defaults stay implicit, so the child resolves them from config exactly as a foreground start does.
- Slice flags (`--conversation-host`) repeat rather than stringifying as `[a,b]`, which pflag cannot parse back.
- `--detach` is dropped — the child *is* the detached daemon.

Flags are filtered against what the child will accept, because two other callers reach the same spawn carrying flag sets of their own: `daemon restart` and `install --start`. A flag `daemon start` does not declare is dropped rather than handed to a process that would exit on "unknown flag". The accepted set unions the command's own flags with its inherited persistent ones — cobra merges those lazily, and neither of those callers ever executes `daemon start`, so `--log-level` / `--config` would otherwise look unrecognised and be dropped.

Autostart (`gortex mcp`, `gortex track`) keeps spawning with a bare argv: there is no user-typed command line to forward there.

### Two follow-on changes

**The `GORTEX_TOOLS` / `GORTEX_TOOLS_MODE` injection goes away** with the premise it was compensating for. It also made detach diverge from foreground: env overrides `--tools`, so re-injecting the flag's value as env let it win a precedence contest it loses on the foreground path. Both behave the same now.

**`daemonStartCmd`'s `RunE` moves into `init()`** — `runDaemonStart` now names `daemonStartCmd` to read its flag set, and leaving `RunE` in the composite literal closes an initialization cycle the compiler rejects.

## Verification

Unit tests (`cmd/gortex/daemon_detach_args_test.go`) cover argv construction end-to-end through a real cobra parse: the reported `--http-addr` case, `--detach` exclusion, explicit `--embeddings=false`, repeated slice flags, values with spaces and leading dashes, unknown-flag filtering, and that the accepted set really does span local + inherited flags.

Manually, against a detached daemon in an isolated home:

- `--detach --http-addr 0.0.0.0:7411` — the **child** now enforces the bind's token requirement (`--http-addr "0.0.0.0:7411" is non-localhost; --http-auth-token ... is required`) and exits; on `main` the flag never reached it.
- `--detach --http-addr 127.0.0.1:7411 --log-level debug` — child logs `daemon: HTTP surface configured (/mcp + /v1) addr=127.0.0.1:7411`, `POST /mcp` on 7411 answers, and debug-level lines appear in the log.

`go build ./...`, `go vet`, `go test -race ./cmd/gortex/` (132 tests) and `golangci-lint run ./cmd/gortex/...` are all clean.
