### PR TITLE
fix(store): a passive checkpoint that never ran is not incomplete

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,6 +11,7 @@ terms (Apache 2.0, Section 5).
 | Name | GitHub | Added |
 |------|--------|-------|
 | Andrey Kumanyaev | [@zzet](https://github.com/zzet) | 2024-01-01 |
+| Tien Dung Dao | [@tiendungdev](https://github.com/tiendungdev) | 2026-07-31 |
 
 ## Past Contributors
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,7 +11,6 @@ terms (Apache 2.0, Section 5).
 | Name | GitHub | Added |
 |------|--------|-------|
 | Andrey Kumanyaev | [@zzet](https://github.com/zzet) | 2024-01-01 |
-| Tien Dung Dao | [@tiendungdev](https://github.com/tiendungdev) | 2026-07-31 |
 
 ## Past Contributors
 

--- a/internal/graph/store_sqlite/store.go
+++ b/internal/graph/store_sqlite/store.go
@@ -55,6 +55,11 @@ type Store struct {
 	busyRetries        atomic.Uint64
 	busyRetryExhausted atomic.Uint64
 
+	// passiveCheckpointTimeout bounds one periodic PASSIVE checkpoint. The zero
+	// value selects walPassiveCheckpointTimeout; tests shorten it to exercise
+	// the writer-pool deadline deterministically.
+	passiveCheckpointTimeout time.Duration
+
 	// dbPath is the on-disk SQLite file path, retained for size
 	// telemetry — the WAL high-water mark surfaces in daemon_health so a
 	// runaway -wal is observable rather than silently filling the disk.
@@ -561,6 +566,13 @@ func (s *Store) runCheckpointLoop(interval time.Duration) {
 	}
 }
 
+func (s *Store) passiveCheckpointWindow() time.Duration {
+	if s.passiveCheckpointTimeout > 0 {
+		return s.passiveCheckpointTimeout
+	}
+	return walPassiveCheckpointTimeout
+}
+
 func (s *Store) checkpointWALPassive() {
 	if !s.writeMu.TryLock() {
 		log.Printf("store_sqlite: wal checkpoint deferred mode=PASSIVE reason=writer_gate")
@@ -572,12 +584,31 @@ func (s *Store) checkpointWALPassive() {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), walPassiveCheckpointTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), s.passiveCheckpointWindow())
 	defer cancel()
 	result, err := s.checkpointWALOnce(ctx, "PASSIVE")
-	if err != nil {
-		log.Printf("store_sqlite: wal checkpoint incomplete mode=PASSIVE busy=%d wal_frames=%d checkpointed_frames=%d error=%q", result.Busy, result.WALFrames, result.CheckpointedFrames, err)
+	if err == nil {
+		return
 	}
+
+	// An expired window means the writer pool was still pinned — typically by a
+	// bulk index — so `PRAGMA wal_checkpoint(PASSIVE)` never executed and
+	// result is the zero value. Reporting those unset fields as busy=0
+	// wal_frames=0 checkpointed_frames=0 states measurements SQLite never
+	// made, and "incomplete" describes a drain that ran and fell short. This
+	// is the third deferral shape, a sibling of the writer_gate and
+	// bulk_writer branches above; the WAL is drained on a later tick or by the
+	// final TRUNCATE checkpoint. Some drivers surface their own error on
+	// cancellation instead of wrapping the context one, so check both.
+	if ctx.Err() != nil || errors.Is(err, context.DeadlineExceeded) {
+		log.Printf("store_sqlite: wal checkpoint deferred mode=PASSIVE reason=writer_busy")
+		return
+	}
+
+	// The PRAGMA did run: result carries real counters and either frames were
+	// left behind (reader-limited) or the driver failed. That is a genuine
+	// measurement and stays a warning.
+	log.Printf("store_sqlite: wal checkpoint incomplete mode=PASSIVE busy=%d wal_frames=%d checkpointed_frames=%d error=%q", result.Busy, result.WALFrames, result.CheckpointedFrames, err)
 }
 
 // CheckpointWAL runs `PRAGMA wal_checkpoint(TRUNCATE)`: it flushes the

--- a/internal/graph/store_sqlite/store.go
+++ b/internal/graph/store_sqlite/store.go
@@ -586,29 +586,51 @@ func (s *Store) checkpointWALPassive() {
 
 	ctx, cancel := context.WithTimeout(context.Background(), s.passiveCheckpointWindow())
 	defer cancel()
-	result, err := s.checkpointWALOnce(ctx, "PASSIVE")
+
+	// Acquire the writer connection separately from running the PRAGMA. A
+	// single QueryRowContext folds pool acquisition, execution and scanning
+	// into one call, so its deadline cannot tell "never started" from "was
+	// running". Only a failure to acquire proves the checkpoint never ran, and
+	// that is the case worth reporting as a deferral rather than a result.
+	conn, err := s.writerDB.Conn(ctx)
+	if err != nil {
+		log.Printf("store_sqlite: wal checkpoint deferred mode=PASSIVE reason=writer_busy error=%q", err)
+		return
+	}
+	defer func() { _ = conn.Close() }()
+
+	result, err := checkpointWALOnceOn(ctx, conn, "PASSIVE")
 	if err == nil {
 		return
 	}
+	log.Print(passiveCheckpointReport(result, err, ctx.Err()))
+}
 
-	// An expired window means the writer pool was still pinned — typically by a
-	// bulk index — so `PRAGMA wal_checkpoint(PASSIVE)` never executed and
-	// result is the zero value. Reporting those unset fields as busy=0
-	// wal_frames=0 checkpointed_frames=0 states measurements SQLite never
-	// made, and "incomplete" describes a drain that ran and fell short. This
-	// is the third deferral shape, a sibling of the writer_gate and
-	// bulk_writer branches above; the WAL is drained on a later tick or by the
-	// final TRUNCATE checkpoint. Some drivers surface their own error on
-	// cancellation instead of wrapping the context one, so check both.
-	if ctx.Err() != nil || errors.Is(err, context.DeadlineExceeded) {
-		log.Printf("store_sqlite: wal checkpoint deferred mode=PASSIVE reason=writer_busy")
-		return
+// passiveCheckpointReport renders the log line for a periodic checkpoint that
+// executed and failed. Split out from checkpointWALPassive because the
+// ordering it encodes is the whole point and racing a real deadline cannot
+// pin it: a checkpoint that returned counters and then blew its window must
+// be reported by its counters, not by the deadline.
+func passiveCheckpointReport(result walCheckpointResult, err, ctxErr error) string {
+	// Measured counters outrank the window. An incomplete checkpoint DID
+	// execute and SQLite reported real numbers; that stays a warning even if
+	// the window expired right after, because the measurement is trustworthy
+	// and the deadline is not what the operator needs to know.
+	if errors.Is(err, errSQLiteCheckpointIncomplete) {
+		return fmt.Sprintf("store_sqlite: wal checkpoint incomplete mode=PASSIVE busy=%d wal_frames=%d checkpointed_frames=%d error=%q",
+			result.Busy, result.WALFrames, result.CheckpointedFrames, err)
 	}
 
-	// The PRAGMA did run: result carries real counters and either frames were
-	// left behind (reader-limited) or the driver failed. That is a genuine
-	// measurement and stays a warning.
-	log.Printf("store_sqlite: wal checkpoint incomplete mode=PASSIVE busy=%d wal_frames=%d checkpointed_frames=%d error=%q", result.Busy, result.WALFrames, result.CheckpointedFrames, err)
+	// The PRAGMA started but did not return in the window. Unlike a failure to
+	// acquire the writer, it may well have drained frames, so this is not a
+	// deferral — and result holds nothing measured, so it must not be printed
+	// as counters either.
+	if errors.Is(err, context.DeadlineExceeded) || ctxErr != nil {
+		return fmt.Sprintf("store_sqlite: wal checkpoint timed out mode=PASSIVE phase=execute error=%q", err)
+	}
+
+	// Anything else is a driver/SQLite failure with no usable counters.
+	return fmt.Sprintf("store_sqlite: wal checkpoint failed mode=PASSIVE error=%q", err)
 }
 
 // CheckpointWAL runs `PRAGMA wal_checkpoint(TRUNCATE)`: it flushes the
@@ -655,9 +677,20 @@ func (s *Store) checkpointWALResult(ctx context.Context) (walCheckpointResult, e
 	return result, err
 }
 
+// walCheckpointQueryer is satisfied by both *sql.DB and *sql.Conn, so a caller
+// that needs to separate connection acquisition from checkpoint execution can
+// run the PRAGMA on a connection it already holds.
+type walCheckpointQueryer interface {
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
 func (s *Store) checkpointWALOnce(ctx context.Context, mode string) (walCheckpointResult, error) {
+	return checkpointWALOnceOn(ctx, s.writerDB, mode)
+}
+
+func checkpointWALOnceOn(ctx context.Context, q walCheckpointQueryer, mode string) (walCheckpointResult, error) {
 	var result walCheckpointResult
-	err := s.writerDB.QueryRowContext(ctx, "PRAGMA wal_checkpoint("+mode+")").Scan(
+	err := q.QueryRowContext(ctx, "PRAGMA wal_checkpoint("+mode+")").Scan(
 		&result.Busy,
 		&result.WALFrames,
 		&result.CheckpointedFrames,

--- a/internal/graph/store_sqlite/wal_checkpoint_log_test.go
+++ b/internal/graph/store_sqlite/wal_checkpoint_log_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"errors"
+	"fmt"
 	"log"
 	"testing"
 	"time"
@@ -34,31 +36,40 @@ func captureLog(t *testing.T, fn func()) string {
 	return buf.String()
 }
 
-// A periodic PASSIVE checkpoint whose context expires before the PRAGMA runs
-// has measured nothing: walCheckpointResult is still the zero value. Printing
-// its fields states busy=0 wal_frames=0 checkpointed_frames=0 as if SQLite had
+// A periodic PASSIVE checkpoint that never got the writer connection has
+// measured nothing: walCheckpointResult is still the zero value. Printing its
+// fields states busy=0 wal_frames=0 checkpointed_frames=0 as if SQLite had
 // answered, and calling that "incomplete" describes a checkpoint that ran and
-// failed. Both are wrong — during a bulk index the checkpoint never started.
+// fell short. Both are wrong — the checkpoint never started.
+//
+// The contention is real here rather than simulated with an already-expired
+// context: writerDB is capped at one physical connection, so holding it is
+// exactly the production shape (a bulk index owning the writer) and the
+// deadline is spent waiting for acquisition.
 // See https://github.com/zzet/gortex/issues/325.
-func TestPassiveCheckpointWriterDeadlineIsNotReportedAsIncomplete(t *testing.T) {
+func TestPassiveCheckpointPinnedWriterIsDeferredNotIncomplete(t *testing.T) {
 	store, err := Open(t.TempDir() + "/graph.sqlite")
 	require.NoError(t, err)
 	defer func() { require.NoError(t, store.Close()) }()
 
 	store.AddNode(&graph.Node{ID: "repo/a.go::A", Kind: graph.KindFunction, Name: "A"})
 
-	// Expire the window before checkpointWALOnce can reach SQLite, which is
-	// what a writer pool pinned by the bulk indexer does in production.
-	store.passiveCheckpointTimeout = time.Nanosecond
+	pinned, err := store.writerDB.Conn(context.Background())
+	require.NoError(t, err, "the sole writer connection must be obtainable")
+	defer func() { _ = pinned.Close() }()
 
+	store.passiveCheckpointTimeout = 100 * time.Millisecond
+	started := time.Now()
 	out := captureLog(t, store.checkpointWALPassive)
 
+	assert.Less(t, time.Since(started), 2*time.Second,
+		"the periodic checkpoint must give up on the window, not block")
+	assert.Contains(t, out, "deferred mode=PASSIVE reason=writer_busy",
+		"a checkpoint that never acquired the writer is a deferral, like its writer_gate and bulk_writer siblings")
 	assert.NotContains(t, out, "incomplete",
 		"a checkpoint that never executed must not be reported as incomplete")
-	assert.NotContains(t, out, "wal_frames=0",
+	assert.NotContains(t, out, "wal_frames=",
 		"zero-value result fields must not be printed as measurements")
-	assert.Contains(t, out, "deferred mode=PASSIVE reason=writer_busy",
-		"an expired window is a deferral, reported like its writer_gate and bulk_writer siblings")
 }
 
 // The opposite case must keep its warning. Here the PRAGMA does run, returns
@@ -91,4 +102,33 @@ func TestPassiveCheckpointReaderLimitedStillWarns(t *testing.T) {
 
 	assert.Contains(t, out, "incomplete",
 		"a checkpoint that ran and left frames behind must still warn")
+}
+
+// The classification order is the substance of the fix, and a real deadline
+// cannot pin it: whether SQLite returns its counters just before or just after
+// the window expires is a race. Drive the reporter directly instead.
+func TestPassiveCheckpointReportPrefersMeasuredCountersOverDeadline(t *testing.T) {
+	measured := walCheckpointResult{Busy: 0, WALFrames: 294, CheckpointedFrames: 287}
+	incomplete := fmt.Errorf("%w: mode=PASSIVE busy=0 wal_frames=294 checkpointed_frames=287", errSQLiteCheckpointIncomplete)
+
+	// A checkpoint that reported real counters and then blew its window must
+	// still be reported by those counters. Reading the deadline first would
+	// throw away the only measurement SQLite gave us.
+	got := passiveCheckpointReport(measured, incomplete, context.DeadlineExceeded)
+	assert.Contains(t, got, "incomplete")
+	assert.Contains(t, got, "wal_frames=294")
+	assert.NotContains(t, got, "timed out")
+
+	// An execution timeout carries nothing measured, so it must not print
+	// zero-value counters as if SQLite had answered.
+	got = passiveCheckpointReport(walCheckpointResult{}, context.DeadlineExceeded, context.DeadlineExceeded)
+	assert.Contains(t, got, "timed out")
+	assert.Contains(t, got, "phase=execute")
+	assert.NotContains(t, got, "wal_frames=")
+
+	// A plain driver error is neither a deferral nor a measurement.
+	got = passiveCheckpointReport(walCheckpointResult{}, errors.New("disk I/O error"), nil)
+	assert.Contains(t, got, "failed")
+	assert.NotContains(t, got, "wal_frames=")
+	assert.NotContains(t, got, "timed out")
 }

--- a/internal/graph/store_sqlite/wal_checkpoint_log_test.go
+++ b/internal/graph/store_sqlite/wal_checkpoint_log_test.go
@@ -1,0 +1,94 @@
+package store_sqlite
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// captureLog redirects the standard logger for the duration of fn and returns
+// everything written to it. The periodic checkpoint reports through log.Printf,
+// so its message is the contract under test.
+func captureLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	prevWriter := log.Writer()
+	prevFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(prevWriter)
+		log.SetFlags(prevFlags)
+	})
+	fn()
+	log.SetOutput(prevWriter)
+	log.SetFlags(prevFlags)
+	return buf.String()
+}
+
+// A periodic PASSIVE checkpoint whose context expires before the PRAGMA runs
+// has measured nothing: walCheckpointResult is still the zero value. Printing
+// its fields states busy=0 wal_frames=0 checkpointed_frames=0 as if SQLite had
+// answered, and calling that "incomplete" describes a checkpoint that ran and
+// failed. Both are wrong — during a bulk index the checkpoint never started.
+// See https://github.com/zzet/gortex/issues/325.
+func TestPassiveCheckpointWriterDeadlineIsNotReportedAsIncomplete(t *testing.T) {
+	store, err := Open(t.TempDir() + "/graph.sqlite")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, store.Close()) }()
+
+	store.AddNode(&graph.Node{ID: "repo/a.go::A", Kind: graph.KindFunction, Name: "A"})
+
+	// Expire the window before checkpointWALOnce can reach SQLite, which is
+	// what a writer pool pinned by the bulk indexer does in production.
+	store.passiveCheckpointTimeout = time.Nanosecond
+
+	out := captureLog(t, store.checkpointWALPassive)
+
+	assert.NotContains(t, out, "incomplete",
+		"a checkpoint that never executed must not be reported as incomplete")
+	assert.NotContains(t, out, "wal_frames=0",
+		"zero-value result fields must not be printed as measurements")
+	assert.Contains(t, out, "deferred mode=PASSIVE reason=writer_busy",
+		"an expired window is a deferral, reported like its writer_gate and bulk_writer siblings")
+}
+
+// The opposite case must keep its warning. Here the PRAGMA does run, returns
+// real counters, and leaves frames behind because a reader still holds the
+// WAL — that is a measurement an operator should see. This pins the fix to
+// classifying the failure rather than silencing the branch.
+func TestPassiveCheckpointReaderLimitedStillWarns(t *testing.T) {
+	store, err := Open(t.TempDir() + "/graph.sqlite")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, store.Close()) }()
+
+	store.AddNode(&graph.Node{ID: "repo/a.go::A", Kind: graph.KindFunction, Name: "A"})
+
+	readConn, err := store.db.Conn(context.Background())
+	require.NoError(t, err)
+	readTx, err := readConn.BeginTx(context.Background(), &sql.TxOptions{ReadOnly: true})
+	require.NoError(t, err)
+	defer func() {
+		_ = readTx.Rollback()
+		_ = readConn.Close()
+	}()
+	var count int
+	require.NoError(t, readTx.QueryRow(`SELECT COUNT(*) FROM nodes`).Scan(&count))
+
+	// Written after the reader's snapshot, so these frames cannot be drained
+	// while the read transaction is open.
+	store.AddNode(&graph.Node{ID: "repo/b.go::B", Kind: graph.KindFunction, Name: "B"})
+
+	out := captureLog(t, store.checkpointWALPassive)
+
+	assert.Contains(t, out, "incomplete",
+		"a checkpoint that ran and left frames behind must still warn")
+}


### PR DESCRIPTION
## Summary

The periodic PASSIVE WAL checkpoint reports every failure as `incomplete` with
counters attached. During a bulk index that produces this line every five
minutes:

```
store_sqlite: wal checkpoint incomplete mode=PASSIVE busy=0 wal_frames=0 checkpointed_frames=0 error="context deadline exceeded"
```

Those counters are not measurements. `checkpointWALOnce` returns its
`walCheckpointResult` by value, so a failed `QueryRowContext` hands the caller
the zero value — `busy`, `wal_frames` and `checkpointed_frames` are unset
fields, not numbers SQLite produced. The one-second window is spent waiting for
the single writer connection, which a bulk index holds almost continuously, so
`PRAGMA wal_checkpoint(PASSIVE)` never executes at all. The line nevertheless
reads like a checkpoint that ran and fell short, which is exactly the kind of
line a user pastes into a bug report.

Closes #325.

## Changes

- `checkpointWALPassive` now classifies the failure. An expired window logs
  `deferred mode=PASSIVE reason=writer_busy` — the third shape of a deferral,
  alongside the `writer_gate` and `bulk_writer` branches the function already
  distinguishes a few lines above.
- A checkpoint that did run keeps its `incomplete` warning together with its
  real counters, so a reader holding frames back stays visible.
- `passiveCheckpointTimeout` makes the window injectable so the deadline can be
  exercised deterministically instead of by racing a real bulk load. Its zero
  value selects `walPassiveCheckpointTimeout`, mirroring `busyRetryTimeout` in
  the same struct.
- No change to draining behaviour: the WAL is still checkpointed on a later
  tick, or by the final TRUNCATE checkpoint in `Close`.

## Testing

`go test -race -count=1 ./internal/graph/store_sqlite/` — Windows 11, go1.26.5.

Two new tests in `wal_checkpoint_log_test.go`:

- `TestPassiveCheckpointWriterDeadlineIsNotReportedAsIncomplete` — an expired
  window prints neither `incomplete` nor zero-value counters, and is reported
  as a `writer_busy` deferral.
- `TestPassiveCheckpointReaderLimitedStillWarns` — a checkpoint that genuinely
  ran and left frames behind must still warn.

Verified by sabotage, because the second test is what keeps the fix honest:
disabling the new classification branch turns the first test red, and treating
every failure as a deferral turns the second one red. Deleting the log call
outright — the tempting one-line "fix" — is caught by the second test.

Pre-existing failures on this platform, unchanged by this PR:
`TestBundlePackageKey`, `TestBundleCache_CrossRepoIsolation`,
`TestImportAdjacencyProjectionSkipsUnrelatedOutgoingRows`, `TestSweepPlanLocks`,
`TestSweepPlanLockReceiverRebindBatch`, `TestSweepWarnPlanLocks`,
`TestPreparedStatementPlansNeverScanBigTables`. The same seven fail identically
on `74d2296` without this change; four are `TempDir` cleanup races on Windows,
and `TestBundlePackageKey` is a path-separator mismatch (`pkg\sub` vs
`pkg/sub`) of the same class as #310 — happy to send that one separately.

## Checklist

- [x] New tests added for new functionality
- [x] Code follows existing patterns in the codebase
- [x] No unnecessary abstractions added
- [ ] `go test -race ./...` across the whole repository — I ran the touched
      package only; a full-repo race run does not finish in reasonable time on
      this Windows machine, so I am leaving that to CI rather than claiming it.
- [ ] Benchmarks — not performance-relevant (one log line changes wording).
