### PR TITLE
refactor(indexer): remove legacy reconciliation pipeline

### DIFF
--- a/bench/fixtures/retrieval.yaml
+++ b/bench/fixtures/retrieval.yaml
@@ -56,7 +56,7 @@ cases:
   - { id: exact-MultiIndexer,        tier: exact, query: "MultiIndexer",                expected: [internal/indexer/multi.go::MultiIndexer] }
   - { id: exact-IndexFile,           tier: exact, query: "IndexFile",                   expected: [internal/indexer/indexer.go::Indexer.IndexFile] }
   - { id: exact-IndexFileNoResolve,  tier: exact, query: "IndexFileNoResolve",          expected: [internal/indexer/indexer.go::Indexer.IndexFileNoResolve] }
-  - { id: exact-IncrementalReindex,  tier: exact, query: "IncrementalReindex",          expected: [internal/indexer/indexer.go::Indexer.IncrementalReindex] }
+  - { id: exact-IncrementalReindexPaths, tier: exact, query: "IncrementalReindexPaths",          expected: [internal/indexer/indexer.go::Indexer.IncrementalReindexPaths] }
   - { id: exact-SetEmbedder,         tier: exact, query: "SetEmbedder",                 expected: [internal/indexer/indexer.go::Indexer.SetEmbedder] }
   - { id: exact-EvictFile,           tier: exact, query: "EvictFile",                   expected: [internal/graph/graph.go::Graph.EvictFile] }
   - { id: exact-EvictRepo,           tier: exact, query: "EvictRepo",                   expected: [internal/graph/graph.go::Graph.EvictRepo] }
@@ -164,7 +164,7 @@ cases:
   - { id: concept-set-embedder,      tier: concept, query: "attach embedding provider to the indexer",      expected: [internal/indexer/indexer.go::Indexer.SetEmbedder] }
   - { id: concept-new-server,        tier: concept, query: "construct a new MCP server instance",           expected: [internal/mcp/server.go::NewServer] }
   - { id: concept-new-hybrid,        tier: concept, query: "construct a hybrid BM25+vector backend",        expected: [internal/search/hybrid.go::NewHybrid] }
-  - { id: concept-reindex-all,       tier: concept, query: "incremental reindex after file changes",        expected: [internal/indexer/indexer.go::Indexer.IncrementalReindex] }
+  - { id: concept-reindex-all,       tier: concept, query: "incremental reindex after file changes",        expected: [internal/indexer/indexer.go::Indexer.IncrementalReindexPaths] }
   - { id: concept-new-vector,        tier: concept, query: "HNSW vector index backend",                     expected: [internal/search/vector.go::VectorBackend] }
   - { id: concept-api-embedder,      tier: concept, query: "OpenAI-compatible embeddings API provider",     expected: [internal/embedding/api.go::APIProvider] }
   - { id: concept-guard-rules,       tier: concept, query: "team convention guard rule evaluation",         expected: [internal/mcp/tools_enhancements.go::Server.handleCheckGuards] }
@@ -282,7 +282,7 @@ cases:
       - internal/indexer/indexer.go::Indexer.Index
       - internal/indexer/indexer.go::Indexer.IndexFile
       - internal/indexer/indexer.go::Indexer.IndexFileNoResolve
-      - internal/indexer/indexer.go::Indexer.IncrementalReindex
+      - internal/indexer/indexer.go::Indexer.IncrementalReindexPaths
       - internal/indexer/indexer.go::Indexer.Search
       - internal/indexer/indexer.go::Indexer.Graph
 

--- a/bench/fixtures/retrieval_typo.yaml
+++ b/bench/fixtures/retrieval_typo.yaml
@@ -49,7 +49,7 @@ cases:
       tier: exact
       query: IncrementalPeindex
       expected:
-        - internal/indexer/indexer.go::Indexer.IncrementalReindex
+        - internal/indexer/indexer.go::Indexer.IncrementalReindexPaths
     - id: exact-SetEmbedder-typo
       tier: exact
       query: SetEmbeeder
@@ -564,7 +564,7 @@ cases:
       tier: concept
       query: incremental reindex after file cwhanges
       expected:
-        - internal/indexer/indexer.go::Indexer.IncrementalReindex
+        - internal/indexer/indexer.go::Indexer.IncrementalReindexPaths
     - id: concept-new-vector-typo
       tier: concept
       query: HNSW vector indxe backend
@@ -720,7 +720,7 @@ cases:
         - internal/indexer/indexer.go::Indexer.Index
         - internal/indexer/indexer.go::Indexer.IndexFile
         - internal/indexer/indexer.go::Indexer.IndexFileNoResolve
-        - internal/indexer/indexer.go::Indexer.IncrementalReindex
+        - internal/indexer/indexer.go::Indexer.IncrementalReindexPaths
         - internal/indexer/indexer.go::Indexer.Search
         - internal/indexer/indexer.go::Indexer.Graph
     - id: mh-multi-repo-typo

--- a/cmd/gortex/daemon.go
+++ b/cmd/gortex/daemon.go
@@ -541,7 +541,7 @@ func runDaemonStart(cmd *cobra.Command, _ []string) error {
 	defer stopSnapshotter()
 
 	// Periodic reconciliation — the "janitor". Walks each tracked repo
-	// and runs IncrementalReindex to evict files deleted offline and
+	// and runs IncrementalReindexPaths to evict files deleted offline and
 	// re-index files whose mtime changed. Insurance against gaps in
 	// fsnotify coverage (inotify watch limits, NFS mounts, kernel
 	// event-queue overflow). Default interval 1 h; override via
@@ -680,7 +680,7 @@ func reconcileInterval() time.Duration {
 // function can be called unconditionally.
 //
 // The worktree GC runs *before* ReconcileAll on purpose: a removed
-// worktree's root no longer exists, so ReconcileAll's IncrementalReindex
+// worktree's root no longer exists, so ReconcileAll's IncrementalReindexPaths
 // would only error on the missing path without evicting anything.
 // Pruning the vanished worktrees first keeps the reconcile sweep
 // working on live repos and stops a deleted worktree's snapshot slot

--- a/cmd/gortex/daemon_snapshot.go
+++ b/cmd/gortex/daemon_snapshot.go
@@ -35,7 +35,7 @@ func init() {
 
 // snapshotRepo carries the per-repo metadata needed to reconcile a
 // restarting daemon with the filesystem: specifically, FileMtimes so
-// IncrementalReindex can skip unchanged files and evict deleted ones.
+// IncrementalReindexPaths can skip unchanged files and evict deleted ones.
 // Added additively — absent in v≤2 snapshots, where RepoCount decodes
 // as zero and the repo section is empty.
 type snapshotRepo struct {
@@ -53,7 +53,7 @@ type snapshotRepo struct {
 
 // snapshotContract is the wire form of contracts.Contract. Persisted so
 // per-repo contract registries survive daemon restarts without having to
-// re-run extractContracts during warmup — in steady state IncrementalReindex
+// re-run extractContracts during warmup — in steady state IncrementalReindexPaths
 // skips the extraction step entirely, which used to leave the registry nil
 // for every repo whose mtimes hadn't drifted. Isolates the wire schema from
 // unrelated evolution of the runtime Contract type: an additive field on
@@ -337,10 +337,10 @@ func migrateSnapshotFile(path string, fromVersion int) (io.Reader, error) {
 // snapshot path. Called from the daemon's shutdown hook. Errors are
 // logged but never propagated — a failed snapshot write should never
 // block clean shutdown. The repos slice carries per-repo FileMtimes so
-// the next warmup can use IncrementalReindex instead of a full re-scan.
+// the next warmup can use IncrementalReindexPaths instead of a full re-scan.
 // The contracts slice carries per-repo contract entries so the warmup
 // can rehydrate each indexer's contracts.Registry without re-running the
-// extractors — IncrementalReindex skips extraction in steady state, so
+// extractors — IncrementalReindexPaths skips extraction in steady state, so
 // without this the registries came back nil after every restart.
 // The vec argument carries the workspace-global vector-search index so
 // a default-on daemon does not re-embed the whole graph on restart.

--- a/cmd/gortex/daemon_state.go
+++ b/cmd/gortex/daemon_state.go
@@ -48,7 +48,7 @@ type daemonState struct {
 	snapshotRepos map[string]*snapshotRepo
 	// snapshotContracts carries the per-repo contract entries restored
 	// from the snapshot. Warmup injects these into each indexer after
-	// ReconcileRepoCtx when IncrementalReindex skipped re-extraction (no
+	// ReconcileRepoCtx when IncrementalReindexPaths skipped re-extraction (no
 	// stale files). Without this the per-repo contracts.Registry stays
 	// nil for every quiescent repo, so `contracts` / `contracts check`
 	// return empty results even though the graph holds the nodes.
@@ -60,7 +60,7 @@ type daemonState struct {
 	// this, edges that the loader dropped never come back — every
 	// restart erodes the graph further until exported methods like
 	// (*Node).Type show zero callers despite having dozens of real
-	// callers in source. The IncrementalReindex path never re-resolves
+	// callers in source. The IncrementalReindexPaths path never re-resolves
 	// unchanged files, so the lost edges are invisible to it.
 	snapshotPartial bool
 	// snapshotVector carries the workspace-global semantic-search
@@ -456,7 +456,7 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 						}
 					}()
 					// Route repos whose nodes came from the snapshot through
-					// ReconcileRepoCtx — it calls IncrementalReindex, which
+					// ReconcileRepoCtx — it calls IncrementalReindexPaths, which
 					// evicts files deleted while the daemon was down and
 					// re-indexes only files whose mtime changed. Repos not in
 					// the snapshot (newly tracked, or first startup after a
@@ -748,7 +748,7 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 
 	// Rehydrate per-repo contract registries from the snapshot. Only
 	// target indexers whose registry is still nil — a non-nil registry
-	// means IncrementalReindex (or a fresh TrackRepoCtx) re-extracted
+	// means IncrementalReindexPaths (or a fresh TrackRepoCtx) re-extracted
 	// contracts from source, and that result is authoritative. Without
 	// this, every steady-state repo's ContractRegistry stays nil and
 	// MergedContractRegistry skips them, so `contracts` returns only
@@ -810,7 +810,7 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 	}
 
 	// Run a cross-repo resolution pass once warmup has stamped the
-	// workspace slugs. Files touched by IncrementalReindex already
+	// workspace slugs. Files touched by IncrementalReindexPaths already
 	// re-resolve via the per-repo Resolver; this catches cross-repo
 	// edges in unchanged files plus stamps cross_workspace_deps
 	// eligibility on stubs. Mirrors what MultiIndexer.IndexAll does
@@ -1189,7 +1189,7 @@ func priorMtimesForEntry(repos map[string]*snapshotRepo, entry config.RepoEntry)
 // collectSnapshotRepos snapshots the per-repo metadata needed to
 // reconcile the next startup: RepoPrefix, RootPath, and FileMtimes.
 // Called from the shutdown and periodic-snapshot paths so restart
-// warmups can run IncrementalReindex instead of a full walk.
+// warmups can run IncrementalReindexPaths instead of a full walk.
 func collectSnapshotRepos(mi *indexer.MultiIndexer) []snapshotRepo {
 	if mi == nil {
 		return nil

--- a/cmd/gortex/mcp.go
+++ b/cmd/gortex/mcp.go
@@ -315,7 +315,7 @@ func runMCP(cmd *cobra.Command, args []string) error {
 						}
 					}
 
-					result, err := idx.IncrementalReindex(mcpIndex)
+					result, err := idx.IncrementalReindexPaths(mcpIndex, nil)
 					if err != nil {
 						fmt.Fprintf(os.Stderr, "[gortex] incremental reindex failed: %v\n", err)
 					} else {

--- a/docs/multi-repo.md
+++ b/docs/multi-repo.md
@@ -75,7 +75,7 @@ watch:
 
 Environment variables:
 
-- `GORTEX_RECONCILE_INTERVAL` — janitor tick that walks every tracked repo and runs `IncrementalReindex` against disk. Insurance against fsnotify gaps on NFS/SMB mounts, inotify watch-limit exhaustion, or daemon downtime where edits happened offline. Default `1h`; `"0"` or `"off"` disables; otherwise any Go duration string (e.g., `15m`).
+- `GORTEX_RECONCILE_INTERVAL` — janitor tick that walks every tracked repo and runs the full-tree `IncrementalReindexPaths` pipeline against disk. Insurance against fsnotify gaps on NFS/SMB mounts, inotify watch-limit exhaustion, or daemon downtime where edits happened offline. Default `1h`; `"0"` or `"off"` disables; otherwise any Go duration string (e.g., `15m`).
 - The daemon also watches each tracked repo's `.git/HEAD`, so branch switches and rebases reconcile incrementally (via `git diff --name-status`) rather than by re-indexing every changed file individually — no configuration needed.
 - `GORTEX_WARMUP_FULL_RETRACK=1` — force every repo through a whole-repo re-track (evict + re-parse every file) on the next warm restart instead of the default scoped reconcile. An escape hatch for when the on-disk change census itself is suspect.
 - `GORTEX_WARMUP_FULL_RESOLVE=1` — force the warm-restart master resolve to re-examine the whole graph instead of scoping to changed repos; also makes the resolver ignore the durable terminal-edge stamp and re-attempt every previously-given-up-on edge. Use when a scoped resolve is suspected of missing edges.

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -2535,7 +2535,7 @@ func (g *Graph) addNodeLocked(s *shard, n *Node) {
 			// an empty-prefix re-add silently strip the node out of its
 			// byRepo bucket. The downgrade-to-empty case has no
 			// legitimate caller (contract nodes use distinct IDs that
-			// never collide with symbol IDs; the parse and IncrementalReindex
+			// never collide with symbol IDs; the parse and IncrementalReindexPaths
 			// paths route through applyRepoPrefix which always stamps
 			// the active idx.repoPrefix on the new node) and previously
 			// caused per-repo `byRepo[prefix]` to drain mid-warmup,

--- a/internal/indexer/affected_by_e2e_test.go
+++ b/internal/indexer/affected_by_e2e_test.go
@@ -70,7 +70,7 @@ func TestAffectedBy_SignatureChange_ReresolvesCaller(t *testing.T) {
 // changes only a function BODY produces no signature delta and must not
 // fan out — the whole point of delta detection is that the common case
 // (a body edit) costs nothing beyond the changed file itself. Driven
-// through whole-root IncrementalReindex to cover that sync route too.
+// through whole-root IncrementalReindexPaths to cover that sync route too.
 func TestAffectedBy_BodyOnlyEdit_NoFanout(t *testing.T) {
 	dir := t.TempDir()
 	aPath := filepath.Join(dir, "a.go")
@@ -84,7 +84,7 @@ func TestAffectedBy_BodyOnlyEdit_NoFanout(t *testing.T) {
 	callerID := fnNodeID(t, g, "b.go", "Caller")
 
 	bumpMtime(t, aPath, "package p\n\nfunc F(x int) int { return x + 1 }\n")
-	res, err := idx.IncrementalReindex(dir)
+	res, err := idx.IncrementalReindexPaths(dir, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, res.StaleFileCount)
 

--- a/internal/indexer/affected_set.go
+++ b/internal/indexer/affected_set.go
@@ -1,22 +1,6 @@
 package indexer
 
-import (
-	"os"
-	"strings"
-
-	"github.com/zzet/gortex/internal/graph"
-)
-
-// scopedGlobalPassesEnabled reports whether incremental reindex should scope
-// the global inference passes (InferImplements / InferOverrides) to the
-// changed-affected type set instead of re-running them over the whole graph.
-// GORTEX_INDEX_SCOPED_GLOBAL_PASSES overrides the config key. ON by default.
-func (idx *Indexer) scopedGlobalPassesEnabled() bool {
-	if v := os.Getenv("GORTEX_INDEX_SCOPED_GLOBAL_PASSES"); v != "" {
-		return v == "1" || strings.EqualFold(v, "true")
-	}
-	return idx.config.ScopedGlobalPassesEnabledOrDefault()
-}
+import "github.com/zzet/gortex/internal/graph"
 
 // affectedTypeSet computes the type/interface IDs whose inferred
 // implements/override edges a set of changed (stale) files can affect:
@@ -100,22 +84,4 @@ func (idx *Indexer) staleFilesAffectDerivedEdges(staleFiles []string) bool {
 		}
 	}
 	return false
-}
-
-// runScopedInferencePasses runs the implements/override inference passes scoped
-// to the types/interfaces a set of stale files can affect. Returns false when
-// scoping is disabled (caller should run the full passes). When nothing
-// type/interface-shaped changed, the passes are skipped entirely (the common
-// case for a function-body edit).
-func (idx *Indexer) runScopedInferencePasses(staleFiles []string) bool {
-	if !idx.scopedGlobalPassesEnabled() {
-		return false
-	}
-	types, ifaces := idx.affectedTypeSet(idx.graphFilePaths(staleFiles))
-	if len(types) == 0 && len(ifaces) == 0 {
-		return true // no type/interface change → no inferred edges to re-derive
-	}
-	idx.resolver.InferImplementsScoped(types, ifaces)
-	idx.resolver.InferOverridesScoped(types)
-	return true
 }

--- a/internal/indexer/bench_lowmem_test.go
+++ b/internal/indexer/bench_lowmem_test.go
@@ -64,7 +64,7 @@ func BenchmarkIndex_Self_Incremental(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
-		_, _ = idx.IncrementalReindex("../..")
+		_, _ = idx.IncrementalReindexPaths("../..", nil)
 	}
 }
 

--- a/internal/indexer/capability_edges_incremental_test.go
+++ b/internal/indexer/capability_edges_incremental_test.go
@@ -52,7 +52,7 @@ func Run() error {
 }
 `)
 
-	_, err = idx.IncrementalReindex(dir)
+	_, err = idx.IncrementalReindexPaths(dir, nil)
 	require.NoError(t, err)
 
 	assert.Positive(t, countExec(),

--- a/internal/indexer/deferred_enrich_gate_test.go
+++ b/internal/indexer/deferred_enrich_gate_test.go
@@ -133,10 +133,10 @@ func TestIndexer_PendingEnrich_SetByIndexAndIncremental(t *testing.T) {
 
 	// A zero-change reconcile must not raise the marker.
 	idx.pendingEnrich.Store(false)
-	_, err = idx.IncrementalReindex(dir)
+	_, err = idx.IncrementalReindexPaths(dir, nil)
 	require.NoError(t, err)
 	assert.False(t, idx.pendingEnrich.Load(),
-		"a no-op IncrementalReindex must leave pendingEnrich clear")
+		"a no-op IncrementalReindexPaths call must leave pendingEnrich clear")
 
 	// A scoped incremental pass that re-indexes a stale file sets it.
 	bumpMtime(t, filepath.Join(dir, "main.go"),

--- a/internal/indexer/incremental_derived.go
+++ b/internal/indexer/incremental_derived.go
@@ -34,6 +34,30 @@ type IncrementalDerivedReport struct {
 	DurationMs          int64
 }
 
+// runStandaloneIncrementalDerivedPasses reuses the exact MultiIndexer derived
+// coordinator for a direct Indexer. The synthetic coordinator intentionally
+// contains only this repository; real shared-graph callers must use their owning
+// MultiIndexer so contract and cross-repository passes see every sibling.
+func (idx *Indexer) runStandaloneIncrementalDerivedPasses(plan DerivedInvalidationPlan) IncrementalDerivedReport {
+	if idx == nil || idx.graph == nil || idx.deferGlobalPasses || plan.Empty() {
+		return IncrementalDerivedReport{}
+	}
+	logger := idx.logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	prefix := idx.RepoPrefix()
+	mi := NewMultiIndexer(idx.graph, idx.registry, idx.search, nil, logger)
+	mi.indexers[prefix] = idx
+	mi.repos[prefix] = &RepoMetadata{
+		RepoPrefix: prefix,
+		RootPath:   idx.RootPath(),
+	}
+	return mi.RunIncrementalDerivedPasses(context.Background(), map[string]DerivedInvalidationPlan{
+		prefix: plan,
+	})
+}
+
 // RunIncrementalDerivedPasses executes only the derived families invalidated
 // by the exact per-file plans. A legacy database without persisted fingerprints
 // takes the old scoped-global path once; ordinary body/metadata edits never do.

--- a/internal/indexer/incremental_reindex_paths_test.go
+++ b/internal/indexer/incremental_reindex_paths_test.go
@@ -39,6 +39,31 @@ func TestIncrementalReindexPaths_EmptyPathsFallsBackToWholeRoot(t *testing.T) {
 		"the whole-root pass must re-index the changed file")
 }
 
+func TestIncrementalReindexPaths_FullRootRestoresDetectedTotal(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.go"), "package main\n\nfunc A() {}\n")
+	writeFile(t, filepath.Join(dir, "b.go"), "package main\n\nfunc B() {}\n")
+
+	mtimes := make(map[string]int64, 2)
+	for _, name := range []string{"a.go", "b.go"} {
+		info, err := os.Stat(filepath.Join(dir, name))
+		require.NoError(t, err)
+		mtimes[name] = info.ModTime().UnixNano()
+	}
+
+	idx := newTestIndexer(graph.New())
+	idx.SetRootPath(dir)
+	idx.SetFileMtimes(mtimes)
+	require.Zero(t, idx.TotalDetected(), "snapshot restore starts without a discovery total")
+
+	res, err := idx.IncrementalReindexPaths(dir, nil)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Zero(t, res.StaleFileCount)
+	assert.Equal(t, 2, idx.TotalDetected(),
+		"a full-tree reconcile must restore the health discovery baseline")
+}
+
 // TestIncrementalReindexPaths_ScopesToDirectory checks that a directory
 // path scopes the pass: a stale file inside the scoped directory is
 // re-indexed, while a stale file outside it is left untouched.

--- a/internal/indexer/incremental_reindex_test.go
+++ b/internal/indexer/incremental_reindex_test.go
@@ -140,16 +140,16 @@ func TestIncrementalReindex_ConvergesToFullIndex(t *testing.T) {
 
 	bumpMtime(t, filepath.Join(dir, "main.go"),
 		"package main\n\nfunc main() { helper(); helper() }\n\nfunc helper() {}\n")
-	_, err = idxA.IncrementalReindex(dir)
+	_, err = idxA.IncrementalReindexPaths(dir, nil)
 	require.NoError(t, err)
 
 	bumpMtime(t, filepath.Join(dir, "pkg", "util.go"),
 		"package pkg\n\ntype Config struct{ Port int }\n\nfunc New() *Config { return &Config{} }\n\nfunc Reset(c *Config) {}\n")
-	_, err = idxA.IncrementalReindex(dir)
+	_, err = idxA.IncrementalReindexPaths(dir, nil)
 	require.NoError(t, err)
 
 	require.NoError(t, os.Remove(filepath.Join(dir, "extra.go")))
-	_, err = idxA.IncrementalReindex(dir)
+	_, err = idxA.IncrementalReindexPaths(dir, nil)
 	require.NoError(t, err)
 
 	// Path B: a single cold index of the same final disk state.

--- a/internal/indexer/incremental_reindex_test.go
+++ b/internal/indexer/incremental_reindex_test.go
@@ -41,7 +41,7 @@ func Dropped() {}
 	// Mid-flight exclusion: drop.go remains on disk but must leave the graph.
 	idx.SetExcludePatterns(append(append([]string{}, excludes.Builtin...), "drop.go"))
 
-	res, err := idx.IncrementalReindex(dir)
+	res, err := idx.IncrementalReindexPaths(dir, nil)
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	assert.Equal(t, 1, res.DeletedFileCount, "excluded-but-present file must count as deleted")
@@ -72,7 +72,7 @@ func Gone() {}
 
 	require.NoError(t, os.Remove(gonePath))
 
-	_, err = idx.IncrementalReindex(dir)
+	_, err = idx.IncrementalReindexPaths(dir, nil)
 	require.NoError(t, err)
 
 	assert.NotEmpty(t, g.FindNodesByName("Kept"))
@@ -190,7 +190,7 @@ func TestIncrementalReindex_FailedFileSurfacedAndRetried(t *testing.T) {
 	future := time.Now().Add(2 * time.Second)
 	require.NoError(t, os.Chtimes(bad, future, future))
 
-	res, err := idx.IncrementalReindex(dir)
+	res, err := idx.IncrementalReindexPaths(dir, nil)
 	require.NoError(t, err)
 	assert.Contains(t, res.FailedFiles, bad,
 		"an unreadable stale file must be surfaced on FailedFiles")
@@ -198,7 +198,7 @@ func TestIncrementalReindex_FailedFileSurfacedAndRetried(t *testing.T) {
 	// Readable again: the file is still stale (its failed pass never
 	// recorded an mtime), so the next incremental pass recovers it.
 	require.NoError(t, os.Chmod(bad, 0o644))
-	res2, err := idx.IncrementalReindex(dir)
+	res2, err := idx.IncrementalReindexPaths(dir, nil)
 	require.NoError(t, err)
 	assert.Empty(t, res2.FailedFiles, "the file indexes cleanly once readable")
 	assert.NotEmpty(t, g.FindNodesByName("Bad"))
@@ -231,7 +231,7 @@ func TestIncrementalReindex_MerkleMode(t *testing.T) {
 	future := time.Now().Add(2 * time.Second)
 	require.NoError(t, os.Chtimes(filepath.Join(dir, "touched.go"), future, future))
 
-	res, err := idx.IncrementalReindex(dir)
+	res, err := idx.IncrementalReindexPaths(dir, nil)
 	require.NoError(t, err)
 
 	assert.NotEmpty(t, g.FindNodesByName("AlsoEdited"),

--- a/internal/indexer/incremental_watcher_batch.go
+++ b/internal/indexer/incremental_watcher_batch.go
@@ -100,10 +100,9 @@ func (idx *Indexer) observeIncrementalCatchup(kind string, files []string) {
 }
 
 // runIncrementalResolutionCatchup owns every resolution-dependent tail for a
-// deferred watcher mutation. The changed-file resolver, dataflow rewrite,
+// deferred incremental mutation. The changed-file resolver, dataflow rewrite,
 // affected-by resolver and durable fact refresh each run at most once for the
-// complete batch; ordinary IncrementalReindexPaths callers never enter here and
-// retain their existing chunk-local behavior.
+// complete batch.
 func (idx *Indexer) runIncrementalResolutionCatchup(
 	files []string,
 	batch *reparsePendingEnrichmentBatch,
@@ -153,11 +152,11 @@ func (idx *Indexer) runIncrementalWatcherSemantic(graphPaths []string) {
 	idx.setReparsePendingEnrichments(pending)
 }
 
-// incrementalReindexWatcherPaths is the direct-Indexer fallback used outside a
-// MultiWatcher. It performs one bounded parse/evict batch, then one exact-file
-// resolver pass and one batched reference-fact refresh. The ordinary daemon path
-// uses MultiIndexer.IncrementalReindexRepo instead so shared-graph derived work
-// is also caught up exactly once.
+// incrementalReindexWatcherPaths is the complete direct-Indexer coordinator used
+// outside a MultiIndexer. It performs one bounded parse/evict batch, one exact
+// resolver/reference-fact catch-up, semantic refresh, and the precise standalone
+// derived passes. Shared-graph callers use MultiIndexer so cross-repository work
+// sees every sibling registry and indexer.
 func (idx *Indexer) incrementalReindexWatcherPaths(root string, paths []string) (*IndexResult, error) {
 	result, receipt, batch, err := idx.incrementalReindexPathsWithReceipt(root, paths)
 	if err != nil {
@@ -176,7 +175,11 @@ func (idx *Indexer) incrementalReindexWatcherPaths(root string, paths []string) 
 		idx.observeIncrementalCatchup("resolve", nil)
 		idx.ResolveAll()
 	}
-	idx.runIncrementalWatcherSemantic(result.DerivedInvalidation.Files)
+	if !idx.deferGlobalPasses {
+		idx.runIncrementalWatcherSemantic(result.DerivedInvalidation.Files)
+		idx.observeIncrementalCatchup("derived", result.DerivedInvalidation.Files)
+		idx.runStandaloneIncrementalDerivedPasses(result.DerivedInvalidation)
+	}
 	return result, nil
 }
 

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -57,7 +57,7 @@ type IndexResult struct {
 	// and incremental-reconcile paths.
 	FileCount int `json:"file_count"`
 	// StaleFileCount is the number of files that were actually
-	// re-indexed in this pass (only populated by IncrementalReindex
+	// re-indexed in this pass (only populated by IncrementalReindexPaths
 	// — full-index passes treat every file as stale and would
 	// duplicate FileCount). Used by the janitor / reconcile log to
 	// report "how much work did the snapshot delta require".
@@ -91,7 +91,7 @@ type IndexResult struct {
 	SkippedFiles int `json:"skipped_files,omitempty"`
 	// DeletedFileCount is the number of previously-indexed files that
 	// were evicted this pass because they no longer exist on disk (only
-	// populated by IncrementalReindex). Together with StaleFileCount it
+	// populated by IncrementalReindexPaths). Together with StaleFileCount it
 	// lets a batch caller — the daemon warmup loop in particular — decide
 	// whether a repo actually changed since the last shutdown: when both
 	// are zero across every repo, the persisted graph already carries
@@ -353,8 +353,8 @@ type Indexer struct {
 	deferredGoModDone bool
 
 	// pendingEnrich is raised by an index pass that did real work — IndexCtx
-	// that observed files (or a whole-repo re-track) and IncrementalReindex /
-	// IncrementalReindexPaths that re-indexed or evicted at least one file. It
+	// that observed files (or a whole-repo re-track) and any
+	// IncrementalReindexPaths pass that re-indexed or evicted at least one file. It
 	// is cleared only after runDeferredEnrich completes its queued file batch or
 	// repository pass without a partial result. The daemon warmup enriches every
 	// indexer it collected, so this gates the (multi-minute LSP hover) pass to
@@ -393,7 +393,7 @@ type Indexer struct {
 
 	// reparsedThisRun is the scoped analogue of fullReindexed: it is raised by a
 	// scoped incremental pass that re-parsed at least one stale file this run —
-	// IncrementalReindexPaths / IncrementalReindex with a non-zero
+	// IncrementalReindexPaths with a non-zero
 	// StaleFileCount. A scoped re-parse evicts and re-creates just the changed
 	// files' nodes, dropping THEIR hover-enrichment edges exactly as a whole-repo
 	// re-parse drops every node's, so the deferred pass must likewise run past
@@ -406,7 +406,7 @@ type Indexer struct {
 	// two claims distinct. A fresh Indexer per daemon run starts it false.
 	reparsedThisRun atomic.Bool
 
-	// deferGlobalPasses, when set, makes IndexCtx and IncrementalReindex
+	// deferGlobalPasses, when set, makes IndexCtx and IncrementalReindexPaths
 	// skip the graph-wide derivation passes (InferImplements,
 	// InferOverrides, markTestSymbolsAndEmitEdges). These passes walk the
 	// entire shared graph, so running them per-repo inside a batch loop
@@ -896,7 +896,7 @@ func (idx *Indexer) ContractRegistry() *contracts.Registry { return idx.contract
 
 // SetContractRegistry installs reg as the indexer's contract registry.
 // Used by the daemon warmup path to rehydrate the registry from a
-// snapshot when IncrementalReindex skipped extraction (no stale files
+// snapshot when incremental reconciliation skipped extraction (no stale files
 // → extractContracts never ran → idx.contractRegistry stays nil after
 // reconcile, which used to leave multi-repo `contracts` queries silently
 // empty). Callers should only install when ContractRegistry() is nil;
@@ -922,7 +922,7 @@ func (idx *Indexer) SetSkipResolveInDeferred(v bool) { idx.skipResolveInDeferred
 
 // SetDeferGlobalPasses toggles whether the graph-wide derivation passes
 // (InferImplements, InferOverrides, markTestSymbolsAndEmitEdges) run
-// inline at the end of IndexCtx / IncrementalReindex. Set true when the
+// inline at the end of IndexCtx / IncrementalReindexPaths. Set true when the
 // caller drives a batch (e.g. daemon warmup) and will invoke
 // RunGlobalGraphPasses once at the end. See the deferGlobalPasses field
 // comment.
@@ -933,7 +933,7 @@ func (idx *Indexer) SetDeferGlobalPasses(v bool) { idx.deferGlobalPasses = v }
 // already has these edges — InferImplements / InferOverrides skip
 // existing parents, and graph.AddEdge dedupes by edgeKey so EdgeTests
 // re-emission is a no-op. Logs counts for telemetry. Use when batching
-// multiple per-repo TrackRepoCtx / IncrementalReindex calls under
+// multiple per-repo TrackRepoCtx / IncrementalReindexPaths calls under
 // SetDeferGlobalPasses(true).
 func (idx *Indexer) RunGlobalGraphPasses(ctx context.Context) {
 	if idx.graph == nil {
@@ -1435,7 +1435,7 @@ func (idx *Indexer) ResolveFilePath(graphPath string) string {
 // precomposed NFC. Keying the bulk walk under one form and an
 // incremental patch under the other would split a single file across
 // two graph keys: the watcher's evict would miss the walk's node,
-// IncrementalReindex would see the file as both deleted and freshly
+// incremental reconciliation would see the file as both deleted and freshly
 // created, and the daemon would carry a stale duplicate. Folding every
 // key through one form here removes that whole class of mismatch.
 //
@@ -3235,7 +3235,7 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 							localContracts = append(localContracts, c...)
 
 							// Populate the per-file contract cache so a
-							// later IncrementalReindex can skip this file
+							// later incremental reconciliation can skip this file
 							// on a cache hit. Mtime comes from the walk-
 							// time d.Info() — no extra stat here.
 							if wf.mtimeNano > 0 {
@@ -5392,7 +5392,7 @@ func (idx *Indexer) SetRootPath(root string) {
 // Each path may be absolute or relative to root, and may be a file or a
 // directory; directories are walked recursively with the same
 // exclude / language filters as a full pass. Within that scoped file
-// set the behaviour matches IncrementalReindex: only files that are
+// set, the behaviour is a full-tree reconcile: only files that are
 // stale (mtime or, in Merkle mode, content) are re-indexed, and a file
 // previously tracked under one of the scoped paths but now absent from
 // disk is evicted.
@@ -5423,7 +5423,7 @@ func (idx *Indexer) incrementalReindexPaths(
 	if fullRoot {
 		// An empty scope means the repository root. detectDeletions decides
 		// whether absent persisted paths are evicted; keeping that choice here
-		// lets IncrementalReindex share this bounded implementation without a
+		// lets full-tree and scoped callers share this bounded implementation without a
 		// recursive wrapper call.
 		paths = []string{root}
 	}
@@ -5570,7 +5570,7 @@ func (idx *Indexer) incrementalReindexPaths(
 			absPath := filepath.Join(absRoot, filepath.FromSlash(relPath))
 			_, statErr := os.Stat(absPath)
 			if statErr == nil {
-				// Present-but-excluded must be purged (same as full IncrementalReindex).
+				// Present-but-excluded must be purged (same as full-tree reconciliation).
 				if idx.shouldExclude(absPath, absRoot, false) {
 					deletedFiles = append(deletedFiles, relPath)
 				}
@@ -5686,262 +5686,6 @@ func relPathInScope(relPath string, scope map[string]bool) bool {
 		}
 	}
 	return false
-}
-
-// IncrementalReindex walks the file tree and re-indexes only files that changed
-// since the last snapshot. It also evicts nodes for deleted files.
-func (idx *Indexer) IncrementalReindex(root string) (*IndexResult, error) {
-	start := time.Now()
-
-	absRoot, err := filepath.Abs(root)
-	if err != nil {
-		return nil, err
-	}
-	idx.storeRootPath(absRoot)
-
-	// Collect files currently on disk.
-	diskFiles := make(map[string]bool)
-	var staleFiles []string
-
-	// Merkle mode replaces per-file mtime staleness with a
-	// content-addressed Merkle-tree diff computed after the walk.
-	merkleMode := idx.merkleEnabled()
-
-	err = filepath.WalkDir(absRoot, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return nil
-		}
-		if d.IsDir() {
-			if idx.shouldPruneDir(path, absRoot) {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if _, ok := idx.effectiveLanguage(path, nil); !ok && !idx.isIncrementalContractManifest(path) {
-			return nil
-		}
-		if idx.shouldExclude(path, absRoot, false) {
-			return nil
-		}
-
-		// relKey (slash + NFC) so the disk set is keyed identically
-		// to fileMtimes — otherwise a non-ASCII file the snapshot
-		// stored under one Unicode form and this walk observes under
-		// another would be seen as both deleted and newly created.
-		relPath := idx.relKey(path)
-		diskFiles[relPath] = true
-
-		if !merkleMode && idx.IsStale(relPath) {
-			staleFiles = append(staleFiles, path)
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	// In Merkle mode the per-file mtime check above is skipped; the
-	// stale set comes from a content-addressed tree diff instead.
-	if merkleMode {
-		staleFiles = idx.merkleStaleFiles(absRoot, diskFiles)
-	}
-
-	// Detect deleted files. A file that's tracked in fileMtimes but
-	// absent from the current discovery walk is a candidate, but
-	// "absent from discovery" is not always "absent from disk":
-	//
-	//   - Newly excluded (user/config intent): treat as deleted so the
-	//     graph does not retain permanent orphans (#321).
-	//   - Language extractor Extensions() shrank: file still on disk and
-	//     not excluded — preserve graph state.
-	//   - WalkDir swallowed a transient error (EACCES, EIO, NFS hiccup,
-	//     ELOOP) — preserve on non-ENOENT stat failures.
-	//
-	// Stat the candidate: ENOENT => deleted; exists+excluded => deleted;
-	// exists+not-excluded => preserve; other errors => preserve.
-	idx.mtimeMu.RLock()
-	var candidates []string
-	for relPath := range idx.fileMtimes {
-		if !diskFiles[relPath] {
-			candidates = append(candidates, relPath)
-		}
-	}
-	idx.mtimeMu.RUnlock()
-
-	var deletedFiles []string
-	for _, relPath := range candidates {
-		absPath := filepath.Join(absRoot, relPath)
-		_, err := os.Stat(absPath)
-		if err == nil {
-			// File still exists on disk but was not admitted by this walk.
-			// If the admission set now excludes it, treat it like a deletion
-			// so exclude-list refinements do not leave permanent orphans
-			// (file_count drops while node_count/search stay stale). See #321.
-			// If it is not excluded (e.g. extension no longer detected),
-			// preserve graph state.
-			if idx.shouldExclude(absPath, absRoot, false) {
-				deletedFiles = append(deletedFiles, relPath)
-			}
-			continue
-		}
-		if errors.Is(err, os.ErrNotExist) {
-			deletedFiles = append(deletedFiles, relPath)
-			continue
-		}
-		// Transient error — preserve to be safe.
-		idx.logger.Warn("incremental reindex: stat failed during deletion detection, preserving",
-			zap.String("rel", relPath), zap.Error(err))
-	}
-
-	// Capture surviving dependents while the deleted symbols and their incoming
-	// adjacency are still present. Keep the exact deleted paths too so contract
-	// registries can remove their stale entries after graph eviction.
-	deletedDependencyFiles := idx.semanticDependencyFrontierForDeletedFiles(deletedFiles)
-	partialFrontier := appendUniqueSorted(nil, deletedDependencyFiles...)
-	for _, relPath := range deletedFiles {
-		partialFrontier = append(partialFrontier, idx.prefixPath(filepath.FromSlash(relPath)))
-	}
-	partialFrontier = appendUniqueSorted(nil, partialFrontier...)
-
-	// Evict only files that are truly absent from disk.
-	for _, relPath := range deletedFiles {
-		// relPath is a fileMtimes key (relKey: slash + NFC); the graph
-		// keys nodes under OS-native separators, so convert before the
-		// evict or a deleted file's nodes leak on Windows. FromSlash is
-		// a no-op on POSIX.
-		graphPath := idx.prefixPath(filepath.FromSlash(relPath))
-		idx.restubIncomingRefs(graphPath)
-		idx.evictEnrichment(graphPath)
-		idx.graph.EvictFile(graphPath)
-		idx.mtimeMu.Lock()
-		delete(idx.fileMtimes, relPath)
-		idx.mtimeMu.Unlock()
-	}
-	// Prune the persisted mtime rows for deleted files too, so the next
-	// warm restart does not see them as phantom deletions (the in-memory
-	// delete above does not reach the store's sidecar table).
-	idx.pruneDeletedFileMtimes(deletedFiles)
-
-	// Re-index stale files. A file that fails — most often because it
-	// was locked or mid-write when the walk caught it — is collected
-	// and retried once below. A failure that survives the retry is
-	// surfaced on IndexResult.FailedFiles so the caller can replay it.
-	// A file whose bytes couldn't be read at all keeps no mtime
-	// recorded, so it stays stale for the next incremental pass; a
-	// file that read but failed to parse gets its mtime recorded (see
-	// indexFile's result==nil branch), so it stops being retried until
-	// its content changes again — see IndexResult.FailedFiles.
-	sourceStaleFiles, manifestFiles := splitIncrementalContractManifests(idx, staleFiles)
-	markerBatch := &reparsePendingEnrichmentBatch{}
-	var failedFiles []string
-	var reparsedFiles []string
-	for _, f := range sourceStaleFiles {
-		if err := idx.indexFile(f, true, markerBatch); err != nil {
-			idx.logger.Debug("incremental reindex: failed to index file",
-				zap.String("file", f), zap.Error(err))
-			failedFiles = append(failedFiles, f)
-		} else {
-			reparsedFiles = append(reparsedFiles, f)
-		}
-	}
-	if len(failedFiles) > 0 {
-		retry := failedFiles
-		failedFiles = nil
-		for _, f := range retry {
-			if err := idx.indexFile(f, true, markerBatch); err != nil {
-				idx.logger.Warn("incremental reindex: file failed after retry",
-					zap.String("file", f), zap.Error(err))
-				failedFiles = append(failedFiles, f)
-			} else {
-				reparsedFiles = append(reparsedFiles, f)
-			}
-		}
-	}
-
-	partialFrontier = appendUniqueSorted(partialFrontier, idx.graphFilePaths(reparsedFiles)...)
-	manifestPlan, manifestFailed := idx.refreshIncrementalContractManifests(manifestFiles)
-	failedFiles = appendUniqueSorted(failedFiles, manifestFailed...)
-	partialFrontier = appendUniqueSorted(partialFrontier, manifestPlan.Files...)
-	idx.flushReparsePendingEnrichment(markerBatch)
-
-	// Re-infer interface implementations (edges may have been lost
-	// during eviction). Skipped under deferGlobalPasses so a batch
-	// caller (ReconcileAll, warmup) can run a single global pass at
-	// the end instead of paying O(global) per repo.
-	if !idx.deferGlobalPasses {
-		// Scoped inference passes re-derive only the affected types/interfaces
-		// (add-parity with the full pass); fall back to whole-graph when off.
-		if !idx.runScopedInferencePasses(staleFiles) {
-			idx.resolver.InferImplements()
-			idx.resolver.InferOverrides()
-		}
-		// Capability edges (reads_env / executes_process / accesses_field)
-		// and framework dynamic-dispatch synthesis are whole-graph recomputes
-		// that derive edges only from structural nodes in the changed files.
-		// When nothing structural changed — no stale code file (a doc/config
-		// edit or a true zero-change reconcile) and no deletion — they can
-		// produce no new edge, so re-running them is pure cost: the dominant
-		// waste in a no-op IncrementalReindex, which the periodic janitor runs
-		// per repo per tick. Gate them on the same predicate the path-scoped
-		// IncrementalReindexPaths already uses. Deletions still trigger a
-		// re-run because an evicted file may have been a dispatch endpoint.
-		if len(deletedFiles) > 0 || idx.staleFilesAffectDerivedEdges(staleFiles) {
-			synthesizeCapabilityEdges(idx.graph)
-			resolver.RunFrameworkSynthesizers(idx.graph)
-		}
-		// External-call synthesis (opt-in) — file-scoped to the reindexed
-		// files (O(edited files)), not a full-graph recompute. Eviction
-		// already dropped a removed file's synthetic edges; a re-indexed
-		// file's fresh external terminals are re-materialised here.
-		resolver.SynthesizeExternalCallsForFiles(idx.graph, idx.externalCallSynthesisEnabled(), idx.graphFilePaths(staleFiles))
-		// Clone detection is not re-run here: each stale file was
-		// re-indexed through IndexFile above, whose resolve pass
-		// already recomputed EdgeSimilarTo against the fresh graph,
-		// and deleted files self-clean via EvictFile's bidirectional
-		// edge removal. Under deferGlobalPasses the batch caller runs
-		// the global clone pass once at the end.
-	}
-
-	// Rebuild search index to ensure consistency — but skip it on a
-	// zero-change reconcile against a backend that persists its search
-	// structures natively (the on-disk backend). See the matching guard
-	// in the other incremental path: re-embedding is wasted work and
-	// there is nothing to rebuild when no file changed.
-	if len(staleFiles) > 0 || len(deletedFiles) > 0 || !isSymbolSearcherBackend(idx.search) {
-		idx.buildSearchIndex()
-	}
-
-	// Update totalDetected so index_health reports correctly after cache restore.
-	if idx.totalDetected == 0 {
-		idx.totalDetected = len(diskFiles)
-	}
-
-	// Refresh contracts only for the changed/deleted/dependent frontier. The
-	// registry bootstrap and cross-file expansion remain contract-scoped; this
-	// path never scans the repository merely because one file changed.
-	if len(staleFiles) > 0 || len(deletedFiles) > 0 {
-		idx.refreshContractsForFiles(partialFrontier)
-		idx.indexGen.Add(1) // files changed — invalidate the trigram cache
-	}
-
-	nodes, edges := idx.repoNodeEdgeCount()
-	result := &IndexResult{
-		NodeCount:        nodes,
-		EdgeCount:        edges,
-		FileCount:        len(diskFiles),
-		StaleFileCount:   len(staleFiles),
-		DeletedFileCount: len(deletedFiles),
-		FailedFiles:      failedFiles,
-		DurationMs:       time.Since(start).Milliseconds(),
-	}
-	idx.warnIfEdgeSanityViolated(result)
-	// Queue only the exact changed/deleted/dependent file frontier. The deferred
-	// runner handles all surviving languages in batches and clears this generation
-	// only after every selected provider succeeds.
-	if len(staleFiles) > 0 || len(deletedFiles) > 0 {
-		idx.markPendingEnrichFiles(partialFrontier)
-	}
-	return result, nil
 }
 
 // LastIndexTime returns the timestamp of the last full index.
@@ -8190,7 +7934,7 @@ func (idx *Indexer) extractGoModContracts(reg *contracts.Registry) {
 // GraphQL, topics, etc.). Detected contracts are added as graph nodes
 // with provides/consumes edges.
 //
-// This full-walk path is used by IncrementalReindex (where many files
+// This full-walk path is used by full-tree reconciliation (where many files
 // are already cached). IndexCtx instead runs the per-file work inline
 // with parsing — see the worker loop — and skips this function.
 func (idx *Indexer) extractContracts() {
@@ -8339,13 +8083,13 @@ func (idx *Indexer) extractContracts() {
 // HasChangesSinceMtimes reports whether any indexable file under root
 // changed (mtime differs or is new) or was deleted, relative to the
 // indexer's currently-loaded fileMtimes. It runs the SAME walk +
-// staleness + deletion logic as IncrementalReindex but writes nothing.
+// staleness + deletion logic as full-tree reconciliation but writes nothing.
 //
 // The daemon warmup uses it to choose a reconcile strategy for a
 // reopened repo: a repo with zero changes takes the fast no-op
-// IncrementalReindex path, while a repo that changed while the daemon
+// incremental reconciliation path, while a repo that changed while the daemon
 // was down is routed through the shadow/bulk re-track path instead.
-// That routing matters because IncrementalReindex re-resolves changed
+// That routing matters because incremental reconciliation re-resolves changed
 // files through per-edge graph.ReindexEdges, and the per-edge write
 // path against a freshly reopened disk store is slow and unreliable.
 // The shadow path resolves entirely in an in-memory graph and commits

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -5397,10 +5397,11 @@ func (idx *Indexer) SetRootPath(root string) {
 // previously tracked under one of the scoped paths but now absent from
 // disk is evicted.
 //
-// When paths is empty the call degrades to IncrementalReindex(root) —
-// callers can therefore pass an optional path list unconditionally.
+// When paths is empty the call reconciles the whole repository tree. The
+// standalone entry point owns the complete parse, resolve, semantic, and exact
+// derived-pass pipeline; MultiIndexer uses the receipt-aware core directly.
 func (idx *Indexer) IncrementalReindexPaths(root string, paths []string) (*IndexResult, error) {
-	return idx.incrementalReindexPaths(root, paths, true)
+	return idx.incrementalReindexWatcherPaths(root, paths)
 }
 
 // incrementalDiscoverPaths discovers and refreshes files beneath paths without
@@ -5418,7 +5419,8 @@ func (idx *Indexer) incrementalReindexPaths(
 	detectDeletions bool,
 	markerBatches ...*reparsePendingEnrichmentBatch,
 ) (*IndexResult, error) {
-	if len(paths) == 0 {
+	fullRoot := len(paths) == 0
+	if fullRoot {
 		// An empty scope means the repository root. detectDeletions decides
 		// whether absent persisted paths are evicted; keeping that choice here
 		// lets IncrementalReindex share this bounded implementation without a
@@ -5538,6 +5540,13 @@ func (idx *Indexer) incrementalReindexPaths(
 				staleFiles = append(staleFiles, abs)
 			}
 		}
+	}
+
+	// Restored snapshots populate fileMtimes without running IndexCtx. Preserve
+	// the full-tree health baseline that the retired reconciliation path set.
+	// Scoped calls cannot infer a repository-wide discovery total.
+	if fullRoot && idx.totalDetected == 0 {
+		idx.totalDetected = len(diskFiles)
 	}
 
 	var deletedFiles []string

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -174,10 +174,11 @@ func TestIncrementalReindexPaths_MtimeBumpFlagsReparse(t *testing.T) {
 		"a scoped re-parse of an mtime-drifted file must force deferred enrichment")
 }
 
-// TestIncrementalReindex_MtimeBumpFlagsReparse is the whole-root sibling of the
-// scoped fingerprint no-op above: an mtime-stale but byte-identical file is
-// examined without eviction and therefore leaves reparsedThisRun clear.
-func TestIncrementalReindex_MtimeBumpFlagsReparse(t *testing.T) {
+// TestIncrementalReindexPaths_WholeRootMtimeBumpFlagsReparse proves the unified
+// modern pipeline preserves the enrichment marker contract for nil-path scans:
+// an mtime-stale file that is re-parsed must report that work just like an
+// explicitly scoped call.
+func TestIncrementalReindexPaths_WholeRootMtimeBumpFlagsReparse(t *testing.T) {
 	dir := t.TempDir()
 	main := filepath.Join(dir, "main.go")
 	const content = "package main\n\nfunc Hello() {}\n"
@@ -190,11 +191,11 @@ func TestIncrementalReindex_MtimeBumpFlagsReparse(t *testing.T) {
 	require.False(t, idx.reparsedThisRun.Load())
 
 	bumpMtime(t, main, content)
-	result, err := idx.IncrementalReindex(dir)
+	result, err := idx.IncrementalReindexPaths(dir, nil)
 	require.NoError(t, err)
 	require.Positive(t, result.StaleFileCount)
-	assert.False(t, idx.reparsedThisRun.Load(),
-		"a whole-root content-identical fingerprint no-op must not force deferred enrichment")
+	assert.True(t, idx.reparsedThisRun.Load(),
+		"a whole-root re-parse must force deferred enrichment for the touched file")
 }
 
 // TestIncrementalReindex_NoChangeLeavesReparseClear guards the other side: a
@@ -209,7 +210,7 @@ func TestIncrementalReindex_NoChangeLeavesReparseClear(t *testing.T) {
 	_, err := idx.Index(dir)
 	require.NoError(t, err)
 
-	result, err := idx.IncrementalReindex(dir)
+	result, err := idx.IncrementalReindexPaths(dir, nil)
 	require.NoError(t, err)
 	require.Zero(t, result.StaleFileCount, "nothing changed on disk")
 	assert.False(t, idx.reparsedThisRun.Load(),
@@ -312,7 +313,7 @@ func TestGrepText(t *testing.T) {
 	// freshly added literal is visible.
 	bumpMtime(t, filepath.Join(dir, "main.go"),
 		"package main\n\nfunc main() {}\n\nfunc BrandNew() {}\n")
-	_, err = idx.IncrementalReindex(dir)
+	_, err = idx.IncrementalReindexPaths(dir, nil)
 	require.NoError(t, err)
 	assert.NotEmpty(t, idx.GrepText("func BrandNew", 0),
 		"GrepText must reflect content added by an incremental reindex")

--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -70,7 +70,7 @@ type MultiIndexer struct {
 	// evicts the prior EdgeMatches / topic / bridge generation and mints
 	// a fresh one across many independent graph-store writes — it is NOT
 	// atomic. Several goroutines drive it concurrently (the periodic
-	// janitor's ReconcileAll, the file-watcher's IncrementalReindex,
+	// janitor's ReconcileAll, the file-watcher's incremental reconciliation,
 	// MCP-triggered track / untrack / index), and mi.mu is only taken in
 	// fine-grained spots inside, not across the whole pass. Without this
 	// lock two overlapping reconciles can interleave evict and mint and
@@ -370,7 +370,7 @@ func (mi *MultiIndexer) SetOnRepoTracked(fn func(prefix, absPath string)) {
 // BeginBatch enables deferred-global-passes mode for every per-repo
 // Indexer that this MultiIndexer constructs after the call AND for
 // every Indexer already in mi.indexers (so ReconcileAll's per-repo
-// IncrementalReindex calls also skip the O(global) walks). Pair with
+// incremental reconciliation calls also skip the O(global) walks). Pair with
 // EndBatch.
 func (mi *MultiIndexer) BeginBatch() {
 	mi.mu.Lock()
@@ -1205,7 +1205,7 @@ func (mi *MultiIndexer) EndBatch() {
 // only recompute what's already on disk — the work that turns a warm
 // restart into a 30s–500s stall. The per-Indexer SetDeferGlobalPasses
 // flag is still restored so a later watch-triggered TrackRepoCtx /
-// IncrementalReindex runs its passes inline as normal.
+// incremental reconciliation runs its passes inline as normal.
 func (mi *MultiIndexer) ResetBatch() {
 	mi.mu.Lock()
 	defer mi.mu.Unlock()
@@ -2235,7 +2235,7 @@ func (mi *MultiIndexer) TrackRepoCtx(ctx context.Context, entry config.RepoEntry
 // (typically restored from a daemon snapshot) and brings it back into
 // agreement with the filesystem without a full re-index. priorMtimes
 // carries the mtimes recorded at the time the snapshot was taken;
-// IncrementalReindex uses them to detect files that changed offline
+// IncrementalReindexPaths uses them to detect files that changed offline
 // (re-indexes) and files that were deleted offline (evicts).
 //
 // Falls back to TrackRepoCtx when the repo is not yet tracked AND no
@@ -2281,7 +2281,7 @@ func (mi *MultiIndexer) ReconcileRepoCtx(ctx context.Context, entry config.RepoE
 
 	// Fall back to full TrackRepoCtx when we have no prior mtimes:
 	// there's nothing meaningful to reconcile against, and
-	// IncrementalReindex would treat every file as stale, producing
+	// an incremental pass would treat every file as stale, producing
 	// the same duplicate-writes problem we're fixing. entry.Name is
 	// already pinned by resolveTrackPrefix, so the fallback reproduces
 	// the same prefix.
@@ -2306,11 +2306,11 @@ func (mi *MultiIndexer) ReconcileRepoCtx(ctx context.Context, entry config.RepoE
 	// is reserved for the cases where scoping is unsafe or not worth it: the
 	// census could not be taken, the churn is a large fraction of the repo,
 	// or an operator forced it via GORTEX_WARMUP_FULL_RETRACK. A repo with
-	// zero changes keeps the fast IncrementalReindex no-op (walk + 0 stale →
+	// zero changes keeps the fast full-tree incremental no-op (walk + 0 stale →
 	// return), which is what makes an unchanged warm restart near-instant.
 	//
 	// The in-memory backend (*graph.Graph) keeps its exact prior behaviour:
-	// IncrementalReindex is the authoritative path there — it evicts
+	// the full-tree modern pipeline is authoritative there — it evicts
 	// offline-deleted files in place, has no reopened disk store, and so no
 	// per-edge write to route around. Gate on the store type.
 	_, memoryBacked := mi.graph.(*graph.Graph)
@@ -2358,6 +2358,11 @@ func (mi *MultiIndexer) ReconcileRepoCtx(ctx context.Context, entry config.RepoE
 	}
 	if err != nil {
 		return nil, fmt.Errorf("reconciling %s: %w", absPath, err)
+	}
+	// A scoped snapshot reconcile cannot derive its total from the walked
+	// scope. Its post-mutation tracked count is the repository-wide baseline.
+	if idx.totalDetected == 0 {
+		idx.totalDetected = result.FileCount
 	}
 	result.RepoPrefix = prefix
 
@@ -2428,7 +2433,7 @@ func firstNStrings(s []string, n int) []string {
 	return s[:n]
 }
 
-// ReconcileAll runs IncrementalReindex on every tracked repo. Used by
+// ReconcileAll runs the modern full-tree pipeline on every tracked repo. Used by
 // the daemon's periodic janitor to catch files whose mutations slipped
 // past fsnotify — inotify watch limits, NFS / SMB mounts, kernel event
 // queue overflow, or daemon downtime where edits happened while nobody
@@ -2454,7 +2459,7 @@ func (mi *MultiIndexer) ReconcileAllCtx(ctx context.Context) map[string]*IndexRe
 	}
 	mi.mu.RUnlock()
 
-	// Same batch trick as warmup: each per-repo IncrementalReindex
+	// Same batch trick as warmup: each per-repo full-tree incremental pass
 	// triggers an O(global) InferImplements/InferOverrides walk if we
 	// don't suppress it. With ~100 repos that's ~100× the work for the
 	// hourly janitor.
@@ -2605,7 +2610,7 @@ type WorktreeGC struct {
 // `git worktree remove` (or manual deletion) case. Each vanished
 // worktree's branch-keyed snapshot slot and graph nodes would otherwise
 // leak forever: a removed worktree never fires a per-file fsnotify
-// delete for its whole tree, and the janitor's IncrementalReindex just
+// delete for its whole tree, and the janitor's full-tree reconciliation just
 // errors out on the missing root without evicting anything.
 //
 // Only repos recorded as worktrees (RepoMetadata.IsWorktree) are

--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -2316,6 +2316,8 @@ func (mi *MultiIndexer) ReconcileRepoCtx(ctx context.Context, entry config.RepoE
 	_, memoryBacked := mi.graph.(*graph.Graph)
 	var (
 		result           *IndexResult
+		receipt          *graph.MutationReceipt
+		batch            *reparsePendingEnrichmentBatch
 		changed, deleted []string
 		route            = "incremental"
 	)
@@ -2332,7 +2334,7 @@ func (mi *MultiIndexer) ReconcileRepoCtx(ctx context.Context, entry config.RepoE
 	}
 	switch {
 	case memoryBacked:
-		result, err = idx.IncrementalReindex(absPath)
+		result, receipt, batch, err = idx.incrementalReindexPathsWithReceipt(absPath, nil)
 	default:
 		var censusErr error
 		changed, deleted, censusErr = idx.ChangedSinceMtimes(absPath)
@@ -2345,13 +2347,13 @@ func (mi *MultiIndexer) ReconcileRepoCtx(ctx context.Context, entry config.RepoE
 			result, err = fullRetrack()
 		case churn == 0:
 			route = "incremental"
-			result, err = idx.IncrementalReindex(absPath)
+			result, receipt, batch, err = idx.incrementalReindexPathsWithReceipt(absPath, nil)
 		case priorCount > 0 && churn*100 > priorCount*40:
 			route = "full_retrack"
 			result, err = fullRetrack()
 		default:
 			route = "scoped"
-			result, err = idx.IncrementalReindexPaths(absPath, append(changed, deleted...))
+			result, receipt, batch, err = idx.incrementalReindexPathsWithReceipt(absPath, append(changed, deleted...))
 		}
 	}
 	if err != nil {
@@ -2380,8 +2382,21 @@ func (mi *MultiIndexer) ReconcileRepoCtx(ctx context.Context, entry config.RepoE
 		mi.logger.Warn("failed to add repo to config", zap.Error(err))
 	}
 
-	// See TrackRepoCtx for why this is skipped under deferGlobalPasses.
-	if !mi.deferGlobalPasses {
+	// A restored incremental route parsed against an Indexer that was not yet
+	// registered. Once registration makes it visible to the shared resolver,
+	// consume its receipt and exact derived plan through this MultiIndexer.
+	// Parallel warmup deliberately defers both tails to its later workspace
+	// resolve/global phases. A full retrack already ran its own resolve/derived
+	// pipeline and only needs the existing cross-repository contract reconcile.
+	if !result.FullRetrack && !mi.deferResolve {
+		mi.resolveIncrementalRepoMutation(prefix, result, receipt, batch)
+		if !mi.deferGlobalPasses {
+			idx.observeIncrementalCatchup("derived", result.DerivedInvalidation.Files)
+			mi.RunIncrementalDerivedPasses(ctx, map[string]DerivedInvalidationPlan{
+				prefix: result.DerivedInvalidation,
+			})
+		}
+	} else if result.FullRetrack && !mi.deferGlobalPasses {
 		mi.ReconcileContractEdges()
 	}
 
@@ -2470,12 +2485,13 @@ func (mi *MultiIndexer) ReconcileAllCtx(ctx context.Context) map[string]*IndexRe
 		if !ok || !metaOK || meta == nil || meta.RootPath == "" {
 			continue
 		}
-		result, err := idx.IncrementalReindex(meta.RootPath)
+		result, receipt, batch, err := idx.incrementalReindexPathsWithReceipt(meta.RootPath, nil)
 		if err != nil {
 			mi.logger.Warn("janitor: reconcile failed",
 				zap.String("prefix", prefix), zap.Error(err))
 			continue
 		}
+		mi.resolveIncrementalRepoMutation(prefix, result, receipt, batch)
 		if result != nil && (result.StaleFileCount > 0 || result.DeletedFileCount > 0) {
 			mi.logger.Info("janitor: reconciled repo",
 				zap.String("prefix", prefix),

--- a/internal/indexer/multi_reconcile_test.go
+++ b/internal/indexer/multi_reconcile_test.go
@@ -105,6 +105,88 @@ func TestReconcileRepoCtx_DoesNotDuplicateUnchanged(t *testing.T) {
 		"reconciling unchanged files must not grow edges (B1 regression)")
 }
 
+// TestReconcileRepoCtx_RunsDerivedPassesForOfflineChange proves a restored
+// repository consumes the modern pipeline's exact derived plan after an edit
+// that happened while the coordinator was offline.
+func TestReconcileRepoCtx_RunsDerivedPassesForOfflineChange(t *testing.T) {
+	dir := t.TempDir()
+	repoPath := filepath.Join(dir, "repo")
+	require.NoError(t, os.MkdirAll(repoPath, 0o755))
+	writeFile(t, filepath.Join(repoPath, "base.go"), "package main\nfunc main() {}\n")
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	gc := &config.GlobalConfig{Repos: []config.RepoEntry{{Path: repoPath, Name: "repo"}}}
+	gc.SetConfigPath(cfgPath)
+	require.NoError(t, gc.Save())
+	cm, err := config.NewConfigManager(cfgPath)
+	require.NoError(t, err)
+
+	g := graph.New()
+	mi := NewMultiIndexer(g, newTestRegistry(), search.NewBM25(), cm, zap.NewNop())
+	_, err = mi.IndexAll()
+	require.NoError(t, err)
+	priorMtimes := mi.GetMetadata("repo").FileMtimes
+
+	writeFile(t, filepath.Join(repoPath, "shell.go"), `package main
+import "os/exec"
+func Run() error { return exec.Command("true").Run() }
+`)
+
+	mi2 := NewMultiIndexer(g, newTestRegistry(), search.NewBM25(), cm, zap.NewNop())
+	result, err := mi2.ReconcileRepoCtx(
+		context.Background(), config.RepoEntry{Path: repoPath, Name: "repo"}, priorMtimes,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.False(t, result.DerivedInvalidation.Empty(), "offline edit must return its exact derived plan")
+	assert.True(t, result.DerivedInvalidation.Flags.Has(DerivedInvalidatesRuntime))
+	assert.True(t, reconcileHasEdgeKind(g, graph.EdgeExecutesProcess),
+		"snapshot reconciliation must consume the derived plan")
+	require.NotNil(t, mi2.GetIndexer("repo"))
+	assert.Equal(t, 2, mi2.GetIndexer("repo").TotalDetected())
+}
+
+func TestReconcileAll_RunsDerivedPassesForMissedChange(t *testing.T) {
+	dir := t.TempDir()
+	repoPath := filepath.Join(dir, "repo")
+	require.NoError(t, os.MkdirAll(repoPath, 0o755))
+	writeFile(t, filepath.Join(repoPath, "base.go"), "package main\nfunc main() {}\n")
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	gc := &config.GlobalConfig{Repos: []config.RepoEntry{{Path: repoPath, Name: "repo"}}}
+	gc.SetConfigPath(cfgPath)
+	require.NoError(t, gc.Save())
+	cm, err := config.NewConfigManager(cfgPath)
+	require.NoError(t, err)
+
+	g := graph.New()
+	mi := NewMultiIndexer(g, newTestRegistry(), search.NewBM25(), cm, zap.NewNop())
+	_, err = mi.IndexAll()
+	require.NoError(t, err)
+
+	writeFile(t, filepath.Join(repoPath, "shell.go"), `package main
+import "os/exec"
+func Run() error { return exec.Command("true").Run() }
+`)
+
+	results := mi.ReconcileAllCtx(context.Background())
+	require.Contains(t, results, "repo")
+	require.NotNil(t, results["repo"])
+	assert.False(t, results["repo"].DerivedInvalidation.Empty(),
+		"janitor must retain the modern pipeline's exact derived plan")
+	assert.True(t, reconcileHasEdgeKind(g, graph.EdgeExecutesProcess),
+		"janitor must consume the plan after the batched repository loop")
+}
+
+func reconcileHasEdgeKind(g graph.Store, kind graph.EdgeKind) bool {
+	for _, edge := range g.AllEdges() {
+		if edge != nil && edge.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
 // TestReconcileAll_CatchesJanitorTargets runs ReconcileAll directly —
 // the entry point the daemon's periodic janitor calls. Tests the same
 // B2 invariant but through the public janitor API rather than the

--- a/internal/indexer/realtime_reliability_test.go
+++ b/internal/indexer/realtime_reliability_test.go
@@ -287,7 +287,7 @@ func haveGit(t *testing.T) bool {
 // gap is closed: a pathless EventOverflow on the Events channel triggers
 // a coalesced full-tree reconcile (the signal the Linux inotify backend
 // raises when its queue overflows and events are lost). The reconcileFn
-// seam stands in for IncrementalReindex so the assertion is
+// seam stands in for full-tree reconciliation so the assertion is
 // deterministic and platform-independent.
 func TestWatcher_OverflowEventTriggersReconcile(t *testing.T) {
 	idx, _ := newToggleIndexer(t)
@@ -366,7 +366,7 @@ func TestWatcher_OverflowReconcileCoalesces(t *testing.T) {
 }
 
 // TestWatcher_OverflowReconcileIndexesMissedFile is the end-to-end proof
-// that the real reconcile path (IncrementalReindex) recovers a file
+// that the real IncrementalReindexPaths reconcile recovers a file
 // whose create/modify event was lost. We index a tree, drop a brand-new
 // file on disk (simulating a missed inotify create), then drive an
 // overflow through the real reconcile and assert the new file is now in
@@ -396,12 +396,12 @@ func TestWatcher_OverflowReconcileIndexesMissedFile(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "missed.fk"), "recovered body")
 	require.Empty(t, g.GetFileNodes("missed.fk"), "missed file must be absent before the reconcile")
 
-	// Drive the real IncrementalReindex through the overflow path, with
+	// Drive the real full-tree reconciliation through the overflow path, with
 	// a thin wrapper only to know when it finishes.
 	done := make(chan struct{}, 1)
 	w.reconcileMu.Lock()
 	w.reconcileFn = func() {
-		_, rerr := idx.IncrementalReindex(dir)
+		_, rerr := idx.IncrementalReindexPaths(dir, nil)
 		require.NoError(t, rerr)
 		done <- struct{}{}
 	}

--- a/internal/indexer/unicode_path_test.go
+++ b/internal/indexer/unicode_path_test.go
@@ -167,7 +167,7 @@ func TestIncrementalReindex_NonASCIIFileNoDuplicate(t *testing.T) {
 
 	// Modify and re-index incrementally.
 	bumpMtime(t, target, goSrc("After"))
-	_, err = idx.IncrementalReindex(dir)
+	_, err = idx.IncrementalReindexPaths(dir, nil)
 	require.NoError(t, err)
 
 	fileNodesAfter := fileKindNodes(g, key)
@@ -194,7 +194,7 @@ func TestIncrementalReindex_NonASCIIFileNotSpuriouslyDeleted(t *testing.T) {
 	require.NotEmpty(t, g.FindNodesByName("Survivor"))
 
 	// Re-index with nothing changed on disk.
-	_, err = idx.IncrementalReindex(dir)
+	_, err = idx.IncrementalReindexPaths(dir, nil)
 	require.NoError(t, err)
 
 	assert.NotEmpty(t, g.FindNodesByName("Survivor"),

--- a/internal/indexer/warm_restart_mtime_prune_test.go
+++ b/internal/indexer/warm_restart_mtime_prune_test.go
@@ -90,7 +90,7 @@ func TestWarmRestart_PrunesDeletedFileMtimes_FastPath(t *testing.T) {
 
 // TestIncrementalReindex_PrunesDeletedFileMtimes covers the watcher /
 // incremental path: a file deleted between scans must have its persisted
-// mtime row removed by IncrementalReindex (via DeleteFileMtimes), not just
+// mtime row removed by IncrementalReindexPaths (via DeleteFileMtimes), not just
 // its in-memory entry — otherwise the next warm restart re-discovers it as a
 // phantom deletion.
 func TestIncrementalReindex_PrunesDeletedFileMtimes(t *testing.T) {
@@ -115,7 +115,7 @@ func TestIncrementalReindex_PrunesDeletedFileMtimes(t *testing.T) {
 	// Delete drop.go and run the incremental path (the janitor / watcher
 	// route), not a full re-track.
 	require.NoError(t, os.Remove(filepath.Join(repoPath, "drop.go")))
-	res, err := idx.IncrementalReindex(repoPath)
+	res, err := idx.IncrementalReindexPaths(repoPath, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, res.DeletedFileCount, "incremental reindex must report the deletion")
 

--- a/internal/indexer/watcher.go
+++ b/internal/indexer/watcher.go
@@ -162,7 +162,7 @@ type Watcher struct {
 	// FSEvents self-heals (it re-scans on UserDropped/KernelDropped),
 	// but Linux inotify does not — without this the lost event waits on
 	// the up-to-1h janitor. reconcileFn is a test seam: nil in
-	// production (the real IncrementalReindex runs).
+	// production (the real full-tree coordinator runs).
 	reconcileMu      sync.Mutex
 	reconcilePending bool
 	reconcileFn      func()
@@ -1807,7 +1807,7 @@ func (w *Watcher) reconcileKindWithDisk(path string, kind ChangeKind) ChangeKind
 // persisted mtime row outlives the file: the next warm restart reads it
 // back, finds the path gone from disk, and treats it as a phantom deletion
 // — re-running a scoped reconcile for a file that is already correct on
-// every boot. Mirrors IncrementalReindex's deletion handling: prune the
+// every boot. Mirrors full-tree reconciliation's deletion handling: prune the
 // in-memory map first (pruneDeletedFileMtimes documents that its caller has
 // already done so, and a later snapshot persist would otherwise resurrect
 // the row from the stale in-memory entry), then the store, which self-skips

--- a/internal/indexer/watcher.go
+++ b/internal/indexer/watcher.go
@@ -1113,12 +1113,16 @@ func (w *Watcher) triggerOverflowReconcile(reason string) {
 			fn()
 			return
 		}
-		if _, err := w.indexer.IncrementalReindex(w.indexer.rootPath); err != nil {
-			if w.logger != nil {
-				w.logger.Warn("watcher: overflow reconcile failed",
-					zap.String("reason", reason),
-					zap.Error(err))
-			}
+		var err error
+		if w.batchReindex != nil {
+			_, err = w.batchReindex(nil)
+		} else {
+			_, err = w.indexer.IncrementalReindexPaths(w.indexer.rootPath, nil)
+		}
+		if err != nil && w.logger != nil {
+			w.logger.Warn("watcher: overflow reconcile failed",
+				zap.String("reason", reason),
+				zap.Error(err))
 		}
 	}()
 }

--- a/internal/indexer/watcher_test.go
+++ b/internal/indexer/watcher_test.go
@@ -74,6 +74,24 @@ func waitForEvent(t *testing.T, w *Watcher, timeout time.Duration) GraphChangeEv
 	}
 }
 
+func TestWatcher_OverflowReconcileUsesBatchCoordinator(t *testing.T) {
+	_, _, w := setupWatcher(t)
+	called := make(chan []string, 1)
+	w.batchReindex = func(paths []string) (*IndexResult, error) {
+		called <- paths
+		return &IndexResult{}, nil
+	}
+
+	w.triggerOverflowReconcile("test")
+	select {
+	case paths := <-called:
+		assert.Nil(t, paths, "overflow must request a full-tree batch reconcile")
+	case <-time.After(2 * time.Second):
+		t.Fatal("overflow reconcile did not invoke the batch coordinator")
+	}
+	w.asyncWork.Wait()
+}
+
 func TestWatcher_FileModify(t *testing.T) {
 	dir, idx, w := setupWatcher(t)
 

--- a/internal/indexer/worktree.go
+++ b/internal/indexer/worktree.go
@@ -103,7 +103,7 @@ func ResolveWorktree(path string) WorktreeInfo {
 // error (EACCES on a mounted volume, an NFS hiccup) returns false so a
 // flaky filesystem can never trigger a destructive index eviction.
 //
-// This mirrors the deletion-detection rule IncrementalReindex already
+// This mirrors the deletion-detection rule IncrementalReindexPaths already
 // uses for individual files: only os.ErrNotExist counts as gone, every
 // other Stat error is treated as "preserve, can't verify."
 //

--- a/internal/mcp/tools_simulate_test.go
+++ b/internal/mcp/tools_simulate_test.go
@@ -108,7 +108,7 @@ func TestPreviewEdit_RenameSymbol(t *testing.T) {
 	require.NoError(t, writeSeedFile(helperPath,
 		"package main\n\nfunc Encode(payload []byte) []byte { return payload }\n"))
 	srv.OverlayManager().Drop("seed")
-	_, err := srv.indexer.IncrementalReindex(dir)
+	_, err := srv.indexer.IncrementalReindexPaths(dir, nil)
 	require.NoError(t, err)
 	srv.indexer.ResolveAll()
 

--- a/internal/reach/reach.go
+++ b/internal/reach/reach.go
@@ -952,7 +952,7 @@ func safeUint64(v any) (uint64, bool) {
 // InvalidateIndex advances the global build counter so every future
 // Lookup recomputes against the new graph state. Call this whenever
 // the graph mutates in a way that could change reach sets — at the
-// end of every IndexCtx / IncrementalReindex / global-pass run.
+// end of every IndexCtx / IncrementalReindexPaths / global-pass run.
 //
 // The cached Meta entries on nodes that survived the mutation are
 // not deleted; they're simply tagged with a stale build counter, so


### PR DESCRIPTION
## Summary

- replace the retired whole-tree implementation with the bounded, receipt-aware IncrementalReindexPaths pipeline and delete the legacy method
- route snapshot restoration, hourly janitor reconciliation, and watcher overflow through the correct standalone or MultiIndexer coordinator
- consume exact DerivedInvalidation plans and preserve totalDetected across restored full-tree and scoped reconciliations
- migrate remaining callers, tests, docs, and retrieval fixtures

This is intentionally a separate follow-up to #403.

## Verification

- go test ./internal/indexer -count=1
- go test ./... -run ^$
- go test -race ./internal/indexer -run Test\(IncrementalReindex\|Watcher_Overflow\|ReconcileRepoCtx_\|ReconcileAll_\) -count=1
- go test -race ./internal/mcp -count=1
- go test ./internal/mcp -run TestPreviewEdit_RenameSymbol -count=1