### PR TITLE
perf(resolver): bound framework census edge retention

### DIFF
--- a/internal/resolver/chain_factory.go
+++ b/internal/resolver/chain_factory.go
@@ -40,8 +40,7 @@ func resolveFactoryChains(g graph.Store, cands *frameworkPassCandidates) int {
 	// fraction of the total edge count on a large multi-repo graph.
 	stream := edgesByKinds(g, []graph.EdgeKind{graph.EdgeCalls, graph.EdgeReferences})
 	if cands != nil {
-		merged := refetchFrameworkCandidates(g, cands.calls)
-		merged = append(merged, refetchFrameworkCandidates(g, cands.refs)...)
+		merged := append(append([]*graph.Edge(nil), cands.calls...), cands.refs...)
 		stream = frameworkEdgeSeq(merged)
 	}
 	resolved := 0

--- a/internal/resolver/fastapi_resolve.go
+++ b/internal/resolver/fastapi_resolve.go
@@ -40,8 +40,8 @@ func resolveFastAPIDeps(g graph.Store, cands *frameworkPassCandidates) int {
 	callsStream := g.EdgesByKind(graph.EdgeCalls)
 	refsStream := g.EdgesByKind(graph.EdgeReferences)
 	if cands != nil {
-		callsStream = frameworkEdgeSeq(refetchFrameworkCandidates(g, cands.calls))
-		refsStream = frameworkEdgeSeq(refetchFrameworkCandidates(g, cands.refs))
+		callsStream = frameworkEdgeSeq(cands.calls)
+		refsStream = frameworkEdgeSeq(cands.refs)
 	}
 	resolved := 0
 	var reindex []graph.EdgeReindex

--- a/internal/resolver/fn_pointer_dispatch.go
+++ b/internal/resolver/fn_pointer_dispatch.go
@@ -60,7 +60,7 @@ func resolveFnPointerDispatch(g graph.Store, cands *frameworkPassCandidates) int
 
 	regStream := g.EdgesByKind(graph.EdgeReferences)
 	if cands != nil {
-		regStream = frameworkEdgeSeq(refetchFrameworkCandidates(g, cands.refs))
+		regStream = frameworkEdgeSeq(cands.refs)
 	}
 	var regReindex []graph.EdgeReindex
 	for e := range regStream {
@@ -125,7 +125,7 @@ func resolveFnPointerDispatch(g graph.Store, cands *frameworkPassCandidates) int
 
 	dispatchStream := g.EdgesByKind(graph.EdgeCalls)
 	if cands != nil {
-		dispatchStream = frameworkEdgeSeq(refetchFrameworkCandidates(g, cands.calls))
+		dispatchStream = frameworkEdgeSeq(cands.calls)
 	}
 	resolved := 0
 	var reindex []graph.EdgeReindex
@@ -204,9 +204,9 @@ func fnPtrFanoutEdge(e *graph.Edge, target *graph.Node, st, field string) *graph
 		Confidence:      fnPointerConfidence,
 		ConfidenceLabel: graph.ConfidenceLabelFor(graph.EdgeCalls, fnPointerConfidence),
 		Meta: map[string]any{
-			"via":          fnPtrDispatchVia,
-			"fnptr_struct": st,
-			"fnptr_field":  field,
+			"via":             fnPtrDispatchVia,
+			"fnptr_struct":    st,
+			"fnptr_field":     field,
 			MetaSynthesizedBy: SynthFnPointerDispatch,
 			MetaProvenance:    ProvenanceHeuristic,
 		},

--- a/internal/resolver/framework_stream_mux.go
+++ b/internal/resolver/framework_stream_mux.go
@@ -24,16 +24,22 @@ import (
 // refetchFrameworkCandidates), so an edge retargeted by an earlier pass in
 // the same run drops out exactly as it would vanish from a fresh stream walk.
 
-// frameworkPassCandidates is the per-synthesizer bundle handed to a
-// converted pass in place of its own whole-stream scans.
+// frameworkPassCandidateIdentities is the compact census-time buffer for one
+// synthesizer. It retains only logical edge keys while the other passes run;
+// payloads and Meta are fetched exactly when this pass is about to start.
+type frameworkPassCandidateIdentities struct {
+	calls     []graph.EdgeIdentity
+	refs      []graph.EdgeIdentity
+	annotated []graph.EdgeIdentity
+	nodes     *frameworkNodeSnapshot
+}
+
+// frameworkPassCandidates is the live per-synthesizer bundle handed to a
+// converted pass in place of its own whole-stream scans. It exists only for
+// that pass invocation and reflects all mutations committed by earlier passes.
 type frameworkPassCandidates struct {
-	// calls / refs hold the pass's EdgeCalls / EdgeReferences candidates in
-	// census stream order. They are census-time reads: consult them through
-	// refetchFrameworkCandidates so mutations by earlier passes are honoured.
-	calls []*graph.Edge
-	refs  []*graph.Edge
-	// annotated holds the temporal-tagged EdgeAnnotated edges (temporal
-	// only). No pass mutates annotation edges, so they are used directly.
+	calls     []*graph.Edge
+	refs      []*graph.Edge
 	annotated []*graph.Edge
 	// nodes is the run-wide shared node snapshot (one decoded walk per node
 	// kind for the whole synthesizer loop).
@@ -88,7 +94,7 @@ func frameworkKindNodes(g graph.Store, snap *frameworkNodeSnapshot, kind graph.N
 // frameworkStreamCandidates owns the armed collectors and the per-pass
 // buffers for one full-census run.
 type frameworkStreamCandidates struct {
-	perPass map[string]*frameworkPassCandidates
+	perPass map[string]*frameworkPassCandidateIdentities
 	nodes   *frameworkNodeSnapshot
 
 	// macroNames / macroIDs pre-filter the macro-expansion use-site arm.
@@ -121,7 +127,7 @@ type frameworkCandidateCollector struct {
 // never correctness.
 func newFrameworkStreamCandidates(g graph.Store, present, markers map[string]int) *frameworkStreamCandidates {
 	sc := &frameworkStreamCandidates{
-		perPass: map[string]*frameworkPassCandidates{},
+		perPass: map[string]*frameworkPassCandidateIdentities{},
 		nodes:   &frameworkNodeSnapshot{},
 	}
 	armed := func(name string) bool {
@@ -199,22 +205,23 @@ func newFrameworkStreamCandidates(g graph.Store, present, markers map[string]int
 	return sc
 }
 
-func (sc *frameworkStreamCandidates) ensurePass(name string) *frameworkPassCandidates {
+func (sc *frameworkStreamCandidates) ensurePass(name string) *frameworkPassCandidateIdentities {
 	pc := sc.perPass[name]
 	if pc == nil {
-		pc = &frameworkPassCandidates{nodes: sc.nodes}
+		pc = &frameworkPassCandidateIdentities{nodes: sc.nodes}
 		sc.perPass[name] = pc
 	}
 	return pc
 }
 
-// passStreams returns the bundle for one pass, or nil when its collectors
-// were not armed (the pass then runs its legacy whole-stream form).
-func (sc *frameworkStreamCandidates) passStreams(name string) *frameworkPassCandidates {
+// passStreams materialises one pass's current edges with a single exact-key
+// batch read. Stores without the optional exact lookup fall back to the legacy
+// whole-stream form rather than issuing a broad adjacency query.
+func (sc *frameworkStreamCandidates) passStreams(g graph.Store, name string) *frameworkPassCandidates {
 	if sc == nil {
 		return nil
 	}
-	return sc.perPass[name]
+	return refetchFrameworkCandidates(g, sc.perPass[name])
 }
 
 // collectCalls hands one census-walk EdgeCalls edge to every armed
@@ -227,7 +234,7 @@ func (sc *frameworkStreamCandidates) collectCalls(e *graph.Edge) {
 	for _, c := range sc.callsCollectors {
 		if c.pred(e) {
 			pc := sc.perPass[c.name]
-			pc.calls = append(pc.calls, e)
+			pc.calls = append(pc.calls, graph.EdgeIdentityFor(e))
 		}
 	}
 }
@@ -240,7 +247,7 @@ func (sc *frameworkStreamCandidates) collectRefs(e *graph.Edge) {
 	for _, c := range sc.refsCollectors {
 		if c.pred(e) {
 			pc := sc.perPass[c.name]
-			pc.refs = append(pc.refs, e)
+			pc.refs = append(pc.refs, graph.EdgeIdentityFor(e))
 		}
 	}
 }
@@ -254,8 +261,11 @@ func (sc *frameworkStreamCandidates) wantsAnnotated() bool {
 }
 
 func (sc *frameworkStreamCandidates) addAnnotated(e *graph.Edge) {
+	if sc == nil || e == nil {
+		return
+	}
 	pc := sc.perPass[SynthTemporalStub]
-	pc.annotated = append(pc.annotated, e)
+	pc.annotated = append(pc.annotated, graph.EdgeIdentityFor(e))
 }
 
 func (sc *frameworkStreamCandidates) annotatedCount() int {
@@ -268,37 +278,36 @@ func (sc *frameworkStreamCandidates) annotatedCount() int {
 	return 0
 }
 
-// refetchFrameworkCandidates re-reads the CURRENT form of the collected
-// candidates, in collection order, through the pass's own store view. A
-// candidate whose (from, to, kind, file, line) identity no longer exists —
-// retargeted or removed by an earlier pass — is dropped, exactly as it
-// would no longer match a fresh predicate walk; one that survives is
-// returned in its live form (staged-overlay and Meta-current), so the
-// pass's own loop filters see the same state a fresh stream would yield.
-// One batched out-edge read replaces a whole-kind decode.
-func refetchFrameworkCandidates(g graph.Store, cands []*graph.Edge) []*graph.Edge {
-	if len(cands) == 0 {
+// refetchFrameworkCandidates re-reads one pass's CURRENT candidates in census
+// order. A candidate retargeted or removed by an earlier pass is absent from
+// the exact lookup and therefore drops out exactly as it would from a fresh
+// kind scan. The lookup happens once, immediately before the pass begins.
+func refetchFrameworkCandidates(g graph.Store, cands *frameworkPassCandidateIdentities) *frameworkPassCandidates {
+	if cands == nil {
 		return nil
 	}
-	fromIDs := make([]string, 0, len(cands))
-	for _, e := range cands {
-		fromIDs = append(fromIDs, e.From)
+	finder, ok := g.(graph.EdgeIdentityBatchFinder)
+	if !ok {
+		return nil
 	}
-	byKey := map[string]*graph.Edge{}
-	for _, edges := range g.GetOutEdgesByNodeIDs(dedupeFrameworkIDs(fromIDs)) {
-		for _, e := range edges {
-			if e != nil {
-				byKey[frameworkScopedEdgeKey(e)] = e
+	identities := make([]graph.EdgeIdentity, 0, len(cands.calls)+len(cands.refs)+len(cands.annotated))
+	identities = append(identities, cands.calls...)
+	identities = append(identities, cands.refs...)
+	identities = append(identities, cands.annotated...)
+	current := finder.FindEdgesByIdentities(identities)
+	materialize := func(ids []graph.EdgeIdentity) []*graph.Edge {
+		out := make([]*graph.Edge, 0, len(ids))
+		for _, identity := range ids {
+			if edge := current[identity]; edge != nil {
+				out = append(out, edge)
 			}
 		}
+		return out
 	}
-	out := make([]*graph.Edge, 0, len(cands))
-	for _, c := range cands {
-		if e := byKey[frameworkScopedEdgeKey(c)]; e != nil {
-			out = append(out, e)
-		}
+	return &frameworkPassCandidates{
+		calls: materialize(cands.calls), refs: materialize(cands.refs),
+		annotated: materialize(cands.annotated), nodes: cands.nodes,
 	}
-	return out
 }
 
 // frameworkEdgeSeq adapts a candidate slice to the iterator shape a kind

--- a/internal/resolver/framework_stream_mux.go
+++ b/internal/resolver/framework_stream_mux.go
@@ -224,6 +224,22 @@ func (sc *frameworkStreamCandidates) passStreams(g graph.Store, name string) *fr
 	return refetchFrameworkCandidates(g, sc.perPass[name])
 }
 
+// releasePass drops both the compact census buffer and the pass-local live
+// edge slices as soon as the registry turn finishes. A skipped/gated pass has
+// no live bundle, but its armed census buffer is still released here.
+func (sc *frameworkStreamCandidates) releasePass(name string, bundle *frameworkPassCandidates) {
+	if sc != nil {
+		delete(sc.perPass, name)
+	}
+	if bundle == nil {
+		return
+	}
+	bundle.calls = nil
+	bundle.refs = nil
+	bundle.annotated = nil
+	bundle.nodes = nil
+}
+
 // collectCalls hands one census-walk EdgeCalls edge to every armed
 // collector. Edges without a source node are skipped: no pass can act on a
 // degenerate edge and the current-form re-read below is keyed by source.

--- a/internal/resolver/framework_stream_mux_test.go
+++ b/internal/resolver/framework_stream_mux_test.go
@@ -95,6 +95,30 @@ func TestFrameworkPassCandidatesHydrateOnceByExactIdentity(t *testing.T) {
 	}
 }
 
+func TestFrameworkPassCandidatesReleaseDropsBufferedAndLiveEdges(t *testing.T) {
+	edge := &graph.Edge{From: "caller", To: "callee", Kind: graph.EdgeCalls}
+	snapshot := &frameworkNodeSnapshot{}
+	sc := &frameworkStreamCandidates{perPass: map[string]*frameworkPassCandidateIdentities{
+		"admitted": {calls: []graph.EdgeIdentity{graph.EdgeIdentityFor(edge)}, nodes: snapshot},
+		"gated":    {refs: []graph.EdgeIdentity{{From: "caller", To: "ref", Kind: graph.EdgeReferences}}, nodes: snapshot},
+	}}
+	bundle := &frameworkPassCandidates{
+		calls: []*graph.Edge{edge}, refs: []*graph.Edge{edge}, annotated: []*graph.Edge{edge}, nodes: snapshot,
+	}
+
+	sc.releasePass("admitted", bundle)
+	if _, retained := sc.perPass["admitted"]; retained {
+		t.Fatal("admitted census buffer was retained")
+	}
+	if bundle.calls != nil || bundle.refs != nil || bundle.annotated != nil || bundle.nodes != nil {
+		t.Fatalf("live pass bundle retained data: %#v", bundle)
+	}
+	sc.releasePass("gated", nil)
+	if len(sc.perPass) != 0 {
+		t.Fatalf("gated census buffers retained: %#v", sc.perPass)
+	}
+}
+
 func TestFrameworkPassCandidatesWithoutExactLookupUseLegacyPath(t *testing.T) {
 	g := graph.New()
 	edge := &graph.Edge{From: "caller", To: "callee", Kind: graph.EdgeCalls}

--- a/internal/resolver/framework_stream_mux_test.go
+++ b/internal/resolver/framework_stream_mux_test.go
@@ -1,0 +1,112 @@
+package resolver
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+type frameworkIdentityLookupTestStore struct {
+	graph.Store
+	exactCalls int
+	requested  []graph.EdgeIdentity
+	broadCalls int
+}
+
+func (s *frameworkIdentityLookupTestStore) FindEdgesByIdentities(
+	identities []graph.EdgeIdentity,
+) map[graph.EdgeIdentity]*graph.Edge {
+	s.exactCalls++
+	s.requested = append([]graph.EdgeIdentity(nil), identities...)
+	finder := s.Store.(graph.EdgeIdentityBatchFinder)
+	return finder.FindEdgesByIdentities(identities)
+}
+
+func (s *frameworkIdentityLookupTestStore) GetOutEdgesByNodeIDs(
+	ids []string,
+) map[string][]*graph.Edge {
+	s.broadCalls++
+	return s.Store.GetOutEdgesByNodeIDs(ids)
+}
+
+type frameworkBroadOnlyTestStore struct {
+	graph.Store
+	broadCalls int
+}
+
+func (s *frameworkBroadOnlyTestStore) GetOutEdgesByNodeIDs(
+	ids []string,
+) map[string][]*graph.Edge {
+	s.broadCalls++
+	return s.Store.GetOutEdgesByNodeIDs(ids)
+}
+
+func TestFrameworkPassCandidatesHydrateOnceByExactIdentity(t *testing.T) {
+	g := graph.New()
+	first := &graph.Edge{From: "caller", To: "first", Kind: graph.EdgeCalls, FilePath: "a.go", Line: 1, Meta: map[string]any{"version": "old"}}
+	second := &graph.Edge{From: "caller", To: "second", Kind: graph.EdgeCalls, FilePath: "a.go", Line: 2}
+	removed := &graph.Edge{From: "caller", To: "removed", Kind: graph.EdgeCalls, FilePath: "a.go", Line: 3}
+	ref := &graph.Edge{From: "caller", To: "ref", Kind: graph.EdgeReferences, FilePath: "a.go", Line: 4}
+	annotated := &graph.Edge{From: "caller", To: "annotation", Kind: graph.EdgeAnnotated, FilePath: "a.go", Line: 5}
+	g.AddBatch(nil, []*graph.Edge{first, second, removed, ref, annotated})
+
+	firstID := graph.EdgeIdentityFor(first)
+	secondID := graph.EdgeIdentityFor(second)
+	removedID := graph.EdgeIdentityFor(removed)
+	refID := graph.EdgeIdentityFor(ref)
+	annotatedID := graph.EdgeIdentityFor(annotated)
+
+	// Same logical key, newer payload: hydration must return the live row.
+	g.AddEdge(&graph.Edge{From: first.From, To: first.To, Kind: first.Kind, FilePath: first.FilePath, Line: first.Line, Meta: map[string]any{"version": "live"}})
+	// An earlier pass removed this identity: it must disappear from the bundle.
+	g.RemoveEdge(removed.From, removed.To, removed.Kind)
+
+	store := &frameworkIdentityLookupTestStore{Store: g}
+	sc := &frameworkStreamCandidates{perPass: map[string]*frameworkPassCandidateIdentities{
+		"pass": {
+			calls:     []graph.EdgeIdentity{secondID, firstID, removedID},
+			refs:      []graph.EdgeIdentity{refID},
+			annotated: []graph.EdgeIdentity{annotatedID},
+		},
+	}}
+	bundle := sc.passStreams(store, "pass")
+	if bundle == nil {
+		t.Fatal("exact-capable store returned no candidate bundle")
+	}
+	if store.exactCalls != 1 || store.broadCalls != 0 {
+		t.Fatalf("reads = exact:%d broad:%d, want 1/0", store.exactCalls, store.broadCalls)
+	}
+	wantRequested := []graph.EdgeIdentity{secondID, firstID, removedID, refID, annotatedID}
+	if !reflect.DeepEqual(store.requested, wantRequested) {
+		t.Fatalf("requested identities = %#v, want %#v", store.requested, wantRequested)
+	}
+	if len(bundle.calls) != 2 || bundle.calls[0].To != "second" || bundle.calls[1].To != "first" {
+		t.Fatalf("call order/live filtering = %#v", bundle.calls)
+	}
+	if got := bundle.calls[1].Meta["version"]; got != "live" {
+		t.Fatalf("hydrated payload version = %#v, want live", got)
+	}
+	if len(bundle.refs) != 1 || bundle.refs[0].To != "ref" {
+		t.Fatalf("refs = %#v", bundle.refs)
+	}
+	if len(bundle.annotated) != 1 || bundle.annotated[0].To != "annotation" {
+		t.Fatalf("annotated = %#v", bundle.annotated)
+	}
+}
+
+func TestFrameworkPassCandidatesWithoutExactLookupUseLegacyPath(t *testing.T) {
+	g := graph.New()
+	edge := &graph.Edge{From: "caller", To: "callee", Kind: graph.EdgeCalls}
+	g.AddEdge(edge)
+	store := &frameworkBroadOnlyTestStore{Store: g}
+	sc := &frameworkStreamCandidates{perPass: map[string]*frameworkPassCandidateIdentities{
+		"pass": {calls: []graph.EdgeIdentity{graph.EdgeIdentityFor(edge)}},
+	}}
+	if bundle := sc.passStreams(store, "pass"); bundle != nil {
+		t.Fatalf("bundle = %#v, want nil legacy fallback", bundle)
+	}
+	if store.broadCalls != 0 {
+		t.Fatalf("broad adjacency reads = %d, want 0", store.broadCalls)
+	}
+}

--- a/internal/resolver/framework_synth.go
+++ b/internal/resolver/framework_synth.go
@@ -1156,7 +1156,7 @@ func runFrameworkSynthesizersScoped(
 		var n int
 		if shouldRunFrameworkSynthesizer(s, scope, candidates) {
 			if sf, ok := s.(synthFunc); ok {
-				bundle := candidates.streams.passStreams(sf.name)
+				bundle := candidates.streams.passStreams(g, sf.name)
 				switch {
 				case sf.candFn != nil && bundle != nil:
 					// Shared-stream form. streams exist only on a full-census

--- a/internal/resolver/framework_synth.go
+++ b/internal/resolver/framework_synth.go
@@ -1154,9 +1154,10 @@ func runFrameworkSynthesizersScoped(
 	for _, s := range defaultFrameworkSynthesizers() {
 		start := time.Now()
 		var n int
+		var bundle *frameworkPassCandidates
 		if shouldRunFrameworkSynthesizer(s, scope, candidates) {
 			if sf, ok := s.(synthFunc); ok {
-				bundle := candidates.streams.passStreams(g, sf.name)
+				bundle = candidates.streams.passStreams(g, sf.name)
 				switch {
 				case sf.candFn != nil && bundle != nil:
 					// Shared-stream form. streams exist only on a full-census
@@ -1184,7 +1185,11 @@ func runFrameworkSynthesizersScoped(
 		}
 		rep.Per = append(rep.Per, SynthCount{Name: s.Name(), Edges: n, Millis: time.Since(start).Milliseconds()})
 		rep.Total += n
+		candidates.streams.releasePass(s.Name(), bundle)
 	}
+	// The registry consumed or discarded every armed buffer. Release the
+	// shared node snapshot before the independent tail gates and claimers run.
+	candidates.streams = nil
 	// Drop coincidental cross-language-family reference/import results before
 	// the claiming resolvers run, so a gated edge cannot be mistaken for a
 	// resolved placeholder downstream. Bridge synthesizers are exempt.

--- a/internal/resolver/grpc_stub_calls.go
+++ b/internal/resolver/grpc_stub_calls.go
@@ -66,7 +66,7 @@ func resolveGRPCStubCalls(g graph.Store, cands *frameworkPassCandidates) int {
 	callsStream := g.EdgesByKind(graph.EdgeCalls)
 	var sharedCalls []*graph.Edge
 	if cands != nil {
-		sharedCalls = refetchFrameworkCandidates(g, cands.calls)
+		sharedCalls = cands.calls
 		callsStream = frameworkEdgeSeq(sharedCalls)
 	}
 

--- a/internal/resolver/macro_expansion_calls.go
+++ b/internal/resolver/macro_expansion_calls.go
@@ -140,7 +140,7 @@ func resolveMacroExpansionCalls(g graph.Store, cands *frameworkPassCandidates) i
 	}
 	useSiteStream := g.EdgesByKind(graph.EdgeCalls)
 	if cands != nil {
-		useSiteStream = frameworkEdgeSeq(refetchFrameworkCandidates(g, cands.calls))
+		useSiteStream = frameworkEdgeSeq(cands.calls)
 	}
 	var callEdges []*graph.Edge
 	var candidateCallerIDs []string

--- a/internal/resolver/rails_resolve.go
+++ b/internal/resolver/rails_resolve.go
@@ -48,13 +48,12 @@ func resolveRailsRefs(g graph.Store, cands *frameworkPassCandidates) int {
 	}
 	stream := g.EdgesByKind(graph.EdgeCalls)
 	if cands != nil {
-		refetched := refetchFrameworkCandidates(g, cands.calls)
-		if len(refetched) == 0 {
+		if len(cands.calls) == 0 {
 			// The convention indexes below are pure reads consumed only by
 			// the loop; with no candidates the pass provably lands nothing.
 			return 0
 		}
-		stream = frameworkEdgeSeq(refetched)
+		stream = frameworkEdgeSeq(cands.calls)
 	}
 	models := railsModelClassSet(g)
 	methodsByClass := railsClassMethodIndex(g)

--- a/internal/resolver/react_resolve.go
+++ b/internal/resolver/react_resolve.go
@@ -54,8 +54,8 @@ func resolveReactHooksContext(g graph.Store, cands *frameworkPassCandidates) int
 	callsStream := g.EdgesByKind(graph.EdgeCalls)
 	refsStream := g.EdgesByKind(graph.EdgeReferences)
 	if cands != nil {
-		callsStream = frameworkEdgeSeq(refetchFrameworkCandidates(g, cands.calls))
-		refsStream = frameworkEdgeSeq(refetchFrameworkCandidates(g, cands.refs))
+		callsStream = frameworkEdgeSeq(cands.calls)
+		refsStream = frameworkEdgeSeq(cands.refs)
 	}
 	resolved := 0
 	var reindex []graph.EdgeReindex

--- a/internal/resolver/rust_scope.go
+++ b/internal/resolver/rust_scope.go
@@ -103,7 +103,7 @@ func resolveRustScopeCalls(g graph.Store, cands *frameworkPassCandidates) int {
 	fromIDs := make(map[string]struct{})
 	callStream := g.EdgesByKind(graph.EdgeCalls)
 	if cands != nil {
-		callStream = frameworkEdgeSeq(refetchFrameworkCandidates(g, cands.calls))
+		callStream = frameworkEdgeSeq(cands.calls)
 	}
 	for e := range callStream {
 		if e == nil {

--- a/internal/resolver/store_factory_calls.go
+++ b/internal/resolver/store_factory_calls.go
@@ -65,7 +65,7 @@ func resolveStoreFactoryCalls(g graph.Store, cands *frameworkPassCandidates) int
 
 	stream := g.EdgesByKind(graph.EdgeCalls)
 	if cands != nil {
-		stream = frameworkEdgeSeq(refetchFrameworkCandidates(g, cands.calls))
+		stream = frameworkEdgeSeq(cands.calls)
 	}
 	resolved := 0
 	var reindex []graph.EdgeReindex

--- a/internal/resolver/temporal_calls.go
+++ b/internal/resolver/temporal_calls.go
@@ -412,7 +412,7 @@ func resolveTemporalCalls(g graph.Store, cands *frameworkPassCandidates) int {
 	shared := cands != nil
 	var wrapperSeed []*graph.Edge
 	if shared {
-		wrapperSeed = refetchFrameworkCandidates(g, cands.calls)
+		wrapperSeed = cands.calls
 	}
 	for i := 0; i < 16; i++ {
 		added := resolveTemporalWrapperCalls(g, wrapperSeed, shared)
@@ -431,7 +431,7 @@ func resolveTemporalCalls(g graph.Store, cands *frameworkPassCandidates) int {
 	// literal name supplied at the executor's construction site. Also runs
 	// before the sweep so the rewritten stubs resolve below.
 	if shared {
-		resolveTemporalExecutorFields(g, refetchFrameworkCandidates(g, cands.calls), true)
+		resolveTemporalExecutorFields(g, cands.calls, true)
 	} else {
 		resolveTemporalExecutorFields(g, nil, false)
 	}
@@ -452,7 +452,7 @@ func resolveTemporalCalls(g graph.Store, cands *frameworkPassCandidates) int {
 	if shared {
 		// The census candidates plus this pass's own staged wrapper stubs
 		// are exactly the overlay a fresh stream walk would surface here.
-		sweep := refetchFrameworkCandidates(g, cands.calls)
+		sweep := cands.calls
 		if bs, ok := g.(*frameworkEdgeBatchStore); ok {
 			sweep = append(sweep, bs.stagedEdgesMatching(func(e *graph.Edge) bool {
 				if e.Kind != graph.EdgeCalls || e.Meta == nil {
@@ -742,7 +742,7 @@ func resolveTemporalCalls(g graph.Store, cands *frameworkPassCandidates) int {
 	// sweep above and the via=temporal.handler edges emitted by the Go
 	// extractor. Additive — graph.AddEdge dedupes.
 	if shared {
-		resolveTemporalCrossLanguage(g, refetchFrameworkCandidates(g, cands.calls), true)
+		resolveTemporalCrossLanguage(g, cands.calls, true)
 	} else {
 		resolveTemporalCrossLanguage(g, nil, false)
 	}


### PR DESCRIPTION
## Summary

- retain compact graph.EdgeIdentity keys during the framework census instead of decoded edge payloads and metadata
- hydrate calls, references, and annotations with one exact identity batch lookup immediately before each admitted pass
- release admitted and gated pass buffers at their registry turn, then drop the shared snapshot before tail passes
- preserve legacy scans for adapter stores without exact lookup support

## Verification

- go test ./internal/resolver
- go test ./internal/graph/... ./internal/resolver ./internal/indexer
- go test -race ./internal/resolver

## Commits

- perf(resolver): hydrate framework candidates by identity
- perf(resolver): release framework pass buffers eagerly