### PR TITLE
csharp: type awaited receivers by unwrapping Task<T>

### DIFF
--- a/internal/indexer/extractor_version.go
+++ b/internal/indexer/extractor_version.go
@@ -32,7 +32,7 @@ var extractorVersions = map[string]int{
 	//   "go": 2,
 	"c":      generatedParserProjectionPolicyVersion, // generated parser projection covers all strictly detected table sizes
 	"php":    2,                                      // class/interface inheritance now emits typed structural edges
-	"csharp": 4,                                      // this./base.-qualified call edges (was: scoped/global using + receiver/param shape stamps; null-conditional call edges)
+	"csharp": 5,                                      // awaited-receiver Task<T> unwrap + return_shape (was: this./base.-qualified call edges)
 }
 
 // extractorSaltExtLang maps a lower-case file extension to the language

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -86,6 +86,18 @@ const qCSharpAll = `
         name: (identifier) @callm.method))) @callm.expr
 
   (invocation_expression
+    function: (conditional_access_expression
+      "this"
+      (member_binding_expression
+        name: (identifier) @callself.method))) @callself.expr
+
+  (invocation_expression
+    function: (conditional_access_expression
+      "base"
+      (member_binding_expression
+        name: (identifier) @callbase.method))) @callbase.expr
+
+  (invocation_expression
     function: (member_access_expression
       "this"
       name: (identifier) @callself.method)) @callself.expr

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -435,11 +435,26 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 				return
 			}
 			done = true
+			// The initializer must BE the await (parens aside): in
+			// `var w = (await Load()).Weigh()` the local holds Weigh's
+			// return, and stamping the awaited T would hand the
+			// resolver a confident wrong answer.
+			for p := n.Parent(); p != nil; p = p.Parent() {
+				switch p.Type() {
+				case "parenthesized_expression":
+					continue
+				case "equals_value_clause", "variable_declarator":
+					// direct initializer — accept
+				default:
+					return // nested inside a longer expression
+				}
+				break
+			}
 			inner := n.NamedChild(0)
 			if inner == nil {
 				return
 			}
-			if t := csharpAwaitedCallType(inner.Content(src), tenvByOwner[owner], result); t != "" {
+			if t := csharpAwaitedCallType(inner.Content(src), csharpOwnerTypeName(owner), tenvByOwner[owner], result); t != "" {
 				setLocalType(owner, l.name, t)
 			}
 		})
@@ -561,7 +576,7 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 				// `(await LoadAsync()).X()` — the chain walker collapses a
 				// fully-parenthesized receiver to nothing; the receiver is
 				// the T inside the awaited call's Task<T>.
-				if t := csharpAwaitedCallType(inner, tenvByOwner[callerID], result); t != "" {
+				if t := csharpAwaitedCallType(inner, csharpOwnerTypeName(callerID), tenvByOwner[callerID], result); t != "" {
 					edge.Meta = map[string]any{"receiver_type": t}
 				}
 			} else if strings.Contains(c.receiver, ".") || strings.Contains(c.receiver, "(") {
@@ -1828,7 +1843,10 @@ func csharpAwaitedReceiver(recv string) string {
 // prefix through the shared chain walker first; the final hop reads the
 // lossless return_shape because the normalized return_type has already
 // dropped the generic argument — which is exactly the awaited T.
-func csharpAwaitedCallType(expr string, tenv typeEnv, result *parser.ExtractionResult) string {
+// enclosing is the caller's own type: it anchors unqualified and
+// this-qualified calls so a same-named method on an unrelated sibling
+// class never leaks its return shape in.
+func csharpAwaitedCallType(expr, enclosing string, tenv typeEnv, result *parser.ExtractionResult) string {
 	expr = strings.TrimSpace(expr)
 	// Split the final segment off at the last depth-0 dot; the raw prefix
 	// text keeps its call parens so factory-chain seeding still works.
@@ -1847,25 +1865,33 @@ func csharpAwaitedCallType(expr string, tenv typeEnv, result *parser.ExtractionR
 	}
 	if cut < 0 {
 		name := stripCallArgs(expr)
-		return csharpUnwrapTaskType(csharpCallableReturnShape("", name, result))
+		return csharpUnwrapTaskType(csharpCallableReturnShape("", enclosing, name, result))
 	}
 	name := stripCallArgs(expr[cut+1:])
-	recvType := resolveChainType(expr[:cut], tenv, result)
-	if recvType == "" && isKnownType(expr[:cut], result) {
-		recvType = expr[:cut] // static call on a type: `Repo.LoadAsync()`
+	var recvType string
+	switch prefix := expr[:cut]; {
+	case prefix == "this":
+		recvType = enclosing
+	default:
+		recvType = resolveChainType(prefix, tenv, result)
+		if recvType == "" && isKnownType(prefix, result) {
+			recvType = prefix // static call on a type: `Repo.LoadAsync()`
+		}
 	}
 	if name == "" || recvType == "" {
 		return ""
 	}
-	return csharpUnwrapTaskType(csharpCallableReturnShape(recvType, name, result))
+	return csharpUnwrapTaskType(csharpCallableReturnShape(recvType, "", name, result))
 }
 
 // csharpCallableReturnShape finds the declared return shape of a callable
-// named name — on receiverType when given, else receiver-agnostically (an
-// unqualified call inside a method body), where a receiver-less free
-// function wins over a same-named method.
-func csharpCallableReturnShape(receiverType, name string, result *parser.ExtractionResult) string {
-	var fallback string
+// named name. With a receiverType, only an exact receiver match counts.
+// Without one (an unqualified call inside a method body) the enclosing
+// class's own member wins, then a receiver-less free function — never an
+// arbitrary same-named method off an unrelated class, whose shape would
+// ride into receiver_type as a confident wrong answer.
+func csharpCallableReturnShape(receiverType, enclosing, name string, result *parser.ExtractionResult) string {
+	var free string
 	for _, n := range result.Nodes {
 		if n == nil || (n.Kind != graph.KindMethod && n.Kind != graph.KindFunction) || n.Name != name {
 			continue
@@ -1884,14 +1910,29 @@ func csharpCallableReturnShape(receiverType, name string, result *parser.Extract
 			}
 			continue
 		}
-		if recv == "" {
+		if enclosing != "" && recv == enclosing {
 			return shape
 		}
-		if fallback == "" {
-			fallback = shape
+		if recv == "" && free == "" {
+			free = shape
 		}
 	}
-	return fallback
+	return free
+}
+
+// csharpOwnerTypeName extracts the enclosing type's simple name from a
+// symbol owner ID ("file.cs::Outer.Inner.Method" → "Inner"); "" for a
+// top-level function.
+func csharpOwnerTypeName(ownerID string) string {
+	idx := strings.LastIndex(ownerID, "::")
+	if idx < 0 {
+		return ""
+	}
+	parts := strings.Split(ownerID[idx+2:], ".")
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[len(parts)-2]
 }
 
 // csharpUnwrapTaskType strips the Task<>/ValueTask<> wrapper from a return

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -370,6 +370,7 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 	// and the receiver gate act on that evidence):
 	//   Tier 0 — explicit type annotations (skip "var" placeholder)
 	//   Tier 1 — `var x = new Foo()` walk for `var`-keyed locals only
+	//   Tier 2 — `var x = await LoadAsync()` walk → the awaited Task<T>'s T
 	localOwner := func(l csharpDeferredLocal) string {
 		if l.defNode == nil {
 			return ""
@@ -414,6 +415,32 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 					setLocalType(owner, l.name, typeName)
 					done = true
 				}
+			}
+		})
+	}
+	//   Tier 2 — `var x = await LoadAsync()` walk: no object_creation ever
+	//   appears; the local's type is the T inside the awaited call's Task<T>,
+	//   reachable through the called method's declared return shape.
+	for _, l := range locals {
+		owner := localOwner(l)
+		if owner == "" || l.rawType != "var" || l.defNode == nil {
+			continue
+		}
+		if _, exists := tenvByOwner[owner][l.name]; exists {
+			continue
+		}
+		done := false
+		walkNodes(l.defNode, func(n *sitter.Node) {
+			if done || n.Type() != "await_expression" {
+				return
+			}
+			done = true
+			inner := n.NamedChild(0)
+			if inner == nil {
+				return
+			}
+			if t := csharpAwaitedCallType(inner.Content(src), tenvByOwner[owner], result); t != "" {
+				setLocalType(owner, l.name, t)
 			}
 		})
 	}
@@ -529,6 +556,13 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 				edge.Meta = map[string]any{"receiver_builtin": bt}
 				if shape := shapesByOwner[callerID][c.receiver]; shape != "" && shape != bt {
 					edge.Meta["receiver_shape"] = shape
+				}
+			} else if inner := csharpAwaitedReceiver(c.receiver); inner != "" {
+				// `(await LoadAsync()).X()` — the chain walker collapses a
+				// fully-parenthesized receiver to nothing; the receiver is
+				// the T inside the awaited call's Task<T>.
+				if t := csharpAwaitedCallType(inner, tenvByOwner[callerID], result); t != "" {
+					edge.Meta = map[string]any{"receiver_type": t}
 				}
 			} else if strings.Contains(c.receiver, ".") || strings.Contains(c.receiver, "(") {
 				stampFactoryChainReceiver(edge, c.receiver, resolveChainType(c.receiver, tenvByOwner[callerID], result))
@@ -1002,8 +1036,11 @@ func (e *CSharpExtractor) emitMethod(m parser.QueryResult, filePath, fileID stri
 	if isIface {
 		meta["iface_member"] = true
 	}
-	if rt := extractCSharpMethodReturnType(def.Node, src, name); rt != "" {
+	if rt, shape := extractCSharpMethodReturnType(def.Node, src, name); rt != "" {
 		meta["return_type"] = rt
+		if shape != rt {
+			meta["return_shape"] = shape
+		}
 	}
 	if csharpHasModifier(def.Node, src, "async") {
 		meta["async"] = true
@@ -1734,10 +1771,12 @@ func csharpTypeParamConstraints(methodNode *sitter.Node, src []byte, param strin
 }
 
 // extractCSharpMethodReturnType walks a method_declaration node for
-// the type child preceding the method name.
-func extractCSharpMethodReturnType(methodNode *sitter.Node, src []byte, methodName string) string {
+// the type child preceding the method name. Returns the normalized name
+// plus the raw declared shape — normalization drops generic arguments,
+// and for a Task<T> the argument is exactly what an await evaluates to.
+func extractCSharpMethodReturnType(methodNode *sitter.Node, src []byte, methodName string) (string, string) {
 	if methodNode == nil {
-		return ""
+		return "", ""
 	}
 	for i, _nc := 0, int(methodNode.ChildCount()); i < _nc; i++ {
 		child := methodNode.Child(i)
@@ -1749,9 +1788,131 @@ func extractCSharpMethodReturnType(methodNode *sitter.Node, src []byte, methodNa
 			"nullable_type", "array_type", "tuple_type":
 			rawType := string(src[child.StartByte():child.EndByte()])
 			if rt := normalizeCSharpTypeName(rawType); rt != "" && rt != "var" {
-				return rt
+				return rt, strings.TrimSpace(rawType)
 			}
 		}
+	}
+	return "", ""
+}
+
+// csharpAwaitedReceiver returns the awaited expression inside a receiver
+// that is exactly one parenthesized await group — `(await LoadAsync(id))`
+// → `LoadAsync(id)` — and "" for every other receiver shape.
+func csharpAwaitedReceiver(recv string) string {
+	s := strings.TrimSpace(recv)
+	if !strings.HasPrefix(s, "(") || !strings.HasSuffix(s, ")") {
+		return ""
+	}
+	depth := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 && i != len(s)-1 {
+				return "" // opening paren closes early — not one group
+			}
+		}
+	}
+	inner := strings.TrimSpace(s[1 : len(s)-1])
+	if rest := strings.TrimPrefix(inner, "await "); rest != inner {
+		return strings.TrimSpace(rest)
+	}
+	return ""
+}
+
+// csharpAwaitedCallType resolves the type an awaited call expression
+// evaluates to: the called method's declared return shape with the
+// Task<>/ValueTask<> wrapper stripped. A chained call types its receiver
+// prefix through the shared chain walker first; the final hop reads the
+// lossless return_shape because the normalized return_type has already
+// dropped the generic argument — which is exactly the awaited T.
+func csharpAwaitedCallType(expr string, tenv typeEnv, result *parser.ExtractionResult) string {
+	expr = strings.TrimSpace(expr)
+	// Split the final segment off at the last depth-0 dot; the raw prefix
+	// text keeps its call parens so factory-chain seeding still works.
+	depth, cut := 0, -1
+	for i := 0; i < len(expr); i++ {
+		switch expr[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case '.':
+			if depth == 0 {
+				cut = i
+			}
+		}
+	}
+	if cut < 0 {
+		name := stripCallArgs(expr)
+		return csharpUnwrapTaskType(csharpCallableReturnShape("", name, result))
+	}
+	name := stripCallArgs(expr[cut+1:])
+	recvType := resolveChainType(expr[:cut], tenv, result)
+	if recvType == "" && isKnownType(expr[:cut], result) {
+		recvType = expr[:cut] // static call on a type: `Repo.LoadAsync()`
+	}
+	if name == "" || recvType == "" {
+		return ""
+	}
+	return csharpUnwrapTaskType(csharpCallableReturnShape(recvType, name, result))
+}
+
+// csharpCallableReturnShape finds the declared return shape of a callable
+// named name — on receiverType when given, else receiver-agnostically (an
+// unqualified call inside a method body), where a receiver-less free
+// function wins over a same-named method.
+func csharpCallableReturnShape(receiverType, name string, result *parser.ExtractionResult) string {
+	var fallback string
+	for _, n := range result.Nodes {
+		if n == nil || (n.Kind != graph.KindMethod && n.Kind != graph.KindFunction) || n.Name != name {
+			continue
+		}
+		shape, _ := n.Meta["return_shape"].(string)
+		if shape == "" {
+			shape, _ = n.Meta["return_type"].(string)
+		}
+		if shape == "" {
+			continue
+		}
+		recv, _ := n.Meta["receiver"].(string)
+		if receiverType != "" {
+			if recv == receiverType {
+				return shape
+			}
+			continue
+		}
+		if recv == "" {
+			return shape
+		}
+		if fallback == "" {
+			fallback = shape
+		}
+	}
+	return fallback
+}
+
+// csharpUnwrapTaskType strips the Task<>/ValueTask<> wrapper from a return
+// shape and returns the normalized result type — what an await on that
+// call evaluates to. Anything else (bare Task, custom awaitables) yields
+// "" rather than a guess.
+func csharpUnwrapTaskType(shape string) string {
+	s := strings.TrimSpace(shape)
+	lt := strings.Index(s, "<")
+	if lt <= 0 || !strings.HasSuffix(s, ">") {
+		return ""
+	}
+	head := s[:lt]
+	if dot := strings.LastIndex(head, "."); dot >= 0 {
+		head = head[dot+1:]
+	}
+	if head != "Task" && head != "ValueTask" {
+		return ""
+	}
+	if t := normalizeCSharpTypeName(s[lt+1 : len(s)-1]); t != "" && t != "var" {
+		return t
 	}
 	return ""
 }

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -1881,10 +1881,9 @@ func csharpAwaitedCallType(expr, enclosing string, tenv typeEnv, result *parser.
 	}
 	name := stripCallArgs(expr[cut+1:])
 	var recvType string
-	switch prefix := expr[:cut]; {
-	case prefix == "this":
+	if prefix := expr[:cut]; prefix == "this" {
 		recvType = enclosing
-	default:
+	} else {
 		recvType = resolveChainType(prefix, tenv, result)
 		if recvType == "" && isKnownType(prefix, result) {
 			recvType = prefix // static call on a type: `Repo.LoadAsync()`

--- a/internal/parser/languages/csharp_awaited_receiver_test.go
+++ b/internal/parser/languages/csharp_awaited_receiver_test.go
@@ -59,3 +59,138 @@ namespace App {
 	assert.Equal(t, "DrumScale", inlineCall.Meta["receiver_type"],
 		"inline awaited receiver unwraps Task<T>")
 }
+
+// A local whose initializer merely CONTAINS an await is not the awaited
+// value: `var w = (await LoadAsync(id)).Weigh(id)` holds Weigh's return,
+// and stamping the awaited T on it would make the resolver confidently
+// bind the wrong member — worse than the honest no-stamp.
+func TestCSharpExtractor_AwaitedLocalRequiresBareAwaitInitializer(t *testing.T) {
+	src := []byte(`using System.Threading.Tasks;
+namespace App {
+    public class Widget { public int Poke() { return 1; } }
+    public class DrumScale { public Widget Weigh(int id) { return new Widget(); } }
+    public class ScaleLoader {
+        public Task<DrumScale> LoadAsync(int id) { return Task.FromResult(new DrumScale()); }
+        public async Task<int> Use(int id) {
+            var w = (await LoadAsync(id)).Weigh(id);
+            return w.Poke();
+        }
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("Scales.cs", src)
+	require.NoError(t, err)
+
+	for _, ed := range result.Edges {
+		if ed.Kind != graph.EdgeCalls || ed.From != "Scales.cs::ScaleLoader.Use" {
+			continue
+		}
+		if !strings.Contains(ed.To, "Poke") || ed.Meta == nil {
+			continue
+		}
+		assert.NotEqual(t, "DrumScale", ed.Meta["receiver_type"],
+			"w holds Weigh's return, never the awaited DrumScale")
+	}
+}
+
+// An unqualified awaited call resolves against the ENCLOSING class (or a
+// true free function) — never a same-named method picked off an unrelated
+// sibling class in the file. this-qualified awaits name the enclosing
+// class explicitly and must resolve the same way.
+func TestCSharpExtractor_AwaitedUnqualifiedCallPrefersEnclosingClass(t *testing.T) {
+	src := []byte(`using System.Threading.Tasks;
+namespace App {
+    public class Alpha { public int Foo() { return 1; } }
+    public class Beta { public int Foo() { return 2; } }
+    public class AService {
+        public Task<Alpha> LoadAsync(int id) { return Task.FromResult(new Alpha()); }
+    }
+    public class BService {
+        public Task<Beta> LoadAsync(int id) { return Task.FromResult(new Beta()); }
+        public async Task<int> Use(int id) {
+            var x = await LoadAsync(id);
+            return x.Foo();
+        }
+        public async Task<int> UseSelf(int id) {
+            var y = await this.LoadAsync(id);
+            return y.Foo();
+        }
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("Svc.cs", src)
+	require.NoError(t, err)
+
+	byFrom := map[string]*graph.Edge{}
+	for _, ed := range result.Edges {
+		if ed.Kind == graph.EdgeCalls && strings.Contains(ed.To, "Foo") {
+			byFrom[ed.From] = ed
+		}
+	}
+
+	use := byFrom["Svc.cs::BService.Use"]
+	require.NotNil(t, use, "x.Foo() must emit a call edge")
+	require.NotNil(t, use.Meta)
+	assert.Equal(t, "Beta", use.Meta["receiver_type"],
+		"unqualified LoadAsync is BService's, not the sibling AService's")
+
+	useSelf := byFrom["Svc.cs::BService.UseSelf"]
+	require.NotNil(t, useSelf, "y.Foo() must emit a call edge")
+	require.NotNil(t, useSelf.Meta)
+	assert.Equal(t, "Beta", useSelf.Meta["receiver_type"],
+		"this.LoadAsync names the enclosing class explicitly")
+}
+
+// The unwrap is deliberately conservative: only Task<T>/ValueTask<T>
+// produce a type. Everything else must yield no stamp — a guessed
+// receiver_type is worse than a missing one.
+func TestCSharpExtractor_AwaitedUnwrapRefusalMatrix(t *testing.T) {
+	src := []byte(`using System.Threading.Tasks;
+namespace App {
+    public class DrumScale { public int Weigh(int id) { return id; } }
+    public class MyTask<T> { }
+    public class Loader {
+        public Task PlainAsync(int id) { return Task.CompletedTask; }
+        public ValueTask<DrumScale> ValueAsync(int id) { return default; }
+        public MyTask<DrumScale> FakeAsync(int id) { return new MyTask<DrumScale>(); }
+
+        public async Task<int> UsePlain(int id) {
+            var a = await PlainAsync(id);
+            return a.Weigh(id);
+        }
+        public async Task<int> UseValue(int id) {
+            var b = await ValueAsync(id);
+            return b.Weigh(id);
+        }
+        public async Task<int> UseFake(int id) {
+            var c = await FakeAsync(id);
+            return c.Weigh(id);
+        }
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("Loader.cs", src)
+	require.NoError(t, err)
+
+	recvType := func(from string) any {
+		for _, ed := range result.Edges {
+			if ed.Kind == graph.EdgeCalls && ed.From == from && strings.Contains(ed.To, "Weigh") {
+				if ed.Meta == nil {
+					return nil
+				}
+				return ed.Meta["receiver_type"]
+			}
+		}
+		return nil
+	}
+
+	assert.Nil(t, recvType("Loader.cs::Loader.UsePlain"),
+		"bare Task has no T - must not stamp")
+	assert.Equal(t, "DrumScale", recvType("Loader.cs::Loader.UseValue"),
+		"ValueTask<T> unwraps like Task<T>")
+	assert.Nil(t, recvType("Loader.cs::Loader.UseFake"),
+		"MyTask<T> is not an awaitable wrapper we understand - must not stamp")
+}

--- a/internal/parser/languages/csharp_awaited_receiver_test.go
+++ b/internal/parser/languages/csharp_awaited_receiver_test.go
@@ -1,0 +1,61 @@
+package languages
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Awaited receivers must be typed by unwrapping Task<T>: a local assigned
+// `await LoadAsync()` and an inline `(await LoadAsync()).X()` both evaluate
+// to the T inside the task, not to Task<T> — and previously to nothing at
+// all (the tenv walk only knew `new`, and the chain walker collapsed a
+// fully-parenthesized receiver to an empty string).
+func TestCSharpExtractor_AwaitedReceivers(t *testing.T) {
+	src := []byte(`using System.Threading.Tasks;
+namespace App {
+    public class DrumScale {
+        public int Weigh(int id) { return id; }
+    }
+    public class ScaleLoader {
+        public Task<DrumScale> LoadAsync(int id) { return Task.FromResult(new DrumScale()); }
+        public async Task<int> WeighLoaded(int id) {
+            var scale = await LoadAsync(id);
+            return scale.Weigh(id);
+        }
+        public async Task<int> WeighInline(int id) {
+            return (await LoadAsync(id)).Weigh(id);
+        }
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("Scales.cs", src)
+	require.NoError(t, err)
+
+	var localCall, inlineCall *graph.Edge
+	for _, ed := range result.Edges {
+		if ed.Kind != graph.EdgeCalls || !strings.Contains(ed.To, "Weigh") {
+			continue
+		}
+		switch ed.From {
+		case "Scales.cs::ScaleLoader.WeighLoaded":
+			localCall = ed
+		case "Scales.cs::ScaleLoader.WeighInline":
+			inlineCall = ed
+		}
+	}
+	require.NotNil(t, localCall, "scale.Weigh() on an awaited local must emit a call edge")
+	require.NotNil(t, localCall.Meta)
+	assert.Equal(t, "DrumScale", localCall.Meta["receiver_type"],
+		"awaited-local receiver unwraps Task<T>")
+
+	require.NotNil(t, inlineCall, "(await ...).Weigh() must emit a call edge")
+	require.NotNil(t, inlineCall.Meta)
+	assert.Equal(t, "DrumScale", inlineCall.Meta["receiver_type"],
+		"inline awaited receiver unwraps Task<T>")
+}

--- a/internal/parser/languages/csharp_conditional_this_base_test.go
+++ b/internal/parser/languages/csharp_conditional_this_base_test.go
@@ -1,0 +1,55 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// this?./base?.-qualified invocations must emit member-call edges like
+// their unconditional twins — the conditional-access pattern's `(_)`
+// condition capture has the same anonymous-token blindness the plain
+// member-access pattern had.
+func TestCSharpExtractor_ConditionalThisBaseCalls(t *testing.T) {
+	src := []byte(`namespace App {
+    public class Tower {
+        public int Chime() { return 1; }
+    }
+    public class Belfry : Tower {
+        public new int Chime() { return 2; }
+        public int RingSelf() { return this?.Chime() ?? 0; }
+        public int RingBase() { return base?.Chime() ?? 0; }
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("Belfry.cs", src)
+	require.NoError(t, err)
+
+	var selfCall, baseCall *graph.Edge
+	for _, ed := range result.Edges {
+		if ed.Kind != graph.EdgeCalls {
+			continue
+		}
+		switch ed.From {
+		case "Belfry.cs::Belfry.RingSelf":
+			selfCall = ed
+		case "Belfry.cs::Belfry.RingBase":
+			baseCall = ed
+		}
+	}
+	require.NotNil(t, selfCall, "this?.Chime() must emit a call edge")
+	require.NotNil(t, selfCall.Meta)
+	assert.Equal(t, true, selfCall.Meta["member_call"])
+	assert.Equal(t, "Belfry", selfCall.Meta["receiver_type"],
+		"this-receiver is the enclosing type")
+
+	require.NotNil(t, baseCall, "base?.Chime() must emit a call edge")
+	require.NotNil(t, baseCall.Meta)
+	assert.Equal(t, true, baseCall.Meta["member_call"])
+	assert.Equal(t, "Tower", baseCall.Meta["receiver_type"],
+		"base-receiver is the declared base class")
+}

--- a/internal/resolver/csharp_awaited_spec_test.go
+++ b/internal/resolver/csharp_awaited_spec_test.go
@@ -1,0 +1,70 @@
+package resolver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// fooCallEdge returns the Foo call edge out of fromID — the resolved edge
+// when binding ran, the unresolved stub otherwise — so specs can assert
+// both the target and the confidence it was bound at.
+func fooCallEdge(g graph.Store, fromID string) *graph.Edge {
+	for _, e := range g.GetOutEdges(fromID) {
+		if e.Kind != graph.EdgeCalls {
+			continue
+		}
+		if graph.IsUnresolvedTarget(e.To) {
+			if name := graph.UnresolvedName(e.To); name == "*.Foo" || name == "Foo" {
+				return e
+			}
+			continue
+		}
+		if n := g.GetNode(e.To); n != nil && n.Name == "Foo" {
+			return e
+		}
+	}
+	return nil
+}
+
+// Awaited receivers evaluate to the T inside Task<T>. With a same-named
+// decoy member in scope, both call shapes must bind the awaited type's
+// member confidently — not luck-pick between candidates at zero confidence.
+func TestResolveCSharp_AwaitedReceivers(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Lib.cs": `using System.Threading.Tasks;
+namespace App {
+    public class DrumScale { public int Foo(int id) { return id; } }
+    public class NoiseMaker { public int Foo(int id) { return 0; } }
+    public class ScaleLoader {
+        public Task<DrumScale> LoadAsync(int id) { return Task.FromResult(new DrumScale()); }
+        public async Task<int> WeighLoaded(int id) {
+            var scale = await LoadAsync(id);
+            return scale.Foo(id);
+        }
+        public async Task<int> WeighInline(int id) {
+            return (await LoadAsync(id)).Foo(id);
+        }
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	local := fooCallEdge(g, "Lib.cs::ScaleLoader.WeighLoaded")
+	require.NotNil(t, local, "awaited-local Foo() must produce a call edge")
+	assert.True(t, strings.Contains(local.To, "DrumScale.Foo"),
+		"awaited local binds the unwrapped type's member, got %q", local.To)
+	assert.GreaterOrEqual(t, local.Confidence, 0.9,
+		"typed receiver must bind confidently, not by fallback luck")
+
+	inline := fooCallEdge(g, "Lib.cs::ScaleLoader.WeighInline")
+	require.NotNil(t, inline, "(await ...).Foo() must produce a call edge")
+	assert.True(t, strings.Contains(inline.To, "DrumScale.Foo"),
+		"inline awaited receiver binds the unwrapped type's member, got %q", inline.To)
+	assert.GreaterOrEqual(t, inline.Confidence, 0.9,
+		"typed receiver must bind confidently, not by fallback luck")
+}


### PR DESCRIPTION

`var x = await LoadAsync(id); x.Weigh(id)` and `(await LoadAsync(id)).Weigh(id)` both resolve their receiver by luck today — the awaited type is invisible for three stacked reasons:

- `return_type` meta is normalized at emission, so `Task<DrumScale>` is stored as bare `Task` — the `T` (exactly what an `await` evaluates to) was unrecoverable anywhere downstream.
- The `var` tenv walk only knows `object_creation_expression`; an await initializer never contains one.
- The inline shape is worse: the chain walker's paren-stripper collapses the fully-parenthesized receiver `(await LoadAsync(id))` to an empty string before any typing can start.

On a production C# codebase this is the dominant receiver shape — with count around 1,900 await-assigned locals plus the inline sites, all binding their member calls at zero confidence.

**Fix** (extraction only, resolver untouched):

- `return_shape` meta preserves the raw declared return type alongside the normalized `return_type`, stamped only when the two differ (mirrors the existing `receiver_shape` convention).
- tenv **Tier 2**: a `var` local whose initializer *is* an await (parens aside — `var w = (await X()).M()` holds `M`'s return, not the awaited T, and is deliberately left untyped) types as the `T` inside the called method's `Task<T>`/`ValueTask<T>` return shape. Chained receivers (`await svc.LoadAsync()`) type their prefix through the existing chain walker; a static-type receiver (`await Repo.LoadAsync()`) seeds from the declared type.
- A new awaited-receiver branch handles `(await X()).M()` by unwrapping the parens + `await` keyword and resolving through the same path.
- An unqualified or `this.`-qualified awaited call resolves against the **enclosing class** (or a true free function) — never a same-named method picked off an unrelated sibling class in the file, whose return shape would ride into `receiver_type` as a confident wrong answer.
- The unwrap is deliberately conservative: only `Task<T>`/`ValueTask<T>` produce a type; bare `Task`, custom awaitables, and lookalikes (`MyTask<T>`) yield nothing rather than a guess.

The stamped `receiver_type` then rides the existing receiver-typed member binding path — no new resolver machinery.

Also included: the conditional-access follow-up from the #466 review — `this?.Foo()` / `base?.Foo()` now emit call edges with `receiver_type` stamped, via the same literal-token alternations on the `conditional_access_expression` pattern (its `condition: (_)` capture had the identical anonymous-token blindness). The existing handler cases needed no changes.

**Tests**: extractor specs for both happy shapes plus the negative pins (await-nested-in-a-longer-initializer must not stamp; sibling-class same-named method must not leak in; a refusal matrix for bare `Task` / `ValueTask<T>` / `MyTask<T>`), and an end-to-end resolver spec with a same-named decoy member that additionally asserts confidence ≥ 0.9 — the old behaviour luck-picked the right target at confidence 0, so a target-only assertion would pass vacuously. All new tests were written first and failed against the old behaviour before their fixes landed. `internal/parser/languages` fully green; `internal/resolver` and `internal/indexer` at their pre-existing Windows baselines with zero new failures.

The first commit bumps the `csharp` extractor version 4→5 so existing stores restage `.cs` files — one bump covers everything here. Validated live on a counted C# fixture repo — binary swap, no store wipe, explicit reindex — with both call shapes binding the compiler-correct target at 0.95 with `receiver_type` stamped (plus the expected interface+impl pair). One operational note from that validation: on the current daemon the version check only runs inside a full-root reindex pass, so a binary swap + daemon restart alone does not trigger the restage until something reindexes — happy to file that separately if it isn't intended behaviour.
