### PR TITLE
fix(graph): preserve and scope duplicate qualified names

### DIFF
--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -2975,29 +2975,35 @@ func (g *Graph) GetNodeByQualName(qualName string) *Node {
 	return nil
 }
 
-// GetNodesByQualNames is the batch form of GetNodeByQualName — returns
-// only the qual_names that have a node (an absent key means "no node").
-// The in-memory byQual index makes each lookup O(1); the method exists
-// for Store-interface parity with the disk backend, where it collapses
-// N per-edge qual_name scans into a single IN-scan.
-func (g *Graph) GetNodesByQualNames(qualNames []string) map[string]*Node {
-	out := make(map[string]*Node, len(qualNames))
+// GetNodesByQualNames is the multi-valued batch form of
+// GetNodeByQualName. It scans each shard's canonical node map once because the
+// legacy byQual point index is intentionally single-valued and cannot represent
+// valid duplicate qualified names. Missing and empty names are absent.
+func (g *Graph) GetNodesByQualNames(qualNames []string) map[string][]*Node {
+	requested := make(map[string]struct{}, len(qualNames))
 	for _, q := range qualNames {
-		if q == "" {
-			continue
+		if q != "" {
+			requested[q] = struct{}{}
 		}
-		if _, done := out[q]; done {
-			continue
-		}
-		for _, s := range g.shards {
-			s.mu.RLock()
-			n, ok := s.byQual[q]
-			s.mu.RUnlock()
-			if ok {
-				out[q] = n
-				break
+	}
+	if len(requested) == 0 {
+		return nil
+	}
+
+	out := make(map[string][]*Node, len(requested))
+	for _, s := range g.shards {
+		s.mu.RLock()
+		for _, n := range s.nodes {
+			if n != nil {
+				if _, ok := requested[n.QualName]; ok {
+					out[n.QualName] = append(out[n.QualName], n)
+				}
 			}
 		}
+		s.mu.RUnlock()
+	}
+	for q := range out {
+		sort.Slice(out[q], func(i, j int) bool { return out[q][i].ID < out[q][j].ID })
 	}
 	return out
 }

--- a/internal/graph/overlay.go
+++ b/internal/graph/overlay.go
@@ -390,23 +390,73 @@ func (v *OverlaidView) GetNodeByQualName(qualName string) *Node {
 	return n
 }
 
-// GetNodesByQualNames resolves each name through GetNodeByQualName so the
-// overlay's layer-first / shadowed-file filtering applies — an inherited
-// base batch would bypass the overlay. Per-name is fine: an interactive
-// overlay's working set is small (the batch form exists for the
-// cold-warmup scale on the base store, not here). Returns only hits.
-func (v *OverlaidView) GetNodesByQualNames(qualNames []string) map[string]*Node {
-	out := make(map[string]*Node, len(qualNames))
+type qualifiedNameBatchReader interface {
+	GetNodesByQualNames(qualNames []string) map[string][]*Node
+}
+
+// GetNodesByQualNames merges every overlay and surviving base candidate.
+// Overlay-covered base files stay hidden, and each result slice is deduplicated
+// and sorted by ID so resolver selection is backend-independent.
+func (v *OverlaidView) GetNodesByQualNames(qualNames []string) map[string][]*Node {
+	requested := make(map[string]struct{}, len(qualNames))
 	for _, q := range qualNames {
-		if q == "" {
-			continue
+		if q != "" {
+			requested[q] = struct{}{}
 		}
-		if _, done := out[q]; done {
-			continue
+	}
+	if len(requested) == 0 {
+		return nil
+	}
+
+	out := make(map[string][]*Node, len(requested))
+	seen := make(map[string]map[string]struct{}, len(requested))
+	add := func(n *Node) {
+		if n == nil {
+			return
 		}
-		if n := v.GetNodeByQualName(q); n != nil {
-			out[q] = n
+		if _, ok := requested[n.QualName]; !ok {
+			return
 		}
+		ids := seen[n.QualName]
+		if ids == nil {
+			ids = make(map[string]struct{})
+			seen[n.QualName] = ids
+		}
+		if _, exists := ids[n.ID]; exists {
+			return
+		}
+		ids[n.ID] = struct{}{}
+		out[n.QualName] = append(out[n.QualName], n)
+	}
+
+	if v.layer != nil {
+		for _, n := range v.layer.nodeByID {
+			add(n)
+		}
+	}
+	if v.base != nil {
+		var baseHits map[string][]*Node
+		if batch, ok := v.base.(qualifiedNameBatchReader); ok {
+			baseHits = batch.GetNodesByQualNames(qualNames)
+		} else {
+			baseHits = make(map[string][]*Node, len(requested))
+			for q := range requested {
+				if n := v.base.GetNodeByQualName(q); n != nil {
+					baseHits[q] = []*Node{n}
+				}
+			}
+		}
+		for _, hits := range baseHits {
+			for _, n := range hits {
+				if n != nil && v.layer != nil && v.layer.HasFile(IDFile(n.ID)) {
+					continue
+				}
+				add(n)
+			}
+		}
+	}
+	for q := range out {
+		sort.Slice(out[q], func(i, j int) bool { return out[q][i].ID < out[q][j].ID })
 	}
 	return out
 }

--- a/internal/graph/qual_name_batch_test.go
+++ b/internal/graph/qual_name_batch_test.go
@@ -1,0 +1,121 @@
+package graph
+
+import "testing"
+
+func TestGraphGetNodesByQualNamesOneShardTracksUpdatesAndEviction(t *testing.T) {
+	g := newWithShardCount(1)
+	if g.shardCount != 1 {
+		t.Fatalf("newWithShardCount(1) created %d shards", g.shardCount)
+	}
+
+	const (
+		sharedQual = "example.com/shared.Foo"
+		movedQual  = "example.com/shared.MovedFoo"
+	)
+	first := &Node{
+		ID:         "repo-a/a.go::Foo",
+		Kind:       KindFunction,
+		Name:       "Foo",
+		QualName:   sharedQual,
+		FilePath:   "repo-a/a.go",
+		RepoPrefix: "repo-a",
+	}
+	second := &Node{
+		ID:         "repo-b/b.go::Foo",
+		Kind:       KindFunction,
+		Name:       "Foo",
+		QualName:   sharedQual,
+		FilePath:   "repo-b/b.go",
+		RepoPrefix: "repo-b",
+	}
+	g.AddNode(first)
+	g.AddNode(second)
+
+	requireQualNameBatchIDs(t, g.GetNodesByQualNames([]string{sharedQual}), sharedQual, first.ID, second.ID)
+
+	moved := *second
+	moved.QualName = movedQual
+	g.AddNode(&moved)
+	requireQualNameBatchIDs(t, g.GetNodesByQualNames([]string{sharedQual, movedQual}), sharedQual, first.ID)
+	requireQualNameBatchIDs(t, g.GetNodesByQualNames([]string{sharedQual, movedQual}), movedQual, second.ID)
+
+	g.EvictFile(first.FilePath)
+	got := g.GetNodesByQualNames([]string{sharedQual, movedQual})
+	requireQualNameBatchIDs(t, got, sharedQual)
+	requireQualNameBatchIDs(t, got, movedQual, second.ID)
+}
+
+func TestOverlaidViewGetNodesByQualNamesMergesAndFiltersDuplicates(t *testing.T) {
+	base := newWithShardCount(1)
+	const qualName = "example.com/shared.Foo"
+
+	hiddenBase := &Node{
+		ID:         "repo-a/a.go::BaseFoo",
+		Kind:       KindFunction,
+		Name:       "Foo",
+		QualName:   qualName,
+		FilePath:   "repo-a/a.go",
+		RepoPrefix: "repo-a",
+	}
+	visibleBase := &Node{
+		ID:         "repo-b/b.go::Foo",
+		Kind:       KindFunction,
+		Name:       "Foo",
+		QualName:   qualName,
+		FilePath:   "repo-b/b.go",
+		RepoPrefix: "repo-b",
+	}
+	base.AddNode(hiddenBase)
+	base.AddNode(visibleBase)
+
+	layer := NewOverlayLayer()
+	layer.MarkFile("repo-a/a.go", false)
+	overlayReplacement := &Node{
+		ID:         "repo-a/a.go::OverlayFoo",
+		Kind:       KindFunction,
+		Name:       "Foo",
+		QualName:   qualName,
+		FilePath:   "repo-a/a.go",
+		RepoPrefix: "repo-a",
+	}
+	layer.AddNode("repo-a/a.go", overlayReplacement)
+
+	layer.MarkFile("repo-c/c.go", false)
+	overlayDuplicate := &Node{
+		ID:         "repo-c/c.go::Foo",
+		Kind:       KindFunction,
+		Name:       "Foo",
+		QualName:   qualName,
+		FilePath:   "repo-c/c.go",
+		RepoPrefix: "repo-c",
+	}
+	layer.AddNode("repo-c/c.go", overlayDuplicate)
+
+	view := NewOverlaidView(base, layer)
+	got := view.GetNodesByQualNames([]string{qualName, qualName, "", "missing.QualName"})
+	requireQualNameBatchIDs(t, got, qualName, overlayReplacement.ID, visibleBase.ID, overlayDuplicate.ID)
+	requireQualNameBatchIDs(t, got, "")
+	requireQualNameBatchIDs(t, got, "missing.QualName")
+}
+
+func requireQualNameBatchIDs(t *testing.T, got map[string][]*Node, qualName string, wantIDs ...string) {
+	t.Helper()
+	hits, ok := got[qualName]
+	if len(wantIDs) == 0 {
+		if ok {
+			t.Fatalf("GetNodesByQualNames unexpectedly returned key %q with %d nodes", qualName, len(hits))
+		}
+		return
+	}
+	if !ok {
+		t.Fatalf("GetNodesByQualNames omitted key %q", qualName)
+	}
+	if len(hits) != len(wantIDs) {
+		t.Fatalf("GetNodesByQualNames[%q] returned %d nodes, want %d", qualName, len(hits), len(wantIDs))
+	}
+	for i, wantID := range wantIDs {
+		if hits[i] == nil || hits[i].ID != wantID {
+			t.Fatalf("GetNodesByQualNames[%q][%d] = %#v, want ID %q", qualName, i, hits[i], wantID)
+		}
+	}
+}

--- a/internal/graph/store.go
+++ b/internal/graph/store.go
@@ -152,14 +152,12 @@ type Store interface {
 	GetNode(id string) *Node
 	GetNodeByQualName(qualName string) *Node
 
-	// GetNodesByQualNames returns a map qualName→*Node (first match per
-	// qual_name) for the whole batch — the qual-name twin of
-	// FindNodesByNames. It pre-warms the resolver's import resolution so
-	// per-edge point lookups become one batched probe; both the batch and
-	// the point lookup ride the partial nodes_by_qual index (their SQL
-	// restates the index predicate literally, which is what makes a
-	// partial index usable against bound parameters).
-	GetNodesByQualNames(qualNames []string) map[string]*Node
+	// GetNodesByQualNames returns every node for each requested qualified
+	// name. Qualified names are lookup labels rather than global identities,
+	// so callers that need one target must disambiguate the candidate slice by
+	// repository/workspace context. Candidate order is deterministic by node ID.
+	// The batch pre-warms import resolution with one indexed store probe.
+	GetNodesByQualNames(qualNames []string) map[string][]*Node
 
 	// --- Name + scope queries --------------------------------------
 

--- a/internal/graph/store_sqlite/bulk_load.go
+++ b/internal/graph/store_sqlite/bulk_load.go
@@ -65,10 +65,9 @@ const coldFTSMergePages = 64
 // once, so they are dropped up front and rebuilt in one pass at the end.
 //
 // Deliberately excluded:
-//   - nodes_by_qual (UNIQUE): enforces qual_name dedup on every
-//     INSERT OR REPLACE. Dropping it would change insert conflict semantics
-//     (collapsed qual_name collisions would diverge from the non-bulk path)
-//     and a duplicate could make the recreate fail. It stays live.
+//   - nodes_by_qual: resolver lookups use INDEXED BY and must fail closed
+//     rather than scan the full nodes table. Keeping the compact partial index
+//     live preserves that contract during every bulk-load phase.
 //   - the edges UNIQUE(from_id, …) table constraint and every WITHOUT ROWID
 //     primary-key index: not standalone indexes; they cannot be dropped while
 //     the table/constraint exists.

--- a/internal/graph/store_sqlite/contract_owner_replace_test.go
+++ b/internal/graph/store_sqlite/contract_owner_replace_test.go
@@ -75,14 +75,18 @@ func TestSQLiteReplaceContractOwnersRollsBackDeleteAndInsertTogether(t *testing.
 	}, []*graph.Edge{
 		{From: "repo-a::handler", To: "shared-contract", Kind: graph.EdgeProvides, FilePath: "repo-a/a.go", Line: 10},
 	})
+	_, err = store.writerDB.Exec(`CREATE TRIGGER fail_new_contract
+BEFORE INSERT ON nodes WHEN NEW.id = 'new-contract'
+BEGIN SELECT RAISE(ABORT, 'forced replacement failure'); END`)
+	require.NoError(t, err)
 
 	_, err = store.ReplaceContractOwners(graph.ContractOwnerReplacement{
 		RepoPrefix:     "repo-a",
 		FilePaths:      []string{"repo-a/a.go"},
 		TouchedNodeIDs: []string{"shared-contract"},
 		Nodes: []*graph.Node{
-			{ID: "shared-contract", Kind: graph.KindContract, Name: "shared-contract", QualName: "duplicate.qual", FilePath: "repo-a/a.go", RepoPrefix: "repo-a"},
-			{ID: "new-contract", Kind: graph.KindContract, Name: "new-contract", QualName: "duplicate.qual", FilePath: "repo-a/a.go", RepoPrefix: "repo-a"},
+			{ID: "shared-contract", Kind: graph.KindContract, Name: "shared-contract", QualName: "contract.shared", FilePath: "repo-a/a.go", RepoPrefix: "repo-a"},
+			{ID: "new-contract", Kind: graph.KindContract, Name: "new-contract", QualName: "contract.new", FilePath: "repo-a/a.go", RepoPrefix: "repo-a"},
 		},
 		Edges: []*graph.Edge{
 			{From: "repo-a::handler", To: "shared-contract", Kind: graph.EdgeConsumes, FilePath: "repo-a/a.go", Line: 11},

--- a/internal/graph/store_sqlite/derived_contract_replace_test.go
+++ b/internal/graph/store_sqlite/derived_contract_replace_test.go
@@ -25,13 +25,17 @@ func TestSQLiteReplaceDerivedContractsRollsBackEntireFrontier(t *testing.T) {
 		{ID: "bridge::ws::project::contract", Kind: graph.KindContractBridge, Name: "contract", FilePath: "contracts://bridges", WorkspaceID: "ws", ProjectID: "project"},
 		{ID: "topic::kafka::orders", Kind: graph.KindTopic, Name: "orders", FilePath: "provider.go"},
 	}, []*graph.Edge{oldMatch, oldBridge, oldTopic})
+	_, err = store.writerDB.Exec(`CREATE TRIGGER fail_replacement_b
+BEFORE INSERT ON nodes WHEN NEW.id = 'replacement-b'
+BEGIN SELECT RAISE(ABORT, 'forced replacement failure'); END`)
+	require.NoError(t, err)
 
 	_, err = store.ReplaceDerivedContracts(graph.DerivedContractReplacement{
 		RemoveEdges:         []*graph.Edge{oldMatch, oldTopic},
 		RemoveBridgeNodeIDs: []string{"bridge::ws::project::contract"},
 		Nodes: []*graph.Node{
-			{ID: "replacement-a", Kind: graph.KindContractBridge, Name: "a", QualName: "duplicate.qual", FilePath: "contracts://bridges"},
-			{ID: "replacement-b", Kind: graph.KindContractBridge, Name: "b", QualName: "duplicate.qual", FilePath: "contracts://bridges"},
+			{ID: "replacement-a", Kind: graph.KindContractBridge, Name: "a", QualName: "contract.a", FilePath: "contracts://bridges"},
+			{ID: "replacement-b", Kind: graph.KindContractBridge, Name: "b", QualName: "contract.b", FilePath: "contracts://bridges"},
 		},
 		TouchedTopicNodeIDs: []string{"topic::kafka::orders"},
 	})

--- a/internal/graph/store_sqlite/plan_lock_v1_test.go
+++ b/internal/graph/store_sqlite/plan_lock_v1_test.go
@@ -27,7 +27,7 @@ func TestSweepPlanLocks(t *testing.T) {
 			// bound parameter alone cannot be proven non-empty and the
 			// statement scans all nodes (measured on a production store).
 			name:   "get_node_by_qual",
-			query:  `SELECT ` + lookupNodeCols + ` FROM nodes WHERE qual_name = ? AND qual_name <> '' LIMIT 1`,
+			query:  `SELECT ` + lookupNodeCols + ` FROM nodes WHERE qual_name = ? AND qual_name <> '' ORDER BY id LIMIT 1`,
 			args:   1,
 			want:   []string{"nodes_by_qual (qual_name=?)"},
 			forbid: []string{"SCAN nodes"},

--- a/internal/graph/store_sqlite/qual_name_lookup.go
+++ b/internal/graph/store_sqlite/qual_name_lookup.go
@@ -2,11 +2,11 @@ package store_sqlite
 
 import "encoding/json"
 
-// nodes_by_qual is the existing UNIQUE partial qualified-name index. The
-// explicit partial predicate lets SQLite prove the index is applicable, while
-// one JSON value keeps even very large resolver pages to a single bind and a
-// single indexed query. nodes is WITHOUT ROWID, so id is the stable secondary
-// order (and the unique index guarantees at most one row per qual_name).
+// nodes_by_qual is the partial qualified-name lookup index. The explicit
+// predicate lets SQLite prove the index is applicable, while one JSON value
+// keeps even very large resolver pages to a single bind and indexed query.
+// Qualified names may repeat, so id supplies a deterministic secondary order
+// within each candidate slice returned by the Store API.
 const nodesByQualNameLookupSQL = `SELECT ` + lookupNodeCols + `
 FROM nodes INDEXED BY nodes_by_qual
 WHERE qual_name <> ''

--- a/internal/graph/store_sqlite/qual_name_lookup_test.go
+++ b/internal/graph/store_sqlite/qual_name_lookup_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/zzet/gortex/internal/graph"
 )
 
-func TestGetNodesByQualNamesUsesUniquePartialIndexAndReopens(t *testing.T) {
+func TestGetNodesByQualNamesUsesPartialIndexAndReopens(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "qual-name.sqlite")
 	store, err := Open(path)
 	if err != nil {
@@ -39,18 +39,18 @@ func TestGetNodesByQualNamesUsesUniquePartialIndexAndReopens(t *testing.T) {
 		}
 	}
 
-	// Preserve the existing qualified-name quality contract: the partial
-	// index is UNIQUE for non-empty values, even though empty qual_names may
-	// repeat freely.
+	// Qualified names are lookup labels, not identities. Preserve both rows and
+	// keep the legacy singleton API deterministic by returning the smallest ID.
 	if _, err := store.writerDB.Exec(
 		`INSERT INTO nodes(id, kind, name, qual_name, file_path) VALUES (?, ?, ?, ?, ?)`,
 		"node::duplicate", graph.KindFunction, "Duplicate", "pkg.Alpha", "duplicate.go",
-	); err == nil {
-		t.Fatal("duplicate non-empty qual_name unexpectedly bypassed nodes_by_qual uniqueness")
+	); err != nil {
+		t.Fatalf("insert duplicate non-empty qual_name: %v", err)
 	}
 	if got := store.GetNodeByQualName("pkg.Alpha"); got == nil || got.ID != "node::alpha" {
-		t.Fatalf("failed duplicate insert changed original qualified-name owner: %#v", got)
+		t.Fatalf("GetNodeByQualName(pkg.Alpha) = %#v, want deterministic smallest ID", got)
 	}
+	assertQualNameCandidateIDs(t, store, "pkg.Alpha", "node::alpha", "node::duplicate")
 
 	if err := store.Close(); err != nil {
 		t.Fatal(err)
@@ -61,6 +61,7 @@ func TestGetNodesByQualNamesUsesUniquePartialIndexAndReopens(t *testing.T) {
 	}
 	assertQualNameLookupPlan(t, store)
 	assertQualNameLookupParity(t, store)
+	assertQualNameCandidateIDs(t, store, "pkg.Alpha", "node::alpha", "node::duplicate")
 }
 
 func TestGetNodesByQualNamesSingleJSONBindHandles40001Names(t *testing.T) {
@@ -97,8 +98,9 @@ func TestGetNodesByQualNamesSingleJSONBindHandles40001Names(t *testing.T) {
 		"hit.middle": "node::middle",
 		"hit.last":   "node::last",
 	} {
-		if node := got[qualName]; node == nil || node.ID != wantID {
-			t.Fatalf("large lookup[%q] = %#v, want id %q", qualName, node, wantID)
+		nodes := got[qualName]
+		if len(nodes) != 1 || nodes[0] == nil || nodes[0].ID != wantID {
+			t.Fatalf("large lookup[%q] = %#v, want one node with id %q", qualName, nodes, wantID)
 		}
 	}
 }
@@ -118,7 +120,8 @@ func TestGetNodesByQualNamesFailsClosedOnDecodeQueryAndClosedStoreErrors(t *test
 	}
 
 	got := store.GetNodesByQualNames([]string{"bad.qual", "good.qual"})
-	if len(got) != 1 || got["good.qual"] == nil || got["good.qual"].ID != "node::good" {
+	good := got["good.qual"]
+	if len(got) != 1 || len(good) != 1 || good[0] == nil || good[0].ID != "node::good" {
 		t.Fatalf("decode failure should skip only the corrupt row, got %#v", got)
 	}
 	if got["bad.qual"] != nil {
@@ -186,8 +189,9 @@ func assertQualNameLookupParity(t *testing.T, store *Store) {
 		if want == nil {
 			t.Fatalf("individual lookup unexpectedly missed %q", qualName)
 		}
-		if node := got[qualName]; node == nil || node.ID != want.ID {
-			t.Fatalf("batch lookup[%q] = %#v, individual lookup = %#v", qualName, node, want)
+		nodes := got[qualName]
+		if len(nodes) == 0 || nodes[0] == nil || nodes[0].ID != want.ID {
+			t.Fatalf("batch lookup[%q] = %#v, individual lookup = %#v", qualName, nodes, want)
 		}
 	}
 	if _, exists := got["missing.qual"]; exists {
@@ -195,5 +199,18 @@ func assertQualNameLookupParity(t *testing.T, store *Store) {
 	}
 	if _, exists := got[""]; exists {
 		t.Fatal("batched lookup retained an empty qualified name")
+	}
+}
+
+func assertQualNameCandidateIDs(t *testing.T, store *Store, qualName string, wantIDs ...string) {
+	t.Helper()
+	nodes := store.GetNodesByQualNames([]string{qualName, qualName})[qualName]
+	if len(nodes) != len(wantIDs) {
+		t.Fatalf("qualified-name candidates for %q = %#v, want IDs %v", qualName, nodes, wantIDs)
+	}
+	for i, wantID := range wantIDs {
+		if nodes[i] == nil || nodes[i].ID != wantID {
+			t.Fatalf("qualified-name candidate %d for %q = %#v, want ID %q", i, qualName, nodes[i], wantID)
+		}
 	}
 }

--- a/internal/graph/store_sqlite/schema.go
+++ b/internal/graph/store_sqlite/schema.go
@@ -454,8 +454,8 @@ CREATE TABLE IF NOT EXISTS analysis_blobs (
 //     (partial index -- empty repo_prefix is
 //     the common case and indexing it would
 //     be pure overhead)
-//     nodes_by_qual      -- GetNodeByQualName, unique so duplicate
-//     qual_names surface as constraint errors
+//     nodes_by_qual      -- GetNodeByQualName; non-unique because a
+//     language-level identity is not a global graph identity
 //     edges_by_from      -- GetOutEdges (kind included so RemoveEdge
 //     can probe by (from, kind) without a
 //     second hop)
@@ -493,9 +493,11 @@ CREATE TABLE IF NOT EXISTS nodes (
 -- nodes_by_name / _kind / _file / _repo are created from the shared
 -- bulkDroppableIndexes set (see bulk_load.go), not here, so the bulk-load
 -- fast path can drop and rebuild the EXACT same DDL without drift.
--- nodes_by_qual is UNIQUE — it enforces qual_name dedup on every
--- INSERT OR REPLACE, so it is never dropped and stays defined here.
-CREATE UNIQUE INDEX IF NOT EXISTS nodes_by_qual ON nodes(qual_name) WHERE qual_name <> '';
+-- Qualified names are language-level lookup labels, not graph identities:
+-- forks, worktrees, manifest overlays and independent repositories may emit
+-- the same value. Keep this index non-unique and let repository/workspace-aware
+-- callers disambiguate candidates.
+CREATE INDEX IF NOT EXISTS nodes_by_qual ON nodes(qual_name) WHERE qual_name <> '';
 
 CREATE TABLE IF NOT EXISTS edges (
     id               INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/internal/graph/store_sqlite/schema_version.go
+++ b/internal/graph/store_sqlite/schema_version.go
@@ -32,7 +32,7 @@ import (
 // index changes in a way an old on-disk DB would not already have, and append a
 // matching schemaMigrations entry describing how to bring an older store
 // forward (in place, or by rebuild).
-const currentSchemaVersion = 7
+const currentSchemaVersion = 8
 
 // schemaMigration is one forward step. Exactly one strategy applies:
 //   - rebuild=true: the change introduces structure/data that can only come
@@ -72,6 +72,20 @@ var schemaMigrations = []schemaMigration{
 	// copy beside them. Purge the old population here — see the function
 	// for why in-place beats rebuild and why global externals survive.
 	{version: 7, name: "purge unprefixed solo-repo rows", inPlace: purgeUnprefixedRepoRows},
+	{version: 8, name: "allow duplicate qualified names", inPlace: relaxNodeQualNameUniqueness},
+}
+
+// relaxNodeQualNameUniqueness removes the historical assumption that a
+// language-level qualified name is a global graph identity. Resource manifests,
+// forks, worktrees and overload-like constructs may legitimately repeat one.
+// The replacement keeps the same name, key and partial predicate so existing
+// point and batch lookups retain their indexed plans.
+func relaxNodeQualNameUniqueness(tx *sql.Tx) error {
+	if _, err := tx.Exec(`DROP INDEX IF EXISTS nodes_by_qual`); err != nil {
+		return err
+	}
+	_, err := tx.Exec(`CREATE INDEX nodes_by_qual ON nodes(qual_name) WHERE qual_name <> ''`)
+	return err
 }
 
 // compactResolverEdgeIndexes removes the one-shot global Go receiver index and

--- a/internal/graph/store_sqlite/schema_version_test.go
+++ b/internal/graph/store_sqlite/schema_version_test.go
@@ -247,11 +247,10 @@ func TestOpenV2RequiresTopologyIntegrityRebuild(t *testing.T) {
 	}
 }
 
-// TestOpenV6RepairsDuplicateQualNamesWithoutRebuild covers the release upgrade
-// failure from issue #278. Open repairs ambiguous qualified names before
-// schemaSQL creates nodes_by_qual, preserving every node and edge without
-// requiring destructive-rebuild authority.
-func TestOpenV6RepairsDuplicateQualNamesWithoutRebuild(t *testing.T) {
+// TestOpenWithoutQualIndexPreservesDuplicateQualNames covers legacy or damaged
+// stores whose qualified-name index is absent. Reopening recreates the lookup
+// index without rewriting valid duplicate identities or requiring a rebuild.
+func TestOpenWithoutQualIndexPreservesDuplicateQualNames(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "store.sqlite")
 	seed, err := Open(path)
 	if err != nil {
@@ -297,8 +296,8 @@ func TestOpenV6RepairsDuplicateQualNamesWithoutRebuild(t *testing.T) {
 	if err := repaired.db.QueryRow(`SELECT qual_name FROM nodes WHERE id = 'b'`).Scan(&bQual); err != nil {
 		t.Fatalf("read repaired duplicate: %v", err)
 	}
-	if aQual != "pkg.Run" || bQual != "" {
-		t.Fatalf("repaired qualified names = a:%q b:%q, want a:%q b:%q", aQual, bQual, "pkg.Run", "")
+	if aQual != "pkg.Run" || bQual != "pkg.Run" {
+		t.Fatalf("qualified names after reopen = a:%q b:%q, want both %q", aQual, bQual, "pkg.Run")
 	}
 	var uniqueIndex int
 	if err := repaired.db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = 'nodes_by_qual'`).Scan(&uniqueIndex); err != nil || uniqueIndex != 1 {
@@ -315,6 +314,62 @@ func TestOpenV6RepairsDuplicateQualNamesWithoutRebuild(t *testing.T) {
 	defer reopened.Close()
 	if n := nodeCount(t, reopened.db); n != 2 {
 		t.Fatalf("node count after warm reopen = %d, want 2", n)
+	}
+}
+
+func TestOpenV7RelaxesQualNameUniquenessInPlace(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "store.sqlite")
+	seed, err := Open(path)
+	if err != nil {
+		t.Fatalf("create current store: %v", err)
+	}
+	if _, err := seed.writerDB.Exec(`INSERT INTO nodes
+		(id, kind, name, qual_name, file_path, repo_prefix)
+		VALUES ('repo-a/k8s::ClusterRole::_default::prometheus', 'resource', 'prometheus',
+		        'ClusterRole/prometheus', 'repo-a/deploy/rbac.yaml', 'repo-a')`); err != nil {
+		t.Fatalf("seed first resource: %v", err)
+	}
+	if err := seed.Close(); err != nil {
+		t.Fatalf("close seed store: %v", err)
+	}
+
+	withRawDB(t, path, func(db *sql.DB) {
+		if _, err := db.Exec(`DROP INDEX nodes_by_qual`); err != nil {
+			t.Fatalf("drop current qualified-name index: %v", err)
+		}
+		if _, err := db.Exec(`CREATE UNIQUE INDEX nodes_by_qual ON nodes(qual_name) WHERE qual_name <> ''`); err != nil {
+			t.Fatalf("restore v7 qualified-name index: %v", err)
+		}
+		if _, err := db.Exec(`PRAGMA user_version = 7`); err != nil {
+			t.Fatalf("stamp v7: %v", err)
+		}
+	})
+
+	migrated, err := Open(path)
+	if err != nil {
+		t.Fatalf("open v7 store: %v", err)
+	}
+	defer migrated.Close()
+	if migrated.NeedsRebuild() {
+		t.Fatal("qualified-name index migration unexpectedly requested a rebuild")
+	}
+	if _, err := migrated.writerDB.Exec(`INSERT INTO nodes
+		(id, kind, name, qual_name, file_path, repo_prefix)
+		VALUES ('repo-b/k8s::ClusterRole::_default::prometheus', 'resource', 'prometheus',
+		        'ClusterRole/prometheus', 'repo-b/manifests/roles.yaml', 'repo-b')`); err != nil {
+		t.Fatalf("insert duplicate qualified name after v7 migration: %v", err)
+	}
+
+	var duplicates int
+	if err := migrated.db.QueryRow(`SELECT COUNT(*) FROM nodes WHERE qual_name = 'ClusterRole/prometheus'`).Scan(&duplicates); err != nil || duplicates != 2 {
+		t.Fatalf("duplicate qualified-name rows = %d (err %v), want 2", duplicates, err)
+	}
+	var unique int
+	if err := migrated.db.QueryRow(`SELECT "unique" FROM pragma_index_list('nodes') WHERE name = 'nodes_by_qual'`).Scan(&unique); err != nil || unique != 0 {
+		t.Fatalf("nodes_by_qual unique flag = %d (err %v), want 0", unique, err)
+	}
+	if version, err := readUserVersion(migrated.db); err != nil || version != currentSchemaVersion {
+		t.Fatalf("migrated user_version = %d (err %v), want %d", version, err, currentSchemaVersion)
 	}
 }
 

--- a/internal/graph/store_sqlite/store.go
+++ b/internal/graph/store_sqlite/store.go
@@ -349,18 +349,6 @@ func openWith(path string, current int, migrations []schemaMigration, allowRebui
 			plan = schemaPlan{stamp: true}
 		}
 	}
-	// Some v6 stores predate nodes_by_qual and may contain duplicate non-empty
-	// qualified names. schemaSQL cannot create the unique index over those rows,
-	// so repair the ambiguity transactionally before applying DDL. All nodes and
-	// edges remain intact; the lexicographically smallest node ID keeps the name.
-	// Once the index exists this probe is constant time on normal warm opens.
-	if !plan.wipe {
-		if err := repairDuplicateNodeQualNamesWithoutIndex(db); err != nil {
-			_ = db.Close()
-			return nil, fmt.Errorf("sqlite repair qualified-name uniqueness: %w", err)
-		}
-	}
-
 	didWipe := false
 	if plan.wipe && !isMemoryPath(path) {
 		// Refuse the destructive rebuild unless the caller proved it holds
@@ -526,38 +514,6 @@ func hasGraphStoreTables(db *sql.DB) (bool, error) {
 	var count int
 	err := db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name IN ('nodes','edges')`).Scan(&count)
 	return count > 0, err
-}
-
-func repairDuplicateNodeQualNamesWithoutIndex(db *sql.DB) error {
-	tx, err := db.Begin()
-	if err != nil {
-		return err
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	var nodesTable, qualIndex int
-	if err := tx.QueryRow(`SELECT
-		EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'nodes'),
-		EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = 'nodes_by_qual')`).Scan(&nodesTable, &qualIndex); err != nil {
-		return err
-	}
-	if nodesTable != 0 && qualIndex == 0 {
-		// Preserve every row and all ID-based topology. For each ambiguous
-		// qualified name, the stable smallest ID remains addressable by that
-		// name and every other node falls back to its ordinary ID/name lookups.
-		if _, err := tx.Exec(`UPDATE nodes AS duplicate
-SET qual_name = ''
-WHERE duplicate.qual_name <> ''
-  AND EXISTS (
-      SELECT 1
-      FROM nodes AS keeper
-      WHERE keeper.qual_name = duplicate.qual_name
-        AND keeper.id < duplicate.id
-  )`); err != nil {
-			return err
-		}
-	}
-	return tx.Commit()
 }
 
 // walCheckpointInterval is how often runCheckpointLoop passively drains WAL
@@ -801,7 +757,7 @@ func (s *Store) prepare() error {
 	// on resolver hot paths (measured against a production store). Every
 	// reader of a partial index must restate its predicate literally.
 	prep(&s.stmtGetNodeByQual,
-		`SELECT `+nodeCols+` FROM nodes WHERE qual_name = ? AND qual_name <> '' LIMIT 1`)
+		`SELECT `+nodeCols+` FROM nodes WHERE qual_name = ? AND qual_name <> '' ORDER BY id LIMIT 1`)
 	prep(&s.stmtFindByName,
 		`SELECT `+nodeCols+` FROM nodes WHERE name = ?`)
 	prep(&s.stmtFindByNameInRepo,

--- a/internal/graph/store_sqlite/store_lookups.go
+++ b/internal/graph/store_sqlite/store_lookups.go
@@ -157,22 +157,19 @@ func (s *Store) FindNodesByNameContaining(substr string, limit int) []*graph.Nod
 	return s.queryNodesSQL(q, pattern)
 }
 
-// GetNodesByQualNames returns a map qualName→*Node (first match per
-// qual_name) for the batch — the qual-name twin of FindNodesByNames, used to
-// pre-warm import resolution. Driven by the unique nodes_by_qual index.
-func (s *Store) GetNodesByQualNames(qualNames []string) map[string]*graph.Node {
+// GetNodesByQualNames returns every candidate for each requested qualified
+// name. The query orders by qual_name then ID, so each candidate slice is
+// deterministic and repository/workspace-aware callers can disambiguate it.
+func (s *Store) GetNodesByQualNames(qualNames []string) map[string][]*graph.Node {
 	uniq := dedupeNonEmpty(qualNames)
 	if len(uniq) == 0 {
 		return nil
 	}
 
-	out := make(map[string]*graph.Node, len(uniq))
+	out := make(map[string][]*graph.Node, len(uniq))
 	for _, n := range s.queryNodesSQL(nodesByQualNameLookupSQL, qualNameLookupPayload(uniq)) {
-		if n == nil {
-			continue
-		}
-		if _, ok := out[n.QualName]; !ok {
-			out[n.QualName] = n
+		if n != nil {
+			out[n.QualName] = append(out[n.QualName], n)
 		}
 	}
 	return out

--- a/internal/graph/storetest/storetest.go
+++ b/internal/graph/storetest/storetest.go
@@ -50,6 +50,8 @@ func RunConformance(t *testing.T, factory Factory) {
 	t.Run("GetRepoNodes", func(t *testing.T) { testGetRepoNodes(t, factory) })
 	t.Run("GetRepoEdges", func(t *testing.T) { testGetRepoEdges(t, factory) })
 	t.Run("GetNodeByQualName", func(t *testing.T) { testGetNodeByQualName(t, factory) })
+	t.Run("DuplicateQualNameAcrossRepos", func(t *testing.T) { testDuplicateQualNameAcrossRepos(t, factory) })
+	t.Run("DuplicateQualNameWithinRepo", func(t *testing.T) { testDuplicateQualNameWithinRepo(t, factory) })
 	t.Run("Stats", func(t *testing.T) { testStats(t, factory) })
 	t.Run("RepoStats", func(t *testing.T) { testRepoStats(t, factory) })
 	t.Run("RepoPrefixes", func(t *testing.T) { testRepoPrefixes(t, factory) })
@@ -598,6 +600,92 @@ func testGetNodeByQualName(t *testing.T, factory Factory) {
 	}
 	if s.GetNodeByQualName("missing.Qual") != nil {
 		t.Fatalf("GetNodeByQualName missing should be nil")
+	}
+}
+
+func testDuplicateQualNameAcrossRepos(t *testing.T, factory Factory) {
+	t.Helper()
+	s := factory(t)
+
+	const qualName = "ClusterRole/prometheus"
+	first := mkRepoNode(
+		"repo-a/k8s::ClusterRole::_default::prometheus",
+		"prometheus", "repo-a/deploy/rbac.yaml", "repo-a", graph.KindResource,
+	)
+	first.QualName = qualName
+	second := mkRepoNode(
+		"repo-b/k8s::ClusterRole::_default::prometheus",
+		"prometheus", "repo-b/manifests/roles.yaml", "repo-b", graph.KindResource,
+	)
+	second.QualName = qualName
+
+	s.AddNode(first)
+	s.AddNode(second)
+
+	for _, want := range []*graph.Node{first, second} {
+		got := s.GetNode(want.ID)
+		if got == nil {
+			t.Fatalf("GetNode(%q) = nil after adding the same qual_name in another repo", want.ID)
+		}
+		if got.RepoPrefix != want.RepoPrefix {
+			t.Fatalf("GetNode(%q).RepoPrefix = %q, want %q", want.ID, got.RepoPrefix, want.RepoPrefix)
+		}
+	}
+
+	gotByName := s.FindNodesByName("prometheus")
+	gotRepos := make(map[string]bool, len(gotByName))
+	for _, got := range gotByName {
+		if got != nil && got.QualName == qualName {
+			gotRepos[got.RepoPrefix] = true
+		}
+	}
+	for _, wantRepo := range []string{"repo-a", "repo-b"} {
+		if !gotRepos[wantRepo] {
+			t.Errorf("FindNodesByName(prometheus) repos = %v, missing %q", gotRepos, wantRepo)
+		}
+	}
+
+	gotByQual := s.GetNodesByQualNames([]string{qualName, qualName, "", "missing/qualified-name"})
+	hits := gotByQual[qualName]
+	wantIDs := []string{first.ID, second.ID}
+	if len(hits) != len(wantIDs) {
+		t.Fatalf("GetNodesByQualNames duplicate input returned %d nodes, want %d: %v", len(hits), len(wantIDs), sortNodeIDs(hits))
+	}
+	for i, wantID := range wantIDs {
+		if hits[i] == nil || hits[i].ID != wantID {
+			t.Fatalf("GetNodesByQualNames[%q][%d] = %#v, want ID %q (stable ID order)", qualName, i, hits[i], wantID)
+		}
+	}
+	for _, absent := range []string{"", "missing/qualified-name"} {
+		if _, ok := gotByQual[absent]; ok {
+			t.Errorf("GetNodesByQualNames unexpectedly returned absent key %q: %v", absent, sortNodeIDs(gotByQual[absent]))
+		}
+	}
+}
+
+func testDuplicateQualNameWithinRepo(t *testing.T, factory Factory) {
+	t.Helper()
+	s := factory(t)
+
+	const qualName = "Deployment/api"
+	for _, namespace := range []string{"blue", "green"} {
+		n := mkRepoNode(
+			"repo-a/k8s::Deployment::"+namespace+"::api",
+			"api", "repo-a/manifests/"+namespace+".yaml", "repo-a", graph.KindResource,
+		)
+		n.QualName = qualName
+		s.AddNode(n)
+	}
+
+	got := s.FindNodesByName("api")
+	if len(got) != 2 {
+		t.Fatalf("FindNodesByName(api) returned %d nodes, want both namespace-specific resources", len(got))
+	}
+	for _, namespace := range []string{"blue", "green"} {
+		id := "repo-a/k8s::Deployment::" + namespace + "::api"
+		if s.GetNode(id) == nil {
+			t.Errorf("GetNode(%q) = nil after adding a duplicate qual_name in the same repo", id)
+		}
 	}
 }
 

--- a/internal/indexer/multi_node_id_test.go
+++ b/internal/indexer/multi_node_id_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/zzet/gortex/internal/config"
 	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser/languages"
 	"github.com/zzet/gortex/internal/search"
 )
 
@@ -229,5 +230,63 @@ func TestTrackRepoCtx_FirstOfManyStillGetsPrefix(t *testing.T) {
 	}
 	for id, found := range want {
 		assert.True(t, found, "expected prefixed node %s not found in graph", id)
+	}
+}
+
+func TestTrackRepoCtx_DuplicateKubernetesQualNamesAreRepoScoped(t *testing.T) {
+	manifest := func(repo, relPath, resource string) string {
+		t.Helper()
+		root := filepath.Join(t.TempDir(), repo)
+		path := filepath.Join(root, relPath)
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(resource), 0o644))
+		return root
+	}
+
+	repoA := manifest("repo-a", "deploy/rbac.yaml", `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get"]
+`)
+	repoB := manifest("repo-b", "manifests/roles.yaml", `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list"]
+`)
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	gc := &config.GlobalConfig{Repos: []config.RepoEntry{
+		{Path: repoA, Name: "repo-a"},
+		{Path: repoB, Name: "repo-b"},
+	}}
+	gc.SetConfigPath(cfgPath)
+	require.NoError(t, gc.Save())
+	cm, err := config.NewConfigManager(cfgPath)
+	require.NoError(t, err)
+
+	g := graph.New()
+	registry := newTestRegistry()
+	registry.Register(languages.NewYAMLExtractor())
+	mi := NewMultiIndexer(g, registry, search.NewBM25(), cm, zap.NewNop())
+	for _, entry := range cm.Global().Repos {
+		_, err := mi.TrackRepoCtx(context.Background(), entry)
+		require.NoError(t, err, "tracking %s", entry.Name)
+	}
+
+	for _, repo := range []string{"repo-a", "repo-b"} {
+		id := repo + "/k8s::ClusterRole::_default::prometheus"
+		n := g.GetNode(id)
+		require.NotNil(t, n, "resource node %s", id)
+		assert.Equal(t, repo, n.RepoPrefix)
+		assert.Equal(t, "ClusterRole/prometheus", n.QualName)
+		assert.True(t, strings.HasPrefix(n.FilePath, repo+"/"), "resource path %q must be owned by %s", n.FilePath, repo)
 	}
 }

--- a/internal/parser/languages/php_namespace.go
+++ b/internal/parser/languages/php_namespace.go
@@ -226,13 +226,12 @@ func phpNamespaceScopedKind(k graph.NodeKind) bool {
 // lives in and records on each type-reference edge the fully-qualified name the
 // source names.
 //
-// Deliberately NOT Node.QualName. That field backs a UNIQUE SQLite index
-// (nodes_by_qual): a second node with the same non-empty qual_name fails the
-// insert outright, which would take the whole index down rather than degrade.
+// Deliberately NOT Node.QualName. Qualified-name persistence now tolerates
+// duplicates, but the compatibility lookup API still returns one representative.
 // PHP produces duplicate fully-qualified names in practice — indexing
 // laravel/framework mints six, where a class and the annotation stub for a
 // same-named attribute land in one namespace — so the FQN lives in scope_ns,
-// which is plain Meta and tolerates repetition. Everything that would have used
+// which preserves the complete candidate set. Everything that would have used
 // QualName (reference narrowing, import binding) matches on scope_ns instead.
 func applyPHPNamespaceIdentity(root *sitter.Node, src []byte, result *parser.ExtractionResult) {
 	if result == nil || root == nil {

--- a/internal/resolver/cross_repo.go
+++ b/internal/resolver/cross_repo.go
@@ -94,7 +94,7 @@ type CrossRepoResolver struct {
 	placeholderSrcIdx placeholderSourceIndex
 	nodesByName       map[string][]*graph.Node
 	nodesByNameRepo   map[string]map[string][]*graph.Node
-	nodesByQualName   map[string]*graph.Node
+	nodesByQualName   map[string][]*graph.Node
 	dirIndex          map[string][]*graph.Node
 	lastDirIndex      map[string][]*graph.Node
 	// reachableReposByFile maps a caller file's ID to the set of repo
@@ -262,37 +262,37 @@ func (cr *CrossRepoResolver) pickImportCandidate(callerWS, importPath string, ca
 	return nil
 }
 
-// pickQualNameCandidate enumerates every node that shares qualName and
-// returns the one in the caller's own workspace, else the first the
-// cross-workspace policy permits, else nil. The graph's qual-name index
-// is single-valued, so when the same module is checked out twice (a
-// canonical checkout plus a worktree instance under its own prefix) only
-// one node is reachable by qual name; the two share a Name, so the
-// multi-valued by-name index recovers the full candidate set. `single`
-// is the node the single-valued lookup already returned — used to learn
-// the shared Name without a second qual-name probe.
-func (cr *CrossRepoResolver) pickQualNameCandidate(callerWS, qualName string, single *graph.Node) *graph.Node {
-	if single == nil || single.Name == "" {
-		return nil
+// pickQualNameCandidate applies repository/workspace policy to the complete
+// qualified-name candidate set. The boolean reports an ambiguous eligible
+// foreign set, which must stay unresolved rather than bind by row order.
+func (cr *CrossRepoResolver) pickQualNameCandidate(callerRepo, callerWS, qualName string, candidates []*graph.Node) (*graph.Node, bool) {
+	if candidate := lowestIDQualNameCandidate(candidates, func(n *graph.Node) bool {
+		return n.RepoPrefix == callerRepo && candidateWorkspaceID(n) == callerWS
+	}); candidate != nil {
+		return candidate, false
 	}
-	all := cr.graph.FindNodesByNames([]string{single.Name})[single.Name]
-	var cands []*graph.Node
-	for _, c := range all {
-		if c != nil && c.QualName == qualName {
-			cands = append(cands, c)
+	if candidate := lowestIDQualNameCandidate(candidates, func(n *graph.Node) bool {
+		return n.RepoPrefix == callerRepo
+	}); candidate != nil {
+		return candidate, false
+	}
+	if candidate := lowestIDQualNameCandidate(candidates, func(n *graph.Node) bool {
+		return candidateWorkspaceID(n) == callerWS
+	}); candidate != nil {
+		return candidate, false
+	}
+
+	var eligible *graph.Node
+	for _, candidate := range candidates {
+		if candidate == nil || !cr.crossWorkspaceEligible(callerWS, candidateWorkspaceID(candidate), qualName) {
+			continue
 		}
-	}
-	for _, c := range cands {
-		if candidateWorkspaceID(c) == callerWS {
-			return c
+		if eligible != nil {
+			return nil, true
 		}
+		eligible = candidate
 	}
-	for _, c := range cands {
-		if cr.crossWorkspaceEligible(callerWS, candidateWorkspaceID(c), qualName) {
-			return c
-		}
-	}
-	return nil
+	return eligible, false
 }
 
 // ResolveAll resolves all unresolved edges in the graph, trying same-repo
@@ -795,8 +795,8 @@ func (cr *CrossRepoResolver) warmLookupCache(pending []*graph.Edge) {
 			nameSet[bare] = struct{}{}
 		}
 		// Import targets: mirror resolveEdge's dispatch (TrimPrefix of the
-		// bare unresolved:: form) so the seeded qual-name matches what
-		// resolveImport looks up via GetNodeByQualName.
+		// bare unresolved:: form) so the seeded name matches the complete
+		// qualified-name candidate lookup used by resolveImport.
 		if t := strings.TrimPrefix(e.To, unresolvedPrefix); strings.HasPrefix(t, "import::") {
 			if qn := strings.TrimPrefix(t, "import::"); qn != "" {
 				qualNameSet[qn] = struct{}{}
@@ -858,9 +858,8 @@ func (cr *CrossRepoResolver) warmLookupCache(pending []*graph.Edge) {
 		}
 		cr.nodesByNameRepo[name] = byRepo
 	}
-	// Pre-warm the import qual-name cache + authoritative negatives, so
-	// resolveImport's GetNodeByQualName hits instead of scanning the
-	// unindexed qual_name column per cross-repo import edge.
+	// Pre-warm every import qualified-name candidate plus authoritative
+	// negatives, avoiding one indexed store probe per cross-repo import edge.
 	if len(qualNameSet) > 0 {
 		qns := make([]string, 0, len(qualNameSet))
 		for q := range qualNameSet {
@@ -868,7 +867,7 @@ func (cr *CrossRepoResolver) warmLookupCache(pending []*graph.Edge) {
 		}
 		cr.nodesByQualName = cr.graph.GetNodesByQualNames(qns)
 		if cr.nodesByQualName == nil {
-			cr.nodesByQualName = make(map[string]*graph.Node, len(qualNameSet))
+			cr.nodesByQualName = make(map[string][]*graph.Node, len(qualNameSet))
 		}
 		for q := range qualNameSet {
 			if _, ok := cr.nodesByQualName[q]; !ok {
@@ -964,19 +963,18 @@ func (cr *CrossRepoResolver) cachedFindNodesByName(name string) []*graph.Node {
 	return cr.graph.FindNodesByName(name)
 }
 
-// cachedGetNodeByQualName serves resolveImport's qual-name lookup from the
-// per-pass cache (authoritative negative for queried-but-absent import
-// paths), mirroring Resolver.cachedGetNodeByQualName.
-func (cr *CrossRepoResolver) cachedGetNodeByQualName(qualName string) *graph.Node {
+// cachedFindNodesByQualName serves resolveImport's complete candidate lookup
+// from the per-pass cache, including authoritative negative slices.
+func (cr *CrossRepoResolver) cachedFindNodesByQualName(qualName string) []*graph.Node {
 	if qualName == "" {
 		return nil
 	}
 	if cr.nodesByQualName != nil {
-		if n, ok := cr.nodesByQualName[qualName]; ok {
-			return n
+		if nodes, ok := cr.nodesByQualName[qualName]; ok {
+			return nodes
 		}
 	}
-	return cr.graph.GetNodeByQualName(qualName)
+	return cr.graph.GetNodesByQualNames([]string{qualName})[qualName]
 }
 
 func (cr *CrossRepoResolver) resolveEdge(e *graph.Edge, stats *CrossRepoStats, batch *[]graph.EdgeReindex) {
@@ -1185,6 +1183,7 @@ func (cr *CrossRepoResolver) resolveFunctionCall(e *graph.Edge, funcName string,
 func (cr *CrossRepoResolver) resolveImport(e *graph.Edge, importPath string, stats *CrossRepoStats) {
 	callerRepo := cr.callerRepoPrefix(e)
 	callerWS := cr.callerWorkspaceID(e)
+	ambiguousQualName := false
 
 	// npm-alias rewrite: see Resolver.resolveImport. Applied here too
 	// so a JS/TS import of an alias key resolves cross-repo to a
@@ -1209,18 +1208,11 @@ func (cr *CrossRepoResolver) resolveImport(e *graph.Edge, importPath string, sta
 		return
 	}
 
-	// Look for a package node with matching qualified name.
-	if node := cr.cachedGetNodeByQualName(importPath); node != nil {
-		picked := node
-		if !cr.crossWorkspaceEligible(callerWS, candidateWorkspaceID(picked), importPath) {
-			// The qual-name index is single-valued, so a same-module
-			// instance in the caller's own workspace (a worktree of the
-			// imported module, tracked under its own prefix) can be
-			// shadowed by a copy in another workspace. Enumerate every
-			// node sharing this qual name and prefer the caller's
-			// workspace before giving up.
-			picked = cr.pickQualNameCandidate(callerWS, importPath, node)
-		}
+	// Look at every package node with this qualified name. Exact caller repo,
+	// then caller workspace, wins before cross-workspace dependency policy is
+	// consulted; an eligible foreign row can no longer shadow a local worktree.
+	if candidates := cr.cachedFindNodesByQualName(importPath); len(candidates) > 0 {
+		picked, ambiguous := cr.pickQualNameCandidate(callerRepo, callerWS, importPath, candidates)
 		if picked != nil {
 			e.To = picked.ID
 			if isCrossRepoHop(callerRepo, picked.RepoPrefix) {
@@ -1231,9 +1223,9 @@ func (cr *CrossRepoResolver) resolveImport(e *graph.Edge, importPath string, sta
 			stats.Resolved++
 			return
 		}
-		// A qual-name hit with no workspace-eligible instance falls
-		// through to the directory-match scan below rather than bailing
-		// straight to external.
+		ambiguousQualName = ambiguous
+		// No unique policy-eligible candidate: retain directory/dependency
+		// evidence fallbacks below before deciding that the import is ambiguous.
 	}
 
 	// Look for file nodes whose directory matches the import path. Two
@@ -1348,18 +1340,26 @@ func (cr *CrossRepoResolver) resolveImport(e *graph.Edge, importPath string, sta
 	// package node itself. See Resolver.resolveImport.
 	if npmAliased {
 		if pkg := npmPackagePrefix(importPath); pkg != "" {
-			if node := cr.cachedGetNodeByQualName(pkg); node != nil &&
-				cr.crossWorkspaceEligible(callerWS, candidateWorkspaceID(node), pkg) {
-				e.To = node.ID
-				if isCrossRepoHop(callerRepo, node.RepoPrefix) {
-					e.CrossRepo = true
-					stats.CrossRepoEdges++
-					stats.ByRepo[node.RepoPrefix]++
+			if candidates := cr.cachedFindNodesByQualName(pkg); len(candidates) > 0 {
+				node, ambiguous := cr.pickQualNameCandidate(callerRepo, callerWS, pkg, candidates)
+				if node != nil {
+					e.To = node.ID
+					if isCrossRepoHop(callerRepo, node.RepoPrefix) {
+						e.CrossRepo = true
+						stats.CrossRepoEdges++
+						stats.ByRepo[node.RepoPrefix]++
+					}
+					stats.Resolved++
+					return
 				}
-				stats.Resolved++
-				return
+				ambiguousQualName = ambiguousQualName || ambiguous
 			}
 		}
+	}
+
+	if ambiguousQualName {
+		stats.Unresolved++
+		return
 	}
 
 	// External/unresolvable import.

--- a/internal/resolver/cross_repo_test.go
+++ b/internal/resolver/cross_repo_test.go
@@ -132,6 +132,97 @@ func TestCrossRepoResolveAll_ImportCrossRepo(t *testing.T) {
 	assert.True(t, edge.CrossRepo)
 }
 
+func TestCrossRepoResolveAll_ImportQualNamePrefersSameWorkspaceOverEligibleForeign(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		reverse bool
+	}{
+		{name: "forward_insert"},
+		{name: "reverse_insert", reverse: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := graph.New()
+			const qualName = "github.com/acme/shared"
+
+			caller := &graph.Node{ID: "consumer/main.go", Kind: graph.KindFile, Name: "main.go", FilePath: "consumer/main.go", Language: "go", RepoPrefix: "consumer", WorkspaceID: "consumer-ws"}
+			sameWorkspace := &graph.Node{ID: "z-local/shared.go::shared", Kind: graph.KindPackage, Name: "shared", QualName: qualName, FilePath: "z-local/shared.go", Language: "go", RepoPrefix: "z-local", WorkspaceID: "consumer-ws"}
+			eligibleForeign := &graph.Node{ID: "a-foreign/shared.go::shared", Kind: graph.KindPackage, Name: "shared", QualName: qualName, FilePath: "a-foreign/shared.go", Language: "go", RepoPrefix: "a-foreign", WorkspaceID: "foreign-ws"}
+
+			g.AddNode(caller)
+			candidates := []*graph.Node{eligibleForeign, sameWorkspace}
+			if tc.reverse {
+				candidates[0], candidates[1] = candidates[1], candidates[0]
+			}
+			for _, candidate := range candidates {
+				g.AddNode(candidate)
+			}
+
+			edge := &graph.Edge{From: caller.ID, To: "unresolved::import::" + qualName, Kind: graph.EdgeImports, FilePath: caller.FilePath, Line: 3}
+			g.AddEdge(edge)
+
+			cr := NewCrossRepo(g)
+			cr.SetCrossWorkspaceDepLookup(func(sourceWorkspaceID string) []CrossWorkspaceDepRule {
+				if sourceWorkspaceID != "consumer-ws" {
+					return nil
+				}
+				return []CrossWorkspaceDepRule{{Workspace: "foreign-ws", Modules: []string{qualName}}}
+			})
+			stats := cr.ResolveAll()
+
+			require.Equal(t, 1, stats.Resolved)
+			assert.Equal(t, sameWorkspace.ID, edge.To)
+			assert.True(t, edge.CrossRepo)
+			assert.Equal(t, 1, stats.CrossRepoEdges)
+		})
+	}
+}
+
+func TestCrossRepoResolveAll_ImportQualNameLeavesEquivalentForeignCandidatesUnresolved(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		reverse bool
+	}{
+		{name: "forward_insert"},
+		{name: "reverse_insert", reverse: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := graph.New()
+			const qualName = "github.com/acme/shared"
+
+			caller := &graph.Node{ID: "consumer/main.go", Kind: graph.KindFile, Name: "main.go", FilePath: "consumer/main.go", Language: "go", RepoPrefix: "consumer", WorkspaceID: "consumer-ws"}
+			candidateA := &graph.Node{ID: "a-foreign/shared.go::shared", Kind: graph.KindPackage, Name: "shared", QualName: qualName, FilePath: "a-foreign/shared.go", Language: "go", RepoPrefix: "a-foreign", WorkspaceID: "foreign-ws"}
+			candidateZ := &graph.Node{ID: "z-foreign/shared.go::shared", Kind: graph.KindPackage, Name: "shared", QualName: qualName, FilePath: "z-foreign/shared.go", Language: "go", RepoPrefix: "z-foreign", WorkspaceID: "foreign-ws"}
+
+			g.AddNode(caller)
+			candidates := []*graph.Node{candidateA, candidateZ}
+			if tc.reverse {
+				candidates[0], candidates[1] = candidates[1], candidates[0]
+			}
+			for _, candidate := range candidates {
+				g.AddNode(candidate)
+			}
+
+			unresolvedID := "unresolved::import::" + qualName
+			edge := &graph.Edge{From: caller.ID, To: unresolvedID, Kind: graph.EdgeImports, FilePath: caller.FilePath, Line: 3}
+			g.AddEdge(edge)
+
+			cr := NewCrossRepo(g)
+			cr.SetCrossWorkspaceDepLookup(func(sourceWorkspaceID string) []CrossWorkspaceDepRule {
+				if sourceWorkspaceID != "consumer-ws" {
+					return nil
+				}
+				return []CrossWorkspaceDepRule{{Workspace: "foreign-ws", Modules: []string{qualName}}}
+			})
+			stats := cr.ResolveAll()
+
+			require.Equal(t, 0, stats.Resolved)
+			assert.Equal(t, unresolvedID, edge.To)
+			assert.False(t, edge.CrossRepo)
+			assert.Equal(t, 0, stats.CrossRepoEdges)
+		})
+	}
+}
+
 func TestCrossRepoResolveAll_MethodCrossRepo(t *testing.T) {
 	g := graph.New()
 

--- a/internal/resolver/qual_name_candidates.go
+++ b/internal/resolver/qual_name_candidates.go
@@ -1,0 +1,48 @@
+package resolver
+
+import "github.com/zzet/gortex/internal/graph"
+
+// lowestIDQualNameCandidate makes every policy tier deterministic without
+// treating qualified-name order as semantic identity.
+func lowestIDQualNameCandidate(candidates []*graph.Node, accept func(*graph.Node) bool) *graph.Node {
+	var picked *graph.Node
+	for _, candidate := range candidates {
+		if candidate == nil || !accept(candidate) {
+			continue
+		}
+		if picked == nil || candidate.ID < picked.ID {
+			picked = candidate
+		}
+	}
+	return picked
+}
+
+// pickResolverQualNameCandidate handles the normal resolver, where an exact
+// caller-repository instance is authoritative. A same-workspace instance wins
+// among duplicates in that repository. A single foreign candidate preserves
+// the historical cross-repo import behavior; several foreign candidates are
+// ambiguous and must be deferred to the cross-repository resolver.
+func pickResolverQualNameCandidate(candidates []*graph.Node, callerRepo, callerWorkspace string) (*graph.Node, bool) {
+	if candidate := lowestIDQualNameCandidate(candidates, func(n *graph.Node) bool {
+		return n.RepoPrefix == callerRepo && candidateWorkspaceID(n) == callerWorkspace
+	}); candidate != nil {
+		return candidate, false
+	}
+	if candidate := lowestIDQualNameCandidate(candidates, func(n *graph.Node) bool {
+		return n.RepoPrefix == callerRepo
+	}); candidate != nil {
+		return candidate, false
+	}
+
+	var only *graph.Node
+	for _, candidate := range candidates {
+		if candidate == nil {
+			continue
+		}
+		if only != nil {
+			return nil, true
+		}
+		only = candidate
+	}
+	return only, false
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -273,7 +273,7 @@ type Resolver struct {
 	missingNodeByID map[string]struct{}
 
 	nodesByName     map[string][]*graph.Node
-	nodesByQualName map[string]*graph.Node
+	nodesByQualName map[string][]*graph.Node
 	// nodesByRepoLanguageName is the authoritative per-pending-page cache for
 	// normal resolution. It is keyed by exact repository plus compatible source
 	// language family, so a Go call never materialises or examines Python
@@ -1695,9 +1695,9 @@ func (r *Resolver) warmLookupCacheWithSources(pending []*graph.Edge, sources map
 			idSet[e.From] = struct{}{}
 		}
 		// Import targets resolve by qualified name: resolveImport's first
-		// lookup is GetNodeByQualName(importPath), an unindexed scan per
-		// import edge on a disk backend. Seed the import path so it hits the
-		// qual-name cache (or its authoritative negative) instead.
+		// lookup needs every qualified-name candidate. Seed the import path so
+		// the disk backend performs one indexed batch probe and the workers hit
+		// the complete candidate cache (or its authoritative negative).
 		if t := graph.UnresolvedName(e.To); strings.HasPrefix(t, "import::") {
 			if qn := strings.TrimPrefix(t, "import::"); qn != "" {
 				qualNameSet[qn] = struct{}{}
@@ -1777,9 +1777,8 @@ func (r *Resolver) warmLookupCacheWithSources(pending []*graph.Edge, sources map
 	}
 	foldElapsed := time.Since(foldStart)
 	qualStart := time.Now()
-	// Pre-warm the import qual-name cache + record authoritative negatives,
-	// so resolveImport's GetNodeByQualName hits the cache instead of
-	// scanning the unindexed qual_name column once per import edge.
+	// Pre-warm the complete import qualified-name candidate cache and record
+	// authoritative negatives, avoiding one indexed store probe per edge.
 	if len(qualNameSet) > 0 {
 		qns := make([]string, 0, len(qualNameSet))
 		for q := range qualNameSet {
@@ -1787,7 +1786,7 @@ func (r *Resolver) warmLookupCacheWithSources(pending []*graph.Edge, sources map
 		}
 		r.nodesByQualName = r.graph.GetNodesByQualNames(qns)
 		if r.nodesByQualName == nil {
-			r.nodesByQualName = make(map[string]*graph.Node, len(qualNameSet))
+			r.nodesByQualName = make(map[string][]*graph.Node, len(qualNameSet))
 		}
 		for q := range qualNameSet {
 			if _, ok := r.nodesByQualName[q]; !ok {
@@ -1959,22 +1958,19 @@ func (r *Resolver) cachedFindNodesByName(name string) []*graph.Node {
 	return r.graph.FindNodesByName(name)
 }
 
-// cachedGetNodeByQualName serves resolveImport's qual-name lookup from the
-// per-pass cache. A pre-warmed qual_name with no node returns nil
-// (authoritative negative — most import paths have no matching package
-// node, and the unindexed per-edge GetNodeByQualName scan for them was a
-// cold-warmup compute storm); a qual_name absent from the cache falls
-// through to the store.
-func (r *Resolver) cachedGetNodeByQualName(qualName string) *graph.Node {
+// cachedFindNodesByQualName serves resolveImport's complete candidate lookup
+// from the per-pass cache. A present nil slice is an authoritative negative;
+// an absent key falls through to one indexed batch probe.
+func (r *Resolver) cachedFindNodesByQualName(qualName string) []*graph.Node {
 	if qualName == "" {
 		return nil
 	}
 	if r.nodesByQualName != nil {
-		if n, ok := r.nodesByQualName[qualName]; ok {
-			return n
+		if nodes, ok := r.nodesByQualName[qualName]; ok {
+			return nodes
 		}
 	}
-	return r.graph.GetNodeByQualName(qualName)
+	return r.graph.GetNodesByQualNames([]string{qualName})[qualName]
 }
 
 // cachedFindNodesByNameInRepo is the repo-scoped twin of
@@ -2992,6 +2988,8 @@ func pendingShapeSummary(pending []*graph.Edge) string {
 
 func (r *Resolver) resolveImport(e *graph.Edge, importPath string, stats *ResolveStats) {
 	callerRepo := r.callerRepoPrefix(e)
+	callerWorkspace := r.callerWorkspaceID(e)
+	ambiguousQualName := false
 
 	// JS/TS relative + tsconfig-path-alias / baseUrl import: resolve the
 	// specifier onto the in-repo file (or exported symbol) it names. The
@@ -3059,15 +3057,20 @@ func (r *Resolver) resolveImport(e *graph.Edge, importPath string, stats *Resolv
 		}
 	}
 
-	// Look for a package node with matching qualified name.
-	node := r.cachedGetNodeByQualName(importPath)
-	if node != nil {
-		e.To = node.ID
-		if callerRepo != "" && node.RepoPrefix != "" && node.RepoPrefix != callerRepo {
-			e.CrossRepo = true
+	// Look for every package node with this qualified name. The same import
+	// path may legitimately exist in several tracked repositories/workspaces;
+	// bind the caller-local instance instead of whichever row sorted first.
+	if candidates := r.cachedFindNodesByQualName(importPath); len(candidates) > 0 {
+		node, ambiguous := pickResolverQualNameCandidate(candidates, callerRepo, callerWorkspace)
+		if node != nil {
+			e.To = node.ID
+			if callerRepo != "" && node.RepoPrefix != "" && node.RepoPrefix != callerRepo {
+				e.CrossRepo = true
+			}
+			stats.Resolved++
+			return
 		}
-		stats.Resolved++
-		return
+		ambiguousQualName = ambiguous
 	}
 
 	// Inverted-index lookup instead of a per-edge AllNodes() scan —
@@ -3177,15 +3180,26 @@ func (r *Resolver) resolveImport(e *graph.Edge, importPath string, stats *Resolv
 	// sub-module the importer reached for.
 	if npmAliased {
 		if pkg := npmPackagePrefix(importPath); pkg != "" {
-			if node := r.cachedGetNodeByQualName(pkg); node != nil {
-				e.To = node.ID
-				if callerRepo != "" && node.RepoPrefix != "" && node.RepoPrefix != callerRepo {
-					e.CrossRepo = true
+			if candidates := r.cachedFindNodesByQualName(pkg); len(candidates) > 0 {
+				node, ambiguous := pickResolverQualNameCandidate(candidates, callerRepo, callerWorkspace)
+				if node != nil {
+					e.To = node.ID
+					if callerRepo != "" && node.RepoPrefix != "" && node.RepoPrefix != callerRepo {
+						e.CrossRepo = true
+					}
+					stats.Resolved++
+					return
 				}
-				stats.Resolved++
-				return
+				ambiguousQualName = ambiguousQualName || ambiguous
 			}
 		}
+	}
+
+	// Several policy-equivalent qualified-name candidates are not evidence for
+	// an arbitrary edge. Leave the import pending for the cross-repository pass.
+	if ambiguousQualName {
+		stats.Unresolved++
+		return
 	}
 
 	// External/unresolvable import — create a stub target ID.
@@ -4753,4 +4767,17 @@ func (r *Resolver) callerRepoPrefix(e *graph.Edge) string {
 		return fromNode.RepoPrefix
 	}
 	return ""
+}
+
+// callerWorkspaceID returns the source workspace, falling back to its exact
+// repository prefix just like candidateWorkspaceID.
+func (r *Resolver) callerWorkspaceID(e *graph.Edge) string {
+	fromNode := r.cachedGetNode(e.From)
+	if fromNode == nil {
+		return ""
+	}
+	if fromNode.WorkspaceID != "" {
+		return fromNode.WorkspaceID
+	}
+	return fromNode.RepoPrefix
 }

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -87,6 +87,87 @@ func TestResolveAll_ExternalImport(t *testing.T) {
 	assert.Equal(t, "external::fmt", importEdge.To)
 }
 
+func TestResolveAll_ImportQualNamePrefersCallerRepoAcrossDuplicates(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		reverse bool
+	}{
+		{name: "forward_insert"},
+		{name: "reverse_insert", reverse: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := graph.New()
+			const qualName = "github.com/acme/shared"
+
+			callerA := &graph.Node{ID: "a-repo/main.go", Kind: graph.KindFile, Name: "main.go", FilePath: "a-repo/main.go", Language: "go", RepoPrefix: "a-repo", WorkspaceID: "ws-a"}
+			callerZ := &graph.Node{ID: "z-repo/main.go", Kind: graph.KindFile, Name: "main.go", FilePath: "z-repo/main.go", Language: "go", RepoPrefix: "z-repo", WorkspaceID: "ws-z"}
+			pkgA := &graph.Node{ID: "a-repo/shared/pkg.go::shared", Kind: graph.KindPackage, Name: "shared", QualName: qualName, FilePath: "a-repo/shared/pkg.go", Language: "go", RepoPrefix: "a-repo", WorkspaceID: "ws-a"}
+			pkgZ := &graph.Node{ID: "z-repo/shared/pkg.go::shared", Kind: graph.KindPackage, Name: "shared", QualName: qualName, FilePath: "z-repo/shared/pkg.go", Language: "go", RepoPrefix: "z-repo", WorkspaceID: "ws-z"}
+
+			g.AddNode(callerA)
+			g.AddNode(callerZ)
+			packages := []*graph.Node{pkgA, pkgZ}
+			if tc.reverse {
+				packages[0], packages[1] = packages[1], packages[0]
+			}
+			for _, pkg := range packages {
+				g.AddNode(pkg)
+			}
+
+			edgeA := &graph.Edge{From: callerA.ID, To: "unresolved::import::" + qualName, Kind: graph.EdgeImports, FilePath: callerA.FilePath, Line: 3}
+			edgeZ := &graph.Edge{From: callerZ.ID, To: "unresolved::import::" + qualName, Kind: graph.EdgeImports, FilePath: callerZ.FilePath, Line: 3}
+			g.AddEdge(edgeA)
+			g.AddEdge(edgeZ)
+
+			stats := New(g).ResolveAll()
+
+			require.Equal(t, 2, stats.Resolved)
+			assert.Equal(t, pkgA.ID, edgeA.To)
+			assert.Equal(t, pkgZ.ID, edgeZ.To)
+			assert.False(t, edgeA.CrossRepo)
+			assert.False(t, edgeZ.CrossRepo)
+		})
+	}
+}
+
+func TestResolveAll_ImportQualNameLeavesEquivalentForeignCandidatesUnresolved(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		reverse bool
+	}{
+		{name: "forward_insert"},
+		{name: "reverse_insert", reverse: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := graph.New()
+			const qualName = "github.com/acme/shared"
+
+			caller := &graph.Node{ID: "consumer/main.go", Kind: graph.KindFile, Name: "main.go", FilePath: "consumer/main.go", Language: "go", RepoPrefix: "consumer", WorkspaceID: "consumer-ws"}
+			candidateA := &graph.Node{ID: "a-foreign/shared.go::shared", Kind: graph.KindPackage, Name: "shared", QualName: qualName, FilePath: "a-foreign/shared.go", Language: "go", RepoPrefix: "a-foreign", WorkspaceID: "foreign-ws"}
+			candidateZ := &graph.Node{ID: "z-foreign/shared.go::shared", Kind: graph.KindPackage, Name: "shared", QualName: qualName, FilePath: "z-foreign/shared.go", Language: "go", RepoPrefix: "z-foreign", WorkspaceID: "foreign-ws"}
+
+			g.AddNode(caller)
+			candidates := []*graph.Node{candidateA, candidateZ}
+			if tc.reverse {
+				candidates[0], candidates[1] = candidates[1], candidates[0]
+			}
+			for _, candidate := range candidates {
+				g.AddNode(candidate)
+			}
+
+			unresolvedID := "unresolved::import::" + qualName
+			edge := &graph.Edge{From: caller.ID, To: unresolvedID, Kind: graph.EdgeImports, FilePath: caller.FilePath, Line: 3}
+			g.AddEdge(edge)
+
+			stats := New(g).ResolveAll()
+
+			require.Equal(t, 0, stats.Resolved)
+			assert.Equal(t, unresolvedID, edge.To)
+			assert.False(t, edge.CrossRepo)
+		})
+	}
+}
+
 func TestResolveAll_MethodCall(t *testing.T) {
 	g := graph.New()
 	g.AddNode(&graph.Node{ID: "pkg/a.go", Kind: graph.KindFile, Name: "a.go", FilePath: "pkg/a.go", Language: "go"})


### PR DESCRIPTION
## Summary

Allow legitimate duplicate qualified names without aborting SQLite writes or cross-binding imports to an arbitrary tracked repository.

Qualified names are lookup labels, not global graph identities. Forks, worktrees, manifest overlays, and separate repositories can emit the same value, and Kubernetes resources can also repeat one within a repository across namespaces.

## Changes

- Replace the global unique `nodes_by_qual` index with a non-unique partial index through an in-place schema v8 migration.
- Preserve duplicate qualified names when opening legacy or index-missing stores instead of blanking all but one row.
- Make batched qualified-name lookup return every candidate in deterministic node-ID order across Graph, SQLite, and overlay backends.
- Make normal import resolution prefer the exact caller repository, then its workspace.
- Make cross-repository resolution prefer caller repository/workspace before dependency-policy candidates.
- Leave policy-equivalent foreign candidates unresolved instead of choosing by row or insertion order.
- Add end-to-end coverage for two tracked Kubernetes repositories emitting `ClusterRole/prometheus` with distinct IDs, ownership, paths, and content.
- Keep the legacy singular qualified-name lookup as a compatibility API; semantic resolution now uses the complete candidate set.

## Testing

- [ ] All tests pass (`go test -race ./...`) — the repository-wide race suite was not run.
- [x] New tests added for new functionality
- [ ] Benchmarks run if performance-relevant — not run.

Verified:

- `go test ./internal/graph ./internal/graph/storetest ./internal/graph/store_sqlite ./internal/resolver ./internal/indexer ./internal/parser/languages -count=1`
- `go test -race ./internal/graph ./internal/graph/store_sqlite`
- `go test -race ./internal/resolver`
- `go build ./internal/graph/... ./internal/resolver/... ./internal/indexer/...`
- `git diff --check`

## Checklist

- [x] Code follows existing patterns in the codebase
- [x] No unnecessary abstractions added
- [x] Language extractor includes `Meta["methods"]` for interfaces (not applicable)
- [x] Methods have `EdgeMemberOf` edges to their containing type (not applicable)