### PR TITLE
Improve Python parsing coverage and receiver typing

### DIFF
--- a/internal/parser/languages/python.go
+++ b/internal/parser/languages/python.go
@@ -29,8 +29,7 @@ const qPyAll = `
   (class_definition
     name: (identifier) @class.name) @class.def
 
-  (import_statement
-    name: (dotted_name) @import.name) @import.def
+  (import_statement) @import.def
 
   (import_from_statement
     module_name: (dotted_name) @import.module) @importfrom.def
@@ -707,32 +706,54 @@ func pyDocstringFromDef(defNode *sitter.Node, src []byte) string {
 // emitImport handles `import os`, `import os.path`, `import numpy as np`.
 // Walks the import_statement node to populate the alias→module map used
 // by attribute-call classification.
+//
+// The query deliberately matches `(import_statement)` with no `name:`
+// constraint. That field holds a `dotted_name` for `import os` but an
+// `aliased_import` for `import numpy as np`, so a pattern anchored on
+// `(dotted_name)` never fired for an aliased import — and `import x as y`
+// is how the entire numpy/pandas idiom is written. Walking the children
+// here covers both shapes, and every name in the statement.
 func (e *PythonExtractor) emitImport(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, imports map[string]string) {
-	name := m.Captures["import.name"]
-	pyEmitImportNode(filePath, fileID, name.Text, "", name.StartLine+1, result)
-	result.Edges = append(result.Edges, &graph.Edge{
-		From: fileID, To: "unresolved::import::" + name.Text,
-		Kind: graph.EdgeImports, FilePath: filePath, Line: name.StartLine + 1,
-	})
 	def, ok := m.Captures["import.def"]
 	if !ok || def.Node == nil {
 		return
 	}
 	stmt := def.Node
+	emit := func(modulePath, alias string, line int) {
+		if modulePath == "" {
+			return
+		}
+		pyEmitImportNode(filePath, fileID, modulePath, alias, line, result)
+		result.Edges = append(result.Edges, &graph.Edge{
+			From: fileID, To: "unresolved::import::" + modulePath,
+			Kind: graph.EdgeImports, FilePath: filePath, Line: line,
+		})
+	}
+	// One statement can bind several modules (`import os.path, numpy as
+	// np`), so every name child emits its own import node — the previous
+	// single-node-per-statement shape dropped the trailing names.
 	for i, _nc := 0, int(stmt.NamedChildCount()); i < _nc; i++ {
 		child := stmt.NamedChild(i)
+		if child == nil {
+			continue
+		}
+		line := int(child.StartPoint().Row) + 1
 		switch child.Type() {
 		case "dotted_name":
 			dotted := child.Content(src)
-			alias := dotted
+			bind := dotted
 			if j := strings.Index(dotted, "."); j >= 0 {
-				alias = dotted[:j] // `import os.path` binds `os`
+				bind = dotted[:j] // `import os.path` binds `os`
 			}
-			imports[alias] = dotted
+			imports[bind] = dotted
+			emit(dotted, "", line)
 		case "aliased_import":
 			var modulePath, alias string
-			for j, _nc := 0, int(child.NamedChildCount()); j < _nc; j++ {
+			for j, _jc := 0, int(child.NamedChildCount()); j < _jc; j++ {
 				cc := child.NamedChild(j)
+				if cc == nil {
+					continue
+				}
 				switch cc.Type() {
 				case "dotted_name":
 					modulePath = cc.Content(src)
@@ -740,9 +761,11 @@ func (e *PythonExtractor) emitImport(m parser.QueryResult, filePath, fileID stri
 					alias = cc.Content(src)
 				}
 			}
-			if alias != "" && modulePath != "" {
-				imports[alias] = modulePath
+			if alias == "" || modulePath == "" {
+				continue
 			}
+			imports[alias] = modulePath
+			emit(modulePath, alias, line)
 		}
 	}
 }

--- a/internal/parser/languages/python.go
+++ b/internal/parser/languages/python.go
@@ -592,9 +592,96 @@ func (e *PythonExtractor) emitClass(m parser.QueryResult, filePath, fileID strin
 	// PEP-695 generic class declarations (`class Foo[T]:`) carry a
 	// `type_parameters` child same as functions; reuse the helper.
 	emitPyGenericParamNodes(id, def.Node, src, filePath, def.StartLine+1, result)
+	// Base classes: `class A(B, mod.C, Generic[T])`.
+	pyEmitBaseClassEdges(def.Node, src, id, filePath, result)
 	// ORM model attribution: emit EdgeModelsTable when the class
 	// inherits from a known ORM base (SQLAlchemy / Django).
 	detectPythonORMModel(def.Node, src, id, name, filePath, result)
+}
+
+// pyEmitBaseClassEdges emits one EdgeExtends per declared base class.
+// Python was the only major language in the graph emitting no
+// inheritance edges at all — C#, Dart, Erlang, Go, Haskell, Java,
+// Kotlin, Pascal, PHP, R, Ruby, Rust and TypeScript all do — which left
+// every hierarchy-shaped query (relations hierarchy, override dispatch,
+// mixin reachability, abstract-base coverage) blind on Python. 83% of
+// classes in a 4,392-file corpus of Django, SQLAlchemy, pydantic, rich,
+// flask, httpx and requests declare at least one base: 21,290 of 25,576.
+//
+// The `superclasses` field is an argument_list, so besides real bases it
+// carries keyword arguments (`metaclass=ABCMeta`, PEP-487
+// `__init_subclass__` kwargs) and splats (`*bases`). Those are skipped
+// rather than minted as phantom parents — a wrong parent edge would
+// propagate through every inherited-member walk that trusts it.
+func pyEmitBaseClassEdges(classNode *sitter.Node, src []byte, typeID, filePath string, result *parser.ExtractionResult) {
+	if classNode == nil {
+		return
+	}
+	supers := classNode.ChildByFieldName("superclasses")
+	if supers == nil {
+		return
+	}
+	seen := map[string]bool{}
+	for i, _nc := 0, int(supers.NamedChildCount()); i < _nc; i++ {
+		arg := supers.NamedChild(i)
+		if arg == nil {
+			continue
+		}
+		name, qualified, generic := pyBaseClassName(arg, src)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		edge := &graph.Edge{
+			From: typeID, To: "unresolved::" + name, Kind: graph.EdgeExtends,
+			FilePath: filePath, Line: int(arg.StartPoint().Row) + 1,
+		}
+		meta := map[string]any{}
+		// Keep the written-out path (`models.Model`) alongside the bare
+		// name. 330 class names in the corpus are defined in more than one
+		// file, so the bare name alone cannot pick out the right base —
+		// the qualifier is what a resolver needs to disambiguate.
+		if qualified != "" && qualified != name {
+			meta["base_path"] = qualified
+		}
+		if generic {
+			meta["via"] = "generic"
+		}
+		if len(meta) > 0 {
+			edge.Meta = meta
+		}
+		result.Edges = append(result.Edges, edge)
+	}
+}
+
+// pyBaseClassName reduces one entry of a class's superclass list to its
+// bare base-class name, the written-out path, and whether it was written
+// as a generic subscript. Returns an empty name for entries that are not
+// base classes at all.
+func pyBaseClassName(arg *sitter.Node, src []byte) (name, qualified string, generic bool) {
+	switch arg.Type() {
+	case "identifier":
+		text := strings.TrimSpace(arg.Content(src))
+		return text, text, false
+	case "attribute":
+		// `models.Model`, `abc.ABC` — bind on the trailing name, the same
+		// reduction pyRaiseExceptionName uses for `raise mod.Err`.
+		text := strings.TrimSpace(arg.Content(src))
+		if i := strings.LastIndex(text, "."); i >= 0 {
+			return strings.TrimSpace(text[i+1:]), text, false
+		}
+		return text, text, false
+	case "subscript":
+		// `Generic[T]`, `Sequence[int]`, `Protocol[T]` — the base is the
+		// subscripted value; the type arguments are not parents.
+		if v := arg.ChildByFieldName("value"); v != nil {
+			n, q, _ := pyBaseClassName(v, src)
+			return n, q, true
+		}
+	}
+	// keyword_argument (`metaclass=…`), list_splat (`*bases`),
+	// dictionary_splat (`**kwargs`), call — not a base class.
+	return "", "", false
 }
 
 // pyDecoratorNodes returns the `decorator` AST nodes attached to a

--- a/internal/parser/languages/python.go
+++ b/internal/parser/languages/python.go
@@ -268,7 +268,16 @@ func (e *PythonExtractor) Extract(filePath string, src []byte) (*parser.Extracti
 	for _, c := range calls {
 		callerID := findEnclosingFunc(funcRanges, c.line)
 		if callerID == "" {
-			continue
+			// Module-level call (`app = Flask(__name__)`), a call in a
+			// class body (`name = Column(String)`), or a decorator
+			// expression — decorators sit above the `def` line, so they
+			// fall outside every function range. All three execute at
+			// import time and belong to the file. Attribute them to the
+			// file node rather than dropping them: dropping made every
+			// such callee invisible to find_usages / get_callers, which
+			// in Python costs the whole module-level configuration layer
+			// (routes, ORM columns, settings, registrations).
+			callerID = fileID
 		}
 		if c.dynShape != "" {
 			// Tagged dynamic-dispatch blind-spot call. The placeholder carries

--- a/internal/parser/languages/python.go
+++ b/internal/parser/languages/python.go
@@ -109,6 +109,19 @@ type pyDeferredCall struct {
 	returnUsage string
 }
 
+// pyDeferredVar is a module-level `name = ...` binding held back until the
+// whole file has been walked, so real definitions win the shared id.
+// Values are copied out of the match rather than holding the
+// *parser.CapturedNode: EachMatch recycles those between matches, so a
+// retained pointer reads back another match's capture. Node pointers are
+// stable — they address the tree, which outlives the walk.
+type pyDeferredVar struct {
+	name      string
+	node      *sitter.Node
+	startLine int
+	endLine   int
+}
+
 // pyStringLiteralValue returns the unquoted value of a Python string-literal
 // token (handling an optional r/f/b/u prefix), or "" when the token is not a
 // string literal (e.g. a variable subscript key obj[name]).
@@ -162,6 +175,7 @@ func (e *PythonExtractor) Extract(filePath string, src []byte) (*parser.Extracti
 
 	var calls []pyDeferredCall
 	var typeUses []deferredTypeUse
+	var topLevelVars []pyDeferredVar
 
 	parser.EachMatch(e.qAll, root, src, func(m parser.QueryResult) {
 		switch {
@@ -259,9 +273,26 @@ func (e *PythonExtractor) Extract(filePath string, src []byte) (*parser.Extracti
 			}
 
 		case m.Captures["var.def"] != nil:
-			e.emitTopLevelVar(m, filePath, fileID, result, seen)
+			if nameCap, defCap := m.Captures["var.name"], m.Captures["var.def"]; nameCap != nil && defCap != nil {
+				topLevelVars = append(topLevelVars, pyDeferredVar{
+					name:      nameCap.Text,
+					node:      defCap.Node,
+					startLine: defCap.StartLine,
+					endLine:   defCap.EndLine,
+				})
+			}
 		}
 	})
+
+	// Module-level variables are emitted only after the whole walk, so a
+	// class or function of the same name has already claimed the canonical
+	// `file::Name` id and the variable yields to it. `seen` is shared
+	// across all three emitters — emitting a variable inline would let
+	// `Config = load()` sitting above `class Config:` take the id and
+	// delete the class from the graph entirely.
+	for _, v := range topLevelVars {
+		e.emitTopLevelVar(v, filePath, fileID, result, seen)
+	}
 
 	// All function/method nodes have been emitted; map call sites to
 	// their enclosing definition.
@@ -1183,10 +1214,22 @@ func pyImportDisplayName(path string) string {
 	return path
 }
 
-func (e *PythonExtractor) emitTopLevelVar(m parser.QueryResult, filePath, fileID string, result *parser.ExtractionResult, seen map[string]bool) {
-	name := m.Captures["var.name"].Text
-	def := m.Captures["var.def"]
-	if def.Node == nil || def.Node.Parent() == nil || def.Node.Parent().Type() != "module" {
+func (e *PythonExtractor) emitTopLevelVar(v pyDeferredVar, filePath, fileID string, result *parser.ExtractionResult, seen map[string]bool) {
+	name := v.name
+	if v.node == nil {
+		return
+	}
+	// An `assignment` is never a direct child of `module` — tree-sitter
+	// wraps every bare expression in an `expression_statement` first. The
+	// old check compared the assignment's immediate parent against
+	// "module", which no module-level assignment could ever satisfy, so
+	// this whole function was unreachable and Python emitted zero
+	// variable nodes for any file.
+	parent := v.node.Parent()
+	if parent != nil && parent.Type() == "expression_statement" {
+		parent = parent.Parent()
+	}
+	if parent == nil || parent.Type() != "module" {
 		return
 	}
 	id := filePath + "::" + name
@@ -1196,11 +1239,11 @@ func (e *PythonExtractor) emitTopLevelVar(m parser.QueryResult, filePath, fileID
 	seen[id] = true
 	result.Nodes = append(result.Nodes, &graph.Node{
 		ID: id, Kind: graph.KindVariable, Name: name,
-		FilePath: filePath, StartLine: def.StartLine + 1, EndLine: def.EndLine + 1,
+		FilePath: filePath, StartLine: v.startLine + 1, EndLine: v.endLine + 1,
 		Language: "python",
 	})
 	result.Edges = append(result.Edges, &graph.Edge{
-		From: fileID, To: id, Kind: graph.EdgeDefines, FilePath: filePath, Line: def.StartLine + 1,
+		From: fileID, To: id, Kind: graph.EdgeDefines, FilePath: filePath, Line: v.startLine + 1,
 	})
 }
 

--- a/internal/parser/languages/python.go
+++ b/internal/parser/languages/python.go
@@ -61,6 +61,14 @@ const qPyAll = `
     left: (identifier) @uvar.name
     right: (call
       function: (identifier) @uvar.callee)) @uvar.def
+
+  (typed_parameter
+    (identifier) @tparam.name
+    type: (type) @tparam.type) @tparam.def
+
+  (typed_default_parameter
+    name: (identifier) @tdparam.name
+    type: (type) @tdparam.type) @tdparam.def
 ]
 `
 
@@ -146,8 +154,11 @@ func (e *PythonExtractor) Extract(filePath string, src []byte) (*parser.Extracti
 	seen := make(map[string]bool)
 	annotationSeen := make(map[string]bool)
 	imports := map[string]string{} // alias → module path
-	tenv := make(typeEnv)
-	tenvHasExplicit := make(map[string]bool) // names with Tier 0 type, lock from Tier 1 overwrite
+	// Name→type bindings are collected flat here and bucketed into
+	// per-function scopes once the function ranges exist — the query walk
+	// runs in document order, before any function node is available to
+	// own them. See buildPyScopedTypeEnv.
+	var assigns []pyAssign
 
 	var calls []pyDeferredCall
 	var typeUses []deferredTypeUse
@@ -210,33 +221,41 @@ func (e *PythonExtractor) Extract(filePath string, src []byte) (*parser.Extracti
 			calls = append(calls, dc)
 
 		case m.Captures["tvar.def"] != nil:
-			// Tier 0: explicit type annotation — overwrite tenv.
-			name := m.Captures["tvar.name"].Text
+			// Tier 0: a written annotation on an assignment.
 			rawType := m.Captures["tvar.type"].Text
-			typeName := normalizePyTypeName(rawType)
-			if typeName != "" {
-				tenv[name] = typeName
-				tenvHasExplicit[name] = true
+			line := m.Captures["tvar.def"].StartLine + 1
+			if typeName := normalizePyTypeName(rawType); typeName != "" {
+				assigns = append(assigns, pyAssign{
+					name: m.Captures["tvar.name"].Text, typeName: typeName,
+					line: line, explicit: true,
+				})
 			}
 			typeUses = append(typeUses, deferredTypeUse{
 				typeText: rawType,
-				line:     m.Captures["tvar.def"].StartLine + 1,
+				line:     line,
 			})
 
+		case m.Captures["tparam.def"] != nil:
+			// A written parameter annotation declares that parameter's
+			// type for the whole function body. Annotated parameters are
+			// the second-largest source of statically stated receivers
+			// after `self`, and were previously ignored entirely.
+			pyAppendParamAssign(&assigns, m.Captures["tparam.name"], m.Captures["tparam.type"])
+
+		case m.Captures["tdparam.def"] != nil:
+			pyAppendParamAssign(&assigns, m.Captures["tdparam.name"], m.Captures["tdparam.type"])
+
 		case m.Captures["uvar.def"] != nil:
-			// Tier 1: constructor-call inference. Only fills in keys
-			// that didn't get an explicit type — match the legacy
-			// `if _, exists := tenv[name]; exists { continue }` guard.
-			name := m.Captures["uvar.name"].Text
-			if tenvHasExplicit[name] {
-				return
-			}
-			if _, exists := tenv[name]; exists {
-				return
-			}
+			// Tier 1: constructor-call inference. Precedence against an
+			// explicit annotation, and the two-different-classes conflict
+			// rule, are both applied in buildPyScopedTypeEnv once the
+			// binding's scope is known.
 			callee := m.Captures["uvar.callee"].Text
 			if callee != "" && unicode.IsUpper(rune(callee[0])) {
-				tenv[name] = callee
+				assigns = append(assigns, pyAssign{
+					name: m.Captures["uvar.name"].Text, typeName: callee,
+					line: m.Captures["uvar.def"].StartLine + 1,
+				})
 			}
 
 		case m.Captures["var.def"] != nil:
@@ -247,6 +266,9 @@ func (e *PythonExtractor) Extract(filePath string, src []byte) (*parser.Extracti
 	// All function/method nodes have been emitted; map call sites to
 	// their enclosing definition.
 	funcRanges := buildFuncRanges(result)
+
+	// Bucket the name→type bindings into the scope that owns each one.
+	scoped := buildPyScopedTypeEnv(assigns, funcRanges)
 
 	// Type-use edges: a `x: T` annotation references type T. Attributed
 	// to the enclosing function (fallback: the file node) so find_usages(T)
@@ -265,7 +287,8 @@ func (e *PythonExtractor) Extract(filePath string, src []byte) (*parser.Extracti
 	emitPythonReferenceForms(root, src, filePath, fileID, funcRanges, result)
 
 	for _, c := range calls {
-		callerID := findEnclosingFunc(funcRanges, c.line)
+		ownerFunc := findEnclosingFunc(funcRanges, c.line)
+		callerID := ownerFunc
 		if callerID == "" {
 			// Module-level call (`app = Flask(__name__)`), a call in a
 			// class body (`name = Column(String)`), or a decorator
@@ -314,10 +337,24 @@ func (e *PythonExtractor) Extract(filePath string, src []byte) (*parser.Extracti
 				From: callerID, To: "unresolved::*." + c.name,
 				Kind: graph.EdgeCalls, FilePath: filePath, Line: c.line,
 			}
-			if recvType, ok := tenv[c.receiver]; ok {
-				edge.Meta = map[string]any{"receiver_type": recvType}
-			} else if strings.Contains(c.receiver, ".") || strings.Contains(c.receiver, "(") {
-				stampFactoryChainReceiver(edge, c.receiver, resolveChainType(c.receiver, tenv, result))
+			switch c.receiver {
+			case "self", "cls":
+				// `self`/`cls` name the class the call is written in.
+				// That is known exactly — no inference, no ambiguity —
+				// and it is the single most common typed receiver in
+				// idiomatic Python. It is also the shape an inherited
+				// method needs: the declaring class may be an ancestor,
+				// which a name-only match cannot find.
+				if cls := pyEnclosingClassName(c.expr, src); cls != "" {
+					edge.Meta = map[string]any{"receiver_type": cls}
+				}
+			default:
+				if recvType, ok := scoped.lookup(ownerFunc, c.receiver); ok {
+					edge.Meta = map[string]any{"receiver_type": recvType}
+				} else if strings.Contains(c.receiver, ".") || strings.Contains(c.receiver, "(") {
+					stampFactoryChainReceiver(edge, c.receiver,
+						resolveChainType(c.receiver, scoped.flatten(ownerFunc), result))
+				}
 			}
 			stampReturnUsage(edge, c.returnUsage)
 			result.Edges = append(result.Edges, edge)

--- a/internal/parser/languages/python_callsite_test.go
+++ b/internal/parser/languages/python_callsite_test.go
@@ -1,0 +1,77 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestPyCalls_ModuleLevelAndClassBodyAreAttributedToFile(t *testing.T) {
+	// Module-level and class-body calls execute at import time. Dropping
+	// them made the whole module-level configuration layer — routes, ORM
+	// columns, settings, registrations — invisible to find_usages.
+	src := []byte(`from flask import Flask
+from db import Column, String
+
+app = Flask(__name__)
+register(app)
+
+
+class User:
+    name = Column(String)
+
+    def save(self):
+        persist(self)
+`)
+	e := NewPythonExtractor()
+	result, err := e.Extract("app.py", src)
+	require.NoError(t, err)
+
+	fromFile := map[string]bool{}
+	fromMethod := map[string]bool{}
+	for _, ed := range result.Edges {
+		if ed.Kind != graph.EdgeCalls {
+			continue
+		}
+		switch ed.From {
+		case "app.py":
+			fromFile[ed.To] = true
+		case "app.py::User.save":
+			fromMethod[ed.To] = true
+		}
+	}
+
+	assert.True(t, fromFile["unresolved::extern::flask.Flask::Flask"],
+		"module-level `app = Flask(...)` must be attributed to the file node")
+	assert.True(t, fromFile["unresolved::register"],
+		"module-level `register(app)` must be attributed to the file node")
+	assert.True(t, fromFile["unresolved::extern::db.Column::Column"],
+		"a call in a class body must be attributed to the file node")
+	assert.True(t, fromMethod["unresolved::persist"],
+		"calls inside a method still belong to the method, not the file")
+}
+
+func TestPyCalls_DecoratorCallIsNotDropped(t *testing.T) {
+	// A decorator sits above the `def` line, so it falls outside every
+	// function range and used to be dropped along with module-level calls.
+	src := []byte(`from app import app
+
+
+@app.route("/")
+def index():
+    return "hi"
+`)
+	e := NewPythonExtractor()
+	result, err := e.Extract("routes.py", src)
+	require.NoError(t, err)
+
+	var found bool
+	for _, ed := range result.Edges {
+		if ed.Kind == graph.EdgeCalls && ed.From == "routes.py" && ed.To == "unresolved::extern::app.app::route" {
+			found = true
+		}
+	}
+	assert.True(t, found, "the decorator's own call site belongs to the file")
+}

--- a/internal/parser/languages/python_import_alias_test.go
+++ b/internal/parser/languages/python_import_alias_test.go
@@ -1,0 +1,76 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func pyEdgeTargets(edges []*graph.Edge, kind graph.EdgeKind) []string {
+	var out []string
+	for _, e := range edges {
+		if e.Kind == kind {
+			out = append(out, e.To)
+		}
+	}
+	return out
+}
+
+func TestPyImports_AliasedImportIsNotDropped(t *testing.T) {
+	// `import numpy as np` puts the module name in an `aliased_import`
+	// node, so a query anchored on `(dotted_name)` never matched it — and
+	// that is how the entire numpy/pandas idiom is written.
+	src := []byte(`import numpy as np
+
+
+def go():
+    np.array([1])
+`)
+	e := NewPythonExtractor()
+	result, err := e.Extract("calc.py", src)
+	require.NoError(t, err)
+
+	imports := nodesOfKind(result.Nodes, graph.KindImport)
+	require.Len(t, imports, 1)
+	assert.Equal(t, "numpy", imports[0].Meta["path"])
+	assert.Equal(t, "np", imports[0].Meta["alias"])
+
+	assert.Contains(t, pyEdgeTargets(result.Edges, graph.EdgeImports),
+		"unresolved::import::numpy")
+	assert.Contains(t, pyEdgeTargets(result.Edges, graph.EdgeCalls),
+		"unresolved::extern::numpy::array",
+		"the aliased receiver must attribute the call to its module")
+}
+
+func TestPyImports_EveryNameInAMultiImportEmitsANode(t *testing.T) {
+	src := []byte(`import os.path, numpy as np, json
+`)
+	e := NewPythonExtractor()
+	result, err := e.Extract("multi.py", src)
+	require.NoError(t, err)
+
+	paths := map[string]bool{}
+	for _, n := range nodesOfKind(result.Nodes, graph.KindImport) {
+		paths[n.Meta["path"].(string)] = true
+	}
+	assert.Equal(t, map[string]bool{"os.path": true, "numpy": true, "json": true}, paths,
+		"one statement can bind several modules; each needs its own import node")
+}
+
+func TestPyImports_PlainImportStillBindsItsRootName(t *testing.T) {
+	src := []byte(`import os.path
+
+
+def go():
+    os.path.join("a", "b")
+`)
+	e := NewPythonExtractor()
+	result, err := e.Extract("paths.py", src)
+	require.NoError(t, err)
+
+	assert.Contains(t, pyEdgeTargets(result.Edges, graph.EdgeCalls),
+		"unresolved::extern::os.path::join",
+		"`import os.path` binds `os`, so os.path.join resolves through it")
+}

--- a/internal/parser/languages/python_inherit_test.go
+++ b/internal/parser/languages/python_inherit_test.go
@@ -1,0 +1,104 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestPyClass_EmitsInheritanceEdges(t *testing.T) {
+	src := []byte(`import abc
+from django.db import models
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+
+class Repo(models.Model, abc.ABC, Generic[T], metaclass=abc.ABCMeta):
+    pass
+
+
+class Standalone:
+    pass
+`)
+	e := NewPythonExtractor()
+	result, err := e.Extract("repo.py", src)
+	require.NoError(t, err)
+
+	var bases []string
+	byTarget := map[string]*graph.Edge{}
+	for _, ed := range result.Edges {
+		if ed.Kind != graph.EdgeExtends {
+			continue
+		}
+		assert.Equal(t, "repo.py::Repo", ed.From)
+		bases = append(bases, ed.To)
+		byTarget[ed.To] = ed
+	}
+	assert.ElementsMatch(t, []string{
+		"unresolved::Model", "unresolved::ABC", "unresolved::Generic",
+	}, bases, "metaclass= is a keyword argument, not a base class")
+
+	// The written-out path is kept so a resolver can disambiguate a bare
+	// base name that several files define.
+	assert.Equal(t, "models.Model", byTarget["unresolved::Model"].Meta["base_path"])
+	assert.Equal(t, "generic", byTarget["unresolved::Generic"].Meta["via"])
+	assert.Nil(t, byTarget["unresolved::ABC"].Meta["via"])
+}
+
+func TestPyClass_MultipleInheritanceKeepsEveryBase(t *testing.T) {
+	src := []byte(`class Handler(LoggingMixin, RetryMixin, BaseHandler):
+    pass
+`)
+	e := NewPythonExtractor()
+	result, err := e.Extract("handler.py", src)
+	require.NoError(t, err)
+
+	var bases []string
+	for _, ed := range result.Edges {
+		if ed.Kind == graph.EdgeExtends {
+			bases = append(bases, ed.To)
+		}
+	}
+	assert.ElementsMatch(t, []string{
+		"unresolved::LoggingMixin", "unresolved::RetryMixin", "unresolved::BaseHandler",
+	}, bases)
+}
+
+func TestPyClass_NoBasesEmitsNoInheritanceEdges(t *testing.T) {
+	src := []byte(`class Plain:
+    pass
+
+
+class AlsoPlain():
+    pass
+`)
+	e := NewPythonExtractor()
+	result, err := e.Extract("plain.py", src)
+	require.NoError(t, err)
+	assert.Empty(t, edgesOfKind(result.Edges, graph.EdgeExtends))
+}
+
+func TestPyClass_NestedClassStillGetsItsBase(t *testing.T) {
+	src := []byte(`from django.db import models
+
+
+class Article(models.Model):
+    class Meta(BaseMeta):
+        ordering = ["id"]
+`)
+	e := NewPythonExtractor()
+	result, err := e.Extract("article.py", src)
+	require.NoError(t, err)
+
+	byFrom := map[string]string{}
+	for _, ed := range result.Edges {
+		if ed.Kind == graph.EdgeExtends {
+			byFrom[ed.From] = ed.To
+		}
+	}
+	assert.Equal(t, "unresolved::Model", byFrom["article.py::Article"])
+	assert.Equal(t, "unresolved::BaseMeta", byFrom["article.py::Meta"])
+}

--- a/internal/parser/languages/python_receiver.go
+++ b/internal/parser/languages/python_receiver.go
@@ -1,0 +1,324 @@
+package languages
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/zzet/gortex/internal/parser"
+	sitter "github.com/zzet/gortex/internal/parser/tsitter"
+)
+
+// pyAssign is one name→type binding observed while walking a file. The
+// line is kept so the binding can be attributed to a scope once function
+// ranges are known — the walk sees matches in document order, before any
+// function node exists to own them.
+type pyAssign struct {
+	name     string
+	typeName string
+	line     int
+	// explicit marks a binding that came from a written annotation
+	// (`x: Foo`, `def f(x: Foo)`) rather than one inferred from a
+	// constructor call (`x = Foo()`). A declaration outranks an
+	// inference when the two disagree.
+	explicit bool
+}
+
+// pyScopedTypeEnv holds one typeEnv per owning function, keyed by the
+// function's node ID; the empty key is module scope.
+type pyScopedTypeEnv map[string]typeEnv
+
+// buildPyScopedTypeEnv buckets every binding into the scope that owns it
+// and drops any name bound to two different types within one scope.
+//
+// Scoping is a precision fix. With one file-wide map, a `m = Foo()` in
+// any function typed every unrelated `m.bar()` in every other function of
+// the same file — the receiver_type stamped on those edges was simply
+// wrong. The rule applied here is Python's own: a call sees its own
+// function's bindings, then module-level bindings, and never another
+// function's locals. Nested functions resolve to their outermost
+// enclosing function (findEnclosingFunc returns the first, i.e. outermost,
+// matching range), so a closure and the function that encloses it share
+// one scope and a captured variable still resolves.
+//
+// The conflict rule is the one the PHP receiver work settled on: a name
+// assigned two different classes in the same scope yields NOTHING. A
+// flow-insensitive environment cannot say which assignment reaches the
+// call, and a wrong receiver_type binds the edge at a high-confidence
+// tier — strictly worse than leaving the call untyped.
+func buildPyScopedTypeEnv(assigns []pyAssign, funcRanges []funcRange) pyScopedTypeEnv {
+	type binding struct {
+		typeName string
+		explicit bool
+		conflict bool
+	}
+	scoped := map[string]map[string]*binding{}
+	for _, a := range assigns {
+		if a.name == "" || a.typeName == "" {
+			continue
+		}
+		owner := findEnclosingFunc(funcRanges, a.line)
+		byName, ok := scoped[owner]
+		if !ok {
+			byName = map[string]*binding{}
+			scoped[owner] = byName
+		}
+		cur, ok := byName[a.name]
+		if !ok {
+			byName[a.name] = &binding{typeName: a.typeName, explicit: a.explicit}
+			continue
+		}
+		if cur.typeName == a.typeName {
+			continue
+		}
+		switch {
+		case a.explicit && !cur.explicit:
+			// A written annotation replaces an inferred type outright.
+			cur.typeName, cur.explicit, cur.conflict = a.typeName, true, false
+		case !a.explicit && cur.explicit:
+			// Keep the declaration; an inference does not override it.
+		default:
+			// Two declarations, or two inferences, that disagree.
+			cur.conflict = true
+		}
+	}
+	out := pyScopedTypeEnv{}
+	for owner, byName := range scoped {
+		env := typeEnv{}
+		for name, b := range byName {
+			if b.conflict {
+				continue
+			}
+			env[name] = b.typeName
+		}
+		if len(env) > 0 {
+			out[owner] = env
+		}
+	}
+	return out
+}
+
+// lookup resolves a name for a call owned by ownerID: the owning
+// function's own bindings first, then module scope. Another function's
+// locals are never consulted.
+func (s pyScopedTypeEnv) lookup(ownerID, name string) (string, bool) {
+	if env, ok := s[ownerID]; ok {
+		if t, ok := env[name]; ok {
+			return t, true
+		}
+	}
+	if ownerID != "" {
+		if t, ok := s[""][name]; ok {
+			return t, true
+		}
+	}
+	return "", false
+}
+
+// flatten returns the bindings visible to ownerID as one typeEnv, for
+// helpers that take a flat map (resolveChainType).
+func (s pyScopedTypeEnv) flatten(ownerID string) typeEnv {
+	env := typeEnv{}
+	for k, v := range s[""] {
+		env[k] = v
+	}
+	if ownerID != "" {
+		for k, v := range s[ownerID] {
+			env[k] = v
+		}
+	}
+	return env
+}
+
+// pyAppendParamAssign records an annotated parameter as an explicit
+// binding for its enclosing function. The parameter's own line is used
+// so the binding lands in the function that declares it.
+//
+// Variadic parameters never reach here: `*args: int` and `**kw: int` wrap
+// their name in a list_splat_pattern / dictionary_splat_pattern, which the
+// query's `(identifier)` child does not match. That exclusion is load
+// bearing — the value of `*args` is a tuple, not an instance of the
+// annotated type, so binding it would be wrong.
+func pyAppendParamAssign(assigns *[]pyAssign, nameCap, typeCap *parser.CapturedNode) {
+	if nameCap == nil || typeCap == nil {
+		return
+	}
+	typeName := pyReceiverTypeFromAnnotation(typeCap.Text)
+	if typeName == "" || nameCap.Text == "" {
+		return
+	}
+	*assigns = append(*assigns, pyAssign{
+		name:     nameCap.Text,
+		typeName: typeName,
+		line:     nameCap.StartLine + 1,
+		explicit: true,
+	})
+}
+
+// pyEnclosingClassName walks up to the nearest enclosing class_definition
+// and returns its name, or "" at module scope. This is what makes
+// `self.method()` bindable: `self` names the class the call is written
+// in, which is known exactly, with no inference involved. It is by far
+// the most common typed receiver in idiomatic Python — 26% of all
+// attribute calls in a 4,400-file corpus.
+func pyEnclosingClassName(n *sitter.Node, src []byte) string {
+	for cur := n; cur != nil; cur = cur.Parent() {
+		if cur.Type() != "class_definition" {
+			continue
+		}
+		if nameNode := cur.ChildByFieldName("name"); nameNode != nil {
+			return nameNode.Content(src)
+		}
+		return ""
+	}
+	return ""
+}
+
+// pyContainerTypes are annotations whose value is a CONTAINER, not an
+// instance of whatever sits inside the brackets. `xs: list[Foo]` must not
+// type `xs` as Foo: `xs.append(...)` is a list operation, and binding it
+// to Foo would attach the call to an unrelated class. Unwrapping these
+// is the difference between a useful hint and a fabricated one.
+var pyContainerTypes = map[string]bool{
+	"list": true, "List": true, "dict": true, "Dict": true,
+	"set": true, "Set": true, "frozenset": true, "FrozenSet": true,
+	"tuple": true, "Tuple": true, "Sequence": true, "MutableSequence": true,
+	"Mapping": true, "MutableMapping": true, "Iterable": true,
+	"Iterator": true, "Generator": true, "AsyncIterable": true,
+	"AsyncIterator": true, "AsyncGenerator": true, "Awaitable": true,
+	"Coroutine": true, "Callable": true, "Deque": true, "DefaultDict": true,
+	"Counter": true, "OrderedDict": true, "ChainMap": true,
+	"Type": true, "type": true,
+}
+
+// pyNonBindingTypes never name a concrete class a receiver could be.
+var pyNonBindingTypes = map[string]bool{
+	"": true, "Any": true, "None": true, "object": true, "Self": true,
+	"AnyStr": true, "NoReturn": true, "Never": true, "Ellipsis": true,
+	"int": true, "float": true, "str": true, "bool": true, "bytes": true,
+	"bytearray": true, "complex": true, "memoryview": true, "range": true,
+}
+
+// pyReceiverTypeFromAnnotation reduces a type annotation to the class an
+// value of that type is an instance of, or "" when no single class can be
+// named.
+//
+// It exists because normalizePyTypeName simply truncates at the first
+// bracket, which turns `Optional[Foo]` into the meaningless wrapper name
+// `Optional` and `list[Foo]` into `list`. For a receiver hint that is not
+// good enough in either direction: the wrapper cases lose a type that is
+// perfectly recoverable, and the container cases would hand back the
+// element type, which is actively wrong. This unwraps the wrappers that
+// preserve the instance type and REFUSES the ones that do not.
+func pyReceiverTypeFromAnnotation(t string) string {
+	t = strings.TrimSpace(t)
+	// Forward references are written as string literals: `x: "Foo"`.
+	if len(t) >= 2 && (t[0] == '"' || t[0] == '\'') && t[len(t)-1] == t[0] {
+		t = strings.TrimSpace(t[1 : len(t)-1])
+	}
+	if t == "" {
+		return ""
+	}
+	// PEP 604 unions: `Foo | None` is a Foo; `Foo | Bar` names no single
+	// class. Only a TOP-LEVEL `|` makes this a union — in
+	// `Optional[int | str]` the bar is nested inside the brackets, and
+	// treating it as a union here would hand the whole string back
+	// unchanged and recurse forever.
+	if parts := splitPyTopLevel(t, '|'); len(parts) > 1 {
+		return pyOnlyNonNone(parts)
+	}
+	open := strings.IndexByte(t, '[')
+	if open < 0 {
+		return pyBareReceiverType(t)
+	}
+	if !strings.HasSuffix(t, "]") {
+		return ""
+	}
+	head := pyUnqualified(strings.TrimSpace(t[:open]))
+	args := splitPyTopLevel(t[open+1:len(t)-1], ',')
+	switch head {
+	case "Optional", "Final", "ClassVar", "Required", "NotRequired", "InitVar":
+		if len(args) == 1 {
+			return pyReceiverTypeFromAnnotation(args[0])
+		}
+		return ""
+	case "Union":
+		return pyOnlyNonNone(args)
+	case "Annotated":
+		// `Annotated[Foo, metadata...]` — the type is the first argument.
+		if len(args) >= 1 {
+			return pyReceiverTypeFromAnnotation(args[0])
+		}
+		return ""
+	}
+	if pyContainerTypes[head] {
+		return ""
+	}
+	// A generic instance (`Repo[User]`) is still an instance of `Repo`.
+	return pyBareReceiverType(head)
+}
+
+// pyOnlyNonNone returns the single non-None member of a union, or "" when
+// the union holds none or more than one distinct type.
+func pyOnlyNonNone(parts []string) string {
+	only := ""
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" || p == "None" {
+			continue
+		}
+		if only != "" && only != p {
+			return ""
+		}
+		only = p
+	}
+	if only == "" {
+		return ""
+	}
+	return pyReceiverTypeFromAnnotation(only)
+}
+
+// pyBareReceiverType accepts an unsubscripted annotation as a class name.
+func pyBareReceiverType(t string) string {
+	t = pyUnqualified(strings.TrimSpace(t))
+	if pyNonBindingTypes[t] || pyContainerTypes[t] {
+		return ""
+	}
+	// A class name starts upper-case by universal Python convention; the
+	// existing constructor-call inference applies the same test. A
+	// lower-case annotation is a builtin or a type alias we cannot bind.
+	if !unicode.IsUpper(rune(t[0])) {
+		return ""
+	}
+	return t
+}
+
+// pyUnqualified strips a module qualifier: `models.Model` → `Model`,
+// `typing.Optional` → `Optional`.
+func pyUnqualified(t string) string {
+	if i := strings.LastIndexByte(t, '.'); i >= 0 {
+		return strings.TrimSpace(t[i+1:])
+	}
+	return t
+}
+
+// splitPyTopLevel splits on sep, ignoring separators nested inside
+// brackets, parentheses or braces — `Dict[str, int] | None` splits into
+// two parts on '|', not three.
+func splitPyTopLevel(s string, sep byte) []string {
+	var parts []string
+	depth, start := 0, 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '[', '(', '{':
+			depth++
+		case ']', ')', '}':
+			depth--
+		case sep:
+			if depth == 0 {
+				parts = append(parts, s[start:i])
+				start = i + 1
+			}
+		}
+	}
+	return append(parts, s[start:])
+}

--- a/internal/parser/languages/python_receiver_test.go
+++ b/internal/parser/languages/python_receiver_test.go
@@ -1,0 +1,264 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// pyCallReceiverTypes maps `unresolved::*.<method>` → receiver_type for
+// every method-call edge that carries one.
+func pyCallReceiverTypes(edges []*graph.Edge) map[string]string {
+	out := map[string]string{}
+	for _, e := range edges {
+		if e.Kind != graph.EdgeCalls || e.Meta == nil {
+			continue
+		}
+		rt, ok := e.Meta["receiver_type"].(string)
+		if !ok || rt == "" {
+			continue
+		}
+		out[e.To] = rt
+	}
+	return out
+}
+
+func TestPyReceiver_SelfAndClsBindToEnclosingClass(t *testing.T) {
+	src := []byte(`class Console:
+    def render(self):
+        pass
+
+    def show(self):
+        self.render()
+
+    @classmethod
+    def build(cls):
+        cls.render()
+
+
+def free_function(self):
+    # self outside a class names nothing bindable.
+    self.render()
+`)
+	e := NewPythonExtractor()
+	result, err := e.Extract("console.py", src)
+	require.NoError(t, err)
+
+	recv := pyCallReceiverTypes(result.Edges)
+	assert.Equal(t, "Console", recv["unresolved::*.render"],
+		"self./cls. calls must bind to the class they are written in")
+
+	// The module-level `self.render()` has no enclosing class, so it must
+	// not invent one — but it must still produce a call edge.
+	var renderCalls int
+	for _, ed := range result.Edges {
+		if ed.Kind == graph.EdgeCalls && ed.To == "unresolved::*.render" {
+			renderCalls++
+		}
+	}
+	assert.Equal(t, 3, renderCalls, "every self/cls call site emits an edge")
+}
+
+func TestPyReceiver_AnnotatedParametersBind(t *testing.T) {
+	src := []byte(`from typing import Optional
+
+
+class Widget:
+    pass
+
+
+def draw(target: Widget, fallback: Optional[Widget], maybe: Widget | None, quoted: "Widget", n: int = 0):
+    target.paint()
+    fallback.paint()
+    maybe.paint()
+    quoted.paint()
+`)
+	e := NewPythonExtractor()
+	result, err := e.Extract("draw.py", src)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Widget", pyCallReceiverTypes(result.Edges)["unresolved::*.paint"],
+		"annotated parameters, Optional[...], PEP 604 `| None` and quoted forward refs all name Widget")
+}
+
+func TestPyReceiver_ContainerAnnotationsAreNotBound(t *testing.T) {
+	// The element type of a container is NOT the type of the variable —
+	// binding `xs.append(...)` to Widget would attach the call to an
+	// unrelated class.
+	src := []byte(`class Widget:
+    pass
+
+
+def collect(xs: list[Widget], m: dict[str, Widget], cb: Callable[[Widget], None], both: Widget | Console):
+    xs.append(1)
+    m.update({})
+    cb.call()
+    both.paint()
+`)
+	e := NewPythonExtractor()
+	result, err := e.Extract("collect.py", src)
+	require.NoError(t, err)
+
+	recv := pyCallReceiverTypes(result.Edges)
+	for _, target := range []string{
+		"unresolved::*.append", "unresolved::*.update",
+		"unresolved::*.call", "unresolved::*.paint",
+	} {
+		assert.Empty(t, recv[target],
+			"container elements and ambiguous unions must not be stamped as a receiver type (%s)", target)
+	}
+}
+
+func TestPyReceiver_BindingsDoNotLeakAcrossFunctions(t *testing.T) {
+	src := []byte(`class Console:
+    pass
+
+
+def owns_it():
+    m = Console()
+    m.render()
+
+
+def borrows_the_name():
+    m.render()
+`)
+	e := NewPythonExtractor()
+	result, err := e.Extract("scope.py", src)
+	require.NoError(t, err)
+
+	var typed, untyped int
+	for _, ed := range result.Edges {
+		if ed.Kind != graph.EdgeCalls || ed.To != "unresolved::*.render" {
+			continue
+		}
+		if ed.Meta != nil && ed.Meta["receiver_type"] == "Console" {
+			typed++
+		} else {
+			untyped++
+		}
+	}
+	assert.Equal(t, 1, typed, "only the function that assigned `m` gets the type")
+	assert.Equal(t, 1, untyped, "another function's local must not type this call")
+}
+
+func TestPyReceiver_ModuleScopeIsVisibleInsideFunctions(t *testing.T) {
+	src := []byte(`class Console:
+    pass
+
+
+console = Console()
+
+
+def render_it():
+    console.render()
+`)
+	e := NewPythonExtractor()
+	result, err := e.Extract("modscope.py", src)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Console", pyCallReceiverTypes(result.Edges)["unresolved::*.render"],
+		"module-level bindings are globals and stay visible inside functions")
+}
+
+func TestPyReceiver_ConflictingAssignmentsYieldNoType(t *testing.T) {
+	// A flow-insensitive environment cannot say which assignment reaches
+	// the call, and a wrong receiver_type binds at a high-confidence tier.
+	src := []byte(`class Console:
+    pass
+
+
+class Widget:
+    pass
+
+
+def ambiguous(flag):
+    thing = Console()
+    if flag:
+        thing = Widget()
+    thing.render()
+`)
+	e := NewPythonExtractor()
+	result, err := e.Extract("conflict.py", src)
+	require.NoError(t, err)
+
+	assert.Empty(t, pyCallReceiverTypes(result.Edges)["unresolved::*.render"],
+		"a name assigned two different classes in one scope must yield no receiver type")
+}
+
+func TestPyReceiver_AnnotationOutranksConstructorInference(t *testing.T) {
+	src := []byte(`class Console:
+    pass
+
+
+class Widget:
+    pass
+
+
+def declared(thing: Widget):
+    thing = Console()
+    thing.render()
+`)
+	e := NewPythonExtractor()
+	result, err := e.Extract("declared.py", src)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Widget", pyCallReceiverTypes(result.Edges)["unresolved::*.render"],
+		"a written annotation is a declaration and outranks an inferred constructor type")
+}
+
+func TestPyReceiverTypeFromAnnotation(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"Widget", "Widget"},
+		{"models.Model", "Model"},
+		{"Optional[Widget]", "Widget"},
+		{"typing.Optional[Widget]", "Widget"},
+		{"Union[Widget, None]", "Widget"},
+		{"Widget | None", "Widget"},
+		{"None | Widget", "Widget"},
+		{"Annotated[Widget, Field(...)]", "Widget"},
+		{"Final[Widget]", "Widget"},
+		{`"Widget"`, "Widget"},
+		{"'Widget'", "Widget"},
+		{"Repo[User]", "Repo"},
+		// Nested `|` inside brackets is not a top-level union — this shape
+		// once recursed until the stack overflowed.
+		{"Optional[int | str]", ""},
+		{"Widget | Console", ""},
+		{"list[Widget]", ""},
+		{"dict[str, Widget]", ""},
+		{"Sequence[Widget]", ""},
+		{"Callable[[Widget], None]", ""},
+		{"Type[Widget]", ""},
+		{"int", ""},
+		{"str", ""},
+		{"Any", ""},
+		{"None", ""},
+		{"object", ""},
+		{"self", ""},
+		{"", ""},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, pyReceiverTypeFromAnnotation(c.in), "annotation %q", c.in)
+	}
+}
+
+func TestPyReceiver_VariadicParamsAreNotBound(t *testing.T) {
+	// `*args: Widget` makes args a TUPLE of Widget, not a Widget.
+	src := []byte(`class Widget:
+    pass
+
+
+def spread(*args: Widget, **kwargs: Widget):
+    args.count(1)
+    kwargs.get("x")
+`)
+	e := NewPythonExtractor()
+	result, err := e.Extract("variadic.py", src)
+	require.NoError(t, err)
+
+	recv := pyCallReceiverTypes(result.Edges)
+	assert.Empty(t, recv["unresolved::*.count"])
+	assert.Empty(t, recv["unresolved::*.get"])
+}

--- a/internal/parser/languages/python_topvar_test.go
+++ b/internal/parser/languages/python_topvar_test.go
@@ -1,0 +1,96 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestPyTopLevelVar_ModuleAssignmentsBecomeNodes(t *testing.T) {
+	src := []byte(`from flask import Flask
+
+VERSION = "1.0"
+app = Flask(__name__)
+_private = 3
+
+
+def handler():
+    local_only = 1
+    return local_only
+
+
+class Config:
+    attr = 5
+`)
+	e := NewPythonExtractor()
+	result, err := e.Extract("settings.py", src)
+	require.NoError(t, err)
+
+	names := map[string]bool{}
+	for _, n := range nodesOfKind(result.Nodes, graph.KindVariable) {
+		names[n.Name] = true
+		assert.Equal(t, "settings.py::"+n.Name, n.ID)
+	}
+	assert.Equal(t, map[string]bool{"VERSION": true, "app": true}, names,
+		"only public module-level bindings become variable nodes")
+
+	var defines int
+	for _, ed := range result.Edges {
+		if ed.Kind == graph.EdgeDefines && ed.To == "settings.py::app" {
+			defines++
+		}
+	}
+	assert.Equal(t, 1, defines, "the file defines the module-level binding")
+}
+
+func TestPyTopLevelVar_RealDefinitionKeepsTheSharedID(t *testing.T) {
+	// `seen` is shared by the class, function and variable emitters, and
+	// they all key on `file::Name`. A variable emitted inline would take
+	// the id first and delete the class from the graph outright.
+	src := []byte(`Config = load()
+
+
+class Config:
+    pass
+
+
+Handler = 1
+
+
+def Handler():
+    pass
+`)
+	e := NewPythonExtractor()
+	result, err := e.Extract("shadow.py", src)
+	require.NoError(t, err)
+
+	require.Len(t, nodesOfKind(result.Nodes, graph.KindType), 1,
+		"the class must survive a same-named module binding above it")
+	require.Len(t, nodesOfKind(result.Nodes, graph.KindFunction), 1,
+		"the function must survive a same-named module binding above it")
+	assert.Empty(t, nodesOfKind(result.Nodes, graph.KindVariable),
+		"the binding yields to the real definition rather than duplicating its id")
+}
+
+func TestPyTopLevelVar_NestedAssignmentsAreNotModuleLevel(t *testing.T) {
+	// A `try:`/`if:` block is a suite, not the module, so an assignment
+	// inside one is deliberately out of scope for this pass.
+	src := []byte(`try:
+    import ujson as json_impl
+except ImportError:
+    json_impl = None
+
+
+def f():
+    x = 1
+`)
+	e := NewPythonExtractor()
+	result, err := e.Extract("compat.py", src)
+	require.NoError(t, err)
+
+	for _, n := range nodesOfKind(result.Nodes, graph.KindVariable) {
+		assert.NotEqual(t, "x", n.Name, "function locals are not module bindings")
+	}
+}


### PR DESCRIPTION
Python's graph was thinner than it looked, and the cause was not parsing.
tree-sitter-python parses the corpus below with **1 error node and 0 missing
nodes across 4,394 files**. The extractor simply did not emit what the parse
tree already contained: **8% of all call sites were dropped on the floor**,
`import numpy as np` was invisible, Python was the only major language in the
graph with **no inheritance edges at all**, module-level variables produced
**zero nodes** because their emitter was unreachable, and only **10.8%** of
method-call edges carried a `receiver_type`.

Ground truth throughout is CPython's own `ast` module, so every number below is
a comparison against the language's own parser rather than against a second
implementation of the same guesses.

**Corpus** (4,394 `.py` files; `ast` parses 4,392 — two are deliberately
invalid fixtures): Django, SQLAlchemy, pydantic, rich, flask, httpx, requests.
Chosen to mix framework code, library code and large test suites; Django and
SQLAlchemy carry the class-heavy, inheritance-heavy shapes that
pydantic/rich/flask alone under-represent.

## What was wrong

### 1. Every call outside a function body was discarded

`Extract` mapped each call site to its enclosing function and did
`if callerID == "" { continue }`. In Python that is not an edge case. Module
level is where an application is wired together, class bodies are where ORM
columns and framework fields are declared, and a decorator sits *above* the
`def` line so it falls outside the range of the very function it decorates.

Ground truth over the corpus: **21,353 module-level + 9,765 class-body call
sites = 31,118**, 7% of every call written. The callee had no caller anywhere
in the graph, so `get_callers` could not see `app = Flask(__name__)`,
`name = Column(String)` or `@app.route("/")` at all, and `find_usages` saw only
the minority of those sites that happened to also emit an instantiation edge.

TypeScript already fixed this identical bug and attributes such sites to the
file node — with a comment explaining that dropping them made every such callee
invisible. Python never got the same treatment, though this same file already
did it for type-use edges.

### 2. `import numpy as np` matched nothing

The query was `(import_statement name: (dotted_name) @import.name)`. An
`import_statement`'s `name` field holds a `dotted_name` for `import os` but an
**`aliased_import`** for `import numpy as np`, so the pattern could never fire
on an aliased import. No import node, no import edge, and no alias binding —
which left every `np.array(...)` falling through to a bare
`unresolved::*.array` instead of attributing to numpy. `import x as y` is how
the entire numpy/pandas idiom is written.

The alias-handling code inside `emitImport` was already correct; it was simply
never reached. The one shape that worked by accident was
`import numpy as np, json`, where the sibling plain import made the pattern
match and the child walk then recovered the alias.

The same pattern also emitted exactly one import node per statement even when
the statement bound several modules, so the trailing names of
`import os.path, json` were silently lost.

### 3. Python emitted no inheritance edges

C#, Dart, Erlang, Go, Haskell, Java, Kotlin, Pascal, PHP, R, Ruby, Rust and
TypeScript all emit `EdgeExtends`/`EdgeImplements`. `emitClass` emitted the
class node, its members, its decorators, its PEP-695 type parameters and its
ORM table attribution — and never read the `superclasses` field.

Every hierarchy-shaped query was therefore blind on Python: class hierarchy
walks, override dispatch, mixin reachability, abstract-base coverage. Across
the corpus **21,290 of 25,576 classes declare at least one base**, for 24,274
base references.

### 4. `self` was never typed, and the type environment leaked across functions

`receiver_type` is what lets the resolver's exact-type passes bind `x.foo()` to
the `foo` belonging to x's type. It covered **21,614 of 200,626** Python
method-call edges — 10.8%. The environment was fed by assignments alone, so the
two receivers a reader can name with certainty were both invisible:

- **`self` and `cls`.** These name the class the call is written in, which the
  enclosing `class_definition` states outright — no inference, no ambiguity.
  That is **66,987 + 585 attribute-call receivers, 26% of all of them**.
- **Annotated parameters** (`def handle(self, req: Request)`).

Worse, the environment was **file-global**: one map per file, populated by every
assignment anywhere in it. A `m = Foo()` in any function stamped
`receiver_type=Foo` on every unrelated `m.bar()` in every other function of the
same file. Those edges were not merely unhelpful, they were **wrong**, and a
wrong `receiver_type` binds a call at a high-confidence tier instead of leaving
it to the name-match fallback.

### 5. `emitTopLevelVar` was unreachable

It guarded on the assignment's immediate parent being `module`. Tree-sitter
wraps every bare expression in an `expression_statement` first, so an
`assignment` is never a direct child of `module` and the check could not pass
for any input. Python emitted **zero** `KindVariable` nodes for every file ever
indexed — including the module singletons every framework is assembled from.

## Commits

1. **Attribute module-level and class-body calls to the file node.** Matches
   what TypeScript does for the same shape and what this file already did for
   type-use edges.

2. **Bind imports written with an alias.** Match `(import_statement)` with no
   field constraint and let `emitImport` walk the children, where both shapes
   were already handled. Every bound name emits its own node; an aliased import
   records its alias in node `Meta`.

3. **Emit inheritance edges.** One `EdgeExtends` per declared base. Bases
   written as attributes (`models.Model`, 6,486 of them) bind on the trailing
   name and keep the written-out path in `Meta["base_path"]` — 330 class names
   in the corpus are defined in more than one file, so the bare name alone
   cannot pick the right parent. Generic bases (`Generic[T]`) bind on the
   subscripted value, since type arguments are not parents. Keyword arguments
   (`metaclass=ABCMeta`) and splats (`*bases`) are skipped rather than minted as
   phantom parents: a wrong parent edge propagates through every
   inherited-member walk that trusts it.

4. **Type receivers from `self`, `cls` and annotated parameters**, and scope the
   type environment. Bindings are bucketed into the scope that owns them and
   resolved the way Python resolves them: the call's own function first, then
   module scope, never another function's locals. Nested functions share their
   outermost enclosing function's scope, so a closure still sees a captured
   variable.

   Precision is guarded rather than assumed:

   - a name assigned two different classes in one scope yields **nothing** — a
     flow-insensitive environment cannot say which assignment reaches the call
   - a written annotation outranks a constructor-call inference
   - **container annotations yield nothing**: `xs: list[Widget]` makes
     `xs.append(...)` a list call, not a Widget call
   - `*args: Widget` is a tuple, not a Widget, so variadic parameters are
     excluded by construction (their name is wrapped in a splat pattern the
     query does not match)
   - a union naming two real classes yields nothing; only `T | None` and
     `Optional[T]` collapse to `T`

   `pyReceiverTypeFromAnnotation` replaces truncate-at-first-bracket for this
   path, which had turned `Optional[Foo]` into the wrapper name `Optional`. It
   unwraps `Optional`/`Union`/`Annotated`/`Final` and PEP 604 unions, resolves
   quoted forward references, and refuses containers.

5. **Emit module-level variable nodes.** Walk through the `expression_statement`
   wrapper before comparing against `module`. Emission is deferred to the end of
   the file walk: `seen` is shared by the class, function and variable emitters
   and they all key on `file::Name`, so emitting inline let `Config = load()`
   sitting above `class Config:` claim the id and **delete the class from the
   graph** — 8 classes and 6 inheritance edges in the corpus. Deferring makes
   the real definition win and the binding yield.

## Measured

Same corpus, same binary, before and after — the extractor run directly over
all 4,394 files:

| | before | after | ground truth |
|---|---|---|---|
| call edges | 404,172 | **439,860** | 439,479 written call sites |
| method calls with `receiver_type` | 21,614 (10.8%) | **82,694 (40.6%)** | — |
| inheritance edges | 0 | **18,240** | 18,245 reachable |
| module-level variable nodes | 0 | **5,335** | — |
| import nodes | 35,616 | **35,799** | 183 aliased imports |

Call recall lands slightly above the ground-truth count because the extractor
also synthesises edges the source does not write literally (FastAPI `Depends`,
pub/sub, SQL call sites).

The inheritance figure is **99.97% of the 18,245 bases that are reachable at
all**; the rest belong to classes the extractor never emits, for the separate
reason in the next section.

Two defects here were found by running against the corpus rather than by
reading the code, which is the argument for doing both:

- `Optional[int | str]` contains a `|` that is *not* a top-level union. Testing
  for the character before splitting handed the whole string back unchanged and
  recursed until the stack overflowed. The unit tests passed; the first corpus
  run crashed.
- Commit 5's first draft silently deleted 8 classes and 6 inheritance edges via
  the shared `seen` map. Nothing failed — the totals just moved, which is only
  visible if you re-measure after every change.

Verified with `go test ./...` (138 packages pass) and `golangci-lint run` on
the touched package. 21 test functions added across five files.

The one test that failed in that run, `bench/index-perf`'s
`TestColdIndexNoWallClockRegression`, is a wall-clock gate and was failing on
machine load, not on this change. Its fixture is ten `.go` files, so the Python
extractor is never invoked during the measured region, and `RegisterAll` — the
only place the added query patterns compile — runs outside the timer. An
interleaved A/B against `main` puts the two arms inside each other's noise
(branch best 24.12 ms vs main best 24.31 ms over four alternating rounds), and
back-to-back runs of the identical binary alternate between fail and pass.

## Deliberately not in this change

An adversarially-verified sweep of the whole Python surface produced 45
candidate defects; 41 did not survive verification. The three that did, and are
not fixed here:

- **Class node identity.** `emitClass` keys class nodes on
  `filePath + "::" + name` and returns early on a collision instead of using
  the `disambiguateID` helper its sibling `emitFunction` already uses, so a
  class whose bare name repeats in one file is dropped, its methods'
  `EdgeMemberOf` binds to the first same-named class, and its base classes are
  the missing inheritance edges above.

  The raw count is 7,372 dropped definitions, but that number is almost
  entirely an artifact of test suites: **7,349 are in test files and 23 in
  library source** (0.5% of 4,697 library classes), and **6,895 of them are
  throwaway classes declared inside a test function body** — pydantic and
  Django writing `class Model(BaseModel)` in each test. Worth fixing for
  correctness, but it is a change to Python symbol identity with resolver blast
  radius, and the library-source prize does not justify riding it along with
  extraction fixes.

- **`findEnclosingFunc` returns the outermost containing range, not the
  innermost.** 2,782 call sites are credited to an ancestor function and 1,355
  function/method nodes contain calls yet have no outgoing call edge — the
  decorator/closure layer (`wrapper`, `decorator`, `wrapped_view`). A fix needs
  a Python-local innermost-wins lookup rather than changing the shared helper,
  which has 123 call sites across ~50 language files, and it interacts with the
  scope chain added in commit 4 (innermost ownership needs innermost →
  enclosing → module lookup to avoid losing closure receivers). 72% of the
  affected sites are in test files.

- **`@overload` takes the canonical method id.** In all 55 overload sets in the
  corpus the unsuffixed id resolves to a `...`-bodied stub rather than the real
  implementation, which gets an `_L<line>` suffix. Small — 0.4% of declarations.
