### PR TITLE
fix(paths): package identity is slash-only, not filepath-shaped

### DIFF
--- a/internal/analysis/communities.go
+++ b/internal/analysis/communities.go
@@ -541,7 +541,7 @@ func inferCommunityLabel(members []string, nodeMap map[string]*graph.Node, files
 		return np
 	}
 
-	return path.Dir(files[0])
+	return path.Dir(filepath.ToSlash(files[0]))
 }
 
 // pureClusterLabel returns a name for clusters whose files share a
@@ -567,9 +567,10 @@ func pureClusterLabel(files []string) string {
 func mixedClusterLabel(files []string) string {
 	dirCount := make(map[string]int)
 	for _, f := range files {
-		// Slash-only: this directory is rendered into the label and trimmed
-		// by helpers that split on "/".
-		dirCount[path.Dir(f)]++
+		// Graph file paths keep OS-native separators (see graphRelKey), so
+		// normalise before taking the directory: the result is rendered into
+		// the label and trimmed by helpers that split on "/".
+		dirCount[path.Dir(filepath.ToSlash(f))]++
 	}
 	if len(dirCount) == 0 {
 		return ""
@@ -606,13 +607,14 @@ func longestCommonDirPrefix(paths []string) string {
 	if len(paths) == 0 {
 		return ""
 	}
-	// path.Dir, not filepath.Dir: the trimming loop below cuts at "/", so a
-	// prefix cleaned to the OS separator can never be shortened and the
-	// function bails out with "" on the first mismatch — on Windows that made
-	// every cluster label empty.
-	pfx := path.Dir(paths[0])
+	// Graph file paths keep OS-native separators (see graphRelKey), so
+	// normalise with ToSlash first, then take the directory with path.Dir —
+	// the trimming loop below cuts at "/", so a prefix carrying the OS
+	// separator could never be shortened and the function would bail out with
+	// "" on the first mismatch.
+	pfx := path.Dir(filepath.ToSlash(paths[0]))
 	for _, p := range paths[1:] {
-		dir := path.Dir(p)
+		dir := path.Dir(filepath.ToSlash(p))
 		for pfx != "" && !isPathPrefix(dir, pfx) {
 			cut := strings.LastIndex(pfx, "/")
 			if cut < 0 {

--- a/internal/analysis/communities.go
+++ b/internal/analysis/communities.go
@@ -3,6 +3,7 @@ package analysis
 import (
 	"fmt"
 	"math"
+	"path"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -540,7 +541,7 @@ func inferCommunityLabel(members []string, nodeMap map[string]*graph.Node, files
 		return np
 	}
 
-	return filepath.Dir(files[0])
+	return path.Dir(files[0])
 }
 
 // pureClusterLabel returns a name for clusters whose files share a
@@ -566,7 +567,9 @@ func pureClusterLabel(files []string) string {
 func mixedClusterLabel(files []string) string {
 	dirCount := make(map[string]int)
 	for _, f := range files {
-		dirCount[filepath.Dir(f)]++
+		// Slash-only: this directory is rendered into the label and trimmed
+		// by helpers that split on "/".
+		dirCount[path.Dir(f)]++
 	}
 	if len(dirCount) == 0 {
 		return ""
@@ -603,9 +606,13 @@ func longestCommonDirPrefix(paths []string) string {
 	if len(paths) == 0 {
 		return ""
 	}
-	pfx := filepath.Dir(paths[0])
+	// path.Dir, not filepath.Dir: the trimming loop below cuts at "/", so a
+	// prefix cleaned to the OS separator can never be shortened and the
+	// function bails out with "" on the first mismatch — on Windows that made
+	// every cluster label empty.
+	pfx := path.Dir(paths[0])
 	for _, p := range paths[1:] {
-		dir := filepath.Dir(p)
+		dir := path.Dir(p)
 		for pfx != "" && !isPathPrefix(dir, pfx) {
 			cut := strings.LastIndex(pfx, "/")
 			if cut < 0 {

--- a/internal/analysis/communities_label_test.go
+++ b/internal/analysis/communities_label_test.go
@@ -1,6 +1,52 @@
 package analysis
 
-import "testing"
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The cases above spell their inputs with forward slashes, which is what a
+// POSIX graph stores — but graphRelKey keeps OS-native separators, so on
+// Windows a real graph path reads "gortex/internal\parser\languages\cpp.go":
+// the repo prefix is joined with "/" and the repo-relative remainder is not.
+// Feeding that shape in is what distinguishes "normalises first" from "happens
+// to work because the test used slashes". filepath.FromSlash makes the input
+// native on whichever platform runs it, so this is a real assertion on Windows
+// and an identity on POSIX rather than a skip.
+func TestClusterLabelsNormaliseOSNativeGraphPaths(t *testing.T) {
+	// Mirror the "<prefix>/<os-native remainder>" shape graph nodes carry.
+	native := func(prefix, rel string) string {
+		return prefix + "/" + filepath.FromSlash(rel)
+	}
+	files := []string{
+		native("gortex", "internal/parser/languages/cpp.go"),
+		native("gortex", "internal/parser/languages/dart.go"),
+		native("gortex", "internal/parser/languages/python.go"),
+	}
+
+	if got := pureClusterLabel(files); got != "parser/languages" {
+		t.Errorf("pureClusterLabel(%v) = %q; want %q", files, got, "parser/languages")
+	}
+
+	// A label must never leak the OS separator to the wire, whichever branch
+	// produced it.
+	for _, got := range []string{pureClusterLabel(files), mixedClusterLabel(files)} {
+		if filepath.Separator != '/' && strings.ContainsRune(got, filepath.Separator) {
+			t.Errorf("label %q carries the OS separator", got)
+		}
+	}
+
+	// Spread across sibling directories: the shared ancestor is still found,
+	// so the modal-directory branch reports a real prefix rather than "".
+	mixed := []string{
+		native("gortex", "internal/parser/languages/cpp.go"),
+		native("gortex", "internal/parser/golang/extract.go"),
+	}
+	if got := longestCommonDirPrefix(mixed); got != "gortex/internal/parser" {
+		t.Errorf("longestCommonDirPrefix(%v) = %q; want %q", mixed, got, "gortex/internal/parser")
+	}
+}
 
 func TestPureClusterLabel(t *testing.T) {
 	tests := []struct {

--- a/internal/analysis/incremental_communities.go
+++ b/internal/analysis/incremental_communities.go
@@ -2,6 +2,7 @@ package analysis
 
 import (
 	"hash/fnv"
+	"path"
 	"path/filepath"
 	"sort"
 
@@ -223,7 +224,11 @@ func packageKey(filePath string) string {
 	if filePath == "" {
 		return ""
 	}
-	dir := filepath.Dir(filepath.ToSlash(filePath))
+	// path.Dir, not filepath.Dir: these keys are compared against
+	// forward-slash keys elsewhere (the bundle cache mirrors this function),
+	// and filepath.Dir cleans to the OS separator, undoing the ToSlash on
+	// Windows.
+	dir := path.Dir(filepath.ToSlash(filePath))
 	if dir == "." {
 		return ""
 	}

--- a/internal/graph/store_sqlite/bundle_cache.go
+++ b/internal/graph/store_sqlite/bundle_cache.go
@@ -2,6 +2,7 @@ package store_sqlite
 
 import (
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -244,7 +245,12 @@ func bundlePackageKey(filePath string) string {
 	if filePath == "" {
 		return ""
 	}
-	dir := filepath.Dir(filepath.ToSlash(filePath))
+	// path.Dir, not filepath.Dir: stored file paths are forward-slash by
+	// contract, and so are the keys of the fingerprint map this key is looked
+	// up in. filepath.Dir cleans to the OS separator, which on Windows undoes
+	// the ToSlash and yields "repoA\pkg" for a map keyed "repoA/pkg" — every
+	// entry then reads as unfingerprinted and the cache never serves a hit.
+	dir := path.Dir(filepath.ToSlash(filePath))
 	if dir == "." {
 		return ""
 	}

--- a/internal/graph/store_sqlite/bundle_cache_test.go
+++ b/internal/graph/store_sqlite/bundle_cache_test.go
@@ -3,6 +3,7 @@ package store_sqlite
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -97,6 +98,21 @@ func TestBundlePackageKey(t *testing.T) {
 	for in, want := range cases {
 		if got := bundlePackageKey(in); got != want {
 			t.Errorf("bundlePackageKey(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// The key is looked up in a fingerprint map whose keys are forward-slash, so
+// it must never carry an OS separator. Stated separately from the table above
+// because the table only fails on a platform whose separator differs from "/",
+// and this spells out why that matters rather than leaving it to be rediscovered.
+func TestBundlePackageKeyNeverUsesOSSeparator(t *testing.T) {
+	if filepath.Separator == '/' {
+		t.Skip("separator matches the contract on this platform")
+	}
+	for _, in := range []string{"pkg/sub/x.go", "repoA/pkg/x.go", "a/b/c/d.go"} {
+		if got := bundlePackageKey(in); strings.ContainsRune(got, filepath.Separator) {
+			t.Errorf("bundlePackageKey(%q) = %q, must stay forward-slash", in, got)
 		}
 	}
 }

--- a/internal/mcp/tools_analyze_clusters.go
+++ b/internal/mcp/tools_analyze_clusters.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -391,11 +392,14 @@ func commonFilePrefix(files []string) string {
 	if len(files) == 0 {
 		return ""
 	}
-	prefix := filepath.Dir(filepath.ToSlash(files[0]))
+	// path.Dir, not filepath.Dir: the containment test below joins with "/",
+	// so a prefix cleaned to the OS separator could never match it on
+	// Windows and every cluster would report an empty prefix.
+	prefix := path.Dir(filepath.ToSlash(files[0]))
 	for _, f := range files[1:] {
-		dir := filepath.Dir(filepath.ToSlash(f))
+		dir := path.Dir(filepath.ToSlash(f))
 		for !strings.HasPrefix(dir+"/", prefix+"/") && prefix != "." && prefix != "/" {
-			prefix = filepath.Dir(prefix)
+			prefix = path.Dir(prefix)
 		}
 		if prefix == "." || prefix == "/" {
 			return ""


### PR DESCRIPTION
## Summary

A package key, a cluster label and a cache fingerprint key are **identifiers
inside the graph** — none of them is ever opened from disk. They are built with
`path/filepath` anyway, so on Windows they come out spelled with backslashes
while everything they are compared against stays forward-slash, and the
comparison quietly fails.

`bundlePackageKey` is the clearest case:

```go
dir := filepath.Dir(filepath.ToSlash(filePath))
```

`ToSlash` rewrites the separator and `filepath.Dir` immediately cleans it back,
so the normalisation is undone by the line wrapping it. The result is then
looked up in a fingerprint map keyed `"repoA/pkg"` while the key itself reads
`"repoA\pkg"` — no entry ever validates, and **the bundle cache serves nothing
on Windows**.

`longestCommonDirPrefix` shows the same mismatch inside a single function:

```go
pfx := filepath.Dir(paths[0])
...
cut := strings.LastIndex(pfx, "/")
if cut < 0 { pfx = ""; break }
```

The trimming loop cuts at `"/"` — the author knew these are slash paths — but
the prefix is built with the OS separator, so the cut never lands and the
function bails out empty on the first mismatch. Every cluster label on Windows
is either `""` or `"gortex\internal\parser\languages"`.

## Changes

Switch these to `path.Dir`. This is not a normalisation layered on top:
`path` is the correct package for identifiers, `path/filepath` is for talking
to the filesystem. `filepath.Base` is deliberately left alone — it accepts both
separators and returns the same answer either way.

| site | package | effect on Windows |
|---|---|---|
| `bundlePackageKey` | `graph/store_sqlite` | bundle cache never hits |
| `packageKey` | `analysis` | the function the cache mirrors; same key, same mismatch |
| `longestCommonDirPrefix`, `mixedClusterLabel` | `analysis` | cluster labels empty or backslash-spelled |
| `commonFilePrefix` | `mcp` | containment test joins with `"/"`, so an OS-separator prefix can never match |

## Testing

Windows 11, go1.26.5, measured against `74d2296` as the baseline:

| package | baseline | with this change |
|---|---|---|
| `internal/analysis` | 6 failures | **2** |
| `internal/graph/store_sqlite` | 7 failures | **5** |

The six that flip: `TestBundlePackageKey`,
`TestBundleCache_CrossRepoIsolation`, `TestPureClusterLabel`,
`TestMixedClusterLabel`, `TestInferCommunityLabelDistinguishesSameBasename`,
`TestDetectCommunitiesLeidenIncremental`. Nothing regresses — I ran the same
packages on `74d2296` and diffed the failure sets rather than eyeballing them.

What remains in those packages is `TempDir`-cleanup contention on Windows and
one diff-parsing case (`TestParseDiffLinesNewSide`), both unrelated to this
change and failing identically on the baseline.

`TestBundlePackageKeyNeverUsesOSSeparator` states the contract on its own
instead of leaving it implicit in a table that only fails off-POSIX. It skips
where the separator already is `"/"`, so it is a no-op on the platforms CI runs
today.

## Why this class of bug reaches users

The test matrix is `[ubuntu-latest, macos-latest]` and `build-windows` only
builds — so nothing in CI ever evaluates a path comparison on a platform whose
separator differs. On POSIX both spellings coincide and every one of these
sites looks correct.

I am not proposing a matrix change here (a good number of tests fail on
Windows today for unrelated reasons, mostly `TempDir` cleanup contention, so
turning it on now would just paint CI red). Mentioning it because it explains
why these went unnoticed, and I am happy to work through the remaining Windows
failures separately if that is a direction you want.

There is a sibling case in `internal/analysis/diffmap.go` — `parseDiffLines`
cleans git's forward-slash paths with `filepath.Clean` — but fixing it in
isolation breaks the review-pack consumers, which normalise inconsistently
(`tools_review.go` has both `filepath.Clean` and `filepath.ToSlash(filepath.Clean(...))`).
That needs the whole chain audited together, so I left it out of this PR
rather than half-fixing it.

## Checklist

- [x] New tests added for new functionality
- [x] Code follows existing patterns in the codebase
- [x] No unnecessary abstractions added
- [ ] `go test -race ./...` across the whole repository — I ran the affected
      packages without `-race`; a full-repo race run does not finish in
      reasonable time on this machine, so I am leaving that to CI rather than
      claiming it.
- [ ] Benchmarks — not performance-relevant in the measured sense, though it
      does restore a cache that currently never hits on Windows.
