### PR TITLE
perf(indexer): share immutable mtime snapshots

### DIFF
--- a/cmd/gortex/daemon_state.go
+++ b/cmd/gortex/daemon_state.go
@@ -1203,13 +1203,10 @@ func collectSnapshotRepos(mi *indexer.MultiIndexer) []snapshotRepo {
 		if m == nil {
 			continue
 		}
-		// Copy the mtimes map — saveSnapshot encodes asynchronously
-		// on shutdown and we don't want a late watcher event mutating
-		// the live map mid-encode.
-		mtimes := make(map[string]int64, len(m.FileMtimes))
-		for k, v := range m.FileMtimes {
-			mtimes[k] = v
-		}
+		// RepoMetadata publishes an immutable snapshot. Later indexer writes
+		// detach first, so asynchronous encoding can safely share this map
+		// without retaining a second repository-sized copy.
+		mtimes := m.FileMtimes
 		out = append(out, snapshotRepo{
 			RepoPrefix: prefix,
 			RootPath:   m.RootPath,

--- a/internal/indexer/file_mtime_snapshot_test.go
+++ b/internal/indexer/file_mtime_snapshot_test.go
@@ -1,0 +1,121 @@
+package indexer
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublishedFileMtimesDetachOnFirstMutation(t *testing.T) {
+	idx := &Indexer{fileMtimes: map[string]int64{
+		"a.go": 1,
+		"b.go": 2,
+	}}
+
+	published := idx.publishFileMtimes()
+	require.True(t, idx.fileMtimesShared)
+
+	idx.recordFileMtimeValue("a.go", 10)
+	assert.Equal(t, int64(1), published["a.go"], "published snapshot must remain immutable")
+	assert.Equal(t, int64(10), idx.fileMtimes["a.go"])
+	assert.False(t, idx.fileMtimesShared, "the first write must detach the working map")
+
+	idx.recordFileMtimeValue("c.go", 3)
+	assert.Equal(t, int64(3), idx.fileMtimes["c.go"])
+	assert.NotContains(t, published, "c.go")
+	assert.False(t, idx.fileMtimesShared, "later writes reuse the detached working map")
+
+	republished := idx.publishFileMtimes()
+	idx.mtimeMu.Lock()
+	idx.ensureFileMtimesWritableLocked()
+	delete(idx.fileMtimes, "b.go")
+	idx.mtimeMu.Unlock()
+	assert.Contains(t, republished, "b.go", "deletion must detach from a republished snapshot")
+	assert.NotContains(t, idx.fileMtimes, "b.go")
+}
+
+func TestPublishedFileMtimesRemainStableDuringConcurrentWrites(t *testing.T) {
+	const files = 2048
+	mtimes := make(map[string]int64, files)
+	for i := 0; i < files; i++ {
+		mtimes[fmt.Sprintf("file-%04d.go", i)] = int64(i)
+	}
+	idx := &Indexer{fileMtimes: mtimes}
+	published := idx.publishFileMtimes()
+
+	var readers sync.WaitGroup
+	for reader := 0; reader < 8; reader++ {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for pass := 0; pass < 25; pass++ {
+				seen := 0
+				for range published {
+					seen++
+				}
+				assert.Equal(t, files, seen)
+			}
+		}()
+	}
+
+	for i := 0; i < 128; i++ {
+		idx.recordFileMtimeValue(fmt.Sprintf("new-%04d.go", i), int64(i))
+	}
+	readers.Wait()
+
+	assert.Len(t, published, files)
+	assert.Len(t, idx.fileMtimes, files+128)
+}
+
+func TestSetFileMtimesOwnsRestoredMap(t *testing.T) {
+	restored := map[string]int64{"a.go": 1}
+	idx := &Indexer{fileMtimes: map[string]int64{"old.go": 2}, fileMtimesShared: true}
+
+	idx.SetFileMtimes(restored)
+	restored["a.go"] = 99
+
+	assert.Equal(t, int64(1), idx.fileMtimes["a.go"])
+	assert.False(t, idx.fileMtimesShared)
+}
+
+func TestMultiIndexerFileMtimesReturnsPublishedSnapshot(t *testing.T) {
+	idx := &Indexer{fileMtimes: map[string]int64{"a.go": 1}}
+	published := idx.publishFileMtimes()
+	mi := &MultiIndexer{repos: map[string]*RepoMetadata{
+		"repo": {FileMtimes: published},
+	}}
+
+	assert.Equal(t, published, mi.FileMtimes("repo"))
+	assert.Nil(t, mi.FileMtimes("missing"))
+
+	idx.recordFileMtimeValue("a.go", 2)
+	assert.Equal(t, int64(1), mi.FileMtimes("repo")["a.go"])
+}
+
+func BenchmarkFileMtimeSnapshot(b *testing.B) {
+	const files = 50_000
+	mtimes := make(map[string]int64, files)
+	for i := 0; i < files; i++ {
+		mtimes[fmt.Sprintf("path/to/file-%05d.go", i)] = int64(i)
+	}
+	idx := &Indexer{fileMtimes: mtimes}
+
+	b.Run("copy", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			snapshot := idx.FileMtimes()
+			runtime.KeepAlive(snapshot)
+		}
+	})
+	b.Run("published", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			snapshot := idx.publishFileMtimes()
+			runtime.KeepAlive(snapshot)
+		}
+	})
+}

--- a/internal/indexer/file_mtime_writers_test.go
+++ b/internal/indexer/file_mtime_writers_test.go
@@ -1,0 +1,83 @@
+package indexer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestBatchedFileMtimeUpsertDetachesPublishedSnapshot(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "a.go")
+	require.NoError(t, os.WriteFile(path, []byte("package sample\n"), 0o644))
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+
+	idx := newTestIndexer(graph.New())
+	idx.fileMtimes = map[string]int64{"a.go": 1}
+	published := idx.publishFileMtimes()
+
+	fresh, stale := idx.recordFileReadVersionsBatched([]fileReadReceipt{{
+		absPath:  path,
+		mtimeKey: "a.go",
+		readVersion: fileReadVersion{
+			info:  info,
+			mtime: info.ModTime().UnixNano(),
+			size:  info.Size(),
+			valid: true,
+		},
+	}})
+
+	assert.Equal(t, []string{path}, fresh)
+	assert.Empty(t, stale)
+	assert.Equal(t, int64(1), published["a.go"])
+	assert.Equal(t, info.ModTime().UnixNano(), idx.fileMtimes["a.go"])
+}
+
+func TestBatchedFileMtimeEvictionDetachesPublishedSnapshot(t *testing.T) {
+	idx := newTestIndexer(graph.New())
+	idx.fileMtimes = map[string]int64{"a.go": 1, "b.go": 2}
+	published := idx.publishFileMtimes()
+
+	idx.evictDeletedFilesBatched([]string{"a.go"}, &DerivedInvalidationPlan{})
+
+	assert.Equal(t, int64(1), published["a.go"])
+	assert.NotContains(t, idx.fileMtimes, "a.go")
+	assert.Equal(t, int64(2), idx.fileMtimes["b.go"])
+}
+
+func TestRefreshFileMtimeDetachesPublishedSnapshot(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "a.go")
+	require.NoError(t, os.WriteFile(path, []byte("package sample\n"), 0o644))
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+
+	idx := newTestIndexer(graph.New())
+	idx.SetRootPath(root)
+	key := idx.relKey(path)
+	idx.fileMtimes = map[string]int64{key: 1}
+	published := idx.publishFileMtimes()
+
+	idx.RefreshFileMtime(path)
+
+	assert.Equal(t, int64(1), published[key])
+	assert.Equal(t, info.ModTime().UnixNano(), idx.fileMtimes[key])
+}
+
+func TestMultiIndexerFileMtimesReturnsOwnedCopy(t *testing.T) {
+	published := map[string]int64{"a.go": 1}
+	mi := &MultiIndexer{repos: map[string]*RepoMetadata{
+		"repo": {FileMtimes: published},
+	}}
+
+	owned := mi.FileMtimes("repo")
+	owned["a.go"] = 99
+
+	assert.Equal(t, int64(1), published["a.go"])
+	assert.Equal(t, int64(1), mi.repos["repo"].FileMtimes["a.go"])
+}

--- a/internal/indexer/full_topology_transaction_test.go
+++ b/internal/indexer/full_topology_transaction_test.go
@@ -67,7 +67,7 @@ func TestIndexCtxStaleHandleUsesCurrentIndexerAndMetadata(t *testing.T) {
 	require.Equal(t, result.FileCount, meta.FileCount)
 	require.Equal(t, result.NodeCount, meta.NodeCount)
 	require.Equal(t, result.EdgeCount, meta.EdgeCount)
-	_, metadataHasNewFile := meta.FileMtimes[newKey]
+	_, metadataHasNewFile := mi.FileMtimes("repo")[newKey]
 	require.True(t, metadataHasNewFile)
 }
 

--- a/internal/indexer/incremental_batch.go
+++ b/internal/indexer/incremental_batch.go
@@ -988,6 +988,7 @@ func (idx *Indexer) recordFileReadVersionsBatched(receipts []fileReadReceipt) (f
 		return fresh, stale
 	}
 	idx.mtimeMu.Lock()
+	idx.ensureFileMtimesWritableLocked()
 	for path, mtime := range mtimes {
 		idx.fileMtimes[path] = mtime
 	}
@@ -1511,6 +1512,7 @@ func (idx *Indexer) evictDeletedFilesBatched(deleted []string, plan *DerivedInva
 		edgesRemoved += edges
 	}
 	idx.mtimeMu.Lock()
+	idx.ensureFileMtimesWritableLocked()
 	for _, relPath := range deleted {
 		delete(idx.fileMtimes, relPath)
 	}

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -315,11 +315,12 @@ type Indexer struct {
 	workspaceMembers     *workspaceMembershipIndex
 
 	// Mtime tracking and parse error retention for index health diagnostics.
-	parseErrors   []IndexError
-	fileMtimes    map[string]int64
-	lastIndexTime time.Time
-	totalDetected int
-	mtimeMu       sync.RWMutex
+	parseErrors      []IndexError
+	fileMtimes       map[string]int64
+	fileMtimesShared bool
+	lastIndexTime    time.Time
+	totalDetected    int
+	mtimeMu          sync.RWMutex
 
 	// contractCache memoizes the contract-extractor output per file.
 	// Keyed by graph file path (with repo prefix); value is the file's
@@ -2418,7 +2419,7 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (*IndexResult, er
 		prefix := current.repoPrefix
 		if owner != nil && prefix != "" {
 			rootPath := current.RootPath()
-			fileMtimes := current.FileMtimes()
+			fileMtimes := current.publishFileMtimes()
 			owner.mu.Lock()
 			if meta := owner.repos[prefix]; meta != nil && owner.indexers[prefix] == current {
 				owner.repos[prefix] = &RepoMetadata{
@@ -3489,15 +3490,16 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 	// captured via d.Info(); no per-file os.Stat round-trip here.
 	idx.mtimeMu.Lock()
 	idx.fileMtimes = make(map[string]int64, len(files))
+	idx.fileMtimesShared = false
 	for _, f := range files {
 		if f.mtimeNano > 0 {
 			idx.fileMtimes[idx.relKey(f.path)] = f.mtimeNano
 		}
 	}
-	mtimeSnapshot := make(map[string]int64, len(idx.fileMtimes))
-	for k, v := range idx.fileMtimes {
-		mtimeSnapshot[k] = v
-	}
+	// Bulk persistence consumes the snapshot after mtimeMu is released.
+	// Publish it immutably so later mutations detach before writing.
+	idx.fileMtimesShared = true
+	mtimeSnapshot := idx.fileMtimes
 	idx.mtimeMu.Unlock()
 
 	// Persist the per-file mtimes through the store's optional
@@ -4406,6 +4408,7 @@ func (idx *Indexer) recordFileReadVersion(relPath, absPath string, version fileR
 
 func (idx *Indexer) recordFileMtimeValue(relPath string, mtime int64) {
 	idx.mtimeMu.Lock()
+	idx.ensureFileMtimesWritableLocked()
 	idx.fileMtimes[relPath] = mtime
 	idx.mtimeMu.Unlock()
 	if w, ok := idx.graph.(graph.FileMtimeWriter); ok {
@@ -5469,6 +5472,31 @@ func (idx *Indexer) FileMtimes() map[string]int64 {
 	return out
 }
 
+// publishFileMtimes returns the current map as an immutable committed
+// snapshot. Every later element mutation must call
+// ensureFileMtimesWritableLocked first; that copy-on-write boundary lets the
+// Indexer, RepoMetadata, poller, and daemon snapshot share one map safely.
+func (idx *Indexer) publishFileMtimes() map[string]int64 {
+	idx.mtimeMu.Lock()
+	defer idx.mtimeMu.Unlock()
+	idx.fileMtimesShared = true
+	return idx.fileMtimes
+}
+
+// ensureFileMtimesWritableLocked detaches the working map from any published
+// snapshot. The caller must hold mtimeMu for writing.
+func (idx *Indexer) ensureFileMtimesWritableLocked() {
+	if !idx.fileMtimesShared {
+		return
+	}
+	writable := make(map[string]int64, len(idx.fileMtimes))
+	for path, mtime := range idx.fileMtimes {
+		writable[path] = mtime
+	}
+	idx.fileMtimes = writable
+	idx.fileMtimesShared = false
+}
+
 // trackedFileCount reports how many files this indexer currently holds
 // mtime records for — the repo's whole file set, independent of any one
 // pass's scope. A scoped pass adds and evicts its own files within scope
@@ -5511,6 +5539,7 @@ func (idx *Indexer) RefreshFileMtime(filePath string) {
 	idx.mtimeMu.Lock()
 	_, tracked := idx.fileMtimes[key]
 	if tracked {
+		idx.ensureFileMtimesWritableLocked()
 		idx.fileMtimes[key] = mtime
 	}
 	idx.mtimeMu.Unlock()
@@ -5548,6 +5577,7 @@ func (idx *Indexer) SetFileMtimes(mtimes map[string]int64) {
 	idx.mtimeMu.Lock()
 	defer idx.mtimeMu.Unlock()
 	idx.fileMtimes = make(map[string]int64, len(mtimes))
+	idx.fileMtimesShared = false
 	for k, v := range mtimes {
 		idx.fileMtimes[k] = v
 	}

--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -40,7 +40,10 @@ type RepoMetadata struct {
 	NodeCount     int
 	EdgeCount     int
 	ParseErrors   []IndexError
-	FileMtimes    map[string]int64
+	// FileMtimes is the immutable committed snapshot shared with the owning
+	// Indexer. Treat it as read-only: later indexer mutations detach through
+	// copy-on-write, so this map never observes a partially applied batch.
+	FileMtimes map[string]int64
 	// IsWorktree records whether RootPath was a linked git worktree
 	// (as opposed to a main checkout) at the time the repo was
 	// tracked. Captured here because once the worktree directory is
@@ -1889,8 +1892,9 @@ func (mi *MultiIndexer) indexMultiRepo(repos []config.RepoEntry) (map[string]*In
 						NodeCount:     result.NodeCount,
 						EdgeCount:     result.EdgeCount,
 						ParseErrors:   result.Errors,
-						FileMtimes:    idx.FileMtimes(),
-						IsWorktree:    ResolveWorktree(r.absPath).IsWorktree,
+						FileMtimes:    idx.publishFileMtimes(),
+
+						IsWorktree: ResolveWorktree(r.absPath).IsWorktree,
 					}
 
 					resultCh <- repoResult{prefix: r.prefix, result: result, idx: idx, meta: meta}
@@ -2056,6 +2060,7 @@ func (mi *MultiIndexer) indexRepoRaw(repoPrefix string) (*IndexResult, error) {
 		return nil, fmt.Errorf("indexing %s returned a nil result", meta.RootPath)
 	}
 
+	fileMtimes := idx.publishFileMtimes()
 	mi.mu.Lock()
 	mi.repos[repoPrefix] = &RepoMetadata{
 		RepoPrefix:    repoPrefix,
@@ -2066,8 +2071,9 @@ func (mi *MultiIndexer) indexRepoRaw(repoPrefix string) (*IndexResult, error) {
 		NodeCount:     result.NodeCount,
 		EdgeCount:     result.EdgeCount,
 		ParseErrors:   result.Errors,
-		FileMtimes:    idx.FileMtimes(),
-		IsWorktree:    meta.IsWorktree,
+		FileMtimes:    fileMtimes,
+
+		IsWorktree: meta.IsWorktree,
 	}
 	mi.indexers[repoPrefix] = idx
 	mi.mu.Unlock()
@@ -2243,6 +2249,7 @@ func (mi *MultiIndexer) incrementalEvictRepoRaw(repoPrefix, path string) (nodesR
 		mi.resolveIncrementalRepoMutation(repoPrefix, result, nil, eviction.batch)
 	}
 
+	fileMtimes := idx.publishFileMtimes()
 	mi.mu.Lock()
 	mi.repos[repoPrefix] = &RepoMetadata{
 		RepoPrefix:    repoPrefix,
@@ -2253,8 +2260,9 @@ func (mi *MultiIndexer) incrementalEvictRepoRaw(repoPrefix, path string) (nodesR
 		NodeCount:     result.NodeCount,
 		EdgeCount:     result.EdgeCount,
 		ParseErrors:   result.Errors,
-		FileMtimes:    idx.FileMtimes(),
-		IsWorktree:    meta.IsWorktree,
+		FileMtimes:    fileMtimes,
+
+		IsWorktree: meta.IsWorktree,
 	}
 	mi.mu.Unlock()
 
@@ -2300,6 +2308,7 @@ func (mi *MultiIndexer) incrementalReindexRepoRawMode(repoPrefix string, paths [
 		repoPrefix, result, receipt, batch, mode.exactPointSemantic,
 	)
 
+	fileMtimes := idx.publishFileMtimes()
 	mi.mu.Lock()
 	mi.repos[repoPrefix] = &RepoMetadata{
 		RepoPrefix:    repoPrefix,
@@ -2310,7 +2319,8 @@ func (mi *MultiIndexer) incrementalReindexRepoRawMode(repoPrefix string, paths [
 		NodeCount:     result.NodeCount,
 		EdgeCount:     result.EdgeCount,
 		ParseErrors:   result.Errors,
-		FileMtimes:    idx.FileMtimes(),
+		FileMtimes:    fileMtimes,
+
 		// Carried over from the prior metadata: this pass doesn't change
 		// it, and dropping it here (zero value on a fresh struct literal)
 		// used to silently flip a worktree back to its false default on
@@ -2553,6 +2563,7 @@ func (mi *MultiIndexer) TrackRepoCtx(ctx context.Context, entry config.RepoEntry
 		}
 		result.RepoPrefix = prefix
 
+		fileMtimes := idx.publishFileMtimes()
 		mi.mu.Lock()
 		mi.repos[prefix] = &RepoMetadata{
 			RepoPrefix:    prefix,
@@ -2563,8 +2574,9 @@ func (mi *MultiIndexer) TrackRepoCtx(ctx context.Context, entry config.RepoEntry
 			NodeCount:     result.NodeCount,
 			EdgeCount:     result.EdgeCount,
 			ParseErrors:   result.Errors,
-			FileMtimes:    idx.FileMtimes(),
-			IsWorktree:    ResolveWorktree(absPath).IsWorktree,
+			FileMtimes:    fileMtimes,
+
+			IsWorktree: ResolveWorktree(absPath).IsWorktree,
 		}
 		mi.indexers[prefix] = idx
 		mi.mu.Unlock()
@@ -2756,6 +2768,7 @@ func (mi *MultiIndexer) ReconcileRepoCtx(ctx context.Context, entry config.RepoE
 		}
 		result.RepoPrefix = prefix
 
+		fileMtimes := idx.publishFileMtimes()
 		mi.mu.Lock()
 		mi.repos[prefix] = &RepoMetadata{
 			RepoPrefix:    prefix,
@@ -2766,8 +2779,9 @@ func (mi *MultiIndexer) ReconcileRepoCtx(ctx context.Context, entry config.RepoE
 			NodeCount:     result.NodeCount,
 			EdgeCount:     result.EdgeCount,
 			ParseErrors:   result.Errors,
-			FileMtimes:    idx.FileMtimes(),
-			IsWorktree:    ResolveWorktree(absPath).IsWorktree,
+			FileMtimes:    fileMtimes,
+
+			IsWorktree: ResolveWorktree(absPath).IsWorktree,
 		}
 		mi.indexers[prefix] = idx
 		mi.mu.Unlock()
@@ -3085,6 +3099,26 @@ func (mi *MultiIndexer) GetMetadata(repoPrefix string) *RepoMetadata {
 	mi.mu.RLock()
 	defer mi.mu.RUnlock()
 	return mi.repos[repoPrefix]
+}
+
+// FileMtimes returns an owned copy of the repository's committed mtime
+// snapshot. Internal poller and daemon paths use the immutable RepoMetadata
+// snapshot directly; this public accessor keeps callers from mutating it.
+func (mi *MultiIndexer) FileMtimes(repoPrefix string) map[string]int64 {
+	mi.mu.RLock()
+	meta := mi.repos[repoPrefix]
+	if meta == nil {
+		mi.mu.RUnlock()
+		return nil
+	}
+	published := meta.FileMtimes
+	mi.mu.RUnlock()
+
+	out := make(map[string]int64, len(published))
+	for path, mtime := range published {
+		out[path] = mtime
+	}
+	return out
 }
 
 // AllMetadata returns a copy of all repo metadata.

--- a/internal/indexer/multi_reconcile_sqlite_test.go
+++ b/internal/indexer/multi_reconcile_sqlite_test.go
@@ -47,7 +47,7 @@ func TestReconcileRepoCtx_Sqlite_FullRetrackFlag(t *testing.T) {
 
 	meta := mi.GetMetadata("repo")
 	require.NotNil(t, meta)
-	priorMtimes := meta.FileMtimes
+	priorMtimes := mi.FileMtimes("repo")
 
 	// While the daemon is "down", a new file appears on disk. This is
 	// enough to trip HasChangesSinceMtimes and route ReconcileRepoCtx
@@ -68,7 +68,7 @@ func TestReconcileRepoCtx_Sqlite_FullRetrackFlag(t *testing.T) {
 	// so ReconcileRepoCtx must report neither flag.
 	meta2 := mi2.GetMetadata("repo")
 	require.NotNil(t, meta2)
-	unchangedMtimes := meta2.FileMtimes
+	unchangedMtimes := mi2.FileMtimes("repo")
 
 	mi3 := NewMultiIndexer(graph.Store(s), newTestRegistry(), search.NewBM25(), cm, zap.NewNop())
 	result2, err := mi3.ReconcileRepoCtx(context.Background(), config.RepoEntry{Path: repoPath, Name: "repo"}, unchangedMtimes)

--- a/internal/indexer/multi_reconcile_test.go
+++ b/internal/indexer/multi_reconcile_test.go
@@ -43,7 +43,7 @@ func TestReconcileRepoCtx_EvictsOfflineDeletions(t *testing.T) {
 
 	meta := mi.GetMetadata("repo")
 	require.NotNil(t, meta)
-	priorMtimes := meta.FileMtimes
+	priorMtimes := mi.FileMtimes("repo")
 
 	// Before we "restart", delete b.go from disk. This mirrors the
 	// user editing offline while the daemon is stopped.
@@ -91,7 +91,7 @@ func TestReconcileRepoCtx_DoesNotDuplicateUnchanged(t *testing.T) {
 	require.NoError(t, err)
 
 	want := g.Stats()
-	priorMtimes := mi.GetMetadata("repo").FileMtimes
+	priorMtimes := mi.FileMtimes("repo")
 
 	// Simulate restart: fresh MultiIndexer on the same graph, reconcile.
 	mi2 := NewMultiIndexer(g, newTestRegistry(), search.NewBM25(), cm, zap.NewNop())
@@ -125,7 +125,7 @@ func TestReconcileRepoCtx_RunsDerivedPassesForOfflineChange(t *testing.T) {
 	mi := NewMultiIndexer(g, newTestRegistry(), search.NewBM25(), cm, zap.NewNop())
 	_, err = mi.IndexAll()
 	require.NoError(t, err)
-	priorMtimes := mi.GetMetadata("repo").FileMtimes
+	priorMtimes := mi.FileMtimes("repo")
 
 	writeFile(t, filepath.Join(repoPath, "shell.go"), `package main
 import "os/exec"

--- a/internal/indexer/poller.go
+++ b/internal/indexer/poller.go
@@ -454,7 +454,7 @@ func (p *Poller) finalizeGitHead(observation pollGitObservation) error {
 	})
 }
 
-// pollFilesystem snapshots the indexer's per-file mtime map and returns
+// pollFilesystem reads the indexer's immutable per-file mtime snapshot and returns
 // changed or unreadable tracked paths. It performs discovery only: pollOnce
 // unions these paths with Git evidence and the repository batch owns every
 // freshness stamp and deletion decision.
@@ -469,12 +469,12 @@ func (p *Poller) pollFilesystem() []string {
 	if idx == nil {
 		return nil
 	}
-	snapshot := idx.FileMtimes()
+	snapshot := idx.publishFileMtimes()
 	if len(snapshot) == 0 {
 		return nil
 	}
 	paths := make([]string, 0)
-	for relPath, recorded := range snapshot {
+	for relPath, recordedMtime := range snapshot {
 		abs := filepath.Clean(filepath.Join(p.rootPath, filepath.FromSlash(relPath)))
 		info, err := os.Stat(abs)
 		if err != nil {
@@ -491,7 +491,7 @@ func (p *Poller) pollFilesystem() []string {
 		if info.IsDir() {
 			continue
 		}
-		if info.ModTime().UnixNano() != recorded {
+		if info.ModTime().UnixNano() != recordedMtime {
 			paths = append(paths, abs)
 		}
 	}

--- a/internal/indexer/reconcile_scoped_routing_test.go
+++ b/internal/indexer/reconcile_scoped_routing_test.go
@@ -97,7 +97,7 @@ func TestReconcileRepoCtx_ScopedEqualsFullIndex(t *testing.T) {
 	mi := NewMultiIndexer(graph.Store(s), newTestRegistry(), search.NewBM25(), cm, zap.NewNop())
 	_, err = mi.IndexAll()
 	require.NoError(t, err)
-	priorMtimes := mi.GetMetadata("repo").FileMtimes
+	priorMtimes := mi.FileMtimes("repo")
 	require.NotEmpty(t, priorMtimes)
 
 	// Mutate on disk while the daemon is "down": add, edit, delete, rename.
@@ -169,7 +169,7 @@ func TestReconcileRepoCtx_Routing(t *testing.T) {
 		mi := NewMultiIndexer(graph.Store(s), newTestRegistry(), search.NewBM25(), cm, zap.NewNop())
 		_, err = mi.IndexAll()
 		require.NoError(t, err)
-		return s, cm, mi.GetMetadata("repo").FileMtimes
+		return s, cm, mi.FileMtimes("repo")
 	}
 
 	reconcile := func(t *testing.T, s *store_sqlite.Store, cm *config.ConfigManager, repoPath string, prior map[string]int64) *IndexResult {


### PR DESCRIPTION
## Summary

- publish the committed per-repository mtime map as an immutable snapshot
- detach the working map on the first later upsert, eviction, or refresh
- let polling and daemon snapshot encoding share that map without repository-sized copies
- keep the public accessor safe by returning an owned copy outside the registry lock

## Benchmark

50,000 tracked files on Apple M1 Pro:

- copied snapshot: ~1.71 ms/op, 1,747,510 B/op, 130 allocs/op
- published snapshot: ~42.5 ns/op, 0 B/op, 0 allocs/op

## Verification

- `go test ./... -count=1`
- `go test -race ./cmd/gortex/... ./internal/indexer/... -count=1`
- focused COW writer/race tests (batched upsert, eviction, refresh, concurrent readers)
- `golangci-lint run ./...`
- `git diff --check origin/main...HEAD`