### PR TITLE
Improve explore localization candidate selection

### DIFF
--- a/internal/mcp/explore_artifact_intent.go
+++ b/internal/mcp/explore_artifact_intent.go
@@ -29,6 +29,12 @@ type exploreArtifactIntent struct {
 	probes        []string
 }
 
+type exploreArtifactProbeCandidate struct {
+	value    string
+	priority int
+	order    int
+}
+
 type exploreArtifactHit struct {
 	file        *graph.Node
 	path        string
@@ -48,9 +54,11 @@ type exploreArtifactLane struct {
 }
 
 var (
-	exploreArtifactPathRE  = regexp.MustCompile(`[A-Za-z0-9_@+.-]*(?:[\\/][A-Za-z0-9_@+.-]+)+|[A-Za-z0-9_@+-]+(?:\.[A-Za-z0-9_@+-]+)+`)
-	exploreArtifactProbeRE = regexp.MustCompile("`[^`\\n]{2,96}`|\\\"[^\\\"\\n]{2,96}\\\"|'[^'\\n]{2,96}'|(?:^|\\s)--?[A-Za-z][A-Za-z0-9_.-]{1,63}|\\b[A-Z][A-Z0-9_]{2,63}\\b")
-	exploreArtifactCallRE  = regexp.MustCompile(`\b[A-Za-z_][A-Za-z0-9_]*(?:(?:::|\.)[A-Za-z_][A-Za-z0-9_]*)?\s*\(`)
+	exploreArtifactPathRE       = regexp.MustCompile(`[A-Za-z0-9_@+.-]*(?:[\\/][A-Za-z0-9_@+.-]+)+|[A-Za-z0-9_@+-]+(?:\.[A-Za-z0-9_@+-]+)+`)
+	exploreArtifactProbeRE      = regexp.MustCompile("`[^`\\n]{2,96}`|\\\"[^\\\"\\n]{2,96}\\\"|'[^'\\n]{2,96}'|(?:^|\\s)--?[A-Za-z][A-Za-z0-9_.-]{1,63}|\\b[A-Z][A-Z0-9_]{2,63}\\b")
+	exploreArtifactPropertyRE   = regexp.MustCompile(`(?i)(?:^|[\s,;])/(?:p|property):([A-Za-z_][A-Za-z0-9_.-]{1,63})`)
+	exploreArtifactAssignmentRE = regexp.MustCompile(`\b([A-Za-z_][A-Za-z0-9_.-]{1,63})\s*=`)
+	exploreArtifactCallRE       = regexp.MustCompile(`\b[A-Za-z_][A-Za-z0-9_]*(?:(?:::|\.)[A-Za-z_][A-Za-z0-9_]*)?\s*\(`)
 )
 
 func classifyExploreArtifactIntent(task string) exploreArtifactIntent {
@@ -68,6 +76,17 @@ func classifyExploreArtifactIntent(task string) exploreArtifactIntent {
 		seen[key] = struct{}{}
 		out.paths = append(out.paths, raw)
 	}
+	addSemanticPath := func(word string) {
+		word = strings.ToLower(strings.TrimSpace(word))
+		if word == "" || len(out.paths) == exploreArtifactPathLimit {
+			return
+		}
+		if _, ok := seen[word]; ok {
+			return
+		}
+		seen[word] = struct{}{}
+		out.paths = append(out.paths, word)
+	}
 	for _, raw := range exploreArtifactPathRE.FindAllString(task, -1) {
 		addPath(raw)
 	}
@@ -80,14 +99,15 @@ func classifyExploreArtifactIntent(task string) exploreArtifactIntent {
 	out.explicitCount = len(out.paths)
 
 	artifactScore, sourceScore := 0, 0
-	for _, word := range exploreArtifactWords(task) {
+	semanticPaths := make([]string, 0, 8)
+	seenSemantic := make(map[string]struct{})
+	for _, rawWord := range exploreArtifactWords(task) {
+		word := canonicalExploreArtifactWord(rawWord)
 		if exploreArtifactWord(word) {
 			artifactScore++
-			if exploreArtifactPathWord(word) && len(out.paths) < exploreArtifactPathLimit {
-				if _, ok := seen[word]; !ok {
-					seen[word] = struct{}{}
-					out.paths = append(out.paths, word)
-				}
+			if _, ok := seenSemantic[word]; !ok {
+				seenSemantic[word] = struct{}{}
+				semanticPaths = append(semanticPaths, word)
 			}
 		}
 		if exploreSourceWord(word) {
@@ -103,24 +123,157 @@ func classifyExploreArtifactIntent(task string) exploreArtifactIntent {
 		sourceScore += 2
 	}
 	out.semantic = artifactScore >= 2
-	for _, raw := range exploreArtifactProbeRE.FindAllString(task, -1) {
-		probe := strings.TrimSpace(strings.Trim(raw, "`'\""))
-		probe = strings.TrimSpace(probe)
-		if len(probe) < 2 || exploreArtifactFile(probe) || strings.EqualFold(probe, "CI") {
+	for _, word := range semanticPaths {
+		if exploreArtifactPathWord(word) {
+			addSemanticPath(word)
+		}
+	}
+	out.probes = rankedExploreArtifactProbes(task, seen)
+	// "build configuration" alone is too broad to scan every artifact file.
+	// Build becomes a secondary filename family only after an explicit artifact,
+	// another semantic path family, or a distinctive content probe activates a
+	// genuinely searchable lane. Environment/property probes such as TF_BUILD
+	// also carry that family even though their separators are intentionally kept
+	// intact by exploreArtifactWords.
+	_, buildMentioned := seenSemantic["build"]
+	for _, probe := range out.probes {
+		for _, word := range strings.FieldsFunc(probe, func(r rune) bool {
+			return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+		}) {
+			if strings.EqualFold(word, "build") {
+				buildMentioned = true
+				break
+			}
+		}
+	}
+	if buildMentioned && (out.explicitCount > 0 || len(out.paths) > 0 || len(out.probes) > 0) {
+		addSemanticPath("build")
+	}
+	// A model may faithfully ask for both "source/configuration files" and
+	// "precise symbols" even when the supplied anchors are overwhelmingly
+	// artifact-shaped. Do not let those incidental source nouns veto a lane
+	// corroborated by at least three artifact terms and two distinctive probes.
+	// The thresholds keep ordinary config-parser and settings-class tasks on the
+	// source path.
+	strongSemanticEvidence := out.semantic && artifactScore >= 3 && len(out.probes) >= 2
+	artifactEligible := out.explicitCount > 0 || (out.semantic && (sourceScore == 0 || strongSemanticEvidence))
+	out.active = artifactEligible && (len(out.paths) > 0 || len(out.probes) > 0)
+	return out
+}
+
+func canonicalExploreArtifactWord(word string) string {
+	switch strings.ToLower(word) {
+	case "artifacts":
+		return "artifact"
+	case "deployments":
+		return "deployment"
+	case "pipelines":
+		return "pipeline"
+	case "releases":
+		return "release"
+	case "settings":
+		return "setting"
+	case "workflows":
+		return "workflow"
+	default:
+		return strings.ToLower(word)
+	}
+}
+
+func rankedExploreArtifactProbes(task string, seen map[string]struct{}) []string {
+	candidates := make(map[string]exploreArtifactProbeCandidate)
+	add := func(value string, priority, order int) {
+		value = strings.TrimSpace(strings.Trim(value, "`'\""))
+		if len(value) < 2 || exploreArtifactFile(value) || strings.EqualFold(value, "CI") {
+			return
+		}
+		key := strings.ToLower(value)
+		if _, exists := seen[key]; exists {
+			return
+		}
+		candidate := exploreArtifactProbeCandidate{value: value, priority: priority, order: order}
+		if current, exists := candidates[key]; exists &&
+			(current.priority > candidate.priority || (current.priority == candidate.priority && current.order <= candidate.order)) {
+			return
+		}
+		candidates[key] = candidate
+	}
+	for _, match := range exploreArtifactPropertyRE.FindAllStringSubmatchIndex(task, -1) {
+		if len(match) >= 4 && match[2] >= 0 {
+			add(task[match[2]:match[3]], 500, match[2])
+		}
+	}
+	for _, match := range exploreArtifactAssignmentRE.FindAllStringSubmatchIndex(task, -1) {
+		if len(match) < 4 || match[2] < 0 {
 			continue
 		}
-		key := strings.ToLower(probe)
-		if _, ok := seen[key]; ok {
-			continue
+		value := task[match[2]:match[3]]
+		priority := 220
+		if exploreArtifactEnvironmentProbe(value) {
+			priority = 450
+		} else if exploreArtifactCamelProbe(value) {
+			priority = 400
 		}
+		add(value, priority, match[2])
+	}
+	for _, match := range exploreArtifactProbeRE.FindAllStringIndex(task, -1) {
+		raw := task[match[0]:match[1]]
+		trimmed := strings.TrimSpace(raw)
+		priority := 100
+		switch {
+		case strings.HasPrefix(trimmed, "`") || strings.HasPrefix(trimmed, "\"") || strings.HasPrefix(trimmed, "'"):
+			priority = 350
+		case strings.HasPrefix(trimmed, "-"):
+			priority = 300
+		case exploreArtifactEnvironmentProbe(trimmed):
+			priority = 425
+		}
+		add(trimmed, priority, match[0])
+	}
+	ordered := make([]exploreArtifactProbeCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		ordered = append(ordered, candidate)
+	}
+	sort.Slice(ordered, func(i, j int) bool {
+		if ordered[i].priority != ordered[j].priority {
+			return ordered[i].priority > ordered[j].priority
+		}
+		if ordered[i].order != ordered[j].order {
+			return ordered[i].order < ordered[j].order
+		}
+		return ordered[i].value < ordered[j].value
+	})
+	out := make([]string, 0, exploreArtifactProbeLimit)
+	for _, candidate := range ordered {
+		key := strings.ToLower(candidate.value)
 		seen[key] = struct{}{}
-		out.probes = append(out.probes, probe)
-		if len(out.probes) == exploreArtifactProbeLimit {
+		out = append(out, candidate.value)
+		if len(out) == exploreArtifactProbeLimit {
 			break
 		}
 	}
-	out.active = (out.explicitCount > 0 || (sourceScore == 0 && out.semantic)) && (len(out.paths) > 0 || len(out.probes) > 0)
 	return out
+}
+
+func exploreArtifactEnvironmentProbe(value string) bool {
+	if !strings.Contains(value, "_") {
+		return false
+	}
+	for _, r := range value {
+		if unicode.IsLower(r) || (!unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_') {
+			return false
+		}
+	}
+	return true
+}
+
+func exploreArtifactCamelProbe(value string) bool {
+	hasLower, hasUpper := false, false
+	for _, r := range value {
+		hasLower = hasLower || unicode.IsLower(r)
+		hasUpper = hasUpper || unicode.IsUpper(r)
+	}
+	return hasLower && hasUpper
 }
 
 const (
@@ -150,6 +303,30 @@ func exploreArtifactPathWord(word string) bool { return exploreInSet(exploreArti
 func exploreSourceWord(word string) bool       { return exploreInSet(exploreSourceWordsSet, word) }
 func exploreSourceExtension(ext string) bool   { return exploreInSet(exploreSourceExtsSet, ext) }
 
+const exploreArtifactToolMetadataRoots = "|.claude|.codegraph|.codex|.flow|.gitnexus|.graphify|.serena|graphify-out|"
+
+func exploreArtifactPathEligible(intent exploreArtifactIntent, path string) bool {
+	normalized := strings.TrimPrefix(strings.ReplaceAll(strings.TrimSpace(path), "\\", "/"), "./")
+	root, _, _ := strings.Cut(normalized, "/")
+	if !exploreInSet(exploreArtifactToolMetadataRoots, root) {
+		return true
+	}
+	// Tool/session metadata is not implementation evidence merely because it
+	// repeats issue vocabulary. It remains searchable when the task names that
+	// path or basename explicitly, which preserves real configuration work.
+	for index, explicit := range intent.paths {
+		if index >= intent.explicitCount {
+			break
+		}
+		explicit = strings.TrimPrefix(strings.ReplaceAll(strings.TrimSpace(explicit), "\\", "/"), "./")
+		if strings.EqualFold(explicit, normalized) ||
+			(!strings.Contains(explicit, "/") && strings.EqualFold(filepath.Base(explicit), filepath.Base(normalized))) {
+			return true
+		}
+	}
+	return false
+}
+
 // gatherExploreArtifactLane reuses search(files)' graph file nodes and
 // search(text)'s trigram backend. The inactive path returns before either I/O.
 func (s *Server) gatherExploreArtifactLane(ctx context.Context, intent exploreArtifactIntent, scope query.QueryOptions) exploreArtifactLane {
@@ -163,6 +340,9 @@ func (s *Server) gatherExploreArtifactLane(ctx context.Context, intent exploreAr
 			continue
 		}
 		rel := repoRelativePath(node)
+		if !exploreArtifactPathEligible(intent, rel) {
+			continue
+		}
 		hit := &exploreArtifactHit{file: node, path: rel}
 		files = append(files, hit)
 		key := strings.ToLower(strings.ReplaceAll(rel, "\\", "/"))
@@ -171,38 +351,7 @@ func (s *Server) gatherExploreArtifactLane(ctx context.Context, intent exploreAr
 			byPath[strings.ToLower(node.RepoPrefix)+"/"+key] = hit
 		}
 	}
-	exactBasenames := make(map[string]int)
-	for _, hit := range files {
-		for i, term := range intent.paths {
-			score, ok := scoreFilenameMatch(term, filepath.Base(hit.path), hit.path, false)
-			if !ok {
-				continue
-			}
-			hit.pathHit = true
-			hit.score += score
-			if i >= intent.explicitCount {
-				continue
-			}
-			normalizedTerm := strings.TrimPrefix(strings.ReplaceAll(term, "\\", "/"), "./")
-			normalizedHit := strings.TrimPrefix(strings.ReplaceAll(hit.path, "\\", "/"), "./")
-			switch {
-			case strings.Contains(normalizedTerm, "/") && strings.EqualFold(normalizedTerm, normalizedHit):
-				hit.fullPath = true
-				hit.score += 20
-			case strings.EqualFold(filepath.Base(term), filepath.Base(hit.path)):
-				hit.exactBase = strings.ToLower(filepath.Base(term))
-				exactBasenames[hit.exactBase]++
-				hit.score += 20
-			}
-		}
-	}
-	for _, hit := range files {
-		hit.uniqueBase = hit.exactBase != "" && exactBasenames[hit.exactBase] == 1
-	}
-	sort.Slice(files, func(i, j int) bool { return files[i].score > files[j].score })
-	if len(files) > exploreArtifactPathLimit {
-		files = files[:exploreArtifactPathLimit]
-	}
+	files = rankExploreArtifactPathHits(files, intent)
 	kept := make(map[*graph.Node]*exploreArtifactHit, len(files))
 	for _, hit := range files {
 		if hit.pathHit {
@@ -227,8 +376,10 @@ func (s *Server) gatherExploreArtifactLane(ctx context.Context, intent exploreAr
 			if hit == nil || !exploreArtifactFile(hit.path) {
 				continue
 			}
+			if !hit.contentHit {
+				hit.score += 5
+			}
 			hit.contentHit = true
-			hit.score += 5
 			hit.declaration = match.SymbolID
 			if hit.snippet == "" {
 				hit.snippet = truncateExploreArtifactSnippet(match.Text)
@@ -240,15 +391,7 @@ func (s *Server) gatherExploreArtifactLane(ctx context.Context, intent exploreAr
 	for _, hit := range kept {
 		results = append(results, hit)
 	}
-	sort.SliceStable(results, func(i, j int) bool {
-		if results[i].score != results[j].score {
-			return results[i].score > results[j].score
-		}
-		return results[i].path < results[j].path
-	})
-	if len(results) > exploreArtifactResultLimit {
-		results = results[:exploreArtifactResultLimit]
-	}
+	results = selectExploreArtifactResults(results, exploreArtifactResultLimit)
 	ids := make([]string, 0, len(results))
 	for _, hit := range results {
 		if hit.declaration != "" {
@@ -272,6 +415,102 @@ func (s *Server) gatherExploreArtifactLane(ctx context.Context, intent exploreAr
 		lane.ready = exploreArtifactTerminal(intent, results[0], runnerUp)
 	}
 	return lane
+}
+
+func rankExploreArtifactPathHits(files []*exploreArtifactHit, intent exploreArtifactIntent) []*exploreArtifactHit {
+	exactBasenames := make(map[string]int)
+	for _, hit := range files {
+		if hit == nil {
+			continue
+		}
+		explicitScore, semanticScore, explicitBonus := 0, 0, 0
+		for i, term := range intent.paths {
+			score, ok := scoreFilenameMatch(term, filepath.Base(hit.path), hit.path, false)
+			if !ok {
+				continue
+			}
+			hit.pathHit = true
+			if i >= intent.explicitCount {
+				if score > semanticScore {
+					semanticScore = score
+				}
+				continue
+			}
+			if score > explicitScore {
+				explicitScore = score
+			}
+			normalizedTerm := strings.TrimPrefix(strings.ReplaceAll(term, "\\", "/"), "./")
+			normalizedHit := strings.TrimPrefix(strings.ReplaceAll(hit.path, "\\", "/"), "./")
+			switch {
+			case strings.Contains(normalizedTerm, "/") && strings.EqualFold(normalizedTerm, normalizedHit):
+				hit.fullPath = true
+				explicitBonus = 20
+			case strings.EqualFold(filepath.Base(term), filepath.Base(hit.path)):
+				hit.exactBase = strings.ToLower(filepath.Base(term))
+				exactBasenames[hit.exactBase]++
+				explicitBonus = 20
+			}
+		}
+		hit.score += explicitScore + semanticScore + explicitBonus
+	}
+	for _, hit := range files {
+		if hit != nil {
+			hit.uniqueBase = hit.exactBase != "" && exactBasenames[hit.exactBase] == 1
+		}
+	}
+	sort.SliceStable(files, func(i, j int) bool { return exploreArtifactHitLess(files[i], files[j]) })
+	if len(files) > exploreArtifactPathLimit {
+		files = files[:exploreArtifactPathLimit]
+	}
+	return files
+}
+
+func selectExploreArtifactResults(results []*exploreArtifactHit, limit int) []*exploreArtifactHit {
+	sort.SliceStable(results, func(i, j int) bool { return exploreArtifactHitLess(results[i], results[j]) })
+	if limit <= 0 || len(results) <= limit {
+		return results
+	}
+	selected := make([]*exploreArtifactHit, 0, limit)
+	deferred := make([]*exploreArtifactHit, 0)
+	exactBaseCounts := make(map[string]int)
+	for _, hit := range results {
+		if hit == nil {
+			continue
+		}
+		if hit.exactBase != "" && !hit.fullPath && exactBaseCounts[hit.exactBase] >= 2 {
+			deferred = append(deferred, hit)
+			continue
+		}
+		selected = append(selected, hit)
+		if hit.exactBase != "" {
+			exactBaseCounts[hit.exactBase]++
+		}
+		if len(selected) == limit {
+			return selected
+		}
+	}
+	for _, hit := range deferred {
+		selected = append(selected, hit)
+		if len(selected) == limit {
+			break
+		}
+	}
+	return selected
+}
+
+func exploreArtifactHitLess(left, right *exploreArtifactHit) bool {
+	if left == nil || right == nil {
+		return right == nil && left != nil
+	}
+	if left.score != right.score {
+		return left.score > right.score
+	}
+	leftDepth := strings.Count(strings.Trim(strings.ReplaceAll(left.path, "\\", "/"), "/"), "/")
+	rightDepth := strings.Count(strings.Trim(strings.ReplaceAll(right.path, "\\", "/"), "/"), "/")
+	if leftDepth != rightDepth {
+		return leftDepth < rightDepth
+	}
+	return left.path < right.path
 }
 
 func truncateExploreArtifactSnippet(snippet string) string {

--- a/internal/mcp/explore_artifact_intent_test.go
+++ b/internal/mcp/explore_artifact_intent_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -41,11 +42,74 @@ func TestClassifyExploreArtifactIntentUsesIndependentSignals(t *testing.T) {
 	if !got.active || got.explicitCount != 0 || !got.semantic {
 		t.Fatalf("intent=%#v", got)
 	}
-	if len(got.probes) != exploreArtifactProbeLimit || got.probes[0] != "CollectCoverage" || got.probes[1] != "COVERAGE_FORMAT" {
+	if len(got.probes) != exploreArtifactProbeLimit || !containsFold(got.probes, "CollectCoverage") || !containsFold(got.probes, "COVERAGE_FORMAT") {
 		t.Fatalf("probes=%q", got.probes)
 	}
 	if len(got.paths) == 0 { // semantic filename channel (ci/coverage)
 		t.Fatal("semantic artifact terms must seed the independent path channel")
+	}
+}
+
+func TestClassifyExploreArtifactIntentRanksDistinctiveBuildSignals(t *testing.T) {
+	t.Parallel()
+	task := "LOCALIZE ONLY: testconfig.json settings differ across Pipelines and CI coverage. MTP is enabled, TF_BUILD is true, and /p:EmitCompilerGeneratedFiles=true."
+	got := classifyExploreArtifactIntent(task)
+	if !got.active || !containsFold(got.paths, "pipeline") || !containsFold(got.paths, "build") {
+		t.Fatalf("intent=%#v", got)
+	}
+	if len(got.probes) != exploreArtifactProbeLimit || got.probes[0] != "EmitCompilerGeneratedFiles" || got.probes[1] != "TF_BUILD" {
+		t.Fatalf("distinctive probes lost to directive words: %q", got.probes)
+	}
+}
+
+func TestRankExploreArtifactHitsPreservesIndependentRootLeads(t *testing.T) {
+	t.Parallel()
+	intent := classifyExploreArtifactIntent("testconfig.json differs across Pipelines and CI coverage; TF_BUILD is true and /p:EmitCompilerGeneratedFiles=true")
+	paths := []string{
+		"tests/a/testconfig.json", "tests/b/testconfig.json", "tests/c/testconfig.json",
+		"tests/d/testconfig.json", "tests/e/testconfig.json", "tests/f/testconfig.json",
+		"Directory.Build.props", "azure-pipelines.yml",
+		".flow/checkpoints/fix-build-ci-code-coverage.json",
+		".flow/fix-ci-code-coverage.json",
+	}
+	hits := make([]*exploreArtifactHit, 0, len(paths))
+	for _, path := range paths {
+		hits = append(hits, &exploreArtifactHit{path: path})
+	}
+	ranked := rankExploreArtifactPathHits(hits, intent)
+	for _, hit := range ranked {
+		if hit.path == "Directory.Build.props" {
+			hit.contentHit = true
+			hit.score += 5
+		}
+		if strings.HasPrefix(hit.path, ".flow/") && hit.score > 50 {
+			t.Fatalf("semantic term stuffing accumulated score for %s: %d", hit.path, hit.score)
+		}
+	}
+	selected := selectExploreArtifactResults(ranked, exploreArtifactResultLimit)
+	if !artifactHitsContainPath(selected, "Directory.Build.props") || !artifactHitsContainPath(selected, "azure-pipelines.yml") {
+		t.Fatalf("independent root leads were starved: %#v", selected)
+	}
+	duplicates := 0
+	for _, hit := range selected {
+		if strings.EqualFold(filepath.Base(hit.path), "testconfig.json") {
+			duplicates++
+		}
+	}
+	if duplicates > 2 {
+		t.Fatalf("repeated basename consumed %d result slots", duplicates)
+	}
+}
+
+func TestClassifyExploreArtifactIntentAcceptsStrongArtifactTaskWithIncidentalSourceNouns(t *testing.T) {
+	t.Parallel()
+	task := "Localize bug report “Simplify CI code coverage configuration”. Identify the source/configuration files and precise symbols that would need changing to reduce/centralize the current Microsoft.Testing.Platform (MTP) code coverage settings (DeterministicReport=true, ExcludeAssembliesWithoutSources=None, ModulePaths.Include limiting coverage to Humanizer/Humanizer.Analyzers/Humanizer.SourceGenerators) and Azure Pipelines invocation settings (/p:EmitCompilerGeneratedFiles=true; ReportGenerator sourcedirs=$(Build.SourcesDirectory) and settings:rawMode=false while merging per-test-project Cobertura files). Preserve all user identifiers. Do not fix."
+	got := classifyExploreArtifactIntent(task)
+	if !got.active || !got.semantic || len(got.probes) < 2 {
+		t.Fatalf("strong mixed artifact intent was vetoed: %#v", got)
+	}
+	if !containsFold(got.probes, "DeterministicReport") || !containsFold(got.probes, "ExcludeAssembliesWithoutSources") {
+		t.Fatalf("distinctive artifact probes were not retained: %q", got.probes)
 	}
 }
 
@@ -163,6 +227,47 @@ func TestExploreArtifactFileRecognition(t *testing.T) {
 			t.Errorf("%q recognized as artifact", path)
 		}
 	}
+}
+
+func TestExploreArtifactPathEligibleFiltersImplicitToolMetadata(t *testing.T) {
+	t.Parallel()
+	implicit := classifyExploreArtifactIntent("Simplify CI code coverage configuration using testconfig.json and ReportGenerator")
+	for _, path := range []string{
+		".codex/agents/build-scout.toml",
+		".flow/.checkpoint-fix-ci-code-coverage.json",
+		".gitnexus/cache/coverage.json",
+	} {
+		if exploreArtifactPathEligible(implicit, path) {
+			t.Errorf("implicit tool metadata %q is eligible", path)
+		}
+	}
+	for _, path := range []string{"Directory.Build.props", "azure-pipelines.yml", ".github/workflows/ci.yml"} {
+		if !exploreArtifactPathEligible(implicit, path) {
+			t.Errorf("repository artifact %q was filtered", path)
+		}
+	}
+	explicit := classifyExploreArtifactIntent("Change .codex/agents/build-scout.toml build configuration")
+	if !exploreArtifactPathEligible(explicit, ".codex/agents/build-scout.toml") {
+		t.Fatal("an explicitly named tool configuration must remain eligible")
+	}
+}
+
+func containsFold(values []string, want string) bool {
+	for _, value := range values {
+		if strings.EqualFold(value, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func artifactHitsContainPath(hits []*exploreArtifactHit, want string) bool {
+	for _, hit := range hits {
+		if hit != nil && strings.EqualFold(hit.path, want) {
+			return true
+		}
+	}
+	return false
 }
 
 func queryOptionsForArtifactTest() query.QueryOptions { return query.QueryOptions{} }

--- a/internal/mcp/explore_causal_change.go
+++ b/internal/mcp/explore_causal_change.go
@@ -1,0 +1,652 @@
+package mcp
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+const (
+	exploreCausalChangeFileNodeCap     = 96
+	exploreCausalConsumerSeedLimit     = 5
+	exploreCausalConsumerDepth         = 3
+	exploreCausalConsumerFrontierCap   = 24
+	exploreCausalConsumerNodeFanoutCap = 8
+)
+
+type exploreCausalChangeCandidate struct {
+	node         *graph.Node
+	continuation *graph.Node
+	parentID     string
+	parentRank   int
+	direction    string
+	hop          int
+	delegated    bool
+	consumer     bool
+	crossFile    bool
+	overlap      int
+	longest      int
+}
+
+type exploreCausalChangeHydrator func(*graph.Node) ([]*graph.Node, bool)
+
+// promoteExploreCausalChangeTargets reserves one graph-proven change site
+// before localization packing. It starts only from hydrated, task-aligned
+// production callables and follows their already-bounded direct relations or
+// depth-two callee projection. This makes a wrapper's implementation and a
+// task-aligned cross-file caller/callee compete on causality instead of raw
+// keyword rank.
+//
+// When the promoted callable crosses a file boundary, one same-file owning
+// type is admitted as well. A uniquely returned type wins over the callable's
+// enclosing type because it owns the state constructed by builder/factory
+// methods; otherwise the enclosing type is the natural change owner. The lane
+// never scans a repository, reads at most one source body, and replaces only
+// unprotected retrieval-tail rows.
+func promoteExploreCausalChangeTargets(
+	task string,
+	targets []exploreTarget,
+	store graph.Store,
+	maxSymbols int,
+	readSource func(*graph.Node) string,
+	hydrateBridges ...exploreCausalChangeHydrator,
+) []exploreTarget {
+	if len(targets) == 0 || !exploreQueryIsConceptTask(task) {
+		return targets
+	}
+	var hydrateBridge exploreCausalChangeHydrator
+	if len(hydrateBridges) > 0 {
+		hydrateBridge = hydrateBridges[0]
+	}
+	candidate, ok := selectExploreCausalChangeTargetWithConsumers(task, targets, store)
+	if !ok {
+		return targets
+	}
+
+	bridge, bridgePresent := exploreTargetByID(targets, candidate.node.ID)
+	bridge.node = candidate.node
+	bridge.causalChangeBridge = true
+	bridge.causalChangeLeaf = false
+	if candidate.hop == 1 && (candidate.direction == "caller" || candidate.direction == "callee") {
+		bridge.localizationRelation = "direct_" + candidate.direction
+	}
+	if strings.TrimSpace(bridge.source) == "" && readSource != nil {
+		bridge.source = readSource(candidate.node)
+	}
+	if !bridge.directCalleesComplete && hydrateBridge != nil {
+		bridge.callees, bridge.directCalleesComplete = hydrateBridge(candidate.node)
+	}
+
+	leaf := bridge
+	leafPresent := bridgePresent
+	bridgeNeeded := false
+	if continuation := selectExploreCausalContinuation(task, bridge, candidate.continuation); continuation != nil {
+		leaf, leafPresent = exploreTargetByID(targets, continuation.ID)
+		leaf.node = continuation
+		leaf.causalChangeBridge = false
+		leaf.causalChangeLeaf = true
+		leaf.localizationRelation = "direct_callee"
+		bridgeNeeded = true
+	} else {
+		leaf.causalChangeBridge = false
+		leaf.causalChangeLeaf = true
+	}
+
+	var owner exploreTarget
+	ownerPresent := false
+	if candidate.crossFile {
+		if node := exploreCausalChangeOwner(task, candidate.node, store); node != nil {
+			owner, ownerPresent = exploreTargetByID(targets, node.ID)
+			owner.node = node
+			owner.causalChangeOwner = true
+		}
+	}
+
+	missing := 0
+	if bridgeNeeded && !bridgePresent {
+		missing++
+	}
+	if !leafPresent {
+		missing++
+	}
+	if owner.node != nil && !ownerPresent {
+		missing++
+	}
+	if maxSymbols <= 0 {
+		maxSymbols = len(targets)
+	}
+	overflow := len(targets) + missing - maxSymbols
+	if overflow < 0 {
+		overflow = 0
+	}
+
+	evict := make(map[int]struct{}, overflow)
+	for index := len(targets) - 1; index >= 0 && len(evict) < overflow; index-- {
+		if exploreCausalChangeAdmissionProtected(task, targets, index, candidate.parentID) {
+			continue
+		}
+		evict[index] = struct{}{}
+	}
+	if len(evict) != overflow {
+		return targets
+	}
+
+	promoted := make([]exploreTarget, 0, len(targets)-len(evict)+missing)
+	for index, target := range targets {
+		if _, drop := evict[index]; drop {
+			continue
+		}
+		switch {
+		case target.node != nil && target.node.ID == leaf.node.ID:
+			promoted = append(promoted, leaf)
+		case bridgeNeeded && target.node != nil && target.node.ID == bridge.node.ID:
+			promoted = append(promoted, bridge)
+		case owner.node != nil && target.node != nil && target.node.ID == owner.node.ID:
+			promoted = append(promoted, owner)
+		default:
+			promoted = append(promoted, target)
+		}
+	}
+	if bridgeNeeded && !bridgePresent {
+		promoted = append(promoted, bridge)
+	}
+	if !leafPresent {
+		promoted = append(promoted, leaf)
+	}
+	if owner.node != nil && !ownerPresent {
+		promoted = append(promoted, owner)
+	}
+	return promoted
+}
+
+type exploreCausalContinuationMetric struct {
+	node      *graph.Node
+	hinted    bool
+	delegated bool
+	sameOwner bool
+	compound  bool
+	overlap   int
+	mentions  int
+	segments  int
+	shared    int
+	longest   int
+}
+
+func selectExploreCausalContinuation(task string, bridge exploreTarget, hinted *graph.Node) *graph.Node {
+	if bridge.node == nil || !bridge.directCalleesComplete || len(bridge.callees) == 0 {
+		return nil
+	}
+	query := shapeExploreQuery(task)
+	if exploreQueryIsConceptTask(query) {
+		query = stripLeadingExploreDirective(query)
+	}
+	terms := exploreTerminalTerms(query)
+	seen := make(map[string]struct{}, len(bridge.callees))
+	var best exploreCausalContinuationMetric
+	tied := false
+	compare := func(left, right exploreCausalContinuationMetric) int {
+		boolCompare := func(a, b bool) int {
+			switch {
+			case a && !b:
+				return 1
+			case !a && b:
+				return -1
+			default:
+				return 0
+			}
+		}
+		for _, pair := range [][2]bool{
+			{left.hinted, right.hinted},
+			{left.delegated, right.delegated},
+			{left.sameOwner, right.sameOwner},
+			{left.compound, right.compound},
+		} {
+			if order := boolCompare(pair[0], pair[1]); order != 0 {
+				return order
+			}
+		}
+		for _, pair := range [][2]int{
+			{left.overlap, right.overlap},
+			{left.mentions, right.mentions},
+			{left.segments, right.segments},
+			{left.shared, right.shared},
+			{left.longest, right.longest},
+		} {
+			if pair[0] > pair[1] {
+				return 1
+			}
+			if pair[0] < pair[1] {
+				return -1
+			}
+		}
+		return 0
+	}
+
+	bridgePath := exploreNormalizedPath(nodeDisplayPath(bridge.node))
+	for _, node := range bridge.callees {
+		if node == nil || node.ID == "" || node.ID == bridge.node.ID ||
+			(node.Kind != graph.KindFunction && node.Kind != graph.KindMethod) ||
+			exploreDraftIsTestNode(node) || !exploreNodesShareExactScope(bridge.node, node) {
+			continue
+		}
+		if _, duplicate := seen[node.ID]; duplicate {
+			continue
+		}
+		seen[node.ID] = struct{}{}
+		sameOwner := exploreSameCallableOwner(bridge.node, node)
+		sameFile := bridgePath != "" && bridgePath == exploreNormalizedPath(nodeDisplayPath(node))
+		if !sameOwner && !sameFile {
+			continue
+		}
+		delegated := exploreDelegatedImplementationCallee(bridge.node, node)
+		mentions := exploreBodyIdentifierMentions(bridge.source, node.Name)
+		if !delegated && mentions == 0 {
+			continue
+		}
+		overlap, longest := exploreDraftTermOverlap(terms, node)
+		shared, _ := exploreStructuralSignals(bridge.node, node)
+		segments := exploreIdentifierSegmentCount(node.Name)
+		metric := exploreCausalContinuationMetric{
+			node: node, hinted: hinted != nil && hinted.ID == node.ID,
+			delegated: delegated, sameOwner: sameOwner, compound: segments >= 2,
+			overlap: overlap, mentions: mentions, segments: segments,
+			shared: shared, longest: longest,
+		}
+		if best.node == nil {
+			best, tied = metric, false
+			continue
+		}
+		switch compare(metric, best) {
+		case 1:
+			best, tied = metric, false
+		case 0:
+			tied = true
+		}
+	}
+	if best.node == nil || tied {
+		return nil
+	}
+	return best.node
+}
+
+func selectExploreCausalChangeTargetWithConsumers(
+	task string,
+	targets []exploreTarget,
+	store graph.Store,
+) (exploreCausalChangeCandidate, bool) {
+	direct, directOK := selectExploreCausalChangeTarget(task, targets)
+	consumer, consumerOK := selectExploreCausalConsumerTarget(task, targets, store)
+	switch {
+	case !consumerOK:
+		return direct, directOK
+	case !directOK || exploreCausalChangeLess(consumer, direct):
+		return consumer, true
+	default:
+		return direct, true
+	}
+}
+
+// selectExploreCausalConsumerTarget fills one missing implementation slot by
+// following reverse call edges from the bounded ranked head. It collapses only
+// same-file wrappers and admits only a task-aligned production callable in a
+// directory already represented by the evidence page. That directory join is
+// the proof that a cross-file caller connects two retrieved feature families;
+// it prevents a generic high-fanout caller walk from becoming another broad
+// search channel.
+func selectExploreCausalConsumerTarget(
+	task string,
+	targets []exploreTarget,
+	store graph.Store,
+) (exploreCausalChangeCandidate, bool) {
+	if store == nil || len(targets) == 0 {
+		return exploreCausalChangeCandidate{}, false
+	}
+	terms := exploreTerminalTerms(shapeExploreQuery(task))
+	if len(terms) == 0 {
+		return exploreCausalChangeCandidate{}, false
+	}
+	targetIDs := make(map[string]struct{}, len(targets))
+	targetDirectories := make(map[string]struct{}, len(targets))
+	for _, target := range targets {
+		if target.node == nil || target.node.ID == "" {
+			continue
+		}
+		targetIDs[target.node.ID] = struct{}{}
+		if directory := exploreCausalChangeDirectory(target.node); directory != "" {
+			targetDirectories[directory] = struct{}{}
+		}
+	}
+	if len(targetDirectories) == 0 {
+		return exploreCausalChangeCandidate{}, false
+	}
+
+	byID := make(map[string]exploreCausalChangeCandidate)
+	seedLimit := min(len(targets), exploreCausalConsumerSeedLimit)
+	for parentRank := 0; parentRank < seedLimit; parentRank++ {
+		seed := targets[parentRank]
+		if seed.node == nil || seed.node.ID == "" ||
+			(seed.node.Kind != graph.KindFunction && seed.node.Kind != graph.KindMethod) ||
+			exploreDraftIsTestNode(seed.node) {
+			continue
+		}
+		seedPath := exploreNormalizedPath(nodeDisplayPath(seed.node))
+		if seedPath == "" {
+			continue
+		}
+		expanded := make(map[string]struct{}, exploreCausalConsumerFrontierCap)
+		frontier := make([]*graph.Node, 0, 1+len(seed.callees))
+		appendFrontier := func(node *graph.Node) {
+			if node == nil || node.ID == "" || !exploreNodesShareExactScope(seed.node, node) {
+				return
+			}
+			if _, exists := expanded[node.ID]; exists {
+				return
+			}
+			expanded[node.ID] = struct{}{}
+			frontier = append(frontier, node)
+		}
+		appendFrontier(seed.node)
+		for _, callee := range seed.callees {
+			appendFrontier(callee)
+		}
+
+		for depth := 1; depth <= exploreCausalConsumerDepth && len(frontier) > 0; depth++ {
+			sort.SliceStable(frontier, func(i, j int) bool { return frontier[i].ID < frontier[j].ID })
+			if len(frontier) > exploreCausalConsumerFrontierCap {
+				frontier = frontier[:exploreCausalConsumerFrontierCap]
+			}
+			ids := make([]string, len(frontier))
+			for index, node := range frontier {
+				ids[index] = node.ID
+			}
+			incoming := store.GetInEdgesByNodeIDs(ids)
+			callerSet := make(map[string]struct{}, exploreCausalConsumerFrontierCap)
+			for _, id := range ids {
+				local := make(map[string]struct{}, exploreCausalConsumerNodeFanoutCap+1)
+				for _, edge := range incoming[id] {
+					if edge == nil || edge.Kind != graph.EdgeCalls || edge.From == "" {
+						continue
+					}
+					local[edge.From] = struct{}{}
+				}
+				if len(local) > exploreCausalConsumerNodeFanoutCap {
+					continue
+				}
+				for callerID := range local {
+					callerSet[callerID] = struct{}{}
+				}
+			}
+			callerIDs := make([]string, 0, len(callerSet))
+			for id := range callerSet {
+				callerIDs = append(callerIDs, id)
+			}
+			sort.Strings(callerIDs)
+			if len(callerIDs) > exploreCausalConsumerFrontierCap {
+				callerIDs = callerIDs[:exploreCausalConsumerFrontierCap]
+			}
+			nodes := store.GetNodesByIDs(callerIDs)
+			next := make([]*graph.Node, 0, len(callerIDs))
+			for _, callerID := range callerIDs {
+				if _, exists := expanded[callerID]; exists {
+					continue
+				}
+				node := nodes[callerID]
+				if node == nil || !exploreNodesShareExactScope(seed.node, node) ||
+					(node.Kind != graph.KindFunction && node.Kind != graph.KindMethod) ||
+					exploreDraftIsTestNode(node) {
+					continue
+				}
+				expanded[callerID] = struct{}{}
+				nodePath := exploreNormalizedPath(nodeDisplayPath(node))
+				if nodePath == seedPath {
+					next = append(next, node)
+				}
+				if nodePath == "" || nodePath == seedPath {
+					continue
+				}
+				if _, alreadyVisible := targetIDs[node.ID]; alreadyVisible {
+					continue
+				}
+				if _, represented := targetDirectories[exploreCausalChangeDirectory(node)]; !represented {
+					continue
+				}
+				overlap, longest := exploreDraftTermOverlap(terms, node)
+				if overlap < 2 && (overlap != 1 || longest < 5) {
+					continue
+				}
+				candidate := exploreCausalChangeCandidate{
+					node: node, parentID: seed.node.ID, parentRank: parentRank,
+					direction: "caller", hop: depth, consumer: true,
+					crossFile: true, overlap: overlap, longest: longest,
+				}
+				if current, exists := byID[node.ID]; !exists || exploreCausalChangeLess(candidate, current) {
+					byID[node.ID] = candidate
+				}
+			}
+			frontier = next
+		}
+	}
+	if len(byID) == 0 {
+		return exploreCausalChangeCandidate{}, false
+	}
+	candidates := make([]exploreCausalChangeCandidate, 0, len(byID))
+	for _, candidate := range byID {
+		candidates = append(candidates, candidate)
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return exploreCausalChangeLess(candidates[i], candidates[j])
+	})
+	best := candidates[0]
+	bestPath := exploreNormalizedPath(nodeDisplayPath(best.node))
+	for _, candidate := range candidates[1:] {
+		if candidate.overlap != best.overlap || candidate.longest != best.longest || candidate.hop != best.hop {
+			break
+		}
+		if exploreNormalizedPath(nodeDisplayPath(candidate.node)) != bestPath {
+			return exploreCausalChangeCandidate{}, false
+		}
+	}
+	return best, true
+}
+
+func exploreCausalChangeDirectory(node *graph.Node) string {
+	path := exploreNormalizedPath(nodeDisplayPath(node))
+	if index := strings.LastIndex(path, "/"); index > 0 {
+		return path[:index]
+	}
+	return ""
+}
+
+func selectExploreCausalChangeTarget(task string, targets []exploreTarget) (exploreCausalChangeCandidate, bool) {
+	query := shapeExploreQuery(task)
+	if exploreQueryIsConceptTask(query) {
+		query = stripLeadingExploreDirective(query)
+	}
+	terms := exploreTerminalTerms(query)
+	byID := make(map[string]exploreCausalChangeCandidate)
+	for parentRank, target := range targets {
+		if !exploreHydratedProductionCallable(target) || !exploreStrongCausalSeed(query, target) {
+			continue
+		}
+		continuationHint := func(bridge *graph.Node) *graph.Node {
+			var hinted *graph.Node
+			for _, neighbor := range target.causalCallees {
+				if neighbor.hop != 2 || neighbor.node == nil ||
+					!exploreNodesShareExactScope(bridge, neighbor.node) ||
+					!exploreDelegatedImplementationCallee(bridge, neighbor.node) {
+					continue
+				}
+				if hinted != nil && hinted.ID != neighbor.node.ID {
+					return nil
+				}
+				hinted = neighbor.node
+			}
+			return hinted
+		}
+		consider := func(node *graph.Node, continuation *graph.Node, direction string, hop int) {
+			if node == nil || node.ID == "" || node.ID == target.node.ID ||
+				(node.Kind != graph.KindFunction && node.Kind != graph.KindMethod) ||
+				exploreDraftIsTestNode(node) || !exploreNodesShareExactScope(target.node, node) {
+				return
+			}
+			delegated := continuation != nil || (direction == "callee" && hop == 1 &&
+				exploreDelegatedImplementationCallee(target.node, node))
+			crossFile := exploreNormalizedPath(nodeDisplayPath(target.node)) !=
+				exploreNormalizedPath(nodeDisplayPath(node))
+			overlap, longest := exploreDraftTermOverlap(terms, node)
+			if !delegated && (!crossFile || overlap == 0) {
+				return
+			}
+			candidate := exploreCausalChangeCandidate{
+				node: node, continuation: continuation,
+				parentID: target.node.ID, parentRank: parentRank,
+				direction: direction, hop: hop, delegated: delegated,
+				crossFile: crossFile, overlap: overlap, longest: longest,
+			}
+			if current, exists := byID[node.ID]; !exists || exploreCausalChangeLess(candidate, current) {
+				byID[node.ID] = candidate
+			}
+		}
+		for _, node := range target.callers {
+			consider(node, nil, "caller", 1)
+		}
+		for _, node := range target.callees {
+			consider(node, continuationHint(node), "callee", 1)
+		}
+		for _, neighbor := range target.causalCallees {
+			consider(neighbor.node, nil, "callee", neighbor.hop)
+		}
+	}
+	if len(byID) == 0 {
+		return exploreCausalChangeCandidate{}, false
+	}
+	candidates := make([]exploreCausalChangeCandidate, 0, len(byID))
+	for _, candidate := range byID {
+		candidates = append(candidates, candidate)
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return exploreCausalChangeLess(candidates[i], candidates[j])
+	})
+	return candidates[0], true
+}
+
+func exploreCausalChangeLess(left, right exploreCausalChangeCandidate) bool {
+	if left.delegated != right.delegated {
+		return left.delegated
+	}
+	if left.consumer != right.consumer {
+		return left.consumer
+	}
+	if left.overlap != right.overlap {
+		return left.overlap > right.overlap
+	}
+	if (left.direction == "caller") != (right.direction == "caller") {
+		return left.direction == "caller"
+	}
+	if left.crossFile != right.crossFile {
+		return left.crossFile
+	}
+	if left.longest != right.longest {
+		return left.longest > right.longest
+	}
+	if left.hop != right.hop {
+		return left.hop > right.hop
+	}
+	if left.parentRank != right.parentRank {
+		return left.parentRank < right.parentRank
+	}
+	return exploreDraftNodeKey(left.node) < exploreDraftNodeKey(right.node)
+}
+
+func exploreCausalChangeOwner(task string, leaf *graph.Node, store graph.Store) *graph.Node {
+	if leaf == nil || leaf.FilePath == "" || store == nil {
+		return nil
+	}
+	fileNodes := store.GetFileNodesByPaths([]string{leaf.FilePath})[leaf.FilePath]
+	if len(fileNodes) == 0 || len(fileNodes) > exploreCausalChangeFileNodeCap {
+		return nil
+	}
+	types := make([]*graph.Node, 0, 8)
+	for _, node := range fileNodes {
+		if node == nil || node.Kind != graph.KindType || exploreDraftIsTestNode(node) ||
+			!exploreNodesShareExactScope(leaf, node) {
+			continue
+		}
+		types = append(types, node)
+	}
+	if len(types) == 0 {
+		return nil
+	}
+	sort.SliceStable(types, func(i, j int) bool {
+		return exploreDraftNodeKey(types[i]) < exploreDraftNodeKey(types[j])
+	})
+
+	returnText := exploreCallableReturnText(leaf.RetrievalMetadata().Signature)
+	returned := make([]*graph.Node, 0, 2)
+	for _, node := range types {
+		if exploreContainsIdentifier(returnText, node.Name) {
+			returned = append(returned, node)
+		}
+	}
+	terms := exploreTerminalTerms(shapeExploreQuery(task))
+	if len(returned) == 1 {
+		if overlap, _ := exploreDraftTermOverlap(terms, returned[0]); overlap > 0 {
+			return returned[0]
+		}
+	}
+	if len(returned) > 1 {
+		var aligned *graph.Node
+		bestOverlap := 0
+		tied := false
+		for _, node := range returned {
+			overlap, _ := exploreDraftTermOverlap(terms, node)
+			switch {
+			case overlap > bestOverlap:
+				aligned, bestOverlap, tied = node, overlap, false
+			case overlap == bestOverlap && overlap > 0:
+				tied = true
+			}
+		}
+		if aligned != nil && !tied {
+			return aligned
+		}
+	}
+
+	ownerID, _ := graph.EnclosingFromID(leaf.ID, leaf.Kind)
+	for _, node := range types {
+		if node.ID == ownerID {
+			return node
+		}
+	}
+	return nil
+}
+
+func exploreCallableReturnText(signature string) string {
+	signature = strings.TrimSpace(signature)
+	open := strings.IndexByte(signature, '(')
+	if open < 0 {
+		return ""
+	}
+	close, ok := exploreMatchingParen(signature, open)
+	if !ok || close+1 >= len(signature) {
+		return ""
+	}
+	return strings.TrimSpace(signature[close+1:])
+}
+
+func exploreCausalChangeAdmissionProtected(task string, targets []exploreTarget, index int, parentID string) bool {
+	if index < 0 || index >= len(targets) {
+		return true
+	}
+	target := targets[index]
+	if target.node == nil || index < exploreDraftPrimaryLimit || target.node.ID == parentID {
+		return true
+	}
+	return target.causalChangeBridge || target.causalChangeLeaf || target.causalChangeOwner ||
+		target.divergentDefaultOwner || target.divergentDefaultType ||
+		target.conceptImplementation || target.conceptComplement ||
+		target.exactContent || target.exactContentAmbiguous ||
+		target.sourceLiteral || target.typedAnchorProjection ||
+		exploreLocalizationExplicitAnchor(task, target.node)
+}

--- a/internal/mcp/explore_causal_change_test.go
+++ b/internal/mcp/explore_causal_change_test.go
@@ -1,0 +1,377 @@
+package mcp
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func causalChangeTestNode(id, name, file string, kind graph.NodeKind, signature string) *graph.Node {
+	meta := map[string]any{}
+	if signature != "" {
+		meta["signature"] = signature
+	}
+	return &graph.Node{
+		ID: id, Name: name, QualName: name, Kind: kind, FilePath: file,
+		Language: "rust", RepoPrefix: "repo", WorkspaceID: "workspace", ProjectID: "project",
+		StartLine: 10, EndLine: 20, Meta: meta,
+	}
+}
+
+func causalChangeTargetIDs(targets []exploreTarget) []string {
+	ids := make([]string, 0, len(targets))
+	for _, target := range targets {
+		if target.node != nil {
+			ids = append(ids, target.node.ID)
+		}
+	}
+	return ids
+}
+
+func TestPromoteExploreCausalChangeTargetsReservesDelegatedLeaf(t *testing.T) {
+	wrapper := causalChangeTestNode(
+		"repo/router/tree.go::node.resolveCaseInsensitivePath",
+		"resolveCaseInsensitivePath", "router/tree.go", graph.KindMethod,
+		"func (n *node) resolveCaseInsensitivePath(path string) []byte",
+	)
+	leaf := causalChangeTestNode(
+		"repo/router/tree.go::node.resolveCaseInsensitivePathRec",
+		"resolveCaseInsensitivePathRec", "router/tree.go", graph.KindMethod,
+		"func (n *node) resolveCaseInsensitivePathRec(path string) []byte",
+	)
+	targets := []exploreTarget{
+		{node: wrapper, source: "func resolveCaseInsensitivePath(path string) []byte { return n.resolveCaseInsensitivePathRec(path) }", callees: []*graph.Node{leaf}},
+		{node: causalChangeTestNode("repo/router/engine.go::Engine.handle", "handle", "router/engine.go", graph.KindMethod, "func handle()")},
+		{node: causalChangeTestNode("repo/router/config.go::Config.redirect", "redirect", "router/config.go", graph.KindMethod, "func redirect()")},
+		{node: causalChangeTestNode("repo/router/log.go::logInvalidPath", "logInvalidPath", "router/log.go", graph.KindFunction, "func logInvalidPath()")},
+		{node: causalChangeTestNode("repo/router/errors.go::invalidNodeDiagnostic", "invalidNodeDiagnostic", "router/errors.go", graph.KindFunction, "func invalidNodeDiagnostic()")},
+	}
+	task := "Request execution panics during case insensitive path fallback instead of returning not found"
+	got := promoteExploreCausalChangeTargets(task, targets, nil, len(targets), func(node *graph.Node) string {
+		if node.ID == leaf.ID {
+			return "func resolveCaseInsensitivePathRec(path string) []byte { return nil }"
+		}
+		return ""
+	})
+
+	if len(got) != len(targets) {
+		t.Fatalf("promoted targets = %d, want fixed width %d", len(got), len(targets))
+	}
+	for index := 0; index < exploreDraftPrimaryLimit; index++ {
+		if got[index].node.ID != targets[index].node.ID {
+			t.Fatalf("direct head row %d changed from %q to %q", index, targets[index].node.ID, got[index].node.ID)
+		}
+	}
+	leafIndex := exploreTargetIndex(got, leaf.ID)
+	if leafIndex < 0 || !got[leafIndex].causalChangeLeaf || got[leafIndex].source == "" {
+		t.Fatalf("delegated leaf was not reserved and hydrated: %#v", got)
+	}
+	planned := localizationEvidenceTargetsFromDraft(task, "", got, nil)
+	if len(planned) < 2 || planned[0].node.ID != wrapper.ID || planned[1].node.ID != leaf.ID {
+		t.Fatalf("causal leaf did not follow retrieval head before packing: %v", causalChangeTargetIDs(planned))
+	}
+}
+
+func TestPromoteExploreCausalChangeTargetsPrefersGraphCallerOverKeywordOnlyTail(t *testing.T) {
+	matcher := causalChangeTestNode(
+		"repo/matcher/api.rs::Matcher.replace_with_captures",
+		"replace_with_captures", "matcher/api.rs", graph.KindMethod,
+		"fn replace_with_captures(&self) -> Result<()> ",
+	)
+	leaf := causalChangeTestNode(
+		"repo/output/rewrite.rs::OutputRewriter.apply_replacements",
+		"apply_replacements", "output/rewrite.rs", graph.KindMethod,
+		"fn apply_replacements(&mut self) -> io::Result<()> ",
+	)
+	owner := causalChangeTestNode(
+		"repo/output/rewrite.rs::OutputRewriter", "OutputRewriter",
+		"output/rewrite.rs", graph.KindType, "struct OutputRewriter",
+	)
+	g := graph.New()
+	g.AddNode(leaf)
+	g.AddNode(owner)
+
+	directHead := causalChangeTestNode("repo/search/run.rs::Search.run", "runSearch", "search/run.rs", graph.KindMethod, "fn run_search()")
+	keywordOnly := causalChangeTestNode(
+		"repo/search/diagnostics.rs::multiline_replace_output_diagnostic",
+		"multiline_replace_output_diagnostic", "search/diagnostics.rs", graph.KindFunction,
+		"fn multiline_replace_output_diagnostic()",
+	)
+	targets := []exploreTarget{
+		{node: matcher, source: "fn replace_with_captures() { /* multiline replace */ }", callers: []*graph.Node{leaf}},
+		{node: directHead},
+		{node: causalChangeTestNode("repo/search/options.rs::Options.multiline", "multiline", "search/options.rs", graph.KindMethod, "fn multiline()")},
+		{node: causalChangeTestNode("repo/search/output.rs::duplicate_output", "duplicate_output", "search/output.rs", graph.KindFunction, "fn duplicate_output()")},
+		{node: keywordOnly},
+	}
+	task := "Multiline replace duplicates output when replacement captures span several lines"
+	got := promoteExploreCausalChangeTargets(task, targets, g, len(targets), func(node *graph.Node) string {
+		if node.ID == leaf.ID {
+			return "fn apply_replacements(&mut self) -> io::Result<()> { Ok(()) }"
+		}
+		return ""
+	})
+
+	if slices.Contains(causalChangeTargetIDs(got), keywordOnly.ID) {
+		t.Fatalf("non-causal keyword-only tail survived ahead of graph change site: %v", causalChangeTargetIDs(got))
+	}
+	leafIndex, ownerIndex := exploreTargetIndex(got, leaf.ID), exploreTargetIndex(got, owner.ID)
+	if leafIndex < 0 || ownerIndex < 0 || !got[leafIndex].causalChangeLeaf || !got[ownerIndex].causalChangeOwner {
+		t.Fatalf("caller/owner pair not admitted: %#v", got)
+	}
+	planned := localizationEvidenceTargetsFromDraft(task, "", got, nil)
+	want := []string{matcher.ID, owner.ID, leaf.ID}
+	if ids := causalChangeTargetIDs(planned); len(ids) < len(want) || !slices.Equal(ids[:len(want)], want) {
+		t.Fatalf("planned causal prefix = %v, want %v", ids, want)
+	}
+}
+
+func TestExploreCausalChangeOwnerPrefersUniquelyReturnedStateType(t *testing.T) {
+	leaf := causalChangeTestNode(
+		"repo/state/build.rs::RuleBuilder.build_with_context",
+		"build_with_context", "state/build.rs", graph.KindMethod,
+		"fn build_with_context(&self, root: &Path) -> RuleState",
+	)
+	builder := causalChangeTestNode(
+		"repo/state/build.rs::RuleBuilder", "RuleBuilder", "state/build.rs", graph.KindType, "struct RuleBuilder",
+	)
+	state := causalChangeTestNode(
+		"repo/state/build.rs::RuleState", "RuleState", "state/build.rs", graph.KindType, "struct RuleState",
+	)
+	g := graph.New()
+	g.AddNode(leaf)
+	g.AddNode(builder)
+	g.AddNode(state)
+
+	got := exploreCausalChangeOwner("parallel roots leak rule state between traversals", leaf, g)
+	if got == nil || got.ID != state.ID {
+		t.Fatalf("change owner = %#v, want uniquely returned state type %q", got, state.ID)
+	}
+}
+
+func causalChangeRouteNode(id, name, qualName, file string, kind graph.NodeKind) *graph.Node {
+	node := causalChangeTestNode(id, name, file, kind, "")
+	node.QualName = qualName
+	node.Language = "go"
+	return node
+}
+
+func requireCausalChangeTarget(t *testing.T, targets []exploreTarget, id string) exploreTarget {
+	t.Helper()
+	index := exploreTargetIndex(targets, id)
+	if index < 0 {
+		t.Fatalf("target %q missing from %v", id, causalChangeTargetIDs(targets))
+		return exploreTarget{}
+	}
+	return targets[index]
+}
+
+func TestPromoteExploreCausalChangeTargetsCarriesCrossFileBridgeToContinuationAndOwner(t *testing.T) {
+	seed := causalChangeRouteNode(
+		"repo/crates/matcher/src/matcher.rs::Matcher.replace_with_captures_at",
+		"replace_with_captures_at", "Matcher.replace_with_captures_at",
+		"crates/matcher/src/matcher.rs", graph.KindMethod,
+	)
+	bridge := causalChangeRouteNode(
+		"repo/crates/printer/src/util.rs::Replacer.replace_all",
+		"replace_all", "Replacer.replace_all", "crates/printer/src/util.rs", graph.KindMethod,
+	)
+	continuation := causalChangeRouteNode(
+		"repo/crates/printer/src/util.rs::replace_with_captures_in_context",
+		"replace_with_captures_in_context", "replace_with_captures_in_context",
+		"crates/printer/src/util.rs", graph.KindFunction,
+	)
+	owner := causalChangeRouteNode(
+		"repo/crates/printer/src/util.rs::Replacer",
+		"Replacer", "Replacer", "crates/printer/src/util.rs", graph.KindType,
+	)
+	store := graph.New()
+	store.AddNode(bridge)
+	store.AddNode(continuation)
+	store.AddNode(owner)
+
+	readCalls, hydrateCalls := 0, 0
+	task := "The replace with captures at path should replace all matches while preserving captures in their surrounding context"
+	got := promoteExploreCausalChangeTargets(task, []exploreTarget{{
+		node: seed, source: "replace_with_captures_at replaces captures", callers: []*graph.Node{bridge},
+	}}, store, 4, func(node *graph.Node) string {
+		readCalls++
+		if node.ID != bridge.ID {
+			t.Fatalf("source read for %q, want bridge %q", node.ID, bridge.ID)
+		}
+		return "func (r *Replacer) replace_all() { replace_with_captures_in_context() }"
+	}, func(node *graph.Node) ([]*graph.Node, bool) {
+		hydrateCalls++
+		if node.ID != bridge.ID {
+			t.Fatalf("hydrated %q, want bridge %q", node.ID, bridge.ID)
+		}
+		return []*graph.Node{continuation}, true
+	})
+
+	if readCalls != 1 || hydrateCalls != 1 {
+		t.Fatalf("bounded reads = source:%d adjacency:%d, want 1 each", readCalls, hydrateCalls)
+	}
+	if len(got) != 4 {
+		t.Fatalf("promoted targets = %d, want seed + owner + bridge + continuation", len(got))
+	}
+	bridgeTarget := requireCausalChangeTarget(t, got, bridge.ID)
+	leafTarget := requireCausalChangeTarget(t, got, continuation.ID)
+	ownerTarget := requireCausalChangeTarget(t, got, owner.ID)
+	if !bridgeTarget.causalChangeBridge || bridgeTarget.causalChangeLeaf {
+		t.Fatalf("bridge flags = bridge:%t leaf:%t", bridgeTarget.causalChangeBridge, bridgeTarget.causalChangeLeaf)
+	}
+	if !exploreFoldedTargetMandatory(bridgeTarget, nil) {
+		t.Fatal("causal bridge was not protected from owner folding")
+	}
+	if !leafTarget.causalChangeLeaf || leafTarget.causalChangeBridge || !ownerTarget.causalChangeOwner {
+		t.Fatalf("continuation/owner flags were not preserved: %#v %#v", leafTarget, ownerTarget)
+	}
+	planned := localizationEvidenceTargetsFromDraft(task, "", got, nil)
+	want := []string{seed.ID, owner.ID, bridge.ID, continuation.ID}
+	if ids := causalChangeTargetIDs(planned); len(ids) < len(want) || !slices.Equal(ids[:len(want)], want) {
+		t.Fatalf("planned causal route = %v, want prefix %v", ids, want)
+	}
+}
+
+func TestPromoteExploreCausalChangeTargetsUsesNestedDelegationHint(t *testing.T) {
+	seed := causalChangeRouteNode(
+		"repo/gin.go::Engine.redirectFixedPath", "redirectFixedPath", "Engine.redirectFixedPath",
+		"gin.go", graph.KindMethod,
+	)
+	cleanPath := causalChangeRouteNode(
+		"repo/path.go::cleanPath", "cleanPath", "cleanPath", "gin.go", graph.KindFunction,
+	)
+	bridge := causalChangeRouteNode(
+		"repo/tree.go::node.findCaseInsensitivePath", "findCaseInsensitivePath", "node.findCaseInsensitivePath",
+		"tree.go", graph.KindMethod,
+	)
+	continuation := causalChangeRouteNode(
+		"repo/tree.go::node.findCaseInsensitivePathRec", "findCaseInsensitivePathRec", "node.findCaseInsensitivePathRec",
+		"tree.go", graph.KindMethod,
+	)
+	targets := []exploreTarget{{
+		node:          seed,
+		source:        "redirectFixedPath follows the case insensitive path fallback",
+		callees:       []*graph.Node{cleanPath, bridge},
+		causalCallees: []exploreCausalNeighbor{{node: bridge, hop: 1}, {node: continuation, hop: 2}},
+	}}
+	task := "The redirect fixed path fallback should follow case insensitive path lookup recursively without cleaning away valid request segments"
+	got := promoteExploreCausalChangeTargets(task, targets, nil, 3, func(node *graph.Node) string {
+		if node.ID != bridge.ID {
+			t.Fatalf("source read for %q, want hinted bridge %q", node.ID, bridge.ID)
+		}
+		return "func (n *node) findCaseInsensitivePath() { n.findCaseInsensitivePathRec() }"
+	}, func(node *graph.Node) ([]*graph.Node, bool) {
+		if node.ID != bridge.ID {
+			t.Fatalf("hydrated %q, want hinted bridge %q", node.ID, bridge.ID)
+		}
+		return []*graph.Node{continuation}, true
+	})
+
+	if len(got) != 3 {
+		t.Fatalf("promoted targets = %d, want seed + bridge + continuation", len(got))
+	}
+	if slices.Contains(causalChangeTargetIDs(got), cleanPath.ID) {
+		t.Fatalf("unrelated sibling callee was promoted: %v", causalChangeTargetIDs(got))
+	}
+	if !requireCausalChangeTarget(t, got, bridge.ID).causalChangeBridge ||
+		!requireCausalChangeTarget(t, got, continuation.ID).causalChangeLeaf {
+		t.Fatalf("nested causal route flags missing: %#v", got)
+	}
+}
+
+func TestPromoteExploreCausalChangeTargetsContinuesInheritedCaller(t *testing.T) {
+	seed := causalChangeRouteNode(
+		"repo/src/Handler/AbstractHandler.php::AbstractHandler.isHandling",
+		"isHandling", "AbstractHandler.isHandling", "src/Handler/AbstractHandler.php", graph.KindMethod,
+	)
+	genericCaller := causalChangeRouteNode(
+		"repo/src/Handler/AbstractProcessingHandler.php::AbstractProcessingHandler.handle",
+		"handle", "AbstractProcessingHandler.handle", "src/Handler/AbstractProcessingHandler.php", graph.KindMethod,
+	)
+	bridge := causalChangeRouteNode(
+		"repo/src/Handler/HipChatHandler.php::HipChatHandler.handleBatch",
+		"handleBatch", "HipChatHandler.handleBatch", "src/Handler/HipChatHandler.php", graph.KindMethod,
+	)
+	write := causalChangeRouteNode(
+		"repo/src/Handler/HipChatHandler.php::HipChatHandler.write",
+		"write", "HipChatHandler.write", "src/Handler/HipChatHandler.php", graph.KindMethod,
+	)
+	continuation := causalChangeRouteNode(
+		"repo/src/Handler/HipChatHandler.php::HipChatHandler.combineRecords",
+		"combineRecords", "HipChatHandler.combineRecords", "src/Handler/HipChatHandler.php", graph.KindMethod,
+	)
+	task := "The Hip Chat handler should handle each batch by combining records before checking handling and writing messages to the API"
+	got := promoteExploreCausalChangeTargets(task, []exploreTarget{{
+		node: seed, source: "isHandling checks every record", callers: []*graph.Node{genericCaller, bridge},
+	}}, nil, 3, func(node *graph.Node) string {
+		if node.ID != bridge.ID {
+			t.Fatalf("source read for %q, want inherited caller %q", node.ID, bridge.ID)
+		}
+		return "function handleBatch() { $records = $this->combineRecords(); $this->write($records); }"
+	}, func(node *graph.Node) ([]*graph.Node, bool) {
+		return []*graph.Node{write, continuation}, true
+	})
+
+	if slices.Contains(causalChangeTargetIDs(got), genericCaller.ID) || slices.Contains(causalChangeTargetIDs(got), write.ID) {
+		t.Fatalf("generic inherited route won over concrete continuation: %v", causalChangeTargetIDs(got))
+	}
+	if !requireCausalChangeTarget(t, got, bridge.ID).causalChangeBridge ||
+		!requireCausalChangeTarget(t, got, continuation.ID).causalChangeLeaf {
+		t.Fatalf("inherited caller route flags missing: %#v", got)
+	}
+}
+
+func TestPromoteExploreCausalChangeTargetsContinuationFailsClosed(t *testing.T) {
+	seed := causalChangeRouteNode(
+		"repo/router/resolve.go::Resolver.resolveRequestPath", "resolveRequestPath", "Resolver.resolveRequestPath",
+		"router/resolve.go", graph.KindMethod,
+	)
+	bridge := causalChangeRouteNode(
+		"repo/router/dispatch.go::RouteHandler.dispatchRequest", "dispatchRequest", "RouteHandler.dispatchRequest",
+		"router/dispatch.go", graph.KindMethod,
+	)
+	primary := causalChangeRouteNode(
+		"repo/router/dispatch.go::RouteHandler.dispatchPrimaryWork", "dispatchPrimaryWork", "RouteHandler.dispatchPrimaryWork",
+		"router/dispatch.go", graph.KindMethod,
+	)
+	backup := causalChangeRouteNode(
+		"repo/router/dispatch.go::RouteHandler.dispatchBackupWork", "dispatchBackupWork", "RouteHandler.dispatchBackupWork",
+		"router/dispatch.go", graph.KindMethod,
+	)
+	task := "The resolve request path flow asks the route handler to dispatch request work before selecting any terminal implementation"
+
+	tests := []struct {
+		name     string
+		children []*graph.Node
+		complete bool
+	}{
+		{name: "ambiguous", children: []*graph.Node{primary, backup}, complete: true},
+		{name: "incomplete", children: []*graph.Node{primary}, complete: false},
+		{name: "out_of_scope", children: []*graph.Node{func() *graph.Node {
+			outside := *primary
+			outside.WorkspaceID = "other-workspace"
+			return &outside
+		}()}, complete: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := promoteExploreCausalChangeTargets(task, []exploreTarget{{
+				node: seed, source: "resolveRequestPath dispatches request work", callers: []*graph.Node{bridge},
+			}}, nil, 3, func(*graph.Node) string {
+				return "func dispatchRequest() { dispatchPrimaryWork(); dispatchBackupWork() }"
+			}, func(*graph.Node) ([]*graph.Node, bool) {
+				return test.children, test.complete
+			})
+
+			bridgeTarget := requireCausalChangeTarget(t, got, bridge.ID)
+			if bridgeTarget.causalChangeBridge || !bridgeTarget.causalChangeLeaf {
+				t.Fatalf("uncertain bridge must remain terminal leaf, got bridge:%t leaf:%t", bridgeTarget.causalChangeBridge, bridgeTarget.causalChangeLeaf)
+			}
+			if slices.Contains(causalChangeTargetIDs(got), primary.ID) || slices.Contains(causalChangeTargetIDs(got), backup.ID) {
+				t.Fatalf("uncertain continuation escaped fail-closed selection: %v", causalChangeTargetIDs(got))
+			}
+		})
+	}
+}

--- a/internal/mcp/explore_causal_consumer_test.go
+++ b/internal/mcp/explore_causal_consumer_test.go
@@ -1,0 +1,116 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestSelectExploreCausalConsumerTargetBridgesRetainedComponent(t *testing.T) {
+	store := graph.New()
+	seed := &graph.Node{
+		ID: "crates/matcher/src/lib.rs::Matcher.replace_with_captures_at", Name: "replace_with_captures_at",
+		Kind: graph.KindMethod, FilePath: "crates/matcher/src/lib.rs",
+	}
+	callee := &graph.Node{
+		ID: "crates/matcher/src/lib.rs::Matcher.captures_iter_at", Name: "captures_iter_at",
+		Kind: graph.KindMethod, FilePath: "crates/matcher/src/lib.rs",
+	}
+	printerPeer := &graph.Node{
+		ID: "crates/printer/src/standard.rs::StandardBuilder", Name: "StandardBuilder",
+		Kind: graph.KindType, FilePath: "crates/printer/src/standard.rs",
+	}
+	consumer := &graph.Node{
+		ID: "crates/printer/src/util.rs::replace_with_captures_in_context", Name: "replace_with_captures_in_context",
+		Kind: graph.KindFunction, FilePath: "crates/printer/src/util.rs",
+	}
+	for _, node := range []*graph.Node{seed, callee, printerPeer, consumer} {
+		store.AddNode(node)
+	}
+	store.AddEdge(&graph.Edge{From: consumer.ID, To: callee.ID, Kind: graph.EdgeCalls})
+
+	candidate, ok := selectExploreCausalConsumerTarget(
+		"panic while using --replace with multiline captures in context",
+		[]exploreTarget{{node: seed, callees: []*graph.Node{callee}}, {node: printerPeer}},
+		store,
+	)
+	if !ok {
+		t.Fatal("expected a unique cross-file consumer")
+	}
+	if candidate.node == nil || candidate.node.ID != consumer.ID || !candidate.consumer ||
+		candidate.parentID != seed.ID || candidate.hop != 1 {
+		t.Fatalf("unexpected consumer candidate: %#v", candidate)
+	}
+}
+
+func TestSelectExploreCausalConsumerTargetCollapsesSameFileWrappers(t *testing.T) {
+	store := graph.New()
+	seed := &graph.Node{
+		ID: "crates/ignore/src/gitignore.rs::Glob.is_whitelist", Name: "is_whitelist",
+		Kind: graph.KindMethod, FilePath: "crates/ignore/src/gitignore.rs",
+	}
+	wrapper1 := &graph.Node{
+		ID: "crates/ignore/src/gitignore.rs::Gitignore.matched_stripped", Name: "matched_stripped",
+		Kind: graph.KindMethod, FilePath: "crates/ignore/src/gitignore.rs",
+	}
+	wrapper2 := &graph.Node{
+		ID: "crates/ignore/src/gitignore.rs::Gitignore.matched", Name: "matched",
+		Kind: graph.KindMethod, FilePath: "crates/ignore/src/gitignore.rs",
+	}
+	consumer := &graph.Node{
+		ID: "crates/ignore/src/dir.rs::Ignore.matched_ignore", Name: "matched_ignore",
+		Kind: graph.KindMethod, FilePath: "crates/ignore/src/dir.rs",
+	}
+	for _, node := range []*graph.Node{seed, wrapper1, wrapper2, consumer} {
+		store.AddNode(node)
+	}
+	store.AddEdge(&graph.Edge{From: wrapper1.ID, To: seed.ID, Kind: graph.EdgeCalls})
+	store.AddEdge(&graph.Edge{From: wrapper2.ID, To: wrapper1.ID, Kind: graph.EdgeCalls})
+	store.AddEdge(&graph.Edge{From: consumer.ID, To: wrapper2.ID, Kind: graph.EdgeCalls})
+
+	candidate, ok := selectExploreCausalConsumerTarget(
+		"hidden files whitelisted by an ancestor .ignore fail for explicit current directory",
+		[]exploreTarget{{node: seed}},
+		store,
+	)
+	if !ok || candidate.node == nil || candidate.node.ID != consumer.ID || candidate.hop != 3 {
+		t.Fatalf("same-file wrapper chain did not recover consumer: ok=%v candidate=%#v", ok, candidate)
+	}
+}
+
+func TestSelectExploreCausalConsumerTargetRejectsAmbiguousFiles(t *testing.T) {
+	store := graph.New()
+	seed := &graph.Node{
+		ID: "crates/matcher/src/lib.rs::Matcher.captures_iter_at", Name: "captures_iter_at",
+		Kind: graph.KindMethod, FilePath: "crates/matcher/src/lib.rs",
+	}
+	printerPeer := &graph.Node{
+		ID: "crates/printer/src/standard.rs::StandardBuilder", Name: "StandardBuilder",
+		Kind: graph.KindType, FilePath: "crates/printer/src/standard.rs",
+	}
+	otherPeer := &graph.Node{
+		ID: "crates/other/src/standard.rs::OtherBuilder", Name: "OtherBuilder",
+		Kind: graph.KindType, FilePath: "crates/other/src/standard.rs",
+	}
+	first := &graph.Node{
+		ID: "crates/printer/src/util.rs::replace_all", Name: "replace_all",
+		Kind: graph.KindFunction, FilePath: "crates/printer/src/util.rs",
+	}
+	second := &graph.Node{
+		ID: "crates/other/src/util.rs::replace_each", Name: "replace_each",
+		Kind: graph.KindFunction, FilePath: "crates/other/src/util.rs",
+	}
+	for _, node := range []*graph.Node{seed, printerPeer, otherPeer, first, second} {
+		store.AddNode(node)
+	}
+	store.AddEdge(&graph.Edge{From: first.ID, To: seed.ID, Kind: graph.EdgeCalls})
+	store.AddEdge(&graph.Edge{From: second.ID, To: seed.ID, Kind: graph.EdgeCalls})
+
+	if candidate, ok := selectExploreCausalConsumerTarget(
+		"replace output is duplicated",
+		[]exploreTarget{{node: seed}, {node: printerPeer}, {node: otherPeer}},
+		store,
+	); ok {
+		t.Fatalf("ambiguous cross-file consumers should be rejected: %#v", candidate)
+	}
+}

--- a/internal/mcp/explore_component_conjunction_test.go
+++ b/internal/mcp/explore_component_conjunction_test.go
@@ -1,0 +1,228 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/search/rerank"
+)
+
+func componentConjunctionTestCandidate(id, name, qualName, file string, kind graph.NodeKind) *rerank.Candidate {
+	return &rerank.Candidate{Node: &graph.Node{
+		ID:          id,
+		Name:        name,
+		QualName:    qualName,
+		Kind:        kind,
+		FilePath:    file,
+		WorkspaceID: "workspace",
+		ProjectID:   "project",
+		RepoPrefix:  "repo",
+	}}
+}
+
+func componentConjunctionTestIDs(candidates []*rerank.Candidate) []string {
+	ids := make([]string, len(candidates))
+	for index, candidate := range candidates {
+		if candidate != nil && candidate.Node != nil {
+			ids[index] = candidate.Node.ID
+		}
+	}
+	return ids
+}
+
+func componentConjunctionAssertIDs(t *testing.T, got []*rerank.Candidate, want []string) {
+	t.Helper()
+	gotIDs := componentConjunctionTestIDs(got)
+	if len(gotIDs) != len(want) {
+		t.Fatalf("candidate count = %d, want %d: got=%v", len(gotIDs), len(want), gotIDs)
+	}
+	for index := range want {
+		if gotIDs[index] != want[index] {
+			t.Fatalf("candidate %d = %q, want %q: got=%v", index, gotIDs[index], want[index], gotIDs)
+		}
+	}
+}
+
+func TestReserveExploreComponentConjunctionPromotesRipgrepPrinterUtility(t *testing.T) {
+	utility := componentConjunctionTestCandidate(
+		"crates/printer/src/util.rs::Replacer.replace_all",
+		"replace_all",
+		"Replacer<M>.replace_all",
+		"crates/printer/src/util.rs",
+		graph.KindMethod,
+	)
+	utility.Signals = map[string]float64{"prior": 0.25}
+	candidates := []*rerank.Candidate{
+		componentConjunctionTestCandidate(
+			"crates/matcher/src/captures.rs::replace_with_captures",
+			"replace_with_captures",
+			"Captures.replace_with_captures",
+			"crates/matcher/src/captures.rs",
+			graph.KindFunction,
+		),
+		componentConjunctionTestCandidate(
+			"crates/printer/src/standard.rs::StandardBuilder.only_matching",
+			"only_matching",
+			"StandardBuilder.only_matching",
+			"crates/printer/src/standard.rs",
+			graph.KindMethod,
+		),
+		componentConjunctionTestCandidate(
+			"crates/printer/src/standard.rs::invert_context_only_matching_multi_line",
+			"invert_context_only_matching_multi_line",
+			"invert_context_only_matching_multi_line",
+			"crates/printer/src/standard.rs",
+			graph.KindFunction,
+		),
+		componentConjunctionTestCandidate(
+			"crates/core/src/search.rs::search_reader",
+			"search_reader",
+			"search_reader",
+			"crates/core/src/search.rs",
+			graph.KindFunction,
+		),
+		componentConjunctionTestCandidate(
+			"crates/core/src/flags.rs::build_flags",
+			"build_flags",
+			"build_flags",
+			"crates/core/src/flags.rs",
+			graph.KindFunction,
+		),
+		utility,
+	}
+	query := "only matching multi line captures must replace printer text"
+	got := reserveExploreComponentConjunction(query, rerank.QueryClassConcept, candidates, 5)
+
+	if len(got) != len(candidates) {
+		t.Fatalf("candidate count = %d, want %d", len(got), len(candidates))
+	}
+	if got[0] != candidates[0] {
+		t.Fatal("semantic head changed")
+	}
+	if got[4].Node.ID != utility.Node.ID {
+		t.Fatalf("final visible candidate = %q, want %q", got[4].Node.ID, utility.Node.ID)
+	}
+	if got[4].Signals[exploreConceptComplementSignal] != 1 {
+		t.Fatalf("utility signals = %#v, want component complement", got[4].Signals)
+	}
+	if got[4].Signals["prior"] != 0.25 {
+		t.Fatalf("utility signals = %#v, want prior signal preserved", got[4].Signals)
+	}
+	if utility.Signals[exploreConceptComplementSignal] != 0 {
+		t.Fatal("original utility candidate was mutated")
+	}
+
+	wantIDs := componentConjunctionTestIDs(got)
+	again := reserveExploreComponentConjunction(query, rerank.QueryClassConcept, got, 5)
+	componentConjunctionAssertIDs(t, again, wantIDs)
+	if again[4].Signals[exploreConceptComplementSignal] != 1 {
+		t.Fatalf("second pass signals = %#v, want stable component complement", again[4].Signals)
+	}
+}
+
+func TestReserveExploreComponentConjunctionRejectsFalsePositives(t *testing.T) {
+	tests := []struct {
+		name       string
+		query      string
+		maxSymbols int
+		candidates []*rerank.Candidate
+	}{
+		{
+			name:       "repeated term has no local marginal",
+			query:      "only matching must replace output",
+			maxSymbols: 2,
+			candidates: []*rerank.Candidate{
+				componentConjunctionTestCandidate("src/printer/standard.rs::OnlyMatchingPrinter", "OnlyMatchingPrinter", "OnlyMatchingPrinter", "src/printer/standard.rs", graph.KindType),
+				componentConjunctionTestCandidate("src/printer/util.rs::matching_only", "matching_only", "matching_only", "src/printer/util.rs", graph.KindFunction),
+			},
+		},
+		{
+			name:       "different parent directory",
+			query:      "only matching must replace text",
+			maxSymbols: 2,
+			candidates: []*rerank.Candidate{
+				componentConjunctionTestCandidate("src/printer/standard.rs::OnlyMatchingPrinter", "OnlyMatchingPrinter", "OnlyMatchingPrinter", "src/printer/standard.rs", graph.KindType),
+				componentConjunctionTestCandidate("src/replacer/util.rs::replace_all", "replace_all", "Replacer.replace_all", "src/replacer/util.rs", graph.KindMethod),
+			},
+		},
+		{
+			name:       "generic declaration",
+			query:      "only matching handle must replace text",
+			maxSymbols: 2,
+			candidates: func() []*rerank.Candidate {
+				generic := componentConjunctionTestCandidate("src/printer/util.rs::Handler.Handle", "Handle", "Handler.Handle", "src/printer/util.rs", graph.KindMethod)
+				generic.Node.Meta = map[string]any{"signature": "interface Handler", "doc": "only matching replacement"}
+				return []*rerank.Candidate{
+					componentConjunctionTestCandidate("src/printer/standard.rs::OnlyMatchingPrinter", "OnlyMatchingPrinter", "OnlyMatchingPrinter", "src/printer/standard.rs", graph.KindType),
+					generic,
+				}
+			}(),
+		},
+		{
+			name:       "low value terms only",
+			query:      "line output diagnostic",
+			maxSymbols: 2,
+			candidates: []*rerank.Candidate{
+				componentConjunctionTestCandidate("src/printer/standard.rs::LineOutputPrinter", "LineOutputPrinter", "LineOutputPrinter", "src/printer/standard.rs", graph.KindType),
+				componentConjunctionTestCandidate("src/printer/util.rs::trim_line_output", "trim_line_output", "trim_line_output", "src/printer/util.rs", graph.KindFunction),
+			},
+		},
+		{
+			name:       "root component",
+			query:      "only matching must replace text",
+			maxSymbols: 2,
+			candidates: []*rerank.Candidate{
+				componentConjunctionTestCandidate("standard.rs::OnlyMatchingPrinter", "OnlyMatchingPrinter", "OnlyMatchingPrinter", "standard.rs", graph.KindType),
+				componentConjunctionTestCandidate("util.rs::replace_all", "replace_all", "Replacer.replace_all", "util.rs", graph.KindMethod),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			want := componentConjunctionTestIDs(test.candidates)
+			got := reserveExploreComponentConjunction(test.query, rerank.QueryClassConcept, test.candidates, test.maxSymbols)
+			componentConjunctionAssertIDs(t, got, want)
+			for _, candidate := range got {
+				if candidate != nil && candidate.Signals[exploreConceptComplementSignal] > 0 {
+					t.Fatalf("unexpected component complement on %q", candidate.Node.ID)
+				}
+			}
+		})
+	}
+}
+
+func TestReserveExploreComponentConjunctionRejectsAmbiguousComponents(t *testing.T) {
+	candidates := []*rerank.Candidate{
+		componentConjunctionTestCandidate("src/a/standard.rs::OnlyMatchingA", "OnlyMatchingA", "OnlyMatchingA", "src/a/standard.rs", graph.KindType),
+		componentConjunctionTestCandidate("src/b/standard.rs::OnlyMatchingB", "OnlyMatchingB", "OnlyMatchingB", "src/b/standard.rs", graph.KindType),
+		componentConjunctionTestCandidate("src/other/one.rs::parse_config", "parse_config", "parse_config", "src/other/one.rs", graph.KindFunction),
+		componentConjunctionTestCandidate("src/other/two.rs::build_config", "build_config", "build_config", "src/other/two.rs", graph.KindFunction),
+		componentConjunctionTestCandidate("src/a/util.rs::replace_all", "replace_all", "Replacer.replace_all", "src/a/util.rs", graph.KindMethod),
+		componentConjunctionTestCandidate("src/b/util.rs::replace_all", "replace_all", "Replacer.replace_all", "src/b/util.rs", graph.KindMethod),
+	}
+	want := componentConjunctionTestIDs(candidates)
+	got := reserveExploreComponentConjunction("only matching must replace text", rerank.QueryClassConcept, candidates, 4)
+	componentConjunctionAssertIDs(t, got, want)
+	for _, candidate := range got {
+		if candidate.Signals[exploreConceptComplementSignal] > 0 {
+			t.Fatalf("ambiguous candidate %q was marked", candidate.Node.ID)
+		}
+	}
+}
+
+func TestReserveExploreComponentConjunctionMarksVisibleCandidateInPlace(t *testing.T) {
+	candidates := []*rerank.Candidate{
+		componentConjunctionTestCandidate("src/printer/standard.rs::OnlyMatchingPrinter", "OnlyMatchingPrinter", "OnlyMatchingPrinter", "src/printer/standard.rs", graph.KindType),
+		componentConjunctionTestCandidate("src/printer/util.rs::replace_all", "replace_all", "Replacer.replace_all", "src/printer/util.rs", graph.KindMethod),
+	}
+	want := componentConjunctionTestIDs(candidates)
+	got := reserveExploreComponentConjunction("only matching must replace text", rerank.QueryClassConcept, candidates, 2)
+	componentConjunctionAssertIDs(t, got, want)
+	if got[1].Signals[exploreConceptComplementSignal] != 1 {
+		t.Fatalf("visible utility signals = %#v, want component complement", got[1].Signals)
+	}
+	if got[0] != candidates[0] {
+		t.Fatal("visible marking changed the semantic head")
+	}
+}

--- a/internal/mcp/explore_owner_folding.go
+++ b/internal/mcp/explore_owner_folding.go
@@ -271,7 +271,8 @@ func exploreFoldedTargetMandatory(target exploreTarget, reserved map[string]stru
 		return true
 	}
 	return target.sourceLiteral || target.sourceLiteralCallee || target.exactContent ||
-		target.conceptImplementation || target.typedAnchorProjection ||
+		target.causalChangeBridge || target.causalChangeLeaf || target.causalChangeOwner ||
+		target.conceptImplementation || target.conceptComplement || target.syntacticAnchor || target.typedAnchorProjection ||
 		target.divergentDefaultOwner || target.divergentDefaultType
 }
 

--- a/internal/mcp/explore_syntactic_anchor.go
+++ b/internal/mcp/explore_syntactic_anchor.go
@@ -2,6 +2,9 @@ package mcp
 
 import (
 	"context"
+	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -12,8 +15,9 @@ import (
 )
 
 const (
-	exploreSyntacticAnchorMaxTerms = 3
-	exploreSyntacticAnchorFetch    = 10
+	exploreSyntacticAnchorMaxTerms         = 3
+	exploreSyntacticAnchorFetch            = 10
+	exploreSyntacticAnchorCompetitionFetch = 32
 )
 
 // exploreSyntacticAnchor is a bounded, implementation-shaped clue copied
@@ -21,10 +25,11 @@ const (
 // prose query shaping poorly, but often name the missing implementation more
 // precisely than the surrounding natural language.
 type exploreSyntacticAnchor struct {
-	query   string
-	source  string
-	terms   []string
-	compact string
+	query         string
+	source        string
+	terms         []string
+	compact       string
+	qualifiedName string
 }
 
 // exploreSyntacticAnchors extracts only syntactically strong, unquoted clues.
@@ -52,7 +57,11 @@ func exploreSyntacticAnchors(task string) []exploreSyntacticAnchor {
 		if !strings.HasPrefix(token, "--") || len(token) <= 2 {
 			continue
 		}
-		add(strings.TrimLeft(token, "-"))
+		flag := strings.TrimLeft(token, "-")
+		if assignment := strings.IndexByte(flag, '='); assignment >= 0 {
+			flag = flag[:assignment]
+		}
+		add(flag)
 		if len(out) == exploreSyntacticAnchorMaxTerms {
 			return out
 		}
@@ -62,7 +71,7 @@ func exploreSyntacticAnchors(task string) []exploreSyntacticAnchor {
 		if strings.HasPrefix(token, "--") {
 			continue
 		}
-		if !exploreCodeShapedToken(token) {
+		if exploreSyntacticAnchorRuntimeDataPath(token) || !exploreCodeShapedToken(token) {
 			continue
 		}
 		add(token)
@@ -75,6 +84,27 @@ func exploreSyntacticAnchors(task string) []exploreSyntacticAnchor {
 
 func newExploreSyntacticAnchor(raw string) (exploreSyntacticAnchor, bool) {
 	raw = strings.Trim(raw, " \t\r\n()[]{}<>,.;:'\"")
+	// Stack traces commonly suffix an otherwise exact source anchor with a
+	// decimal line/column (`tree.go:637` or `tree.go:637:12`). Those coordinates
+	// are not identifier terms; retaining them makes both lexical lookup and
+	// node matching miss the named file.
+	for {
+		colon := strings.LastIndexByte(raw, ':')
+		if colon < 0 || colon == len(raw)-1 {
+			break
+		}
+		digits := true
+		for _, r := range raw[colon+1:] {
+			if r < '0' || r > '9' {
+				digits = false
+				break
+			}
+		}
+		if !digits {
+			break
+		}
+		raw = raw[:colon]
+	}
 	if raw == "" {
 		return exploreSyntacticAnchor{}, false
 	}
@@ -102,11 +132,18 @@ func newExploreSyntacticAnchor(raw string) (exploreSyntacticAnchor, bool) {
 	if len(terms) > 1 {
 		queryTerms = append(queryTerms, strings.Join(terms, "_"), compact)
 	}
+	query := strings.Join(queryTerms, " ")
+	qualifiedName := ""
+	if strings.Contains(raw, "::") {
+		query = strings.Join(strings.Fields(strings.ReplaceAll(raw, "::", " ")), " ")
+		qualifiedName = strings.ReplaceAll(strings.Join(strings.Fields(raw), ""), "::", ".")
+	}
 	return exploreSyntacticAnchor{
-		query:   strings.Join(queryTerms, " "),
-		source:  strings.ToLower(raw),
-		terms:   terms,
-		compact: compact,
+		query:         query,
+		source:        strings.ToLower(raw),
+		terms:         terms,
+		compact:       compact,
+		qualifiedName: qualifiedName,
 	}, true
 }
 
@@ -122,6 +159,21 @@ func exploreSyntacticAnchorNoise(compact string) bool {
 func exploreSyntacticAnchorEquivalent(left, right exploreSyntacticAnchor) bool {
 	if left.compact == right.compact {
 		return true
+	}
+	leftQualified := strings.Contains(left.source, "::")
+	rightQualified := strings.Contains(right.source, "::")
+	if leftQualified != rightQualified {
+		qualified, plain := left, right
+		if !leftQualified {
+			qualified, plain = right, left
+		}
+		// An explicitly qualified member is complementary to its owner, not a
+		// spelling variant of it. Keep both retrieval lanes so a task naming
+		// HipChatHandler and HipChatHandler::buildContent can surface the class
+		// context and the requested method independently.
+		if strings.HasPrefix(qualified.compact, plain.compact) {
+			return false
+		}
 	}
 	shorter, longer := left.compact, right.compact
 	if len(shorter) > len(longer) {
@@ -165,6 +217,290 @@ func exploreUnquotedCodeTokens(task string) []string {
 	})
 }
 
+const (
+	exploreSourceRangeSignal      = "explore_source_range"
+	exploreSourceRangeMaxAnchors  = 4
+	exploreSourceRangeContextSize = 320
+	exploreSourceRangeMaxSpan     = 512
+	exploreSourceRangeMaxAliases  = 4
+)
+
+var (
+	exploreSourceRangeLineRE   = regexp.MustCompile(`(?i)\blines?\s+([0-9]{1,8})(?:\s+(?:to|-)\s+([0-9]{1,8}))?`)
+	exploreSourceRangeInlineRE = regexp.MustCompile(`^\s*:([0-9]{1,8})(?:-([0-9]{1,8}))?`)
+)
+
+// exploreSourceRangeSpecs pairs an explicit source path with the line citation
+// immediately following it. GitHub issue bodies render these as a path and a
+// later "Lines X to Y" fragment; stack traces commonly use path:line instead.
+// Both shapes are bounded and ignored unless the path has a source extension.
+func exploreSourceRangeSpecs(task string) []rangeSpec {
+	matches := exploreArtifactPathRE.FindAllStringIndex(task, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, exploreSourceRangeMaxAnchors)
+	out := make([]rangeSpec, 0, exploreSourceRangeMaxAnchors)
+	for index, match := range matches {
+		path := strings.Trim(task[match[0]:match[1]], "`'\"()[]{}<>,;")
+		normalizedPath := strings.ReplaceAll(path, "\\", "/")
+		if !exploreSourceExtension(filepath.Ext(normalizedPath)) {
+			continue
+		}
+		tailEnd := len(task)
+		if index+1 < len(matches) {
+			tailEnd = matches[index+1][0]
+		}
+		if limit := match[1] + exploreSourceRangeContextSize; tailEnd > limit {
+			tailEnd = limit
+		}
+		start, end, ok := exploreSourceRangeLines(task[match[1]:tailEnd])
+		if !ok {
+			continue
+		}
+		key := strings.ToLower(normalizedPath) + ":" + strconv.Itoa(start) + "-" + strconv.Itoa(end)
+		if _, duplicate := seen[key]; duplicate {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, rangeSpec{File: path, StartLine: start, EndLine: end})
+		if len(out) == exploreSourceRangeMaxAnchors {
+			break
+		}
+	}
+	return out
+}
+
+func exploreSourceRangeLines(tail string) (int, int, bool) {
+	match := exploreSourceRangeInlineRE.FindStringSubmatch(tail)
+	if match == nil {
+		match = exploreSourceRangeLineRE.FindStringSubmatch(tail)
+	}
+	if len(match) < 2 {
+		return 0, 0, false
+	}
+	start, err := strconv.Atoi(match[1])
+	if err != nil || start <= 0 {
+		return 0, 0, false
+	}
+	end := start
+	if len(match) > 2 && match[2] != "" {
+		if parsed, parseErr := strconv.Atoi(match[2]); parseErr == nil && parsed >= start {
+			end = parsed
+		}
+	}
+	if end-start >= exploreSourceRangeMaxSpan {
+		end = start + exploreSourceRangeMaxSpan - 1
+	}
+	return start, end, true
+}
+
+// exploreSourceRangeDefinitions chooses the narrowest editable declaration at
+// each cited line. Anonymous closures are implementation detail: when a cited
+// line falls inside one, the enclosing named method/function remains the useful
+// localization symbol (for example FingersCrossedHandler::flushBuffer).
+func exploreSourceRangeDefinitions(index *fileSymbolIndex, start, end int) []*graph.Node {
+	if index == nil {
+		return nil
+	}
+	if end < start {
+		end = start
+	}
+	if end-start >= exploreSourceRangeMaxSpan {
+		end = start + exploreSourceRangeMaxSpan - 1
+	}
+	seen := make(map[string]struct{})
+	out := make([]*graph.Node, 0, 2)
+	for line := start; line <= end; line++ {
+		var best *graph.Node
+		bestSpan := int(^uint(0) >> 1)
+		for _, node := range index.syms {
+			if node == nil {
+				continue
+			}
+			if node.StartLine > line {
+				break
+			}
+			if node.Kind == graph.KindClosure || node.EndLine < line {
+				continue
+			}
+			span := node.EndLine - node.StartLine
+			if best == nil || span < bestSpan {
+				best = node
+				bestSpan = span
+			}
+		}
+		if best == nil {
+			best = index.smallestEnclosing(line)
+		}
+		if best == nil || best.ID == "" {
+			continue
+		}
+		if _, duplicate := seen[best.ID]; duplicate {
+			continue
+		}
+		seen[best.ID] = struct{}{}
+		out = append(out, best)
+	}
+	return out
+}
+
+// exploreSourceRangeGraphPathAliases returns a bounded exact-to-suffix lookup
+// order. Benchmark and issue text often prefixes paths with an isolated repo
+// label (for example monolog/src/... while a lone repo indexes src/...). The
+// exact path always wins; suffixes are only fallback lookup keys.
+func exploreSourceRangeGraphPathAliases(graphPath string) []string {
+	clean := filepath.ToSlash(filepath.Clean(graphPath))
+	if clean == "." || clean == "/" || clean == "" {
+		return nil
+	}
+	clean = strings.TrimPrefix(clean, "./")
+	out := make([]string, 0, exploreSourceRangeMaxAliases)
+	for len(out) < exploreSourceRangeMaxAliases && clean != "" {
+		out = append(out, clean)
+		slash := strings.IndexByte(clean, '/')
+		if slash < 0 || slash+1 >= len(clean) {
+			break
+		}
+		clean = clean[slash+1:]
+	}
+	return out
+}
+
+// exploreSourceRangeIndex chooses the exact indexed path when present. If it is
+// absent, exactly one suffix alias may resolve; multiple suffix hits are
+// deliberately rejected so an explicit citation never promotes an ambiguous
+// same-named file.
+func exploreSourceRangeIndex(indexes map[string]*fileSymbolIndex, aliases []string) *fileSymbolIndex {
+	if len(aliases) == 0 {
+		return nil
+	}
+	if exact := indexes[aliases[0]]; exact != nil {
+		return exact
+	}
+	var resolved *fileSymbolIndex
+	for _, alias := range aliases[1:] {
+		index := indexes[alias]
+		if index == nil {
+			continue
+		}
+		if resolved != nil && resolved != index {
+			return nil
+		}
+		resolved = index
+	}
+	return resolved
+}
+
+// promoteExploreSourceRangeCandidates puts task-cited declarations ahead of
+// semantic neighbours without reranking the completed search. Existing
+// candidates retain their scores; missing exact declarations are admitted with
+// neutral ranks. The syntactic marker protects and labels this task-spelled
+// evidence through the existing bounded selection and rendering policy.
+func (s *Server) promoteExploreSourceRangeCandidates(
+	ctx context.Context,
+	task string,
+	ordinary []*rerank.Candidate,
+	scope query.QueryOptions,
+) []*rerank.Candidate {
+	specs := exploreSourceRangeSpecs(task)
+	if s == nil || s.graph == nil || len(specs) == 0 || ctx.Err() != nil {
+		return ordinary
+	}
+	type resolvedRange struct {
+		spec       rangeSpec
+		graphPaths []string
+	}
+	resolved := make([]resolvedRange, 0, len(specs))
+	orderedPaths := make([]string, 0, len(specs)*exploreSourceRangeMaxAliases)
+	seenPaths := make(map[string]struct{}, len(specs)*exploreSourceRangeMaxAliases)
+	for _, spec := range specs {
+		absPath, relPath, err := s.resolveFilePath(spec.File)
+		if err != nil {
+			continue
+		}
+		graphPaths := exploreSourceRangeGraphPathAliases(s.resolveOverlayGraphPath(relPath, absPath))
+		if len(graphPaths) == 0 {
+			continue
+		}
+		resolved = append(resolved, resolvedRange{spec: spec, graphPaths: graphPaths})
+		for _, graphPath := range graphPaths {
+			if _, duplicate := seenPaths[graphPath]; !duplicate {
+				seenPaths[graphPath] = struct{}{}
+				orderedPaths = append(orderedPaths, graphPath)
+			}
+		}
+	}
+	if len(resolved) == 0 {
+		return ordinary
+	}
+	indexes := s.buildFileSymbolIndexForOrderedPathsContext(ctx, orderedPaths)
+	exactNodes := make([]*graph.Node, 0, len(resolved))
+	seenNodes := make(map[string]struct{}, len(resolved))
+	for _, item := range resolved {
+		index := exploreSourceRangeIndex(indexes, item.graphPaths)
+		for _, node := range exploreSourceRangeDefinitions(index, item.spec.StartLine, item.spec.EndLine) {
+			if node == nil || !exploreLocalizableKind(node.Kind) || !scope.ScopeAllows(node) ||
+				!s.nodeInSessionScope(ctx, node) {
+				continue
+			}
+			if _, duplicate := seenNodes[node.ID]; duplicate {
+				continue
+			}
+			seenNodes[node.ID] = struct{}{}
+			exactNodes = append(exactNodes, node)
+			if len(exactNodes) == exploreSourceRangeMaxAnchors {
+				break
+			}
+		}
+		if len(exactNodes) == exploreSourceRangeMaxAnchors {
+			break
+		}
+	}
+	if len(exactNodes) == 0 {
+		return ordinary
+	}
+	ordinaryByID := make(map[string]*rerank.Candidate, len(ordinary))
+	for _, candidate := range ordinary {
+		if candidate != nil && candidate.Node != nil {
+			ordinaryByID[candidate.Node.ID] = candidate
+		}
+	}
+	out := make([]*rerank.Candidate, 0, len(ordinary)+len(exactNodes))
+	promoted := make(map[string]struct{}, len(exactNodes))
+	for _, node := range exactNodes {
+		candidate := &rerank.Candidate{Node: node, TextRank: -1, VectorRank: -1}
+		if existing := ordinaryByID[node.ID]; existing != nil {
+			clone := *existing
+			candidate = &clone
+		}
+		markExploreSyntacticAnchorCandidate(candidate)
+		candidate.Signals[exploreSourceRangeSignal] = 1
+		out = append(out, candidate)
+		promoted[node.ID] = struct{}{}
+	}
+	for _, candidate := range ordinary {
+		if candidate == nil || candidate.Node == nil {
+			continue
+		}
+		if _, exact := promoted[candidate.Node.ID]; exact {
+			continue
+		}
+		out = append(out, candidate)
+	}
+	return out
+}
+
+func exploreSyntacticAnchorRuntimeDataPath(token string) bool {
+	lower := strings.ToLower(strings.Trim(token, "-_.:()[]{}<>,;'\""))
+	for _, suffix := range []string{".txt", ".log", ".csv", ".tsv"} {
+		if strings.HasSuffix(lower, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
 func exploreCodeShapedToken(token string) bool {
 	token = strings.Trim(token, "-_.:")
 	first, _ := utf8.DecodeRuneInString(token)
@@ -175,6 +511,18 @@ func exploreCodeShapedToken(token string) bool {
 	for _, suffix := range []string{".ai", ".com", ".dev", ".io", ".net", ".org"} {
 		if strings.HasSuffix(lower, suffix) {
 			return false
+		}
+	}
+	// Route-registration examples such as r.GET("/users/:id") describe
+	// runtime input, not implementation anchors. They otherwise consume the
+	// three-slot syntactic budget ahead of a later stack-trace file/symbol.
+	if dot := strings.LastIndex(token, "."); dot >= 0 && dot < len(token)-1 {
+		member := token[dot+1:]
+		if member == strings.ToUpper(member) {
+			switch member {
+			case "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS", "CONNECT", "TRACE":
+				return false
+			}
 		}
 	}
 	if strings.Contains(token, "_") || strings.Contains(token, "::") || strings.Contains(token, ".") {
@@ -195,7 +543,37 @@ func exploreSyntacticAnchorMatchesNode(anchor exploreSyntacticAnchor, node *grap
 		return false
 	}
 	return exploreSyntacticAnchorMatchesIdentifier(anchor, node.Name) ||
-		exploreSyntacticAnchorMatchesIdentifier(anchor, node.QualName)
+		exploreSyntacticAnchorMatchesIdentifier(anchor, node.QualName) ||
+		(strings.Contains(anchor.source, "::") && exploreSyntacticAnchorMatchesIdentifier(anchor, node.ID)) ||
+		exploreSyntacticAnchorMatchesPath(anchor, node)
+}
+
+// exploreTaskQualifiedSyntacticAnchorMatchesNode checks the untouched task so a
+// late Owner::member anchor survives long-report query shaping and truncation.
+// Only explicit qualified members use this route; ordinary prose and bare
+// identifiers continue to rely on the shaped query.
+func exploreTaskQualifiedSyntacticAnchorMatchesNode(task string, node *graph.Node) bool {
+	if node == nil || node.Kind == graph.KindType || node.Kind == graph.KindInterface ||
+		utf8.RuneCountInString(task) < shapeMinReportChars || !strings.ContainsAny(task, "\r\n") {
+		return false
+	}
+	for _, anchor := range exploreSyntacticAnchors(task) {
+		if anchor.qualifiedName != "" &&
+			(exploreSyntacticAnchorMatchesIdentifier(anchor, node.ID) ||
+				exploreSyntacticAnchorMatchesIdentifier(anchor, node.QualName)) {
+			return true
+		}
+	}
+	return false
+}
+
+func exploreSyntacticAnchorMatchesPath(anchor exploreSyntacticAnchor, node *graph.Node) bool {
+	if node == nil || !strings.ContainsAny(anchor.source, ".\\/") {
+		return false
+	}
+	want := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(anchor.source), "\\", "/"))
+	got := strings.ToLower(strings.ReplaceAll(nodeDisplayPath(node), "\\", "/"))
+	return want != "" && got != "" && (got == want || strings.HasSuffix(got, "/"+want))
 }
 
 func exploreSyntacticAnchorMatchesIdentifier(anchor exploreSyntacticAnchor, identifier string) bool {
@@ -246,6 +624,9 @@ func exploreSyntacticAnchorNodeStrength(anchor exploreSyntacticAnchor, node *gra
 	}
 	identifierTerms := rerank.Tokenize(node.Name)
 	strength := 0
+	if exploreSyntacticAnchorMatchesPath(anchor, node) {
+		strength = 4
+	}
 	for _, anchorTerm := range anchor.terms {
 		best := 0
 		for _, rawIdentifierTerm := range identifierTerms {
@@ -286,9 +667,34 @@ func exploreSyntacticAnchorCandidate(
 	scope query.QueryOptions,
 	usedIDs, usedFiles map[string]struct{},
 ) *rerank.Candidate {
+	return exploreSyntacticAnchorCandidateWithTie(
+		anchor, candidates, scope, usedIDs, usedFiles, false,
+	)
+}
+
+func exploreSyntacticAnchorCompetingCandidate(
+	anchor exploreSyntacticAnchor,
+	candidates []*rerank.Candidate,
+	scope query.QueryOptions,
+	usedIDs, usedFiles map[string]struct{},
+) *rerank.Candidate {
+	return exploreSyntacticAnchorCandidateWithTie(
+		anchor, candidates, scope, usedIDs, usedFiles, true,
+	)
+}
+
+func exploreSyntacticAnchorCandidateWithTie(
+	anchor exploreSyntacticAnchor,
+	candidates []*rerank.Candidate,
+	scope query.QueryOptions,
+	usedIDs, usedFiles map[string]struct{},
+	preferImplementation bool,
+) *rerank.Candidate {
 	var best *rerank.Candidate
 	bestStrength := 0
 	bestDiverse := false
+	bestSpan := 0
+	bestNameWidth := 0
 	for _, candidate := range candidates {
 		if candidate == nil || !exploreSyntacticAnchorEligibleNode(candidate.Node) ||
 			!scope.ScopeAllows(candidate.Node) || !exploreSyntacticAnchorMatchesNode(anchor, candidate.Node) {
@@ -300,13 +706,56 @@ func exploreSyntacticAnchorCandidate(
 		strength := exploreSyntacticAnchorNodeStrength(anchor, candidate.Node)
 		_, repeatedFile := usedFiles[candidate.Node.FilePath]
 		diverse := !repeatedFile
-		if best == nil || strength > bestStrength || (strength == bestStrength && diverse && !bestDiverse) {
+		span := max(0, candidate.Node.EndLine-candidate.Node.StartLine)
+		nameWidth := len(strings.TrimSpace(candidate.Node.Name))
+		if best == nil || strength > bestStrength ||
+			(strength == bestStrength && diverse && !bestDiverse) ||
+			(preferImplementation && strength == bestStrength && diverse == bestDiverse && nameWidth < bestNameWidth) ||
+			(preferImplementation && strength == bestStrength && diverse == bestDiverse && nameWidth == bestNameWidth && span > bestSpan) {
 			best = candidate
 			bestStrength = strength
 			bestDiverse = diverse
+			bestSpan = span
+			bestNameWidth = nameWidth
 		}
 	}
 	return best
+}
+
+// A bare one-term flag can match several equally strong compound callables.
+// Fetch the existing bounded lexical lane only for that ambiguity class; the
+// ordinary selector remains unchanged for every other anchor.
+func exploreSyntacticAnchorNeedsLexicalCompetition(anchor exploreSyntacticAnchor, candidate *rerank.Candidate) bool {
+	if candidate == nil || candidate.Node == nil || len(anchor.terms) != 1 ||
+		exploreSyntacticAnchorMatchesPath(anchor, candidate.Node) {
+		return false
+	}
+	switch candidate.Node.Kind {
+	case graph.KindFunction, graph.KindMethod:
+	default:
+		return false
+	}
+	identifierTerms := rerank.Tokenize(candidate.Node.Name)
+	if len(identifierTerms) < 2 {
+		return false
+	}
+	for _, term := range identifierTerms {
+		if strings.EqualFold(term, anchor.terms[0]) {
+			return true
+		}
+	}
+	return false
+}
+
+// Ambiguous one-term flags such as --replace often have many prefix-sharing
+// helpers. Widen only that bounded lexical lane so the concrete implementation
+// (for example replace_all) can compete with generic helpers such as
+// replace_separator; ordinary identifiers retain the smaller fetch.
+func exploreSyntacticAnchorFetchLimit(anchor exploreSyntacticAnchor, candidate *rerank.Candidate) int {
+	if exploreSyntacticAnchorNeedsLexicalCompetition(anchor, candidate) {
+		return exploreSyntacticAnchorCompetitionFetch
+	}
+	return exploreSyntacticAnchorFetch
 }
 
 func exploreSyntacticAnchorReusesProtected(
@@ -314,8 +763,12 @@ func exploreSyntacticAnchorReusesProtected(
 	candidates []*rerank.Candidate,
 	usedIDs map[string]struct{},
 ) string {
+	qualifiedMember := strings.Contains(anchor.source, "::")
 	for _, candidate := range candidates {
 		if candidate == nil || candidate.Node == nil {
+			continue
+		}
+		if qualifiedMember && (candidate.Node.Kind == graph.KindType || candidate.Node.Kind == graph.KindInterface) {
 			continue
 		}
 		if _, used := usedIDs[candidate.Node.ID]; used && exploreSyntacticAnchorMatchesNode(anchor, candidate.Node) {
@@ -325,10 +778,71 @@ func exploreSyntacticAnchorReusesProtected(
 	return ""
 }
 
+// exploreExactQualifiedAnchorCandidate resolves the parser's exact member name
+// before the bounded lexical lane. Graph nodes commonly store only the terminal
+// method Name while the ID tail carries Owner.member, so query both exact forms.
+// This lookup is restricted to explicit Owner::member task syntax and still
+// applies session, query, kind, and diversity filters through the ordinary
+// anchor selector.
+func (s *Server) exploreExactQualifiedAnchorCandidate(
+	ctx context.Context,
+	anchor exploreSyntacticAnchor,
+	scope query.QueryOptions,
+	usedIDs, usedFiles map[string]struct{},
+) *rerank.Candidate {
+	if s == nil || s.graph == nil || anchor.qualifiedName == "" || ctx.Err() != nil {
+		return nil
+	}
+	names := []string{anchor.qualifiedName}
+	if dot := strings.LastIndexByte(anchor.qualifiedName, '.'); dot >= 0 && dot < len(anchor.qualifiedName)-1 {
+		names = []string{anchor.qualifiedName[dot+1:], anchor.qualifiedName}
+	}
+	candidates := make([]*rerank.Candidate, 0, exploreSyntacticAnchorFetch)
+	seen := make(map[string]struct{}, exploreSyntacticAnchorFetch)
+	for _, name := range names {
+		for _, node := range s.graph.FindNodesByName(name) {
+			if node == nil || !s.nodeInSessionScope(ctx, node) {
+				continue
+			}
+			if _, duplicate := seen[node.ID]; duplicate {
+				continue
+			}
+			seen[node.ID] = struct{}{}
+			candidates = append(candidates, &rerank.Candidate{Node: node, VectorRank: -1})
+			if len(candidates) == exploreSyntacticAnchorFetch {
+				break
+			}
+		}
+		if len(candidates) == exploreSyntacticAnchorFetch {
+			break
+		}
+	}
+	return exploreSyntacticAnchorCandidate(anchor, candidates, scope, usedIDs, usedFiles)
+}
+
 // gatherExploreSyntacticAnchorCandidates performs a tiny lexical retrieval for
 // each anchor not represented by the ordinary over-fetch pool. Only after that
 // identifier lane misses do we invoke the existing request-local source scan.
 // One diverse node per anchor is retained; no source body is persisted.
+func markExploreSyntacticAnchorCandidate(candidate *rerank.Candidate) {
+	if candidate == nil {
+		return
+	}
+	// Candidate clones elsewhere in the reranking pipeline may share the same
+	// signal map. Copy before tagging so provenance cannot leak to an unselected
+	// sibling through that shallow clone.
+	signals := make(map[string]float64, len(candidate.Signals)+2)
+	for name, value := range candidate.Signals {
+		signals[name] = value
+	}
+	// The concept marker preserves the row in existing bounded selectors; the
+	// dedicated marker survives into rendered provenance so PRIMARY confidence
+	// can distinguish an explicit task-spelled anchor from a semantic neighbour.
+	signals[exploreConceptComplementSignal] = 1
+	signals[exploreSyntacticAnchorSignal] = 1
+	candidate.Signals = signals
+}
+
 func (s *Server) gatherExploreSyntacticAnchorCandidates(
 	ctx context.Context,
 	task string,
@@ -351,6 +865,7 @@ func (s *Server) gatherExploreSyntacticAnchorCandidates(
 		if candidate.Node.FilePath != "" {
 			usedFiles[candidate.Node.FilePath] = struct{}{}
 		}
+		markExploreSyntacticAnchorCandidate(candidate)
 	}
 
 	additions := make([]*rerank.Candidate, 0, len(anchors))
@@ -370,17 +885,35 @@ func (s *Server) gatherExploreSyntacticAnchorCandidates(
 			protected[index] = reused
 			continue
 		}
+		if exactCandidate := s.exploreExactQualifiedAnchorCandidate(ctx, anchor, scope, usedIDs, usedFiles); exactCandidate != nil {
+			protectedCandidate := exactCandidate
+			for _, existing := range ordinary {
+				if existing != nil && existing.Node != nil && existing.Node.ID == exactCandidate.Node.ID {
+					protectedCandidate = existing
+					break
+				}
+			}
+			if protectedCandidate == exactCandidate {
+				additions = append(additions, exactCandidate)
+			}
+			addProtected(index, protectedCandidate)
+			continue
+		}
 		ordinaryCandidate := exploreSyntacticAnchorCandidate(anchor, ordinary, scope, usedIDs, usedFiles)
-		if ordinaryCandidate != nil && exploreSyntacticAnchorNodeStrength(anchor, ordinaryCandidate.Node) >= 4 {
+		compete := exploreSyntacticAnchorNeedsLexicalCompetition(anchor, ordinaryCandidate)
+		if ordinaryCandidate != nil && exploreSyntacticAnchorNodeStrength(anchor, ordinaryCandidate.Node) >= 4 && !compete {
 			addProtected(index, ordinaryCandidate)
 			continue
 		}
-		rows := eng.GatherSymbolCandidates(anchor.query, exploreSyntacticAnchorFetch, anchorOpts, rctx)
+		rows := eng.GatherSymbolCandidates(anchor.query, exploreSyntacticAnchorFetchLimit(anchor, ordinaryCandidate), anchorOpts, rctx)
 		combined := rows
 		if ordinaryCandidate != nil {
 			combined = append([]*rerank.Candidate{ordinaryCandidate}, rows...)
 		}
 		candidate := exploreSyntacticAnchorCandidate(anchor, combined, scope, usedIDs, usedFiles)
+		if compete {
+			candidate = exploreSyntacticAnchorCompetingCandidate(anchor, combined, scope, usedIDs, usedFiles)
+		}
 		if candidate == nil {
 			missed = append(missed, index)
 			continue

--- a/internal/mcp/localization_explicit_anchor_test.go
+++ b/internal/mcp/localization_explicit_anchor_test.go
@@ -1,0 +1,386 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/query"
+	"github.com/zzet/gortex/internal/search/rerank"
+)
+
+func TestExploreSyntacticAnchorsDoNotSpendBudgetOnHTTPRouteMethods(t *testing.T) {
+	task := `HandleMethodNotAllowed with r.GET("/base/metrics"), r.DELETE("/base/v1/organizations/:id"), then panic in tree.go getValue`
+	anchors := exploreSyntacticAnchors(task)
+	if len(anchors) != 3 {
+		t.Fatalf("anchors = %#v, want three implementation anchors", anchors)
+	}
+	got := []string{anchors[0].compact, anchors[1].compact, anchors[2].compact}
+	want := []string{"handlemethodnotallowed", "tree", "getvalue"}
+	for index := range want {
+		if got[index] != want[index] {
+			t.Fatalf("anchor %d = %q, want %q (all=%v)", index, got[index], want[index], got)
+		}
+	}
+}
+
+func TestExploreSyntacticAnchorsPreserveQualifiedMemberAlongsideOwner(t *testing.T) {
+	anchors := exploreSyntacticAnchors(`Find HipChatHandler and HipChatHandler::buildContent()`)
+	if len(anchors) != 2 {
+		t.Fatalf("anchors = %#v, want owner and qualified member", anchors)
+	}
+	if anchors[0].compact != "hipchathandler" || anchors[1].compact != "hipchathandlerbuildcontent" {
+		t.Fatalf("anchor compacts = [%s, %s], want owner then qualified member", anchors[0].compact, anchors[1].compact)
+	}
+	if anchors[1].query != "HipChatHandler buildContent" {
+		t.Fatalf("qualified member lookup = %q, want literal owner and member", anchors[1].query)
+	}
+	if anchors[1].qualifiedName != "HipChatHandler.buildContent" {
+		t.Fatalf("qualified graph name = %q, want parser owner.member name", anchors[1].qualifiedName)
+	}
+}
+
+func TestExploreSyntacticAnchorsKeepQualifiedMemberInLongIssue(t *testing.T) {
+	anchors := exploreSyntacticAnchors(`Title: HipChatHandler: Parameter validation/handling
+The HipChat API at https://www.hipchat.com/docs/api/method/rooms/message limits the from parameter.
+When a HipChatHandler is instantiated with a longer name it should fail.
+Similarly, strip longer messages within HipChatHandler::buildContent().`)
+	for _, anchor := range anchors {
+		if anchor.qualifiedName == "HipChatHandler.buildContent" {
+			return
+		}
+	}
+	t.Fatalf("anchors = %#v, qualified member was displaced from bounded issue anchors", anchors)
+}
+
+func TestExploreSyntacticAnchorQualifiedMemberDoesNotReuseOwner(t *testing.T) {
+	anchors := exploreSyntacticAnchors(`Find HipChatHandler and HipChatHandler::buildContent()`)
+	if len(anchors) != 2 {
+		t.Fatalf("anchors = %#v, want owner and qualified member", anchors)
+	}
+	owner := &rerank.Candidate{Node: &graph.Node{
+		ID: "HipChatHandler.php::HipChatHandler", Name: "HipChatHandler",
+		QualName: "Monolog.Handler.HipChatHandler", Kind: graph.KindType,
+	}}
+	member := &rerank.Candidate{Node: &graph.Node{
+		ID: "HipChatHandler.php::HipChatHandler.buildContent", Name: "HipChatHandler.buildContent",
+		Kind: graph.KindMethod,
+	}}
+	wrongOwner := &graph.Node{
+		ID: "OtherHandler.php::OtherHandler.buildContent", Name: "buildContent",
+		Kind: graph.KindMethod,
+	}
+	if !exploreSyntacticAnchorMatchesNode(anchors[1], member.Node) {
+		t.Fatal("qualified member did not match its parser ID when QualName was empty")
+	}
+	if exploreSyntacticAnchorMatchesNode(anchors[1], wrongOwner) {
+		t.Fatal("qualified member matched the same method name under a different owner")
+	}
+	candidates := []*rerank.Candidate{owner, member}
+	if got := exploreSyntacticAnchorReusesProtected(anchors[0], candidates, map[string]struct{}{owner.Node.ID: {}}); got != owner.Node.ID {
+		t.Fatalf("owner reuse = %q, want %q", got, owner.Node.ID)
+	}
+	used := map[string]struct{}{owner.Node.ID: {}, member.Node.ID: {}}
+	if got := exploreSyntacticAnchorReusesProtected(anchors[1], candidates, used); got != member.Node.ID {
+		t.Fatalf("qualified member reuse = %q, want %q instead of owner", got, member.Node.ID)
+	}
+}
+
+func TestExploreExactQualifiedAnchorCandidateFindsParserName(t *testing.T) {
+	anchors := exploreSyntacticAnchors(`Find HipChatHandler and HipChatHandler::buildContent()`)
+	if len(anchors) != 2 {
+		t.Fatalf("anchors = %#v, want owner and qualified member", anchors)
+	}
+	g := graph.New()
+	member := &graph.Node{
+		ID:   "src/Monolog/Handler/HipChatHandler.php::HipChatHandler.buildContent",
+		Name: "buildContent", Kind: graph.KindMethod,
+		FilePath: "src/Monolog/Handler/HipChatHandler.php", StartLine: 89,
+	}
+	g.AddNode(member)
+	g.AddNode(&graph.Node{
+		ID:   "src/Monolog/Handler/OtherHandler.php::OtherHandler.buildContent",
+		Name: "OtherHandler.buildContent", Kind: graph.KindMethod,
+		FilePath: "src/Monolog/Handler/OtherHandler.php", StartLine: 42,
+	})
+	server := &Server{graph: g}
+	got := server.exploreExactQualifiedAnchorCandidate(
+		context.Background(), anchors[1], query.QueryOptions{},
+		map[string]struct{}{}, map[string]struct{}{},
+	)
+	if got == nil || got.Node == nil {
+		t.Fatal("exact qualified lookup returned no candidate")
+	}
+	if got.Node.ID != member.ID {
+		t.Fatalf("exact qualified lookup = %q, want %q", got.Node.ID, member.ID)
+	}
+}
+
+func TestExploreSourceRangeSpecsPairPathsWithFollowingLines(t *testing.T) {
+	task := `monolog/src/Monolog/Handler/FingersCrossedHandler.php
+		Lines 185 to 187
+		monolog/tests/Monolog/Handler/FingersCrossedHandlerTest.php
+		Lines 253 to 265`
+	specs := exploreSourceRangeSpecs(task)
+	if len(specs) != 2 {
+		t.Fatalf("source range specs = %#v, want production and test ranges", specs)
+	}
+	if specs[0].File != "monolog/src/Monolog/Handler/FingersCrossedHandler.php" || specs[0].StartLine != 185 || specs[0].EndLine != 187 {
+		t.Fatalf("production range = %#v", specs[0])
+	}
+	if specs[1].File != "monolog/tests/Monolog/Handler/FingersCrossedHandlerTest.php" || specs[1].StartLine != 253 || specs[1].EndLine != 265 {
+		t.Fatalf("test range = %#v", specs[1])
+	}
+}
+
+func TestExploreSourceRangeDefinitionsPreferNamedOwnerOverClosure(t *testing.T) {
+	idx := &fileSymbolIndex{}
+	idx.add(&graph.Node{ID: "handler.php::flushBuffer", Name: "flushBuffer", Kind: graph.KindMethod, StartLine: 170, EndLine: 200})
+	idx.add(&graph.Node{ID: "handler.php::flushBuffer#closure", Name: "closure", Kind: graph.KindClosure, StartLine: 185, EndLine: 187})
+	idx.finalise()
+	got := exploreSourceRangeDefinitions(idx, 185, 187)
+	if len(got) != 1 || got[0].ID != "handler.php::flushBuffer" {
+		t.Fatalf("source range definitions = %#v, want named enclosing method", got)
+	}
+}
+
+func TestPromoteExploreSourceRangeCandidatesMapsToEnclosingMethod(t *testing.T) {
+	server, store := setupNavServer(t)
+	start := store.GetNode(navFindMethod(t, store, "Start"))
+	stop := store.GetNode(navFindMethod(t, store, "Stop"))
+	task := fmt.Sprintf("svc.go\nLines %d to %d", start.StartLine, start.EndLine)
+	ordinary := []*rerank.Candidate{{Node: stop, TextRank: 0, VectorRank: -1}}
+	got := server.promoteExploreSourceRangeCandidates(context.Background(), task, ordinary, query.QueryOptions{})
+	if len(got) != 2 || got[0].Node.ID != start.ID || got[1].Node.ID != stop.ID {
+		t.Fatalf("promoted candidates = %#v, want cited Start then ordinary Stop", got)
+	}
+	if got[0].Signals[exploreSyntacticAnchorSignal] != 1 || got[0].Signals[exploreConceptComplementSignal] != 1 {
+		t.Fatalf("cited candidate signals = %#v, want protected syntactic evidence", got[0].Signals)
+	}
+}
+
+func TestPromoteExploreSourceRangeCandidatesStripsIsolatedRepoLabel(t *testing.T) {
+	server, store := setupNavServer(t)
+	start := store.GetNode(navFindMethod(t, store, "Start"))
+	stop := store.GetNode(navFindMethod(t, store, "Stop"))
+	task := fmt.Sprintf("monolog/svc.go\nLines %d to %d", start.StartLine, start.EndLine)
+	ordinary := []*rerank.Candidate{{Node: stop, TextRank: 0, VectorRank: -1}}
+	got := server.promoteExploreSourceRangeCandidates(context.Background(), task, ordinary, query.QueryOptions{})
+	if len(got) != 2 || got[0].Node.ID != start.ID || got[1].Node.ID != stop.ID {
+		t.Fatalf("promoted candidates = %#v, want repo-prefixed citation to resolve indexed svc.go", got)
+	}
+}
+
+func TestExploreSourceRangeIndexRejectsAmbiguousSuffixes(t *testing.T) {
+	exact := &fileSymbolIndex{}
+	first := &fileSymbolIndex{}
+	second := &fileSymbolIndex{}
+	aliases := []string{"repo/pkg/svc.go", "pkg/svc.go", "svc.go"}
+	if got := exploreSourceRangeIndex(map[string]*fileSymbolIndex{aliases[0]: exact, aliases[1]: first, aliases[2]: second}, aliases); got != exact {
+		t.Fatalf("exact index = %p, want %p", got, exact)
+	}
+	if got := exploreSourceRangeIndex(map[string]*fileSymbolIndex{aliases[1]: first, aliases[2]: second}, aliases); got != nil {
+		t.Fatalf("ambiguous suffix index = %p, want nil", got)
+	}
+	if got := exploreSourceRangeIndex(map[string]*fileSymbolIndex{aliases[1]: first}, aliases); got != first {
+		t.Fatalf("unique suffix index = %p, want %p", got, first)
+	}
+}
+
+func TestExploreLocalizationTestLaneCandidateKeepsCitedTestRange(t *testing.T) {
+	node := &graph.Node{
+		ID: "tests/HandlerTest.php::testPassthruOnClose", Name: "testPassthruOnClose",
+		Kind: graph.KindMethod, FilePath: "tests/HandlerTest.php", Meta: map[string]any{"is_test": true},
+	}
+	candidate := &rerank.Candidate{Node: node, Signals: map[string]float64{exploreSourceRangeSignal: 1}}
+	if exploreLocalizationTestLaneCandidate("passthru level failure", candidate) {
+		t.Fatal("explicitly cited test range was demoted")
+	}
+	delete(candidate.Signals, exploreSourceRangeSignal)
+	if !exploreLocalizationTestLaneCandidate("passthru level failure", candidate) {
+		t.Fatal("ordinary test candidate was not demoted")
+	}
+}
+
+func TestExploreSyntacticAnchorsCollapseAssignedAndBareFlags(t *testing.T) {
+	anchors := exploreSyntacticAnchors(`rg panic caused by --replace, --multiline, a particular pattern, and search text containing repeats and newlines. Panic message: "slice index starts at x but ends at y" where x and y are integers and y < x. Reproduction: rg "(^|[^a-z])((([a-z]+)?)\s)?b(\s([a-z]+)?)($|[^a-z])" --replace=x --multiline lines2.txt where lines2.txt contains " b b b b b b b b\nc". Also reproduces with lines5.txt containing " b\nb\nb\nb\nc". Bug is very sensitive to exact pattern and text.`)
+	if len(anchors) != 2 {
+		t.Fatalf("anchors = %#v, want one replace lane and one multiline lane", anchors)
+	}
+	if anchors[0].compact != "replace" || anchors[1].compact != "multiline" {
+		t.Fatalf("anchor compacts = [%s, %s], want replace then multiline", anchors[0].compact, anchors[1].compact)
+	}
+}
+
+func TestExploreSyntacticAnchorCompetitionIsScopedToBareCompoundCallable(t *testing.T) {
+	anchor, ok := newExploreSyntacticAnchor("--replace")
+	if !ok {
+		t.Fatal("replace flag did not produce a syntactic anchor")
+	}
+	separator := &rerank.Candidate{Node: &graph.Node{
+		ID: "crates/printer/src/util.rs::replace_separator", Name: "replace_separator",
+		QualName: "replace_separator", Kind: graph.KindFunction, FilePath: "crates/printer/src/util.rs",
+		StartLine: 10, EndLine: 210,
+	}}
+	replacement := &rerank.Candidate{Node: &graph.Node{
+		ID: "crates/printer/src/util.rs::Replacer.replacement", Name: "replacement",
+		QualName: "Replacer.replacement", Kind: graph.KindMethod, FilePath: "crates/printer/src/util.rs",
+		StartLine: 113, EndLine: 124,
+	}}
+	replaceAll := &rerank.Candidate{Node: &graph.Node{
+		ID: "crates/printer/src/util.rs::Replacer.replace_all", Name: "replace_all",
+		QualName: "Replacer.replace_all", Kind: graph.KindMethod, FilePath: "crates/printer/src/util.rs",
+		StartLine: 55, EndLine: 111,
+	}}
+	candidates := []*rerank.Candidate{separator, replacement, replaceAll}
+	usedIDs, usedFiles := map[string]struct{}{}, map[string]struct{}{}
+	if !exploreSyntacticAnchorNeedsLexicalCompetition(anchor, separator) {
+		t.Fatal("bare replace anchor prematurely settled on compound replace_separator")
+	}
+	ordinary := exploreSyntacticAnchorCandidate(
+		anchor, candidates, query.QueryOptions{}, usedIDs, usedFiles,
+	)
+	if ordinary == nil || ordinary.Node.ID != separator.Node.ID {
+		t.Fatalf("ordinary selection = %#v, want stable first candidate", ordinary)
+	}
+	competing := exploreSyntacticAnchorCompetingCandidate(
+		anchor, candidates, query.QueryOptions{}, usedIDs, usedFiles,
+	)
+	if competing == nil || competing.Node.ID != replaceAll.Node.ID {
+		t.Fatalf("competing selection = %#v, want specific replace_all implementation despite larger generic body", competing)
+	}
+
+	explicit, ok := newExploreSyntacticAnchor("replace_separator")
+	if !ok {
+		t.Fatal("explicit replace_separator did not produce an anchor")
+	}
+	if exploreSyntacticAnchorNeedsLexicalCompetition(explicit, separator) {
+		t.Fatal("multi-term explicit replace_separator was treated as ambiguous")
+	}
+	exact := &rerank.Candidate{Node: &graph.Node{
+		ID: "crates/printer/src/util.rs::replace", Name: "replace",
+		Kind: graph.KindFunction, FilePath: "crates/printer/src/util.rs",
+	}}
+	if exploreSyntacticAnchorNeedsLexicalCompetition(anchor, exact) {
+		t.Fatal("atomic exact replace match was treated as ambiguous")
+	}
+	if got := exploreSyntacticAnchorFetchLimit(anchor, separator); got != exploreSyntacticAnchorCompetitionFetch {
+		t.Fatalf("ambiguous replace fetch = %d, want %d", got, exploreSyntacticAnchorCompetitionFetch)
+	}
+	if got := exploreSyntacticAnchorFetchLimit(explicit, separator); got != exploreSyntacticAnchorFetch {
+		t.Fatalf("exact replace_separator fetch = %d, want %d", got, exploreSyntacticAnchorFetch)
+	}
+}
+
+func TestMarkExploreSyntacticAnchorCandidateCarriesDedicatedProvenanceSignal(t *testing.T) {
+	shared := map[string]float64{"existing": 1}
+	candidate := &rerank.Candidate{Node: &graph.Node{ID: "pkg/util.rs::Replacer.replace_all"}, Signals: shared}
+	sibling := &rerank.Candidate{Node: &graph.Node{ID: "pkg/lines.rs::lines"}, Signals: shared}
+	markExploreSyntacticAnchorCandidate(candidate)
+	if candidate.Signals[exploreConceptComplementSignal] != 1 || candidate.Signals[exploreSyntacticAnchorSignal] != 1 {
+		t.Fatalf("signals = %#v, want concept retention plus syntactic provenance", candidate.Signals)
+	}
+	if sibling.Signals[exploreConceptComplementSignal] != 0 || sibling.Signals[exploreSyntacticAnchorSignal] != 0 {
+		t.Fatalf("syntactic provenance leaked to unselected sibling: %#v", sibling.Signals)
+	}
+	if candidate.Signals["existing"] != 1 {
+		t.Fatalf("existing signal was lost: %#v", candidate.Signals)
+	}
+}
+
+func TestExploreQueryPathAnchorsIgnoreHTTPRouteExamples(t *testing.T) {
+	query := `HandleMethodNotAllowed r.GET("/base/metrics") r.GET("/base/v1/:id/devices") panic in github.com/gin-gonic/gin.(*node).getValue at tree.go:637`
+	syntactic := exploreSyntacticAnchors(query)
+	if len(syntactic) != 3 || syntactic[2].compact != "tree" {
+		t.Fatalf("stack source location anchor = %#v, want trailing tree", syntactic)
+	}
+	anchors, hasDirectory := exploreQueryPathAnchors(query)
+	if hasDirectory || len(anchors) != 0 {
+		t.Fatalf("runtime routes became source paths: anchors=%v hasDirectory=%v", anchors, hasDirectory)
+	}
+	node := &graph.Node{
+		ID:       "tree.go::node.getValue",
+		Name:     "getValue",
+		QualName: "node.getValue",
+		Kind:     graph.KindMethod,
+		FilePath: "tree.go",
+	}
+	if !exploreLocalizationExplicitAnchor(query, node) {
+		t.Fatal("explicit tree.go/getValue anchor was hidden by HTTP route examples")
+	}
+}
+
+func TestLocalizationEvidenceTargetsPreserveProtectedSyntacticAnchorBeforeDraftRelations(t *testing.T) {
+	head := exploreTarget{node: &graph.Node{
+		ID: "crates/core/flags/hiargs.rs::suggest_multiline", Name: "suggest_multiline",
+		QualName: "suggest_multiline", Kind: graph.KindFunction, FilePath: "crates/core/flags/hiargs.rs",
+	}}
+	unrelated := exploreTarget{node: &graph.Node{
+		ID: "crates/core/flags/hiargs.rs::BinaryMode.Auto", Name: "Auto",
+		QualName: "BinaryMode.Auto", Kind: graph.KindMethod, FilePath: "crates/core/flags/hiargs.rs",
+	}}
+	replaceAll := exploreTarget{
+		node: &graph.Node{
+			ID: "crates/printer/src/util.rs::Replacer.replace_all", Name: "replace_all",
+			QualName: "Replacer.replace_all", Kind: graph.KindMethod, FilePath: "crates/printer/src/util.rs",
+		},
+		conceptComplement: true,
+	}
+	targets := []exploreTarget{head, unrelated, replaceAll}
+	selected := localizationEvidenceTargetsFromDraft(
+		"--replace with --multiline panics while replacing repeated matches",
+		"",
+		targets,
+		[]exploreDraftEntry{{node: head.node}, {node: unrelated.node}, {node: replaceAll.node}},
+	)
+	if len(selected) != len(targets) {
+		t.Fatalf("selected = %#v, want all targets", selected)
+	}
+	if selected[0].node.ID != head.node.ID || selected[1].node.ID != replaceAll.node.ID {
+		t.Fatalf("selected order = [%s, %s], want retrieval head then protected replace anchor", selected[0].node.ID, selected[1].node.ID)
+	}
+}
+
+func TestLocalizationEvidenceTargetsPrioritizeExplicitConsumerBeforeCausalOwner(t *testing.T) {
+	explicit := exploreTarget{node: &graph.Node{
+		ID:       "src/Monolog/Handler/StreamHandler.php::StreamHandler.write",
+		Name:     "write",
+		QualName: "StreamHandler.write",
+		Kind:     graph.KindMethod,
+		FilePath: "src/Monolog/Handler/StreamHandler.php",
+	}}
+	owner := exploreTarget{
+		node: &graph.Node{
+			ID:       "src/Monolog/Handler/RotatingFileHandler.php::RotatingFileHandler.__construct",
+			Name:     "__construct",
+			QualName: "RotatingFileHandler.__construct",
+			Kind:     graph.KindMethod,
+			FilePath: "src/Monolog/Handler/RotatingFileHandler.php",
+		},
+		divergentDefaultOwner: true,
+	}
+	ownerType := exploreTarget{
+		node: &graph.Node{
+			ID:       "src/Monolog/Handler/RotatingFileHandler.php::RotatingFileHandler",
+			Name:     "RotatingFileHandler",
+			QualName: "RotatingFileHandler",
+			Kind:     graph.KindType,
+			FilePath: "src/Monolog/Handler/RotatingFileHandler.php",
+		},
+		divergentDefaultType: true,
+	}
+	targets := []exploreTarget{owner, ownerType, explicit}
+	selected := localizationEvidenceTargetsFromDraft(
+		"chmod failure in src/Monolog/Handler/StreamHandler.php::StreamHandler.write",
+		owner.node.ID,
+		targets,
+		[]exploreDraftEntry{{node: owner.node}, {node: ownerType.node}, {node: explicit.node}},
+	)
+	if len(selected) < 2 {
+		t.Fatalf("selected = %#v, want explicit target plus causal owner", selected)
+	}
+	if selected[0].node.ID != explicit.node.ID || selected[1].node.ID != owner.node.ID {
+		t.Fatalf("selected order = [%s, %s], want explicit consumer then causal owner", selected[0].node.ID, selected[1].node.ID)
+	}
+}

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -84,11 +84,15 @@ type exploreTarget struct {
 	callees               []*graph.Node
 	directCalleesComplete bool // false when the direct projection was truncated, bounded, or otherwise lower-bound
 	causalCallees         []exploreCausalNeighbor
+	causalChangeBridge    bool   // one graph-proven caller/callee retained as provenance for a promoted continuation
+	causalChangeLeaf      bool   // graph-proven wrapper implementation or task-aligned cross-file change callable
+	causalChangeOwner     bool   // same-file type that encloses or is uniquely returned by the causal change callable
 	source                string // full body (may be empty for non-source kinds)
 	divergentDefaultOwner bool   // unique child constructor whose concrete default causes the queried behavior
 	divergentDefaultType  bool   // owning type paired with divergentDefaultOwner for coherent file/symbol output
 	conceptImplementation bool   // primary identifier-backed callable; may establish answer readiness
 	conceptComplement     bool   // marginal concept callable protected as evidence, never as terminal proof
+	syntacticAnchor       bool   // task-spelled flag/identifier owner protected by bounded lexical competition
 	exactContent          bool   // verified full quoted-literal hit from content_fts
 	exactContentAmbiguous bool   // exact evidence has visible or possibly truncated peers
 	sourceLiteral         bool   // exact source-body hit that must survive final envelope packing
@@ -2582,6 +2586,27 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 		}, s.divergentDefaultFallbackSLOOverride)
 		targets = append(targets[:len(artifactTargets):len(artifactTargets)], symbolTargets...)
 	}
+	// Causal-change promotion is the second concept lane over the same ranked
+	// head. A divergent-default proof is the stronger, pinned claim on that head
+	// and already carries its own provenance pair, so only reach for a causal
+	// route when that promotion did not take the lead.
+	if len(targets) > len(artifactTargets) {
+		symbolTargets := targets[len(artifactTargets):]
+		if exploreDivergentDefaultOwnerSymbol(symbolTargets) == "" {
+			symbolTargets = promoteExploreCausalChangeTargets(task, symbolTargets, s.graph, maxSymbols, func(node *graph.Node) string {
+				return s.manifestSymbolSource(ctx, node)
+			}, func(node *graph.Node) ([]*graph.Node, bool) {
+				callees := eng.GetCallChain(node.ID, ringOpts)
+				if callees == nil {
+					return nil, false
+				}
+				direct, projectionComplete := ringNeighborsProjection(callees.Nodes, node.ID, exploreRingCap)
+				complete := !callees.Truncated && !callees.BudgetHit && !callees.LowerBound && projectionComplete
+				return direct, complete
+			})
+			targets = append(targets[:len(artifactTargets):len(artifactTargets)], symbolTargets...)
+		}
+	}
 	// Direct retrieval owns the ranked head. Once graph promotion has selected
 	// a cross-file boundary, materialize exactly that one node so both text and
 	// structured responses can reserve a source body without a broad read.
@@ -3166,6 +3191,27 @@ func localizationEvidenceTargetsFromDraft(task, exactID string, targets []explor
 			appendTarget(target)
 		}
 	}
+	// A graph-proven change owner, bridge, and continuation outrank concept-only
+	// retrieval complements. The retrieval head remains first; this reservation
+	// only replaces non-causal tail rows when the final evidence window is full.
+	for _, target := range targets {
+		if target.causalChangeOwner {
+			appendTarget(target)
+			break
+		}
+	}
+	for _, target := range targets {
+		if target.causalChangeBridge {
+			appendTarget(target)
+			break
+		}
+	}
+	for _, target := range targets {
+		if target.causalChangeLeaf {
+			appendTarget(target)
+			break
+		}
+	}
 	// Concept reservations are weaker than exact, source-literal, typed, and
 	// divergent causal evidence, but stronger than draft relations. Keep the
 	// primary and up to two diverse complements adjacent whenever those stronger
@@ -3288,11 +3334,13 @@ func interleaveLocalizationDirectRelationsWithRoutes(
 		}
 		direct[target.node.ID] = target
 		if index < localizationDirectEvidenceReserve || target.node.ID == requiredID ||
+			target.causalChangeBridge || target.causalChangeLeaf || target.causalChangeOwner ||
 			target.divergentDefaultOwner || target.divergentDefaultType || target.conceptImplementation || target.conceptComplement ||
 			target.exactContent || target.sourceLiteral || target.typedAnchorProjection {
 			protected[target.node.ID] = struct{}{}
 		}
-		if target.node.ID == requiredID || target.divergentDefaultOwner || target.divergentDefaultType ||
+		if target.node.ID == requiredID || target.causalChangeBridge || target.causalChangeLeaf || target.causalChangeOwner ||
+			target.divergentDefaultOwner || target.divergentDefaultType ||
 			target.conceptImplementation || target.conceptComplement ||
 			target.exactContent || target.sourceLiteral || target.typedAnchorProjection {
 			orderedPrefix = index + 1
@@ -3410,6 +3458,7 @@ func interleaveLocalizationDirectRelationsWithRoutes(
 		if !exists {
 			relation = exploreTarget{node: best.node, localizationRelation: best.direction}
 		} else if relation.node.ID != requiredID &&
+			!relation.causalChangeBridge && !relation.causalChangeLeaf && !relation.causalChangeOwner &&
 			!relation.divergentDefaultOwner && !relation.divergentDefaultType &&
 			!relation.conceptImplementation && !relation.conceptComplement &&
 			!relation.exactContent && !relation.sourceLiteral && !relation.typedAnchorProjection {

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path"
 	"regexp"
 	"sort"
 	"strings"
@@ -477,7 +478,8 @@ func exploreAnswerDraft(task string, targets []exploreTarget) []exploreDraftEntr
 	}
 	makeEntry := func(n *graph.Node, source, evidence string, direct bool, parentRank int) (exploreDraftEntry, int) {
 		overlap, longest := exploreDraftTermOverlap(queryTerms, n)
-		explicitAnchor := exploreLocalizationExplicitAnchor(query, n)
+		explicitAnchor := exploreLocalizationExplicitAnchor(query, n) ||
+			exploreTaskQualifiedSyntacticAnchorMatchesNode(task, n)
 		exact := exploreDraftExactAnchor(query, n) || explicitAnchor
 		// Concept prompts often mention a nearby test helper while asking how the
 		// production path works. Do not let that lexical anchor outrank the
@@ -1274,7 +1276,6 @@ func exploreAnswerReady(task string, targets []exploreTarget) bool {
 		!exploreSyntacticAnchorEvidenceReady(task, targets) && !strongSourceLiteral {
 		return false
 	}
-
 	// Paths, signatures, and identifier-shaped queries carry explicit anchors.
 	// A shared token is not enough: the ranked head must cover the complete
 	// path, qualified symbol, or signature anchor from the request.
@@ -1420,11 +1421,50 @@ func exploreNormalizedPath(text string) string {
 }
 
 func exploreQueryPathAnchors(query string) ([]string, bool) {
-	anchors := make([]string, 0, 1)
+	fields := make([]string, 0, 2)
+	routeLike := 0
+	for _, raw := range strings.Fields(query) {
+		field := strings.Trim(raw, "`'\"()[]{}<>,;")
+		// A route is commonly embedded in a call token such as
+		// r.GET("/base/:id"). Extract the quoted value before classifying it;
+		// treating the whole call as a source path poisons every later basename
+		// match in the request.
+		if quote := strings.IndexAny(field, "`'\""); quote >= 0 {
+			field = field[quote+1:]
+			if end := strings.IndexAny(field, "`'\""); end >= 0 {
+				field = field[:end]
+			}
+			field = strings.Trim(field, "`'\"()[]{}<>,;")
+		}
+		if !strings.ContainsAny(field, "/\\") || strings.Contains(field, "://") {
+			continue
+		}
+		// A fully qualified Go stack symbol (`github.com/acme/pkg.(*T).M`) is
+		// a package-qualified callable, not a user-supplied source directory.
+		// Let a later basename/file:line anchor such as `tree.go:637` match
+		// instead of making this package token veto every basename.
+		if strings.Contains(field, "(*") && strings.Contains(field, ").") {
+			continue
+		}
+		fields = append(fields, field)
+		normalized := strings.ReplaceAll(field, "\\", "/")
+		if strings.HasPrefix(normalized, "/") {
+			base := normalized[strings.LastIndex(normalized, "/")+1:]
+			dot := strings.LastIndex(base, ".")
+			if dot <= 0 || dot == len(base)-1 {
+				routeLike++
+			}
+		}
+	}
+
+	anchors := make([]string, 0, len(fields))
 	hasDirectory := false
-	for _, field := range strings.Fields(query) {
-		field = strings.Trim(field, "`'\"()[]{}<>,;")
-		if !strings.ContainsAny(field, "/\\") {
+	for _, field := range fields {
+		normalized := strings.ReplaceAll(field, "\\", "/")
+		base := normalized[strings.LastIndex(normalized, "/")+1:]
+		dot := strings.LastIndex(base, ".")
+		rootedWithoutExtension := strings.HasPrefix(normalized, "/") && (dot <= 0 || dot == len(base)-1)
+		if rootedWithoutExtension && (routeLike >= 2 || strings.Contains(normalized, "/:") || strings.ContainsAny(normalized, "{}")) {
 			continue
 		}
 		hasDirectory = true
@@ -1506,6 +1546,13 @@ func exploreLocalizationExplicitAnchor(query string, n *graph.Node) bool {
 // accepted here: it can rank a neighborhood but must not prescribe the one
 // allowed post-localization source read.
 func exploreLocalizationExplicitTarget(task string, targets []exploreTarget) string {
+	// Preserve exact qualified members from the untouched issue before shaping
+	// can truncate a late Owner::member mention out of a long report body.
+	for _, target := range targets {
+		if target.node != nil && exploreTaskQualifiedSyntacticAnchorMatchesNode(task, target.node) {
+			return target.node.ID
+		}
+	}
 	query := shapeExploreQuery(task)
 	if exploreQueryClass(query) == rerank.QueryClassConcept {
 		query = stripLeadingExploreDirective(query)
@@ -1808,9 +1855,322 @@ type exploreConceptImplementationMetric struct {
 	matchedMask uint64
 }
 
-const exploreConceptComplementSignal = "explore_concept_complement"
+const (
+	exploreConceptComplementSignal = "explore_concept_complement"
+	exploreSyntacticAnchorSignal   = "explore_syntactic_anchor"
+)
 
 // reserveExploreConceptImplementation keeps the strongest identifier-backed
+type exploreComponentConjunctionKey struct {
+	workspaceID string
+	projectID   string
+	repoPrefix  string
+	directory   string
+}
+
+type exploreComponentConjunctionSeed struct {
+	index   int
+	node    *graph.Node
+	file    string
+	matched []bool
+}
+
+type exploreComponentConjunctionScore struct {
+	groups   int
+	marginal int
+	rarity   int
+	longest  int
+}
+
+type exploreComponentConjunctionWinner struct {
+	index    int
+	seedRank int
+	score    exploreComponentConjunctionScore
+}
+
+func exploreComponentConjunctionFile(node *graph.Node) string {
+	if node == nil {
+		return ""
+	}
+	file := path.Clean(strings.ReplaceAll(strings.TrimSpace(node.FilePath), "\\", "/"))
+	if file == "" || file == "." || file == "/" || file == ".." || strings.HasPrefix(file, "../") {
+		return ""
+	}
+	return strings.ToLower(file)
+}
+
+func exploreComponentConjunctionComponent(node *graph.Node) (exploreComponentConjunctionKey, bool) {
+	file := exploreComponentConjunctionFile(node)
+	if file == "" {
+		return exploreComponentConjunctionKey{}, false
+	}
+	directory := path.Dir(file)
+	if directory == "" || directory == "." || directory == "/" || directory == ".." || strings.HasPrefix(directory, "../") {
+		return exploreComponentConjunctionKey{}, false
+	}
+	return exploreComponentConjunctionKey{
+		workspaceID: strings.ToLower(strings.TrimSpace(node.WorkspaceID)),
+		projectID:   strings.ToLower(strings.TrimSpace(node.ProjectID)),
+		repoPrefix:  strings.ToLower(strings.TrimSpace(node.RepoPrefix)),
+		directory:   directory,
+	}, true
+}
+
+func exploreComponentConjunctionMatches(node *graph.Node, terms []string) []bool {
+	matched := make([]bool, len(terms))
+	for index, term := range terms {
+		matched[index] = exploreConceptImplementationHasTerm(node, term)
+	}
+	return matched
+}
+
+func exploreComponentConjunctionScoreCompare(left, right exploreComponentConjunctionScore) int {
+	for _, pair := range [...][2]int{
+		{left.groups, right.groups},
+		{left.marginal, right.marginal},
+		{left.rarity, right.rarity},
+		{left.longest, right.longest},
+	} {
+		if pair[0] > pair[1] {
+			return 1
+		}
+		if pair[0] < pair[1] {
+			return -1
+		}
+	}
+	return 0
+}
+
+// reserveExploreComponentConjunction recovers one callable whose identifier
+// completes a task concept already visible in another file of the same exact
+// component. It only reorders the bounded retrieval pool: no graph or source
+// work is added, the semantic head is fixed, and ambiguous component ties are
+// deliberately left untouched.
+func reserveExploreComponentConjunction(
+	query string,
+	queryClass rerank.QueryClass,
+	candidates []*rerank.Candidate,
+	maxSymbols int,
+) []*rerank.Candidate {
+	if queryClass != rerank.QueryClassConcept || maxSymbols < 2 || len(candidates) < 2 {
+		return candidates
+	}
+	width := min(maxSymbols, len(candidates))
+	if width < 2 {
+		return candidates
+	}
+
+	lowValue := exploreConceptComplementLowValueTermSet(query)
+	queryTermSet := exploreTerminalTerms(query)
+	terms := make([]string, 0, len(queryTermSet))
+	groups := make(map[string]struct{}, len(queryTermSet))
+	for term := range queryTermSet {
+		if _, low := lowValue[term]; low {
+			continue
+		}
+		terms = append(terms, term)
+		groups[exploreConceptBehavioralTermGroup(term)] = struct{}{}
+	}
+	if len(terms) < 2 || len(groups) < 2 {
+		return candidates
+	}
+	sort.Strings(terms)
+
+	leadTerms := exploreTerminalTerms(exploreConceptIssueLead(query))
+	lead := make([]bool, len(terms))
+	leadCount := 0
+	for index, term := range terms {
+		if _, present := leadTerms[term]; present {
+			lead[index] = true
+			leadCount++
+		}
+	}
+	if leadCount == 0 {
+		return candidates
+	}
+
+	matches := make([][]bool, len(candidates))
+	frequency := make([]int, len(terms))
+	for candidateIndex, candidate := range candidates {
+		if candidate == nil || candidate.Node == nil {
+			continue
+		}
+		matches[candidateIndex] = exploreComponentConjunctionMatches(candidate.Node, terms)
+		for termIndex, matched := range matches[candidateIndex] {
+			if matched {
+				frequency[termIndex]++
+			}
+		}
+	}
+
+	seeds := make(map[exploreComponentConjunctionKey][]exploreComponentConjunctionSeed)
+	for index := 0; index < width; index++ {
+		candidate := candidates[index]
+		if candidate == nil || candidate.Node == nil || exploreDraftIsTestNode(candidate.Node) ||
+			!exploreCodeDefinitionKind(candidate.Node.Kind) {
+			continue
+		}
+		component, ok := exploreComponentConjunctionComponent(candidate.Node)
+		if !ok {
+			continue
+		}
+		taskAligned := false
+		for _, matched := range matches[index] {
+			if matched {
+				taskAligned = true
+				break
+			}
+		}
+		if !taskAligned {
+			continue
+		}
+		seeds[component] = append(seeds[component], exploreComponentConjunctionSeed{
+			index: index, node: candidate.Node,
+			file: exploreComponentConjunctionFile(candidate.Node), matched: matches[index],
+		})
+	}
+	if len(seeds) == 0 {
+		return candidates
+	}
+
+	sameNode := func(left, right *graph.Node) bool {
+		if left == nil || right == nil {
+			return false
+		}
+		if left.ID != "" && right.ID != "" {
+			return left.ID == right.ID
+		}
+		return left == right
+	}
+	bestByComponent := make(map[exploreComponentConjunctionKey]exploreComponentConjunctionWinner)
+	for index, candidate := range candidates {
+		if candidate == nil || candidate.Node == nil || exploreDraftIsTestNode(candidate.Node) ||
+			(candidate.Node.Kind != graph.KindFunction && candidate.Node.Kind != graph.KindMethod) ||
+			exploreDraftGenericCandidate(candidate.Node, "") {
+			continue
+		}
+		component, ok := exploreComponentConjunctionComponent(candidate.Node)
+		if !ok {
+			continue
+		}
+		componentSeeds := seeds[component]
+		if len(componentSeeds) == 0 {
+			continue
+		}
+
+		base := make([]bool, len(terms))
+		candidateFile := exploreComponentConjunctionFile(candidate.Node)
+		seedRank := len(candidates)
+		hasOtherSeed := false
+		differentFile := false
+		for _, seed := range componentSeeds {
+			if sameNode(seed.node, candidate.Node) {
+				continue
+			}
+			hasOtherSeed = true
+			if seed.index < seedRank {
+				seedRank = seed.index
+			}
+			if seed.file != candidateFile {
+				differentFile = true
+			}
+			for termIndex, matched := range seed.matched {
+				base[termIndex] = base[termIndex] || matched
+			}
+		}
+		if !hasOtherSeed || !differentFile {
+			continue
+		}
+
+		candidateMatched := 0
+		marginal := 0
+		rarity := 0
+		longest := 0
+		unionGroups := make(map[string]struct{}, len(groups))
+		leadAligned := false
+		for termIndex, term := range terms {
+			candidateHasTerm := matches[index][termIndex]
+			if candidateHasTerm {
+				candidateMatched++
+				if len(term) > longest {
+					longest = len(term)
+				}
+				if !base[termIndex] {
+					marginal++
+					denominator := frequency[termIndex]
+					if denominator < 1 {
+						denominator = 1
+					}
+					rarity += 1000 / denominator
+				}
+			}
+			if base[termIndex] || candidateHasTerm {
+				unionGroups[exploreConceptBehavioralTermGroup(term)] = struct{}{}
+				leadAligned = leadAligned || lead[termIndex]
+			}
+		}
+		if candidateMatched == 0 || marginal == 0 || len(unionGroups) < 2 || !leadAligned ||
+			(longest < 5 && candidateMatched < 2) {
+			continue
+		}
+
+		winner := exploreComponentConjunctionWinner{
+			index:    index,
+			seedRank: seedRank,
+			score: exploreComponentConjunctionScore{
+				groups: len(unionGroups), marginal: marginal, rarity: rarity, longest: longest,
+			},
+		}
+		previous, exists := bestByComponent[component]
+		comparison := exploreComponentConjunctionScoreCompare(winner.score, previous.score)
+		if !exists || comparison > 0 ||
+			(comparison == 0 && (winner.seedRank < previous.seedRank ||
+				(winner.seedRank == previous.seedRank && winner.index < previous.index))) {
+			bestByComponent[component] = winner
+		}
+	}
+	if len(bestByComponent) == 0 {
+		return candidates
+	}
+
+	best := exploreComponentConjunctionWinner{index: -1}
+	ambiguous := false
+	for _, winner := range bestByComponent {
+		if best.index < 0 {
+			best = winner
+			continue
+		}
+		comparison := exploreComponentConjunctionScoreCompare(winner.score, best.score)
+		if comparison > 0 {
+			best = winner
+			ambiguous = false
+		} else if comparison == 0 {
+			ambiguous = true
+		}
+	}
+	if best.index < 0 || ambiguous {
+		return candidates
+	}
+
+	result := append([]*rerank.Candidate(nil), candidates...)
+	clone := *result[best.index]
+	clone.Signals = make(map[string]float64, len(result[best.index].Signals)+1)
+	for key, value := range result[best.index].Signals {
+		clone.Signals[key] = value
+	}
+	clone.Signals[exploreConceptComplementSignal] = 1
+	promoted := &clone
+	if best.index < width {
+		result[best.index] = promoted
+		return result
+	}
+
+	target := width - 1
+	copy(result[target+1:best.index+1], result[target:best.index])
+	result[target] = promoted
+	return result
+}
+
 // callable plus up to two callables that cover distinct task concepts in the
 // final window. Retrieval width and response size remain unchanged. The
 // semantic head stays first; reserved implementations occupy the next slots.
@@ -2390,6 +2750,10 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 			ranked = mergeExploreCandidates(ranked, anchorCandidates, fetch)
 		}
 	}
+	// Exact source citations in issue bodies are stronger than semantic ranking:
+	// map each bounded file/line range to its smallest enclosing declaration and
+	// place those task-spelled candidates at the head before final selection.
+	ranked = s.promoteExploreSourceRangeCandidates(ctx, task, ranked, opts)
 	// Resilience ladder: a warm-restarted daemon can transiently return an
 	// empty scoped ranked result (workspace stamps not yet backfilled, or
 	// search bundles served before their node payloads re-materialise)
@@ -2427,7 +2791,7 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 		if c == nil || c.Node == nil || !exploreLocalizableKind(c.Node.Kind) {
 			continue
 		}
-		if exploreLocalizationTestLaneNode(searchQuery, c.Node) || !exploreCodeDefinitionKind(c.Node.Kind) {
+		if exploreLocalizationTestLaneCandidate(searchQuery, c) || !exploreCodeDefinitionKind(c.Node.Kind) {
 			test = append(test, c)
 		} else {
 			prod = append(prod, c)
@@ -2453,6 +2817,7 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 		_, prod = diversifyByFile(prodNodes, prod, defaultMaxPerFile)
 	}
 	prod, protectedImplementationID := reserveExploreConceptImplementation(searchQuery, queryClass, prod, maxSymbols)
+	prod = reserveExploreComponentConjunction(searchQuery, queryClass, prod, maxSymbols)
 	cands := selectFinalExploreCandidates(prod, test, maxSymbols)
 	if len(protectedSyntacticAnchors) > 0 {
 		// Source-literal selection owns its own final-slot guarantees. Re-union
@@ -2521,6 +2886,7 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 		}
 		if c.Signals != nil {
 			t.conceptComplement = c.Signals[exploreConceptComplementSignal] > 0
+			t.syntacticAnchor = c.Signals[exploreSyntacticAnchorSignal] > 0
 			t.exactContent = c.Signals[exploreContentRecallExactSignal] > 0
 			t.exactContentAmbiguous = c.Signals[exploreContentRecallAmbiguousSignal] > 0
 			t.sourceLiteral = c.Signals[exploreSourceLiteralSignal] > 0
@@ -3135,6 +3501,17 @@ func localizationEvidenceTargetsFromDraft(task, exactID string, targets []explor
 	if draft == nil && strings.TrimSpace(task) != "" {
 		draft = exploreAnswerDraft(task, targets)
 	}
+	// Preserve the issue author's explicit file/symbol anchor before causal
+	// owner promotion. The owner still remains adjacent, but a proven upstream
+	// cause must not hide the named implementation target from PRIMARY evidence.
+	if explicitID := exploreLocalizationExplicitTarget(task, targets); explicitID != "" {
+		for _, target := range targets {
+			if target.node != nil && target.node.ID == explicitID {
+				appendTarget(target)
+				break
+			}
+		}
+	}
 	// A graph-proven causal constructor and its owning type outrank the
 	// downstream retrieval seed. Their explicit admission metadata survives
 	// draft ranking, owner folding, and byte-budget packing, so this ordering is
@@ -3500,6 +3877,41 @@ func interleaveLocalizationDirectRelationsWithRoutes(
 	return selected
 }
 
+// prioritizeLocalizationConceptComplement keeps the implementation pair close
+// enough for agents to interpret it as one unit. The semantic head and its
+// primary implementation retain ranks one and two; a later task-complementary
+// callable is stably rotated into rank three before the aligned wire projection
+// is packed. No row is added or removed.
+func prioritizeLocalizationConceptComplement(targets []exploreTarget) []exploreTarget {
+	if len(targets) < 3 {
+		return targets
+	}
+	hasLeadingImplementation := false
+	for index := 0; index < 2; index++ {
+		if targets[index].conceptImplementation {
+			hasLeadingImplementation = true
+			break
+		}
+	}
+	if !hasLeadingImplementation {
+		return targets
+	}
+	for index := 2; index < len(targets); index++ {
+		if !targets[index].conceptComplement {
+			continue
+		}
+		if index == 2 {
+			return targets
+		}
+		ordered := append([]exploreTarget(nil), targets...)
+		complement := ordered[index]
+		copy(ordered[3:index+1], ordered[2:index])
+		ordered[2] = complement
+		return ordered
+	}
+	return targets
+}
+
 func newLocalizationExploreResult(completion localizationCompletion, targets []exploreTarget, budget int) *mcp.CallToolResult {
 	return newLocalizationExploreResultForTask(completion, "", targets, budget)
 }
@@ -3631,10 +4043,14 @@ func buildLocalizationExploreResultForTaskFinalized(
 	targets = localizationEvidenceTargetsFromDraft(task, requiredSymbol, targets, draft)
 	if refinementFirst {
 		targets = prioritizeLocalizationEvidenceTarget(requiredSymbol, targets)
+		// A divergent-default refinement is one causal unit: keep the prescribed
+		// constructor adjacent to its owning type before the named consumer.
+		targets = preserveExploreDivergentDefaultOrder(targets)
 	}
 	targets = interleaveLocalizationDirectRelationsWithRoutes(
 		task, requiredSymbol, targets, completion.refinementRoutes,
 	)
+	targets = prioritizeLocalizationConceptComplement(targets)
 	contract := localizationContractFor(completion)
 	envelope := localizationExploreEnvelope{
 		Completion: contract.Completion,
@@ -4798,6 +5214,16 @@ func exploreQuotedRecallHasExactSourceNode(
 // a `spec/` directory), so the draft detector votes too — unless the request is
 // about test code or names this candidate outright, in which case the test node
 // is the answer and keeps its production slot.
+func exploreLocalizationTestLaneCandidate(query string, candidate *rerank.Candidate) bool {
+	if candidate == nil || candidate.Node == nil {
+		return false
+	}
+	if candidate.Signals[exploreSourceRangeSignal] > 0 {
+		return false
+	}
+	return exploreLocalizationTestLaneNode(query, candidate.Node)
+}
+
 func exploreLocalizationTestLaneNode(query string, node *graph.Node) bool {
 	if node == nil {
 		return false


### PR DESCRIPTION
## Summary

Three independent improvements to how `explore` localization picks candidates. Each is a separate commit and each builds on its own.

- **Rank explore artifact candidates by distinctive path probes** — derive ranked probes from the task (camel-split identifiers, environment tokens, canonical artifact words), score path hits against them, and drop paths that only match implicit tool-metadata roots.
- **Localize the graph-proven cause behind a reported symbol** — a concept task naming a downstream symbol was localized to that symbol alone. Walk the graph from the named candidate to retain one proven bridge, promote its continuation leaf, and add the same-file owning type when the route crosses files.
- **Anchor localization on the symbols and ranges a task spells out** — resolve qualified `Owner::member` mentions against parser ids so a late mention survives query shaping; map cited `file:line` ranges to their smallest enclosing declaration; reserve one callable satisfying every term of a multi-word component name.

## Promotion lane priority

Causal-change promotion and divergent-default promotion are two lanes over the same ranked concept head. Divergent-default keeps priority: it is the SLO-pinned lane and already emits its own provenance pair, so causal selection only runs when divergent-default did not lead.

This matters because the failure is quiet. With causal running first the node still lands at rank 0 — ordering assertions pass — but it carries `causalChange*` flags instead of `divergentDefaultOwner`, and `localizationTargetProvenance` emits `direct_caller`. Only `TestHandleExplorePromotesDivergentDefaultOwnerFromSQLitePHPIndex` catches it, because it asserts provenance rather than order.

## Validation

- `go build ./...`, `go vet ./internal/mcp/`, `gofmt` — clean
- Full repo suite (`go test ./...`) — no failures
- `go test -race ./internal/mcp/` — pass
- `golangci-lint run ./internal/mcp/...` — 0 issues
- Each of the three commits builds and vets independently
