### PR TITLE
fix(indexer): coordinate cross-repo mutation resolution

### DIFF
--- a/internal/indexer/incremental_watcher_batch.go
+++ b/internal/indexer/incremental_watcher_batch.go
@@ -121,10 +121,10 @@ func (idx *Indexer) runIncrementalResolutionCatchup(
 	files []string,
 	batch *reparsePendingEnrichmentBatch,
 	resolveFiles func([]string),
-) {
+) []string {
 	files = appendUniqueSorted(nil, files...)
 	if len(files) == 0 {
-		return
+		return nil
 	}
 	idx.observeIncrementalCatchup("resolve", files)
 	resolveFiles(files)
@@ -141,12 +141,13 @@ func (idx *Indexer) runIncrementalResolutionCatchup(
 	factFiles := appendUniqueSorted(files, affected.files...)
 	idx.observeIncrementalCatchup("ref_facts", factFiles)
 	idx.persistRefFactsForFiles(factFiles)
+	return factFiles
 }
 
-func (idx *Indexer) runIncrementalWatcherSemantic(graphPaths []string) {
+func (idx *Indexer) runIncrementalWatcherSemantic(graphPaths []string) []string {
 	if idx == nil || idx.semanticMgr == nil || !idx.semanticMgr.Enabled() ||
 		!idx.semanticMgr.HasProviders() || !idx.semanticMgr.EnrichesOnWatch() {
-		return
+		return nil
 	}
 	pendingFiles, _, _ := idx.deferredEnrichScope()
 	if len(pendingFiles) == 0 {
@@ -155,7 +156,7 @@ func (idx *Indexer) runIncrementalWatcherSemantic(graphPaths []string) {
 	idx.observeIncrementalCatchup("semantic", pendingFiles)
 	idx.runDeferredEnrich()
 	if idx.pendingEnrich.Load() {
-		return
+		return pendingFiles
 	}
 	pending := make(map[string]bool, len(graphPaths))
 	for _, graphPath := range graphPaths {
@@ -164,20 +165,21 @@ func (idx *Indexer) runIncrementalWatcherSemantic(graphPaths []string) {
 		}
 	}
 	idx.setReparsePendingEnrichments(pending)
+	return pendingFiles
 }
 
 // runIncrementalPointSemantic preserves IndexFile's exact single-save semantic
 // contract. Storm and reconciliation batches use runIncrementalWatcherSemantic
 // to amortize provider work; one explicit point mutation calls EnrichFile so
 // in-process type providers can confirm the new edges before IndexFile returns.
-func (idx *Indexer) runIncrementalPointSemantic(graphPaths []string) {
+func (idx *Indexer) runIncrementalPointSemantic(graphPaths []string) []string {
 	if idx == nil || idx.semanticMgr == nil || !idx.semanticMgr.Enabled() ||
 		!idx.semanticMgr.HasProviders() || !idx.semanticMgr.EnrichesOnWatch() {
-		return
+		return nil
 	}
 	paths := appendUniqueSorted(nil, graphPaths...)
 	if len(paths) == 0 {
-		return
+		return nil
 	}
 	idx.observeIncrementalCatchup("semantic", paths)
 	pending := make(map[string]bool, len(paths))
@@ -191,6 +193,7 @@ func (idx *Indexer) runIncrementalPointSemantic(graphPaths []string) {
 		pending[graphPath] = false
 	}
 	idx.setReparsePendingEnrichments(pending)
+	return paths
 }
 
 // incrementalReindexWatcherPaths is the complete direct-Indexer coordinator used
@@ -331,10 +334,11 @@ func (gw *GitWatcher) reindexChangedPaths(paths []string) (*IndexResult, error) 
 	return gw.indexer.IncrementalReindexPaths(gw.repoPath, paths)
 }
 
-// resolveIncrementalRepoMutation runs one shared resolver pass for a complete
-// receipt frontier or, when the store cannot certify its eviction shape, the
-// indexer's conservative successful-file frontier. A whole-graph fallback is
-// reserved for the exceptional case where neither source yields any scope.
+// resolveIncrementalRepoMutation runs one same-repo pass and one coordinated
+// cross-repo outgoing-plus-incoming pass for a complete receipt frontier or,
+// when the store cannot certify its eviction shape, the indexer's conservative
+// successful-file frontier. A whole-graph fallback is reserved for the
+// exceptional case where neither source yields any safe scope.
 func (mi *MultiIndexer) resolveIncrementalRepoMutation(
 	repoPrefix string,
 	result *IndexResult,
@@ -352,15 +356,20 @@ func (mi *MultiIndexer) resolveIncrementalRepoMutationMode(
 	exactPointSemantic bool,
 ) {
 	files, needed, _ := incrementalResolutionFrontier(result, receipt)
+	crossRepoFiles := appendUniqueSorted(nil, files...)
+	if result != nil {
+		crossRepoFiles = appendUniqueSorted(crossRepoFiles, result.DerivedInvalidation.Files...)
+	}
 	idx := mi.GetIndexer(repoPrefix)
 	if needed && len(files) > 0 && idx != nil {
-		idx.runIncrementalResolutionCatchup(files, batch, func(frontier []string) {
+		resolvedFiles := idx.runIncrementalResolutionCatchup(files, batch, func(frontier []string) {
 			if idx.incrementalResolveFilesHook != nil {
 				idx.incrementalResolveFilesHook(frontier)
 				return
 			}
 			mi.runMasterResolveFiles(frontier, false)
 		})
+		crossRepoFiles = appendUniqueSorted(crossRepoFiles, resolvedFiles...)
 	} else if needed && len(files) > 0 {
 		mi.runMasterResolveFiles(files, false)
 	} else if needed {
@@ -373,17 +382,31 @@ func (mi *MultiIndexer) resolveIncrementalRepoMutationMode(
 		// second graph-wide dataflow or durable-fact scan.
 		if idx != nil && result != nil {
 			known := appendUniqueSorted(nil, result.DerivedInvalidation.Files...)
+			crossRepoFiles = appendUniqueSorted(crossRepoFiles, known...)
 			idx.observeIncrementalCatchup("dataflow", known)
 			idx.materializeDataflowParamsForFiles(known)
 			idx.observeIncrementalCatchup("ref_facts", known)
 			idx.persistRefFactsForFiles(known)
 		}
 	}
+
+	var semanticFiles []string
 	if idx != nil && result != nil {
 		if exactPointSemantic {
-			idx.runIncrementalPointSemantic(result.DerivedInvalidation.Files)
+			semanticFiles = idx.runIncrementalPointSemantic(result.DerivedInvalidation.Files)
 		} else {
-			idx.runIncrementalWatcherSemantic(result.DerivedInvalidation.Files)
+			semanticFiles = idx.runIncrementalWatcherSemantic(result.DerivedInvalidation.Files)
+		}
+		crossRepoFiles = appendUniqueSorted(crossRepoFiles, semanticFiles...)
+	}
+	if needed || len(semanticFiles) > 0 {
+		if idx != nil {
+			idx.observeIncrementalCatchup("cross_repo", crossRepoFiles)
+		}
+		if len(crossRepoFiles) > 0 {
+			mi.runCrossRepoResolveFiles(crossRepoFiles)
+		} else {
+			mi.runCrossRepoResolve(false)
 		}
 	}
 }

--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -2300,10 +2300,11 @@ func (mi *MultiIndexer) incrementalReindexRepoRawMode(repoPrefix string, paths [
 		return nil, fmt.Errorf("reindexing %s: %w", meta.RootPath, err)
 	}
 
-	// Resolve exactly once after the bounded parse/evict batch. Complete
-	// mutation receipts provide the precise changed/definition file frontier;
-	// only an incomplete receipt falls back to the conservative scoped-global
-	// resolver. Derived invalidations run once below after bindings are current.
+	// Run the same-repo and cross-repo resolver tails exactly once after the
+	// bounded parse/evict batch. Complete mutation receipts provide the precise
+	// changed/definition file frontier; only an incomplete receipt falls back to
+	// conservative scoped-global resolution. Derived invalidations run once
+	// below after both binding layers are current.
 	mi.resolveIncrementalRepoMutationMode(
 		repoPrefix, result, receipt, batch, mode.exactPointSemantic,
 	)

--- a/internal/indexer/watcher_storm_batch_test.go
+++ b/internal/indexer/watcher_storm_batch_test.go
@@ -401,6 +401,15 @@ func TestMultiWatcherBatchCallbackRunsOneExactResolveAndDerivedCatchup(t *testin
 		resolveCalls++
 		frontier = append([]string(nil), files...)
 	}
+	crossRepoCalls := 0
+	var crossRepoFrontier []string
+	idx.incrementalCatchupHook = func(kind string, files []string) {
+		if kind != "cross_repo" {
+			return
+		}
+		crossRepoCalls++
+		crossRepoFrontier = append([]string(nil), files...)
+	}
 
 	core, observed := observer.New(zap.InfoLevel)
 	logger := zap.New(core)
@@ -424,6 +433,12 @@ func TestMultiWatcherBatchCallbackRunsOneExactResolveAndDerivedCatchup(t *testin
 	for _, graphPath := range frontier {
 		require.True(t, strings.HasPrefix(graphPath, "repo/"),
 			"receipt frontier must use repo-prefixed graph paths: %q", graphPath)
+	}
+	require.Equal(t, 1, crossRepoCalls)
+	require.NotEmpty(t, crossRepoFrontier)
+	for _, graphPath := range crossRepoFrontier {
+		require.True(t, strings.HasPrefix(graphPath, "repo/"),
+			"cross-repo frontier must use repo-prefixed graph paths: %q", graphPath)
 	}
 	require.Equal(t, 1, observed.FilterMessage("incremental derived passes complete").Len(),
 		"one batch must trigger one derived catch-up")
@@ -494,18 +509,23 @@ func TestMultiWatcherThreeChunksRunEveryCatchupTailOnce(t *testing.T) {
 		indexers: map[string]*Indexer{"repo": idx},
 		logger:   zap.NewNop(),
 	}
+	idx.attachRepositoryMutationCoordinator(mi.repositoryMutationCoordinator("repo"))
 	result, err := mi.IncrementalReindexRepo("repo", paths)
 	require.NoError(t, err)
 	require.Equal(t, len(paths), result.StaleFileCount)
 	require.Empty(t, result.FailedFiles)
 
-	for _, tail := range []string{"resolve", "dataflow", "affected_by", "ref_facts", "semantic", "derived"} {
+	for _, tail := range []string{"resolve", "dataflow", "affected_by", "ref_facts", "semantic", "cross_repo", "derived"} {
 		require.Equalf(t, 1, tailCalls[tail], "%s tail must run once for the complete batch", tail)
 	}
 	require.Len(t, tailFiles["resolve"], len(paths),
 		"the scoped fallback must contain exactly the successful mutation files")
 	require.Equal(t, []string{"repo/caller.go"}, tailFiles["affected_by"],
 		"the surviving caller must be handled once by the separate affected frontier")
+	require.Len(t, tailFiles["cross_repo"], len(paths)+1,
+		"the cross-repo batch must union the changed and affected file frontiers")
+	require.Contains(t, tailFiles["cross_repo"], "repo/caller.go",
+		"the cross-repo batch must include incoming edges owned by affected callers")
 	require.Equal(t, 1, provider.batchCalls)
 	require.Zero(t, provider.singleCalls)
 	require.Zero(t, provider.fullCalls)

--- a/internal/indexer/workspace_resolve.go
+++ b/internal/indexer/workspace_resolve.go
@@ -290,9 +290,9 @@ func (mi *MultiIndexer) RunGlobalResolve() {
 // only the changed repos' out-edges here left those inbound edges unbound until
 // the post-enrichment global resolve, so cross-repo queries returned incomplete
 // results for the whole enrichment window even though the daemon reported ready.
-func (mi *MultiIndexer) runCrossRepoResolve(reconcileContracts bool) {
+func (mi *MultiIndexer) newCrossRepoResolver() *resolver.CrossRepoResolver {
 	if mi == nil || mi.graph == nil {
-		return
+		return nil
 	}
 	cr := resolver.NewCrossRepo(mi.graph)
 	cr.SetLogger(mi.logger)
@@ -301,10 +301,33 @@ func (mi *MultiIndexer) runCrossRepoResolve(reconcileContracts bool) {
 	cr.SetPathAliasResolver(mi.pathAliasResolver())
 	cr.SetWorkspaceMembership(mi.workspaceMembershipResolver())
 	mi.applyRemoteStitch(cr)
+	return cr
+}
+
+func (mi *MultiIndexer) runCrossRepoResolve(reconcileContracts bool) {
+	cr := mi.newCrossRepoResolver()
+	if cr == nil {
+		return
+	}
 	cr.ResolveAll()
 	if reconcileContracts {
 		mi.ReconcileContractEdges()
 	}
+}
+
+// runCrossRepoResolveFiles binds both outgoing and incoming unresolved edges
+// for one coordinated mutation frontier. Its caller owns the repository lane
+// and global topology-writer gate, so the graph cannot expose a half-resolved
+// batch between same-repo, semantic, and cross-repository phases.
+func (mi *MultiIndexer) runCrossRepoResolveFiles(filePaths []string) {
+	if len(filePaths) == 0 {
+		return
+	}
+	cr := mi.newCrossRepoResolver()
+	if cr == nil {
+		return
+	}
+	cr.ResolveFilesAndIncoming(filePaths)
 }
 
 // crossWorkspaceLookup builds a resolver.CrossWorkspaceDepLookup from

--- a/internal/resolver/cross_repo.go
+++ b/internal/resolver/cross_repo.go
@@ -55,12 +55,12 @@ type CrossWorkspaceDepLookup func(sourceWorkspaceID string) []CrossWorkspaceDepR
 // passes so we don't pay the memory cost while idle.
 //
 // mu is the graph-wide resolver lock shared with every Resolver built
-// from the same Graph. Private to CrossRepoResolver wasn't enough:
-// MultiWatcher.forwardEvents calls ResolveForRepo while the per-repo
-// Watcher's debounce timer concurrently calls Resolver.ResolveFile,
-// and both paths iterate shared predicate projections and mutate Edge.To in
-// place. Sharing g.ResolveMutex() serialises both resolver
-// types against the same graph.
+// from the same Graph. Private to CrossRepoResolver is not enough: the
+// coordinated incremental tail and master resolution both iterate shared
+// predicate projections and mutate Edge.To in place. Sharing
+// g.ResolveMutex() serialises both resolver types against the same graph;
+// the incremental coordinator additionally keeps its repository lane and
+// topology-writer gate held around the one batched cross-repo pass.
 //
 // crossWorkspaceLookup is the workspace-boundary check. Empty (nil)
 // means the resolver is in legacy mode: cross-repo / cross-workspace
@@ -532,12 +532,11 @@ func (cr *CrossRepoResolver) ResolveForRepo(repoPrefix string) *CrossRepoStats {
 // absolute watcher path via Indexer.RelKey first. A path matching no
 // nodes is a no-op.
 //
-// Scope note: this resolves edges the changed file OWNS. A new
-// definition in this file that would resolve some OTHER file's pending
-// unresolved edge (inbound resolution) is not re-checked here — that
-// case is rare, self-heals when the referencing file is next touched,
-// and is swept up by the periodic full ResolveAll. ResolveForRepo
-// remains for warmup / global recompute.
+// Scope note: this legacy API resolves only edges the changed file owns.
+// Coordinated MultiIndexer mutation paths use ResolveFilesAndIncoming instead,
+// so a complete Git/storm batch also re-checks other files' unresolved edges
+// that point at symbols newly defined by the changed files. ResolveForRepo
+// remains for callers that explicitly request a repository-wide recompute.
 func (cr *CrossRepoResolver) ResolveForFile(repoPrefix, relPath string) *CrossRepoStats {
 	cr.mu.Lock()
 	defer cr.mu.Unlock()
@@ -566,23 +565,32 @@ func (cr *CrossRepoResolver) ResolveForFile(repoPrefix, relPath string) *CrossRe
 
 // resolveScopedLocked lifts every unresolved target among edges to its
 // real cross-repo node, then materialises the cross_repo_* parallel-edge
-// layer. Shared by ResolveForRepo (whole-repo edge set) and
-// ResolveForFile (one changed file's out-edges). Caller holds cr.mu.
+// layer. Shared by repository, legacy file, and batched files-plus-incoming
+// scopes. Caller holds cr.mu.
 func (cr *CrossRepoResolver) resolveScopedLocked(edges []*graph.Edge) *CrossRepoStats {
+	stats := &CrossRepoStats{ByRepo: make(map[string]int)}
+	pending := make([]*graph.Edge, 0, len(edges))
+	for _, edge := range edges {
+		if edge != nil && graph.IsUnresolvedTarget(edge.To) {
+			pending = append(pending, edge)
+		}
+	}
+	if len(pending) == 0 {
+		return stats
+	}
+
 	cr.buildDirIndexes()
 	defer cr.clearDirIndexes()
 	cr.buildDepModuleIndex()
 	defer cr.clearDepModuleIndex()
 	cr.buildReachableReposIndex()
 	defer cr.clearReachableReposIndex()
+	cr.warmLookupCache(pending)
+	defer cr.clearLookupCache()
 
-	stats := &CrossRepoStats{ByRepo: make(map[string]int)}
 	var reindexBatch []graph.EdgeReindex
-	for _, e := range edges {
-		if e == nil || !strings.HasPrefix(e.To, unresolvedPrefix) {
-			continue
-		}
-		cr.resolveEdge(e, stats, &reindexBatch)
+	for _, edge := range pending {
+		cr.resolveEdge(edge, stats, &reindexBatch)
 	}
 	if len(reindexBatch) > 0 {
 		cr.graph.ReindexEdges(reindexBatch)

--- a/internal/resolver/cross_repo_incremental.go
+++ b/internal/resolver/cross_repo_incremental.go
@@ -2,6 +2,41 @@ package resolver
 
 import "github.com/zzet/gortex/internal/graph"
 
+// ResolveFilesAndIncoming runs one scoped cross-repository pass for a complete
+// mutation batch. The frontier contains unresolved edges emitted by the changed
+// files and unresolved incoming stub buckets for the symbols they define. Both
+// directions share one resolver lock and one build of the directory,
+// dependency, reachability, and lookup indexes.
+func (cr *CrossRepoResolver) ResolveFilesAndIncoming(filePaths []string) *CrossRepoStats {
+	stats := &CrossRepoStats{ByRepo: make(map[string]int)}
+	if cr == nil || cr.graph == nil || len(filePaths) == 0 {
+		return stats
+	}
+
+	cr.mu.Lock()
+	defer cr.mu.Unlock()
+
+	frontier := collectIncrementalFileFrontier(cr.graph, filePaths, nil)
+	pending := make([]*graph.Edge, 0, len(frontier.pending))
+	seen := make(map[graph.EdgeIdentity]struct{}, len(frontier.pending))
+	for _, edge := range frontier.pending {
+		if edge == nil || !graph.IsUnresolvedTarget(edge.To) {
+			continue
+		}
+		identity := graph.EdgeIdentityFor(edge)
+		if _, duplicate := seen[identity]; duplicate {
+			continue
+		}
+		seen[identity] = struct{}{}
+		pending = append(pending, edge)
+	}
+	if len(pending) > 0 {
+		stats = cr.resolveScopedLocked(pending)
+	}
+	DetectCrossRepoEdgesForFiles(cr.graph, frontier.paths)
+	return stats
+}
+
 // DetectCrossRepoEdgesForFiles materializes the cross-repo layer only for base
 // edges incident to nodes in the exact changed-file frontier. Inspecting both
 // incoming and outgoing edges covers unchanged callers rebound to a changed

--- a/internal/resolver/cross_repo_test.go
+++ b/internal/resolver/cross_repo_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"iter"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -435,4 +436,94 @@ func TestCrossRepoResolveAll_BindsInboundEdgeIntoChangedRepo(t *testing.T) {
 	assert.Equal(t, "repoB/b.go::Foo", inbound.To,
 		"the whole-graph cross-repo resolve must bind the unchanged consumer's inbound reference into the changed provider")
 	assert.True(t, inbound.CrossRepo)
+}
+
+type crossRepoPassCountingStore struct {
+	graph.Store
+	directoryIndexBuilds    int
+	dependencyIndexBuilds   int
+	reachabilityIndexBuilds int
+}
+
+func (s *crossRepoPassCountingStore) FileNodeIdentitiesSeq(repoPrefixes []string) iter.Seq[graph.FileNodeIdentity] {
+	s.directoryIndexBuilds++
+	return graph.FileNodeIdentitiesSeq(s.Store, repoPrefixes)
+}
+
+func (s *crossRepoPassCountingStore) RepoNodeIdentitiesSeq(
+	repoPrefixes []string,
+	kinds ...graph.NodeKind,
+) iter.Seq[graph.RepoNodeIdentity] {
+	s.dependencyIndexBuilds++
+	return graph.RepoNodeIdentitiesSeq(s.Store, repoPrefixes, kinds...)
+}
+
+func (s *crossRepoPassCountingStore) EdgesLightSeq(kinds ...graph.EdgeKind) iter.Seq[*graph.Edge] {
+	if len(kinds) == 1 && kinds[0] == graph.EdgeImports {
+		s.reachabilityIndexBuilds++
+	}
+	return graph.EdgesLightSeq(s.Store, kinds...)
+}
+
+func TestCrossRepoResolveFilesAndIncoming_BatchesBothDirectionsWithOneIndexBuild(t *testing.T) {
+	g := &crossRepoPassCountingStore{Store: graph.New()}
+	const (
+		changedCallerFile   = "repoA/pkg/caller.go"
+		outgoingTargetFile  = "repoB/lib/helper.go"
+		incomingCallerFile  = "repoC/pkg/caller.go"
+		changedProviderFile = "repoD/lib/added.go"
+	)
+
+	g.AddNode(&graph.Node{
+		ID: "repoA/pkg/caller.go::Caller", Kind: graph.KindFunction, Name: "Caller",
+		FilePath: changedCallerFile, Language: "go", RepoPrefix: "repoA",
+	})
+	g.AddNode(&graph.Node{
+		ID: "repoB/lib/helper.go::Helper", Kind: graph.KindFunction, Name: "Helper",
+		FilePath: outgoingTargetFile, Language: "go", RepoPrefix: "repoB",
+	})
+	wireImport(g, changedCallerFile, "repoB", outgoingTargetFile)
+	outgoing := &graph.Edge{
+		From: "repoA/pkg/caller.go::Caller", To: "unresolved::Helper",
+		Kind: graph.EdgeCalls, FilePath: changedCallerFile, Line: 7,
+	}
+	g.AddEdge(outgoing)
+
+	g.AddNode(&graph.Node{
+		ID: "repoC/pkg/caller.go::Caller", Kind: graph.KindFunction, Name: "Caller",
+		FilePath: incomingCallerFile, Language: "go", RepoPrefix: "repoC",
+	})
+	g.AddNode(&graph.Node{
+		ID: "repoD/lib/added.go::Added", Kind: graph.KindFunction, Name: "Added",
+		FilePath: changedProviderFile, Language: "go", RepoPrefix: "repoD",
+	})
+	wireImport(g, incomingCallerFile, "repoD", changedProviderFile)
+	incoming := &graph.Edge{
+		From: "repoC/pkg/caller.go::Caller", To: "repoD::unresolved::Added",
+		Kind: graph.EdgeCalls, FilePath: incomingCallerFile, Line: 11,
+	}
+	g.AddEdge(incoming)
+
+	cr := NewCrossRepo(g)
+	emptyStats := cr.ResolveFilesAndIncoming([]string{"missing.go"})
+	require.Zero(t, emptyStats.Resolved)
+	require.Zero(t, g.directoryIndexBuilds)
+	require.Zero(t, g.dependencyIndexBuilds)
+	require.Zero(t, g.reachabilityIndexBuilds)
+
+	stats := cr.ResolveFilesAndIncoming([]string{
+		changedProviderFile,
+		changedCallerFile,
+		changedCallerFile,
+	})
+
+	require.Equal(t, 2, stats.Resolved)
+	require.Equal(t, 2, stats.CrossRepoEdges)
+	assert.Equal(t, "repoB/lib/helper.go::Helper", outgoing.To)
+	assert.True(t, outgoing.CrossRepo)
+	assert.Equal(t, "repoD/lib/added.go::Added", incoming.To)
+	assert.True(t, incoming.CrossRepo)
+	require.Equal(t, 1, g.directoryIndexBuilds)
+	require.Equal(t, 1, g.dependencyIndexBuilds)
+	require.Equal(t, 1, g.reachabilityIndexBuilds)
 }

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -2189,7 +2189,18 @@ func (r *Resolver) pendingEdgesForFileAndIncoming(filePath string) []*graph.Edge
 // calls: one batched file-node read, one outgoing-adjacency read, and one
 // incoming-stub read. Backends may chunk each request at their bind limit.
 func (r *Resolver) collectIncrementalFileFrontier(filePaths []string) incrementalFileFrontier {
+	return collectIncrementalFileFrontier(r.graph, filePaths, r.incrementalSkipped)
+}
+
+func collectIncrementalFileFrontier(
+	g graph.Store,
+	filePaths []string,
+	skip func(*graph.Edge) bool,
+) incrementalFileFrontier {
 	var frontier incrementalFileFrontier
+	if g == nil {
+		return frontier
+	}
 	seenPaths := make(map[string]struct{}, len(filePaths))
 	for _, path := range filePaths {
 		if path == "" {
@@ -2205,7 +2216,7 @@ func (r *Resolver) collectIncrementalFileFrontier(filePaths []string) incrementa
 		return frontier
 	}
 
-	frontier.nodesByFile = r.graph.GetFileNodesByPaths(frontier.paths)
+	frontier.nodesByFile = g.GetFileNodesByPaths(frontier.paths)
 	var nodeIDs []string
 	for _, path := range frontier.paths {
 		for _, node := range frontier.nodesByFile[path] {
@@ -2214,7 +2225,7 @@ func (r *Resolver) collectIncrementalFileFrontier(filePaths []string) incrementa
 			}
 		}
 	}
-	frontier.outByNode = r.graph.GetOutEdgesByNodeIDs(nodeIDs)
+	frontier.outByNode = g.GetOutEdgesByNodeIDs(nodeIDs)
 
 	seenStubKeys := make(map[string]struct{})
 	appendStubKey := func(key string) {
@@ -2233,7 +2244,7 @@ func (r *Resolver) collectIncrementalFileFrontier(filePaths []string) incrementa
 				continue
 			}
 			for _, edge := range frontier.outByNode[node.ID] {
-				if graph.IsUnresolvedTarget(edge.To) && !r.incrementalSkipped(edge) {
+				if graph.IsUnresolvedTarget(edge.To) && (skip == nil || !skip(edge)) {
 					frontier.pending = append(frontier.pending, edge)
 				}
 			}
@@ -2248,7 +2259,7 @@ func (r *Resolver) collectIncrementalFileFrontier(filePaths []string) incrementa
 	}
 	// The unresolved target string is the incoming-edge bucket key even when
 	// no node with that ID exists.
-	inByStub := r.graph.GetInEdgesByNodeIDs(frontier.stubKeys)
+	inByStub := g.GetInEdgesByNodeIDs(frontier.stubKeys)
 	for _, key := range frontier.stubKeys {
 		for _, edge := range inByStub[key] {
 			if edge != nil && graph.IsUnresolvedTarget(edge.To) {


### PR DESCRIPTION
## Summary

- run exactly one configured cross-repo resolution pass after each coordinated mutation batch
- resolve both outgoing changed-file edges and incoming unresolved stub buckets under the existing repository lane and topology writer
- reuse the three-query incremental frontier, deduplicate logical edges, warm lookup caches once, and skip directory/dependency/reachability index builds for no-op scopes
- cover watcher/storm batching plus outgoing and inbound binding with one-build regression tests

## Verification

- `go test ./internal/resolver ./internal/indexer -count=1`
- `go test -race ./internal/indexer/... ./internal/resolver/... -count=1`
- `go vet ./internal/resolver ./internal/indexer`
- `golangci-lint run ./internal/resolver ./internal/indexer`
- `go test ./... -run "^$" -count=1`
- repository-wide functional run passed all packages; its wall-clock sentinel missed once by 0.02 ms and passed immediately in isolation
