### PR TITLE
Layer .gitignore from the git root down to a tracked subdirectory

### DIFF
--- a/docs/multi-repo.md
+++ b/docs/multi-repo.md
@@ -21,7 +21,9 @@ Two-tier config hierarchy:
 - **Global config** (`~/.gortex/config.yaml`) — projects, repo lists, active project, reference tags
 - **Workspace config** (`.gortex.yaml` per repo) — guards, excludes, local overrides
 
-Excludes are layered — builtin → repo's own `.gitignore` → global → per-repo entry → workspace — with gitignore semantics. The repo's `.gitignore` is respected by default so you don't have to re-declare entries already curated for git; opt out per-workspace with `respect_gitignore: false` in `.gortex.yaml`. Use `!pattern` in a later layer to re-include something an earlier layer excluded. Beyond `.gitignore`, the index walk also honors per-directory `.gortexignore` files (Gortex's own ignore file, a sibling to `.gitignore`) and ripgrep's `.ignore` / `.rgignore` — each scoped to the directory that contains it.
+Excludes are layered — builtin → the repo's `.gitignore` chain → global → per-repo entry → workspace — with gitignore semantics. `.gitignore` is respected by default so you don't have to re-declare entries already curated for git; opt out per-workspace with `respect_gitignore: false` in `.gortex.yaml`. Use `!pattern` in a later layer to re-include something an earlier layer excluded. Beyond `.gitignore`, the index walk also honors per-directory `.gortexignore` files (Gortex's own ignore file, a sibling to `.gitignore`) and ripgrep's `.ignore` / `.rgignore` — each scoped to the directory that contains it.
+
+When a tracked root sits below its git root — the monorepo case, `gortex track repo/projects/App` with the repository at `repo/` — every `.gitignore` from the git root down to the tracked root applies, as it would for git, with ancestor patterns re-anchored onto the tracked root. A deeper file overrides a shallower one, so a `!pattern` next to your code still wins over the repository-wide rule. Ancestor patterns that describe a sibling subtree are dropped, and so is one that would ignore the tracked root itself: you asked Gortex to index that directory explicitly.
 
 ```yaml
 # ~/.gortex/config.yaml

--- a/internal/config/gitignore.go
+++ b/internal/config/gitignore.go
@@ -8,27 +8,30 @@ import (
 	"unicode/utf8"
 )
 
-// loadRepoGitignore reads the `.gitignore` file at the repo root and
-// returns its entries as gitignore-syntax patterns ready to feed into
-// the excludes matcher. Blank lines and `#` comments are stripped.
+// loadRepoGitignore reads the `.gitignore` file in dir and returns its
+// entries as gitignore-syntax patterns ready to feed into the excludes
+// matcher. Blank lines and `#` comments are stripped.
 //
-// We deliberately do NOT walk the per-directory hierarchy here:
-//   - The repo-root file already covers ~95% of the value (build
-//     output, dependency caches, generated code).
-//   - Per-directory `.gitignore` semantics (path anchoring relative to
-//     the file's location) would require either nested matchers or a
-//     pattern-rewrite pass; both add complexity for marginal coverage.
+// Callers pass one directory at a time. gitignoreChain assembles the
+// upward chain — every `.gitignore` from the enclosing git root down to
+// the tracked root — and re-anchors ancestor patterns; this function only
+// parses one file.
+//
+// We deliberately do NOT walk *downward* into per-directory `.gitignore`
+// files here:
+//   - The files at and above the tracked root already cover ~95% of the
+//     value (build output, dependency caches, generated code).
 //   - Users with sub-directory ignores can list them in `.gortex.yaml`
-//     `excludes` until/unless we add hierarchy support.
+//     `excludes` until/unless we add downward hierarchy support.
 //
 // Returns nil when the file is absent or unreadable — gitignore reading
 // is a convenience, never a hard requirement, so a missing or
 // permission-denied file silently no-ops.
-func loadRepoGitignore(repoPath string) []string {
-	if repoPath == "" {
+func loadRepoGitignore(dir string) []string {
+	if dir == "" {
 		return nil
 	}
-	f, err := os.Open(filepath.Join(repoPath, ".gitignore"))
+	f, err := os.Open(filepath.Join(dir, ".gitignore"))
 	if err != nil {
 		return nil
 	}

--- a/internal/config/gitignore_cache.go
+++ b/internal/config/gitignore_cache.go
@@ -28,22 +28,24 @@ func (s gitignoreStat) equal(o gitignoreStat) bool {
 	return s.exists == o.exists && s.size == o.size && s.modTime.Equal(o.modTime)
 }
 
-// statGitignore returns the current staleness key for repoPath's root
-// `.gitignore`. A missing or unstattable file yields the zero
-// (exists=false) key, matching loadRepoGitignore's "absent → nil" contract.
-func statGitignore(repoPath string) gitignoreStat {
-	if repoPath == "" {
+// statGitignore returns the current staleness key for the `.gitignore` in
+// dir. A missing or unstattable file yields the zero (exists=false) key,
+// matching loadRepoGitignore's "absent → nil" contract.
+func statGitignore(dir string) gitignoreStat {
+	if dir == "" {
 		return gitignoreStat{}
 	}
-	info, err := os.Stat(filepath.Join(repoPath, ".gitignore"))
+	info, err := os.Stat(filepath.Join(dir, ".gitignore"))
 	if err != nil {
 		return gitignoreStat{}
 	}
 	return gitignoreStat{exists: true, modTime: info.ModTime(), size: info.Size()}
 }
 
-// gitignoreEntry caches the parsed patterns of one repo's `.gitignore`
-// alongside the stat key they were parsed from.
+// gitignoreEntry caches the parsed patterns of one `.gitignore` alongside
+// the stat key they were parsed from. Entries are keyed by the directory
+// holding the file, so two tracked roots under one git root share the
+// parse of their common ancestors.
 type gitignoreEntry struct {
 	stat     gitignoreStat
 	patterns []string // shared, immutable — callers must not mutate
@@ -59,28 +61,31 @@ type mergedEntry struct {
 	ws       *Config
 	repoPath string
 	respect  bool
-	giStat   gitignoreStat
+	chain    []gitignoreLayer
 	merged   []string // clipped, shared, immutable — callers must not mutate
 }
 
 // excludeCache memoizes the two per-call allocations ConfigManager.
 // EffectiveExclude previously repeated on every invocation:
 //
-//   - the parsed root `.gitignore`, keyed by repo root path (the dominant
-//     cost: a fresh 64 KiB scanner buffer plus a string per line, read on
-//     every call);
+//   - each parsed `.gitignore`, keyed by the directory holding it (the
+//     dominant cost: a fresh 64 KiB scanner buffer plus a string per line,
+//     read on every call);
 //   - the fully layered exclude list, keyed by repoPrefix (a fresh merge
 //     slice per call).
 //
-// A steady-state call does one os.Stat and returns shared, immutable
-// slices; the underlying file read and slice merge happen only when a
-// config pointer or the `.gitignore` stat actually changes.
+// A steady-state call does one os.Stat per `.gitignore` in the repo's
+// chain and returns shared, immutable slices; the underlying file reads,
+// pattern re-anchoring, and slice merge happen only when a config pointer
+// or one of the chain's stats actually changes.
 type excludeCache struct {
 	mu        sync.RWMutex
-	gitignore map[string]*gitignoreEntry // repo root path → parsed .gitignore
-	merged    map[string]*mergedEntry    // repoPrefix → layered excludes
-	// readFn reads a repo's root `.gitignore`. nil selects loadRepoGitignore;
-	// tests substitute a counting reader to assert cache hits never re-read.
+	gitignore map[string]*gitignoreEntry  // .gitignore's directory → parsed patterns
+	merged    map[string]*mergedEntry     // repoPrefix → layered excludes
+	chains    map[string][]gitignoreLayer // tracked root → chain shape (dirs, no stats)
+	// readFn reads the `.gitignore` in a directory. nil selects
+	// loadRepoGitignore; tests substitute a counting reader to assert cache
+	// hits never re-read.
 	readFn func(string) []string
 }
 
@@ -95,48 +100,91 @@ func newExcludeCache() *excludeCache {
 	return &excludeCache{
 		gitignore: make(map[string]*gitignoreEntry),
 		merged:    make(map[string]*mergedEntry),
+		chains:    make(map[string][]gitignoreLayer),
 	}
 }
 
-func (c *excludeCache) read(repoPath string) []string {
+// chain returns the repo's `.gitignore` chain with freshly read stat keys.
+//
+// The chain's *shape* — which directories hold a `.gitignore` git would
+// apply — is discovered once per tracked root and reused, because it moves
+// only when a `.git` appears or disappears above the tracked root. That
+// walk is the expensive half (an os.Lstat per level, all the way to `/` for
+// a root outside any repository), and it runs on the same firehose of calls
+// the merged cache exists to protect. Every call still re-stats each
+// member, so an edit to any file in the chain is seen immediately;
+// forgetChain re-runs the discovery when a repo is (re)tracked.
+func (c *excludeCache) chain(repoPath string) []gitignoreLayer {
+	if repoPath == "" {
+		return nil
+	}
+	c.mu.RLock()
+	shape, ok := c.chains[repoPath]
+	c.mu.RUnlock()
+	if !ok {
+		shape = gitignoreChainShape(repoPath)
+		c.mu.Lock()
+		if len(c.chains) >= excludeCacheCap {
+			c.chains = make(map[string][]gitignoreLayer)
+		}
+		c.chains[repoPath] = shape
+		c.mu.Unlock()
+	}
+	return stampGitignoreStats(shape)
+}
+
+// forgetChain drops the memoized chain shape for a tracked root so the next
+// EffectiveExclude rediscovers it. Called whenever a repo's path is
+// published (track, reindex, config refresh) — the points at which a `.git`
+// above it could plausibly have appeared or moved.
+func (c *excludeCache) forgetChain(repoPath string) {
+	if repoPath == "" {
+		return
+	}
+	c.mu.Lock()
+	delete(c.chains, repoPath)
+	c.mu.Unlock()
+}
+
+func (c *excludeCache) read(dir string) []string {
 	if c.readFn != nil {
-		return c.readFn(repoPath)
+		return c.readFn(dir)
 	}
-	return loadRepoGitignore(repoPath)
+	return loadRepoGitignore(dir)
 }
 
-// patterns returns the shared, immutable parsed patterns of repoPath's
-// root `.gitignore` for the given (already-computed) stat key, re-reading
-// only when the file changed. An absent file returns nil without opening
-// anything.
-func (c *excludeCache) patterns(repoPath string, st gitignoreStat) []string {
+// patterns returns the shared, immutable parsed patterns of the
+// `.gitignore` in dir for the given (already-computed) stat key,
+// re-reading only when the file changed. An absent file returns nil
+// without opening anything.
+func (c *excludeCache) patterns(dir string, st gitignoreStat) []string {
 	if !st.exists {
 		return nil
 	}
 	c.mu.RLock()
-	e := c.gitignore[repoPath]
+	e := c.gitignore[dir]
 	c.mu.RUnlock()
 	if e != nil && e.stat.equal(st) {
 		return e.patterns
 	}
-	patterns := c.read(repoPath)
+	patterns := c.read(dir)
 	c.mu.Lock()
 	if len(c.gitignore) >= excludeCacheCap {
 		c.gitignore = make(map[string]*gitignoreEntry)
 	}
-	c.gitignore[repoPath] = &gitignoreEntry{stat: st, patterns: patterns}
+	c.gitignore[dir] = &gitignoreEntry{stat: st, patterns: patterns}
 	c.mu.Unlock()
 	return patterns
 }
 
 // lookupMerged returns the cached layered exclude list for repoPrefix when
 // it is still valid for the given config pointers, respect flag, and
-// `.gitignore` stat. The returned slice is shared — callers must not mutate.
-func (c *excludeCache) lookupMerged(repoPrefix string, gc *GlobalConfig, ws *Config, repoPath string, respect bool, st gitignoreStat) ([]string, bool) {
+// `.gitignore` chain. The returned slice is shared — callers must not mutate.
+func (c *excludeCache) lookupMerged(repoPrefix string, gc *GlobalConfig, ws *Config, repoPath string, respect bool, chain []gitignoreLayer) ([]string, bool) {
 	c.mu.RLock()
 	e := c.merged[repoPrefix]
 	c.mu.RUnlock()
-	if e != nil && e.gc == gc && e.ws == ws && e.repoPath == repoPath && e.respect == respect && e.giStat.equal(st) {
+	if e != nil && e.gc == gc && e.ws == ws && e.repoPath == repoPath && e.respect == respect && equalGitignoreChains(e.chain, chain) {
 		return e.merged, true
 	}
 	return nil, false
@@ -145,7 +193,7 @@ func (c *excludeCache) lookupMerged(repoPrefix string, gc *GlobalConfig, ws *Con
 // storeMerged records the layered exclude list for repoPrefix. merged must
 // be clipped (len == cap) by the caller so a consumer appending to it is
 // forced to reallocate and can never write through the shared backing array.
-func (c *excludeCache) storeMerged(repoPrefix string, gc *GlobalConfig, ws *Config, repoPath string, respect bool, st gitignoreStat, merged []string) {
+func (c *excludeCache) storeMerged(repoPrefix string, gc *GlobalConfig, ws *Config, repoPath string, respect bool, chain []gitignoreLayer, merged []string) {
 	c.mu.Lock()
 	if len(c.merged) >= excludeCacheCap {
 		c.merged = make(map[string]*mergedEntry)
@@ -155,7 +203,7 @@ func (c *excludeCache) storeMerged(repoPrefix string, gc *GlobalConfig, ws *Conf
 		ws:       ws,
 		repoPath: repoPath,
 		respect:  respect,
-		giStat:   st,
+		chain:    chain,
 		merged:   merged,
 	}
 	c.mu.Unlock()

--- a/internal/config/gitignore_cache_test.go
+++ b/internal/config/gitignore_cache_test.go
@@ -257,6 +257,46 @@ func BenchmarkEffectiveExclude(b *testing.B) {
 	}
 }
 
+// benchSetupLayout builds a repo `depth` directories below its git root and
+// tracks the deepest one, so the benchmark quotes the steady-state cost of
+// the chain walk for each real-world layout. depth 0 is the common case
+// (tracked root == git root); depth 2 is the monorepo the chain exists for.
+func benchSetupLayout(b *testing.B, depth int) *ConfigManager {
+	b.Helper()
+	cm, err := NewConfigManager("/tmp/nonexistent-gortex-cache-bench/config.yaml")
+	require.NoError(b, err)
+	root := b.TempDir()
+	require.NoError(b, os.MkdirAll(filepath.Join(root, ".git"), 0o755))
+	require.NoError(b, os.WriteFile(filepath.Join(root, ".gitignore"), []byte(benchGitignore), 0o644))
+	tracked := root
+	for i := 0; i < depth; i++ {
+		tracked = filepath.Join(tracked, "nested")
+	}
+	require.NoError(b, os.MkdirAll(tracked, 0o755))
+	cm.LoadWorkspaceConfig("r", tracked)
+	return cm
+}
+
+func BenchmarkEffectiveExcludeAtGitRoot(b *testing.B) {
+	cm := benchSetupLayout(b, 0)
+	cm.EffectiveExclude("r")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = cm.EffectiveExclude("r")
+	}
+}
+
+func BenchmarkEffectiveExcludeBelowGitRoot(b *testing.B) {
+	cm := benchSetupLayout(b, 2)
+	cm.EffectiveExclude("r")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = cm.EffectiveExclude("r")
+	}
+}
+
 func BenchmarkEffectiveExcludeUncached(b *testing.B) {
 	cm := benchSetup(b)
 	cm.mu.RLock()

--- a/internal/config/gitignore_chain.go
+++ b/internal/config/gitignore_chain.go
@@ -1,0 +1,295 @@
+package config
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// maxGitignoreChainDepth bounds the walk from the tracked root up towards
+// the git root. A tracked root nested deeper than this below its repository
+// is pathological; rather than keep statting, the walk gives up and falls
+// back to the tracked root's own `.gitignore`.
+const maxGitignoreChainDepth = 64
+
+// gitignoreLayer is one `.gitignore` file that git would apply to content
+// under the tracked root.
+//
+//   - dir is the directory holding the file.
+//   - sub is the tracked root's path relative to dir, slash-separated and
+//     empty for the tracked root's own file. Patterns from an ancestor file
+//     are re-anchored through sub before they join the merged list.
+//   - stat is the staleness key for dir/.gitignore.
+type gitignoreLayer struct {
+	dir  string
+	sub  string
+	stat gitignoreStat
+}
+
+func (l gitignoreLayer) equal(o gitignoreLayer) bool {
+	return l.dir == o.dir && l.sub == o.sub && l.stat.equal(o.stat)
+}
+
+// equalGitignoreChains compares two chains element-wise. A layer appearing,
+// disappearing, or changing content all invalidate the merged exclude list.
+func equalGitignoreChains(a, b []gitignoreLayer) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !a[i].equal(b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// gitignoreChainShape returns the directories whose `.gitignore` git would
+// apply to paths under repoPath, outermost first — the order the merged
+// matcher needs, since the last matching pattern wins and git lets a deeper
+// file override a shallower one. Stat keys are left unset; stampGitignore
+// Stats fills them.
+//
+// Git applies ignore files from the repository root downward. Gortex is
+// routinely pointed at a subdirectory of a repository (the monorepo case:
+// git root at `repo/`, tracked root at `repo/projects/App`), so reading
+// only the tracked root's own file silently drops the entire ignore layer
+// the user wrote. The walk therefore climbs to the nearest enclosing `.git`
+// and includes every directory on the way down.
+//
+// When repoPath is not inside a git repository at all, only its own
+// `.gitignore` applies — ancestor files outside a repository are not
+// something git would honour either.
+func gitignoreChainShape(repoPath string) []gitignoreLayer {
+	if repoPath == "" {
+		return nil
+	}
+	self := gitignoreLayer{dir: repoPath}
+	ancestors := gitRootAncestors(repoPath)
+	if len(ancestors) == 0 {
+		return []gitignoreLayer{self}
+	}
+	out := make([]gitignoreLayer, 0, len(ancestors)+1)
+	for _, dir := range ancestors {
+		sub, err := filepath.Rel(dir, repoPath)
+		if err != nil {
+			continue
+		}
+		out = append(out, gitignoreLayer{dir: dir, sub: filepath.ToSlash(sub)})
+	}
+	return append(out, self)
+}
+
+// stampGitignoreStats returns a copy of shape with each layer's staleness
+// key read fresh from disk. The shape is discovered once per repo path and
+// reused; the stats are what every call re-reads, so an edit to any file in
+// the chain is picked up immediately.
+func stampGitignoreStats(shape []gitignoreLayer) []gitignoreLayer {
+	if len(shape) == 0 {
+		return nil
+	}
+	out := make([]gitignoreLayer, len(shape))
+	copy(out, shape)
+	for i := range out {
+		out[i].stat = statGitignore(out[i].dir)
+	}
+	return out
+}
+
+// gitignoreChain discovers the chain and stats it in one step. Callers on
+// the hot path go through excludeCache.chain instead, which reuses the
+// discovered shape.
+func gitignoreChain(repoPath string) []gitignoreLayer {
+	return stampGitignoreStats(gitignoreChainShape(repoPath))
+}
+
+// gitRootAncestors returns the directories from the git root down to (but
+// excluding) repoPath, outermost first. It returns nil when repoPath is
+// itself the git root, when no `.git` is found above it, or when the walk
+// exceeds maxGitignoreChainDepth.
+//
+// Only `.git`'s presence is tested, never its type: it is a directory in a
+// normal clone and a file in a linked worktree or submodule, and both mark
+// a root whose ignore files apply downward.
+func gitRootAncestors(repoPath string) []string {
+	if isGitRoot(repoPath) {
+		return nil
+	}
+	var up []string
+	dir := repoPath
+	for depth := 0; depth < maxGitignoreChainDepth; depth++ {
+		parent := filepath.Dir(dir)
+		if parent == dir || parent == "" {
+			return nil // filesystem root: repoPath is not inside a repository
+		}
+		up = append(up, parent)
+		if isGitRoot(parent) {
+			for i, j := 0, len(up)-1; i < j; i, j = i+1, j-1 {
+				up[i], up[j] = up[j], up[i]
+			}
+			return up
+		}
+		dir = parent
+	}
+	return nil
+}
+
+func isGitRoot(dir string) bool {
+	_, err := os.Lstat(filepath.Join(dir, ".git"))
+	return err == nil
+}
+
+// reanchorGitignore rewrites the patterns of a `.gitignore` that sits above
+// the tracked root so they carry the same meaning when matched against
+// tracked-root-relative paths. sub is the tracked root's path relative to
+// the file's directory; an empty sub (the tracked root's own file) returns
+// the patterns untouched.
+func reanchorGitignore(patterns []string, sub string) []string {
+	subSegs := splitPathSegments(sub)
+	if len(subSegs) == 0 {
+		return patterns
+	}
+	out := make([]string, 0, len(patterns))
+	for _, p := range patterns {
+		out = append(out, reanchorPattern(p, subSegs)...)
+	}
+	return out
+}
+
+// reanchorPattern translates one ancestor pattern into the equivalent
+// pattern(s) relative to the tracked root, returning nothing when the
+// pattern cannot describe anything inside it.
+//
+// Two cases, mirroring git's own split:
+//
+//   - A pattern with no separator (beyond a trailing one) is unanchored:
+//     git matches it at every depth below the file's directory, which
+//     includes every depth below the tracked root. It carries over verbatim.
+//   - A pattern with a separator is anchored to the file's directory, so it
+//     only survives if it can consume the whole of sub first; what remains
+//     is re-anchored at the tracked root.
+//
+// A pattern that swallows the tracked root itself (`/projects/app/`, or an
+// ancestor of it) is dropped rather than turned into a blanket exclude: the
+// user asked Gortex to track that directory explicitly, and honouring the
+// ignore would empty the index of the very repo they pointed at.
+func reanchorPattern(pattern string, subSegs []string) []string {
+	body := strings.TrimSpace(pattern)
+	if body == "" || strings.HasPrefix(body, "#") {
+		return nil
+	}
+	negated := strings.HasPrefix(body, "!")
+	if negated {
+		body = body[1:]
+	}
+	dirOnly := strings.HasSuffix(body, "/")
+	body = strings.TrimSuffix(body, "/")
+	if body == "" {
+		return nil
+	}
+	if !strings.Contains(body, "/") {
+		return []string{pattern}
+	}
+
+	segs := splitPathSegments(body)
+	if len(segs) == 0 {
+		return nil
+	}
+	var out []string
+	for _, rem := range anchoredRemainders(segs, subSegs) {
+		p := strings.Join(rem, "/")
+		// A remainder still led by "**" already means "at any depth"; the
+		// rest stay anchored at the tracked root with a leading slash.
+		if rem[0] != "**" {
+			p = "/" + p
+		}
+		if dirOnly {
+			p += "/"
+		}
+		if negated {
+			p = "!" + p
+		}
+		if !slices.Contains(out, p) {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// anchoredRemainders returns every suffix of pat that is left to match
+// beneath the tracked root after pat's leading segments have consumed the
+// whole of sub. Multiple suffixes can qualify because "**" matches zero or
+// more segments and may keep matching below the tracked root.
+//
+// reach[i][j] means "pat[:i] can consume sub[:j]", with "**" modelled as a
+// self-loop that stays at i while advancing j. Every transition increases
+// i+j, so a single ascending sweep settles it — and bounds a pattern packed
+// with "**" to O(len(pat)*len(sub)) work instead of exponential branching.
+func anchoredRemainders(pat, sub []string) [][]string {
+	reach := make([][]bool, len(pat)+1)
+	for i := range reach {
+		reach[i] = make([]bool, len(sub)+1)
+	}
+	reach[0][0] = true
+	for i := 0; i < len(pat); i++ {
+		for j := 0; j <= len(sub); j++ {
+			if !reach[i][j] {
+				continue
+			}
+			if pat[i] == "**" {
+				reach[i+1][j] = true
+				if j < len(sub) {
+					reach[i][j+1] = true
+				}
+				continue
+			}
+			if j < len(sub) && segmentMatches(pat[i], sub[j]) {
+				reach[i+1][j+1] = true
+			}
+		}
+	}
+	var out [][]string
+	// i == len(pat) is deliberately excluded: an exhausted pattern means it
+	// named the tracked root (or an ancestor) rather than something inside it.
+	for i := 0; i < len(pat); i++ {
+		if !reach[i][len(sub)] {
+			continue
+		}
+		// pat[i:] led by "**" already matches at any depth, so the suffix
+		// starting one segment later says nothing new. Emitting both would
+		// only pad the merged list.
+		if i > 0 && pat[i-1] == "**" && reach[i-1][len(sub)] {
+			continue
+		}
+		out = append(out, pat[i:])
+	}
+	return out
+}
+
+// segmentMatches reports whether one gitignore path segment matches one
+// concrete directory name. path.Match carries the glob semantics gitignore
+// uses within a segment ('*' and '?' never cross a separator, '[...]'
+// classes); a malformed class is treated as matching nothing, the same way
+// git's own matcher fails closed.
+func segmentMatches(pattern, name string) bool {
+	ok, err := path.Match(pattern, name)
+	return err == nil && ok
+}
+
+func splitPathSegments(p string) []string {
+	p = filepath.ToSlash(strings.TrimSpace(p))
+	if p == "" || p == "." {
+		return nil
+	}
+	parts := strings.Split(p, "/")
+	out := make([]string, 0, len(parts))
+	for _, s := range parts {
+		if s == "" || s == "." {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}

--- a/internal/config/gitignore_chain_test.go
+++ b/internal/config/gitignore_chain_test.go
@@ -1,0 +1,461 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/excludes"
+)
+
+// mkGitRepo marks dir as a git repository root by planting a `.git`
+// directory — enough for the chain walk, which only tests for presence.
+func mkGitRepo(t *testing.T, dir string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o755))
+}
+
+func mkDir(t *testing.T, parts ...string) string {
+	t.Helper()
+	dir := filepath.Join(parts...)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	return dir
+}
+
+// excludeMatcher builds the matcher the indexer and watcher would use for
+// the tracked root, so assertions read as "would this path be indexed".
+func excludeMatcher(t *testing.T, cm *ConfigManager, prefix string) *excludes.Matcher {
+	t.Helper()
+	return excludes.New(cm.EffectiveExclude(prefix))
+}
+
+// TestEffectiveExclude_GitignoreAboveTrackedRoot is the issue repro: a
+// monorepo whose git root sits above the tracked root. Git applies the
+// root `.gitignore` to everything below it, so tracking a subdirectory
+// must not silently drop the whole ignore layer.
+func TestEffectiveExclude_GitignoreAboveTrackedRoot(t *testing.T) {
+	root := t.TempDir()
+	mkGitRepo(t, root)
+	writeGitignore(t, root, "junk/\n*.log\n")
+	app := mkDir(t, root, "projects", "app")
+
+	cm := newTestConfigManager(t)
+	cm.LoadWorkspaceConfig("r", app)
+
+	m := excludeMatcher(t, cm, "r")
+	assert.True(t, m.MatchRel("junk/noise.txt"),
+		"an unanchored ancestor pattern must apply below the tracked root")
+	assert.True(t, m.MatchRel("nested/junk/noise.txt"),
+		"an unanchored ancestor pattern matches at any depth, as git does")
+	assert.True(t, m.MatchRel("build.log"))
+	assert.False(t, m.MatchRel("Real.cs"), "real source must stay indexable")
+}
+
+// A .NET-shaped monorepo: the git root's ignore file carries exactly the
+// entries the issue reports as missing.
+func TestEffectiveExclude_DotNetMonorepoLayout(t *testing.T) {
+	root := t.TempDir()
+	mkGitRepo(t, root)
+	writeGitignore(t, root, "[Oo]bj/\n[Bb]in/\n.vs/\n")
+	app := mkDir(t, root, "src", "Solution", "App")
+
+	cm := newTestConfigManager(t)
+	cm.LoadWorkspaceConfig("r", app)
+
+	m := excludeMatcher(t, cm, "r")
+	for _, p := range []string{
+		"obj/Debug/net8.0/App.AssemblyInfo.cs",
+		"obj/project.assets.json",
+		"bin/Release/net8.0/App.deps.json",
+		".vs/App/v17/HierarchyCache.v1.txt",
+	} {
+		assert.Truef(t, m.MatchRel(p), "build artifact %q must stay out of the index", p)
+	}
+	assert.False(t, m.MatchRel("Controllers/HomeController.cs"))
+}
+
+// An anchored ancestor pattern only survives if it can consume the whole
+// path from its own directory down to the tracked root; what is left is
+// re-anchored at the tracked root rather than left matching at any depth.
+func TestEffectiveExclude_AncestorAnchoredPatternIsReanchored(t *testing.T) {
+	root := t.TempDir()
+	mkGitRepo(t, root)
+	writeGitignore(t, root, "/projects/app/generated/\n")
+	app := mkDir(t, root, "projects", "app")
+
+	cm := newTestConfigManager(t)
+	cm.LoadWorkspaceConfig("r", app)
+
+	m := excludeMatcher(t, cm, "r")
+	assert.True(t, m.MatchRel("generated/api.cs"),
+		"the anchored ancestor pattern must land on the tracked root")
+	assert.False(t, m.MatchRel("src/generated/api.cs"),
+		"re-anchoring must stay anchored, not degrade to any-depth matching")
+}
+
+// An anchored pattern aimed at a sibling subtree describes nothing inside
+// the tracked root and must not leak into its exclude list.
+func TestEffectiveExclude_AncestorPatternForSiblingIsDropped(t *testing.T) {
+	root := t.TempDir()
+	mkGitRepo(t, root)
+	writeGitignore(t, root, "/projects/other/\n/tools/gen/\n")
+	app := mkDir(t, root, "projects", "app")
+
+	cm := newTestConfigManager(t)
+	cm.LoadWorkspaceConfig("r", app)
+
+	m := excludeMatcher(t, cm, "r")
+	assert.False(t, m.MatchRel("other/thing.cs"))
+	assert.False(t, m.MatchRel("gen/thing.cs"))
+	assert.False(t, m.MatchRel("Real.cs"))
+}
+
+// An ancestor pattern that ignores the tracked root itself is dropped: the
+// user pointed Gortex at that directory explicitly, and honouring the
+// ignore would empty the index of the very repo they asked for.
+func TestEffectiveExclude_PatternSwallowingTrackedRootIsDropped(t *testing.T) {
+	for _, pattern := range []string{"/projects/app/", "/projects/", "projects/app"} {
+		t.Run(pattern, func(t *testing.T) {
+			root := t.TempDir()
+			mkGitRepo(t, root)
+			writeGitignore(t, root, pattern+"\n")
+			app := mkDir(t, root, "projects", "app")
+
+			cm := newTestConfigManager(t)
+			cm.LoadWorkspaceConfig("r", app)
+
+			m := excludeMatcher(t, cm, "r")
+			assert.False(t, m.MatchRel("Real.cs"),
+				"an explicitly tracked root must stay indexable")
+			assert.False(t, m.MatchRel("src/Real.cs"))
+		})
+	}
+}
+
+// `**` matches zero or more directories, so an ancestor pattern can reach
+// into the tracked root at more than one depth. Both readings must survive
+// re-anchoring.
+func TestEffectiveExclude_AncestorDoubleStarPattern(t *testing.T) {
+	root := t.TempDir()
+	mkGitRepo(t, root)
+	writeGitignore(t, root, "projects/**/artifacts/\n**/coverage/\n")
+	app := mkDir(t, root, "projects", "app")
+
+	cm := newTestConfigManager(t)
+	cm.LoadWorkspaceConfig("r", app)
+
+	m := excludeMatcher(t, cm, "r")
+	assert.True(t, m.MatchRel("artifacts/gen.cs"), "`**` may consume exactly the tracked root")
+	assert.True(t, m.MatchRel("deep/nested/artifacts/gen.cs"), "`**` may also consume more")
+	assert.True(t, m.MatchRel("coverage/report.xml"))
+	assert.False(t, m.MatchRel("src/App.cs"))
+}
+
+// Wildcards in the segments that reach the tracked root are evaluated
+// against the real directory names, so a glob that cannot describe this
+// tracked root drops out while one that can survives.
+func TestEffectiveExclude_AncestorWildcardSegments(t *testing.T) {
+	root := t.TempDir()
+	mkGitRepo(t, root)
+	writeGitignore(t, root, "/*/app/packed/\n/*/other/staged/\n")
+	app := mkDir(t, root, "projects", "app")
+
+	cm := newTestConfigManager(t)
+	cm.LoadWorkspaceConfig("r", app)
+
+	m := excludeMatcher(t, cm, "r")
+	assert.True(t, m.MatchRel("packed/gen.cs"), "`*` matches the real `projects` segment")
+	assert.False(t, m.MatchRel("staged/bundle.js"), "the `other` segment does not match `app`")
+}
+
+// Layers are appended outermost first, so the deeper file wins — including
+// when it re-includes something an ancestor ignored, which is what git does.
+func TestEffectiveExclude_DeeperGitignoreOverridesAncestor(t *testing.T) {
+	root := t.TempDir()
+	mkGitRepo(t, root)
+	writeGitignore(t, root, "*.log\ngenerated/\n")
+	app := mkDir(t, root, "projects", "app")
+	writeGitignore(t, app, "!keep.log\n!generated/\n")
+
+	cm := newTestConfigManager(t)
+	cm.LoadWorkspaceConfig("r", app)
+
+	m := excludeMatcher(t, cm, "r")
+	assert.False(t, m.MatchRel("keep.log"), "the tracked root's re-include must win")
+	assert.True(t, m.MatchRel("other.log"), "the ancestor pattern still applies elsewhere")
+	assert.False(t, m.MatchRel("generated/api.cs"))
+}
+
+// Every `.gitignore` between the git root and the tracked root counts, not
+// just the two endpoints.
+func TestEffectiveExclude_IntermediateGitignoreApplies(t *testing.T) {
+	root := t.TempDir()
+	mkGitRepo(t, root)
+	writeGitignore(t, root, "root-junk/\n")
+	projects := mkDir(t, root, "projects")
+	writeGitignore(t, projects, "mid-junk/\n/app/scoped/\n/other/scoped/\n")
+	app := mkDir(t, projects, "app")
+	writeGitignore(t, app, "leaf-junk/\n")
+
+	cm := newTestConfigManager(t)
+	cm.LoadWorkspaceConfig("r", app)
+
+	m := excludeMatcher(t, cm, "r")
+	assert.True(t, m.MatchRel("root-junk/a.txt"))
+	assert.True(t, m.MatchRel("mid-junk/a.txt"))
+	assert.True(t, m.MatchRel("leaf-junk/a.txt"))
+	assert.True(t, m.MatchRel("scoped/a.txt"),
+		"an intermediate anchored pattern re-anchors onto the tracked root")
+	assert.False(t, m.MatchRel("App.cs"))
+}
+
+// Outside a git repository there is no root to layer from, so only the
+// tracked root's own `.gitignore` applies — the pre-existing behaviour.
+func TestEffectiveExclude_NoGitRootIgnoresAncestors(t *testing.T) {
+	root := t.TempDir()
+	writeGitignore(t, root, "junk/\n")
+	app := mkDir(t, root, "projects", "app")
+	writeGitignore(t, app, "own-junk/\n")
+
+	cm := newTestConfigManager(t)
+	cm.LoadWorkspaceConfig("r", app)
+
+	m := excludeMatcher(t, cm, "r")
+	assert.True(t, m.MatchRel("own-junk/a.txt"))
+	assert.False(t, m.MatchRel("junk/a.txt"),
+		"an ancestor outside any repository is not something git would honour")
+}
+
+// A nested repository (submodule, vendored clone) is its own root: git does
+// not apply the outer repo's ignore file inside it, and neither do we.
+func TestEffectiveExclude_NestedRepoStopsAtItsOwnRoot(t *testing.T) {
+	root := t.TempDir()
+	mkGitRepo(t, root)
+	writeGitignore(t, root, "junk/\n")
+	inner := mkDir(t, root, "vendor", "inner")
+	mkGitRepo(t, inner)
+	writeGitignore(t, inner, "inner-junk/\n")
+
+	cm := newTestConfigManager(t)
+	cm.LoadWorkspaceConfig("r", inner)
+
+	m := excludeMatcher(t, cm, "r")
+	assert.True(t, m.MatchRel("inner-junk/a.txt"))
+	assert.False(t, m.MatchRel("junk/a.txt"),
+		"the outer repo's ignore file does not reach into a nested repository")
+}
+
+// A linked worktree or submodule checkout marks its root with a `.git`
+// *file*, not a directory. Presence is what matters, not the type.
+func TestEffectiveExclude_GitFileMarksRoot(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".git"),
+		[]byte("gitdir: /elsewhere/.git/worktrees/wt\n"), 0o644))
+	writeGitignore(t, root, "junk/\n")
+	app := mkDir(t, root, "projects", "app")
+
+	cm := newTestConfigManager(t)
+	cm.LoadWorkspaceConfig("r", app)
+
+	assert.True(t, excludeMatcher(t, cm, "r").MatchRel("junk/a.txt"))
+}
+
+// `respect_gitignore: false` opts out of the whole layer, ancestors included.
+func TestEffectiveExclude_RespectGitignoreFalseSkipsChain(t *testing.T) {
+	root := t.TempDir()
+	mkGitRepo(t, root)
+	writeGitignore(t, root, "junk/\n")
+	app := mkDir(t, root, "projects", "app")
+	writeGitignore(t, app, "own-junk/\n")
+	writeWorkspace(t, app, "respect_gitignore: false\n")
+
+	cm := newTestConfigManager(t)
+	cm.LoadWorkspaceConfig("r", app)
+
+	m := excludeMatcher(t, cm, "r")
+	assert.False(t, m.MatchRel("junk/a.txt"))
+	assert.False(t, m.MatchRel("own-junk/a.txt"))
+}
+
+// The cache key spans the whole chain, so editing an ancestor file — not
+// just the tracked root's own — invalidates the merged list, and exactly
+// the changed file is re-read.
+func TestEffectiveExclude_AncestorGitignoreEditInvalidatesCache(t *testing.T) {
+	root := t.TempDir()
+	mkGitRepo(t, root)
+	writeGitignore(t, root, "old-only/\n")
+	app := mkDir(t, root, "projects", "app")
+	writeGitignore(t, app, "leaf/\n")
+
+	cm := newTestConfigManager(t)
+	cm.LoadWorkspaceConfig("r", app)
+	reads := countingReader(cm)
+
+	first := excludes.New(cm.EffectiveExclude("r"))
+	assert.True(t, first.MatchRel("old-only/a.txt"))
+	require.Equal(t, int64(2), atomic.LoadInt64(reads), "both chain members read once")
+
+	_ = cm.EffectiveExclude("r")
+	require.Equal(t, int64(2), atomic.LoadInt64(reads), "the second call must be a cache hit")
+
+	writeGitignore(t, root, "new-only/\nsecond-new/\n")
+	bumpMtime(t, filepath.Join(root, ".gitignore"))
+
+	second := excludes.New(cm.EffectiveExclude("r"))
+	assert.True(t, second.MatchRel("new-only/a.txt"), "the ancestor edit must take effect")
+	assert.False(t, second.MatchRel("old-only/a.txt"), "stale ancestor patterns must be dropped")
+	assert.True(t, second.MatchRel("leaf/a.txt"), "the unchanged leaf layer survives")
+	assert.Equal(t, int64(3), atomic.LoadInt64(reads),
+		"only the changed ancestor is re-read; the leaf stays cached")
+}
+
+// A `.gitignore` appearing mid-session in a directory that had none changes
+// the shape of the chain, which the merged cache must notice.
+func TestEffectiveExclude_NewIntermediateGitignoreInvalidatesCache(t *testing.T) {
+	root := t.TempDir()
+	mkGitRepo(t, root)
+	writeGitignore(t, root, "root-junk/\n")
+	projects := mkDir(t, root, "projects")
+	app := mkDir(t, projects, "app")
+
+	cm := newTestConfigManager(t)
+	cm.LoadWorkspaceConfig("r", app)
+
+	first := excludeMatcher(t, cm, "r")
+	assert.True(t, first.MatchRel("root-junk/a.txt"))
+	assert.False(t, first.MatchRel("mid-junk/a.txt"))
+
+	writeGitignore(t, projects, "mid-junk/\n")
+
+	second := excludeMatcher(t, cm, "r")
+	assert.True(t, second.MatchRel("mid-junk/a.txt"),
+		"a newly added intermediate .gitignore must invalidate the cached merge")
+	assert.True(t, second.MatchRel("root-junk/a.txt"))
+}
+
+// Two tracked roots under one git root see the same ancestor layer, each
+// re-anchored to its own depth.
+func TestEffectiveExclude_SiblingTrackedRootsShareAncestor(t *testing.T) {
+	root := t.TempDir()
+	mkGitRepo(t, root)
+	writeGitignore(t, root, "junk/\n/projects/a/gen/\n/projects/b/gen/\n")
+	a := mkDir(t, root, "projects", "a")
+	b := mkDir(t, root, "projects", "b")
+
+	cm := newTestConfigManager(t)
+	cm.LoadWorkspaceConfig("a", a)
+	cm.LoadWorkspaceConfig("b", b)
+
+	for _, prefix := range []string{"a", "b"} {
+		m := excludeMatcher(t, cm, prefix)
+		assert.Truef(t, m.MatchRel("junk/x.txt"), "prefix %q", prefix)
+		assert.Truef(t, m.MatchRel("gen/x.cs"), "prefix %q", prefix)
+		assert.Falsef(t, m.MatchRel("src/x.cs"), "prefix %q", prefix)
+	}
+}
+
+// The chain's shape is memoized per tracked root, so a `.git` appearing
+// above it mid-session is picked up when the repo is next published —
+// tracked, reindexed, or refreshed — rather than on every call.
+func TestEffectiveExclude_RepublishRediscoversGitRoot(t *testing.T) {
+	root := t.TempDir()
+	writeGitignore(t, root, "junk/\n")
+	app := mkDir(t, root, "projects", "app")
+
+	cm := newTestConfigManager(t)
+	cm.LoadWorkspaceConfig("r", app)
+	assert.False(t, excludeMatcher(t, cm, "r").MatchRel("junk/a.txt"),
+		"no repository yet, so the ancestor file does not apply")
+
+	mkGitRepo(t, root)
+	cm.LoadWorkspaceConfig("r", app)
+
+	assert.True(t, excludeMatcher(t, cm, "r").MatchRel("junk/a.txt"),
+		"republishing the repo must rediscover its git root")
+}
+
+func TestGitignoreChain_TrackedRootIsGitRoot(t *testing.T) {
+	root := t.TempDir()
+	mkGitRepo(t, root)
+	writeGitignore(t, root, "junk/\n")
+
+	chain := gitignoreChain(root)
+	require.Len(t, chain, 1, "the git root's own file is the whole chain")
+	assert.Equal(t, root, chain[0].dir)
+	assert.Empty(t, chain[0].sub)
+	assert.True(t, chain[0].stat.exists)
+}
+
+func TestGitignoreChain_OrderedOutermostFirst(t *testing.T) {
+	root := t.TempDir()
+	mkGitRepo(t, root)
+	projects := mkDir(t, root, "projects")
+	app := mkDir(t, projects, "app")
+
+	chain := gitignoreChain(app)
+	require.Len(t, chain, 3)
+	assert.Equal(t, []string{root, projects, app},
+		[]string{chain[0].dir, chain[1].dir, chain[2].dir})
+	assert.Equal(t, []string{"projects/app", "app", ""},
+		[]string{chain[0].sub, chain[1].sub, chain[2].sub})
+}
+
+func TestReanchorPattern(t *testing.T) {
+	sub := []string{"projects", "app"}
+	cases := []struct {
+		name    string
+		pattern string
+		want    []string
+	}{
+		{"unanchored carries over", "obj/", []string{"obj/"}},
+		{"unanchored glob carries over", "*.log", []string{"*.log"}},
+		{"unanchored negation carries over", "!keep.log", []string{"!keep.log"}},
+		{"anchored on path re-anchors", "/projects/app/obj/", []string{"/obj/"}},
+		{"anchored without leading slash re-anchors", "projects/app/obj", []string{"/obj"}},
+		{"anchored negation keeps its bang", "!/projects/app/obj/", []string{"!/obj/"}},
+		{"deeper tail survives", "/projects/app/a/b/c", []string{"/a/b/c"}},
+		{"sibling subtree drops out", "/projects/other/obj/", nil},
+		{"unrelated root entry drops out", "/build/", nil},
+		{"pattern swallowing the tracked root drops out", "/projects/app/", nil},
+		{"pattern swallowing an ancestor drops out", "/projects/", nil},
+		{"wildcard segment matches the real name", "/*/app/obj/", []string{"/obj/"}},
+		{"wildcard segment that misses drops out", "/*/other/obj/", nil},
+		{"class segment matches the real name", "/[Pp]rojects/app/obj/", []string{"/obj/"}},
+		{"double star spans the tracked root", "projects/**/obj/", []string{"**/obj/"}},
+		{"leading double star stays depth-agnostic", "**/obj/", []string{"**/obj/"}},
+		{"trailing double star re-anchors", "/projects/app/gen/**", []string{"/gen/**"}},
+		{"comment drops out", "# comment", nil},
+		{"blank drops out", "   ", nil},
+		{"bare slash drops out", "/", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, reanchorPattern(tc.pattern, sub))
+		})
+	}
+}
+
+func TestReanchorGitignore_EmptySubIsIdentity(t *testing.T) {
+	in := []string{"/build/", "*.log", "a/b/c"}
+	assert.Equal(t, in, reanchorGitignore(in, ""))
+	assert.Equal(t, in, reanchorGitignore(in, "."))
+}
+
+// A pattern packed with `**` must stay linear-ish rather than branching
+// exponentially over the chain depth.
+func TestAnchoredRemainders_DoubleStarDoesNotExplode(t *testing.T) {
+	pat := make([]string, 0, 41)
+	for i := 0; i < 20; i++ {
+		pat = append(pat, "**", "x")
+	}
+	pat = append(pat, "tail")
+	sub := make([]string, 20)
+	for i := range sub {
+		sub[i] = "x"
+	}
+	assert.NotEmpty(t, anchoredRemainders(pat, sub))
+}

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -219,6 +219,11 @@ func (cm *ConfigManager) readWorkspaceConfig(repoPrefix, repoPath string) (*Conf
 // The remembered path is never cleared: EffectiveExclude needs it to locate
 // the repo's own `.gitignore`, which is independent of `.gortex.yaml`.
 func (cm *ConfigManager) publishWorkspaceConfig(repoPrefix, repoPath string, cfg *Config, authoritative bool) {
+	// Publishing a path is the one moment we know a repo was just tracked,
+	// reindexed, or refreshed — re-discover where its git root is rather
+	// than trusting a shape memoized before the repo existed in this form.
+	cm.excludeCache.forgetChain(repoPath)
+
 	cm.mu.Lock()
 	changed := false
 	if repoPath != "" && cm.workspacePaths[repoPrefix] != repoPath {
@@ -314,7 +319,9 @@ func (cm *ConfigManager) GetRepoConfig(repoPrefix string) *Config {
 // layered in precedence order (later layers can re-include via !pattern):
 //
 //  1. Builtin baseline (excludes.Builtin)
-//  2. Repo's own `.gitignore` (read from disk; opt out with
+//  2. Every `.gitignore` from the enclosing git root down to the tracked
+//     root, outermost first, with ancestor patterns re-anchored relative to
+//     the tracked root (read from disk; opt out with
 //     `respect_gitignore: false` in `.gortex.yaml`)
 //  3. Global Exclude from ~/.gortex/config.yaml
 //  4. Matching RepoEntry.Exclude (first match in Repos, then Projects)
@@ -323,11 +330,11 @@ func (cm *ConfigManager) GetRepoConfig(repoPrefix string) *Config {
 //
 // This runs on a firehose of calls (every indexer walk and per-file
 // reconcile), so the layered result is memoized per repo and returned
-// shared: a steady-state call does one os.Stat of the repo's `.gitignore`
-// and returns the cached slice without re-reading or re-merging. The cache
-// invalidates on config changes (the global and workspace configs are
+// shared: a steady-state call does one os.Stat per `.gitignore` in the
+// chain and returns the cached slice without re-reading or re-merging. The
+// cache invalidates on config changes (the global and workspace configs are
 // swapped, never mutated in place, so pointer identity is the version) and
-// on a `.gitignore` mtime/size change.
+// on any chain member's mtime/size change.
 //
 // The returned slice is SHARED and IMMUTABLE: callers MUST NOT mutate its
 // elements. It is clipped (len == cap), so appending to it is safe —
@@ -340,23 +347,25 @@ func (cm *ConfigManager) EffectiveExclude(repoPrefix string) []string {
 	cm.mu.RUnlock()
 
 	respect := shouldRespectGitignore(ws)
-	var st gitignoreStat
+	var chain []gitignoreLayer
 	if respect && repoPath != "" {
-		st = statGitignore(repoPath)
+		chain = cm.excludeCache.chain(repoPath)
 	}
-	if m, ok := cm.excludeCache.lookupMerged(repoPrefix, gc, ws, repoPath, respect, st); ok {
+	if m, ok := cm.excludeCache.lookupMerged(repoPrefix, gc, ws, repoPath, respect, chain); ok {
 		return m
 	}
 
 	out := make([]string, 0, 32)
 	out = append(out, excludes.Builtin...)
 
-	// Layer 2: repo `.gitignore`, unless the workspace config explicitly
-	// opts out. The parse is cached per repo path and refreshed only when
-	// the file's mtime/size changes (see excludeCache), so a mid-session
-	// edit is still picked up on the next call.
-	if respect && repoPath != "" {
-		out = append(out, cm.excludeCache.patterns(repoPath, st)...)
+	// Layer 2: the repo's `.gitignore` chain, unless the workspace config
+	// explicitly opts out. Layers arrive outermost first so a deeper file
+	// overrides a shallower one, as git does. Each parse is cached per
+	// directory and refreshed only when that file's mtime/size changes (see
+	// excludeCache), so a mid-session edit is still picked up on the next
+	// call.
+	for _, layer := range chain {
+		out = append(out, reanchorGitignore(cm.excludeCache.patterns(layer.dir, layer.stat), layer.sub)...)
 	}
 
 	if gc != nil {
@@ -396,7 +405,7 @@ func (cm *ConfigManager) EffectiveExclude(repoPrefix string) []string {
 	// forced to reallocate and can never write through the shared backing
 	// array the cache hands to every reader.
 	out = out[:len(out):len(out)]
-	cm.excludeCache.storeMerged(repoPrefix, gc, ws, repoPath, respect, st, out)
+	cm.excludeCache.storeMerged(repoPrefix, gc, ws, repoPath, respect, chain, out)
 	return out
 }
 

--- a/internal/excludes/builtin.go
+++ b/internal/excludes/builtin.go
@@ -48,6 +48,28 @@ var Builtin = []string{
 	".bundle/",    // Ruby Bundler cache
 	".dart_tool/", // Dart/Flutter build cache
 	".pub-cache/", // Dart global pub cache, occasionally vendored
+	// Visual Studio / MSBuild artifacts.
+	".vs/",         // Visual Studio per-solution cache
+	"TestResults/", // Visual Studio / `dotnet test` output
+	// MSBuild's intermediate output. `obj/` itself is deliberately NOT
+	// excluded wholesale: it is first-party source elsewhere (Go's own
+	// toolchain ships `cmd/internal/obj`), and a silent blanket drop is the
+	// same failure this list exists to prevent. These entries name what
+	// MSBuild actually writes — the per-configuration trees holding
+	// regenerated C# (`*.AssemblyInfo.cs`, `*.GlobalUsings.g.cs`,
+	// `*.csproj.FileListAbsolute.txt`) and the NuGet restore metadata —
+	// so a first-party `obj` package stays indexed.
+	//
+	// `bin/` is likewise absent: MSBuild's output directory, but also
+	// committed source in other ecosystems (Rails' `bin/rails`, an npm
+	// package's `bin/cli.js`). .NET repos ignore both in `.gitignore`,
+	// which Gortex layers from the git root down, so this list only has to
+	// cover the repo that forgot to.
+	"obj/[Dd]ebug/",
+	"obj/[Rr]elease/",
+	"obj/project.assets.json",
+	"obj/project.nuget.cache",
+	"**/obj/*.nuget.*", // *.csproj.nuget.{dgspec.json,g.props,g.targets}
 	"*.tmp",
 	// Editor scratch/backup files. Vim cycles swap suffixes backward
 	// through the alphabet (.swp → .swo → .swn → ...); neovim writes a

--- a/internal/excludes/builtin_test.go
+++ b/internal/excludes/builtin_test.go
@@ -38,3 +38,49 @@ func TestBuiltinDoesNotExcludeSimilarSourcePaths(t *testing.T) {
 		}
 	}
 }
+
+func TestBuiltinExcludesVisualStudioArtifacts(t *testing.T) {
+	t.Parallel()
+
+	matcher := New(Builtin)
+	for _, path := range []string{
+		".vs/Solution/v17/HierarchyCache.v1.txt",
+		".vs/Solution/v18/HierarchyCache.v1.txt",
+		"TestResults/run-1/results.trx",
+		"App/obj/Debug/net8.0/App.AssemblyInfo.cs",
+		"App/obj/Debug/net8.0/App.GlobalUsings.g.cs",
+		"App/obj/Debug/net8.0/App.csproj.FileListAbsolute.txt",
+		"App/obj/Release/net8.0/App.AssemblyInfo.cs",
+		"App/obj/release/net8.0/App.AssemblyInfo.cs",
+		"App/obj/project.assets.json",
+		"App/obj/project.nuget.cache",
+		"App/obj/App.csproj.nuget.g.props",
+		"App/obj/App.csproj.nuget.dgspec.json",
+		"obj/project.assets.json",
+	} {
+		if !matcher.MatchRel(path) {
+			t.Errorf("Builtin should exclude MSBuild artifact %q", path)
+		}
+	}
+}
+
+// The MSBuild entries name what MSBuild writes rather than blanket-dropping
+// `obj/` or `bin/`, both of which are committed source in other ecosystems.
+func TestBuiltinDoesNotExcludeFirstPartyObjOrBin(t *testing.T) {
+	t.Parallel()
+
+	matcher := New(Builtin)
+	for _, path := range []string{
+		"cmd/internal/obj/link.go", // Go's own toolchain
+		"src/cmd/internal/obj/x86/asm6.go",
+		"obj/writer.go",
+		"bin/rails",
+		"bin/cli.js",
+		"bin/setup",
+		"App/Controllers/HomeController.cs",
+	} {
+		if matcher.MatchRel(path) {
+			t.Errorf("Builtin unexpectedly excludes first-party path %q", path)
+		}
+	}
+}

--- a/internal/indexer/gitignore_chain_index_test.go
+++ b/internal/indexer/gitignore_chain_index_test.go
@@ -1,0 +1,73 @@
+package indexer
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+// TestIndex_GitignoreAboveTrackedRoot walks a repo tracked one level below
+// its git root — the monorepo layout — with the exclude list a real
+// ConfigManager hands the indexer. The git root's `.gitignore` must reach
+// the walk: build output beneath the tracked root stays out of the graph
+// while hand-written source is indexed.
+func TestIndex_GitignoreAboveTrackedRoot(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, ".git"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".gitignore"),
+		[]byte("junk/\n[Oo]bj/\n"), 0o644))
+
+	tracked := filepath.Join(root, "projects", "app")
+	mustWrite := func(rel, content string) {
+		p := filepath.Join(tracked, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+		writeFile(t, p, content)
+	}
+	php := func(fn string) string { return "<?php\nfunction " + fn + "() { return 1; }\n" }
+
+	mustWrite("Real.php", php("realWork"))
+	mustWrite("junk/noise.php", php("noise"))
+	mustWrite("obj/gen.php", php("generated"))
+
+	cm, err := config.NewConfigManager(filepath.Join(t.TempDir(), "config.yaml"))
+	require.NoError(t, err)
+	cm.LoadWorkspaceConfig("app", tracked)
+
+	reg := parser.NewRegistry()
+	reg.Register(languages.NewPHPExtractor())
+	cfg := config.Default().Index
+	cfg.Workers = 2
+	cfg.Exclude = cm.EffectiveExclude("app")
+
+	g := graph.New()
+	_, err = New(g, reg, cfg, zap.NewNop()).Index(tracked)
+	require.NoError(t, err)
+
+	hasFile := func(suffix string) bool {
+		for _, n := range g.AllNodes() {
+			if strings.Contains(filepath.ToSlash(n.FilePath), suffix) {
+				return true
+			}
+		}
+		return false
+	}
+
+	if !hasFile("Real.php") {
+		t.Error("hand-written source Real.php was not indexed")
+	}
+	if hasFile("junk/noise.php") {
+		t.Error("junk/noise.php leaked in: the git root's .gitignore did not reach the walk")
+	}
+	if hasFile("obj/gen.php") {
+		t.Error("obj/gen.php leaked in: the git root's .gitignore did not reach the walk")
+	}
+}


### PR DESCRIPTION
Fixes #419.

## Validation

Reproduced first, as a failing test: with the git root at `repo/` and the tracked root at `repo/projects/app`, `ConfigManager.EffectiveExclude` returned the builtin baseline and nothing else — every pattern in `repo/.gitignore` was absent. `statGitignore(repoPath)` only ever looked at the tracked root itself, so for any repo tracked below its git root the whole ignore layer silently disappeared.

## 1. Layer the whole `.gitignore` chain (`internal/config`)

The chain now climbs to the nearest enclosing `.git` — a directory in a clone, a *file* in a linked worktree or submodule — and layers every `.gitignore` from there down to the tracked root, outermost first so a deeper file still overrides a shallower one (go-gitignore is last-match-wins, so a `!re-include` next to your code beats the repository-wide rule).

Ancestor patterns are re-anchored onto the tracked root, mirroring git's own anchored/unanchored split:

| ancestor pattern (git root, tracked root `projects/app`) | becomes |
|---|---|
| `junk/`, `*.log` — unanchored, matches at any depth | carried over verbatim |
| `/projects/app/generated/` | `/generated/` |
| `/projects/other/` — sibling subtree | dropped |
| `/*/app/packed/` — wildcard segment matching the real name | `/packed/` |
| `projects/**/artifacts/` | `**/artifacts/` |
| `/projects/app/` — swallows the tracked root | dropped |

That last row is a deliberate call: the user pointed Gortex at that directory explicitly, and honouring an ancestor ignore of it would empty the index of the very repo they asked for.

`**` matches zero or more segments, so a pattern can reach into the tracked root at more than one depth. `anchoredRemainders` resolves this with a reachability sweep over `(pattern segment, sub-path segment)` — `**` modelled as a self-loop — which keeps a pattern packed with `**` polynomial instead of exponentially branching, and drops a remainder that a `**`-led sibling already subsumes.

Outside a git repository nothing changes: only the tracked root's own file applies, since ancestor files outside a repository are not something git would honour either.

### Keeping the hot path hot

`EffectiveExclude` runs on a firehose of calls, and the upward `.git` walk is an `os.Lstat` per level — for a tracked root outside any repository, all the way to `/`. Discovering the chain on every call cost 6.7× and 14× the allocations:

| layout | before | naive chain | shipped |
|---|---|---|---|
| tracked root == git root | 2.0 µs / 3 allocs | 9.5 µs / 7 allocs | 2.3 µs / 4 allocs |
| two levels below git root | — | 30.8 µs / 25 allocs | 6.5 µs / 12 allocs |
| no repository above (walk to `/`) | 2.0 µs / 3 allocs | 37.0 µs / 42 allocs | 2.3 µs / 4 allocs |

The chain's *shape* — which directories git would read a `.gitignore` from — is memoized per tracked root, since it moves only when a `.git` appears or disappears above it. Every call still re-stats each member, so an edit anywhere in the chain is picked up immediately; `publishWorkspaceConfig` forgets the shape whenever a repo's path is published (track, reindex, config refresh), which is where a newly created git root gets noticed. The parse cache is now keyed by the `.gitignore`'s own directory, so sibling tracked roots under one git root share their common ancestors' parse.

## 2. Visual Studio / MSBuild artifacts in `excludes.Builtin`

Defense-in-depth for the repo whose ignore layer is missing entirely: `.vs/`, `TestResults/`, and what MSBuild actually writes under `obj/` — the per-configuration trees holding regenerated C# and the NuGet restore metadata.

`obj/` and `bin/` are **not** excluded wholesale, which is where this departs from the issue's suggestion. Both are first-party source outside .NET — Go's own toolchain ships `cmd/internal/obj`, Rails commits `bin/rails`, npm packages commit `bin/cli.js` — and a silent blanket drop of real source is the same failure this list exists to prevent, just pointed the other way. Naming what MSBuild writes covers every artifact the issue reports while leaving a first-party `obj` package indexed; a .NET repo with a normal `.gitignore` gets `bin/` from part 1 regardless.

## Testing

- Chain behaviour: monorepo repro, the .NET layout, re-anchoring, sibling-drop, tracked-root-swallow, `**`, wildcard segments, deeper-overrides-ancestor, intermediate files, no-git-root, nested repo, `.git`-as-a-file, `respect_gitignore: false`, sibling tracked roots.
- Cache: ancestor edit invalidates and re-reads exactly the changed file, a newly added intermediate `.gitignore` reshapes the chain, republishing rediscovers a git root that appeared mid-session.
- Unit table over `reanchorPattern`, plus a `**`-saturation case pinning the sweep's bound.
- End-to-end through the real index walk: a repo tracked below its git root indexes its source and keeps `junk/` and `obj/` out of the graph.
- `excludes.Builtin`: the MSBuild artifacts match; `cmd/internal/obj/link.go`, `bin/rails`, `bin/cli.js` do not.
- `go build ./...`, `go vet ./...`, `golangci-lint run ./internal/... ./cmd/...` clean; `go test -race` green on `internal/config`, `internal/excludes`, and `internal/indexer`. A full-tree `go test -race ./...` is still running at the time of opening — I will report the result here.

## Known gaps

- `.git/info/exclude` and `core.excludesFile` are still not read — the chain covers `.gitignore` files only.
- Per-directory `.gitignore` files *below* the tracked root remain unread (`.gortexignore` / `.ignore` / `.rgignore` already are, via `excludes.Hierarchical`).
- `gortex config exclude list` prints the builtin/global/repo/workspace layers but has never shown the `.gitignore` layer; unchanged here, but it means the CLI still under-reports the effective list.
- A whitelist-style root `.gitignore` (`*` plus explicit re-includes) now applies to a tracked subdirectory the way git applies it, which can exclude more than before. That is the intended semantics; `respect_gitignore: false` or an `include:` entry opts out.
