### PR TITLE
Resolve GDScript calls by receiver instead of method name

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -255,7 +255,7 @@ What is **not** covered:
 | ActionScript | `.as` | `package`, classes, interfaces, `function`, `import X.Y.*;` |
 | Dart | `.dart` | Full (see core matrix) |
 | Swift | `.swift` | Full (see core matrix) |
-| GDScript | `.gd` | `func`, `class`, signals |
+| GDScript | `.gd`, `project.godot` | `func`, `class`, signals; receiver-typed calls — a script's funcs are methods of its `class_name`, and `Notify.event()` / typed locals / params / `self` bind by receiver, so a project-global class resolves across directories. `[autoload]` singletons in `project.godot` bind to their declared script. |
 | Verse (UEFN) | `.verse` | `class` / `struct` / `enum` / `interface`, functions with specifier blocks, `using { /Path }` |
 | Nix | `.nix` | Attribute sets, functions, `import` / `<nixpkgs>` |
 | AL (Business Central) | `.al` | Tables, pages, codeunits, procedures |

--- a/internal/indexer/gdscript_receiver_e2e_test.go
+++ b/internal/indexer/gdscript_receiver_e2e_test.go
@@ -1,0 +1,154 @@
+package indexer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+// A GDScript call's receiver decides its target. This indexes a Godot
+// project shaped like the reported one — a `class_name` global called
+// across directories, a same-named method sitting next door to the
+// caller, and an autoload singleton — and asserts the whole pipeline
+// binds each call to the definition its receiver names.
+//
+// Every case here failed before receivers were extracted: the call
+// degraded to a bare name, so the resolver's locality fallback answered
+// `Notify.event()` with the unrelated `BannerPath.event` in the
+// caller's own directory, while the cross-directory calls were reverted
+// by the cross-package guard for want of an import edge GDScript has no
+// syntax to express.
+func gdIndexProject(t *testing.T) *graph.Graph {
+	t.Helper()
+	dir := t.TempDir()
+	files := map[string]string{
+		"project.godot": `config_version=5
+
+[application]
+
+config/name="Latticefall"
+
+[autoload]
+
+Game="*res://src/core/Game.gd"
+`,
+		// The real target: a global class in a directory of its own.
+		"src/systems/Notify.gd": `class_name Notify
+extends Node
+
+func event(msg: String) -> void:
+    print(msg)
+`,
+		// A same-named method next door to the caller — the phantom.
+		"src/ui/BannerPath.gd": `class_name BannerPath
+extends Node2D
+
+func event(kind: int) -> void:
+    pass
+`,
+		"src/ui/Main.gd": `class_name Main
+extends Control
+
+func _on_night_rest_toggle() -> void:
+    Notify.event("ui_siege.05")
+`,
+		"src/data/Techs.gd": `class_name Techs
+extends RefCounted
+
+func get_tech(id: String):
+    return id
+`,
+		// A cross-directory caller with no preload and no import — the
+		// language has no syntax for either.
+		"src/systems/Research.gd": `class_name ResearchSystem
+extends Node
+
+func run() -> void:
+    Techs.get_tech("smithing")
+`,
+		// An autoload target: reachable project-wide as `Game` purely
+		// because project.godot says so. No class_name.
+		"src/core/Game.gd": `extends Node
+
+func set_speed(v: float) -> void:
+    pass
+`,
+		// In a directory of its own, so the call to the autoload cannot
+		// ride same-package locality to its target.
+		"src/boot/Setup.gd": `class_name Setup
+extends Node
+
+func boot() -> void:
+    Game.set_speed(1.0)
+`,
+	}
+	for name, src := range files {
+		path := filepath.Join(dir, filepath.FromSlash(name))
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(src), 0o644))
+	}
+
+	g := graph.New()
+	reg := parser.NewRegistry()
+	languages.RegisterAll(reg)
+	idx := New(g, reg, config.Default().Index, zap.NewNop())
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+	idx.ResolveAll()
+	return g
+}
+
+// gdCallTargets returns the resolved call targets of a caller symbol.
+func gdCallTargets(g *graph.Graph, from string) []string {
+	var out []string
+	for _, e := range g.GetOutEdges(from) {
+		if e.Kind == graph.EdgeCalls && !graph.IsUnresolvedTarget(e.To) {
+			out = append(out, e.To)
+		}
+	}
+	return out
+}
+
+func TestGDScriptReceiver_EndToEnd(t *testing.T) {
+	g := gdIndexProject(t)
+
+	t.Run("receiver picks the global class over the same-named neighbour", func(t *testing.T) {
+		targets := gdCallTargets(g, "src/ui/Main.gd::_on_night_rest_toggle")
+		assert.Contains(t, targets, "src/systems/Notify.gd::event",
+			"Notify.event() must bind to Notify")
+		assert.NotContains(t, targets, "src/ui/BannerPath.gd::event",
+			"the same-named method in the caller's own directory is a phantom")
+	})
+
+	t.Run("a class_name global resolves across directories", func(t *testing.T) {
+		assert.Contains(t, gdCallTargets(g, "src/systems/Research.gd::run"),
+			"src/data/Techs.gd::get_tech",
+			"class_name is project-global; no import exists to corroborate it")
+	})
+
+	t.Run("an autoload singleton resolves to its declared script", func(t *testing.T) {
+		assert.Contains(t, gdCallTargets(g, "src/boot/Setup.gd::boot"),
+			"src/core/Game.gd::set_speed",
+			"project.godot is the only place the name Game names this script")
+	})
+
+	t.Run("callers see every call site", func(t *testing.T) {
+		var callers []string
+		for _, e := range g.GetInEdges("src/data/Techs.gd::get_tech") {
+			if e.Kind == graph.EdgeCalls {
+				callers = append(callers, e.From)
+			}
+		}
+		assert.Contains(t, callers, "src/systems/Research.gd::run",
+			"blast-radius analysis is only as honest as the caller list")
+	})
+}

--- a/internal/parser/languages/gdscript.go
+++ b/internal/parser/languages/gdscript.go
@@ -13,17 +13,48 @@ import (
 // `extends`, `signal`, `var`, `const`, `enum`, inner `class`, and
 // `preload(...)` / `load(...)` imports. Indentation defines scope, so
 // `findBlockEnd` gives a reasonable function range.
+//
+// Call sites carry their receiver. A `.gd` file IS a class, and
+// `class_name X` registers X as a PROJECT-GLOBAL name — no import
+// statement exists in the language, so nothing in the graph's import
+// closure can corroborate a cross-directory call. Emitting a call as a
+// bare `unresolved::event` therefore hands the resolver a name with no
+// evidence attached, and its locality fallback answers with whatever
+// same-named method sits nearest the caller: `Notify.event()` in
+// src/ui/ bound to an unrelated `event` in src/ui/, while the real
+// `Notify.event` in src/systems/ was reverted by the cross-package
+// guard for want of an import edge GDScript never emits.
+//
+// So: a call with a receiver is emitted in the member-call shape
+// (`unresolved::*.event`) with Meta["receiver_type"] naming the
+// receiver's type, and the funcs of a `class_name` script are emitted
+// as KindMethod carrying Meta["receiver"] = that class name. Those are
+// the two halves the resolver's exact-receiver passes match on, and
+// together they bind the call structurally — at the ast_resolved tier,
+// which the cross-package guard does not police — regardless of which
+// directory the definition lives in.
 var (
 	gdFuncRe      = regexp.MustCompile(`(?m)^[ \t]*(?:static\s+)?func\s+(\w+)\s*\(`)
 	gdClassNameRe = regexp.MustCompile(`(?m)^\s*class_name\s+(\w+)`)
 	gdInnerClass  = regexp.MustCompile(`(?m)^[ \t]*class\s+(\w+)`)
 	gdExtendsRe   = regexp.MustCompile(`(?m)^\s*extends\s+([\w.]+)`)
-	gdVarRe       = regexp.MustCompile(`(?m)^[ \t]*(?:@\w+\s+)?(?:static\s+)?var\s+(\w+)`)
+	gdVarRe       = regexp.MustCompile(`(?m)^[ \t]*(?:@\w+(?:\([^)]*\))?\s+)*(?:static\s+)?var\s+(\w+)`)
 	gdConstRe     = regexp.MustCompile(`(?m)^[ \t]*const\s+(\w+)`)
 	gdEnumRe      = regexp.MustCompile(`(?m)^[ \t]*enum\s+(\w+)`)
 	gdSignalRe    = regexp.MustCompile(`(?m)^[ \t]*signal\s+(\w+)`)
 	gdPreloadRe   = regexp.MustCompile(`\b(?:preload|load)\s*\(\s*["']([^"']+)["']\s*\)`)
-	gdCallRe      = regexp.MustCompile(`\b([A-Za-z_]\w*)\s*\(`)
+
+	// gdCallRe captures an optional dotted receiver chain ahead of the
+	// callee. `Notify.event(` yields ("Notify", "event"); `a.b.c(`
+	// yields ("a.b", "c") — the last segment is the receiver
+	// expression; a bare `hello(` yields ("", "hello").
+	gdCallRe = regexp.MustCompile(`(?:([A-Za-z_][\w.]*)\s*\.\s*)?\b([A-Za-z_]\w*)\s*\(`)
+
+	// Declared-type sources for the receiver type environment.
+	gdTypedVarRe = regexp.MustCompile(`(?m)^[ \t]*(?:@\w+(?:\([^)]*\))?\s+)*(?:static\s+)?var\s+(\w+)\s*:\s*([A-Za-z_]\w*)`)
+	gdNewVarRe   = regexp.MustCompile(`(?m)^[ \t]*(?:@\w+(?:\([^)]*\))?\s+)*(?:static\s+)?var\s+(\w+)\s*:?=\s*([A-Za-z_]\w*)\s*\.\s*new\s*\(`)
+	gdFuncSigRe  = regexp.MustCompile(`(?m)^[ \t]*(?:static\s+)?func\s+\w+\s*\(([^)]*)\)`)
+	gdParamRe    = regexp.MustCompile(`(\w+)\s*:\s*([A-Za-z_]\w*)`)
 )
 
 // GDScriptExtractor extracts Godot GDScript source using regex.
@@ -33,6 +64,15 @@ func NewGDScriptExtractor() *GDScriptExtractor { return &GDScriptExtractor{} }
 
 func (e *GDScriptExtractor) Language() string     { return "gdscript" }
 func (e *GDScriptExtractor) Extensions() []string { return []string{".gd"} }
+
+// gdOwner is a class body — an inner `class` — that owns the funcs
+// declared inside its line span. The file-level `class_name` class owns
+// everything outside any inner-class span.
+type gdOwner struct {
+	name  string
+	start int
+	end   int
+}
 
 func (e *GDScriptExtractor) Extract(filePath string, src []byte) (*parser.ExtractionResult, error) {
 	lines := strings.Split(string(src), "\n")
@@ -67,27 +107,51 @@ func (e *GDScriptExtractor) Extract(filePath string, src []byte) (*parser.Extrac
 		})
 	}
 
+	// The script's own global class name, if it declares one. Godot
+	// allows at most one `class_name` per script.
+	selfClass := ""
 	for _, m := range gdClassNameRe.FindAllSubmatchIndex(src, -1) {
 		name := string(src[m[2]:m[3]])
 		line := lineAt(src, m[0])
 		add(name, graph.KindType, line, line, map[string]any{"gd_kind": "class_name"})
+		if selfClass == "" {
+			selfClass = name
+		}
 	}
+
+	var owners []gdOwner
 	for _, m := range gdInnerClass.FindAllSubmatchIndex(src, -1) {
 		name := string(src[m[2]:m[3]])
 		line := lineAt(src, m[0])
 		end := findIndentedBlockEnd(lines, line)
 		add(name, graph.KindType, line, end, map[string]any{"gd_kind": "inner_class"})
+		owners = append(owners, gdOwner{name: name, start: line, end: end})
 	}
+	ownerAt := func(line int) string {
+		for _, o := range owners {
+			if line >= o.start && line <= o.end {
+				return o.name
+			}
+		}
+		return selfClass
+	}
+
+	// Func declarations. A func owned by a named class is a method
+	// carrying Meta["receiver"] — what the resolver's exact
+	// receiver-type passes match a call's receiver_type against. A func
+	// in a script with no `class_name` and no enclosing inner class has
+	// no nameable owner, so it stays a plain function.
+	declOffsets := make(map[int]bool)
 	for _, m := range gdFuncRe.FindAllSubmatchIndex(src, -1) {
 		name := string(src[m[2]:m[3]])
 		line := lineAt(src, m[0])
 		end := findIndentedBlockEnd(lines, line)
-		kind := graph.KindFunction
-		if strings.HasPrefix(name, "_") && name != "_init" && name != "_ready" && name != "_process" && name != "_physics_process" {
-			// Private-looking; still a function.
-			kind = graph.KindFunction
+		declOffsets[m[2]] = true
+		if owner := ownerAt(line); owner != "" {
+			add(name, graph.KindMethod, line, end, map[string]any{"receiver": owner})
+		} else {
+			add(name, graph.KindFunction, line, end, nil)
 		}
-		add(name, kind, line, end, nil)
 	}
 	for _, m := range gdVarRe.FindAllSubmatchIndex(src, -1) {
 		name := string(src[m[2]:m[3]])
@@ -107,6 +171,9 @@ func (e *GDScriptExtractor) Extract(filePath string, src []byte) (*parser.Extrac
 	for _, m := range gdSignalRe.FindAllSubmatchIndex(src, -1) {
 		name := string(src[m[2]:m[3]])
 		line := lineAt(src, m[0])
+		// `signal died(reason: String)` is a declaration, not a call to
+		// `died` — record the offset so the call scan skips it.
+		declOffsets[m[2]] = true
 		add(name, graph.KindMethod, line, line, map[string]any{"gd_kind": "signal"})
 	}
 
@@ -128,23 +195,205 @@ func (e *GDScriptExtractor) Extract(filePath string, src []byte) (*parser.Extrac
 	}
 
 	funcRanges := buildFuncRanges(result)
-	for _, m := range gdCallRe.FindAllSubmatchIndex(src, -1) {
-		name := string(src[m[2]:m[3]])
-		if isGDKeyword(name) {
+	types := gdBuildTypeEnv(src, funcRanges)
+
+	// Comments and string literals are masked before the call scan so a
+	// `#` note or a `"res://..."` path cannot mint a call edge. Masking
+	// preserves length, so every offset below still indexes src alike.
+	masked := gdMaskLiterals(src)
+	for _, m := range gdCallRe.FindAllSubmatchIndex(masked, -1) {
+		name := string(masked[m[4]:m[5]])
+		if isGDKeyword(name) || declOffsets[m[4]] {
 			continue
 		}
-		line := lineAt(src, m[0])
+		line := lineAt(masked, m[0])
 		callerID := findEnclosingFunc(funcRanges, line)
-		if callerID == "" || strings.HasSuffix(callerID, "::"+name) {
+		if callerID == "" {
 			continue
+		}
+		recv := ""
+		if m[2] >= 0 {
+			recv = string(masked[m[2]:m[3]])
+			if i := strings.LastIndexByte(recv, '.'); i >= 0 {
+				recv = recv[i+1:]
+			}
+		}
+
+		member, recvType := false, ""
+		switch recv {
+		case "":
+			// A bare call to a name this script itself declares is a
+			// self-call; anything else (an engine builtin, a method
+			// inherited from Node) keeps the free-function shape it has
+			// always had rather than claiming a receiver type nothing
+			// in the file supports.
+			if owner := ownerAt(line); owner != "" && seen[filePath+"::"+name] {
+				member, recvType = true, owner
+			}
+		case "self":
+			member, recvType = true, ownerAt(line)
+		default:
+			member = true
+			if t := types.lookup(callerID, recv); t != "" {
+				recvType = t
+			} else if gdLooksGlobalName(recv) {
+				// GDScript style reserves PascalCase for `class_name`
+				// globals, autoload singletons and engine singletons,
+				// and snake_case for locals — so an unbound PascalCase
+				// receiver names a type directly. When the repo defines
+				// no such type (an engine singleton like `Input`), the
+				// resolver's own in-repo-type gate declines the hint.
+				recvType = recv
+			}
+		}
+
+		// Self-recursion carries no information the definition does not
+		// already have, and a self-loop would show up as a cycle. Only a
+		// call that really is to the enclosing func qualifies: gated on
+		// the receiver, an `other.foo()` inside `func foo()` is a call to
+		// a different object that must not be dropped for sharing a name.
+		if (recv == "" || recv == "self") && strings.HasSuffix(callerID, "::"+name) {
+			continue
+		}
+
+		to := "unresolved::" + name
+		var meta map[string]any
+		if member {
+			to = "unresolved::*." + name
+			if recvType != "" {
+				meta = map[string]any{"receiver_type": recvType}
+			}
 		}
 		result.Edges = append(result.Edges, &graph.Edge{
-			From: callerID, To: "unresolved::" + name,
+			From: callerID, To: to,
 			Kind: graph.EdgeCalls, FilePath: filePath, Line: line,
+			Meta: meta,
 		})
 	}
 
 	return result, nil
+}
+
+// gdTypeEnv maps a receiver expression to its declared type, scoped to
+// the function that declares it with a file-level fallback for the
+// script's member vars.
+type gdTypeEnv struct {
+	file map[string]string
+	byFn map[string]map[string]string
+}
+
+func (t gdTypeEnv) lookup(fnID, name string) string {
+	if fn, ok := t.byFn[fnID]; ok {
+		if v := fn[name]; v != "" {
+			return v
+		}
+	}
+	return t.file[name]
+}
+
+// gdBuildTypeEnv collects declared receiver types from typed vars
+// (`var x: Techs`), constructor-inferred vars (`var x := Techs.new()`)
+// and typed parameters (`func f(a: Techs)`). A declaration inside a
+// function scopes to that function; a member var scopes to the file.
+func gdBuildTypeEnv(src []byte, ranges []funcRange) gdTypeEnv {
+	env := gdTypeEnv{file: map[string]string{}, byFn: map[string]map[string]string{}}
+	bind := func(fnID, name, typ string) {
+		if name == "" || typ == "" || isGDKeyword(typ) {
+			return
+		}
+		if fnID == "" {
+			env.file[name] = typ
+			return
+		}
+		if env.byFn[fnID] == nil {
+			env.byFn[fnID] = map[string]string{}
+		}
+		env.byFn[fnID][name] = typ
+	}
+	for _, re := range []*regexp.Regexp{gdTypedVarRe, gdNewVarRe} {
+		for _, m := range re.FindAllSubmatchIndex(src, -1) {
+			line := lineAt(src, m[0])
+			bind(findEnclosingFunc(ranges, line), string(src[m[2]:m[3]]), string(src[m[4]:m[5]]))
+		}
+	}
+	for _, m := range gdFuncSigRe.FindAllSubmatchIndex(src, -1) {
+		line := lineAt(src, m[0])
+		fnID := findEnclosingFunc(ranges, line)
+		if fnID == "" {
+			continue
+		}
+		for _, p := range gdParamRe.FindAllSubmatch(src[m[2]:m[3]], -1) {
+			bind(fnID, string(p[1]), string(p[2]))
+		}
+	}
+	return env
+}
+
+// gdMaskLiterals blanks GDScript comments and string literals, keeping
+// the byte length (and therefore every offset and line number) intact
+// so the caller can index the masked copy and the original alike.
+func gdMaskLiterals(src []byte) []byte {
+	out := make([]byte, len(src))
+	copy(out, src)
+	blank := func(i int) {
+		if out[i] != '\n' {
+			out[i] = ' '
+		}
+	}
+	for i := 0; i < len(out); {
+		switch quote := out[i]; quote {
+		case '#':
+			for ; i < len(out) && out[i] != '\n'; i++ {
+				blank(i)
+			}
+		case '"', '\'':
+			n := 1
+			if i+2 < len(out) && out[i+1] == quote && out[i+2] == quote {
+				n = 3
+			}
+			for j := 0; j < n; j++ {
+				blank(i + j)
+			}
+			i += n
+			for i < len(out) {
+				if out[i] == '\\' && n == 1 {
+					blank(i)
+					if i+1 < len(out) {
+						blank(i + 1)
+					}
+					i += 2
+					continue
+				}
+				if out[i] == quote &&
+					(n == 1 || (i+2 < len(out) && out[i+1] == quote && out[i+2] == quote)) {
+					for j := 0; j < n && i+j < len(out); j++ {
+						blank(i + j)
+					}
+					i += n
+					break
+				}
+				if out[i] == '\n' && n == 1 {
+					break // an unterminated single-line string ends at EOL
+				}
+				blank(i)
+				i++
+			}
+		default:
+			i++
+		}
+	}
+	return out
+}
+
+// gdLooksGlobalName reports whether an identifier follows the Godot
+// convention for a global class / singleton name: PascalCase, i.e. a
+// leading uppercase letter and at least one lowercase character (so a
+// SCREAMING_CASE constant is not mistaken for a type).
+func gdLooksGlobalName(s string) bool {
+	if s == "" || s[0] < 'A' || s[0] > 'Z' || isGDKeyword(s) {
+		return false
+	}
+	return strings.ToUpper(s) != s
 }
 
 func isGDKeyword(s string) bool {

--- a/internal/parser/languages/gdscript_test.go
+++ b/internal/parser/languages/gdscript_test.go
@@ -7,7 +7,19 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
 )
+
+// gdCalls indexes a GDScript extraction's call edges by target.
+func gdCalls(res *parser.ExtractionResult) map[string]*graph.Edge {
+	out := map[string]*graph.Edge{}
+	for _, e := range res.Edges {
+		if e.Kind == graph.EdgeCalls {
+			out[e.To] = e
+		}
+	}
+	return out
+}
 
 func TestGDScriptExtractor_PlayerScript(t *testing.T) {
 	src := []byte(`class_name Player
@@ -40,18 +52,20 @@ func _spawn_weapon() -> void:
 	res, err := e.Extract("player.gd", src)
 	require.NoError(t, err)
 
-	types, funcs, vars, signals, imports := 0, 0, 0, 0, 0
+	types, methods, vars, signals, imports := 0, 0, 0, 0, 0
+	byName := map[string]*graph.Node{}
 	for _, n := range res.Nodes {
+		byName[n.Name] = n
 		switch n.Kind {
 		case graph.KindType:
 			types++
-		case graph.KindFunction:
-			funcs++
 		case graph.KindVariable:
 			vars++
 		case graph.KindMethod:
 			if n.Meta != nil && n.Meta["gd_kind"] == "signal" {
 				signals++
+			} else {
+				methods++
 			}
 		}
 	}
@@ -62,10 +76,19 @@ func _spawn_weapon() -> void:
 	}
 
 	assert.GreaterOrEqual(t, types, 3, "Player + InnerHelper + State enum")
-	assert.GreaterOrEqual(t, funcs, 3, "bump + _ready + _spawn_weapon")
 	assert.GreaterOrEqual(t, vars, 2, "SPEED const + health")
 	assert.GreaterOrEqual(t, signals, 1, "died signal")
 	assert.GreaterOrEqual(t, imports, 2, "extends CharacterBody2D + preload")
+
+	// A script IS a class: its funcs are methods of the `class_name`,
+	// and an inner class owns the funcs in its block.
+	assert.GreaterOrEqual(t, methods, 3, "bump + _ready + _spawn_weapon")
+	require.Contains(t, byName, "_ready")
+	assert.Equal(t, graph.KindMethod, byName["_ready"].Kind)
+	assert.Equal(t, "Player", byName["_ready"].Meta["receiver"])
+	require.Contains(t, byName, "bump")
+	assert.Equal(t, "InnerHelper", byName["bump"].Meta["receiver"],
+		"a func inside `class InnerHelper:` belongs to InnerHelper")
 }
 
 func TestGDScriptExtractor_CallEdges(t *testing.T) {
@@ -87,9 +110,160 @@ func hello():
 	assert.GreaterOrEqual(t, calls, 2)
 }
 
+// A call's receiver decides its target. `Notify.event(...)` must not
+// degrade to the bare name `event`, which the resolver's locality
+// fallback answers with whatever same-named method sits nearest the
+// caller — the phantom edge to an unrelated `BannerPath.event`.
+func TestGDScriptExtractor_ReceiverStampedOnCall(t *testing.T) {
+	src := []byte(`class_name Main
+extends Control
+
+func _on_night_rest_toggle():
+    Notify.event(L10n.t("ui_siege.05"))
+`)
+	res, err := NewGDScriptExtractor().Extract("src/ui/Main.gd", src)
+	require.NoError(t, err)
+	calls := gdCalls(res)
+
+	require.NotContains(t, calls, "unresolved::event",
+		"a call with a receiver must not be emitted as a bare name")
+	ev := calls["unresolved::*.event"]
+	require.NotNil(t, ev, "Notify.event() is a member call")
+	assert.Equal(t, "Notify", ev.Meta["receiver_type"])
+	assert.Equal(t, "src/ui/Main.gd::_on_night_rest_toggle", ev.From)
+
+	tr := calls["unresolved::*.t"]
+	require.NotNil(t, tr, "the nested L10n.t() call keeps its own receiver")
+	assert.Equal(t, "L10n", tr.Meta["receiver_type"])
+}
+
+func TestGDScriptExtractor_ReceiverTypeFromDeclarations(t *testing.T) {
+	src := []byte(`class_name ResearchSystem
+
+var overlay: CodexOverlay
+var techs := Techs.new()
+
+func apply(store: Techs, raw):
+    store.get_tech(raw)
+    techs.get_tech(raw)
+    overlay.refresh()
+    self.recompute()
+    recompute()
+    untyped.whatever()
+
+func recompute():
+    pass
+`)
+	res, err := NewGDScriptExtractor().Extract("src/sys/ResearchSystem.gd", src)
+	require.NoError(t, err)
+	calls := gdCalls(res)
+
+	getTech := calls["unresolved::*.get_tech"]
+	require.NotNil(t, getTech)
+	assert.Equal(t, "Techs", getTech.Meta["receiver_type"],
+		"a typed parameter names the receiver's type")
+
+	refresh := calls["unresolved::*.refresh"]
+	require.NotNil(t, refresh)
+	assert.Equal(t, "CodexOverlay", refresh.Meta["receiver_type"],
+		"a typed member var names the receiver's type")
+
+	recompute := calls["unresolved::*.recompute"]
+	require.NotNil(t, recompute)
+	assert.Equal(t, "ResearchSystem", recompute.Meta["receiver_type"],
+		"self. and a bare call to an own method both resolve to the script's class")
+
+	// An untyped local receiver still produces a member call — the
+	// resolver's lone-definition rule can bind it — but claims no type
+	// it cannot support.
+	whatever := calls["unresolved::*.whatever"]
+	require.NotNil(t, whatever)
+	assert.Nil(t, whatever.Meta, "no receiver type may be invented for an untyped local")
+}
+
+// A bare call to something the script does not declare (an engine
+// builtin, a method inherited from Node) keeps the free-function shape:
+// claiming the script's own class as its receiver would be a lie.
+func TestGDScriptExtractor_BareBuiltinCallKeepsFreeFunctionShape(t *testing.T) {
+	src := []byte(`class_name Spawner
+
+func spawn():
+    add_child(self)
+    emit_signal("done")
+`)
+	res, err := NewGDScriptExtractor().Extract("src/Spawner.gd", src)
+	require.NoError(t, err)
+	calls := gdCalls(res)
+	assert.Contains(t, calls, "unresolved::add_child")
+	assert.NotContains(t, calls, "unresolved::*.add_child")
+}
+
+func TestGDScriptExtractor_CommentsAndStringsAreNotCalls(t *testing.T) {
+	src := []byte(`class_name Doc
+
+func run():
+    # never_called() in a comment
+    var s = "also_not_called() in a string"
+    real_call()
+
+func real_call():
+    pass
+`)
+	res, err := NewGDScriptExtractor().Extract("doc.gd", src)
+	require.NoError(t, err)
+	calls := gdCalls(res)
+	assert.NotContains(t, calls, "unresolved::never_called")
+	assert.NotContains(t, calls, "unresolved::also_not_called")
+	assert.Contains(t, calls, "unresolved::*.real_call")
+}
+
+// `signal died(reason: String)` declares a signal; it is not a call to
+// something named `died`.
+func TestGDScriptExtractor_SignalDeclarationIsNotACall(t *testing.T) {
+	src := []byte(`class_name Actor
+
+signal died(reason: String)
+
+func hit():
+    died.emit("hp")
+`)
+	res, err := NewGDScriptExtractor().Extract("actor.gd", src)
+	require.NoError(t, err)
+	calls := gdCalls(res)
+	assert.NotContains(t, calls, "unresolved::died")
+	assert.Contains(t, calls, "unresolved::*.emit")
+}
+
+// A script with no `class_name` has no nameable owner, so its funcs stay
+// plain functions rather than methods of a class that does not exist.
+func TestGDScriptExtractor_NoClassNameKeepsFunctions(t *testing.T) {
+	src := []byte(`extends Node
+
+func helper():
+    pass
+`)
+	res, err := NewGDScriptExtractor().Extract("anon.gd", src)
+	require.NoError(t, err)
+	for _, n := range res.Nodes {
+		if n.Name == "helper" {
+			assert.Equal(t, graph.KindFunction, n.Kind)
+			assert.Nil(t, n.Meta)
+		}
+	}
+}
+
 func TestGDScriptExtractor_EmptyInput(t *testing.T) {
 	res, err := NewGDScriptExtractor().Extract("empty.gd", []byte(""))
 	require.NoError(t, err)
 	require.Len(t, res.Nodes, 1)
 	assert.Equal(t, graph.KindFile, res.Nodes[0].Kind)
+}
+
+func TestGDLooksGlobalName(t *testing.T) {
+	for _, s := range []string{"Notify", "Techs", "CodexOverlay"} {
+		assert.True(t, gdLooksGlobalName(s), s)
+	}
+	for _, s := range []string{"", "notify", "MAX_HP", "self", "String"} {
+		assert.False(t, gdLooksGlobalName(s), s)
+	}
 }

--- a/internal/parser/languages/godot_project.go
+++ b/internal/parser/languages/godot_project.go
@@ -1,0 +1,131 @@
+package languages
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+)
+
+// Godot's `project.godot` is the project manifest. The one thing in it
+// the call graph cannot do without is the `[autoload]` section:
+//
+//	[autoload]
+//	Game="*res://src/core/Game.gd"
+//	Notify="*res://src/systems/Notify.gd"
+//
+// Each entry binds a PROJECT-GLOBAL identifier to a script. `Game` is
+// then callable from any script in the project with no import, no
+// preload and no `class_name` on the target — so without reading this
+// file there is nothing anywhere in the sources that connects the name
+// `Game` to `src/core/Game.gd`, and every `Game.set_speed()` call in
+// the project is unresolvable by construction.
+//
+// The extractor emits one KindType node per autoload, carrying the
+// declared script path in Meta["gd_script"]. ResolveGDScriptAutoloads
+// consumes those to bind the calls. Emitting KindType (rather than a
+// variable) is deliberate: an autoload names a singleton *type* for the
+// resolver's in-repo-type gate, which is what keeps a receiver hint of
+// `Game` from being discarded as an unknown external.
+//
+// The leading `*` marks the autoload as enabled; a disabled entry keeps
+// the same binding and is indexed the same way — the name still
+// resolves for anyone reading the code.
+var (
+	godotSectionRe  = regexp.MustCompile(`(?m)^\s*\[([^\]]+)\]`)
+	godotAutoloadRe = regexp.MustCompile(`(?m)^\s*([A-Za-z_]\w*)\s*=\s*"([^"]*)"`)
+)
+
+// GodotProjectExtractor indexes a Godot `project.godot` manifest.
+type GodotProjectExtractor struct{}
+
+func NewGodotProjectExtractor() *GodotProjectExtractor { return &GodotProjectExtractor{} }
+
+func (e *GodotProjectExtractor) Language() string { return "godot_project" }
+
+// Extensions claims the manifest by exact basename. `.godot` is not
+// claimed as an extension — the engine's `.godot/` cache directory and
+// any other file ending that way are none of this extractor's business.
+func (e *GodotProjectExtractor) Extensions() []string { return []string{"project.godot"} }
+
+func (e *GodotProjectExtractor) Extract(filePath string, src []byte) (*parser.ExtractionResult, error) {
+	lines := strings.Split(string(src), "\n")
+	result := &parser.ExtractionResult{}
+
+	fileNode := &graph.Node{
+		ID: filePath, Kind: graph.KindFile, Name: filePath,
+		FilePath: filePath, StartLine: 1, EndLine: len(lines),
+		Language: "godot_project",
+	}
+	result.Nodes = append(result.Nodes, fileNode)
+
+	start, end := godotAutoloadSection(src)
+	if start < 0 {
+		return result, nil
+	}
+
+	seen := make(map[string]bool)
+	for _, m := range godotAutoloadRe.FindAllSubmatchIndex(src[start:end], -1) {
+		name := string(src[start+m[2] : start+m[3]])
+		value := string(src[start+m[4] : start+m[5]])
+		script := godotResPath(value)
+		if script == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		line := lineAt(src, start+m[0])
+		id := filePath + "::" + name
+		result.Nodes = append(result.Nodes, &graph.Node{
+			ID: id, Kind: graph.KindType, Name: name,
+			FilePath: filePath, StartLine: line, EndLine: line,
+			Language: "godot_project",
+			Meta:     map[string]any{"gd_kind": "autoload", "gd_script": script},
+		})
+		result.Edges = append(result.Edges,
+			&graph.Edge{
+				From: fileNode.ID, To: id, Kind: graph.EdgeDefines,
+				FilePath: filePath, Line: line,
+			},
+			&graph.Edge{
+				From: id, To: "unresolved::import::" + script,
+				Kind: graph.EdgeImports, FilePath: filePath, Line: line,
+			},
+		)
+	}
+	return result, nil
+}
+
+// godotAutoloadSection returns the byte range of the `[autoload]`
+// section body — from just past its header to the start of the next
+// section header (or EOF). Returns (-1, -1) when the file has none.
+func godotAutoloadSection(src []byte) (int, int) {
+	for _, m := range godotSectionRe.FindAllSubmatchIndex(src, -1) {
+		if strings.TrimSpace(string(src[m[2]:m[3]])) != "autoload" {
+			continue
+		}
+		body := m[1]
+		if next := godotSectionRe.FindIndex(src[body:]); next != nil {
+			return body, body + next[0]
+		}
+		return body, len(src)
+	}
+	return -1, -1
+}
+
+// godotResPath converts an autoload value (`*res://src/core/Game.gd`)
+// to a repo-relative script path. The `*` enable-marker and the
+// `res://` project-root scheme are stripped. Values naming anything but
+// a script (a scene autoload, `res://x.tscn`) return "" — the resolver
+// pass binds calls to script members only.
+func godotResPath(value string) string {
+	v := strings.TrimSpace(value)
+	v = strings.TrimPrefix(v, "*")
+	v, ok := strings.CutPrefix(v, "res://")
+	if !ok || !strings.HasSuffix(v, ".gd") {
+		return ""
+	}
+	return strings.TrimPrefix(v, "/")
+}
+
+var _ parser.Extractor = (*GodotProjectExtractor)(nil)

--- a/internal/parser/languages/godot_project_test.go
+++ b/internal/parser/languages/godot_project_test.go
@@ -1,0 +1,92 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+const godotManifest = `; Engine configuration file.
+config_version=5
+
+[application]
+
+config/name="Latticefall"
+run/main_scene="res://src/ui/Main.tscn"
+
+[autoload]
+
+Game="*res://src/core/Game.gd"
+Notify="*res://src/systems/Notify.gd"
+Disabled="res://src/systems/Legacy.gd"
+Scene="*res://src/ui/Hud.tscn"
+
+[display]
+
+window/size/viewport_width=1920
+`
+
+func godotAutoloads(t *testing.T, src string) map[string]*graph.Node {
+	t.Helper()
+	e := NewGodotProjectExtractor()
+	require.Equal(t, "godot_project", e.Language())
+	require.Equal(t, []string{"project.godot"}, e.Extensions())
+
+	res, err := e.Extract("project.godot", []byte(src))
+	require.NoError(t, err)
+
+	out := map[string]*graph.Node{}
+	for _, n := range res.Nodes {
+		if n.Meta != nil && n.Meta["gd_kind"] == "autoload" {
+			out[n.Name] = n
+		}
+	}
+	return out
+}
+
+func TestGodotProjectExtractor_Autoloads(t *testing.T) {
+	loads := godotAutoloads(t, godotManifest)
+
+	require.Contains(t, loads, "Game")
+	assert.Equal(t, "src/core/Game.gd", loads["Game"].Meta["gd_script"])
+	assert.Equal(t, graph.KindType, loads["Game"].Kind,
+		"an autoload names a singleton type for the resolver's in-repo-type gate")
+
+	require.Contains(t, loads, "Notify")
+	assert.Equal(t, "src/systems/Notify.gd", loads["Notify"].Meta["gd_script"])
+
+	// A disabled entry (no `*`) still binds the name to the script.
+	require.Contains(t, loads, "Disabled")
+	assert.Equal(t, "src/systems/Legacy.gd", loads["Disabled"].Meta["gd_script"])
+
+	// A scene autoload has no script members to bind calls to.
+	assert.NotContains(t, loads, "Scene")
+
+	// Keys from other sections never leak in.
+	assert.NotContains(t, loads, "config")
+	assert.NotContains(t, loads, "window")
+}
+
+func TestGodotProjectExtractor_NoAutoloadSection(t *testing.T) {
+	res, err := NewGodotProjectExtractor().Extract("project.godot", []byte("config_version=5\n\n[application]\n\nconfig/name=\"X\"\n"))
+	require.NoError(t, err)
+	require.Len(t, res.Nodes, 1)
+	assert.Equal(t, graph.KindFile, res.Nodes[0].Kind)
+}
+
+func TestGodotProjectExtractor_AutoloadSectionIsLast(t *testing.T) {
+	loads := godotAutoloads(t, "config_version=5\n\n[autoload]\n\nGame=\"*res://src/core/Game.gd\"\n")
+	require.Contains(t, loads, "Game")
+	assert.Equal(t, "src/core/Game.gd", loads["Game"].Meta["gd_script"])
+}
+
+func TestGodotResPath(t *testing.T) {
+	assert.Equal(t, "src/core/Game.gd", godotResPath(`*res://src/core/Game.gd`))
+	assert.Equal(t, "src/core/Game.gd", godotResPath(`res://src/core/Game.gd`))
+	assert.Equal(t, "", godotResPath(`*res://src/ui/Hud.tscn`), "scenes have no members")
+	assert.Equal(t, "", godotResPath(`user://save.cfg`), "only project-root paths bind")
+	assert.Equal(t, "", godotResPath(``))
+}

--- a/internal/parser/languages/register.go
+++ b/internal/parser/languages/register.go
@@ -91,6 +91,10 @@ func RegisterAll(reg *parser.Registry) {
 	reg.Register(NewAutoHotkeyExtractor())
 	reg.Register(NewAssemblyExtractor())
 	reg.Register(NewGDScriptExtractor())
+	// Claims the `project.godot` manifest by exact basename so Godot
+	// autoload singletons become globally-nameable types; the bare
+	// ".godot" extension stays unclaimed.
+	reg.Register(NewGodotProjectExtractor())
 	reg.Register(NewNixExtractor())
 	reg.Register(NewFortranExtractor())
 	reg.Register(NewSolidityExtractor())

--- a/internal/resolver/cross_pkg_guard.go
+++ b/internal/resolver/cross_pkg_guard.go
@@ -347,12 +347,16 @@ func (r *Resolver) loneMemberDefnKeep(target *graph.Node, e *graph.Edge, oldTo s
 // a class-based member call is the language's dispatch model. PHP qualifies:
 // its calls carry a receiver, and since PHP call sites stamp receiver_type the
 // external-receiver gate above screens them more effectively than it does for
-// most of this list. TS / Python / JS stay out — an object literal or a
-// dynamically attached method makes a same-name coincidence likelier there,
-// and their guard revert is load-bearing.
+// most of this list. GDScript qualifies for the same reason and needs it more
+// than any of them: a script IS a class, `class_name` registers it
+// project-globally, and the language has no import statement at all — so the
+// import closure this guard consults is structurally empty for every
+// cross-directory call and would revert all of them. TS / Python / JS stay
+// out — an object literal or a dynamically attached method makes a same-name
+// coincidence likelier there, and their guard revert is load-bearing.
 func loneMemberLang(lang string) bool {
 	switch lang {
-	case "java", "go", "rust", "csharp", "kotlin", "scala", "php":
+	case "java", "go", "rust", "csharp", "kotlin", "scala", "php", "gdscript":
 		return true
 	}
 	return false

--- a/internal/resolver/framework_synth.go
+++ b/internal/resolver/framework_synth.go
@@ -124,6 +124,7 @@ const (
 	SynthSwiftUIResolve      = "swiftui-resolve"
 	SynthUIKitResolve        = "uikit-resolve"
 	SynthVaporResolve        = "vapor-resolve"
+	SynthGodotAutoload       = "godot-autoload"
 	SynthGinMiddleware       = "gin-middleware"
 	SynthSvelteKitLoad       = "sveltekit-load"
 	SynthSpeculative         = "speculative-dispatch"
@@ -965,6 +966,10 @@ func defaultFrameworkSynthesizers() []FrameworkSynthesizer {
 		// `User.find` / `ApplicationHelper.fmt` call binds to the directory-
 		// located service / model / helper definition named by its receiver.
 		synthFunc{name: SynthRailsResolve, fn: ResolveRailsRefs, candFn: resolveRailsRefs},
+		// Godot autoload resolution: a `Game.set_speed()` call binds to
+		// the script `project.godot` declares the singleton `Game` to
+		// be — the only place that mapping exists.
+		synthFunc{name: SynthGodotAutoload, fn: ResolveGDScriptAutoloads},
 		// SwiftUI directory-convention fallback: a residual `*View` /
 		// `*ViewModel` / `*Store` / `*Manager` / PascalCase-model reference
 		// binds to its /Views/ /ViewModels/ /Stores/ /Models/ definition.

--- a/internal/resolver/gdscript_autoload.go
+++ b/internal/resolver/gdscript_autoload.go
@@ -1,0 +1,171 @@
+package resolver
+
+import (
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Godot autoload resolution. An `[autoload]` entry in `project.godot`
+// binds a project-global identifier to a script:
+//
+//	Game="*res://src/core/Game.gd"
+//
+// From then on `Game.set_speed()` is legal in every script in the
+// project — with no import, no preload, and no `class_name` on the
+// target. The GDScript extractor stamps `Game` as the call's
+// receiver_type, but the generic receiver passes can only match that
+// against a method whose own `receiver` says `Game`, and an autoload
+// script typically declares no `class_name` at all. So the name and the
+// definition never meet, and every cross-script autoload call stays
+// unresolved.
+//
+// This pass supplies the missing link: it reads the autoload nodes the
+// project.godot extractor emitted, maps each singleton name to its
+// script, and binds residual `unresolved::*.method` calls whose
+// receiver_type names an autoload to that script's member of the same
+// name. Already-resolved edges are never touched, and a name the script
+// does not define is left alone rather than bound to the file.
+func ResolveGDScriptAutoloads(g graph.Store) int {
+	if g == nil {
+		return 0
+	}
+	scripts := gdAutoloadScripts(g)
+	if len(scripts) == 0 {
+		return 0
+	}
+	members := gdMembersByFile(g, scripts)
+	resolved := 0
+	var reindex []graph.EdgeReindex
+	for e := range g.EdgesByKind(graph.EdgeCalls) {
+		if e == nil || e.Meta == nil || !graph.IsUnresolvedTarget(e.To) {
+			continue
+		}
+		recv, _ := e.Meta["receiver_type"].(string)
+		if recv == "" {
+			continue
+		}
+		fileID, ok := scripts[recv]
+		if !ok {
+			continue
+		}
+		method := strings.TrimPrefix(graph.UnresolvedName(e.To), "*.")
+		target := members[fileID][method]
+		if target == "" {
+			continue
+		}
+		oldTo := e.To
+		e.To = target
+		// The binding is structural, not a name guess: project.godot
+		// states which script the receiver names, and the script
+		// declares the member. That is the same grade of evidence the
+		// extractor's own receiver_type match carries.
+		e.Origin = graph.OriginASTResolved
+		e.Confidence = 0.9
+		e.ConfidenceLabel = graph.ConfidenceLabelFor(graph.EdgeCalls, 0.9)
+		StampSynthesized(e, SynthGodotAutoload)
+		reindex = append(reindex, graph.EdgeReindex{Edge: e, OldTo: oldTo})
+		resolved++
+	}
+	if len(reindex) > 0 {
+		g.ReindexEdges(reindex)
+	}
+	return resolved
+}
+
+// gdAutoloadScripts maps each autoload singleton name to the graph file
+// ID of the script it names. An entry whose script is not indexed, and
+// a name declared by two different manifests with conflicting targets,
+// are both dropped — a wrong binding here is worse than none.
+func gdAutoloadScripts(g graph.Store) map[string]string {
+	var decls map[string]string
+	for n := range g.NodesByKind(graph.KindType) {
+		if n == nil || n.Meta == nil || n.Language != "godot_project" {
+			continue
+		}
+		if kind, _ := n.Meta["gd_kind"].(string); kind != "autoload" {
+			continue
+		}
+		script, _ := n.Meta["gd_script"].(string)
+		if script == "" {
+			continue
+		}
+		if decls == nil {
+			decls = map[string]string{}
+		}
+		if prev, dup := decls[n.Name]; dup && prev != script {
+			decls[n.Name] = ""
+			continue
+		}
+		decls[n.Name] = script
+	}
+	if len(decls) == 0 {
+		return nil
+	}
+	// `res://` paths are project-root relative; graph file IDs carry the
+	// repo prefix and the repo-relative path. Match by path suffix on a
+	// separator boundary, and drop any singleton whose path is ambiguous
+	// across two indexed scripts. One pass over the file nodes serves
+	// every autoload — NodesByKind is a full scan on a disk backend, and
+	// a scan per singleton would multiply that by the manifest's length.
+	out := make(map[string]string, len(decls))
+	ambiguous := make(map[string]bool, len(decls))
+	for f := range g.NodesByKind(graph.KindFile) {
+		if f == nil || f.Language != "gdscript" {
+			continue
+		}
+		for name, script := range decls {
+			if script == "" || ambiguous[name] || !gdPathMatches(f.FilePath, script) {
+				continue
+			}
+			if prev, seen := out[name]; seen && prev != f.ID {
+				delete(out, name)
+				ambiguous[name] = true
+				continue
+			}
+			out[name] = f.ID
+		}
+	}
+	return out
+}
+
+// gdPathMatches reports whether an indexed file path ends with the
+// project-relative script path on a path-separator boundary, so
+// `src/core/Game.gd` matches `<repo>/src/core/Game.gd` but never
+// `src/core/NotGame.gd`.
+func gdPathMatches(filePath, script string) bool {
+	p := strings.ReplaceAll(filePath, "\\", "/")
+	if p == script {
+		return true
+	}
+	return strings.HasSuffix(p, "/"+script)
+}
+
+// gdMembersByFile indexes the callable members declared by each autoload
+// script, by name. Signals are included: `Game.started.emit()` and a
+// direct connect both reference the signal as a member.
+func gdMembersByFile(g graph.Store, scripts map[string]string) map[string]map[string]string {
+	want := make(map[string]bool, len(scripts))
+	for _, fileID := range scripts {
+		want[fileID] = true
+	}
+	out := make(map[string]map[string]string, len(want))
+	for _, kind := range []graph.NodeKind{graph.KindMethod, graph.KindFunction} {
+		for n := range g.NodesByKind(kind) {
+			if n == nil || n.Language != "gdscript" {
+				continue
+			}
+			fileID, _, ok := strings.Cut(n.ID, "::")
+			if !ok || !want[fileID] {
+				continue
+			}
+			if out[fileID] == nil {
+				out[fileID] = map[string]string{}
+			}
+			if _, exists := out[fileID][n.Name]; !exists {
+				out[fileID][n.Name] = n.ID
+			}
+		}
+	}
+	return out
+}

--- a/internal/resolver/gdscript_autoload_test.go
+++ b/internal/resolver/gdscript_autoload_test.go
@@ -1,0 +1,123 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func gdAutoloadNode(g *graph.Graph, name, script string) {
+	g.AddNode(&graph.Node{
+		ID: "project.godot::" + name, Kind: graph.KindType, Name: name,
+		FilePath: "project.godot", Language: "godot_project",
+		Meta: map[string]any{"gd_kind": "autoload", "gd_script": script},
+	})
+}
+
+func gdScriptFile(g *graph.Graph, path string, methods ...string) {
+	g.AddNode(&graph.Node{
+		ID: path, Kind: graph.KindFile, Name: path,
+		FilePath: path, Language: "gdscript",
+	})
+	for _, m := range methods {
+		g.AddNode(&graph.Node{
+			ID: path + "::" + m, Kind: graph.KindMethod, Name: m,
+			FilePath: path, Language: "gdscript",
+		})
+	}
+}
+
+func gdRecvCall(g *graph.Graph, from, file, method, recv string) {
+	g.AddEdge(&graph.Edge{
+		From: from, To: "unresolved::*." + method, Kind: graph.EdgeCalls, FilePath: file,
+		Meta: map[string]any{"receiver_type": recv},
+	})
+}
+
+func gdCallEdge(g graph.Store, from, to string) *graph.Edge {
+	for e := range g.EdgesByKind(graph.EdgeCalls) {
+		if e != nil && e.From == from && e.To == to {
+			return e
+		}
+	}
+	return nil
+}
+
+func gdAutoloadGraph(t *testing.T) *graph.Graph {
+	t.Helper()
+	g := graph.New()
+	gdAutoloadNode(g, "Game", "src/core/Game.gd")
+	gdScriptFile(g, "src/core/Game.gd", "set_speed", "pause")
+	gdScriptFile(g, "src/ui/Main.gd", "_ready")
+	return g
+}
+
+// `project.godot` is the only place that says the global name `Game`
+// means `src/core/Game.gd` — no import, preload or `class_name` in any
+// script carries that mapping.
+func TestResolveGDScriptAutoloads_BindsSingletonCall(t *testing.T) {
+	g := gdAutoloadGraph(t)
+	const caller = "src/ui/Main.gd::_ready"
+	gdRecvCall(g, caller, "src/ui/Main.gd", "set_speed", "Game")
+
+	require.Equal(t, 1, ResolveGDScriptAutoloads(g))
+
+	e := gdCallEdge(g, caller, "src/core/Game.gd::set_speed")
+	require.NotNil(t, e, "the call binds across directories")
+	assert.Equal(t, graph.OriginASTResolved, e.Origin)
+	assert.Equal(t, SynthGodotAutoload, e.Meta[MetaSynthesizedBy])
+}
+
+func TestResolveGDScriptAutoloads_UnknownMemberLeftAlone(t *testing.T) {
+	g := gdAutoloadGraph(t)
+	gdRecvCall(g, "src/ui/Main.gd::_ready", "src/ui/Main.gd", "no_such_method", "Game")
+	assert.Equal(t, 0, ResolveGDScriptAutoloads(g),
+		"a name the autoload script does not declare must not bind to it")
+}
+
+func TestResolveGDScriptAutoloads_NonAutoloadReceiverLeftAlone(t *testing.T) {
+	g := gdAutoloadGraph(t)
+	gdRecvCall(g, "src/ui/Main.gd::_ready", "src/ui/Main.gd", "set_speed", "Input")
+	assert.Equal(t, 0, ResolveGDScriptAutoloads(g))
+}
+
+func TestResolveGDScriptAutoloads_ResolvedEdgeNotTouched(t *testing.T) {
+	g := gdAutoloadGraph(t)
+	const caller = "src/ui/Main.gd::_ready"
+	g.AddEdge(&graph.Edge{
+		From: caller, To: "src/core/Game.gd::pause", Kind: graph.EdgeCalls,
+		FilePath: "src/ui/Main.gd", Origin: graph.OriginLSPResolved,
+		Meta: map[string]any{"receiver_type": "Game"},
+	})
+	assert.Equal(t, 0, ResolveGDScriptAutoloads(g))
+	assert.Equal(t, graph.OriginLSPResolved, gdCallEdge(g, caller, "src/core/Game.gd::pause").Origin)
+}
+
+// A singleton whose script two indexed files could satisfy is dropped:
+// a wrong cross-directory binding is worse than an unresolved call.
+func TestResolveGDScriptAutoloads_AmbiguousScriptDropped(t *testing.T) {
+	g := gdAutoloadGraph(t)
+	gdScriptFile(g, "addons/vendor/src/core/Game.gd", "set_speed")
+	gdRecvCall(g, "src/ui/Main.gd::_ready", "src/ui/Main.gd", "set_speed", "Game")
+	assert.Equal(t, 0, ResolveGDScriptAutoloads(g))
+}
+
+func TestResolveGDScriptAutoloads_NoManifest(t *testing.T) {
+	g := graph.New()
+	gdScriptFile(g, "src/core/Game.gd", "set_speed")
+	gdRecvCall(g, "src/ui/Main.gd::_ready", "src/ui/Main.gd", "set_speed", "Game")
+	assert.Equal(t, 0, ResolveGDScriptAutoloads(g))
+	assert.Equal(t, 0, ResolveGDScriptAutoloads(nil))
+}
+
+func TestGDPathMatches(t *testing.T) {
+	assert.True(t, gdPathMatches("src/core/Game.gd", "src/core/Game.gd"))
+	assert.True(t, gdPathMatches("game/src/core/Game.gd", "src/core/Game.gd"))
+	assert.True(t, gdPathMatches(`game\src\core\Game.gd`, "src/core/Game.gd"))
+	assert.False(t, gdPathMatches("src/core/NotGame.gd", "src/core/Game.gd"),
+		"the suffix must land on a path-separator boundary")
+	assert.False(t, gdPathMatches("src/core/Game.gd", "other/Game.gd"))
+}


### PR DESCRIPTION
Fixes #461.

## Validation

Reproduced and confirmed at the source. `internal/parser/languages/gdscript.go` matched calls with `\b([A-Za-z_]\w*)\s*\(` and emitted `unresolved::<name>` — the receiver was never captured, so `Notify.event(...)` reached the resolver as the bare name `event`. Both reported symptoms follow directly:

- **Phantom edge.** With no receiver evidence, `resolveMethodCall`'s locality fallback prefers a same-directory candidate — so a call in `src/ui/Main.gd` binds to `src/ui/BannerPath.gd::event` at the `text_matched` tier.
- **Missing edges.** GDScript has no import statement, so `buildImportClosure` is structurally empty for it. `guardCrossPackageCallEdges` reverts every name-only cross-package bind that `targetImportReachable` can't corroborate, and its `loneMemberDefnKeep` escape hatch only applies to member calls — a shape GDScript never emitted. Only callers in the definition's own directory survived, which is exactly the "1 caller instead of 23" in the report.
- **Autoloads.** `project.godot` was not indexed at all, so nothing anywhere connected the global name `Game` to `src/core/Game.gd`.

The report's proposed fix — use `class_name`, `[autoload]`, and declared receiver types — is what this implements.

## Changes

**Receiver-aware extraction.** A call with a receiver is emitted in the member-call shape (`unresolved::*.event`) with `Meta["receiver_type"]`, and the funcs of a `class_name` script are emitted as `KindMethod` with `Meta["receiver"]` naming that class. Those are the two halves the resolver's existing exact-receiver passes match on, so calls now bind at the `ast_resolved` tier — which the cross-package guard does not police — regardless of directory. No resolver changes were needed for this half.

Receiver types are taken from typed vars (`var x: CodexOverlay`), `X.new()` initialisers, typed parameters (`func f(a: Techs)`), `self`, and PascalCase receivers naming a global directly. An untyped local still produces a member call but claims no type — inventing one is how you get the phantom back.

**Autoloads.** `project.godot` is indexed for its `[autoload]` section (claimed by exact basename; the bare `.godot` extension stays unclaimed), emitting each singleton as a type node carrying its script path. A new `godot-autoload` resolver pass binds residual member calls whose receiver names an autoload to that script's member. A singleton whose script is unindexed, ambiguous across two scripts, or missing the called name is left unresolved.

**Along the way,** also in scope because each one mints or drops edges on the same code path: `gdscript` joins the guard's lone-member languages; comments and string literals are masked before the call scan so neither can mint an edge; `signal died(reason: String)` is no longer read as a call to `died`; and a foreign `other.foo()` is no longer dropped for sharing a name with its enclosing func.

## Verification

`internal/indexer/gdscript_receiver_e2e_test.go` indexes a project shaped like the reported one and asserts all three cases through the real pipeline:

```
src/ui/Main.gd::_on_night_rest_toggle -> src/systems/Notify.gd::event   ast_resolved 0.85
src/systems/Research.gd::run          -> src/data/Techs.gd::get_tech    ast_resolved 0.85
src/boot/Setup.gd::boot               -> src/core/Game.gd::set_speed    ast_resolved 0.90  (godot-autoload)
```

The `BannerPath.event` phantom is asserted absent. The autoload edge carries `guard_reverted:true` alongside `synthesized_by:godot-autoload` — the cross-package guard did revert the weak locality guess, and the new pass bound it correctly afterwards.

Full suite green (142 packages), `-race` green on the three touched packages, `golangci-lint` clean.

## Not addressed

The report's "secondary issues" section lists five further problems that are independent of receiver resolution and want their own changes: `min_tier` not surfacing unresolved calls, `refactor:rename` reporting edits it never writes with `dry_run: false`, the localization contract deadlocking a session, `.tscn` `ext_resource` links not becoming edges, and `Dockerfile.*` suffix detection. The `rename` and localization-contract ones look the most serious — `rename` claiming `high` confidence for writes it did not perform is a data-loss-shaped bug in its own right. Worth splitting into separate issues.
