### PR TITLE
Close the gaps between what Rust source contains and what the graph records

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -70,7 +70,7 @@ on interface nodes stores the expected method set for implementation matching.
 | TypeScript | Full | Full | Full | Full + Meta["methods"] | Full | Full | Full |
 | JavaScript | Full | Full | Full | - | Full | Full | Full |
 | Python | Full | Full | Full | - | Full | Full | Partial |
-| Rust | Full | Full (impl blocks) | Full | Full + Meta["methods"] | Full | Full | Full |
+| Rust | Full (+ `extern` blocks) | Full (impl blocks) | Structs/Enums/Unions/Aliases | Full + Meta["methods"] | Full (+ `extern crate`) | Full (+ macro bodies) | Consts/Statics |
 | Java | Full | Full | Full | Full + Meta["methods"] | Full | Full | Fields |
 | C# | Full | Full | Full | Full + Meta["methods"] | Full | Full | Fields |
 | Kotlin | Full | Full | Full | Full | Full | Full | Properties |
@@ -84,6 +84,27 @@ on interface nodes stores the expected method set for implementation matching.
 | Dart | Full | Full | Classes/Enums/Mixins/Extensions | Abstract interface | Full | Full | Full |
 | OCaml | Full | Full (class) | Types/Modules | Module types | open | Full | Full |
 | Lua | Full | Full (M.func/M:method) | - | - | require() | Full | Full |
+
+### Rust specifics
+
+`mod` is a namespace rather than a dependency, so it indexes as a package node
+(the C++/C# namespace precedent) and items inside it carry `Meta["scope_mod"]`
+while keeping flat ids. Two same-named types in one file both survive via the
+shared id-disambiguation helper.
+
+Rust does not parse macro arguments as expressions — every `macro_invocation`
+holds an opaque token tree — so calls written inside one are recovered by a
+token scan and labelled `Meta["via_macro"]`; filter on it to keep only
+grammar-certain call edges. Pattern and cfg-predicate macros (`matches!`,
+`cfg!`) are excluded, since their bodies hold patterns rather than calls. This
+matters most for tests, where the call a `#[test]` exercises normally sits
+inside an `assert*!`.
+
+Entry points are stamped for `fn main` in a Cargo binary target, async-runtime
+mains (`#[tokio::main]` and friends), test/bench harness attributes, and FFI
+exports (`#[no_mangle]`, `#[wasm_bindgen]`, pyo3, napi). Declarations inside an
+`extern` block are stamped `rust:ffi-import` — their body lives in another
+language, so a missing definition is not a missing implementation.
 
 Recent extraction refinements (each covered by a per-feature CI golden): Java `@interface` annotation types index as interfaces and participate in implementation matching; Java `new T(){…}` and C# `new { … }` anonymous classes/types become synthetic type nodes with an `extends` edge (to the instantiated type, or to `object` for C#); JS/TS arrow-valued class fields (`x = () => {…}`) are emitted as callable methods; JS/TS named imports emit one `imports` edge per binding (alias-aware via `Edge.Alias`) and barrel re-exports emit `re_exports` edges; JS/TS cross-file imports resolve onto the target file/symbol for relative specifiers (`./x`, `../x`) and for `tsconfig.json` / `jsconfig.json` `compilerOptions.paths` / `baseUrl` path aliases (`@/lib/x`), so callers / usages / blast-radius span aliased imports the same as relative ones; chained / factory-call receivers (`New().Build()`) carry an inferred `receiver_type`. See [features.md](features.md) and [architecture.md](architecture.md) for the edge semantics.
 

--- a/internal/entrypoints/entrypoints.go
+++ b/internal/entrypoints/entrypoints.go
@@ -37,6 +37,8 @@ func Detect(relPath, lang string, nodes []*graph.Node, edges []*graph.Edge) int 
 		return detectASPNet(slashed, nodes) + detectDotNetFramework(nodes, edges)
 	case "java":
 		return detectJava(nodes, edges)
+	case "rust":
+		return detectRust(slashed, nodes, edges)
 	}
 	return 0
 }

--- a/internal/entrypoints/entrypoints_rust.go
+++ b/internal/entrypoints/entrypoints_rust.go
@@ -1,0 +1,122 @@
+package entrypoints
+
+import (
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+const rustAnnoPrefix = "annotation::rust::"
+
+// rustEntryFnAnnos maps a function attribute to the entry-point kind it
+// implies. Each names a symbol some runtime other than application code
+// calls: an async runtime's generated main, a test harness, a benchmark
+// harness, or a foreign runtime reaching in across an FFI boundary.
+var rustEntryFnAnnos = map[string]string{
+	"tokio::main":       "rust:async-main",
+	"actix_web::main":   "rust:async-main",
+	"actix_rt::main":    "rust:async-main",
+	"async_std::main":   "rust:async-main",
+	"rocket::main":      "rust:async-main",
+	"test":              "rust:test",
+	"tokio::test":       "rust:test",
+	"actix_rt::test":    "rust:test",
+	"async_std::test":   "rust:test",
+	"bench":             "rust:bench",
+	"no_mangle":         "rust:ffi-export",
+	"wasm_bindgen":      "rust:ffi-export",
+	"pyfunction":        "rust:ffi-export",
+	"pymethods":         "rust:ffi-export",
+	"napi":              "rust:ffi-export",
+	"unsafe(no_mangle)": "rust:ffi-export",
+}
+
+// rustEntryTypeAnnos maps a type attribute to its entry-point kind. A
+// clap derive makes the type the process's argument surface, and a pyo3
+// module or class is instantiated by the Python interpreter.
+var rustEntryTypeAnnos = map[string]string{
+	"pyclass":      "rust:ffi-export",
+	"pymodule":     "rust:ffi-export",
+	"wasm_bindgen": "rust:ffi-export",
+	"napi":         "rust:ffi-export",
+}
+
+// detectRust flags the symbols a Rust runtime reaches without any
+// in-crate caller. Without it `fn main`, every #[test], and every
+// #[no_mangle] FFI export look unreachable to a call-graph walk, so a
+// binary crate's entire call tree reads as dead code.
+func detectRust(relPath string, nodes []*graph.Node, edges []*graph.Edge) int {
+	annos := map[string]map[string]bool{}
+	for _, e := range edges {
+		if e.Kind != graph.EdgeAnnotated {
+			continue
+		}
+		name, ok := strings.CutPrefix(e.To, rustAnnoPrefix)
+		if !ok {
+			continue
+		}
+		if annos[e.From] == nil {
+			annos[e.From] = map[string]bool{}
+		}
+		annos[e.From][name] = true
+	}
+
+	count := 0
+	for _, n := range nodes {
+		switch {
+		case isFnOrMethod(n.Kind):
+			kind := ""
+			for a := range annos[n.ID] {
+				if k, ok := rustEntryFnAnnos[a]; ok {
+					kind = k
+					break
+				}
+			}
+			// Cargo runs `fn main` in a binary or example target; the
+			// crate itself never calls it.
+			if kind == "" && n.Name == "main" && rustBinaryTarget(relPath) {
+				kind = "rust:main"
+			}
+			// An extern "C" declaration is the foreign half of an FFI
+			// boundary — its body lives in another language, so a
+			// missing definition is not a missing implementation.
+			if kind == "" && n.Meta != nil && n.Meta["external"] == true &&
+				n.Meta["is_extern"] == true {
+				kind = "rust:ffi-import"
+			}
+			if kind != "" && stamp(n, kind) {
+				count++
+			}
+		case n.Kind == graph.KindType || n.Kind == graph.KindInterface:
+			for a := range annos[n.ID] {
+				if k, ok := rustEntryTypeAnnos[a]; ok {
+					if stamp(n, k) {
+						count++
+					}
+					break
+				}
+			}
+		}
+	}
+	return count
+}
+
+// rustBinaryTarget reports whether a path is one Cargo builds as an
+// executable. Cargo's layout convention is what decides this: src/main.rs
+// and src/bin/*.rs are binaries, and examples/ and benches/ are run
+// directly too. A `fn main` anywhere else is an ordinary function.
+func rustBinaryTarget(relPath string) bool {
+	switch {
+	case relPath == "main.rs" || strings.HasSuffix(relPath, "/main.rs"):
+		return true
+	case strings.Contains(relPath, "src/bin/"):
+		return true
+	case strings.HasPrefix(relPath, "examples/") || strings.Contains(relPath, "/examples/"):
+		return true
+	case strings.HasPrefix(relPath, "benches/") || strings.Contains(relPath, "/benches/"):
+		return true
+	case strings.HasPrefix(relPath, "tests/") || strings.Contains(relPath, "/tests/"):
+		return true
+	}
+	return false
+}

--- a/internal/entrypoints/entrypoints_rust_test.go
+++ b/internal/entrypoints/entrypoints_rust_test.go
@@ -1,0 +1,89 @@
+package entrypoints
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+// detectRustFor runs the real Rust extractor over src and then the
+// detector, so the test exercises the annotation shape the extractor
+// actually emits rather than a hand-built one.
+func detectRustFor(t *testing.T, relPath, src string) map[string]*graph.Node {
+	t.Helper()
+	e := languages.NewRustExtractor()
+	result, err := e.Extract(relPath, []byte(src))
+	require.NoError(t, err)
+	Detect(relPath, "rust", result.Nodes, result.Edges)
+	byID := map[string]*graph.Node{}
+	for _, n := range result.Nodes {
+		byID[n.ID] = n
+	}
+	return byID
+}
+
+// Without a Rust arm, `fn main` was never a live root and a binary
+// crate's entire call tree read as dead code.
+func TestDetectRust_MainInBinaryTarget(t *testing.T) {
+	byID := detectRustFor(t, "src/main.rs", `fn main() { run(); }
+fn run() {}
+`)
+	m := byID["src/main.rs::main"]
+	require.NotNil(t, m)
+	assert.Equal(t, true, m.Meta[MetaEntryPoint])
+	assert.Equal(t, "rust:main", m.Meta[MetaEntryKind])
+
+	assert.NotEqual(t, true, byID["src/main.rs::run"].Meta[MetaEntryPoint],
+		"an ordinary function is not an entry point")
+}
+
+// A `fn main` in a library module is an ordinary function — only
+// Cargo's binary targets are executables.
+func TestDetectRust_MainOutsideBinaryTargetIsNotAnEntryPoint(t *testing.T) {
+	byID := detectRustFor(t, "src/helpers.rs", `fn main() {}`)
+	assert.NotEqual(t, true, byID["src/helpers.rs::main"].Meta[MetaEntryPoint])
+}
+
+func TestDetectRust_AsyncMainAndTests(t *testing.T) {
+	byID := detectRustFor(t, "src/lib.rs", `#[tokio::main]
+async fn main() {}
+
+#[test]
+fn it_works() {}
+
+#[tokio::test]
+async fn async_works() {}
+`)
+	assert.Equal(t, "rust:async-main", byID["src/lib.rs::main"].Meta[MetaEntryKind],
+		"#[tokio::main] marks an entry point even outside a binary target")
+	assert.Equal(t, "rust:test", byID["src/lib.rs::it_works"].Meta[MetaEntryKind])
+	assert.Equal(t, "rust:test", byID["src/lib.rs::async_works"].Meta[MetaEntryKind])
+}
+
+// An FFI export is called from another language entirely, so nothing in
+// the crate refers to it.
+func TestDetectRust_FFIExports(t *testing.T) {
+	byID := detectRustFor(t, "src/lib.rs", `#[no_mangle]
+pub extern "C" fn gx_open() -> i32 { 0 }
+
+#[wasm_bindgen]
+pub fn greet() {}
+`)
+	assert.Equal(t, "rust:ffi-export", byID["src/lib.rs::gx_open"].Meta[MetaEntryKind])
+	assert.Equal(t, "rust:ffi-export", byID["src/lib.rs::greet"].Meta[MetaEntryKind])
+}
+
+// An extern block declares the foreign half of the boundary: its body
+// lives in C, so a missing definition is not a missing implementation.
+func TestDetectRust_ExternBlockDeclarationsAreNotDeadCode(t *testing.T) {
+	byID := detectRustFor(t, "src/ffi.rs", `extern "C" {
+    fn sqlite3_open(name: *const u8) -> i32;
+}
+`)
+	n := byID["src/ffi.rs::sqlite3_open"]
+	require.NotNil(t, n)
+	assert.Equal(t, "rust:ffi-import", n.Meta[MetaEntryKind])
+}

--- a/internal/parser/languages/rust.go
+++ b/internal/parser/languages/rust.go
@@ -579,9 +579,11 @@ func (e *RustExtractor) emitFunction(m parser.QueryResult, filePath, fileID stri
 			return
 		}
 		meta := map[string]any{
-			"receiver":   implType,
-			"signature":  buildRustSignature(def.Node, name, src),
-			"visibility": visibility,
+			"receiver":  implType,
+			"signature": buildRustSignature(def.Node, name, src),
+			// A trait impl's method is callable by anyone who can name
+			// the trait, so an absent `pub` does not make it private.
+			"visibility": rustTraitImplVisibility(def.Node, src),
 		}
 		applyRustFnQualifiers(meta, def.Node, src)
 		applyRustScopeMod(meta, def.Node, src)
@@ -1767,9 +1769,16 @@ func (e *RustExtractor) emitTraitMethodNode(traitName, name string, def *parser.
 	meta := map[string]any{
 		"receiver":   traitName,
 		"trait_decl": "true",
-		"signature":  "fn " + name + "(...)",
-		"visibility": rustVisibility(def.Node, src),
+		"signature":  buildRustSignature(def.Node, name, src),
+		// A trait member carries no visibility modifier of its own — it
+		// is exactly as reachable as the trait that declares it. Reading
+		// the absent modifier as "private" made every method of every
+		// public trait look private, which understates the public API
+		// surface and invites the dead-code pass to over-reach.
+		"visibility": rustEnclosingTraitVisibility(def.Node, src),
 	}
+	applyRustFnQualifiers(meta, def.Node, src)
+	applyRustScopeMod(meta, def.Node, src)
 	if doc := ExtractDocAbove(src, def.StartLine, DocLangSlashSlash); doc != "" {
 		meta["doc"] = doc
 	}

--- a/internal/parser/languages/rust.go
+++ b/internal/parser/languages/rust.go
@@ -67,6 +67,8 @@ const qRustAll = `
 
   (ordered_field_declaration_list) @tuplefields.def
 
+  (impl_item) @impl.def
+
   (macro_invocation) @minvoke.expr
 
   (let_declaration
@@ -253,6 +255,9 @@ func (e *RustExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 
 		case m.Captures["xcrate.def"] != nil:
 			emitRustExternCrate(m.Captures["xcrate.def"].Node, filePath, fileID, src, result)
+
+		case m.Captures["impl.def"] != nil:
+			emitRustImplBlock(m.Captures["impl.def"].Node, filePath, src, result, annotationSeen)
 
 		case m.Captures["tuplefields.def"] != nil:
 			emitRustTupleFields(m.Captures["tuplefields.def"].Node, filePath, src, result, seen, containers)
@@ -1171,11 +1176,26 @@ func emitRustAnnotationEdges(attrs []*sitter.Node, fromID, filePath string, src 
 		}
 		line := int(attr.StartPoint().Row) + 1
 		if name == "derive" && args != "" {
-			for _, t := range strings.Split(args, ",") {
+			for _, t := range rustSplitTopLevel(args, ',') {
 				traitName := strings.TrimSpace(t)
-				if traitName != "" {
-					EmitAnnotationEdge(fromID, "rust", traitName, "", filePath, line, result, seen)
+				if traitName == "" {
+					continue
 				}
+				EmitAnnotationEdge(fromID, "rust", traitName, "", filePath, line, result, seen)
+				// A derive really does implement the trait — it is how
+				// most Rust types acquire Debug, Clone, Serialize. The
+				// annotation edge alone left find_implementations and
+				// get_class_hierarchy blind to all of them.
+				base := rustTraitPathBaseName(traitName)
+				if base == "" {
+					continue
+				}
+				result.Edges = append(result.Edges, &graph.Edge{
+					From: fromID, To: "unresolved::" + base,
+					Kind: graph.EdgeImplements, FilePath: filePath, Line: line,
+					Origin: graph.OriginASTInferred,
+					Meta:   map[string]any{"via": "derive"},
+				})
 			}
 			continue
 		}

--- a/internal/parser/languages/rust.go
+++ b/internal/parser/languages/rust.go
@@ -65,6 +65,8 @@ const qRustAll = `
 
   (associated_type) @assoc.def
 
+  (ordered_field_declaration_list) @tuplefields.def
+
   (macro_invocation) @minvoke.expr
 
   (let_declaration
@@ -251,6 +253,9 @@ func (e *RustExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 
 		case m.Captures["xcrate.def"] != nil:
 			emitRustExternCrate(m.Captures["xcrate.def"].Node, filePath, fileID, src, result)
+
+		case m.Captures["tuplefields.def"] != nil:
+			emitRustTupleFields(m.Captures["tuplefields.def"].Node, filePath, src, result, seen, containers)
 
 		case m.Captures["assoc.def"] != nil:
 			emitRustAssociatedType(m.Captures["assoc.def"].Node, filePath, src, result, seen)
@@ -1447,12 +1452,16 @@ func (e *RustExtractor) emitField(m parser.QueryResult, filePath string, src []b
 	// A named field can sit in a struct, a union, or a struct-shaped
 	// enum variant. Only the struct case used to be handled, so union
 	// fields and variant payloads were dropped outright.
-	ownerNode, ownerName := rustFieldOwner(def.Node, src)
+	ownerNode, ownerName, variant := rustFieldOwner(def.Node, src)
 	if ownerNode == nil || ownerName == "" {
 		return
 	}
 	fieldName := m.Captures["field.name"].Text
 	structID := containers.lookup(ownerNode, filePath+"::"+ownerName)
+	if variant != "" {
+		structID += "." + variant
+		ownerName += "." + variant
+	}
 	fieldID := structID + "." + fieldName
 	meta := map[string]any{
 		"receiver":   ownerName,

--- a/internal/parser/languages/rust.go
+++ b/internal/parser/languages/rust.go
@@ -49,6 +49,24 @@ const qRustAll = `
   (use_declaration
     argument: (_) @use.path) @use.def
 
+  (mod_item
+    name: (identifier) @mod.name) @mod.def
+
+  (type_item
+    name: (type_identifier) @alias.name) @alias.def
+
+  (union_item
+    name: (type_identifier) @union.name) @union.def
+
+  (macro_definition
+    name: (identifier) @macro.name) @macro.def
+
+  (extern_crate_declaration) @xcrate.def
+
+  (associated_type) @assoc.def
+
+  (macro_invocation) @minvoke.expr
+
   (let_declaration
     pattern: (identifier) @lvar.name
     type: (_)? @lvar.type
@@ -65,6 +83,25 @@ const qRustAll = `
     function: (field_expression
       value: (_) @callm.receiver
       field: (field_identifier) @callm.method)) @callm.expr
+
+  ; Turbofish call sites. A trailing ::<T> wraps the callee in a
+  ; generic_function node, so the three patterns above never match
+  ; xs.collect::<Vec<_>>() or parse::<u32>(s) — 5,301 such sites went
+  ; unrecorded across a 4,000-file sample of crate source.
+  (call_expression
+    function: (generic_function
+      function: (identifier) @callg.name)) @callg.expr
+
+  (call_expression
+    function: (generic_function
+      function: (scoped_identifier
+        name: (identifier) @callgp.name))) @callgp.expr
+
+  (call_expression
+    function: (generic_function
+      function: (field_expression
+        value: (_) @callgm.receiver
+        field: (field_identifier) @callgm.method))) @callgm.expr
 ]
 `
 
@@ -97,6 +134,14 @@ type rustDeferredCall struct {
 	// (graph.ReturnUsage* label), classified at capture time and
 	// stamped as edge Meta on the EdgeCalls emitted for this site.
 	returnUsage string
+	// viaMacro names the macro whose body the site was recovered from
+	// ("" for an ordinary call_expression). Recovered sites are token
+	// matches rather than parsed expressions, so consumers that want
+	// only grammar-certain edges can filter on it.
+	viaMacro string
+	// isMacro marks the site as a macro invocation rather than a
+	// function call, so it can bind to a `macro_rules!` node.
+	isMacro bool
 }
 
 // rustDeferredLet buffers a let_declaration for the post-pass type-env
@@ -141,6 +186,7 @@ func (e *RustExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 	seen := make(map[string]bool)
 	annotationSeen := make(map[string]bool)
 	traitMethods := make(map[string][]string) // trait name → declared method names
+	containers := make(rustContainerIDs)      // container start row → minted node id
 
 	var calls []rustDeferredCall
 	var lets []rustDeferredLet
@@ -164,19 +210,19 @@ func (e *RustExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 			funcDefs = append(funcDefs, rustFuncDef{node: sd.Node, owner: rustTraitMethodOwner(sd.Node, src), line: sd.StartLine + 1})
 
 		case m.Captures["struct.def"] != nil:
-			e.emitStruct(m, filePath, fileID, src, result, seen, annotationSeen)
+			e.emitStruct(m, filePath, fileID, src, result, seen, annotationSeen, containers)
 
 		case m.Captures["enum.def"] != nil:
-			e.emitEnum(m, filePath, fileID, src, result, seen, annotationSeen)
+			e.emitEnum(m, filePath, fileID, src, result, seen, annotationSeen, containers)
 
 		case m.Captures["trait.def"] != nil:
-			e.emitTrait(m, filePath, fileID, src, result, seen, annotationSeen, traitMethods)
+			e.emitTrait(m, filePath, fileID, src, result, seen, annotationSeen, traitMethods, containers)
 
 		case m.Captures["variant.def"] != nil:
-			e.emitVariant(m, filePath, src, result)
+			e.emitVariant(m, filePath, src, result, containers)
 
 		case m.Captures["field.def"] != nil:
-			e.emitField(m, filePath, src, result)
+			e.emitField(m, filePath, src, result, containers)
 
 		case m.Captures["const.def"] != nil:
 			e.emitNamed(m, "const", filePath, fileID, result, seen)
@@ -186,6 +232,56 @@ func (e *RustExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 
 		case m.Captures["use.def"] != nil:
 			e.emitUse(m, filePath, fileID, src, result)
+
+		case m.Captures["mod.def"] != nil:
+			emitRustModule(m.Captures["mod.def"].Node, m.Captures["mod.name"].Text,
+				filePath, fileID, src, result, seen, annotationSeen)
+
+		case m.Captures["alias.def"] != nil:
+			emitRustTypeAlias(m.Captures["alias.def"].Node, m.Captures["alias.name"].Text,
+				filePath, fileID, src, result, seen, annotationSeen)
+
+		case m.Captures["union.def"] != nil:
+			emitRustUnion(m.Captures["union.def"].Node, m.Captures["union.name"].Text,
+				filePath, fileID, src, result, seen, annotationSeen, containers)
+
+		case m.Captures["macro.def"] != nil:
+			emitRustMacroDef(m.Captures["macro.def"].Node, m.Captures["macro.name"].Text,
+				filePath, fileID, src, result, seen, annotationSeen)
+
+		case m.Captures["xcrate.def"] != nil:
+			emitRustExternCrate(m.Captures["xcrate.def"].Node, filePath, fileID, src, result)
+
+		case m.Captures["assoc.def"] != nil:
+			emitRustAssociatedType(m.Captures["assoc.def"].Node, filePath, src, result, seen)
+
+		case m.Captures["minvoke.expr"] != nil:
+			inv := m.Captures["minvoke.expr"]
+			// The invocation itself is a use of the macro, so a
+			// `macro_rules!` definition gets incoming edges.
+			if mn := inv.Node.ChildByFieldName("macro"); mn != nil {
+				full := mn.Content(src)
+				c := rustDeferredCall{
+					name:    rustLastPathSegment(full),
+					line:    inv.StartLine + 1,
+					isMacro: true,
+				}
+				if strings.Contains(full, "::") {
+					c.path = full
+				}
+				calls = append(calls, c)
+			}
+			for _, mc := range scanRustMacroCalls(inv.Node, src) {
+				calls = append(calls, rustDeferredCall{
+					name:       mc.name,
+					receiver:   mc.receiver,
+					path:       mc.path,
+					line:       mc.line,
+					isSelector: mc.isSelector,
+					viaMacro:   mc.macroName,
+					isMacro:    mc.isMacro,
+				})
+			}
 
 		case m.Captures["lvar.def"] != nil:
 			d := rustDeferredLet{
@@ -241,6 +337,38 @@ func (e *RustExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 			expr := m.Captures["call.expr"]
 			calls = append(calls, rustDeferredCall{
 				name:        m.Captures["call.name"].Text,
+				line:        expr.StartLine + 1,
+				returnUsage: classifyReturnUsage(expr.Node, src, rustReturnUsageSpec),
+			})
+
+		case m.Captures["callgm.expr"] != nil:
+			expr := m.Captures["callgm.expr"]
+			calls = append(calls, rustDeferredCall{
+				name:        m.Captures["callgm.method"].Text,
+				receiver:    m.Captures["callgm.receiver"].Text,
+				line:        expr.StartLine + 1,
+				isSelector:  true,
+				returnUsage: classifyReturnUsage(expr.Node, src, rustReturnUsageSpec),
+			})
+
+		case m.Captures["callgp.expr"] != nil:
+			expr := m.Captures["callgp.expr"]
+			c := rustDeferredCall{
+				name:        m.Captures["callgp.name"].Text,
+				line:        expr.StartLine + 1,
+				returnUsage: classifyReturnUsage(expr.Node, src, rustReturnUsageSpec),
+			}
+			if fn := expr.Node.ChildByFieldName("function"); fn != nil {
+				if inner := fn.ChildByFieldName("function"); inner != nil {
+					c.path = inner.Content(src)
+				}
+			}
+			calls = append(calls, c)
+
+		case m.Captures["callg.expr"] != nil:
+			expr := m.Captures["callg.expr"]
+			calls = append(calls, rustDeferredCall{
+				name:        m.Captures["callg.name"].Text,
 				line:        expr.StartLine + 1,
 				returnUsage: classifyReturnUsage(expr.Node, src, rustReturnUsageSpec),
 			})
@@ -363,6 +491,7 @@ func (e *RustExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 				edge.Meta["rust_recv_expr"] = c.receiver
 			}
 			stampReturnUsage(edge, c.returnUsage)
+			stampRustMacroOrigin(edge, c)
 			result.Edges = append(result.Edges, edge)
 			continue
 		}
@@ -377,6 +506,7 @@ func (e *RustExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 			edge.Meta = map[string]any{"rust_path": c.path}
 		}
 		stampReturnUsage(edge, c.returnUsage)
+		stampRustMacroOrigin(edge, c)
 		result.Edges = append(result.Edges, edge)
 	}
 
@@ -440,9 +570,11 @@ func (e *RustExtractor) emitFunction(m parser.QueryResult, filePath, fileID stri
 		}
 		meta := map[string]any{
 			"receiver":   implType,
-			"signature":  "fn " + name + "(...)",
+			"signature":  buildRustSignature(def.Node, name, src),
 			"visibility": visibility,
 		}
+		applyRustFnQualifiers(meta, def.Node, src)
+		applyRustScopeMod(meta, def.Node, src)
 		if doc != "" {
 			meta["doc"] = doc
 		}
@@ -499,11 +631,19 @@ func (e *RustExtractor) emitFunction(m parser.QueryResult, filePath, fileID stri
 		return
 	}
 	meta := map[string]any{
-		"signature":  "fn " + name + "(...)",
+		"signature":  buildRustSignature(def.Node, name, src),
 		"visibility": visibility,
 	}
+	applyRustFnQualifiers(meta, def.Node, src)
+	applyRustScopeMod(meta, def.Node, src)
 	if doc != "" {
 		meta["doc"] = doc
+	}
+	// Parity with the impl-method and trait-method paths, which have
+	// always stamped return_type — a free function is just as worth
+	// filtering by what it returns.
+	if rt := extractRustReturnType(def.Node, src); rt != "" {
+		meta["return_type"] = rt
 	}
 	if len(typeParams) > 0 {
 		meta["type_params"] = typeParams
@@ -926,13 +1066,14 @@ func rustRawReturnType(node *sitter.Node, src []byte) string {
 // extracted unambiguously.
 func rustErrorTypeFromResult(rt string) string {
 	rt = strings.TrimSpace(rt)
-	// Strip leading qualifier like `std::result::` to land on `Result`.
-	if i := strings.LastIndex(rt, "::"); i >= 0 {
-		head := rt[:i]
-		// Only strip qualifier when what follows starts with Result.
-		if strings.HasPrefix(rt[i+2:], "Result<") {
-			_ = head
-			rt = rt[i+2:]
+	// Strip a leading qualifier like `std::result::` to land on
+	// `Result`. Anchor on the "Result<" token rather than the last
+	// "::" in the string: for `std::result::Result<T, io::Error>` the
+	// last "::" sits inside the *error* type, so the old scan looked at
+	// "Error>", concluded there was no Result, and dropped the edge.
+	if i := strings.Index(rt, "Result<"); i > 0 {
+		if strings.HasSuffix(rt[:i], "::") {
+			rt = rt[i:]
 		}
 	}
 	if !strings.HasPrefix(rt, "Result<") {
@@ -940,25 +1081,11 @@ func rustErrorTypeFromResult(rt string) string {
 	}
 	inner := strings.TrimPrefix(rt, "Result<")
 	inner = strings.TrimSuffix(inner, ">")
-	// Split on the top-level comma — depth tracking for nested
-	// generics like Result<Vec<T>, MyError>.
-	depth := 0
-	parts := []string{}
-	start := 0
-	for i, r := range inner {
-		switch r {
-		case '<':
-			depth++
-		case '>':
-			depth--
-		case ',':
-			if depth == 0 {
-				parts = append(parts, inner[start:i])
-				start = i + 1
-			}
-		}
-	}
-	parts = append(parts, inner[start:])
+	// Split on the top-level comma. Depth tracking has to cover tuples
+	// and slices as well as generics: counting only <> made
+	// `Result<(u8, u16), MyError>` split inside the tuple and stamp a
+	// throws edge to the literal target "u16)".
+	parts := rustSplitTopLevel(inner, ',')
 	if len(parts) < 2 {
 		return ""
 	}
@@ -1001,6 +1128,13 @@ func rustCollectAttributes(item *sitter.Node) []*sitter.Node {
 	}
 	var out []*sitter.Node
 	for sib := item.PrevSibling(); sib != nil; sib = sib.PrevSibling() {
+		// A doc or explanatory comment interleaved with the attribute
+		// stack is ordinary Rust style. Breaking on it discarded every
+		// attribute above the comment — so a `#[derive(Serialize)]`
+		// separated from its struct by one `// note` line vanished.
+		if t := sib.Type(); t == "line_comment" || t == "block_comment" {
+			continue
+		}
 		if sib.Type() != "attribute_item" {
 			break
 		}
@@ -1107,6 +1241,11 @@ func (e *RustExtractor) recordTraitMethod(m parser.QueryResult, filePath, fileID
 	def := m.Captures["sig.def"]
 	traitNode := findEnclosingRustContainer(def.Node, "trait_item")
 	if traitNode == nil {
+		// Not a trait signature. The other producer of bodyless
+		// functions is an `extern "C" { .. }` block, whose declarations
+		// are the whole FFI surface of a -sys crate — 38,973 such
+		// blocks across the sample corpus produced no node at all.
+		e.emitForeignFunction(m, filePath, fileID, src, result, seen, annotationSeen)
 		return
 	}
 	traitName := rustDeclName(traitNode, src)
@@ -1121,15 +1260,67 @@ func (e *RustExtractor) recordTraitMethod(m parser.QueryResult, filePath, fileID
 	e.emitTraitMethodNode(traitName, name, def, filePath, fileID, src, result, seen, annotationSeen)
 }
 
-func (e *RustExtractor) emitStruct(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen, annotationSeen map[string]bool) {
-	name := m.Captures["struct.name"].Text
-	def := m.Captures["struct.def"]
-	id := filePath + "::" + name
-	if seen[id] {
+// emitForeignFunction emits a node for a bodyless `fn` inside an
+// `extern "C" { .. }` block. These declare the foreign side of an FFI
+// boundary: they are the call targets of every unsafe call into C, and
+// an audit that asks "what does this crate link against" has nothing to
+// answer with unless they exist as nodes.
+func (e *RustExtractor) emitForeignFunction(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen, annotationSeen map[string]bool) {
+	def := m.Captures["sig.def"]
+	nameCap := m.Captures["sig.name"]
+	if def == nil || nameCap == nil {
 		return
 	}
-	seen[id] = true
+	abi, inForeign := rustForeignABI(def.Node, src)
+	if !inForeign {
+		return
+	}
+	name := nameCap.Text
+	startLine1 := def.StartLine + 1
+	id, ok := disambiguateID(seen, filePath+"::"+name, startLine1)
+	if !ok {
+		return
+	}
+	meta := map[string]any{
+		"signature":  buildRustSignature(def.Node, name, src),
+		"visibility": rustVisibility(def.Node, src),
+		"is_extern":  true,
+		"is_unsafe":  true,
+		"abi":        abi,
+		// The body lives in another language entirely, so mark the node
+		// as a declaration — a dead-code pass must not treat a missing
+		// body as a missing implementation.
+		"external": true,
+	}
+	applyRustScopeMod(meta, def.Node, src)
+	if doc := ExtractDocAbove(src, def.StartLine, DocLangSlashSlash); doc != "" {
+		meta["doc"] = doc
+	}
+	if rt := extractRustReturnType(def.Node, src); rt != "" {
+		meta["return_type"] = rt
+	}
+	result.Nodes = append(result.Nodes, &graph.Node{
+		ID: id, Kind: graph.KindFunction, Name: name,
+		FilePath: filePath, StartLine: startLine1, EndLine: def.EndLine + 1,
+		Language: "rust", Meta: meta,
+	})
+	result.Edges = append(result.Edges, &graph.Edge{
+		From: fileID, To: id, Kind: graph.EdgeDefines, FilePath: filePath, Line: startLine1,
+	})
+	emitRustAnnotationEdges(rustCollectAttributes(def.Node), id, filePath, src, result, annotationSeen)
+	emitRustFunctionShape(id, def.Node, src, filePath, startLine1, result)
+}
+
+func (e *RustExtractor) emitStruct(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen, annotationSeen map[string]bool, containers rustContainerIDs) {
+	name := m.Captures["struct.name"].Text
+	def := m.Captures["struct.def"]
+	id, ok := disambiguateID(seen, filePath+"::"+name, def.StartLine+1)
+	if !ok {
+		return
+	}
+	containers.register(def.Node, id)
 	meta := map[string]any{"visibility": rustVisibility(def.Node, src)}
+	applyRustScopeMod(meta, def.Node, src)
 	if doc := ExtractDocAbove(src, def.StartLine, DocLangSlashSlash); doc != "" {
 		meta["doc"] = doc
 	}
@@ -1147,19 +1338,20 @@ func (e *RustExtractor) emitStruct(m parser.QueryResult, filePath, fileID string
 	emitRustGenericParamNodes(id, def.Node, src, filePath, def.StartLine+1, result)
 }
 
-func (e *RustExtractor) emitEnum(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen, annotationSeen map[string]bool) {
+func (e *RustExtractor) emitEnum(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen, annotationSeen map[string]bool, containers rustContainerIDs) {
 	name := m.Captures["enum.name"].Text
 	def := m.Captures["enum.def"]
-	id := filePath + "::" + name
-	if seen[id] {
+	id, ok := disambiguateID(seen, filePath+"::"+name, def.StartLine+1)
+	if !ok {
 		return
 	}
-	seen[id] = true
+	containers.register(def.Node, id)
 	meta := map[string]any{
 		"kind":        "enum",
 		"type_flavor": "enum",
 		"visibility":  rustVisibility(def.Node, src),
 	}
+	applyRustScopeMod(meta, def.Node, src)
 	if doc := ExtractDocAbove(src, def.StartLine, DocLangSlashSlash); doc != "" {
 		meta["doc"] = doc
 	}
@@ -1176,15 +1368,16 @@ func (e *RustExtractor) emitEnum(m parser.QueryResult, filePath, fileID string, 
 	emitRustGenericParamNodes(id, def.Node, src, filePath, def.StartLine+1, result)
 }
 
-func (e *RustExtractor) emitTrait(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen, annotationSeen map[string]bool, traitMethods map[string][]string) {
+func (e *RustExtractor) emitTrait(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen, annotationSeen map[string]bool, traitMethods map[string][]string, containers rustContainerIDs) {
 	name := m.Captures["trait.name"].Text
 	def := m.Captures["trait.def"]
-	id := filePath + "::" + name
-	if seen[id] {
+	id, ok := disambiguateID(seen, filePath+"::"+name, def.StartLine+1)
+	if !ok {
 		return
 	}
-	seen[id] = true
+	containers.register(def.Node, id)
 	meta := map[string]any{"visibility": rustVisibility(def.Node, src)}
+	applyRustScopeMod(meta, def.Node, src)
 	if methods, ok := traitMethods[name]; ok {
 		meta["methods"] = methods
 	}
@@ -1222,7 +1415,7 @@ func (e *RustExtractor) emitTrait(m parser.QueryResult, filePath, fileID string,
 	emitRustGenericParamNodes(id, def.Node, src, filePath, def.StartLine+1, result)
 }
 
-func (e *RustExtractor) emitVariant(m parser.QueryResult, filePath string, src []byte, result *parser.ExtractionResult) {
+func (e *RustExtractor) emitVariant(m parser.QueryResult, filePath string, src []byte, result *parser.ExtractionResult, containers rustContainerIDs) {
 	def := m.Captures["variant.def"]
 	enumNode := findEnclosingRustContainer(def.Node, "enum_item")
 	if enumNode == nil {
@@ -1233,7 +1426,7 @@ func (e *RustExtractor) emitVariant(m parser.QueryResult, filePath string, src [
 		return
 	}
 	variantName := m.Captures["variant.name"].Text
-	enumID := filePath + "::" + enumName
+	enumID := containers.lookup(enumNode, filePath+"::"+enumName)
 	variantID := enumID + "." + variantName
 	result.Nodes = append(result.Nodes, &graph.Node{
 		ID: variantID, Kind: graph.KindVariable, Name: variantName,
@@ -1249,23 +1442,20 @@ func (e *RustExtractor) emitVariant(m parser.QueryResult, filePath string, src [
 	})
 }
 
-func (e *RustExtractor) emitField(m parser.QueryResult, filePath string, src []byte, result *parser.ExtractionResult) {
+func (e *RustExtractor) emitField(m parser.QueryResult, filePath string, src []byte, result *parser.ExtractionResult, containers rustContainerIDs) {
 	def := m.Captures["field.def"]
-	// Legacy only emitted struct fields. tree-sitter-rust also produces
-	// field_declaration nodes inside union_item; skip those.
-	structNode := findEnclosingRustContainer(def.Node, "struct_item")
-	if structNode == nil {
-		return
-	}
-	structName := rustDeclName(structNode, src)
-	if structName == "" {
+	// A named field can sit in a struct, a union, or a struct-shaped
+	// enum variant. Only the struct case used to be handled, so union
+	// fields and variant payloads were dropped outright.
+	ownerNode, ownerName := rustFieldOwner(def.Node, src)
+	if ownerNode == nil || ownerName == "" {
 		return
 	}
 	fieldName := m.Captures["field.name"].Text
-	structID := filePath + "::" + structName
+	structID := containers.lookup(ownerNode, filePath+"::"+ownerName)
 	fieldID := structID + "." + fieldName
 	meta := map[string]any{
-		"receiver":   structName,
+		"receiver":   ownerName,
 		"visibility": rustVisibility(def.Node, src),
 	}
 	if t := def.Node.ChildByFieldName("type"); t != nil {

--- a/internal/parser/languages/rust.go
+++ b/internal/parser/languages/rust.go
@@ -1612,7 +1612,55 @@ func rustImplMethodReceiver(fn *sitter.Node, src []byte) string {
 	if typeNode == nil {
 		return ""
 	}
-	return typeNode.Content(src)
+	return rustImplReceiverName(typeNode.Content(src))
+}
+
+// rustImplReceiverName reduces an impl target to the name a method node
+// can hang off. `impl Trait for &'a Buf` used to mint the method id
+// `<file>::&'a Buf.show` with a member_of edge to a node that never
+// exists; the same went for slice, array and raw-pointer impls.
+//
+// The generic spelling is deliberately preserved — `Replacer<M>.replace`
+// is the established id shape, and rebindRustLocalGenericMemberOwners
+// repairs the member_of target for it separately.
+func rustImplReceiverName(t string) string {
+	t = strings.TrimSpace(t)
+	for {
+		trimmed := t
+		// Reference: &T, &mut T, &'a T.
+		if strings.HasPrefix(trimmed, "&") {
+			trimmed = strings.TrimSpace(trimmed[1:])
+			if strings.HasPrefix(trimmed, "'") {
+				if i := strings.IndexAny(trimmed, " \t"); i > 0 {
+					trimmed = strings.TrimSpace(trimmed[i:])
+				}
+			}
+			trimmed = strings.TrimSpace(strings.TrimPrefix(trimmed, "mut "))
+		}
+		// Raw pointer: *const T, *mut T.
+		if strings.HasPrefix(trimmed, "*") {
+			trimmed = strings.TrimSpace(trimmed[1:])
+			trimmed = strings.TrimPrefix(trimmed, "const ")
+			trimmed = strings.TrimPrefix(trimmed, "mut ")
+			trimmed = strings.TrimSpace(trimmed)
+		}
+		// Slice or array: [T] and [T; N].
+		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+			inner := strings.TrimSpace(trimmed[1 : len(trimmed)-1])
+			if parts := rustSplitTopLevel(inner, ';'); len(parts) > 0 {
+				inner = parts[0]
+			}
+			trimmed = strings.TrimSpace(inner)
+		}
+		if strings.HasPrefix(trimmed, "dyn ") {
+			trimmed = strings.TrimSpace(trimmed[4:])
+		}
+		if trimmed == t {
+			break
+		}
+		t = trimmed
+	}
+	return t
 }
 
 // rustTraitMethodOwner returns the trait name when fn is a direct member

--- a/internal/parser/languages/rust.go
+++ b/internal/parser/languages/rust.go
@@ -225,10 +225,10 @@ func (e *RustExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 			e.emitField(m, filePath, src, result, containers)
 
 		case m.Captures["const.def"] != nil:
-			e.emitNamed(m, "const", filePath, fileID, result, seen)
+			e.emitNamed(m, "const", filePath, fileID, src, result, seen, annotationSeen, containers)
 
 		case m.Captures["static.def"] != nil:
-			e.emitNamed(m, "static", filePath, fileID, result, seen)
+			e.emitNamed(m, "static", filePath, fileID, src, result, seen, annotationSeen, containers)
 
 		case m.Captures["use.def"] != nil:
 			e.emitUse(m, filePath, fileID, src, result)
@@ -1481,26 +1481,69 @@ func (e *RustExtractor) emitField(m parser.QueryResult, filePath string, src []b
 // emitNamed handles const_item / static_item — they share the same
 // node shape so we collapse them into one helper that takes the
 // capture-name prefix.
-func (e *RustExtractor) emitNamed(m parser.QueryResult, kind, filePath, fileID string, result *parser.ExtractionResult, seen map[string]bool) {
+func (e *RustExtractor) emitNamed(m parser.QueryResult, kind, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen, annotationSeen map[string]bool, containers rustContainerIDs) {
 	nameCap := m.Captures[kind+".name"]
 	def := m.Captures[kind+".def"]
 	if nameCap == nil || def == nil {
 		return
 	}
 	name := nameCap.Text
-	id := filePath + "::" + name
-	if seen[id] {
+	startLine1 := def.StartLine + 1
+
+	meta := map[string]any{
+		"decl":       kind,
+		"visibility": rustVisibility(def.Node, src),
+	}
+	applyRustScopeMod(meta, def.Node, src)
+	if t := def.Node.ChildByFieldName("type"); t != nil {
+		meta["declared_type"] = strings.TrimSpace(t.Content(src))
+	}
+	if doc := ExtractDocAbove(src, def.StartLine, DocLangSlashSlash); doc != "" {
+		meta["doc"] = doc
+	}
+
+	// An associated const belongs to its impl or trait. Emitting it at
+	// file scope meant `impl A { const MAX }` and `impl B { const MAX }`
+	// fought over one id and the loser was dropped entirely.
+	base := filePath + "::" + name
+	ownerNode, ownerName := rustAssociatedItemOwner(def.Node, src)
+	if ownerName != "" {
+		base = containers.lookup(ownerNode, filePath+"::"+ownerName) + "." + name
+		meta["receiver"] = ownerName
+	}
+	id, ok := disambiguateID(seen, base, startLine1)
+	if !ok {
 		return
 	}
-	seen[id] = true
+
+	// `static mut` is the one form that is actually mutable shared
+	// state, which is worth being able to query for on its own.
+	nodeKind := graph.KindConstant
+	if kind == "static" {
+		nodeKind = graph.KindVariable
+		for i, _nc := 0, int(def.Node.ChildCount()); i < _nc; i++ {
+			if c := def.Node.Child(i); c != nil && c.Content(src) == "mut" {
+				meta["mutable"] = true
+				break
+			}
+		}
+	}
+
 	result.Nodes = append(result.Nodes, &graph.Node{
-		ID: id, Kind: graph.KindVariable, Name: name,
-		FilePath: filePath, StartLine: def.StartLine + 1, EndLine: def.EndLine + 1,
-		Language: "rust",
+		ID: id, Kind: nodeKind, Name: name,
+		FilePath: filePath, StartLine: startLine1, EndLine: def.EndLine + 1,
+		Language: "rust", Meta: meta,
 	})
 	result.Edges = append(result.Edges, &graph.Edge{
-		From: fileID, To: id, Kind: graph.EdgeDefines, FilePath: filePath, Line: def.StartLine + 1,
+		From: fileID, To: id, Kind: graph.EdgeDefines, FilePath: filePath, Line: startLine1,
 	})
+	if ownerName != "" {
+		result.Edges = append(result.Edges, &graph.Edge{
+			From: id, To: containers.lookup(ownerNode, filePath+"::"+ownerName),
+			Kind: graph.EdgeMemberOf, FilePath: filePath, Line: startLine1,
+		})
+	}
+	emitRustAnnotationEdges(rustCollectAttributes(def.Node), id, filePath, src, result, annotationSeen)
 }
 
 func (e *RustExtractor) emitUse(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult) {

--- a/internal/parser/languages/rust_function_shape.go
+++ b/internal/parser/languages/rust_function_shape.go
@@ -200,7 +200,7 @@ func emitRustParamNodes(ownerID string, params *sitter.Node, src []byte, filePat
 			Line:     startLine,
 			Origin:   graph.OriginASTResolved,
 		})
-		if canon := canonicalizeRustTypeRef(typeRaw); canon != "" && !isRustPrimitive(canon) {
+		for _, canon := range rustCanonicalTypeRefs(typeRaw) {
 			result.Edges = append(result.Edges, &graph.Edge{
 				From:     paramID,
 				To:       "unresolved::" + canon,
@@ -246,21 +246,21 @@ func emitRustReturnEdges(ownerID, returnText, filePath string, line int, result 
 	if returnText == "" {
 		return
 	}
-	t := canonicalizeRustTypeRef(returnText)
-	if t == "" || isRustPrimitive(t) {
-		return
+	// A tuple return names one type per slot, so each gets its own edge
+	// at its own position.
+	for i, t := range rustCanonicalTypeRefs(returnText) {
+		result.Edges = append(result.Edges, &graph.Edge{
+			From:     ownerID,
+			To:       "unresolved::" + t,
+			Kind:     graph.EdgeReturns,
+			FilePath: filePath,
+			Line:     line,
+			Origin:   graph.OriginASTInferred,
+			Meta: map[string]any{
+				"position": i,
+			},
+		})
 	}
-	result.Edges = append(result.Edges, &graph.Edge{
-		From:     ownerID,
-		To:       "unresolved::" + t,
-		Kind:     graph.EdgeReturns,
-		FilePath: filePath,
-		Line:     line,
-		Origin:   graph.OriginASTInferred,
-		Meta: map[string]any{
-			"position": 0,
-		},
-	})
 }
 
 // emitRustTypeUseEdges emits an EdgeTypedAs from ownerID to the named
@@ -276,18 +276,16 @@ func emitRustTypeUseEdges(ownerID, typeText, filePath string, line int, result *
 	if ownerID == "" || typeText == "" {
 		return
 	}
-	canon := canonicalizeRustTypeRef(typeText)
-	if canon == "" || isRustPrimitive(canon) {
-		return
+	for _, canon := range rustCanonicalTypeRefs(typeText) {
+		result.Edges = append(result.Edges, &graph.Edge{
+			From:     ownerID,
+			To:       "unresolved::" + canon,
+			Kind:     graph.EdgeTypedAs,
+			FilePath: filePath,
+			Line:     line,
+			Origin:   graph.OriginASTInferred,
+		})
 	}
-	result.Edges = append(result.Edges, &graph.Edge{
-		From:     ownerID,
-		To:       "unresolved::" + canon,
-		Kind:     graph.EdgeTypedAs,
-		FilePath: filePath,
-		Line:     line,
-		Origin:   graph.OriginASTInferred,
-	})
 }
 
 func emitRustGenericParamNodes(ownerID string, funcNode *sitter.Node, src []byte, filePath string, line int, result *parser.ExtractionResult) {
@@ -395,6 +393,21 @@ func canonicalizeRustTypeRef(t string) string {
 		t = strings.TrimSpace(t[4:])
 		return canonicalizeRustTypeRef(t)
 	}
+	// Raw pointers: *const T / *mut T.
+	if strings.HasPrefix(t, "*") {
+		t = strings.TrimSpace(t[1:])
+		t = strings.TrimPrefix(t, "const ")
+		t = strings.TrimPrefix(t, "mut ")
+		return canonicalizeRustTypeRef(strings.TrimSpace(t))
+	}
+	// Slices and arrays: [T] and [T; N] both carry T.
+	if strings.HasPrefix(t, "[") && strings.HasSuffix(t, "]") {
+		inner := strings.TrimSpace(t[1 : len(t)-1])
+		if parts := rustSplitTopLevel(inner, ';'); len(parts) > 0 {
+			inner = parts[0]
+		}
+		return canonicalizeRustTypeRef(inner)
+	}
 	// Strip generic <...> tail.
 	if idx := strings.Index(t, "<"); idx > 0 {
 		t = t[:idx]
@@ -403,11 +416,49 @@ func canonicalizeRustTypeRef(t string) string {
 	for strings.HasPrefix(t, "(") && strings.HasSuffix(t, ")") {
 		t = strings.TrimSpace(t[1 : len(t)-1])
 	}
+	// A trait-object or bound list keeps only its first trait:
+	// `Error + Send + 'static` names Error.
+	if idx := strings.Index(t, "+"); idx > 0 {
+		t = strings.TrimSpace(t[:idx])
+	}
 	// Strip module path: crate::foo::Bar → Bar.
 	if idx := strings.LastIndex(t, "::"); idx >= 0 {
 		t = t[idx+2:]
 	}
-	return strings.TrimSpace(t)
+	t = strings.TrimSpace(t)
+	// Anything still carrying punctuation is not a type name. Emitting
+	// it anyway produced targets like "unresolved::u8, u16" and
+	// "unresolved::[Item]" — edges that can never resolve and that
+	// pollute every unresolved-reference report.
+	if !rustSimpleIdentifier(t) {
+		return ""
+	}
+	return t
+}
+
+// rustCanonicalTypeRefs expands a type expression into every named type
+// it mentions at the top level. A tuple names one type per element, so
+// `(Config, Sender)` must not be collapsed to a single garbage target
+// the way stripping its parens used to.
+func rustCanonicalTypeRefs(t string) []string {
+	t = strings.TrimSpace(t)
+	// Only a genuine tuple — parens wrapping a top-level comma list.
+	if strings.HasPrefix(t, "(") && strings.HasSuffix(t, ")") {
+		inner := strings.TrimSpace(t[1 : len(t)-1])
+		if parts := rustSplitTopLevel(inner, ','); len(parts) > 1 {
+			out := make([]string, 0, len(parts))
+			for _, p := range parts {
+				if canon := canonicalizeRustTypeRef(p); canon != "" && !isRustPrimitive(canon) {
+					out = append(out, canon)
+				}
+			}
+			return out
+		}
+	}
+	if canon := canonicalizeRustTypeRef(t); canon != "" && !isRustPrimitive(canon) {
+		return []string{canon}
+	}
+	return nil
 }
 
 func isRustPrimitive(t string) bool {

--- a/internal/parser/languages/rust_implements_test.go
+++ b/internal/parser/languages/rust_implements_test.go
@@ -1,0 +1,76 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func rustImplementsEdges(t *testing.T, src string) map[string]*graph.Edge {
+	t.Helper()
+	_, edges := rustNodesByID(t, src)
+	out := map[string]*graph.Edge{}
+	for _, e := range edges {
+		if e.Kind == graph.EdgeImplements {
+			out[e.From+" -> "+e.To] = e
+		}
+	}
+	return out
+}
+
+// A derive really does implement the trait — it is how most Rust types
+// acquire Debug, Clone and Serialize. Only an annotation edge was
+// emitted, leaving find_implementations blind to every one of them.
+func TestRsExtractor_DeriveImplementsTrait(t *testing.T) {
+	impls := rustImplementsEdges(t, `#[derive(Debug, serde::Serialize)]
+pub struct Dto { x: i32 }
+`)
+	require.Contains(t, impls, "probe.rs::Dto -> unresolved::Debug")
+	assert.Equal(t, "derive", impls["probe.rs::Dto -> unresolved::Debug"].Meta["via"])
+	require.Contains(t, impls, "probe.rs::Dto -> unresolved::Serialize",
+		"a path-qualified derive resolves to its base trait name")
+}
+
+// A marker impl carries no methods, so the method-level EdgeOverrides
+// that used to be the only signal left no trace of it at all.
+func TestRsExtractor_ImplBlockImplementsTrait(t *testing.T) {
+	impls := rustImplementsEdges(t, `struct Handle;
+impl Send for Handle {}
+impl std::fmt::Display for Handle { fn fmt(&self) {} }
+`)
+	require.Contains(t, impls, "probe.rs::Handle -> unresolved::Send",
+		"a marker impl with no methods must still record the relationship")
+	assert.Equal(t, "impl", impls["probe.rs::Handle -> unresolved::Send"].Meta["via"])
+	require.Contains(t, impls, "probe.rs::Handle -> unresolved::Display",
+		"a fully-qualified trait path reduces to its base name")
+}
+
+// Attributes written on an impl block were dropped wholesale, which is
+// why the file-level wasm_bindgen sentinel only ever saw function-level
+// attributes.
+func TestRsExtractor_ImplBlockAttributes(t *testing.T) {
+	e := NewRustExtractor()
+	result, err := e.Extract("probe.rs", []byte(`struct Dto;
+#[wasm_bindgen]
+impl Dto { pub fn go(&self) {} }
+`))
+	require.NoError(t, err)
+
+	var annotated bool
+	for _, ed := range result.Edges {
+		if ed.Kind == graph.EdgeAnnotated && ed.From == "probe.rs::Dto" &&
+			ed.To == "annotation::rust::wasm_bindgen" {
+			annotated = true
+		}
+	}
+	assert.True(t, annotated, "an impl-block attribute attaches to the impl target")
+
+	for _, n := range result.Nodes {
+		if n.Kind == graph.KindFile {
+			assert.Equal(t, true, n.Meta["uses_wasm_bindgen"],
+				"the interop sentinel must fire for an impl-level #[wasm_bindgen]")
+		}
+	}
+}

--- a/internal/parser/languages/rust_items.go
+++ b/internal/parser/languages/rust_items.go
@@ -422,6 +422,32 @@ func rustTupleFieldOwner(list *sitter.Node, src []byte) (*sitter.Node, string, s
 	return nil, "", ""
 }
 
+// rustEnclosingTraitVisibility returns the visibility of the trait
+// declaring n. A trait member has no visibility modifier of its own, so
+// its reachability is the trait's.
+func rustEnclosingTraitVisibility(n *sitter.Node, src []byte) string {
+	if tr := findEnclosingRustContainer(n, "trait_item"); tr != nil {
+		return rustVisibility(tr, src)
+	}
+	return rustVisibility(n, src)
+}
+
+// rustTraitImplVisibility returns the visibility to record for a method
+// in `impl Trait for Type`. Such a method is callable by anyone who can
+// name the trait, whatever the impl block looks like, so it is public
+// rather than the "private" an absent modifier would otherwise imply.
+// An inherent impl keeps ordinary per-method visibility.
+func rustTraitImplVisibility(fn *sitter.Node, src []byte) string {
+	explicit := rustVisibility(fn, src)
+	if explicit != VisibilityPrivate {
+		return explicit
+	}
+	if rustImplTraitName(fn, src) != "" {
+		return VisibilityPublic
+	}
+	return explicit
+}
+
 // rustAssociatedItemOwner returns the impl or trait an associated item
 // (a const, static or type declared inside a `declaration_list`) belongs
 // to, together with the owner's type name. Returns a nil node and an

--- a/internal/parser/languages/rust_items.go
+++ b/internal/parser/languages/rust_items.go
@@ -1,6 +1,7 @@
 package languages
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/zzet/gortex/internal/graph"
@@ -295,6 +296,88 @@ func emitRustAssociatedType(def *sitter.Node, filePath string, src []byte, resul
 	})
 }
 
+// emitRustTupleFields emits positional fields for a tuple struct or a
+// tuple enum variant. `struct Meters(f64)` and `Msg::Failed(Error)` used
+// to emit no member at all, which also meant the wrapped type was
+// invisible: find_usages on Error could not see that Msg::Failed carries
+// one. Fields are named by position, matching how Rust addresses them
+// (`self.0`).
+func emitRustTupleFields(list *sitter.Node, filePath string, src []byte, result *parser.ExtractionResult, seen map[string]bool, containers rustContainerIDs) {
+	if list == nil {
+		return
+	}
+	ownerNode, ownerName, variant := rustTupleFieldOwner(list, src)
+	if ownerNode == nil || ownerName == "" {
+		return
+	}
+	ownerID := containers.lookup(ownerNode, filePath+"::"+ownerName)
+	if variant != "" {
+		// A variant payload nests under the variant, not the enum, so
+		// two payload-carrying variants cannot collide on ".0".
+		ownerID += "." + variant
+		ownerName += "." + variant
+	}
+	pos := 0
+	for i := 0; i < int(list.ChildCount()); i++ {
+		c := list.Child(i)
+		if c == nil || list.FieldNameForChild(i) != "type" {
+			continue
+		}
+		typeText := strings.TrimSpace(c.Content(src))
+		line := int(c.StartPoint().Row) + 1
+		name := strconv.Itoa(pos)
+		id, ok := disambiguateID(seen, ownerID+"."+name, line)
+		pos++
+		if !ok {
+			continue
+		}
+		result.Nodes = append(result.Nodes, &graph.Node{
+			ID: id, Kind: graph.KindField, Name: name,
+			FilePath: filePath, StartLine: line, EndLine: int(c.EndPoint().Row) + 1,
+			Language: "rust",
+			Meta: map[string]any{
+				"receiver":   ownerName,
+				"field_type": typeText,
+				"positional": true,
+				"visibility": rustVisibility(list.Parent(), src),
+			},
+		})
+		result.Edges = append(result.Edges, &graph.Edge{
+			From: id, To: ownerID, Kind: graph.EdgeMemberOf, FilePath: filePath, Line: line,
+		})
+		emitRustTypeUseEdges(id, typeText, filePath, line, result)
+	}
+}
+
+// rustTupleFieldOwner resolves the struct or enum variant that owns a
+// positional field list. The third result is the variant name when the
+// owner is an enum variant, so the caller can nest the field under it.
+func rustTupleFieldOwner(list *sitter.Node, src []byte) (*sitter.Node, string, string) {
+	parent := list.Parent()
+	if parent == nil {
+		return nil, "", ""
+	}
+	switch parent.Type() {
+	case "struct_item":
+		return parent, rustDeclName(parent, src), ""
+	case "enum_variant":
+		variant := ""
+		if n := parent.ChildByFieldName("name"); n != nil {
+			variant = n.Content(src)
+		}
+		enum := findEnclosingRustContainer(parent, "enum_item")
+		if enum == nil || variant == "" {
+			return nil, "", ""
+		}
+		enumName := rustDeclName(enum, src)
+		if enumName == "" {
+			return nil, "", ""
+		}
+		return enum, enumName, variant
+	}
+	return nil, "", ""
+}
+
 // rustAssociatedItemOwner returns the impl or trait an associated item
 // (a const, static or type declared inside a `declaration_list`) belongs
 // to, together with the owner's type name. Returns a nil node and an
@@ -328,11 +411,11 @@ func rustAssociatedItemOwner(item *sitter.Node, src []byte) (*sitter.Node, strin
 // `field_declaration` can appear under a struct, a union, or a
 // struct-shaped enum variant; the owner name for a variant is
 // `Enum.Variant` so it nests under the enum rather than floating free.
-func rustFieldOwner(field *sitter.Node, src []byte) (*sitter.Node, string) {
+func rustFieldOwner(field *sitter.Node, src []byte) (*sitter.Node, string, string) {
 	for p := field.Parent(); p != nil; p = p.Parent() {
 		switch p.Type() {
 		case "struct_item", "union_item":
-			return p, rustDeclName(p, src)
+			return p, rustDeclName(p, src), ""
 		case "enum_variant":
 			variant := ""
 			if n := p.ChildByFieldName("name"); n != nil {
@@ -340,18 +423,18 @@ func rustFieldOwner(field *sitter.Node, src []byte) (*sitter.Node, string) {
 			}
 			enum := findEnclosingRustContainer(p, "enum_item")
 			if enum == nil || variant == "" {
-				return nil, ""
+				return nil, "", ""
 			}
 			enumName := rustDeclName(enum, src)
 			if enumName == "" {
-				return nil, ""
+				return nil, "", ""
 			}
 			// Anchor on the enum so the field id reads
 			// <file>::<Enum>.<Variant>.<field>.
-			return enum, enumName + "." + variant
+			return enum, enumName, variant
 		}
 	}
-	return nil, ""
+	return nil, "", ""
 }
 
 // rustEnclosingModulePath walks the parent chain and joins every

--- a/internal/parser/languages/rust_items.go
+++ b/internal/parser/languages/rust_items.go
@@ -295,6 +295,35 @@ func emitRustAssociatedType(def *sitter.Node, filePath string, src []byte, resul
 	})
 }
 
+// rustAssociatedItemOwner returns the impl or trait an associated item
+// (a const, static or type declared inside a `declaration_list`) belongs
+// to, together with the owner's type name. Returns a nil node and an
+// empty name for a file-scope item.
+func rustAssociatedItemOwner(item *sitter.Node, src []byte) (*sitter.Node, string) {
+	if item == nil {
+		return nil, ""
+	}
+	parent := item.Parent()
+	if parent == nil || parent.Type() != "declaration_list" {
+		return nil, ""
+	}
+	owner := parent.Parent()
+	if owner == nil {
+		return nil, ""
+	}
+	switch owner.Type() {
+	case "trait_item":
+		return owner, rustDeclName(owner, src)
+	case "impl_item":
+		t := owner.ChildByFieldName("type")
+		if t == nil {
+			return nil, ""
+		}
+		return owner, rustTraitPathBaseName(strings.TrimSpace(t.Content(src)))
+	}
+	return nil, ""
+}
+
 // rustFieldOwner resolves the declaration a named field belongs to. A
 // `field_declaration` can appear under a struct, a union, or a
 // struct-shaped enum variant; the owner name for a variant is

--- a/internal/parser/languages/rust_items.go
+++ b/internal/parser/languages/rust_items.go
@@ -296,6 +296,50 @@ func emitRustAssociatedType(def *sitter.Node, filePath string, src []byte, resul
 	})
 }
 
+// emitRustImplBlock handles what an `impl` block carries beyond its
+// methods: the trait it implements, and the attributes written on the
+// block itself.
+//
+// `impl Display for Buf` left no relationship between Buf and Display at
+// all — only a method-level EdgeOverrides — so find_implementations and
+// get_class_hierarchy could not see the trait hierarchy, and a marker
+// impl with no methods (`impl Send for Handle {}`) left no trace
+// whatsoever.
+//
+// Attributes on the block were dropped outright, which is how
+// #[wasm_bindgen] impl, #[async_trait] impl and #[pymethods] all went
+// unrecorded — including the file-level wasm_bindgen sentinel, which
+// only ever saw function-level attributes.
+func emitRustImplBlock(def *sitter.Node, filePath string, src []byte, result *parser.ExtractionResult, annotationSeen map[string]bool) {
+	if def == nil {
+		return
+	}
+	typeNode := def.ChildByFieldName("type")
+	if typeNode == nil {
+		return
+	}
+	implType := rustImplReceiverName(typeNode.Content(src))
+	if implType == "" {
+		return
+	}
+	line := int(def.StartPoint().Row) + 1
+	// The impl target may be a generic instantiation (`Replacer<M>`);
+	// the node it belongs to is declared under the bare name.
+	typeID := filePath + "::" + rustTraitPathBaseName(implType)
+
+	if tr := def.ChildByFieldName("trait"); tr != nil {
+		if base := rustTraitPathBaseName(strings.TrimSpace(tr.Content(src))); base != "" {
+			result.Edges = append(result.Edges, &graph.Edge{
+				From: typeID, To: "unresolved::" + base,
+				Kind: graph.EdgeImplements, FilePath: filePath, Line: line,
+				Origin: graph.OriginASTInferred,
+				Meta:   map[string]any{"via": "impl"},
+			})
+		}
+	}
+	emitRustAnnotationEdges(rustCollectAttributes(def), typeID, filePath, src, result, annotationSeen)
+}
+
 // emitRustTupleFields emits positional fields for a tuple struct or a
 // tuple enum variant. `struct Meters(f64)` and `Msg::Failed(Error)` used
 // to emit no member at all, which also meant the wrapped type was

--- a/internal/parser/languages/rust_items.go
+++ b/internal/parser/languages/rust_items.go
@@ -1,0 +1,487 @@
+package languages
+
+import (
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	sitter "github.com/zzet/gortex/internal/parser/tsitter"
+)
+
+// This file covers the Rust item kinds the original query set never
+// captured. Measured against 4,000 files of real crate source, they are
+// not corner cases: 10,094 type aliases, 4,206 modules, 1,148
+// `macro_rules!` definitions, 416 `extern crate` declarations and 38,973
+// `extern` blocks produced exactly zero graph nodes between them.
+
+// rustContainerIDs maps a container declaration's 0-based start row to
+// the node id actually minted for it. Two same-named types in one file
+// — the norm once inline modules exist — get distinct ids from
+// disambiguateID, so a member can no longer reconstruct its owner's id
+// by name alone. Without this the second `mod`'s fields silently
+// attached to the first `mod`'s type.
+type rustContainerIDs map[int]string
+
+// register records the id minted for a container node.
+func (c rustContainerIDs) register(def *sitter.Node, id string) {
+	if def != nil && id != "" {
+		c[int(def.StartPoint().Row)] = id
+	}
+}
+
+// lookup returns the minted id for a container node, falling back to the
+// by-name form for containers emitted before this map existed.
+func (c rustContainerIDs) lookup(def *sitter.Node, fallback string) string {
+	if def == nil {
+		return fallback
+	}
+	if id, ok := c[int(def.StartPoint().Row)]; ok {
+		return id
+	}
+	return fallback
+}
+
+// emitRustModule mints a node for a `mod` item. Rust modules are a
+// namespace, not a dependency, so they follow the C++/C# namespace
+// precedent (KindPackage) rather than KindModule — which Gortex reserves
+// for package-manager dependencies (see dotnet_project.go, mcp_config.go).
+//
+// Items inside the module keep their flat `<file>::<Name>` ids and gain a
+// `scope_mod` meta instead, mirroring C#'s `scope_ns`. Qualifying the ids
+// themselves would rewrite every Rust node id in the graph and every
+// resolver path that reconstructs one; the scope meta buys attribution
+// without that churn.
+func emitRustModule(def *sitter.Node, name, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen, annotationSeen map[string]bool) string {
+	id, ok := disambiguateID(seen, filePath+"::"+name, int(def.StartPoint().Row)+1)
+	if !ok {
+		return ""
+	}
+	meta := map[string]any{
+		"visibility":  rustVisibility(def, src),
+		"type_flavor": "module",
+	}
+	// `mod foo;` (no body) points at another file — worth distinguishing
+	// from an inline module because the resolver has to go find it.
+	if def.ChildByFieldName("body") == nil {
+		meta["declaration_only"] = true
+	}
+	if path := rustEnclosingModulePath(def, src); path != "" {
+		meta["scope_mod"] = path
+	}
+	if doc := ExtractDocAbove(src, int(def.StartPoint().Row), DocLangSlashSlash); doc != "" {
+		meta["doc"] = doc
+	}
+	result.Nodes = append(result.Nodes, &graph.Node{
+		ID: id, Kind: graph.KindPackage, Name: name,
+		FilePath:  filePath,
+		StartLine: int(def.StartPoint().Row) + 1,
+		EndLine:   int(def.EndPoint().Row) + 1,
+		Language:  "rust",
+		Meta:      meta,
+	})
+	result.Edges = append(result.Edges, &graph.Edge{
+		From: fileID, To: id, Kind: graph.EdgeDefines,
+		FilePath: filePath, Line: int(def.StartPoint().Row) + 1,
+	})
+	emitRustAnnotationEdges(rustCollectAttributes(def), id, filePath, src, result, annotationSeen)
+	return id
+}
+
+// emitRustTypeAlias mints a node for `type Alias<T> = Target;`. The alias
+// target is recorded both as meta and as a type-usage edge so
+// find_usages on the aliased type reaches the alias.
+func emitRustTypeAlias(def *sitter.Node, name, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen, annotationSeen map[string]bool) {
+	line := int(def.StartPoint().Row) + 1
+	id, ok := disambiguateID(seen, filePath+"::"+name, line)
+	if !ok {
+		return
+	}
+	meta := map[string]any{
+		"visibility":  rustVisibility(def, src),
+		"type_flavor": "alias",
+	}
+	if t := def.ChildByFieldName("type"); t != nil {
+		target := strings.TrimSpace(t.Content(src))
+		meta["aliases"] = target
+		emitRustTypeUseEdges(id, target, filePath, line, result)
+	}
+	if doc := ExtractDocAbove(src, int(def.StartPoint().Row), DocLangSlashSlash); doc != "" {
+		meta["doc"] = doc
+	}
+	if scope := rustEnclosingModulePath(def, src); scope != "" {
+		meta["scope_mod"] = scope
+	}
+	result.Nodes = append(result.Nodes, &graph.Node{
+		ID: id, Kind: graph.KindType, Name: name,
+		FilePath:  filePath,
+		StartLine: line,
+		EndLine:   int(def.EndPoint().Row) + 1,
+		Language:  "rust",
+		Meta:      meta,
+	})
+	result.Edges = append(result.Edges, &graph.Edge{
+		From: fileID, To: id, Kind: graph.EdgeDefines, FilePath: filePath, Line: line,
+	})
+	emitRustAnnotationEdges(rustCollectAttributes(def), id, filePath, src, result, annotationSeen)
+	emitRustGenericParamNodes(id, def, src, filePath, line, result)
+}
+
+// emitRustUnion mints a node for a `union`. Its fields flow through the
+// ordinary field pass once that stops skipping non-struct containers.
+func emitRustUnion(def *sitter.Node, name, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen, annotationSeen map[string]bool, containers rustContainerIDs) {
+	line := int(def.StartPoint().Row) + 1
+	id, ok := disambiguateID(seen, filePath+"::"+name, line)
+	if !ok {
+		return
+	}
+	containers.register(def, id)
+	meta := map[string]any{
+		"visibility":  rustVisibility(def, src),
+		"type_flavor": "union",
+		// A union is inherently unsafe to read; surfacing that lets an
+		// audit query find every one without re-parsing.
+		"unsafe_access": true,
+	}
+	if doc := ExtractDocAbove(src, int(def.StartPoint().Row), DocLangSlashSlash); doc != "" {
+		meta["doc"] = doc
+	}
+	if scope := rustEnclosingModulePath(def, src); scope != "" {
+		meta["scope_mod"] = scope
+	}
+	result.Nodes = append(result.Nodes, &graph.Node{
+		ID: id, Kind: graph.KindType, Name: name,
+		FilePath:  filePath,
+		StartLine: line,
+		EndLine:   int(def.EndPoint().Row) + 1,
+		Language:  "rust",
+		Meta:      meta,
+	})
+	result.Edges = append(result.Edges, &graph.Edge{
+		From: fileID, To: id, Kind: graph.EdgeDefines, FilePath: filePath, Line: line,
+	})
+	emitRustAnnotationEdges(rustCollectAttributes(def), id, filePath, src, result, annotationSeen)
+	emitRustGenericParamNodes(id, def, src, filePath, line, result)
+}
+
+// emitRustMacroDef mints a node for a `macro_rules!` definition so
+// invocation sites have something to bind to.
+func emitRustMacroDef(def *sitter.Node, name, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen, annotationSeen map[string]bool) {
+	line := int(def.StartPoint().Row) + 1
+	id, ok := disambiguateID(seen, filePath+"::"+name+"!", line)
+	if !ok {
+		return
+	}
+	meta := map[string]any{"type_flavor": "macro_rules"}
+	// #[macro_export] is what makes a macro reachable from other crates —
+	// the macro equivalent of `pub`.
+	for _, attr := range rustCollectAttributes(def) {
+		if strings.Contains(attr.Content(src), "macro_export") {
+			meta["visibility"] = VisibilityPublic
+			meta["exported"] = true
+			break
+		}
+	}
+	if _, ok := meta["visibility"]; !ok {
+		meta["visibility"] = VisibilityPrivate
+	}
+	if doc := ExtractDocAbove(src, int(def.StartPoint().Row), DocLangSlashSlash); doc != "" {
+		meta["doc"] = doc
+	}
+	if scope := rustEnclosingModulePath(def, src); scope != "" {
+		meta["scope_mod"] = scope
+	}
+	// Arity is the number of `macro_rule` arms — a cheap proxy for how
+	// much surface the macro has.
+	arms := 0
+	for child := range def.NamedChildren() {
+		if child.Type() == "macro_rule" {
+			arms++
+		}
+	}
+	if arms > 0 {
+		meta["rules"] = arms
+	}
+	result.Nodes = append(result.Nodes, &graph.Node{
+		ID: id, Kind: graph.KindMacro, Name: name,
+		FilePath:  filePath,
+		StartLine: line,
+		EndLine:   int(def.EndPoint().Row) + 1,
+		Language:  "rust",
+		Meta:      meta,
+	})
+	result.Edges = append(result.Edges, &graph.Edge{
+		From: fileID, To: id, Kind: graph.EdgeDefines, FilePath: filePath, Line: line,
+	})
+	emitRustAnnotationEdges(rustCollectAttributes(def), id, filePath, src, result, annotationSeen)
+}
+
+// emitRustExternCrate records a 2015-edition `extern crate serde;` as an
+// import, so a crate dependency declared that way is as visible as one
+// declared with `use`.
+func emitRustExternCrate(def *sitter.Node, filePath, fileID string, src []byte, result *parser.ExtractionResult) {
+	nameNode := def.ChildByFieldName("name")
+	if nameNode == nil {
+		return
+	}
+	crate := nameNode.Content(src)
+	line := int(def.StartPoint().Row) + 1
+	edge := &graph.Edge{
+		From: fileID, To: "unresolved::import::" + crate,
+		Kind: graph.EdgeImports, FilePath: filePath, Line: line,
+		Meta: map[string]any{"extern_crate": true},
+	}
+	if alias := def.ChildByFieldName("alias"); alias != nil {
+		edge.Meta["alias"] = alias.Content(src)
+	}
+	if v := rustVisibility(def, src); v == VisibilityPublic || v == VisibilityInternal {
+		edge.Meta["reexport"] = true
+	}
+	result.Edges = append(result.Edges, edge)
+}
+
+// emitRustAssociatedType mints a node for a trait's `type Item;`. The
+// associated type is part of the trait's contract, so it hangs off the
+// trait the same way a trait method does.
+func emitRustAssociatedType(def *sitter.Node, filePath string, src []byte, result *parser.ExtractionResult, seen map[string]bool) {
+	nameNode := def.ChildByFieldName("name")
+	if nameNode == nil {
+		return
+	}
+	owner := findEnclosingRustContainer(def, "trait_item")
+	if owner == nil {
+		owner = findEnclosingRustContainer(def, "impl_item")
+	}
+	if owner == nil {
+		return
+	}
+	ownerName := rustDeclName(owner, src)
+	if ownerName == "" {
+		if t := owner.ChildByFieldName("type"); t != nil {
+			ownerName = rustTraitPathBaseName(strings.TrimSpace(t.Content(src)))
+		}
+	}
+	if ownerName == "" {
+		return
+	}
+	name := nameNode.Content(src)
+	line := int(def.StartPoint().Row) + 1
+	ownerID := filePath + "::" + ownerName
+	id, ok := disambiguateID(seen, ownerID+"."+name, line)
+	if !ok {
+		return
+	}
+	meta := map[string]any{
+		"receiver":    ownerName,
+		"type_flavor": "associated_type",
+	}
+	// A bound on an associated type (`type Item: Display;`) is part of
+	// the contract callers can rely on.
+	for child := range def.NamedChildren() {
+		if child.Type() == "trait_bounds" {
+			meta["bound"] = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(child.Content(src)), ":"))
+			break
+		}
+	}
+	result.Nodes = append(result.Nodes, &graph.Node{
+		ID: id, Kind: graph.KindType, Name: name,
+		FilePath:  filePath,
+		StartLine: line,
+		EndLine:   int(def.EndPoint().Row) + 1,
+		Language:  "rust",
+		Meta:      meta,
+	})
+	result.Edges = append(result.Edges, &graph.Edge{
+		From: id, To: ownerID, Kind: graph.EdgeMemberOf, FilePath: filePath, Line: line,
+	})
+}
+
+// rustFieldOwner resolves the declaration a named field belongs to. A
+// `field_declaration` can appear under a struct, a union, or a
+// struct-shaped enum variant; the owner name for a variant is
+// `Enum.Variant` so it nests under the enum rather than floating free.
+func rustFieldOwner(field *sitter.Node, src []byte) (*sitter.Node, string) {
+	for p := field.Parent(); p != nil; p = p.Parent() {
+		switch p.Type() {
+		case "struct_item", "union_item":
+			return p, rustDeclName(p, src)
+		case "enum_variant":
+			variant := ""
+			if n := p.ChildByFieldName("name"); n != nil {
+				variant = n.Content(src)
+			}
+			enum := findEnclosingRustContainer(p, "enum_item")
+			if enum == nil || variant == "" {
+				return nil, ""
+			}
+			enumName := rustDeclName(enum, src)
+			if enumName == "" {
+				return nil, ""
+			}
+			// Anchor on the enum so the field id reads
+			// <file>::<Enum>.<Variant>.<field>.
+			return enum, enumName + "." + variant
+		}
+	}
+	return nil, ""
+}
+
+// rustEnclosingModulePath walks the parent chain and joins every
+// enclosing `mod` name with "::", so an item in `mod a { mod b { .. } }`
+// reports "a::b". Empty for a top-level item.
+func rustEnclosingModulePath(n *sitter.Node, src []byte) string {
+	var parts []string
+	for p := n.Parent(); p != nil; p = p.Parent() {
+		if p.Type() != "mod_item" {
+			continue
+		}
+		if name := p.ChildByFieldName("name"); name != nil {
+			parts = append(parts, name.Content(src))
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	// The walk collects innermost-first; the path reads outermost-first.
+	for i, j := 0, len(parts)-1; i < j; i, j = i+1, j-1 {
+		parts[i], parts[j] = parts[j], parts[i]
+	}
+	return strings.Join(parts, "::")
+}
+
+// rustForeignABI returns the ABI string of the `extern "C" { .. }` block
+// enclosing n (defaulting to "C", which is what a bare `extern` means),
+// plus whether n is inside a foreign block at all.
+func rustForeignABI(n *sitter.Node, src []byte) (string, bool) {
+	block := findEnclosingRustContainer(n, "foreign_mod_item")
+	if block == nil {
+		return "", false
+	}
+	for child := range block.NamedChildren() {
+		if child.Type() != "extern_modifier" {
+			continue
+		}
+		for lit := range child.NamedChildren() {
+			if lit.Type() == "string_literal" {
+				return strings.Trim(lit.Content(src), `"`), true
+			}
+		}
+	}
+	return "C", true
+}
+
+// rustFnQualifiers reads the keyword prefix of a function item —
+// `pub async unsafe extern "C" fn` — which the extractor previously
+// discarded wholesale. Without it the graph cannot answer "which
+// functions are async" or "which cross the FFI boundary".
+func rustFnQualifiers(fn *sitter.Node, src []byte) map[string]any {
+	out := map[string]any{}
+	if fn == nil {
+		return out
+	}
+	for i := 0; i < int(fn.ChildCount()); i++ {
+		c := fn.Child(i)
+		if c == nil {
+			continue
+		}
+		// Stop at the name: everything after it is signature, not
+		// qualifier.
+		if c.Type() == "identifier" {
+			break
+		}
+		switch c.Type() {
+		case "function_modifiers":
+			text := c.Content(src)
+			if strings.Contains(text, "async") {
+				out["is_async"] = true
+			}
+			if strings.Contains(text, "unsafe") {
+				out["is_unsafe"] = true
+			}
+			if strings.Contains(text, "const") {
+				out["is_const"] = true
+			}
+			if strings.Contains(text, "extern") {
+				out["is_extern"] = true
+				if q := strings.Index(text, `"`); q >= 0 {
+					if end := strings.Index(text[q+1:], `"`); end >= 0 {
+						out["abi"] = text[q+1 : q+1+end]
+					}
+				} else {
+					out["abi"] = "C"
+				}
+			}
+		}
+	}
+	return out
+}
+
+// buildRustSignature reconstructs a readable signature instead of the
+// placeholder `fn name(...)` the extractor stamped on every function.
+// Parameters, return type, generics and the where-clause all survive.
+func buildRustSignature(fn *sitter.Node, name string, src []byte) string {
+	if fn == nil {
+		return "fn " + name + "(...)"
+	}
+	var b strings.Builder
+	if mods := childOfTypeRust(fn, "function_modifiers"); mods != nil {
+		b.WriteString(strings.Join(strings.Fields(mods.Content(src)), " "))
+		b.WriteByte(' ')
+	}
+	b.WriteString("fn ")
+	b.WriteString(name)
+	if tp := fn.ChildByFieldName("type_parameters"); tp != nil {
+		b.WriteString(collapseRustWhitespace(tp.Content(src)))
+	}
+	if params := fn.ChildByFieldName("parameters"); params != nil {
+		b.WriteString(collapseRustWhitespace(params.Content(src)))
+	} else {
+		b.WriteString("()")
+	}
+	if rt := fn.ChildByFieldName("return_type"); rt != nil {
+		b.WriteString(" -> ")
+		b.WriteString(collapseRustWhitespace(rt.Content(src)))
+	}
+	if wc := childOfTypeRust(fn, "where_clause"); wc != nil {
+		b.WriteByte(' ')
+		b.WriteString(collapseRustWhitespace(wc.Content(src)))
+	}
+	return b.String()
+}
+
+// childOfTypeRust returns the first direct child of n with the given
+// node type, or nil.
+func childOfTypeRust(n *sitter.Node, t string) *sitter.Node {
+	if n == nil {
+		return nil
+	}
+	for i := 0; i < int(n.ChildCount()); i++ {
+		c := n.Child(i)
+		if c != nil && c.Type() == t {
+			return c
+		}
+	}
+	return nil
+}
+
+// collapseRustWhitespace flattens a multi-line signature fragment onto
+// one line so the stamped signature stays a single readable string.
+func collapseRustWhitespace(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// applyRustFnQualifiers merges the async/unsafe/const/extern markers
+// into a node's meta.
+func applyRustFnQualifiers(meta map[string]any, fn *sitter.Node, src []byte) {
+	for k, v := range rustFnQualifiers(fn, src) {
+		meta[k] = v
+	}
+}
+
+// applyRustScopeMod stamps the enclosing module path on an item. Ids stay
+// flat, so this is what tells two same-named items in different modules
+// apart, and what lets a consumer reconstruct `crate::a::b::Item`.
+func applyRustScopeMod(meta map[string]any, n *sitter.Node, src []byte) {
+	if path := rustEnclosingModulePath(n, src); path != "" {
+		meta["scope_mod"] = path
+	}
+}

--- a/internal/parser/languages/rust_items_test.go
+++ b/internal/parser/languages/rust_items_test.go
@@ -191,6 +191,47 @@ pub struct Dto { x: i32 }
 	assert.True(t, got["annotation::rust::Clone"])
 }
 
+// An associated const belongs to its impl. Emitting every const at file
+// scope meant two impls declaring the same const name fought over one id
+// and the loser was dropped with no node and no edge.
+func TestRsExtractor_AssociatedConstsKeepTheirOwner(t *testing.T) {
+	byID, edges := rustNodesByID(t, `const MAX: u32 = 1;
+struct A;
+struct B;
+impl A { pub const LIMIT: usize = 10; }
+impl B { pub const LIMIT: usize = 20; }
+`)
+	require.NotNil(t, byID["probe.rs::A.LIMIT"], "impl A's const must survive")
+	require.NotNil(t, byID["probe.rs::B.LIMIT"], "impl B's const must survive too")
+	assert.Equal(t, "A", byID["probe.rs::A.LIMIT"].Meta["receiver"])
+	assert.Equal(t, "B", byID["probe.rs::B.LIMIT"].Meta["receiver"])
+
+	owners := map[string]string{}
+	for _, e := range edges {
+		if e.Kind == graph.EdgeMemberOf {
+			owners[e.From] = e.To
+		}
+	}
+	assert.Equal(t, "probe.rs::A", owners["probe.rs::A.LIMIT"])
+	assert.Equal(t, "probe.rs::B", owners["probe.rs::B.LIMIT"])
+
+	top := byID["probe.rs::MAX"]
+	require.NotNil(t, top)
+	assert.Equal(t, graph.KindConstant, top.Kind, "a const is a constant, not a variable")
+	assert.Equal(t, "u32", top.Meta["declared_type"])
+}
+
+// `static mut` is the one form that is genuinely mutable shared state.
+func TestRsExtractor_StaticMutIsMarked(t *testing.T) {
+	byID, _ := rustNodesByID(t, `static mut COUNTER: u64 = 0;
+static NAME: &str = "x";
+`)
+	require.NotNil(t, byID["probe.rs::COUNTER"])
+	assert.Equal(t, graph.KindVariable, byID["probe.rs::COUNTER"].Kind)
+	assert.Equal(t, true, byID["probe.rs::COUNTER"].Meta["mutable"])
+	assert.Nil(t, byID["probe.rs::NAME"].Meta["mutable"])
+}
+
 // Result error extraction split on every comma and looked at the last
 // "::" in the string, so a tuple payload produced the literal target
 // "u16)" and a fully-qualified Result produced no edge at all.

--- a/internal/parser/languages/rust_items_test.go
+++ b/internal/parser/languages/rust_items_test.go
@@ -1,0 +1,203 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func rustNodesByID(t *testing.T, src string) (map[string]*graph.Node, []*graph.Edge) {
+	t.Helper()
+	e := NewRustExtractor()
+	result, err := e.Extract("probe.rs", []byte(src))
+	require.NoError(t, err)
+	byID := make(map[string]*graph.Node, len(result.Nodes))
+	for _, n := range result.Nodes {
+		byID[n.ID] = n
+	}
+	return byID, result.Edges
+}
+
+// A `mod` is a namespace, so it lands as KindPackage the way a C++ or C#
+// namespace does — and the items inside it record which module they came
+// from.
+func TestRsExtractor_ModuleNode(t *testing.T) {
+	byID, _ := rustNodesByID(t, `mod inner {
+    pub fn hi() {}
+}
+mod declared_elsewhere;
+`)
+	mod := byID["probe.rs::inner"]
+	require.NotNil(t, mod, "an inline mod must mint a node")
+	assert.Equal(t, graph.KindPackage, mod.Kind)
+	assert.Equal(t, "module", mod.Meta["type_flavor"])
+
+	decl := byID["probe.rs::declared_elsewhere"]
+	require.NotNil(t, decl, "a bodyless `mod foo;` must mint a node too")
+	assert.Equal(t, true, decl.Meta["declaration_only"])
+
+	require.NotNil(t, byID["probe.rs::hi"])
+	assert.Equal(t, "inner", byID["probe.rs::hi"].Meta["scope_mod"])
+}
+
+// Two same-named types in two modules of one file both have to survive.
+// Before this, the second was dropped and — worse — its fields were
+// re-parented onto the first, so the surviving type reported members it
+// does not have.
+func TestRsExtractor_SameNameAcrossModulesBothSurvive(t *testing.T) {
+	byID, edges := rustNodesByID(t, `mod alpha {
+    pub struct Config { pub a: u8 }
+}
+mod beta {
+    pub struct Config { pub b: u8 }
+}
+`)
+	first := byID["probe.rs::Config"]
+	second := byID["probe.rs::Config_L5"]
+	require.NotNil(t, first, "first Config must keep the clean id")
+	require.NotNil(t, second, "second Config must survive under a disambiguated id")
+	assert.Equal(t, "alpha", first.Meta["scope_mod"])
+	assert.Equal(t, "beta", second.Meta["scope_mod"])
+
+	require.NotNil(t, byID["probe.rs::Config.a"])
+	require.NotNil(t, byID["probe.rs::Config_L5.b"])
+
+	// Each field must point at its own struct, not at whichever struct
+	// happened to be emitted first.
+	owners := map[string]string{}
+	for _, e := range edges {
+		if e.Kind == graph.EdgeMemberOf {
+			owners[e.From] = e.To
+		}
+	}
+	assert.Equal(t, "probe.rs::Config", owners["probe.rs::Config.a"])
+	assert.Equal(t, "probe.rs::Config_L5", owners["probe.rs::Config_L5.b"])
+}
+
+func TestRsExtractor_TypeAlias(t *testing.T) {
+	byID, _ := rustNodesByID(t, `pub type Registry<T> = HashMap<String, T>;`)
+	n := byID["probe.rs::Registry"]
+	require.NotNil(t, n, "a type alias must mint a node")
+	assert.Equal(t, graph.KindType, n.Kind)
+	assert.Equal(t, "alias", n.Meta["type_flavor"])
+	assert.Equal(t, "HashMap<String, T>", n.Meta["aliases"])
+}
+
+func TestRsExtractor_UnionAndItsFields(t *testing.T) {
+	byID, _ := rustNodesByID(t, `pub union Value { int: i64, float: f64 }`)
+	u := byID["probe.rs::Value"]
+	require.NotNil(t, u, "a union must mint a node")
+	assert.Equal(t, "union", u.Meta["type_flavor"])
+	require.NotNil(t, byID["probe.rs::Value.int"], "union fields were previously skipped outright")
+	require.NotNil(t, byID["probe.rs::Value.float"])
+}
+
+func TestRsExtractor_MacroRulesDefinition(t *testing.T) {
+	byID, _ := rustNodesByID(t, `#[macro_export]
+macro_rules! log_it {
+    () => {};
+    ($x:expr) => {};
+}
+`)
+	m := byID["probe.rs::log_it!"]
+	require.NotNil(t, m, "macro_rules! must mint a node")
+	assert.Equal(t, graph.KindMacro, m.Kind)
+	assert.Equal(t, VisibilityPublic, m.Meta["visibility"], "#[macro_export] makes a macro public")
+	assert.Equal(t, 2, m.Meta["rules"])
+}
+
+// An `extern "C"` block declares the foreign half of an FFI boundary.
+// These are the call targets of every unsafe call into C.
+func TestRsExtractor_ExternBlockFunctions(t *testing.T) {
+	byID, _ := rustNodesByID(t, `extern "C" {
+    fn sqlite3_open(name: *const u8) -> i32;
+}
+`)
+	fn := byID["probe.rs::sqlite3_open"]
+	require.NotNil(t, fn, "an extern block fn must mint a node")
+	assert.Equal(t, graph.KindFunction, fn.Kind)
+	assert.Equal(t, "C", fn.Meta["abi"])
+	assert.Equal(t, true, fn.Meta["is_extern"])
+	assert.Equal(t, true, fn.Meta["external"])
+}
+
+func TestRsExtractor_ExternCrate(t *testing.T) {
+	_, edges := rustNodesByID(t, `extern crate serde;`)
+	var found bool
+	for _, e := range edges {
+		if e.Kind == graph.EdgeImports && e.To == "unresolved::import::serde" {
+			found = true
+			assert.Equal(t, true, e.Meta["extern_crate"])
+		}
+	}
+	assert.True(t, found, "extern crate must record an import edge")
+}
+
+func TestRsExtractor_AssociatedType(t *testing.T) {
+	byID, edges := rustNodesByID(t, `trait Source {
+    type Item: Clone;
+    fn get(&self) -> Self::Item;
+}
+`)
+	at := byID["probe.rs::Source.Item"]
+	require.NotNil(t, at, "a trait's associated type must mint a node")
+	assert.Equal(t, "associated_type", at.Meta["type_flavor"])
+	assert.Equal(t, "Clone", at.Meta["bound"])
+
+	var member bool
+	for _, e := range edges {
+		if e.From == "probe.rs::Source.Item" && e.To == "probe.rs::Source" && e.Kind == graph.EdgeMemberOf {
+			member = true
+		}
+	}
+	assert.True(t, member, "an associated type belongs to its trait")
+}
+
+// The signature meta used to be the literal placeholder "fn name(...)"
+// for every function in every Rust file.
+func TestRsExtractor_SignatureAndQualifiers(t *testing.T) {
+	byID, _ := rustNodesByID(t, `pub async unsafe fn fetch<T: Clone>(url: &str, n: usize) -> Option<T> where T: Send { todo!() }
+pub const fn zero() -> i32 { 0 }
+`)
+	f := byID["probe.rs::fetch"]
+	require.NotNil(t, f)
+	assert.Equal(t,
+		"async unsafe fn fetch<T: Clone>(url: &str, n: usize) -> Option<T> where T: Send",
+		f.Meta["signature"])
+	assert.Equal(t, true, f.Meta["is_async"])
+	assert.Equal(t, true, f.Meta["is_unsafe"])
+
+	z := byID["probe.rs::zero"]
+	require.NotNil(t, z)
+	assert.Equal(t, true, z.Meta["is_const"])
+}
+
+// A comment sitting between an attribute stack and its item is ordinary
+// Rust style; it used to discard every attribute above it.
+func TestRsExtractor_AttributesSurviveInterleavedComment(t *testing.T) {
+	_, edges := rustNodesByID(t, `#[derive(Debug, Clone)]
+// why this type exists
+pub struct Dto { x: i32 }
+`)
+	got := map[string]bool{}
+	for _, e := range edges {
+		if e.Kind == graph.EdgeAnnotated && e.From == "probe.rs::Dto" {
+			got[e.To] = true
+		}
+	}
+	assert.True(t, got["annotation::rust::Debug"], "attributes above a comment must still attach")
+	assert.True(t, got["annotation::rust::Clone"])
+}
+
+// Result error extraction split on every comma and looked at the last
+// "::" in the string, so a tuple payload produced the literal target
+// "u16)" and a fully-qualified Result produced no edge at all.
+func TestRustErrorTypeFromResult_TupleAndQualified(t *testing.T) {
+	assert.Equal(t, "MyError", rustErrorTypeFromResult("Result<(u8, u16), MyError>"))
+	assert.Equal(t, "Error", rustErrorTypeFromResult("std::result::Result<u8, io::Error>"))
+	assert.Equal(t, "ParseError", rustErrorTypeFromResult("Result<Vec<[u8; 4]>, ParseError>"))
+	assert.Equal(t, "", rustErrorTypeFromResult("anyhow::Result<u8>"))
+	assert.Equal(t, "", rustErrorTypeFromResult("i32"))
+}

--- a/internal/parser/languages/rust_items_test.go
+++ b/internal/parser/languages/rust_items_test.go
@@ -191,6 +191,34 @@ pub struct Dto { x: i32 }
 	assert.True(t, got["annotation::rust::Clone"])
 }
 
+// A newtype's wrapped type used to be invisible: no field node meant
+// find_usages on Config could not see that Wrapper carries one.
+func TestRsExtractor_TupleStructAndVariantPayloads(t *testing.T) {
+	byID, edges := rustNodesByID(t, `struct Wrapper(Config, u8);
+enum Msg { Started, Failed(Error), Rich { code: u16 } }
+`)
+	w0 := byID["probe.rs::Wrapper.0"]
+	require.NotNil(t, w0, "a tuple struct's positional field must exist")
+	assert.Equal(t, "Config", w0.Meta["field_type"])
+	assert.Equal(t, true, w0.Meta["positional"])
+	require.NotNil(t, byID["probe.rs::Wrapper.1"])
+
+	// A payload nests under its variant so two payload-carrying
+	// variants cannot collide on ".0".
+	require.NotNil(t, byID["probe.rs::Msg.Failed.0"])
+	assert.Equal(t, "Msg.Failed", byID["probe.rs::Msg.Failed.0"].Meta["receiver"])
+	require.NotNil(t, byID["probe.rs::Msg.Rich.code"],
+		"a struct-shaped variant's fields were dropped as well")
+
+	var typed bool
+	for _, e := range edges {
+		if e.From == "probe.rs::Wrapper.0" && e.To == "unresolved::Config" && e.Kind == graph.EdgeTypedAs {
+			typed = true
+		}
+	}
+	assert.True(t, typed, "the wrapped type must be reachable from the newtype")
+}
+
 // An associated const belongs to its impl. Emitting every const at file
 // scope meant two impls declaring the same const name fought over one id
 // and the loser was dropped with no node and no edge.

--- a/internal/parser/languages/rust_macrocalls.go
+++ b/internal/parser/languages/rust_macrocalls.go
@@ -1,0 +1,223 @@
+package languages
+
+import (
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+	sitter "github.com/zzet/gortex/internal/parser/tsitter"
+)
+
+// Rust's grammar does not parse macro arguments as expressions: every
+// `macro_invocation` carries an opaque `token_tree` of raw tokens. A
+// call written inside one is therefore invisible to a query over
+// `call_expression`, and the amount hiding there is not marginal —
+// across 4,000 files of real crate source there are 68,551 macro
+// invocations concealing 65,525 call sites, against 238,457 call edges
+// the extractor finds everywhere else. Test suites suffer worst: 42,511
+// of those invocations are `assert*!`, so the call that a `#[test]`
+// actually exercises is precisely the one that goes unrecorded.
+//
+// scanRustMacroCalls recovers them by walking the token stream for the
+// three call shapes Rust can spell, using the anonymous `.` / `::`
+// separator tokens to tell them apart.
+
+// rustMacroCall is one call site recovered from a macro body.
+type rustMacroCall struct {
+	name       string
+	receiver   string // receiver identifier for `x.method(...)`
+	path       string // full `a::b::c` path for a qualified call
+	line       int
+	isSelector bool
+	macroName  string // the macro whose body it was found in
+	isMacro    bool   // the site is itself a nested macro invocation
+}
+
+// rustPatternMacros are macros whose token tree holds patterns, cfg
+// predicates or literal text rather than expressions. Scanning them
+// mints calls to things that are not functions — `matches!(x, Some(_))`
+// would otherwise report a call to `Some`, and `cfg!(any(unix, windows))`
+// a call to `any`.
+var rustPatternMacros = map[string]bool{
+	"cfg": true, "cfg_if": true, "cfg_attr": true, "cfg_match": true,
+	"matches": true, "assert_matches": true, "debug_assert_matches": true,
+	"derive": true, "stringify": true, "concat": true, "concat_idents": true,
+	"include": true, "include_str": true, "include_bytes": true,
+	"env": true, "option_env": true, "line": true, "file": true,
+	"column": true, "module_path": true, "compile_error": true,
+}
+
+// rustNonCallIdents are prelude constructors that dominate macro bodies
+// but carry no call-graph value: `assert_eq!(f(), Ok(3))` is a statement
+// about `f`, not about `Ok`. Across the sample corpus these three alone
+// accounted for 5,733 of 17,322 plain-call hits.
+var rustNonCallIdents = map[string]bool{
+	"Some": true, "Ok": true, "Err": true,
+}
+
+// scanRustMacroCalls walks the token trees of a macro_invocation and
+// returns every call site it can identify.
+func scanRustMacroCalls(inv *sitter.Node, src []byte) []rustMacroCall {
+	if inv == nil {
+		return nil
+	}
+	macroName := ""
+	if mn := inv.ChildByFieldName("macro"); mn != nil {
+		macroName = rustLastPathSegment(mn.Content(src))
+	}
+	if rustPatternMacros[macroName] {
+		return nil
+	}
+	var out []rustMacroCall
+	for i := 0; i < int(inv.ChildCount()); i++ {
+		c := inv.Child(i)
+		if c != nil && c.Type() == "token_tree" {
+			scanRustTokenTree(c, src, macroName, &out)
+		}
+	}
+	return out
+}
+
+// scanRustTokenTree is the recursive token walk. It looks for an
+// identifier immediately followed by a parenthesised token tree, then
+// classifies the site by the token that precedes the identifier.
+func scanRustTokenTree(tt *sitter.Node, src []byte, macroName string, out *[]rustMacroCall) {
+	n := int(tt.ChildCount())
+	for i := 0; i < n; i++ {
+		c := tt.Child(i)
+		if c == nil {
+			continue
+		}
+		if c.Type() == "token_tree" {
+			scanRustTokenTree(c, src, macroName, out)
+			continue
+		}
+		if c.Type() != "identifier" {
+			continue
+		}
+		if i+1 >= n {
+			continue
+		}
+		name := c.Content(src)
+		line := int(c.StartPoint().Row) + 1
+
+		// A nested macro invocation: `ident ! ( .. )`. Record the
+		// invocation, and only descend into its body when that macro
+		// holds expressions.
+		if nxt := tt.Child(i + 1); nxt != nil && nxt.Content(src) == "!" {
+			if i+2 < n {
+				if body := tt.Child(i + 2); body != nil && body.Type() == "token_tree" {
+					*out = append(*out, rustMacroCall{
+						name: name, line: line, macroName: macroName, isMacro: true,
+					})
+					if !rustPatternMacros[name] {
+						scanRustTokenTree(body, src, name, out)
+					}
+					i += 2
+					continue
+				}
+			}
+			continue
+		}
+
+		nxt := tt.Child(i + 1)
+		if nxt == nil || nxt.Type() != "token_tree" || !strings.HasPrefix(nxt.Content(src), "(") {
+			continue
+		}
+
+		// Classify by the separator token in front of the identifier.
+		sep, prev := "", (*sitter.Node)(nil)
+		if i > 0 {
+			prev = tt.Child(i - 1)
+			if prev != nil {
+				sep = prev.Content(src)
+			}
+		}
+		switch sep {
+		case ".":
+			recv := ""
+			if i >= 2 {
+				if r := tt.Child(i - 2); r != nil {
+					t := r.Type()
+					if t == "identifier" || t == "self" {
+						recv = r.Content(src)
+					}
+				}
+			}
+			*out = append(*out, rustMacroCall{
+				name: name, receiver: recv, line: line,
+				isSelector: true, macroName: macroName,
+			})
+		case "::":
+			*out = append(*out, rustMacroCall{
+				name: name, line: line, macroName: macroName,
+				path: rustMacroCallPath(tt, i, src),
+			})
+		default:
+			if rustNonCallIdents[name] {
+				continue
+			}
+			*out = append(*out, rustMacroCall{
+				name: name, line: line, macroName: macroName,
+			})
+		}
+	}
+}
+
+// rustMacroCallPath rebuilds the full `a::b::c` path of a qualified call
+// by walking backwards over alternating `::` separators and identifiers.
+func rustMacroCallPath(tt *sitter.Node, nameIdx int, src []byte) string {
+	parts := []string{tt.Child(nameIdx).Content(src)}
+	i := nameIdx - 1
+	for i >= 1 {
+		sep := tt.Child(i)
+		if sep == nil || sep.Content(src) != "::" {
+			break
+		}
+		seg := tt.Child(i - 1)
+		if seg == nil {
+			break
+		}
+		switch seg.Type() {
+		case "identifier", "self", "super", "crate", "metavariable":
+			parts = append(parts, seg.Content(src))
+		default:
+			i = -1
+			continue
+		}
+		i -= 2
+	}
+	for a, b := 0, len(parts)-1; a < b; a, b = a+1, b-1 {
+		parts[a], parts[b] = parts[b], parts[a]
+	}
+	if len(parts) < 2 {
+		return ""
+	}
+	return strings.Join(parts, "::")
+}
+
+// stampRustMacroOrigin records how a call site was recovered. A site
+// found by the token scan is a weaker signal than one the grammar
+// parsed as a call_expression, so it is labelled rather than silently
+// mixed in.
+func stampRustMacroOrigin(e *graph.Edge, c rustDeferredCall) {
+	if c.viaMacro == "" && !c.isMacro {
+		return
+	}
+	if e.Meta == nil {
+		e.Meta = map[string]any{}
+	}
+	if c.viaMacro != "" {
+		e.Meta["via_macro"] = c.viaMacro
+	}
+	if c.isMacro {
+		e.Meta["rust_macro"] = true
+	}
+}
+
+// rustLastPathSegment reduces `tokio::spawn` to `spawn`.
+func rustLastPathSegment(s string) string {
+	if i := strings.LastIndex(s, "::"); i >= 0 {
+		return s[i+2:]
+	}
+	return s
+}

--- a/internal/parser/languages/rust_macrocalls_test.go
+++ b/internal/parser/languages/rust_macrocalls_test.go
@@ -1,0 +1,101 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// rustCallTargets collects every EdgeCalls target emitted for src.
+func rustCallTargets(t *testing.T, src string) map[string]*graph.Edge {
+	t.Helper()
+	e := NewRustExtractor()
+	result, err := e.Extract("probe.rs", []byte(src))
+	require.NoError(t, err)
+	out := map[string]*graph.Edge{}
+	for _, ed := range result.Edges {
+		if ed.Kind == graph.EdgeCalls {
+			out[ed.To] = ed
+		}
+	}
+	return out
+}
+
+// Rust does not parse macro arguments as expressions, so a call written
+// inside one is invisible to a query over call_expression. Test suites
+// are hit hardest: the call a #[test] actually exercises is normally the
+// one inside assert_eq!.
+func TestRsExtractor_CallsInsideMacroBodies(t *testing.T) {
+	calls := rustCallTargets(t, `fn subject() -> u32 { 1 }
+#[test]
+fn it_works() {
+    assert_eq!(subject(), 1);
+    println!("{}", helper());
+}
+`)
+	require.Contains(t, calls, "unresolved::subject",
+		"the call a #[test] exercises must be recorded even inside assert_eq!")
+	assert.Equal(t, "assert_eq", calls["unresolved::subject"].Meta["via_macro"],
+		"a token-recovered site is labelled with the macro it came from")
+	require.Contains(t, calls, "unresolved::helper")
+}
+
+func TestRsExtractor_MacroBodyCallShapes(t *testing.T) {
+	calls := rustCallTargets(t, `fn f() {
+    let v = vec![Foo::new()];
+    write!(out, "{}", self.name());
+}
+`)
+	require.Contains(t, calls, "unresolved::new", "a path call inside a macro body")
+	assert.Equal(t, "Foo::new", calls["unresolved::new"].Meta["rust_path"])
+	require.Contains(t, calls, "unresolved::*.name", "a method call inside a macro body")
+	assert.Equal(t, "self", calls["unresolved::*.name"].Meta["rust_recv"])
+}
+
+// The invocation itself is a use of the macro, so a macro_rules!
+// definition gets incoming edges.
+func TestRsExtractor_MacroInvocationRecordsUse(t *testing.T) {
+	calls := rustCallTargets(t, `macro_rules! log_it { () => {} }
+fn f() { log_it!(); }
+`)
+	require.Contains(t, calls, "unresolved::log_it")
+	assert.Equal(t, true, calls["unresolved::log_it"].Meta["rust_macro"])
+}
+
+// Pattern and cfg-predicate macros hold patterns, not expressions.
+// Scanning them would mint calls to things that are not functions.
+func TestRsExtractor_PatternMacrosAreNotScanned(t *testing.T) {
+	calls := rustCallTargets(t, `fn f(x: Option<u8>) {
+    let _ = matches!(x, Some(_));
+    let _ = cfg!(any(unix, windows));
+}
+`)
+	assert.NotContains(t, calls, "unresolved::Some",
+		"matches! holds a pattern — Some(_) is not a call")
+	assert.NotContains(t, calls, "unresolved::any",
+		"cfg! holds a predicate — any(..) is not a call")
+}
+
+// Prelude constructors dominate macro bodies but carry no call-graph
+// value: assert_eq!(f(), Ok(3)) is a statement about f, not about Ok.
+func TestRsExtractor_PreludeConstructorsSkippedInMacros(t *testing.T) {
+	calls := rustCallTargets(t, `fn f() { assert_eq!(compute(), Ok(3)); }`)
+	require.Contains(t, calls, "unresolved::compute")
+	assert.NotContains(t, calls, "unresolved::Ok")
+}
+
+// A trailing ::<T> wraps the callee in a generic_function node, which
+// none of the three original call patterns matched.
+func TestRsExtractor_TurbofishCallSites(t *testing.T) {
+	calls := rustCallTargets(t, `fn f(items: Vec<u32>) {
+    let a = items.iter().collect::<Vec<u32>>();
+    let b = parse::<u32>("3");
+}
+`)
+	require.Contains(t, calls, "unresolved::*.collect",
+		"xs.collect::<Vec<_>>() is a method call")
+	require.Contains(t, calls, "unresolved::parse",
+		"parse::<u32>(s) is a plain call")
+}

--- a/internal/parser/languages/rust_typetargets_test.go
+++ b/internal/parser/languages/rust_typetargets_test.go
@@ -1,0 +1,73 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Canonicalisation stripped a tuple's parens and left the comma, and had
+// no case at all for slices, arrays or raw pointers — so it produced
+// targets like "unresolved::u8, u16" and "unresolved::[Item]" that can
+// never resolve and pollute every unresolved-reference report.
+func TestCanonicalizeRustTypeRef_RejectsNonTypeNames(t *testing.T) {
+	assert.Equal(t, "Item", canonicalizeRustTypeRef("&[Item]"))
+	assert.Equal(t, "Item", canonicalizeRustTypeRef("[Item; 4]"))
+	assert.Equal(t, "c_void", canonicalizeRustTypeRef("*mut c_void"))
+	assert.Equal(t, "Error", canonicalizeRustTypeRef("Box<dyn Error + Send + 'static>"))
+	assert.Equal(t, "", canonicalizeRustTypeRef("(u8, u16)"),
+		"a tuple is not one type name")
+}
+
+// A tuple names one type per slot, so each slot gets its own edge.
+func TestRustCanonicalTypeRefs_ExpandsTuples(t *testing.T) {
+	assert.Equal(t, []string{"Item", "Cfg"}, rustCanonicalTypeRefs("(Item, Cfg)"))
+	assert.Equal(t, []string{"Cfg"}, rustCanonicalTypeRefs("(u8, Cfg)"),
+		"primitives are skipped, named types are kept")
+	assert.Equal(t, []string{"Item"}, rustCanonicalTypeRefs("Vec<Item>"))
+}
+
+func TestRsExtractor_TupleReturnEmitsOneEdgePerSlot(t *testing.T) {
+	_, edges := rustNodesByID(t, `fn process() -> (Item, Cfg) { todo!() }`)
+	got := map[string]int{}
+	for _, e := range edges {
+		if e.Kind == graph.EdgeReturns {
+			got[e.To] = e.Meta["position"].(int)
+		}
+	}
+	require.Contains(t, got, "unresolved::Item")
+	require.Contains(t, got, "unresolved::Cfg")
+	assert.Equal(t, 0, got["unresolved::Item"])
+	assert.Equal(t, 1, got["unresolved::Cfg"])
+}
+
+// `impl Trait for &'a Buf` minted the method id `<file>::&'a Buf.show`
+// and pointed its member_of at a node that never exists.
+func TestRustImplReceiverName_UnwrapsNonNominalTargets(t *testing.T) {
+	assert.Equal(t, "Buf", rustImplReceiverName("&'a Buf"))
+	assert.Equal(t, "Buf", rustImplReceiverName("&mut Buf"))
+	assert.Equal(t, "Item", rustImplReceiverName("[Item; 4]"))
+	assert.Equal(t, "c_void", rustImplReceiverName("*mut c_void"))
+	// The generic spelling is the established id shape and must survive.
+	assert.Equal(t, "Replacer<M>", rustImplReceiverName("Replacer<M>"))
+}
+
+func TestRsExtractor_RefImplMethodBindsToRealOwner(t *testing.T) {
+	byID, edges := rustNodesByID(t, `struct Buf;
+impl Display for &'a Buf { fn show(&self) {} }
+`)
+	m := byID["probe.rs::Buf.show"]
+	require.NotNil(t, m, "the method must hang off the named type")
+	assert.Equal(t, "Buf", m.Meta["receiver"])
+
+	var bound bool
+	for _, e := range edges {
+		if e.From == "probe.rs::Buf.show" && e.Kind == graph.EdgeMemberOf {
+			assert.Equal(t, "probe.rs::Buf", e.To, "member_of must name a node that exists")
+			bound = true
+		}
+	}
+	assert.True(t, bound)
+}

--- a/internal/parser/languages/rust_visibility_test.go
+++ b/internal/parser/languages/rust_visibility_test.go
@@ -1,0 +1,52 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A trait member carries no visibility modifier of its own — it is
+// exactly as reachable as the trait that declares it. Reading the absent
+// modifier as "private" made every method of every public trait look
+// private, understating the public API surface.
+func TestRsExtractor_TraitMembersInheritTraitVisibility(t *testing.T) {
+	byID, _ := rustNodesByID(t, `pub trait Handler {
+    fn handle(&self);
+    fn ready(&self) -> bool { true }
+}
+trait Internal { fn tick(&self); }
+`)
+	require.NotNil(t, byID["probe.rs::Handler.handle"])
+	assert.Equal(t, VisibilityPublic, byID["probe.rs::Handler.handle"].Meta["visibility"],
+		"a public trait's signature is public")
+	assert.Equal(t, VisibilityPublic, byID["probe.rs::Handler.ready"].Meta["visibility"],
+		"a public trait's default method is public too")
+	assert.Equal(t, VisibilityPrivate, byID["probe.rs::Internal.tick"].Meta["visibility"],
+		"a private trait's members stay private")
+}
+
+// A trait impl's method is callable by anyone who can name the trait,
+// whatever the impl block looks like.
+func TestRsExtractor_TraitImplMethodsArePublic(t *testing.T) {
+	byID, _ := rustNodesByID(t, `struct H;
+impl Handler for H { fn handle(&self) {} }
+impl H { fn helper(&self) {} }
+`)
+	assert.Equal(t, VisibilityPublic, byID["probe.rs::H.handle"].Meta["visibility"],
+		"reachable through the trait")
+	assert.Equal(t, VisibilityPrivate, byID["probe.rs::H.helper"].Meta["visibility"],
+		"an inherent impl keeps ordinary per-method visibility")
+}
+
+// Trait declarations used to keep the "fn name(...)" placeholder even
+// after the free-function and impl-method paths stopped using it.
+func TestRsExtractor_TraitMethodSignatureIsReal(t *testing.T) {
+	byID, _ := rustNodesByID(t, `pub trait Handler {
+    fn ready(&self, tries: u8) -> bool;
+}
+`)
+	assert.Equal(t, "fn ready(&self, tries: u8) -> bool",
+		byID["probe.rs::Handler.ready"].Meta["signature"])
+}


### PR DESCRIPTION
## Why

Rust extraction looked complete — `docs/languages.md` rated it "Full" across the
board — but measuring it against real crate source told a different story. I ran
the extractor over 4,000 `.rs` files (68 MB, ~577 crates from the local Cargo
registry), counting tree-sitter node types present in the source against graph
nodes actually emitted.

Whole categories of declaration produced **zero** nodes:

| construct | present in corpus | nodes emitted |
|---|--:|--:|
| `macro_invocation` (concealing call sites) | 68,551 | 0 |
| `extern "C"` blocks | 38,973 | 0 |
| `type` aliases | 10,094 | 0 |
| `generic_function` calls (`xs.collect::<Vec<_>>()`) | 5,301 | 0 |
| `mod` | 4,206 | 0 |
| `macro_rules!` | 1,148 | 0 |
| `extern crate` / `associated_type` / `union` | 416 / 225 / 162 | 0 |

Others were silently **wrong**, which is worse than missing — a confidently
incorrect edge is one nobody re-checks.

## What changed

Eight commits, one per behaviour.

**Coverage.** Query patterns and emitters for `mod` (indexed as a package node,
following the C++/C# namespace precedent — `KindModule` is reserved for
package-manager dependencies), type aliases, unions and their fields,
`macro_rules!`, `extern`-block functions with their ABI, `extern crate`,
associated types, and tuple-struct / enum-variant payload fields.

**Calls hidden in macros.** Rust does not parse macro arguments as expressions —
every `macro_invocation` carries an opaque token tree — so any query over
`call_expression` is blind to calls written inside one. 42,511 of the corpus's
invocations are `assert*!`, meaning the call a `#[test]` actually exercises was
precisely the one never recorded. Recovered by a token scan over the three call
shapes Rust can spell, labelled `Meta["via_macro"]` so consumers wanting only
grammar-certain edges can filter. Pattern and cfg-predicate macros are excluded,
so `matches!(x, Some(_))` does not report a call to `Some`.

**Correctness fixes**, each reproduced with a probe before being fixed:

- Two same-named types in one file collapsed into one node **and the loser's
  fields were re-parented onto the survivor**, which then reported members it
  does not have. Now routed through the existing `disambiguateID` helper, with
  `scope_mod` distinguishing them.
- Associated consts were emitted at file scope, so `impl A { const LIMIT }` and
  `impl B { const LIMIT }` fought over one id and the loser vanished entirely.
- Type canonicalisation emitted targets that name no possible node —
  `unresolved::"u8, u16"` from `Result<(u8, u16), E>`, `unresolved::"[Item]"`
  from `&[Item]`, `unresolved::"Error + Send + 'static"` from a boxed trait
  object. A tuple now expands to one edge per slot.
- `impl Trait for &'a Buf` minted the method id `<file>::&'a Buf.show` with a
  `member_of` edge to a node that never exists, orphaning the method.
- `rustCollectAttributes` stopped at the first non-attribute sibling, so a
  comment between an attribute stack and its item discarded every attribute
  above it.
- `Result` error extraction split on every comma and anchored on the last `::`
  in the string, so `Result<(u8, u16), E>` emitted a throws edge to the literal
  `"u16)"` and `std::result::Result<T, io::Error>` emitted none at all.
- Trait members were reported `private` even when their trait was `pub`,
  understating the public API surface.
- `signature` was the hardcoded placeholder `fn name(...)` on every Rust
  function; `async`/`unsafe`/`const`/`extern` qualifiers were never recorded.

**Relationships.** Neither way a Rust type acquires a trait produced an
implements edge: `impl Display for Buf` emitted only a method-level
`EdgeOverrides` (so a marker impl left no trace at all) and `#[derive(...)]`
emitted only an annotation — despite derive being how most Rust types get
`Debug`, `Clone` and `Serialize`. Attributes on impl blocks were dropped
wholesale, which is why the file-level `wasm_bindgen` sentinel missed the form
the wasm-bindgen guide recommends for methods.

**Entry points.** `entrypoints.Detect` had no `rust` case, so nothing in a Rust
repo was ever a live root and the dead-code analyzer reported every binary
crate's entire call tree as dead. Now stamps `fn main` in Cargo binary targets,
async-runtime mains, test/bench harnesses, and FFI exports; `extern` block
declarations are stamped `rust:ffi-import` because their body lives in another
language, so a missing definition is not a missing implementation.

## Result

Re-measured over the same 4,000 files:

| | before | after |
|---|--:|--:|
| call edges | 238,457 | **381,608** (+60%) |
| total nodes | 221,676 | **370,822** (+67%) |
| `implements` edges | 0 | **35,604** |
| `typed_as` edges | 30,544 | **103,130** |
| `returns` edges | 21,325 | **51,819** |
| `annotated` edges | 54,545 | **99,778** |

`go build ./...` and `go test -race ./...` pass. 663 lines of new tests, each
asserting the specific defect it covers.

## Deliberately not in this change

The audit also surfaced problems outside the parsing layer, listed here so they
are not lost. The resolver ones matter most because they produce confidently
wrong results rather than missing ones:

- `use super::X` from a non-`mod.rs` module file resolves one directory too high
  and binds to the **wrong file** at full `ast_resolved` confidence.
- Module-qualified path calls (`alpha::helper()`) bind to an unrelated module's
  same-named function.
- `#[path = "..."]` is ignored; glob re-exports (`pub use inner::*`) are dropped;
  group imports (`use crate::{a, b}`) never resolve.
- Cargo workspace siblings are misclassified as external dependencies, and
  `[workspace.dependencies]` is never parsed.
- Axum/actix attribute routes bind to the function *preceding* the attribute.
- No tokio channel-ops, `sqlx` SQL extraction, or ORM lane for diesel/sea-orm.

I also verified and rejected one reported issue: a field's doc comment bleeding
onto the next undocumented field does not reproduce.
