### PR TITLE
Resolve NodeNext emitted-JavaScript import specifiers in the JS/TS call graph

### DIFF
--- a/internal/graph/extraction_gap.go
+++ b/internal/graph/extraction_gap.go
@@ -209,7 +209,9 @@ func importConsumerCount(g Store, symbolID string) int {
 var zeroEdgeMessages = map[ZeroEdgeClass]string{
 	ZeroEdgeLikelyUnused: "no incoming call or reference edges, but the symbol is " +
 		"indexed (it has structural or outgoing edges) — consistent with genuine " +
-		"unused code that is safe to remove.",
+		"unused code. It is also what an import specifier the resolver could not " +
+		"expand looks like, so this is evidence of no callers, not proof: confirm " +
+		"with a text search for the symbol name before removing it.",
 	ZeroEdgePossibleExtractionGap: "the symbol has no graph edges of any kind. A " +
 		"normally indexed symbol always has at least a structural edge, so the " +
 		"extractor most likely did not process it — treat this empty result as " +

--- a/internal/graph/parity_audit_test.go
+++ b/internal/graph/parity_audit_test.go
@@ -225,8 +225,12 @@ func scanKindUsage(repoRoot string, declared []kindDecl) (map[string]int, error)
 		}
 		// Worktrees can hide a duplicate copy of the source tree
 		// under .claude/worktrees/* — already skipped by the .claude
-		// directory rule above; defensive double-check.
-		if strings.Contains(path, "/worktrees/") {
+		// directory rule above; defensive double-check. Match against
+		// the repo-relative path: the checkout ITSELF often lives under
+		// a `worktrees/` directory, and testing the absolute path there
+		// skips every file in the repo, orphaning all 108 kinds.
+		if rel, relErr := filepath.Rel(repoRoot, path); relErr == nil &&
+			strings.Contains(filepath.ToSlash(rel), "worktrees/") {
 			return nil
 		}
 		// Don't let the audit's own file count as a reference — it

--- a/internal/indexer/nodenext_js_specifier_test.go
+++ b/internal/indexer/nodenext_js_specifier_test.go
@@ -1,0 +1,121 @@
+package indexer
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// importEdgeCount returns how many EdgeImports land directly on symbolID —
+// the per-binding import edges find_usages reports as usages.
+func importEdgeCount(t *testing.T, g graph.Store, symbolID string) int {
+	t.Helper()
+	n := 0
+	for _, e := range g.GetInEdges(symbolID) {
+		if e.Kind == graph.EdgeImports {
+			n++
+		}
+	}
+	return n
+}
+
+// TestNodeNextEmittedJSSpecifier_CallGraph covers issue #304: under
+// `moduleResolution: node16` / `nodenext` a TypeScript module is imported
+// by the name of the file the compiler EMITS (`./alpha.ts` is imported as
+// `./alpha.js`), which is mandatory for ESM TypeScript. Probing that
+// specifier only verbatim never matched the source on disk, so the import
+// edge stayed unresolved and the cross-package guard reverted every call
+// routed through it to `unresolved::*`.
+//
+// The reported symptom was "`../x` breaks, `./x` works", but the parent
+// traversal is a confound: a same-directory call survives the guard
+// anyway, because buildImportClosure seeds every file's own directory.
+// The extension is the real variable — hence the extension-crossed matrix
+// below, with a no-extension parent-directory row as the control that
+// already passed before the fix.
+func TestNodeNextEmittedJSSpecifier_CallGraph(t *testing.T) {
+	cases := []struct {
+		name       string
+		calleeFile string
+		callerFile string
+		spec       string
+	}{
+		// Controls: no extension. These bound before the fix, in both
+		// the same directory and a parent one.
+		{"sameDir/noExt", "src/alpha.ts", "src/main.ts", "./alpha"},
+		{"parentDir/noExt", "src/alpha.ts", "src/sub/beta.ts", "../alpha"},
+
+		// The regression: an emitted-JS extension, at every traversal
+		// depth the issue reported.
+		{"sameDir/jsExt", "src/alpha.ts", "src/main.ts", "./alpha.js"},
+		{"parentDir/jsExt", "src/alpha.ts", "src/sub/beta.ts", "../alpha.js"},
+		{"grandparentDir/jsExt", "src/snapshot/readers/alpha.ts",
+			"src/historical/handlers/beta.ts", "../../snapshot/readers/alpha.js"},
+
+		// Every emitted extension maps to the source that compiles to it.
+		{"parentDir/jsExt→tsx", "src/alpha.tsx", "src/sub/beta.ts", "../alpha.js"},
+		{"parentDir/jsxExt→tsx", "src/alpha.tsx", "src/sub/beta.ts", "../alpha.jsx"},
+		{"parentDir/mjsExt→mts", "src/alpha.mts", "src/sub/beta.ts", "../alpha.mjs"},
+		{"parentDir/cjsExt→cts", "src/alpha.cts", "src/sub/beta.ts", "../alpha.cjs"},
+
+		// A directory barrel named by its emitted entry point.
+		{"parentDir/barrelIndexJs", "src/lib/index.ts", "src/sub/beta.ts", "../lib/index.js"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFileMk(t, filepath.Join(dir, "package.json"), "{\"type\":\"module\"}\n")
+			writeFileMk(t, filepath.Join(dir, "tsconfig.json"),
+				"{\"compilerOptions\":{\"module\":\"NodeNext\",\"moduleResolution\":\"NodeNext\"}}\n")
+			writeFileMk(t, filepath.Join(dir, filepath.FromSlash(tc.calleeFile)),
+				"export function readAlpha(x: number): number { return x * 2 }\n")
+			writeFileMk(t, filepath.Join(dir, filepath.FromSlash(tc.callerFile)),
+				"import { readAlpha } from '"+tc.spec+"'\n"+
+					"export function handleBeta(): number { return readAlpha(21) }\n")
+
+			idx, _ := newSQLiteIndexer(t)
+			_, err := idx.Index(dir)
+			require.NoError(t, err)
+			idx.ResolveAll()
+
+			g := idx.Graph()
+			want := tc.calleeFile + "::readAlpha"
+
+			require.Equal(t, want, callTargetForName(t, g, tc.callerFile, "handleBeta"),
+				"call through %q must bind to the TypeScript source that emits it", tc.spec)
+			require.Positive(t, importEdgeCount(t, g, want),
+				"per-binding import edge through %q must land on the symbol so "+
+					"find_usages / get_callers report the importer", tc.spec)
+		})
+	}
+}
+
+// TestNodeNextEmittedJSSpecifier_PrefersRealFile pins the one deliberate
+// deviation from tsc's resolution order. tsc resolves `./alpha.js` to a
+// co-located `alpha.ts` even when `alpha.js` itself exists; the graph
+// probes the verbatim path first, because binding to a JavaScript file
+// that is really indexed beats binding to a sibling that may only carry
+// types. The `.d.ts` fallbacks are ordered last for the same reason.
+func TestNodeNextEmittedJSSpecifier_PrefersRealFile(t *testing.T) {
+	dir := t.TempDir()
+	writeFileMk(t, filepath.Join(dir, "src", "alpha.js"),
+		"export function readAlpha(x) { return x * 2 }\n")
+	writeFileMk(t, filepath.Join(dir, "src", "alpha.d.ts"),
+		"export declare function readAlpha(x: number): number\n")
+	writeFileMk(t, filepath.Join(dir, "src", "sub", "beta.ts"),
+		"import { readAlpha } from '../alpha.js'\n"+
+			"export function handleBeta(): number { return readAlpha(21) }\n")
+
+	idx, _ := newSQLiteIndexer(t)
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+	idx.ResolveAll()
+
+	require.Equal(t, "src/alpha.js::readAlpha",
+		callTargetForName(t, idx.Graph(), "src/sub/beta.ts", "handleBeta"),
+		"an indexed .js implementation must outrank its .d.ts declaration")
+}

--- a/internal/mcp/reexport_barrel.go
+++ b/internal/mcp/reexport_barrel.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/query"
+	"github.com/zzet/gortex/internal/resolver"
 )
 
 // Barrel re-export resolve-through for find_usages.
@@ -118,8 +119,29 @@ func parseReExportTarget(to string) (spec, orig string) {
 // probeRelativeModuleFile joins a relative specifier against the importing
 // file's directory and returns the matching file node's id, trying the module
 // extensions and an index file, or "" when no such file node exists.
+//
+// A specifier carrying an emitted-JavaScript extension — `./impl.js` for a
+// module whose source is `impl.ts`, mandatory under `moduleResolution:
+// node16` / `nodenext` — is probed verbatim and then against the sources
+// that compile to it; appending extensions alone would only ever look for
+// `impl.js.ts` (issue #304).
 func probeRelativeModuleFile(g graph.Store, fromFile, spec string) string {
 	stem := path.Clean(path.Join(path.Dir(fromFile), spec))
+	isFile := func(id string) bool {
+		n := g.GetNode(id)
+		return n != nil && n.Kind == graph.KindFile
+	}
+	if ext := path.Ext(stem); ext != "" {
+		if isFile(stem) {
+			return stem
+		}
+		base := strings.TrimSuffix(stem, ext)
+		for _, srcExt := range resolver.EmittedJSSourceExts(ext) {
+			if isFile(base + srcExt) {
+				return base + srcExt
+			}
+		}
+	}
 	for _, ext := range jsBarrelExts {
 		if g.GetNode(stem+ext) != nil {
 			return stem + ext

--- a/internal/mcp/reexport_barrel_nodenext_test.go
+++ b/internal/mcp/reexport_barrel_nodenext_test.go
@@ -1,0 +1,78 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// TestReExportBarrel_EmittedJSSpecifier covers the barrel half of issue
+// #304: under `moduleResolution: node16` / `nodenext` a re-export names
+// the file the compiler EMITS (`export { persist } from './impl.js'`),
+// which is mandatory for ESM TypeScript. Probing only `<stem>.<ext>` turns
+// that into `./impl.js.ts` and never matches, so the barrel binding fails
+// to canonicalise and find_usages on it reports nothing.
+func TestReExportBarrel_EmittedJSSpecifier(t *testing.T) {
+	newGraph := func(declFile, spec string) graph.Store {
+		g := graph.New()
+		addFile := func(id string) {
+			g.AddNode(&graph.Node{ID: id, Kind: graph.KindFile, Name: id,
+				FilePath: id, Language: "typescript"})
+		}
+		addFile(declFile)
+		g.AddNode(&graph.Node{ID: declFile + "::persist", Kind: graph.KindFunction,
+			Name: "persist", FilePath: declFile, Language: "typescript"})
+		addFile("src/index.ts")
+		g.AddEdge(&graph.Edge{From: "src/index.ts",
+			To: "unresolved::import::" + spec + "::persist", Kind: graph.EdgeReExports,
+			FilePath: "src/index.ts", Line: 1})
+		return g
+	}
+
+	cases := []struct {
+		name     string
+		declFile string
+		spec     string
+	}{
+		{"noExt_control", "src/impl.ts", "./impl"},
+		{"jsExt", "src/impl.ts", "./impl.js"},
+		{"jsExt_tsxTarget", "src/impl.tsx", "./impl.js"},
+		{"mjsExt", "src/impl.mts", "./impl.mjs"},
+		{"cjsExt", "src/impl.cts", "./impl.cjs"},
+		{"parentDir_jsExt", "impl.ts", "../impl.js"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := newGraph(tc.declFile, tc.spec)
+			assert.Equal(t, tc.declFile+"::persist",
+				reExportBindingCanonical(g, "src/index.ts::persist", 0),
+				"barrel re-export through %q must canonicalise to the TypeScript source", tc.spec)
+		})
+	}
+}
+
+// TestReExportBarrel_PrefersRealFile pins the same deliberate ordering the
+// resolver uses: a `.js` file that really exists in the graph outranks the
+// TypeScript counterparts probed for an emitted-JS specifier.
+func TestReExportBarrel_PrefersRealFile(t *testing.T) {
+	g := graph.New()
+	addFile := func(id string) {
+		g.AddNode(&graph.Node{ID: id, Kind: graph.KindFile, Name: id,
+			FilePath: id, Language: "javascript"})
+	}
+	for _, f := range []string{"src/impl.js", "src/impl.d.ts"} {
+		addFile(f)
+		g.AddNode(&graph.Node{ID: f + "::persist", Kind: graph.KindFunction,
+			Name: "persist", FilePath: f, Language: "javascript"})
+	}
+	addFile("src/index.ts")
+	g.AddEdge(&graph.Edge{From: "src/index.ts",
+		To: "unresolved::import::./impl.js::persist", Kind: graph.EdgeReExports,
+		FilePath: "src/index.ts", Line: 1})
+
+	assert.Equal(t, "src/impl.js::persist",
+		reExportBindingCanonical(g, "src/index.ts::persist", 0),
+		"an indexed .js implementation must outrank its .d.ts declaration")
+}

--- a/internal/resolver/jsts_imports.go
+++ b/internal/resolver/jsts_imports.go
@@ -37,6 +37,38 @@ var jsTSImportExts = []string{
 	".ts", ".tsx", ".d.ts", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs",
 }
 
+// jsTSEmittedSourceExts maps an EMITTED JavaScript extension a module
+// specifier may carry to the TypeScript source extensions that compile to
+// it, in TypeScript's own resolution order.
+//
+// Under `moduleResolution: node16` / `nodenext` — mandatory for ESM
+// TypeScript, and what `"type": "module"` projects use — a specifier names
+// the file the compiler EMITS, not the file on disk: `./alpha.ts` is
+// imported as `./alpha.js`, `./alpha.mts` as `./alpha.mjs`. Probing such a
+// stem only verbatim (and then as `alpha.js.ts`, `alpha.js/index.ts`)
+// never matches the real source, so the import edge stays unresolved and
+// every call routed through it is reverted by the cross-package guard
+// (issue #304).
+//
+// Deliberate deviation from tsc: the verbatim `.js` is probed BEFORE these
+// counterparts, whereas tsc prefers `.ts`/`.d.ts` over a co-located `.js`.
+// A graph binds to implementations, so an indexed `alpha.js` that really
+// exists is the better target than a sibling `alpha.d.ts` that carries
+// types but no body. `.d.*` entries stay last for the same reason.
+var jsTSEmittedSourceExts = map[string][]string{
+	".js":  {".ts", ".tsx", ".d.ts"},
+	".jsx": {".tsx", ".d.ts"},
+	".mjs": {".mts", ".d.mts"},
+	".cjs": {".cts", ".d.cts"},
+}
+
+// EmittedJSSourceExts returns the TypeScript source extensions that compile
+// to the emitted-JavaScript extension ext (".js", ".jsx", ".mjs", ".cjs"),
+// in probe order — nil for anything else. Exported so the query layer's
+// re-export barrel walk expands `nodenext` specifiers exactly the way the
+// resolver does, instead of keeping a second copy of the mapping.
+func EmittedJSSourceExts(ext string) []string { return jsTSEmittedSourceExts[ext] }
+
 // resolveJSTSImportTarget resolves a JS/TS EdgeImports / EdgeReExports
 // specifier onto the in-repo file (or exported symbol) it names, or
 // returns "" when the caller is not JS/TS, the specifier is a genuine
@@ -130,11 +162,18 @@ func probeJSTSFile(getNode func(string) *graph.Node, stem string) string {
 		return n != nil && n.Kind == graph.KindFile
 	}
 	// An explicit source extension the author wrote (`./auth.js`) is tried
-	// verbatim first.
-	switch jsTSExt(stem) {
+	// verbatim first, then — when it names an emitted JavaScript file —
+	// against the TypeScript sources that compile to it.
+	switch ext := jsTSExt(stem); ext {
 	case ".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs":
 		if isFile(stem) {
 			return stem
+		}
+		base := strings.TrimSuffix(stem, ext)
+		for _, srcExt := range jsTSEmittedSourceExts[ext] {
+			if id := base + srcExt; isFile(id) {
+				return id
+			}
 		}
 	}
 	for _, ext := range jsTSImportExts {


### PR DESCRIPTION
Fixes #304.

## The reported diagnosis is a confound

The issue concludes that "the only variable that flips the result is whether the specifier leaves the importer's directory." Reproducing the matrix through the real indexer shows that is not the trigger. `../` was never broken — the **extension** was.

Two pieces of evidence, both reproducible on `main`:

- `internal/indexer/tsconfig_path_alias_test.go:53` has covered `import { getAuth } from '../lib/auth'` — cross-directory, parent traversal — since #136, and it passes.
- Adding the row the issue's matrix never tested, `'../alpha'` with no extension, resolves correctly before any change here.

Crossing extension against traversal depth isolates it (measured on `main`, `call` = the `EdgeCalls` target, `imports` = per-binding import edges landing on the symbol):

| Specifier | Caller vs. callee | call | imports |
|---|---|---|---|
| `'./alpha'` | same dir | bound | 1 |
| `'../alpha'` | parent dir | bound | 1 |
| `'./alpha.js'` | same dir | bound | **0** |
| `'../alpha.js'` | parent dir | **unresolved** | **0** |
| `'../../a/b/alpha.js'` | two up | **unresolved** | **0** |
| `'../alpha.mjs'`, `'../alpha.cjs'`, `'../alpha.jsx'`, `'../lib/index.js'` | parent dir | **unresolved** | **0** |

The traversal depth looked causal because it changes *how visible* the same defect is. A broken import edge means `buildImportClosure` never sees the target module, so the cross-package guard reverts the call — but the closure is seeded with each file's own directory, so a **same-directory** call survives the guard anyway and still binds. Cross-directory has no such rescue.

The issue's own repro table already contains the tell: case A (`'./helper.js'`) reports **1** edge and case B (`'./helper'`) reports **2**. Case A was read as "PRESENT ✅", but it had already silently lost its import edge — the same bug, half-masked.

## Root cause

Under `moduleResolution: node16` / `nodenext` — mandatory for ESM TypeScript, and what every `"type": "module"` project uses — an import specifier names the file the compiler **emits**, not the file on disk. `alpha.ts` is imported as `'./alpha.js'`, `alpha.mts` as `'./alpha.mjs'`.

`probeJSTSFile` tried such a stem verbatim, then appended each source extension to it — looking for `alpha.js.ts` and `alpha.js/index.ts`. Neither exists, so the import edge stayed unresolved and every call routed through it was reverted to `unresolved::*`.

This is why the reporter's repos are hit so hard: `NodeNext` ESM *requires* the extension, so essentially every cross-module import in the project carries it.

## Changes

**`internal/resolver/jsts_imports.go`** — map each emitted-JS extension to the TypeScript sources that compile to it (`.js` → `.ts`/`.tsx`/`.d.ts`, `.mjs` → `.mts`/`.d.mts`, `.cjs` → `.cts`/`.d.cts`, `.jsx` → `.tsx`/`.d.ts`) and probe those when the verbatim path misses.

Verbatim stays first, a deliberate deviation from `tsc`, which prefers a co-located `.ts`/`.d.ts` over an existing `.js`. A code graph binds to implementations: an indexed `alpha.js` is a better target than a sibling `alpha.d.ts` carrying types and no body. The `.d.*` entries are ordered last for the same reason. Both orderings are pinned by tests.

**`internal/mcp/reexport_barrel.go`** — the same gap, one step worse: `probeRelativeModuleFile` never tried the joined stem verbatim at all, only `stem+ext`. A barrel written the way NodeNext requires (`export { persist } from './impl.js'`) never canonicalised, so `find_usages` on the binding returned nothing — and a plain JavaScript project whose `impl.js` genuinely exists failed identically. It now reuses the resolver's mapping rather than keeping a second copy that can drift.

**`internal/graph/extraction_gap.go`** — the issue's closing point, and a fair one. The `likely_unused` caveat ended "consistent with genuine unused code that is safe to remove", which reads as a verdict; an agent acting on it autonomously deletes live code. Zero incoming edges is also precisely what an unexpandable import specifier looks like — the exact shape this bug produced. It now states the evidence, declines to call it proof, and names the cheap confirmation step. The sibling classes already hedged this way; this one did not.

**`internal/graph/parity_audit_test.go`** — incidental, unrelated to #304, but it blocked verification so it is fixed here rather than left. `TestSchemaParityAudit` skipped any `.go` file whose **absolute** path contained `/worktrees/`. When the checkout itself lives under such a path — any git worktree under `.claude/worktrees/` — the filter matched every file in the repo, the usage scan found nothing, and all 108 node/edge kinds were reported as orphaned emitters. It now matches the repo-relative path. It is in its own commit and can be dropped or split out if you would rather land it separately.

## Verification

`internal/indexer/nodenext_js_specifier_test.go` crosses extension against traversal depth, keeping the two no-extension rows as controls. Without the resolver change, exactly the 8 emitted-extension rows fail and both controls pass; with it, all 10 pass. Each row asserts the call edge **and** the per-binding import edge, so the same-directory under-reporting is covered too, not just the cross-directory break.

`internal/mcp/reexport_barrel_nodenext_test.go` does the same for the barrel walk, plus the `.js`-outranks-`.d.ts` ordering.

`go build ./...`, `go vet`, and `go test -race ./...` are clean.

## Adjacent, deliberately not changed

`workspaceFileExists` in `internal/indexer/npm_alias_resolve.go` probes a stem the same way and would have the same gap if an npm-workspace specifier carried an emitted extension. That path needs a workspace alias to reach; the repos in #304 have no aliases at all, so it is outside this fix and I have not verified whether it is reachable in practice. `tsFileCandidates` in `internal/indexer/contract_import_resolve.go` looked similar but already strips the extension to a stem first, so it is correct as-is.
