### PR TITLE
fix(indexer): evict idle trigram caches on deadline

### DIFF
--- a/internal/indexer/grep.go
+++ b/internal/indexer/grep.go
@@ -31,34 +31,36 @@ func (idx *Indexer) GrepText(query string, limit int) []trigram.Match {
 func (idx *Indexer) warmTrigramSearcher() *trigram.Searcher {
 	gen := idx.indexGen.Load()
 
-	// Announce the use before taking trigramMu: touch may evict OTHER
-	// repos' searchers, and each eviction takes that repo's trigramMu.
-	// Doing it here keeps this goroutine holding at most one trigramMu at
-	// a time, so two repos warming concurrently cannot deadlock.
-	defer idx.trigramBudget().touch(idx, idx.releaseTrigramSearcher)
-
 	idx.trigramMu.Lock()
-	defer idx.trigramMu.Unlock()
-	if idx.trigramSearcher != nil && idx.trigramGen == gen {
-		return idx.trigramSearcher
-	}
+	if idx.trigramSearcher == nil || idx.trigramGen != gen {
+		root := idx.rootPath
+		if root != "" {
+			idx.mtimeMu.RLock()
+			rels := make([]string, 0, len(idx.fileMtimes))
+			for rel := range idx.fileMtimes {
+				rels = append(rels, rel)
+			}
+			idx.mtimeMu.RUnlock()
+			sort.Strings(rels)
 
-	root := idx.rootPath
-	if root == "" {
-		return idx.trigramSearcher
+			idx.trigramSearcher = trigram.Build(root, rels)
+			idx.trigramGen = gen
+		}
 	}
-
-	idx.mtimeMu.RLock()
-	rels := make([]string, 0, len(idx.fileMtimes))
-	for rel := range idx.fileMtimes {
-		rels = append(rels, rel)
+	searcher := idx.trigramSearcher
+	var release func()
+	if searcher != nil {
+		release = idx.trigramReleaseLocked()
 	}
-	idx.mtimeMu.RUnlock()
-	sort.Strings(rels)
+	idx.trigramMu.Unlock()
 
-	idx.trigramSearcher = trigram.Build(root, rels)
-	idx.trigramGen = gen
-	return idx.trigramSearcher
+	// Touch only after dropping trigramMu: an over-budget touch may release a
+	// different repo, whose callback takes that repo's trigramMu. The lease
+	// captured above prevents a delayed callback from racing a later re-touch.
+	if release != nil {
+		idx.trigramBudget().touch(idx, release)
+	}
+	return searcher
 }
 
 // trigramBudget returns the budget this Indexer participates in, defaulting
@@ -80,8 +82,27 @@ func (idx *Indexer) releaseTrigramSearcher() {
 		return
 	}
 	idx.trigramMu.Lock()
+	idx.trigramLease++
 	idx.trigramSearcher = nil
 	idx.trigramGen = 0
+	idx.trigramMu.Unlock()
+}
+
+// trigramReleaseLocked returns a callback tied to the current cache-use lease.
+// The caller must hold trigramMu. A re-touch advances the lease before the old
+// callback can take the mutex, making a delayed timer/LRU release a no-op.
+func (idx *Indexer) trigramReleaseLocked() func() {
+	idx.trigramLease++
+	lease := idx.trigramLease
+	return func() { idx.releaseTrigramSearcherLease(lease) }
+}
+
+func (idx *Indexer) releaseTrigramSearcherLease(lease uint64) {
+	idx.trigramMu.Lock()
+	if idx.trigramLease == lease {
+		idx.trigramSearcher = nil
+		idx.trigramGen = 0
+	}
 	idx.trigramMu.Unlock()
 }
 

--- a/internal/indexer/grep_bounded.go
+++ b/internal/indexer/grep_bounded.go
@@ -25,8 +25,13 @@ func (idx *Indexer) GrepTextBounded(
 	idx.trigramMu.Lock()
 	searcher := idx.trigramSearcher
 	warm := searcher != nil && idx.trigramGen == gen
+	var release func()
+	if warm {
+		release = idx.trigramReleaseLocked()
+	}
 	idx.trigramMu.Unlock()
 	if warm {
+		idx.trigramBudget().touch(idx, release)
 		matches, stats := searcher.GrepBounded(ctx, query, limit, maxFiles)
 		return matches, stats.Incomplete
 	}
@@ -59,8 +64,13 @@ func (idx *Indexer) GrepLiteralBounded(
 	idx.trigramMu.Lock()
 	searcher := idx.trigramSearcher
 	warm := searcher != nil && idx.trigramGen == gen
+	var release func()
+	if warm {
+		release = idx.trigramReleaseLocked()
+	}
 	idx.trigramMu.Unlock()
 	if warm {
+		idx.trigramBudget().touch(idx, release)
 		matches, stats := searcher.GrepLiteralBounded(
 			ctx, query, limit, maxFiles, isProductionSourcePath,
 		)

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -198,6 +198,10 @@ type Indexer struct {
 	trigramSearcher *trigram.Searcher
 	trigramGen      uint64
 	trigramMu       sync.Mutex
+	// trigramLease is protected by trigramMu. Every warm-cache use advances
+	// it so a delayed idle/LRU callback cannot release a searcher that was
+	// re-touched after the budget selected its previous lease for eviction.
+	trigramLease uint64
 	// trigramBudgetOverride scopes the idle/LRU eviction budget to one
 	// test rather than the process-wide default. Nil in production.
 	trigramBudgetOverride *trigramBudget

--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -2523,9 +2523,17 @@ func (mi *MultiIndexer) UntrackRepo(repoPrefix string) (int, int) {
 		mi.mu.Unlock()
 		return 0, 0
 	}
+	idx := mi.indexers[repoPrefix]
 	delete(mi.repos, repoPrefix)
 	delete(mi.indexers, repoPrefix)
 	mi.mu.Unlock()
+
+	// The process-wide trigram budget otherwise retains the removed Indexer
+	// (and its full-text cache) until an unrelated search happens to evict it.
+	if idx != nil {
+		idx.releaseTrigramSearcher()
+		idx.trigramBudget().forget(idx)
+	}
 
 	// Every repo's nodes live in its byRepo bucket, so the sidecar-aware
 	// purge covers all of them. Single-repo-mode nodes used to carry an

--- a/internal/indexer/trigram_budget.go
+++ b/internal/indexer/trigram_budget.go
@@ -37,11 +37,13 @@ const (
 // than the searchers themselves so the owning Indexer keeps sole ownership
 // of its field and its own mutex discipline.
 type trigramBudget struct {
-	mu      sync.Mutex
-	ttl     time.Duration
-	maxLive int
-	entries map[*Indexer]*trigramEntry
-	now     func() time.Time // swappable in tests
+	mu        sync.Mutex
+	ttl       time.Duration
+	maxLive   int
+	entries   map[*Indexer]*trigramEntry
+	now       func() time.Time // swappable in tests
+	afterFunc func(time.Duration, func()) *time.Timer
+	timer     *time.Timer
 }
 
 type trigramEntry struct {
@@ -59,16 +61,19 @@ func newTrigramBudget(ttl time.Duration, maxLive int) *trigramBudget {
 		maxLive = defaultTrigramMaxLive
 	}
 	return &trigramBudget{
-		ttl:     ttl,
-		maxLive: maxLive,
-		entries: make(map[*Indexer]*trigramEntry),
-		now:     time.Now,
+		ttl:       ttl,
+		maxLive:   maxLive,
+		entries:   make(map[*Indexer]*trigramEntry),
+		now:       time.Now,
+		afterFunc: time.AfterFunc,
 	}
 }
 
 // touch records that owner's searcher is live and just used, then evicts
 // everything that has aged out and, if still over the cap, the
-// least-recently-used entries until it fits.
+// least-recently-used entries until it fits. It also arms the budget's one
+// reusable deadline timer, so a lone warm cache is reclaimed without waiting
+// for another grep to enter this method.
 //
 // Release callbacks run after the budget's own lock is dropped: each one
 // takes its Indexer's trigramMu, and holding both locks in one order here
@@ -95,7 +100,7 @@ func (b *trigramBudget) touch(owner *Indexer, release func()) {
 		if other == owner {
 			continue
 		}
-		if now.Sub(entry.lastUsed) >= b.ttl {
+		if !now.Before(entry.lastUsed.Add(b.ttl)) {
 			evictions = append(evictions, entry.release)
 			delete(b.entries, other)
 		}
@@ -120,9 +125,60 @@ func (b *trigramBudget) touch(owner *Indexer, release func()) {
 		evictions = append(evictions, b.entries[oldest].release)
 		delete(b.entries, oldest)
 	}
+	b.scheduleExpiryLocked(now)
 	b.mu.Unlock()
 
-	for _, release := range evictions {
+	runTrigramReleases(evictions)
+}
+
+// scheduleExpiryLocked maintains one timer for the earliest idle deadline.
+// A callback that loses a Stop/Reset race always re-checks current deadlines,
+// so it cannot evict an entry that was touched after the callback was queued.
+func (b *trigramBudget) scheduleExpiryLocked(now time.Time) {
+	if len(b.entries) == 0 || b.afterFunc == nil {
+		if b.timer != nil {
+			b.timer.Stop()
+		}
+		return
+	}
+
+	var next time.Time
+	for _, entry := range b.entries {
+		deadline := entry.lastUsed.Add(b.ttl)
+		if next.IsZero() || deadline.Before(next) {
+			next = deadline
+		}
+	}
+	delay := next.Sub(now)
+	if delay < 0 {
+		delay = 0
+	}
+	if b.timer == nil {
+		b.timer = b.afterFunc(delay, b.expireIdle)
+		return
+	}
+	b.timer.Reset(delay)
+}
+
+func (b *trigramBudget) expireIdle() {
+	var evictions []func()
+
+	b.mu.Lock()
+	now := b.now()
+	for owner, entry := range b.entries {
+		if !now.Before(entry.lastUsed.Add(b.ttl)) {
+			evictions = append(evictions, entry.release)
+			delete(b.entries, owner)
+		}
+	}
+	b.scheduleExpiryLocked(now)
+	b.mu.Unlock()
+
+	runTrigramReleases(evictions)
+}
+
+func runTrigramReleases(releases []func()) {
+	for _, release := range releases {
 		if release != nil {
 			release()
 		}
@@ -138,6 +194,7 @@ func (b *trigramBudget) forget(owner *Indexer) {
 	}
 	b.mu.Lock()
 	delete(b.entries, owner)
+	b.scheduleExpiryLocked(b.now())
 	b.mu.Unlock()
 }
 

--- a/internal/indexer/trigram_budget_test.go
+++ b/internal/indexer/trigram_budget_test.go
@@ -1,11 +1,15 @@
 package indexer
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/search/trigram"
+	"go.uber.org/zap"
 )
 
 // The trigram searcher is a full-text in-memory index built per repo and
@@ -15,7 +19,35 @@ import (
 func newTestTrigramBudget(ttl time.Duration, maxLive int, clock *time.Time) *trigramBudget {
 	b := newTrigramBudget(ttl, maxLive)
 	b.now = func() time.Time { return *clock }
+	// Fake-clock tests drive expiry by touch; do not arm a real timer against
+	// an artificial wall clock.
+	b.afterFunc = nil
 	return b
+}
+
+func TestTrigramBudgetEvictsLoneIdleOwnerWithoutAnotherTouch(t *testing.T) {
+	b := newTrigramBudget(20*time.Millisecond, 10)
+	released := make(chan struct{})
+	b.touch(&Indexer{}, func() { close(released) })
+
+	select {
+	case <-released:
+	case <-time.After(2 * time.Second):
+		t.Fatal("idle trigram cache was not released at its own deadline")
+	}
+	require.Zero(t, b.live())
+}
+
+func TestTrigramBudgetReusesOneDeadlineTimer(t *testing.T) {
+	b := newTrigramBudget(time.Hour, 10)
+	owner := &Indexer{}
+	b.touch(owner, func() {})
+	first := b.timer
+	require.NotNil(t, first)
+
+	b.touch(owner, func() {})
+	require.Same(t, first, b.timer, "touches must reset one timer, not allocate one per query")
+	b.forget(owner)
 }
 
 func TestTrigramBudgetEvictsIdleOwners(t *testing.T) {
@@ -118,6 +150,76 @@ func TestReleaseTrigramSearcherIsSafeWhenNothingBuilt(t *testing.T) {
 	require.NotPanics(t, idx.releaseTrigramSearcher)
 	require.Nil(t, idx.trigramSearcher)
 	require.Zero(t, idx.trigramGen, "a released searcher must not keep a generation that would look warm")
+}
+
+func TestStaleTrigramLeaseCannotReleaseRetouchedSearcher(t *testing.T) {
+	idx := &Indexer{trigramSearcher: &trigram.Searcher{}, trigramGen: 7}
+	idx.trigramMu.Lock()
+	stale := idx.trigramReleaseLocked()
+	current := idx.trigramReleaseLocked()
+	idx.trigramMu.Unlock()
+
+	stale()
+	require.NotNil(t, idx.trigramSearcher)
+	require.Equal(t, uint64(7), idx.trigramGen)
+
+	current()
+	require.Nil(t, idx.trigramSearcher)
+	require.Zero(t, idx.trigramGen)
+}
+
+func TestBoundedWarmSearchRefreshesTrigramBudget(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	budget := newTestTrigramBudget(time.Minute, 1, &now)
+	dir := t.TempDir()
+	writeTestFile(t, dir+"/main.go", "package main\n\nfunc Warm() int { return 0 }\n")
+	idx := &Indexer{
+		rootPath:              dir,
+		fileMtimes:            map[string]int64{"main.go": 1},
+		trigramBudgetOverride: budget,
+	}
+	require.NotNil(t, idx.warmTrigramSearcher())
+
+	now = now.Add(30 * time.Second)
+	idx.GrepTextBounded(context.Background(), "Warm", 10, 10)
+
+	budget.mu.Lock()
+	lastUsed := budget.entries[idx].lastUsed
+	budget.mu.Unlock()
+	require.Equal(t, now, lastUsed, "bounded-only activity must keep a warm cache alive")
+
+	now = now.Add(10 * time.Second)
+	idx.GrepLiteralBounded(context.Background(), "Warm", 10, 10)
+	budget.mu.Lock()
+	lastUsed = budget.entries[idx].lastUsed
+	budget.mu.Unlock()
+	require.Equal(t, now, lastUsed, "bounded literal activity must also refresh the cache")
+}
+
+func TestUntrackRepoForgetsAndReleasesTrigramCache(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	budget := newTestTrigramBudget(time.Hour, 1, &now)
+	idx := &Indexer{
+		trigramSearcher:       &trigram.Searcher{},
+		trigramGen:            7,
+		trigramBudgetOverride: budget,
+	}
+	idx.trigramMu.Lock()
+	release := idx.trigramReleaseLocked()
+	idx.trigramMu.Unlock()
+	budget.touch(idx, release)
+
+	mi := &MultiIndexer{
+		graph:    graph.New(),
+		repos:    map[string]*RepoMetadata{"repo": {}},
+		indexers: map[string]*Indexer{"repo": idx},
+		logger:   zap.NewNop(),
+	}
+	mi.UntrackRepo("repo")
+
+	require.Zero(t, budget.live())
+	require.Nil(t, idx.trigramSearcher)
+	require.Zero(t, idx.trigramGen)
 }
 
 // End-to-end over the real warm path: building a searcher in one repo must


### PR DESCRIPTION
## Summary

Make the trigram cache's 10-minute idle TTL an actual deadline. Previously, expiry was evaluated only when another grep touched the shared budget, so a lone warm index could remain resident indefinitely. A live quiet-heap profile attributed about 155.8 MiB to that index.

This PR keeps the change focused on cache lifecycle. Posting-list compression and the broader reconciliation allocation audit remain separate follow-ups.

## Changes

- maintain one reusable timer for the earliest cache deadline
- re-check current deadlines when a timer callback races with `Stop`/`Reset`
- attach lease generations to release callbacks so stale eviction cannot clear a recently reused searcher
- refresh the budget from bounded text and literal grep paths
- release and forget a repository's trigram cache immediately on untrack
- add coverage for lone idle expiry, timer reuse, stale-release safety, bounded activity, LRU limits, and untrack cleanup

## Testing

- [x] `go test ./internal/indexer`
- [x] `go test -race ./internal/indexer`
- [x] New tests added for the new lifecycle and concurrency behavior
- [ ] Benchmarks run — not applicable; this changes eviction scheduling rather than posting/query representation

## Checklist

- [x] Code follows existing patterns in the codebase
- [x] No public signatures changed
- [x] No unnecessary abstractions added
- [x] Interface metadata / `EdgeMemberOf` checks are not applicable
