### PR TITLE
perf(indexer): share parse memory admission across repositories

### DIFF
--- a/cmd/gortex/daemon_state.go
+++ b/cmd/gortex/daemon_state.go
@@ -419,14 +419,26 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 	if workers > len(repos) {
 		workers = len(repos)
 	}
+	parseBudget, currentMemory, budgetErr := currentWarmupMemoryBudgetBytes()
+	state.multiIndexer.SetSharedParseMemoryBudget(parseBudget)
+	if budgetErr != nil {
+		logger.Warn("daemon: invalid warmup memory budget; using automatic budget",
+			zap.String("env", warmupMemoryBudgetEnv),
+			zap.String("value", os.Getenv(warmupMemoryBudgetEnv)),
+			zap.Error(budgetErr))
+	}
 	logger.Info("daemon: warmup phase start",
 		zap.String("phase", "parallel_parse"),
 		zap.Int("repos", len(repos)),
 		zap.Int("workers", workers),
+		zap.Int64("shared_parse_budget_mb", parseBudget>>20),
+		zap.Uint64("managed_memory_mb", currentMemory>>20),
 		zap.Bool("snapshot_partial_forces_full_walk", state.snapshotPartial))
 	publishReadinessPhase(state, "parallel_parse", false, map[string]any{
-		"tracked_repos": len(repos),
-		"workers":       workers,
+		"tracked_repos":          len(repos),
+		"workers":                workers,
+		"shared_parse_budget_mb": parseBudget >> 20,
+		"managed_memory_mb":      currentMemory >> 20,
 	})
 	phaseStart := time.Now()
 

--- a/cmd/gortex/daemon_warmup_admission.go
+++ b/cmd/gortex/daemon_warmup_admission.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"runtime/debug"
+	"strconv"
+	"strings"
+)
+
+const (
+	defaultWarmupMemoryBudgetBytes int64 = 512 << 20
+	minWarmupMemoryBudgetBytes     int64 = 32 << 20
+	warmupMemoryBudgetEnv                = "GORTEX_WARMUP_MEMORY_MB"
+)
+
+// currentGoMemoryBytes matches the runtime memory-limit definition:
+// MemStats.Sys - MemStats.HeapReleased. HeapAlloc alone omits stacks, runtime
+// metadata, retained spans, and other managed memory that counts toward
+// GOMEMLIMIT and would overstate the headroom available to parsing.
+func currentGoMemoryBytes(mem runtime.MemStats) uint64 {
+	if mem.HeapReleased >= mem.Sys {
+		return 0
+	}
+	return mem.Sys - mem.HeapReleased
+}
+
+func currentWarmupMemoryBudgetBytes() (budget int64, current uint64, overrideErr error) {
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+	current = currentGoMemoryBytes(mem)
+	limit := debug.SetMemoryLimit(-1)
+	budget, overrideErr = resolvedWarmupMemoryBudgetBytes(
+		os.Getenv(warmupMemoryBudgetEnv), limit, current,
+	)
+	return budget, current, overrideErr
+}
+
+func resolvedWarmupMemoryBudgetBytes(rawOverride string, goMemoryLimit int64, currentMemory uint64) (int64, error) {
+	budget, overrideErr := warmupMemoryBudgetBytes(rawOverride, goMemoryLimit, currentMemory)
+	if overrideErr != nil {
+		// Ignore only the malformed override. Retain the automatic
+		// GOMEMLIMIT/headroom calculation rather than jumping to 512 MiB.
+		budget, _ = warmupMemoryBudgetBytes("", goMemoryLimit, currentMemory)
+	}
+	return budget, overrideErr
+}
+
+// warmupMemoryBudgetBytes resolves the daemon-wide parse bytes-in-flight
+// budget. An explicit positive MiB override wins. Otherwise at most half of
+// remaining Go-managed-memory headroom is admitted, capped at the existing
+// 512 MiB per-Indexer default. A small floor guarantees forward progress when
+// the process is already close to a configured limit; the shared gate still
+// admits only one floor-sized-or-larger file in that state.
+func warmupMemoryBudgetBytes(rawOverride string, goMemoryLimit int64, currentMemory uint64) (int64, error) {
+	if rawOverride != "" {
+		mb, err := strconv.ParseInt(strings.TrimSpace(rawOverride), 10, 64)
+		if err != nil || mb <= 0 || mb > (1<<62)/(1<<20) {
+			return 0, fmt.Errorf("%s must be a positive MiB integer", warmupMemoryBudgetEnv)
+		}
+		return mb << 20, nil
+	}
+
+	budget := defaultWarmupMemoryBudgetBytes
+	if goMemoryLimit <= 0 || goMemoryLimit >= 1<<60 {
+		return budget, nil
+	}
+	headroom := goMemoryLimit - int64(currentMemory)
+	if headroom <= 0 {
+		return minWarmupMemoryBudgetBytes, nil
+	}
+	if headroom/2 < budget {
+		budget = headroom / 2
+	}
+	if budget < minWarmupMemoryBudgetBytes {
+		budget = minWarmupMemoryBudgetBytes
+	}
+	return budget, nil
+}

--- a/cmd/gortex/daemon_warmup_admission_test.go
+++ b/cmd/gortex/daemon_warmup_admission_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCurrentGoMemoryBytesMatchesRuntimeLimitMetric(t *testing.T) {
+	tests := []struct {
+		name string
+		mem  runtime.MemStats
+		want uint64
+	}{
+		{name: "subtracts released pages", mem: runtime.MemStats{Sys: 1_000, HeapReleased: 300}, want: 700},
+		{name: "equal is zero", mem: runtime.MemStats{Sys: 1_000, HeapReleased: 1_000}, want: 0},
+		{name: "greater is guarded", mem: runtime.MemStats{Sys: 1_000, HeapReleased: 1_100}, want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, currentGoMemoryBytes(tt.mem))
+		})
+	}
+}
+
+func TestWarmupMemoryBudgetBytes(t *testing.T) {
+	const mib = int64(1 << 20)
+	tests := []struct {
+		name     string
+		override string
+		limit    int64
+		current  uint64
+		want     int64
+		wantErr  bool
+	}{
+		{name: "explicit override", override: "768", limit: 256 * mib, current: 240 << 20, want: 768 * mib},
+		{name: "unlimited uses default", limit: 1 << 62, want: defaultWarmupMemoryBudgetBytes},
+		{name: "half remaining headroom", limit: 1 << 30, current: 256 << 20, want: 384 * mib},
+		{name: "headroom is capped", limit: 4 << 30, current: 128 << 20, want: defaultWarmupMemoryBudgetBytes},
+		{name: "near limit keeps progress floor", limit: 256 * mib, current: 224 << 20, want: minWarmupMemoryBudgetBytes},
+		{name: "at limit keeps progress floor", limit: 256 * mib, current: 256 << 20, want: minWarmupMemoryBudgetBytes},
+		{name: "invalid override", override: "many", limit: 1 << 62, wantErr: true},
+		{name: "zero override", override: "0", limit: 1 << 62, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := warmupMemoryBudgetBytes(tt.override, tt.limit, tt.current)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResolvedWarmupMemoryBudgetInvalidOverrideKeepsAutomaticHeadroom(t *testing.T) {
+	const mib = int64(1 << 20)
+	budget, err := resolvedWarmupMemoryBudgetBytes("many", 256*mib, 224<<20)
+	require.Error(t, err)
+	assert.Equal(t, minWarmupMemoryBudgetBytes, budget)
+}

--- a/internal/indexer/file_delta.go
+++ b/internal/indexer/file_delta.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/zzet/gortex/internal/graph"
@@ -41,6 +42,8 @@ type preparedExtraction struct {
 	src         []byte
 	result      *parser.ExtractionResult
 	readVersion fileReadVersion
+	parseLease  *parseAdmissionLease
+	releaseOnce sync.Once
 }
 
 // fileDeltaProbe exposes phase timings and the three delta boundaries used by
@@ -61,32 +64,67 @@ type fileDeltaProbe struct {
 // fingerprint gets one conservative structural patch, which stamps the file
 // for subsequent edits.
 func (idx *Indexer) prepareFileDelta(filePath string) (fileDeltaProbe, bool) {
+	probe, ok, _ := idx.prepareFileDeltaWithAdmission(filePath, false)
+	return probe, ok
+}
+
+// prepareFileDeltaWithAdmission optionally attempts shared admission without
+// waiting. Incremental chunks use tryOnly after they retain their first staged
+// result: pressure then returns admissionBusy so the caller can commit and
+// release the partial chunk before retrying this file. The first file in a
+// chunk still waits, guaranteeing progress even when it is larger than the
+// entire budget (its weight is clamped to capacity).
+func (idx *Indexer) prepareFileDeltaWithAdmission(filePath string, tryOnly bool) (fileDeltaProbe, bool, bool) {
 	var probe fileDeltaProbe
 	absPath, err := filepath.Abs(filePath)
 	if err != nil {
-		return probe, false
+		return probe, false, false
 	}
+	var parseLease *parseAdmissionLease
+	if tryOnly {
+		var admitted bool
+		parseLease, admitted = idx.tryAcquireSharedParsePath(absPath)
+		if !admitted {
+			return probe, false, true
+		}
+	} else {
+		parseLease, err = idx.acquireSharedParsePath(absPath)
+		if err != nil {
+			return probe, false, false
+		}
+	}
+	var (
+		result  *parser.ExtractionResult
+		skipped bool
+	)
+	stored := false
+	defer func() {
+		if !stored {
+			result.ReleaseTree()
+			parseLease.Release()
+		}
+	}()
 	relPath := idx.relKey(absPath)
 
 	started := time.Now()
 	src, readVersion, err := readFileWithVersion(absPath)
 	probe.read = time.Since(started)
 	if err != nil {
-		return probe, false
+		return probe, false, false
 	}
 	lang, ok := idx.effectiveLanguage(absPath, src)
 	if !ok {
-		return probe, false
+		return probe, false, false
 	}
 	ext, _ := idx.registry.GetByLanguage(lang)
 	if ext == nil {
-		return probe, false
+		return probe, false, false
 	}
 	if maxSize := idx.config.MaxFileSize; maxSize > 0 && int64(len(src)) > maxSize {
-		return probe, false
+		return probe, false, false
 	}
 	if _, skip := idx.newContentAdmissionGate().skip(lang, int64(len(src))); skip {
-		return probe, false
+		return probe, false, false
 	}
 	src = idx.transforms.run(relPath, src)
 
@@ -96,23 +134,16 @@ func (idx *Indexer) prepareFileDelta(filePath string) (fileDeltaProbe, bool) {
 		pool, quarantine = idx.sharedParsePool()
 	}
 	started = time.Now()
-	result, skipped, err := idx.extractFile(pool, quarantine, absPath, relPath, lang, ext, src)
+	result, skipped, err = idx.extractFile(pool, quarantine, absPath, relPath, lang, ext, src)
 	probe.extract = time.Since(started)
 	if quarantine != nil && quarantine.Len() > 0 {
 		_ = quarantine.Save()
 	}
-	// Ownership of the result's tree-sitter tree — C memory the Go GC
-	// cannot reclaim — passes to idx.prepared only on the success path
-	// at the bottom. Every early return below drops the result on the
-	// floor, so release the tree unless it was stored.
-	stored := false
-	defer func() {
-		if !stored {
-			result.ReleaseTree()
-		}
-	}()
+	// Ownership of the result's tree-sitter tree, source bytes, and shared
+	// admission lease passes to idx.prepared only on the success path below.
+	// The defer releases all three resources on every rejected probe.
 	if result == nil || skipped || err != nil {
-		return probe, false
+		return probe, false, false
 	}
 
 	started = time.Now()
@@ -123,7 +154,7 @@ func (idx *Indexer) prepareFileDelta(filePath string) (fileDeltaProbe, bool) {
 	fingerprints, derived, ok := extractionFingerprints(result)
 	probe.fingerprintTime = time.Since(started)
 	if !ok {
-		return probe, false
+		return probe, false, false
 	}
 	probe.fingerprints = fingerprints
 	probe.derived = derived
@@ -145,37 +176,42 @@ func (idx *Indexer) prepareFileDelta(filePath string) (fileDeltaProbe, bool) {
 		src:         append([]byte(nil), src...),
 		result:      result,
 		readVersion: readVersion,
+		parseLease:  parseLease,
 	}
 	idx.preparedMu.Unlock()
-	// Released outside the lock: Release closes the tree through cgo.
-	displaced.releaseTree()
+	// Released outside the lock: release closes the tree through cgo and
+	// returns the displaced entry's shared admission capacity.
+	displaced.release()
 	stored = true
 	probe.readVersion = readVersion
-	return probe, true
+	return probe, true, false
 }
 
-// releaseTree drops the prepared extraction's parse tree. Nil-safe on
-// the entry and on the result, so a caller that took a map slot which
-// may or may not have been occupied can call it unconditionally.
-func (p *preparedExtraction) releaseTree() {
+// release drops every resource owned by a prepared extraction. It is nil-safe
+// and idempotent because prepared entries can be released by a deferred batch
+// cleanup after an explicit post-commit release.
+func (p *preparedExtraction) release() {
 	if p == nil {
 		return
 	}
-	p.result.ReleaseTree()
+	p.releaseOnce.Do(func() {
+		p.result.ReleaseTree()
+		p.parseLease.Release()
+	})
 }
 
-func (idx *Indexer) takePreparedExtraction(absPath, relPath, lang string, src []byte) (*parser.ExtractionResult, bool) {
+func (idx *Indexer) takePreparedExtraction(absPath, relPath, lang string, src []byte) (*preparedExtraction, bool) {
 	idx.preparedMu.Lock()
 	prepared := idx.prepared[absPath]
 	delete(idx.prepared, absPath)
 	idx.preparedMu.Unlock()
 	if prepared == nil || prepared.relPath != relPath || prepared.lang != lang || !bytes.Equal(prepared.src, src) {
-		// The entry is already out of the map and the caller gets
-		// nothing, so this is the last reference to its tree.
-		prepared.releaseTree()
+		// The entry is already out of the map and the caller gets nothing,
+		// so this is the last reference to its retained resources.
+		prepared.release()
 		return nil, false
 	}
-	return prepared.result, true
+	return prepared, true
 }
 
 // takePreparedSnapshot consumes the speculative parse without re-reading disk.
@@ -205,14 +241,14 @@ func (idx *Indexer) takePreparedRefresh(filePath string) (*preparedExtraction, b
 	}
 	current, readVersion, err := readFileWithVersion(absPath)
 	if err != nil {
-		prepared.releaseTree()
+		prepared.release()
 		return nil, false
 	}
 	current = idx.transforms.run(prepared.relPath, current)
 	if !bytes.Equal(current, prepared.src) {
 		// The file moved on since the speculative parse; the entry is
-		// already out of the map, so drop its tree with it.
-		prepared.releaseTree()
+		// already out of the map, so drop all retained resources with it.
+		prepared.release()
 		return nil, false
 	}
 	prepared.readVersion = readVersion
@@ -228,8 +264,8 @@ func (idx *Indexer) discardPreparedExtraction(filePath string) {
 	discarded := idx.prepared[absPath]
 	delete(idx.prepared, absPath)
 	idx.preparedMu.Unlock()
-	// Released outside the lock: Release closes the tree through cgo.
-	discarded.releaseTree()
+	// Released outside the lock: release closes the tree through cgo.
+	discarded.release()
 }
 
 type fingerprintMode uint8
@@ -709,7 +745,7 @@ func (idx *Indexer) applyPreparedMetadataRefresh(filePath string, priorNodes []*
 	// so this function owns the tree. Only Nodes/Edges are read from
 	// here on, and every shape-mismatch check below returns early —
 	// release on all of them.
-	defer result.ReleaseTree()
+	defer prepared.release()
 	idx.applyRepoPrefix(result.Nodes, result.Edges)
 	graphPath := idx.prefixPath(prepared.relPath)
 

--- a/internal/indexer/incremental_batch.go
+++ b/internal/indexer/incremental_batch.go
@@ -33,6 +33,7 @@ type incrementalBatchStage struct {
 	graphPath     string
 	src           []byte
 	result        *parser.ExtractionResult
+	prepared      *preparedExtraction
 	priorNodes    []*graph.Node
 	storedGraph   fileDeltaFingerprints
 	storedDerived derivedFingerprints
@@ -43,6 +44,16 @@ type incrementalBatchStage struct {
 	reuse         map[reuseKey]*reuseVal
 	priorPending  []*graph.Edge
 	bytes         int64
+}
+
+func (stage *incrementalBatchStage) releasePrepared() {
+	if stage == nil {
+		return
+	}
+	stage.prepared.release()
+	stage.prepared = nil
+	stage.src = nil
+	stage.result = nil
 }
 
 type fileReadReceipt struct {
@@ -170,9 +181,7 @@ func (idx *Indexer) reindexIncrementalChunk(
 	// release the batch's trees on every exit, committed or not.
 	defer func() {
 		for _, stage := range stages {
-			if stage != nil {
-				stage.result.ReleaseTree()
-			}
+			stage.releasePrepared()
 		}
 	}()
 	fallbacks := make([]incrementalFallback, 0)
@@ -185,7 +194,15 @@ func (idx *Indexer) reindexIncrementalChunk(
 		priorNodes := priorByFile[graphPath]
 		storedGraph := storedExtractionGraphFingerprints(priorNodes)
 		storedDerived := storedDerivedFingerprints(priorNodes)
-		probe, probeOK := idx.prepareFileDelta(filePath)
+		// Once this chunk retains a prepared result, never block while
+		// asking the shared budget for another. Admission pressure flushes
+		// the partial chunk and retries this file in the next chunk; this
+		// prevents repositories from each holding a partial batch while all
+		// wait for capacity owned by the others.
+		probe, probeOK, admissionBusy := idx.prepareFileDeltaWithAdmission(filePath, len(stages) > 0)
+		if admissionBusy {
+			break
+		}
 		consumed++
 
 		if probeOK && storedGraph.semantic != "" &&
@@ -214,6 +231,7 @@ func (idx *Indexer) reindexIncrementalChunk(
 			prepared, ok = idx.takePreparedRefresh(filePath)
 		}
 		if !ok || prepared == nil || prepared.result == nil {
+			prepared.release()
 			fallbacks = append(fallbacks, incrementalFallback{
 				filePath: filePath, graphPath: graphPath, priorNodes: priorNodes,
 				storedGraph: storedGraph, storedDerived: storedDerived,
@@ -227,7 +245,7 @@ func (idx *Indexer) reindexIncrementalChunk(
 			absPath: filePath, mtimeKey: idx.relKey(filePath),
 			readVersion: prepared.readVersion,
 			relPath:     prepared.relPath, graphPath: graphPath,
-			src: prepared.src, result: prepared.result, priorNodes: priorNodes,
+			src: prepared.src, result: prepared.result, prepared: prepared, priorNodes: priorNodes,
 			storedGraph: storedGraph, storedDerived: storedDerived, probe: probe,
 			metadataOnly: storedGraph.semantic != "" &&
 				probe.fingerprints.semantic == storedGraph.semantic,
@@ -249,6 +267,12 @@ func (idx *Indexer) reindexIncrementalChunk(
 			receipts = append(receipts, fileReadReceipt{
 				absPath: stage.absPath, mtimeKey: stage.mtimeKey, readVersion: stage.readVersion,
 			})
+		}
+		// Commit no longer reads the staged source, result, or tree. Return
+		// their shared admission capacity before fallback work or receipt
+		// validation can wait behind another repository.
+		for _, stage := range stages {
+			stage.releasePrepared()
 		}
 	}
 	freshPaths, stalePaths := idx.recordFileReadVersionsBatched(receipts)

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -157,6 +157,11 @@ type Indexer struct {
 	// directly through the bounded graph accumulator.
 	shadowAdmission *shadowAdmissionBudget
 
+	// parseAdmission is the optional daemon-wide bytes-in-flight gate shared by
+	// every repository. Each Indexer keeps its private configured gate too; a
+	// file must satisfy both before its bytes and parse tree are materialised.
+	parseAdmission atomic.Pointer[parseAdmissionBudget]
+
 	// indexCount tracks how many IndexCtx calls this Indexer has
 	// completed. Gates the cold-start shadow-swap: each per-repo
 	// Indexer in MultiIndexer is fresh (indexCount==0), so all of
@@ -2982,11 +2987,12 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 	// serialises instead of all workers materialising whole files and
 	// their parse trees at once. Code files are tiny and flow freely;
 	// only genuinely large inputs queue. budget <= 0 disables the cap.
-	parseBudget := idx.config.MaxParseBytesInFlight
-	var parseSem *semaphore.Weighted
-	if parseBudget > 0 {
-		parseSem = semaphore.NewWeighted(parseBudget)
+	localParseBudget := idx.config.MaxParseBytesInFlight
+	var localParseSem *semaphore.Weighted
+	if localParseBudget > 0 {
+		localParseSem = semaphore.NewWeighted(localParseBudget)
 	}
+	sharedParseAdmission := idx.parseAdmission.Load()
 
 	// In addition to the bytes-in-flight budget above, cap how many
 	// genuinely large files are *read* concurrently: a few huge PDFs /
@@ -3095,13 +3101,14 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 					// bytes-in-flight budget before reading it, so large
 					// content files serialise instead of all workers
 					// materialising whole files at once.
-					var weight int64
-					if parseSem != nil {
-						weight = clampParseWeight(wf.size, parseBudget)
-						semStart := time.Now()
-						if aerr := parseSem.Acquire(ctx, weight); aerr != nil {
-							return
-						}
+					semStart := time.Now()
+					parseLease, aerr := acquireParseAdmission(
+						ctx, wf.size, localParseBudget, localParseSem, sharedParseAdmission,
+					)
+					if aerr != nil {
+						return
+					}
+					if parseLease != nil {
 						atomic.AddInt64(&parseSemWaitNS, int64(time.Since(semStart)))
 					}
 
@@ -3113,9 +3120,6 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 					if walkExt, found := idx.registry.GetByLanguage(wf.lang); found && parsePool == nil {
 						if se, ok := walkExt.(parser.StreamingExtractor); ok {
 							result, serr := idx.extractStreaming(se, path, relPath)
-							if parseSem != nil {
-								parseSem.Release(weight)
-							}
 							if serr != nil {
 								errMu.Lock()
 								errors = append(errors, IndexError{FilePath: path, Error: serr.Error()})
@@ -3125,6 +3129,7 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 								errMu.Unlock()
 							}
 							if result == nil {
+								parseLease.Release()
 								continue
 							}
 							idx.applyRepoPrefix(result.Nodes, result.Edges)
@@ -3152,6 +3157,7 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 								}
 							}
 							sidecars.addConstValues(result)
+							parseLease.Release()
 							continue
 						}
 					}
@@ -3163,9 +3169,7 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 						errMu.Lock()
 						errors = append(errors, IndexError{FilePath: path, Error: err.Error()})
 						errMu.Unlock()
-						if parseSem != nil {
-							parseSem.Release(weight)
-						}
+						parseLease.Release()
 						continue
 					}
 
@@ -3188,9 +3192,7 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 						}
 					}
 					if ext == nil {
-						if parseSem != nil {
-							parseSem.Release(weight)
-						}
+						parseLease.Release()
 						continue
 					}
 
@@ -3202,15 +3204,13 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 					extractStart := time.Now()
 					result, skipped, err := idx.extractFile(parsePool, quarantine, path, relPath, lang, ext, src)
 					atomic.AddInt64(&parseExtractNS, int64(time.Since(extractStart)))
-					if parseSem != nil {
-						parseSem.Release(weight)
-					}
 					if err != nil {
 						errMu.Lock()
 						errors = append(errors, IndexError{FilePath: path, Error: err.Error()})
 						errMu.Unlock()
 					}
 					if result == nil {
+						parseLease.Release()
 						// A full-index parse failure that produced no nodes:
 						// record it for a skip-node post-pass so the file
 						// stays visible instead of vanishing. (The live-modify
@@ -3333,6 +3333,7 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 					// long-lived worker goroutine, so a defer would pin
 					// every tree in the chunk until the worker exits.
 					result.ReleaseTree()
+					parseLease.Release()
 					atomic.AddInt64(&fileCount, 1)
 				}
 				if len(localContracts) > 0 {
@@ -4051,69 +4052,96 @@ func (idx *Indexer) indexFile(
 		idx.graph.EvictFile(graphPath)
 	}
 
-	src, readVersion, err := readFileWithVersion(absPath)
-	if err != nil {
-		return err
+	// A delta probe already owns a shared admission lease together with its
+	// transformed source and parse tree. Validate and consume that snapshot
+	// before acquiring another lease; acquiring first can self-deadlock when
+	// one oversized prepared file owns the entire shared budget.
+	preparedEntry, prepared := idx.takePreparedRefresh(absPath)
+	if prepared && preparedEntry.relPath != relPath {
+		preparedEntry.release()
+		preparedEntry = nil
+		prepared = false
 	}
+	var (
+		parseLease  *parseAdmissionLease
+		src         []byte
+		readVersion fileReadVersion
+		lang        string
+		result      *parser.ExtractionResult
+		skipped     bool
+	)
+	defer func() { parseLease.Release() }()
 
-	lang, ok := idx.effectiveLanguage(absPath, src)
-	if !ok {
-		return nil
-	}
-	ext, _ := idx.registry.GetByLanguage(lang)
-	if ext == nil {
-		return nil
-	}
-
-	// Honour the size cap on the incremental path too: an over-cap
-	// file gets a synthetic skip node, not a parse — matching the
-	// bulk IndexCtx walk. This IS a successful result, so it evicts the
-	// prior state and installs the synthetic node, same as before.
-	if maxSize := idx.config.MaxFileSize; maxSize > 0 && int64(len(src)) > maxSize {
-		n := sizeSkipNode(skippedFile{
-			relPath: relPath, lang: lang, size: int64(len(src)),
-		}, maxSize)
-		idx.applyRepoPrefix([]*graph.Node{n}, nil)
-		evictExisting()
-		idx.graph.AddBatch([]*graph.Node{n}, nil)
-		if !idx.recordFileReadVersion(mtimeKey, absPath, readVersion) {
-			return errFileVersionChanged
+	if prepared {
+		parseLease = preparedEntry.parseLease
+		src = preparedEntry.src
+		readVersion = preparedEntry.readVersion
+		lang = preparedEntry.lang
+		result = preparedEntry.result
+	} else {
+		parseLease, err = idx.acquireSharedParsePath(absPath)
+		if err != nil {
+			return err
 		}
-		return nil
-	}
-
-	// Honour the content-admission gate on the incremental path too, so a
-	// document over its cap (or a data asset, by default) the cold walk
-	// would skip doesn't get parsed back in when the watcher re-indexes it
-	// — same synthetic-skip-node treatment as the size cap above.
-	if reason, skip := idx.newContentAdmissionGate().skip(lang, int64(len(src))); skip {
-		n := contentSkipNode(skippedFile{
-			relPath: relPath, lang: lang, size: int64(len(src)), reason: reason,
-		})
-		idx.applyRepoPrefix([]*graph.Node{n}, nil)
-		evictExisting()
-		idx.graph.AddBatch([]*graph.Node{n}, nil)
-		if !idx.recordFileReadVersion(mtimeKey, absPath, readVersion) {
-			return errFileVersionChanged
+		src, readVersion, err = readFileWithVersion(absPath)
+		if err != nil {
+			return err
 		}
-		return nil
-	}
 
-	// Pre-ingestion transforms — same pipeline as the bulk path.
-	src = idx.transforms.run(relPath, src)
+		var ok bool
+		lang, ok = idx.effectiveLanguage(absPath, src)
+		if !ok {
+			return nil
+		}
+		ext, _ := idx.registry.GetByLanguage(lang)
+		if ext == nil {
+			return nil
+		}
 
-	// Crash isolation for the incremental path: a file the user just
-	// saved that SIGSEGVs the parser is quarantined instead of taking
-	// the daemon down with it. The pool is long-lived and shared, so
-	// the watcher hot path never forks a worker subprocess per file.
-	var pool *crashpool.Pool
-	var quarantine *crashpool.Quarantine
-	if idx.crashIsolationEnabled() {
-		pool, quarantine = idx.sharedParsePool()
-	}
-	result, prepared := idx.takePreparedExtraction(absPath, relPath, lang, src)
-	skipped := false
-	if !prepared {
+		// Honour the size cap on the incremental path too: an over-cap
+		// file gets a synthetic skip node, not a parse — matching the
+		// bulk IndexCtx walk. This IS a successful result, so it evicts the
+		// prior state and installs the synthetic node, same as before.
+		if maxSize := idx.config.MaxFileSize; maxSize > 0 && int64(len(src)) > maxSize {
+			n := sizeSkipNode(skippedFile{
+				relPath: relPath, lang: lang, size: int64(len(src)),
+			}, maxSize)
+			idx.applyRepoPrefix([]*graph.Node{n}, nil)
+			evictExisting()
+			idx.graph.AddBatch([]*graph.Node{n}, nil)
+			if !idx.recordFileReadVersion(mtimeKey, absPath, readVersion) {
+				return errFileVersionChanged
+			}
+			return nil
+		}
+
+		// Honour the content-admission gate on the incremental path too,
+		// so a document over its cap (or a data asset, by default) the cold
+		// walk would skip does not get parsed back in after a watcher event.
+		if reason, skip := idx.newContentAdmissionGate().skip(lang, int64(len(src))); skip {
+			n := contentSkipNode(skippedFile{
+				relPath: relPath, lang: lang, size: int64(len(src)), reason: reason,
+			})
+			idx.applyRepoPrefix([]*graph.Node{n}, nil)
+			evictExisting()
+			idx.graph.AddBatch([]*graph.Node{n}, nil)
+			if !idx.recordFileReadVersion(mtimeKey, absPath, readVersion) {
+				return errFileVersionChanged
+			}
+			return nil
+		}
+
+		// Pre-ingestion transforms — same pipeline as the bulk path.
+		src = idx.transforms.run(relPath, src)
+
+		// Crash isolation for the incremental path: a file the user just
+		// saved that SIGSEGVs the parser is quarantined instead of taking
+		// the daemon down with it. The pool is long-lived and shared.
+		var pool *crashpool.Pool
+		var quarantine *crashpool.Quarantine
+		if idx.crashIsolationEnabled() {
+			pool, quarantine = idx.sharedParsePool()
+		}
 		result, skipped, err = idx.extractFile(pool, quarantine, absPath, relPath, lang, ext, src)
 		if quarantine != nil && quarantine.Len() > 0 {
 			_ = quarantine.Save()
@@ -4223,6 +4251,11 @@ func (idx *Indexer) indexFile(
 	idx.graph.AddBatch(result.Nodes, result.Edges)
 	idx.persistConstValues(result)
 	idx.persistFileMeta(relPath, src, result)
+	// No subsequent stage reads source bytes or the parse tree. Release both
+	// here instead of retaining them through resolver/enrichment work; the
+	// deferred calls above remain as idempotent guards for every early return.
+	result.ReleaseTree()
+	parseLease.Release()
 
 	// Add new symbols to search index. shouldIndexForSearch enforces
 	// the same SkipSearch filter used by the bulk and upgrade paths.

--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -84,6 +84,12 @@ type MultiIndexer struct {
 	// immediately stream to SQLite instead of waiting or overcommitting RAM.
 	shadowAdmission *shadowAdmissionBudget
 
+	// parseAdmission is the daemon-wide bytes-in-flight gate propagated to
+	// every per-repo Indexer. Unlike the shadow gate it blocks briefly instead
+	// of falling back, because parsing must happen somewhere; sharing one gate
+	// prevents N parallel repos from each consuming their full private budget.
+	parseAdmission atomic.Pointer[parseAdmissionBudget]
+
 	// reconcileMu serialises ReconcileContractEdges end-to-end. The pass
 	// evicts the prior EdgeMatches / topic / bridge generation and mints
 	// a fresh one across many independent graph-store writes — it is NOT
@@ -295,6 +301,7 @@ func (mi *MultiIndexer) newPerRepoIndexerGuardedWithMode(
 ) *Indexer {
 	idx := New(mi.graph, mi.registry, cfg, mi.logger)
 	idx.shadowAdmission = mi.shadowAdmission
+	idx.parseAdmission.Store(mi.parseAdmission.Load())
 	idx.repositoryMutationOwner = mi
 	idx.search = mi.search
 	if mi.embedder != nil {

--- a/internal/indexer/parse_admission.go
+++ b/internal/indexer/parse_admission.go
@@ -1,0 +1,255 @@
+package indexer
+
+import (
+	"context"
+	"os"
+	"sync"
+
+	"golang.org/x/sync/semaphore"
+)
+
+// parseAdmissionBudget is shared by every per-repository Indexer owned by one
+// daemon. Local Indexer budgets still apply; this additional gate prevents the
+// parallel warmup/watcher lanes from multiplying that per-repo allowance.
+type parseAdmissionBudget struct {
+	capacity int64
+	mu       sync.Mutex
+	used     int64
+	waiters  []*parseAdmissionWaiter
+	bypasses int
+}
+
+type parseAdmissionWaiter struct {
+	weight  int64
+	ready   chan struct{}
+	granted bool
+}
+
+// A partial incremental chunk may continue past an already-queued first-file
+// waiter so SQLite batching does not collapse immediately under concurrency.
+// The allowance is deliberately one less than the 32-file chunk ceiling: once
+// spent, every active chunk must flush and release, guaranteeing the FIFO head
+// eventually obtains even a capacity-sized reservation.
+const maxParseAdmissionBypasses = incrementalBatchFiles - 1
+
+func newParseAdmissionBudget(capacity int64) *parseAdmissionBudget {
+	if capacity <= 0 {
+		return nil
+	}
+	return &parseAdmissionBudget{capacity: capacity}
+}
+
+func (budget *parseAdmissionBudget) acquire(ctx context.Context, weight int64) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	budget.mu.Lock()
+	select {
+	case <-ctx.Done():
+		budget.mu.Unlock()
+		return ctx.Err()
+	default:
+	}
+	if len(budget.waiters) == 0 && budget.used+weight <= budget.capacity {
+		budget.used += weight
+		budget.mu.Unlock()
+		return nil
+	}
+	waiter := &parseAdmissionWaiter{weight: weight, ready: make(chan struct{})}
+	budget.waiters = append(budget.waiters, waiter)
+	budget.grantWaitersLocked()
+	if waiter.granted {
+		budget.mu.Unlock()
+		return nil
+	}
+	budget.mu.Unlock()
+
+	select {
+	case <-waiter.ready:
+		select {
+		case <-ctx.Done():
+			budget.release(waiter.weight)
+			return ctx.Err()
+		default:
+			return nil
+		}
+	case <-ctx.Done():
+		budget.mu.Lock()
+		if waiter.granted {
+			// The reservation won the race with cancellation. Return the
+			// caller's cancellation while making the granted capacity
+			// immediately available to the next FIFO waiter.
+			budget.used -= waiter.weight
+		} else {
+			for i, queued := range budget.waiters {
+				if queued == waiter {
+					budget.waiters = append(budget.waiters[:i], budget.waiters[i+1:]...)
+					break
+				}
+			}
+		}
+		budget.grantWaitersLocked()
+		budget.mu.Unlock()
+		return ctx.Err()
+	}
+}
+
+func (budget *parseAdmissionBudget) grantWaitersLocked() {
+	for len(budget.waiters) > 0 {
+		waiter := budget.waiters[0]
+		if budget.used+waiter.weight > budget.capacity {
+			return
+		}
+		budget.waiters[0] = nil
+		budget.waiters = budget.waiters[1:]
+		budget.used += waiter.weight
+		waiter.granted = true
+		close(waiter.ready)
+		budget.bypasses = 0
+	}
+	budget.bypasses = 0
+}
+
+// tryAcquire admits currently available capacity ahead of a FIFO waiter only
+// for a bounded number of chunk continuations. This preserves useful SQLite
+// batching without the unbounded starvation of an unfair try-lock or the
+// immediate one-file collapse of x/sync/semaphore.TryAcquire.
+func (budget *parseAdmissionBudget) tryAcquire(weight int64) bool {
+	budget.mu.Lock()
+	defer budget.mu.Unlock()
+	if budget.used+weight > budget.capacity {
+		return false
+	}
+	if len(budget.waiters) > 0 {
+		if budget.bypasses >= maxParseAdmissionBypasses {
+			return false
+		}
+		budget.bypasses++
+	}
+	budget.used += weight
+	return true
+}
+
+func (budget *parseAdmissionBudget) release(weight int64) {
+	if budget == nil || weight <= 0 {
+		return
+	}
+	budget.mu.Lock()
+	budget.used -= weight
+	budget.grantWaitersLocked()
+	budget.mu.Unlock()
+}
+
+type parseAdmissionLease struct {
+	shared       *parseAdmissionBudget
+	sharedWeight int64
+	local        *semaphore.Weighted
+	localWeight  int64
+	once         sync.Once
+}
+
+// acquireParseAdmission takes the process-wide lease first and the private
+// per-Indexer lease second. Every caller uses that order, so cross-repository
+// parsing cannot deadlock. If local admission is cancelled, the already-held
+// shared capacity is returned before the error escapes.
+func acquireParseAdmission(
+	ctx context.Context,
+	fileSize int64,
+	localBudget int64,
+	local *semaphore.Weighted,
+	shared *parseAdmissionBudget,
+) (*parseAdmissionLease, error) {
+	if local == nil && shared == nil {
+		return nil, nil
+	}
+	lease := &parseAdmissionLease{shared: shared, local: local}
+	if shared != nil {
+		lease.sharedWeight = clampParseWeight(fileSize, shared.capacity)
+		if err := shared.acquire(ctx, lease.sharedWeight); err != nil {
+			return nil, err
+		}
+	}
+	if local != nil {
+		lease.localWeight = clampParseWeight(fileSize, localBudget)
+		if err := local.Acquire(ctx, lease.localWeight); err != nil {
+			if shared != nil {
+				shared.release(lease.sharedWeight)
+			}
+			return nil, err
+		}
+	}
+	return lease, nil
+}
+
+func (lease *parseAdmissionLease) Release() {
+	if lease == nil {
+		return
+	}
+	lease.once.Do(func() {
+		if lease.local != nil {
+			lease.local.Release(lease.localWeight)
+		}
+		if lease.shared != nil {
+			lease.shared.release(lease.sharedWeight)
+		}
+	})
+}
+
+func (idx *Indexer) acquireSharedParsePath(path string) (*parseAdmissionLease, error) {
+	shared := idx.parseAdmission.Load()
+	if shared == nil {
+		return nil, nil
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		// The caller's authoritative read/stat path reports the filesystem
+		// error. No bytes can be materialised, so no admission is needed.
+		return nil, nil
+	}
+	return acquireParseAdmission(context.Background(), info.Size(), 0, nil, shared)
+}
+
+// tryAcquireSharedParsePath is the non-blocking counterpart used while an
+// incremental chunk already owns prepared results. If the shared budget is
+// busy, the caller flushes that partial chunk (releasing its leases) before it
+// retries the current file. That rule prevents multiple repositories from
+// each retaining a partial chunk while all wait for more shared capacity.
+func (idx *Indexer) tryAcquireSharedParsePath(path string) (*parseAdmissionLease, bool) {
+	shared := idx.parseAdmission.Load()
+	if shared == nil {
+		return nil, true
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		// The authoritative read path reports the filesystem error. No bytes
+		// can be materialised, so admission must not turn it into "busy".
+		return nil, true
+	}
+	weight := clampParseWeight(info.Size(), shared.capacity)
+	if !shared.tryAcquire(weight) {
+		return nil, false
+	}
+	return &parseAdmissionLease{shared: shared, sharedWeight: weight}, true
+}
+
+// SetSharedParseMemoryBudget installs one bytes-in-flight budget across every
+// repository owned by this MultiIndexer. Call it before starting repository
+// mutation workers. The budget remains active for later watcher/Git mutations,
+// preventing independent repository lanes from recreating the startup peak.
+// A non-positive value disables the shared gate while retaining per-repo caps.
+func (mi *MultiIndexer) SetSharedParseMemoryBudget(capacity int64) {
+	admission := newParseAdmissionBudget(capacity)
+	mi.parseAdmission.Store(admission)
+
+	mi.mu.RLock()
+	live := make([]*Indexer, 0, len(mi.indexers))
+	for _, idx := range mi.indexers {
+		live = append(live, idx)
+	}
+	mi.mu.RUnlock()
+	for _, idx := range live {
+		idx.parseAdmission.Store(admission)
+	}
+}

--- a/internal/indexer/parse_admission_test.go
+++ b/internal/indexer/parse_admission_test.go
@@ -1,13 +1,20 @@
 package indexer
 
 import (
+	"context"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"golang.org/x/sync/semaphore"
 
 	"github.com/zzet/gortex/internal/config"
 	"github.com/zzet/gortex/internal/graph"
@@ -30,14 +37,20 @@ func TestDefaultParseBudgetEnabled(t *testing.T) {
 		"default config must enable the parse-memory budget so a bare `gortex init` bounds peak memory")
 }
 
-// TestParseAdmissionIndexesOversizedFiles verifies the bytes-in-flight
-// admission semaphore neither drops nor deadlocks on a file larger than the
-// whole budget: with a tiny budget, every file — including one far over it —
-// must still be indexed.
 func TestParseAdmissionIndexesOversizedFiles(t *testing.T) {
+	testParseAdmissionIndexesOversizedFiles(t, false)
+}
+
+func TestSharedParseAdmissionIndexesOversizedFiles(t *testing.T) {
+	testParseAdmissionIndexesOversizedFiles(t, true)
+}
+
+// testParseAdmissionIndexesOversizedFiles verifies neither the private nor the
+// shared bytes-in-flight gate drops or deadlocks on a file larger than the
+// whole budget: its weight clamps to capacity and it is admitted alone.
+func testParseAdmissionIndexesOversizedFiles(t *testing.T, shared bool) {
+	t.Helper()
 	dir := t.TempDir()
-	// One file far bigger than the budget (must be admitted alone), plus
-	// several small ones that would otherwise all parse concurrently.
 	writeFile(t, filepath.Join(dir, "big.go"),
 		"package p\n\nvar Big = \""+strings.Repeat("x", 8192)+"\"\n")
 	for i := 0; i < 8; i++ {
@@ -49,8 +62,11 @@ func TestParseAdmissionIndexesOversizedFiles(t *testing.T) {
 	reg := parser.NewRegistry()
 	languages.RegisterAll(reg)
 	cfg := config.Default().Index
-	cfg.MaxParseBytesInFlight = 256 // tiny: big.go far exceeds it
+	cfg.MaxParseBytesInFlight = 256
 	idx := New(g, reg, cfg, zap.NewNop())
+	if shared {
+		idx.parseAdmission.Store(newParseAdmissionBudget(256))
+	}
 	_, err := idx.Index(dir)
 	require.NoError(t, err)
 
@@ -60,10 +76,328 @@ func TestParseAdmissionIndexesOversizedFiles(t *testing.T) {
 			present[filepath.Base(n.FilePath)] = true
 		}
 	}
-	require.True(t, present["big.go"],
-		"oversized file must still be indexed (admitted alone under the budget)")
+	require.True(t, present["big.go"], "oversized file must still be indexed")
 	for i := 0; i < 8; i++ {
 		name := "small" + strconv.Itoa(i) + ".go"
 		require.True(t, present[name], "small file %s must be indexed", name)
+	}
+}
+
+func TestSharedParseAdmissionSerializesAcrossPrivateRepoBudgets(t *testing.T) {
+	const mib = int64(1 << 20)
+	shared := newParseAdmissionBudget(64 * mib)
+	localA := semaphore.NewWeighted(64 * mib)
+	localB := semaphore.NewWeighted(64 * mib)
+
+	first, err := acquireParseAdmission(t.Context(), 48*mib, 64*mib, localA, shared)
+	require.NoError(t, err)
+
+	type outcome struct {
+		lease *parseAdmissionLease
+		err   error
+	}
+	secondStarted := make(chan struct{})
+	secondDone := make(chan outcome, 1)
+	go func() {
+		close(secondStarted)
+		lease, acquireErr := acquireParseAdmission(t.Context(), 48*mib, 64*mib, localB, shared)
+		secondDone <- outcome{lease: lease, err: acquireErr}
+	}()
+	<-secondStarted
+	select {
+	case got := <-secondDone:
+		got.lease.Release()
+		t.Fatalf("second repository passed aggregate budget before release: %v", got.err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	first.Release()
+	select {
+	case got := <-secondDone:
+		require.NoError(t, got.err)
+		got.lease.Release()
+	case <-time.After(time.Second):
+		t.Fatal("second repository did not acquire after shared capacity was released")
+	}
+
+	require.True(t, shared.tryAcquire(shared.capacity))
+	shared.release(shared.capacity)
+}
+
+func TestParseAdmissionCancellationReturnsSharedCapacity(t *testing.T) {
+	const mib = int64(1 << 20)
+	shared := newParseAdmissionBudget(64 * mib)
+	local := semaphore.NewWeighted(1)
+	require.NoError(t, local.Acquire(t.Context(), 1))
+	defer local.Release(1)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 25*time.Millisecond)
+	defer cancel()
+	lease, err := acquireParseAdmission(ctx, 32*mib, 1, local, shared)
+	assert.Nil(t, lease)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.True(t, shared.tryAcquire(shared.capacity), "cancelled local admission leaked shared capacity")
+	shared.release(shared.capacity)
+}
+
+func TestSharedParseAdmissionCancellationWhileWaiting(t *testing.T) {
+	shared := newParseAdmissionBudget(1)
+	held, err := acquireParseAdmission(t.Context(), 1, 0, nil, shared)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 25*time.Millisecond)
+	defer cancel()
+	waiting, err := acquireParseAdmission(ctx, 1, 0, nil, shared)
+	assert.Nil(t, waiting)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	shared.mu.Lock()
+	queued := len(shared.waiters)
+	shared.mu.Unlock()
+	require.Zero(t, queued, "cancelled shared waiter must leave the FIFO queue")
+
+	held.Release()
+	require.True(t, shared.tryAcquire(shared.capacity))
+	shared.release(shared.capacity)
+}
+
+func TestSharedParseAdmissionRejectsPreCancelledImmediateAcquire(t *testing.T) {
+	shared := newParseAdmissionBudget(1)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	lease, err := acquireParseAdmission(ctx, 1, 0, nil, shared)
+	assert.Nil(t, lease)
+	require.ErrorIs(t, err, context.Canceled)
+	require.True(t, shared.tryAcquire(shared.capacity),
+		"pre-cancelled acquire must not consume immediately available capacity")
+	shared.release(shared.capacity)
+}
+
+func TestSharedParseAdmissionCancellationWinsGrantRace(t *testing.T) {
+	for range 50 {
+		shared := newParseAdmissionBudget(1)
+		held, err := acquireParseAdmission(t.Context(), 1, 0, nil, shared)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		out := make(chan error, 1)
+		go func() {
+			lease, acquireErr := acquireParseAdmission(ctx, 1, 0, nil, shared)
+			if lease != nil {
+				lease.Release()
+			}
+			out <- acquireErr
+		}()
+		require.Eventually(t, func() bool {
+			shared.mu.Lock()
+			defer shared.mu.Unlock()
+			return len(shared.waiters) == 1
+		}, time.Second, time.Millisecond)
+
+		cancel()
+		held.Release()
+		require.ErrorIs(t, <-out, context.Canceled)
+		require.True(t, shared.tryAcquire(shared.capacity),
+			"cancel/grant race must refund the FIFO reservation")
+		shared.release(shared.capacity)
+	}
+}
+
+func TestSharedParseAdmissionLargeWaiterProgressAfterBoundedBypass(t *testing.T) {
+	shared := newParseAdmissionBudget(4)
+	held, err := acquireParseAdmission(t.Context(), 2, 0, nil, shared)
+	require.NoError(t, err)
+
+	largeDone := make(chan *parseAdmissionLease, 1)
+	go func() {
+		lease, acquireErr := acquireParseAdmission(t.Context(), 4, 0, nil, shared)
+		if acquireErr != nil {
+			largeDone <- nil
+			return
+		}
+		largeDone <- lease
+	}()
+	require.Eventually(t, func() bool {
+		shared.mu.Lock()
+		defer shared.mu.Unlock()
+		return len(shared.waiters) == 1
+	}, time.Second, time.Millisecond)
+
+	for range maxParseAdmissionBypasses {
+		require.True(t, shared.tryAcquire(1), "bounded chunk continuation should use free capacity")
+		shared.release(1)
+	}
+	require.False(t, shared.tryAcquire(1),
+		"spent bypass allowance must force active chunks to drain for the FIFO head")
+
+	held.Release()
+	select {
+	case large := <-largeDone:
+		require.NotNil(t, large, "capacity-sized FIFO waiter must make progress")
+		large.Release()
+	case <-time.After(time.Second):
+		t.Fatal("capacity-sized FIFO waiter starved after bounded bypasses drained")
+	}
+}
+
+func TestSharedParseAdmissionConcurrentInvariant(t *testing.T) {
+	const capacity = int64(4)
+	shared := newParseAdmissionBudget(capacity)
+	var active atomic.Int64
+	var violated atomic.Bool
+	var wg sync.WaitGroup
+	for worker := range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for iteration := range 200 {
+				var lease *parseAdmissionLease
+				if (worker+iteration)%3 == 0 {
+					for !shared.tryAcquire(1) {
+						runtime.Gosched()
+					}
+					lease = &parseAdmissionLease{shared: shared, sharedWeight: 1}
+				} else {
+					var err error
+					lease, err = acquireParseAdmission(t.Context(), 1, 0, nil, shared)
+					if err != nil {
+						violated.Store(true)
+						return
+					}
+				}
+				if active.Add(1) > capacity {
+					violated.Store(true)
+				}
+				active.Add(-1)
+				lease.Release()
+			}
+		}()
+	}
+	wg.Wait()
+	require.False(t, violated.Load())
+	require.Zero(t, active.Load())
+	require.True(t, shared.tryAcquire(capacity))
+	shared.release(capacity)
+}
+
+func TestParseAdmissionReleaseIsIdempotent(t *testing.T) {
+	shared := newParseAdmissionBudget(64)
+	lease, err := acquireParseAdmission(t.Context(), 32, 0, nil, shared)
+	require.NoError(t, err)
+	lease.Release()
+	lease.Release()
+	require.True(t, shared.tryAcquire(shared.capacity))
+	shared.release(shared.capacity)
+}
+
+func TestPreparedExtractionRetainsSharedAdmissionUntilDiscard(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.go")
+	writeFile(t, path, "package main\n\nfunc Before() {}\n")
+
+	g := graph.New()
+	reg := parser.NewRegistry()
+	languages.RegisterAll(reg)
+	idx := New(g, reg, config.Default().Index, zap.NewNop())
+	idx.storeRootPath(dir)
+	shared := newParseAdmissionBudget(1)
+	idx.parseAdmission.Store(shared)
+
+	_, ok := idx.prepareFileDelta(path)
+	require.True(t, ok)
+	require.False(t, shared.tryAcquire(shared.capacity),
+		"prepared source/tree must retain its shared admission lease")
+
+	idx.discardPreparedExtraction(path)
+	require.True(t, shared.tryAcquire(shared.capacity),
+		"discard must return the prepared extraction's shared capacity")
+	shared.release(shared.capacity)
+}
+
+func TestIncrementalChunkFlushesBeforeWaitingForSharedAdmission(t *testing.T) {
+	dir := t.TempDir()
+	firstPath := filepath.Join(dir, "first.go")
+	secondPath := filepath.Join(dir, "second.go")
+	writeFile(t, firstPath, "package p\n\nfunc FirstBefore() {}\n")
+	writeFile(t, secondPath, "package p\n\nfunc SecondBefore() {}\n")
+
+	g := graph.New()
+	reg := parser.NewRegistry()
+	languages.RegisterAll(reg)
+	idx := New(g, reg, config.Default().Index, zap.NewNop())
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+	idx.SetDeferGlobalPasses(true)
+	shared := newParseAdmissionBudget(1)
+	idx.parseAdmission.Store(shared)
+
+	writeFile(t, firstPath, "package p\n\nfunc FirstAfter() {}\n")
+	writeFile(t, secondPath, "package p\n\nfunc SecondAfter() {}\n")
+	consumed, _, _, failed, _ := idx.reindexIncrementalChunk(
+		[]string{firstPath, secondPath}, nil, false,
+	)
+	require.Equal(t, 1, consumed,
+		"a full shared budget must flush the retained partial chunk before the next file")
+	require.Empty(t, failed)
+	require.True(t, shared.tryAcquire(shared.capacity),
+		"committing the partial chunk must release shared capacity")
+	shared.release(shared.capacity)
+
+	consumed, _, _, failed, _ = idx.reindexIncrementalChunk([]string{secondPath}, nil, false)
+	require.Equal(t, 1, consumed)
+	require.Empty(t, failed)
+
+	// Exercise the outer retry loop as well: the busy second file must not be
+	// counted as consumed or silently skipped when the first partial chunk
+	// flushes under the one-byte shared budget.
+	writeFile(t, firstPath, "package p\n\nfunc FirstFinal() {}\n")
+	writeFile(t, secondPath, "package p\n\nfunc SecondFinal() {}\n")
+	_, reparsed, failed, _ := idx.reindexIncrementalStalePass(
+		[]string{firstPath, secondPath}, nil, false,
+	)
+	require.Empty(t, failed)
+	assert.ElementsMatch(t, []string{firstPath, secondPath}, reparsed)
+
+	names := make(map[string]bool)
+	for _, node := range g.AllNodes() {
+		names[node.Name] = true
+	}
+	require.True(t, names["FirstFinal"])
+	require.True(t, names["SecondFinal"])
+}
+
+func TestIncrementalStageReleaseClearsRetainedObjects(t *testing.T) {
+	shared := newParseAdmissionBudget(1)
+	lease, err := acquireParseAdmission(t.Context(), 1, 0, nil, shared)
+	require.NoError(t, err)
+	prepared := &preparedExtraction{
+		src:        []byte("retained source"),
+		result:     &parser.ExtractionResult{},
+		parseLease: lease,
+	}
+	stage := &incrementalBatchStage{
+		src:      prepared.src,
+		result:   prepared.result,
+		prepared: prepared,
+	}
+
+	stage.releasePrepared()
+	require.Nil(t, stage.src)
+	require.Nil(t, stage.result)
+	require.Nil(t, stage.prepared)
+	require.True(t, shared.tryAcquire(shared.capacity))
+	shared.release(shared.capacity)
+}
+
+func BenchmarkSharedParseAdmissionUncontended(b *testing.B) {
+	shared := newParseAdmissionBudget(512 << 20)
+	local := semaphore.NewWeighted(512 << 20)
+	b.ReportAllocs()
+	for b.Loop() {
+		lease, err := acquireParseAdmission(context.Background(), 32<<10, 512<<20, local, shared)
+		if err != nil {
+			b.Fatal(err)
+		}
+		lease.Release()
 	}
 }


### PR DESCRIPTION
## Summary

- install one daemon-wide weighted source-byte admission budget across every per-repository Indexer while retaining existing private parse limits
- derive the automatic budget from Go managed memory usage (Sys minus HeapReleased) and GOMEMLIMIT headroom, with GORTEX_WARMUP_MEMORY_MB as an override
- keep clean discovery and no-op reconciliation concurrent; admit only work that actually reads, parses, or retains prepared source/tree state
- carry permits through incremental batch commit, clear all retained aliases before releasing, and flush partial chunks under pressure without skipping files
- use FIFO first-file reservations with a bounded 31-file continuation allowance so large waiters make progress without collapsing normal 32-file SQLite batches

This is a weighted input-byte heuristic for active source/tree materialization, not a hard RSS or total-heap cap. Existing shadow and graph batch bounds remain independent.

## Verification

- go test ./internal/indexer -count=1
- go test -race ./internal/indexer -count=1
- go test ./cmd/gortex -count=1
- go test -race ./cmd/gortex -count=1
- golangci-lint run ./internal/indexer/... ./cmd/gortex/...
- go build ./cmd/gortex
- BenchmarkSharedParseAdmissionUncontended: about 70-80 ns/op, 48 B/op, 1 alloc/op
