### PR TITLE
Record a contract-tier completion marker and report an unbuilt tier

### DIFF
--- a/internal/graph/store.go
+++ b/internal/graph/store.go
@@ -1286,6 +1286,45 @@ type EnrichmentStateStore interface {
 	SetEnrichmentState(state EnrichmentState) error
 }
 
+// ContractState is the per-repo completion marker for the contract tier: the
+// git revision the whole-repo contract pass last committed at, when it
+// finished, and how many contracts it wrote.
+//
+// Contracts are committed all-at-once by the tail of a full index (the
+// deferred contract pass, or its inline equivalent), while re-index admission
+// is per-file mtime. Those two policies disagree: a run whose tail never
+// completes leaves the contract tier EMPTY — not degraded, empty — and every
+// later warm restart sees unchanged mtimes, re-extracts nothing, and keeps it
+// empty for the life of the index. Nothing on disk recorded that the pass was
+// owed, so nothing could tell an unbuilt tier from a repo that genuinely
+// declares no contracts.
+//
+// This row is that record. A repo with no ContractState row has never had a
+// whole-repo contract pass commit against this store, so a zero-row answer
+// from a contract / route query is unbuilt rather than empty.
+type ContractState struct {
+	RepoPrefix    string
+	IndexedSHA    string
+	CompletedAt   int64 // unix seconds
+	ContractCount int
+}
+
+// ContractStateStore is an optional capability backends MAY implement to
+// persist and read back the per-repo contract-tier completion marker.
+// Backends without durable state (the in-memory graph) simply do not
+// implement it — callers type-assert and, when the assertion fails, report no
+// signal at all rather than a false "unbuilt" (an in-memory graph rebuilds
+// its contract tier from scratch on every start, so the failure mode this
+// marker exists to catch cannot occur there).
+//
+// GetContractState's bool is false when no row has been recorded yet: either
+// the repo's contract pass never completed, or the store predates the marker.
+// Both are "not known to be built", which is what the query path reports.
+type ContractStateStore interface {
+	GetContractState(repoPrefix string) (ContractState, bool, error)
+	SetContractState(state ContractState) error
+}
+
 // LightNodeReader is an optional store capability: a repo-scoped node scan
 // that skips decoding each row's opaque meta blob, populating only struct
 // columns and the already-promoted meta keys (signature/visibility/doc/

--- a/internal/graph/store_sqlite/schema.go
+++ b/internal/graph/store_sqlite/schema.go
@@ -566,6 +566,23 @@ CREATE TABLE IF NOT EXISTS enrichment_state (
     PRIMARY KEY (repo_prefix, provider)
 ) WITHOUT ROWID;
 
+-- contract_state records, per repo, that a WHOLE-REPO contract pass committed
+-- against this store: the revision it ran at, when it finished, and how many
+-- contracts it wrote. Contracts are committed all-at-once by the tail of a
+-- full index while re-index admission is per-file mtime, so a run whose tail
+-- is lost leaves the contract tier empty and every later warm restart sees
+-- unchanged mtimes and re-extracts nothing. Absent this row the empty tier is
+-- indistinguishable from a repo that genuinely declares no contracts; the
+-- contract / route query path reads it to say which one it is answering. One
+-- row per repo_prefix; WITHOUT ROWID — the PK index IS the table, like
+-- file_mtimes / repo_index_state.
+CREATE TABLE IF NOT EXISTS contract_state (
+    repo_prefix    TEXT PRIMARY KEY,
+    indexed_sha    TEXT NOT NULL DEFAULT '',
+    completed_at   INTEGER NOT NULL DEFAULT 0,
+    contract_count INTEGER NOT NULL DEFAULT 0
+) WITHOUT ROWID;
+
 -- clone_shingles is the per-symbol MinHash shingle-set sidecar. Each
 -- function/method node's []uint64 shingle set is stored as a little-
 -- endian BLOB (8 bytes/elem) keyed by node_id so the maintained clone-

--- a/internal/graph/store_sqlite/store_contract_state.go
+++ b/internal/graph/store_sqlite/store_contract_state.go
@@ -1,0 +1,46 @@
+package store_sqlite
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Compile-time assertion that the SQLite Store persists the contract-tier
+// completion marker. It lives in the same backend as the graph it describes,
+// so a warm restart can tell an unbuilt contract tier (the tail that commits
+// it was lost, and per-file mtime admission will never re-extract it) from a
+// repo that genuinely declares no contracts.
+var _ graph.ContractStateStore = (*Store)(nil)
+
+// SetContractState upserts the completion marker for one repo — written when
+// a whole-repo contract pass finishes committing. One row per repo_prefix.
+func (s *Store) SetContractState(st graph.ContractState) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	_, err := s.execActiveWriteLocked(context.Background(), `
+INSERT OR REPLACE INTO contract_state
+  (repo_prefix, indexed_sha, completed_at, contract_count)
+VALUES (?, ?, ?, ?)`,
+		st.RepoPrefix, st.IndexedSHA, st.CompletedAt, st.ContractCount)
+	return err
+}
+
+// GetContractState returns the recorded completion marker for a repo. The
+// bool is false when no row exists yet — the repo's contract pass never
+// completed against this store, or the store predates the marker.
+func (s *Store) GetContractState(repoPrefix string) (graph.ContractState, bool, error) {
+	row := s.db.QueryRow(`
+SELECT indexed_sha, completed_at, contract_count
+  FROM contract_state WHERE repo_prefix = ?`, repoPrefix)
+	st := graph.ContractState{RepoPrefix: repoPrefix}
+	err := row.Scan(&st.IndexedSHA, &st.CompletedAt, &st.ContractCount)
+	if err == sql.ErrNoRows {
+		return graph.ContractState{RepoPrefix: repoPrefix}, false, nil
+	}
+	if err != nil {
+		return graph.ContractState{RepoPrefix: repoPrefix}, false, err
+	}
+	return st, true, nil
+}

--- a/internal/graph/store_sqlite/store_contract_state_test.go
+++ b/internal/graph/store_sqlite/store_contract_state_test.go
@@ -1,0 +1,139 @@
+package store_sqlite
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// TestContractStateRoundTrip: set/get, missing-row, upsert-in-place, and
+// per-repo row isolation on the SQLite store.
+func TestContractStateRoundTrip(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "store.sqlite"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer s.Close()
+
+	// Missing row → found=false, no error. That is the "contract tier never
+	// built here" signal the query path reports on.
+	if _, found, err := s.GetContractState("repo"); err != nil || found {
+		t.Fatalf("missing row: found=%v err=%v, want found=false, err=nil", found, err)
+	}
+
+	st := graph.ContractState{
+		RepoPrefix:    "repo",
+		IndexedSHA:    "abc123",
+		CompletedAt:   1_700_000_000,
+		ContractCount: 149,
+	}
+	if err := s.SetContractState(st); err != nil {
+		t.Fatalf("SetContractState: %v", err)
+	}
+
+	got, found, err := s.GetContractState("repo")
+	if err != nil || !found {
+		t.Fatalf("get after set: found=%v err=%v, want found=true", found, err)
+	}
+	if got.RepoPrefix != "repo" || got.IndexedSHA != "abc123" ||
+		got.CompletedAt != 1_700_000_000 || got.ContractCount != 149 {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+
+	// Upsert on repo_prefix replaces in place.
+	st.IndexedSHA = "def456"
+	st.ContractCount = 151
+	if err := s.SetContractState(st); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	got, _, _ = s.GetContractState("repo")
+	if got.IndexedSHA != "def456" || got.ContractCount != 151 {
+		t.Fatalf("upsert did not replace in place: %+v", got)
+	}
+
+	// A repo that committed a tier holding zero contracts is still MARKED —
+	// "the pass ran" and "the pass found something" are different facts.
+	if err := s.SetContractState(graph.ContractState{RepoPrefix: "empty", CompletedAt: 7}); err != nil {
+		t.Fatalf("seed empty-tier marker: %v", err)
+	}
+	got, found, err = s.GetContractState("empty")
+	if err != nil || !found || got.ContractCount != 0 {
+		t.Fatalf("empty-tier marker: got %+v found=%v err=%v", got, found, err)
+	}
+
+	// A different repo is a distinct row.
+	if _, found, _ := s.GetContractState("other"); found {
+		t.Fatalf("a different repo must be its own row, got found=true")
+	}
+}
+
+// TestOpenPreservesContractStateOnReopen proves the new table is picked up by
+// an existing store with no wipe: a marker written on the first open survives
+// the second open (which re-runs schemaSQL unconditionally) and the schema
+// version does not drift.
+func TestOpenPreservesContractStateOnReopen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "store.sqlite")
+
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+	if err := s.SetContractState(graph.ContractState{
+		RepoPrefix: "r", IndexedSHA: "sha1", CompletedAt: 42, ContractCount: 8,
+	}); err != nil {
+		t.Fatalf("seed marker: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	s2, err := Open(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer s2.Close()
+
+	got, found, err := s2.GetContractState("r")
+	if err != nil || !found {
+		t.Fatalf("marker lost across reopen: found=%v err=%v (the table must survive a no-op reopen)", found, err)
+	}
+	if got.IndexedSHA != "sha1" || got.ContractCount != 8 {
+		t.Fatalf("marker corrupted across reopen: %+v", got)
+	}
+	if v, _ := readUserVersion(s2.db); v != currentSchemaVersion {
+		t.Fatalf("schema version drifted to %d after reopen, want %d", v, currentSchemaVersion)
+	}
+}
+
+// PurgeRepo must clear the marker with the rest of the repo's residue —
+// otherwise an untracked-then-retracked repo would look "already built" while
+// its contract nodes were deleted.
+func TestPurgeRepoClearsContractState(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "store.sqlite"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer s.Close()
+
+	s.AddBatch([]*graph.Node{{
+		ID: "gone/a.go::A", Kind: graph.KindFunction, Name: "A", FilePath: "gone/a.go", RepoPrefix: "gone",
+	}}, nil)
+	if err := s.SetContractState(graph.ContractState{RepoPrefix: "gone", ContractCount: 3}); err != nil {
+		t.Fatalf("seed marker: %v", err)
+	}
+	if err := s.SetContractState(graph.ContractState{RepoPrefix: "kept", ContractCount: 5}); err != nil {
+		t.Fatalf("seed sibling marker: %v", err)
+	}
+
+	if err := s.PurgeRepo("gone"); err != nil {
+		t.Fatalf("PurgeRepo: %v", err)
+	}
+
+	if _, found, _ := s.GetContractState("gone"); found {
+		t.Fatalf("PurgeRepo left the purged repo's contract marker behind")
+	}
+	if _, found, _ := s.GetContractState("kept"); !found {
+		t.Fatalf("PurgeRepo removed a sibling repo's contract marker")
+	}
+}

--- a/internal/graph/store_sqlite/store_purge.go
+++ b/internal/graph/store_sqlite/store_purge.go
@@ -9,8 +9,8 @@ import (
 
 // This file adds the repo-scoped store hygiene the base eviction path lacks.
 // EvictRepo (store.go) deletes ONLY nodes+edges, but a repo owns fifteen
-// other sidecar tables (file_mtimes, repo_index_state,
-// enrichment_state, semantic_binding_types, clone_shingles, constant_values,
+// other sidecar tables (file_mtimes, repo_index_state, enrichment_state,
+// contract_state, semantic_binding_types, clone_shingles, constant_values,
 // files, ref_facts, vectors, churn/coverage/release/blame_enrichment,
 // symbol_fts, symbol_fts_rowid, content_fts — see schema.go). Untracking a repo through
 // EvictRepo leaks every one of them, so a long-lived store accumulates
@@ -37,6 +37,7 @@ var purgeSidecarTables = []string{
 	"file_mtimes",
 	"repo_index_state",
 	"enrichment_state",
+	"contract_state",
 	"semantic_binding_types",
 	"clone_shingles",
 	"clone_corpus_state",
@@ -209,18 +210,19 @@ func (s *Store) OrphanRepoPrefixes(known []string) []string {
 // rekeyMoveTables are the sidecar tables RekeyRepoPrefix relabels from old
 // to new. Every one is keyed by repo_prefix (+ file_path or provider), NOT
 // by node_id, so its row content survives a node-id change: file_mtimes /
-// files by (repo_prefix, file_path); repo_index_state / enrichment_state by
-// repo_prefix (+ provider). At a solo->multi migration every ” row in these
-// belongs to the one migrating repo — global externals live in the NODES
-// table and hold NO rows here — so moving them wholesale is safe. UPDATE OR
-// REPLACE folds any row the re-mint re-index already wrote under new
-// (identical content: same files, same mtimes, same commit) instead of
-// tripping the primary-key conflict a plain UPDATE would.
+// files by (repo_prefix, file_path); repo_index_state / contract_state /
+// enrichment_state by repo_prefix (+ provider). At a solo->multi migration
+// every ” row in these belongs to the one migrating repo — global externals
+// live in the NODES table and hold NO rows here — so moving them wholesale
+// is safe. UPDATE OR REPLACE folds any row the re-mint re-index already wrote
+// under new (identical content: same files, same mtimes, same commit) instead
+// of tripping the primary-key conflict a plain UPDATE would.
 var rekeyMoveTables = []string{
 	"file_mtimes",
 	"files",
 	"repo_index_state",
 	"enrichment_state",
+	"contract_state",
 }
 
 // rekeyDropTables are the sidecar tables RekeyRepoPrefix DROPS (rather than

--- a/internal/indexer/contract_state_marker_test.go
+++ b/internal/indexer/contract_state_marker_test.go
@@ -1,0 +1,207 @@
+package indexer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+// contractStateGraph embeds *graph.Graph (auto-satisfying graph.Store) and
+// adds the ContractStateStore capability, standing in for the on-disk backend
+// so a test can observe the marker without opening SQLite.
+type contractStateGraph struct {
+	*graph.Graph
+
+	state map[string]graph.ContractState
+}
+
+func newContractStateGraph() *contractStateGraph {
+	return &contractStateGraph{Graph: graph.New(), state: map[string]graph.ContractState{}}
+}
+
+func (c *contractStateGraph) SetContractState(st graph.ContractState) error {
+	c.state[st.RepoPrefix] = st
+	return nil
+}
+
+func (c *contractStateGraph) GetContractState(repoPrefix string) (graph.ContractState, bool, error) {
+	st, ok := c.state[repoPrefix]
+	if !ok {
+		return graph.ContractState{RepoPrefix: repoPrefix}, false, nil
+	}
+	return st, true, nil
+}
+
+// writeGoRouteRepo lays down a repo whose single route is registered with a Go
+// 1.22 method pattern — the shape the contract extractor turns into an
+// EdgeHandlesRoute.
+func writeGoRouteRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	src := `package app
+
+import "net/http"
+
+type handlers struct{}
+
+func (h handlers) Register(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/users", h.listUsers)
+}
+
+func (h handlers) listUsers(w http.ResponseWriter, r *http.Request) {
+	_ = w
+	_ = r
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "app.go"), []byte(src), 0o644))
+	return dir
+}
+
+func handlesRouteEdgeCount(g graph.Store) int {
+	n := 0
+	for _, e := range g.AllEdges() {
+		if e.Kind == graph.EdgeHandlesRoute {
+			n++
+		}
+	}
+	return n
+}
+
+func newRouteIndexer(t *testing.T, g graph.Store) *Indexer {
+	t.Helper()
+	reg := parser.NewRegistry()
+	languages.RegisterAll(reg)
+	return New(g, reg, config.Default().Index, zap.NewNop())
+}
+
+// A lost deferred tail leaves the contract tier EMPTY — not degraded — and
+// writes no completion marker. This is the state issue #436 reported: the node
+// layer is complete, `analyze kind=routes` returns a clean zero, and per-file
+// mtime admission will never re-extract the tier on a later restart. The
+// absent marker is what makes that zero reportable instead of silent.
+func TestLostContractTailLeavesTierEmptyAndUnmarked(t *testing.T) {
+	dir := writeGoRouteRepo(t)
+	g := newContractStateGraph()
+	idx := newRouteIndexer(t, g)
+	idx.SetDeferResolve(true)
+
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+
+	// The tail never runs: the parked registry is the only place the
+	// extracted contracts live.
+	require.NotNil(t, idx.pendingContractReg, "contracts should be parked for the deferred tail")
+	require.Zero(t, handlesRouteEdgeCount(g), "an uncommitted tier has no route edges")
+
+	_, found, err := g.GetContractState("")
+	require.NoError(t, err)
+	require.False(t, found, "no marker may be recorded for a tier that was never committed")
+}
+
+// Running the deferred tail commits the tier and records the marker, so a
+// later query can tell a built tier from an unbuilt one.
+func TestDeferredContractTailRecordsCompletionMarker(t *testing.T) {
+	dir := writeGoRouteRepo(t)
+	g := newContractStateGraph()
+	idx := newRouteIndexer(t, g)
+	idx.SetDeferResolve(true)
+
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+	idx.ResolveAll()
+	idx.runDeferredContracts()
+
+	require.NotZero(t, handlesRouteEdgeCount(g), "the tail must commit the route edges")
+
+	st, found, err := g.GetContractState("")
+	require.NoError(t, err)
+	require.True(t, found, "the completed tail must record a contract-tier marker")
+	require.Positive(t, st.ContractCount, "the marker records what the pass committed")
+	require.Positive(t, st.CompletedAt)
+}
+
+// The inline (non-deferred) full-index path commits contracts itself and must
+// record the same marker — otherwise a single-repo daemon would report every
+// healthy tier as unbuilt.
+func TestInlineContractPassRecordsCompletionMarker(t *testing.T) {
+	dir := writeGoRouteRepo(t)
+	g := newContractStateGraph()
+	idx := newRouteIndexer(t, g)
+
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+
+	require.NotZero(t, handlesRouteEdgeCount(g))
+	st, found, err := g.GetContractState("")
+	require.NoError(t, err)
+	require.True(t, found, "the inline contract pass must record a contract-tier marker")
+	require.Positive(t, st.ContractCount)
+}
+
+// A repo that genuinely declares no contracts still gets a marker: the marker
+// records that the pass RAN, not that it found something. Without this, "no
+// contracts here" would be indistinguishable from "the tier was never built" —
+// the very confusion the marker exists to remove.
+func TestContractPassRecordsMarkerForRepoWithNoContracts(t *testing.T) {
+	dir := t.TempDir()
+	src := `package app
+
+func Add(a, b int) int { return a + b }
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "math.go"), []byte(src), 0o644))
+
+	g := newContractStateGraph()
+	idx := newRouteIndexer(t, g)
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+
+	_, found, err := g.GetContractState("")
+	require.NoError(t, err)
+	require.True(t, found, "a contract pass that found nothing still completed")
+}
+
+// The bulk-load path parses into an in-memory shadow and drains it to disk
+// afterwards, so the inline contract pass commits while idx.graph is the
+// throwaway shadow. The marker must still land on the store the contract nodes
+// end up in — otherwise a shadow-backed index would drain a healthy tier to
+// disk and leave it looking permanently unbuilt.
+func TestContractMarkerLandsOnDiskStoreBehindShadow(t *testing.T) {
+	dir := writeGoRouteRepo(t)
+
+	s, err := store_sqlite.Open(filepath.Join(t.TempDir(), "store.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	idx := newRouteIndexer(t, graph.Store(s))
+	idx.SetRootPath(dir)
+	_, err = idx.IndexCtx(context.Background(), dir)
+	require.NoError(t, err)
+
+	require.NotZero(t, handlesRouteEdgeCount(s), "route edges must reach the disk store")
+	st, found, err := s.GetContractState("")
+	require.NoError(t, err)
+	require.True(t, found, "the marker must reach the disk store, not die with the shadow")
+	require.Positive(t, st.ContractCount)
+}
+
+// A backend without the capability (the in-memory graph, which rebuilds its
+// tier on every start) must not fail the commit.
+func TestContractMarkerIsNoOpWithoutCapableStore(t *testing.T) {
+	dir := writeGoRouteRepo(t)
+	g := graph.New()
+	idx := newRouteIndexer(t, g)
+
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+	require.NotZero(t, handlesRouteEdgeCount(g))
+}

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -294,6 +294,16 @@ type Indexer struct {
 	// Set during the shadow swap, cleared when idx.graph is restored.
 	contentSink graph.ContentSearcher
 
+	// contractStateSink mirrors bulkVectorSink for the contract-tier
+	// completion marker: the disk store captured at the shadow swap, so the
+	// inline contract pass records the marker on the backend even while
+	// idx.graph points at the in-memory shadow (which does not implement
+	// graph.ContractStateStore). Without it a shadow-backed full index would
+	// drain its contract nodes to disk while its marker died with the shadow,
+	// and every later query would call that healthy tier unbuilt.
+	// Set during the shadow swap, cleared when idx.graph is restored.
+	contractStateSink graph.ContractStateStore
+
 	// embedChunkOpts tunes the AST sub-chunking buildSearchIndex applies
 	// to large symbols before embedding. The zero value makes the
 	// chunker fall back to its package defaults.
@@ -2828,6 +2838,10 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 		// Same capture for the content index: the per-file content stream
 		// must reach content_fts on disk while idx.graph is the shadow.
 		idx.contentSink, _ = diskTarget.(graph.ContentSearcher)
+		// Same capture for the contract-tier marker: the inline contract
+		// pass commits while idx.graph is the shadow, and the marker must
+		// describe the disk store the drained contract nodes land in.
+		idx.contractStateSink, _ = diskTarget.(graph.ContractStateStore)
 		// The resolver was constructed at indexer.New with the disk
 		// Store. Redirect it at the shadow too, otherwise ResolveAll
 		// reads from the empty disk Store, finds no pending edges,
@@ -2842,6 +2856,7 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 				idx.graph = diskTarget
 				idx.bulkVectorSink = nil
 				idx.contentSink = nil
+				idx.contractStateSink = nil
 				if idx.resolver != nil {
 					idx.resolver.SetGraph(diskTarget)
 				}
@@ -2996,6 +3011,7 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 			idx.graph = diskTarget
 			idx.bulkVectorSink = nil
 			idx.contentSink = nil
+			idx.contractStateSink = nil
 			// Mirror of the SetGraph(inMemShadow) above: the resolver
 			// must follow the graph pointer back to the disk store, or
 			// every post-index per-file resolve (the watcher save path,
@@ -6693,10 +6709,54 @@ func (idx *Indexer) commitContracts(reg *contracts.Registry) {
 	if idx.repoPrefix != "" {
 		repo = idx.repoPrefix
 	}
+	idx.recordContractStateMarker(len(all))
 	idx.logger.Info("contracts extracted",
 		zap.String("repo", repo),
 		zap.Int("count", len(all)),
 		zap.Duration("commit_bulk_elapsed", bulkElapsed))
+}
+
+// recordContractStateMarker persists this repo's contract-tier completion
+// marker once a whole-repo contract pass has committed.
+//
+// commitContracts is the only writer of the whole-repo contract tier — the
+// deferred tail (runDeferredContracts), the inline full-index path, and the
+// full-walk extractContracts all funnel through it, while the incremental
+// per-file path (refreshContractsForFiles) deliberately does not. So a run
+// that reaches here committed the tier for the repo, and a repo with no
+// marker never did: its tier is unbuilt, and per-file mtime admission will
+// never re-extract it on its own. That asymmetry is exactly what the query
+// path needs to tell an unbuilt tier from a repo with no contracts.
+//
+// The marker records presence, not freshness: it is written even on a dirty
+// tree or a non-git root (indexed_sha stays empty), because "this repo's
+// contract pass has completed at least once against this store" is the fact
+// callers need, and refusing to write it on a dirty tree would report a false
+// unbuilt tier for every repo with uncommitted work. A backend that does not
+// persist contract state (the in-memory graph, which rebuilds the tier from
+// scratch on every start) is a no-op.
+func (idx *Indexer) recordContractStateMarker(count int) {
+	// contractStateSink is set only while idx.graph is the in-memory shadow
+	// of a bulk-load index; it is the disk store the shadow drains into, and
+	// the marker must describe that store rather than die with the shadow.
+	store := idx.contractStateSink
+	if store == nil {
+		capable, ok := idx.graph.(graph.ContractStateStore)
+		if !ok {
+			return
+		}
+		store = capable
+	}
+	if err := store.SetContractState(graph.ContractState{
+		RepoPrefix:    idx.repoPrefix,
+		IndexedSHA:    repoHead(idx.rootPath),
+		CompletedAt:   time.Now().Unix(),
+		ContractCount: count,
+	}); err != nil {
+		idx.logger.Warn("persist contract-tier marker failed",
+			zap.String("repo", idx.repoPrefix),
+			zap.Error(err))
+	}
 }
 
 // bulkCommit writes nodes + edges in one AddBatch call. The bulk

--- a/internal/mcp/contract_tier.go
+++ b/internal/mcp/contract_tier.go
@@ -1,0 +1,136 @@
+package mcp
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// The contract tier is committed all-at-once by the tail of a full index,
+// while re-index admission is per-file mtime. Those policies disagree: a run
+// whose tail never completes leaves the tier EMPTY, and every later warm
+// restart sees unchanged mtimes, re-extracts nothing, and keeps it empty for
+// the life of the index. The graph is otherwise complete, the daemon is past
+// warmup, so `analyze kind=routes` answers a clean `rows=0` that reads exactly
+// like "this repository has no routes".
+//
+// graph.ContractState is the durable record of a completed whole-repo contract
+// pass. The helpers here read it so a zero-row contract / route answer can say
+// which zero it is instead of silently failing open.
+
+// contractTierCaveatKey is the stable token callers can match on. It names the
+// condition, not the presentation, so a client can branch on it without
+// parsing prose.
+const contractTierCaveatKey = "contract_tier_unbuilt"
+
+const contractTierDetail = "no contract-tier completion marker is recorded for these repositories, so this empty result is not evidence that they declare no routes or contracts: a full index whose contract tail was lost commits nothing to the tier, and per-file mtime admission then re-extracts nothing on every later restart. (An index written before this marker existed also has no row.)"
+
+const contractTierRemedy = "rebuild the tier with a whole-repo re-parse — untrack_repository then track_repository, or restart the daemon with GORTEX_WARMUP_FULL_RETRACK=1. reindex_repository will NOT rebuild it: it admits files by mtime, and an unbuilt tier leaves every mtime unchanged."
+
+// contractTierScopeRepos returns the repo prefixes an empty contract / route
+// answer covered, narrowed the same way the answer itself was: an explicit
+// allow-set first, then the session workspace, then every tracked repo. The
+// single-repo daemon reports the one empty prefix it indexes under.
+func (s *Server) contractTierScopeRepos(ctx context.Context, allow map[string]bool) []string {
+	if len(allow) > 0 {
+		out := make([]string, 0, len(allow))
+		for p, ok := range allow {
+			if ok {
+				out = append(out, p)
+			}
+		}
+		sort.Strings(out)
+		return out
+	}
+	if s.multiIndexer == nil {
+		return []string{""}
+	}
+	if ws, _, bound := s.sessionScope(ctx); bound {
+		inWorkspace := s.multiIndexer.ReposInWorkspace(ws)
+		out := make([]string, 0, len(inWorkspace))
+		for p := range inWorkspace {
+			out = append(out, p)
+		}
+		sort.Strings(out)
+		return out
+	}
+	out := s.multiIndexer.RepoPrefixes()
+	sort.Strings(out)
+	return out
+}
+
+// contractTierUnbuiltRepos returns the in-scope repositories whose contract
+// tier carries no completion marker, sorted.
+//
+// Empty — no caveat — when the backend does not persist contract state. The
+// in-memory graph is the only such backend and it rebuilds its contract tier
+// from scratch on every start, so the lost-tail hole this reports cannot
+// survive there and claiming otherwise would be a false alarm.
+func (s *Server) contractTierUnbuiltRepos(ctx context.Context, allow map[string]bool) []string {
+	store, ok := s.graph.(graph.ContractStateStore)
+	if !ok {
+		return nil
+	}
+	var unbuilt []string
+	for _, prefix := range s.contractTierScopeRepos(ctx, allow) {
+		_, found, err := store.GetContractState(prefix)
+		if err != nil || found {
+			continue
+		}
+		unbuilt = append(unbuilt, prefix)
+	}
+	return unbuilt
+}
+
+// contractTierCaveat is the structured caveat attached to a zero-row contract
+// or route answer whose scope holds a repository with no completion marker.
+func contractTierCaveat(repos []string) map[string]any {
+	return map[string]any{
+		"caveat": contractTierCaveatKey,
+		"repos":  displayRepoPrefixes(repos),
+		"detail": contractTierDetail,
+		"remedy": contractTierRemedy,
+	}
+}
+
+// contractTierCaveatLine renders the caveat for the compact text encodings.
+func contractTierCaveatLine(repos []string) string {
+	return contractTierCaveatKey + ": " + strings.Join(displayRepoPrefixes(repos), ", ") +
+		" — " + contractTierDetail + " " + contractTierRemedy + "\n"
+}
+
+// stampContractTierCaveat records the caveat on a response whose body encoding
+// carries no room for it (GCX). Mirrors stampScopeNote: the token lands in the
+// result meta, where a client that dispatches on it can still see it.
+func stampContractTierCaveat(res *mcp.CallToolResult, repos []string) {
+	if res == nil || len(repos) == 0 {
+		return
+	}
+	note := contractTierCaveatLine(repos)
+	if res.Meta == nil {
+		res.Meta = mcp.NewMetaFromMap(map[string]any{contractTierCaveatKey: note})
+		return
+	}
+	if res.Meta.AdditionalFields == nil {
+		res.Meta.AdditionalFields = map[string]any{}
+	}
+	res.Meta.AdditionalFields[contractTierCaveatKey] = note
+}
+
+// displayRepoPrefixes renders the empty prefix (the single-repo daemon's sole
+// repo, and the shared-externals bucket in multi-repo mode) as a readable
+// placeholder instead of an empty string in the middle of a list.
+func displayRepoPrefixes(repos []string) []string {
+	out := make([]string, 0, len(repos))
+	for _, p := range repos {
+		if p == "" {
+			p = "(default)"
+		}
+		out = append(out, p)
+	}
+	return out
+}

--- a/internal/mcp/contract_tier_test.go
+++ b/internal/mcp/contract_tier_test.go
@@ -1,0 +1,165 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/query"
+)
+
+// contractStateGraph embeds *graph.Graph and adds the ContractStateStore
+// capability, standing in for the on-disk backend the daemon runs on.
+type contractStateGraph struct {
+	*graph.Graph
+
+	state map[string]graph.ContractState
+}
+
+func (c *contractStateGraph) SetContractState(st graph.ContractState) error {
+	c.state[st.RepoPrefix] = st
+	return nil
+}
+
+func (c *contractStateGraph) GetContractState(repoPrefix string) (graph.ContractState, bool, error) {
+	st, ok := c.state[repoPrefix]
+	if !ok {
+		return graph.ContractState{RepoPrefix: repoPrefix}, false, nil
+	}
+	return st, true, nil
+}
+
+// newContractStateGraph builds a store that persists contract state, so the
+// marker gate is live (setupTestServer's plain in-memory graph does not
+// implement the capability).
+func newContractStateGraph() *contractStateGraph {
+	return &contractStateGraph{Graph: graph.New(), state: map[string]graph.ContractState{}}
+}
+
+// dropContractMarkers simulates the reported failure: the index completed and
+// the graph is populated, but no whole-repo contract pass ever committed, so
+// nothing recorded a marker.
+func (c *contractStateGraph) dropContractMarkers() {
+	c.state = map[string]graph.ContractState{}
+}
+
+func newContractTierServer(t *testing.T, g graph.Store) *Server {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0o644))
+	cfg := config.Default()
+	idx := indexer.New(g, testRegistry(), cfg.Index, zap.NewNop())
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+	return NewServer(query.NewEngine(g), g, idx, nil, zap.NewNop(), nil)
+}
+
+func analyzeRoutesPayload(t *testing.T, srv *Server) map[string]any {
+	t.Helper()
+	req := mcplib.CallToolRequest{}
+	req.Params.Name = "analyze"
+	req.Params.Arguments = map[string]any{"kind": "routes"}
+	res, err := srv.handleAnalyze(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, res.IsError, "analyze routes errored: %+v", res.Content)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal([]byte(res.Content[0].(mcplib.TextContent).Text), &out))
+	return out
+}
+
+// The failure this guards: a repo whose contract tail was lost answers
+// `analyze kind=routes` with a clean zero that reads exactly like "this repo
+// registers no routes". With no completion marker on record, the zero must say
+// so. See https://github.com/zzet/gortex/issues/436.
+func TestAnalyzeRoutes_ZeroRowsFlagsUnbuiltContractTier(t *testing.T) {
+	g := newContractStateGraph()
+	srv := newContractTierServer(t, g)
+	g.dropContractMarkers()
+
+	out := analyzeRoutesPayload(t, srv)
+	require.Equal(t, float64(0), out["total"])
+
+	caveat, ok := out["contract_tier"].(map[string]any)
+	require.True(t, ok, "a zero-row route answer over an unmarked tier must carry a contract_tier caveat, got: %v", out)
+	require.Equal(t, contractTierCaveatKey, caveat["caveat"])
+	require.Contains(t, caveat, "remedy")
+	repos, _ := caveat["repos"].([]any)
+	require.Len(t, repos, 1)
+}
+
+// A recorded marker means the pass ran: the zero is then a true zero and must
+// NOT be qualified, or every repo without routes would carry a permanent
+// caveat.
+func TestAnalyzeRoutes_ZeroRowsWithMarkerIsATrueZero(t *testing.T) {
+	g := newContractStateGraph()
+	srv := newContractTierServer(t, g)
+	// The index above ran a whole-repo contract pass, which recorded the
+	// marker — exactly what a healthy repo looks like.
+	_, found, err := g.GetContractState("")
+	require.NoError(t, err)
+	require.True(t, found, "a completed index must record the contract-tier marker")
+
+	out := analyzeRoutesPayload(t, srv)
+	require.Equal(t, float64(0), out["total"])
+	require.NotContains(t, out, "contract_tier")
+}
+
+// Rows on the table are their own proof that the tier was built, so an answer
+// that returned routes is never qualified — not even on a store written before
+// the marker existed.
+func TestAnalyzeRoutes_RowsPresentSuppressCaveat(t *testing.T) {
+	g := newContractStateGraph()
+	srv := newContractTierServer(t, g)
+	g.dropContractMarkers()
+	addContractNode(srv.graph, "http::GET::/v1/users", "http", map[string]any{"method": "GET", "path": "/v1/users"})
+	addHandlesRouteEdge(srv.graph, "handlers/users.go::List", "http::GET::/v1/users", "handlers/users.go", 12)
+
+	out := analyzeRoutesPayload(t, srv)
+	require.Equal(t, float64(1), out["total"])
+	require.NotContains(t, out, "contract_tier")
+}
+
+// A backend that does not persist contract state (the in-memory graph, which
+// rebuilds its tier on every start) has no signal to report, and must not
+// invent one.
+func TestAnalyzeRoutes_NoCaveatWithoutContractStateCapability(t *testing.T) {
+	srv := newContractTierServer(t, graph.New())
+
+	out := analyzeRoutesPayload(t, srv)
+	require.Equal(t, float64(0), out["total"])
+	require.NotContains(t, out, "contract_tier")
+}
+
+// The compact encoding carries the same signal — an agent reading "no routes"
+// there is as misled as one reading rows=0 in JSON.
+func TestAnalyzeRoutes_CompactCarriesContractTierCaveat(t *testing.T) {
+	g := newContractStateGraph()
+	srv := newContractTierServer(t, g)
+	g.dropContractMarkers()
+
+	req := mcplib.CallToolRequest{}
+	req.Params.Name = "analyze"
+	req.Params.Arguments = map[string]any{"kind": "routes", "compact": true}
+	res, err := srv.handleAnalyze(context.Background(), req)
+	require.NoError(t, err)
+	text := res.Content[0].(mcplib.TextContent).Text
+	require.Contains(t, text, "no routes")
+	require.Contains(t, text, contractTierCaveatKey)
+}
+
+// The empty repo prefix — the single-repo daemon's sole repo — renders as a
+// readable placeholder rather than an empty string in the middle of a list.
+func TestContractTierCaveatRendersDefaultRepoPrefix(t *testing.T) {
+	line := contractTierCaveatLine([]string{""})
+	require.True(t, strings.HasPrefix(line, contractTierCaveatKey+": (default)"), "got %q", line)
+}

--- a/internal/mcp/tools_analyze_framework.go
+++ b/internal/mcp/tools_analyze_framework.go
@@ -93,12 +93,26 @@ func (s *Server) handleAnalyzeRoutes(ctx context.Context, req mcp.CallToolReques
 		}
 		return rows[i].Handler < rows[j].Handler
 	})
+	// A zero-row answer here is ambiguous: this repository may register no
+	// routes, or its contract tier may never have been built (a lost index
+	// tail commits nothing, and per-file mtime admission never re-extracts
+	// it). Say which one when the graph knows — see contract_tier.go. Only
+	// an empty answer is qualified; rows on the table are their own proof
+	// that the tier was built.
+	var unbuilt []string
+	if len(rows) == 0 {
+		unbuilt = s.contractTierUnbuiltRepos(ctx, repoAllowFromContext(ctx))
+	}
 	if s.isGCX(ctx, req) {
 		items := make([]routeItem, 0, len(rows))
 		for _, r := range rows {
 			items = append(items, routeItem(*r))
 		}
-		return s.gcxResponseWithBudget(req)(encodeAnalyze("routes", items))
+		res, err := s.gcxResponseWithBudget(req)(encodeAnalyze("routes", items))
+		if err == nil {
+			stampContractTierCaveat(res, unbuilt)
+		}
+		return res, err
 	}
 	if isCompact(req) {
 		var b strings.Builder
@@ -108,12 +122,19 @@ func (s *Server) handleAnalyzeRoutes(ctx context.Context, req mcp.CallToolReques
 		if len(rows) == 0 {
 			b.WriteString("no routes\n")
 		}
+		if len(unbuilt) > 0 {
+			b.WriteString(contractTierCaveatLine(unbuilt))
+		}
 		return mcp.NewToolResultText(b.String()), nil
 	}
-	return s.respondJSONOrTOON(ctx, req, map[string]any{
+	payload := map[string]any{
 		"routes": rows,
 		"total":  len(rows),
-	})
+	}
+	if len(unbuilt) > 0 {
+		payload["contract_tier"] = contractTierCaveat(unbuilt)
+	}
+	return s.respondJSONOrTOON(ctx, req, payload)
 }
 
 // handleAnalyzeRouteFrameworks lists the registered structural route passes

--- a/internal/mcp/tools_enhancements.go
+++ b/internal/mcp/tools_enhancements.go
@@ -3840,7 +3840,15 @@ func (s *Server) handleContracts(ctx context.Context, req mcp.CallToolRequest) (
 func (s *Server) handleGetContracts(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	registry := s.effectiveContractRegistry()
 	if registry == nil {
-		return mcp.NewToolResultError("no contract registry available — index a repository first"), nil
+		// A repository indexed with a lost contract tail reaches here too:
+		// nothing ever committed the tier, so no registry was retained. Name
+		// that possibility instead of sending the caller off to re-index a
+		// repository that is already indexed.
+		msg := "no contract registry available — index a repository first"
+		if unbuilt := s.contractTierUnbuiltRepos(ctx, nil); len(unbuilt) > 0 {
+			msg += "; " + contractTierCaveatLine(unbuilt)
+		}
+		return mcp.NewToolResultError(msg), nil
 	}
 
 	contractType := req.GetString("type", "")
@@ -3923,6 +3931,16 @@ func (s *Server) handleGetContracts(ctx context.Context, req mcp.CallToolRequest
 		contractsNextCursor = encodeCursor(contractsEnd)
 	}
 
+	// An in-scope total of zero is ambiguous: these repositories may declare
+	// no contracts, or their contract tier may never have been built (a lost
+	// index tail commits nothing, and per-file mtime admission never
+	// re-extracts it). Qualify the empty answer when the graph knows — see
+	// contract_tier.go.
+	var unbuiltTier []string
+	if contractsTotal == 0 {
+		unbuiltTier = s.contractTierUnbuiltRepos(ctx, contractRepoAllow)
+	}
+
 	if isCompact(req) {
 		var b strings.Builder
 		// Group by repo for readability in multi-repo mode.
@@ -3952,6 +3970,9 @@ func (s *Server) handleGetContracts(ctx context.Context, req mcp.CallToolRequest
 		if depsSkipped > 0 {
 			fmt.Fprintf(&b, "dependencies_skipped: %d (pass include_deps=true to include)\n", depsSkipped)
 		}
+		if len(unbuiltTier) > 0 {
+			b.WriteString(contractTierCaveatLine(unbuiltTier))
+		}
 		res := mcp.NewToolResultText(b.String())
 		if !allRepos {
 			res = decorateResultWithScope(res, resolved)
@@ -3969,6 +3990,9 @@ func (s *Server) handleGetContracts(ctx context.Context, req mcp.CallToolRequest
 			extra = append(extra, "dependencies_skipped", fmt.Sprintf("%d", depsSkipped))
 		}
 		res, err := s.gcxResponseWithBudget(req)(encodeContractsList(filtered, len(filtered), extra...))
+		if err == nil {
+			stampContractTierCaveat(res, unbuiltTier)
+		}
 		if !allRepos {
 			return withScopeResult(res, err, resolved)
 		}
@@ -4017,6 +4041,9 @@ func (s *Server) handleGetContracts(ctx context.Context, req mcp.CallToolRequest
 			"total": depsSkipped,
 			"hint":  "pass include_deps=true to include type=dependency and vendor-pathed contracts",
 		}
+	}
+	if len(unbuiltTier) > 0 {
+		payload["contract_tier"] = contractTierCaveat(unbuiltTier)
 	}
 	if !allRepos {
 		return s.respondScopedJSONOrTOON(ctx, req, payload, resolved)


### PR DESCRIPTION
Fixes #436.

## What was wrong

Contract nodes and `handles_route` edges are committed **all at once** by `commitContracts` — reachable only from a whole-repo pass (the deferred tail `runDeferredContracts`, the inline full-index branch, or the full-walk `extractContracts`). Re-index admission, by contrast, is **per-file mtime**.

Those two policies disagree, and the disagreement is silent and permanent. A full index whose contract tail never completes leaves the tier **empty — not degraded, empty** — while the node layer is complete. Every later warm restart then sees unchanged mtimes, re-extracts nothing, and the tier stays empty for the life of the index. `reindex_repository` cannot repair it either: it admits files by mtime, and an unbuilt tier changes no file.

Nothing on disk recorded that the pass was owed, so nothing could tell that state apart from a repository that genuinely declares no routes. `analyze kind=routes` answered a clean `rows=0`, past warmup, with no `warming` block — and the reporter read that zero as ground truth and wrote "gortex has no Go route pass" into their tooling notes, where it sat for weeks.

## What this changes

**Persist the fact.** A new per-repo `contract_state` row (`repo_prefix` PK, `indexed_sha`, `completed_at`, `contract_count`) records that a whole-repo contract pass committed against this store — modelled on `enrichment_state`, same `WITHOUT ROWID` shape, same purge/rekey integration. `graph.ContractStateStore` is an optional backend capability, so the in-memory graph (which rebuilds its tier on every start and cannot exhibit this failure) simply does not implement it.

The marker is written from `commitContracts`, the single choke point every whole-repo pass funnels through. The per-file incremental path (`refreshContractsForFiles`) deliberately does **not** write it — that path is exactly what rebuilt a handful of contracts on the reporter's broken daemon while the tier as a whole stayed unbuilt, and treating it as completion would paper over the hole.

The marker records **presence, not freshness**: it is written on a dirty tree and on a non-git root too (`indexed_sha` stays empty). "This repo's contract pass has completed at least once against this store" is the fact callers need; gating the write on a clean tree would report a false unbuilt tier for every repo with uncommitted work.

**Report it on the query path.** When `analyze kind=routes` or `contracts action=list` returns **zero rows** and a repository in scope has no marker, the answer carries a `contract_tier` caveat — stable token `contract_tier_unbuilt`, the repos it applies to, what the zero means, and the remedy. Rows on the table are their own proof the tier was built, so a non-empty answer is never qualified. All four encodings carry it (JSON/TOON payload field, compact line, GCX result meta), and the `no contract registry available` error path names the same possibility instead of telling the caller to index an already-indexed repository.

## Scope

This is deliberately **fail-closed, not self-healing** — the shape the reporter proposed and asked about before sending a PR. Re-running a lost tail on marker absence changes the indexing lifecycle (it would force a whole-repo re-parse on the next start for every repo tracked before this marker existed, including very large ones), so it belongs in its own change on top of this persistence layer. Today the remedy is a whole-repo re-parse: re-track the repo, or restart with `GORTEX_WARMUP_FULL_RETRACK=1`. The caveat says so.

An index written before this change also has no row, so its first empty route/contract answer carries the caveat until the repo is re-parsed. That is honest — the store genuinely cannot certify the tier was built — and it self-clears on the next whole-repo pass.

## Notes on the fix itself

The bulk-load index path parses into an in-memory shadow and drains it to disk in a deferred func, so the inline contract pass commits while `idx.graph` is the throwaway shadow. A first cut wrote the marker there and lost it on every shadow-backed index — a healthy tier draining to disk while its marker died, i.e. a permanent false caveat. `contractStateSink` captures the disk target at the shadow swap, mirroring the existing `bulkVectorSink` / `contentSink` pattern; `TestContractMarkerLandsOnDiskStoreBehindShadow` covers it and fails without the sink.

## Tests

- `internal/indexer/contract_state_marker_test.go` — a lost deferred tail leaves the tier empty **and** unmarked (the reported state); the completed tail, the inline pass, and a repo with zero contracts all record the marker; the marker survives the shadow→disk drain; a store without the capability is a no-op.
- `internal/graph/store_sqlite/store_contract_state_test.go` — round-trip, upsert-in-place, zero-count marker, per-repo isolation, survival across reopen with no schema-version drift, and `PurgeRepo` clearing it without touching siblings.
- `internal/mcp/contract_tier_test.go` — a zero-row route answer over an unmarked tier carries the caveat; a marked tier's zero does not; rows suppress it; a store without the capability invents no signal; compact carries it too.

`go build ./...`, `golangci-lint run` on the touched trees, and the `indexer` / `mcp` / `store_sqlite` suites are green. No schema-version bump: `contract_state` is created by the idempotent `CREATE TABLE IF NOT EXISTS` that runs on every `Open`, so existing stores pick it up with no rebuild.
