### PR TITLE
Tighten the DI registration prefilter and unify the binding contract spelling

### DIFF
--- a/internal/graph/edge.go
+++ b/internal/graph/edge.go
@@ -706,13 +706,27 @@ const MetaSpeculative = "speculative"
 // framework synthesizers consume them. Exported here so both sides
 // compile against one spelling.
 const (
-	MetaDIBinding       = "binding"        // DIBindingUseClass or DIBindingAsImplemented
+	MetaDIBinding       = "binding"        // one of the DIBinding* values below
 	MetaDIProvidesFor   = "provides_for"   // interface short name the binding serves
 	MetaDISource        = "di"             // declaring container ("spring", "autofac", …)
 	MetaDIInterfaceFQCN = "interface_fqcn" // full interface name, for fidelity
 	MetaDIImplFQCN      = "impl_fqcn"      // full implementation name
+	// MetaDIToken names the injection token for the binding forms that
+	// have no concrete class to point at (useValue / useFactory /
+	// useExisting), where provides_for is absent.
+	MetaDIToken = "di_token"
+	// MetaDIOrigin records the provider method or decorator that
+	// declared the binding. Unrelated to Edge.Origin, which records how
+	// the edge itself was resolved.
+	MetaDIOrigin = "origin"
 
-	DIBindingUseClass      = "useClass"
+	// Binding forms. useClass and bean name their abstract via
+	// provides_for; the token forms use MetaDIToken instead.
+	DIBindingUseClass      = "useClass"    // container maps an abstract to a concrete class
+	DIBindingBean          = "bean"        // Spring @Bean factory method
+	DIBindingUseValue      = "useValue"    // token bound to a literal value
+	DIBindingUseFactory    = "useFactory"  // token bound to a factory function
+	DIBindingUseExisting   = "useExisting" // token aliased to another provider
 	DIBindingAsImplemented = "asImplementedInterfaces"
 )
 

--- a/internal/graph/edge.go
+++ b/internal/graph/edge.go
@@ -705,6 +705,13 @@ const MetaSpeculative = "speculative"
 // EdgeProvides with these Meta keys; the resolver's provides-index and
 // framework synthesizers consume them. Exported here so both sides
 // compile against one spelling.
+//
+// Scoped to EdgeProvides. "binding" is not a reserved word elsewhere in
+// the graph: the ORM extractors put an unrelated "binding" on model
+// NODES (values "subclass" / "decorator" / "annotation" / "schema-macro",
+// beside "orm" and "table_name") describing how a model was declared.
+// The two never meet — different carrier, different values — so a
+// key-name sweep must not fold them together.
 const (
 	MetaDIBinding       = "binding"        // one of the DIBinding* values below
 	MetaDIProvidesFor   = "provides_for"   // interface short name the binding serves

--- a/internal/graph/store_sqlite/language_gate.go
+++ b/internal/graph/store_sqlite/language_gate.go
@@ -8,8 +8,8 @@ import (
 	"github.com/zzet/gortex/internal/graph"
 )
 
-// HasLanguage reports whether any indexed node carries the given language
-// (backs the resolver's graphHasLanguage gate). nodes has no
+// HasLanguage reports whether any indexed NAMED node carries the given
+// language (backs the resolver's graphHasLanguage gate). nodes has no
 // language-leading index, so a bare language predicate would scan the
 // table exactly on the miss — the case a gate exists for. The recursive
 // CTE instead skip-scans the distinct repo prefixes (one MIN seek each,
@@ -17,6 +17,18 @@ import (
 // nodes_by_repo_language_name partial index — the non-empty-name
 // predicate is what makes it eligible. Unexpected errors answer true so
 // a gated pass runs rather than being silently skipped.
+//
+// Measured on a 5.3 GB, 34-prefix store: 8ms on a miss and ~1ms on a hit,
+// against 2.5s for the equivalent `WHERE language = ? LIMIT 1`.
+//
+// `name <> ''` is therefore load-bearing for the plan, and it narrows the
+// question to "are there NAMED nodes in this language" — a language
+// present only as unnamed nodes answers false. That is the right question
+// for every caller today (each gates a pass over symbols), and no such
+// language exists in practice: on the same store, every language with any
+// node has at least one named node. Callers needing raw presence,
+// including of nameless nodes, need a different probe — this one cannot
+// answer it without giving up the index.
 func (s *Store) HasLanguage(lang string) bool {
 	if lang == "" {
 		return false

--- a/internal/graph/store_sqlite/language_gate_test.go
+++ b/internal/graph/store_sqlite/language_gate_test.go
@@ -50,6 +50,33 @@ func TestSQLiteHasLanguageEmptyStore(t *testing.T) {
 	}
 }
 
+// TestSQLiteHasLanguageNarrowsToNamedNodes pins the documented boundary:
+// the `name <> ''` predicate is what makes the partial index eligible, so
+// the probe answers "are there NAMED nodes in this language". A language
+// present only as unnamed nodes reads as absent. Every caller gates a
+// pass over symbols, so that is the intended question — but it is a real
+// narrowing, and dropping the predicate to widen it would silently cost
+// the index scan the probe exists to avoid.
+func TestSQLiteHasLanguageNarrowsToNamedNodes(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "graph.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	store.AddBatch([]*graph.Node{
+		{ID: "a.rb::Widget", Kind: graph.KindType, Name: "Widget", Language: "ruby", FilePath: "a.rb"},
+		{ID: "b.zig", Kind: graph.KindFile, Name: "", Language: "zig", FilePath: "b.zig"},
+	}, nil)
+
+	if !store.HasLanguage("ruby") {
+		t.Error("a language with a named node must be present")
+	}
+	if store.HasLanguage("zig") {
+		t.Error("a language with only unnamed nodes reads as absent — see HasLanguage's doc comment")
+	}
+}
+
 // TestSQLiteNodesByKindLang: the pushed-down filter must yield exactly the
 // kind∩language intersection and honour early stop.
 func TestSQLiteNodesByKindLang(t *testing.T) {

--- a/internal/indexer/di_contracts.go
+++ b/internal/indexer/di_contracts.go
@@ -71,10 +71,10 @@ func (idx *Indexer) linkSpringBeansFromEdges(repoEdges []*graph.Edge) {
 		if e.Kind != graph.EdgeProvides || e.Meta == nil {
 			return
 		}
-		if b, _ := e.Meta["binding"].(string); b != "bean" {
+		if b, _ := e.Meta[graph.MetaDIBinding].(string); b != graph.DIBindingBean {
 			return
 		}
-		rt, _ := e.Meta["provides_for"].(string)
+		rt, _ := e.Meta[graph.MetaDIProvidesFor].(string)
 		if rt == "" {
 			return
 		}
@@ -197,32 +197,30 @@ func diContractFromEdge(e *graph.Edge) (contracts.Contract, bool) {
 
 	switch e.Kind {
 	case graph.EdgeProvides:
-		// Providers carry binding: "useClass" / "useValue" / "useFactory"
-		// / "useExisting" / "bean". useClass and Spring's bean both
-		// name their abstract via provides_for; the token forms use
-		// the token name itself.
-		binding, _ := e.Meta["binding"].(string)
+		// useClass and Spring's bean both name their abstract via
+		// provides_for; the token forms use the token name itself.
+		binding, _ := e.Meta[graph.MetaDIBinding].(string)
 		switch binding {
-		case "useClass", "bean":
-			if s, _ := e.Meta["provides_for"].(string); s != "" {
+		case graph.DIBindingUseClass, graph.DIBindingBean:
+			if s, _ := e.Meta[graph.MetaDIProvidesFor].(string); s != "" {
 				token = s
 			}
-		case "useValue", "useFactory", "useExisting":
-			if s, _ := e.Meta["di_token"].(string); s != "" {
+		case graph.DIBindingUseValue, graph.DIBindingUseFactory, graph.DIBindingUseExisting:
+			if s, _ := e.Meta[graph.MetaDIToken].(string); s != "" {
 				token = s
 			}
 		default:
 			return zero, false
 		}
 		role = contracts.RoleProvider
-		meta = map[string]any{"binding": binding}
+		meta = map[string]any{graph.MetaDIBinding: binding}
 		if target := e.To; target != "" {
 			// For useClass / bean, record the concrete target so the
 			// orphan list in the contracts tool links straight to
 			// either the concrete class (useClass) or the factory
 			// method (bean). Token-form providers point at the token
 			// directly, no extra info needed.
-			if binding == "useClass" || binding == "bean" {
+			if binding == graph.DIBindingUseClass || binding == graph.DIBindingBean {
 				meta[binding] = target
 			}
 		}
@@ -230,7 +228,7 @@ func diContractFromEdge(e *graph.Edge) (contracts.Contract, bool) {
 		if v, _ := e.Meta["via"].(string); v != "@Inject" {
 			return zero, false
 		}
-		token, _ = e.Meta["di_token"].(string)
+		token, _ = e.Meta[graph.MetaDIToken].(string)
 		role = contracts.RoleConsumer
 		meta = map[string]any{"via": "@Inject"}
 	default:

--- a/internal/parser/languages/csharp_dotnet.go
+++ b/internal/parser/languages/csharp_dotnet.go
@@ -110,6 +110,34 @@ func detectDotNetSurfaces(src []byte, result *parser.ExtractionResult) {
 	}
 }
 
+// diRegistrationSentinels are the literal substrings the registration
+// patterns require: no match is possible in a file containing none of
+// them, so the six alternations are skipped outright.
+//
+// Spelled out per lifetime rather than probing the shorter ".Add",
+// which `list.Add(x)` makes one of the most common substrings in any C#
+// file — the loose sentinel admitted nearly every file to the full
+// sweep. The regexes allow no space between "Add" and the lifetime
+// (`\.Add(Scoped|Singleton|Transient|HostedService)`), so each is a
+// contiguous literal.
+var diRegistrationSentinels = []string{
+	"RegisterType",     // autofac generic, typeof, and AsImplementedInterfaces forms
+	".Register",        // autofac factory lambda
+	"AddScoped",        // MS.DI two-arg generic + factory lambda
+	"AddSingleton",     //
+	"AddTransient",     //
+	"AddHostedService", // two-arg generic only
+}
+
+func hasDIRegistrationSentinel(text string) bool {
+	for _, sentinel := range diRegistrationSentinels {
+		if strings.Contains(text, sentinel) {
+			return true
+		}
+	}
+	return false
+}
+
 // emitDotNetDIBindings turns explicit .NET DI registrations into
 // EdgeProvides interface→implementation bindings — the shape the
 // resolver's provides-index consumes to land interface-typed call sites
@@ -144,8 +172,7 @@ func detectDotNetSurfaces(src []byte, result *parser.ExtractionResult) {
 func emitDotNetDIBindings(text string, file *graph.Node, result *parser.ExtractionResult) {
 	// Cheap containment gate before six full-file regex alternations —
 	// most C# files are not composition roots.
-	if !strings.Contains(text, "RegisterType") &&
-		!strings.Contains(text, ".Add") && !strings.Contains(text, ".Register") {
+	if !hasDIRegistrationSentinel(text) {
 		return
 	}
 	// One newline table serves all six passes — each restarts at offset

--- a/internal/parser/languages/csharp_dotnet_binding_test.go
+++ b/internal/parser/languages/csharp_dotnet_binding_test.go
@@ -199,3 +199,49 @@ builder.RegisterType<ClaimDataWriteService>()
 	require.Contains(t, collectProvides(result),
 		provided{iface: "IWriteService", impl: "ClaimDataWriteService", source: "autofac"})
 }
+
+// TestDIRegistrationSentinel_SkipsOrdinaryCollectionCode locks the
+// tightened prefilter: `.Add(` is among the most common substrings in
+// C#, so ordinary collection code must not reach the six alternations.
+// Guarded from the other side by every binding test above — each covered
+// form still has to pass the gate.
+func TestDIRegistrationSentinel_SkipsOrdinaryCollectionCode(t *testing.T) {
+	for name, src := range map[string]string{
+		"list add":     `public void Load() { var xs = new List<int>(); xs.Add(1); xs.AddRange(ys); }`,
+		"dict add":     `public void Seed() { map.Add("k", v); map.Add("k2", v2); }`,
+		"no di at all": `public class Plain { public int Value => 42; }`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if hasDIRegistrationSentinel(src) {
+				t.Errorf("ordinary code reached the regex sweep: %s", src)
+			}
+			result := &parser.ExtractionResult{
+				Nodes: []*graph.Node{{ID: "F.cs", Kind: graph.KindFile, FilePath: "F.cs"}},
+			}
+			detectDotNetSurfaces([]byte(src), result)
+			require.Empty(t, collectProvides(result), "no bindings from non-registration code")
+		})
+	}
+}
+
+// TestDIRegistrationSentinel_AdmitsEveryCoveredForm pins the sentinel
+// list to the patterns: a form the gate rejects can never emit, and the
+// failure would be silent under-detection rather than a test error in
+// the binding tests, which build their own source.
+func TestDIRegistrationSentinel_AdmitsEveryCoveredForm(t *testing.T) {
+	for _, src := range []string{
+		`services.AddScoped<IFoo, Foo>();`,
+		`services.AddSingleton<IClock, SystemClock>();`,
+		`services.AddTransient<IFoo, Foo>();`,
+		`services.AddHostedService<Worker>();`,
+		`services.AddScoped<IMailer>(sp => new SmtpMailer());`,
+		`builder.RegisterType<Foo>().As<IFoo>();`,
+		`builder.RegisterType(typeof(Foo)).As(typeof(IFoo));`,
+		`builder.RegisterType<Foo>().AsImplementedInterfaces();`,
+		`builder.Register(c => new PdfRenderer()).As<IRenderer>();`,
+	} {
+		if !hasDIRegistrationSentinel(src) {
+			t.Errorf("covered registration form rejected by the prefilter: %s", src)
+		}
+	}
+}

--- a/internal/parser/languages/di_container.go
+++ b/internal/parser/languages/di_container.go
@@ -26,8 +26,10 @@ import (
 //
 // The binding is modelled as an EdgeProvides carrying
 // binding:"useClass" + provides_for:<interface> and pointing at
-// `unresolved::<impl>` (Meta keys exported as graph.MetaDI* /
-// graph.DIBinding* so the resolver consumes the same spelling). That is
+// `unresolved::<impl>`. Every Meta key and binding form in this contract
+// is enumerated as a graph.MetaDI* / graph.DIBinding* constant, and both
+// the emitters here and the consumers (resolver.buildProvidesForIndex,
+// indexer's DI post-pass) compile against that one spelling. That is
 // the exact shape NestJS useClass and
 // Laravel `$this->app->bind` already produce, so the existing
 // resolver.buildProvidesForIndex pass — which rewrites abstract-typed

--- a/internal/parser/languages/java.go
+++ b/internal/parser/languages/java.go
@@ -788,8 +788,8 @@ func (e *JavaExtractor) emitMethod(m parser.QueryResult, filePath, fileID string
 					FilePath: filePath,
 					Line:     startLine1,
 					Meta: map[string]any{
-						"provides_for": rt,
-						"binding":      "bean",
+						graph.MetaDIProvidesFor: rt,
+						graph.MetaDIBinding:     graph.DIBindingBean,
 					},
 				})
 			}

--- a/internal/parser/languages/php.go
+++ b/internal/parser/languages/php.go
@@ -1165,9 +1165,9 @@ func (e *PHPExtractor) emitLaravelBindings(methodNodes map[string]*sitter.Node, 
 						FilePath: filePath,
 						Line:     line,
 						Meta: map[string]any{
-							"provides_for": first,
-							"binding":      "useClass",
-							"origin":       method,
+							graph.MetaDIProvidesFor: first,
+							graph.MetaDIBinding:     graph.DIBindingUseClass,
+							graph.MetaDIOrigin:      method,
 						},
 					})
 				}
@@ -1183,9 +1183,13 @@ func (e *PHPExtractor) emitLaravelBindings(methodNodes map[string]*sitter.Node, 
 					FilePath: filePath,
 					Line:     line,
 					Meta: map[string]any{
-						"di_token": first,
-						"binding":  method,
-						"origin":   method,
+						graph.MetaDIToken: first,
+						// Laravel's binding method name (bind / singleton /
+						// instance), not one of the graph's DIBinding* forms —
+						// these token providers are deliberately outside the
+						// contract switch in di_contracts.go.
+						graph.MetaDIBinding: method,
+						graph.MetaDIOrigin:  method,
 					},
 				})
 			}

--- a/internal/parser/languages/typescript.go
+++ b/internal/parser/languages/typescript.go
@@ -1555,6 +1555,11 @@ func emitProvidersFromObject(config *sitter.Node, src []byte, classID, filePath 
 		if abstract == "" {
 			continue
 		}
+		// The NestJS provider field names coincide with the graph's
+		// binding values, but they are different vocabularies — the field
+		// is a source token, the binding is the graph contract. Pair them
+		// explicitly so a NestJS rename cannot silently rewrite the
+		// contract (or vice versa).
 		if concrete := objectFieldIdentifier(entry, src, "useClass"); concrete != "" {
 			result.Edges = append(result.Edges, &graph.Edge{
 				From:     classID,
@@ -1563,15 +1568,19 @@ func emitProvidersFromObject(config *sitter.Node, src []byte, classID, filePath 
 				FilePath: filePath,
 				Line:     int(entry.StartPoint().Row) + 1,
 				Meta: map[string]any{
-					"provides_for": abstract,
-					"binding":      "useClass",
-					"origin":       originTag,
+					graph.MetaDIProvidesFor: abstract,
+					graph.MetaDIBinding:     graph.DIBindingUseClass,
+					graph.MetaDIOrigin:      originTag,
 				},
 			})
 			continue
 		}
-		for _, variant := range []string{"useValue", "useFactory", "useExisting"} {
-			if objectFieldValue(entry, src, variant) == nil {
+		for _, variant := range []struct{ field, binding string }{
+			{"useValue", graph.DIBindingUseValue},
+			{"useFactory", graph.DIBindingUseFactory},
+			{"useExisting", graph.DIBindingUseExisting},
+		} {
+			if objectFieldValue(entry, src, variant.field) == nil {
 				continue
 			}
 			result.Edges = append(result.Edges, &graph.Edge{
@@ -1581,9 +1590,9 @@ func emitProvidersFromObject(config *sitter.Node, src []byte, classID, filePath 
 				FilePath: filePath,
 				Line:     int(entry.StartPoint().Row) + 1,
 				Meta: map[string]any{
-					"di_token": abstract,
-					"binding":  variant,
-					"origin":   originTag,
+					graph.MetaDIToken:   abstract,
+					graph.MetaDIBinding: variant.binding,
+					graph.MetaDIOrigin:  originTag,
 				},
 			})
 			break
@@ -1744,8 +1753,8 @@ func emitInjectFromDecorator(dec *sitter.Node, src []byte, classID, filePath str
 		FilePath: filePath,
 		Line:     int(dec.StartPoint().Row) + 1,
 		Meta: map[string]any{
-			"di_token": tok,
-			"via":      "@Inject",
+			graph.MetaDIToken: tok,
+			"via":             "@Inject",
 		},
 	})
 }


### PR DESCRIPTION
Follow-ups from the review of #374, kept as four separate commits.

## 1. Narrow the .NET DI registration prefilter (`6ae0ff52`)

The containment gate ahead of the six registration alternations probed `".Add"`. `list.Add(x)` makes that one of the most common substrings in any C# file, so nearly every file was admitted to the full regex sweep the gate exists to avoid.

It now probes the literals the patterns actually require — `AddScoped` / `AddSingleton` / `AddTransient` / `AddHostedService`, plus `RegisterType` and `.Register`. The regexes allow no space between `Add` and the lifetime, so each is contiguous in the source.

Tested from both sides: ordinary collection code must not reach the sweep, and every covered registration form must still pass the gate. The second direction matters more than it looks — a form the gate rejected would silently stop emitting bindings rather than fail an existing binding test, since those build their own source strings.

## 2. One spelling for the DI binding contract (`933c5f6a`)

#374 exported `graph.MetaDI*` / `graph.DIBinding*`, but only the C# side adopted them. The java, php, and typescript emitters and the indexer's contract reader still spelled keys and values as literals, so the two halves of the contract could drift without a compile error.

All converted. The constant set needed completing to do it: the binding forms `bean` / `useValue` / `useFactory` / `useExisting` and the keys `di_token` / `origin` were part of the wire contract with no constant at all.

Two collisions deliberately left alone, because they share only the word:

- `<bean>` in the Spring XML reader is an **element name**, not a binding value.
- NestJS provider fields (`useClass`, `useValue`, …) are **source tokens** that happen to equal the binding values. They are now paired explicitly with the constant each maps to, so a rename on either side cannot silently rewrite the other.

The consumer-side `via` / `@Inject` vocabulary is a separate contract and is untouched.

## 3. Document the named-node narrowing in `HasLanguage` (`09227a22`)

The `name <> ''` predicate is what makes the partial index eligible, so it is load-bearing rather than incidental — and it narrows the probe to *"are there **named** nodes in this language"*. A language present only as unnamed nodes reads as absent.

That is the right question for every caller today (each gates a pass over symbols), but nothing said so, and a future reader tempted to widen the probe would silently trade away the index scan it exists to avoid. The doc comment now records the boundary and the measured numbers behind it; a test pins the behaviour so the trade-off has to be made deliberately.

Measured on a 5.3 GB, 34-prefix store: **8 ms** on a miss and ~1 ms on a hit, against **2.5 s** for the equivalent `WHERE language = ? LIMIT 1`.

## 4. Warn that the binding key is not reserved graph-wide (`954ce29b`)

The ORM extractors put an unrelated `"binding"` on model **nodes** — `subclass` / `decorator` / `annotation` / `schema-macro`, beside `orm` and `table_name`. Different carrier, different values, different consumers.

Commit 2 is exactly the kind of change that would fold them together by matching on the key name, so the constants now scope the contract to `EdgeProvides` and name the collision.

## Testing

- `go build ./...` and `go vet ./...` clean.
- `go test -race` across `parser/languages`, `indexer`, `resolver`, `graph`, `entrypoints`: 4550 passed, 8 skipped.
- `store_sqlite` under `-race` passes at 486.3s against 487.2s on the merge base — the two runs are within noise of each other. Note it sits close to the default 10m timeout: running it alongside an overlapping `./internal/graph/...` selection tips it over on a contended machine. Pre-existing, but worth knowing.
