### PR TITLE
csharp: extract this./base.-qualified member calls

### DIFF
--- a/internal/indexer/extractor_version.go
+++ b/internal/indexer/extractor_version.go
@@ -32,7 +32,7 @@ var extractorVersions = map[string]int{
 	//   "go": 2,
 	"c":      generatedParserProjectionPolicyVersion, // generated parser projection covers all strictly detected table sizes
 	"php":    2,                                      // class/interface inheritance now emits typed structural edges
-	"csharp": 3,                                      // scoped/global using + receiver/param shape stamps for extension binding (was: null-conditional call edges; caseless reference forms)
+	"csharp": 4,                                      // this./base.-qualified call edges (was: scoped/global using + receiver/param shape stamps; null-conditional call edges)
 }
 
 // extractorSaltExtLang maps a lower-case file extension to the language

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -85,6 +85,16 @@ const qCSharpAll = `
       (member_binding_expression
         name: (identifier) @callm.method))) @callm.expr
 
+  (invocation_expression
+    function: (member_access_expression
+      "this"
+      name: (identifier) @callself.method)) @callself.expr
+
+  (invocation_expression
+    function: (member_access_expression
+      "base"
+      name: (identifier) @callbase.method)) @callbase.expr
+
   (local_declaration_statement
     (variable_declaration
       type: (_) @lvar.type
@@ -115,6 +125,10 @@ func (e *CSharpExtractor) Extensions() []string { return []string{".cs"} }
 type csharpDeferredCall struct {
 	name     string
 	receiver string
+	// recvType is the receiver type a `this.`/`base.` qualifier names —
+	// resolved at capture time from the enclosing declaration, since the
+	// keyword itself never appears in any tenv.
+	recvType string
 	line     int
 	isMember bool
 	// returnUsage is how the call site consumes the return value
@@ -277,6 +291,28 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 			calls = append(calls, csharpDeferredCall{
 				name:        m.Captures["callm.method"].Text,
 				receiver:    m.Captures["callm.receiver"].Text,
+				line:        expr.StartLine + 1,
+				isMember:    true,
+				returnUsage: classifyReturnUsage(expr.Node, src, csharpReturnUsageSpec),
+			})
+
+		case m.Captures["callself.expr"] != nil:
+			expr := m.Captures["callself.expr"]
+			calls = append(calls, csharpDeferredCall{
+				name:        m.Captures["callself.method"].Text,
+				receiver:    "this",
+				recvType:    csharpQualifiedReceiverType(expr.Node, src, "this"),
+				line:        expr.StartLine + 1,
+				isMember:    true,
+				returnUsage: classifyReturnUsage(expr.Node, src, csharpReturnUsageSpec),
+			})
+
+		case m.Captures["callbase.expr"] != nil:
+			expr := m.Captures["callbase.expr"]
+			calls = append(calls, csharpDeferredCall{
+				name:        m.Captures["callbase.method"].Text,
+				receiver:    "base",
+				recvType:    csharpQualifiedReceiverType(expr.Node, src, "base"),
 				line:        expr.StartLine + 1,
 				isMember:    true,
 				returnUsage: classifyReturnUsage(expr.Node, src, csharpReturnUsageSpec),
@@ -476,7 +512,11 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 				From: callerID, To: "unresolved::*." + c.name,
 				Kind: graph.EdgeCalls, FilePath: filePath, Line: c.line,
 			}
-			if recvType, ok := tenvByOwner[callerID][c.receiver]; ok {
+			if c.recvType != "" {
+				// this./base.-qualified: the receiver type came from the
+				// enclosing declaration, not from any variable lookup.
+				edge.Meta = map[string]any{"receiver_type": c.recvType}
+			} else if recvType, ok := tenvByOwner[callerID][c.receiver]; ok {
 				edge.Meta = map[string]any{"receiver_type": recvType}
 				if shape := shapesByOwner[callerID][c.receiver]; shape != "" && shape != recvType {
 					edge.Meta["receiver_shape"] = shape
@@ -1490,6 +1530,63 @@ func emitCSharpBaseList(typeID string, decl *sitter.Node, src []byte, filePath s
 		}
 		result.Edges = append(result.Edges, edge)
 	}
+}
+
+// csharpQualifiedReceiverType resolves the type a `this.` or `base.`
+// call qualifier names: the innermost enclosing type declaration for
+// `this`, its declared base class for `base`. The keywords are anonymous
+// tokens in the grammar — a plain `(_)` receiver capture never matches
+// them — so the type must be recovered from the declaration instead of a
+// tenv. Base discrimination mirrors emitCSharpBaseList: the first
+// base_list entry that is a ctor-base or not I-prefixed is the
+// superclass. Empty when nothing applies (struct `base.`, interface-only
+// bases) — the call still emits as a plain member_call.
+func csharpQualifiedReceiverType(node *sitter.Node, src []byte, keyword string) string {
+	var decl *sitter.Node
+	for n := node; n != nil && decl == nil; n = n.Parent() {
+		switch n.Type() {
+		case "class_declaration", "struct_declaration", "record_declaration", "interface_declaration":
+			decl = n
+		}
+	}
+	if decl == nil {
+		return ""
+	}
+	if keyword == "this" {
+		if nm := decl.ChildByFieldName("name"); nm != nil {
+			return nm.Content(src)
+		}
+		return ""
+	}
+	if !csharpDeclAllowsBaseClass(decl) {
+		return ""
+	}
+	baseList := decl.ChildByFieldName("bases")
+	if baseList == nil {
+		for i, _nc := 0, int(decl.ChildCount()); i < _nc; i++ {
+			if c := decl.Child(i); c != nil && c.Type() == "base_list" {
+				baseList = c
+				break
+			}
+		}
+	}
+	if baseList == nil {
+		return ""
+	}
+	for i, _nc := 0, int(baseList.NamedChildCount()); i < _nc; i++ {
+		entry := baseList.NamedChild(i)
+		if entry == nil {
+			continue
+		}
+		name, isCtorBase := csharpBaseTypeName(entry, src)
+		if name == "" {
+			continue
+		}
+		if isCtorBase || !csharpInterfaceNamePattern.MatchString(name) {
+			return name
+		}
+	}
+	return ""
 }
 
 // csharpDeclAllowsBaseClass reports whether a class/struct/record

--- a/internal/parser/languages/csharp_this_base_call_test.go
+++ b/internal/parser/languages/csharp_this_base_call_test.go
@@ -1,0 +1,54 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// this./base.-qualified invocations must emit member-call edges. The grammar
+// keeps `this` and `base` as anonymous tokens, so a bare `(_)` receiver
+// capture never matches them — both calls used to vanish from the graph.
+func TestCSharpExtractor_ThisBaseQualifiedCalls(t *testing.T) {
+	src := []byte(`namespace App {
+    public class Tower {
+        public int Chime() { return 1; }
+    }
+    public class Belfry : Tower {
+        public new int Chime() { return 2; }
+        public int RingSelf() { return this.Chime(); }
+        public int RingBase() { return base.Chime(); }
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("Belfry.cs", src)
+	require.NoError(t, err)
+
+	var selfCall, baseCall *graph.Edge
+	for _, ed := range result.Edges {
+		if ed.Kind != graph.EdgeCalls {
+			continue
+		}
+		switch ed.From {
+		case "Belfry.cs::Belfry.RingSelf":
+			selfCall = ed
+		case "Belfry.cs::Belfry.RingBase":
+			baseCall = ed
+		}
+	}
+	require.NotNil(t, selfCall, "this.Chime() must emit a call edge")
+	require.NotNil(t, selfCall.Meta)
+	assert.Equal(t, true, selfCall.Meta["member_call"])
+	assert.Equal(t, "Belfry", selfCall.Meta["receiver_type"],
+		"this-receiver is the enclosing type")
+
+	require.NotNil(t, baseCall, "base.Chime() must emit a call edge")
+	require.NotNil(t, baseCall.Meta)
+	assert.Equal(t, true, baseCall.Meta["member_call"])
+	assert.Equal(t, "Tower", baseCall.Meta["receiver_type"],
+		"base-receiver is the declared base class")
+}

--- a/internal/resolver/csharp_this_base_spec_test.go
+++ b/internal/resolver/csharp_this_base_spec_test.go
@@ -1,0 +1,36 @@
+package resolver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// this./base.-qualified calls name their receiver explicitly: `this.Foo()`
+// resolves against the enclosing type (a `new` member hides the base one),
+// `base.Foo()` against the declared base class — no inference involved.
+func TestResolveCSharp_ThisBaseQualifiedCalls(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Lib.cs": `namespace App {
+    public class Tower { public int Foo() { return 1; } }
+    public class Belfry : Tower {
+        public new int Foo() { return 2; }
+        public int RingSelf() { return this.Foo(); }
+        public int RingBase() { return base.Foo(); }
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	selfTarget := fooCallTarget(g, "Lib.cs::Belfry.RingSelf")
+	require.NotEmpty(t, selfTarget, "this.Foo() must produce a call edge")
+	assert.True(t, strings.Contains(selfTarget, "Belfry.Foo"),
+		"this.Foo() binds the hiding member, got %q", selfTarget)
+
+	baseTarget := fooCallTarget(g, "Lib.cs::Belfry.RingBase")
+	require.NotEmpty(t, baseTarget, "base.Foo() must produce a call edge")
+	assert.True(t, strings.Contains(baseTarget, "Tower.Foo"),
+		"base.Foo() binds the base member, got %q", baseTarget)
+}


### PR DESCRIPTION

`this.Foo()` and `base.Foo()` currently emit no call edge at all — both member-call query patterns capture the receiver with `expression: (_)`, but `this` and `base` are **anonymous tokens** in tree-sitter-c-sharp, and a named-node wildcard never matches them. Every qualified self/base call in a C# codebase silently vanishes from the graph (noticeable on `base.OnActionExecuting(...)`-style overrides, which are everywhere in ASP.NET code).

**Fix** (extraction only, resolver untouched):

- Two new query alternations match the anonymous token literally (`(member_access_expression "this" name: (identifier))` and the `base` twin).
- The receiver type is resolved at capture time from the enclosing declaration — `this` → the innermost type's name, `base` → its declared base class (discrimination mirrors `emitCSharpBaseList`: first base-list entry that is a ctor-base or not I-prefixed; structs and interface-only bases stamp nothing and the call still emits as a plain `member_call`).
- The stamped `receiver_type` then rides the existing receiver-typed member binding path, so `this.Foo()` binds the hiding member and `base.Foo()` the base member with no new resolver machinery.

**Tests**: extractor spec (edges + `receiver_type` stamps for both qualifiers, `new`-hiding case) and an end-to-end resolver spec (`this.Foo()` → hiding member, `base.Foo()` → base member). Both watched red before the fix. `internal/parser/languages` fully green; `internal/resolver` and `internal/indexer` at their pre-existing Windows baselines with zero new failures.

The second commit bumps the `csharp` extractor version 3→4 so existing stores restage `.cs` files and grow the new edges. Validated live on a counted C# fixture repo via exactly that path — binary swap, no store wipe, salt-triggered restage — with both call shapes binding their compiler-correct targets (`this.X()` → the `new`-hiding member, `base.X()` → the base member) at 0.95 with `receiver_type` stamped.
