### PR TITLE
Extract every CREATE TABLE in a multi-statement SQL migration

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -104,6 +104,41 @@ Recent extraction refinements (each covered by a per-feature CI golden): Java `@
 | Makefile | `Makefile`, `GNUmakefile`, `.mk`, `.make` | Targets, `define…endef`, `VAR = …`, `include` / `-include` |
 | CMake | `CMakeLists.txt`, `.cmake` | `function(…)`, `macro(…)`, `add_library`, `add_executable`, `include(…)`, `set(…)` |
 
+### SQL coverage boundary
+
+A `.sql` file is read by two independent passes, and knowing which one
+produced a symbol explains what you can ask of it.
+
+- **The tree-sitter DDL walk** runs on every `.sql` file and emits a
+  `type` node per `CREATE TABLE` / `CREATE VIEW`, a `function` node per
+  `CREATE FUNCTION`, and `variable` nodes for indexes and triggers.
+  Schema-qualified names are indexed under the object's own name
+  (`identity.kyc_submissions` → `kyc_submissions`), with the schema on
+  `meta.schema` and the full name on `meta.qualified_name`; the same
+  table name under two schemas stays two symbols. The walk descends
+  through parse errors, so statements following a dollar-quoted
+  PL/pgSQL body are still extracted.
+- **Migration ingest** additionally runs on files under `migrate/` or
+  `migrations/`, and on `gortex db schema` dumps anywhere, emitting the
+  canonical `table` / `column` / `migration` nodes plus `provides`
+  edges. This pass is regex-based: it reads `CREATE TABLE` and ignores
+  `ALTER` / `DROP`, so a column added by a later migration is not on
+  the table.
+
+What is **not** covered:
+
+- **Query edges from application code are opt-in.** Table reads and
+  writes found in string-literal SQL are gated behind the `sql`
+  coverage domain, which is off by default because literal-scanning is
+  noisy. With it off there are no `queries` edges, and the analyzers
+  built on them (`sql_call_sites`, `orphan_tables`,
+  `unreferenced_tables`) return an empty result annotated with
+  `query_edges: 0` — an empty layer, not an all-clear.
+- **Dynamic SQL is invisible** — queries assembled by concatenation or
+  a query builder have no literal to read.
+- **Schema deltas are not modeled.** The graph holds the shape each
+  migration declares, not the accumulated result of replaying them.
+
 ## Template engines
 
 | Language | Extensions | What it extracts |

--- a/internal/indexer/migration_ingest_test.go
+++ b/internal/indexer/migration_ingest_test.go
@@ -88,3 +88,61 @@ func TestIndex_GeneratedSchemaIngestedAnywhere(t *testing.T) {
 		t.Error("generated-schema column node 'owner' missing")
 	}
 }
+
+// TestIndex_SchemaQualifiedMultiStatementMigration is the end-to-end
+// repro from issue #313: a migration that declares several
+// schema-qualified tables around a dollar-quoted PL/pgSQL body. Every
+// table must be reachable by its own name through both extraction
+// paths — the canonical KindTable nodes the migration ingest emits and
+// the KindType nodes the tree-sitter walk emits — instead of collapsing
+// into one symbol named after the schema.
+func TestIndex_SchemaQualifiedMultiStatementMigration(t *testing.T) {
+	dir := t.TempDir()
+	mig := filepath.Join(dir, "db", "migrations")
+	require.NoError(t, os.MkdirAll(mig, 0o755))
+	writeFile(t, filepath.Join(mig, "000009_identity_kyc.up.sql"), `CREATE TABLE identity.accounts (
+    id uuid NOT NULL,
+    email text NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE OR REPLACE FUNCTION identity.set_updated_at() RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER accounts_touch BEFORE UPDATE ON identity.accounts
+    FOR EACH ROW EXECUTE FUNCTION identity.set_updated_at();
+
+CREATE TABLE identity.kyc_submissions (
+    id uuid NOT NULL,
+    account_id uuid NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE billing.balance_transactions (
+    id bigint NOT NULL,
+    PRIMARY KEY (id)
+);
+`)
+
+	g := graph.New()
+	idx := newSQLTestIndexer(g)
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+
+	for _, table := range []string{"accounts", "kyc_submissions", "balance_transactions"} {
+		if findKindNamed(g, graph.KindTable, table) == nil {
+			t.Errorf("KindTable node for schema-qualified table %q missing", table)
+		}
+		if findKindNamed(g, graph.KindType, table) == nil {
+			t.Errorf("KindType node for schema-qualified table %q missing", table)
+		}
+	}
+	// The schema is metadata, never a table in its own right.
+	if n := findKindNamed(g, graph.KindType, "identity"); n != nil {
+		t.Errorf("schema name leaked as a table symbol: %s", n.ID)
+	}
+}

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -246,6 +246,9 @@ func (s *Server) handleResourceSchema(_ context.Context, req mcp.ReadResourceReq
 - methods    — interface/trait method names ([]string, for IMPLEMENTS inference)
 - proto_type — protobuf: "message", "enum"
 - sql_type   — SQL: "table", "view", "index", "trigger"
+- schema     — SQL: schema qualifier of a schema-qualified object (Name stays the bare object name)
+- qualified_name — SQL: "schema.object", set only when the declaration was qualified
+- indexes    — SQL: qualified name of the table a CREATE INDEX covers
 - visibility — "private" for unexported symbols
 - temporal_role — Temporal node role: activity / workflow / activity_interface / workflow_interface / signal / query / update
 

--- a/internal/mcp/tools_analyze_orphan_tables_test.go
+++ b/internal/mcp/tools_analyze_orphan_tables_test.go
@@ -138,3 +138,67 @@ func TestAnalyzeOrphanTables_TableWithoutQueriesIsNotOrphan(t *testing.T) {
 		t.Errorf("declared-but-unused table must not appear as orphan, got %v", got)
 	}
 }
+
+// A zero result only means "nothing to clean up" when there was
+// something to cross-reference. With no query edges in the graph both
+// table analyzers are structurally incapable of returning a row, so the
+// response has to say the layer is empty rather than let an agent read
+// the 0 as an all-clear.
+func TestAnalyzeOrphanTables_NoQueryEdgesFlagsVacuousResult(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	addTable(srv.graph, "db::generic::users", "users", "generic")
+	addMigrationEdge(srv.graph, "migration::a.sql", "db::generic::users")
+
+	out := callAnalyzeOrphanTables(t, srv, map[string]any{})
+	if got, _ := out["total"].(float64); got != 0 {
+		t.Fatalf("expected zero orphans, got %v", got)
+	}
+	if got, _ := out["query_edges"].(float64); got != 0 {
+		t.Errorf("query_edges = %v, want 0", got)
+	}
+	note, _ := out["note"].(string)
+	if note == "" {
+		t.Error("empty result with zero query edges must carry a not-meaningful note")
+	}
+}
+
+func TestAnalyzeOrphanTables_QueryEdgesPresentNoNote(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	addTable(srv.graph, "db::generic::users", "users", "generic")
+	addMigrationEdge(srv.graph, "migration::a.sql", "db::generic::users")
+	addQueryEdge(srv.graph, "f.go::Q", "db::generic::users")
+
+	out := callAnalyzeOrphanTables(t, srv, map[string]any{})
+	if got, _ := out["query_edges"].(float64); got != 1 {
+		t.Errorf("query_edges = %v, want 1", got)
+	}
+	if note, _ := out["note"].(string); note != "" {
+		t.Errorf("a computable empty result must not be flagged: %q", note)
+	}
+}
+
+func TestAnalyzeUnreferencedTables_NoQueryEdgesFlagsVacuousResult(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	addTable(srv.graph, "db::generic::users", "users", "generic")
+	addMigrationEdge(srv.graph, "migration::a.sql", "db::generic::users")
+
+	req := mcplib.CallToolRequest{}
+	req.Params.Name = "analyze"
+	req.Params.Arguments = map[string]any{"kind": "unreferenced_tables"}
+	res, err := srv.handleAnalyze(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleAnalyze: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(res.Content[0].(mcplib.TextContent).Text), &out); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	// Every provided table looks unreferenced when no query edges exist,
+	// so the rows are present but not trustworthy on their own.
+	if got, _ := out["total"].(float64); got != 1 {
+		t.Fatalf("expected the provided table to be listed, got %v", got)
+	}
+	if note, _ := out["note"].(string); note == "" {
+		t.Error("result computed against zero query edges must carry a note")
+	}
+}

--- a/internal/mcp/tools_enhancements.go
+++ b/internal/mcp/tools_enhancements.go
@@ -1795,9 +1795,11 @@ func (s *Server) handleAnalyzeOrphanTables(ctx context.Context, req mcp.CallTool
 		QueryCount int    `json:"query_count"`
 	}
 	var rows []orphanRow
+	tableCount, queryEdges := 0, 0
 	// Kind pushdown — only KindTable carries the providers/queries
 	// fan-in we care about; the rest of the node table is noise.
 	for _, n := range s.scopedNodesByKinds(ctx, []graph.NodeKind{graph.KindTable}) {
+		tableCount++
 		// Walk incoming edges to detect both providers (migrations)
 		// and consumers (query call sites).
 		hasProvider := false
@@ -1810,6 +1812,7 @@ func (s *Server) handleAnalyzeOrphanTables(ctx context.Context, req mcp.CallTool
 				queryCount++
 			}
 		}
+		queryEdges += queryCount
 		if hasProvider {
 			continue
 		}
@@ -1837,20 +1840,52 @@ func (s *Server) handleAnalyzeOrphanTables(ctx context.Context, req mcp.CallTool
 		return rows[i].ID < rows[j].ID
 	})
 
+	note := vacuousTableAnalysisNote(tableCount, queryEdges)
 	if isCompact(req) {
 		var b strings.Builder
 		for _, r := range rows {
 			fmt.Fprintf(&b, "%-3d  %s\n", r.QueryCount, r.ID)
 		}
 		if len(rows) == 0 {
-			b.WriteString("no orphan tables\n")
+			if note != "" {
+				fmt.Fprintf(&b, "%s\n", note)
+			} else {
+				b.WriteString("no orphan tables\n")
+			}
 		}
 		return mcp.NewToolResultText(b.String()), nil
 	}
-	return s.respondJSONOrTOON(ctx, req, map[string]any{
-		"orphans": rows,
-		"total":   len(rows),
-	})
+	out := map[string]any{
+		"orphans":     rows,
+		"total":       len(rows),
+		"tables":      tableCount,
+		"query_edges": queryEdges,
+	}
+	if note != "" {
+		out["note"] = note
+	}
+	return s.respondJSONOrTOON(ctx, req, out)
+}
+
+// vacuousTableAnalysisNote returns the caveat to attach when a
+// table analyzer's empty result carries no information.
+//
+// orphan_tables and unreferenced_tables both cross-reference migration
+// providers against query call sites. When the graph holds no
+// EdgeQueries at all — SQL query extraction is gated off, or the code
+// side builds its queries in a shape the extractor does not see — each
+// returns a number that reads like an all-clear but was never computed
+// against anything. Saying so is the difference between "nothing to
+// clean up" and "this layer is empty".
+func vacuousTableAnalysisNote(tableCount, queryEdges int) string {
+	switch {
+	case tableCount == 0:
+		return "tables: 0 — no table nodes in scope; result is not meaningful"
+	case queryEdges == 0:
+		return "query_edges: 0 — no SQL query edges in scope, so provider/consumer " +
+			"cross-referencing had nothing to compare; result is not meaningful"
+	}
+	return ""
 }
 
 // handleAnalyzeUnreferencedTables is the inverse of
@@ -1875,8 +1910,10 @@ func (s *Server) handleAnalyzeUnreferencedTables(ctx context.Context, req mcp.Ca
 		ProviderCount int    `json:"provider_count"`
 	}
 	var rows []unrefRow
+	tableCount, queryEdges := 0, 0
 	// Kind pushdown — same story as orphan_tables.
 	for _, n := range s.scopedNodesByKinds(ctx, []graph.NodeKind{graph.KindTable}) {
+		tableCount++
 		providerCount := 0
 		queryCount := 0
 		for _, e := range s.graph.GetInEdges(n.ID) {
@@ -1887,6 +1924,7 @@ func (s *Server) handleAnalyzeUnreferencedTables(ctx context.Context, req mcp.Ca
 				queryCount++
 			}
 		}
+		queryEdges += queryCount
 		if providerCount == 0 || queryCount > 0 {
 			continue
 		}
@@ -1908,20 +1946,30 @@ func (s *Server) handleAnalyzeUnreferencedTables(ctx context.Context, req mcp.Ca
 		return rows[i].ID < rows[j].ID
 	})
 
+	note := vacuousTableAnalysisNote(tableCount, queryEdges)
 	if isCompact(req) {
 		var b strings.Builder
 		for _, r := range rows {
 			fmt.Fprintln(&b, r.ID)
 		}
-		if len(rows) == 0 {
+		if len(rows) == 0 && note == "" {
 			b.WriteString("no unreferenced tables\n")
+		}
+		if note != "" {
+			fmt.Fprintf(&b, "%s\n", note)
 		}
 		return mcp.NewToolResultText(b.String()), nil
 	}
-	return s.respondJSONOrTOON(ctx, req, map[string]any{
+	out := map[string]any{
 		"unreferenced": rows,
 		"total":        len(rows),
-	})
+		"tables":       tableCount,
+		"query_edges":  queryEdges,
+	}
+	if note != "" {
+		out["note"] = note
+	}
+	return s.respondJSONOrTOON(ctx, req, out)
 }
 
 // handleAnalyzeCoverageSummary aggregates meta.coverage_pct per

--- a/internal/parser/languages/sql.go
+++ b/internal/parser/languages/sql.go
@@ -1,6 +1,8 @@
 package languages
 
 import (
+	"strings"
+
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/parser"
 	sitter "github.com/zzet/gortex/internal/parser/tsitter"
@@ -55,44 +57,62 @@ func (e *SQLExtractor) Extract(filePath string, src []byte) (*parser.ExtractionR
 	}
 
 	seen := make(map[string]bool)
-
-	// Walk top-level statements.
-	for i, _nc := 0, int(root.NamedChildCount()); i < _nc; i++ {
-		stmt := root.NamedChild(i)
-		if stmt.Type() != "statement" {
-			continue
-		}
-		for j, _nc := 0, int(stmt.NamedChildCount()); j < _nc; j++ {
-			child := stmt.NamedChild(j)
-			switch child.Type() {
-			case "create_table":
-				e.extractCreateTable(child, src, filePath, fileNode.ID, seen, result)
-			case "create_view":
-				e.extractCreateView(child, src, filePath, fileNode.ID, seen, result)
-			case "create_function":
-				e.extractCreateFunction(child, src, filePath, fileNode.ID, seen, result)
-			case "create_index":
-				e.extractCreateIndex(child, src, filePath, fileNode.ID, seen, result)
-			case "create_trigger":
-				e.extractCreateTrigger(child, src, filePath, fileNode.ID, seen, result)
-			}
-		}
-	}
+	e.walkDDL(root, src, filePath, fileNode.ID, seen, result, 0)
 
 	return result, nil
 }
 
-func (e *SQLExtractor) extractCreateTable(node *sitter.Node, src []byte, filePath, fileID string, seen map[string]bool, result *parser.ExtractionResult) {
-	name := findObjectName(node, src)
-	if name == "" || seen[name] {
+// maxDDLWalkDepth bounds the recursive descent. Real DDL nests a handful
+// of levels; a deeper tree is either pathological or an error cascade,
+// and neither is worth unbounded stack.
+const maxDDLWalkDepth = 64
+
+// walkDDL descends the whole tree looking for CREATE statements rather
+// than only visiting `statement` children of the root.
+//
+// The recursion is load-bearing, not defensive. tree-sitter-sql has no
+// grammar for dollar-quoted PL/pgSQL bodies, so a `CREATE FUNCTION … $$
+// BEGIN … END $$` — routine in Postgres migrations — parses as an ERROR
+// node that swallows the rest of the file. Under a top-level-only walk
+// every table declared after the first trigger function silently
+// disappeared, which is most of a real migration set. Descending through
+// ERROR recovers those statements: the sub-nodes are still parsed
+// correctly, they are just re-parented under the error.
+func (e *SQLExtractor) walkDDL(node *sitter.Node, src []byte, filePath, fileID string, seen map[string]bool, result *parser.ExtractionResult, depth int) {
+	if depth > maxDDLWalkDepth {
 		return
 	}
-	seen[name] = true
-	id := filePath + "::" + name
+	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
+		child := node.NamedChild(i)
+		switch child.Type() {
+		case "create_table":
+			e.extractCreateTable(child, src, filePath, fileID, seen, result)
+		case "create_view":
+			e.extractCreateView(child, src, filePath, fileID, seen, result)
+		case "create_function":
+			e.extractCreateFunction(child, src, filePath, fileID, seen, result)
+		case "create_index":
+			e.extractCreateIndex(child, src, filePath, fileID, seen, result)
+		case "create_trigger":
+			e.extractCreateTrigger(child, src, filePath, fileID, seen, result)
+		default:
+			e.walkDDL(child, src, filePath, fileID, seen, result, depth+1)
+		}
+	}
+}
+
+func (e *SQLExtractor) extractCreateTable(node *sitter.Node, src []byte, filePath, fileID string, seen map[string]bool, result *parser.ExtractionResult) {
+	obj := findObject(node, src)
+	if obj.Name == "" || seen[obj.key("table")] {
+		return
+	}
+	seen[obj.key("table")] = true
+	name := obj.Name
+	id := filePath + "::" + obj.qualified()
 	result.Nodes = append(result.Nodes, &graph.Node{
 		ID: id, Kind: graph.KindType, Name: name,
 		FilePath: filePath, StartLine: int(node.StartPoint().Row) + 1, EndLine: int(node.EndPoint().Row) + 1,
-		Language: "sql", Meta: map[string]any{"sql_type": "table", "type_flavor": "table"},
+		Language: "sql", Meta: obj.meta(map[string]any{"sql_type": "table", "type_flavor": "table"}),
 	})
 	result.Edges = append(result.Edges, &graph.Edge{
 		From: fileID, To: id, Kind: graph.EdgeDefines,
@@ -106,7 +126,7 @@ func (e *SQLExtractor) extractCreateTable(node *sitter.Node, src []byte, filePat
 			for k, _nc := 0, int(child.NamedChildCount()); k < _nc; k++ {
 				col := child.NamedChild(k)
 				if col.Type() == "column_definition" {
-					colName := firstNamedChildOfType(col, "identifier", src)
+					colName := stripSQLQuoting(firstNamedChildOfType(col, "identifier", src))
 					if colName != "" {
 						colID := id + "." + colName
 						if !seen[colID] {
@@ -129,16 +149,16 @@ func (e *SQLExtractor) extractCreateTable(node *sitter.Node, src []byte, filePat
 }
 
 func (e *SQLExtractor) extractCreateView(node *sitter.Node, src []byte, filePath, fileID string, seen map[string]bool, result *parser.ExtractionResult) {
-	name := findObjectName(node, src)
-	if name == "" || seen[name] {
+	obj := findObject(node, src)
+	if obj.Name == "" || seen[obj.key("view")] {
 		return
 	}
-	seen[name] = true
-	id := filePath + "::" + name
+	seen[obj.key("view")] = true
+	id := filePath + "::" + obj.qualified()
 	result.Nodes = append(result.Nodes, &graph.Node{
-		ID: id, Kind: graph.KindType, Name: name,
+		ID: id, Kind: graph.KindType, Name: obj.Name,
 		FilePath: filePath, StartLine: int(node.StartPoint().Row) + 1, EndLine: int(node.EndPoint().Row) + 1,
-		Language: "sql", Meta: map[string]any{"sql_type": "view", "type_flavor": "view"},
+		Language: "sql", Meta: obj.meta(map[string]any{"sql_type": "view", "type_flavor": "view"}),
 	})
 	result.Edges = append(result.Edges, &graph.Edge{
 		From: fileID, To: id, Kind: graph.EdgeDefines,
@@ -147,16 +167,16 @@ func (e *SQLExtractor) extractCreateView(node *sitter.Node, src []byte, filePath
 }
 
 func (e *SQLExtractor) extractCreateFunction(node *sitter.Node, src []byte, filePath, fileID string, seen map[string]bool, result *parser.ExtractionResult) {
-	name := findObjectName(node, src)
-	if name == "" || seen[name] {
+	obj := findObject(node, src)
+	if obj.Name == "" || seen[obj.key("function")] {
 		return
 	}
-	seen[name] = true
-	id := filePath + "::" + name
+	seen[obj.key("function")] = true
+	id := filePath + "::" + obj.qualified()
 	result.Nodes = append(result.Nodes, &graph.Node{
-		ID: id, Kind: graph.KindFunction, Name: name,
+		ID: id, Kind: graph.KindFunction, Name: obj.Name,
 		FilePath: filePath, StartLine: int(node.StartPoint().Row) + 1, EndLine: int(node.EndPoint().Row) + 1,
-		Language: "sql",
+		Language: "sql", Meta: obj.meta(nil),
 	})
 	result.Edges = append(result.Edges, &graph.Edge{
 		From: fileID, To: id, Kind: graph.EdgeDefines,
@@ -164,17 +184,26 @@ func (e *SQLExtractor) extractCreateFunction(node *sitter.Node, src []byte, file
 	})
 }
 
+// extractCreateIndex names the index after its own identifier, not the
+// table it indexes. `CREATE INDEX idx ON schema.tbl (col)` puts the index
+// name in a bare `identifier` child and the ON-target in the statement's
+// first `object_reference`; the shared findObject path would therefore
+// name every index after the table it covers.
 func (e *SQLExtractor) extractCreateIndex(node *sitter.Node, src []byte, filePath, fileID string, seen map[string]bool, result *parser.ExtractionResult) {
-	name := findObjectName(node, src)
-	if name == "" || seen[name] {
+	obj := findDeclaredIdentifier(node, src)
+	if obj.Name == "" || seen[obj.key("index")] {
 		return
 	}
-	seen[name] = true
-	id := filePath + "::" + name
+	seen[obj.key("index")] = true
+	meta := obj.meta(map[string]any{"sql_type": "index"})
+	if target := findObject(node, src); target.Name != "" {
+		meta["indexes"] = target.qualified()
+	}
+	id := filePath + "::" + obj.qualified()
 	result.Nodes = append(result.Nodes, &graph.Node{
-		ID: id, Kind: graph.KindVariable, Name: name,
+		ID: id, Kind: graph.KindVariable, Name: obj.Name,
 		FilePath: filePath, StartLine: int(node.StartPoint().Row) + 1, EndLine: int(node.EndPoint().Row) + 1,
-		Language: "sql", Meta: map[string]any{"sql_type": "index"},
+		Language: "sql", Meta: meta,
 	})
 	result.Edges = append(result.Edges, &graph.Edge{
 		From: fileID, To: id, Kind: graph.EdgeDefines,
@@ -183,16 +212,19 @@ func (e *SQLExtractor) extractCreateIndex(node *sitter.Node, src []byte, filePat
 }
 
 func (e *SQLExtractor) extractCreateTrigger(node *sitter.Node, src []byte, filePath, fileID string, seen map[string]bool, result *parser.ExtractionResult) {
-	name := findObjectName(node, src)
-	if name == "" || seen[name] {
+	// A trigger's own name is the statement's first `object_reference`
+	// (`CREATE TRIGGER trg BEFORE UPDATE ON tbl …`), so the shared path
+	// is correct here — unlike CREATE INDEX.
+	obj := findObject(node, src)
+	if obj.Name == "" || seen[obj.key("trigger")] {
 		return
 	}
-	seen[name] = true
-	id := filePath + "::" + name
+	seen[obj.key("trigger")] = true
+	id := filePath + "::" + obj.qualified()
 	result.Nodes = append(result.Nodes, &graph.Node{
-		ID: id, Kind: graph.KindVariable, Name: name,
+		ID: id, Kind: graph.KindVariable, Name: obj.Name,
 		FilePath: filePath, StartLine: int(node.StartPoint().Row) + 1, EndLine: int(node.EndPoint().Row) + 1,
-		Language: "sql", Meta: map[string]any{"sql_type": "trigger"},
+		Language: "sql", Meta: obj.meta(map[string]any{"sql_type": "trigger"}),
 	})
 	result.Edges = append(result.Edges, &graph.Edge{
 		From: fileID, To: id, Kind: graph.EdgeDefines,
@@ -200,17 +232,110 @@ func (e *SQLExtractor) extractCreateTrigger(node *sitter.Node, src []byte, fileP
 	})
 }
 
-// findObjectName extracts the name from a CREATE statement by finding
-// the first object_reference > identifier child.
-func findObjectName(node *sitter.Node, src []byte) string {
+// sqlObject is the identifier a CREATE statement declares, split into
+// the object's own name and the schema it was qualified with.
+type sqlObject struct {
+	Name   string // bare object name, quoting stripped
+	Schema string // schema qualifier; "" when the name was unqualified
+}
+
+// qualified renders the name the graph keys the object under. Staying
+// bare for unqualified names keeps node IDs stable for the single-schema
+// files that already worked.
+func (o sqlObject) qualified() string {
+	if o.Schema == "" {
+		return o.Name
+	}
+	return o.Schema + "." + o.Name
+}
+
+// key is the per-file dedupe key. It is qualified and kind-scoped so
+// `identity.accounts` and `billing.accounts` in one migration are two
+// tables rather than one, and a trigger may share a table's name.
+func (o sqlObject) key(kind string) string { return kind + "::" + o.qualified() }
+
+// meta merges the schema qualifier into a node's metadata, leaving base
+// untouched (and nil-preserving) when the name was unqualified.
+func (o sqlObject) meta(base map[string]any) map[string]any {
+	if o.Schema == "" {
+		return base
+	}
+	if base == nil {
+		base = map[string]any{}
+	}
+	base["schema"] = o.Schema
+	base["qualified_name"] = o.qualified()
+	return base
+}
+
+// findObject resolves the object a CREATE statement declares from its
+// first `object_reference`.
+//
+// A schema-qualified reference (`identity.kyc_submissions`) exposes one
+// `identifier` child per dotted segment, so the object's own name is the
+// LAST segment. Reading the first segment named every table after its
+// schema instead — which then collapsed under the per-file dedupe, so a
+// migration declaring `identity.accounts` and `identity.kyc_submissions`
+// produced a single bogus symbol called `identity` and lost the rest.
+func findObject(node *sitter.Node, src []byte) sqlObject {
 	for i, _nc := 0, int(node.NamedChildCount()); i < _nc; i++ {
 		child := node.NamedChild(i)
 		if child.Type() == "object_reference" {
-			return firstNamedChildOfType(child, "identifier", src)
+			return objectFromReference(child, src)
 		}
 	}
-	// Fallback: first identifier child directly.
-	return firstNamedChildOfType(node, "identifier", src)
+	// Fallback: a bare identifier child, no object_reference wrapper.
+	return sqlObject{Name: stripSQLQuoting(firstNamedChildOfType(node, "identifier", src))}
+}
+
+// objectFromReference splits an `object_reference` into schema + name.
+// Segments carry their own quoting (`"billing"."balance_transactions"`,
+// MySQL backticks), which is stripped per segment so a quoted name
+// containing a dot stays intact — something splitting the raw text on
+// the last dot would get wrong.
+func objectFromReference(ref *sitter.Node, src []byte) sqlObject {
+	var segments []string
+	for i, _nc := 0, int(ref.NamedChildCount()); i < _nc; i++ {
+		child := ref.NamedChild(i)
+		if child.Type() == "identifier" {
+			segments = append(segments, stripSQLQuoting(child.Content(src)))
+		}
+	}
+	switch len(segments) {
+	case 0:
+		return sqlObject{}
+	case 1:
+		return sqlObject{Name: segments[0]}
+	default:
+		// `db.schema.table` keeps only the immediate parent as schema,
+		// matching internal/sql's splitSchemaTable.
+		return sqlObject{Name: segments[len(segments)-1], Schema: segments[len(segments)-2]}
+	}
+}
+
+// findDeclaredIdentifier resolves the name of a statement that declares
+// its object as a bare identifier ahead of an ON-target — CREATE INDEX.
+func findDeclaredIdentifier(node *sitter.Node, src []byte) sqlObject {
+	if name := stripSQLQuoting(firstNamedChildOfType(node, "identifier", src)); name != "" {
+		return sqlObject{Name: name}
+	}
+	return findObject(node, src)
+}
+
+// stripSQLQuoting removes the three identifier-quoting styles: double
+// quotes (ANSI), backticks (MySQL), brackets (T-SQL).
+func stripSQLQuoting(name string) string {
+	name = strings.TrimSpace(name)
+	if len(name) >= 2 {
+		first, last := name[0], name[len(name)-1]
+		switch {
+		case first == '"' && last == '"',
+			first == '`' && last == '`',
+			first == '[' && last == ']':
+			return name[1 : len(name)-1]
+		}
+	}
+	return name
 }
 
 func firstNamedChildOfType(node *sitter.Node, nodeType string, src []byte) string {

--- a/internal/parser/languages/sql_migration_test.go
+++ b/internal/parser/languages/sql_migration_test.go
@@ -1,0 +1,189 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// sqlNodeNames returns the Name of every node of kind.
+func sqlNodeNames(nodes []*graph.Node, kind graph.NodeKind) []string {
+	var out []string
+	for _, n := range nodesOfKind(nodes, kind) {
+		out = append(out, n.Name)
+	}
+	return out
+}
+
+// nodeNamed returns the single node of kind with the given name.
+func nodeNamed(t *testing.T, nodes []*graph.Node, kind graph.NodeKind, name string) *graph.Node {
+	t.Helper()
+	var found *graph.Node
+	for _, n := range nodesOfKind(nodes, kind) {
+		if n.Name == name {
+			require.Nil(t, found, "duplicate %s node named %q", kind, name)
+			found = n
+		}
+	}
+	require.NotNil(t, found, "no %s node named %q in %v", kind, name, sqlNodeNames(nodes, kind))
+	return found
+}
+
+// A schema-qualified CREATE TABLE names the node after the table, not
+// after the schema. Reading the first identifier of the object_reference
+// named `identity.kyc_submissions` "identity", so searching for the
+// table returned nothing.
+func TestSQLExtractor_SchemaQualifiedTableKeepsTableName(t *testing.T) {
+	src := []byte(`CREATE TABLE identity.kyc_submissions (
+    id UUID PRIMARY KEY,
+    account_id UUID NOT NULL
+);
+`)
+	result, err := NewSQLExtractor().Extract("db/migrations/000009_identity_kyc.up.sql", src)
+	require.NoError(t, err)
+
+	tbl := nodeNamed(t, result.Nodes, graph.KindType, "kyc_submissions")
+	assert.Equal(t, "identity", tbl.Meta["schema"])
+	assert.Equal(t, "identity.kyc_submissions", tbl.Meta["qualified_name"])
+	assert.Equal(t, "db/migrations/000009_identity_kyc.up.sql::identity.kyc_submissions", tbl.ID)
+
+	// Columns hang off the qualified table id.
+	memberEdges := edgesOfKind(result.Edges, graph.EdgeMemberOf)
+	require.Len(t, memberEdges, 2)
+	for _, e := range memberEdges {
+		assert.Equal(t, tbl.ID, e.To)
+	}
+}
+
+// Every schema-qualified table in a multi-statement migration survives.
+// Keying the per-file dedupe on the (wrongly derived) schema name meant
+// the first table in a schema shadowed every later one.
+func TestSQLExtractor_MultiStatementMigrationKeepsEveryTable(t *testing.T) {
+	src := []byte(`CREATE TABLE identity.accounts (
+    id UUID PRIMARY KEY
+);
+
+CREATE TABLE identity.kyc_submissions (
+    id UUID PRIMARY KEY
+);
+
+CREATE TABLE billing.balance_transactions (
+    id BIGSERIAL PRIMARY KEY
+);
+`)
+	result, err := NewSQLExtractor().Extract("db/migrations/000009_identity_kyc.up.sql", src)
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t,
+		[]string{"accounts", "kyc_submissions", "balance_transactions"},
+		sqlNodeNames(result.Nodes, graph.KindType))
+}
+
+// The same table name under two schemas is two tables, not one.
+func TestSQLExtractor_SameTableNameAcrossSchemas(t *testing.T) {
+	src := []byte(`CREATE TABLE identity.accounts (id UUID PRIMARY KEY);
+CREATE TABLE billing.accounts (id UUID PRIMARY KEY);
+`)
+	result, err := NewSQLExtractor().Extract("db/migrations/001_accounts.up.sql", src)
+	require.NoError(t, err)
+
+	types := nodesOfKind(result.Nodes, graph.KindType)
+	require.Len(t, types, 2)
+	var ids []string
+	for _, n := range types {
+		assert.Equal(t, "accounts", n.Name)
+		ids = append(ids, n.ID)
+	}
+	assert.ElementsMatch(t, []string{
+		"db/migrations/001_accounts.up.sql::identity.accounts",
+		"db/migrations/001_accounts.up.sql::billing.accounts",
+	}, ids)
+}
+
+// tree-sitter-sql has no grammar for dollar-quoted PL/pgSQL bodies, so a
+// CREATE FUNCTION parses as an ERROR node that re-parents the rest of
+// the file under itself. A top-level-only walk therefore stopped
+// extracting at the first trigger function — the common shape of a
+// Postgres migration.
+func TestSQLExtractor_RecoversStatementsAfterDollarQuotedBody(t *testing.T) {
+	src := []byte(`CREATE TABLE identity.accounts (
+    id UUID PRIMARY KEY
+);
+
+CREATE OR REPLACE FUNCTION identity.set_updated_at() RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER accounts_touch BEFORE UPDATE ON identity.accounts
+    FOR EACH ROW EXECUTE FUNCTION identity.set_updated_at();
+
+CREATE TABLE identity.kyc_submissions (
+    id UUID PRIMARY KEY
+);
+
+CREATE TABLE billing.balance_transactions (
+    id BIGSERIAL PRIMARY KEY
+);
+`)
+	result, err := NewSQLExtractor().Extract("db/migrations/000009_identity_kyc.up.sql", src)
+	require.NoError(t, err)
+
+	// Tables declared after the function body are still extracted.
+	assert.ElementsMatch(t,
+		[]string{"accounts", "kyc_submissions", "balance_transactions"},
+		sqlNodeNames(result.Nodes, graph.KindType))
+
+	// So is the function the error node swallowed.
+	fn := nodeNamed(t, result.Nodes, graph.KindFunction, "set_updated_at")
+	assert.Equal(t, "identity", fn.Meta["schema"])
+}
+
+// CREATE INDEX takes its own name, not the name of the table it covers.
+func TestSQLExtractor_IndexNamedAfterIndexNotTarget(t *testing.T) {
+	src := []byte(`CREATE TABLE identity.kyc_submissions (id UUID PRIMARY KEY, account_id UUID);
+CREATE INDEX idx_kyc_account ON identity.kyc_submissions (account_id);
+CREATE UNIQUE INDEX idx_accounts_email ON accounts (email);
+`)
+	result, err := NewSQLExtractor().Extract("db/migrations/000009_identity_kyc.up.sql", src)
+	require.NoError(t, err)
+
+	idx := nodeNamed(t, result.Nodes, graph.KindVariable, "idx_kyc_account")
+	assert.Equal(t, "index", idx.Meta["sql_type"])
+	assert.Equal(t, "identity.kyc_submissions", idx.Meta["indexes"])
+
+	unique := nodeNamed(t, result.Nodes, graph.KindVariable, "idx_accounts_email")
+	assert.Equal(t, "accounts", unique.Meta["indexes"])
+}
+
+// Quoting is stripped per dotted segment, so a quoted name keeps its own
+// dots instead of being split on the last one.
+func TestSQLExtractor_QuotedSchemaQualifiedNames(t *testing.T) {
+	src := []byte("CREATE TABLE \"billing\".\"balance_transactions\" (id BIGINT);\n" +
+		"CREATE TABLE `app`.`events` (id INT);\n")
+	result, err := NewSQLExtractor().Extract("db/migrations/002_billing.up.sql", src)
+	require.NoError(t, err)
+
+	bt := nodeNamed(t, result.Nodes, graph.KindType, "balance_transactions")
+	assert.Equal(t, "billing", bt.Meta["schema"])
+
+	ev := nodeNamed(t, result.Nodes, graph.KindType, "events")
+	assert.Equal(t, "app", ev.Meta["schema"])
+}
+
+// Unqualified names keep the bare id they have always had — the schema
+// fix must not renumber the single-schema files that already worked.
+func TestSQLExtractor_UnqualifiedIDsUnchanged(t *testing.T) {
+	src := []byte(`CREATE TABLE users (id INTEGER PRIMARY KEY);`)
+	result, err := NewSQLExtractor().Extract("schema.sql", src)
+	require.NoError(t, err)
+
+	tbl := nodeNamed(t, result.Nodes, graph.KindType, "users")
+	assert.Equal(t, "schema.sql::users", tbl.ID)
+	assert.NotContains(t, tbl.Meta, "schema")
+	assert.NotContains(t, tbl.Meta, "qualified_name")
+}

--- a/internal/sql/sql.go
+++ b/internal/sql/sql.go
@@ -795,11 +795,19 @@ func MigrationNodeID(path string) string {
 // (case-insensitive). Matches Rails (db/migrate/), golang-migrate
 // (migrations/), Alembic when wrapped (we mostly handle alembic
 // via Python parsers separately), and most ORM generators.
+//
+// Separators are folded to '/' first. The indexer hands coverage
+// extractors an OS-native relative path on purpose (graphRelKey keeps
+// backslashes on Windows so incremental evictions match the keys the
+// cold walk wrote), so matching '/'-only segments here silently
+// disabled migration extraction for every nested path on Windows —
+// no migration nodes, no provides edges, and unreferenced_tables
+// reporting zero because nothing had a provider at all.
 func IsMigrationPath(filePath string) bool {
 	if !strings.HasSuffix(strings.ToLower(filePath), ".sql") {
 		return false
 	}
-	lower := strings.ToLower(filePath)
+	lower := strings.ReplaceAll(strings.ToLower(filePath), "\\", "/")
 	for _, segment := range []string{"/migrate/", "/migrations/", "/migrate.", "/migrations."} {
 		if strings.Contains(lower, segment) {
 			return true

--- a/internal/sql/sql_test.go
+++ b/internal/sql/sql_test.go
@@ -228,6 +228,15 @@ func TestIsMigrationPath(t *testing.T) {
 		{"pkg/queries/select.sql", false},
 		{"main.go", false},
 		{"docs/migration_guide.md", false}, // not .sql
+
+		// The indexer hands coverage extractors an OS-native relative
+		// path, so on Windows these arrive backslash-separated. Matching
+		// '/'-only segments disabled migration extraction there for every
+		// nested path.
+		{`db\migrate\001_create_users.sql`, true},
+		{`services\domain-core\db\migrations\000009_identity_kyc.up.sql`, true},
+		{`internal\db\migrations\init.sql`, true},
+		{`pkg\queries\select.sql`, false},
 	}
 	for _, c := range cases {
 		if got := IsMigrationPath(c.path); got != c.want {


### PR DESCRIPTION
Fixes #313.

## Validated

Reproduced exactly. A migration declaring `identity.accounts`,
`identity.kyc_submissions` and `billing.balance_transactions` around a
PL/pgSQL trigger function extracted, before this change:

```
kind=type  name="identity"         # should be accounts, schema identity
kind=type  name="billing"          # should be balance_transactions
                                   # kyc_submissions: gone entirely
```

Unqualified `CREATE TABLE outbox_events` came out right, which is why
coverage looked arbitrary — the split is qualified vs. unqualified, not
random.

## Root causes

Three defects, compounding:

1. **The schema was read as the object name.** A schema-qualified
   `object_reference` exposes one `identifier` child per dotted segment.
   The extractor took the first, so every table in `identity.*` was
   named `identity`.
2. **The per-file dedupe then erased the rest.** `seen` keyed on that
   name, so the second table in a schema was discarded as a duplicate of
   the first. One symbol survived per schema per file.
3. **A dollar-quoted body truncated the file.** tree-sitter-sql has no
   grammar for PL/pgSQL, so `CREATE FUNCTION … $$ … $$` parses as an
   ERROR node that re-parents every following statement under itself.
   The walk only visited top-level `statement` children, so extraction
   stopped at the first trigger function — the shape of most real
   Postgres migration sets.

A fourth, found while tracing the follow-up comment about
`sql_call_sites: 0` and reported on Windows: `IsMigrationPath` matched
`/`-separated segments only. The indexer hands coverage extractors an
OS-native relative path deliberately (`graphRelKey` keeps backslashes so
incremental evictions match the cold walk's keys), so on Windows **no**
nested migration file was recognised. Migration ingest never ran, the
canonical `table` / `column` / `migration` nodes were never emitted, and
`unreferenced_tables` returned 0 because nothing had a provider at all.

## Changes

- Name schema-qualified objects after the object; schema goes on
  `meta.schema`, the full name on `meta.qualified_name`. Dedupe and node
  IDs key on the qualified name, so `identity.accounts` and
  `billing.accounts` are two tables. Unqualified declarations keep the
  IDs they already had.
- Descend through error nodes so statements after a `$$` body are still
  extracted.
- Name a `CREATE INDEX` after its own identifier instead of the table it
  covers; record the covered table on `meta.indexes`.
- Fold path separators in `IsMigrationPath`.
- `orphan_tables` / `unreferenced_tables` now report the `tables` and
  `query_edges` counts their verdict was computed from, and carry a
  `note` when there are no query edges — the case the follow-up comment
  hit, where a 0 reads as an all-clear but nothing was compared.
- Document the SQL coverage boundary in `docs/languages.md`: which of
  the two passes produced a symbol, and what is out of scope (query
  edges are opt-in behind the `sql` domain, dynamic SQL is invisible,
  the graph holds declarations rather than the replayed schema).

## Tests

Every new test was confirmed to fail on `main` and pass here:

- `TestIndex_SchemaQualifiedMultiStatementMigration` — the issue's repro
  through the real indexing pipeline; asserts all three tables are
  reachable by name via both extraction paths and that the schema name
  never leaks as a table symbol.
- Extractor units for qualified naming, cross-schema collisions,
  post-`$$` recovery, index naming, quoted identifiers, and unchanged
  unqualified IDs.
- `IsMigrationPath` cases with backslash separators.
- Analyzer tests for the vacuity note, and for its absence when query
  edges exist.

`go build ./...`, `go vet ./...` and `golangci-lint` are clean;
`go test -race` passes for `internal/parser/...`, `internal/sql`,
`internal/indexer`, `internal/mcp`, `internal/graph`, `internal/eval/...`,
`internal/contracts` and `internal/analysis`.