### PR TITLE
Seed workspace configs with defaults — a partial .gortex.yaml silently zeroed workers and the parse budget

### DIFF
--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -190,8 +190,14 @@ func (cm *ConfigManager) readWorkspaceConfig(repoPrefix, repoPath string) (*Conf
 		return nil, false
 	}
 
-	var cfg Config
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+	// Seed with Default() and unmarshal the file OVER it — the same
+	// overlay semantics config.Load() applies. A zero-value seed turned
+	// the file's mere presence into a wholesale replacement: every field
+	// a partial .gortex.yaml didn't mention lost its documented default
+	// (unset index.workers → parse pool of 1, unset
+	// max_parse_bytes_in_flight → admission semaphore disabled).
+	cfg := Default()
+	if err := yaml.Unmarshal(data, cfg); err != nil {
 		// Malformed workspace config — log warning, keep the last good parse.
 		cm.logger.Warn("malformed workspace config, keeping the last good parse",
 			zap.String("repo", repoPrefix),
@@ -200,7 +206,7 @@ func (cm *ConfigManager) readWorkspaceConfig(repoPrefix, repoPath string) (*Conf
 		return nil, false
 	}
 
-	return &cfg, true
+	return cfg, true
 }
 
 // publishWorkspaceConfig publishes a per-repo state transition and advances

--- a/internal/config/manager_defaults_test.go
+++ b/internal/config/manager_defaults_test.go
@@ -1,0 +1,65 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetRepoConfig_PartialWorkspaceConfigKeepsDefaults: a .gortex.yaml
+// that sets only what it cares about must not zero every other field.
+// Before the fix, the file's mere presence replaced Default() wholesale:
+// unset index.workers collapsed the parse pool to a single core (a
+// silent ~12× cold-index slowdown) and unset max_parse_bytes_in_flight
+// disabled the parse-admission semaphore outright.
+func TestGetRepoConfig_PartialWorkspaceConfigKeepsDefaults(t *testing.T) {
+	cm, err := NewConfigManager(filepath.Join(t.TempDir(), "config.yaml"))
+	require.NoError(t, err)
+
+	repoDir := t.TempDir()
+	wsContent := `
+index:
+  exclude:
+    - "**/[Bb]in/**"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".gortex.yaml"), []byte(wsContent), 0644))
+	cm.LoadWorkspaceConfig("my-repo", repoDir)
+
+	cfg := cm.GetRepoConfig("my-repo")
+	require.NotNil(t, cfg)
+
+	def := Default()
+	assert.Equal(t, runtime.NumCPU(), cfg.Index.Workers,
+		"unset index.workers must keep the NumCPU default, not collapse to 0→1")
+	assert.Equal(t, def.Index.MaxParseBytesInFlight, cfg.Index.MaxParseBytesInFlight,
+		"unset max_parse_bytes_in_flight must keep the admission budget, not disable it")
+	assert.Equal(t, def.Index.Content.MaxDocumentBytes, cfg.Index.Content.MaxDocumentBytes,
+		"content-admission caps must survive a partial workspace config")
+	// The file's own settings still land.
+	assert.Contains(t, cfg.Index.Exclude, "**/[Bb]in/**")
+}
+
+// TestGetRepoConfig_ExplicitWorkspaceValuesStillWin: seeding defaults
+// must not override what the file actually sets.
+func TestGetRepoConfig_ExplicitWorkspaceValuesStillWin(t *testing.T) {
+	cm, err := NewConfigManager(filepath.Join(t.TempDir(), "config.yaml"))
+	require.NoError(t, err)
+
+	repoDir := t.TempDir()
+	wsContent := `
+index:
+  workers: 3
+  max_file_size: 2097152
+`
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".gortex.yaml"), []byte(wsContent), 0644))
+	cm.LoadWorkspaceConfig("my-repo", repoDir)
+
+	cfg := cm.GetRepoConfig("my-repo")
+	require.NotNil(t, cfg)
+	assert.Equal(t, 3, cfg.Index.Workers)
+	assert.Equal(t, int64(2097152), cfg.Index.MaxFileSize)
+}


### PR DESCRIPTION
## Summary

The presence of a per-repo `.gortex.yaml` replaces `Default()` wholesale: `readWorkspaceConfig` unmarshals into a zero-value struct, and `GetRepoConfig` uses that raw struct as the repo's entire effective config — every field the YAML doesn't mention becomes a Go zero value instead of its documented default.

Two verified consequences on a 19,473-file C# solution (M-series Mac, 12 usable perf cores):

- unset `index.workers` → `0`, clamped to **1** — the whole parse phase on a single core. Cold index went from **94 s** (explicit `workers: 12`) to **>8 min, killed twice**, with nothing logged about the collapse.
- unset `index.max_parse_bytes_in_flight` → `0` → the bytes-in-flight admission semaphore is **disabled** (only created when `> 0`) — the opposite failure direction, unbounded concurrent parse admission.

Because the daemon's warmup pool is repo-level (`min(NumCPU, 12)` capped to repo count), a single-repo workspace gets *all* intra-repo parallelism from `Index.Workers` — which is exactly where the zeroing lands hardest.

Corroboration from a second machine (Windows, two repos under one daemon): the repo without a config file parses with `workers: 32` (NumCPU) while this repository's own **committed** `.gortex.yaml` — which sets `workers: 8` explicitly but not the parse budget — parses with 8. That committed `workers:` line reads like this footgun's workaround already applied in-tree; the semaphore consequence is live for this repo on every machine.

## Fix

Mirror `config.Load()`'s semantics in `readWorkspaceConfig`: seed with `Default()` and unmarshal the file over it, so a partial file keeps every documented default. `config.Load()` already does exactly this for the CLI path; the workspace loader was the only reader with replace-instead-of-overlay semantics. The hand-restored fields in `GetRepoConfig` (`SkipEmbed` / `SkipSearch` / `IndexProse` / the `EffectiveExclude` layering) overwrite unconditionally after the branch, so their behaviour is unchanged.

Behaviour notes, explicit so nothing lands silently:

- "Explicitly set to 0" becomes indistinguishable from "unset" — for both headline fields zero is already an invalid/clamped value, so nothing meaningful is lost.
- Every other documented default now also survives a partial workspace config, notably `semantic.enabled: true`, `index.content` admission caps, `watch.debounce_ms`, and the query depth defaults. Previously a repo with any `.gortex.yaml` silently zeroed all of these; if any of them was *intended* to be replace-semantics, say the word and I'll carve it out.

## Testing

- [x] New: `TestGetRepoConfig_PartialWorkspaceConfigKeepsDefaults` (exclude-only file keeps `Workers == NumCPU`, the parse budget, and content caps) and `TestGetRepoConfig_ExplicitWorkspaceValuesStillWin`.
- [x] Full `internal/config` suite green (`go test -race`; the two `TestDefaultGlobalConfigPath_*` failures on the Windows dev box pre-exist on a pristine tree — HOME resolution, unrelated).
- [x] **Real-world A/B on the affected Mac (M5 Max, 18 logical cores, 128 GB), at `2ba1f08d`:** recreated the exact regression config — the original 19,473-file C# repo with a `.gortex.yaml` containing only `index.exclude`, no `workers:` key — and cold-reindexed via `GORTEX_WARMUP_FULL_RETRACK=1`:

  ```
  {"msg":"indexer: parse subphases","repo":"app","wall":100.031,
   "sem_wait_workers":0.0047,"read_workers":3.325,"extract_workers":699.930,
   "batch_workers":9.106,"workers":18,"files":19473}
  ```

  - `workers: 18` = full NumCPU with no explicit setting — on `main` this exact config runs 1 worker (>8 min cold parse, killed twice).
  - Wall time back in the expected range: 100 s vs the 94 s previously measured *with* the explicit `workers: 12` workaround (the delta is full-retrack eviction of the 321k prior nodes, running 18-wide vs 12).
  - `sem_wait_workers` is **nonzero** — on zeroed-config runs it reads exactly `0` because `parseSem` is nil, so this is direct log evidence the `max_parse_bytes_in_flight` default is restored too, not merely absence of regression.
  - Resulting graph identical to the workaround run (321,190 nodes / 19,231 files); daemon healthy.

## Checklist

- [x] Code follows existing patterns (identical overlay semantics to `config.Load()`)
- [x] No unnecessary abstractions added
