### PR TITLE
Type an untyped PHP property from what the class assigns it

### DIFF
--- a/internal/parser/languages/php_receiver.go
+++ b/internal/parser/languages/php_receiver.go
@@ -312,6 +312,7 @@ func phpClassPropertyTypes(body *sitter.Node, src []byte) map[string]string {
 			}
 		}
 	}
+	collectPHPAssignedPropertyTypes(body, src, props)
 	if len(props) == 0 {
 		return nil
 	}
@@ -386,4 +387,68 @@ func (env phpReceiverEnv) phpScopeReceiverType(scope *sitter.Node, src []byte) s
 		return env.lookupVar(strings.TrimPrefix(strings.TrimSpace(scope.Content(src)), "$"))
 	}
 	return ""
+}
+
+
+// collectPHPAssignedPropertyTypes types a property that carries no type
+// DECLARATION from `$this->prop = new Foo()` in the class body. PHP only got
+// typed properties in 7.4, so a large body of code declares `private $handler;`
+// and states the type solely by what it assigns — 7.1% of every member call
+// laravel/framework leaves untyped reads through such a property.
+//
+// A declared type always wins, and a property assigned two different classes
+// anywhere in the class is dropped, for the same reason a conflicting local
+// `new` is: a flow-insensitive answer that is sometimes wrong binds a call to
+// the wrong method at the resolved tier.
+func collectPHPAssignedPropertyTypes(body *sitter.Node, src []byte, props map[string]string) {
+	if body == nil || props == nil {
+		return
+	}
+	assigned := map[string]string{}
+	conflicted := map[string]bool{}
+	var walk func(n *sitter.Node)
+	walk = func(n *sitter.Node) {
+		if n == nil {
+			return
+		}
+		if n.Type() == "assignment_expression" {
+			left := n.ChildByFieldName("left")
+			right := n.ChildByFieldName("right")
+			if left != nil && right != nil && left.Type() == "member_access_expression" {
+				if name := phpThisPropertyName(left, src); name != "" && !conflicted[name] {
+					if cls := phpNewExpressionClass(right, src); cls != "" {
+						if prev, ok := assigned[name]; ok && prev != cls {
+							delete(assigned, name)
+							conflicted[name] = true
+						} else {
+							assigned[name] = cls
+						}
+					}
+				}
+			}
+		}
+		for i, c := 0, int(n.NamedChildCount()); i < c; i++ {
+			walk(n.NamedChild(i))
+		}
+	}
+	walk(body)
+	for name, cls := range assigned {
+		if _, declared := props[name]; !declared {
+			props[name] = cls
+		}
+	}
+}
+
+// phpThisPropertyName returns the property name of a `$this->name` access, or
+// "" for any other receiver or a computed member.
+func phpThisPropertyName(access *sitter.Node, src []byte) string {
+	inner := access.ChildByFieldName("object")
+	nameNode := access.ChildByFieldName("name")
+	if inner == nil || nameNode == nil || nameNode.Type() != "name" {
+		return ""
+	}
+	if inner.Type() != "variable_name" || strings.TrimSpace(inner.Content(src)) != "$this" {
+		return ""
+	}
+	return strings.TrimSpace(nameNode.Content(src))
 }

--- a/internal/parser/languages/php_receiver_test.go
+++ b/internal/parser/languages/php_receiver_test.go
@@ -358,3 +358,125 @@ function run(string $cls): void {
 	require.True(t, found)
 	assert.Equal(t, "", rt)
 }
+
+// PHP only got typed properties in 7.4, so a large body of code declares
+// `private $handler;` and states the type solely by what it assigns.
+func TestPHPReceiver_UntypedPropertyTypedByConstructorAssignment(t *testing.T) {
+	rt, found := phpCallReceiver(t, `<?php
+class Service {
+    private $logger;
+
+    public function __construct() {
+        $this->logger = new FileLogger();
+    }
+
+    public function run(): void {
+        $this->logger->warning('x');
+    }
+}
+`, "warning")
+	require.True(t, found)
+	assert.Equal(t, "FileLogger", rt)
+}
+
+// The assignment may be anywhere in the class, not only the constructor —
+// a setUp() method is the same statement about the property.
+func TestPHPReceiver_UntypedPropertyTypedByAnyMethodAssignment(t *testing.T) {
+	rt, found := phpCallReceiver(t, `<?php
+class ServiceTest {
+    private $handler;
+
+    protected function setUp(): void {
+        $this->handler = new StreamHandler();
+    }
+
+    public function testWrites(): void {
+        $this->handler->close();
+    }
+}
+`, "close")
+	require.True(t, found)
+	assert.Equal(t, "StreamHandler", rt)
+}
+
+// A declaration always wins over an assignment: the declared type is the
+// contract, the assignment is one of possibly many values.
+func TestPHPReceiver_DeclaredPropertyTypeBeatsAssignment(t *testing.T) {
+	rt, found := phpCallReceiver(t, `<?php
+class Service {
+    private HandlerInterface $handler;
+
+    public function __construct() {
+        $this->handler = new StreamHandler();
+    }
+
+    public function run(): void {
+        $this->handler->close();
+    }
+}
+`, "close")
+	require.True(t, found)
+	assert.Equal(t, "HandlerInterface", rt)
+}
+
+// A property assigned two different classes cannot be typed
+// flow-insensitively, for the same reason a conflicting local `new` is dropped.
+func TestPHPReceiver_ConflictingPropertyAssignmentsStayUntyped(t *testing.T) {
+	rt, found := phpCallReceiver(t, `<?php
+class Service {
+    private $handler;
+
+    public function boot(bool $rotate): void {
+        $this->handler = new StreamHandler();
+        if ($rotate) {
+            $this->handler = new RotatingFileHandler();
+        }
+    }
+
+    public function run(): void {
+        $this->handler->close();
+    }
+}
+`, "close")
+	require.True(t, found)
+	assert.Equal(t, "", rt)
+}
+
+// Only `$this->prop` counts — an assignment through another object says
+// nothing about this class's property.
+func TestPHPReceiver_ForeignPropertyAssignmentIgnored(t *testing.T) {
+	rt, found := phpCallReceiver(t, `<?php
+class Service {
+    private $handler;
+
+    public function boot(Other $o): void {
+        $o->handler = new StreamHandler();
+    }
+
+    public function run(): void {
+        $this->handler->close();
+    }
+}
+`, "close")
+	require.True(t, found)
+	assert.Equal(t, "", rt)
+}
+
+// `new $cls` names no static class, so it types nothing.
+func TestPHPReceiver_DynamicPropertyAssignmentStaysUntyped(t *testing.T) {
+	rt, found := phpCallReceiver(t, `<?php
+class Service {
+    private $handler;
+
+    public function boot(string $cls): void {
+        $this->handler = new $cls();
+    }
+
+    public function run(): void {
+        $this->handler->close();
+    }
+}
+`, "close")
+	require.True(t, found)
+	assert.Equal(t, "", rt)
+}


### PR DESCRIPTION
Stacked on #387 (base is `feat/php-namespace-identity`; GitHub will retarget to
`main` when that merges).

This started as "close the remaining PHP receiver-typing gap". I measured two
candidate approaches. **One of them does not work, and the larger part of this
PR's value is the negative result** — it closes off a line of work that looks
obviously right on paper.

## What shipped

Typed properties arrived in PHP 7.4, so a large body of code declares
`private $handler;` and states the type solely by what it assigns. The receiver
environment read declarations only, so every call through such a property was
untyped — **7.1% of the member calls laravel/framework leaves untyped read
through one**.

A property with no declared type now takes the class it is assigned, from
anywhere in the class body: a constructor, a `setUp()`, a `boot()`. Only
`$this->prop = new Foo()` counts — an assignment through another object says
nothing about this class's property, and `new $cls` names no static class.

The guards match the ones already on local variables:

- a declaration always wins, because the declared type is the contract and an
  assignment is one of possibly several values;
- a property assigned two different classes anywhere in the class is dropped
  rather than guessed, since a flow-insensitive answer that is sometimes wrong
  binds the call to the wrong method at the *resolved* tier.

In-principle call resolution on laravel/framework: **77.0% → 77.2%** (+234
edges). monolog, symfony/console and guzzle are unchanged, which is the point —
they use typed properties throughout, and this reaches the code that predates
them.

## What did not work, and why

The bigger bucket looked far more promising. Across four corpora, the two
largest shapes the environment cannot type are call results, not declarations:

| shape | monolog | sf-console | guzzle | laravel |
|---|---|---|---|---|
| fluent chain `call()->m()` | 52.6% | 31.6% | 30.9% | 50.3% |
| `$v = call()`, callee has a declared return type | 8.6% | 32.2% | 19.7% | 12.1% |

Neither needs interprocedural analysis — the producing method's return type is
*declared*, so the chain can be walked one hop at a time. The resolver even has
the walker already: `ResolveFactoryChains` reads `Meta["receiver_expr"]` and
follows each hop's return type across the graph. It never fired for PHP only
because `stampFactoryChainReceiver` stamps solely when the base segment was
itself invoked, which no `$this->x()` chain looks like.

I implemented it: the extractor renders the chain with each base substituted for
something the graph can name (`$this` → the enclosing class, a typed variable →
its type, a variable assigned from a call → that call's own chain), plus a
PHP-specific walker, because the generic one resolves each hop with
`findMethodNodeConformant` — which searches *downward* to implementors, the
wrong direction for PHP, where the method a receiver exposes is normally
declared on a trait, abstract base or interface.

It stamped 655 / 1288 / 948 / 44616 edges across the four corpora and bound
**+10, +8, +0, and 0**. Every eligible Laravel edge failed. Instrumenting the
walk says why:

```
m.mock.shouldReceive              # Mockery — a vendor test-double library
LoggerTest.getMockBuilder.disableOriginalConstructor.onlyMethods.getMock
DB.table.whereTime                # a Laravel facade: __callStatic, no declared method
app.getSymfonyTransport           # a global helper returning mixed
```

Real PHP's fluent-chain population is dominated by vendor test doubles, facade
`__callStatic` magic, and helpers returning `mixed`. None has a declared return
type to walk, and none ever will. The `$this->getFormatter()->format()` shape I
built this for is real but rare next to them.

My earlier estimate that 12–32% was recoverable was **wrong**, and worth
recording: the probe behind it keyed "has a declared return type" by method
*name globally*, so `getMock` counted as typed because something, somewhere,
declared a return type for a method of that name. Walking actually requires the
base to be an in-repo type *and* that specific method on it.

So the chain work is reverted, not shipped. Reaching those calls needs the
declared types of the *dependencies* — reading return types out of `vendor/`, or
a language server — not more static inference over first-party source.

## Verification

`go test -race ./...`, `golangci-lint run ./internal/...`. Six new test cases
covering the assignment rule and each guard.
