### PR TITLE
perf(search): eliminate full-node substring scan churn

### DIFF
--- a/cmd/gortex/daemon_search_backend_test.go
+++ b/cmd/gortex/daemon_search_backend_test.go
@@ -49,13 +49,14 @@ func TestResolveSearchBackend_SymbolSearcherBackend(t *testing.T) {
 }
 
 func TestResolveSearchBackend_SymbolSearcherBackend_CountFromIndex(t *testing.T) {
-	// Adds and removes move the adapter's delta; the reported figure must
-	// still be the index's own count, not that delta.
+	// Adds and removes move the adapter's delta. Count combines that delta
+	// with the persisted baseline, while status still reports the index's own
+	// authoritative count.
 	b := search.NewSymbolSearcherBackend(countingSymbolSearcher{count: 48572})
 	b.Add("node-1")
 	b.Remove("node-2")
 	b.Remove("node-3")
-	assert.Negative(t, b.Count(), "precondition: the delta is negative here")
+	assert.Equal(t, 48571, b.Count(), "Count must combine the persisted baseline with the adapter delta")
 
 	info := resolveSearchBackend(b)
 

--- a/internal/graph/node_search_keys.go
+++ b/internal/graph/node_search_keys.go
@@ -1,0 +1,123 @@
+package graph
+
+import "context"
+
+// DefaultNodeSearchKeyPageSize is the bounded page used by compact node-key
+// scans when callers do not request a positive size.
+const DefaultNodeSearchKeyPageSize = 256
+
+// NodeSearchKey is the metadata-free projection needed to rank degraded-mode
+// symbol-search candidates. Full nodes are loaded only for the winning IDs.
+type NodeSearchKey struct {
+	ID   string
+	Kind NodeKind
+	Name string
+}
+
+// NodeSearchKeyScanner is an optional Reader capability. Implementations must
+// visit every node visible through the reader exactly once. Ordering is backend
+// specific; callers that need deterministic results must rank or sort keys.
+//
+// A page is borrowed storage and is valid only until yield returns. Producers
+// must release database rows, connections, and graph locks before calling
+// yield, so the callback may safely re-enter the same reader. Returning false
+// stops the scan without error. Context cancellation is returned as ctx.Err().
+type NodeSearchKeyScanner interface {
+	ScanNodeSearchKeys(ctx context.Context, pageSize int, yield func([]NodeSearchKey) bool) error
+}
+
+// ScanNodeSearchKeys selects the compact optional capability. Unknown Reader
+// implementations retain compatibility through an already-materialized light
+// snapshot; production Graph, SQLite, and OverlaidView readers all implement
+// NodeSearchKeyScanner directly.
+func ScanNodeSearchKeys(ctx context.Context, r Reader, pageSize int, yield func([]NodeSearchKey) bool) error {
+	if r == nil || yield == nil {
+		return nil
+	}
+	ctx = nodeSearchContext(ctx)
+	pageSize = nodeSearchPageSize(pageSize)
+	if scanner, ok := r.(NodeSearchKeyScanner); ok {
+		return scanner.ScanNodeSearchKeys(ctx, pageSize, yield)
+	}
+
+	// AllNodesLight has returned before yield runs, so even the compatibility
+	// path cannot retain an open cursor or reader lock across callback re-entry.
+	nodes := AllNodesLight(r)
+	page := make([]NodeSearchKey, 0, pageSize)
+	for _, node := range nodes {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if node == nil {
+			continue
+		}
+		page = append(page, NodeSearchKey{ID: node.ID, Kind: node.Kind, Name: node.Name})
+		if len(page) < pageSize {
+			continue
+		}
+		if !yield(page) {
+			return nil
+		}
+		clear(page)
+		page = page[:0]
+	}
+	if len(page) > 0 {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		yield(page)
+	}
+	return nil
+}
+
+// ScanNodeSearchKeys is the in-memory implementation. NodesLightSeq copies at
+// most one shard's pointers while holding its lock, then releases that lock
+// before yielding any node, so callbacks here are safe to re-enter Graph.
+func (g *Graph) ScanNodeSearchKeys(ctx context.Context, pageSize int, yield func([]NodeSearchKey) bool) error {
+	if g == nil || yield == nil {
+		return nil
+	}
+	ctx = nodeSearchContext(ctx)
+	pageSize = nodeSearchPageSize(pageSize)
+	page := make([]NodeSearchKey, 0, pageSize)
+	for node := range g.NodesLightSeq() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if node == nil {
+			continue
+		}
+		page = append(page, NodeSearchKey{ID: node.ID, Kind: node.Kind, Name: node.Name})
+		if len(page) < pageSize {
+			continue
+		}
+		if !yield(page) {
+			return nil
+		}
+		clear(page)
+		page = page[:0]
+	}
+	if len(page) > 0 {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		yield(page)
+	}
+	return nil
+}
+
+func nodeSearchContext(ctx context.Context) context.Context {
+	if ctx == nil {
+		return context.Background()
+	}
+	return ctx
+}
+
+func nodeSearchPageSize(pageSize int) int {
+	if pageSize <= 0 {
+		return DefaultNodeSearchKeyPageSize
+	}
+	return pageSize
+}
+
+var _ NodeSearchKeyScanner = (*Graph)(nil)

--- a/internal/graph/node_search_keys_test.go
+++ b/internal/graph/node_search_keys_test.go
@@ -1,0 +1,122 @@
+package graph
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestScanNodeSearchKeysGraphIsPagedCompleteAndReentrant(t *testing.T) {
+	g := New()
+	want := map[string]NodeSearchKey{
+		"c.go::Gamma": {ID: "c.go::Gamma", Kind: KindFunction, Name: "Gamma"},
+		"a.go::Alpha": {ID: "a.go::Alpha", Kind: KindMethod, Name: "Alpha"},
+		"b.go::Beta":  {ID: "b.go::Beta", Kind: KindFunction, Name: "Beta"},
+	}
+	for _, key := range want {
+		g.AddNode(&Node{ID: key.ID, Kind: key.Kind, Name: key.Name, FilePath: IDFile(key.ID)})
+	}
+
+	got := make(map[string]NodeSearchKey)
+	var pageSizes []int
+	err := ScanNodeSearchKeys(context.Background(), g, 2, func(page []NodeSearchKey) bool {
+		pageSizes = append(pageSizes, len(page))
+		if len(page) == 0 || len(page) > 2 {
+			t.Fatalf("page size = %d, want 1..2", len(page))
+		}
+		// Graph releases its shard lock before callbacks, so point lookup is
+		// safe even when a page lands in the middle of a shard.
+		if g.GetNode(page[0].ID) == nil {
+			t.Fatalf("callback could not re-enter Graph for %q", page[0].ID)
+		}
+		for _, key := range page {
+			if _, duplicate := got[key.ID]; duplicate {
+				t.Fatalf("duplicate key %q", key.ID)
+			}
+			got[key.ID] = key
+		}
+		return true
+	})
+	if err != nil {
+		t.Fatalf("ScanNodeSearchKeys: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("keys = %#v, want %#v", got, want)
+	}
+	sort.Ints(pageSizes)
+	if !reflect.DeepEqual(pageSizes, []int{1, 2}) {
+		t.Fatalf("page sizes = %v, want [1 2]", pageSizes)
+	}
+}
+
+func TestScanNodeSearchKeysHonorsCancellationAndEarlyStop(t *testing.T) {
+	g := New()
+	for _, id := range []string{"a.go::A", "b.go::B", "c.go::C"} {
+		g.AddNode(&Node{ID: id, Kind: KindFunction, Name: id})
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := ScanNodeSearchKeys(ctx, g, 1, func([]NodeSearchKey) bool {
+		t.Fatal("callback ran after cancellation")
+		return true
+	}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+
+	calls := 0
+	if err := ScanNodeSearchKeys(context.Background(), g, 1, func([]NodeSearchKey) bool {
+		calls++
+		return false
+	}); err != nil {
+		t.Fatalf("early-stop scan: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("callbacks = %d, want 1", calls)
+	}
+}
+
+func TestOverlaidViewScanNodeSearchKeysAppliesMasksAndProxiesRevision(t *testing.T) {
+	base := New()
+	base.AddNode(&Node{ID: "keep.go::Keep", Kind: KindFunction, Name: "Keep", FilePath: "keep.go"})
+	base.AddNode(&Node{ID: "replace.go::Old", Kind: KindMethod, Name: "Old", FilePath: "replace.go"})
+	base.AddNode(&Node{ID: "module::Removed", Kind: KindModule, Name: "Removed"})
+
+	layer := NewOverlayLayer()
+	layer.MarkFile("replace.go", false)
+	layer.AddNode("replace.go", &Node{ID: "replace.go::New", Kind: KindMethod, Name: "New", FilePath: "replace.go"})
+	layer.MarkRemoved("Removed", "module::Removed")
+	view := NewOverlaidView(base, layer)
+
+	got := make(map[string]NodeSearchKey)
+	if err := view.ScanNodeSearchKeys(context.Background(), 1, func(page []NodeSearchKey) bool {
+		if len(page) != 1 {
+			t.Fatalf("page size = %d, want 1", len(page))
+		}
+		if view.GetNode(page[0].ID) == nil {
+			t.Fatalf("callback could not re-enter overlay for %q", page[0].ID)
+		}
+		got[page[0].ID] = page[0]
+		return true
+	}); err != nil {
+		t.Fatalf("ScanNodeSearchKeys: %v", err)
+	}
+	want := map[string]NodeSearchKey{
+		"keep.go::Keep":   {ID: "keep.go::Keep", Kind: KindFunction, Name: "Keep"},
+		"replace.go::New": {ID: "replace.go::New", Kind: KindMethod, Name: "New"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("overlay keys = %#v, want %#v", got, want)
+	}
+
+	before, known := view.SearchMutationRevision()
+	if !known {
+		t.Fatal("overlay revision should be known for a Graph base")
+	}
+	base.AddNode(&Node{ID: "later.go::Later", Kind: KindFunction, Name: "Later", FilePath: "later.go"})
+	if after, known := view.SearchMutationRevision(); !known || after <= before {
+		t.Fatalf("overlay revision did not follow base: before=%d after=%d known=%v", before, after, known)
+	}
+}

--- a/internal/graph/overlay_node_search_keys.go
+++ b/internal/graph/overlay_node_search_keys.go
@@ -1,0 +1,104 @@
+package graph
+
+import "context"
+
+// ScanNodeSearchKeys merges compact keys through the same overlay masks as the
+// point/name readers: base nodes owned by overlaid files (or explicitly removed
+// names) disappear, and the overlay's replacement nodes are appended. Ordering
+// is intentionally unspecified; the search consumer performs its own total
+// ranking by score, name length, and ID.
+func (v *OverlaidView) ScanNodeSearchKeys(ctx context.Context, pageSize int, yield func([]NodeSearchKey) bool) error {
+	if v == nil || yield == nil {
+		return nil
+	}
+	ctx = nodeSearchContext(ctx)
+	pageSize = nodeSearchPageSize(pageSize)
+
+	page := make([]NodeSearchKey, 0, pageSize)
+	stopped := false
+	emit := func(key NodeSearchKey) bool {
+		page = append(page, key)
+		if len(page) < pageSize {
+			return true
+		}
+		if !yield(page) {
+			stopped = true
+			return false
+		}
+		clear(page)
+		page = page[:0]
+		return true
+	}
+
+	if v.base != nil {
+		err := ScanNodeSearchKeys(ctx, v.base, pageSize, func(keys []NodeSearchKey) bool {
+			for _, key := range keys {
+				if ctx.Err() != nil {
+					return false
+				}
+				if v.layer != nil {
+					if v.nodeBelongsToOverlay(key.ID) {
+						continue
+					}
+					if removed := v.layer.nameRemoved[key.Name]; removed != nil && removed[key.ID] {
+						continue
+					}
+				}
+				if !emit(key) {
+					return false
+				}
+			}
+			return true
+		})
+		if err != nil {
+			return err
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if stopped {
+			return nil
+		}
+	}
+
+	if v.layer != nil {
+		for _, node := range v.layer.nodeByID {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if node == nil {
+				continue
+			}
+			if !emit(NodeSearchKey{ID: node.ID, Kind: node.Kind, Name: node.Name}) {
+				return nil
+			}
+		}
+	}
+
+	if len(page) > 0 {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		yield(page)
+	}
+	return nil
+}
+
+// SearchMutationRevision forwards the base reader's optional invalidation
+// token without pretending that an unsupported base has an authoritative zero
+// revision. Overlay layers are immutable after view construction, so only base
+// mutations can invalidate a scan/hydration pair.
+func (v *OverlaidView) SearchMutationRevision() (uint64, bool) {
+	if v == nil || v.base == nil {
+		return 0, false
+	}
+	if revisioner, ok := v.base.(interface{ MutationRevision() uint64 }); ok {
+		return revisioner.MutationRevision(), true
+	}
+	if revisioner, ok := v.base.(interface{ SearchMutationRevision() (uint64, bool) }); ok {
+		return revisioner.SearchMutationRevision()
+	}
+	return 0, false
+}
+
+var _ NodeSearchKeyScanner = (*OverlaidView)(nil)

--- a/internal/graph/store.go
+++ b/internal/graph/store.go
@@ -552,11 +552,10 @@ type SymbolSearcher interface {
 	SearchSymbols(query string, limit int) ([]SymbolHit, error)
 }
 
-// SymbolFTSCounter is the optional authoritative document count. The
-// search.Backend Count() contract reports a since-construction delta of the
-// indexer's Add/Remove calls, which is not a corpus size and can legitimately
-// be negative; anything that wants to report how many documents are actually
-// indexed must ask the store instead of the adapter.
+// SymbolFTSCounter is the optional authoritative document count. Search
+// adapters use it to seed readiness lazily, while user-facing reporting reads
+// it directly because the adapter's cached snapshot plus incremental deltas can
+// drift from the current corpus size.
 type SymbolFTSCounter interface {
 	SymbolFTSCount() (int, error)
 }

--- a/internal/graph/store_sqlite/node_search_keys.go
+++ b/internal/graph/store_sqlite/node_search_keys.go
@@ -1,0 +1,122 @@
+package store_sqlite
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// ScanNodeSearchKeys reads the compact search projection in bounded ID-keyset
+// pages. Each page cursor is fully consumed and closed before yield runs, so a
+// callback may safely re-enter Store and no long-lived read snapshot pins WAL
+// checkpoints while ranking candidates.
+func (s *Store) ScanNodeSearchKeys(ctx context.Context, pageSize int, yield func([]graph.NodeSearchKey) bool) error {
+	if s == nil || yield == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if pageSize <= 0 {
+		pageSize = graph.DefaultNodeSearchKeyPageSize
+	}
+
+	// Freeze the upper boundary so inserts with larger IDs cannot extend an
+	// in-progress scan indefinitely. The query layer compares MutationRevision
+	// around scan + hydration and retries once when any committed mutation races.
+	var highWater string
+	err := s.db.QueryRowContext(ctx, `SELECT id FROM nodes ORDER BY id DESC LIMIT 1`).Scan(&highWater)
+	if err == sql.ErrNoRows {
+		return nil
+	}
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		panicOnFatal(err)
+		return nil
+	}
+
+	after := ""
+	firstPage := true
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		var rows *sql.Rows
+		if firstPage {
+			rows, err = s.db.QueryContext(ctx, `
+SELECT id, kind, name
+FROM nodes
+WHERE id <= ?
+ORDER BY id
+LIMIT ?`, highWater, pageSize)
+		} else {
+			rows, err = s.db.QueryContext(ctx, `
+SELECT id, kind, name
+FROM nodes
+WHERE id > ? AND id <= ?
+ORDER BY id
+LIMIT ?`, after, highWater, pageSize)
+		}
+		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+			panicOnFatal(err)
+			return nil
+		}
+
+		page := make([]graph.NodeSearchKey, 0, pageSize)
+		for rows.Next() {
+			var key graph.NodeSearchKey
+			if scanErr := rows.Scan(&key.ID, &key.Kind, &key.Name); scanErr != nil {
+				_ = rows.Close()
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return ctxErr
+				}
+				panicOnFatal(scanErr)
+				return nil
+			}
+			page = append(page, key)
+		}
+		rowsErr := rows.Err()
+		closeErr := rows.Close()
+		if rowsErr != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+			panicOnFatal(rowsErr)
+			return nil
+		}
+		if closeErr != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+			panicOnFatal(closeErr)
+			return nil
+		}
+		if len(page) == 0 {
+			return nil
+		}
+
+		after = page[len(page)-1].ID
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if !yield(page) {
+			return nil
+		}
+		if len(page) < pageSize {
+			return nil
+		}
+		firstPage = false
+	}
+}
+
+var _ graph.NodeSearchKeyScanner = (*Store)(nil)

--- a/internal/graph/store_sqlite/node_search_keys_test.go
+++ b/internal/graph/store_sqlite/node_search_keys_test.go
@@ -1,0 +1,145 @@
+package store_sqlite
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func openNodeSearchKeyTestStore(tb testing.TB) *Store {
+	tb.Helper()
+	store, err := Open(filepath.Join(tb.TempDir(), "graph.db"))
+	if err != nil {
+		tb.Fatalf("Open: %v", err)
+	}
+	tb.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			tb.Errorf("Close: %v", err)
+		}
+	})
+	return store
+}
+
+func TestScanNodeSearchKeysUsesBoundedOrderedPagesAndClosesRows(t *testing.T) {
+	store := openNodeSearchKeyTestStore(t)
+	for _, node := range []*graph.Node{
+		{ID: "c.go::Gamma", Kind: graph.KindFunction, Name: "Gamma", FilePath: "c.go"},
+		{ID: "a.go::Alpha", Kind: graph.KindMethod, Name: "Alpha", FilePath: "a.go"},
+		{ID: "b.go::Beta", Kind: graph.KindFunction, Name: "Beta", FilePath: "b.go"},
+	} {
+		store.AddNode(node)
+	}
+
+	// A single reader connection makes an accidentally open page cursor
+	// observable in the callback: InUse would remain one and a point lookup
+	// would have no connection available.
+	store.db.SetMaxOpenConns(1)
+	store.db.SetMaxIdleConns(1)
+
+	var got []graph.NodeSearchKey
+	var pageSizes []int
+	insertedAfterHighWater := false
+	err := store.ScanNodeSearchKeys(context.Background(), 1, func(page []graph.NodeSearchKey) bool {
+		pageSizes = append(pageSizes, len(page))
+		if inUse := store.db.Stats().InUse; inUse != 0 {
+			t.Fatalf("reader connections in use during callback = %d, want 0", inUse)
+		}
+		if store.GetNode(page[0].ID) == nil {
+			t.Fatalf("callback could not re-enter Store for %q", page[0].ID)
+		}
+		got = append(got, page...)
+		if !insertedAfterHighWater {
+			insertedAfterHighWater = true
+			store.AddNode(&graph.Node{ID: "z.go::Later", Kind: graph.KindFunction, Name: "Later", FilePath: "z.go"})
+		}
+		return true
+	})
+	if err != nil {
+		t.Fatalf("ScanNodeSearchKeys: %v", err)
+	}
+	want := []graph.NodeSearchKey{
+		{ID: "a.go::Alpha", Kind: graph.KindMethod, Name: "Alpha"},
+		{ID: "b.go::Beta", Kind: graph.KindFunction, Name: "Beta"},
+		{ID: "c.go::Gamma", Kind: graph.KindFunction, Name: "Gamma"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("keys = %#v, want %#v", got, want)
+	}
+	if !reflect.DeepEqual(pageSizes, []int{1, 1, 1}) {
+		t.Fatalf("page sizes = %v, want [1 1 1]", pageSizes)
+	}
+}
+
+func TestScanNodeSearchKeysReturnsCancellationBetweenPages(t *testing.T) {
+	store := openNodeSearchKeyTestStore(t)
+	for _, id := range []string{"a.go::A", "b.go::B", "c.go::C"} {
+		store.AddNode(&graph.Node{ID: id, Kind: graph.KindFunction, Name: id, FilePath: graph.IDFile(id)})
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	err := store.ScanNodeSearchKeys(ctx, 1, func([]graph.NodeSearchKey) bool {
+		calls++
+		cancel()
+		return true
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if calls != 1 {
+		t.Fatalf("callbacks = %d, want 1", calls)
+	}
+}
+
+var nodeSearchKeyBenchmarkCount int
+
+func BenchmarkScanNodeSearchKeysVsAllNodes(b *testing.B) {
+	store := openNodeSearchKeyTestStore(b)
+	const nodeCount = 2048
+	payload := strings.Repeat("nontrivial metadata payload ", 64)
+	nodes := make([]*graph.Node, 0, nodeCount)
+	for i := 0; i < nodeCount; i++ {
+		file := fmt.Sprintf("pkg/file_%05d.go", i)
+		nodes = append(nodes, &graph.Node{
+			ID:       fmt.Sprintf("%s::Symbol_%05d", file, i),
+			Kind:     graph.KindFunction,
+			Name:     fmt.Sprintf("Symbol_%05d", i),
+			FilePath: file,
+			Language: "go",
+			Meta: map[string]any{
+				"payload": payload,
+				"ordinal": i,
+				"active":  i%2 == 0,
+			},
+		})
+	}
+	store.AddBatch(nodes, nil)
+
+	b.Run("AllNodes", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			nodeSearchKeyBenchmarkCount = len(store.AllNodes())
+		}
+	})
+
+	b.Run("ScanNodeSearchKeys", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			count := 0
+			err := store.ScanNodeSearchKeys(context.Background(), graph.DefaultNodeSearchKeyPageSize, func(page []graph.NodeSearchKey) bool {
+				count += len(page)
+				return true
+			})
+			if err != nil {
+				b.Fatalf("ScanNodeSearchKeys: %v", err)
+			}
+			nodeSearchKeyBenchmarkCount = count
+		}
+	})
+}

--- a/internal/query/engine.go
+++ b/internal/query/engine.go
@@ -1,6 +1,8 @@
 package query
 
 import (
+	"container/heap"
+	"context"
 	"sort"
 	"strconv"
 	"strings"
@@ -946,67 +948,184 @@ type bigramProvider interface {
 	BigramCandidates(query string, minOverlap int) []string
 }
 
-func (e *Engine) searchSubstring(query string, limit int) []*graph.Node {
-	lower := strings.ToLower(query)
+const substringSearchPageSize = 256
 
-	exact := e.g.FindNodesByName(query)
+type substringCandidate struct {
+	id      string
+	nameLen int
+	score   int
+}
 
-	type scored struct {
+func substringCandidateBetter(a, b substringCandidate) bool {
+	if a.score != b.score {
+		return a.score < b.score
+	}
+	if a.nameLen != b.nameLen {
+		return a.nameLen < b.nameLen
+	}
+	return a.id < b.id
+}
+
+// substringCandidateHeap keeps the worst retained candidate at its root.
+type substringCandidateHeap []substringCandidate
+
+func (h substringCandidateHeap) Len() int { return len(h) }
+func (h substringCandidateHeap) Less(i, j int) bool {
+	return substringCandidateBetter(h[j], h[i])
+}
+func (h substringCandidateHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+func (h *substringCandidateHeap) Push(x any) {
+	*h = append(*h, x.(substringCandidate))
+}
+func (h *substringCandidateHeap) Pop() any {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+type nodeSearchMutationRevisioner interface {
+	SearchMutationRevision() (uint64, bool)
+}
+
+type nodeMutationRevisioner interface {
+	MutationRevision() uint64
+}
+
+func nodeMutationRevision(r graph.Reader) (uint64, bool) {
+	if revisioned, ok := r.(nodeSearchMutationRevisioner); ok {
+		return revisioned.SearchMutationRevision()
+	}
+	if revisioned, ok := r.(nodeMutationRevisioner); ok {
+		return revisioned.MutationRevision(), true
+	}
+	return 0, false
+}
+
+func nodeMutationChanged(r graph.Reader, before uint64, known bool) bool {
+	if !known {
+		return false
+	}
+	after, ok := nodeMutationRevision(r)
+	return ok && after != before
+}
+
+func substringScore(id, name string, kind graph.NodeKind, query, lower string) (int, bool) {
+	if kind == graph.KindFile || kind == graph.KindImport {
+		return 0, false
+	}
+	switch {
+	case name == query:
+		return 0, true
+	case hasPrefixFold(name, lower):
+		return 1, true
+	case containsFold(name, lower):
+		return 2, true
+	case containsFold(id, lower):
+		return 3, true
+	default:
+		return 0, false
+	}
+}
+
+func (e *Engine) scanSubstringCandidates(query, lower string, limit int) ([]substringCandidate, error) {
+	top := make(substringCandidateHeap, 0, limit)
+	err := graph.ScanNodeSearchKeys(context.Background(), e.g, substringSearchPageSize, func(page []graph.NodeSearchKey) bool {
+		for _, key := range page {
+			score, ok := substringScore(key.ID, key.Name, key.Kind, query, lower)
+			if !ok {
+				continue
+			}
+			candidate := substringCandidate{id: key.ID, nameLen: len(key.Name), score: score}
+			if len(top) < limit {
+				candidate.id = strings.Clone(candidate.id)
+				heap.Push(&top, candidate)
+				continue
+			}
+			if substringCandidateBetter(candidate, top[0]) {
+				candidate.id = strings.Clone(candidate.id)
+				top[0] = candidate
+				heap.Fix(&top, 0)
+			}
+		}
+		return true
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(top, func(i, j int) bool {
+		return substringCandidateBetter(top[i], top[j])
+	})
+	return top, nil
+}
+
+func (e *Engine) hydrateSubstringCandidates(candidates []substringCandidate, query, lower string, limit int) []*graph.Node {
+	ids := make([]string, len(candidates))
+	for i := range candidates {
+		ids[i] = candidates[i].id
+	}
+	nodeByID := e.g.GetNodesByIDs(ids)
+
+	type hydratedCandidate struct {
 		node  *graph.Node
 		score int
 	}
-	var results []scored
-	seen := make(map[string]bool)
-
-	for _, n := range exact {
-		if n.Kind == graph.KindFile || n.Kind == graph.KindImport {
+	hydrated := make([]hydratedCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		node := nodeByID[candidate.id]
+		if node == nil {
 			continue
 		}
-		seen[n.ID] = true
-		results = append(results, scored{n, 0})
+		score, ok := substringScore(node.ID, node.Name, node.Kind, query, lower)
+		if !ok {
+			continue
+		}
+		hydrated = append(hydrated, hydratedCandidate{node: node, score: score})
 	}
-
-	// Fold-matching instead of lowering every candidate: ToLower on both the
-	// name and the ID of every node allocated two strings per node per query
-	// — a quarter-million allocations per call on a mid-size graph, on the
-	// degraded-mode path a stale search index falls back to.
-	allNodes := e.g.AllNodes()
-	for _, n := range allNodes {
-		if seen[n.ID] || n.Kind == graph.KindFile || n.Kind == graph.KindImport {
-			continue
+	sort.Slice(hydrated, func(i, j int) bool {
+		if hydrated[i].score != hydrated[j].score {
+			return hydrated[i].score < hydrated[j].score
 		}
-		if hasPrefixFold(n.Name, lower) {
-			results = append(results, scored{n, 1})
-		} else if containsFold(n.Name, lower) {
-			results = append(results, scored{n, 2})
-		} else if containsFold(n.ID, lower) {
-			results = append(results, scored{n, 3})
-		} else {
-			continue
+		if len(hydrated[i].node.Name) != len(hydrated[j].node.Name) {
+			return len(hydrated[i].node.Name) < len(hydrated[j].node.Name)
 		}
-		seen[n.ID] = true
-	}
-
-	sort.Slice(results, func(i, j int) bool {
-		if results[i].score != results[j].score {
-			return results[i].score < results[j].score
-		}
-		if len(results[i].node.Name) != len(results[j].node.Name) {
-			return len(results[i].node.Name) < len(results[j].node.Name)
-		}
-		// Final tie-break on node ID — equal (score, name-length)
-		// pairs would otherwise resolve in random map-iteration order.
-		return results[i].node.ID < results[j].node.ID
+		return hydrated[i].node.ID < hydrated[j].node.ID
 	})
-
-	out := make([]*graph.Node, 0, limit)
-	for i, r := range results {
-		if i >= limit {
-			break
-		}
-		out = append(out, r.node)
+	if len(hydrated) > limit {
+		hydrated = hydrated[:limit]
+	}
+	out := make([]*graph.Node, len(hydrated))
+	for i := range hydrated {
+		out[i] = hydrated[i].node
 	}
 	return out
+}
+
+func (e *Engine) searchSubstring(query string, limit int) []*graph.Node {
+	if limit <= 0 {
+		return nil
+	}
+	lower := strings.ToLower(query)
+	for attempt := 0; attempt < 2; attempt++ {
+		before, revisionKnown := nodeMutationRevision(e.g)
+		candidates, err := e.scanSubstringCandidates(query, lower, limit)
+		if err != nil {
+			// SearchSymbols cannot return an error. Preserve the Reader contract:
+			// unexpected storage failures must remain visible, not look like an
+			// ordinary empty result.
+			panic(err)
+		}
+		if attempt == 0 && nodeMutationChanged(e.g, before, revisionKnown) {
+			continue
+		}
+		out := e.hydrateSubstringCandidates(candidates, query, lower, limit)
+		if attempt == 0 && nodeMutationChanged(e.g, before, revisionKnown) {
+			continue
+		}
+		return out
+	}
+	return nil
 }
 
 // SearchSymbolsInRepo performs full-text search filtered to a specific repository.

--- a/internal/query/substring_fallback_test.go
+++ b/internal/query/substring_fallback_test.go
@@ -1,0 +1,296 @@
+package query
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+type substringProbeStore struct {
+	*graph.Graph
+
+	scanCalls        int
+	pageCalls        int
+	maxPage          int
+	allNodesCalls    int
+	hydrationBatches [][]string
+	revisions        []uint64
+	revisionCalls    int
+}
+
+func (s *substringProbeStore) ScanNodeSearchKeys(
+	ctx context.Context,
+	pageSize int,
+	yield func([]graph.NodeSearchKey) bool,
+) error {
+	s.scanCalls++
+	return s.Graph.ScanNodeSearchKeys(ctx, pageSize, func(page []graph.NodeSearchKey) bool {
+		s.pageCalls++
+		if len(page) > s.maxPage {
+			s.maxPage = len(page)
+		}
+		return yield(page)
+	})
+}
+
+func (s *substringProbeStore) GetNodesByIDs(ids []string) map[string]*graph.Node {
+	s.hydrationBatches = append(s.hydrationBatches, append([]string(nil), ids...))
+	return s.Graph.GetNodesByIDs(ids)
+}
+
+func (s *substringProbeStore) AllNodes() []*graph.Node {
+	s.allNodesCalls++
+	return s.Graph.AllNodes()
+}
+
+func (s *substringProbeStore) MutationRevision() uint64 {
+	s.revisionCalls++
+	if len(s.revisions) == 0 {
+		return s.Graph.MutationRevision()
+	}
+	idx := s.revisionCalls - 1
+	if idx >= len(s.revisions) {
+		return s.revisions[len(s.revisions)-1]
+	}
+	return s.revisions[idx]
+}
+
+func newSubstringGraph(nodes ...*graph.Node) *graph.Graph {
+	g := graph.New()
+	for _, node := range nodes {
+		g.AddNode(node)
+	}
+	return g
+}
+
+func substringNodeIDs(nodes []*graph.Node) []string {
+	ids := make([]string, len(nodes))
+	for i, node := range nodes {
+		ids[i] = node.ID
+	}
+	return ids
+}
+
+// legacySubstringSearch reproduces the pre-paging implementation. Keeping the
+// oracle in the test makes ranking changes visible independently of scan order.
+func legacySubstringSearch(r graph.Reader, query string, limit int) []*graph.Node {
+	if limit <= 0 {
+		return nil
+	}
+	lower := strings.ToLower(query)
+	type scored struct {
+		node  *graph.Node
+		score int
+	}
+	var results []scored
+	seen := make(map[string]bool)
+	for _, node := range r.FindNodesByName(query) {
+		if node.Kind == graph.KindFile || node.Kind == graph.KindImport {
+			continue
+		}
+		seen[node.ID] = true
+		results = append(results, scored{node: node, score: 0})
+	}
+	for _, node := range r.AllNodes() {
+		if seen[node.ID] || node.Kind == graph.KindFile || node.Kind == graph.KindImport {
+			continue
+		}
+		score := 0
+		switch {
+		case hasPrefixFold(node.Name, lower):
+			score = 1
+		case containsFold(node.Name, lower):
+			score = 2
+		case containsFold(node.ID, lower):
+			score = 3
+		default:
+			continue
+		}
+		seen[node.ID] = true
+		results = append(results, scored{node: node, score: score})
+	}
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].score != results[j].score {
+			return results[i].score < results[j].score
+		}
+		if len(results[i].node.Name) != len(results[j].node.Name) {
+			return len(results[i].node.Name) < len(results[j].node.Name)
+		}
+		return results[i].node.ID < results[j].node.ID
+	})
+	if len(results) > limit {
+		results = results[:limit]
+	}
+	out := make([]*graph.Node, len(results))
+	for i := range results {
+		out[i] = results[i].node
+	}
+	return out
+}
+
+func TestSearchSubstringMatchesLegacyRanking(t *testing.T) {
+	g := newSubstringGraph(
+		&graph.Node{ID: "exact", Kind: graph.KindFunction, Name: "needle"},
+		&graph.Node{ID: "prefix", Kind: graph.KindMethod, Name: "NeedleWorker"},
+		&graph.Node{ID: "contains", Kind: graph.KindType, Name: "useNEEDLEValue"},
+		&graph.Node{ID: "repo::needle::id-only", Kind: graph.KindFunction, Name: "Elsewhere"},
+		&graph.Node{ID: "unicode-prefix", Kind: graph.KindFunction, Name: "Ångström"},
+		&graph.Node{ID: "unicode-contains", Kind: graph.KindFunction, Name: "preÅNGpost"},
+		&graph.Node{ID: "tie-z", Kind: graph.KindFunction, Name: "xfoo"},
+		&graph.Node{ID: "tie-a", Kind: graph.KindFunction, Name: "yfoo"},
+		&graph.Node{ID: "needle.go", Kind: graph.KindFile, Name: "needle"},
+		&graph.Node{ID: "import::needle", Kind: graph.KindImport, Name: "needle"},
+		&graph.Node{ID: "unrelated", Kind: graph.KindVariable, Name: "Other"},
+	)
+	engine := NewEngine(g)
+	for _, tc := range []struct {
+		query string
+		limit int
+	}{
+		{query: "needle", limit: 20},
+		{query: "ång", limit: 20},
+		{query: "foo", limit: 1},
+		{query: "foo", limit: 20},
+		{query: "missing", limit: 20},
+	} {
+		t.Run(fmt.Sprintf("%s/limit=%d", tc.query, tc.limit), func(t *testing.T) {
+			want := substringNodeIDs(legacySubstringSearch(g, tc.query, tc.limit))
+			got := substringNodeIDs(engine.searchSubstring(tc.query, tc.limit))
+			if fmt.Sprint(got) != fmt.Sprint(want) {
+				t.Fatalf("searchSubstring(%q, %d) = %v, legacy = %v", tc.query, tc.limit, got, want)
+			}
+		})
+	}
+}
+
+func TestSearchSubstringCaseFoldIDAndExcludedKinds(t *testing.T) {
+	g := newSubstringGraph(
+		&graph.Node{ID: "exact", Kind: graph.KindFunction, Name: "needle"},
+		&graph.Node{ID: "prefix-short", Kind: graph.KindFunction, Name: "NeedleX"},
+		&graph.Node{ID: "prefix-long", Kind: graph.KindFunction, Name: "NEEDLEHandler"},
+		&graph.Node{ID: "name-substring", Kind: graph.KindFunction, Name: "useNEEDLE"},
+		&graph.Node{ID: "repo::needle::id-only", Kind: graph.KindFunction, Name: "Elsewhere"},
+		&graph.Node{ID: "needle.go", Kind: graph.KindFile, Name: "needle"},
+		&graph.Node{ID: "import::needle", Kind: graph.KindImport, Name: "needle"},
+	)
+	got := substringNodeIDs(NewEngine(g).searchSubstring("needle", 20))
+	want := []string{"exact", "prefix-short", "prefix-long", "name-substring", "repo::needle::id-only"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("results = %v, want %v", got, want)
+	}
+}
+
+func TestSearchSubstringUnicodeMatchesCurrentFoldHelpers(t *testing.T) {
+	g := newSubstringGraph(
+		&graph.Node{ID: "unicode-prefix", Kind: graph.KindFunction, Name: "Ångström"},
+		&graph.Node{ID: "unicode-substring", Kind: graph.KindFunction, Name: "preÅNGpost"},
+		&graph.Node{ID: "length-changing-fold", Kind: graph.KindFunction, Name: "Kelvin"},
+	)
+	engine := NewEngine(g)
+	if got, want := substringNodeIDs(engine.searchSubstring("ång", 20)), []string{"unicode-prefix", "unicode-substring"}; fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("Unicode fold results = %v, want %v", got, want)
+	}
+	if got := engine.searchSubstring("kel", 20); len(got) != 0 {
+		t.Fatalf("length-changing Kelvin fold unexpectedly matched: %v", substringNodeIDs(got))
+	}
+}
+
+func TestSearchSubstringTiesUseByteLengthThenID(t *testing.T) {
+	g := newSubstringGraph(
+		&graph.Node{ID: "z-short", Kind: graph.KindFunction, Name: "xfoo"},
+		&graph.Node{ID: "a-short", Kind: graph.KindFunction, Name: "yfoo"},
+		&graph.Node{ID: "m-short", Kind: graph.KindFunction, Name: "wfoo"},
+		&graph.Node{ID: "a-long", Kind: graph.KindFunction, Name: "éfoo"},
+	)
+	got := substringNodeIDs(NewEngine(g).searchSubstring("foo", 20))
+	want := []string{"a-short", "m-short", "z-short", "a-long"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("results = %v, want byte-length then ID order %v", got, want)
+	}
+}
+
+func TestSearchSubstringHonorsLimit(t *testing.T) {
+	g := newSubstringGraph(
+		&graph.Node{ID: "exact", Kind: graph.KindFunction, Name: "needle"},
+		&graph.Node{ID: "prefix", Kind: graph.KindFunction, Name: "NeedleWorker"},
+		&graph.Node{ID: "substring", Kind: graph.KindFunction, Name: "useNeedle"},
+	)
+	engine := NewEngine(g)
+	if got, want := substringNodeIDs(engine.searchSubstring("needle", 2)), []string{"exact", "prefix"}; fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("limited results = %v, want %v", got, want)
+	}
+	if got := engine.searchSubstring("needle", 0); got != nil {
+		t.Fatalf("zero limit returned %v, want nil", substringNodeIDs(got))
+	}
+	if got := engine.searchSubstring("needle", -1); got != nil {
+		t.Fatalf("negative limit returned %v, want nil", substringNodeIDs(got))
+	}
+}
+
+func TestSearchSubstringBoundsPagesAndHydration(t *testing.T) {
+	g := graph.New()
+	for i := 0; i < substringSearchPageSize*3+17; i++ {
+		g.AddNode(&graph.Node{
+			ID:   fmt.Sprintf("bulk/%04d", i),
+			Kind: graph.KindFunction,
+			Name: fmt.Sprintf("candidate-%04d-needle", i),
+			Meta: map[string]any{"payload": strings.Repeat("x", 256)},
+		})
+	}
+	g.AddNode(&graph.Node{ID: "winner-exact", Kind: graph.KindFunction, Name: "needle"})
+	g.AddNode(&graph.Node{ID: "winner-prefix", Kind: graph.KindFunction, Name: "NeedleX"})
+
+	probe := &substringProbeStore{Graph: g}
+	const limit = 11
+	got := NewEngine(probe).searchSubstring("needle", limit)
+	want := legacySubstringSearch(g, "needle", limit)
+	if gotIDs, wantIDs := substringNodeIDs(got), substringNodeIDs(want); fmt.Sprint(gotIDs) != fmt.Sprint(wantIDs) {
+		t.Fatalf("top-K results = %v, legacy = %v", gotIDs, wantIDs)
+	}
+	if probe.scanCalls != 1 {
+		t.Fatalf("scan calls = %d, want 1", probe.scanCalls)
+	}
+	if probe.pageCalls < 4 {
+		t.Fatalf("page callbacks = %d, want at least 4", probe.pageCalls)
+	}
+	if probe.maxPage > substringSearchPageSize {
+		t.Fatalf("largest page = %d, want <= %d", probe.maxPage, substringSearchPageSize)
+	}
+	if probe.allNodesCalls != 0 {
+		t.Fatalf("AllNodes calls = %d, want 0", probe.allNodesCalls)
+	}
+	if len(probe.hydrationBatches) != 1 {
+		t.Fatalf("hydration calls = %d, want 1", len(probe.hydrationBatches))
+	}
+	if got := len(probe.hydrationBatches[0]); got != limit {
+		t.Fatalf("hydrated IDs = %d, want exactly top-K limit %d", got, limit)
+	}
+}
+
+func TestSearchSubstringRetriesExactlyOnceAfterMutation(t *testing.T) {
+	g := newSubstringGraph(
+		&graph.Node{ID: "match", Kind: graph.KindFunction, Name: "Needle"},
+		&graph.Node{ID: "other", Kind: graph.KindFunction, Name: "Other"},
+	)
+	// The first attempt sees a stable scan (7 -> 7), hydrates, then observes
+	// revision 8. The second attempt starts at 8 and is returned without a
+	// third attempt even though the implementation deliberately caps retries.
+	probe := &substringProbeStore{Graph: g, revisions: []uint64{7, 7, 8, 8}}
+	got := NewEngine(probe).searchSubstring("needle", 5)
+	if gotIDs, want := substringNodeIDs(got), []string{"match"}; fmt.Sprint(gotIDs) != fmt.Sprint(want) {
+		t.Fatalf("results = %v, want %v", gotIDs, want)
+	}
+	if probe.scanCalls != 2 {
+		t.Fatalf("scan calls = %d, want 2 (one retry)", probe.scanCalls)
+	}
+	if len(probe.hydrationBatches) != 2 {
+		t.Fatalf("hydration calls = %d, want 2 (one retry)", len(probe.hydrationBatches))
+	}
+	if probe.revisionCalls != 4 {
+		t.Fatalf("revision calls = %d, want 4", probe.revisionCalls)
+	}
+}

--- a/internal/search/symbolsearcher_backend.go
+++ b/internal/search/symbolsearcher_backend.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	"github.com/zzet/gortex/internal/graph"
@@ -35,14 +36,12 @@ import (
 type SymbolSearcherBackend struct {
 	s graph.SymbolSearcher
 
-	// count tracks the indexer's incremental Add / Remove deltas
-	// only — it does NOT report the actual size of the backend
-	// FTS index (which lives in the disk store and is queryable
-	// via the SymbolSearcher's own primitives). Used for the
-	// search.Backend.Count() contract by callers that just want a
-	// rough magnitude (no caller currently treats this as
-	// authoritative).
-	count atomic.Int64
+	// count is lazily seeded from the authoritative persisted FTS count on its
+	// first read, then follows the indexer's incremental Add/Remove deltas. Lazy
+	// initialization avoids a discarded global count query for each per-repo
+	// Indexer constructed by MultiIndexer.
+	countInit sync.Once
+	count     atomic.Int64
 }
 
 // NewSymbolSearcherBackend wraps a SymbolSearcher in the
@@ -120,10 +119,9 @@ func (b *SymbolSearcherBackend) Search(query string, limit int) []SearchResult {
 }
 
 // Add is a no-op — the indexer drives UpsertSymbolFTS on the wrapped
-// SymbolSearcher directly. count is bumped so the Count() figure
-// tracks the deltas-since-construction (best-effort, not
-// authoritative — the disk index may be larger from a prior cold
-// load).
+// SymbolSearcher directly. count is bumped immediately so deltas that arrive
+// before the first Count call are preserved when the persisted snapshot is
+// added.
 func (b *SymbolSearcherBackend) Add(id string, _ ...string) {
 	if b == nil || id == "" {
 		return
@@ -142,25 +140,30 @@ func (b *SymbolSearcherBackend) Remove(id string) {
 	b.count.Add(-1)
 }
 
-// Count returns the running delta-since-construction. Used for
-// observability / "is the index populated?" gates — never as a
-// load-bearing decision input. The authoritative size lives in
-// the disk FTS index, which is queryable via the
-// SymbolSearcher's native primitives if needed.
+// Count returns the persisted corpus snapshot observed on its first call plus
+// subsequent Add/Remove deltas. It is suitable for readiness gates and rough
+// magnitude only; DocCount reads the authoritative current size.
 func (b *SymbolSearcherBackend) Count() int {
 	if b == nil {
 		return 0
 	}
+	b.countInit.Do(func() {
+		if counter, ok := b.s.(graph.SymbolFTSCounter); ok {
+			if count, err := counter.SymbolFTSCount(); err == nil && count > 0 {
+				b.count.Add(int64(count))
+			}
+		}
+	})
 	return int(b.count.Load())
 }
 
 // DocCount returns the authoritative number of indexed documents, straight
 // from the underlying index, and reports whether it could be obtained.
 //
-// Count() must not be used for this: it is a delta of the indexer's Add and
-// Remove calls since construction, so it is not a corpus size and can be
-// negative. Anything user-facing asks here and omits the figure when the
-// answer is unavailable, rather than printing the delta.
+// Count() must not be used for this: its cached readiness snapshot can drift as
+// direct store maintenance and best-effort Add/Remove deltas diverge. Anything
+// user-facing asks here and omits the figure when the authoritative answer is
+// unavailable.
 func (b *SymbolSearcherBackend) DocCount() (int, bool) {
 	if b == nil || b.s == nil {
 		return 0, false

--- a/internal/search/symbolsearcher_backend_test.go
+++ b/internal/search/symbolsearcher_backend_test.go
@@ -1,0 +1,81 @@
+package search
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+type symbolSearcherStub struct{}
+
+func (symbolSearcherStub) UpsertSymbolFTS(string, string) error { return nil }
+func (symbolSearcherStub) BulkUpsertSymbolFTS(string, []graph.SymbolFTSItem) error {
+	return nil
+}
+func (symbolSearcherStub) BuildSymbolIndex() error { return nil }
+func (symbolSearcherStub) SearchSymbols(string, int) ([]graph.SymbolHit, error) {
+	return nil, nil
+}
+
+type countedSymbolSearcherStub struct {
+	symbolSearcherStub
+	count int
+	err   error
+	calls int
+}
+
+func (s *countedSymbolSearcherStub) SymbolFTSCount() (int, error) {
+	s.calls++
+	return s.count, s.err
+}
+
+func TestNewSymbolSearcherBackendSeedsPersistedCountLazily(t *testing.T) {
+	store := &countedSymbolSearcherStub{count: 37}
+	backend := NewSymbolSearcherBackend(store)
+	if store.calls != 0 {
+		t.Fatalf("constructor SymbolFTSCount calls = %d, want 0", store.calls)
+	}
+
+	backend.Add("new-before-first-count")
+	if got := backend.Count(); got != 38 {
+		t.Fatalf("first Count() = %d, want persisted count plus prior delta 38", got)
+	}
+	if store.calls != 1 {
+		t.Fatalf("SymbolFTSCount calls = %d, want 1", store.calls)
+	}
+	if got := backend.Count(); got != 38 {
+		t.Fatalf("second Count() = %d, want cached count 38", got)
+	}
+	if store.calls != 1 {
+		t.Fatalf("repeated Count SymbolFTSCount calls = %d, want 1", store.calls)
+	}
+
+	backend.Remove("new-before-first-count")
+	if got := backend.Count(); got != 37 {
+		t.Fatalf("Count() after balanced delta = %d, want 37", got)
+	}
+}
+
+func TestNewSymbolSearcherBackendLeavesCountEmptyWithoutPersistedCorpus(t *testing.T) {
+	counterErr := errors.New("count unavailable")
+	tests := []struct {
+		name  string
+		store graph.SymbolSearcher
+	}{
+		{name: "nil store", store: nil},
+		{name: "counter unsupported", store: symbolSearcherStub{}},
+		{name: "empty corpus", store: &countedSymbolSearcherStub{}},
+		{name: "invalid negative count", store: &countedSymbolSearcherStub{count: -1}},
+		{name: "counter error", store: &countedSymbolSearcherStub{count: 41, err: counterErr}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backend := NewSymbolSearcherBackend(tt.store)
+			if got := backend.Count(); got != 0 {
+				t.Fatalf("Count() = %d, want 0", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- restore persisted SQLite FTS readiness after daemon restart so a warm index does not fall back to substring scanning
- replace full `AllNodes` decoding with bounded 256-row `(id, kind, name)` keyset pages behind an optional graph capability
- close every SQLite cursor before yielding, freeze a high-water mark, and retry once when the mutation revision changes
- retain only the exact top-K compact identities, then batch-hydrate and revalidate the winners
- preserve overlay masks, fallback compatibility, ranking semantics, and fatal SQLite error handling

## Performance

Apple M1 Pro, 2,048 metadata-heavy SQLite nodes, three runs:

| Path | Time/op | Bytes/op | Allocs/op |
| --- | ---: | ---: | ---: |
| `AllNodes` | 7.88–8.09 ms | 15,744,904 | 51,039 |
| compact key scan | 1.74–1.75 ms | 440,506 | 14,575 |

The compact scan is about 4.5x faster in this workload and reduces allocation bytes by about 97.2%.

## Verification

- `go test ./...`
- `go build ./internal/graph/... ./internal/graph/store_sqlite/... ./internal/query/...`
- `go test -race ./internal/graph/... ./internal/graph/store_sqlite/... ./internal/query/...`
- `golangci-lint run ./internal/search/... ./internal/query/... ./internal/graph/... ./cmd/gortex/...`
- `go test ./internal/graph/store_sqlite -run "^$" -bench "^BenchmarkScanNodeSearchKeysVsAllNodes$" -benchmem -count=3`
