### PR TITLE
Fix four stacked search-recall failures: post-filter wipeouts, cross-repo FTS floods, exact-name container hijack, warm-restart degradation

### DIFF
--- a/internal/graph/store.go
+++ b/internal/graph/store.go
@@ -724,6 +724,16 @@ type SymbolBundleSearcher interface {
 	SearchSymbolBundles(query string, limit int) ([]SymbolBundle, error)
 }
 
+// ScopedSymbolBundleSearcher is the repo-narrowed variant of
+// SymbolBundleSearcher: repoAllow filters inside the FTS query, not
+// over a bounded fetched head — a post-fetch filter starves when
+// out-of-scope rows outrank every in-scope one deeper than any
+// over-fetch. Unowned rows (empty repo prefix) always pass, the
+// ScopeAllows carve-out.
+type ScopedSymbolBundleSearcher interface {
+	SearchSymbolBundlesRepoScoped(query string, repoAllow []string, limit int) ([]SymbolBundle, error)
+}
+
 // VectorItem is the payload BulkUpsertEmbeddings takes per node:
 // the node's ID and its embedding vector. Length of Vec must
 // match the dim the corresponding BuildVectorIndex call declared

--- a/internal/graph/store_sqlite/fts_repo_scope_test.go
+++ b/internal/graph/store_sqlite/fts_repo_scope_test.go
@@ -1,0 +1,141 @@
+package store_sqlite
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// floodedScopeStore seeds two repos: "noise" holds noiseCount symbols
+// whose token bag is exactly the query token (they win BM25 outright),
+// "app" holds one WidgetExtensions. This is the cross-repo flood shape:
+// every unscoped head slot goes to noise rows, so any post-fetch scope
+// filter starves no matter how far the caller over-fetches.
+func floodedScopeStore(t *testing.T, noiseCount int) *Store {
+	t.Helper()
+	s, err := Open(filepath.Join(t.TempDir(), "scope.sqlite"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	appID := "app/widget.go::WidgetExtensions"
+	s.AddNode(&graph.Node{
+		ID: appID, Kind: graph.KindType, Name: "WidgetExtensions",
+		FilePath: "app/widget.go", Language: "go", RepoPrefix: "app",
+	})
+	if err := s.UpsertSymbolFTS(appID, "widget extensions"); err != nil {
+		t.Fatalf("UpsertSymbolFTS(app): %v", err)
+	}
+
+	for i := 0; i < noiseCount; i++ {
+		id := fmt.Sprintf("noise/f%d.go::Extensions", i)
+		s.AddNode(&graph.Node{
+			ID: id, Kind: graph.KindFunction, Name: "Extensions",
+			FilePath: fmt.Sprintf("noise/f%d.go", i), Language: "go", RepoPrefix: "noise",
+		})
+		if err := s.UpsertSymbolFTS(id, "extensions"); err != nil {
+			t.Fatalf("UpsertSymbolFTS(noise %d): %v", i, err)
+		}
+	}
+	return s
+}
+
+// TestSearchSymbolsRepoScoped_CrossRepoFloodDoesNotStarve: with 250
+// out-of-scope rows outranking the one in-scope symbol, the scoped
+// search must return that symbol — filtering inside the FTS query,
+// not over a bounded head.
+func TestSearchSymbolsRepoScoped_CrossRepoFloodDoesNotStarve(t *testing.T) {
+	s := floodedScopeStore(t, 250)
+
+	hits, err := s.SearchSymbolsRepoScoped("Extensions", []string{"app"}, 20)
+	if err != nil {
+		t.Fatalf("SearchSymbolsRepoScoped: %v", err)
+	}
+	if len(hits) != 1 || hits[0].NodeID != "app/widget.go::WidgetExtensions" {
+		t.Fatalf("scoped search = %+v, want exactly the app symbol", hits)
+	}
+}
+
+// TestSearchSymbolsRepoScoped_ExactNameTierRespectsScope: the exact-name
+// tier-0 short-circuit must not leak out-of-scope nodes; when every
+// exact-name hit is out of scope it falls through to the scoped FTS.
+func TestSearchSymbolsRepoScoped_ExactNameTierRespectsScope(t *testing.T) {
+	s := floodedScopeStore(t, 30)
+
+	// "Extensions" is the exact name of every noise node and no app node.
+	hits, err := s.SearchSymbolsRepoScoped("Extensions", []string{"app"}, 20)
+	if err != nil {
+		t.Fatalf("SearchSymbolsRepoScoped: %v", err)
+	}
+	for _, h := range hits {
+		if h.NodeID == "" || h.NodeID[:4] == "nois" {
+			t.Fatalf("exact-name tier leaked out-of-scope hit %q", h.NodeID)
+		}
+	}
+	if len(hits) != 1 {
+		t.Fatalf("scoped search = %+v, want the single app symbol", hits)
+	}
+}
+
+// TestSearchSymbolsRepoScoped_AdmitsUnownedNodes: rows with an empty
+// repo_prefix (synthetic externals) pass every repo-narrow predicate
+// in the codebase (see QueryOptions.ScopeAllows) — the FTS-level
+// narrow must agree or scoped searches silently lose externals.
+func TestSearchSymbolsRepoScoped_AdmitsUnownedNodes(t *testing.T) {
+	s := floodedScopeStore(t, 3)
+
+	extID := "dep::widgets/WidgetExtensions"
+	s.AddNode(&graph.Node{
+		ID: extID, Kind: graph.KindType, Name: "WidgetExtensions", Language: "go",
+	})
+	if err := s.UpsertSymbolFTS(extID, "widget extensions external"); err != nil {
+		t.Fatalf("UpsertSymbolFTS(ext): %v", err)
+	}
+
+	hits, err := s.SearchSymbolsRepoScoped("widget", []string{"app"}, 20)
+	if err != nil {
+		t.Fatalf("SearchSymbolsRepoScoped: %v", err)
+	}
+	found := map[string]bool{}
+	for _, h := range hits {
+		found[h.NodeID] = true
+	}
+	if !found["app/widget.go::WidgetExtensions"] || !found[extID] {
+		t.Fatalf("scoped search = %+v, want the app symbol AND the unowned external", hits)
+	}
+}
+
+// TestSearchSymbolsRepoScoped_EmptyScopeMatchesUnscoped: a nil allow
+// list means no repo narrowing — identical behaviour to SearchSymbols.
+func TestSearchSymbolsRepoScoped_EmptyScopeMatchesUnscoped(t *testing.T) {
+	s := floodedScopeStore(t, 5)
+
+	scoped, err := s.SearchSymbolsRepoScoped("Extensions", nil, 50)
+	if err != nil {
+		t.Fatalf("SearchSymbolsRepoScoped(nil): %v", err)
+	}
+	unscoped, err := s.SearchSymbols("Extensions", 50)
+	if err != nil {
+		t.Fatalf("SearchSymbols: %v", err)
+	}
+	if len(scoped) != len(unscoped) {
+		t.Fatalf("nil-scope hits = %d, unscoped = %d — must match", len(scoped), len(unscoped))
+	}
+}
+
+// TestSearchSymbolBundlesRepoScoped_FiltersInQuery: the bundle variant
+// inherits the scoped hit query and returns only in-scope bundles.
+func TestSearchSymbolBundlesRepoScoped_FiltersInQuery(t *testing.T) {
+	s := floodedScopeStore(t, 250)
+
+	bundles, err := s.SearchSymbolBundlesRepoScoped("Extensions", []string{"app"}, 20)
+	if err != nil {
+		t.Fatalf("SearchSymbolBundlesRepoScoped: %v", err)
+	}
+	if len(bundles) != 1 || bundles[0].Node == nil || bundles[0].Node.ID != "app/widget.go::WidgetExtensions" {
+		t.Fatalf("scoped bundles = %+v, want exactly the app symbol", bundles)
+	}
+}

--- a/internal/graph/store_sqlite/fts_repo_scope_test.go
+++ b/internal/graph/store_sqlite/fts_repo_scope_test.go
@@ -3,6 +3,7 @@ package store_sqlite
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/zzet/gortex/internal/graph"
@@ -71,7 +72,7 @@ func TestSearchSymbolsRepoScoped_ExactNameTierRespectsScope(t *testing.T) {
 		t.Fatalf("SearchSymbolsRepoScoped: %v", err)
 	}
 	for _, h := range hits {
-		if h.NodeID == "" || h.NodeID[:4] == "nois" {
+		if strings.HasPrefix(h.NodeID, "noise/") {
 			t.Fatalf("exact-name tier leaked out-of-scope hit %q", h.NodeID)
 		}
 	}
@@ -138,6 +139,32 @@ func TestSearchSymbols_ExactNameModuleDoesNotEclipseFTS(t *testing.T) {
 	if !found["app/widget.go::WidgetExtensions"] {
 		t.Fatalf("container-kind exact-name hits eclipsed the FTS tier; hits=%+v", hits)
 	}
+	// The containers are MERGED, not dropped — a kind:module caller
+	// post-filtering these hits must still find its module.
+	if !found["module::x:app/Core/Extensions"] {
+		t.Fatalf("exact-name container hits must ride along for kind-filtered callers; hits=%+v", hits)
+	}
+}
+
+// TestSearchSymbols_ExactTypeWinsOverSiblings pins the intended
+// tier-0 contract: a symbol-kind node named exactly like the query
+// short-circuits even when same-suffix siblings exist — "I typed the
+// name, give me the name". Sibling discovery is the prefix query's job.
+func TestSearchSymbols_ExactTypeWinsOverSiblings(t *testing.T) {
+	s := floodedScopeStore(t, 3)
+	exact := "app/exact.go::Extensions"
+	s.AddNode(&graph.Node{ID: exact, Kind: graph.KindType, Name: "Extensions", Language: "go", RepoPrefix: "app"})
+	if err := s.UpsertSymbolFTS(exact, "extensions"); err != nil {
+		t.Fatalf("UpsertSymbolFTS: %v", err)
+	}
+
+	hits, err := s.SearchSymbolsRepoScoped("Extensions", []string{"app"}, 20)
+	if err != nil {
+		t.Fatalf("SearchSymbolsRepoScoped: %v", err)
+	}
+	if len(hits) != 1 || hits[0].NodeID != exact || hits[0].Score != 100.0 {
+		t.Fatalf("exact symbol-kind hit must keep the short-circuit; hits=%+v", hits)
+	}
 }
 
 // TestSearchSymbols_ExactNameTypeStillShortCircuits: a genuine
@@ -169,6 +196,32 @@ func TestSearchSymbolsRepoScoped_EmptyScopeMatchesUnscoped(t *testing.T) {
 	}
 	if len(scoped) != len(unscoped) {
 		t.Fatalf("nil-scope hits = %d, unscoped = %d — must match", len(scoped), len(unscoped))
+	}
+}
+
+// TestSearchSymbolsRepoScoped_MultipleRepos: the IN-list arity above
+// one — both allowed repos' rows return, the third stays out.
+func TestSearchSymbolsRepoScoped_MultipleRepos(t *testing.T) {
+	s := floodedScopeStore(t, 3)
+	otherID := "beta/w.go::BetaWidgetExtensions"
+	s.AddNode(&graph.Node{ID: otherID, Kind: graph.KindType, Name: "BetaWidgetExtensions", Language: "go", RepoPrefix: "beta"})
+	if err := s.UpsertSymbolFTS(otherID, "beta widget extensions"); err != nil {
+		t.Fatalf("UpsertSymbolFTS: %v", err)
+	}
+
+	hits, err := s.SearchSymbolsRepoScoped("widget", []string{"app", "beta"}, 20)
+	if err != nil {
+		t.Fatalf("SearchSymbolsRepoScoped: %v", err)
+	}
+	found := map[string]bool{}
+	for _, h := range hits {
+		found[h.NodeID] = true
+		if strings.HasPrefix(h.NodeID, "noise/") {
+			t.Fatalf("multi-repo scope leaked %q", h.NodeID)
+		}
+	}
+	if !found["app/widget.go::WidgetExtensions"] || !found[otherID] {
+		t.Fatalf("both allowed repos must return; hits=%+v", hits)
 	}
 }
 

--- a/internal/graph/store_sqlite/fts_repo_scope_test.go
+++ b/internal/graph/store_sqlite/fts_repo_scope_test.go
@@ -108,6 +108,52 @@ func TestSearchSymbolsRepoScoped_AdmitsUnownedNodes(t *testing.T) {
 	}
 }
 
+// TestSearchSymbols_ExactNameModuleDoesNotEclipseFTS: an exact-name
+// tier-0 hit that is only a container node (module / package — e.g.
+// a .NET project named "Extensions") must not short-circuit the FTS
+// tier where the real classes rank. Observed live: two csproj module
+// nodes named "Extensions" eclipsed 63 `*Extensions` types.
+func TestSearchSymbols_ExactNameModuleDoesNotEclipseFTS(t *testing.T) {
+	s := floodedScopeStore(t, 3)
+
+	for i, id := range []string{"module::x:app/Core/Extensions", "app/pkgdecoy::Extensions"} {
+		kind := graph.KindModule
+		if i == 1 {
+			kind = graph.KindPackage
+		}
+		s.AddNode(&graph.Node{ID: id, Kind: kind, Name: "Extensions", Language: "go", RepoPrefix: "app"})
+		if err := s.UpsertSymbolFTS(id, "extensions"); err != nil {
+			t.Fatalf("UpsertSymbolFTS(%s): %v", id, err)
+		}
+	}
+
+	hits, err := s.SearchSymbolsRepoScoped("Extensions", []string{"app"}, 20)
+	if err != nil {
+		t.Fatalf("SearchSymbolsRepoScoped: %v", err)
+	}
+	found := map[string]bool{}
+	for _, h := range hits {
+		found[h.NodeID] = true
+	}
+	if !found["app/widget.go::WidgetExtensions"] {
+		t.Fatalf("container-kind exact-name hits eclipsed the FTS tier; hits=%+v", hits)
+	}
+}
+
+// TestSearchSymbols_ExactNameTypeStillShortCircuits: a genuine
+// exact-name symbol hit keeps the tier-0 fast path.
+func TestSearchSymbols_ExactNameTypeStillShortCircuits(t *testing.T) {
+	s := floodedScopeStore(t, 3)
+
+	hits, err := s.SearchSymbolsRepoScoped("WidgetExtensions", []string{"app"}, 20)
+	if err != nil {
+		t.Fatalf("SearchSymbolsRepoScoped: %v", err)
+	}
+	if len(hits) != 1 || hits[0].NodeID != "app/widget.go::WidgetExtensions" || hits[0].Score != 100.0 {
+		t.Fatalf("exact-name type must keep the tier-0 fast path; hits=%+v", hits)
+	}
+}
+
 // TestSearchSymbolsRepoScoped_EmptyScopeMatchesUnscoped: a nil allow
 // list means no repo narrowing — identical behaviour to SearchSymbols.
 func TestSearchSymbolsRepoScoped_EmptyScopeMatchesUnscoped(t *testing.T) {

--- a/internal/graph/store_sqlite/store_fts.go
+++ b/internal/graph/store_sqlite/store_fts.go
@@ -42,12 +42,13 @@ import (
 // implements them, routing search_symbols through on-disk FTS5 instead
 // of the in-process BM25 index.
 var (
-	_ graph.SymbolSearcher         = (*Store)(nil)
-	_ graph.SymbolFTSBatchUpserter = (*Store)(nil)
-	_ graph.SymbolFTSRepoResetter  = (*Store)(nil)
-	_ graph.SymbolFTSBatchDeleter  = (*Store)(nil)
-	_ graph.SymbolBundleSearcher   = (*Store)(nil)
-	_ graph.BundleFingerprintSink  = (*Store)(nil)
+	_ graph.SymbolSearcher             = (*Store)(nil)
+	_ graph.SymbolFTSBatchUpserter     = (*Store)(nil)
+	_ graph.SymbolFTSRepoResetter      = (*Store)(nil)
+	_ graph.SymbolFTSBatchDeleter      = (*Store)(nil)
+	_ graph.SymbolBundleSearcher       = (*Store)(nil)
+	_ graph.ScopedSymbolBundleSearcher = (*Store)(nil)
+	_ graph.BundleFingerprintSink      = (*Store)(nil)
 )
 
 // ftsInsertChunkRows bounds the rows per multi-row INSERT. Each FTS row
@@ -522,9 +523,11 @@ func (s *Store) SearchSymbols(query string, limit int) ([]graph.SymbolHit, error
 // SearchSymbolsRepoScoped is SearchSymbols narrowed to the repoAllow
 // prefixes inside the queries themselves — a post-fetch scope filter
 // starves whenever another repo owns the whole BM25 head, which can
-// run deeper than any bounded over-fetch. repo_prefix is the same
-// UNINDEXED literal column the per-repo staleness wipe filters on.
-// A nil / empty repoAllow is the exact unscoped behaviour.
+// run deeper than any bounded over-fetch. Filtering the UNINDEXED
+// repo_prefix column here is free: the rows are already materialised
+// by the MATCH + bm25 ORDER BY (the plan is identical with and
+// without the IN). A nil / empty repoAllow is the exact unscoped
+// behaviour.
 func (s *Store) SearchSymbolsRepoScoped(query string, repoAllow []string, limit int) ([]graph.SymbolHit, error) {
 	if query == "" {
 		return nil, nil

--- a/internal/graph/store_sqlite/store_fts.go
+++ b/internal/graph/store_sqlite/store_fts.go
@@ -516,18 +516,35 @@ func (s *Store) BuildSymbolIndex() error {
 // SQLite's bm25() returns lower-is-better, so the stored Score is its
 // negation (higher-is-better, matching the SymbolHit contract).
 func (s *Store) SearchSymbols(query string, limit int) ([]graph.SymbolHit, error) {
+	return s.SearchSymbolsRepoScoped(query, nil, limit)
+}
+
+// SearchSymbolsRepoScoped is SearchSymbols narrowed to the repoAllow
+// prefixes inside the queries themselves — a post-fetch scope filter
+// starves whenever another repo owns the whole BM25 head, which can
+// run deeper than any bounded over-fetch. repo_prefix is the same
+// UNINDEXED literal column the per-repo staleness wipe filters on.
+// A nil / empty repoAllow is the exact unscoped behaviour.
+func (s *Store) SearchSymbolsRepoScoped(query string, repoAllow []string, limit int) ([]graph.SymbolHit, error) {
 	if query == "" {
 		return nil, nil
 	}
 	if limit <= 0 {
 		limit = 20
 	}
+	var allowed map[string]struct{}
+	if len(repoAllow) > 0 {
+		allowed = make(map[string]struct{}, len(repoAllow))
+		for _, r := range repoAllow {
+			allowed[r] = struct{}{}
+		}
+	}
 
 	// Tier 0: exact-name lookup. Only engage for identifier-shaped
 	// queries (no whitespace / path separators); multi-word queries are
 	// concept searches that need BM25 ranking. We only short-circuit
-	// when the lookup hits at least one node — misses fall through so a
-	// partial-identifier query still reaches FTS.
+	// when the lookup hits at least one IN-SCOPE node — out-of-scope
+	// exact matches must not mask the scoped FTS tier below.
 	if isIdentifierQuery(query) {
 		ns := s.FindNodesByName(query)
 		if len(ns) > 0 {
@@ -535,6 +552,13 @@ func (s *Store) SearchSymbols(query string, limit int) ([]graph.SymbolHit, error
 			for _, n := range ns {
 				if n == nil || n.ID == "" {
 					continue
+				}
+				// Unowned nodes (empty prefix) pass every repo narrow —
+				// the ScopeAllows carve-out.
+				if allowed != nil && n.RepoPrefix != "" {
+					if _, ok := allowed[n.RepoPrefix]; !ok {
+						continue
+					}
 				}
 				out = append(out, graph.SymbolHit{NodeID: n.ID, Score: 100.0})
 				if len(out) >= limit {
@@ -552,8 +576,20 @@ func (s *Store) SearchSymbols(query string, limit int) ([]graph.SymbolHit, error
 		return nil, nil
 	}
 
-	const q = `SELECT node_id, bm25(symbol_fts) FROM symbol_fts WHERE symbol_fts MATCH ? ORDER BY bm25(symbol_fts) LIMIT ?`
-	rows, err := s.db.Query(q, match, limit)
+	q := `SELECT node_id, bm25(symbol_fts) FROM symbol_fts WHERE symbol_fts MATCH ?`
+	args := []any{match}
+	if len(repoAllow) > 0 {
+		// The empty prefix always passes: unowned rows (synthetic
+		// externals) are admitted by every repo-narrow predicate — see
+		// QueryOptions.ScopeAllows for the invariant.
+		q += ` AND repo_prefix IN ('', ?` + strings.Repeat(`,?`, len(repoAllow)-1) + `)`
+		for _, r := range repoAllow {
+			args = append(args, r)
+		}
+	}
+	q += ` ORDER BY bm25(symbol_fts) LIMIT ?`
+	args = append(args, limit)
+	rows, err := s.db.Query(q, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -627,6 +663,23 @@ func (s *Store) SearchSymbolBundles(query string, limit int) ([]graph.SymbolBund
 	if err != nil {
 		return nil, err
 	}
+	return s.bundlesForHits(hits)
+}
+
+// SearchSymbolBundlesRepoScoped is SearchSymbolBundles over the
+// repo-scoped hit query — see SearchSymbolsRepoScoped for why the
+// narrowing must happen inside the FTS query.
+func (s *Store) SearchSymbolBundlesRepoScoped(query string, repoAllow []string, limit int) ([]graph.SymbolBundle, error) {
+	hits, err := s.SearchSymbolsRepoScoped(query, repoAllow, limit)
+	if err != nil {
+		return nil, err
+	}
+	return s.bundlesForHits(hits)
+}
+
+// bundlesForHits materialises ranked hits into SymbolBundles through
+// the content-addressed cache + batched node/edge fetches.
+func (s *Store) bundlesForHits(hits []graph.SymbolHit) ([]graph.SymbolBundle, error) {
 	if len(hits) == 0 {
 		return nil, nil
 	}

--- a/internal/graph/store_sqlite/store_fts.go
+++ b/internal/graph/store_sqlite/store_fts.go
@@ -543,14 +543,17 @@ func (s *Store) SearchSymbolsRepoScoped(query string, repoAllow []string, limit 
 	// Tier 0: exact-name lookup. Only engage for identifier-shaped
 	// queries (no whitespace / path separators); multi-word queries are
 	// concept searches that need BM25 ranking. We only short-circuit
-	// when the lookup hits at least one IN-SCOPE node — out-of-scope
-	// exact matches must not mask the scoped FTS tier below.
+	// when the lookup hits at least one IN-SCOPE, SYMBOL-LIKE node —
+	// out-of-scope exact matches must not mask the scoped FTS tier
+	// below, and neither may container/binding kinds: a .NET project
+	// module named "Extensions" would otherwise eclipse every
+	// `*Extensions` class the FTS ranks first.
 	if isIdentifierQuery(query) {
 		ns := s.FindNodesByName(query)
 		if len(ns) > 0 {
 			out := make([]graph.SymbolHit, 0, minInt(len(ns), limit))
 			for _, n := range ns {
-				if n == nil || n.ID == "" {
+				if n == nil || n.ID == "" || !tier0ShortCircuitKind(n.Kind) {
 					continue
 				}
 				// Unowned nodes (empty prefix) pass every repo narrow —
@@ -616,6 +619,22 @@ func (s *Store) SearchSymbolsRepoScoped(query string, repoAllow []string, limit 
 		return nil, err
 	}
 	return hits, nil
+}
+
+// tier0ShortCircuitKind reports whether an exact-name hit may
+// short-circuit the FTS tier. Container and binding kinds are excluded:
+// they share names with the symbols users actually search for (a
+// project/module named X vs the X* classes inside it) and a search page
+// of containers eclipses the ranked symbols outright. They remain
+// reachable through the FTS tier's own ranking.
+func tier0ShortCircuitKind(k graph.NodeKind) bool {
+	switch k {
+	case graph.KindModule, graph.KindPackage, graph.KindFile, graph.KindImport,
+		graph.KindLocal, graph.KindParam, graph.KindGenericParam, graph.KindClosure,
+		graph.KindBuiltin:
+		return false
+	}
+	return true
 }
 
 // buildFTSMatch tokenises the query with the write-side splitter and

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -1688,6 +1688,35 @@ func (s *Server) handleSearchSymbols(ctx context.Context, req mcp.CallToolReques
 	}
 	nodes = applyAllPostFilters(nodes)
 
+	// Post-filter wipeout rescue: the fetch found candidates but the
+	// filters dropped every one — the real matches likely sit past the
+	// fetch horizon, outranked by rows the filters remove (doc/junk
+	// sections sharing the query's tokens; the classic case is a
+	// suffix-convention query like "Extensions"). Refetch deeper under
+	// the same scope BEFORE the filter-dropping fallbacks below.
+	fetchEscalated := false
+	if len(nodes) == 0 && candsAfterGather > 0 && q != "" {
+		for _, mult := range []int{5, 25} {
+			deepLimit := fetchLimit * mult
+			var refetched []*graph.Node
+			if len(expandedTerms) > 0 {
+				refetched, _ = fetchAndMergeBM25Timed(s.engineFor(ctx), q, expandedTerms, deepLimit, scope, timings)
+			} else {
+				refetched = s.engineFor(ctx).SearchSymbolsScoped(q, deepLimit, scope)
+			}
+			if kept := applyAllPostFilters(refetched); len(kept) > 0 {
+				nodes = kept
+				fetchEscalated = true
+				break
+			}
+			// A short page means the corpus is exhausted — a deeper
+			// fetch cannot surface anything new.
+			if len(refetched) < deepLimit {
+				break
+			}
+		}
+	}
+
 	// Fuzzy fallback: a field-qualified query that filtered down to
 	// nothing retries on the free text alone (still inside the
 	// caller's repo / project scope), so an over-narrow or typo'd
@@ -1914,6 +1943,9 @@ func (s *Server) handleSearchSymbols(ctx context.Context, req mcp.CallToolReques
 		wide.RepoAllow = nil
 		wideNodes, _ := fetchAndMergeBM25Timed(s.engineFor(ctx), q, expandedTerms, offset+limit, wide, timings)
 		resp["scope_note"] = scopeZeroNote(resolved, len(wideNodes))
+	}
+	if fetchEscalated {
+		resp["fetch_escalated"] = true
 	}
 	if filtersRelaxed {
 		resp["filters_relaxed"] = true

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -1694,10 +1694,20 @@ func (s *Server) handleSearchSymbols(ctx context.Context, req mcp.CallToolReques
 	// sections sharing the query's tokens; the classic case is a
 	// suffix-convention query like "Extensions"). Refetch deeper under
 	// the same scope BEFORE the filter-dropping fallbacks below.
+	// Content sections live only in content_fts — this channel cannot
+	// rescue them, so a content-corpus wipeout skips the refetch.
 	fetchEscalated := false
-	if len(nodes) == 0 && candsAfterGather > 0 && q != "" {
+	if len(nodes) == 0 && candsAfterGather > 0 && q != "" && corpus != corpusContent {
 		for _, mult := range []int{5, 25} {
+			if ctx.Err() != nil {
+				break
+			}
 			deepLimit := fetchLimit * mult
+			// Bound the deepest fetch: past this, bundle materialisation
+			// cost dwarfs any plausible rescue.
+			if deepLimit > 2000 {
+				deepLimit = 2000
+			}
 			var refetched []*graph.Node
 			if len(expandedTerms) > 0 {
 				refetched, _ = fetchAndMergeBM25Timed(s.engineFor(ctx), q, expandedTerms, deepLimit, scope, timings)

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -1698,6 +1698,14 @@ func (s *Server) handleSearchSymbols(ctx context.Context, req mcp.CallToolReques
 	// rescue them, so a content-corpus wipeout skips the refetch.
 	fetchEscalated := false
 	if len(nodes) == 0 && candsAfterGather > 0 && q != "" && corpus != corpusContent {
+		// The requested cursor window must be reachable: a shallow
+		// rescue that survives the filters but ends before offset+limit
+		// would slice to an empty later page (with no next cursor) even
+		// though a deeper fetch fills it. So a partial rescue keeps the
+		// best set so far and keeps escalating until the window is
+		// reachable or the corpus is exhausted.
+		want := offset + limit
+		prevDepth := 0
 		for _, mult := range []int{5, 25} {
 			if ctx.Err() != nil {
 				break
@@ -1708,20 +1716,28 @@ func (s *Server) handleSearchSymbols(ctx context.Context, req mcp.CallToolReques
 			if deepLimit > 2000 {
 				deepLimit = 2000
 			}
+			// The cap can collapse successive multipliers into the same
+			// effective depth — an identical re-query cannot change the
+			// outcome, so don't pay it twice.
+			if deepLimit == prevDepth {
+				break
+			}
+			prevDepth = deepLimit
 			var refetched []*graph.Node
 			if len(expandedTerms) > 0 {
 				refetched, _ = fetchAndMergeBM25Timed(s.engineFor(ctx), q, expandedTerms, deepLimit, scope, timings)
 			} else {
 				refetched = s.engineFor(ctx).SearchSymbolsScoped(q, deepLimit, scope)
 			}
-			if kept := applyAllPostFilters(refetched); len(kept) > 0 {
+			kept := applyAllPostFilters(refetched)
+			if len(kept) > 0 {
 				nodes = kept
 				fetchEscalated = true
-				break
 			}
-			// A short page means the corpus is exhausted — a deeper
-			// fetch cannot surface anything new.
-			if len(refetched) < deepLimit {
+			// Done when the window is reachable, or the corpus is
+			// exhausted — a short raw page means a deeper fetch cannot
+			// surface anything new.
+			if len(kept) >= want || len(refetched) < deepLimit {
 				break
 			}
 		}

--- a/internal/mcp/tools_search_escalation_test.go
+++ b/internal/mcp/tools_search_escalation_test.go
@@ -1,0 +1,81 @@
+package mcp
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/query"
+	"github.com/zzet/gortex/internal/search"
+)
+
+// floodTestServer builds a server whose BM25 head for the token
+// "extensions" is fully occupied by doc-section nodes: one real code
+// symbol (WidgetExtensions) plus docCount KindDoc nodes that all
+// outrank it (single-token name, tripled term frequency). With the
+// default corpus=code filter, every fetched candidate is dropped —
+// the shape a suffix-convention query takes on a repo whose doc/junk
+// files share the naming tokens.
+func floodTestServer(t *testing.T, docCount int) *Server {
+	t.Helper()
+	g := graph.New()
+	bm := search.NewBM25()
+
+	id := "pkg/WidgetExtensions.go::WidgetExtensions"
+	g.AddNode(&graph.Node{
+		ID: id, Kind: graph.KindType, Name: "WidgetExtensions",
+		FilePath: "pkg/WidgetExtensions.go", StartLine: 1, EndLine: 5, Language: "go",
+	})
+	bm.Add(id, "WidgetExtensions", "pkg/WidgetExtensions.go", "")
+
+	for i := 0; i < docCount; i++ {
+		docID := fmt.Sprintf("junk/list%d.txt::sec%d", i, i)
+		g.AddNode(&graph.Node{
+			ID: docID, Kind: graph.KindDoc, Name: "Extensions",
+			FilePath: fmt.Sprintf("junk/list%d.txt", i), StartLine: 1, EndLine: 3, Language: "text",
+		})
+		bm.Add(docID, "Extensions Extensions Extensions")
+	}
+
+	eng := query.NewEngine(g)
+	eng.SetSearch(bm)
+	srv := NewServer(eng, g, nil, nil, zap.NewNop(), nil)
+	srv.RunAnalysis()
+	return srv
+}
+
+// TestSearchSymbols_EscalatesWhenPostFilterEmptiesFetch is the core
+// feature test: the bounded fetch returns only doc hits, the corpus
+// filter empties the page, and the deeper refetch must rescue the
+// real symbol sitting past the original fetch horizon.
+func TestSearchSymbols_EscalatesWhenPostFilterEmptiesFetch(t *testing.T) {
+	srv := floodTestServer(t, 60)
+	resp := searchResp(t, srv, map[string]any{"query": "Extensions"})
+	ids := respIDs(resp)
+	require.Truef(t, ids["pkg/WidgetExtensions.go::WidgetExtensions"],
+		"escalated refetch should rescue the code symbol past the flooded head; got %v", ids)
+	require.Equal(t, true, resp["fetch_escalated"], "the rescued response must carry fetch_escalated:true")
+}
+
+// TestSearchSymbols_NoEscalationOnPrimaryHit: when the primary page
+// already holds a surviving candidate, no escalation runs and the
+// flag stays absent.
+func TestSearchSymbols_NoEscalationOnPrimaryHit(t *testing.T) {
+	srv := floodTestServer(t, 60)
+	resp := searchResp(t, srv, map[string]any{"query": "WidgetExtensions"})
+	require.NotEmpty(t, respIDs(resp))
+	require.Nil(t, resp["fetch_escalated"], "fetch_escalated must be absent when the primary fetch survived")
+}
+
+// TestSearchSymbols_TrueMissDoesNotEscalate: a query with no raw
+// candidates at all has nothing to rescue — the empty result returns
+// without the escalation flag (and without paying the refetch).
+func TestSearchSymbols_TrueMissDoesNotEscalate(t *testing.T) {
+	srv := floodTestServer(t, 10)
+	resp := searchResp(t, srv, map[string]any{"query": "zzqwxnomatch"})
+	require.Empty(t, respIDs(resp))
+	require.Nil(t, resp["fetch_escalated"], "a true miss must not set fetch_escalated")
+}

--- a/internal/mcp/tools_search_escalation_test.go
+++ b/internal/mcp/tools_search_escalation_test.go
@@ -47,6 +47,105 @@ func floodTestServer(t *testing.T, docCount int) *Server {
 	return srv
 }
 
+// floodTestServerN is floodTestServer with codeCount rescuable code
+// symbols behind the doc flood — the multi-page rescue shape from the
+// PR review: a partially-successful shallow rescue must not strand a
+// later cursor page a deeper fetch would fill.
+func floodTestServerN(t *testing.T, docCount, codeCount int) *Server {
+	t.Helper()
+	g := graph.New()
+	bm := search.NewBM25()
+
+	for i := 0; i < codeCount; i++ {
+		id := fmt.Sprintf("pkg/w%d.go::WidgetExtensions%d", i, i)
+		g.AddNode(&graph.Node{
+			ID: id, Kind: graph.KindType, Name: fmt.Sprintf("WidgetExtensions%d", i),
+			FilePath: fmt.Sprintf("pkg/w%d.go", i), StartLine: 1, EndLine: 5, Language: "go",
+		})
+		bm.Add(id, fmt.Sprintf("WidgetExtensions%d", i), fmt.Sprintf("pkg/w%d.go", i), "")
+	}
+	for i := 0; i < docCount; i++ {
+		docID := fmt.Sprintf("junk/list%d.txt::sec%d", i, i)
+		g.AddNode(&graph.Node{
+			ID: docID, Kind: graph.KindDoc, Name: "Extensions",
+			FilePath: fmt.Sprintf("junk/list%d.txt", i), StartLine: 1, EndLine: 3, Language: "text",
+		})
+		bm.Add(docID, "Extensions Extensions Extensions")
+	}
+
+	eng := query.NewEngine(g)
+	eng.SetSearch(bm)
+	srv := NewServer(eng, g, nil, nil, zap.NewNop(), nil)
+	srv.RunAnalysis()
+	return srv
+}
+
+// TestSearchSymbols_EscalationReachesCursorWindow: the review's
+// confirmed pagination bug. 170 doc rows own the head; the ×5 refetch
+// (identifier fast path: depth (20+10+5)×5 = 175) surfaces only the
+// first 5 code symbols — a non-empty rescue — but the requested window
+// starts at offset 20, so stopping there returns an empty page 2 with
+// no cursor even though the ×25 fetch exposes all 30. Escalation must
+// continue until offset+limit is reachable or the backend is exhausted.
+func TestSearchSymbols_EscalationReachesCursorWindow(t *testing.T) {
+	srv := floodTestServerN(t, 170, 30)
+	resp := searchResp(t, srv, map[string]any{
+		"query": "Extensions", "limit": 10, "cursor": encodeCursor(20),
+	})
+	ids := respIDs(resp)
+	require.Lenf(t, ids, 10,
+		"page 2 (offset 20, limit 10) must hold the remaining rescued symbols; got %v", ids)
+	require.Equal(t, true, resp["fetch_escalated"], "the rescued response must carry fetch_escalated:true")
+}
+
+// TestSearchSymbols_EscalationSkipsDuplicateDepth: once the depth cap
+// clamps a multiplier, the next multiplier collapses to the same
+// effective depth — an identical re-query cannot change the outcome and
+// must be skipped, not paid a second time.
+func TestSearchSymbols_EscalationSkipsDuplicateDepth(t *testing.T) {
+	g := graph.New()
+	bm := search.NewBM25()
+	for i := 0; i < 2100; i++ {
+		docID := fmt.Sprintf("junk/list%d.txt::sec%d", i, i)
+		g.AddNode(&graph.Node{
+			ID: docID, Kind: graph.KindDoc, Name: "Extensions",
+			FilePath: fmt.Sprintf("junk/list%d.txt", i), StartLine: 1, EndLine: 3, Language: "text",
+		})
+		bm.Add(docID, "Extensions Extensions Extensions")
+	}
+	counter := &countingBackend{BM25Backend: bm}
+	eng := query.NewEngine(g)
+	eng.SetSearch(counter)
+	srv := NewServer(eng, g, nil, nil, zap.NewNop(), nil)
+	srv.RunAnalysis()
+
+	resp := searchResp(t, srv, map[string]any{
+		"query": "Extensions", "limit": 100, "cursor": encodeCursor(400),
+	})
+	require.Empty(t, respIDs(resp), "an all-doc corpus yields no code page")
+	require.NotEmpty(t, counter.limits, "counting backend must intercept Search calls")
+	deep := 0
+	for _, l := range counter.limits {
+		if l >= 2000 {
+			deep++
+		}
+	}
+	require.LessOrEqualf(t, deep, 1,
+		"capped escalation depths must not repeat an identical query; deep-call limits: %v", counter.limits)
+}
+
+// countingBackend wraps the BM25 backend and records every Search
+// limit, so a test can prove an identical capped depth is not re-paid.
+type countingBackend struct {
+	*search.BM25Backend
+	limits []int
+}
+
+func (c *countingBackend) Search(q string, limit int) []search.SearchResult {
+	c.limits = append(c.limits, limit)
+	return c.BM25Backend.Search(q, limit)
+}
+
 // TestSearchSymbols_EscalatesWhenPostFilterEmptiesFetch is the core
 // feature test: the bounded fetch returns only doc hits, the corpus
 // filter empties the page, and the deeper refetch must rescue the

--- a/internal/query/engine.go
+++ b/internal/query/engine.go
@@ -723,9 +723,13 @@ func (e *Engine) gatherBackendCandidates(query string, limit int, opts QueryOpti
 		// Gate on the flattened list, not the map: an all-false map is
 		// "deny everything" under ScopeAllows and must not select the
 		// scoped path with an empty (= unscoped!) allow list.
+		scopedAnswered := false
 		if allow := repoAllowList(opts.RepoAllow); len(allow) > 0 {
 			if sb, ok := backend.(search.ScopedSymbolBundleSearcherBackend); ok {
 				bundles = sb.SearchSymbolBundlesScoped(query, allow, limit*2)
+				// nil = no scoped support (or error); anything non-nil —
+				// an empty slice included — is the scoped path's answer.
+				scopedAnswered = bundles != nil
 			}
 		}
 		// nil = no scoped support (or error); a non-nil empty slice is
@@ -762,6 +766,12 @@ func (e *Engine) gatherBackendCandidates(query string, limit int, opts QueryOpti
 			if rctx != nil {
 				rctx.SeedEdgeCaches(inSeed, outSeed, true)
 			}
+		} else if scopedAnswered {
+			// A scoped query that answered zero IS the answer. Leaving
+			// bundleHandled false here would send the miss down the
+			// unscoped channel fallback — re-running the very cross-repo
+			// flood fetch the scoped path exists to remove.
+			bundleHandled = true
 		}
 		// Vector channel: only when the bundle path took the BM25
 		// branch. Otherwise the fallback path below pulls both.

--- a/internal/query/engine.go
+++ b/internal/query/engine.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/zzet/gortex/internal/graph"
@@ -29,6 +30,14 @@ type Engine struct {
 	g              graph.Reader
 	searchProvider SearchProvider
 	rerank         *rerank.Pipeline
+	// corpusSeen memoises a positive backendHasCorpus answer. The
+	// DocCount fallback is a real COUNT(*) on the disk store and the
+	// warm-restart window (delta Count 0, populated disk FTS) would
+	// otherwise pay it on every gather; a corpus never un-populates
+	// within a backend's lifetime. Reset by SetSearch/SetSearchProvider.
+	// Pointer so WithReader clones share it (same backend, same corpus)
+	// and the shallow copy stays vet-clean.
+	corpusSeen *atomic.Bool
 }
 
 // WithReader returns a shallow clone of the engine that reads
@@ -54,7 +63,7 @@ func (e *Engine) Reader() graph.Reader { return e.g }
 // default 11-signal rerank.Pipeline is wired in; callers wanting a
 // custom signal set / weights override via SetRerank.
 func NewEngine(g graph.Store) *Engine {
-	return &Engine{g: g, rerank: rerank.NewDefault()}
+	return &Engine{g: g, rerank: rerank.NewDefault(), corpusSeen: &atomic.Bool{}}
 }
 
 // SetRerank installs a custom rerank pipeline. Pass nil to disable
@@ -81,11 +90,13 @@ func (e *Engine) ApplyRerankWeights(weights map[string]float64) {
 // SetSearch sets a static search backend (for backward compatibility).
 func (e *Engine) SetSearch(s search.Backend) {
 	e.searchProvider = func() search.Backend { return s }
+	e.corpusSeen.Store(false)
 }
 
 // SetSearchProvider sets a dynamic search provider that is called on every query.
 func (e *Engine) SetSearchProvider(p SearchProvider) {
 	e.searchProvider = p
+	e.corpusSeen.Store(false)
 }
 
 // getSearch returns the current search backend.
@@ -482,9 +493,17 @@ func (e *Engine) GatherSymbolCandidates(query string, limit int, opts QueryOptio
 	}
 	fetchLimit := limit
 	if opts.hasScopeFilter() {
+		// Over-fetch so the post-fetch scope filter still fills the
+		// page, but never clamp below the caller's own ask — an
+		// explicit deep limit (the wipeout-escalation refetch) exists
+		// precisely to dig past this cap, and flattening it turns the
+		// deeper iterations into byte-identical re-queries.
 		fetchLimit = limit * 4
 		if fetchLimit > 200 {
 			fetchLimit = 200
+		}
+		if fetchLimit < limit {
+			fetchLimit = limit
 		}
 	}
 
@@ -494,7 +513,7 @@ func (e *Engine) GatherSymbolCandidates(query string, limit int, opts QueryOptio
 	}
 
 	var cands []*rerank.Candidate
-	if s := e.getSearch(); s != nil && backendHasCorpus(s) {
+	if s := e.getSearch(); s != nil && e.backendHasCorpus(s) {
 		cands = e.gatherBackendCandidates(query, fetchLimit, opts, gatherCtx)
 	} else {
 		start := time.Now()
@@ -614,17 +633,24 @@ func (e *Engine) SearchSymbolsScoped(query string, limit int, opts QueryOptions)
 // populated disk FTS reads 0 and every search would silently divert
 // to the substring fallback until the first file edit. The
 // authoritative disk corpus size rides DocCount when the backend
-// exposes it (the SymbolSearcherBackend chain does).
-func backendHasCorpus(s search.Backend) bool {
-	if s.Count() > 0 {
+// exposes it (the SymbolSearcherBackend chain does); a positive
+// answer is memoised — see Engine.corpusSeen.
+func (e *Engine) backendHasCorpus(s search.Backend) bool {
+	if e.corpusSeen != nil && e.corpusSeen.Load() {
 		return true
 	}
-	if dc, ok := s.(interface{ DocCount() (int, bool) }); ok {
+	has := false
+	if s.Count() > 0 {
+		has = true
+	} else if dc, ok := s.(search.DocCounter); ok {
 		if n, known := dc.DocCount(); known && n > 0 {
-			return true
+			has = true
 		}
 	}
-	return false
+	if has && e.corpusSeen != nil {
+		e.corpusSeen.Store(true)
+	}
+	return has
 }
 
 // repoAllowList flattens a RepoAllow set into a sorted slice for the
@@ -694,11 +720,17 @@ func (e *Engine) gatherBackendCandidates(query string, limit int, opts QueryOpti
 		// whole BM25 head deeper than this fetch — only the backend can
 		// narrow without a depth limit.
 		var bundles []search.SymbolBundle
-		if len(opts.RepoAllow) > 0 {
+		// Gate on the flattened list, not the map: an all-false map is
+		// "deny everything" under ScopeAllows and must not select the
+		// scoped path with an empty (= unscoped!) allow list.
+		if allow := repoAllowList(opts.RepoAllow); len(allow) > 0 {
 			if sb, ok := backend.(search.ScopedSymbolBundleSearcherBackend); ok {
-				bundles = sb.SearchSymbolBundlesScoped(query, repoAllowList(opts.RepoAllow), limit*2)
+				bundles = sb.SearchSymbolBundlesScoped(query, allow, limit*2)
 			}
 		}
+		// nil = no scoped support (or error); a non-nil empty slice is
+		// the scoped path's real answer and must NOT trigger the
+		// unscoped flood fetch its emptiness proves useless.
 		if bundles == nil {
 			bundles = bsb.SearchSymbolBundles(query, limit*2)
 		}

--- a/internal/query/engine.go
+++ b/internal/query/engine.go
@@ -608,6 +608,19 @@ func (e *Engine) SearchSymbolsScoped(query string, limit int, opts QueryOptions)
 	return out
 }
 
+// repoAllowList flattens a RepoAllow set into a sorted slice for the
+// scoped backend call — sorted so the generated SQL is deterministic.
+func repoAllowList(allow map[string]bool) []string {
+	out := make([]string, 0, len(allow))
+	for r, ok := range allow {
+		if ok {
+			out = append(out, r)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
 // gatherBackendCandidates fetches BM25 + (optional) vector results,
 // dedups them across channels, and supplements with exact-name /
 // substring / bigram-rescue matches. Each candidate carries its
@@ -656,7 +669,20 @@ func (e *Engine) gatherBackendCandidates(query string, limit int, opts QueryOpti
 		}
 		vectorOnlyBackend, vectorOnlyOK := backend.(vectorOnly)
 		bundleStart := time.Now()
-		bundles := bsb.SearchSymbolBundles(query, limit*2)
+		// Repo-narrowed sessions take the scoped bundle path when the
+		// backend can filter inside the FTS query. The post-fetch
+		// ScopeAllows pass below starves whenever another repo owns the
+		// whole BM25 head deeper than this fetch — only the backend can
+		// narrow without a depth limit.
+		var bundles []search.SymbolBundle
+		if len(opts.RepoAllow) > 0 {
+			if sb, ok := backend.(search.ScopedSymbolBundleSearcherBackend); ok {
+				bundles = sb.SearchSymbolBundlesScoped(query, repoAllowList(opts.RepoAllow), limit*2)
+			}
+		}
+		if bundles == nil {
+			bundles = bsb.SearchSymbolBundles(query, limit*2)
+		}
 		if timings != nil {
 			timings.BundleMS += time.Since(bundleStart).Milliseconds()
 		}

--- a/internal/query/engine.go
+++ b/internal/query/engine.go
@@ -494,7 +494,7 @@ func (e *Engine) GatherSymbolCandidates(query string, limit int, opts QueryOptio
 	}
 
 	var cands []*rerank.Candidate
-	if s := e.getSearch(); s != nil && s.Count() > 0 {
+	if s := e.getSearch(); s != nil && backendHasCorpus(s) {
 		cands = e.gatherBackendCandidates(query, fetchLimit, opts, gatherCtx)
 	} else {
 		start := time.Now()
@@ -606,6 +606,25 @@ func (e *Engine) SearchSymbolsScoped(query string, limit int, opts QueryOptions)
 		out = append(out, c.Node)
 	}
 	return out
+}
+
+// backendHasCorpus reports whether the search backend has anything to
+// answer with. Count() alone is wrong here: it is a delta of THIS
+// process's Add/Remove calls, so a daemon warm-started over a
+// populated disk FTS reads 0 and every search would silently divert
+// to the substring fallback until the first file edit. The
+// authoritative disk corpus size rides DocCount when the backend
+// exposes it (the SymbolSearcherBackend chain does).
+func backendHasCorpus(s search.Backend) bool {
+	if s.Count() > 0 {
+		return true
+	}
+	if dc, ok := s.(interface{ DocCount() (int, bool) }); ok {
+		if n, known := dc.DocCount(); known && n > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // repoAllowList flattens a RepoAllow set into a sorted slice for the

--- a/internal/query/engine_corpus_gate_test.go
+++ b/internal/query/engine_corpus_gate_test.go
@@ -1,0 +1,66 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/search"
+)
+
+// warmStoreBackend models a backend over a pre-populated disk FTS
+// right after a daemon restart: the Add/Remove delta counter is zero
+// (nothing indexed THIS process) but the disk corpus is fully loaded.
+type warmStoreBackend struct {
+	hits []search.SearchResult
+	docs int
+}
+
+func (b *warmStoreBackend) Add(string, ...string) {}
+func (b *warmStoreBackend) Remove(string)         {}
+func (b *warmStoreBackend) Count() int            { return 0 }
+func (b *warmStoreBackend) Close()                {}
+func (b *warmStoreBackend) DocCount() (int, bool) { return b.docs, true }
+func (b *warmStoreBackend) Search(string, int) []search.SearchResult {
+	return append([]search.SearchResult(nil), b.hits...)
+}
+
+// TestGatherSymbolCandidates_WarmStoreUsesBackend: a zero delta
+// counter must not divert the engine to the substring fallback when
+// the backend's authoritative DocCount proves the corpus exists —
+// otherwise every daemon restart over an existing store silently
+// degrades search until the first file edit bumps the counter.
+func TestGatherSymbolCandidates_WarmStoreUsesBackend(t *testing.T) {
+	g := graph.New()
+	n := &graph.Node{ID: "app/w.go::WidgetExtensions", Name: "WidgetExtensions", Kind: graph.KindType, RepoPrefix: "app"}
+	g.AddNode(n)
+	backend := &warmStoreBackend{hits: []search.SearchResult{{ID: n.ID, Score: 5}}, docs: 12345}
+	engine := NewEngine(g)
+	engine.SetSearch(backend)
+
+	// A two-word concept query: the substring fallback cannot match it
+	// against "WidgetExtensions", so a result can only come from the
+	// backend — the discriminator between the two paths.
+	got := engine.GatherSymbolCandidates("widget extensions", 5, QueryOptions{SkipInnerRerank: true, SkipVectorChannel: true}, nil)
+	if len(got) != 1 || got[0].Node.ID != n.ID {
+		t.Fatalf("warm-store backend was bypassed (substring fallback?); got %#v", got)
+	}
+	if got[0].TextRank != 0 {
+		t.Fatalf("backend hit must carry its text rank; got %#v", got[0])
+	}
+}
+
+// TestGatherSymbolCandidates_EmptyBackendStillFallsBack: no delta
+// count AND no doc count keeps the substring fallback for genuinely
+// empty in-process backends.
+func TestGatherSymbolCandidates_EmptyBackendStillFallsBack(t *testing.T) {
+	g := graph.New()
+	n := &graph.Node{ID: "app/w.go::WidgetExtensions", Name: "WidgetExtensions", Kind: graph.KindType, RepoPrefix: "app"}
+	g.AddNode(n)
+	engine := NewEngine(g)
+	engine.SetSearch(search.NewBM25()) // empty: Count 0, no corpus
+
+	got := engine.GatherSymbolCandidates("WidgetExtensions", 5, QueryOptions{SkipInnerRerank: true, SkipVectorChannel: true}, nil)
+	if len(got) != 1 || got[0].Node.ID != n.ID {
+		t.Fatalf("substring fallback must still rescue empty backends; got %#v", got)
+	}
+}

--- a/internal/query/engine_corpus_gate_test.go
+++ b/internal/query/engine_corpus_gate_test.go
@@ -11,15 +11,19 @@ import (
 // right after a daemon restart: the Add/Remove delta counter is zero
 // (nothing indexed THIS process) but the disk corpus is fully loaded.
 type warmStoreBackend struct {
-	hits []search.SearchResult
-	docs int
+	hits          []search.SearchResult
+	docs          int
+	docCountCalls int
 }
 
 func (b *warmStoreBackend) Add(string, ...string) {}
 func (b *warmStoreBackend) Remove(string)         {}
 func (b *warmStoreBackend) Count() int            { return 0 }
 func (b *warmStoreBackend) Close()                {}
-func (b *warmStoreBackend) DocCount() (int, bool) { return b.docs, true }
+func (b *warmStoreBackend) DocCount() (int, bool) {
+	b.docCountCalls++
+	return b.docs, true
+}
 func (b *warmStoreBackend) Search(string, int) []search.SearchResult {
 	return append([]search.SearchResult(nil), b.hits...)
 }
@@ -48,6 +52,100 @@ func TestGatherSymbolCandidates_WarmStoreUsesBackend(t *testing.T) {
 		t.Fatalf("backend hit must carry its text rank; got %#v", got[0])
 	}
 }
+
+// TestGatherSymbolCandidates_CorpusGateMemoized: DocCount is a real
+// COUNT(*) on the disk store, and the warm-restart window makes the
+// gate fire on every gather — a positive answer is monotone for the
+// backend's lifetime and must be asked at most once.
+func TestGatherSymbolCandidates_CorpusGateMemoized(t *testing.T) {
+	g := graph.New()
+	n := &graph.Node{ID: "app/w.go::WidgetExtensions", Name: "WidgetExtensions", Kind: graph.KindType, RepoPrefix: "app"}
+	g.AddNode(n)
+	backend := &warmStoreBackend{hits: []search.SearchResult{{ID: n.ID, Score: 5}}, docs: 12345}
+	engine := NewEngine(g)
+	engine.SetSearch(backend)
+
+	opts := QueryOptions{SkipInnerRerank: true, SkipVectorChannel: true}
+	for i := 0; i < 5; i++ {
+		engine.GatherSymbolCandidates("widget extensions", 5, opts, nil)
+	}
+	if backend.docCountCalls > 1 {
+		t.Fatalf("corpus gate asked DocCount %d times across 5 gathers; a positive answer must be memoized", backend.docCountCalls)
+	}
+}
+
+// TestGatherSymbolCandidates_ExplicitDeepLimitPiercesScopeCap: the
+// scoped over-fetch cap (200) exists to bound implicit slack, not to
+// flatten an explicit deep request — the handler's post-filter-wipeout
+// escalation asks for limit 625 precisely to dig past the head, and a
+// cap below the ask turns its deeper iterations into byte-identical
+// re-queries.
+func TestGatherSymbolCandidates_ExplicitDeepLimitPiercesScopeCap(t *testing.T) {
+	g := graph.New()
+	backend := &depthRecordingBackend{}
+	engine := NewEngine(g)
+	engine.SetSearch(backend)
+
+	opts := QueryOptions{RepoAllow: map[string]bool{"app": true}, SkipInnerRerank: true, SkipVectorChannel: true}
+	engine.GatherSymbolCandidates("widget extensions", 625, opts, nil)
+	if backend.maxLimit < 625 {
+		t.Fatalf("explicit limit 625 was clamped to %d — escalation depth flattened", backend.maxLimit)
+	}
+
+	backend.maxLimit = 0
+	engine.GatherSymbolCandidates("widget extensions", 20, opts, nil)
+	if backend.maxLimit > 200 {
+		t.Fatalf("small-page scoped over-fetch must stay capped; backend saw %d", backend.maxLimit)
+	}
+}
+
+type depthRecordingBackend struct {
+	maxLimit int
+}
+
+func (b *depthRecordingBackend) Add(string, ...string) {}
+func (b *depthRecordingBackend) Remove(string)         {}
+func (b *depthRecordingBackend) Count() int            { return 1 }
+func (b *depthRecordingBackend) Close()                {}
+func (b *depthRecordingBackend) Search(_ string, limit int) []search.SearchResult {
+	if limit > b.maxLimit {
+		b.maxLimit = limit
+	}
+	return nil
+}
+
+// TestGatherSymbolCandidates_DocCountContractCorners: an
+// empty-but-known store and an unknown count must both keep the
+// fallback — only known-and-positive proves a corpus.
+func TestGatherSymbolCandidates_DocCountContractCorners(t *testing.T) {
+	g := graph.New()
+	n := &graph.Node{ID: "app/w.go::WidgetExtensions", Name: "WidgetExtensions", Kind: graph.KindType, RepoPrefix: "app"}
+	g.AddNode(n)
+	opts := QueryOptions{SkipInnerRerank: true, SkipVectorChannel: true}
+
+	for name, backend := range map[string]*warmStoreBackend{
+		"empty-but-known": {hits: []search.SearchResult{{ID: n.ID, Score: 5}}, docs: 0},
+		"unknown":         {hits: []search.SearchResult{{ID: n.ID, Score: 5}}, docs: -1},
+	} {
+		engine := NewEngine(g)
+		if name == "unknown" {
+			engine.SetSearch(&unknownCountBackend{warmStoreBackend: *backend})
+		} else {
+			engine.SetSearch(backend)
+		}
+		// Identifier query: the substring fallback CAN answer this, so
+		// a result proves the fallback ran; the backend's two-word-only
+		// hit list proves the backend did not.
+		got := engine.GatherSymbolCandidates("WidgetExtensions", 5, opts, nil)
+		if len(got) != 1 || got[0].Node.ID != n.ID {
+			t.Fatalf("%s: fallback must still answer; got %#v", name, got)
+		}
+	}
+}
+
+type unknownCountBackend struct{ warmStoreBackend }
+
+func (b *unknownCountBackend) DocCount() (int, bool) { return 12345, false }
 
 // TestGatherSymbolCandidates_EmptyBackendStillFallsBack: no delta
 // count AND no doc count keeps the substring fallback for genuinely

--- a/internal/query/engine_scoped_bundles_test.go
+++ b/internal/query/engine_scoped_bundles_test.go
@@ -1,0 +1,83 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/search"
+)
+
+// scopedBundleBackend simulates the cross-repo flood at the backend
+// boundary: the unscoped bundle call returns only out-of-scope rows
+// (the flood is deeper than any head the engine could fetch), while
+// the scoped call — narrowing inside the query — reaches the in-scope
+// symbol.
+type scopedBundleBackend struct {
+	flood       []search.SymbolBundle
+	scoped      []search.SymbolBundle
+	scopedCalls int
+}
+
+func (b *scopedBundleBackend) Add(string, ...string)                    {}
+func (b *scopedBundleBackend) Remove(string)                            {}
+func (b *scopedBundleBackend) Search(string, int) []search.SearchResult { return nil }
+func (b *scopedBundleBackend) Count() int                               { return len(b.flood) }
+func (b *scopedBundleBackend) Close()                                   {}
+
+func (b *scopedBundleBackend) SearchSymbolBundles(string, int) []search.SymbolBundle {
+	return append([]search.SymbolBundle(nil), b.flood...)
+}
+
+func (b *scopedBundleBackend) SearchSymbolBundlesScoped(_ string, _ []string, _ int) []search.SymbolBundle {
+	b.scopedCalls++
+	return append([]search.SymbolBundle(nil), b.scoped...)
+}
+
+// TestGatherSymbolCandidates_RepoScopeUsesScopedBundles: with a repo
+// narrow set and a backend that can scope inside the query, the engine
+// must take the scoped path — post-filtering the unscoped head would
+// return nothing here.
+func TestGatherSymbolCandidates_RepoScopeUsesScopedBundles(t *testing.T) {
+	g := graph.New()
+	appNode := &graph.Node{ID: "app/w.go::WidgetExtensions", Name: "WidgetExtensions", Kind: graph.KindType, RepoPrefix: "app"}
+	g.AddNode(appNode)
+	var flood []search.SymbolBundle
+	for i := 0; i < 3; i++ {
+		n := &graph.Node{ID: "noise/f.go::Extensions", Name: "Extensions", Kind: graph.KindFunction, RepoPrefix: "noise"}
+		flood = append(flood, search.SymbolBundle{Node: n, Score: 10})
+	}
+	backend := &scopedBundleBackend{
+		flood:  flood,
+		scoped: []search.SymbolBundle{{Node: appNode, Score: 1}},
+	}
+	engine := NewEngine(g)
+	engine.SetSearch(backend)
+
+	opts := QueryOptions{RepoAllow: map[string]bool{"app": true}, SkipInnerRerank: true, SkipVectorChannel: true}
+	got := engine.GatherSymbolCandidates("Extensions", 5, opts, nil)
+	if len(got) != 1 || got[0].Node.ID != appNode.ID {
+		t.Fatalf("scoped gather = %#v, want exactly the in-scope symbol", got)
+	}
+	if backend.scopedCalls != 1 {
+		t.Fatalf("scoped backend path used %d times, want 1", backend.scopedCalls)
+	}
+}
+
+// TestGatherSymbolCandidates_NoScopeKeepsUnscopedBundles: without a
+// repo narrow the engine must not pay the scoped path.
+func TestGatherSymbolCandidates_NoScopeKeepsUnscopedBundles(t *testing.T) {
+	g := graph.New()
+	n := &graph.Node{ID: "noise/f.go::Extensions", Name: "Extensions", Kind: graph.KindFunction, RepoPrefix: "noise"}
+	g.AddNode(n)
+	backend := &scopedBundleBackend{flood: []search.SymbolBundle{{Node: n, Score: 10}}}
+	engine := NewEngine(g)
+	engine.SetSearch(backend)
+
+	got := engine.GatherSymbolCandidates("Extensions", 5, QueryOptions{SkipInnerRerank: true, SkipVectorChannel: true}, nil)
+	if len(got) != 1 || got[0].Node.ID != n.ID {
+		t.Fatalf("unscoped gather = %#v, want the flood row", got)
+	}
+	if backend.scopedCalls != 0 {
+		t.Fatalf("scoped path used without a repo narrow (%d calls)", backend.scopedCalls)
+	}
+}

--- a/internal/query/engine_scoped_bundles_test.go
+++ b/internal/query/engine_scoped_bundles_test.go
@@ -13,24 +13,38 @@ import (
 // the scoped call — narrowing inside the query — reaches the in-scope
 // symbol.
 type scopedBundleBackend struct {
-	flood       []search.SymbolBundle
-	scoped      []search.SymbolBundle
-	scopedCalls int
+	flood         []search.SymbolBundle
+	scoped        []search.SymbolBundle
+	scopedCalls   int
+	unscopedCalls int
+	searchCalls   int
 }
 
-func (b *scopedBundleBackend) Add(string, ...string)                    {}
-func (b *scopedBundleBackend) Remove(string)                            {}
-func (b *scopedBundleBackend) Search(string, int) []search.SearchResult { return nil }
-func (b *scopedBundleBackend) Count() int                               { return len(b.flood) }
-func (b *scopedBundleBackend) Close()                                   {}
+func (b *scopedBundleBackend) Add(string, ...string) {}
+func (b *scopedBundleBackend) Remove(string)         {}
+func (b *scopedBundleBackend) Search(string, int) []search.SearchResult {
+	b.searchCalls++
+	return nil
+}
+func (b *scopedBundleBackend) Count() int { return len(b.flood) }
+func (b *scopedBundleBackend) Close()     {}
 
 func (b *scopedBundleBackend) SearchSymbolBundles(string, int) []search.SymbolBundle {
+	b.unscopedCalls++
 	return append([]search.SymbolBundle(nil), b.flood...)
 }
 
 func (b *scopedBundleBackend) SearchSymbolBundlesScoped(_ string, _ []string, _ int) []search.SymbolBundle {
 	b.scopedCalls++
-	return append([]search.SymbolBundle(nil), b.scoped...)
+	// Preserve nil-vs-empty: a non-nil empty scoped answer is the
+	// sentinel contract the engine must honour (append would flatten
+	// it back to nil).
+	if b.scoped == nil {
+		return nil
+	}
+	out := make([]search.SymbolBundle, len(b.scoped))
+	copy(out, b.scoped)
+	return out
 }
 
 // TestGatherSymbolCandidates_RepoScopeUsesScopedBundles: with a repo
@@ -60,6 +74,34 @@ func TestGatherSymbolCandidates_RepoScopeUsesScopedBundles(t *testing.T) {
 	}
 	if backend.scopedCalls != 1 {
 		t.Fatalf("scoped backend path used %d times, want 1", backend.scopedCalls)
+	}
+}
+
+// TestGatherSymbolCandidates_ScopedZeroDoesNotFloodFetch: a scoped
+// query that legitimately answers zero IS the answer — the engine must
+// not fall back to the unscoped bundle fetch (the cross-repo flood cost
+// the scoped path exists to remove) nor the channel/Search path.
+func TestGatherSymbolCandidates_ScopedZeroDoesNotFloodFetch(t *testing.T) {
+	g := graph.New()
+	noise := &graph.Node{ID: "noise/f.go::Extensions", Name: "Extensions", Kind: graph.KindFunction, RepoPrefix: "noise"}
+	g.AddNode(noise)
+	backend := &scopedBundleBackend{
+		flood:  []search.SymbolBundle{{Node: noise, Score: 10}},
+		scoped: []search.SymbolBundle{}, // non-nil empty: scoped answered zero
+	}
+	engine := NewEngine(g)
+	engine.SetSearch(backend)
+
+	opts := QueryOptions{RepoAllow: map[string]bool{"app": true}, SkipInnerRerank: true, SkipVectorChannel: true}
+	got := engine.GatherSymbolCandidates("Extensions", 5, opts, nil)
+	if len(got) != 0 {
+		t.Fatalf("scoped zero answer must yield no candidates, got %#v", got)
+	}
+	if backend.unscopedCalls != 0 {
+		t.Fatalf("unscoped bundle fetch ran %d times after a scoped zero answer", backend.unscopedCalls)
+	}
+	if backend.searchCalls != 0 {
+		t.Fatalf("fallback Search ran %d times after a scoped zero answer", backend.searchCalls)
 	}
 }
 

--- a/internal/search/hybrid.go
+++ b/internal/search/hybrid.go
@@ -169,7 +169,7 @@ func (h *HybridBackend) DocCount() (int, bool) {
 	if h == nil || h.text == nil {
 		return 0, false
 	}
-	if dc, ok := h.text.(interface{ DocCount() (int, bool) }); ok {
+	if dc, ok := h.text.(DocCounter); ok {
 		return dc.DocCount()
 	}
 	return 0, false

--- a/internal/search/hybrid.go
+++ b/internal/search/hybrid.go
@@ -163,6 +163,19 @@ func (h *HybridBackend) SearchSymbolBundles(query string, limit int) []SymbolBun
 	return nil
 }
 
+// SearchSymbolBundlesScoped forwards the repo-narrowed bundle path to
+// the text backend; the vector channel does not participate, exactly
+// as in SearchSymbolBundles.
+func (h *HybridBackend) SearchSymbolBundlesScoped(query string, repoAllow []string, limit int) []SymbolBundle {
+	if h == nil || h.text == nil {
+		return nil
+	}
+	if bs, ok := h.text.(ScopedSymbolBundleSearcherBackend); ok {
+		return bs.SearchSymbolBundlesScoped(query, repoAllow, limit)
+	}
+	return nil
+}
+
 func (h *HybridBackend) searchChannels(query string, limit int) ([]SearchResult, []string, ChannelTimings) {
 	var stats ChannelTimings
 	tStart := time.Now()

--- a/internal/search/hybrid.go
+++ b/internal/search/hybrid.go
@@ -163,6 +163,18 @@ func (h *HybridBackend) SearchSymbolBundles(query string, limit int) []SymbolBun
 	return nil
 }
 
+// DocCount forwards the text backend's authoritative corpus size for
+// the engine's has-corpus gate, mirroring the Swappable forward.
+func (h *HybridBackend) DocCount() (int, bool) {
+	if h == nil || h.text == nil {
+		return 0, false
+	}
+	if dc, ok := h.text.(interface{ DocCount() (int, bool) }); ok {
+		return dc.DocCount()
+	}
+	return 0, false
+}
+
 // SearchSymbolBundlesScoped forwards the repo-narrowed bundle path to
 // the text backend; the vector channel does not participate, exactly
 // as in SearchSymbolBundles.

--- a/internal/search/swappable.go
+++ b/internal/search/swappable.go
@@ -122,9 +122,14 @@ func (s *Swappable) SearchSymbolBundles(query string, limit int) []SymbolBundle 
 // warm-started daemon over a populated disk FTS isn't mistaken for an
 // empty backend.
 func (s *Swappable) DocCount() (int, bool) {
+	// Snapshot the inner backend under the lock but run the count
+	// outside it — DocCount can be a real store query and holding
+	// the RLock across it would stall a pending Swap (and, behind
+	// it, every new reader).
 	s.mu.RLock()
-	defer s.mu.RUnlock()
-	if dc, ok := s.inner.(interface{ DocCount() (int, bool) }); ok {
+	inner := s.inner
+	s.mu.RUnlock()
+	if dc, ok := inner.(DocCounter); ok {
 		return dc.DocCount()
 	}
 	return 0, false

--- a/internal/search/swappable.go
+++ b/internal/search/swappable.go
@@ -117,6 +117,19 @@ func (s *Swappable) SearchSymbolBundles(query string, limit int) []SymbolBundle 
 	return nil
 }
 
+// DocCount forwards the authoritative corpus size when the inner
+// backend exposes it — the engine's has-corpus gate reads this so a
+// warm-started daemon over a populated disk FTS isn't mistaken for an
+// empty backend.
+func (s *Swappable) DocCount() (int, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if dc, ok := s.inner.(interface{ DocCount() (int, bool) }); ok {
+		return dc.DocCount()
+	}
+	return 0, false
+}
+
 // SearchSymbolBundlesScoped forwards the repo-narrowed bundle path the
 // same way; nil when the inner backend doesn't expose it.
 func (s *Swappable) SearchSymbolBundlesScoped(query string, repoAllow []string, limit int) []SymbolBundle {

--- a/internal/search/swappable.go
+++ b/internal/search/swappable.go
@@ -117,6 +117,17 @@ func (s *Swappable) SearchSymbolBundles(query string, limit int) []SymbolBundle 
 	return nil
 }
 
+// SearchSymbolBundlesScoped forwards the repo-narrowed bundle path the
+// same way; nil when the inner backend doesn't expose it.
+func (s *Swappable) SearchSymbolBundlesScoped(query string, repoAllow []string, limit int) []SymbolBundle {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if bs, ok := s.inner.(ScopedSymbolBundleSearcherBackend); ok {
+		return bs.SearchSymbolBundlesScoped(query, repoAllow, limit)
+	}
+	return nil
+}
+
 // VectorChannelOnly forwards to the inner backend when it implements
 // the vector-only channel pull (today: HybridBackend). Lets the
 // engine fetch the vector channel without re-running text BM25 —

--- a/internal/search/symbolsearcher_backend.go
+++ b/internal/search/symbolsearcher_backend.go
@@ -95,6 +95,33 @@ type SymbolBundleSearcherBackend interface {
 	SearchSymbolBundles(query string, limit int) []SymbolBundle
 }
 
+// SearchSymbolBundlesScoped is the repo-narrowed bundle path — the
+// narrowing runs inside the wrapped store's FTS query (see
+// graph.ScopedSymbolBundleSearcher for why a post-fetch filter can't
+// substitute). Returns nil when the store has no scoped support;
+// callers fall back to the unscoped bundle path.
+func (b *SymbolSearcherBackend) SearchSymbolBundlesScoped(query string, repoAllow []string, limit int) []SymbolBundle {
+	if b == nil || b.s == nil || strings.TrimSpace(query) == "" {
+		return nil
+	}
+	bs, ok := b.s.(graph.ScopedSymbolBundleSearcher)
+	if !ok {
+		return nil
+	}
+	bundles, err := bs.SearchSymbolBundlesRepoScoped(query, repoAllow, limit)
+	if err != nil {
+		return nil
+	}
+	return bundles
+}
+
+// ScopedSymbolBundleSearcherBackend is the engine's detection
+// interface for the repo-narrowed bundle path. *SymbolSearcherBackend
+// implements it; Swappable and HybridBackend forward.
+type ScopedSymbolBundleSearcherBackend interface {
+	SearchSymbolBundlesScoped(query string, repoAllow []string, limit int) []SymbolBundle
+}
+
 // Search forwards to SymbolSearcher.SearchSymbols and translates
 // the per-hit (NodeID, Score) into search.SearchResult so callers
 // don't see the graph package at all.

--- a/internal/search/symbolsearcher_backend.go
+++ b/internal/search/symbolsearcher_backend.go
@@ -112,6 +112,13 @@ func (b *SymbolSearcherBackend) SearchSymbolBundlesScoped(query string, repoAllo
 	if err != nil {
 		return nil
 	}
+	if bundles == nil {
+		// Non-nil empty = "scoped path answered: nothing in scope".
+		// Callers fall back to the unscoped fetch only on nil — a
+		// genuine zero must not trigger a doomed cross-repo flood
+		// query whose head ScopeAllows would discard wholesale.
+		return []SymbolBundle{}
+	}
 	return bundles
 }
 
@@ -179,6 +186,14 @@ func (b *SymbolSearcherBackend) Count() int {
 		return 0
 	}
 	return int(b.count.Load())
+}
+
+// DocCounter is the capability interface for the authoritative corpus
+// size — distinct from Backend.Count(), which is a process-local
+// Add/Remove delta. The engine's has-corpus gate asserts this;
+// Swappable and HybridBackend forward it.
+type DocCounter interface {
+	DocCount() (int, bool)
 }
 
 // DocCount returns the authoritative number of indexed documents, straight


### PR DESCRIPTION
## Summary

`search_symbols` for a suffix-convention name — `Extensions`, `Controller`, `Repository`, the shapes .NET codebases name by — returned **zero results** on a production C# solution whose graph demonstrably held 67 matching classes (exact-name lookup found each one). Root-causing that single symptom uncovered four independent mechanisms stacked on top of each other, each one masking the next. This PR fixes all four, each with a failing-test-first repro:

1. **Post-filter wipeout** (`internal/mcp/tools_core.go`). Corpus / repo / kind filters run after a bounded fetch; when noise rows own the whole BM25 head, the filters empty the page and the existing zero-result fallbacks re-run the same poisoned fetch. Fix: when the raw fetch had candidates but post-filtering emptied it, refetch at ×5 then ×25 depth under the same scope — before the fallbacks that relax the caller's filters. Response carries `fetch_escalated: true`.

2. **Cross-repo floods outrun any bounded over-fetch** (`store_fts.go` + engine threading). The FTS query is repo-blind; the engine's scope filter runs over a head capped at 200 rows. One tracked Go repo contributes 232 exact-token `Extensions` symbols — deeper than the cap, so a scoped session could never see the other repo's classes, and BM25's IDF makes the flood direction flip as index composition changes. Fix: `SearchSymbolsRepoScoped` / `SearchSymbolBundlesRepoScoped` filter `repo_prefix` inside the SQL (the same UNINDEXED-literal-column shape the per-repo staleness wipe uses), threaded to the engine via a `ScopedSymbolBundleSearcher` capability with `Swappable` / `HybridBackend` forwards — the `SymbolBundleSearcher` pattern. Unowned rows (empty prefix) always pass, matching the `ScopeAllows` carve-out. With scoping, the flagship query's true best match ranks **0** instead of past-200.

3. **Container nodes hijack the exact-name tier** (`store_fts.go`). Tier 0 short-circuits to exact-name hits before FTS. Two `.csproj` module nodes named `Extensions` — in-scope, exactly named — eclipsed every `*Extensions` class, and since downstream shaping drops container kinds, the page came back empty while looking "handled" to the wipeout rescue. Fix: container/binding kinds (module, package, file, import, local, param, generic param, closure, builtin) no longer short-circuit; they remain reachable through FTS ranking. Exact-name hits on real symbols keep the fast path.

4. **Warm-restarted daemons silently degrade to substring search** (`internal/query/engine.go`). The engine gates the backend on `Count() > 0` — but `Count` is a delta of this process's Add/Remove calls (its own doc warns it is not a corpus size), so a daemon restarted over a populated disk FTS reads 0 and every search takes the substring fallback until the first file edit. Easy to miss when dogfooding (active development bumps the counter constantly); guaranteed for read-mostly consumers. Fix: `backendHasCorpus` consults the authoritative `DocCount` (forwarded through `Swappable` / `HybridBackend`) before falling back.

## Real-world results (reference .NET solution, ~8,000 indexed files, two-repo workspace)

- `Extensions`: 0 → **71 hits**, the four same-named module-variant classes first, immediately after a cold daemon restart with no file activity.
- `Controller` / `Repository` suffix queries return the expected controllers/repositories.
- Exact-name, camelCase-prefix, and cross-repo Go queries unchanged (regression battery on both repos).
- Each mechanism was bisected live against the real store (a copy driven through store → bundles → engine layers) before its fix.

A fifth commit hardens the four fixes against an adversarial review pass: the corpus gate memoises its positive answer (the `DocCount` fallback is a real `COUNT(*)`; a corpus never un-populates within a backend's lifetime) and releases the `Swappable` read-lock before querying; the engine's scoped over-fetch cap no longer clamps below an explicit caller limit (which silently flattened the escalation's deeper iterations into byte-identical re-queries); a scoped query that legitimately finds nothing returns a non-nil empty page instead of falling back to the doomed unscoped flood fetch; the escalation skips the content corpus (those rows live only in `content_fts`), caps its deepest fetch, and honours context cancellation; an all-`false` `RepoAllow` map can no longer select the scoped path with an empty (= unscoped) allow list; and the tier-0 contract is pinned by tests in both directions — exact symbol-kind hits keep the fast path, container hits ride along for `kind:`-filtered callers rather than being droppable.

## Known gaps (documented, not silent)

- Param / generic-param nodes are still FTS-indexed and dilute BM25 heads (the KindLocal exclusion rationale applies to them verbatim); excluding them needs an index rebuild, so it is left for a follow-up.
- The escalation depths are bounded (×25, absolute cap 2000); a flood deeper than that falls back to the previous empty-page behaviour rather than an unbounded scan.
- Repo-grain narrowing rides the FTS query; project-grain (sub-repo) scope still filters post-fetch over the bounded head.
- The escalation refetch re-runs the code-shaped channel only; a `corpus:docs` wipeout relies on prose ranking within it rather than re-running the widened doc channel.

## Testing

- [x] New: 3 handler tests (flood rescue, no-flag-on-hit, true-miss no-refetch), 9 scoped-store tests (cross-repo flood, exact-name scope, unowned carve-out, nil-scope equivalence, multi-repo allow list, scoped bundles, container-kind gate, container merge-along, exact-type-wins pin), 6 engine tests (scoped-path selection, unscoped preservation, corpus gate warm/empty, DocCount contract corners, gate memoisation, cap-piercing depth).
- [x] `go test` on mcp / query / search / store_sqlite packages — failure set on the Windows dev box is byte-identical to clean `origin/main` (pre-existing platform failures; verified by name-level diff).

## Checklist

- [x] Code follows existing patterns (capability-interface threading mirrors `SymbolBundleSearcher`; SQL shape mirrors the per-repo wipe)
- [x] No unnecessary abstractions added
