### PR TITLE
fix(resolver): stop bare JS/TS specifiers binding same-named local dirs

### DIFF
--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -558,6 +558,10 @@ func New(g graph.Store, reg *parser.Registry, cfg config.IndexConfig, logger *za
 	// local index. The index is built lazily on first use — the repo
 	// root and prefix are not final until after New().
 	idx.resolver.SetNpmAliasResolver(idx.resolveNpmAliasImport)
+	// Refuse to bind a bare JS/TS specifier the importer declares as an
+	// external (registry / git / tarball) dependency to any in-repo
+	// directory. Same lazy-build rationale.
+	idx.resolver.SetNpmDependencyLookup(idx.declaresExternalNpmDep)
 	// Expand JS/TS tsconfig/jsconfig path-alias imports (`@/lib/x`)
 	// against the local index so cross-directory alias imports resolve
 	// to their real file. Same lazy-build rationale.
@@ -578,6 +582,18 @@ func (idx *Indexer) resolveNpmAliasImport(callerFile, specifier string) string {
 		idx.npmAlias = newNpmAliasIndex(map[string]string{idx.repoPrefix: idx.rootPath})
 	})
 	return idx.npmAlias.Resolve(callerFile, specifier)
+}
+
+// declaresExternalNpmDep is the resolver.NpmDependencyLookup installed on
+// this Indexer's resolver. It reports whether the importing file declares
+// the specifier's package as a dependency resolving outside the repo, so
+// the resolver can refuse to bind it to a same-named local directory. The
+// backing npmAliasIndex is the one resolveNpmAliasImport builds.
+func (idx *Indexer) declaresExternalNpmDep(callerFile, specifier string) bool {
+	idx.npmAliasOnce.Do(func() {
+		idx.npmAlias = newNpmAliasIndex(map[string]string{idx.repoPrefix: idx.rootPath})
+	})
+	return idx.npmAlias.DeclaresExternalDependency(callerFile, specifier)
 }
 
 // swappable returns the search backend cast to *search.Swappable. Panics

--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -231,6 +231,25 @@ func (mi *MultiIndexer) npmAliasResolver() resolver.NpmAliasResolver {
 	return idx.Resolve
 }
 
+// npmDependencyLookup builds a resolver.NpmDependencyLookup covering every
+// tracked repo's on-disk root. Installed alongside npmAliasResolver so a
+// bare JS/TS specifier declared as an external dependency never binds to a
+// same-named in-repo directory. Returns nil when no repo has a usable root
+// — callers treat that as "no dependency signal".
+func (mi *MultiIndexer) npmDependencyLookup() resolver.NpmDependencyLookup {
+	roots := map[string]string{}
+	for prefix, meta := range mi.AllMetadata() {
+		if meta != nil && meta.RootPath != "" {
+			roots[prefix] = meta.RootPath
+		}
+	}
+	idx := newNpmAliasIndex(roots)
+	if idx == nil {
+		return nil
+	}
+	return idx.DeclaresExternalDependency
+}
+
 // workspaceMembershipResolver builds a resolver.WorkspaceMembership
 // covering every tracked repo's on-disk root. Installed on the global
 // post-pass resolver and the cross-repo resolver so a same-named import
@@ -889,6 +908,7 @@ func (mi *MultiIndexer) newMasterResolver(useLSP bool) *resolver.Resolver {
 		master.SetLSPHelper(mi.resolverLSPHelper)
 	}
 	master.SetNpmAliasResolver(mi.npmAliasResolver())
+	master.SetNpmDependencyLookup(mi.npmDependencyLookup())
 	master.SetPathAliasResolver(mi.pathAliasResolver())
 	master.SetWorkspaceMembership(mi.workspaceMembershipResolver())
 	return master

--- a/internal/indexer/npm_alias_resolve.go
+++ b/internal/indexer/npm_alias_resolve.go
@@ -40,6 +40,10 @@ type npmAliasIndex struct {
 	// A nil value records "read, but no npm-alias entries / missing
 	// file" so a miss is not re-read on every import edge.
 	aliasCache map[string]map[string]string
+	// depsCache memoises the full declared-dependency map of one
+	// package.json: disk path → (package name → verbatim version spec).
+	// A nil value records "read, but no dependencies / missing file".
+	depsCache map[string]map[string]string
 	// exportsCache memoises the parsed `exports` subpath map of one
 	// package.json: disk path → packageExports. A nil value records
 	// "read, but no usable `exports` field / missing file" so a miss
@@ -80,6 +84,7 @@ func newNpmAliasIndex(roots map[string]string) *npmAliasIndex {
 	return &npmAliasIndex{
 		roots:        usable,
 		aliasCache:   map[string]map[string]string{},
+		depsCache:    map[string]map[string]string{},
 		exportsCache: map[string]*packageExports{},
 	}
 }
@@ -216,6 +221,103 @@ func (x *npmAliasIndex) aliasesFor(absPath string) map[string]string {
 	}
 	x.aliasCache[absPath] = aliases
 	return aliases
+}
+
+// DeclaresExternalDependency implements resolver.NpmDependencyLookup: it
+// reports whether the importing file's nearest-ancestor package.json
+// declares the specifier's package portion as a dependency that resolves
+// OUTSIDE the repository.
+//
+// npm honours the nearest manifest, so the walk stops at the first
+// package.json declaring the name — a nearer `workspace:*` correctly
+// shadows a farther registry range. A name declared nowhere reports false:
+// absence of a manifest entry is not evidence either way (the file may sit
+// outside any package, or the manifest may be unreadable), and the caller's
+// entry-point rule still applies.
+func (x *npmAliasIndex) DeclaresExternalDependency(callerFile, specifier string) bool {
+	if x == nil || callerFile == "" || specifier == "" {
+		return false
+	}
+	if !isJSTSFile(callerFile) {
+		return false
+	}
+	if strings.HasPrefix(specifier, ".") || strings.HasPrefix(specifier, "/") {
+		return false
+	}
+	root, relDir, ok := x.locate(callerFile)
+	if !ok {
+		return false
+	}
+	pkgName, _ := splitPackageSpecifier(specifier)
+	if pkgName == "" {
+		return false
+	}
+	for dir := relDir; ; dir = path.Dir(dir) {
+		manifest := joinPath(root, joinRel(dir, "package.json"))
+		if version, found := x.dependenciesFor(manifest)[pkgName]; found {
+			return !npmSpecResolvesInRepo(version)
+		}
+		if dir == "." || dir == "" || dir == "/" {
+			return false
+		}
+	}
+}
+
+// npmSpecResolvesInRepo reports whether an npm dependency version spec
+// names something inside the repository rather than a published artifact:
+// a workspace member (`workspace:*`), a linked or portalled directory
+// (`link:../ui`, `portal:../ui`), a local path (`file:../ui`, `./ui`,
+// `../ui`, `/abs/ui`).
+//
+// Everything else — semver ranges, dist-tags, `npm:` aliases, git/github
+// specs, tarball URLs, pnpm `catalog:` entries (which resolve to a registry
+// version) — comes from outside the tree. The distinction matters because a
+// pnpm monorepo declares its own members as dependencies too, and those DO
+// legitimately bind to an in-repo directory; `pnpm-workspace.yaml` members
+// are not covered by the root manifest's `workspaces` globs, so they reach
+// the resolver's directory cascade and must not be refused there.
+func npmSpecResolvesInRepo(version string) bool {
+	v := strings.TrimSpace(version)
+	if v == "" {
+		return false
+	}
+	for _, prefix := range []string{"workspace:", "link:", "portal:", "file:"} {
+		if strings.HasPrefix(v, prefix) {
+			return true
+		}
+	}
+	return strings.HasPrefix(v, "./") || strings.HasPrefix(v, "../") || strings.HasPrefix(v, "/")
+}
+
+// dependenciesFor returns the declared-dependency map (package name →
+// verbatim version spec) of the package.json at absPath, reading and
+// caching it on first request. A nil value records "read, but no
+// dependencies / missing file" so a miss is not re-read per import edge.
+//
+// This reuses the very parse aliasesFor already performs — ParsePackageJSON
+// returns every dependencies / devDependencies / peerDependencies /
+// optionalDependencies entry, and aliasesFor discards all but the aliased
+// ones.
+func (x *npmAliasIndex) dependenciesFor(absPath string) map[string]string {
+	x.mu.Lock()
+	defer x.mu.Unlock()
+	if cached, seen := x.depsCache[absPath]; seen {
+		return cached
+	}
+	var deps map[string]string
+	if src, ok := readDiskFile(absPath); ok {
+		for _, spec := range modules.ParsePackageJSON(src) {
+			if spec.Ecosystem != "npm" || spec.Path == "" {
+				continue
+			}
+			if deps == nil {
+				deps = map[string]string{}
+			}
+			deps[spec.Path] = spec.Version
+		}
+	}
+	x.depsCache[absPath] = deps
+	return deps
 }
 
 // exportsFor returns the parsed `exports` subpath map of the

--- a/internal/indexer/npm_dependency_lookup_test.go
+++ b/internal/indexer/npm_dependency_lookup_test.go
@@ -1,0 +1,128 @@
+package indexer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeManifest(t *testing.T, root, dir, body string) {
+	t.Helper()
+	abs := filepath.Join(root, filepath.FromSlash(dir))
+	require.NoError(t, os.MkdirAll(abs, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(abs, "package.json"), []byte(body), 0o644))
+}
+
+// TestDeclaresExternalDependency_RegistryVsWorkspace pins the discriminator
+// that keeps pnpm monorepos working: a registry range is external, a
+// `workspace:*` member is not.
+func TestDeclaresExternalDependency_RegistryVsWorkspace(t *testing.T) {
+	root := t.TempDir()
+	writeManifest(t, root, ".", `{
+		"dependencies": {
+			"graphql": "^16.8.0",
+			"logger": "workspace:*",
+			"ui": "link:../ui",
+			"legacy": "file:../legacy",
+			"vendored": "portal:../vendored",
+			"rel": "../sibling",
+			"forked": "github:acme/forked",
+			"tagged": "latest"
+		},
+		"devDependencies": { "zod": "3.22.4" }
+	}`)
+
+	x := newNpmAliasIndex(map[string]string{"": root})
+	require.NotNil(t, x)
+
+	external := []string{"graphql", "zod", "forked", "tagged"}
+	for _, pkg := range external {
+		assert.True(t, x.DeclaresExternalDependency("src/app.ts", pkg),
+			"%q should be external", pkg)
+	}
+	inRepo := []string{"logger", "ui", "legacy", "vendored", "rel"}
+	for _, pkg := range inRepo {
+		assert.False(t, x.DeclaresExternalDependency("src/app.ts", pkg),
+			"%q should resolve in-repo", pkg)
+	}
+}
+
+// TestDeclaresExternalDependency_UndeclaredIsNotEvidence pins that a name no
+// manifest declares reports false — absence is not evidence, and the
+// resolver's entry-point rule still applies.
+func TestDeclaresExternalDependency_UndeclaredIsNotEvidence(t *testing.T) {
+	root := t.TempDir()
+	writeManifest(t, root, ".", `{"dependencies": {"graphql": "^16.8.0"}}`)
+
+	x := newNpmAliasIndex(map[string]string{"": root})
+	require.NotNil(t, x)
+
+	assert.False(t, x.DeclaresExternalDependency("src/app.ts", "never-declared"))
+}
+
+// TestDeclaresExternalDependency_NearestManifestWins pins npm resolution
+// order: a nearer `workspace:*` shadows a farther registry range.
+func TestDeclaresExternalDependency_NearestManifestWins(t *testing.T) {
+	root := t.TempDir()
+	writeManifest(t, root, ".", `{"dependencies": {"logger": "^2.0.0"}}`)
+	writeManifest(t, root, "packages/app", `{"dependencies": {"logger": "workspace:*"}}`)
+
+	x := newNpmAliasIndex(map[string]string{"": root})
+	require.NotNil(t, x)
+
+	assert.False(t, x.DeclaresExternalDependency("packages/app/src/main.ts", "logger"),
+		"the nearer workspace: entry wins")
+	assert.True(t, x.DeclaresExternalDependency("tools/cli/main.ts", "logger"),
+		"outside that member the root registry range applies")
+}
+
+// TestDeclaresExternalDependency_ScopedAndSubpath pins that the package
+// portion is what gets looked up, not the whole specifier.
+func TestDeclaresExternalDependency_ScopedAndSubpath(t *testing.T) {
+	root := t.TempDir()
+	writeManifest(t, root, ".", `{"dependencies": {"@acme/utils": "^1.0.0", "lodash": "^4.17.21"}}`)
+
+	x := newNpmAliasIndex(map[string]string{"": root})
+	require.NotNil(t, x)
+
+	assert.True(t, x.DeclaresExternalDependency("src/app.ts", "@acme/utils"))
+	assert.True(t, x.DeclaresExternalDependency("src/app.ts", "@acme/utils/format"))
+	assert.True(t, x.DeclaresExternalDependency("src/app.ts", "lodash/merge"))
+}
+
+// TestDeclaresExternalDependency_NonJSTSAndPathSpecifiers pins the cheap
+// rejections: only JS/TS callers with bare specifiers are answered.
+func TestDeclaresExternalDependency_NonJSTSAndPathSpecifiers(t *testing.T) {
+	root := t.TempDir()
+	writeManifest(t, root, ".", `{"dependencies": {"graphql": "^16.8.0"}}`)
+
+	x := newNpmAliasIndex(map[string]string{"": root})
+	require.NotNil(t, x)
+
+	assert.False(t, x.DeclaresExternalDependency("app/main.py", "graphql"), "non-JS/TS caller")
+	assert.False(t, x.DeclaresExternalDependency("src/app.ts", "./graphql"), "relative specifier")
+	assert.False(t, x.DeclaresExternalDependency("src/app.ts", "/graphql"), "absolute specifier")
+	assert.False(t, x.DeclaresExternalDependency("", "graphql"))
+	assert.False(t, x.DeclaresExternalDependency("src/app.ts", ""))
+}
+
+// TestDeclaresExternalDependency_NilIndexIsSafe pins the nil receiver — the
+// resolver treats a nil lookup as "no signal".
+func TestDeclaresExternalDependency_NilIndexIsSafe(t *testing.T) {
+	var x *npmAliasIndex
+	assert.False(t, x.DeclaresExternalDependency("src/app.ts", "graphql"))
+}
+
+func TestNpmSpecResolvesInRepo(t *testing.T) {
+	inRepo := []string{"workspace:*", "workspace:^1.0.0", "link:../ui", "portal:../ui", "file:../legacy", "./local", "../sibling", "/abs/path"}
+	for _, v := range inRepo {
+		assert.True(t, npmSpecResolvesInRepo(v), "%q", v)
+	}
+	external := []string{"^16.8.0", "~3.4.1", ">=2 <3", "latest", "*", "npm:@acme/real@1.0.0", "github:acme/forked", "git+ssh://git@host/x.git", "https://example.com/x.tgz", "catalog:", ""}
+	for _, v := range external {
+		assert.False(t, npmSpecResolvesInRepo(v), "%q", v)
+	}
+}

--- a/internal/indexer/workspace_resolve.go
+++ b/internal/indexer/workspace_resolve.go
@@ -323,6 +323,7 @@ func (mi *MultiIndexer) newCrossRepoResolver() *resolver.CrossRepoResolver {
 	cr.SetLogger(mi.logger)
 	cr.SetCrossWorkspaceDepLookup(mi.crossWorkspacePassLookup())
 	cr.SetNpmAliasResolver(mi.npmAliasResolver())
+	cr.SetNpmDependencyLookup(mi.npmDependencyLookup())
 	cr.SetPathAliasResolver(mi.pathAliasResolver())
 	cr.SetWorkspaceMembership(mi.workspaceMembershipResolver())
 	mi.applyRemoteStitch(cr)

--- a/internal/resolver/cross_repo.go
+++ b/internal/resolver/cross_repo.go
@@ -1305,10 +1305,17 @@ func (cr *CrossRepoResolver) resolveImport(e *graph.Edge, importPath string, sta
 	// own workspace; otherwise the first same-repo hit short-circuits
 	// the scan as before.
 	collectAll := cr.workspaceMembers != nil
+	// A JS/TS bare specifier names a node_modules package or a workspace
+	// member — only a directory entry point is evidence. Mirrors
+	// Resolver.resolveImport; see isJSTSDirEntryPoint (issue #450).
+	bareJSTS := isJSTSBareSpecifier(jsTSImportCallerFile(e), importPath)
 	var sameRepo graph.FileNodeIdentity
 	var sameRepoFound bool
 	var sameRepoAll, crossRepoAll []graph.FileNodeIdentity
 	consider := func(file graph.FileNodeIdentity) {
+		if bareJSTS && !isJSTSDirEntryPoint(file.FilePath) {
+			return
+		}
 		if file.RepoPrefix == callerRepo {
 			if !sameRepoFound {
 				sameRepo, sameRepoFound = file, true

--- a/internal/resolver/cross_repo.go
+++ b/internal/resolver/cross_repo.go
@@ -133,6 +133,11 @@ type CrossRepoResolver struct {
 	// ancestor package.json. Same contract as the field of the
 	// same name on Resolver — see npm_alias.go.
 	npmAlias NpmAliasResolver
+	// npmDep reports whether a bare JS/TS specifier is declared by the
+	// importer as a dependency resolving outside the repository. Same
+	// contract as the field of the same name on Resolver — see
+	// npm_dependency.go.
+	npmDep NpmDependencyLookup
 	// pathAlias expands a JS/TS tsconfig/jsconfig path-alias / baseUrl
 	// import specifier to the repo-prefixed file stem it targets. Same
 	// contract as the field of the same name on Resolver — see
@@ -1309,6 +1314,9 @@ func (cr *CrossRepoResolver) resolveImport(e *graph.Edge, importPath string, sta
 	// member — only a directory entry point is evidence. Mirrors
 	// Resolver.resolveImport; see isJSTSDirEntryPoint (issue #450).
 	bareJSTS := isJSTSBareSpecifier(jsTSImportCallerFile(e), importPath)
+	// Declared node_modules package — no in-repo directory is a candidate.
+	// Mirrors Resolver.resolveImport; see declaresExternalNpmDep.
+	externalNpmDep := bareJSTS && declaresExternalNpmDep(cr.npmDep, jsTSImportCallerFile(e), importPath)
 	var sameRepo graph.FileNodeIdentity
 	var sameRepoFound bool
 	var sameRepoAll, crossRepoAll []graph.FileNodeIdentity
@@ -1337,7 +1345,9 @@ func (cr *CrossRepoResolver) resolveImport(e *graph.Edge, importPath string, sta
 		}
 	}
 	stop := func() bool { return sameRepoFound && !collectAll }
-	if cr.dirIndex != nil {
+	if externalNpmDep {
+		// Declared node_modules package — skip the cascade outright.
+	} else if cr.dirIndex != nil {
 		for _, file := range cr.dirIndex[importPath] {
 			consider(file)
 			if stop() {

--- a/internal/resolver/jsts_bare_specifier_test.go
+++ b/internal/resolver/jsts_bare_specifier_test.go
@@ -1,0 +1,217 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// seedImportEdge drops in a pending `unresolved::import::<spec>` edge —
+// the shape resolveImport consumes.
+func seedImportEdge(g graph.Store, fileID, spec string) *graph.Edge {
+	e := &graph.Edge{
+		From:     fileID,
+		To:       "unresolved::import::" + spec,
+		Kind:     graph.EdgeImports,
+		FilePath: fileID,
+		Line:     1,
+	}
+	g.AddEdge(e)
+	return e
+}
+
+// TestResolveImport_BareNpmSpecifierDoesNotBindSameNamedDir pins issue #450:
+// a bare npm specifier must never bind to a same-repo directory that merely
+// shares its name. The `lastDirIndex` cascade keys on the last path component
+// of every indexed file's directory, so `import … from 'graphql'` used to also
+// land on whatever file sits under some unrelated `*/graphql/` directory.
+func TestResolveImport_BareNpmSpecifierDoesNotBindSameNamedDir(t *testing.T) {
+	g := graph.New()
+	seedFile(g, "src/consumer-graphql.ts", "typescript")
+	seedFile(g, "src/feature/graphql/create.mutation.gql", "graphql")
+	e := seedImportEdge(g, "src/consumer-graphql.ts", "graphql")
+
+	New(g).ResolveAll()
+
+	assert.Equal(t, "external::graphql", e.To,
+		"a bare npm specifier must stay external, not bind to src/feature/graphql/")
+}
+
+// TestResolveImport_ScopedBareSpecifierDoesNotBindSameNamedDir covers the
+// scoped-package shape: `@acme/utils` last-components to `utils`, which
+// matches every `*/utils/` directory in the repo.
+func TestResolveImport_ScopedBareSpecifierDoesNotBindSameNamedDir(t *testing.T) {
+	g := graph.New()
+	seedFile(g, "src/app.tsx", "typescript")
+	seedFile(g, "src/shared/utils/format.ts", "typescript")
+	e := seedImportEdge(g, "src/app.tsx", "@acme/utils")
+
+	New(g).ResolveAll()
+
+	assert.Equal(t, "external::@acme/utils", e.To,
+		"a scoped bare specifier must stay external, not bind to src/shared/utils/")
+}
+
+// TestResolveImport_BareSpecifierSubpathDoesNotBindSameNamedDir covers a
+// deep specifier (`lodash/merge`) whose last component collides with a repo
+// directory.
+func TestResolveImport_BareSpecifierSubpathDoesNotBindSameNamedDir(t *testing.T) {
+	g := graph.New()
+	seedFile(g, "src/app.js", "javascript")
+	seedFile(g, "src/state/merge/reducer.js", "javascript")
+	e := seedImportEdge(g, "src/app.js", "lodash/merge")
+
+	New(g).ResolveAll()
+
+	assert.Equal(t, "external::lodash/merge", e.To,
+		"a bare subpath specifier must stay external, not bind to src/state/merge/")
+}
+
+// TestResolveImport_BareSpecifierWithNoCollisionStaysExternal is the control
+// from the issue: with no same-named directory the specifier was already
+// external, and must stay that way.
+func TestResolveImport_BareSpecifierWithNoCollisionStaysExternal(t *testing.T) {
+	g := graph.New()
+	seedFile(g, "src/consumer-lodash.ts", "typescript")
+	e := seedImportEdge(g, "src/consumer-lodash.ts", "lodash")
+
+	New(g).ResolveAll()
+
+	assert.Equal(t, "external::lodash", e.To)
+}
+
+// TestResolveImport_JSTSRelativeSpecifierStillResolves guards the fix's
+// blast radius: relative specifiers are not bare and keep resolving onto the
+// in-repo file they name (issue #136 / #304 behaviour).
+func TestResolveImport_JSTSRelativeSpecifierStillResolves(t *testing.T) {
+	g := graph.New()
+	seedFile(g, "src/app.ts", "typescript")
+	seedFile(g, "src/lib/auth.ts", "typescript")
+	e := seedImportEdge(g, "src/app.ts", "./lib/auth")
+
+	New(g).ResolveAll()
+
+	assert.Equal(t, "src/lib/auth.ts", e.To, "relative JS/TS imports must keep resolving")
+}
+
+// TestResolveImport_JSTSPathAliasStillResolves guards that a tsconfig path
+// alias — expanded before the directory cascade — is untouched by the fix.
+func TestResolveImport_JSTSPathAliasStillResolves(t *testing.T) {
+	g := graph.New()
+	seedFile(g, "src/app.ts", "typescript")
+	seedFile(g, "src/lib/auth.ts", "typescript")
+	e := seedImportEdge(g, "src/app.ts", "@/lib/auth")
+
+	r := New(g)
+	r.SetPathAliasResolver(func(callerFile, specifier string) string {
+		if len(specifier) > 2 && specifier[:2] == "@/" {
+			return "src/" + specifier[2:]
+		}
+		return ""
+	})
+	r.ResolveAll()
+
+	assert.Equal(t, "src/lib/auth.ts", e.To, "tsconfig path aliases must keep resolving")
+}
+
+// TestResolveImport_NonJSTSCallerKeepsDirectoryCascade pins that the fix is
+// scoped to JS/TS callers: a Go/Python-style bare package import of an
+// in-repo directory still resolves through the cascade, which is the
+// behaviour buildDirIndexes documents ("an import of `logger` matches any
+// file under .../logger/").
+func TestResolveImport_NonJSTSCallerKeepsDirectoryCascade(t *testing.T) {
+	g := graph.New()
+	seedFile(g, "app/main.py", "python")
+	seedFile(g, "app/logger/handler.py", "python")
+	e := seedImportEdge(g, "app/main.py", "logger")
+
+	New(g).ResolveAll()
+
+	assert.Equal(t, "app/logger/handler.py", e.To,
+		"non-JS/TS bare imports keep the package-directory cascade")
+}
+
+// TestResolveImport_BareSpecifierBindsDirectoryEntryPoint pins the surviving
+// half of the rule: a bare specifier naming an in-repo package directory
+// still resolves — but only through that directory's entry point, the way
+// Node and tsc load a directory-shaped module.
+func TestResolveImport_BareSpecifierBindsDirectoryEntryPoint(t *testing.T) {
+	g := graph.New()
+	seedFile(g, "src/app.ts", "typescript")
+	seedFile(g, "packages/logger/index.ts", "typescript")
+	e := seedImportEdge(g, "src/app.ts", "logger")
+
+	New(g).ResolveAll()
+
+	assert.Equal(t, "packages/logger/index.ts", e.To,
+		"a bare specifier still binds a package directory via its entry point")
+}
+
+// TestResolveImport_BareSpecifierSkipsNonEntryPointSiblings pins that the
+// entry point wins over an arbitrary sibling regardless of iteration order —
+// the sibling is no longer an eligible candidate at all.
+func TestResolveImport_BareSpecifierSkipsNonEntryPointSiblings(t *testing.T) {
+	g := graph.New()
+	seedFile(g, "src/app.ts", "typescript")
+	seedFile(g, "packages/logger/aaa-first.ts", "typescript")
+	seedFile(g, "packages/logger/index.ts", "typescript")
+	e := seedImportEdge(g, "src/app.ts", "logger")
+
+	New(g).ResolveAll()
+
+	assert.Equal(t, "packages/logger/index.ts", e.To,
+		"only the directory entry point is an eligible candidate")
+}
+
+func TestIsJSTSDirEntryPoint(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"packages/logger/index.ts", true},
+		{"packages/logger/index.tsx", true},
+		{"packages/logger/index.js", true},
+		{"packages/logger/index.mjs", true},
+		{"packages/logger/index.cjs", true},
+		{"packages/logger/index.d.ts", true},
+		{"index.ts", true},
+		{"packages/logger/Index.TS", true}, // case-insensitive
+		{"packages/logger/handler.ts", false},
+		{"packages/logger/index.go", false},
+		{"packages/logger/index.gql", false},
+		{"packages/logger/reindex.ts", false},
+		{"packages/logger/index", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, isJSTSDirEntryPoint(c.path), "path=%q", c.path)
+	}
+}
+
+func TestIsJSTSBareSpecifier(t *testing.T) {
+	cases := []struct {
+		caller string
+		spec   string
+		want   bool
+	}{
+		{"src/app.ts", "graphql", true},
+		{"src/app.tsx", "@acme/utils", true},
+		{"src/app.js", "lodash/merge", true},
+		{"src/app.mjs", "node:fs", true},
+		{"src/app.ts", "graphql::parse", true}, // per-binding edge payload
+		{"src/app.ts", "./lib/auth", false},
+		{"src/app.ts", "../lib/auth", false},
+		{"src/app.ts", ".", false},
+		{"src/app.ts", "..", false},
+		{"src/app.ts", "/abs/path", false},
+		{"src/app.ts", "", false},
+		{"app/main.py", "graphql", false}, // non-JS/TS caller
+		{"main.go", "logger", false},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, isJSTSBareSpecifier(c.caller, c.spec),
+			"caller=%q spec=%q", c.caller, c.spec)
+	}
+}

--- a/internal/resolver/jsts_bare_specifier_test.go
+++ b/internal/resolver/jsts_bare_specifier_test.go
@@ -165,6 +165,62 @@ func TestResolveImport_BareSpecifierSkipsNonEntryPointSiblings(t *testing.T) {
 		"only the directory entry point is an eligible candidate")
 }
 
+// TestResolveImport_DeclaredExternalDepRefusesEntryPoint closes the residual
+// case the entry-point rule alone cannot reach: a repo that both depends on
+// npm `graphql` AND contains `src/feature/graphql/index.ts`. The manifest
+// says the package comes from the registry, so no in-repo directory is a
+// candidate.
+func TestResolveImport_DeclaredExternalDepRefusesEntryPoint(t *testing.T) {
+	g := graph.New()
+	seedFile(g, "src/app.ts", "typescript")
+	seedFile(g, "src/feature/graphql/index.ts", "typescript")
+	e := seedImportEdge(g, "src/app.ts", "graphql")
+
+	r := New(g)
+	r.SetNpmDependencyLookup(func(callerFile, specifier string) bool {
+		return specifier == "graphql" // declared "^16.8.0"
+	})
+	r.ResolveAll()
+
+	assert.Equal(t, "external::graphql", e.To,
+		"a declared registry dependency must not bind an in-repo entry point")
+}
+
+// TestResolveImport_WorkspaceProtocolDepStillBinds is the other half: a
+// dependency declared as `workspace:*` genuinely names an in-repo package,
+// so the lookup reports false and the entry-point binding survives. This is
+// what keeps pnpm monorepos working — their members are not covered by the
+// root manifest's `workspaces` globs.
+func TestResolveImport_WorkspaceProtocolDepStillBinds(t *testing.T) {
+	g := graph.New()
+	seedFile(g, "src/app.ts", "typescript")
+	seedFile(g, "packages/logger/index.ts", "typescript")
+	e := seedImportEdge(g, "src/app.ts", "logger")
+
+	r := New(g)
+	r.SetNpmDependencyLookup(func(callerFile, specifier string) bool {
+		return false // declared "workspace:*" → resolves in-repo
+	})
+	r.ResolveAll()
+
+	assert.Equal(t, "packages/logger/index.ts", e.To,
+		"a workspace-protocol dependency must still bind its in-repo entry point")
+}
+
+// TestResolveImport_NilDependencyLookupKeepsEntryPointRule pins that without
+// an injected lookup (no indexer wired) behaviour falls back to the
+// entry-point rule alone.
+func TestResolveImport_NilDependencyLookupKeepsEntryPointRule(t *testing.T) {
+	g := graph.New()
+	seedFile(g, "src/app.ts", "typescript")
+	seedFile(g, "packages/logger/index.ts", "typescript")
+	e := seedImportEdge(g, "src/app.ts", "logger")
+
+	New(g).ResolveAll()
+
+	assert.Equal(t, "packages/logger/index.ts", e.To)
+}
+
 func TestIsJSTSDirEntryPoint(t *testing.T) {
 	cases := []struct {
 		path string

--- a/internal/resolver/jsts_bare_specifier_test.go
+++ b/internal/resolver/jsts_bare_specifier_test.go
@@ -221,6 +221,42 @@ func TestResolveImport_NilDependencyLookupKeepsEntryPointRule(t *testing.T) {
 	assert.Equal(t, "packages/logger/index.ts", e.To)
 }
 
+// TestImportedDirForSpec_BareSpecifierGatesReachability pins the second
+// cascade site: reachableDirsByFile must not gain a directory just because
+// its name matches a bare npm specifier. A bogus entry there survives into
+// filterByReachability, where it lets a same-named call candidate defined in
+// that directory win a call edge.
+func TestImportedDirForSpec_BareSpecifierGatesReachability(t *testing.T) {
+	g := graph.New()
+	seedFile(g, "src/app.ts", "typescript")
+	seedFile(g, "src/feature/graphql/create.mutation.gql", "graphql")
+	seedFile(g, "packages/logger/index.ts", "typescript")
+	seedFile(g, "app/main.py", "python")
+	// A distinct name so the Python assertions can't collide with the
+	// `logger` candidates above — for non-JS/TS callers the cascade keeps
+	// its pre-existing first-hit-among-many behaviour, which would make a
+	// shared name ambiguous rather than wrong.
+	seedFile(g, "app/pylog/handler.py", "python")
+
+	r := New(g)
+	r.buildDirIndexes()
+
+	assert.Equal(t, "", r.importedDirForSpec("src/app.ts", "graphql"),
+		"a non-entry-point file must not make its directory reachable")
+	assert.Equal(t, "packages/logger", r.importedDirForSpec("src/app.ts", "logger"),
+		"an entry point still contributes reachability")
+	assert.Equal(t, "app/pylog", r.importedDirForSpec("app/main.py", "pylog"),
+		"non-JS/TS callers keep the unfiltered cascade")
+
+	r.SetNpmDependencyLookup(func(callerFile, specifier string) bool {
+		return specifier == "logger" || specifier == "pylog"
+	})
+	assert.Equal(t, "", r.importedDirForSpec("src/app.ts", "logger"),
+		"a declared external dependency contributes no in-repo directory")
+	assert.Equal(t, "app/pylog", r.importedDirForSpec("app/main.py", "pylog"),
+		"the dependency gate is JS/TS-only")
+}
+
 func TestIsJSTSDirEntryPoint(t *testing.T) {
 	cases := []struct {
 		path string

--- a/internal/resolver/jsts_imports.go
+++ b/internal/resolver/jsts_imports.go
@@ -226,3 +226,67 @@ func isJSTSPath(p string) bool {
 	}
 	return false
 }
+
+// isJSTSBareSpecifier reports whether callerFile is a JS/TS source importing
+// a BARE specifier — one Node resolves through `node_modules` / a workspace
+// member (`graphql`, `@acme/utils`, `lodash/merge`, `node:fs`) rather than
+// through the file system (`./auth`, `../lib/auth`, `/abs`). importPath is the
+// raw `import::` payload, so the optional `::<export>` suffix is stripped
+// first.
+//
+// Callers pair this with isJSTSDirEntryPoint to gate the package-directory
+// cascade in resolveImport; see that function for why.
+func isJSTSBareSpecifier(callerFile, importPath string) bool {
+	if !isJSTSPath(callerFile) {
+		return false
+	}
+	spec, _ := splitImportSpecSymbol(importPath)
+	switch {
+	case spec == "", spec == ".", spec == "..":
+		return false
+	case strings.HasPrefix(spec, "./"), strings.HasPrefix(spec, "../"), strings.HasPrefix(spec, "/"):
+		return false
+	}
+	return true
+}
+
+// isJSTSDirEntryPoint reports whether filePath is the module entry point of
+// its own directory — `index.<ext>` for any JS/TS module extension.
+//
+// This is the evidence bar the dirIndex/lastDirIndex cascade in resolveImport
+// must clear before binding a JS/TS BARE specifier to an in-repo file. The
+// cascade is package-directory-oriented — a Go/Python notion, documented on
+// buildDirIndexes as "an import of `logger` matches any file under
+// .../logger/" — and lastDirIndex keys on nothing but the last path component
+// of each file's directory. For a bare specifier that is every indexed file
+// under any same-named directory, and the same-repo branch of `consider`
+// accepts the first one with no further check. So a repo that merely contains
+// a `*/graphql/` directory made every `import … from 'graphql'` also bind to
+// an arbitrary file inside it, accumulating phantom importers on that file
+// (issue #450).
+//
+// Node and tsc load a directory-shaped module through its entry point
+// (`package.json` main/exports, else `index.<ext>`) — never through an
+// arbitrary file inside it. Requiring an `index.*` candidate is therefore not
+// just a filter but the correct rule: it keeps the intended monorepo
+// behaviour (a bare `logger` resolving to `packages/app/logger/index.ts`,
+// pinned by the workspace-membership tests) while refusing the false binding,
+// which by construction never names an entry point.
+//
+// Deliberately NOT solved by applying dirMatchesImport to the same-repo
+// branch: that gate answers a different question (does this directory
+// genuinely spell out the import path) and would regress that same monorepo
+// behaviour, since dirMatchesImport("packages/app/logger", "logger") is false.
+func isJSTSDirEntryPoint(filePath string) bool {
+	base := filePath
+	if i := strings.LastIndexByte(base, '/'); i >= 0 {
+		base = base[i+1:]
+	}
+	base = strings.ToLower(base)
+	for _, ext := range jsTSImportExts {
+		if base == "index"+ext {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/resolver/npm_dependency.go
+++ b/internal/resolver/npm_dependency.go
@@ -1,0 +1,53 @@
+package resolver
+
+// NpmDependencyLookup reports whether a JS/TS importer declares a bare
+// module specifier as a dependency that resolves OUTSIDE the repository —
+// a registry semver range, a dist-tag, an `npm:` alias, a git/github spec,
+// a tarball URL. It returns false for a specifier the importer does not
+// declare at all, and for one declared as an in-repo dependency
+// (`workspace:*`, `link:`, `portal:`, `file:`, a relative path), because
+// those genuinely do name a directory in the tree.
+//
+// callerFile is the importing file's graph path (repo-prefixed in
+// multi-repo mode); specifier is the module specifier with any
+// `::<export>` payload already stripped.
+//
+// Like NpmAliasResolver and PathAliasResolver it lives in the resolver
+// package so the resolver carries no compile-time dependency on the
+// indexer or the filesystem: the indexer builds a concrete implementation
+// (reading package.json from disk) and injects it via
+// SetNpmDependencyLookup.
+type NpmDependencyLookup func(callerFile, specifier string) bool
+
+// SetNpmDependencyLookup installs an external-npm-dependency oracle. Pass
+// nil to detach. Must be called before ResolveAll / ResolveFile — the
+// resolver caches no dependency state across passes.
+func (r *Resolver) SetNpmDependencyLookup(fn NpmDependencyLookup) { r.npmDep = fn }
+
+// SetNpmDependencyLookup installs the oracle on the cross-repo resolver.
+// Same contract as the Resolver method.
+func (cr *CrossRepoResolver) SetNpmDependencyLookup(fn NpmDependencyLookup) { cr.npmDep = fn }
+
+// declaresExternalNpmDep reports whether importPath's module specifier is
+// declared by callerFile as a dependency resolving outside the repository.
+//
+// This is the strongest available evidence that a bare specifier is a
+// node_modules package rather than an in-repo directory, and it is exactly
+// the evidence isJSTSDirEntryPoint cannot supply: a repo that both depends
+// on npm `graphql` AND contains a `src/feature/graphql/index.ts` clears the
+// entry-point bar while still being a false binding (issue #450). When the
+// manifest says the package comes from the registry, no in-repo directory
+// is a candidate at all.
+//
+// A nil lookup (no indexer wired, or no usable repo root) reports false, so
+// the entry-point rule remains the only gate — the pre-feature behaviour.
+func declaresExternalNpmDep(fn NpmDependencyLookup, callerFile, importPath string) bool {
+	if fn == nil || callerFile == "" {
+		return false
+	}
+	spec, _ := splitImportSpecSymbol(importPath)
+	if spec == "" {
+		return false
+	}
+	return fn(callerFile, spec)
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -4337,13 +4337,7 @@ func (r *Resolver) buildReachabilityIndex() {
 		switch {
 		case graph.IsUnresolvedTarget(e.To) && strings.HasPrefix(graph.UnresolvedName(e.To), "import::"):
 			path := strings.TrimPrefix(graph.UnresolvedName(e.To), "import::")
-			if files := r.dirIndex[path]; len(files) > 0 {
-				importedDir = filepath.Dir(files[0].FilePath)
-			} else if last := lastPathComponent(path); last != "" {
-				if files := r.lastDirIndex[last]; len(files) > 0 {
-					importedDir = filepath.Dir(files[0].FilePath)
-				}
-			}
+			importedDir = r.importedDirForSpec(jsTSImportCallerFile(e), path)
 		case strings.HasPrefix(e.To, "external::"):
 			// External / unindexed package — nothing to add.
 		default:
@@ -4493,13 +4487,7 @@ func (r *Resolver) buildReachabilityIndexForPendingCached(
 					r.buildDirIndexes()
 				}
 				path := strings.TrimPrefix(graph.UnresolvedName(targetID), "import::")
-				if files := r.dirIndex[path]; len(files) > 0 {
-					importedDir = filepath.Dir(files[0].FilePath)
-				} else if last := lastPathComponent(path); last != "" {
-					if files := r.lastDirIndex[last]; len(files) > 0 {
-						importedDir = filepath.Dir(files[0].FilePath)
-					}
-				}
+				importedDir = r.importedDirForSpec(filePath, path)
 			case graph.IsUnresolvedTarget(targetID):
 				stable = false
 			case strings.HasPrefix(targetID, "external::"):
@@ -4556,6 +4544,43 @@ func (r *Resolver) legacyImportTargetsByFile(filePaths []string) map[string][]st
 func (r *Resolver) clearReachabilityIndex() {
 	r.reachableDirsByFile = nil
 	r.dirByFilePath = nil
+}
+
+// importedDirForSpec returns the directory that an unresolved
+// `import::<spec>` target makes reachable from callerFile, or "" when no
+// credible candidate matches.
+//
+// The dirIndex / lastDirIndex probe here has the same last-path-component
+// looseness as the cascade in resolveImport: for a JS/TS BARE specifier,
+// lastDirIndex[spec] is every indexed file under any same-named directory,
+// and taking files[0] admits an arbitrary one. Unlike resolveImport this
+// mints no edge, so it cannot produce the false `imports` edges of issue
+// #450 — but reachableDirsByFile feeds filterByReachability, and a bogus
+// reachable directory lets a same-named call candidate defined there
+// survive the narrowing and win a call edge. So the same gate applies:
+// only a directory entry point counts for a bare specifier, and a declared
+// external npm dependency contributes no in-repo directory at all.
+func (r *Resolver) importedDirForSpec(callerFile, spec string) string {
+	bare := isJSTSBareSpecifier(callerFile, spec)
+	if bare && declaresExternalNpmDep(r.npmDep, callerFile, spec) {
+		return ""
+	}
+	pick := func(files []graph.FileNodeIdentity) string {
+		for _, f := range files {
+			if bare && !isJSTSDirEntryPoint(f.FilePath) {
+				continue
+			}
+			return filepath.Dir(f.FilePath)
+		}
+		return ""
+	}
+	if d := pick(r.dirIndex[spec]); d != "" {
+		return d
+	}
+	if last := lastPathComponent(spec); last != "" {
+		return pick(r.lastDirIndex[last])
+	}
+	return ""
 }
 
 // dirFor returns filepath.Dir(path), served from the per-file memo built in

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -395,6 +395,12 @@ type Resolver struct {
 	// contract. Set via SetNpmAliasResolver before ResolveAll runs.
 	npmAlias NpmAliasResolver
 
+	// npmDep, when non-nil, reports whether a bare JS/TS specifier is
+	// declared by the importer as a dependency resolving outside the
+	// repository. See npm_dependency.go for the contract. Set via
+	// SetNpmDependencyLookup before ResolveAll runs.
+	npmDep NpmDependencyLookup
+
 	// pathAlias, when non-nil, expands a JS/TS tsconfig/jsconfig
 	// `compilerOptions.paths` / `baseUrl` import specifier to the
 	// repo-prefixed file stem it targets. See jsts_imports.go for the
@@ -3279,6 +3285,13 @@ func (r *Resolver) resolveImport(e *graph.Edge, importPath string, stats *Resolv
 	// binds `import … from 'graphql'` to an arbitrary file under any
 	// same-named local directory (issue #450). See isJSTSDirEntryPoint.
 	bareJSTS := isJSTSBareSpecifier(jsTSImportCallerFile(e), importPath)
+	// Stronger evidence when the manifest is readable: a bare specifier the
+	// importer declares as a registry / git / tarball dependency comes from
+	// node_modules by definition, so NO in-repo directory is a candidate —
+	// not even one holding an entry point. This is what closes the residual
+	// case the entry-point rule alone cannot: a repo that both depends on
+	// npm `graphql` and contains `src/feature/graphql/index.ts`.
+	externalNpmDep := bareJSTS && declaresExternalNpmDep(r.npmDep, jsTSImportCallerFile(e), importPath)
 	var sameRepo, crossRepoFile graph.FileNodeIdentity
 	var sameRepoFound, crossRepoFound bool
 	var sameRepoAll []graph.FileNodeIdentity
@@ -3308,7 +3321,9 @@ func (r *Resolver) resolveImport(e *graph.Edge, importPath string, stats *Resolv
 	// same-repo hit is found and we are not collecting every candidate
 	// for workspace disambiguation.
 	stop := func() bool { return sameRepoFound && !collectAll }
-	if r.dirIndex != nil {
+	if externalNpmDep {
+		// Declared node_modules package — skip the cascade outright.
+	} else if r.dirIndex != nil {
 		for _, file := range r.dirIndex[importPath] {
 			consider(file)
 			if stop() {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -3273,10 +3273,19 @@ func (r *Resolver) resolveImport(e *graph.Edge, importPath string, stats *Resolv
 	// the first same-repo hit short-circuits the scan, preserving the
 	// pre-feature cost.
 	collectAll := r.workspaceMembers != nil
+	// A JS/TS bare specifier names a node_modules package or a workspace
+	// member. Node and tsc load such a directory through its entry point, so
+	// only an `index.*` candidate is evidence — without this the cascade
+	// binds `import … from 'graphql'` to an arbitrary file under any
+	// same-named local directory (issue #450). See isJSTSDirEntryPoint.
+	bareJSTS := isJSTSBareSpecifier(jsTSImportCallerFile(e), importPath)
 	var sameRepo, crossRepoFile graph.FileNodeIdentity
 	var sameRepoFound, crossRepoFound bool
 	var sameRepoAll []graph.FileNodeIdentity
 	consider := func(file graph.FileNodeIdentity) {
+		if bareJSTS && !isJSTSDirEntryPoint(file.FilePath) {
+			return
+		}
 		if callerRepo == "" || file.RepoPrefix == callerRepo {
 			if !sameRepoFound {
 				sameRepo, sameRepoFound = file, true


### PR DESCRIPTION
Fixes #450.

Three commits: the reported defect, then the two residual gaps it exposed.

## Validation

Reproduced exactly as reported, using the issue's own repro. Before the fix:

| specifier | resolved to |
|---|---|
| `graphql` from `src/consumer-graphql.ts` | `src/feature/graphql/create.mutation.gql` |
| `@acme/utils` from `src/app.tsx` | `src/shared/utils/format.ts` |
| `lodash/merge` from `src/app.js` | `src/state/merge/reducer.js` |
| `lodash` (control, no colliding dir) | `external::lodash` |

The issue's root-cause analysis is accurate down to the line numbers: `lastDirIndex` keys on nothing but the last path component of each file's directory, and the same-repo branch of `consider` accepts the first hit with no suffix check, while the cross-repo branch is gated by `dirMatchesImport`.

## 1. Entry-point rule (`01e476e1`)

The issue proposes skipping the directory cascade entirely for JS/TS bare specifiers. That regresses three tests in `workspace_membership_test.go`, which pin a monorepo where a bare `logger` is *supposed* to resolve to `packages/app/logger/index.ts`. (The issue also correctly anticipates that applying `dirMatchesImport` to the same-repo branch would regress the same behaviour.)

Instead, gate the cascade on the candidate being the matched directory's **entry point** (`index.<ext>`). Node and tsc load a directory-shaped module through its entry point, never through an arbitrary file inside it — so this is the correct rule rather than just a filter. Every false binding is refused (by construction none names an entry point) and the monorepo case keeps working. Applied at both cascade sites.

## 2. Declared external npm dependencies (`c8214172`)

The entry-point rule still admits a repo that both depends on npm `graphql` AND contains `src/feature/graphql/index.ts`.

The manifest already answers this, and more cheaply than expected: `aliasesFor` calls `modules.ParsePackageJSON`, which returns every dependencies / devDependencies / peerDependencies / optionalDependencies entry — then discards all but the aliased ones. Keep the full map and expose it as `resolver.NpmDependencyLookup`, injected exactly the way `NpmAliasResolver` and `PathAliasResolver` already are. When the importer's nearest package.json declares the specifier as a dependency resolving outside the tree, no in-repo directory is a candidate and the cascade is skipped outright.

The version spec is the discriminator, and it has to be: a pnpm monorepo declares its own members as dependencies too, and those DO legitimately bind in-repo — `pnpm-workspace.yaml` members are not covered by the root manifest's `workspaces` globs, so they reach the cascade rather than being rewritten upstream by `workspaceRewrite`. `workspace:` / `link:` / `portal:` / `file:` / relative paths report in-repo; semver, dist-tags, `npm:` aliases, git specs, tarballs and `catalog:` report external.

npm honours the nearest manifest, so the walk stops at the first package.json declaring the name — a nearer `workspace:*` shadows a farther registry range. Undeclared reports false (absence is not evidence); a nil lookup falls back to entry-point-only, preserving current behaviour.

## 3. Reachability cascade (`a64eda6b`)

`buildReachabilityIndex` and `buildReachabilityIndexForPendingCached` probe the same indexes for an unresolved `import::<spec>` target and take `files[0]`, with the same last-component looseness.

These mint no edge, so they cannot produce the false `imports` edges of the original defect — but they are **not** merely a different trade-off, which is how I first characterised them. Their output, `reachableDirsByFile`, feeds `filterByReachability`, which narrows call candidates to those in a reachable directory. A bogus reachable directory lets a same-named candidate defined there survive the narrowing and win a call edge.

Both now route through one `importedDirForSpec` helper applying the same two rules. Non-JS/TS callers keep the unfiltered cascade.

Behaviour change worth review attention: when `dirIndex[spec]` matches but every candidate is gated out, the probe now falls through to `lastDirIndex` instead of yielding nothing. That path is reachable only when the gate is active, so non-JS/TS resolution is untouched.

## Tests

`internal/resolver/jsts_bare_specifier_test.go` and `internal/indexer/npm_dependency_lookup_test.go`.

Four tests fail without commit 1 and pass with it (the three collision shapes, plus a same-directory ordering case). The rest guard blast radius and pin the new rules: relative specifiers, tsconfig path aliases, non-JS/TS callers, the no-collision control, entry-point binding, declared-registry refusal, `workspace:`-protocol survival, nil-lookup fallback, nearest-manifest shadowing, scoped/subpath lookup, and the reachability gate.

## Verification

- `golangci-lint run ./internal/resolver/... ./internal/indexer/...` — 0 issues.
- Full `go test -race -count=1` suite: all 179 packages green. Run in chunks against raw `go test` output, because the local `rtk` wrapper rewrites `go test` into a summary that omits FAIL rows — an earlier pass through the wrapper reported green misleadingly.
- `internal/graph/store_sqlite` needs ~1086s and exceeds the default 600s timeout; it passes with a longer one. It has 538 transitive deps, none of them `internal/resolver` or `internal/indexer`, so it cannot be affected by this change.