### PR TITLE
fix(daemon): stop control RPCs from stalling behind the indexer

### DIFF
--- a/cmd/gortex/daemon_controller.go
+++ b/cmd/gortex/daemon_controller.go
@@ -661,9 +661,22 @@ func (c *realController) Status(_ context.Context) (daemon.StatusResponse, error
 	g := c.graph
 	c.mu.Unlock()
 	var memEstimates map[string]graph.RepoMemoryEstimate
+	var wholeStoreNodes, wholeStoreEdges int
 	if g != nil {
 		memEstimates = g.AllRepoMemoryEstimates()
+		// NodeCount/EdgeCount share that profile: COUNT(*) on the SQLite
+		// backend, a walk of every shard in memory. They were computed
+		// under c.mu until the same stall showed up on the whole-store
+		// path, so they are hoisted out alongside the estimate.
+		wholeStoreNodes = g.NodeCount()
+		wholeStoreEdges = g.EdgeCount()
 	}
+
+	// runtime.ReadMemStats stops the world. Under reindex allocation churn
+	// that pause is long enough to matter, and holding c.mu across it makes
+	// every queued control request wait out the pause as well.
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -717,11 +730,8 @@ func (c *realController) Status(_ context.Context) (daemon.StatusResponse, error
 		// not the reported bug.
 		allMeta := c.multiIndexer.AllMetadata()
 		soleRepo := len(allMeta) == 1
-		var wholeStoreNodes, wholeStoreEdges int
-		if g != nil {
-			wholeStoreNodes = g.NodeCount()
-			wholeStoreEdges = g.EdgeCount()
-		}
+		// wholeStoreNodes / wholeStoreEdges were computed above, before the
+		// controller mutex was taken — see the note at the top of Status.
 
 		// Diagnostic: when AllMetadata has tracked repos but
 		// AllRepoMemoryEstimates returns nothing (or a much smaller
@@ -750,7 +760,7 @@ func (c *realController) Status(_ context.Context) (daemon.StatusResponse, error
 				c.logger.Warn("daemon: per-repo counters below tracked-repo count — graph mutation cleared per-repo index?",
 					zap.Int("tracked_repos", tracked),
 					zap.Int("counter_buckets", counted),
-					zap.Int("graph_total_nodes", c.graph.NodeCount()))
+					zap.Int("graph_total_nodes", wholeStoreNodes))
 			}
 		}
 
@@ -935,8 +945,8 @@ func (c *realController) Status(_ context.Context) (daemon.StatusResponse, error
 		workspaces = append(workspaces, *wsAgg[k])
 	}
 
-	var mem runtime.MemStats
-	runtime.ReadMemStats(&mem)
+	// mem was sampled before the mutex was taken — see the note at the top
+	// of Status.
 
 	resp := daemon.StatusResponse{
 		TrackedRepos:  tracked,
@@ -1103,11 +1113,31 @@ func enrichmentProgressFromStatuses(statuses []semantic.EnrichmentStatus) *daemo
 	return out
 }
 
+// searchSymbolsFetchFactor bounds how many name-index candidates
+// SearchSymbols pulls before the File/Import and repo filters run. The name
+// index cannot express those filters, so pushing the caller's limit down
+// verbatim can return a page saturated with rows the filter then drops.
+// Over-fetching absorbs that without giving up the bound; a repo-scoped
+// probe over-fetches harder because one repo can be a thin slice of a
+// multi-repo workspace.
+const (
+	searchSymbolsFetchFactor     = 8
+	searchSymbolsRepoFetchFactor = 32
+	searchSymbolsMaxFetch        = 2000
+)
+
 // SearchSymbols runs a substring match over node names and returns the
 // matching symbols. It's the cheap probe path for clients (notably the
 // Grep-redirect hook) that need a fast yes/no without setting up a full
 // MCP session. File and Import nodes are excluded — the hook only cares
 // about real symbol matches.
+//
+// Candidates come from the sharded name index — one shard read-locked at a
+// time, with the fetch bound pushed down — not from AllNodes. AllNodes
+// read-locks every shard at once and materialises a slice of the entire
+// graph, so on a multi-repo daemon this probe queued behind the indexer's
+// shard writers and blew past the hook's 200ms budget. The hook then logged
+// probed_miss / timed_out and never once produced a hit.
 func (c *realController) SearchSymbols(_ context.Context, p daemon.SearchSymbolsParams) (daemon.SearchSymbolsResult, error) {
 	c.mu.Lock()
 	g := c.graph
@@ -1121,32 +1151,93 @@ func (c *realController) SearchSymbols(_ context.Context, p daemon.SearchSymbols
 	if limit <= 0 || limit > 50 {
 		limit = 20
 	}
-	needle := strings.ToLower(p.Query)
 	hits := make([]daemon.SymbolHit, 0, limit)
-	for _, n := range g.AllNodes() {
-		if n == nil {
+
+	// Fast path. Everything that reaches this probe is a grep pattern the
+	// hook already classified as identifier-shaped, and the overwhelmingly
+	// common answer is a symbol whose short name matches exactly. byName is
+	// a hash bucket per shard, so this is a handful of map lookups rather
+	// than a walk over every name in the graph — the difference between
+	// microseconds and blowing the hook's probe budget on a large graph.
+	for _, n := range g.FindNodesByName(p.Query) {
+		if !probeSymbolCandidate(n, p.Repo) {
 			continue
 		}
-		if n.Kind == graph.KindFile || n.Kind == graph.KindImport {
-			continue
-		}
-		if p.Repo != "" && n.RepoPrefix != p.Repo {
-			continue
-		}
-		if !strings.Contains(strings.ToLower(n.Name), needle) {
-			continue
-		}
-		hits = append(hits, daemon.SymbolHit{
-			Name:     n.Name,
-			Kind:     string(n.Kind),
-			FilePath: n.FilePath,
-			Line:     n.StartLine,
-		})
+		hits = append(hits, probeSymbolHit(n))
 		if len(hits) >= limit {
 			break
 		}
 	}
+	if len(hits) > 0 {
+		return daemon.SearchSymbolsResult{Hits: hits}, nil
+	}
+
+	// Substring fallback, for patterns that name part of a symbol. The name
+	// index cannot express the File/Import or repo filters, so a saturated
+	// page can come back with every row filtered away — a query matching
+	// many file paths crowds real symbols off it. Widen and retry rather
+	// than under-report, but stay bounded: a few rounds capped at
+	// searchSymbolsMaxFetch, still orders of magnitude below a full scan.
+	//
+	// The explicit Contains re-check preserves the pre-index semantics
+	// exactly (full Unicode case folding, where SQLite's LIKE folds ASCII
+	// only).
+	needle := strings.ToLower(p.Query)
+	fetch := limit * searchSymbolsFetchFactor
+	if p.Repo != "" {
+		fetch = limit * searchSymbolsRepoFetchFactor
+	}
+	for {
+		if fetch > searchSymbolsMaxFetch {
+			fetch = searchSymbolsMaxFetch
+		}
+		candidates := g.FindNodesByNameContaining(p.Query, fetch)
+		hits = hits[:0]
+		for _, n := range candidates {
+			if !probeSymbolCandidate(n, p.Repo) {
+				continue
+			}
+			if !strings.Contains(strings.ToLower(n.Name), needle) {
+				continue
+			}
+			hits = append(hits, probeSymbolHit(n))
+			if len(hits) >= limit {
+				break
+			}
+		}
+		// Enough hits, the index is exhausted, or the bound is reached.
+		if len(hits) >= limit || len(candidates) < fetch || fetch >= searchSymbolsMaxFetch {
+			break
+		}
+		fetch *= 4
+	}
 	return daemon.SearchSymbolsResult{Hits: hits}, nil
+}
+
+// probeSymbolCandidate reports whether n can answer a symbol probe. File and
+// Import nodes are named for paths rather than code, so they must never make
+// a grep pattern look like a real symbol; a repo-scoped probe additionally
+// keeps only that repo's nodes.
+func probeSymbolCandidate(n *graph.Node, repo string) bool {
+	if n == nil {
+		return false
+	}
+	if n.Kind == graph.KindFile || n.Kind == graph.KindImport {
+		return false
+	}
+	if repo != "" && n.RepoPrefix != repo {
+		return false
+	}
+	return true
+}
+
+func probeSymbolHit(n *graph.Node) daemon.SymbolHit {
+	return daemon.SymbolHit{
+		Name:     n.Name,
+		Kind:     string(n.Kind),
+		FilePath: n.FilePath,
+		Line:     n.StartLine,
+	}
 }
 
 // AttachWatcher is called by warmup to hand over the MultiWatcher once

--- a/cmd/gortex/daemon_controller_search_probe_test.go
+++ b/cmd/gortex/daemon_controller_search_probe_test.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/daemon"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// probeGraph builds a graph holding `filler` non-matching symbols plus
+// whatever the caller adds, standing in for a large multi-repo daemon graph.
+func probeGraph(t *testing.T, filler int) *graph.Graph {
+	t.Helper()
+	g := graph.New()
+	for i := range filler {
+		g.AddNode(&graph.Node{
+			ID:        fmt.Sprintf("filler/f%d.go::Unrelated%d", i, i),
+			Name:      fmt.Sprintf("Unrelated%d", i),
+			Kind:      graph.KindFunction,
+			FilePath:  fmt.Sprintf("filler/f%d.go", i),
+			StartLine: 1,
+		})
+	}
+	return g
+}
+
+// TestSearchSymbols_FindsSymbolAmongManyNodes is the behavioural floor for the
+// control-plane probe the Grep-redirect hook calls: a matching symbol must
+// come back even when it is a needle in a large graph. This used to be served
+// by an AllNodes() scan, which read-locked every shard at once and so queued
+// behind the indexer's writers; the probe's 200ms budget expired first and the
+// hook logged probed_miss / timed_out instead of a hit.
+func TestSearchSymbols_FindsSymbolAmongManyNodes(t *testing.T) {
+	g := probeGraph(t, 5000)
+	g.AddNode(&graph.Node{
+		ID:        "pkg/probe.go::ZebraProbeMarker",
+		Name:      "ZebraProbeMarker",
+		Kind:      graph.KindFunction,
+		FilePath:  "pkg/probe.go",
+		StartLine: 42,
+	})
+
+	c := &realController{graph: g}
+	res, err := c.SearchSymbols(context.Background(), daemon.SearchSymbolsParams{
+		Query: "ZebraProbeMarker",
+		Limit: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Hits, 1)
+	assert.Equal(t, "ZebraProbeMarker", res.Hits[0].Name)
+	assert.Equal(t, "pkg/probe.go", res.Hits[0].FilePath)
+	assert.Equal(t, 42, res.Hits[0].Line)
+	assert.Equal(t, string(graph.KindFunction), res.Hits[0].Kind)
+}
+
+// TestSearchSymbols_ExcludesFileAndImportNodes locks in the kind filter: the
+// hook asks "is this pattern a real symbol", so a file path or import path
+// that happens to contain the needle must not answer yes.
+func TestSearchSymbols_ExcludesFileAndImportNodes(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID: "config/config.go", Name: "config/config.go",
+		Kind: graph.KindFile, FilePath: "config/config.go",
+	})
+	g.AddNode(&graph.Node{
+		ID: "import::example.com/config", Name: "example.com/config",
+		Kind: graph.KindImport, FilePath: "main.go",
+	})
+
+	c := &realController{graph: g}
+	res, err := c.SearchSymbols(context.Background(), daemon.SearchSymbolsParams{Query: "config"})
+	require.NoError(t, err)
+	assert.Empty(t, res.Hits, "file and import nodes must never satisfy a symbol probe")
+}
+
+// TestSearchSymbols_FileNodesDoNotCrowdOutSymbols is the regression for the
+// bounded-fetch rewrite. Candidates now come from the name index, which cannot
+// express the File/Import filter, so a query matching thousands of file paths
+// could return a page the filter empties completely. The probe must widen the
+// page rather than report a false "no such symbol".
+func TestSearchSymbols_FileNodesDoNotCrowdOutSymbols(t *testing.T) {
+	g := graph.New()
+	// Far more matching file nodes than the first page holds.
+	for i := range 1000 {
+		p := fmt.Sprintf("pkg/config_%d.go", i)
+		g.AddNode(&graph.Node{ID: p, Name: p, Kind: graph.KindFile, FilePath: p})
+	}
+	g.AddNode(&graph.Node{
+		ID: "pkg/load.go::configLoader", Name: "configLoader",
+		Kind: graph.KindFunction, FilePath: "pkg/load.go", StartLine: 7,
+	})
+
+	c := &realController{graph: g}
+	res, err := c.SearchSymbols(context.Background(), daemon.SearchSymbolsParams{
+		Query: "config",
+		Limit: 5,
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Hits, 1)
+	assert.Equal(t, "configLoader", res.Hits[0].Name)
+}
+
+// TestSearchSymbols_RespectsLimit keeps the probe's response bounded — the
+// hook renders these inline, so an unbounded list would flood the agent.
+func TestSearchSymbols_RespectsLimit(t *testing.T) {
+	g := graph.New()
+	for i := range 100 {
+		name := fmt.Sprintf("handlerAlpha%d", i)
+		g.AddNode(&graph.Node{
+			ID: "h.go::" + name, Name: name,
+			Kind: graph.KindFunction, FilePath: "h.go",
+		})
+	}
+
+	c := &realController{graph: g}
+	res, err := c.SearchSymbols(context.Background(), daemon.SearchSymbolsParams{
+		Query: "handlerAlpha",
+		Limit: 7,
+	})
+	require.NoError(t, err)
+	assert.Len(t, res.Hits, 7)
+}
+
+// TestSearchSymbols_FiltersByRepo covers the repo-scoped probe on a
+// multi-repo daemon, where one repo can be a thin slice of the graph.
+func TestSearchSymbols_FiltersByRepo(t *testing.T) {
+	g := graph.New()
+	for i := range 800 {
+		name := fmt.Sprintf("sharedName%d", i)
+		g.AddNode(&graph.Node{
+			ID: "other/x.go::" + name, Name: name, Kind: graph.KindFunction,
+			FilePath: "other/x.go", RepoPrefix: "other",
+		})
+	}
+	g.AddNode(&graph.Node{
+		ID: "mine/y.go::sharedNameTarget", Name: "sharedNameTarget",
+		Kind: graph.KindFunction, FilePath: "mine/y.go", RepoPrefix: "mine",
+	})
+
+	c := &realController{graph: g}
+	res, err := c.SearchSymbols(context.Background(), daemon.SearchSymbolsParams{
+		Query: "sharedName",
+		Repo:  "mine",
+		Limit: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Hits, 1)
+	assert.Equal(t, "sharedNameTarget", res.Hits[0].Name)
+}
+
+// TestSearchSymbols_PrefersExactName covers the fast path: an exact short-name
+// match is answered from the per-shard byName bucket, so a large population of
+// symbols that merely contain the query cannot crowd it out.
+func TestSearchSymbols_PrefersExactName(t *testing.T) {
+	g := graph.New()
+	for i := range 5000 {
+		name := fmt.Sprintf("configLoader%d", i)
+		g.AddNode(&graph.Node{
+			ID: "bulk.go::" + name, Name: name,
+			Kind: graph.KindFunction, FilePath: "bulk.go",
+		})
+	}
+	g.AddNode(&graph.Node{
+		ID: "pkg/exact.go::config", Name: "config",
+		Kind: graph.KindType, FilePath: "pkg/exact.go", StartLine: 3,
+	})
+
+	c := &realController{graph: g}
+	res, err := c.SearchSymbols(context.Background(), daemon.SearchSymbolsParams{
+		Query: "config",
+		Limit: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Hits, 1)
+	assert.Equal(t, "config", res.Hits[0].Name)
+	assert.Equal(t, "pkg/exact.go", res.Hits[0].FilePath)
+}
+
+// TestSearchSymbols_EmptyQueryAndNilGraph covers the two short-circuits the
+// hook relies on to distinguish "no signal" from "probed and missed".
+func TestSearchSymbols_EmptyQueryAndNilGraph(t *testing.T) {
+	c := &realController{graph: graph.New()}
+	res, err := c.SearchSymbols(context.Background(), daemon.SearchSymbolsParams{Query: ""})
+	require.NoError(t, err)
+	assert.Empty(t, res.Hits)
+
+	empty := &realController{}
+	res, err = empty.SearchSymbols(context.Background(), daemon.SearchSymbolsParams{Query: "anything"})
+	require.NoError(t, err)
+	assert.Empty(t, res.Hits)
+}


### PR DESCRIPTION
## What this fixes

The Grep-redirect hook probes the daemon over `ControlSearchSymbols` with a 200ms budget. On a multi-repo daemon that probe never once returned a hit — `hook-decisions.jsonl` held **1023 `probed_miss`, 158 `timed_out`, and zero `probed_hit` across 2975 entries spanning 16 days**.

The hook logic was fine. The control plane could not answer in time.

## Root cause

`realController.SearchSymbols` served every probe from `g.AllNodes()`, which calls `lockAllRead()` — it read-locks **every shard simultaneously** and materialises a slice of the whole graph. Under the indexer's write load it queued behind the shard writers before doing any work, then linearly scanned hundreds of thousands of nodes to answer a question about a single identifier.

`realController.Status` had the same shape one layer up. `NodeCount`/`EdgeCount` are `COUNT(*)` on the SQLite backend and whole-shard walks in memory, and `runtime.ReadMemStats` stops the world — all three ran while holding the coarse controller mutex, so every queued control request waited them out. That is what put `gortex daemon status` at 17–25s, which in turn starves the 2s budget in the hook's tracked-repo lookup; on timeout that lookup silently reports zero tracked repos and skips PostToolUse enrichment before it ever dials.

## The change

**Probe path.** Everything reaching this RPC is a pattern the hook already classified as identifier-shaped, so it tries the per-shard `byName` bucket first — a few map lookups instead of a graph walk. Patterns naming only part of a symbol fall back to the name index with the fetch bound pushed down, widening on a saturated page so a query matching many file paths cannot crowd real symbols off it and read as a false "no such symbol".

**Status path.** `NodeCount`/`EdgeCount`/`ReadMemStats` hoisted out of the mutex, alongside the per-repo memory estimate already hoisted for this reason.

## Measured

200k-node graph with a concurrent writer, worst case over 25 probes:

| | worst-case probe |
|---|---|
| before (`AllNodes` scan) | 493ms — over the 200ms budget |
| after (`byName` fast path) | **245µs** — 2013x |

The writer in that benchmark is a tight allocation loop with no pause, harsher than a real indexer — it illustrates the lock-queueing failure mode rather than reproducing any specific production timing.

End-to-end against a live daemon with this build: `decision=probed_hit` at 1ms, PreToolUse returns `BLOCKED` with concrete symbol hits, PostToolUse returns graph context for the Codex Bash shape, and `daemon status` returns in 0.02s.

## Tests

Seven new regression tests for the probe: exact-name preference, the File/Import exclusion, repo scoping, limit bounds, the empty-query and nil-graph short-circuits, and the crowd-out case the bounded fetch introduces.

`go test` green across `cmd/gortex`, `internal/daemon`, `internal/hooks`, `internal/graph` (1848 tests); `go vet`, `gofmt` and `golangci-lint` clean.

## Context

Surfaced while validating #241. The two hook gaps reported there — alternation-aware PreToolUse probing and the PostToolUse socket migration — are already fixed and verified working end-to-end; this addresses the separate control-plane bug that kept the reporter's symptom alive regardless.