### PR TITLE
fix(mcp): let a directed read release a stuck localization contract

### DIFF
--- a/internal/mcp/localization_current_capture_test.go
+++ b/internal/mcp/localization_current_capture_test.go
@@ -257,8 +257,14 @@ func TestLocalizationRecoveryDoesNotAuthorizeReadFile(t *testing.T) {
 		generation:               2,
 		recoveryRetriesRemaining: 1,
 	}
+	// read.file is still not a recovery anchor: it can never spend the bounded
+	// allowance or drive the contract to answer_ready. Without an explicit
+	// target it is not a directed read either, so it stays refused.
 	blocked, token := state.authorizeWithToken("read", "file", map[string]any{"path": "repo/storage/disk.go"})
 	if token != 0 || blocked == nil {
 		t.Fatalf("read.file authorization = token %d result %#v", token, blocked)
+	}
+	if localizationDirectedRead("read", "file", map[string]any{"path": "repo/storage/disk.go"}) {
+		t.Fatal("an untargeted read.file was treated as a directed read")
 	}
 }

--- a/internal/mcp/localization_directed_read_test.go
+++ b/internal/mcp/localization_directed_read_test.go
@@ -1,0 +1,227 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+)
+
+func directedFileRead(path string) map[string]any {
+	return map[string]any{"target": map[string]any{"file": path}}
+}
+
+func armedRefinement(t *testing.T, task string) *localizationTerminalState {
+	t.Helper()
+	state := newLocalizationTerminalState()
+	candidate := "repo/tools/unrelated.go::Script"
+	state.armRefinementRoutesForTask(
+		task,
+		candidate,
+		[]string{candidate},
+		map[string]localizationRefinementRoute{candidate: {}},
+		nil,
+	)
+	if state.state != localizationStateNeedsRefinement {
+		t.Fatalf("arm produced state %q, want needs_refinement", state.state)
+	}
+	return state
+}
+
+// A ranked page whose candidates are all wrong used to gate every read-only
+// navigation call while leaving edit and refactor untouched. Naming a file is
+// the caller declaring it no longer needs this localization.
+func TestDirectedReadReleasesRefinementContract(t *testing.T) {
+	state := armedRefinement(t, "locate the resolver behaviour")
+
+	blocked, token := state.authorizeWithToken("read", "file", directedFileRead("internal/other/other.go"))
+	if blocked != nil || token != 0 {
+		t.Fatalf("directed read was not admitted: blocked=%#v token=%d", blocked, token)
+	}
+	if state.state != localizationStateInactive {
+		t.Fatalf("directed read left state %q, want inactive", state.state)
+	}
+
+	// The whole point of releasing: the rest of the navigation surface works.
+	if blocked, token := state.authorizeWithToken("search", "text", map[string]any{"query": "anything at all"}); blocked != nil || token != 0 {
+		t.Fatalf("search still gated after release: blocked=%#v token=%d", blocked, token)
+	}
+}
+
+func TestDirectedReadReleasesEveryNonTerminalContract(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		state *localizationTerminalState
+	}{
+		{"needs_refinement", armedRefinement(t, "locate the resolver behaviour")},
+		{"needs_exact_read", func() *localizationTerminalState {
+			s := newLocalizationTerminalState()
+			s.armForTask(newLocalizationCompletion(false, "repo/pkg/file.go::Run"), "locate run")
+			return s
+		}()},
+		{"needs_recovery", func() *localizationTerminalState {
+			s := newLocalizationTerminalState()
+			s.armForTask(newLocalizationRecoveryCompletion(), "locate run")
+			return s
+		}()},
+		{"planned_recovery", func() *localizationTerminalState {
+			s := newLocalizationTerminalState()
+			s.armForTask(newLocalizationPlannedRecoveryCompletion("search.symbols", "Resolver"), "locate run")
+			return s
+		}()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// interceptAnswerReady runs first in dispatch; it must not refuse the
+			// call, and authorizeWithToken is where the release lands (intercept
+			// only owns answer_ready and needs_recovery).
+			if blocked, _ := tc.state.interceptAnswerReady("read", "file", directedFileRead("internal/other/other.go")); blocked != nil {
+				t.Fatalf("intercept refused the directed read: %#v", blocked)
+			}
+			if blocked, token := tc.state.authorizeWithToken("read", "file", directedFileRead("internal/other/other.go")); blocked != nil || token != 0 {
+				t.Fatalf("authorize refused the directed read: blocked=%#v token=%d", blocked, token)
+			}
+			if tc.state.state != localizationStateInactive {
+				t.Fatalf("dispatch left state %q, want inactive", tc.state.state)
+			}
+			if blocked, token := tc.state.authorizeWithToken("search", "text", map[string]any{"query": "anything at all"}); blocked != nil || token != 0 {
+				t.Fatalf("navigation still gated after release: blocked=%#v token=%d", blocked, token)
+			}
+		})
+	}
+}
+
+// The measured terminality contract is not a deadlock: after answer_ready a
+// directed read still replays the retained evidence.
+func TestDirectedReadDoesNotReleaseAnswerReady(t *testing.T) {
+	state := newLocalizationTerminalState()
+	state.arm(newLocalizationCompletion(true, ""))
+
+	blocked, token := state.authorizeWithToken("read", "file", directedFileRead("internal/other/other.go"))
+	if blocked == nil || token != 0 {
+		t.Fatalf("directed read escaped answer_ready: blocked=%#v token=%d", blocked, token)
+	}
+	if state.state != localizationStateAnswerReady {
+		t.Fatalf("answer_ready was released to %q", state.state)
+	}
+	if intercepted, _ := state.interceptAnswerReady("read", "file", directedFileRead("internal/other/other.go")); intercepted == nil {
+		t.Fatal("intercept admitted a directed read after answer_ready")
+	}
+}
+
+// An in-flight state means another permitted call is mid-handler. Releasing
+// there would race its finalizer, and the condition resolves on its own.
+func TestDirectedReadDoesNotReleaseInFlightContract(t *testing.T) {
+	for _, inFlight := range []string{
+		localizationStateRefineInFlight,
+		localizationStateExactReadInFlight,
+		localizationStateRecoveryInFlight,
+	} {
+		t.Run(inFlight, func(t *testing.T) {
+			state := &localizationTerminalState{state: inFlight, generation: 3}
+			blocked, token := state.authorizeWithToken("read", "file", directedFileRead("internal/other/other.go"))
+			if blocked == nil || token != 0 {
+				t.Fatalf("directed read admitted mid-flight: blocked=%#v token=%d", blocked, token)
+			}
+			if state.state != inFlight {
+				t.Fatalf("in-flight state became %q", state.state)
+			}
+		})
+	}
+}
+
+// Releasing on read.source would discard the refinement steering instead of
+// following it, so the prescribed call keeps its existing meaning.
+func TestReadSourceKeepsRefinementSteering(t *testing.T) {
+	state := armedRefinement(t, "locate the resolver behaviour")
+
+	wrong := map[string]any{"target": map[string]any{"symbol": "repo/pkg/wrong.go::Wrong"}}
+	if blocked, token := state.authorizeWithToken("read", "source", wrong); blocked == nil || token != 0 {
+		t.Fatalf("unauthorized read.source was admitted: blocked=%#v token=%d", blocked, token)
+	}
+	if state.state != localizationStateNeedsRefinement {
+		t.Fatalf("unauthorized read.source released the contract to %q", state.state)
+	}
+
+	allowed := map[string]any{"target": map[string]any{"symbol": "repo/tools/unrelated.go::Script"}}
+	if blocked, token := state.authorizeWithToken("read", "source", allowed); blocked != nil || token == 0 {
+		t.Fatalf("prescribed read.source was not reserved: blocked=%#v token=%d", blocked, token)
+	}
+}
+
+func TestDirectedReadRequiresAnExplicitTarget(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		operation string
+		arguments map[string]any
+		want      bool
+	}{
+		{"file target", "file", directedFileRead("a/b.go"), true},
+		{"summary target", "summary", directedFileRead("a/b.go"), true},
+		{"editing_context target", "editing_context", directedFileRead("a/b.go"), true},
+		{"symbol target", "history", map[string]any{"target": map[string]any{"symbol": "a/b.go::C"}}, true},
+		{"symbols target", "symbols", map[string]any{"target": map[string]any{"symbols": []any{"a/b.go::C"}}}, true},
+		{"source is prescribed, not directed", "source", directedFileRead("a/b.go"), false},
+		{"no target", "file", map[string]any{"path": "a/b.go"}, false},
+		{"empty target", "file", map[string]any{"target": map[string]any{"file": "  "}}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := localizationDirectedRead("read", tc.operation, tc.arguments); got != tc.want {
+				t.Fatalf("localizationDirectedRead = %v, want %v", got, tc.want)
+			}
+		})
+	}
+	if localizationDirectedRead("search", "text", directedFileRead("a/b.go")) {
+		t.Fatal("a non-read facade was treated as a directed read")
+	}
+}
+
+// The reporter's session: a literal lifted verbatim out of a task that wrapped
+// it across lines could not match the whitespace-collapsed fingerprint.
+func TestRecoveryAcceptsMultiLineVerbatimTaskLiteral(t *testing.T) {
+	task := localizationTaskFingerprint("`gortex review` reports nothing on a dirty worktree. It prints:\n\n    No changes\n    in the current branch\n\nFind the emit site.")
+	query := "No changes\n    in the current branch"
+
+	if !localizationRecoveryQueryAligned(task, query) {
+		t.Fatal("a literal copied verbatim from the task was rejected as unspecific")
+	}
+	if localizationRecoveryQueryAligned(task, "No changes in some other project entirely") {
+		t.Fatal("a literal absent from the task was accepted")
+	}
+}
+
+// A rejected recovery query is no longer a dead end: the release is reachable
+// from needs_recovery whether or not the next anchor is ever accepted.
+func TestRejectedRecoveryQueryStillLeavesAReachableMove(t *testing.T) {
+	state := newLocalizationTerminalState()
+	state.armForTask(newLocalizationRecoveryCompletion(), "locate the emit site behind the staleness gate")
+
+	blocked, token := state.authorizeWithToken("search", "text", map[string]any{"query": "neighbor"})
+	if blocked == nil || token != 0 {
+		t.Fatalf("unanchored search.text was admitted: blocked=%#v token=%d", blocked, token)
+	}
+	if state.state != localizationStateNeedsRecovery {
+		t.Fatalf("a refused anchor consumed the contract: state=%q", state.state)
+	}
+	text := toolResultText(blocked)
+	if !strings.Contains(text, "releases this localization") {
+		t.Fatalf("recovery refusal names no reachable move: %s", text)
+	}
+
+	if blocked, token := state.authorizeWithToken("read", "file", directedFileRead("internal/other/other.go")); blocked != nil || token != 0 {
+		t.Fatalf("release refused after a rejected anchor: blocked=%#v token=%d", blocked, token)
+	}
+}
+
+// Every refusal that leaves the caller with no reachable move must name one.
+func TestBlockedNavigationNamesTheRelease(t *testing.T) {
+	state := armedRefinement(t, "locate the resolver behaviour")
+	blocked, _ := state.authorizeWithToken("relations", "usages", map[string]any{"target": map[string]any{"symbol": "a/b.go::C"}})
+	if blocked == nil {
+		t.Fatal("relations was admitted under a refinement contract")
+	}
+	// The payload is JSON, so the inner quotes arrive escaped.
+	text := toolResultText(blocked)
+	for _, required := range []string{`read(operation:`, `file`, `releases this localization`} {
+		if !strings.Contains(text, required) {
+			t.Fatalf("refusal is missing %q, so it names no reachable move: %s", required, text)
+		}
+	}
+}

--- a/internal/mcp/localization_recovery_test.go
+++ b/internal/mcp/localization_recovery_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
@@ -602,7 +603,10 @@ func TestPlannedRecoveryIsExactRetriableAndWeakResultReleasesAdvisory(t *testing
 		t.Fatalf("session-only recovery anchor leaked onto wire: %s", encoded)
 	}
 
-	wrong, generation := state.interceptAnswerReady("read", "file", map[string]any{"target": map[string]any{"file": "CHANGELOG.md"}})
+	// A search on some other anchor is genuinely off-plan. read.file is not a
+	// counter-example any more: naming a file releases the contract by design,
+	// so the planned plan is checked with a call that has no such meaning.
+	wrong, generation := state.interceptAnswerReady("search", "symbols", map[string]any{"query": "SomeOtherAnchor"})
 	if wrong == nil || !wrong.IsError || generation != 0 {
 		t.Fatalf("wrong planned navigation = (%#v, %d), want retriable block", wrong, generation)
 	}
@@ -689,9 +693,20 @@ func requireLocalizationResultStateEqual(
 		if wire.RequiredAction != "recover_once" || len(wire.AllowedOperations) != len(localizationRecoveryOperations) {
 			t.Fatalf("recovery completion is not directional/machine-readable: %#v", wire)
 		}
-		wantInstruction := `Make one accepted, bounded Gortex MCP recovery call: search(operation:"text" or "symbols", query:<specific task anchor>) or read(operation:"source", target:{symbol:<exact id>}). If Gortex explicitly rejects an overbroad request and preserves the recovery allowance, correct it using only Gortex MCP search or read; the rejected request does not count as the accepted recovery. Do not call host Read, Grep, Glob, Bash, or any other non-Gortex tool. Then respond from the accepted result and follow its completion.`
+		wantInstruction := newLocalizationRecoveryCompletion().Instruction
 		if wire.Instruction != wantInstruction {
 			t.Fatalf("recovery instruction = %q, want %q", wire.Instruction, wantInstruction)
+		}
+		// The instruction sends the caller to Gortex rather than to host tools, so
+		// it must also name the move that works when the candidates are wrong.
+		for _, required := range []string{
+			`search(operation:"text" or "symbols"`,
+			`read(operation:"file", target:{file:"<path>"})`,
+			"Do not call host Read, Grep, Glob, Bash",
+		} {
+			if !strings.Contains(wire.Instruction, required) {
+				t.Fatalf("recovery instruction is missing %q: %q", required, wire.Instruction)
+			}
 		}
 	}
 

--- a/internal/mcp/localization_refinement_contract.go
+++ b/internal/mcp/localization_refinement_contract.go
@@ -1,3 +1,6 @@
 package mcp
 
+// The refinement page is byte-budgeted (see the tight-budget builder test), so
+// this stays the happy-path instruction only. The release that unsticks a wrong
+// ranking is named on the refusals, which is where a blocked caller reads.
 const localizationRefinementRequiredActionFormat = `Call Gortex MCP read(operation:"source", target:{symbol:%q}); the named symbol is recommended; any returned candidate is permitted only when its ID appears in completion.allowed_symbols; do not call a host file-read tool.`

--- a/internal/mcp/localization_terminal.go
+++ b/internal/mcp/localization_terminal.go
@@ -25,6 +25,11 @@ const (
 
 var localizationRecoveryOperations = []string{"search.text", "search.symbols", "read.source"}
 
+// localizationDirectedReadRelease names the exit on every refusal that would
+// otherwise leave the caller with no move it can reach. A refusal that only
+// says "blocked" is what turns a bad ranking into a stuck session.
+const localizationDirectedReadRelease = `. If these candidates are wrong, read(operation:"file", target:{file:"<path>"}) reads a file you name and releases this localization.`
+
 const localizationSingleResultInstruction = "The indexed localization pass is complete for this request. Its bounded evidence contains exactly one supported primary production implementation candidate and no competing direct candidate. Continue the requested coding work using this result. Editing, building, testing, and other task tools remain available; further localization is unnecessary unless they reveal contradictory evidence."
 
 // localizationCompletion is the host-neutral terminality contract returned by
@@ -123,7 +128,7 @@ func newLocalizationRecoveryCompletion() localizationCompletion {
 		State:             localizationStateNeedsRecovery,
 		Scope:             "localization",
 		RequiredAction:    "recover_once",
-		Instruction:       `Make one accepted, bounded Gortex MCP recovery call: search(operation:"text" or "symbols", query:<specific task anchor>) or read(operation:"source", target:{symbol:<exact id>}). If Gortex explicitly rejects an overbroad request and preserves the recovery allowance, correct it using only Gortex MCP search or read; the rejected request does not count as the accepted recovery. Do not call host Read, Grep, Glob, Bash, or any other non-Gortex tool. Then respond from the accepted result and follow its completion.`,
+		Instruction:       `Make one accepted, bounded Gortex MCP recovery call: search(operation:"text" or "symbols", query:<specific task anchor>) or read(operation:"source", target:{symbol:<exact id>}). If Gortex explicitly rejects an overbroad request and preserves the recovery allowance, correct it using only Gortex MCP search or read; the rejected request does not count as the accepted recovery. If the retained candidates are wrong and you already know the file you need, read(operation:"file", target:{file:"<path>"}) reads it and releases this localization. Do not call host Read, Grep, Glob, Bash, or any other non-Gortex tool. Then respond from the accepted result and follow its completion.`,
 		AllowedToolCalls:  1,
 		ContractVersion:   localizationTerminalContractV2,
 		AllowedOperations: append([]string(nil), localizationRecoveryOperations...),
@@ -599,6 +604,13 @@ func (s *localizationTerminalState) interceptAnswerReady(facade, operation strin
 	case localizationStateAnswerReady:
 		return localizationTerminalResult(s.completionLocked(), facade, operation), 0
 	case localizationStateNeedsRecovery:
+		if localizationDirectedRead(facade, operation, arguments) {
+			// Checked ahead of the planned-recovery mismatch, which returns without
+			// releasing and would otherwise make a planned recovery the one state a
+			// directed read cannot leave.
+			s.releaseLocalizationAdvisoryLocked(nil)
+			return nil, 0
+		}
 		if s.localizationRecoveryPlannedLocked() && !s.localizationRecoveryAllowsLocked(facade, operation, arguments) {
 			return localizationPlannedRecoveryMismatchResult(s.completionLocked(), facade, operation), 0
 		}
@@ -698,6 +710,14 @@ func localizationRecoveryQueryAligned(task, query string) bool {
 	// short for identifier tokenization but occur verbatim in the request.
 	trimmedAnchor := strings.Trim(lowerQuery, " \t\r\n`'\"")
 	if len(trimmedAnchor) >= 2 && strings.Contains(lowerTask, trimmedAnchor) {
+		return true
+	}
+	// The task side is stored whitespace-collapsed (localizationTaskFingerprint),
+	// so a literal copied character-for-character out of a task that wrapped it
+	// across lines or indented it fails the raw containment above. Collapse the
+	// anchor the same way before giving up on the most specific anchor there is.
+	if collapsed := strings.Join(strings.Fields(trimmedAnchor), " "); len(collapsed) >= 2 &&
+		collapsed != trimmedAnchor && strings.Contains(lowerTask, collapsed) {
 		return true
 	}
 	taskTerms := exploreTerminalTerms(task)
@@ -1225,6 +1245,43 @@ func localizationRecoveryOperationAllowed(facade, operation string) bool {
 	}
 }
 
+// localizationDirectedRead reports whether a read call names the target it
+// wants instead of asking localization to find one. The session-start rule
+// already tells agents to read an explicitly named file with
+// read(operation:"file", target:{file:...}) rather than localize it, so a
+// contract that refuses that same call contradicts its own instruction — and,
+// because every other navigation facade is gated too, leaves a session whose
+// ranked candidates were wrong with nowhere left to look. read.source is
+// excluded: it is the call the contract prescribes, and routing it through the
+// release would discard the refinement steering rather than follow it.
+func localizationDirectedRead(facade, operation string, arguments map[string]any) bool {
+	if facade != "read" || operation == "source" {
+		return false
+	}
+	target, ok := arguments["target"].(map[string]any)
+	if !ok {
+		return false
+	}
+	return facadeSelectorPresent(target["file"]) ||
+		facadeSelectorPresent(target["symbol"]) ||
+		facadeSelectorPresent(target["symbols"])
+}
+
+// localizationReleasableByDirectedRead names the non-terminal states a directed
+// read may abandon. answer_ready is deliberately absent: replaying its retained
+// evidence is the measured terminality contract, not a deadlock. The in-flight
+// states are absent because they mean another permitted call is mid-handler — a
+// transient condition that resolves itself, and releasing under it would race
+// that call's finalizer.
+func localizationReleasableByDirectedRead(state string) bool {
+	switch state {
+	case localizationStateNeedsExactRead, localizationStateNeedsRefinement, localizationStateNeedsRecovery:
+		return true
+	default:
+		return false
+	}
+}
+
 func (s *localizationTerminalState) consumeInvalidRecovery(facade, operation string, generation uint64) (localizationCompletion, bool) {
 	if s == nil || generation == 0 || !localizationRecoveryOperationAllowed(facade, operation) {
 		return newLocalizationOpenCompletion(), false
@@ -1254,7 +1311,7 @@ func localizationPlannedRecoveryMismatchResult(completion localizationCompletion
 func localizationRecoveryMisalignedResult(completion localizationCompletion, facade, operation string) *mcpgo.CallToolResult {
 	return newStructuredErrorResult(StructuredError{
 		ErrorCode: ErrCodeLocalizationComplete,
-		Message:   "the recovery search query is not specific to the localization task; use a task term or a concrete path/literal anchor; the recovery allowance is still available",
+		Message:   "the recovery search query is not specific to the localization task; use a task term, a qualified or camelCase identifier with search(operation:\"symbols\"), or a concrete path/literal anchor; the recovery allowance is still available" + localizationDirectedReadRelease,
 		Retriable: true,
 		Data: map[string]any{
 			"contract":           localizationContractFor(completion),
@@ -1431,6 +1488,15 @@ func (s *localizationTerminalState) authorizeWithToken(facade, operation string,
 	if s.state == localizationStateAnswerReady {
 		return localizationTerminalResult(s.completionLocked(), facade, operation), 0
 	}
+	// A read that names its own target is the agent declaring it no longer needs
+	// this localization. Admit it and release, so a session whose candidates were
+	// wrong is never left with a gated read-only surface and an ungated mutating
+	// one. Ordered ahead of every non-terminal branch below: those all end in a
+	// refusal that leaves the state untouched.
+	if localizationReleasableByDirectedRead(s.state) && localizationDirectedRead(facade, operation, arguments) {
+		s.releaseLocalizationAdvisoryLocked(nil)
+		return nil, 0
+	}
 	if s.state == localizationStateNeedsRecovery {
 		if s.localizationRecoveryPlannedLocked() && !s.localizationRecoveryAllowsLocked(facade, operation, arguments) {
 			return localizationPlannedRecoveryMismatchResult(s.completionLocked(), facade, operation), 0
@@ -1470,11 +1536,11 @@ func (s *localizationTerminalState) authorizeWithToken(facade, operation string,
 	message := "localization is complete; return the existing evidence without another Gortex navigation call"
 	switch s.state {
 	case localizationStateNeedsExactRead:
-		message = fmt.Sprintf("localization needs exactly one read(operation:\"source\") for %q; other navigation calls are blocked", s.exactSymbol)
+		message = fmt.Sprintf("localization needs exactly one read(operation:\"source\") for %q; other navigation calls are blocked%s", s.exactSymbol, localizationDirectedReadRelease)
 	case localizationStateExactReadInFlight:
 		message = "the permitted exact localization read is already in progress"
 	case localizationStateNeedsRefinement:
-		message = fmt.Sprintf("localization permits exactly one read(operation:\"source\") for %q; other navigation calls are blocked", s.refinementSymbol)
+		message = fmt.Sprintf("localization permits exactly one read(operation:\"source\") for %q; other navigation calls are blocked%s", s.refinementSymbol, localizationDirectedReadRelease)
 	case localizationStateRefineInFlight:
 		message = "the permitted localization refinement read is already in progress"
 	case localizationStateRecoveryInFlight:


### PR DESCRIPTION
Fixes #464.

## The report holds up

I reproduced each step against the real state machine with throwaway Go probes driving `handleFacade`, then ran an independent pass whose job was to refute the findings. Nothing was refuted.

| Reported behaviour | Verdict |
|---|---|
| `read(operation:"file")` refused under `needs_refinement` / `needs_exact_read` | Confirmed — all seven read operations refused, `retriable:false`, handler ran 0 times |
| Mutation unrestricted while navigation is gated | Confirmed — `edit_file` and `rename_symbol` executed in every contract state |
| Recovery-query rejection too strict to recover from | Confirmed — `memcpy`, `pending`, `teardown`, `MAXBUF` refused; `Memcpy`, `mem_cpy` admitted for the same task |
| No release surface | Partly — `reset()` has no production callers, but `explore` + `new_user_task:true` does release; it is just documented as something else |
| `new_user_task:true` does not reset | Partly — it does reset; the fresh contract simply re-lands in `needs_recovery` |

Two corrections worth carrying forward. The boundary is **navigation-facade membership**, not read-versus-write: `change.impact`, `pr.list` and `recall.notes` are read-effect and equally ungated, so "mutation unrestricted vs read-only blocked" mislocates it. And planned recovery is the *harder* trap — `interceptAnswerReady` returns a retriable mismatch that never releases, and `beginLocalize`'s own release branch is unreachable behind it.

The sharpest finding is one the issue did not have. `internal/hooks/sessionstart.go:296` already instructs agents that an explicitly named file is read with `read(operation:"file", target:{file:...})` rather than localized — and `authorizeWithToken` refused precisely that call. **The enforcement contradicted the shipped instruction.**

## The fix

A `read` that names its own target releases a non-terminal contract and runs. That is the caller declaring it no longer needs this localization: retained candidates stay provisional, navigation reopens, and the release is reachable from `needs_refinement`, `needs_exact_read`, and both planned and unplanned `needs_recovery`.

I resolve the inverted ordering by ungating reads, not by gating writes.

Deliberately unchanged:

- **`answer_ready`** still replays its retained evidence. Terminality there is the measured contract, not a deadlock.
- **In-flight states** still refuse — releasing under them would race the pending finalizer, and the condition resolves itself.
- **`read.source`** stays prescribed rather than releasing, so refinement steering still steers. An out-of-set symbol is still refused, but that is one extra turn now, not a dead end.

Two smaller repairs on the same path: a recovery anchor copied verbatim out of a task that wrapped it across lines now matches the whitespace-collapsed fingerprint it is compared against, and every refusal that would otherwise leave no reachable move names the release.

## What I chose not to do

The anti-invention guard on symbol-search recovery queries decides by spelling — `Memcpy` is admitted where `memcpy` is not — and `TestRecoveryAllowsInferredConcreteIdentifierOnlyForScopedSymbolEvidence` pins that on purpose: it stops an agent inventing a nearby generic name and mistaking valid-but-unrelated hits for causal evidence. I had loosened it, saw the test fail, and reverted. It is a real asymmetry, but weakening a tested guard is a retrieval-quality trade I cannot measure here, and the deadlock is fixed without it. Worth a separate issue.

I also left the refinement `required_action` alone after discovering it is byte-budgeted (`TestLocalizationBuilderLeadsWithRequiredSymbolAndItsFileUnderTightBudget`, 256 tokens). The release is named on the refusals instead, which is where a blocked caller is actually reading.

No hook changes are needed: the hook marker is only armed from an `answer_ready` receipt, so nothing re-imposes the block in the states this touches.

## Testing

- `go test ./...` — full suite green, exit 0, zero failures
- `go test -race ./internal/mcp/ ./internal/hooks/ ./internal/profiles/` — green
- `golangci-lint run ./internal/mcp/...` — 0 issues
- New `internal/mcp/localization_directed_read_test.go` covers the release in all four non-terminal states, `answer_ready` and in-flight refusing it, refinement steering surviving, the target-shape predicate, the multi-line verbatim anchor, and refusals naming a reachable move.

Three existing tests changed. `TestPlannedRecoveryIsExactRetriableAndWeakResultReleasesAdvisory` used `read.file` as its example of wrong navigation — the exact call the issue says must work — so it now checks the plan with an off-plan `search.symbols`. `TestLocalizationRecoveryDoesNotAuthorizeReadFile` keeps its real invariant (`read.file` is not a recovery anchor) and gains the untargeted-read case. One golden-string assertion now reads the production constant instead of duplicating it, plus substantive checks.