### PR TITLE
fix(indexer): coordinate repository mutation pipelines

### DIFF
--- a/internal/indexer/batch_census_test.go
+++ b/internal/indexer/batch_census_test.go
@@ -1,23 +1,45 @@
 package indexer
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-// The full-coverage census attestation is strictly one-shot: consumed by the
-// next global-pass run and reset, so a cold batch's attestation can never
-// leak into a later incremental batch.
-func TestArmBatchCensusEligibleIsOneShot(t *testing.T) {
+func TestBatchScopeAndCensusBelongOnlyToEndBatch(t *testing.T) {
 	mi := &MultiIndexer{}
-	assert.False(t, mi.takeBatchCensusEligible(), "unarmed by default")
 
+	// Arming outside an active batch is inert.
+	mi.ArmBatchScope(map[string]struct{}{"ignored": {}})
 	mi.ArmBatchCensusEligible()
-	assert.True(t, mi.takeBatchCensusEligible(), "armed attestation is consumed once")
-	assert.False(t, mi.takeBatchCensusEligible(), "consumption must reset the attestation")
+	assert.Nil(t, mi.batchChangedPrefixes)
+	assert.False(t, mi.batchCensusEligible)
+
+	mi.BeginBatch()
+	first := map[string]struct{}{"repo-a": {}}
+	mi.ArmBatchScope(first)
+	delete(first, "repo-a")
+	first["caller-mutation"] = struct{}{}
+	mi.ArmBatchScope(map[string]struct{}{"repo-b": {}})
+	mi.ArmBatchCensusEligible()
+
+	// An unrelated public run is explicitly unscoped and cannot steal the
+	// one-shot state that belongs to EndBatch.
+	mi.RunGlobalGraphPasses(context.Background())
+	mi.mu.RLock()
+	assert.Equal(t, map[string]struct{}{"repo-a": {}, "repo-b": {}}, mi.batchChangedPrefixes)
+	assert.True(t, mi.batchCensusEligible)
+	mi.mu.RUnlock()
+
+	mi.EndBatch()
+	mi.mu.RLock()
+	assert.Nil(t, mi.batchChangedPrefixes)
+	assert.False(t, mi.batchCensusEligible)
+	assert.False(t, mi.deferGlobalPasses)
+	assert.False(t, mi.deferResolve)
+	mi.mu.RUnlock()
 
 	var nilIndexer *MultiIndexer
 	nilIndexer.ArmBatchCensusEligible()
-	assert.False(t, nilIndexer.takeBatchCensusEligible(), "nil receiver is inert")
 }

--- a/internal/indexer/batch_transition_coordinator_test.go
+++ b/internal/indexer/batch_transition_coordinator_test.go
@@ -1,0 +1,403 @@
+package indexer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+	"github.com/zzet/gortex/internal/reach"
+	"github.com/zzet/gortex/internal/search"
+)
+
+const batchTransitionTestTimeout = 5 * time.Second
+
+func newBatchTransitionTestMulti(g graph.Store) *MultiIndexer {
+	if g == nil {
+		g = graph.New()
+	}
+	return NewMultiIndexer(g, parser.NewRegistry(), search.NewBM25(), nil, zap.NewNop())
+}
+
+func requireBatchTransitionBlocked(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-done:
+		t.Fatal("batch transition completed while a repository mutation was active")
+	case <-time.After(75 * time.Millisecond):
+	}
+}
+
+func TestIndexAllWorkersDoNotReenterRegistryLock(t *testing.T) {
+	g := graph.New()
+	reg := parser.NewRegistry()
+	reg.Register(languages.NewGoExtractor())
+	cm := newTestConfigManager(t)
+
+	for _, name := range []string{"repo-a", "repo-b"} {
+		root := filepath.Join(t.TempDir(), name)
+		require.NoError(t, os.MkdirAll(root, 0o755))
+		writeFile(t, filepath.Join(root, "main.go"), "package main\nfunc "+name[len(name)-1:]+"() {}\n")
+		cm.Global().Repos = append(cm.Global().Repos, config.RepoEntry{Path: root, Name: name})
+	}
+
+	mi := NewMultiIndexer(g, reg, search.NewAuto(), cm, zap.NewNop())
+	done := make(chan error, 1)
+	go func() {
+		_, err := mi.IndexAll()
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(batchTransitionTestTimeout):
+		t.Fatal("IndexAll deadlocked while workers constructed per-repository indexers")
+	}
+}
+
+func TestParallelBatchPropagatesAndResetClearsBothIndexerFlags(t *testing.T) {
+	mi := newBatchTransitionTestMulti(nil)
+	existing := &Indexer{}
+	mi.indexers["existing"] = existing
+
+	mi.BeginParallelBatch()
+	assert.True(t, existing.deferGlobalPasses.Load())
+	assert.True(t, existing.deferResolve.Load())
+
+	created := mi.newPerRepoIndexer(config.IndexConfig{})
+	assert.True(t, created.deferGlobalPasses.Load(), "a batch-created indexer must inherit global deferral")
+	assert.True(t, created.deferResolve.Load(), "a batch-created indexer must inherit resolver deferral")
+	mi.mu.Lock()
+	mi.indexers["created"] = created
+	mi.mu.Unlock()
+
+	mi.ResetBatch()
+	for name, idx := range map[string]*Indexer{"existing": existing, "created": created} {
+		assert.False(t, idx.deferGlobalPasses.Load(), "%s retained global deferral", name)
+		assert.False(t, idx.deferResolve.Load(), "%s retained resolver deferral", name)
+	}
+}
+
+func TestBatchTransitionWaitsForReconcileExecutor(t *testing.T) {
+	mi := newBatchTransitionTestMulti(nil)
+	idx := &Indexer{}
+	mi.indexers["repo"] = idx
+	coordinator := mi.repositoryMutationCoordinator("repo")
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	coordinator.mu.Lock()
+	coordinator.executor = func([]string) (*IndexResult, error) {
+		close(started)
+		<-release
+		return &IndexResult{}, nil
+	}
+	coordinator.mu.Unlock()
+
+	reconcileDone := make(chan error, 1)
+	go func() {
+		_, err := coordinator.reconcile(context.Background(), []string{"a.go"})
+		reconcileDone <- err
+	}()
+	select {
+	case <-started:
+	case <-time.After(batchTransitionTestTimeout):
+		t.Fatal("reconcile executor did not start")
+	}
+
+	transitionDone := make(chan struct{})
+	go func() {
+		mi.BeginParallelBatch()
+		close(transitionDone)
+	}()
+	requireBatchTransitionBlocked(t, transitionDone)
+
+	close(release)
+	require.NoError(t, <-reconcileDone)
+	select {
+	case <-transitionDone:
+	case <-time.After(batchTransitionTestTimeout):
+		t.Fatal("batch transition did not resume after reconcile executor completed")
+	}
+	assert.True(t, idx.deferGlobalPasses.Load())
+	assert.True(t, idx.deferResolve.Load())
+	mi.ResetBatch()
+}
+
+func TestBatchTransitionWaitsForExclusiveCallback(t *testing.T) {
+	mi := newBatchTransitionTestMulti(nil)
+	idx := &Indexer{}
+	mi.indexers["repo"] = idx
+	coordinator := mi.repositoryMutationCoordinator("repo")
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	mutationDone := make(chan error, 1)
+	go func() {
+		mutationDone <- coordinator.runExclusive(context.Background(), func() error {
+			close(started)
+			<-release
+			return nil
+		})
+	}()
+	select {
+	case <-started:
+	case <-time.After(batchTransitionTestTimeout):
+		t.Fatal("exclusive mutation did not start")
+	}
+
+	transitionDone := make(chan struct{})
+	go func() {
+		mi.BeginBatch()
+		close(transitionDone)
+	}()
+	requireBatchTransitionBlocked(t, transitionDone)
+
+	close(release)
+	require.NoError(t, <-mutationDone)
+	select {
+	case <-transitionDone:
+	case <-time.After(batchTransitionTestTimeout):
+		t.Fatal("batch transition did not resume after exclusive mutation completed")
+	}
+	assert.True(t, idx.deferGlobalPasses.Load())
+	assert.False(t, idx.deferResolve.Load())
+	mi.ResetBatch()
+}
+
+func TestQueuedMutationReappliesModeAfterTransition(t *testing.T) {
+	mi := newBatchTransitionTestMulti(nil)
+	idx := &Indexer{}
+	coordinator := mi.repositoryMutationCoordinator("repo")
+
+	mi.batchMutationGate.Lock()
+	submitted := make(chan struct{})
+	observed := make(chan multiIndexerBatchMode, 1)
+	mutationDone := make(chan error, 1)
+	go func() {
+		close(submitted)
+		mutationDone <- coordinator.runExclusive(context.Background(), func() error {
+			observed <- mi.reapplyBatchModeForMutation(idx)
+			return nil
+		})
+	}()
+	<-submitted
+	select {
+	case <-observed:
+		mi.batchMutationGate.Unlock()
+		t.Fatal("queued mutation crossed the transition write gate")
+	case <-time.After(75 * time.Millisecond):
+	}
+
+	// Model the flag update performed by BeginParallelBatch without propagating
+	// to this not-yet-registered Indexer. Its guarded callback must close that
+	// construction-to-admission window from the authoritative MultiIndexer mode.
+	mi.mu.Lock()
+	mi.deferGlobalPasses = true
+	mi.deferResolve = true
+	mi.mu.Unlock()
+	mi.batchMutationGate.Unlock()
+
+	var mode multiIndexerBatchMode
+	select {
+	case mode = <-observed:
+	case <-time.After(batchTransitionTestTimeout):
+		t.Fatal("queued mutation did not resume after transition")
+	}
+	require.NoError(t, <-mutationDone)
+	assert.True(t, mode.deferGlobalPasses)
+	assert.True(t, mode.deferResolve)
+	assert.True(t, idx.deferGlobalPasses.Load())
+	assert.True(t, idx.deferResolve.Load())
+	mi.ResetBatch()
+}
+
+type blockingBatchCheckpointStore struct {
+	graph.Store
+	entered chan struct{}
+	release <-chan struct{}
+	once    sync.Once
+}
+
+func (s *blockingBatchCheckpointStore) CheckpointWAL() error {
+	s.once.Do(func() { close(s.entered) })
+	<-s.release
+	return nil
+}
+
+func TestEndBatchHoldsTransitionGateThroughGlobalPass(t *testing.T) {
+	releaseCheckpoint := make(chan struct{})
+	store := &blockingBatchCheckpointStore{
+		Store:   graph.New(),
+		entered: make(chan struct{}),
+		release: releaseCheckpoint,
+	}
+	mi := newBatchTransitionTestMulti(store)
+	store.AddNode(&graph.Node{ID: "sink", Kind: graph.KindFunction, Name: "sink", FilePath: "sink.go"})
+	_, _, _, hit := reach.Lookup(store, "sink")
+	require.True(t, hit)
+	beforeBuild := reach.BuildCounter()
+	mi.BeginBatch()
+
+	endDone := make(chan struct{})
+	go func() {
+		mi.EndBatch()
+		close(endDone)
+	}()
+	select {
+	case <-store.entered:
+	case <-time.After(batchTransitionTestTimeout):
+		t.Fatal("EndBatch did not reach the global-pass checkpoint")
+	}
+
+	coordinator := mi.repositoryMutationCoordinator("repo")
+	callbackRan := make(chan struct{})
+	mutationDone := make(chan error, 1)
+	go func() {
+		mutationDone <- coordinator.runExclusive(context.Background(), func() error {
+			close(callbackRan)
+			return nil
+		})
+	}()
+	select {
+	case <-callbackRan:
+		t.Fatal("repository mutation ran while EndBatch global pass held the write gate")
+	case <-time.After(75 * time.Millisecond):
+	}
+
+	lookupStarted := make(chan struct{})
+	lookupDone := make(chan struct{})
+	go func() {
+		close(lookupStarted)
+		reach.Lookup(store, "sink")
+		close(lookupDone)
+	}()
+	<-lookupStarted
+	select {
+	case <-lookupDone:
+		t.Fatal("reach lookup escaped the EndBatch topology transaction")
+	case <-time.After(75 * time.Millisecond):
+	}
+
+	close(releaseCheckpoint)
+	select {
+	case <-endDone:
+	case <-time.After(batchTransitionTestTimeout):
+		t.Fatal("EndBatch did not finish after checkpoint release")
+	}
+	require.NoError(t, <-mutationDone)
+	select {
+	case <-callbackRan:
+	case <-time.After(batchTransitionTestTimeout):
+		t.Fatal("repository mutation did not resume after EndBatch")
+	}
+	select {
+	case <-lookupDone:
+	case <-time.After(batchTransitionTestTimeout):
+		t.Fatal("reach lookup did not resume after EndBatch publication")
+	}
+	require.Greater(t, reach.BuildCounter(), beforeBuild)
+}
+
+type blockingBatchPurgeStore struct {
+	graph.Store
+	entered chan struct{}
+	release <-chan struct{}
+	once    sync.Once
+}
+
+func (s *blockingBatchPurgeStore) PurgeRepo(string) error {
+	s.once.Do(func() { close(s.entered) })
+	<-s.release
+	return nil
+}
+
+func TestUntrackTeardownBlocksDirectGlobalPass(t *testing.T) {
+	releasePurge := make(chan struct{})
+	store := &blockingBatchPurgeStore{
+		Store:   graph.New(),
+		entered: make(chan struct{}),
+		release: releasePurge,
+	}
+	mi := newBatchTransitionTestMulti(store)
+	store.AddNode(&graph.Node{ID: "sink", Kind: graph.KindFunction, Name: "sink", FilePath: "sink.go"})
+	_, _, _, hit := reach.Lookup(store, "sink")
+	require.True(t, hit)
+	beforeBuild := reach.BuildCounter()
+	coordinator := mi.repositoryMutationCoordinator("repo")
+	idx := &Indexer{}
+	idx.attachRepositoryMutationCoordinator(coordinator)
+	mi.mu.Lock()
+	mi.indexers["repo"] = idx
+	mi.repos["repo"] = &RepoMetadata{RepoPrefix: "repo", NodeCount: 1, EdgeCount: 2}
+	mi.mu.Unlock()
+
+	type removalCounts struct{ nodes, edges int }
+	untrackDone := make(chan removalCounts, 1)
+	go func() {
+		nodes, edges := mi.UntrackRepo("repo")
+		untrackDone <- removalCounts{nodes: nodes, edges: edges}
+	}()
+	select {
+	case <-store.entered:
+	case <-time.After(batchTransitionTestTimeout):
+		t.Fatal("UntrackRepo did not reach the repository purge")
+	}
+
+	globalSubmitted := make(chan struct{})
+	globalDone := make(chan struct{})
+	go func() {
+		close(globalSubmitted)
+		mi.RunGlobalGraphPasses(context.Background())
+		close(globalDone)
+	}()
+	<-globalSubmitted
+	select {
+	case <-globalDone:
+		t.Fatal("direct global pass crossed an in-flight untrack teardown")
+	case <-time.After(75 * time.Millisecond):
+	}
+
+	lookupStarted := make(chan struct{})
+	lookupDone := make(chan struct{})
+	go func() {
+		close(lookupStarted)
+		reach.Lookup(store, "sink")
+		close(lookupDone)
+	}()
+	<-lookupStarted
+	select {
+	case <-lookupDone:
+		t.Fatal("reach lookup escaped an in-flight untrack topology transaction")
+	case <-time.After(75 * time.Millisecond):
+	}
+
+	close(releasePurge)
+	select {
+	case removed := <-untrackDone:
+		assert.Equal(t, removalCounts{nodes: 1, edges: 2}, removed)
+	case <-time.After(batchTransitionTestTimeout):
+		t.Fatal("UntrackRepo did not finish after purge release")
+	}
+	select {
+	case <-globalDone:
+	case <-time.After(batchTransitionTestTimeout):
+		t.Fatal("direct global pass did not resume after untrack teardown")
+	}
+	select {
+	case <-lookupDone:
+	case <-time.After(batchTransitionTestTimeout):
+		t.Fatal("reach lookup did not resume after untrack publication")
+	}
+	require.Greater(t, reach.BuildCounter(), beforeBuild)
+}

--- a/internal/indexer/dataflow_scoped_equiv_test.go
+++ b/internal/indexer/dataflow_scoped_equiv_test.go
@@ -98,7 +98,11 @@ func echo(s string) string { return s }
 	files := goFilesUnder(t, dir)
 	require.NotEmpty(t, files)
 	for _, f := range files {
-		require.NoError(t, idx.IndexFileNoResolve(f))
+		// This fixture deliberately stops before resolver/dataflow work. The
+		// public IndexFileNoResolve compatibility alias now owns the complete
+		// coordinated point-mutation pipeline, so use the package-private raw
+		// helper to preserve the test's pre-materialisation graph state.
+		require.NoError(t, idx.indexFile(f, false))
 	}
 	idx.resolver.ResolveAll()
 

--- a/internal/indexer/deferred_work_test.go
+++ b/internal/indexer/deferred_work_test.go
@@ -121,7 +121,7 @@ func TestDeferredIncrementalGoFrontierUsesOneBatchAndNoRepoPass(t *testing.T) {
 			languages.RegisterAll(registry)
 			idx := New(store, registry, config.IndexConfig{}, zap.NewNop())
 			idx.rootPath = root
-			idx.deferGlobalPasses = true
+			idx.deferGlobalPasses.Store(true)
 
 			provider := &deferredBatchProvider{}
 			manager := semantic.NewManager(semantic.Config{

--- a/internal/indexer/direct_mutation_api_test.go
+++ b/internal/indexer/direct_mutation_api_test.go
@@ -1,0 +1,164 @@
+package indexer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+	"github.com/zzet/gortex/internal/search"
+)
+
+func TestIndexFileRejectsMissingAndDirectoryBeforeAdmission(t *testing.T) {
+	root := t.TempDir()
+	coordinator := newRepositoryMutationCoordinator(func([]string) (*IndexResult, error) {
+		t.Fatal("invalid IndexFile request reached the repository executor")
+		return nil, nil
+	})
+	idx := &Indexer{rootPath: root}
+	idx.attachRepositoryMutationCoordinator(coordinator)
+
+	require.Error(t, idx.IndexFile("missing.go"))
+	require.ErrorContains(t, idx.IndexFile("."), "repository root")
+	directory := filepath.Join(root, "pkg")
+	require.NoError(t, os.Mkdir(directory, 0o755))
+	require.ErrorContains(t, idx.IndexFile(directory), "not a regular file")
+	require.Zero(t, coordinator.stats().RequestedGeneration)
+}
+
+func TestIndexFileRevalidatesAfterWaitingForRepositoryLane(t *testing.T) {
+	root := t.TempDir()
+	filePath := filepath.Join(root, "queued.go")
+	require.NoError(t, os.WriteFile(filePath, []byte("package queued\n"), 0o644))
+
+	coordinator := newRepositoryMutationCoordinator(nil)
+	var batchGate sync.RWMutex
+	batchGate.Lock()
+	coordinator.batchMutationGate = &batchGate
+	idx := &Indexer{rootPath: root}
+	idx.attachRepositoryMutationCoordinator(coordinator)
+
+	done := make(chan error, 1)
+	go func() { done <- idx.IndexFile(filePath) }()
+	require.Eventually(t, func() bool {
+		return len(coordinator.lane) == 0
+	}, time.Second, time.Millisecond, "IndexFile never acquired the repository lane")
+	require.NoError(t, os.Remove(filePath))
+	batchGate.Unlock()
+
+	require.ErrorContains(t, <-done, "queued.go")
+}
+
+func TestDirectMutationAPIsUseStableLaneAndCurrentIndexer(t *testing.T) {
+	root := t.TempDir()
+	filePath := filepath.Join(root, "main.go")
+	require.NoError(t, os.WriteFile(filePath, []byte("package main\nfunc Original() {}\n"), 0o644))
+
+	g := graph.New()
+	reg := parser.NewRegistry()
+	reg.Register(languages.NewGoExtractor())
+	cfg := config.Default()
+	cfg.Index.Workers = 1
+	mi := NewMultiIndexer(g, reg, search.NewAuto(), nil, zap.NewNop())
+	current := mi.newPerRepoIndexer(cfg.Index)
+	current.SetRepoPrefix("repo")
+	// Fixture construction mirrors TrackRepo/IndexRepo: the per-repository
+	// Indexer is not live until it is published in mi.indexers, so initialize
+	// its graph through the already-coordinated raw full-tree primitive.
+	_, err := current.indexCtxRaw(context.Background(), root)
+	require.NoError(t, err)
+	coordinator := mi.repositoryMutationCoordinator("repo")
+	current.attachRepositoryMutationCoordinator(coordinator)
+	mi.mu.Lock()
+	mi.indexers["repo"] = current
+	mi.repos["repo"] = &RepoMetadata{
+		RepoPrefix: "repo",
+		RootPath:   root,
+		FileCount:  1,
+		NodeCount:  len(g.GetFileNodes("repo/main.go")),
+		FileMtimes: current.FileMtimes(),
+	}
+	mi.mu.Unlock()
+
+	// The stale handle intentionally has an empty parser registry and a separate
+	// graph. Success therefore proves raw work selected the current registered
+	// Indexer after admission on the prefix-owned lane.
+	stale := New(graph.New(), parser.NewRegistry(), cfg.Index, zap.NewNop())
+	stale.SetRepoPrefix("repo")
+	stale.storeRootPath(root)
+	stale.repositoryMutationOwner = mi
+	stale.attachRepositoryMutationCoordinator(coordinator)
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	blockDone := make(chan error, 1)
+	go func() {
+		blockDone <- stale.coordinateRepositoryMutation(context.Background(), func() error {
+			close(entered)
+			<-release
+			return nil
+		})
+	}()
+	<-entered
+	require.NoError(t, os.WriteFile(filePath, []byte("package main\nfunc Modern() {}\n"), 0o644))
+	indexDone := make(chan error, 1)
+	go func() { indexDone <- stale.IndexFile(filePath) }()
+	select {
+	case err := <-indexDone:
+		t.Fatalf("IndexFile crossed an occupied repository lane: %v", err)
+	case <-time.After(75 * time.Millisecond):
+	}
+	close(release)
+	require.NoError(t, <-blockDone)
+	require.NoError(t, <-indexDone)
+	require.NotEmpty(t, g.FindNodesByName("Modern"))
+	require.Empty(t, g.FindNodesByName("Original"))
+
+	require.NoError(t, os.WriteFile(filePath, []byte("package main\nfunc Compatible() {}\n"), 0o644))
+	require.NoError(t, stale.IndexFileNoResolve("main.go"))
+	require.NotEmpty(t, g.FindNodesByName("Compatible"), "deprecated alias must run the complete modern point tail")
+	require.NoError(t, stale.ReresolveFileScoped("main.go"))
+
+	nodesRemoved, _ := stale.EvictFile("main.go")
+	require.Positive(t, nodesRemoved)
+	_, statErr := os.Stat(filePath)
+	require.NoError(t, statErr, "forced eviction must not delete or require deletion of the disk file")
+	require.Empty(t, g.GetFileNodes("repo/main.go"))
+	require.False(t, current.incrementalPathOwned(filePath), "file metadata sidecar survived forced eviction")
+	current.mtimeMu.RLock()
+	_, mtimePresent := current.fileMtimes["main.go"]
+	current.mtimeMu.RUnlock()
+	require.False(t, mtimePresent, "file mtime survived forced eviction")
+}
+
+func TestEvictFileClearsOrphanSidecarsWithoutGraphOwnership(t *testing.T) {
+	root := t.TempDir()
+	g := graph.New()
+	cfg := config.Default()
+	idx := New(g, parser.NewRegistry(), cfg.Index, zap.NewNop())
+	idx.SetRepoPrefix("repo")
+	idx.storeRootPath(root)
+	idx.SetFileMtimes(map[string]int64{"orphan.go": 42})
+	require.NoError(t, g.SetFileMetas("repo", []graph.FileMetaRow{{
+		FilePath:    "repo/orphan.go",
+		ContentHash: "orphaned-sidecar",
+	}}))
+	require.Empty(t, g.GetFileNodes("repo/orphan.go"), "fixture must not have graph ownership")
+
+	nodesRemoved, edgesRemoved := idx.EvictFile("orphan.go")
+	require.Zero(t, nodesRemoved)
+	require.Zero(t, edgesRemoved)
+	rows, err := g.FileMetasForRepo("repo")
+	require.NoError(t, err)
+	require.Empty(t, rows, "forced eviction left an orphan file metadata sidecar")
+	require.NotContains(t, idx.FileMtimes(), "orphan.go", "forced eviction left an orphan mtime")
+}

--- a/internal/indexer/file_delta.go
+++ b/internal/indexer/file_delta.go
@@ -178,7 +178,11 @@ func (idx *Indexer) takePreparedExtraction(absPath, relPath, lang string, src []
 	return prepared.result, true
 }
 
-func (idx *Indexer) takePreparedRefresh(filePath string) (*preparedExtraction, bool) {
+// takePreparedSnapshot consumes the speculative parse without re-reading disk.
+// Direct IndexFile uses this to commit the exact accepted read and let its
+// original receipt report a concurrent write. Batch refreshes use
+// takePreparedRefresh below, which replaces a stale speculative parse instead.
+func (idx *Indexer) takePreparedSnapshot(filePath string) (*preparedExtraction, bool) {
 	absPath, err := filepath.Abs(filePath)
 	if err != nil {
 		return nil, false
@@ -187,7 +191,16 @@ func (idx *Indexer) takePreparedRefresh(filePath string) (*preparedExtraction, b
 	prepared := idx.prepared[absPath]
 	delete(idx.prepared, absPath)
 	idx.preparedMu.Unlock()
-	if prepared == nil {
+	return prepared, prepared != nil
+}
+
+func (idx *Indexer) takePreparedRefresh(filePath string) (*preparedExtraction, bool) {
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		return nil, false
+	}
+	prepared, ok := idx.takePreparedSnapshot(absPath)
+	if !ok {
 		return nil, false
 	}
 	current, readVersion, err := readFileWithVersion(absPath)

--- a/internal/indexer/file_delta_read_version_test.go
+++ b/internal/indexer/file_delta_read_version_test.go
@@ -105,15 +105,18 @@ func TestIncrementalBatchDoesNotStampWriteDuringCommit(t *testing.T) {
 	require.NoError(t, os.Chtimes(path, firstMtime, firstMtime))
 
 	type chunkResult struct {
-		consumed int
-		reparsed []string
-		failed   []string
+		consumed      int
+		reparsed      []string
+		failed        []string
+		versionChange []string
 	}
 	store.armed.Store(true)
 	done := make(chan chunkResult, 1)
 	go func() {
-		consumed, _, reparsed, failed := idx.reindexIncrementalChunk([]string{path}, nil)
-		done <- chunkResult{consumed: consumed, reparsed: reparsed, failed: failed}
+		consumed, _, reparsed, failed, versionChange := idx.reindexIncrementalChunk([]string{path}, nil, false)
+		done <- chunkResult{
+			consumed: consumed, reparsed: reparsed, failed: failed, versionChange: versionChange,
+		}
 	}()
 	select {
 	case <-store.entered:
@@ -127,12 +130,14 @@ func TestIncrementalBatchDoesNotStampWriteDuringCommit(t *testing.T) {
 	result := <-done
 	require.Equal(t, 1, result.consumed)
 	require.Contains(t, result.failed, path)
+	require.Contains(t, result.versionChange, path)
 	require.NotContains(t, result.reparsed, path)
 	require.NotEqual(t, secondMtime.UnixNano(), idx.FileMtimes()[idx.relKey(path)])
 
 	store.armed.Store(false)
-	_, _, reparsed, failed := idx.reindexIncrementalChunk([]string{path}, nil)
+	_, _, reparsed, failed, versionChange := idx.reindexIncrementalChunk([]string{path}, nil, false)
 	require.Empty(t, failed)
+	require.Empty(t, versionChange)
 	require.Contains(t, reparsed, path)
 	require.Equal(t, secondMtime.UnixNano(), idx.FileMtimes()[idx.relKey(path)])
 	assertFileNodeName(t, base, idx.graphRelKey(path), "Second")

--- a/internal/indexer/full_topology_transaction_test.go
+++ b/internal/indexer/full_topology_transaction_test.go
@@ -1,0 +1,326 @@
+package indexer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+	"github.com/zzet/gortex/internal/reach"
+	"github.com/zzet/gortex/internal/search"
+)
+
+func TestIndexCtxStaleHandleUsesCurrentIndexerAndMetadata(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "main.go"), "package sample\nfunc Existing() {}\n")
+
+	g := graph.New()
+	reg := parser.NewRegistry()
+	reg.Register(languages.NewGoExtractor())
+	cm := newTestConfigManager(t)
+	mi := NewMultiIndexer(g, reg, search.NewBM25(), cm, zap.NewNop())
+	entry := config.RepoEntry{Path: root, Name: "repo"}
+
+	beforeTrack := reach.BuildCounter()
+	_, err := mi.TrackRepo(entry)
+	require.NoError(t, err)
+	require.Greater(t, reach.BuildCounter(), beforeTrack)
+	stale := mi.GetIndexer("repo")
+	require.NotNil(t, stale)
+
+	beforeReplace := reach.BuildCounter()
+	_, err = mi.IndexRepo("repo")
+	require.NoError(t, err)
+	require.Greater(t, reach.BuildCounter(), beforeReplace)
+	current := mi.GetIndexer("repo")
+	require.NotNil(t, current)
+	require.NotSame(t, stale, current)
+
+	newPath := filepath.Join(root, "new.go")
+	writeFile(t, newPath, "package sample\nfunc Added() {}\n")
+	newKey := stale.relKey(newPath)
+	_, staleHadNewFile := stale.FileMtimes()[newKey]
+	require.False(t, staleHadNewFile)
+
+	beforeIndex := reach.BuildCounter()
+	result, err := stale.IndexCtx(context.Background(), root)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Greater(t, reach.BuildCounter(), beforeIndex)
+	require.Same(t, current, mi.GetIndexer("repo"))
+	_, staleHasNewFile := stale.FileMtimes()[newKey]
+	require.False(t, staleHasNewFile, "stale receiver must remain untouched")
+	_, currentHasNewFile := current.FileMtimes()[newKey]
+	require.True(t, currentHasNewFile, "live replacement must receive the full-tree index")
+
+	meta := mi.GetMetadata("repo")
+	require.NotNil(t, meta)
+	require.Equal(t, result.FileCount, meta.FileCount)
+	require.Equal(t, result.NodeCount, meta.NodeCount)
+	require.Equal(t, result.EdgeCount, meta.EdgeCount)
+	_, metadataHasNewFile := meta.FileMtimes[newKey]
+	require.True(t, metadataHasNewFile)
+}
+
+func TestReconcileTopologyGenerationChangesOnlyForRealMutation(t *testing.T) {
+	root := t.TempDir()
+	mainPath := filepath.Join(root, "main.go")
+	writeFile(t, mainPath, "package sample\nfunc Existing() {}\n")
+
+	g := graph.New()
+	reg := parser.NewRegistry()
+	reg.Register(languages.NewGoExtractor())
+	cm := newTestConfigManager(t)
+	entry := config.RepoEntry{Path: root, Name: "repo"}
+	seed := NewMultiIndexer(g, reg, search.NewBM25(), cm, zap.NewNop())
+	_, err := seed.TrackRepo(entry)
+	require.NoError(t, err)
+	prior := seed.GetIndexer("repo").FileMtimes()
+
+	writeFile(t, filepath.Join(root, "added.go"), "package sample\nfunc Added() {}\n")
+	changed := NewMultiIndexer(g, reg, search.NewBM25(), cm, zap.NewNop())
+	beforeChanged := reach.BuildCounter()
+	changedResult, err := changed.ReconcileRepoCtx(context.Background(), entry, prior)
+	require.NoError(t, err)
+	require.NotNil(t, changedResult)
+	require.Greater(t, reach.BuildCounter(), beforeChanged)
+
+	unchangedPrior := changed.GetIndexer("repo").FileMtimes()
+	unchanged := NewMultiIndexer(g, reg, search.NewBM25(), cm, zap.NewNop())
+	beforeUnchanged := reach.BuildCounter()
+	unchangedResult, err := unchanged.ReconcileRepoCtx(context.Background(), entry, unchangedPrior)
+	require.NoError(t, err)
+	require.NotNil(t, unchangedResult)
+	require.False(t, incrementalTopologyChanged(unchangedResult))
+	require.Equal(t, beforeUnchanged, reach.BuildCounter(), "unchanged hourly reconciliation must not flush lazy reach")
+}
+
+type armableBlockingAddBatchStore struct {
+	graph.Store
+	mu        sync.Mutex
+	remaining int
+	entered   chan struct{}
+	release   chan struct{}
+}
+
+func (s *armableBlockingAddBatchStore) arm(blocks int) (<-chan struct{}, chan struct{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.remaining = blocks
+	s.entered = make(chan struct{}, blocks)
+	s.release = make(chan struct{})
+	return s.entered, s.release
+}
+
+func (s *armableBlockingAddBatchStore) AddBatch(nodes []*graph.Node, edges []*graph.Edge) {
+	s.mu.Lock()
+	shouldBlock := s.remaining > 0
+	entered := s.entered
+	release := s.release
+	if shouldBlock {
+		s.remaining--
+	}
+	s.mu.Unlock()
+	if shouldBlock {
+		entered <- struct{}{}
+		<-release
+	}
+	s.Store.AddBatch(nodes, edges)
+}
+
+func TestIndexAllHoldsEveryLaneAndTopologyThroughPublication(t *testing.T) {
+	reg := parser.NewRegistry()
+	reg.Register(languages.NewGoExtractor())
+	cm := newTestConfigManager(t)
+	for _, name := range []string{"repo-a", "repo-b"} {
+		root := filepath.Join(t.TempDir(), name)
+		require.NoError(t, os.MkdirAll(root, 0o755))
+		writeFile(t, filepath.Join(root, "main.go"), "package sample\nfunc Existing() {}\n")
+		cm.Global().Repos = append(cm.Global().Repos, config.RepoEntry{Path: root, Name: name})
+	}
+	store := &armableBlockingAddBatchStore{Store: graph.New()}
+	mi := NewMultiIndexer(store, reg, search.NewBM25(), cm, zap.NewNop())
+	_, err := mi.IndexAll()
+	require.NoError(t, err)
+	oldA := mi.GetIndexer("repo-a")
+	require.NotNil(t, oldA)
+	coordinatorA := mi.repositoryMutationCoordinator("repo-a")
+
+	store.AddNode(&graph.Node{ID: "topology-sink", Kind: graph.KindFunction, Name: "sink", FilePath: "sink.go"})
+	_, _, _, hit := reach.Lookup(store, "topology-sink")
+	require.True(t, hit)
+	beforeBuild := reach.BuildCounter()
+	entered, release := store.arm(2)
+
+	indexDone := make(chan error, 1)
+	go func() {
+		_, indexErr := mi.IndexAll()
+		indexDone <- indexErr
+	}()
+	for i := 0; i < 2; i++ {
+		select {
+		case <-entered:
+		case <-time.After(batchTransitionTestTimeout):
+			t.Fatal("parallel IndexAll workers did not both reach AddBatch")
+		}
+	}
+
+	callbackRan := make(chan *Indexer, 1)
+	callbackDone := make(chan error, 1)
+	go func() {
+		callbackDone <- coordinatorA.runExclusive(context.Background(), func() error {
+			callbackRan <- mi.GetIndexer("repo-a")
+			return nil
+		})
+	}()
+	select {
+	case <-callbackRan:
+		t.Fatal("same-repository mutation crossed the active IndexAll lane")
+	case <-time.After(75 * time.Millisecond):
+	}
+
+	lookupStarted := make(chan struct{})
+	lookupDone := make(chan struct{})
+	go func() {
+		close(lookupStarted)
+		reach.Lookup(store, "topology-sink")
+		close(lookupDone)
+	}()
+	<-lookupStarted
+	select {
+	case <-lookupDone:
+		t.Fatal("reach lookup escaped the active IndexAll topology transaction")
+	case <-time.After(75 * time.Millisecond):
+	}
+
+	close(release)
+	select {
+	case err := <-indexDone:
+		require.NoError(t, err)
+	case <-time.After(batchTransitionTestTimeout):
+		t.Fatal("IndexAll did not finish after AddBatch release")
+	}
+	require.NoError(t, <-callbackDone)
+	var callbackIndexer *Indexer
+	select {
+	case callbackIndexer = <-callbackRan:
+	case <-time.After(batchTransitionTestTimeout):
+		t.Fatal("same-repository mutation did not resume after IndexAll")
+	}
+	select {
+	case <-lookupDone:
+	case <-time.After(batchTransitionTestTimeout):
+		t.Fatal("reach lookup did not resume after IndexAll publication")
+	}
+	currentA := mi.GetIndexer("repo-a")
+	require.NotNil(t, currentA)
+	require.NotSame(t, oldA, currentA)
+	require.Same(t, currentA, callbackIndexer)
+	require.Same(t, coordinatorA, currentA.attachedRepositoryMutationCoordinator())
+	require.Greater(t, reach.BuildCounter(), beforeBuild)
+}
+
+type countingIndexAllStore struct {
+	graph.Store
+	mu      sync.Mutex
+	batches int
+}
+
+func (s *countingIndexAllStore) AddBatch(nodes []*graph.Node, edges []*graph.Edge) {
+	s.mu.Lock()
+	s.batches++
+	s.mu.Unlock()
+	s.Store.AddBatch(nodes, edges)
+}
+
+func (s *countingIndexAllStore) batchCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.batches
+}
+
+func TestIndexAllDeduplicatesIdenticalRepositoryEntries(t *testing.T) {
+	run := func(entries int) int {
+		t.Helper()
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, "main.go"), "package sample\nfunc Existing() {}\n")
+		reg := parser.NewRegistry()
+		reg.Register(languages.NewGoExtractor())
+		cm := newTestConfigManager(t)
+		for i := 0; i < entries; i++ {
+			cm.Global().Repos = append(cm.Global().Repos, config.RepoEntry{Path: root, Name: "repo"})
+		}
+		store := &countingIndexAllStore{Store: graph.New()}
+		mi := NewMultiIndexer(store, reg, search.NewBM25(), cm, zap.NewNop())
+		results, err := mi.IndexAll()
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		require.Same(t, mi.repositoryMutationCoordinator("repo"), mi.GetIndexer("repo").attachedRepositoryMutationCoordinator())
+		return store.batchCount()
+	}
+
+	one := run(1)
+	twoIdentical := run(2)
+	require.Positive(t, one)
+	require.Equal(t, one, twoIdentical, "a duplicate config entry must not launch a second raw worker")
+}
+
+func TestTrackRepoRechecksSamePathAcrossDifferentPrefixLanes(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "main.go"), "package sample\nfunc Existing() {}\n")
+	reg := parser.NewRegistry()
+	reg.Register(languages.NewGoExtractor())
+	mi := NewMultiIndexer(graph.New(), reg, search.NewBM25(), newTestConfigManager(t), zap.NewNop())
+
+	arrived := make(chan struct{}, 2)
+	release := make(chan struct{})
+	mi.SetOnRepoTracked(func(string, string) {
+		arrived <- struct{}{}
+		<-release
+	})
+
+	type trackOutcome struct {
+		result *IndexResult
+		err    error
+	}
+	outcomes := make(chan trackOutcome, 2)
+	for _, name := range []string{"first", "second"} {
+		name := name
+		go func() {
+			result, err := mi.TrackRepoCtx(context.Background(), config.RepoEntry{Path: root, Name: name})
+			outcomes <- trackOutcome{result: result, err: err}
+		}()
+	}
+	for i := 0; i < 2; i++ {
+		select {
+		case <-arrived:
+		case <-time.After(batchTransitionTestTimeout):
+			t.Fatal("concurrent track did not reach the cross-prefix admission barrier")
+		}
+	}
+	close(release)
+
+	nonNilResults := 0
+	for i := 0; i < 2; i++ {
+		select {
+		case outcome := <-outcomes:
+			require.NoError(t, outcome.err)
+			if outcome.result != nil {
+				nonNilResults++
+			}
+		case <-time.After(batchTransitionTestTimeout):
+			t.Fatal("concurrent track did not complete")
+		}
+	}
+	require.Equal(t, 1, nonNilResults)
+	require.Len(t, mi.AllMetadata(), 1, "one directory must not be registered under two prefix lanes")
+}

--- a/internal/indexer/git_watcher.go
+++ b/internal/indexer/git_watcher.go
@@ -30,18 +30,22 @@ import (
 // `git reset --mixed` leaving the working tree dirty) still fire
 // normal fsnotify events and flow through the per-file path.
 type GitWatcher struct {
-	repoPath    string
-	indexer     *Indexer
-	logger      *zap.Logger
-	fsw         *fsnotify.Watcher
-	debounce    time.Duration
-	done        chan struct{}
-	stopped     chan struct{}
-	mu          sync.Mutex
-	lastSHA     string
-	fireTimer   *time.Timer
-	loopStarted bool
-	stopCalled  bool
+	repoPath string
+	// indexer is the construction-time stable repository-lane carrier.
+	// MultiWatcher installs currentIndexer so the freshness tail resolves the
+	// currently registered Indexer only after that lane admits it.
+	indexer        *Indexer
+	currentIndexer func() *Indexer
+	logger         *zap.Logger
+	fsw            *fsnotify.Watcher
+	debounce       time.Duration
+	done           chan struct{}
+	stopped        chan struct{}
+	mu             sync.Mutex
+	lastSHA        string
+	fireTimer      *time.Timer
+	loopStarted    bool
+	stopCalled     bool
 	// reconciling single-flights reconcile: a ref event landing while
 	// one is in flight sets rerun instead of spawning a second
 	// concurrent reconcile from the same stale base (each AfterFunc
@@ -78,6 +82,32 @@ func NewGitWatcher(repoPath string, idx *Indexer, logger *zap.Logger) (*GitWatch
 		done:     make(chan struct{}),
 		stopped:  make(chan struct{}),
 	}, nil
+}
+
+func (gw *GitWatcher) registeredIndexer() *Indexer {
+	if gw.currentIndexer != nil {
+		return gw.currentIndexer()
+	}
+	return gw.indexer
+}
+
+// finalizeReconcile publishes commit freshness only while holding the stable
+// repository lane. IndexRepo replacement uses the same lane, so the registry
+// lookup and state restamp cannot land on a retired Indexer. lastSHA advances
+// after the restamp; failed lane admission therefore leaves the prior SHA for
+// the next ref notification to retry.
+func (gw *GitWatcher) finalizeReconcile(ctx context.Context, newSHA string) error {
+	return gw.indexer.coordinateRepositoryMutation(ctx, func() error {
+		idx := gw.registeredIndexer()
+		if idx == nil {
+			return fmt.Errorf("git-watcher: repository indexer is no longer registered")
+		}
+		idx.reconcileRepoIndexState(gw.repoPath)
+		gw.mu.Lock()
+		gw.lastSHA = newSHA
+		gw.mu.Unlock()
+		return nil
+	})
 }
 
 // Start sets up fsnotify watches on the repo's git control files and
@@ -259,12 +289,14 @@ func (gw *GitWatcher) reconcile(trigger string) {
 		return
 	}
 
-	// First observation (no prior SHA) — just record it without
-	// diffing. The caller warmed up with a full index already.
+	// First observation (no prior SHA) needs no diff because the caller
+	// warmed up with a full index already, but its SHA/restamp publication
+	// still uses the repository lane and current Indexer.
 	if oldSHA == "" {
-		gw.mu.Lock()
-		gw.lastSHA = newSHA
-		gw.mu.Unlock()
+		if err := gw.finalizeReconcile(context.Background(), newSHA); err != nil {
+			gw.logger.Warn("git-watcher: freshness finalization failed",
+				zap.String("trigger", trigger), zap.Error(err))
+		}
 		return
 	}
 
@@ -300,19 +332,31 @@ func (gw *GitWatcher) reconcile(trigger string) {
 		if res != nil {
 			patched = res.StaleFileCount + res.DeletedFileCount
 			failed = len(res.FailedFiles)
+			if failed > 0 {
+				gw.logger.Warn("git-watcher: batched reindex left failed files",
+					zap.String("trigger", trigger),
+					zap.Int("paths", len(changedPaths)),
+					zap.Int("failed", failed),
+					zap.Bool("large_batch", largeBatch))
+				return
+			}
 		}
 	}
 
+	// Publish the new SHA and on-disk freshness row together under the stable
+	// repository lane. Empty commits reach this tail without calling the batch
+	// reindexer; lane admission failure intentionally keeps oldSHA for retry.
+	if err := gw.finalizeReconcile(context.Background(), newSHA); err != nil {
+		gw.logger.Warn("git-watcher: freshness finalization failed",
+			zap.String("trigger", trigger),
+			zap.String("from", oldSHA),
+			zap.String("to", newSHA),
+			zap.Error(err))
+		return
+	}
 	gw.mu.Lock()
-	gw.lastSHA = newSHA
 	drained := gw.drained
 	gw.mu.Unlock()
-
-	// Re-stamp the on-disk freshness row at the new HEAD. The graph now
-	// reflects this commit, but the persisted repo_index_state row is
-	// otherwise written only by a full (re)index — leave it and
-	// `gortex repos` keeps reporting the repo stale after every commit.
-	gw.indexer.reconcileRepoIndexState(gw.repoPath)
 
 	gw.logger.Info("git-watcher: reconciled ref change",
 		zap.String("from", oldSHA[:min(len(oldSHA), 12)]),

--- a/internal/indexer/git_watcher_coordinator_test.go
+++ b/internal/indexer/git_watcher_coordinator_test.go
@@ -1,0 +1,156 @@
+package indexer
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+type gitWatcherStateStore struct {
+	graph.Store
+	mu     sync.Mutex
+	states []graph.RepoIndexState
+}
+
+func (store *gitWatcherStateStore) SetRepoIndexState(state graph.RepoIndexState) error {
+	store.mu.Lock()
+	store.states = append(store.states, state)
+	store.mu.Unlock()
+	return nil
+}
+
+func (store *gitWatcherStateStore) snapshotStates() []graph.RepoIndexState {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	return append([]graph.RepoIndexState(nil), store.states...)
+}
+
+func gitWatcherBoundaryIndexer(t *testing.T, store graph.Store, repoPath, prefix string) *Indexer {
+	t.Helper()
+	registry := parser.NewRegistry()
+	registry.Register(languages.NewGoExtractor())
+	cfg := config.Default()
+	cfg.Index.Workers = 1
+	idx := New(store, registry, cfg.Index, zap.NewNop())
+	idx.SetRepoPrefix(prefix)
+	idx.rootPath = repoPath
+	return idx
+}
+
+func runGitWatcherGit(t *testing.T, repoPath string, args ...string) string {
+	t.Helper()
+	commandArgs := append([]string{"-C", repoPath}, args...)
+	cmd := exec.Command("git", commandArgs...)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %s: %s", strings.Join(args, " "), output)
+	return strings.TrimSpace(string(output))
+}
+
+func initGitWatcherRepo(t *testing.T) (string, string) {
+	t.Helper()
+	repoPath := t.TempDir()
+	runGitWatcherGit(t, repoPath, "init")
+	runGitWatcherGit(t, repoPath, "config", "user.name", "Gortex Test")
+	runGitWatcherGit(t, repoPath, "config", "user.email", "gortex@example.invalid")
+	runGitWatcherGit(t, repoPath, "config", "commit.gpgsign", "false")
+	require.NoError(t, os.WriteFile(filepath.Join(repoPath, "main.go"), []byte("package main\n"), 0o644))
+	runGitWatcherGit(t, repoPath, "add", "main.go")
+	runGitWatcherGit(t, repoPath, "commit", "-m", "initial")
+	return repoPath, runGitWatcherGit(t, repoPath, "rev-parse", "HEAD")
+}
+
+func TestGitWatcherFreshnessTailWaitsForLaneAndUsesReplacementIndexer(t *testing.T) {
+	repoPath, _ := initGitWatcherRepo(t)
+	oldStore := &gitWatcherStateStore{Store: graph.New()}
+	newStore := &gitWatcherStateStore{Store: graph.New()}
+	oldIndexer := gitWatcherBoundaryIndexer(t, oldStore, repoPath, "repo")
+	newIndexer := gitWatcherBoundaryIndexer(t, newStore, repoPath, "repo")
+	coordinator := newRepositoryMutationCoordinator(nil)
+	oldIndexer.attachRepositoryMutationCoordinator(coordinator)
+	newIndexer.attachRepositoryMutationCoordinator(coordinator)
+
+	watcher, err := NewGitWatcher(repoPath, oldIndexer, zap.NewNop())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = watcher.Stop() })
+	watcher.currentIndexer = func() *Indexer { return newIndexer }
+	watcher.lastSHA = "old-sha"
+
+	laneEntered := make(chan struct{})
+	releaseLane := make(chan struct{})
+	holderDone := make(chan error, 1)
+	go func() {
+		holderDone <- oldIndexer.coordinateRepositoryMutation(context.Background(), func() error {
+			close(laneEntered)
+			<-releaseLane
+			return nil
+		})
+	}()
+	<-laneEntered
+
+	finalizeDone := make(chan error, 1)
+	go func() {
+		finalizeDone <- watcher.finalizeReconcile(context.Background(), "new-sha")
+	}()
+	select {
+	case err := <-finalizeDone:
+		t.Fatalf("freshness tail bypassed the occupied repository lane: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	watcher.mu.Lock()
+	assert.Equal(t, "old-sha", watcher.lastSHA)
+	watcher.mu.Unlock()
+	assert.Empty(t, oldStore.snapshotStates())
+	assert.Empty(t, newStore.snapshotStates())
+
+	close(releaseLane)
+	require.NoError(t, <-holderDone)
+	require.NoError(t, <-finalizeDone)
+	watcher.mu.Lock()
+	assert.Equal(t, "new-sha", watcher.lastSHA)
+	watcher.mu.Unlock()
+	assert.Empty(t, oldStore.snapshotStates(), "retired Indexer must not be restamped")
+	require.Len(t, newStore.snapshotStates(), 1, "replacement Indexer must receive the restamp")
+}
+
+func TestGitWatcherEmptyCommitFinalizesWithoutFullReindex(t *testing.T) {
+	repoPath, oldSHA := initGitWatcherRepo(t)
+	runGitWatcherGit(t, repoPath, "commit", "--allow-empty", "-m", "empty")
+	newSHA := runGitWatcherGit(t, repoPath, "rev-parse", "HEAD")
+	require.NotEqual(t, oldSHA, newSHA)
+
+	store := &gitWatcherStateStore{Store: graph.New()}
+	idx := gitWatcherBoundaryIndexer(t, store, repoPath, "repo")
+	idx.attachRepositoryMutationCoordinator(newRepositoryMutationCoordinator(nil))
+	watcher, err := NewGitWatcher(repoPath, idx, zap.NewNop())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = watcher.Stop() })
+	watcher.lastSHA = oldSHA
+
+	var batchCalls atomic.Int32
+	watcher.batchReindex = func(paths []string) (*IndexResult, error) {
+		batchCalls.Add(1)
+		return &IndexResult{}, nil
+	}
+	watcher.reconcile("empty-commit-test")
+
+	assert.Zero(t, batchCalls.Load(), "an empty commit must not escalate nil paths into a full reindex")
+	watcher.mu.Lock()
+	assert.Equal(t, newSHA, watcher.lastSHA)
+	watcher.mu.Unlock()
+	require.Len(t, store.snapshotStates(), 1, "empty commit must still restamp repository freshness")
+}

--- a/internal/indexer/incremental_batch.go
+++ b/internal/indexer/incremental_batch.go
@@ -1,6 +1,7 @@
 package indexer
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"sort"
@@ -67,18 +68,21 @@ type incrementalPriorView struct {
 	outByNode   map[string][]*graph.Edge
 }
 
-// reindexIncrementalFilesBatched owns the multi-file path only. IndexFile and
-// its single-save semantics stay unchanged; exceptional files that cannot be
-// prepared safely fall back to that exact implementation and retain its retry
-// behaviour.
+// reindexIncrementalFilesBatched owns the bounded multi-file engine. Normal
+// reconciliation retries first-pass failures once. A direct IndexFile request
+// can instead stop after a first-pass version race so its historical receipt
+// contract remains observable while watcher storms retain retry behaviour.
 func (idx *Indexer) reindexIncrementalFilesBatched(
 	staleFiles, deletedFiles []string,
 	markerBatch *reparsePendingEnrichmentBatch,
-) (DerivedInvalidationPlan, []string, []string) {
+	surfaceFirstVersionChange bool,
+) (DerivedInvalidationPlan, []string, []string, []string) {
 	var invalidation DerivedInvalidationPlan
 	idx.evictDeletedFilesBatched(deletedFiles, &invalidation)
 
-	passPlan, reparsed, failed := idx.reindexIncrementalStalePass(staleFiles, markerBatch)
+	passPlan, reparsed, failed, versionChanged := idx.reindexIncrementalStalePass(
+		staleFiles, markerBatch, surfaceFirstVersionChange,
+	)
 	invalidation.Merge(passPlan)
 	for _, filePath := range failed {
 		idx.logger.Debug("incremental reindex: failed to index file",
@@ -88,12 +92,24 @@ func (idx *Indexer) reindexIncrementalFilesBatched(
 		if len(reparsed) > 0 {
 			idx.reparsedThisRun.Store(true)
 		}
-		return invalidation, reparsed, nil
+		return invalidation, reparsed, nil, nil
+	}
+	if surfaceFirstVersionChange {
+		// Direct IndexFile is a single accepted-read operation. Do not let a
+		// retry hide any first-pass failure; its caller distinguishes an actual
+		// version race from parse/read failures after the complete mutation tail.
+		if len(reparsed) > 0 || len(invalidation.Files) > 0 {
+			idx.reparsedThisRun.Store(true)
+		}
+		return invalidation, reparsed, failed, versionChanged
 	}
 
-	retryPlan, retryReparsed, retryFailed := idx.reindexIncrementalStalePass(failed, markerBatch)
+	retryPlan, retryReparsed, retryFailed, retryVersionChanged := idx.reindexIncrementalStalePass(
+		failed, markerBatch, false,
+	)
 	invalidation.Merge(retryPlan)
 	reparsed = appendUniqueSorted(reparsed, retryReparsed...)
+	versionChanged = appendUniqueSorted(versionChanged, retryVersionChanged...)
 	for _, filePath := range retryFailed {
 		idx.logger.Warn("incremental reindex: file failed after retry",
 			zap.String("file", filePath))
@@ -101,19 +117,20 @@ func (idx *Indexer) reindexIncrementalFilesBatched(
 	if len(reparsed) > 0 {
 		idx.reparsedThisRun.Store(true)
 	}
-	return invalidation, reparsed, retryFailed
+	return invalidation, reparsed, retryFailed, versionChanged
 }
 
 func (idx *Indexer) reindexIncrementalStalePass(
 	files []string,
 	markerBatch *reparsePendingEnrichmentBatch,
-) (DerivedInvalidationPlan, []string, []string) {
+	acceptPreparedSnapshot bool,
+) (DerivedInvalidationPlan, []string, []string, []string) {
 	var plan DerivedInvalidationPlan
-	var reparsed, failed []string
+	var reparsed, failed, versionChanged []string
 	for start := 0; start < len(files); {
 		end := min(start+incrementalBatchFiles, len(files))
-		consumed, chunkPlan, chunkReparsed, chunkFailed := idx.reindexIncrementalChunk(
-			files[start:end], markerBatch,
+		consumed, chunkPlan, chunkReparsed, chunkFailed, chunkVersionChanged := idx.reindexIncrementalChunk(
+			files[start:end], markerBatch, acceptPreparedSnapshot,
 		)
 		if consumed <= 0 {
 			consumed = 1
@@ -122,17 +139,22 @@ func (idx *Indexer) reindexIncrementalStalePass(
 		plan.Merge(chunkPlan)
 		reparsed = append(reparsed, chunkReparsed...)
 		failed = append(failed, chunkFailed...)
+		versionChanged = append(versionChanged, chunkVersionChanged...)
 	}
-	return plan, appendUniqueSorted(nil, reparsed...), appendUniqueSorted(nil, failed...)
+	return plan,
+		appendUniqueSorted(nil, reparsed...),
+		appendUniqueSorted(nil, failed...),
+		appendUniqueSorted(nil, versionChanged...)
 }
 
 func (idx *Indexer) reindexIncrementalChunk(
 	files []string,
 	markerBatch *reparsePendingEnrichmentBatch,
-) (int, DerivedInvalidationPlan, []string, []string) {
+	acceptPreparedSnapshot bool,
+) (int, DerivedInvalidationPlan, []string, []string, []string) {
 	var plan DerivedInvalidationPlan
 	if len(files) == 0 {
-		return 0, plan, nil, nil
+		return 0, plan, nil, nil, nil
 	}
 
 	graphPaths := make([]string, len(files))
@@ -184,7 +206,13 @@ func (idx *Indexer) reindexIncrementalChunk(
 			})
 			continue
 		}
-		prepared, ok := idx.takePreparedRefresh(filePath)
+		var prepared *preparedExtraction
+		var ok bool
+		if acceptPreparedSnapshot {
+			prepared, ok = idx.takePreparedSnapshot(filePath)
+		} else {
+			prepared, ok = idx.takePreparedRefresh(filePath)
+		}
 		if !ok || prepared == nil || prepared.result == nil {
 			fallbacks = append(fallbacks, incrementalFallback{
 				filePath: filePath, graphPath: graphPath, priorNodes: priorNodes,
@@ -231,10 +259,14 @@ func (idx *Indexer) reindexIncrementalChunk(
 
 	var reparsed []string
 	failed := append([]string(nil), stalePaths...)
+	versionChanged := append([]string(nil), stalePaths...)
 	for _, fallback := range fallbacks {
 		if err := idx.reindexIncrementalFallback(fallback, markerBatch, &plan); err != nil {
 			idx.discardPreparedExtraction(fallback.filePath)
 			failed = append(failed, fallback.filePath)
+			if errors.Is(err, errFileVersionChanged) {
+				versionChanged = append(versionChanged, fallback.filePath)
+			}
 			continue
 		}
 		reparsed = append(reparsed, fallback.filePath)
@@ -244,7 +276,7 @@ func (idx *Indexer) reindexIncrementalChunk(
 			reparsed = append(reparsed, stage.absPath)
 		}
 	}
-	return consumed, plan, reparsed, failed
+	return consumed, plan, reparsed, failed, versionChanged
 }
 
 func (idx *Indexer) reindexIncrementalFallback(
@@ -438,7 +470,7 @@ func (idx *Indexer) commitIncrementalStages(
 	}
 	for _, stage := range structural {
 		applyResolvedOutEdgesFromView(stage.result.Edges, stage.reuse, existing)
-		if !idx.deferGlobalPasses {
+		if !idx.deferGlobalPasses.Load() {
 			stage.abSnap = snapshotAffectedByFromView(stage.priorNodes, view)
 		}
 	}
@@ -450,7 +482,7 @@ func (idx *Indexer) commitIncrementalStages(
 			stage.metadataOnly = false
 			structural = append(structural, stage)
 			applyResolvedOutEdgesFromView(stage.result.Edges, stage.reuse, existing)
-			if !idx.deferGlobalPasses {
+			if !idx.deferGlobalPasses.Load() {
 				stage.abSnap = snapshotAffectedByFromView(stage.priorNodes, view)
 			}
 			continue
@@ -746,7 +778,7 @@ func (idx *Indexer) commitStructuralIncrementalBatch(
 		idx.materializeDataflowParamsForStages(stages)
 	}
 
-	if !idx.deferGlobalPasses {
+	if !idx.deferGlobalPasses.Load() {
 		freshFuncs := cloneFuncNodes(nodes)
 		if len(oldFuncIDs) > 0 || len(freshFuncs) > 0 {
 			if idx.cloneIndex != nil && idx.cloneIndex.Ready() {
@@ -761,10 +793,10 @@ func (idx *Indexer) commitStructuralIncrementalBatch(
 	if !deferResolverCatchup {
 		idx.observeIncrementalCatchup("ref_facts", paths)
 		idx.persistRefFactsForFiles(paths)
-		if !idx.deferGlobalPasses {
+		if !idx.deferGlobalPasses.Load() {
 			idx.reresolveAffectedByStages(stages)
 		}
-	} else if !idx.deferGlobalPasses {
+	} else if !idx.deferGlobalPasses.Load() {
 		markerBatch.mergeDeferredAffected(idx.planAffectedByStages(stages))
 	}
 	idx.enrichAndMarkIncrementalStages(stages, markerBatch)
@@ -1054,7 +1086,7 @@ func (idx *Indexer) enrichAndMarkIncrementalStages(
 	for _, stage := range stages {
 		pending[stage.graphPath] = providersPresent
 	}
-	watchEnrichment := providersPresent && !idx.deferGlobalPasses && idx.semanticMgr.EnrichesOnWatch() &&
+	watchEnrichment := providersPresent && !idx.deferGlobalPasses.Load() && idx.semanticMgr.EnrichesOnWatch() &&
 		(markerBatch == nil || !markerBatch.deferResolverCatchup)
 	if watchEnrichment {
 		paths := make([]string, 0, len(stages))
@@ -1357,9 +1389,82 @@ func (idx *Indexer) reresolveAffectedByStages(stages []*incrementalBatchStage) {
 	}
 }
 
-func (idx *Indexer) evictDeletedFilesBatched(deleted []string, plan *DerivedInvalidationPlan) {
-	if len(deleted) == 0 {
+type forcedFileEviction struct {
+	result       *IndexResult
+	batch        *reparsePendingEnrichmentBatch
+	nodesRemoved int
+	edgesRemoved int
+}
+
+// evictFileIncrementalRaw forcibly removes one canonical repository-relative
+// path even when it still exists on disk. The caller already owns the stable
+// repository lane. It reuses the bounded deletion core so every graph/search
+// sidecar and mtime is removed and returns the exact invalidation frontier for
+// the resolver/semantic/derived tail.
+func (idx *Indexer) evictFileIncrementalRaw(relPath string) forcedFileEviction {
+	batch := &reparsePendingEnrichmentBatch{deferResolverCatchup: true}
+	result := &IndexResult{}
+	if idx == nil || relPath == "" {
+		return forcedFileEviction{result: result, batch: batch}
+	}
+	// Explicit eviction is intentionally unconditional. Ownership sidecars may
+	// be partially missing after an interrupted or older indexing pass; the
+	// bounded deletion core is idempotent and must still clear orphan mtimes,
+	// search content, ref facts, contracts, and enrichment state.
+	dependencyFiles := idx.semanticDependencyFrontierForDeletedFiles([]string{relPath})
+	var invalidation DerivedInvalidationPlan
+	nodesRemoved, edgesRemoved := idx.evictDeletedFilesBatched([]string{relPath}, &invalidation)
+	graphPath := idx.prefixPath(filepath.FromSlash(relPath))
+	idx.removeIncrementalContractsForFile(graphPath, &invalidation)
+	invalidation.Files = appendUniqueSorted(invalidation.Files, dependencyFiles...)
+
+	idx.indexGen.Add(1)
+	nodes, edges := idx.repoNodeEdgeCount()
+	result.NodeCount = nodes
+	result.EdgeCount = edges
+	result.FileCount = idx.trackedFileCount()
+	result.DeletedFileCount = 1
+	result.DerivedInvalidation = invalidation
+	idx.markPendingEnrichFiles(invalidation.Files)
+	return forcedFileEviction{
+		result:       result,
+		batch:        batch,
+		nodesRemoved: nodesRemoved,
+		edgesRemoved: edgesRemoved,
+	}
+}
+
+func (idx *Indexer) removeIncrementalContractsForFile(graphPath string, plan *DerivedInvalidationPlan) {
+	reg := idx.ensureIncrementalContractRegistry()
+	prior := reg.ByFile(graphPath)
+	idx.contractCacheMu.Lock()
+	delete(idx.contractCache, graphPath)
+	idx.contractCacheMu.Unlock()
+	if len(prior) == 0 {
 		return
+	}
+
+	priorIDs := make(map[string]struct{}, len(prior))
+	refresh := contractRefreshResult{Changed: true}
+	refresh.addFrontier(prior)
+	for _, contract := range prior {
+		if contract.ID != "" {
+			priorIDs[contract.ID] = struct{}{}
+		}
+	}
+	refresh.Groups = mergeContractGroups(nil, refresh.Groups...)
+	refresh.SymbolIDs = appendUniqueSorted(nil, refresh.SymbolIDs...)
+	reg.ReplaceFile(graphPath, nil)
+	idx.commitIncrementalContractFiles(reg, []string{graphPath}, priorIDs)
+
+	plan.Flags |= DerivedInvalidatesContracts
+	plan.ContractGroups = mergeContractGroups(plan.ContractGroups, refresh.Groups...)
+	plan.ContractSymbolIDs = appendUniqueSorted(plan.ContractSymbolIDs, refresh.SymbolIDs...)
+}
+
+func (idx *Indexer) evictDeletedFilesBatched(deleted []string, plan *DerivedInvalidationPlan) (nodesRemoved, edgesRemoved int) {
+	if len(deleted) == 0 {
+		return 0, 0
 	}
 	for start := 0; start < len(deleted); start += deletedBatchFiles {
 		end := min(start+deletedBatchFiles, len(deleted))
@@ -1401,13 +1506,16 @@ func (idx *Indexer) evictDeletedFilesBatched(deleted []string, plan *DerivedInva
 		idx.deleteRefFactsForFiles(idx.repoPrefix, graphPaths)
 		idx.deleteIncrementalSidecars(graphPaths)
 		idx.clearIncrementalContent(graphPaths)
-		evictFilesBatched(idx.graph, graphPaths)
+		nodes, edges := evictFilesBatched(idx.graph, graphPaths)
+		nodesRemoved += nodes
+		edgesRemoved += edges
 	}
 	idx.mtimeMu.Lock()
 	for _, relPath := range deleted {
 		delete(idx.fileMtimes, relPath)
 	}
 	idx.mtimeMu.Unlock()
+	return nodesRemoved, edgesRemoved
 }
 
 func (idx *Indexer) deleteEnrichmentByNodeIDs(nodeIDs []string) {

--- a/internal/indexer/incremental_batch_test.go
+++ b/internal/indexer/incremental_batch_test.go
@@ -174,7 +174,7 @@ func runIncrementalBatchScale(t *testing.T, fileCount int) incrementalBatchCount
 	idx := newTestIndexer(counting)
 	_, err := idx.Index(dir)
 	require.NoError(t, err)
-	idx.deferGlobalPasses = true
+	idx.deferGlobalPasses.Store(true)
 	counting.resetCounts()
 
 	future := time.Now().Add(3 * time.Second)

--- a/internal/indexer/incremental_derived.go
+++ b/internal/indexer/incremental_derived.go
@@ -7,6 +7,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/zzet/gortex/internal/entrypoints"
+	"github.com/zzet/gortex/internal/reach"
 	"github.com/zzet/gortex/internal/resolver"
 )
 
@@ -39,7 +40,7 @@ type IncrementalDerivedReport struct {
 // contains only this repository; real shared-graph callers must use their owning
 // MultiIndexer so contract and cross-repository passes see every sibling.
 func (idx *Indexer) runStandaloneIncrementalDerivedPasses(plan DerivedInvalidationPlan) IncrementalDerivedReport {
-	if idx == nil || idx.graph == nil || idx.deferGlobalPasses || plan.Empty() {
+	if idx == nil || idx.graph == nil || idx.deferGlobalPasses.Load() || plan.Empty() {
 		return IncrementalDerivedReport{}
 	}
 	logger := idx.logger
@@ -53,7 +54,7 @@ func (idx *Indexer) runStandaloneIncrementalDerivedPasses(plan DerivedInvalidati
 		RepoPrefix: prefix,
 		RootPath:   idx.RootPath(),
 	}
-	return mi.RunIncrementalDerivedPasses(context.Background(), map[string]DerivedInvalidationPlan{
+	return mi.runIncrementalDerivedPassesTopologyHeld(context.Background(), map[string]DerivedInvalidationPlan{
 		prefix: plan,
 	})
 }
@@ -62,6 +63,46 @@ func (idx *Indexer) runStandaloneIncrementalDerivedPasses(plan DerivedInvalidati
 // by the exact per-file plans. A legacy database without persisted fingerprints
 // takes the old scoped-global path once; ordinary body/metadata edits never do.
 func (mi *MultiIndexer) RunIncrementalDerivedPasses(
+	ctx context.Context,
+	plans map[string]DerivedInvalidationPlan,
+) IncrementalDerivedReport {
+	if mi == nil || mi.graph == nil || len(plans) == 0 {
+		return IncrementalDerivedReport{}
+	}
+	if ctx != nil {
+		select {
+		case <-ctx.Done():
+			return IncrementalDerivedReport{}
+		default:
+		}
+	}
+	hasWork := false
+	for _, plan := range plans {
+		if !plan.Empty() {
+			hasWork = true
+			break
+		}
+	}
+	if !hasWork {
+		return IncrementalDerivedReport{}
+	}
+	mi.batchMutationGate.Lock()
+	defer mi.batchMutationGate.Unlock()
+	if ctx != nil {
+		select {
+		case <-ctx.Done():
+			return IncrementalDerivedReport{}
+		default:
+		}
+	}
+	finishTopologyMutation := reach.BeginTopologyMutation(mi.graph)
+	defer finishTopologyMutation(true)
+	return mi.runIncrementalDerivedPassesTopologyHeld(ctx, plans)
+}
+
+// runIncrementalDerivedPassesTopologyHeld is the non-reentrant implementation
+// for mutation pipelines that already own the global topology writer.
+func (mi *MultiIndexer) runIncrementalDerivedPassesTopologyHeld(
 	ctx context.Context,
 	plans map[string]DerivedInvalidationPlan,
 ) IncrementalDerivedReport {
@@ -99,8 +140,9 @@ func (mi *MultiIndexer) RunIncrementalDerivedPasses(
 	}
 
 	if merged.LegacyFallback {
-		mi.ArmBatchScope(prefixSet)
-		mi.RunGlobalGraphPasses(ctx)
+		// Legacy fingerprints need a scoped global rebuild, but this one-off
+		// fallback must not arm or consume an unrelated active batch.
+		mi.runGlobalGraphPassesTopologyHeld(ctx, prefixSet, false)
 		if merged.Flags.Has(DerivedInvalidatesContracts) {
 			report.Contracts = mi.ReconcileContractEdges()
 		}

--- a/internal/indexer/incremental_derived_topology_test.go
+++ b/internal/indexer/incremental_derived_topology_test.go
@@ -1,0 +1,160 @@
+package indexer
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/reach"
+)
+
+const incrementalDerivedLegacyChildEnv = "GORTEX_TEST_INCREMENTAL_DERIVED_LEGACY_CHILD"
+
+type incrementalDerivedProbeStore struct {
+	graph.Store
+	checkpoints atomic.Int64
+}
+
+func (s *incrementalDerivedProbeStore) CheckpointWAL() error {
+	s.checkpoints.Add(1)
+	return nil
+}
+
+func newIncrementalDerivedTestMultiIndexer(store graph.Store) *MultiIndexer {
+	return NewMultiIndexer(store, parser.NewRegistry(), nil, nil, zap.NewNop())
+}
+
+func incrementalDerivedLegacyPlan() map[string]DerivedInvalidationPlan {
+	return map[string]DerivedInvalidationPlan{
+		"repo": {
+			Files:          []string{"repo/main.go"},
+			LegacyFallback: true,
+		},
+	}
+}
+
+func waitForIncrementalDerivedBatchWriter(t *testing.T, mi *MultiIndexer) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if !mi.batchMutationGate.TryRLock() {
+			return
+		}
+		mi.batchMutationGate.RUnlock()
+		if time.Now().After(deadline) {
+			t.Fatal("incremental derived wrapper did not queue for the batch write gate")
+		}
+		runtime.Gosched()
+	}
+}
+
+func TestRunIncrementalDerivedPassesLegacyFallbackDoesNotReenterTopology(t *testing.T) {
+	if os.Getenv(incrementalDerivedLegacyChildEnv) == "1" {
+		store := &incrementalDerivedProbeStore{Store: graph.New()}
+		mi := newIncrementalDerivedTestMultiIndexer(store)
+		before := reach.BuildCounter()
+
+		report := mi.RunIncrementalDerivedPasses(context.Background(), incrementalDerivedLegacyPlan())
+
+		require.True(t, report.LegacyFallback)
+		require.Equal(t, 1, report.Repos)
+		require.Equal(t, 1, report.Files)
+		require.Positive(t, store.checkpoints.Load(), "legacy fallback did not enter global passes")
+		require.Greater(t, reach.BuildCounter(), before)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0],
+		"-test.run=^TestRunIncrementalDerivedPassesLegacyFallbackDoesNotReenterTopology$",
+		"-test.count=1",
+	)
+	cmd.Env = append(os.Environ(), incrementalDerivedLegacyChildEnv+"=1")
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		t.Fatalf("legacy fallback deadlocked while re-entering the topology gate:\n%s", output)
+	}
+	require.NoErrorf(t, err, "legacy fallback subprocess failed:\n%s", output)
+}
+
+func TestRunIncrementalDerivedPassesTakesBatchWriteGate(t *testing.T) {
+	mi := newIncrementalDerivedTestMultiIndexer(graph.New())
+	plan := map[string]DerivedInvalidationPlan{
+		"repo": {Files: []string{"repo/main.go"}},
+	}
+
+	mi.batchMutationGate.RLock()
+	gateHeld := true
+	defer func() {
+		if gateHeld {
+			mi.batchMutationGate.RUnlock()
+		}
+	}()
+
+	before := reach.BuildCounter()
+	done := make(chan IncrementalDerivedReport, 1)
+	go func() {
+		done <- mi.RunIncrementalDerivedPasses(context.Background(), plan)
+	}()
+	waitForIncrementalDerivedBatchWriter(t, mi)
+	select {
+	case <-done:
+		t.Fatal("incremental derived wrapper bypassed the batch write gate")
+	default:
+	}
+
+	mi.batchMutationGate.RUnlock()
+	gateHeld = false
+	select {
+	case report := <-done:
+		require.Equal(t, 1, report.Repos)
+		require.Equal(t, 1, report.Files)
+		require.Greater(t, reach.BuildCounter(), before)
+	case <-time.After(5 * time.Second):
+		t.Fatal("incremental derived wrapper did not resume after the batch gate was released")
+	}
+}
+
+func TestRunIncrementalDerivedPassesCanceledWhileQueuedSkipsTopologyAndGlobalWork(t *testing.T) {
+	store := &incrementalDerivedProbeStore{Store: graph.New()}
+	mi := newIncrementalDerivedTestMultiIndexer(store)
+
+	mi.batchMutationGate.RLock()
+	gateHeld := true
+	defer func() {
+		if gateHeld {
+			mi.batchMutationGate.RUnlock()
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	before := reach.BuildCounter()
+	done := make(chan IncrementalDerivedReport, 1)
+	go func() {
+		done <- mi.RunIncrementalDerivedPasses(ctx, incrementalDerivedLegacyPlan())
+	}()
+	waitForIncrementalDerivedBatchWriter(t, mi)
+	cancel()
+
+	mi.batchMutationGate.RUnlock()
+	gateHeld = false
+	select {
+	case report := <-done:
+		require.Equal(t, IncrementalDerivedReport{}, report)
+	case <-time.After(5 * time.Second):
+		t.Fatal("canceled incremental derived wrapper did not return after the batch gate was released")
+	}
+	require.Equal(t, before, reach.BuildCounter(), "canceled queued work entered the topology transaction")
+	require.Zero(t, store.checkpoints.Load(), "canceled queued work entered global passes")
+}

--- a/internal/indexer/incremental_watcher_batch.go
+++ b/internal/indexer/incremental_watcher_batch.go
@@ -4,7 +4,10 @@ import (
 	"fmt"
 	"sort"
 
+	"go.uber.org/zap"
+
 	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/reach"
 )
 
 // watcherBatchReindex is the common large-change entry point used by both the
@@ -20,11 +23,22 @@ type watcherBatchReindex func(paths []string) (*IndexResult, error)
 func (idx *Indexer) incrementalReindexPathsWithReceipt(
 	root string,
 	paths []string,
+	detectDeletions bool,
+) (result *IndexResult, receipt *graph.MutationReceipt, batch *reparsePendingEnrichmentBatch, err error) {
+	return idx.incrementalReindexPathsWithReceiptMode(root, paths, incrementalPathMode{
+		detectDeletions: detectDeletions,
+	})
+}
+
+func (idx *Indexer) incrementalReindexPathsWithReceiptMode(
+	root string,
+	paths []string,
+	mode incrementalPathMode,
 ) (result *IndexResult, receipt *graph.MutationReceipt, batch *reparsePendingEnrichmentBatch, err error) {
 	batch = &reparsePendingEnrichmentBatch{deferResolverCatchup: true}
 	receiptStore, _ := idx.graph.(graph.MutationReceiptStore)
 	if receiptStore == nil {
-		result, err = idx.incrementalReindexPaths(root, paths, true, batch)
+		result, err = idx.incrementalReindexPathsMode(root, paths, mode, batch)
 		return result, nil, batch, err
 	}
 
@@ -33,7 +47,7 @@ func (idx *Indexer) incrementalReindexPathsWithReceipt(
 		observed := receiptStore.EndMutationReceipt(token)
 		receipt = &observed
 	}()
-	result, err = idx.incrementalReindexPaths(root, paths, true, batch)
+	result, err = idx.incrementalReindexPathsMode(root, paths, mode, batch)
 	return result, receipt, batch, err
 }
 
@@ -152,13 +166,122 @@ func (idx *Indexer) runIncrementalWatcherSemantic(graphPaths []string) {
 	idx.setReparsePendingEnrichments(pending)
 }
 
+// runIncrementalPointSemantic preserves IndexFile's exact single-save semantic
+// contract. Storm and reconciliation batches use runIncrementalWatcherSemantic
+// to amortize provider work; one explicit point mutation calls EnrichFile so
+// in-process type providers can confirm the new edges before IndexFile returns.
+func (idx *Indexer) runIncrementalPointSemantic(graphPaths []string) {
+	if idx == nil || idx.semanticMgr == nil || !idx.semanticMgr.Enabled() ||
+		!idx.semanticMgr.HasProviders() || !idx.semanticMgr.EnrichesOnWatch() {
+		return
+	}
+	paths := appendUniqueSorted(nil, graphPaths...)
+	if len(paths) == 0 {
+		return
+	}
+	idx.observeIncrementalCatchup("semantic", paths)
+	pending := make(map[string]bool, len(paths))
+	for _, graphPath := range paths {
+		pending[graphPath] = true
+		if _, err := idx.semanticMgr.EnrichFile(idx.graph, idx.rootPath, graphPath); err != nil {
+			idx.logger.Debug("indexer: exact point semantic enrichment failed",
+				zap.String("file", graphPath), zap.Error(err))
+			continue
+		}
+		pending[graphPath] = false
+	}
+	idx.setReparsePendingEnrichments(pending)
+}
+
 // incrementalReindexWatcherPaths is the complete direct-Indexer coordinator used
 // outside a MultiIndexer. It performs one bounded parse/evict batch, one exact
 // resolver/reference-fact catch-up, semantic refresh, and the precise standalone
 // derived passes. Shared-graph callers use MultiIndexer so cross-repository work
 // sees every sibling registry and indexer.
+func incrementalTopologyChanged(result *IndexResult) bool {
+	if result == nil {
+		return false
+	}
+	if result.DeletedFileCount > 0 || result.FullRetrack {
+		return true
+	}
+	plan := result.DerivedInvalidation
+	nonTopologyFiles := plan.InertFiles
+	// Metadata refreshes preserve node and edge identity. Files is populated for
+	// their exact derived frontier, so only the topology-bearing plan fields
+	// below disqualify them from the no-invalidation path.
+	metadataTopologyFree := plan.Flags == 0 &&
+		len(plan.TypeIDs) == 0 &&
+		len(plan.ContractGroups) == 0 &&
+		len(plan.ContractSymbolIDs) == 0 &&
+		len(plan.ContractBridgeNodeIDs) == 0 &&
+		!plan.LegacyFallback
+	if metadataTopologyFree {
+		nonTopologyFiles += plan.MetadataOnlyFiles
+	}
+	return result.StaleFileCount > nonTopologyFiles
+}
+
 func (idx *Indexer) incrementalReindexWatcherPaths(root string, paths []string) (*IndexResult, error) {
-	result, receipt, batch, err := idx.incrementalReindexPathsWithReceipt(root, paths)
+	return idx.incrementalWatcherPaths(root, paths, incrementalPathMode{detectDeletions: true})
+}
+
+func (idx *Indexer) incrementalDiscoverWatcherPaths(root string, paths []string) (*IndexResult, error) {
+	return idx.incrementalWatcherPaths(root, paths, incrementalPathMode{})
+}
+
+// incrementalEvictWatcherPath is the standalone already-held-lane forced
+// deletion executor. Unlike incrementalPointWatcherPath it never consults disk
+// presence to decide between reparse and deletion.
+func (idx *Indexer) incrementalEvictWatcherPath(path string) (nodesRemoved, edgesRemoved int, err error) {
+	finishTopologyMutation := reach.BeginTopologyMutation(idx.graph)
+	topologyChanged := true
+	defer func() { finishTopologyMutation(topologyChanged) }()
+
+	eviction := idx.evictFileIncrementalRaw(path)
+	result := eviction.result
+	files, needed, exact := incrementalResolutionFrontier(result, nil)
+	if needed && len(files) > 0 {
+		idx.runIncrementalResolutionCatchup(files, eviction.batch, func(frontier []string) {
+			if idx.incrementalResolveFilesHook != nil {
+				idx.incrementalResolveFilesHook(frontier)
+				return
+			}
+			idx.resolver.ResolveFilesAndIncoming(frontier)
+		})
+	} else if needed && !exact {
+		idx.observeIncrementalCatchup("resolve", nil)
+		idx.ResolveAll()
+	}
+	if result != nil && result.DeletedFileCount > 0 {
+		idx.runIncrementalWatcherSemantic(result.DerivedInvalidation.Files)
+		idx.observeIncrementalCatchup("derived", result.DerivedInvalidation.Files)
+		idx.runStandaloneIncrementalDerivedPasses(result.DerivedInvalidation)
+	}
+	topologyChanged = incrementalTopologyChanged(result)
+	return eviction.nodesRemoved, eviction.edgesRemoved, nil
+}
+
+// incrementalPointWatcherPath is the standalone, already-held-lane point
+// executor. It forces the explicit path through content classification and the
+// complete resolver/semantic/derived tail without re-entering a public
+// coordinated API.
+func (idx *Indexer) incrementalPointWatcherPath(root, path string) (*IndexResult, error) {
+	return idx.incrementalWatcherPaths(root, []string{path}, incrementalPathMode{
+		detectDeletions:    true,
+		forceExplicitFiles: true,
+	})
+}
+
+func (idx *Indexer) incrementalWatcherPaths(root string, paths []string, mode incrementalPathMode) (*IndexResult, error) {
+	// The coordinator owns the repository lane before invoking this executor.
+	// Take the reachability topology gate second and retain it through resolver
+	// and derived catch-up so readers observe the complete old or new graph.
+	finishTopologyMutation := reach.BeginTopologyMutation(idx.graph)
+	topologyChanged := true
+	defer func() { finishTopologyMutation(topologyChanged) }()
+
+	result, receipt, batch, err := idx.incrementalReindexPathsWithReceiptMode(root, paths, mode)
 	if err != nil {
 		return result, err
 	}
@@ -175,11 +298,16 @@ func (idx *Indexer) incrementalReindexWatcherPaths(root string, paths []string) 
 		idx.observeIncrementalCatchup("resolve", nil)
 		idx.ResolveAll()
 	}
-	if !idx.deferGlobalPasses {
-		idx.runIncrementalWatcherSemantic(result.DerivedInvalidation.Files)
+	if mode.forceExplicitFiles || !idx.deferGlobalPasses.Load() {
+		if mode.exactPointSemantic {
+			idx.runIncrementalPointSemantic(result.DerivedInvalidation.Files)
+		} else {
+			idx.runIncrementalWatcherSemantic(result.DerivedInvalidation.Files)
+		}
 		idx.observeIncrementalCatchup("derived", result.DerivedInvalidation.Files)
 		idx.runStandaloneIncrementalDerivedPasses(result.DerivedInvalidation)
 	}
+	topologyChanged = incrementalTopologyChanged(result)
 	return result, nil
 }
 
@@ -190,7 +318,7 @@ func (w *Watcher) reindexStormPaths(paths []string) (*IndexResult, error) {
 	if w.indexer == nil || w.indexer.rootPath == "" {
 		return nil, fmt.Errorf("watcher: index root is not initialized")
 	}
-	return w.indexer.incrementalReindexWatcherPaths(w.indexer.rootPath, paths)
+	return w.indexer.IncrementalReindexPaths(w.indexer.rootPath, paths)
 }
 
 func (gw *GitWatcher) reindexChangedPaths(paths []string) (*IndexResult, error) {
@@ -200,7 +328,7 @@ func (gw *GitWatcher) reindexChangedPaths(paths []string) (*IndexResult, error) 
 	if gw.indexer == nil {
 		return nil, fmt.Errorf("git-watcher: indexer is not initialized")
 	}
-	return gw.indexer.incrementalReindexWatcherPaths(gw.repoPath, paths)
+	return gw.indexer.IncrementalReindexPaths(gw.repoPath, paths)
 }
 
 // resolveIncrementalRepoMutation runs one shared resolver pass for a complete
@@ -212,6 +340,16 @@ func (mi *MultiIndexer) resolveIncrementalRepoMutation(
 	result *IndexResult,
 	receipt *graph.MutationReceipt,
 	batch *reparsePendingEnrichmentBatch,
+) {
+	mi.resolveIncrementalRepoMutationMode(repoPrefix, result, receipt, batch, false)
+}
+
+func (mi *MultiIndexer) resolveIncrementalRepoMutationMode(
+	repoPrefix string,
+	result *IndexResult,
+	receipt *graph.MutationReceipt,
+	batch *reparsePendingEnrichmentBatch,
+	exactPointSemantic bool,
 ) {
 	files, needed, _ := incrementalResolutionFrontier(result, receipt)
 	idx := mi.GetIndexer(repoPrefix)
@@ -242,6 +380,10 @@ func (mi *MultiIndexer) resolveIncrementalRepoMutation(
 		}
 	}
 	if idx != nil && result != nil {
-		idx.runIncrementalWatcherSemantic(result.DerivedInvalidation.Files)
+		if exactPointSemantic {
+			idx.runIncrementalPointSemantic(result.DerivedInvalidation.Files)
+		} else {
+			idx.runIncrementalWatcherSemantic(result.DerivedInvalidation.Files)
+		}
 	}
 }

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -120,6 +120,12 @@ type IndexResult struct {
 	// incremental reconcile. A zero plan proves that no graph-wide derived
 	// pass is required; callers must not infer work merely from stale count.
 	DerivedInvalidation DerivedInvalidationPlan `json:"derived_invalidation,omitempty"`
+
+	// mutationErr carries a point-operation compatibility error through the
+	// resolver/semantic/derived tail. It is intentionally unexported and never
+	// serialized: coordinated callers surface it only after the committed graph
+	// has reached a coherent post-mutation state.
+	mutationErr error
 }
 
 // EdgeSanityViolated reports the post-reindex sanity-check failure: an
@@ -344,7 +350,7 @@ type Indexer struct {
 	// different repos into the shared graph race on Edge.Meta during the
 	// resolver's mutation phase vs. the contract pass's graph walk via
 	// AllEdges().
-	deferResolve       bool
+	deferResolve       atomic.Bool
 	pendingContractReg *contracts.Registry
 	// deferredGoModDone makes go.mod contract materialisation idempotent for
 	// one pending contract generation. Coordinated multi-repo cold/warmup runs
@@ -414,7 +420,7 @@ type Indexer struct {
 	// counts in the hundreds. The batch caller is responsible for invoking
 	// RunGlobalGraphPasses exactly once at the end. Has no effect on the
 	// deferResolve path (multi-repo IndexCtx already skips those passes).
-	deferGlobalPasses bool
+	deferGlobalPasses atomic.Bool
 
 	// skipResolveInDeferred, when set, makes RunDeferredPasses skip the
 	// per-repo resolver.ResolveAll() call. ResolveAll walks the entire
@@ -464,8 +470,9 @@ type Indexer struct {
 	// repositoryMutation is the single discovery/parse/resolve/derived lane
 	// for this repository. It is lazy so focused Indexer fixtures do not need
 	// constructor changes, while every production entry point shares it.
-	repositoryMutationOnce sync.Once
-	repositoryMutation     *repositoryMutationCoordinator
+	repositoryMutationMu    sync.Mutex
+	repositoryMutation      *repositoryMutationCoordinator
+	repositoryMutationOwner *MultiIndexer
 
 	// incrementalResolveFilesHook is a focused test seam for proving a
 	// multi-file watcher batch invokes the scoped resolver exactly once. nil in
@@ -917,7 +924,7 @@ func (idx *Indexer) SetTrackedRepoModules(m map[string]string) { idx.trackedRepo
 
 // SetDeferResolve toggles whether IndexCtx defers the cross-cutting passes
 // to a later RunDeferredPasses call. See the deferResolve field comment.
-func (idx *Indexer) SetDeferResolve(v bool) { idx.deferResolve = v }
+func (idx *Indexer) SetDeferResolve(v bool) { idx.deferResolve.Store(v) }
 
 // SetSkipResolveInDeferred toggles whether RunDeferredPasses calls
 // idx.resolver.ResolveAll. The MultiIndexer batch driver sets this so
@@ -932,7 +939,7 @@ func (idx *Indexer) SetSkipResolveInDeferred(v bool) { idx.skipResolveInDeferred
 // caller drives a batch (e.g. daemon warmup) and will invoke
 // RunGlobalGraphPasses once at the end. See the deferGlobalPasses field
 // comment.
-func (idx *Indexer) SetDeferGlobalPasses(v bool) { idx.deferGlobalPasses = v }
+func (idx *Indexer) SetDeferGlobalPasses(v bool) { idx.deferGlobalPasses.Store(v) }
 
 // RunGlobalGraphPasses runs the graph-wide derivation passes once
 // against the indexer's shared graph. Safe to call against a graph that
@@ -1486,7 +1493,12 @@ func (idx *Indexer) RelKey(absPath string) string { return idx.relKey(absPath) }
 
 // SetRepoPrefix sets the repository prefix for multi-repo mode.
 // When non-empty, all node IDs and file paths are prefixed with "<repoPrefix>/".
-func (idx *Indexer) SetRepoPrefix(prefix string) { idx.repoPrefix = prefix }
+func (idx *Indexer) SetRepoPrefix(prefix string) {
+	idx.repoPrefix = prefix
+	if idx.repositoryMutationOwner != nil && prefix != "" {
+		idx.attachRepositoryMutationCoordinator(idx.repositoryMutationOwner.repositoryMutationCoordinator(prefix))
+	}
+}
 
 // RepoPrefix returns the current repository prefix.
 func (idx *Indexer) RepoPrefix() string { return idx.repoPrefix }
@@ -2356,10 +2368,6 @@ func (idx *Indexer) Index(root string) (*IndexResult, error) {
 	return idx.IndexCtx(context.Background(), root)
 }
 
-// IndexCtx is Index with a context, enabling progress reporting. The reporter
-// is pulled from ctx via progress.FromContext — attach one with
-// progress.WithReporter to receive stage updates. If no reporter is attached,
-// stage calls are silently dropped.
 // clampParseWeight maps a file size to a parse-admission weight bounded to
 // [1, budget]. A file larger than the whole budget is admitted alone
 // (weight == budget) so the bytes-in-flight semaphore can never deadlock.
@@ -2373,7 +2381,69 @@ func clampParseWeight(size, budget int64) int64 {
 	return size
 }
 
-func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexResult, retErr error) {
+// IndexCtx is Index with a context, enabling progress reporting. The reporter
+// is pulled from ctx via progress.FromContext — attach one with
+// progress.WithReporter to receive stage updates. If no reporter is attached,
+// stage calls are silently dropped. Full-tree indexing shares the repository
+// mutation lane with watcher, polling, reconciliation, and MCP edits.
+func (idx *Indexer) IndexCtx(ctx context.Context, root string) (*IndexResult, error) {
+	var result *IndexResult
+	err := idx.coordinateRepositoryMutation(ctx, func() error {
+		current, currentErr := idx.currentRepositoryMutationIndexer()
+		if currentErr != nil {
+			return currentErr
+		}
+		// A public handle may outlive IndexRepo replacement. Validate and store
+		// the root only on the live executor selected after lane admission.
+		if rootErr := current.ensureRepositoryMutationRoot(root); rootErr != nil {
+			return rootErr
+		}
+
+		finishTopologyMutation := reach.BeginTopologyMutation(current.graph)
+		defer finishTopologyMutation(true)
+
+		var rawErr error
+		result, rawErr = current.indexCtxRaw(ctx, root)
+		if rawErr != nil {
+			return rawErr
+		}
+		if result == nil {
+			return errors.New("full-tree indexing returned a nil result")
+		}
+
+		// Keep the owning MultiIndexer generation consistent with the graph
+		// replacement before releasing the stable lane. A stale receiver remains
+		// untouched; only the currently published Indexer and its metadata move.
+		owner := current.repositoryMutationOwner
+		prefix := current.repoPrefix
+		if owner != nil && prefix != "" {
+			rootPath := current.RootPath()
+			fileMtimes := current.FileMtimes()
+			owner.mu.Lock()
+			if meta := owner.repos[prefix]; meta != nil && owner.indexers[prefix] == current {
+				owner.repos[prefix] = &RepoMetadata{
+					RepoPrefix:    prefix,
+					RootPath:      rootPath,
+					Identity:      meta.Identity,
+					LastIndexTime: time.Now(),
+					FileCount:     result.FileCount,
+					NodeCount:     result.NodeCount,
+					EdgeCount:     result.EdgeCount,
+					ParseErrors:   result.Errors,
+					FileMtimes:    fileMtimes,
+					IsWorktree:    meta.IsWorktree,
+				}
+			}
+			owner.mu.Unlock()
+		}
+		return nil
+	})
+	return result, err
+}
+
+// indexCtxRaw performs full-tree indexing while the caller holds the
+// repository mutation lane.
+func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *IndexResult, retErr error) {
 	start := time.Now()
 	reporter := progress.FromContext(ctx)
 
@@ -2390,7 +2460,7 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 	if err != nil {
 		return nil, err
 	}
-	idx.rootPath = absRoot
+	idx.storeRootPath(absRoot)
 	idx.projectName = search.DetectProjectName(absRoot)
 
 	reporter.Report("walking files", 0, 0)
@@ -3524,7 +3594,7 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 	idx.totalDetected = len(files)
 	idx.lastIndexTime = time.Now()
 
-	if idx.deferResolve {
+	if idx.deferResolve.Load() {
 		// Multi-repo orchestrator runs these serially after wg.Wait()
 		// to avoid races on the shared graph between this goroutine's
 		// ResolveAll mutation phase and a sibling goroutine's contract
@@ -3548,7 +3618,7 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 		// the final shared graph instead of paying the O(global) walk
 		// per repo. InferOverrides depends on InferImplements running
 		// first.
-		if !idx.deferGlobalPasses {
+		if !idx.deferGlobalPasses.Load() {
 			reporter.Report("inferring interfaces", 0, 0)
 			idx.resolver.InferImplements()
 			idx.resolver.InferOverrides()
@@ -3589,7 +3659,7 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 	// Build search index.
 	idx.buildSearchIndex()
 
-	if !idx.deferResolve {
+	if !idx.deferResolve.Load() {
 		// Contracts were already extracted inline during parse (per file,
 		// per worker). Here we just finish up. extractGoModContracts
 		// already ran (see the !deferResolve branch above) so dep
@@ -3603,7 +3673,7 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (result *IndexRes
 		// Test-edge pass — runs once the call graph is final. Skipped
 		// under deferGlobalPasses so a batch caller can fold this into
 		// one global pass after the per-repo loop.
-		if !idx.deferGlobalPasses {
+		if !idx.deferGlobalPasses.Load() {
 			reporter.Report("test edge pass", 0, 0)
 			marked, emitted := markTestSymbolsAndEmitEdges(idx.graph)
 			if marked > 0 || emitted > 0 {
@@ -3796,16 +3866,102 @@ func (idx *Indexer) warnIfEdgeSanityViolated(r *IndexResult) {
 // add), including per-file resolver work for cross-file references.
 // Use in the single-event fsnotify path where each edit is isolated.
 func (idx *Indexer) IndexFile(filePath string) error {
-	return idx.indexFile(filePath, true, nil)
+	root, err := idx.repositoryMutationRootPath()
+	if err != nil {
+		return err
+	}
+	canonical, err := canonicalRepositoryMutationPath(root, filePath)
+	if err != nil {
+		return err
+	}
+	if err := validateRepositoryMutationRegularFile(root, canonical); err != nil {
+		return err
+	}
+	return idx.coordinateRepositoryMutation(context.Background(), func() error {
+		// The path may be deleted or replaced while this call waits for the
+		// repository lane. Revalidate after admission so IndexFile preserves its
+		// existing-regular-file contract instead of turning a queued update into
+		// an implicit eviction.
+		currentRoot, rootErr := idx.repositoryMutationRootPath()
+		if rootErr != nil {
+			return rootErr
+		}
+		if validateErr := validateRepositoryMutationRegularFile(currentRoot, canonical); validateErr != nil {
+			return validateErr
+		}
+		absPath := filepath.Join(currentRoot, filepath.FromSlash(canonical))
+		acceptedVersion, versionErr := os.Stat(absPath)
+		if versionErr != nil {
+			return fmt.Errorf("index file %q: %w", canonical, versionErr)
+		}
+		result, reindexErr := idx.reindexPointMutationRaw(canonical)
+		if reindexErr != nil {
+			return reindexErr
+		}
+		currentVersion, versionErr := os.Stat(absPath)
+		if versionErr != nil || !sameFileVersion(acceptedVersion, currentVersion) {
+			return fmt.Errorf("%w: %s", errFileVersionChanged, canonical)
+		}
+		if result == nil {
+			return fmt.Errorf("indexing %q returned no result", canonical)
+		}
+		if result.mutationErr != nil {
+			return result.mutationErr
+		}
+		if len(result.FailedFiles) > 0 {
+			return fmt.Errorf("indexing %q failed after retry: %s", canonical, strings.Join(result.FailedFiles, ", "))
+		}
+		return nil
+	})
 }
 
-// IndexFileNoResolve is IndexFile minus the per-file resolver call.
-// Callers in batch paths (storm mode, branch-switch reconcile, git
-// diff dispatch) use this when they will run resolver.ResolveAll()
-// once at the end of the batch; otherwise a 500-file checkout pays
-// the per-file resolver cost 500 times instead of once.
+// IndexFileNoResolve is retained for source compatibility.
+//
+// Deprecated: use IndexFile. Modern batch paths own private already-held raw
+// helpers and one exact resolver/derived tail; exposing a partial public
+// mutation would leave graph quality dependent on an external follow-up pass.
 func (idx *Indexer) IndexFileNoResolve(filePath string) error {
-	return idx.indexFile(filePath, false, nil)
+	return idx.IndexFile(filePath)
+}
+
+// currentRepositoryMutationIndexer resolves the live per-repository Indexer
+// after the caller has acquired the stable mutation lane. A watcher or public
+// handle may outlive an IndexRepo replacement; raw graph work must never target
+// that stale instance.
+func (idx *Indexer) currentRepositoryMutationIndexer() (*Indexer, error) {
+	if idx == nil {
+		return nil, errors.New("repository mutation indexer is nil")
+	}
+	if owner := idx.repositoryMutationOwner; owner != nil && idx.repoPrefix != "" {
+		current := owner.GetIndexer(idx.repoPrefix)
+		if current == nil {
+			return nil, fmt.Errorf("repository mutation executor has no live indexer: %s", idx.repoPrefix)
+		}
+		return current, nil
+	}
+	return idx, nil
+}
+
+// reindexPointMutationRaw is an already-held-lane executor. It must never call
+// a public coordinated API.
+func (idx *Indexer) reindexPointMutationRaw(path string) (*IndexResult, error) {
+	mode := incrementalPathMode{
+		detectDeletions:           true,
+		forceExplicitFiles:        true,
+		surfaceFirstVersionChange: true,
+		exactPointSemantic:        true,
+	}
+	if owner := idx.repositoryMutationOwner; owner != nil && idx.repoPrefix != "" {
+		return owner.incrementalReindexRepoRawMode(idx.repoPrefix, []string{path}, mode)
+	}
+	current, err := idx.currentRepositoryMutationIndexer()
+	if err != nil {
+		return nil, err
+	}
+	if current.rootPath == "" {
+		return nil, errors.New("repository mutation root is unavailable")
+	}
+	return current.incrementalWatcherPaths(current.rootPath, []string{path}, mode)
 }
 
 func (idx *Indexer) indexFile(
@@ -3980,7 +4136,7 @@ func (idx *Indexer) indexFile(
 	var reuseIdx map[reuseKey]*reuseVal
 	var priorUnresolved []*graph.Edge
 	deferredResolverCatchup := markerBatch != nil && markerBatch.deferResolverCatchup
-	if (resolve || deferredResolverCatchup) && !idx.deferGlobalPasses && !skipped {
+	if (resolve || deferredResolverCatchup) && !idx.deferGlobalPasses.Load() && !skipped {
 		snapshotStarted := time.Now()
 		abSnap = idx.snapshotAffectedBy(graphPath)
 		// Snapshot the file's outgoing edges before eviction: resolved ones so
@@ -4108,7 +4264,7 @@ func (idx *Indexer) indexFile(
 		// the index (built=false) we fall back to the full recompute.
 		// Skipped under deferGlobalPasses — a batch caller (ReconcileAll,
 		// warmup) runs the global pass once at the end.
-		if !idx.deferGlobalPasses {
+		if !idx.deferGlobalPasses.Load() {
 			newCloneFuncs := cloneFuncNodes(result.Nodes)
 			// A file with no old or new function nodes cannot change clone
 			// topology. In particular, do not make the first JSON/Markdown/data
@@ -4152,7 +4308,7 @@ func (idx *Indexer) indexFile(
 			// their pre-enrichment tier until the next full reindex. This caller
 			// enforces Config.EnrichOnWatch; deferred batches use EnrichFiles.
 			providersPresent := idx.semanticMgr != nil && idx.semanticMgr.Enabled() && idx.semanticMgr.HasProviders()
-			watchEnrichment := providersPresent && !idx.deferGlobalPasses && idx.semanticMgr.EnrichesOnWatch()
+			watchEnrichment := providersPresent && !idx.deferGlobalPasses.Load() && idx.semanticMgr.EnrichesOnWatch()
 			reEnriched := false
 			if watchEnrichment {
 				enrichStarted := time.Now()
@@ -4393,24 +4549,46 @@ func (idx *Indexer) ResolveAll() {
 // actually finds the file's nodes rather than silently no-opping and
 // leaving a stale subtree behind.
 func (idx *Indexer) EvictFile(filePath string) (int, int) {
-	absPath := filePath
-	if !filepath.IsAbs(absPath) {
-		absPath = filepath.Join(idx.rootPath, filePath)
+	root, err := idx.repositoryMutationRootPath()
+	if err != nil {
+		idx.logEvictFileError(filePath, err)
+		return 0, 0
 	}
-	// graphRelKey (OS-native + NFC), not relKey (slash + NFC): the graph
-	// stores nodes under OS-native separators, so a slash-form lookup
-	// would miss them on Windows and leave a stale subtree behind.
-	relPath := idx.graphRelKey(absPath)
-	// In multi-repo mode, the graph stores prefixed file paths.
-	graphPath := idx.prefixPath(relPath)
-	// Remove from search index.
-	for _, n := range idx.graph.GetFileNodes(graphPath) {
-		idx.removeFromSearch(n)
+	canonical, err := canonicalRepositoryMutationPath(root, filePath)
+	if err != nil {
+		idx.logEvictFileError(filePath, err)
+		return 0, 0
 	}
-	idx.restubIncomingRefs(graphPath)
-	idx.evictEnrichment(graphPath)
-	idx.deleteRefFactsForFiles(idx.repoPrefix, []string{graphPath})
-	return idx.graph.EvictFile(graphPath)
+	var nodesRemoved, edgesRemoved int
+	err = idx.coordinateRepositoryMutation(context.Background(), func() error {
+		var evictErr error
+		nodesRemoved, edgesRemoved, evictErr = idx.evictPointMutationRaw(canonical)
+		return evictErr
+	})
+	if err != nil {
+		idx.logEvictFileError(filePath, err)
+		return 0, 0
+	}
+	return nodesRemoved, edgesRemoved
+}
+
+func (idx *Indexer) logEvictFileError(filePath string, err error) {
+	if idx != nil && idx.logger != nil && err != nil {
+		idx.logger.Warn("indexer: file eviction failed", zap.String("file", filePath), zap.Error(err))
+	}
+}
+
+// evictPointMutationRaw is an already-held-lane executor. It preserves forced
+// removal semantics even when the canonical path still exists on disk.
+func (idx *Indexer) evictPointMutationRaw(path string) (int, int, error) {
+	if owner := idx.repositoryMutationOwner; owner != nil && idx.repoPrefix != "" {
+		return owner.incrementalEvictRepoRaw(idx.repoPrefix, path)
+	}
+	current, err := idx.currentRepositoryMutationIndexer()
+	if err != nil {
+		return 0, 0, err
+	}
+	return current.incrementalEvictWatcherPath(path)
 }
 
 // ReresolveFileScoped forces the scoped re-resolution + LSP re-verify a normal
@@ -4422,6 +4600,26 @@ func (idx *Indexer) EvictFile(filePath string) (int, int) {
 // wired, its incremental enrichment. O(file), no whole-graph pass. No-op when
 // the file has no nodes (evicted since it was enqueued).
 func (idx *Indexer) ReresolveFileScoped(filePath string) error {
+	root, err := idx.repositoryMutationRootPath()
+	if err != nil {
+		return err
+	}
+	canonical, err := canonicalRepositoryMutationPath(root, filePath)
+	if err != nil {
+		return err
+	}
+	return idx.coordinateRepositoryMutation(context.Background(), func() error {
+		current, currentErr := idx.currentRepositoryMutationIndexer()
+		if currentErr != nil {
+			return currentErr
+		}
+		return current.reresolveFileScopedRaw(canonical)
+	})
+}
+
+// reresolveFileScopedRaw is the non-coordinating implementation used by
+// callers that already hold the repository lane.
+func (idx *Indexer) reresolveFileScopedRaw(filePath string) error {
 	absPath := filePath
 	if !filepath.IsAbs(absPath) {
 		absPath = filepath.Join(idx.rootPath, filePath)
@@ -4467,34 +4665,6 @@ func (idx *Indexer) ReresolveFileScoped(filePath string) error {
 // agnostic: GetInEdges + ReindexEdges are the same Store primitives the
 // resolver uses, so this behaves identically on the in-memory and disk
 // stores.
-// evictEnrichment drops the per-node enrichment sidecar rows (churn,
-// coverage, release, blame — change A) for a file's nodes on the
-// delete/rename paths only, so a removed file leaves no orphan
-// enrichment. Capability-gated. A modify re-indexes the same node IDs
-// (enrichment stays valid) so it is NOT cascaded there.
-func (idx *Indexer) evictEnrichment(graphPath string) {
-	nodes := idx.graph.GetFileNodes(graphPath)
-	if len(nodes) == 0 {
-		return
-	}
-	ids := make([]string, 0, len(nodes))
-	for _, n := range nodes {
-		ids = append(ids, n.ID)
-	}
-	if w, ok := idx.graph.(graph.ChurnEnrichmentWriter); ok {
-		_ = w.DeleteChurn(ids)
-	}
-	if w, ok := idx.graph.(graph.CoverageEnrichmentWriter); ok {
-		_ = w.DeleteCoverage(ids)
-	}
-	if w, ok := idx.graph.(graph.ReleaseEnrichmentWriter); ok {
-		_ = w.DeleteReleases(ids)
-	}
-	if w, ok := idx.graph.(graph.BlameEnrichmentWriter); ok {
-		_ = w.DeleteBlame(ids)
-	}
-}
-
 func (idx *Indexer) restubIncomingRefs(graphPath string) {
 	nodes := idx.graph.GetFileNodes(graphPath)
 	if len(nodes) == 0 {
@@ -5407,7 +5577,14 @@ func (idx *Indexer) SetRootPath(root string) {
 // standalone entry point owns the complete parse, resolve, semantic, and exact
 // derived-pass pipeline; MultiIndexer uses the receipt-aware core directly.
 func (idx *Indexer) IncrementalReindexPaths(root string, paths []string) (*IndexResult, error) {
-	return idx.incrementalReindexWatcherPaths(root, paths)
+	if err := idx.ensureRepositoryMutationRoot(root); err != nil {
+		return nil, err
+	}
+	canonical, err := canonicalRepositoryMutationPaths(root, paths)
+	if err != nil {
+		return nil, err
+	}
+	return idx.coordinateRepositoryReindex(context.Background(), canonical)
 }
 
 // incrementalDiscoverPaths discovers and refreshes files beneath paths without
@@ -5419,10 +5596,48 @@ func (idx *Indexer) incrementalDiscoverPaths(root string, paths []string) (*Inde
 	return idx.incrementalReindexPaths(root, paths, false)
 }
 
+// incrementalPathMode keeps forced point semantics private to the caller that
+// owns an explicit filesystem receipt. Reconcile, storm, and discovery callers
+// retain their historical mtime/Merkle filtering.
+type incrementalPathMode struct {
+	detectDeletions           bool
+	forceExplicitFiles        bool
+	surfaceFirstVersionChange bool
+	exactPointSemantic        bool
+}
+
+func (idx *Indexer) incrementalPathOwned(absPath string) bool {
+	graphPath := idx.prefixPath(idx.graphRelKey(absPath))
+	if len(idx.graph.GetFileNodes(graphPath)) > 0 {
+		return true
+	}
+	reader, ok := idx.graph.(graph.FileMetaPathReader)
+	if !ok {
+		return false
+	}
+	rows, err := reader.FileMetasByPaths(idx.repoPrefix, []string{graphPath})
+	if err != nil {
+		return false
+	}
+	_, ok = rows[graphPath]
+	return ok
+}
+
 func (idx *Indexer) incrementalReindexPaths(
 	root string,
 	paths []string,
 	detectDeletions bool,
+	markerBatches ...*reparsePendingEnrichmentBatch,
+) (*IndexResult, error) {
+	return idx.incrementalReindexPathsMode(root, paths, incrementalPathMode{
+		detectDeletions: detectDeletions,
+	}, markerBatches...)
+}
+
+func (idx *Indexer) incrementalReindexPathsMode(
+	root string,
+	paths []string,
+	mode incrementalPathMode,
 	markerBatches ...*reparsePendingEnrichmentBatch,
 ) (*IndexResult, error) {
 	fullRoot := len(paths) == 0
@@ -5451,6 +5666,7 @@ func (idx *Indexer) incrementalReindexPaths(
 	// disk; staleFiles is the subset that changed since the last pass.
 	diskFiles := make(map[string]bool)
 	var staleFiles []string
+	var forcedDeletedFiles []string
 
 	merkleMode := idx.merkleEnabled()
 
@@ -5478,6 +5694,9 @@ func (idx *Indexer) incrementalReindexPaths(
 			// a deleted file the caller still wants evicted. Deletion
 			// detection below handles it via scopeRels.
 			if errors.Is(statErr, os.ErrNotExist) {
+				if mode.forceExplicitFiles && idx.incrementalPathOwned(absPath) {
+					forcedDeletedFiles = append(forcedDeletedFiles, idx.relKey(absPath))
+				}
 				continue
 			}
 			return nil, fmt.Errorf("incremental reindex: stat %q: %w", p, statErr)
@@ -5528,7 +5747,7 @@ func (idx *Indexer) incrementalReindexPaths(
 		// regardless of the Unicode form the caller supplied.
 		relPath := idx.relKey(absPath)
 		diskFiles[relPath] = true
-		if !merkleMode && idx.IsStale(relPath) {
+		if mode.forceExplicitFiles || (!merkleMode && idx.IsStale(relPath)) {
 			staleFiles = append(staleFiles, absPath)
 		}
 	}
@@ -5547,6 +5766,7 @@ func (idx *Indexer) incrementalReindexPaths(
 			}
 		}
 	}
+	staleFiles = appendUniqueSorted(nil, staleFiles...)
 
 	// Restored snapshots populate fileMtimes without running IndexCtx. Preserve
 	// the full-tree health baseline that the retired reconciliation path set.
@@ -5556,21 +5776,31 @@ func (idx *Indexer) incrementalReindexPaths(
 	}
 
 	var deletedFiles []string
-	if detectDeletions {
+	if mode.detectDeletions {
 		// Deletion detection is deliberately opt-in. General scoped
 		// reconciles need it, while directory-create discovery must never
 		// consume a concurrent delete before the watcher can notify clients.
+		// Forced exact watcher paths additionally consult graph/file-meta
+		// ownership so a missing in-memory mtime cannot hide a real deletion.
+		candidateSet := make(map[string]struct{}, len(forcedDeletedFiles)+4)
+		for _, relPath := range forcedDeletedFiles {
+			candidateSet[relPath] = struct{}{}
+		}
 		idx.mtimeMu.RLock()
-		var candidates []string
 		for relPath := range idx.fileMtimes {
 			if diskFiles[relPath] {
 				continue
 			}
 			if relPathInScope(relPath, scopeRels) {
-				candidates = append(candidates, relPath)
+				candidateSet[relPath] = struct{}{}
 			}
 		}
 		idx.mtimeMu.RUnlock()
+		candidates := make([]string, 0, len(candidateSet))
+		for relPath := range candidateSet {
+			candidates = append(candidates, relPath)
+		}
+		sort.Strings(candidates)
 
 		for _, relPath := range candidates {
 			absPath := filepath.Join(absRoot, filepath.FromSlash(relPath))
@@ -5590,6 +5820,7 @@ func (idx *Indexer) incrementalReindexPaths(
 				zap.String("rel", relPath), zap.Error(statErr))
 		}
 	}
+	deletedFiles = appendUniqueSorted(nil, deletedFiles...)
 
 	// Capture surviving dependents before deletion evicts the target symbols and
 	// their incoming adjacency. The helper performs one batched node/edge
@@ -5600,8 +5831,8 @@ func (idx *Indexer) incrementalReindexPaths(
 	if len(markerBatches) > 0 && markerBatches[0] != nil {
 		markerBatch = markerBatches[0]
 	}
-	invalidation, reparsedFiles, failedFiles := idx.reindexIncrementalFilesBatched(
-		sourceStaleFiles, deletedFiles, markerBatch,
+	invalidation, reparsedFiles, failedFiles, versionChangedFiles := idx.reindexIncrementalFilesBatched(
+		sourceStaleFiles, deletedFiles, markerBatch, mode.surfaceFirstVersionChange,
 	)
 	manifestPlan, manifestFailed := idx.refreshIncrementalContractManifests(manifestFiles)
 	invalidation.Merge(manifestPlan)
@@ -5664,6 +5895,11 @@ func (idx *Indexer) incrementalReindexPaths(
 		FailedFiles:         failedFiles,
 		DurationMs:          time.Since(start).Milliseconds(),
 		DerivedInvalidation: invalidation,
+	}
+	if mode.surfaceFirstVersionChange && len(versionChangedFiles) > 0 {
+		result.mutationErr = fmt.Errorf(
+			"%w: %s", errFileVersionChanged, strings.Join(versionChangedFiles, ", "),
+		)
 	}
 	idx.warnIfEdgeSanityViolated(result)
 	// Partial work always queues the exact changed/deleted/dependent graph-file

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -461,6 +461,12 @@ type Indexer struct {
 	affectedByFilesResolved atomic.Int64
 	affectedByDropped       atomic.Int64
 
+	// repositoryMutation is the single discovery/parse/resolve/derived lane
+	// for this repository. It is lazy so focused Indexer fixtures do not need
+	// constructor changes, while every production entry point shares it.
+	repositoryMutationOnce sync.Once
+	repositoryMutation     *repositoryMutationCoordinator
+
 	// incrementalResolveFilesHook is a focused test seam for proving a
 	// multi-file watcher batch invokes the scoped resolver exactly once. nil in
 	// production; the real path calls resolver.ResolveFilesAndIncoming.

--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -23,6 +23,7 @@ import (
 	"github.com/zzet/gortex/internal/parser"
 	"github.com/zzet/gortex/internal/pathkey"
 	"github.com/zzet/gortex/internal/progress"
+	"github.com/zzet/gortex/internal/reach"
 	"github.com/zzet/gortex/internal/resolver"
 	"github.com/zzet/gortex/internal/search"
 	"github.com/zzet/gortex/internal/search/trigram"
@@ -61,6 +62,20 @@ type MultiIndexer struct {
 	logger    *zap.Logger
 	mu        sync.RWMutex
 
+	// repositoryMutations owns one stable mutation lane per repository prefix.
+	// The slot survives Indexer replacement so an explicit re-index cannot race
+	// an old watcher instance on a second lane.
+	repositoryMutationMu sync.Mutex
+	repositoryMutations  map[string]*repositoryMutationCoordinator
+
+	// batchMutationGate makes a batch-mode transition atomic with respect to
+	// complete repository mutation pipelines. Stable coordinators take the read
+	// side only after their repository lane is acquired; Begin/End/Reset take the
+	// write side while flags are propagated. globalPassMu independently prevents
+	// explicit/global derived runs from interleaving with one another.
+	batchMutationGate sync.RWMutex
+	globalPassMu      sync.Mutex
+
 	// shadowAdmission is process-wide, not per MultiIndexer. Every cold repo
 	// competes for the same weighted in-memory budget; repos that do not fit
 	// immediately stream to SQLite instead of waiting or overcommitting RAM.
@@ -89,7 +104,7 @@ type MultiIndexer struct {
 
 	// deferGlobalPasses, when set, propagates SetDeferGlobalPasses(true)
 	// to every per-repo Indexer constructed by this MultiIndexer. Batch
-	// callers (warmup, ReconcileAll) flip it on around their loop and
+	// warmup callers flip it on around their loop and
 	// invoke RunGlobalGraphPasses once at the end so the O(global) walks
 	// (InferImplements / InferOverrides / markTestSymbolsAndEmitEdges)
 	// don't run R times against an R-repo graph.
@@ -223,18 +238,66 @@ func (mi *MultiIndexer) workspaceMembershipResolver() resolver.WorkspaceMembersh
 }
 
 // newPerRepoIndexer constructs a per-repo Indexer with the standard
-// MultiIndexer wiring (shared search backend, embedder if configured,
-// deferred-global-passes flag propagated). Centralised so the flag
-// plumbing stays in one place.
+type multiIndexerBatchMode struct {
+	deferGlobalPasses bool
+	deferResolve      bool
+}
+
+func (mi *MultiIndexer) currentBatchMode() multiIndexerBatchMode {
+	mi.mu.RLock()
+	mode := multiIndexerBatchMode{
+		deferGlobalPasses: mi.deferGlobalPasses,
+		deferResolve:      mi.deferResolve,
+	}
+	mi.mu.RUnlock()
+	return mode
+}
+
+func applyMultiIndexerBatchMode(idx *Indexer, mode multiIndexerBatchMode) {
+	idx.SetDeferGlobalPasses(mode.deferGlobalPasses)
+	idx.SetDeferResolve(mode.deferResolve)
+}
+
+// reapplyBatchModeForMutation closes the construction-to-admission window for
+// Track/Reconcile: the caller already owns the stable lane and transition read
+// gate, so this snapshot is authoritative for the complete mutation.
+func (mi *MultiIndexer) reapplyBatchModeForMutation(idx *Indexer) multiIndexerBatchMode {
+	mode := mi.currentBatchMode()
+	applyMultiIndexerBatchMode(idx, mode)
+	return mode
+}
+
+// newPerRepoIndexer takes one transition-guarded batch-mode snapshot. Callers
+// that already hold batchMutationGate.RLock use newPerRepoIndexerGuarded to
+// avoid recursively acquiring an RWMutex read lock while a writer is queued.
 func (mi *MultiIndexer) newPerRepoIndexer(cfg config.IndexConfig) *Indexer {
+	mi.batchMutationGate.RLock()
+	defer mi.batchMutationGate.RUnlock()
+	return mi.newPerRepoIndexerGuarded(cfg)
+}
+
+// newPerRepoIndexerGuarded wires a per-repository Indexer while the caller
+// already owns the batch transition read side.
+func (mi *MultiIndexer) newPerRepoIndexerGuarded(cfg config.IndexConfig) *Indexer {
+	return mi.newPerRepoIndexerGuardedWithMode(cfg, mi.currentBatchMode())
+}
+
+// newPerRepoIndexerGuardedWithMode wires a per-repository Indexer while the
+// caller owns the batch transition read side and has already captured the
+// transition-stable batch mode. The multi-repo worker path uses this form so it
+// never re-enters mi.mu while the collector is publishing completed repos.
+func (mi *MultiIndexer) newPerRepoIndexerGuardedWithMode(
+	cfg config.IndexConfig,
+	mode multiIndexerBatchMode,
+) *Indexer {
 	idx := New(mi.graph, mi.registry, cfg, mi.logger)
 	idx.shadowAdmission = mi.shadowAdmission
+	idx.repositoryMutationOwner = mi
 	idx.search = mi.search
 	if mi.embedder != nil {
 		idx.SetEmbedder(mi.embedder)
 	}
-	idx.SetDeferGlobalPasses(mi.deferGlobalPasses)
-	idx.SetDeferResolve(mi.deferResolve)
+	applyMultiIndexerBatchMode(idx, mode)
 	idx.SetSkipVectorBuild(mi.skipVectorBuild)
 	idx.SetEmbeddingChunkOptions(mi.embedChunkOpts)
 	idx.SetEmbeddingMaxSymbols(mi.embedMaxSymbols)
@@ -368,16 +431,22 @@ func (mi *MultiIndexer) SetOnRepoTracked(fn func(prefix, absPath string)) {
 }
 
 // BeginBatch enables deferred-global-passes mode for every per-repo
-// Indexer that this MultiIndexer constructs after the call AND for
-// every Indexer already in mi.indexers (so ReconcileAll's per-repo
-// incremental reconciliation calls also skip the O(global) walks). Pair with
-// EndBatch.
+// Indexer that this MultiIndexer constructs after the call and for
+// every Indexer already in mi.indexers. Pair with EndBatch; callers own the
+// matching global pass after their batch completes.
 func (mi *MultiIndexer) BeginBatch() {
+	mi.batchMutationGate.Lock()
+	defer mi.batchMutationGate.Unlock()
+
 	mi.mu.Lock()
 	defer mi.mu.Unlock()
 	mi.deferGlobalPasses = true
+	mode := multiIndexerBatchMode{
+		deferGlobalPasses: mi.deferGlobalPasses,
+		deferResolve:      mi.deferResolve,
+	}
 	for _, idx := range mi.indexers {
-		idx.SetDeferGlobalPasses(true)
+		applyMultiIndexerBatchMode(idx, mode)
 	}
 }
 
@@ -390,12 +459,16 @@ func (mi *MultiIndexer) BeginBatch() {
 // EndBatch; call RunDeferredPassesAll between the parallel parse and
 // EndBatch to run the deferred per-repo passes serially.
 func (mi *MultiIndexer) BeginParallelBatch() {
+	mi.batchMutationGate.Lock()
+	defer mi.batchMutationGate.Unlock()
+
 	mi.mu.Lock()
 	defer mi.mu.Unlock()
 	mi.deferGlobalPasses = true
 	mi.deferResolve = true
+	mode := multiIndexerBatchMode{deferGlobalPasses: true, deferResolve: true}
 	for _, idx := range mi.indexers {
-		idx.SetDeferGlobalPasses(true)
+		applyMultiIndexerBatchMode(idx, mode)
 	}
 }
 
@@ -1128,46 +1201,48 @@ func (mi *MultiIndexer) ArmBatchScope(changedPrefixes map[string]struct{}) {
 		return
 	}
 	mi.mu.Lock()
-	mi.batchChangedPrefixes = changedPrefixes
-	mi.mu.Unlock()
+	defer mi.mu.Unlock()
+	if !mi.deferGlobalPasses {
+		return
+	}
+	if mi.batchChangedPrefixes == nil {
+		mi.batchChangedPrefixes = make(map[string]struct{}, len(changedPrefixes))
+	}
+	for prefix := range changedPrefixes {
+		mi.batchChangedPrefixes[prefix] = struct{}{}
+	}
 }
 
-// ArmBatchCensusEligible records the daemon's attestation that the armed
+// ArmBatchCensusEligible records the daemon's attestation that the active
 // batch scope covers EVERY tracked repository (a cold index or a full warm
-// reconciliation). The framework-synthesis pass then builds its admission
-// census from the raw whole store while execution stays scoped. One-shot:
-// consumed by the next RunGlobalGraphPasses and reset, so it can never leak
-// into a later incremental batch. The attestation is the caller's — it is
-// deliberately not inferred here from scope size.
+// reconciliation). EndBatch detaches this attestation together with the scope;
+// a public global-pass call cannot consume either half of the armed state.
 func (mi *MultiIndexer) ArmBatchCensusEligible() {
 	if mi == nil {
 		return
 	}
 	mi.mu.Lock()
-	mi.batchCensusEligible = true
-	mi.mu.Unlock()
-}
-
-func (mi *MultiIndexer) takeBatchCensusEligible() bool {
-	if mi == nil {
-		return false
+	defer mi.mu.Unlock()
+	if mi.deferGlobalPasses {
+		mi.batchCensusEligible = true
 	}
-	mi.mu.Lock()
-	eligible := mi.batchCensusEligible
-	mi.batchCensusEligible = false
-	mi.mu.Unlock()
-	return eligible
 }
 
-// takeBatchScope returns the armed clone-pass scope and clears it, so the
-// scope governs exactly one RunGlobalGraphPasses run. A nil result means
-// "no scope — run the clone passes for every repo".
-func (mi *MultiIndexer) takeBatchScope() map[string]struct{} {
-	mi.mu.Lock()
-	scope := mi.batchChangedPrefixes
+type batchGlobalPassState struct {
+	scope          map[string]struct{}
+	censusEligible bool
+}
+
+// detachBatchGlobalPassStateLocked transfers the one-shot scope and census as
+// one unit. The caller holds mi.mu and owns the batch-transition write gate.
+func (mi *MultiIndexer) detachBatchGlobalPassStateLocked() batchGlobalPassState {
+	state := batchGlobalPassState{
+		scope:          mi.batchChangedPrefixes,
+		censusEligible: mi.batchCensusEligible,
+	}
 	mi.batchChangedPrefixes = nil
-	mi.mu.Unlock()
-	return scope
+	mi.batchCensusEligible = false
+	return state
 }
 
 // scopedGlobalPassesEnabled reports whether per-repo global passes may be
@@ -1186,14 +1261,22 @@ func (mi *MultiIndexer) scopedGlobalPassesEnabled() bool {
 }
 
 func (mi *MultiIndexer) EndBatch() {
+	mi.batchMutationGate.Lock()
+	defer mi.batchMutationGate.Unlock()
+
 	mi.mu.Lock()
 	mi.deferGlobalPasses = false
 	mi.deferResolve = false
+	state := mi.detachBatchGlobalPassStateLocked()
+	mode := multiIndexerBatchMode{}
 	for _, idx := range mi.indexers {
-		idx.SetDeferGlobalPasses(false)
+		applyMultiIndexerBatchMode(idx, mode)
 	}
 	mi.mu.Unlock()
-	mi.RunGlobalGraphPasses(context.Background())
+
+	// Keep the transition write side through the complete global pass: a
+	// watcher admitted before or during EndBatch runs wholly before or after it.
+	mi.runGlobalGraphPasses(context.Background(), state.scope, state.censusEligible)
 }
 
 // ResetBatch clears deferred-batch mode WITHOUT running the graph-wide
@@ -1207,12 +1290,18 @@ func (mi *MultiIndexer) EndBatch() {
 // flag is still restored so a later watch-triggered TrackRepoCtx /
 // incremental reconciliation runs its passes inline as normal.
 func (mi *MultiIndexer) ResetBatch() {
+	mi.batchMutationGate.Lock()
+	defer mi.batchMutationGate.Unlock()
+
 	mi.mu.Lock()
 	defer mi.mu.Unlock()
 	mi.deferGlobalPasses = false
 	mi.deferResolve = false
+	mi.batchChangedPrefixes = nil
+	mi.batchCensusEligible = false
+	mode := multiIndexerBatchMode{}
 	for _, idx := range mi.indexers {
-		idx.SetDeferGlobalPasses(false)
+		applyMultiIndexerBatchMode(idx, mode)
 	}
 }
 
@@ -1223,6 +1312,37 @@ func (mi *MultiIndexer) ResetBatch() {
 // (test→subject EdgeTests). Idempotent — graph.AddEdge dedupes by
 // edgeKey and the resolver passes skip already-present parents.
 func (mi *MultiIndexer) RunGlobalGraphPasses(ctx context.Context) {
+	// Direct callers own no transition gate. Exclude repository mutation
+	// pipelines for the complete unscoped derivation run; callers already under
+	// a batch gate use runGlobalGraphPasses directly.
+	mi.batchMutationGate.Lock()
+	defer mi.batchMutationGate.Unlock()
+	mi.runGlobalGraphPasses(ctx, nil, false)
+}
+
+// runGlobalGraphPasses owns the reachability topology writer for callers that
+// already hold the appropriate batch transition gate. Incremental pipelines
+// that already own topology call runGlobalGraphPassesTopologyHeld directly.
+func (mi *MultiIndexer) runGlobalGraphPasses(
+	ctx context.Context,
+	scope map[string]struct{},
+	censusEligible bool,
+) {
+	finishTopologyMutation := reach.BeginTopologyMutation(mi.graph)
+	defer finishTopologyMutation(true)
+	mi.runGlobalGraphPassesTopologyHeld(ctx, scope, censusEligible)
+}
+
+// runGlobalGraphPassesTopologyHeld runs with caller-owned topology and
+// scope/census state. It never reads or consumes armed batch fields; EndBatch
+// is their sole consumer.
+func (mi *MultiIndexer) runGlobalGraphPassesTopologyHeld(
+	ctx context.Context,
+	scope map[string]struct{},
+	censusEligible bool,
+) {
+	mi.globalPassMu.Lock()
+	defer mi.globalPassMu.Unlock()
 	if mi.graph == nil {
 		return
 	}
@@ -1250,7 +1370,6 @@ func (mi *MultiIndexer) RunGlobalGraphPasses(ctx context.Context) {
 	//     in a changed repo and whose parent is in an unchanged one (or vice
 	//     versa) is still re-derived; structural implements never crosses repos
 	//     (its same-repo gate), so scoping both its sides here is complete.
-	scope := mi.takeBatchScope()
 	var changedPrefixes map[string]bool
 	var scopedTypeIfaceIDs map[string]bool
 	var scopedRepoPrefixes []string
@@ -1440,15 +1559,10 @@ func (mi *MultiIndexer) RunGlobalGraphPasses(ctx context.Context) {
 	reporter.Report("framework dispatch synthesis (global)", 0, 0)
 	passStart("framework_synthesis")
 	// A full-coverage batch (cold index / full-workspace reconciliation)
-	// carries the daemon's one-shot census attestation: admission censuses
-	// read the raw store while synthesizer execution keeps the scoped view.
-	// Taken OUTSIDE the pass timer: it contends on mi.mu, and a stall there
-	// must read as its own number, not as unattributable synthesis wall.
-	censusTakeStart := time.Now()
-	batchCensusEligible := mi.takeBatchCensusEligible()
-	censusTakeWait := time.Since(censusTakeStart)
+	// carries the caller's detached census attestation: admission censuses read
+	// the raw whole store while synthesizer execution keeps the scoped view.
 	fwStart := time.Now()
-	fwRep := resolver.RunFrameworkSynthesizersScopedWithCensus(mi.graph, changedPrefixes, batchCensusEligible)
+	fwRep := resolver.RunFrameworkSynthesizersScopedWithCensus(mi.graph, changedPrefixes, censusEligible)
 	mi.logger.Info("global pass: framework dispatch synthesis",
 		zap.Int("edges", fwRep.Total),
 		zap.Any("per_synthesizer", fwRep.Per),
@@ -1457,7 +1571,6 @@ func (mi *MultiIndexer) RunGlobalGraphPasses(ctx context.Context) {
 		zap.Int64("gate_ms", fwRep.GateMillis),
 		zap.Int64("claim_ms", fwRep.ClaimMillis),
 		zap.Int64("demote_ms", fwRep.DemoteMillis),
-		zap.Duration("census_take_wait", censusTakeWait),
 		zap.Duration("elapsed", time.Since(fwStart)))
 	// External-call placeholder synthesis (opt-in). Runs after the
 	// stub passes so only genuinely un-indexed external targets are
@@ -1688,7 +1801,12 @@ func (mi *MultiIndexer) indexMultiRepo(repos []config.RepoEntry) (map[string]*In
 		// (e.g. two worktrees declaring the same workspace). resolveTrackPrefix
 		// only sees already-tracked repos, so guard against collisions within
 		// this batch too.
-		if prev, ok := seenPrefix[prefix]; ok && prev != absPath {
+		if prev, ok := seenPrefix[prefix]; ok {
+			if pathkey.SamePathIdentity(prev, absPath) {
+				// Duplicate config entries for one repository must not launch
+				// concurrent raw workers behind a single held repository lane.
+				continue
+			}
 			prefix += "-" + shortPathHash(absPath)
 			e.Name = prefix
 		}
@@ -1700,149 +1818,208 @@ func (mi *MultiIndexer) indexMultiRepo(repos []config.RepoEntry) (map[string]*In
 		}
 	}
 
-	resultCh := make(chan repoResult, len(resolved))
-	var wg sync.WaitGroup
-	coordinatedBulk, _ := mi.graph.(graph.CoordinatedBulkLoader)
-	coordinatedBulkActive := coordinatedBulk != nil && coordinatedBulk.BeginCoordinatedBulkLoad()
-	defer func() {
-		if coordinatedBulkActive {
-			if err := coordinatedBulk.EndCoordinatedBulkLoad(); err != nil {
-				mi.logger.Error("multi-repo bulk-load cleanup failed", zap.Error(err))
-			}
+	if len(resolved) == 0 {
+		if len(resolveErrors) == 0 {
+			return map[string]*IndexResult{}, nil
 		}
-	}()
+		sort.Strings(resolveErrors)
+		return nil, fmt.Errorf("all repos failed to index: %s", strings.Join(resolveErrors, "; "))
+	}
 
-	for _, rr := range resolved {
-		wg.Add(1)
-		go func(r resolvedRepo) {
-			defer wg.Done()
+	prefixes := make([]string, 0, len(resolved))
+	for _, repo := range resolved {
+		prefixes = append(prefixes, repo.prefix)
+	}
+	var finalResults map[string]*IndexResult
+	laneErr := mi.withRepositoryMutationLanes(context.Background(), prefixes, func() error {
+		// Freeze one batch-mode generation only after every stable repository
+		// lane is held. The one topology writer then covers parse, publication,
+		// deferred/cross-repo tails, ref-facts, and global derivation.
+		mi.batchMutationGate.RLock()
+		defer mi.batchMutationGate.RUnlock()
+		batchMode := mi.currentBatchMode()
+		finishTopologyMutation := reach.BeginTopologyMutation(mi.graph)
+		defer finishTopologyMutation(true)
 
-			idx := mi.newPerRepoIndexer(r.cfg.Index)
-			idx.SetRepoPrefix(r.prefix)
-			entryCopy := r.entry
-			idx.SetWorkspaceID(resolveWorkspaceID(&entryCopy, r.cfg, r.prefix))
-			idx.SetProjectID(resolveProjectID(&entryCopy, r.cfg, r.prefix))
-			idx.SetTrackedRepoModules(trackedModules)
-			// Defer the per-repo cross-cutting passes (ResolveAll,
-			// semantic enrich, contract extract+commit) so they don't
-			// race against each other across goroutines on the shared
-			// graph. They run serially below via RunDeferredPasses after
-			// wg.Wait(). The graph-wide derivation passes run once after
-			// the loop via mi.RunGlobalGraphPasses().
-			idx.SetDeferResolve(true)
+		pipelineResults, pipelineErr := func() (map[string]*IndexResult, error) {
+			resultCh := make(chan repoResult, len(resolved))
+			var wg sync.WaitGroup
+			coordinatedBulk, _ := mi.graph.(graph.CoordinatedBulkLoader)
+			coordinatedBulkActive := coordinatedBulk != nil && coordinatedBulk.BeginCoordinatedBulkLoad()
+			defer func() {
+				if coordinatedBulkActive {
+					if err := coordinatedBulk.EndCoordinatedBulkLoad(); err != nil {
+						mi.logger.Error("multi-repo bulk-load cleanup failed", zap.Error(err))
+					}
+				}
+			}()
 
-			result, err := idx.Index(r.absPath)
-			if err != nil {
-				resultCh <- repoResult{prefix: r.prefix, err: fmt.Errorf("indexing %s: %w", r.absPath, err)}
-				return
+			for _, rr := range resolved {
+				wg.Add(1)
+				go func(r resolvedRepo) {
+					defer wg.Done()
+
+					idx := mi.newPerRepoIndexerGuardedWithMode(r.cfg.Index, batchMode)
+					idx.SetRepoPrefix(r.prefix)
+					entryCopy := r.entry
+					idx.SetWorkspaceID(resolveWorkspaceID(&entryCopy, r.cfg, r.prefix))
+					idx.SetProjectID(resolveProjectID(&entryCopy, r.cfg, r.prefix))
+					idx.SetTrackedRepoModules(trackedModules)
+					// Defer the per-repo cross-cutting passes (ResolveAll,
+					// semantic enrich, contract extract+commit) so they don't
+					// race against each other across goroutines on the shared
+					// graph. They run serially below via RunDeferredPasses after
+					// wg.Wait(). The graph-wide derivation passes run once after
+					// the loop via mi.RunGlobalGraphPasses().
+					idx.SetDeferResolve(true)
+
+					result, err := idx.indexCtxRaw(context.Background(), r.absPath)
+					if err != nil {
+						resultCh <- repoResult{prefix: r.prefix, err: fmt.Errorf("indexing %s: %w", r.absPath, err)}
+						return
+					}
+					result.RepoPrefix = r.prefix
+
+					meta := &RepoMetadata{
+						RepoPrefix:    r.prefix,
+						RootPath:      r.absPath,
+						Identity:      r.identity,
+						LastIndexTime: time.Now(),
+						FileCount:     result.FileCount,
+						NodeCount:     result.NodeCount,
+						EdgeCount:     result.EdgeCount,
+						ParseErrors:   result.Errors,
+						FileMtimes:    idx.FileMtimes(),
+						IsWorktree:    ResolveWorktree(r.absPath).IsWorktree,
+					}
+
+					resultCh <- repoResult{prefix: r.prefix, result: result, idx: idx, meta: meta}
+				}(rr)
 			}
-			result.RepoPrefix = r.prefix
 
-			meta := &RepoMetadata{
-				RepoPrefix:    r.prefix,
-				RootPath:      r.absPath,
-				Identity:      r.identity,
-				LastIndexTime: time.Now(),
-				FileCount:     result.FileCount,
-				NodeCount:     result.NodeCount,
-				EdgeCount:     result.EdgeCount,
-				ParseErrors:   result.Errors,
-				FileMtimes:    idx.FileMtimes(),
-				IsWorktree:    ResolveWorktree(r.absPath).IsWorktree,
+			go func() {
+				wg.Wait()
+				close(resultCh)
+			}()
+
+			results := make(map[string]*IndexResult)
+			indexErrors := resolveErrors
+			completed := make([]repoResult, 0, len(resolved))
+
+			// Drain workers without holding the registry lock. Constructors and future
+			// worker tails may need read access to MultiIndexer state; pinning mi.mu
+			// across the channel range turns any such read into a producer/consumer
+			// deadlock and blocks unrelated registry readers for the whole warmup.
+			for rr := range resultCh {
+				if rr.err != nil {
+					mi.logger.Error("failed to index repo", zap.String("prefix", rr.prefix), zap.Error(rr.err))
+					indexErrors = append(indexErrors, rr.err.Error())
+					continue
+				}
+				completed = append(completed, rr)
+				results[rr.prefix] = rr.result
+			}
+			mi.mu.Lock()
+			for _, rr := range completed {
+				mi.repos[rr.prefix] = rr.meta
+				mi.indexers[rr.prefix] = rr.idx
+			}
+			mi.mu.Unlock()
+			if coordinatedBulkActive {
+				if err := coordinatedBulk.EndCoordinatedBulkLoad(); err != nil {
+					return nil, fmt.Errorf("multi-repo bulk-load finalize: %w", err)
+				}
+				coordinatedBulkActive = false
 			}
 
-			resultCh <- repoResult{prefix: r.prefix, result: result, idx: idx, meta: meta}
-		}(rr)
-	}
+			// Do not publish a completed pipeline when no repository reached the
+			// deferred stages. Besides making the failure deterministic, this prevents
+			// global passes from deriving edges from a partially-drained failed batch.
+			if len(indexErrors) > 0 && len(results) == 0 {
+				sort.Strings(indexErrors)
+				return nil, fmt.Errorf("all repos failed to index: %s", strings.Join(indexErrors, "; "))
+			}
 
-	go func() {
-		wg.Wait()
-		close(resultCh)
-	}()
+			// Complete cold multi-repo indexing through the same coordinated pipeline
+			// used by daemon warmup:
+			//   1. materialise go.mod contracts once, then run one shared base resolve;
+			//   2. enrich repositories in bounded language-aware batches (large Go
+			//      repositories remain exclusive), committing contracts only after each
+			//      batch drains;
+			//   3. use the mutation receipt to perform only the exact catch-up needed for
+			//      semantic/contract mutations.
+			//
+			// The old loop called idx.RunDeferredPasses with
+			// skipResolveInDeferred=false, so every repository performed ResolveAll over
+			// the entire shared graph. At R repositories and E edges that was O(R*E) and
+			// was the dominant cold-index regression. runDeferredGoMod is generation-
+			// idempotent, so RunDeferredPassesAll does not repeat the pre-resolve work.
+			deferCtx := context.Background()
+			mi.RunPreEnrichResolve(deferCtx, nil, nil)
+			enrichScheduled := mi.RunDeferredPassesAll(deferCtx)
+			mi.logger.Info("multi-repo coordinated deferred passes complete",
+				zap.Int("repos_indexed", len(results)),
+				zap.Int("repos_failed", len(indexErrors)),
+				zap.Int("enrich_scheduled", enrichScheduled))
 
-	results := make(map[string]*IndexResult)
-	indexErrors := resolveErrors
+			// Semantic and contract passes can add new cross-repository candidates.
+			// Refresh them once after the receipt-scoped same-repo catch-up and reconcile
+			// contract bridges before graph-wide derivation consumes the final graph.
+			mi.runCrossRepoResolve(true)
 
-	mi.mu.Lock()
-	for rr := range resultCh {
-		if rr.err != nil {
-			mi.logger.Error("failed to index repo", zap.String("prefix", rr.prefix), zap.Error(rr.err))
-			indexErrors = append(indexErrors, rr.err.Error())
-			continue
-		}
-		mi.repos[rr.prefix] = rr.meta
-		mi.indexers[rr.prefix] = rr.idx
-		results[rr.prefix] = rr.result
-	}
-	mi.mu.Unlock()
-	if coordinatedBulkActive {
-		if err := coordinatedBulk.EndCoordinatedBulkLoad(); err != nil {
-			return nil, fmt.Errorf("multi-repo bulk-load finalize: %w", err)
-		}
-		coordinatedBulkActive = false
-	}
+			// ResolveAll normally seeds ref_facts after a full resolve. The coordinated
+			// cold path intentionally bypasses per-repository ResolveAll, so seed the
+			// successful repository set once after every base, semantic catch-up, and
+			// cross-repository mutation has settled. Sorting makes the boundary stable
+			// for tracing/tests; SQLite consumes the whole slice in one transaction.
+			successfulPrefixes := make([]string, 0, len(results))
+			for prefix := range results {
+				successfulPrefixes = append(successfulPrefixes, prefix)
+			}
+			sort.Strings(successfulPrefixes)
+			if err := mi.rebuildColdRefFacts(deferCtx, successfulPrefixes); err != nil {
+				return results, fmt.Errorf("multi-repo reference-fact rebuild: %w", err)
+			}
 
-	// Do not publish a completed pipeline when no repository reached the
-	// deferred stages. Besides making the failure deterministic, this prevents
-	// global passes from deriving edges from a partially-drained failed batch.
-	if len(indexErrors) > 0 && len(results) == 0 {
-		sort.Strings(indexErrors)
-		return nil, fmt.Errorf("all repos failed to index: %s", strings.Join(indexErrors, "; "))
-	}
+			// Graph-wide derivation passes run exactly once after every repo
+			// has been parsed, every per-repo and cross-repo resolver has lifted
+			// placeholder edges, and contract bridges are in place. RunDeferredPasses
+			// intentionally skips these so we don't pay an O(global) walk per
+			// repo (was the dominant cost at R≈100+).
+			mi.runGlobalGraphPassesTopologyHeld(context.Background(), nil, false)
 
-	// Complete cold multi-repo indexing through the same coordinated pipeline
-	// used by daemon warmup:
-	//   1. materialise go.mod contracts once, then run one shared base resolve;
-	//   2. enrich repositories in bounded language-aware batches (large Go
-	//      repositories remain exclusive), committing contracts only after each
-	//      batch drains;
-	//   3. use the mutation receipt to perform only the exact catch-up needed for
-	//      semantic/contract mutations.
-	//
-	// The old loop called idx.RunDeferredPasses with
-	// skipResolveInDeferred=false, so every repository performed ResolveAll over
-	// the entire shared graph. At R repositories and E edges that was O(R*E) and
-	// was the dominant cold-index regression. runDeferredGoMod is generation-
-	// idempotent, so RunDeferredPassesAll does not repeat the pre-resolve work.
-	deferCtx := context.Background()
-	mi.RunPreEnrichResolve(deferCtx, nil, nil)
-	enrichScheduled := mi.RunDeferredPassesAll(deferCtx)
-	mi.logger.Info("multi-repo coordinated deferred passes complete",
-		zap.Int("repos_indexed", len(results)),
-		zap.Int("repos_failed", len(indexErrors)),
-		zap.Int("enrich_scheduled", enrichScheduled))
-
-	// Semantic and contract passes can add new cross-repository candidates.
-	// Refresh them once after the receipt-scoped same-repo catch-up and reconcile
-	// contract bridges before graph-wide derivation consumes the final graph.
-	mi.runCrossRepoResolve(true)
-
-	// ResolveAll normally seeds ref_facts after a full resolve. The coordinated
-	// cold path intentionally bypasses per-repository ResolveAll, so seed the
-	// successful repository set once after every base, semantic catch-up, and
-	// cross-repository mutation has settled. Sorting makes the boundary stable
-	// for tracing/tests; SQLite consumes the whole slice in one transaction.
-	successfulPrefixes := make([]string, 0, len(results))
-	for prefix := range results {
-		successfulPrefixes = append(successfulPrefixes, prefix)
-	}
-	sort.Strings(successfulPrefixes)
-	if err := mi.rebuildColdRefFacts(deferCtx, successfulPrefixes); err != nil {
-		return results, fmt.Errorf("multi-repo reference-fact rebuild: %w", err)
-	}
-
-	// Graph-wide derivation passes run exactly once after every repo
-	// has been parsed, every per-repo and cross-repo resolver has lifted
-	// placeholder edges, and contract bridges are in place. RunDeferredPasses
-	// intentionally skips these so we don't pay an O(global) walk per
-	// repo (was the dominant cost at R≈100+).
-	mi.RunGlobalGraphPasses(context.Background())
-
-	return results, nil
+			return results, nil
+		}()
+		finalResults = pipelineResults
+		return pipelineErr
+	})
+	return finalResults, laneErr
 }
 
 // IndexRepo re-indexes a single repo by prefix. Evicts existing data first.
 func (mi *MultiIndexer) IndexRepo(repoPrefix string) (*IndexResult, error) {
+	mi.mu.RLock()
+	_, ok := mi.repos[repoPrefix]
+	mi.mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("repository not found: %s", repoPrefix)
+	}
+	var result *IndexResult
+	var indexErr error
+	err := mi.repositoryMutationCoordinator(repoPrefix).runExclusive(context.Background(), func() error {
+		finishTopologyMutation := reach.BeginTopologyMutation(mi.graph)
+		defer finishTopologyMutation(true)
+		result, indexErr = mi.indexRepoRaw(repoPrefix)
+		return indexErr
+	})
+	if err != nil {
+		return result, err
+	}
+	return result, indexErr
+}
+
+// indexRepoRaw replaces one live Indexer while its stable repository lane is held.
+func (mi *MultiIndexer) indexRepoRaw(repoPrefix string) (*IndexResult, error) {
 	mi.mu.RLock()
 	meta, ok := mi.repos[repoPrefix]
 	mi.mu.RUnlock()
@@ -1857,7 +2034,7 @@ func (mi *MultiIndexer) IndexRepo(repoPrefix string) (*IndexResult, error) {
 
 	mi.configMgr.LoadWorkspaceConfig(repoPrefix, meta.RootPath)
 	cfg := mi.configMgr.GetRepoConfig(repoPrefix)
-	idx := mi.newPerRepoIndexer(cfg.Index)
+	idx := mi.newPerRepoIndexerGuarded(cfg.Index)
 	// Always stamp the repo prefix, even when this is the only tracked repo.
 	// The multi-repo cold path (indexMultiRepo) already prefixes
 	// unconditionally; gating the single-repo re-index on repo count left the
@@ -1871,9 +2048,12 @@ func (mi *MultiIndexer) IndexRepo(repoPrefix string) (*IndexResult, error) {
 	idx.SetWorkspaceID(resolveWorkspaceID(entry, cfg, repoPrefix))
 	idx.SetProjectID(resolveProjectID(entry, cfg, repoPrefix))
 
-	result, err := idx.Index(meta.RootPath)
+	result, err := idx.indexCtxRaw(context.Background(), meta.RootPath)
 	if err != nil {
 		return nil, fmt.Errorf("indexing %s: %w", meta.RootPath, err)
+	}
+	if result == nil {
+		return nil, fmt.Errorf("indexing %s returned a nil result", meta.RootPath)
 	}
 
 	mi.mu.Lock()
@@ -1887,6 +2067,7 @@ func (mi *MultiIndexer) IndexRepo(repoPrefix string) (*IndexResult, error) {
 		EdgeCount:     result.EdgeCount,
 		ParseErrors:   result.Errors,
 		FileMtimes:    idx.FileMtimes(),
+		IsWorktree:    meta.IsWorktree,
 	}
 	mi.indexers[repoPrefix] = idx
 	mi.mu.Unlock()
@@ -1951,6 +2132,143 @@ func (mi *MultiIndexer) RefreshRepoConfigs() int {
 // directories; otherwise the whole repo root is scanned. Returns an
 // error when the prefix is not a tracked repo.
 func (mi *MultiIndexer) IncrementalReindexRepo(repoPrefix string, paths []string) (*IndexResult, error) {
+	for attempt := 0; attempt < 3; attempt++ {
+		mi.mu.RLock()
+		meta, ok := mi.repos[repoPrefix]
+		idx := mi.indexers[repoPrefix]
+		mi.mu.RUnlock()
+		if !ok || meta == nil {
+			return nil, fmt.Errorf("repository not found: %s", repoPrefix)
+		}
+		canonical, err := canonicalRepositoryMutationPaths(meta.RootPath, paths)
+		if err != nil {
+			return nil, err
+		}
+		if idx == nil {
+			return mi.IndexRepo(repoPrefix)
+		}
+
+		coordinator, current := mi.repositoryMutationCoordinatorForSnapshot(repoPrefix, meta, idx)
+		if !current {
+			continue
+		}
+		result, err := coordinator.reconcile(context.Background(), canonical)
+		if err == errRepositoryMutationCoordinatorClosed {
+			continue
+		}
+		return result, err
+	}
+	return nil, fmt.Errorf("repository changed while admitting reindex: %s", repoPrefix)
+}
+
+// incrementalDiscoverRepo performs additive-only directory discovery. The
+// watcher coalesces directory paths before calling this method; runExclusive
+// preserves delete-event ownership while sharing the stable repository lane.
+func (mi *MultiIndexer) incrementalDiscoverRepo(repoPrefix string, paths []string) (*IndexResult, error) {
+	for attempt := 0; attempt < 3; attempt++ {
+		mi.mu.RLock()
+		meta, ok := mi.repos[repoPrefix]
+		idx := mi.indexers[repoPrefix]
+		mi.mu.RUnlock()
+		if !ok || meta == nil || idx == nil {
+			return nil, fmt.Errorf("repository not found: %s", repoPrefix)
+		}
+		coordinator, current := mi.repositoryMutationCoordinatorForSnapshot(repoPrefix, meta, idx)
+		if !current {
+			continue
+		}
+		var result *IndexResult
+		err := coordinator.runExclusive(context.Background(), func() error {
+			var rawErr error
+			result, rawErr = mi.incrementalDiscoverRepoRaw(repoPrefix, paths)
+			return rawErr
+		})
+		if err == errRepositoryMutationCoordinatorClosed {
+			continue
+		}
+		return result, err
+	}
+	return nil, fmt.Errorf("repository changed while admitting discovery: %s", repoPrefix)
+}
+
+// incrementalReindexRepoRaw is the coordinator executor. It must never submit
+// back into IncrementalReindexRepo or the same repository lane would deadlock.
+func (mi *MultiIndexer) incrementalReindexRepoRaw(repoPrefix string, paths []string) (*IndexResult, error) {
+	return mi.incrementalReindexRepoRawMode(repoPrefix, paths, incrementalPathMode{detectDeletions: true})
+}
+
+func (mi *MultiIndexer) incrementalDiscoverRepoRaw(repoPrefix string, paths []string) (*IndexResult, error) {
+	return mi.incrementalReindexRepoRawMode(repoPrefix, paths, incrementalPathMode{})
+}
+
+// incrementalPointRepoRaw is called only after the stable per-repository lane
+// is held by Watcher. It resolves the current registered Indexer and runs the
+// full shared resolver, semantic, metadata, and precise derived tail without
+// submitting back into a coordinated public API.
+func (mi *MultiIndexer) incrementalPointRepoRaw(repoPrefix, path string) (*IndexResult, error) {
+	return mi.incrementalReindexRepoRawMode(repoPrefix, []string{path}, incrementalPathMode{
+		detectDeletions:    true,
+		forceExplicitFiles: true,
+	})
+}
+
+// incrementalEvictRepoRaw is the MultiIndexer already-held-lane forced deletion
+// executor. It selects the current registered Indexer after admission and keeps
+// the shared resolver, metadata, and derived tails inside the same topology
+// transaction.
+func (mi *MultiIndexer) incrementalEvictRepoRaw(repoPrefix, path string) (nodesRemoved, edgesRemoved int, err error) {
+	mi.mu.RLock()
+	meta, ok := mi.repos[repoPrefix]
+	idx := mi.indexers[repoPrefix]
+	mi.mu.RUnlock()
+	if !ok || meta == nil {
+		return 0, 0, fmt.Errorf("repository not found: %s", repoPrefix)
+	}
+	if idx == nil {
+		return 0, 0, fmt.Errorf("repository mutation executor has no live indexer: %s", repoPrefix)
+	}
+
+	finishTopologyMutation := reach.BeginTopologyMutation(mi.graph)
+	topologyChanged := true
+	defer func() { finishTopologyMutation(topologyChanged) }()
+
+	eviction := idx.evictFileIncrementalRaw(path)
+	result := eviction.result
+	if result == nil {
+		return eviction.nodesRemoved, eviction.edgesRemoved, fmt.Errorf(
+			"evicting %s from %s returned a nil result", path, repoPrefix,
+		)
+	}
+	if result.DeletedFileCount > 0 {
+		mi.resolveIncrementalRepoMutation(repoPrefix, result, nil, eviction.batch)
+	}
+
+	mi.mu.Lock()
+	mi.repos[repoPrefix] = &RepoMetadata{
+		RepoPrefix:    repoPrefix,
+		RootPath:      meta.RootPath,
+		Identity:      meta.Identity,
+		LastIndexTime: time.Now(),
+		FileCount:     result.FileCount,
+		NodeCount:     result.NodeCount,
+		EdgeCount:     result.EdgeCount,
+		ParseErrors:   result.Errors,
+		FileMtimes:    idx.FileMtimes(),
+		IsWorktree:    meta.IsWorktree,
+	}
+	mi.mu.Unlock()
+
+	if result.DeletedFileCount > 0 {
+		idx.observeIncrementalCatchup("derived", result.DerivedInvalidation.Files)
+		mi.runIncrementalDerivedPassesTopologyHeld(context.Background(), map[string]DerivedInvalidationPlan{
+			repoPrefix: result.DerivedInvalidation,
+		})
+	}
+	topologyChanged = incrementalTopologyChanged(result)
+	return eviction.nodesRemoved, eviction.edgesRemoved, nil
+}
+
+func (mi *MultiIndexer) incrementalReindexRepoRawMode(repoPrefix string, paths []string, mode incrementalPathMode) (*IndexResult, error) {
 	mi.mu.RLock()
 	meta, ok := mi.repos[repoPrefix]
 	idx := mi.indexers[repoPrefix]
@@ -1959,13 +2277,17 @@ func (mi *MultiIndexer) IncrementalReindexRepo(repoPrefix string, paths []string
 		return nil, fmt.Errorf("repository not found: %s", repoPrefix)
 	}
 	if idx == nil {
-		// Tracked but no live indexer (e.g. restored from snapshot
-		// without one) — fall back to a full re-index, which rebuilds
-		// the per-repo indexer from scratch.
-		return mi.IndexRepo(repoPrefix)
+		return nil, fmt.Errorf("repository mutation executor has no live indexer: %s", repoPrefix)
 	}
 
-	result, receipt, batch, err := idx.incrementalReindexPathsWithReceipt(meta.RootPath, paths)
+	// The stable per-repository lane is held before this executor runs. Take
+	// the global reachability topology gate second and keep it through the
+	// resolver, metadata, and derived tails to avoid lane/gate inversion.
+	finishTopologyMutation := reach.BeginTopologyMutation(mi.graph)
+	topologyChanged := true
+	defer func() { finishTopologyMutation(topologyChanged) }()
+
+	result, receipt, batch, err := idx.incrementalReindexPathsWithReceiptMode(meta.RootPath, paths, mode)
 	if err != nil {
 		return nil, fmt.Errorf("reindexing %s: %w", meta.RootPath, err)
 	}
@@ -1974,7 +2296,9 @@ func (mi *MultiIndexer) IncrementalReindexRepo(repoPrefix string, paths []string
 	// mutation receipts provide the precise changed/definition file frontier;
 	// only an incomplete receipt falls back to the conservative scoped-global
 	// resolver. Derived invalidations run once below after bindings are current.
-	mi.resolveIncrementalRepoMutation(repoPrefix, result, receipt, batch)
+	mi.resolveIncrementalRepoMutationMode(
+		repoPrefix, result, receipt, batch, mode.exactPointSemantic,
+	)
 
 	mi.mu.Lock()
 	mi.repos[repoPrefix] = &RepoMetadata{
@@ -1997,10 +2321,11 @@ func (mi *MultiIndexer) IncrementalReindexRepo(repoPrefix string, paths []string
 	mi.mu.Unlock()
 
 	idx.observeIncrementalCatchup("derived", result.DerivedInvalidation.Files)
-	mi.RunIncrementalDerivedPasses(context.Background(), map[string]DerivedInvalidationPlan{
+	mi.runIncrementalDerivedPassesTopologyHeld(context.Background(), map[string]DerivedInvalidationPlan{
 		repoPrefix: result.DerivedInvalidation,
 	})
 
+	topologyChanged = incrementalTopologyChanged(result)
 	return result, nil
 }
 
@@ -2190,44 +2515,79 @@ func (mi *MultiIndexer) TrackRepoCtx(ctx context.Context, entry config.RepoEntry
 	idx.SetWorkspaceID(resolveWorkspaceID(&entryCopy, cfg, prefix))
 	idx.SetProjectID(resolveProjectID(&entryCopy, cfg, prefix))
 
-	result, err := idx.IndexCtx(ctx, absPath)
+	var result *IndexResult
+	err = idx.coordinateRepositoryMutation(ctx, func() error {
+		// Construction can precede a queued batch transition. Once the stable
+		// lane and transition read gate are held, reapply the authoritative mode.
+		batchMode := mi.reapplyBatchModeForMutation(idx)
+		finishTopologyMutation := reach.BeginTopologyMutation(mi.graph)
+		topologyChanged := false
+		defer func() { finishTopologyMutation(topologyChanged) }()
+
+		// A concurrent track for the same resolved prefix — or for the same
+		// directory through a case/Unicode spelling that resolved to another
+		// prefix lane — may have completed while this caller waited.
+		mi.mu.RLock()
+		_, exists := mi.repos[prefix]
+		if !exists {
+			for _, meta := range mi.repos {
+				if meta != nil && pathkey.SamePathIdentity(meta.RootPath, absPath) {
+					exists = true
+					break
+				}
+			}
+		}
+		mi.mu.RUnlock()
+		if exists {
+			return nil
+		}
+		topologyChanged = true
+
+		var indexErr error
+		result, indexErr = idx.indexCtxRaw(ctx, absPath)
+		if indexErr != nil {
+			return fmt.Errorf("indexing %s: %w", absPath, indexErr)
+		}
+		if result == nil {
+			return fmt.Errorf("indexing %s returned a nil result", absPath)
+		}
+		result.RepoPrefix = prefix
+
+		mi.mu.Lock()
+		mi.repos[prefix] = &RepoMetadata{
+			RepoPrefix:    prefix,
+			RootPath:      absPath,
+			Identity:      identity,
+			LastIndexTime: time.Now(),
+			FileCount:     result.FileCount,
+			NodeCount:     result.NodeCount,
+			EdgeCount:     result.EdgeCount,
+			ParseErrors:   result.Errors,
+			FileMtimes:    idx.FileMtimes(),
+			IsWorktree:    ResolveWorktree(absPath).IsWorktree,
+		}
+		mi.indexers[prefix] = idx
+		mi.mu.Unlock()
+
+		// Add to global config.
+		entry.Path = absPath
+		if err := mi.configMgr.Global().AddRepo(entry); err != nil {
+			mi.logger.Warn("failed to add repo to config", zap.Error(err))
+		}
+
+		// Skip the per-repo contract reconcile when batching: it walks every
+		// edge in the shared graph to evict stale EdgeMatches and rebuilds
+		// the matcher across every indexer, so paying it once per repo on a
+		// warmup over 100+ repos is O(R · E). The batch caller runs it once
+		// after the loop (RunGlobalResolve does this for daemon warmup).
+		if !batchMode.deferGlobalPasses {
+			mi.ReconcileContractEdges()
+		}
+		return nil
+	})
 	if err != nil {
-		return nil, fmt.Errorf("indexing %s: %w", absPath, err)
+		return nil, err
 	}
-	result.RepoPrefix = prefix
-
-	mi.mu.Lock()
-	mi.repos[prefix] = &RepoMetadata{
-		RepoPrefix:    prefix,
-		RootPath:      absPath,
-		Identity:      identity,
-		LastIndexTime: time.Now(),
-		FileCount:     result.FileCount,
-		NodeCount:     result.NodeCount,
-		EdgeCount:     result.EdgeCount,
-		ParseErrors:   result.Errors,
-		FileMtimes:    idx.FileMtimes(),
-		IsWorktree:    ResolveWorktree(absPath).IsWorktree,
-	}
-	mi.indexers[prefix] = idx
-	mi.mu.Unlock()
-
-	// Add to global config.
-	entry.Path = absPath
-	if err := mi.configMgr.Global().AddRepo(entry); err != nil {
-		mi.logger.Warn("failed to add repo to config", zap.Error(err))
-	}
-
-	// Skip the per-repo contract reconcile when batching: it walks every
-	// edge in the shared graph to evict stale EdgeMatches and rebuilds
-	// the matcher across every indexer, so paying it once per repo on a
-	// warmup over 100+ repos is O(R · E). The batch caller runs it once
-	// after the loop (RunGlobalResolve does, and the janitor's ReconcileAll
-	// fires it post-loop too).
-	if !mi.deferGlobalPasses {
-		mi.ReconcileContractEdges()
-	}
-
 	return result, nil
 }
 
@@ -2298,128 +2658,163 @@ func (mi *MultiIndexer) ReconcileRepoCtx(ctx context.Context, entry config.RepoE
 	idx.SetRootPath(absPath)
 	idx.SetFileMtimes(priorMtimes)
 
-	// Choose the reconcile strategy from a census of what changed on disk
-	// while the daemon was down. Scoped incremental is the default: re-index
-	// only the changed files and evict only the deleted ones, leaving the
-	// rest of the already-persisted graph untouched. A whole-repo re-track
-	// (IndexCtx — which evicts and re-parses every file, then bulk-drains)
-	// is reserved for the cases where scoping is unsafe or not worth it: the
-	// census could not be taken, the churn is a large fraction of the repo,
-	// or an operator forced it via GORTEX_WARMUP_FULL_RETRACK. A repo with
-	// zero changes keeps the fast full-tree incremental no-op (walk + 0 stale →
-	// return), which is what makes an unchanged warm restart near-instant.
-	//
-	// The in-memory backend (*graph.Graph) keeps its exact prior behaviour:
-	// the full-tree modern pipeline is authoritative there — it evicts
-	// offline-deleted files in place, has no reopened disk store, and so no
-	// per-edge write to route around. Gate on the store type.
-	_, memoryBacked := mi.graph.(*graph.Graph)
-	var (
-		result           *IndexResult
-		receipt          *graph.MutationReceipt
-		batch            *reparsePendingEnrichmentBatch
-		changed, deleted []string
-		route            = "incremental"
-	)
-	// fullRetrack is the whole-repo re-track — the ONE place FullRetrack is
-	// stamped. StaleFileCount keeps its honest incremental-work meaning (0
-	// here) because the changed-file set is not enumerated on this path, so
-	// callers must key "did this repo change" off FullRetrack instead.
-	fullRetrack := func() (*IndexResult, error) {
-		r, e := idx.IndexCtx(ctx, absPath)
-		if e == nil && r != nil {
-			r.FullRetrack = true
+	var result *IndexResult
+	err = idx.coordinateRepositoryMutation(ctx, func() error {
+		// Construction can precede a queued batch transition. Once the stable
+		// lane and transition read gate are held, reapply the authoritative mode.
+		batchMode := mi.reapplyBatchModeForMutation(idx)
+		finishTopologyMutation := reach.BeginTopologyMutation(mi.graph)
+		topologyChanged := false
+		defer func() { finishTopologyMutation(topologyChanged) }()
+
+		// Snapshot restoration may race another admission for this prefix or
+		// the same directory through a case/Unicode spelling on another lane.
+		// Recheck both identities only after owning the stable lane.
+		mi.mu.RLock()
+		_, exists := mi.repos[prefix]
+		if !exists {
+			for _, meta := range mi.repos {
+				if meta != nil && pathkey.SamePathIdentity(meta.RootPath, absPath) {
+					exists = true
+					break
+				}
+			}
 		}
-		return r, e
-	}
-	switch {
-	case memoryBacked:
-		result, receipt, batch, err = idx.incrementalReindexPathsWithReceipt(absPath, nil)
-	default:
-		var censusErr error
-		changed, deleted, censusErr = idx.ChangedSinceMtimes(absPath)
-		churn := len(changed) + len(deleted)
-		priorCount := len(priorMtimes)
-		forceFull := os.Getenv("GORTEX_WARMUP_FULL_RETRACK") == "1"
+		mi.mu.RUnlock()
+		if exists {
+			return nil
+		}
+		topologyChanged = true
+
+		// Choose the reconcile strategy from a census of what changed on disk
+		// while the daemon was down. Scoped incremental is the default: re-index
+		// only the changed files and evict only the deleted ones, leaving the
+		// rest of the already-persisted graph untouched. A whole-repo re-track
+		// (IndexCtx — which evicts and re-parses every file, then bulk-drains)
+		// is reserved for the cases where scoping is unsafe or not worth it: the
+		// census could not be taken, the churn is a large fraction of the repo,
+		// or an operator forced it via GORTEX_WARMUP_FULL_RETRACK. A repo with
+		// zero changes keeps the fast full-tree incremental no-op (walk + 0 stale →
+		// return), which is what makes an unchanged warm restart near-instant.
+		//
+		// The in-memory backend (*graph.Graph) keeps its exact prior behaviour:
+		// the full-tree modern pipeline is authoritative there — it evicts
+		// offline-deleted files in place, has no reopened disk store, and so no
+		// per-edge write to route around. Gate on the store type.
+		_, memoryBacked := mi.graph.(*graph.Graph)
+		var (
+			receipt          *graph.MutationReceipt
+			batch            *reparsePendingEnrichmentBatch
+			changed, deleted []string
+			route            = "incremental"
+		)
+		// fullRetrack is the whole-repo re-track — the ONE place FullRetrack is
+		// stamped. StaleFileCount keeps its honest incremental-work meaning (0
+		// here) because the changed-file set is not enumerated on this path, so
+		// callers must key "did this repo change" off FullRetrack instead.
+		fullRetrack := func() (*IndexResult, error) {
+			r, e := idx.indexCtxRaw(ctx, absPath)
+			if e == nil && r != nil {
+				r.FullRetrack = true
+			}
+			return r, e
+		}
 		switch {
-		case censusErr != nil || forceFull:
-			route = "full_retrack"
-			result, err = fullRetrack()
-		case churn == 0:
-			route = "incremental"
-			result, receipt, batch, err = idx.incrementalReindexPathsWithReceipt(absPath, nil)
-		case priorCount > 0 && churn*100 > priorCount*40:
-			route = "full_retrack"
-			result, err = fullRetrack()
+		case memoryBacked:
+			result, receipt, batch, err = idx.incrementalReindexPathsWithReceipt(absPath, nil, true)
 		default:
-			route = "scoped"
-			result, receipt, batch, err = idx.incrementalReindexPathsWithReceipt(absPath, append(changed, deleted...))
+			var censusErr error
+			changed, deleted, censusErr = idx.ChangedSinceMtimes(absPath)
+			churn := len(changed) + len(deleted)
+			priorCount := len(priorMtimes)
+			forceFull := os.Getenv("GORTEX_WARMUP_FULL_RETRACK") == "1"
+			switch {
+			case censusErr != nil || forceFull:
+				route = "full_retrack"
+				result, err = fullRetrack()
+			case churn == 0:
+				route = "incremental"
+				result, receipt, batch, err = idx.incrementalReindexPathsWithReceipt(absPath, nil, true)
+			case priorCount > 0 && churn*100 > priorCount*40:
+				route = "full_retrack"
+				result, err = fullRetrack()
+			default:
+				route = "scoped"
+				result, receipt, batch, err = idx.incrementalReindexPathsWithReceipt(absPath, append(changed, deleted...), true)
+			}
 		}
-	}
-	if err != nil {
-		return nil, fmt.Errorf("reconciling %s: %w", absPath, err)
-	}
-	// A scoped snapshot reconcile cannot derive its total from the walked
-	// scope. Its post-mutation tracked count is the repository-wide baseline.
-	if idx.totalDetected == 0 {
-		idx.totalDetected = result.FileCount
-	}
-	result.RepoPrefix = prefix
-
-	mi.mu.Lock()
-	mi.repos[prefix] = &RepoMetadata{
-		RepoPrefix:    prefix,
-		RootPath:      absPath,
-		Identity:      identity,
-		LastIndexTime: time.Now(),
-		FileCount:     result.FileCount,
-		NodeCount:     result.NodeCount,
-		EdgeCount:     result.EdgeCount,
-		ParseErrors:   result.Errors,
-		FileMtimes:    idx.FileMtimes(),
-		IsWorktree:    ResolveWorktree(absPath).IsWorktree,
-	}
-	mi.indexers[prefix] = idx
-	mi.mu.Unlock()
-
-	entry.Path = absPath
-	if err := mi.configMgr.Global().AddRepo(entry); err != nil {
-		mi.logger.Warn("failed to add repo to config", zap.Error(err))
-	}
-
-	// A restored incremental route parsed against an Indexer that was not yet
-	// registered. Once registration makes it visible to the shared resolver,
-	// consume its receipt and exact derived plan through this MultiIndexer.
-	// Parallel warmup deliberately defers both tails to its later workspace
-	// resolve/global phases. A full retrack already ran its own resolve/derived
-	// pipeline and only needs the existing cross-repository contract reconcile.
-	if !result.FullRetrack && !mi.deferResolve {
-		mi.resolveIncrementalRepoMutation(prefix, result, receipt, batch)
-		if !mi.deferGlobalPasses {
-			idx.observeIncrementalCatchup("derived", result.DerivedInvalidation.Files)
-			mi.RunIncrementalDerivedPasses(ctx, map[string]DerivedInvalidationPlan{
-				prefix: result.DerivedInvalidation,
-			})
+		if err != nil {
+			return fmt.Errorf("reconciling %s: %w", absPath, err)
 		}
-	} else if result.FullRetrack && !mi.deferGlobalPasses {
-		mi.ReconcileContractEdges()
-	}
+		if result == nil {
+			return fmt.Errorf("reconciling %s returned a nil result", absPath)
+		}
+		// A scoped snapshot reconcile cannot derive its total from the walked
+		// scope. Its post-mutation tracked count is the repository-wide baseline.
+		if idx.totalDetected == 0 {
+			idx.totalDetected = result.FileCount
+		}
+		result.RepoPrefix = prefix
 
-	mi.logger.Info("daemon: reconciled repo from snapshot",
-		zap.String("prefix", prefix),
-		zap.String("route", route),
-		zap.Int("changed", len(changed)),
-		zap.Int("deleted", len(deleted)),
-		zap.Bool("full_retrack", result.FullRetrack),
-		zap.Int("stale_files_reindexed", result.StaleFileCount),
-		zap.Duration("elapsed", time.Since(start)))
-	if len(changed) > 0 || len(deleted) > 0 {
-		mi.logger.Debug("daemon: reconcile changed-file census",
+		mi.mu.Lock()
+		mi.repos[prefix] = &RepoMetadata{
+			RepoPrefix:    prefix,
+			RootPath:      absPath,
+			Identity:      identity,
+			LastIndexTime: time.Now(),
+			FileCount:     result.FileCount,
+			NodeCount:     result.NodeCount,
+			EdgeCount:     result.EdgeCount,
+			ParseErrors:   result.Errors,
+			FileMtimes:    idx.FileMtimes(),
+			IsWorktree:    ResolveWorktree(absPath).IsWorktree,
+		}
+		mi.indexers[prefix] = idx
+		mi.mu.Unlock()
+
+		entry.Path = absPath
+		if err := mi.configMgr.Global().AddRepo(entry); err != nil {
+			mi.logger.Warn("failed to add repo to config", zap.Error(err))
+		}
+
+		// A restored incremental route parsed against an Indexer that was not yet
+		// registered. Once registration makes it visible to the shared resolver,
+		// consume its receipt and exact derived plan through this MultiIndexer.
+		// Parallel warmup deliberately defers both tails to its later workspace
+		// resolve/global phases. A full retrack already ran its own resolve/derived
+		// pipeline and only needs the existing cross-repository contract reconcile.
+		if !result.FullRetrack && !batchMode.deferResolve {
+			mi.resolveIncrementalRepoMutation(prefix, result, receipt, batch)
+			if !batchMode.deferGlobalPasses {
+				idx.observeIncrementalCatchup("derived", result.DerivedInvalidation.Files)
+				mi.runIncrementalDerivedPassesTopologyHeld(context.Background(), map[string]DerivedInvalidationPlan{
+					prefix: result.DerivedInvalidation,
+				})
+			}
+		} else if result.FullRetrack && !batchMode.deferGlobalPasses {
+			mi.ReconcileContractEdges()
+		}
+
+		mi.logger.Info("daemon: reconciled repo from snapshot",
 			zap.String("prefix", prefix),
-			zap.Strings("changed", firstNStrings(changed, 5)),
-			zap.Strings("deleted", firstNStrings(deleted, 5)))
+			zap.String("route", route),
+			zap.Int("changed", len(changed)),
+			zap.Int("deleted", len(deleted)),
+			zap.Bool("full_retrack", result.FullRetrack),
+			zap.Int("stale_files_reindexed", result.StaleFileCount),
+			zap.Duration("elapsed", time.Since(start)))
+		if len(changed) > 0 || len(deleted) > 0 {
+			mi.logger.Debug("daemon: reconcile changed-file census",
+				zap.String("prefix", prefix),
+				zap.Strings("changed", firstNStrings(changed, 5)),
+				zap.Strings("deleted", firstNStrings(deleted, 5)))
+		}
+		topologyChanged = incrementalTopologyChanged(result)
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
-
 	return result, nil
 }
 
@@ -2450,31 +2845,17 @@ func (mi *MultiIndexer) ReconcileAll() map[string]*IndexResult {
 }
 
 // ReconcileAllCtx is ReconcileAll with cooperative cancellation between
-// repositories and before the derived pass coordinator.
+// repositories and while waiting for each repository mutation lane.
 func (mi *MultiIndexer) ReconcileAllCtx(ctx context.Context) map[string]*IndexResult {
 	mi.mu.RLock()
 	prefixes := make([]string, 0, len(mi.indexers))
-	for p := range mi.indexers {
-		prefixes = append(prefixes, p)
+	for prefix := range mi.indexers {
+		prefixes = append(prefixes, prefix)
 	}
 	mi.mu.RUnlock()
-
-	// Same batch trick as warmup: each per-repo full-tree incremental pass
-	// triggers an O(global) InferImplements/InferOverrides walk if we
-	// don't suppress it. With ~100 repos that's ~100× the work for the
-	// hourly janitor.
-	mi.BeginBatch()
-	// Always restore batch flags on exit (incl. panic) WITHOUT running the
-	// graph-wide derivation passes — those are run explicitly below, and
-	// only when a repo actually reindexed. The hourly janitor used to run
-	// EndBatch unconditionally, walking the full graph (InferImplements /
-	// InferOverrides / clone detection over hundreds of thousands of
-	// edges) every cycle even when nothing changed — wasted CPU and, on a
-	// small resident buffer pool, needless memory churn.
-	defer mi.ResetBatch()
+	sort.Strings(prefixes)
 
 	results := make(map[string]*IndexResult, len(prefixes))
-	plans := make(map[string]DerivedInvalidationPlan)
 	for _, prefix := range prefixes {
 		if ctx != nil {
 			select {
@@ -2483,68 +2864,99 @@ func (mi *MultiIndexer) ReconcileAllCtx(ctx context.Context) map[string]*IndexRe
 			default:
 			}
 		}
+
 		mi.mu.RLock()
-		idx, ok := mi.indexers[prefix]
-		meta, metaOK := mi.repos[prefix]
+		idx := mi.indexers[prefix]
+		meta := mi.repos[prefix]
 		mi.mu.RUnlock()
-		if !ok || !metaOK || meta == nil || meta.RootPath == "" {
+		if idx == nil || meta == nil || meta.RootPath == "" {
 			continue
 		}
-		result, receipt, batch, err := idx.incrementalReindexPathsWithReceipt(meta.RootPath, nil)
+
+		// A nil scope is an explicit full-tree reconciliation. Admission goes
+		// through the stable prefix lane, so watcher/Git/MCP requests arriving
+		// during discovery advance the dirty generation and run once more after
+		// this pass. The coordinator executor owns resolution, metadata, and
+		// exact derived invalidation; no shared batch flags can leak to another
+		// repository's concurrent mutation.
+		coordinator, current := mi.repositoryMutationCoordinatorForSnapshot(prefix, meta, idx)
+		if !current {
+			continue
+		}
+		result, err := coordinator.reconcile(ctx, nil)
+		if err == errRepositoryMutationCoordinatorClosed {
+			continue
+		}
 		if err != nil {
+			if ctx != nil && ctx.Err() != nil {
+				return results
+			}
 			mi.logger.Warn("janitor: reconcile failed",
 				zap.String("prefix", prefix), zap.Error(err))
 			continue
 		}
-		mi.resolveIncrementalRepoMutation(prefix, result, receipt, batch)
+		results[prefix] = result
 		if result != nil && (result.StaleFileCount > 0 || result.DeletedFileCount > 0) {
 			mi.logger.Info("janitor: reconciled repo",
 				zap.String("prefix", prefix),
-				zap.Int("stale_files_reindexed", result.StaleFileCount))
-			plan := plans[prefix]
-			plan.Merge(result.DerivedInvalidation)
-			plans[prefix] = plan
+				zap.Int("stale_files_reindexed", result.StaleFileCount),
+				zap.Int("deleted_files_evicted", result.DeletedFileCount))
 		}
-		results[prefix] = result
-
-		// Keep RepoMetadata.FileMtimes in sync so the next snapshot
-		// picks up the reconciled mtimes.
-		mi.mu.Lock()
-		if m, ok := mi.repos[prefix]; ok && m != nil {
-			m.FileMtimes = idx.FileMtimes()
-			m.LastIndexTime = time.Now()
-			// This pass was whole-repo, so its counts describe the repo
-			// and are safe to stamp. Doing so also heals metadata that a
-			// scoped pass left describing only its own scope, so a daemon
-			// already reporting a wrong file count converges on its own
-			// instead of needing a restart.
-			if result != nil {
-				m.FileCount = result.FileCount
-				m.NodeCount = result.NodeCount
-				m.EdgeCount = result.EdgeCount
-			}
-		}
-		mi.mu.Unlock()
-	}
-
-	if len(plans) > 0 {
-		// Run only the derived families selected by each repo's exact file
-		// deltas. Body-only and metadata-only changes therefore avoid global
-		// derivation, while structural changes retain conservative fallbacks.
-		mi.RunIncrementalDerivedPasses(ctx, plans)
 	}
 	return results
 }
 
 // UntrackRepo evicts a repo from the graph and removes it from config.
 func (mi *MultiIndexer) UntrackRepo(repoPrefix string) (int, int) {
+	// Snapshot the exact live registry generation first. Legacy restores and
+	// direct-map fixtures may not have a stable lane yet; backfill one only
+	// while both metadata and Indexer pointers still match this generation.
+	mi.mu.RLock()
+	metaSnapshot, tracked := mi.repos[repoPrefix]
+	idx := mi.indexers[repoPrefix]
+	mi.mu.RUnlock()
+	if !tracked {
+		return 0, 0
+	}
+	coordinator, current := mi.repositoryMutationCoordinatorForTeardownSnapshot(
+		repoPrefix, metaSnapshot, idx,
+	)
+	if !current {
+		return 0, 0
+	}
+
+	// Close admission before removing the live Indexer or purging its graph.
+	// Waiting outside mi.mu lets the in-flight mutation tail finish without
+	// lock inversion; every later admission observes the closed stable lane.
+	if err := coordinator.closeAndWait(context.Background()); err != nil {
+		mi.logger.Warn("failed to drain repository mutation coordinator",
+			zap.String("prefix", repoPrefix), zap.Error(err))
+		return 0, 0
+	}
+
+	// The lane is now closed and drained, so taking the transition read side
+	// cannot invert the usual lane -> gate order. Retain it through exact-
+	// generation validation, graph/config purge, contract reconciliation, and
+	// conditional detach; EndBatch and direct global passes see either the
+	// complete repository or its complete absence.
+	mi.batchMutationGate.RLock()
+	defer mi.batchMutationGate.RUnlock()
+	finishTopologyMutation := reach.BeginTopologyMutation(mi.graph)
+	defer finishTopologyMutation(true)
+
 	mi.mu.Lock()
 	meta, ok := mi.repos[repoPrefix]
-	if !ok {
+	idx = mi.indexers[repoPrefix]
+	// A concurrent teardown may have removed the old generation and a later
+	// track may already have installed a fresh Indexer/slot for this prefix.
+	// Delete metadata only when both live objects still belong to the exact
+	// coordinator generation drained above.
+	if !ok ||
+		mi.existingRepositoryMutationCoordinator(repoPrefix) != coordinator ||
+		(idx != nil && !idx.hasRepositoryMutationCoordinator(coordinator)) {
 		mi.mu.Unlock()
 		return 0, 0
 	}
-	idx := mi.indexers[repoPrefix]
 	delete(mi.repos, repoPrefix)
 	delete(mi.indexers, repoPrefix)
 	mi.mu.Unlock()
@@ -2594,6 +3006,10 @@ func (mi *MultiIndexer) UntrackRepo(repoPrefix string) (int, int) {
 
 	mi.ReconcileContractEdges()
 
+	// Keep the closed slot installed until every purge/config side effect is
+	// complete, then remove only the exact generation drained above. A stale
+	// teardown racing a retrack must leave the replacement lane installed.
+	mi.detachRepositoryMutationCoordinator(repoPrefix, coordinator)
 	return nodesRemoved, edgesRemoved
 }
 

--- a/internal/indexer/multi_cold_orchestration_test.go
+++ b/internal/indexer/multi_cold_orchestration_test.go
@@ -225,7 +225,10 @@ func serialColdReference(t *testing.T, repos []config.RepoEntry) *MultiIndexer {
 		idx.SetWorkspaceID(prefix)
 		idx.SetProjectID(prefix)
 		idx.SetDeferResolve(true)
-		result, err := idx.Index(absPath)
+		// Match the production cold path: this Indexer is not live until the
+		// serial fixture publishes it below, so initialize it with the raw
+		// primitive while the fixture owns orchestration.
+		result, err := idx.indexCtxRaw(context.Background(), absPath)
 		require.NoError(t, err)
 		result.RepoPrefix = prefix
 		mi.indexers[prefix] = idx

--- a/internal/indexer/multi_reconcile_test.go
+++ b/internal/indexer/multi_reconcile_test.go
@@ -178,6 +178,49 @@ func Run() error { return exec.Command("true").Run() }
 		"janitor must consume the plan after the batched repository loop")
 }
 
+func TestReconcileAllCtx_PreservesExistingBatchFlags(t *testing.T) {
+	dir := t.TempDir()
+	repoAPath := filepath.Join(dir, "repo-a")
+	repoBPath := filepath.Join(dir, "repo-b")
+	require.NoError(t, os.MkdirAll(repoAPath, 0o755))
+	require.NoError(t, os.MkdirAll(repoBPath, 0o755))
+	writeFile(t, filepath.Join(repoAPath, "a.go"), "package a\nfunc A() {}\n")
+	writeFile(t, filepath.Join(repoBPath, "b.go"), "package b\nfunc B() {}\n")
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	gc := &config.GlobalConfig{Repos: []config.RepoEntry{
+		{Path: repoAPath, Name: "repo-a"},
+		{Path: repoBPath, Name: "repo-b"},
+	}}
+	gc.SetConfigPath(cfgPath)
+	require.NoError(t, gc.Save())
+	cm, err := config.NewConfigManager(cfgPath)
+	require.NoError(t, err)
+
+	mi := NewMultiIndexer(graph.New(), newTestRegistry(), search.NewBM25(), cm, zap.NewNop())
+	_, err = mi.IndexAll()
+	require.NoError(t, err)
+
+	idxA := mi.GetIndexer("repo-a")
+	idxB := mi.GetIndexer("repo-b")
+	require.NotNil(t, idxA)
+	require.NotNil(t, idxB)
+
+	// ReconcileAllCtx may run while an outer batch owns the shared flag. Give
+	// the second repository an intentionally independent value so this also
+	// catches per-repository state leaking across the reconciliation loop.
+	mi.BeginBatch()
+	t.Cleanup(mi.ResetBatch)
+	idxB.SetDeferGlobalPasses(false)
+
+	results := mi.ReconcileAllCtx(context.Background())
+	require.Contains(t, results, "repo-a")
+	require.Contains(t, results, "repo-b")
+	assert.True(t, mi.deferGlobalPasses, "reconciliation must preserve the outer batch state")
+	assert.True(t, idxA.deferGlobalPasses.Load(), "reconciliation must preserve repo-a's batch state")
+	assert.False(t, idxB.deferGlobalPasses.Load(), "reconciliation must not leak repo-a's state into repo-b")
+}
+
 func reconcileHasEdgeKind(g graph.Store, kind graph.EdgeKind) bool {
 	for _, edge := range g.AllEdges() {
 		if edge != nil && edge.Kind == kind {

--- a/internal/indexer/multi_watcher.go
+++ b/internal/indexer/multi_watcher.go
@@ -11,7 +11,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/zzet/gortex/internal/config"
-	"github.com/zzet/gortex/internal/resolver"
 )
 
 // MultiWatcher manages file watchers across multiple repositories.
@@ -20,7 +19,6 @@ type MultiWatcher struct {
 	gitWatchers map[string]*GitWatcher // repoPrefix → .git ref watcher
 	started     map[string]bool        // tracks which watchers have been started
 	multi       *MultiIndexer
-	resolver    *resolver.CrossRepoResolver
 	logger      *zap.Logger
 	events      chan GraphChangeEvent
 	done        chan struct{}
@@ -51,25 +49,10 @@ func NewMultiWatcher(
 		gitWatchers: make(map[string]*GitWatcher),
 		started:     make(map[string]bool),
 		multi:       mi,
-		resolver:    resolver.NewCrossRepo(mi.Graph()),
 		logger:      logger,
 		events:      make(chan GraphChangeEvent, 128),
 		done:        make(chan struct{}),
 	}
-	// Wire the cross-workspace boundary check into the resolver so
-	// cross-repo edges are only resolved when the source workspace
-	// declared the target via `cross_workspace_deps`.
-	mw.resolver.SetCrossWorkspaceDepLookup(mi.crossWorkspaceLookup())
-	// Resolve JS/TS imports declared through an npm alias to their
-	// locally-vendored real package.
-	mw.resolver.SetNpmAliasResolver(mi.npmAliasResolver())
-	mw.resolver.SetPathAliasResolver(mi.pathAliasResolver())
-	// Break same-named import collisions in favour of the importer's
-	// own package-manager workspace member.
-	mw.resolver.SetWorkspaceMembership(mi.workspaceMembershipResolver())
-	// Cross-daemon proxy-edge minting: mint proxy edges on incremental
-	// re-resolution too, when the daemon installed a prober (flag on).
-	mi.applyRemoteStitch(mw.resolver)
 
 	for prefix, cfg := range configs {
 		if err := mw.createWatcher(prefix, cfg); err != nil {
@@ -101,17 +84,39 @@ func (mw *MultiWatcher) createWatcher(prefix string, cfg config.WatchConfig) err
 	if idx == nil {
 		return fmt.Errorf("no indexer for repo: %s", prefix)
 	}
+	idx.attachRepositoryMutationCoordinator(mw.multi.repositoryMutationCoordinator(prefix))
 
 	w, err := NewWatcher(idx, cfg, mw.logger.With(zap.String("repo", prefix)))
 	if err != nil {
 		return fmt.Errorf("creating watcher for %s: %w", prefix, err)
 	}
+	// The watcher outlives an IndexRepo replacement. Its construction-time
+	// Indexer remains the stable lane carrier; graph work selects the current
+	// registry entry only after that lane admits it.
+	w.currentIndexer = func() *Indexer {
+		return mw.multi.GetIndexer(prefix)
+	}
 	w.batchReindex = func(paths []string) (*IndexResult, error) {
 		return mw.multi.IncrementalReindexRepo(prefix, paths)
+	}
+	w.discoverReindex = func(paths []string) (*IndexResult, error) {
+		return mw.multi.incrementalDiscoverRepo(prefix, paths)
+	}
+	w.pointReindexRaw = func(filePath string) (*IndexResult, error) {
+		return mw.multi.incrementalPointRepoRaw(prefix, filePath)
 	}
 
 	mw.watchers[prefix] = w
 	return nil
+}
+
+func (mw *MultiWatcher) configureGitWatcher(prefix string, gw *GitWatcher) {
+	gw.currentIndexer = func() *Indexer {
+		return mw.multi.GetIndexer(prefix)
+	}
+	gw.batchReindex = func(paths []string) (*IndexResult, error) {
+		return mw.multi.IncrementalReindexRepo(prefix, paths)
+	}
 }
 
 // Start begins watching all configured repos. Events from per-repo watchers
@@ -180,9 +185,7 @@ func (mw *MultiWatcher) Start() error {
 			if idx := mw.multi.GetIndexer(prefix); idx != nil {
 				gw, err := NewGitWatcher(rootPath, idx, mw.logger.With(zap.String("repo", prefix)))
 				if err == nil {
-					gw.batchReindex = func(paths []string) (*IndexResult, error) {
-						return mw.multi.IncrementalReindexRepo(prefix, paths)
-					}
+					mw.configureGitWatcher(prefix, gw)
 				}
 				if err != nil {
 					mw.logger.Debug("git-watcher: init failed",
@@ -215,10 +218,10 @@ func (mw *MultiWatcher) Start() error {
 	return nil
 }
 
-// forwardEvents reads events from a per-repo watcher and forwards them
-// to the merged events channel. After each event, it triggers cross-repo
-// resolution for the owning repo.
-func (mw *MultiWatcher) forwardEvents(prefix string, w *Watcher) {
+// forwardEvents reads events from a per-repo watcher and forwards them to the
+// merged events channel. Cross-repository resolution already completed inside
+// the originating watcher's coordinated mutation tail.
+func (mw *MultiWatcher) forwardEvents(_ string, w *Watcher) {
 	for {
 		select {
 		case <-mw.done:
@@ -227,31 +230,10 @@ func (mw *MultiWatcher) forwardEvents(prefix string, w *Watcher) {
 			if !ok {
 				return
 			}
-
-			// After re-indexing, trigger cross-repo resolution — scoped
-			// to the file that changed, not the whole repo. ResolveForRepo
-			// materialised the repo's entire edge set on every save (the
-			// per-edit allocation flood); ResolveForFile only re-resolves
-			// the changed file's out-edges. The watcher path is absolute,
-			// so convert it to the repo-relative graph key first.
-			if mw.multi.IsMultiRepo() {
-				relPath := ev.FilePath
-				if w.indexer != nil {
-					relPath = w.indexer.RelKey(ev.FilePath)
-				}
-				stats := mw.resolver.ResolveForFile(prefix, relPath)
-				if stats.CrossRepoEdges > 0 {
-					mw.logger.Debug("cross-repo edges updated after file change",
-						zap.String("repo", prefix),
-						zap.String("file", ev.FilePath),
-						zap.Int("cross_repo_edges", stats.CrossRepoEdges),
-					)
-				}
-			}
-
-			// Non-blocking send to merged channel.
 			select {
 			case mw.events <- ev:
+			case <-mw.done:
+				return
 			default:
 			}
 		}
@@ -452,6 +434,7 @@ func (mw *MultiWatcher) AddRepo(repoPrefix string, cfg config.WatchConfig) error
 	mw.started[repoPrefix] = true
 	if idx := mw.multi.GetIndexer(repoPrefix); idx != nil {
 		if gw, err := NewGitWatcher(meta.RootPath, idx, mw.logger.With(zap.String("repo", repoPrefix))); err == nil {
+			mw.configureGitWatcher(repoPrefix, gw)
 			if err := gw.Start(); err == nil {
 				mw.gitWatchers[repoPrefix] = gw
 			} else {

--- a/internal/indexer/partial_scope_fallback_test.go
+++ b/internal/indexer/partial_scope_fallback_test.go
@@ -87,7 +87,7 @@ func TestPartialNonGoReparseUsesOneLanguageBatchAndNoRepoPass(t *testing.T) {
 	store := graph.New()
 	idx := New(store, partialScopeRegistry(), config.IndexConfig{}, zap.NewNop())
 	idx.SetRootPath(root)
-	idx.deferGlobalPasses = true
+	idx.deferGlobalPasses.Store(true)
 	provider := &partialScopeBatchProvider{language: "python"}
 	manager := semantic.NewManager(semantic.Config{
 		Enabled: true,

--- a/internal/indexer/poller.go
+++ b/internal/indexer/poller.go
@@ -2,8 +2,10 @@ package indexer
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -50,6 +52,14 @@ type Poller struct {
 	lastSHA     string
 	loopStarted bool
 	stopCalled  bool
+
+	// pollMu guards dirty-generation singleflight admission. Timer and notify
+	// triggers never queue behind a running filesystem scan: they advance
+	// pollRequested and return. The active owner observes that generation after
+	// its sweep and performs one coalesced follow-up when necessary.
+	pollMu        sync.Mutex
+	pollRequested uint64
+	pollRunning   bool
 
 	// swept is a test hook fired after every poll cycle with the
 	// number of files the cycle re-dispatched. nil in production.
@@ -119,10 +129,10 @@ func newPoller(w *Watcher, idx *Indexer, logger *zap.Logger) *Poller {
 		lastSHA, _ = pollerHeadSHA(root)
 	}
 	return &Poller{
-		watcher:  w,
-		indexer:  idx,
-		rootPath: root,
-		logger:   logger,
+		watcher:    w,
+		indexer:    idx,
+		rootPath:   root,
+		logger:     logger,
 		interval:   pollInterval(nodeCount),
 		lastSHA:    lastSHA,
 		done:       make(chan struct{}),
@@ -194,144 +204,299 @@ func (p *Poller) loop() {
 	}
 }
 
-// poll runs one fallback cycle: detect git HEAD movement, then scan
-// tracked-file mtimes for changes the fsnotify backend may have
-// missed, dispatching each through the same per-file patch path the
-// live watcher uses. Best-effort throughout — a failed git call or an
-// unreadable file is logged and skipped, never fatal.
+// poll admits one fallback request. Timer and notify callers never wait behind
+// an active scan: they only dirty the generation and return. The active owner
+// folds every overlapping request into the minimum necessary follow-up sweep.
 func (p *Poller) poll() {
-	swept := 0
-	if p.pollGitHead() {
-		swept++
+	p.pollMu.Lock()
+	p.pollRequested++
+	generation := p.pollRequested
+	if p.pollRunning {
+		p.pollMu.Unlock()
+		return
 	}
-	swept += p.pollFilesystem()
-	if p.swept != nil {
-		p.swept(swept)
+	p.pollRunning = true
+	p.pollMu.Unlock()
+
+	for {
+		p.pollOnce()
+
+		p.pollMu.Lock()
+		if p.pollRequested == generation {
+			p.pollRunning = false
+			p.pollMu.Unlock()
+			return
+		}
+		generation = p.pollRequested
+		p.pollMu.Unlock()
 	}
 }
 
-// pollGitHead checks whether HEAD has moved since the last cycle. A
-// moved HEAD is the branch-switch / commit signal the GitWatcher's
-// fsnotify watch normally catches; the poller is the backstop for the
-// case where that watch missed the ref-file event. It dispatches the
-// reconcile through the indexer's existing per-file batch path by
-// re-indexing every changed path, mirroring GitWatcher.reconcile.
-// Returns true when a move was observed and reconciled.
-func (p *Poller) pollGitHead() bool {
+// pollOnce discovers Git and filesystem changes independently, unions their
+// exact paths, and submits one bounded watcher batch. Discovery never mutates
+// freshness bookkeeping; the indexing batch owns those stamps under the
+// repository mutation lane.
+func (p *Poller) pollOnce() {
+	git := p.observeGitHead()
+	pathSet := make(map[string]struct{}, len(git.paths))
+	for _, path := range git.paths {
+		if path != "" {
+			pathSet[filepath.Clean(path)] = struct{}{}
+		}
+	}
+	for _, path := range p.pollFilesystem() {
+		if path != "" {
+			pathSet[filepath.Clean(path)] = struct{}{}
+		}
+	}
+	paths := make([]string, 0, len(pathSet))
+	for path := range pathSet {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	reconciled := len(paths) == 0
+	var result *IndexResult
+	var reconcileErr error
+	if len(paths) > 0 {
+		if p.watcher == nil {
+			reconcileErr = fmt.Errorf("watcher: poller has no watcher for %d changed paths", len(paths))
+		} else {
+			result, reconcileErr = p.watcher.reindexStormPaths(paths)
+			if reconcileErr == nil && result != nil && len(result.FailedFiles) > 0 {
+				reconcileErr = fmt.Errorf("watcher: poller batch left %d failed files", len(result.FailedFiles))
+			}
+		}
+		reconciled = reconcileErr == nil
+		if reconcileErr != nil && p.logger != nil {
+			p.logger.Warn("watcher: poller batch reconcile failed",
+				zap.Int("paths", len(paths)), zap.Error(reconcileErr))
+		} else if p.logger != nil {
+			p.logger.Info("watcher: poller reconciled changes missed by live watchers",
+				zap.Int("paths", len(paths)))
+		}
+	}
+
+	// A changed Git range is committed only after all of its paths shared the
+	// successful batch above. An empty successful diff has no batch work and can
+	// enter the same lane-owned freshness finalization directly. Diff failures
+	// never reach this point, so the old range remains retryable.
+	if git.diffSucceeded && (len(git.paths) == 0 || reconciled) {
+		if err := p.finalizeGitHead(git); err != nil {
+			if p.logger != nil {
+				p.logger.Warn("watcher: poller Git freshness finalization failed",
+					zap.String("from", git.oldSHA), zap.String("to", git.newSHA),
+					zap.Error(err))
+			}
+		} else if git.oldSHA != "" && git.newSHA != "" && git.oldSHA != git.newSHA && p.logger != nil {
+			p.logger.Info("watcher: poller reconciled missed ref change",
+				zap.String("from", git.oldSHA[:min(len(git.oldSHA), 12)]),
+				zap.String("to", git.newSHA[:min(len(git.newSHA), 12)]),
+				zap.Int("paths", len(git.paths)))
+		}
+	}
+
+	if p.swept != nil {
+		p.swept(len(paths))
+	}
+}
+
+// pollGitObservation separates range discovery from freshness publication.
+// pollOnce can therefore union the range with filesystem evidence before one
+// repository batch, then advance lastSHA only when that batch succeeds.
+type pollGitObservation struct {
+	oldSHA        string
+	newSHA        string
+	paths         []string
+	diffSucceeded bool
+}
+
+func (p *Poller) observeGitHead() pollGitObservation {
 	newSHA, err := pollerHeadSHA(p.rootPath)
 	if err != nil || newSHA == "" {
-		return false
+		return pollGitObservation{}
 	}
 	p.mu.Lock()
 	oldSHA := p.lastSHA
 	p.mu.Unlock()
-	if oldSHA == "" {
-		// First observation: seed lastSHA and don't diff against a
-		// phantom range. There is no prior commit to reconcile from.
-		p.mu.Lock()
-		p.lastSHA = newSHA
-		p.mu.Unlock()
-		return false
-	}
 	if oldSHA == newSHA {
-		return false
+		return pollGitObservation{}
+	}
+	if oldSHA == "" {
+		// First observation has no range to reconcile. Return a successful
+		// zero-path observation so pollOnce commits the baseline uniformly.
+		return pollGitObservation{newSHA: newSHA, diffSucceeded: true}
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	changes, err := pollerDiffNameStatus(ctx, p.rootPath, oldSHA, newSHA)
 	if err != nil {
-		// Leave lastSHA at oldSHA so the next cycle retries this exact
-		// range. Advancing it here would permanently skip the
-		// un-reconciled oldSHA..newSHA span on a transient diff failure.
+		// Leave lastSHA at oldSHA so the next cycle retries this exact range.
 		if p.logger != nil {
 			p.logger.Debug("watcher: poller git diff failed",
 				zap.String("from", oldSHA), zap.String("to", newSHA),
 				zap.Error(err))
 		}
-		return false
+		return pollGitObservation{}
 	}
 
-	// Diff succeeded — the range is now safe to mark reconciled. Advance
-	// lastSHA before dispatching so a concurrent poll doesn't re-diff the
-	// same span; dispatch failures of individual files are best-effort
-	// and don't warrant re-running the whole diff.
-	p.mu.Lock()
-	p.lastSHA = newSHA
-	p.mu.Unlock()
-
-	n := 0
-	for _, c := range changes {
-		switch c.Status {
-		case 'A', 'M', 'T', 'R', 'C':
-			abs := filepath.Join(p.rootPath, c.Path)
-			if _, statErr := os.Stat(abs); statErr != nil {
-				continue
-			}
-			if err := p.watcher.patchGraph(abs, ChangeModified); err != nil && p.logger != nil {
-				p.logger.Warn("watcher: poller patch failed", zap.String("path", abs), zap.Error(err))
-			}
-			n++
-		case 'D':
-			abs := filepath.Join(p.rootPath, c.Path)
-			if _, statErr := os.Stat(abs); statErr != nil {
-				if err := p.watcher.patchGraph(abs, ChangeDeleted); err != nil && p.logger != nil {
-					p.logger.Warn("watcher: poller patch failed", zap.String("path", abs), zap.Error(err))
-				}
-				n++
-			}
+	pathSet := make(map[string]struct{}, len(changes)+1)
+	add := func(relPath string) {
+		if relPath == "" {
+			return
+		}
+		pathSet[filepath.Clean(filepath.Join(p.rootPath, filepath.FromSlash(relPath)))] = struct{}{}
+	}
+	for _, change := range changes {
+		switch change.Status {
+		case 'A', 'M', 'T', 'C', 'D':
+			add(change.Path)
+		case 'R':
+			// Both sides matter: the new path is parsed and the old path is
+			// deletion-detected by the same bounded batch.
+			add(change.OldPath)
+			add(change.Path)
 		}
 	}
-	if p.logger != nil {
-		p.logger.Info("watcher: poller reconciled missed ref change",
-			zap.String("from", oldSHA[:min(len(oldSHA), 12)]),
-			zap.String("to", newSHA[:min(len(newSHA), 12)]),
-			zap.Int("paths", n))
+	paths := make([]string, 0, len(pathSet))
+	for path := range pathSet {
+		paths = append(paths, path)
 	}
-	return n > 0
+	sort.Strings(paths)
+	return pollGitObservation{
+		oldSHA: oldSHA, newSHA: newSHA, paths: paths, diffSucceeded: true,
+	}
 }
 
-// pollFilesystem walks the indexer's per-file mtime map and re-indexes
-// any tracked file whose on-disk mtime advanced past the recorded
-// value — the modification the fsnotify backend should have reported.
-// It also evicts files that have vanished from disk. The mtime map is
-// the indexer's own bookkeeping (it stamps every file it indexes), so
-// this reuses an existing source of truth instead of re-walking the
-// tree. Returns the number of files re-dispatched.
-func (p *Poller) pollFilesystem() int {
-	snapshot := p.indexer.FileMtimes()
-	if len(snapshot) == 0 {
-		return 0
+// pollGitHead is retained for focused in-package callers. Production sweeps use
+// observeGitHead so Git and filesystem paths can share one batch; this helper
+// still reconciles its Git-only observation as one bounded batch.
+func (p *Poller) pollGitHead() bool {
+	observation := p.observeGitHead()
+	if !observation.diffSucceeded {
+		return false
 	}
-	n := 0
+	if len(observation.paths) == 0 {
+		if err := p.finalizeGitHead(observation); err != nil && p.logger != nil {
+			p.logger.Warn("watcher: poller Git freshness finalization failed",
+				zap.String("from", observation.oldSHA), zap.String("to", observation.newSHA),
+				zap.Error(err))
+		}
+		return false
+	}
+	if p.watcher == nil {
+		return false
+	}
+	result, err := p.watcher.reindexStormPaths(observation.paths)
+	if err == nil && result != nil && len(result.FailedFiles) > 0 {
+		err = fmt.Errorf("watcher: poller batch left %d failed files", len(result.FailedFiles))
+	}
+	if err != nil {
+		if p.logger != nil {
+			p.logger.Warn("watcher: poller git reconcile failed",
+				zap.Int("paths", len(observation.paths)), zap.Error(err))
+		}
+		return false
+	}
+	if err := p.finalizeGitHead(observation); err != nil {
+		if p.logger != nil {
+			p.logger.Warn("watcher: poller Git freshness finalization failed",
+				zap.String("from", observation.oldSHA), zap.String("to", observation.newSHA),
+				zap.Error(err))
+		}
+		return false
+	}
+	return true
+}
+
+func (p *Poller) registeredIndexer() *Indexer {
+	if p.watcher != nil {
+		return p.watcher.currentMutationIndexer()
+	}
+	return p.indexer
+}
+
+// finalizeGitHead publishes Git and repository freshness together while
+// holding the construction-time Indexer's stable mutation lane. The current
+// registry entry is resolved only after admission, so IndexRepo replacement
+// cannot redirect the restamp to a retired Indexer. A fresh background context
+// keeps lane admission independent of the short-lived Git diff timeout.
+func (p *Poller) finalizeGitHead(observation pollGitObservation) error {
+	if observation.newSHA == "" {
+		return nil
+	}
+	if p.indexer == nil {
+		return fmt.Errorf("watcher: poller has no stable repository lane")
+	}
+	return p.indexer.coordinateRepositoryMutation(context.Background(), func() error {
+		idx := p.registeredIndexer()
+		if idx == nil {
+			return fmt.Errorf("watcher: poller repository indexer is no longer registered")
+		}
+
+		p.mu.Lock()
+		stillCurrent := p.lastSHA == observation.oldSHA
+		p.mu.Unlock()
+		if !stillCurrent {
+			return nil
+		}
+
+		idx.reconcileRepoIndexState(p.rootPath)
+		p.mu.Lock()
+		// Singleflight owns Git observations, but keep this conditional so a test
+		// or future explicit reset cannot be overwritten by an older completion.
+		if p.lastSHA == observation.oldSHA {
+			p.lastSHA = observation.newSHA
+		}
+		p.mu.Unlock()
+		return nil
+	})
+}
+
+// pollFilesystem snapshots the indexer's per-file mtime map and returns
+// changed or unreadable tracked paths. It performs discovery only: pollOnce
+// unions these paths with Git evidence and the repository batch owns every
+// freshness stamp and deletion decision.
+func (p *Poller) pollFilesystem() []string {
+	idx := p.indexer
+	if p.watcher != nil {
+		// MultiWatcher instances outlive IndexRepo replacement. Resolve the
+		// current registry entry for discovery too; the construction-time
+		// Indexer is retained only as the stable lane carrier.
+		idx = p.watcher.currentMutationIndexer()
+	}
+	if idx == nil {
+		return nil
+	}
+	snapshot := idx.FileMtimes()
+	if len(snapshot) == 0 {
+		return nil
+	}
+	paths := make([]string, 0)
 	for relPath, recorded := range snapshot {
-		abs := filepath.Join(p.rootPath, filepath.FromSlash(relPath))
+		abs := filepath.Clean(filepath.Join(p.rootPath, filepath.FromSlash(relPath)))
 		info, err := os.Stat(abs)
 		if err != nil {
-			// The file is gone — the delete event was missed.
-			if patchErr := p.watcher.patchGraph(abs, ChangeDeleted); patchErr != nil && p.logger != nil {
-				p.logger.Warn("watcher: poller patch failed", zap.String("path", abs), zap.Error(patchErr))
+			if os.IsNotExist(err) {
+				paths = append(paths, abs)
+			} else if p.logger != nil {
+				// A transient permission/I/O error must not abort the shared batch
+				// and prevent unrelated valid paths from converging.
+				p.logger.Debug("watcher: poller stat failed; preserving tracked path",
+					zap.String("path", abs), zap.Error(err))
 			}
-			n++
 			continue
 		}
 		if info.IsDir() {
 			continue
 		}
-		if info.ModTime().UnixNano() > recorded {
-			// The file changed on disk after we last indexed it —
-			// the modify event was missed.
-			if err := p.watcher.patchGraph(abs, ChangeModified); err != nil && p.logger != nil {
-				p.logger.Warn("watcher: poller patch failed", zap.String("path", abs), zap.Error(err))
-			}
-			n++
+		if info.ModTime().UnixNano() != recorded {
+			paths = append(paths, abs)
 		}
 	}
-	if n > 0 && p.logger != nil {
-		p.logger.Info("watcher: poller re-indexed files missed by fsnotify",
-			zap.Int("paths", n))
-	}
-	return n
+	sort.Strings(paths)
+	return paths
 }
 
 // pollerHeadSHA resolves the current HEAD commit SHA of a worktree.

--- a/internal/indexer/poller_test.go
+++ b/internal/indexer/poller_test.go
@@ -1,9 +1,11 @@
 package indexer
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -21,10 +23,10 @@ import (
 // rarely. The interval must be monotonically non-decreasing in the
 // node count so adding code never makes the fallback more aggressive.
 func TestPollInterval_ScalesWithProjectSize(t *testing.T) {
-	small := pollInterval(100)              // a tiny service
-	medium := pollInterval(20 * 1000)       // a mid-size repo
-	large := pollInterval(500 * 1000)       // a large monorepo
-	huge := pollInterval(50 * 1000 * 1000)  // absurdly large
+	small := pollInterval(100)             // a tiny service
+	medium := pollInterval(20 * 1000)      // a mid-size repo
+	large := pollInterval(500 * 1000)      // a large monorepo
+	huge := pollInterval(50 * 1000 * 1000) // absurdly large
 
 	assert.LessOrEqual(t, small, medium,
 		"a small repo must not poll less often than a medium one")
@@ -365,4 +367,417 @@ func TestPoller_SweepHookReportsWork(t *testing.T) {
 	require.NoError(t, os.Chtimes(path, future, future))
 	p.poll()
 	assert.Equal(t, 1, swept, "the poll cycle must report the one file it re-indexed")
+}
+
+// TestPoller_ConcurrentPollsAreSingleFlight proves overlapping timer/notify
+// requests never block behind a scan. They dirty one generation and return;
+// the active owner performs exactly one coalesced follow-up.
+func TestPoller_ConcurrentPollsAreSingleFlight(t *testing.T) {
+	idx := newTestIndexer(graph.New())
+	idx.SetRootPath(t.TempDir())
+	p := newPoller(nil, idx, zap.NewNop())
+
+	firstEntered := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var hookMu sync.Mutex
+	hookCalls := 0
+	p.swept = func(int) {
+		hookMu.Lock()
+		hookCalls++
+		call := hookCalls
+		hookMu.Unlock()
+		if call == 1 {
+			close(firstEntered)
+			<-releaseFirst
+		}
+	}
+
+	ownerDone := make(chan struct{})
+	go func() {
+		p.poll()
+		close(ownerDone)
+	}()
+	select {
+	case <-firstEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first poll did not reach the scan hook")
+	}
+
+	const overlapping = 16
+	var callers sync.WaitGroup
+	callers.Add(overlapping)
+	for i := 0; i < overlapping; i++ {
+		go func() {
+			defer callers.Done()
+			p.poll()
+		}()
+	}
+	callersDone := make(chan struct{})
+	go func() {
+		callers.Wait()
+		close(callersDone)
+	}()
+	select {
+	case <-callersDone:
+		// Dirty requests returned without waiting for the active scan.
+	case <-time.After(2 * time.Second):
+		t.Fatal("overlapping poll callers queued behind the active scan")
+	}
+
+	hookMu.Lock()
+	assert.Equal(t, 1, hookCalls, "no follow-up may overlap the active scan")
+	hookMu.Unlock()
+	close(releaseFirst)
+	select {
+	case <-ownerDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("poll owner did not finish its coalesced follow-up")
+	}
+
+	hookMu.Lock()
+	assert.Equal(t, 2, hookCalls, "all overlapping requests must collapse into one follow-up sweep")
+	hookMu.Unlock()
+	p.pollMu.Lock()
+	assert.False(t, p.pollRunning, "singleflight ownership must clear after the follow-up")
+	p.pollMu.Unlock()
+}
+
+func TestPoller_SweepUnionsGitAndFilesystemPathsIntoOneBatch(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available in PATH")
+	}
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init", "-q", "-b", "main")
+	runGit(t, repoDir, "config", "user.email", "test@example.com")
+	runGit(t, repoDir, "config", "user.name", "Test")
+	runGit(t, repoDir, "config", "commit.gpgsign", "false")
+
+	aPath := filepath.Join(repoDir, "a.go")
+	bPath := filepath.Join(repoDir, "b.go")
+	writeFile(t, aPath, "package main\nfunc Alpha() {}\n")
+	writeFile(t, bPath, "package main\nfunc Beta() {}\n")
+	runGit(t, repoDir, "add", ".")
+	runGit(t, repoDir, "commit", "-q", "-m", "initial")
+
+	g := graph.New()
+	idx := New(g, newTestRegistry(), config.IndexConfig{Workers: 1}, zap.NewNop())
+	idx.search = search.NewBM25()
+	idx.SetRootPath(repoDir)
+	_, err := idx.IndexCtx(testCtx(), repoDir)
+	require.NoError(t, err)
+	w, err := NewWatcher(idx, config.WatchConfig{Enabled: true, DebounceMs: 10}, zap.NewNop())
+	require.NoError(t, err)
+	p := newPoller(w, idx, zap.NewNop())
+
+	batchCalls := 0
+	var submitted []string
+	w.batchReindex = func(paths []string) (*IndexResult, error) {
+		batchCalls++
+		submitted = append([]string(nil), paths...)
+		return &IndexResult{}, nil
+	}
+
+	// A clean sweep has no work and must not call the batch coordinator.
+	p.poll()
+	assert.Equal(t, 0, batchCalls)
+
+	future := time.Now().Add(2 * time.Second)
+	writeFile(t, aPath, "package main\nfunc AlphaChanged() {}\n")
+	writeFile(t, bPath, "package main\nfunc BetaChanged() {}\n")
+	require.NoError(t, os.Chtimes(aPath, future, future))
+	require.NoError(t, os.Chtimes(bPath, future, future))
+	// Commit only a.go. It is visible to both Git and the mtime sweep, while
+	// b.go is filesystem-only; the union must contain each path exactly once.
+	runGit(t, repoDir, "add", "a.go")
+	runGit(t, repoDir, "commit", "-q", "-m", "change a")
+
+	p.poll()
+	require.Equal(t, 1, batchCalls, "one sweep must submit one repository batch")
+	assert.Equal(t, []string{aPath, bPath}, submitted, "Git/filesystem overlap must be sorted and deduplicated")
+	head, err := pollerHeadSHA(repoDir)
+	require.NoError(t, err)
+	p.mu.Lock()
+	settled := p.lastSHA
+	p.mu.Unlock()
+	assert.Equal(t, head, settled, "successful unified reconciliation advances Git freshness")
+}
+
+func TestPoller_GitSHAAdvancesOnlyAfterSuccessfulBatch(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available in PATH")
+	}
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init", "-q", "-b", "main")
+	runGit(t, repoDir, "config", "user.email", "test@example.com")
+	runGit(t, repoDir, "config", "user.name", "Test")
+	runGit(t, repoDir, "config", "commit.gpgsign", "false")
+
+	path := filepath.Join(repoDir, "main.go")
+	writeFile(t, path, "package main\nfunc Before() {}\n")
+	runGit(t, repoDir, "add", ".")
+	runGit(t, repoDir, "commit", "-q", "-m", "before")
+
+	g := graph.New()
+	idx := New(g, newTestRegistry(), config.IndexConfig{Workers: 1}, zap.NewNop())
+	idx.search = search.NewBM25()
+	idx.SetRootPath(repoDir)
+	_, err := idx.IndexCtx(testCtx(), repoDir)
+	require.NoError(t, err)
+	w, err := NewWatcher(idx, config.WatchConfig{Enabled: true, DebounceMs: 10}, zap.NewNop())
+	require.NoError(t, err)
+	p := newPoller(w, idx, zap.NewNop())
+	oldSHA := p.lastSHA
+
+	future := time.Now().Add(2 * time.Second)
+	writeFile(t, path, "package main\nfunc After() {}\n")
+	require.NoError(t, os.Chtimes(path, future, future))
+	runGit(t, repoDir, "add", "main.go")
+	runGit(t, repoDir, "commit", "-q", "-m", "after")
+	newSHA, err := pollerHeadSHA(repoDir)
+	require.NoError(t, err)
+
+	calls := 0
+	w.batchReindex = func(paths []string) (*IndexResult, error) {
+		calls++
+		require.Equal(t, []string{path}, paths)
+		switch calls {
+		case 1:
+			return nil, errors.New("transient batch failure")
+		case 2:
+			return &IndexResult{FailedFiles: []string{path}}, nil
+		default:
+			return &IndexResult{}, nil
+		}
+	}
+
+	p.poll()
+	p.mu.Lock()
+	first := p.lastSHA
+	p.mu.Unlock()
+	assert.Equal(t, oldSHA, first, "an errored batch must leave the Git range retryable")
+	p.poll()
+	p.mu.Lock()
+	second := p.lastSHA
+	p.mu.Unlock()
+	assert.Equal(t, oldSHA, second, "a partial batch must leave the Git range retryable")
+	closedCoordinator := newRepositoryMutationCoordinator(nil)
+	require.NoError(t, closedCoordinator.closeAndWait(testCtx()))
+	idx.attachRepositoryMutationCoordinator(closedCoordinator)
+	p.poll()
+	p.mu.Lock()
+	third := p.lastSHA
+	p.mu.Unlock()
+	assert.Equal(t, oldSHA, third, "failed lane admission must leave the Git range retryable")
+
+	idx.attachRepositoryMutationCoordinator(newRepositoryMutationCoordinator(nil))
+	p.poll()
+	p.mu.Lock()
+	fourth := p.lastSHA
+	p.mu.Unlock()
+	assert.Equal(t, newSHA, fourth, "Git freshness advances only after the batch and freshness tail succeed")
+	assert.Equal(t, 4, calls, "the same range must be retried until reconciliation and finalization succeed")
+}
+
+func TestPoller_EmptyGitDiffAdvancesWithoutBatch(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available in PATH")
+	}
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init", "-q", "-b", "main")
+	runGit(t, repoDir, "config", "user.email", "test@example.com")
+	runGit(t, repoDir, "config", "user.name", "Test")
+	runGit(t, repoDir, "config", "commit.gpgsign", "false")
+	writeFile(t, filepath.Join(repoDir, "main.go"), "package main\nfunc Main() {}\n")
+	runGit(t, repoDir, "add", ".")
+	runGit(t, repoDir, "commit", "-q", "-m", "initial")
+
+	idx := newTestIndexer(graph.New())
+	idx.SetRootPath(repoDir)
+	_, err := idx.Index(repoDir)
+	require.NoError(t, err)
+	w, err := NewWatcher(idx, config.WatchConfig{Enabled: true, DebounceMs: 10}, zap.NewNop())
+	require.NoError(t, err)
+	p := newPoller(w, idx, zap.NewNop())
+
+	runGit(t, repoDir, "commit", "-q", "--allow-empty", "-m", "empty")
+	newSHA, err := pollerHeadSHA(repoDir)
+	require.NoError(t, err)
+	batchCalls := 0
+	w.batchReindex = func([]string) (*IndexResult, error) {
+		batchCalls++
+		return &IndexResult{}, nil
+	}
+
+	p.poll()
+	assert.Equal(t, 0, batchCalls, "a successful zero-path diff must not reindex")
+	p.mu.Lock()
+	settled := p.lastSHA
+	p.mu.Unlock()
+	assert.Equal(t, newSHA, settled, "a successful zero-path diff advances Git freshness")
+}
+
+func TestPoller_GitFinalizationWaitsForLaneAndUsesReplacementIndexer(t *testing.T) {
+	repoPath, oldSHA := initGitWatcherRepo(t)
+	runGitWatcherGit(t, repoPath, "commit", "--allow-empty", "-m", "empty")
+	newSHA := runGitWatcherGit(t, repoPath, "rev-parse", "HEAD")
+	require.NotEqual(t, oldSHA, newSHA)
+
+	oldStore := &gitWatcherStateStore{Store: graph.New()}
+	newStore := &gitWatcherStateStore{Store: graph.New()}
+	oldIndexer := gitWatcherBoundaryIndexer(t, oldStore, repoPath, "repo")
+	newIndexer := gitWatcherBoundaryIndexer(t, newStore, repoPath, "repo")
+	coordinator := newRepositoryMutationCoordinator(nil)
+	oldIndexer.attachRepositoryMutationCoordinator(coordinator)
+	newIndexer.attachRepositoryMutationCoordinator(coordinator)
+
+	watcher, err := NewWatcher(oldIndexer, config.WatchConfig{Enabled: true, DebounceMs: 10}, zap.NewNop())
+	require.NoError(t, err)
+	poller := newPoller(watcher, oldIndexer, zap.NewNop())
+	poller.lastSHA = oldSHA
+
+	resolvedCurrent := make(chan struct{}, 1)
+	watcher.currentIndexer = func() *Indexer {
+		resolvedCurrent <- struct{}{}
+		return newIndexer
+	}
+
+	laneEntered := make(chan struct{})
+	releaseLane := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseLane) }) }
+	defer release()
+	holderDone := make(chan error, 1)
+	go func() {
+		holderDone <- oldIndexer.coordinateRepositoryMutation(testCtx(), func() error {
+			close(laneEntered)
+			<-releaseLane
+			return nil
+		})
+	}()
+	<-laneEntered
+
+	finalizeDone := make(chan error, 1)
+	go func() {
+		finalizeDone <- poller.finalizeGitHead(pollGitObservation{
+			oldSHA: oldSHA, newSHA: newSHA, diffSucceeded: true,
+		})
+	}()
+	select {
+	case err := <-finalizeDone:
+		t.Fatalf("freshness tail bypassed the occupied repository lane: %v", err)
+	case <-resolvedCurrent:
+		t.Error("current Indexer was resolved before repository-lane admission")
+	case <-time.After(100 * time.Millisecond):
+	}
+	poller.mu.Lock()
+	assert.Equal(t, oldSHA, poller.lastSHA)
+	poller.mu.Unlock()
+	assert.Empty(t, oldStore.snapshotStates())
+	assert.Empty(t, newStore.snapshotStates())
+
+	release()
+	require.NoError(t, <-holderDone)
+	require.NoError(t, <-finalizeDone)
+	select {
+	case <-resolvedCurrent:
+	case <-time.After(time.Second):
+		t.Fatal("freshness tail did not resolve the current Indexer after admission")
+	}
+	poller.mu.Lock()
+	assert.Equal(t, newSHA, poller.lastSHA)
+	poller.mu.Unlock()
+	assert.Empty(t, oldStore.snapshotStates(), "retired Indexer must not be restamped")
+	require.Len(t, newStore.snapshotStates(), 1, "replacement Indexer must receive the restamp")
+}
+
+func TestPoller_MultiWatcherUsesCurrentIndexerFileMtimesAfterReplacement(t *testing.T) {
+	dir := t.TempDir()
+	retiredPath := filepath.Join(dir, "retired.go")
+	currentPath := filepath.Join(dir, "current.go")
+	writeTestFile(t, retiredPath, "package main\nfunc Retired() {}\n")
+	writeTestFile(t, currentPath, "package main\nfunc Current() {}\n")
+
+	const prefix = "repo"
+	g := graph.New()
+	oldIndexer := newTestIndexer(g)
+	oldIndexer.SetRootPath(dir)
+	oldIndexer.mtimeMu.Lock()
+	oldIndexer.fileMtimes = map[string]int64{"retired.go": 1}
+	oldIndexer.mtimeMu.Unlock()
+
+	multi := NewMultiIndexer(g, newTestRegistry(), nil, nil, zap.NewNop())
+	multi.repos[prefix] = &RepoMetadata{RepoPrefix: prefix, RootPath: dir}
+	multi.indexers[prefix] = oldIndexer
+	multiWatcher, err := NewMultiWatcher(multi, map[string]config.WatchConfig{
+		prefix: {DebounceMs: 10},
+	}, zap.NewNop())
+	require.NoError(t, err)
+	watcher := multiWatcher.watchers[prefix]
+	require.NotNil(t, watcher)
+	poller := newPoller(watcher, oldIndexer, zap.NewNop())
+
+	currentIndexer := newTestIndexer(g)
+	currentIndexer.SetRootPath(dir)
+	currentIndexer.mtimeMu.Lock()
+	currentIndexer.fileMtimes = map[string]int64{"current.go": 1}
+	currentIndexer.mtimeMu.Unlock()
+	currentIndexer.attachRepositoryMutationCoordinator(multi.repositoryMutationCoordinator(prefix))
+	multi.mu.Lock()
+	multi.indexers[prefix] = currentIndexer
+	multi.mu.Unlock()
+
+	batchCalls := 0
+	var submitted []string
+	watcher.batchReindex = func(paths []string) (*IndexResult, error) {
+		batchCalls++
+		submitted = append([]string(nil), paths...)
+		return &IndexResult{}, nil
+	}
+	poller.poll()
+
+	require.Equal(t, 1, batchCalls)
+	assert.Equal(t, []string{currentPath}, submitted,
+		"poll discovery must use the replacement Indexer's FileMtimes, not the retired construction-time map")
+}
+
+func TestPoller_TransientStatErrorIsPreservedOutsideSharedBatch(t *testing.T) {
+	dir := t.TempDir()
+	loopPath := filepath.Join(dir, "loop.go")
+	if err := os.Symlink("loop.go", loopPath); err != nil {
+		t.Skipf("self-referential symlink unavailable on this platform: %v", err)
+	}
+	_, statErr := os.Stat(loopPath)
+	if statErr == nil || os.IsNotExist(statErr) {
+		t.Skipf("platform does not expose a deterministic non-ENOENT stat error for a symlink loop: %v", statErr)
+	}
+
+	idx := newTestIndexer(graph.New())
+	idx.SetRootPath(dir)
+	idx.mtimeMu.Lock()
+	idx.fileMtimes = map[string]int64{"loop.go": 1}
+	idx.mtimeMu.Unlock()
+	watcher, err := NewWatcher(idx, config.WatchConfig{Enabled: true, DebounceMs: 10}, zap.NewNop())
+	require.NoError(t, err)
+	poller := newPoller(watcher, idx, zap.NewNop())
+
+	batchCalls := 0
+	var submitted []string
+	watcher.batchReindex = func(paths []string) (*IndexResult, error) {
+		batchCalls++
+		submitted = append([]string(nil), paths...)
+		return &IndexResult{}, nil
+	}
+	poller.poll()
+	assert.Equal(t, 0, batchCalls,
+		"a transient stat failure alone must preserve the tracked path without entering the shared batch")
+
+	validPath := filepath.Join(dir, "valid.go")
+	writeTestFile(t, validPath, "package main\nfunc Valid() {}\n")
+	idx.mtimeMu.Lock()
+	idx.fileMtimes["valid.go"] = 1
+	idx.mtimeMu.Unlock()
+	poller.poll()
+	require.Equal(t, 1, batchCalls)
+	assert.Equal(t, []string{validPath}, submitted,
+		"the transiently unreadable path must not poison an unrelated valid batch")
 }

--- a/internal/indexer/repo_projections_test.go
+++ b/internal/indexer/repo_projections_test.go
@@ -1,7 +1,6 @@
 package indexer
 
 import (
-	"context"
 	"reflect"
 	"testing"
 
@@ -69,11 +68,12 @@ func TestBatchLanguageSetsUsesOneNodeOnlyProjection(t *testing.T) {
 func TestRunGlobalGraphPassesProjectsScopedTypeIDsOnce(t *testing.T) {
 	store := &countingRepoProjectionStore{Store: graph.New()}
 	mi := &MultiIndexer{
-		graph:                store,
-		logger:               zap.NewNop(),
-		batchChangedPrefixes: map[string]struct{}{"b": {}, "a": {}},
+		graph:  store,
+		logger: zap.NewNop(),
 	}
-	mi.RunGlobalGraphPasses(context.Background())
+	mi.BeginBatch()
+	mi.ArmBatchScope(map[string]struct{}{"b": {}, "a": {}})
+	mi.EndBatch()
 
 	if store.kindIDCalls != 1 {
 		t.Fatalf("kind-ID projection calls = %d, want 1", store.kindIDCalls)

--- a/internal/indexer/repository_mutation_admission_test.go
+++ b/internal/indexer/repository_mutation_admission_test.go
@@ -1,0 +1,201 @@
+package indexer
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+const repositoryMutationAdmissionTestTimeout = 2 * time.Second
+
+func waitForRepositoryMutationLaneTokens(
+	t *testing.T,
+	coordinator *repositoryMutationCoordinator,
+	want int,
+) {
+	t.Helper()
+	deadline := time.NewTimer(repositoryMutationAdmissionTestTimeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if got := len(coordinator.lane); got == want {
+			return
+		}
+		select {
+		case <-deadline.C:
+			t.Fatalf("repository mutation lane token count = %d, want %d", len(coordinator.lane), want)
+		case <-ticker.C:
+		}
+	}
+}
+
+func TestWithRepositoryMutationLanesCancellationUnwindsSortedLanes(t *testing.T) {
+	mi := &MultiIndexer{}
+	earlier := mi.repositoryMutationCoordinator("a")
+	later := mi.repositoryMutationCoordinator("z")
+
+	// Hold the later lane. Passing the prefixes in reverse order proves that
+	// withRepositoryMutationLanes sorts before acquisition: it must take "a"
+	// before blocking on "z".
+	<-later.lane
+	laterHeld := true
+	t.Cleanup(func() {
+		if laterHeld {
+			later.lane <- struct{}{}
+		}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	callbackCalled := make(chan struct{}, 1)
+	done := make(chan error, 1)
+	go func() {
+		done <- mi.withRepositoryMutationLanes(ctx, []string{"z", "a", "z"}, func() error {
+			callbackCalled <- struct{}{}
+			return nil
+		})
+	}()
+
+	waitForRepositoryMutationLaneTokens(t, earlier, 0)
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("cancelled multi-lane acquisition error = %v, want context.Canceled", err)
+		}
+	case <-time.After(repositoryMutationAdmissionTestTimeout):
+		t.Fatal("cancelled multi-lane acquisition did not return")
+	}
+	select {
+	case <-callbackCalled:
+		t.Fatal("multi-lane callback ran without acquiring the held later lane")
+	default:
+	}
+	if got := len(earlier.lane); got != 1 {
+		t.Fatalf("earlier lane token count after cancellation = %d, want 1", got)
+	}
+
+	later.lane <- struct{}{}
+	laterHeld = false
+	callbackRan := false
+	if err := mi.withRepositoryMutationLanes(
+		context.Background(),
+		[]string{"z", "a", "z"},
+		func() error {
+			callbackRan = true
+			return nil
+		},
+	); err != nil {
+		t.Fatalf("reusing lanes after cancellation: %v", err)
+	}
+	if !callbackRan {
+		t.Fatal("multi-lane callback did not run after cancelled acquisition unwound")
+	}
+}
+
+type repositorySnapshotAdmissionResult struct {
+	coordinator *repositoryMutationCoordinator
+	current     bool
+}
+
+func TestRepositoryMutationSnapshotAdmissionDoesNotCrossRetrackGeneration(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		attachOld       bool
+		wantCurrent     bool
+		wantCoordinator bool
+	}{
+		{
+			name:            "attached snapshot keeps closed old generation",
+			attachOld:       true,
+			wantCurrent:     true,
+			wantCoordinator: true,
+		},
+		{
+			name:        "unattached snapshot backstop rejects replacement",
+			attachOld:   false,
+			wantCurrent: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			const prefix = "same-prefix"
+			mi := &MultiIndexer{
+				repos:    make(map[string]*RepoMetadata),
+				indexers: make(map[string]*Indexer),
+			}
+			oldRoot := t.TempDir()
+			replacementRoot := t.TempDir()
+			oldMeta := &RepoMetadata{RepoPrefix: prefix, RootPath: oldRoot}
+			oldIndexer := &Indexer{}
+			oldCoordinator := mi.repositoryMutationCoordinator(prefix)
+			if tc.attachOld {
+				oldIndexer.attachRepositoryMutationCoordinator(oldCoordinator)
+			}
+			mi.repos[prefix] = oldMeta
+			mi.indexers[prefix] = oldIndexer
+
+			// Capture the exact metadata and Indexer pointers, then delay admission
+			// until the same prefix has been untracked and retracked at another
+			// root. This is the ABA window IncrementalReindexRepo must survive.
+			captured := make(chan struct{})
+			admit := make(chan struct{})
+			done := make(chan repositorySnapshotAdmissionResult, 1)
+			go func(meta *RepoMetadata, idx *Indexer) {
+				close(captured)
+				<-admit
+				coordinator, current := mi.repositoryMutationCoordinatorForSnapshot(prefix, meta, idx)
+				done <- repositorySnapshotAdmissionResult{coordinator: coordinator, current: current}
+			}(oldMeta, oldIndexer)
+			<-captured
+
+			if err := oldCoordinator.closeAndWait(context.Background()); err != nil {
+				t.Fatalf("closing old coordinator: %v", err)
+			}
+			mi.mu.Lock()
+			delete(mi.repos, prefix)
+			delete(mi.indexers, prefix)
+			mi.mu.Unlock()
+			if !mi.detachRepositoryMutationCoordinator(prefix, oldCoordinator) {
+				t.Fatal("old coordinator was not detached during simulated untrack")
+			}
+
+			replacementCoordinator := mi.repositoryMutationCoordinator(prefix)
+			replacementIndexer := &Indexer{}
+			replacementIndexer.attachRepositoryMutationCoordinator(replacementCoordinator)
+			replacementMeta := &RepoMetadata{RepoPrefix: prefix, RootPath: replacementRoot}
+			mi.mu.Lock()
+			mi.repos[prefix] = replacementMeta
+			mi.indexers[prefix] = replacementIndexer
+			mi.mu.Unlock()
+
+			close(admit)
+			var admitted repositorySnapshotAdmissionResult
+			select {
+			case admitted = <-done:
+			case <-time.After(repositoryMutationAdmissionTestTimeout):
+				t.Fatal("stale snapshot admission did not return")
+			}
+			if admitted.current != tc.wantCurrent {
+				t.Fatalf("stale snapshot current = %v, want %v", admitted.current, tc.wantCurrent)
+			}
+			if tc.wantCoordinator {
+				if admitted.coordinator != oldCoordinator {
+					t.Fatalf("stale snapshot coordinator = %p, want old generation %p", admitted.coordinator, oldCoordinator)
+				}
+			} else if admitted.coordinator != nil {
+				t.Fatalf("stale unattached snapshot coordinator = %p, want nil", admitted.coordinator)
+			}
+			if oldIndexer.attachedRepositoryMutationCoordinator() == replacementCoordinator {
+				t.Fatal("stale Indexer was attached to the replacement coordinator")
+			}
+			if got := replacementIndexer.attachedRepositoryMutationCoordinator(); got != replacementCoordinator {
+				t.Fatalf("replacement Indexer coordinator = %p, want %p", got, replacementCoordinator)
+			}
+			if got, current := mi.repositoryMutationCoordinatorForSnapshot(prefix, replacementMeta, replacementIndexer); !current || got != replacementCoordinator {
+				t.Fatalf("replacement snapshot admission = (%p, %v), want (%p, true)", got, current, replacementCoordinator)
+			}
+		})
+	}
+}

--- a/internal/indexer/repository_mutation_coordinator.go
+++ b/internal/indexer/repository_mutation_coordinator.go
@@ -3,6 +3,7 @@ package indexer
 import (
 	"context"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"sort"
 	"sync"
@@ -19,33 +20,34 @@ type repositoryMutationScope struct {
 	paths map[string]struct{}
 }
 
-func (s *repositoryMutationScope) merge(paths []string) {
+func (s *repositoryMutationScope) merge(paths []string) error {
+	// Explicit paths are validated before any shared scope mutation. Even a
+	// pending full request must not let a malformed waiter join its outcome.
+	for _, path := range paths {
+		if path == "" {
+			return errEmptyRepositoryMutationPath
+		}
+	}
 	if s.full {
-		return
+		return nil
 	}
 	if len(paths) == 0 {
 		s.full = true
 		s.paths = nil
-		return
+		return nil
 	}
 	if s.paths == nil {
 		s.paths = make(map[string]struct{}, len(paths))
 	}
 	for _, path := range paths {
-		if path == "" {
-			continue
-		}
 		s.paths[filepath.Clean(path)] = struct{}{}
 		if len(s.paths) > repositoryMutationPathCap {
 			s.full = true
 			s.paths = nil
-			return
+			return nil
 		}
 	}
-	if len(s.paths) == 0 {
-		s.full = true
-		s.paths = nil
-	}
+	return nil
 }
 
 func (s *repositoryMutationScope) take() []string {
@@ -73,7 +75,7 @@ type repositoryMutationWaiter struct {
 	done       chan repositoryMutationOutcome
 }
 
-// repositoryMutationCoordinator is the single mutation lane for one Indexer.
+// repositoryMutationCoordinator is the stable single mutation lane for one repository.
 // Reconcile requests coalesce while queued: path scopes union, a full request
 // dominates, and requests admitted during execution advance the dirty
 // generation and force another pass before the worker becomes idle. Point
@@ -85,9 +87,14 @@ type repositoryMutationCoordinator struct {
 	lane chan struct{}
 	work sync.WaitGroup
 
-	executor repositoryMutationExecutor
-	closed   bool
-	running  bool
+	// batchMutationGate is shared by every stable repository lane owned by a
+	// MultiIndexer. The lane is acquired first; the read side is held only
+	// around actual mutation execution so batch transitions can wait for a
+	// complete pipeline without blocking or racing admission.
+	batchMutationGate *sync.RWMutex
+	executor          repositoryMutationExecutor
+	closed            bool
+	running           bool
 
 	requestedGeneration uint64
 	completedGeneration uint64
@@ -101,22 +108,6 @@ func newRepositoryMutationCoordinator(executor repositoryMutationExecutor) *repo
 	return &repositoryMutationCoordinator{lane: lane, executor: executor}
 }
 
-func (c *repositoryMutationCoordinator) setExecutor(executor repositoryMutationExecutor) error {
-	if executor == nil {
-		return errors.New("repository mutation executor is nil")
-	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.closed {
-		return errRepositoryMutationCoordinatorClosed
-	}
-	if c.running || c.requestedGeneration != c.completedGeneration {
-		return errors.New("repository mutation executor cannot change while work is pending")
-	}
-	c.executor = executor
-	return nil
-}
-
 func (c *repositoryMutationCoordinator) reconcile(
 	ctx context.Context,
 	paths []string,
@@ -124,15 +115,21 @@ func (c *repositoryMutationCoordinator) reconcile(
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	waiter := &repositoryMutationWaiter{done: make(chan repositoryMutationOutcome, 1)}
 	c.mu.Lock()
 	if c.closed {
 		c.mu.Unlock()
 		return nil, errRepositoryMutationCoordinatorClosed
 	}
+	if err := c.pending.merge(paths); err != nil {
+		c.mu.Unlock()
+		return nil, err
+	}
 	c.requestedGeneration++
 	waiter.generation = c.requestedGeneration
-	c.pending.merge(paths)
 	c.waiters = append(c.waiters, waiter)
 	if !c.running {
 		c.running = true
@@ -170,13 +167,15 @@ func (c *repositoryMutationCoordinator) drain() {
 		waiters := c.waiters
 		c.waiters = nil
 		executor := c.executor
+		batchMutationGate := c.batchMutationGate
 		c.mu.Unlock()
 
-		var outcome repositoryMutationOutcome
-		if executor == nil {
-			outcome.err = errors.New("repository mutation executor is not configured")
-		} else {
-			outcome.result, outcome.err = executor(paths)
+		if batchMutationGate != nil {
+			batchMutationGate.RLock()
+		}
+		outcome := executeRepositoryMutation(executor, paths)
+		if batchMutationGate != nil {
+			batchMutationGate.RUnlock()
 		}
 		c.lane <- struct{}{}
 
@@ -191,12 +190,46 @@ func (c *repositoryMutationCoordinator) drain() {
 	}
 }
 
+func executeRepositoryMutation(executor repositoryMutationExecutor, paths []string) (outcome repositoryMutationOutcome) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			outcome.result = nil
+			outcome.err = fmt.Errorf("repository mutation panic: %v", recovered)
+		}
+	}()
+	if executor == nil {
+		outcome.err = errors.New("repository mutation executor is not configured")
+		return outcome
+	}
+	outcome.result, outcome.err = executor(paths)
+	return outcome
+}
+
 func (c *repositoryMutationCoordinator) runExclusive(ctx context.Context, fn func() error) error {
+	return c.runExclusiveMode(ctx, true, fn)
+}
+
+// runExclusiveLaneOnly acquires only the stable repository lane. A multi-repo
+// transition uses it recursively in sorted-prefix order, then acquires the one
+// shared batch gate after every lane is held. Calling runExclusive there would
+// nest batch read locks and can deadlock behind a queued transition writer.
+func (c *repositoryMutationCoordinator) runExclusiveLaneOnly(ctx context.Context, fn func() error) error {
+	return c.runExclusiveMode(ctx, false, fn)
+}
+
+func (c *repositoryMutationCoordinator) runExclusiveMode(
+	ctx context.Context,
+	acquireBatchGate bool,
+	fn func() error,
+) error {
 	if fn == nil {
 		return nil
 	}
 	if ctx == nil {
 		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	c.mu.Lock()
 	if c.closed {
@@ -213,6 +246,22 @@ func (c *repositoryMutationCoordinator) runExclusive(ctx context.Context, fn fun
 	case <-c.lane:
 	}
 	defer func() { c.lane <- struct{}{} }()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	if acquireBatchGate {
+		c.mu.Lock()
+		batchMutationGate := c.batchMutationGate
+		c.mu.Unlock()
+		if batchMutationGate != nil {
+			batchMutationGate.RLock()
+			defer batchMutationGate.RUnlock()
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	return fn()
 }
 
@@ -257,17 +306,198 @@ func (c *repositoryMutationCoordinator) stats() repositoryMutationCoordinatorSta
 	}
 }
 
-func (idx *Indexer) repositoryMutations() *repositoryMutationCoordinator {
-	idx.repositoryMutationOnce.Do(func() {
-		idx.repositoryMutation = newRepositoryMutationCoordinator(func(paths []string) (*IndexResult, error) {
-			return idx.incrementalReindexWatcherPaths(idx.rootPath, paths)
+func (mi *MultiIndexer) repositoryMutationCoordinator(repoPrefix string) *repositoryMutationCoordinator {
+	mi.repositoryMutationMu.Lock()
+	defer mi.repositoryMutationMu.Unlock()
+	if mi.repositoryMutations == nil {
+		mi.repositoryMutations = make(map[string]*repositoryMutationCoordinator)
+	}
+	coordinator := mi.repositoryMutations[repoPrefix]
+	if coordinator == nil {
+		coordinator = newRepositoryMutationCoordinator(func(paths []string) (*IndexResult, error) {
+			return mi.incrementalReindexRepoRaw(repoPrefix, paths)
 		})
-	})
+		// Attach before publishing the slot: every execution through this stable
+		// lane must participate in the owning MultiIndexer's batch transition.
+		coordinator.batchMutationGate = &mi.batchMutationGate
+		mi.repositoryMutations[repoPrefix] = coordinator
+	}
+	return coordinator
+}
+
+// withRepositoryMutationLanes acquires a deterministic set of stable lanes
+// without touching the shared batch gate. The callback must acquire that gate
+// once after every lane is held. Recursive defers release lanes in reverse
+// order, preserving the global sorted-prefix lock order on every exit path.
+func (mi *MultiIndexer) withRepositoryMutationLanes(
+	ctx context.Context,
+	prefixes []string,
+	fn func() error,
+) error {
+	if fn == nil {
+		return nil
+	}
+	ordered := append([]string(nil), prefixes...)
+	sort.Strings(ordered)
+	compact := ordered[:0]
+	for _, prefix := range ordered {
+		if len(compact) == 0 || compact[len(compact)-1] != prefix {
+			compact = append(compact, prefix)
+		}
+	}
+	coordinators := make([]*repositoryMutationCoordinator, len(compact))
+	for i, prefix := range compact {
+		coordinators[i] = mi.repositoryMutationCoordinator(prefix)
+	}
+	var acquire func(int) error
+	acquire = func(i int) error {
+		if i == len(coordinators) {
+			return fn()
+		}
+		return coordinators[i].runExclusiveLaneOnly(ctx, func() error {
+			return acquire(i + 1)
+		})
+	}
+	return acquire(0)
+}
+
+// existingRepositoryMutationCoordinator returns the exact coordinator slot
+// currently owned by repoPrefix without creating a replacement. Lifecycle
+// teardown must use this lookup: a create-if-missing lookup can cross an
+// untrack/retrack boundary and close the new repository generation.
+func (mi *MultiIndexer) existingRepositoryMutationCoordinator(repoPrefix string) *repositoryMutationCoordinator {
+	mi.repositoryMutationMu.Lock()
+	defer mi.repositoryMutationMu.Unlock()
+	return mi.repositoryMutations[repoPrefix]
+}
+
+// attachedRepositoryMutationCoordinator snapshots an Indexer's exact lane
+// generation without creating or replacing one. A stale Indexer must never be
+// attached to a coordinator minted by a later untrack/retrack generation.
+func (idx *Indexer) attachedRepositoryMutationCoordinator() *repositoryMutationCoordinator {
+	if idx == nil {
+		return nil
+	}
+	idx.repositoryMutationMu.Lock()
+	defer idx.repositoryMutationMu.Unlock()
 	return idx.repositoryMutation
 }
 
-func (idx *Indexer) setRepositoryMutationExecutor(executor repositoryMutationExecutor) error {
-	return idx.repositoryMutations().setExecutor(executor)
+// repositoryMutationCoordinatorForSnapshot returns the lane already attached
+// to an Indexer snapshot. Only direct-map fixtures/restores with no attachment
+// take the backstop path; that path creates and attaches a lane while mi.mu
+// proves both metadata and Indexer pointers still name the same generation.
+func (mi *MultiIndexer) repositoryMutationCoordinatorForSnapshot(
+	repoPrefix string,
+	expectedMeta *RepoMetadata,
+	expectedIdx *Indexer,
+) (*repositoryMutationCoordinator, bool) {
+	if expectedIdx == nil {
+		return nil, false
+	}
+	if coordinator := expectedIdx.attachedRepositoryMutationCoordinator(); coordinator != nil {
+		return coordinator, true
+	}
+
+	mi.mu.RLock()
+	defer mi.mu.RUnlock()
+	if mi.repos[repoPrefix] != expectedMeta || mi.indexers[repoPrefix] != expectedIdx {
+		return nil, false
+	}
+	coordinator := mi.repositoryMutationCoordinator(repoPrefix)
+	expectedIdx.attachRepositoryMutationCoordinator(coordinator)
+	return coordinator, true
+}
+
+// repositoryMutationCoordinatorForTeardownSnapshot atomically backfills the
+// prefix-owned lane for legacy/direct-map registry entries that predate stable
+// coordinator attachment. Holding mi.mu through slot creation and attachment
+// prevents an old teardown from ever borrowing a retracked generation's lane.
+func (mi *MultiIndexer) repositoryMutationCoordinatorForTeardownSnapshot(
+	repoPrefix string,
+	expectedMeta *RepoMetadata,
+	expectedIdx *Indexer,
+) (*repositoryMutationCoordinator, bool) {
+	mi.mu.RLock()
+	defer mi.mu.RUnlock()
+	if mi.repos[repoPrefix] != expectedMeta || mi.indexers[repoPrefix] != expectedIdx {
+		return nil, false
+	}
+	coordinator := mi.repositoryMutationCoordinator(repoPrefix)
+	if expectedIdx != nil {
+		expectedIdx.attachRepositoryMutationCoordinator(coordinator)
+	}
+	return coordinator, true
+}
+
+// detachRepositoryMutationCoordinator removes repoPrefix only when the slot is
+// still the coordinator this teardown drained. A stale teardown must never
+// detach a replacement installed by a later track generation.
+func (mi *MultiIndexer) detachRepositoryMutationCoordinator(
+	repoPrefix string,
+	expected *repositoryMutationCoordinator,
+) bool {
+	if expected == nil {
+		return false
+	}
+	mi.repositoryMutationMu.Lock()
+	defer mi.repositoryMutationMu.Unlock()
+	if mi.repositoryMutations[repoPrefix] != expected {
+		return false
+	}
+	delete(mi.repositoryMutations, repoPrefix)
+	return true
+}
+
+func (idx *Indexer) hasRepositoryMutationCoordinator(expected *repositoryMutationCoordinator) bool {
+	if idx == nil || expected == nil {
+		return false
+	}
+	idx.repositoryMutationMu.Lock()
+	defer idx.repositoryMutationMu.Unlock()
+	return idx.repositoryMutation == expected
+}
+
+func (idx *Indexer) attachRepositoryMutationCoordinator(coordinator *repositoryMutationCoordinator) {
+	idx.repositoryMutationMu.Lock()
+	idx.repositoryMutation = coordinator
+	idx.repositoryMutationMu.Unlock()
+}
+
+func (idx *Indexer) ensureRepositoryMutationRoot(root string) error {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return err
+	}
+	idx.repositoryMutationMu.Lock()
+	defer idx.repositoryMutationMu.Unlock()
+	if idx.rootPath == "" {
+		idx.rootPath = absRoot
+		return nil
+	}
+	current, err := filepath.Abs(idx.rootPath)
+	if err != nil {
+		return err
+	}
+	if filepath.Clean(current) != filepath.Clean(absRoot) {
+		return fmt.Errorf("repository mutation root changed from %q to %q", current, absRoot)
+	}
+	return nil
+}
+
+func (idx *Indexer) repositoryMutations() *repositoryMutationCoordinator {
+	idx.repositoryMutationMu.Lock()
+	defer idx.repositoryMutationMu.Unlock()
+	if idx.repositoryMutation == nil {
+		if idx.repositoryMutationOwner != nil && idx.repoPrefix != "" {
+			idx.repositoryMutation = idx.repositoryMutationOwner.repositoryMutationCoordinator(idx.repoPrefix)
+		} else {
+			idx.repositoryMutation = newRepositoryMutationCoordinator(func(paths []string) (*IndexResult, error) {
+				return idx.incrementalReindexWatcherPaths(idx.rootPath, paths)
+			})
+		}
+	}
+	return idx.repositoryMutation
 }
 
 func (idx *Indexer) coordinateRepositoryReindex(
@@ -277,14 +507,10 @@ func (idx *Indexer) coordinateRepositoryReindex(
 	return idx.repositoryMutations().reconcile(ctx, paths)
 }
 
-// CoordinateRepositoryMutation serializes one non-coalescible repository
+// coordinateRepositoryMutation serializes one non-coalescible repository
 // mutation with every watcher, reconciliation, and janitor pipeline for this
 // Indexer. The callback must use raw mutation methods and must not submit back
 // into the coordinator.
-func (idx *Indexer) CoordinateRepositoryMutation(ctx context.Context, fn func() error) error {
+func (idx *Indexer) coordinateRepositoryMutation(ctx context.Context, fn func() error) error {
 	return idx.repositoryMutations().runExclusive(ctx, fn)
-}
-
-func (idx *Indexer) closeRepositoryMutations(ctx context.Context) error {
-	return idx.repositoryMutations().closeAndWait(ctx)
 }

--- a/internal/indexer/repository_mutation_coordinator.go
+++ b/internal/indexer/repository_mutation_coordinator.go
@@ -1,0 +1,290 @@
+package indexer
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sort"
+	"sync"
+)
+
+const repositoryMutationPathCap = 2048
+
+var errRepositoryMutationCoordinatorClosed = errors.New("repository mutation coordinator is closed")
+
+type repositoryMutationExecutor func(paths []string) (*IndexResult, error)
+
+type repositoryMutationScope struct {
+	full  bool
+	paths map[string]struct{}
+}
+
+func (s *repositoryMutationScope) merge(paths []string) {
+	if s.full {
+		return
+	}
+	if len(paths) == 0 {
+		s.full = true
+		s.paths = nil
+		return
+	}
+	if s.paths == nil {
+		s.paths = make(map[string]struct{}, len(paths))
+	}
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+		s.paths[filepath.Clean(path)] = struct{}{}
+		if len(s.paths) > repositoryMutationPathCap {
+			s.full = true
+			s.paths = nil
+			return
+		}
+	}
+	if len(s.paths) == 0 {
+		s.full = true
+		s.paths = nil
+	}
+}
+
+func (s *repositoryMutationScope) take() []string {
+	if s.full {
+		s.full = false
+		s.paths = nil
+		return nil
+	}
+	paths := make([]string, 0, len(s.paths))
+	for path := range s.paths {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	s.paths = nil
+	return paths
+}
+
+type repositoryMutationOutcome struct {
+	result *IndexResult
+	err    error
+}
+
+type repositoryMutationWaiter struct {
+	generation uint64
+	done       chan repositoryMutationOutcome
+}
+
+// repositoryMutationCoordinator is the single mutation lane for one Indexer.
+// Reconcile requests coalesce while queued: path scopes union, a full request
+// dominates, and requests admitted during execution advance the dirty
+// generation and force another pass before the worker becomes idle. Point
+// mutations use runExclusive and share the same lane without being folded
+// together, preserving watcher receipts and callbacks.
+type repositoryMutationCoordinator struct {
+	mu sync.Mutex
+
+	lane chan struct{}
+	work sync.WaitGroup
+
+	executor repositoryMutationExecutor
+	closed   bool
+	running  bool
+
+	requestedGeneration uint64
+	completedGeneration uint64
+	pending             repositoryMutationScope
+	waiters             []*repositoryMutationWaiter
+}
+
+func newRepositoryMutationCoordinator(executor repositoryMutationExecutor) *repositoryMutationCoordinator {
+	lane := make(chan struct{}, 1)
+	lane <- struct{}{}
+	return &repositoryMutationCoordinator{lane: lane, executor: executor}
+}
+
+func (c *repositoryMutationCoordinator) setExecutor(executor repositoryMutationExecutor) error {
+	if executor == nil {
+		return errors.New("repository mutation executor is nil")
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return errRepositoryMutationCoordinatorClosed
+	}
+	if c.running || c.requestedGeneration != c.completedGeneration {
+		return errors.New("repository mutation executor cannot change while work is pending")
+	}
+	c.executor = executor
+	return nil
+}
+
+func (c *repositoryMutationCoordinator) reconcile(
+	ctx context.Context,
+	paths []string,
+) (*IndexResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	waiter := &repositoryMutationWaiter{done: make(chan repositoryMutationOutcome, 1)}
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil, errRepositoryMutationCoordinatorClosed
+	}
+	c.requestedGeneration++
+	waiter.generation = c.requestedGeneration
+	c.pending.merge(paths)
+	c.waiters = append(c.waiters, waiter)
+	if !c.running {
+		c.running = true
+		c.work.Add(1)
+		go c.drain()
+	}
+	c.mu.Unlock()
+
+	select {
+	case outcome := <-waiter.done:
+		return outcome.result, outcome.err
+	case <-ctx.Done():
+		// Admission is durable. Cancellation stops this caller waiting but does
+		// not abandon disk reconciliation or the dirty follow-up generation.
+		return nil, ctx.Err()
+	}
+}
+
+func (c *repositoryMutationCoordinator) drain() {
+	defer c.work.Done()
+	for {
+		// Acquire the mutation lane before snapshotting pending scope. Requests
+		// admitted while a point mutation owns the lane therefore coalesce into
+		// one batch instead of being split merely because the worker was queued.
+		<-c.lane
+		c.mu.Lock()
+		if len(c.waiters) == 0 {
+			c.running = false
+			c.mu.Unlock()
+			c.lane <- struct{}{}
+			return
+		}
+		generation := c.requestedGeneration
+		paths := c.pending.take()
+		waiters := c.waiters
+		c.waiters = nil
+		executor := c.executor
+		c.mu.Unlock()
+
+		var outcome repositoryMutationOutcome
+		if executor == nil {
+			outcome.err = errors.New("repository mutation executor is not configured")
+		} else {
+			outcome.result, outcome.err = executor(paths)
+		}
+		c.lane <- struct{}{}
+
+		c.mu.Lock()
+		if generation > c.completedGeneration {
+			c.completedGeneration = generation
+		}
+		c.mu.Unlock()
+		for _, waiter := range waiters {
+			waiter.done <- outcome
+		}
+	}
+}
+
+func (c *repositoryMutationCoordinator) runExclusive(ctx context.Context, fn func() error) error {
+	if fn == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return errRepositoryMutationCoordinatorClosed
+	}
+	c.work.Add(1)
+	c.mu.Unlock()
+	defer c.work.Done()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.lane:
+	}
+	defer func() { c.lane <- struct{}{} }()
+	return fn()
+}
+
+func (c *repositoryMutationCoordinator) closeAndWait(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	c.mu.Lock()
+	c.closed = true
+	c.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		c.work.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+type repositoryMutationCoordinatorStats struct {
+	RequestedGeneration uint64
+	CompletedGeneration uint64
+	Running             bool
+	PendingPaths        int
+	PendingFull         bool
+}
+
+func (c *repositoryMutationCoordinator) stats() repositoryMutationCoordinatorStats {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return repositoryMutationCoordinatorStats{
+		RequestedGeneration: c.requestedGeneration,
+		CompletedGeneration: c.completedGeneration,
+		Running:             c.running,
+		PendingPaths:        len(c.pending.paths),
+		PendingFull:         c.pending.full,
+	}
+}
+
+func (idx *Indexer) repositoryMutations() *repositoryMutationCoordinator {
+	idx.repositoryMutationOnce.Do(func() {
+		idx.repositoryMutation = newRepositoryMutationCoordinator(func(paths []string) (*IndexResult, error) {
+			return idx.incrementalReindexWatcherPaths(idx.rootPath, paths)
+		})
+	})
+	return idx.repositoryMutation
+}
+
+func (idx *Indexer) setRepositoryMutationExecutor(executor repositoryMutationExecutor) error {
+	return idx.repositoryMutations().setExecutor(executor)
+}
+
+func (idx *Indexer) coordinateRepositoryReindex(
+	ctx context.Context,
+	paths []string,
+) (*IndexResult, error) {
+	return idx.repositoryMutations().reconcile(ctx, paths)
+}
+
+// CoordinateRepositoryMutation serializes one non-coalescible repository
+// mutation with every watcher, reconciliation, and janitor pipeline for this
+// Indexer. The callback must use raw mutation methods and must not submit back
+// into the coordinator.
+func (idx *Indexer) CoordinateRepositoryMutation(ctx context.Context, fn func() error) error {
+	return idx.repositoryMutations().runExclusive(ctx, fn)
+}
+
+func (idx *Indexer) closeRepositoryMutations(ctx context.Context) error {
+	return idx.repositoryMutations().closeAndWait(ctx)
+}

--- a/internal/indexer/repository_mutation_coordinator_test.go
+++ b/internal/indexer/repository_mutation_coordinator_test.go
@@ -8,6 +8,11 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	"go.uber.org/zap"
 )
 
 func waitForRepositoryMutationStats(
@@ -31,13 +36,19 @@ func waitForRepositoryMutationStats(
 
 func TestRepositoryMutationScopeUnionAndFullEscalation(t *testing.T) {
 	var scope repositoryMutationScope
-	scope.merge([]string{"b.go", "a.go", "a.go"})
+	if err := scope.merge([]string{"b.go", "a.go", "a.go"}); err != nil {
+		t.Fatal(err)
+	}
 	if got, want := scope.take(), []string{"a.go", "b.go"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("union = %#v, want %#v", got, want)
 	}
 
-	scope.merge([]string{"one.go"})
-	scope.merge(nil)
+	if err := scope.merge([]string{"one.go"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := scope.merge(nil); err != nil {
+		t.Fatal(err)
+	}
 	if got := scope.take(); got != nil {
 		t.Fatalf("explicit full scope = %#v, want nil", got)
 	}
@@ -46,7 +57,9 @@ func TestRepositoryMutationScopeUnionAndFullEscalation(t *testing.T) {
 	for i := range paths {
 		paths[i] = time.Unix(int64(i), 0).Format("20060102150405.000000000")
 	}
-	scope.merge(paths)
+	if err := scope.merge(paths); err != nil {
+		t.Fatal(err)
+	}
 	if got := scope.take(); got != nil {
 		t.Fatalf("cap-escalated scope retained %d paths", len(got))
 	}
@@ -154,6 +167,51 @@ func TestRepositoryMutationCoordinatorFullDominatesQueuedPaths(t *testing.T) {
 	}
 }
 
+func TestRepositoryMutationCoordinatorRecoversPanicAndRunsDirtyFollowup(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var calls atomic.Int32
+	coordinator := newRepositoryMutationCoordinator(func(paths []string) (*IndexResult, error) {
+		call := calls.Add(1)
+		if call == 1 {
+			close(started)
+			<-release
+			panic("store failure")
+		}
+		return &IndexResult{FileCount: int(call)}, nil
+	})
+
+	type response struct {
+		result *IndexResult
+		err    error
+	}
+	first := make(chan response, 1)
+	second := make(chan response, 1)
+	go func() {
+		result, err := coordinator.reconcile(context.Background(), []string{"first.go"})
+		first <- response{result: result, err: err}
+	}()
+	<-started
+	go func() {
+		result, err := coordinator.reconcile(context.Background(), []string{"second.go"})
+		second <- response{result: result, err: err}
+	}()
+	waitForRepositoryMutationStats(t, coordinator, func(stats repositoryMutationCoordinatorStats) bool {
+		return stats.RequestedGeneration == 2 && stats.PendingPaths == 1
+	})
+	close(release)
+
+	if got := <-first; got.result != nil || got.err == nil {
+		t.Fatalf("panic outcome = result:%#v err:%v", got.result, got.err)
+	}
+	if got := <-second; got.err != nil || got.result == nil || got.result.FileCount != 2 {
+		t.Fatalf("dirty followup = result:%#v err:%v", got.result, got.err)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("executor calls = %d, want 2", calls.Load())
+	}
+}
+
 func TestRepositoryMutationCoordinatorSerializesMixedWork(t *testing.T) {
 	var active atomic.Int32
 	var maximum atomic.Int32
@@ -194,6 +252,28 @@ func TestRepositoryMutationCoordinatorSerializesMixedWork(t *testing.T) {
 	}
 }
 
+func TestRepositoryMutationCoordinatorRejectsPreCanceledWork(t *testing.T) {
+	var executions atomic.Int32
+	coordinator := newRepositoryMutationCoordinator(func(paths []string) (*IndexResult, error) {
+		executions.Add(1)
+		return &IndexResult{}, nil
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if result, err := coordinator.reconcile(ctx, []string{"a.go"}); result != nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("pre-canceled reconcile = result:%#v err:%v", result, err)
+	}
+	if err := coordinator.runExclusive(ctx, func() error {
+		executions.Add(1)
+		return nil
+	}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("pre-canceled exclusive error = %v", err)
+	}
+	if executions.Load() != 0 {
+		t.Fatalf("pre-canceled executions = %d, want 0", executions.Load())
+	}
+}
+
 func TestRepositoryMutationCancellationDoesNotCancelAdmittedWork(t *testing.T) {
 	started := make(chan struct{})
 	release := make(chan struct{})
@@ -229,5 +309,323 @@ func TestRepositoryMutationCancellationDoesNotCancelAdmittedWork(t *testing.T) {
 	}
 	if err := coordinator.runExclusive(context.Background(), func() error { return nil }); !errors.Is(err, errRepositoryMutationCoordinatorClosed) {
 		t.Fatalf("closed exclusive error = %v", err)
+	}
+}
+
+func TestIndexCtxWaitsForRepositoryMutationLane(t *testing.T) {
+	cfg := config.Default()
+	idx := New(graph.New(), parser.NewRegistry(), cfg.Index, zap.NewNop())
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	holderDone := make(chan error, 1)
+	go func() {
+		holderDone <- idx.coordinateRepositoryMutation(context.Background(), func() error {
+			close(entered)
+			<-release
+			return nil
+		})
+	}()
+	<-entered
+
+	ctx, cancel := context.WithCancel(context.Background())
+	root := t.TempDir()
+	indexDone := make(chan error, 1)
+	go func() {
+		_, err := idx.IndexCtx(ctx, root)
+		indexDone <- err
+	}()
+	select {
+	case err := <-indexDone:
+		t.Fatalf("full index bypassed repository mutation lane: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	cancel()
+	if err := <-indexDone; !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled full index error = %v, want context.Canceled", err)
+	}
+
+	close(release)
+	if err := <-holderDone; err != nil {
+		t.Fatalf("lane holder: %v", err)
+	}
+}
+
+func TestRepositoryMutationLaneSurvivesIndexerReplacement(t *testing.T) {
+	const prefix = "repo"
+	mi := &MultiIndexer{indexers: make(map[string]*Indexer)}
+
+	original := &Indexer{repositoryMutationOwner: mi}
+	original.SetRepoPrefix(prefix)
+	mi.indexers[prefix] = original
+
+	enteredOriginal := make(chan struct{})
+	releaseOriginal := make(chan struct{})
+	originalDone := make(chan error, 1)
+	go func() {
+		originalDone <- original.coordinateRepositoryMutation(context.Background(), func() error {
+			close(enteredOriginal)
+			<-releaseOriginal
+			return nil
+		})
+	}()
+	<-enteredOriginal
+
+	replacement := &Indexer{repositoryMutationOwner: mi}
+	replacement.SetRepoPrefix(prefix)
+	mi.mu.Lock()
+	mi.indexers[prefix] = replacement
+	mi.mu.Unlock()
+	if original.repositoryMutations() != replacement.repositoryMutations() {
+		t.Fatal("replacement Indexer attached a second repository mutation lane")
+	}
+
+	enteredReplacement := make(chan struct{})
+	replacementDone := make(chan error, 1)
+	go func() {
+		replacementDone <- replacement.coordinateRepositoryMutation(context.Background(), func() error {
+			close(enteredReplacement)
+			return nil
+		})
+	}()
+	select {
+	case <-enteredReplacement:
+		t.Fatal("replacement mutation overlapped the original Indexer mutation")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(releaseOriginal)
+	if err := <-originalDone; err != nil {
+		t.Fatalf("original mutation: %v", err)
+	}
+	select {
+	case <-enteredReplacement:
+	case <-time.After(2 * time.Second):
+		t.Fatal("replacement mutation did not enter the shared lane")
+	}
+	if err := <-replacementDone; err != nil {
+		t.Fatalf("replacement mutation: %v", err)
+	}
+}
+
+func TestRepositoryMutationKeepsExistingWatcherOnSharedLaneAfterReplacement(t *testing.T) {
+	const prefix = "repo"
+	mi := &MultiIndexer{indexers: make(map[string]*Indexer)}
+	existing := &Indexer{repositoryMutationOwner: mi}
+	existing.SetRepoPrefix(prefix)
+	replacement := &Indexer{repositoryMutationOwner: mi}
+	replacement.SetRepoPrefix(prefix)
+	mi.indexers[prefix] = replacement
+
+	var called atomic.Bool
+	err := existing.coordinateRepositoryMutation(context.Background(), func() error {
+		called.Store(true)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("existing watcher mutation after replacement: %v", err)
+	}
+	if !called.Load() {
+		t.Fatal("existing watcher stopped mutating after Indexer replacement")
+	}
+	if existing.repositoryMutations() != replacement.repositoryMutations() {
+		t.Fatal("existing watcher no longer shares the replacement repository lane")
+	}
+}
+
+func TestUntrackRepoWaitsForMutationLaneAndRejectsAdmission(t *testing.T) {
+	const prefix = "repo"
+	mi := &MultiIndexer{
+		graph:    graph.New(),
+		repos:    map[string]*RepoMetadata{prefix: {RepoPrefix: prefix}},
+		indexers: map[string]*Indexer{prefix: nil},
+		logger:   zap.NewNop(),
+	}
+	coordinator := mi.repositoryMutationCoordinator(prefix)
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	mutationDone := make(chan error, 1)
+	go func() {
+		mutationDone <- coordinator.runExclusive(context.Background(), func() error {
+			close(entered)
+			<-release
+			return nil
+		})
+	}()
+	<-entered
+
+	type untrackResult struct {
+		nodes int
+		edges int
+	}
+	untrackDone := make(chan untrackResult, 1)
+	go func() {
+		nodes, edges := mi.UntrackRepo(prefix)
+		untrackDone <- untrackResult{nodes: nodes, edges: edges}
+	}()
+
+	deadline := time.NewTimer(2 * time.Second)
+	defer deadline.Stop()
+	for {
+		coordinator.mu.Lock()
+		closed := coordinator.closed
+		coordinator.mu.Unlock()
+		if closed {
+			break
+		}
+		select {
+		case <-untrackDone:
+			t.Fatal("UntrackRepo returned before closing and draining the repository mutation lane")
+		case <-deadline.C:
+			t.Fatal("UntrackRepo did not close the repository mutation lane")
+		case <-time.After(time.Millisecond):
+		}
+	}
+	if current := mi.repositoryMutationCoordinator(prefix); current != coordinator {
+		t.Fatal("UntrackRepo detached the closed lane before repository teardown completed")
+	} else if err := current.runExclusive(context.Background(), func() error { return nil }); !errors.Is(err, errRepositoryMutationCoordinatorClosed) {
+		t.Fatalf("mutation admitted after untrack started: %v", err)
+	}
+	select {
+	case <-untrackDone:
+		t.Fatal("UntrackRepo returned before the active repository mutation completed")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(release)
+	if err := <-mutationDone; err != nil {
+		t.Fatalf("active mutation: %v", err)
+	}
+	select {
+	case <-untrackDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("UntrackRepo did not finish after the active mutation drained")
+	}
+}
+
+func TestRepositoryMutationConditionalDetachPreservesRetrackedLane(t *testing.T) {
+	const prefix = "repo"
+	mi := &MultiIndexer{}
+
+	old := mi.repositoryMutationCoordinator(prefix)
+	if got := mi.existingRepositoryMutationCoordinator(prefix); got != old {
+		t.Fatalf("existing coordinator = %p, want old slot %p", got, old)
+	}
+	if !mi.detachRepositoryMutationCoordinator(prefix, old) {
+		t.Fatal("exact old coordinator was not detached")
+	}
+
+	replacement := mi.repositoryMutationCoordinator(prefix)
+	if replacement == old {
+		t.Fatal("retrack reused the detached coordinator")
+	}
+	// This is the delayed tail of the old teardown. It must not remove the
+	// replacement generation that now owns the same prefix.
+	if mi.detachRepositoryMutationCoordinator(prefix, old) {
+		t.Fatal("stale teardown detached the retracked coordinator")
+	}
+	if got := mi.existingRepositoryMutationCoordinator(prefix); got != replacement {
+		t.Fatalf("coordinator after stale detach = %p, want replacement %p", got, replacement)
+	}
+	if err := replacement.runExclusive(context.Background(), func() error { return nil }); err != nil {
+		t.Fatalf("replacement coordinator is not open: %v", err)
+	}
+}
+
+func TestConcurrentUntrackRepoLeavesFreshRetrackLaneOpen(t *testing.T) {
+	const prefix = "repo"
+	cfg := config.Default()
+	store := graph.New()
+	registry := parser.NewRegistry()
+	mi := &MultiIndexer{
+		graph:    store,
+		registry: registry,
+		repos: map[string]*RepoMetadata{
+			prefix: {RepoPrefix: prefix},
+		},
+		indexers: make(map[string]*Indexer),
+		logger:   zap.NewNop(),
+	}
+	oldIndexer := New(store, registry, cfg.Index, zap.NewNop())
+	oldIndexer.repositoryMutationOwner = mi
+	oldIndexer.SetRepoPrefix(prefix)
+	mi.indexers[prefix] = oldIndexer
+	old := mi.existingRepositoryMutationCoordinator(prefix)
+	if old == nil {
+		t.Fatal("old repository coordinator was not installed")
+	}
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	holderDone := make(chan error, 1)
+	go func() {
+		holderDone <- old.runExclusive(context.Background(), func() error {
+			close(entered)
+			<-release
+			return nil
+		})
+	}()
+	<-entered
+
+	start := make(chan struct{})
+	ready := make(chan struct{}, 2)
+	untracked := make(chan struct{}, 2)
+	for range 2 {
+		go func() {
+			ready <- struct{}{}
+			<-start
+			mi.UntrackRepo(prefix)
+			untracked <- struct{}{}
+		}()
+	}
+	<-ready
+	<-ready
+	close(start)
+
+	deadline := time.NewTimer(2 * time.Second)
+	defer deadline.Stop()
+	for {
+		old.mu.Lock()
+		closed := old.closed
+		old.mu.Unlock()
+		if closed {
+			break
+		}
+		select {
+		case <-deadline.C:
+			t.Fatal("concurrent untrack did not close the old coordinator")
+		case <-time.After(time.Millisecond):
+		}
+	}
+	close(release)
+	if err := <-holderDone; err != nil {
+		t.Fatalf("lane holder: %v", err)
+	}
+	for range 2 {
+		select {
+		case <-untracked:
+		case <-time.After(2 * time.Second):
+			t.Fatal("concurrent untrack did not finish")
+		}
+	}
+	if got := mi.existingRepositoryMutationCoordinator(prefix); got != nil {
+		t.Fatalf("double untrack stranded coordinator %p", got)
+	}
+
+	// Re-track the same prefix and prove the new generation is neither the old
+	// closed lane nor a closed lane manufactured by the losing untrack.
+	replacementIndexer := New(store, registry, cfg.Index, zap.NewNop())
+	replacementIndexer.repositoryMutationOwner = mi
+	replacementIndexer.SetRepoPrefix(prefix)
+	replacement := mi.existingRepositoryMutationCoordinator(prefix)
+	if replacement == nil || replacement == old {
+		t.Fatalf("replacement coordinator = %p, old = %p", replacement, old)
+	}
+	mi.mu.Lock()
+	mi.repos[prefix] = &RepoMetadata{RepoPrefix: prefix}
+	mi.indexers[prefix] = replacementIndexer
+	mi.mu.Unlock()
+	if err := replacement.runExclusive(context.Background(), func() error { return nil }); err != nil {
+		t.Fatalf("fresh retrack lane rejected mutation: %v", err)
 	}
 }

--- a/internal/indexer/repository_mutation_coordinator_test.go
+++ b/internal/indexer/repository_mutation_coordinator_test.go
@@ -1,0 +1,233 @@
+package indexer
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func waitForRepositoryMutationStats(
+	t *testing.T,
+	coordinator *repositoryMutationCoordinator,
+	predicate func(repositoryMutationCoordinatorStats) bool,
+) repositoryMutationCoordinatorStats {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		stats := coordinator.stats()
+		if predicate(stats) {
+			return stats
+		}
+		time.Sleep(time.Millisecond)
+	}
+	stats := coordinator.stats()
+	t.Fatalf("coordinator state did not converge: %+v", stats)
+	return stats
+}
+
+func TestRepositoryMutationScopeUnionAndFullEscalation(t *testing.T) {
+	var scope repositoryMutationScope
+	scope.merge([]string{"b.go", "a.go", "a.go"})
+	if got, want := scope.take(), []string{"a.go", "b.go"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("union = %#v, want %#v", got, want)
+	}
+
+	scope.merge([]string{"one.go"})
+	scope.merge(nil)
+	if got := scope.take(); got != nil {
+		t.Fatalf("explicit full scope = %#v, want nil", got)
+	}
+
+	paths := make([]string, repositoryMutationPathCap+1)
+	for i := range paths {
+		paths[i] = time.Unix(int64(i), 0).Format("20060102150405.000000000")
+	}
+	scope.merge(paths)
+	if got := scope.take(); got != nil {
+		t.Fatalf("cap-escalated scope retained %d paths", len(got))
+	}
+}
+
+func TestRepositoryMutationCoordinatorUnionsDirtyFollowup(t *testing.T) {
+	var mu sync.Mutex
+	var calls [][]string
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	coordinator := newRepositoryMutationCoordinator(func(paths []string) (*IndexResult, error) {
+		mu.Lock()
+		call := len(calls) + 1
+		calls = append(calls, append([]string(nil), paths...))
+		mu.Unlock()
+		if call == 1 {
+			close(firstStarted)
+			<-releaseFirst
+		}
+		return &IndexResult{FileCount: call}, nil
+	})
+
+	type response struct {
+		result *IndexResult
+		err    error
+	}
+	responses := make(chan response, 3)
+	go func() {
+		result, err := coordinator.reconcile(context.Background(), []string{"a.go"})
+		responses <- response{result: result, err: err}
+	}()
+	<-firstStarted
+	go func() {
+		result, err := coordinator.reconcile(context.Background(), []string{"c.go"})
+		responses <- response{result: result, err: err}
+	}()
+	go func() {
+		result, err := coordinator.reconcile(context.Background(), []string{"b.go", "c.go"})
+		responses <- response{result: result, err: err}
+	}()
+	waitForRepositoryMutationStats(t, coordinator, func(stats repositoryMutationCoordinatorStats) bool {
+		return stats.RequestedGeneration == 3 && stats.PendingPaths == 2
+	})
+	close(releaseFirst)
+
+	for range 3 {
+		response := <-responses
+		if response.err != nil || response.result == nil {
+			t.Fatalf("response = result:%#v err:%v", response.result, response.err)
+		}
+	}
+	if err := coordinator.closeAndWait(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if got, want := calls, [][]string{{"a.go"}, {"b.go", "c.go"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("executions = %#v, want %#v", got, want)
+	}
+}
+
+func TestRepositoryMutationCoordinatorFullDominatesQueuedPaths(t *testing.T) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var calls atomic.Int32
+	var gotPaths []string
+	coordinator := newRepositoryMutationCoordinator(func(paths []string) (*IndexResult, error) {
+		calls.Add(1)
+		gotPaths = append([]string(nil), paths...)
+		return &IndexResult{}, nil
+	})
+	exclusiveDone := make(chan error, 1)
+	go func() {
+		exclusiveDone <- coordinator.runExclusive(context.Background(), func() error {
+			close(entered)
+			<-release
+			return nil
+		})
+	}()
+	<-entered
+
+	results := make(chan error, 2)
+	go func() {
+		_, err := coordinator.reconcile(context.Background(), []string{"one.go"})
+		results <- err
+	}()
+	go func() {
+		_, err := coordinator.reconcile(context.Background(), nil)
+		results <- err
+	}()
+	waitForRepositoryMutationStats(t, coordinator, func(stats repositoryMutationCoordinatorStats) bool {
+		return stats.RequestedGeneration == 2 && stats.PendingFull
+	})
+	close(release)
+	if err := <-exclusiveDone; err != nil {
+		t.Fatal(err)
+	}
+	for range 2 {
+		if err := <-results; err != nil {
+			t.Fatal(err)
+		}
+	}
+	if calls.Load() != 1 || gotPaths != nil {
+		t.Fatalf("full execution = calls:%d paths:%#v, want 1/nil", calls.Load(), gotPaths)
+	}
+}
+
+func TestRepositoryMutationCoordinatorSerializesMixedWork(t *testing.T) {
+	var active atomic.Int32
+	var maximum atomic.Int32
+	enter := func() {
+		now := active.Add(1)
+		for {
+			old := maximum.Load()
+			if now <= old || maximum.CompareAndSwap(old, now) {
+				break
+			}
+		}
+		time.Sleep(time.Millisecond)
+		active.Add(-1)
+	}
+	coordinator := newRepositoryMutationCoordinator(func(paths []string) (*IndexResult, error) {
+		enter()
+		return &IndexResult{}, nil
+	})
+
+	var wait sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wait.Add(2)
+		go func() {
+			defer wait.Done()
+			_, _ = coordinator.reconcile(context.Background(), []string{"same.go"})
+		}()
+		go func() {
+			defer wait.Done()
+			_ = coordinator.runExclusive(context.Background(), func() error {
+				enter()
+				return nil
+			})
+		}()
+	}
+	wait.Wait()
+	if maximum.Load() != 1 {
+		t.Fatalf("maximum concurrent mutation pipelines = %d, want 1", maximum.Load())
+	}
+}
+
+func TestRepositoryMutationCancellationDoesNotCancelAdmittedWork(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	finished := make(chan struct{})
+	coordinator := newRepositoryMutationCoordinator(func(paths []string) (*IndexResult, error) {
+		close(started)
+		<-release
+		close(finished)
+		return &IndexResult{}, nil
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	result, err := coordinator.reconcile(ctx, []string{"a.go"})
+	if result != nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("canceled wait = result:%#v err:%v", result, err)
+	}
+	<-started
+	close(release)
+	select {
+	case <-finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("admitted mutation was canceled with its waiter")
+	}
+	if err := coordinator.closeAndWait(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	stats := coordinator.stats()
+	if stats.CompletedGeneration != 1 || stats.Running {
+		t.Fatalf("completed state = %+v", stats)
+	}
+	if _, err := coordinator.reconcile(context.Background(), nil); !errors.Is(err, errRepositoryMutationCoordinatorClosed) {
+		t.Fatalf("closed reconcile error = %v", err)
+	}
+	if err := coordinator.runExclusive(context.Background(), func() error { return nil }); !errors.Is(err, errRepositoryMutationCoordinatorClosed) {
+		t.Fatalf("closed exclusive error = %v", err)
+	}
+}

--- a/internal/indexer/repository_mutation_paths.go
+++ b/internal/indexer/repository_mutation_paths.go
@@ -1,0 +1,127 @@
+package indexer
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/zzet/gortex/internal/pathkey"
+)
+
+var errEmptyRepositoryMutationPath = errors.New("repository mutation path is empty")
+
+// canonicalRepositoryMutationPaths validates one caller's explicit scope before
+// it can join a coalesced coordinator generation. Returned paths are
+// repository-relative, slash-separated NFC keys, so absolute/relative and
+// Unicode-normalization aliases occupy one coordinator slot. A nil/empty input
+// remains the sole spelling of a full-tree request.
+func canonicalRepositoryMutationPaths(root string, paths []string) ([]string, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
+	if root == "" {
+		return nil, errors.New("repository mutation root is empty")
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("repository mutation root %q: %w", root, err)
+	}
+	absRoot = filepath.Clean(absRoot)
+
+	canonical := make(map[string]struct{}, len(paths))
+	full := false
+	for _, path := range paths {
+		if path == "" {
+			return nil, errEmptyRepositoryMutationPath
+		}
+		absPath := path
+		if !filepath.IsAbs(absPath) {
+			absPath = filepath.Join(absRoot, filepath.FromSlash(path))
+		}
+		absPath, err = filepath.Abs(absPath)
+		if err != nil {
+			return nil, fmt.Errorf("repository mutation path %q: %w", path, err)
+		}
+		absPath = filepath.Clean(absPath)
+		rel, relErr := filepath.Rel(absRoot, absPath)
+		if relErr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			if relErr != nil {
+				return nil, fmt.Errorf("repository mutation path %q relative to %q: %w", path, absRoot, relErr)
+			}
+			return nil, fmt.Errorf("repository mutation path %q is outside repository root %q", path, absRoot)
+		}
+		// A missing path is a valid deletion scope. Other stat failures (invalid
+		// bytes, permissions, I/O) are caller-local errors and must not poison a
+		// generation shared with otherwise valid waiters.
+		if _, statErr := os.Stat(absPath); statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+			return nil, fmt.Errorf("repository mutation stat %q: %w", path, statErr)
+		}
+		if rel == "." {
+			full = true
+			continue
+		}
+		canonical[pathkey.Normalize(filepath.ToSlash(rel))] = struct{}{}
+	}
+	if full {
+		return nil, nil
+	}
+	result := make([]string, 0, len(canonical))
+	for path := range canonical {
+		result = append(result, path)
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+func canonicalRepositoryMutationPath(root, path string) (string, error) {
+	paths, err := canonicalRepositoryMutationPaths(root, []string{path})
+	if err != nil {
+		return "", err
+	}
+	if len(paths) != 1 {
+		return "", fmt.Errorf("repository mutation path %q resolves to the repository root", path)
+	}
+	return paths[0], nil
+}
+
+func validateRepositoryMutationRegularFile(root, relPath string) error {
+	absPath := filepath.Join(root, filepath.FromSlash(relPath))
+	info, err := os.Stat(absPath)
+	if err != nil {
+		return fmt.Errorf("index file %q: %w", relPath, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("index file %q is not a regular file", relPath)
+	}
+	return nil
+}
+
+// repositoryMutationRootPath returns the authoritative root used to validate a
+// public point mutation. A stale MultiIndexer-owned Indexer consults current
+// prefix metadata rather than admitting a path against its construction-time
+// root.
+func (idx *Indexer) repositoryMutationRootPath() (string, error) {
+	if idx == nil {
+		return "", errors.New("repository mutation indexer is nil")
+	}
+	if owner := idx.repositoryMutationOwner; owner != nil && idx.repoPrefix != "" {
+		owner.mu.RLock()
+		meta := owner.repos[idx.repoPrefix]
+		root := ""
+		if meta != nil {
+			root = meta.RootPath
+		}
+		owner.mu.RUnlock()
+		if root == "" {
+			return "", fmt.Errorf("repository mutation root is unavailable for %q", idx.repoPrefix)
+		}
+		return root, nil
+	}
+	if idx.rootPath == "" {
+		return "", errors.New("repository mutation root is unavailable")
+	}
+	return idx.rootPath, nil
+}

--- a/internal/indexer/repository_mutation_paths_test.go
+++ b/internal/indexer/repository_mutation_paths_test.go
@@ -1,0 +1,91 @@
+package indexer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/text/unicode/norm"
+)
+
+func TestCanonicalRepositoryMutationPathsDeduplicatesAliases(t *testing.T) {
+	root := t.TempDir()
+	asciiPath := filepath.Join(root, "a.go")
+	unicodeName := "caf\u00e9.go"
+	unicodePath := filepath.Join(root, unicodeName)
+	require.NoError(t, os.WriteFile(asciiPath, []byte("package p\n"), 0o644))
+	require.NoError(t, os.WriteFile(unicodePath, []byte("package p\n"), 0o644))
+
+	paths, err := canonicalRepositoryMutationPaths(root, []string{
+		"a.go",
+		filepath.Join(".", "a.go"),
+		asciiPath,
+		unicodeName,
+		norm.NFD.String(unicodeName),
+		unicodePath,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"a.go", unicodeName}, paths)
+}
+
+func TestCanonicalRepositoryMutationPathsValidation(t *testing.T) {
+	root := t.TempDir()
+
+	t.Run("missing in root is a deletion scope", func(t *testing.T) {
+		paths, err := canonicalRepositoryMutationPaths(root, []string{"deleted.go"})
+		require.NoError(t, err)
+		require.Equal(t, []string{"deleted.go"}, paths)
+	})
+
+	t.Run("explicit root is full", func(t *testing.T) {
+		paths, err := canonicalRepositoryMutationPaths(root, []string{"."})
+		require.NoError(t, err)
+		require.Nil(t, paths)
+	})
+
+	t.Run("empty explicit path is rejected", func(t *testing.T) {
+		_, err := canonicalRepositoryMutationPaths(root, []string{""})
+		require.ErrorIs(t, err, errEmptyRepositoryMutationPath)
+	})
+
+	t.Run("outside root is rejected", func(t *testing.T) {
+		_, err := canonicalRepositoryMutationPaths(root, []string{filepath.Join(root, "..", "outside.go")})
+		require.ErrorContains(t, err, "outside repository root")
+	})
+
+	t.Run("invalid stat is rejected", func(t *testing.T) {
+		_, err := canonicalRepositoryMutationPaths(root, []string{"bad\x00.go"})
+		require.ErrorContains(t, err, "repository mutation stat")
+	})
+}
+
+func TestIncrementalReindexPathsValidatesBeforeCoordinatorAdmission(t *testing.T) {
+	root := t.TempDir()
+	filePath := filepath.Join(root, "a.go")
+	require.NoError(t, os.WriteFile(filePath, []byte("package p\n"), 0o644))
+
+	executed := make(chan []string, 1)
+	coordinator := newRepositoryMutationCoordinator(func(paths []string) (*IndexResult, error) {
+		executed <- append([]string(nil), paths...)
+		return &IndexResult{}, nil
+	})
+	idx := &Indexer{rootPath: root}
+	idx.attachRepositoryMutationCoordinator(coordinator)
+
+	_, err := idx.IncrementalReindexPaths(root, []string{filepath.Join(root, "..", "outside.go")})
+	require.Error(t, err)
+	stats := coordinator.stats()
+	require.Zero(t, stats.RequestedGeneration)
+	require.Zero(t, stats.PendingPaths)
+
+	_, err = idx.IncrementalReindexPaths(root, []string{"a.go", filePath})
+	require.NoError(t, err)
+	require.Equal(t, []string{"a.go"}, <-executed)
+	require.Equal(t, uint64(1), coordinator.stats().RequestedGeneration)
+
+	_, err = coordinator.reconcile(context.Background(), []string{""})
+	require.ErrorIs(t, err, errEmptyRepositoryMutationPath)
+	require.Equal(t, uint64(1), coordinator.stats().RequestedGeneration)
+}

--- a/internal/indexer/watcher.go
+++ b/internal/indexer/watcher.go
@@ -20,7 +20,6 @@ import (
 	"github.com/zzet/gortex/internal/excludes"
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/pathkey"
-	"github.com/zzet/gortex/internal/reach"
 )
 
 // ChangeKind describes the type of filesystem change.
@@ -66,12 +65,27 @@ type MutationResult struct {
 // It receives the file path, old symbols (before eviction), and new symbols (after re-index).
 type SymbolChangeCallback func(filePath string, oldSymbols, newSymbols []*graph.Node)
 
+// symbolChangeNotification freezes one callback and its payload while a graph
+// mutation is still admitted. The callback itself is dispatched only after the
+// repository lane has been released, so a callback may safely re-enter an
+// indexing API for the same repository.
+type symbolChangeNotification struct {
+	callback   SymbolChangeCallback
+	filePath   string
+	oldSymbols []*graph.Node
+	newSymbols []*graph.Node
+}
+
 // Watcher keeps the knowledge graph in live sync with the filesystem.
 type Watcher struct {
-	indexer  *Indexer
-	fsw      fswatcher.Watcher
-	fsCancel context.CancelFunc
-	config   config.WatchConfig
+	// indexer is the original lane carrier. MultiWatcher installs currentIndexer
+	// so a long-lived watcher selects the currently registered Indexer only after
+	// this stable per-repository lane admits the mutation.
+	indexer        *Indexer
+	currentIndexer func() *Indexer
+	fsw            fswatcher.Watcher
+	fsCancel       context.CancelFunc
+	config         config.WatchConfig
 	// degradedNoFsnotify is set when Start detected a slow mount (a WSL2
 	// 9p/drvfs Windows drive, an SMB share) and skipped the native fsnotify
 	// backend, relying on the adaptive poller + git hooks instead.
@@ -142,8 +156,12 @@ type Watcher struct {
 	stormStopped     bool                  // Stop has closed storm admission
 	stormWork        sync.WaitGroup        // scheduled/running timer callbacks
 	stormDrained     func(int)             // test hook: batch drained; batch size arg
-	stormBeforeLock  func()                // test hook: immediately before patchMu acquisition
+	stormBeforeLock  func()                // test hook: immediately before repository-lane admission
 	batchReindex     watcherBatchReindex   // one bounded batch; MultiWatcher installs shared catch-up
+	discoverReindex  watcherBatchReindex   // additive directory discovery with the same complete tail
+	// pointReindexRaw runs the complete exact-path pipeline after the watcher
+	// already owns the repository lane. MultiWatcher installs its raw tail here.
+	pointReindexRaw func(string) (*IndexResult, error)
 
 	// poller is the adaptive-interval fallback that re-checks git
 	// HEAD movement and tracked-file mtimes on a timer, catching the
@@ -154,18 +172,20 @@ type Watcher struct {
 	poller *Poller
 
 	// reconcileMu guards the overflow-driven full-tree reconcile.
-	// reconcilePending coalesces a burst of overflow / dropped-event
-	// signals into at most one reconcile in flight: the kernel inotify
-	// queue can overflow (EventOverflow) or the backend can drop events
+	// reconcilePending keeps one worker in flight; reconcileGeneration advances
+	// for every overflow / dropped-event signal so a signal arriving during a
+	// tree walk produces one coalesced follow-up pass. The kernel inotify queue
+	// can overflow (EventOverflow) or the backend can drop events
 	// under backpressure (the Dropped() channel), and either means we
 	// may have lost a create/modify with no path to re-index. macOS
 	// FSEvents self-heals (it re-scans on UserDropped/KernelDropped),
 	// but Linux inotify does not — without this the lost event waits on
 	// the up-to-1h janitor. reconcileFn is a test seam: nil in
 	// production (the real full-tree coordinator runs).
-	reconcileMu      sync.Mutex
-	reconcilePending bool
-	reconcileFn      func()
+	reconcileMu         sync.Mutex
+	reconcilePending    bool
+	reconcileGeneration uint64
+	reconcileFn         func()
 
 	// pendingScanDirs coalesces newly-created directories awaiting a
 	// scoped subtree re-index — the new-subdir race (see enqueueDirScan).
@@ -189,9 +209,10 @@ type Watcher struct {
 const maxHistory = 1000
 
 var (
-	errMutationSuperseded   = errors.New("mutation generation superseded")
-	errMutationPatchAborted = errors.New("mutation patch aborted")
-	errWatcherStopped       = errors.New("watcher stopped before mutation completed")
+	errMutationSuperseded    = errors.New("mutation generation superseded")
+	errMutationPatchAborted  = errors.New("mutation patch aborted")
+	errWatcherStopped        = errors.New("watcher stopped before mutation completed")
+	errWatcherIndexerMissing = errors.New("watcher repository indexer is no longer registered")
 )
 
 // probeMarker is the substring embedded in handshake-probe filenames
@@ -244,6 +265,98 @@ func NewWatcher(idx *Indexer, cfg config.WatchConfig, logger *zap.Logger) (*Watc
 		done:              make(chan struct{}),
 		stopped:           make(chan struct{}),
 	}, nil
+}
+
+// currentMutationIndexer returns the currently registered per-repository
+// Indexer for a MultiWatcher-owned watcher. Standalone watchers have no
+// registry indirection and continue to use their construction-time Indexer.
+func (w *Watcher) currentMutationIndexer() *Indexer {
+	if w.currentIndexer != nil {
+		return w.currentIndexer()
+	}
+	return w.indexer
+}
+
+// cloneSymbolChangeNodes detaches callback payloads from graph-owned node and
+// metadata maps. Graph swaps may reuse or update those objects as soon as the
+// repository lane opens for the next mutation.
+func cloneSymbolChangeNodes(nodes []*graph.Node) []*graph.Node {
+	if nodes == nil {
+		return nil
+	}
+	cloned := make([]*graph.Node, len(nodes))
+	for i, node := range nodes {
+		if node == nil {
+			continue
+		}
+		copyNode := *node
+		if node.Meta != nil {
+			copyNode.Meta = make(map[string]any, len(node.Meta))
+			for key, value := range node.Meta {
+				copyNode.Meta[key] = cloneSymbolChangeMeta(value)
+			}
+		}
+		cloned[i] = &copyNode
+	}
+	return cloned
+}
+
+func cloneSymbolChangeMeta(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		cloned := make(map[string]any, len(typed))
+		for key, nested := range typed {
+			cloned[key] = cloneSymbolChangeMeta(nested)
+		}
+		return cloned
+	case map[string]string:
+		cloned := make(map[string]string, len(typed))
+		for key, nested := range typed {
+			cloned[key] = nested
+		}
+		return cloned
+	case []any:
+		cloned := make([]any, len(typed))
+		for i, nested := range typed {
+			cloned[i] = cloneSymbolChangeMeta(nested)
+		}
+		return cloned
+	case []string:
+		return append([]string(nil), typed...)
+	case []int:
+		return append([]int(nil), typed...)
+	default:
+		return value
+	}
+}
+
+func (w *Watcher) captureSymbolChange(
+	pending *symbolChangeNotification,
+	filePath string,
+	oldSymbols, newSymbols []*graph.Node,
+) {
+	if pending == nil {
+		return
+	}
+	w.symbolChangeCbMu.RLock()
+	callback := w.symbolChangeCb
+	w.symbolChangeCbMu.RUnlock()
+	if callback == nil {
+		return
+	}
+	*pending = symbolChangeNotification{
+		callback:   callback,
+		filePath:   filePath,
+		oldSymbols: cloneSymbolChangeNodes(oldSymbols),
+		newSymbols: cloneSymbolChangeNodes(newSymbols),
+	}
+}
+
+func (pending *symbolChangeNotification) dispatch() {
+	if pending == nil || pending.callback == nil {
+		return
+	}
+	pending.callback(pending.filePath, pending.oldSymbols, pending.newSymbols)
 }
 
 // Start begins watching the given paths recursively. The backend is
@@ -1079,20 +1192,21 @@ func (w *Watcher) beginReconcileWork() bool {
 // reconcile in response to a lost-event signal (a kernel inotify queue
 // overflow or a backpressure-dropped event). A burst of signals
 // collapses into at most one reconcile in flight: the first caller sets
-// reconcilePending and runs the reconcile off the event loop; concurrent
-// callers observe the flag and return immediately. Best-effort and
+// One worker drains reconcileGeneration off the event loop. Concurrent
+// callers only advance the dirty generation and return; the active worker
+// observes it after the current walk and runs one follow-up. Best-effort and
 // logged — the event loop is never blocked.
 func (w *Watcher) triggerOverflowReconcile(reason string) {
 	if !w.beginReconcileWork() {
 		return
 	}
+	w.reconcileGeneration++
 	if w.reconcilePending {
 		w.reconcileMu.Unlock()
 		w.asyncWork.Done()
 		return
 	}
 	w.reconcilePending = true
-	fn := w.reconcileFn
 	w.reconcileMu.Unlock()
 
 	if w.logger != nil {
@@ -1103,26 +1217,45 @@ func (w *Watcher) triggerOverflowReconcile(reason string) {
 
 	go func() {
 		defer w.asyncWork.Done()
+		normalExit := false
 		defer func() {
+			if normalExit {
+				return
+			}
 			w.reconcileMu.Lock()
 			w.reconcilePending = false
 			w.reconcileMu.Unlock()
 		}()
 		defer w.guardWatcherPanic("overflow-reconcile")
-		if fn != nil {
-			fn()
-			return
-		}
-		var err error
-		if w.batchReindex != nil {
-			_, err = w.batchReindex(nil)
-		} else {
-			_, err = w.indexer.IncrementalReindexPaths(w.indexer.rootPath, nil)
-		}
-		if err != nil && w.logger != nil {
-			w.logger.Warn("watcher: overflow reconcile failed",
-				zap.String("reason", reason),
-				zap.Error(err))
+
+		for {
+			w.reconcileMu.Lock()
+			generation := w.reconcileGeneration
+			fn := w.reconcileFn
+			w.reconcileMu.Unlock()
+
+			var err error
+			if fn != nil {
+				fn()
+			} else if w.batchReindex != nil {
+				_, err = w.batchReindex(nil)
+			} else {
+				_, err = w.indexer.IncrementalReindexPaths(w.indexer.rootPath, nil)
+			}
+			if err != nil && w.logger != nil {
+				w.logger.Warn("watcher: overflow reconcile failed",
+					zap.String("reason", reason),
+					zap.Error(err))
+			}
+
+			w.reconcileMu.Lock()
+			if w.reconcileGeneration == generation {
+				w.reconcilePending = false
+				normalExit = true
+				w.reconcileMu.Unlock()
+				return
+			}
+			w.reconcileMu.Unlock()
 		}
 	}()
 }
@@ -1189,23 +1322,37 @@ func (w *Watcher) runDirScan(dirs map[string]struct{}, fn func(map[string]struct
 		fn(dirs)
 		return
 	}
-	if len(dirs) > dirScanEscalateCap {
+
+	paths := make([]string, 0, len(dirs))
+	full := len(dirs) > dirScanEscalateCap
+	if full {
 		if w.logger != nil {
 			w.logger.Info("watcher: large new-directory burst — full-tree discovery",
 				zap.Int("dirs", len(dirs)), zap.String("root", w.indexer.rootPath))
 		}
-		if _, err := w.indexer.incrementalDiscoverPaths(w.indexer.rootPath, nil); err != nil && w.logger != nil {
-			w.logger.Warn("watcher: new-directory discovery failed", zap.Error(err))
+	} else {
+		for dir := range dirs {
+			paths = append(paths, dir)
 		}
-		return
+		sort.Strings(paths)
 	}
-	paths := make([]string, 0, len(dirs))
-	for d := range dirs {
-		paths = append(paths, d)
+
+	discoveryPaths := paths
+	if full {
+		discoveryPaths = nil
 	}
-	if _, err := w.indexer.incrementalDiscoverPaths(w.indexer.rootPath, paths); err != nil && w.logger != nil {
-		w.logger.Warn("watcher: new-directory scan failed",
-			zap.Strings("dirs", paths), zap.Error(err))
+	var err error
+	if w.discoverReindex != nil {
+		_, err = w.discoverReindex(discoveryPaths)
+	} else {
+		err = w.indexer.coordinateRepositoryMutation(context.Background(), func() error {
+			_, rawErr := w.indexer.incrementalDiscoverWatcherPaths(w.indexer.rootPath, discoveryPaths)
+			return rawErr
+		})
+	}
+	if err != nil && w.logger != nil {
+		w.logger.Warn("watcher: new-directory discovery failed",
+			zap.Strings("dirs", paths), zap.Bool("full", full), zap.Error(err))
 	}
 }
 
@@ -1633,14 +1780,13 @@ func (w *Watcher) drainStorm() {
 		w.completeStormMutationWaiters(generations, nil, errMutationPatchAborted)
 		return
 	}
-	// A pending point patch may already have left the debounce queue when storm
-	// mode took over, and the adaptive poller enters patchGraph directly. Keep
-	// the batch's snapshot/mutation boundary serialized with both producers.
+	// Point patches and the batch runner now meet at the repository lane. Keep
+	// the test hook at that admission boundary, but never take patchMu before a
+	// coordinated batch: point work acquires the repository lane first and
+	// nested lock ordering here would deadlock.
 	if w.stormBeforeLock != nil {
 		w.stormBeforeLock()
 	}
-	w.patchMu.Lock()
-	defer w.patchMu.Unlock()
 	var result *IndexResult
 	completionErr := errMutationPatchAborted
 	defer func() {
@@ -1654,23 +1800,12 @@ func (w *Watcher) drainStorm() {
 
 	start := time.Now()
 	w.logger.Info("watcher: storm drain starting", zap.Int("paths", len(paths)))
-	finishTopologyMutation := reach.BeginTopologyMutation(w.indexer.graph)
-	mutationFinished := false
-	defer func() {
-		if !mutationFinished {
-			// The batch is non-empty and may have partially applied before a
-			// panic. Invalidate conservatively before unblocking readers.
-			finishTopologyMutation(true)
-		}
-	}()
 
+	// reindexStormPaths enters the repository coordinator; its raw executor
+	// acquires the topology gate only after the repository lane is held.
 	var err error
 	result, err = w.reindexStormPaths(paths)
 	completionErr = err
-	// A batch-level error can arrive after sibling files committed. Invalidate
-	// conservatively and report it without retrying every path one-by-one.
-	finishTopologyMutation(true)
-	mutationFinished = true
 
 	reindexed, deleted, failed := 0, 0, 0
 	if result != nil {
@@ -1801,26 +1936,6 @@ func (w *Watcher) reconcileKindWithDisk(path string, kind ChangeKind) ChangeKind
 	return kind
 }
 
-// forgetDeletedFileMtime drops a just-evicted file's recorded mtime from
-// both the in-memory map and the store's FileMtime sidecar. EvictFile
-// removes the file's nodes but leaves its mtime behind, so without this the
-// persisted mtime row outlives the file: the next warm restart reads it
-// back, finds the path gone from disk, and treats it as a phantom deletion
-// — re-running a scoped reconcile for a file that is already correct on
-// every boot. Mirrors full-tree reconciliation's deletion handling: prune the
-// in-memory map first (pruneDeletedFileMtimes documents that its caller has
-// already done so, and a later snapshot persist would otherwise resurrect
-// the row from the stale in-memory entry), then the store, which self-skips
-// on a backend without the FileMtimeDeleter capability. relPath must be the
-// canonical relKey the mtime map and store are keyed on — the same key
-// EvictFile evicted the file's nodes under.
-func (w *Watcher) forgetDeletedFileMtime(relPath string) {
-	w.indexer.mtimeMu.Lock()
-	delete(w.indexer.fileMtimes, relPath)
-	w.indexer.mtimeMu.Unlock()
-	w.indexer.pruneDeletedFileMtimes([]string{relPath})
-}
-
 func (w *Watcher) generationCurrent(path string, generation uint64) bool {
 	if generation == 0 {
 		return true
@@ -1862,272 +1977,169 @@ func (w *Watcher) patchGraphWithReceiptState(path string, kind ChangeKind, gener
 		return errMutationSuperseded
 	}
 	defer w.finishGeneration(path, generation)
+
+	var pending symbolChangeNotification
+	// w.indexer carries the stable lane installed when this watcher was
+	// created. Select the registered Indexer only after admission, because an
+	// IndexRepo replacement uses the same lane and cannot change underneath
+	// the raw patch.
+	err := w.indexer.coordinateRepositoryMutation(context.Background(), func() error {
+		idx := w.currentMutationIndexer()
+		if idx == nil {
+			return errWatcherIndexerMissing
+		}
+		return w.patchGraphWithReceiptStateRawModern(idx, path, kind, generation, receiptChecked, &pending)
+	})
+	// User callbacks are deliberately outside the repository lane. Their
+	// payload was copied while the graph mutation still owned the lane.
+	pending.dispatch()
+	return err
+}
+
+func pointMutationClassification(
+	kind ChangeKind,
+	plan DerivedInvalidationPlan,
+	prior, fresh fileDeltaFingerprints,
+) string {
+	if kind == ChangeDeleted || kind == ChangeRenamed {
+		return "structural"
+	}
+	switch {
+	case plan.InertFiles > 0:
+		return "inert"
+	case plan.MetadataOnlyFiles > 0:
+		return "metadata_only"
+	case prior.core != "" && fresh.core != "" && prior.core == fresh.core:
+		return "artifact_only"
+	default:
+		return "structural"
+	}
+}
+
+// reindexPointPathRaw runs after the caller has acquired the repository lane.
+// MultiWatcher supplies the cross-repository resolver and derived tail; a
+// standalone Watcher falls back to the equivalent single-repository tail.
+func (w *Watcher) reindexPointPathRaw(idx *Indexer, path string) (*IndexResult, error) {
+	if w.pointReindexRaw != nil {
+		return w.pointReindexRaw(path)
+	}
+	if idx == nil || idx.rootPath == "" {
+		return nil, errWatcherIndexerMissing
+	}
+	return idx.incrementalPointWatcherPath(idx.rootPath, path)
+}
+
+// patchGraphWithReceiptStateRawModern replaces the historical hand-built point
+// patch with the same receipt, resolver, and exact derived-invalidation pipeline
+// used by bounded reconciliation. The caller already owns the repository lane.
+func (w *Watcher) patchGraphWithReceiptStateRawModern(
+	idx *Indexer,
+	path string,
+	kind ChangeKind,
+	generation uint64,
+	receiptChecked bool,
+	pending *symbolChangeNotification,
+) error {
+	if !w.generationCurrent(path, generation) {
+		return errMutationSuperseded
+	}
 	w.patchMu.Lock()
 	defer w.patchMu.Unlock()
 	if !w.generationCurrent(path, generation) {
 		return errMutationSuperseded
 	}
-	// A replace/revert (rename-over or unlink+recreate) reaches us as a
-	// delete/rename even though a file is right back at the same path;
-	// reconcile against disk so it takes the parse-then-swap + incoming-
-	// rebind modify path instead of a hard evict that would silently zero
-	// the definition's callers. A vanished create/modify becomes a delete.
-	kind = w.reconcileKindWithDisk(path, kind)
+
 	start := time.Now()
-	classification := "structural"
-	var nodesAdded, nodesRemoved, edgesAdded, edgesRemoved int
-	var finishTopologyMutation func(bool)
-	topologyChanged := false
-	// Keep a panic/error-safe release so no lookup can remain parked behind the
-	// reach topology gate if an incremental path exits early.
-	defer func() {
-		if finishTopologyMutation != nil {
-			finishTopologyMutation(topologyChanged)
-		}
-	}()
-	beginTopologyMutation := func() {
-		finishTopologyMutation = reach.BeginTopologyMutation(w.indexer.graph)
-		// Conservatively invalidate after every structural reindex attempt. Most
-		// parse failures leave the old graph untouched, but treating that as a
-		// cache miss is safer than trusting count-based telemetry to prove no
-		// resolver edge was retargeted.
-		topologyChanged = true
-	}
-	endTopologyMutation := func() {
-		if finishTopologyMutation == nil {
-			return
-		}
-		finishTopologyMutation(topologyChanged)
-		finishTopologyMutation = nil
+	kind = w.reconcileKindWithDisk(path, kind)
+	// This is the identity duplicate gate for native watcher events. A Darwin
+	// startup replay already checked the persisted receipt, so it bypasses this
+	// cheap in-memory mtime test and forces the exact observed path.
+	if kind == ChangeModified && !receiptChecked && idx.fileMtimeMatches(path) {
+		return nil
 	}
 
-	// Two keys for this file. relPath (RelKey: slash form + NFC) is the
-	// mtime-forget / change-callback key. graphKey (graphRelKey:
-	// OS-native separators + NFC, repo-prefixed) is what the graph
-	// stores the file's nodes under, so the GetFileNodes /
-	// snapshotSymbols lookups below MUST use it — a slash-form key
-	// misses the backslash-keyed nodes on Windows and would report every
-	// symbol as added/removed. Both fold an NFD (macOS) event path to
-	// NFC so a non-ASCII name still hits the indexed node. On POSIX the
-	// two keys coincide.
-	relPath := path
-	graphKey := path
-	if w.indexer.rootPath != "" {
-		relPath = w.indexer.RelKey(path)
-		graphKey = w.indexer.prefixPath(w.indexer.graphRelKey(path))
+	relPath := idx.graphRelKey(path)
+	callbackPath := idx.RelKey(path)
+	graphKey := idx.prefixPath(relPath)
+	priorNodes := idx.graph.GetFileNodes(graphKey)
+	priorFingerprint := storedExtractionGraphFingerprints(priorNodes)
+	priorEdges := w.countFileEdges(priorNodes)
+	priorResolved := 0
+	var priorIncoming map[string]int
+	if kind == ChangeModified {
+		priorResolved = w.countResolvedFileEdges(priorNodes)
+		priorIncoming = w.resolvedIncomingByNode(priorNodes)
+	}
+	// Freeze the before-image while the lane still owns the pre-mutation graph.
+	// Metadata-only refreshes may reuse and mutate the graph-owned node objects.
+	oldSymbols := cloneSymbolChangeNodes(callbackSymbols(priorNodes))
+
+	result, err := w.reindexPointPathRaw(idx, path)
+	if err != nil {
+		return err
+	}
+	if !w.generationCurrent(path, generation) {
+		return errMutationSuperseded
+	}
+	if result == nil {
+		return errors.New("watcher: exact-path reindex returned no result")
+	}
+	if len(result.FailedFiles) > 0 {
+		return fmt.Errorf("watcher: exact-path reindex failed for %s", strings.Join(result.FailedFiles, ", "))
+	}
+	// A second absent-file notification reaches a graph with neither source
+	// rows nor sidecar ownership. It is an identity duplicate, not a deletion.
+	if result.StaleFileCount == 0 && result.DeletedFileCount == 0 {
+		return nil
 	}
 
-	switch kind {
-	case ChangeCreated:
-		beginTopologyMutation()
-		if err := w.indexer.IndexFile(path); err != nil {
-			w.logger.Warn("index file failed", zap.String("path", path), zap.Error(err))
-			return err
-		}
-		newSymbols := w.indexer.graph.GetFileNodes(graphKey)
-		nodesAdded = len(newSymbols)
-		edgesAdded = w.countFileEdges(newSymbols)
-		endTopologyMutation()
-
-		// Notify callback: no old symbols, only new symbols.
-		w.symbolChangeCbMu.RLock()
-		cb := w.symbolChangeCb
-		w.symbolChangeCbMu.RUnlock()
-		if cb != nil {
-			cb(relPath, nil, newSymbols)
-		}
-
-	case ChangeModified:
-		// Native backends and the adaptive poller deliberately overlap. A late
-		// startup replay or duplicate report can therefore arrive after the file
-		// is already committed. Mtime is only the fast receipt gate: equal values
-		// are confirmed against the persisted content hash, so a timestamp-
-		// preserving real edit still enters the normal mutation lifecycle.
-		if !receiptChecked && w.indexer.fileMtimeMatches(path) {
-			return nil
-		}
-		// Read the prior file state once. It supplies the callback snapshot,
-		// gross change telemetry and the durable raw-extraction fingerprint;
-		// repeating GetFileNodes here is particularly costly when SQLite is
-		// under analysis load.
-		snapshotStarted := time.Now()
-		priorNodes := w.indexer.graph.GetFileNodes(graphKey)
-		oldSymbols := make([]*graph.Node, 0, len(priorNodes))
-		for _, n := range priorNodes {
-			if n == nil || n.Kind == graph.KindFile || n.Kind == graph.KindImport {
-				continue
-			}
-			cp := &graph.Node{ID: n.ID, Kind: n.Kind, Name: n.Name, QualName: n.QualName, FilePath: n.FilePath}
-			if sig, ok := n.Meta["signature"]; ok {
-				cp.Meta = map[string]any{"signature": sig}
-			}
-			oldSymbols = append(oldSymbols, cp)
-		}
-		snapshotDuration := time.Since(snapshotStarted)
-
-		// Parse once and compare the complete post-coverage extraction, not
-		// only declarations. A changed call target, doc, TODO, location,
-		// metadata field or edge changes this fingerprint and must patch the
-		// graph. Only a byte-for-byte-equivalent graph output is inert. The
-		// prepared extraction is consumed by IndexFile below, avoiding the old
-		// double parse on structural edits.
-		probe, probeOK := w.indexer.prepareFileDelta(path)
-		if !w.generationCurrent(path, generation) {
-			w.indexer.discardPreparedExtraction(path)
-			return errMutationSuperseded
-		}
-		stored := storedExtractionGraphFingerprints(priorNodes)
-		classification := "structural"
-		if probeOK && stored.semantic != "" {
-			switch {
-			case probe.fingerprints.semantic == stored.semantic && probe.fingerprints.metadata == stored.metadata:
-				w.indexer.discardPreparedExtraction(path)
-				w.logger.Info("watcher: inert delta phases",
-					zap.String("file", path), zap.String("delta_class", "inert"),
-					zap.Duration("snapshot", snapshotDuration), zap.Duration("read", probe.read),
-					zap.Duration("extract", probe.extract), zap.Duration("coverage", probe.coverage),
-					zap.Duration("fingerprint", probe.fingerprintTime))
-				fresh := w.recordInertModify(path, relPath, oldSymbols, start, probe.readVersion)
-				if !fresh {
-					return errFileVersionChanged
-				}
-				return nil
-			case probe.fingerprints.semantic == stored.semantic:
-				var refreshed []*graph.Node
-				var applied, fresh bool
-				if generation == 0 {
-					refreshed, applied, fresh = w.indexer.applyPreparedMetadataRefresh(path, priorNodes)
-				} else {
-					// Serialise generation validation with the bounded commit. A newer
-					// event cannot register between the byte check and fingerprint/mtime write.
-					w.mu.Lock()
-					if w.pendingGeneration[path] == generation {
-						refreshed, applied, fresh = w.indexer.applyPreparedMetadataRefresh(path, priorNodes)
-					}
-					w.mu.Unlock()
-				}
-				if applied {
-					w.logger.Info("watcher: metadata-only delta phases",
-						zap.String("file", path), zap.String("delta_class", "metadata_only"),
-						zap.Duration("snapshot", snapshotDuration), zap.Duration("read", probe.read),
-						zap.Duration("extract", probe.extract), zap.Duration("coverage", probe.coverage),
-						zap.Duration("fingerprint", probe.fingerprintTime))
-					w.recordMetadataModify(path, relPath, oldSymbols, refreshed, start)
-					if !fresh {
-						return errFileVersionChanged
-					}
-					return nil
-				}
-			case stored.core != "" && probe.fingerprints.core == stored.core:
-				classification = "artifact_only"
-			}
-		}
-
-		// Do NOT pre-evict. IndexFile parse-then-swaps internally and consumes
-		// the prepared extraction when its transformed bytes still match.
-		reindexStarted := time.Now()
-		fileEdgesBefore := w.countFileEdges(priorNodes)
-		resolvedBefore := w.countResolvedFileEdges(priorNodes)
-		incomingBeforeByID := w.resolvedIncomingByNode(priorNodes)
-		beginTopologyMutation()
-		if err := w.indexer.IndexFile(path); err != nil {
-			w.logger.Warn("reindex file failed", zap.String("path", path), zap.Error(err))
-			return err
-		}
-		nodesRemoved = len(priorNodes)
-		newSymbols := w.indexer.graph.GetFileNodes(graphKey)
-		nodesAdded = len(newSymbols)
-		// Edge churn scoped to this file's nodes. A graph-wide
-		// EdgeCount delta would also pick up edges landed by whatever
-		// else mutates the graph during this patch (concurrent
-		// reconciles, deferred passes), which made the edges+ figure
-		// meaningless noise on a busy daemon.
-		if fileEdgesAfter := w.countFileEdges(newSymbols); fileEdgesAfter >= fileEdgesBefore {
-			edgesAdded = fileEdgesAfter - fileEdgesBefore
-		} else {
-			edgesRemoved = fileEdgesBefore - fileEdgesAfter
-		}
-		// Shape-degradation guard: a modify that kept its symbols but lost
-		// most of its resolved edges is a transient resolution failure, not a
-		// real deletion — flag it and enqueue a forced scoped re-resolve so it
-		// self-heals instead of persisting the degraded shape.
-		incomingBefore, incomingAfter := w.incomingRegressionForSurvivors(incomingBeforeByID, newSymbols)
-		w.guardResolvedEdgeRegression(path, len(priorNodes), len(newSymbols), resolvedBefore, w.countResolvedFileEdges(newSymbols), incomingBefore, incomingAfter)
-		endTopologyMutation()
-		w.logger.Info("watcher: structural delta phases",
-			zap.String("file", path),
-			zap.String("delta_class", classification),
-			zap.Duration("snapshot", snapshotDuration),
-			zap.Duration("read", probe.read),
-			zap.Duration("extract", probe.extract),
-			zap.Duration("coverage", probe.coverage),
-			zap.Duration("fingerprint", probe.fingerprintTime),
-			zap.Duration("reindex", time.Since(reindexStarted)),
-			zap.Bool("probe_complete", probeOK),
-			zap.Bool("clone_pending", w.indexer.CloneIndexPending()))
-
-		// Notify callback with old and new symbols.
-		w.symbolChangeCbMu.RLock()
-		cb := w.symbolChangeCb
-		w.symbolChangeCbMu.RUnlock()
-		if cb != nil {
-			cb(relPath, oldSymbols, newSymbols)
-		}
-
-	case ChangeDeleted, ChangeRenamed:
-		// Snapshot old symbols before eviction.
-		oldSymbols := w.snapshotSymbols(graphKey)
-
-		beginTopologyMutation()
-		nr, er := w.indexer.EvictFile(path)
-		nodesRemoved = nr
-		edgesRemoved = er
-		topologyChanged = nr > 0 || er > 0
-		endTopologyMutation()
-
-		// The file is genuinely gone from disk here — reconcileKindWithDisk
-		// already downgraded a replace/revert (path still present) to
-		// ChangeModified. Drop its now-orphaned mtime so a warm restart does
-		// not re-discover the vanished path as a phantom deletion. relPath is
-		// the canonical relKey EvictFile evicted under.
-		w.forgetDeletedFileMtime(relPath)
-		// fsnotify and the adaptive poller are deliberately redundant. They
-		// may both report the same deletion, but only the producer that
-		// actually removed graph topology represents a semantic change. Do
-		// not publish a second empty callback/history/event: consumers would
-		// otherwise lose the pre-delete symbol snapshot or repeat downstream
-		// invalidation work. EvictFile's zero delta is authoritative even for
-		// source files that contain no symbols of their own.
-		if nr == 0 && er == 0 {
-			return nil
-		}
-
-		// Notify callback: old symbols removed, no new symbols.
-		w.symbolChangeCbMu.RLock()
-		cb := w.symbolChangeCb
-		w.symbolChangeCbMu.RUnlock()
-		if cb != nil {
-			cb(relPath, oldSymbols, nil)
-		}
-	}
+	freshNodes := idx.graph.GetFileNodes(graphKey)
+	freshFingerprint := storedExtractionGraphFingerprints(freshNodes)
+	classification := pointMutationClassification(kind, result.DerivedInvalidation, priorFingerprint, freshFingerprint)
+	freshEdges := w.countFileEdges(freshNodes)
 
 	ev := GraphChangeEvent{
 		FilePath:       path,
 		Kind:           kind,
 		Classification: classification,
-		NodesAdded:     nodesAdded,
-		NodesRemoved:   nodesRemoved,
-		EdgesAdded:     edgesAdded,
-		EdgesRemoved:   edgesRemoved,
 		Timestamp:      time.Now(),
 		DurationMs:     time.Since(start).Milliseconds(),
 	}
-
-	// Reach invalidation is published by endTopologyMutation before any
-	// callbacks or events can observe the new graph. The topology gate spans
-	// IndexFile's parse-then-swap and nested resolver work without taking the
-	// resolver's non-reentrant mutex twice; impact readers therefore see the
-	// complete old graph or the complete new graph, never the eviction gap.
+	switch kind {
+	case ChangeCreated:
+		ev.NodesAdded = len(freshNodes)
+		ev.EdgesAdded = freshEdges
+		w.captureSymbolChange(pending, callbackPath, nil, callbackSymbols(freshNodes))
+	case ChangeModified:
+		if classification == "structural" || classification == "artifact_only" {
+			ev.NodesRemoved = len(priorNodes)
+			ev.NodesAdded = len(freshNodes)
+			if freshEdges >= priorEdges {
+				ev.EdgesAdded = freshEdges - priorEdges
+			} else {
+				ev.EdgesRemoved = priorEdges - freshEdges
+			}
+			incomingBefore, incomingAfter := w.incomingRegressionForSurvivors(priorIncoming, freshNodes)
+			w.guardResolvedEdgeRegression(
+				path,
+				len(priorNodes),
+				len(freshNodes),
+				priorResolved,
+				w.countResolvedFileEdges(freshNodes),
+				incomingBefore,
+				incomingAfter,
+			)
+		}
+		if classification == "inert" {
+			w.captureSymbolChange(pending, callbackPath, oldSymbols, oldSymbols)
+		} else {
+			w.captureSymbolChange(pending, callbackPath, oldSymbols, callbackSymbols(freshNodes))
+		}
+	case ChangeDeleted, ChangeRenamed:
+		ev.NodesRemoved = len(priorNodes)
+		ev.EdgesRemoved = priorEdges
+		w.captureSymbolChange(pending, callbackPath, oldSymbols, nil)
+	}
 
 	w.historyMu.Lock()
 	w.history = append(w.history, ev)
@@ -2135,22 +2147,17 @@ func (w *Watcher) patchGraphWithReceiptState(path string, kind ChangeKind, gener
 		w.history = w.history[len(w.history)-maxHistory:]
 	}
 	w.historyMu.Unlock()
-
-	// Non-blocking send.
 	select {
 	case w.events <- ev:
 	default:
 	}
-
-	w.logger.Info("graph patch",
-		zap.String("kind", string(kind)),
-		zap.String("file", path),
-		zap.Int("nodes+", nodesAdded),
-		zap.Int("nodes-", nodesRemoved),
-		zap.Int("edges+", edgesAdded),
-		zap.Int("edges-", edgesRemoved),
-		zap.Int64("ms", ev.DurationMs),
-	)
+	if w.logger != nil {
+		w.logger.Info("graph patch complete",
+			zap.String("file", path),
+			zap.String("kind", string(kind)),
+			zap.String("delta_class", classification),
+			zap.Int64("ms", ev.DurationMs))
+	}
 	return nil
 }
 
@@ -2159,7 +2166,8 @@ func (w *Watcher) patchGraphWithReceiptState(path string, kind ChangeKind, gener
 // (an intra-file edge is already counted on its From side). Batched
 // so a disk backend pays two bulk lookups instead of 2N point queries.
 func (w *Watcher) countFileEdges(nodes []*graph.Node) int {
-	if len(nodes) == 0 {
+	idx := w.currentMutationIndexer()
+	if idx == nil || len(nodes) == 0 {
 		return 0
 	}
 	ids := make([]string, 0, len(nodes))
@@ -2169,10 +2177,10 @@ func (w *Watcher) countFileEdges(nodes []*graph.Node) int {
 		inFile[n.ID] = struct{}{}
 	}
 	total := 0
-	for _, edges := range w.indexer.graph.GetOutEdgesByNodeIDs(ids) {
+	for _, edges := range idx.graph.GetOutEdgesByNodeIDs(ids) {
 		total += len(edges)
 	}
-	for _, edges := range w.indexer.graph.GetInEdgesByNodeIDs(ids) {
+	for _, edges := range idx.graph.GetInEdgesByNodeIDs(ids) {
 		for _, e := range edges {
 			if _, ok := inFile[e.From]; !ok {
 				total++
@@ -2194,7 +2202,8 @@ const resolvedEdgeRegressionFloor = 4
 // cannot give: an edge demoted from a resolved target to a stub keeps the total
 // incident-edge count identical while losing a resolution.
 func (w *Watcher) countResolvedFileEdges(nodes []*graph.Node) int {
-	if len(nodes) == 0 {
+	idx := w.currentMutationIndexer()
+	if idx == nil || len(nodes) == 0 {
 		return 0
 	}
 	ids := make([]string, 0, len(nodes))
@@ -2202,7 +2211,7 @@ func (w *Watcher) countResolvedFileEdges(nodes []*graph.Node) int {
 		ids = append(ids, n.ID)
 	}
 	total := 0
-	for _, edges := range w.indexer.graph.GetOutEdgesByNodeIDs(ids) {
+	for _, edges := range idx.graph.GetOutEdgesByNodeIDs(ids) {
 		for _, e := range edges {
 			if e != nil && !graph.IsUnresolvedTarget(e.To) {
 				total++
@@ -2262,7 +2271,8 @@ func (w *Watcher) guardResolvedEdgeRegression(path string, nodesBefore, nodesAft
 // — this is the signal that catches an external revert zeroing a surviving
 // symbol's usages.
 func (w *Watcher) resolvedIncomingByNode(nodes []*graph.Node) map[string]int {
-	if len(nodes) == 0 {
+	idx := w.currentMutationIndexer()
+	if idx == nil || len(nodes) == 0 {
 		return nil
 	}
 	ids := make([]string, 0, len(nodes))
@@ -2275,7 +2285,7 @@ func (w *Watcher) resolvedIncomingByNode(nodes []*graph.Node) map[string]int {
 		return nil
 	}
 	byNode := make(map[string]int, len(ids))
-	for id, edges := range w.indexer.graph.GetInEdgesByNodeIDs(ids) {
+	for id, edges := range idx.graph.GetInEdgesByNodeIDs(ids) {
 		c := 0
 		for _, e := range edges {
 			if e != nil && graph.IsResolvableRefEdge(e.Kind) {
@@ -2354,83 +2364,54 @@ func (w *Watcher) enqueueReresolve(path string) {
 					fn(files)
 					return
 				}
-				for p := range files {
-					if err := w.indexer.ReresolveFileScoped(p); err != nil && w.logger != nil {
-						w.logger.Warn("watcher: forced scoped re-resolve failed",
-							zap.String("file", p), zap.Error(err))
+				paths := make([]string, 0, len(files))
+				for path := range files {
+					paths = append(paths, path)
+				}
+				sort.Strings(paths)
+				// Admit on the watcher's stable lane, then resolve the current
+				// registered Indexer. IndexRepo replacement cannot interleave
+				// between that lookup and the scoped re-resolve loop.
+				err := w.indexer.coordinateRepositoryMutation(context.Background(), func() error {
+					idx := w.currentMutationIndexer()
+					if idx == nil {
+						return errWatcherIndexerMissing
 					}
+					for _, path := range paths {
+						if err := idx.reresolveFileScopedRaw(path); err != nil && w.logger != nil {
+							w.logger.Warn("watcher: forced scoped re-resolve failed",
+								zap.String("file", path), zap.Error(err))
+						}
+					}
+					return nil
+				})
+				if err != nil && w.logger != nil {
+					w.logger.Warn("watcher: forced scoped re-resolve admission failed", zap.Error(err))
 				}
 			}()
 		}
 	}()
 }
 
-// recordInertModify finishes a ChangeModified patch that the
-// content-aware skip proved structurally inert. The graph already
-// holds the correct symbols, so the destructive evict + reindex is
-// skipped; this records the bookkeeping the skipped path would
-// otherwise have produced:
-//
-//   - the indexer's recorded mtime is restamped so the adaptive
-//     poller's mtime sweep does not keep re-flagging the file;
-//   - a zero-delta GraphChangeEvent is appended to history and
-//     published, so get_recent_changes still shows the save (with
-//     all node/edge counts zero — nothing structural moved);
-//   - the symbol-change callback fires with the unchanged symbol set
-//     on both sides, mirroring the no-op so consumers see a
-//     consistent before == after.
-//
-// The reachability index is intentionally not rebuilt — the topology
-// did not change, so the existing reach stamps stay valid.
-func (w *Watcher) recordInertModify(path, relPath string, symbols []*graph.Node, start time.Time, version fileReadVersion) bool {
-	// Claim only the exact byte version whose fingerprints were compared. A
-	// later write must stay dirty for the next poll/native event even though the
-	// earlier, real save still owns this inert event and callback.
-	fresh := w.indexer.recordFileReadVersion(relPath, path, version)
-	w.recordNonStructuralModify(path, relPath, symbols, symbols, "inert", start)
-	return fresh
-}
-
-func (w *Watcher) recordMetadataModify(path, relPath string, oldSymbols, refreshed []*graph.Node, start time.Time) {
-	newSymbols := make([]*graph.Node, 0, len(refreshed))
-	for _, node := range refreshed {
+func callbackSymbols(nodes []*graph.Node) []*graph.Node {
+	symbols := make([]*graph.Node, 0, len(nodes))
+	for _, node := range nodes {
 		if node == nil || node.Kind == graph.KindFile || node.Kind == graph.KindImport {
 			continue
 		}
-		newSymbols = append(newSymbols, node)
+		symbols = append(symbols, node)
 	}
-	w.recordNonStructuralModify(path, relPath, oldSymbols, newSymbols, "metadata_only", start)
-}
-
-func (w *Watcher) recordNonStructuralModify(path, relPath string, oldSymbols, newSymbols []*graph.Node, classification string, start time.Time) {
-	ev := GraphChangeEvent{
-		FilePath: path, Kind: ChangeModified, Classification: classification,
-		Timestamp: time.Now(), DurationMs: time.Since(start).Milliseconds(),
-	}
-	w.historyMu.Lock()
-	w.history = append(w.history, ev)
-	if len(w.history) > maxHistory {
-		w.history = w.history[len(w.history)-maxHistory:]
-	}
-	w.historyMu.Unlock()
-	select {
-	case w.events <- ev:
-	default:
-	}
-	w.symbolChangeCbMu.RLock()
-	cb := w.symbolChangeCb
-	w.symbolChangeCbMu.RUnlock()
-	if cb != nil {
-		cb(relPath, oldSymbols, newSymbols)
-	}
-	w.logger.Info("graph patch: non-structural change",
-		zap.String("file", path), zap.String("delta_class", classification), zap.Int64("ms", ev.DurationMs))
+	return symbols
 }
 
 // snapshotSymbols returns a deep copy of the symbols for a file, preserving
 // their signatures in Meta so they can be compared after re-indexing.
 func (w *Watcher) snapshotSymbols(graphKey string) []*graph.Node {
-	nodes := w.indexer.graph.GetFileNodes(graphKey)
+	idx := w.currentMutationIndexer()
+	if idx == nil {
+		return nil
+	}
+	nodes := idx.graph.GetFileNodes(graphKey)
 	snapshot := make([]*graph.Node, 0, len(nodes))
 	for _, n := range nodes {
 		// Skip file and import nodes — we only track code symbols.

--- a/internal/indexer/watcher_coordinator_boundary_test.go
+++ b/internal/indexer/watcher_coordinator_boundary_test.go
@@ -1,0 +1,120 @@
+package indexer
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+func watcherBoundaryTestIndexer(t *testing.T, store graph.Store, root, prefix string) *Indexer {
+	t.Helper()
+	registry := parser.NewRegistry()
+	registry.Register(languages.NewGoExtractor())
+	cfg := config.Default()
+	cfg.Index.Workers = 1
+	idx := New(store, registry, cfg.Index, zap.NewNop())
+	idx.SetRepoPrefix(prefix)
+	_, err := idx.Index(root)
+	require.NoError(t, err)
+	return idx
+}
+
+func TestWatcher_SymbolChangeCallbackRunsAfterRepositoryLaneRelease(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.go")
+	writeTestFile(t, path, "package main\n\nfunc Original() {}\n")
+
+	idx := watcherBoundaryTestIndexer(t, graph.New(), dir, "")
+	watcher, err := NewWatcher(idx, config.WatchConfig{DebounceMs: 10}, zap.NewNop())
+	require.NoError(t, err)
+
+	var callbackOld, callbackNew []*graph.Node
+	callbackResult := make(chan error, 1)
+	watcher.OnSymbolChange(func(_ string, oldSymbols, newSymbols []*graph.Node) {
+		callbackOld = oldSymbols
+		callbackNew = newSymbols
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		callbackResult <- idx.coordinateRepositoryMutation(ctx, func() error { return nil })
+	})
+
+	writeTestFile(t, path, "package main\n\nfunc Modified() {}\n")
+	require.NoError(t, watcher.patchGraph(path, ChangeModified))
+	select {
+	case err := <-callbackResult:
+		require.NoError(t, err, "callback must be able to re-enter the repository lane")
+	case <-time.After(2 * time.Second):
+		t.Fatal("symbol callback did not complete")
+	}
+
+	oldNames := make([]string, 0, len(callbackOld))
+	for _, node := range callbackOld {
+		oldNames = append(oldNames, node.Name)
+	}
+	newNames := make([]string, 0, len(callbackNew))
+	for _, node := range callbackNew {
+		if node.Kind != graph.KindFile && node.Kind != graph.KindImport {
+			newNames = append(newNames, node.Name)
+		}
+	}
+	assert.Contains(t, oldNames, "Original")
+	assert.Contains(t, newNames, "Modified")
+
+	liveByID := make(map[string]*graph.Node)
+	for _, node := range idx.graph.GetFileNodes("main.go") {
+		liveByID[node.ID] = node
+	}
+	for _, callbackNode := range callbackNew {
+		if live := liveByID[callbackNode.ID]; live != nil {
+			assert.NotSame(t, live, callbackNode, "callback payload must not alias graph-owned nodes")
+		}
+	}
+}
+
+func TestMultiWatcher_PointPatchUsesCurrentIndexerAfterReplacement(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.go")
+	writeTestFile(t, path, "package main\n\nfunc Original() {}\n")
+
+	const prefix = "repo"
+	oldGraph := graph.New()
+	oldIndexer := watcherBoundaryTestIndexer(t, oldGraph, dir, prefix)
+
+	registry := parser.NewRegistry()
+	registry.Register(languages.NewGoExtractor())
+	multi := NewMultiIndexer(oldGraph, registry, nil, nil, zap.NewNop())
+	multi.repos[prefix] = &RepoMetadata{RepoPrefix: prefix, RootPath: dir}
+	multi.indexers[prefix] = oldIndexer
+
+	multiWatcher, err := NewMultiWatcher(multi, map[string]config.WatchConfig{
+		prefix: {DebounceMs: 10},
+	}, zap.NewNop())
+	require.NoError(t, err)
+	watcher := multiWatcher.watchers[prefix]
+	require.NotNil(t, watcher)
+
+	newGraph := graph.New()
+	newIndexer := watcherBoundaryTestIndexer(t, newGraph, dir, prefix)
+	newIndexer.attachRepositoryMutationCoordinator(multi.repositoryMutationCoordinator(prefix))
+	multi.mu.Lock()
+	multi.indexers[prefix] = newIndexer
+	multi.mu.Unlock()
+
+	writeTestFile(t, path, "package main\n\nfunc Modified() {}\n")
+	require.NoError(t, watcher.patchGraph(path, ChangeModified))
+
+	assert.NotEmpty(t, oldGraph.FindNodesByName("Original"), "retired Indexer graph must remain untouched")
+	assert.Empty(t, oldGraph.FindNodesByName("Modified"), "retired Indexer must not receive the point patch")
+	assert.Empty(t, newGraph.FindNodesByName("Original"))
+	assert.NotEmpty(t, newGraph.FindNodesByName("Modified"), "current registered Indexer must receive the point patch")
+}

--- a/internal/indexer/watcher_enqueue_test.go
+++ b/internal/indexer/watcher_enqueue_test.go
@@ -100,3 +100,53 @@ func TestWatcherEnqueueFileMutationUnchangedCompletesWithoutPublishing(t *testin
 	require.Empty(t, watcher.History())
 	requireNoWatcherEvent(t, watcher)
 }
+
+func TestWatcherEnqueueFileMutationWaitsForCompletePointTail(t *testing.T) {
+	dir, idx, watcher := inertTestWatcher(t, "main.go", "package main\n\nfunc value() int { return 0 }\n")
+	path := filepath.Join(dir, "main.go")
+	writeTestFile(t, path, "package main\n\nfunc value() int { return 1 }\nfunc added() {}\n")
+
+	resolveEntered := make(chan string, 1)
+	releaseResolve := make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(releaseResolve)
+		}
+	}()
+	watcher.pointReindexRaw = func(filePath string) (*IndexResult, error) {
+		result, err := idx.incrementalPointWatcherPath(idx.rootPath, filePath)
+		resolveEntered <- filePath
+		<-releaseResolve
+		return result, err
+	}
+
+	ticket, err := watcher.EnqueueFileMutation(context.Background(), path)
+	require.NoError(t, err)
+	require.NotNil(t, ticket)
+
+	select {
+	case resolvedPath := <-resolveEntered:
+		require.Equal(t, path, resolvedPath)
+	case <-time.After(2 * time.Second):
+		t.Fatal("point patch did not enter post-patch resolution")
+	}
+	select {
+	case result := <-ticket.Done:
+		t.Fatalf("mutation ticket completed before post-patch resolution: %+v", result)
+	default:
+	}
+	require.Empty(t, watcher.History(), "history must not publish before the coordinated tail")
+
+	close(releaseResolve)
+	released = true
+	select {
+	case result := <-ticket.Done:
+		require.NoError(t, result.Err)
+		require.True(t, result.Reindexed)
+		require.Equal(t, ticket.Generation, result.AppliedGeneration)
+	case <-time.After(2 * time.Second):
+		t.Fatal("mutation ticket did not complete after post-patch resolution")
+	}
+	require.Len(t, watcher.History(), 1)
+}

--- a/internal/indexer/watcher_event_ownership_test.go
+++ b/internal/indexer/watcher_event_ownership_test.go
@@ -96,11 +96,6 @@ func TestWatcherInertModifyDoesNotStampWriteAfterProbe(t *testing.T) {
 	_, err := idx.Index(dir)
 	require.NoError(t, err)
 
-	w, err := NewWatcher(idx, config.WatchConfig{DebounceMs: 1}, zap.NewNop())
-	require.NoError(t, err)
-	var callbacks int
-	w.OnSymbolChange(func(_ string, _, _ []*graph.Node) { callbacks++ })
-
 	initial := indexedFileMtime(t, idx, path)
 	firstMtime := initial.Add(time.Second)
 	secondMtime := initial.Add(2 * time.Second)
@@ -116,13 +111,9 @@ func TestWatcherInertModifyDoesNotStampWriteAfterProbe(t *testing.T) {
 	// its intentional zero-delta event/callback.
 	writeTestFile(t, path, "package main\n\nfunc Value() int { return 0 }\n\n\n")
 	require.NoError(t, os.Chtimes(path, secondMtime, secondMtime))
-	symbols := g.GetFileNodes(idx.graphRelKey(path))
-	fresh := w.recordInertModify(path, idx.relKey(path), symbols, time.Now(), probe.readVersion)
+	fresh := idx.recordFileReadVersion(idx.relKey(path), path, probe.readVersion)
 	require.False(t, fresh)
 	require.NotEqual(t, secondMtime.UnixNano(), idx.FileMtimes()[idx.relKey(path)])
-	require.Equal(t, 1, callbacks)
-	event := waitForEvent(t, w, time.Second)
-	require.Equal(t, "inert", event.Classification)
 }
 
 func watcherSymbolNames(nodes []*graph.Node) []string {

--- a/internal/indexer/watcher_point_pipeline_test.go
+++ b/internal/indexer/watcher_point_pipeline_test.go
@@ -1,0 +1,231 @@
+package indexer
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestWatcherPointPipelineForcesReceiptCheckedEqualMtime(t *testing.T) {
+	dir, idx, watcher := inertTestWatcher(t, "main.go", "package main\n\nfunc Value() int { return 0 }\n")
+	path := filepath.Join(dir, "main.go")
+	mtime := time.Unix(0, idx.FileMtimes()[idx.relKey(path)])
+
+	var callbackPath string
+	watcher.OnSymbolChange(func(filePath string, _, _ []*graph.Node) {
+		callbackPath = filePath
+	})
+	writeTestFile(t, path, "package main\n\nfunc Value() int { return 1 }\nfunc Added() {}\n")
+	require.NoError(t, os.Chtimes(path, mtime, mtime))
+
+	require.NoError(t, watcher.patchGraphAfterReceiptCheck(path, ChangeModified))
+	require.NotEmpty(t, idx.graph.FindNodesByName("Added"))
+	require.Equal(t, idx.RelKey(path), callbackPath)
+
+	event := waitForEvent(t, watcher, time.Second)
+	require.Equal(t, path, event.FilePath)
+	require.Equal(t, ChangeModified, event.Kind)
+	require.Equal(t, "structural", event.Classification)
+}
+
+func TestWatcherPointPipelineDeletesOwnedFileWithoutMtime(t *testing.T) {
+	dir, idx, watcher := inertTestWatcher(t, "main.go", "package main\n\nfunc Value() int { return 0 }\n")
+	path := filepath.Join(dir, "main.go")
+	graphPath := idx.prefixPath(idx.graphRelKey(path))
+	require.NotEmpty(t, idx.graph.GetFileNodes(graphPath))
+
+	idx.mtimeMu.Lock()
+	delete(idx.fileMtimes, idx.relKey(path))
+	idx.mtimeMu.Unlock()
+	require.NoError(t, os.Remove(path))
+
+	require.NoError(t, watcher.patchGraph(path, ChangeDeleted))
+	require.Empty(t, idx.graph.GetFileNodes(graphPath))
+	event := waitForEvent(t, watcher, time.Second)
+	require.Equal(t, ChangeDeleted, event.Kind)
+	require.Positive(t, event.NodesRemoved)
+	require.Len(t, watcher.History(), 1)
+
+	// A second absent notification has neither graph rows nor sidecar ownership
+	// and therefore is an identity duplicate rather than another deletion.
+	require.NoError(t, watcher.patchGraph(path, ChangeDeleted))
+	require.Len(t, watcher.History(), 1)
+	requireNoWatcherEvent(t, watcher)
+}
+
+func TestWatcherPointPipelineFreezesMetadataCallbackBeforeImage(t *testing.T) {
+	dir, _, watcher := inertTestWatcher(t, "main.go", "package main\n\n// old docs\nfunc Value() int { return 0 }\n")
+	path := filepath.Join(dir, "main.go")
+
+	var oldSymbols, newSymbols []*graph.Node
+	watcher.OnSymbolChange(func(_ string, oldPayload, newPayload []*graph.Node) {
+		oldSymbols = oldPayload
+		newSymbols = newPayload
+	})
+	writeTestFile(t, path, "package main\n\n// new docs\nfunc Value() int { return 0 }\n")
+	require.NoError(t, watcher.patchGraphAfterReceiptCheck(path, ChangeModified))
+
+	require.NotEmpty(t, oldSymbols)
+	require.NotEmpty(t, newSymbols)
+	require.NotSame(t, oldSymbols[0], newSymbols[0])
+	require.Contains(t, oldSymbols[0].Meta, "doc")
+	require.Equal(t, "old docs", oldSymbols[0].Meta["doc"])
+	require.Equal(t, "new docs", newSymbols[0].Meta["doc"])
+	event := waitForEvent(t, watcher, time.Second)
+	require.Equal(t, "metadata_only", event.Classification)
+}
+
+func TestMultiWatcherPointPublishesAfterCurrentRawTail(t *testing.T) {
+	const prefix = "repo"
+	root := t.TempDir()
+	path := filepath.Join(root, "main.go")
+	writeTestFile(t, path, "package main\n\nfunc Value() int { return 0 }\n")
+
+	g := graph.New()
+	oldIdx := newTestIndexer(g)
+	oldIdx.SetRepoPrefix(prefix)
+	oldIdx.SetRootPath(root)
+	_, err := oldIdx.Index(root)
+	require.NoError(t, err)
+
+	multi := NewMultiIndexer(g, newTestRegistry(), nil, nil, zap.NewNop())
+	multi.repos[prefix] = &RepoMetadata{RepoPrefix: prefix, RootPath: root}
+	multi.indexers[prefix] = oldIdx
+	mw, err := NewMultiWatcher(multi, map[string]config.WatchConfig{
+		prefix: {Enabled: false},
+	}, zap.NewNop())
+	require.NoError(t, err)
+	watcher := mw.watchers[prefix]
+	require.NotNil(t, watcher)
+
+	newIdx := newTestIndexer(g)
+	newIdx.SetRepoPrefix(prefix)
+	newIdx.SetRootPath(root)
+	newIdx.attachRepositoryMutationCoordinator(multi.repositoryMutationCoordinator(prefix))
+	multi.mu.Lock()
+	multi.indexers[prefix] = newIdx
+	multi.mu.Unlock()
+
+	oldTail := make(chan struct{}, 1)
+	oldIdx.incrementalCatchupHook = func(string, []string) {
+		select {
+		case oldTail <- struct{}{}:
+		default:
+		}
+	}
+	derivedEntered := make(chan struct{})
+	releaseDerived := make(chan struct{})
+	var derivedOnce sync.Once
+	var phasesMu sync.Mutex
+	var phases []string
+	newIdx.incrementalCatchupHook = func(phase string, _ []string) {
+		phasesMu.Lock()
+		phases = append(phases, phase)
+		phasesMu.Unlock()
+		if phase == "derived" {
+			derivedOnce.Do(func() { close(derivedEntered) })
+			<-releaseDerived
+		}
+	}
+
+	callback := make(chan string, 1)
+	watcher.OnSymbolChange(func(filePath string, _, _ []*graph.Node) {
+		callback <- filePath
+	})
+	writeTestFile(t, path, "package main\n\nfunc Value() int { return 1 }\nfunc Added() {}\n")
+	pointDone := make(chan error, 1)
+	go func() {
+		pointDone <- watcher.patchGraphAfterReceiptCheck(path, ChangeModified)
+	}()
+
+	select {
+	case <-derivedEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Multi raw point tail did not reach derived catch-up")
+	}
+	phasesMu.Lock()
+	observed := append([]string(nil), phases...)
+	phasesMu.Unlock()
+	require.Contains(t, observed, "resolve")
+	require.Contains(t, observed, "derived")
+	select {
+	case <-oldTail:
+		t.Fatal("retired Indexer executed the point tail")
+	default:
+	}
+	require.Empty(t, watcher.History(), "event history published before the Multi tail completed")
+	select {
+	case event := <-watcher.Events():
+		t.Fatalf("event published before the Multi tail completed: %+v", event)
+	default:
+	}
+	select {
+	case callbackPath := <-callback:
+		t.Fatalf("callback ran before the repository lane released: %s", callbackPath)
+	default:
+	}
+
+	close(releaseDerived)
+	select {
+	case err := <-pointDone:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("point mutation did not finish after derived catch-up")
+	}
+	require.Equal(t, newIdx.RelKey(path), <-callback)
+	event := waitForEvent(t, watcher, time.Second)
+	require.Equal(t, ChangeModified, event.Kind)
+	require.NotEmpty(t, newIdx.graph.FindNodesByName("Added"))
+}
+
+func TestPointMutationClassification(t *testing.T) {
+	tests := []struct {
+		name           string
+		kind           ChangeKind
+		plan           DerivedInvalidationPlan
+		prior          fileDeltaFingerprints
+		fresh          fileDeltaFingerprints
+		classification string
+	}{
+		{name: "inert", kind: ChangeModified, plan: DerivedInvalidationPlan{InertFiles: 1}, classification: "inert"},
+		{name: "metadata", kind: ChangeModified, plan: DerivedInvalidationPlan{MetadataOnlyFiles: 1}, classification: "metadata_only"},
+		{name: "artifact", kind: ChangeModified, prior: fileDeltaFingerprints{core: "same"}, fresh: fileDeltaFingerprints{core: "same"}, classification: "artifact_only"},
+		{name: "structural", kind: ChangeModified, prior: fileDeltaFingerprints{core: "before"}, fresh: fileDeltaFingerprints{core: "after"}, classification: "structural"},
+		{name: "delete", kind: ChangeDeleted, plan: DerivedInvalidationPlan{InertFiles: 1}, classification: "structural"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.classification, pointMutationClassification(test.kind, test.plan, test.prior, test.fresh))
+		})
+	}
+}
+
+func TestIncrementalTopologyChangedExcludesOnlySafePointPlans(t *testing.T) {
+	tests := []struct {
+		name   string
+		result *IndexResult
+		want   bool
+	}{
+		{name: "nil", result: nil, want: false},
+		{name: "inert", result: &IndexResult{StaleFileCount: 1, DerivedInvalidation: DerivedInvalidationPlan{InertFiles: 1}}, want: false},
+		{name: "metadata", result: &IndexResult{StaleFileCount: 1, DerivedInvalidation: DerivedInvalidationPlan{Files: []string{"main.go"}, MetadataOnlyFiles: 1}}, want: false},
+		{name: "metadata topology frontier", result: &IndexResult{StaleFileCount: 1, DerivedInvalidation: DerivedInvalidationPlan{Flags: DerivedInvalidationFlags(1), MetadataOnlyFiles: 1}}, want: true},
+		{name: "structural", result: &IndexResult{StaleFileCount: 1}, want: true},
+		{name: "artifact", result: &IndexResult{StaleFileCount: 1, DerivedInvalidation: DerivedInvalidationPlan{BodyOnlyFiles: 1}}, want: true},
+		{name: "delete", result: &IndexResult{DeletedFileCount: 1}, want: true},
+		{name: "full", result: &IndexResult{FullRetrack: true}, want: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, incrementalTopologyChanged(test.result))
+		})
+	}
+}

--- a/internal/indexer/watcher_storm_batch_test.go
+++ b/internal/indexer/watcher_storm_batch_test.go
@@ -135,45 +135,70 @@ func TestWatcherStormTakeoverCompletesSupersededMutationTickets(t *testing.T) {
 }
 
 func TestWatcherStormDrainWaitsForClaimedPointPatchLane(t *testing.T) {
-	idx := newTestIndexer(graph.New())
-	idx.rootPath = t.TempDir()
-	watcher, err := NewWatcher(idx, config.WatchConfig{}, zap.NewNop())
-	require.NoError(t, err)
-	path := filepath.Join(idx.rootPath, "main.go")
-	watcher.stormBatch[path] = ChangeModified
+	dir, idx, watcher := inertTestWatcher(t, "main.go", "package main\n\nfunc value() int { return 0 }\n")
+	path := filepath.Join(dir, "main.go")
+	writeTestFile(t, path, "package main\n\nfunc value() int { return 1 }\nfunc added() {}\n")
 
-	beforeLock := make(chan bool, 1)
-	watcher.stormBeforeLock = func() {
-		available := watcher.patchMu.TryLock()
-		if available {
-			watcher.patchMu.Unlock()
-		}
-		beforeLock <- available
-	}
-	batchEntered := make(chan struct{})
-	watcher.batchReindex = func([]string) (*IndexResult, error) {
-		close(batchEntered)
-		return &IndexResult{}, nil
-	}
-	done := make(chan struct{})
-
-	watcher.patchMu.Lock()
-	locked := true
+	pointTailEntered := make(chan struct{})
+	releasePoint := make(chan struct{})
+	released := false
 	defer func() {
-		if locked {
-			watcher.patchMu.Unlock()
+		if !released {
+			close(releasePoint)
 		}
 	}()
+	watcher.pointReindexRaw = func(filePath string) (*IndexResult, error) {
+		result, err := idx.incrementalPointWatcherPath(idx.rootPath, filePath)
+		close(pointTailEntered)
+		<-releasePoint
+		return result, err
+	}
+	pointDone := make(chan error, 1)
+	go func() {
+		pointDone <- watcher.patchGraph(path, ChangeModified)
+	}()
+
+	select {
+	case <-pointTailEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("point patch did not reach its coordinated tail")
+	}
+
+	watcher.stormMu.Lock()
+	watcher.stormBatch[path] = ChangeModified
+	watcher.stormMu.Unlock()
+	stormAtAdmission := make(chan struct{})
+	watcher.stormBeforeLock = func() { close(stormAtAdmission) }
+	stormDone := make(chan struct{})
 	go func() {
 		watcher.drainStorm()
-		close(done)
+		close(stormDone)
 	}()
 
-	require.False(t, <-beforeLock, "a claimed point patch must own the patch lane")
-	watcher.patchMu.Unlock()
-	locked = false
-	<-batchEntered
-	<-done
+	select {
+	case <-stormAtAdmission:
+	case <-time.After(2 * time.Second):
+		t.Fatal("storm drain did not reach repository-lane admission")
+	}
+	select {
+	case <-stormDone:
+		t.Fatal("storm batch overlapped an admitted point patch")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(releasePoint)
+	released = true
+	select {
+	case err := <-pointDone:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("point patch did not finish after releasing its tail")
+	}
+	select {
+	case <-stormDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("storm batch did not acquire the repository lane")
+	}
 }
 
 func TestWatcherStopCancelsQueuedStormAndFailsAdoptedTickets(t *testing.T) {
@@ -558,6 +583,38 @@ func TestGitWatcherLargeBranchReconcileBatchesOnceAndPreservesFailureRetry(t *te
 		require.Equal(t, 1, batchCalls)
 		require.Equal(t, baseSHA, gw.lastSHA,
 			"a failed batch must remain retryable from the prior commit")
+		require.Zero(t, drained)
+	})
+
+	t.Run("partial batch failure retains old sha", func(t *testing.T) {
+		batchCalls := 0
+		drained := 0
+		finalizeLookups := 0
+		gw := &GitWatcher{
+			repoPath: dir,
+			indexer:  idx,
+			currentIndexer: func() *Indexer {
+				finalizeLookups++
+				return idx
+			},
+			logger:  zap.NewNop(),
+			lastSHA: baseSHA,
+			batchReindex: func(paths []string) (*IndexResult, error) {
+				batchCalls++
+				return &IndexResult{
+					StaleFileCount: len(paths) - 1,
+					FailedFiles:    []string{paths[len(paths)-1]},
+				}, nil
+			},
+			drained: func(n int) { drained++ },
+		}
+
+		gw.reconcile("branch-switch-partial-failure-test")
+
+		require.Equal(t, 1, batchCalls)
+		require.Equal(t, baseSHA, gw.lastSHA,
+			"a partial batch failure must remain retryable from the prior commit")
+		require.Zero(t, finalizeLookups, "failed files must skip freshness finalization")
 		require.Zero(t, drained)
 	})
 }

--- a/internal/indexer/watcher_test.go
+++ b/internal/indexer/watcher_test.go
@@ -92,6 +92,67 @@ func TestWatcher_OverflowReconcileUsesBatchCoordinator(t *testing.T) {
 	w.asyncWork.Wait()
 }
 
+func TestWatcher_OverflowDuringReconcileSchedulesOneFollowUp(t *testing.T) {
+	_, _, w := setupWatcher(t)
+	firstStarted := make(chan struct{})
+	secondStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var stateMu sync.Mutex
+	calls, active, maxActive := 0, 0, 0
+	w.reconcileFn = func() {
+		stateMu.Lock()
+		active++
+		if active > maxActive {
+			maxActive = active
+		}
+		calls++
+		call := calls
+		stateMu.Unlock()
+		defer func() {
+			stateMu.Lock()
+			active--
+			stateMu.Unlock()
+		}()
+
+		switch call {
+		case 1:
+			close(firstStarted)
+			<-releaseFirst
+		case 2:
+			close(secondStarted)
+		}
+	}
+
+	w.triggerOverflowReconcile("first")
+	select {
+	case <-firstStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first overflow reconcile did not start")
+	}
+
+	for range 3 {
+		w.triggerOverflowReconcile("during-walk")
+	}
+	select {
+	case <-secondStarted:
+		t.Fatal("overflow follow-up ran concurrently with the active reconcile")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseFirst)
+	select {
+	case <-secondStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("overflow during the active walk did not schedule a follow-up")
+	}
+	w.asyncWork.Wait()
+
+	stateMu.Lock()
+	defer stateMu.Unlock()
+	require.Equal(t, 2, calls, "a burst during one walk must coalesce into one follow-up")
+	require.Equal(t, 1, maxActive, "overflow reconciliation must remain single-flight")
+}
+
 func TestWatcher_FileModify(t *testing.T) {
 	dir, idx, w := setupWatcher(t)
 
@@ -289,4 +350,68 @@ func Original() {}
 		t.Fatalf("duplicate delete event published: %+v", ev)
 	default:
 	}
+}
+
+func TestWatcher_DirScanWaitsForPointMutationRepositoryLane(t *testing.T) {
+	dir, idx, watcher := inertTestWatcher(t, "main.go", "package main\n\nfunc value() int { return 0 }\n")
+	path := filepath.Join(dir, "main.go")
+	writeTestFile(t, path, "package main\n\nfunc value() int { return 1 }\nfunc added() {}\n")
+
+	pointTailEntered := make(chan struct{})
+	releasePoint := make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(releasePoint)
+		}
+	}()
+	watcher.pointReindexRaw = func(filePath string) (*IndexResult, error) {
+		result, err := idx.incrementalPointWatcherPath(idx.rootPath, filePath)
+		close(pointTailEntered)
+		<-releasePoint
+		return result, err
+	}
+	pointDone := make(chan error, 1)
+	go func() {
+		pointDone <- watcher.patchGraph(path, ChangeModified)
+	}()
+	select {
+	case <-pointTailEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("point patch did not reach its coordinated tail")
+	}
+
+	newDir := filepath.Join(dir, "nested")
+	require.NoError(t, os.MkdirAll(newDir, 0o755))
+	writeTestFile(t, filepath.Join(newDir, "discovered.go"), "package nested\n\nfunc Discovered() {}\n")
+	scanStarted := make(chan struct{})
+	scanDone := make(chan struct{})
+	go func() {
+		close(scanStarted)
+		watcher.runDirScan(map[string]struct{}{newDir: {}}, nil)
+		close(scanDone)
+	}()
+	<-scanStarted
+
+	select {
+	case <-scanDone:
+		t.Fatal("directory discovery overlapped an admitted point patch")
+	case <-time.After(100 * time.Millisecond):
+	}
+	require.Empty(t, idx.graph.FindNodesByName("Discovered"))
+
+	close(releasePoint)
+	released = true
+	select {
+	case err := <-pointDone:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("point patch did not finish after releasing its tail")
+	}
+	select {
+	case <-scanDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("directory discovery did not acquire the repository lane")
+	}
+	require.NotEmpty(t, idx.graph.FindNodesByName("Discovered"))
 }

--- a/internal/indexer/watcher_test.go
+++ b/internal/indexer/watcher_test.go
@@ -224,13 +224,9 @@ func TestWatcher_SymbolChangeCallback_Modify(t *testing.T) {
 		newSymbols []*graph.Node
 	}
 
-	var mu sync.Mutex
-	var calls []callbackData
-
+	callbackDone := make(chan callbackData, 1)
 	w.OnSymbolChange(func(filePath string, oldSymbols, newSymbols []*graph.Node) {
-		mu.Lock()
-		defer mu.Unlock()
-		calls = append(calls, callbackData{filePath, oldSymbols, newSymbols})
+		callbackDone <- callbackData{filePath, oldSymbols, newSymbols}
 	})
 
 	// Modify the file — changes function name.
@@ -240,16 +236,19 @@ func Modified() {}
 `)
 	_ = waitForEvent(t, w, 2*time.Second)
 
-	mu.Lock()
-	defer mu.Unlock()
-	require.Len(t, calls, 1)
+	var call callbackData
+	select {
+	case call = <-callbackDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for symbol-change callback")
+	}
 
 	// Old symbols should contain "Original", new should contain "Modified".
 	var oldNames, newNames []string
-	for _, n := range calls[0].oldSymbols {
+	for _, n := range call.oldSymbols {
 		oldNames = append(oldNames, n.Name)
 	}
-	for _, n := range calls[0].newSymbols {
+	for _, n := range call.newSymbols {
 		if n.Kind != graph.KindFile && n.Kind != graph.KindImport {
 			newNames = append(newNames, n.Name)
 		}
@@ -268,25 +267,24 @@ func TestWatcher_SymbolChangeCallback_Delete(t *testing.T) {
 		newSymbols []*graph.Node
 	}
 
-	var mu sync.Mutex
-	var calls []callbackData
-
+	callbackDone := make(chan callbackData, 1)
 	w.OnSymbolChange(func(filePath string, oldSymbols, newSymbols []*graph.Node) {
-		mu.Lock()
-		defer mu.Unlock()
-		calls = append(calls, callbackData{filePath, oldSymbols, newSymbols})
+		callbackDone <- callbackData{filePath, oldSymbols, newSymbols}
 	})
 
 	require.NoError(t, os.Remove(filepath.Join(dir, "main.go")))
 	_ = waitForEvent(t, w, 2*time.Second)
 
-	mu.Lock()
-	defer mu.Unlock()
-	require.Len(t, calls, 1)
+	var call callbackData
+	select {
+	case call = <-callbackDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for symbol-change callback")
+	}
 
 	// Old symbols should have entries, new should be nil (deleted).
-	assert.NotEmpty(t, calls[0].oldSymbols, "callback=%+v", calls[0])
-	assert.Nil(t, calls[0].newSymbols)
+	assert.NotEmpty(t, call.oldSymbols, "callback=%+v", call)
+	assert.Nil(t, call.newSymbols)
 }
 
 func TestWatcher_DirScanDeleteOverlapPublishesPrimaryOnce(t *testing.T) {

--- a/internal/mcp/reindex_repository_paths_test.go
+++ b/internal/mcp/reindex_repository_paths_test.go
@@ -1,0 +1,61 @@
+package mcp
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/zzet/gortex/internal/indexer"
+)
+
+func TestNormalizeReindexPaths(t *testing.T) {
+	tests := []struct {
+		name    string
+		paths   []string
+		want    []string
+		wantErr bool
+	}{
+		{name: "omitted means full repository"},
+		{name: "explicit empty means full repository", paths: []string{}},
+		{name: "all blank means full repository", paths: []string{"", " \t"}},
+		{
+			name:  "mixed blanks retain scoped paths",
+			paths: []string{"", "internal/indexer", "  ", "README.md"},
+			want:  []string{"internal/indexer", "README.md"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeReindexPaths(tt.paths)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("normalizeReindexPaths() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("normalizeReindexPaths() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIncrementalReindexSucceeded(t *testing.T) {
+	tests := []struct {
+		name   string
+		result *indexer.IndexResult
+		err    error
+		want   bool
+	}{
+		{name: "successful batch", result: &indexer.IndexResult{}, want: true},
+		{name: "nil result", result: nil},
+		{name: "batch error", result: &indexer.IndexResult{}, err: errors.New("boom")},
+		{name: "isolated file failure", result: &indexer.IndexResult{FailedFiles: []string{"broken.go"}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := incrementalReindexSucceeded(tt.result, tt.err); got != tt.want {
+				t.Fatalf("incrementalReindexSucceeded() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -1228,21 +1228,34 @@ func (s *Server) recordIndexTelemetry(fileCount int) {
 	telemetry.RecordIndex(s.recorder, fileCount, langs)
 }
 
-// handleReindexRepository implements the reindex_repository tool: an
-// incremental re-index that re-parses only changed files (and evicts
-// deleted ones) instead of rebuilding the whole graph. The optional
-// `paths` argument scopes the pass to specific files / directories.
-func (s *Server) handleReindexRepository(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	paths := req.GetStringSlice("paths", nil)
-	// Drop blank entries so a caller passing [""] doesn't accidentally
-	// degrade a scoped request into a whole-repo scan.
+// normalizeReindexPaths removes blank entries from a scoped reindex request.
+// Omitted, empty, and all-blank path lists all preserve the established
+// whole-repository meaning. Mixed lists retain only their non-blank scopes.
+func normalizeReindexPaths(paths []string) ([]string, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
 	cleaned := make([]string, 0, len(paths))
 	for _, p := range paths {
 		if strings.TrimSpace(p) != "" {
 			cleaned = append(cleaned, p)
 		}
 	}
-	paths = cleaned
+	if len(cleaned) == 0 {
+		return nil, nil
+	}
+	return cleaned, nil
+}
+
+// handleReindexRepository implements the reindex_repository tool: an
+// incremental re-index that re-parses only changed files (and evicts
+// deleted ones) instead of rebuilding the whole graph. The optional
+// `paths` argument scopes the pass to specific files / directories.
+func (s *Server) handleReindexRepository(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	paths, pathsErr := normalizeReindexPaths(req.GetStringSlice("paths", nil))
+	if pathsErr != nil {
+		return mcp.NewToolResultError(pathsErr.Error()), nil
+	}
 
 	pathArg := req.GetString("path", "")
 

--- a/internal/mcp/tools_fileops.go
+++ b/internal/mcp/tools_fileops.go
@@ -15,7 +15,6 @@ import (
 	"github.com/zzet/gortex/internal/elide"
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/indexer"
-	"github.com/zzet/gortex/internal/reach"
 	"github.com/zzet/gortex/internal/tokens"
 )
 
@@ -650,28 +649,28 @@ func (s *Server) repoRelative(absPath string) string {
 	return absPath
 }
 
+func incrementalReindexSucceeded(result *indexer.IndexResult, err error) bool {
+	return err == nil && result != nil && len(result.FailedFiles) == 0
+}
+
 // reindexFile refreshes the graph for a single file after a write. Best-effort:
 // non-source files or files outside any indexed repo are silently skipped.
 func (s *Server) reindexFile(absPath string) bool {
-	reindex := func(idx *indexer.Indexer) bool {
-		finishTopologyMutation := reach.BeginTopologyMutation(s.graph)
-		// Conservatively invalidate reachability after every reindex attempt:
-		// an error may still follow a partial topology mutation.
-		defer finishTopologyMutation(true)
-		return idx.IndexFile(absPath) == nil
-	}
-
 	if s.multiIndexer != nil {
 		if prefix := s.multiIndexer.RepoForFile(absPath); prefix != "" {
-			if idx := s.multiIndexer.GetIndexer(prefix); idx != nil && reindex(idx) {
+			result, err := s.multiIndexer.IncrementalReindexRepo(prefix, []string{absPath})
+			if incrementalReindexSucceeded(result, err) {
 				return true
 			}
 		}
 	}
 	if s.indexer != nil {
 		if root := s.indexer.RootPath(); root != "" {
-			if rel, err := filepath.Rel(root, absPath); err == nil && !strings.HasPrefix(rel, "..") && reindex(s.indexer) {
-				return true
+			if rel, err := filepath.Rel(root, absPath); err == nil && !strings.HasPrefix(rel, "..") {
+				result, reindexErr := s.indexer.IncrementalReindexPaths(root, []string{absPath})
+				if incrementalReindexSucceeded(result, reindexErr) {
+					return true
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- add one stable per-repository mutation coordinator that unions pending paths, escalates to full scope, serializes the complete pipeline, and reruns when its dirty generation advances
- route watcher, Git, poller, overflow, reconciliation, direct file APIs, batch transitions, and MCP-triggered mutations through an exact-generation lane
- standardize lock order as repository lane -> batch gate -> topology gate, with topology-held raw helpers to prevent re-entry deadlocks
- reuse the modern incremental pipeline for point mutations, preserve precise derived invalidation, and finalize Git/poller freshness only after successful work
- close ABA, cancellation, stale-indexer, cache teardown, duplicate IndexAll, and callback re-entry edge cases with deterministic regression coverage
- preserve MCP full-repository semantics for omitted/empty/all-blank path lists while rejecting failed incremental outcomes

## Verification

- `go test ./internal/indexer -count=1`
- `go test -race ./internal/indexer -count=1`
- `go test ./internal/mcp -count=1`
- `go test -race ./internal/mcp -count=1`
- `go vet ./internal/indexer ./internal/mcp`
- `golangci-lint run ./internal/indexer/... ./internal/mcp/...`
- `go build ./internal/indexer/... ./internal/mcp/...`
- repository-wide `go test ./... -count=1`: all functional packages passed; the load-sensitive cold-index wall-clock benchmark failed only during the parallel all-package run and passed in isolation (23.48 ms vs 24.92 ms limit)
