### PR TITLE
perf(daemon): release consumed warmup snapshots

### DIFF
--- a/cmd/gortex/daemon_state.go
+++ b/cmd/gortex/daemon_state.go
@@ -821,10 +821,6 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 				zap.Duration("elapsed", time.Since(phaseStart)))
 		}
 	}
-	// Contract registries now own decoded entries; the legacy snapshot
-	// fallback is no longer needed for the rest of the daemon lifetime.
-	snapshotContracts = nil
-
 	// Backfill `WorkspaceID` / `ProjectID` onto nodes and contracts
 	// loaded from a legacy snapshot. Old snapshots have these fields
 	// as zero (gob decodes unknown fields silently); without this
@@ -924,10 +920,6 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 		}
 		state.multiIndexer.SetSkipVectorBuild(false)
 	}
-	// ImportVectorIndex has consumed the serialized bytes (or there were none).
-	// Drop the final local reference before watcher setup and steady state.
-	restoredVector = snapshotVector{}
-
 	watchCfgs := make(map[string]config.WatchConfig)
 	for prefix := range state.multiIndexer.AllMetadata() {
 		watchCfgs[prefix] = state.configManager.GetRepoConfig(prefix).Watch

--- a/cmd/gortex/daemon_state.go
+++ b/cmd/gortex/daemon_state.go
@@ -265,8 +265,33 @@ func healDuplicateRepos(gc *config.GlobalConfig, logger *zap.Logger) int {
 	return len(removed)
 }
 
+// takeWarmupSnapshotPayloads moves one-use restart data out of daemonState.
+// The warmup owns the returned values and drops each after its final consumer;
+// clearing the long-lived fields here prevents successful and failed warmups
+// from retaining serialized repository, contract, or vector payloads.
+func (state *daemonState) takeWarmupSnapshotPayloads() (
+	map[string]*snapshotRepo,
+	map[string][]contracts.Contract,
+	snapshotVector,
+) {
+	if state == nil {
+		return nil, nil, snapshotVector{}
+	}
+	repos := state.snapshotRepos
+	contractEntries := state.snapshotContracts
+	vector := state.snapshotVector
+	state.snapshotRepos = nil
+	state.snapshotContracts = nil
+	state.snapshotVector = snapshotVector{}
+	return repos, contractEntries, vector
+}
+
 func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func()) (*indexer.MultiWatcher, *warmupTimings) {
 	timings := &warmupTimings{}
+	if state == nil {
+		return nil, timings
+	}
+	snapshotRepos, snapshotContracts, restoredVector := state.takeWarmupSnapshotPayloads()
 	if state.multiIndexer == nil || state.configManager == nil {
 		return nil, timings
 	}
@@ -484,7 +509,7 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 					// hasn't seen this repo yet.
 					priorMtimes := priorMtimesFromStore(state.graph, state.configManager, entry, logger)
 					if len(priorMtimes) == 0 {
-						priorMtimes = priorMtimesForEntry(state.snapshotRepos, entry)
+						priorMtimes = priorMtimesForEntry(snapshotRepos, entry)
 					}
 					if state.snapshotPartial {
 						priorMtimes = nil
@@ -537,7 +562,7 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 							// run for it instead of silently serving the shrunken
 							// graph, and surface the event so a ratchet can't hide
 							// behind an all-green index_health.
-							if res != nil && bootShapeShortfall(state.snapshotRepos, res.RepoPrefix, res.NodeCount, res.EdgeCount) {
+							if res != nil && bootShapeShortfall(snapshotRepos, res.RepoPrefix, res.NodeCount, res.EdgeCount) {
 								indexer.RecordResolutionRegression()
 								logger.Warn("daemon: boot shape-degradation guard — repo graph materially short of snapshot; re-running resolution",
 									zap.String("prefix", res.RepoPrefix),
@@ -584,6 +609,9 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 	}
 	close(jobs)
 	wg.Wait()
+	// Every reconcile and shape guard has finished; release the restored
+	// per-repository mtime maps before the later resolver/enrichment phases.
+	snapshotRepos = nil
 	if coordinatedBulkActive {
 		flushStart := time.Now()
 		if err := coordinatedBulk.EndCoordinatedBulkLoad(); err != nil {
@@ -773,7 +801,7 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 				// daemons upgrading across this change. The
 				// snapshot copy is read-only by this point so the
 				// two sources can't drift mid-flight.
-				cs, ok := state.snapshotContracts[prefix]
+				cs, ok := snapshotContracts[prefix]
 				if !ok || len(cs) == 0 {
 					continue
 				}
@@ -793,6 +821,9 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 				zap.Duration("elapsed", time.Since(phaseStart)))
 		}
 	}
+	// Contract registries now own decoded entries; the legacy snapshot
+	// fallback is no longer needed for the rest of the daemon lifetime.
+	snapshotContracts = nil
 
 	// Backfill `WorkspaceID` / `ProjectID` onto nodes and contracts
 	// loaded from a legacy snapshot. Old snapshots have these fields
@@ -880,7 +911,7 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 	// step that lets a default-on daemon avoid re-embedding the whole
 	// graph on every restart. SetSkipVectorBuild(false) afterwards means
 	// any later file-change re-index rebuilds vectors normally.
-	if vec := state.snapshotVector; len(vec.Index) > 0 {
+	if vec := restoredVector; len(vec.Index) > 0 {
 		phaseStart = time.Now()
 		if err := state.multiIndexer.ImportVectorIndex(vec.Index, vec.Dims, vec.Count); err != nil {
 			logger.Warn("daemon: vector index restore failed — semantic search will rebuild on next index",
@@ -893,6 +924,9 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 		}
 		state.multiIndexer.SetSkipVectorBuild(false)
 	}
+	// ImportVectorIndex has consumed the serialized bytes (or there were none).
+	// Drop the final local reference before watcher setup and steady state.
+	restoredVector = snapshotVector{}
 
 	watchCfgs := make(map[string]config.WatchConfig)
 	for prefix := range state.multiIndexer.AllMetadata() {

--- a/cmd/gortex/daemon_warmup_payload_test.go
+++ b/cmd/gortex/daemon_warmup_payload_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/contracts"
+)
+
+func TestTakeWarmupSnapshotPayloadsMovesAndClearsState(t *testing.T) {
+	state := &daemonState{
+		snapshotRepos: map[string]*snapshotRepo{
+			"repo": {RepoPrefix: "repo", FileMtimes: map[string]int64{"a.go": 1}},
+		},
+		snapshotContracts: map[string][]contracts.Contract{
+			"repo": {{ID: "contract"}},
+		},
+		snapshotVector: snapshotVector{Index: []byte{1, 2, 3}, Dims: 8, Count: 1},
+	}
+
+	repos, contractEntries, vector := state.takeWarmupSnapshotPayloads()
+
+	require.Contains(t, repos, "repo")
+	assert.Equal(t, int64(1), repos["repo"].FileMtimes["a.go"])
+	require.Len(t, contractEntries["repo"], 1)
+	assert.Equal(t, "contract", contractEntries["repo"][0].ID)
+	assert.Equal(t, []byte{1, 2, 3}, vector.Index)
+	assert.Equal(t, 8, vector.Dims)
+	assert.Equal(t, 1, vector.Count)
+
+	assert.Nil(t, state.snapshotRepos)
+	assert.Nil(t, state.snapshotContracts)
+	assert.Empty(t, state.snapshotVector.Index)
+	assert.Zero(t, state.snapshotVector.Dims)
+	assert.Zero(t, state.snapshotVector.Count)
+
+	repos, contractEntries, vector = state.takeWarmupSnapshotPayloads()
+	assert.Nil(t, repos)
+	assert.Nil(t, contractEntries)
+	assert.Empty(t, vector.Index)
+}
+
+func TestTakeWarmupSnapshotPayloadsHandlesNilState(t *testing.T) {
+	var state *daemonState
+	repos, contractEntries, vector := state.takeWarmupSnapshotPayloads()
+	assert.Nil(t, repos)
+	assert.Nil(t, contractEntries)
+	assert.Empty(t, vector.Index)
+}
+
+func TestWarmupClearsSnapshotPayloadsBeforeDependencyGuard(t *testing.T) {
+	state := &daemonState{
+		snapshotRepos: map[string]*snapshotRepo{"repo": {RepoPrefix: "repo"}},
+		snapshotContracts: map[string][]contracts.Contract{
+			"repo": {{ID: "contract"}},
+		},
+		snapshotVector: snapshotVector{Index: []byte{1}, Dims: 1, Count: 1},
+	}
+
+	watcher, timings := warmupDaemonState(state, zap.NewNop(), nil)
+
+	assert.Nil(t, watcher)
+	require.NotNil(t, timings)
+	assert.Nil(t, state.snapshotRepos)
+	assert.Nil(t, state.snapshotContracts)
+	assert.Empty(t, state.snapshotVector.Index)
+}


### PR DESCRIPTION
## Summary

- move one-use repository, contract, and vector restart payloads out of long-lived daemon state when warmup begins
- release repository mtime maps after reconcile workers and shape guards finish
- release legacy contract payloads after registry rehydration
- release serialized vector bytes immediately after import
- clear payloads on invalid/failed warmup paths as well

## Verification

- `go test ./cmd/gortex -count=1`
- `go test -race ./cmd/gortex/... -count=1`
- `go build ./cmd/gortex/...`
- `golangci-lint run ./cmd/gortex/...`
- focused ownership-transfer and dependency-guard tests
- independent lifecycle review confirmed every payload survives through its final consumer and the vector decoder does not retain serialized bytes