### PR TITLE
test(mcp): release sidecar handles so TempDir can remove them on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
     # CGO build smoke-test on native Windows. tree-sitter needs a C/C++
     # compiler — the GitHub windows runner ships mingw-w64 on PATH, so no
     # extra toolchain setup is required. `go build ./...` compiles every
-    # production package; the focused agents test also exercises Windows-only
-    # integration paths without opting into the unsupported full test suite.
+    # production package; the focused agents and sidecar tests also exercise
+    # Windows-only paths without opting into the unsupported full test suite.
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -55,6 +55,13 @@ jobs:
 
       - name: Test Windows agent integrations
         run: go test -timeout=5m -count=1 ./internal/agents
+
+      # Windows refuses to unlink an open file, so a leaked sidecar handle
+      # pins its directory and fails the enclosing t.TempDir() cleanup. That
+      # asymmetry is invisible on the linux/macos matrix, which is why this
+      # one test runs here rather than only there.
+      - name: Test sidecar handle release
+        run: go test -timeout=5m -count=1 -run TestCloseSidecar ./internal/persistence
 
   build-linux-static:
     # The linux release ships a statically linked binary so it runs on any

--- a/internal/mcp/index_health_tool_surface_test.go
+++ b/internal/mcp/index_health_tool_surface_test.go
@@ -19,7 +19,7 @@ func TestIndexHealth_SurfacesToolPreset(t *testing.T) {
 	require.False(t, hasLearned)
 
 	// After a learned promotion, the count + names surface.
-	srv.InitLearnedTools(t.TempDir(), t.TempDir())
+	srv.InitLearnedTools(tempSidecarDir(t), tempSidecarDir(t))
 	srv.RecordLearnedPromotion("get_architecture", "")
 	payload = srv.buildIndexHealthPayload()
 	require.Equal(t, 1, payload["learned_tools"])

--- a/internal/mcp/memories_test.go
+++ b/internal/mcp/memories_test.go
@@ -169,6 +169,7 @@ func TestMemoryManager_PersistenceRoundTrip(t *testing.T) {
 	repoPath := filepath.Join(tmp, "fake-repo")
 	require.NoError(t, os.MkdirAll(repoPath, 0o755))
 	cacheDir := filepath.Join(tmp, "cache")
+	closeSidecarOnCleanup(t, cacheDir)
 
 	mm := newMemoryManager(cacheDir, repoPath)
 	_, err := mm.Save(persistence.MemoryEntry{

--- a/internal/mcp/notes_test.go
+++ b/internal/mcp/notes_test.go
@@ -98,7 +98,7 @@ func TestNotesManager_UpdateMissingID(t *testing.T) {
 }
 
 func TestNotesManager_PersistenceRoundTrip(t *testing.T) {
-	cache := t.TempDir()
+	cache := tempSidecarDir(t)
 	repo := "/tmp/notes-test-repo"
 
 	nm1 := newNotesManager(cache, repo)

--- a/internal/mcp/path_scope_test.go
+++ b/internal/mcp/path_scope_test.go
@@ -63,7 +63,7 @@ func TestApplyPathFilter_StripsRepoPrefix(t *testing.T) {
 }
 
 func TestSavedScope_PathsJSONRoundTrip(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "scopes.json")
+	path := filepath.Join(tempSidecarDir(t), "scopes.json")
 	st := newScopeStore(path)
 	require.NoError(t, st.put(SavedScope{
 		Name:  "billing",
@@ -83,7 +83,7 @@ func TestSavedScope_PathsJSONRoundTrip(t *testing.T) {
 }
 
 func TestResolvePathFilter_Sources(t *testing.T) {
-	t.Setenv("GORTEX_SCOPES_PATH", filepath.Join(t.TempDir(), "scopes.json"))
+	t.Setenv("GORTEX_SCOPES_PATH", filepath.Join(tempSidecarDir(t), "scopes.json"))
 	g := graph.New()
 	eng := query.NewEngine(g)
 	eng.SetSearch(search.NewBM25())

--- a/internal/mcp/promoted_tools_test.go
+++ b/internal/mcp/promoted_tools_test.go
@@ -18,8 +18,8 @@ import (
 // a promotion persists across "restarts" (fresh managers over the same
 // store) and is demoted once it has gone unused past the hysteresis window.
 func TestPromotedToolsManager_PersistAndDemote(t *testing.T) {
-	cacheDir := t.TempDir()
-	repo := filepath.Join(t.TempDir(), "repo")
+	cacheDir := tempSidecarDir(t)
+	repo := filepath.Join(tempSidecarDir(t), "repo")
 
 	// Session 1 (epoch 1): promote a deferred tool.
 	m1 := newPromotedToolsManager(cacheDir, repo)
@@ -40,8 +40,8 @@ func TestPromotedToolsManager_PersistAndDemote(t *testing.T) {
 // TestPromotedToolsManager_UseResetsClock: re-using a promotion resets its
 // demotion clock, so it outlives what would otherwise be its window.
 func TestPromotedToolsManager_UseResetsClock(t *testing.T) {
-	cacheDir := t.TempDir()
-	repo := filepath.Join(t.TempDir(), "repo")
+	cacheDir := tempSidecarDir(t)
+	repo := filepath.Join(tempSidecarDir(t), "repo")
 
 	// Promote at epoch 1, then re-use at epoch 2 (resets last_used to 2).
 	m1 := newPromotedToolsManager(cacheDir, repo)
@@ -77,8 +77,8 @@ func buildLearnedServer(t *testing.T, cacheDir, dir string) *Server {
 // in one session is re-promoted into the cold agent surface on the next
 // server startup — the learned surface persists across restarts.
 func TestLearnedSurface_SurvivesRestart(t *testing.T) {
-	cacheDir := t.TempDir()
-	dir := t.TempDir()
+	cacheDir := tempSidecarDir(t)
+	dir := tempSidecarDir(t)
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"),
 		[]byte("package app\n\nfunc Main() {}\n"), 0o644))
 

--- a/internal/mcp/scopes_test.go
+++ b/internal/mcp/scopes_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestScopeStore_PersistsRoundTrip(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "scopes.json")
+	path := filepath.Join(tempSidecarDir(t), "scopes.json")
 	st := newScopeStore(path)
 	require.NoError(t, st.put(SavedScope{Name: "backend", Description: "be", Repos: []string{"api", "core"}}))
 
@@ -31,7 +31,7 @@ func TestScopeStore_PersistsRoundTrip(t *testing.T) {
 // TestSavedScope_FiltersSearchResults drives save_scope + a scoped
 // search_symbols end-to-end and confirms the scope confines results.
 func TestSavedScope_FiltersSearchResults(t *testing.T) {
-	t.Setenv("GORTEX_SCOPES_PATH", filepath.Join(t.TempDir(), "scopes.json"))
+	t.Setenv("GORTEX_SCOPES_PATH", filepath.Join(tempSidecarDir(t), "scopes.json"))
 	srv, _, _ := newIsolationServer(t)
 	ctx := context.Background() // unbound session — the scope is the only filter
 
@@ -52,7 +52,7 @@ func TestSavedScope_FiltersSearchResults(t *testing.T) {
 }
 
 func TestSavedScope_UnknownScopeErrors(t *testing.T) {
-	t.Setenv("GORTEX_SCOPES_PATH", filepath.Join(t.TempDir(), "scopes.json"))
+	t.Setenv("GORTEX_SCOPES_PATH", filepath.Join(tempSidecarDir(t), "scopes.json"))
 	srv, _, _ := newIsolationServer(t)
 	req := mcplib.CallToolRequest{}
 	req.Params.Name = "search_symbols"

--- a/internal/mcp/sidecar_migration_test.go
+++ b/internal/mcp/sidecar_migration_test.go
@@ -15,7 +15,7 @@ import (
 // notes.gob.gz is imported into the sidecar on first manager open and
 // the legacy file is renamed to *.bak (never deleted).
 func TestNotesManager_MigratesLegacyGobGz(t *testing.T) {
-	cache := t.TempDir()
+	cache := tempSidecarDir(t)
 	repo := "/tmp/migrate-notes-repo"
 	legacyDir := persistence.NotesDir(cache, repo)
 	require.NoError(t, persistence.SaveNotes(legacyDir, &persistence.NoteStore{
@@ -45,7 +45,7 @@ func TestNotesManager_MigratesLegacyGobGz(t *testing.T) {
 
 // TestMemoryManager_MigratesLegacyGobGz proves the same for memories.
 func TestMemoryManager_MigratesLegacyGobGz(t *testing.T) {
-	cache := t.TempDir()
+	cache := tempSidecarDir(t)
 	repo := "/tmp/migrate-mem-repo"
 	legacyDir := persistence.MemoriesDir(cache, repo)
 	require.NoError(t, persistence.SaveMemories(legacyDir, &persistence.MemoryStore{
@@ -67,7 +67,7 @@ func TestMemoryManager_MigratesLegacyGobGz(t *testing.T) {
 // TestScopeStore_MigratesLegacyJSON proves a pre-existing scopes.json
 // is imported into the sidecar and renamed to *.bak.
 func TestScopeStore_MigratesLegacyJSON(t *testing.T) {
-	dir := t.TempDir()
+	dir := tempSidecarDir(t)
 	legacyPath := filepath.Join(dir, "scopes.json")
 	require.NoError(t, os.WriteFile(legacyPath,
 		[]byte(`[{"name":"backend","description":"be","repos":["api","core"]}]`), 0o644))
@@ -90,7 +90,7 @@ func TestScopeStore_MigratesLegacyJSON(t *testing.T) {
 // <repo>/.gortex/notebook/<id>.md files are imported into the sidecar
 // and renamed to *.bak.
 func TestNotebookManager_MigratesLegacyMarkdown(t *testing.T) {
-	repo := t.TempDir()
+	repo := tempNotebookRepo(t)
 	mdDir := filepath.Join(repo, ".gortex", "notebook")
 	require.NoError(t, os.MkdirAll(mdDir, 0o755))
 	md := notebookMarshal(notebookEntry{
@@ -115,7 +115,7 @@ func TestNotebookManager_MigratesLegacyMarkdown(t *testing.T) {
 // TestNotebookManager_PersistsAcrossRestart proves notebook entries
 // survive a manager restart (the sidecar is the durable store).
 func TestNotebookManager_PersistsAcrossRestart(t *testing.T) {
-	repo := t.TempDir()
+	repo := tempNotebookRepo(t)
 	nm1 := newNotebookManager(repo)
 	saved, err := nm1.Save(notebookEntry{Title: "t1", Body: "b1", Tags: []string{"x"}})
 	require.NoError(t, err)

--- a/internal/mcp/sidecar_testing_test.go
+++ b/internal/mcp/sidecar_testing_test.go
@@ -1,0 +1,47 @@
+package mcp
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/persistence"
+)
+
+// closeSidecarOnCleanup releases the sidecar rooted at dataDir before the
+// enclosing t.TempDir() is removed.
+//
+// OpenSidecar keeps handles in a process-wide cache keyed by absolute path, so
+// any manager built over a test directory leaves that file open for the life
+// of the test binary. POSIX unlinks an open file happily and nothing shows;
+// Windows refuses, t.TempDir()'s RemoveAll fails, and the test is reported as
+// failed even though every assertion in it passed.
+//
+// Cleanups run LIFO, so registering here — after t.TempDir() has registered
+// its own removal — closes the handle first.
+func closeSidecarOnCleanup(t *testing.T, dataDir string) {
+	t.Helper()
+	t.Cleanup(func() {
+		require.NoError(t, persistence.CloseSidecar(persistence.DefaultSidecarPath(dataDir)))
+	})
+}
+
+// tempSidecarDir is the common case: a temp directory used directly as a
+// manager's data dir.
+func tempSidecarDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	closeSidecarOnCleanup(t, dir)
+	return dir
+}
+
+// tempNotebookRepo returns a temp repo directory for the notebook manager,
+// which roots its sidecar at <repo>/.gortex rather than at the path it is
+// handed — so the release has to name that subdirectory.
+func tempNotebookRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	closeSidecarOnCleanup(t, filepath.Join(dir, ".gortex"))
+	return dir
+}

--- a/internal/mcp/tools_notebook_test.go
+++ b/internal/mcp/tools_notebook_test.go
@@ -16,7 +16,7 @@ import (
 
 func newNotebookTestServer(t *testing.T) (*Server, string) {
 	t.Helper()
-	dir := t.TempDir()
+	dir := tempNotebookRepo(t)
 	s := &Server{
 		graph:      graph.New(),
 		session:    newSessionState(),
@@ -227,7 +227,7 @@ func TestNotebook_NoDirManagerStillSafe(t *testing.T) {
 }
 
 func TestNotebook_PrunesByTTL(t *testing.T) {
-	dir := t.TempDir()
+	dir := tempNotebookRepo(t)
 	nm := newNotebookManager(dir)
 	// TTL must comfortably exceed the Save→prune latency. pruneLocked's
 	// cutoff is computed *after* the fresh entry's Updated stamp is
@@ -256,7 +256,7 @@ func TestNotebook_PrunesByTTL(t *testing.T) {
 }
 
 func TestNotebook_DeleteIdempotent(t *testing.T) {
-	dir := t.TempDir()
+	dir := tempNotebookRepo(t)
 	nm := newNotebookManager(dir)
 	_, _ = nm.Save(notebookEntry{ID: "x", Title: "x"})
 	require.NoError(t, nm.Delete("x"))

--- a/internal/persistence/sidecar_close_test.go
+++ b/internal/persistence/sidecar_close_test.go
@@ -1,0 +1,74 @@
+package persistence
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// CloseSidecar exists so a test can release the process-wide handle cache
+// before its temp directory is removed. On POSIX an open file unlinks happily,
+// so nothing here would fail even if CloseSidecar were a no-op — the case that
+// actually bites is Windows, where RemoveAll refuses while a handle is open.
+// This test is therefore wired into the Windows CI job as well.
+func TestCloseSidecar_ReleasesTheHandleAndStaysHarmless(t *testing.T) {
+	dir := t.TempDir()
+	path := DefaultSidecarPath(dir)
+
+	t.Run("closing a path that was never opened creates nothing", func(t *testing.T) {
+		unopened := filepath.Join(t.TempDir(), "nested", "sidecar.sqlite")
+		require.NoError(t, CloseSidecar(unopened))
+
+		_, err := os.Stat(unopened)
+		assert.True(t, os.IsNotExist(err), "no database file may be created")
+		_, err = os.Stat(filepath.Dir(unopened))
+		assert.True(t, os.IsNotExist(err), "no parent directory may be created")
+	})
+
+	t.Run("empty path is a no-op", func(t *testing.T) {
+		require.NoError(t, CloseSidecar(""))
+	})
+
+	first, err := OpenSidecar(path)
+	require.NoError(t, err)
+	require.NotNil(t, first)
+
+	t.Run("reopen after close yields a usable store", func(t *testing.T) {
+		require.NoError(t, CloseSidecar(path))
+
+		second, err := OpenSidecar(path)
+		require.NoError(t, err)
+		require.NotNil(t, second)
+		assert.NotSame(t, first, second,
+			"the cache entry must be gone, so a reopen builds a fresh store")
+
+		// Usable, not merely non-nil: the reopened handle has to serve a query.
+		var one int
+		require.NoError(t, second.db.QueryRow("SELECT 1").Scan(&one))
+		assert.Equal(t, 1, one)
+
+		require.NoError(t, CloseSidecar(path))
+	})
+
+	t.Run("closing repeatedly is harmless", func(t *testing.T) {
+		require.NoError(t, CloseSidecar(path))
+		require.NoError(t, CloseSidecar(path))
+	})
+
+	t.Run("the containing directory can be removed afterwards", func(t *testing.T) {
+		// The point of the whole exercise. RemoveAll succeeds on POSIX whether
+		// or not the handle was released, so this assertion only has teeth on
+		// a platform that refuses to unlink an open file.
+		if runtime.GOOS != "windows" {
+			t.Log("note: on this platform RemoveAll would succeed even with the handle open")
+		}
+		require.NoError(t, os.RemoveAll(dir),
+			"a released sidecar must not keep its directory pinned")
+		_, err := os.Stat(dir)
+		assert.True(t, os.IsNotExist(err))
+	})
+}

--- a/internal/persistence/sidecar_sqlite.go
+++ b/internal/persistence/sidecar_sqlite.go
@@ -351,8 +351,17 @@ func CloseSidecar(path string) error {
 	if err != nil {
 		abs = path
 	}
+	// Evict under the same lock that found it. Releasing between the lookup
+	// and the close would let a concurrent OpenSidecar hand out the handle
+	// this call is about to close; dropping the entry first makes that lookup
+	// miss and open a fresh one instead. Close still runs outside the lock —
+	// it takes sidecarMu itself to clear any other keys pointing at the same
+	// store.
 	sidecarMu.Lock()
 	st, ok := sidecarCache[abs]
+	if ok {
+		delete(sidecarCache, abs)
+	}
 	sidecarMu.Unlock()
 	if !ok || st == nil {
 		return nil

--- a/internal/persistence/sidecar_sqlite.go
+++ b/internal/persistence/sidecar_sqlite.go
@@ -334,6 +334,32 @@ func (s *SidecarStore) Close() error {
 	return s.db.Close()
 }
 
+// CloseSidecar closes the cached sidecar rooted at path, if one is open, and
+// drops it from the shared cache. Unlike OpenSidecar(path).Close() — the idiom
+// a test otherwise has to reach for — it never creates the file or its parent
+// directory when nothing was open, so a caller can release a path
+// unconditionally without leaving a database behind.
+//
+// The daemon holds its sidecar for the process lifetime; this exists for
+// teardown, where a still-open handle keeps the file locked on Windows and
+// makes an otherwise-passing test fail in RemoveAll.
+func CloseSidecar(path string) error {
+	if path == "" {
+		return nil
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		abs = path
+	}
+	sidecarMu.Lock()
+	st, ok := sidecarCache[abs]
+	sidecarMu.Unlock()
+	if !ok || st == nil {
+		return nil
+	}
+	return st.Close()
+}
+
 // ---------------------------------------------------------------------------
 // JSON helpers for []string columns.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`OpenSidecar` keeps handles in a process-wide cache keyed by absolute path, so
a manager built over a test directory holds that file open for the life of the
test binary. POSIX unlinks an open file happily and nothing shows. Windows
refuses, `t.TempDir()`'s `RemoveAll` fails, and the test is reported as failed
even though every assertion in it passed:

```
testing.go:1464: TempDir RemoveAll cleanup: unlinkat
...\001\sidecar.sqlite: The process cannot access the file because it is
being used by another process.
```

**28 tests** across the `mcp` package fail this way. Nothing in the message
points at the sidecar, so each one reads as an unrelated flake rather than one
shared cause.

## Changes

**`persistence.CloseSidecar(path)`** — closes the cached sidecar rooted at
`path` and drops it from the shared cache.

`5980a1f3` reached for `OpenSidecar(path).Close()` to release one test's
handle. That works, but it *creates* the file and its parent directory when
nothing was open — repeated across 28 call sites it would leave a trail of
empty databases behind every run. `CloseSidecar` returns `nil` when the cache
has nothing for that path, so a caller can release unconditionally.

**Test helpers**, registered through `t.Cleanup`. Ordering matters here:
cleanups run LIFO, so registering *after* `t.TempDir()` has queued its own
removal closes the handle first. Three shapes, because managers root their
sidecar differently and the difference is not visible at the call site:

| helper | for |
|---|---|
| `tempSidecarDir` | the directory *is* the data dir — notes, memories, promoted tools, scopes (via `filepath.Dir`) |
| `tempNotebookRepo` | `newNotebookManager` roots at `<repo>/.gortex` |
| `closeSidecarOnCleanup` | explicit, for tests deriving a cache dir themselves (memories) or passing two (learned tools) |

## Testing

Windows 11, go1.26.5, measured against `6d97beb1`:

| | before | after |
|---|---|---|
| affected test set | 29 failures | **1** |
| of those, `TempDir` cleanup | **28** | **0** |

The whole `mcp` package still reports 33 failures, **none of them new** — I ran
the same package on the baseline and diffed the failure sets. The remainder are
ordinary assertion failures unrelated to teardown, including
`TestNotesManager_SaveQueryDelete`, which fails identically without this
change.

Also clean: `golangci-lint v2.11.4` on `./internal/mcp/... ./internal/persistence/...`,
`go vet`, and `-race` over the affected tests. (`internal/persistence`'s
`TestFeedbackDir` fails on the baseline too — a separate path-separator issue,
same class as #411, untouched here.)

## Why this matters beyond the red

The test matrix is `[ubuntu-latest, macos-latest]` and `build-windows` only
builds, so nothing in CI ever exercises a teardown path where an open file
cannot be unlinked. That is why a whole cluster of tests can be red on Windows
indefinitely without anyone noticing.

I am not proposing a matrix change in this PR. Two smaller clusters remain
first — the plan-lock sqlite handles in `store_sqlite` and one git-dir case in
`analysis` — and both are a different mechanism than this one, so they want
separate changes. Happy to work through them if that is a direction you want.

## Checklist

- [x] New tests added for new functionality — n/a; this fixes existing tests'
      teardown. `CloseSidecar` is exercised by every helper that calls it.
- [x] Code follows existing patterns in the codebase
- [x] No unnecessary abstractions added
- [ ] `go test -race ./...` across the whole repository — I ran the affected
      packages plus `-race` over the touched tests; a full-repo race run does
      not finish in reasonable time on this machine, so I am leaving that to
      CI rather than claiming it.
- [ ] Benchmarks — not performance-relevant.
