### PR TITLE
perf(sqlite): avoid per-row BLOB copies in cursor scans

### DIFF
--- a/internal/graph/store_sqlite/analysis_projection.go
+++ b/internal/graph/store_sqlite/analysis_projection.go
@@ -84,7 +84,7 @@ func (s *Store) NodesByKindsSeq(kinds ...graph.NodeKind) iter.Seq[*graph.Node] {
 		}
 		defer rows.Close()
 		for rows.Next() {
-			node, scanErr := scanNode(rows)
+			node, scanErr := scanNodeCursor(rows)
 			if scanErr != nil {
 				panicOnFatal(scanErr)
 				return

--- a/internal/graph/store_sqlite/dataflow_batch.go
+++ b/internal/graph/store_sqlite/dataflow_batch.go
@@ -2,6 +2,7 @@ package store_sqlite
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/zzet/gortex/internal/graph"
 )
@@ -112,7 +113,7 @@ func scanDataflowEdge(scanner interface{ Scan(...any) error }) (int64, *graph.Ed
 	var (
 		rowID     int64
 		edge      graph.Edge
-		metaBlob  []byte
+		metaBlob  sql.RawBytes
 		crossRepo int64
 		promoted  promotedEdgeMeta
 	)

--- a/internal/graph/store_sqlite/edge_identity_lookup.go
+++ b/internal/graph/store_sqlite/edge_identity_lookup.go
@@ -95,7 +95,7 @@ func (s *Store) findEdgesByIdentities(identities []graph.EdgeIdentity) (map[grap
 		}
 
 		for rows.Next() {
-			edge, scanErr := scanEdge(rows)
+			edge, scanErr := scanEdgeCursor(rows)
 			if scanErr != nil {
 				_ = rows.Close()
 				panicOnFatal(scanErr)

--- a/internal/graph/store_sqlite/lsp_projection.go
+++ b/internal/graph/store_sqlite/lsp_projection.go
@@ -146,7 +146,7 @@ ORDER BY e.from_id, e.to_id, e.kind, e.file_path, e.line`, languagesJSON, filesJ
 	defer rows.Close()
 	var out []*graph.Edge
 	for rows.Next() {
-		edge, err := scanEdge(rows)
+		edge, err := scanEdgeCursor(rows)
 		if err != nil {
 			panicOnFatal(err)
 			return out
@@ -207,7 +207,7 @@ ORDER BY e.from_id, e.to_id, e.kind, e.file_path, e.line`, languagesJSON, filesJ
 	defer rows.Close()
 	var out []*graph.Edge
 	for rows.Next() {
-		edge, err := scanEdge(rows)
+		edge, err := scanEdgeCursor(rows)
 		if err != nil {
 			panicOnFatal(err)
 			return out
@@ -295,7 +295,7 @@ ORDER BY e.from_id, e.to_id, e.kind, e.file_path, e.line`, idsJSON, kindsJSON)
 	defer rows.Close()
 	var out []*graph.Edge
 	for rows.Next() {
-		edge, err := scanEdge(rows)
+		edge, err := scanEdgeCursor(rows)
 		if err != nil {
 			panicOnFatal(err)
 			return out

--- a/internal/graph/store_sqlite/rawbytes_scan_test.go
+++ b/internal/graph/store_sqlite/rawbytes_scan_test.go
@@ -1,0 +1,233 @@
+package store_sqlite
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestCursorMetadataDecodedBeforeRowsNext(t *testing.T) {
+	store := openRawBytesTestStore(t)
+	payloadA := strings.Repeat("a", 4096)
+	payloadB := strings.Repeat("b", 4096)
+	store.AddBatch([]*graph.Node{
+		{ID: "a", Kind: graph.KindFunction, Name: "a", QualName: "pkg.a", Meta: map[string]any{"payload": payloadA}},
+		{ID: "b", Kind: graph.KindFunction, Name: "b", QualName: "pkg.b", Meta: map[string]any{"payload": payloadB}},
+	}, []*graph.Edge{
+		{From: "a", To: "b", Kind: graph.EdgeCalls, FilePath: "a.go", Line: 1, Meta: map[string]any{"payload": payloadA}},
+		{From: "b", To: "a", Kind: graph.EdgeCalls, FilePath: "b.go", Line: 2, Meta: map[string]any{"payload": payloadB}},
+	})
+
+	nodeRows, err := store.db.Query(`SELECT ` + nodeInsertColumns + ` FROM nodes ORDER BY id`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var nodes []*graph.Node
+	for nodeRows.Next() {
+		node, scanErr := scanNodeCursor(nodeRows)
+		if scanErr != nil {
+			_ = nodeRows.Close()
+			t.Fatal(scanErr)
+		}
+		nodes = append(nodes, node)
+	}
+	if err := nodeRows.Err(); err != nil {
+		_ = nodeRows.Close()
+		t.Fatal(err)
+	}
+	if err := nodeRows.Close(); err != nil {
+		t.Fatal(err)
+	}
+	assertMetadataPayload(t, nodesByID(nodes)["a"].Meta, payloadA)
+	assertMetadataPayload(t, nodesByID(nodes)["b"].Meta, payloadB)
+
+	edgeRows, err := store.db.Query(`SELECT ` + edgeInsertColumns + ` FROM edges ORDER BY id`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var edges []*graph.Edge
+	for edgeRows.Next() {
+		edge, scanErr := scanEdgeCursor(edgeRows)
+		if scanErr != nil {
+			_ = edgeRows.Close()
+			t.Fatal(scanErr)
+		}
+		edges = append(edges, edge)
+	}
+	if err := edgeRows.Err(); err != nil {
+		_ = edgeRows.Close()
+		t.Fatal(err)
+	}
+	if err := edgeRows.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if len(edges) != 2 {
+		t.Fatalf("edges = %d, want 2", len(edges))
+	}
+	for _, edge := range edges {
+		if edge.From == "a" {
+			assertMetadataPayload(t, edge.Meta, payloadA)
+		} else {
+			assertMetadataPayload(t, edge.Meta, payloadB)
+		}
+	}
+}
+
+func TestPointNodeScansKeepCopiedMetadata(t *testing.T) {
+	store := openRawBytesTestStore(t)
+	payload := strings.Repeat("point", 1024)
+	store.AddNode(&graph.Node{
+		ID:       "point",
+		Kind:     graph.KindFunction,
+		Name:     "point",
+		QualName: "pkg.point",
+		Meta:     map[string]any{"payload": payload},
+	})
+
+	assertMetadataPayload(t, store.GetNode("point").Meta, payload)
+	assertMetadataPayload(t, store.GetNodeByQualName("pkg.point").Meta, payload)
+	node, err := store.GetNodeContext(context.Background(), "point")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertMetadataPayload(t, node.Meta, payload)
+}
+
+func openRawBytesTestStore(tb testing.TB) *Store {
+	tb.Helper()
+	store, err := Open(filepath.Join(tb.TempDir(), "rawbytes.sqlite"))
+	if err != nil {
+		tb.Fatal(err)
+	}
+	tb.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func nodesByID(nodes []*graph.Node) map[string]*graph.Node {
+	out := make(map[string]*graph.Node, len(nodes))
+	for _, node := range nodes {
+		out[node.ID] = node
+	}
+	return out
+}
+
+func assertMetadataPayload(t *testing.T, meta map[string]any, want string) {
+	t.Helper()
+	got, _ := meta["payload"].(string)
+	if got != want {
+		t.Fatalf("metadata payload length = %d, want %d", len(got), len(want))
+	}
+}
+
+var benchmarkMetadataSink any
+
+func BenchmarkMetadataCursorScan(b *testing.B) {
+	for _, metadataBytes := range []int{256, 4096} {
+		store := metadataBenchmarkStore(b, metadataBytes)
+		b.Run(fmt.Sprintf("node/%d/copied-bytes", metadataBytes), func(b *testing.B) {
+			benchmarkNodeMetadataCursor(b, store, false)
+		})
+		b.Run(fmt.Sprintf("node/%d/raw-bytes", metadataBytes), func(b *testing.B) {
+			benchmarkNodeMetadataCursor(b, store, true)
+		})
+		b.Run(fmt.Sprintf("edge/%d/copied-bytes", metadataBytes), func(b *testing.B) {
+			benchmarkEdgeMetadataCursor(b, store, false)
+		})
+		b.Run(fmt.Sprintf("edge/%d/raw-bytes", metadataBytes), func(b *testing.B) {
+			benchmarkEdgeMetadataCursor(b, store, true)
+		})
+	}
+}
+
+func metadataBenchmarkStore(b *testing.B, metadataBytes int) *Store {
+	b.Helper()
+	store := openRawBytesTestStore(b)
+	payload := strings.Repeat("x", metadataBytes)
+	const rowCount = 128
+	nodes := make([]*graph.Node, 0, rowCount)
+	edges := make([]*graph.Edge, 0, rowCount)
+	for i := 0; i < rowCount; i++ {
+		id := fmt.Sprintf("n-%03d", i)
+		nodes = append(nodes, &graph.Node{
+			ID: id, Kind: graph.KindFunction, Name: id,
+			Meta: map[string]any{"payload": payload, "row": id},
+		})
+		to := fmt.Sprintf("n-%03d", (i+1)%rowCount)
+		edges = append(edges, &graph.Edge{
+			From: id, To: to, Kind: graph.EdgeCalls, FilePath: "bench.go", Line: i + 1,
+			Meta: map[string]any{"payload": payload, "row": id},
+		})
+	}
+	store.AddBatch(nodes, edges)
+	return store
+}
+
+func benchmarkNodeMetadataCursor(b *testing.B, store *Store, raw bool) {
+	b.Helper()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rows, err := store.db.Query(`SELECT ` + nodeInsertColumns + ` FROM nodes ORDER BY id`)
+		if err != nil {
+			b.Fatal(err)
+		}
+		for rows.Next() {
+			var node *graph.Node
+			if raw {
+				node, err = scanNodeCursor(rows)
+			} else {
+				var metaBlob []byte
+				node, err = scanNodeWithMeta(rows, &metaBlob)
+			}
+			if err != nil {
+				_ = rows.Close()
+				b.Fatal(err)
+			}
+			benchmarkMetadataSink = node.Meta["payload"]
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			b.Fatal(err)
+		}
+		if err := rows.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func benchmarkEdgeMetadataCursor(b *testing.B, store *Store, raw bool) {
+	b.Helper()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rows, err := store.db.Query(`SELECT ` + edgeInsertColumns + ` FROM edges ORDER BY id`)
+		if err != nil {
+			b.Fatal(err)
+		}
+		for rows.Next() {
+			var edge *graph.Edge
+			if raw {
+				edge, err = scanEdgeCursor(rows)
+			} else {
+				var metaBlob []byte
+				edge, err = scanEdgeWithMeta(rows, &metaBlob)
+			}
+			if err != nil {
+				_ = rows.Close()
+				b.Fatal(err)
+			}
+			benchmarkMetadataSink = edge.Meta["payload"]
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			b.Fatal(err)
+		}
+		if err := rows.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/graph/store_sqlite/repo_language_name_batch.go
+++ b/internal/graph/store_sqlite/repo_language_name_batch.go
@@ -1,6 +1,7 @@
 package store_sqlite
 
 import (
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -154,7 +155,7 @@ func scanResolverNameScopeNode(scanner interface {
 		scopeID            int
 		sortRepo, sortLang string
 		n                  graph.Node
-		metaBlob           []byte
+		metaBlob           sql.RawBytes
 		p                  promotedNodeMeta
 	)
 	err := scanner.Scan(

--- a/internal/graph/store_sqlite/repo_projections.go
+++ b/internal/graph/store_sqlite/repo_projections.go
@@ -326,7 +326,7 @@ func (s *Store) RepoEdgesByKinds(repoPrefixes []string, kinds []graph.EdgeKind) 
 	var out []graph.RepoEdgeRow
 	for rows.Next() {
 		var repoPrefix string
-		edge, err := scanEdge(repoPrefixedEdgeScanner{scanner: rows, repo: &repoPrefix})
+		edge, err := scanEdgeCursor(repoPrefixedEdgeScanner{scanner: rows, repo: &repoPrefix})
 		if err != nil {
 			panicOnFatal(err)
 			return out

--- a/internal/graph/store_sqlite/schema_version.go
+++ b/internal/graph/store_sqlite/schema_version.go
@@ -226,7 +226,7 @@ LIMIT ?`, afterID, []byte(edgeSemanticSourceMetaMarker), limits.pageRows)
 		updates := make([]edgeSemanticSourceMigrationRow, 0, min(limits.pageRows, limits.updateRows))
 		for rows.Next() {
 			var id int64
-			var blob []byte
+			var blob sql.RawBytes
 			if err := rows.Scan(&id, &blob); err != nil {
 				_ = rows.Close()
 				return stats, err

--- a/internal/graph/store_sqlite/scoped_projection.go
+++ b/internal/graph/store_sqlite/scoped_projection.go
@@ -100,7 +100,7 @@ func (s *Store) streamScopedNodes(query string, args []any, summary bool, yield 
 			if summary {
 				node, scanErr = scanNodeSummary(rows)
 			} else {
-				node, scanErr = scanNode(rows)
+				node, scanErr = scanNodeCursor(rows)
 			}
 			if scanErr != nil {
 				_ = rows.Close()
@@ -175,7 +175,7 @@ func (s *Store) streamScopedEdges(query string, args []any, maxID int64, yield f
 		page := make([]*graph.Edge, 0, scopedProjectionPage)
 		for rows.Next() {
 			var edgeID int64
-			edge, scanErr := scanEdge(edgeIDScanner{scanner: rows, id: &edgeID})
+			edge, scanErr := scanEdgeCursor(edgeIDScanner{scanner: rows, id: &edgeID})
 			if scanErr != nil {
 				_ = rows.Close()
 				panicOnFatal(scanErr)

--- a/internal/graph/store_sqlite/store.go
+++ b/internal/graph/store_sqlite/store.go
@@ -910,13 +910,29 @@ func (s *Store) prepare() error {
 
 // -- row scanners ---------------------------------------------------------
 
-func scanNode(scanner interface {
+type rowScanner interface {
 	Scan(...any) error
-}) (*graph.Node, error) {
+}
+
+// scanNode is reserved for point lookups backed by sql.Row. database/sql
+// rejects sql.RawBytes for Row.Scan because Row closes its cursor before Scan
+// returns, so these callers must retain the driver's defensive []byte copy.
+func scanNode(scanner rowScanner) (*graph.Node, error) {
+	var metaBlob []byte
+	return scanNodeWithMeta(scanner, &metaBlob)
+}
+
+// scanNodeCursor decodes metadata while the Rows cursor still owns the bytes.
+// The decoded map never retains the RawBytes slice beyond Rows.Next.
+func scanNodeCursor(scanner rowScanner) (*graph.Node, error) {
+	var metaBlob sql.RawBytes
+	return scanNodeWithMeta(scanner, &metaBlob)
+}
+
+func scanNodeWithMeta[B ~[]byte](scanner rowScanner, metaBlob *B) (*graph.Node, error) {
 	var (
-		n        graph.Node
-		metaBlob []byte
-		p        promotedNodeMeta
+		n graph.Node
+		p promotedNodeMeta
 	)
 	err := scanner.Scan(
 		&n.ID, &n.Kind, &n.Name, &n.QualName, &n.FilePath,
@@ -925,14 +941,14 @@ func scanNode(scanner interface {
 		&p.sig, &p.vis, &p.doc, &p.external, &p.returnType,
 		&p.isAsync, &p.isStatic, &p.isAbstract, &p.isExported, &p.updatedAt,
 		&p.dataClass, &p.semanticType, &p.semanticSource, &p.cloneSig,
-		&p.entryPoint, &p.entryPointKind, &metaBlob,
+		&p.entryPoint, &p.entryPointKind, metaBlob,
 		&p.searchSig, &p.searchQualName, &p.searchDoc, &p.searchSuppressed, &p.sectionText,
 	)
 	if err != nil {
 		return nil, err
 	}
-	if len(metaBlob) > 0 {
-		m, derr := decodeMeta(metaBlob)
+	if len(*metaBlob) > 0 {
+		m, derr := decodeMeta([]byte(*metaBlob))
 		if derr != nil {
 			return nil, derr
 		}
@@ -995,26 +1011,30 @@ func scanNodeSummary(scanner interface {
 	return &n, nil
 }
 
-func scanEdge(scanner interface {
-	Scan(...any) error
-}) (*graph.Edge, error) {
+// scanEdgeCursor is cursor-only: metadata is decoded before Rows.Next, so the
+// driver-owned RawBytes never escapes into the returned edge.
+func scanEdgeCursor(scanner rowScanner) (*graph.Edge, error) {
+	var metaBlob sql.RawBytes
+	return scanEdgeWithMeta(scanner, &metaBlob)
+}
+
+func scanEdgeWithMeta[B ~[]byte](scanner rowScanner, metaBlob *B) (*graph.Edge, error) {
 	var (
 		e         graph.Edge
-		metaBlob  []byte
 		crossRepo int64
 		p         promotedEdgeMeta
 	)
 	err := scanner.Scan(
 		&e.From, &e.To, &e.Kind, &e.FilePath, &e.Line,
 		&e.Confidence, &e.ConfidenceLabel, &e.Origin, &e.Tier,
-		&crossRepo, &metaBlob, &p.resolveTerminal, &p.resolveTerminalReason, &p.semanticSource,
+		&crossRepo, metaBlob, &p.resolveTerminal, &p.resolveTerminalReason, &p.semanticSource,
 	)
 	if err != nil {
 		return nil, err
 	}
 	e.CrossRepo = crossRepo != 0
-	if len(metaBlob) > 0 {
-		m, derr := decodeMeta(metaBlob)
+	if len(*metaBlob) > 0 {
+		m, derr := decodeMeta([]byte(*metaBlob))
 		if derr != nil {
 			return nil, derr
 		}
@@ -1710,7 +1730,7 @@ func (s *Store) queryNodesContext(ctx context.Context, stmt *sql.Stmt, args ...a
 	defer rows.Close()
 	var out []*graph.Node
 	for rows.Next() {
-		n, err := scanNode(rows)
+		n, err := scanNodeCursor(rows)
 		if err != nil {
 			if ctx.Err() != nil {
 				return out
@@ -1802,7 +1822,7 @@ func (s *Store) scanNodeQuery(query string, args ...any) []*graph.Node {
 	defer rows.Close()
 	var out []*graph.Node
 	for rows.Next() {
-		n, err := scanNode(rows)
+		n, err := scanNodeCursor(rows)
 		if err != nil {
 			panicOnFatal(err)
 			return out
@@ -1913,7 +1933,7 @@ func (s *Store) queryEdges(stmt *sql.Stmt, args ...any) []*graph.Edge {
 	defer rows.Close()
 	var out []*graph.Edge
 	for rows.Next() {
-		e, err := scanEdge(rows)
+		e, err := scanEdgeCursor(rows)
 		if err != nil {
 			panicOnFatal(err)
 			return out
@@ -2347,7 +2367,7 @@ func (s *Store) queryEdgesSQL(q string, args ...any) []*graph.Edge {
 	defer rows.Close()
 	var out []*graph.Edge
 	for rows.Next() {
-		e, err := scanEdge(rows)
+		e, err := scanEdgeCursor(rows)
 		if err != nil || e == nil {
 			continue
 		}
@@ -2365,7 +2385,7 @@ func (s *Store) queryNodesSQL(q string, args ...any) []*graph.Node {
 	defer rows.Close()
 	var out []*graph.Node
 	for rows.Next() {
-		n, err := scanNode(rows)
+		n, err := scanNodeCursor(rows)
 		if err != nil || n == nil {
 			continue
 		}

--- a/internal/graph/store_sqlite/store_analysis.go
+++ b/internal/graph/store_sqlite/store_analysis.go
@@ -12,6 +12,7 @@ package store_sqlite
 // created in schema.go (edges_by_from / edges_by_to / nodes_by_kind).
 
 import (
+	"database/sql"
 	"fmt"
 
 	"github.com/zzet/gortex/internal/graph"
@@ -116,7 +117,7 @@ WHERE e.kind = ? AND n.kind = ? AND n.meta IS NOT NULL`
 	var out []graph.IfaceImplementsRow
 	for rows.Next() {
 		var fromID, ifaceID string
-		var metaBlob []byte
+		var metaBlob sql.RawBytes
 		if err := rows.Scan(&fromID, &ifaceID, &metaBlob); err != nil {
 			continue
 		}
@@ -558,7 +559,7 @@ ORDER BY e.id`
 		}
 		for mrows.Next() {
 			var name string
-			var metaBlob []byte
+			var metaBlob sql.RawBytes
 			if err := mrows.Scan(&name, &metaBlob); err != nil {
 				continue
 			}

--- a/internal/graph/store_sqlite/store_clone_corpus.go
+++ b/internal/graph/store_sqlite/store_clone_corpus.go
@@ -220,7 +220,7 @@ LIMIT ?`, repoPrefix, afterNodeID, limit)
 	for rows.Next() {
 		var (
 			row  graph.CloneCorpusRow
-			blob []byte
+			blob sql.RawBytes
 			sig  sql.NullString
 		)
 		if err := rows.Scan(&row.NodeID, &blob, &sig, &row.TokenCount); err != nil {

--- a/internal/graph/store_sqlite/store_clone_shingles.go
+++ b/internal/graph/store_sqlite/store_clone_shingles.go
@@ -1,6 +1,7 @@
 package store_sqlite
 
 import (
+	"database/sql"
 	"encoding/binary"
 
 	"github.com/zzet/gortex/internal/graph"
@@ -137,7 +138,7 @@ func (s *Store) LoadCloneShingles(repoPrefix string) (map[string][]uint64, error
 	out := make(map[string][]uint64)
 	for rows.Next() {
 		var id string
-		var blob []byte
+		var blob sql.RawBytes
 		if err := rows.Scan(&id, &blob); err != nil {
 			return nil, err
 		}

--- a/internal/graph/store_sqlite/store_lookups.go
+++ b/internal/graph/store_sqlite/store_lookups.go
@@ -221,7 +221,7 @@ func (s *Store) GetNodesByIDsContext(ctx context.Context, ids []string) (map[str
 			return out, fmt.Errorf("get nodes by ids: %w", err)
 		}
 		for rows.Next() {
-			n, scanErr := scanNode(rows)
+			n, scanErr := scanNodeCursor(rows)
 			if scanErr != nil {
 				_ = rows.Close()
 				return out, fmt.Errorf("scan node by id: %w", scanErr)
@@ -556,7 +556,7 @@ func (s *Store) queryEdgeCandidatesSQL(query string, args ...any) ([]*graph.Edge
 	}
 	var out []*graph.Edge
 	for rows.Next() {
-		edge, scanErr := scanEdge(rows)
+		edge, scanErr := scanEdgeCursor(rows)
 		if scanErr != nil {
 			_ = rows.Close()
 			return nil, scanErr

--- a/internal/graph/store_sqlite/store_vector.go
+++ b/internal/graph/store_sqlite/store_vector.go
@@ -3,6 +3,7 @@ package store_sqlite
 import (
 	"container/heap"
 	"context"
+	"database/sql"
 	"encoding/binary"
 	"errors"
 	"math"
@@ -175,7 +176,7 @@ func (s *Store) GetEmbeddings(ids []string) map[string][]float32 {
 		for rows.Next() {
 			var (
 				id   string
-				blob []byte
+				blob sql.RawBytes
 			)
 			if err := rows.Scan(&id, &blob); err != nil {
 				_ = rows.Close()
@@ -217,7 +218,7 @@ func (s *Store) SimilarTo(vec []float32, limit int) ([]graph.VectorHit, error) {
 	h := &hitHeap{}
 	for rows.Next() {
 		var id string
-		var blob []byte
+		var blob sql.RawBytes
 		if err := rows.Scan(&id, &blob); err != nil {
 			return nil, err
 		}

--- a/internal/graph/store_sqlite/unresolved_pages.go
+++ b/internal/graph/store_sqlite/unresolved_pages.go
@@ -1,6 +1,7 @@
 package store_sqlite
 
 import (
+	"database/sql"
 	"fmt"
 
 	"github.com/zzet/gortex/internal/graph"
@@ -135,7 +136,7 @@ func scanUnresolvedEdge(scanner interface{ Scan(...any) error }) (int64, *graph.
 	var (
 		id        int64
 		edge      graph.Edge
-		metaBlob  []byte
+		metaBlob  sql.RawBytes
 		crossRepo int64
 		promoted  promotedEdgeMeta
 	)


### PR DESCRIPTION
## Summary

- decode cursor-backed node and edge metadata from sql.RawBytes before Rows.Next while preserving copied []byte for QueryRow lookups
- remove the same avoidable cursor allocation from specialized resolver, migration, clone-shingle, and vector BLOB scans
- add cursor-lifetime and point-lookup regression coverage plus allocation benchmarks

## Benchmark

128 rows with a 4 KiB metadata payload on Apple M1 Pro:

- node scan: 1,988,319 -> 1,365,724 B/op (-31.3%); 664.7 -> 602.0 us/op
- edge scan: 1,902,075 -> 1,279,480 B/op (-32.7%); 535.6 -> 457.2 us/op
- both paths remove exactly one allocation per row

## Verification

- go test ./internal/graph/store_sqlite
- go test ./internal/graph/...
- go test -race ./internal/graph/store_sqlite
- golangci-lint run ./internal/graph/store_sqlite
- go test ./... (all functional packages passed; the wall-clock cold-index perf gate failed once and passed its immediate isolated rerun)
