### PR TITLE
fix(embedding): recover from Ollama tokenizer EOF

### DIFF
--- a/internal/embedding/api.go
+++ b/internal/embedding/api.go
@@ -377,7 +377,7 @@ func (p *APIProvider) recoverOllamaSingleton(ctx context.Context, text string, i
 	}
 
 	return nil, fmt.Errorf(
-		"Ollama tokenizer runner failed for one input after %d recovery attempts: %w",
+		"ollama tokenizer runner failed for one input after %d recovery attempts: %w",
 		attempts, lastErr,
 	)
 }

--- a/internal/embedding/api.go
+++ b/internal/embedding/api.go
@@ -32,6 +32,13 @@ const maxRetryAfterWait = 60 * time.Second
 // generated symbols.
 const maxEmbedInputBytes = 8000
 
+// maxOllamaBatchSize bounds the number of inputs sent in one /api/embed
+// request. Ollama fans an input array out internally, so forwarding the
+// indexer's 500-item chunks unchanged can overwhelm or crash its runner.
+// Keeping the provider-level cap here also protects direct EmbedBatch
+// callers while preserving the indexer's configured outer concurrency.
+const maxOllamaBatchSize = 64
+
 // truncateEmbedInputs head-truncates any input over the byte cap, on a
 // UTF-8 rune boundary so the JSON payload stays valid. Returns the same
 // slice when nothing needed trimming (the common case).
@@ -257,8 +264,9 @@ func parseRetryAfter(v string) time.Duration {
 // --- Ollama API ---
 
 type ollamaRequest struct {
-	Model string `json:"model"`
-	Input any    `json:"input"` // string or []string
+	Model    string `json:"model"`
+	Input    any    `json:"input"` // string or []string
+	Truncate bool   `json:"truncate"`
 }
 
 type ollamaResponse struct {
@@ -266,9 +274,27 @@ type ollamaResponse struct {
 }
 
 func (p *APIProvider) embedOllama(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) <= maxOllamaBatchSize {
+		return p.embedOllamaOnce(ctx, texts)
+	}
+
+	vecs := make([][]float32, 0, len(texts))
+	for start := 0; start < len(texts); start += maxOllamaBatchSize {
+		end := min(start+maxOllamaBatchSize, len(texts))
+		batch, err := p.embedOllamaOnce(ctx, texts[start:end])
+		if err != nil {
+			return nil, err
+		}
+		vecs = append(vecs, batch...)
+	}
+	return vecs, nil
+}
+
+func (p *APIProvider) embedOllamaOnce(ctx context.Context, texts []string) ([][]float32, error) {
 	reqBody := ollamaRequest{
-		Model: p.model,
-		Input: truncateEmbedInputs(texts),
+		Model:    p.model,
+		Input:    truncateEmbedInputs(texts),
+		Truncate: true,
 	}
 
 	body, err := json.Marshal(reqBody)

--- a/internal/embedding/api.go
+++ b/internal/embedding/api.go
@@ -4,9 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -39,6 +42,23 @@ const maxEmbedInputBytes = 8000
 // callers while preserving the indexer's configured outer concurrency.
 const maxOllamaBatchSize = 64
 
+// maxOllamaSingletonRetries bounds recovery once bisection isolates one
+// input. The first retry is unchanged so a restarted runner can accept it;
+// the next two halve the UTF-8-safe byte cap (8000 → 4000 → 2000) to handle
+// Ollama runners that repeatedly die on one long embedding input.
+const maxOllamaSingletonRetries = 3
+
+func truncateUTF8Head(text string, maxBytes int) string {
+	if len(text) <= maxBytes {
+		return text
+	}
+	end := maxBytes
+	for end > 0 && text[end]&0xC0 == 0x80 {
+		end--
+	}
+	return text[:end]
+}
+
 // truncateEmbedInputs head-truncates any input over the byte cap, on a
 // UTF-8 rune boundary so the JSON payload stays valid. Returns the same
 // slice when nothing needed trimming (the common case).
@@ -52,11 +72,7 @@ func truncateEmbedInputs(texts []string) []string {
 			out = make([]string, len(texts))
 			copy(out, texts)
 		}
-		b := []byte(t[:maxEmbedInputBytes])
-		for len(b) > 0 && b[len(b)-1]&0xC0 == 0x80 { // back off mid-rune
-			b = b[:len(b)-1]
-		}
-		out[i] = string(b)
+		out[i] = truncateUTF8Head(t, maxEmbedInputBytes)
 	}
 	if out == nil {
 		return texts
@@ -273,21 +289,137 @@ type ollamaResponse struct {
 	Embeddings [][]float32 `json:"embeddings"`
 }
 
+type ollamaAPIError struct {
+	statusCode int
+	body       string
+}
+
+func (e *ollamaAPIError) Error() string {
+	return fmt.Sprintf("API error %d: %s", e.statusCode, e.body)
+}
+
 func (p *APIProvider) embedOllama(ctx context.Context, texts []string) ([][]float32, error) {
 	if len(texts) <= maxOllamaBatchSize {
-		return p.embedOllamaOnce(ctx, texts)
+		return p.embedOllamaRecover(ctx, texts)
 	}
 
 	vecs := make([][]float32, 0, len(texts))
 	for start := 0; start < len(texts); start += maxOllamaBatchSize {
 		end := min(start+maxOllamaBatchSize, len(texts))
-		batch, err := p.embedOllamaOnce(ctx, texts[start:end])
+		batch, err := p.embedOllamaRecover(ctx, texts[start:end])
 		if err != nil {
 			return nil, err
 		}
 		vecs = append(vecs, batch...)
 	}
 	return vecs, nil
+}
+
+func (p *APIProvider) embedOllamaRecover(ctx context.Context, texts []string) ([][]float32, error) {
+	vecs, err := p.embedOllamaOnce(ctx, texts)
+	if err == nil {
+		return vecs, nil
+	}
+	if !isOllamaRunnerTokenizerEOF(err) {
+		return nil, err
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, ctxErr
+	}
+	if len(texts) == 0 {
+		return nil, err
+	}
+	if len(texts) == 1 {
+		return p.recoverOllamaSingleton(ctx, texts[0], err)
+	}
+
+	mid := len(texts) / 2
+	left, err := p.embedOllamaRecover(ctx, texts[:mid])
+	if err != nil {
+		return nil, err
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, ctxErr
+	}
+	right, err := p.embedOllamaRecover(ctx, texts[mid:])
+	if err != nil {
+		return nil, err
+	}
+	return append(left, right...), nil
+}
+
+func (p *APIProvider) recoverOllamaSingleton(ctx context.Context, text string, initialErr error) ([][]float32, error) {
+	candidate := truncateUTF8Head(text, maxEmbedInputBytes)
+	lastErr := initialErr
+	attempts := 0
+
+	for retry := 0; retry < maxOllamaSingletonRetries; retry++ {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		if retry > 0 {
+			shortened := truncateUTF8Head(candidate, len(candidate)/2)
+			if shortened == "" || shortened == candidate {
+				break
+			}
+			candidate = shortened
+		}
+
+		attempts++
+		vecs, err := p.embedOllamaOnce(ctx, []string{candidate})
+		if err == nil {
+			return vecs, nil
+		}
+		if !isOllamaRunnerTokenizerEOF(err) {
+			return nil, err
+		}
+		lastErr = err
+	}
+
+	return nil, fmt.Errorf(
+		"Ollama tokenizer runner failed for one input after %d recovery attempts: %w",
+		attempts, lastErr,
+	)
+}
+
+// isOllamaRunnerTokenizerEOF recognizes the narrow failure reported in
+// #296: Ollama returns HTTP 400 even though its private loopback tokenizer
+// transport died. Ordinary validation errors, remote URLs, other runner
+// endpoints, and other status codes must not trigger retries.
+func isOllamaRunnerTokenizerEOF(err error) bool {
+	var apiErr *ollamaAPIError
+	if !errors.As(err, &apiErr) || apiErr.statusCode != http.StatusBadRequest {
+		return false
+	}
+
+	var payload struct {
+		Error string `json:"error"`
+	}
+	if json.Unmarshal([]byte(apiErr.body), &payload) != nil {
+		return false
+	}
+
+	const postMarker = `Post "`
+	start := strings.Index(payload.Error, postMarker)
+	if start < 0 {
+		return false
+	}
+	rest := payload.Error[start+len(postMarker):]
+	end := strings.IndexByte(rest, '"')
+	if end < 0 || strings.TrimSpace(rest[end+1:]) != ": EOF" {
+		return false
+	}
+
+	runnerURL, err := url.Parse(rest[:end])
+	if err != nil || runnerURL.Scheme != "http" || runnerURL.Path != "/tokenize" || runnerURL.Port() == "" {
+		return false
+	}
+	host := runnerURL.Hostname()
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 func (p *APIProvider) embedOllamaOnce(ctx context.Context, texts []string) ([][]float32, error) {
@@ -320,7 +452,10 @@ func (p *APIProvider) embedOllamaOnce(ctx context.Context, texts []string) ([][]
 
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("API error %d: %s", resp.StatusCode, string(respBody))
+		return nil, &ollamaAPIError{
+			statusCode: resp.StatusCode,
+			body:       string(respBody),
+		}
 	}
 
 	var result ollamaResponse

--- a/internal/embedding/api_test.go
+++ b/internal/embedding/api_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -82,6 +83,276 @@ func TestAPIProvider_OllamaBoundsBatchSize(t *testing.T) {
 	for _, size := range batchSizes {
 		assert.LessOrEqual(t, size, maxOllamaBatchSize)
 	}
+}
+
+func TestAPIProvider_OllamaSplitsAfterTokenizerEOF(t *testing.T) {
+	texts := make([]string, 17)
+	ordinals := make(map[string]int, len(texts))
+	for i := range texts {
+		texts[i] = "input-" + strconv.Itoa(i)
+		ordinals[texts[i]] = i
+	}
+
+	var (
+		mu         sync.Mutex
+		batchSizes []int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ollamaRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		inputs, ok := req.Input.([]any)
+		if !ok {
+			http.Error(w, "expected input array", http.StatusBadRequest)
+			return
+		}
+
+		mu.Lock()
+		batchSizes = append(batchSizes, len(inputs))
+		mu.Unlock()
+
+		if len(inputs) > 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"Post \"http://127.0.0.1:51824/tokenize\": EOF"}`))
+			return
+		}
+
+		embeddings := make([][]float32, len(inputs))
+		for i, value := range inputs {
+			text, ok := value.(string)
+			if !ok {
+				http.Error(w, "expected string input", http.StatusBadRequest)
+				return
+			}
+			ordinal, ok := ordinals[text]
+			if !ok {
+				http.Error(w, "unexpected input", http.StatusBadRequest)
+				return
+			}
+			embeddings[i] = []float32{float32(ordinal)}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(ollamaResponse{Embeddings: embeddings})
+	}))
+	defer srv.Close()
+
+	p := NewAPIProvider(srv.URL, "nomic-embed-text")
+	p.format = formatOllama
+	vecs, err := p.EmbedBatch(context.Background(), texts)
+	require.NoError(t, err)
+	require.Len(t, vecs, len(texts))
+	for i := range vecs {
+		assert.Equal(t, []float32{float32(i)}, vecs[i], "split responses must retain input order")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Len(t, batchSizes, 2*len(texts)-1,
+		"a backend accepting only singletons should exercise the complete bounded split tree")
+	assert.Equal(t, len(texts), countEqual(batchSizes, 1))
+}
+
+func TestAPIProvider_OllamaTokenizerEOFRetriesAreBounded(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"Post \"http://127.0.0.1:51824/tokenize\": EOF"}`))
+	}))
+	defer srv.Close()
+
+	p := NewAPIProvider(srv.URL, "nomic-embed-text")
+	p.format = formatOllama
+	texts := make([]string, maxOllamaBatchSize)
+	for i := range texts {
+		texts[i] = strings.Repeat("x", 16)
+	}
+	_, err := p.EmbedBatch(context.Background(), texts)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "after 3 recovery attempts")
+	assert.Equal(t, int32(10), atomic.LoadInt32(&calls),
+		"a persistent failure should follow one branch to a singleton, then stop after bounded retries")
+}
+
+func TestAPIProvider_OllamaRetriesSingletonBeforeShortening(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		received []string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Input []string `json:"input"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil || len(req.Input) != 1 {
+			http.Error(w, "invalid input", http.StatusBadRequest)
+			return
+		}
+		mu.Lock()
+		received = append(received, req.Input[0])
+		call := len(received)
+		mu.Unlock()
+
+		if call == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"Post \"http://127.0.0.1:51824/tokenize\": EOF"}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(ollamaResponse{Embeddings: [][]float32{{1, 2}}})
+	}))
+	defer srv.Close()
+
+	p := NewAPIProvider(srv.URL, "nomic-embed-text")
+	p.format = formatOllama
+	vecs, err := p.EmbedBatch(context.Background(), []string{"unchanged retry"})
+	require.NoError(t, err)
+	assert.Equal(t, [][]float32{{1, 2}}, vecs)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []string{"unchanged retry", "unchanged retry"}, received)
+}
+
+func TestAPIProvider_OllamaShortensCrashingSingleton(t *testing.T) {
+	text := strings.Repeat("x", 64)
+	var (
+		mu        sync.Mutex
+		byteSizes []int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Input []string `json:"input"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil || len(req.Input) != 1 {
+			http.Error(w, "invalid input", http.StatusBadRequest)
+			return
+		}
+		mu.Lock()
+		byteSizes = append(byteSizes, len(req.Input[0]))
+		mu.Unlock()
+
+		if len(req.Input[0]) > 16 {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"Post \"http://127.0.0.1:51824/tokenize\": EOF"}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(ollamaResponse{Embeddings: [][]float32{{3, 4}}})
+	}))
+	defer srv.Close()
+
+	p := NewAPIProvider(srv.URL, "nomic-embed-text")
+	p.format = formatOllama
+	vecs, err := p.EmbedBatch(context.Background(), []string{text})
+	require.NoError(t, err)
+	assert.Equal(t, [][]float32{{3, 4}}, vecs)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []int{64, 64, 32, 16}, byteSizes)
+}
+
+func TestAPIProvider_OllamaDoesNotRetryUnrelated400(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"input validation failed with EOF"}`))
+	}))
+	defer srv.Close()
+
+	p := NewAPIProvider(srv.URL, "nomic-embed-text")
+	p.format = formatOllama
+	_, err := p.EmbedBatch(context.Background(), []string{"one", "two"})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "input validation failed")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls))
+}
+
+func TestAPIProvider_OllamaTokenizerEOFHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		cancel()
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"Post \"http://127.0.0.1:51824/tokenize\": EOF"}`))
+	}))
+	defer srv.Close()
+
+	p := NewAPIProvider(srv.URL, "nomic-embed-text")
+	p.format = formatOllama
+	_, err := p.EmbedBatch(ctx, []string{"one", "two"})
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls))
+}
+
+func TestIsOllamaRunnerTokenizerEOF(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "reported IPv4 runner failure",
+			err: &ollamaAPIError{
+				statusCode: http.StatusBadRequest,
+				body:       `{"error":"Post \"http://127.0.0.1:51824/tokenize\": EOF"}`,
+			},
+			want: true,
+		},
+		{
+			name: "localhost runner failure",
+			err: &ollamaAPIError{
+				statusCode: http.StatusBadRequest,
+				body:       `{"error":"Post \"http://localhost:51824/tokenize\": EOF"}`,
+			},
+			want: true,
+		},
+		{
+			name: "remote URL",
+			err: &ollamaAPIError{
+				statusCode: http.StatusBadRequest,
+				body:       `{"error":"Post \"http://example.com:51824/tokenize\": EOF"}`,
+			},
+		},
+		{
+			name: "other endpoint",
+			err: &ollamaAPIError{
+				statusCode: http.StatusBadRequest,
+				body:       `{"error":"Post \"http://127.0.0.1:51824/v1/embeddings\": EOF"}`,
+			},
+		},
+		{
+			name: "other status",
+			err: &ollamaAPIError{
+				statusCode: http.StatusInternalServerError,
+				body:       `{"error":"Post \"http://127.0.0.1:51824/tokenize\": EOF"}`,
+			},
+		},
+		{
+			name: "malformed body",
+			err:  &ollamaAPIError{statusCode: http.StatusBadRequest, body: "EOF"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isOllamaRunnerTokenizerEOF(tt.err))
+		})
+	}
+}
+
+func countEqual(values []int, want int) int {
+	count := 0
+	for _, value := range values {
+		if value == want {
+			count++
+		}
+	}
+	return count
 }
 
 // TestParseRetryAfter covers the delta-seconds Retry-After parser.
@@ -346,4 +617,8 @@ func TestTruncateEmbedInputs(t *testing.T) {
 
 	in := []string{"a", "b"}
 	assert.Equal(t, in, truncateEmbedInputs(in), "no oversize → same slice values")
+
+	multibyte := strings.Repeat("a", maxEmbedInputBytes-1) + "€"
+	assert.Equal(t, strings.Repeat("a", maxEmbedInputBytes-1), truncateEmbedInputs([]string{multibyte})[0],
+		"truncation must drop a partial UTF-8 rune")
 }

--- a/internal/embedding/api_test.go
+++ b/internal/embedding/api_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -19,6 +21,67 @@ import (
 func TestAPIProvider_Concurrent(t *testing.T) {
 	p := NewAPIProvider("http://localhost:11434", "")
 	assert.True(t, p.Concurrent(), "the API provider must opt into concurrent embedding")
+}
+
+func TestAPIProvider_OllamaBoundsBatchSize(t *testing.T) {
+	texts := make([]string, 500)
+	ordinals := make(map[string]int, len(texts))
+	for i := range texts {
+		texts[i] = "input-" + strconv.Itoa(i)
+		ordinals[texts[i]] = i
+	}
+
+	var (
+		mu         sync.Mutex
+		batchSizes []int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Input    []string `json:"input"`
+			Truncate bool     `json:"truncate"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if !req.Truncate {
+			http.Error(w, "truncate must be explicit", http.StatusBadRequest)
+			return
+		}
+
+		mu.Lock()
+		batchSizes = append(batchSizes, len(req.Input))
+		mu.Unlock()
+
+		embeddings := make([][]float32, len(req.Input))
+		for i, text := range req.Input {
+			ordinal, ok := ordinals[text]
+			if !ok {
+				http.Error(w, "unexpected input", http.StatusBadRequest)
+				return
+			}
+			embeddings[i] = []float32{float32(ordinal)}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(ollamaResponse{Embeddings: embeddings})
+	}))
+	defer srv.Close()
+
+	p := NewAPIProvider(srv.URL, "nomic-embed-text")
+	p.format = formatOllama
+	vecs, err := p.EmbedBatch(context.Background(), texts)
+	require.NoError(t, err)
+	require.Len(t, vecs, len(texts))
+	for i := range vecs {
+		assert.Equal(t, []float32{float32(i)}, vecs[i], "output order must match input order")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, batchSizes, 8, "500 inputs should be sent as seven full batches and one remainder")
+	for _, size := range batchSizes {
+		assert.LessOrEqual(t, size, maxOllamaBatchSize)
+	}
 }
 
 // TestParseRetryAfter covers the delta-seconds Retry-After parser.


### PR DESCRIPTION
## Summary

Prevent an Ollama internal tokenizer runner EOF from aborting the entire vector indexing pass.

Fixes #296.

## Changes

- Limit Ollama /api/embed arrays to 64 inputs, preserve response order, and send truncate: true explicitly.
- Recognize only the reported HTTP 400 loopback /tokenize EOF as recoverable; ordinary 400, authentication, validation, and model errors remain single-attempt failures.
- Bisect a failed batch down to single inputs, retry a singleton unchanged for runner restart, then use two bounded UTF-8-safe head reductions for deterministic long-input crashes.
- Honor context cancellation and bound persistent failure recovery to ten requests per capped batch.
- Add regression coverage for 500-input batching, order preservation, exact error classification, bisection to singleton, restart retry, long-input shortening, cancellation, and retry bounds.

## Testing

- [x] Repository race suite exercised (go test -race ./...); all packages passed, with internal/mcp rerun alone after a concurrent workspace run caused the combined invocation to fail.
- [x] New tests added for new functionality.
- [x] Cold-index benchmark passed in isolation and in the race suite.

## Checklist

- [x] Code follows existing patterns in the codebase.
- [x] No unnecessary abstractions added.
- [x] Language extractor includes Meta[methods] for interfaces (not applicable).
- [x] Methods have EdgeMemberOf edges to their containing type (not applicable).