### PR TITLE
Scope the remaining analyze legacy-alias kinds to the caller's workspace

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -266,7 +266,7 @@ over a very large tree, or `ask` against a slow local model.
 | `batch_symbols` | Multiple symbols with source/callers/callees in one call |
 | `find_import_path` | Correct import path for a symbol |
 | `explain_change_impact` | Risk-tiered blast radius with affected processes. A zero-edge target carries the "likely unused" vs "possible extraction gap" caveat |
-| `get_recent_changes` | Files/symbols changed since timestamp |
+| `get_recent_changes` | Files/symbols changed since timestamp. Rows are clamped to the session workspace and narrowed further by `repo`/`project`/`scope`; each multi-repo row names its `repo` |
 | `edit_symbol` | Edit a symbol's source directly by ID — no Read needed. Line-ending tolerant: an LF-authored `old_source` matches a CRLF file (and vice versa) and the replacement adopts the file's endings (`eol_normalized: true` rides on the response). Optional `base_sha` content-hash guard refuses the write when the on-disk SHA has drifted; every success carries `new_sha` so the next edit can pipeline without re-reading |
 | `edit_file` | Edit any file (markdown, config, spec, template, source) by exact string replacement — accepts absolute paths or repo-rooted paths. Line-ending tolerant: an LF-authored `old_string` matches a CRLF file (and vice versa) and the replacement is written with the file's own endings (`eol_normalized: true` rides on the response). Same `base_sha` / `new_sha` drift guard. Kills Read-before-Edit for files not in the graph |
 | `write_file` | Create or overwrite any file — atomic temp+rename, re-indexes on write. Same `base_sha` / `new_sha` drift guard |
@@ -307,8 +307,8 @@ Gortex captures every large tool response into a bounded per-session ring; these
 
 | Tool | Description |
 |------|-------------|
-| `get_communities` | Functional clusters (Louvain). Without `id`: list all. With `id`: members and cohesion for one community |
-| `get_processes` | Discovered execution flows. Without `id`: list all. With `id`: step-by-step trace |
+| `get_communities` | Functional clusters (Louvain). Without `id`: list all. With `id`: members and cohesion for one community. Members and files are clamped to the session workspace; the partition is global, so a `repo`/`project`/`scope` narrowing is widened to the workspace and the response discloses it |
+| `get_processes` | Discovered execution flows. Without `id`: list all. With `id`: step-by-step trace. Clamped to the session workspace and narrowed further by `repo`/`project`/`scope` — out-of-scope steps are excised by subtree so the surviving chain keeps its real call shape |
 | `detect_changes` | Git diff mapped to affected symbols |
 | `index_repository` | Index or re-index a repository path |
 | `reindex_repository` | Incrementally re-index a tracked repository — whole-root, or scoped to an optional `paths` subset. Multi-repo aware |

--- a/docs/multi-repo.md
+++ b/docs/multi-repo.md
@@ -126,6 +126,13 @@ Locate, reach, and analyze query tools uniformly accept `repo`, `project`, `work
 
 For `analyze`, the overrides genuinely narrow its **graph-node** kinds — `dead_code`, `hotspots`, `cycles`, `health_score`, `todos`, `stale_code`, `ownership`, `coverage_gaps`, `coverage_summary`, `impact`, `bottlenecks`, `role`, `k8s_resources`, `images`, `kustomize`, `dbt_models`, `external_calls`, and the like — and, since v1, its **edge-walk / graph-algorithm / framework / file-AST-scan** kinds too (`channel_ops`, `pubsub`, `routes`, `models`, `pagerank`, `kcore`, `edge_audit`, `tests_as_edges`, `sast`, `review`, …), which prune their rows / re-tally their counts against the same workspace + repo allow-set. The narrowing also resolves the two kind-specific collisions: `kind=cross_repo` keeps `repo` as its boundary filter and `kind=cycles` keeps `scope` as a file-path / package prefix (both are stripped from the uniform scope-resolution view). **v1 caveat:** the remaining long-tail kinds — community detection (`clusters`, `concepts`, `suggest_boundaries`), git/disk-mining (`blame`, `coverage`, `fixes_history`, `retrieval_log`, `temporal_verify`), per-id (`would_create_cycle`, `def_use`), `synthesizers` / `resolution_outcomes`, and `sql_rebuild` — remain workspace-bound but are **not** repo-narrowed — passing a narrowing arg on such a kind stamps a `scope_note` on the response disclosing the no-op.
 
+Some `analyze` operation names are not dispatcher kinds at all: the facade maps them to a separate legacy tool, which the dispatcher — and so `resolveScope` — never sees. Those tools carry the clamp themselves, and they split the same two ways:
+
+- **Workspace-clamped and repo-narrowed:** `health` (`audit_health`), `clones` (`find_clones`), `inspections` (`run_inspections`), `processes` (`get_processes`), `recent_changes` (`get_recent_changes`). Their rows are per-node, per-pair, or per-file, so a `repo` / `project` / `scope` selector narrows them for real.
+- **Workspace-clamped only:** `communities` (`get_communities`), for the same reason as the `clusters` / `concepts` kinds — one partition is computed over the whole index, so a narrowing arg is resolved for `scope_applied` and then widened to the workspace, with the response disclosing it.
+
+Their by-id lookups (`get_communities id:`, `get_processes id:`) resolve against the clamped set, so an out-of-scope id reports the same miss as one that never existed.
+
 ## Tool scoping by intent
 
 Tools are split by intent — each group has a different default scope:
@@ -161,7 +168,7 @@ When intent defaults are on, you can still widen or narrow explicitly:
 
 ### Uniform parameter set
 
-Every locate/reach/analyze tool now uniformly accepts `repo`, `project`, `workspace`, and `scope` parameters. All are clamped to the session workspace (the hard isolation boundary). For `analyze` this narrows the graph-node, edge-walk, graph-algorithm, framework, and file/AST-scan kinds; the remaining community / git-mining / per-id / synthesizer kinds are workspace-bound but not repo-narrowed in v1 (see the [MCP tools](#mcp-tools) caveat above).
+Every locate/reach/analyze tool now uniformly accepts `repo`, `project`, `workspace`, and `scope` parameters — including the legacy tools the `analyze` facade forwards to (`audit_health`, `find_clones`, `run_inspections`, `get_communities`, `get_processes`, `get_recent_changes`). All are clamped to the session workspace (the hard isolation boundary). For `analyze` this narrows the graph-node, edge-walk, graph-algorithm, framework, and file/AST-scan kinds; the remaining community / git-mining / per-id / synthesizer kinds are workspace-bound but not repo-narrowed in v1 (see the [MCP tools](#mcp-tools) caveat above).
 
 ### Response metadata
 

--- a/internal/analysis/communities.go
+++ b/internal/analysis/communities.go
@@ -544,6 +544,25 @@ func inferCommunityLabel(members []string, nodeMap map[string]*graph.Node, files
 	return path.Dir(filepath.ToSlash(files[0]))
 }
 
+// RelabelNarrowedCommunity recomputes a community's label from a member /
+// file set that was narrowed AFTER detection ran — the shape a scope clamp
+// produces when it drops the members a caller may not see.
+//
+// The detection-time label is derived from the whole partition cell: it is
+// the modal directory across every file in it, so a cell that straddles a
+// scope boundary is labelled with whichever side contributed more files.
+// Reporting that label next to a narrowed member list is both a disclosure
+// of the other side and a description of a cluster the caller was not
+// shown. Recomputing over the surviving files keeps the label a description
+// of what was actually returned.
+//
+// The name-prefix fallback needs hydrated nodes and is skipped here; a
+// narrowed cell falls through to its first surviving file's directory
+// instead, which needs no graph reads.
+func RelabelNarrowedCommunity(members, files []string) string {
+	return inferCommunityLabel(members, nil, files)
+}
+
 // pureClusterLabel returns a name for clusters whose files share a
 // meaningful directory ancestor (deeper than repo/plumbing). Returns
 // "" when no such ancestor exists, signalling a mixed cluster.

--- a/internal/indexer/multi_watcher_test.go
+++ b/internal/indexer/multi_watcher_test.go
@@ -300,13 +300,20 @@ func ChangedB() {}
 	require.NotEmpty(t, hist, "history should contain both repo edits")
 
 	// At minimum: one event per repo from each modify burst.
+	//
+	// FilePath is absolute, so the merged feed carries no attribution of
+	// its own — RepoPrefix is what lets a consumer tell which repo (and so
+	// which workspace) a row belongs to, and it must agree with the root
+	// the path falls under.
 	repoSeen := map[string]bool{}
 	for _, ev := range hist {
 		if strings.HasPrefix(ev.FilePath, repoADir) {
 			repoSeen["a"] = true
+			assert.Equal(t, "repo-a", ev.RepoPrefix, "repo-a event must be stamped with its repo prefix")
 		}
 		if strings.HasPrefix(ev.FilePath, repoBDir) {
 			repoSeen["b"] = true
+			assert.Equal(t, "repo-b", ev.RepoPrefix, "repo-b event must be stamped with its repo prefix")
 		}
 	}
 	assert.True(t, repoSeen["a"], "history must include repo-a event")

--- a/internal/indexer/watcher.go
+++ b/internal/indexer/watcher.go
@@ -33,8 +33,15 @@ const (
 )
 
 // GraphChangeEvent is emitted after a successful graph patch.
+//
+// RepoPrefix names the repository whose watcher produced the event.
+// MultiWatcher merges the per-repo histories into one feed, and FilePath is
+// absolute, so without this field a merged row carries no attribution a
+// consumer can filter on. It is empty in single-repo mode, where the lone
+// Indexer keeps an empty prefix.
 type GraphChangeEvent struct {
 	FilePath       string     `json:"file_path"`
+	RepoPrefix     string     `json:"repo_prefix,omitempty"`
 	Kind           ChangeKind `json:"kind"`
 	Classification string     `json:"classification,omitempty"`
 	NodesAdded     int        `json:"nodes_added"`
@@ -2099,7 +2106,11 @@ func (w *Watcher) patchGraphWithReceiptStateRawModern(
 	freshEdges := w.countFileEdges(freshNodes)
 
 	ev := GraphChangeEvent{
-		FilePath:       path,
+		FilePath: path,
+		// The per-repo Indexer's prefix IS the key this watcher is
+		// registered under in MultiWatcher, so stamping it here is what
+		// makes a merged history row attributable to its repository.
+		RepoPrefix:     idx.RepoPrefix(),
 		Kind:           kind,
 		Classification: classification,
 		Timestamp:      time.Now(),

--- a/internal/mcp/analyze_alias_analysis_scope_test.go
+++ b/internal/mcp/analyze_alias_analysis_scope_test.go
@@ -1,0 +1,323 @@
+package mcp
+
+// Scope regression tests for `analyze kind=communities` and
+// `analyze kind=processes`, which the facade routes to the legacy
+// get_communities / get_processes tools instead of the analyze
+// dispatcher. Because those aliases shadow the dispatcher, neither
+// handler ran resolveScope: both read the cached whole-index analysis
+// snapshot and emitted every community / flow in it, so a
+// workspace-bound session saw sibling workspaces' subsystem maps, entry
+// points and call chains — and the by-id detail paths handed back the
+// full member / step lists for an id the session had no right to.
+//
+// The substring probe ("repo-a" / "repo-b") and the fixtures match
+// analyze_scope_test.go: multi-repo node IDs and file paths carry the
+// repo name, so a result narrowed to repo-a must never contain "repo-b".
+
+import (
+	"context"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/analysis"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// ─── fixtures ───────────────────────────────────────────────────────────────
+
+// installProcessesForTest publishes a synthetic process result under the
+// same graph-token discipline installCommunitiesForTest uses: getProcesses
+// rejects a snapshot that is not tied to the current graph revision, so a
+// bare s.processes assignment reads back as nil.
+func installProcessesForTest(s *Server, processes *analysis.ProcessResult) {
+	s.analysisMu.Lock()
+	defer s.analysisMu.Unlock()
+
+	s.processes = processes
+	s.communitiesToken = s.currentCommunityToken()
+	s.analysisEpoch++
+}
+
+// callableIDsForRepo returns the callable node IDs of one repo, sorted by
+// the graph's own order, so fixtures reference symbols that really exist.
+func callableIDsForRepo(t *testing.T, g graph.Store, repoPrefix string) []string {
+	t.Helper()
+	var ids []string
+	for _, n := range g.AllNodes() {
+		if n == nil || n.RepoPrefix != repoPrefix {
+			continue
+		}
+		if n.Kind == graph.KindFunction || n.Kind == graph.KindMethod {
+			ids = append(ids, n.ID)
+		}
+	}
+	require.GreaterOrEqual(t, len(ids), 2, "fixture repo %q needs >=2 callables", repoPrefix)
+	return ids
+}
+
+// filesForIDs maps node IDs to their graph file paths.
+func filesForIDs(g graph.Store, ids []string) []string {
+	out := make([]string, 0, len(ids))
+	seen := map[string]bool{}
+	for _, id := range ids {
+		n := g.GetNode(id)
+		if n == nil || n.FilePath == "" || seen[n.FilePath] {
+			continue
+		}
+		seen[n.FilePath] = true
+		out = append(out, n.FilePath)
+	}
+	return out
+}
+
+// twoWorkspaceAnalysisServer builds repo-a/alpha + repo-b/beta and installs
+// one community and one process per repo, so every assertion below can name
+// exactly which rows must survive a clamp.
+func twoWorkspaceAnalysisServer(t *testing.T) (*Server, map[string]string) {
+	t.Helper()
+	srv, paths := newAnalyzeServer(t, true,
+		analyzeRepoSpec{name: "repo-a", workspace: "alpha", body: structuralBody("a")},
+		analyzeRepoSpec{name: "repo-b", workspace: "beta", body: structuralBody("b")},
+	)
+	installAnalysisFixtures(t, srv)
+	return srv, paths
+}
+
+func installAnalysisFixtures(t *testing.T, srv *Server) {
+	t.Helper()
+	idsA := callableIDsForRepo(t, srv.graph, "repo-a")
+	idsB := callableIDsForRepo(t, srv.graph, "repo-b")
+
+	installCommunitiesForTest(srv, &analysis.CommunityResult{
+		Communities: []analysis.Community{
+			{
+				ID: "community-0", Label: "repo-a/main", Size: len(idsA), Cohesion: 0.8,
+				Members: idsA, Files: filesForIDs(srv.graph, idsA),
+			},
+			{
+				ID: "community-1", Label: "repo-b/main", Size: len(idsB), Cohesion: 0.7,
+				Members: idsB, Files: filesForIDs(srv.graph, idsB),
+			},
+		},
+		Modularity: 0.42,
+	})
+	installProcessesForTest(srv, &analysis.ProcessResult{
+		Processes: []analysis.Process{
+			{
+				ID: "process-0", Name: "a flow", EntryPoint: idsA[0],
+				Steps:     []analysis.Step{{ID: idsA[0], Depth: 0}, {ID: idsA[1], Depth: 1}},
+				StepCount: 2, Files: filesForIDs(srv.graph, idsA[:2]), Score: 0.9,
+			},
+			{
+				ID: "process-1", Name: "b flow", EntryPoint: idsB[0],
+				Steps:     []analysis.Step{{ID: idsB[0], Depth: 0}, {ID: idsB[1], Depth: 1}},
+				StepCount: 2, Files: filesForIDs(srv.graph, idsB[:2]), Score: 0.9,
+			},
+		},
+		NodeToProcs: map[string][]string{
+			idsA[0]: {"process-0"}, idsA[1]: {"process-0"},
+			idsB[0]: {"process-1"}, idsB[1]: {"process-1"},
+		},
+	})
+}
+
+// runToolOK drives a handler and returns its response text plus the
+// scope_applied meta value, failing the test on any tool error.
+func runToolOK(t *testing.T, srv *Server, ctx context.Context, name string, args map[string]any,
+	h func(context.Context, mcplib.CallToolRequest) (*mcplib.CallToolResult, error),
+) (string, string) {
+	t.Helper()
+	res, err := h(ctx, makeReq(name, args))
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.False(t, res.IsError, "%s %v errored: %s", name, args, toolResultText(res))
+	applied := ""
+	if res.Meta != nil {
+		applied, _ = res.Meta.AdditionalFields["scope_applied"].(string)
+	}
+	return toolResultText(res), applied
+}
+
+// ─── get_communities (analyze kind=communities) ─────────────────────────────
+
+// TestGetCommunities_WorkspaceIsolation is the isolation invariant: an
+// alpha-bound session must not be shown beta's community. Before the fix
+// the handler returned the global partition verbatim, and the summary's
+// repo_prefix named the sibling repo outright.
+func TestGetCommunities_WorkspaceIsolation(t *testing.T) {
+	srv, paths := twoWorkspaceAnalysisServer(t)
+
+	text, applied := runToolOK(t, srv, sessionCtx("s-alpha", paths["repo-a"]), "get_communities", nil,
+		srv.handleGetCommunities)
+
+	assert.Contains(t, text, "repo-a", "alpha session must still see its own community")
+	assert.NotContains(t, text, "repo-b",
+		"alpha-bound session leaked a beta community — cross-workspace isolation breach")
+	assert.NotEmpty(t, applied, "every scoped response must disclose scope_applied")
+}
+
+// TestGetCommunities_DetailByIDIsNotProbeable pins the by-id path: an
+// out-of-workspace community id must report the same miss as a fabricated
+// one, so the boundary cannot be enumerated. Before the fix the id lookup
+// scanned the global partition and returned beta's full member and file
+// lists.
+func TestGetCommunities_DetailByIDIsNotProbeable(t *testing.T) {
+	srv, paths := twoWorkspaceAnalysisServer(t)
+	ctxA := sessionCtx("s-alpha", paths["repo-a"])
+
+	own, _ := runToolOK(t, srv, ctxA, "get_communities", map[string]any{"id": "community-0"},
+		srv.handleGetCommunities)
+	assert.Contains(t, own, "repo-a", "alpha session must still be able to open its own community")
+
+	foreign, err := srv.handleGetCommunities(ctxA, makeReq("get_communities", map[string]any{"id": "community-1"}))
+	require.NoError(t, err)
+	require.True(t, foreign.IsError, "a beta community id must not resolve for an alpha session")
+	assert.Equal(t, "community not found: community-1", toolResultText(foreign))
+
+	fabricated, err := srv.handleGetCommunities(ctxA, makeReq("get_communities", map[string]any{"id": "community-99"}))
+	require.NoError(t, err)
+	require.True(t, fabricated.IsError)
+	assert.Equal(t, "community not found: community-99", toolResultText(fabricated),
+		"an out-of-workspace id must be indistinguishable from a genuine miss")
+}
+
+// TestGetCommunities_StraddlingCommunityDropsForeignMembers covers the case
+// a 404-only fix would miss: a community whose members span both workspaces
+// is legitimately the alpha session's, but must come back with beta's
+// members and files removed.
+func TestGetCommunities_StraddlingCommunityDropsForeignMembers(t *testing.T) {
+	srv, paths := newAnalyzeServer(t, true,
+		analyzeRepoSpec{name: "repo-a", workspace: "alpha", body: structuralBody("a")},
+		analyzeRepoSpec{name: "repo-b", workspace: "beta", body: structuralBody("b")},
+	)
+	idsA := callableIDsForRepo(t, srv.graph, "repo-a")
+	idsB := callableIDsForRepo(t, srv.graph, "repo-b")
+	mixed := append(append([]string{}, idsA...), idsB...)
+	installCommunitiesForTest(srv, &analysis.CommunityResult{
+		Communities: []analysis.Community{{
+			ID: "community-0", Label: "mixed", Size: len(mixed), Cohesion: 0.5,
+			Members: mixed, Files: filesForIDs(srv.graph, mixed),
+		}},
+	})
+
+	text, _ := runToolOK(t, srv, sessionCtx("s-alpha", paths["repo-a"]), "get_communities",
+		map[string]any{"id": "community-0"}, srv.handleGetCommunities)
+
+	assert.Contains(t, text, "repo-a")
+	assert.NotContains(t, text, "repo-b",
+		"a straddling community must be served with its out-of-workspace members removed")
+}
+
+// TestGetCommunities_UnboundSessionUnchanged pins the strict no-op: an
+// unbound session (no cwd — CLI, control clients, the dashboard) must still
+// see the whole partition.
+func TestGetCommunities_UnboundSessionUnchanged(t *testing.T) {
+	srv, _ := twoWorkspaceAnalysisServer(t)
+
+	text, _ := runToolOK(t, srv, context.Background(), "get_communities", nil, srv.handleGetCommunities)
+
+	assert.Contains(t, text, "repo-a")
+	assert.Contains(t, text, "repo-b", "an unbound session must not be clamped")
+}
+
+// TestGetCommunities_DisclosesWidenedNarrowing pins the honesty contract:
+// the partition is global, so a repo selector is widened to the workspace
+// rather than silently ignored — and the response says so.
+func TestGetCommunities_DisclosesWidenedNarrowing(t *testing.T) {
+	srv, paths := newAnalyzeServer(t, true,
+		analyzeRepoSpec{name: "repo-a", workspace: "shared-ws", body: structuralBody("a")},
+		analyzeRepoSpec{name: "repo-b", workspace: "shared-ws", body: structuralBody("b")},
+	)
+	installAnalysisFixtures(t, srv)
+	ctx := sessionCtx("s-shared", paths["repo-a"])
+
+	text, applied := runToolOK(t, srv, ctx, "get_communities", map[string]any{"repo": "repo-a"},
+		srv.handleGetCommunities)
+
+	assert.Equal(t, "repo:repo-a", applied, "scope_applied must report the scope that was resolved")
+	assert.Contains(t, text, "not repo/project-narrowed",
+		"a kind that cannot honour the narrowing must disclose that it widened it")
+}
+
+// TestGetCommunities_RejectsUnknownSavedScope pins that the selectors are
+// now validated rather than dropped on the floor.
+func TestGetCommunities_RejectsUnknownSavedScope(t *testing.T) {
+	srv, paths := twoWorkspaceAnalysisServer(t)
+
+	res, err := srv.handleGetCommunities(sessionCtx("s-alpha", paths["repo-a"]),
+		makeReq("get_communities", map[string]any{"scope": "no-such-scope"}))
+	require.NoError(t, err)
+	require.True(t, res.IsError, "an unknown saved scope must be an error, not a silent no-op")
+}
+
+// ─── get_processes (analyze kind=processes) ─────────────────────────────────
+
+// TestGetProcesses_WorkspaceIsolation is the isolation invariant for the
+// list path: entry_point and repo_prefixes are raw node IDs and repo names,
+// so an unclamped list hands an alpha session beta's flow inventory.
+func TestGetProcesses_WorkspaceIsolation(t *testing.T) {
+	srv, paths := twoWorkspaceAnalysisServer(t)
+
+	text, applied := runToolOK(t, srv, sessionCtx("s-alpha", paths["repo-a"]), "get_processes", nil,
+		srv.handleGetProcesses)
+
+	assert.Contains(t, text, "repo-a", "alpha session must still see its own flow")
+	assert.NotContains(t, text, "repo-b",
+		"alpha-bound session leaked a beta process — cross-workspace isolation breach")
+	assert.NotEmpty(t, applied)
+}
+
+// TestGetProcesses_DetailByIDIsNotProbeable pins the by-id path, which
+// returned the entire Process — every step ID and file path — for any id.
+func TestGetProcesses_DetailByIDIsNotProbeable(t *testing.T) {
+	srv, paths := twoWorkspaceAnalysisServer(t)
+	ctxA := sessionCtx("s-alpha", paths["repo-a"])
+
+	own, _ := runToolOK(t, srv, ctxA, "get_processes", map[string]any{"id": "process-0"},
+		srv.handleGetProcesses)
+	assert.Contains(t, own, "repo-a")
+
+	foreign, err := srv.handleGetProcesses(ctxA, makeReq("get_processes", map[string]any{"id": "process-1"}))
+	require.NoError(t, err)
+	require.True(t, foreign.IsError, "a beta process id must not resolve for an alpha session")
+	assert.Equal(t, "process not found: process-1", toolResultText(foreign))
+}
+
+// TestGetProcesses_RepoNarrows is the difference from get_communities: a
+// flow's rows are per-step and every step belongs to exactly one repo, so
+// this kind honours an explicit repo selector instead of widening it.
+func TestGetProcesses_RepoNarrows(t *testing.T) {
+	srv, paths := newAnalyzeServer(t, true,
+		analyzeRepoSpec{name: "repo-a", workspace: "shared-ws", body: structuralBody("a")},
+		analyzeRepoSpec{name: "repo-b", workspace: "shared-ws", body: structuralBody("b")},
+	)
+	installAnalysisFixtures(t, srv)
+	ctx := sessionCtx("s-shared", paths["repo-a"])
+
+	wide, _ := runToolOK(t, srv, ctx, "get_processes", nil, srv.handleGetProcesses)
+	require.Contains(t, wide, "repo-b", "both repos share one workspace, so both flows start visible")
+
+	byName, applied := runToolOK(t, srv, ctx, "get_processes", map[string]any{"repo": "repo-a"},
+		srv.handleGetProcesses)
+	assert.Contains(t, byName, "repo-a")
+	assert.NotContains(t, byName, "repo-b", "an explicit repo selector must narrow the flow list")
+	assert.Equal(t, "repo:repo-a", applied)
+
+	byPath, _ := runToolOK(t, srv, ctx, "get_processes", map[string]any{"repo": paths["repo-a"]},
+		srv.handleGetProcesses)
+	assert.Equal(t, byName, byPath, "the tracked-name and path forms of repo must narrow identically")
+}
+
+// TestGetProcesses_UnboundSessionUnchanged pins the strict no-op for
+// unbound callers (the dashboard reads this tool with no session cwd).
+func TestGetProcesses_UnboundSessionUnchanged(t *testing.T) {
+	srv, _ := twoWorkspaceAnalysisServer(t)
+
+	text, _ := runToolOK(t, srv, context.Background(), "get_processes", nil, srv.handleGetProcesses)
+
+	assert.Contains(t, text, "repo-a")
+	assert.Contains(t, text, "repo-b", "an unbound session must not be clamped")
+}

--- a/internal/mcp/analyze_alias_analysis_scope_test.go
+++ b/internal/mcp/analyze_alias_analysis_scope_test.go
@@ -196,10 +196,25 @@ func TestGetCommunities_StraddlingCommunityDropsForeignMembers(t *testing.T) {
 	idsA := callableIDsForRepo(t, srv.graph, "repo-a")
 	idsB := callableIDsForRepo(t, srv.graph, "repo-b")
 	mixed := append(append([]string{}, idsA...), idsB...)
+	// Label, Hub and ParentID are computed at detection time over the whole
+	// cell, so a straddling community carries the other side's content in
+	// all three: the label is the modal directory across every file (here
+	// repo-b's root, which contributes the most), the hub is the
+	// highest-degree member's symbol name, and the parent is a grouping key
+	// built from that label. Reproduce that shape exactly.
+	mixedFiles := append(filesForIDs(srv.graph, mixed), "repo-b/a.go", "repo-b/b.go")
+	label := analysis.RelabelNarrowedCommunity(mixed, mixedFiles)
+	require.Contains(t, label, "repo-b", "fixture must reproduce a label derived from the beta side")
 	installCommunitiesForTest(srv, &analysis.CommunityResult{
 		Communities: []analysis.Community{{
-			ID: "community-0", Label: "mixed", Size: len(mixed), Cohesion: 0.5,
-			Members: mixed, Files: filesForIDs(srv.graph, mixed),
+			ID:       "community-0",
+			Label:    label,
+			Hub:      "bBillingService",
+			ParentID: "group/repo-b",
+			Size:     len(mixed),
+			Cohesion: 0.5,
+			Members:  mixed,
+			Files:    mixedFiles,
 		}},
 	})
 
@@ -209,6 +224,8 @@ func TestGetCommunities_StraddlingCommunityDropsForeignMembers(t *testing.T) {
 	assert.Contains(t, text, "repo-a")
 	assert.NotContains(t, text, "repo-b",
 		"a straddling community must be served with its out-of-workspace members removed")
+	assert.NotContains(t, text, "bBillingService",
+		"the hub was derived from members that were removed — it must not survive the clamp")
 }
 
 // TestGetCommunities_UnboundSessionUnchanged pins the strict no-op: an

--- a/internal/mcp/analyze_alias_inspections_scope_test.go
+++ b/internal/mcp/analyze_alias_inspections_scope_test.go
@@ -1,0 +1,137 @@
+package mcp
+
+// Scope regression tests for `analyze kind=inspections`, which the facade
+// routes to the legacy run_inspections tool instead of the analyze
+// dispatcher. Because that alias shadows the dispatcher, the handler never
+// ran resolveScope, and every inspector sourced its rows from the whole
+// graph: a workspace-bound session got a punch list naming sibling
+// workspaces' symbols in `file`, `symbol_id` and `message`. The `cycles`
+// inspector was the sharpest — it joined the entire cycle path into the
+// message before any filter ran, so one visible anchor leaked the rest of
+// the chain.
+//
+// The substring probe ("repo-a" / "repo-b") and the fixtures match
+// analyze_scope_test.go: multi-repo node IDs and file paths carry the
+// repo name, so a result narrowed to repo-a must never contain "repo-b".
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runInspections drives the handler and returns its response text plus the
+// scope_applied meta value.
+func runInspections(t *testing.T, srv *Server, ctx context.Context, args map[string]any) (string, string) {
+	t.Helper()
+	if args == nil {
+		args = map[string]any{}
+	}
+	if _, ok := args["inspections"]; !ok {
+		args["inspections"] = "all"
+	}
+	return runToolOK(t, srv, ctx, "run_inspections", args, srv.handleRunInspections)
+}
+
+// TestRunInspections_WorkspaceIsolation is the isolation invariant. The
+// structural fixture produces dead code (unreferenced helpers) and a call
+// cycle in each repo, so every inspector that reads the node table has rows
+// to leak.
+func TestRunInspections_WorkspaceIsolation(t *testing.T) {
+	srv, paths := newAnalyzeServer(t, true,
+		analyzeRepoSpec{name: "repo-a", workspace: "alpha", body: structuralBody("a")},
+		analyzeRepoSpec{name: "repo-b", workspace: "beta", body: structuralBody("b")},
+	)
+
+	text, applied := runInspections(t, srv, sessionCtx("s-alpha", paths["repo-a"]), nil)
+
+	assert.Contains(t, text, "repo-a", "alpha session must still see its own violations")
+	assert.NotContains(t, text, "repo-b",
+		"alpha-bound session leaked beta violations — cross-workspace isolation breach")
+	assert.NotEmpty(t, applied, "every scoped response must disclose scope_applied")
+}
+
+// TestRunInspections_CycleChainDoesNotLeak covers the cycles inspector
+// specifically: its message rolls the whole path into one string, so a
+// row-level filter on the anchor alone would still have leaked every other
+// member of the chain.
+func TestRunInspections_CycleChainDoesNotLeak(t *testing.T) {
+	srv, paths := newAnalyzeServer(t, true,
+		analyzeRepoSpec{name: "repo-a", workspace: "alpha", body: structuralBody("a")},
+		analyzeRepoSpec{name: "repo-b", workspace: "beta", body: structuralBody("b")},
+	)
+
+	text, _ := runInspections(t, srv, sessionCtx("s-alpha", paths["repo-a"]),
+		map[string]any{"inspections": "cycles"})
+
+	assert.NotContains(t, text, "repo-b",
+		"a cycle message must not carry out-of-workspace members of the chain")
+}
+
+// TestRunInspections_RepoNarrows pins the explicit selector: inspectors are
+// whole-graph rollups over per-node rows, so this kind honours a repo
+// narrowing like health_score / dead_code / hotspots do.
+func TestRunInspections_RepoNarrows(t *testing.T) {
+	srv, paths := newStructuralWorkspaceServer(t, true)
+	ctx := sessionCtx("s-shared", paths["repo-a"])
+
+	wide, _ := runInspections(t, srv, ctx, nil)
+	require.Contains(t, wide, "repo-b", "both repos share one workspace, so both start visible")
+
+	byName, applied := runInspections(t, srv, ctx, map[string]any{"repo": "repo-a"})
+	assert.Contains(t, byName, "repo-a")
+	assert.NotContains(t, byName, "repo-b", "an explicit repo selector must narrow every inspector")
+	assert.Equal(t, "repo:repo-a", applied)
+
+	byPath, _ := runInspections(t, srv, ctx, map[string]any{"repo": paths["repo-a"]})
+	assert.NotContains(t, byPath, "repo-b", "the path form of repo must narrow like the tracked name")
+	// Compare the per-inspector counts rather than the whole body: the
+	// cycles inspector picks its anchor from an SCC whose member order is
+	// not stable, so two identically-narrowed calls can name either end of
+	// the same two-node cycle.
+	assert.Equal(t, inspectionSummary(t, byName), inspectionSummary(t, byPath),
+		"the tracked-name and path forms of repo must narrow identically")
+}
+
+// inspectionSummary decodes the by-inspection violation counts.
+func inspectionSummary(t *testing.T, body string) map[string]any {
+	t.Helper()
+	var payload struct {
+		Summary map[string]any `json:"summary"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(body), &payload))
+	require.NotEmpty(t, payload.Summary)
+	return payload.Summary
+}
+
+// TestRunInspections_OutOfWorkspaceRepoErrors pins that a cross-workspace
+// selector is refused outright rather than answered with a plausible
+// global punch list.
+func TestRunInspections_OutOfWorkspaceRepoErrors(t *testing.T) {
+	srv, paths := newAnalyzeServer(t, true,
+		analyzeRepoSpec{name: "repo-a", workspace: "alpha", body: structuralBody("a")},
+		analyzeRepoSpec{name: "repo-b", workspace: "beta", body: structuralBody("b")},
+	)
+
+	res, err := srv.handleRunInspections(sessionCtx("s-alpha", paths["repo-a"]),
+		makeReq("run_inspections", map[string]any{"inspections": "all", "repo": "repo-b"}))
+	require.NoError(t, err)
+	require.True(t, res.IsError, "a sibling-workspace repo selector must error, not answer")
+}
+
+// TestRunInspections_UnboundSessionUnchanged is the compatibility fence:
+// an unbound caller must still get the whole index.
+func TestRunInspections_UnboundSessionUnchanged(t *testing.T) {
+	srv, _ := newAnalyzeServer(t, true,
+		analyzeRepoSpec{name: "repo-a", workspace: "alpha", body: structuralBody("a")},
+		analyzeRepoSpec{name: "repo-b", workspace: "beta", body: structuralBody("b")},
+	)
+
+	text, _ := runInspections(t, srv, context.Background(), nil)
+
+	assert.Contains(t, text, "repo-a")
+	assert.Contains(t, text, "repo-b", "an unbound session must not be clamped")
+}

--- a/internal/mcp/analyze_alias_recent_changes_scope_test.go
+++ b/internal/mcp/analyze_alias_recent_changes_scope_test.go
@@ -1,0 +1,171 @@
+package mcp
+
+// Scope regression tests for `analyze kind=recent_changes`, which the
+// facade routes to the legacy get_recent_changes tool instead of the
+// analyze dispatcher. Because that alias shadows the dispatcher, the
+// handler never ran resolveScope — and under the daemon the watcher it
+// reads is a MultiWatcher whose History unions the per-repo feeds of every
+// tracked repo, across workspaces. Each row's `file` is an absolute path,
+// so a workspace-bound session learned sibling workspaces' on-disk roots,
+// file names and edit timestamps.
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/indexer"
+)
+
+// historyTestWatcher is a watcherHistory double returning a fixed feed —
+// the shape MultiWatcher produces after merging its per-repo histories.
+type historyTestWatcher struct {
+	events []indexer.GraphChangeEvent
+}
+
+func (w historyTestWatcher) History() []indexer.GraphChangeEvent { return w.events }
+
+func (w historyTestWatcher) HistorySince(since time.Time) []indexer.GraphChangeEvent {
+	var out []indexer.GraphChangeEvent
+	for _, ev := range w.events {
+		if ev.Timestamp.After(since) {
+			out = append(out, ev)
+		}
+	}
+	return out
+}
+
+func (historyTestWatcher) OnSymbolChange(indexer.SymbolChangeCallback) {}
+
+// recentChangesServer builds a two-repo server and installs a merged feed
+// carrying one event per repo, each stamped with its repo prefix the way a
+// per-repo Watcher stamps it.
+func recentChangesServer(t *testing.T, repos ...analyzeRepoSpec) (*Server, map[string]string) {
+	t.Helper()
+	srv, paths := newAnalyzeServer(t, true, repos...)
+	events := make([]indexer.GraphChangeEvent, 0, len(repos))
+	for _, r := range repos {
+		events = append(events, indexer.GraphChangeEvent{
+			FilePath:   filepath.Join(paths[r.name], "main.go"),
+			RepoPrefix: r.name,
+			Kind:       indexer.ChangeModified,
+			NodesAdded: 1,
+			Timestamp:  time.Now().Add(-time.Minute),
+		})
+	}
+	srv.SetWatcher(historyTestWatcher{events: events})
+	return srv, paths
+}
+
+func runRecentChanges(t *testing.T, srv *Server, ctx context.Context, args map[string]any) (string, string) {
+	t.Helper()
+	return runToolOK(t, srv, ctx, "get_recent_changes", args, srv.handleGetRecentChanges)
+}
+
+// TestGetRecentChanges_WorkspaceIsolation is the isolation invariant: the
+// merged feed must be narrowed to the session's own workspace.
+func TestGetRecentChanges_WorkspaceIsolation(t *testing.T) {
+	srv, paths := recentChangesServer(t,
+		analyzeRepoSpec{name: "repo-a", workspace: "alpha", body: structuralBody("a")},
+		analyzeRepoSpec{name: "repo-b", workspace: "beta", body: structuralBody("b")},
+	)
+
+	text, applied := runRecentChanges(t, srv, sessionCtx("s-alpha", paths["repo-a"]), nil)
+
+	assert.Contains(t, text, "repo-a", "alpha session must still see its own file churn")
+	assert.NotContains(t, text, "repo-b",
+		"alpha-bound session leaked beta's file churn — cross-workspace isolation breach")
+	assert.NotEmpty(t, applied, "every scoped response must disclose scope_applied")
+}
+
+// TestGetRecentChanges_SinceBranchIsClamped guards the `since` path
+// independently: the handler used to render it in a second, duplicated
+// loop, so a clamp applied to only one branch would have looked correct.
+func TestGetRecentChanges_SinceBranchIsClamped(t *testing.T) {
+	srv, paths := recentChangesServer(t,
+		analyzeRepoSpec{name: "repo-a", workspace: "alpha", body: structuralBody("a")},
+		analyzeRepoSpec{name: "repo-b", workspace: "beta", body: structuralBody("b")},
+	)
+
+	since := time.Now().Add(-time.Hour).Format(time.RFC3339)
+	text, _ := runRecentChanges(t, srv, sessionCtx("s-alpha", paths["repo-a"]),
+		map[string]any{"since": since})
+
+	assert.Contains(t, text, "repo-a", "the since branch must still return in-workspace rows")
+	assert.NotContains(t, text, "repo-b", "the since branch must be clamped like the full-history branch")
+}
+
+// TestGetRecentChanges_RepoNarrows pins the explicit selector inside a
+// single workspace holding two repos.
+func TestGetRecentChanges_RepoNarrows(t *testing.T) {
+	srv, paths := recentChangesServer(t,
+		analyzeRepoSpec{name: "repo-a", workspace: "shared-ws", body: structuralBody("a")},
+		analyzeRepoSpec{name: "repo-b", workspace: "shared-ws", body: structuralBody("b")},
+	)
+	ctx := sessionCtx("s-shared", paths["repo-a"])
+
+	wide, _ := runRecentChanges(t, srv, ctx, nil)
+	require.Contains(t, wide, "repo-b", "both repos share one workspace, so both start visible")
+
+	byName, applied := runRecentChanges(t, srv, ctx, map[string]any{"repo": "repo-a"})
+	assert.Contains(t, byName, "repo-a")
+	assert.NotContains(t, byName, "repo-b", "an explicit repo selector must narrow the feed")
+	assert.Equal(t, "repo:repo-a", applied)
+
+	byPath, _ := runRecentChanges(t, srv, ctx, map[string]any{"repo": paths["repo-a"]})
+	assert.Equal(t, byName, byPath, "the tracked-name and path forms of repo must narrow identically")
+}
+
+// TestGetRecentChanges_RowsCarryRepoAttribution pins the new field. Without
+// it a merged row is unattributable: FilePath is absolute and
+// GraphChangeEvent carried nothing naming the repo it came from.
+func TestGetRecentChanges_RowsCarryRepoAttribution(t *testing.T) {
+	srv, paths := recentChangesServer(t,
+		analyzeRepoSpec{name: "repo-a", workspace: "shared-ws", body: structuralBody("a")},
+		analyzeRepoSpec{name: "repo-b", workspace: "shared-ws", body: structuralBody("b")},
+	)
+
+	text, _ := runRecentChanges(t, srv, sessionCtx("s-shared", paths["repo-a"]), nil)
+
+	assert.Contains(t, text, `"repo":"repo-a"`)
+	assert.Contains(t, text, `"repo":"repo-b"`)
+}
+
+// TestGetRecentChanges_UnboundSessionUnchanged is the compatibility fence
+// for the single-repo `gortex mcp --watch` path and for CLI / control
+// clients, which carry no session cwd: they must still see the full feed,
+// and a single-repo watcher's unprefixed rows must not be filtered away.
+func TestGetRecentChanges_UnboundSessionUnchanged(t *testing.T) {
+	srv, paths := recentChangesServer(t,
+		analyzeRepoSpec{name: "repo-a", workspace: "alpha", body: structuralBody("a")},
+		analyzeRepoSpec{name: "repo-b", workspace: "beta", body: structuralBody("b")},
+	)
+	srv.SetWatcher(historyTestWatcher{events: []indexer.GraphChangeEvent{
+		{FilePath: filepath.Join(paths["repo-a"], "main.go"), Kind: indexer.ChangeModified, Timestamp: time.Now()},
+		{FilePath: filepath.Join(paths["repo-b"], "main.go"), Kind: indexer.ChangeModified, Timestamp: time.Now()},
+	}})
+
+	text, _ := runRecentChanges(t, srv, context.Background(), nil)
+
+	assert.Contains(t, text, "repo-a")
+	assert.Contains(t, text, "repo-b", "an unbound session must not be clamped")
+	assert.NotContains(t, text, `"repo":`, "an unprefixed row must keep its original shape")
+}
+
+// TestGetRecentChanges_NoWatcherStillErrors keeps the pre-existing contract:
+// the watch-mode check must run before any scope work.
+func TestGetRecentChanges_NoWatcherStillErrors(t *testing.T) {
+	srv, paths := newAnalyzeServer(t, true,
+		analyzeRepoSpec{name: "repo-a", workspace: "alpha", body: structuralBody("a")},
+	)
+
+	res, err := srv.handleGetRecentChanges(sessionCtx("s-alpha", paths["repo-a"]),
+		makeReq("get_recent_changes", nil))
+	require.NoError(t, err)
+	require.True(t, res.IsError)
+	assert.Equal(t, "watch mode is not active", toolResultText(res))
+}

--- a/internal/mcp/scope_init.go
+++ b/internal/mcp/scope_init.go
@@ -121,8 +121,9 @@ var defaultToolScopes = map[string]ToolScope{
 	// Analysis. Historically takes an optional `repo`; classified
 	// scope: repo to keep behavior unchanged. A follow-up may upgrade
 	// to fan-out once the UX is reviewed.
-	"analyze":   ScopeRepo,
-	"contracts": ScopeRepo,
+	"analyze":         ScopeRepo,
+	"contracts":       ScopeRepo,
+	"run_inspections": ScopeRepo,
 
 	// CPG-lite dataflow primitives. Both walk the active graph by
 	// node ID / name pattern; like analyze + contracts, they take

--- a/internal/mcp/scope_resolve.go
+++ b/internal/mcp/scope_resolve.go
@@ -415,6 +415,30 @@ func (s *Server) communitiesInSessionScope(ctx context.Context, cr *analysis.Com
 	return &out
 }
 
+// repoPrefixVisible is the prefix-level analogue of analyzeNodeVisible for
+// handlers whose rows carry a repo prefix instead of a graph node — a
+// watcher event, a contract record. It applies the same two gates in the
+// same order: the session-workspace ceiling first, then the resolved repo
+// allow-set.
+//
+// An empty prefix is admitted by the workspace ceiling and rejected by an
+// explicit allow-set, matching QueryOptions.ScopeAllows and
+// analyzeNodeVisible. Single-repo daemons mint unprefixed rows, and an
+// allow-set keyed by registry prefixes would otherwise narrow all of them
+// away; an explicit narrow, by contrast, names prefixes an unattributed
+// row cannot satisfy.
+func (s *Server) repoPrefixVisible(ctx context.Context, prefix string) bool {
+	if wsRepos, bound := s.sessionWorkspaceRepoSet(ctx); bound && len(wsRepos) > 0 {
+		if prefix != "" && !wsRepos[prefix] {
+			return false
+		}
+	}
+	if allow := repoAllowFromContext(ctx); len(allow) > 0 && !allow[prefix] {
+		return false
+	}
+	return true
+}
+
 // processesInSessionScope returns a scope-clamped copy of pr: processes
 // whose entry point the caller may not see are dropped, and each surviving
 // chain has its out-of-scope steps excised. Process discovery runs over the

--- a/internal/mcp/scope_resolve.go
+++ b/internal/mcp/scope_resolve.go
@@ -407,6 +407,18 @@ func (s *Server) communitiesInSessionScope(ctx context.Context, cr *analysis.Com
 				files = append(files, f)
 			}
 		}
+		// A cell that straddled the boundary keeps display fields derived
+		// from the members that were just removed: Label is the modal
+		// directory across the whole cell (so it can name a sibling repo
+		// outright), Hub is the highest-degree member's symbol name, and
+		// ParentID is a grouping key built from that Label. Recompute the
+		// label over what survives and drop the two fields that cannot be
+		// recomputed without the members that are gone.
+		if len(members) != len(c.Members) {
+			c.Label = analysis.RelabelNarrowedCommunity(members, files)
+			c.Hub = ""
+			c.ParentID = ""
+		}
 		c.Members = members
 		c.Files = files
 		c.Size = len(members)
@@ -421,22 +433,20 @@ func (s *Server) communitiesInSessionScope(ctx context.Context, cr *analysis.Com
 // same order: the session-workspace ceiling first, then the resolved repo
 // allow-set.
 //
-// An empty prefix is admitted by the workspace ceiling and rejected by an
-// explicit allow-set, matching QueryOptions.ScopeAllows and
-// analyzeNodeVisible. Single-repo daemons mint unprefixed rows, and an
-// allow-set keyed by registry prefixes would otherwise narrow all of them
-// away; an explicit narrow, by contrast, names prefixes an unattributed
-// row cannot satisfy.
+// An unattributed row — one whose prefix is empty — is admitted by both
+// gates. The allow-set half routes through repoNarrowAdmits, the single
+// definition of what a repo narrow does to something carrying no prefix;
+// the workspace half follows it for the same reason. Single-repo daemons
+// emit unprefixed rows, so rejecting would not narrow a result, it would
+// empty one. In multi-repo mode every row of both kinds this gates is
+// attributed at its source, so the admitted case does not arise there.
 func (s *Server) repoPrefixVisible(ctx context.Context, prefix string) bool {
 	if wsRepos, bound := s.sessionWorkspaceRepoSet(ctx); bound && len(wsRepos) > 0 {
 		if prefix != "" && !wsRepos[prefix] {
 			return false
 		}
 	}
-	if allow := repoAllowFromContext(ctx); len(allow) > 0 && !allow[prefix] {
-		return false
-	}
-	return true
+	return repoNarrowAdmits(repoAllowFromContext(ctx), prefix)
 }
 
 // processesInSessionScope returns a scope-clamped copy of pr: processes

--- a/internal/mcp/scope_resolve.go
+++ b/internal/mcp/scope_resolve.go
@@ -415,6 +415,91 @@ func (s *Server) communitiesInSessionScope(ctx context.Context, cr *analysis.Com
 	return &out
 }
 
+// processesInSessionScope returns a scope-clamped copy of pr: processes
+// whose entry point the caller may not see are dropped, and each surviving
+// chain has its out-of-scope steps excised. Process discovery runs over the
+// whole index, so without this the process surface would hand a
+// workspace-bound caller a sibling workspace's entry points, call chains and
+// file lists. Strict no-op for an unbound session with no repo allow-set;
+// the cached snapshot is never mutated.
+//
+// Excision is by subtree, not by element. Steps are a DFS preorder whose
+// parent relation is implicit — the parent of a step is the nearest
+// preceding step with a smaller depth (see analysis.Step). Dropping a step
+// on its own would re-parent its children onto an unrelated ancestor and
+// assert a call that does not exist. Removing an out-of-scope step at depth
+// d together with the following run of steps at depth > d cannot do that:
+// any survivor's parent has a strictly smaller depth than the survivor, so
+// a parent inside the removed run would put the survivor inside it too.
+// Depths are therefore left untouched and the surviving tree is exactly the
+// pre-filter tree minus whole subtrees.
+func (s *Server) processesInSessionScope(ctx context.Context, pr *analysis.ProcessResult) *analysis.ProcessResult {
+	// The step / entry-point scope test is a syntactic split of the node id
+	// (graph.RepoPrefixOfID), which only names a repository in multi-repo
+	// mode — on an unprefixed single-repo id it returns the first directory
+	// name. Bail out before that misreads a directory as a repo.
+	if pr == nil || s.multiIndexer == nil {
+		return pr
+	}
+	wsRepos, bound := s.sessionWorkspaceRepoSet(ctx)
+	clampWorkspace := bound && len(wsRepos) > 0
+	repoAllow := repoAllowFromContext(ctx)
+	if !clampWorkspace && len(repoAllow) == 0 {
+		return pr
+	}
+	inScope := func(id string) bool {
+		prefix := graph.RepoPrefixOfID(id)
+		if clampWorkspace && !wsRepos[prefix] {
+			return false
+		}
+		return len(repoAllow) == 0 || repoAllow[prefix]
+	}
+
+	out := *pr
+	out.Processes = make([]analysis.Process, 0, len(pr.Processes))
+	out.NodeToProcs = make(map[string][]string, len(pr.NodeToProcs))
+	for _, p := range pr.Processes {
+		if !inScope(p.EntryPoint) {
+			continue
+		}
+		steps := make([]analysis.Step, 0, len(p.Steps))
+		excised := false
+		for i := 0; i < len(p.Steps); i++ {
+			step := p.Steps[i]
+			if inScope(step.ID) {
+				steps = append(steps, step)
+				continue
+			}
+			// Skip this step and the whole subtree rooted at it: every
+			// following step deeper than it is one of its descendants.
+			excised = true
+			for i+1 < len(p.Steps) && p.Steps[i+1].Depth > step.Depth {
+				i++
+			}
+		}
+		// A process is a chain; discovery itself discards anything
+		// shorter than two steps (analysis.discoverProcesses).
+		if len(steps) < 2 {
+			continue
+		}
+		files := make([]string, 0, len(p.Files))
+		for _, f := range p.Files {
+			if inScope(f) {
+				files = append(files, f)
+			}
+		}
+		p.Steps = steps
+		p.StepCount = len(steps)
+		p.Files = files
+		p.Truncated = p.Truncated || excised
+		out.Processes = append(out.Processes, p)
+		for _, step := range steps {
+			out.NodeToProcs[step.ID] = append(out.NodeToProcs[step.ID], p.ID)
+		}
+	}
+	return &out
+}
+
 // scopeNarrowingRequested reports whether the caller passed an explicit
 // repo / project / scope / ref narrowing arg (other than the "*"
 // all-repos escape hatch).

--- a/internal/mcp/tools_analysis.go
+++ b/internal/mcp/tools_analysis.go
@@ -15,8 +15,12 @@ import (
 func (s *Server) registerAnalysisTools() {
 	s.addTool(
 		mcp.NewTool("get_communities",
-			mcp.WithDescription("Returns functional clusters discovered by community detection. Without id: list all communities with summaries. With id: full details of a specific community (members, files, cohesion)."),
+			mcp.WithDescription("Returns functional clusters discovered by community detection. Without id: list all communities with summaries. With id: full details of a specific community (members, files, cohesion). Members and files are clamped to the session workspace."),
 			mcp.WithString("id", mcp.Description("Optional community ID (e.g. community-0). When set, returns full details of that community instead of the list.")),
+			mcp.WithString("repo", mcp.Description("Narrow to a single repository prefix (tracked name or path). The partition is computed over the whole index, so this is clamped and widened to the session workspace; the response discloses it.")),
+			mcp.WithString("project", mcp.Description("Narrow to the repositories in a project. Clamped and widened to the session workspace like repo.")),
+			mcp.WithString("workspace", mcp.Description("Restrict to the active workspace slug; daemon sessions may only name their own workspace.")),
+			mcp.WithString("scope", mcp.Description("Name of a saved scope (see save_scope). Clamped and widened to the session workspace like repo.")),
 		),
 		s.handleGetCommunities,
 	)
@@ -25,6 +29,10 @@ func (s *Server) registerAnalysisTools() {
 		mcp.NewTool("get_processes",
 			mcp.WithDescription("Returns discovered execution flows — named chains of function calls starting from entry points. Without id: list all processes. With id: full step-by-step call chain for that process."),
 			mcp.WithString("id", mcp.Description("Optional process ID (e.g. process-0). When set, returns the full step-by-step call chain for that process instead of the list.")),
+			mcp.WithString("repo", mcp.Description("Narrow to a single repository prefix (tracked name or path), clamped to the session workspace. Steps outside it are excised from the chains.")),
+			mcp.WithString("project", mcp.Description("Narrow to the repositories in a project, clamped to the session workspace.")),
+			mcp.WithString("workspace", mcp.Description("Restrict to the active workspace slug; daemon sessions may only name their own workspace.")),
+			mcp.WithString("scope", mcp.Description("Name of a saved scope (see save_scope) — its repositories narrow the flows, clamped to the session workspace.")),
 			mcp.WithString("format", mcp.Description("Output format: json (default), gcx (GCX1 compact wire format), or toon")),
 			mcp.WithNumber("max_bytes", mcp.Description("Cap the marshaled response at this many bytes; truncation metadata rides on the response.")),
 		),
@@ -70,11 +78,33 @@ func (s *Server) registerAnalysisTools() {
 	)
 }
 
+// handleGetCommunities lists (or details) the cached community partition,
+// clamped to the caller's workspace.
+//
+// `analyze kind=communities` is a facade alias that forwards straight to
+// this tool, so the analyze dispatcher's resolveScope never runs here — the
+// clamp has to be applied by the handler, exactly as PR #395 did for
+// audit_health and find_clones. Community detection runs one partition over
+// the whole index, so the clamp is the same workspace-only shape the sibling
+// kinds use (analyze clusters / concepts / suggest_boundaries): a repo /
+// project / scope narrowing is resolved for the response's scope_applied and
+// then widened to the workspace, which workspaceScopeBlock discloses in the
+// body. Repo-narrowing the members of a partition cell would return a
+// "community" of no graph the caller can name, and would make this kind
+// disagree with `analyze kind=clusters` over the very same cached partition.
 func (s *Server) handleGetCommunities(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	if pending := s.ensureAnalysis(); !pending.Ready {
-		return s.respondJSONOrTOON(ctx, req, analysisPendingPayload(pending, "communities"))
+	resolved, errResult := s.resolveScope(ctx, req, IntentAnalyze)
+	if errResult != nil {
+		return errResult, nil
 	}
-	comms := s.getCommunities()
+	if pending := s.ensureAnalysis(); !pending.Ready {
+		return s.respondScopedJSONOrTOON(ctx, req, analysisPendingPayload(pending, "communities"), resolved)
+	}
+	// Clamp before the id branch: an out-of-workspace id then reports the
+	// same "not found" as a fabricated one, so the boundary is not
+	// probeable, and a community that straddles the boundary still has its
+	// foreign members dropped.
+	comms := s.communitiesInSessionScope(ctx, s.getCommunities())
 
 	// If id is provided, return the single community in detail.
 	if id := req.GetString("id", ""); id != "" {
@@ -83,7 +113,7 @@ func (s *Server) handleGetCommunities(ctx context.Context, req mcp.CallToolReque
 		}
 		for _, c := range comms.Communities {
 			if c.ID == id {
-				return s.respondJSONOrTOON(ctx, req, c)
+				return s.respondScopedJSONOrTOON(ctx, req, c, resolved)
 			}
 		}
 		return mcp.NewToolResultError("community not found: " + id), nil
@@ -91,10 +121,14 @@ func (s *Server) handleGetCommunities(ctx context.Context, req mcp.CallToolReque
 
 	// Otherwise return the list of summaries.
 	if comms == nil || len(comms.Communities) == 0 {
-		return s.respondJSONOrTOON(ctx, req, map[string]any{
+		empty := map[string]any{
 			"communities": []any{},
 			"message":     "no communities detected yet — run index_repository first",
-		})
+		}
+		if blk := s.workspaceScopeBlock(ctx, req, "communities"); blk != nil {
+			empty["scope"] = blk
+		}
+		return s.respondScopedJSONOrTOON(ctx, req, empty, resolved)
 	}
 
 	// List mode deliberately omits per-community `files` (can be hundreds
@@ -124,18 +158,44 @@ func (s *Server) handleGetCommunities(ctx context.Context, req mcp.CallToolReque
 			ParentID:   c.ParentID,
 		})
 	}
-	return s.respondJSONOrTOON(ctx, req, map[string]any{
-		"communities": summaries,
-		"total":       len(summaries),
-		"modularity":  comms.Modularity,
-	})
+	// `modularity` and the per-row `cohesion` are the global partition's
+	// scores — the clamp drops members, it does not re-run detection — so
+	// they are labelled rather than silently re-reported as if they had
+	// been recomputed for the narrowed set.
+	payload := map[string]any{
+		"communities":      summaries,
+		"total":            len(summaries),
+		"modularity":       comms.Modularity,
+		"modularity_scope": "global-partition",
+	}
+	if blk := s.workspaceScopeBlock(ctx, req, "communities"); blk != nil {
+		payload["scope"] = blk
+	}
+	return s.respondScopedJSONOrTOON(ctx, req, payload, resolved)
 }
 
+// handleGetProcesses lists (or details) the discovered execution flows,
+// clamped to the caller's scope.
+//
+// `analyze kind=processes` is a facade alias that forwards straight to this
+// tool, so the analyze dispatcher's resolveScope never runs here. Unlike the
+// community partition, a flow's rows are per-step and every step is
+// attributable to exactly one repo, so this kind honours the full
+// repo/project/scope narrowing on top of the workspace ceiling — see
+// processesInSessionScope for the subtree-excision rule that keeps a
+// filtered chain honest.
 func (s *Server) handleGetProcesses(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	if pending := s.ensureAnalysis(); !pending.Ready {
-		return s.respondJSONOrTOON(ctx, req, analysisPendingPayload(pending, "processes"))
+	resolved, errResult := s.resolveScope(ctx, req, IntentAnalyze)
+	if errResult != nil {
+		return errResult, nil
 	}
-	procs := s.getProcesses()
+	ctx = withRepoAllow(ctx, resolved.RepoAllow)
+	if pending := s.ensureAnalysis(); !pending.Ready {
+		return s.respondScopedJSONOrTOON(ctx, req, analysisPendingPayload(pending, "processes"), resolved)
+	}
+	// Clamp before the id branch so an out-of-scope process id reports the
+	// same "not found" as a fabricated one.
+	procs := s.processesInSessionScope(ctx, s.getProcesses())
 
 	// If id is provided, return the single process in detail.
 	if id := req.GetString("id", ""); id != "" {
@@ -144,7 +204,7 @@ func (s *Server) handleGetProcesses(ctx context.Context, req mcp.CallToolRequest
 		}
 		for _, p := range procs.Processes {
 			if p.ID == id {
-				return s.respondJSONOrTOON(ctx, req, p)
+				return s.respondScopedJSONOrTOON(ctx, req, p, resolved)
 			}
 		}
 		return mcp.NewToolResultError("process not found: " + id), nil
@@ -152,10 +212,10 @@ func (s *Server) handleGetProcesses(ctx context.Context, req mcp.CallToolRequest
 
 	// Otherwise return the list of summaries.
 	if procs == nil || len(procs.Processes) == 0 {
-		return s.respondJSONOrTOON(ctx, req, map[string]any{
+		return s.respondScopedJSONOrTOON(ctx, req, map[string]any{
 			"processes": []any{},
 			"message":   "no processes discovered yet — run index_repository first",
-		})
+		}, resolved)
 	}
 
 	// `repo_prefixes` is the ordered set of distinct "owner/repo" prefixes
@@ -182,10 +242,10 @@ func (s *Server) handleGetProcesses(ctx context.Context, req mcp.CallToolRequest
 			RepoPrefixes: uniqueRepoPrefixesFromSteps(p.Steps),
 		})
 	}
-	return s.respondJSONOrTOON(ctx, req, map[string]any{
+	return s.respondScopedJSONOrTOON(ctx, req, map[string]any{
 		"processes": summaries,
 		"total":     len(summaries),
-	})
+	}, resolved)
 }
 
 // repoPrefixOf extracts the repo prefix from a node ID of the form

--- a/internal/mcp/tools_coding.go
+++ b/internal/mcp/tools_coding.go
@@ -226,8 +226,12 @@ func (s *Server) registerCodingTools() {
 
 	s.addTool(
 		mcp.NewTool("get_recent_changes",
-			mcp.WithDescription("Returns files and symbols that changed since the last call (watch mode only). Use to re-orient after the user edits files outside of Claude Code's view, without re-reading anything."),
+			mcp.WithDescription("Returns files and symbols that changed since the last call (watch mode only). Use to re-orient after the user edits files outside of Claude Code's view, without re-reading anything. Rows are clamped to the session workspace and narrowed further by repo/project/scope."),
 			mcp.WithString("since", mcp.Description("ISO 8601 timestamp (omit for all changes since index)")),
+			mcp.WithString("repo", mcp.Description("Narrow to a single repository prefix (tracked name or path), clamped to the session workspace.")),
+			mcp.WithString("project", mcp.Description("Narrow to the repositories in a project, clamped to the session workspace.")),
+			mcp.WithString("workspace", mcp.Description("Restrict to the active workspace slug; daemon sessions may only name their own workspace.")),
+			mcp.WithString("scope", mcp.Description("Name of a saved scope (see save_scope) — its repositories narrow the feed, clamped to the session workspace.")),
 		),
 		s.handleGetRecentChanges,
 	)
@@ -734,45 +738,60 @@ func (s *Server) handleFindImportPath(ctx context.Context, req mcp.CallToolReque
 	})
 }
 
+// handleGetRecentChanges returns the watcher's change feed, narrowed to the
+// repositories the caller may see.
+//
+// Under the daemon the watcher is a MultiWatcher whose History merges the
+// per-repo feeds of every tracked repo — across workspaces — and each row's
+// `file` is an absolute path. `analyze kind=recent_changes` is a facade alias
+// that forwards straight to this tool, so nothing upstream narrows it: the
+// clamp belongs here. Rows are attributed by the repo prefix the emitting
+// watcher stamps on the event.
 func (s *Server) handleGetRecentChanges(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	watcher := s.currentWatcher()
 	if watcher == nil {
 		return mcp.NewToolResultError("watch mode is not active"), nil
 	}
+	resolved, errResult := s.resolveScope(ctx, req, IntentAnalyze)
+	if errResult != nil {
+		return errResult, nil
+	}
+	ctx = withRepoAllow(ctx, resolved.RepoAllow)
 
 	sinceStr := req.GetString("since", "")
-	var changes []map[string]any
-
+	events := watcher.History()
 	if sinceStr != "" {
 		t, err := time.Parse(time.RFC3339, sinceStr)
 		if err != nil {
 			return mcp.NewToolResultError("invalid timestamp: " + sinceStr), nil
 		}
-		for _, ev := range watcher.HistorySince(t) {
-			changes = append(changes, map[string]any{
-				"file":          ev.FilePath,
-				"kind":          ev.Kind,
-				"nodes_added":   ev.NodesAdded,
-				"nodes_removed": ev.NodesRemoved,
-				"timestamp":     ev.Timestamp.Format(time.RFC3339),
-			})
-		}
-	} else {
-		for _, ev := range watcher.History() {
-			changes = append(changes, map[string]any{
-				"file":          ev.FilePath,
-				"kind":          ev.Kind,
-				"nodes_added":   ev.NodesAdded,
-				"nodes_removed": ev.NodesRemoved,
-				"timestamp":     ev.Timestamp.Format(time.RFC3339),
-			})
-		}
+		events = watcher.HistorySince(t)
 	}
 
-	return s.respondJSONOrTOON(ctx, req, map[string]any{
+	var changes []map[string]any
+	for _, ev := range events {
+		if !s.repoPrefixVisible(ctx, ev.RepoPrefix) {
+			continue
+		}
+		row := map[string]any{
+			"file":          ev.FilePath,
+			"kind":          ev.Kind,
+			"nodes_added":   ev.NodesAdded,
+			"nodes_removed": ev.NodesRemoved,
+			"timestamp":     ev.Timestamp.Format(time.RFC3339),
+		}
+		// Only present in multi-repo mode; a single-repo watcher leaves the
+		// prefix empty and the row shape is unchanged.
+		if ev.RepoPrefix != "" {
+			row["repo"] = ev.RepoPrefix
+		}
+		changes = append(changes, row)
+	}
+
+	return s.respondScopedJSONOrTOON(ctx, req, map[string]any{
 		"changes":             changes,
 		"graph_current_as_of": time.Now().Format(time.RFC3339),
-	})
+	}, resolved)
 }
 
 // suggestSymbolIDs builds a short "did you mean" hint for a symbol id that

--- a/internal/mcp/tools_coding.go
+++ b/internal/mcp/tools_coding.go
@@ -15,6 +15,7 @@ import (
 	"github.com/zzet/gortex/internal/agents"
 	"github.com/zzet/gortex/internal/elide"
 	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/indexer"
 	"github.com/zzet/gortex/internal/query"
 	"github.com/zzet/gortex/internal/search/rerank"
 	"github.com/zzet/gortex/internal/tokens"
@@ -758,14 +759,17 @@ func (s *Server) handleGetRecentChanges(ctx context.Context, req mcp.CallToolReq
 	}
 	ctx = withRepoAllow(ctx, resolved.RepoAllow)
 
-	sinceStr := req.GetString("since", "")
-	events := watcher.History()
-	if sinceStr != "" {
+	// Exactly one of the two reads runs: each copies every tracked repo's
+	// ring buffer under its own lock, and the merged form sorts the union.
+	var events []indexer.GraphChangeEvent
+	if sinceStr := req.GetString("since", ""); sinceStr != "" {
 		t, err := time.Parse(time.RFC3339, sinceStr)
 		if err != nil {
 			return mcp.NewToolResultError("invalid timestamp: " + sinceStr), nil
 		}
 		events = watcher.HistorySince(t)
+	} else {
+		events = watcher.History()
 	}
 
 	var changes []map[string]any

--- a/internal/mcp/tools_inspections.go
+++ b/internal/mcp/tools_inspections.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/zzet/gortex/internal/analysis"
 	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/contracts"
 	"github.com/zzet/gortex/internal/graph"
 )
 
@@ -45,7 +46,11 @@ func (s *Server) registerInspectionsTools() {
 		mcp.NewTool("run_inspections",
 			mcp.WithDescription("Run one or more inspections and return uniform violation rows: {inspection, severity, file, line, message, symbol_id?}. Set `inspections=all` to run every inspector, or pass a CSV of ids from list_inspections. Aggregated under a summary {by_inspection, total_violations} so the caller can present a punch list. Composes existing analyzers (dead_code, cycles, todos, unsafe_patterns, coverage_gaps, stale_code), guards, and contract checks — no JetBrains dependency."),
 			mcp.WithString("inspections", mcp.Description("Comma-separated inspection IDs to run, or `all` for the full catalog. Required.")),
-			mcp.WithString("path_prefix", mcp.Description("Scope every inspector to nodes under this file-path prefix.")),
+			mcp.WithString("path_prefix", mcp.Description("Scope every inspector to nodes under this file-path prefix. Orthogonal to repo/project/scope — it filters paths, not repositories.")),
+			mcp.WithString("repo", mcp.Description("Narrow every inspector to a single repository prefix (tracked name or path), clamped to the session workspace.")),
+			mcp.WithString("project", mcp.Description("Narrow every inspector to the repositories in a project, clamped to the session workspace.")),
+			mcp.WithString("workspace", mcp.Description("Restrict to the active workspace slug; daemon sessions may only name their own workspace.")),
+			mcp.WithString("scope", mcp.Description("Name of a saved scope (see save_scope) — its repositories narrow every inspector, clamped to the session workspace.")),
 			mcp.WithString("severity", mcp.Description("Filter results to this severity (error / warning / info). Empty = no filter.")),
 			mcp.WithNumber("max_per_inspection", mcp.Description("Cap on violations per inspector (default: 50).")),
 			mcp.WithString("format", mcp.Description("Output format: json (default), gcx, or toon")),
@@ -67,13 +72,22 @@ type inspectionViolation struct {
 // inspectionSpec is the registry entry. run returns the inspector's
 // violations bounded by the scope predicate (which may be nil for
 // "no filter").
+//
+// ctx carries the session workspace and the resolved repo allow-set: every
+// inspector reads the whole graph, so each one is responsible for narrowing
+// its own rows through the scoped-node accessors or analyzeNodeVisible.
 type inspectionSpec struct {
 	ID          string
 	Category    string
 	Description string
 	Severity    string
-	Run         func(s *Server, scope inspectionScope) []inspectionViolation
+	Run         func(ctx context.Context, s *Server, scope inspectionScope) []inspectionViolation
 }
+
+// inspectionCallableKinds is the callable kind set the coverage and
+// staleness inspectors walk. Declared once so the scoped-node pushdown
+// agrees with what those inspectors mean by "callable".
+var inspectionCallableKinds = []graph.NodeKind{graph.KindFunction, graph.KindMethod}
 
 // inspectionScope is the call-side filter passed to every inspector.
 // Keep it minimal — adding fields here forces every inspector to
@@ -155,11 +169,26 @@ func (s *Server) handleListInspections(ctx context.Context, req mcp.CallToolRequ
 	})
 }
 
+// handleRunInspections runs the requested inspectors over the nodes the
+// caller may actually see.
+//
+// `analyze kind=inspections` is a facade alias that forwards straight to
+// this tool, so the analyze dispatcher's resolveScope never runs here and
+// the clamp has to be applied by the handler. Every inspector is a
+// whole-graph rollup over first-party symbols — the same shape as the
+// health_score / dead_code / hotspots analyze kinds — so this resolves the
+// uniform repo/project/workspace/scope narrowing and each inspector sources
+// its rows through the scoped accessors.
 func (s *Server) handleRunInspections(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	idsArg, err := req.RequireString("inspections")
 	if err != nil {
 		return mcp.NewToolResultError("`inspections` is required (CSV of ids, or `all`)"), nil
 	}
+	resolved, errResult := s.resolveScope(ctx, req, IntentAnalyze)
+	if errResult != nil {
+		return errResult, nil
+	}
+	ctx = withRepoAllow(ctx, resolved.RepoAllow)
 	scope := inspectionScope{
 		PathPrefix: strings.TrimSpace(req.GetString("path_prefix", "")),
 	}
@@ -185,7 +214,7 @@ func (s *Server) handleRunInspections(ctx context.Context, req mcp.CallToolReque
 		if !want[sp.ID] {
 			continue
 		}
-		raw := sp.Run(s, scope)
+		raw := sp.Run(ctx, s, scope)
 		// Apply per-call filters: severity + cap.
 		filtered := make([]inspectionViolation, 0, len(raw))
 		for _, v := range raw {
@@ -215,7 +244,7 @@ func (s *Server) handleRunInspections(ctx context.Context, req mcp.CallToolReque
 		return results[i]["inspection"].(string) < results[j]["inspection"].(string)
 	})
 
-	return s.respondJSONOrTOON(ctx, req, map[string]any{
+	return s.respondScopedJSONOrTOON(ctx, req, map[string]any{
 		"results": results,
 		"summary": map[string]any{
 			"by_inspection":    byInspection,
@@ -223,16 +252,24 @@ func (s *Server) handleRunInspections(ctx context.Context, req mcp.CallToolReque
 		},
 		"path_prefix":        scope.PathPrefix,
 		"max_per_inspection": maxPer,
-	})
+	}, resolved)
 }
 
 // --- Inspector implementations --------------------------------------
 
-func runDeadCodeInspection(s *Server, scope inspectionScope) []inspectionViolation {
+func runDeadCodeInspection(ctx context.Context, s *Server, scope inspectionScope) []inspectionViolation {
+	// FindDeadCode reads the whole store and the global process snapshot —
+	// both are the analyzer's inputs and stay global so an entry point in
+	// another repo still keeps a symbol alive. Only the rows are narrowed,
+	// matching handleFindDeadCode.
 	entries := analysis.FindDeadCode(s.graph, s.getProcesses(), nil)
+	scoped := s.scopeFiltersActive(ctx)
 	out := make([]inspectionViolation, 0, len(entries))
 	for _, e := range entries {
 		if !scope.keep(e.FilePath) {
+			continue
+		}
+		if scoped && !s.analyzeNodeVisible(ctx, s.graph.GetNode(e.ID)) {
 			continue
 		}
 		out = append(out, inspectionViolation{
@@ -247,10 +284,21 @@ func runDeadCodeInspection(s *Server, scope inspectionScope) []inspectionViolati
 	return out
 }
 
-func runCyclesInspection(s *Server, scope inspectionScope) []inspectionViolation {
+func runCyclesInspection(ctx context.Context, s *Server, scope inspectionScope) []inspectionViolation {
+	// DetectCycles' own scope argument stays empty on purpose: it drops
+	// out-of-prefix nodes before Tarjan runs, which splits or dissolves
+	// SCCs rather than filtering rows. Narrow the results instead.
 	cycles := analysis.DetectCycles(s.graph, s.getCommunities(), "")
+	scoped := s.scopeFiltersActive(ctx)
 	out := make([]inspectionViolation, 0, len(cycles))
 	for _, c := range cycles {
+		// A cycle is kept only when EVERY node on its path is visible: the
+		// message below rolls the whole path into one string, so a partly
+		// visible chain would leak the rest of its members. This runs
+		// before the join for that reason.
+		if scoped && !s.cycleVisible(ctx, c) {
+			continue
+		}
 		// Cycle path is a list of node IDs; surface the first as the
 		// anchor and roll the chain into the message so the agent
 		// sees the loop without an extra round-trip.
@@ -280,12 +328,9 @@ func runCyclesInspection(s *Server, scope inspectionScope) []inspectionViolation
 	return out
 }
 
-func runTodosInspection(s *Server, scope inspectionScope) []inspectionViolation {
+func runTodosInspection(ctx context.Context, s *Server, scope inspectionScope) []inspectionViolation {
 	out := make([]inspectionViolation, 0)
-	for _, n := range s.graph.AllNodes() {
-		if n.Kind != graph.KindTodo {
-			continue
-		}
+	for _, n := range s.scopedNodesByKinds(ctx, []graph.NodeKind{graph.KindTodo}) {
 		if !scope.keep(n.FilePath) {
 			continue
 		}
@@ -313,13 +358,10 @@ func runTodosInspection(s *Server, scope inspectionScope) []inspectionViolation 
 	return out
 }
 
-func runCoverageGapsInspection(s *Server, scope inspectionScope) []inspectionViolation {
+func runCoverageGapsInspection(ctx context.Context, s *Server, scope inspectionScope) []inspectionViolation {
 	out := make([]inspectionViolation, 0)
 	covRows := s.coverageByID()
-	for _, n := range s.graph.AllNodes() {
-		if n.Kind != graph.KindFunction && n.Kind != graph.KindMethod {
-			continue
-		}
+	for _, n := range s.scopedNodesByKinds(ctx, inspectionCallableKinds) {
 		if !scope.keep(n.FilePath) {
 			continue
 		}
@@ -344,15 +386,12 @@ func runCoverageGapsInspection(s *Server, scope inspectionScope) []inspectionVio
 // surfaced as a stale_code inspection.
 const staleInspectionDays = 365
 
-func runStaleCodeInspection(s *Server, scope inspectionScope) []inspectionViolation {
+func runStaleCodeInspection(ctx context.Context, s *Server, scope inspectionScope) []inspectionViolation {
 	out := make([]inspectionViolation, 0)
 	now := time.Now().Unix()
 	cutoff := now - staleInspectionDays*24*3600
 	blame := blameRowsByID(s.graph)
-	for _, n := range s.graph.AllNodes() {
-		if n.Kind != graph.KindFunction && n.Kind != graph.KindMethod {
-			continue
-		}
+	for _, n := range s.scopedNodesByKinds(ctx, inspectionCallableKinds) {
 		if !scope.keep(n.FilePath) {
 			continue
 		}
@@ -381,7 +420,7 @@ func runStaleCodeInspection(s *Server, scope inspectionScope) []inspectionViolat
 	return out
 }
 
-func runGuardsInspection(s *Server, scope inspectionScope) []inspectionViolation {
+func runGuardsInspection(ctx context.Context, s *Server, scope inspectionScope) []inspectionViolation {
 	// Evaluate against every node in scope. check_guards' substrate
 	// accepts a slice of IDs; we pass the scoped set.
 	if !s.anyGuardRulesConfigured() {
@@ -392,7 +431,10 @@ func runGuardsInspection(s *Server, scope inspectionScope) []inspectionViolation
 	rulesByRepo := make(map[string][]config.GuardRule, 2)
 	resolver := s.newRepoScopeResolver()
 	out := make([]inspectionViolation, 0)
-	for _, n := range s.graph.AllNodes() {
+	// newRepoScopeResolver answers "whose .gortex.yaml governs this node",
+	// not "may this session see it" — the visibility narrowing is the
+	// scoped node set.
+	for _, n := range s.scopedNodes(ctx) {
 		if !scope.keep(n.FilePath) {
 			continue
 		}
@@ -426,12 +468,22 @@ func runGuardsInspection(s *Server, scope inspectionScope) []inspectionViolation
 	return out
 }
 
-func runContractOrphansInspection(s *Server, scope inspectionScope) []inspectionViolation {
+func runContractOrphansInspection(ctx context.Context, s *Server, scope inspectionScope) []inspectionViolation {
 	if s.contractRegistry == nil {
 		return nil
 	}
 	out := make([]inspectionViolation, 0)
-	all := s.contractRegistry.All()
+	// Narrow BEFORE the provider/consumer pairing below. Pairing is a
+	// two-sided join: a provider whose only consumer lives outside the
+	// caller's scope must still be reported as an orphan, which it would
+	// not be if the counterpart were counted first and filtered after.
+	all := make([]contracts.Contract, 0, len(s.contractRegistry.All()))
+	for _, c := range s.contractRegistry.All() {
+		if !s.repoPrefixVisible(ctx, c.RepoPrefix) {
+			continue
+		}
+		all = append(all, c)
+	}
 	byID := map[string]int{}
 	roleByID := map[string]map[string]int{}
 	for _, c := range all {

--- a/internal/mcp/tools_inspections_stale_test.go
+++ b/internal/mcp/tools_inspections_stale_test.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"context"
 	"strings"
 	"testing"
 )
@@ -14,7 +15,7 @@ func TestRunStaleCodeInspection(t *testing.T) {
 	addBlameEnrichedNode(srv.graph, "f.go::Stale", "f.go", 5, "bob@x", "bbb", 400)
 	addBlameEnrichedNode(srv.graph, "f.go::Ancient", "f.go", 9, "carol@x", "ccc", 800)
 
-	got := runStaleCodeInspection(srv, inspectionScope{})
+	got := runStaleCodeInspection(context.Background(), srv, inspectionScope{})
 	if len(got) != 2 {
 		t.Fatalf("want 2 stale violations (Stale+Ancient, 365d default), got %d: %+v", len(got), got)
 	}


### PR DESCRIPTION
Fixes #397.

## The report holds for all four

Each of `run_inspections` / `get_communities` / `get_processes` / `get_recent_changes` is globally unscoped today, and each is reachable only through its alias — none of the four is an `analyze` kind, so there is no dispatcher branch to fall back to. A workspace-bound session gets rows from every repo the daemon tracks:

| kind → tool | what leaks | why |
|---|---|---|
| `inspections` → `run_inspections` | `file`, `symbol_id`, `message` on every violation row | all seven inspectors read `graph.AllNodes()` or a global cached snapshot |
| `communities` → `get_communities` | `label`, `repo_prefix`, and the full `members` / `files` on the by-id path | the cached Leiden partition is returned verbatim |
| `processes` → `get_processes` | `entry_point`, `repo_prefixes`, and the full `steps` / `files` on the by-id path | same, for the cached process result |
| `recent_changes` → `get_recent_changes` | `file` — an absolute path — on every row | under the daemon the watcher is a `MultiWatcher` whose `History` unions every tracked repo's feed |

The by-id paths are the sharper half: both matched on id alone, and ids are sequential (`community-0`, `process-0`) with the list path handing them out. So an alpha-bound session could page beta's member inventory or call chains without knowing beta existed.

None of this needs an unusual layout. `ReposInWorkspace` falls back to the repo prefix as the workspace id when a repo declares no `workspace:` slug, so any daemon tracking two repos has two workspaces and a live boundary.

## The fix

Each handler resolves the uniform `repo` / `project` / `workspace` / `scope` narrowing itself and returns through `withScopeResult`, the shape #395 established for `audit_health` / `find_clones`. The two clamps that read a cached analysis snapshot run *before* the id branch, so an out-of-scope id reports the same miss as a fabricated one and a straddling community is served with its foreign members removed.

They do not all get the same narrowing, because their rows are not the same shape.

**`inspections`, `processes`, `recent_changes` take the full narrowing.** Their rows are per-node, per-step and per-file — every one is attributable to exactly one repo, so a `repo` selector narrows them for real.

**`communities` is workspace-clamped only.** A community is a cell of one partition computed over the whole index; filtering its members down to a single repo returns a "community" of no graph the caller can name, and cross-repo cohesion is the signal a multi-repo workspace wants from this tool. This matches the sibling kinds that read the *same cached partition* — `clusters`, `concepts`, `suggest_boundaries` — which are pinned as workspace-clamped-but-not-scope-aware. Repo-narrowing it here would make `analyze kind=communities` disagree with `analyze kind=clusters` over one partition, which is the class of inconsistency this issue exists to remove. A selector is still resolved for `scope_applied` and then widened, with `workspaceScopeBlock` disclosing that in the body. `modularity` is labelled rather than silently reported as if it had been recomputed for the narrowed set.

Three things were more than a `resolveScope` call.

**Process chains are excised by subtree.** `analysis.Step` is a DFS preorder whose parent relation is implicit — the parent of a step is the nearest preceding step with a smaller depth. Dropping an out-of-scope step on its own re-parents its children onto an unrelated ancestor and asserts a call that does not exist: in `[A0, B1, X2, Y3, C2]`, removing `X2` makes `Y3`'s nearest-preceding-smaller-depth `B1`, claiming a `B → Y` edge no `EdgeCalls` backs. So the clamp removes the out-of-scope step *and the following run of steps deeper than it*. Any survivor's parent has a strictly smaller depth than the survivor, so a parent inside the removed run would put the survivor inside it too — depths are left untouched and the surviving tree is exactly the pre-filter tree minus whole subtrees. `Truncated` is set when anything was excised, and the cached snapshot is never mutated.

**Watcher events gained a repo.** `GraphChangeEvent` carried only an absolute `FilePath`, so a merged row was unattributable and nothing downstream *could* filter it — re-deriving a repo from the path at read time fails for a repo untracked since the event. The event now carries the prefix of the repo whose watcher produced it, stamped at the single construction site from the per-repo `Indexer` that `MultiWatcher` already binds to the map key. It is empty in single-repo mode, and rides `History`, `HistorySince` and the `Events` channel alike, so the daemon's other consumers of the feed gain the same attribution.

**`cycles` filters before it formats.** The inspector joined the whole cycle path into `message` before any filter ran, and its one filter checked only the anchor — and only when the anchor resolved. A cycle is now dropped unless every node on its path is visible. `DetectCycles`' own scope argument stays empty on purpose: it drops nodes before Tarjan runs, which splits or dissolves SCCs rather than filtering rows.

Two smaller correctness points in the same area: `contracts_orphans` narrows the contract set *before* the provider/consumer pairing, since pairing is a two-sided join and filtering the counterpart first would score a provider as matched and hide it from the orphan list; and `dead_code` keeps `FindDeadCode` over the whole store and the global process snapshot — those are the analyzer's inputs, and an entry point in another repo legitimately keeps a symbol alive — narrowing only the rows it emits.

Review of the above found one residual leak, fixed in the last commit: a straddling community kept `label` / `hub` / `parent_id`, all computed at detection time over the whole cell. A cell whose other side contributes the most root-level files is labelled with that repo's name verbatim. The clamp now recomputes the label over the surviving files and drops the two fields that cannot be recomputed without the members that are gone — only when the member set actually shrank, so unclamped communities and unbound sessions are untouched. `clusters` and `concepts` inherit the fix.

## On `audit_agent_config`

#395 called it "root-pinned by design" and #397 says it is "possibly correct as-is". Both are wrong, but not in the direction the issue guessed — and the real answer is why it is still not fixed here.

It is not fan-out. `audit.DiscoverConfigFiles` walks exactly one root, and that root is `s.indexer.RootPath()` falling back to `os.Getwd()`. In daemon mode the primary indexer is never given a root (only the per-repo indexers under `multiIndexer` are), so `RootPath()` is empty and the audit runs against **the daemon process's working directory** — fixed at launch, independent of the session's workspace or active project. So the tool is neither fan-out nor workspace-bound; it is daemon-CWD-bound, and the `ScopeFanOut` classification's rationale comment describes behaviour that is not implemented.

Separately, `root` and `files` are consumed without `resolveFilePath`, so an absolute or `../`-relative entry reaches `os.ReadFile` — a path-confinement question, not a workspace-scoping one.

Making it match its own documentation means fanning out across the session workspace's repos, which changes the response from one `audit.Report` to a per-repo shape that `tools_pr_review_context.go` and the `gortex://audit` resource both consume, plus a confinement fix on two arguments. That is a different change with a different blast radius, and it deserves its own issue rather than riding along here.

## The alias table has a second tier

Sweeping the fourteen alias entries #397 did not name: eight are genuinely clean (`architecture`, `churn`, `coupling`, `extraction`, `knowledge_gaps`, `surprising_connections`, `untested` all source through the scoped accessors; `contracts` resolves scope with an explicit documented `all_repos` opt-out), and `inspection_catalog` touches no graph.

The remaining five — `lint`, `citation`, `why`, `replay`, `co_change` — are unscoped, but in a different and milder way: each dereferences a target the caller must name, rather than enumerating rows unasked. They cannot be used to discover a sibling workspace, only to read one once an id is already known. That is a real gap and worth its own issue, but it is a different severity class from the four here and wants a different decision (a by-id visibility gate, not a row filter).

## Verification

`go test -race -timeout=25m ./...` passes. `golangci-lint run ./...` is clean.

21 new tests across three files, plus a repo-attribution assertion added to the existing `MultiWatcher` history test. Every leak case was verified to fail against the pre-fix handler — including the straddling-community label/hub case, which reproduces as `"label":"repo-b +1 dirs","hub":"bBillingService","parent_id":"group/repo-b"` alongside a correctly-narrowed member list.

The rest are compatibility fences, and they pass both before and after by construction: an unbound session — the CLI, control clients, and the dashboard, none of which carry a session cwd — still sees the whole index through every one of these tools, and single-repo mode is unchanged, including the row shape of an unprefixed watcher event. `get_recent_changes`' `since` branch is covered separately because it used to render through its own duplicated loop, where a partial fix would have looked correct.
