### PR TITLE
perf(resolver): eliminate framework edge-key allocation churn

### DIFF
--- a/internal/resolver/csharp_iface_dispatch.go
+++ b/internal/resolver/csharp_iface_dispatch.go
@@ -282,7 +282,7 @@ func ResolveCSharpInterfaceDispatchScoped(g graph.Store, scope map[string]bool) 
 	callEdges := frameworkEdgesByKinds(g, graph.EdgeCalls)
 	if scope != nil {
 		callEdges = nil
-		callSeen := make(map[string]struct{})
+		callSeen := make(map[graph.EdgeIdentity]struct{})
 		callEdges = appendUniqueFrameworkEdges(callEdges, callSeen, scopedSourceCalls...)
 		familyMemberIDs := make([]string, 0, len(famsOfMember))
 		for id := range famsOfMember {

--- a/internal/resolver/framework_edge_batch.go
+++ b/internal/resolver/framework_edge_batch.go
@@ -16,16 +16,16 @@ import (
 // duplicates use last-write-wins, matching Graph.AddEdge and Graph.AddBatch.
 type frameworkEdgeBatchStore struct {
 	graph.Store
-	staged    map[string]*graph.Edge
-	order     []string
-	orderSeen map[string]struct{}
+	staged    map[graph.EdgeIdentity]*graph.Edge
+	order     []graph.EdgeIdentity
+	orderSeen map[graph.EdgeIdentity]struct{}
 }
 
 func newFrameworkEdgeBatchStore(store graph.Store) *frameworkEdgeBatchStore {
 	return &frameworkEdgeBatchStore{
 		Store:     store,
-		staged:    make(map[string]*graph.Edge),
-		orderSeen: make(map[string]struct{}),
+		staged:    make(map[graph.EdgeIdentity]*graph.Edge),
+		orderSeen: make(map[graph.EdgeIdentity]struct{}),
 	}
 }
 
@@ -35,7 +35,7 @@ func (s *frameworkEdgeBatchStore) AllNodes() []*graph.Node {
 
 func (s *frameworkEdgeBatchStore) AddEdge(edge *graph.Edge) {
 	copy := cloneFrameworkEdge(edge)
-	key := frameworkScopedEdgeKey(copy)
+	key := graph.EdgeIdentityFor(copy)
 	if _, seen := s.orderSeen[key]; !seen {
 		s.orderSeen[key] = struct{}{}
 		s.order = append(s.order, key)
@@ -50,7 +50,7 @@ func (s *frameworkEdgeBatchStore) AddEdge(edge *graph.Edge) {
 func (s *frameworkEdgeBatchStore) AddBatch(nodes []*graph.Node, edges []*graph.Edge) {
 	for _, edge := range edges {
 		if edge != nil {
-			delete(s.staged, frameworkScopedEdgeKey(edge))
+			delete(s.staged, graph.EdgeIdentityFor(edge))
 		}
 	}
 	s.Store.AddBatch(nodes, edges)
@@ -73,9 +73,9 @@ func (s *frameworkEdgeBatchStore) flush() {
 	// observable and no later synthesizer runs; mutation receipts/errors retain
 	// the backend's native AddBatch semantics.
 	s.Store.AddBatch(nil, edges)
-	s.staged = make(map[string]*graph.Edge)
+	s.staged = make(map[graph.EdgeIdentity]*graph.Edge)
 	s.order = nil
-	s.orderSeen = make(map[string]struct{})
+	s.orderSeen = make(map[graph.EdgeIdentity]struct{})
 }
 
 func runLegacyFrameworkSynth(store graph.Store, fn func(graph.Store) int) int {
@@ -380,12 +380,12 @@ func (s *frameworkEdgeBatchStore) mergeEdges(
 		return base
 	}
 	out := make([]*graph.Edge, 0, len(base)+len(s.staged))
-	seen := make(map[string]struct{}, len(s.staged))
+	seen := make(map[graph.EdgeIdentity]struct{}, len(s.staged))
 	for _, edge := range base {
 		if edge == nil {
 			continue
 		}
-		key := frameworkScopedEdgeKey(edge)
+		key := graph.EdgeIdentityFor(edge)
 		if staged := s.staged[key]; staged != nil {
 			seen[key] = struct{}{}
 			if include(staged) {
@@ -411,12 +411,12 @@ func (s *frameworkEdgeBatchStore) mergeEdgeSeq(
 	include func(*graph.Edge) bool,
 ) iter.Seq[*graph.Edge] {
 	return func(yield func(*graph.Edge) bool) {
-		seen := make(map[string]struct{}, len(s.staged))
+		seen := make(map[graph.EdgeIdentity]struct{}, len(s.staged))
 		for edge := range base {
 			if edge == nil {
 				continue
 			}
-			key := frameworkScopedEdgeKey(edge)
+			key := graph.EdgeIdentityFor(edge)
 			if staged := s.staged[key]; staged != nil {
 				seen[key] = struct{}{}
 				if include(staged) && !yield(staged) {

--- a/internal/resolver/framework_edge_batch_test.go
+++ b/internal/resolver/framework_edge_batch_test.go
@@ -120,7 +120,7 @@ func TestFrameworkEdgeBatchReadYourWritesAndOrdering(t *testing.T) {
 		}
 		seen := 0
 		for candidate := range store.EdgesByKind(graph.EdgeCalls) {
-			if candidate != nil && frameworkScopedEdgeKey(candidate) == frameworkScopedEdgeKey(edge) {
+			if candidate != nil && graph.EdgeIdentityFor(candidate) == graph.EdgeIdentityFor(edge) {
 				seen++
 			}
 		}
@@ -219,6 +219,53 @@ func TestMacroExpansionUsesConstantBatchReadsAndOneWrite(t *testing.T) {
 	}
 	if g.EdgeCount() != 201 {
 		t.Fatalf("stored edges = %d, want 201", g.EdgeCount())
+	}
+}
+
+func TestFrameworkIdentityMapKeysDoNotCollideOnNUL(t *testing.T) {
+	left := &graph.Edge{From: "a", To: "b\x00c", Kind: graph.EdgeCalls, FilePath: "x.go", Line: 7}
+	right := &graph.Edge{From: "a\x00b", To: "c", Kind: graph.EdgeCalls, FilePath: "x.go", Line: 7}
+	if graph.EdgeIdentityFor(left) == graph.EdgeIdentityFor(right) {
+		t.Fatal("distinct edge identities collided")
+	}
+
+	g := graph.New()
+	batch := newFrameworkEdgeBatchStore(g)
+	batch.AddEdge(left)
+	batch.AddEdge(right)
+	if len(batch.staged) != 2 || len(batch.order) != 2 {
+		t.Fatalf("batch identity entries = staged:%d ordered:%d, want 2/2", len(batch.staged), len(batch.order))
+	}
+	batch.flush()
+	if g.EdgeCount() != 2 {
+		t.Fatalf("stored edges = %d, want 2", g.EdgeCount())
+	}
+
+	view := &frameworkScopedStore{
+		incidentSeen:   make(map[graph.EdgeIdentity]struct{}),
+		incidentByKind: make(map[graph.EdgeKind][]*graph.Edge),
+	}
+	if !view.rememberEdge(left) || !view.rememberEdge(right) {
+		t.Fatal("scoped store rejected identity collision fixtures")
+	}
+	if view.retainedRows != 2 || len(view.incidentSeen) != 2 {
+		t.Fatalf("scoped retained identities = rows:%d seen:%d, want 2/2", view.retainedRows, len(view.incidentSeen))
+	}
+}
+
+var frameworkIdentityBenchmarkSink bool
+
+func BenchmarkFrameworkEdgeIdentityMapLookup(b *testing.B) {
+	edge := &graph.Edge{
+		From: "repo::internal/resolver.(*frameworkScopedStore).rememberEdge",
+		To:   "repo::internal/graph.EdgeIdentityFor",
+		Kind: graph.EdgeCalls, FilePath: "internal/resolver/framework_scoped_store.go", Line: 316,
+	}
+	index := map[graph.EdgeIdentity]struct{}{graph.EdgeIdentityFor(edge): {}}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, frameworkIdentityBenchmarkSink = index[graph.EdgeIdentityFor(edge)]
 	}
 }
 

--- a/internal/resolver/framework_scope.go
+++ b/internal/resolver/framework_scope.go
@@ -2,7 +2,6 @@ package resolver
 
 import (
 	"sort"
-	"strconv"
 
 	"github.com/zzet/gortex/internal/graph"
 )
@@ -53,20 +52,12 @@ func frameworkRepoEdges(g graph.Store, scope map[string]bool, kinds ...graph.Edg
 	return out
 }
 
-func frameworkEdgeIdentity(edge *graph.Edge) string {
-	if edge == nil {
-		return ""
-	}
-	return edge.From + "\x00" + edge.To + "\x00" + string(edge.Kind) + "\x00" +
-		edge.FilePath + "\x00" + strconv.Itoa(edge.Line)
-}
-
-func appendUniqueFrameworkEdges(dst []*graph.Edge, seen map[string]struct{}, edges ...*graph.Edge) []*graph.Edge {
+func appendUniqueFrameworkEdges(dst []*graph.Edge, seen map[graph.EdgeIdentity]struct{}, edges ...*graph.Edge) []*graph.Edge {
 	for _, edge := range edges {
-		key := frameworkEdgeIdentity(edge)
-		if key == "" {
+		if edge == nil {
 			continue
 		}
+		key := graph.EdgeIdentityFor(edge)
 		if _, duplicate := seen[key]; duplicate {
 			continue
 		}
@@ -84,7 +75,7 @@ func frameworkCallsForScope(g graph.Store, scope map[string]bool) []*graph.Edge 
 		return frameworkEdgesByKinds(g, graph.EdgeCalls)
 	}
 	prefixes := frameworkScopePrefixes(scope)
-	seen := make(map[string]struct{})
+	seen := make(map[graph.EdgeIdentity]struct{})
 	var out []*graph.Edge
 	for _, row := range graph.ReadRepoEdgesByKinds(g, prefixes, []graph.EdgeKind{graph.EdgeCalls}) {
 		out = appendUniqueFrameworkEdges(out, seen, row.Edge)

--- a/internal/resolver/framework_scope_test.go
+++ b/internal/resolver/framework_scope_test.go
@@ -1,0 +1,39 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestAppendUniqueFrameworkEdgesUsesExactIdentity(t *testing.T) {
+	zero := &graph.Edge{}
+	first := &graph.Edge{
+		From: "caller", To: "callee", Kind: graph.EdgeCalls,
+		FilePath: "x.go", Line: 7, Origin: graph.OriginASTResolved,
+		Meta: map[string]any{"version": "first"},
+	}
+	duplicatePayload := &graph.Edge{
+		From: first.From, To: first.To, Kind: first.Kind,
+		FilePath: first.FilePath, Line: first.Line,
+		Origin: graph.OriginASTInferred, Confidence: 0.9,
+		Meta: map[string]any{"version": "second"},
+	}
+	left := &graph.Edge{From: "a", To: "b\x00c", Kind: graph.EdgeCalls}
+	right := &graph.Edge{From: "a\x00b", To: "c", Kind: graph.EdgeCalls}
+
+	seen := make(map[graph.EdgeIdentity]struct{})
+	got := appendUniqueFrameworkEdges(nil, seen, nil, zero, first, duplicatePayload, left, right)
+	if len(got) != 4 || len(seen) != 4 {
+		t.Fatalf("unique edges = rows:%d seen:%d, want 4/4", len(got), len(seen))
+	}
+	if got[0] != zero {
+		t.Fatal("real zero-valued edge was confused with nil")
+	}
+	if got[1] != first {
+		t.Fatal("duplicate identity did not preserve the first edge")
+	}
+	if got[2] != left || got[3] != right {
+		t.Fatalf("NUL-bearing identities collided or reordered: %#v", got[2:])
+	}
+}

--- a/internal/resolver/framework_scoped_store.go
+++ b/internal/resolver/framework_scoped_store.go
@@ -1,7 +1,6 @@
 package resolver
 
 import (
-	"fmt"
 	"iter"
 	"sort"
 	"strings"
@@ -81,7 +80,7 @@ type frameworkScopedStore struct {
 
 	nodes          map[string]*graph.Node
 	incidentByKind map[graph.EdgeKind][]*graph.Edge
-	incidentSeen   map[string]struct{}
+	incidentSeen   map[graph.EdgeIdentity]struct{}
 	inEdges        map[string][]*graph.Edge
 	outEdges       map[string][]*graph.Edge
 	inReady        map[string]struct{}
@@ -102,7 +101,7 @@ func newFrameworkScopedStore(
 		scope:          newFrameworkExecutionScope(repos, filePaths),
 		nodes:          make(map[string]*graph.Node),
 		incidentByKind: make(map[graph.EdgeKind][]*graph.Edge),
-		incidentSeen:   make(map[string]struct{}),
+		incidentSeen:   make(map[graph.EdgeIdentity]struct{}),
 		inEdges:        make(map[string][]*graph.Edge),
 		outEdges:       make(map[string][]*graph.Edge),
 		inReady:        make(map[string]struct{}),
@@ -313,7 +312,7 @@ func (v *frameworkScopedStore) rememberEdge(edge *graph.Edge) bool {
 	if edge == nil {
 		return false
 	}
-	key := frameworkScopedEdgeKey(edge)
+	key := graph.EdgeIdentityFor(edge)
 	if _, exists := v.incidentSeen[key]; exists {
 		return true
 	}
@@ -377,11 +376,6 @@ func frameworkValueBytes(value any) int {
 	default:
 		return 16
 	}
-}
-
-func frameworkScopedEdgeKey(edge *graph.Edge) string {
-	return edge.From + "\x00" + edge.To + "\x00" + string(edge.Kind) + "\x00" +
-		edge.FilePath + "\x00" + fmt.Sprint(edge.Line)
 }
 
 // seedChangedFileFrontier admits only exact changed-file nodes, their incident

--- a/internal/resolver/framework_stream_mux.go
+++ b/internal/resolver/framework_stream_mux.go
@@ -284,17 +284,17 @@ func refetchFrameworkCandidates(g graph.Store, cands []*graph.Edge) []*graph.Edg
 	for _, e := range cands {
 		fromIDs = append(fromIDs, e.From)
 	}
-	byKey := map[string]*graph.Edge{}
+	byKey := map[graph.EdgeIdentity]*graph.Edge{}
 	for _, edges := range g.GetOutEdgesByNodeIDs(dedupeFrameworkIDs(fromIDs)) {
 		for _, e := range edges {
 			if e != nil {
-				byKey[frameworkScopedEdgeKey(e)] = e
+				byKey[graph.EdgeIdentityFor(e)] = e
 			}
 		}
 	}
 	out := make([]*graph.Edge, 0, len(cands))
 	for _, c := range cands {
-		if e := byKey[frameworkScopedEdgeKey(c)]; e != nil {
+		if e := byKey[graph.EdgeIdentityFor(c)]; e != nil {
 			out = append(out, e)
 		}
 	}

--- a/internal/resolver/macro_expansion_calls.go
+++ b/internal/resolver/macro_expansion_calls.go
@@ -204,11 +204,11 @@ func resolveMacroExpansionCalls(g graph.Store, cands *frameworkPassCandidates) i
 	for _, site := range sites {
 		callerIDs = append(callerIDs, site.caller)
 	}
-	existingCalls := make(map[string]*graph.Edge)
+	existingCalls := make(map[graph.EdgeIdentity]*graph.Edge)
 	for _, edges := range g.GetOutEdgesByNodeIDs(dedupeFrameworkIDs(callerIDs)) {
 		for _, edge := range edges {
 			if edge != nil && edge.Kind == graph.EdgeCalls {
-				existingCalls[frameworkScopedEdgeKey(edge)] = edge
+				existingCalls[graph.EdgeIdentityFor(edge)] = edge
 			}
 		}
 	}
@@ -235,7 +235,7 @@ func resolveMacroExpansionCalls(g graph.Store, cands *frameworkPassCandidates) i
 					MetaProvenance:    ProvenanceHeuristic,
 				},
 			}
-			key := frameworkScopedEdgeKey(edge)
+			key := graph.EdgeIdentityFor(edge)
 			if existing := existingCalls[key]; existing != nil {
 				if v, _ := existing.Meta["via"].(string); v != macroExpansionVia {
 					// A real edge already occupies this exact identity


### PR DESCRIPTION
## Summary

- replace NUL-delimited string edge keys with comparable graph.EdgeIdentity values across scoped retention, write batching, candidate refetch, and macro expansion
- remove the duplicate scoped-call serializer and use the same exact identity type for deduplication
- preserve first-seen and last-write-wins behavior while distinguishing identities the old serializer could collide
- add collision, payload-insensitivity, nil/zero-edge, ordering, and allocation coverage

## Allocation result

BenchmarkFrameworkEdgeIdentityMapLookup: 45.42 ns/op, 0 B/op, 0 allocs/op on darwin/arm64.

## Verification

- go test ./internal/resolver
- go test ./internal/graph/... ./internal/resolver ./internal/indexer
- go test -race ./internal/resolver
- go test ./internal/resolver -run ^$ -bench ^BenchmarkFrameworkEdgeIdentityMapLookup$ -benchmem -count=1

## Commits

- perf(resolver): key framework edges by identity
- perf(resolver): deduplicate scoped edges by identity