### PR TITLE
fix: apply per-repo .gortex.yaml changes without a daemon restart

### DIFF
--- a/cmd/gortex/daemon_controller.go
+++ b/cmd/gortex/daemon_controller.go
@@ -509,6 +509,13 @@ func (c *realController) Reload(ctx context.Context) (json.RawMessage, error) {
 		return nil, fmt.Errorf("reload config: %w", err)
 	}
 
+	// Re-read every already-tracked repo's `.gortex.yaml` and push the
+	// refreshed excludes into its live indexer. The tracked-repo diff
+	// below keeps such repos by root path and never re-tracks them, so
+	// without this an edit to a per-repo config could not reach a running
+	// daemon at all: reload was global-config-only in practice.
+	refreshed := c.multiIndexer.RefreshRepoConfigs()
+
 	var added, removed int
 
 	// Match configured entries to currently-tracked instances by ROOT
@@ -556,8 +563,9 @@ func (c *realController) Reload(ctx context.Context) (json.RawMessage, error) {
 	}
 
 	return json.Marshal(map[string]any{
-		"added":   added,
-		"removed": removed,
+		"added":     added,
+		"removed":   removed,
+		"refreshed": refreshed,
 	})
 }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -46,7 +46,7 @@ gortex daemon start --detach        # spawn in background
 gortex daemon status                # PID, uptime, memory, tracked repos, sessions, server roster, search backend, warmup + enrichment progress
 gortex daemon stop                  # graceful shutdown + final snapshot
 gortex daemon restart               # stop + start
-gortex daemon reload                # re-read config, pick up new/removed repos
+gortex daemon reload                # re-read the global config AND every tracked repo's .gortex.yaml, pick up new/removed repos
 gortex daemon logs -n 50            # tail the log file
 
 # Multi-server roster — let the daemon route to additional Gortex servers (local sockets or remote HTTPS):

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -223,6 +223,12 @@ gortex daemon reload          # re-read config, pick up new/removed repos
 gortex daemon logs -n 50      # tail the log
 ```
 
+`reload` re-reads the global `~/.gortex/config.yaml` *and* every tracked
+repo's own `.gortex.yaml`, so an edit to a repo's `exclude:`, `include:`,
+`guards:` or workspace slugs applies without restarting the daemon. The
+refreshed exclude list is pushed into each repo's live indexer, so the next
+walk — full or incremental — honours it.
+
 ### Auto-start at login (optional)
 
 Let the OS supervise the daemon so it starts at login and restarts on crash. No sudo required — the unit lives under `$HOME`.

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -89,13 +90,29 @@ func (cm *ConfigManager) Revision() uint64 {
 }
 
 // Reload re-reads the GlobalConfig from disk, keeping the same config
-// path. Workspace caches are preserved — individual `.gortex.yaml`
-// files are re-read lazily on demand. Used by the daemon's `reload`
-// control RPC to pick up manual edits to the global config without a
-// full process restart.
+// path, AND re-reads every per-repo `.gortex.yaml` this manager has seen.
+// Used by the daemon's `reload` control RPC to pick up manual edits to
+// either file without a full process restart.
+//
+// The per-repo re-read is not optional bookkeeping. This used to drop the
+// workspace caches and wait for a "lazy" re-read, but the only writer of
+// those caches is LoadWorkspaceConfig, which runs at track / index time
+// and never on this path — so the lazy re-read never happened. Worse,
+// workspacePaths is what EffectiveExclude uses to locate a repo's own
+// `.gitignore`, so dropping it left every tracked repo running with no
+// workspace config AND no gitignore layer (builtin-only admission) until
+// the process restarted: strictly worse than the stale state the drop was
+// meant to avoid.
+//
+// Every file is read before anything is published, so a concurrent
+// indexer walk never observes a config-less window.
 func (cm *ConfigManager) Reload() error {
 	cm.mu.Lock()
 	path := cm.global.ConfigPath()
+	known := make(map[string]string, len(cm.workspacePaths))
+	for prefix, repoPath := range cm.workspacePaths {
+		known[prefix] = repoPath
+	}
 	cm.mu.Unlock()
 
 	var fresh *GlobalConfig
@@ -109,64 +126,108 @@ func (cm *ConfigManager) Reload() error {
 		return fmt.Errorf("reload global config: %w", err)
 	}
 
+	reread := make(map[string]*Config, len(known))
+	var dropped []string
+	for prefix, repoPath := range known {
+		cfg, authoritative := cm.readWorkspaceConfig(prefix, repoPath)
+		switch {
+		case !authoritative:
+			// Present but unreadable / malformed — keep the last good
+			// parse rather than silently downgrading the repo to global
+			// defaults on a transient I/O error or a half-saved edit.
+		case cfg == nil:
+			// The `.gortex.yaml` is gone; so are its overrides.
+			dropped = append(dropped, prefix)
+		default:
+			reread[prefix] = cfg
+		}
+	}
+
+	// Apply per prefix rather than swapping the whole map: a repo tracked
+	// concurrently with this reload must not be erased by a map snapshot
+	// taken before it existed.
 	cm.mu.Lock()
 	cm.global = fresh
-	// Drop workspace cache so stale per-repo overrides don't linger;
-	// they'll be reloaded on the next LoadWorkspaceConfig call.
-	cm.workspace = make(map[string]*Config)
-	cm.workspacePaths = make(map[string]string)
+	for prefix, cfg := range reread {
+		cm.workspace[prefix] = cfg
+	}
+	for _, prefix := range dropped {
+		delete(cm.workspace, prefix)
+	}
 	cm.revision.Add(1)
 	cm.mu.Unlock()
 	return nil
 }
 
 // LoadWorkspaceConfig loads a .gortex.yaml from the given repo root
-// and caches it under the given repoPrefix. If the file is missing,
-// no entry is cached (global defaults will apply). If the file is
-// malformed, a warning is logged and no entry is cached.
+// and caches it under the given repoPrefix. If the file is missing, any
+// entry cached under that prefix is dropped (global defaults will
+// apply). If the file exists but is unreadable or malformed, a warning
+// is logged and the last good parse is kept.
 func (cm *ConfigManager) LoadWorkspaceConfig(repoPrefix, repoPath string) {
+	cfg, authoritative := cm.readWorkspaceConfig(repoPrefix, repoPath)
+	cm.publishWorkspaceConfig(repoPrefix, repoPath, cfg, authoritative)
+}
+
+// readWorkspaceConfig reads and parses a repo's `.gortex.yaml`. The second
+// return reports whether the result reflects what is on disk: it is false
+// only when the file exists but could not be read or parsed, in which case
+// the caller keeps whatever it had cached. A (nil, true) result means the
+// file genuinely does not exist.
+func (cm *ConfigManager) readWorkspaceConfig(repoPrefix, repoPath string) (*Config, bool) {
 	configPath := filepath.Join(repoPath, ".gortex.yaml")
 
 	data, err := os.ReadFile(configPath)
 	if err != nil {
-		cm.updateWorkspaceConfig(repoPrefix, repoPath, nil)
 		if os.IsNotExist(err) {
 			// No workspace config — global defaults will apply.
-			return
+			return nil, true
 		}
 		cm.logger.Warn("failed to read workspace config",
 			zap.String("repo", repoPrefix),
 			zap.String("path", configPath),
 			zap.Error(err))
-		return
+		return nil, false
 	}
 
 	var cfg Config
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		cm.updateWorkspaceConfig(repoPrefix, repoPath, nil)
-		// Malformed workspace config — log warning, return global defaults.
-		cm.logger.Warn("malformed workspace config, using global defaults",
+		// Malformed workspace config — log warning, keep the last good parse.
+		cm.logger.Warn("malformed workspace config, keeping the last good parse",
 			zap.String("repo", repoPrefix),
 			zap.String("path", configPath),
 			zap.Error(err))
-		return
+		return nil, false
 	}
 
-	cm.updateWorkspaceConfig(repoPrefix, repoPath, &cfg)
+	return &cfg, true
 }
 
-// updateWorkspaceConfig publishes a per-repo state transition and advances
-// revision only when the cached state actually changes. A nil cfg updates the
-// remembered path without replacing an existing parsed config, preserving the
-// prior missing/malformed-file behavior.
-func (cm *ConfigManager) updateWorkspaceConfig(repoPrefix, repoPath string, cfg *Config) {
+// publishWorkspaceConfig publishes a per-repo state transition and advances
+// revision only when the cached state actually changes. authoritative says
+// whether cfg reflects what is on disk: a failed read/parse updates only the
+// remembered path and leaves the cached config alone, while an authoritative
+// nil (no `.gortex.yaml` on disk) drops it — deleting the file must stop its
+// overrides applying, without waiting for a daemon restart.
+//
+// The remembered path is never cleared: EffectiveExclude needs it to locate
+// the repo's own `.gitignore`, which is independent of `.gortex.yaml`.
+func (cm *ConfigManager) publishWorkspaceConfig(repoPrefix, repoPath string, cfg *Config, authoritative bool) {
 	cm.mu.Lock()
 	changed := false
 	if repoPath != "" && cm.workspacePaths[repoPrefix] != repoPath {
 		cm.workspacePaths[repoPrefix] = repoPath
 		changed = true
 	}
-	if cfg != nil && !reflect.DeepEqual(cm.workspace[repoPrefix], cfg) {
+	switch {
+	case !authoritative:
+		// Keep the last good parse.
+	case cfg == nil:
+		if _, ok := cm.workspace[repoPrefix]; ok {
+			delete(cm.workspace, repoPrefix)
+			changed = true
+		}
+	case !reflect.DeepEqual(cm.workspace[repoPrefix], cfg):
 		cm.workspace[repoPrefix] = cfg
 		changed = true
 	}
@@ -174,6 +235,25 @@ func (cm *ConfigManager) updateWorkspaceConfig(repoPrefix, repoPath string, cfg 
 		cm.revision.Add(1)
 	}
 	cm.mu.Unlock()
+}
+
+// WorkspacePrefixes returns the repo prefixes this manager has loaded a
+// workspace config for — i.e. every repo that has been tracked or indexed
+// in this process, whether or not it has a `.gortex.yaml`. Callers use it
+// to tell a real repo prefix from the leading path segment of an
+// unprefixed node ID.
+func (cm *ConfigManager) WorkspacePrefixes() []string {
+	if cm == nil {
+		return nil
+	}
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	out := make([]string, 0, len(cm.workspacePaths))
+	for prefix := range cm.workspacePaths {
+		out = append(out, prefix)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // getWorkspaceConfig returns the cached workspace config for a repo, or nil.

--- a/internal/config/manager_test.go
+++ b/internal/config/manager_test.go
@@ -528,3 +528,141 @@ func TestPropertyConfigLayeringSemantics(t *testing.T) {
 			"repo without workspace config should get global default guard rules")
 	})
 }
+
+// --- Reload re-reads per-repo `.gortex.yaml` (issue #320) ---
+
+// writeWorkspaceConfig writes a `.gortex.yaml` into repoDir.
+func writeWorkspaceConfig(t *testing.T, repoDir, body string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".gortex.yaml"), []byte(body), 0644))
+}
+
+func TestReload_RereadsWorkspaceConfigForTrackedRepos(t *testing.T) {
+	cm, err := NewConfigManager("/tmp/nonexistent-gortex-test-cm/config.yaml")
+	require.NoError(t, err)
+
+	repoDir := t.TempDir()
+	writeWorkspaceConfig(t, repoDir, `
+exclude:
+  - "old-dir/**"
+guards:
+  rules:
+    - name: old-rule
+      kind: boundary
+      source: "pkg/a"
+      target: "pkg/b"
+      message: "boundary violation"
+`)
+	cm.LoadWorkspaceConfig("repo", repoDir)
+	require.Contains(t, cm.EffectiveExclude("repo"), "old-dir/**")
+
+	// The user edits the repo's config and asks the daemon to reload. No
+	// LoadWorkspaceConfig call follows — that is the whole point: nothing
+	// on the reload path used to make one for an already-tracked repo.
+	writeWorkspaceConfig(t, repoDir, `
+exclude:
+  - "new-dir/**"
+guards:
+  rules:
+    - name: new-rule
+      kind: boundary
+      source: "pkg/c"
+      target: "pkg/d"
+      message: "boundary violation"
+`)
+	require.NoError(t, cm.Reload())
+
+	got := cm.EffectiveExclude("repo")
+	assert.Contains(t, got, "new-dir/**", "reload must pick up the edited exclude list")
+	assert.NotContains(t, got, "old-dir/**", "reload must drop the superseded exclude list")
+
+	rules := cm.EffectiveGuardRules("repo")
+	require.Len(t, rules, 1)
+	assert.Equal(t, "new-rule", rules[0].Name, "reload must pick up the edited guard rules")
+}
+
+func TestReload_KeepsGitignoreLayerForTrackedRepos(t *testing.T) {
+	cm, err := NewConfigManager("/tmp/nonexistent-gortex-test-cm/config.yaml")
+	require.NoError(t, err)
+
+	repoDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".gitignore"), []byte("tmp/\n"), 0644))
+	cm.LoadWorkspaceConfig("repo", repoDir)
+	require.Contains(t, cm.EffectiveExclude("repo"), "tmp/")
+
+	// Reload used to clear workspacePaths, which is how EffectiveExclude
+	// locates the repo's own `.gitignore` — so the whole gitignore layer
+	// died with the workspace config and the walk fell back to
+	// builtin-only admission.
+	require.NoError(t, cm.Reload())
+
+	assert.Contains(t, cm.EffectiveExclude("repo"), "tmp/",
+		"reload must not sever the repo's .gitignore layer")
+}
+
+func TestReload_DropsDeletedWorkspaceConfig(t *testing.T) {
+	cm, err := NewConfigManager("/tmp/nonexistent-gortex-test-cm/config.yaml")
+	require.NoError(t, err)
+
+	repoDir := t.TempDir()
+	writeWorkspaceConfig(t, repoDir, "exclude:\n  - \"gone/**\"\n")
+	cm.LoadWorkspaceConfig("repo", repoDir)
+	require.Contains(t, cm.EffectiveExclude("repo"), "gone/**")
+
+	require.NoError(t, os.Remove(filepath.Join(repoDir, ".gortex.yaml")))
+	require.NoError(t, cm.Reload())
+
+	assert.NotContains(t, cm.EffectiveExclude("repo"), "gone/**",
+		"a deleted .gortex.yaml must stop applying")
+	assert.Nil(t, cm.getWorkspaceConfig("repo"))
+}
+
+func TestReload_KeepsLastGoodParseOnMalformedEdit(t *testing.T) {
+	cm, err := NewConfigManager("/tmp/nonexistent-gortex-test-cm/config.yaml")
+	require.NoError(t, err)
+
+	repoDir := t.TempDir()
+	writeWorkspaceConfig(t, repoDir, "exclude:\n  - \"good/**\"\n")
+	cm.LoadWorkspaceConfig("repo", repoDir)
+	require.Contains(t, cm.EffectiveExclude("repo"), "good/**")
+
+	// A half-saved edit must not silently downgrade the repo to global
+	// defaults — that is indistinguishable from the bug being fixed here.
+	writeWorkspaceConfig(t, repoDir, ":::invalid yaml content")
+	require.NoError(t, cm.Reload())
+
+	assert.Contains(t, cm.EffectiveExclude("repo"), "good/**",
+		"a malformed edit must keep the last good parse")
+}
+
+func TestLoadWorkspaceConfig_DeletedFileDropsCachedConfig(t *testing.T) {
+	cm, err := NewConfigManager("/tmp/nonexistent-gortex-test-cm/config.yaml")
+	require.NoError(t, err)
+
+	repoDir := t.TempDir()
+	writeWorkspaceConfig(t, repoDir, "exclude:\n  - \"gone/**\"\n")
+	cm.LoadWorkspaceConfig("repo", repoDir)
+	require.NotNil(t, cm.getWorkspaceConfig("repo"))
+
+	require.NoError(t, os.Remove(filepath.Join(repoDir, ".gortex.yaml")))
+	cm.LoadWorkspaceConfig("repo", repoDir)
+
+	assert.Nil(t, cm.getWorkspaceConfig("repo"),
+		"re-reading a repo whose .gortex.yaml was deleted must drop the cached config")
+}
+
+func TestLoadWorkspaceConfig_MalformedEditKeepsLastGoodParse(t *testing.T) {
+	cm, err := NewConfigManager("/tmp/nonexistent-gortex-test-cm/config.yaml")
+	require.NoError(t, err)
+
+	repoDir := t.TempDir()
+	writeWorkspaceConfig(t, repoDir, "exclude:\n  - \"good/**\"\n")
+	cm.LoadWorkspaceConfig("repo", repoDir)
+
+	writeWorkspaceConfig(t, repoDir, ":::invalid yaml content")
+	cm.LoadWorkspaceConfig("repo", repoDir)
+
+	cfg := cm.getWorkspaceConfig("repo")
+	require.NotNil(t, cfg)
+	assert.Equal(t, []string{"good/**"}, cfg.Exclude)
+}

--- a/internal/indexer/incremental_reindex_test.go
+++ b/internal/indexer/incremental_reindex_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -40,9 +39,7 @@ func Dropped() {}
 	require.NotEmpty(t, g.FindNodesByName("Dropped"))
 
 	// Mid-flight exclusion: drop.go remains on disk but must leave the graph.
-	idx.config.Exclude = append(append([]string{}, excludes.Builtin...), "drop.go")
-	idx.excludes = nil
-	idx.excludeOnce = sync.Once{}
+	idx.SetExcludePatterns(append(append([]string{}, excludes.Builtin...), "drop.go"))
 
 	res, err := idx.IncrementalReindex(dir)
 	require.NoError(t, err)

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -157,14 +157,21 @@ type Indexer struct {
 	// them take the shadow path regardless of what sibling repos
 	// have already drained into the shared disk store. Per-repo-
 	// prefixed stub IDs make the concurrent drains conflict-free.
-	indexCount    atomic.Int32
-	registry      *parser.Registry
-	resolver      *resolver.Resolver
-	search        search.Backend
-	config        config.IndexConfig
-	transforms    *transformPipeline
-	excludes      *excludes.Matcher
-	excludeOnce   sync.Once
+	indexCount atomic.Int32
+	registry   *parser.Registry
+	resolver   *resolver.Resolver
+	search     search.Backend
+	config     config.IndexConfig
+	transforms *transformPipeline
+	// excludes is the compiled ignore matcher, built lazily from
+	// config.Exclude. It is hot-swappable rather than build-once: a
+	// per-repo Indexer outlives many `.gortex.yaml` edits, and without a
+	// swap every incremental / scoped re-index kept walking with the
+	// exclude list the Indexer was constructed with. excludeMu guards the
+	// build and the swap (and the config.Exclude read/write that goes with
+	// them); readers pay only the atomic load.
+	excludes      atomic.Pointer[excludes.Matcher]
+	excludeMu     sync.Mutex
 	dirIgnore     *excludes.Hierarchical
 	dirIgnoreOnce sync.Once
 	rootPath      string
@@ -5228,18 +5235,42 @@ func (idx *Indexer) dirIgnoreMatcher(root string) *excludes.Hierarchical {
 }
 
 func (idx *Indexer) excludeMatcher() *excludes.Matcher {
-	idx.excludeOnce.Do(func() {
-		patterns := idx.config.Exclude
-		// A nil/empty list from upstream means "no layering was applied"
-		// (e.g. a direct caller of indexer.New without ConfigManager).
-		// Fall back to the builtin baseline so the walk still skips the
-		// obvious non-source dirs.
-		if len(patterns) == 0 {
-			patterns = excludes.Builtin
-		}
-		idx.excludes = excludes.New(patterns)
-	})
-	return idx.excludes
+	if m := idx.excludes.Load(); m != nil {
+		return m
+	}
+	idx.excludeMu.Lock()
+	defer idx.excludeMu.Unlock()
+	if m := idx.excludes.Load(); m != nil {
+		return m
+	}
+	m := excludes.New(effectiveExcludePatterns(idx.config.Exclude))
+	idx.excludes.Store(m)
+	return m
+}
+
+// SetExcludePatterns installs a new effective ignore list on a live
+// Indexer and rebuilds the matcher, so the next walk honours it. Called
+// when a repo's `.gortex.yaml` is re-read (daemon reload / re-track):
+// the per-repo Indexer is long-lived and is reused by every incremental
+// and scoped re-index, so without this an exclude added after the repo
+// was tracked did not take effect until the daemon restarted.
+func (idx *Indexer) SetExcludePatterns(patterns []string) {
+	idx.excludeMu.Lock()
+	defer idx.excludeMu.Unlock()
+	idx.config.Exclude = patterns
+	idx.excludes.Store(excludes.New(effectiveExcludePatterns(patterns)))
+}
+
+// effectiveExcludePatterns falls back to the builtin baseline when the
+// list is empty. A nil/empty list from upstream means "no layering was
+// applied" (e.g. a direct caller of indexer.New without ConfigManager),
+// not "index everything" — the walk should still skip the obvious
+// non-source dirs.
+func effectiveExcludePatterns(patterns []string) []string {
+	if len(patterns) == 0 {
+		return excludes.Builtin
+	}
+	return patterns
 }
 
 // ParseErrors returns the parse errors from the last full index.

--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -2053,6 +2053,48 @@ func (mi *MultiIndexer) IndexRepo(repoPrefix string) (*IndexResult, error) {
 	return result, nil
 }
 
+// RefreshRepoConfigs re-reads every tracked repo's `.gortex.yaml` and
+// pushes the refreshed effective exclude list into that repo's live
+// Indexer. Returns the number of repos whose config was re-read.
+//
+// This is the deterministic re-read path for an already-tracked repo.
+// Track and index both load the workspace config on their way in, but a
+// repo that is already tracked short-circuits before that — so an edit to
+// `.gortex.yaml` had no way to reach a running daemon. Pushing the
+// exclude list into the live Indexer matters just as much: it is reused
+// by every incremental and scoped re-index, and it froze its ignore list
+// at construction.
+func (mi *MultiIndexer) RefreshRepoConfigs() int {
+	if mi == nil || mi.configMgr == nil {
+		return 0
+	}
+
+	mi.mu.RLock()
+	roots := make(map[string]string, len(mi.repos))
+	for prefix, meta := range mi.repos {
+		if meta != nil && meta.RootPath != "" {
+			roots[prefix] = meta.RootPath
+		}
+	}
+	mi.mu.RUnlock()
+
+	for prefix, root := range roots {
+		mi.configMgr.LoadWorkspaceConfig(prefix, root)
+
+		cfg := mi.configMgr.GetRepoConfig(prefix)
+		if cfg == nil {
+			continue
+		}
+		mi.mu.RLock()
+		idx := mi.indexers[prefix]
+		mi.mu.RUnlock()
+		if idx != nil {
+			idx.SetExcludePatterns(cfg.Index.Exclude)
+		}
+	}
+	return len(roots)
+}
+
 // IncrementalReindexRepo incrementally re-indexes a single tracked repo
 // by prefix: only the files that changed since the last pass are
 // re-parsed and deleted files are evicted, against the repo's existing

--- a/internal/indexer/multi_refresh_config_test.go
+++ b/internal/indexer/multi_refresh_config_test.go
@@ -1,0 +1,63 @@
+package indexer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/search"
+)
+
+// A repo's `.gortex.yaml` can change while the daemon runs, but an
+// already-tracked repo short-circuits every path that would re-read it,
+// and its per-repo Indexer froze the effective exclude list at
+// construction — so a newly added exclude did not take effect until the
+// process restarted (issue #320).
+func TestMultiIndexer_RefreshRepoConfigs_AppliesEditedExcludeToLiveIndexer(t *testing.T) {
+	dir := setupRepoDir(t, "myrepo")
+	writeFile(t, filepath.Join(dir, "drop.go"), `package main
+
+func Dropped() {}
+`)
+
+	tmpCfg := filepath.Join(t.TempDir(), "config.yaml")
+	gc := &config.GlobalConfig{Repos: []config.RepoEntry{{Path: dir, Name: "myrepo"}}}
+	gc.SetConfigPath(tmpCfg)
+	require.NoError(t, gc.Save())
+
+	cm, err := config.NewConfigManager(tmpCfg)
+	require.NoError(t, err)
+
+	g := graph.New()
+	mi := NewMultiIndexer(g, newTestRegistry(), search.NewBM25(), cm, zap.NewNop())
+	_, err = mi.IndexAll()
+	require.NoError(t, err)
+	require.NotEmpty(t, g.FindNodesByName("Dropped"), "precondition: drop.go is indexed")
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".gortex.yaml"),
+		[]byte("exclude:\n  - \"drop.go\"\n"), 0o644))
+
+	assert.Equal(t, 1, mi.RefreshRepoConfigs())
+	assert.Contains(t, cm.EffectiveExclude("myrepo"), "drop.go",
+		"the refreshed config must reach the ConfigManager")
+
+	res, err := mi.IncrementalReindexRepo("myrepo", nil)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	assert.Empty(t, g.FindNodesByName("Dropped"),
+		"a file excluded after tracking must leave the graph on the next pass")
+	assert.NotEmpty(t, g.FindNodesByName("Hello"),
+		"unrelated symbols must survive the refresh")
+}
+
+func TestMultiIndexer_RefreshRepoConfigs_NoConfigManager(t *testing.T) {
+	mi := NewMultiIndexer(graph.New(), newTestRegistry(), search.NewBM25(), nil, zap.NewNop())
+	assert.Equal(t, 0, mi.RefreshRepoConfigs())
+}

--- a/internal/mcp/change_contract.go
+++ b/internal/mcp/change_contract.go
@@ -353,7 +353,7 @@ func (s *Server) lowerDiffSource(ctx context.Context, req mcp.CallToolRequest) (
 // family (events, taint) is a registration here, not a new pipeline branch.
 func (s *Server) ruleFamilies() []analysis.RuleFamily {
 	fams := []analysis.RuleFamily{
-		analysis.GuardsFamily{Rules: s.guardRules},
+		guardsFamily{srv: s},
 		analysis.ArchitectureFamily{Config: s.architecture},
 	}
 	fams = append(fams, s.extraRuleFamilies()...)

--- a/internal/mcp/guard_rules.go
+++ b/internal/mcp/guard_rules.go
@@ -1,0 +1,174 @@
+package mcp
+
+import (
+	"github.com/zzet/gortex/internal/analysis"
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Guard rules are declared per repo, in that repo's `.gortex.yaml`, but
+// Server.guardRules is a single process-level snapshot taken at
+// construction. In the daemon that snapshot comes from whatever
+// `.gortex.yaml` happened to sit in the daemon's own working directory —
+// which for a multi-repo daemon governs none of the tracked repos, and for
+// a daemon started outside the repo governs nothing at all. That is why a
+// daemon could honour a repo's excludes on the indexer walk (the walk
+// resolves config per repo through the ConfigManager) while check_guards
+// on the same daemon answered "no guard rules configured".
+//
+// The ConfigManager holds the real per-repo config, keyed by repo prefix,
+// so resolve through it and keep the process-level snapshot only as the
+// fallback for servers wired without one (embedded single-repo mode,
+// tests).
+
+// guardRulesFor returns the guard rules governing one repo prefix.
+func (s *Server) guardRulesFor(repoPrefix string) []config.GuardRule {
+	if s.configManager != nil {
+		if rules := s.configManager.EffectiveGuardRules(repoPrefix); len(rules) > 0 {
+			return rules
+		}
+	}
+	return s.guardRules
+}
+
+// repoScopeResolver maps node IDs to the repo prefix whose config governs
+// them. repoPrefixOf alone will not do: it returns the leading path
+// segment, which in a solo (unprefixed) repo is a source directory rather
+// than a repo — "pkg/handler/h.go::Handle" would resolve to repo "pkg".
+// Checking the segment against the set of repos actually tracked in this
+// process tells the two apart, and a single tracked repo absorbs every ID
+// that names no repo of its own.
+type repoScopeResolver struct {
+	tracked map[string]struct{}
+	sole    string
+}
+
+// newRepoScopeResolver collects the tracked repo prefixes from both
+// sources that know them: the ConfigManager (every repo whose workspace
+// config was loaded) and the MultiIndexer (every repo registered on the
+// graph). Either may be absent depending on how the server was wired.
+func (s *Server) newRepoScopeResolver() repoScopeResolver {
+	r := repoScopeResolver{tracked: make(map[string]struct{}, 4)}
+	for _, prefix := range s.configManager.WorkspacePrefixes() {
+		if prefix != "" {
+			r.tracked[prefix] = struct{}{}
+		}
+	}
+	if s.multiIndexer != nil {
+		for prefix := range s.multiIndexer.AllMetadata() {
+			if prefix != "" {
+				r.tracked[prefix] = struct{}{}
+			}
+		}
+	}
+	if len(r.tracked) == 1 {
+		for prefix := range r.tracked {
+			r.sole = prefix
+		}
+	}
+	return r
+}
+
+// prefixOf returns the repo prefix governing one node ID.
+func (r repoScopeResolver) prefixOf(id string) string {
+	p := repoPrefixOf(id)
+	if p == "" {
+		return r.sole
+	}
+	if _, ok := r.tracked[p]; ok {
+		return p
+	}
+	if len(r.tracked) == 0 {
+		// Nothing to check against (embedded mode, tests): the ID's own
+		// leading segment is the best information available.
+		return p
+	}
+	// Not a tracked repo — an unprefixed ID from a solo repo.
+	return r.sole
+}
+
+// groupIDsByRepo buckets node IDs by the repo prefix whose config governs
+// them, returning the buckets plus the prefixes in first-seen order so
+// results stay deterministic.
+func (s *Server) groupIDsByRepo(ids []string) (map[string][]string, []string) {
+	resolver := s.newRepoScopeResolver()
+	groups := make(map[string][]string, 2)
+	order := make([]string, 0, 2)
+	for _, id := range ids {
+		prefix := resolver.prefixOf(id)
+		if _, seen := groups[prefix]; !seen {
+			order = append(order, prefix)
+		}
+		groups[prefix] = append(groups[prefix], id)
+	}
+	return groups, order
+}
+
+// evaluateGuards evaluates each ID against the guard rules of its OWN
+// repo. Evaluating the union of every repo's rules over every ID would let
+// a rule declared in one repo fire against another repo's symbols, so the
+// IDs are grouped by repo first.
+func (s *Server) evaluateGuards(ids []string) []analysis.GuardViolation {
+	if len(ids) == 0 {
+		return nil
+	}
+	groups, order := s.groupIDsByRepo(ids)
+	var out []analysis.GuardViolation
+	for _, prefix := range order {
+		rules := s.guardRulesFor(prefix)
+		if len(rules) == 0 {
+			continue
+		}
+		out = append(out, analysis.EvaluateGuards(s.graph, rules, groups[prefix])...)
+	}
+	return out
+}
+
+// hasGuardRules reports whether any guard rule could fire for these IDs.
+// The cheap gate in front of evaluateGuards, and the check behind the
+// "no guard rules configured" answer.
+func (s *Server) hasGuardRules(ids []string) bool {
+	if len(s.guardRules) > 0 {
+		return true
+	}
+	if s.configManager == nil {
+		return false
+	}
+	_, order := s.groupIDsByRepo(ids)
+	for _, prefix := range order {
+		if len(s.configManager.EffectiveGuardRules(prefix)) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// anyGuardRulesConfigured reports whether any TRACKED repo declares guard
+// rules, independent of a particular ID set. Used where there is no
+// changed-symbol set to scope by.
+func (s *Server) anyGuardRulesConfigured() bool {
+	if len(s.guardRules) > 0 {
+		return true
+	}
+	if s.configManager == nil {
+		return false
+	}
+	for prefix := range s.newRepoScopeResolver().tracked {
+		if len(s.configManager.EffectiveGuardRules(prefix)) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// guardsFamily adapts the per-repo guard resolution to
+// analysis.RuleFamily, so the change-contract pipeline scopes rules to
+// each changed symbol's repo exactly like check_guards does. It replaces
+// analysis.GuardsFamily, which can only carry one flat rule list.
+type guardsFamily struct{ srv *Server }
+
+func (f guardsFamily) Name() string { return "guards" }
+
+func (f guardsFamily) Evaluate(_ graph.Store, changedSet []string) []analysis.GuardViolation {
+	return f.srv.evaluateGuards(changedSet)
+}

--- a/internal/mcp/guard_rules_test.go
+++ b/internal/mcp/guard_rules_test.go
@@ -1,0 +1,186 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// guardRulesTestManager returns a ConfigManager with one repo per entry of
+// bodies, each body written as that repo's `.gortex.yaml`.
+func guardRulesTestManager(t *testing.T, bodies map[string]string) *config.ConfigManager {
+	t.Helper()
+	cm, err := config.NewConfigManager(filepath.Join(t.TempDir(), "config.yaml"))
+	require.NoError(t, err)
+	for prefix, body := range bodies {
+		repoDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".gortex.yaml"), []byte(body), 0o644))
+		cm.LoadWorkspaceConfig(prefix, repoDir)
+	}
+	return cm
+}
+
+const guardRulesRepoA = `
+guards:
+  rules:
+    - name: a-rule
+      kind: co-change
+      source: "repo-a/pkg/handler"
+      target: "repo-a/pkg/store"
+      message: "repo-a handler changed without its store"
+`
+
+const guardRulesRepoB = `
+guards:
+  rules:
+    - name: b-rule
+      kind: co-change
+      source: "repo-b/pkg/handler"
+      target: "repo-b/pkg/store"
+      message: "repo-b handler changed without its store"
+`
+
+func TestGuardRulesFor_ResolvesPerRepoWorkspaceConfig(t *testing.T) {
+	// The daemon's own process config declares nothing — the normal case
+	// for a multi-repo daemon, whose working directory belongs to none of
+	// the tracked repos.
+	s := &Server{configManager: guardRulesTestManager(t, map[string]string{
+		"repo-a": guardRulesRepoA,
+		"repo-b": guardRulesRepoB,
+	})}
+
+	a := s.guardRulesFor("repo-a")
+	require.Len(t, a, 1)
+	assert.Equal(t, "a-rule", a[0].Name)
+
+	b := s.guardRulesFor("repo-b")
+	require.Len(t, b, 1)
+	assert.Equal(t, "b-rule", b[0].Name)
+
+	assert.Empty(t, s.guardRulesFor("repo-c"), "a repo with no rules must resolve to none")
+}
+
+func TestGuardRulesFor_FallsBackToProcessSnapshot(t *testing.T) {
+	// Embedded single-repo mode and tests wire no ConfigManager; the
+	// snapshot the server was constructed with must still apply.
+	snapshot := []config.GuardRule{{Name: "proc-rule", Kind: "co-change"}}
+
+	s := &Server{guardRules: snapshot}
+	assert.Equal(t, snapshot, s.guardRulesFor("repo-a"))
+
+	withCM := &Server{
+		guardRules:    snapshot,
+		configManager: guardRulesTestManager(t, map[string]string{"repo-a": guardRulesRepoA}),
+	}
+	assert.Equal(t, snapshot, withCM.guardRulesFor("repo-b"),
+		"a repo that declares no rules of its own falls back to the snapshot")
+}
+
+func TestHasGuardRules_SeesRulesDeclaredOnlyInWorkspaceConfig(t *testing.T) {
+	// The reported bug: check_guards answered "no guard rules configured"
+	// because it gated on the process-level snapshot alone, which in a
+	// daemon holds the config of the daemon's working directory rather
+	// than of any tracked repo.
+	s := &Server{configManager: guardRulesTestManager(t, map[string]string{"repo-a": guardRulesRepoA})}
+
+	assert.Empty(t, s.guardRules, "precondition: no process-level rules")
+	assert.True(t, s.hasGuardRules([]string{"repo-a/pkg/handler/h.go::Handle"}))
+	assert.True(t, s.anyGuardRulesConfigured())
+
+	// repo-c is not tracked, so this ID cannot be attributed to it; with
+	// repo-a the only tracked repo, it falls back there.
+	assert.True(t, s.hasGuardRules([]string{"repo-c/pkg/handler/h.go::Handle"}))
+}
+
+func TestRepoScopeResolver_UnprefixedIDsResolveToTheSoleTrackedRepo(t *testing.T) {
+	// A solo repo indexes unprefixed IDs, so the leading path segment is a
+	// source directory, not a repo. Resolving it as one would look up
+	// guard rules for a repo named "pkg" and find none.
+	s := &Server{configManager: guardRulesTestManager(t, map[string]string{"solo": guardRulesRepoA})}
+
+	groups, order := s.groupIDsByRepo([]string{"pkg/handler/h.go::Handle", "internal/x.go::X"})
+	assert.Equal(t, []string{"solo"}, order)
+	assert.Len(t, groups["solo"], 2)
+
+	rules := s.guardRulesFor(order[0])
+	require.Len(t, rules, 1)
+	assert.Equal(t, "a-rule", rules[0].Name)
+}
+
+func TestRepoScopeResolver_KeepsDistinctTrackedPrefixesApart(t *testing.T) {
+	s := &Server{configManager: guardRulesTestManager(t, map[string]string{
+		"repo-a": guardRulesRepoA,
+		"repo-b": guardRulesRepoB,
+	})}
+
+	_, order := s.groupIDsByRepo([]string{
+		"repo-a/pkg/x.go::X",
+		"repo-b/pkg/y.go::Y",
+		"repo-a/pkg/z.go::Z",
+	})
+	assert.Equal(t, []string{"repo-a", "repo-b"}, order)
+}
+
+func TestEvaluateGuards_EvaluatesEachIDAgainstItsOwnRepoRules(t *testing.T) {
+	g := graph.New()
+	for _, n := range []*graph.Node{
+		{ID: "repo-a/pkg/handler/h.go::Handle", Name: "Handle", Kind: graph.KindFunction, FilePath: "repo-a/pkg/handler/h.go"},
+		{ID: "repo-b/pkg/handler/h.go::Handle", Name: "Handle", Kind: graph.KindFunction, FilePath: "repo-b/pkg/handler/h.go"},
+	} {
+		g.AddNode(n)
+	}
+
+	s := &Server{
+		graph: g,
+		configManager: guardRulesTestManager(t, map[string]string{
+			"repo-a": guardRulesRepoA,
+			"repo-b": guardRulesRepoB,
+		}),
+	}
+
+	got := s.evaluateGuards([]string{
+		"repo-a/pkg/handler/h.go::Handle",
+		"repo-b/pkg/handler/h.go::Handle",
+	})
+
+	names := make([]string, 0, len(got))
+	for _, v := range got {
+		names = append(names, v.RuleName)
+	}
+	assert.ElementsMatch(t, []string{"a-rule", "b-rule"}, names,
+		"each repo's rules must fire for that repo's changed symbols")
+}
+
+func TestEvaluateGuards_RulesDoNotLeakAcrossRepos(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID:       "repo-b/pkg/handler/h.go::Handle",
+		Name:     "Handle",
+		Kind:     graph.KindFunction,
+		FilePath: "repo-b/pkg/handler/h.go",
+	})
+
+	// Only repo-a declares rules; repo-b's symbols must not be judged by them.
+	s := &Server{
+		graph:         g,
+		configManager: guardRulesTestManager(t, map[string]string{"repo-a": guardRulesRepoA}),
+	}
+
+	assert.Empty(t, s.evaluateGuards([]string{"repo-b/pkg/handler/h.go::Handle"}))
+}
+
+func TestGroupIDsByRepo_NoTrackedSetTrustsTheIDPrefix(t *testing.T) {
+	// Neither ConfigManager nor MultiIndexer wired (embedded mode, tests):
+	// the ID's own leading segment is the best information available.
+	s := &Server{}
+	groups, order := s.groupIDsByRepo([]string{"pkg/handler/h.go::Handle", "repo-a/pkg/x.go::X"})
+	assert.Equal(t, []string{"pkg", "repo-a"}, order)
+	assert.Equal(t, []string{"pkg/handler/h.go::Handle"}, groups["pkg"])
+	assert.Equal(t, []string{"repo-a/pkg/x.go::X"}, groups["repo-a"])
+}

--- a/internal/mcp/tools_enhancements.go
+++ b/internal/mcp/tools_enhancements.go
@@ -454,7 +454,7 @@ func (s *Server) handleCheckGuards(ctx context.Context, req mcp.CallToolRequest)
 		ids[i] = strings.TrimSpace(ids[i])
 	}
 
-	if len(s.guardRules) == 0 && s.architecture.IsEmpty() {
+	if !s.hasGuardRules(ids) && s.architecture.IsEmpty() {
 		// Honor compact here too. This branch used to return JSON regardless,
 		// so a compact caller (the Stop hook) got a raw payload under a
 		// "Guard Violations" heading that had nothing to report.
@@ -474,7 +474,7 @@ func (s *Server) handleCheckGuards(ctx context.Context, req mcp.CallToolRequest)
 		return s.respondJSONOrTOON(ctx, req, empty)
 	}
 
-	violations := analysis.EvaluateGuards(s.graph, s.guardRules, ids)
+	violations := s.evaluateGuards(ids)
 	violations = append(violations, analysis.EvaluateArchitecture(s.graph, s.architecture, ids)...)
 
 	if isCompact(req) {

--- a/internal/mcp/tools_inspections.go
+++ b/internal/mcp/tools_inspections.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/zzet/gortex/internal/analysis"
+	"github.com/zzet/gortex/internal/config"
 	"github.com/zzet/gortex/internal/graph"
 )
 
@@ -383,13 +384,23 @@ func runStaleCodeInspection(s *Server, scope inspectionScope) []inspectionViolat
 func runGuardsInspection(s *Server, scope inspectionScope) []inspectionViolation {
 	// Evaluate against every node in scope. check_guards' substrate
 	// accepts a slice of IDs; we pass the scoped set.
-	if len(s.guardRules) == 0 {
+	if !s.anyGuardRulesConfigured() {
 		return nil
 	}
+	// Rules are per repo; memoize the lookup so a whole-graph sweep pays
+	// one config resolution per repo rather than one per node.
+	rulesByRepo := make(map[string][]config.GuardRule, 2)
+	resolver := s.newRepoScopeResolver()
 	out := make([]inspectionViolation, 0)
 	for _, n := range s.graph.AllNodes() {
 		if !scope.keep(n.FilePath) {
 			continue
+		}
+		prefix := resolver.prefixOf(n.ID)
+		rules, ok := rulesByRepo[prefix]
+		if !ok {
+			rules = s.guardRulesFor(prefix)
+			rulesByRepo[prefix] = rules
 		}
 		// Cheap proxy: a real implementation would evaluate the rule
 		// expression. We surface the guard rule's name + scope when
@@ -397,7 +408,7 @@ func runGuardsInspection(s *Server, scope inspectionScope) []inspectionViolation
 		// pointer to the relevant rule. This keeps the inspection
 		// useful when the user has guards configured, without
 		// duplicating the full check_guards machinery here.
-		for _, rule := range s.guardRules {
+		for _, rule := range rules {
 			if rule.Name == "" {
 				continue
 			}

--- a/internal/mcp/tools_pr_review_context.go
+++ b/internal/mcp/tools_pr_review_context.go
@@ -268,8 +268,8 @@ func (s *Server) handlePRReviewContext(ctx context.Context, req mcp.CallToolRequ
 	}
 
 	// --- guards gate (architecture + co-change / boundary rules) ---
-	if len(ids) > 0 && (len(s.guardRules) > 0 || !s.architecture.IsEmpty()) {
-		guards := analysis.EvaluateGuards(s.graph, s.guardRules, ids)
+	if len(ids) > 0 && (s.hasGuardRules(ids) || !s.architecture.IsEmpty()) {
+		guards := s.evaluateGuards(ids)
 		guards = append(guards, analysis.EvaluateArchitecture(s.graph, s.architecture, ids)...)
 		out.Guards = guards
 		out.Gates = append(out.Gates, prReviewGuardGate(guards))

--- a/internal/mcp/tools_review.go
+++ b/internal/mcp/tools_review.go
@@ -1090,8 +1090,8 @@ func (s *Server) handleReviewPack(ctx context.Context, req mcp.CallToolRequest) 
 
 	// Gate: guard + architecture rules.
 	var guards []analysis.GuardViolation
-	if len(ids) > 0 && (len(s.guardRules) > 0 || !s.architecture.IsEmpty()) {
-		guards = analysis.EvaluateGuards(s.graph, s.guardRules, ids)
+	if len(ids) > 0 && (s.hasGuardRules(ids) || !s.architecture.IsEmpty()) {
+		guards = s.evaluateGuards(ids)
 		guards = append(guards, analysis.EvaluateArchitecture(s.graph, s.architecture, ids)...)
 	}
 


### PR DESCRIPTION
Fixes #320.

## What was wrong

The report is three separate defects that all present as "editing a repo's `.gortex.yaml` needs a full daemon restart."

**1. `ConfigManager.Reload()` dropped the workspace caches and nothing re-read them.**

The code cleared `workspace` and `workspacePaths` with a comment saying individual files would be re-read "lazily on demand." Nothing does: the only writer of those caches is `LoadWorkspaceConfig`, which runs at track / index time and never on the reload path. `realController.Reload` then matches configured entries against tracked instances by root path and keeps the ones already tracked, so an existing repo never goes through the track path either.

The reporter's `.gitignore` observation pinned the blast radius. `workspacePaths` is what `EffectiveExclude` uses to locate a repo's own `.gitignore`, and it was cleared too — so the gitignore layer died along with the workspace config and the walk fell back to builtin-only admission, absorbing whole ignored trees. Dropping the cache was strictly worse than keeping it stale.

**2. Guards never consulted the per-repo config at all.**

`check_guards` reads `Server.guardRules`, a one-time snapshot of `conf.Guards.Rules` taken at construction, where `conf = config.Load(cfgFile)` in `buildDaemonState` — i.e. the config of the **daemon process's own working directory**. For a multi-repo daemon that governs none of the tracked repos; for a daemon started outside the repo it governs nothing. `ConfigManager.EffectiveGuardRules` already existed, but its only caller was the dashboard.

This is the third comment's sharpest datapoint, exactly: the indexer walk honours `.gortex.yaml` (it resolves config per repo through the ConfigManager) while `check_guards` on the same daemon answers `no guard rules configured`. It also explains the apparent intermittency — the behaviour tracks where the daemon was started, not what changed on disk.

**3. The per-repo `Indexer` froze its exclude list at construction.**

The ignore matcher was built once, behind a `sync.Once`, from `config.Exclude`. `IncrementalReindexRepo` reuses `mi.indexers[prefix]`, so a scoped reindex kept walking with the old list even once the config had been re-read — the `file_count: 309` over excluded directories in repro step 2. Only `IndexRepo` / `TrackRepoCtx`, which build a fresh `Indexer`, ever picked up a change.

## What changed

- **`Reload` re-reads every per-repo file it knows about.** All reads happen before anything is published, so a concurrent indexer walk never observes a config-less window, and results are applied per prefix rather than by swapping the map, so a repo tracked concurrently with the reload isn't erased. A deleted `.gortex.yaml` now drops its cached config instead of applying forever; an unreadable or malformed one keeps the last good parse rather than silently downgrading the repo to global defaults on a half-saved edit.
- **New `MultiIndexer.RefreshRepoConfigs`**, called by the reload RPC before the tracked-repo diff, re-reads each tracked repo's file and pushes the refreshed exclude list into its live `Indexer`. The matcher is now hot-swappable behind an atomic pointer instead of build-once. The RPC reports the count as `refreshed`.
- **Guards resolve through the `ConfigManager`, keyed by repo prefix**, with the process-level snapshot kept as the fallback for servers wired without one (embedded single-repo mode, tests). IDs are grouped by repo before evaluation, so a rule declared in one repo can never fire against another repo's symbols. Attribution needs more than an ID's leading path segment — a solo repo indexes unprefixed IDs where that segment is a source directory, so `pkg/handler/h.go::Handle` would resolve to a repo named `pkg`; the segment is checked against the repos actually tracked in this process, and a single tracked repo absorbs every ID that names no repo of its own. The same resolution backs the change-contract guards family, the review and PR-review context gates, and the guards inspection.

## On the config-less boot reports

I could not find a boot path that skips the per-repo load: both `TrackRepoCtx` and `ReconcileRepoCtx` call `resolveTrackPrefix` → `LoadWorkspaceConfig` before walking, and `warmupDaemonState` additionally loads via `EffectiveRepoPrefix` and `BackfillWorkspaceSlugs`. Defect 1 is the most likely explanation for the observed shape (any reload in the session leaves the daemon config-less until restart, and the builtin-only walk is its exact signature). If a config-less boot reproduces on a daemon that never received a reload, that is worth a separate issue with the boot log — this PR would not fix it.

## Verification

- 15 new tests covering: reload re-reading an edited file, the gitignore anchor surviving reload, deletion dropping the config, a malformed edit keeping the last good parse, an exclude added after tracking evicting nodes on the next incremental pass, per-repo guard resolution, the snapshot fallback, rules not leaking across repos, and unprefixed-ID attribution.
- `go test -race ./...` — 12,034 passed across 178 packages.
- `go vet` and `golangci-lint` clean.