### PR TITLE
perf: bound attribution edge rewrites

### DIFF
--- a/internal/graph/edge_kind_batches.go
+++ b/internal/graph/edge_kind_batches.go
@@ -1,0 +1,162 @@
+package graph
+
+// EdgesByKindsBatchScanner is an optional capability for mutation passes that
+// need full edge payloads in bounded pages. Implementations must close the
+// read cursor before invoking yield. Backends whose rewrites insert new rows
+// should also freeze a scan high-water so those rows cannot re-enter the same
+// pass.
+type EdgesByKindsBatchScanner interface {
+	ScanEdgesByKindsBatched(kinds []EdgeKind, batchSize int, yield func([]*Edge) bool)
+}
+
+var _ EdgesByKindsBatchScanner = (*Graph)(nil)
+
+// ScanEdgesByKindsBatched is the mutation-stable in-memory implementation.
+// It snapshots source bucket names before visiting a shard and remembers each
+// yielded pointer. A callback may therefore reindex an edge into a bucket or
+// shard that has not yet been visited without causing a second yield. Only one
+// source bucket and one callback batch of edge pointers are materialized at a
+// time; the seen set is pointer-only and does not duplicate edge payloads the
+// graph already owns.
+func (g *Graph) ScanEdgesByKindsBatched(
+	kinds []EdgeKind,
+	batchSize int,
+	yield func([]*Edge) bool,
+) {
+	if g == nil || yield == nil {
+		return
+	}
+	kinds = normalizedEdgeBatchKinds(kinds)
+	if len(kinds) == 0 {
+		return
+	}
+	if batchSize <= 0 {
+		batchSize = 1
+	}
+	kindSet := make(map[EdgeKind]struct{}, len(kinds))
+	for _, kind := range kinds {
+		kindSet[kind] = struct{}{}
+	}
+
+	seen := make(map[*Edge]struct{})
+	batch := make([]*Edge, 0, batchSize)
+	flush := func() bool {
+		if len(batch) == 0 {
+			return true
+		}
+		keepGoing := yield(batch)
+		batch = make([]*Edge, 0, batchSize)
+		return keepGoing
+	}
+
+	for _, shard := range g.shards {
+		shard.mu.RLock()
+		sourceIDs := make([]string, 0, len(shard.outEdges))
+		for sourceID := range shard.outEdges {
+			sourceIDs = append(sourceIDs, sourceID)
+		}
+		shard.mu.RUnlock()
+
+		for _, sourceID := range sourceIDs {
+			shard.mu.RLock()
+			edges := append([]*Edge(nil), shard.outEdges[sourceID]...)
+			shard.mu.RUnlock()
+			for _, edge := range edges {
+				if edge == nil {
+					continue
+				}
+				if _, duplicate := seen[edge]; duplicate {
+					continue
+				}
+				if _, selected := kindSet[edge.Kind]; !selected {
+					continue
+				}
+				seen[edge] = struct{}{}
+				batch = append(batch, edge)
+				if len(batch) == batchSize && !flush() {
+					return
+				}
+			}
+		}
+	}
+	flush()
+}
+
+// ScanEdgesByKindsBatched selects the strong backend capability when present
+// and otherwise batches the existing kind-filtered iterator. Empty and blank
+// kind sets do no work; duplicate kinds never duplicate rows. A non-positive
+// batch size is normalized to one.
+func ScanEdgesByKindsBatched(
+	s Store,
+	kinds []EdgeKind,
+	batchSize int,
+	yield func([]*Edge) bool,
+) {
+	if s == nil || yield == nil {
+		return
+	}
+	kinds = normalizedEdgeBatchKinds(kinds)
+	if len(kinds) == 0 {
+		return
+	}
+	if batchSize <= 0 {
+		batchSize = 1
+	}
+	if scanner, ok := s.(EdgesByKindsBatchScanner); ok {
+		scanner.ScanEdgesByKindsBatched(kinds, batchSize, yield)
+		return
+	}
+
+	batch := make([]*Edge, 0, batchSize)
+	keepGoing := true
+	flush := func() {
+		if len(batch) == 0 || !keepGoing {
+			return
+		}
+		keepGoing = yield(batch)
+		batch = make([]*Edge, 0, batchSize)
+	}
+	appendEdge := func(edge *Edge) bool {
+		if edge == nil {
+			return true
+		}
+		batch = append(batch, edge)
+		if len(batch) == batchSize {
+			flush()
+		}
+		return keepGoing
+	}
+
+	if scanner, ok := s.(EdgesByKindsScanner); ok {
+		for edge := range scanner.EdgesByKinds(kinds) {
+			if !appendEdge(edge) {
+				return
+			}
+		}
+	} else {
+		for _, kind := range kinds {
+			for edge := range s.EdgesByKind(kind) {
+				if !appendEdge(edge) {
+					return
+				}
+			}
+		}
+	}
+	flush()
+}
+
+func normalizedEdgeBatchKinds(kinds []EdgeKind) []EdgeKind {
+	seen := make(map[EdgeKind]struct{}, len(kinds))
+	uniq := make([]EdgeKind, 0, len(kinds))
+	for _, kind := range kinds {
+		if kind == "" {
+			continue
+		}
+		if _, duplicate := seen[kind]; duplicate {
+			continue
+		}
+		seen[kind] = struct{}{}
+		uniq = append(uniq, kind)
+	}
+	return uniq
+}

--- a/internal/graph/edge_kind_batches_mutation_test.go
+++ b/internal/graph/edge_kind_batches_mutation_test.go
@@ -1,0 +1,60 @@
+package graph
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestGraphScanEdgesByKindsBatchedYieldsCrossShardMoveOnce(t *testing.T) {
+	g := newWithShardCount(4)
+	oldFrom := sourceIDForShard(t, g, 0)
+	newFrom := sourceIDForShard(t, g, g.shardCount-1)
+	edge := &Edge{
+		From: oldFrom, To: "target", Kind: EdgeReturnsTo,
+		FilePath: "repo/file.go", Line: 17,
+	}
+	g.AddEdge(edge)
+
+	visits := 0
+	ScanEdgesByKindsBatched(g, []EdgeKind{EdgeReturnsTo}, 1, func(batch []*Edge) bool {
+		if len(batch) != 1 || batch[0] != edge {
+			t.Fatalf("batch = %#v, want the original edge", batch)
+		}
+		visits++
+		previousFrom := edge.From
+		edge.From = newFrom
+		g.ReindexEdges([]EdgeReindex{{
+			Edge:            edge,
+			OldFrom:         previousFrom,
+			OldTo:           edge.To,
+			OldKind:         edge.Kind,
+			OldFilePath:     edge.FilePath,
+			OldLine:         edge.Line,
+			RefreshIdentity: true,
+		}})
+		return true
+	})
+
+	if visits != 1 {
+		t.Fatalf("edge visited %d times after moving from shard 0 to shard %d; want exactly once", visits, g.shardCount-1)
+	}
+	if got := g.GetOutEdges(oldFrom); len(got) != 0 {
+		t.Fatalf("old source still has %d outgoing edges", len(got))
+	}
+	got := g.GetOutEdges(newFrom)
+	if len(got) != 1 || got[0] != edge {
+		t.Fatalf("new source outgoing edges = %#v, want the moved edge", got)
+	}
+}
+
+func sourceIDForShard(t *testing.T, g *Graph, want int) string {
+	t.Helper()
+	for i := 0; i < 10_000; i++ {
+		candidate := fmt.Sprintf("source-%d", i)
+		if g.shardIdx(candidate) == want {
+			return candidate
+		}
+	}
+	t.Fatalf("could not find source id for shard %d", want)
+	return ""
+}

--- a/internal/graph/edge_kind_batches_test.go
+++ b/internal/graph/edge_kind_batches_test.go
@@ -1,0 +1,110 @@
+package graph
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestScanEdgesByKindsBatchedFallbackBoundsAndDeduplicates(t *testing.T) {
+	g := New()
+	var want []string
+	for i := 0; i < 11; i++ {
+		kind := EdgeCalls
+		if i%2 == 0 {
+			kind = EdgeReads
+		}
+		edge := &Edge{
+			From: fmt.Sprintf("from-%02d", i), To: fmt.Sprintf("to-%02d", i),
+			Kind: kind, FilePath: "repo/file.go", Line: i + 1,
+		}
+		g.AddEdge(edge)
+		want = append(want, edge.From)
+	}
+
+	var got []string
+	var batchSizes []int
+	ScanEdgesByKindsBatched(g, []EdgeKind{EdgeReads, "", EdgeCalls, EdgeReads}, 3, func(batch []*Edge) bool {
+		batchSizes = append(batchSizes, len(batch))
+		for _, edge := range batch {
+			got = append(got, edge.From)
+		}
+		return true
+	})
+	if len(got) != len(want) {
+		t.Fatalf("visited %d edges, want %d: %v", len(got), len(want), got)
+	}
+	seen := make(map[string]int, len(got))
+	for _, id := range got {
+		seen[id]++
+	}
+	for _, id := range want {
+		if seen[id] != 1 {
+			t.Fatalf("edge %q visited %d times", id, seen[id])
+		}
+	}
+	for _, size := range batchSizes {
+		if size < 1 || size > 3 {
+			t.Fatalf("batch size = %d, want 1..3", size)
+		}
+	}
+}
+
+func TestScanEdgesByKindsBatchedFallbackHonorsEarlyStopAndMinimumSize(t *testing.T) {
+	g := New()
+	for i := 0; i < 3; i++ {
+		g.AddEdge(&Edge{
+			From: fmt.Sprintf("from-%d", i), To: fmt.Sprintf("to-%d", i),
+			Kind: EdgeReads, FilePath: "repo/file.go", Line: i + 1,
+		})
+	}
+	calls := 0
+	ScanEdgesByKindsBatched(g, []EdgeKind{EdgeReads}, 0, func(batch []*Edge) bool {
+		calls++
+		if len(batch) != 1 {
+			t.Fatalf("batch size = %d, want 1", len(batch))
+		}
+		return false
+	})
+	if calls != 1 {
+		t.Fatalf("callback calls = %d, want 1", calls)
+	}
+
+	ScanEdgesByKindsBatched(g, nil, 2, func([]*Edge) bool {
+		t.Fatal("empty kind set invoked callback")
+		return false
+	})
+}
+
+type recordingEdgeBatchStore struct {
+	Store
+	kinds     []EdgeKind
+	batchSize int
+	called    bool
+}
+
+func (s *recordingEdgeBatchStore) ScanEdgesByKindsBatched(
+	kinds []EdgeKind,
+	batchSize int,
+	yield func([]*Edge) bool,
+) {
+	s.called = true
+	s.kinds = append([]EdgeKind(nil), kinds...)
+	s.batchSize = batchSize
+	yield([]*Edge{{From: "from", To: "to", Kind: EdgeReads}})
+}
+
+func TestScanEdgesByKindsBatchedPrefersCapability(t *testing.T) {
+	store := &recordingEdgeBatchStore{}
+	calls := 0
+	ScanEdgesByKindsBatched(store, []EdgeKind{EdgeReads, "", EdgeReads}, 7, func(batch []*Edge) bool {
+		calls++
+		return len(batch) == 1
+	})
+	if !store.called || calls != 1 {
+		t.Fatalf("capability called=%v callbacks=%d", store.called, calls)
+	}
+	if !reflect.DeepEqual(store.kinds, []EdgeKind{EdgeReads}) || store.batchSize != 7 {
+		t.Fatalf("capability args kinds=%v batchSize=%d", store.kinds, store.batchSize)
+	}
+}

--- a/internal/graph/store_sqlite/dataflow_batch.go
+++ b/internal/graph/store_sqlite/dataflow_batch.go
@@ -7,32 +7,47 @@ import (
 	"github.com/zzet/gortex/internal/graph"
 )
 
-const maxDataflowScanBatch = 4096
+const maxEdgeKindScanBatch = 4096
 
-// ScanDataflowEdgesBatched walks the two dataflow rewrite kinds through
-// bounded row-id pages. The high-water mark is captured before the first
-// page, so delete+insert identity rewrites cannot make a just-rewritten row
-// reappear later in the same pass. Each cursor is closed before yield runs,
-// allowing the callback to issue batched writes even with a one-connection
-// pool or an active pinned bulk connection.
+// ScanDataflowEdgesBatched retains the original dataflow-specific capability
+// while delegating to the generic bounded kind scanner.
 func (s *Store) ScanDataflowEdgesBatched(batchSize int, yield func([]*graph.Edge) bool) {
+	s.ScanEdgesByKindsBatched(
+		[]graph.EdgeKind{graph.EdgeArgOf, graph.EdgeReturnsTo}, batchSize, yield,
+	)
+}
+
+// ScanEdgesByKindsBatched walks full edge rows through bounded row-id pages.
+// The high-water mark is captured before the first page, so delete+insert
+// identity rewrites cannot make a just-rewritten row reappear in the same
+// pass. Each cursor is closed before yield runs, allowing the callback to
+// write even with a one-connection pool or an active pinned bulk connection.
+func (s *Store) ScanEdgesByKindsBatched(
+	kinds []graph.EdgeKind,
+	batchSize int,
+	yield func([]*graph.Edge) bool,
+) {
 	if yield == nil {
+		return
+	}
+	kindValues := sqliteEdgeBatchKinds(kinds)
+	if len(kindValues) == 0 {
 		return
 	}
 	if batchSize <= 0 {
 		batchSize = 1
 	}
-	if batchSize > maxDataflowScanBatch {
-		batchSize = maxDataflowScanBatch
+	if batchSize > maxEdgeKindScanBatch {
+		batchSize = maxEdgeKindScanBatch
 	}
-	highWater, ok := s.dataflowEdgeHighWater()
+	highWater, ok := s.edgeKindHighWater(kindValues)
 	if !ok || highWater == 0 {
 		return
 	}
 
 	var after int64
 	for after < highWater {
-		edges, next, ok := s.dataflowEdgePage(after, highWater, batchSize)
+		edges, next, ok := s.edgeKindPage(kindValues, after, highWater, batchSize)
 		if !ok || len(edges) == 0 || next <= after {
 			return
 		}
@@ -43,13 +58,12 @@ func (s *Store) ScanDataflowEdgesBatched(batchSize int, yield func([]*graph.Edge
 	}
 }
 
-func (s *Store) dataflowEdgeHighWater() (int64, bool) {
+func (s *Store) edgeKindHighWater(kinds []string) (int64, bool) {
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
-	rows, err := s.queryActiveWriteLocked(context.Background(), `
-		SELECT COALESCE(MAX(id), 0)
-		FROM edges
-		WHERE kind IN (?, ?)`, string(graph.EdgeArgOf), string(graph.EdgeReturnsTo))
+	query := `SELECT COALESCE(MAX(id), 0) FROM edges WHERE kind IN (` +
+		inPlaceholders(len(kinds)) + `)`
+	rows, err := s.queryActiveWriteLocked(context.Background(), query, toAnyArgs(kinds)...)
 	if err != nil {
 		panicOnFatal(err)
 		return 0, false
@@ -70,17 +84,25 @@ func (s *Store) dataflowEdgeHighWater() (int64, bool) {
 	return highWater, true
 }
 
-func (s *Store) dataflowEdgePage(after, highWater int64, limit int) ([]*graph.Edge, int64, bool) {
+func (s *Store) edgeKindPage(
+	kinds []string,
+	after, highWater int64,
+	limit int,
+) ([]*graph.Edge, int64, bool) {
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
-	rows, err := s.queryActiveWriteLocked(context.Background(), `
-		SELECT id, from_id, to_id, kind, file_path, line,
-		       confidence, confidence_label, origin, tier, cross_repo,
-		       meta, resolve_terminal, resolve_terminal_reason, semantic_source
-		FROM edges NOT INDEXED
-		WHERE id > ? AND id <= ? AND kind IN (?, ?)
-		ORDER BY id
-		LIMIT ?`, after, highWater, string(graph.EdgeArgOf), string(graph.EdgeReturnsTo), limit)
+	query := `SELECT id, from_id, to_id, kind, file_path, line,
+	       confidence, confidence_label, origin, tier, cross_repo,
+	       meta, resolve_terminal, resolve_terminal_reason, semantic_source
+	FROM edges NOT INDEXED
+	WHERE id > ? AND id <= ? AND kind IN (` + inPlaceholders(len(kinds)) + `)
+	ORDER BY id
+	LIMIT ?`
+	args := make([]any, 0, len(kinds)+3)
+	args = append(args, after, highWater)
+	args = append(args, toAnyArgs(kinds)...)
+	args = append(args, limit)
+	rows, err := s.queryActiveWriteLocked(context.Background(), query, args...)
 	if err != nil {
 		panicOnFatal(err)
 		return nil, after, false
@@ -90,7 +112,7 @@ func (s *Store) dataflowEdgePage(after, highWater int64, limit int) ([]*graph.Ed
 	edges := make([]*graph.Edge, 0, limit)
 	next := after
 	for rows.Next() {
-		rowID, edge, err := scanDataflowEdge(rows)
+		rowID, edge, err := scanBatchedEdge(rows)
 		if err != nil {
 			panicOnFatal(err)
 			return nil, after, false
@@ -109,7 +131,7 @@ func (s *Store) dataflowEdgePage(after, highWater int64, limit int) ([]*graph.Ed
 	return edges, next, true
 }
 
-func scanDataflowEdge(scanner interface{ Scan(...any) error }) (int64, *graph.Edge, error) {
+func scanBatchedEdge(scanner interface{ Scan(...any) error }) (int64, *graph.Edge, error) {
 	var (
 		rowID     int64
 		edge      graph.Edge
@@ -135,6 +157,24 @@ func scanDataflowEdge(scanner interface{ Scan(...any) error }) (int64, *graph.Ed
 	restorePromotedEdgeMeta(&edge, promoted)
 	return rowID, &edge, nil
 }
+
+func sqliteEdgeBatchKinds(kinds []graph.EdgeKind) []string {
+	seen := make(map[graph.EdgeKind]struct{}, len(kinds))
+	values := make([]string, 0, len(kinds))
+	for _, kind := range kinds {
+		if kind == "" {
+			continue
+		}
+		if _, duplicate := seen[kind]; duplicate {
+			continue
+		}
+		seen[kind] = struct{}{}
+		values = append(values, string(kind))
+	}
+	return values
+}
+
+var _ graph.EdgesByKindsBatchScanner = (*Store)(nil)
 
 // GetDataflowParamEdgesByOwnerIDs fetches only param_of edges for a bounded
 // callee batch. It avoids both per-callee incoming queries and decoding an

--- a/internal/graph/store_sqlite/edge_kind_batch_limit_test.go
+++ b/internal/graph/store_sqlite/edge_kind_batch_limit_test.go
@@ -1,0 +1,36 @@
+package store_sqlite
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestScanEdgesByKindsBatchedCapsRequestedPageSize(t *testing.T) {
+	store := openEdgeKindBatchTestStore(t)
+	edges := make([]*graph.Edge, 0, maxEdgeKindScanBatch+1)
+	for i := 0; i < maxEdgeKindScanBatch+1; i++ {
+		edges = append(edges, &graph.Edge{
+			From: fmt.Sprintf("from-%05d", i), To: fmt.Sprintf("to-%05d", i),
+			Kind: graph.EdgeReads, FilePath: "repo/file.go", Line: i + 1,
+		})
+	}
+	store.AddBatch(nil, edges)
+
+	total := 0
+	maxPage := 0
+	store.ScanEdgesByKindsBatched([]graph.EdgeKind{graph.EdgeReads}, maxEdgeKindScanBatch*2, func(page []*graph.Edge) bool {
+		total += len(page)
+		if len(page) > maxPage {
+			maxPage = len(page)
+		}
+		return true
+	})
+	if total != len(edges) {
+		t.Fatalf("visited %d edges, want %d", total, len(edges))
+	}
+	if maxPage != maxEdgeKindScanBatch {
+		t.Fatalf("largest page = %d, want %d", maxPage, maxEdgeKindScanBatch)
+	}
+}

--- a/internal/graph/store_sqlite/edge_kind_batches_test.go
+++ b/internal/graph/store_sqlite/edge_kind_batches_test.go
@@ -1,0 +1,119 @@
+package store_sqlite
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func openEdgeKindBatchTestStore(t *testing.T) *Store {
+	t.Helper()
+	store, err := Open(filepath.Join(t.TempDir(), "graph.sqlite"))
+	if err != nil {
+		t.Fatalf("open SQLite store: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("close SQLite store: %v", err)
+		}
+	})
+	return store
+}
+
+func TestScanEdgesByKindsBatchedBoundsRewritesAndFreezesHighWater(t *testing.T) {
+	store := openEdgeKindBatchTestStore(t)
+	store.db.SetMaxOpenConns(1)
+	store.db.SetMaxIdleConns(1)
+
+	const selectedCount = 7
+	edges := make([]*graph.Edge, 0, selectedCount+2)
+	for i := 0; i < selectedCount; i++ {
+		kind := graph.EdgeReads
+		if i%2 != 0 {
+			kind = graph.EdgeReferences
+		}
+		edges = append(edges, &graph.Edge{
+			From: fmt.Sprintf("from-%02d", i), To: fmt.Sprintf("unresolved::name-%02d", i),
+			Kind: kind, FilePath: "repo/file.go", Line: i + 1,
+			Confidence: 0.75, ConfidenceLabel: "high", Origin: "parser", Tier: "syntax",
+			CrossRepo: true,
+			Meta: map[string]any{
+				"custom": "value", "resolve_terminal": true,
+				"resolve_terminal_reason": "fixture", "semantic_source": "test",
+			},
+		})
+	}
+	edges = append(edges,
+		&graph.Edge{From: "ignored-1", To: "target", Kind: graph.EdgeCalls, FilePath: "repo/file.go", Line: 100},
+		&graph.Edge{From: "ignored-2", To: "target", Kind: graph.EdgeImports, FilePath: "repo/file.go", Line: 101},
+	)
+	store.AddBatch(nil, edges)
+
+	seen := make(map[string]int, selectedCount)
+	var batchSizes []int
+	store.ScanEdgesByKindsBatched(
+		[]graph.EdgeKind{graph.EdgeReads, "", graph.EdgeReferences, graph.EdgeReads},
+		3,
+		func(page []*graph.Edge) bool {
+			if inUse := store.db.Stats().InUse; inUse != 0 {
+				t.Fatalf("yield retained %d read connection(s)", inUse)
+			}
+			batchSizes = append(batchSizes, len(page))
+			rewrites := make([]graph.EdgeReindex, 0, len(page))
+			for _, edge := range page {
+				seen[edge.From]++
+				if edge.Confidence != 0.75 || edge.ConfidenceLabel != "high" || edge.Origin != "parser" || edge.Tier != "syntax" || !edge.CrossRepo {
+					t.Fatalf("edge payload was not preserved: %#v", edge)
+				}
+				if edge.Meta["custom"] != "value" || edge.Meta["resolve_terminal_reason"] != "fixture" || edge.Meta["semantic_source"] != "test" {
+					t.Fatalf("edge metadata was not preserved: %#v", edge.Meta)
+				}
+				oldTo := edge.To
+				edge.To = "resolved::" + edge.From
+				rewrites = append(rewrites, graph.EdgeReindex{Edge: edge, OldTo: oldTo})
+			}
+			store.ReindexEdges(rewrites)
+			return true
+		},
+	)
+
+	if len(seen) != selectedCount {
+		t.Fatalf("visited %d selected edges, want %d: %v", len(seen), selectedCount, seen)
+	}
+	for id, count := range seen {
+		if count != 1 {
+			t.Fatalf("edge %q visited %d times", id, count)
+		}
+	}
+	for _, size := range batchSizes {
+		if size < 1 || size > 3 {
+			t.Fatalf("batch size = %d, want 1..3", size)
+		}
+	}
+}
+
+func TestScanEdgesByKindsBatchedEmptyAndEarlyStop(t *testing.T) {
+	store := openEdgeKindBatchTestStore(t)
+	store.AddBatch(nil, []*graph.Edge{
+		{From: "from-1", To: "to-1", Kind: graph.EdgeReads, FilePath: "repo/file.go", Line: 1},
+		{From: "from-2", To: "to-2", Kind: graph.EdgeReads, FilePath: "repo/file.go", Line: 2},
+	})
+
+	store.ScanEdgesByKindsBatched(nil, 2, func([]*graph.Edge) bool {
+		t.Fatal("empty kinds invoked callback")
+		return false
+	})
+	calls := 0
+	store.ScanEdgesByKindsBatched([]graph.EdgeKind{graph.EdgeReads}, 1, func(page []*graph.Edge) bool {
+		calls++
+		if len(page) != 1 {
+			t.Fatalf("page size = %d, want 1", len(page))
+		}
+		return false
+	})
+	if calls != 1 {
+		t.Fatalf("callback calls = %d, want 1", calls)
+	}
+}

--- a/internal/indexer/dataflow.go
+++ b/internal/indexer/dataflow.go
@@ -8,14 +8,6 @@ import (
 
 const dataflowRewriteBatchSize = 2048
 
-// dataflowBatchScanner is implemented by disk stores that can close each
-// bounded read cursor before the callback mutates edge identities. The SQLite
-// implementation also captures a row-id high-water mark, so rewritten rows
-// cannot re-enter the same pass under their newly inserted row id.
-type dataflowBatchScanner interface {
-	ScanDataflowEdgesBatched(batchSize int, yield func([]*graph.Edge) bool)
-}
-
 // materializeDataflowParams runs after the regular call resolver
 // pass to lift the placeholder targets carried by EdgeArgOf and
 // EdgeReturnsTo edges to concrete graph IDs. The Go dataflow
@@ -57,37 +49,12 @@ func (idx *Indexer) materializeDataflowParams() {
 }
 
 func forEachDataflowEdgeBatch(g graph.Store, batchSize int, yield func([]*graph.Edge) bool) {
-	if scanner, ok := g.(dataflowBatchScanner); ok {
-		scanner.ScanDataflowEdgesBatched(batchSize, yield)
-		return
-	}
-	if batchSize <= 0 {
-		batchSize = 1
-	}
-	batch := make([]*graph.Edge, 0, batchSize)
-	keepGoing := true
-	flush := func() {
-		if len(batch) == 0 || !keepGoing {
-			return
-		}
-		keepGoing = yield(batch)
-		batch = make([]*graph.Edge, 0, batchSize)
-	}
-	for _, kind := range []graph.EdgeKind{graph.EdgeArgOf, graph.EdgeReturnsTo} {
-		for edge := range g.EdgesByKind(kind) {
-			if edge == nil {
-				continue
-			}
-			batch = append(batch, edge)
-			if len(batch) == batchSize {
-				flush()
-				if !keepGoing {
-					return
-				}
-			}
-		}
-	}
-	flush()
+	graph.ScanEdgesByKindsBatched(
+		g,
+		[]graph.EdgeKind{graph.EdgeArgOf, graph.EdgeReturnsTo},
+		batchSize,
+		yield,
+	)
 }
 
 // materializeDataflowParamsForFile is the single-file equivalent of

--- a/internal/indexer/dataflow_batch_test.go
+++ b/internal/indexer/dataflow_batch_test.go
@@ -25,10 +25,14 @@ func newDataflowBatchCountingStore() *dataflowBatchCountingStore {
 	return &dataflowBatchCountingStore{Store: graph.New()}
 }
 
-func (s *dataflowBatchCountingStore) ScanDataflowEdgesBatched(batchSize int, yield func([]*graph.Edge) bool) {
+func (s *dataflowBatchCountingStore) ScanEdgesByKindsBatched(
+	kinds []graph.EdgeKind,
+	batchSize int,
+	yield func([]*graph.Edge) bool,
+) {
 	s.scanCalls++
 	var edges []*graph.Edge
-	for _, kind := range []graph.EdgeKind{graph.EdgeArgOf, graph.EdgeReturnsTo} {
+	for _, kind := range kinds {
 		for edge := range s.EdgesByKind(kind) {
 			if edge != nil {
 				edges = append(edges, edge)

--- a/internal/resolver/attribution_reindex_batch.go
+++ b/internal/resolver/attribution_reindex_batch.go
@@ -1,0 +1,57 @@
+package resolver
+
+import "github.com/zzet/gortex/internal/graph"
+
+// attributionReindexBatchSize bounds the number of full edge payloads retained
+// while attribution passes rewrite graph targets. It is deliberately below the
+// SQLite store's transaction chunk so one resolver batch remains one write.
+const attributionReindexBatchSize = 2048
+
+// attributionReindexCollector preserves rewrite order while keeping both the
+// caller-local buffer and the incremental cross-file queue bounded.
+type attributionReindexCollector struct {
+	resolver *Resolver
+	batch    []graph.EdgeReindex
+}
+
+func newAttributionReindexCollector(r *Resolver) *attributionReindexCollector {
+	return &attributionReindexCollector{resolver: r}
+}
+
+func (c *attributionReindexCollector) add(edge *graph.Edge, oldTo string) {
+	if edge == nil || oldTo == "" {
+		return
+	}
+	c.batch = append(c.batch, graph.EdgeReindex{Edge: edge, OldTo: oldTo})
+	if len(c.batch) == attributionReindexBatchSize {
+		c.flush()
+	}
+}
+
+func (c *attributionReindexCollector) flush() {
+	if len(c.batch) == 0 {
+		return
+	}
+	c.resolver.persistAttributionReindexes(c.batch)
+	// Drop the backing array as well as its length: EdgeReindex contains a full
+	// *Edge, so retaining capacity would keep already-written payloads alive.
+	c.batch = nil
+}
+
+// reindexAttributionEdgesBatched scans only the requested edge kinds and
+// rewrites them in bounded batches. Backends with a native batch scanner close
+// each read cursor before the callback, allowing ReindexEdges to safely re-enter
+// a single-connection store.
+func (r *Resolver) reindexAttributionEdgesBatched(
+	kinds []graph.EdgeKind,
+	rewrite func(*graph.Edge) string,
+) {
+	collector := newAttributionReindexCollector(r)
+	graph.ScanEdgesByKindsBatched(r.graph, kinds, attributionReindexBatchSize, func(edges []*graph.Edge) bool {
+		for _, edge := range edges {
+			collector.add(edge, rewrite(edge))
+		}
+		return true
+	})
+	collector.flush()
+}

--- a/internal/resolver/attribution_reindex_batch_test.go
+++ b/internal/resolver/attribution_reindex_batch_test.go
@@ -1,0 +1,129 @@
+package resolver
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+type attributionBatchRecordingStore struct {
+	graph.Store
+
+	edges          []*graph.Edge
+	scanCalls      int
+	scanKinds      []graph.EdgeKind
+	scanBatchSize  int
+	reindexBatches [][]graph.EdgeReindex
+}
+
+func (s *attributionBatchRecordingStore) ScanEdgesByKindsBatched(
+	kinds []graph.EdgeKind,
+	batchSize int,
+	yield func([]*graph.Edge) bool,
+) {
+	s.scanCalls++
+	s.scanKinds = append([]graph.EdgeKind(nil), kinds...)
+	s.scanBatchSize = batchSize
+	for start := 0; start < len(s.edges); start += batchSize {
+		end := start + batchSize
+		if end > len(s.edges) {
+			end = len(s.edges)
+		}
+		if !yield(s.edges[start:end]) {
+			return
+		}
+	}
+}
+
+func (s *attributionBatchRecordingStore) ReindexEdges(batch []graph.EdgeReindex) {
+	copied := append([]graph.EdgeReindex(nil), batch...)
+	s.reindexBatches = append(s.reindexBatches, copied)
+}
+
+func TestReindexAttributionEdgesBatchedBoundsFullEdges(t *testing.T) {
+	const count = attributionReindexBatchSize*2 + 7
+	store := &attributionBatchRecordingStore{edges: make([]*graph.Edge, 0, count)}
+	for i := 0; i < count; i++ {
+		store.edges = append(store.edges, &graph.Edge{
+			From: fmt.Sprintf("from-%d", i),
+			To:   fmt.Sprintf("unresolved::target-%d", i),
+			Kind: graph.EdgeReferences,
+			Meta: map[string]any{"payload": i},
+		})
+	}
+
+	resolver := &Resolver{graph: store}
+	resolver.reindexAttributionEdgesBatched(
+		[]graph.EdgeKind{graph.EdgeReads, graph.EdgeReferences},
+		func(edge *graph.Edge) string {
+			oldTo := edge.To
+			edge.To = "resolved::" + edge.From
+			return oldTo
+		},
+	)
+
+	require.Equal(t, 1, store.scanCalls)
+	assert.Equal(t, attributionReindexBatchSize, store.scanBatchSize)
+	assert.Equal(t, []graph.EdgeKind{graph.EdgeReads, graph.EdgeReferences}, store.scanKinds)
+	assertAttributionReindexBatches(t, store.reindexBatches, count)
+}
+
+func TestPersistAttributionReindexesBoundsDirectWrites(t *testing.T) {
+	const count = attributionReindexBatchSize*2 + 7
+	store := &attributionBatchRecordingStore{}
+	resolver := &Resolver{graph: store}
+
+	resolver.persistAttributionReindexes(makeAttributionReindexes(count))
+
+	assertAttributionReindexBatches(t, store.reindexBatches, count)
+}
+
+func TestPersistAttributionReindexesBoundsIncrementalQueue(t *testing.T) {
+	const count = attributionReindexBatchSize*2 + 7
+	store := &attributionBatchRecordingStore{}
+	resolver := &Resolver{
+		graph:                  store,
+		incrementalNodesByFile: map[string][]*graph.Node{},
+	}
+
+	resolver.persistAttributionReindexes(makeAttributionReindexes(count))
+
+	require.Len(t, store.reindexBatches, 2, "full chunks should flush immediately")
+	assert.Len(t, resolver.incrementalAttributionReindex, 7, "only the bounded tail should remain queued")
+	resolver.flushIncrementalAttributionReindexes()
+	assert.Nil(t, resolver.incrementalAttributionReindex)
+	assertAttributionReindexBatches(t, store.reindexBatches, count)
+}
+
+func makeAttributionReindexes(count int) []graph.EdgeReindex {
+	batch := make([]graph.EdgeReindex, 0, count)
+	for i := 0; i < count; i++ {
+		batch = append(batch, graph.EdgeReindex{
+			Edge:  &graph.Edge{From: fmt.Sprintf("from-%d", i)},
+			OldTo: fmt.Sprintf("old-%d", i),
+		})
+	}
+	return batch
+}
+
+func assertAttributionReindexBatches(t *testing.T, batches [][]graph.EdgeReindex, count int) {
+	t.Helper()
+	seen := 0
+	for _, batch := range batches {
+		require.NotEmpty(t, batch)
+		assert.LessOrEqual(t, len(batch), attributionReindexBatchSize)
+		for _, rewrite := range batch {
+			assert.Equal(t, fmt.Sprintf("from-%d", seen), rewrite.Edge.From)
+			if rewrite.OldTo != fmt.Sprintf("old-%d", seen) &&
+				rewrite.OldTo != fmt.Sprintf("unresolved::target-%d", seen) {
+				t.Fatalf("rewrite %d has unexpected OldTo %q", seen, rewrite.OldTo)
+			}
+			seen++
+		}
+	}
+	assert.Equal(t, count, seen)
+}

--- a/internal/resolver/bare_name_scope_bind.go
+++ b/internal/resolver/bare_name_scope_bind.go
@@ -73,32 +73,19 @@ func (r *Resolver) bindBareNameScopeRefs() {
 		return
 	}
 
-	var batch []graph.EdgeReindex
-	for e := range r.graph.EdgesByKind(graph.EdgeReads) {
-		if rewrote := r.tryBindBareName(e, owned); rewrote != "" {
-			batch = append(batch, graph.EdgeReindex{Edge: e, OldTo: rewrote})
-		}
-	}
-	for e := range r.graph.EdgesByKind(graph.EdgeReferences) {
-		if rewrote := r.tryBindBareName(e, owned); rewrote != "" {
-			batch = append(batch, graph.EdgeReindex{Edge: e, OldTo: rewrote})
-		}
-	}
 	// EdgeArgOf and EdgeValueFlow carry the same shape — `unresolved::<name>`
 	// is the dataflow source/target the parser couldn't bind.
-	for e := range r.graph.EdgesByKind(graph.EdgeArgOf) {
-		if rewrote := r.tryBindBareName(e, owned); rewrote != "" {
-			batch = append(batch, graph.EdgeReindex{Edge: e, OldTo: rewrote})
-		}
-	}
-	for e := range r.graph.EdgesByKind(graph.EdgeValueFlow) {
-		if rewrote := r.tryBindBareName(e, owned); rewrote != "" {
-			batch = append(batch, graph.EdgeReindex{Edge: e, OldTo: rewrote})
-		}
-	}
-	if len(batch) > 0 {
-		r.graph.ReindexEdges(batch)
-	}
+	r.reindexAttributionEdgesBatched(
+		[]graph.EdgeKind{
+			graph.EdgeReads,
+			graph.EdgeReferences,
+			graph.EdgeArgOf,
+			graph.EdgeValueFlow,
+		},
+		func(edge *graph.Edge) string {
+			return r.tryBindBareName(edge, owned)
+		},
+	)
 }
 
 // bindBareNameScopeRefsForFile is the single-file scope of
@@ -128,16 +115,14 @@ func (r *Resolver) bindBareNameScopeRefsForFile(filePath string) {
 		return
 	}
 
-	var batch []graph.EdgeReindex
-	for _, e := range r.fileOutEdges(filePath) {
-		switch e.Kind {
+	collector := newAttributionReindexCollector(r)
+	for _, edge := range r.fileOutEdges(filePath) {
+		switch edge.Kind {
 		case graph.EdgeReads, graph.EdgeReferences, graph.EdgeArgOf, graph.EdgeValueFlow:
-			if rewrote := r.tryBindBareName(e, owned); rewrote != "" {
-				batch = append(batch, graph.EdgeReindex{Edge: e, OldTo: rewrote})
-			}
+			collector.add(edge, r.tryBindBareName(edge, owned))
 		}
 	}
-	r.persistAttributionReindexes(batch)
+	collector.flush()
 }
 
 // tryBindBareName tries to rewrite e.To from `unresolved::<name>` to a

--- a/internal/resolver/dataflow_callee_bind.go
+++ b/internal/resolver/dataflow_callee_bind.go
@@ -61,17 +61,12 @@ func (r *Resolver) bindDataflowCalleeRefs() {
 	if len(idx.byFile) == 0 && len(idx.bySite) == 0 {
 		return
 	}
-	var batch []graph.EdgeReindex
-	for _, ek := range []graph.EdgeKind{graph.EdgeArgOf, graph.EdgeValueFlow} {
-		for e := range r.graph.EdgesByKind(ek) {
-			if old := bindDataflowCalleeEdge(e, idx); old != "" {
-				batch = append(batch, graph.EdgeReindex{Edge: e, OldTo: old})
-			}
-		}
-	}
-	if len(batch) > 0 {
-		r.graph.ReindexEdges(batch)
-	}
+	r.reindexAttributionEdgesBatched(
+		[]graph.EdgeKind{graph.EdgeArgOf, graph.EdgeValueFlow},
+		func(edge *graph.Edge) string {
+			return bindDataflowCalleeEdge(edge, idx)
+		},
+	)
 }
 
 // bindDataflowCalleeRefsForFile is the single-file scope of
@@ -108,16 +103,14 @@ func (r *Resolver) bindDataflowCalleeRefsForFile(filePath string) {
 			idx.indexCallSite(e)
 		}
 	}
-	var batch []graph.EdgeReindex
-	for _, e := range fileEdges {
-		if e == nil || (e.Kind != graph.EdgeArgOf && e.Kind != graph.EdgeValueFlow) {
+	collector := newAttributionReindexCollector(r)
+	for _, edge := range fileEdges {
+		if edge == nil || (edge.Kind != graph.EdgeArgOf && edge.Kind != graph.EdgeValueFlow) {
 			continue
 		}
-		if old := bindDataflowCalleeEdge(e, idx); old != "" {
-			batch = append(batch, graph.EdgeReindex{Edge: e, OldTo: old})
-		}
+		collector.add(edge, bindDataflowCalleeEdge(edge, idx))
 	}
-	r.persistAttributionReindexes(batch)
+	collector.flush()
 }
 
 // calleeIndex holds the per-pass lookup tables bindDataflowCallee* uses.

--- a/internal/resolver/incremental_attribution_cache.go
+++ b/internal/resolver/incremental_attribution_cache.go
@@ -89,9 +89,17 @@ func (r *Resolver) runFileAttributionPassesForFilesLocked(frontier incrementalFi
 }
 
 func (r *Resolver) flushIncrementalAttributionReindexes() {
-	if len(r.incrementalAttributionReindex) > 0 {
-		r.graph.ReindexEdges(r.incrementalAttributionReindex)
-		r.incrementalAttributionReindex = nil
+	batch := r.incrementalAttributionReindex
+	// Release the resolver-owned backing array before entering the store. Every
+	// emitted chunk is still referenced by batch until its write completes.
+	r.incrementalAttributionReindex = nil
+	for len(batch) > 0 {
+		n := attributionReindexBatchSize
+		if len(batch) < n {
+			n = len(batch)
+		}
+		r.graph.ReindexEdges(batch[:n])
+		batch = batch[n:]
 	}
 }
 
@@ -105,11 +113,33 @@ func (r *Resolver) persistAttributionReindexes(batch []graph.EdgeReindex) {
 	if len(batch) == 0 {
 		return
 	}
-	if r.incrementalNodesByFile != nil {
-		r.incrementalAttributionReindex = append(r.incrementalAttributionReindex, batch...)
+	if r.incrementalNodesByFile == nil {
+		for len(batch) > 0 {
+			n := attributionReindexBatchSize
+			if len(batch) < n {
+				n = len(batch)
+			}
+			r.graph.ReindexEdges(batch[:n])
+			batch = batch[n:]
+		}
 		return
 	}
-	r.graph.ReindexEdges(batch)
+
+	for len(batch) > 0 {
+		if len(r.incrementalAttributionReindex) >= attributionReindexBatchSize {
+			r.flushIncrementalAttributionReindexes()
+		}
+		room := attributionReindexBatchSize - len(r.incrementalAttributionReindex)
+		n := room
+		if len(batch) < n {
+			n = len(batch)
+		}
+		r.incrementalAttributionReindex = append(r.incrementalAttributionReindex, batch[:n]...)
+		batch = batch[n:]
+		if len(r.incrementalAttributionReindex) == attributionReindexBatchSize {
+			r.flushIncrementalAttributionReindexes()
+		}
+	}
 }
 
 func (r *Resolver) incrementalFileNodes(filePath string) []*graph.Node {


### PR DESCRIPTION
## Summary

- add a reusable full-edge batch scanner by kind
- use SQLite row-id high-water paging and close each cursor before callbacks re-enter the store
- make in-memory scans exact-once when callbacks move edges across shards
- flush bare-name and dataflow attribution rewrites in batches of at most 2,048
- bound the shared incremental attribution queue while preserving FIFO and pass order

## Memory behavior

Resolver passes no longer retain every rewritten full edge until the end of a whole-graph or changed-file pass. SQLite scan pages are capped at 4,096 rows and resolver write buffers at 2,048 edges.

## Validation

- go test -count=1 ./internal/graph/... ./internal/indexer ./internal/resolver
- go test -race -count=1 ./internal/resolver
- focused graph, SQLite, and indexer race tests
- golangci-lint run ./internal/graph/... ./internal/indexer/... ./internal/resolver/...
- isolated cold-index wall-clock gate passed three consecutive runs
- full go test ./... passed every functional package; its concurrent cold-index timing gate missed once and passed when rerun in isolation