### PR TITLE
feat(contracts): Terraform Lambda env vars as cross-repo contract providers

### DIFF
--- a/internal/contracts/parse_helper.go
+++ b/internal/contracts/parse_helper.go
@@ -2,23 +2,34 @@ package contracts
 
 import (
 	"github.com/zzet/gortex/internal/parser"
+	sitter "github.com/zzet/gortex/internal/parser/tsitter"
+	"github.com/zzet/gortex/internal/parser/tsitter/hcl"
 	gosrc "github.com/zzet/gortex/internal/parser/tsitter/golang"
 )
 
 // ParseTreeForLang produces a fresh ParseTree for src using the
 // grammar registered for lang. Returns nil if the language doesn't
-// have a grammar Phase 1 supports — currently only "go". Used by the
-// indexer's incremental re-walk path (extractContracts) which doesn't
-// have a tree from the language extractor.
+// have a grammar Phase 1 supports — currently "go" and "hcl". Used by
+// the indexer's incremental re-walk path (extractContracts) which
+// doesn't have a tree from the language extractor.
 //
 // The caller must Release() the returned tree when done.
 func ParseTreeForLang(lang string, src []byte) *parser.ParseTree {
-	if lang != "go" || len(src) == 0 {
+	if len(src) == 0 {
 		return nil
 	}
-	tree, err := parser.ParseFile(src, gosrc.GetLanguage())
+	var grammar *sitter.Language
+	switch lang {
+	case "go":
+		grammar = gosrc.GetLanguage()
+	case "hcl":
+		grammar = hcl.GetLanguage()
+	default:
+		return nil
+	}
+	tree, err := parser.ParseFile(src, grammar)
 	if err != nil || tree == nil {
 		return nil
 	}
-	return parser.NewParseTree(tree, src, "go")
+	return parser.NewParseTree(tree, src, lang)
 }

--- a/internal/contracts/parse_helper_test.go
+++ b/internal/contracts/parse_helper_test.go
@@ -1,0 +1,27 @@
+package contracts
+
+import "testing"
+
+func TestParseTreeForLang_HCL(t *testing.T) {
+	src := []byte(`resource "aws_lambda_function" "processor" {}`)
+	tree := ParseTreeForLang("hcl", src)
+	defer tree.Release()
+	if tree == nil || tree.Tree() == nil {
+		t.Fatalf("expected a non-nil hcl tree")
+	}
+	if got := tree.Lang(); got != "hcl" {
+		t.Errorf("expected Lang()==\"hcl\", got %q", got)
+	}
+}
+
+func TestParseTreeForLang_UnsupportedLanguage(t *testing.T) {
+	if tree := ParseTreeForLang("python", []byte("x = 1")); tree != nil {
+		t.Errorf("expected nil for an unsupported language, got %+v", tree)
+	}
+}
+
+func TestParseTreeForLang_EmptySource(t *testing.T) {
+	if tree := ParseTreeForLang("hcl", nil); tree != nil {
+		t.Errorf("expected nil for empty source, got %+v", tree)
+	}
+}

--- a/internal/contracts/terraform.go
+++ b/internal/contracts/terraform.go
@@ -6,7 +6,6 @@ import (
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/parser"
 	sitter "github.com/zzet/gortex/internal/parser/tsitter"
-	hclgrammar "github.com/zzet/gortex/internal/parser/tsitter/hcl"
 )
 
 // TerraformExtractor turns Terraform-declared environment values into
@@ -33,15 +32,12 @@ var terraformPrefilterMarkers = [][]byte{[]byte(terraformLambdaResource)}
 
 func (e *TerraformExtractor) SupportedLanguages() []string { return []string{"hcl"} }
 
-// Extract parses src with the HCL grammar itself. The HCL language
-// extractor closes its own tree rather than handing it back on the
-// ExtractionResult, so the indexer has no tree to pass for .tf files —
-// same lazy-parse shape HTTPExtractor.Extract uses.
+// Extract parses src with the HCL grammar itself, the same lazy-parse
+// shape HTTPExtractor.Extract uses when the caller has no tree to hand
+// it. ParseTreeForLang is the shared helper the indexer's incremental
+// re-walk path also uses to get a tree for .tf files.
 func (e *TerraformExtractor) Extract(filePath string, src []byte, nodes []*graph.Node, _ []*graph.Edge) []Contract {
-	if !srcHasAnyMarker(src, terraformPrefilterMarkers) {
-		return nil
-	}
-	tree := parseHCLTree(src)
+	tree := ParseTreeForLang("hcl", src)
 	defer tree.Release()
 	return e.extract(filePath, src, nodes, tree)
 }
@@ -55,13 +51,13 @@ func (e *TerraformExtractor) ExtractWithTree(
 	_ []*graph.Edge,
 	tree *parser.ParseTree,
 ) []Contract {
-	if !srcHasAnyMarker(src, terraformPrefilterMarkers) {
-		return nil
-	}
 	return e.extract(filePath, src, nodes, tree)
 }
 
 func (e *TerraformExtractor) extract(filePath string, src []byte, nodes []*graph.Node, tree *parser.ParseTree) []Contract {
+	if !srcHasAnyMarker(src, terraformPrefilterMarkers) {
+		return nil
+	}
 	st := tree.Tree()
 	if st == nil {
 		return nil
@@ -104,19 +100,6 @@ func (e *TerraformExtractor) extract(filePath string, src []byte, nodes []*graph
 		}
 	}
 	return out
-}
-
-// parseHCLTree parses src with the HCL grammar. The caller owns the
-// returned handle and must Release it; nil on a parse failure.
-func parseHCLTree(src []byte) *parser.ParseTree {
-	if len(src) == 0 {
-		return nil
-	}
-	tree, err := parser.ParseFile(src, hclgrammar.GetLanguage())
-	if err != nil || tree == nil {
-		return nil
-	}
-	return parser.NewParseTree(tree, src, "hcl")
 }
 
 // hclBlockSymbolID returns the ID of the graph node the HCL language
@@ -206,9 +189,6 @@ func hclNestedBlockBodies(body *sitter.Node, name string, src []byte) []*sitter.
 // hclAttrExpr returns the value expression of the attribute named name
 // declared directly inside body, or nil when there is none.
 func hclAttrExpr(body *sitter.Node, name string, src []byte) *sitter.Node {
-	if body == nil {
-		return nil
-	}
 	for i, nc := 0, int(body.ChildCount()); i < nc; i++ {
 		attr := body.Child(i)
 		if attr == nil || attr.Type() != "attribute" {

--- a/internal/contracts/terraform.go
+++ b/internal/contracts/terraform.go
@@ -1,0 +1,345 @@
+package contracts
+
+import (
+	"fmt"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	sitter "github.com/zzet/gortex/internal/parser/tsitter"
+	hclgrammar "github.com/zzet/gortex/internal/parser/tsitter/hcl"
+)
+
+// TerraformExtractor turns Terraform-declared environment values into
+// contract providers so a value defined in an infrastructure repo pairs
+// with the os.Getenv / process.env read that consumes it in a different
+// application repo.
+//
+// Coverage is deliberately one resource type: an aws_lambda_function's
+// `environment { variables = {...} }` map, where the declared key IS the
+// environment variable name the function sees at runtime. Other Terraform
+// config sources — bare variable/output blocks, kubernetes_config_map and
+// kubernetes_secret data keys — carry no such structural guarantee (a
+// ConfigMap key only becomes an env var if some Pod spec binds it via
+// envFrom/valueFrom, which this extractor doesn't inspect), so minting a
+// provider from them would assert a binding we can't verify. Those stay
+// graph-level only.
+type TerraformExtractor struct{}
+
+const terraformLambdaResource = "aws_lambda_function"
+
+// terraformPrefilterMarkers short-circuits the tree-sitter parse for the
+// overwhelming majority of .tf files, which declare no Lambda at all.
+var terraformPrefilterMarkers = [][]byte{[]byte(terraformLambdaResource)}
+
+func (e *TerraformExtractor) SupportedLanguages() []string { return []string{"hcl"} }
+
+// Extract parses src with the HCL grammar itself. The HCL language
+// extractor closes its own tree rather than handing it back on the
+// ExtractionResult, so the indexer has no tree to pass for .tf files —
+// same lazy-parse shape HTTPExtractor.Extract uses.
+func (e *TerraformExtractor) Extract(filePath string, src []byte, nodes []*graph.Node, _ []*graph.Edge) []Contract {
+	if !srcHasAnyMarker(src, terraformPrefilterMarkers) {
+		return nil
+	}
+	tree := parseHCLTree(src)
+	defer tree.Release()
+	return e.extract(filePath, src, nodes, tree)
+}
+
+// ExtractWithTree implements TreeAwareExtractor, consuming a parse tree
+// the caller already built instead of reparsing.
+func (e *TerraformExtractor) ExtractWithTree(
+	filePath string,
+	src []byte,
+	nodes []*graph.Node,
+	_ []*graph.Edge,
+	tree *parser.ParseTree,
+) []Contract {
+	if !srcHasAnyMarker(src, terraformPrefilterMarkers) {
+		return nil
+	}
+	return e.extract(filePath, src, nodes, tree)
+}
+
+func (e *TerraformExtractor) extract(filePath string, src []byte, nodes []*graph.Node, tree *parser.ParseTree) []Contract {
+	st := tree.Tree()
+	if st == nil {
+		return nil
+	}
+	root := st.RootNode()
+	if root == nil {
+		return nil
+	}
+
+	fileNodes := filterFileNodes(filePath, nodes)
+	var out []Contract
+	for _, block := range hclTopLevelBlocks(root) {
+		blockType, labels, body := hclBlockParts(block, src)
+		if blockType != "resource" || len(labels) < 2 || labels[0] != terraformLambdaResource || body == nil {
+			continue
+		}
+		address := labels[0] + "." + labels[1]
+		symbolID := hclBlockSymbolID(fileNodes, address)
+
+		for _, envBody := range hclNestedBlockBodies(body, "environment", src) {
+			obj := hclLiteralObject(hclAttrExpr(envBody, "variables", src))
+			for _, entry := range hclObjectKeys(obj, src) {
+				out = append(out, Contract{
+					ID:       fmt.Sprintf("env::%s", entry.name),
+					Type:     ContractEnv,
+					Role:     RoleProvider,
+					SymbolID: symbolID,
+					FilePath: filePath,
+					Line:     entry.line,
+					Meta: map[string]any{
+						"var":        entry.name,
+						"source":     "terraform",
+						"tf_address": address,
+					},
+					// Attribute-inferred rather than an unambiguous
+					// declaration, matching EnvVarExtractor's 0.95/0.9 split.
+					Confidence: 0.9,
+				})
+			}
+		}
+	}
+	return out
+}
+
+// parseHCLTree parses src with the HCL grammar. The caller owns the
+// returned handle and must Release it; nil on a parse failure.
+func parseHCLTree(src []byte) *parser.ParseTree {
+	if len(src) == 0 {
+		return nil
+	}
+	tree, err := parser.ParseFile(src, hclgrammar.GetLanguage())
+	if err != nil || tree == nil {
+		return nil
+	}
+	return parser.NewParseTree(tree, src, "hcl")
+}
+
+// hclBlockSymbolID returns the ID of the graph node the HCL language
+// extractor emitted for the block at the given Terraform address. HCL
+// blocks are graph.KindType nodes, so findEnclosingSymbol — which only
+// considers functions and methods — would silently return "" for every
+// Terraform contract.
+func hclBlockSymbolID(fileNodes []*graph.Node, address string) string {
+	for _, n := range fileNodes {
+		if n.Kind != graph.KindType {
+			continue
+		}
+		if addr, _ := n.Meta["tf_address"].(string); addr == address {
+			return n.ID
+		}
+	}
+	return ""
+}
+
+// hclTopLevelBlocks returns every block that isn't nested inside another
+// block, descending only the config_file / body wrappers.
+func hclTopLevelBlocks(root *sitter.Node) []*sitter.Node {
+	var out []*sitter.Node
+	var walk func(n *sitter.Node)
+	walk = func(n *sitter.Node) {
+		if n == nil {
+			return
+		}
+		for i, nc := 0, int(n.ChildCount()); i < nc; i++ {
+			child := n.Child(i)
+			if child == nil {
+				continue
+			}
+			switch child.Type() {
+			case "block":
+				out = append(out, child)
+			case "config_file", "body":
+				walk(child)
+			}
+		}
+	}
+	walk(root)
+	return out
+}
+
+// hclBlockParts splits a block into its type identifier, its string
+// labels, and its body — `resource "aws_lambda_function" "worker" {…}`
+// yields ("resource", ["aws_lambda_function", "worker"], body).
+func hclBlockParts(block *sitter.Node, src []byte) (blockType string, labels []string, body *sitter.Node) {
+	for i, nc := 0, int(block.ChildCount()); i < nc; i++ {
+		child := block.Child(i)
+		if child == nil {
+			continue
+		}
+		switch child.Type() {
+		case "identifier":
+			if blockType == "" {
+				blockType = child.Content(src)
+			}
+		case "string_lit":
+			if text := hclStringText(child, src); text != "" {
+				labels = append(labels, text)
+			}
+		case "body":
+			body = child
+		}
+	}
+	return blockType, labels, body
+}
+
+// hclNestedBlockBodies returns the bodies of every block named name
+// declared directly inside body.
+func hclNestedBlockBodies(body *sitter.Node, name string, src []byte) []*sitter.Node {
+	var out []*sitter.Node
+	for i, nc := 0, int(body.ChildCount()); i < nc; i++ {
+		child := body.Child(i)
+		if child == nil || child.Type() != "block" {
+			continue
+		}
+		if blockType, _, nested := hclBlockParts(child, src); blockType == name && nested != nil {
+			out = append(out, nested)
+		}
+	}
+	return out
+}
+
+// hclAttrExpr returns the value expression of the attribute named name
+// declared directly inside body, or nil when there is none.
+func hclAttrExpr(body *sitter.Node, name string, src []byte) *sitter.Node {
+	if body == nil {
+		return nil
+	}
+	for i, nc := 0, int(body.ChildCount()); i < nc; i++ {
+		attr := body.Child(i)
+		if attr == nil || attr.Type() != "attribute" {
+			continue
+		}
+		var key string
+		var expr *sitter.Node
+		for j, anc := 0, int(attr.ChildCount()); j < anc; j++ {
+			c := attr.Child(j)
+			if c == nil {
+				continue
+			}
+			switch c.Type() {
+			case "identifier":
+				if key == "" {
+					key = c.Content(src)
+				}
+			case "expression":
+				expr = c
+			}
+		}
+		if key == name {
+			return expr
+		}
+	}
+	return nil
+}
+
+// hclLiteralObject returns the object literal an expression evaluates to,
+// or nil when the expression is anything else. A `for` expression, a
+// merge(...) call, or a reference to a local map all parse to different
+// node types, and their individual keys aren't statically enumerable —
+// skipping them is the point, not a limitation to work around.
+func hclLiteralObject(expr *sitter.Node) *sitter.Node {
+	if expr == nil {
+		return nil
+	}
+	for i, nc := 0, int(expr.ChildCount()); i < nc; i++ {
+		coll := expr.Child(i)
+		if coll == nil || coll.Type() != "collection_value" {
+			continue
+		}
+		for j, cnc := 0, int(coll.ChildCount()); j < cnc; j++ {
+			if obj := coll.Child(j); obj != nil && obj.Type() == "object" {
+				return obj
+			}
+		}
+	}
+	return nil
+}
+
+type hclObjectKey struct {
+	name string
+	line int
+}
+
+// hclObjectKeys returns the statically known keys of an object literal.
+// Terraform accepts both a bare identifier and a quoted string as a key
+// and treats each as a literal name; anything else (a parenthesised
+// expression, an interpolated string) names no single key and is skipped.
+func hclObjectKeys(obj *sitter.Node, src []byte) []hclObjectKey {
+	if obj == nil {
+		return nil
+	}
+	var out []hclObjectKey
+	for i, nc := 0, int(obj.ChildCount()); i < nc; i++ {
+		elem := obj.Child(i)
+		if elem == nil || elem.Type() != "object_elem" {
+			continue
+		}
+		var keyExpr *sitter.Node
+		for j, enc := 0, int(elem.ChildCount()); j < enc; j++ {
+			if c := elem.Child(j); c != nil && c.Type() == "expression" {
+				keyExpr = c
+				break
+			}
+		}
+		// A single child means an undecorated name: a longer chain is a
+		// traversal like local.key, which names no literal key.
+		if keyExpr == nil || keyExpr.ChildCount() != 1 {
+			continue
+		}
+		var name string
+		switch head := keyExpr.Child(0); head.Type() {
+		case "variable_expr":
+			name = hclIdentifierText(head, src)
+		case "literal_value":
+			for j, hnc := 0, int(head.ChildCount()); j < hnc; j++ {
+				if lit := head.Child(j); lit != nil && lit.Type() == "string_lit" {
+					name = hclStringText(lit, src)
+				}
+			}
+		}
+		if name == "" {
+			continue
+		}
+		out = append(out, hclObjectKey{name: name, line: int(elem.StartPoint().Row) + 1})
+	}
+	return out
+}
+
+// hclIdentifierText returns the identifier a variable_expr names.
+func hclIdentifierText(varExpr *sitter.Node, src []byte) string {
+	for i, nc := 0, int(varExpr.ChildCount()); i < nc; i++ {
+		if c := varExpr.Child(i); c != nil && c.Type() == "identifier" {
+			return c.Content(src)
+		}
+	}
+	return ""
+}
+
+// hclStringText returns the text of a plain quoted string, or "" when the
+// string interpolates ("PREFIX_${var.env}") — a name assembled at plan
+// time isn't one this extractor can report.
+func hclStringText(lit *sitter.Node, src []byte) string {
+	var text string
+	for i, nc := 0, int(lit.ChildCount()); i < nc; i++ {
+		c := lit.Child(i)
+		if c == nil {
+			continue
+		}
+		switch c.Type() {
+		case "quoted_template_start", "quoted_template_end":
+		case "template_literal":
+			if text != "" {
+				return ""
+			}
+			text = c.Content(src)
+		default:
+			return ""
+		}
+	}
+	return text
+}

--- a/internal/contracts/terraform_test.go
+++ b/internal/contracts/terraform_test.go
@@ -224,11 +224,10 @@ func TestTerraformExtractor_SkipsNonLiteralVariableMaps(t *testing.T) {
 	}
 }
 
-// merge(local.base, { EXTRA = "1" }) is skipped wholesale above; this
-// pins that a Lambda whose map is partly literal doesn't leak the inline
-// object's keys while dropping the rest, which would report a partial
-// env set as if it were complete.
-func TestTerraformExtractor_MixedLiteralAndDynamicLambdas(t *testing.T) {
+// Two Lambdas in one file are attributed independently: the skipped
+// one contributes nothing, and the literal one's contract carries its
+// own tf_address rather than leaking the other's.
+func TestTerraformExtractor_ResourcesAreAttributedIndependently(t *testing.T) {
 	src := []byte(`resource "aws_lambda_function" "dynamic" {
   environment {
     variables = merge(local.base_env, { EXTRA = "1" })
@@ -270,7 +269,7 @@ func TestTerraformExtractor_ExtractWithTreeMatchesExtract(t *testing.T) {
 }
 `)
 	ext := &TerraformExtractor{}
-	tree := parseHCLTree(src)
+	tree := ParseTreeForLang("hcl", src)
 	defer tree.Release()
 
 	withTree := ext.ExtractWithTree("infra/lambda.tf", src, nil, nil, tree)

--- a/internal/contracts/terraform_test.go
+++ b/internal/contracts/terraform_test.go
@@ -1,0 +1,284 @@
+package contracts
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// lambdaResourceNode mirrors the KindType node the HCL language
+// extractor emits for a resource block, which is what the Terraform
+// contract's SymbolID anchors to.
+func lambdaResourceNode(filePath, address string) *graph.Node {
+	return &graph.Node{
+		ID:       "hcl::infra::" + address,
+		Kind:     graph.KindType,
+		Name:     "resource." + address,
+		FilePath: filePath,
+		Language: "hcl",
+		Meta:     map[string]any{"block_type": "resource", "tf_address": address},
+	}
+}
+
+func TestTerraformExtractor_LambdaEnvironmentVariables(t *testing.T) {
+	ext := &TerraformExtractor{}
+	src := []byte(`resource "aws_lambda_function" "processor" {
+  function_name = "processor"
+
+  environment {
+    variables = {
+      MAX_BATCH_SIZE = "100"
+      "QUEUE_URL"    = aws_sqs_queue.jobs.url
+    }
+  }
+}
+`)
+	nodes := []*graph.Node{lambdaResourceNode("infra/lambda.tf", "aws_lambda_function.processor")}
+
+	got := ext.Extract("infra/lambda.tf", src, nodes, nil)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 provider contracts, got %d: %+v", len(got), got)
+	}
+	assertContract(t, got[0], "env::MAX_BATCH_SIZE", ContractEnv, RoleProvider)
+	assertContract(t, got[1], "env::QUEUE_URL", ContractEnv, RoleProvider)
+
+	first := got[0]
+	if first.Confidence != 0.9 {
+		t.Errorf("expected confidence 0.9 (attribute-inferred), got %v", first.Confidence)
+	}
+	if first.Line != 6 {
+		t.Errorf("expected line 6, got %d", first.Line)
+	}
+	// A regression to findEnclosingSymbol would return "" here, since
+	// HCL blocks are KindType rather than KindFunction/KindMethod.
+	if first.SymbolID != "hcl::infra::aws_lambda_function.processor" {
+		t.Errorf("expected SymbolID anchored to the Lambda resource node, got %q", first.SymbolID)
+	}
+	if first.Meta["source"] != "terraform" {
+		t.Errorf("expected Meta[source]=terraform, got %v", first.Meta["source"])
+	}
+	if first.Meta["var"] != "MAX_BATCH_SIZE" {
+		t.Errorf("expected Meta[var]=MAX_BATCH_SIZE, got %v", first.Meta["var"])
+	}
+	// The indexer stamps these centrally; extractors must leave them unset.
+	if first.RepoPrefix != "" || first.WorkspaceID != "" || first.ProjectID != "" {
+		t.Errorf("expected repo/workspace/project unset by the extractor, got %+v", first)
+	}
+}
+
+func TestTerraformExtractor_PairsWithGetenvSameRepo(t *testing.T) {
+	tf := &TerraformExtractor{}
+	tfSrc := []byte(`resource "aws_lambda_function" "processor" {
+  environment {
+    variables = {
+      MAX_BATCH_SIZE = "100"
+    }
+  }
+}
+`)
+	goSrc := []byte(`package worker
+
+func batchSize() string {
+	return os.Getenv("MAX_BATCH_SIZE")
+}
+`)
+
+	reg := NewRegistry()
+	for _, c := range tf.Extract("infra/lambda.tf", tfSrc, nil, nil) {
+		c.RepoPrefix = "svc"
+		reg.Add(c)
+	}
+	for _, c := range (&EnvVarExtractor{}).Extract("worker/batch.go", goSrc, nil, nil) {
+		c.RepoPrefix = "svc"
+		reg.Add(c)
+	}
+
+	result := Match(reg)
+	if len(result.Matched) != 1 {
+		t.Fatalf("expected the Terraform provider to pair with os.Getenv; got %d matches, %d orphan providers, %d orphan consumers",
+			len(result.Matched), len(result.OrphanProviders), len(result.OrphanConsumers))
+	}
+	m := result.Matched[0]
+	if m.ContractID != "env::MAX_BATCH_SIZE" {
+		t.Errorf("expected env::MAX_BATCH_SIZE, got %q", m.ContractID)
+	}
+	if m.Provider.FilePath != "infra/lambda.tf" || m.Consumer.FilePath != "worker/batch.go" {
+		t.Errorf("unexpected pair: provider=%s consumer=%s", m.Provider.FilePath, m.Consumer.FilePath)
+	}
+	if m.CrossRepo {
+		t.Errorf("expected CrossRepo=false within one repo, got %+v", m)
+	}
+}
+
+func TestTerraformExtractor_PairsWithGetenvCrossRepo(t *testing.T) {
+	tf := &TerraformExtractor{}
+	tfSrc := []byte(`resource "aws_lambda_function" "processor" {
+  environment {
+    variables = {
+      MAX_BATCH_SIZE = "100"
+    }
+  }
+}
+`)
+	goSrc := []byte(`package worker
+
+func batchSize() string {
+	return os.Getenv("MAX_BATCH_SIZE")
+}
+`)
+
+	// Repo A declares the value in Terraform; repo B reads it. Both sit
+	// in one workspace, which is the boundary Match() pairs inside.
+	reg := NewRegistry()
+	for _, c := range tf.Extract("infra/lambda.tf", tfSrc, nil, nil) {
+		c.RepoPrefix = "acme-infra"
+		c.WorkspaceID = "acme"
+		c.ProjectID = "acme"
+		reg.Add(c)
+	}
+	for _, c := range (&EnvVarExtractor{}).Extract("worker/batch.go", goSrc, nil, nil) {
+		c.RepoPrefix = "acme-worker"
+		c.WorkspaceID = "acme"
+		c.ProjectID = "acme"
+		reg.Add(c)
+	}
+
+	result := Match(reg)
+	if len(result.Matched) != 1 {
+		t.Fatalf("expected 1 cross-repo match; got %d (%s)", len(result.Matched), summarisePairs(result))
+	}
+	m := result.Matched[0]
+	if !m.CrossRepo {
+		t.Fatalf("expected CrossRepo=true across acme-infra → acme-worker; got %+v", m)
+	}
+	if m.Provider.RepoPrefix != "acme-infra" || m.Consumer.RepoPrefix != "acme-worker" {
+		t.Errorf("unexpected pair: provider=%s consumer=%s", m.Provider.RepoPrefix, m.Consumer.RepoPrefix)
+	}
+}
+
+// Terraform config sources whose keys aren't structurally guaranteed to
+// be environment variables stay graph-level only. Minting providers from
+// them would assert a binding this extractor never verified.
+func TestTerraformExtractor_NoProviderForVariableOrConfigMapBlocks(t *testing.T) {
+	ext := &TerraformExtractor{}
+	src := []byte(`variable "chunk_size" {
+  default = 500
+}
+
+output "queue_url" {
+  value = aws_sqs_queue.jobs.url
+}
+
+resource "kubernetes_config_map" "settings" {
+  data = {
+    MAX_BATCH_SIZE = "100"
+  }
+}
+
+resource "aws_lambda_function" "anchor" {
+  function_name = "anchor"
+}
+`)
+	if got := ext.Extract("infra/main.tf", src, nil, nil); len(got) != 0 {
+		t.Fatalf("expected no contracts from variable/output/config-map blocks, got %+v", got)
+	}
+}
+
+func TestTerraformExtractor_IgnoresResourcesOutsideAllowlist(t *testing.T) {
+	ext := &TerraformExtractor{}
+	src := []byte(`resource "aws_instance" "web" {
+  environment {
+    variables = {
+      MAX_BATCH_SIZE = "100"
+    }
+  }
+}
+`)
+	if got := ext.Extract("infra/ec2.tf", src, nil, nil); len(got) != 0 {
+		t.Fatalf("expected no contracts from a non-allowlisted resource, got %+v", got)
+	}
+}
+
+func TestTerraformExtractor_SkipsNonLiteralVariableMaps(t *testing.T) {
+	cases := map[string]string{
+		"for expression": `variables = { for k, v in var.settings : k => v }`,
+		"merge call":     `variables = merge(local.base_env, { EXTRA = "1" })`,
+		"local map ref":  `variables = local.lambda_env`,
+		"interpolated key": `variables = {
+        "PREFIX_${var.stage}" = "1"
+      }`,
+	}
+	for name, attr := range cases {
+		t.Run(name, func(t *testing.T) {
+			src := []byte(`resource "aws_lambda_function" "processor" {
+  environment {
+    ` + attr + `
+  }
+}
+`)
+			got := (&TerraformExtractor{}).Extract("infra/lambda.tf", src, nil, nil)
+			if len(got) != 0 {
+				t.Fatalf("expected no contracts from a non-enumerable variables map, got %+v", got)
+			}
+		})
+	}
+}
+
+// merge(local.base, { EXTRA = "1" }) is skipped wholesale above; this
+// pins that a Lambda whose map is partly literal doesn't leak the inline
+// object's keys while dropping the rest, which would report a partial
+// env set as if it were complete.
+func TestTerraformExtractor_MixedLiteralAndDynamicLambdas(t *testing.T) {
+	src := []byte(`resource "aws_lambda_function" "dynamic" {
+  environment {
+    variables = merge(local.base_env, { EXTRA = "1" })
+  }
+}
+
+resource "aws_lambda_function" "literal" {
+  environment {
+    variables = {
+      MAX_BATCH_SIZE = "100"
+    }
+  }
+}
+`)
+	got := (&TerraformExtractor{}).Extract("infra/lambda.tf", src, nil, nil)
+	if len(got) != 1 {
+		t.Fatalf("expected only the literal Lambda's key, got %+v", got)
+	}
+	assertContract(t, got[0], "env::MAX_BATCH_SIZE", ContractEnv, RoleProvider)
+	if got[0].Meta["tf_address"] != "aws_lambda_function.literal" {
+		t.Errorf("expected the contract attributed to the literal Lambda, got %v", got[0].Meta["tf_address"])
+	}
+}
+
+func TestTerraformExtractor_SupportedLanguages(t *testing.T) {
+	langs := (&TerraformExtractor{}).SupportedLanguages()
+	if len(langs) != 1 || langs[0] != "hcl" {
+		t.Fatalf("expected the extractor to claim hcl only, got %v", langs)
+	}
+}
+
+func TestTerraformExtractor_ExtractWithTreeMatchesExtract(t *testing.T) {
+	src := []byte(`resource "aws_lambda_function" "processor" {
+  environment {
+    variables = {
+      MAX_BATCH_SIZE = "100"
+    }
+  }
+}
+`)
+	ext := &TerraformExtractor{}
+	tree := parseHCLTree(src)
+	defer tree.Release()
+
+	withTree := ext.ExtractWithTree("infra/lambda.tf", src, nil, nil, tree)
+	plain := ext.Extract("infra/lambda.tf", src, nil, nil)
+	if len(withTree) != 1 || len(plain) != 1 {
+		t.Fatalf("expected 1 contract from both paths, got %d and %d", len(withTree), len(plain))
+	}
+	if withTree[0].ID != plain[0].ID || withTree[0].Line != plain[0].Line {
+		t.Errorf("tree-aware and lazy-parse paths disagree: %+v vs %+v", withTree[0], plain[0])
+	}
+}

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -6070,6 +6070,7 @@ func (idx *Indexer) buildPerFileContractExtractors() ([]contracts.Extractor, map
 		&contracts.WebSocketExtractor{},
 		&contracts.NestMicroserviceExtractor{},
 		&contracts.EnvVarExtractor{},
+		&contracts.TerraformExtractor{},
 	}
 	// Config-driven event bus: only registered when the user declared
 	// boundaries (index.event_bus / CODEGRAPH_EVENT_CONFIG), so the default


### PR DESCRIPTION
## Summary

Adds a new `TreeAwareExtractor` (`internal/contracts/terraform.go`) that turns Terraform-declared Lambda environment variables into genuine cross-repo `Contract` providers — the actual deliverable described in #412 . A value declared in one repo's Terraform now pairs, through the existing unmodified `Match()` logic, with an `os.Getenv`/`process.env`/`os.environ`/`System.getenv` read in a *different* repo, including across workspace/project boundaries.

**This is the companion PR to #442** (the same-repo graph-level mirror, already open). The two are deliberately independent and separately mergeable — this PR does not depend on #442's code and touches none of the same files.

## Scope

Coverage is intentionally narrow: **`aws_lambda_function` resources' `environment { variables = {...} }` block only.** This is the one v1 Terraform shape where the declared key is structurally guaranteed to be the actual environment variable name, with no separate binding step. Bare `variable`/`output` blocks and `kubernetes_config_map`/`kubernetes_secret` `data` keys are deliberately excluded here — a ConfigMap/Secret key only becomes an env var if some Pod spec binds it via `envFrom`/`valueFrom`, which this extractor doesn't inspect, so minting a provider from them would assert a binding we can't verify. Those stay graph-level only (#442).

## What's in this PR

- `internal/contracts/terraform.go`: new `TreeAwareExtractor`, registered for `"hcl"`. Walks the parse tree directly (mirroring `HTTPExtractor`'s pattern) rather than depending on the HCL language extractor's own node emission. `SymbolID` is anchored to the enclosing Lambda resource's own HCL graph node (via `Meta["tf_address"]`) rather than the existing `findEnclosingSymbol` helper, which only considers `KindFunction`/`KindMethod` nodes and would silently produce an empty `SymbolID` for every Terraform contract.
- `internal/contracts/parse_helper.go`: `ParseTreeForLang` gains an `"hcl"` case alongside the existing `"go"` one, shared by the indexer's incremental re-walk and contract re-parse paths.
- `internal/indexer/indexer.go`: one-line registration in `buildPerFileContractExtractors`.
- Tests: happy path (including a `SymbolID` assertion that would catch a regression to the empty-string `findEnclosingSymbol` result), same-repo and cross-repo `Match()` pairing (mirroring `TestCrossWorkspaceContractMatching`), the negative case proving `variable`/`output`/ConfigMap blocks produce no contract, non-allowlisted resource types, non-literal/computed `variables` maps (`merge()`, `for`-expressions, `local` references, interpolated keys) skipped without erroring, per-resource attribution independence, and `ExtractWithTree`/`Extract` parity.

## Test plan

- [x] `go test ./internal/contracts/...` — new + existing tests pass
- [x] `go test -race ./...` — full suite passes (one unrelated pre-existing flake in `internal/gitcmd` — `TestConcurrencyCapNeverExceeded` / `TestCancelWhileWaitingForSlot` — confirmed to pass reliably in isolation and untouched by this diff, same full-suite-load timing sensitivity seen on #442)

## Known trade-offs (surfaced deliberately)

- **BLOCK-verdict behavior change.** New Terraform-sourced contracts feed the PR-review-gate's `computeContractImpact` the same as any other provider, so repos using Gortex's review gate may see new BLOCK findings that never fired before. This is intentional detection improvement, not a regression — confirmed with the maintainer on the issue thread.
- **Matching stays purely name-based.** `Match()` pairs `env::<name>` providers/consumers by string equality within a workspace/project scope, with no concept of deployment topology. Two unrelated Lambda functions in the same workspace declaring the same env var name (e.g. `TIMEOUT_SECONDS`) will be reported as matched even though they're unrelated. Pre-existing property of Gortex's whole env-var contract model, not introduced here — worth a caveat when interpreting a match.
- **Standing inconsistency with Kubernetes.** After both this PR and #442 ship, a `kubernetes_config_map`/`secret` defined via Terraform is visible to graph-level tooling but not to contract-level cross-repo matching, while the same resource read via raw K8s YAML is tracked by neither today. The maintainer previously flagged this as worth keeping connectable long-term rather than a permanent split — noted here as a deliberate near-term scope boundary, not an oversight.
- **`SymbolID` resolution considered, deferred.** Review raised routing `SymbolID` through a widened `findEnclosingSymbol` (parameterized to accept `graph.KindType`) instead of the current `Meta["tf_address"]` scan, for consistency with how every other contract type in this package resolves its symbol. `findEnclosingSymbol` anchors ~28 call sites across the package, so widening it is a bigger, separate change than this PR's scope warrants — flagging here in case a maintainer wants it done as its own follow-up.
- **Double-parse on the main index path.** `ParseTreeForLang` now supports `"hcl"`, which fixes `ExtractWithTree` actually firing on the indexer's incremental re-walk and contract-pass re-parse paths. The *main* full-index pass still reparses, because `internal/parser/languages/hcl.go`'s language extractor closes its own tree rather than exposing it on `ExtractionResult` (unlike the Go extractor). Fixing that changes tree-ownership lifecycle for the HCL extractor repo-wide and belongs in its own change, not this one.