### PR TITLE
perf(resolver): share post-bare attribution census

### DIFF
--- a/internal/resolver/attribution_census.go
+++ b/internal/resolver/attribution_census.go
@@ -1,0 +1,172 @@
+package resolver
+
+import "github.com/zzet/gortex/internal/graph"
+
+const (
+	postBareAttributionCensusMaxCandidates    = 256 << 10
+	postBareAttributionCensusMaxRetainedBytes = int64(64 << 20)
+	// EdgeIdentity currently carries four string headers and one int. Include
+	// padding plus a small slice/accounting allowance, then add the retained
+	// string bytes below. The estimate deliberately over-counts in-memory
+	// stores (their strings are already graph-owned) so the cap always fails
+	// toward the exact legacy scans, never toward another heap spike.
+	attributionCensusIdentityOverhead = int64(80)
+)
+
+var postBareAttributionCensusKinds = []graph.EdgeKind{
+	graph.EdgeCalls,
+	graph.EdgeReferences,
+	graph.EdgeArgOf,
+	graph.EdgeValueFlow,
+	graph.EdgeTypedAs,
+	graph.EdgeReturns,
+	graph.EdgeInstantiates,
+}
+
+type attributionCensusLimits struct {
+	maxCandidates    int
+	maxRetainedBytes int64
+}
+
+var defaultAttributionCensusLimits = attributionCensusLimits{
+	maxCandidates:    postBareAttributionCensusMaxCandidates,
+	maxRetainedBytes: postBareAttributionCensusMaxRetainedBytes,
+}
+
+type postBareAttributionCensus struct {
+	finder             graph.EdgeIdentityBatchFinder
+	callee             *calleeIndex
+	dataflowCandidates []graph.EdgeIdentity
+	genericCandidates  []graph.EdgeIdentity
+	retainedBytes      int64
+}
+
+type attributionCensusStats struct {
+	rowsScanned        int
+	dataflowCandidates int
+	genericCandidates  int
+	retainedBytes      int64
+	fallbackReason     string
+}
+
+// buildPostBareAttributionCensus replaces the six corpus reads behind the
+// dataflow and generic-parameter passes with one metadata-free kind-union walk.
+// It runs after bare-name attribution, so references that pass just resolved
+// already contribute their current call-site target to callee.bySite. Only
+// compact logical identities survive the walk; each pass exact-refetches its
+// current rows in bounded pages immediately before mutation.
+//
+// This deliberately does not share Resolver.ResolveAll's unresolved pages
+// with CrossRepoResolver. The master compute, guard, and attribution tails can
+// retarget or revert those rows before cross-repo resolution begins, while an
+// interleaving writer can add a new unresolved row between the two passes.
+// Retaining the raw pages would also recreate the whole-frontier heap spike.
+// A safe cross-resolver hand-off therefore needs a store-owned, revision-bound,
+// disk-resident frontier and is a separate change.
+func (r *Resolver) buildPostBareAttributionCensus(
+	limits attributionCensusLimits,
+) (*postBareAttributionCensus, attributionCensusStats) {
+	var stats attributionCensusStats
+	light, lightOK := r.graph.(graph.LightEdgeSequencer)
+	finder, finderOK := r.graph.(graph.EdgeIdentityBatchFinder)
+	if !lightOK || !finderOK {
+		stats.fallbackReason = "missing_projection_capability"
+		return nil, stats
+	}
+	if limits.maxCandidates <= 0 || limits.maxRetainedBytes <= 0 {
+		stats.fallbackReason = "invalid_limit"
+		return nil, stats
+	}
+
+	census := &postBareAttributionCensus{
+		finder: finder,
+		callee: newCalleeIndex(),
+	}
+	appendCandidate := func(dst *[]graph.EdgeIdentity, edge *graph.Edge) bool {
+		identity := graph.EdgeIdentityFor(edge)
+		retained := attributionCensusIdentityBytes(identity)
+		count := len(census.dataflowCandidates) + len(census.genericCandidates)
+		if count >= limits.maxCandidates {
+			stats.fallbackReason = "candidate_cap"
+			return false
+		}
+		if census.retainedBytes+retained > limits.maxRetainedBytes {
+			stats.fallbackReason = "retained_byte_cap"
+			return false
+		}
+		*dst = append(*dst, identity)
+		census.retainedBytes += retained
+		return true
+	}
+
+	complete := true
+	for edge := range light.EdgesLightSeq(postBareAttributionCensusKinds...) {
+		if edge == nil {
+			continue
+		}
+		stats.rowsScanned++
+		switch edge.Kind {
+		case graph.EdgeCalls, graph.EdgeReferences:
+			census.callee.indexCallSite(edge)
+		}
+		switch edge.Kind {
+		case graph.EdgeArgOf, graph.EdgeValueFlow:
+			if dataflowCalleeTargetShape(edge.To) {
+				complete = appendCandidate(&census.dataflowCandidates, edge)
+			}
+		case graph.EdgeReferences, graph.EdgeTypedAs, graph.EdgeReturns, graph.EdgeInstantiates:
+			if _, ok := genericParamTargetName(edge.To); ok {
+				complete = appendCandidate(&census.genericCandidates, edge)
+			}
+		}
+		if !complete {
+			break
+		}
+	}
+
+	stats.dataflowCandidates = len(census.dataflowCandidates)
+	stats.genericCandidates = len(census.genericCandidates)
+	stats.retainedBytes = census.retainedBytes
+	if !complete {
+		census.close()
+		return nil, stats
+	}
+	// The callable-node projection can be large. Defer it until candidate
+	// admission succeeds so a capped census does not build this index only for
+	// the exact legacy fallback to build it again moments later. Call-site
+	// evidence still comes from the single light edge walk above.
+	callSites := census.callee.bySite
+	census.callee = r.buildCalleeIndex()
+	census.callee.bySite = callSites
+	return census, stats
+}
+
+func attributionCensusIdentityBytes(identity graph.EdgeIdentity) int64 {
+	return attributionCensusIdentityOverhead + int64(
+		len(identity.From)+len(identity.To)+len(identity.Kind)+len(identity.FilePath),
+	)
+}
+
+func (c *postBareAttributionCensus) releaseDataflow() {
+	if c == nil {
+		return
+	}
+	c.dataflowCandidates = nil
+	c.callee = nil
+}
+
+func (c *postBareAttributionCensus) releaseGeneric() {
+	if c == nil {
+		return
+	}
+	c.genericCandidates = nil
+}
+
+func (c *postBareAttributionCensus) close() {
+	if c == nil {
+		return
+	}
+	c.releaseDataflow()
+	c.releaseGeneric()
+	c.finder = nil
+}

--- a/internal/resolver/attribution_census_bench_test.go
+++ b/internal/resolver/attribution_census_bench_test.go
@@ -1,0 +1,114 @@
+package resolver
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+)
+
+const attributionCensusBenchmarkEdges = 100_000
+
+// BenchmarkPostBareAttributionCensusSQLite100K compares the pre-census tail
+// (six separate corpus reads, including full metadata hydration) with the
+// shared light projection plus bounded exact hydration. The candidate density
+// is about 3.4%, close to the measured production corpus, and every edge carries
+// a payload that the light projection deliberately avoids decoding.
+func BenchmarkPostBareAttributionCensusSQLite100K(b *testing.B) {
+	for _, benchmark := range []struct {
+		name string
+		run  func(*testing.B, *Resolver)
+	}{
+		{
+			name: "LegacyFullScans",
+			run: func(_ *testing.B, resolver *Resolver) {
+				resolver.bindDataflowCalleeRefs()
+				resolver.bindGenericParamRefs()
+			},
+		},
+		{
+			name: "SharedLightCensus",
+			run: func(b *testing.B, resolver *Resolver) {
+				census, stats := resolver.buildPostBareAttributionCensus(defaultAttributionCensusLimits)
+				if census == nil {
+					b.Fatalf("unexpected census fallback: %s", stats.fallbackReason)
+				}
+				resolver.bindDataflowCalleeRefsFromCensus(census)
+				census.releaseDataflow()
+				resolver.bindGenericParamRefsFromCensus(census)
+				census.close()
+			},
+		},
+	} {
+		b.Run(benchmark.name, func(b *testing.B) {
+			store := buildAttributionCensusSQLiteBenchmarkStore(b)
+			b.Cleanup(func() { _ = store.Close() })
+			resolver := New(store)
+			b.ReportAllocs()
+			b.ReportMetric(attributionCensusBenchmarkEdges, "edges/op")
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				benchmark.run(b, resolver)
+			}
+		})
+	}
+}
+
+func buildAttributionCensusSQLiteBenchmarkStore(b *testing.B) *store_sqlite.Store {
+	b.Helper()
+	store, err := store_sqlite.Open(filepath.Join(b.TempDir(), "attribution-census.sqlite"))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	owner := &graph.Node{
+		ID: "repo::Owner", Kind: graph.KindFunction, Name: "Owner",
+		FilePath: "pkg/owner.go", Language: "go", RepoPrefix: "repo",
+	}
+	typeParam := &graph.Node{
+		ID: "repo::Owner#tparam:T", Kind: graph.KindGenericParam, Name: "T",
+		FilePath: owner.FilePath, Language: "go", RepoPrefix: "repo",
+	}
+	store.AddBatch([]*graph.Node{owner, typeParam}, nil)
+
+	kinds := []graph.EdgeKind{
+		graph.EdgeCalls,
+		graph.EdgeReferences,
+		graph.EdgeArgOf,
+		graph.EdgeValueFlow,
+		graph.EdgeTypedAs,
+		graph.EdgeReturns,
+		graph.EdgeInstantiates,
+	}
+	payload := strings.Repeat("m", 512)
+	const batchSize = 5_000
+	for start := 0; start < attributionCensusBenchmarkEdges; start += batchSize {
+		end := min(start+batchSize, attributionCensusBenchmarkEdges)
+		edges := make([]*graph.Edge, 0, end-start)
+		for i := start; i < end; i++ {
+			kind := kinds[i%len(kinds)]
+			to := "repo::resolved-target"
+			if i%25 == 0 {
+				switch kind {
+				case graph.EdgeArgOf, graph.EdgeValueFlow:
+					to = graph.UnresolvedMarker + "MissingCallee"
+				case graph.EdgeReferences, graph.EdgeTypedAs, graph.EdgeReturns, graph.EdgeInstantiates:
+					to = graph.UnresolvedMarker + "MissingTypeParam"
+				}
+			}
+			edges = append(edges, &graph.Edge{
+				From:     fmt.Sprintf("repo::Other#local:%06d", i),
+				To:       to,
+				Kind:     kind,
+				FilePath: fmt.Sprintf("pkg/corpus-%03d.go", i%100),
+				Line:     i + 1,
+				Meta:     map[string]any{"payload": payload, "sequence": i},
+			})
+		}
+		store.AddBatch(nil, edges)
+	}
+	return store
+}

--- a/internal/resolver/attribution_census_sqlite_test.go
+++ b/internal/resolver/attribution_census_sqlite_test.go
@@ -1,0 +1,104 @@
+package resolver
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+)
+
+func TestPostBareAttributionCensusSQLiteDoesNotDecodeCorruptMeta(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "corrupt-meta.sqlite")
+	store, err := store_sqlite.Open(path)
+	require.NoError(t, err)
+	store.AddEdge(&graph.Edge{
+		From: "arg", To: "unresolved::Target", Kind: graph.EdgeArgOf,
+		FilePath: "pkg/file.go", Line: 10, Meta: map[string]any{"payload": "valid"},
+	})
+	require.NoError(t, store.Close())
+
+	raw, err := sql.Open("sqlite", path)
+	require.NoError(t, err)
+	_, err = raw.Exec("UPDATE edges SET meta = ?", []byte{0xff})
+	require.NoError(t, err)
+	require.NoError(t, raw.Close())
+
+	reopened, err := store_sqlite.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = reopened.Close() })
+	census, stats := New(reopened).buildPostBareAttributionCensus(defaultAttributionCensusLimits)
+	require.NotNil(t, census)
+	defer census.close()
+	assert.Empty(t, stats.fallbackReason)
+	assert.Equal(t, 1, stats.rowsScanned)
+	assert.Equal(t, 1, stats.dataflowCandidates)
+}
+
+func TestPostBareAttributionCensusSQLiteMatchesLegacyPasses(t *testing.T) {
+	legacyStore, err := store_sqlite.Open(filepath.Join(t.TempDir(), "legacy.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = legacyStore.Close() })
+	sharedStore, err := store_sqlite.Open(filepath.Join(t.TempDir(), "shared.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sharedStore.Close() })
+
+	sources := addPostBareAttributionSQLiteFixture(legacyStore)
+	addPostBareAttributionSQLiteFixture(sharedStore)
+
+	legacy := New(legacyStore)
+	legacy.bindDataflowCalleeRefs()
+	legacy.bindGenericParamRefs()
+
+	shared := New(sharedStore)
+	census, stats := shared.buildPostBareAttributionCensus(defaultAttributionCensusLimits)
+	require.NotNil(t, census)
+	require.Empty(t, stats.fallbackReason)
+	assert.Equal(t, 4, stats.rowsScanned)
+	assert.Equal(t, 2, stats.dataflowCandidates)
+	assert.Equal(t, 1, stats.genericCandidates)
+	shared.bindDataflowCalleeRefsFromCensus(census)
+	census.releaseDataflow()
+	shared.bindGenericParamRefsFromCensus(census)
+	census.close()
+
+	for source, want := range sources {
+		legacyEdges := legacyStore.GetOutEdges(source)
+		require.Len(t, legacyEdges, 1, "legacy source %s", source)
+		sharedEdges := sharedStore.GetOutEdges(source)
+		require.Len(t, sharedEdges, 1, "shared source %s", source)
+		assert.Equal(t, want, legacyEdges[0].To, "legacy source %s", source)
+		assert.Equal(t, want, sharedEdges[0].To, "shared source %s", source)
+	}
+}
+
+func addPostBareAttributionSQLiteFixture(store graph.Store) map[string]string {
+	file := "pkg/file.go"
+	owner := file + "::Owner"
+	functionTarget := file + "::Do"
+	methodTarget := file + "::Worker.Run"
+	tparamTarget := owner + "#tparam:T"
+	argFunction := owner + "#arg:0"
+	argMethod := owner + "#arg:1"
+	genericUse := owner + "#local:value"
+	store.AddBatch([]*graph.Node{
+		{ID: owner, Kind: graph.KindFunction, Name: "Owner", FilePath: file, Language: "go"},
+		{ID: functionTarget, Kind: graph.KindFunction, Name: "Do", FilePath: file, Language: "go"},
+		{ID: methodTarget, Kind: graph.KindMethod, Name: "Run", FilePath: file, Language: "go"},
+		{ID: tparamTarget, Kind: graph.KindGenericParam, Name: "T", FilePath: file, Language: "go"},
+	}, []*graph.Edge{
+		{From: owner, To: methodTarget, Kind: graph.EdgeCalls, FilePath: file, Line: 20},
+		{From: argFunction, To: "unresolved::Do", Kind: graph.EdgeArgOf, FilePath: file, Line: 10},
+		{From: argMethod, To: "unresolved::*.Run", Kind: graph.EdgeValueFlow, FilePath: file, Line: 20},
+		{From: genericUse, To: "unresolved::T", Kind: graph.EdgeTypedAs, FilePath: file, Line: 30},
+	})
+	return map[string]string{
+		argFunction: functionTarget,
+		argMethod:   methodTarget,
+		genericUse:  tparamTarget,
+	}
+}

--- a/internal/resolver/attribution_census_test.go
+++ b/internal/resolver/attribution_census_test.go
@@ -1,0 +1,328 @@
+package resolver
+
+import (
+	"fmt"
+	"iter"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+type attributionCensusRecordingStore struct {
+	graph.Store
+
+	lightEdges     []*graph.Edge
+	lightCalls     int
+	lightKinds     []graph.EdgeKind
+	callableCalls  int
+	finderCalls    [][]graph.EdgeIdentity
+	current        map[graph.EdgeIdentity]*graph.Edge
+	reindexBatches [][]graph.EdgeReindex
+}
+
+func (s *attributionCensusRecordingStore) EdgesLightSeq(kinds ...graph.EdgeKind) iter.Seq[*graph.Edge] {
+	s.lightCalls++
+	s.lightKinds = append([]graph.EdgeKind(nil), kinds...)
+	wanted := make(map[graph.EdgeKind]struct{}, len(kinds))
+	for _, kind := range kinds {
+		wanted[kind] = struct{}{}
+	}
+	return func(yield func(*graph.Edge) bool) {
+		for _, edge := range s.lightEdges {
+			if edge == nil {
+				continue
+			}
+			if _, ok := wanted[edge.Kind]; !ok {
+				continue
+			}
+			if !yield(edge) {
+				return
+			}
+		}
+	}
+}
+
+func (s *attributionCensusRecordingStore) CallableBindingNodesSeq(
+	_ ...graph.NodeKind,
+) iter.Seq[graph.CallableBindingNode] {
+	s.callableCalls++
+	return func(func(graph.CallableBindingNode) bool) {}
+}
+
+func (s *attributionCensusRecordingStore) FindEdgesByIdentities(
+	identities []graph.EdgeIdentity,
+) map[graph.EdgeIdentity]*graph.Edge {
+	s.finderCalls = append(s.finderCalls, append([]graph.EdgeIdentity(nil), identities...))
+	found := make(map[graph.EdgeIdentity]*graph.Edge, len(identities))
+	for _, identity := range identities {
+		if edge := s.current[identity]; edge != nil {
+			found[identity] = edge
+		}
+	}
+	return found
+}
+
+func (s *attributionCensusRecordingStore) ReindexEdges(batch []graph.EdgeReindex) {
+	s.reindexBatches = append(s.reindexBatches, append([]graph.EdgeReindex(nil), batch...))
+}
+
+type attributionCensusNoProjectionStore struct {
+	graph.Store
+}
+
+func TestBuildPostBareAttributionCensusFallsBackWithoutProjectionCapabilities(t *testing.T) {
+	store := &attributionCensusNoProjectionStore{Store: graph.New()}
+	census, stats := (&Resolver{graph: store}).buildPostBareAttributionCensus(defaultAttributionCensusLimits)
+
+	assert.Nil(t, census)
+	assert.Equal(t, "missing_projection_capability", stats.fallbackReason)
+	assert.Zero(t, stats.rowsScanned)
+}
+
+func TestBuildPostBareAttributionCensusUsesOneLightWalk(t *testing.T) {
+	resolvedMethod := "repo/pkg/file.go::Worker.Run"
+	edges := []*graph.Edge{
+		{From: "caller", To: resolvedMethod, Kind: graph.EdgeCalls, FilePath: "pkg/file.go", Line: 9},
+		{From: "arg-1", To: "unresolved::Do", Kind: graph.EdgeArgOf, FilePath: "pkg/file.go", Line: 10},
+		{From: "arg-2", To: "repo::unresolved::*.Run", Kind: graph.EdgeValueFlow, FilePath: "pkg/file.go", Line: 9},
+		{From: "fn#local:x", To: "unresolved::T", Kind: graph.EdgeReferences, FilePath: "pkg/file.go", Line: 11},
+		{From: "fn#local:y", To: "unresolved::pkg.T", Kind: graph.EdgeTypedAs, FilePath: "pkg/file.go", Line: 12},
+		{From: "fn#local:z", To: "repo::unresolved::T", Kind: graph.EdgeReturns, FilePath: "pkg/file.go", Line: 13},
+		{From: "ignored", To: "unresolved::Do", Kind: graph.EdgeMemberOf},
+	}
+	store := &attributionCensusRecordingStore{Store: graph.New(), lightEdges: edges}
+	r := &Resolver{graph: store}
+
+	census, stats := r.buildPostBareAttributionCensus(defaultAttributionCensusLimits)
+	require.NotNil(t, census)
+	defer census.close()
+
+	assert.Equal(t, 1, store.lightCalls)
+	assert.Equal(t, 1, store.callableCalls)
+	assert.Equal(t, postBareAttributionCensusKinds, store.lightKinds)
+	assert.Equal(t, 6, stats.rowsScanned)
+	assert.Equal(t, 2, stats.dataflowCandidates)
+	assert.Equal(t, 1, stats.genericCandidates)
+	assert.Empty(t, stats.fallbackReason)
+	assert.Equal(t, resolvedMethod, uniqueSiteCallee(census.callee.bySite[siteKey("pkg/file.go", 9)], "Run"))
+
+	wantBytes := attributionCensusIdentityBytes(graph.EdgeIdentityFor(edges[1])) +
+		attributionCensusIdentityBytes(graph.EdgeIdentityFor(edges[2])) +
+		attributionCensusIdentityBytes(graph.EdgeIdentityFor(edges[3]))
+	assert.Equal(t, wantBytes, stats.retainedBytes)
+
+	census.releaseDataflow()
+	assert.Nil(t, census.callee)
+	assert.Nil(t, census.dataflowCandidates)
+	assert.Len(t, census.genericCandidates, 1)
+}
+
+func TestBuildPostBareAttributionCensusFallsBackAtCaps(t *testing.T) {
+	edges := []*graph.Edge{
+		{From: "arg-1", To: "unresolved::First", Kind: graph.EdgeArgOf, FilePath: "pkg/file.go"},
+		{From: "arg-2", To: "unresolved::Second", Kind: graph.EdgeArgOf, FilePath: "pkg/file.go"},
+	}
+
+	t.Run("candidate_count", func(t *testing.T) {
+		store := &attributionCensusRecordingStore{Store: graph.New(), lightEdges: edges}
+		census, stats := (&Resolver{graph: store}).buildPostBareAttributionCensus(attributionCensusLimits{
+			maxCandidates:    1,
+			maxRetainedBytes: 1 << 20,
+		})
+		assert.Nil(t, census)
+		assert.Equal(t, "candidate_cap", stats.fallbackReason)
+		assert.Equal(t, 2, stats.rowsScanned)
+		assert.Equal(t, 1, stats.dataflowCandidates)
+		assert.Zero(t, store.callableCalls)
+	})
+
+	t.Run("retained_bytes", func(t *testing.T) {
+		store := &attributionCensusRecordingStore{Store: graph.New(), lightEdges: edges}
+		firstBytes := attributionCensusIdentityBytes(graph.EdgeIdentityFor(edges[0]))
+		census, stats := (&Resolver{graph: store}).buildPostBareAttributionCensus(attributionCensusLimits{
+			maxCandidates:    10,
+			maxRetainedBytes: firstBytes - 1,
+		})
+		assert.Nil(t, census)
+		assert.Equal(t, "retained_byte_cap", stats.fallbackReason)
+		assert.Equal(t, 1, stats.rowsScanned)
+		assert.Zero(t, stats.dataflowCandidates)
+		assert.Zero(t, stats.retainedBytes)
+		assert.Zero(t, store.callableCalls)
+	})
+}
+
+func TestReindexAttributionIdentitiesBatchedBoundsHydration(t *testing.T) {
+	const count = attributionReindexBatchSize*2 + 7
+	store := &attributionCensusRecordingStore{
+		Store:   graph.New(),
+		current: make(map[graph.EdgeIdentity]*graph.Edge, count),
+	}
+	identities := make([]graph.EdgeIdentity, 0, count)
+	for i := 0; i < count; i++ {
+		edge := &graph.Edge{
+			From: fmt.Sprintf("from-%d", i), To: fmt.Sprintf("unresolved::target-%d", i),
+			Kind: graph.EdgeReferences, FilePath: "pkg/file.go", Line: i + 1,
+		}
+		identity := graph.EdgeIdentityFor(edge)
+		identities = append(identities, identity)
+		store.current[identity] = edge
+	}
+	r := &Resolver{graph: store}
+
+	r.reindexAttributionIdentitiesBatched(store, identities, func(edge *graph.Edge) string {
+		oldTo := edge.To
+		edge.To = "resolved::" + edge.From
+		return oldTo
+	})
+
+	require.Len(t, store.finderCalls, 3)
+	for _, call := range store.finderCalls {
+		assert.LessOrEqual(t, len(call), attributionReindexBatchSize)
+	}
+	assertAttributionReindexBatches(t, store.reindexBatches, count)
+}
+
+func TestReindexAttributionIdentitiesBatchedDropsStaleIdentity(t *testing.T) {
+	old := graph.EdgeIdentity{From: "from", To: "unresolved::Old", Kind: graph.EdgeReferences, FilePath: "pkg/file.go", Line: 1}
+	currentEdge := &graph.Edge{From: old.From, To: "resolved::New", Kind: old.Kind, FilePath: old.FilePath, Line: old.Line}
+	store := &attributionCensusRecordingStore{
+		Store: graph.New(),
+		current: map[graph.EdgeIdentity]*graph.Edge{
+			graph.EdgeIdentityFor(currentEdge): currentEdge,
+		},
+	}
+	rewrites := 0
+
+	(&Resolver{graph: store}).reindexAttributionIdentitiesBatched(
+		store,
+		[]graph.EdgeIdentity{old},
+		func(edge *graph.Edge) string {
+			rewrites++
+			return edge.To
+		},
+	)
+
+	assert.Zero(t, rewrites)
+	assert.Empty(t, store.reindexBatches)
+	assert.Equal(t, "resolved::New", currentEdge.To)
+}
+
+func TestReindexAttributionIdentitiesBatchedUsesCurrentSameKeyPayload(t *testing.T) {
+	identity := graph.EdgeIdentity{
+		From: "from", To: "unresolved::Target", Kind: graph.EdgeReferences,
+		FilePath: "pkg/file.go", Line: 1,
+	}
+	replacement := &graph.Edge{
+		From: identity.From, To: identity.To, Kind: identity.Kind,
+		FilePath: identity.FilePath, Line: identity.Line,
+		Origin: graph.OriginLSPResolved,
+		Meta:   map[string]any{"payload": "fresh"},
+	}
+	store := &attributionCensusRecordingStore{
+		Store:   graph.New(),
+		current: map[graph.EdgeIdentity]*graph.Edge{identity: replacement},
+	}
+
+	(&Resolver{graph: store}).reindexAttributionIdentitiesBatched(
+		store,
+		[]graph.EdgeIdentity{identity},
+		func(edge *graph.Edge) string {
+			oldTo := edge.To
+			edge.To = "resolved::Target"
+			return oldTo
+		},
+	)
+
+	require.Len(t, store.reindexBatches, 1)
+	require.Len(t, store.reindexBatches[0], 1)
+	reindexed := store.reindexBatches[0][0]
+	assert.Same(t, replacement, reindexed.Edge)
+	assert.Equal(t, identity.To, reindexed.OldTo)
+	assert.Equal(t, graph.OriginLSPResolved, reindexed.Edge.Origin)
+	assert.Equal(t, "fresh", reindexed.Edge.Meta["payload"])
+}
+
+func TestPostBareAttributionCensusMatchesLegacyPasses(t *testing.T) {
+	legacyGraph, sources := buildPostBareAttributionParityGraph()
+	sharedGraph, _ := buildPostBareAttributionParityGraph()
+
+	legacy := &Resolver{graph: legacyGraph}
+	legacy.bindDataflowCalleeRefs()
+	legacy.bindGenericParamRefs()
+
+	shared := &Resolver{graph: sharedGraph}
+	census, stats := shared.buildPostBareAttributionCensus(defaultAttributionCensusLimits)
+	require.NotNil(t, census)
+	require.Empty(t, stats.fallbackReason)
+	shared.bindDataflowCalleeRefsFromCensus(census)
+	census.releaseDataflow()
+	shared.bindGenericParamRefsFromCensus(census)
+	census.releaseGeneric()
+	census.close()
+
+	for source, want := range sources {
+		assert.Equal(t, want, soleOutTarget(t, legacyGraph, source), "legacy source %s", source)
+		assert.Equal(t, want, soleOutTarget(t, sharedGraph, source), "shared source %s", source)
+	}
+}
+
+func TestPostBareAttributionCensusCapFallbackUsesLegacyPasses(t *testing.T) {
+	g, sources := buildPostBareAttributionParityGraph()
+	previousLimits := defaultAttributionCensusLimits
+	defaultAttributionCensusLimits = attributionCensusLimits{
+		maxCandidates:    1,
+		maxRetainedBytes: 1 << 20,
+	}
+	defer func() { defaultAttributionCensusLimits = previousLimits }()
+
+	New(g).runFileAttributionPassesLocked()
+
+	for source, want := range sources {
+		assert.Equal(t, want, soleOutTarget(t, g, source), "fallback source %s", source)
+	}
+}
+
+func buildPostBareAttributionParityGraph() (*graph.Graph, map[string]string) {
+	g := graph.New()
+	file := "pkg/file.go"
+	owner := file + "::Owner"
+	functionTarget := file + "::Do"
+	methodTarget := file + "::Worker.Run"
+	tparamTarget := owner + "#tparam:T"
+	argFunction := owner + "#arg:0"
+	argMethod := owner + "#arg:1"
+	genericUse := owner + "#local:value"
+
+	nodes := []*graph.Node{
+		{ID: owner, Kind: graph.KindFunction, Name: "Owner", FilePath: file, Language: "go"},
+		{ID: functionTarget, Kind: graph.KindFunction, Name: "Do", FilePath: file, Language: "go"},
+		{ID: methodTarget, Kind: graph.KindMethod, Name: "Run", FilePath: file, Language: "go"},
+		{ID: tparamTarget, Kind: graph.KindGenericParam, Name: "T", FilePath: file, Language: "go"},
+		{ID: argFunction, Kind: graph.KindVariable, Name: "arg0", FilePath: file, Language: "go"},
+		{ID: argMethod, Kind: graph.KindVariable, Name: "arg1", FilePath: file, Language: "go"},
+		{ID: genericUse, Kind: graph.KindVariable, Name: "value", FilePath: file, Language: "go"},
+	}
+	edges := []*graph.Edge{
+		{From: owner, To: methodTarget, Kind: graph.EdgeCalls, FilePath: file, Line: 20},
+		{From: argFunction, To: "unresolved::Do", Kind: graph.EdgeArgOf, FilePath: file, Line: 10},
+		{From: argMethod, To: "unresolved::*.Run", Kind: graph.EdgeValueFlow, FilePath: file, Line: 20},
+		{From: genericUse, To: "unresolved::T", Kind: graph.EdgeTypedAs, FilePath: file, Line: 30},
+	}
+	g.AddBatch(nodes, edges)
+	return g, map[string]string{
+		argFunction: functionTarget,
+		argMethod:   methodTarget,
+		genericUse:  tparamTarget,
+	}
+}
+
+func soleOutTarget(t *testing.T, g *graph.Graph, source string) string {
+	t.Helper()
+	edges := g.GetOutEdges(source)
+	require.Len(t, edges, 1)
+	return edges[0].To
+}

--- a/internal/resolver/attribution_reindex_batch.go
+++ b/internal/resolver/attribution_reindex_batch.go
@@ -55,3 +55,34 @@ func (r *Resolver) reindexAttributionEdgesBatched(
 	})
 	collector.flush()
 }
+
+// reindexAttributionIdentitiesBatched exact-refetches census candidates in
+// bounded pages. Re-fetching immediately before each pass preserves sequential
+// attribution semantics: an edge retargeted or removed after the census no
+// longer exists under its old logical identity and is therefore not
+// resurrected. The finder never receives more than the existing attribution
+// payload bound, and each page is persisted before its full rows are released.
+func (r *Resolver) reindexAttributionIdentitiesBatched(
+	finder graph.EdgeIdentityBatchFinder,
+	identities []graph.EdgeIdentity,
+	rewrite func(*graph.Edge) string,
+) {
+	if finder == nil || rewrite == nil {
+		return
+	}
+	for start := 0; start < len(identities); start += attributionReindexBatchSize {
+		end := start + attributionReindexBatchSize
+		if end > len(identities) {
+			end = len(identities)
+		}
+		page := identities[start:end]
+		current := finder.FindEdgesByIdentities(page)
+		collector := newAttributionReindexCollector(r)
+		for _, identity := range page {
+			if edge := current[identity]; edge != nil {
+				collector.add(edge, rewrite(edge))
+			}
+		}
+		collector.flush()
+	}
+}

--- a/internal/resolver/dataflow_callee_bind.go
+++ b/internal/resolver/dataflow_callee_bind.go
@@ -41,16 +41,7 @@ import (
 // materializeDataflowParams (which then refines a resolved function/method
 // callee to its param node).
 func (r *Resolver) bindDataflowCalleeRefs() {
-	idx := newCalleeIndex()
-	for node := range graph.CallableBindingNodesSeq(r.graph, graph.KindFunction, graph.KindMethod) {
-		if node.Name == "" || node.FilePath == "" {
-			continue
-		}
-		indexName(idx.byFile, node.FilePath, node.Name, node.ID)
-		if node.Kind == graph.KindFunction {
-			indexName(idx.byDir, filepath.Dir(node.FilePath), node.Name, node.ID)
-		}
-	}
+	idx := r.buildCalleeIndex()
 	for _, k := range []graph.EdgeKind{graph.EdgeCalls, graph.EdgeReferences} {
 		for e := range graph.EdgesLightSeq(r.graph, k) {
 			idx.indexCallSite(e)
@@ -61,6 +52,37 @@ func (r *Resolver) bindDataflowCalleeRefs() {
 	}
 	r.reindexAttributionEdgesBatched(
 		[]graph.EdgeKind{graph.EdgeArgOf, graph.EdgeValueFlow},
+		func(edge *graph.Edge) string {
+			return bindDataflowCalleeEdge(edge, idx)
+		},
+	)
+}
+
+func (r *Resolver) buildCalleeIndex() *calleeIndex {
+	idx := newCalleeIndex()
+	for node := range graph.CallableBindingNodesSeq(r.graph, graph.KindFunction, graph.KindMethod) {
+		if node.Name == "" || node.FilePath == "" {
+			continue
+		}
+		indexName(idx.byFile, node.FilePath, node.Name, node.ID)
+		if node.Kind == graph.KindFunction {
+			indexName(idx.byDir, filepath.Dir(node.FilePath), node.Name, node.ID)
+		}
+	}
+	return idx
+}
+
+func (r *Resolver) bindDataflowCalleeRefsFromCensus(census *postBareAttributionCensus) {
+	if census == nil || census.callee == nil {
+		return
+	}
+	idx := census.callee
+	if len(idx.byFile) == 0 && len(idx.bySite) == 0 {
+		return
+	}
+	r.reindexAttributionIdentitiesBatched(
+		census.finder,
+		census.dataflowCandidates,
 		func(edge *graph.Edge) string {
 			return bindDataflowCalleeEdge(edge, idx)
 		},
@@ -154,7 +176,7 @@ func indexName(m map[string]map[string][]string, key, name, id string) {
 // rewrite happened (for the batched reindex) or "" when the edge was left alone
 // (not an unresolved target, no unambiguous match, or a shape another pass owns).
 func bindDataflowCalleeEdge(e *graph.Edge, idx *calleeIndex) string {
-	if e == nil || !graph.IsUnresolvedTarget(e.To) {
+	if e == nil || !dataflowCalleeTargetShape(e.To) {
 		return ""
 	}
 	name := graph.UnresolvedName(e.To)
@@ -188,6 +210,23 @@ func bindDataflowCalleeEdge(e *graph.Edge, idx *calleeIndex) string {
 	oldTo := e.To
 	e.To = chosen
 	return oldTo
+}
+
+// dataflowCalleeTargetShape is the edge-only admission predicate shared by
+// the light census and the authoritative binder. It deliberately excludes
+// every shape bindDataflowCalleeEdge would reject before consulting an index,
+// so retaining an identity can over-collect only on graph evidence, never on
+// syntax; the exact-refetched edge still runs through the full binder.
+func dataflowCalleeTargetShape(to string) bool {
+	if !graph.IsUnresolvedTarget(to) {
+		return false
+	}
+	name := graph.UnresolvedName(to)
+	if strings.HasPrefix(name, "*.") {
+		method := name[2:]
+		return method != "" && !strings.ContainsAny(method, ".*:#")
+	}
+	return name != "" && !strings.ContainsAny(name, ".*:#")
 }
 
 // uniqueSiteCallee returns the sole resolved callee at a call site whose id

--- a/internal/resolver/generic_param_bind.go
+++ b/internal/resolver/generic_param_bind.go
@@ -22,29 +22,7 @@ import (
 // inside its body. The owner-keyed index built here lets each edge
 // resolve in O(1) without re-walking the graph.
 func (r *Resolver) bindGenericParamRefs() {
-	// owner-function ID → set of tparam-name → tparam-node-id.
-	owned := map[string]map[string]string{}
-	for n := range graph.NamedLanguageNodesSeq(r.graph, graph.KindGenericParam) {
-		if n.Language != "go" || n.Name == "" {
-			continue
-		}
-		owner := enclosingFunctionForBinding(n.ID)
-		if owner == "" || owner == n.ID {
-			continue
-		}
-		set, ok := owned[owner]
-		if !ok {
-			set = map[string]string{}
-			owned[owner] = set
-		}
-		// Don't overwrite — two tparams with the same name in the
-		// same function shouldn't happen in valid Go, but be defensive.
-		if _, dup := set[n.Name]; dup {
-			set[n.Name] = ""
-			continue
-		}
-		set[n.Name] = n.ID
-	}
+	owned := r.buildGenericParamOwnerIndex()
 	if len(owned) == 0 {
 		return
 	}
@@ -69,6 +47,50 @@ func (r *Resolver) bindGenericParamRefs() {
 	if len(batch) > 0 {
 		r.graph.ReindexEdges(batch)
 	}
+}
+
+func (r *Resolver) buildGenericParamOwnerIndex() map[string]map[string]string {
+	// owner-function ID → set of tparam-name → tparam-node-id.
+	owned := map[string]map[string]string{}
+	for n := range graph.NamedLanguageNodesSeq(r.graph, graph.KindGenericParam) {
+		if n.Language != "go" || n.Name == "" {
+			continue
+		}
+		owner := enclosingFunctionForBinding(n.ID)
+		if owner == "" || owner == n.ID {
+			continue
+		}
+		set, ok := owned[owner]
+		if !ok {
+			set = map[string]string{}
+			owned[owner] = set
+		}
+		// Don't overwrite — two tparams with the same name in the
+		// same function shouldn't happen in valid Go, but be defensive.
+		if _, dup := set[n.Name]; dup {
+			set[n.Name] = ""
+			continue
+		}
+		set[n.Name] = n.ID
+	}
+	return owned
+}
+
+func (r *Resolver) bindGenericParamRefsFromCensus(census *postBareAttributionCensus) {
+	if census == nil {
+		return
+	}
+	owned := r.buildGenericParamOwnerIndex()
+	if len(owned) == 0 {
+		return
+	}
+	r.reindexAttributionIdentitiesBatched(
+		census.finder,
+		census.genericCandidates,
+		func(edge *graph.Edge) string {
+			return r.tryBindGenericParam(edge, owned)
+		},
+	)
 }
 
 // bindGenericParamRefsForFile is the single-file-resolve form of
@@ -115,11 +137,11 @@ func (r *Resolver) bindGenericParamRefsForFile(filePath string) {
 // tryBindGenericParam returns the old To value (for batched reindex)
 // when the edge was rewritten, or "" when left alone.
 func (r *Resolver) tryBindGenericParam(e *graph.Edge, owned map[string]map[string]string) string {
-	if e == nil || !strings.HasPrefix(e.To, "unresolved::") {
+	if e == nil {
 		return ""
 	}
-	name := strings.TrimPrefix(e.To, "unresolved::")
-	if name == "" || strings.ContainsAny(name, ".*:#") {
+	name, ok := genericParamTargetName(e.To)
+	if !ok {
 		return ""
 	}
 	ownerID := enclosingFunctionForBinding(e.From)
@@ -137,4 +159,19 @@ func (r *Resolver) tryBindGenericParam(e *graph.Edge, owned map[string]map[strin
 	oldTo := e.To
 	e.To = target
 	return oldTo
+}
+
+// genericParamTargetName is the exact target-shape gate shared by the light
+// census and tryBindGenericParam. Repo-qualified unresolved targets remain
+// excluded: type parameters are owned by the source function and use the bare
+// unresolved::<name> representation.
+func genericParamTargetName(to string) (string, bool) {
+	if !strings.HasPrefix(to, "unresolved::") {
+		return "", false
+	}
+	name := strings.TrimPrefix(to, "unresolved::")
+	if name == "" || strings.ContainsAny(name, ".*:#") {
+		return "", false
+	}
+	return name, true
 }

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -2448,7 +2448,7 @@ func (r *Resolver) applyIncrementalReindexesLocked(
 // check makes a second sweep a no-op). Caller holds r.mu.
 func (r *Resolver) runFileAttributionPassesLocked() {
 	// Announce each sub-pass up front: several run 30-90s on a large cold
-	// graph, and the retrospective breakdown below only lands after ALL six —
+	// graph, and the retrospective breakdown below only lands after ALL passes —
 	// until then the log was silent for the whole sweep.
 	sub := func(pass string) {
 		r.logger.Info("resolver: attribution sub-pass starting", zap.String("pass", pass))
@@ -2460,11 +2460,40 @@ func (r *Resolver) runFileAttributionPassesLocked() {
 	sub("bind_bare_name_scope_refs")
 	r.bindBareNameScopeRefs()
 	t2 := time.Now()
+	sub("shared_dataflow_generic_census")
+	census, censusStats := r.buildPostBareAttributionCensus(defaultAttributionCensusLimits)
+	censusDone := time.Now()
+	censusUsed := census != nil
+	if census != nil {
+		defer census.close()
+	}
+	r.logger.Info("resolver: shared attribution census",
+		zap.Bool("used", censusUsed),
+		zap.String("fallback_reason", censusStats.fallbackReason),
+		zap.Int("rows_scanned", censusStats.rowsScanned),
+		zap.Int("dataflow_candidates", censusStats.dataflowCandidates),
+		zap.Int("generic_candidates", censusStats.genericCandidates),
+		zap.Int64("retained_bytes_estimate", censusStats.retainedBytes),
+		zap.Int("candidate_cap", defaultAttributionCensusLimits.maxCandidates),
+		zap.Int64("retained_bytes_cap", defaultAttributionCensusLimits.maxRetainedBytes),
+		zap.Duration("elapsed", censusDone.Sub(t2)))
 	sub("bind_dataflow_callee_refs")
-	r.bindDataflowCalleeRefs()
+	if census != nil {
+		r.bindDataflowCalleeRefsFromCensus(census)
+		// The callee index and dataflow identities are the largest retained
+		// census state. Drop both before generic-owner indexing starts.
+		census.releaseDataflow()
+	} else {
+		r.bindDataflowCalleeRefs()
+	}
 	t3 := time.Now()
 	sub("bind_generic_param_refs")
-	r.bindGenericParamRefs()
+	if census != nil {
+		r.bindGenericParamRefsFromCensus(census)
+		census.releaseGeneric()
+	} else {
+		r.bindGenericParamRefs()
+	}
 	t4 := time.Now()
 	sub("attribute_go_builtins")
 	r.attributeGoBuiltins()
@@ -2484,7 +2513,9 @@ func (r *Resolver) runFileAttributionPassesLocked() {
 	r.logger.Info("resolver: attribution sub-passes",
 		zap.Duration("rebind_go_method_receivers", t1.Sub(t0)),
 		zap.Duration("bind_bare_name_scope_refs", t2.Sub(t1)),
-		zap.Duration("bind_dataflow_callee_refs", t3.Sub(t2)),
+		zap.Duration("shared_dataflow_generic_census", censusDone.Sub(t2)),
+		zap.Bool("shared_dataflow_generic_census_used", censusUsed),
+		zap.Duration("bind_dataflow_callee_refs", t3.Sub(censusDone)),
 		zap.Duration("bind_generic_param_refs", t4.Sub(t3)),
 		zap.Duration("attribute_go_builtins", t5.Sub(t4)),
 		zap.Duration("attribute_go_external_calls", t6.Sub(t5)),


### PR DESCRIPTION
## Summary

- Replace the post-bare dataflow/generic attribution tail's repeated corpus reads with one metadata-free edge-kind union walk.
- Retain only exact logical identities for syntax-qualified candidates, exact-refetch them in pages of at most 2,048, and release dataflow census state before generic-owner indexing.
- Preserve the existing full-scan implementations as the exact fallback when projection capabilities are unavailable or admission exceeds 262,144 identities / a 64 MiB conservative retained-identity estimate.
- Emit production counters for census use, fallback reason, rows, candidates, retained-byte estimate, caps, and duration.

## Measured boundary

On the local 4,779,322-edge production SQLite corpus, the current post-bare tail logically decodes 5,614,556 rows (about 12.67M estimated physical row visits because several paths traverse the table independently). The shared boundary walks 3,035,353 light rows and admits 128,056 exact candidates: 75,562 dataflow plus 52,494 generic. Their conservative retained-identity estimate is 27,981,492 bytes (~26.7 MiB), below both production caps.

That changes the estimated physical work to ~7.94M row visits and removes about 92% of post-bare full-Meta hydration. The 64 MiB value intentionally caps candidate identity state; it is logged as an estimate and is not presented as a hard total-heap limit (the callee site map and slice spare capacity are separate).

The checked-in 100K SQLite benchmark uses a ~3.4% candidate density and a 512-byte Meta payload per edge. Median of 3 runs at 3 iterations/run on an Apple M1 Pro:

| Path | ns/op | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| Legacy full scans | 328,843,792 | 210,305,909 | 2,541,861 |
| Shared light census | 289,151,847 | 71,005,093 | 1,490,587 |
| Delta | -12.1% | -66.2% | -41.4% |

## Correctness and scope

- The census is built immediately after bare-name attribution, preserving the existing sequential pass order.
- Candidate hydration always fetches the current persisted row; stale logical identities disappear, while a same-key replacement keeps its current provenance and Meta.
- Count/byte cap admission stops the partial census before callable-node hydration, then runs the unchanged legacy passes.
- Whole-graph and SQLite parity tests cover bare callee, method-site, and generic-parameter rewrites. A malformed SQLite Meta blob also verifies that the census walk itself never decodes payloads.
- Incremental per-file attribution is unchanged.

Master-to-cross-repo frontier sharing remains deliberately out of scope. Master compute/guard/tail phases may retarget or revert rows before cross-repo resolution, and an interleaving writer may add new unresolved rows. Retaining the raw master pages would also recreate the heap spike. A safe follow-up needs a store-owned, revision-bound, disk-resident frontier.

## Verification

- `go test ./internal/resolver -count=1`
- `go test -race ./internal/resolver -run 'Test(BuildPostBareAttributionCensus|ReindexAttributionIdentitiesBatched|PostBareAttributionCensus)' -count=1`
- `go vet ./internal/resolver`
- `golangci-lint run --timeout=5m ./internal/resolver/...`
- `go test ./internal/resolver -run '^$' -bench '^BenchmarkPostBareAttributionCensusSQLite100K$' -benchmem -benchtime=3x -count=3`
