### PR TITLE
Let a published batch receipt own its storage

### DIFF
--- a/internal/mcp/batch_transaction.go
+++ b/internal/mcp/batch_transaction.go
@@ -75,24 +75,40 @@ type batchTransactionState struct {
 	receipt     batchTransactionReceipt
 }
 
+// cloneBatchReceipt returns a receipt that shares no slice or map storage with
+// the original. Both state boundaries copy through it, so a published receipt is
+// owned solely by the state: a publisher stays free to keep mutating its own
+// copy — runBatchTransaction stamps Results[i].Status = "applied" in place after
+// publishing "prepared" — without writing into memory a concurrent reader holds.
+func cloneBatchReceipt(receipt batchTransactionReceipt) batchTransactionReceipt {
+	clone := receipt
+	clone.Results = append([]batchEditResult(nil), receipt.Results...)
+	clone.Files = append([]batchTransactionFile(nil), receipt.Files...)
+	if receipt.Summary != nil {
+		clone.Summary = make(map[string]int, len(receipt.Summary))
+		for key, value := range receipt.Summary {
+			clone.Summary[key] = value
+		}
+	}
+	if receipt.CompletedAt != nil {
+		completedAt := *receipt.CompletedAt
+		clone.CompletedAt = &completedAt
+	}
+	return clone
+}
+
 func (state *batchTransactionState) snapshot() batchTransactionReceipt {
 	state.mu.RLock()
 	defer state.mu.RUnlock()
-	copyReceipt := state.receipt
-	copyReceipt.Results = append([]batchEditResult(nil), state.receipt.Results...)
-	copyReceipt.Files = append([]batchTransactionFile(nil), state.receipt.Files...)
-	if state.receipt.Summary != nil {
-		copyReceipt.Summary = make(map[string]int, len(state.receipt.Summary))
-		for key, value := range state.receipt.Summary {
-			copyReceipt.Summary[key] = value
-		}
-	}
-	return copyReceipt
+	return cloneBatchReceipt(state.receipt)
 }
 
 func (state *batchTransactionState) publish(receipt batchTransactionReceipt, terminal bool) {
+	// Copy before taking the lock: the clone reads only the publisher's own
+	// storage, and the state must not retain a slice the publisher still holds.
+	stored := cloneBatchReceipt(receipt)
 	state.mu.Lock()
-	state.receipt = receipt
+	state.receipt = stored
 	state.mu.Unlock()
 	if terminal {
 		state.doneOnce.Do(func() { close(state.done) })

--- a/internal/mcp/batch_transaction_test.go
+++ b/internal/mcp/batch_transaction_test.go
@@ -195,6 +195,113 @@ func TestAtomicBatchConcurrentIdempotencyWritesOnce(t *testing.T) {
 	}
 }
 
+func TestBatchTransactionPublishCopiesReceiptStorage(t *testing.T) {
+	state := &batchTransactionState{done: make(chan struct{})}
+	completedAt := time.Now().UTC()
+	original := completedAt
+	published := batchTransactionReceipt{
+		Status:      "prepared",
+		Results:     []batchEditResult{{FilePath: "a.txt", Status: "validated"}},
+		Files:       []batchTransactionFile{{Path: "/tmp/a.txt"}},
+		Summary:     map[string]int{"total": 1},
+		CompletedAt: &completedAt,
+	}
+	state.publish(published, false)
+
+	// A publisher goes on mutating its own receipt after publishing; none of
+	// that may reach the state, which concurrent readers snapshot under RLock.
+	published.Results[0].Status = "applied"
+	published.Files[0].ReindexReceipt = "receipt-1"
+	published.Summary["total"] = 99
+	*published.CompletedAt = completedAt.Add(time.Hour) // also rewrites completedAt
+
+	stored := state.snapshot()
+	if stored.Results[0].Status != "validated" {
+		t.Errorf("Results storage is shared with the publisher: %q", stored.Results[0].Status)
+	}
+	if stored.Files[0].ReindexReceipt != "" {
+		t.Errorf("Files storage is shared with the publisher: %q", stored.Files[0].ReindexReceipt)
+	}
+	if stored.Summary["total"] != 1 {
+		t.Errorf("Summary map is shared with the publisher: %d", stored.Summary["total"])
+	}
+	if !stored.CompletedAt.Equal(original) {
+		t.Errorf("CompletedAt is shared with the publisher: %s", stored.CompletedAt)
+	}
+
+	// The snapshot side owes the same isolation in the other direction.
+	stored.Results[0].Status = "failed"
+	stored.Summary["total"] = 7
+	if again := state.snapshot(); again.Results[0].Status != "validated" || again.Summary["total"] != 1 {
+		t.Errorf("snapshot storage is shared with the state: %+v", again)
+	}
+}
+
+func TestAtomicBatchSnapshotIsolatedFromCommitInProgress(t *testing.T) {
+	s := newAtomicBatchTestServer(t, mutationTestWatcher{})
+	path := writeAtomicBatchFixture(t, t.TempDir(), "isolated.txt", "old\n")
+	edits := []batchEditItem{atomicFileEdit(path, "old", "new")}
+	fingerprint := batchEditFingerprint(edits)
+
+	committing := make(chan struct{})
+	s.batchWriteOverride = func(target string, content []byte, mode os.FileMode) error {
+		// Signalled without waiting on the reader: a back-edge would order the
+		// commit loop's writes behind the reader's loads and hide the race.
+		close(committing)
+		return agents.AtomicWriteFile(target, content, mode)
+	}
+
+	stop := make(chan struct{})
+	torn := make(chan string, 1)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-committing
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			// The call path the race detector reported: an idempotent retry
+			// classifies the in-flight transaction by snapshotting its receipt.
+			state, _, err := s.loadOrCreateBatchTransaction("isolated-key", fingerprint)
+			if err != nil {
+				continue
+			}
+			observed := state.snapshot()
+			if observed.Status == "committed" {
+				continue
+			}
+			for _, result := range observed.Results {
+				if result.Status == "applied" {
+					select {
+					case torn <- fmt.Sprintf("status %q carried an applied result", observed.Status):
+					default:
+					}
+					return
+				}
+			}
+		}
+	}()
+
+	receipt, err := s.runBatchTransaction(context.Background(), edits, "isolated-key")
+	close(stop)
+	wg.Wait()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Status != "committed" || receipt.GraphStatus != "fresh" {
+		t.Fatalf("receipt = %+v", receipt)
+	}
+	select {
+	case message := <-torn:
+		t.Fatalf("reader observed a receipt the committer was still mutating: %s", message)
+	default:
+	}
+}
+
 func TestAtomicBatchPreflightFailureWritesNothing(t *testing.T) {
 	var scheduled atomic.Int64
 	s := newAtomicBatchTestServer(t, mutationTestWatcher{scheduled: &scheduled})


### PR DESCRIPTION
Fixes the data race that turned `main` red on the macOS runner: `TestAtomicBatchConcurrentIdempotencyWritesOnce`, `batch_transaction.go:501` (write) against `batch_transaction.go:82` (read) via `batch_transaction_journal.go:84`.

## Root cause

`batchTransactionState.publish` stored the receipt struct under the write lock, but `Results`, `Files` and `Summary` are reference types — the stored copy kept pointing at the publisher's backing array. `snapshot()` deep-copies on the way *out*, so it looked symmetric, but nothing stopped the publisher from writing into storage it had already handed over.

`runBatchTransaction` does exactly that:

1. publishes the receipt as `"prepared"` (results still `"validated"`),
2. commits to disk,
3. stamps `receipt.Results[i].Status = "applied"` **in place**,
4. republishes as `"committed"`.

Step 3 writes into the array a concurrent `snapshot()` reads under `RLock`. The lock protected the slice header; it never protected the elements.

## Why it is more than a detector complaint

A concurrent idempotent retry classifies the in-flight transaction by snapshotting its receipt. Between the applied-loop and the `"committed"` publish sits a manifest write and an fsync, so a reader reliably observes a torn receipt: `status "prepared"` already carrying `applied` results. The added test asserts that directly and fails without the fix.

## Fix

Copy through a single `cloneBatchReceipt` helper at *both* boundaries, so a published receipt is owned solely by the state and publishers stay free to keep mutating their own copy. `publish` clones before taking the lock — the clone touches only the publisher's own storage. `CompletedAt` is cloned too, closing the same aliasing hole for the one pointer field.

## Verification

- New `TestBatchTransactionPublishCopiesReceiptStorage` — deterministic, no race detector needed. Fails 3/3 without the fix on all four fields, in both directions.
- New `TestAtomicBatchSnapshotIsolatedFromCommitInProgress` — drives the reported interleaving through the same call path as the CI stack. Without the fix it reports the race **and** the torn observation; the write override deliberately signals without waiting, since a back-edge to the reader orders the commit loop behind its reads and hides the bug.
- Originally failing test stressed 30x at `-cpu=2,8`: clean.
- Full `go test -race ./internal/mcp/`: clean. `go build ./...`, `go vet`, `golangci-lint`: clean.