### PR TITLE
fix(claudecli): make the headless spawn a completion engine, not an interactive session

### DIFF
--- a/docs/llm.md
+++ b/docs/llm.md
@@ -70,7 +70,7 @@ llm:
   claudecli:                 # provider: claudecli — spawns the `claude` CLI per call
     # binary: claude          # binary name or absolute path (resolved via $PATH; default "claude")
     model: sonnet             # optional — forwarded as `--model`; empty = CLI default
-    # args: ["--allowed-tools", ""]   # extra args appended after our flags (disable tools, etc.)
+    # args: ["--permission-mode", "plan"]   # extra args appended after our flags; a flag here overrides the matching headless default
     # timeout_seconds: 180    # cap per Complete call; 0 → 120s
 
   codex:                     # provider: codex — spawns the OpenAI `codex` CLI per call
@@ -114,6 +114,17 @@ llm:
     simple_model: claude-haiku-4-5    # low-complexity runs (empty = configured model)
     complex_model: claude-opus-4-7    # multi-hop / refactor-scale runs
 ```
+
+**`claudecli` headless defaults.** A `claude -p` spawn otherwise loads the user's whole interactive configuration, none of which a one-shot completion wants. The provider therefore passes, by default:
+
+| Flag | Why |
+|---|---|
+| `--settings '{"disableAllHooks":true}'` | The user's hooks run inside the spawn. A `SessionEnd` hook that fails in a headless context exits the CLI nonzero — and that failed the entire call. |
+| `--tools ""` | Even under `--print` the CLI exposes `Bash` / `Read` / `Grep` / …, and a model that opens with a native tool call spends the single `--max-turns 1` turn on it: the run dies with `Reached max turns (1)`. `--allowed-tools` is **not** a substitute — it governs auto-approval, not availability, so the call is still attempted. |
+| `--strict-mcp-config` | Skip the user's MCP servers: startup latency, plus more tools to be tempted by. |
+| `--system-prompt` (instead of `--append-system-prompt`) | Appending leaves Claude Code's agentic persona, the discovered `CLAUDE.md` files and the injected environment block (“you are in `<cwd>`, which is not a git repository”) in force, and that context routinely beats the structured-output instruction — the reply comes back as a clarifying question instead of JSON. |
+
+Every one of these is skipped when `llm.claudecli.args` already carries the same flag, so the config file is the final word: `args: ["--tools", "default"]` restores the built-in toolset, and a custom `--system-prompt` keeps gortex's schema instruction as an `--append-system-prompt` rider rather than dropping it.
 
 **Local provider idle unload.** The in-process llama.cpp model is unloaded after sitting idle (freeing its memory), and reloaded lazily on the next call. Default idle TTL is 10 minutes; override with `GORTEX_LLM_IDLE_TTL` (a verbatim Go duration, e.g. `5m`); `0` / `off` / `none` disables idle unloading, keeping the model resident once loaded.
 

--- a/internal/llm/agent/agent.go
+++ b/internal/llm/agent/agent.go
@@ -254,6 +254,8 @@ func (a *Agent) systemPrompt(extras string) string {
 	sys.WriteString("You are a tool-using agent. ")
 	sys.WriteString("On each turn, emit ONE JSON object: ")
 	sys.WriteString(`{"tool": "<name>", "args": {...}}.`)
+	sys.WriteString(" Emit that object on its own — never wrapped in an array, ")
+	sys.WriteString("never inside markdown fences, with no prose around it.")
 	sys.WriteString(" Available tools:\n")
 	for _, n := range a.names {
 		fmt.Fprintf(&sys, "- %s: %s\n", n, a.tools[n].Description)
@@ -274,9 +276,30 @@ type toolCall struct {
 	Args map[string]any `json:"args"`
 }
 
+// parseToolCall decodes one step's payload into a tool call. It is
+// deliberately lenient about the *envelope*: the subprocess providers
+// have no native structured output, so the shape they return is only
+// as reliable as the model tier behind them. Smaller models routinely
+// wrap the single call in a one-element array however firmly the
+// system prompt says not to — decoding that strictly would make whole
+// model tiers unable to drive the agent loop at all. The contents are
+// still validated strictly.
 func parseToolCall(s string) (toolCall, error) {
+	payload := strings.TrimSpace(s)
+	if strings.HasPrefix(payload, "[") {
+		var arr []json.RawMessage
+		if err := json.Unmarshal([]byte(payload), &arr); err != nil {
+			return toolCall{}, err
+		}
+		if len(arr) == 0 {
+			return toolCall{}, errors.New("empty tool-call array")
+		}
+		// Take the first call; the loop asks for the next one on the
+		// following step anyway.
+		payload = string(arr[0])
+	}
 	var c toolCall
-	if err := json.Unmarshal([]byte(s), &c); err != nil {
+	if err := json.Unmarshal([]byte(payload), &c); err != nil {
 		return c, err
 	}
 	if c.Tool == "" {

--- a/internal/llm/agent/agent_test.go
+++ b/internal/llm/agent/agent_test.go
@@ -1,0 +1,101 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+// The subprocess CLI providers have no native structured output, so the
+// envelope a step comes back in is only as reliable as the model tier
+// behind them. Small models wrap the single call in a one-element array
+// often enough that strict decoding makes whole tiers unusable.
+func TestParseToolCall_Envelopes(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      string
+		wantTool string
+		wantArg  string
+	}{
+		{
+			name:     "bare object",
+			raw:      `{"tool":"search_symbols","args":{"query":"sqlc schema"}}`,
+			wantTool: "search_symbols",
+			wantArg:  "sqlc schema",
+		},
+		{
+			name:     "array-wrapped single call",
+			raw:      `[{"tool":"search_symbols","args":{"query":"sqlc schema"}}]`,
+			wantTool: "search_symbols",
+			wantArg:  "sqlc schema",
+		},
+		{
+			name:     "array with several calls takes the first",
+			raw:      `[{"tool":"search_symbols","args":{"query":"sqlc schema"}},{"tool":"read_file","args":{}}]`,
+			wantTool: "search_symbols",
+			wantArg:  "sqlc schema",
+		},
+		{
+			name:     "leading whitespace",
+			raw:      "\n  [{\"tool\":\"search_symbols\",\"args\":{\"query\":\"sqlc schema\"}}]\n",
+			wantTool: "search_symbols",
+			wantArg:  "sqlc schema",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			call, err := parseToolCall(tc.raw)
+			if err != nil {
+				t.Fatalf("parseToolCall: %v", err)
+			}
+			if call.Tool != tc.wantTool {
+				t.Errorf("tool=%q want %q", call.Tool, tc.wantTool)
+			}
+			if got, _ := call.Args["query"].(string); got != tc.wantArg {
+				t.Errorf("args[query]=%q want %q", got, tc.wantArg)
+			}
+		})
+	}
+}
+
+func TestParseToolCall_MissingArgsDefaultsToEmptyMap(t *testing.T) {
+	call, err := parseToolCall(`{"tool":"final_answer"}`)
+	if err != nil {
+		t.Fatalf("parseToolCall: %v", err)
+	}
+	if call.Args == nil {
+		t.Fatal("Args must never be nil")
+	}
+	if len(call.Args) != 0 {
+		t.Errorf("Args=%v want empty", call.Args)
+	}
+}
+
+// Leniency about the envelope must not become leniency about the
+// contents.
+func TestParseToolCall_Rejects(t *testing.T) {
+	for _, raw := range []string{
+		``,
+		`[]`,
+		`[`,
+		`not json`,
+		`{"args":{"query":"x"}}`,
+		`[{"args":{"query":"x"}}]`,
+	} {
+		if _, err := parseToolCall(raw); err == nil {
+			t.Errorf("parseToolCall(%q) = nil error, want failure", raw)
+		}
+	}
+}
+
+func TestSystemPrompt_ForbidsArrayAndFenceWrapping(t *testing.T) {
+	a := &Agent{
+		names: []string{"search_symbols"},
+		tools: map[string]Tool{"search_symbols": {Description: "search"}},
+	}
+	got := a.systemPrompt("")
+	for _, want := range []string{"never wrapped in an array", "never inside markdown fences"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("system prompt missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/internal/llm/clitext.go
+++ b/internal/llm/clitext.go
@@ -73,6 +73,19 @@ func ExtractJSON(text string) (string, bool) {
 	return "", false
 }
 
+// FailureSnippet picks the most informative blob to attach to a failed
+// CLI spawn. stderr comes first — that is where a well-behaved CLI puts
+// its diagnostics — but the coding-agent CLIs print terminal errors on
+// stdout in print mode (`claude -p` reports "Error: Reached max turns
+// (1)" there and exits 1 with an empty stderr), and an empty stderr
+// must not collapse a real message into a bare "exit status 1".
+func FailureSnippet(stdout, stderr []byte) string {
+	if s := Snippet(stderr); s != "" {
+		return s
+	}
+	return Snippet(stdout)
+}
+
 // Snippet truncates a stderr / stdout blob for inclusion in an error
 // message. Operates on runes so multi-byte characters at the cut point
 // stay intact.

--- a/internal/llm/clitext_test.go
+++ b/internal/llm/clitext_test.go
@@ -5,6 +5,26 @@ import (
 	"testing"
 )
 
+func TestFailureSnippet(t *testing.T) {
+	cases := []struct {
+		name           string
+		stdout, stderr string
+		want           string
+	}{
+		{"prefers stderr", "some output", "auth required", "auth required"},
+		{"falls back to stdout", "Error: Reached max turns (1)", "", "Error: Reached max turns (1)"},
+		{"whitespace-only stderr is empty", "Error: boom", "  \n", "Error: boom"},
+		{"both empty", "", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := FailureSnippet([]byte(tc.stdout), []byte(tc.stderr)); got != tc.want {
+				t.Errorf("FailureSnippet=%q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestExtractJSON_Variants(t *testing.T) {
 	cases := []struct {
 		name  string

--- a/internal/llm/config.go
+++ b/internal/llm/config.go
@@ -311,8 +311,12 @@ type ClaudeCLIConfig struct {
 	// pick its own default.
 	Model string `mapstructure:"model" yaml:"model,omitempty"`
 	// Args is a list of extra arguments appended after the provider's
-	// own flags. Useful for `--allowed-tools ""` to disable tools, or
-	// `--permission-mode plan` for a read-only profile.
+	// own flags. It also overrides them: the provider skips any of its
+	// headless defaults (`--tools ""`, `--strict-mcp-config`,
+	// `--settings '{"disableAllHooks":true}'`, `--system-prompt`) whose
+	// flag appears here. `["--tools", "default"]` restores the built-in
+	// toolset; `["--permission-mode", "plan"]` picks a read-only
+	// profile.
 	Args []string `mapstructure:"args" yaml:"args,omitempty"`
 	// TimeoutSeconds caps one Complete call. 0 → 120s.
 	TimeoutSeconds int `mapstructure:"timeout_seconds" yaml:"timeout_seconds,omitempty"`

--- a/internal/llm/provider/agentcli/agentcli.go
+++ b/internal/llm/provider/agentcli/agentcli.go
@@ -163,9 +163,9 @@ func (p *Provider) Complete(ctx context.Context, req llm.CompletionRequest) (llm
 
 	if err := cmd.Run(); err != nil {
 		if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
-			return llm.CompletionResponse{}, fmt.Errorf("%s: timed out after %s: %s", p.spec.ProviderID, p.spec.Timeout, llm.Snippet(stderr.Bytes()))
+			return llm.CompletionResponse{}, fmt.Errorf("%s: timed out after %s: %s", p.spec.ProviderID, p.spec.Timeout, llm.FailureSnippet(stdout.Bytes(), stderr.Bytes()))
 		}
-		if msg := llm.Snippet(stderr.Bytes()); msg != "" {
+		if msg := llm.FailureSnippet(stdout.Bytes(), stderr.Bytes()); msg != "" {
 			return llm.CompletionResponse{}, fmt.Errorf("%s: %w: %s", p.spec.ProviderID, err, msg)
 		}
 		return llm.CompletionResponse{}, fmt.Errorf("%s: %w", p.spec.ProviderID, err)

--- a/internal/llm/provider/claudecli/claudecli.go
+++ b/internal/llm/provider/claudecli/claudecli.go
@@ -5,9 +5,13 @@
 // binary, which reuses the user's Claude Code subscription instead of
 // requiring an Anthropic API key. Each Complete call spawns one
 // `claude -p` subprocess: the conversation is flattened to text, the
-// system prompt is forwarded via --append-system-prompt, and the
-// prompt text is fed on stdin so very large contexts don't trip
-// ARG_MAX.
+// system prompt is forwarded via --system-prompt, and the prompt text
+// is fed on stdin so very large contexts don't trip ARG_MAX.
+//
+// The spawn is deliberately stripped down to a completion engine —
+// see headlessArgs for why an interactive Claude Code session's
+// hooks, native tools, MCP servers and default system prompt all have
+// to be turned off before a one-shot call is reliable.
 //
 // Structured output (the expand / rerank / verify shapes and the
 // agent tool-call shape) is obtained by appending a JSON-Schema
@@ -38,6 +42,14 @@ import (
 // one model round-trip is comfortably under 120s for the small
 // prompts the assist/agent loop emits.
 const defaultTimeout = 120 * time.Second
+
+// headlessSettings is the --settings payload the provider passes by
+// default. A one-shot completion has no session lifecycle worth
+// hooking, but the spawn still loads the user's interactive Claude
+// Code configuration — so a SessionEnd hook that fails in a headless
+// context (or a plugin hook that is simply meaningless there) exits
+// the CLI nonzero and takes the whole Complete call down with it.
+const headlessSettings = `{"disableAllHooks":true}`
 
 // Provider implements llm.Provider against the `claude` CLI.
 type Provider struct {
@@ -82,11 +94,11 @@ func (p *Provider) Close() error { return nil }
 
 // Complete implements llm.Provider. It runs one `claude -p`
 // subprocess: the system messages are joined and forwarded via
-// --append-system-prompt, every other message is flattened into a
-// chat-style prompt that is piped on stdin, and stdout is captured
-// as the model's text. For structured shapes the schema is injected
-// into the system prompt and the first balanced JSON object is
-// extracted from the response.
+// --system-prompt, every other message is flattened into a chat-style
+// prompt that is piped on stdin, and stdout is captured as the
+// model's text. For structured shapes the schema is injected into the
+// system prompt and the first balanced JSON object is extracted from
+// the response.
 func (p *Provider) Complete(ctx context.Context, req llm.CompletionRequest) (llm.CompletionResponse, error) {
 	system, prompt := flatten(req.Messages)
 	structured := req.Shape != llm.ShapeFreeform
@@ -95,6 +107,7 @@ func (p *Provider) Complete(ctx context.Context, req llm.CompletionRequest) (llm
 	}
 
 	args := []string{"--print", "--output-format", "text"}
+	args = append(args, p.headlessArgs()...)
 	if p.model != "" {
 		args = append(args, "--model", p.model)
 	}
@@ -104,8 +117,23 @@ func (p *Provider) Complete(ctx context.Context, req llm.CompletionRequest) (llm
 	// best-effort: the CLI exposes no equivalent flag, so we lean on
 	// the model's own behaviour given a short system prompt.
 	args = append(args, "--max-turns", "1")
-	if system != "" {
-		args = append(args, "--append-system-prompt", system)
+	// --system-prompt REPLACES Claude Code's default agentic system
+	// prompt; --append-system-prompt only adds to it. Appending leaves
+	// the interactive-agent persona, the discovered CLAUDE.md files and
+	// the injected environment block ("you are in <cwd>, which is not a
+	// git repository") in force, and that context routinely beats the
+	// structured-output instruction — the reply comes back as a
+	// clarifying question instead of JSON. Replace it, even with an
+	// empty string, so this spawn is a plain completion engine.
+	if hasFlag(p.extra, "--system-prompt") {
+		// The user is supplying their own base prompt. Ours carries the
+		// structured-output rider, so demote it to an append rather than
+		// let two --system-prompt values fight.
+		if system != "" {
+			args = append(args, "--append-system-prompt", system)
+		}
+	} else {
+		args = append(args, "--system-prompt", system)
 	}
 	args = append(args, p.extra...)
 
@@ -127,9 +155,9 @@ func (p *Provider) Complete(ctx context.Context, req llm.CompletionRequest) (llm
 		// Distinguish a context-timeout from an exec failure so the
 		// agent loop can log something meaningful.
 		if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
-			return llm.CompletionResponse{}, fmt.Errorf("claudecli: timed out after %s: %s", p.timeout, llm.Snippet(stderr.Bytes()))
+			return llm.CompletionResponse{}, fmt.Errorf("claudecli: timed out after %s: %s", p.timeout, llm.FailureSnippet(stdout.Bytes(), stderr.Bytes()))
 		}
-		if msg := llm.Snippet(stderr.Bytes()); msg != "" {
+		if msg := llm.FailureSnippet(stdout.Bytes(), stderr.Bytes()); msg != "" {
 			return llm.CompletionResponse{}, fmt.Errorf("claudecli: %w: %s", err, msg)
 		}
 		return llm.CompletionResponse{}, fmt.Errorf("claudecli: %w", err)
@@ -149,12 +177,54 @@ func (p *Provider) Complete(ctx context.Context, req llm.CompletionRequest) (llm
 	return llm.CompletionResponse{Text: text}, nil
 }
 
+// headlessArgs returns the flags that turn an interactive coding agent
+// into a one-shot completion engine. Each one is skipped when
+// llm.claudecli.args already carries the same flag, so the config file
+// stays the final word (`args: ["--tools", "default"]` restores the
+// built-in toolset, for instance).
+//
+// Callers must keep at least one further flag after these — --max-turns
+// is unconditional, so that holds — because --tools is variadic: it
+// swallows every following argument until the next flag.
+func (p *Provider) headlessArgs() []string {
+	var args []string
+	if !hasFlag(p.extra, "--tools") {
+		// Empty toolset. Even under --print the CLI exposes Bash / Read /
+		// Grep / …, and a model that opens with a native tool call spends
+		// the single --max-turns turn on it: the run then dies with
+		// "Reached max turns (1)" and a nonzero exit. --allowed-tools is
+		// not a substitute — it governs auto-approval, not availability,
+		// so the call is still attempted.
+		args = append(args, "--tools", "")
+	}
+	if !hasFlag(p.extra, "--strict-mcp-config") {
+		// Skip the user's MCP servers: startup latency and more tools to
+		// be tempted by, for a spawn that only has to emit text.
+		args = append(args, "--strict-mcp-config")
+	}
+	if !hasFlag(p.extra, "--settings") {
+		args = append(args, "--settings", headlessSettings)
+	}
+	return args
+}
+
+// hasFlag reports whether argv already carries the named flag, in
+// either "--flag value" or "--flag=value" form.
+func hasFlag(argv []string, flag string) bool {
+	for _, a := range argv {
+		if a == flag || strings.HasPrefix(a, flag+"=") {
+			return true
+		}
+	}
+	return false
+}
+
 // flatten splits the conversation into a system block (every
 // RoleSystem message joined with a blank line) and a chat-style
 // prompt (every other message rendered as "User:" / "Assistant:" /
 // "Tool result:" turns). The CLI takes the system part via
-// --append-system-prompt and reads the prompt part from stdin. Using
-// stdin avoids the ARG_MAX ceiling on long contexts.
+// --system-prompt and reads the prompt part from stdin. Using stdin
+// avoids the ARG_MAX ceiling on long contexts.
 func flatten(in []llm.Message) (system, prompt string) {
 	var sys []string
 	var b strings.Builder

--- a/internal/llm/provider/claudecli/claudecli_test.go
+++ b/internal/llm/provider/claudecli/claudecli_test.go
@@ -35,9 +35,11 @@ func fakeClaude(t *testing.T, dir string, opts fakeOpts) string {
 	stderrPayload := strings.ReplaceAll(opts.stderr, "'", "'\\''")
 	stdoutPayload := strings.ReplaceAll(opts.stdout, "'", "'\\''")
 
+	// NUL-separated so an argument carrying newlines (the JSON-Schema
+	// rider does) still round-trips as exactly one argv entry.
 	body := "#!/bin/sh\n" +
 		"set -e\n" +
-		"printf '%s\\n' \"$@\" > '" + argsLog + "'\n" +
+		"printf '%s\\0' \"$@\" > '" + argsLog + "'\n" +
 		"cat > '" + stdinLog + "'\n"
 	if opts.sleep > 0 {
 		body += fmt.Sprintf("sleep %d\n", int(opts.sleep.Seconds()+1))
@@ -72,6 +74,41 @@ func readSidecar(t *testing.T, scriptPath, name string) string {
 		t.Fatalf("read %s: %v", name, err)
 	}
 	return string(b)
+}
+
+// argv reconstructs the exact argument vector the fake CLI received.
+func argv(t *testing.T, scriptPath string) []string {
+	t.Helper()
+	raw := readSidecar(t, scriptPath, "args.txt")
+	raw = strings.TrimSuffix(raw, "\x00")
+	if raw == "" {
+		return nil
+	}
+	return strings.Split(raw, "\x00")
+}
+
+// flagValue returns the argument following flag, and whether flag was
+// passed at all (a trailing flag reports "" plus true).
+func flagValue(args []string, flag string) (string, bool) {
+	for i, a := range args {
+		if a != flag {
+			continue
+		}
+		if i+1 < len(args) {
+			return args[i+1], true
+		}
+		return "", true
+	}
+	return "", false
+}
+
+func hasArg(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestNew_BinaryNotFound(t *testing.T) {
@@ -121,18 +158,181 @@ func TestComplete_FreeformSuccess(t *testing.T) {
 		t.Errorf("text=%q want hello world", resp.Text)
 	}
 
-	gotArgs := readSidecar(t, script, "args.txt")
-	for _, want := range []string{"--print", "--output-format", "text", "--append-system-prompt", "be terse"} {
-		if !strings.Contains(gotArgs, want) {
-			t.Errorf("args missing %q\nargs=\n%s", want, gotArgs)
+	args := argv(t, script)
+	for _, want := range []string{"--print", "--output-format", "text"} {
+		if !hasArg(args, want) {
+			t.Errorf("args missing %q\nargs=%q", want, args)
 		}
+	}
+	if got, ok := flagValue(args, "--system-prompt"); !ok || got != "be terse" {
+		t.Errorf("--system-prompt=%q present=%v, want %q", got, ok, "be terse")
 	}
 	stdin := readSidecar(t, script, "stdin.txt")
 	if !strings.Contains(stdin, "User: hi") {
 		t.Errorf("stdin missing user turn:\n%s", stdin)
 	}
 	if strings.Contains(stdin, "be terse") {
-		t.Error("system content must travel via --append-system-prompt, not stdin")
+		t.Error("system content must travel via --system-prompt, not stdin")
+	}
+}
+
+// The provider must REPLACE Claude Code's default system prompt rather
+// than append to it: appending leaves the interactive agent persona,
+// the discovered CLAUDE.md files and the injected cwd/environment block
+// in force, and that context beats the structured-output instruction.
+func TestComplete_ReplacesDefaultSystemPrompt(t *testing.T) {
+	script := fakeClaude(t, "", fakeOpts{stdout: "ok"})
+
+	p, _ := New(llm.ClaudeCLIConfig{Binary: script})
+	defer p.Close()
+
+	if _, err := p.Complete(context.Background(), llm.CompletionRequest{
+		Messages: []llm.Message{{Role: llm.RoleUser, Content: "hi"}},
+	}); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	args := argv(t, script)
+	if hasArg(args, "--append-system-prompt") {
+		t.Errorf("must not append to the default system prompt; args=%q", args)
+	}
+	// Emitted even with no system messages — an empty replacement is
+	// what strips the default agentic prompt.
+	got, ok := flagValue(args, "--system-prompt")
+	if !ok || got != "" {
+		t.Errorf("--system-prompt=%q present=%v, want an empty replacement", got, ok)
+	}
+}
+
+// The headless defaults: hooks off (the reported failure — a user's
+// SessionEnd hook exiting nonzero failed the whole call), no native
+// toolset, no MCP servers.
+func TestComplete_HeadlessDefaults(t *testing.T) {
+	script := fakeClaude(t, "", fakeOpts{stdout: "ok"})
+
+	p, _ := New(llm.ClaudeCLIConfig{Binary: script})
+	defer p.Close()
+
+	if _, err := p.Complete(context.Background(), llm.CompletionRequest{
+		Messages: []llm.Message{{Role: llm.RoleUser, Content: "hi"}},
+	}); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	args := argv(t, script)
+
+	if got, ok := flagValue(args, "--settings"); !ok || !strings.Contains(got, `"disableAllHooks":true`) {
+		t.Errorf("--settings=%q present=%v, want disableAllHooks", got, ok)
+	}
+	if got, ok := flagValue(args, "--tools"); !ok || got != "" {
+		t.Errorf("--tools=%q present=%v, want an empty toolset", got, ok)
+	}
+	if !hasArg(args, "--strict-mcp-config") {
+		t.Errorf("args missing --strict-mcp-config; args=%q", args)
+	}
+}
+
+// --tools is variadic: it swallows every following argument up to the
+// next flag. The value must therefore always be followed by one.
+func TestComplete_ToolsFlagIsFollowedByAFlag(t *testing.T) {
+	script := fakeClaude(t, "", fakeOpts{stdout: "ok"})
+
+	p, _ := New(llm.ClaudeCLIConfig{Binary: script})
+	defer p.Close()
+
+	if _, err := p.Complete(context.Background(), llm.CompletionRequest{
+		Messages: []llm.Message{{Role: llm.RoleUser, Content: "hi"}},
+	}); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	args := argv(t, script)
+	i := -1
+	for n, a := range args {
+		if a == "--tools" {
+			i = n
+			break
+		}
+	}
+	if i < 0 {
+		t.Fatalf("no --tools in args=%q", args)
+	}
+	if i+2 >= len(args) {
+		t.Fatalf("--tools value is the last argument; a variadic flag must be followed by another flag: args=%q", args)
+	}
+	if next := args[i+2]; !strings.HasPrefix(next, "-") {
+		t.Errorf("argument after --tools value is %q, want a flag (it would be swallowed); args=%q", next, args)
+	}
+}
+
+// Any flag in llm.claudecli.args wins over the matching headless
+// default — the config file stays the final word.
+func TestComplete_ArgsOverrideHeadlessDefaults(t *testing.T) {
+	script := fakeClaude(t, "", fakeOpts{stdout: "ok"})
+
+	p, _ := New(llm.ClaudeCLIConfig{
+		Binary: script,
+		Args:   []string{"--tools", "default", "--settings=/etc/claude.json"},
+	})
+	defer p.Close()
+
+	if _, err := p.Complete(context.Background(), llm.CompletionRequest{
+		Messages: []llm.Message{{Role: llm.RoleUser, Content: "hi"}},
+	}); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	args := argv(t, script)
+
+	var tools, settings int
+	for _, a := range args {
+		switch {
+		case a == "--tools":
+			tools++
+		case a == "--settings" || strings.HasPrefix(a, "--settings="):
+			settings++
+		}
+	}
+	if tools != 1 {
+		t.Errorf("--tools appears %d times, want 1 (the user's); args=%q", tools, args)
+	}
+	if settings != 1 {
+		t.Errorf("--settings appears %d times, want 1 (the user's); args=%q", settings, args)
+	}
+	if got, _ := flagValue(args, "--tools"); got != "default" {
+		t.Errorf("--tools=%q, want the user's %q", got, "default")
+	}
+	// Untouched defaults still apply.
+	if !hasArg(args, "--strict-mcp-config") {
+		t.Errorf("args missing --strict-mcp-config; args=%q", args)
+	}
+}
+
+// A user-supplied --system-prompt replaces the base prompt, so the
+// provider's own instruction (which carries the JSON-Schema rider) must
+// survive as an append rather than be dropped.
+func TestComplete_UserSystemPromptKeepsSchemaRider(t *testing.T) {
+	script := fakeClaude(t, "", fakeOpts{stdout: `{"terms":["a"]}`})
+
+	p, _ := New(llm.ClaudeCLIConfig{
+		Binary: script,
+		Args:   []string{"--system-prompt", "you are terse"},
+	})
+	defer p.Close()
+
+	if _, err := p.Complete(context.Background(), llm.CompletionRequest{
+		Messages: []llm.Message{{Role: llm.RoleUser, Content: "expand 'x'"}},
+		Shape:    llm.ShapeExpandTerms,
+	}); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	args := argv(t, script)
+
+	if got, ok := flagValue(args, "--system-prompt"); !ok || got != "you are terse" {
+		t.Errorf("--system-prompt=%q present=%v, want the user's", got, ok)
+	}
+	appended, ok := flagValue(args, "--append-system-prompt")
+	if !ok {
+		t.Fatalf("schema rider dropped; args=%q", args)
+	}
+	if !strings.Contains(appended, "JSON Schema") {
+		t.Errorf("--append-system-prompt=%q, want the JSON-Schema rider", appended)
 	}
 }
 
@@ -147,9 +347,8 @@ func TestComplete_PassesModel(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Complete: %v", err)
 	}
-	args := readSidecar(t, script, "args.txt")
-	if !strings.Contains(args, "--model\nsonnet") && !strings.Contains(args, "--model sonnet") {
-		t.Errorf("args missing --model sonnet:\n%s", args)
+	if got, ok := flagValue(argv(t, script), "--model"); !ok || got != "sonnet" {
+		t.Errorf("--model=%q present=%v, want sonnet", got, ok)
 	}
 }
 
@@ -171,9 +370,9 @@ func TestComplete_StructuredExtractsJSON(t *testing.T) {
 		t.Errorf("text=%q want the unwrapped JSON object", resp.Text)
 	}
 
-	args := readSidecar(t, script, "args.txt")
-	if !strings.Contains(args, "JSON Schema") {
-		t.Errorf("structured request must inject a JSON Schema rider; args=\n%s", args)
+	rider, ok := flagValue(argv(t, script), "--system-prompt")
+	if !ok || !strings.Contains(rider, "JSON Schema") {
+		t.Errorf("structured request must inject a JSON Schema rider; got %q", rider)
 	}
 }
 
@@ -208,6 +407,26 @@ func TestComplete_NonZeroExit(t *testing.T) {
 	}
 }
 
+// `claude -p` prints its terminal errors on stdout and leaves stderr
+// empty, so a stderr-only error message collapses a real diagnosis into
+// an opaque "exit status 1".
+func TestComplete_NonZeroExitFallsBackToStdout(t *testing.T) {
+	script := fakeClaude(t, "", fakeOpts{exitCode: 1, stdout: "Error: Reached max turns (1)"})
+
+	p, _ := New(llm.ClaudeCLIConfig{Binary: script})
+	defer p.Close()
+
+	_, err := p.Complete(context.Background(), llm.CompletionRequest{
+		Messages: []llm.Message{{Role: llm.RoleUser, Content: "hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for non-zero exit")
+	}
+	if !strings.Contains(err.Error(), "Reached max turns") {
+		t.Errorf("error should fall back to the stdout snippet; got: %v", err)
+	}
+}
+
 func TestComplete_EmptyResponseErrors(t *testing.T) {
 	script := fakeClaude(t, "", fakeOpts{stdout: ""})
 
@@ -237,7 +456,7 @@ func TestComplete_ContextCancellation(t *testing.T) {
 func TestComplete_ExtraArgsForwarded(t *testing.T) {
 	script := fakeClaude(t, "", fakeOpts{stdout: "ok"})
 
-	p, _ := New(llm.ClaudeCLIConfig{Binary: script, Args: []string{"--allowed-tools", ""}})
+	p, _ := New(llm.ClaudeCLIConfig{Binary: script, Args: []string{"--permission-mode", "plan"}})
 	defer p.Close()
 
 	if _, err := p.Complete(context.Background(), llm.CompletionRequest{
@@ -245,9 +464,8 @@ func TestComplete_ExtraArgsForwarded(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Complete: %v", err)
 	}
-	args := readSidecar(t, script, "args.txt")
-	if !strings.Contains(args, "--allowed-tools") {
-		t.Errorf("args missing --allowed-tools:\n%s", args)
+	if got, ok := flagValue(argv(t, script), "--permission-mode"); !ok || got != "plan" {
+		t.Errorf("--permission-mode=%q present=%v, want plan", got, ok)
 	}
 }
 

--- a/internal/llm/provider/codex/codex.go
+++ b/internal/llm/provider/codex/codex.go
@@ -143,9 +143,9 @@ func (p *Provider) Complete(ctx context.Context, req llm.CompletionRequest) (llm
 
 	if err := cmd.Run(); err != nil {
 		if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
-			return llm.CompletionResponse{}, fmt.Errorf("codex: timed out after %s: %s", p.timeout, llm.Snippet(stderr.Bytes()))
+			return llm.CompletionResponse{}, fmt.Errorf("codex: timed out after %s: %s", p.timeout, llm.FailureSnippet(stdout.Bytes(), stderr.Bytes()))
 		}
-		if msg := llm.Snippet(stderr.Bytes()); msg != "" {
+		if msg := llm.FailureSnippet(stdout.Bytes(), stderr.Bytes()); msg != "" {
 			return llm.CompletionResponse{}, fmt.Errorf("codex: %w: %s", err, msg)
 		}
 		return llm.CompletionResponse{}, fmt.Errorf("codex: %w", err)


### PR DESCRIPTION
Fixes #323.

## What was wrong

A `claude -p` spawn loads the user's whole interactive Claude Code configuration. The reporter peeled off four stacked failures before `ask` worked at all, and each one is a real defect in the adapter:

1. **Hooks run inside the spawn.** A user's `SessionEnd` hook that fails in a headless context exits the CLI nonzero, and the adapter fails the whole `Complete` call. This was the original report.
2. **Native tools eat the single turn.** Even under `--print` the CLI exposes `Bash` / `Read` / `Grep` / …, so a model that opens with a native tool call spends the one `--max-turns 1` turn on it and dies with `Reached max turns (1)`.
3. **The system prompt was appended, not replaced.** `--append-system-prompt` leaves Claude Code's agentic persona, the discovered `CLAUDE.md` files and the injected environment block ("you are in `<cwd>`, which is not a git repository") in force — and that context routinely beats the structured-output instruction, so the reply is a clarifying question instead of JSON.
4. **Strict tool-call decoding.** Smaller models wrap the single call in a one-element array; `parseToolCall` rejected it outright, making whole model tiers unable to drive the agent loop.

On top of those, the failure was near-undiagnosable: `claude -p` prints terminal errors on **stdout** and exits 1 with an empty stderr, but the adapter only snippets stderr — so all of the above surfaced as an opaque `claudecli: exit status 1`.

## What changed

**`claudecli` headless defaults** — the spawn is now a completion engine, not an interactive session:

| Flag | Fixes |
|---|---|
| `--settings '{"disableAllHooks":true}'` | (1) |
| `--tools ""` | (2). `--allowed-tools` is *not* a substitute — it governs auto-approval, not availability, so the call is still attempted. |
| `--strict-mcp-config` | startup latency + fewer tools to be tempted by |
| `--system-prompt` instead of `--append-system-prompt` | (3) — replaces the default prompt, even when the replacement is empty |

Every one is skipped when `llm.claudecli.args` already carries the same flag, so the config file stays the final word (`args: ["--tools", "default"]` restores the built-in toolset). A user-supplied `--system-prompt` keeps gortex's schema instruction as an `--append-system-prompt` rider rather than silently dropping it.

**`llm.FailureSnippet`** prefers stderr and falls back to stdout on a failed spawn — applied to `claudecli`, `codex`, and the shared `agentcli` engine behind `copilot` / `cursor` / `opencode`.

**`parseToolCall`** unwraps an array envelope to its first element and the agent system prompt now spells the constraint out. The envelope is lenient; the contents are still validated strictly.

`docs/llm.md` documents the defaults and how to override them, and drops the now-misleading `--allowed-tools ""` hint.

## Verification

- `go build ./...`, `go test -race ./internal/llm/... ./internal/config/... ./internal/mcp/... ./internal/wiki/...` — all pass.
- `golangci-lint run ./internal/llm/...` — 0 issues.
- New unit tests cover each default, the override path, the schema-rider-survives-a-custom-base-prompt path, the `--tools` variadic footgun (a variadic flag must never be the last argument), the stdout error fallback, and the array-wrapped tool call.
- **Live check against the real `claude` CLI** (v2.1.221, `model: haiku`, from a non-repo cwd, with hooks/plugins/MCP servers installed): the provider returns a clean bare tool-call object — `{"tool": "search_symbols", "args": {"query": "schema snapshot"}}` — in 12.9s. That is the exact configuration the reporter measured as 0/2 compliant and unusable.

## Not addressed here

- **`cmd.Dir` is still inherited.** With `--system-prompt` replacing the default prompt, no cwd-derived environment context reaches the model at all (the live check above ran from `/tmp` and was unaffected), and `-p` skips the workspace-trust dialog. Setting it properly needs the active repo root plumbed into `llm.Config`, which is a wider change than this fix warrants.
- **The 60s MCP request lifetime on `ask`** is tracked separately in #326. This PR reduces the pressure — it makes the cheap, fast tier viable again by removing the reasons it was failing — but does not change the deadline.
- **Zero `usage` for subprocess providers** is inherent: a spawned CLI reports no token counts. Reporting `0` vs. omitting the field is a response-shaping decision outside this fix.
