### PR TITLE
perf(indexer): bound poller receipt verification

### DIFF
--- a/internal/graph/store.go
+++ b/internal/graph/store.go
@@ -1556,6 +1556,25 @@ type FileMetaPathReader interface {
 	FileMetasByPaths(repoPrefix string, filePaths []string) (map[string]FileMetaRow, error)
 }
 
+// FileReceipt is the compact polling projection joining one tracked path's
+// durable mtime with its optional content identity. ContentHash is empty for
+// tracked paths (such as contract manifests) that do not have a files row.
+type FileReceipt struct {
+	FilePath    string
+	MtimeNS     int64
+	ContentHash string
+	Size        int64
+}
+
+// FileReceiptPager reads tracked-file receipts through bounded keyset pages.
+// A caller freezes HighWater before a rotation, then advances AfterPath until
+// the returned page is short. Implementations must close their database cursor
+// before returning so filesystem work cannot pin a read transaction.
+type FileReceiptPager interface {
+	FileReceiptHighWater(repoPrefix string) (string, error)
+	FileReceiptPage(repoPrefix, afterPath, highWaterPath string, limit int, includeContent bool) ([]FileReceipt, error)
+}
+
 // RefFact is one durable resolved-reference fact: a reference edge from
 // FromID resolved TO ToID with the provenance tier that resolved it. Persisted
 // per source file so a reference's resolution is an auditable, diffable record

--- a/internal/graph/store_sqlite/store_file_receipt_test.go
+++ b/internal/graph/store_sqlite/store_file_receipt_test.go
@@ -1,0 +1,117 @@
+package store_sqlite
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestFileReceiptPagerFreezesHighWaterAndClosesRows(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "receipts.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	require.NoError(t, store.BulkSetFileMtimes("repo", map[string]int64{
+		"a.go": 1,
+		"b.go": 2,
+		"c.go": 3,
+		"d.go": 4,
+	}))
+	require.NoError(t, store.SetFileMetas("repo", []graph.FileMetaRow{
+		{FilePath: "repo/a.go", ContentHash: "hash-a", Size: 10, NodeCount: 999, Errors: "large metadata is not projected"},
+		{FilePath: "repo/b.go", ContentHash: "hash-b", Size: 20},
+		{FilePath: "repo/c.go", ContentHash: "hash-c", Size: 30},
+		{FilePath: "repo/d.go", ContentHash: "hash-d", Size: 40},
+	}))
+
+	highWater, err := store.FileReceiptHighWater("repo")
+	require.NoError(t, err)
+	require.Equal(t, "d.go", highWater)
+
+	// One connection turns an accidentally open mtime cursor into a deadlock
+	// when includeContent starts its second compact query. Returning proves the
+	// first result was closed before content lookup; InUse proves both closed.
+	store.db.SetMaxOpenConns(1)
+	store.db.SetMaxIdleConns(1)
+	page, err := store.FileReceiptPage("repo", "", highWater, 2, true)
+	require.NoError(t, err)
+	require.Equal(t, []graph.FileReceipt{
+		{FilePath: "a.go", MtimeNS: 1, ContentHash: "hash-a", Size: 10},
+		{FilePath: "b.go", MtimeNS: 2, ContentHash: "hash-b", Size: 20},
+	}, page)
+	require.Zero(t, store.db.Stats().InUse)
+
+	// A path inserted beyond the frozen high-water cannot prolong this scan.
+	// An in-place update below it is safe to observe at its latest value.
+	require.NoError(t, store.BulkSetFileMtimes("repo", map[string]int64{
+		"c.go": 33,
+		"z.go": 99,
+	}))
+	require.NoError(t, store.SetFileMetas("repo", []graph.FileMetaRow{
+		{FilePath: "repo/c.go", ContentHash: "hash-c-new", Size: 31},
+		{FilePath: "repo/z.go", ContentHash: "hash-z", Size: 99},
+	}))
+	page, err = store.FileReceiptPage("repo", "b.go", highWater, 8, true)
+	require.NoError(t, err)
+	require.Equal(t, []graph.FileReceipt{
+		{FilePath: "c.go", MtimeNS: 33, ContentHash: "hash-c-new", Size: 31},
+		{FilePath: "d.go", MtimeNS: 4, ContentHash: "hash-d", Size: 40},
+	}, page)
+
+	planRows, err := store.db.Query(
+		"EXPLAIN QUERY PLAN "+fileReceiptPageQuery,
+		"repo", "", highWater, 128,
+	)
+	require.NoError(t, err)
+	var plan []string
+	for planRows.Next() {
+		var id, parent, unused int
+		var detail string
+		require.NoError(t, planRows.Scan(&id, &parent, &unused, &detail))
+		plan = append(plan, detail)
+	}
+	require.NoError(t, planRows.Err())
+	require.NoError(t, planRows.Close())
+	require.Contains(t, strings.ToUpper(strings.Join(plan, "\n")), "PRIMARY KEY")
+}
+
+func TestFileReceiptPagerUsesCanonicalSlashPathAndHandlesDeletedHighWater(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "receipts.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	require.NoError(t, store.BulkSetFileMtimes("repo", map[string]int64{
+		"nested/a.go": 1,
+		"nested/b.go": 2,
+	}))
+	graphA := "repo/" + filepath.FromSlash("nested/a.go")
+	graphB := "repo/" + filepath.FromSlash("nested/b.go")
+	require.NoError(t, store.SetFileMetas("repo", []graph.FileMetaRow{
+		{FilePath: graphA, ContentHash: "a", Size: 1},
+		{FilePath: graphB, ContentHash: "b", Size: 2},
+	}))
+
+	highWater, err := store.FileReceiptHighWater("repo")
+	require.NoError(t, err)
+	page, err := store.FileReceiptPage("repo", "", highWater, 1, true)
+	require.NoError(t, err)
+	require.Equal(t, []graph.FileReceipt{{
+		FilePath: "nested/a.go", MtimeNS: 1, ContentHash: "a", Size: 1,
+	}}, page)
+
+	// Deleting the exact high-water between pages yields a clean empty terminal
+	// page; the Poller owns rotation reset and must not hold an open cursor.
+	require.NoError(t, store.DeleteFileMtimes("repo", []string{"nested/b.go"}))
+	page, err = store.FileReceiptPage("repo", "nested/a.go", highWater, 1, false)
+	require.NoError(t, err)
+	require.Empty(t, page)
+	require.Zero(t, store.db.Stats().InUse)
+
+	empty, err := store.FileReceiptPage("repo", highWater, highWater, 1, true)
+	require.NoError(t, err)
+	require.Empty(t, empty)
+}

--- a/internal/graph/store_sqlite/store_mtime.go
+++ b/internal/graph/store_sqlite/store_mtime.go
@@ -3,6 +3,7 @@ package store_sqlite
 import (
 	"context"
 	"database/sql"
+	"path/filepath"
 
 	"github.com/zzet/gortex/internal/graph"
 )
@@ -16,6 +17,23 @@ var (
 	_ graph.FileMtimeReader   = (*Store)(nil)
 	_ graph.FileMtimeReplacer = (*Store)(nil)
 	_ graph.FileMtimeDeleter  = (*Store)(nil)
+	_ graph.FileReceiptPager  = (*Store)(nil)
+)
+
+const (
+	fileReceiptHighWaterQuery = `SELECT file_path
+FROM file_mtimes
+WHERE repo_prefix = ?
+ORDER BY file_path DESC
+LIMIT 1`
+
+	fileReceiptPageQuery = `SELECT file_path, mtime_ns
+FROM file_mtimes
+WHERE repo_prefix = ?
+  AND file_path > ?
+  AND file_path <= ?
+ORDER BY file_path
+LIMIT ?`
 )
 
 // mtimeChunk bounds how many (repo_prefix, file_path, mtime_ns) tuples
@@ -241,4 +259,119 @@ func (s *Store) FileMtimes(repoPrefix string) (map[string]int64, error) {
 		return nil, err
 	}
 	return out, nil
+}
+
+// FileReceiptHighWater freezes the lexicographically greatest tracked path
+// for one bounded polling rotation. Rows added above it wait for the next
+// rotation instead of extending the current one indefinitely.
+func (s *Store) FileReceiptHighWater(repoPrefix string) (string, error) {
+	var highWater string
+	err := s.db.QueryRow(fileReceiptHighWaterQuery, repoPrefix).Scan(&highWater)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	return highWater, err
+}
+
+// FileReceiptPage returns one compact mtime-keyset page and closes that cursor
+// before optionally fetching the page's content identities. No result cursor
+// survives this call, so the poller's filesystem reads never pin a SQLite read
+// transaction or reader connection.
+func (s *Store) FileReceiptPage(
+	repoPrefix, afterPath, highWaterPath string,
+	limit int,
+	includeContent bool,
+) ([]graph.FileReceipt, error) {
+	if limit <= 0 || highWaterPath == "" || afterPath >= highWaterPath {
+		return nil, nil
+	}
+	rows, err := s.db.Query(
+		fileReceiptPageQuery,
+		repoPrefix, afterPath, highWaterPath, limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	receipts := make([]graph.FileReceipt, 0, limit)
+	for rows.Next() {
+		var receipt graph.FileReceipt
+		if err := rows.Scan(&receipt.FilePath, &receipt.MtimeNS); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		receipts = append(receipts, receipt)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, err
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if !includeContent || len(receipts) == 0 {
+		return receipts, nil
+	}
+	if err := s.fillFileReceiptContent(repoPrefix, receipts); err != nil {
+		return nil, err
+	}
+	return receipts, nil
+}
+
+// fillFileReceiptContent reads only content_hash + size for a bounded mtime
+// page. file_mtimes uses slash-form unprefixed keys, while files uses the
+// graph's prefixed, OS-native path, so map the keys in Go rather than baking a
+// platform-specific path expression into the SQL lookup.
+func (s *Store) fillFileReceiptContent(repoPrefix string, receipts []graph.FileReceipt) error {
+	byGraphPath := make(map[string]int, len(receipts))
+	graphPaths := make([]string, len(receipts))
+	for i, receipt := range receipts {
+		graphPath := filepath.FromSlash(receipt.FilePath)
+		if repoPrefix != "" {
+			graphPath = repoPrefix + "/" + graphPath
+		}
+		graphPaths[i] = graphPath
+		byGraphPath[graphPath] = i
+	}
+
+	for start := 0; start < len(graphPaths); start += fileMetaChunk {
+		end := min(start+fileMetaChunk, len(graphPaths))
+		chunk := graphPaths[start:end]
+		args := make([]any, 0, len(chunk)+1)
+		args = append(args, repoPrefix)
+		stmt := make([]byte, 0, 96+len(chunk)*2)
+		stmt = append(stmt, "SELECT file_path, content_hash, size FROM files WHERE repo_prefix = ? AND file_path IN ("...)
+		for i, filePath := range chunk {
+			if i > 0 {
+				stmt = append(stmt, ',')
+			}
+			stmt = append(stmt, '?')
+			args = append(args, filePath)
+		}
+		stmt = append(stmt, ')')
+
+		rows, err := s.db.Query(string(stmt), args...)
+		if err != nil {
+			return err
+		}
+		for rows.Next() {
+			var filePath, contentHash string
+			var size int64
+			if err := rows.Scan(&filePath, &contentHash, &size); err != nil {
+				_ = rows.Close()
+				return err
+			}
+			if i, ok := byGraphPath[filePath]; ok {
+				receipts[i].ContentHash = contentHash
+				receipts[i].Size = size
+			}
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		if err := rows.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/indexer/incremental_batch.go
+++ b/internal/indexer/incremental_batch.go
@@ -1019,6 +1019,7 @@ func (idx *Indexer) recordFileReadVersionsBatched(receipts []fileReadReceipt) (f
 	idx.mtimeMu.Unlock()
 	if writer, ok := idx.graph.(graph.FileMtimeWriter); ok {
 		if err := writer.BulkSetFileMtimes(idx.repoPrefix, mtimes); err != nil {
+			idx.markFileMtimePersistenceDirty()
 			idx.logger.Warn("persist file mtimes failed",
 				zap.String("repo", idx.repoPrefix), zap.Int("files", len(mtimes)), zap.Error(err))
 		}

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -323,9 +323,13 @@ type Indexer struct {
 	parseErrors      []IndexError
 	fileMtimes       map[string]int64
 	fileMtimesShared bool
-	lastIndexTime    time.Time
-	totalDetected    int
-	mtimeMu          sync.RWMutex
+	// Any failed sidecar write can leave the durable keyset incomplete even
+	// while the immutable in-memory snapshot is current. Receipt paging must
+	// fall back to that snapshot until a full authoritative replace repairs it.
+	fileMtimePersistenceDirty atomic.Bool
+	lastIndexTime             time.Time
+	totalDetected             int
+	mtimeMu                   sync.RWMutex
 
 	// contractCache memoizes the contract-extractor output per file.
 	// Keyed by graph file path (with repo prefix); value is the file's
@@ -3050,6 +3054,7 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 		streamMtimeMu.Unlock()
 		if flush != nil {
 			if err := w.BulkSetFileMtimes(idx.repoPrefix, flush); err != nil {
+				idx.markFileMtimePersistenceDirty()
 				idx.logger.Warn("indexer: incremental mtime batch persist failed",
 					zap.String("repo", idx.repoPrefix), zap.Error(err))
 			}
@@ -3068,6 +3073,7 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 			return
 		}
 		if err := w.BulkSetFileMtimes(idx.repoPrefix, flush); err != nil {
+			idx.markFileMtimePersistenceDirty()
 			idx.logger.Warn("indexer: final incremental mtime batch persist failed",
 				zap.String("repo", idx.repoPrefix), zap.Error(err))
 		}
@@ -3443,6 +3449,7 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 				}
 				if len(batch) > 0 {
 					if err := w.BulkSetFileMtimes(idx.repoPrefix, batch); err != nil {
+						idx.markFileMtimePersistenceDirty()
 						idx.logger.Warn("indexer: streaming-flush chunk mtime persist failed",
 							zap.String("repo", idx.repoPrefix), zap.Error(err))
 					}
@@ -3541,16 +3548,21 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 	if len(mtimeSnapshot) > 0 {
 		var perr error
 		persisted := false
+		authoritative := false
 		if r, ok := mtimeTarget.(graph.FileMtimeReplacer); ok {
-			perr, persisted = r.ReplaceFileMtimes(idx.repoPrefix, mtimeSnapshot), true
+			perr, persisted, authoritative = r.ReplaceFileMtimes(idx.repoPrefix, mtimeSnapshot), true, true
 		} else if w, ok := mtimeTarget.(graph.FileMtimeWriter); ok {
 			perr, persisted = w.BulkSetFileMtimes(idx.repoPrefix, mtimeSnapshot), true
 		}
 		if persisted {
 			if perr != nil {
+				idx.markFileMtimePersistenceDirty()
 				idx.logger.Warn("persist file mtimes failed",
 					zap.String("repo", idx.repoPrefix), zap.Error(perr))
 			} else {
+				if authoritative {
+					idx.fileMtimePersistenceDirty.Store(false)
+				}
 				idx.logger.Info("persisted file mtimes",
 					zap.String("repo", idx.repoPrefix),
 					zap.Int("count", len(mtimeSnapshot)))
@@ -4471,6 +4483,7 @@ func (idx *Indexer) recordFileMtimeValue(relPath string, mtime int64) {
 	idx.mtimeMu.Unlock()
 	if w, ok := idx.graph.(graph.FileMtimeWriter); ok {
 		if err := w.BulkSetFileMtimes(idx.repoPrefix, map[string]int64{relPath: mtime}); err != nil {
+			idx.markFileMtimePersistenceDirty()
 			idx.logger.Warn("persist file mtime failed",
 				zap.String("repo", idx.repoPrefix), zap.String("file", relPath), zap.Error(err))
 		}
@@ -5541,6 +5554,14 @@ func (idx *Indexer) publishFileMtimes() map[string]int64 {
 	return idx.fileMtimes
 }
 
+func (idx *Indexer) markFileMtimePersistenceDirty() {
+	idx.fileMtimePersistenceDirty.Store(true)
+}
+
+func (idx *Indexer) fileReceiptPagingReliable() bool {
+	return !idx.fileMtimePersistenceDirty.Load()
+}
+
 // ensureFileMtimesWritableLocked detaches the working map from any published
 // snapshot. The caller must hold mtimeMu for writing.
 func (idx *Indexer) ensureFileMtimesWritableLocked() {
@@ -5606,6 +5627,7 @@ func (idx *Indexer) RefreshFileMtime(filePath string) {
 	}
 	if w, ok := idx.graph.(graph.FileMtimeWriter); ok {
 		if err := w.BulkSetFileMtimes(idx.repoPrefix, map[string]int64{key: mtime}); err != nil {
+			idx.markFileMtimePersistenceDirty()
 			idx.logger.Warn("persist file mtime failed",
 				zap.String("repo", idx.repoPrefix), zap.String("file", key), zap.Error(err))
 		}
@@ -5624,6 +5646,7 @@ func (idx *Indexer) pruneDeletedFileMtimes(deleted []string) {
 	}
 	if d, ok := idx.graph.(graph.FileMtimeDeleter); ok {
 		if err := d.DeleteFileMtimes(idx.repoPrefix, deleted); err != nil {
+			idx.markFileMtimePersistenceDirty()
 			idx.logger.Warn("prune deleted file mtimes failed",
 				zap.String("repo", idx.repoPrefix), zap.Error(err))
 		}

--- a/internal/indexer/poller.go
+++ b/internal/indexer/poller.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/zzet/gortex/internal/gitcmd"
+	"github.com/zzet/gortex/internal/graph"
 	"go.uber.org/zap"
 )
 
@@ -61,9 +62,23 @@ type Poller struct {
 	pollRequested uint64
 	pollRunning   bool
 
+	// SQLite-backed pollers advance two independent bounded receipt rotations.
+	// The mtime cursor may move through thousands of cheap stat rows while the
+	// content cursor stops at its own byte budget; coupling them would let one
+	// large file delay ordinary drift/deletion detection.
+	receiptIndexer  *Indexer
+	mtimeRotation   fileReceiptRotation
+	contentRotation fileReceiptRotation
+	// A failed filesystem batch is retried before any new receipt page is
+	// consumed. One discovery page contributes at most the bounded mtime page
+	// plus the 128-row content page, so repeated failures cannot grow this set.
+	pendingFilesystemPaths map[string]struct{}
+
 	// swept is a test hook fired after every poll cycle with the
 	// number of files the cycle re-dispatched. nil in production.
-	swept func(int)
+	swept           func(int)
+	readReceiptFile func(string) ([]byte, error)
+	statReceiptFile func(string) (os.FileInfo, error)
 }
 
 // Poll-interval bounds. A small repo polls near the floor; a large
@@ -82,7 +97,23 @@ const (
 	// and a large monorepo (tens of thousands of nodes) sits at the
 	// ceiling.
 	pollNodesPerStep = 2000
+
+	pollMtimeRotationTarget = time.Hour
+	pollMtimePageMinRows    = 128
+	pollMtimePageMaxRows    = 4096
+	pollContentPageRows     = 128
+	pollContentPageBytes    = int64(4 << 20)
 )
+
+type fileReceiptRotation struct {
+	afterPath     string
+	highWaterPath string
+}
+
+func (r *fileReceiptRotation) reset() {
+	r.afterPath = ""
+	r.highWaterPath = ""
+}
 
 // pollInterval derives an adaptive poll interval from a project-size
 // signal — the indexed node count. The mapping is linear in the node
@@ -104,6 +135,24 @@ func pollInterval(nodeCount int) time.Duration {
 		return pollIntervalMax
 	}
 	return d
+}
+
+// pollMtimePageRows sizes one cheap-stat page so an uncapped rotation finishes
+// in roughly one janitor interval. The hard row cap bounds receipt heap for a
+// very large workspace; the hourly full-tree janitor remains the outer latency
+// bound for ordinary mtime drift when that cap is reached.
+func pollMtimePageRows(tracked int, interval time.Duration) int {
+	if tracked <= 0 {
+		return 0
+	}
+	if interval <= 0 {
+		interval = pollIntervalMin
+	}
+	ticks := max(int(pollMtimeRotationTarget/interval), 1)
+	rows := (tracked + ticks - 1) / ticks
+	rows = max(rows, pollMtimePageMinRows)
+	rows = min(rows, pollMtimePageMaxRows)
+	return min(rows, tracked)
 }
 
 // newPoller builds an adaptive-interval poller for a Watcher. The
@@ -238,13 +287,17 @@ func (p *Poller) poll() {
 // repository mutation lane.
 func (p *Poller) pollOnce() {
 	git := p.observeGitHead()
+	filesystemPaths := p.pendingFilesystemRetryPaths()
+	if len(filesystemPaths) == 0 {
+		filesystemPaths = p.pollFilesystem()
+	}
 	pathSet := make(map[string]struct{}, len(git.paths))
 	for _, path := range git.paths {
 		if path != "" {
 			pathSet[filepath.Clean(path)] = struct{}{}
 		}
 	}
-	for _, path := range p.pollFilesystem() {
+	for _, path := range filesystemPaths {
 		if path != "" {
 			pathSet[filepath.Clean(path)] = struct{}{}
 		}
@@ -276,6 +329,13 @@ func (p *Poller) pollOnce() {
 				zap.Int("paths", len(paths)))
 		}
 	}
+	if len(filesystemPaths) > 0 {
+		if reconciled {
+			p.pendingFilesystemPaths = nil
+		} else {
+			p.retainFilesystemRetryPaths(filesystemPaths)
+		}
+	}
 
 	// A changed Git range is committed only after all of its paths shared the
 	// successful batch above. An empty successful diff has no batch work and can
@@ -298,6 +358,26 @@ func (p *Poller) pollOnce() {
 
 	if p.swept != nil {
 		p.swept(len(paths))
+	}
+}
+
+func (p *Poller) pendingFilesystemRetryPaths() []string {
+	paths := make([]string, 0, len(p.pendingFilesystemPaths))
+	for path := range p.pendingFilesystemPaths {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func (p *Poller) retainFilesystemRetryPaths(paths []string) {
+	if p.pendingFilesystemPaths == nil {
+		p.pendingFilesystemPaths = make(map[string]struct{}, len(paths))
+	}
+	for _, path := range paths {
+		if path != "" {
+			p.pendingFilesystemPaths[filepath.Clean(path)] = struct{}{}
+		}
 	}
 }
 
@@ -454,10 +534,11 @@ func (p *Poller) finalizeGitHead(observation pollGitObservation) error {
 	})
 }
 
-// pollFilesystem reads the indexer's immutable per-file mtime snapshot and returns
-// changed or unreadable tracked paths. It performs discovery only: pollOnce
-// unions these paths with Git evidence and the repository batch owns every
-// freshness stamp and deletion decision.
+// pollFilesystem returns tracked paths whose durable receipt no longer matches
+// disk. SQLite stores use two independent, high-water-frozen keyset rotations:
+// a dynamically-sized mtime page and a smaller byte-bounded content page that
+// catches edits whose timestamp was restored. Other stores retain the original
+// immutable-map scan.
 func (p *Poller) pollFilesystem() []string {
 	idx := p.indexer
 	if p.watcher != nil {
@@ -473,6 +554,58 @@ func (p *Poller) pollFilesystem() []string {
 	if len(snapshot) == 0 {
 		return nil
 	}
+	if !idx.fileReceiptPagingReliable() {
+		// A later authoritative repair must start both rotations from its fresh
+		// durable keyset, not resume a high-water frozen before the failed write.
+		p.mtimeRotation.reset()
+		p.contentRotation.reset()
+		return p.pollFilesystemSnapshot(snapshot)
+	}
+	pager, ok := idx.graph.(graph.FileReceiptPager)
+	if !ok {
+		return p.pollFilesystemSnapshot(snapshot)
+	}
+	if p.receiptIndexer != idx {
+		p.receiptIndexer = idx
+		p.mtimeRotation.reset()
+		p.contentRotation.reset()
+	}
+
+	mtimeRows, mtimeExhausted, mtimeScan, err := p.readReceiptPage(
+		pager, idx.repoPrefix, &p.mtimeRotation,
+		pollMtimePageRows(len(snapshot), p.interval), false,
+	)
+	if err != nil || !mtimeScan {
+		if err != nil && p.logger != nil {
+			p.logger.Debug("watcher: poller receipt page failed; using mtime snapshot",
+				zap.String("root", p.rootPath), zap.Error(err))
+		}
+		// A non-empty in-memory snapshot with no durable receipt page can occur
+		// after a persistence failure. Preserve the prior correctness path.
+		p.mtimeRotation.reset()
+		return p.pollFilesystemSnapshot(snapshot)
+	}
+	paths := p.changedMtimeReceiptPaths(snapshot, mtimeRows)
+	p.advanceReceiptRotation(&p.mtimeRotation, mtimeRows, len(mtimeRows), mtimeExhausted)
+
+	contentRows, contentExhausted, _, contentErr := p.readReceiptPage(
+		pager, idx.repoPrefix, &p.contentRotation,
+		pollContentPageRows, true,
+	)
+	if contentErr != nil {
+		if p.logger != nil {
+			p.logger.Debug("watcher: poller content receipt page failed",
+				zap.String("root", p.rootPath), zap.Error(contentErr))
+		}
+		return appendUniqueSorted(nil, paths...)
+	}
+	contentPaths, processed := p.changedContentReceiptPaths(idx, snapshot, contentRows)
+	paths = append(paths, contentPaths...)
+	p.advanceReceiptRotation(&p.contentRotation, contentRows, processed, contentExhausted)
+	return appendUniqueSorted(nil, paths...)
+}
+
+func (p *Poller) pollFilesystemSnapshot(snapshot map[string]int64) []string {
 	paths := make([]string, 0)
 	for relPath, recordedMtime := range snapshot {
 		abs := filepath.Clean(filepath.Join(p.rootPath, filepath.FromSlash(relPath)))
@@ -497,6 +630,184 @@ func (p *Poller) pollFilesystem() []string {
 	}
 	sort.Strings(paths)
 	return paths
+}
+
+func (p *Poller) readReceiptPage(
+	pager graph.FileReceiptPager,
+	repoPrefix string,
+	rotation *fileReceiptRotation,
+	limit int,
+	includeContent bool,
+) ([]graph.FileReceipt, bool, bool, error) {
+	if limit <= 0 {
+		return nil, true, false, nil
+	}
+	if rotation.highWaterPath == "" {
+		highWater, err := pager.FileReceiptHighWater(repoPrefix)
+		if err != nil {
+			return nil, false, false, err
+		}
+		if highWater == "" {
+			return nil, true, false, nil
+		}
+		rotation.afterPath = ""
+		rotation.highWaterPath = highWater
+	}
+	rows, err := pager.FileReceiptPage(
+		repoPrefix, rotation.afterPath, rotation.highWaterPath, limit, includeContent,
+	)
+	if err != nil {
+		return nil, false, true, err
+	}
+	exhausted := len(rows) < limit
+	if len(rows) == 0 || rows[len(rows)-1].FilePath >= rotation.highWaterPath {
+		exhausted = true
+	}
+	return rows, exhausted, true, nil
+}
+
+func (p *Poller) advanceReceiptRotation(
+	rotation *fileReceiptRotation,
+	rows []graph.FileReceipt,
+	processed int,
+	pageExhausted bool,
+) {
+	processed = min(max(processed, 0), len(rows))
+	if processed > 0 {
+		rotation.afterPath = rows[processed-1].FilePath
+	}
+	if processed == len(rows) && pageExhausted {
+		rotation.reset()
+	}
+}
+
+func (p *Poller) changedMtimeReceiptPaths(
+	snapshot map[string]int64,
+	receipts []graph.FileReceipt,
+) []string {
+	paths := make([]string, 0)
+	for _, receipt := range receipts {
+		recordedMtime, tracked := snapshot[receipt.FilePath]
+		if !tracked {
+			continue
+		}
+		abs := filepath.Clean(filepath.Join(p.rootPath, filepath.FromSlash(receipt.FilePath)))
+		info, err := os.Stat(abs)
+		if err != nil {
+			if os.IsNotExist(err) {
+				paths = append(paths, abs)
+			} else if p.logger != nil {
+				p.logger.Debug("watcher: poller stat failed; preserving tracked path",
+					zap.String("path", abs), zap.Error(err))
+			}
+			continue
+		}
+		if !info.IsDir() && info.ModTime().UnixNano() != recordedMtime {
+			paths = append(paths, abs)
+		}
+	}
+	return paths
+}
+
+func (p *Poller) changedContentReceiptPaths(
+	idx *Indexer,
+	snapshot map[string]int64,
+	receipts []graph.FileReceipt,
+) ([]string, int) {
+	paths := make([]string, 0)
+	processed := 0
+	var bytesRead int64
+	for _, receipt := range receipts {
+		recordedMtime, tracked := snapshot[receipt.FilePath]
+		if !tracked {
+			processed++
+			continue
+		}
+		abs := filepath.Clean(filepath.Join(p.rootPath, filepath.FromSlash(receipt.FilePath)))
+		before, err := p.receiptStat(abs)
+		if err != nil {
+			if os.IsNotExist(err) {
+				paths = append(paths, abs)
+			} else if p.logger != nil {
+				p.logger.Debug("watcher: poller content stat failed; preserving tracked path",
+					zap.String("path", abs), zap.Error(err))
+			}
+			if os.IsNotExist(err) {
+				processed++
+				continue
+			}
+			// A transient stat failure is uncomparable. Keep this row at the
+			// cursor so the next poll retries it instead of waiting a rotation.
+			break
+		}
+		if before.IsDir() {
+			processed++
+			continue
+		}
+		if before.ModTime().UnixNano() != recordedMtime {
+			paths = append(paths, abs)
+			processed++
+			continue
+		}
+		if receipt.ContentHash == "" {
+			processed++
+			continue
+		}
+
+		size := max(before.Size(), int64(0))
+		if bytesRead > 0 && size > pollContentPageBytes-bytesRead {
+			break
+		}
+		matches, comparable, read := p.contentReceiptMatches(idx, abs, before, receipt)
+		bytesRead += read
+		if !comparable {
+			// A transient read/stat race is not evidence that the indexed bytes
+			// changed, but advancing would postpone its next verification for a
+			// full rotation. Retry this exact row on the next poll.
+			break
+		}
+		if !matches {
+			// Do not advance past a proven mismatch. A failed reconcile retries
+			// it next poll; after success the refreshed receipt matches and the
+			// independent content cursor can continue.
+			paths = append(paths, abs)
+			break
+		}
+		processed++
+	}
+	return paths, processed
+}
+
+func (p *Poller) contentReceiptMatches(
+	idx *Indexer,
+	absPath string,
+	before os.FileInfo,
+	receipt graph.FileReceipt,
+) (matches bool, comparable bool, bytesRead int64) {
+	readFile := os.ReadFile
+	if p.readReceiptFile != nil {
+		readFile = p.readReceiptFile
+	}
+	src, err := readFile(absPath)
+	if err != nil {
+		return false, false, 0
+	}
+	bytesRead = int64(len(src))
+	after, err := p.receiptStat(absPath)
+	if err != nil || !sameFileVersion(before, after) {
+		return false, false, bytesRead
+	}
+	relPath := idx.graphRelKey(absPath)
+	src = idx.transforms.run(relPath, src)
+	return int64(len(src)) == receipt.Size && contentHashForSource(src) == receipt.ContentHash,
+		true, bytesRead
+}
+
+func (p *Poller) receiptStat(path string) (os.FileInfo, error) {
+	if p.statReceiptFile != nil {
+		return p.statReceiptFile(path)
+	}
+	return os.Stat(path)
 }
 
 // pollerHeadSHA resolves the current HEAD commit SHA of a worktree.

--- a/internal/indexer/poller_receipt_test.go
+++ b/internal/indexer/poller_receipt_test.go
@@ -1,0 +1,408 @@
+package indexer
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+)
+
+type pollerReceiptPageCall struct {
+	after          string
+	highWater      string
+	limit          int
+	includeContent bool
+}
+
+type pollerReceiptStore struct {
+	*graph.Graph
+	highWater     string
+	rows          []graph.FileReceipt
+	calls         []pollerReceiptPageCall
+	mtimeWriteErr error
+}
+
+func (s *pollerReceiptStore) BulkSetFileMtimes(string, map[string]int64) error {
+	return s.mtimeWriteErr
+}
+
+func (s *pollerReceiptStore) FileReceiptHighWater(string) (string, error) {
+	if s.highWater != "" {
+		return s.highWater, nil
+	}
+	if len(s.rows) == 0 {
+		return "", nil
+	}
+	return s.rows[len(s.rows)-1].FilePath, nil
+}
+
+func (s *pollerReceiptStore) FileReceiptPage(
+	_, afterPath, highWaterPath string,
+	limit int,
+	includeContent bool,
+) ([]graph.FileReceipt, error) {
+	s.calls = append(s.calls, pollerReceiptPageCall{
+		after: afterPath, highWater: highWaterPath, limit: limit, includeContent: includeContent,
+	})
+	out := make([]graph.FileReceipt, 0, limit)
+	for _, row := range s.rows {
+		if row.FilePath <= afterPath || row.FilePath > highWaterPath {
+			continue
+		}
+		if !includeContent {
+			row.ContentHash = ""
+			row.Size = 0
+		}
+		out = append(out, row)
+		if len(out) == limit {
+			break
+		}
+	}
+	return out, nil
+}
+
+func TestPollMtimePageRowsTargetsOneHourAndCapsHeap(t *testing.T) {
+	tests := []struct {
+		name     string
+		tracked  int
+		interval time.Duration
+	}{
+		{name: "small floor", tracked: 1000, interval: 15 * time.Second},
+		{name: "ten thousand at ceiling", tracked: 10_000, interval: 10 * time.Minute},
+		{name: "non-divisible interval", tracked: 1001, interval: 17 * time.Second},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rows := pollMtimePageRows(tc.tracked, tc.interval)
+			require.Positive(t, rows)
+			require.LessOrEqual(t, rows, pollMtimePageMaxRows)
+			polls := (tc.tracked + rows - 1) / rows
+			assert.LessOrEqual(t, time.Duration(polls)*tc.interval,
+				pollMtimeRotationTarget+tc.interval,
+				"an uncapped typical rotation should finish in about one hour")
+		})
+	}
+
+	assert.Equal(t, pollMtimePageMaxRows, pollMtimePageRows(100_000, 10*time.Minute),
+		"very large repositories must honor the receipt-heap cap")
+	assert.Zero(t, pollMtimePageRows(0, time.Minute))
+}
+
+func TestPollerReceiptRotationResetsAfterDeletedHighWater(t *testing.T) {
+	store := &pollerReceiptStore{
+		Graph:     graph.New(),
+		highWater: "b.go",
+		rows: []graph.FileReceipt{
+			{FilePath: "a.go", MtimeNS: 1},
+			{FilePath: "b.go", MtimeNS: 2},
+		},
+	}
+	p := &Poller{}
+	var rotation fileReceiptRotation
+
+	page, exhausted, scan, err := p.readReceiptPage(store, "repo", &rotation, 1, false)
+	require.NoError(t, err)
+	require.True(t, scan)
+	require.False(t, exhausted)
+	require.Equal(t, []graph.FileReceipt{{FilePath: "a.go", MtimeNS: 1}}, page)
+	p.advanceReceiptRotation(&rotation, page, len(page), exhausted)
+	require.Equal(t, "a.go", rotation.afterPath)
+	require.Equal(t, "b.go", rotation.highWaterPath)
+
+	// Delete the frozen upper bound between exact-size pages. The empty page is
+	// terminal for this existing scan (not "no durable receipts") and resets it.
+	store.rows = store.rows[:1]
+	page, exhausted, scan, err = p.readReceiptPage(store, "repo", &rotation, 1, false)
+	require.NoError(t, err)
+	require.True(t, scan)
+	require.True(t, exhausted)
+	require.Empty(t, page)
+	p.advanceReceiptRotation(&rotation, page, 0, exhausted)
+	require.Equal(t, fileReceiptRotation{}, rotation)
+}
+
+func TestPollerDetectsSameMtimeSameSizeEditFromSQLiteReceipt(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.go")
+	beforeSource := "package p\nfunc Alpha() int { return 1 }\n"
+	afterSource := "package p\nfunc Beta_() int { return 2 }\n"
+	require.Len(t, afterSource, len(beforeSource))
+	require.NoError(t, os.WriteFile(path, []byte(beforeSource), 0o644))
+
+	store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "graph.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	idx := newTestIndexer(store)
+	idx.SetRootPath(dir)
+	_, err = idx.Index(dir)
+	require.NoError(t, err)
+	indexedInfo, err := os.Stat(path)
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(path, []byte(afterSource), 0o644))
+	require.NoError(t, os.Chtimes(path, indexedInfo.ModTime(), indexedInfo.ModTime()))
+	currentInfo, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, indexedInfo.ModTime().UnixNano(), currentInfo.ModTime().UnixNano())
+	require.Equal(t, indexedInfo.Size(), currentInfo.Size())
+
+	p := newPoller(nil, idx, zap.NewNop())
+	require.Equal(t, []string{path}, p.pollFilesystem(),
+		"content rotation must detect an edit hidden from both mtime and size")
+	assert.Empty(t, p.contentRotation.afterPath,
+		"a proven mismatch stays retryable until reconciliation refreshes its receipt")
+}
+
+func TestPollerContentBudgetRetriesUnprocessedAndOversizedRows(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name string, size int) graph.FileReceipt {
+		t.Helper()
+		src := bytes.Repeat([]byte{'x'}, size)
+		path := filepath.Join(dir, name)
+		require.NoError(t, os.WriteFile(path, src, 0o644))
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		return graph.FileReceipt{
+			FilePath: name, MtimeNS: info.ModTime().UnixNano(),
+			ContentHash: contentHashForSource(src), Size: int64(len(src)),
+		}
+	}
+	a := write("a.go", 3<<20)
+	b := write("b.go", 3<<20)
+	oversized := write("oversized.go", 5<<20)
+	snapshot := map[string]int64{
+		a.FilePath: a.MtimeNS, b.FilePath: b.MtimeNS, oversized.FilePath: oversized.MtimeNS,
+	}
+	idx := newTestIndexer(graph.New())
+	idx.SetRootPath(dir)
+	p := &Poller{indexer: idx, rootPath: dir, logger: zap.NewNop()}
+
+	paths, processed := p.changedContentReceiptPaths(idx, snapshot, []graph.FileReceipt{a, b})
+	require.Empty(t, paths)
+	require.Equal(t, 1, processed, "the second row must wait rather than cross the 4 MiB budget")
+	paths, processed = p.changedContentReceiptPaths(idx, snapshot, []graph.FileReceipt{b})
+	require.Empty(t, paths)
+	require.Equal(t, 1, processed, "the unprocessed row must make progress on the next page")
+
+	paths, processed = p.changedContentReceiptPaths(idx, snapshot, []graph.FileReceipt{oversized})
+	require.Empty(t, paths)
+	require.Equal(t, 1, processed, "one individually oversized file must be admitted for progress")
+}
+
+func TestPollerContentReadFailureDoesNotAdvanceRotation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "retry.go")
+	src := []byte("package p\n")
+	require.NoError(t, os.WriteFile(path, src, 0o644))
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	receipt := graph.FileReceipt{
+		FilePath: "retry.go", MtimeNS: info.ModTime().UnixNano(),
+		ContentHash: contentHashForSource(src), Size: int64(len(src)),
+	}
+	idx := newTestIndexer(graph.New())
+	idx.SetRootPath(dir)
+	p := &Poller{
+		indexer: idx, rootPath: dir, logger: zap.NewNop(),
+		readReceiptFile: func(string) ([]byte, error) { return nil, errors.New("transient read") },
+		contentRotation: fileReceiptRotation{highWaterPath: receipt.FilePath},
+	}
+	paths, processed := p.changedContentReceiptPaths(
+		idx, map[string]int64{receipt.FilePath: receipt.MtimeNS}, []graph.FileReceipt{receipt},
+	)
+	require.Empty(t, paths)
+	require.Zero(t, processed)
+	p.advanceReceiptRotation(&p.contentRotation, []graph.FileReceipt{receipt}, processed, true)
+	require.Empty(t, p.contentRotation.afterPath)
+	require.Equal(t, receipt.FilePath, p.contentRotation.highWaterPath,
+		"an uncomparable row must retry on the next poll, not after a full rotation")
+}
+
+func TestPollerContentStatFailureDoesNotAdvanceRotation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "retry.go")
+	src := []byte("package p\n")
+	require.NoError(t, os.WriteFile(path, src, 0o644))
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	receipt := graph.FileReceipt{
+		FilePath: "retry.go", MtimeNS: info.ModTime().UnixNano(),
+		ContentHash: contentHashForSource(src), Size: int64(len(src)),
+	}
+	idx := newTestIndexer(graph.New())
+	idx.SetRootPath(dir)
+	p := &Poller{
+		indexer: idx, rootPath: dir, logger: zap.NewNop(),
+		statReceiptFile: func(string) (os.FileInfo, error) { return nil, errors.New("transient stat") },
+		contentRotation: fileReceiptRotation{highWaterPath: receipt.FilePath},
+	}
+	paths, processed := p.changedContentReceiptPaths(
+		idx, map[string]int64{receipt.FilePath: receipt.MtimeNS}, []graph.FileReceipt{receipt},
+	)
+	require.Empty(t, paths)
+	require.Zero(t, processed)
+	p.advanceReceiptRotation(&p.contentRotation, []graph.FileReceipt{receipt}, processed, true)
+	require.Empty(t, p.contentRotation.afterPath)
+	require.Equal(t, receipt.FilePath, p.contentRotation.highWaterPath)
+}
+
+func TestPollerPagedReceiptsResetForReplacementIndexer(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "current.go")
+	require.NoError(t, os.WriteFile(path, []byte("package p\n"), 0o644))
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+
+	oldStore := &pollerReceiptStore{Graph: graph.New(), rows: []graph.FileReceipt{{FilePath: "old.go", MtimeNS: 1}}}
+	oldIdx := newTestIndexer(oldStore)
+	oldIdx.SetRootPath(dir)
+	oldIdx.SetFileMtimes(map[string]int64{"old.go": 1})
+
+	newStore := &pollerReceiptStore{Graph: graph.New(), rows: []graph.FileReceipt{{
+		FilePath: "current.go", MtimeNS: info.ModTime().UnixNano() - 1,
+	}}}
+	newIdx := newTestIndexer(newStore)
+	newIdx.SetRootPath(dir)
+	newIdx.SetFileMtimes(map[string]int64{"current.go": info.ModTime().UnixNano() - 1})
+
+	p := newPoller(nil, oldIdx, zap.NewNop())
+	p.receiptIndexer = oldIdx
+	p.mtimeRotation = fileReceiptRotation{afterPath: "old.go", highWaterPath: "old.go"}
+	p.contentRotation = fileReceiptRotation{afterPath: "old.go", highWaterPath: "old.go"}
+	p.indexer = newIdx
+
+	require.Equal(t, []string{path}, p.pollFilesystem())
+	require.Same(t, newIdx, p.receiptIndexer)
+	require.Len(t, newStore.calls, 2)
+	assert.Empty(t, newStore.calls[0].after,
+		"replacement Indexer must not inherit the retired store's keyset cursor")
+	assert.False(t, newStore.calls[0].includeContent)
+	assert.True(t, newStore.calls[1].includeContent)
+}
+
+func TestPollerRetriesFailedFilesystemBatchBeforeConsumingNewPages(t *testing.T) {
+	dir := t.TempDir()
+	mtimePath := filepath.Join(dir, "a-mtime.go")
+	deletedPath := filepath.Join(dir, "b-deleted.go")
+	contentPath := filepath.Join(dir, "c-content.go")
+	require.NoError(t, os.WriteFile(mtimePath, []byte("mtime"), 0o644))
+	require.NoError(t, os.WriteFile(contentPath, []byte("new-content"), 0o644))
+	mtimeInfo, err := os.Stat(mtimePath)
+	require.NoError(t, err)
+	contentInfo, err := os.Stat(contentPath)
+	require.NoError(t, err)
+
+	store := &pollerReceiptStore{Graph: graph.New(), rows: []graph.FileReceipt{
+		{FilePath: "a-mtime.go", MtimeNS: mtimeInfo.ModTime().UnixNano() - 1},
+		{FilePath: "b-deleted.go", MtimeNS: 1},
+		{
+			FilePath: "c-content.go", MtimeNS: contentInfo.ModTime().UnixNano(),
+			ContentHash: contentHashForSource([]byte("old-content")), Size: int64(len("old-content")),
+		},
+	}}
+	idx := newTestIndexer(store)
+	idx.SetRootPath(dir)
+	idx.SetFileMtimes(map[string]int64{
+		"a-mtime.go":   mtimeInfo.ModTime().UnixNano() - 1,
+		"b-deleted.go": 1,
+		"c-content.go": contentInfo.ModTime().UnixNano(),
+	})
+	w, err := NewWatcher(idx, config.WatchConfig{Enabled: true, DebounceMs: 10}, zap.NewNop())
+	require.NoError(t, err)
+	p := newPoller(w, idx, zap.NewNop())
+
+	want := []string{mtimePath, deletedPath, contentPath}
+	batchCalls := 0
+	w.batchReindex = func(paths []string) (*IndexResult, error) {
+		batchCalls++
+		require.Equal(t, want, paths)
+		if batchCalls == 1 {
+			return nil, errors.New("transient reconcile failure")
+		}
+		return &IndexResult{}, nil
+	}
+
+	p.poll()
+	require.Len(t, p.pendingFilesystemPaths, len(want))
+	pageCalls := len(store.calls)
+	// Remove every durable row: the second submission can only come from the
+	// bounded pending set, not by rediscovering through an advanced cursor.
+	store.rows = nil
+	store.highWater = ""
+	p.poll()
+	require.Equal(t, 2, batchCalls)
+	require.Empty(t, p.pendingFilesystemPaths)
+	require.Equal(t, pageCalls, len(store.calls),
+		"retry must not consume another mtime or content page")
+}
+
+func TestPollerFallsBackWhenMtimeSidecarWriteDiverges(t *testing.T) {
+	dir := t.TempDir()
+	durablePath := filepath.Join(dir, "durable.go")
+	missingPath := filepath.Join(dir, "missing.go")
+	require.NoError(t, os.WriteFile(durablePath, []byte("durable"), 0o644))
+	require.NoError(t, os.WriteFile(missingPath, []byte("changed"), 0o644))
+	durableInfo, err := os.Stat(durablePath)
+	require.NoError(t, err)
+	missingInfo, err := os.Stat(missingPath)
+	require.NoError(t, err)
+
+	store := &pollerReceiptStore{
+		Graph: graph.New(),
+		rows: []graph.FileReceipt{{
+			FilePath: "durable.go", MtimeNS: durableInfo.ModTime().UnixNano(),
+		}},
+		mtimeWriteErr: errors.New("sidecar write failed"),
+	}
+	idx := newTestIndexer(store)
+	idx.SetRootPath(dir)
+	idx.SetFileMtimes(map[string]int64{"durable.go": durableInfo.ModTime().UnixNano()})
+	idx.recordFileMtimeValue("missing.go", missingInfo.ModTime().UnixNano()-1)
+	require.False(t, idx.fileReceiptPagingReliable())
+
+	p := newPoller(nil, idx, zap.NewNop())
+	p.mtimeRotation = fileReceiptRotation{afterPath: "old.go", highWaterPath: "z.go"}
+	p.contentRotation = fileReceiptRotation{afterPath: "old.go", highWaterPath: "z.go"}
+	require.Equal(t, []string{missingPath}, p.pollFilesystem(),
+		"a partial durable keyset must fall back to the complete immutable snapshot")
+	require.Empty(t, store.calls, "degraded persistence must bypass receipt paging entirely")
+	require.Equal(t, fileReceiptRotation{}, p.mtimeRotation)
+	require.Equal(t, fileReceiptRotation{}, p.contentRotation,
+		"a later authoritative repair must begin a fresh durable rotation")
+}
+
+func TestSetFileMtimesDoesNotClaimDurableSidecarRepair(t *testing.T) {
+	idx := newTestIndexer(graph.New())
+	idx.markFileMtimePersistenceDirty()
+
+	idx.SetFileMtimes(map[string]int64{"main.go": 1})
+
+	require.False(t, idx.fileReceiptPagingReliable(),
+		"restoring an in-memory snapshot does not authoritatively replace durable rows")
+}
+
+func TestAuthoritativeFullIndexRepairsMtimeSidecar(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte("package p\n"), 0o644))
+	store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "graph.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	idx := newTestIndexer(store)
+	idx.SetRootPath(dir)
+	idx.markFileMtimePersistenceDirty()
+
+	_, err = idx.Index(dir)
+	require.NoError(t, err)
+	require.True(t, idx.fileReceiptPagingReliable(),
+		"a successful authoritative replacement repairs durable receipt paging")
+}


### PR DESCRIPTION
## Summary

- replace every-poll full tracked-file sweeps on SQLite with bounded, high-water-frozen keyset pages
- run independent mtime and content rotations, with the content pass capped at 128 rows and 4 MiB per poll
- detect equal-mtime, equal-size edits by verifying stable transformed content receipts
- close SQLite cursors before filesystem work and before the compact content projection
- retry failed reconciliation batches before consuming more pages
- fall back to the immutable mtime snapshot whenever sidecar persistence diverges, until a successful authoritative replacement repairs it
 
## Verification

- go test ./internal/graph/store_sqlite ./internal/indexer -count=1
- go test -race ./internal/graph/store_sqlite ./internal/indexer -run 'Test(FileReceiptPager|PollMtime|Poller|SetFileMtimes|AuthoritativeFullIndex)' -count=1
- go vet ./internal/graph/store_sqlite ./internal/indexer
- golangci-lint run ./internal/graph/store_sqlite/... ./internal/indexer/...