### PR TITLE
feat(hcl): emit graph-level config-key nodes for Terraform-declared values

### DIFF
--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -1997,10 +1997,10 @@ func stripConfigArtifacts(result *parser.ExtractionResult) {
 }
 
 // isInfraOriginConfigKey reports whether a KindConfigKey node was
-// emitted by the K8s / Kustomize / Dockerfile extractors. These
-// nodes carry Meta["origin"] = "k8s" or "dockerfile" by convention.
-// The code-side extractors (Go os.Getenv, Python os.environ, viper,
-// struct-tag, …) leave Meta["origin"] empty.
+// emitted by the K8s / Kustomize / Dockerfile / Terraform extractors.
+// These nodes carry Meta["origin"] = "k8s", "dockerfile", or
+// "terraform" by convention. The code-side extractors (Go os.Getenv,
+// Python os.environ, viper, struct-tag, …) leave Meta["origin"] empty.
 // isMigrationOriginNode reports whether a node was emitted by migration /
 // live-DB DDL extraction (Meta["origin"]=="migration"). These schema nodes
 // are high-signal and survive the sql-domain strip — the gate only removes
@@ -2018,7 +2018,7 @@ func isInfraOriginConfigKey(n *graph.Node) bool {
 		return false
 	}
 	origin, _ := n.Meta["origin"].(string)
-	return origin == "k8s" || origin == "dockerfile"
+	return origin == "k8s" || origin == "dockerfile" || origin == "terraform"
 }
 
 // isDocFrontmatterConfigKey reports whether a KindConfigKey node is a

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -1996,11 +1996,6 @@ func stripConfigArtifacts(result *parser.ExtractionResult) {
 	result.Edges = keptEdges
 }
 
-// isInfraOriginConfigKey reports whether a KindConfigKey node was
-// emitted by the K8s / Kustomize / Dockerfile / Terraform extractors.
-// These nodes carry Meta["origin"] = "k8s", "dockerfile", or
-// "terraform" by convention. The code-side extractors (Go os.Getenv,
-// Python os.environ, viper, struct-tag, …) leave Meta["origin"] empty.
 // isMigrationOriginNode reports whether a node was emitted by migration /
 // live-DB DDL extraction (Meta["origin"]=="migration"). These schema nodes
 // are high-signal and survive the sql-domain strip — the gate only removes
@@ -2013,6 +2008,11 @@ func isMigrationOriginNode(n *graph.Node) bool {
 	return o == "migration"
 }
 
+// isInfraOriginConfigKey reports whether a KindConfigKey node was
+// emitted by the K8s / Kustomize / Dockerfile / Terraform extractors.
+// These nodes carry Meta["origin"] = "k8s", "dockerfile", or
+// "terraform" by convention. The code-side extractors (Go os.Getenv,
+// Python os.environ, viper, struct-tag, …) leave Meta["origin"] empty.
 func isInfraOriginConfigKey(n *graph.Node) bool {
 	if n == nil || n.Kind != graph.KindConfigKey || n.Meta == nil {
 		return false

--- a/internal/indexer/strip_config_frontmatter_test.go
+++ b/internal/indexer/strip_config_frontmatter_test.go
@@ -23,6 +23,7 @@ func TestStripConfigArtifacts_PreservesDocFrontmatter(t *testing.T) {
 			{ID: "cfg::env::AWS_SECRET", Kind: graph.KindConfigKey, Name: "AWS_SECRET", Meta: map[string]any{"source": "env"}},
 			{ID: "report.qmd::cfg:title", Kind: graph.KindConfigKey, Name: "title", Meta: map[string]any{"source": "quarto_frontmatter"}},
 			{ID: "k8s::cfg::REPLICAS", Kind: graph.KindConfigKey, Name: "REPLICAS", Meta: map[string]any{"origin": "k8s"}},
+			{ID: "cfg::env::MAX_BATCH_SIZE", Kind: graph.KindConfigKey, Name: "MAX_BATCH_SIZE", Meta: map[string]any{"origin": "terraform", "source": "env"}},
 			{ID: "report.qmd", Kind: graph.KindFile, Name: "report.qmd"},
 		},
 		Edges: []*graph.Edge{
@@ -48,6 +49,9 @@ func TestStripConfigArtifacts_PreservesDocFrontmatter(t *testing.T) {
 	}
 	if !has("k8s::cfg::REPLICAS") {
 		t.Error("infra-origin config key must survive the strip")
+	}
+	if !has("cfg::env::MAX_BATCH_SIZE") {
+		t.Error("terraform-origin config key must survive the strip")
 	}
 
 	defines, reads := 0, 0
@@ -96,5 +100,36 @@ Some prose.
 	}
 	if len(g.FindNodesByName("format")) == 0 {
 		t.Error("quarto frontmatter key 'format' missing from default-config index")
+	}
+}
+
+// TestIndex_TerraformConfigKeySurvivesDefaultConfig is the end-to-end guard
+// for U2: indexing a .tf file with the default config (configs domain off)
+// still yields the Terraform-origin config-key node, the same way K8s- and
+// Dockerfile-origin nodes already do.
+func TestIndex_TerraformConfigKeySurvivesDefaultConfig(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "lambda.tf"), `resource "aws_lambda_function" "processor" {
+  function_name = "processor"
+
+  environment {
+    variables = {
+      MAX_BATCH_SIZE = "100"
+    }
+  }
+}
+`)
+	reg := parser.NewRegistry()
+	reg.Register(languages.NewHCLExtractor())
+	cfg := config.Default().Index
+	cfg.Workers = 2
+
+	g := graph.New()
+	idx := New(g, reg, cfg, zap.NewNop())
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+
+	if len(g.FindNodesByName("MAX_BATCH_SIZE")) == 0 {
+		t.Error("terraform-origin config key 'MAX_BATCH_SIZE' missing from default-config index")
 	}
 }

--- a/internal/parser/languages/hcl.go
+++ b/internal/parser/languages/hcl.go
@@ -57,8 +57,7 @@ func (e *HCLExtractor) Extract(filePath string, src []byte) (*parser.ExtractionR
 	dir := hclModuleDir(filePath)
 	seen := make(map[string]bool)    // block-name dedup, per file
 	refSeen := make(map[string]bool) // (from\x00to) reference dedup
-	cfgSeen := make(map[string]bool) // config-key node + edge dedup
-	e.walkTopLevel(root, src, filePath, dir, fileNode.ID, result, seen, refSeen, cfgSeen)
+	e.walkTopLevel(root, src, filePath, dir, fileNode.ID, result, seen, refSeen)
 
 	return result, nil
 }
@@ -83,7 +82,7 @@ func hclNodeID(dir, address string) string { return "hcl::" + dir + "::" + addre
 // Nested blocks (ingress, lifecycle, dynamic, …) are not separate
 // definition nodes — their value expressions are attributed to the
 // enclosing top-level block as references.
-func (e *HCLExtractor) walkTopLevel(node *sitter.Node, src []byte, filePath, dir, fileID string, result *parser.ExtractionResult, seen, refSeen, cfgSeen map[string]bool) {
+func (e *HCLExtractor) walkTopLevel(node *sitter.Node, src []byte, filePath, dir, fileID string, result *parser.ExtractionResult, seen, refSeen map[string]bool) {
 	if node == nil {
 		return
 	}
@@ -94,14 +93,14 @@ func (e *HCLExtractor) walkTopLevel(node *sitter.Node, src []byte, filePath, dir
 		}
 		switch child.Type() {
 		case "block":
-			e.extractBlock(child, src, filePath, dir, fileID, result, seen, refSeen, cfgSeen)
+			e.extractBlock(child, src, filePath, dir, fileID, result, seen, refSeen)
 		case "config_file", "body":
-			e.walkTopLevel(child, src, filePath, dir, fileID, result, seen, refSeen, cfgSeen)
+			e.walkTopLevel(child, src, filePath, dir, fileID, result, seen, refSeen)
 		}
 	}
 }
 
-func (e *HCLExtractor) extractBlock(node *sitter.Node, src []byte, filePath, dir, fileID string, result *parser.ExtractionResult, seen, refSeen, cfgSeen map[string]bool) {
+func (e *HCLExtractor) extractBlock(node *sitter.Node, src []byte, filePath, dir, fileID string, result *parser.ExtractionResult, seen, refSeen map[string]bool) {
 	// A block is: identifier (block type), string_lit labels, then body.
 	// E.g. resource "aws_instance" "web" { ... }
 	var blockType string
@@ -158,7 +157,7 @@ func (e *HCLExtractor) extractBlock(node *sitter.Node, src []byte, filePath, dir
 		})
 	}
 
-	e.extractConfigKeys(blockType, labels, body, src, filePath, id, startLine, result, cfgSeen)
+	e.extractConfigKeys(blockType, labels, body, src, filePath, id, startLine, result)
 
 	// A locals block declares N independently-addressable values
 	// (local.<key>); emit one KindConstant per key and resolve each
@@ -184,22 +183,7 @@ func (e *HCLExtractor) extractLocals(body *sitter.Node, src []byte, filePath, di
 		if attr == nil || attr.Type() != "attribute" {
 			continue
 		}
-		var key string
-		var expr *sitter.Node
-		for j, _nc := 0, int(attr.ChildCount()); j < _nc; j++ {
-			c := attr.Child(j)
-			if c == nil {
-				continue
-			}
-			switch c.Type() {
-			case "identifier":
-				if key == "" {
-					key = c.Content(src)
-				}
-			case "expression":
-				expr = c
-			}
-		}
+		key, expr := hclAttrKeyExpr(attr, src)
 		if key == "" {
 			continue
 		}
@@ -248,16 +232,15 @@ var tfConfigKeySites = map[string]tfConfigKeySite{
 // literal an allowlisted resource type declares its config values in.
 // Every key lands on the shared cfg::env::<NAME> ID so a code-side
 // os.Getenv read resolves to the same node.
-func (e *HCLExtractor) extractConfigKeys(blockType string, labels []string, body *sitter.Node, src []byte, filePath, blockID string, startLine int, result *parser.ExtractionResult, cfgSeen map[string]bool) {
+func (e *HCLExtractor) extractConfigKeys(blockType string, labels []string, body *sitter.Node, src []byte, filePath, blockID string, startLine int, result *parser.ExtractionResult) {
 	if len(labels) == 0 {
 		return
 	}
-	switch blockType {
-	case "variable", "output":
-		emitHCLConfigKey(result, blockID, labels[0], "tf_"+blockType, filePath, startLine, cfgSeen)
+	if blockType == "variable" || blockType == "output" {
+		emitHCLConfigKey(result, blockID, labels[0], "tf_"+blockType, filePath, startLine)
 		return
-	case "resource":
-	default:
+	}
+	if blockType != "resource" {
 		return
 	}
 	site, ok := tfConfigKeySites[labels[0]]
@@ -283,42 +266,46 @@ func (e *HCLExtractor) extractConfigKeys(blockType string, labels []string, body
 		if key == "" {
 			continue
 		}
-		emitHCLConfigKey(result, blockID, key, site.source, filePath,
-			int(elem.StartPoint().Row)+1, cfgSeen)
+		emitHCLConfigKey(result, blockID, key, site.source, filePath, int(elem.StartPoint().Row)+1)
 	}
 }
 
 // emitHCLConfigKey materialises one KindConfigKey node plus the
 // EdgeUsesEnv edge from the declaring block, mirroring the Kubernetes
-// and Dockerfile extractors. Both are deduped per file so a name
-// declared twice yields one node and one edge per declaring block.
-func emitHCLConfigKey(result *parser.ExtractionResult, fromID, name, source, filePath string, line int, cfgSeen map[string]bool) {
+// and Dockerfile extractors. Not deduped, matching dockerfile.go's own
+// config-key extractor: AddNode dedupes by ID and edges dedupe by
+// {From,To,Kind,FilePath,Line} once committed to the graph, so a second
+// identical emission here is a harmless no-op downstream.
+func emitHCLConfigKey(result *parser.ExtractionResult, fromID, name, source, filePath string, line int) {
 	if name == "" {
 		return
 	}
 	keyID := configKeyEnvID(name)
-	if !cfgSeen[keyID] {
-		cfgSeen[keyID] = true
-		result.Nodes = append(result.Nodes, &graph.Node{
-			ID: keyID, Kind: graph.KindConfigKey, Name: name,
-			FilePath: filePath, StartLine: line, EndLine: line,
-			Language: "hcl",
-			Meta: map[string]any{
-				"source": source,
-				"origin": "terraform",
-			},
-		})
-	}
-	edgeKey := fromID + "\x00" + keyID
-	if cfgSeen[edgeKey] {
-		return
-	}
-	cfgSeen[edgeKey] = true
+	result.Nodes = append(result.Nodes, &graph.Node{
+		ID: keyID, Kind: graph.KindConfigKey, Name: name,
+		FilePath: filePath, StartLine: line, EndLine: line,
+		Language: "hcl",
+		Meta: map[string]any{
+			"source": source,
+			"origin": "terraform",
+		},
+	})
 	result.Edges = append(result.Edges, &graph.Edge{
 		From: fromID, To: keyID, Kind: graph.EdgeUsesEnv,
 		FilePath: filePath, Line: line,
 		Meta: map[string]any{"scope": "runtime"},
 	})
+}
+
+// hclAttrKeyExpr splits an "attribute" node (`key = expr`) into its
+// identifier key and expression value. Shared by extractLocals (which
+// wants every attribute) and hclAttrObject (which wants one by name).
+func hclAttrKeyExpr(attr *sitter.Node, src []byte) (string, *sitter.Node) {
+	var key string
+	if id := findChildByType(attr, "identifier"); id != nil {
+		key = id.Content(src)
+	}
+	return key, findChildByType(attr, "expression")
 }
 
 // hclNestedBlockBody returns the body of the first nested block named
@@ -330,25 +317,11 @@ func hclNestedBlockBody(body *sitter.Node, name string, src []byte) *sitter.Node
 		if child == nil || child.Type() != "block" {
 			continue
 		}
-		var blockType string
-		var inner *sitter.Node
-		for j, _jc := 0, int(child.ChildCount()); j < _jc; j++ {
-			c := child.Child(j)
-			if c == nil {
-				continue
-			}
-			switch c.Type() {
-			case "identifier":
-				if blockType == "" {
-					blockType = c.Content(src)
-				}
-			case "body":
-				inner = c
-			}
+		id := findChildByType(child, "identifier")
+		if id == nil || id.Content(src) != name {
+			continue
 		}
-		if blockType == name {
-			return inner
-		}
+		return findChildByType(child, "body")
 	}
 	return nil
 }
@@ -364,22 +337,7 @@ func hclAttrObject(body *sitter.Node, name string, src []byte) *sitter.Node {
 		if attr == nil || attr.Type() != "attribute" {
 			continue
 		}
-		var key string
-		var expr *sitter.Node
-		for j, _jc := 0, int(attr.ChildCount()); j < _jc; j++ {
-			c := attr.Child(j)
-			if c == nil {
-				continue
-			}
-			switch c.Type() {
-			case "identifier":
-				if key == "" {
-					key = c.Content(src)
-				}
-			case "expression":
-				expr = c
-			}
-		}
+		key, expr := hclAttrKeyExpr(attr, src)
 		if key != name || expr == nil {
 			continue
 		}
@@ -392,43 +350,33 @@ func hclAttrObject(body *sitter.Node, name string, src []byte) *sitter.Node {
 // direct children are inspected, so an object nested inside a function
 // call or for-expression is not mistaken for the attribute's own value.
 func hclObjectOf(expr *sitter.Node) *sitter.Node {
-	for i, _nc := 0, int(expr.ChildCount()); i < _nc; i++ {
-		coll := expr.Child(i)
-		if coll == nil || coll.Type() != "collection_value" {
-			continue
-		}
-		for j, _jc := 0, int(coll.ChildCount()); j < _jc; j++ {
-			if o := coll.Child(j); o != nil && o.Type() == "object" {
-				return o
-			}
-		}
+	coll := findChildByType(expr, "collection_value")
+	if coll == nil {
+		return nil
 	}
-	return nil
+	return findChildByType(coll, "object")
 }
 
 // hclObjectElemKey returns the literal key of an object_elem — the bare
 // form (KEY = "v") or the quoted form ("KEY" = "v"). A computed key
 // ((var.x) = "v") has no static name and yields "".
 func hclObjectElemKey(elem *sitter.Node, src []byte) string {
-	for i, _nc := 0, int(elem.ChildCount()); i < _nc; i++ {
-		expr := elem.Child(i)
-		if expr == nil || expr.Type() != "expression" {
+	expr := findChildByType(elem, "expression")
+	if expr == nil {
+		return ""
+	}
+	// The first expression child is the key; the second is the value.
+	for j, _jc := 0, int(expr.ChildCount()); j < _jc; j++ {
+		c := expr.Child(j)
+		if c == nil {
 			continue
 		}
-		// The first expression child is the key; the second is the value.
-		for j, _jc := 0, int(expr.ChildCount()); j < _jc; j++ {
-			c := expr.Child(j)
-			if c == nil {
-				continue
-			}
-			switch c.Type() {
-			case "variable_expr":
-				return hclIdentText(c, src)
-			case "literal_value":
-				return trimQuotes(strings.TrimSpace(c.Content(src)))
-			}
+		switch c.Type() {
+		case "variable_expr":
+			return hclIdentText(c, src)
+		case "literal_value":
+			return trimQuotes(strings.TrimSpace(c.Content(src)))
 		}
-		return ""
 	}
 	return ""
 }

--- a/internal/parser/languages/hcl.go
+++ b/internal/parser/languages/hcl.go
@@ -18,7 +18,11 @@ import (
 // KindConstant node addressed `local.<key>`. Cross-block value
 // expressions (var.x, local.y, module.m, data.t.n, aws_instance.web.id)
 // produce EdgeReferences edges so a change-impact walk can answer "what
-// breaks if this resource/variable changes?". Block node IDs are scoped
+// breaks if this resource/variable changes?". Config values a config
+// declares — variable/output names, and the keys an allow-listed
+// resource type declares (see tfConfigKeySites) — additionally yield
+// KindConfigKey nodes on the shared cfg::env::<NAME> ID plus an
+// EdgeUsesEnv edge from the declaring block. Block node IDs are scoped
 // to the file's directory — the Terraform module boundary — so a
 // reference in one .tf file resolves to a block defined in a sibling .tf
 // file of the same module by exact ID match.
@@ -53,7 +57,8 @@ func (e *HCLExtractor) Extract(filePath string, src []byte) (*parser.ExtractionR
 	dir := hclModuleDir(filePath)
 	seen := make(map[string]bool)    // block-name dedup, per file
 	refSeen := make(map[string]bool) // (from\x00to) reference dedup
-	e.walkTopLevel(root, src, filePath, dir, fileNode.ID, result, seen, refSeen)
+	cfgSeen := make(map[string]bool) // config-key node + edge dedup
+	e.walkTopLevel(root, src, filePath, dir, fileNode.ID, result, seen, refSeen, cfgSeen)
 
 	return result, nil
 }
@@ -78,7 +83,7 @@ func hclNodeID(dir, address string) string { return "hcl::" + dir + "::" + addre
 // Nested blocks (ingress, lifecycle, dynamic, …) are not separate
 // definition nodes — their value expressions are attributed to the
 // enclosing top-level block as references.
-func (e *HCLExtractor) walkTopLevel(node *sitter.Node, src []byte, filePath, dir, fileID string, result *parser.ExtractionResult, seen, refSeen map[string]bool) {
+func (e *HCLExtractor) walkTopLevel(node *sitter.Node, src []byte, filePath, dir, fileID string, result *parser.ExtractionResult, seen, refSeen, cfgSeen map[string]bool) {
 	if node == nil {
 		return
 	}
@@ -89,14 +94,14 @@ func (e *HCLExtractor) walkTopLevel(node *sitter.Node, src []byte, filePath, dir
 		}
 		switch child.Type() {
 		case "block":
-			e.extractBlock(child, src, filePath, dir, fileID, result, seen, refSeen)
+			e.extractBlock(child, src, filePath, dir, fileID, result, seen, refSeen, cfgSeen)
 		case "config_file", "body":
-			e.walkTopLevel(child, src, filePath, dir, fileID, result, seen, refSeen)
+			e.walkTopLevel(child, src, filePath, dir, fileID, result, seen, refSeen, cfgSeen)
 		}
 	}
 }
 
-func (e *HCLExtractor) extractBlock(node *sitter.Node, src []byte, filePath, dir, fileID string, result *parser.ExtractionResult, seen, refSeen map[string]bool) {
+func (e *HCLExtractor) extractBlock(node *sitter.Node, src []byte, filePath, dir, fileID string, result *parser.ExtractionResult, seen, refSeen, cfgSeen map[string]bool) {
 	// A block is: identifier (block type), string_lit labels, then body.
 	// E.g. resource "aws_instance" "web" { ... }
 	var blockType string
@@ -152,6 +157,8 @@ func (e *HCLExtractor) extractBlock(node *sitter.Node, src []byte, filePath, dir
 			FilePath: filePath, Line: startLine,
 		})
 	}
+
+	e.extractConfigKeys(blockType, labels, body, src, filePath, id, startLine, result, cfgSeen)
 
 	// A locals block declares N independently-addressable values
 	// (local.<key>); emit one KindConstant per key and resolve each
@@ -213,6 +220,217 @@ func (e *HCLExtractor) extractLocals(body *sitter.Node, src []byte, filePath, di
 			e.collectReferences(expr, src, filePath, dir, id, result, refSeen)
 		}
 	}
+}
+
+// tfConfigKeySite names, for one allowlisted Terraform resource type,
+// where that type's declared config values live: an attribute holding an
+// object literal, optionally inside a single nested block.
+type tfConfigKeySite struct {
+	block  string // enclosing nested block, "" when attr sits in the resource body
+	attr   string // attribute whose object literal declares the keys
+	source string // Meta["source"] tag for the emitted config-key nodes
+}
+
+// tfConfigKeySites is the v1 allowlist of resource types whose declared
+// config values become KindConfigKey nodes. It is deliberately an
+// allowlist of exact attribute paths rather than a general nested-block
+// traversal — every entry here is a shape where the declared key is
+// known to name a config value, which is not true of Terraform block
+// attributes in general.
+var tfConfigKeySites = map[string]tfConfigKeySite{
+	"aws_lambda_function":   {block: "environment", attr: "variables", source: "env"},
+	"kubernetes_config_map": {attr: "data", source: "k8s_cm"},
+	"kubernetes_secret":     {attr: "data", source: "k8s_secret"},
+}
+
+// extractConfigKeys emits the KindConfigKey nodes a block declares:
+// the name of a variable/output block, and each key of the object
+// literal an allowlisted resource type declares its config values in.
+// Every key lands on the shared cfg::env::<NAME> ID so a code-side
+// os.Getenv read resolves to the same node.
+func (e *HCLExtractor) extractConfigKeys(blockType string, labels []string, body *sitter.Node, src []byte, filePath, blockID string, startLine int, result *parser.ExtractionResult, cfgSeen map[string]bool) {
+	if len(labels) == 0 {
+		return
+	}
+	switch blockType {
+	case "variable", "output":
+		emitHCLConfigKey(result, blockID, labels[0], "tf_"+blockType, filePath, startLine, cfgSeen)
+		return
+	case "resource":
+	default:
+		return
+	}
+	site, ok := tfConfigKeySites[labels[0]]
+	if !ok || body == nil {
+		return
+	}
+	scope := body
+	if site.block != "" {
+		if scope = hclNestedBlockBody(body, site.block, src); scope == nil {
+			return
+		}
+	}
+	obj := hclAttrObject(scope, site.attr, src)
+	if obj == nil {
+		return
+	}
+	for i, _nc := 0, int(obj.ChildCount()); i < _nc; i++ {
+		elem := obj.Child(i)
+		if elem == nil || elem.Type() != "object_elem" {
+			continue
+		}
+		key := hclObjectElemKey(elem, src)
+		if key == "" {
+			continue
+		}
+		emitHCLConfigKey(result, blockID, key, site.source, filePath,
+			int(elem.StartPoint().Row)+1, cfgSeen)
+	}
+}
+
+// emitHCLConfigKey materialises one KindConfigKey node plus the
+// EdgeUsesEnv edge from the declaring block, mirroring the Kubernetes
+// and Dockerfile extractors. Both are deduped per file so a name
+// declared twice yields one node and one edge per declaring block.
+func emitHCLConfigKey(result *parser.ExtractionResult, fromID, name, source, filePath string, line int, cfgSeen map[string]bool) {
+	if name == "" {
+		return
+	}
+	keyID := configKeyEnvID(name)
+	if !cfgSeen[keyID] {
+		cfgSeen[keyID] = true
+		result.Nodes = append(result.Nodes, &graph.Node{
+			ID: keyID, Kind: graph.KindConfigKey, Name: name,
+			FilePath: filePath, StartLine: line, EndLine: line,
+			Language: "hcl",
+			Meta: map[string]any{
+				"source": source,
+				"origin": "terraform",
+			},
+		})
+	}
+	edgeKey := fromID + "\x00" + keyID
+	if cfgSeen[edgeKey] {
+		return
+	}
+	cfgSeen[edgeKey] = true
+	result.Edges = append(result.Edges, &graph.Edge{
+		From: fromID, To: keyID, Kind: graph.EdgeUsesEnv,
+		FilePath: filePath, Line: line,
+		Meta: map[string]any{"scope": "runtime"},
+	})
+}
+
+// hclNestedBlockBody returns the body of the first nested block named
+// `name` inside body, or nil when absent. Scoped to one named block on
+// purpose — this is not a general nested-block traversal.
+func hclNestedBlockBody(body *sitter.Node, name string, src []byte) *sitter.Node {
+	for i, _nc := 0, int(body.ChildCount()); i < _nc; i++ {
+		child := body.Child(i)
+		if child == nil || child.Type() != "block" {
+			continue
+		}
+		var blockType string
+		var inner *sitter.Node
+		for j, _jc := 0, int(child.ChildCount()); j < _jc; j++ {
+			c := child.Child(j)
+			if c == nil {
+				continue
+			}
+			switch c.Type() {
+			case "identifier":
+				if blockType == "" {
+					blockType = c.Content(src)
+				}
+			case "body":
+				inner = c
+			}
+		}
+		if blockType == name {
+			return inner
+		}
+	}
+	return nil
+}
+
+// hclAttrObject returns the object node of `<name> = { … }` inside body,
+// or nil when the attribute is absent or its value isn't a literal
+// object. A map built by merge(…), a for-expression, or a reference to a
+// local has no statically enumerable keys, so those are skipped rather
+// than guessed at.
+func hclAttrObject(body *sitter.Node, name string, src []byte) *sitter.Node {
+	for i, _nc := 0, int(body.ChildCount()); i < _nc; i++ {
+		attr := body.Child(i)
+		if attr == nil || attr.Type() != "attribute" {
+			continue
+		}
+		var key string
+		var expr *sitter.Node
+		for j, _jc := 0, int(attr.ChildCount()); j < _jc; j++ {
+			c := attr.Child(j)
+			if c == nil {
+				continue
+			}
+			switch c.Type() {
+			case "identifier":
+				if key == "" {
+					key = c.Content(src)
+				}
+			case "expression":
+				expr = c
+			}
+		}
+		if key != name || expr == nil {
+			continue
+		}
+		return hclObjectOf(expr)
+	}
+	return nil
+}
+
+// hclObjectOf unwraps expression → collection_value → object. Only
+// direct children are inspected, so an object nested inside a function
+// call or for-expression is not mistaken for the attribute's own value.
+func hclObjectOf(expr *sitter.Node) *sitter.Node {
+	for i, _nc := 0, int(expr.ChildCount()); i < _nc; i++ {
+		coll := expr.Child(i)
+		if coll == nil || coll.Type() != "collection_value" {
+			continue
+		}
+		for j, _jc := 0, int(coll.ChildCount()); j < _jc; j++ {
+			if o := coll.Child(j); o != nil && o.Type() == "object" {
+				return o
+			}
+		}
+	}
+	return nil
+}
+
+// hclObjectElemKey returns the literal key of an object_elem — the bare
+// form (KEY = "v") or the quoted form ("KEY" = "v"). A computed key
+// ((var.x) = "v") has no static name and yields "".
+func hclObjectElemKey(elem *sitter.Node, src []byte) string {
+	for i, _nc := 0, int(elem.ChildCount()); i < _nc; i++ {
+		expr := elem.Child(i)
+		if expr == nil || expr.Type() != "expression" {
+			continue
+		}
+		// The first expression child is the key; the second is the value.
+		for j, _jc := 0, int(expr.ChildCount()); j < _jc; j++ {
+			c := expr.Child(j)
+			if c == nil {
+				continue
+			}
+			switch c.Type() {
+			case "variable_expr":
+				return hclIdentText(c, src)
+			case "literal_value":
+				return trimQuotes(strings.TrimSpace(c.Content(src)))
+			}
+		}
+		return ""
+	}
+	return ""
 }
 
 // collectReferences walks an expression subtree and emits an

--- a/internal/parser/languages/hcl_test.go
+++ b/internal/parser/languages/hcl_test.go
@@ -340,6 +340,42 @@ resource "aws_lambda_function" "processor" {
 	}
 }
 
+// Two resources declaring the same env var name each get their own
+// EdgeUsesEnv edge to the shared cfg::env::<NAME> node — this extractor
+// does not dedup within a file (the graph's AddNode/edge-key dedup
+// handles collapsing identical nodes/edges downstream), so a second
+// declaration must not silently disappear here.
+func TestHCLExtractor_SharedKeyNameAcrossResourcesEachGetsAnEdge(t *testing.T) {
+	src := []byte(`resource "aws_lambda_function" "a" {
+  environment {
+    variables = {
+      TIMEOUT_SECONDS = "30"
+    }
+  }
+}
+
+resource "aws_lambda_function" "b" {
+  environment {
+    variables = {
+      TIMEOUT_SECONDS = "60"
+    }
+  }
+}
+`)
+	e := NewHCLExtractor()
+	result, err := e.Extract("lambdas.tf", src)
+	require.NoError(t, err)
+
+	id := "cfg::env::TIMEOUT_SECONDS"
+	nodes := nodesByID(result.Nodes)
+	require.Contains(t, nodes, id)
+
+	for _, from := range []string{"hcl::.::aws_lambda_function.a", "hcl::.::aws_lambda_function.b"} {
+		assert.True(t, hasEdgeBetween(result.Edges, graph.EdgeUsesEnv, from, id),
+			"missing EdgeUsesEnv %s -> %s", from, id)
+	}
+}
+
 func TestHCLExtractor_FileNode(t *testing.T) {
 	src := []byte(`variable "name" {}
 `)

--- a/internal/parser/languages/hcl_test.go
+++ b/internal/parser/languages/hcl_test.go
@@ -132,6 +132,214 @@ output "ip" {
 	}
 }
 
+func TestHCLExtractor_VariableAndOutputEmitConfigKeys(t *testing.T) {
+	src := []byte(`variable "chunk_size" {
+  default = 500
+}
+
+output "queue_url" {
+  value = aws_sqs_queue.jobs.url
+}
+`)
+	e := NewHCLExtractor()
+	result, err := e.Extract("main.tf", src)
+	require.NoError(t, err)
+
+	nodes := nodesByID(result.Nodes)
+	for _, tc := range []struct{ name, from, source string }{
+		{"chunk_size", "hcl::.::var.chunk_size", "tf_variable"},
+		{"queue_url", "hcl::.::output.queue_url", "tf_output"},
+	} {
+		id := "cfg::env::" + tc.name
+		require.Contains(t, nodes, id, "missing config_key for %q", tc.name)
+		assert.Equal(t, graph.KindConfigKey, nodes[id].Kind)
+		assert.Equal(t, tc.name, nodes[id].Name)
+		assert.Equal(t, "terraform", nodes[id].Meta["origin"])
+		assert.Equal(t, tc.source, nodes[id].Meta["source"])
+		assert.True(t, hasEdgeBetween(result.Edges, graph.EdgeUsesEnv, tc.from, id),
+			"missing EdgeUsesEnv %s -> %s", tc.from, id)
+	}
+}
+
+func TestHCLExtractor_LambdaEnvironmentVariables(t *testing.T) {
+	src := []byte(`resource "aws_lambda_function" "processor" {
+  function_name = "processor"
+
+  environment {
+    variables = {
+      MAX_BATCH_SIZE = "100"
+      "CHUNK_SIZE"   = "500"
+    }
+  }
+}
+`)
+	e := NewHCLExtractor()
+	result, err := e.Extract("lambda.tf", src)
+	require.NoError(t, err)
+
+	nodes := nodesByID(result.Nodes)
+	resID := "hcl::.::aws_lambda_function.processor"
+	require.Contains(t, nodes, resID, "resource block node should still be emitted")
+
+	// Every declared key gets its own node — bare and quoted alike.
+	for _, key := range []string{"MAX_BATCH_SIZE", "CHUNK_SIZE"} {
+		id := "cfg::env::" + key
+		require.Contains(t, nodes, id, "missing config_key for %q", key)
+		assert.Equal(t, graph.KindConfigKey, nodes[id].Kind)
+		assert.Equal(t, "env", nodes[id].Meta["source"])
+		assert.Equal(t, "terraform", nodes[id].Meta["origin"])
+		assert.True(t, hasEdgeBetween(result.Edges, graph.EdgeUsesEnv, resID, id),
+			"missing EdgeUsesEnv %s -> %s", resID, id)
+	}
+}
+
+func TestHCLExtractor_KubernetesProviderDataKeys(t *testing.T) {
+	src := []byte(`resource "kubernetes_config_map" "app" {
+  metadata {
+    name = "app"
+  }
+  data = {
+    LOG_LEVEL   = "debug"
+    FEATURE_X   = "on"
+  }
+}
+
+resource "kubernetes_secret" "app" {
+  data = {
+    API_TOKEN = "shhh"
+  }
+}
+`)
+	e := NewHCLExtractor()
+	result, err := e.Extract("k8s.tf", src)
+	require.NoError(t, err)
+
+	nodes := nodesByID(result.Nodes)
+	cmID := "hcl::.::kubernetes_config_map.app"
+	secID := "hcl::.::kubernetes_secret.app"
+
+	for _, tc := range []struct{ key, from, source string }{
+		{"LOG_LEVEL", cmID, "k8s_cm"},
+		{"FEATURE_X", cmID, "k8s_cm"},
+		{"API_TOKEN", secID, "k8s_secret"},
+	} {
+		id := "cfg::env::" + tc.key
+		require.Contains(t, nodes, id, "missing config_key for %q", tc.key)
+		assert.Equal(t, graph.KindConfigKey, nodes[id].Kind)
+		assert.Equal(t, tc.source, nodes[id].Meta["source"])
+		assert.Equal(t, "terraform", nodes[id].Meta["origin"])
+		assert.True(t, hasEdgeBetween(result.Edges, graph.EdgeUsesEnv, tc.from, id),
+			"missing EdgeUsesEnv %s -> %s", tc.from, id)
+	}
+}
+
+func TestHCLExtractor_ResourceOutsideAllowlistEmitsNoConfigKeys(t *testing.T) {
+	src := []byte(`resource "aws_instance" "web" {
+  ami = "ami-12345"
+
+  tags = {
+    Name = "web"
+  }
+}
+`)
+	e := NewHCLExtractor()
+	result, err := e.Extract("main.tf", src)
+	require.NoError(t, err)
+
+	assert.Empty(t, nodesOfKind(result.Nodes, graph.KindConfigKey),
+		"non-allowlisted resource types must not emit config keys")
+	for _, ed := range result.Edges {
+		assert.NotEqual(t, graph.EdgeUsesEnv, ed.Kind)
+	}
+
+	// The generic block node is unaffected.
+	nodes := nodesByID(result.Nodes)
+	require.Contains(t, nodes, "hcl::.::aws_instance.web")
+	assert.Equal(t, graph.KindType, nodes["hcl::.::aws_instance.web"].Kind)
+}
+
+// Keys are only enumerable from a literal object. Anything computed —
+// merge(), a for-expression, a reference to a local — must be skipped
+// rather than guessed at, and a missing block must not panic.
+func TestHCLExtractor_NonLiteralConfigMapsAreSkipped(t *testing.T) {
+	src := []byte(`resource "aws_lambda_function" "merged" {
+  environment {
+    variables = merge(local.base_env, { SHOULD_NOT_APPEAR = "1" })
+  }
+}
+
+resource "aws_lambda_function" "computed" {
+  environment {
+    variables = { for k, v in local.env_map : k => v }
+  }
+}
+
+resource "aws_lambda_function" "indirect" {
+  environment {
+    variables = local.env_map
+  }
+}
+
+resource "aws_lambda_function" "empty" {
+  environment {
+    variables = {}
+  }
+}
+
+resource "aws_lambda_function" "bare" {
+  function_name = "bare"
+}
+
+resource "kubernetes_config_map" "nodata" {
+  metadata {
+    name = "nodata"
+  }
+}
+`)
+	e := NewHCLExtractor()
+	result, err := e.Extract("lambda.tf", src)
+	require.NoError(t, err)
+
+	assert.Empty(t, nodesOfKind(result.Nodes, graph.KindConfigKey),
+		"non-literal, empty, and absent maps must yield no config keys")
+}
+
+// The config-key walker is additive: block nodes and the reference
+// edges between blocks are unchanged, and a declared key name never
+// leaks into the reference graph as a phantom block address.
+func TestHCLExtractor_ConfigKeysDoNotDisturbReferences(t *testing.T) {
+	src := []byte(`variable "log_level" {
+  default = "info"
+}
+
+resource "aws_lambda_function" "processor" {
+  role = aws_iam_role.lambda.arn
+
+  environment {
+    variables = {
+      LOG_LEVEL = var.log_level
+    }
+  }
+}
+`)
+	e := NewHCLExtractor()
+	result, err := e.Extract("main.tf", src)
+	require.NoError(t, err)
+
+	lambda := "hcl::.::aws_lambda_function.processor"
+	assert.True(t, hasEdgeBetween(result.Edges, graph.EdgeReferences, lambda,
+		"hcl::.::aws_iam_role.lambda"))
+	assert.True(t, hasEdgeBetween(result.Edges, graph.EdgeReferences, lambda,
+		"hcl::.::var.log_level"), "value expressions inside the env block still resolve")
+
+	for _, ed := range result.Edges {
+		if ed.Kind == graph.EdgeReferences {
+			assert.NotContains(t, ed.To, "LOG_LEVEL",
+				"an env key name must not become a reference target")
+		}
+	}
+}
+
 func TestHCLExtractor_FileNode(t *testing.T) {
 	src := []byte(`variable "name" {}
 `)


### PR DESCRIPTION
## Summary

Extends Terraform (`.tf`/HCL) parsing to emit the same graph-level config-tracking nodes that the Kubernetes and Dockerfile extractors already emit for their inputs: `variable`/`output` blocks and a v1 allowlist of resource types that declare config values in native HCL structure (`aws_lambda_function`'s `environment.variables`, `kubernetes_config_map`/`kubernetes_secret`'s `data`) now produce `KindConfigKey` nodes with `EdgeUsesEnv` edges, on the same `cfg::env::<NAME>` ID convention Dockerfile/K8s already use.

**This is the same-repo half of the work described in #412 .** It gives Terraform config values the same local graph visibility (MCP analyze tools, `handleAnalyzeK8sResources`-adjacent traceability) that Kubernetes and Dockerfile already have. It does **not** make these values cross-repo `Contract` providers — that's a structurally different mechanism (`internal/contracts`' `Registry`/`Match()`), and is scoped to a separate, follow-up PR (tracked as U3 in the corrected-scope discussion on the issue). Splitting the two was the maintainer's call in that thread, and this PR is the smaller, lower-risk half.

## Why two separate mechanisms

Early in this work it became clear Gortex has two independent systems that both happen to involve environment variables, and the original issue conflated them:

- **Graph-level node sharing** (what this PR extends) — same-repo only. The indexer rewrites every node ID to `<repoPrefix>/<id>` before committing to the graph, so identical env var names in different repos never collide through this path.
- **Contract-level matching** (`internal/contracts/matcher.go`) — the actual cross-repo mechanism, pairing `Contract` records by workspace/project regardless of source repo. Its env-var source (`EnvVarExtractor`) has no Terraform awareness today, and adding it is a materially different piece of work (a new `TreeAwareExtractor`, not an HCL-parser extension) — see the follow-up PR.

Full details in the issue comment thread.

## What's in this PR

- `internal/parser/languages/hcl.go`: new narrowly-scoped nested-block walker for `variable`/`output` blocks and the v1 resource allowlist. Deliberately does not attempt general nested-block traversal — only the specific attribute paths listed above.
- `internal/indexer/indexer.go`: `isInfraOriginConfigKey`'s allowlist extended to include `origin == "terraform"`, so these new nodes survive the strip when the `configs` coverage domain is gated off (the default), the same way K8s/Dockerfile nodes already do.
- Tests: happy-path coverage for variable/output blocks, Lambda environment blocks, and K8s-provider resource `data` keys; a non-allowlisted resource type (`aws_instance`) confirmed to emit nothing extra; non-literal/computed maps (`merge()`, `for`-expressions, `local` references) confirmed to be skipped rather than guessed at; confirmation that existing reference-graph construction (`EdgeReferences`) is untouched; an end-to-end index test mirroring the existing Quarto-frontmatter strip-gate test.

## Test plan

- [x] `go test ./internal/parser/languages/...` — new + existing tests pass
- [x] `go test ./internal/indexer/...` — new + existing tests pass
- [x] `go test -race ./...` — full suite passes (one unrelated pre-existing flake in `internal/gitcmd`'s `TestConcurrencyCapNeverExceeded`, confirmed to pass in isolation and untouched by this diff — a full-suite-load timing sensitivity, not a regression)

## Known limitation (surfaced deliberately, not hidden)

After this ships, a `kubernetes_config_map`/`kubernetes_secret` resource defined via Terraform is visible to the same graph-level tooling as one defined via hand-written K8s YAML, but the two remain tracked by disconnected code paths under the hood.  This is a deliberate near-term scope boundary, not an oversight, and there should be a future pass that connects the two properly.
