### PR TITLE
perf(resolver): use fixed-column graph projections

### DIFF
--- a/internal/graph/resolver_projection.go
+++ b/internal/graph/resolver_projection.go
@@ -1,0 +1,437 @@
+package graph
+
+import "iter"
+
+// ScopeBindingNode is the exact row retained by lexical bare-name indexes.
+// File paths, text, repository state, and Meta never cross the storage boundary.
+type ScopeBindingNode struct {
+	ID        string
+	Kind      NodeKind
+	Name      string
+	StartLine int
+}
+
+// ScopeBindingNodeSequencer streams lexical binding rows for an exact kind set.
+type ScopeBindingNodeSequencer interface {
+	ScopeBindingNodesSeq(kinds ...NodeKind) iter.Seq[ScopeBindingNode]
+}
+
+// CallableBindingNode is the exact row retained by dataflow callee indexes.
+// Source lines, text, repository state, and Meta never cross the boundary.
+type CallableBindingNode struct {
+	ID       string
+	Kind     NodeKind
+	Name     string
+	FilePath string
+}
+
+// CallableBindingNodeSequencer streams callable rows for an exact kind set.
+type CallableBindingNodeSequencer interface {
+	CallableBindingNodesSeq(kinds ...NodeKind) iter.Seq[CallableBindingNode]
+}
+
+// FileLanguageNode is the exact row used by import dispatch and file-language
+// indexes.
+type FileLanguageNode struct {
+	ID       string
+	Language string
+}
+
+// FileLanguageNodeSequencer streams file IDs and languages.
+type FileLanguageNodeSequencer interface {
+	FileLanguageNodesSeq() iter.Seq[FileLanguageNode]
+}
+
+// RepoNodeIdentity is the exact row used by repository-owned dependency
+// indexes.
+type RepoNodeIdentity struct {
+	ID         string
+	RepoPrefix string
+}
+
+// RepoNodeIdentitySequencer streams kind-filtered identities. Nil repository
+// scope means global; a non-nil empty scope means no rows.
+type RepoNodeIdentitySequencer interface {
+	RepoNodeIdentitiesSeq(repoPrefixes []string, kinds ...NodeKind) iter.Seq[RepoNodeIdentity]
+}
+
+// NamedLanguageNode is the exact row used by language-gated name binders.
+type NamedLanguageNode struct {
+	ID       string
+	Name     string
+	Language string
+}
+
+// NamedLanguageNodeSequencer streams fixed name/language rows by kind.
+type NamedLanguageNodeSequencer interface {
+	NamedLanguageNodesSeq(kinds ...NodeKind) iter.Seq[NamedLanguageNode]
+}
+
+// QualifiedNodeIdentity is the fixed-column identity used by qualified-name
+// target indexes without retaining complete Nodes.
+type QualifiedNodeIdentity struct {
+	ID         string
+	Name       string
+	QualName   string
+	Language   string
+	FilePath   string
+	RepoPrefix string
+}
+
+// QualifiedNodeIdentitySequencer streams qualified identities by kind.
+type QualifiedNodeIdentitySequencer interface {
+	QualifiedNodeIdentitiesSeq(kinds ...NodeKind) iter.Seq[QualifiedNodeIdentity]
+}
+
+// FileNodeIdentity is the complete file-node state retained by resolver
+// directory indexes. Keeping a value row prevents a full Node allocation per
+// file and makes accidental access to unprojected fields impossible.
+type FileNodeIdentity struct {
+	ID          string
+	FilePath    string
+	RepoPrefix  string
+	WorkspaceID string
+}
+
+// FileNodeIdentitySequencer streams file identities. A nil repository slice
+// means all repositories; a non-nil empty slice means no rows.
+type FileNodeIdentitySequencer interface {
+	FileNodeIdentitiesSeq(repoPrefixes []string) iter.Seq[FileNodeIdentity]
+}
+
+// NodePlacement is the minimal endpoint projection used by reachability
+// builders after collecting an explicit ID batch.
+type NodePlacement struct {
+	Kind       NodeKind
+	FilePath   string
+	RepoPrefix string
+}
+
+// NodePlacementBatchReader resolves an explicit ID set without decoding full
+// nodes or metadata.
+type NodePlacementBatchReader interface {
+	NodePlacementsByIDs(ids []string) map[string]NodePlacement
+}
+
+// ScopeBindingNodesSeq selects the compact capability when available. The
+// compatibility fallback preserves third-party Store behavior.
+func ScopeBindingNodesSeq(s Store, kinds ...NodeKind) iter.Seq[ScopeBindingNode] {
+	if s == nil || len(kinds) == 0 {
+		return func(func(ScopeBindingNode) bool) {}
+	}
+	if seq, ok := s.(ScopeBindingNodeSequencer); ok {
+		return seq.ScopeBindingNodesSeq(kinds...)
+	}
+	return func(yield func(ScopeBindingNode) bool) {
+		for node := range NodesByKindsSeq(s, kinds...) {
+			if node == nil {
+				continue
+			}
+			if !yield(ScopeBindingNode{
+				ID: node.ID, Kind: node.Kind, Name: node.Name, StartLine: node.StartLine,
+			}) {
+				return
+			}
+		}
+	}
+}
+
+// CallableBindingNodesSeq selects the compact capability when available. The
+// compatibility fallback preserves third-party Store behavior.
+func CallableBindingNodesSeq(s Store, kinds ...NodeKind) iter.Seq[CallableBindingNode] {
+	if s == nil || len(kinds) == 0 {
+		return func(func(CallableBindingNode) bool) {}
+	}
+	if seq, ok := s.(CallableBindingNodeSequencer); ok {
+		return seq.CallableBindingNodesSeq(kinds...)
+	}
+	return func(yield func(CallableBindingNode) bool) {
+		for node := range NodesByKindsSeq(s, kinds...) {
+			if node == nil {
+				continue
+			}
+			if !yield(CallableBindingNode{
+				ID: node.ID, Kind: node.Kind, Name: node.Name, FilePath: node.FilePath,
+			}) {
+				return
+			}
+		}
+	}
+}
+
+// FileLanguageNodesSeq selects the compact file-language capability.
+func FileLanguageNodesSeq(s Store) iter.Seq[FileLanguageNode] {
+	if s == nil {
+		return func(func(FileLanguageNode) bool) {}
+	}
+	if seq, ok := s.(FileLanguageNodeSequencer); ok {
+		return seq.FileLanguageNodesSeq()
+	}
+	return func(yield func(FileLanguageNode) bool) {
+		for node := range s.NodesByKind(KindFile) {
+			if node != nil && !yield(FileLanguageNode{ID: node.ID, Language: node.Language}) {
+				return
+			}
+		}
+	}
+}
+
+// RepoNodeIdentitiesSeq selects a compact repository/kind capability.
+func RepoNodeIdentitiesSeq(s Store, repoPrefixes []string, kinds ...NodeKind) iter.Seq[RepoNodeIdentity] {
+	if s == nil || len(kinds) == 0 || (repoPrefixes != nil && len(repoPrefixes) == 0) {
+		return func(func(RepoNodeIdentity) bool) {}
+	}
+	if seq, ok := s.(RepoNodeIdentitySequencer); ok {
+		return seq.RepoNodeIdentitiesSeq(repoPrefixes, kinds...)
+	}
+	return func(yield func(RepoNodeIdentity) bool) {
+		var nodes iter.Seq[*Node]
+		if repoPrefixes == nil {
+			nodes = NodesByKindsSeq(s, kinds...)
+		} else {
+			nodes = NodesInScopeSeq(s, repoPrefixes, nil, kinds...)
+		}
+		for node := range nodes {
+			if node != nil && !yield(RepoNodeIdentity{ID: node.ID, RepoPrefix: node.RepoPrefix}) {
+				return
+			}
+		}
+	}
+}
+
+// NamedLanguageNodesSeq selects the compact name/language capability.
+func NamedLanguageNodesSeq(s Store, kinds ...NodeKind) iter.Seq[NamedLanguageNode] {
+	if s == nil || len(kinds) == 0 {
+		return func(func(NamedLanguageNode) bool) {}
+	}
+	if seq, ok := s.(NamedLanguageNodeSequencer); ok {
+		return seq.NamedLanguageNodesSeq(kinds...)
+	}
+	return func(yield func(NamedLanguageNode) bool) {
+		for node := range NodesByKindsSeq(s, kinds...) {
+			if node != nil && !yield(NamedLanguageNode{ID: node.ID, Name: node.Name, Language: node.Language}) {
+				return
+			}
+		}
+	}
+}
+
+// QualifiedNodeIdentitiesSeq selects the compact qualified identity capability.
+func QualifiedNodeIdentitiesSeq(s Store, kinds ...NodeKind) iter.Seq[QualifiedNodeIdentity] {
+	if s == nil || len(kinds) == 0 {
+		return func(func(QualifiedNodeIdentity) bool) {}
+	}
+	if seq, ok := s.(QualifiedNodeIdentitySequencer); ok {
+		return seq.QualifiedNodeIdentitiesSeq(kinds...)
+	}
+	return func(yield func(QualifiedNodeIdentity) bool) {
+		for node := range NodesByKindsSeq(s, kinds...) {
+			if node != nil && !yield(QualifiedNodeIdentity{
+				ID: node.ID, Name: node.Name, QualName: node.QualName,
+				Language: node.Language, FilePath: node.FilePath, RepoPrefix: node.RepoPrefix,
+			}) {
+				return
+			}
+		}
+	}
+}
+
+// NodeIDsForKinds uses the existing ID-only backend capability when available.
+func NodeIDsForKinds(s Store, kinds ...NodeKind) []string {
+	if s == nil || len(kinds) == 0 {
+		return nil
+	}
+	if reader, ok := s.(NodeIDsByKinds); ok {
+		return reader.NodeIDsByKinds(kinds)
+	}
+	var ids []string
+	for node := range NodesByKindsSeq(s, kinds...) {
+		if node != nil && node.ID != "" {
+			ids = append(ids, node.ID)
+		}
+	}
+	return ids
+}
+
+// FileNodeIdentitiesSeq selects the compact file capability when available.
+func FileNodeIdentitiesSeq(s Store, repoPrefixes []string) iter.Seq[FileNodeIdentity] {
+	if s == nil || (repoPrefixes != nil && len(repoPrefixes) == 0) {
+		return func(func(FileNodeIdentity) bool) {}
+	}
+	if seq, ok := s.(FileNodeIdentitySequencer); ok {
+		return seq.FileNodeIdentitiesSeq(repoPrefixes)
+	}
+	return func(yield func(FileNodeIdentity) bool) {
+		var nodes iter.Seq[*Node]
+		if repoPrefixes == nil {
+			nodes = s.NodesByKind(KindFile)
+		} else {
+			nodes = NodesInScopeSeq(s, repoPrefixes, nil, KindFile)
+		}
+		for node := range nodes {
+			if node != nil && !yield(fileNodeIdentity(node)) {
+				return
+			}
+		}
+	}
+}
+
+// NodePlacementsByIDs selects the compact batch capability when available.
+func NodePlacementsByIDs(s Store, ids []string) map[string]NodePlacement {
+	if s == nil || len(ids) == 0 {
+		return map[string]NodePlacement{}
+	}
+	if reader, ok := s.(NodePlacementBatchReader); ok {
+		return reader.NodePlacementsByIDs(ids)
+	}
+	nodes := s.GetNodesByIDs(ids)
+	out := make(map[string]NodePlacement, len(nodes))
+	for id, node := range nodes {
+		if node == nil {
+			continue
+		}
+		out[id] = NodePlacement{Kind: node.Kind, FilePath: node.FilePath, RepoPrefix: node.RepoPrefix}
+	}
+	return out
+}
+
+func (g *Graph) ScopeBindingNodesSeq(kinds ...NodeKind) iter.Seq[ScopeBindingNode] {
+	return func(yield func(ScopeBindingNode) bool) {
+		for node := range g.NodesByKindsSeq(kinds...) {
+			if node != nil && !yield(ScopeBindingNode{
+				ID: node.ID, Kind: node.Kind, Name: node.Name, StartLine: node.StartLine,
+			}) {
+				return
+			}
+		}
+	}
+}
+
+func (g *Graph) CallableBindingNodesSeq(kinds ...NodeKind) iter.Seq[CallableBindingNode] {
+	return func(yield func(CallableBindingNode) bool) {
+		for node := range g.NodesByKindsSeq(kinds...) {
+			if node != nil && !yield(CallableBindingNode{
+				ID: node.ID, Kind: node.Kind, Name: node.Name, FilePath: node.FilePath,
+			}) {
+				return
+			}
+		}
+	}
+}
+
+func (g *Graph) FileLanguageNodesSeq() iter.Seq[FileLanguageNode] {
+	return func(yield func(FileLanguageNode) bool) {
+		for node := range g.NodesByKind(KindFile) {
+			if node != nil && !yield(FileLanguageNode{ID: node.ID, Language: node.Language}) {
+				return
+			}
+		}
+	}
+}
+
+func (g *Graph) RepoNodeIdentitiesSeq(repoPrefixes []string, kinds ...NodeKind) iter.Seq[RepoNodeIdentity] {
+	wanted := resolverProjectionStringSet(repoPrefixes)
+	return func(yield func(RepoNodeIdentity) bool) {
+		if repoPrefixes != nil && len(repoPrefixes) == 0 {
+			return
+		}
+		for node := range g.NodesByKindsSeq(kinds...) {
+			if node == nil {
+				continue
+			}
+			if wanted != nil {
+				if _, ok := wanted[node.RepoPrefix]; !ok {
+					continue
+				}
+			}
+			if !yield(RepoNodeIdentity{ID: node.ID, RepoPrefix: node.RepoPrefix}) {
+				return
+			}
+		}
+	}
+}
+
+func (g *Graph) NamedLanguageNodesSeq(kinds ...NodeKind) iter.Seq[NamedLanguageNode] {
+	return func(yield func(NamedLanguageNode) bool) {
+		for node := range g.NodesByKindsSeq(kinds...) {
+			if node != nil && !yield(NamedLanguageNode{ID: node.ID, Name: node.Name, Language: node.Language}) {
+				return
+			}
+		}
+	}
+}
+
+func (g *Graph) QualifiedNodeIdentitiesSeq(kinds ...NodeKind) iter.Seq[QualifiedNodeIdentity] {
+	return func(yield func(QualifiedNodeIdentity) bool) {
+		for node := range g.NodesByKindsSeq(kinds...) {
+			if node != nil && !yield(QualifiedNodeIdentity{
+				ID: node.ID, Name: node.Name, QualName: node.QualName,
+				Language: node.Language, FilePath: node.FilePath, RepoPrefix: node.RepoPrefix,
+			}) {
+				return
+			}
+		}
+	}
+}
+
+func (g *Graph) FileNodeIdentitiesSeq(repoPrefixes []string) iter.Seq[FileNodeIdentity] {
+	wanted := resolverProjectionStringSet(repoPrefixes)
+	return func(yield func(FileNodeIdentity) bool) {
+		if repoPrefixes != nil && len(repoPrefixes) == 0 {
+			return
+		}
+		for node := range g.NodesByKind(KindFile) {
+			if node == nil {
+				continue
+			}
+			if wanted != nil {
+				if _, ok := wanted[node.RepoPrefix]; !ok {
+					continue
+				}
+			}
+			if !yield(fileNodeIdentity(node)) {
+				return
+			}
+		}
+	}
+}
+
+func (g *Graph) NodePlacementsByIDs(ids []string) map[string]NodePlacement {
+	nodes := g.GetNodesByIDs(ids)
+	out := make(map[string]NodePlacement, len(nodes))
+	for id, node := range nodes {
+		if node != nil {
+			out[id] = NodePlacement{Kind: node.Kind, FilePath: node.FilePath, RepoPrefix: node.RepoPrefix}
+		}
+	}
+	return out
+}
+
+func fileNodeIdentity(node *Node) FileNodeIdentity {
+	return FileNodeIdentity{
+		ID: node.ID, FilePath: node.FilePath,
+		RepoPrefix: node.RepoPrefix, WorkspaceID: node.WorkspaceID,
+	}
+}
+
+func resolverProjectionStringSet(values []string) map[string]struct{} {
+	if values == nil {
+		return nil
+	}
+	out := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		out[value] = struct{}{}
+	}
+	return out
+}
+
+var (
+	_ ScopeBindingNodeSequencer      = (*Graph)(nil)
+	_ CallableBindingNodeSequencer   = (*Graph)(nil)
+	_ FileLanguageNodeSequencer      = (*Graph)(nil)
+	_ RepoNodeIdentitySequencer      = (*Graph)(nil)
+	_ NamedLanguageNodeSequencer     = (*Graph)(nil)
+	_ QualifiedNodeIdentitySequencer = (*Graph)(nil)
+	_ FileNodeIdentitySequencer      = (*Graph)(nil)
+	_ NodePlacementBatchReader       = (*Graph)(nil)
+)

--- a/internal/graph/resolver_projection_test.go
+++ b/internal/graph/resolver_projection_test.go
@@ -1,0 +1,74 @@
+package graph
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// resolverProjectionStoreOnly deliberately hides optional projection
+// capabilities to lock the compatibility path required by third-party Stores.
+type resolverProjectionStoreOnly struct{ Store }
+
+func collectResolverProjectionRows[T any](seq func(func(T) bool)) []T {
+	var rows []T
+	for row := range seq {
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+func TestResolverProjectionFallbacks(t *testing.T) {
+	memory := New()
+	memory.AddBatch([]*Node{
+		{
+			ID: "a::main.go", Kind: KindFile, Name: "main.go", FilePath: "a::main.go",
+			RepoPrefix: "a", WorkspaceID: "workspace-a", Meta: map[string]any{"large": make([]byte, 4096)},
+		},
+		{
+			ID: "a::main.go::run", Kind: KindFunction, Name: "run", FilePath: "a::main.go",
+			RepoPrefix: "a", StartLine: 7, Meta: map[string]any{"large": make([]byte, 4096)},
+		},
+		{
+			ID: "b::lib.go", Kind: KindFile, Name: "lib.go", FilePath: "b::lib.go",
+			RepoPrefix: "b", WorkspaceID: "workspace-b", Meta: map[string]any{"large": make([]byte, 4096)},
+		},
+	}, nil)
+	store := resolverProjectionStoreOnly{Store: memory}
+
+	entries := collectResolverProjectionRows(CallableBindingNodesSeq(store, KindFunction, KindFunction, ""))
+	wantEntries := []CallableBindingNode{{
+		ID: "a::main.go::run", Kind: KindFunction, Name: "run", FilePath: "a::main.go",
+	}}
+	if !reflect.DeepEqual(entries, wantEntries) {
+		t.Fatalf("index entries = %#v, want %#v", entries, wantEntries)
+	}
+
+	files := collectResolverProjectionRows(FileNodeIdentitiesSeq(store, nil))
+	sort.Slice(files, func(i, j int) bool { return files[i].ID < files[j].ID })
+	wantFiles := []FileNodeIdentity{
+		{ID: "a::main.go", FilePath: "a::main.go", RepoPrefix: "a", WorkspaceID: "workspace-a"},
+		{ID: "b::lib.go", FilePath: "b::lib.go", RepoPrefix: "b", WorkspaceID: "workspace-b"},
+	}
+	if !reflect.DeepEqual(files, wantFiles) {
+		t.Fatalf("file identities = %#v, want %#v", files, wantFiles)
+	}
+	if empty := collectResolverProjectionRows(FileNodeIdentitiesSeq(store, []string{})); len(empty) != 0 {
+		t.Fatalf("non-nil empty repository scope returned %d rows", len(empty))
+	}
+	scoped := collectResolverProjectionRows(FileNodeIdentitiesSeq(store, []string{"a", "a"}))
+	if want := wantFiles[:1]; !reflect.DeepEqual(scoped, want) {
+		t.Fatalf("scoped file identities = %#v, want %#v", scoped, want)
+	}
+
+	placements := NodePlacementsByIDs(store, []string{"", "a::main.go::run", "missing", "a::main.go::run"})
+	wantPlacements := map[string]NodePlacement{
+		"a::main.go::run": {Kind: KindFunction, FilePath: "a::main.go", RepoPrefix: "a"},
+	}
+	if !reflect.DeepEqual(placements, wantPlacements) {
+		t.Fatalf("placements = %#v, want %#v", placements, wantPlacements)
+	}
+	if got := NodePlacementsByIDs(store, nil); len(got) != 0 {
+		t.Fatalf("nil ID batch returned %d rows", len(got))
+	}
+}

--- a/internal/graph/store_sqlite/resolver_projection.go
+++ b/internal/graph/store_sqlite/resolver_projection.go
@@ -1,0 +1,473 @@
+package store_sqlite
+
+import (
+	"container/heap"
+	"database/sql"
+	"iter"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+const resolverProjectionPageSize = 256
+
+// ScopeBindingNodesSeq projects only lexical binding fields. Pages are fully
+// consumed and closed before yielding, so consumers may safely re-enter Store.
+func (s *Store) ScopeBindingNodesSeq(kinds ...graph.NodeKind) iter.Seq[graph.ScopeBindingNode] {
+	return resolverNodeProjectionSeq(
+		s,
+		kinds,
+		nil,
+		`id, kind, name, start_line`,
+		func(rows *sql.Rows) (graph.ScopeBindingNode, string, error) {
+			var row graph.ScopeBindingNode
+			err := rows.Scan(&row.ID, &row.Kind, &row.Name, &row.StartLine)
+			return row, row.ID, err
+		},
+	)
+}
+
+// CallableBindingNodesSeq projects only callable binding fields. Pages are
+// fully consumed and closed before yielding, so consumers may safely re-enter.
+func (s *Store) CallableBindingNodesSeq(kinds ...graph.NodeKind) iter.Seq[graph.CallableBindingNode] {
+	return resolverNodeProjectionSeq(
+		s,
+		kinds,
+		nil,
+		`id, kind, name, file_path`,
+		func(rows *sql.Rows) (graph.CallableBindingNode, string, error) {
+			var row graph.CallableBindingNode
+			err := rows.Scan(&row.ID, &row.Kind, &row.Name, &row.FilePath)
+			return row, row.ID, err
+		},
+	)
+}
+
+func resolverNodeProjectionSeq[T any](
+	s *Store,
+	kinds []graph.NodeKind,
+	repoPrefixes []string,
+	columns string,
+	scan func(*sql.Rows) (T, string, error),
+) iter.Seq[T] {
+	uniq, _ := aggDedupeNodeKinds(kinds)
+	if repoPrefixes != nil {
+		prefixes := resolverProjectionRepoPrefixes(repoPrefixes)
+		return resolverScopedNodeProjectionSeq(s, uniq, prefixes, columns, scan)
+	}
+	return func(yield func(T) bool) {
+		for _, kind := range uniq {
+			baseArgs := []any{kind}
+			var highWater string
+			err := s.db.QueryRow(`SELECT id FROM nodes WHERE kind = ? ORDER BY id DESC LIMIT 1`, baseArgs...).Scan(&highWater)
+			if err == sql.ErrNoRows {
+				continue
+			}
+			if err != nil {
+				panicOnFatal(err)
+				return
+			}
+
+			after := ""
+			firstPage := true
+			page := make([]T, 0, resolverProjectionPageSize)
+			for {
+				query := `SELECT ` + columns + `
+FROM nodes
+WHERE kind = ? AND id <= ?
+ORDER BY id
+LIMIT ?`
+				args := append([]any(nil), baseArgs...)
+				args = append(args, highWater, resolverProjectionPageSize)
+				if !firstPage {
+					query = `SELECT ` + columns + `
+FROM nodes
+WHERE kind = ? AND id > ? AND id <= ?
+ORDER BY id
+LIMIT ?`
+					args = append([]any(nil), baseArgs...)
+					args = append(args, after, highWater, resolverProjectionPageSize)
+				}
+				rows, queryErr := s.db.Query(query, args...)
+				if queryErr != nil {
+					panicOnFatal(queryErr)
+					return
+				}
+				page = page[:0]
+				var lastID string
+				for rows.Next() {
+					row, id, scanErr := scan(rows)
+					if scanErr != nil {
+						_ = rows.Close()
+						panicOnFatal(scanErr)
+						return
+					}
+					page = append(page, row)
+					lastID = id
+				}
+				rowsErr := rows.Err()
+				closeErr := rows.Close()
+				if rowsErr != nil {
+					panicOnFatal(rowsErr)
+					return
+				}
+				if closeErr != nil {
+					panicOnFatal(closeErr)
+					return
+				}
+				if len(page) == 0 {
+					break
+				}
+				after = lastID
+				for _, row := range page {
+					if !yield(row) {
+						return
+					}
+				}
+				if len(page) < resolverProjectionPageSize || after == highWater {
+					break
+				}
+				firstPage = false
+			}
+		}
+	}
+}
+
+const resolverProjectionBufferBudget = 4096
+
+type resolverProjectionPageRow[T any] struct {
+	value T
+	id    string
+}
+
+type resolverProjectionPrefixState[T any] struct {
+	prefix    string
+	highWater string
+	after     string
+	page      []resolverProjectionPageRow[T]
+	next      int
+	started   bool
+	exhausted bool
+}
+
+type resolverProjectionHeapItem[T any] struct {
+	row   resolverProjectionPageRow[T]
+	state int
+}
+
+type resolverProjectionHeap[T any] []resolverProjectionHeapItem[T]
+
+func (h resolverProjectionHeap[T]) Len() int { return len(h) }
+func (h resolverProjectionHeap[T]) Less(i, j int) bool {
+	if h[i].row.id == h[j].row.id {
+		return h[i].state < h[j].state
+	}
+	return h[i].row.id < h[j].row.id
+}
+func (h resolverProjectionHeap[T]) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+func (h *resolverProjectionHeap[T]) Push(value any) {
+	*h = append(*h, value.(resolverProjectionHeapItem[T]))
+}
+func (h *resolverProjectionHeap[T]) Pop() any {
+	old := *h
+	last := len(old) - 1
+	value := old[last]
+	old[last] = resolverProjectionHeapItem[T]{}
+	*h = old[:last]
+	return value
+}
+
+// resolverScopedNodeProjectionSeq reads one indexed keyset stream per
+// repository and merges the closed page buffers by ID. This preserves the
+// previous global ORDER BY id contract without making SQLite rebuild a
+// temporary sort for every multi-repository page.
+func resolverScopedNodeProjectionSeq[T any](
+	s *Store,
+	kinds []graph.NodeKind,
+	prefixes []string,
+	columns string,
+	scan func(*sql.Rows) (T, string, error),
+) iter.Seq[T] {
+	return func(yield func(T) bool) {
+		if len(kinds) == 0 || len(prefixes) == 0 {
+			return
+		}
+		for _, kind := range kinds {
+			if !streamResolverScopedKindProjection(s, kind, prefixes, columns, scan, yield) {
+				return
+			}
+		}
+	}
+}
+
+const resolverScopedProjectionHighWaterQuery = `SELECT id FROM nodes WHERE repo_prefix = ? AND kind = ? ORDER BY id DESC LIMIT 1`
+
+func resolverScopedProjectionPageQuery(columns string, started bool) string {
+	if started {
+		return `SELECT ` + columns + `
+FROM nodes
+WHERE repo_prefix = ? AND kind = ? AND id > ? AND id <= ?
+ORDER BY id
+LIMIT ?`
+	}
+	return `SELECT ` + columns + `
+FROM nodes
+WHERE repo_prefix = ? AND kind = ? AND id <= ?
+ORDER BY id
+LIMIT ?`
+}
+
+func streamResolverScopedKindProjection[T any](
+	s *Store,
+	kind graph.NodeKind,
+	prefixes []string,
+	columns string,
+	scan func(*sql.Rows) (T, string, error),
+	yield func(T) bool,
+) bool {
+	states := make([]resolverProjectionPrefixState[T], 0, len(prefixes))
+	for _, prefix := range prefixes {
+		var highWater string
+		err := s.db.QueryRow(
+			resolverScopedProjectionHighWaterQuery, prefix, kind,
+		).Scan(&highWater)
+		if err == sql.ErrNoRows {
+			continue
+		}
+		if err != nil {
+			panicOnFatal(err)
+			return false
+		}
+		states = append(states, resolverProjectionPrefixState[T]{
+			prefix: prefix, highWater: highWater,
+		})
+	}
+	if len(states) == 0 {
+		return true
+	}
+
+	pageSize := resolverProjectionPageSize
+	if perPrefix := resolverProjectionBufferBudget / len(states); perPrefix < pageSize {
+		pageSize = perPrefix
+	}
+	if pageSize < 1 {
+		pageSize = 1
+	}
+	for i := range states {
+		states[i].page = make([]resolverProjectionPageRow[T], 0, pageSize)
+	}
+
+	pending := make(resolverProjectionHeap[T], 0, len(states))
+	for i := range states {
+		if !fillResolverProjectionPage(s, kind, columns, scan, pageSize, &states[i]) {
+			return false
+		}
+		if len(states[i].page) > 0 {
+			pending = append(pending, resolverProjectionHeapItem[T]{row: states[i].page[0], state: i})
+			states[i].next = 1
+		}
+	}
+	heap.Init(&pending)
+
+	for pending.Len() > 0 {
+		item := heap.Pop(&pending).(resolverProjectionHeapItem[T])
+		if !yield(item.row.value) {
+			return false
+		}
+
+		state := &states[item.state]
+		if state.next >= len(state.page) && !state.exhausted {
+			if !fillResolverProjectionPage(s, kind, columns, scan, pageSize, state) {
+				return false
+			}
+		}
+		if state.next < len(state.page) {
+			heap.Push(&pending, resolverProjectionHeapItem[T]{
+				row: state.page[state.next], state: item.state,
+			})
+			state.next++
+		}
+	}
+	return true
+}
+
+func fillResolverProjectionPage[T any](
+	s *Store,
+	kind graph.NodeKind,
+	columns string,
+	scan func(*sql.Rows) (T, string, error),
+	pageSize int,
+	state *resolverProjectionPrefixState[T],
+) bool {
+	query := resolverScopedProjectionPageQuery(columns, state.started)
+	args := []any{state.prefix, kind, state.highWater, pageSize}
+	if state.started {
+		args = []any{state.prefix, kind, state.after, state.highWater, pageSize}
+	}
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		panicOnFatal(err)
+		return false
+	}
+
+	state.page = state.page[:0]
+	state.next = 0
+	var lastID string
+	for rows.Next() {
+		value, id, scanErr := scan(rows)
+		if scanErr != nil {
+			_ = rows.Close()
+			panicOnFatal(scanErr)
+			return false
+		}
+		state.page = append(state.page, resolverProjectionPageRow[T]{value: value, id: id})
+		lastID = id
+	}
+	rowsErr := rows.Err()
+	closeErr := rows.Close()
+	if rowsErr != nil {
+		panicOnFatal(rowsErr)
+		return false
+	}
+	if closeErr != nil {
+		panicOnFatal(closeErr)
+		return false
+	}
+
+	state.started = true
+	if len(state.page) == 0 {
+		state.exhausted = true
+		return true
+	}
+	state.after = lastID
+	state.exhausted = len(state.page) < pageSize || state.after == state.highWater
+	return true
+}
+
+func resolverProjectionRepoPrefixes(prefixes []string) []string {
+	seen := make(map[string]struct{}, len(prefixes))
+	uniq := make([]string, 0, len(prefixes))
+	for _, prefix := range prefixes {
+		if _, duplicate := seen[prefix]; duplicate {
+			continue
+		}
+		seen[prefix] = struct{}{}
+		uniq = append(uniq, prefix)
+	}
+	return uniq
+}
+
+// FileLanguageNodesSeq projects the fixed file ID/language pair.
+func (s *Store) FileLanguageNodesSeq() iter.Seq[graph.FileLanguageNode] {
+	return resolverNodeProjectionSeq(
+		s, []graph.NodeKind{graph.KindFile}, nil, `id, language`,
+		func(rows *sql.Rows) (graph.FileLanguageNode, string, error) {
+			var row graph.FileLanguageNode
+			err := rows.Scan(&row.ID, &row.Language)
+			return row, row.ID, err
+		},
+	)
+}
+
+// RepoNodeIdentitiesSeq projects IDs and repository owners for exact kinds.
+func (s *Store) RepoNodeIdentitiesSeq(repoPrefixes []string, kinds ...graph.NodeKind) iter.Seq[graph.RepoNodeIdentity] {
+	return resolverNodeProjectionSeq(
+		s, kinds, repoPrefixes, `id, repo_prefix`,
+		func(rows *sql.Rows) (graph.RepoNodeIdentity, string, error) {
+			var row graph.RepoNodeIdentity
+			err := rows.Scan(&row.ID, &row.RepoPrefix)
+			return row, row.ID, err
+		},
+	)
+}
+
+// NamedLanguageNodesSeq projects fixed name/language binding fields.
+func (s *Store) NamedLanguageNodesSeq(kinds ...graph.NodeKind) iter.Seq[graph.NamedLanguageNode] {
+	return resolverNodeProjectionSeq(
+		s, kinds, nil, `id, name, language`,
+		func(rows *sql.Rows) (graph.NamedLanguageNode, string, error) {
+			var row graph.NamedLanguageNode
+			err := rows.Scan(&row.ID, &row.Name, &row.Language)
+			return row, row.ID, err
+		},
+	)
+}
+
+// QualifiedNodeIdentitiesSeq projects fixed qualified target fields.
+func (s *Store) QualifiedNodeIdentitiesSeq(kinds ...graph.NodeKind) iter.Seq[graph.QualifiedNodeIdentity] {
+	return resolverNodeProjectionSeq(
+		s, kinds, nil, `id, name, qual_name, language, file_path, repo_prefix`,
+		func(rows *sql.Rows) (graph.QualifiedNodeIdentity, string, error) {
+			var row graph.QualifiedNodeIdentity
+			err := rows.Scan(
+				&row.ID, &row.Name, &row.QualName,
+				&row.Language, &row.FilePath, &row.RepoPrefix,
+			)
+			return row, row.ID, err
+		},
+	)
+}
+
+// FileNodeIdentitiesSeq keeps resolver directory indexes on a metadata-free
+// file projection. Nil prefixes mean global; non-nil empty means no rows. The
+// ID keyset preserves the prior deterministic candidate order, freezes an
+// upper boundary, and closes each bounded page before yielding.
+func (s *Store) FileNodeIdentitiesSeq(repoPrefixes []string) iter.Seq[graph.FileNodeIdentity] {
+	return resolverNodeProjectionSeq(
+		s, []graph.NodeKind{graph.KindFile}, repoPrefixes,
+		`id, file_path, repo_prefix, workspace_id`,
+		func(rows *sql.Rows) (graph.FileNodeIdentity, string, error) {
+			var row graph.FileNodeIdentity
+			err := rows.Scan(&row.ID, &row.FilePath, &row.RepoPrefix, &row.WorkspaceID)
+			return row, row.ID, err
+		},
+	)
+}
+
+// NodePlacementsByIDs resolves an explicit endpoint batch without decoding
+// names, text, promoted metadata, or the residual metadata blob.
+func (s *Store) NodePlacementsByIDs(ids []string) map[string]graph.NodePlacement {
+	uniq := dedupeNonEmpty(ids)
+	out := make(map[string]graph.NodePlacement, len(uniq))
+	for start := 0; start < len(uniq); start += lookupChunkSize {
+		end := minInt(start+lookupChunkSize, len(uniq))
+		chunk := uniq[start:end]
+		query := `SELECT id, kind, file_path, repo_prefix FROM nodes WHERE id IN (` +
+			inPlaceholders(len(chunk)) + `)`
+		rows, err := s.db.Query(query, toAnyArgs(chunk)...)
+		if err != nil {
+			panicOnFatal(err)
+			return out
+		}
+		for rows.Next() {
+			var id string
+			var placement graph.NodePlacement
+			if err := rows.Scan(&id, &placement.Kind, &placement.FilePath, &placement.RepoPrefix); err != nil {
+				_ = rows.Close()
+				panicOnFatal(err)
+				return out
+			}
+			out[id] = placement
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			panicOnFatal(err)
+			return out
+		}
+		if err := rows.Close(); err != nil {
+			panicOnFatal(err)
+			return out
+		}
+	}
+	return out
+}
+
+var (
+	_ graph.ScopeBindingNodeSequencer      = (*Store)(nil)
+	_ graph.CallableBindingNodeSequencer   = (*Store)(nil)
+	_ graph.FileLanguageNodeSequencer      = (*Store)(nil)
+	_ graph.RepoNodeIdentitySequencer      = (*Store)(nil)
+	_ graph.NamedLanguageNodeSequencer     = (*Store)(nil)
+	_ graph.QualifiedNodeIdentitySequencer = (*Store)(nil)
+	_ graph.FileNodeIdentitySequencer      = (*Store)(nil)
+	_ graph.NodePlacementBatchReader       = (*Store)(nil)
+)

--- a/internal/graph/store_sqlite/resolver_projection_bench_test.go
+++ b/internal/graph/store_sqlite/resolver_projection_bench_test.go
@@ -1,0 +1,100 @@
+package store_sqlite
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+const (
+	resolverProjectionBenchRows = 2048
+	resolverProjectionBenchMeta = 32 << 10
+)
+
+var resolverProjectionBenchSink uint64
+
+func openResolverProjectionBenchStore(b *testing.B, kind graph.NodeKind) *Store {
+	b.Helper()
+	store, err := Open(filepath.Join(b.TempDir(), "graph.db"))
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() { _ = store.Close() })
+
+	payload := bytes.Repeat([]byte{0xa5}, resolverProjectionBenchMeta)
+	nodes := make([]*graph.Node, 0, resolverProjectionBenchRows)
+	for i := 0; i < resolverProjectionBenchRows; i++ {
+		file := fmt.Sprintf("bench/file-%06d.go", i)
+		id, name := file, filepath.Base(file)
+		if kind == graph.KindLocal {
+			id, name = file+"::local", "local"
+		}
+		nodes = append(nodes, &graph.Node{
+			ID: id, Kind: kind, Name: name, FilePath: file,
+			RepoPrefix: "bench", WorkspaceID: "bench-workspace", StartLine: i + 1,
+			Meta: map[string]any{"bench_payload": payload},
+		})
+	}
+	store.AddBatch(nodes, nil)
+	runtime.GC()
+	return store
+}
+
+func BenchmarkResolverNodeProjection(b *testing.B) {
+	b.Run("ScopeBinding/FullNodesByKind", func(b *testing.B) {
+		store := openResolverProjectionBenchStore(b, graph.KindLocal)
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.ReportMetric(resolverProjectionBenchRows, "rows/op")
+		var sink uint64
+		for i := 0; i < b.N; i++ {
+			for node := range store.NodesByKind(graph.KindLocal) {
+				sink += uint64(len(node.ID) + len(node.Name) + node.StartLine + len(node.Meta))
+			}
+		}
+		resolverProjectionBenchSink = sink
+	})
+	b.Run("ScopeBinding/Projected", func(b *testing.B) {
+		store := openResolverProjectionBenchStore(b, graph.KindLocal)
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.ReportMetric(resolverProjectionBenchRows, "rows/op")
+		var sink uint64
+		for i := 0; i < b.N; i++ {
+			for node := range store.ScopeBindingNodesSeq(graph.KindLocal) {
+				sink += uint64(len(node.ID) + len(node.Name) + node.StartLine)
+			}
+		}
+		resolverProjectionBenchSink = sink
+	})
+	b.Run("FileIdentity/FullNodesByKind", func(b *testing.B) {
+		store := openResolverProjectionBenchStore(b, graph.KindFile)
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.ReportMetric(resolverProjectionBenchRows, "rows/op")
+		var sink uint64
+		for i := 0; i < b.N; i++ {
+			for node := range store.NodesByKind(graph.KindFile) {
+				sink += uint64(len(node.ID) + len(node.FilePath) + len(node.RepoPrefix) + len(node.WorkspaceID) + len(node.Meta))
+			}
+		}
+		resolverProjectionBenchSink = sink
+	})
+	b.Run("FileIdentity/Projected", func(b *testing.B) {
+		store := openResolverProjectionBenchStore(b, graph.KindFile)
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.ReportMetric(resolverProjectionBenchRows, "rows/op")
+		var sink uint64
+		for i := 0; i < b.N; i++ {
+			for node := range store.FileNodeIdentitiesSeq(nil) {
+				sink += uint64(len(node.ID) + len(node.FilePath) + len(node.RepoPrefix) + len(node.WorkspaceID))
+			}
+		}
+		resolverProjectionBenchSink = sink
+	})
+}

--- a/internal/graph/store_sqlite/resolver_projection_merge_test.go
+++ b/internal/graph/store_sqlite/resolver_projection_merge_test.go
@@ -1,0 +1,27 @@
+package store_sqlite
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestResolverScopedProjectionMergesRepositoriesByGlobalID(t *testing.T) {
+	store := openResolverProjectionTestStore(t)
+	store.AddBatch([]*graph.Node{
+		{ID: "a-id", Kind: graph.KindFile, FilePath: "a-id", RepoPrefix: "z"},
+		{ID: "b-id", Kind: graph.KindFile, FilePath: "b-id", RepoPrefix: "a"},
+		{ID: "c-id", Kind: graph.KindFile, FilePath: "c-id", RepoPrefix: "z"},
+		{ID: "d-id", Kind: graph.KindFile, FilePath: "d-id", RepoPrefix: "ignored"},
+	}, nil)
+
+	rows := collectResolverProjection(store.FileNodeIdentitiesSeq([]string{"z", "a", "z"}))
+	var ids []string
+	for _, row := range rows {
+		ids = append(ids, row.ID)
+	}
+	if want := []string{"a-id", "b-id", "c-id"}; !reflect.DeepEqual(ids, want) {
+		t.Fatalf("scoped IDs = %v, want %v", ids, want)
+	}
+}

--- a/internal/graph/store_sqlite/resolver_projection_metadata_test.go
+++ b/internal/graph/store_sqlite/resolver_projection_metadata_test.go
@@ -1,0 +1,39 @@
+package store_sqlite
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestResolverFixedColumnProjectionsDoNotDecodeMetadata(t *testing.T) {
+	store := openResolverProjectionTestStore(t)
+	store.AddBatch([]*graph.Node{
+		{ID: "repo::main.go", Kind: graph.KindFile, FilePath: "repo::main.go", RepoPrefix: "repo", Language: "go", WorkspaceID: "workspace"},
+		{ID: "repo::main.go::fn", Kind: graph.KindFunction, Name: "fn", FilePath: "repo::main.go", RepoPrefix: "repo", Language: "go"},
+		{ID: "repo::main.go::T", Kind: graph.KindGenericParam, Name: "T", FilePath: "repo::main.go", RepoPrefix: "repo", Language: "go"},
+		{ID: "repo::main.go::Iface", Kind: graph.KindInterface, Name: "Iface", QualName: "pkg.Iface", FilePath: "repo::main.go", RepoPrefix: "repo", Language: "go"},
+	}, nil)
+	if _, err := store.writerDB.Exec(`UPDATE nodes SET meta = ?`, []byte{0xff, 0x00, 0x7f}); err != nil {
+		t.Fatalf("corrupt residual metadata fixture: %v", err)
+	}
+
+	if got := collectResolverProjection(store.CallableBindingNodesSeq(graph.KindFunction)); len(got) != 1 || got[0].ID != "repo::main.go::fn" {
+		t.Fatalf("callable projection = %#v", got)
+	}
+	if got := collectResolverProjection(store.FileLanguageNodesSeq()); len(got) != 1 || got[0].Language != "go" {
+		t.Fatalf("file-language projection = %#v", got)
+	}
+	if got := collectResolverProjection(store.RepoNodeIdentitiesSeq([]string{"repo"}, graph.KindFunction)); len(got) != 1 || got[0].RepoPrefix != "repo" {
+		t.Fatalf("repository projection = %#v", got)
+	}
+	if got := collectResolverProjection(store.NamedLanguageNodesSeq(graph.KindGenericParam)); len(got) != 1 || got[0].Name != "T" {
+		t.Fatalf("named-language projection = %#v", got)
+	}
+	if got := collectResolverProjection(store.QualifiedNodeIdentitiesSeq(graph.KindInterface)); len(got) != 1 || got[0].QualName != "pkg.Iface" {
+		t.Fatalf("qualified projection = %#v", got)
+	}
+	if got := collectResolverProjection(store.FileNodeIdentitiesSeq([]string{"repo"})); len(got) != 1 || got[0].WorkspaceID != "workspace" {
+		t.Fatalf("file identity projection = %#v", got)
+	}
+}

--- a/internal/graph/store_sqlite/resolver_projection_plan_test.go
+++ b/internal/graph/store_sqlite/resolver_projection_plan_test.go
@@ -1,0 +1,95 @@
+package store_sqlite
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestResolverScopedProjectionMergesAcrossPageBoundaries(t *testing.T) {
+	store := openResolverProjectionTestStore(t)
+	rowCount := resolverProjectionPageSize*2 + 2
+	nodes := make([]*graph.Node, 0, rowCount)
+	want := make([]string, 0, rowCount)
+	for i := 0; i < rowCount; i++ {
+		id := fmt.Sprintf("id-%04d", i)
+		prefix := "a"
+		if i%2 != 0 {
+			prefix = "b"
+		}
+		nodes = append(nodes, &graph.Node{
+			ID: id, Kind: graph.KindFile, FilePath: id, RepoPrefix: prefix,
+		})
+		want = append(want, id)
+	}
+	store.AddBatch(nodes, nil)
+
+	var got []string
+	for row := range store.FileNodeIdentitiesSeq([]string{"b", "a", "b"}) {
+		got = append(got, row.ID)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("scoped page IDs = %v, want %v", got, want)
+	}
+}
+
+func TestResolverScopedProjectionQueriesUseRepoKindIndex(t *testing.T) {
+	store := openResolverProjectionTestStore(t)
+	tests := []struct {
+		name  string
+		query string
+		args  []any
+	}{
+		{
+			name:  "high water",
+			query: `SELECT id FROM nodes WHERE repo_prefix = ? AND kind = ? ORDER BY id DESC LIMIT 1`,
+			args:  []any{"repo", graph.KindFile},
+		},
+		{
+			name:  "first page",
+			query: `SELECT id, file_path, repo_prefix, workspace_id FROM nodes WHERE repo_prefix = ? AND kind = ? AND id <= ? ORDER BY id LIMIT ?`,
+			args:  []any{"repo", graph.KindFile, "repo::z", resolverProjectionPageSize},
+		},
+		{
+			name:  "next page",
+			query: `SELECT id, file_path, repo_prefix, workspace_id FROM nodes WHERE repo_prefix = ? AND kind = ? AND id > ? AND id <= ? ORDER BY id LIMIT ?`,
+			args:  []any{"repo", graph.KindFile, "repo::a", "repo::z", resolverProjectionPageSize},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rows, err := store.db.Query(`EXPLAIN QUERY PLAN `+tt.query, tt.args...)
+			if err != nil {
+				t.Fatalf("explain query: %v", err)
+			}
+			var details []string
+			for rows.Next() {
+				var id, parent, unused int
+				var detail string
+				if err := rows.Scan(&id, &parent, &unused, &detail); err != nil {
+					_ = rows.Close()
+					t.Fatalf("scan query plan: %v", err)
+				}
+				details = append(details, detail)
+			}
+			if err := rows.Err(); err != nil {
+				_ = rows.Close()
+				t.Fatalf("query plan rows: %v", err)
+			}
+			if err := rows.Close(); err != nil {
+				t.Fatalf("close query plan: %v", err)
+			}
+			plan := strings.Join(details, "\n")
+			if !strings.Contains(plan, "nodes_by_repo_kind") {
+				t.Fatalf("query plan does not use nodes_by_repo_kind:\n%s", plan)
+			}
+			if strings.Contains(plan, "USE TEMP B-TREE") || strings.Contains(plan, "SCAN nodes") {
+				t.Fatalf("query plan is not an indexed keyset seek:\n%s", plan)
+			}
+		})
+	}
+}

--- a/internal/graph/store_sqlite/resolver_projection_querybuilder_test.go
+++ b/internal/graph/store_sqlite/resolver_projection_querybuilder_test.go
@@ -1,0 +1,63 @@
+package store_sqlite
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestResolverScopedProjectionProductionQueriesUseRepoKindIndex(t *testing.T) {
+	store := openResolverProjectionTestStore(t)
+	tests := []struct {
+		name  string
+		query string
+		args  []any
+	}{
+		{
+			name: "high water", query: resolverScopedProjectionHighWaterQuery,
+			args: []any{"repo", graph.KindFile},
+		},
+		{
+			name: "first page", query: resolverScopedProjectionPageQuery("id, file_path, repo_prefix, workspace_id", false),
+			args: []any{"repo", graph.KindFile, "repo::z", resolverProjectionPageSize},
+		},
+		{
+			name: "next page", query: resolverScopedProjectionPageQuery("id, file_path, repo_prefix, workspace_id", true),
+			args: []any{"repo", graph.KindFile, "repo::a", "repo::z", resolverProjectionPageSize},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rows, err := store.db.Query(`EXPLAIN QUERY PLAN `+tt.query, tt.args...)
+			if err != nil {
+				t.Fatalf("explain query: %v", err)
+			}
+			var details []string
+			for rows.Next() {
+				var id, parent, unused int
+				var detail string
+				if err := rows.Scan(&id, &parent, &unused, &detail); err != nil {
+					_ = rows.Close()
+					t.Fatalf("scan query plan: %v", err)
+				}
+				details = append(details, detail)
+			}
+			if err := rows.Err(); err != nil {
+				_ = rows.Close()
+				t.Fatalf("query plan rows: %v", err)
+			}
+			if err := rows.Close(); err != nil {
+				t.Fatalf("close query plan: %v", err)
+			}
+			plan := strings.Join(details, "\n")
+			if !strings.Contains(plan, "nodes_by_repo_kind") {
+				t.Fatalf("query plan does not use nodes_by_repo_kind:\n%s", plan)
+			}
+			if strings.Contains(plan, "USE TEMP B-TREE") || strings.Contains(plan, "SCAN nodes") {
+				t.Fatalf("query plan is not an indexed keyset seek:\n%s", plan)
+			}
+		})
+	}
+}

--- a/internal/graph/store_sqlite/resolver_projection_reentry_test.go
+++ b/internal/graph/store_sqlite/resolver_projection_reentry_test.go
@@ -1,0 +1,35 @@
+package store_sqlite
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestResolverScopedProjectionYieldCanReenterStore(t *testing.T) {
+	store := openResolverProjectionTestStore(t)
+	store.AddBatch([]*graph.Node{
+		{ID: "a-id", Kind: graph.KindFile, FilePath: "a-id", RepoPrefix: "a"},
+		{ID: "b-id", Kind: graph.KindFile, FilePath: "b-id", RepoPrefix: "b"},
+	}, nil)
+	store.db.SetMaxOpenConns(1)
+	store.db.SetMaxIdleConns(1)
+
+	count := 0
+	for range store.FileNodeIdentitiesSeq([]string{"b", "a"}) {
+		if inUse := store.db.Stats().InUse; inUse != 0 {
+			t.Fatalf("scoped yield retained %d read connection(s)", inUse)
+		}
+		var one int
+		if err := store.db.QueryRow(`SELECT 1`).Scan(&one); err != nil {
+			t.Fatalf("scoped re-entry query: %v", err)
+		}
+		if one != 1 {
+			t.Fatalf("SELECT 1 = %d", one)
+		}
+		count++
+	}
+	if count != 2 {
+		t.Fatalf("scoped projection yielded %d rows, want 2", count)
+	}
+}

--- a/internal/graph/store_sqlite/resolver_projection_test.go
+++ b/internal/graph/store_sqlite/resolver_projection_test.go
@@ -1,0 +1,225 @@
+package store_sqlite
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func openResolverProjectionTestStore(t *testing.T) *Store {
+	t.Helper()
+	store, err := Open(filepath.Join(t.TempDir(), "graph.db"))
+	if err != nil {
+		t.Fatalf("open SQLite store: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("close SQLite store: %v", err)
+		}
+	})
+	return store
+}
+
+func collectResolverProjection[T any](seq func(func(T) bool)) []T {
+	var rows []T
+	for row := range seq {
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+func TestResolverProjectionRowsIgnoreMetadata(t *testing.T) {
+	store := openResolverProjectionTestStore(t)
+	store.AddBatch([]*graph.Node{
+		{
+			ID: "a::src/main.go", Kind: graph.KindFile, Name: "main.go",
+			FilePath: "a::src/main.go", RepoPrefix: "a", WorkspaceID: "workspace-a",
+			Meta: map[string]any{"large": make([]byte, 1<<20)},
+		},
+		{
+			ID: "a::src/main.go::local", Kind: graph.KindLocal, Name: "local",
+			FilePath: "a::src/main.go", RepoPrefix: "a", StartLine: 12,
+			Meta: map[string]any{"large": make([]byte, 1<<20)},
+		},
+		{
+			ID: "b::lib.go", Kind: graph.KindFile, Name: "lib.go",
+			FilePath: "b::lib.go", RepoPrefix: "b", WorkspaceID: "workspace-b",
+			Meta: map[string]any{"large": make([]byte, 1<<20)},
+		},
+	}, nil)
+
+	// A full node scan would have to decode this invalid payload. Resolver
+	// projections select only fixed columns, so malformed residual metadata is
+	// deliberately irrelevant to all three reads below.
+	if _, err := store.writerDB.Exec(`UPDATE nodes SET meta = ?`, []byte{0xff, 0x00, 0x7f}); err != nil {
+		t.Fatalf("corrupt residual metadata fixture: %v", err)
+	}
+
+	entries := collectResolverProjection(store.ScopeBindingNodesSeq(graph.KindLocal, graph.KindLocal))
+	wantEntries := []graph.ScopeBindingNode{{
+		ID: "a::src/main.go::local", Kind: graph.KindLocal, Name: "local", StartLine: 12,
+	}}
+	if !reflect.DeepEqual(entries, wantEntries) {
+		t.Fatalf("index entries = %#v, want %#v", entries, wantEntries)
+	}
+
+	globalFiles := collectResolverProjection(store.FileNodeIdentitiesSeq(nil))
+	wantGlobalFiles := []graph.FileNodeIdentity{
+		{ID: "a::src/main.go", FilePath: "a::src/main.go", RepoPrefix: "a", WorkspaceID: "workspace-a"},
+		{ID: "b::lib.go", FilePath: "b::lib.go", RepoPrefix: "b", WorkspaceID: "workspace-b"},
+	}
+	if !reflect.DeepEqual(globalFiles, wantGlobalFiles) {
+		t.Fatalf("global file identities = %#v, want %#v", globalFiles, wantGlobalFiles)
+	}
+
+	scopedFiles := collectResolverProjection(store.FileNodeIdentitiesSeq([]string{"b", "b"}))
+	if want := wantGlobalFiles[1:]; !reflect.DeepEqual(scopedFiles, want) {
+		t.Fatalf("scoped file identities = %#v, want %#v", scopedFiles, want)
+	}
+	if empty := collectResolverProjection(store.FileNodeIdentitiesSeq([]string{})); len(empty) != 0 {
+		t.Fatalf("non-nil empty repository scope returned %d rows", len(empty))
+	}
+
+	placements := store.NodePlacementsByIDs([]string{
+		"", "a::src/main.go", "a::src/main.go", "a::src/main.go::local", "missing",
+	})
+	wantPlacements := map[string]graph.NodePlacement{
+		"a::src/main.go":        {Kind: graph.KindFile, FilePath: "a::src/main.go", RepoPrefix: "a"},
+		"a::src/main.go::local": {Kind: graph.KindLocal, FilePath: "a::src/main.go", RepoPrefix: "a"},
+	}
+	if !reflect.DeepEqual(placements, wantPlacements) {
+		t.Fatalf("placements = %#v, want %#v", placements, wantPlacements)
+	}
+}
+
+func TestNodePlacementsByIDsChunksAndDeduplicates(t *testing.T) {
+	store := openResolverProjectionTestStore(t)
+	firstID := "repo::first.go"
+	secondID := "repo::second.go"
+	store.AddBatch([]*graph.Node{
+		{ID: firstID, Kind: graph.KindFile, Name: "first.go", FilePath: firstID, RepoPrefix: "repo"},
+		{ID: secondID, Kind: graph.KindFile, Name: "second.go", FilePath: secondID, RepoPrefix: "repo"},
+	}, nil)
+
+	ids := make([]string, lookupChunkSize+1)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("missing-%04d", i)
+	}
+	ids[0] = firstID
+	ids[lookupChunkSize] = secondID
+	ids = append(ids, firstID, "", "missing")
+
+	placements := store.NodePlacementsByIDs(ids)
+	if len(placements) != 2 {
+		t.Fatalf("placements returned %d rows, want 2", len(placements))
+	}
+	for _, id := range []string{firstID, secondID} {
+		if got, ok := placements[id]; !ok || got.FilePath != id || got.Kind != graph.KindFile || got.RepoPrefix != "repo" {
+			t.Fatalf("placement[%q] = %#v, %v", id, got, ok)
+		}
+	}
+	if _, ok := placements["missing"]; ok {
+		t.Fatal("missing ID unexpectedly returned a placement")
+	}
+}
+
+func TestResolverProjectionYieldCanReenterStore(t *testing.T) {
+	store := openResolverProjectionTestStore(t)
+	store.AddBatch([]*graph.Node{
+		{
+			ID: "repo::file.go", Kind: graph.KindFile, Name: "file.go",
+			FilePath: "repo::file.go", RepoPrefix: "repo",
+		},
+		{
+			ID: "repo::file.go::local", Kind: graph.KindLocal, Name: "local",
+			FilePath: "repo::file.go", RepoPrefix: "repo", StartLine: 3,
+		},
+	}, nil)
+	store.db.SetMaxOpenConns(1)
+	store.db.SetMaxIdleConns(1)
+
+	assertReentry := func(label string) {
+		t.Helper()
+		if inUse := store.db.Stats().InUse; inUse != 0 {
+			t.Fatalf("%s yield retained %d read connection(s)", label, inUse)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		var one int
+		if err := store.db.QueryRowContext(ctx, `SELECT 1`).Scan(&one); err != nil {
+			t.Fatalf("%s re-entry query: %v", label, err)
+		}
+		if one != 1 {
+			t.Fatalf("%s SELECT 1 = %d", label, one)
+		}
+	}
+
+	for range store.ScopeBindingNodesSeq(graph.KindLocal) {
+		assertReentry("node index")
+		break
+	}
+	for range store.FileNodeIdentitiesSeq(nil) {
+		assertReentry("file identity")
+		break
+	}
+}
+
+func TestResolverProjectionKeysetFreezesHighWaterAcrossPages(t *testing.T) {
+	store := openResolverProjectionTestStore(t)
+	rowCount := resolverProjectionPageSize + 1
+	nodes := make([]*graph.Node, 0, rowCount*2)
+	wantBindingIDs := make([]string, 0, rowCount)
+	wantFileIDs := make([]string, 0, rowCount)
+	for i := 0; i < rowCount; i++ {
+		fileID := fmt.Sprintf("repo::file-%04d.go", i)
+		localID := fileID + "::local"
+		nodes = append(nodes,
+			&graph.Node{
+				ID: fileID, Kind: graph.KindFile, Name: fmt.Sprintf("file-%04d.go", i),
+				FilePath: fileID, RepoPrefix: "repo",
+			},
+			&graph.Node{
+				ID: localID, Kind: graph.KindLocal, Name: fmt.Sprintf("local-%04d", i),
+				FilePath: fileID, RepoPrefix: "repo",
+			},
+		)
+		wantFileIDs = append(wantFileIDs, fileID)
+		wantBindingIDs = append(wantBindingIDs, localID)
+	}
+	store.AddBatch(nodes, nil)
+
+	var bindingIDs []string
+	insertedBinding := false
+	for row := range store.ScopeBindingNodesSeq(graph.KindLocal) {
+		bindingIDs = append(bindingIDs, row.ID)
+		if !insertedBinding {
+			insertedBinding = true
+			store.AddBatch([]*graph.Node{{
+				ID: "z::z.go::local", Kind: graph.KindLocal, Name: "z", FilePath: "z::z.go",
+			}}, nil)
+		}
+	}
+	if !reflect.DeepEqual(bindingIDs, wantBindingIDs) {
+		t.Fatalf("binding page IDs = %v, want %v", bindingIDs, wantBindingIDs)
+	}
+
+	var fileIDs []string
+	insertedFile := false
+	for row := range store.FileNodeIdentitiesSeq(nil) {
+		fileIDs = append(fileIDs, row.ID)
+		if !insertedFile {
+			insertedFile = true
+			store.AddBatch([]*graph.Node{{
+				ID: "z::z.go", Kind: graph.KindFile, Name: "z.go", FilePath: "z::z.go", RepoPrefix: "z",
+			}}, nil)
+		}
+	}
+	if !reflect.DeepEqual(fileIDs, wantFileIDs) {
+		t.Fatalf("file page IDs = %v, want %v", fileIDs, wantFileIDs)
+	}
+}

--- a/internal/resolver/bare_name_scope_bind.go
+++ b/internal/resolver/bare_name_scope_bind.go
@@ -51,22 +51,13 @@ func (r *Resolver) bindBareNameScopeRefs() {
 	// once up front so the per-edge bind is an O(matching-name) walk
 	// rather than a graph-wide FindNodesByName.
 	owned := map[string][]scopeNode{}
-	for n := range r.graph.NodesByKind(graph.KindLocal) {
-		owner := enclosingFunctionForBinding(n.ID)
+	for node := range graph.ScopeBindingNodesSeq(r.graph, graph.KindLocal, graph.KindParam) {
+		owner := enclosingFunctionForBinding(node.ID)
 		if owner == "" {
 			continue
 		}
 		owned[owner] = append(owned[owner], scopeNode{
-			id: n.ID, name: n.Name, startLine: n.StartLine, kind: graph.KindLocal,
-		})
-	}
-	for n := range r.graph.NodesByKind(graph.KindParam) {
-		owner := enclosingFunctionForBinding(n.ID)
-		if owner == "" {
-			continue
-		}
-		owned[owner] = append(owned[owner], scopeNode{
-			id: n.ID, name: n.Name, startLine: n.StartLine, kind: graph.KindParam,
+			id: node.ID, name: node.Name, startLine: node.StartLine, kind: node.Kind,
 		})
 	}
 	if len(owned) == 0 {

--- a/internal/resolver/cpp_overload_test.go
+++ b/internal/resolver/cpp_overload_test.go
@@ -11,19 +11,19 @@ func TestCppConversionRank(t *testing.T) {
 	ptr := cppShape{isPointer: true}
 	ellipsis := cppShape{}
 	cases := []struct {
-		arg, param   string
-		ash, psh     cppShape
-		want         int
+		arg, param string
+		ash, psh   cppShape
+		want       int
 	}{
-		{"int", "int", v, v, 0},          // exact
-		{"int", "int", v, ptr, cppRankInf}, // value≠pointer (shape-aware)
-		{"int", "int", ptr, ptr, 0},      // pointer exact
-		{"char", "int", v, v, 1},         // integral promotion
-		{"bool", "int", v, v, 1},         // bool→int promotion
-		{"int", "double", v, v, 2},       // arithmetic standard
-		{"null", "int", v, ptr, 2},       // nullptr→T*
-		{"null", "bool", v, v, 3},        // nullptr→bool (worse than →T*)
-		{"int", "...", v, ellipsis, 5},   // ellipsis
+		{"int", "int", v, v, 0},             // exact
+		{"int", "int", v, ptr, cppRankInf},  // value≠pointer (shape-aware)
+		{"int", "int", ptr, ptr, 0},         // pointer exact
+		{"char", "int", v, v, 1},            // integral promotion
+		{"bool", "int", v, v, 1},            // bool→int promotion
+		{"int", "double", v, v, 2},          // arithmetic standard
+		{"null", "int", v, ptr, 2},          // nullptr→T*
+		{"null", "bool", v, v, 3},           // nullptr→bool (worse than →T*)
+		{"int", "...", v, ellipsis, 5},      // ellipsis
 		{"string", "int", v, v, cppRankInf}, // mismatch
 	}
 	for _, c := range cases {

--- a/internal/resolver/cross_pkg_guard.go
+++ b/internal/resolver/cross_pkg_guard.go
@@ -2,6 +2,7 @@ package resolver
 
 import (
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"go.uber.org/zap"
@@ -391,15 +392,22 @@ func (r *Resolver) buildImportClosureFiltered(repos map[string]struct{}) map[str
 		}
 		set[dir] = struct{}{}
 	}
-	for n := range r.graph.NodesByKind(graph.KindFile) {
-		if n.FilePath != "" && inScope(n.ID) {
-			add(n.FilePath, filepath.Dir(n.FilePath))
+	var repoPrefixes []string
+	if repos != nil {
+		repoPrefixes = make([]string, 0, len(repos))
+		for prefix := range repos {
+			repoPrefixes = append(repoPrefixes, prefix)
+		}
+		sort.Strings(repoPrefixes)
+	}
+	for file := range graph.FileNodeIdentitiesSeq(r.graph, repoPrefixes) {
+		if file.FilePath != "" && inScope(file.ID) {
+			add(file.FilePath, filepath.Dir(file.FilePath))
 		}
 	}
-	// Materialise the resolved import edges and batch-load their endpoints
-	// (caller file + target) in one GetNodesByIDs — a per-edge GetNode here
-	// is a query round-trip per import on a disk backend. Inlines
-	// edgeCallerFile's cached-node logic against the batch map.
+	// Materialise metadata-free import projections and batch-load only the
+	// endpoint placement fields needed by the closure. A per-edge point lookup
+	// here would be a query round-trip per import on a disk backend.
 	//
 	// Re-export edges ride the same batch: an import that lands on a
 	// barrel (`import { persist } from 'zustand/middleware'` resolving to
@@ -425,7 +433,7 @@ func (r *Resolver) buildImportClosureFiltered(repos map[string]struct{}) map[str
 			ids[e.To] = struct{}{}
 		}
 	}
-	for e := range r.graph.EdgesByKind(graph.EdgeImports) {
+	for e := range graph.EdgesLightSeq(r.graph, graph.EdgeImports) {
 		// Skip imports still pointing at an unresolved placeholder or an
 		// out-of-repo stub — neither names an in-repo directory that a
 		// name-only call candidate could legitimately live in.
@@ -440,7 +448,7 @@ func (r *Resolver) buildImportClosureFiltered(repos map[string]struct{}) map[str
 		imports = append(imports, e)
 		collect(e)
 	}
-	for e := range r.graph.EdgesByKind(graph.EdgeReExports) {
+	for e := range graph.EdgesLightSeq(r.graph, graph.EdgeReExports) {
 		if skipTarget(e.To) {
 			continue
 		}
@@ -454,7 +462,7 @@ func (r *Resolver) buildImportClosureFiltered(repos map[string]struct{}) map[str
 	for id := range ids {
 		idList = append(idList, id)
 	}
-	nodes := r.graph.GetNodesByIDs(idList)
+	placements := graph.NodePlacementsByIDs(r.graph, idList)
 
 	// Direct barrel-file → re-export-target-file map, then a memoised
 	// transitive walk so chained barrels (src/index.ts → src/middleware.ts
@@ -462,11 +470,11 @@ func (r *Resolver) buildImportClosureFiltered(repos map[string]struct{}) map[str
 	reexpTargets := make(map[string][]string)
 	for _, e := range reexports {
 		barrel := e.FilePath
-		if n := nodes[e.From]; n != nil && n.FilePath != "" {
-			barrel = n.FilePath
+		if from, ok := placements[e.From]; ok && from.FilePath != "" {
+			barrel = from.FilePath
 		}
-		if t := nodes[e.To]; t != nil && t.FilePath != "" && barrel != "" {
-			reexpTargets[barrel] = append(reexpTargets[barrel], t.FilePath)
+		if to, ok := placements[e.To]; ok && to.FilePath != "" && barrel != "" {
+			reexpTargets[barrel] = append(reexpTargets[barrel], to.FilePath)
 		}
 	}
 	barrelDirCache := make(map[string][]string)
@@ -490,10 +498,10 @@ func (r *Resolver) buildImportClosureFiltered(repos map[string]struct{}) map[str
 
 	for _, e := range imports {
 		callerFile := e.FilePath
-		if n := nodes[e.From]; n != nil && n.FilePath != "" {
-			callerFile = n.FilePath
+		if from, ok := placements[e.From]; ok && from.FilePath != "" {
+			callerFile = from.FilePath
 		}
-		if target := nodes[e.To]; target != nil && target.FilePath != "" {
+		if target, ok := placements[e.To]; ok && target.FilePath != "" {
 			add(callerFile, filepath.Dir(target.FilePath))
 			for _, d := range barrelDirs(target.FilePath, map[string]bool{}) {
 				add(callerFile, d)

--- a/internal/resolver/cross_repo.go
+++ b/internal/resolver/cross_repo.go
@@ -95,8 +95,8 @@ type CrossRepoResolver struct {
 	nodesByName       map[string][]*graph.Node
 	nodesByNameRepo   map[string]map[string][]*graph.Node
 	nodesByQualName   map[string][]*graph.Node
-	dirIndex          map[string][]*graph.Node
-	lastDirIndex      map[string][]*graph.Node
+	dirIndex          map[string][]graph.FileNodeIdentity
+	lastDirIndex      map[string][]graph.FileNodeIdentity
 	// reachableReposByFile maps a caller file's ID to the set of repo
 	// prefixes that file imports (derived from resolved EdgeImports
 	// edges). It is the import-reachability evidence gate: a name-only
@@ -203,6 +203,13 @@ func candidateWorkspaceID(n *graph.Node) string {
 	return n.RepoPrefix
 }
 
+func fileCandidateWorkspaceID(file graph.FileNodeIdentity) string {
+	if file.WorkspaceID != "" {
+		return file.WorkspaceID
+	}
+	return file.RepoPrefix
+}
+
 // crossWorkspaceEligible reports whether sourceWS is permitted to
 // reach a candidate in targetWS, optionally constrained by the
 // candidate's import path. importPath == "" means "any module"
@@ -248,18 +255,18 @@ func (cr *CrossRepoResolver) crossWorkspaceEligible(sourceWS, targetWS, importPa
 // modules live in different workspaces — the worktree-instance case,
 // where the importer's workspace has its own copy of the imported module
 // but the canonical copy (in another workspace) sorted first.
-func (cr *CrossRepoResolver) pickImportCandidate(callerWS, importPath string, candidates []*graph.Node) *graph.Node {
-	for _, c := range candidates {
-		if candidateWorkspaceID(c) == callerWS {
-			return c
+func (cr *CrossRepoResolver) pickImportCandidate(callerWS, importPath string, candidates []graph.FileNodeIdentity) (graph.FileNodeIdentity, bool) {
+	for _, candidate := range candidates {
+		if fileCandidateWorkspaceID(candidate) == callerWS {
+			return candidate, true
 		}
 	}
-	for _, c := range candidates {
-		if cr.crossWorkspaceEligible(callerWS, candidateWorkspaceID(c), importPath) {
-			return c
+	for _, candidate := range candidates {
+		if cr.crossWorkspaceEligible(callerWS, fileCandidateWorkspaceID(candidate), importPath) {
+			return candidate, true
 		}
 	}
-	return nil
+	return graph.FileNodeIdentity{}, false
 }
 
 // pickQualNameCandidate applies repository/workspace policy to the complete
@@ -599,14 +606,14 @@ func (cr *CrossRepoResolver) resolveScopedLocked(edges []*graph.Edge) *CrossRepo
 // These maps are torn down via clearDirIndexes when the pass completes
 // so we don't keep ~N pointers alive between resolves.
 func (cr *CrossRepoResolver) buildDirIndexes() {
-	cr.dirIndex = make(map[string][]*graph.Node, 128)
-	cr.lastDirIndex = make(map[string][]*graph.Node, 128)
-	for n := range cr.graph.NodesByKind(graph.KindFile) {
-		dir := filepath.Dir(n.FilePath)
-		cr.dirIndex[dir] = append(cr.dirIndex[dir], n)
+	cr.dirIndex = make(map[string][]graph.FileNodeIdentity, 128)
+	cr.lastDirIndex = make(map[string][]graph.FileNodeIdentity, 128)
+	for file := range graph.FileNodeIdentitiesSeq(cr.graph, nil) {
+		dir := filepath.Dir(file.FilePath)
+		cr.dirIndex[dir] = append(cr.dirIndex[dir], file)
 		last := lastPathComponent(dir)
 		if last != "" && last != dir {
-			cr.lastDirIndex[last] = append(cr.lastDirIndex[last], n)
+			cr.lastDirIndex[last] = append(cr.lastDirIndex[last], file)
 		}
 	}
 }
@@ -617,7 +624,7 @@ func (cr *CrossRepoResolver) buildDirIndexes() {
 // importing file's own go.mod.
 func (cr *CrossRepoResolver) buildDepModuleIndex() {
 	by := make(map[string][]depModuleEntry)
-	for n := range cr.graph.NodesByKind(graph.KindContract) {
+	for n := range graph.RepoNodeIdentitiesSeq(cr.graph, nil, graph.KindContract) {
 		if !strings.HasPrefix(n.ID, "dep::") {
 			continue
 		}
@@ -627,7 +634,7 @@ func (cr *CrossRepoResolver) buildDepModuleIndex() {
 		}
 		by[n.RepoPrefix] = append(by[n.RepoPrefix], depModuleEntry{
 			modulePath: mp,
-			node:       n,
+			nodeID:     n.ID,
 		})
 	}
 	for k := range by {
@@ -643,15 +650,15 @@ func (cr *CrossRepoResolver) clearDepModuleIndex() {
 	cr.depModuleIndex = nil
 }
 
-// lookupDepModule returns the dep::<module> contract node whose
-// module path is a prefix of importPath, scoped to callerRepo.
-func (cr *CrossRepoResolver) lookupDepModule(callerRepo, importPath string) *graph.Node {
+// lookupDepModule returns the dep::<module> contract ID whose module path is a
+// prefix of importPath, scoped to callerRepo. Empty means no match.
+func (cr *CrossRepoResolver) lookupDepModule(callerRepo, importPath string) string {
 	for _, entry := range cr.depModuleIndex[callerRepo] {
 		if importPath == entry.modulePath || strings.HasPrefix(importPath, entry.modulePath+"/") {
-			return entry.node
+			return entry.nodeID
 		}
 	}
-	return nil
+	return ""
 }
 
 func (cr *CrossRepoResolver) clearDirIndexes() {
@@ -669,14 +676,13 @@ func (cr *CrossRepoResolver) clearDirIndexes() {
 // graph is settled enough to be trustworthy evidence.
 func (cr *CrossRepoResolver) buildReachableReposIndex() {
 	idx := make(map[string]map[string]struct{})
-	// Materialise the import edges and batch-load their targets in one
-	// GetNodesByIDs — a per-edge GetNode(e.To) here is a query round-trip
-	// per import on a disk backend, which under the cross-repo pass's
-	// import population was a multi-minute cold-warmup stall (it runs
-	// before the pass even logs "pass start").
+	// Materialise metadata-free import projections and batch-load only target
+	// placement fields. A per-edge point lookup here is a query round-trip per
+	// import on a disk backend, which under the cross-repo pass's import
+	// population was a multi-minute cold-warmup stall.
 	var imports []*graph.Edge
 	ids := make(map[string]struct{})
-	for e := range cr.graph.EdgesByKind(graph.EdgeImports) {
+	for e := range graph.EdgesLightSeq(cr.graph, graph.EdgeImports) {
 		imports = append(imports, e)
 		if e.To != "" {
 			ids[e.To] = struct{}{}
@@ -690,12 +696,12 @@ func (cr *CrossRepoResolver) buildReachableReposIndex() {
 	for id := range ids {
 		idList = append(idList, id)
 	}
-	nodes := cr.graph.GetNodesByIDs(idList)
+	placements := graph.NodePlacementsByIDs(cr.graph, idList)
 	for _, e := range imports {
 		// Only resolved imports carry evidence — an unresolved import
 		// target tells us nothing about which repo the caller reaches.
-		to := nodes[e.To]
-		if to == nil || to.RepoPrefix == "" {
+		to, ok := placements[e.To]
+		if !ok || to.RepoPrefix == "" {
 			continue
 		}
 		set := idx[e.From]
@@ -1246,18 +1252,16 @@ func (cr *CrossRepoResolver) resolveImport(e *graph.Edge, importPath string, sta
 	// own workspace; otherwise the first same-repo hit short-circuits
 	// the scan as before.
 	collectAll := cr.workspaceMembers != nil
-	var sameRepo *graph.Node
-	var sameRepoAll, crossRepoAll []*graph.Node
-	consider := func(n *graph.Node) {
-		if n.Kind != graph.KindFile {
-			return
-		}
-		if n.RepoPrefix == callerRepo {
-			if sameRepo == nil {
-				sameRepo = n
+	var sameRepo graph.FileNodeIdentity
+	var sameRepoFound bool
+	var sameRepoAll, crossRepoAll []graph.FileNodeIdentity
+	consider := func(file graph.FileNodeIdentity) {
+		if file.RepoPrefix == callerRepo {
+			if !sameRepoFound {
+				sameRepo, sameRepoFound = file, true
 			}
 			if collectAll {
-				sameRepoAll = append(sameRepoAll, n)
+				sameRepoAll = append(sameRepoAll, file)
 			}
 			return
 		}
@@ -1268,31 +1272,31 @@ func (cr *CrossRepoResolver) resolveImport(e *graph.Edge, importPath string, sta
 		// `*/bindings/go` directory sorts first. Collect every match so
 		// the workspace-aware pick below can prefer the importer's own
 		// workspace instead of the first one encountered.
-		if dirMatchesImport(filepath.Dir(n.FilePath), importPath) {
-			crossRepoAll = append(crossRepoAll, n)
+		if dirMatchesImport(filepath.Dir(file.FilePath), importPath) {
+			crossRepoAll = append(crossRepoAll, file)
 		}
 	}
-	stop := func() bool { return sameRepo != nil && !collectAll }
+	stop := func() bool { return sameRepoFound && !collectAll }
 	if cr.dirIndex != nil {
-		for _, n := range cr.dirIndex[importPath] {
-			consider(n)
+		for _, file := range cr.dirIndex[importPath] {
+			consider(file)
 			if stop() {
 				break
 			}
 		}
-		if sameRepo == nil || collectAll {
-			for _, n := range cr.lastDirIndex[lastPathComponent(importPath)] {
-				consider(n)
+		if !sameRepoFound || collectAll {
+			for _, file := range cr.lastDirIndex[lastPathComponent(importPath)] {
+				consider(file)
 				if stop() {
 					break
 				}
 			}
 		}
 	} else {
-		for n := range cr.graph.NodesByKind(graph.KindFile) {
-			dir := filepath.Dir(n.FilePath)
+		for file := range graph.FileNodeIdentitiesSeq(cr.graph, nil) {
+			dir := filepath.Dir(file.FilePath)
 			if strings.HasSuffix(dir, lastPathComponent(importPath)) || dir == importPath {
-				consider(n)
+				consider(file)
 				if stop() {
 					break
 				}
@@ -1300,11 +1304,11 @@ func (cr *CrossRepoResolver) resolveImport(e *graph.Edge, importPath string, sta
 		}
 	}
 
-	if sameRepo != nil {
+	if sameRepoFound {
 		// Name-collision tie-break: prefer the same-repo file in the
 		// importing file's own package-manager workspace.
-		if ws := cr.preferSameWorkspaceFile(e.FilePath, sameRepoAll); ws != nil {
-			sameRepo = ws
+		if workspaceFile, ok := cr.preferSameWorkspaceFile(e.FilePath, sameRepoAll); ok {
+			sameRepo = workspaceFile
 		}
 		e.To = sameRepo.ID
 		stats.Resolved++
@@ -1315,7 +1319,7 @@ func (cr *CrossRepoResolver) resolveImport(e *graph.Edge, importPath string, sta
 	// on the first ineligible candidate — a same-workspace instance (a
 	// worktree of the imported module tracked under its own prefix) may
 	// appear later in the list.
-	if picked := cr.pickImportCandidate(callerWS, importPath, crossRepoAll); picked != nil {
+	if picked, ok := cr.pickImportCandidate(callerWS, importPath, crossRepoAll); ok {
 		e.To = picked.ID
 		stats.Resolved++
 		if isCrossRepoHop(callerRepo, picked.RepoPrefix) {
@@ -1329,8 +1333,8 @@ func (cr *CrossRepoResolver) resolveImport(e *graph.Edge, importPath string, sta
 	// No file node matched. Try the dep::<module> contract from the
 	// caller's go.mod before giving up. The dep node lives in the
 	// caller's own repo, so this is a same-repo edge.
-	if depNode := cr.lookupDepModule(callerRepo, importPath); depNode != nil {
-		e.To = depNode.ID
+	if depNodeID := cr.lookupDepModule(callerRepo, importPath); depNodeID != "" {
+		e.To = depNodeID
 		stats.Resolved++
 		return
 	}

--- a/internal/resolver/cross_repo_edges.go
+++ b/internal/resolver/cross_repo_edges.go
@@ -70,7 +70,7 @@ func DetectCrossRepoEdgesForReindexes(g graph.Store, batch []graph.EdgeReindex) 
 			ids = append(ids, id)
 		}
 	}
-	nodes := g.GetNodesByIDs(ids)
+	placements := graph.NodePlacementsByIDs(g, ids)
 	rows := make([]graph.CrossRepoCandidateRow, 0, len(batch))
 	for _, reindex := range batch {
 		edge := reindex.Edge
@@ -80,8 +80,9 @@ func DetectCrossRepoEdgesForReindexes(g graph.Store, batch []graph.EdgeReindex) 
 		if _, ok := graph.CrossRepoKindFor(edge.Kind); !ok {
 			continue
 		}
-		from, to := nodes[edge.From], nodes[edge.To]
-		if from == nil || to == nil || from.RepoPrefix == "" || to.RepoPrefix == "" || from.RepoPrefix == to.RepoPrefix {
+		from, fromOK := placements[edge.From]
+		to, toOK := placements[edge.To]
+		if !fromOK || !toOK || from.RepoPrefix == "" || to.RepoPrefix == "" || from.RepoPrefix == to.RepoPrefix {
 			continue
 		}
 		rows = append(rows, graph.CrossRepoCandidateRow{
@@ -234,31 +235,22 @@ func crossRepoCandidatesFallback(g graph.Store, baseKinds []graph.EdgeKind, repo
 	if len(baseKinds) == 0 || (repos != nil && len(repos) == 0) || (files != nil && len(files) == 0) {
 		return nil
 	}
-	seenKinds := make(map[graph.EdgeKind]struct{}, len(baseKinds))
 	var edges []*graph.Edge
-	for _, kind := range baseKinds {
-		if kind == "" {
-			continue
-		}
-		if _, duplicate := seenKinds[kind]; duplicate {
-			continue
-		}
-		seenKinds[kind] = struct{}{}
-		for edge := range g.EdgesByKind(kind) {
-			if edge != nil {
-				edges = append(edges, edge)
-			}
+	for edge := range graph.EdgesLightSeq(g, baseKinds...) {
+		if edge != nil {
+			edges = append(edges, edge)
 		}
 	}
 	endpointIDs := make([]string, 0, len(edges)*2)
 	for _, edge := range edges {
 		endpointIDs = append(endpointIDs, edge.From, edge.To)
 	}
-	nodes := g.GetNodesByIDs(endpointIDs)
+	placements := graph.NodePlacementsByIDs(g, endpointIDs)
 	out := make([]graph.CrossRepoCandidateRow, 0, len(edges))
 	for _, edge := range edges {
-		from, to := nodes[edge.From], nodes[edge.To]
-		if from == nil || to == nil || from.RepoPrefix == "" || to.RepoPrefix == "" || from.RepoPrefix == to.RepoPrefix {
+		from, fromOK := placements[edge.From]
+		to, toOK := placements[edge.To]
+		if !fromOK || !toOK || from.RepoPrefix == "" || to.RepoPrefix == "" || from.RepoPrefix == to.RepoPrefix {
 			continue
 		}
 		if repos != nil {

--- a/internal/resolver/csharp_iface_dispatch.go
+++ b/internal/resolver/csharp_iface_dispatch.go
@@ -427,7 +427,7 @@ func csharpMemberMethodsAllByType(g graph.Store) map[string]map[string][]*graph.
 	}
 	var edges []*graph.Edge
 	methodIDs := make([]string, 0)
-	for e := range g.EdgesByKind(graph.EdgeMemberOf) {
+	for e := range graph.EdgesLightSeq(g, graph.EdgeMemberOf) {
 		if e == nil {
 			continue
 		}

--- a/internal/resolver/dataflow_callee_bind.go
+++ b/internal/resolver/dataflow_callee_bind.go
@@ -42,19 +42,17 @@ import (
 // callee to its param node).
 func (r *Resolver) bindDataflowCalleeRefs() {
 	idx := newCalleeIndex()
-	for _, k := range []graph.NodeKind{graph.KindFunction, graph.KindMethod} {
-		for n := range r.graph.NodesByKind(k) {
-			if n == nil || n.Name == "" || n.FilePath == "" {
-				continue
-			}
-			indexName(idx.byFile, n.FilePath, n.Name, n.ID)
-			if k == graph.KindFunction {
-				indexName(idx.byDir, filepath.Dir(n.FilePath), n.Name, n.ID)
-			}
+	for node := range graph.CallableBindingNodesSeq(r.graph, graph.KindFunction, graph.KindMethod) {
+		if node.Name == "" || node.FilePath == "" {
+			continue
+		}
+		indexName(idx.byFile, node.FilePath, node.Name, node.ID)
+		if node.Kind == graph.KindFunction {
+			indexName(idx.byDir, filepath.Dir(node.FilePath), node.Name, node.ID)
 		}
 	}
 	for _, k := range []graph.EdgeKind{graph.EdgeCalls, graph.EdgeReferences} {
-		for e := range r.graph.EdgesByKind(k) {
+		for e := range graph.EdgesLightSeq(r.graph, k) {
 			idx.indexCallSite(e)
 		}
 	}

--- a/internal/resolver/event_channel_calls.go
+++ b/internal/resolver/event_channel_calls.go
@@ -89,7 +89,7 @@ func ResolveEventChannelCalls(g graph.Store) int {
 	}
 
 	listenersByEvent := map[string][]string{}
-	for e := range g.EdgesByKind(graph.EdgeListensOn) {
+	for e := range graph.EdgesLightSeq(g, graph.EdgeListensOn) {
 		if e == nil || e.To == "" || e.From == "" {
 			continue
 		}

--- a/internal/resolver/express_resolve.go
+++ b/internal/resolver/express_resolve.go
@@ -120,7 +120,7 @@ func expressResolveMember(g graph.Store, cls, method, fromFile string, classMeth
 // via the EdgeMemberOf edges.
 func expressClassMethodIndex(g graph.Store) map[string]map[string][]*graph.Node {
 	classOf := map[string]string{}
-	for e := range g.EdgesByKind(graph.EdgeMemberOf) {
+	for e := range graph.EdgesLightSeq(g, graph.EdgeMemberOf) {
 		if e != nil && e.From != "" && e.To != "" {
 			classOf[e.From] = expressSimpleName(e.To)
 		}

--- a/internal/resolver/framework_edge_batch.go
+++ b/internal/resolver/framework_edge_batch.go
@@ -181,6 +181,19 @@ func (s *frameworkEdgeBatchStore) EdgesByKinds(kinds []graph.EdgeKind) iter.Seq[
 	})
 }
 
+func (s *frameworkEdgeBatchStore) EdgesLightSeq(kinds ...graph.EdgeKind) iter.Seq[*graph.Edge] {
+	wanted := make(map[graph.EdgeKind]struct{}, len(kinds))
+	for _, kind := range kinds {
+		if kind != "" {
+			wanted[kind] = struct{}{}
+		}
+	}
+	return s.mergeEdgeSeq(graph.EdgesLightSeq(s.Store, kinds...), func(edge *graph.Edge) bool {
+		_, ok := wanted[edge.Kind]
+		return ok
+	})
+}
+
 func (s *frameworkEdgeBatchStore) EdgesWithUnresolvedTarget() iter.Seq[*graph.Edge] {
 	return s.mergeEdgeSeq(s.Store.EdgesWithUnresolvedTarget(), func(edge *graph.Edge) bool {
 		return graph.IsUnresolvedTarget(edge.To) && !graph.IsFnValuePlaceholder(edge.To)
@@ -226,6 +239,42 @@ func (s *frameworkEdgeBatchStore) NodesByKinds(kinds []graph.NodeKind) []*graph.
 		}
 	}
 	return out
+}
+
+func (s *frameworkEdgeBatchStore) ScopeBindingNodesSeq(kinds ...graph.NodeKind) iter.Seq[graph.ScopeBindingNode] {
+	return graph.ScopeBindingNodesSeq(s.Store, kinds...)
+}
+
+func (s *frameworkEdgeBatchStore) CallableBindingNodesSeq(kinds ...graph.NodeKind) iter.Seq[graph.CallableBindingNode] {
+	return graph.CallableBindingNodesSeq(s.Store, kinds...)
+}
+
+func (s *frameworkEdgeBatchStore) FileLanguageNodesSeq() iter.Seq[graph.FileLanguageNode] {
+	return graph.FileLanguageNodesSeq(s.Store)
+}
+
+func (s *frameworkEdgeBatchStore) RepoNodeIdentitiesSeq(repoPrefixes []string, kinds ...graph.NodeKind) iter.Seq[graph.RepoNodeIdentity] {
+	return graph.RepoNodeIdentitiesSeq(s.Store, repoPrefixes, kinds...)
+}
+
+func (s *frameworkEdgeBatchStore) NamedLanguageNodesSeq(kinds ...graph.NodeKind) iter.Seq[graph.NamedLanguageNode] {
+	return graph.NamedLanguageNodesSeq(s.Store, kinds...)
+}
+
+func (s *frameworkEdgeBatchStore) QualifiedNodeIdentitiesSeq(kinds ...graph.NodeKind) iter.Seq[graph.QualifiedNodeIdentity] {
+	return graph.QualifiedNodeIdentitiesSeq(s.Store, kinds...)
+}
+
+func (s *frameworkEdgeBatchStore) FileNodeIdentitiesSeq(repoPrefixes []string) iter.Seq[graph.FileNodeIdentity] {
+	return graph.FileNodeIdentitiesSeq(s.Store, repoPrefixes)
+}
+
+func (s *frameworkEdgeBatchStore) NodePlacementsByIDs(ids []string) map[string]graph.NodePlacement {
+	return graph.NodePlacementsByIDs(s.Store, ids)
+}
+
+func (s *frameworkEdgeBatchStore) NodeIDsByKinds(kinds []graph.NodeKind) []string {
+	return graph.NodeIDsForKinds(s.Store, kinds...)
 }
 
 // ConstantValuesByNodeIDs preserves the Temporal pass's sidecar projection.

--- a/internal/resolver/generic_param_bind.go
+++ b/internal/resolver/generic_param_bind.go
@@ -24,7 +24,7 @@ import (
 func (r *Resolver) bindGenericParamRefs() {
 	// owner-function ID → set of tparam-name → tparam-node-id.
 	owned := map[string]map[string]string{}
-	for n := range r.graph.NodesByKind(graph.KindGenericParam) {
+	for n := range graph.NamedLanguageNodesSeq(r.graph, graph.KindGenericParam) {
 		if n.Language != "go" || n.Name == "" {
 			continue
 		}

--- a/internal/resolver/grpc_stub_calls.go
+++ b/internal/resolver/grpc_stub_calls.go
@@ -228,7 +228,7 @@ func buildGRPCHandlerIndex(g graph.Store, shared bool, sharedCalls []*graph.Edge
 	// later impl filter (Unimplemented*).
 	implementorsByIface := map[string][]string{}
 	var registrations []*graph.Edge
-	for e := range g.EdgesByKind(graph.EdgeImplements) {
+	for e := range graph.EdgesLightSeq(g, graph.EdgeImplements) {
 		if e == nil {
 			continue
 		}

--- a/internal/resolver/incremental_attribution_cache.go
+++ b/internal/resolver/incremental_attribution_cache.go
@@ -23,7 +23,7 @@ func (r *Resolver) prepareIncrementalAttributionCache(frontier incrementalFileFr
 	missingSet := make(map[string]struct{})
 	for _, path := range frontier.paths {
 		for _, fileNode := range r.dirIndex[filepath.Dir(path)] {
-			if fileNode == nil || fileNode.FilePath == "" {
+			if fileNode.FilePath == "" {
 				continue
 			}
 			if _, cached := r.incrementalNodesByFile[fileNode.FilePath]; !cached {

--- a/internal/resolver/laravel_event_calls.go
+++ b/internal/resolver/laravel_event_calls.go
@@ -27,7 +27,7 @@ func ResolveLaravelEventCalls(g graph.Store) int {
 	handleByClass := map[string][]*graph.Node{}
 	listenersByType := map[string][]*graph.Node{}
 	classByMethod := map[string]string{}
-	for e := range g.EdgesByKind(graph.EdgeMemberOf) {
+	for e := range graph.EdgesLightSeq(g, graph.EdgeMemberOf) {
 		if e != nil && e.From != "" && e.To != "" {
 			classByMethod[e.From] = laravelSimpleName(e.To)
 		}

--- a/internal/resolver/lsp_cutoff_test.go
+++ b/internal/resolver/lsp_cutoff_test.go
@@ -34,12 +34,12 @@ func (c *switchedClock) now() time.Time {
 // clock after its first successful answer, so the expensive-path cutoff
 // trips deterministically at the next per-page check site.
 type flippingLSPHelper struct {
-	clock      *switchedClock
-	flipAfter  int
-	defPath    string
-	defLine    int
-	mu         sync.Mutex
-	calls      []string
+	clock     *switchedClock
+	flipAfter int
+	defPath   string
+	defLine   int
+	mu        sync.Mutex
+	calls     []string
 }
 
 func (h *flippingLSPHelper) SupportsPath(string) bool { return true }

--- a/internal/resolver/lua_imports.go
+++ b/internal/resolver/lua_imports.go
@@ -26,21 +26,21 @@ func (r *Resolver) resolveLuaRequires() {
 	if !r.graphHasLanguage("lua") && !r.graphHasLanguage("luau") {
 		return
 	}
-	fileLang := r.collectFileLanguages()
-
+	fileLang := make(map[string]string, 1024)
 	fileIDs := make(map[string]struct{}, 1024)
 	// filesByBase indexes every KindFile by basename for the suffix nets.
 	filesByBase := make(map[string][]string, 1024)
-	for n := range r.graph.NodesByKind(graph.KindFile) {
-		if n == nil || n.ID == "" {
+	for file := range graph.FileLanguageNodesSeq(r.graph) {
+		if file.ID == "" {
 			continue
 		}
-		fileIDs[n.ID] = struct{}{}
-		base := n.ID
-		if i := strings.LastIndex(n.ID, "/"); i >= 0 {
-			base = n.ID[i+1:]
+		fileLang[file.ID] = file.Language
+		fileIDs[file.ID] = struct{}{}
+		base := file.ID
+		if i := strings.LastIndex(file.ID, "/"); i >= 0 {
+			base = file.ID[i+1:]
 		}
-		filesByBase[base] = append(filesByBase[base], n.ID)
+		filesByBase[base] = append(filesByBase[base], file.ID)
 	}
 
 	var reindexBatch []graph.EdgeReindex

--- a/internal/resolver/method_receiver_rebind.go
+++ b/internal/resolver/method_receiver_rebind.go
@@ -115,7 +115,7 @@ func (r *Resolver) rebindGoMethodReceiversForFile(filePath string) {
 		// per package or issuing one file query per package member.
 		var packageFiles []string
 		for _, fileNode := range r.dirIndex[dir] {
-			if fileNode != nil && fileNode.RepoPrefix == repoPrefix && fileNode.FilePath != "" {
+			if fileNode.RepoPrefix == repoPrefix && fileNode.FilePath != "" {
 				packageFiles = append(packageFiles, fileNode.FilePath)
 			}
 		}

--- a/internal/resolver/module_attribution.go
+++ b/internal/resolver/module_attribution.go
@@ -103,7 +103,7 @@ func (r *Resolver) attributeNonGoModuleImports() {
 	// read on every backend, plus a Go-side map build that turns
 	// the per-rewrite check into a constant-time lookup.
 	existingDepends := make(map[string]map[string]struct{})
-	for e := range r.graph.EdgesByKind(graph.EdgeDependsOnModule) {
+	for e := range graph.EdgesLightSeq(r.graph, graph.EdgeDependsOnModule) {
 		// Only the rewrites' own callers (in scope) are queried below, so a
 		// scoped pass needs the dedupe index for just those repos.
 		if !r.edgeFromInScope(e.From) {
@@ -164,8 +164,8 @@ func (r *Resolver) attributeNonGoModuleImports() {
 // (file ID → language) for the per-edge dispatch above.
 func (r *Resolver) collectFileLanguages() map[string]string {
 	out := map[string]string{}
-	for n := range r.graph.NodesByKind(graph.KindFile) {
-		out[n.ID] = n.Language
+	for file := range graph.FileLanguageNodesSeq(r.graph) {
+		out[file.ID] = file.Language
 	}
 	return out
 }

--- a/internal/resolver/pascal_form.go
+++ b/internal/resolver/pascal_form.go
@@ -26,12 +26,9 @@ func ResolvePascalForms(g graph.Store) int {
 	if g == nil {
 		return 0
 	}
-	units := map[string]*graph.Node{}
-	forms := map[string]*graph.Node{}
-	for _, n := range nodesByKindsOrAll(g, graph.KindFile) {
-		if n == nil {
-			continue
-		}
+	units := map[string]graph.FileNodeIdentity{}
+	forms := map[string]graph.FileNodeIdentity{}
+	for n := range graph.FileNodeIdentitiesSeq(g, nil) {
 		switch strings.ToLower(filepath.Ext(n.FilePath)) {
 		case ".pas", ".pp", ".dpr", ".lpr":
 			units[pascalFormKey(n.FilePath)] = n
@@ -52,7 +49,7 @@ func ResolvePascalForms(g graph.Store) int {
 	for _, key := range keys {
 		unit := units[key]
 		form, ok := forms[key]
-		if !ok || !sameDispatchBoundary(unit, form) {
+		if !ok || unit.WorkspaceID != form.WorkspaceID {
 			continue
 		}
 		batch = append(batch, &graph.Edge{

--- a/internal/resolver/php_override_dispatch.go
+++ b/internal/resolver/php_override_dispatch.go
@@ -210,7 +210,7 @@ func (r *Resolver) phpTypeHierarchy() (direct, closure map[string]map[string]boo
 		}
 	}
 	// Trait `use` (and any other extends-shaped) relationship is a graph edge.
-	for e := range g.EdgesByKind(graph.EdgeExtends) {
+	for e := range graph.EdgesLightSeq(g, graph.EdgeExtends) {
 		if e == nil {
 			continue
 		}

--- a/internal/resolver/php_override_dispatch_test.go
+++ b/internal/resolver/php_override_dispatch_test.go
@@ -251,7 +251,7 @@ func TestResolvePHPOverrideDispatch_ReceiverTypeBindsInheritedMethod(t *testing.
 	s.AddEdge(&graph.Edge{
 		From: caller, To: "unresolved::*.getRecord", Kind: graph.EdgeCalls,
 		FilePath: leaf, Line: 12,
-		Meta:     map[string]any{"receiver_type": "StreamHandlerTest"},
+		Meta: map[string]any{"receiver_type": "StreamHandlerTest"},
 	})
 
 	require.Positive(t, New(s).resolvePHPOverrideDispatch())
@@ -281,7 +281,7 @@ func TestResolvePHPOverrideDispatch_ReceiverTypePrefersOwnDeclaration(t *testing
 	s.AddEdge(&graph.Edge{
 		From: caller, To: "unresolved::*.handle", Kind: graph.EdgeCalls,
 		FilePath: app, Line: 3,
-		Meta:     map[string]any{"receiver_type": "StreamHandler"},
+		Meta: map[string]any{"receiver_type": "StreamHandler"},
 	})
 
 	require.Positive(t, New(s).resolvePHPOverrideDispatch())
@@ -310,7 +310,7 @@ func TestResolvePHPOverrideDispatch_UnknownReceiverTypeStaysUnresolved(t *testin
 	s.AddEdge(&graph.Edge{
 		From: caller, To: "unresolved::*.send", Kind: graph.EdgeCalls,
 		FilePath: app, Line: 7,
-		Meta:     map[string]any{"receiver_type": "GuzzleClient"},
+		Meta: map[string]any{"receiver_type": "GuzzleClient"},
 	})
 
 	New(s).resolvePHPOverrideDispatch()
@@ -337,7 +337,7 @@ func TestResolvePHPOverrideDispatch_ReceiverTypeBindsThroughTrait(t *testing.T) 
 	s.AddEdge(&graph.Edge{
 		From: caller, To: "unresolved::*.logInfo", Kind: graph.EdgeCalls,
 		FilePath: cls, Line: 9,
-		Meta:     map[string]any{"receiver_type": "Worker"},
+		Meta: map[string]any{"receiver_type": "Worker"},
 	})
 
 	require.Positive(t, New(s).resolvePHPOverrideDispatch())
@@ -371,7 +371,7 @@ func TestResolveAll_PHPTypedReceiverBeatsSameDirectoryGuess(t *testing.T) {
 	s.AddEdge(&graph.Edge{
 		From: callerID, To: "unresolved::*.getFormatter", Kind: graph.EdgeCalls,
 		FilePath: caller, Line: 124,
-		Meta:     map[string]any{"receiver_type": "AmqpHandler"},
+		Meta: map[string]any{"receiver_type": "AmqpHandler"},
 	})
 
 	New(s).ResolveAll()

--- a/internal/resolver/placeholder_sources.go
+++ b/internal/resolver/placeholder_sources.go
@@ -25,7 +25,7 @@ func (idx *placeholderSourceIndex) ensure(g graph.Store) {
 	}
 	idx.built = true
 	for _, kind := range []graph.EdgeKind{graph.EdgeArgOf, graph.EdgeValueFlow} {
-		for e := range g.EdgesByKind(kind) {
+		for e := range graph.EdgesLightSeq(g, kind) {
 			if e == nil || !strings.Contains(e.From, graph.UnresolvedMarker) {
 				continue
 			}

--- a/internal/resolver/rails_resolve.go
+++ b/internal/resolver/rails_resolve.go
@@ -123,7 +123,7 @@ func railsRefDirs(recv string) (isModel bool, dirs []string) {
 // ActiveRecord models — those with an outgoing EdgeModelsTable.
 func railsModelClassSet(g graph.Store) map[string]bool {
 	out := map[string]bool{}
-	for e := range g.EdgesByKind(graph.EdgeModelsTable) {
+	for e := range graph.EdgesLightSeq(g, graph.EdgeModelsTable) {
 		if e != nil && e.From != "" {
 			out[e.From] = true
 		}
@@ -135,7 +135,7 @@ func railsModelClassSet(g graph.Store) map[string]bool {
 // ID via the EdgeMemberOf edges.
 func railsClassMethodIndex(g graph.Store) map[string]map[string]string {
 	classOf := map[string]string{}
-	for e := range g.EdgesByKind(graph.EdgeMemberOf) {
+	for e := range graph.EdgesLightSeq(g, graph.EdgeMemberOf) {
 		if e != nil && e.From != "" && e.To != "" {
 			classOf[e.From] = e.To
 		}

--- a/internal/resolver/relative_imports.go
+++ b/internal/resolver/relative_imports.go
@@ -30,7 +30,7 @@ func (r *Resolver) resolveRelativeImports() {
 		!r.graphHasLanguage("php") {
 		return
 	}
-	fileLang := r.collectFileLanguages()
+	fileLang := make(map[string]string, 1024)
 	var reindexBatch []graph.EdgeReindex
 
 	// Pre-build a map of every KindFile node's ID. The relative-
@@ -45,15 +45,17 @@ func (r *Resolver) resolveRelativeImports() {
 	// C-family include (`foo/bar.h`) can be resolved against an include root
 	// without enumerating the whole file set per include (the `-I` search).
 	filesByBase := make(map[string][]string, 1024)
-	for n := range r.graph.NodesByKind(graph.KindFile) {
-		if n != nil && n.ID != "" {
-			fileIDs[n.ID] = struct{}{}
-			base := n.ID
-			if i := strings.LastIndex(n.ID, "/"); i >= 0 {
-				base = n.ID[i+1:]
-			}
-			filesByBase[base] = append(filesByBase[base], n.ID)
+	for file := range graph.FileLanguageNodesSeq(r.graph) {
+		if file.ID == "" {
+			continue
 		}
+		fileLang[file.ID] = file.Language
+		fileIDs[file.ID] = struct{}{}
+		base := file.ID
+		if i := strings.LastIndex(file.ID, "/"); i >= 0 {
+			base = file.ID[i+1:]
+		}
+		filesByBase[base] = append(filesByBase[base], file.ID)
 	}
 	resolvePython := func(stem string) string {
 		if !strings.Contains(stem, "/") {

--- a/internal/resolver/resolve_all_pending.go
+++ b/internal/resolver/resolve_all_pending.go
@@ -295,15 +295,15 @@ func (p *resolveAllPassIndexes) ensureDir(prefixes []string) {
 		return
 	}
 	if p.resolver.dirIndex == nil {
-		p.resolver.dirIndex = make(map[string][]*graph.Node, 128)
-		p.resolver.lastDirIndex = make(map[string][]*graph.Node, 128)
+		p.resolver.dirIndex = make(map[string][]graph.FileNodeIdentity, 128)
+		p.resolver.lastDirIndex = make(map[string][]graph.FileNodeIdentity, 128)
 	}
-	for node := range graph.NodesInScopeSeq(p.resolver.graph, missing, nil, graph.KindFile) {
-		dir := filepath.Dir(node.FilePath)
-		p.resolver.dirIndex[dir] = append(p.resolver.dirIndex[dir], node)
+	for file := range graph.FileNodeIdentitiesSeq(p.resolver.graph, missing) {
+		dir := filepath.Dir(file.FilePath)
+		p.resolver.dirIndex[dir] = append(p.resolver.dirIndex[dir], file)
 		last := lastPathComponent(dir)
 		if last != "" && last != dir {
-			p.resolver.lastDirIndex[last] = append(p.resolver.lastDirIndex[last], node)
+			p.resolver.lastDirIndex[last] = append(p.resolver.lastDirIndex[last], file)
 		}
 	}
 }
@@ -324,7 +324,7 @@ func (p *resolveAllPassIndexes) ensureDep(prefixes []string) {
 	if p.resolver.depModuleIndex == nil {
 		p.resolver.depModuleIndex = make(map[string][]depModuleEntry)
 	}
-	for node := range graph.NodesInScopeSeq(p.resolver.graph, missing, nil, graph.KindContract) {
+	for node := range graph.RepoNodeIdentitiesSeq(p.resolver.graph, missing, graph.KindContract) {
 		if !strings.HasPrefix(node.ID, "dep::") {
 			continue
 		}
@@ -334,7 +334,7 @@ func (p *resolveAllPassIndexes) ensureDep(prefixes []string) {
 		}
 		p.resolver.depModuleIndex[node.RepoPrefix] = append(
 			p.resolver.depModuleIndex[node.RepoPrefix],
-			depModuleEntry{modulePath: modulePath, node: node},
+			depModuleEntry{modulePath: modulePath, nodeID: node.ID},
 		)
 	}
 	for _, prefix := range missing {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -146,8 +146,8 @@ type ResolveStats struct {
 type Resolver struct {
 	graph        graph.Store
 	logger       *zap.Logger
-	dirIndex     map[string][]*graph.Node
-	lastDirIndex map[string][]*graph.Node
+	dirIndex     map[string][]graph.FileNodeIdentity
+	lastDirIndex map[string][]graph.FileNodeIdentity
 	// OnComputeDone, when set, fires once per ResolveAll immediately after
 	// the parallel compute loop has committed — BEFORE the deferred LSP
 	// batch and the serial refinement tail (guard, attribution, dispatch
@@ -422,11 +422,10 @@ type lspLocKey struct {
 }
 
 // depModuleEntry pairs a Go module path (parsed from a dep:: contract
-// node ID) with the node itself, so import-path prefix matches can
-// jump straight to the target.
+// node ID) with the compact target identity used by import resolution.
 type depModuleEntry struct {
 	modulePath string
-	node       *graph.Node
+	nodeID     string
 }
 
 // New creates a Resolver for the given store. The returned Resolver
@@ -1608,9 +1607,6 @@ func (r *Resolver) scopedTailExceedsFileBudget() bool {
 	perRepo := make(map[string]int, len(r.scope))
 	for _, nodes := range r.dirIndex {
 		for _, n := range nodes {
-			if n == nil {
-				continue
-			}
 			prefix := n.RepoPrefix
 			if prefix == "" {
 				prefix = graph.RepoPrefixOfID(n.ID)
@@ -1651,16 +1647,14 @@ func (r *Resolver) scopedFiles() []string {
 //   - lastDirIndex keys on the last path component of that directory
 //     so an import of "logger" matches any file under .../logger/.
 func (r *Resolver) buildDirIndexes() {
-	r.dirIndex = make(map[string][]*graph.Node, 128)
-	r.lastDirIndex = make(map[string][]*graph.Node, 128)
-	// NodesByKind pushes the file-kind filter into the store; disk
-	// backends iterate just the file nodes instead of every node.
-	for n := range r.graph.NodesByKind(graph.KindFile) {
-		dir := filepath.Dir(n.FilePath)
-		r.dirIndex[dir] = append(r.dirIndex[dir], n)
+	r.dirIndex = make(map[string][]graph.FileNodeIdentity, 128)
+	r.lastDirIndex = make(map[string][]graph.FileNodeIdentity, 128)
+	for file := range graph.FileNodeIdentitiesSeq(r.graph, nil) {
+		dir := filepath.Dir(file.FilePath)
+		r.dirIndex[dir] = append(r.dirIndex[dir], file)
 		last := lastPathComponent(dir)
 		if last != "" && last != dir {
-			r.lastDirIndex[last] = append(r.lastDirIndex[last], n)
+			r.lastDirIndex[last] = append(r.lastDirIndex[last], file)
 		}
 	}
 }
@@ -2023,7 +2017,7 @@ func (r *Resolver) cachedFindNodesByNameInRepo(name, repo string) []*graph.Node 
 // have no module path embedded in the ID.
 func (r *Resolver) buildDepModuleIndex() {
 	by := make(map[string][]depModuleEntry)
-	for n := range r.graph.NodesByKind(graph.KindContract) {
+	for n := range graph.RepoNodeIdentitiesSeq(r.graph, nil, graph.KindContract) {
 		if !strings.HasPrefix(n.ID, "dep::") {
 			continue
 		}
@@ -2033,7 +2027,7 @@ func (r *Resolver) buildDepModuleIndex() {
 		}
 		by[n.RepoPrefix] = append(by[n.RepoPrefix], depModuleEntry{
 			modulePath: mp,
-			node:       n,
+			nodeID:     n.ID,
 		})
 	}
 	for k := range by {
@@ -2049,16 +2043,15 @@ func (r *Resolver) clearDepModuleIndex() {
 	r.depModuleIndex = nil
 }
 
-// lookupDepModule returns the dep::<module> contract node whose
-// module path is a prefix of importPath, scoped to the caller's repo.
-// Returns nil if no dep declaration covers this import.
-func (r *Resolver) lookupDepModule(callerRepo, importPath string) *graph.Node {
+// lookupDepModule returns the dep::<module> contract ID whose module path is a
+// prefix of importPath, scoped to the caller's repo. Empty means no match.
+func (r *Resolver) lookupDepModule(callerRepo, importPath string) string {
 	for _, entry := range r.depModuleIndex[callerRepo] {
 		if importPath == entry.modulePath || strings.HasPrefix(importPath, entry.modulePath+"/") {
-			return entry.node
+			return entry.nodeID
 		}
 	}
-	return nil
+	return ""
 }
 
 // buildPassIndexes builds the four per-pass lookup indexes every
@@ -3097,18 +3090,16 @@ func (r *Resolver) resolveImport(e *graph.Edge, importPath string, stats *Resolv
 	// the first same-repo hit short-circuits the scan, preserving the
 	// pre-feature cost.
 	collectAll := r.workspaceMembers != nil
-	var sameRepo, crossRepoNode *graph.Node
-	var sameRepoAll []*graph.Node
-	consider := func(n *graph.Node) {
-		if n.Kind != graph.KindFile {
-			return
-		}
-		if callerRepo == "" || n.RepoPrefix == callerRepo {
-			if sameRepo == nil {
-				sameRepo = n
+	var sameRepo, crossRepoFile graph.FileNodeIdentity
+	var sameRepoFound, crossRepoFound bool
+	var sameRepoAll []graph.FileNodeIdentity
+	consider := func(file graph.FileNodeIdentity) {
+		if callerRepo == "" || file.RepoPrefix == callerRepo {
+			if !sameRepoFound {
+				sameRepo, sameRepoFound = file, true
 			}
 			if collectAll {
-				sameRepoAll = append(sameRepoAll, n)
+				sameRepoAll = append(sameRepoAll, file)
 			}
 			return
 		}
@@ -3117,34 +3108,34 @@ func (r *Resolver) resolveImport(e *graph.Edge, importPath string, stats *Resolv
 		// the last path component only, so without this gate an import
 		// of `.../tree-sitter-c/bindings/go` would resolve to whichever
 		// `*/bindings/go` directory sorts first.
-		if crossRepoNode == nil && dirMatchesImport(filepath.Dir(n.FilePath), importPath) {
-			crossRepoNode = n
+		if !crossRepoFound && dirMatchesImport(filepath.Dir(file.FilePath), importPath) {
+			crossRepoFile, crossRepoFound = file, true
 		}
 	}
 	// stop reports whether the candidate scan can short-circuit: once a
 	// same-repo hit is found and we are not collecting every candidate
 	// for workspace disambiguation.
-	stop := func() bool { return sameRepo != nil && !collectAll }
+	stop := func() bool { return sameRepoFound && !collectAll }
 	if r.dirIndex != nil {
-		for _, n := range r.dirIndex[importPath] {
-			consider(n)
+		for _, file := range r.dirIndex[importPath] {
+			consider(file)
 			if stop() {
 				break
 			}
 		}
-		if sameRepo == nil || collectAll {
-			for _, n := range r.lastDirIndex[lastPathComponent(importPath)] {
-				consider(n)
+		if !sameRepoFound || collectAll {
+			for _, file := range r.lastDirIndex[lastPathComponent(importPath)] {
+				consider(file)
 				if stop() {
 					break
 				}
 			}
 		}
 	} else {
-		for n := range r.graph.NodesByKind(graph.KindFile) {
-			dir := filepath.Dir(n.FilePath)
+		for file := range graph.FileNodeIdentitiesSeq(r.graph, nil) {
+			dir := filepath.Dir(file.FilePath)
 			if strings.HasSuffix(dir, lastPathComponent(importPath)) || dir == importPath {
-				consider(n)
+				consider(file)
 				if stop() {
 					break
 				}
@@ -3152,20 +3143,20 @@ func (r *Resolver) resolveImport(e *graph.Edge, importPath string, stats *Resolv
 		}
 	}
 
-	if sameRepo != nil {
+	if sameRepoFound {
 		// Name-collision tie-break: when several same-repo files match
 		// a bare import name, prefer the one in the importing file's
 		// own package-manager workspace.
-		if ws := r.preferSameWorkspaceFile(e.FilePath, sameRepoAll); ws != nil {
-			sameRepo = ws
+		if workspaceFile, ok := r.preferSameWorkspaceFile(e.FilePath, sameRepoAll); ok {
+			sameRepo = workspaceFile
 		}
 		e.To = sameRepo.ID
 		stats.Resolved++
 		return
 	}
-	if crossRepoNode != nil {
-		e.To = crossRepoNode.ID
-		if callerRepo != "" && crossRepoNode.RepoPrefix != "" && crossRepoNode.RepoPrefix != callerRepo {
+	if crossRepoFound {
+		e.To = crossRepoFile.ID
+		if callerRepo != "" && crossRepoFile.RepoPrefix != "" && crossRepoFile.RepoPrefix != callerRepo {
 			e.CrossRepo = true
 		}
 		stats.Resolved++
@@ -3177,8 +3168,8 @@ func (r *Resolver) resolveImport(e *graph.Edge, importPath string, stats *Resolv
 	// caller's go.mod — that bridge is what gives third-party imports
 	// like "github.com/foo/bar/sub/pkg" an incoming edge on the
 	// dep::github.com/foo/bar node.
-	if depNode := r.lookupDepModule(callerRepo, importPath); depNode != nil {
-		e.To = depNode.ID
+	if depNodeID := r.lookupDepModule(callerRepo, importPath); depNodeID != "" {
+		e.To = depNodeID
 		stats.Resolved++
 		return
 	}
@@ -4092,14 +4083,25 @@ func (r *Resolver) buildReachabilityIndex() {
 	// Seed with each indexed file's own directory, and memoise the per-file
 	// dir so filterByReachability never recomputes filepath.Dir per edge.
 	dirByPath := make(map[string]string)
-	for n := range r.graph.NodesByKind(graph.KindFile) {
-		dir := filepath.Dir(n.FilePath)
-		dirByPath[n.FilePath] = dir
-		addDir(n.ID, dir)
+	seedFile := func(file graph.FileNodeIdentity) {
+		dir := filepath.Dir(file.FilePath)
+		dirByPath[file.FilePath] = dir
+		addDir(file.ID, dir)
+	}
+	if r.dirIndex != nil {
+		for _, files := range r.dirIndex {
+			for _, file := range files {
+				seedFile(file)
+			}
+		}
+	} else {
+		for file := range graph.FileNodeIdentitiesSeq(r.graph, nil) {
+			seedFile(file)
+		}
 	}
 
 	// Materialise the import edges and batch-load the endpoints of the
-	// resolved ones (e.To naming a concrete node) in one GetNodesByIDs.
+	// resolved ones (e.To naming a concrete node) in one placement projection.
 	// A per-edge GetNode here is a query round-trip per import on a disk
 	// backend — the same batching buildImportClosure already applies.
 	// Unresolved / external targets never name an in-repo file node, so
@@ -4107,20 +4109,20 @@ func (r *Resolver) buildReachabilityIndex() {
 	// or not at all).
 	var imports []*graph.Edge
 	ids := make(map[string]struct{})
-	for e := range r.graph.EdgesByKind(graph.EdgeImports) {
+	for e := range graph.EdgesLightSeq(r.graph, graph.EdgeImports) {
 		imports = append(imports, e)
 		if e.To == "" || graph.IsUnresolvedTarget(e.To) || strings.HasPrefix(e.To, "external::") {
 			continue
 		}
 		ids[e.To] = struct{}{}
 	}
-	var nodes map[string]*graph.Node
+	var placements map[string]graph.NodePlacement
 	if len(ids) > 0 {
 		idList := make([]string, 0, len(ids))
 		for id := range ids {
 			idList = append(idList, id)
 		}
-		nodes = r.graph.GetNodesByIDs(idList)
+		placements = graph.NodePlacementsByIDs(r.graph, idList)
 	}
 
 	for _, e := range imports {
@@ -4138,8 +4140,8 @@ func (r *Resolver) buildReachabilityIndex() {
 		case strings.HasPrefix(e.To, "external::"):
 			// External / unindexed package — nothing to add.
 		default:
-			if n := nodes[e.To]; n != nil && n.Kind == graph.KindFile {
-				importedDir = filepath.Dir(n.FilePath)
+			if placement, ok := placements[e.To]; ok && placement.Kind == graph.KindFile {
+				importedDir = filepath.Dir(placement.FilePath)
 			}
 		}
 		if importedDir != "" {
@@ -4188,9 +4190,17 @@ func (r *Resolver) buildReachabilityIndexForPendingCached(
 	for id := range missingCallerSet {
 		missingCallerIDs = append(missingCallerIDs, id)
 	}
-	missingCallers := sources
-	if missingCallers == nil && len(missingCallerIDs) > 0 {
-		missingCallers = r.graph.GetNodesByIDs(missingCallerIDs)
+	missingCallerPaths := make(map[string]string, len(missingCallerIDs))
+	if sources != nil {
+		for _, id := range missingCallerIDs {
+			if source := sources[id]; source != nil {
+				missingCallerPaths[id] = source.FilePath
+			}
+		}
+	} else {
+		for id, placement := range graph.NodePlacementsByIDs(r.graph, missingCallerIDs) {
+			missingCallerPaths[id] = placement.FilePath
+		}
 	}
 	for _, edge := range pending {
 		if edge == nil {
@@ -4198,9 +4208,7 @@ func (r *Resolver) buildReachabilityIndexForPendingCached(
 		}
 		callerPath := edge.FilePath
 		if callerPath == "" {
-			if from := missingCallers[edge.From]; from != nil {
-				callerPath = from.FilePath
-			}
+			callerPath = missingCallerPaths[edge.From]
 		}
 		if callerPath != "" {
 			callerPaths[callerPath] = struct{}{}
@@ -4265,7 +4273,7 @@ func (r *Resolver) buildReachabilityIndexForPendingCached(
 	for id := range targetSet {
 		targetIDs = append(targetIDs, id)
 	}
-	targets := r.graph.GetNodesByIDs(targetIDs)
+	targets := graph.NodePlacementsByIDs(r.graph, targetIDs)
 
 	for _, filePath := range missingFiles {
 		stable := true
@@ -4289,7 +4297,7 @@ func (r *Resolver) buildReachabilityIndexForPendingCached(
 				stable = false
 			case strings.HasPrefix(targetID, "external::"):
 			default:
-				if target := targets[targetID]; target != nil && target.FilePath != "" {
+				if target, ok := targets[targetID]; ok && target.FilePath != "" {
 					importedDir = filepath.Dir(target.FilePath)
 					dirs[target.FilePath] = importedDir
 				}

--- a/internal/resolver/rust_aliases.go
+++ b/internal/resolver/rust_aliases.go
@@ -98,14 +98,20 @@ func addRustAlias[K comparable](aliases map[K]rustAliasEntry, key K, entry rustA
 // aliases at the crate boundary. It returns the canonical Rust path, whether an
 // alias was traversed, and false when the alias set is ambiguous or cyclic.
 func (idx *rustTypeAliasIndex) resolve(node *graph.Node, name string) (string, bool, bool) {
+	if node == nil {
+		name = normalizeRustUsePath(name)
+		return name, false, name != ""
+	}
+	return idx.resolveAt(node.RepoPrefix, node.FilePath, name)
+}
+
+func (idx *rustTypeAliasIndex) resolveAt(repo, file, name string) (string, bool, bool) {
 	name = normalizeRustUsePath(name)
-	if idx == nil || node == nil || name == "" {
+	if idx == nil || name == "" {
 		return name, false, name != ""
 	}
 
-	repo := node.RepoPrefix
-	crate := rustAliasCrate(node.FilePath)
-	file := node.FilePath
+	crate := rustAliasCrate(file)
 	current := name
 	changed := false
 	seen := make(map[string]struct{}, rustAliasDepthLimit)

--- a/internal/resolver/rust_bounds.go
+++ b/internal/resolver/rust_bounds.go
@@ -240,7 +240,7 @@ type rustTraitTargetEntry struct {
 type rustTraitTargetIndex struct {
 	exact    map[rustTraitTargetKey]rustTraitTargetEntry
 	basename map[rustTraitTargetKey]rustTraitTargetEntry
-	nodes    map[string]*graph.Node
+	nodes    map[string]graph.QualifiedNodeIdentity
 }
 
 func resolveRustTraitExtendsWithIndex(g graph.Store, idx *rustTraitTargetIndex, aliases *rustTypeAliasIndex) int {
@@ -252,8 +252,8 @@ func resolveRustTraitExtendsWithIndex(g graph.Store, idx *rustTraitTargetIndex, 
 		if edge == nil || !strings.HasPrefix(edge.To, "unresolved::extends::") {
 			continue
 		}
-		child := idx.nodes[edge.From]
-		if child == nil {
+		child, ok := idx.nodes[edge.From]
+		if !ok {
 			continue
 		}
 		raw := strings.TrimPrefix(edge.To, "unresolved::extends::")
@@ -263,13 +263,13 @@ func resolveRustTraitExtendsWithIndex(g graph.Store, idx *rustTraitTargetIndex, 
 			}
 		}
 		if aliases != nil {
-			resolvedPath, _, ok := aliases.resolve(child, raw)
+			resolvedPath, _, ok := aliases.resolveAt(child.RepoPrefix, child.FilePath, raw)
 			if !ok {
 				continue
 			}
 			raw = resolvedPath
 		}
-		target := idx.resolve(child, raw)
+		target := idx.resolveAt(child.FilePath, child.RepoPrefix, raw)
 		if target == "" || target == edge.From {
 			continue
 		}
@@ -294,10 +294,10 @@ func newRustTraitTargetIndex(g graph.Store) *rustTraitTargetIndex {
 	idx := &rustTraitTargetIndex{
 		exact:    make(map[rustTraitTargetKey]rustTraitTargetEntry),
 		basename: make(map[rustTraitTargetKey]rustTraitTargetEntry),
-		nodes:    make(map[string]*graph.Node),
+		nodes:    make(map[string]graph.QualifiedNodeIdentity),
 	}
-	for node := range g.NodesByKind(graph.KindInterface) {
-		if node == nil || node.Language != "rust" || node.ID == "" || node.Name == "" {
+	for node := range graph.QualifiedNodeIdentitiesSeq(g, graph.KindInterface) {
+		if node.Language != "rust" || node.ID == "" || node.Name == "" {
 			continue
 		}
 		crateRoot, module := rustTraitCrateAndModule(node.FilePath)
@@ -330,6 +330,14 @@ func newRustTraitTargetIndex(g graph.Store) *rustTraitTargetIndex {
 	return idx
 }
 
+func (idx *rustTraitTargetIndex) has(id string) bool {
+	if idx == nil {
+		return false
+	}
+	_, ok := idx.nodes[id]
+	return ok
+}
+
 func addRustTraitTarget(index map[rustTraitTargetKey]rustTraitTargetEntry, key rustTraitTargetKey, id string) {
 	if key.path == "" || id == "" {
 		return
@@ -346,17 +354,24 @@ func addRustTraitTarget(index map[rustTraitTargetKey]rustTraitTargetEntry, key r
 }
 
 func (idx *rustTraitTargetIndex) resolve(child *graph.Node, raw string) string {
-	if idx == nil || child == nil {
+	if child == nil {
+		return ""
+	}
+	return idx.resolveAt(child.FilePath, child.RepoPrefix, raw)
+}
+
+func (idx *rustTraitTargetIndex) resolveAt(filePath, repoPrefix, raw string) string {
+	if idx == nil {
 		return ""
 	}
 	path := normalizeRustTraitPath(raw)
 	if path == "" || strings.HasPrefix(strings.TrimSpace(raw), "?") {
 		return ""
 	}
-	crateRoot, module := rustTraitCrateAndModule(child.FilePath)
+	crateRoot, module := rustTraitCrateAndModule(filePath)
 	lookupExact := func(candidate string) string {
 		entry, ok := idx.exact[rustTraitTargetKey{
-			repo: child.RepoPrefix, crateRoot: crateRoot, path: candidate,
+			repo: repoPrefix, crateRoot: crateRoot, path: candidate,
 		}]
 		if !ok || entry.ambiguous {
 			return ""
@@ -400,7 +415,7 @@ func (idx *rustTraitTargetIndex) resolve(child *graph.Node, raw string) string {
 		return id
 	}
 	entry, ok := idx.basename[rustTraitTargetKey{
-		repo: child.RepoPrefix, crateRoot: crateRoot, path: path,
+		repo: repoPrefix, crateRoot: crateRoot, path: path,
 	}]
 	if !ok || entry.ambiguous {
 		return ""
@@ -470,8 +485,8 @@ func (idx *rustTraitTargetIndex) ownerAliases(id string) []string {
 	if idx == nil {
 		return nil
 	}
-	node := idx.nodes[id]
-	if node == nil {
+	node, ok := idx.nodes[id]
+	if !ok {
 		return nil
 	}
 	crateRoot, module := rustTraitCrateAndModule(node.FilePath)
@@ -514,8 +529,8 @@ func inheritRustTraitMethods(g graph.Store, scope *rustScopeIndex, targets *rust
 
 	directByTrait := make(map[string][]*graph.Node)
 	assigned := make(map[string]bool)
-	for edge := range g.EdgesByKind(graph.EdgeMemberOf) {
-		if edge == nil || targets.nodes[edge.To] == nil {
+	for edge := range graph.EdgesLightSeq(g, graph.EdgeMemberOf) {
+		if edge == nil || !targets.has(edge.To) {
 			continue
 		}
 		method := methodByID[edge.From]
@@ -541,8 +556,8 @@ func inheritRustTraitMethods(g graph.Store, scope *rustScopeIndex, targets *rust
 	}
 
 	supers := make(map[string][]string)
-	for edge := range g.EdgesByKind(graph.EdgeExtends) {
-		if edge == nil || edge.From == edge.To || targets.nodes[edge.From] == nil || targets.nodes[edge.To] == nil {
+	for edge := range graph.EdgesLightSeq(g, graph.EdgeExtends) {
+		if edge == nil || edge.From == edge.To || !targets.has(edge.From) || !targets.has(edge.To) {
 			continue
 		}
 		supers[edge.From] = append(supers[edge.From], edge.To)

--- a/internal/resolver/rust_bounds_test.go
+++ b/internal/resolver/rust_bounds_test.go
@@ -145,7 +145,10 @@ func TestRustTraitTargetIndexConservativeResolution(t *testing.T) {
 	idx := &rustTraitTargetIndex{
 		exact:    make(map[rustTraitTargetKey]rustTraitTargetEntry),
 		basename: make(map[rustTraitTargetKey]rustTraitTargetEntry),
-		nodes:    map[string]*graph.Node{child.ID: child},
+		nodes: map[string]graph.QualifiedNodeIdentity{child.ID: {
+			ID: child.ID, Name: child.Name, Language: child.Language,
+			FilePath: child.FilePath, RepoPrefix: child.RepoPrefix,
+		}},
 	}
 	addRustTraitTarget(idx.exact, rustTraitTargetKey{repo: repo, crateRoot: root, path: "crate::nested::child::Local"}, "local-id")
 	addRustTraitTarget(idx.exact, rustTraitTargetKey{repo: repo, crateRoot: root, path: "crate::nested::Parent"}, "parent-id")

--- a/internal/resolver/rust_module_imports.go
+++ b/internal/resolver/rust_module_imports.go
@@ -46,9 +46,9 @@ func resolveRustModuleImports(g graph.Store) int {
 	}
 
 	fileIDs := make(map[string]struct{}, 1024)
-	for n := range g.NodesByKind(graph.KindFile) {
-		if n != nil && n.ID != "" {
-			fileIDs[n.ID] = struct{}{}
+	for _, id := range graph.NodeIDsForKinds(g, graph.KindFile) {
+		if id != "" {
+			fileIDs[id] = struct{}{}
 		}
 	}
 

--- a/internal/resolver/spring_event_calls.go
+++ b/internal/resolver/spring_event_calls.go
@@ -136,7 +136,7 @@ func springListenersFor(evType string, byType map[string][]*graph.Node, parents 
 func springTypeParents(g graph.Store) map[string][]string {
 	parents := map[string][]string{}
 	add := func(kind graph.EdgeKind) {
-		for e := range g.EdgesByKind(kind) {
+		for e := range graph.EdgesLightSeq(g, kind) {
 			if e == nil || e.From == "" || e.To == "" {
 				continue
 			}

--- a/internal/resolver/sveltekit_load.go
+++ b/internal/resolver/sveltekit_load.go
@@ -25,9 +25,10 @@ func ResolveSvelteKitLoad(g graph.Store) int {
 	// Per route dir: the page node and the server module file, plus the load
 	// function declared in the server module.
 	type routeDir struct {
-		pageNode     *graph.Node
-		serverFile   *graph.Node
-		serverLoadID string
+		pageNode      *graph.Node
+		serverFile    graph.FileNodeIdentity
+		hasServerFile bool
+		serverLoadID  string
 	}
 	dirs := map[string]*routeDir{}
 	get := func(dir string) *routeDir {
@@ -38,13 +39,12 @@ func ResolveSvelteKitLoad(g graph.Store) int {
 	}
 
 	// First pass over file + component nodes to populate the page / server file.
-	for n := range g.NodesByKind(graph.KindFile) {
-		if n == nil {
-			continue
-		}
-		base, dir := pathBaseDir(n.FilePath)
+	for file := range graph.FileNodeIdentitiesSeq(g, nil) {
+		base, dir := pathBaseDir(file.FilePath)
 		if isSvelteKitServerFile(base) {
-			get(dir).serverFile = n
+			route := get(dir)
+			route.serverFile = file
+			route.hasServerFile = true
 		}
 	}
 	for _, kind := range []graph.NodeKind{graph.KindType, graph.KindFunction} {
@@ -79,17 +79,15 @@ func ResolveSvelteKitLoad(g graph.Store) int {
 		}
 		// Prefer the explicit load function; fall back to the server module file.
 		to := rd.serverLoadID
-		var toNode *graph.Node
+		sameBoundary := false
 		if to != "" {
-			toNode = g.GetNode(to)
-		} else if rd.serverFile != nil {
+			toNode := g.GetNode(to)
+			sameBoundary = sameDispatchBoundary(rd.pageNode, toNode)
+		} else if rd.hasServerFile {
 			to = rd.serverFile.ID
-			toNode = rd.serverFile
+			sameBoundary = rd.pageNode.WorkspaceID == rd.serverFile.WorkspaceID
 		}
-		if to == "" || toNode == nil {
-			continue
-		}
-		if !sameDispatchBoundary(rd.pageNode, toNode) {
+		if to == "" || !sameBoundary {
 			continue
 		}
 		batch = append(batch, &graph.Edge{

--- a/internal/resolver/workspace_membership.go
+++ b/internal/resolver/workspace_membership.go
@@ -49,41 +49,39 @@ func (cr *CrossRepoResolver) SetWorkspaceMembership(fn WorkspaceMembership) {
 // when an import of a bare name (`logger`) matches a directory in two
 // different workspace members, the member that belongs to the
 // importer's own workspace wins.
-func (r *Resolver) preferSameWorkspaceFile(callerFile string, candidates []*graph.Node) *graph.Node {
+func (r *Resolver) preferSameWorkspaceFile(callerFile string, candidates []graph.FileNodeIdentity) (graph.FileNodeIdentity, bool) {
 	return pickSameWorkspaceFile(r.workspaceMembers, callerFile, candidates)
 }
 
 // preferSameWorkspaceFile is the CrossRepoResolver counterpart — same
 // rule, same contract.
-func (cr *CrossRepoResolver) preferSameWorkspaceFile(callerFile string, candidates []*graph.Node) *graph.Node {
+func (cr *CrossRepoResolver) preferSameWorkspaceFile(callerFile string, candidates []graph.FileNodeIdentity) (graph.FileNodeIdentity, bool) {
 	return pickSameWorkspaceFile(cr.workspaceMembers, callerFile, candidates)
 }
 
 // pickSameWorkspaceFile is the shared body of the two
 // preferSameWorkspaceFile methods.
-func pickSameWorkspaceFile(fn WorkspaceMembership, callerFile string, candidates []*graph.Node) *graph.Node {
+func pickSameWorkspaceFile(fn WorkspaceMembership, callerFile string, candidates []graph.FileNodeIdentity) (graph.FileNodeIdentity, bool) {
 	if fn == nil || callerFile == "" || len(candidates) < 2 {
-		return nil
+		return graph.FileNodeIdentity{}, false
 	}
 	callerWS := fn(callerFile)
 	if callerWS == "" {
-		return nil
+		return graph.FileNodeIdentity{}, false
 	}
-	var match *graph.Node
-	for _, n := range candidates {
-		if n == nil || n.Kind != graph.KindFile {
+	var match graph.FileNodeIdentity
+	found := false
+	for _, file := range candidates {
+		if fn(file.FilePath) != callerWS {
 			continue
 		}
-		if fn(n.FilePath) != callerWS {
-			continue
-		}
-		if match != nil {
+		if found {
 			// More than one candidate sits in the importer's
 			// workspace — the workspace does not disambiguate, so
 			// defer to the caller's existing tie-break.
-			return nil
+			return graph.FileNodeIdentity{}, false
 		}
-		match = n
+		match, found = file, true
 	}
-	return match
+	return match, found
 }

--- a/internal/resolver/workspace_membership_test.go
+++ b/internal/resolver/workspace_membership_test.go
@@ -114,24 +114,24 @@ func TestResolveImport_WorkspaceLookupNoMatchKeepsFirstHit(t *testing.T) {
 
 // TestPickSameWorkspaceFile_AmbiguousLeavesTieBreak pins the unit
 // contract: when several candidates share the importer's workspace the
-// helper returns nil so the caller's existing tie-break decides.
+// helper reports no unique match so the caller's existing tie-break decides.
 func TestPickSameWorkspaceFile_AmbiguousLeavesTieBreak(t *testing.T) {
 	caller := "packages/app/src/main.ts"
-	candidates := []*graph.Node{
-		{ID: "packages/app/a/logger.ts", Kind: graph.KindFile, FilePath: "packages/app/a/logger.ts"},
-		{ID: "packages/app/b/logger.ts", Kind: graph.KindFile, FilePath: "packages/app/b/logger.ts"},
+	candidates := []graph.FileNodeIdentity{
+		{ID: "packages/app/a/logger.ts", FilePath: "packages/app/a/logger.ts"},
+		{ID: "packages/app/b/logger.ts", FilePath: "packages/app/b/logger.ts"},
 	}
-	if got := pickSameWorkspaceFile(memberOf, caller, candidates); got != nil {
+	if got, ok := pickSameWorkspaceFile(memberOf, caller, candidates); ok {
 		t.Errorf("two candidates in the importer's workspace should be ambiguous, got %q", got.ID)
 	}
 
 	// A single same-workspace candidate among decoys resolves cleanly.
-	candidates = []*graph.Node{
-		{ID: "packages/admin/logger.ts", Kind: graph.KindFile, FilePath: "packages/admin/logger.ts"},
-		{ID: "packages/app/logger.ts", Kind: graph.KindFile, FilePath: "packages/app/logger.ts"},
+	candidates = []graph.FileNodeIdentity{
+		{ID: "packages/admin/logger.ts", FilePath: "packages/admin/logger.ts"},
+		{ID: "packages/app/logger.ts", FilePath: "packages/app/logger.ts"},
 	}
-	got := pickSameWorkspaceFile(memberOf, caller, candidates)
-	if got == nil || got.ID != "packages/app/logger.ts" {
+	got, ok := pickSameWorkspaceFile(memberOf, caller, candidates)
+	if !ok || got.ID != "packages/app/logger.ts" {
 		t.Errorf("expected the packages/app candidate, got %v", got)
 	}
 }


### PR DESCRIPTION
## Summary

- add typed fixed-column node projections with Graph fallbacks and SQLite keyset paging
- preserve global ID ordering for multi-repository scopes with bounded per-repository streams merged in Go, using nodes_by_repo_kind without temporary sorts
- migrate resolver directory, dependency, reachability, binding, framework-facade, and structural edge scans away from full node or edge hydration
- add metadata-corruption, high-water, page-boundary, cursor re-entry, query-plan, fallback, race, and allocation benchmark coverage

## Memory and performance

On the included 2,048-row fixture with 64 MiB of residual metadata:

- scope binding: about 575 MiB to 0.36 MiB allocated per operation, roughly 7x faster
- file identity: about 575 MiB to 0.42 MiB allocated per operation, roughly 9x faster

Both projected paths reduce allocated bytes by more than 99.9% while keeping cursor callbacks safe for store re-entry.

## Verification

- go test -count=1 ./internal/graph ./internal/graph/store_sqlite ./internal/resolver
- focused projection race tests plus full internal/graph and internal/resolver race tests
- golangci-lint run ./internal/graph/... ./internal/resolver/...
- go test -count=1 ./...
  - every functional package passed; the cold-index wall-clock gate missed once by 0.17 ms, then passed once and passed three consecutive reruns
- projection benchmark with benchmem
