### PR TITLE
perf(indexer): reuse authoritative warm-restart census

### DIFF
--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -3852,6 +3852,32 @@ func (idx *Indexer) repoNodeEdgeCount() (int, int) {
 	return est.NodeCount, est.EdgeCount
 }
 
+// cleanCensusResult publishes the same zero-delta state as the full-root
+// incremental pipeline after ChangedSinceMtimes has already proved the tree
+// unchanged. It preserves the one necessary side effect for non-persistent
+// search backends without repeating filesystem discovery.
+func (idx *Indexer) cleanCensusResult(detected int, started time.Time) *IndexResult {
+	if idx.totalDetected == 0 {
+		idx.totalDetected = detected
+	}
+	if !isSymbolSearcherBackend(idx.search) {
+		idx.buildSearchIndex()
+	}
+	nodes, edges := idx.repoNodeEdgeCount()
+	fileCount := idx.trackedFileCount()
+	if fileCount == 0 {
+		fileCount = detected
+	}
+	result := &IndexResult{
+		NodeCount:  nodes,
+		EdgeCount:  edges,
+		FileCount:  fileCount,
+		DurationMs: time.Since(started).Milliseconds(),
+	}
+	idx.warnIfEdgeSanityViolated(result)
+	return result
+}
+
 // warnIfEdgeSanityViolated logs a loud warning when an index pass
 // produced files and symbol nodes but no edges — see
 // IndexResult.EdgeSanityViolated.
@@ -8467,16 +8493,29 @@ func (idx *Indexer) HasChangesSinceMtimes(root string) bool {
 // caller treats that as "unknown, do a full re-track", exactly as
 // HasChangesSinceMtimes conservatively returns true on the same condition.
 func (idx *Indexer) ChangedSinceMtimes(root string) (changed []string, deleted []string, err error) {
+	changed, deleted, _, err = idx.changedSinceMtimesCensus(root)
+	return changed, deleted, err
+}
+
+// changedSinceMtimesCensus also returns the complete tracked-source count from
+// the same walk. ReconcileRepoCtx uses that count to publish an honest clean
+// result without repeating the full-tree discovery in the incremental path.
+func (idx *Indexer) changedSinceMtimesCensus(root string) (
+	changed []string,
+	deleted []string,
+	detected int,
+	err error,
+) {
 	absRoot, absErr := filepath.Abs(root)
 	if absErr != nil {
-		return nil, nil, absErr
+		return nil, nil, 0, absErr
 	}
 	idx.storeRootPath(absRoot)
 
 	diskFiles := make(map[string]bool)
 	walkErr := filepath.WalkDir(absRoot, func(path string, d os.DirEntry, werr error) error {
 		if werr != nil {
-			return nil
+			return werr
 		}
 		if d.IsDir() {
 			if idx.shouldPruneDir(path, absRoot) {
@@ -8484,7 +8523,7 @@ func (idx *Indexer) ChangedSinceMtimes(root string) (changed []string, deleted [
 			}
 			return nil
 		}
-		if _, ok := idx.effectiveLanguage(path, nil); !ok {
+		if _, ok := idx.effectiveLanguage(path, nil); !ok && !idx.isIncrementalContractManifest(path) {
 			return nil
 		}
 		if idx.shouldExclude(path, absRoot, false) {
@@ -8498,25 +8537,31 @@ func (idx *Indexer) ChangedSinceMtimes(root string) (changed []string, deleted [
 		return nil
 	})
 	if walkErr != nil {
-		return nil, nil, walkErr
+		return nil, nil, 0, walkErr
 	}
 
-	// Deletion check: a previously-indexed file absent from the walk and
-	// confirmed gone from disk counts as a change (its edges must drop).
+	// Deletion check mirrors the modern incremental path: missing files and
+	// files that became excluded must both leave the restored graph.
 	idx.mtimeMu.RLock()
-	var candidates []string
+	candidates := make([]string, 0)
 	for rel := range idx.fileMtimes {
 		if !diskFiles[rel] {
 			candidates = append(candidates, rel)
 		}
 	}
 	idx.mtimeMu.RUnlock()
+	sort.Strings(candidates)
 	for _, rel := range candidates {
-		if _, statErr := os.Stat(filepath.Join(absRoot, filepath.FromSlash(rel))); errors.Is(statErr, os.ErrNotExist) {
+		absPath := filepath.Join(absRoot, filepath.FromSlash(rel))
+		_, statErr := os.Stat(absPath)
+		switch {
+		case statErr == nil && idx.shouldExclude(absPath, absRoot, false):
+			deleted = append(deleted, rel)
+		case errors.Is(statErr, os.ErrNotExist):
 			deleted = append(deleted, rel)
 		}
 	}
-	return changed, deleted, nil
+	return changed, deleted, len(diskFiles), nil
 }
 
 func (idx *Indexer) IsStale(relPath string) bool {

--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -2703,11 +2703,12 @@ func (mi *MultiIndexer) ReconcileRepoCtx(ctx context.Context, entry config.RepoE
 		// only the changed files and evict only the deleted ones, leaving the
 		// rest of the already-persisted graph untouched. A whole-repo re-track
 		// (IndexCtx — which evicts and re-parses every file, then bulk-drains)
-		// is reserved for the cases where scoping is unsafe or not worth it: the
-		// census could not be taken, the churn is a large fraction of the repo,
-		// or an operator forced it via GORTEX_WARMUP_FULL_RETRACK. A repo with
-		// zero changes keeps the fast full-tree incremental no-op (walk + 0 stale →
-		// return), which is what makes an unchanged warm restart near-instant.
+		// is reserved for cases where scoped replacement is not worth it: churn is
+		// a large fraction of the repo, or an operator forced it via
+		// GORTEX_WARMUP_FULL_RETRACK. A failed census falls back to the preserving
+		// full-root incremental path. A repo with zero changes returns directly
+		// from an authoritative non-Merkle census instead of repeating the same
+		// full-tree walk in the incremental pipeline.
 		//
 		// The in-memory backend (*graph.Graph) keeps its exact prior behaviour:
 		// the full-tree modern pipeline is authoritative there — it evicts
@@ -2718,6 +2719,7 @@ func (mi *MultiIndexer) ReconcileRepoCtx(ctx context.Context, entry config.RepoE
 			receipt          *graph.MutationReceipt
 			batch            *reparsePendingEnrichmentBatch
 			changed, deleted []string
+			detected         int
 			route            = "incremental"
 		)
 		// fullRetrack is the whole-repo re-track — the ONE place FullRetrack is
@@ -2736,17 +2738,48 @@ func (mi *MultiIndexer) ReconcileRepoCtx(ctx context.Context, entry config.RepoE
 			result, receipt, batch, err = idx.incrementalReindexPathsWithReceipt(absPath, nil, true)
 		default:
 			var censusErr error
-			changed, deleted, censusErr = idx.ChangedSinceMtimes(absPath)
+			changed, deleted, detected, censusErr = idx.changedSinceMtimesCensus(absPath)
 			churn := len(changed) + len(deleted)
 			priorCount := len(priorMtimes)
 			forceFull := os.Getenv("GORTEX_WARMUP_FULL_RETRACK") == "1"
+			manifestOnly := churn > 0
+			for _, relPath := range append(append([]string(nil), changed...), deleted...) {
+				absChangedPath := filepath.Join(absPath, filepath.FromSlash(relPath))
+				if !idx.isIncrementalContractManifest(absChangedPath) {
+					manifestOnly = false
+					break
+				}
+			}
 			switch {
-			case censusErr != nil || forceFull:
-				route = "full_retrack"
-				result, err = fullRetrack()
-			case churn == 0:
+			case censusErr != nil:
+				// A partial filesystem census cannot safely authorize replacement:
+				// preserve rows below unreadable paths through the existing
+				// full-root incremental pipeline.
 				route = "incremental"
 				result, receipt, batch, err = idx.incrementalReindexPathsWithReceipt(absPath, nil, true)
+			case forceFull:
+				route = "full_retrack"
+				result, err = fullRetrack()
+			case churn == 0 && !idx.merkleEnabled():
+				route = "census_noop"
+				result = idx.cleanCensusResult(detected, start)
+			case churn == 0:
+				// The mtime census cannot prove a Merkle-enabled repository clean:
+				// a missing baseline or extractor-salt change still requires the
+				// content-addressed full-tree incremental check.
+				route = "incremental"
+				result, receipt, batch, err = idx.incrementalReindexPathsWithReceipt(absPath, nil, true)
+			case manifestOnly && idx.merkleEnabled():
+				// Keep the Merkle baseline repository-wide; a scoped tree would
+				// replace it with the manifest-only projection.
+				route = "incremental"
+				result, receipt, batch, err = idx.incrementalReindexPathsWithReceipt(absPath, nil, true)
+			case manifestOnly:
+				// Root contract manifests are not part of the source-file count, so
+				// one changed go.mod must not look like >40% source churn in a tiny
+				// repository. The scoped refresh records its mtime and converges.
+				route = "scoped"
+				result, receipt, batch, err = idx.incrementalReindexPathsWithReceipt(absPath, append(changed, deleted...), true)
 			case priorCount > 0 && churn*100 > priorCount*40:
 				route = "full_retrack"
 				result, err = fullRetrack()

--- a/internal/indexer/reconcile_clean_census_manifest_test.go
+++ b/internal/indexer/reconcile_clean_census_manifest_test.go
@@ -1,0 +1,59 @@
+package indexer
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/search"
+)
+
+func TestReconcileRepoCtxRoutesManifestOnlyChurnScopedAndConverges(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "main.go"), "package sample\nfunc Alpha() {}\n")
+	writeFile(t, filepath.Join(root, "go.mod"), "module example.com/sample\n")
+	entry := config.RepoEntry{Path: root, Name: "repo"}
+	cm := newTestConfigManager(t)
+	cm.Global().Repos = []config.RepoEntry{entry}
+
+	store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "store.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	seed := NewMultiIndexer(graph.Store(store), newTestRegistry(), search.NewBM25(), cm, zap.NewNop())
+	_, err = seed.IndexAll()
+	require.NoError(t, err)
+	prior := seed.GetIndexer("repo").FileMtimes()
+	_, manifestTrackedByFullIndex := prior["go.mod"]
+	assert.False(t, manifestTrackedByFullIndex)
+
+	core, logs := observer.New(zap.DebugLevel)
+	firstRestart := NewMultiIndexer(graph.Store(store), newTestRegistry(), search.NewBM25(), cm, zap.New(core))
+	result, err := firstRestart.ReconcileRepoCtx(t.Context(), entry, prior)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.False(t, result.FullRetrack)
+	entries := logs.FilterMessage("daemon: reconciled repo from snapshot").All()
+	require.Len(t, entries, 1)
+	assert.Equal(t, "scoped", entries[0].ContextMap()["route"])
+
+	convergedMtimes := firstRestart.GetIndexer("repo").FileMtimes()
+	_, manifestTracked := convergedMtimes["go.mod"]
+	assert.True(t, manifestTracked)
+
+	core, logs = observer.New(zap.DebugLevel)
+	secondRestart := NewMultiIndexer(graph.Store(store), newTestRegistry(), search.NewBM25(), cm, zap.New(core))
+	result, err = secondRestart.ReconcileRepoCtx(t.Context(), entry, convergedMtimes)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	entries = logs.FilterMessage("daemon: reconciled repo from snapshot").All()
+	require.Len(t, entries, 1)
+	assert.Equal(t, "census_noop", entries[0].ContextMap()["route"])
+}

--- a/internal/indexer/reconcile_clean_census_merkle_route_test.go
+++ b/internal/indexer/reconcile_clean_census_merkle_route_test.go
@@ -1,0 +1,59 @@
+package indexer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/search"
+)
+
+func TestReconcileRepoCtxKeepsMerkleFallbackForCleanMtimeCensus(t *testing.T) {
+	t.Setenv("GORTEX_MERKLE", "1")
+	root := t.TempDir()
+	path := filepath.Join(root, "main.go")
+	writeFile(t, path, "package sample\nfunc Alpha() {}\n")
+	entry := config.RepoEntry{Path: root, Name: "repo"}
+	cm := newTestConfigManager(t)
+	cm.Global().Repos = []config.RepoEntry{entry}
+
+	store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "store.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	seed := NewMultiIndexer(graph.Store(store), newTestRegistry(), search.NewBM25(), cm, zap.NewNop())
+	_, err = seed.IndexAll()
+	require.NoError(t, err)
+	prior := seed.GetIndexer("repo").FileMtimes()
+
+	indexedInfo, err := os.Stat(path)
+	require.NoError(t, err)
+	writeFile(t, path, "package sample\nfunc Bravo() {}\n")
+	require.NoError(t, os.Chtimes(path, indexedInfo.ModTime(), indexedInfo.ModTime()))
+
+	// A restored mtime makes the cheap census look clean. If the persisted
+	// Merkle baseline is missing, the preserving full-root incremental path
+	// hashes the file and surfaces it. The direct census no-op must therefore
+	// remain disabled for every Merkle-enabled repository.
+	require.NoError(t, os.Remove(merkleTreeFile(root)))
+	core, logs := observer.New(zap.DebugLevel)
+	restarted := NewMultiIndexer(graph.Store(store), newTestRegistry(), search.NewBM25(), cm, zap.New(core))
+	result, err := restarted.ReconcileRepoCtx(t.Context(), entry, prior)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 1, result.StaleFileCount)
+	assert.NotEmpty(t, store.FindNodesByName("Bravo"))
+	assert.Empty(t, store.FindNodesByName("Alpha"))
+
+	entries := logs.FilterMessage("daemon: reconciled repo from snapshot").All()
+	require.Len(t, entries, 1)
+	assert.Equal(t, "incremental", entries[0].ContextMap()["route"])
+}

--- a/internal/indexer/reconcile_clean_census_merkle_test.go
+++ b/internal/indexer/reconcile_clean_census_merkle_test.go
@@ -1,0 +1,44 @@
+package indexer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestMerkleIncrementalFallbackSeesSameMtimeChangeWithoutBaseline(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "main.go")
+	writeFile(t, path, "package sample\nfunc Alpha() {}\n")
+
+	idx := newTestIndexer(graph.New())
+	idx.config.Merkle = true
+	_, err := idx.Index(root)
+	require.NoError(t, err)
+
+	indexedInfo, err := os.Stat(path)
+	require.NoError(t, err)
+	writeFile(t, path, "package sample\nfunc Bravo() {}\n")
+	require.NoError(t, os.Chtimes(path, indexedInfo.ModTime(), indexedInfo.ModTime()))
+
+	// A restored mtime makes the cheap census look clean. With no persisted
+	// Merkle baseline, however, the full-root incremental path must hash the
+	// file and surface it. ReconcileRepoCtx therefore cannot use census_noop
+	// for a Merkle-enabled repository.
+	require.NoError(t, os.Remove(merkleTreeFile(root)))
+	changed, deleted, detected, err := idx.changedSinceMtimesCensus(root)
+	require.NoError(t, err)
+	assert.Empty(t, changed)
+	assert.Empty(t, deleted)
+	assert.Equal(t, 1, detected)
+
+	result, err := idx.incrementalReindexPathsMode(root, nil, incrementalPathMode{detectDeletions: true})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 1, result.StaleFileCount)
+}

--- a/internal/indexer/reconcile_clean_census_test.go
+++ b/internal/indexer/reconcile_clean_census_test.go
@@ -1,0 +1,160 @@
+package indexer
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/search"
+)
+
+func TestChangedSinceMtimesCensusIncludesContractManifests(t *testing.T) {
+	root := t.TempDir()
+	manifest := filepath.Join(root, "go.mod")
+	require.NoError(t, os.WriteFile(manifest, []byte("module example.com/sample\n"), 0o644))
+
+	idx := newTestIndexer(graph.New())
+	idx.SetFileMtimes(map[string]int64{"go.mod": 1})
+
+	changed, deleted, detected, err := idx.changedSinceMtimesCensus(root)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"go.mod"}, changed)
+	assert.Empty(t, deleted)
+	assert.Equal(t, 1, detected)
+
+	require.NoError(t, os.Remove(manifest))
+	changed, deleted, detected, err = idx.changedSinceMtimesCensus(root)
+	require.NoError(t, err)
+	assert.Empty(t, changed)
+	assert.Equal(t, []string{"go.mod"}, deleted)
+	assert.Zero(t, detected)
+}
+
+func TestChangedSinceMtimesCensusDeletesNewlyExcludedTrackedFile(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "ignored.go")
+	require.NoError(t, os.WriteFile(path, []byte("package sample\n"), 0o644))
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+
+	idx := newTestIndexer(graph.New())
+	idx.SetFileMtimes(map[string]int64{"ignored.go": info.ModTime().UnixNano()})
+	idx.SetExcludePatterns([]string{"ignored.go"})
+
+	changed, deleted, detected, err := idx.changedSinceMtimesCensus(root)
+	require.NoError(t, err)
+	assert.Empty(t, changed)
+	assert.Equal(t, []string{"ignored.go"}, deleted)
+	assert.Zero(t, detected)
+}
+
+func TestCleanCensusResultBootstrapsNonPersistentSearch(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID:       "function::Alpha",
+		Kind:     graph.KindFunction,
+		Name:     "Alpha",
+		FilePath: "a.go",
+	})
+	idx := newTestIndexer(g)
+	idx.search = search.NewBM25()
+	idx.SetFileMtimes(map[string]int64{"a.go": 1})
+
+	result := idx.cleanCensusResult(1, time.Now())
+
+	require.NotNil(t, result)
+	assert.Equal(t, 1, result.FileCount)
+	assert.Equal(t, 1, result.NodeCount)
+	assert.Equal(t, 1, idx.TotalDetected())
+	assert.Equal(t, 1, idx.search.Count())
+	require.NotEmpty(t, idx.search.Search("Alpha", 10))
+}
+
+func TestReconcileRepoCtxUsesCleanCensusNoOp(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "main.go"), "package sample\nfunc Alpha() {}\n")
+	entry := config.RepoEntry{Path: root, Name: "repo"}
+	cm := newTestConfigManager(t)
+	cm.Global().Repos = []config.RepoEntry{entry}
+
+	store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "store.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	seed := NewMultiIndexer(graph.Store(store), newTestRegistry(), search.NewBM25(), cm, zap.NewNop())
+	_, err = seed.IndexAll()
+	require.NoError(t, err)
+	prior := seed.GetIndexer("repo").FileMtimes()
+	before := store.Stats()
+
+	core, logs := observer.New(zap.DebugLevel)
+	restarted := NewMultiIndexer(graph.Store(store), newTestRegistry(), search.NewBM25(), cm, zap.New(core))
+	result, err := restarted.ReconcileRepoCtx(t.Context(), entry, prior)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	after := store.Stats()
+	assert.Zero(t, result.StaleFileCount)
+	assert.Zero(t, result.DeletedFileCount)
+	assert.False(t, result.FullRetrack)
+	assert.Equal(t, before.TotalNodes, after.TotalNodes)
+	assert.Equal(t, before.TotalEdges, after.TotalEdges)
+	assert.Equal(t, len(prior), result.FileCount)
+	assert.Equal(t, result.FileCount, restarted.GetIndexer("repo").TotalDetected())
+
+	entries := logs.FilterMessage("daemon: reconciled repo from snapshot").All()
+	require.Len(t, entries, 1)
+	assert.Equal(t, "census_noop", entries[0].ContextMap()["route"])
+}
+
+func BenchmarkCleanReconcileDiscovery(b *testing.B) {
+	root := b.TempDir()
+	const files = 512
+	mtimes := make(map[string]int64, files)
+	for i := 0; i < files; i++ {
+		rel := fmt.Sprintf("pkg/file-%04d.go", i)
+		path := filepath.Join(root, filepath.FromSlash(rel))
+		require.NoError(b, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(b, os.WriteFile(path, []byte("package sample\n"), 0o644))
+		info, err := os.Stat(path)
+		require.NoError(b, err)
+		mtimes[rel] = info.ModTime().UnixNano()
+	}
+	idx := newTestIndexer(graph.New())
+	idx.SetFileMtimes(mtimes)
+
+	b.Run("authoritative_census", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			changed, deleted, detected, err := idx.changedSinceMtimesCensus(root)
+			if err != nil || len(changed) != 0 || len(deleted) != 0 {
+				b.Fatalf("clean census: changed=%d deleted=%d err=%v", len(changed), len(deleted), err)
+			}
+			idx.cleanCensusResult(detected, time.Now())
+		}
+	})
+
+	b.Run("legacy_double_walk", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			changed, deleted, _, err := idx.changedSinceMtimesCensus(root)
+			if err != nil || len(changed) != 0 || len(deleted) != 0 {
+				b.Fatalf("clean census: changed=%d deleted=%d err=%v", len(changed), len(deleted), err)
+			}
+			result, err := idx.incrementalReindexPathsMode(root, nil, incrementalPathMode{detectDeletions: true})
+			if err != nil || result.StaleFileCount != 0 || result.DeletedFileCount != 0 {
+				b.Fatalf("legacy no-op: result=%+v err=%v", result, err)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- reuse the warm-restart mtime census as the authoritative zero-change result instead of walking the repository twice
- preserve full-root incremental fallback for Merkle repositories and census errors
- route root contract-manifest-only churn through a bounded refresh so tiny Go repositories converge without full retracks
- keep non-persistent search bootstrap, exact counts, invalidation behavior, exclusions, and restored totalDetected semantics

## Benchmark
BenchmarkCleanReconcileDiscovery on 512 unchanged files, three runs:
- authoritative census: 10.77–10.93 ms/op, 480–482 KB/op, 4,146 allocs/op
- legacy double walk: 21.22–21.73 ms/op, 962–966 KB/op, 8,293–8,294 allocs/op

This removes roughly half the unchanged-restart discovery time and allocations.

## Verification
- go test ./internal/indexer -count=1
- go test -race ./internal/indexer -count=1
- golangci-lint run ./internal/indexer/...
- focused clean-census, Merkle fallback, exclusion, contract-manifest, and search-bootstrap tests
- go test ./... passed every package except one concurrent-load wall-clock benchmark; rerunning TestColdIndexNoWallClockRegression alone passed

Independent review found and verified the Merkle, filesystem-error, and tiny-repository manifest routing guards.