### PR TITLE
perf(indexer): reuse finalized clone corpus baseline

### DIFF
--- a/internal/clones/lsh.go
+++ b/internal/clones/lsh.go
@@ -381,6 +381,41 @@ func DetectPairsStreamingWithStats(items []Item, threshold float64, emit func(Pa
 	for _, it := range items {
 		ix.Add(it.ID, it.Sig)
 	}
+	return ix.detectPairsStreamingWithStats(threshold, emit)
+}
+
+// detectPairsWithStats runs detection over an already-populated Index. It is
+// the retained-index counterpart of DetectPairsWithStats and lets the
+// stratified incremental index reuse its live per-class buckets during the
+// global pass instead of building a second temporary LSH.
+func (ix *Index) detectPairsWithStats(threshold float64) (pairs []Pair, skippedBuckets, skippedBucketItems int) {
+	var mu sync.Mutex
+	skippedBuckets, skippedBucketItems = ix.detectPairsStreamingWithStats(threshold, func(p Pair) {
+		mu.Lock()
+		pairs = append(pairs, p)
+		mu.Unlock()
+	})
+	sort.Slice(pairs, func(i, j int) bool {
+		if pairs[i].Similarity != pairs[j].Similarity {
+			return pairs[i].Similarity > pairs[j].Similarity
+		}
+		if pairs[i].A != pairs[j].A {
+			return pairs[i].A < pairs[j].A
+		}
+		return pairs[i].B < pairs[j].B
+	})
+	return pairs, skippedBuckets, skippedBucketItems
+}
+
+// detectPairsStreamingWithStats is the worker pipeline shared by fresh batch
+// indexes and retained indexes. ix is read-only for the duration of the walk.
+func (ix *Index) detectPairsStreamingWithStats(threshold float64, emit func(Pair)) (skippedBuckets, skippedBucketItems int) {
+	if threshold <= 0 {
+		threshold = DefaultThreshold
+	}
+	if ix == nil || len(ix.sigs) < 2 {
+		return 0, 0
+	}
 
 	workers := runtime.NumCPU()
 	if workers < 1 {

--- a/internal/clones/maintained.go
+++ b/internal/clones/maintained.go
@@ -44,6 +44,41 @@ func NewStratifiedIndex() *StratifiedIndex {
 	}
 }
 
+// DetectPairsWithStats runs the batch clone detector over the live per-class
+// indexes already held by s. It preserves the same bucket-cap telemetry,
+// cross-class pair deduplication, and deterministic ordering as
+// DetectPairsStratifiedWithStats, but does not repartition items or rebuild
+// temporary LSH indexes.
+func (s *StratifiedIndex) DetectPairsWithStats(threshold float64) (pairs []Pair, skippedBuckets, skippedBucketItems int) {
+	if s == nil {
+		return nil, 0, 0
+	}
+	seen := make(map[[2]string]struct{})
+	for _, ix := range s.classes {
+		classPairs, sb, sbi := ix.detectPairsWithStats(threshold)
+		skippedBuckets += sb
+		skippedBucketItems += sbi
+		for _, p := range classPairs {
+			key := [2]string{p.A, p.B}
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			pairs = append(pairs, p)
+		}
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		if pairs[i].Similarity != pairs[j].Similarity {
+			return pairs[i].Similarity > pairs[j].Similarity
+		}
+		if pairs[i].A != pairs[j].A {
+			return pairs[i].A < pairs[j].A
+		}
+		return pairs[i].B < pairs[j].B
+	})
+	return pairs, skippedBuckets, skippedBucketItems
+}
+
 // Add banks an item into every length class its TokenCount falls in
 // (lengthClassesOf), recording the TokenCount so a later Remove can
 // recover the same class set. Adding an id that is already present

--- a/internal/clones/maintained_test.go
+++ b/internal/clones/maintained_test.go
@@ -1,6 +1,7 @@
 package clones
 
 import (
+	"fmt"
 	"reflect"
 	"sort"
 	"testing"
@@ -143,6 +144,43 @@ func TestStratifiedIndexEquivalence(t *testing.T) {
 
 	if !reflect.DeepEqual(batchSet, maintained) {
 		t.Fatalf("maintained query set != batch set\n  batch=%v\n  maintained=%v", batchSet, maintained)
+	}
+}
+
+func TestStratifiedIndexDetectPairsWithStatsEquivalence(t *testing.T) {
+	tests := []struct {
+		name  string
+		items func(*testing.T) []Item
+	}{
+		{name: "multiple length classes", items: fixtureItems},
+		{name: "capped bucket telemetry", items: func(t *testing.T) []Item {
+			t.Helper()
+			sig := sigFromShingles(t, makeShingleRange(1, 120))
+			items := make([]Item, maxBucketSize+1)
+			for i := range items {
+				items[i] = Item{ID: fmt.Sprintf("item-%03d", i), Sig: sig, TokenCount: 60}
+			}
+			return items
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			items := tt.items(t)
+			wantPairs, wantBuckets, wantBucketItems := DetectPairsStratifiedWithStats(items, DefaultThreshold)
+			index := NewStratifiedIndex()
+			for _, item := range items {
+				index.Add(item)
+			}
+			gotPairs, gotBuckets, gotBucketItems := index.DetectPairsWithStats(DefaultThreshold)
+			if !reflect.DeepEqual(wantPairs, gotPairs) {
+				t.Fatalf("retained detection differs from batch\nwant=%v\n got=%v", wantPairs, gotPairs)
+			}
+			if gotBuckets != wantBuckets || gotBucketItems != wantBucketItems {
+				t.Fatalf("bucket telemetry differs: got (%d, %d), want (%d, %d)",
+					gotBuckets, gotBucketItems, wantBuckets, wantBucketItems)
+			}
+		})
 	}
 }
 

--- a/internal/indexer/clone_incremental.go
+++ b/internal/indexer/clone_incremental.go
@@ -223,6 +223,42 @@ func (ci *incrementalCloneIndex) Rebuild(g graph.Store, repoPrefix string) {
 	ci.pending = false
 }
 
+// AdoptBaselineOrRebuild seeds the steady-state clone index from the complete
+// compact corpus that the immediately preceding global detector already read.
+// This transfers the CMS, retained LSH and raw-shingle cache without a second
+// CloneCorpusPage scan or LSH build. Legacy stores, incomplete/error or
+// cancelled finalization, prefix mismatches, and malformed baselines retain the
+// exact Rebuild fallback.
+func (ci *incrementalCloneIndex) AdoptBaselineOrRebuild(g graph.Store, repoPrefix string, baseline *cloneCorpusBaseline) {
+	if ci == nil {
+		return
+	}
+	if baseline == nil || !baseline.complete || baseline.repoPrefix != repoPrefix ||
+		baseline.cms == nil || baseline.lsh == nil || baseline.shingles == nil ||
+		baseline.corpus <= 0 || baseline.corpus < baseline.itemCount {
+		ci.Rebuild(g, repoPrefix)
+		return
+	}
+
+	ci.mu.Lock()
+	ci.cms = baseline.cms
+	ci.lsh = baseline.lsh
+	ci.shingles = baseline.shingles
+	ci.corpus = baseline.corpus
+	ci.built = true
+	ci.pending = false
+	// A baseline is a single-consumer handoff. Clearing the large fields both
+	// documents that ownership transfer and prevents accidental double use.
+	baseline.cms = nil
+	baseline.lsh = nil
+	baseline.shingles = nil
+	baseline.items = nil
+	baseline.itemCount = 0
+	baseline.corpus = 0
+	baseline.complete = false
+	ci.mu.Unlock()
+}
+
 // Ready reports whether one-file clone maintenance can run without a
 // graph-wide seed.
 func (ci *incrementalCloneIndex) Ready() bool {

--- a/internal/indexer/clone_sqlite_persistence_test.go
+++ b/internal/indexer/clone_sqlite_persistence_test.go
@@ -2,7 +2,10 @@ package indexer
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"path/filepath"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -83,27 +86,147 @@ func TestSQLiteCloneCorpusSurvivesReloadAndWarmReplay(t *testing.T) {
 	require.True(t, maintained.built)
 	require.Equal(t, len(page), maintained.corpus)
 	require.Len(t, maintained.shingles, len(page))
-	seededPair := false
-	for _, row := range page {
-		probe, ok := clones.DecodeSignature(row.Signature)
-		require.True(t, ok)
-		if len(maintained.lsh.QueryPairs(clones.Item{
-			ID: row.NodeID, Sig: probe, TokenCount: row.TokenCount,
-		}, clones.DefaultThreshold)) > 0 {
-			seededPair = true
-			break
+
+	assertEquivalent := func(actual *incrementalCloneIndex) {
+		t.Helper()
+		require.True(t, actual.built)
+		require.Equal(t, maintained.corpus, actual.corpus)
+		require.Equal(t, maintained.shingles, actual.shingles)
+		seededPair := false
+		for _, row := range page {
+			probe, ok := clones.DecodeSignature(row.Signature)
+			require.True(t, ok)
+			item := clones.Item{ID: row.NodeID, Sig: probe, TokenCount: row.TokenCount}
+			expectedPairs := maintained.lsh.QueryPairs(item, clones.DefaultThreshold)
+			seededPair = seededPair || len(expectedPairs) > 0
+			require.ElementsMatch(t,
+				expectedPairs,
+				actual.lsh.QueryPairs(item, clones.DefaultThreshold),
+			)
+			for _, shingle := range row.Shingles {
+				require.Equal(t, maintained.cms.Count(shingle), actual.cms.Count(shingle))
+			}
 		}
+		require.True(t, seededPair, "incremental indexes must retain the persisted clone pair")
 	}
-	require.True(t, seededPair, "rebuild must seed the persisted signatures into LSH")
 
 	counted.pageCalls = 0
 	counted.writeCalls = 0
 	counted.writeRows = 0
 	beforeEdges := reopened.EdgeCount()
-	stats := detectClonesAndEmitEdgesCtx(context.Background(), counted, "", clones.DefaultThreshold)
-	require.Equal(t, len(page), stats.Items)
-	require.Equal(t, 1, counted.pageCalls, "warm finalized corpus needs one bounded page query")
+	replayed := newTestIndexer(counted)
+	replayed.RunGlobalGraphPasses(context.Background())
+	require.Equal(t, 1, counted.pageCalls, "warm global pass must scan the finalized corpus exactly once")
 	require.Zero(t, counted.writeCalls, "warm finalized corpus must not rewrite signatures")
 	require.Zero(t, counted.writeRows)
 	require.Equal(t, beforeEdges, reopened.EdgeCount(), "warm replay must be graph-idempotent")
+	assertEquivalent(replayed.cloneIndex)
+
+	counted.pageCalls = 0
+	fallback := newIncrementalCloneIndex()
+	fallback.AdoptBaselineOrRebuild(counted, "", nil)
+	require.Equal(t, 1, counted.pageCalls, "missing baseline must retain the bounded rebuild fallback")
+	assertEquivalent(fallback)
+}
+
+type cloneCorpusBenchmarkStore struct {
+	graph.Store
+	rows      []graph.CloneCorpusRow
+	pageCalls int
+	failAfter int
+}
+
+func (s *cloneCorpusBenchmarkStore) CloneCorpusPage(_ string, after string, limit int) ([]graph.CloneCorpusRow, error) {
+	s.pageCalls++
+	if s.failAfter > 0 && s.pageCalls > s.failAfter {
+		return nil, errors.New("injected clone corpus page failure")
+	}
+	start := sort.Search(len(s.rows), func(i int) bool { return s.rows[i].NodeID > after })
+	if start == len(s.rows) {
+		return nil, nil
+	}
+	end := min(start+limit, len(s.rows))
+	return s.rows[start:end], nil
+}
+
+func (s *cloneCorpusBenchmarkStore) BulkSetCloneCorpus(_ string, _ []graph.CloneCorpusRow) error {
+	return nil
+}
+
+func benchmarkCloneCorpus(size int) (*cloneCorpusBaseline, []graph.CloneCorpusRow) {
+	baseline := &cloneCorpusBaseline{
+		cms:       clones.NewCMS(65536, 4),
+		lsh:       clones.NewStratifiedIndex(),
+		shingles:  make(map[string][]uint64, size),
+		itemCount: size,
+		corpus:    size,
+		complete:  true,
+	}
+	rows := make([]graph.CloneCorpusRow, 0, size)
+	for i := 0; i < size; i++ {
+		id := fmt.Sprintf("node-%06d", i)
+		shingles := make([]uint64, 12)
+		for j := range shingles {
+			shingles[j] = uint64(i*32 + j + 1)
+			baseline.cms.Add(shingles[j])
+		}
+		sig, ok := clones.SignatureFromShingles(shingles, 0)
+		if !ok {
+			panic("benchmark corpus unexpectedly produced no signature")
+		}
+		item := clones.Item{ID: id, Sig: sig, TokenCount: 100}
+		baseline.shingles[id] = shingles
+		baseline.lsh.Add(item)
+		rows = append(rows, graph.CloneCorpusRow{
+			NodeID: id, Shingles: shingles, TokenCount: item.TokenCount,
+			Signature: clones.EncodeSignature(sig), Finalized: true,
+		})
+	}
+	return baseline, rows
+}
+
+func TestFinaliseCloneCorpusAbortReleasesBaseline(t *testing.T) {
+	_, rows := benchmarkCloneCorpus(cloneCorpusFinalizeBatch)
+	store := &cloneCorpusBenchmarkStore{rows: rows, failAfter: 1}
+	baseline := finaliseCloneCorpusCtx(context.Background(), store, "")
+
+	require.False(t, baseline.complete)
+	require.Nil(t, baseline.cms)
+	require.Nil(t, baseline.lsh)
+	require.Nil(t, baseline.shingles)
+	require.Nil(t, baseline.items)
+	require.Zero(t, baseline.itemCount)
+	require.Zero(t, baseline.corpus)
+}
+
+func BenchmarkIncrementalCloneIndexBaselineReuse(b *testing.B) {
+	baseline, rows := benchmarkCloneCorpus(2 * cloneCorpusFinalizeBatch)
+	store := &cloneCorpusBenchmarkStore{rows: rows}
+
+	b.Run("adopt_finalized_baseline", func(b *testing.B) {
+		b.ReportAllocs()
+		store.pageCalls = 0
+		for i := 0; i < b.N; i++ {
+			candidate := *baseline
+			ci := &incrementalCloneIndex{}
+			ci.AdoptBaselineOrRebuild(store, "", &candidate)
+			if !ci.Ready() {
+				b.Fatal("adopted index is not ready")
+			}
+		}
+		b.ReportMetric(float64(store.pageCalls)/float64(b.N), "corpus_pages/op")
+	})
+
+	b.Run("rebuild_from_pager", func(b *testing.B) {
+		b.ReportAllocs()
+		store.pageCalls = 0
+		for i := 0; i < b.N; i++ {
+			ci := &incrementalCloneIndex{}
+			ci.Rebuild(store, "")
+			if !ci.Ready() {
+				b.Fatal("rebuilt index is not ready")
+			}
+		}
+		b.ReportMetric(float64(store.pageCalls)/float64(b.N), "corpus_pages/op")
+	})
 }

--- a/internal/indexer/clones.go
+++ b/internal/indexer/clones.go
@@ -315,35 +315,75 @@ func cloneRepoNodes(g graph.Store, repoPrefix string) []*graph.Node {
 	return g.GetRepoNodes(repoPrefix)
 }
 
-// finaliseCloneSignaturesCtx takes the SQLite-first compact projection path
-// when available. It keyset-pages the corpus twice only when at least one row
-// is pending; an unchanged warm corpus is read once and performs no writes.
-func finaliseCloneSignaturesCtx(ctx context.Context, g graph.Store, repoPrefix string) []clones.Item {
+// cloneCorpusBaseline is the complete in-memory seed produced while the
+// compact clone corpus is finalized. Successful paged finalization banks each
+// signed row directly into the persistent stratified LSH; the global detector
+// scans that retained index and the incremental maintainer then adopts it with
+// the CMS, raw-shingle cache and corpus count. No item slice, duplicate LSH, or
+// second corpus scan is needed on that path.
+// complete is deliberately false for legacy, cancelled and error paths so the
+// maintainer falls back to its existing bounded Rebuild implementation.
+type cloneCorpusBaseline struct {
+	repoPrefix string
+	cms        *clones.CMS
+	lsh        *clones.StratifiedIndex
+	shingles   map[string][]uint64
+	items      []clones.Item // legacy fallback only
+	itemCount  int
+	corpus     int
+	complete   bool
+}
+
+// finaliseCloneCorpusCtx takes the SQLite-first compact projection path. It
+// keyset-pages the corpus twice only when at least one row is pending; an
+// unchanged warm corpus is read once and performs no writes. A successful
+// paged pass returns a complete baseline suitable for single-consumer adoption.
+func finaliseCloneCorpusCtx(ctx context.Context, g graph.Store, repoPrefix string) *cloneCorpusBaseline {
+	baseline := &cloneCorpusBaseline{repoPrefix: repoPrefix}
 	pager, paged := g.(graph.CloneCorpusPager)
 	writer, writable := g.(graph.CloneCorpusWriter)
 	if !paged || !writable {
-		return finaliseCloneSignaturesFromNodes(g, repoPrefix)
+		baseline.items = finaliseCloneSignaturesFromNodes(g, repoPrefix)
+		return baseline
 	}
 
-	cms := clones.NewCMS(65536, 4)
-	items := make([]clones.Item, 0, cloneCorpusFinalizeBatch)
+	baseline.cms = clones.NewCMS(65536, 4)
+	baseline.lsh = clones.NewStratifiedIndex()
+	baseline.shingles = make(map[string][]uint64, cloneCorpusFinalizeBatch)
+	addItem := func(item clones.Item) {
+		baseline.lsh.Add(item)
+		baseline.itemCount++
+	}
+	abort := func() *cloneCorpusBaseline {
+		baseline.cms = nil
+		baseline.lsh = nil
+		baseline.shingles = nil
+		baseline.items = nil
+		baseline.itemCount = 0
+		baseline.corpus = 0
+		baseline.complete = false
+		return baseline
+	}
 	corpus, pending := 0, false
 	after := ""
 	for {
 		if ctx.Err() != nil {
-			return nil
+			return abort()
 		}
 		page, err := pager.CloneCorpusPage(repoPrefix, after, cloneCorpusFinalizeBatch)
 		if err != nil {
-			return nil
+			return abort()
 		}
 		if len(page) == 0 {
 			break
 		}
 		for _, row := range page {
 			corpus++
+			if len(row.Shingles) > 0 {
+				baseline.shingles[row.NodeID] = row.Shingles
+			}
 			for _, shingle := range row.Shingles {
-				cms.Add(shingle)
+				baseline.cms.Add(shingle)
 			}
 			if !row.Finalized {
 				pending = true
@@ -357,23 +397,31 @@ func finaliseCloneSignaturesCtx(ctx context.Context, g graph.Store, repoPrefix s
 				pending = true
 				continue
 			}
-			items = append(items, clones.Item{ID: row.NodeID, Sig: sig, TokenCount: row.TokenCount})
+			addItem(clones.Item{ID: row.NodeID, Sig: sig, TokenCount: row.TokenCount})
 		}
 		after = page[len(page)-1].NodeID
 		if len(page) < cloneCorpusFinalizeBatch {
 			break
 		}
 	}
+	baseline.corpus = corpus
 	if corpus == 0 {
 		// Compatibility for a pre-projection store: one legacy scoped read
 		// populates the sidecar, after which every restart takes the paged path.
-		return finaliseCloneSignaturesFromNodes(g, repoPrefix)
+		baseline.cms = nil
+		baseline.lsh = nil
+		baseline.shingles = nil
+		baseline.itemCount = 0
+		baseline.items = finaliseCloneSignaturesFromNodes(g, repoPrefix)
+		return baseline
 	}
 	if !pending {
-		return items
+		baseline.complete = true
+		return baseline
 	}
 
-	items = items[:0]
+	baseline.lsh = clones.NewStratifiedIndex()
+	baseline.itemCount = 0
 	useFilter := corpus >= cmsMinCorpus
 	threshold := uint32(0)
 	if useFilter {
@@ -385,34 +433,35 @@ func finaliseCloneSignaturesCtx(ctx context.Context, g graph.Store, repoPrefix s
 	after = ""
 	for {
 		if ctx.Err() != nil {
-			return nil
+			return abort()
 		}
 		page, err := pager.CloneCorpusPage(repoPrefix, after, cloneCorpusFinalizeBatch)
 		if err != nil {
-			return nil
+			return abort()
 		}
 		if len(page) == 0 {
 			break
 		}
 		for i := range page {
 			row := &page[i]
-			sig, ok := computeCloneSigFromShingles(cms, threshold, useFilter, row.Shingles)
+			sig, ok := computeCloneSigFromShingles(baseline.cms, threshold, useFilter, row.Shingles)
 			row.Finalized = true
 			row.Signature = ""
 			if ok {
 				row.Signature = clones.EncodeSignature(sig)
-				items = append(items, clones.Item{ID: row.NodeID, Sig: sig, TokenCount: row.TokenCount})
+				addItem(clones.Item{ID: row.NodeID, Sig: sig, TokenCount: row.TokenCount})
 			}
 		}
 		if err := writer.BulkSetCloneCorpus(repoPrefix, page); err != nil {
-			return nil
+			return abort()
 		}
 		after = page[len(page)-1].NodeID
 		if len(page) < cloneCorpusFinalizeBatch {
 			break
 		}
 	}
-	return items
+	baseline.complete = true
+	return baseline
 }
 
 func finaliseCloneSignaturesFromNodes(g graph.Store, repoPrefix string) []clones.Item {
@@ -586,9 +635,18 @@ func detectClonesAndEmitEdges(g graph.Store, repoPrefix string, threshold float6
 // "clone detection pass" marker followed by minutes of silence — no
 // way to tell finalise-signatures from LSH from edge-emission.
 func detectClonesAndEmitEdgesCtx(ctx context.Context, g graph.Store, repoPrefix string, threshold float64) CloneDetectionStats {
+	stats, _ := detectClonesAndEmitEdgesWithBaselineCtx(ctx, g, repoPrefix, threshold)
+	return stats
+}
+
+// detectClonesAndEmitEdgesWithBaselineCtx performs the context-aware clone
+// pass and also returns the finalized compact-corpus baseline. The baseline is
+// complete only when the paged projection was read successfully; callers hand
+// it to AdoptBaselineOrRebuild after this function releases ResolveMutex.
+func detectClonesAndEmitEdgesWithBaselineCtx(ctx context.Context, g graph.Store, repoPrefix string, threshold float64) (CloneDetectionStats, *cloneCorpusBaseline) {
 	var stats CloneDetectionStats
 	if g == nil {
-		return stats
+		return stats, nil
 	}
 	reporter := progress.FromContext(ctx)
 	// Serialise against other graph-wide passes that mutate Node.Meta
@@ -616,14 +674,23 @@ func detectClonesAndEmitEdgesCtx(ctx context.Context, g graph.Store, repoPrefix 
 	// (delete clone_shingles, set clone_sig) don't race the AllNodes
 	// walk below.
 	reporter.Report("clones: CMS-finalise signatures", 0, 0)
-	items := finaliseCloneSignaturesCtx(ctx, g, repoPrefix)
-	stats.Items = len(items)
-	if len(items) < 2 {
-		return stats
+	baseline := finaliseCloneCorpusCtx(ctx, g, repoPrefix)
+	stats.Items = baseline.itemCount
+	if !baseline.complete || baseline.lsh == nil {
+		stats.Items = len(baseline.items)
+	}
+	if stats.Items < 2 {
+		return stats, baseline
 	}
 
-	reporter.Report("clones: LSH + Jaccard filter", len(items), 0)
-	detected, sb, sbi := clones.DetectPairsStratifiedWithStats(items, threshold)
+	reporter.Report("clones: LSH + Jaccard filter", stats.Items, 0)
+	var detected []clones.Pair
+	var sb, sbi int
+	if baseline.complete && baseline.lsh != nil {
+		detected, sb, sbi = baseline.lsh.DetectPairsWithStats(threshold)
+	} else {
+		detected, sb, sbi = clones.DetectPairsStratifiedWithStats(baseline.items, threshold)
+	}
 	stats.SkippedBuckets = sb
 	stats.SkippedBucketItems = sbi
 	stats.Pairs = len(detected)
@@ -640,7 +707,7 @@ func detectClonesAndEmitEdgesCtx(ctx context.Context, g graph.Store, repoPrefix 
 	dp, de := diffuseSimilarityEdges(g, detected, directPairs)
 	stats.DiffusedPairs = dp
 	stats.DiffusedEdges = de
-	return stats
+	return stats, baseline
 }
 
 // Diffusion-pass tuning constants. The graph-diffusion smoothing pass

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -978,7 +978,8 @@ func (idx *Indexer) RunGlobalGraphPasses(ctx context.Context) {
 		)
 	}
 	reporter.Report("clone detection pass (global)", 0, 0)
-	if cs := detectClonesAndEmitEdgesCtx(ctx, idx.graph, idx.repoPrefix, idx.cloneThreshold()); cs.Items > 0 {
+	cs, cloneBaseline := detectClonesAndEmitEdgesWithBaselineCtx(ctx, idx.graph, idx.repoPrefix, idx.cloneThreshold())
+	if cs.Items > 0 {
 		idx.logger.Info("clone edges emitted (global)",
 			zap.Int("items", cs.Items),
 			zap.Int("clone_pairs", cs.Pairs),
@@ -989,11 +990,10 @@ func (idx *Indexer) RunGlobalGraphPasses(ctx context.Context) {
 			zap.Int("diffused_edges", cs.DiffusedEdges),
 		)
 	}
-	// Seed the incremental clone index from the freshly-baselined
-	// signatures + sidecar so steady-state single-file edits after this
-	// batch go incremental instead of re-running the whole-graph pass.
+	// Adopt the freshly-finalized CMS/corpus seed so steady-state single-file
+	// edits go incremental without paging the same compact corpus again.
 	if idx.cloneIndex != nil {
-		idx.cloneIndex.Rebuild(idx.graph, idx.repoPrefix)
+		idx.cloneIndex.AdoptBaselineOrRebuild(idx.graph, idx.repoPrefix, cloneBaseline)
 	}
 	// Framework dynamic-dispatch synthesis (gRPC stubs, Temporal
 	// workflow→activity, in-process / native event channels, native
@@ -3695,7 +3695,8 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 				)
 			}
 			reporter.Report("clone detection pass", 0, 0)
-			if cs := detectClonesAndEmitEdgesCtx(ctx, idx.graph, idx.repoPrefix, idx.cloneThreshold()); cs.Items > 0 {
+			cs, cloneBaseline := detectClonesAndEmitEdgesWithBaselineCtx(ctx, idx.graph, idx.repoPrefix, idx.cloneThreshold())
+			if cs.Items > 0 {
 				idx.logger.Info("clone edges emitted",
 					zap.Int("items", cs.Items),
 					zap.Int("clone_pairs", cs.Pairs),
@@ -3706,13 +3707,11 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 					zap.Int("diffused_edges", cs.DiffusedEdges),
 				)
 			}
-			// Seed the incremental clone index from the freshly-baselined
-			// signatures + sidecar so steady-state single-file edits go
-			// incremental (EvictFuncs/UpdateFuncs) instead of re-running
-			// this whole-graph pass per file. The batch pass remains the
-			// re-baseline (corrects CMS drift) and owns diffusion.
+			// Adopt the freshly-finalized CMS/corpus seed so steady-state
+			// single-file edits go incremental without another corpus scan.
+			// The batch pass remains the re-baseline and owns diffusion.
 			if idx.cloneIndex != nil {
-				idx.cloneIndex.Rebuild(idx.graph, idx.repoPrefix)
+				idx.cloneIndex.AdoptBaselineOrRebuild(idx.graph, idx.repoPrefix, cloneBaseline)
 			}
 			// Framework dynamic-dispatch synthesis — runs once the call
 			// graph and interface inference are final. Skipped under

--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -1501,8 +1501,11 @@ func (mi *MultiIndexer) runGlobalGraphPassesTopologyHeld(
 		return ok
 	}
 	passStart("clone_detect")
-	cloneDetectStart := time.Now()
+	clonePassStart := time.Now()
+	cloneDetectElapsed := time.Duration(0)
+	cloneRebuildElapsed := time.Duration(0)
 	clonesDetected := 0
+	clonesRebuilt := 0
 	for _, idx := range cloneIdx {
 		if !inCloneScope(idx.repoPrefix) {
 			continue
@@ -1513,7 +1516,10 @@ func (mi *MultiIndexer) runGlobalGraphPassesTopologyHeld(
 		// (UpdateFuncs/Rebuild → idx.cloneThreshold()), or the batch and
 		// incremental edge sets diverge for any repo whose configured
 		// threshold differs from the workspace maximum.
-		if cs := detectClonesAndEmitEdgesCtx(ctx, mi.graph, idx.repoPrefix, idx.cloneThreshold()); cs.Items > 0 {
+		detectStart := time.Now()
+		cs, cloneBaseline := detectClonesAndEmitEdgesWithBaselineCtx(ctx, mi.graph, idx.repoPrefix, idx.cloneThreshold())
+		cloneDetectElapsed += time.Since(detectStart)
+		if cs.Items > 0 {
 			mi.logger.Info("clone edges emitted (global)",
 				zap.String("repo", idx.repoPrefix),
 				zap.Int("items", cs.Items),
@@ -1525,33 +1531,26 @@ func (mi *MultiIndexer) runGlobalGraphPassesTopologyHeld(
 				zap.Int("diffused_edges", cs.DiffusedEdges),
 			)
 		}
-	}
-	// Seed each per-repo indexer's incremental clone index from the
-	// freshly-baselined signatures + sidecar (scoped to that repo's
-	// prefix) so steady-state single-file edits after this batch go
-	// incremental instead of re-running the whole-graph pass per file.
-	cloneRebuildStart := time.Now()
-	clonesRebuilt := 0
-	for _, idx := range cloneIdx {
-		if !inCloneScope(idx.repoPrefix) {
-			continue
-		}
+		// Adopt each repo's baseline immediately so the loop never retains
+		// every repository's raw-shingle corpus at once. Invalid or incomplete
+		// baselines take the existing bounded Rebuild fallback.
+		rebuildStart := time.Now()
 		if idx.cloneIndex != nil {
-			idx.cloneIndex.Rebuild(mi.graph, idx.repoPrefix)
+			idx.cloneIndex.AdoptBaselineOrRebuild(mi.graph, idx.repoPrefix, cloneBaseline)
 			clonesRebuilt++
 		}
+		cloneRebuildElapsed += time.Since(rebuildStart)
 	}
-	// Aggregate timing for the clone passes — previously the most expensive
-	// and least observable part of a warm restart (the per-repo logs above
-	// only fire when a repo actually has clone pairs, so a long run could
-	// pass with no breadcrumbs).
+	// Aggregate timing for the clone passes — the historical field names are
+	// retained for dashboards even though successful seeds are now adoptions.
 	mi.logger.Info("clone passes done (global)",
 		zap.Bool("scoped", scope != nil),
 		zap.Int("repos_total", len(cloneIdx)),
 		zap.Int("detected", clonesDetected),
 		zap.Int("rebuilt", clonesRebuilt),
-		zap.Duration("detect_elapsed", cloneRebuildStart.Sub(cloneDetectStart)),
-		zap.Duration("rebuild_elapsed", time.Since(cloneRebuildStart)),
+		zap.Duration("detect_elapsed", cloneDetectElapsed),
+		zap.Duration("rebuild_elapsed", cloneRebuildElapsed),
+		zap.Duration("elapsed", time.Since(clonePassStart)),
 	)
 	// Framework dynamic-dispatch synthesis (gRPC stubs, Temporal
 	// workflow→activity, in-process / native event channels, native


### PR DESCRIPTION
Summary
- Build the persistent stratified clone index while paging the finalized compact corpus, then reuse it for detection and incremental maintenance.
- Transfer the complete CMS, shingle cache, corpus count, and retained LSH into each incremental clone index without a second corpus scan or duplicate LSH build.
- Preserve bounded Rebuild fallbacks for legacy stores, cancellation, page/write errors, prefix mismatches, and incomplete baselines; clear large aborted baselines promptly.
- Adopt per-repository baselines immediately so multi-repo warmup does not retain every repository corpus at once.

Verification
- make lint
- go test ./internal/clones ./internal/indexer -count=1
- focused SQLite warm-replay, abort-cleanup, and retained-index equivalence tests
- benchmark at 2,048 rows: adoption uses 0 corpus pages and 48 B / 1 allocation; rebuild uses 3 pages and about 15.2 MB / 74.9k allocations

The warm SQLite regression asserts the production global pass pages the finalized corpus exactly once, performs no signature rewrites, preserves edges, and adopts CMS, shingles, and LSH state equivalent to Rebuild.