### PR TITLE
Improve generic localization quality and evidence preservation

### DIFF
--- a/docs/04-evaluation/README.md
+++ b/docs/04-evaluation/README.md
@@ -21,6 +21,9 @@ methodology against a tagged build.
   with canonical answers.
 - [`run.md`](run.md) — operational recipe: how to invoke the
   harness, where outputs land, how to publish results.
+- [`localization-quality-spec.md`](localization-quality-spec.md) —
+  benchmark-independent parser, resolver, retrieval, evidence, and validation
+  invariants for localization-quality work.
 
 ## Why this exists
 

--- a/docs/04-evaluation/localization-quality-spec.md
+++ b/docs/04-evaluation/localization-quality-spec.md
@@ -1,0 +1,173 @@
+# Localization quality specification
+
+Status: implementation specification. This document controls localization-quality work until it is superseded by a reviewed revision.
+
+## Objective
+
+Given a natural-language coding task, return the production files and declared symbols that a developer should inspect or change. The system must solve this generically from syntax, graph structure, query intent, and evidence provenance. It must not recognize benchmark cases.
+
+The quality targets are:
+
+- at least 90% file recall and 75% declared-symbol recall for every supported language with a statistically meaningful sample;
+- no material regression in languages already above a target;
+- every emitted symbol claim resolves to a declaration in the emitted file;
+- bounded, deterministic localization with no unbounded graph walk or model-dependent repair step.
+
+A scorer result is a measurement, not an input to production behavior. Once a task set influences implementation choices, it is a development/regression set. Claims of generalization require a fresh holdout.
+
+## Non-goals
+
+- Memorizing repository names, issue identifiers, prompt phrases, file paths, or gold answers.
+- Adding per-project routing or language-and-repository special cases.
+- Treating a filename mention, prose occurrence, or line-local label as a declared-symbol hit.
+- Replacing precise syntax extraction with a universal text scanner.
+- Maximizing a single benchmark at the expense of latency, determinism, or other task classes.
+
+## Anti-overfitting contract
+
+Production code and tests introduced for localization work must satisfy all of these rules:
+
+1. No benchmark task identifiers, titles, repositories, paths, transcripts, or expected answers.
+2. No lookup table or conditional keyed by project identity, corpus identity, or a combination of language and project identity.
+3. Test fixtures are minimal synthetic programs that exercise a language construct or graph topology. Their identifiers describe the construct, not a benchmark case.
+4. Heuristics are expressed in generic features: node kind, declaration span, owner, edge kind, path role, query term, provenance channel, or graph distance.
+5. Language-specific behavior is allowed only in parsing and syntax-aware resolution, where the language grammar requires it.
+6. Every ranking rule needs an ablation or focused test demonstrating the generic invariant it implements.
+7. Development-set metrics, paired canary metrics, and fresh-holdout metrics are reported separately.
+
+A review that finds a forbidden artifact blocks the change even if metrics improve.
+
+## Failure model
+
+Localization is a pipeline. Each stage has a distinct responsibility and should be measured separately.
+
+| Stage | Responsibility | Typical failure |
+| --- | --- | --- |
+| Parse | Extract declarations, spans, and syntax-local references | declaration absent or wrong span |
+| Resolve | Assign canonical owners and connect references to declarations | method attached to a local label, wrong overload, unresolved member |
+| Retrieve | Find candidates from lexical, literal, structural, and semantic signals | correct file or symbol never enters the candidate set |
+| Expand | Follow bounded relationships to likely implementation owners | wrapper, configuration, test, or caller is returned without its implementation |
+| Rank | Order and diversify valid candidates | correct evidence is present but falls below the visible budget |
+| Preserve | Merge evidence across initial, refinement, exact-read, and recovery passes | earlier correct evidence disappears after a later pass |
+| Terminalize | Decide whether evidence is sufficient and render it | unresolved state is presented as a confident answer |
+| Validate | Ensure final file/symbol tuples refer to real declarations | prose or path text is mistaken for a symbol claim |
+
+Metrics must distinguish candidate recall from visible recall and final-claim recall. Otherwise retrieval failures and presentation failures are conflated.
+
+## Parser and resolver policy
+
+### Tree-sitter
+
+Tree-sitter is the default extractor for declarations, lexical scopes, receivers, signatures, and source spans. Query files and AST walks should cover ordinary language syntax, including declarations nested in language-defined containers.
+
+Use tree-sitter when a fact is represented structurally in the grammar. A ranking heuristic must never compensate for a declaration that the parser can extract correctly.
+
+### Manual parsing
+
+A manual scanner is acceptable only as a narrow fallback when at least one of the following is true:
+
+- the supported tree-sitter grammar omits the construct;
+- error recovery removes the structural node but balanced delimiters still define a safe declaration boundary;
+- a preprocessor or macro layer hides structure from the grammar;
+- a language-specific external block has a small, documented syntax surface.
+
+Manual scanners must be bounded, delimiter-aware, comment/string-aware where relevant, and covered by malformed-input tests. They emit the same declaration representation as tree-sitter and are deduplicated by canonical identity. They must not become a second general-purpose parser.
+
+### Resolution
+
+The resolver owns canonical symbol identity. A canonical declaration is the tuple:
+
+`(repository, normalized file, declaration kind, canonical owner chain, name, declaration start)`
+
+Display names may differ, but candidate merging and final validation use canonical identity. Local labels such as `name@line` are navigation aids, not final symbol identities; they must resolve to the enclosing declared function, method, type, or field before emission.
+
+Member resolution should use receiver/type information first, then owner scope, arity/signature evidence, imports, and only then name fallback. Ambiguous fallback results remain multiple candidates and cannot become an enforceable terminal answer.
+
+## Retrieval and expansion policy
+
+Initial retrieval combines independent channels rather than relying on one query formulation:
+
+- declaration-name and qualified-name search;
+- exact literals and configuration keys mentioned in the task;
+- file/path/module concepts;
+- structural graph matches;
+- semantic retrieval when available.
+
+Every candidate records its channel and supporting provenance. A later pass may add evidence or rank, but must not silently erase an earlier valid candidate.
+
+After initial retrieval, perform at most one bounded implementation-owner expansion from candidates with a non-implementation role, including tests/examples, configuration/registration sites, fields/constants, interfaces/traits, adapters, callers, and generic forwarding wrappers. Eligible edges are typed graph relations such as calls, implements, overrides, references, aliases/re-exports, and member ownership. Expansion is subject to a fixed node/edge budget, same-repository preference, declaration validation, and cycle detection.
+
+Expansion is evidence, not certainty. A unique complete wrapper-to-callee route can be strong proof; incomplete or ambiguous routes remain ranked alternatives.
+
+## Ranking and visibility
+
+Ranking uses generic, inspectable features:
+
+- task-term agreement with declared and qualified names;
+- exact literal or path evidence;
+- declaration kind and production/test/generated role;
+- relationship type and graph distance;
+- direct versus expanded provenance;
+- ambiguity and resolution confidence;
+- independent-channel support.
+
+Production declarations receive a prior for implementation questions, but test, example, configuration, and generated candidates are not discarded. They can be the task subject and can provide routes to production implementations.
+
+The visible result budget reserves diversity across evidence roles and source files before filling remaining slots by score. This prevents several near-duplicate candidates from hiding a lower-ranked implementation candidate supported by a different channel.
+
+## Evidence invariants
+
+1. **Declaration backed:** every candidate has a resolvable declaration identity and file. Non-declaration evidence may support a candidate but cannot itself be emitted as a symbol.
+2. **Tuple consistent:** a file/symbol claim is valid only when that declaration belongs to that file.
+3. **Monotonic preservation:** for one task generation, accepted evidence is unioned by canonical identity across initial, refinement, exact-read, and recovery passes. It can be removed only when validation proves it stale or invalid, and that reason is recorded.
+4. **Provenance preserving:** merging unions channels, routes, scores, and proof flags rather than replacing an earlier row with a weaker later row.
+5. **Bounded expansion:** graph expansion has explicit hop and candidate caps, deterministic ordering, and cycle prevention.
+6. **Honest terminality:** `answer_ready` requires visible declaration-backed evidence that satisfies the evidence policy. A depleted recovery budget is not proof.
+7. **No silent unresolved finalization:** an unresolved or ambiguous state remains advisory and reports uncertainty; it is never upgraded merely because the allowed call was consumed.
+
+## First implementation slice
+
+The first slice is intentionally cross-language and addresses pipeline loss before adding parser breadth:
+
+1. Preserve and union declaration-backed evidence across terminal-state recovery and exact/refinement reads.
+2. Keep bounded implementation routes visible alongside their originating candidates.
+3. Validate emitted file/symbol tuples against indexed declarations and normalize navigation-only labels to their declared owner.
+4. Add role-diverse visible-result selection so a production implementation is not hidden by several candidates of one role.
+5. Add one concrete parser/resolver correction only where a generic syntax construct is demonstrably misrepresented; do not add corpus-derived aliases.
+
+Further parser work is prioritized from extraction-gap measurements after this slice, not from aggregate symbol misses alone.
+
+## Verification
+
+### Unit and property tests
+
+- Synthetic snippets for declaration ownership, nested scopes, receivers, extensions/implementations, overloads, generics, macros or recovery syntax as applicable.
+- State-machine tests proving evidence monotonicity across every permitted transition.
+- Tuple-validation tests proving that prose, paths, signatures, and wrong-file symbols cannot become declaration claims.
+- Expansion tests with wrapper, test-to-production, configuration-to-handler, interface-to-implementation, and ambiguous/cyclic graphs.
+- Determinism tests under shuffled insertion order.
+- Budget tests proving fixed upper bounds.
+
+### Evaluation ladder
+
+1. Run parser and resolver unit tests.
+2. Run localization contract, digest, terminal-state, retrieval, and ranking tests.
+3. Replay frozen transcripts and candidate artifacts offline; do not rebill model calls.
+4. Run a small paired canary on a single pinned binary and scorer revision.
+5. Run the full development benchmark only after the canary passes.
+6. Evaluate a fresh, sealed holdout before making a generalization claim.
+
+Every evaluation artifact records the task-set checksum, transcript prefix/count and checksum, scorer revision, corpus revision, Gortex revision/build identity, exclusions, and completion marker.
+
+## Acceptance gates
+
+A change is ready to merge when:
+
+- the anti-overfitting contract passes review;
+- all new generic tests and affected existing suites pass;
+- candidate recall, visible recall, and final-claim recall are reported separately;
+- no supported language shows a material regression on the frozen development set;
+- latency and result-size budgets remain within their documented limits;
+- any claimed cross-corpus improvement is confirmed on a fresh holdout.
+
+The 90%/75% targets are release objectives, not permission to weaken these gates.

--- a/internal/mcp/enclosing.go
+++ b/internal/mcp/enclosing.go
@@ -33,13 +33,14 @@ func (s *Server) buildFileSymbolIndex(targets []astquery.Target) map[string]*fil
 		if _, ok := wanted[n.FilePath]; !ok {
 			continue
 		}
-		// Functions, methods, closures are the meaningful
-		// "enclosing scope" candidates. KindType (struct/class)
-		// is included too so a match in a class-body declaration
-		// still gets a symbol_id (e.g. a Java field that's
-		// flagged by string-equality detection).
+		// Functions, methods, closures, and macros are meaningful
+		// "enclosing scope" candidates. Macro nodes are declaration-backed and
+		// already carry exact source ranges; token-tree contents are never parsed
+		// as declarations here. KindType (struct/class) is included too so a
+		// class-body match still gets a symbol identity.
 		switch n.Kind {
-		case graph.KindFunction, graph.KindMethod, graph.KindClosure, graph.KindType, graph.KindInterface:
+		case graph.KindFunction, graph.KindMethod, graph.KindClosure, graph.KindMacro,
+			graph.KindType, graph.KindInterface:
 			idx := out[n.FilePath]
 			if idx == nil {
 				idx = &fileSymbolIndex{}
@@ -69,10 +70,15 @@ func (i *fileSymbolIndex) finalise() {
 		if i.syms[a].StartLine != i.syms[b].StartLine {
 			return i.syms[a].StartLine < i.syms[b].StartLine
 		}
-		// For nodes at the same start line, narrowest-first so
-		// the deepest scope wins on ties.
-		return (i.syms[a].EndLine - i.syms[a].StartLine) <
-			(i.syms[b].EndLine - i.syms[b].StartLine)
+		// For nodes at the same start line, narrowest-first so the deepest
+		// scope wins. Equal line ranges are not distinguishable without byte
+		// positions, so canonical identity supplies a deterministic final tie.
+		spanA := i.syms[a].EndLine - i.syms[a].StartLine
+		spanB := i.syms[b].EndLine - i.syms[b].StartLine
+		if spanA != spanB {
+			return spanA < spanB
+		}
+		return i.syms[a].ID < i.syms[b].ID
 	})
 }
 
@@ -243,7 +249,7 @@ func (s *Server) buildFileSymbolIndexForOrderedPathsContext(ctx context.Context,
 		}
 		for _, n := range nodes {
 			switch n.Kind {
-			case graph.KindFunction, graph.KindMethod, graph.KindClosure,
+			case graph.KindFunction, graph.KindMethod, graph.KindClosure, graph.KindMacro,
 				graph.KindType, graph.KindInterface:
 				idx := out[n.FilePath]
 				if idx == nil {

--- a/internal/mcp/enclosing_macro_test.go
+++ b/internal/mcp/enclosing_macro_test.go
@@ -1,0 +1,55 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestFileSymbolIndexMapsInteriorMacroLinesToDeclaration(t *testing.T) {
+	g := graph.New()
+	for _, node := range []*graph.Node{
+		{ID: "fixture.c::configure", Name: "configure", Kind: graph.KindFunction, FilePath: "fixture.c", StartLine: 1, EndLine: 10},
+		{ID: "fixture.c::APPLY", Name: "APPLY", Kind: graph.KindMacro, FilePath: "fixture.c", StartLine: 2, EndLine: 4},
+		{ID: "fixture.rs::apply", Name: "apply", Kind: graph.KindMacro, FilePath: "fixture.rs", StartLine: 20, EndLine: 24},
+	} {
+		g.AddNode(node)
+	}
+
+	server := &Server{graph: g}
+	indexes := server.buildFileSymbolIndexForPaths(map[string]struct{}{
+		"fixture.c":  {},
+		"fixture.rs": {},
+	})
+	for _, test := range []struct {
+		name string
+		file string
+		line int
+		id   string
+	}{
+		{name: "multiline C macro", file: "fixture.c", line: 3, id: "fixture.c::APPLY"},
+		{name: "Rust macro rule body", file: "fixture.rs", line: 22, id: "fixture.rs::apply"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			index := indexes[test.file]
+			if index == nil {
+				t.Fatalf("no symbol index for %s", test.file)
+			}
+			if got, _ := index.find(test.line); got != test.id {
+				t.Fatalf("enclosing symbol at %s:%d = %q, want %q", test.file, test.line, got, test.id)
+			}
+		})
+	}
+}
+
+func TestFileSymbolIndexEqualRangesUseDeterministicIdentityTie(t *testing.T) {
+	index := &fileSymbolIndex{}
+	// Reverse lexical insertion order to model graph-map iteration.
+	index.add(&graph.Node{ID: "fixture.rs::zeta", Name: "zeta", Kind: graph.KindMacro, StartLine: 7, EndLine: 7})
+	index.add(&graph.Node{ID: "fixture.rs::alpha", Name: "alpha", Kind: graph.KindMacro, StartLine: 7, EndLine: 7})
+	index.finalise()
+
+	if got, _ := index.find(7); got != "fixture.rs::alpha" {
+		t.Fatalf("equal-range owner = %q, want canonical identity tie-break", got)
+	}
+}

--- a/internal/mcp/facade_tools.go
+++ b/internal/mcp/facade_tools.go
@@ -722,7 +722,7 @@ func (s *Server) localizationTextMatchNode(ctx context.Context, match enrichedTe
 // was successfully read. It never reconstructs identity from serialized output.
 func captureLocalizationReadSource(ctx context.Context, node *graph.Node) {
 	rows := make([]localizationDigestRow, 0, 1)
-	if row, ok := localizationDigestRowFromNode(node, "permitted_read_source"); ok {
+	if row, ok := localizationDigestRowFromNode(node, localizationProvenancePermittedReadSource); ok {
 		rows = append(rows, row)
 	}
 	captureLocalizationRows(ctx, rows)

--- a/internal/mcp/localization_current_capture_test.go
+++ b/internal/mcp/localization_current_capture_test.go
@@ -21,7 +21,7 @@ func captureTestRow(id, file string) localizationDigestRow {
 	}
 }
 
-func TestMergeLocalizationEvidenceDigestIsCurrentFirstAlignedAndBounded(t *testing.T) {
+func TestMergeLocalizationEvidenceDigestReservesPriorWindowAndStaysAligned(t *testing.T) {
 	retained := mergeLocalizationEvidenceDigest([]localizationDigestRow{
 		captureTestRow("repo/storage/base.go::Storage.Load", "repo/storage/base.go"),
 		captureTestRow("repo/storage/cloud.go::CloudStorage.Load", "repo/storage/cloud.go"),
@@ -43,10 +43,10 @@ func TestMergeLocalizationEvidenceDigestIsCurrentFirstAlignedAndBounded(t *testi
 	wantIDs := []string{
 		"repo/storage/disk.go::DiskStorage.Load",
 		"repo/storage/base.go::Storage.Load",
-		"repo/storage/mirror.go::Mirror.Load",
 		"repo/storage/cloud.go::CloudStorage.Load",
 		"repo/storage/cache.go::Cache.Load",
 		"repo/storage/archive.go::Archive.Load",
+		"repo/storage/mirror.go::Mirror.Load",
 	}
 	for index, want := range wantIDs {
 		row := merged.Evidence[index]
@@ -194,7 +194,7 @@ func TestFinishReservedReadWithDigestMergesOnlyOnAnswerReady(t *testing.T) {
 	}
 }
 
-func TestFinishReservedReadWithDigestRetriesRecordedZeroThenPreservesCurrentTaskDigest(t *testing.T) {
+func TestFinishReservedReadWithDigestEmptySuccessReleasesAdvisoryAndPreservesCurrentTaskDigest(t *testing.T) {
 	retained := mergeLocalizationEvidenceDigest([]localizationDigestRow{
 		captureTestRow("repo/storage/base.go::Storage.Load", "repo/storage/base.go"),
 	}, nil)
@@ -207,25 +207,17 @@ func TestFinishReservedReadWithDigestRetriesRecordedZeroThenPreservesCurrentTask
 		digest:                   retained,
 	}
 	completion := state.finishReservedReadTokenWithDigest(21, true, nil, true)
-	if completion.State != localizationStateNeedsRecovery || completion.AllowedToolCalls != 1 {
-		t.Fatalf("first zero-result completion = %#v", completion)
+	if completion.State != localizationStateLocalized || completion.AllowedToolCalls != 0 || completion.Enforceable {
+		t.Fatalf("empty accepted recovery did not release an advisory result: %#v", completion)
 	}
-	if state.digest == nil {
-		t.Fatal("bounded retry discarded digest before exhaustion")
+	if state.state != localizationStateInactive {
+		t.Fatalf("empty accepted recovery left state restricted: %q", state.state)
 	}
-
-	state.state = localizationStateRecoveryInFlight
-	state.readReservationToken = 22
-	state.readReservationGen = state.generation
-	completion = state.finishReservedReadTokenWithDigest(22, true, nil, true)
-	if completion.State != localizationStateAnswerReady {
-		t.Fatalf("exhausted zero-result state = %q", completion.State)
-	}
-	if state.digest != retained || completion.digest != retained {
-		t.Fatalf("same-task exhaustion discarded retained evidence: state=%#v completion=%#v", state.digest, completion.digest)
+	if state.digest != nil || completion.digest != retained {
+		t.Fatalf("advisory release did not return retained evidence and clear internal authorization: state=%#v completion=%#v", state.digest, completion.digest)
 	}
 	if got := completion.digest.Evidence[0].ID; got != "repo/storage/base.go::Storage.Load" {
-		t.Fatalf("same-task exhaustion changed retained identity: %q", got)
+		t.Fatalf("same-task advisory release changed retained identity: %q", got)
 	}
 }
 

--- a/internal/mcp/localization_digest.go
+++ b/internal/mcp/localization_digest.go
@@ -19,9 +19,9 @@ const (
 	// localizationDigestMaxBytes bounds retained session state independently of
 	// the original envelope budget.
 	localizationDigestMaxBytes = 4096
-	// localizationReplayEvidenceLimit preserves the five strongest direct rows
-	// plus at most one graph-validated direct relationship for each. The retained
-	// byte cap remains authoritative when long identities cannot all fit.
+	// localizationReplayEvidenceLimit preserves the complete eight-symbol
+	// refinement window plus two graph-relationship slots. The retained byte cap
+	// remains authoritative when long identities cannot all fit.
 	localizationReplayEvidenceLimit = 10
 	// localizationFinalResponseMaxBytes bounds the ready-to-emit answer that
 	// accompanies the retained digest on terminal responses and replays.
@@ -120,7 +120,7 @@ func newLocalizationEvidenceDigestForTask(task string, envelope localizationExpl
 			return digest
 		}
 		last := len(digest.Evidence) - 1
-		if shedLocalizationDigestRowOptionalFields(&digest.Evidence[last]) {
+		if shedLocalizationDigestOptionalFields(digest.Evidence) {
 			continue
 		}
 		// The identity and file are the irreducible row. If even one pathological
@@ -180,14 +180,66 @@ func cloneLocalizationDigestRows(rows []localizationDigestRow) []localizationDig
 	return cloned
 }
 
+const localizationMergedRelationCap = exploreRingCap * 2
+
+func mergeLocalizationDigestStrings(primary, supplementary []string) []string {
+	merged := make([]string, 0, min(localizationMergedRelationCap, len(primary)+len(supplementary)))
+	seen := make(map[string]struct{}, cap(merged))
+	for _, values := range [][]string{primary, supplementary} {
+		for _, value := range values {
+			value = strings.TrimSpace(value)
+			if value == "" {
+				continue
+			}
+			if _, exists := seen[value]; exists {
+				continue
+			}
+			seen[value] = struct{}{}
+			merged = append(merged, value)
+			if len(merged) == localizationMergedRelationCap {
+				return merged
+			}
+		}
+	}
+	return merged
+}
+
+// mergeLocalizationDigestRowEvidence preserves the first-ranked identity while
+// filling metadata and unioning bounded graph evidence from a later observation.
+// File disagreement is deliberately not repaired here: one ID cannot authorize
+// two declaration files, so the first tuple remains authoritative.
+func mergeLocalizationDigestRowEvidence(primary, supplementary localizationDigestRow) localizationDigestRow {
+	if strings.TrimSpace(primary.File) != strings.TrimSpace(supplementary.File) {
+		return primary
+	}
+	if primary.Name == "" {
+		primary.Name = supplementary.Name
+	}
+	if primary.QualName == "" {
+		primary.QualName = supplementary.QualName
+	}
+	if primary.Kind == "" {
+		primary.Kind = supplementary.Kind
+	}
+	if primary.Line == 0 {
+		primary.Line = supplementary.Line
+	}
+	if primary.Signature == "" {
+		primary.Signature = supplementary.Signature
+	}
+	if primary.Provenance == "" {
+		primary.Provenance = supplementary.Provenance
+	}
+	primary.Callers = mergeLocalizationDigestStrings(primary.Callers, supplementary.Callers)
+	primary.Callees = mergeLocalizationDigestStrings(primary.Callees, supplementary.Callees)
+	return primary
+}
+
 // localizationFreshEvidenceReserve bounds how much of the retained digest the
-// terminalizing call's own output may claim. A targeted read returns one row and
-// deserves to lead; a broad search returns a whole page of its own and would
-// otherwise evict every ranked localization row — including a rank-one ground
-// truth the caller has already read — leaving an answer built entirely from the
-// caller's last query. The localization evidence is what the session exists to
-// deliver, so it keeps the majority of the bounded digest.
-const localizationFreshEvidenceReserve = 3
+// terminalizing call's own output may claim. The remainder is exactly the full
+// refinement authorization window, so one broad recovery page cannot evict a
+// candidate that the preceding contract said was safe to inspect.
+const localizationFreshEvidenceReserve = localizationReplayEvidenceLimit - localizationRefinementAllowedSymbolCap
 
 // mergeLocalizationEvidenceDigest puts evidence returned by the terminalizing
 // permitted call first, then fills the bounded tail from the retained localize
@@ -196,24 +248,25 @@ const localizationFreshEvidenceReserve = 3
 // retained ranking out of its own answer.
 func mergeLocalizationEvidenceDigest(current []localizationDigestRow, retained *localizationEvidenceDigest) *localizationEvidenceDigest {
 	digest := &localizationEvidenceDigest{}
-	seen := make(map[string]struct{}, localizationReplayEvidenceLimit)
+	seen := make(map[string]int, localizationReplayEvidenceLimit)
 	appendRows := func(rows []localizationDigestRow, limit int) {
 		if limit > localizationReplayEvidenceLimit {
 			limit = localizationReplayEvidenceLimit
 		}
 		for _, row := range rows {
-			if len(digest.Evidence) >= limit {
-				return
-			}
 			row.ID = strings.TrimSpace(row.ID)
 			row.File = strings.TrimSpace(row.File)
 			if row.ID == "" || row.File == "" {
 				continue
 			}
-			if _, exists := seen[row.ID]; exists {
+			if index, exists := seen[row.ID]; exists {
+				digest.Evidence[index] = mergeLocalizationDigestRowEvidence(digest.Evidence[index], row)
 				continue
 			}
-			seen[row.ID] = struct{}{}
+			if len(digest.Evidence) >= limit {
+				return
+			}
+			seen[row.ID] = len(digest.Evidence)
 			row.Callers = append([]string(nil), row.Callers...)
 			row.Callees = append([]string(nil), row.Callees...)
 			digest.Evidence = append(digest.Evidence, row)
@@ -240,7 +293,7 @@ func mergeLocalizationEvidenceDigest(current []localizationDigestRow, retained *
 			return digest
 		}
 		last := len(digest.Evidence) - 1
-		if shedLocalizationDigestRowOptionalFields(&digest.Evidence[last]) {
+		if shedLocalizationDigestOptionalFields(digest.Evidence) {
 			continue
 		}
 		if last == 0 {
@@ -403,6 +456,19 @@ func shedLocalizationDigestRowOptionalFields(row *localizationDigestRow) bool {
 	return false
 }
 
+// shedLocalizationDigestOptionalFields compacts supplementary detail across the
+// complete retained window before any declaration identity is removed. Walking
+// from the tail preserves richer metadata on higher-ranked rows when the byte
+// cap can be met without stripping the whole page.
+func shedLocalizationDigestOptionalFields(rows []localizationDigestRow) bool {
+	for index := len(rows) - 1; index >= 0; index-- {
+		if shedLocalizationDigestRowOptionalFields(&rows[index]) {
+			return true
+		}
+	}
+	return false
+}
+
 func rebuildLocalizationDigestSkeleton(digest *localizationEvidenceDigest) {
 	digest.Files = digest.Files[:0]
 	digest.Symbols = digest.Symbols[:0]
@@ -550,13 +616,9 @@ func localizationFinalResponseRows(task string, current, rows []localizationDige
 	for _, row := range rows {
 		rowsByID[strings.TrimSpace(row.ID)] = row
 	}
-	// A successful authorized read is the freshest bounded evidence and leads
-	// the presentation even when its retained predecessor carried more metadata.
-	for _, row := range current {
-		if retained, exists := rowsByID[strings.TrimSpace(row.ID)]; exists {
-			appendRow(&primaries, localizationFinalResponsePrimaryLimit, retained)
-		}
-	}
+	// Fresh rows already lead the merged evidence order. Primary status is earned
+	// from proof, task alignment, or owner coherence below; arrival time alone
+	// must not displace stronger retained evidence.
 	for _, row := range rows {
 		if localizationFinalResponsePrimaryProvenance(row.Provenance) {
 			appendRow(&primaries, localizationFinalResponsePrimaryLimit, row)
@@ -841,7 +903,7 @@ func localizationCompletionBoundedByDigest(completion localizationCompletion, di
 	}
 	retained := localizationDigestRowsByID(digest)
 	advisory := func() localizationCompletion {
-		bounded := newLocalizationCompletion(true, "")
+		bounded := newLocalizationAdvisoryCompletion()
 		bounded.taskLead = completion.taskLead
 		return bounded
 	}
@@ -906,6 +968,18 @@ func localizationCompletionBoundedByDigest(completion localizationCompletion, di
 		return bounded
 	}
 	return completion
+}
+
+// localizationContractReconciledWithDigest is the only projection boundary
+// from retained evidence to a wire contract. Call it after every digest reshape:
+// byte shedding may remove an authorized identity or one of its proof rows.
+func localizationContractReconciledWithDigest(
+	completion localizationCompletion,
+	digest *localizationEvidenceDigest,
+) localizationTerminalContract {
+	completion = localizationCompletionBoundedByDigest(completion, digest)
+	completion = localizationCompletionWithDigest(completion, digest)
+	return localizationContractFor(completion)
 }
 
 // localizationStateCarriesEvidence reports whether a state is inside a

--- a/internal/mcp/localization_digest.go
+++ b/internal/mcp/localization_digest.go
@@ -510,7 +510,8 @@ func localizationFinalResponsePrimaryProvenance(provenance string) bool {
 	case localizationProvenanceSourceLiteralCallee,
 		localizationProvenanceDivergentDefault,
 		localizationProvenanceImplementationTarget,
-		localizationProvenanceTypedAnchorProjection:
+		localizationProvenanceTypedAnchorProjection,
+		localizationProvenancePermittedReadSource:
 		return true
 	default:
 		return false

--- a/internal/mcp/localization_digest_test.go
+++ b/internal/mcp/localization_digest_test.go
@@ -22,50 +22,6 @@ func testEvidenceDigest() *localizationEvidenceDigest {
 	})
 }
 
-func requireLocalizationTerminalError(t *testing.T, result *mcpgo.CallToolResult, facade, operation string) localizationTerminalContract {
-	t.Helper()
-	if result == nil || !result.IsError {
-		t.Fatalf("terminal result = %#v, want typed MCP error", result)
-	}
-	text, ok := singleTextContent(result)
-	if !ok {
-		t.Fatalf("terminal result content = %#v, want one text block", result.Content)
-	}
-	var payload struct {
-		ErrorCode ErrorCode `json:"error_code"`
-		Message   string    `json:"message"`
-		Retriable bool      `json:"retriable"`
-		Data      struct {
-			Contract  localizationTerminalContract `json:"contract"`
-			Facade    string                       `json:"facade"`
-			Operation string                       `json:"operation"`
-		} `json:"data"`
-	}
-	if err := json.Unmarshal([]byte(text), &payload); err != nil {
-		t.Fatalf("decode terminal error %q: %v", text, err)
-	}
-	var wire map[string]json.RawMessage
-	if err := json.Unmarshal([]byte(text), &wire); err != nil {
-		t.Fatalf("decode terminal error wire %q: %v", text, err)
-	}
-	if raw, exists := wire["retriable"]; !exists || string(raw) != "false" {
-		t.Fatalf("terminal error must explicitly encode retriable=false: %s", text)
-	}
-	if payload.ErrorCode != ErrCodeLocalizationTerminal || payload.Message == "" || payload.Retriable {
-		t.Fatalf("terminal error = %#v", payload)
-	}
-	if payload.Data.Facade != facade || payload.Data.Operation != operation {
-		t.Fatalf("terminal error route = %q/%q, want %q/%q", payload.Data.Facade, payload.Data.Operation, facade, operation)
-	}
-	contract := payload.Data.Contract
-	if !contract.Terminal || contract.Completion.State != localizationStateAnswerReady ||
-		contract.Completion.ContractVersion != localizationTerminalContractV2 ||
-		contract.Completion.AllowedToolCalls != 0 {
-		t.Fatalf("terminal contract = %#v", contract)
-	}
-	return contract
-}
-
 func requireLocalizationTerminalReplay(t *testing.T, result *mcpgo.CallToolResult, _, _ string) localizationTerminalContract {
 	t.Helper()
 	if result == nil || result.IsError {
@@ -253,7 +209,7 @@ func TestDigestLifecycleAndLegacyFallback(t *testing.T) {
 	requireLocalizationTerminalReplay(t, blocked, "search", "symbols")
 }
 
-func TestDigestByteCapShedsEvidenceTail(t *testing.T) {
+func TestDigestByteCapShedsOptionalMetadataBeforeEvidenceTail(t *testing.T) {
 	envelope := localizationExploreEnvelope{}
 	for i := 0; i < 400; i++ {
 		envelope.Evidence = append(envelope.Evidence, localizationEvidence{
@@ -273,8 +229,17 @@ func TestDigestByteCapShedsEvidenceTail(t *testing.T) {
 	if len(encoded) > localizationDigestMaxBytes {
 		t.Fatalf("digest = %d bytes, want <= %d", len(encoded), localizationDigestMaxBytes)
 	}
-	if len(digest.Evidence) == 0 || len(digest.Evidence) >= localizationReplayEvidenceLimit {
-		t.Fatalf("byte cap retained %d rows, want a non-empty shed prefix", len(digest.Evidence))
+	if len(digest.Evidence) != localizationReplayEvidenceLimit {
+		t.Fatalf("byte cap retained %d rows, want all %d declaration identities", len(digest.Evidence), localizationReplayEvidenceLimit)
+	}
+	stripped := 0
+	for _, row := range digest.Evidence {
+		if row.Signature == "" {
+			stripped++
+		}
+	}
+	if stripped == 0 {
+		t.Fatal("byte cap retained every optional signature instead of compacting metadata")
 	}
 	if len(digest.Files) != len(digest.Evidence) || len(digest.Symbols) != len(digest.Evidence) {
 		t.Fatalf("files=%d symbols=%d evidence=%d, want positional rows", len(digest.Files), len(digest.Symbols), len(digest.Evidence))
@@ -480,11 +445,11 @@ func TestLocalizationCompletionReconcilesShedAllowedSymbols(t *testing.T) {
 		if len(digest.Evidence) != 0 {
 			t.Fatalf("pathological identity survived digest: %#v", digest.Evidence)
 		}
-		if bounded.State != localizationStateAnswerReady || bounded.RequiredAction != "respond" || bounded.AllowedToolCalls != 0 || len(bounded.AllowedSymbols) != 0 {
-			t.Fatalf("empty authorization did not use advisory fallback: %#v", bounded)
+		if bounded.State != localizationStateLocalized || bounded.RequiredAction != "continue_task" || bounded.AllowedToolCalls != 0 || len(bounded.AllowedSymbols) != 0 {
+			t.Fatalf("empty authorization did not use nonterminal advisory fallback: %#v", bounded)
 		}
-		if bounded.FinalResponse == "" {
-			t.Fatal("advisory fallback omitted bounded final response")
+		if bounded.FinalResponse != "" {
+			t.Fatalf("empty evidence should not manufacture a provisional identity page: %q", bounded.FinalResponse)
 		}
 	})
 }
@@ -606,8 +571,8 @@ func TestDigestDowngradesAuthorizationWhenDependencyCannotFit(t *testing.T) {
 		if _, retained := localizationDigestRowsByID(digest)[implementation]; retained {
 			t.Fatal("pathological implementation unexpectedly fit the digest")
 		}
-		if bounded.State != localizationStateAnswerReady || len(bounded.AllowedSymbols) != 0 {
-			t.Fatalf("wrapper remained authorized without its implementation: %#v", bounded)
+		if bounded.State != localizationStateLocalized || len(bounded.AllowedSymbols) != 0 || bounded.AllowedToolCalls != 0 {
+			t.Fatalf("missing implementation proof did not release an advisory completion: %#v", bounded)
 		}
 	})
 
@@ -657,7 +622,7 @@ func TestDigestDowngradesAuthorizationWhenDependencyCannotFit(t *testing.T) {
 	})
 }
 
-func TestTaskAwareDigestMergeRetainsLongTailSameOwnerCohort(t *testing.T) {
+func TestTaskAwareDigestMergePromotesLongTailSameOwnerCohortWithoutIdentityLoss(t *testing.T) {
 	const (
 		currentID = "repo/gate.go::BatchGate.drainPending"
 		targetID  = "repo/gate.go::BatchGate.discardPending"
@@ -696,8 +661,8 @@ func TestTaskAwareDigestMergeRetainsLongTailSameOwnerCohort(t *testing.T) {
 		return false
 	}
 	baseline := mergeLocalizationEvidenceDigest([]localizationDigestRow{current}, retained)
-	if contains(baseline, targetID) {
-		t.Fatal("fixture did not force the unrelated tail to shed the coherent target")
+	if !contains(baseline, targetID) {
+		t.Fatal("byte compaction shed a declaration identity before optional metadata")
 	}
 
 	digest := mergeLocalizationEvidenceDigestForTask(

--- a/internal/mcp/localization_evidence_policy.go
+++ b/internal/mcp/localization_evidence_policy.go
@@ -16,6 +16,10 @@ const (
 	localizationProvenanceImplementationRoute   = "implementation_route"
 	localizationProvenanceImplementationTarget  = "implementation_target"
 	localizationProvenanceTypedAnchorProjection = "typed_anchor_projection"
+	// localizationProvenancePermittedReadSource marks the declaration returned
+	// by the exact read the contract itself prescribed. It is proof, not
+	// arrival order: the session named that symbol before the read happened.
+	localizationProvenancePermittedReadSource = "permitted_read_source"
 )
 
 type localizationEvidenceProof struct {

--- a/internal/mcp/localization_generic_invariants_test.go
+++ b/internal/mcp/localization_generic_invariants_test.go
@@ -239,6 +239,46 @@ func TestRecoveryInterceptionCannotInvalidateConcurrentNewUserLocalizeReservatio
 	})
 }
 
+// A reserved read that ends in the advisory release commits, and committing
+// bumps the generation that a concurrently reserved localize staged against.
+// The newer request owns the session's next contract; the finishing read must
+// not silently discard it.
+func TestAdvisoryReleaseCannotInvalidateConcurrentLocalizeReservation(t *testing.T) {
+	state := newLocalizationTerminalState()
+	state.armForTask(newLocalizationRecoveryCompletion(), "old task")
+
+	blocked, readToken := state.authorizeWithToken("search", "text",
+		map[string]any{"query": "old task"})
+	if blocked != nil || readToken == 0 {
+		t.Fatalf("recovery authorization = (%#v, %d), want a reserved read token", blocked, readToken)
+	}
+
+	localizeToken, refused := state.beginLocalize("replacement task", true)
+	if localizeToken == 0 || refused != nil {
+		t.Fatalf("replacement reservation = (%d, %#v)", localizeToken, refused)
+	}
+	state.armForTask(newLocalizationCompletion(true, ""), "replacement task")
+
+	// The recovery page returns evidence that does not prove a task-aligned
+	// declaration, so the bounded workflow ends advisory, not answer_ready.
+	completion := state.finishReservedReadTokenWithDigest(readToken, true,
+		[]localizationDigestRow{{ID: "fixture/other.go::Other.Run", File: "fixture/other.go", Name: "Run"}},
+		true)
+	if completion.State == localizationStateAnswerReady {
+		t.Fatalf("weak recovery terminalized: %#v", completion)
+	}
+
+	if !state.finishLocalize(localizeToken, true) {
+		t.Fatal("advisory release invalidated the concurrently reserved localize")
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.state != localizationStateAnswerReady || state.reservation != nil {
+		t.Fatalf("replacement completion was not committed: state=%q reservation=%#v",
+			state.state, state.reservation)
+	}
+}
+
 func TestAcceptedEmptyRecoveryReleasesAdvisorySession(t *testing.T) {
 	state := newLocalizationTerminalState()
 	completion := newLocalizationRecoveryCompletion()

--- a/internal/mcp/localization_generic_invariants_test.go
+++ b/internal/mcp/localization_generic_invariants_test.go
@@ -1,0 +1,263 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestConceptAnchorChoosesBoundedRefinementWhileFocusedLookupStaysExact(t *testing.T) {
+	const exact = "fixture/worker.go::Worker.Run"
+	cases := []struct {
+		name        string
+		answerReady bool
+		task        string
+		causalExact string
+		want        bool
+	}{
+		{
+			name: "anchor embedded in prose",
+			task: "Trace why Worker.Run keeps retrying requests after the queue has already acknowledged successful delivery",
+			want: true,
+		},
+		{name: "focused qualified lookup", task: exact, want: false},
+		{name: "focused signature lookup", task: "func (Worker) Run() error", want: false},
+		{
+			name:        "graph proven causal identity",
+			task:        "Trace why Worker.Run keeps retrying requests after the queue has already acknowledged successful delivery",
+			causalExact: "fixture/config.go::newWorker",
+			want:        false,
+		},
+		{
+			name:        "already answer ready",
+			answerReady: true,
+			task:        "Trace why Worker.Run keeps retrying requests after the queue has already acknowledged successful delivery",
+			want:        false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := exploreLocalizationUsesConceptRefinement(tc.answerReady, tc.task, exact, tc.causalExact); got != tc.want {
+				t.Fatalf("concept refinement = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestContractReconcilesAfterLateDigestShedding(t *testing.T) {
+	const wrapper = "fixture/wrapper.go::Forwarder.Forward"
+	const implementation = "fixture/engine.go::Engine.Execute"
+	completion := newLocalizationRefinementCompletion(wrapper)
+	completion.refinementRoutes = map[string]localizationRefinementRoute{
+		wrapper: {implementationSymbol: implementation, enforceable: true},
+	}
+	digest := &localizationEvidenceDigest{Evidence: []localizationDigestRow{
+		{ID: wrapper, Name: "Forward", Kind: "method", File: "fixture/wrapper.go", Provenance: localizationProvenanceImplementationRoute},
+		{ID: implementation, Name: "Execute", Kind: "method", File: "fixture/engine.go", Provenance: localizationProvenanceImplementationTarget},
+	}}
+	rebuildLocalizationDigestSkeleton(digest)
+	refreshLocalizationDigestResponses(digest, "forward execution", nil)
+
+	contract := localizationContractReconciledWithDigest(completion, digest)
+	if contract.Terminal || contract.Completion.State != localizationStateNeedsRefinement {
+		t.Fatalf("complete proof was not retained as refinement: %#v", contract)
+	}
+
+	// Model the final envelope-fit loop dropping a proof dependency after the
+	// first reconciliation pass.
+	digest.Evidence = digest.Evidence[:1]
+	rebuildLocalizationDigestSkeleton(digest)
+	refreshLocalizationDigestResponses(digest, "forward execution", nil)
+	contract = localizationContractReconciledWithDigest(contract.Completion, digest)
+	if contract.Terminal || contract.Completion.State != localizationStateLocalized || len(contract.Completion.AllowedSymbols) != 0 {
+		t.Fatalf("late proof shedding left stale authorization: %#v", contract)
+	}
+}
+
+func TestDirectRelationProjectionPreservesAuthorizedDirectFloor(t *testing.T) {
+	targets := make([]exploreTarget, 0, localizationReplayEvidenceLimit)
+	for index := 0; index < localizationReplayEvidenceLimit; index++ {
+		node := &graph.Node{
+			ID:       fmt.Sprintf("fixture/direct_%02d.go::Candidate%02d", index, index),
+			Name:     fmt.Sprintf("Candidate%02d", index),
+			Kind:     graph.KindFunction,
+			FilePath: fmt.Sprintf("fixture/direct_%02d.go", index),
+		}
+		targets = append(targets, exploreTarget{node: node})
+	}
+	implementation := &graph.Node{
+		ID: "fixture/engine.go::ExecuteRequest", Name: "ExecuteRequest",
+		Kind: graph.KindFunction, FilePath: "fixture/engine.go",
+	}
+	targets[0].callees = []*graph.Node{implementation}
+
+	got := interleaveLocalizationDirectRelations("execute request behavior", "", targets)
+	if len(got) != localizationReplayEvidenceLimit {
+		t.Fatalf("projection length = %d, want %d", len(got), localizationReplayEvidenceLimit)
+	}
+	seen := make(map[string]bool, len(got))
+	for _, target := range got {
+		seen[target.node.ID] = true
+	}
+	for index := 0; index < localizationRefinementAllowedSymbolCap; index++ {
+		if id := targets[index].node.ID; !seen[id] {
+			t.Fatalf("authorized direct candidate %d was evicted: %s", index+1, id)
+		}
+	}
+	if !seen[implementation.ID] {
+		t.Fatalf("bounded relationship slot did not retain implementation %s", implementation.ID)
+	}
+}
+
+func TestRecoveryMergePreservesPriorAuthorizationWindow(t *testing.T) {
+	retained := &localizationEvidenceDigest{}
+	for index := 0; index < localizationRefinementAllowedSymbolCap; index++ {
+		retained.Evidence = append(retained.Evidence, localizationDigestRow{
+			ID:        fmt.Sprintf("fixture/retained_%02d.go::Candidate%02d", index, index),
+			File:      fmt.Sprintf("fixture/retained_%02d.go", index),
+			Name:      fmt.Sprintf("Candidate%02d", index),
+			Signature: strings.Repeat("parameter metadata ", 45),
+			Callers:   []string{strings.Repeat("fixture/caller.go::Dispatch", 20)},
+			Callees:   []string{strings.Repeat("fixture/store.go::Commit", 20)},
+		})
+	}
+	current := make([]localizationDigestRow, 5)
+	for index := range current {
+		current[index] = localizationDigestRow{
+			ID:        fmt.Sprintf("fixture/recovery_%02d.go::Result%02d", index, index),
+			File:      fmt.Sprintf("fixture/recovery_%02d.go", index),
+			Signature: strings.Repeat("recovery detail ", 45),
+		}
+	}
+	// A fresh observation of the first retained declaration expands its graph
+	// metadata, exercising duplicate union as well as the near-cap window.
+	current[0].ID = retained.Evidence[0].ID
+	current[0].File = retained.Evidence[0].File
+	current[0].Callers = []string{strings.Repeat("fixture/queue.go::Enqueue", 20)}
+
+	merged := mergeLocalizationEvidenceDigest(current, retained)
+	seen := make(map[string]bool, len(merged.Evidence))
+	for _, row := range merged.Evidence {
+		seen[row.ID] = true
+	}
+	for _, row := range retained.Evidence {
+		if !seen[row.ID] {
+			t.Fatalf("recovery evicted previously authorized candidate %s", row.ID)
+		}
+	}
+	encoded, err := json.Marshal(merged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(encoded) > localizationDigestMaxBytes {
+		t.Fatalf("merged digest = %d bytes, cap %d", len(encoded), localizationDigestMaxBytes)
+	}
+}
+
+func TestRecoveryMergeUnionsDuplicateEvidenceMetadata(t *testing.T) {
+	const id = "fixture/worker.go::Worker.Run"
+	retained := &localizationEvidenceDigest{Evidence: []localizationDigestRow{{
+		ID: id, File: "fixture/worker.go", Signature: "func (Worker) Run() error",
+		Callers:    []string{"fixture/app.go::Start"},
+		Callees:    []string{"fixture/store.go::Store.Flush"},
+		Provenance: localizationProvenanceImplementationTarget,
+	}}}
+	current := []localizationDigestRow{{
+		ID: id, Name: "Run", Kind: "method", File: "fixture/worker.go", Line: 21,
+		Callers: []string{"fixture/queue.go::Dispatch", "fixture/app.go::Start"},
+	}}
+
+	merged := mergeLocalizationEvidenceDigest(current, retained)
+	if len(merged.Evidence) != 1 {
+		t.Fatalf("duplicate declaration produced %d rows", len(merged.Evidence))
+	}
+	row := merged.Evidence[0]
+	if row.Signature == "" || row.Provenance != localizationProvenanceImplementationTarget {
+		t.Fatalf("retained declaration metadata was lost: %#v", row)
+	}
+	if got, want := row.Callers, []string{"fixture/queue.go::Dispatch", "fixture/app.go::Start"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("callers = %#v, want %#v", got, want)
+	}
+	if got, want := row.Callees, []string{"fixture/store.go::Store.Flush"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("callees = %#v, want %#v", got, want)
+	}
+}
+
+func TestRecoveryInterceptionCannotInvalidateConcurrentNewUserLocalizeReservation(t *testing.T) {
+	stageReplacement := func(t *testing.T, state *localizationTerminalState) uint64 {
+		t.Helper()
+		state.armForTask(newLocalizationRecoveryCompletion(), "old task")
+		token, blocked := state.beginLocalize("replacement task", true)
+		if token == 0 || blocked != nil {
+			t.Fatalf("replacement reservation = (%d, %#v)", token, blocked)
+		}
+		state.armForTask(newLocalizationCompletion(true, ""), "replacement task")
+		return token
+	}
+	assertReplacementCommitted := func(t *testing.T, state *localizationTerminalState, token uint64) {
+		t.Helper()
+		if !state.finishLocalize(token, true) {
+			t.Fatal("replacement localization was invalidated by recovery interception")
+		}
+		state.mu.Lock()
+		defer state.mu.Unlock()
+		if state.state != localizationStateAnswerReady || state.reservation != nil {
+			t.Fatalf("replacement completion was not committed: state=%q reservation=%#v", state.state, state.reservation)
+		}
+	}
+
+	t.Run("unsupported navigation", func(t *testing.T) {
+		state := newLocalizationTerminalState()
+		token := stageReplacement(t, state)
+		blocked, generation := state.interceptAnswerReady("search", "files", map[string]any{"query": "worker"})
+		if blocked == nil || generation != 0 {
+			t.Fatalf("concurrent unsupported recovery = (%#v, %d), want in-progress block", blocked, generation)
+		}
+		assertReplacementCommitted(t, state, token)
+	})
+
+	t.Run("schema-invalid recovery ticket", func(t *testing.T) {
+		state := newLocalizationTerminalState()
+		state.armForTask(newLocalizationRecoveryCompletion(), "old anchor task")
+		_, generation := state.interceptAnswerReady("search", "text", map[string]any{"query": "old anchor"})
+		if generation == 0 {
+			t.Fatal("valid recovery request did not receive a schema-validation ticket")
+		}
+		token, blocked := state.beginLocalize("replacement task", true)
+		if token == 0 || blocked != nil {
+			t.Fatalf("replacement reservation = (%d, %#v)", token, blocked)
+		}
+		state.armForTask(newLocalizationCompletion(true, ""), "replacement task")
+		if completion, consumed := state.consumeInvalidRecovery("search", "text", generation); consumed || completion.State != localizationStateInactive {
+			t.Fatalf("stale schema ticket consumed replacement reservation: (%#v, %v)", completion, consumed)
+		}
+		assertReplacementCommitted(t, state, token)
+	})
+}
+
+func TestAcceptedEmptyRecoveryReleasesAdvisorySession(t *testing.T) {
+	state := newLocalizationTerminalState()
+	completion := newLocalizationRecoveryCompletion()
+	completion.digest = &localizationEvidenceDigest{Evidence: []localizationDigestRow{{
+		ID: "fixture/storage.go::Commit", File: "fixture/storage.go",
+	}}}
+	state.armForTask(completion, "storage commit stalls")
+
+	blocked, token := state.authorizeWithToken("search", "symbols", map[string]any{"query": "storage"})
+	if blocked != nil || token == 0 {
+		t.Fatalf("recovery authorization = (%#v, %d)", blocked, token)
+	}
+	advisory := state.finishReservedReadTokenWithDigest(token, true, nil, true)
+	if advisory.State != localizationStateLocalized || advisory.AllowedToolCalls != 0 || advisory.Enforceable {
+		t.Fatalf("empty accepted recovery did not return advisory completion: %#v", advisory)
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.state != localizationStateInactive {
+		t.Fatalf("advisory wire completion left session restricted: %q", state.state)
+	}
+}

--- a/internal/mcp/localization_recovery_test.go
+++ b/internal/mcp/localization_recovery_test.go
@@ -171,7 +171,7 @@ func TestRecoveryRejectsDigestOnlyTermFromRG2095Incident(t *testing.T) {
 	}
 }
 
-func TestRecoveryFailureRestoresOnceAndTerminalizesSameResponse(t *testing.T) {
+func TestRecoveryFailureRestoresOnceThenReleasesAdvisory(t *testing.T) {
 	server := setupPresetServer(t, ToolPolicyConfig{Preset: "core", Mode: "defer"})
 	ctx := WithSessionID(context.Background(), "weak_recovery_failure")
 	terminal := server.localizationFor(ctx)
@@ -198,15 +198,14 @@ func TestRecoveryFailureRestoresOnceAndTerminalizesSameResponse(t *testing.T) {
 	if err != nil || second == nil || !second.IsError || calls != 2 {
 		t.Fatalf("second failed recovery = (%#v, %v), calls=%d", second, err, calls)
 	}
-	requireLocalizationResultStateEqual(t, terminal, second, localizationStateAnswerReady, true, 0)
+	requireLocalizationResultStateEqual(t, terminal, second, localizationStateLocalized, false, 0)
 
 	third, err := server.handleFacade(ctx, "search", request)
-	if err != nil {
-		t.Fatalf("post-exhaustion search returned transport error: %v", err)
+	if err == nil || third != nil {
+		t.Fatalf("released navigation did not expose the ordinary handler error: (%#v, %v)", third, err)
 	}
-	requireLocalizationTerminalReplay(t, third, "search", "symbols")
-	if calls != 2 {
-		t.Fatalf("recovery allowance restored more than once: calls=%d", calls)
+	if calls != 3 {
+		t.Fatalf("advisory release kept localization interception active: calls=%d", calls)
 	}
 }
 
@@ -239,29 +238,22 @@ func TestEnforceableAnswerReadyLocksBeforeHandler(t *testing.T) {
 	}
 }
 
-func TestUnsupportedRecoveryAttemptTerminatesBeforeSchemaDispatch(t *testing.T) {
+func TestUnsupportedRecoveryAttemptReleasesAdvisoryBeforeSchemaDispatch(t *testing.T) {
 	server := setupPresetServer(t, ToolPolicyConfig{Preset: "core", Mode: "defer"})
 	ctx := WithSessionID(context.Background(), "unsupported_recovery")
-	server.localizationFor(ctx).armForTask(newLocalizationRecoveryCompletion(), "find candidate resolution")
+	terminal := server.localizationFor(ctx)
+	terminal.armForTask(newLocalizationRecoveryCompletion(), "find candidate resolution")
 
 	result, err := server.handleFacade(ctx, "search", localizationRecoveryRequest("search", "not_an_operation", map[string]any{
 		"query": "resolveCandidate",
 	}))
 	if err != nil || result == nil || !result.IsError {
-		t.Fatalf("unsupported recovery = (%#v, %v), want terminal tool error", result, err)
+		t.Fatalf("unsupported recovery = (%#v, %v), want advisory tool error", result, err)
 	}
-	requireLocalizationTerminalError(t, result, "search", "not_an_operation")
-
-	valid, err := server.handleFacade(ctx, "search", localizationRecoveryRequest("search", "text", map[string]any{
-		"query": "resolveCandidate",
-	}))
-	if err != nil {
-		t.Fatalf("post-rejection recovery returned transport error: %v", err)
-	}
-	requireLocalizationTerminalReplay(t, valid, "search", "text")
+	requireLocalizationResultStateEqual(t, terminal, result, localizationStateLocalized, false, 0)
 }
 
-func TestSchemaInvalidAllowedRecoveryTerminatesBeforeHandler(t *testing.T) {
+func TestSchemaInvalidAllowedRecoveryReleasesAdvisoryBeforeHandler(t *testing.T) {
 	server := setupPresetServer(t, ToolPolicyConfig{Preset: "core", Mode: "defer"})
 	ctx := WithSessionID(context.Background(), "schema_invalid_recovery")
 	terminal := server.localizationFor(ctx)
@@ -281,9 +273,9 @@ func TestSchemaInvalidAllowedRecoveryTerminatesBeforeHandler(t *testing.T) {
 		"options": "not-an-object",
 	}))
 	if err != nil || invalid == nil || !invalid.IsError {
-		t.Fatalf("schema-invalid recovery = (%#v, %v), want terminal tool error", invalid, err)
+		t.Fatalf("schema-invalid recovery = (%#v, %v), want advisory tool error", invalid, err)
 	}
-	requireLocalizationResultStateEqual(t, terminal, invalid, localizationStateAnswerReady, true, 0)
+	requireLocalizationResultStateEqual(t, terminal, invalid, localizationStateLocalized, false, 0)
 	if calls != 0 {
 		t.Fatalf("schema-invalid recovery reached handler: calls=%d", calls)
 	}
@@ -291,12 +283,11 @@ func TestSchemaInvalidAllowedRecoveryTerminatesBeforeHandler(t *testing.T) {
 	valid, err := server.handleFacade(ctx, "search", localizationRecoveryRequest("search", "text", map[string]any{
 		"query": "resolveCandidate",
 	}))
-	if err != nil {
-		t.Fatalf("post-invalid recovery returned transport error: %v", err)
+	if err != nil || valid == nil || valid.IsError {
+		t.Fatalf("released navigation did not reach ordinary handler: (%#v, %v)", valid, err)
 	}
-	requireLocalizationTerminalReplay(t, valid, "search", "text")
-	if calls != 0 {
-		t.Fatalf("recovery allowance survived invalid schema: calls=%d", calls)
+	if calls != 1 {
+		t.Fatalf("advisory release kept schema-invalid recovery interception active: calls=%d", calls)
 	}
 }
 
@@ -324,8 +315,8 @@ func TestStaleInvalidRecoveryTicketCannotConsumeNewTaskState(t *testing.T) {
 		t.Fatalf("new invalid-recovery preflight = (%#v, %d), old generation=%d", blocked, newGeneration, oldGeneration)
 	}
 	completion, consumed := state.consumeInvalidRecovery("search", "text", newGeneration)
-	if !consumed || completion.State != localizationStateAnswerReady {
-		t.Fatalf("current invalid request consumption = (%#v, %v)", completion, consumed)
+	if !consumed || completion.State != localizationStateLocalized || completion.Enforceable {
+		t.Fatalf("current invalid request did not release advisory state: (%#v, %v)", completion, consumed)
 	}
 }
 
@@ -411,64 +402,43 @@ func TestRecoveryEvidenceRejectsGenericCallableWithSignatureOnlyOverlap(t *testi
 	}
 }
 
-func TestRecoveryWeakResultPreservesAllowanceForEveryOperation(t *testing.T) {
+func TestRecoveryWeakResultReleasesAdvisoryForEveryOperation(t *testing.T) {
 	longSink := localizationDigestRow{
-		ID:        "repo/storage/report.go::Reporter.ReportStorageFailureAsPending",
+		ID:        "fixture/storage/report.go::Reporter.ReportStorageFailureAsPending",
 		Name:      "ReportStorageFailureAsPending",
 		QualName:  "Reporter.ReportStorageFailureAsPending",
 		Kind:      "method",
-		File:      "repo/storage/report.go",
+		File:      "fixture/storage/report.go",
 		Signature: "storage writes stall during commit",
 	}
-	implementation := localizationDigestRow{
-		ID:       "repo/storage/flush.go::Storage.Flush",
-		Name:     "StorageFlush",
-		QualName: "Storage.Flush",
-		Kind:     "method",
-		File:     "repo/storage/flush.go",
-	}
 	tests := []struct {
-		name           string
-		facade         string
-		operation      string
-		arguments      map[string]any
-		retryArguments map[string]any
+		name      string
+		facade    string
+		operation string
+		arguments map[string]any
 	}{
-		{
-			name: "text search", facade: "search", operation: "text",
-			arguments: map[string]any{"query": "storage"}, retryArguments: map[string]any{"query": "storage"},
-		},
-		{
-			name: "symbol search", facade: "search", operation: "symbols",
-			arguments: map[string]any{"query": "storage"}, retryArguments: map[string]any{"query": implementation.Name},
-		},
-		{
-			name: "source read", facade: "read", operation: "source",
-			arguments:      map[string]any{"target": map[string]any{"symbol": longSink.ID}},
-			retryArguments: map[string]any{"target": map[string]any{"symbol": implementation.ID}},
-		},
+		{name: "text search", facade: "search", operation: "text", arguments: map[string]any{"query": "storage"}},
+		{name: "symbol search", facade: "search", operation: "symbols", arguments: map[string]any{"query": "storage"}},
+		{name: "source read", facade: "read", operation: "source", arguments: map[string]any{"target": map[string]any{"symbol": longSink.ID}}},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			state := newLocalizationTerminalState()
 			state.armForTask(newLocalizationRecoveryCompletion(), "Storage writes stall during commit")
 
-			blocked, token := state.authorizeWithToken(tt.facade, tt.operation, tt.arguments)
+			blocked, token := state.authorizeWithToken(test.facade, test.operation, test.arguments)
 			if blocked != nil || token == 0 {
-				t.Fatalf("first recovery authorization = (%#v, %d)", blocked, token)
+				t.Fatalf("recovery authorization = (%#v, %d)", blocked, token)
 			}
 			completion := state.finishReservedReadTokenWithDigest(token, true, []localizationDigestRow{longSink}, true)
-			if completion.State != localizationStateNeedsRecovery || completion.AllowedToolCalls != 1 {
-				t.Fatalf("weak recovery completion = %#v, want preserved allowance", completion)
+			if completion.State != localizationStateLocalized || completion.AllowedToolCalls != 0 || completion.Enforceable {
+				t.Fatalf("weak accepted recovery did not release advisory completion: %#v", completion)
 			}
-
-			blocked, retryToken := state.authorizeWithToken(tt.facade, tt.operation, tt.retryArguments)
-			if blocked != nil || retryToken == 0 {
-				t.Fatalf("retry recovery authorization = (%#v, %d)", blocked, retryToken)
-			}
-			completion = state.finishReservedReadTokenWithDigest(retryToken, true, []localizationDigestRow{implementation}, true)
-			if completion.State != localizationStateAnswerReady || completion.AllowedToolCalls != 0 {
-				t.Fatalf("strong recovery completion = %#v, want answer_ready", completion)
+			state.mu.Lock()
+			storedState := state.state
+			state.mu.Unlock()
+			if storedState != localizationStateInactive {
+				t.Fatalf("weak accepted recovery left session restricted: %q", storedState)
 			}
 		})
 	}
@@ -589,7 +559,7 @@ func TestPlannedRecoveryReplaceFamilyRegression(t *testing.T) {
 	}
 }
 
-func TestPlannedRecoveryIsExactRetriableAndFallsBackToGeneric(t *testing.T) {
+func TestPlannedRecoveryIsExactRetriableAndWeakResultReleasesAdvisory(t *testing.T) {
 	task := "Printed records are duplicated unexpectedly\ncombining --multiline with --replace while --only-matching spans lines"
 	preferred := "crates/searcher/src/sink.rs::sink_slow_multi_line_only_matching"
 	current := []localizationDigestRow{{
@@ -666,14 +636,13 @@ func TestPlannedRecoveryIsExactRetriableAndFallsBackToGeneric(t *testing.T) {
 		Name: "replace_with_captures", Kind: "method", File: "crates/searcher/src/glue.rs",
 	}}
 	completion = state.finishReservedReadTokenWithDigest(token, true, weak, true)
-	generic := newLocalizationRecoveryCompletion()
-	if completion.RequiredAction != generic.RequiredAction || completion.Instruction != generic.Instruction ||
-		len(completion.AllowedOperations) != len(generic.AllowedOperations) {
-		t.Fatalf("weak planned result did not fall back to generic recovery: %#v", completion)
+	if completion.State != localizationStateLocalized || completion.RequiredAction != "continue_task" ||
+		completion.AllowedToolCalls != 0 || completion.Enforceable {
+		t.Fatalf("weak planned result did not release an advisory completion: %#v", completion)
 	}
 }
 
-func TestPlannedRecoveryEmptyResultFallsBackToGeneric(t *testing.T) {
+func TestPlannedRecoveryEmptyResultReleasesAdvisory(t *testing.T) {
 	state := newLocalizationTerminalState()
 	state.armForTask(newLocalizationPlannedRecoveryCompletion("search.symbols", "transform_with"), "--multi-line with --transform duplicates output")
 	blocked, token := state.authorizeWithToken("search", "symbols", map[string]any{"query": "transform_with"})
@@ -681,10 +650,9 @@ func TestPlannedRecoveryEmptyResultFallsBackToGeneric(t *testing.T) {
 		t.Fatalf("planned recovery authorization = (%#v, %d)", blocked, token)
 	}
 	completion := state.finishReservedReadTokenWithDigest(token, true, nil, true)
-	generic := newLocalizationRecoveryCompletion()
-	if completion.State != localizationStateNeedsRecovery || completion.RequiredAction != generic.RequiredAction ||
-		completion.Instruction != generic.Instruction || len(completion.AllowedOperations) != len(generic.AllowedOperations) {
-		t.Fatalf("empty planned result did not fall back to generic recovery: %#v", completion)
+	if completion.State != localizationStateLocalized || completion.RequiredAction != "continue_task" ||
+		completion.AllowedToolCalls != 0 || completion.Enforceable {
+		t.Fatalf("empty planned result did not release an advisory completion: %#v", completion)
 	}
 }
 
@@ -738,7 +706,13 @@ func requireLocalizationResultStateEqual(
 	stored := state.completionLocked()
 	state.mu.Unlock()
 	requireLocalizationCompletionJSONEqual(t, wire, host.Contract.Completion, "wire/meta")
-	requireLocalizationCompletionJSONEqual(t, wire, stored, "wire/state")
+	if wantState == localizationStateLocalized {
+		if stored.State != localizationStateInactive {
+			t.Fatalf("localized advisory did not release session state: %#v", stored)
+		}
+	} else {
+		requireLocalizationCompletionJSONEqual(t, wire, stored, "wire/state")
+	}
 	if host.Contract.Terminal != wantTerminal {
 		t.Fatalf("host terminal = %v, want %v", host.Contract.Terminal, wantTerminal)
 	}

--- a/internal/mcp/localization_refinement_route_test.go
+++ b/internal/mcp/localization_refinement_route_test.go
@@ -338,11 +338,9 @@ func TestGenericCorrectionSharesOneRetryAcrossRouteHops(t *testing.T) {
 
 	requireRefinementSourceReservation(t, state, implementation)
 	completion = state.finishReservedRead(false)
-	requireRefinementCompletion(t, completion, localizationStateAnswerReady, "", 0)
-	if result, reserved := state.authorize("read", "source", refinementSourceArgs(implementation)); reserved {
-		t.Fatal("implementation hop received a second route-level retry")
-	} else {
-		requireLocalizationTerminalReplay(t, result, "read", "source")
+	requireRefinementCompletion(t, completion, localizationStateLocalized, "", 0)
+	if result, reserved := state.authorize("read", "source", refinementSourceArgs(implementation)); reserved || result != nil {
+		t.Fatalf("advisory release kept route authorization active: (%#v, %v)", result, reserved)
 	}
 }
 
@@ -371,11 +369,9 @@ func TestInitialRefinementFailureRestoresOnlyOnce(t *testing.T) {
 
 	requireRefinementSourceReservation(t, state, preferred)
 	completion = state.finishReservedRead(false)
-	requireRefinementCompletion(t, completion, localizationStateAnswerReady, "", 0)
-	if result, reserved := state.authorize("read", "source", refinementSourceArgs(preferred)); reserved {
-		t.Fatal("initial refinement failure restored more than once")
-	} else {
-		requireLocalizationTerminalReplay(t, result, "read", "source")
+	requireRefinementCompletion(t, completion, localizationStateLocalized, "", 0)
+	if result, reserved := state.authorize("read", "source", refinementSourceArgs(preferred)); reserved || result != nil {
+		t.Fatalf("advisory release kept refinement authorization active: (%#v, %v)", result, reserved)
 	}
 }
 
@@ -420,11 +416,9 @@ func TestWeakCorrectionFailureRestoresOnlyOnce(t *testing.T) {
 		t.Fatalf("restored correction read = (%+v, %d), want reservation", blocked, token)
 	}
 	completion = state.finishReservedReadToken(token, false)
-	requireRefinementCompletion(t, completion, localizationStateAnswerReady, "", 0)
-	if result, reserved := state.authorize("read", "source", refinementSourceArgs(alternate)); reserved {
-		t.Fatal("correction was restored more than once")
-	} else {
-		requireLocalizationTerminalReplay(t, result, "read", "source")
+	requireRefinementCompletion(t, completion, localizationStateLocalized, "", 0)
+	if result, reserved := state.authorize("read", "source", refinementSourceArgs(alternate)); reserved || result != nil {
+		t.Fatalf("advisory release kept correction authorization active: (%#v, %v)", result, reserved)
 	}
 }
 

--- a/internal/mcp/localization_terminal.go
+++ b/internal/mcp/localization_terminal.go
@@ -566,7 +566,15 @@ func (s *localizationTerminalState) releaseLocalizationAdvisoryLocked(
 		digest = s.digest
 	}
 	taskLead := s.taskLead
-	s.commitLocalizationLocked(newLocalizationOpenCompletion(), "")
+	// Releasing commits, and committing bumps the generation. A localize that
+	// is already in flight staged its contract against the generation it
+	// reserved, so bumping here would make finishLocalize discard the newer
+	// request in favour of this finishing call's advisory state. The reserved
+	// localize owns the session's next contract; leave the state for it to
+	// replace and return the advisory page for this response only.
+	if s.reservation == nil {
+		s.commitLocalizationLocked(newLocalizationOpenCompletion(), "")
+	}
 	completion := newLocalizationAdvisoryCompletion()
 	completion.taskLead = taskLead
 	completion.digest = digest

--- a/internal/mcp/localization_terminal.go
+++ b/internal/mcp/localization_terminal.go
@@ -182,6 +182,21 @@ func newLocalizationSingleResultCompletion() localizationCompletion {
 	}
 }
 
+// newLocalizationAdvisoryCompletion closes the bounded localization workflow
+// without converting missing, weak, or failed evidence into answer_ready. The
+// wire response keeps its provisional candidate page, while armForTask treats
+// localized as inactive so later coding and navigation work remains available.
+func newLocalizationAdvisoryCompletion() localizationCompletion {
+	return localizationCompletion{
+		State:            localizationStateLocalized,
+		Scope:            "localization",
+		RequiredAction:   "continue_task",
+		Instruction:      "The bounded localization workflow ended without enough declaration-backed evidence for a confident answer. Treat the retained candidates as provisional and continue the task; navigation is no longer restricted by this localization request.",
+		AllowedToolCalls: 0,
+		ContractVersion:  localizationTerminalContractV2,
+	}
+}
+
 func newLocalizationExactReadCompletion(exactSymbol string, correction bool) localizationCompletion {
 	instruction := fmt.Sprintf(`Call Gortex MCP read(operation:"source", target:{symbol:%q}); then respond.`, exactSymbol)
 	if correction {
@@ -490,6 +505,11 @@ func (s *localizationTerminalState) commitLocalizationLocked(completion localiza
 	if completion.State == localizationStateNeedsRecovery {
 		s.recoveryRetriesRemaining = 1
 	}
+	if completion.State == localizationStateNeedsExactRead {
+		// A handler failure may be transient, but the exact-read contract must
+		// remain bounded. One retry is shared by ordinary and corrective reads.
+		s.correctionRetriesRemaining = 1
+	}
 	s.taskFingerprint = fingerprint
 	s.taskLead = completion.taskLead
 	// The digest follows the contract: an inactive commit (keepOpenForTask)
@@ -534,6 +554,25 @@ func (s *localizationTerminalState) completionLocked() localizationCompletion {
 	return localizationCompletionWithDigest(completion, s.digest)
 }
 
+// releaseLocalizationAdvisoryLocked returns the retained candidates as an
+// explicitly provisional wire page and atomically releases the session's
+// localization authorization. Callers hold s.mu. Missing evidence, a weak
+// recovery, or an exhausted handler retry can end the bounded workflow, but it
+// cannot manufacture answer_ready confidence.
+func (s *localizationTerminalState) releaseLocalizationAdvisoryLocked(
+	digest *localizationEvidenceDigest,
+) localizationCompletion {
+	if digest == nil {
+		digest = s.digest
+	}
+	taskLead := s.taskLead
+	s.commitLocalizationLocked(newLocalizationOpenCompletion(), "")
+	completion := newLocalizationAdvisoryCompletion()
+	completion.taskLead = taskLead
+	completion.digest = digest
+	return localizationCompletionWithDigest(completion, digest)
+}
+
 // interceptAnswerReady is the cheap pre-validation gate used by facade
 // dispatch. It makes localization terminality independent of operation
 // validity, and consumes an unsupported advisory recovery attempt before a
@@ -545,6 +584,9 @@ func (s *localizationTerminalState) interceptAnswerReady(facade, operation strin
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.reservation != nil {
+		return localizationInProgressResult(), 0
+	}
 	switch s.state {
 	case localizationStateAnswerReady:
 		return localizationTerminalResult(s.completionLocked(), facade, operation), 0
@@ -563,9 +605,8 @@ func (s *localizationTerminalState) interceptAnswerReady(facade, operation strin
 			// better evidence instead of terminalizing the localization session.
 			return localizationRecoveryMisalignedResult(s.completionLocked(), facade, operation), 0
 		}
-		s.state = localizationStateAnswerReady
-		s.recoveryRetriesRemaining = 0
-		return localizationRecoveryRejectedResult(s.completionLocked(), facade, operation), 0
+		completion := s.releaseLocalizationAdvisoryLocked(nil)
+		return localizationRecoveryRejectedResult(completion, facade, operation), 0
 	default:
 		return nil, 0
 	}
@@ -1182,12 +1223,10 @@ func (s *localizationTerminalState) consumeInvalidRecovery(facade, operation str
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.state != localizationStateNeedsRecovery || s.generation != generation {
+	if s.reservation != nil || s.state != localizationStateNeedsRecovery || s.generation != generation {
 		return newLocalizationOpenCompletion(), false
 	}
-	s.state = localizationStateAnswerReady
-	s.recoveryRetriesRemaining = 0
-	return s.completionLocked(), true
+	return s.releaseLocalizationAdvisoryLocked(nil), true
 }
 
 func localizationPlannedRecoveryMismatchResult(completion localizationCompletion, facade, operation string) *mcpgo.CallToolResult {
@@ -1219,17 +1258,22 @@ func localizationRecoveryMisalignedResult(completion localizationCompletion, fac
 }
 
 func localizationRecoveryRejectedResult(completion localizationCompletion, facade, operation string) *mcpgo.CallToolResult {
+	contract := localizationContractFor(completion)
 	result := newStructuredErrorResult(StructuredError{
-		ErrorCode: ErrCodeLocalizationTerminal,
-		Message:   "the one bounded localization recovery call must be search.text or search.symbols with a task-aligned query, or read.source with a concrete symbol; localization is now terminal",
+		ErrorCode: ErrCodeLocalizationComplete,
+		Message:   "the bounded localization recovery call was not valid; no confident answer was inferred, retained candidates remain provisional, and localization navigation is released",
 		Retriable: false,
 		Data: map[string]any{
-			"contract":           localizationContractFor(completion),
+			"contract":           contract,
 			"facade":             facade,
 			"operation":          operation,
 			"allowed_operations": append([]string(nil), localizationRecoveryOperations...),
 		},
 	}, true)
+	// This is a synthetic localization response, not an underlying tool payload.
+	// Project the advisory contract on the structured wire as well as metadata so
+	// hosts that prefer structured content observe the same released state.
+	result.StructuredContent = localizationTerminalStructuredContent(nil, contract)
 	return attachLocalizationHostEnvelope(result, completion, completion.digest)
 }
 
@@ -1255,9 +1299,8 @@ func (s *localizationTerminalState) beginLocalize(task string, newUserTask bool)
 	if s.state != localizationStateInactive && !newUserTask {
 		completion := s.completionLocked()
 		if s.state == localizationStateNeedsRecovery {
-			s.state = localizationStateAnswerReady
-			s.recoveryRetriesRemaining = 0
-			return 0, localizationRecoveryRejectedResult(s.completionLocked(), "explore", "localize")
+			completion = s.releaseLocalizationAdvisoryLocked(nil)
+			return 0, localizationRecoveryRejectedResult(completion, "explore", "localize")
 		}
 		// A repeat localize against a terminal contract gets the same compact,
 		// typed non-retriable signal as every other post-terminal navigation
@@ -1393,9 +1436,8 @@ func (s *localizationTerminalState) authorizeWithToken(facade, operation string,
 		if localizationRecoveryAllows(facade, operation, arguments) {
 			return localizationRecoveryMisalignedResult(s.completionLocked(), facade, operation), 0
 		}
-		s.state = localizationStateAnswerReady
-		s.recoveryRetriesRemaining = 0
-		return localizationRecoveryRejectedResult(s.completionLocked(), facade, operation), 0
+		completion := s.releaseLocalizationAdvisoryLocked(nil)
+		return localizationRecoveryRejectedResult(completion, facade, operation), 0
 	}
 	if s.state == localizationStateNeedsExactRead && facade == "read" && operation == "source" && exactLocalizationSymbol(arguments) == s.exactSymbol {
 		s.inFlightImplementationSymbol = s.exactReadRoute.implementationSymbol
@@ -1530,7 +1572,6 @@ func (s *localizationTerminalState) finishReservedReadTokenInternal(
 	case localizationStateRecoveryInFlight:
 		requested := s.inFlightRecoveryAnchor
 		operation := s.inFlightRecoveryOperation
-		plannedRecovery := s.localizationRecoveryPlannedLocked()
 		s.inFlightRecoveryAnchor = ""
 		s.inFlightRecoveryOperation = ""
 		legacyRecovery := !captureRequired || (wireSuccess && !evidenceRecorded) ||
@@ -1544,26 +1585,19 @@ func (s *localizationTerminalState) finishReservedReadTokenInternal(
 			s.recoveryRetriesRemaining = 0
 			return s.completionLocked()
 		}
-		if success || (plannedRecovery && zeroResult) {
-			// A successful but structurally weak page is not an accepted recovery.
-			// A planned weak or empty page clears only the plan and returns to the
-			// byte-identical generic recovery contract with its allowance intact.
-			if plannedRecovery {
-				s.recoveryOperation = ""
-				s.recoveryAnchor = ""
-			}
-			s.state = localizationStateNeedsRecovery
-			return s.completionLocked()
+		if wireSuccess {
+			// The one accepted recovery call completed but did not prove a
+			// declaration aligned with the task. Preserve everything it surfaced,
+			// then release the contract as advisory instead of opening a loop or
+			// manufacturing terminal confidence.
+			return s.releaseLocalizationAdvisoryLocked(mergedDigest)
 		}
 		if s.recoveryRetriesRemaining > 0 {
 			s.recoveryRetriesRemaining--
 			s.state = localizationStateNeedsRecovery
 			return s.completionLocked()
 		}
-		s.recoveryOperation = ""
-		s.recoveryAnchor = ""
-		s.state = localizationStateAnswerReady
-		return s.completionLocked()
+		return s.releaseLocalizationAdvisoryLocked(nil)
 	case localizationStateExactReadInFlight:
 		implementationSymbol := s.inFlightImplementationSymbol
 		routeEnforceable := s.inFlightEnforceable
@@ -1598,20 +1632,12 @@ func (s *localizationTerminalState) finishReservedReadTokenInternal(
 			return s.completionLocked()
 		}
 		s.enforceableOnAnswerReady = false
-		if s.exactReadIsCorrection {
-			if s.correctionRetriesRemaining > 0 {
-				s.correctionRetriesRemaining--
-				s.state = localizationStateNeedsExactRead
-				return s.completionLocked()
-			}
-			s.state = localizationStateAnswerReady
-			s.exactSymbol = ""
-			s.exactReadIsCorrection = false
-			s.exactReadRoute = localizationRefinementRoute{}
-			s.correctionRetriesRemaining = 0
+		if s.correctionRetriesRemaining > 0 {
+			s.correctionRetriesRemaining--
+			s.state = localizationStateNeedsExactRead
 			return s.completionLocked()
 		}
-		s.state = localizationStateNeedsExactRead
+		return s.releaseLocalizationAdvisoryLocked(nil)
 	case localizationStateRefineInFlight:
 		confidentRead := capturedResult && mergedDigest != nil && len(mergedDigest.Evidence) > 0 &&
 			localizationReservedReadEvidenceAlignedWithLead(s.taskFingerprint, s.taskLead, s.refinementSymbol, currentEvidence)
@@ -1669,12 +1695,7 @@ func (s *localizationTerminalState) finishReservedReadTokenInternal(
 			s.state = localizationStateNeedsRefinement
 			return s.completionLocked()
 		}
-		s.state = localizationStateAnswerReady
-		s.refinementSymbol = ""
-		s.refinementSymbols = nil
-		s.refinementRoutes = nil
-		s.correctionSymbol = ""
-		s.correctionRoute = localizationRefinementRoute{}
+		return s.releaseLocalizationAdvisoryLocked(nil)
 	}
 	return s.completionLocked()
 }

--- a/internal/mcp/localization_terminal_evidence_v8_test.go
+++ b/internal/mcp/localization_terminal_evidence_v8_test.go
@@ -142,11 +142,15 @@ func TestLocalizationDirectRelationsRequireRelevantOrProvenRoute(t *testing.T) {
 			implementation.ID: {proofSymbol: wrapper.ID, enforceable: true},
 		}
 		got := interleaveLocalizationDirectRelationsWithRoutes(task, "", targets, routes)
-		want := []string{wrapper.ID, implementation.ID, targets[1].node.ID, targets[2].node.ID}
-		for index, id := range want {
-			if got[index].node.ID != id {
-				t.Fatalf("proven route row %d = %q, want %q", index+1, got[index].node.ID, id)
+		// All four direct candidates fit inside the authorization floor, so the
+		// proven implementation stays visible without displacing their ranking.
+		for index, target := range targets {
+			if got[index].node.ID != target.node.ID {
+				t.Fatalf("proven route changed protected direct row %d: got %q want %q", index+1, got[index].node.ID, target.node.ID)
 			}
+		}
+		if got[len(got)-1].node.ID != implementation.ID {
+			t.Fatalf("proven implementation was not retained: %#v", got)
 		}
 	})
 
@@ -250,19 +254,23 @@ func TestRecoveryAllowsInferredConcreteIdentifierOnlyForScopedSymbolEvidence(t *
 		t.Fatalf("inferred exact identifier authorization = (%#v, %d)", blocked, firstToken)
 	}
 	zero := state.finishReservedReadTokenWithDigest(firstToken, true, nil, true)
-	if zero.State != localizationStateNeedsRecovery || zero.AllowedToolCalls != 1 || zero.digest != retained {
-		t.Fatalf("empty typed page consumed recovery: %#v", zero)
+	if zero.State != localizationStateLocalized || zero.AllowedToolCalls != 0 || zero.Enforceable {
+		t.Fatalf("empty typed page did not release an advisory completion: %#v", zero)
 	}
 
-	blocked, secondToken := state.authorizeWithToken("search", "symbols", args)
-	if blocked != nil || secondToken == 0 || secondToken == firstToken {
-		t.Fatalf("restored exact identifier authorization = (%#v, %d)", blocked, secondToken)
+	positiveState := newLocalizationTerminalState()
+	positiveCompletion := newLocalizationRecoveryCompletion()
+	positiveCompletion.digest = retained
+	positiveState.armForTask(positiveCompletion, "investigate registry configuration behavior")
+	blocked, secondToken := positiveState.authorizeWithToken("search", "symbols", args)
+	if blocked != nil || secondToken == 0 {
+		t.Fatalf("fresh exact identifier authorization = (%#v, %d)", blocked, secondToken)
 	}
 	captureCtx := withLocalizationPermittedEvidenceCapture(context.Background(), secondToken)
 	node := localizationV8Node("repo/policy.go::DerivedPolicy.ApplyRule", "ApplyRule", "repo/policy.go")
 	captureLocalizationSearchSymbols(captureCtx, []*graph.Node{node})
 	rows, recorded := localizationEvidenceForPermittedCall(captureCtx, "search", "symbols", secondToken)
-	ready := state.finishReservedReadTokenWithDigest(secondToken, true, rows, recorded)
+	ready := positiveState.finishReservedReadTokenWithDigest(secondToken, true, rows, recorded)
 	if ready.State != localizationStateAnswerReady || ready.digest == nil || ready.digest.Evidence[0].ID != node.ID {
 		t.Fatalf("nonempty typed symbol page did not terminalize current-first: %#v", ready)
 	}
@@ -575,7 +583,13 @@ func TestFacadeAuthArgumentIsStrippedAndPublishesTypedTerminalReceipts(t *testin
 	errorArgs := map[string]any{"operation": "unsupported_operation", "query": "Registry.Configure", localizationauth.ArgumentKey: errorToken}
 	terminalError, err := server.handleFacade(errorCtx, "search", mcpgo.CallToolRequest{Params: mcpgo.CallToolParams{Name: "search", Arguments: errorArgs}})
 	if err != nil || terminalError == nil || !terminalError.IsError {
-		t.Fatalf("authenticated terminal error = (%#v, %v)", terminalError, err)
+		t.Fatalf("authenticated advisory rejection = (%#v, %v)", terminalError, err)
 	}
-	requireReceipt(t, errorToken, terminalError)
+	if _, published := localizationauth.Consume(errorToken); published {
+		t.Fatal("unproven advisory rejection published a terminal receipt")
+	}
+	host, ok := terminalError.Meta.AdditionalFields[localizationHostMetaKey].(localizationHostEnvelope)
+	if !ok || host.Contract.Terminal || host.Contract.Completion.State != localizationStateLocalized {
+		t.Fatalf("advisory rejection host contract = %#v", terminalError.Meta)
+	}
 }

--- a/internal/mcp/localization_terminal_test.go
+++ b/internal/mcp/localization_terminal_test.go
@@ -674,7 +674,7 @@ func TestHandleFacadeExactReadCommitsOnlyOnSuccess(t *testing.T) {
 	requireLocalizationTerminalReplay(t, fourth, "read", "source")
 }
 
-func TestHandleFacadeExhaustedCorrectionFailureCarriesTerminalCompletion(t *testing.T) {
+func TestHandleFacadeExhaustedCorrectionFailureCarriesAdvisoryCompletion(t *testing.T) {
 	registry := newFacadeRegistry()
 	preferred := "repo/pkg/find.go::Find"
 	alternate := "repo/pkg/resolve.go::Resolve"
@@ -732,17 +732,12 @@ func TestHandleFacadeExhaustedCorrectionFailureCarriesTerminalCompletion(t *test
 	}
 	thirdBody, _ := singleTextContent(third)
 	if !strings.Contains(thirdBody, "persistent correction failure") ||
-		!strings.Contains(thirdBody, `"state":"answer_ready"`) ||
-		!strings.Contains(thirdBody, `"required_action":"respond"`) ||
-		!strings.Contains(thirdBody, `"terminal":true`) {
-		t.Fatalf("exhausted failure omitted terminal completion: %q", thirdBody)
+		!strings.Contains(thirdBody, `"state":"localized"`) ||
+		!strings.Contains(thirdBody, `"required_action":"continue_task"`) ||
+		!strings.Contains(thirdBody, `"terminal":false`) {
+		t.Fatalf("exhausted failure omitted advisory completion: %q", thirdBody)
 	}
 	requireFacadeIdentity(t, third, facadeOperationSpec{Facade: "read", Operation: "source", Legacy: "get_symbol_source"})
-	if blocked, err := read(alternate); err != nil {
-		t.Fatalf("post-terminal read returned transport error: %v", err)
-	} else {
-		requireLocalizationTerminalReplay(t, blocked, "read", "source")
-	}
 }
 
 func TestDecorateExhaustedLocalizationReadFailureKeepsErrorAndFacadeIdentity(t *testing.T) {

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -1223,6 +1223,14 @@ func exploreLocalizationCompletion(
 	return newLocalizationCompletion(answerReady, exactSymbol)
 }
 
+// exploreLocalizationUsesConceptRefinement distinguishes an anchor mentioned as
+// evidence inside prose from a compact lookup target. A graph-proven causal
+// identity remains exact because its exclusivity comes from a complete route,
+// not merely from text that happened to contain a declaration name.
+func exploreLocalizationUsesConceptRefinement(answerReady bool, task, exactSymbol, causalExactSymbol string) bool {
+	return !answerReady && causalExactSymbol == "" && exactSymbol != "" && exploreQueryIsConceptTask(task)
+}
+
 // exploreAnswerReady decides whether the ranked head is strong enough to end
 // localization. A result is terminal only when its symbols visibly align with
 // the shaped query; rank alone is not enough because broad review/audit prompts
@@ -2623,18 +2631,30 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 	// an issue author's downstream symbol anchor. Read that proven constructor,
 	// while retaining the explicitly named consumer immediately after it in the
 	// evidence projection.
-	if causalSymbol := exploreDivergentDefaultOwnerSymbol(symbolTargets); causalSymbol != "" {
-		exactSymbol = causalSymbol
+	causalExactSymbol := exploreDivergentDefaultOwnerSymbol(symbolTargets)
+	if causalExactSymbol != "" {
+		exactSymbol = causalExactSymbol
 	}
-	if !answerReady && exactSymbol == "" {
+	// An identifier embedded in a natural-language concept task is evidence, not
+	// an exclusivity instruction. Keep compact path/symbol/signature lookups as
+	// exact reads, but let concept tasks choose among the full bounded candidate
+	// window with the explicit declaration as their preferred seed.
+	conceptAnchor := exploreLocalizationUsesConceptRefinement(answerReady, task, exactSymbol, causalExactSymbol)
+	if !answerReady && (exactSymbol == "" || conceptAnchor) {
 		// Uncertain localization is still useful evidence. Returning it as an
 		// MCP error makes hosts discard the ranked candidates and restart broad
 		// exploration, multiplying turns and payloads. Name one concrete ranked
 		// target for the only permitted refinement read; source-literal evidence
 		// wins because it is absent from ordinary symbol metadata.
 		routes := exploreLocalizationRefinementRoutes(symbolTargets)
+		preferred := explorePreferredRefinementSymbol(task, symbolTargets)
+		if conceptAnchor {
+			if _, authorized := routes[exactSymbol]; authorized {
+				preferred = exactSymbol
+			}
+		}
 		preferredSymbol := explorePreferredRoutedRefinementSymbol(
-			explorePreferredRefinementSymbol(task, symbolTargets), symbolTargets, routes,
+			preferred, symbolTargets, routes,
 		)
 		result, refinement, boundedRoutes, digest := buildLocalizationRefinementResultForTask(
 			preferredSymbol, task, targets, budget, routes,
@@ -3189,7 +3209,7 @@ func localizationEvidenceTargetsFromDraft(task, exactID string, targets []explor
 
 const (
 	localizationDirectRelationSourceLimit = 5
-	localizationDirectEvidenceReserve     = 3
+	localizationDirectEvidenceReserve     = localizationRefinementAllowedSymbolCap
 )
 
 // interleaveLocalizationDirectRelations promotes one already-hydrated direct
@@ -3793,12 +3813,11 @@ func buildLocalizationExploreResultForTaskFinalized(
 	envelope.Completion = contract.Completion
 	envelope.Terminal = contract.Terminal
 	digest := newLocalizationEvidenceDigestForTask(task, envelope)
-	envelope.Completion = localizationCompletionBoundedByDigest(envelope.Completion, digest)
 	// The serialized completion, returned state, structuredContent, and host
-	// metadata must carry the same final_response. Build the digest first, then
-	// enrich the one completion value before any wire representation is made.
-	envelope.Completion = localizationCompletionWithDigest(envelope.Completion, digest)
-	contract = localizationContractFor(envelope.Completion)
+	// metadata must be derived from the exact retained rows. This same helper is
+	// called again after any later byte shedding so authorization cannot outlive
+	// its identity or proof dependency.
+	contract = localizationContractReconciledWithDigest(envelope.Completion, digest)
 	envelope.Completion = contract.Completion
 	envelope.Terminal = contract.Terminal
 	// The ready-to-emit answer is derived from the retained rows, so it lands
@@ -3817,7 +3836,9 @@ func buildLocalizationExploreResultForTaskFinalized(
 			digest.Evidence = digest.Evidence[:len(digest.Evidence)-1]
 			rebuildLocalizationDigestSkeleton(digest)
 			refreshLocalizationDigestResponses(digest, task, nil)
-			envelope.Completion = localizationCompletionWithDigest(envelope.Completion, digest)
+			contract = localizationContractReconciledWithDigest(envelope.Completion, digest)
+			envelope.Completion = contract.Completion
+			envelope.Terminal = contract.Terminal
 			continue
 		}
 		shed := -1

--- a/internal/parser/languages/func_range_test.go
+++ b/internal/parser/languages/func_range_test.go
@@ -1,0 +1,50 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+)
+
+func TestFindEnclosingFuncChoosesDeepestDeclaredCallable(t *testing.T) {
+	result := &parser.ExtractionResult{Nodes: []*graph.Node{
+		// Deliberately not in lexical order: extraction order is language- and
+		// query-dependent and must not decide ownership.
+		{ID: "fixture.go::outer#closure@+9", Kind: graph.KindClosure, StartLine: 9, EndLine: 12},
+		{ID: "fixture.go::outer", Kind: graph.KindFunction, StartLine: 1, EndLine: 30},
+		{ID: "fixture.go::inner", Kind: graph.KindFunction, StartLine: 5, EndLine: 20},
+	}}
+	ranges := buildFuncRanges(result)
+	if len(ranges) != 2 {
+		t.Fatalf("line-only callable ranges included an ambiguous closure: %#v", ranges)
+	}
+
+	for _, test := range []struct {
+		name string
+		line int
+		want string
+	}{
+		{name: "outer body", line: 2, want: "fixture.go::outer"},
+		{name: "nested function", line: 6, want: "fixture.go::inner"},
+		{name: "closure declaration line remains with declared owner", line: 9, want: "fixture.go::inner"},
+		{name: "closure body remains with declared owner", line: 10, want: "fixture.go::inner"},
+		{name: "after nested function", line: 25, want: "fixture.go::outer"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := findEnclosingFunc(ranges, test.line); got != test.want {
+				t.Fatalf("findEnclosingFunc(line=%d) = %q, want %q", test.line, got, test.want)
+			}
+		})
+	}
+}
+
+func TestFindEnclosingFuncTieIsDeterministic(t *testing.T) {
+	ranges := []funcRange{
+		{id: "fixture.go::zeta", startLine: 4, endLine: 8},
+		{id: "fixture.go::alpha", startLine: 4, endLine: 8},
+	}
+	if got := findEnclosingFunc(ranges, 6); got != "fixture.go::alpha" {
+		t.Fatalf("equal-span owner = %q, want lexical identity tie-break", got)
+	}
+}

--- a/internal/parser/languages/golang.go
+++ b/internal/parser/languages/golang.go
@@ -2484,13 +2484,33 @@ func buildFuncRanges(result *parser.ExtractionResult) []funcRange {
 	return ranges
 }
 
+// findEnclosingFunc returns the deepest declared function or method covering
+// line. Parser emission order is not a scope order, so nested declarations are
+// selected by span with a stable identity tie-break. Closures are deliberately
+// excluded from buildFuncRanges: line-only references cannot distinguish an
+// outer registration call from an inner same-line closure call; extractors that
+// retain AST positions must resolve those through syntax ancestry instead.
 func findEnclosingFunc(ranges []funcRange, line int) string {
+	bestID := ""
+	bestStart := -1
+	bestSpan := int(^uint(0) >> 1)
 	for _, r := range ranges {
-		if line >= r.startLine && line <= r.endLine {
-			return r.id
+		if line < r.startLine || line > r.endLine {
+			continue
+		}
+		span := r.endLine - r.startLine
+		if span < 0 {
+			continue
+		}
+		if bestID == "" || span < bestSpan ||
+			(span == bestSpan && r.startLine > bestStart) ||
+			(span == bestSpan && r.startLine == bestStart && r.id < bestID) {
+			bestID = r.id
+			bestStart = r.startLine
+			bestSpan = span
 		}
 	}
-	return ""
+	return bestID
 }
 
 // splitReceiverFields splits a receiver's text on top-level whitespace

--- a/internal/parser/languages/helpers_macro.go
+++ b/internal/parser/languages/helpers_macro.go
@@ -41,6 +41,21 @@ var cKeywordsInMacroBody = map[string]bool{
 // ordinary call_expression and already resolves against the macro by
 // name, so caller -> macro -> body-call forms a two-hop path through the
 // expansion.
+// macroEndLine reports the 1-based line that last carries the definition's
+// source. A preprocessor definition is terminated by its newline, and the
+// grammar includes that newline in the node, so tree-sitter reports the end
+// point at column 0 of the following row. Converting that row directly would
+// extend the macro over the next declaration: a one-line `#define` above a
+// function would own the function's own signature line, and every enclosing
+// -symbol lookup on that line would answer with the macro.
+func macroEndLine(defNode *sitter.Node) int {
+	end := defNode.EndPoint()
+	if end.Column == 0 && end.Row > defNode.StartPoint().Row {
+		return int(end.Row)
+	}
+	return int(end.Row) + 1
+}
+
 func emitCMacro(defNode *sitter.Node, isFunc bool, filePath, fileID, lang string, src []byte, result *parser.ExtractionResult, seen map[string]bool) {
 	if defNode == nil {
 		return
@@ -95,7 +110,7 @@ func emitCMacro(defNode *sitter.Node, isFunc bool, filePath, fileID, lang string
 	}
 	result.Nodes = append(result.Nodes, &graph.Node{
 		ID: id, Kind: graph.KindMacro, Name: name,
-		FilePath: filePath, StartLine: line, EndLine: int(defNode.EndPoint().Row) + 1,
+		FilePath: filePath, StartLine: line, EndLine: macroEndLine(defNode),
 		Language: lang, Meta: meta,
 	})
 	result.Edges = append(result.Edges, &graph.Edge{

--- a/internal/parser/languages/macro_range_test.go
+++ b/internal/parser/languages/macro_range_test.go
@@ -1,0 +1,94 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+)
+
+// declRange finds one declaration by name in a real extraction result.
+func declRange(t *testing.T, res *parser.ExtractionResult, name string) (int, int, graph.NodeKind) {
+	t.Helper()
+	for _, n := range res.Nodes {
+		if n.Name == name {
+			return n.StartLine, n.EndLine, n.Kind
+		}
+	}
+	t.Fatalf("declaration %q not extracted; got %v", name, extractedNames(res))
+	return 0, 0, ""
+}
+
+func extractedNames(res *parser.ExtractionResult) []string {
+	var out []string
+	for _, n := range res.Nodes {
+		out = append(out, n.Name)
+	}
+	return out
+}
+
+// A preprocessor definition must not claim the line of the declaration that
+// follows it. The grammar includes the terminating newline in the definition
+// node, so a naive end-point conversion overshoots by one line and the macro
+// becomes the narrowest — and therefore winning — enclosing declaration for
+// the next declaration's own signature line.
+//
+// This drives the real extractors on purpose: a hand-built node range cannot
+// exercise the end-point arithmetic under test.
+func TestMacroDefinitionDoesNotOwnFollowingDeclarationLine(t *testing.T) {
+	cases := []struct {
+		name    string
+		path    string
+		extract func(string, []byte) (*parser.ExtractionResult, error)
+		src     string
+		macro   string
+		next    string
+	}{
+		{
+			name: "c_single_line_define",
+			path: "fixture.c",
+			extract: func(p string, b []byte) (*parser.ExtractionResult, error) {
+				return NewCExtractor().Extract(p, b)
+			},
+			src:   "#define LIMIT 10\nint compute(void) {\n\treturn LIMIT;\n}\n",
+			macro: "LIMIT", next: "compute",
+		},
+		{
+			name: "cpp_single_line_define",
+			path: "fixture.cpp",
+			extract: func(p string, b []byte) (*parser.ExtractionResult, error) {
+				return NewCppExtractor().Extract(p, b)
+			},
+			src:   "#define LIMIT 10\nint compute() {\n\treturn LIMIT;\n}\n",
+			macro: "LIMIT", next: "compute",
+		},
+		{
+			name: "c_multiline_define",
+			path: "fixture.c",
+			extract: func(p string, b []byte) (*parser.ExtractionResult, error) {
+				return NewCExtractor().Extract(p, b)
+			},
+			src: "#define WRAP(x) do { \\\n\t(x)++; \\\n} while (0)\nint compute(void) {\n\treturn 0;\n}\n",
+			macro: "WRAP", next: "compute",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := tc.extract(tc.path, []byte(tc.src))
+			if err != nil {
+				t.Fatalf("extract: %v", err)
+			}
+			mStart, mEnd, mKind := declRange(t, res, tc.macro)
+			if mKind != graph.KindMacro {
+				t.Fatalf("%s kind = %s, want macro", tc.macro, mKind)
+			}
+			nStart, _, _ := declRange(t, res, tc.next)
+			if mEnd >= nStart {
+				t.Errorf("macro %s [%d,%d] overlaps %s starting at line %d; "+
+					"the definition must end on its own last source line",
+					tc.macro, mStart, mEnd, tc.next, nStart)
+			}
+		})
+	}
+}

--- a/internal/parser/languages/php_reffrm.go
+++ b/internal/parser/languages/php_reffrm.go
@@ -198,7 +198,11 @@ func emitPHPReferenceForms(root *sitter.Node, src []byte, filePath, fileID strin
 func buildPHPTypeRanges(result *parser.ExtractionResult) []funcRange {
 	var ranges []funcRange
 	for _, n := range result.Nodes {
-		if n.Kind == graph.KindType || n.Kind == graph.KindInterface {
+		if (n.Kind == graph.KindType || n.Kind == graph.KindInterface) &&
+			!strings.HasPrefix(n.ID, "annotation::") {
+			// Attribute declarations also create synthetic type nodes at the
+			// attribute's exact line. They are reference targets, never lexical
+			// owners of the declaration they annotate.
 			ranges = append(ranges, funcRange{id: n.ID, startLine: n.StartLine, endLine: n.EndLine})
 		}
 	}


### PR DESCRIPTION
## Summary

- add a benchmark-independent localization quality specification with anti-overfitting and evaluation gates
- tighten declaration ownership for nested Go callables, PHP annotations, and C/Rust macros
- preserve declaration-backed evidence across refinement, exact-read, and recovery transitions
- keep terminal state honest when recovery is empty, exhausted, or evidence is shed
- protect concurrent localization reservations and add deterministic, synthetic regression coverage

## Design constraints

- tree-sitter remains the primary source of syntax structure
- manual parsing is limited to bounded grammar, recovery, preprocessor, or external-block gaps
- production behavior is based on syntax, graph structure, query intent, and evidence provenance
- no benchmark task IDs, repositories, paths, transcripts, or expected answers are embedded in implementation or tests

## Behavior notes for hosts

- A rejected bounded recovery call no longer terminalizes the session. It returns
  `ErrCodeLocalizationComplete` (previously `ErrCodeLocalizationTerminal`) with an
  advisory contract: retained candidates stay provisional and navigation is released.
  The advisory contract is also projected on `structuredContent` for hosts that
  prefer it over the text block.
- Weak, empty, or exhausted recovery ends the workflow advisory rather than
  reporting `answer_ready`.

## Review corrections included

Three regressions found by independent review of this branch are fixed here, each
with a test that fails without its fix:

- a one-line `#define` extended over the declaration beneath it, so once macros
  joined the enclosing-symbol index that macro owned the next declaration's
  signature line — reaching `search_text` / `search_ast` symbol ids, sast finding
  owners, and `symbols_for_ranges` diff lowering
- a reserved read finishing into the advisory release bumped the generation a
  concurrently reserved localize had staged against, so the newer request was
  silently discarded
- the declaration returned by the contract-prescribed exact read carried no primary
  provenance and fell out of the ready-to-emit answer entirely

## Verification

- `go test ./internal/mcp ./internal/parser/languages -count=1`
- `go test -race ./internal/mcp -count=1`
- `go build ./internal/mcp/...`
- `golangci-lint run --timeout=10m` — 0 issues
- formatting and diff checks
- independent review of ownership ambiguity, macro determinism, evidence preservation,
  terminal/recovery concurrency, anti-overfitting compliance, and post-rebase drift