### PR TITLE
fix(review): make gortex review report the findings its own engine detects

### DIFF
--- a/internal/mcp/tools_critique_review.go
+++ b/internal/mcp/tools_critique_review.go
@@ -192,7 +192,7 @@ func (s *Server) critiqueFindingsFor(ctx context.Context, req mcp.CallToolReques
 		if err != nil {
 			return nil, err
 		}
-		rulepack = s.reviewRulepackMatches(ctx, diff.ChangedFiles, allowedRepos)
+		rulepack = s.reviewRulepackMatches(ctx, diff.ChangedFiles, repoPrefix, allowedRepos)
 		impact = s.reviewImpact(diff.ChangedSymbols)
 		changedFiles = diff.ChangedFiles
 	}

--- a/internal/mcp/tools_review.go
+++ b/internal/mcp/tools_review.go
@@ -562,7 +562,7 @@ func (s *Server) handleReview(ctx context.Context, req mcp.CallToolRequest) (*mc
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
-		rulepack = s.reviewRulepackMatches(ctx, diff.ChangedFiles, allowedRepos)
+		rulepack = s.reviewRulepackMatches(ctx, diff.ChangedFiles, repoPrefix, allowedRepos)
 		impact = s.reviewImpact(diff.ChangedSymbols)
 		changedFiles = diff.ChangedFiles
 	}
@@ -609,7 +609,12 @@ func (s *Server) handleReview(ctx context.Context, req mcp.CallToolRequest) (*mc
 // the changed files and returns the surviving matches. It mirrors the analyze
 // review path (DetectorsByCategory("review") + GroundReviewMatches) but narrows
 // the AST targets to the changeset so the review tool only flags changed code.
-func (s *Server) reviewRulepackMatches(ctx context.Context, changedFiles []string, allowedRepos map[string]bool) []astquery.Match {
+//
+// repoPrefix bridges the two path vocabularies the narrowing spans: git names
+// changed files relative to the working tree while the graph keys every file
+// node "<prefix>/<rel>". Matches come back repo-relative — the spelling that
+// rule resolution, the per-file risk ranking, and the forge comment API speak.
+func (s *Server) reviewRulepackMatches(ctx context.Context, changedFiles []string, repoPrefix string, allowedRepos map[string]bool) []astquery.Match {
 	bundle := astquery.DetectorsByCategory("review")
 	if len(bundle) == 0 {
 		return nil
@@ -620,15 +625,9 @@ func (s *Server) reviewRulepackMatches(ctx context.Context, changedFiles []strin
 		return nil
 	}
 
-	// Narrow to the changed-file set (graph-relative paths) so the rulepack only
-	// scans the changeset, not the whole repository.
-	changed := make(map[string]bool, len(changedFiles))
-	for _, f := range changedFiles {
-		f = filepath.Clean(strings.TrimSpace(f))
-		if f != "" && f != "." {
-			changed[f] = true
-		}
-	}
+	// Narrow to the changed-file set so the rulepack only scans the changeset,
+	// not the whole repository.
+	changed := reviewChangedGraphPaths(changedFiles, repoPrefix)
 	if len(changed) == 0 {
 		return nil
 	}
@@ -669,8 +668,49 @@ func (s *Server) reviewRulepackMatches(ctx context.Context, changedFiles []strin
 
 	// Graph-grounding post-pass: drop the N+1 / check-then-act rows the resolved
 	// call / loop metadata refutes. This is the same FP-reduction the analyze
-	// review path applies.
-	return review.GroundReviewMatches(s.graph, collected)
+	// review path applies. Grounding keys off the match's symbol id, so the
+	// path is only rewritten once the rows that survive are known.
+	kept := review.GroundReviewMatches(s.graph, collected)
+	for i := range kept {
+		kept[i].File = reviewRepoRelPath(kept[i].File, repoPrefix)
+	}
+	return kept
+}
+
+// reviewChangedGraphPaths maps a changeset's file paths onto the vocabulary the
+// graph keys file nodes in. `git diff` names files relative to the working tree
+// while a multi-repo daemon keys every node "<prefix>/<rel>", so intersecting
+// the two spellings raw matched nothing: `review` reported zero findings on the
+// very code its own detector bundle flags under `analyze --kind review`.
+//
+// Only the prefixed spelling is admitted once a prefix applies — a bare
+// relative path would also match a same-named file in a sibling tracked repo.
+// Paths that already carry the prefix pass through unchanged, so a caller
+// holding graph-keyed paths (a changed symbol's FilePath) joins too.
+func reviewChangedGraphPaths(changedFiles []string, repoPrefix string) map[string]bool {
+	changed := make(map[string]bool, len(changedFiles))
+	for _, f := range changedFiles {
+		f = filepath.Clean(strings.TrimSpace(f))
+		if f == "" || f == "." {
+			continue
+		}
+		if repoPrefix != "" && !strings.HasPrefix(f, repoPrefix+"/") {
+			f = repoPrefix + "/" + f
+		}
+		changed[f] = true
+	}
+	return changed
+}
+
+// reviewRepoRelPath strips the graph repo prefix off a file path, returning the
+// repo-relative spelling the rest of the review pipeline speaks: the rule
+// resolver matches `.gortex.yaml` globs against it, rankFileRisk keys its rows
+// on it, and post_review hands it to the forge's comment API.
+func reviewRepoRelPath(path, repoPrefix string) string {
+	if repoPrefix == "" {
+		return path
+	}
+	return strings.TrimPrefix(path, repoPrefix+"/")
 }
 
 // testLangByExt maps a source-file extension onto the language family its
@@ -1069,7 +1109,7 @@ func (s *Server) handleReviewPack(ctx context.Context, req mcp.CallToolRequest) 
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
-		rulepack = s.reviewRulepackMatches(ctx, diff.ChangedFiles, allowedRepos)
+		rulepack = s.reviewRulepackMatches(ctx, diff.ChangedFiles, repoPrefix, allowedRepos)
 		impact = s.reviewImpact(diff.ChangedSymbols)
 		for _, cs := range diff.ChangedSymbols {
 			if cs.ID != "" {

--- a/internal/mcp/tools_review_post.go
+++ b/internal/mcp/tools_review_post.go
@@ -145,7 +145,7 @@ func (s *Server) postReviewFindingsFor(ctx context.Context, req mcp.CallToolRequ
 		if err != nil {
 			return nil, err
 		}
-		rulepack = s.reviewRulepackMatches(ctx, diff.ChangedFiles, allowedRepos)
+		rulepack = s.reviewRulepackMatches(ctx, diff.ChangedFiles, repoPrefix, allowedRepos)
 		impact = s.reviewImpact(diff.ChangedSymbols)
 		changedFiles = diff.ChangedFiles
 	}

--- a/internal/mcp/tools_review_rulepack_test.go
+++ b/internal/mcp/tools_review_rulepack_test.go
@@ -1,0 +1,167 @@
+package mcp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+	"github.com/zzet/gortex/internal/query"
+	"github.com/zzet/gortex/internal/search"
+)
+
+// reviewRulepackFixture is a Go source the `go-unchecked-type-assertion`
+// review detector fires on. It is deliberately not an N+1 / check-then-act
+// shape so the graph-grounding post-pass keeps the match unconditionally.
+const reviewRulepackFixture = `package pkg
+
+func Widen(v any) string {
+	s := v.(string)
+	return s
+}
+`
+
+// prefixedServerOver indexes an existing directory through the MultiIndexer
+// under the given repo name, so every graph node carries a repo prefix — the
+// daemon's shape, where file nodes are keyed "<prefix>/<rel>" while git emits
+// repo-relative paths. Returns the server and the graph repo prefix.
+func prefixedServerOver(t *testing.T, dir, name string) (*Server, string) {
+	t.Helper()
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	gc := &config.GlobalConfig{Repos: []config.RepoEntry{{Path: dir, Name: name}}}
+	gc.SetConfigPath(cfgPath)
+	require.NoError(t, gc.Save())
+
+	cm, err := config.NewConfigManager(cfgPath)
+	require.NoError(t, err)
+
+	reg := parser.NewRegistry()
+	reg.Register(languages.NewGoExtractor())
+
+	g := graph.New()
+	mi := indexer.NewMultiIndexer(g, reg, search.NewBM25(), cm, zap.NewNop())
+	_, err = mi.IndexAll()
+	require.NoError(t, err)
+
+	srv := NewServer(query.NewEngine(g), g, nil, nil, zap.NewNop(), nil, MultiRepoOptions{
+		ConfigManager: cm,
+		MultiIndexer:  mi,
+	})
+	srv.RunAnalysis()
+
+	// Precondition: the graph really is prefixed, otherwise these tests would
+	// pass for the wrong reason — the pre-fix join worked in unprefixed mode,
+	// which is exactly why the bug reached a release.
+	var prefix string
+	for n := range g.NodesByKind(graph.KindFile) {
+		require.NotEmpty(t, n.RepoPrefix, "file node %q must carry a repo prefix", n.ID)
+		prefix = n.RepoPrefix
+	}
+	require.NotEmpty(t, prefix, "fixture repo produced no indexed file nodes")
+	return srv, prefix
+}
+
+// setupPrefixedReviewServer writes the given repo-relative sources into a fresh
+// directory and indexes it prefixed.
+func setupPrefixedReviewServer(t *testing.T, files map[string]string) (*Server, string) {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "repo-a")
+	for rel, src := range files {
+		abs := filepath.Join(dir, filepath.FromSlash(rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(abs), 0o755))
+		require.NoError(t, os.WriteFile(abs, []byte(src), 0o644))
+	}
+	return prefixedServerOver(t, dir, "repo-a")
+}
+
+// TestReviewRulepackMatches_JoinsRepoRelativeChangedFiles pins the join the
+// review tool depends on: `git diff` names changed files repo-relative while
+// the graph keys them "<prefix>/<rel>", so intersecting the two vocabularies
+// raw matched nothing and `review` reported zero findings on code its own
+// detector bundle flags.
+func TestReviewRulepackMatches_JoinsRepoRelativeChangedFiles(t *testing.T) {
+	srv, prefix := setupPrefixedReviewServer(t, map[string]string{
+		"pkg/widget.go": reviewRulepackFixture,
+	})
+
+	matches := srv.reviewRulepackMatches(context.Background(), []string{"pkg/widget.go"}, prefix, nil)
+	require.NotEmpty(t, matches,
+		"repo-relative changed file must join the prefixed graph path %q/pkg/widget.go", prefix)
+
+	// Findings travel onward to rule resolution, the risk ranking, and the
+	// forge comment API — all of which speak repo-relative paths.
+	for _, m := range matches {
+		require.Equal(t, "pkg/widget.go", m.File,
+			"match paths must be repo-relative, not graph-prefixed")
+	}
+}
+
+// TestReviewRulepackMatches_IgnoresUnchangedFiles keeps the narrowing honest:
+// the rulepack must scan the changeset, not the whole repository.
+func TestReviewRulepackMatches_IgnoresUnchangedFiles(t *testing.T) {
+	srv, prefix := setupPrefixedReviewServer(t, map[string]string{
+		"pkg/widget.go": reviewRulepackFixture,
+		"pkg/other.go":  "package pkg\n\nfunc Other() {}\n",
+	})
+
+	matches := srv.reviewRulepackMatches(context.Background(), []string{"pkg/other.go"}, prefix, nil)
+	require.Empty(t, matches, "a file outside the changeset must not be scanned")
+}
+
+// TestReviewRulepackMatches_AcceptsAlreadyPrefixedChangedFiles covers the
+// callers that hand in graph-keyed paths (a changed symbol's FilePath) rather
+// than git's repo-relative spelling.
+func TestReviewRulepackMatches_AcceptsAlreadyPrefixedChangedFiles(t *testing.T) {
+	srv, prefix := setupPrefixedReviewServer(t, map[string]string{
+		"pkg/widget.go": reviewRulepackFixture,
+	})
+
+	matches := srv.reviewRulepackMatches(context.Background(),
+		[]string{prefix + "/pkg/widget.go"}, prefix, nil)
+	require.NotEmpty(t, matches, "an already-prefixed changed file must still join")
+	require.Equal(t, "pkg/widget.go", matches[0].File)
+}
+
+// TestReview_PrefixedGraphReportsRulepackFinding is the end-to-end regression
+// for the reported failure: against a prefixed graph — the only shape a daemon
+// produces — `review` returned `total: 0` on a changeset whose code the review
+// detector bundle flags under `analyze --kind review`. The BLOCK verdict it
+// paired that with carried nothing to act on.
+func TestReview_PrefixedGraphReportsRulepackFinding(t *testing.T) {
+	dir, file := reviewGitRepo(t)
+	srv, _ := prefixedServerOver(t, dir, "svc-repo")
+
+	out := decodeReview(t, callReview(t, srv, map[string]any{
+		"repo": dir,
+		"base": "base-ref",
+	}))
+
+	require.GreaterOrEqual(t, out.Total, 1,
+		"the planted inverted-err-check must surface; got %+v", out)
+	require.Equal(t, "BLOCK", out.Verdict, "an error-severity finding must block")
+
+	var found bool
+	for _, c := range out.Comments {
+		if c.Rule != "go-inverted-err-check" {
+			continue
+		}
+		found = true
+		require.Equal(t, filepath.ToSlash(file), filepath.ToSlash(c.File),
+			"the comment path must be repo-relative — a forge rejects a prefixed path")
+		require.Greater(t, c.Line, 0, "the finding must be anchored to a real line")
+		require.Equal(t, "rulepack", c.Source)
+	}
+	require.True(t, found, "expected a go-inverted-err-check finding; got %+v", out.Comments)
+
+	for _, fr := range out.FileRisk {
+		require.NotContains(t, fr.File, "svc-repo/", "risk rows stay repo-relative")
+	}
+}

--- a/internal/review/flow_test.go
+++ b/internal/review/flow_test.go
@@ -307,6 +307,47 @@ func TestRankFileRiskCoverageUnknown(t *testing.T) {
 	require.Zero(t, rows[0].Uncovered)
 }
 
+// TestRankFileRiskExemptsTestFilesFromCoverageDebt pins the exemption: a test
+// file's own symbols have no covering test by construction, so counting them
+// as uncovered was an unsatisfiable demand that pinned every branch touching
+// tests at BLOCK with nothing to fix. The blast-radius tier survives; only the
+// coverage debt is dropped, which caps the file's verdict contribution.
+func TestRankFileRiskExemptsTestFilesFromCoverageDebt(t *testing.T) {
+	diff := &analysis.DiffResult{
+		ChangedSymbols: []analysis.ChangedSymbol{
+			{ID: "tests/test_svc.py::test_a", FilePath: "tests/test_svc.py", Line: 1},
+			{ID: "pkg/svc_test.go::TestB", FilePath: "pkg/svc_test.go", Line: 1},
+			{ID: "pkg/svc.go::C", FilePath: "pkg/svc.go", Line: 1},
+		},
+		ChangedFiles: []string{"tests/test_svc.py", "pkg/svc_test.go", "pkg/svc.go"},
+	}
+	impact := map[string]*analysis.ImpactResult{
+		"tests/test_svc.py::test_a": {Risk: analysis.RiskCritical, TotalAffected: 80},
+		"pkg/svc_test.go::TestB":    {Risk: analysis.RiskCritical, TotalAffected: 40},
+		"pkg/svc.go::C":             {Risk: analysis.RiskCritical, TotalAffected: 12},
+	}
+	rows := rankFileRisk(diff, impact, nil, "", true)
+
+	byFile := map[string]FileRisk{}
+	for _, r := range rows {
+		byFile[r.File] = r
+	}
+	for _, f := range []string{"tests/test_svc.py", "pkg/svc_test.go"} {
+		require.Equal(t, 1, byFile[f].Symbols, "%s: the changed symbol is still counted", f)
+		require.Zero(t, byFile[f].Uncovered, "%s: a test file owes no covering test", f)
+		require.Equal(t, string(analysis.RiskCritical), byFile[f].Risk,
+			"%s: the blast-radius tier is a graph fact and stays", f)
+	}
+	require.Equal(t, 1, byFile["pkg/svc.go"].Uncovered, "production code still owes a covering test")
+
+	// The whole point: without the exemption the test files alone would block.
+	require.Equal(t, VerdictReview,
+		computeVerdict(nil, []FileRisk{byFile["tests/test_svc.py"], byFile["pkg/svc_test.go"]}),
+		"a changeset of test files alone must not BLOCK on unsatisfiable coverage debt")
+	require.Equal(t, VerdictBlock, computeVerdict(nil, []FileRisk{byFile["pkg/svc.go"]}),
+		"genuinely untested critical-risk production code still blocks")
+}
+
 // TestSummarizeCoveragePhrasing pins the four risk-driven headlines: untested
 // risk, fully covered risk, unattestable coverage, and coverage that simply
 // was not evaluated.

--- a/internal/review/report.go
+++ b/internal/review/report.go
@@ -41,7 +41,9 @@ type FileRisk struct {
 	// (total transitively affected symbols from the impact analysis).
 	Affected int `json:"affected,omitempty"`
 	// Symbols counts the changed symbols in this file with impact data;
-	// Uncovered counts how many of them have no covering test.
+	// Uncovered counts how many of them have no covering test. A test
+	// file's own symbols are never counted as uncovered — they are the
+	// coverage.
 	Symbols   int `json:"symbols,omitempty"`
 	Uncovered int `json:"uncovered,omitempty"`
 }
@@ -121,7 +123,9 @@ func worseVerdict(a, b Verdict) Verdict {
 // coverageKnown gates the coverage evidence: when the graph indexes no test
 // symbols at all, "no covering test" is blindness, not a finding — the rows
 // then carry no untested counts and the verdict keeps the conservative
-// ladder.
+// ladder. Test files are exempt from the coverage debt for the same reason:
+// a test function needs no test of its own, so counting one as missing is a
+// demand that can never be met.
 func rankFileRisk(diff *analysis.DiffResult, impact map[string]*analysis.ImpactResult, findings []Finding, repoPrefix string, coverageKnown bool) []FileRisk {
 	norm := func(file string) string {
 		file = cleanPath(file)
@@ -173,7 +177,14 @@ func rankFileRisk(diff *analysis.DiffResult, impact map[string]*analysis.ImpactR
 				}
 				if coverageKnown {
 					cov.symbols++
-					if ir == nil || len(ir.TestFiles) == 0 {
+					// A test file's own symbols need no covering test of
+					// their own, so "uncovered" is unsatisfiable for them:
+					// every changeset touching tests pinned those files at
+					// CRITICAL forever and blocked the branch with nothing
+					// actionable to fix. The detectors already exclude test
+					// files; the risk ranking now agrees. The row keeps its
+					// blast-radius tier — only the coverage debt is dropped.
+					if !analysis.IsTestFile(file) && (ir == nil || len(ir.TestFiles) == 0) {
 						cov.uncovered++
 					}
 				}


### PR DESCRIPTION
Fixes #434.

## The bug

`gortex review` returned `total: 0` on code where `gortex analyze --kind review` reported a finding — same repo, same daemon, same indexed file.

`reviewRulepackMatches` narrows the AST target set to the changeset by intersecting two path sets:

- `MapGitDiff(...).ChangedFiles` — repo-relative, as git emits them (`pkg/repro.py`)
- `buildASTTargets(...).GraphPath` — `node.FilePath`, which the daemon keys `<prefix>/<rel>` (`myrepo/pkg/repro.py`)

The two never intersect, so `targets` came back empty and the function returned `nil` before running a single detector. Confirmed on a prefixed fixture graph:

```
target graph_path="repo-a/pkg/widget.go"
matches with repo-relative changed file: 0
matches with PREFIXED changed file:      1   go-unchecked-type-assertion repo-a/pkg/widget.go:4
```

The practical failure mode is the one the issue calls out: against `--base main` the blast-radius ranking still produced rows, so the gate returned **BLOCK with zero findings** — false-positive and false-negative at once, with nothing actionable to fix.

### Why the existing end-to-end test passed

`indexedSiblingServer` indexes through the standalone `indexer.New`, which mints unprefixed paths — the one shape where the raw join works. Every daemon graph is prefixed.

## The fix

**1. Join the changeset onto the graph's path vocabulary.** `reviewRulepackMatches` now takes `repoPrefix` (already in scope at all four call sites — `review`, `review_pack`, `post_review`, `critique_review`) and prefixes changed files before narrowing. Only the prefixed spelling is admitted, so a changed file can't match a same-named file in a sibling tracked repo; already-prefixed input passes through.

Surviving matches are handed back **repo-relative**, the spelling the rest of the pipeline speaks: the rule resolver matches `.gortex.yaml` globs against it, `rankFileRisk` keys its rows on it, and `post_review` hands it to the forge's comment API. The rewrite happens after `GroundReviewMatches`, which keys off the match's symbol id.

**2. Exempt test files from the coverage debt** (the issue's secondary observation). The blast-radius ranking asked every changed file for a covering test, including test files — so `tests/test_svc.py` reported `uncovered=58/81` and sat at CRITICAL permanently, keeping any branch touching tests blocked with no edit that could clear it. Detectors already honour `exclude_tests`; the ranking now agrees. The row keeps its blast-radius tier and only the coverage debt is dropped, which caps a test file's contribution at REVIEW. Genuinely untested production code still blocks.

The issue also notes `pkg/module_b.py` reads `uncovered=8/8` despite having a passing dedicated test module. That is a separate question about Python test-edge attribution, not touched here.

## Tests

- `TestReviewRulepackMatches_JoinsRepoRelativeChangedFiles` — the join, on a MultiIndexer-indexed graph, asserting the graph really is prefixed before asserting anything else
- `TestReviewRulepackMatches_IgnoresUnchangedFiles` — narrowing stays honest; the rulepack scans the changeset, not the repo
- `TestReviewRulepackMatches_AcceptsAlreadyPrefixedChangedFiles` — graph-keyed input still joins
- `TestReview_PrefixedGraphReportsRulepackFinding` — end-to-end through `handleReview` over a real git repo indexed prefixed; reproduces the reported `total: 0` / empty `comments` without the fix
- `TestRankFileRiskExemptsTestFilesFromCoverageDebt` — test files carry no coverage debt and no longer BLOCK on their own; production code still does

`go build ./...`, `go test -race ./internal/review/... ./internal/mcp/... ./internal/analysis/... ./cmd/gortex/...`, `go vet`, and `golangci-lint run` are all clean.