### PR TITLE
fix(indexer): key the file-delta path the way the cold walk does

### DIFF
--- a/internal/indexer/file_delta.go
+++ b/internal/indexer/file_delta.go
@@ -104,7 +104,12 @@ func (idx *Indexer) prepareFileDeltaWithAdmission(filePath string, tryOnly bool)
 			parseLease.Release()
 		}
 	}()
-	relPath := idx.relKey(absPath)
+	// graphRelKey, not relKey: this path is stamped onto node IDs by the
+	// extractor below and becomes the graph key at prefixPath(). relKey
+	// slash-normalises, which on Windows mints "repo/a/b.go" while the
+	// cold walk already stored "repo/a\b.go" — a second node for the
+	// same file rather than an update of the first.
+	relPath := idx.graphRelKey(absPath)
 
 	started := time.Now()
 	src, readVersion, err := readFileWithVersion(absPath)

--- a/internal/indexer/file_delta_pathkey_test.go
+++ b/internal/indexer/file_delta_pathkey_test.go
@@ -1,0 +1,89 @@
+package indexer
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+const pathKeyFixtureV1 = "package sub\n\nfunc Helper() int { return 1 }\n"
+const pathKeyFixtureV2 = "package sub\n\nfunc Helper() int { return 2 }\n"
+
+// TestFileDeltaReusesColdWalkPathKey pins the fix for #437.
+//
+// The cold walk and the single-file delta path both stamp their relPath onto
+// node IDs. graphRelKey deliberately keeps OS-native separators so an
+// incremental lookup matches what the cold walk wrote; relKey slash-normalises
+// for the mtime map. file_delta.go handed the extractor relKey's form, so on
+// Windows the cold walk stored "sub\file.go::Helper" and the first edit moved
+// the symbol to "sub/file.go::Helper" — a different node identity for a file
+// that never moved. On a persistent store the abandoned ID stays behind with
+// whatever line numbers it last held.
+//
+// On POSIX filepath.Rel already yields "/" and the two forms coincide, so this
+// is a no-op guard there and a real regression test on Windows.
+func TestFileDeltaReusesColdWalkPathKey(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "sub"), 0o755))
+	path := filepath.Join(dir, "sub", "file.go")
+	require.NoError(t, os.WriteFile(path, []byte(pathKeyFixtureV1), 0o644))
+
+	store := graph.New()
+	registry := parser.NewRegistry()
+	registry.Register(languages.NewGoExtractor())
+	cfg := config.Default()
+	cfg.Index.Workers = 1
+	idx := New(store, registry, cfg.Index, zap.NewNop())
+	idx.SetRootPath(dir)
+
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+	cold := helperNodeIDs(store)
+	require.Len(t, cold, 1, "cold walk must index exactly one Helper node")
+
+	// Re-index through the delta path, the way the watcher does after an edit.
+	require.NoError(t, os.WriteFile(path, []byte(pathKeyFixtureV2), 0o644))
+	require.NoError(t, idx.IndexFile(path))
+
+	after := helperNodeIDs(store)
+	require.Len(t, after, 1, "delta re-index must not add a second Helper node")
+	require.Equal(t, cold[0], after[0],
+		"a delta re-index must land on the node the cold walk wrote; the ID moved, "+
+			"which on a persistent store leaves the old node behind as a stale twin")
+}
+
+// TestGraphRelKeyMatchesColdWalkForm states the contract the fix relies on:
+// whatever graphRelKey returns is the form the cold walk stamps, so a delta
+// re-index keyed on it lands on the existing node.
+func TestGraphRelKeyMatchesColdWalkForm(t *testing.T) {
+	dir := t.TempDir()
+	idx := New(graph.New(), parser.NewRegistry(), config.Default().Index, zap.NewNop())
+	idx.SetRootPath(dir)
+
+	abs := filepath.Join(dir, "sub", "file.go")
+	graphKey := idx.graphRelKey(abs)
+	coldWalkRel, err := filepath.Rel(dir, abs)
+	require.NoError(t, err)
+
+	require.Equal(t, coldWalkRel, graphKey,
+		"graphRelKey must keep the cold walk's separators, not slash-normalise them")
+}
+
+func helperNodeIDs(store graph.Store) []string {
+	var out []string
+	for _, node := range store.AllNodes() {
+		if strings.HasSuffix(node.ID, "::Helper") {
+			out = append(out, node.ID)
+		}
+	}
+	return out
+}


### PR DESCRIPTION
Fixes #437.

## Root cause

The cold walk and the single-file delta path both stamp their `relPath` onto
node IDs, and they derived it differently:

```go
// internal/indexer/indexer.go:3107 — cold walk
relPath, _ := filepath.Rel(absRoot, path)   // OS-native
//        :3202  extractFile(..., relPath, ...)

// internal/indexer/file_delta.go — single-file delta
relPath := idx.relKey(absPath)              // relKey slash-normalises
//              extractFile(..., relPath, ...)
```

`graphRelKey` exists precisely to keep the cold walk's separators — its own
comment says so — but `file_delta.go` reached for `relKey`, the mtime-map key.

On Windows the first edit therefore moved a symbol's identity:

```
cold walk   sub\file.go::Helper
after edit  sub/file.go::Helper
```

Both forms are then live. On a persistent store the abandoned ID keeps whatever
line numbers it last held, so `search symbols` returns two nodes for one symbol
and either can cite a line that no longer holds it. In the reporting repository
`_mask_noise` was indexed at 137 under one ID and 149 under the other while the
function actually sits at 158 — neither node correct, and wrong by different
amounts, which is what ruled out watcher lag.

On POSIX `filepath.Rel` already yields `/`, so the two forms coincide and this
never appears.

## The change

One line: `file_delta.go` uses `graphRelKey` instead of `relKey`.

`relPath` in that function also feeds `extractFile`, `transforms.run` and
`persistFileMeta`. All three already receive `graphRelKey`'s form from
`file_meta.go` and from the cold walk, so this makes the delta path agree with
its peers rather than introducing a third convention.

## Tests

`TestFileDeltaReusesColdWalkPathKey` drives a cold walk then a delta re-index of
a nested file and asserts the node ID does not move.
`TestGraphRelKeyMatchesColdWalkForm` states the contract the fix leans on.

Both are no-op guards on POSIX and real regression tests on Windows. Reverting
the one-line change turns the first red with `the ID moved`.

## Effect on the existing suite

`go test ./internal/indexer/` on Windows, same machine, before and after:

| | failures |
| --- | --- |
| `main` at d62ceee | 25 |
| with this change | 21 |

No new failures. Four pre-existing ones go green, one of which is named for
exactly this defect:

```
TestIncrementalReindex_NestedFileNoDuplicate
TestIncrementalReindex_ConvergesToFullIndex
TestDeferredIncrementalGoFrontierUsesOneBatchAndNoRepoPass
TestWatcher_NewSubdirScanIndexesPreWatchFile
```

The remaining 21 are unrelated to path keys (compile-commands loading, GC
tuning, template-literal contracts) and fail identically on clean `main`.

## Migration

Existing Windows stores still hold the abandoned IDs. They are reaped by a
re-index; this change does not migrate them. Worth noting in release notes if
you take it.

Environment: Windows 11 Pro, Go 1.26.5.
