### PR TITLE
Index Java method references as incoming reference edges

### DIFF
--- a/internal/parser/languages/fn_ref_special.go
+++ b/internal/parser/languages/fn_ref_special.go
@@ -14,16 +14,18 @@ import (
 // (`this.m` / `self.m` / Kotlin `::m`), a concrete type name when the syntax
 // names one (`Foo::bar`), or "" when the name resolves repo-wide (a selector).
 //
-// Forms handled: Java `method_reference` (`Foo::bar`, `this::bar`), Kotlin
-// `callable_reference` (`::m`, `Foo::m`), `this.`/`self.` member access in
-// JS/TS/Python/C#, Ruby `method(:sym)` and `&:sym`, and Swift/ObjC
+// Forms handled: Java `method_reference` (`Foo::bar`, `this::bar`, `Foo::new`),
+// Kotlin `callable_reference` (`::m`, `Foo::m`), `this.`/`self.` member access
+// in JS/TS/Python/C#, Ruby `method(:sym)` and `&:sym`, and Swift/ObjC
 // `#selector(...)` / `@selector(...)`.
 func normalizeFnRefSpecial(n *sitter.Node, src []byte) (refName, recvHint string, ok bool) {
 	switch n.Type() {
 	case "method_reference":
-		return splitColonColonRef(n, src)
+		// Java is the only grammar with this node type, and its `Foo::new`
+		// constructor form names a real indexed member (`<Type>.<init>`).
+		return splitColonColonRef(n, src, true)
 	case "callable_reference":
-		return splitColonColonRef(n, src)
+		return splitColonColonRef(n, src, false)
 	case "member_expression": // JS / TS
 		return selfMemberAccess(n, src, "object", "property")
 	case "attribute": // Python
@@ -44,7 +46,9 @@ func normalizeFnRefSpecial(n *sitter.Node, src []byte) (refName, recvHint string
 
 // splitColonColonRef handles a `::`-style callable reference: the trailing
 // identifier is the member, an optional leading type/expression the qualifier.
-func splitColonColonRef(n *sitter.Node, src []byte) (refName, recvHint string, ok bool) {
+// With ctorRefs set, a `Type::new` constructor reference resolves to that
+// type's `<Type>.<init>` member instead of being rejected.
+func splitColonColonRef(n *sitter.Node, src []byte, ctorRefs bool) (refName, recvHint string, ok bool) {
 	var first, last *sitter.Node
 	for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
 		c := n.NamedChild(i)
@@ -59,6 +63,19 @@ func splitColonColonRef(n *sitter.Node, src []byte) (refName, recvHint string, o
 	if last == nil {
 		return "", "", false
 	}
+	// `Foo::new` — `new` is an anonymous token, so the type is the node's only
+	// named child and the trailing-identifier rule below would mistake the type
+	// itself for the member. The reference targets Foo's constructor, which the
+	// Java extractor indexes as the `Foo.<init>` method of Foo.
+	if ctorRefs && colonColonRefIsCtor(n, src) {
+		ty := colonColonQualifier(first.Content(src))
+		// `String[]::new` allocates an array — there is no declared
+		// constructor to reference.
+		if ty == "" || strings.ContainsAny(ty, "[]") {
+			return "", "", false
+		}
+		return ty + ".<init>", ty, true
+	}
 	member := strings.TrimSpace(last.Content(src))
 	if member == "" || member == "new" {
 		return "", "", false
@@ -70,9 +87,45 @@ func splitColonColonRef(n *sitter.Node, src []byte) (refName, recvHint string, o
 		if q == "this" || q == "self" {
 			return member, "<self>", true
 		}
-		return member, q, true
+		return member, colonColonQualifier(q), true
 	}
 	return member, "<self>", true
+}
+
+// colonColonRefIsCtor reports whether a `::` reference names a constructor —
+// its member position is the `new` keyword. Read off the source rather than the
+// child list because `new` is an anonymous token with no named node, and an
+// explicit type witness (`Foo::<T>new`) sits between the `::` and it.
+func colonColonRefIsCtor(n *sitter.Node, src []byte) bool {
+	text := strings.TrimSpace(n.Content(src))
+	i := strings.LastIndex(text, "::")
+	if i < 0 {
+		return false
+	}
+	rest := strings.TrimSpace(text[i+2:])
+	if strings.HasPrefix(rest, "<") {
+		if j := strings.LastIndex(rest, ">"); j >= 0 {
+			rest = strings.TrimSpace(rest[j+1:])
+		}
+	}
+	return rest == "new"
+}
+
+// colonColonQualifier reduces the qualifier of a `::` reference to the simple
+// type name methods are indexed under: `app.Outer.Inner` → `Inner`,
+// `Wrapper<String>` → `Wrapper`. Without this an import-qualified or nested
+// type never matches a method's receiver and the reference falls back to a
+// repo-wide unique-or-drop lookup, which silently drops every non-unique name.
+// A qualifier naming a value rather than a type (`instance`) is unchanged.
+func colonColonQualifier(q string) string {
+	q = strings.TrimSpace(q)
+	if i := strings.Index(q, "<"); i >= 0 {
+		q = strings.TrimSpace(q[:i])
+	}
+	if i := strings.LastIndex(q, "."); i >= 0 {
+		q = strings.TrimSpace(q[i+1:])
+	}
+	return q
 }
 
 // selfMemberAccess handles a `this.m` / `self.m` member access: the object must

--- a/internal/parser/languages/fn_value_capture.go
+++ b/internal/parser/languages/fn_value_capture.go
@@ -80,21 +80,26 @@ func captureFnValueCandidates(result *parser.ExtractionResult, root *sitter.Node
 	if root == nil || result == nil {
 		return
 	}
-	lang := ""
+	lang, fileID := "", ""
 	funcs := map[string]bool{}
 	for _, n := range result.Nodes {
 		if n == nil || n.FilePath != filePath {
 			continue
 		}
-		if n.Kind == graph.KindFile && lang == "" {
-			lang = n.Language
+		if n.Kind == graph.KindFile {
+			if lang == "" {
+				lang = n.Language
+			}
+			if fileID == "" {
+				fileID = n.ID
+			}
 		}
 		if n.Kind == graph.KindFunction || n.Kind == graph.KindMethod {
 			funcs[n.Name] = true
 		}
 	}
 	funcRanges := buildFuncRanges(result)
-	if len(funcRanges) == 0 {
+	if len(funcRanges) == 0 && fileID == "" {
 		return
 	}
 	spec := fnRefSpecFor(lang)
@@ -117,6 +122,18 @@ func captureFnValueCandidates(result *parser.ExtractionResult, root *sitter.Node
 			}
 			line := int(n.StartPoint().Row) + 1
 			fromID := findEnclosingFunc(funcRanges, line)
+			if fromID == "" {
+				// A `Foo::bar` in a field or static initializer sits outside
+				// every method body, yet is one of the commonest places a
+				// method reference appears (constant handler tables,
+				// `Comparator` fields). Anchor it to the file node, as the
+				// Java type-use pass already does for class-level type refs,
+				// instead of dropping the reference entirely. Only the
+				// unambiguous `::`-style / selector forms take this fallback —
+				// a bare identifier outside any function is far more likely a
+				// local or a builtin than a callable reference.
+				fromID = fileID
+			}
 			if fromID == "" {
 				return
 			}

--- a/internal/parser/languages/java_method_ref_test.go
+++ b/internal/parser/languages/java_method_ref_test.go
@@ -1,0 +1,212 @@
+package languages
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/resolver"
+)
+
+// javaMethodRefGraph extracts every file and runs the fn-value gate, i.e. the
+// same capture → resolve pair the indexer runs. A method reference only becomes
+// a real edge once both halves have run, so the gate is part of what these
+// tests pin.
+func javaMethodRefGraph(t *testing.T, files map[string]string) *graph.Graph {
+	t.Helper()
+	g := graph.New()
+	paths := make([]string, 0, len(files))
+	for path := range files {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	for _, path := range paths {
+		nodes, edges := runJavaExtract(t, path, files[path])
+		g.AddBatch(nodes, edges)
+	}
+	resolver.ResolveFnValueCallbacks(g)
+	return g
+}
+
+// methodRefSources returns the IDs that reference target through a bound
+// method-reference edge (the gate's callback_registration form).
+func methodRefSources(g *graph.Graph, target string) []string {
+	var out []string
+	for _, e := range g.GetInEdges(target) {
+		if e.Kind != graph.EdgeReferences || e.Meta == nil {
+			continue
+		}
+		if via, _ := e.Meta["via"].(string); via == "callback_registration" {
+			out = append(out, e.From)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func hasMethodRef(g *graph.Graph, target string) bool {
+	return len(methodRefSources(g, target)) > 0
+}
+
+// TestJavaMethodRef_Forms pins the four method-reference forms the Java grammar
+// admits — `Type::staticMethod`, `Type::instanceMethod`, `instance::method`,
+// and `Type::new` — as incoming reference edges on their target. Before this,
+// `Type::new` was rejected outright: the constructor's `new` is an anonymous
+// token, so the trailing-named-child rule read the *type* as the member name
+// and the flood guard then dropped it.
+func TestJavaMethodRef_Forms(t *testing.T) {
+	g := javaMethodRefGraph(t, map[string]string{
+		"app/Pipeline.java": `package app;
+
+import java.util.List;
+
+public class Pipeline {
+	private Helper helper;
+
+	public List<Out> run(List<In> items) {
+		items.forEach(Statics::configure);
+		items.forEach(ExampleType::transform);
+		items.forEach(helper::assist);
+		items.stream().map(Wrapper::new).toList();
+		items.forEach(this::consume);
+		return null;
+	}
+
+	void consume(In in) {}
+}
+`,
+		"app/Statics.java": `package app;
+public class Statics {
+	public static void configure(In in) {}
+}
+`,
+		"app/ExampleType.java": `package app;
+public class ExampleType {
+	public void transform(In in) {}
+}
+`,
+		"app/Helper.java": `package app;
+public class Helper {
+	public void assist(In in) {}
+}
+`,
+		"app/Wrapper.java": `package app;
+public class Wrapper {
+	public Wrapper(In in) {}
+}
+`,
+	})
+
+	for _, tc := range []struct {
+		form   string
+		target string
+	}{
+		{"Type::staticMethod", "app/Statics.java::Statics.configure"},
+		{"Type::instanceMethod", "app/ExampleType.java::ExampleType.transform"},
+		{"instance::method", "app/Helper.java::Helper.assist"},
+		{"Type::new", "app/Wrapper.java::Wrapper.<init>"},
+		{"this::method", "app/Pipeline.java::Pipeline.consume"},
+	} {
+		if !hasMethodRef(g, tc.target) {
+			t.Errorf("%s: expected an incoming reference edge on %s", tc.form, tc.target)
+		}
+	}
+}
+
+// TestJavaMethodRef_QualifiedTypes pins that an import-qualified, nested, or
+// generic qualifier still matches the receiver its methods are indexed under.
+// The raw qualifier text (`app.Deep`, `Outer.Inner`, `Box<In>`) never equals a
+// method's receiver, so these fell through to a repo-wide unique-or-drop
+// lookup that silently dropped every non-unique method name.
+func TestJavaMethodRef_QualifiedTypes(t *testing.T) {
+	g := javaMethodRefGraph(t, map[string]string{
+		"app/Uses.java": `package app;
+import java.util.List;
+public class Uses {
+	public void go(List<String> xs) {
+		xs.forEach(app.Deep::run);
+		xs.forEach(Outer.Inner::run);
+		xs.forEach(Box::run);
+	}
+}
+`,
+		"app/Deep.java": `package app;
+public class Deep {
+	public void run(String s) {}
+}
+`,
+		"app/Outer.java": `package app;
+public class Outer {
+	public static class Inner {
+		public void run(String s) {}
+	}
+}
+`,
+		"app/Box.java": `package app;
+public class Box {
+	public void run(String s) {}
+}
+`,
+	})
+
+	// `run` is declared by three unrelated types, so a repo-wide unique-or-drop
+	// lookup resolves none of them — only receiver matching can.
+	for _, target := range []string{
+		"app/Deep.java::Deep.run",
+		"app/Outer.java::Inner.run",
+		"app/Box.java::Box.run",
+	} {
+		if !hasMethodRef(g, target) {
+			t.Errorf("expected an incoming reference edge on %s", target)
+		}
+	}
+}
+
+// TestJavaMethodRef_NoFalsePositives pins the negatives: an array constructor
+// reference has no declared constructor to bind, and an ordinary call must not
+// be mistaken for a method reference.
+func TestJavaMethodRef_NoFalsePositives(t *testing.T) {
+	files := map[string]string{
+		"app/Uses.java": `package app;
+import java.util.List;
+public class Uses {
+	public void go(List<String> xs) {
+		xs.toArray(String[]::new);
+		Wrapper w = new Wrapper();
+		helper();
+	}
+	void helper() {}
+}
+`,
+		"app/Wrapper.java": `package app;
+public class Wrapper {
+	public Wrapper() {}
+}
+`,
+	}
+	_, edges := runJavaExtract(t, "app/Uses.java", files["app/Uses.java"])
+	for _, e := range edges {
+		if e.Meta == nil {
+			continue
+		}
+		if via, _ := e.Meta["via"].(string); via != "callback_candidate" {
+			continue
+		}
+		name, _ := e.Meta["fn_value_name"].(string)
+		if name == "String.<init>" || name == "String[].<init>" {
+			t.Errorf("`String[]::new` captured a constructor candidate %q — an array allocation has no declared constructor", name)
+		}
+	}
+
+	g := javaMethodRefGraph(t, files)
+	// `new Wrapper()` is an instantiation, not a method reference: it must not
+	// produce a callback_registration edge on the constructor.
+	for _, e := range g.GetInEdges("app/Wrapper.java::Wrapper.<init>") {
+		if e.Meta == nil {
+			continue
+		}
+		if via, _ := e.Meta["via"].(string); via == "callback_registration" {
+			t.Errorf("`new Wrapper()` produced a method-reference edge on the constructor")
+		}
+	}
+}

--- a/internal/parser/languages/java_method_ref_test.go
+++ b/internal/parser/languages/java_method_ref_test.go
@@ -2,8 +2,10 @@ package languages
 
 import (
 	"sort"
+	"strings"
 	"testing"
 
+	"github.com/zzet/gortex/internal/analysis"
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/resolver"
 )
@@ -251,5 +253,102 @@ public class Statics {
 		if srcs[0] != "app/Registry.java" {
 			t.Errorf("class-level reference to %s anchored to %q, want the file node app/Registry.java", target, srcs[0])
 		}
+	}
+}
+
+// TestJavaMethodRef_OverloadSet pins that an overloaded target keeps every
+// overload reachable. Which overload a method reference selects depends on the
+// target functional interface's shape, which the graph does not model — so the
+// unique-or-drop rule discarded the reference entirely and reported the whole
+// set dead. The set binds instead, at reduced confidence to mark the ambiguity.
+func TestJavaMethodRef_OverloadSet(t *testing.T) {
+	g := javaMethodRefGraph(t, map[string]string{
+		"app/Uses.java": `package app;
+import java.util.List;
+public class Uses {
+	public void go(List<String> xs) { xs.forEach(Overloads::handle); }
+}
+`,
+		"app/Overloads.java": `package app;
+public class Overloads {
+	public static void handle(String s) {}
+	public static void handle(int i) {}
+	public static void handle(String s, int i) {}
+}
+`,
+	})
+
+	bound := 0
+	for _, e := range g.GetOutEdges("app/Uses.java::Uses.go") {
+		if e.Meta == nil {
+			continue
+		}
+		if via, _ := e.Meta["via"].(string); via != "callback_registration" {
+			continue
+		}
+		bound++
+		if n, _ := e.Meta["overload_set"].(int); n != 3 {
+			t.Errorf("overload edge -> %s: overload_set = %v, want 3", e.To, e.Meta["overload_set"])
+		}
+		if e.Confidence >= 0.85 {
+			t.Errorf("overload edge -> %s: confidence %v must stay below a unique match's 0.85", e.To, e.Confidence)
+		}
+		if e.Origin != graph.OriginASTInferred {
+			t.Errorf("overload edge -> %s: Origin = %q, want OriginASTInferred", e.To, e.Origin)
+		}
+	}
+	if bound != 3 {
+		t.Errorf("bound %d overloads, want all 3 reachable", bound)
+	}
+}
+
+// TestJavaMethodRef_RescuesFromDeadCode is the issue's acceptance criterion: a
+// non-public method reached only through a method reference must not be
+// reported as dead code. It uses the two positions that produced no edge at all
+// — a class-level field initializer, and an overloaded target — because those
+// are what made dead-code analysis mark a live method dead.
+func TestJavaMethodRef_RescuesFromDeadCode(t *testing.T) {
+	files := map[string]string{
+		"app/Registry.java": `package app;
+import java.util.List;
+import java.util.function.Consumer;
+public class Registry {
+	private static final Consumer<In> HANDLER = ExampleType::transform;
+
+	public void run(List<In> items) {
+		items.forEach(Overloads::handle);
+	}
+}
+`,
+		"app/ExampleType.java": `package app;
+public class ExampleType {
+	void transform(In in) {}
+	void neverReferenced(In in) {}
+}
+`,
+		"app/Overloads.java": `package app;
+public class Overloads {
+	static void handle(In in) {}
+	static void handle(In in, int flags) {}
+}
+`,
+	}
+
+	dead := map[string]bool{}
+	for _, d := range analysis.FindDeadCode(javaMethodRefGraph(t, files), nil, nil) {
+		dead[d.ID] = true
+	}
+
+	if dead["app/ExampleType.java::ExampleType.transform"] {
+		t.Errorf("a method reached through a field-initializer `ExampleType::transform` was reported dead")
+	}
+	for id := range dead {
+		if strings.HasPrefix(id, "app/Overloads.java::Overloads.handle") {
+			t.Errorf("overload %s is reached through `Overloads::handle` but was reported dead", id)
+		}
+	}
+	if !dead["app/ExampleType.java::ExampleType.neverReferenced"] {
+		t.Errorf("a genuinely unreferenced package-private method should still be reported dead — " +
+			"otherwise this test cannot distinguish the fix from a blanket rescue")
 	}
 }

--- a/internal/parser/languages/java_method_ref_test.go
+++ b/internal/parser/languages/java_method_ref_test.go
@@ -210,3 +210,46 @@ public class Wrapper {
 		}
 	}
 }
+
+// TestJavaMethodRef_ClassLevelPosition pins a method reference in a field
+// initializer — a constant handler table or `Comparator` field, one of the
+// commonest places the syntax appears. It sits outside every method body, so
+// the enclosing-function lookup finds no owner; the reference is anchored to
+// the file node rather than dropped.
+func TestJavaMethodRef_ClassLevelPosition(t *testing.T) {
+	g := javaMethodRefGraph(t, map[string]string{
+		"app/Registry.java": `package app;
+
+import java.util.function.Consumer;
+
+public class Registry {
+	private static final Consumer<In> HANDLER = ExampleType::transform;
+	static final Runnable BOOT = Statics::configure;
+}
+`,
+		"app/ExampleType.java": `package app;
+public class ExampleType {
+	public void transform(In in) {}
+}
+`,
+		"app/Statics.java": `package app;
+public class Statics {
+	public static void configure() {}
+}
+`,
+	})
+
+	for _, target := range []string{
+		"app/ExampleType.java::ExampleType.transform",
+		"app/Statics.java::Statics.configure",
+	} {
+		srcs := methodRefSources(g, target)
+		if len(srcs) == 0 {
+			t.Errorf("expected a reference edge on %s from a field initializer", target)
+			continue
+		}
+		if srcs[0] != "app/Registry.java" {
+			t.Errorf("class-level reference to %s anchored to %q, want the file node app/Registry.java", target, srcs[0])
+		}
+	}
+}

--- a/internal/resolver/fn_value_gate.go
+++ b/internal/resolver/fn_value_gate.go
@@ -125,61 +125,74 @@ func resolveFnValueCallbacks(g graph.Store, scope map[string]bool) int {
 		recvHint, _ := edge.Meta["fn_ref_recv_hint"].(string)
 		ungated, _ := edge.Meta["fn_value_ungated"].(bool)
 		skipGate, _ := edge.Meta["skip_gate"].(bool)
-		target := ""
+		var targets []string
 		conf := 0.6
 		origin := graph.OriginASTInferred
 		switch {
 		case skipGate:
+			target := ""
 			if recvHint != "" {
 				target = resolveMemberByTypeMemo(g, recvHint, name, nameMemo)
 			}
 			if target == "" {
 				target = resolveUniqueFnValueMemo(g, name, nameMemo)
 			}
-			conf = 0.5
+			targets, conf = appendTarget(nil, target), 0.5
 		case recvHint == "<self>":
-			if target = resolveFnValueSelfMemberMemo(g, edge.From, name, nameMemo); target != "" {
+			if targets = resolveFnValueSelfMembersMemo(g, edge.From, name, nameMemo); len(targets) > 0 {
 				conf, origin = 0.85, graph.OriginASTResolved
 			} else {
-				target = sameFileTarget(edge.FilePath, name)
+				targets = appendTarget(nil, sameFileTarget(edge.FilePath, name))
 			}
 		case recvHint != "":
-			if target = resolveMemberByTypeMemo(g, recvHint, name, nameMemo); target != "" {
+			if targets = resolveMembersByTypeMemo(g, recvHint, name, nameMemo); len(targets) > 0 {
 				conf, origin = 0.85, graph.OriginASTResolved
 			} else if ungated {
-				target = resolveFnValueCrossModuleMemo(g, name, nameMemo)
+				targets = appendTarget(nil, resolveFnValueCrossModuleMemo(g, name, nameMemo))
 				conf = 0.45
 			}
 		default:
-			target = sameFileTarget(edge.FilePath, name)
-			if target == "" && ungated {
-				target = resolveFnValueCrossModuleMemo(g, name, nameMemo)
+			targets = appendTarget(nil, sameFileTarget(edge.FilePath, name))
+			if len(targets) == 0 && ungated {
+				targets = appendTarget(nil, resolveFnValueCrossModuleMemo(g, name, nameMemo))
 				conf = 0.45
 			}
 		}
-		if target == "" || target == edge.From {
-			continue
+		// An overload set is a genuine ambiguity — exactly one member is the
+		// real target and the graph cannot say which — so each edge in the set
+		// rides the inferred tier at reduced confidence rather than claiming
+		// the resolved-match certainty a lone hit earns.
+		if len(targets) > 1 {
+			conf, origin = 0.6, graph.OriginASTInferred
 		}
-		meta := map[string]any{
-			"via":             fnValueRegistrationVia,
-			metaFnValueName:   name,
-			MetaSynthesizedBy: SynthFnValueCallback,
-			MetaProvenance:    ProvenanceHeuristic,
+		for _, target := range targets {
+			if target == "" || target == edge.From {
+				continue
+			}
+			meta := map[string]any{
+				"via":             fnValueRegistrationVia,
+				metaFnValueName:   name,
+				MetaSynthesizedBy: SynthFnValueCallback,
+				MetaProvenance:    ProvenanceHeuristic,
+			}
+			if form, _ := edge.Meta["fn_ref_form"].(string); form != "" {
+				meta["fn_ref_form"] = form
+			}
+			if len(targets) > 1 {
+				meta["overload_set"] = len(targets)
+			}
+			landed = append(landed, &graph.Edge{
+				From:            edge.From,
+				To:              target,
+				Kind:            graph.EdgeReferences,
+				FilePath:        edge.FilePath,
+				Line:            edge.Line,
+				Confidence:      conf,
+				ConfidenceLabel: graph.ConfidenceLabelFor(graph.EdgeReferences, conf),
+				Origin:          origin,
+				Meta:            meta,
+			})
 		}
-		if form, _ := edge.Meta["fn_ref_form"].(string); form != "" {
-			meta["fn_ref_form"] = form
-		}
-		landed = append(landed, &graph.Edge{
-			From:            edge.From,
-			To:              target,
-			Kind:            graph.EdgeReferences,
-			FilePath:        edge.FilePath,
-			Line:            edge.Line,
-			Confidence:      conf,
-			ConfidenceLabel: graph.ConfidenceLabelFor(graph.EdgeReferences, conf),
-			Origin:          origin,
-			Meta:            meta,
-		})
 	}
 
 	// One bounded AddBatch per chunk instead of an AddEdge per edge: on a
@@ -426,20 +439,64 @@ func resolveMemberByTypeMemo(g graph.Store, typeName, member string, memo map[st
 	return match
 }
 
-// resolveFnValueSelfMemberMemo binds a `this.m` / `self.m` member reference
+// resolveMembersByTypeMemo returns every method of typeName named member —
+// the complete overload set, not the unique-or-drop single match
+// resolveMemberByTypeMemo yields.
+//
+// In Java (and C#, Kotlin, C++) a type may declare one name several times, and
+// a method reference such as `Type::handle` names the whole set: which overload
+// applies is decided by the target functional interface's shape, which the
+// graph does not model. Unique-or-drop therefore discarded the reference
+// outright the moment a target was overloaded, leaving every overload with no
+// incoming reference at all — so an overloaded method reached only through a
+// method reference was reported dead. Binding the set keeps each overload
+// reachable; the caller reduces confidence to mark the ambiguity.
+func resolveMembersByTypeMemo(g graph.Store, typeName, member string, memo map[string][]*graph.Node) []string {
+	if typeName == "" || member == "" {
+		return nil
+	}
+	var out []string
+	seen := map[string]bool{}
+	for _, n := range findNodesByNameMemo(g, member, memo) {
+		if n == nil || n.Kind != graph.KindMethod {
+			continue
+		}
+		if recv, _ := n.Meta["receiver"].(string); recv != typeName {
+			continue
+		}
+		if seen[n.ID] {
+			continue
+		}
+		seen[n.ID] = true
+		out = append(out, n.ID)
+	}
+	return out
+}
+
+// resolveFnValueSelfMembersMemo binds a `this.m` / `self.m` member reference
 // against the methods of the registration site's enclosing type, so it can
-// never bind a coincidentally-named top-level function. A shared per-pass
-// FindNodesByName memo collapses repeated lookups (nil disables memoization).
-func resolveFnValueSelfMemberMemo(g graph.Store, fromID, member string, memo map[string][]*graph.Node) string {
+// never bind a coincidentally-named top-level function. Returns the full
+// overload set. A shared per-pass FindNodesByName memo collapses repeated
+// lookups (nil disables memoization).
+func resolveFnValueSelfMembersMemo(g graph.Store, fromID, member string, memo map[string][]*graph.Node) []string {
 	from := g.GetNode(fromID)
 	if from == nil || from.Meta == nil {
-		return ""
+		return nil
 	}
 	recv, _ := from.Meta["receiver"].(string)
 	if recv == "" {
-		return ""
+		return nil
 	}
-	return resolveMemberByTypeMemo(g, recv, member, memo)
+	return resolveMembersByTypeMemo(g, recv, member, memo)
+}
+
+// appendTarget appends a resolved target ID to a list, skipping the empty
+// "unresolved" sentinel so single-match paths compose with the set-valued ones.
+func appendTarget(dst []string, target string) []string {
+	if target == "" {
+		return dst
+	}
+	return append(dst, target)
 }
 
 // isFnValueNonTarget reports whether name is a literal/keyword/builtin that


### PR DESCRIPTION
Closes #431.

## Validation

The report is confirmed, but the cause is not a missing extractor: Java `method_reference` capture already existed and a plain `ExampleType::transform` between two files does bind. Reproducing against the real extractor + resolver pair found four distinct positions where the reference was silently dropped, which is why a live method looked dead:

| Form | Before | After |
|---|---|---|
| `Type::new` | no candidate emitted | binds to `<Type>.<init>` |
| `app.Deep::run`, `Outer.Inner::run`, `Box<In>::run` | dropped unless the method name is repo-unique | binds by receiver |
| `Foo::bar` in a field / static initializer | dropped | binds, anchored to the file node |
| `Type::method` where the type overloads `method` | dropped, **whole overload set reported dead** | every overload binds |

`analyze dead_code` needed no change — `EdgeReferences` already counts as incoming usage for methods. It reported the method dead because no edge existed at all.

## Changes

**`Type::new` and qualified receivers** (`fn_ref_special.go`) — `new` is an anonymous token in the Java grammar, so the trailing-named-child rule read the *type* as the member name and the flood guard then dropped the candidate. The constructor form is now detected off the source text (an explicit type witness, `Foo::<T>new`, can sit between the `::` and the keyword) and resolved to the `<Type>.<init>` member the extractor already indexes; `String[]::new` is excluded, since an array allocation has no declared constructor. Separately, the receiver hint was raw qualifier text, so it never matched the simple type name a method's receiver is stamped with — it is now reduced to that simple name before lookup.

**Class-level positions** (`fn_value_capture.go`) — a method reference in a field or static initializer sits outside every method body, so the enclosing-function lookup found no owner and the candidate was discarded before reaching the gate. It is now anchored to the file node, matching what the Java type-use pass already does for class-level type references. Only the unambiguous whole-node forms take this fallback; a bare identifier outside any function is far more likely a local or a builtin, so it still requires an enclosing function.

**Overload sets** (`fn_value_gate.go`) — the type-scoped lookup was unique-or-drop, so an overloaded target matched nothing and the ungated fallback dropped it too (also unique-or-drop). Which overload a method reference selects is decided by the target functional interface's shape, which the graph does not model, so the whole set now binds rather than the resolver guessing. Those edges ride the inferred tier at reduced confidence instead of claiming the certainty a lone match earns, and carry `overload_set` for consumers that want to weigh them.

## Tests

`internal/parser/languages/java_method_ref_test.go` runs extract → gate → dead-code, and covers the four forms from the issue (`Type::staticMethod`, `Type::instanceMethod`, `instance::method`, `Type::new`, plus `this::method`), class-level positions, overload sets, qualified/nested/generic receivers, and negatives (`String[]::new` must not fabricate a constructor; `new Wrapper()` must not become a method reference). Each test was verified to fail with the fix reverted.

The dead-code test also asserts a genuinely unreferenced package-private method is *still* reported dead, so it distinguishes the fix from a blanket rescue.

`go build`, `go vet`, `golangci-lint run ./...` (0 issues), `go test ./...` and `go test -race ./...` all green across 179 packages.