### PR TITLE
hooks: narrow the PreToolUse access policy to the surface its message describes

### DIFF
--- a/internal/hooks/hermes.go
+++ b/internal/hooks/hermes.go
@@ -180,11 +180,22 @@ func runHermesPreToolCall(data []byte, port int, mode Mode) {
 // key, which Hermes names `path` rather than Claude's `file_path`);
 // terminal reuses enrichBash, whose `command` key Hermes already
 // matches. Any other tool is a no-op.
+//
+// It reaches those enrichments directly rather than through enrich, so it
+// applies the same tracked-repo gate itself — a Hermes session in an unindexed
+// checkout has no more to redirect to than a Claude one.
 func hermesEnrich(input hermesPreToolInput, _ int) enrichResult {
 	switch input.ToolName {
 	case hermesReadFileTool:
-		return enrichRead(hermesNormalizeReadInput(input.ToolInput), input.CWD)
+		toolInput := hermesNormalizeReadInput(input.ToolInput)
+		if !hookCallTargetsTrackedRepo("Read", toolInput, input.CWD) {
+			return enrichResult{}
+		}
+		return enrichRead(toolInput, input.CWD)
 	case hermesTerminalTool:
+		if !hookCallTargetsTrackedRepo("Bash", input.ToolInput, input.CWD) {
+			return enrichResult{}
+		}
 		return enrichBash(input.ToolInput, input.CWD)
 	default:
 		return enrichResult{}

--- a/internal/hooks/pretool_enforcement_test.go
+++ b/internal/hooks/pretool_enforcement_test.go
@@ -112,16 +112,18 @@ func TestScopeTrackedViaDaemonUnavailable(t *testing.T) {
 	}
 }
 
-func TestEnrichGrepExplicitNonSourceFileStaysSoft(t *testing.T) {
+func TestEnrichGrepExplicitNonSourceFileStaysSilent(t *testing.T) {
 	stubTrackedScope(t, true)
-	stubProbe(t, nil, errDaemonUnreachable)
+	// A daemon that answers with hits is the case that used to hard-deny a
+	// grep of a README because the pattern existed somewhere in the graph.
+	stubProbe(t, []grepSymbolHit{{Name: "TODO", FilePath: "pkg/a.go", Line: 3}}, nil)
 
 	result := enrichGrep(map[string]any{
 		"pattern": "TODO",
 		"path":    "/repo/README.md",
 	}, 0, "/repo")
-	if result.deny || result.context == "" {
-		t.Fatalf("explicit non-source Grep must remain soft: %#v", result)
+	if result.deny || result.context != "" {
+		t.Fatalf("explicit non-source Grep must not fire at all: %#v", result)
 	}
 }
 

--- a/internal/hooks/pretooluse.go
+++ b/internal/hooks/pretooluse.go
@@ -429,6 +429,14 @@ func nudgeReason(guidance string) string {
 }
 
 func enrich(input HookInput, port int) enrichResult {
+	// A call that touches no tracked repo has no graph to redirect to, so the
+	// access policy has nothing true to say about it. Checked once here rather
+	// than per-enrichment so every host tool the policy covers is gated the
+	// same way, and so a Gortex MCP call — which is not repo-scoped — is not.
+	if !isGortexMCPToolName(input.ToolName) &&
+		!hookCallTargetsTrackedRepo(input.ToolName, input.ToolInput, input.CWD) {
+		return enrichResult{}
+	}
 	switch input.ToolName {
 	case "Read":
 		return enrichRead(input.ToolInput, input.CWD)
@@ -569,7 +577,13 @@ func enrichGrep(toolInput map[string]any, _ int, cwdArg ...string) enrichResult 
 	if pattern == "" {
 		return enrichResult{}
 	}
-	if hookSearchScopeIndexed(cwd, toolInput) {
+	switch hookSearchScope(cwd, toolInput) {
+	case searchScopeNonSource:
+		// The search is confined to docs or config. Neither the deny nor the
+		// "do not Grep indexed source" advisory is true of it, and the graph
+		// surface both point at has no answer for it either.
+		return enrichResult{}
+	case searchScopeIndexed:
 		return enrichResult{
 			deny:   true,
 			reason: formatTrackedSearchDeny("Grep", pattern),
@@ -578,30 +592,56 @@ func enrichGrep(toolInput map[string]any, _ int, cwdArg ...string) enrichResult 
 	return probeSymbolPattern("Grep", pattern, defaultGrepGuidance())
 }
 
-func hookSearchScopeIndexed(cwd string, toolInput map[string]any) bool {
+// searchScopeVerdict is what a Grep/Glob scope resolves to. The three states
+// are deliberately distinct: only searchScopeIndexed is proof the policy
+// applies, and only searchScopeNonSource is proof it does not. Unproven keeps
+// the historical posture — probe the pattern, fall back to soft guidance.
+type searchScopeVerdict int
+
+const (
+	searchScopeUnproven searchScopeVerdict = iota
+	searchScopeIndexed
+	searchScopeNonSource
+)
+
+// hookSearchScope classifies what a Grep/Glob call actually searches, from its
+// `path` scope plus (for Grep) the `type` / `glob` filters that narrow it.
+func hookSearchScope(cwd string, toolInput map[string]any) searchScopeVerdict {
+	if searchRestrictedToNonSource(toolInput) {
+		return searchScopeNonSource
+	}
+
 	scope, _ := toolInput["path"].(string)
 	scope = strings.TrimSpace(scope)
-	if scope != "" {
-		abs := scope
-		if !filepath.IsAbs(abs) && cwd != "" {
-			abs = filepath.Join(cwd, abs)
+	if scope != "" && scopeNamesFile(cwd, scope) {
+		if !looksLikeSourceFile(scope) {
+			return searchScopeNonSource
 		}
-		if info, err := os.Stat(abs); err == nil && !info.IsDir() {
-			if !looksLikeSourceFile(scope) {
-				return false
-			}
-			indexed, _ := queryFileIndexed(cwd, scope)
-			return indexed
+		if indexed, _ := queryFileIndexed(cwd, scope); indexed {
+			return searchScopeIndexed
 		}
-		if filepath.Ext(scope) != "" {
-			if !looksLikeSourceFile(scope) {
-				return false
-			}
-			indexed, _ := queryFileIndexed(cwd, scope)
-			return indexed
-		}
+		return searchScopeUnproven
 	}
-	return scopeTrackedFn(cwd, scope)
+
+	if scopeTrackedFn(cwd, scope) {
+		return searchScopeIndexed
+	}
+	return searchScopeUnproven
+}
+
+// scopeNamesFile reports whether a `path` scope names one file rather than a
+// directory to search under. An existing path answers directly; one that is
+// not on disk (a scope the agent typed from memory) is judged by whether it
+// carries an extension.
+func scopeNamesFile(cwd, scope string) bool {
+	abs := scope
+	if !filepath.IsAbs(abs) && cwd != "" {
+		abs = filepath.Join(cwd, abs)
+	}
+	if info, err := os.Stat(abs); err == nil {
+		return !info.IsDir()
+	}
+	return filepath.Ext(scope) != ""
 }
 
 func formatTrackedSearchDeny(tool, query string) string {
@@ -1209,7 +1249,12 @@ func enrichGlob(toolInput map[string]any, cwdArg ...string) enrichResult {
 		return enrichResult{}
 	}
 
-	if hookSearchScopeIndexed(cwd, toolInput) {
+	switch hookSearchScope(cwd, toolInput) {
+	case searchScopeNonSource:
+		// The enumeration is scoped to something that is not indexed source,
+		// so neither the deny nor the soft guidance below describes it.
+		return enrichResult{}
+	case searchScopeIndexed:
 		var b strings.Builder
 		fmt.Fprintf(&b, "[Gortex] BLOCKED: Glob `%s` targets indexed source. Use:\n", pattern)
 		b.WriteString("  - `explore(operation:\"outline\")` — repository/file outline\n")

--- a/internal/hooks/scope_gate.go
+++ b/internal/hooks/scope_gate.go
@@ -1,0 +1,164 @@
+package hooks
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// The PreToolUse matcher is deliberately broad so terminal state can stop any
+// tool, but the access policy underneath it speaks in one voice: "do not read
+// or search indexed source, use the graph instead". That advice only makes
+// sense where a graph exists. Two predicates below narrow the policy to the
+// surface its own message describes.
+//
+//   - hookCallTargetsTrackedRepo: a call in a checkout the daemon has never
+//     indexed has nothing to redirect to. Worse, the grep/find redirect probes
+//     search_symbols workspace-wide, so a pattern that happens to exist in
+//     some *other* tracked repo used to hard-deny a search of an untracked one.
+//   - searchRestrictedToNonSource: a search explicitly narrowed to docs or CI
+//     config is not a search of indexed source, and neither `search_symbols`
+//     nor `search_text` over the graph answers it.
+
+// hookCallTargetsTrackedRepo reports whether a host tool call plausibly
+// touches a repo the daemon tracks.
+//
+// It answers false only when the call can be *proven* to live outside every
+// tracked repo. An unknown tracked-repo list (daemon down, or its status call
+// timed out and came back empty), an unresolvable relative path with no cwd,
+// and a Gortex MCP call all return true, which leaves the historical posture
+// in place — this gate removes false fires, it does not add new silence where
+// nothing was established.
+func hookCallTargetsTrackedRepo(toolName string, toolInput map[string]any, cwd string) bool {
+	if len(hookTrackedReposFn()) == 0 {
+		return true
+	}
+	// An explicit path target overrides cwd: an agent working in one repo can
+	// legitimately name a file in another, and it is the file's repo — not the
+	// shell's — that decides whether the graph has an answer.
+	if target, named := hookScopeTargetPath(toolName, toolInput); named {
+		if abs, ok := hookAbsScopePath(target, cwd); ok {
+			_, tracked := trackedRepoForPath(abs)
+			return tracked
+		}
+	}
+	abs, ok := hookAbsScopePath(cwd, "")
+	if !ok {
+		return true
+	}
+	_, tracked := trackedRepoForPath(abs)
+	return tracked
+}
+
+// hookScopeTargetPath returns the single path a tool call names, when it names
+// one. Bash and Task carry no single target — their scope is the cwd they run
+// in — and a search with no `path` searches the cwd, so both fall through to
+// the caller's cwd check.
+func hookScopeTargetPath(toolName string, toolInput map[string]any) (string, bool) {
+	key := ""
+	switch toolName {
+	case "Read", "Edit", "Write":
+		key = "file_path"
+	case "Grep", "Glob":
+		key = "path"
+	default:
+		return "", false
+	}
+	value, _ := toolInput[key].(string)
+	value = strings.TrimSpace(value)
+	return value, value != ""
+}
+
+// hookAbsScopePath absolutises p against cwd. ok=false when there is nothing
+// to resolve — an empty path, or a relative path with no absolute cwd to
+// anchor it. Deliberately symlink-naive, matching repoRootForFile: a symlinked
+// worktree resolves to no repo, and the caller treats "no repo" as unproven
+// rather than as proof of being outside.
+func hookAbsScopePath(p, cwd string) (string, bool) {
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return "", false
+	}
+	if !filepath.IsAbs(p) {
+		cwd = strings.TrimSpace(cwd)
+		if !filepath.IsAbs(cwd) {
+			return "", false
+		}
+		p = filepath.Join(cwd, p)
+	}
+	return filepath.Clean(p), true
+}
+
+// nonSourceSearchTypes are the ripgrep type names a Grep can be narrowed to
+// that name no indexed source. Deliberately an allowlist of *non*-source
+// types rather than a check against the source list: an unrecognised type
+// stays unproven and keeps the historical posture, so a new language's type
+// name is never silently exempted from the policy.
+var nonSourceSearchTypes = map[string]bool{
+	"md": true, "markdown": true,
+	"yaml": true, "yml": true,
+	"json": true, "toml": true, "ini": true, "config": true,
+	"txt": true, "text": true, "log": true,
+	"xml": true, "csv": true, "tsv": true,
+	"lock": true, "license": true, "readme": true, "svg": true,
+}
+
+// searchRestrictedToNonSource reports whether a Grep's own filters confine it
+// to files the indexer does not treat as source. `type:"yaml"` and
+// `glob:"**/*.md"` are the two shapes agents use to search CI config and docs;
+// answering either with "use search_symbols" points at a graph that has
+// nothing to say.
+//
+// A brace list restricts only when *every* alternative is non-source, and a
+// glob with no extension at all (`internal/**`, `Makefile`) restricts nothing.
+func searchRestrictedToNonSource(toolInput map[string]any) bool {
+	fileType, _ := toolInput["type"].(string)
+	if nonSourceSearchTypes[strings.ToLower(strings.TrimSpace(fileType))] {
+		return true
+	}
+
+	glob, _ := toolInput["glob"].(string)
+	glob = strings.TrimSpace(glob)
+	if glob == "" {
+		return false
+	}
+	alternatives := globAlternatives(glob)
+	if len(alternatives) == 0 {
+		return false
+	}
+	for _, alternative := range alternatives {
+		if filepath.Ext(alternative) == "" || looksLikeSourceFile(alternative) {
+			return false
+		}
+	}
+	return true
+}
+
+// globAlternatives expands a single brace list into one glob per alternative:
+// `**/*.{md,txt}` becomes `**/*.md` and `**/*.txt`. Anything more elaborate
+// (nested or multiple brace groups) returns the pattern unexpanded, which the
+// caller then judges as a whole — an unexpanded `{a,b}` has no extension and
+// so restricts nothing.
+func globAlternatives(glob string) []string {
+	open := strings.Index(glob, "{")
+	if open < 0 {
+		return []string{glob}
+	}
+	closed := strings.Index(glob[open:], "}")
+	if closed < 0 {
+		return []string{glob}
+	}
+	closed += open
+	prefix, suffix := glob[:open], glob[closed+1:]
+	if strings.ContainsAny(prefix+suffix, "{}") {
+		return []string{glob}
+	}
+	var out []string
+	for _, alternative := range strings.Split(glob[open+1:closed], ",") {
+		alternative = strings.TrimSpace(alternative)
+		if alternative == "" {
+			continue
+		}
+		out = append(out, prefix+alternative+suffix)
+	}
+	return out
+}

--- a/internal/hooks/scope_gate_test.go
+++ b/internal/hooks/scope_gate_test.go
@@ -1,0 +1,256 @@
+package hooks
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/daemon"
+)
+
+// stubTrackedRepos installs a tracked-repo list for the scope gate. TestMain
+// defaults the list to empty, which the gate reads as "nothing proven" — so a
+// test that wants the gate to actually judge a path has to say what is tracked.
+func stubTrackedRepos(t *testing.T, paths ...string) {
+	t.Helper()
+	repos := make([]daemon.TrackedRepoStatus, 0, len(paths))
+	for _, p := range paths {
+		repos = append(repos, daemon.TrackedRepoStatus{Path: p})
+	}
+	prev := hookTrackedReposFn
+	hookTrackedReposFn = func() []daemon.TrackedRepoStatus { return repos }
+	t.Cleanup(func() { hookTrackedReposFn = prev })
+}
+
+// A checkout the daemon has never indexed has no graph to redirect to. The
+// grep/find redirect probes search_symbols workspace-wide, so before the gate
+// a pattern that existed in some *other* tracked repo hard-denied a search of
+// an untracked one.
+func TestUntrackedCwdSilencesEveryHostToolPolicy(t *testing.T) {
+	stubTrackedRepos(t, "/tracked")
+	stubTrackedScope(t, false)
+	stubProbe(t, []grepSymbolHit{{Name: "Handler", FilePath: "pkg/a.go", Line: 1}}, nil)
+	stubIndexedFile(t, true, 9)
+
+	cases := []struct {
+		name  string
+		input HookInput
+	}{
+		{"Grep", HookInput{ToolName: "Grep", ToolInput: map[string]any{"pattern": "Handler"}}},
+		{"Glob", HookInput{ToolName: "Glob", ToolInput: map[string]any{"pattern": "**/*.go"}}},
+		{"Read", HookInput{ToolName: "Read", ToolInput: map[string]any{"file_path": "main.go"}}},
+		{"Edit", HookInput{ToolName: "Edit", ToolInput: map[string]any{"file_path": "main.go"}}},
+		{"Write", HookInput{ToolName: "Write", ToolInput: map[string]any{"file_path": "main.go"}}},
+		{"BashGrep", HookInput{ToolName: "Bash", ToolInput: map[string]any{"command": `grep -rn "Handler" .`}}},
+		{"BashCat", HookInput{ToolName: "Bash", ToolInput: map[string]any{"command": "cat internal/x.go"}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.input.CWD = "/untracked"
+			result := enrich(tc.input, 0)
+			if result.deny || result.context != "" {
+				t.Fatalf("policy fired in an untracked checkout: %#v", result)
+			}
+		})
+	}
+}
+
+// The gate judges the target, not the shell: an agent working in an untracked
+// checkout can still name a file in a tracked one, and that file's repo is the
+// one with an answer.
+func TestTrackedTargetOutsideCwdStillEnforced(t *testing.T) {
+	stubTrackedRepos(t, "/tracked")
+	stubIndexedFile(t, true, 9)
+
+	result := enrich(HookInput{
+		ToolName:  "Read",
+		ToolInput: map[string]any{"file_path": "/tracked/pkg/a.go"},
+		CWD:       "/untracked",
+	}, 0)
+	if !result.deny {
+		t.Fatalf("Read of an indexed file in a tracked repo must still be denied: %#v", result)
+	}
+}
+
+// The mirror of the case above: a cwd inside a tracked repo does not license a
+// redirect for a file that lives outside every tracked repo.
+func TestUntrackedTargetFromTrackedCwdIsSilent(t *testing.T) {
+	stubTrackedRepos(t, "/tracked")
+	stubIndexedFile(t, true, 9)
+
+	result := enrich(HookInput{
+		ToolName:  "Read",
+		ToolInput: map[string]any{"file_path": "/elsewhere/pkg/a.go"},
+		CWD:       "/tracked",
+	}, 0)
+	if result.deny || result.context != "" {
+		t.Fatalf("policy fired on a target outside every tracked repo: %#v", result)
+	}
+}
+
+func TestTrackedCwdKeepsEnforcement(t *testing.T) {
+	stubTrackedRepos(t, "/tracked")
+	stubTrackedScope(t, true)
+
+	result := enrich(HookInput{
+		ToolName:  "Grep",
+		ToolInput: map[string]any{"pattern": "Handler"},
+		CWD:       "/tracked/internal",
+	}, 0)
+	if !result.deny {
+		t.Fatalf("tracked cwd must keep the indexed-search deny: %#v", result)
+	}
+}
+
+// An empty tracked-repo list is the daemon-down / status-timed-out shape. It
+// proves nothing, so the gate must not turn it into blanket silence.
+func TestUnknownTrackedRepoListLeavesPostureUnchanged(t *testing.T) {
+	stubTrackedRepos(t) // no repos → nothing proven
+	stubTrackedScope(t, true)
+
+	result := enrich(HookInput{
+		ToolName:  "Grep",
+		ToolInput: map[string]any{"pattern": "Handler"},
+		CWD:       "/anywhere",
+	}, 0)
+	if !result.deny {
+		t.Fatalf("an unknown tracked-repo list must not disable the policy: %#v", result)
+	}
+}
+
+func TestGortexMCPCallsAreNotRepoGated(t *testing.T) {
+	stubTrackedRepos(t, "/tracked")
+
+	result := enrich(HookInput{
+		ToolName:  gortexReadFileTool,
+		ToolInput: map[string]any{"path": "pkg/a.go"},
+		CWD:       "/untracked",
+	}, 0)
+	if result.context == "" && !result.deny {
+		t.Fatal("a Gortex MCP read is not repo-scoped and must still be enriched")
+	}
+}
+
+// "indexed source" is what the policy's own message claims to protect. Docs
+// and CI config are neither, and the graph surface the redirect names has no
+// answer for them.
+func TestGrepRestrictedToNonSourceStaysSilent(t *testing.T) {
+	stubTrackedScope(t, true)
+	stubProbe(t, []grepSymbolHit{{Name: "Handler", FilePath: "pkg/a.go", Line: 1}}, nil)
+
+	for _, toolInput := range []map[string]any{
+		{"pattern": "Handler", "glob": "*.md"},
+		{"pattern": "Handler", "glob": "**/*.{md,txt}"},
+		{"pattern": "Handler", "glob": "docs/**/*.yml"},
+		{"pattern": "Handler", "type": "yaml"},
+		{"pattern": "Handler", "type": "JSON"},
+		{"pattern": "Handler", "path": "README.md"},
+		{"pattern": "Handler", "path": ".github/workflows/ci.yml"},
+	} {
+		result := enrichGrep(toolInput, 0, "/repo")
+		if result.deny || result.context != "" {
+			t.Fatalf("non-source Grep %v fired: %#v", toolInput, result)
+		}
+	}
+}
+
+func TestGrepWithSourceFilterStillEnforced(t *testing.T) {
+	stubTrackedScope(t, true)
+
+	for _, toolInput := range []map[string]any{
+		{"pattern": "Handler", "glob": "*.go"},
+		{"pattern": "Handler", "glob": "**/*.{ts,tsx}"},
+		{"pattern": "Handler", "glob": "**/*.{md,go}"}, // one source alternative is enough
+		{"pattern": "Handler", "glob": "internal/**"},  // no extension restricts nothing
+		{"pattern": "Handler", "type": "go"},
+		{"pattern": "Handler", "type": "not-a-known-type"},
+		{"pattern": "Handler"},
+	} {
+		result := enrichGrep(toolInput, 0, "/repo")
+		if !result.deny {
+			t.Fatalf("source-scoped Grep %v was not denied: %#v", toolInput, result)
+		}
+	}
+}
+
+func TestGlobNonSourceScopeStaysSilent(t *testing.T) {
+	stubTrackedScope(t, true)
+
+	result := enrichGlob(map[string]any{
+		"pattern": "**/*.go",
+		"path":    "docs/README.md",
+	}, "/repo")
+	if result.deny || result.context != "" {
+		t.Fatalf("Glob scoped to a non-source file fired: %#v", result)
+	}
+}
+
+// The policy answers codebase-search shapes. A shell command that names no
+// search verb cannot be satisfied by a graph query, so it must pass through
+// untouched even in a fully tracked, fully indexed repo.
+func TestBashWithoutSearchVerbNeverFires(t *testing.T) {
+	stubTrackedRepos(t, "/tracked")
+	stubIndexedFile(t, true, 12)
+	stubProbe(t, []grepSymbolHit{{Name: "version", FilePath: "pkg/a.go", Line: 1}}, nil)
+
+	for _, command := range []string{
+		`docker version --format '{{.Server.Version}}'`,
+		`curl -sL https://api.github.com/repos/zzet/gortex/releases`,
+		`gh api repos/zzet/gortex/pulls/759/comments`,
+		`ls services/domain-core/scripts/ci/ ; sed -n '107,180p' .github/workflows/domain-core-db.yml`,
+		`npm run build`,
+		`go test ./internal/hooks/`,
+		`git status --short`,
+		`kubectl get pods -n prod`,
+	} {
+		result := enrich(HookInput{
+			ToolName:  "Bash",
+			ToolInput: map[string]any{"command": command},
+			CWD:       "/tracked",
+		}, 0)
+		if result.deny || result.context != "" {
+			t.Fatalf("Bash %q has no search verb but fired: %#v", command, result)
+		}
+	}
+}
+
+func TestGlobAlternatives(t *testing.T) {
+	cases := map[string][]string{
+		"*.md":            {"*.md"},
+		"**/*.{md,txt}":   {"**/*.md", "**/*.txt"},
+		"src/*.{ts, tsx}": {"src/*.ts", "src/*.tsx"},
+		"internal/**":     {"internal/**"},
+		"{a,b}/{c,d}.go":  {"{a,b}/{c,d}.go"}, // multiple groups stay unexpanded
+	}
+	for glob, want := range cases {
+		got := globAlternatives(glob)
+		if len(got) != len(want) {
+			t.Fatalf("globAlternatives(%q) = %v, want %v", glob, got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("globAlternatives(%q) = %v, want %v", glob, got, want)
+			}
+		}
+	}
+}
+
+func TestHookAbsScopePathRequiresAnAnchor(t *testing.T) {
+	if _, ok := hookAbsScopePath("pkg/a.go", ""); ok {
+		t.Fatal("a relative path with no cwd cannot be resolved")
+	}
+	if _, ok := hookAbsScopePath("pkg/a.go", "relative/cwd"); ok {
+		t.Fatal("a relative cwd cannot anchor a relative path")
+	}
+	abs, ok := hookAbsScopePath("pkg/a.go", "/repo")
+	if !ok || abs != "/repo/pkg/a.go" {
+		t.Fatalf("hookAbsScopePath = %q, %v", abs, ok)
+	}
+}
+
+// An unresolvable path proves nothing about where the call lives, so it must
+// leave the historical posture in place rather than silence the policy.
+func TestUnresolvablePathLeavesPostureUnchanged(t *testing.T) {
+	stubTrackedRepos(t, "/tracked")
+	if !hookCallTargetsTrackedRepo("Read", map[string]any{"file_path": "pkg/a.go"}, "") {
+		t.Fatal("an unanchored relative path must not be treated as untracked")
+	}
+}


### PR DESCRIPTION
Fixes #439.

## What I could reproduce

I ran the issue's three claims against `main` before changing anything. Two reproduce, one does not.

**1. Untracked repos — reproduces, and harder than reported.** There was no tracked-repo gate anywhere in the access policy. The grep/find redirect probes `search_symbols` *workspace-wide*, so a pattern that happens to exist in some other tracked repo produced a **hard deny** for a search of a checkout the daemon has never indexed:

```
Grep "Handler" in /untracked  → deny: BLOCKED: "Handler" matches 1 indexed symbol(s) … pkg/a.go:1
Bash grep -rn "Handler" .     → deny: (same)
Read main.go                  → advisory: "Use `explore` first, then `read` for indexed source"
Glob **/*.go                  → advisory: "PREFER graph tools over Glob"
```

The block's own evidence came from a different tree, and the tool it redirected to had nothing to say about the file in front of the agent.

**2. Non-source targets — reproduces for `Grep`.** `Read` already skipped non-source paths (so the 24 `.md`/`.yml`/`.json` reads were not fired by this policy), but `Grep` inspected only `path` — never the `type` / `glob` filters agents use to search docs and CI config — and a `path` naming a non-source file fell through to the workspace-wide symbol probe instead of stopping:

```
Grep "Handler" glob:"*.md"      → deny: BLOCKED … targets indexed source
Grep "Handler" type:"yaml"      → deny: BLOCKED … targets indexed source
Grep "Handler" path:"README.md" → deny: BLOCKED … matches 1 indexed symbol(s)
```

**3. Shell commands with no search verb — does not reproduce on `main`.** All four commands quoted in the issue, plus `npm run build`, `go test`, `git status`, `kubectl get pods`, pass through the access policy silently today — the Bash classifier only flags primary `grep`/`rg`/`find -name`/`cat`-source shapes and recognised write shapes. Your build (`447e66c`) is an ancestor of `main` with the whole localization-terminal cluster landed since, so the likeliest source of those particular fires is the **localization terminal marker** — a separate mechanism that denies *every* tool once a turn's localization reaches `answer_ready`, independent of cwd, file type, or command. That is intentional today, but if it is what you were hitting, it deserves its own issue and I'd rather not fold it in here silently. Either way I've added regression tests so this predicate can't drift into claiming those commands.

## The fix

Two predicates, both in the new `internal/hooks/scope_gate.go`.

**`hookCallTargetsTrackedRepo`** runs once at the top of `enrich`, covering every host tool the policy touches. It judges the call's explicit path target when it names one and the cwd otherwise, so:

- an agent in an untracked tree is still redirected for a file it names inside a tracked one;
- a tracked cwd does not license a redirect for a file outside every tracked repo;
- Gortex's own MCP calls are not repo-scoped and are not gated.

It answers "outside" only where that is *proven*. An unknown tracked-repo list (daemon down, or its status call timed out and came back empty), an unresolvable relative path with no absolute cwd, and a Gortex MCP call all leave the posture exactly as it was — this removes false fires, it does not introduce new silence where nothing was established.

**`hookSearchScope`** replaces the boolean `hookSearchScopeIndexed` with a three-state verdict, so "provably not source" is a distinct answer from "unproven" and stops the fall-through into the symbol probe. It reads `type` and `glob` in addition to `path`. A brace list (`**/*.{md,txt}`) restricts only when *every* alternative is non-source; a glob with no extension (`internal/**`) restricts nothing; an unrecognised `type` stays unproven, so a new language's type name is never silently exempted from the policy.

The Hermes bridge reaches `enrichRead`/`enrichBash` directly rather than through `enrich`, so it applies the same gate itself.

## Behavior change to flag

`TestEnrichGrepExplicitNonSourceFileStaysSoft` asserted that grepping an explicit non-source file kept the soft `"Do not Grep indexed source"` advisory. Per expectation (2) in the issue an advisory is still a fire, and the statement is false of a README — so that case is now fully silent, and the test is renamed and inverted. It was previously passing only because it stubbed the daemon as unreachable; with a daemon that answers, the same call hard-denied.

## Verification

- `go test ./...` — 141 packages, all green
- `go test -race ./internal/hooks/ ./internal/agents/...` — green
- `go vet`, `gofmt -l`, `golangci-lint run internal/hooks/...` — 0 issues
- New tests confirmed non-vacuous: reverting the wiring while keeping the tests fails every behavioral case (`TestUntrackedCwdSilencesEveryHostToolPolicy`, `TestUntrackedTargetFromTrackedCwdIsSilent`, `TestGrepRestrictedToNonSourceStaysSilent`, `TestGlobNonSourceScopeStaysSilent`, and the renamed Grep case)

## Note on the compounding case

The issue also flags redirects toward `analyze(kind:"contracts")` when the contract layer is empty (#436). That is a different layer — the guidance text, not this predicate — and I've left it for #436 rather than widening this change.
