### PR TITLE
fix(indexer): a route's file and line must describe the same site

### DIFF
--- a/internal/indexer/contract_import_resolve.go
+++ b/internal/indexer/contract_import_resolve.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 
@@ -20,12 +21,27 @@ func (mi *MultiIndexer) disambiguateBareTypesViaImportsBatch(registries []*contr
 	srcCache := map[string][]byte{}
 	importCache := map[string]map[string]string{}
 	nameSet := map[string]struct{}{}
+
+	// A bare type is resolved through the imports of the file that mentions
+	// it — the file defining the contract's symbol. For a route registered in
+	// one file and handled in another that is not c.FilePath, which names the
+	// registration site, so resolve the symbol's own file first. One batched
+	// node lookup, mirroring the FindNodesByNames projection below.
+	srcByContract := handlerSourceFiles(registries, g)
+	srcFile := func(c contracts.Contract) string {
+		if p := srcByContract[c.SymbolID]; p != "" {
+			return p
+		}
+		return c.FilePath
+	}
+
 	for _, cr := range registries {
 		if cr == nil {
 			continue
 		}
 		for _, c := range cr.All() {
-			if c.Meta == nil || !isImportResolvableLang(c.FilePath) {
+			src := srcFile(c)
+			if c.Meta == nil || !isImportResolvableLang(src) {
 				continue
 			}
 			for _, key := range []string{"response_type", "request_type"} {
@@ -34,8 +50,8 @@ func (mi *MultiIndexer) disambiguateBareTypesViaImportsBatch(registries []*contr
 					continue
 				}
 				nameSet[name] = struct{}{}
-				if isRustFile(c.FilePath) {
-					for _, candidateName := range mi.rustImportCandidateNames(c.FilePath, name, srcCache) {
+				if isRustFile(src) {
+					for _, candidateName := range mi.rustImportCandidateNames(src, name, srcCache) {
 						nameSet[candidateName] = struct{}{}
 					}
 				}
@@ -52,8 +68,40 @@ func (mi *MultiIndexer) disambiguateBareTypesViaImportsBatch(registries []*contr
 		if cr == nil {
 			continue
 		}
-		mi.disambiguateBareTypesViaImportsPrefetched(cr, srcCache, importCache, candidatesByName)
+		mi.disambiguateBareTypesViaImportsPrefetched(cr, srcCache, importCache, candidatesByName, srcByContract)
 	}
+}
+
+// handlerSourceFiles maps a contract's SymbolID to the file its symbol is
+// defined in. Contracts whose symbol is unknown or absent from the graph are
+// omitted; callers fall back to Contract.FilePath for those.
+func handlerSourceFiles(registries []*contracts.Registry, g graph.Store) map[string]string {
+	idSet := map[string]struct{}{}
+	for _, cr := range registries {
+		if cr == nil {
+			continue
+		}
+		for _, c := range cr.All() {
+			if c.SymbolID != "" {
+				idSet[c.SymbolID] = struct{}{}
+			}
+		}
+	}
+	if len(idSet) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(idSet))
+	for id := range idSet {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	out := make(map[string]string, len(ids))
+	for id, n := range g.GetNodesByIDs(ids) {
+		if n != nil && n.FilePath != "" {
+			out[id] = n.FilePath
+		}
+	}
+	return out
 }
 
 func (mi *MultiIndexer) disambiguateBareTypesViaImportsPrefetched(
@@ -61,17 +109,26 @@ func (mi *MultiIndexer) disambiguateBareTypesViaImportsPrefetched(
 	srcCache map[string][]byte,
 	importCache map[string]map[string]string,
 	candidatesByName map[string][]*graph.Node,
+	srcByContract map[string]string,
 ) {
 	for _, c := range cr.All() {
 		if c.Meta == nil {
 			continue
 		}
-		if !isImportResolvableLang(c.FilePath) {
+		// The imports to consult are the ones in the file defining this
+		// contract's symbol, not the file it was registered in.
+		src := c.FilePath
+		if p := srcByContract[c.SymbolID]; p != "" {
+			src = p
+		}
+		if !isImportResolvableLang(src) {
 			continue
 		}
 		patched := false
 		items := cr.ByID(c.ID)
 		for i := range items {
+			// FilePath still identifies which registry entry this is —
+			// registration site, unchanged.
 			if items[i].FilePath != c.FilePath || items[i].Meta == nil {
 				continue
 			}
@@ -80,7 +137,7 @@ func (mi *MultiIndexer) disambiguateBareTypesViaImportsPrefetched(
 				if name == "" || strings.Contains(name, "::") {
 					continue
 				}
-				resolved := mi.resolveBareTypeViaImportsPrefetched(c.FilePath, name, srcCache, importCache, candidatesByName)
+				resolved := mi.resolveBareTypeViaImportsPrefetched(src, name, srcCache, importCache, candidatesByName)
 				if resolved == "" {
 					continue
 				}

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -6294,6 +6294,15 @@ func (idx *Indexer) resolveProviderHandlers(reg *contracts.Registry) {
 			}
 			// Operate on a copy; Registry entries are values.
 			patched := c
+			// FilePath is swapped to the handler's file only so the enricher
+			// can read that file's tree. Line is not swapped with it — it
+			// keeps describing the registration site — so leaving the
+			// handler's file in place would pair a file and a line that come
+			// from two different places, and every consumer citing file:line
+			// would point at unrelated code (issue #322). Restore it once
+			// enrichment is done. SymbolID stays re-pointed: the resolved
+			// handler is the answer that lookup exists to produce.
+			registrationFile := patched.FilePath
 			patched.SymbolID = handlerNode.ID
 			patched.FilePath = handlerNode.FilePath
 			if patched.Meta == nil {
@@ -6304,6 +6313,7 @@ func (idx *Indexer) resolveProviderHandlers(reg *contracts.Registry) {
 			// want the call-path to be identical to Stage 1).
 			lines := splitLines(src)
 			contracts.EnrichHTTPContractWithTree(&patched, lines, nodes, lang, tree)
+			patched.FilePath = registrationFile
 			delete(patched.Meta, "handler_ident")
 			delete(patched.Meta, "handler_trail")
 			matches[i] = patched

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -6863,7 +6863,18 @@ func (idx *Indexer) prepareContractTypeResolution(
 		if len(names) == 0 {
 			continue
 		}
-		bf := bfCache.For(handlers[c.SymbolID])
+		handlerNode := handlers[c.SymbolID]
+		bf := bfCache.For(handlerNode)
+		// binding.Line comes from the handler's body, and the compiler
+		// bindings this site is looked up against are stored under the
+		// handler's own source file. c.FilePath names the registration site,
+		// which for a cross-file route is a different file — pairing the two
+		// would query <registration file>:<handler line> and either miss the
+		// binding or hit an unrelated one at the same line.
+		siteFile := c.FilePath
+		if handlerNode != nil && handlerNode.FilePath != "" {
+			siteFile = handlerNode.FilePath
+		}
 		for _, name := range names {
 			key := contractBindingKeyFor(c, name)
 			if _, exists := resolution.bindings[key]; exists {
@@ -6876,7 +6887,7 @@ func (idx *Indexer) prepareContractTypeResolution(
 			}
 			site := graph.SemanticBindingSite{
 				RepoPrefix: c.RepoPrefix,
-				FilePath:   c.FilePath,
+				FilePath:   siteFile,
 				Line:       binding.Line,
 				Name:       name,
 			}

--- a/internal/indexer/residual_batch_hotpaths_test.go
+++ b/internal/indexer/residual_batch_hotpaths_test.go
@@ -114,7 +114,11 @@ func TestResolveProviderHandlersUsesOneNameAndFileBatch(t *testing.T) {
 		if len(items) != 1 {
 			t.Fatalf("contract %s count=%d", id, len(items))
 		}
-		if items[0].SymbolID != handlerID || items[0].FilePath != "repo/handlers.go" {
+		// SymbolID is the resolution this pass exists to produce. FilePath
+		// stays on the registration site the contract was extracted from:
+		// Line still describes that site, so re-homing the file would pair a
+		// file and a line from two different places (issue #322).
+		if items[0].SymbolID != handlerID || items[0].FilePath != "repo/router.go" {
 			t.Fatalf("contract %s resolved to symbol=%q file=%q", id, items[0].SymbolID, items[0].FilePath)
 		}
 		if _, ok := items[0].Meta["handler_ident"]; ok {

--- a/internal/indexer/route_registration_site_test.go
+++ b/internal/indexer/route_registration_site_test.go
@@ -1,0 +1,89 @@
+package indexer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+// A route registered in one file and handled in another must report a
+// file:line pair that describes a single site. resolveProviderHandlers swaps
+// the contract's FilePath to the handler's file so the enricher can read that
+// file's tree, but Line keeps describing the registration — so leaving the
+// swap in place pairs a file and a line from two different places and every
+// consumer citing file:line lands on unrelated code.
+// See https://github.com/zzet/gortex/issues/322.
+func TestRouteContractKeepsRegistrationSiteCoherent(t *testing.T) {
+	dir := t.TempDir()
+
+	// The registration literal is handler.go:8.
+	handlerGo := `package app
+
+import "net/http"
+
+type handlers struct{}
+
+func (h handlers) Register(mux *http.ServeMux) {
+	mux.HandleFunc("POST /api/things/{id}/update", h.requestUpdate)
+}
+`
+	// The handler body is actions.go:11 — deliberately a different line
+	// number than the registration, so a mixed pair is detectable.
+	actionsGo := `package app
+
+import "net/http"
+
+//
+//
+//
+//
+//
+// requestUpdate applies a pending change.
+func (h handlers) requestUpdate(w http.ResponseWriter, r *http.Request) {
+	_ = w
+	_ = r
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "handler.go"), []byte(handlerGo), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "actions.go"), []byte(actionsGo), 0o644))
+
+	g := graph.New()
+	reg := parser.NewRegistry()
+	languages.RegisterAll(reg)
+	idx := New(g, reg, config.Default().Index, zap.NewNop())
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+	idx.ResolveAll()
+
+	const routeID = "http::POST::/api/things/{p1}/update"
+	require.NotNil(t, g.GetNode(routeID), "expected a route contract node")
+
+	var edge *graph.Edge
+	for _, e := range g.GetInEdges(routeID) {
+		if e.Kind == graph.EdgeHandlesRoute {
+			edge = e
+			break
+		}
+	}
+	require.NotNil(t, edge, "expected an EdgeHandlesRoute into the route")
+
+	// The cross-file handler resolution itself must keep working: that is the
+	// whole point of the swap, and this pins the fix to restoring FilePath
+	// rather than abandoning the re-point.
+	assert.Equal(t, "actions.go::handlers.requestUpdate", edge.From,
+		"handler must still resolve across files")
+
+	assert.Equal(t, "handler.go", edge.FilePath,
+		"file must name the registration site, which is what Line describes")
+	assert.Equal(t, 8, edge.Line,
+		"line must stay on the registration literal")
+}

--- a/internal/indexer/route_registration_site_test.go
+++ b/internal/indexer/route_registration_site_test.go
@@ -3,6 +3,7 @@ package indexer
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,6 +11,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/contracts"
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/parser"
 	"github.com/zzet/gortex/internal/parser/languages"
@@ -86,4 +88,143 @@ func (h handlers) requestUpdate(w http.ResponseWriter, r *http.Request) {
 		"file must name the registration site, which is what Line describes")
 	assert.Equal(t, 8, edge.Line,
 		"line must stay on the registration literal")
+}
+
+// Keeping FilePath on the registration site must not cost the handler's own
+// schema enrichment. That enrichment reads the handler body and looks its
+// bindings up against compiler facts stored under the handler's real source
+// file, so anything deriving a source path from Contract.FilePath would, for a
+// cross-file route, consult the registration file instead — silently losing
+// the response type or matching an unrelated binding on the same line.
+//
+// This is the two-file form of TestContracts_ResponseFromMakeSlice: the
+// registration lives in router.go, the handler and its type in actions.go.
+func TestContracts_CrossFileHandlerStillResolvesResponseType(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "router.go"), []byte(`package main
+
+import "net/http"
+
+type Handler struct{ tools map[string]any }
+
+func (h *Handler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("GET /v1/tools", h.handleListTools)
+}
+`), 0o644))
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "actions.go"), []byte(`package main
+
+import "net/http"
+
+type toolInfo struct {
+	Name        string `+"`json:\"name\"`"+`
+	Description string `+"`json:\"description\"`"+`
+}
+
+func (h *Handler) handleListTools(w http.ResponseWriter, _ *http.Request) {
+	result := make([]toolInfo, 0, len(h.tools))
+	WriteJSON(w, http.StatusOK, result)
+}
+
+func WriteJSON(w http.ResponseWriter, code int, body any) {}
+`), 0o644))
+
+	g := graph.New()
+	reg := parser.NewRegistry()
+	languages.RegisterAll(reg)
+	idx := New(g, reg, config.Default().Index, zap.NewNop())
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+	idx.ResolveAll()
+
+	cr := idx.ContractRegistry()
+	require.NotNil(t, cr)
+
+	var found contracts.Contract
+	for _, c := range cr.All() {
+		if c.Type == contracts.ContractHTTP && strings.Contains(c.ID, "/v1/tools") {
+			found = c
+			break
+		}
+	}
+	require.NotEmpty(t, found.ID, "expected an HTTP contract for /v1/tools")
+
+	// The enrichment that reads the handler body must still land, even though
+	// the contract's own FilePath now names the registration file.
+	rt, _ := found.Meta["response_type"].(string)
+	assert.Contains(t, rt, "toolInfo",
+		"response_type must resolve from the handler's file, not the registration file")
+	assert.True(t, found.Meta["response_repeated"] == true,
+		"response_repeated must survive cross-file enrichment")
+
+	// And the location itself still describes the registration site.
+	assert.Equal(t, "router.go", found.FilePath,
+		"FilePath must name the registration site")
+	assert.Equal(t, "actions.go::Handler.handleListTools", found.SymbolID,
+		"SymbolID must still point at the resolved cross-file handler")
+}
+
+// bindingSiteRecorder captures the semantic binding sites the contract
+// type-resolution pass queries, so a test can assert which file:line pair the
+// lookup is built from without needing a live compiler-facts provider (which
+// does not run in unit tests).
+type bindingSiteRecorder struct {
+	graph.Store
+	sites []graph.SemanticBindingSite
+}
+
+func (r *bindingSiteRecorder) SemanticBindingTypes(sites []graph.SemanticBindingSite) (map[graph.SemanticBindingSite]string, error) {
+	r.sites = append(r.sites, sites...)
+	return nil, nil
+}
+
+// The binding line comes from the handler's body and the compiler bindings it
+// is matched against are stored under the handler's own source file. Pairing
+// that line with the contract's FilePath — the registration site, once a route
+// is registered cross-file — queries a file:line that describes nothing, and
+// either loses the type or matches an unrelated binding on the same line.
+func TestContractBindingSitesUseTheHandlersOwnFile(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "router.go"), []byte(`package main
+
+import "net/http"
+
+type Handler struct{}
+
+func (h *Handler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("GET /v1/tools", h.handleListTools)
+}
+`), 0o644))
+
+	// The response value is bound from a method call, which the literal
+	// fallback cannot type — so resolution has to go through a semantic
+	// binding site, which is the path under test.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "actions.go"), []byte(`package main
+
+import "net/http"
+
+func (h *Handler) handleListTools(w http.ResponseWriter, _ *http.Request) {
+	result := h.buildResult()
+	WriteJSON(w, http.StatusOK, result)
+}
+
+func WriteJSON(w http.ResponseWriter, code int, body any) {}
+`), 0o644))
+
+	rec := &bindingSiteRecorder{Store: graph.New()}
+	reg := parser.NewRegistry()
+	languages.RegisterAll(reg)
+	idx := New(rec, reg, config.Default().Index, zap.NewNop())
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+	idx.ResolveAll()
+
+	require.NotEmpty(t, rec.sites,
+		"expected the contract pass to query at least one semantic binding site")
+	for _, s := range rec.sites {
+		assert.Equal(t, "actions.go", s.FilePath,
+			"binding site must name the handler's file, since its Line comes from the handler body")
+	}
 }


### PR DESCRIPTION
## Summary

`analyze kind=routes` reports a `file` and a `line` that come from two
different places whenever a route is registered in one file and handled in
another. Minimal reproduction — registration literal at `handler.go:8`,
handler body at `actions.go:11`:

```json
{
  "file":    "route-repro/actions.go",
  "line":    9,
  "handler": "route-repro/actions.go::handlers.requestUpdate",
  "method":  "POST",
  "path":    "/api/admin/things/{p1}/request-update"
}
```

`actions.go:9` is a comment. The method, path and handler symbol are all
correct; only the `file`+`line` pair is incoherent, so anything citing a
route's location points at arbitrary code. The compact renderer prints
exactly that pair — `(%s:%d)` — and an agent auditing an API surface ends up
citing a line that registered nothing.

Closes #322.

## Root cause

`resolveProviderHandlers` (internal/indexer/indexer.go) re-points a route
contract at its resolved handler so `EnrichHTTPContractWithTree` can find the
handler body in that file's tree:

```go
patched := c
patched.SymbolID = handlerNode.ID
patched.FilePath = handlerNode.FilePath
...
contracts.EnrichHTTPContractWithTree(&patched, lines, nodes, lang, tree)
...
matches[i] = patched          // written back into the registry
```

The comment above it describes the swap as temporary — "swap it in
temporarily to the resolved handler so the lookup works" — but `patched` is
written back, and `Line` is never swapped along with `FilePath`. So `FilePath`
follows the handler while `Line` stays on the registration literal, and every
downstream consumer inherits the mixed pair: the contract node, the
`EdgeHandlesRoute` edge (which takes both from the contract), and the
analyzer row.

Single-file registration hides this completely, because both spellings
coincide — which is why the existing fixtures never caught it.

## Fix

Restore `FilePath` after enrichment. `SymbolID` stays re-pointed: the resolved
cross-file handler is the answer this pass exists to produce, and the `handler`
field already carries the handler's file, so naming the registration site in
`file:line` loses no information.

```diff
+registrationFile := patched.FilePath
 patched.SymbolID = handlerNode.ID
 patched.FilePath = handlerNode.FilePath
 ...
 contracts.EnrichHTTPContractWithTree(&patched, lines, nodes, lang, tree)
+patched.FilePath = registrationFile
```

## One existing assertion changed — please sanity-check this call

`TestResolveProviderHandlersUsesOneNameAndFileBatch` asserted the re-homed
`FilePath`. That test is about batching — it counts `findNodesByNames` and
`getFileNodesByPaths` calls — and used `FilePath` only as evidence that the
patch had been applied. It now checks `SymbolID` for that instead, which is the
resolution the pass produces, and pins `FilePath` to the registration site. Its
fixture already separated the two (contract at `repo/router.go`, handler at
`repo/handlers.go`), so the case was expressible; only the expectation encoded
the mixed pair.

If you consider the re-homed `FilePath` intentional, the alternative is to
carry both sites explicitly (`route_file`/`route_line` plus
`handler_file`/`handler_line`) as #322 suggests. That changes the response
shape, so I did not do it unilaterally — happy to switch if you prefer it.

## Testing

`go test -count=1 ./internal/indexer/ ./internal/mcp/ ./internal/contracts/` —
Windows 11, go1.26.5.

New `TestRouteContractKeepsRegistrationSiteCoherent`: a route registered in one
file and handled in another keeps `file:line` on the registration and still
resolves its handler across files.

Verified by sabotage, since either half alone would look like a fix: dropping
the restore turns the coherence assertions red, and dropping the `SymbolID`
re-point turns the cross-file assertion red. The pair pins "borrow and give
back" rather than abandoning the re-point.

Pre-existing failures on this platform: `internal/indexer` and `internal/mcp`
fail **85** tests on `74d2296` without this change (largely `TempDir` cleanup
races and clangd/compile-commands cases specific to Windows). With this change
the same run reports 89; the four-test difference is
`TestResolveProviderHandlersUsesOneNameAndFileBatch` (the assertion updated
above, recorded before that edit) plus `TestReviewPackCoverageEvidenceIsRecorded`,
`TestSiblingDiffContext_GCXAndTOONAndBudget` and `TestVerifyCitation_BadSHA` —
all four pass when run targeted on this branch, and the latter three touch
nothing this PR changes.

## Checklist

- [x] New tests added for new functionality
- [x] Code follows existing patterns in the codebase
- [x] No unnecessary abstractions added
- [ ] `go test -race ./...` across the whole repository — I ran the three
      affected packages without `-race`; a full-repo race run does not finish
      in reasonable time on this Windows machine, so I am leaving that to CI
      rather than claiming it.
- [ ] Benchmarks — not performance-relevant.
