### PR TITLE
Attest review coverage from indexed test symbols

### DIFF
--- a/internal/analysis/coverage_agreement_test.go
+++ b/internal/analysis/coverage_agreement_test.go
@@ -1,0 +1,74 @@
+package analysis
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// coveredSymbolGraph wires one production symbol exercised by one test at
+// testPath, in the shape the indexer produces: a calls edge plus the parallel
+// tests edge its test-edge pass emits.
+func coveredSymbolGraph(prodPath, testPath string) (graph.Store, string) {
+	g := graph.New()
+	prodID := prodPath + "::Target"
+	testID := testPath + "::Exercise"
+	g.AddNode(&graph.Node{ID: prodID, Name: "Target", Kind: graph.KindFunction, FilePath: prodPath})
+	g.AddNode(&graph.Node{
+		ID: testID, Name: "Exercise", Kind: graph.KindFunction, FilePath: testPath,
+		Meta: map[string]any{"is_test": true},
+	})
+	g.AddEdge(&graph.Edge{From: testID, To: prodID, Kind: graph.EdgeCalls})
+	g.AddEdge(&graph.Edge{From: testID, To: prodID, Kind: graph.EdgeTests})
+	return g, prodID
+}
+
+// TestCoverageVocabulariesAgree is the regression for issue #350's second
+// contradiction: the per-file rows counted a symbol covered when a dependent
+// looked like a test file, while the risk receipt counted it covered when a
+// tests edge pointed at it. The path predicate recognised seven filename
+// fragments, so every convention outside that list — a Ruby spec, a JUnit
+// class, anything under a tests/ directory — was covered by one measure and
+// uncovered by the other in the same payload.
+func TestCoverageVocabulariesAgree(t *testing.T) {
+	conventions := []struct{ name, prod, test string }{
+		{"go", "pkg/foo.go", "pkg/foo_test.go"},
+		{"vitest colocated", "src/entity.ts", "src/entity.test.ts"},
+		{"ruby spec", "app/user.rb", "spec/user_spec.rb"},
+		{"junit", "src/User.java", "src/UserTest.java"},
+		{"tests directory", "src/parse.rs", "tests/parse_integration.rs"},
+		{"pytest", "app/service.py", "app/test_service.py"},
+		{"phpunit", "src/Order.php", "tests/OrderTest.php"},
+	}
+	for _, c := range conventions {
+		t.Run(c.name, func(t *testing.T) {
+			g, prodID := coveredSymbolGraph(c.prod, c.test)
+
+			impact := AnalyzeImpact(g, []string{prodID}, nil, nil)
+			require.NotNil(t, impact)
+			require.Contains(t, impact.TestFiles, c.test,
+				"the per-file review rows read coverage off TestFiles")
+
+			require.True(t, hasCoveringTest(g, prodID),
+				"the risk receipt reads coverage off the tests edge")
+			require.Zero(t, ScorePRRisk(g, PRRiskInput{SymbolIDs: []string{prodID}}).UncoveredSymbols)
+		})
+	}
+}
+
+// TestCoverageDoesNotCountTestSubstringPaths pins the false positive the old
+// path predicate carried: it matched "test_" anywhere in a path, so an
+// ordinary caller whose name merely contains the substring inflated a
+// symbol's covering-test list.
+func TestCoverageDoesNotCountTestSubstringPaths(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "pkg/foo.go::Target", Name: "Target", Kind: graph.KindFunction, FilePath: "pkg/foo.go"})
+	g.AddNode(&graph.Node{ID: "pkg/latest_release.go::Publish", Name: "Publish", Kind: graph.KindFunction, FilePath: "pkg/latest_release.go"})
+	g.AddEdge(&graph.Edge{From: "pkg/latest_release.go::Publish", To: "pkg/foo.go::Target", Kind: graph.EdgeCalls})
+
+	impact := AnalyzeImpact(g, []string{"pkg/foo.go::Target"}, nil, nil)
+	require.NotNil(t, impact)
+	require.Empty(t, impact.TestFiles, "a production caller is not a covering test")
+}

--- a/internal/analysis/impact.go
+++ b/internal/analysis/impact.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/reach"
+	"github.com/zzet/gortex/internal/testpath"
 )
 
 // RiskLevel represents the severity of a change's impact.
@@ -549,29 +550,21 @@ func assessRisk(directDeps, transitiveDeps int) RiskLevel {
 }
 
 // IsTestFile reports whether path looks like a test source file — the same
-// suffix set the impact traversal uses to collect covering tests, exported
+// predicate the impact traversal uses to collect covering tests, exported
 // for callers that need to probe whether a graph indexes tests at all.
+//
+// It delegates to internal/testpath, the convention table the indexer's
+// test-edge pass classifies with. Before that, this was a seven-fragment
+// substring match of its own, and the two disagreed: a `_spec.rb`,
+// a `FooTest.java`, or anything under a `tests/` directory got a `tests`
+// edge from the indexer but was not counted as a covering test here, so the
+// same change read as untested in the review's per-file rows and covered in
+// the risk receipt. The old match was also too loose in the other
+// direction — "test_" anywhere in the path made `src/latest_release.go` a
+// test file.
 func IsTestFile(path string) bool { return isTestFile(path) }
 
-func isTestFile(path string) bool {
-	return containsAny(path,
-		"_test.go", ".test.ts", ".test.js", ".spec.ts", ".spec.js",
-		"__tests__/", "test_",
-	)
-}
-
-func containsAny(s string, patterns ...string) bool {
-	for _, p := range patterns {
-		if len(s) >= len(p) {
-			for i := 0; i <= len(s)-len(p); i++ {
-				if s[i:i+len(p)] == p {
-					return true
-				}
-			}
-		}
-	}
-	return false
-}
+func isTestFile(path string) bool { return testpath.IsTestFile(path) }
 
 func dedup(ss []string) []string {
 	seen := make(map[string]bool, len(ss))

--- a/internal/indexer/testpattern.go
+++ b/internal/indexer/testpattern.go
@@ -1,72 +1,20 @@
 package indexer
 
 import (
-	"path/filepath"
 	"strings"
+
+	"github.com/zzet/gortex/internal/testpath"
 )
 
 // IsTestFile returns true when the file's name or directory matches a
-// recognised test convention from the table below. False positives
-// here are downgraded downstream by the symbol-name filter
-// (IsTestSymbol).
+// recognised test convention. False positives here are downgraded
+// downstream by the symbol-name filter (IsTestSymbol).
 //
-// Recognised conventions:
-//
-//	*_test.go                          (Go)
-//	*.test.{ts,tsx,js,jsx,mts,cts}     (TS/JS via Jest/Vitest convention)
-//	*.spec.{ts,tsx,js,jsx,mts,cts}     (TS/JS spec convention)
-//	test_*.py / *_test.py              (Python)
-//	*_test.dart                        (Dart)
-//	*_spec.rb / *_test.rb              (Ruby)
-//	*Test.java / *Tests.java           (JUnit / Spring)
-//	*Test.kt  / *Tests.kt              (Kotlin)
-//	*Tests.cs                          (C# xUnit/NUnit)
-//	*Tests.swift                       (Swift)
-//	*Test.php / *test.php              (PHPUnit / Pest)
-//	files under __tests__/, tests/,
-//	  test/, spec/                     (any language using these dirs)
-func IsTestFile(path string) bool {
-	if path == "" {
-		return false
-	}
-	// Directory-based hints first — covers projects that don't follow
-	// the per-file naming convention.
-	dir := filepath.ToSlash(path)
-	for _, marker := range []string{"/__tests__/", "/tests/", "/test/", "/spec/"} {
-		if strings.Contains(dir, marker) {
-			return true
-		}
-	}
-	if strings.HasPrefix(dir, "tests/") || strings.HasPrefix(dir, "test/") || strings.HasPrefix(dir, "spec/") {
-		return true
-	}
-
-	base := filepath.Base(path)
-	ext := strings.ToLower(filepath.Ext(base))
-	stem := strings.TrimSuffix(base, ext)
-
-	switch ext {
-	case ".go":
-		return strings.HasSuffix(stem, "_test")
-	case ".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs":
-		return strings.HasSuffix(stem, ".test") || strings.HasSuffix(stem, ".spec")
-	case ".py":
-		return strings.HasPrefix(stem, "test_") || strings.HasSuffix(stem, "_test")
-	case ".dart":
-		return strings.HasSuffix(stem, "_test")
-	case ".rb":
-		return strings.HasSuffix(stem, "_spec") || strings.HasSuffix(stem, "_test")
-	case ".java", ".kt":
-		return strings.HasSuffix(stem, "Test") || strings.HasSuffix(stem, "Tests")
-	case ".cs":
-		return strings.HasSuffix(stem, "Tests") || strings.HasSuffix(stem, "Test")
-	case ".swift":
-		return strings.HasSuffix(stem, "Tests")
-	case ".php":
-		return strings.HasSuffix(stem, "Test") || strings.HasSuffix(stem, "test")
-	}
-	return false
-}
+// The convention table lives in the stdlib-only leaf internal/testpath so
+// the resolver and the impact analyzer — neither of which can import the
+// indexer — classify a path exactly the way the test-edge pass does. See
+// that package for the recognised conventions.
+func IsTestFile(path string) bool { return testpath.IsTestFile(path) }
 
 // TestRole classifies a function/method name by its language's test
 // convention and returns the specific role — "test", "benchmark",

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -140,10 +140,12 @@ type Server struct {
 	multiIndexer  *indexer.MultiIndexer
 	configManager *config.ConfigManager
 	activeProject string
-	// testIndexProbe caches, per repo prefix, which test-path fragments the
-	// graph carries symbols for (see testFragmentsIndexed). The answer only
-	// changes with a reindex under a different exclude set, so
-	// daemon-lifetime caching is safe.
+	// testIndexProbe caches, per repo prefix, which language families the
+	// graph carries test symbols for (see testLangsIndexed). The answer
+	// changes with a reindex — and with the test-edge pass that stamps those
+	// symbols, which lands after the first files are indexed — so
+	// resetTestIndexProbe clears it on every analysis pass rather than
+	// pinning the first (possibly mid-warmup) answer for the daemon's life.
 	testIndexProbe sync.Map
 	// trackInFlight guards first-index runs by absolute repo path.
 	// track answers before the index finishes (#326), so without this a
@@ -2383,6 +2385,14 @@ func (s *Server) RunAnalysis() {
 	// idempotent.
 	s.resetConfirmedRefs()
 
+	// The test-symbol probe backing the review's coverage attestation is a
+	// property of the graph that was just rebuilt: a reindex under a new
+	// exclude set, or simply the test-edge pass finishing after a probe ran
+	// mid-warmup, changes the answer. Without this reset the first answer
+	// stuck for the daemon's lifetime and every review claimed the index
+	// carried no test symbols.
+	s.resetTestIndexProbe()
+
 	// Bootstrap-resource payloads (graph_stats, index_health, etc.)
 	// can change after re-warm even when the analysis itself didn't
 	// — node counts move on every reindex. Fire updates regardless.
@@ -2456,6 +2466,18 @@ func ScheduleMemoryReleaseAfterBurst(logger *zap.Logger, reason string) {
 func (s *Server) resetConfirmedRefs() {
 	s.refsConfirmed.Range(func(k, _ any) bool {
 		s.refsConfirmed.Delete(k)
+		return true
+	})
+}
+
+// resetTestIndexProbe clears the per-repo-prefix test-symbol probe (see the
+// testIndexProbe field) so the next review re-scans the rebuilt graph. Like
+// resetConfirmedRefs it ranges-and-deletes because sync.Map has no clear-all,
+// and it is safe against a concurrent testLangsIndexed reader: a racing miss
+// just re-scans, which is idempotent.
+func (s *Server) resetTestIndexProbe() {
+	s.testIndexProbe.Range(func(k, _ any) bool {
+		s.testIndexProbe.Delete(k)
 		return true
 	})
 }

--- a/internal/mcp/tools_review.go
+++ b/internal/mcp/tools_review.go
@@ -20,6 +20,7 @@ import (
 	"github.com/zzet/gortex/internal/query"
 	"github.com/zzet/gortex/internal/review"
 	"github.com/zzet/gortex/internal/semantic/lsp"
+	"github.com/zzet/gortex/internal/testpath"
 )
 
 // registerReviewTools registers the review-engine tool group. Unlike most
@@ -672,34 +673,51 @@ func (s *Server) reviewRulepackMatches(ctx context.Context, changedFiles []strin
 	return review.GroundReviewMatches(s.graph, collected)
 }
 
-// reviewImpact builds the per-changed-symbol blast-radius map review.Run uses to
-// rank per-file risk. A symbol whose impact analysis is empty is omitted.
-// testPatternsByExt maps a source-file extension to the path fragments its
-// covering tests conventionally carry. Only languages with a recognizable
-// convention are probed; a diff touching none of them reads as
-// coverage-unknown.
-var testPatternsByExt = map[string][]string{
-	".go":  {"_test.go"},
-	".ts":  {".test.ts", ".spec.ts", "__tests__/"},
-	".tsx": {".test.ts", ".spec.ts", "__tests__/"},
-	".js":  {".test.js", ".spec.js", "__tests__/"},
-	".jsx": {".test.js", ".spec.js", "__tests__/"},
-	".py":  {"test_"},
+// testLangByExt maps a source-file extension onto the language family its
+// covering tests share. The family is the probe's unit because a test file
+// carries the same extension family as the code it exercises — a `.tsx`
+// component is covered by a `.test.ts` or a `.test.tsx` — so asking "does the
+// index carry tests for this language?" is one lookup per changed file.
+// Extensions absent from the table have no convention to attest and are
+// skipped.
+var testLangByExt = map[string]string{
+	".go":    "go",
+	".ts":    "ts",
+	".tsx":   "ts",
+	".mts":   "ts",
+	".cts":   "ts",
+	".js":    "js",
+	".jsx":   "js",
+	".mjs":   "js",
+	".cjs":   "js",
+	".py":    "py",
+	".rb":    "rb",
+	".rs":    "rs",
+	".dart":  "dart",
+	".java":  "java",
+	".kt":    "kt",
+	".cs":    "cs",
+	".swift": "swift",
+	".php":   "php",
 }
 
-// testFragmentsIndexed reports, per test-path fragment, whether the repo's
-// graph carries any non-file symbol whose path contains it. One scan,
-// cached for the daemon's lifetime — the index's exclude set only changes
-// with a reindex.
-func (s *Server) testFragmentsIndexed(repoPrefix string) map[string]bool {
+// testLangsIndexed returns the language families this repo's graph carries
+// indexed test symbols for. One scan per analysis epoch, cached per repo
+// prefix and invalidated by RunAnalysis — the answer changes with a reindex,
+// and pinning it for the daemon's lifetime meant a probe that ran during
+// warmup (before the test-edge pass stamps its symbols) reported "no tests"
+// until the daemon was restarted.
+//
+// A node counts as evidence when the indexer stamped it a test symbol or its
+// path follows a recognised convention. The stamp is what makes this
+// runner-agnostic: an annotation-driven test (Rust #[test], JUnit @Test) or
+// a co-located vitest probe carries no distinguishing path fragment, and
+// probing for hardcoded fragments instead reported "the index carries no
+// test symbols" over a graph full of them. Every `tests` edge originates at
+// a stamped symbol, so scanning nodes covers the edge evidence too.
+func (s *Server) testLangsIndexed(repoPrefix string) map[string]bool {
 	if v, ok := s.testIndexProbe.Load(repoPrefix); ok {
 		return v.(map[string]bool)
-	}
-	fragments := map[string]bool{}
-	for _, pats := range testPatternsByExt {
-		for _, p := range pats {
-			fragments[p] = false
-		}
 	}
 	var nodes []*graph.Node
 	if repoPrefix != "" {
@@ -707,54 +725,53 @@ func (s *Server) testFragmentsIndexed(repoPrefix string) map[string]bool {
 	} else {
 		nodes = s.graph.AllNodes()
 	}
-	remaining := len(fragments)
+	langs := map[string]bool{}
 	for _, n := range nodes {
-		if n == nil || n.Kind == graph.KindFile || !analysis.IsTestFile(n.FilePath) {
+		if n == nil || n.Kind == graph.KindFile || !nodeIsTestSymbol(n) {
 			continue
 		}
-		for p, seen := range fragments {
-			if !seen && strings.Contains(n.FilePath, p) {
-				fragments[p] = true
-				remaining--
-			}
-		}
-		if remaining == 0 {
-			break
+		if lang, ok := testLangByExt[strings.ToLower(filepath.Ext(n.FilePath))]; ok {
+			langs[lang] = true
 		}
 	}
-	s.testIndexProbe.Store(repoPrefix, fragments)
-	return fragments
+	s.testIndexProbe.Store(repoPrefix, langs)
+	return langs
+}
+
+// nodeIsTestSymbol reports whether a node is test code, preferring the
+// indexer's own stamp over the path convention so a test the runner
+// discovers by attribute rather than by filename still counts.
+func nodeIsTestSymbol(n *graph.Node) bool {
+	if v, ok := n.Meta["is_test"].(bool); ok && v {
+		return true
+	}
+	return testpath.IsTestFile(n.FilePath)
 }
 
 // coverageKnownForDiff reports whether the graph can attest test coverage
 // for this changeset: every changed file whose language has a test
-// convention must have that convention present in the index. An index
-// config that excludes a language's test files (e.g. "**/*_test.go") makes
-// "no covering test" blindness, not a finding — the review then says
+// convention must have test symbols for that language present in the index.
+// An index config that excludes a language's test files (e.g. "**/*_test.go")
+// makes "no covering test" blindness, not a finding — the review then says
 // "coverage unknown" instead of "untested".
 func (s *Server) coverageKnownForDiff(repoPrefix string, changedFiles []string) bool {
-	fragments := s.testFragmentsIndexed(repoPrefix)
+	langs := s.testLangsIndexed(repoPrefix)
 	sawCode := false
 	for _, f := range changedFiles {
-		pats := testPatternsByExt[strings.ToLower(filepath.Ext(f))]
-		if len(pats) == 0 {
+		lang, ok := testLangByExt[strings.ToLower(filepath.Ext(f))]
+		if !ok {
 			continue
 		}
 		sawCode = true
-		ok := false
-		for _, p := range pats {
-			if fragments[p] {
-				ok = true
-				break
-			}
-		}
-		if !ok {
+		if !langs[lang] {
 			return false
 		}
 	}
 	return sawCode
 }
 
+// reviewImpact builds the per-changed-symbol blast-radius map review.Run uses to
+// rank per-file risk. A symbol whose impact analysis is empty is omitted.
 func (s *Server) reviewImpact(changed []analysis.ChangedSymbol) map[string]*analysis.ImpactResult {
 	if len(changed) == 0 {
 		return nil
@@ -1061,6 +1078,14 @@ func (s *Server) handleReviewPack(ctx context.Context, req mcp.CallToolRequest) 
 		}
 	}
 
+	// Impacted test targets → the concrete verification command, and the
+	// changeset's own coverage evidence. Resolved before the review runs
+	// because a non-empty target list is proof the index carries test
+	// symbols for this change: whatever the repo-wide probe concludes, the
+	// envelope must never pair these files with a summary claiming there
+	// are none.
+	testTargets := s.reviewTestTargets(ctx, ids)
+
 	// The review report (deterministic rulepack always; LLM phase gated).
 	useLLM := requestBoolDefault(req, "use_llm", false)
 	gen := s.reviewLLMGenWithUsage(useLLM)
@@ -1068,7 +1093,7 @@ func (s *Server) handleReviewPack(ctx context.Context, req mcp.CallToolRequest) 
 	report, err := review.RunWithUsage(ctx, s.graph, gen, s.reviewPricing(), review.Options{
 		RepoRoot:        repoRoot,
 		RepoPrefix:      repoPrefix,
-		CoverageKnown:   diff != nil && s.coverageKnownForDiff(repoPrefix, diff.ChangedFiles),
+		CoverageKnown:   len(testTargets) > 0 || (diff != nil && s.coverageKnownForDiff(repoPrefix, diff.ChangedFiles)),
 		Scope:           scope,
 		BaseRef:         baseRef,
 		Diff:            diffText,
@@ -1105,8 +1130,6 @@ func (s *Server) handleReviewPack(ctx context.Context, req mcp.CallToolRequest) 
 	// Per-symbol semantic classification, graph-grounded on the diff-hunk text.
 	changedSyms := s.classifyChangedSymbols(diff, impact)
 
-	// Impacted test targets → the concrete verification command.
-	testTargets := s.reviewTestTargets(ctx, ids)
 	verCmd := review.VerificationCommand(testTargets, reviewPackLang(diff))
 
 	// Cost bound: run a speculative preview_edit for the high-risk (d=1-heavy)

--- a/internal/mcp/tools_review_coverage_test.go
+++ b/internal/mcp/tools_review_coverage_test.go
@@ -1,0 +1,114 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// coverageProbeServer builds a bare Server around g — enough for the
+// coverage-attestation probe, which reads nothing but the graph.
+func coverageProbeServer(g graph.Store) *Server {
+	return &Server{graph: g}
+}
+
+func testSymbol(id, file string, meta map[string]any) *graph.Node {
+	return &graph.Node{
+		ID: id, Name: id, Kind: graph.KindFunction, FilePath: file, Meta: meta,
+	}
+}
+
+// TestCoverageKnownFromTestStamp is the regression for issue #350: a vitest
+// probe co-located with the code it exercises carries no path fragment the
+// old probe looked for beyond the filename, and an annotation-driven test
+// carries none at all. The indexer stamps both is_test, so the attestation
+// must follow the stamp rather than a hardcoded fragment list.
+func TestCoverageKnownFromTestStamp(t *testing.T) {
+	g := graph.New()
+	g.AddNode(testSymbol("src/production.ts::resolveEntityOrderBy", "src/production.ts", nil))
+	g.AddNode(testSymbol(
+		"src/production.test.ts::expectResolveEntityOrderByBehaviors",
+		"src/production.test.ts",
+		map[string]any{"is_test": true, "test_runner": "vitest"},
+	))
+	s := coverageProbeServer(g)
+
+	require.True(t, s.coverageKnownForDiff("", []string{"src/production.ts", "src/production.test.ts"}),
+		"a stamped vitest probe attests coverage for the changed TypeScript")
+}
+
+// TestCoverageKnownAnnotationDrivenTest pins the case the fragment probe
+// could never see: a Rust #[test] in a production-path file. It has no test
+// filename and no test directory — only the indexer's stamp.
+func TestCoverageKnownAnnotationDrivenTest(t *testing.T) {
+	g := graph.New()
+	g.AddNode(testSymbol("src/lib.rs::parse", "src/lib.rs", nil))
+	g.AddNode(testSymbol("src/lib.rs::parses_empty", "src/lib.rs", map[string]any{"is_test": true}))
+
+	require.True(t, coverageProbeServer(g).coverageKnownForDiff("", []string{"src/lib.rs"}))
+}
+
+// TestCoverageUnknownWhenIndexExcludesTests pins the behaviour the
+// attestation exists for: an index whose config drops the language's test
+// files must NOT read as "untested", it must read as unknown.
+func TestCoverageUnknownWhenIndexExcludesTests(t *testing.T) {
+	g := graph.New()
+	g.AddNode(testSymbol("pkg/foo.go::Bar", "pkg/foo.go", nil))
+
+	require.False(t, coverageProbeServer(g).coverageKnownForDiff("", []string{"pkg/foo.go"}))
+}
+
+// TestCoverageKnownIsPerLanguage pins that attesting one language does not
+// attest another: a repo that indexes Go tests but excludes its TypeScript
+// tests can still only speak for the Go half of a polyglot diff.
+func TestCoverageKnownIsPerLanguage(t *testing.T) {
+	g := graph.New()
+	g.AddNode(testSymbol("pkg/foo.go::Bar", "pkg/foo.go", nil))
+	g.AddNode(testSymbol("pkg/foo_test.go::TestBar", "pkg/foo_test.go", nil))
+	g.AddNode(testSymbol("src/app.ts::render", "src/app.ts", nil))
+	s := coverageProbeServer(g)
+
+	require.True(t, s.coverageKnownForDiff("", []string{"pkg/foo.go"}))
+	require.False(t, s.coverageKnownForDiff("", []string{"pkg/foo.go", "src/app.ts"}),
+		"Go tests say nothing about whether TypeScript tests are indexed")
+}
+
+// TestCoverageKnownWindowsSeparators pins the Windows shape from the issue
+// report: graph nodes carry backslash-separated paths while git emits
+// forward slashes, and both spellings must classify the same.
+func TestCoverageKnownWindowsSeparators(t *testing.T) {
+	g := graph.New()
+	g.AddNode(testSymbol(`src\production.ts::resolve`, `src\production.ts`, nil))
+	g.AddNode(testSymbol(`src\__tests__\production.ts::probe`, `src\__tests__\production.ts`, nil))
+
+	require.True(t, coverageProbeServer(g).coverageKnownForDiff("", []string{"src/production.ts"}))
+}
+
+// TestTestIndexProbeResetsOnReindex pins the staleness fix: the probe is
+// cached per repo prefix, and a probe that ran before the test-edge pass
+// stamped its symbols used to pin "no tests" for the daemon's lifetime.
+func TestTestIndexProbeResetsOnReindex(t *testing.T) {
+	g := graph.New()
+	g.AddNode(testSymbol("pkg/foo.go::Bar", "pkg/foo.go", nil))
+	s := coverageProbeServer(g)
+
+	require.False(t, s.coverageKnownForDiff("", []string{"pkg/foo.go"}), "mid-warmup: no test symbols yet")
+
+	g.AddNode(testSymbol("pkg/foo_test.go::TestBar", "pkg/foo_test.go", nil))
+	require.False(t, s.coverageKnownForDiff("", []string{"pkg/foo.go"}), "still serving the cached answer")
+
+	s.resetTestIndexProbe()
+	require.True(t, s.coverageKnownForDiff("", []string{"pkg/foo.go"}),
+		"the reset must let the next review see the test symbols the reindex landed")
+}
+
+// TestCoverageKnownIgnoresNonCodeChanges pins that a docs-only changeset
+// carries no language with a test convention to attest.
+func TestCoverageKnownIgnoresNonCodeChanges(t *testing.T) {
+	g := graph.New()
+	g.AddNode(testSymbol("pkg/foo_test.go::TestBar", "pkg/foo_test.go", nil))
+
+	require.False(t, coverageProbeServer(g).coverageKnownForDiff("", []string{"README.md", "docs/guide.md"}))
+}

--- a/internal/mcp/tools_review_pack_coverage_test.go
+++ b/internal/mcp/tools_review_pack_coverage_test.go
@@ -1,0 +1,135 @@
+package mcp
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+// vitestCoveredRepo builds the repo shape from issue #350 — a TypeScript
+// function exercised by a vitest probe, changed on top of a tagged base so
+// review_pack has a changeset with graph-mapped symbols.
+//
+// The suite lives in a tests/ directory rather than beside the code: the
+// indexer classifies it by that directory marker and emits its `tests` edge,
+// so the changed symbol is provably covered, while the filename carries none
+// of the fragments the old coverage probe scanned for. That is the gap the
+// issue's envelope fell into — test targets listed, coverage denied.
+func vitestCoveredRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	write := func(rel, src string) {
+		t.Helper()
+		abs := filepath.Join(dir, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(abs), 0o755))
+		require.NoError(t, os.WriteFile(abs, []byte(src), 0o644))
+	}
+
+	run("init", "-b", "main")
+	run("config", "user.email", "t@t")
+	run("config", "user.name", "t")
+	run("config", "diff.mnemonicPrefix", "false")
+	run("config", "diff.noprefix", "false")
+
+	prod := filepath.Join("src", "production.ts")
+	test := filepath.Join("tests", "production.ts")
+	write(prod, `export function resolveEntityOrderBy(sort: string): string[] {
+  return [sort];
+}
+`)
+	write(test, `import { describe, expect, it } from "vitest";
+import { resolveEntityOrderBy } from "../src/production";
+
+function expectResolveEntityOrderByBehaviors() {
+  expect(resolveEntityOrderBy("name")).toEqual(["name"]);
+  expect(resolveEntityOrderBy("id")).toEqual(["id"]);
+}
+
+describe("resolveEntityOrderBy", () => {
+  it("covers the sort field", expectResolveEntityOrderByBehaviors);
+});
+`)
+	run("add", ".")
+	run("commit", "-m", "base")
+	run("tag", "base-ref")
+
+	write(prod, `export function resolveEntityOrderBy(sort: string): string[] {
+  const field = sort.trim();
+  return [field];
+}
+`)
+	run("add", ".")
+	run("commit", "-m", "change")
+	return dir
+}
+
+// TestReviewPackNeverClaimsNoTestSymbolsWithTestTargets is the end-to-end
+// regression for issue #350. The reported envelope listed the test files
+// covering the change AND a summary asserting the index carried no test
+// symbols — two statements about the same graph that cannot both be true.
+// Whatever the repo-wide coverage probe concludes, the summary and the
+// test-target list must agree.
+func TestReviewPackNeverClaimsNoTestSymbolsWithTestTargets(t *testing.T) {
+	srv := indexedSiblingServer(t, vitestCoveredRepo(t))
+
+	res := callReviewPack(t, srv, map[string]any{"base": "base-ref"})
+	require.False(t, res.IsError, "review_pack errored: %v", res)
+
+	var out struct {
+		Summary     string   `json:"summary"`
+		TestTargets []string `json:"test_targets"`
+		FileRisk    []struct {
+			File      string `json:"file"`
+			Symbols   int    `json:"symbols"`
+			Uncovered int    `json:"uncovered"`
+		} `json:"file_risk"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(res.Content[0].(mcplib.TextContent).Text), &out))
+
+	require.NotEmpty(t, out.TestTargets, "the vitest probe covers the changed symbol")
+	require.NotContains(t, out.Summary, "no test symbols",
+		"the summary contradicts test_targets in the same envelope: %s", out.Summary)
+}
+
+// TestReviewPackCoverageEvidenceIsRecorded pins the other half: with the
+// index attesting coverage, the per-file rows carry the evidence behind the
+// risk tier instead of reporting zero symbols evaluated.
+func TestReviewPackCoverageEvidenceIsRecorded(t *testing.T) {
+	srv := indexedSiblingServer(t, vitestCoveredRepo(t))
+
+	res := callReviewPack(t, srv, map[string]any{"base": "base-ref"})
+	require.False(t, res.IsError, "review_pack errored: %v", res)
+
+	var out struct {
+		FileRisk []struct {
+			File      string `json:"file"`
+			Symbols   int    `json:"symbols"`
+			Uncovered int    `json:"uncovered"`
+		} `json:"file_risk"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(res.Content[0].(mcplib.TextContent).Text), &out))
+
+	evaluated := 0
+	for _, fr := range out.FileRisk {
+		evaluated += fr.Symbols
+	}
+	require.Positive(t, evaluated,
+		"coverage was attestable, so the changed symbols must be evaluated: %+v", out.FileRisk)
+}

--- a/internal/resolver/testpath.go
+++ b/internal/resolver/testpath.go
@@ -1,9 +1,6 @@
 package resolver
 
-import (
-	"path/filepath"
-	"strings"
-)
+import "github.com/zzet/gortex/internal/testpath"
 
 // isTestFilePath reports whether a source path follows a recognised test
 // convention.
@@ -13,54 +10,11 @@ import (
 // positive) without depending on Node.Meta test flags — which are not
 // re-stamped on the incremental-reindex path.
 //
-// RATIONALE: a verbatim port of internal/indexer.IsTestFile. The
-// resolver cannot import the indexer package (indexer → resolver is the
-// established import direction; the reverse would be a cycle), so the
-// predicate is duplicated here. It is intentionally identical in
-// behaviour; the canonical home is internal/indexer/testpattern.go and a
-// future refactor should consolidate both (plus the analysis/* copies)
-// into a leaf internal/pathutil package.
+// RATIONALE: the convention table lives in the stdlib-only leaf
+// internal/testpath. The resolver cannot import the indexer package
+// (indexer → resolver is the established import direction; the reverse
+// would be a cycle), so the predicate used to be duplicated here — and the
+// copies drifted. Both now delegate to the one definition.
 //
 // KEYWORDS: test-file, predicate, temporal, broken_dispatch, no-cycle
-func isTestFilePath(path string) bool {
-	if path == "" {
-		return false
-	}
-	// Directory-based hints first — covers projects that don't follow
-	// the per-file naming convention.
-	dir := filepath.ToSlash(path)
-	for _, marker := range []string{"/__tests__/", "/tests/", "/test/", "/spec/"} {
-		if strings.Contains(dir, marker) {
-			return true
-		}
-	}
-	if strings.HasPrefix(dir, "tests/") || strings.HasPrefix(dir, "test/") || strings.HasPrefix(dir, "spec/") {
-		return true
-	}
-
-	base := filepath.Base(path)
-	ext := strings.ToLower(filepath.Ext(base))
-	stem := strings.TrimSuffix(base, ext)
-
-	switch ext {
-	case ".go":
-		return strings.HasSuffix(stem, "_test")
-	case ".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs":
-		return strings.HasSuffix(stem, ".test") || strings.HasSuffix(stem, ".spec")
-	case ".py":
-		return strings.HasPrefix(stem, "test_") || strings.HasSuffix(stem, "_test")
-	case ".dart":
-		return strings.HasSuffix(stem, "_test")
-	case ".rb":
-		return strings.HasSuffix(stem, "_spec") || strings.HasSuffix(stem, "_test")
-	case ".java", ".kt":
-		return strings.HasSuffix(stem, "Test") || strings.HasSuffix(stem, "Tests")
-	case ".cs":
-		return strings.HasSuffix(stem, "Tests") || strings.HasSuffix(stem, "Test")
-	case ".swift":
-		return strings.HasSuffix(stem, "Tests")
-	case ".php":
-		return strings.HasSuffix(stem, "Test") || strings.HasSuffix(stem, "test")
-	}
-	return false
-}
+func isTestFilePath(path string) bool { return testpath.IsTestFile(path) }

--- a/internal/review/flow.go
+++ b/internal/review/flow.go
@@ -28,11 +28,15 @@ type Options struct {
 	// multi-repo daemons key file paths as "<prefix>/<rel>" while git emits
 	// repo-relative paths. Empty in single-repo / unprefixed mode.
 	RepoPrefix string
-	// CoverageKnown reports whether the graph indexes test symbols for this
-	// repo at all. When false the per-file coverage evidence is unknowable —
-	// an index config that excludes "**/*_test.go" would otherwise make
-	// every change read as untested — so the rows carry no untested counts
-	// and the headline says "coverage unknown" instead.
+	// CoverageKnown reports whether the graph indexes test symbols for the
+	// changed languages. When false the per-file coverage evidence is
+	// unknowable — an index config that excludes "**/*_test.go" would
+	// otherwise make every change read as untested — so the rows carry no
+	// untested counts and the headline says "coverage unknown" instead.
+	//
+	// It is also the only thing that licenses the headline to blame the
+	// index for missing coverage. Empty rows are not evidence of an index
+	// without tests; see summarize.
 	CoverageKnown bool
 	// Scope selects the git diff range: "staged", "all", "compare", or
 	// "unstaged" (default). Ignored when Diff is set.
@@ -401,7 +405,7 @@ func compress(opts Options, plan *reviewPlan, llmFindings []Finding, dropped int
 		Verdict:  verdict,
 		Findings: merged,
 		FileRisk: fileRisk,
-		Summary:  summarize(verdict, merged, fileRisk),
+		Summary:  summarize(verdict, merged, fileRisk, opts.CoverageKnown),
 		Depth:    plan.depth.String(),
 		Stats: ReviewStats{
 			Rulepack:     len(plan.ruleFinds),
@@ -454,14 +458,22 @@ func sortFindings(findings []Finding) {
 // blast radius, tempered by test coverage), so the headline says which tier
 // earned it — and whether the risk is untested — instead of the
 // self-contradictory "BLOCK: no findings".
-func summarize(verdict Verdict, findings []Finding, fileRisk []FileRisk) string {
+//
+// coverageKnown is the caller's attestation that the index carries test
+// symbols for the changed languages, and it is the ONLY thing that licenses
+// blaming the index. The rows alone cannot: FileRisk.Symbols is zero both
+// when coverage was unattestable and when the changeset simply mapped to no
+// graph symbols to evaluate (a pasted diff, a brand-new file), and inferring
+// the first from the second made the headline assert "the index carries no
+// test symbols" over a graph full of them.
+func summarize(verdict Verdict, findings []Finding, fileRisk []FileRisk, coverageKnown bool) string {
 	if len(findings) == 0 {
 		if verdict != VerdictApprove && len(fileRisk) > 0 {
 			worst := fileRisk[0].Risk // sorted worst-first
-			n, untested, known := 0, 0, false
+			n, untested, evaluated := 0, 0, false
 			for _, fr := range fileRisk {
 				if fr.Symbols > 0 {
-					known = true
+					evaluated = true
 				}
 				if fr.Risk != worst {
 					continue
@@ -475,11 +487,14 @@ func summarize(verdict Verdict, findings []Finding, fileRisk []FileRisk) string 
 			case untested > 0:
 				return fmt.Sprintf("%s: no rule findings, but %d of %d changed file(s) carry %s blast-radius risk (%d without covering tests)",
 					verdict, n, len(fileRisk), worst, untested)
-			case known:
+			case evaluated:
 				return fmt.Sprintf("%s: no rule findings; %d of %d changed file(s) carry %s blast-radius risk, all test-covered",
 					verdict, n, len(fileRisk), worst)
+			case !coverageKnown:
+				return fmt.Sprintf("%s: no rule findings, but %d of %d changed file(s) carry %s blast-radius risk (test coverage unknown — the index carries no test symbols for the changed language(s))",
+					verdict, n, len(fileRisk), worst)
 			default:
-				return fmt.Sprintf("%s: no rule findings, but %d of %d changed file(s) carry %s blast-radius risk (test coverage unknown — the index carries no test symbols)",
+				return fmt.Sprintf("%s: no rule findings, but %d of %d changed file(s) carry %s blast-radius risk (coverage not evaluated — no changed symbol mapped to the graph)",
 					verdict, n, len(fileRisk), worst)
 			}
 		}

--- a/internal/review/flow_test.go
+++ b/internal/review/flow_test.go
@@ -307,19 +307,27 @@ func TestRankFileRiskCoverageUnknown(t *testing.T) {
 	require.Zero(t, rows[0].Uncovered)
 }
 
-// TestSummarizeCoveragePhrasing pins the three risk-driven headlines: untested
-// risk, fully covered risk, and unknown coverage.
+// TestSummarizeCoveragePhrasing pins the four risk-driven headlines: untested
+// risk, fully covered risk, unattestable coverage, and coverage that simply
+// was not evaluated.
 func TestSummarizeCoveragePhrasing(t *testing.T) {
 	critical := string(analysis.RiskCritical)
 
-	untested := summarize(VerdictBlock, nil, []FileRisk{{File: "a.go", Risk: critical, Symbols: 2, Uncovered: 1}})
+	untested := summarize(VerdictBlock, nil, []FileRisk{{File: "a.go", Risk: critical, Symbols: 2, Uncovered: 1}}, true)
 	require.Contains(t, untested, "1 without covering tests")
 
-	covered := summarize(VerdictReview, nil, []FileRisk{{File: "a.go", Risk: critical, Symbols: 2}})
+	covered := summarize(VerdictReview, nil, []FileRisk{{File: "a.go", Risk: critical, Symbols: 2}}, true)
 	require.Contains(t, covered, "all test-covered")
 
-	unknown := summarize(VerdictBlock, nil, []FileRisk{{File: "a.go", Risk: critical}})
+	unknown := summarize(VerdictBlock, nil, []FileRisk{{File: "a.go", Risk: critical}}, false)
 	require.Contains(t, unknown, "test coverage unknown")
+
+	// The index DOES carry test symbols; the changeset just mapped to no
+	// graph symbols to evaluate. Blaming the index here is the fabrication
+	// issue #350 reported, so the headline must not.
+	notEvaluated := summarize(VerdictBlock, nil, []FileRisk{{File: "a.go", Risk: critical}}, true)
+	require.Contains(t, notEvaluated, "coverage not evaluated")
+	require.NotContains(t, notEvaluated, "carries no test symbols")
 }
 
 // TestComputeVerdictCoverageCap pins the coverage temper: a critical-risk

--- a/internal/testpath/testpath.go
+++ b/internal/testpath/testpath.go
@@ -1,0 +1,96 @@
+// Package testpath carries the canonical "is this a test source file?"
+// predicate.
+//
+// The predicate is consumed by packages on both sides of every import
+// boundary that matters — the indexer stamps test symbols with it, the
+// resolver excludes test files from dispatch inference, and the impact
+// analyzer uses it to attribute covering tests. Each of those grew its own
+// copy, and the copies drifted: the analysis copy recognised seven filename
+// fragments where the indexer recognised eleven language conventions plus
+// four directory markers, so a Ruby `_spec.rb` or a JUnit `FooTest.java`
+// counted as a test when the indexer emitted its `tests` edges but not when
+// the impact analyzer looked for covering tests. A change could then read as
+// untested in one tool and covered in another, from the same graph.
+//
+// This package is a stdlib-only leaf so every one of those callers can
+// depend on it without an import cycle. It is the single definition.
+package testpath
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// dirMarkers are the directory names that mark everything beneath them as
+// test code, regardless of the per-file naming convention.
+var dirMarkers = []string{"__tests__", "tests", "test", "spec"}
+
+// IsTestFile reports whether the file's name or directory matches a
+// recognised test convention. False positives are downgraded downstream by
+// the symbol-name filter (indexer.IsTestSymbol).
+//
+// Backslashes are folded to slashes on every platform, not just via
+// filepath.ToSlash on Windows. Graph node paths carry the indexing host's
+// separator while git emits forward slashes, so both spellings reach this
+// predicate in the same process; classifying them differently is what let a
+// directory marker slip past. The cost is that a POSIX file whose *name*
+// literally contains a backslash may read as a directory marker — a trade
+// worth making against a cross-platform misclassification.
+//
+// Recognised conventions:
+//
+//	*_test.go                          (Go)
+//	*.test.{ts,tsx,js,jsx,mts,cts}     (TS/JS via Jest/Vitest convention)
+//	*.spec.{ts,tsx,js,jsx,mts,cts}     (TS/JS spec convention)
+//	test_*.py / *_test.py              (Python)
+//	*_test.dart                        (Dart)
+//	*_spec.rb / *_test.rb              (Ruby)
+//	*Test.java / *Tests.java           (JUnit / Spring)
+//	*Test.kt  / *Tests.kt              (Kotlin)
+//	*Tests.cs                          (C# xUnit/NUnit)
+//	*Tests.swift                       (Swift)
+//	*Test.php / *test.php              (PHPUnit / Pest)
+//	files under __tests__/, tests/,
+//	  test/, spec/                     (any language using these dirs)
+func IsTestFile(path string) bool {
+	if path == "" {
+		return false
+	}
+	// Directory-based hints first — covers projects that don't follow
+	// the per-file naming convention.
+	slashed := strings.ReplaceAll(path, `\`, "/")
+	for _, marker := range dirMarkers {
+		if strings.Contains(slashed, "/"+marker+"/") || strings.HasPrefix(slashed, marker+"/") {
+			return true
+		}
+	}
+
+	base := slashed
+	if i := strings.LastIndex(base, "/"); i >= 0 {
+		base = base[i+1:]
+	}
+	ext := strings.ToLower(filepath.Ext(base))
+	stem := strings.TrimSuffix(base, ext)
+
+	switch ext {
+	case ".go":
+		return strings.HasSuffix(stem, "_test")
+	case ".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs":
+		return strings.HasSuffix(stem, ".test") || strings.HasSuffix(stem, ".spec")
+	case ".py":
+		return strings.HasPrefix(stem, "test_") || strings.HasSuffix(stem, "_test")
+	case ".dart":
+		return strings.HasSuffix(stem, "_test")
+	case ".rb":
+		return strings.HasSuffix(stem, "_spec") || strings.HasSuffix(stem, "_test")
+	case ".java", ".kt":
+		return strings.HasSuffix(stem, "Test") || strings.HasSuffix(stem, "Tests")
+	case ".cs":
+		return strings.HasSuffix(stem, "Tests") || strings.HasSuffix(stem, "Test")
+	case ".swift":
+		return strings.HasSuffix(stem, "Tests")
+	case ".php":
+		return strings.HasSuffix(stem, "Test") || strings.HasSuffix(stem, "test")
+	}
+	return false
+}

--- a/internal/testpath/testpath_test.go
+++ b/internal/testpath/testpath_test.go
@@ -1,0 +1,63 @@
+package testpath
+
+import "testing"
+
+func TestIsTestFile(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"", false},
+		{"internal/indexer/indexer_test.go", true},
+		{"cmd/gortex/main.go", false},
+		{"src/components/Button.test.tsx", true},
+		{"src/components/Button.spec.ts", true},
+		{"src/components/Button.tsx", false},
+		{"tests/test_user.py", true},
+		{"app/test_helpers.py", true},
+		{"app/helpers.py", false},
+		{"lib/user_test.dart", true},
+		{"lib/user.dart", false},
+		{"spec/user_spec.rb", true},
+		{"app/user.rb", false},
+		{"src/UserTest.java", true},
+		{"src/User.java", false},
+		{"src/UserTests.kt", true},
+		{"src/User.kt", false},
+		{"X/Y/__tests__/Z.ts", true},
+		{"X/Y/__tests__/Z.js", true},
+		{"X/test/foo.go", true}, // dir marker overrides extension miss
+		{"src/UserTests.cs", true},
+		{"src/UserTests.swift", true},
+		{"src/UserTest.php", true},
+
+		// A repo-root test directory has no leading separator to anchor on.
+		{"__tests__/Z.ts", true},
+		{"tests/helpers.rb", true},
+		{"test/main.c", true},
+		{"spec/support/factory.rb", true},
+
+		// Windows-shaped paths classify like their POSIX spelling. Graph
+		// nodes on Windows carry backslash-separated paths; a separator-blind
+		// substring check used to miss the directory markers entirely.
+		{`src\components\Button.test.ts`, true},
+		{`src\__tests__\Z.ts`, true},
+		{`src\components\Button.ts`, false},
+
+		// A "test" substring is not a test file. The old analysis-side copy
+		// matched "test_" anywhere in the path, so these read as covering
+		// tests and inflated coverage.
+		{"src/latest_release.go", false},
+		{"pkg/contest/entry.py", false},
+		{"internal/attestation.ts", false},
+
+		// Directory markers must be whole path segments.
+		{"src/testing/helper.go", false},
+		{"src/spectrum/color.ts", false},
+	}
+	for _, c := range cases {
+		if got := IsTestFile(c.path); got != c.want {
+			t.Errorf("IsTestFile(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #350.

## Validation

Reproduced. On `main`, a TypeScript function whose vitest suite lives in a `tests/` directory produces exactly the reported envelope — the test file listed under `test_targets`, and a summary denying it exists:

```
summary:      "REVIEW: no rule findings, but 1 of 1 changed file(s) carry MEDIUM
               blast-radius risk (test coverage unknown — the index carries no
               test symbols)"
test_targets: ["tests/production.ts"]
file_risk:    [{ ..., "symbols": 0, "uncovered": 0 }]
```

That is the reporter's payload: `symbols: 0` on every row while `affected` is non-zero, which pins the cause to `CoverageKnown` arriving false. `rankFileRisk` only counts coverage evidence when coverage is attestable, so the rows go empty, and `summarize` then reads those empty rows as proof the index has no tests.

Three separate defects feed it. One caveat on the reporter's table: the `get_test_targets` / `uncovered_count` row is not a contradiction — those were called with different symbol sets (one explicit symbol vs. every changed
symbol), and both already walk the same `tests` edges. The real inconsistency was inside a single `review_pack` payload, between `file_risk[].uncovered` and `receipt.uncovered_count`, which measured coverage two different ways.

## 1. The coverage probe could not see the tests

`coverageKnownForDiff` asked "does this index carry tests for the changed languages?" by scanning graph node **paths** for hardcoded fragments — `_test.go`, `.test.ts`, `__tests__/`, `test_`. Three ways that answers no over a
graph full of test symbols:

- **Attribute-driven tests carry no fragment.** A Rust `#[test]` or a JUnit `@Test` is stamped `is_test` by the indexer and emits `tests` edges from a production-path file. The probe saw nothing.
- **`__tests__/` was matched raw** against node paths, so it never matched on a host that stamps backslash separators — the reporter is on Windows, where graph nodes carry `src\production.test.ts` while git emits `src/production.ts`.
- **The answer was cached for the daemon's lifetime.** A probe that ran during warmup — before the test-edge pass stamps its symbols — pinned "no tests" and no reindex cleared it. This matches the reporter's "re-indexed multiple times, contradiction persisted".

Now the probe reads the indexer's own `is_test` stamp, per language family, and `RunAnalysis` clears it alongside the lazy-enrichment ledger. Every `tests` edge originates at a stamped symbol, so scanning nodes covers the edge evidence too.

`review_pack` additionally resolves its test targets before the review runs and treats a non-empty list as coverage evidence in its own right. Those files come from the `tests`-edge walk, so the envelope can no longer list the tests
covering a change beside a summary asserting none exist — the consistency check the issue asked for.

## 2. The two coverage vocabularies disagreed

`file_risk[].uncovered` came from `ImpactResult.TestFiles` (a dependent whose *path* looks like a test), while `receipt.uncovered_count` came from the inbound `tests` edge. The path predicate was a seven-fragment substring match living in `internal/analysis`; the indexer stamps its edges from an eleven-language convention table. Everything outside the shorter list — a Ruby `_spec.rb`, a JUnit `FooTest.java`, anything under `tests/` — was covered by one measure and uncovered by the other, in the same payload. The short list was also too loose in the other direction, matching `test_` anywhere, so `pkg/latest_release.go` counted as a covering test.

The convention table now lives in a stdlib-only leaf package that the indexer, the resolver, and the impact analyzer all delegate to, so there is one definition instead of three copies that drift. (The resolver's copy already carried a comment asking for exactly this.) Backslashes fold to slashes on every platform rather than only under `filepath.ToSlash` on Windows.

## 3. The summary asserted a fact it never checked

`summarize` inferred "the index carries no test symbols" from finding no per-file row with symbols evaluated. That inference does not hold: a row reports zero evaluated symbols both when coverage was unattestable **and** when the changeset simply mapped to no graph symbols to evaluate — a pasted diff, a brand-new file. Only the caller knows which, and it already passes that answer in as `CoverageKnown`. It now reads it from there, and the second case gets its own wording instead of blaming the index.

## On the expected verdict

The issue expects `APPROVE`. This keeps `REVIEW`, and that is deliberate rather than unfixed: a fully test-covered file with MEDIUM+ blast radius contributes `REVIEW` by design (`computeVerdict` caps it there so blast radius alone cannot block a well-tested change, but does not clear it). What changes is that the summary is now true and self-consistent:

```
REVIEW: no rule findings; 1 of 1 changed file(s) carry MEDIUM blast-radius
        risk, all test-covered
```

Loosening that ladder is a policy change, not a bug fix, so it is left alone.

## Tests

Every new test was confirmed to fail on `main` before the fix:

- `internal/mcp/tools_review_pack_coverage_test.go` — end-to-end through `handleReviewPack`; reproduces the reported summary on `main`.
- `internal/mcp/tools_review_coverage_test.go` — the probe: stamped vitest probe, Rust `#[test]`, Windows separators, per-language scoping, the excluded-tests case the attestation exists for, and the cache reset.
- `internal/analysis/coverage_agreement_test.go` — the two coverage vocabularies agree across seven conventions; the `test_` substring false positive is gone.
- `internal/testpath/testpath_test.go` — the predicate itself.

`go build ./...`, `go vet`, `golangci-lint`, and `gofmt` are clean;
`go test -race ./...` passes.
