### PR TITLE
fix: bound every MCP request and control RPC so a busy daemon cannot hang the caller

### DIFF
--- a/cmd/gortex/cli_daemon.go
+++ b/cmd/gortex/cli_daemon.go
@@ -5,12 +5,31 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/zzet/gortex/internal/daemon"
 	gortexmcp "github.com/zzet/gortex/internal/mcp"
 	"github.com/zzet/gortex/internal/pathkey"
 )
+
+// daemonRoutingProbeTimeout bounds the "does the daemon own this repo?" probe
+// that precedes every CLI graph query. Short on purpose: the answer only picks
+// an execution backend, and waiting on a busy daemon to learn it is strictly
+// worse than getting on with the query.
+const daemonRoutingProbeTimeout = 3 * time.Second
+
+// daemonProbeIndeterminate reports whether a control probe failed in a way
+// that means "the daemon is busy", as opposed to giving a real answer. Covers
+// both ends: the client's own deadline, and the daemon answering that it could
+// not finish in time.
+func daemonProbeIndeterminate(err error, resp daemon.ControlResponse) bool {
+	if errors.Is(err, daemon.ErrDaemonUnresponsive) {
+		return true
+	}
+	return err == nil && !resp.OK && resp.ErrorCode == daemon.ErrTimeout
+}
 
 // ErrNoExecutor signals that no warm daemon owns the repo and no explicit
 // daemonless path (--oneshot) was selected — the caller decides whether to
@@ -169,13 +188,34 @@ func resolveExecutorWithToolSurface(repoPath, tools, toolsMode string) (cliExecu
 
 // daemonOwnsRepo reports whether the running daemon tracks a repo that
 // covers abs (so a daemon query won't answer empty for an untracked path).
+//
+// This runs ahead of every CLI graph query, which made it the single point
+// where a busy daemon stalled the whole CLI: Status serialises behind the
+// controller mutex that track / reload / enrichment hold for minutes, and the
+// call had no bound on either end.
+//
+// It gets a short budget, and when that budget expires it FAILS OPEN — the
+// answer is unknown, not "no". Treating an indeterminate probe as "not ours"
+// would be a lie with an actively harmful remedy: the caller would be told
+// "the daemon does not track <path> — add it with `gortex track <path>`",
+// when the daemon does track it and `track` is itself the unbounded operation
+// holding the lock. Proceeding to the MCP path costs nothing to be wrong
+// about: that path does not need the controller mutex, and a genuinely
+// untracked repo comes back as repo_not_tracked, which surfaces the same
+// message this probe would have produced.
 func daemonOwnsRepo(abs string) bool {
 	c, err := daemon.Dial(daemon.Handshake{Mode: daemon.ModeControl, ClientName: "cli"})
 	if err != nil {
 		return false
 	}
 	defer c.Close()
-	resp, err := c.Control(daemon.ControlStatus, nil)
+	resp, err := c.ControlWithTimeout(daemon.ControlStatus, nil, daemonRoutingProbeTimeout)
+	if daemonProbeIndeterminate(err, resp) {
+		fmt.Fprintf(os.Stderr,
+			"[gortex] daemon did not answer within %s (a track / reload / enrichment may be holding it) — asking it anyway\n",
+			daemonRoutingProbeTimeout)
+		return true
+	}
 	if err != nil || !resp.OK {
 		return false
 	}

--- a/cmd/gortex/daemon.go
+++ b/cmd/gortex/daemon.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -241,16 +242,16 @@ func runDaemonStart(cmd *cobra.Command, _ []string) error {
 			return preset, mode, srv.LearnedToolCount()
 		}
 	}
-	controller.onShutdown = func() error {
+	controller.setShutdownHook(func() error {
 		// Stop watchers first so no late events race the snapshot
 		// write — we want the snapshot to reflect a quiescent graph,
 		// not one being mutated by an in-flight re-index.
-		controller.mu.Lock()
-		mw := controller.multiWatcher
-		controller.mu.Unlock()
-		if mw != nil {
-			_ = mw.Stop()
-		}
+		//
+		// StopWatcher is lock-free by design. This is the first thing a
+		// stop request does, and reading the watcher under the coarse
+		// controller mutex put it straight back behind the long-running
+		// track / reload / enrichment the user is trying to end.
+		controller.StopWatcher()
 		if mg, ok := state.graph.(*graph.Graph); ok {
 			// Memory backend — snapshot the full in-memory graph;
 			// the next warmup replays nodes/edges from the gob+gzip
@@ -272,7 +273,7 @@ func runDaemonStart(cmd *cobra.Command, _ []string) error {
 			_ = state.mcpServer.FlushSavings()
 		}
 		return nil
-	}
+	})
 	srv.Controller = controller
 	// Surface warmup state on the handshake ack: a proxy / CLI that connects
 	// during the (minutes-long) warmup should know the graph is still filling
@@ -997,29 +998,71 @@ func runDaemonStop(cmd *cobra.Command, _ []string) error {
 		// the daemon hasn't cleaned up. Fall back to killing by PID.
 		return killByPID()
 	}
-	resp, err := c.Control(daemon.ControlShutdown, nil)
+	// Explicit budget: the daemon flushes and closes its store before acking,
+	// so the ack is unbounded by policy on the server side (abandoning a
+	// half-done flush is worse than a slow stop). The wait belongs here
+	// instead, where giving up is safe — the daemon is already on its way
+	// down and the exit wait below finishes the job.
+	resp, err := c.ControlWithTimeout(daemon.ControlShutdown, nil, daemonShutdownAckTimeout)
 	_ = c.Close()
-	if err != nil {
+	// A daemon that accepted the request but hasn't acked is not a reason to
+	// abandon the stop. The ack is synchronous with the controller's
+	// flush-and-close, so on a large workspace — or behind a track / reload
+	// holding the controller — it can legitimately overrun the budget while
+	// the process is still on its way down. Returning an error here left the
+	// user with a daemon they could only `kill -9`. Fall through to the exit
+	// wait instead: it force-kills and cleans up if the daemon really is
+	// wedged, so `daemon stop` always terminates and always leaves the socket
+	// and PID file in a startable state.
+	grace := daemonExitGrace
+	switch {
+	case errors.Is(err, daemon.ErrDaemonUnresponsive),
+		err == nil && !resp.OK && resp.ErrorCode == daemon.ErrTimeout:
+		fmt.Fprintln(w, "[gortex daemon] no shutdown ack yet — the daemon is busy; waiting for it to exit")
+		grace = daemonBusyExitGrace
+	case err != nil:
 		return err
-	}
-	if !resp.OK {
+	case !resp.OK:
 		return fmt.Errorf("shutdown rejected: %s %s", resp.ErrorCode, resp.ErrorMsg)
 	}
 	if havePID {
-		waitForDaemonExit(pid)
+		waitForDaemonExitWithin(pid, grace)
 	}
 	emitDaemonStopSummary(w, socket, uptime)
 	return nil
 }
 
-// waitForDaemonExit blocks until the daemon process pid has exited — and thus
-// released the store's on-disk lock — force-killing it if a graceful shutdown
-// stalls. This is what makes `daemon stop` honest: when it returns, the store
-// is free for the next process, which is the foundation `daemon restart`
-// stands on. Polls cheaply; the common case (a clean flush) clears in well
-// under a second.
-func waitForDaemonExit(pid int) {
-	deadline := time.Now().Add(15 * time.Second)
+const (
+	// daemonExitGrace is how long a normal stop waits for the process to go
+	// away after a successful ack — the flush has already happened by then.
+	daemonExitGrace = 15 * time.Second
+	// daemonBusyExitGrace applies when the daemon never acked. The flush is
+	// presumed still running, so force-killing on the normal schedule would
+	// interrupt exactly the store write we want to complete.
+	daemonBusyExitGrace = 2 * time.Minute
+	// daemonStatusCardTimeout bounds the advisory Status lookups that only
+	// decorate output. They must never be the reason a command hangs.
+	daemonStatusCardTimeout = 3 * time.Second
+	// daemonShutdownAckTimeout is how long the stop command waits for the
+	// shutdown ack before switching to watching the process itself. Generous,
+	// because the ack trails a real store flush.
+	daemonShutdownAckTimeout = 30 * time.Second
+)
+
+// waitForDaemonExitWithin blocks until the daemon process pid has exited — and
+// thus released the store's on-disk lock — force-killing it if a graceful
+// shutdown stalls. This is what makes `daemon stop` honest: when it returns,
+// the store is free for the next process, which is the foundation `daemon
+// restart` stands on. Polls cheaply; the common case (a clean flush) clears in
+// well under a second.
+//
+// grace is the caller's, not a constant, because how long to wait depends on
+// what the ack told us: daemonExitGrace after a successful ack (the flush has
+// already happened), daemonBusyExitGrace when none arrived (it probably has
+// not, and force-killing on the normal schedule would interrupt the store
+// write we want to complete).
+func waitForDaemonExitWithin(pid int, grace time.Duration) {
+	deadline := time.Now().Add(grace)
 	for time.Now().Before(deadline) {
 		if !platform.ProcessAlive(pid) {
 			return
@@ -1042,13 +1085,19 @@ func waitForDaemonExit(pid int) {
 // a Status control before shutdown so the summary card can show how long the
 // process ran. Returns 0 on any error — we'd rather degrade the card than
 // fail the stop.
+//
+// Bounded hard: Status aggregates the whole store and serialises behind the
+// controller mutex, so on a busy daemon this decorative lookup was the first
+// thing `daemon stop` blocked on — the stop request had not even been sent
+// yet. A card without an uptime is a fine outcome; a stop that never returns
+// is not.
 func daemonUptimeBeforeStop() time.Duration {
 	c, err := daemonControlClient()
 	if err != nil {
 		return 0
 	}
 	defer c.Close()
-	resp, err := c.Control(daemon.ControlStatus, nil)
+	resp, err := c.ControlWithTimeout(daemon.ControlStatus, nil, daemonStatusCardTimeout)
 	if err != nil || !resp.OK {
 		return 0
 	}

--- a/cmd/gortex/daemon_controller.go
+++ b/cmd/gortex/daemon_controller.go
@@ -42,8 +42,12 @@ type realController struct {
 	indexer       *indexer.Indexer
 	multiIndexer  *indexer.MultiIndexer
 	configManager *config.ConfigManager
-	multiWatcher  *indexer.MultiWatcher
-	logger        *zap.Logger
+	// multiWatcher is an atomic pointer, not a mu-guarded field: the daemon's
+	// teardown hook reads it, and reading it under mu is what kept `daemon
+	// stop` queued behind a running track / reload / enrichment. One writer
+	// (AttachWatcher, during warmup); read via watcher().
+	multiWatcher atomic.Pointer[indexer.MultiWatcher]
+	logger       *zap.Logger
 
 	// liveRouter is the multi-server Router currently wired into the
 	// dispatch path (nil for a local-only daemon with no roster).
@@ -57,6 +61,14 @@ type realController struct {
 
 	// onShutdown is invoked by the Shutdown method. Used by the daemon
 	// main to flush savings, close the snapshot store, etc.
+	//
+	// Guarded by its own mutex, deliberately NOT by mu. Shutdown is the
+	// one control RPC that has to work when the daemon is at its least
+	// healthy, and mu is held for the entire duration of a track / reload /
+	// enrichment — minutes on a large workspace. Reading this field under
+	// mu made `gortex daemon stop` queue behind exactly the condition it
+	// exists to escape.
+	shutdownMu sync.Mutex
 	onShutdown func() error
 
 	// toolSurface reports the active tool-surface preset + mode and the
@@ -121,9 +133,9 @@ func (c *realController) Track(ctx context.Context, p daemon.TrackParams) (json.
 	// flow back into the graph live without a manual reload. Failures
 	// here are logged but don't fail the track — an indexed-but-
 	// unwatched repo is still queryable, just stale if edited.
-	if c.multiWatcher != nil && c.configManager != nil {
+	if mw := c.watcher(); mw != nil && c.configManager != nil {
 		wcfg := c.configManager.GetRepoConfig(prefix).Watch
-		if err := c.multiWatcher.AddRepo(prefix, wcfg); err != nil {
+		if err := mw.AddRepo(prefix, wcfg); err != nil {
 			c.logger.Warn("track: attach watcher failed",
 				zap.String("prefix", prefix), zap.Error(err))
 		}
@@ -417,8 +429,8 @@ func (c *realController) Untrack(_ context.Context, p daemon.UntrackParams) (jso
 	// Detach the watcher before evicting from the graph — otherwise a
 	// late fsnotify event could race the eviction and try to re-index
 	// files whose nodes are already gone.
-	if c.multiWatcher != nil {
-		if err := c.multiWatcher.RemoveRepo(prefix); err != nil {
+	if mw := c.watcher(); mw != nil {
+		if err := mw.RemoveRepo(prefix); err != nil {
 			c.logger.Debug("untrack: detach watcher",
 				zap.String("prefix", prefix), zap.Error(err))
 		}
@@ -657,7 +669,16 @@ func resolveSearchBackend(b search.Backend) searchBackendInfo {
 // Status gathers per-repo stats and basic process metrics. Daemon-level
 // fields (PID, uptime, socket, session count) are filled in by the
 // daemon itself before the response goes out.
-func (c *realController) Status(_ context.Context) (daemon.StatusResponse, error) {
+func (c *realController) Status(ctx context.Context) (daemon.StatusResponse, error) {
+	// Bail before doing any work if the caller is already gone. Status sits
+	// on the critical path of `daemon stop`, `gortex call`, and the agent
+	// hooks, all of which now bound the round trip — once their budget has
+	// expired, finishing the aggregate only burns store reads that nobody
+	// will read.
+	if err := ctx.Err(); err != nil {
+		return daemon.StatusResponse{}, err
+	}
+
 	// Compute the per-repo memory estimate BEFORE taking the coarse
 	// controller mutex. On the SQLite backend AllRepoMemoryEstimates is a
 	// COUNT … GROUP BY scan that turns pathologically slow under
@@ -685,6 +706,13 @@ func (c *realController) Status(_ context.Context) (daemon.StatusResponse, error
 	// every queued control request wait out the pause as well.
 	var mem runtime.MemStats
 	runtime.ReadMemStats(&mem)
+
+	// Everything above is the slow half and c.mu below is the contended half.
+	// Re-check between them: a caller whose budget expired during the scans
+	// must not go on to queue behind a mutex held by a minutes-long track.
+	if err := ctx.Err(); err != nil {
+		return daemon.StatusResponse{}, err
+	}
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -1254,9 +1282,28 @@ func probeSymbolHit(n *graph.Node) daemon.SymbolHit {
 // watcher when the warmup-constructed MultiWatcher iterates
 // mi.AllMetadata() at startup.
 func (c *realController) AttachWatcher(mw *indexer.MultiWatcher) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.multiWatcher = mw
+	c.multiWatcher.Store(mw)
+}
+
+// watcher reads the attached MultiWatcher without touching the coarse mutex.
+// The teardown path needs it, and taking mu there would put the stop request
+// back behind the minutes-long track / reload / enrichment it is trying to end.
+func (c *realController) watcher() *indexer.MultiWatcher {
+	return c.multiWatcher.Load()
+}
+
+// StopWatcher halts filesystem watching. Called first during teardown so no
+// late event races the snapshot write — we want the snapshot to reflect a
+// quiescent graph, not one being mutated by an in-flight re-index.
+//
+// Deliberately lock-free: this is the first statement of the daemon's shutdown
+// hook, and it used to take the coarse controller mutex just to read the
+// watcher pointer, which meant `gortex daemon stop` queued behind whatever
+// long operation was holding it.
+func (c *realController) StopWatcher() {
+	if mw := c.watcher(); mw != nil {
+		_ = mw.Stop()
+	}
 }
 
 // MarkReady flips the ready flag once references are resolved and the graph
@@ -1294,12 +1341,22 @@ func (c *realController) IsEnriched() bool {
 
 // Shutdown gives the caller (the daemon main) a chance to flush any
 // per-instance stores. The actual socket teardown is the Server's job.
+//
+// Takes shutdownMu, never mu: a stop request must not queue behind the
+// long-running work it is trying to end.
 func (c *realController) Shutdown(_ context.Context) error {
-	c.mu.Lock()
+	c.shutdownMu.Lock()
 	hook := c.onShutdown
-	c.mu.Unlock()
+	c.shutdownMu.Unlock()
 	if hook != nil {
 		return hook()
 	}
 	return nil
+}
+
+// setShutdownHook installs the flush-and-close hook Shutdown invokes.
+func (c *realController) setShutdownHook(hook func() error) {
+	c.shutdownMu.Lock()
+	c.onShutdown = hook
+	c.shutdownMu.Unlock()
 }

--- a/cmd/gortex/daemon_controller_shutdown_test.go
+++ b/cmd/gortex/daemon_controller_shutdown_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/daemon"
+)
+
+// TestShutdownDoesNotQueueBehindTheControllerMutex is the #370 invariant.
+//
+// The controller mutex is coarse: Track holds it across the whole indexing run,
+// and Reload and every enricher hold it for their duration too — minutes on a
+// large workspace. Shutdown used to take that same mutex just to read the
+// teardown hook, which meant `gortex daemon stop` queued behind exactly the
+// long-running work the user was trying to stop. Stopping has to be the one
+// thing that still works when the daemon is at its least healthy.
+func TestShutdownDoesNotQueueBehindTheControllerMutex(t *testing.T) {
+	c := &realController{}
+	called := make(chan struct{})
+	// Mirror the first thing the daemon's real teardown hook does
+	// (runDaemonStart wires StopWatcher as its opening statement). Reading
+	// the watcher used to require the coarse mutex, which is precisely how
+	// the stop request ended up queued behind the work it was ending — so a
+	// hook that skipped it would certify the wrapper and miss the defect.
+	c.setShutdownHook(func() error {
+		c.StopWatcher()
+		close(called)
+		return nil
+	})
+
+	// Stand in for an in-flight track / reload / enrichment.
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	done := make(chan error, 1)
+	go func() { done <- c.Shutdown(context.Background()) }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Shutdown blocked while the controller mutex was held — a busy daemon cannot be stopped")
+	}
+
+	select {
+	case <-called:
+	default:
+		t.Fatal("the teardown hook never ran")
+	}
+}
+
+// TestWatcherIsReachableWhileTheControllerMutexIsHeld pins the property the
+// teardown hook depends on directly: the watcher pointer must be readable
+// without the coarse mutex. Moving it back onto mu — the shape this replaced —
+// turns this red.
+func TestWatcherIsReachableWhileTheControllerMutexIsHeld(t *testing.T) {
+	c := &realController{}
+	c.AttachWatcher(nil)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		c.StopWatcher()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reading the watcher required the controller mutex")
+	}
+}
+
+// TestStatusHonoursACancelledCaller: Status is the aggregate that sits ahead of
+// `daemon stop`, every `gortex call`, and the agent hooks. Once the caller's
+// budget has expired, finishing a whole-store scan only burns reads nobody
+// reads — and, worse, goes on to queue for the contended mutex.
+func TestStatusHonoursACancelledCaller(t *testing.T) {
+	c := &realController{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := c.Status(ctx)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+// TestDaemonProbeIndeterminate pins the three-state routing decision. Folding
+// "the daemon is busy" into "the daemon does not own this repo" is what made a
+// slow-but-healthy daemon tell users `gortex track <path>` — advice that is
+// both false (the repo IS tracked) and actively harmful (track is the unbounded
+// operation holding the lock in the first place).
+func TestDaemonProbeIndeterminate(t *testing.T) {
+	ok := daemon.ControlResponse{OK: true}
+
+	assert.True(t, daemonProbeIndeterminate(
+		fmt.Errorf("wrapped: %w", daemon.ErrDaemonUnresponsive), daemon.ControlResponse{}),
+		"a client-side deadline means busy, not absent")
+	assert.True(t, daemonProbeIndeterminate(nil,
+		daemon.ControlResponse{ErrorCode: daemon.ErrTimeout}),
+		"the daemon answering 'timeout' means busy too")
+
+	assert.False(t, daemonProbeIndeterminate(nil, ok),
+		"a real answer is never indeterminate")
+	assert.False(t, daemonProbeIndeterminate(daemon.ErrDaemonUnavailable, daemon.ControlResponse{}),
+		"an absent daemon is a real answer: there is nothing to ask")
+	assert.False(t, daemonProbeIndeterminate(nil,
+		daemon.ControlResponse{ErrorCode: daemon.ErrInternal}),
+		"a genuine controller error is a real answer")
+}

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -225,6 +225,39 @@ Four additional push channels modeled on `subscribe_diagnostics` — per-session
 | `subscribe_graph_invalidated` | `notifications/graph_invalidated` — coarse "the graph was rebuilt, drop cached results" signal. `{node_count, edge_count, reason, ts}`; unfiltered |
 | `unsubscribe_graph_invalidated` | Opt back out — idempotent |
 
+## Request lifetime (why a call can never hang)
+
+Every tool call and resource read is bounded, on every transport. A request that
+overruns its budget is **abandoned**: the client gets a terminal, structured
+error and the transport's slot is released immediately, so the session keeps
+serving later requests. The handler itself keeps running — it may be inside a
+store call that cannot be interrupted — so treat any side effect of an abandoned
+call as *unknown* and re-read before assuming it did or did not land.
+
+| Layer | Bound | Knob |
+|---|---|---|
+| Tool call / resource read / prompt fetch (all transports) | 60 s | `GORTEX_MCP_TOOL_TIMEOUT` (Go duration; `off` disables) |
+| Daemon socket, per JSON-RPC request | 60 s, terminal `-32001` | — |
+| Daemon socket, concurrent dispatches | 8 | `GORTEX_MCP_MAX_CONCURRENT_DISPATCHES` (max 64) |
+| Control RPC (`daemon status` / `search_symbols` / `proxy`) | 30 s, terminal `timeout` | — |
+| Control RPC (`shutdown`) | unbounded on the daemon — the store flush precedes the ack. `gortex daemon stop` bounds its own wait at 30 s, then watches the process for up to 2 min and force-kills | — |
+| Control RPC (`track` / `untrack` / `reload` / `enrich_*`) | unbounded by design | — |
+
+The handler bound fires just inside any deadline the transport already imposed,
+so the client receives the tool-shaped diagnosis rather than an opaque transport
+timeout. Track / reload / enrichment are deliberately left unbounded: they are
+long by design, and a user who starts one is waiting on purpose. Shutdown is
+unbounded for a different reason — abandoning a half-done store flush is worse
+than a slow stop — so the *command* carries the bound instead.
+
+`GORTEX_MCP_TOOL_TIMEOUT` is read in the server's own process, so set it in the
+**daemon's** environment (or the `gortex mcp` process for the embedded server),
+not in the MCP client's config. It can always tighten the bound. It can only
+*raise* it past 60 s on the embedded stdio server and Streamable HTTP — on the
+daemon socket the per-request lifetime is a hard 60 s that clamps it. Raise it
+when a tool legitimately runs longer than a minute: a first `index_repository`
+over a very large tree, or `ask` against a slow local model.
+
 ## Coding workflow
 
 | Tool | Description |

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -51,6 +51,13 @@ func DialTo(socketPath string, h Handshake) (*Client, error) {
 	if h.PID == 0 {
 		h.PID = os.Getpid()
 	}
+	// Bound the handshake exchange. The daemon stamps warmup state onto the
+	// ack, so this is a real round trip through the server — a wedged daemon
+	// would otherwise park every dialler here forever, including the
+	// "is the daemon usable?" probes whose whole job is to degrade quickly.
+	// Cleared below: the connection that follows is long-lived (an MCP proxy
+	// relay streams on it for the life of the session).
+	_ = conn.SetDeadline(time.Now().Add(controlHandshakeTimeoutForTest))
 	if err := WriteJSONLine(conn, h); err != nil {
 		_ = conn.Close()
 		return nil, fmt.Errorf("send handshake: %w", err)
@@ -59,8 +66,13 @@ func DialTo(socketPath string, h Handshake) (*Client, error) {
 	ackLine, err := reader.ReadBytes('\n')
 	if err != nil {
 		_ = conn.Close()
+		if isTimeoutErr(err) {
+			return nil, fmt.Errorf("%w: no handshake ack within %s (the daemon is up but not answering — it may be busy indexing; check `gortex daemon status`)",
+				ErrDaemonUnresponsive, controlHandshakeTimeoutForTest)
+		}
 		return nil, fmt.Errorf("read handshake ack: %w", err)
 	}
+	_ = conn.SetDeadline(time.Time{})
 	var ack HandshakeAck
 	if err := json.Unmarshal(ackLine, &ack); err != nil {
 		_ = conn.Close()
@@ -88,7 +100,30 @@ func (c *Client) Close() error {
 
 // Control sends one control request and returns the paired response.
 // Fails if the Client was opened in ModeMCP.
+//
+// The round trip is bounded by ControlTimeoutFor(kind) — status /
+// search_symbols and friends must answer promptly, while track / reload /
+// enrichment and shutdown are allowed to run as long as they need (see
+// ControlTimeoutFor for why shutdown is in that list, and note that
+// `gortex daemon stop` passes its own budget rather than relying on this
+// default). A bounded kind that overruns returns ErrDaemonUnresponsive rather
+// than blocking forever, which is what kept `gortex daemon stop` and
+// `gortex call` wedged behind a busy controller with nothing printed.
 func (c *Client) Control(kind string, params any) (ControlResponse, error) {
+	return c.ControlWithTimeout(kind, params, ControlTimeoutFor(kind))
+}
+
+// ControlWithTimeout is Control with an explicit round-trip budget. Callers on
+// a latency-sensitive path (advisory lookups whose result only decorates output
+// or picks a backend) should pass a short budget and degrade on
+// ErrDaemonUnresponsive instead of making the user wait for a busy daemon.
+//
+// A zero or negative timeout means "no bound", and in that case the connection's
+// own deadline is left untouched — so a caller that manages Conn deadlines
+// itself keeps full control. With a positive timeout the deadline is set for the
+// round trip and cleared afterwards, which would override any deadline the
+// caller had already installed; pass the budget here instead of setting one.
+func (c *Client) ControlWithTimeout(kind string, params any, timeout time.Duration) (ControlResponse, error) {
 	var raw json.RawMessage
 	if params != nil {
 		var err error
@@ -97,19 +132,34 @@ func (c *Client) Control(kind string, params any) (ControlResponse, error) {
 			return ControlResponse{}, fmt.Errorf("marshal params: %w", err)
 		}
 	}
+	if timeout > 0 {
+		_ = c.Conn.SetDeadline(time.Now().Add(timeout))
+		defer func() { _ = c.Conn.SetDeadline(time.Time{}) }()
+	}
 	req := ControlRequest{Kind: kind, Params: raw}
 	if err := WriteJSONLine(c.Conn, req); err != nil {
-		return ControlResponse{}, fmt.Errorf("send control request: %w", err)
+		return ControlResponse{}, c.controlErr(kind, timeout, "send control request", err)
 	}
 	line, err := c.reader.ReadBytes('\n')
 	if err != nil {
-		return ControlResponse{}, fmt.Errorf("read control response: %w", err)
+		return ControlResponse{}, c.controlErr(kind, timeout, "read control response", err)
 	}
 	var resp ControlResponse
 	if err := json.Unmarshal(line, &resp); err != nil {
 		return ControlResponse{}, fmt.Errorf("parse control response: %w", err)
 	}
 	return resp, nil
+}
+
+// controlErr turns a deadline expiry into ErrDaemonUnresponsive with a
+// message that names the likely cause, so the failure is actionable instead
+// of a bare "i/o timeout".
+func (c *Client) controlErr(kind string, timeout time.Duration, stage string, err error) error {
+	if isTimeoutErr(err) {
+		return fmt.Errorf("%w: %q got no response within %s (the daemon is up but not answering — a long track / reload / enrichment may be holding it; check `gortex daemon status`)",
+			ErrDaemonUnresponsive, kind, timeout)
+	}
+	return fmt.Errorf("%s: %w", stage, err)
 }
 
 // WriteMCPFrame writes a raw MCP JSON-RPC frame to the daemon. Caller is
@@ -158,6 +208,23 @@ var ErrDaemonUnavailable = errors.New("daemon unavailable")
 // the embedded in-process server rather than fail, so an in-flight editor
 // session keeps working across a version skew.
 var ErrProtocolVersionMismatch = errors.New("daemon protocol version mismatch")
+
+// ErrDaemonUnresponsive is returned when the daemon accepted the connection
+// but did not answer inside the request's budget. It is deliberately distinct
+// from ErrDaemonUnavailable: the daemon is running and holding its store lock,
+// so falling back to an embedded server or a fresh start is *not* automatically
+// safe — the caller has to decide whether to degrade, retry, or report.
+var ErrDaemonUnresponsive = errors.New("daemon unresponsive")
+
+// controlHandshakeTimeoutForTest is ControlHandshakeTimeout as a var so the
+// liveness tests can exercise the stall path without a ten-second wait.
+var controlHandshakeTimeoutForTest = ControlHandshakeTimeout
+
+// isTimeoutErr reports whether err is a socket deadline expiry.
+func isTimeoutErr(err error) bool {
+	var ne net.Error
+	return errors.As(err, &ne) && ne.Timeout()
+}
 
 // ShouldFallBackToEmbedded reports whether a Dial error is one the MCP proxy
 // can recover from by running the embedded in-process server instead: the

--- a/internal/daemon/control_lifetime_test.go
+++ b/internal/daemon/control_lifetime_test.go
@@ -1,0 +1,297 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// blockingController blocks Status (and Shutdown) until released, standing in
+// for the real controller's coarse mutex being held by a minutes-long
+// track / reload / enrichment.
+type blockingController struct {
+	fakeController
+	release chan struct{}
+	entered chan struct{}
+}
+
+func newBlockingController() *blockingController {
+	return &blockingController{
+		release: make(chan struct{}),
+		entered: make(chan struct{}, 8),
+	}
+}
+
+func (b *blockingController) Status(ctx context.Context) (StatusResponse, error) {
+	select {
+	case b.entered <- struct{}{}:
+	default:
+	}
+	select {
+	case <-b.release:
+		return b.fakeController.Status(ctx)
+	case <-time.After(30 * time.Second):
+		return StatusResponse{}, errors.New("blockingController: test did not release in time")
+	}
+}
+
+// TestControlTimeoutPolicy pins which kinds may run long. Getting this wrong in
+// either direction is a user-visible regression: bounding track would abort an
+// index the user deliberately started, and leaving status unbounded is the
+// defect itself.
+func TestControlTimeoutPolicy(t *testing.T) {
+	for _, kind := range []string{
+		ControlTrack, ControlUntrack, ControlReload, ControlShutdown,
+		ControlEnrichChurn, ControlEnrichReleases, ControlEnrichBlame,
+		ControlEnrichCoverage, ControlEnrichCochange,
+	} {
+		assert.Zerof(t, ControlTimeoutFor(kind), "%s must stay unbounded — it is long by design", kind)
+	}
+	for _, kind := range []string{ControlStatus, ControlSearchSymbols, ControlProxy} {
+		assert.Equalf(t, DefaultControlTimeout, ControlTimeoutFor(kind),
+			"%s sits on the critical path of ordinary commands and must be bounded", kind)
+	}
+}
+
+// TestShutdownTearsDownEvenWhenTheAckCannotBeDelivered: the stop command now
+// bounds its own wait, so a client that gives up on a slow flush is an ordinary
+// event. The daemon must still go down — a daemon that flushed its store and
+// then kept running would hold the on-disk lock the next `daemon start` needs.
+func TestShutdownTearsDownEvenWhenTheAckCannotBeDelivered(t *testing.T) {
+	ctrl := &fakeController{}
+	srv, socket := newDaemon(t, ctrl)
+
+	c, err := DialTo(socket, Handshake{Mode: ModeControl, ClientName: "cli"})
+	require.NoError(t, err)
+
+	// Send the request, then vanish before the ack can be written.
+	require.NoError(t, WriteJSONLine(c.Conn, ControlRequest{Kind: ControlShutdown}))
+	_ = c.Conn.Close()
+
+	require.Eventually(t, func() bool { return !IsRunningAt(socket) },
+		5*time.Second, 20*time.Millisecond,
+		"the daemon must tear down even when the shutdown ack could not be delivered")
+	_ = srv
+}
+
+// TestControlRequestTimesOutInsteadOfHanging is the #370 server-side contract:
+// a controller wedged behind its own lock must produce a terminal response, not
+// an open-ended silence.
+func TestControlRequestTimesOutInsteadOfHanging(t *testing.T) {
+	ctrl := newBlockingController()
+	srv, socket := newDaemon(t, ctrl)
+	srv.ControlTimeout = 150 * time.Millisecond
+	defer close(ctrl.release)
+
+	c, err := DialTo(socket, Handshake{Mode: ModeControl, ClientName: "cli"})
+	require.NoError(t, err)
+	defer c.Close()
+
+	start := time.Now()
+	resp, err := c.ControlWithTimeout(ControlStatus, nil, 5*time.Second)
+	require.NoError(t, err, "the daemon must answer, not drop the request")
+	assert.False(t, resp.OK)
+	assert.Equal(t, ErrTimeout, resp.ErrorCode,
+		"a busy controller must be reported as busy, not as an internal error")
+	assert.Contains(t, resp.ErrorMsg, "daemon status",
+		"the error must tell the user what to do next")
+	assert.Less(t, time.Since(start), 3*time.Second, "response must arrive on the server's budget")
+}
+
+// TestControlSurvivesAWedgedRequest guards the property that actually rescues a
+// user: one stuck control request must not poison the connection. `gortex
+// daemon stop` has to work while `daemon status` is wedged.
+func TestControlSurvivesAWedgedRequest(t *testing.T) {
+	ctrl := newBlockingController()
+	srv, socket := newDaemon(t, ctrl)
+	srv.ControlTimeout = 150 * time.Millisecond
+	defer close(ctrl.release)
+
+	c, err := DialTo(socket, Handshake{Mode: ModeControl, ClientName: "cli"})
+	require.NoError(t, err)
+	defer c.Close()
+
+	resp, err := c.ControlWithTimeout(ControlStatus, nil, 5*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, ErrTimeout, resp.ErrorCode)
+
+	// Same connection, immediately after: a kind the controller does not block
+	// on must still be served.
+	resp, err = c.ControlWithTimeout(ControlSearchSymbols, SearchSymbolsParams{Query: "x"}, 5*time.Second)
+	require.NoError(t, err)
+	assert.True(t, resp.OK, "the session must stay usable after a timed-out request: %+v", resp)
+}
+
+// TestClientControlReportsUnresponsiveDaemon is the #370 client-side contract.
+// The daemon here accepts and acks the handshake and then goes silent — the
+// shape of a daemon whose controller is wedged. Before this, the CLI blocked in
+// ReadBytes forever with nothing printed; `gortex daemon stop` "hanging
+// indefinitely (tested up to 5 minutes)" is exactly this read.
+func TestClientControlReportsUnresponsiveDaemon(t *testing.T) {
+	socket := silentDaemon(t)
+
+	c, err := DialTo(socket, Handshake{Mode: ModeControl, ClientName: "cli"})
+	require.NoError(t, err, "the handshake must still complete — only the control call goes unanswered")
+	defer c.Close()
+
+	start := time.Now()
+	_, err = c.ControlWithTimeout(ControlShutdown, nil, 200*time.Millisecond)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrDaemonUnresponsive)
+	assert.NotErrorIs(t, err, ErrDaemonUnavailable,
+		"an unresponsive daemon still holds the store lock — it must not be mistaken for an absent one")
+	assert.Contains(t, err.Error(), "daemon status")
+	assert.Less(t, time.Since(start), 5*time.Second)
+}
+
+// TestDialReportsUnresponsiveDaemonOnHandshake covers the earlier failure
+// point: a daemon that accepts the connection but never acks. The handshake ack
+// is a real round trip through the server, so it stalls too.
+func TestDialReportsUnresponsiveDaemonOnHandshake(t *testing.T) {
+	ln := listenShort(t)
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			// Accept and hold: never read, never ack.
+			t.Cleanup(func() { _ = conn.Close() })
+		}
+	}()
+
+	prev := controlHandshakeTimeoutForTest
+	controlHandshakeTimeoutForTest = 200 * time.Millisecond
+	t.Cleanup(func() { controlHandshakeTimeoutForTest = prev })
+
+	start := time.Now()
+	_, err := DialTo(ln.Addr().String(), Handshake{Mode: ModeControl, ClientName: "cli"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrDaemonUnresponsive)
+	assert.Less(t, time.Since(start), 5*time.Second)
+}
+
+// silentDaemon accepts connections, completes the handshake, then never
+// answers a control request.
+func silentDaemon(t *testing.T) string {
+	t.Helper()
+	ln := listenShort(t)
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(conn net.Conn) {
+				defer func() { _ = conn.Close() }()
+				buf := make([]byte, 4096)
+				if _, err := conn.Read(buf); err != nil {
+					return
+				}
+				ack, _ := json.Marshal(HandshakeAck{OK: true, SessionID: "silent", DaemonVersion: "test"})
+				_, _ = conn.Write(append(ack, '\n'))
+				// Drain forever without replying.
+				for {
+					if _, err := conn.Read(buf); err != nil {
+						return
+					}
+				}
+			}(conn)
+		}
+	}()
+	return ln.Addr().String()
+}
+
+// listenShort mints a unix listener under a short path — macOS caps sun_path
+// at ~104 bytes and t.TempDir() with a long test name blows past it.
+func listenShort(t *testing.T) net.Listener {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "gx")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	ln, err := net.Listen("unix", filepath.Join(dir, "s"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+	return ln
+}
+
+// TestHandleControlBoundedTimesOutWithoutASocket pins the timeout branch
+// directly — no listener, no connection, a nil session — so the ErrTimeout
+// response is attributable to handleControlBounded itself rather than to
+// anything the transport does.
+func TestHandleControlBoundedTimesOutWithoutASocket(t *testing.T) {
+	ctrl := newBlockingController()
+	defer close(ctrl.release)
+	srv := New("unused", "test", zap.NewNop())
+	srv.Controller = ctrl
+	srv.ControlTimeout = 50 * time.Millisecond
+	resp := srv.handleControlBounded(nil, ControlRequest{Kind: ControlStatus})
+	assert.Equal(t, ErrTimeout, resp.ErrorCode)
+}
+
+// blockingTrackController blocks Track — an unbounded kind — so the dispatch
+// branch that runs unbounded kinds inline can be pinned.
+type blockingTrackController struct {
+	fakeController
+	release chan struct{}
+	entered chan struct{}
+}
+
+func (b *blockingTrackController) Track(ctx context.Context, p TrackParams) (json.RawMessage, error) {
+	select {
+	case b.entered <- struct{}{}:
+	default:
+	}
+	select {
+	case <-b.release:
+		return b.fakeController.Track(ctx, p)
+	case <-time.After(30 * time.Second):
+		return nil, errors.New("blockingTrackController: test did not release in time")
+	}
+}
+
+// TestUnboundedKindsAreNotClamped is the other half of the timeout policy. The
+// bound exists to stop status-shaped calls hanging; clamping a track would abort
+// an index the user deliberately started, which is a worse bug than the one
+// being fixed. Server.ControlTimeout must not reach the unbounded kinds.
+func TestUnboundedKindsAreNotClamped(t *testing.T) {
+	ctrl := &blockingTrackController{
+		release: make(chan struct{}),
+		entered: make(chan struct{}, 1),
+	}
+	srv, socket := newDaemon(t, ctrl)
+	srv.ControlTimeout = 100 * time.Millisecond
+
+	c, err := DialTo(socket, Handshake{Mode: ModeControl, ClientName: "cli"})
+	require.NoError(t, err)
+	defer c.Close()
+
+	done := make(chan ControlResponse, 1)
+	go func() {
+		resp, _ := c.ControlWithTimeout(ControlTrack, TrackParams{Path: "/tmp/myapp"}, 10*time.Second)
+		done <- resp
+	}()
+
+	<-ctrl.entered
+	// Well past the (deliberately tiny) bounded-kind budget: a track must still
+	// be running, not cut off.
+	select {
+	case resp := <-done:
+		t.Fatalf("track was clamped by the bounded-kind budget: %+v", resp)
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	close(ctrl.release)
+	resp := <-done
+	assert.True(t, resp.OK, "track must complete normally once it finishes: %+v", resp)
+	assert.Contains(t, string(resp.Result), "/tmp/myapp")
+}

--- a/internal/daemon/proto.go
+++ b/internal/daemon/proto.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"time"
 )
 
 // ProtocolVersion is the daemon wire-protocol version. Both ends of a
@@ -92,6 +93,12 @@ const (
 	ErrUnsupportedMode  = "unsupported_mode"
 	ErrRepoNotTracked   = "repo_not_tracked"
 	ErrInternal         = "internal"
+	// ErrTimeout means the daemon accepted the control request but did not
+	// finish it inside the kind's budget — almost always because a
+	// minutes-long track / reload / enrichment is holding the controller
+	// mutex. Distinct from ErrInternal so a caller can retry or degrade
+	// instead of treating a busy daemon as a broken one.
+	ErrTimeout = "timeout"
 )
 
 // ControlRequest is the envelope for every message sent in ModeControl.
@@ -147,6 +154,46 @@ const (
 	// co-change edge mining against the daemon's in-process graph.
 	ControlEnrichCochange = "enrich_cochange"
 )
+
+// DefaultControlTimeout bounds the control kinds that are supposed to answer
+// promptly. It is deliberately generous: a busy daemon can take seconds to
+// aggregate status over a 20-repo workspace, and a bound that fires during
+// normal load would be worse than none. What it rules out is the unbounded
+// case — a controller wedged behind a minutes-long track / reload / enrichment
+// leaving `gortex daemon stop`, `gortex daemon status` and every `gortex call`
+// blocked forever with no output and no error.
+const DefaultControlTimeout = 30 * time.Second
+
+// ControlHandshakeTimeout bounds the handshake exchange. The daemon stamps
+// warmup state onto the ack, so the ack read is a real round trip that a
+// wedged daemon can stall; without a bound every caller — including the
+// liveness probes that are supposed to degrade gracefully — blocks forever.
+const ControlHandshakeTimeout = 10 * time.Second
+
+// ControlTimeoutFor reports the round-trip budget for one control kind, or 0
+// for kinds with no bound. Client and daemon both consult it so the two ends
+// agree on which requests are allowed to run long.
+//
+// Track / untrack / reload / enrich_* legitimately run for many minutes on a
+// large workspace — bounding them would break the operations users start on
+// purpose. Everything else is a status/lifecycle call on the critical path of
+// ordinary commands and must never be able to hang.
+//
+// Shutdown is unbounded too, for a different reason: the daemon flushes and
+// closes its store *before* acking, and abandoning that flush half-done is
+// worse than a slow stop. The stop command bounds its own wait instead and
+// falls through to waiting for the process to exit, so the user is never left
+// blocked either way.
+func ControlTimeoutFor(kind string) time.Duration {
+	switch kind {
+	case ControlTrack, ControlUntrack, ControlReload, ControlShutdown,
+		ControlEnrichChurn, ControlEnrichReleases, ControlEnrichBlame,
+		ControlEnrichCoverage, ControlEnrichCochange:
+		return 0
+	default:
+		return DefaultControlTimeout
+	}
+}
 
 // TrackParams is the payload for ControlTrack.
 type TrackParams struct {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -40,6 +40,13 @@ type Server struct {
 	// MCPToolCallTimeout bounds individual tools/call dispatches. Zero uses DefaultMCPToolCallTimeout.
 	MCPToolCallTimeout time.Duration
 
+	// ControlTimeout overrides the budget applied to bounded control kinds
+	// (see ControlTimeoutFor). Zero uses the per-kind default. Kinds that are
+	// unbounded by policy — track / reload / enrich_* — stay unbounded
+	// regardless: this tunes how long "should be quick" is allowed to take,
+	// it does not put a clock on work the user deliberately started.
+	ControlTimeout time.Duration
+
 	// Controller handles control-mode RPCs (track/untrack/reload/status/shutdown).
 	Controller Controller
 
@@ -559,24 +566,66 @@ func (s *Server) serveControl(conn net.Conn, reader *bufio.Reader, sess *Session
 			})
 			continue
 		}
-		resp := s.handleControl(sess, req)
-		if err := WriteJSONLine(conn, resp); err != nil {
-			return
-		}
+		resp := s.handleControlBounded(sess, req)
+		writeErr := WriteJSONLine(conn, resp)
 		if req.Kind == ControlShutdown && resp.OK {
-			// Give the client one more moment to flush the ack before the
-			// listener goes away, then stop.
+			// Scheduled regardless of whether the ack reached the client. The
+			// controller flushes and closes the store before answering, so a
+			// client that gave up waiting (or died) has already left by the
+			// time we get here — and skipping the teardown on a failed write
+			// would leave a daemon that flushed its store and then kept
+			// running, holding the on-disk lock the next start needs.
+			//
+			// The short delay gives a client that IS still listening a moment
+			// to read the ack before the listener goes away.
 			go func() {
 				time.Sleep(100 * time.Millisecond)
 				_ = s.Shutdown()
 			}()
 			return
 		}
+		if writeErr != nil {
+			return
+		}
 	}
 }
 
-func (s *Server) handleControl(_ *Session, req ControlRequest) ControlResponse {
-	ctx := context.Background()
+// handleControlBounded runs one control request under the kind's budget (see
+// ControlTimeoutFor). Handlers that block past it — the common case being a
+// controller mutex held for the length of a track / reload / enrichment — are
+// abandoned rather than waited on, so the caller gets a terminal ErrTimeout
+// response instead of an open-ended silence. The abandoned handler keeps
+// running and completes normally; only this connection's turn is given back.
+//
+// Unbounded kinds (track / reload / enrich_*) run inline, exactly as before:
+// they are long by design and a caller that starts one is waiting on purpose.
+func (s *Server) handleControlBounded(sess *Session, req ControlRequest) ControlResponse {
+	budget := ControlTimeoutFor(req.Kind)
+	if budget > 0 && s.ControlTimeout > 0 {
+		budget = s.ControlTimeout
+	}
+	if budget <= 0 {
+		return s.handleControl(context.Background(), sess, req)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), budget)
+	defer cancel()
+
+	done := make(chan ControlResponse, 1)
+	go func() { done <- s.handleControl(ctx, sess, req) }()
+
+	select {
+	case resp := <-done:
+		return resp
+	case <-ctx.Done():
+		s.Logger.Warn("daemon: control request exceeded its budget",
+			zap.String("kind", req.Kind), zap.Duration("budget", budget))
+		return controlErr(ErrTimeout, fmt.Sprintf(
+			"control request %q did not complete within %s; the daemon is busy (a track / reload / enrichment may be holding the controller) — retry, or run `gortex daemon status` for progress",
+			req.Kind, budget))
+	}
+}
+
+func (s *Server) handleControl(ctx context.Context, _ *Session, req ControlRequest) ControlResponse {
 	switch req.Kind {
 	case ControlTrack:
 		var p TrackParams

--- a/internal/hooks/probe.go
+++ b/internal/hooks/probe.go
@@ -47,14 +47,24 @@ func probeViaDaemon(pattern string, timeout time.Duration) ([]grepSymbolHit, err
 		}
 		defer client.Close()
 
-		// Cap each socket op at the remaining budget so a stuck daemon
-		// can't pin the goroutine past timeout.
-		_ = client.Conn.SetDeadline(deadline)
-
-		resp, err := client.Control(daemon.ControlSearchSymbols, daemon.SearchSymbolsParams{
+		// Cap the round trip at the remaining budget so a stuck daemon
+		// can't pin the goroutine past timeout. Passed explicitly rather
+		// than left to Control's default: a hook runs on the agent's
+		// critical path and its budget is far tighter than the default.
+		//
+		// The clamp matters: a non-positive budget means "no bound" to
+		// ControlWithTimeout, so handing it a window the dial already
+		// consumed would turn the tightest caller in the tree into the
+		// only unbounded one.
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			done <- probeResult{err: fmt.Errorf("daemon probe budget exhausted before the search rpc")}
+			return
+		}
+		resp, err := client.ControlWithTimeout(daemon.ControlSearchSymbols, daemon.SearchSymbolsParams{
 			Query: pattern,
 			Limit: 10,
-		})
+		}, remaining)
 		if err != nil {
 			done <- probeResult{err: fmt.Errorf("control rpc: %w", err)}
 			return

--- a/internal/hooks/sessionstart.go
+++ b/internal/hooks/sessionstart.go
@@ -94,9 +94,9 @@ func fetchDaemonStatus() (*daemon.StatusResponse, error) {
 	}
 	defer client.Close()
 
-	_ = client.Conn.SetDeadline(time.Now().Add(2 * time.Second))
-
-	resp, err := client.Control(daemon.ControlStatus, nil)
+	// Explicit budget: a session-start hook must degrade fast, well inside
+	// Control's default, so a busy daemon delays nothing the user sees.
+	resp, err := client.ControlWithTimeout(daemon.ControlStatus, nil, 2*time.Second)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mcp/overlay.go
+++ b/internal/mcp/overlay.go
@@ -87,7 +87,11 @@ func (s *Server) wrapToolHandlerMode(h mcpserver.ToolHandlerFunc, injectOverlay 
 	// Prompt-injection screening sits closest to the handler so it
 	// sees the real arguments and the real result (see sanitize.go).
 	h = s.sanitizeToolHandler(h)
-	return func(ctx context.Context, req mcp.CallToolRequest) (res *mcp.CallToolResult, retErr error) {
+	// The hang firewall is the OUTERMOST layer (applied last, at the bottom
+	// of this function) so it bounds the whole middleware chain, not just the
+	// leaf handler — the overlay build, the freshness sweep, and the response
+	// capture below all touch the graph and can block on the same locks.
+	return s.boundToolHandler(func(ctx context.Context, req mcp.CallToolRequest) (res *mcp.CallToolResult, retErr error) {
 		beginMCPToolCall()
 		defer func() {
 			endMCPToolCall(s.logger, req.Params.Name)
@@ -194,7 +198,7 @@ func (s *Server) wrapToolHandlerMode(h mcpserver.ToolHandlerFunc, injectOverlay 
 			res = s.maybeAttachMomentumNote(ctx, req.Params.Name, res)
 		}
 		return res, hErr
-	}
+	})
 }
 
 // errBaseSHADrift is the structured drift error returned by the

--- a/internal/mcp/prompts.go
+++ b/internal/mcp/prompts.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (s *Server) registerPrompts() {
-	s.mcpServer.AddPrompt(
+	s.addPrompt(
 		mcp.NewPrompt("pre_commit",
 			mcp.WithPromptDescription("Review uncommitted changes before committing. Shows changed symbols, blast radius, risk level, affected tests, and run commands."),
 			mcp.WithArgument("scope",
@@ -25,14 +25,14 @@ func (s *Server) registerPrompts() {
 		s.handlePromptPreCommit,
 	)
 
-	s.mcpServer.AddPrompt(
+	s.addPrompt(
 		mcp.NewPrompt("orientation",
 			mcp.WithPromptDescription("Orient in an unfamiliar codebase. Shows graph stats, functional communities, execution flows, and key symbols."),
 		),
 		s.handlePromptOrientation,
 	)
 
-	s.mcpServer.AddPrompt(
+	s.addPrompt(
 		mcp.NewPrompt("safe_to_change",
 			mcp.WithPromptDescription("Analyze whether it's safe to change specific symbols. Shows blast radius, edit plan, affected tests, and risk level."),
 			mcp.WithArgument("ids",

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -11,7 +11,7 @@ import (
 
 func (s *Server) registerResources() {
 	// Session state: survives context compaction.
-	s.mcpServer.AddResource(
+	s.addResource(
 		mcp.NewResource(
 			"gortex://session",
 			"Session State",
@@ -24,7 +24,7 @@ func (s *Server) registerResources() {
 	// Static resource: graph stats (session start orientation). Same
 	// payload as the `graph_stats` tool — kept as a tool too for
 	// back-compat with clients that don't speak resources.
-	s.mcpServer.AddResource(
+	s.addResource(
 		mcp.NewResource(
 			"gortex://stats",
 			"Graph Statistics",
@@ -35,7 +35,7 @@ func (s *Server) registerResources() {
 	)
 
 	// Static resource: graph schema reference.
-	s.mcpServer.AddResource(
+	s.addResource(
 		mcp.NewResource(
 			"gortex://schema",
 			"Graph Schema",
@@ -49,7 +49,7 @@ func (s *Server) registerResources() {
 	// content that used to be pre-paid in the installed CLAUDE.md section —
 	// the LLM-provider matrix, capabilities catalog, token-economy detail,
 	// resources list, and pointers into the analyze / search_ast catalogs.
-	s.mcpServer.AddResource(
+	s.addResource(
 		mcp.NewResource(
 			"gortex://guide",
 			"Gortex Guide",
@@ -60,7 +60,7 @@ func (s *Server) registerResources() {
 	)
 
 	// Template resource: a single guide section by topic keyword.
-	s.mcpServer.AddResourceTemplate(
+	s.addResourceTemplate(
 		mcp.NewResourceTemplate(
 			"gortex://guide/{topic}",
 			"Gortex Guide Section",
@@ -80,7 +80,7 @@ func (s *Server) registerResources() {
 	s.registerAnalyzerResources()
 
 	// Template resources: communities and processes (dynamic, parameterized).
-	s.mcpServer.AddResourceTemplate(
+	s.addResourceTemplate(
 		mcp.NewResourceTemplate(
 			"gortex://communities",
 			"Communities",
@@ -90,7 +90,7 @@ func (s *Server) registerResources() {
 		s.handleResourceCommunities,
 	)
 
-	s.mcpServer.AddResourceTemplate(
+	s.addResourceTemplate(
 		mcp.NewResourceTemplate(
 			"gortex://community/{id}",
 			"Community Detail",
@@ -100,7 +100,7 @@ func (s *Server) registerResources() {
 		s.handleResourceCommunity,
 	)
 
-	s.mcpServer.AddResourceTemplate(
+	s.addResourceTemplate(
 		mcp.NewResourceTemplate(
 			"gortex://processes",
 			"Processes",
@@ -110,7 +110,7 @@ func (s *Server) registerResources() {
 		s.handleResourceProcesses,
 	)
 
-	s.mcpServer.AddResourceTemplate(
+	s.addResourceTemplate(
 		mcp.NewResourceTemplate(
 			"gortex://process/{id}",
 			"Process Detail",

--- a/internal/mcp/resources_analyzer.go
+++ b/internal/mcp/resources_analyzer.go
@@ -22,7 +22,7 @@ import (
 // (top-N, summary counts) — agents that need the full analyzer output
 // fall back to the corresponding `analyze` tool invocation.
 func (s *Server) registerAnalyzerResources() {
-	s.mcpServer.AddResource(
+	s.addResource(
 		mcp.NewResource(
 			"gortex://report",
 			"Orientation Report",
@@ -32,7 +32,7 @@ func (s *Server) registerAnalyzerResources() {
 		s.handleResourceReport,
 	)
 
-	s.mcpServer.AddResource(
+	s.addResource(
 		mcp.NewResource(
 			"gortex://god-nodes",
 			"God Nodes",
@@ -42,7 +42,7 @@ func (s *Server) registerAnalyzerResources() {
 		s.handleResourceGodNodes,
 	)
 
-	s.mcpServer.AddResource(
+	s.addResource(
 		mcp.NewResource(
 			"gortex://surprises",
 			"Codebase Surprises",
@@ -52,7 +52,7 @@ func (s *Server) registerAnalyzerResources() {
 		s.handleResourceSurprises,
 	)
 
-	s.mcpServer.AddResource(
+	s.addResource(
 		mcp.NewResource(
 			"gortex://audit",
 			"Agent Config Audit",
@@ -62,7 +62,7 @@ func (s *Server) registerAnalyzerResources() {
 		s.handleResourceAudit,
 	)
 
-	s.mcpServer.AddResource(
+	s.addResource(
 		mcp.NewResource(
 			"gortex://questions",
 			"Open Questions",

--- a/internal/mcp/resources_bootstrap.go
+++ b/internal/mcp/resources_bootstrap.go
@@ -17,7 +17,7 @@ import (
 // registered. Client support for resources is patchier than tools —
 // keeping the tool form alive avoids regressing those clients.
 func (s *Server) registerBootstrapResources() {
-	s.mcpServer.AddResource(
+	s.addResource(
 		mcp.NewResource(
 			"gortex://index-health",
 			"Index Health",
@@ -27,7 +27,7 @@ func (s *Server) registerBootstrapResources() {
 		s.handleResourceIndexHealth,
 	)
 
-	s.mcpServer.AddResource(
+	s.addResource(
 		mcp.NewResource(
 			"gortex://workspace",
 			"Workspace Info",
@@ -37,7 +37,7 @@ func (s *Server) registerBootstrapResources() {
 		s.handleResourceWorkspace,
 	)
 
-	s.mcpServer.AddResource(
+	s.addResource(
 		mcp.NewResource(
 			"gortex://repos",
 			"Workspace Repos",
@@ -47,7 +47,7 @@ func (s *Server) registerBootstrapResources() {
 		s.handleResourceRepos,
 	)
 
-	s.mcpServer.AddResource(
+	s.addResource(
 		mcp.NewResource(
 			"gortex://active-project",
 			"Active Project",
@@ -58,8 +58,11 @@ func (s *Server) registerBootstrapResources() {
 	)
 }
 
-func (s *Server) handleResourceIndexHealth(_ context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
-	payload := s.buildIndexHealthPayload()
+func (s *Server) handleResourceIndexHealth(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+	payload, err := s.buildIndexHealthPayloadCtx(ctx)
+	if err != nil {
+		return nil, err
+	}
 	if payload == nil {
 		payload = map[string]any{
 			"error": "no indexer available",

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -411,6 +411,13 @@ type Server struct {
 	// NewServer; on by default.
 	sanitizeInjection bool
 
+	// ToolCallTimeout overrides the per-tool-call deadline enforced by the
+	// hang firewall (see tool_deadline.go). Zero takes the value from
+	// GORTEX_MCP_TOOL_TIMEOUT, falling back to DefaultToolCallTimeout;
+	// negative disables the bound. Exported so tests and embedders can
+	// tighten it without touching the environment.
+	ToolCallTimeout time.Duration
+
 	// llmService is the optional LLM service backing the `ask` MCP tool
 	// and the `search_symbols` assist modes. nil until SetLLMService is
 	// called by the daemon entrypoint. The service wraps whichever

--- a/internal/mcp/tool_deadline.go
+++ b/internal/mcp/tool_deadline.go
@@ -1,0 +1,294 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+
+	"fmt"
+	"os"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	"go.uber.org/zap"
+)
+
+// DefaultToolCallTimeout bounds how long one tool handler may occupy its
+// transport before the call is answered with a terminal error. It matches the
+// daemon socket's per-request budget (daemon.DefaultMCPToolCallTimeout) so a
+// tool behaves the same however it was reached: over the daemon socket, over
+// Streamable HTTP, or through the embedded stdio server.
+//
+// Parity is the point. The daemon path has had a request lifetime for a while;
+// the embedded path — `gortex mcp` with no daemon available — had none, because
+// mcp-go's stdio server hands every handler the *server-lifetime* context. One
+// handler blocked on a lock therefore held its worker forever, and once the
+// worker pool and its queue were exhausted mcp-go falls back to running tool
+// calls inline on the read loop, at which point the session stops reading stdin
+// and every later request — including ones that would have answered instantly —
+// hangs with no output and no error.
+const DefaultToolCallTimeout = 60 * time.Second
+
+// ToolCallTimeoutEnv overrides DefaultToolCallTimeout with any Go duration.
+// "0" / "off" disables the bound for operators who would rather have a call
+// hang than be cut off (long analyze / ask runs on a slow box).
+const ToolCallTimeoutEnv = "GORTEX_MCP_TOOL_TIMEOUT"
+
+// maxAbandonedToolCalls caps how many timed-out handlers may still be running
+// in the background. Abandoning a stuck handler frees the transport, but the
+// goroutine lives on until whatever it is blocked on clears; without a cap a
+// permanently wedged subsystem would accumulate one goroutine per retry
+// forever. Past the cap new calls fail fast with a diagnosis instead, which is
+// the honest answer — the server genuinely cannot serve them.
+const maxAbandonedToolCalls = 64
+
+// abandonedToolCalls counts handlers that outran their budget and are still
+// running detached. Process-wide: the limit is about total leaked work, and a
+// wedged store affects every session at once.
+var abandonedToolCalls atomic.Int64
+
+// AbandonedToolCalls reports how many tool handlers outran their deadline and
+// are still running. Non-zero means some subsystem is blocking — it is the
+// signal that distinguishes "this one tool is slow" from "the server is stuck".
+func AbandonedToolCalls() int64 { return abandonedToolCalls.Load() }
+
+// transportDeadlineMargin is how far ahead of an inherited transport deadline
+// the handler bound fires. Without it the two deadlines race and the client
+// sometimes gets a bare JSON-RPC transport error instead of the tool-shaped
+// result that tells an agent what happened and what to do next.
+const transportDeadlineMargin = time.Second
+
+// toolCallTimeout resolves the effective per-call budget.
+func (s *Server) toolCallTimeout() time.Duration {
+	if s != nil && s.ToolCallTimeout != 0 {
+		return s.ToolCallTimeout
+	}
+	return toolCallTimeoutFromEnv()
+}
+
+func toolCallTimeoutFromEnv() time.Duration {
+	raw := strings.TrimSpace(os.Getenv(ToolCallTimeoutEnv))
+	if raw == "" {
+		return DefaultToolCallTimeout
+	}
+	switch strings.ToLower(raw) {
+	case "0", "off", "false", "none":
+		return 0
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		return DefaultToolCallTimeout
+	}
+	return d
+}
+
+// boundToolHandler is the hang firewall: the liveness counterpart to the panic
+// firewall in wrapToolHandlerMode. A panic in one handler used to take down
+// every session's transport; so does a hang, just more quietly. Both are
+// contained at the same chokepoint so every tool on every transport inherits
+// the protection.
+//
+// On expiry the caller gets a terminal, structured tool error and the
+// transport's slot is returned immediately. The handler keeps running on its
+// own goroutine — it may be inside a store call that cannot be interrupted —
+// but it no longer owns the client's turn, so the session stays responsive and
+// the next request is served normally.
+//
+// The derived context is cancelled on the way out, so handlers that *do* watch
+// their context unwind promptly rather than finishing work nobody will read.
+//
+// boundHandler is the shared core; the three callable surfaces (tools,
+// resources, prompts) differ only in how they render "abandoned" — a tool call
+// carries it as an in-band error result, a resource read and a prompt fetch as
+// a JSON-RPC error.
+func boundHandler[Req, Res any](
+	s *Server,
+	kind, name string,
+	h func(context.Context, Req) (Res, error),
+	busy func(stuck int64, timeout time.Duration) (Res, error),
+	expired func(timeout time.Duration) (Res, error),
+	panicked func(recovered any) (Res, error),
+) func(context.Context, Req) (Res, error) {
+	return func(ctx context.Context, req Req) (Res, error) {
+		timeout := s.toolCallTimeout()
+		if timeout <= 0 {
+			return h(ctx, req)
+		}
+		// Fire just inside any deadline the transport already imposed (the
+		// daemon socket's per-request lifetime), so the client receives this
+		// diagnosis rather than the transport's opaque timeout.
+		if deadline, ok := ctx.Deadline(); ok {
+			if remaining := time.Until(deadline) - transportDeadlineMargin; remaining < timeout {
+				timeout = remaining
+			}
+			if timeout <= 0 {
+				return h(ctx, req)
+			}
+		}
+
+		if stuck := abandonedToolCalls.Load(); stuck >= maxAbandonedToolCalls {
+			return busy(stuck, timeout)
+		}
+
+		callCtx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+
+		type outcome struct {
+			res Res
+			err error
+		}
+		// Buffered: the detached handler must be able to finish and exit even
+		// after this frame has returned, or abandoning a call would leak a
+		// goroutine blocked on an unread channel — a second leak on top of the
+		// one we are already tolerating.
+		done := make(chan outcome, 1)
+		started := time.Now()
+		go func() {
+			// Panic firewall. Moving the handler onto its own goroutine takes
+			// it out from under whatever recover the transport provided, so it
+			// has to bring its own — otherwise one panicking handler takes down
+			// the process instead of the request. (Tool handlers also carry the
+			// firewall in wrapToolHandlerMode; this covers the rest, and
+			// double-recovering is harmless.)
+			defer func() {
+				if r := recover(); r != nil {
+					if s != nil && s.logger != nil {
+						s.logger.Error("mcp: handler panic recovered",
+							zap.String("kind", kind), zap.String("name", name),
+							zap.Any("panic", r), zap.Stack("stack"))
+					}
+					done <- func() outcome {
+						res, err := panicked(r)
+						return outcome{res: res, err: err}
+					}()
+				}
+			}()
+			res, err := h(callCtx, req)
+			done <- outcome{res: res, err: err}
+		}()
+
+		select {
+		case got := <-done:
+			return got.res, got.err
+		case <-callCtx.Done():
+			if ctx.Err() != nil {
+				// The *caller* went away (client cancelled, or the transport's
+				// own request lifetime fired first). Report that, not a
+				// deadline we did not reach.
+				var zero Res
+				return zero, ctx.Err()
+			}
+			stuck := abandonedToolCalls.Add(1)
+			go func() {
+				<-done
+				abandonedToolCalls.Add(-1)
+			}()
+			if s != nil && s.logger != nil {
+				s.logger.Warn("mcp: request exceeded its deadline; abandoning to keep the session alive",
+					zap.String("kind", kind),
+					zap.String("name", name),
+					zap.Duration("deadline", timeout),
+					zap.Duration("elapsed", time.Since(started)),
+					zap.Int64("abandoned_in_flight", stuck))
+			}
+			return expired(timeout)
+		}
+	}
+}
+
+// busyMessage is the shared diagnosis for "too many handlers are already
+// stuck to admit another".
+func busyMessage(what string, stuck int64, timeout time.Duration) string {
+	return fmt.Sprintf(
+		"gortex is not serving %s: %d handlers are blocked past their %s deadline. "+
+			"Something the graph depends on is wedged (most often a long index / enrichment holding the store). "+
+			"Check `gortex daemon status`; `gortex daemon restart` clears it.",
+		what, stuck, timeout)
+}
+
+// abandonedMessage is the shared diagnosis for a request that outran its
+// budget. It names the side-effect uncertainty explicitly: the handler is
+// still running, so the agent must not conclude the work did not happen.
+func abandonedMessage(what, name string, timeout time.Duration) string {
+	return fmt.Sprintf(
+		"%s %q exceeded its %s deadline and was abandoned so the session stays responsive. "+
+			"The work may still complete in the background, so treat any side effect as unknown. "+
+			"This usually means the graph is busy (indexing, enrichment, or a slow store) — "+
+			"retry, or check `gortex daemon status`.",
+		what, name, timeout)
+}
+
+func (s *Server) boundToolHandler(h mcpserver.ToolHandlerFunc) mcpserver.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		name := req.Params.Name
+		return boundHandler(s, "tool", name, (func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error))(h),
+			func(stuck int64, timeout time.Duration) (*mcp.CallToolResult, error) {
+				return mcp.NewToolResultError(busyMessage("tool calls", stuck, timeout)), nil
+			},
+			func(timeout time.Duration) (*mcp.CallToolResult, error) {
+				return mcp.NewToolResultError(abandonedMessage("tool", name, timeout)), nil
+			},
+			func(r any) (*mcp.CallToolResult, error) {
+				return mcp.NewToolResultError(fmt.Sprintf("tool %q internal error: %v", name, r)), nil
+			},
+		)(ctx, req)
+	}
+}
+
+// addResource registers a resource with the same hang firewall tool calls get.
+//
+// Resources need it more, not less. mcp-go's stdio transport queues tool calls
+// onto a worker pool but handles every other method — resources/read included —
+// inline on the single goroutine that reads stdin. A slow
+// `gortex://index-health` or `gortex://report` read therefore stops the server
+// reading its own input: not one hung call, a hung session, with the client's
+// notifications/cancelled sitting unread in the pipe behind it.
+func (s *Server) addResource(resource mcp.Resource, handler mcpserver.ResourceHandlerFunc) {
+	s.mcpServer.AddResource(resource, s.boundResourceHandler(resource.URI, handler))
+}
+
+// addResourceTemplate is addResource for URI-templated resources; same
+// transport, same firewall.
+func (s *Server) addResourceTemplate(tmpl mcp.ResourceTemplate, handler mcpserver.ResourceTemplateHandlerFunc) {
+	uri := tmpl.URITemplate.Raw()
+	s.mcpServer.AddResourceTemplate(tmpl,
+		mcpserver.ResourceTemplateHandlerFunc(s.boundResourceHandler(uri, mcpserver.ResourceHandlerFunc(handler))))
+}
+
+// addPrompt registers a prompt with the same firewall. Prompts travel the same
+// inline read-loop path as resources on the embedded stdio transport, and
+// gortex's prompt handlers do real graph work (whole-edge scans, communities,
+// processes, a git diff) — exactly the shape that blocks.
+func (s *Server) addPrompt(prompt mcp.Prompt, handler mcpserver.PromptHandlerFunc) {
+	s.mcpServer.AddPrompt(prompt, s.boundPromptHandler(prompt.Name, handler))
+}
+
+func (s *Server) boundResourceHandler(uri string, h mcpserver.ResourceHandlerFunc) mcpserver.ResourceHandlerFunc {
+	return boundHandler(s, "resource", uri, (func(context.Context, mcp.ReadResourceRequest) ([]mcp.ResourceContents, error))(h),
+		func(stuck int64, timeout time.Duration) ([]mcp.ResourceContents, error) {
+			return nil, errors.New(busyMessage("resource reads", stuck, timeout))
+		},
+		func(timeout time.Duration) ([]mcp.ResourceContents, error) {
+			return nil, errors.New(abandonedMessage("resource", uri, timeout))
+		},
+		func(r any) ([]mcp.ResourceContents, error) {
+			return nil, fmt.Errorf("resource %s internal error: %v", uri, r)
+		},
+	)
+}
+
+func (s *Server) boundPromptHandler(name string, h mcpserver.PromptHandlerFunc) mcpserver.PromptHandlerFunc {
+	return boundHandler(s, "prompt", name, (func(context.Context, mcp.GetPromptRequest) (*mcp.GetPromptResult, error))(h),
+		func(stuck int64, timeout time.Duration) (*mcp.GetPromptResult, error) {
+			return nil, errors.New(busyMessage("prompt requests", stuck, timeout))
+		},
+		func(timeout time.Duration) (*mcp.GetPromptResult, error) {
+			return nil, errors.New(abandonedMessage("prompt", name, timeout))
+		},
+		func(r any) (*mcp.GetPromptResult, error) {
+			return nil, fmt.Errorf("prompt %s internal error: %v", name, r)
+		},
+	)
+}

--- a/internal/mcp/tool_deadline_test.go
+++ b/internal/mcp/tool_deadline_test.go
@@ -1,0 +1,340 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// registerBlockingTool wires a tool that parks until release is closed, using
+// the same addTool path every real tool takes so the test exercises the
+// production middleware chain rather than a bypass.
+func registerBlockingTool(srv *Server, name string, release <-chan struct{}, entered chan<- struct{}) {
+	srv.addTool(
+		mcplib.NewTool(name, mcplib.WithDescription("test-only blocking tool")),
+		func(ctx context.Context, _ mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+			select {
+			case entered <- struct{}{}:
+			default:
+			}
+			select {
+			case <-release:
+			case <-time.After(30 * time.Second):
+			}
+			return mcplib.NewToolResultText("finally"), nil
+		},
+	)
+}
+
+// TestBlockedToolCallReturnsTerminalResult is the #300 contract: a handler that
+// will not return must not become an open-ended silence. This is where the
+// embedded stdio server used to lose the session — mcp-go hands every handler
+// the server-lifetime context, so nothing downstream could ever cut the call
+// off.
+func TestBlockedToolCallReturnsTerminalResult(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	srv.ToolCallTimeout = 100 * time.Millisecond
+
+	release := make(chan struct{})
+	defer close(release)
+	registerBlockingTool(srv, "test_blocks_forever", release, make(chan struct{}, 1))
+
+	start := time.Now()
+	res := callToolByName(t, srv, context.Background(), "test_blocks_forever", nil)
+	elapsed := time.Since(start)
+
+	require.NotNil(t, res)
+	assert.True(t, res.IsError, "an abandoned call must be reported as an error, not a silent empty success")
+	text := toolText(res)
+	assert.Contains(t, text, "deadline")
+	assert.Contains(t, text, "side effect as unknown",
+		"the agent must be told the abandoned work may still land")
+	assert.Less(t, elapsed, 5*time.Second, "the bound must fire on its own budget, got %s", elapsed)
+}
+
+// TestSessionStaysResponsiveAfterBlockedToolCall is the property that actually
+// rescues a session. One wedged handler used to occupy an mcp-go stdio worker
+// permanently; once the pool and its queue were exhausted, tool calls ran
+// inline on the stdin reader and the whole session stopped answering. The
+// firewall returns the transport's slot immediately, so later calls still work.
+func TestSessionStaysResponsiveAfterBlockedToolCall(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	srv.ToolCallTimeout = 100 * time.Millisecond
+
+	release := make(chan struct{})
+	defer close(release)
+	entered := make(chan struct{}, 4)
+	registerBlockingTool(srv, "test_blocks_forever", release, entered)
+
+	for i := 0; i < 3; i++ {
+		res := callToolByName(t, srv, context.Background(), "test_blocks_forever", nil)
+		require.True(t, res.IsError)
+	}
+	<-entered // the handler really did run; this is not a registration no-op
+
+	start := time.Now()
+	res := callToolByName(t, srv, context.Background(), "index_health", map[string]any{"compact": true})
+	require.NotNil(t, res)
+	assert.False(t, res.IsError, "an unrelated tool must still answer: %s", toolText(res))
+	assert.Less(t, time.Since(start), 5*time.Second)
+}
+
+// TestAbandonedToolCallsDrainWhenHandlerFinishes pins the leak accounting: a
+// handler abandoned at its deadline is still running, and the counter that
+// bounds how many of those may pile up has to come back down when it finishes.
+// If it did not, a workspace that was merely slow once would eventually trip
+// the fail-fast cap forever.
+func TestAbandonedToolCallsDrainWhenHandlerFinishes(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	srv.ToolCallTimeout = 50 * time.Millisecond
+
+	release := make(chan struct{})
+	registerBlockingTool(srv, "test_blocks_forever", release, make(chan struct{}, 1))
+
+	before := AbandonedToolCalls()
+	res := callToolByName(t, srv, context.Background(), "test_blocks_forever", nil)
+	require.True(t, res.IsError)
+	require.Eventually(t, func() bool { return AbandonedToolCalls() > before },
+		2*time.Second, 5*time.Millisecond, "an abandoned handler must be accounted for")
+
+	close(release)
+	require.Eventually(t, func() bool { return AbandonedToolCalls() <= before },
+		5*time.Second, 5*time.Millisecond, "the count must drain once the handler completes")
+}
+
+// TestCallerCancellationIsReportedAsCancellation keeps the two failure modes
+// distinct. A client that hangs up is not the same event as a server-side
+// deadline, and conflating them would make the logs useless for telling "the
+// graph is wedged" from "the agent moved on".
+func TestCallerCancellationIsReportedAsCancellation(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	srv.ToolCallTimeout = 10 * time.Second
+
+	release := make(chan struct{})
+	defer close(release)
+	entered := make(chan struct{}, 1)
+	registerBlockingTool(srv, "test_blocks_forever", release, entered)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-entered
+		cancel()
+	}()
+
+	tool := srv.MCPServer().GetTool("test_blocks_forever")
+	require.NotNil(t, tool)
+	_, err := tool.Handler(ctx, mcplib.CallToolRequest{
+		Params: mcplib.CallToolParams{Name: "test_blocks_forever"},
+	})
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// TestToolDeadlineFiresInsideTheTransportBudget: when the transport already
+// imposed a deadline (the daemon socket's per-request lifetime), the handler
+// bound must land first, so the client gets the tool-shaped diagnosis instead
+// of an opaque JSON-RPC transport error.
+func TestToolDeadlineFiresInsideTheTransportBudget(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	srv.ToolCallTimeout = time.Hour // deliberately useless; the transport must win
+
+	release := make(chan struct{})
+	defer close(release)
+	registerBlockingTool(srv, "test_blocks_forever", release, make(chan struct{}, 1))
+
+	// A transport budget generous enough that subtracting the margin still
+	// leaves a positive window.
+	ctx, cancel := context.WithTimeout(context.Background(), transportDeadlineMargin+300*time.Millisecond)
+	defer cancel()
+
+	res := callToolByName(t, srv, ctx, "test_blocks_forever", nil)
+	require.NotNil(t, res, "the handler bound must answer before the transport deadline")
+	assert.True(t, res.IsError)
+	assert.Contains(t, toolText(res), "deadline")
+}
+
+// TestToolDeadlineDisabled keeps the escape hatch honest for operators running
+// legitimately long analyze / ask calls.
+func TestToolDeadlineDisabled(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	srv.ToolCallTimeout = -1
+
+	release := make(chan struct{})
+	entered := make(chan struct{}, 1)
+	registerBlockingTool(srv, "test_blocks_forever", release, entered)
+
+	done := make(chan *mcplib.CallToolResult, 1)
+	go func() {
+		done <- callToolByName(t, srv, context.Background(), "test_blocks_forever", nil)
+	}()
+	<-entered
+	select {
+	case <-done:
+		t.Fatal("with the bound disabled the call must not be cut off")
+	case <-time.After(200 * time.Millisecond):
+	}
+	close(release)
+	res := <-done
+	assert.Contains(t, toolText(res), "finally")
+}
+
+func TestToolCallTimeoutFromEnv(t *testing.T) {
+	t.Setenv(ToolCallTimeoutEnv, "")
+	assert.Equal(t, DefaultToolCallTimeout, toolCallTimeoutFromEnv())
+	t.Setenv(ToolCallTimeoutEnv, "5s")
+	assert.Equal(t, 5*time.Second, toolCallTimeoutFromEnv())
+	t.Setenv(ToolCallTimeoutEnv, "off")
+	assert.Zero(t, toolCallTimeoutFromEnv())
+	t.Setenv(ToolCallTimeoutEnv, "nonsense")
+	assert.Equal(t, DefaultToolCallTimeout, toolCallTimeoutFromEnv(),
+		"an unparseable value must fall back to the default, never to unbounded")
+}
+
+// TestIndexHealthPayloadHonoursCancellation covers the specific handler both
+// issue reports named. Its cost is proportional to workspace size — one stat
+// per tracked file plus a graph scan — and before this it checked nothing, so a
+// client that had already given up still paid for the whole sweep.
+func TestIndexHealthPayloadHonoursCancellation(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	payload, err := srv.buildIndexHealthPayloadCtx(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, payload)
+
+	// The uncancelled path is unchanged.
+	payload, err = srv.buildIndexHealthPayloadCtx(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, payload)
+	assert.Contains(t, payload, "health_score")
+}
+
+// TestIndexHealthToolReportsCancellation: the tool must explain itself rather
+// than return a half-built payload that reads as a healthy index.
+func TestIndexHealthToolReportsCancellation(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	res, err := srv.handleIndexHealth(ctx, mcplib.CallToolRequest{
+		Params: mcplib.CallToolParams{Name: "index_health"},
+	})
+	require.NoError(t, err)
+	require.True(t, res.IsError)
+	assert.True(t, strings.Contains(toolText(res), "cancelled"), "got %q", toolText(res))
+}
+
+// registerBlockingResource wires a resource through the production registrar so
+// the test exercises the wrapper the server actually installs.
+func registerBlockingResource(srv *Server, uri string, release <-chan struct{}) {
+	srv.addResource(
+		mcplib.NewResource(uri, "test-only blocking resource"),
+		func(_ context.Context, req mcplib.ReadResourceRequest) ([]mcplib.ResourceContents, error) {
+			select {
+			case <-release:
+			case <-time.After(30 * time.Second):
+			}
+			return jsonResource(req.Params.URI, map[string]any{"ok": true})
+		},
+	)
+}
+
+// TestBlockedResourceReadReturnsTerminalError covers the half of #300 that a
+// tool-only firewall would miss. mcp-go's stdio transport queues tool calls onto
+// a worker pool but runs resources/read inline on the goroutine that reads
+// stdin — so a blocked resource does not hang one call, it stops the session
+// reading its own input.
+func TestBlockedResourceReadReturnsTerminalError(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	srv.ToolCallTimeout = 100 * time.Millisecond
+
+	release := make(chan struct{})
+	defer close(release)
+	registerBlockingResource(srv, "gortex://test-blocking", release)
+
+	start := time.Now()
+	rpcErr := readResourceExpectingError(t, srv, "gortex://test-blocking")
+	assert.Contains(t, rpcErr, "deadline")
+	assert.Less(t, time.Since(start), 5*time.Second)
+}
+
+// readResourceExpectingError drives a real resources/read frame through the
+// server's dispatch — the path the transports use — and returns the JSON-RPC
+// error message. Invoking the handler function directly would bypass the
+// registrar wrapper this is meant to exercise.
+func readResourceExpectingError(t *testing.T, srv *Server, uri string) string {
+	t.Helper()
+	frame, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "resources/read",
+		"params":  map[string]any{"uri": uri},
+	})
+	require.NoError(t, err)
+
+	reply := srv.MCPServer().HandleMessage(context.Background(), frame)
+	require.NotNil(t, reply, "resources/read must produce a reply")
+	encoded, err := json.Marshal(reply)
+	require.NoError(t, err)
+
+	var envelope struct {
+		Error *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(encoded, &envelope))
+	require.NotNilf(t, envelope.Error, "a blocked/panicking read must fail, not succeed: %s", encoded)
+	return envelope.Error.Message
+}
+
+// TestPanickingResourceReadIsContained: moving handlers onto their own goroutine
+// takes them out from under whatever recover the transport supplied, so the
+// firewall has to bring its own — otherwise one panicking read kills the daemon.
+func TestPanickingResourceReadIsContained(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	srv.addResource(
+		mcplib.NewResource("gortex://test-panic", "test-only panicking resource"),
+		func(_ context.Context, _ mcplib.ReadResourceRequest) ([]mcplib.ResourceContents, error) {
+			panic("boom")
+		},
+	)
+
+	assert.Contains(t, readResourceExpectingError(t, srv, "gortex://test-panic"), "internal error")
+}
+
+// TestFailsFastWhenTooManyHandlersAreStuck pins the ceiling on detached work.
+// Abandoning a stuck handler frees the transport but leaves a goroutine behind;
+// past the cap the honest answer is to refuse, not to keep piling them up.
+func TestFailsFastWhenTooManyHandlersAreStuck(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	srv.ToolCallTimeout = 5 * time.Second // long enough that only the cap can trip
+
+	abandonedToolCalls.Add(maxAbandonedToolCalls)
+	defer abandonedToolCalls.Add(-maxAbandonedToolCalls)
+
+	release := make(chan struct{})
+	defer close(release)
+	entered := make(chan struct{}, 1)
+	registerBlockingTool(srv, "test_blocks_forever", release, entered)
+
+	start := time.Now()
+	res := callToolByName(t, srv, context.Background(), "test_blocks_forever", nil)
+	require.NotNil(t, res)
+	assert.True(t, res.IsError)
+	assert.Contains(t, toolText(res), "not serving tool calls")
+	assert.Less(t, time.Since(start), time.Second, "the cap must refuse immediately, not wait out the budget")
+
+	select {
+	case <-entered:
+		t.Fatal("a refused call must not reach the handler")
+	default:
+	}
+}

--- a/internal/mcp/tools_enhancements.go
+++ b/internal/mcp/tools_enhancements.go
@@ -2990,7 +2990,13 @@ func (s *Server) handleIndexHealth(ctx context.Context, req mcp.CallToolRequest)
 	if s.indexer == nil {
 		return mcp.NewToolResultError("no indexer available"), nil
 	}
-	result := s.buildIndexHealthPayload()
+	result, err := s.buildIndexHealthPayloadCtx(ctx)
+	if err != nil {
+		return mcp.NewToolResultError(
+			"index_health was cancelled before it finished: the scan is proportional to workspace size " +
+				"(one stat per tracked file plus a graph scan) and the caller's deadline expired first. " +
+				"Retry when indexing settles, or pass compact:true for the cheaper summary."), nil
+	}
 
 	if isCompact(req) {
 		stale, _ := result["stale_files"].([]string)
@@ -3009,18 +3015,49 @@ func (s *Server) handleIndexHealth(ctx context.Context, req mcp.CallToolRequest)
 // buildIndexHealthPayload returns the same data the `index_health`
 // tool emits. Shared with the `gortex://index-health` resource.
 // Returns nil when no indexer is wired.
+//
+// Prefer buildIndexHealthPayloadCtx on any request path: this variant cannot
+// be cancelled, and the work below is proportional to workspace size.
 func (s *Server) buildIndexHealthPayload() map[string]any {
+	payload, _ := s.buildIndexHealthPayloadCtx(context.Background())
+	return payload
+}
+
+// healthScanCancelStride is how many iterations pass between context checks in
+// the payload's per-file loops. Checking every iteration would cost more than
+// the syscall it guards on a warm cache; a few hundred keeps the worst-case
+// overshoot in the millisecond range.
+const healthScanCancelStride = 512
+
+// buildIndexHealthPayloadCtx is buildIndexHealthPayload with cancellation.
+//
+// "Minimal health probe" is what the tool looks like from outside, but the work
+// is proportional to the workspace: one os.Stat per tracked file to answer
+// staleness, plus a whole-graph scan. On a 20k-file workspace under indexing
+// load that is tens of seconds of syscalls — and, before this, not one of them
+// checked whether the caller was still there. A client that gave up at 30s left
+// the daemon finishing a scan for nobody, holding a transport slot the whole
+// time.
+func (s *Server) buildIndexHealthPayloadCtx(ctx context.Context) (map[string]any, error) {
 	if s.indexer == nil {
-		return nil
+		return nil, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 
 	totalDetected := s.indexer.TotalDetected()
 	parseErrors := s.indexer.ParseErrors()
 
+	// One whole-graph Stats() for the whole payload. It used to be computed
+	// twice — once for the totalDetected fallback and again below — which on a
+	// large graph doubled the most expensive read in the function for no
+	// additional information.
+	stats := s.graph.Stats()
+
 	// When totalDetected is 0 (e.g., graph restored from cache without a full re-index),
 	// fall back to counting file nodes in the graph.
 	if totalDetected == 0 {
-		stats := s.graph.Stats()
 		if fileCount, ok := stats.ByKind[string(graph.KindFile)]; ok {
 			totalDetected = fileCount
 		}
@@ -3035,13 +3072,19 @@ func (s *Server) buildIndexHealthPayload() map[string]any {
 
 	var staleFiles []string
 	mtimes := s.indexer.FileMtimes()
+	scanned := 0
 	for relPath := range mtimes {
+		if scanned%healthScanCancelStride == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
+		scanned++
 		if s.indexer.IsStale(relPath) {
 			staleFiles = append(staleFiles, relPath)
 		}
 	}
 
-	stats := s.graph.Stats()
 	langCoverage := make(map[string]bool)
 	for lang := range stats.ByLanguage {
 		langCoverage[lang] = true
@@ -3052,7 +3095,14 @@ func (s *Server) buildIndexHealthPayload() map[string]any {
 	// minified / parse_failed / parse_panic) instead of guessing.
 	skipped := map[string]int{}
 	repoPrefixes := map[string]struct{}{}
+	scanned = 0
 	for n := range s.graph.NodesByKind(graph.KindFile) {
+		if scanned%healthScanCancelStride == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
+		scanned++
 		if n == nil {
 			continue
 		}
@@ -3260,7 +3310,7 @@ func (s *Server) buildIndexHealthPayload() map[string]any {
 		result["recommendation"] = recommendation
 	}
 
-	return result
+	return result, nil
 }
 
 // buildIndexHealthFileRollup reads the per-file metadata sidecar (when the


### PR DESCRIPTION
Two reports, one shape: a request that never comes back, with nothing printed and no way out but `kill -9`.

- **#370** (macOS, 20k-file workspace): after `gortex track` finishes, `gortex daemon stop` hangs past five minutes and every `gortex call` hangs with it.
- **#300** (Windows, embedded stdio): `index_health` produces nothing for 30s, `smart_context` for 60s, and every follow-up probe dies the same way.

Neither is a slow-code problem. In both, something took longer than the caller was willing to wait and there was no layer that could say so.

## #370 — the control plane had no bound anywhere

`Client.Control` read the reply with a bare `ReadBytes` and no socket deadline. The handshake ack was read the same way. `handleControl` dispatched with `context.Background()`. The controller's mutex is coarse — `Track` holds it across the whole indexing run, as do `Reload` and every enricher — so any of those turned every other control request into an indefinite, silent block.

`internal/hooks` had already learned this: every one of its control call sites sets a socket deadline. None of the CLI's own verbs did.

Two of those unbounded calls sat where they did the most damage:

- `gortex daemon stop` opens with a Status lookup that exists only to print an uptime on the summary card (`cmd/gortex/daemon.go`, `daemonUptimeBeforeStop`). The stop request had not been sent yet when the command hung.
- Every `gortex call` opens with a Status probe to decide whether the daemon owns the repo (`cmd/gortex/cli_daemon.go`, `daemonOwnsRepo`).

That is the reported shape exactly: stop hangs, every query hangs, nothing is printed either way.

## #300 — the embedded transport had no request lifetime at all

mcp-go's stdio server hands every handler the **server-lifetime** context, so nothing downstream can cut a call off. A blocked handler holds its worker forever; once the pool and its queue are exhausted, `processMessage` falls back to running tool calls **inline on the goroutine that reads stdin**. Every other method — `resources/read`, `prompts/get`, `tools/list` — is already handled inline there.

So one wedged handler stops the server reading its own input, and the client's `notifications/cancelled` sits unread in the pipe behind it. That is why the follow-up probes died too.

The daemon socket was immune: it already wraps each JSON-RPC frame in a 60s request lifetime. The embedded path never got the same guarantee.

`index_health` is a fair thing to have hung on. It is a "minimal health probe" from outside, but the work is proportional to workspace size — one `os.Stat` per tracked file plus a whole-graph scan, run twice — and it checked no context at all.

## What changes

**MCP (`internal/mcp/tool_deadline.go`).** Every tool call, resource read and prompt fetch is bounded, at the middleware chokepoint that already carries the panic firewall. Same argument, different failure: a panic in one handler used to drop every session's transport, and so does a hang, just more quietly.

An overrunning handler is *abandoned*, not killed. The caller gets a terminal structured error naming the deadline; the transport's slot is released immediately so later requests are served. The handler keeps running — it may be inside a store call nothing can interrupt — so the error says the side effect is **unknown** rather than pretending the work did not happen. Detached handlers are counted, and past a ceiling new requests are refused with that count. The bound fires just inside any deadline the transport already imposed, so the client reads the handler's diagnosis instead of an opaque transport timeout. `GORTEX_MCP_TOOL_TIMEOUT` tunes or disables it.

`index_health` now honours cancellation and computes `graph.Stats()` once instead of twice.

**Control plane (`internal/daemon`, `cmd/gortex`).** Kinds carry a budget and both ends agree on it (`ControlTimeoutFor`).

| Kind | Bound |
|---|---|
| `status` / `search_symbols` / `proxy` | 30s, terminal `timeout` naming the likely cause |
| `track` / `untrack` / `reload` / `enrich_*` | unbounded — long by design; a user who starts one is waiting on purpose |
| `shutdown` | unbounded on the daemon (the store flush precedes the ack; abandoning it half-done is worse than a slow stop). `daemon stop` carries the bound itself and falls through to watching the process exit rather than erroring out |

Three follow-on fixes fell out of that:

- The daemon schedules its teardown even when the ack cannot be delivered, so a client that gave up no longer leaves a flushed daemon still holding the store lock.
- Reading the attached watcher — the first thing the teardown hook does — took the coarse mutex for one pointer read. It is an atomic now, so `daemon stop` no longer queues behind the work it is ending.
- The routing probe **fails open**. Treating an indeterminate answer as "the daemon does not own this repo" produced a message that was both false and actively harmful: it told the user to run `gortex track`, which is the unbounded operation holding the lock. Proceeding to the MCP path costs nothing to be wrong about — that path does not need the controller mutex, and a genuinely untracked repo still comes back as `repo_not_tracked`.

## What this does not fix

Worth stating plainly, because #370 has been reproduced five times and the next report should carry the right evidence.

This makes the failure **bounded, attributable and recoverable**. It does not make the daemon fast at the moment indexing completes. `EndCoordinatedBulkLoad` (`internal/graph/store_sqlite/bulk_load.go:349`) holds the store write gate across two FTS merges, the index rebuild loop, and `ANALYZE` — a single multi-minute critical section on a first cold load of a 20k-file workspace, arriving exactly when #370 says the daemon goes quiet. That is consistent with the reported `UN` process state, which is a kernel-side uninterruptible wait (disk), not a goroutine parked on a Go mutex — a mutex wait shows as `S`.

So: after this change that window produces a 30s `timeout` response naming the cause instead of an infinite hang, `daemon stop` terminates and leaves the socket and PID file in a startable state, and `gortex call` still answers over the MCP path. Shortening the window itself is separate work. A goroutine dump (`kill -QUIT`) or a `sample` from a wedged daemon would settle whether anything else contributes.

## Verification

`go build ./...`, `go vet`, `go test -race ./...` — 12,056 tests across 178 packages.

New regression coverage, each one mutation-checked to confirm it fails without the fix:

- reverting `watcher()` to the coarse mutex → the two shutdown tests fail
- reverting the resource registrars to bare `AddResource` → the blocked-read test fails and the panicking-read test **crashes the process**, which is the containment gap it guards
- removing the tool firewall → all three tool-liveness tests fail

Covered: blocked tool call returns a terminal result; the session stays responsive afterwards; the abandoned-handler count drains; caller cancellation stays distinct from a server deadline; the transport-inherited deadline wins; the disable knob works; blocked and panicking resource reads; the fail-fast ceiling; the control timeout policy in both directions (bounded kinds bounded, `track` provably *not* clamped); client- and server-side timeout reporting; teardown when the ack cannot be delivered; and the three-state routing decision.

Fixes #370
Fixes #300
