### PR TITLE
Fix local embedding truncation after tokenizer drift

### DIFF
--- a/internal/embedding/gomlx.go
+++ b/internal/embedding/gomlx.go
@@ -54,9 +54,13 @@ func newGoMLXProvider() (Provider, error) {
 	}
 
 	// Belt-and-suspenders token truncation: the XLA path's Rust tokenizer
-	// already truncates, but keeping the client-side cap here matches the
-	// pure-Go provider and covers a degraded tokenizer. See hugot.go.
+	// already truncates, but keeping the exact client-side cap here matches the
+	// pure-Go provider and preserves the same hard sequence bound. See hugot.go.
 	truncator, terr := newTokenTruncator(modelPath)
+	if truncator == nil {
+		_ = session.Destroy()
+		return nil, fmt.Errorf("gomlx token truncator: %w", terr)
+	}
 	if terr != nil {
 		fmt.Fprintf(os.Stderr, "[gortex embedding] %v\n", terr)
 	}

--- a/internal/embedding/hugot.go
+++ b/internal/embedding/hugot.go
@@ -133,10 +133,14 @@ func newHugotProviderWithSpec(spec HugotVariant) (Provider, error) {
 	// Cap inputs at the model's positional budget before they reach the
 	// pipeline. The pure-Go tokenizer path does not honour
 	// max_position_embeddings, so an over-long text would otherwise abort the
-	// whole vector index with a tensor shape mismatch. A degraded truncator
-	// (missing config.json / corrupt tokenizer.json) still works via a rune
-	// clamp, so we warn and continue rather than fail the provider.
+	// whole vector index with a tensor shape mismatch. A missing config.json can
+	// use the conservative fallback budget, but an exact tokenizer is mandatory:
+	// without it there is no safe sequence-length check.
 	truncator, terr := newTokenTruncator(modelPath)
+	if truncator == nil {
+		_ = session.Destroy()
+		return nil, fmt.Errorf("hugot token truncator: %w", terr)
+	}
 	if terr != nil {
 		fmt.Fprintf(os.Stderr, "[gortex embedding] %v\n", terr)
 	}

--- a/internal/embedding/truncate.go
+++ b/internal/embedding/truncate.go
@@ -12,24 +12,10 @@ import (
 )
 
 const (
-	// fallbackTokenBudget is the token budget used when a model directory has no
-	// parseable config.json to read max_position_embeddings from. 512 - 2 = 510,
-	// matching the classic BERT/MiniLM context window minus the two special tokens.
-	fallbackTokenBudget = 510
-
-	// specialTokenReserve is the number of positions the inference pipeline consumes
-	// for special tokens ([CLS]/[SEP]) appended after client-side truncation, so the
-	// truncation budget is max_position_embeddings minus this.
-	specialTokenReserve = 2
-
-	// runeClampBudgetFactor caps the rune-clamp fallback at budget runes. A
-	// WordPiece token spans at least one rune, so token_count <= rune_count;
-	// clamping to budget runes therefore guarantees token_count <= budget. A
-	// looser cap (e.g. 4*budget) would NOT bound the token count and could let a
-	// token-dense input (CJK, single-char words) overflow the window it is meant
-	// to protect. Recall loss in this rare fallback is an acceptable price for a
-	// hard safety bound.
-	runeClampBudgetFactor = 1
+	// fallbackTokenBudget is the total sequence budget used when a model directory
+	// has no parseable config.json. It matches the classic BERT/MiniLM context
+	// window, including tokenizer-added special tokens.
+	fallbackTokenBudget = 512
 )
 
 // tokenTruncator caps input texts at a model's positional budget before they reach
@@ -41,42 +27,78 @@ const (
 // client-side keeps that failure from ever occurring; because a transformer cannot
 // attend past its positional budget, cutting the tail is lossless by construction.
 //
-// A tokenTruncator returned by newTokenTruncator is always safe to use: if the real
-// tokenizer could not be loaded, tk is nil and Truncate degrades to a rune clamp
-// rather than disabling truncation (and the caller's local backend) entirely.
+// tokenTruncator uses the same post-processing semantics as the inference
+// pipeline. budget is the model's total sequence width, including special tokens.
+type annotatedTokenizer interface {
+	EncodeWithAnnotations(string) api.AnnotatedEncoding
+}
+
 type tokenTruncator struct {
-	tk     *hftokenizer.Tokenizer // nil ⇒ rune-clamp fallback
-	budget int                    // max token count before truncation (max_position_embeddings - 2)
-	clamp  int                    // rune cap used when tk == nil
+	tk              annotatedTokenizer
+	budget          int
+	asciiFastBudget int // >= 0 only for the known BERT + WordPiece pipeline
 }
 
 // newTokenTruncator builds a truncator for the model cached under modelDir. It reads
-// <modelDir>/tokenizer.json (the same file hugot loads) and derives the token budget
-// from <modelDir>/config.json's max_position_embeddings.
+// <modelDir>/tokenizer.json (the same file Hugot loads) and derives the total
+// sequence budget from <modelDir>/config.json's max_position_embeddings.
 //
-// The returned truncator is always non-nil and usable. A non-nil error is
-// informational: it reports a degraded state (a fallback budget because config.json
-// was missing/unparseable, or rune-clamp-only mode because tokenizer.json could not
-// be loaded) so the caller can warn without disabling the provider.
+// A missing or malformed config.json degrades to fallbackTokenBudget and returns an
+// informational error alongside a usable truncator. Tokenizer failures are fatal:
+// without the exact tokenizer there is no safe way to prove an input fits the model.
 func newTokenTruncator(modelDir string) (*tokenTruncator, error) {
 	budget, budgetErr := readTokenBudget(modelDir)
-	t := &tokenTruncator{budget: budget, clamp: budget * runeClampBudgetFactor}
 
 	tkBytes, err := os.ReadFile(filepath.Join(modelDir, "tokenizer.json"))
 	if err != nil {
-		return t, fmt.Errorf("token truncation degraded to rune clamp: read tokenizer.json: %w", err)
+		return nil, fmt.Errorf("read tokenizer.json: %w", err)
 	}
 	tk, err := hftokenizer.NewFromContent(nil, tkBytes)
 	if err != nil {
-		return t, fmt.Errorf("token truncation degraded to rune clamp: parse tokenizer.json: %w", err)
+		return nil, fmt.Errorf("parse tokenizer.json: %w", err)
 	}
-	// Encode without special tokens so every returned span is a real byte span into
-	// the original text; the two reserved positions cover the [CLS]/[SEP] the pipeline
-	// adds later. IncludeSpans is required for EncodeWithAnnotations to populate Spans.
-	if err := tk.With(api.EncodeOptions{IncludeSpans: true, AddSpecialTokens: false}); err != nil {
-		return t, fmt.Errorf("token truncation degraded to rune clamp: configure tokenizer: %w", err)
+	// Match Hugot's inference tokenizer: post-processing is enabled, so [CLS],
+	// [SEP], and any model-specific special tokens count against the same total
+	// max_position_embeddings budget as the tensor sent to the model.
+	if err := tk.With(api.EncodeOptions{
+		AddSpecialTokens:         true,
+		IncludeSpans:             true,
+		IncludeSpecialTokensMask: true,
+	}); err != nil {
+		return nil, fmt.Errorf("configure tokenizer: %w", err)
 	}
-	t.tk = tk
+	specials := len(tk.EncodeWithAnnotations("").IDs)
+	if specials > budget {
+		return nil, fmt.Errorf("tokenizer adds %d special tokens, exceeding model budget %d", specials, budget)
+	}
+	t := &tokenTruncator{tk: tk, budget: budget, asciiFastBudget: -1}
+	var tokenizerConfig struct {
+		Model struct {
+			Type string `json:"type"`
+		} `json:"model"`
+		Normalizer struct {
+			Type string `json:"type"`
+		} `json:"normalizer"`
+		PreTokenizer struct {
+			Type string `json:"type"`
+		} `json:"pre_tokenizer"`
+		PostProcessor struct {
+			Type   string                       `json:"type"`
+			Single []map[string]json.RawMessage `json:"single"`
+		} `json:"post_processor"`
+	}
+	if json.Unmarshal(tkBytes, &tokenizerConfig) == nil &&
+		tokenizerConfig.Model.Type == "WordPiece" &&
+		tokenizerConfig.Normalizer.Type == "BertNormalizer" &&
+		tokenizerConfig.PreTokenizer.Type == "BertPreTokenizer" &&
+		tokenizerConfig.PostProcessor.Type == "TemplateProcessing" &&
+		hasSingleSequenceTemplate(tokenizerConfig.PostProcessor.Single) {
+		// This exact pipeline emits at most one WordPiece token per ASCII byte:
+		// BERT normalization cannot expand ASCII, and every subword consumes at
+		// least one byte. Non-ASCII and other tokenizer pipelines always take the
+		// exact path.
+		t.asciiFastBudget = budget - specials
+	}
 
 	if budgetErr != nil {
 		return t, fmt.Errorf("using fallback token budget %d: %w", budget, budgetErr)
@@ -84,46 +106,115 @@ func newTokenTruncator(modelDir string) (*tokenTruncator, error) {
 	return t, nil
 }
 
-// Truncate returns text unchanged when it fits the token budget, otherwise the
-// longest prefix that stays within budget, cut on a token (and rune) boundary.
+func hasSingleSequenceTemplate(items []map[string]json.RawMessage) bool {
+	sequences := 0
+	for _, item := range items {
+		if len(item) != 1 {
+			return false
+		}
+		if sequence, ok := item["Sequence"]; ok {
+			var spec struct {
+				ID string `json:"id"`
+			}
+			if json.Unmarshal(sequence, &spec) != nil || spec.ID != "A" {
+				return false
+			}
+			sequences++
+			continue
+		}
+		if _, ok := item["SpecialToken"]; !ok {
+			return false
+		}
+	}
+	return sequences == 1
+}
+
+// Truncate returns text unchanged when the inference tokenizer produces a sequence
+// within the model budget. Otherwise it repeatedly cuts to the longest token prefix
+// that can fit, re-tokenizing each candidate until the total sequence (including
+// special tokens) satisfies the hard postcondition.
 func (t *tokenTruncator) Truncate(text string) string {
-	if t == nil || t.budget <= 0 || text == "" {
+	if t == nil || t.tk == nil || t.budget <= 0 || text == "" {
 		return text
 	}
-	// Fast path: a WordPiece/subword token spans at least one rune (true for every
-	// registered variant — MiniLM/BGE/Jina are all WordPiece), so a rune count
-	// within budget guarantees the token count is too. Only longer texts pay for the
-	// extra tokenizer pass; tokenization is µs–ms while inference dominates. (A
-	// byte-level-BPE variant, where one rune can yield several tokens, would need
-	// this invariant revisited — but the exact-tokenize path below is always correct.)
-	if utf8.RuneCountInString(text) <= t.budget {
+	if t.asciiFastBudget >= 0 && len(text) <= t.asciiFastBudget && isASCII(text) {
 		return text
 	}
-	if t.tk == nil {
-		return clampRunes(text, t.clamp)
+	for text != "" {
+		enc := t.tk.EncodeWithAnnotations(text)
+		if len(enc.IDs) <= t.budget {
+			return text
+		}
+
+		cut := tokenPrefixCut(enc.Spans, enc.SpecialTokensMask, t.budget, len(text))
+		if cut <= 0 {
+			cut = geometricPrefixCut(text)
+		}
+		for cut > 0 && cut < len(text) && !utf8.RuneStart(text[cut]) {
+			cut--
+		}
+		text = text[:cut]
 	}
-	enc := t.tk.EncodeWithAnnotations(text)
-	if len(enc.IDs) <= t.budget {
-		return text
+	return text
+}
+
+func isASCII(text string) bool {
+	for i := 0; i < len(text); i++ {
+		if text[i] >= utf8.RuneSelf {
+			return false
+		}
 	}
-	if len(enc.Spans) < t.budget {
-		// Spans unexpectedly short (tokenizer without span support) — degrade safely.
-		return clampRunes(text, t.clamp)
+	return true
+}
+
+// tokenPrefixCut returns the byte end of the longest non-special token prefix
+// that can coexist with the encoded sequence's special tokens inside budget. If
+// several subwords share a full-word span, it walks back to a strict byte prefix;
+// otherwise a one-pass cut could retain the whole word and remain over budget.
+func tokenPrefixCut(spans []api.TokenSpan, specialMask []int, budget, textBytes int) int {
+	if budget <= 0 || len(spans) == 0 || len(spans) != len(specialMask) {
+		return 0
 	}
-	cut := enc.Spans[t.budget-1].End
-	// cut must land strictly inside the text: we only reach here with more than
-	// budget tokens, so the budget-th token ends before the end. cut == len(text)
-	// means a degenerate (zero-width) later span — fall back to the rune clamp
-	// rather than returning the full over-budget text.
-	if cut <= 0 || cut >= len(text) {
-		return clampRunes(text, t.clamp)
+	specials := 0
+	for _, special := range specialMask {
+		if special != 0 {
+			specials++
+		}
 	}
-	// Defensive: token spans already align to rune boundaries, but never hand back a
-	// string split mid-rune.
-	for cut < len(text) && !utf8.RuneStart(text[cut]) {
+	contentBudget := budget - specials
+	if contentBudget <= 0 {
+		return 0
+	}
+	contentTokens := 0
+	target := -1
+	for i := range spans {
+		if specialMask[i] != 0 {
+			continue
+		}
+		contentTokens++
+		if contentTokens == contentBudget {
+			target = i
+			break
+		}
+	}
+	for i := target; i >= 0; i-- {
+		if specialMask[i] == 0 && spans[i].End > 0 && spans[i].End < textBytes {
+			return spans[i].End
+		}
+	}
+	return 0
+}
+
+// geometricPrefixCut is the bounded defensive path for malformed annotations.
+// Halving ensures strict UTF-8-safe progress and at most logarithmically many
+// additional tokenizer passes, rather than removing and re-tokenizing one rune at
+// a time.
+func geometricPrefixCut(text string) int {
+	cut := len(text) / 2
+	for cut > 0 && !utf8.RuneStart(text[cut]) {
 		cut--
 	}
-	return text[:cut]
+	return cut
 }
 
 // TruncateAll applies Truncate to every text. It returns the input slice
@@ -151,9 +242,9 @@ func (t *tokenTruncator) TruncateAll(texts []string) []string {
 	return out
 }
 
-// readTokenBudget derives the truncation budget from <modelDir>/config.json's
-// max_position_embeddings. It returns the fallback budget with a non-nil error when
-// the file is missing, unparseable, or carries an implausible value — never failing.
+// readTokenBudget derives the total sequence budget from
+// <modelDir>/config.json's max_position_embeddings. It returns the fallback budget
+// with a non-nil error when the file is missing, unparseable, or implausible.
 func readTokenBudget(modelDir string) (int, error) {
 	raw, err := os.ReadFile(filepath.Join(modelDir, "config.json"))
 	if err != nil {
@@ -165,24 +256,8 @@ func readTokenBudget(modelDir string) (int, error) {
 	if err := json.Unmarshal(raw, &cfg); err != nil {
 		return fallbackTokenBudget, fmt.Errorf("parse config.json: %w", err)
 	}
-	if cfg.MaxPositionEmbeddings <= specialTokenReserve {
+	if cfg.MaxPositionEmbeddings <= 0 {
 		return fallbackTokenBudget, fmt.Errorf("config.json max_position_embeddings=%d is implausible", cfg.MaxPositionEmbeddings)
 	}
-	return cfg.MaxPositionEmbeddings - specialTokenReserve, nil
-}
-
-// clampRunes returns the longest prefix of text with at most maxRunes runes, always
-// cutting on a rune boundary.
-func clampRunes(text string, maxRunes int) string {
-	if maxRunes <= 0 {
-		return ""
-	}
-	count := 0
-	for i := range text {
-		if count == maxRunes {
-			return text[:i]
-		}
-		count++
-	}
-	return text
+	return cfg.MaxPositionEmbeddings, nil
 }

--- a/internal/embedding/truncate_test.go
+++ b/internal/embedding/truncate_test.go
@@ -8,12 +8,14 @@ import (
 	"strings"
 	"testing"
 	"unicode/utf8"
+
+	"github.com/gomlx/go-huggingface/tokenizers/api"
 )
 
-// tinyWordPieceTokenizer is a minimal handcrafted BERT-style WordPiece tokenizer.json
-// (lowercasing normalizer, whitespace pre-tokenizer, ~14-entry vocab). Each
-// whitespace-separated in-vocab word encodes to exactly one token, which makes the
-// truncation cut points deterministic without a real model download.
+// tinyWordPieceTokenizer is a minimal handcrafted BGE-style WordPiece tokenizer.json
+// (lowercasing normalizer, whitespace pre-tokenizer, [CLS]/[SEP] post-processing,
+// and a small vocab). It covers one-token words plus ASCII and multibyte subwords,
+// making truncation cut points deterministic without a model download.
 const tinyWordPieceTokenizer = `{
   "version": "1.0",
   "truncation": null,
@@ -26,7 +28,25 @@ const tinyWordPieceTokenizer = `{
   ],
   "normalizer": {"type": "BertNormalizer", "lowercase": true},
   "pre_tokenizer": {"type": "BertPreTokenizer"},
-  "post_processor": null,
+  "post_processor": {
+    "type": "TemplateProcessing",
+    "single": [
+      {"SpecialToken": {"id": "[CLS]", "type_id": 0}},
+      {"Sequence": {"id": "A", "type_id": 0}},
+      {"SpecialToken": {"id": "[SEP]", "type_id": 0}}
+    ],
+    "pair": [
+      {"SpecialToken": {"id": "[CLS]", "type_id": 0}},
+      {"Sequence": {"id": "A", "type_id": 0}},
+      {"SpecialToken": {"id": "[SEP]", "type_id": 0}},
+      {"Sequence": {"id": "B", "type_id": 1}},
+      {"SpecialToken": {"id": "[SEP]", "type_id": 1}}
+    ],
+    "special_tokens": {
+      "[CLS]": {"id": "[CLS]", "ids": [101], "tokens": ["[CLS]"]},
+      "[SEP]": {"id": "[SEP]", "ids": [102], "tokens": ["[SEP]"]}
+    }
+  },
   "decoder": {"type": "WordPiece", "prefix": "##"},
   "model": {
     "type": "WordPiece",
@@ -44,7 +64,10 @@ const tinyWordPieceTokenizer = `{
       "the": 104,
       "a": 105,
       "is": 106,
-      "this": 107
+      "this": 107,
+      "##hello": 108,
+      "привет": 109,
+      "##мир": 110
     }
   }
 }`
@@ -52,9 +75,13 @@ const tinyWordPieceTokenizer = `{
 // writeModelDir creates a temp model directory containing tokenizer.json and,
 // optionally, a config.json declaring max_position_embeddings.
 func writeModelDir(t *testing.T, maxPos int) string {
+	return writeModelDirWithTokenizer(t, tinyWordPieceTokenizer, maxPos)
+}
+
+func writeModelDirWithTokenizer(t *testing.T, tokenizer string, maxPos int) string {
 	t.Helper()
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "tokenizer.json"), []byte(tinyWordPieceTokenizer), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "tokenizer.json"), []byte(tokenizer), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if maxPos > 0 {
@@ -67,7 +94,7 @@ func writeModelDir(t *testing.T, maxPos int) string {
 }
 
 func TestNewTokenTruncator_BudgetFromConfig(t *testing.T) {
-	// max_position_embeddings 7 minus the two reserved special-token slots = budget 5.
+	// max_position_embeddings is the total sequence budget, including specials.
 	dir := writeModelDir(t, 7)
 	tr, err := newTokenTruncator(dir)
 	if err != nil {
@@ -76,8 +103,40 @@ func TestNewTokenTruncator_BudgetFromConfig(t *testing.T) {
 	if tr.tk == nil {
 		t.Fatal("expected a real tokenizer to load")
 	}
-	if tr.budget != 5 {
-		t.Fatalf("budget = %d, want 5", tr.budget)
+	if tr.budget != 7 {
+		t.Fatalf("budget = %d, want 7", tr.budget)
+	}
+	if tr.asciiFastBudget != 5 {
+		t.Fatalf("ASCII fast budget = %d, want 5", tr.asciiFastBudget)
+	}
+}
+
+func TestNewTokenTruncator_DisablesFastPathForDuplicatedSequenceTemplate(t *testing.T) {
+	const sequenceItem = `{"Sequence": {"id": "A", "type_id": 0}}`
+	duplicated := strings.Replace(
+		tinyWordPieceTokenizer,
+		sequenceItem,
+		sequenceItem+", "+sequenceItem,
+		1,
+	)
+	if duplicated == tinyWordPieceTokenizer {
+		t.Fatal("test precondition: sequence template was not duplicated")
+	}
+	dir := writeModelDirWithTokenizer(t, duplicated, 7)
+	tr, err := newTokenTruncator(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tr.asciiFastBudget != -1 {
+		t.Fatalf("ASCII fast budget = %d, want disabled (-1)", tr.asciiFastBudget)
+	}
+
+	const input = "a a a" // duplicated A: six content tokens plus [CLS]/[SEP]
+	if got := len(tr.tk.EncodeWithAnnotations(input).IDs); got != 8 {
+		t.Fatalf("test precondition: duplicated template encodes to %d tokens, want 8", got)
+	}
+	if got := len(tr.tk.EncodeWithAnnotations(tr.Truncate(input)).IDs); got > tr.budget {
+		t.Fatalf("truncated duplicated-template input encodes to %d tokens, over budget %d", got, tr.budget)
 	}
 }
 
@@ -101,18 +160,18 @@ func TestTokenTruncator_ShortTextUntouched(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// 5 runes ≤ budget 5 → fast path returns the text verbatim.
+	// One content token plus [CLS]/[SEP] fits the total budget.
 	if got := tr.Truncate("hello"); got != "hello" {
 		t.Fatalf("Truncate(hello) = %q, want unchanged", got)
 	}
-	// 11 runes > budget but only 2 tokens ≤ budget → token-count check returns verbatim.
+	// Two content tokens plus [CLS]/[SEP] also fit.
 	if got := tr.Truncate("hello world"); got != "hello world" {
 		t.Fatalf("Truncate(hello world) = %q, want unchanged", got)
 	}
 }
 
 func TestTokenTruncator_OverBudgetCutAtSpanBoundary(t *testing.T) {
-	dir := writeModelDir(t, 7) // budget 5
+	dir := writeModelDir(t, 7) // five content tokens plus [CLS]/[SEP]
 	tr, err := newTokenTruncator(dir)
 	if err != nil {
 		t.Fatal(err)
@@ -133,11 +192,33 @@ func TestTokenTruncator_OverBudgetCutAtSpanBoundary(t *testing.T) {
 	}
 }
 
+func TestTokenTruncator_MultibyteSubwordBoundary(t *testing.T) {
+	dir := writeModelDir(t, 7) // five content tokens plus [CLS]/[SEP]
+	tr, err := newTokenTruncator(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	input := strings.Repeat("приветмир ", 3) // six content tokens plus specials
+	if n := len(tr.tk.EncodeWithAnnotations(input).IDs); n <= tr.budget {
+		t.Fatalf("test precondition: input encodes to %d tokens, need > budget %d", n, tr.budget)
+	}
+	got := tr.Truncate(input)
+	if got == input {
+		t.Fatal("over-budget multibyte input was not truncated")
+	}
+	if !utf8.ValidString(got) {
+		t.Fatalf("truncated text is not valid UTF-8: %q", got)
+	}
+	if n := len(tr.tk.EncodeWithAnnotations(got).IDs); n > tr.budget {
+		t.Fatalf("truncated text still encodes to %d tokens, over budget %d", n, tr.budget)
+	}
+}
+
 // TestTokenTruncator_TruncateAll covers the batch API actually wired into every
 // provider's EmbedBatch: over-budget entries are shortened, in-budget entries are
 // returned untouched, and an all-fits batch returns the input slice unmodified.
 func TestTokenTruncator_TruncateAll(t *testing.T) {
-	dir := writeModelDir(t, 7) // budget 5
+	dir := writeModelDir(t, 7) // five content tokens plus [CLS]/[SEP]
 	tr, err := newTokenTruncator(dir)
 	if err != nil {
 		t.Fatal(err)
@@ -162,6 +243,130 @@ func TestTokenTruncator_TruncateAll(t *testing.T) {
 	}
 }
 
+func TestTokenTruncator_BGEStyleBatchBoundary(t *testing.T) {
+	dir := writeModelDir(t, 512)
+	tr, err := newTokenTruncator(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// This mirrors #255 exactly: 512 content tokens become a 514-wide sequence
+	// after BGE adds [CLS]/[SEP].
+	offender := strings.Repeat("a ", 512)
+	if got := len(tr.tk.EncodeWithAnnotations(offender).IDs); got != 514 {
+		t.Fatalf("test precondition: got %d pipeline tokens, want 514", got)
+	}
+
+	texts := make([]string, 500)
+	for i := range texts {
+		texts[i] = "short input"
+	}
+	texts[len(texts)-1] = offender
+
+	out := tr.TruncateAll(texts)
+	if len(out) != len(texts) {
+		t.Fatalf("got %d texts, want %d", len(out), len(texts))
+	}
+	for i, text := range out {
+		if got := len(tr.tk.EncodeWithAnnotations(text).IDs); got > tr.budget {
+			t.Fatalf("text %d still encodes to %d tokens, over budget %d", i, got, tr.budget)
+		}
+	}
+	if got := len(tr.tk.EncodeWithAnnotations(out[len(out)-1]).IDs); got > 512 {
+		t.Fatalf("offender encodes to %d tokens after truncation, want at most 512", got)
+	}
+	if out[0] != "short input" {
+		t.Fatalf("in-budget batch member changed: %q", out[0])
+	}
+}
+
+// driftingTokenizer models the offset behavior that exposed #255 in the
+// reporter's repository: the first 510-token cut retains a complete subword group,
+// so its prefix re-tokenizes to the same 514-wide sequence. A second exact check is
+// required before inference.
+type driftingTokenizer struct{}
+
+func (driftingTokenizer) EncodeWithAnnotations(text string) api.AnnotatedEncoding {
+	contentTokens := len(text)
+	if len(text) == 513 {
+		// Model a trailing byte that emits no token: 512 content tokens plus two
+		// specials is the exact [514] sequence from the issue.
+		contentTokens = 512
+	}
+	n := contentTokens + 2
+	enc := api.AnnotatedEncoding{
+		IDs:               make([]int, n),
+		Spans:             make([]api.TokenSpan, n),
+		SpecialTokensMask: make([]int, n),
+	}
+	enc.SpecialTokensMask[0] = 1
+	enc.SpecialTokensMask[n-1] = 1
+	for i := 0; i < contentTokens; i++ {
+		enc.Spans[i+1] = api.TokenSpan{Start: i, End: i + 1}
+	}
+	if len(text) == 513 {
+		// The budget-th content token shares the end of the complete subword
+		// group, so a one-pass span cut keeps all 512 content tokens.
+		for i := 510; i <= 512; i++ {
+			enc.Spans[i].End = 512
+		}
+	}
+	return enc
+}
+
+func TestTokenTruncator_RetokenizesDriftingBatchBoundary(t *testing.T) {
+	tr := &tokenTruncator{
+		tk:              driftingTokenizer{},
+		budget:          512,
+		asciiFastBudget: -1,
+	}
+	offender := strings.Repeat("x", 513)
+	encoded := tr.tk.EncodeWithAnnotations(offender)
+	if got := len(encoded.IDs); got != 514 {
+		t.Fatalf("test precondition: got %d pipeline tokens, want 514", got)
+	}
+	onePassCut := tokenPrefixCut(
+		encoded.Spans,
+		encoded.SpecialTokensMask,
+		tr.budget,
+		len(offender),
+	)
+	if got := len(tr.tk.EncodeWithAnnotations(offender[:onePassCut]).IDs); got != 514 {
+		t.Fatalf("test precondition: one-pass cut encodes to %d tokens, want reported shape 514", got)
+	}
+
+	texts := make([]string, 500)
+	for i := range texts {
+		texts[i] = "short"
+	}
+	texts[len(texts)-1] = offender
+	out := tr.TruncateAll(texts)
+	for i, text := range out {
+		if got := len(tr.tk.EncodeWithAnnotations(text).IDs); got > tr.budget {
+			t.Fatalf("text %d still encodes to %d tokens, over budget %d", i, got, tr.budget)
+		}
+	}
+}
+
+func TestTokenPrefixCut_MalformedAnnotationsUseBoundedFallback(t *testing.T) {
+	spans := []api.TokenSpan{{Start: 0, End: 1}, {Start: 1, End: 3}}
+	if got := tokenPrefixCut(spans, []int{0}, 1, 3); got != 0 {
+		t.Fatalf("mismatched annotations returned cut %d, want fallback signal 0", got)
+	}
+
+	const input = "aébc"
+	cut := geometricPrefixCut(input)
+	if cut <= 0 || cut >= len(input) {
+		t.Fatalf("geometric cut = %d, want a strict prefix of %d bytes", cut, len(input))
+	}
+	if !utf8.ValidString(input[:cut]) {
+		t.Fatalf("geometric cut split UTF-8: %q", input[:cut])
+	}
+	if cut > len(input)/2 {
+		t.Fatalf("geometric cut = %d, want at most half of %d bytes", cut, len(input))
+	}
+}
+
 func TestReadTokenBudget(t *testing.T) {
 	cases := []struct {
 		name       string
@@ -169,12 +374,12 @@ func TestReadTokenBudget(t *testing.T) {
 		want       int
 		wantErr    bool
 	}{
-		{"bert-512", `{"max_position_embeddings": 512}`, 510, false},
-		{"jina-8192", `{"max_position_embeddings": 8192}`, 8190, false},
+		{"bert-512", `{"max_position_embeddings": 512}`, 512, false},
+		{"jina-8192", `{"max_position_embeddings": 8192}`, 8192, false},
 		{"missing", "", fallbackTokenBudget, true},
 		{"unparseable", `{not json`, fallbackTokenBudget, true},
 		{"absent-field", `{"hidden_size": 384}`, fallbackTokenBudget, true},
-		{"implausible", `{"max_position_embeddings": 1}`, fallbackTokenBudget, true},
+		{"implausible", `{"max_position_embeddings": -1}`, fallbackTokenBudget, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -195,78 +400,57 @@ func TestReadTokenBudget(t *testing.T) {
 	}
 }
 
-func TestClampRunes(t *testing.T) {
-	cases := []struct {
-		name     string
-		text     string
-		maxRunes int
-		want     string
-	}{
-		{"multibyte not split", "héllo wörld", 3, "hél"},
-		{"under cap untouched", "abc", 10, "abc"},
-		{"zero cap", "abc", 0, ""},
-		{"exact cap", "abcd", 4, "abcd"},
+// TestHugotProvider_LiveTruncatesOverBudgetInput is the end-to-end regression
+// for the shape-mismatch crash: an input well past the 512-token window used
+// to abort both MiniLM and BGE pipelines. Gated on real cached/downloadable
+// models — set GORTEX_TEST_LIVE_MODELS=1.
+func TestHugotProvider_LiveTruncatesOverBudgetInput(t *testing.T) {
+	if os.Getenv("GORTEX_TEST_LIVE_MODELS") != "1" {
+		t.Skip("set GORTEX_TEST_LIVE_MODELS=1 to run against real embedding models")
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := clampRunes(tc.text, tc.maxRunes)
-			if got != tc.want {
-				t.Fatalf("clampRunes(%q, %d) = %q, want %q", tc.text, tc.maxRunes, got, tc.want)
+	for _, variant := range []string{DefaultHugotVariant, "bge_small"} {
+		t.Run(variant, func(t *testing.T) {
+			prov, err := NewHugotProviderWithVariant(variant)
+			if err != nil {
+				t.Skipf("%s model unavailable: %v", variant, err)
 			}
-			if !utf8.ValidString(got) {
-				t.Fatalf("result not valid UTF-8: %q", got)
+			defer prov.Close()
+
+			// ~120 repetitions of a 9-token sentence is comfortably past the
+			// 512-token window that used to crash the pure-Go tokenizer path.
+			over := strings.Repeat("the quick brown fox jumps over the lazy dog ", 120)
+
+			vec, err := prov.Embed(context.Background(), over)
+			if err != nil {
+				t.Fatalf("embedding an over-budget input failed: %v", err)
+			}
+			if len(vec) != prov.Dimensions() {
+				t.Fatalf("got a %d-dim vector, want %d", len(vec), prov.Dimensions())
+			}
+			nonZero := false
+			for _, v := range vec {
+				if v != 0 {
+					nonZero = true
+					break
+				}
+			}
+			if !nonZero {
+				t.Fatal("embedding vector is all zeros")
+			}
+
+			// A batch mixing an over-budget input with a short one must also succeed.
+			vecs, err := prov.EmbedBatch(context.Background(), []string{over, "short input"})
+			if err != nil {
+				t.Fatalf("mixed batch failed: %v", err)
+			}
+			if len(vecs) != 2 || len(vecs[0]) != prov.Dimensions() || len(vecs[1]) != prov.Dimensions() {
+				t.Fatalf("mixed batch produced wrong shapes: %d vectors", len(vecs))
 			}
 		})
 	}
 }
 
-// TestHugotProvider_LiveTruncatesOverBudgetInput is the end-to-end regression
-// for the shape-mismatch crash: an input well past MiniLM's 512-token window
-// used to abort the pipeline. With truncation it must embed to a real 384-dim
-// vector. Gated on a real cached model — set GORTEX_TEST_LIVE_MODELS=1.
-func TestHugotProvider_LiveTruncatesOverBudgetInput(t *testing.T) {
-	if os.Getenv("GORTEX_TEST_LIVE_MODELS") != "1" {
-		t.Skip("set GORTEX_TEST_LIVE_MODELS=1 to run against the real MiniLM model")
-	}
-	prov, err := newHugotProvider()
-	if err != nil {
-		t.Skipf("MiniLM model unavailable: %v", err)
-	}
-	defer prov.Close()
-
-	// ~120 repetitions of a 9-token sentence ≈ 1000+ tokens — comfortably past
-	// the 512-token window that used to crash the GO tokenizer path.
-	over := strings.Repeat("the quick brown fox jumps over the lazy dog ", 120)
-
-	vec, err := prov.Embed(context.Background(), over)
-	if err != nil {
-		t.Fatalf("embedding an over-budget input failed (truncation regression): %v", err)
-	}
-	if len(vec) != prov.Dimensions() {
-		t.Fatalf("got a %d-dim vector, want %d", len(vec), prov.Dimensions())
-	}
-	nonZero := false
-	for _, v := range vec {
-		if v != 0 {
-			nonZero = true
-			break
-		}
-	}
-	if !nonZero {
-		t.Fatal("embedding vector is all zeros")
-	}
-
-	// A batch mixing an over-budget input with a short one must also succeed.
-	vecs, err := prov.EmbedBatch(context.Background(), []string{over, "short input"})
-	if err != nil {
-		t.Fatalf("mixed batch failed: %v", err)
-	}
-	if len(vecs) != 2 || len(vecs[0]) != prov.Dimensions() || len(vecs[1]) != prov.Dimensions() {
-		t.Fatalf("mixed batch produced wrong shapes: %d vectors", len(vecs))
-	}
-}
-
-func TestNewTokenTruncator_CorruptTokenizerRuneClamp(t *testing.T) {
+func TestNewTokenTruncator_RejectsCorruptTokenizer(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "tokenizer.json"), []byte("{ not a tokenizer"), 0o644); err != nil {
 		t.Fatal(err)
@@ -278,27 +462,7 @@ func TestNewTokenTruncator_CorruptTokenizerRuneClamp(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error when tokenizer.json is corrupt")
 	}
-	if tr == nil {
-		t.Fatal("truncator must be non-nil even on tokenizer failure")
-	}
-	if tr.tk != nil {
-		t.Fatal("tk must be nil in rune-clamp mode")
-	}
-	// clamp must equal the budget (not a multiple): a token spans >= 1 rune, so
-	// budget runes bound the token count to budget — a looser cap would not.
-	if tr.budget != 10 || tr.clamp != 10 {
-		t.Fatalf("budget=%d clamp=%d, want 10/10", tr.budget, tr.clamp)
-	}
-	// A long multibyte text is clamped (not split mid-rune) rather than passed through.
-	long := ""
-	for i := 0; i < 100; i++ {
-		long += "café "
-	}
-	got := tr.Truncate(long)
-	if utf8.RuneCountInString(got) > tr.clamp {
-		t.Fatalf("clamped rune count %d exceeds clamp %d", utf8.RuneCountInString(got), tr.clamp)
-	}
-	if !utf8.ValidString(got) {
-		t.Fatalf("clamped text not valid UTF-8")
+	if tr != nil {
+		t.Fatalf("truncator = %#v, want nil when the exact tokenizer is unavailable", tr)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #255.

The existing local-embedding truncator made one token-span cut and assumed that prefix still fit. With BGE, a cut prefix can re-tokenize to 512 content tokens; Hugot then adds `[CLS]` and `[SEP]`, recreating the reported 514-wide sequence against a 512-position model.

This change treats `max_position_embeddings` as a hard total-sequence postcondition and re-tokenizes every candidate until it fits.

## Changes

- Count tokenizer-added special tokens with the same post-processing semantics used by inference.
- Re-tokenize strict UTF-8 prefix cuts until the total sequence is within the model budget.
- Handle shared subword spans and malformed annotations with bounded, progress-guaranteed fallbacks.
- Preserve the short ASCII fast path only for a validated single-sequence BERT/WordPiece pipeline; all other tokenizers use the exact path.
- Fail Hugot/GoMLX provider setup cleanly when the exact tokenizer is unavailable.
- Add deterministic coverage for the 500-item 514-to-512 drift case, multibyte subwords, duplicated templates, corrupt tokenizers, and live MiniLM/BGE inference.

## Testing

- [x] All tests pass (`go test -race ./...`)
- [x] New tests added for new functionality
- [x] Performance gate exercised (`bench/index-perf` passed on the final race run and 5 isolated branch runs)
- [x] `go test -tags embeddings_gomlx ./internal/embedding -count=1`
- [x] `GORTEX_TEST_LIVE_MODELS=1 go test ./internal/embedding -run ^TestHugotProvider_LiveTruncatesOverBudgetInput$ -count=1 -v`

Two non-race full-suite attempts hit the existing wall-clock index benchmark only under whole-suite load. The same test passed 8 isolated branch runs, 5 isolated `origin/main` runs with comparable timings, and the final repository-wide race run. The benchmark package has no dependency on `internal/embedding`.

## Checklist

- [x] Code follows existing patterns in the codebase
- [x] No unnecessary abstractions added
- [x] Language extractor metadata requirement: N/A
- [x] `EdgeMemberOf` method requirement: N/A