### PR TITLE
Deepen localization evidence pages and extract missing symbol classes

### DIFF
--- a/internal/hooks/deny_evidence_test.go
+++ b/internal/hooks/deny_evidence_test.go
@@ -1,0 +1,240 @@
+package hooks
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/zzet/gortex/internal/toolref"
+)
+
+// stubFileOutline replaces the get_file_summary seam the Read deny consults
+// for its outline. Restored automatically via t.Cleanup.
+func stubFileOutline(t *testing.T, summary *hookFileSummary, ok bool) {
+	t.Helper()
+	prev := fileSummaryFn
+	fileSummaryFn = func(string, string) (*hookFileSummary, bool) { return summary, ok }
+	t.Cleanup(func() { fileSummaryFn = prev })
+}
+
+func TestGrepDenyCarriesProbeHits(t *testing.T) {
+	stubProbe(t, []grepSymbolHit{
+		{Name: "handlePlace", Kind: "function", FilePath: "internal/place/handler.go", Line: 42},
+		{Name: "placeEdges", Kind: "method", FilePath: "internal/place/edges.go", Line: 7},
+	}, nil)
+
+	result := probeSymbolPattern("Grep", "handlePlace", defaultGrepGuidance())
+	if !result.deny {
+		t.Fatalf("probed Grep hit was not denied: %#v", result)
+	}
+	for _, want := range []string{
+		"handlePlace — internal/place/handler.go:42 (function)",
+		"placeEdges — internal/place/edges.go:7 (method)",
+	} {
+		if !strings.Contains(result.reason, want) {
+			t.Fatalf("Grep deny %q does not carry hit %q", result.reason, want)
+		}
+	}
+}
+
+func TestGrepDenyEvidenceStaysWithinByteBound(t *testing.T) {
+	hits := make([]grepSymbolHit, 0, 40)
+	for i := range 40 {
+		hits = append(hits, grepSymbolHit{
+			Name:     fmt.Sprintf("veryLongSymbolNameNumber%02d", i),
+			Kind:     "function",
+			FilePath: fmt.Sprintf("internal/some/deeply/nested/package/path/file%02d.go", i),
+			Line:     i + 1,
+		})
+	}
+
+	block := grepHitEvidence(hits)
+	if block == "" {
+		t.Fatal("bounded evidence block is empty for 40 hits")
+	}
+	if len(block) > denyEvidenceMaxBytes {
+		t.Fatalf("evidence block is %d bytes, want <= %d", len(block), denyEvidenceMaxBytes)
+	}
+	if rows := strings.Count(block, " — "); rows > denyEvidenceMaxLines {
+		t.Fatalf("evidence block carries %d rows, want <= %d", rows, denyEvidenceMaxLines)
+	}
+	if !strings.Contains(block, "... and ") {
+		t.Fatalf("truncated evidence block does not report the dropped hits: %q", block)
+	}
+
+	stubProbe(t, hits, nil)
+	result := probeSymbolPattern("Grep", "veryLongSymbolNameNumber00", defaultGrepGuidance())
+	if !result.deny || !strings.Contains(result.reason, block) {
+		t.Fatalf("Grep deny does not embed the bounded evidence block: %#v", result)
+	}
+}
+
+func TestDenyEvidenceBlockCountsItsHeader(t *testing.T) {
+	rows := make([]denyEvidenceRow, 0, 20)
+	for i := range 20 {
+		rows = append(rows, denyEvidenceRow{
+			Label: fmt.Sprintf("Symbol%02d", i),
+			File:  strings.Repeat("nested/", 12) + "file.go",
+			Line:  i + 1,
+			Note:  "function",
+		})
+	}
+
+	block := denyEvidenceBlock(strings.Repeat("h", 200)+"\n", rows)
+	if len(block) > denyEvidenceMaxBytes {
+		t.Fatalf("headered evidence block is %d bytes, want <= %d", len(block), denyEvidenceMaxBytes)
+	}
+	if !strings.Contains(block, "... and ") {
+		t.Fatalf("headered block dropped rows without saying so: %q", block)
+	}
+}
+
+func TestGrepProbeDaemonUnreachableKeepsBaselineGuidance(t *testing.T) {
+	stubProbe(t, nil, errDaemonUnreachable)
+
+	result := probeSymbolPattern("Grep", "handlePlace", defaultGrepGuidance())
+	if result.deny {
+		t.Fatalf("unreachable daemon must not deny: %#v", result)
+	}
+	if result.context != defaultGrepGuidance() {
+		t.Fatalf("unreachable-daemon guidance = %q, want the baseline message", result.context)
+	}
+}
+
+func TestReadDenyCarriesSymbolOutline(t *testing.T) {
+	stubIndexedFile(t, true, 3)
+	stubFileOutline(t, &hookFileSummary{Symbols: []summaryNode{
+		{Name: "Parse", Kind: "function", StartLine: 12, EndLine: 40},
+		{Name: "Emit", Kind: "method", StartLine: 44, EndLine: 60},
+	}}, true)
+
+	result := enrichRead(map[string]any{"file_path": "internal/hooks/pretooluse.go"}, "/repo")
+	if !result.deny {
+		t.Fatalf("indexed Read was not denied: %#v", result)
+	}
+	for _, want := range []string{
+		readOutlineHeader,
+		"Parse — internal/hooks/pretooluse.go:12 (function)",
+		"Emit — internal/hooks/pretooluse.go:44 (method)",
+	} {
+		if !strings.Contains(result.reason, want) {
+			t.Fatalf("Read deny %q does not carry outline entry %q", result.reason, want)
+		}
+	}
+}
+
+func TestReadDenyOutlineHeadIsBounded(t *testing.T) {
+	symbols := make([]summaryNode, 0, 30)
+	for i := range 30 {
+		symbols = append(symbols, summaryNode{
+			Name:      fmt.Sprintf("SymbolNumber%02d", i),
+			Kind:      "function",
+			StartLine: i + 1,
+		})
+	}
+	stubIndexedFile(t, true, len(symbols))
+	stubFileOutline(t, &hookFileSummary{Symbols: symbols}, true)
+
+	block := readOutlineEvidence("/repo", "internal/hooks/pretooluse.go")
+	if len(block) > denyEvidenceMaxBytes {
+		t.Fatalf("outline block is %d bytes, want <= %d", len(block), denyEvidenceMaxBytes)
+	}
+	if rows := strings.Count(block, " — "); rows > denyEvidenceMaxLines {
+		t.Fatalf("outline block carries %d rows, want <= %d", rows, denyEvidenceMaxLines)
+	}
+	if !strings.Contains(block, "... and 25 more") {
+		t.Fatalf("outline block does not report the remaining symbols: %q", block)
+	}
+}
+
+// baselineReadDeny is the redirect-only Read deny as it reads with no graph
+// results attached. Any degraded path must reproduce it byte for byte.
+func baselineReadDeny(filePath string, symbolCount int) string {
+	return fmt.Sprintf("[Gortex] BLOCKED: Read of %s (%d symbols indexed). Call `explore` first, then use `read` instead:\n", filePath, symbolCount) +
+		"  - `read(target:{symbol:\"<id>\"})` — one symbol\n" +
+		"  - `read(target:{symbols:[\"<id>\"]})` — several symbols\n" +
+		"  - `read(operation:\"editing_context\", target:{file:\"<path>\"})` — full editing context\n" +
+		gcxTip + toolref.MCPRequiredLine()
+}
+
+func TestReadDenyWithoutDaemonMatchesBaselineMessage(t *testing.T) {
+	stubIndexedFile(t, true, 7)
+	stubFileOutline(t, nil, false)
+
+	result := enrichRead(map[string]any{"file_path": "internal/hooks/pretooluse.go"}, "/repo")
+	if !result.deny {
+		t.Fatalf("indexed Read was not denied: %#v", result)
+	}
+	if want := baselineReadDeny("internal/hooks/pretooluse.go", 7); result.reason != want {
+		t.Fatalf("degraded Read deny = %q, want exactly %q", result.reason, want)
+	}
+}
+
+func TestReadDenyOutlineGivesUpOnSlowDaemon(t *testing.T) {
+	stubIndexedFile(t, true, 7)
+	prev := fileSummaryFn
+	fileSummaryFn = func(string, string) (*hookFileSummary, bool) {
+		time.Sleep(3 * time.Second)
+		return &hookFileSummary{Symbols: []summaryNode{{Name: "Parse", Kind: "function", StartLine: 12}}}, true
+	}
+	t.Cleanup(func() { fileSummaryFn = prev })
+
+	start := time.Now()
+	result := enrichRead(map[string]any{"file_path": "internal/hooks/pretooluse.go"}, "/repo")
+	elapsed := time.Since(start)
+
+	if elapsed > time.Second {
+		t.Fatalf("Read deny waited %s on the outline lookup, want the %s budget", elapsed, readOutlineTimeout)
+	}
+	if want := baselineReadDeny("internal/hooks/pretooluse.go", 7); result.reason != want {
+		t.Fatalf("timed-out Read deny = %q, want exactly %q", result.reason, want)
+	}
+}
+
+func TestLocalizationTerminalDenyCarriesNoGraphEvidence(t *testing.T) {
+	configureLocalizationTerminalTestHome(t)
+	stubIndexedFile(t, true, 9)
+	stubFileOutline(t, &hookFileSummary{Symbols: []summaryNode{
+		{Name: "Parse", Kind: "function", StartLine: 12},
+	}}, true)
+	stubProbe(t, []grepSymbolHit{
+		{Name: "Parse", Kind: "function", FilePath: "repo/source.go", Line: 12},
+	}, nil)
+
+	cwd := t.TempDir()
+	identity := beginTestLocalizationTurn(t, "terminal-evidence", "prompt-1", cwd)
+	snapshotTestLocalizationTool(t, identity, gortexMCPToolPrefix+"read", "tool-1")
+	post := localizationPostToolPayload(t, gortexMCPToolPrefix+"read", "tool-1", identity,
+		terminalToolResponse(t, terminalContractMap(), true, false))
+	captureHookStdout(t, func() { runPostToolUse(post) })
+
+	for _, tt := range []struct {
+		name  string
+		tool  string
+		input map[string]any
+	}{
+		{name: "host read", tool: "Read", input: map[string]any{"file_path": "repo/source.go"}},
+		{name: "host grep", tool: "Grep", input: map[string]any{"pattern": "Parse", "path": "repo"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			pre := preToolPayload(t, tt.tool, "", identity, tt.input)
+			raw := captureHookStdout(t, func() { runPreToolUse(pre, 0, ModeDeny) })
+			var output HookOutput
+			if err := json.Unmarshal([]byte(raw), &output); err != nil {
+				t.Fatalf("decode PreToolUse output %q: %v", raw, err)
+			}
+			if output.HookSpecificOutput == nil || output.HookSpecificOutput.PermissionDecision != "deny" {
+				t.Fatalf("expected terminal deny, got %#v", output)
+			}
+			reason := output.HookSpecificOutput.PermissionDecisionReason
+			if !strings.HasPrefix(reason, localizationTerminalDenyReason) {
+				t.Fatalf("terminal deny reason = %q, want prefix %q", reason, localizationTerminalDenyReason)
+			}
+			if strings.Contains(reason, readOutlineHeader) || strings.Contains(reason, "Parse — ") {
+				t.Fatalf("terminal deny leaked access-policy graph evidence: %q", reason)
+			}
+		})
+	}
+}

--- a/internal/hooks/pretooluse.go
+++ b/internal/hooks/pretooluse.go
@@ -483,6 +483,11 @@ func enrichRead(toolInput map[string]any, cwd string) enrichResult {
 		reason.WriteString("  - `read(operation:\"editing_context\", target:{file:\"<path>\"})` — full editing context\n")
 		reason.WriteString(gcxTip)
 		reason.WriteString(toolref.MCPRequiredLine())
+		// Naming the replacement tool without showing what the graph holds
+		// makes the caller spend its next turn asking for what the hook can
+		// already see. The outline is additive: with no answer the deny reads
+		// exactly as it did before.
+		reason.WriteString(readOutlineEvidence(cwd, filePath))
 
 		return enrichResult{
 			deny:   true,
@@ -836,27 +841,155 @@ func defaultGrepGuidance() string {
 }
 
 func formatGrepDeny(pattern string, hits []grepSymbolHit) string {
-	const maxShown = 5
 	var b strings.Builder
 	fmt.Fprintf(&b, "[Gortex] BLOCKED: \"%s\" matches %d indexed symbol(s). Use `search(operation:\"symbols\")` or `relations(operation:\"usages\")`:\n\n", pattern, len(hits))
-	shown := min(len(hits), maxShown)
-	for i := range shown {
-		h := hits[i]
-		kind := h.Kind
-		if kind == "" {
-			kind = "symbol"
-		}
-		fmt.Fprintf(&b, "  %s — %s:%d (%s)\n", h.Name, h.FilePath, h.Line, kind)
-	}
-	if len(hits) > maxShown {
-		fmt.Fprintf(&b, "  ... and %d more\n", len(hits)-maxShown)
-	}
+	b.WriteString(grepHitEvidence(hits))
 	b.WriteString("\n")
 	b.WriteString("Localizing a task rather than one symbol? `explore` returns the ranked neighborhood (symbols + source + call paths) in one call.\n")
 	b.WriteString(gcxTip)
 	b.WriteString(toolref.MCPRequiredLine())
 	b.WriteString("To force text search, add a regex metachar (e.g. \\b) or quote the pattern.")
 	return b.String()
+}
+
+// A deny that only names the replacement tool costs the caller a turn to
+// re-derive what the hook already asked the graph. These bounds decide how
+// much of that answer rides along: enough rows to act on, never enough to
+// bury the redirect itself.
+const (
+	denyEvidenceMaxLines = 5
+	denyEvidenceMaxBytes = 600
+)
+
+// denyEvidenceRow is one graph result rendered into a deny: what was found,
+// where it lives, and an optional parenthesised note (its kind).
+type denyEvidenceRow struct {
+	Label string
+	File  string
+	Line  int
+	Note  string
+}
+
+// denyEvidenceBlock renders rows as "  label — file:line (note)" under an
+// optional header, capped at denyEvidenceMaxLines rows and denyEvidenceMaxBytes
+// for the whole block including the header and the trailing "... and N more".
+// An empty return means nothing fit, and the caller's message stays as it was.
+func denyEvidenceBlock(header string, rows []denyEvidenceRow) string {
+	if len(rows) == 0 {
+		return ""
+	}
+	lines := make([]string, 0, denyEvidenceMaxLines)
+	used := len(header)
+	for _, row := range rows {
+		if len(lines) == denyEvidenceMaxLines {
+			break
+		}
+		line := formatDenyEvidenceRow(row)
+		// Reserve the tail before taking the line. The dropped count only
+		// shrinks as more rows are taken, so budgeting for the tail this row
+		// would leave behind keeps every stopping point inside the cap.
+		tail := 0
+		if dropped := len(rows) - len(lines) - 1; dropped > 0 {
+			tail = len(denyEvidenceMoreLine(dropped))
+		}
+		if used+len(line)+tail > denyEvidenceMaxBytes {
+			break
+		}
+		lines = append(lines, line)
+		used += len(line)
+	}
+	if len(lines) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(header)
+	for _, line := range lines {
+		b.WriteString(line)
+	}
+	if dropped := len(rows) - len(lines); dropped > 0 {
+		b.WriteString(denyEvidenceMoreLine(dropped))
+	}
+	return b.String()
+}
+
+func formatDenyEvidenceRow(row denyEvidenceRow) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "  %s — %s:%d", row.Label, row.File, row.Line)
+	if row.Note != "" {
+		fmt.Fprintf(&b, " (%s)", row.Note)
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
+func denyEvidenceMoreLine(dropped int) string {
+	return fmt.Sprintf("  ... and %d more\n", dropped)
+}
+
+// grepHitEvidence renders the probe hits the deny was decided on. The probe
+// has already run by the time this is called, so the evidence costs nothing
+// beyond formatting.
+func grepHitEvidence(hits []grepSymbolHit) string {
+	rows := make([]denyEvidenceRow, 0, len(hits))
+	for _, h := range hits {
+		kind := h.Kind
+		if kind == "" {
+			kind = "symbol"
+		}
+		rows = append(rows, denyEvidenceRow{Label: h.Name, File: h.FilePath, Line: h.Line, Note: kind})
+	}
+	return denyEvidenceBlock("", rows)
+}
+
+// readOutlineTimeout bounds the outline lookup behind a Read deny. It is much
+// tighter than fileIndexedTimeout because the deny is already decided: the
+// outline only enriches it, so a slow daemon must cost the refusal nothing.
+const readOutlineTimeout = 250 * time.Millisecond
+
+const readOutlineHeader = "\nSymbols indexed in this file:\n"
+
+// readOutlineEvidence returns the head of filePath's indexed symbol outline,
+// or "" when the daemon cannot answer inside readOutlineTimeout. Degrading to
+// "" rather than to a half-formatted section keeps the daemon-less deny byte
+// for byte what it has always been.
+func readOutlineEvidence(cwd, filePath string) string {
+	summary, ok := fileOutlineWithin(cwd, filePath, readOutlineTimeout)
+	if !ok || summary == nil {
+		return ""
+	}
+	rows := make([]denyEvidenceRow, 0, len(summary.Symbols))
+	for _, sym := range summary.Symbols {
+		if sym.Name == "" || sym.StartLine <= 0 {
+			continue
+		}
+		rows = append(rows, denyEvidenceRow{Label: sym.Name, File: filePath, Line: sym.StartLine, Note: sym.Kind})
+	}
+	return denyEvidenceBlock(readOutlineHeader, rows)
+}
+
+// fileOutlineWithin runs the shared get_file_summary probe under a deadline of
+// its own. daemonFileSummaryRaw's socket deadline is sized for the indexed
+// check that gates the deny; this call happens after that verdict, so it gets
+// a budget the caller never waits on.
+func fileOutlineWithin(cwd, filePath string, timeout time.Duration) (*hookFileSummary, bool) {
+	type outlineResult struct {
+		summary *hookFileSummary
+		ok      bool
+	}
+	// Read the seam here, not in the goroutine: an abandoned probe must not
+	// race a test restoring it.
+	probe := fileSummaryFn
+	done := make(chan outlineResult, 1)
+	go func() {
+		summary, ok := probe(cwd, filePath)
+		done <- outlineResult{summary: summary, ok: ok}
+	}()
+	select {
+	case res := <-done:
+		return res.summary, res.ok
+	case <-time.After(timeout):
+		return nil, false
+	}
 }
 
 // queryFileIndexed reports whether the file at filePath is indexed by the

--- a/internal/indexer/ambiguous_header_language_test.go
+++ b/internal/indexer/ambiguous_header_language_test.go
@@ -1,0 +1,90 @@
+package indexer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+// cppHeaderSrc reduces the shape a real header-only C++ library ships: macro
+// namespace markers the preprocessor would expand, an inner `namespace
+// detail`, and a free template function defined at namespace scope. The
+// extension is `.h`, which C, C++ and Objective-C all claim, so the language
+// is decidable only from the content. Parsed as C the template function
+// vanishes — the C grammar cannot see past `template <…>`.
+const cppHeaderSrc = `#ifndef LIB_PRINTF_H_
+#define LIB_PRINTF_H_
+
+#include "format.h"
+
+FMT_BEGIN_NAMESPACE
+FMT_BEGIN_EXPORT
+
+template <typename Char> class basic_printf_context {
+ public:
+  auto out() -> basic_appender<Char> { return out_; }
+
+ private:
+  basic_appender<Char> out_;
+};
+
+namespace detail {
+
+template <typename Char, typename Context>
+void vprintf(buffer<Char>& buf, basic_string_view<Char> format,
+             basic_format_args<Context> args) {
+  auto out = basic_appender<Char>(buf);
+  write(out, format);
+}
+
+}  // namespace detail
+
+FMT_END_EXPORT
+FMT_END_NAMESPACE
+
+#endif  // LIB_PRINTF_H_
+`
+
+// newTestIndexerCFamily registers the C and C++ extractors, the pair that
+// makes `.h` ambiguous: C claims the extension, C++ does not, so only a
+// content probe can route a C++ header to the right extractor.
+func newTestIndexerCFamily(g graph.Store) *Indexer {
+	reg := parser.NewRegistry()
+	reg.Register(languages.NewCExtractor())
+	reg.Register(languages.NewCppExtractor())
+	cfg := config.Default().Index
+	cfg.Workers = 2
+	return New(g, reg, cfg, zap.NewNop())
+}
+
+// TestIndex_AmbiguousHeaderLanguageProbedFromContent proves the bulk index
+// walk resolves a `.h` file's language from its bytes rather than from the
+// extension's default mapping. The walk detects a language before any file is
+// read, so an ambiguous extension can only yield a provisional answer there;
+// reusing it verbatim indexed every C++ header as C and dropped its templates.
+func TestIndex_AmbiguousHeaderLanguageProbedFromContent(t *testing.T) {
+	dir := t.TempDir()
+	inc := filepath.Join(dir, "include", "lib")
+	require.NoError(t, os.MkdirAll(inc, 0o755))
+	writeFile(t, filepath.Join(inc, "printf.h"), cppHeaderSrc)
+
+	g := graph.New()
+	idx := newTestIndexerCFamily(g)
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+
+	nodes := g.FindNodesByName("vprintf")
+	require.NotEmpty(t, nodes, "the free template function must be indexed")
+	assert.Equal(t, "cpp", nodes[0].Language,
+		"a header carrying C++ markers must be parsed by the C++ extractor")
+	assert.Equal(t, graph.KindFunction, nodes[0].Kind)
+}

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -3405,17 +3405,21 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 					}
 					merkleBaseline.record(relPath, src, wf.mtimeNano)
 
-					// Reuse the walk-time language. The walk's
-					// effectiveLanguage call already consulted shebang
-					// bytes via readSniffPrefix (512-byte probe), so a
-					// re-detect against the full src would change the
-					// answer only on the vanishingly rare case where a
-					// language marker lives past byte 512 — and any such
-					// case is content-sniffing-by-luck rather than spec'd
-					// behaviour. The fallback below covers the truly
-					// pathological case where the walk-time language has
-					// no extractor registered (effectively dead code).
+					// Reuse the walk-time language, except where the
+					// extension alone cannot decide it. The walk runs
+					// before any file is read, so for `.h`, `.m` and the
+					// other contested extensions it can only report the
+					// extension's default — reusing that indexed every
+					// C++ header as C, dropping its templates and class
+					// members. The bytes are in hand here, so re-detect;
+					// the second branch still covers a walk-time language
+					// with no extractor registered.
 					lang := wf.lang
+					if parser.ExtensionNeedsContentProbe(path) {
+						if relang, ok := idx.effectiveLanguage(path, src); ok {
+							lang = relang
+						}
+					}
 					ext, _ := idx.registry.GetByLanguage(lang)
 					if ext == nil {
 						if relang, ok := idx.effectiveLanguage(path, src); ok {

--- a/internal/mcp/explore_artifact_intent.go
+++ b/internal/mcp/explore_artifact_intent.go
@@ -29,7 +29,10 @@ type exploreArtifactIntent struct {
 	probes        []string
 }
 
-type exploreArtifactProbeCandidate struct {
+// exploreTaskProbe is one distinctive span a task spells out, ranked by how
+// unlikely it is to appear by accident. The artifact lane greps for it; the
+// source lane matches it against candidate paths.
+type exploreTaskProbe struct {
 	value    string
 	priority int
 	order    int
@@ -180,8 +183,24 @@ func canonicalExploreArtifactWord(word string) string {
 	}
 }
 
+// rankedExploreArtifactProbes is the artifact lane's view of the shared probe
+// ranking: the values only, bounded by what a content grep can afford.
 func rankedExploreArtifactProbes(task string, seen map[string]struct{}) []string {
-	candidates := make(map[string]exploreArtifactProbeCandidate)
+	ranked := rankedExploreTaskProbes(task, seen, exploreArtifactProbeLimit)
+	out := make([]string, 0, len(ranked))
+	for _, probe := range ranked {
+		out = append(out, probe.value)
+	}
+	return out
+}
+
+// rankedExploreTaskProbes ranks the task's distinctive spans — property
+// arguments, assignments, quoted spans, flags and environment names — highest
+// priority first, then earliest mention. Terms already consumed as paths are
+// skipped, and every emitted probe is marked in seen so no later lane re-derives
+// it. The probes are pure task text: no graph, index or file access.
+func rankedExploreTaskProbes(task string, seen map[string]struct{}, limit int) []exploreTaskProbe {
+	candidates := make(map[string]exploreTaskProbe)
 	add := func(value string, priority, order int) {
 		value = strings.TrimSpace(strings.Trim(value, "`'\""))
 		if len(value) < 2 || exploreArtifactFile(value) || strings.EqualFold(value, "CI") {
@@ -191,7 +210,7 @@ func rankedExploreArtifactProbes(task string, seen map[string]struct{}) []string
 		if _, exists := seen[key]; exists {
 			return
 		}
-		candidate := exploreArtifactProbeCandidate{value: value, priority: priority, order: order}
+		candidate := exploreTaskProbe{value: value, priority: priority, order: order}
 		if current, exists := candidates[key]; exists &&
 			(current.priority > candidate.priority || (current.priority == candidate.priority && current.order <= candidate.order)) {
 			return
@@ -230,7 +249,7 @@ func rankedExploreArtifactProbes(task string, seen map[string]struct{}) []string
 		}
 		add(trimmed, priority, match[0])
 	}
-	ordered := make([]exploreArtifactProbeCandidate, 0, len(candidates))
+	ordered := make([]exploreTaskProbe, 0, len(candidates))
 	for _, candidate := range candidates {
 		ordered = append(ordered, candidate)
 	}
@@ -243,14 +262,13 @@ func rankedExploreArtifactProbes(task string, seen map[string]struct{}) []string
 		}
 		return ordered[i].value < ordered[j].value
 	})
-	out := make([]string, 0, exploreArtifactProbeLimit)
+	out := make([]exploreTaskProbe, 0, limit)
 	for _, candidate := range ordered {
-		key := strings.ToLower(candidate.value)
-		seen[key] = struct{}{}
-		out = append(out, candidate.value)
-		if len(out) == exploreArtifactProbeLimit {
+		if len(out) == limit {
 			break
 		}
+		seen[strings.ToLower(candidate.value)] = struct{}{}
+		out = append(out, candidate)
 	}
 	return out
 }

--- a/internal/mcp/explore_exact_name_anchor.go
+++ b/internal/mcp/explore_exact_name_anchor.go
@@ -1,0 +1,319 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/query"
+	"github.com/zzet/gortex/internal/search/rerank"
+)
+
+const (
+	exploreExactNameAnchorMaxTokens = 16
+	exploreExactNameAnchorMinChars  = 4
+	exploreExactNameAnchorMaxChars  = 64
+	// A name this widely shared describes a convention (handle, execute, run),
+	// not the task's subject, so it cannot anchor on its own.
+	exploreExactNameAnchorMaxShared = 8
+	exploreExactNameAnchorMaxNodes  = 10
+	exploreExactNameAnchorOwnerScan = 32
+)
+
+// exploreTaskAnchors is the anchor lane the retrieval side uses: the
+// task-shaped anchors first, then plain prose tokens that name an indexed
+// symbol exactly. Spelling alone cannot recognise an all-lowercase identifier
+// (vprintf, mount), so the graph decides — but only for the slots the
+// code-shaped lane left unclaimed.
+func (s *Server) exploreTaskAnchors(
+	ctx context.Context,
+	task string,
+	ordinary []*rerank.Candidate,
+	scope query.QueryOptions,
+) []exploreSyntacticAnchor {
+	anchors := exploreSyntacticAnchors(task)
+	slots := exploreSyntacticAnchorMaxTerms - len(anchors)
+	if slots <= 0 {
+		return anchors
+	}
+	return append(anchors, s.exploreExactNameAnchors(ctx, task, anchors, ordinary, scope, slots)...)
+}
+
+// exploreExactNameAnchors resolves plain task tokens against the graph name
+// index. Cost is fixed by construction: at most exploreExactNameAnchorMaxTokens
+// name lookups per task, each one sharded-map hit, with no per-candidate store
+// query and no source hydration.
+func (s *Server) exploreExactNameAnchors(
+	ctx context.Context,
+	task string,
+	shaped []exploreSyntacticAnchor,
+	ordinary []*rerank.Candidate,
+	scope query.QueryOptions,
+	slots int,
+) []exploreSyntacticAnchor {
+	if s == nil || s.graph == nil || slots <= 0 || ctx.Err() != nil {
+		return nil
+	}
+	tokens := exploreExactNameAnchorTokens(task)
+	if len(tokens) == 0 {
+		return nil
+	}
+	pooledFiles := exploreRankedPoolFiles(ordinary)
+	out := make([]exploreSyntacticAnchor, 0, slots)
+	for _, token := range tokens {
+		if ctx.Err() != nil {
+			break
+		}
+		nodes := s.exploreExactNameAnchorNodes(ctx, token, scope, pooledFiles)
+		if len(nodes) == 0 {
+			continue
+		}
+		anchor, ok := newExploreSyntacticAnchor(token)
+		if !ok || exploreExactNameAnchorDuplicate(anchor, shaped, out) {
+			continue
+		}
+		anchor.exactNodes = nodes
+		out = append(out, anchor)
+		if len(out) == slots {
+			break
+		}
+	}
+	return out
+}
+
+func exploreExactNameAnchorDuplicate(anchor exploreSyntacticAnchor, groups ...[]exploreSyntacticAnchor) bool {
+	for _, group := range groups {
+		for _, existing := range group {
+			if exploreSyntacticAnchorEquivalent(existing, anchor) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// exploreExactNameAnchorNodes returns the localizable declarations whose name is
+// the task token verbatim. Case matters: `Mount` and `mount` are different
+// symbols, and a case-insensitive match would readmit exactly the prose noise
+// this lane exists to exclude.
+func (s *Server) exploreExactNameAnchorNodes(
+	ctx context.Context,
+	token string,
+	scope query.QueryOptions,
+	pooledFiles map[string]struct{},
+) []*graph.Node {
+	matches := s.graph.FindNodesByName(token)
+	if len(matches) == 0 {
+		return nil
+	}
+	shared := 0
+	eligible := make([]*graph.Node, 0, exploreExactNameAnchorMaxNodes)
+	pooled := make([]*graph.Node, 0, exploreExactNameAnchorMaxNodes)
+	for _, node := range matches {
+		if node == nil || node.Name != token {
+			continue
+		}
+		shared++
+		if !exploreSyntacticAnchorEligibleNode(node) || !scope.ScopeAllows(node) ||
+			!s.nodeInSessionScope(ctx, node) {
+			continue
+		}
+		if len(eligible) < exploreExactNameAnchorMaxNodes {
+			eligible = append(eligible, node)
+		}
+		if _, ranked := pooledFiles[node.FilePath]; ranked && len(pooled) < exploreExactNameAnchorMaxNodes {
+			pooled = append(pooled, node)
+		}
+	}
+	if shared > exploreExactNameAnchorMaxShared {
+		// The ranked pool is independent evidence that one of the homonyms is the
+		// one the task means; without it an ambiguous name stays unanchored.
+		return pooled
+	}
+	return eligible
+}
+
+func exploreRankedPoolFiles(candidates []*rerank.Candidate) map[string]struct{} {
+	files := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		if candidate == nil || candidate.Node == nil || candidate.Node.FilePath == "" {
+			continue
+		}
+		files[candidate.Node.FilePath] = struct{}{}
+	}
+	return files
+}
+
+// exploreExactNameAnchorTokens returns the bounded, deduplicated prose tokens
+// worth one name lookup each. Code-shaped tokens are excluded on purpose: they
+// already own the syntactic lane, and re-admitting them here would spend the
+// budget re-deriving anchors that exist.
+func exploreExactNameAnchorTokens(task string) []string {
+	seen := make(map[string]struct{}, exploreExactNameAnchorMaxTokens)
+	out := make([]string, 0, exploreExactNameAnchorMaxTokens)
+	for _, raw := range exploreUnquotedCodeTokens(task) {
+		token := strings.Trim(raw, "-_.:()[]{}<>,;'\"")
+		if !exploreExactNameAnchorToken(token) {
+			continue
+		}
+		if _, duplicate := seen[token]; duplicate {
+			continue
+		}
+		seen[token] = struct{}{}
+		out = append(out, token)
+		if len(out) == exploreExactNameAnchorMaxTokens {
+			break
+		}
+	}
+	return out
+}
+
+func exploreExactNameAnchorToken(token string) bool {
+	if len(token) < exploreExactNameAnchorMinChars || len(token) > exploreExactNameAnchorMaxChars {
+		return false
+	}
+	first, _ := utf8.DecodeRuneInString(token)
+	if !unicode.IsLetter(first) {
+		return false
+	}
+	for _, r := range token {
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) {
+			return false
+		}
+	}
+	if exploreCodeShapedToken(token) {
+		return false
+	}
+	lower := strings.ToLower(token)
+	if _, stop := assistStopWords[lower]; stop {
+		return false
+	}
+	if _, generic := exploreTerminalGenericTerms[exploreTerminalTermRoot(lower)]; generic {
+		return false
+	}
+	return !exploreSyntacticAnchorNoise(lower)
+}
+
+// exploreDottedQualifiedMention recognises the dynamic-language spelling of a
+// qualified member so Owner.member resolves through the same exact graph lookup
+// as Owner::member. The owner segment must be type-shaped and the mention must
+// not be a file: tree.go and package.json name files, not members.
+func exploreDottedQualifiedMention(raw string) (string, bool) {
+	if strings.Contains(raw, "::") || strings.ContainsAny(raw, "/\\ \t") {
+		return "", false
+	}
+	dot := strings.LastIndexByte(raw, '.')
+	if dot <= 0 || dot == len(raw)-1 {
+		return "", false
+	}
+	if exploreSourceExtension(raw[dot:]) || exploreArtifactFile(raw) {
+		return "", false
+	}
+	owner, member := raw[:dot], raw[dot+1:]
+	if segment := strings.LastIndexByte(owner, '.'); segment >= 0 {
+		owner = owner[segment+1:]
+	}
+	if !exploreQualifiedOwnerSegment(owner) || !exploreQualifiedMemberSegment(member) {
+		return "", false
+	}
+	return owner + "." + member, true
+}
+
+func exploreQualifiedOwnerSegment(owner string) bool {
+	first, _ := utf8.DecodeRuneInString(owner)
+	return len(owner) >= 3 && unicode.IsUpper(first) && exploreIdentifierSegment(owner)
+}
+
+func exploreQualifiedMemberSegment(member string) bool {
+	first, _ := utf8.DecodeRuneInString(member)
+	// A capitalised tail is a nested namespace (Monolog.Handler.HipChatHandler),
+	// not a member of the segment before it.
+	return len(member) >= 3 && (unicode.IsLower(first) || first == '_') && exploreIdentifierSegment(member)
+}
+
+func exploreIdentifierSegment(segment string) bool {
+	for _, r := range segment {
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' {
+			return false
+		}
+	}
+	return segment != ""
+}
+
+// exploreExactAnchorCandidate resolves an anchor straight from the graph when
+// the task spelled a name the index already carries — the exact-name nodes
+// discovered during anchor selection, or the parser's member name for a
+// qualified mention. Both routes still pass the ordinary scope, kind and
+// diversity filters.
+func (s *Server) exploreExactAnchorCandidate(
+	ctx context.Context,
+	anchor exploreSyntacticAnchor,
+	scope query.QueryOptions,
+	usedIDs, usedFiles map[string]struct{},
+) *rerank.Candidate {
+	if len(anchor.exactNodes) > 0 {
+		candidates := make([]*rerank.Candidate, 0, len(anchor.exactNodes))
+		for _, node := range anchor.exactNodes {
+			candidates = append(candidates, &rerank.Candidate{Node: node, VectorRank: -1})
+		}
+		if got := exploreSyntacticAnchorCandidate(anchor, candidates, scope, usedIDs, usedFiles); got != nil {
+			return got
+		}
+	}
+	return s.exploreExactQualifiedAnchorCandidate(ctx, anchor, scope, usedIDs, usedFiles)
+}
+
+// exploreQualifiedAnchorOwnerCandidate resolves the declaring type named by a
+// qualified mention that already resolved to its member. One bounded name-index
+// lookup per qualified anchor (at most exploreSyntacticAnchorMaxTerms per task);
+// the owner declared beside the member wins so a homonym elsewhere in the tree
+// cannot displace it.
+func (s *Server) exploreQualifiedAnchorOwnerCandidate(
+	ctx context.Context,
+	anchor exploreSyntacticAnchor,
+	member *graph.Node,
+	scope query.QueryOptions,
+	usedIDs map[string]struct{},
+) *rerank.Candidate {
+	if s == nil || s.graph == nil || member == nil || anchor.qualifiedName == "" || ctx.Err() != nil {
+		return nil
+	}
+	dot := strings.LastIndexByte(anchor.qualifiedName, '.')
+	if dot <= 0 {
+		return nil
+	}
+	owner := anchor.qualifiedName[:dot]
+	if segment := strings.LastIndexByte(owner, '.'); segment >= 0 {
+		owner = owner[segment+1:]
+	}
+	if owner == "" || owner == member.Name {
+		return nil
+	}
+	var best *graph.Node
+	scanned := 0
+	for _, node := range s.graph.FindNodesByName(owner) {
+		if scanned == exploreExactNameAnchorOwnerScan {
+			break
+		}
+		scanned++
+		if node == nil || node.Name != owner ||
+			(node.Kind != graph.KindType && node.Kind != graph.KindInterface) {
+			continue
+		}
+		if !scope.ScopeAllows(node) || !s.nodeInSessionScope(ctx, node) {
+			continue
+		}
+		if _, used := usedIDs[node.ID]; used {
+			continue
+		}
+		if best == nil || (node.FilePath == member.FilePath && best.FilePath != member.FilePath) {
+			best = node
+		}
+	}
+	if best == nil {
+		return nil
+	}
+	return &rerank.Candidate{Node: best, VectorRank: -1}
+}

--- a/internal/mcp/explore_exact_name_anchor.go
+++ b/internal/mcp/explore_exact_name_anchor.go
@@ -147,24 +147,28 @@ func exploreRankedPoolFiles(candidates []*rerank.Candidate) map[string]struct{} 
 }
 
 // exploreExactNameAnchorTokens returns the bounded, deduplicated prose tokens
-// worth one name lookup each. Code-shaped tokens are excluded on purpose: they
-// already own the syntactic lane, and re-admitting them here would spend the
-// budget re-deriving anchors that exist.
+// worth one name lookup each, then the tokens mined from code blocks. Tokens
+// the author wrote as prose rank first and the shared budget is unchanged, so
+// mining can only spend the lookups prose left over. Code-shaped tokens are
+// excluded on purpose: they already own the syntactic lane, and re-admitting
+// them here would spend the budget re-deriving anchors that exist.
 func exploreExactNameAnchorTokens(task string) []string {
 	seen := make(map[string]struct{}, exploreExactNameAnchorMaxTokens)
 	out := make([]string, 0, exploreExactNameAnchorMaxTokens)
-	for _, raw := range exploreUnquotedCodeTokens(task) {
-		token := strings.Trim(raw, "-_.:()[]{}<>,;'\"")
-		if !exploreExactNameAnchorToken(token) {
-			continue
-		}
-		if _, duplicate := seen[token]; duplicate {
-			continue
-		}
-		seen[token] = struct{}{}
-		out = append(out, token)
-		if len(out) == exploreExactNameAnchorMaxTokens {
-			break
+	for _, lane := range [2][]string{exploreUnquotedCodeTokens(task), exploreFencedCodeTokens(task)} {
+		for _, raw := range lane {
+			token := strings.Trim(raw, "-_.:()[]{}<>,;'\"")
+			if !exploreExactNameAnchorToken(token) {
+				continue
+			}
+			if _, duplicate := seen[token]; duplicate {
+				continue
+			}
+			seen[token] = struct{}{}
+			out = append(out, token)
+			if len(out) == exploreExactNameAnchorMaxTokens {
+				return out
+			}
 		}
 	}
 	return out

--- a/internal/mcp/explore_exact_name_anchor_test.go
+++ b/internal/mcp/explore_exact_name_anchor_test.go
@@ -1,0 +1,201 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/query"
+	"github.com/zzet/gortex/internal/search/rerank"
+)
+
+func exactNameAnchorServer(t *testing.T, nodes ...*graph.Node) *Server {
+	t.Helper()
+	g := graph.New()
+	for _, node := range nodes {
+		g.AddNode(node)
+	}
+	return &Server{graph: g}
+}
+
+func TestExploreTaskAnchorsAdmitLowercaseProseSymbolName(t *testing.T) {
+	vprintf := &graph.Node{
+		ID: "src/print.c::vprintf", Name: "vprintf",
+		Kind: graph.KindFunction, FilePath: "src/print.c", StartLine: 40, EndLine: 88,
+	}
+	server := exactNameAnchorServer(t, vprintf)
+	task := "printing garbles output when the width is negative in vprintf"
+	anchors := server.exploreTaskAnchors(context.Background(), task, nil, query.QueryOptions{})
+	if len(anchors) != 1 {
+		t.Fatalf("anchors = %#v, want the indexed lowercase name", anchors)
+	}
+	if anchors[0].compact != "vprintf" {
+		t.Fatalf("anchor compact = %q, want vprintf", anchors[0].compact)
+	}
+	got := server.exploreExactAnchorCandidate(
+		context.Background(), anchors[0], query.QueryOptions{},
+		map[string]struct{}{}, map[string]struct{}{},
+	)
+	if got == nil || got.Node == nil || got.Node.ID != vprintf.ID {
+		t.Fatalf("exact name candidate = %#v, want %q", got, vprintf.ID)
+	}
+}
+
+func TestReserveExploreSyntacticAnchorCandidatesKeepsGraphResolvedAnchor(t *testing.T) {
+	candidates := []*rerank.Candidate{
+		{Node: &graph.Node{ID: "semantic", Name: "print_width", Kind: graph.KindFunction, FilePath: "src/fmt.c"}},
+		{Node: &graph.Node{ID: "noise-a", Name: "pad_left", Kind: graph.KindFunction, FilePath: "src/pad.c"}},
+		{Node: &graph.Node{ID: "noise-b", Name: "pad_right", Kind: graph.KindFunction, FilePath: "src/pad.c"}},
+		{Node: &graph.Node{ID: "vprintf", Name: "vprintf", Kind: graph.KindFunction, FilePath: "src/print.c"}},
+	}
+	// The task carries no code-shaped token, so the graph-resolved anchor is
+	// recorded past the task-shaped anchor list and can only be reserved by ID.
+	got := reserveExploreSyntacticAnchorCandidates(
+		"printing garbles output when the width is negative in vprintf",
+		candidates, map[int]string{0: "vprintf"}, 2,
+	)
+	if len(got) < 2 {
+		t.Fatalf("reserved = %#v, want the semantic head plus the anchor", got)
+	}
+	if got[0].Node.ID != "semantic" || got[1].Node.ID != "vprintf" {
+		t.Fatalf("reserved order = [%s, %s], want semantic head then vprintf", got[0].Node.ID, got[1].Node.ID)
+	}
+}
+
+func TestExploreTaskAnchorsSkipAmbiguousPlainName(t *testing.T) {
+	nodes := make([]*graph.Node, 0, 9)
+	for index := 0; index < 9; index++ {
+		nodes = append(nodes, &graph.Node{
+			ID:   fmt.Sprintf("pkg/h%d.go::handle", index),
+			Name: "handle", Kind: graph.KindFunction,
+			FilePath: fmt.Sprintf("pkg/h%d.go", index),
+		})
+	}
+	server := exactNameAnchorServer(t, nodes...)
+	task := "requests handle poorly under sustained load"
+	if anchors := server.exploreTaskAnchors(context.Background(), task, nil, query.QueryOptions{}); len(anchors) != 0 {
+		t.Fatalf("anchors = %#v, want no anchor for a name shared by too many symbols", anchors)
+	}
+
+	pool := []*rerank.Candidate{{Node: &graph.Node{
+		ID: "pkg/h3.go::serve", Name: "serve", Kind: graph.KindFunction, FilePath: "pkg/h3.go",
+	}}}
+	anchors := server.exploreTaskAnchors(context.Background(), task, pool, query.QueryOptions{})
+	if len(anchors) != 1 || anchors[0].compact != "handle" {
+		t.Fatalf("anchors = %#v, want the ranked-pool file to disambiguate handle", anchors)
+	}
+	if len(anchors[0].exactNodes) != 1 || anchors[0].exactNodes[0].FilePath != "pkg/h3.go" {
+		t.Fatalf("exact nodes = %#v, want only the ranked-pool declaration", anchors[0].exactNodes)
+	}
+}
+
+func TestExploreTaskAnchorsKeepCodeShapedAnchorsAhead(t *testing.T) {
+	vprintf := &graph.Node{
+		ID: "src/print.c::vprintf", Name: "vprintf",
+		Kind: graph.KindFunction, FilePath: "src/print.c",
+	}
+	server := exactNameAnchorServer(t, vprintf)
+
+	full := server.exploreTaskAnchors(
+		context.Background(),
+		"buildContent then flushBuffer then handleBatch all break vprintf",
+		nil, query.QueryOptions{},
+	)
+	if len(full) != exploreSyntacticAnchorMaxTerms {
+		t.Fatalf("anchors = %#v, want the three code-shaped anchors", full)
+	}
+	for _, anchor := range full {
+		if anchor.compact == "vprintf" {
+			t.Fatalf("plain exact name displaced a code-shaped anchor: %#v", full)
+		}
+	}
+
+	partial := server.exploreTaskAnchors(
+		context.Background(),
+		"buildContent then flushBuffer both break vprintf",
+		nil, query.QueryOptions{},
+	)
+	if len(partial) != exploreSyntacticAnchorMaxTerms {
+		t.Fatalf("anchors = %#v, want the plain exact name to fill the free slot", partial)
+	}
+	if partial[2].compact != "vprintf" {
+		t.Fatalf("anchor order = %#v, want vprintf last", partial)
+	}
+}
+
+func TestExploreExactNameAnchorTokensAreBoundedAndDeduplicated(t *testing.T) {
+	words := []string{
+		"alpha", "bravo", "delta", "gamma", "kappa", "sigma", "theta", "omega",
+		"cargo", "flare", "gauge", "hover", "index", "joint", "knurl", "latch",
+		"mount", "nudge", "orbit", "plumb",
+	}
+	got := exploreExactNameAnchorTokens(strings.Join(words, " "))
+	if len(got) != exploreExactNameAnchorMaxTokens {
+		t.Fatalf("tokens = %d, want the %d-token cap", len(got), exploreExactNameAnchorMaxTokens)
+	}
+	if deduped := exploreExactNameAnchorTokens("mount mount latch"); len(deduped) != 2 {
+		t.Fatalf("tokens = %#v, want deduplicated candidates", deduped)
+	}
+	if short := exploreExactNameAnchorTokens("the fix is in fmt and the tests"); len(short) != 0 {
+		t.Fatalf("tokens = %#v, want short, generic and stopword tokens rejected", short)
+	}
+	if shaped := exploreExactNameAnchorTokens("buildContent and mount"); len(shaped) != 1 || shaped[0] != "mount" {
+		t.Fatalf("tokens = %#v, want only the plain token — code-shaped tokens own the syntactic lane", shaped)
+	}
+}
+
+func TestExploreSyntacticAnchorsResolveDottedOwnerMember(t *testing.T) {
+	anchors := exploreSyntacticAnchors("strip long messages in HipChatHandler.buildContent")
+	if len(anchors) != 1 {
+		t.Fatalf("anchors = %#v, want the dotted qualified member", anchors)
+	}
+	if anchors[0].qualifiedName != "HipChatHandler.buildContent" {
+		t.Fatalf("qualified graph name = %q, want HipChatHandler.buildContent", anchors[0].qualifiedName)
+	}
+	if anchors[0].query != "HipChatHandler buildContent" {
+		t.Fatalf("qualified member lookup = %q, want literal owner and member", anchors[0].query)
+	}
+	for _, anchor := range exploreSyntacticAnchors("panic in tree.go getValue and package.json") {
+		if anchor.qualifiedName != "" {
+			t.Fatalf("file mention became a qualified member: %#v", anchor)
+		}
+	}
+}
+
+func TestExploreDottedQualifiedMentionResolvesMemberAndOwner(t *testing.T) {
+	member := &graph.Node{
+		ID:   "src/Handler/HipChatHandler.php::HipChatHandler.buildContent",
+		Name: "buildContent", Kind: graph.KindMethod,
+		FilePath: "src/Handler/HipChatHandler.php", StartLine: 89,
+	}
+	owner := &graph.Node{
+		ID:   "src/Handler/HipChatHandler.php::HipChatHandler",
+		Name: "HipChatHandler", Kind: graph.KindType,
+		FilePath: "src/Handler/HipChatHandler.php", StartLine: 20,
+	}
+	elsewhere := &graph.Node{
+		ID:   "src/Handler/Legacy/HipChatHandler.php::HipChatHandler",
+		Name: "HipChatHandler", Kind: graph.KindType,
+		FilePath: "src/Handler/Legacy/HipChatHandler.php", StartLine: 12,
+	}
+	server := exactNameAnchorServer(t, member, owner, elsewhere)
+	anchors := exploreSyntacticAnchors("strip long messages in HipChatHandler.buildContent")
+	if len(anchors) != 1 {
+		t.Fatalf("anchors = %#v, want the dotted qualified member", anchors)
+	}
+	got := server.exploreExactAnchorCandidate(
+		context.Background(), anchors[0], query.QueryOptions{},
+		map[string]struct{}{}, map[string]struct{}{},
+	)
+	if got == nil || got.Node == nil || got.Node.ID != member.ID {
+		t.Fatalf("dotted member candidate = %#v, want %q", got, member.ID)
+	}
+	ownerCandidate := server.exploreQualifiedAnchorOwnerCandidate(
+		context.Background(), anchors[0], got.Node, query.QueryOptions{}, map[string]struct{}{},
+	)
+	if ownerCandidate == nil || ownerCandidate.Node == nil || ownerCandidate.Node.ID != owner.ID {
+		t.Fatalf("owner candidate = %#v, want the owner declared beside the member", ownerCandidate)
+	}
+}

--- a/internal/mcp/explore_fenced_mining.go
+++ b/internal/mcp/explore_fenced_mining.go
@@ -1,0 +1,161 @@
+package mcp
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	// exploreFencedMiningMaxRunes bounds how much code-block content one task
+	// contributes to mining. A pasted log dump is unbounded in principle; the
+	// evidence that names an implementation is at its head.
+	exploreFencedMiningMaxRunes = 2000
+	exploreFencedIndentSpaces   = 4
+	// A mined literal has to be long enough to be discriminating in source
+	// content and short enough to still be one source string.
+	exploreFencedLiteralMinRunes = 12
+	exploreFencedLiteralMaxRunes = 128
+	// Stack frames and code lines carry punctuation a message does not. Beyond
+	// this many structural symbols the line is a frame, not an error message.
+	exploreFencedLiteralMaxSymbols = 2
+	// Distinct literal candidates read per task before the bounded term list
+	// decides which of them survive.
+	exploreFencedLiteralMaxCandidates = 16
+)
+
+// exploreFencedCodeLines returns the trimmed lines of fenced and indented code
+// blocks, bounded to exploreFencedMiningMaxRunes of content per task. Query
+// shaping deletes these blocks before retrieval because their commands and log
+// noise out-weigh the defect sentence; the anchor and literal lanes mine them
+// first, so a stack frame or snippet pasted into a report still names the
+// implementation it came from.
+func exploreFencedCodeLines(task string) []string {
+	if !strings.Contains(task, "```") && !strings.Contains(task, "~~~") &&
+		!strings.Contains(task, "\n    ") && !strings.Contains(task, "\n\t") {
+		return nil
+	}
+	out := make([]string, 0, 16)
+	budget := exploreFencedMiningMaxRunes
+	fenced := false
+	for _, raw := range strings.Split(task, "\n") {
+		line := strings.TrimSpace(strings.TrimRight(raw, "\r"))
+		if strings.HasPrefix(line, "```") || strings.HasPrefix(line, "~~~") {
+			fenced = !fenced
+			continue
+		}
+		if line == "" || (!fenced && !exploreIndentedCodeLine(raw)) {
+			continue
+		}
+		if runes := []rune(line); len(runes) > budget {
+			line = string(runes[:budget])
+		}
+		budget -= utf8.RuneCountInString(line)
+		out = append(out, line)
+		if budget <= 0 {
+			break
+		}
+	}
+	return out
+}
+
+// exploreIndentedCodeLine recognises the indented-block spelling of a code
+// block. Markdown list items and quoted lines are indented too, so their
+// markers exclude the line: they are prose the ordinary lanes already read.
+func exploreIndentedCodeLine(raw string) bool {
+	if !strings.HasPrefix(raw, strings.Repeat(" ", exploreFencedIndentSpaces)) &&
+		!strings.HasPrefix(raw, "\t") {
+		return false
+	}
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return false
+	}
+	switch trimmed[0] {
+	case '-', '*', '+', '>', '#':
+		return false
+	}
+	return true
+}
+
+// exploreFencedCodeTokens returns the mined tokens in document order using the
+// prose lane's tokenization, so both anchor lanes apply their existing filters
+// to mined and prose tokens alike.
+func exploreFencedCodeTokens(task string) []string {
+	lines := exploreFencedCodeLines(task)
+	if len(lines) == 0 {
+		return nil
+	}
+	return exploreUnquotedCodeTokens(strings.Join(lines, "\n"))
+}
+
+// exploreFencedRecallLiterals returns the distinctive literals of a task's code
+// blocks: quoted strings first, then message-shaped lines. Both are values a
+// symbol corpus cannot carry — they exist only inside an implementation — which
+// is exactly what the bounded content lane searches for.
+func exploreFencedRecallLiterals(task string) []string {
+	lines := exploreFencedCodeLines(task)
+	if len(lines) == 0 {
+		return nil
+	}
+	quoted := make([]string, 0, exploreFencedLiteralMaxCandidates)
+	messages := make([]string, 0, exploreFencedLiteralMaxCandidates)
+	for _, line := range lines {
+		if len(quoted)+len(messages) >= exploreFencedLiteralMaxCandidates {
+			break
+		}
+		for _, match := range reInlineQuoted.FindAllString(line, -1) {
+			if inner := strings.TrimSpace(match[1 : len(match)-1]); inner != "" {
+				quoted = append(quoted, inner)
+			}
+		}
+		if message, ok := exploreFencedMessageLine(line); ok {
+			messages = append(messages, message)
+		}
+	}
+	return append(quoted, messages...)
+}
+
+// exploreFencedMessageLine extracts the message a code-block line reports. The
+// universal shape is "<origin>: <message>" — a level, an exception class, or a
+// file coordinate followed by the sentence a source literal produced — so the
+// tail after the last such separator is preferred over the whole line, which
+// carries the origin the source never spells.
+func exploreFencedMessageLine(line string) (string, bool) {
+	line = strings.TrimSpace(line)
+	if separator := strings.LastIndex(line, ": "); separator >= 0 {
+		if tail := exploreFencedLiteralShape(line[separator+2:]); tail != "" {
+			return tail, true
+		}
+	}
+	if whole := exploreFencedLiteralShape(line); whole != "" {
+		return whole, true
+	}
+	return "", false
+}
+
+// exploreFencedLiteralShape accepts message-shaped text and rejects code:
+// several words, mostly letters, and almost no structural punctuation.
+func exploreFencedLiteralShape(text string) string {
+	text = strings.Trim(strings.TrimSpace(text), "\"'`")
+	runes := utf8.RuneCountInString(text)
+	if runes < exploreFencedLiteralMinRunes || runes > exploreFencedLiteralMaxRunes ||
+		len(strings.Fields(text)) < 2 {
+		return ""
+	}
+	letters, symbols := 0, 0
+	for _, r := range text {
+		switch {
+		case unicode.IsLetter(r):
+			letters++
+		case unicode.IsDigit(r) || unicode.IsSpace(r):
+		case r == '.' || r == ',' || r == '\'' || r == '-' || r == '_':
+		default:
+			symbols++
+		}
+	}
+	if symbols > exploreFencedLiteralMaxSymbols || letters*10 < runes*6 {
+		return ""
+	}
+	return text
+}

--- a/internal/mcp/explore_fenced_mining_test.go
+++ b/internal/mcp/explore_fenced_mining_test.go
@@ -1,0 +1,173 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/query"
+)
+
+const exploreFencedReportTask = "Chunk upload never retries after a sealed manifest\n\n" +
+	"The client gives up on the second attempt instead of retrying the upload, " +
+	"so a large transfer has to start again from the beginning.\n\n" +
+	"Steps to reproduce are in the attached script; the daemon prints this before it exits:\n\n" +
+	"```\n" +
+	"fatal: unable to seal chunk manifest\n" +
+	"  at ChunkUploader.sealManifest (uploader.go:212)\n" +
+	"```\n"
+
+func TestExploreSyntacticAnchorsMineIdentifiersOnlyInsideFence(t *testing.T) {
+	// The motivating condition: shaping deletes the block before retrieval, so
+	// the identifier reaches ranking only if mining reads it first.
+	require.NotContains(t, shapeExploreQuery(exploreFencedReportTask), "sealManifest")
+
+	anchors := exploreSyntacticAnchors(exploreFencedReportTask)
+	found := false
+	for _, anchor := range anchors {
+		if anchor.qualifiedName == "ChunkUploader.sealManifest" {
+			found = true
+		}
+	}
+	require.True(t, found, "fenced qualified mention must anchor: %#v", anchors)
+}
+
+func TestExploreTaskAnchorsResolveExactNameOnlyInsideFence(t *testing.T) {
+	sealed := &graph.Node{
+		ID: "src/chunk.c::sealchunk", Name: "sealchunk",
+		Kind: graph.KindFunction, FilePath: "src/chunk.c", StartLine: 40, EndLine: 90,
+	}
+	server := exactNameAnchorServer(t, sealed)
+	task := "Uploads stall on retry\n\n```\ntrace: sealchunk returned -1\n```\n"
+
+	anchors := server.exploreTaskAnchors(context.Background(), task, nil, query.QueryOptions{})
+	require.Len(t, anchors, 1, "anchors = %#v", anchors)
+	require.Equal(t, "sealchunk", anchors[0].compact)
+	require.Len(t, anchors[0].exactNodes, 1)
+
+	got := server.exploreExactAnchorCandidate(
+		context.Background(), anchors[0], query.QueryOptions{},
+		map[string]struct{}{}, map[string]struct{}{},
+	)
+	require.NotNil(t, got)
+	require.Equal(t, sealed.ID, got.Node.ID)
+}
+
+func TestExploreFencedMiningRanksMinedTokensAfterProse(t *testing.T) {
+	task := "buildContent and flushBuffer both truncate the payload\n\n" +
+		"The two writers disagree about the payload limit, so the tail is lost.\n\n" +
+		"```\nat RetryQueue.drainBatch (queue.php:44)\n```\n"
+
+	anchors := exploreSyntacticAnchors(task)
+	require.Len(t, anchors, exploreSyntacticAnchorMaxTerms)
+	require.Equal(t, "buildcontent", anchors[0].compact)
+	require.Equal(t, "flushbuffer", anchors[1].compact)
+	require.Equal(t, "retryqueue.drainbatch", anchors[2].source,
+		"mined tokens may only fill the slots prose left unclaimed: %#v", anchors)
+}
+
+func TestExploreFencedMiningRespectsRuneBudget(t *testing.T) {
+	filler := strings.Repeat("  status ok for the current batch of pending records\n", 60)
+	task := "Batch drain stalls once the queue saturates\n\n" +
+		"The drain loop stops making progress while the producer keeps enqueuing.\n\n" +
+		"```\n" + filler + "at TailOnlyOwner.tailOnlyMember (tail.go:9)\n```\n"
+
+	lines := exploreFencedCodeLines(task)
+	runes := 0
+	for _, line := range lines {
+		runes += utf8.RuneCountInString(line)
+	}
+	require.LessOrEqual(t, runes, exploreFencedMiningMaxRunes)
+	require.NotContains(t, strings.Join(lines, "\n"), "tailOnlyMember",
+		"content past the mining budget must stay unread")
+	for _, anchor := range exploreSyntacticAnchors(task) {
+		require.NotEqual(t, "tailonlyowner.tailonlymember", anchor.source)
+	}
+}
+
+func TestExploreQuotedRecallTermsMineFencedLiterals(t *testing.T) {
+	terms := exploreQuotedRecallTerms(exploreFencedReportTask)
+	require.Contains(t, terms, "unable to seal chunk manifest",
+		"an error literal that exists only inside a fence must reach content recall: %#v", terms)
+	require.LessOrEqual(t, len(terms), exploreQuotedRecallMaxMinedTerms)
+}
+
+func TestExploreQuotedRecallTermsKeepProseTermsAheadOfMinedLiterals(t *testing.T) {
+	task := "Registration drops the tenant on rollback\n\n" +
+		"The daemon logs \"tenant registry cleared\" before the retry runs, so the entry is lost.\n\n" +
+		"```\n" +
+		"warn: tenant registry rollback discarded entry\n" +
+		"error: retry scheduled after the registry was cleared\n" +
+		"debug: reader ignored the pending manifest entry\n" +
+		"trace: writer flushed the pending batch to disk\n" +
+		"info: registry rebuilt from the durable snapshot\n" +
+		"```\n"
+	terms := exploreQuotedRecallTerms(task)
+	require.Len(t, terms, exploreQuotedRecallMaxMinedTerms)
+	require.Equal(t, "tenant registry cleared", terms[0], "prose literals keep the leading slots: %#v", terms)
+	require.Contains(t, terms, "tenant registry rollback discarded entry")
+	require.NotContains(t, terms, "registry rebuilt from the durable snapshot",
+		"mined literals stop at the total cap: %#v", terms)
+}
+
+func TestExploreSyntacticAnchorEvidenceReadyIgnoresMinedAnchors(t *testing.T) {
+	targets := []exploreTarget{{
+		node: &graph.Node{
+			ID: "src/upload.go::retryUpload", Name: "retryUpload",
+			Kind: graph.KindFunction, FilePath: "src/upload.go",
+		},
+		source: "func retryUpload() error { return nil }",
+	}}
+	anchors := exploreSyntacticAnchors(exploreFencedReportTask)
+	require.NotEmpty(t, anchors)
+	require.Zero(t, exploreAuthoredSyntacticAnchorCount(anchors))
+	require.True(t, exploreSyntacticAnchorEvidenceReady(exploreFencedReportTask, targets),
+		"a mined frame may name a third-party symbol, so it must not withhold an answer")
+
+	authored := "ChunkUploader.sealManifest never retries the upload"
+	require.Equal(t, 1, exploreAuthoredSyntacticAnchorCount(exploreSyntacticAnchors(authored)))
+	require.False(t, exploreSyntacticAnchorEvidenceReady(authored, targets),
+		"an anchor the requester spelled still needs covering evidence")
+}
+
+func TestExploreQuotedRecallClaimTermsIgnoreMinedLiterals(t *testing.T) {
+	require.NotEmpty(t, exploreQuotedRecallTerms(exploreFencedReportTask))
+	require.Empty(t, exploreQuotedRecallClaimTerms(exploreFencedReportTask),
+		"a mined literal is our inference, so it must not arm the literal-claim terminality gate")
+
+	// A task with no code block keeps one term list, so every gate that reads
+	// claims behaves exactly as it did before mining existed.
+	prose := `find where the locale "tenant-code" is registered`
+	require.Equal(t, exploreQuotedRecallTerms(prose), exploreQuotedRecallClaimTerms(prose))
+}
+
+func TestExploreFencedMessageLineRejectsFramesAndFragments(t *testing.T) {
+	for _, line := range []string{
+		"at com.example.Worker.run(Worker.java:42)",
+		"short",
+		"++++",
+		"|| && ;;",
+	} {
+		_, ok := exploreFencedMessageLine(line)
+		require.False(t, ok, "line %q must not be mined as a literal", line)
+	}
+	got, ok := exploreFencedMessageLine("fatal: unable to seal chunk manifest")
+	require.True(t, ok)
+	require.Equal(t, "unable to seal chunk manifest", got)
+}
+
+func TestExploreFencedMiningReadsIndentedBlocks(t *testing.T) {
+	task := "Manifest sealing fails on the retry path\n\n" +
+		"The retry path reports a failure the first attempt never produced.\n\n" +
+		"    fatal: unable to seal chunk manifest\n" +
+		"    at ChunkUploader.sealManifest (uploader.go:212)\n\n" +
+		"    - an indented bullet item that is prose rather than code\n"
+	lines := exploreFencedCodeLines(task)
+	require.NotEmpty(t, lines)
+	require.NotContains(t, strings.Join(lines, "\n"), "indented bullet item")
+	require.Contains(t, exploreQuotedRecallTerms(task), "unable to seal chunk manifest")
+}

--- a/internal/mcp/explore_leading_file_depth.go
+++ b/internal/mcp/explore_leading_file_depth.go
@@ -40,10 +40,12 @@ func exploreLeadingFileDepthBudget(limit int) int {
 // exploreLeadingRankedFile names the file a ranked pool has settled on, or ""
 // when ranking is still scattered. The top-ranked candidate's file leads once
 // the window corroborates it with a second hit; otherwise only a strict
-// majority of the window counts, which at most one file can hold.
+// majority of the window counts, which at most one file can hold. A window in
+// which no file repeats is decided — if at all — by the task's own path probes.
 func exploreLeadingRankedFile(ranked []*rerank.Candidate) string {
 	files := make([]string, 0, exploreLeadingFileDepthWindow)
 	counts := make(map[string]int, exploreLeadingFileDepthWindow)
+	probed := make(map[string]int, exploreLeadingFileDepthWindow)
 	for _, candidate := range ranked {
 		if len(files) >= exploreLeadingFileDepthWindow {
 			break
@@ -51,8 +53,12 @@ func exploreLeadingRankedFile(ranked []*rerank.Candidate) string {
 		if candidate == nil || candidate.Node == nil || candidate.Node.FilePath == "" {
 			continue
 		}
-		files = append(files, candidate.Node.FilePath)
-		counts[candidate.Node.FilePath]++
+		file := candidate.Node.FilePath
+		files = append(files, file)
+		counts[file]++
+		if score := explorePathProbeScore(candidate); score > probed[file] {
+			probed[file] = score
+		}
 	}
 	if len(files) == 0 {
 		return ""
@@ -65,7 +71,26 @@ func exploreLeadingRankedFile(ranked []*rerank.Candidate) string {
 			return file
 		}
 	}
-	return ""
+	return exploreProbeCorroboratedLeadingFile(files, probed)
+}
+
+// exploreProbeCorroboratedLeadingFile elects the one window file the task
+// corroborates better than every other. Ranking has already declined to choose
+// here, so a shared best score decides nothing and leaves the window scattered.
+func exploreProbeCorroboratedLeadingFile(files []string, probed map[string]int) string {
+	best, bestScore, tied := "", 0, false
+	for _, file := range files {
+		switch score := probed[file]; {
+		case score > bestScore:
+			best, bestScore, tied = file, score, false
+		case score == bestScore && file != best:
+			tied = true
+		}
+	}
+	if bestScore <= 0 || tied {
+		return ""
+	}
+	return best
 }
 
 // reserveExploreLeadingFileDepthTargets admits the leading file's highest-ranked

--- a/internal/mcp/explore_leading_file_depth.go
+++ b/internal/mcp/explore_leading_file_depth.go
@@ -1,0 +1,189 @@
+package mcp
+
+import (
+	"context"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/query"
+	"github.com/zzet/gortex/internal/search/rerank"
+)
+
+// Leading-file depth allocation.
+//
+// Per-file diversification demotes a file's hits once it reaches the per-file
+// cap, so a bounded localization page spends nearly every slot on one row per
+// file. That is the right trade while ranking is still undecided, and the wrong
+// one once it has settled on a file: the sibling declarations that complete the
+// answer live beside the leading row and are exactly the rows diversification
+// pushed below every other file. When one file clearly leads the ranked pool,
+// the expendable breadth tail is re-spent on that file's next-highest-ranked
+// symbols, taken from the pool as it stood before diversification.
+
+const (
+	// exploreLeadingFileDepthWindow is the ranked prefix a file must lead.
+	exploreLeadingFileDepthWindow = 5
+	// exploreLeadingFileDepthReserve bounds the slots depth may claim.
+	exploreLeadingFileDepthReserve = 3
+	// exploreLeadingFileDepthMinReserve keeps depth off pages too narrow to
+	// spare a slot without collapsing breadth entirely.
+	exploreLeadingFileDepthMinReserve = 2
+)
+
+func exploreLeadingFileDepthBudget(limit int) int {
+	reserve := min(limit/3, exploreLeadingFileDepthReserve)
+	if reserve < exploreLeadingFileDepthMinReserve {
+		return 0
+	}
+	return reserve
+}
+
+// exploreLeadingRankedFile names the file a ranked pool has settled on, or ""
+// when ranking is still scattered. The top-ranked candidate's file leads once
+// the window corroborates it with a second hit; otherwise only a strict
+// majority of the window counts, which at most one file can hold.
+func exploreLeadingRankedFile(ranked []*rerank.Candidate) string {
+	files := make([]string, 0, exploreLeadingFileDepthWindow)
+	counts := make(map[string]int, exploreLeadingFileDepthWindow)
+	for _, candidate := range ranked {
+		if len(files) >= exploreLeadingFileDepthWindow {
+			break
+		}
+		if candidate == nil || candidate.Node == nil || candidate.Node.FilePath == "" {
+			continue
+		}
+		files = append(files, candidate.Node.FilePath)
+		counts[candidate.Node.FilePath]++
+	}
+	if len(files) == 0 {
+		return ""
+	}
+	if counts[files[0]] > 1 {
+		return files[0]
+	}
+	for _, file := range files {
+		if counts[file]*2 > len(files) {
+			return file
+		}
+	}
+	return ""
+}
+
+// reserveExploreLeadingFileDepthTargets admits the leading file's highest-ranked
+// symbols that are not already on the page, using free slots first and then the
+// breadth tail past the direct-evidence reserve. Every evidence role that later
+// stages protect stays untouched, so depth can only displace rows the page
+// already treats as expendable. The pool is the ranked order as it stood before
+// per-file diversification, which is where the demoted siblings still are.
+//
+// Allocation is confined to the window the evidence page actually serializes,
+// so a wide max_symbols request keeps both its extra rows and its response
+// width.
+func reserveExploreLeadingFileDepthTargets(
+	ranked []*rerank.Candidate,
+	targets []exploreTarget,
+	limit int,
+	reserved map[string]struct{},
+	hydrate func(*graph.Node) exploreTarget,
+) []exploreTarget {
+	budget := exploreLeadingFileDepthBudget(limit)
+	if budget <= 0 || hydrate == nil || len(ranked) == 0 || len(targets) == 0 {
+		return targets
+	}
+	file := exploreLeadingRankedFile(ranked)
+	if file == "" {
+		return targets
+	}
+	present := make(map[string]struct{}, len(targets))
+	for _, target := range targets {
+		if target.node != nil {
+			present[target.node.ID] = struct{}{}
+		}
+	}
+	nodes := make([]*graph.Node, 0, budget)
+	for _, candidate := range ranked {
+		if len(nodes) >= budget {
+			break
+		}
+		if candidate == nil || candidate.Node == nil || candidate.Node.FilePath != file {
+			continue
+		}
+		if _, exists := present[candidate.Node.ID]; exists {
+			continue
+		}
+		present[candidate.Node.ID] = struct{}{}
+		nodes = append(nodes, candidate.Node)
+	}
+	if len(nodes) == 0 {
+		return targets
+	}
+
+	protected := make(map[string]struct{}, len(reserved)+1)
+	for id := range reserved {
+		protected[id] = struct{}{}
+	}
+	if targets[0].node != nil {
+		protected[targets[0].node.ID] = struct{}{}
+	}
+	pageLimit := min(limit, localizationReplayEvidenceLimit)
+	pageEnd := min(len(targets), pageLimit)
+	free := min(max(pageLimit-len(targets), 0), len(nodes))
+	// Only the tail past the direct-evidence reserve is expendable — the same
+	// rows relationship interleaving already reclaims.
+	evicted := make(map[int]struct{}, len(nodes)-free)
+	for index := pageEnd - 1; index >= localizationDirectEvidenceReserve && free+len(evicted) < len(nodes); index-- {
+		if exploreFoldedTargetMandatory(targets[index], protected) {
+			continue
+		}
+		evicted[index] = struct{}{}
+	}
+	admit := free + len(evicted)
+	if admit <= 0 {
+		return targets
+	}
+	if admit < len(nodes) {
+		nodes = nodes[:admit]
+	}
+
+	page := make([]exploreTarget, 0, len(targets)+len(nodes))
+	for index := 0; index < pageEnd; index++ {
+		if _, drop := evicted[index]; drop {
+			continue
+		}
+		page = append(page, targets[index])
+	}
+	for _, node := range nodes {
+		depth := hydrate(node)
+		if depth.node == nil {
+			continue
+		}
+		depth.leadingFileDepth = true
+		page = append(page, depth)
+	}
+	return append(page, targets[pageEnd:]...)
+}
+
+// hydrateExploreLeadingFileDepthTarget gives an admitted depth row the same
+// bounded body and depth-1 neighborhood every other page row carries, at a
+// fixed per-row cost bounded by exploreLeadingFileDepthReserve.
+func (s *Server) hydrateExploreLeadingFileDepthTarget(
+	ctx context.Context,
+	eng *query.Engine,
+	node *graph.Node,
+	ringOpts query.QueryOptions,
+) exploreTarget {
+	target := exploreTarget{node: node}
+	if node == nil || eng == nil {
+		return target
+	}
+	target.source = s.manifestSymbolSource(ctx, node)
+	if callers := eng.GetCallers(node.ID, ringOpts); callers != nil {
+		target.callers = ringNeighbors(callers.Nodes, node.ID, exploreRingCap)
+	}
+	if callees := eng.GetCallChain(node.ID, ringOpts); callees != nil {
+		complete := !callees.Truncated && !callees.BudgetHit && !callees.LowerBound
+		var projected bool
+		target.callees, projected = ringNeighborsProjection(callees.Nodes, node.ID, exploreRingCap)
+		target.directCalleesComplete = complete && projected
+	}
+	return target
+}

--- a/internal/mcp/explore_leading_file_depth_test.go
+++ b/internal/mcp/explore_leading_file_depth_test.go
@@ -1,0 +1,256 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/search/rerank"
+)
+
+func leadingDepthNode(id, name, file string) *graph.Node {
+	return &graph.Node{
+		ID:        id,
+		Name:      name,
+		QualName:  name,
+		Kind:      graph.KindFunction,
+		FilePath:  file,
+		StartLine: 7,
+		EndLine:   21,
+		Meta:      map[string]any{"signature": "func " + name + "()"},
+	}
+}
+
+func leadingDepthHydrate(node *graph.Node) exploreTarget {
+	return exploreTarget{node: node, source: "func " + node.Name + "() {}"}
+}
+
+func leadingDepthIDs(targets []exploreTarget) []string {
+	ids := make([]string, 0, len(targets))
+	for _, target := range targets {
+		if target.node == nil {
+			ids = append(ids, "")
+			continue
+		}
+		ids = append(ids, target.node.ID)
+	}
+	return ids
+}
+
+// leadingDepthPool builds a ranked pool whose leading file owns global ranks
+// one and three plus three siblings ranked past the final window, with every
+// other rank taken by a distinct file.
+func leadingDepthPool() (pool []*rerank.Candidate, leading, breadth []*graph.Node) {
+	add := func(node *graph.Node) {
+		pool = append(pool, &rerank.Candidate{Node: node, TextRank: len(pool), VectorRank: -1})
+	}
+	first := leadingDepthNode("repo/lead.go::LeadPrimary", "LeadPrimary", "repo/lead.go")
+	second := leadingDepthNode("repo/lead.go::LeadSecond", "LeadSecond", "repo/lead.go")
+	leading = append(leading, first, second)
+	for index := 0; index < 8; index++ {
+		breadth = append(breadth, leadingDepthNode(
+			fmt.Sprintf("repo/other_%d.go::Breadth%d", index, index),
+			fmt.Sprintf("Breadth%d", index),
+			fmt.Sprintf("repo/other_%d.go", index),
+		))
+	}
+	for index := 0; index < 3; index++ {
+		leading = append(leading, leadingDepthNode(
+			fmt.Sprintf("repo/lead.go::LeadSibling%d", index),
+			fmt.Sprintf("LeadSibling%d", index),
+			"repo/lead.go",
+		))
+	}
+	add(leading[0])
+	add(breadth[0])
+	add(leading[1])
+	for _, node := range breadth[1:] {
+		add(node)
+	}
+	for _, node := range leading[2:] {
+		add(node)
+	}
+	return pool, leading, breadth
+}
+
+// leadingDepthWindow is the final window per-file diversification leaves: the
+// leading file's first two rows plus one row per other file.
+func leadingDepthWindow(leading, breadth []*graph.Node) []exploreTarget {
+	targets := []exploreTarget{
+		{node: leading[0]},
+		{node: breadth[0]},
+		{node: leading[1]},
+	}
+	for _, node := range breadth[1:] {
+		targets = append(targets, exploreTarget{node: node})
+	}
+	return targets
+}
+
+func TestLeadingFileDepthAdmitsDemotedSiblingsIntoLocalizationPage(t *testing.T) {
+	pool, leading, breadth := leadingDepthPool()
+	targets := leadingDepthWindow(leading, breadth)
+	if len(targets) != exploreDefaultMaxSymbols {
+		t.Fatalf("fixture window = %d rows, want %d", len(targets), exploreDefaultMaxSymbols)
+	}
+
+	got := reserveExploreLeadingFileDepthTargets(
+		pool, targets, exploreDefaultMaxSymbols, nil, leadingDepthHydrate,
+	)
+	if len(got) != exploreDefaultMaxSymbols {
+		t.Fatalf("depth allocation changed page width to %d, want %d", len(got), exploreDefaultMaxSymbols)
+	}
+	admitted := map[string]bool{}
+	for _, target := range got {
+		if target.node != nil {
+			admitted[target.node.ID] = true
+		}
+	}
+	// Global ranks eleven and twelve, demoted below every other file.
+	for _, node := range leading[2:4] {
+		if !admitted[node.ID] {
+			t.Fatalf("leading-file sibling %q missing from page: %v", node.ID, leadingDepthIDs(got))
+		}
+	}
+	if admitted[breadth[6].ID] || admitted[breadth[7].ID] {
+		t.Fatalf("depth rows did not come from the breadth tail: %v", leadingDepthIDs(got))
+	}
+	for index := 0; index < localizationDirectEvidenceReserve; index++ {
+		if got[index].node == nil || got[index].node.ID != targets[index].node.ID {
+			t.Fatalf("head row %d = %q, want %q", index, leadingDepthIDs(got)[index], targets[index].node.ID)
+		}
+	}
+	for _, target := range got[localizationDirectEvidenceReserve:] {
+		if !target.leadingFileDepth || target.source == "" {
+			t.Fatalf("depth row %q is unmarked or unhydrated", leadingDepthIDs(got))
+		}
+	}
+	again := reserveExploreLeadingFileDepthTargets(
+		pool, targets, exploreDefaultMaxSymbols, nil, leadingDepthHydrate,
+	)
+	if fmt.Sprint(leadingDepthIDs(got)) != fmt.Sprint(leadingDepthIDs(again)) {
+		t.Fatal("depth allocation is not deterministic")
+	}
+}
+
+func TestLeadingFileDepthNeverEvictsProtectedEvidence(t *testing.T) {
+	pool, leading, breadth := leadingDepthPool()
+	targets := leadingDepthWindow(leading, breadth)
+	targets[8].causalChangeOwner = true
+	targets[9].sourceLiteral = true
+
+	got := reserveExploreLeadingFileDepthTargets(
+		pool, targets, exploreDefaultMaxSymbols, nil, leadingDepthHydrate,
+	)
+	if fmt.Sprint(leadingDepthIDs(got)) != fmt.Sprint(leadingDepthIDs(targets)) {
+		t.Fatalf("protected tail was displaced: %v", leadingDepthIDs(got))
+	}
+
+	targets[9].sourceLiteral = false
+	reserved := map[string]struct{}{targets[9].node.ID: {}}
+	got = reserveExploreLeadingFileDepthTargets(
+		pool, targets, exploreDefaultMaxSymbols, reserved, leadingDepthHydrate,
+	)
+	for _, target := range got {
+		if target.node != nil && target.node.ID == targets[9].node.ID {
+			return
+		}
+	}
+	t.Fatalf("externally reserved row was evicted: %v", leadingDepthIDs(got))
+}
+
+func TestLeadingFileDepthStaysInsideTheEvidencePageWindow(t *testing.T) {
+	pool, leading, breadth := leadingDepthPool()
+	targets := leadingDepthWindow(leading, breadth)
+	for index := 0; index < 4; index++ {
+		targets = append(targets, exploreTarget{node: leadingDepthNode(
+			fmt.Sprintf("repo/wide_%d.go::Wide%d", index, index),
+			fmt.Sprintf("Wide%d", index),
+			fmt.Sprintf("repo/wide_%d.go", index),
+		)})
+	}
+
+	got := reserveExploreLeadingFileDepthTargets(
+		pool, targets, exploreMaxMaxSymbols, nil, leadingDepthHydrate,
+	)
+	if len(got) != len(targets) {
+		t.Fatalf("wide request width = %d, want %d", len(got), len(targets))
+	}
+	for index := localizationReplayEvidenceLimit; index < len(got); index++ {
+		if got[index].leadingFileDepth {
+			t.Fatalf("depth row landed at %d, past the serialized page", index)
+		}
+	}
+	depthRows := 0
+	for _, target := range got[:localizationReplayEvidenceLimit] {
+		if target.leadingFileDepth {
+			depthRows++
+		}
+	}
+	if depthRows == 0 {
+		t.Fatalf("no depth row reached the page: %v", leadingDepthIDs(got))
+	}
+}
+
+func TestLeadingFileDepthLeavesScatteredRankingUnchanged(t *testing.T) {
+	var pool []*rerank.Candidate
+	var targets []exploreTarget
+	for index := 0; index < 15; index++ {
+		node := leadingDepthNode(
+			fmt.Sprintf("repo/scatter_%d.go::Scatter%d", index, index),
+			fmt.Sprintf("Scatter%d", index),
+			fmt.Sprintf("repo/scatter_%d.go", index),
+		)
+		pool = append(pool, &rerank.Candidate{Node: node, TextRank: index, VectorRank: -1})
+		if index < exploreDefaultMaxSymbols {
+			targets = append(targets, exploreTarget{node: node})
+		}
+	}
+	got := reserveExploreLeadingFileDepthTargets(
+		pool, targets, exploreDefaultMaxSymbols, nil, leadingDepthHydrate,
+	)
+	if fmt.Sprint(leadingDepthIDs(got)) != fmt.Sprint(leadingDepthIDs(targets)) {
+		t.Fatalf("scattered ranking changed the page: %v", leadingDepthIDs(got))
+	}
+}
+
+func TestLeadingFileDepthRowsSurviveEnvelopePacking(t *testing.T) {
+	pool, leading, breadth := leadingDepthPool()
+	page := reserveExploreLeadingFileDepthTargets(
+		pool, leadingDepthWindow(leading, breadth), exploreDefaultMaxSymbols, nil, leadingDepthHydrate,
+	)
+
+	task := "LeadPrimary LeadSecond LeadSibling0 behavior"
+	completion := newLocalizationCompletion(true, "")
+	result, _, digest, packed := buildLocalizationExploreResultForTaskFinalized(
+		completion, task, page, exploreMaxBudgetTokens,
+	)
+	if result == nil || result.IsError || digest == nil || packed.State == localizationStateInactive {
+		t.Fatalf("packed depth result = (%#v, %#v, %#v)", result, digest, packed)
+	}
+	text, ok := singleTextContent(result)
+	if !ok {
+		t.Fatalf("packed result content = %#v", result.Content)
+	}
+	var envelope localizationExploreEnvelope
+	if err := json.Unmarshal([]byte(text), &envelope); err != nil {
+		t.Fatalf("decode packed depth envelope: %v", err)
+	}
+	if len(envelope.Files) != len(envelope.Evidence) || len(envelope.Symbols) != len(envelope.Evidence) {
+		t.Fatalf("unaligned packed rows: files=%d symbols=%d evidence=%d",
+			len(envelope.Files), len(envelope.Symbols), len(envelope.Evidence))
+	}
+	leadingRows := 0
+	for index, row := range envelope.Evidence {
+		if row.Rank != index+1 || envelope.Files[index] != row.File || envelope.Symbols[index] != row.ID {
+			t.Fatalf("unaligned row %d: %#v", index+1, row)
+		}
+		if row.File == "repo/lead.go" {
+			leadingRows++
+		}
+	}
+	if leadingRows < 3 {
+		t.Fatalf("packed envelope kept %d leading-file rows, want depth beyond diversification", leadingRows)
+	}
+}

--- a/internal/mcp/explore_path_probe.go
+++ b/internal/mcp/explore_path_probe.go
@@ -1,0 +1,254 @@
+package mcp
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/zzet/gortex/internal/search/rerank"
+)
+
+// Task-derived path corroboration for source candidates.
+//
+// A task names the answer's path about as often as it names its symbols: the
+// flag, environment name, quoted span or camel-cased identifier an author
+// quotes is frequently a segment of the file that implements it. The artifact
+// lane already ranks those spans by distinctiveness, but it serves only
+// artifact-intent tasks, so source candidates carried no path-level signal at
+// all — a declaration in the file the task all but spells out ranked on
+// retrieval score alone.
+//
+// Corroboration is a tie-break, never a retrieval channel. It can trade the
+// weakest unreserved row of a bounded page for one better-corroborated row just
+// below the cut, and it can settle a leading-file election ranking left
+// scattered. It can never displace a row another evidence lane reserved.
+
+const (
+	// explorePathProbeLimit bounds the probes derived per localization call.
+	explorePathProbeLimit = 8
+	// explorePathProbeTokenCap bounds the tokens compared per probe.
+	explorePathProbeTokenCap = 4
+	// explorePathProbeSegmentCap bounds the trailing path segments compared, so
+	// a deep tree's shared parents cannot corroborate everything beneath them.
+	explorePathProbeSegmentCap = 6
+	// explorePathProbeMatchCap bounds the probes one path may score with, so a
+	// path echoing half the task cannot outscore a precise match.
+	explorePathProbeMatchCap = 3
+	// explorePathProbeScanCap bounds the candidates scored per call.
+	explorePathProbeScanCap = 128
+	// explorePathProbeLiftReach bounds how far below the cut a lift may reach.
+	explorePathProbeLiftReach = 8
+	// explorePathProbeMinToken is the shortest token worth comparing.
+	explorePathProbeMinToken = 3
+	// explorePathProbeSignal carries a candidate's path corroboration score.
+	explorePathProbeSignal = "explore_path_probe"
+)
+
+type explorePathProbe struct {
+	tokens []string
+	weight int
+}
+
+// explorePathProbes is one task's ranked probe set. The zero value corroborates
+// nothing, so a caller outside localization can hold one unconditionally.
+type explorePathProbes struct {
+	probes []explorePathProbe
+}
+
+// newExplorePathProbes derives the probe set once per call. Probes arrive in
+// priority order and keep it as a descending weight, so the spans an author
+// made distinctive outrank the ones that merely look like identifiers.
+func newExplorePathProbes(task string) explorePathProbes {
+	ranked := rankedExploreTaskProbes(task, make(map[string]struct{}), explorePathProbeLimit)
+	out := explorePathProbes{probes: make([]explorePathProbe, 0, len(ranked))}
+	for _, probe := range ranked {
+		tokens := explorePathProbeTokens(probe.value)
+		if len(tokens) == 0 {
+			continue
+		}
+		out.probes = append(out.probes, explorePathProbe{
+			tokens: tokens,
+			weight: explorePathProbeLimit - len(out.probes),
+		})
+	}
+	return out
+}
+
+func (p explorePathProbes) empty() bool { return len(p.probes) == 0 }
+
+// scorePath sums the weights of the probes a path corroborates. A probe counts
+// only when every one of its tokens names a compared path segment, so sharing a
+// single word with a path is worth nothing.
+func (p explorePathProbes) scorePath(path string) int {
+	if len(p.probes) == 0 {
+		return 0
+	}
+	tokens := explorePathSegmentTokens(path)
+	if len(tokens) == 0 {
+		return 0
+	}
+	score, matched := 0, 0
+	for _, probe := range p.probes {
+		if matched == explorePathProbeMatchCap {
+			break
+		}
+		if !explorePathProbeMatches(probe, tokens) {
+			continue
+		}
+		matched++
+		score += probe.weight
+	}
+	return score
+}
+
+func explorePathProbeMatches(probe explorePathProbe, tokens map[string]struct{}) bool {
+	if len(probe.tokens) == 0 {
+		return false
+	}
+	for _, token := range probe.tokens {
+		if _, present := tokens[token]; !present {
+			return false
+		}
+	}
+	return true
+}
+
+// explorePathProbeTokens keeps a probe's distinctive words. Generic and
+// stopword tokens are dropped rather than required, and a probe left with
+// nothing but boilerplate corroborates nothing.
+func explorePathProbeTokens(value string) []string {
+	tokens := make([]string, 0, explorePathProbeTokenCap)
+	for _, raw := range rerank.Tokenize(value) {
+		token := exploreTerminalTermRoot(strings.ToLower(raw))
+		if len(token) < explorePathProbeMinToken {
+			continue
+		}
+		if _, stop := assistStopWords[token]; stop {
+			continue
+		}
+		if _, generic := exploreTerminalGenericTerms[token]; generic {
+			continue
+		}
+		tokens = append(tokens, token)
+		if len(tokens) == explorePathProbeTokenCap {
+			break
+		}
+	}
+	return tokens
+}
+
+// explorePathSegmentTokens tokenizes a path's trailing segments with the file
+// extension dropped — the extension names a language, not a subject.
+func explorePathSegmentTokens(path string) map[string]struct{} {
+	path = strings.Trim(strings.ReplaceAll(strings.TrimSpace(path), "\\", "/"), "/")
+	if path == "" {
+		return nil
+	}
+	if ext := filepath.Ext(path); ext != "" {
+		path = strings.TrimSuffix(path, ext)
+	}
+	segments := strings.Split(path, "/")
+	if len(segments) > explorePathProbeSegmentCap {
+		segments = segments[len(segments)-explorePathProbeSegmentCap:]
+	}
+	tokens := make(map[string]struct{}, len(segments)*3)
+	for _, segment := range segments {
+		for _, raw := range rerank.Tokenize(segment) {
+			token := exploreTerminalTermRoot(strings.ToLower(raw))
+			if len(token) < explorePathProbeMinToken {
+				continue
+			}
+			tokens[token] = struct{}{}
+		}
+	}
+	return tokens
+}
+
+// stampExplorePathProbeScores records path corroboration once per call, on the
+// bounded ranked prefix the page and its leading-file election can still reach.
+// Scoring is memoized per file and is pure string work — no store query, no
+// source hydration. Every later stage reads the stamp instead of rescoring.
+func stampExplorePathProbeScores(candidates []*rerank.Candidate, probes explorePathProbes) {
+	if probes.empty() {
+		return
+	}
+	byFile := make(map[string]int, explorePathProbeScanCap)
+	for index, candidate := range candidates {
+		if index == explorePathProbeScanCap {
+			return
+		}
+		if candidate == nil || candidate.Node == nil || candidate.Node.FilePath == "" {
+			continue
+		}
+		score, memoized := byFile[candidate.Node.FilePath]
+		if !memoized {
+			score = probes.scorePath(candidate.Node.FilePath)
+			byFile[candidate.Node.FilePath] = score
+		}
+		if score <= 0 {
+			continue
+		}
+		// Reranker clones may share one signal map, so tag a copy — the same rule
+		// the anchor lane follows.
+		signals := make(map[string]float64, len(candidate.Signals)+1)
+		for name, value := range candidate.Signals {
+			signals[name] = value
+		}
+		signals[explorePathProbeSignal] = float64(score)
+		candidate.Signals = signals
+	}
+}
+
+func explorePathProbeScore(candidate *rerank.Candidate) int {
+	if candidate == nil || candidate.Signals == nil {
+		return 0
+	}
+	return int(candidate.Signals[explorePathProbeSignal])
+}
+
+// liftExplorePathProbeCandidates admits the best-corroborated candidate that
+// ranked just below the bounded cut, in exchange for the weakest row inside it
+// that no evidence lane reserved. The admitted row must be strictly better
+// corroborated than the row it replaces, so a page already holding the
+// probe-named file keeps its order, and response width never changes.
+func liftExplorePathProbeCandidates(
+	candidates []*rerank.Candidate,
+	maxSymbols int,
+	reserved map[string]struct{},
+) []*rerank.Candidate {
+	if maxSymbols <= 1 || len(candidates) <= maxSymbols {
+		return candidates
+	}
+	reach := min(len(candidates), maxSymbols+explorePathProbeLiftReach)
+	admit, admitScore := -1, 0
+	for index := maxSymbols; index < reach; index++ {
+		if score := explorePathProbeScore(candidates[index]); score > admitScore {
+			admit, admitScore = index, score
+		}
+	}
+	if admit < 0 {
+		return candidates
+	}
+	// The head is retrieval's own answer and is never traded.
+	replace := -1
+	for index := maxSymbols - 1; index >= 1; index-- {
+		candidate := candidates[index]
+		if candidate == nil || candidate.Node == nil {
+			replace = index
+			break
+		}
+		if _, protected := reserved[candidate.Node.ID]; protected {
+			continue
+		}
+		if explorePathProbeScore(candidate) >= admitScore {
+			return candidates
+		}
+		replace = index
+		break
+	}
+	if replace < 0 {
+		return candidates
+	}
+	lifted := append([]*rerank.Candidate(nil), candidates...)
+	lifted[replace], lifted[admit] = lifted[admit], lifted[replace]
+	return lifted
+}

--- a/internal/mcp/explore_path_probe_test.go
+++ b/internal/mcp/explore_path_probe_test.go
@@ -1,0 +1,250 @@
+package mcp
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/search/rerank"
+)
+
+func pathProbeCandidate(id, file string, textRank int) *rerank.Candidate {
+	return &rerank.Candidate{
+		Node: &graph.Node{
+			ID: id, Name: id, QualName: id,
+			Kind: graph.KindFunction, FilePath: file,
+		},
+		TextRank:   textRank,
+		VectorRank: -1,
+	}
+}
+
+func pathProbeIDs(candidates []*rerank.Candidate) []string {
+	ids := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate == nil || candidate.Node == nil {
+			ids = append(ids, "")
+			continue
+		}
+		ids = append(ids, candidate.Node.ID)
+	}
+	return ids
+}
+
+func TestExplorePathProbesScoreOnlyCorroboratedPaths(t *testing.T) {
+	probes := newExplorePathProbes(
+		"Coverage reports are empty after `CollectCoverage` is enabled and COVERAGE_FORMAT=cobertura",
+	)
+	if probes.empty() {
+		t.Fatal("task with a quoted identifier and an environment probe derived no probes")
+	}
+	if len(probes.probes) > explorePathProbeLimit {
+		t.Fatalf("derived %d probes, want at most %d", len(probes.probes), explorePathProbeLimit)
+	}
+
+	corroborated := probes.scorePath("internal/report/collect_coverage.go")
+	if corroborated <= 0 {
+		t.Fatal("a path naming both probe words scored nothing")
+	}
+	if partial := probes.scorePath("internal/report/collect_symbols.go"); partial >= corroborated {
+		t.Fatalf("partial path match scored %d, want less than %d", partial, corroborated)
+	}
+	if unrelated := probes.scorePath("internal/graph/store.go"); unrelated != 0 {
+		t.Fatalf("unrelated path scored %d, want 0", unrelated)
+	}
+}
+
+func TestExplorePathProbesCapCorroborationPerPath(t *testing.T) {
+	probes := newExplorePathProbes(
+		"`RenderTable` and `ParseHeader` and `WriteFooter` and `ScanBorder` disagree",
+	)
+	if len(probes.probes) < explorePathProbeMatchCap+1 {
+		t.Fatalf("fixture derived %d probes, want more than the match cap", len(probes.probes))
+	}
+	stuffed := probes.scorePath("render_table/parse_header/write_footer/scan_border.go")
+	best := 0
+	for index := 0; index < explorePathProbeMatchCap; index++ {
+		best += probes.probes[index].weight
+	}
+	if stuffed > best {
+		t.Fatalf("term-stuffed path scored %d, want at most %d", stuffed, best)
+	}
+}
+
+func TestExplorePathProbesIgnoreGenericTaskWords(t *testing.T) {
+	probes := newExplorePathProbes("Fix the `issue` in \"the file\" so `code` works")
+	for _, path := range []string{"internal/issue.go", "internal/code/file.go"} {
+		if score := probes.scorePath(path); score != 0 {
+			t.Fatalf("generic probe corroborated %q with %d", path, score)
+		}
+	}
+}
+
+func TestExplorePathProbeLiftAdmitsCorroboratedCandidateBelowCut(t *testing.T) {
+	probes := newExplorePathProbes("`CollectCoverage` returns nothing")
+	prod := []*rerank.Candidate{
+		pathProbeCandidate("head", "internal/a/head.go", 0),
+		pathProbeCandidate("second", "internal/b/second.go", 1),
+		pathProbeCandidate("weakest", "internal/c/weakest.go", 2),
+		pathProbeCandidate("corroborated", "internal/report/collect_coverage.go", 3),
+	}
+	stampExplorePathProbeScores(prod, probes)
+	if explorePathProbeScore(prod[3]) <= 0 {
+		t.Fatal("fixture candidate carries no path corroboration")
+	}
+
+	lifted := liftExplorePathProbeCandidates(prod, 3, nil)
+	selected := selectFinalExploreCandidates(lifted, nil, 3)
+
+	if len(selected) != 3 {
+		t.Fatalf("page width = %d, want 3", len(selected))
+	}
+	if selected[0].Node.ID != "head" {
+		t.Fatalf("head row = %q, want head", selected[0].Node.ID)
+	}
+	if candidateByID(selected, "corroborated") == nil {
+		t.Fatalf("corroborated candidate stayed below the cut: %v", pathProbeIDs(selected))
+	}
+	if candidateByID(selected, "weakest") != nil {
+		t.Fatalf("the lift traded a row other than the weakest: %v", pathProbeIDs(selected))
+	}
+	if candidateByID(selected, "second") == nil {
+		t.Fatalf("the lift displaced a stronger row: %v", pathProbeIDs(selected))
+	}
+	again := liftExplorePathProbeCandidates(prod, 3, nil)
+	if fmt.Sprint(pathProbeIDs(lifted)) != fmt.Sprint(pathProbeIDs(again)) {
+		t.Fatal("the lift is not deterministic")
+	}
+}
+
+func TestExplorePathProbeLiftNeverDisplacesReservedRows(t *testing.T) {
+	probes := newExplorePathProbes("`CollectCoverage` returns nothing")
+	prod := []*rerank.Candidate{
+		pathProbeCandidate("head", "internal/a/head.go", 0),
+		pathProbeCandidate("anchor", "internal/b/anchor.go", 1),
+		pathProbeCandidate("literal", "internal/c/literal.go", 2),
+		pathProbeCandidate("corroborated", "internal/report/collect_coverage.go", 3),
+	}
+	prod[2].Signals = map[string]float64{exploreSourceLiteralSignal: 1}
+	stampExplorePathProbeScores(prod, probes)
+	reserved := exploreFinalReservedCandidateIDs(prod, map[int]string{0: "anchor"}, "")
+
+	lifted := liftExplorePathProbeCandidates(prod, 3, reserved)
+
+	if fmt.Sprint(pathProbeIDs(lifted)) != fmt.Sprint(pathProbeIDs(prod)) {
+		t.Fatalf("path corroboration evicted reserved evidence: %v", pathProbeIDs(lifted))
+	}
+}
+
+func TestExplorePathProbeLiftIsNoOpWithoutCorroboration(t *testing.T) {
+	probes := newExplorePathProbes("`CollectCoverage` returns nothing")
+	prod := []*rerank.Candidate{
+		pathProbeCandidate("head", "internal/a/head.go", 0),
+		pathProbeCandidate("second", "internal/b/second.go", 1),
+		pathProbeCandidate("weakest", "internal/c/weakest.go", 2),
+		pathProbeCandidate("unrelated", "internal/d/unrelated.go", 3),
+	}
+	stampExplorePathProbeScores(prod, probes)
+	for _, candidate := range prod {
+		if explorePathProbeScore(candidate) != 0 {
+			t.Fatalf("candidate %q was stamped without a matching probe", candidate.Node.ID)
+		}
+	}
+
+	lifted := liftExplorePathProbeCandidates(prod, 3, nil)
+
+	if fmt.Sprint(pathProbeIDs(lifted)) != fmt.Sprint(pathProbeIDs(prod)) {
+		t.Fatalf("uncorroborated page was reordered: %v", pathProbeIDs(lifted))
+	}
+}
+
+func TestExplorePathProbeLiftKeepsBetterCorroborationInsideTheCut(t *testing.T) {
+	probes := newExplorePathProbes("`CollectCoverage` returns nothing")
+	prod := []*rerank.Candidate{
+		pathProbeCandidate("head", "internal/a/head.go", 0),
+		pathProbeCandidate("second", "internal/b/second.go", 1),
+		pathProbeCandidate("inside", "internal/report/collect_coverage.go", 2),
+		pathProbeCandidate("below", "cmd/collect_coverage/main.go", 3),
+	}
+	stampExplorePathProbeScores(prod, probes)
+
+	lifted := liftExplorePathProbeCandidates(prod, 3, nil)
+
+	if fmt.Sprint(pathProbeIDs(lifted)) != fmt.Sprint(pathProbeIDs(prod)) {
+		t.Fatalf("an equally corroborated row was traded away: %v", pathProbeIDs(lifted))
+	}
+}
+
+func TestLeadingRankedFilePrefersProbeCorroboratedFileOnTiedRanking(t *testing.T) {
+	probes := newExplorePathProbes("`CollectCoverage` returns nothing")
+	pool := []*rerank.Candidate{
+		pathProbeCandidate("a", "internal/a/first.go", 0),
+		pathProbeCandidate("b", "internal/b/second.go", 1),
+		pathProbeCandidate("c", "internal/report/collect_coverage.go", 2),
+		pathProbeCandidate("d", "internal/d/fourth.go", 3),
+		pathProbeCandidate("e", "internal/e/fifth.go", 4),
+	}
+	if file := exploreLeadingRankedFile(pool); file != "" {
+		t.Fatalf("scattered ranking elected %q before corroboration", file)
+	}
+
+	stampExplorePathProbeScores(pool, probes)
+
+	if file := exploreLeadingRankedFile(pool); file != "internal/report/collect_coverage.go" {
+		t.Fatalf("leading file = %q, want the probe-corroborated file", file)
+	}
+}
+
+func TestLeadingRankedFileKeepsSettledRankingOverProbes(t *testing.T) {
+	probes := newExplorePathProbes("`CollectCoverage` returns nothing")
+	pool := []*rerank.Candidate{
+		pathProbeCandidate("a", "internal/a/first.go", 0),
+		pathProbeCandidate("b", "internal/report/collect_coverage.go", 1),
+		pathProbeCandidate("c", "internal/a/first.go", 2),
+		pathProbeCandidate("d", "internal/d/fourth.go", 3),
+		pathProbeCandidate("e", "internal/e/fifth.go", 4),
+	}
+	stampExplorePathProbeScores(pool, probes)
+
+	if file := exploreLeadingRankedFile(pool); file != "internal/a/first.go" {
+		t.Fatalf("leading file = %q, want the file ranking already settled on", file)
+	}
+}
+
+func TestLeadingRankedFileStaysUnelectedWhenProbesTie(t *testing.T) {
+	probes := newExplorePathProbes("`CollectCoverage` returns nothing")
+	pool := []*rerank.Candidate{
+		pathProbeCandidate("a", "internal/a/first.go", 0),
+		pathProbeCandidate("b", "internal/report/collect_coverage.go", 1),
+		pathProbeCandidate("c", "cmd/collect_coverage/main.go", 2),
+		pathProbeCandidate("d", "internal/d/fourth.go", 3),
+		pathProbeCandidate("e", "internal/e/fifth.go", 4),
+	}
+	stampExplorePathProbeScores(pool, probes)
+
+	if file := exploreLeadingRankedFile(pool); file != "" {
+		t.Fatalf("leading file = %q, want no election while corroboration is tied", file)
+	}
+}
+
+// The source lane derives a wider probe set from the same ranking; the artifact
+// lane's own bound is unchanged.
+func TestRankedExploreArtifactProbesKeepTheirOwnBound(t *testing.T) {
+	task := "`RenderTable` and `ParseHeader` and `WriteFooter` and `ScanBorder` disagree in build config"
+	seen := make(map[string]struct{})
+
+	artifact := rankedExploreArtifactProbes(task, seen)
+
+	if len(artifact) != exploreArtifactProbeLimit {
+		t.Fatalf("artifact probes = %d, want %d", len(artifact), exploreArtifactProbeLimit)
+	}
+	for _, probe := range artifact {
+		if _, marked := seen[strings.ToLower(probe)]; !marked {
+			t.Fatalf("emitted probe %q did not mark the consumed term set", probe)
+		}
+	}
+	if source := newExplorePathProbes(task); len(source.probes) <= exploreArtifactProbeLimit {
+		t.Fatalf("source probes = %d, want more than the artifact bound", len(source.probes))
+	}
+}

--- a/internal/mcp/explore_source_literal.go
+++ b/internal/mcp/explore_source_literal.go
@@ -265,7 +265,7 @@ func (s *Server) gatherExploreSourceLiteralRecall(
 		// Mapping still shares attemptCtx, so the two attempts remain inside the
 		// fixed 150ms request budget without silently halving grep time again.
 		searchCtx, cancelSearch := context.WithTimeout(attemptCtx, searchBudget)
-		result.search = s.searchExploreSourceLiteral(searchCtx, term, repoPrefix, scope)
+		result.search = s.searchExploreSourceLiteral(searchCtx, term, repoPrefix, scope, exploreSourceLiteralRecallMaxHits)
 		result.searchErr = searchCtx.Err()
 		cancelSearch()
 		if ctx.Err() != nil {
@@ -783,12 +783,15 @@ func exploreSourceLiteralUnprefixedPath(path, repoPrefix string) string {
 
 // searchExploreSourceLiteral mirrors search_text's literal backend while
 // deliberately refusing an unscoped multi-repository fan-out. The caller's
-// session locality supplies repoPrefix in normal operation.
+// session locality supplies repoPrefix in normal operation. maxHits is the
+// caller's own recall cap — every caller is responsible for a bound the rest
+// of its response budget can absorb.
 func (s *Server) searchExploreSourceLiteral(
 	ctx context.Context,
 	term string,
 	repoPrefix string,
 	scope query.QueryOptions,
+	maxHits int,
 ) exploreSourceLiteralSearch {
 	if s.multiIndexer != nil {
 		if repoPrefix == "" {
@@ -807,7 +810,7 @@ func (s *Server) searchExploreSourceLiteral(
 		}
 		result := s.multiIndexer.GrepLiteralForRepoBounded(
 			ctx, repoPrefix, term,
-			exploreSourceLiteralRecallMaxHits,
+			maxHits,
 			exploreSourceLiteralRecallMaxFiles,
 		)
 		if result.Owned {
@@ -832,7 +835,7 @@ func (s *Server) searchExploreSourceLiteral(
 	if s.indexer != nil {
 		matches, incomplete := s.indexer.GrepLiteralBounded(
 			ctx, term,
-			exploreSourceLiteralRecallMaxHits,
+			maxHits,
 			exploreSourceLiteralRecallMaxFiles,
 		)
 		return exploreSourceLiteralSearch{

--- a/internal/mcp/explore_source_literal_test.go
+++ b/internal/mcp/explore_source_literal_test.go
@@ -1017,7 +1017,7 @@ func TestSearchExploreSourceLiteralFallsBackWhenMultiIndexerDoesNotOwnRepo(t *te
 	server := &Server{graph: store, indexer: idx, multiIndexer: multi}
 
 	search := server.searchExploreSourceLiteral(
-		context.Background(), "ku", "", query.QueryOptions{},
+		context.Background(), "ku", "", query.QueryOptions{}, exploreSourceLiteralRecallMaxHits,
 	)
 
 	require.Len(t, search.matches, 1)
@@ -1054,7 +1054,7 @@ func TestSearchExploreSourceLiteralDoesNotCrossConfiguredRepository(t *testing.T
 	server := &Server{graph: store, indexer: direct, multiIndexer: multi}
 
 	search := server.searchExploreSourceLiteral(
-		context.Background(), "ku", "repo-b", query.QueryOptions{},
+		context.Background(), "ku", "repo-b", query.QueryOptions{}, exploreSourceLiteralRecallMaxHits,
 	)
 
 	require.Empty(t, search.matches, "unresolved multi-repo scope must not scan the direct backend")

--- a/internal/mcp/explore_syntactic_anchor.go
+++ b/internal/mcp/explore_syntactic_anchor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"unicode"
@@ -30,6 +31,9 @@ type exploreSyntacticAnchor struct {
 	terms         []string
 	compact       string
 	qualifiedName string
+	// exactNodes carries the indexed declarations a plain task token named
+	// verbatim, so the anchor lane never repeats the name lookup that found it.
+	exactNodes []*graph.Node
 }
 
 // exploreSyntacticAnchors extracts only syntactically strong, unquoted clues.
@@ -137,6 +141,9 @@ func newExploreSyntacticAnchor(raw string) (exploreSyntacticAnchor, bool) {
 	if strings.Contains(raw, "::") {
 		query = strings.Join(strings.Fields(strings.ReplaceAll(raw, "::", " ")), " ")
 		qualifiedName = strings.ReplaceAll(strings.Join(strings.Fields(raw), ""), "::", ".")
+	} else if dotted, ok := exploreDottedQualifiedMention(raw); ok {
+		query = strings.Join(strings.Fields(strings.ReplaceAll(raw, ".", " ")), " ")
+		qualifiedName = dotted
 	}
 	return exploreSyntacticAnchor{
 		query:         query,
@@ -160,8 +167,8 @@ func exploreSyntacticAnchorEquivalent(left, right exploreSyntacticAnchor) bool {
 	if left.compact == right.compact {
 		return true
 	}
-	leftQualified := strings.Contains(left.source, "::")
-	rightQualified := strings.Contains(right.source, "::")
+	leftQualified := left.qualifiedName != ""
+	rightQualified := right.qualifiedName != ""
 	if leftQualified != rightQualified {
 		qualified, plain := left, right
 		if !leftQualified {
@@ -544,7 +551,7 @@ func exploreSyntacticAnchorMatchesNode(anchor exploreSyntacticAnchor, node *grap
 	}
 	return exploreSyntacticAnchorMatchesIdentifier(anchor, node.Name) ||
 		exploreSyntacticAnchorMatchesIdentifier(anchor, node.QualName) ||
-		(strings.Contains(anchor.source, "::") && exploreSyntacticAnchorMatchesIdentifier(anchor, node.ID)) ||
+		(anchor.qualifiedName != "" && exploreSyntacticAnchorMatchesIdentifier(anchor, node.ID)) ||
 		exploreSyntacticAnchorMatchesPath(anchor, node)
 }
 
@@ -763,7 +770,7 @@ func exploreSyntacticAnchorReusesProtected(
 	candidates []*rerank.Candidate,
 	usedIDs map[string]struct{},
 ) string {
-	qualifiedMember := strings.Contains(anchor.source, "::")
+	qualifiedMember := anchor.qualifiedName != ""
 	for _, candidate := range candidates {
 		if candidate == nil || candidate.Node == nil {
 			continue
@@ -843,6 +850,24 @@ func markExploreSyntacticAnchorCandidate(candidate *rerank.Candidate) {
 	candidate.Signals = signals
 }
 
+// exploreAnchorPoolCandidate prefers the already-ranked object for a node the
+// ordinary pool holds, so protecting an anchor never discards its channel
+// ranks, and reports whether the pool owned it.
+func exploreAnchorPoolCandidate(
+	ordinary []*rerank.Candidate,
+	candidate *rerank.Candidate,
+) (*rerank.Candidate, bool) {
+	if candidate == nil || candidate.Node == nil {
+		return candidate, false
+	}
+	for _, existing := range ordinary {
+		if existing != nil && existing.Node != nil && existing.Node.ID == candidate.Node.ID {
+			return existing, true
+		}
+	}
+	return candidate, false
+}
+
 func (s *Server) gatherExploreSyntacticAnchorCandidates(
 	ctx context.Context,
 	task string,
@@ -851,8 +876,11 @@ func (s *Server) gatherExploreSyntacticAnchorCandidates(
 	scope query.QueryOptions,
 	rctx *rerank.Context,
 ) ([]*rerank.Candidate, map[int]string) {
-	anchors := exploreSyntacticAnchors(task)
-	if s == nil || s.graph == nil || eng == nil || len(anchors) == 0 || ctx.Err() != nil {
+	if s == nil || s.graph == nil || eng == nil || ctx.Err() != nil {
+		return nil, nil
+	}
+	anchors := s.exploreTaskAnchors(ctx, task, ordinary, scope)
+	if len(anchors) == 0 {
 		return nil, nil
 	}
 
@@ -870,6 +898,9 @@ func (s *Server) gatherExploreSyntacticAnchorCandidates(
 
 	additions := make([]*rerank.Candidate, 0, len(anchors))
 	missed := make([]int, 0, len(anchors))
+	// Owners admitted alongside a resolved qualified member are recorded past
+	// the anchor list: they belong to no task token of their own.
+	ownerIndex := len(anchors)
 	anchorOpts := scope
 	anchorOpts.SkipInnerRerank = true
 	anchorOpts.SkipVectorChannel = true
@@ -885,18 +916,28 @@ func (s *Server) gatherExploreSyntacticAnchorCandidates(
 			protected[index] = reused
 			continue
 		}
-		if exactCandidate := s.exploreExactQualifiedAnchorCandidate(ctx, anchor, scope, usedIDs, usedFiles); exactCandidate != nil {
-			protectedCandidate := exactCandidate
-			for _, existing := range ordinary {
-				if existing != nil && existing.Node != nil && existing.Node.ID == exactCandidate.Node.ID {
-					protectedCandidate = existing
-					break
-				}
-			}
-			if protectedCandidate == exactCandidate {
-				additions = append(additions, exactCandidate)
+		if exactCandidate := s.exploreExactAnchorCandidate(ctx, anchor, scope, usedIDs, usedFiles); exactCandidate != nil {
+			protectedCandidate, pooled := exploreAnchorPoolCandidate(ordinary, exactCandidate)
+			if !pooled {
+				additions = append(additions, protectedCandidate)
 			}
 			addProtected(index, protectedCandidate)
+			// A resolved member without its declaring type reads as a free
+			// function. Admit the owner only into a slot no task token claims,
+			// so the anchor budget stays capped regardless of resolution order.
+			if ownerIndex < exploreSyntacticAnchorMaxTerms {
+				owner := s.exploreQualifiedAnchorOwnerCandidate(
+					ctx, anchor, protectedCandidate.Node, scope, usedIDs,
+				)
+				if owner != nil {
+					ownerCandidate, ownerPooled := exploreAnchorPoolCandidate(ordinary, owner)
+					if !ownerPooled {
+						additions = append(additions, ownerCandidate)
+					}
+					addProtected(ownerIndex, ownerCandidate)
+					ownerIndex++
+				}
+			}
 			continue
 		}
 		ordinaryCandidate := exploreSyntacticAnchorCandidate(anchor, ordinary, scope, usedIDs, usedFiles)
@@ -918,14 +959,7 @@ func (s *Server) gatherExploreSyntacticAnchorCandidates(
 			missed = append(missed, index)
 			continue
 		}
-		alreadyOrdinary := false
-		for _, existing := range ordinary {
-			if existing != nil && existing.Node != nil && existing.Node.ID == candidate.Node.ID {
-				alreadyOrdinary = true
-				break
-			}
-		}
-		if !alreadyOrdinary {
+		if _, pooled := exploreAnchorPoolCandidate(ordinary, candidate); !pooled {
 			additions = append(additions, candidate)
 		}
 		addProtected(index, candidate)
@@ -1007,6 +1041,26 @@ func (s *Server) gatherExploreSyntacticAnchorCandidates(
 	return additions, protected
 }
 
+// exploreReservedAnchorIndexes orders task-shaped anchors first and
+// graph-resolved reservations after them. Anchors admitted by exact graph name,
+// and owners admitted alongside a resolved qualified member, are recorded past
+// the task-shaped list, so they can only be reserved by identifier — this pure
+// step has no graph with which to re-derive them.
+func exploreReservedAnchorIndexes(anchors []exploreSyntacticAnchor, protected map[int]string) []int {
+	indexes := make([]int, 0, len(anchors)+len(protected))
+	for index := range anchors {
+		indexes = append(indexes, index)
+	}
+	resolved := make([]int, 0, len(protected))
+	for index, id := range protected {
+		if id != "" && index >= len(anchors) {
+			resolved = append(resolved, index)
+		}
+	}
+	sort.Ints(resolved)
+	return append(indexes, resolved...)
+}
+
 // reserveExploreSyntacticAnchorCandidates keeps every discovered anchor owner
 // inside the final window while preserving the semantic head and the relative
 // order of all candidates that do not need promotion.
@@ -1017,7 +1071,7 @@ func reserveExploreSyntacticAnchorCandidates(
 	maxSymbols int,
 ) []*rerank.Candidate {
 	anchors := exploreSyntacticAnchors(task)
-	if len(anchors) == 0 || len(candidates) == 0 || maxSymbols <= 0 {
+	if (len(anchors) == 0 && len(protected) == 0) || len(candidates) == 0 || maxSymbols <= 0 {
 		return candidates
 	}
 	if maxSymbols > len(candidates) {
@@ -1026,11 +1080,11 @@ func reserveExploreSyntacticAnchorCandidates(
 
 	usedIDs := make(map[string]struct{}, len(anchors))
 	usedFiles := make(map[string]struct{}, len(anchors))
-	reservationIDs := make([]string, 0, len(anchors))
-	for index, anchor := range anchors {
+	reservationIDs := make([]string, 0, len(anchors)+len(protected))
+	for _, index := range exploreReservedAnchorIndexes(anchors, protected) {
 		id := protected[index]
-		if id == "" {
-			if candidate := exploreSyntacticAnchorCandidate(anchor, candidates, query.QueryOptions{}, usedIDs, usedFiles); candidate != nil {
+		if id == "" && index < len(anchors) {
+			if candidate := exploreSyntacticAnchorCandidate(anchors[index], candidates, query.QueryOptions{}, usedIDs, usedFiles); candidate != nil {
 				id = candidate.Node.ID
 			}
 		}

--- a/internal/mcp/explore_syntactic_anchor.go
+++ b/internal/mcp/explore_syntactic_anchor.go
@@ -34,17 +34,25 @@ type exploreSyntacticAnchor struct {
 	// exactNodes carries the indexed declarations a plain task token named
 	// verbatim, so the anchor lane never repeats the name lookup that found it.
 	exactNodes []*graph.Node
+	// mined marks an anchor read out of a pasted code block rather than spelled
+	// by the requester. It retrieves and ranks like any other anchor, but the
+	// gates that withhold an answer ignore it: a stack frame can name a
+	// third-party symbol this repository will never contain.
+	mined bool
 }
 
 // exploreSyntacticAnchors extracts only syntactically strong, unquoted clues.
 // Flags lead because they are explicit user-facing identifiers; snake/camel/
 // qualified identifiers follow in first-seen order. Prefix-equivalent forms
 // collapse into one anchor, so --replace, replace_all, and Replacer consume a
-// single bounded retrieval lane rather than three.
+// single bounded retrieval lane rather than three. Identifiers mined from code
+// blocks come last: query shaping discards those blocks, so a stack frame or
+// snippet is the only remaining spelling of the symbol it names, but prose the
+// author wrote deliberately still owns the slots it can fill.
 func exploreSyntacticAnchors(task string) []exploreSyntacticAnchor {
 	out := make([]exploreSyntacticAnchor, 0, exploreSyntacticAnchorMaxTerms)
 	tokens := exploreUnquotedCodeTokens(task)
-	add := func(raw string) {
+	add := func(raw string, mined bool) {
 		anchor, ok := newExploreSyntacticAnchor(raw)
 		if !ok {
 			return
@@ -54,6 +62,7 @@ func exploreSyntacticAnchors(task string) []exploreSyntacticAnchor {
 				return
 			}
 		}
+		anchor.mined = mined
 		out = append(out, anchor)
 	}
 
@@ -65,22 +74,24 @@ func exploreSyntacticAnchors(task string) []exploreSyntacticAnchor {
 		if assignment := strings.IndexByte(flag, '='); assignment >= 0 {
 			flag = flag[:assignment]
 		}
-		add(flag)
+		add(flag, false)
 		if len(out) == exploreSyntacticAnchorMaxTerms {
 			return out
 		}
 	}
 
-	for _, token := range tokens {
-		if strings.HasPrefix(token, "--") {
-			continue
-		}
-		if exploreSyntacticAnchorRuntimeDataPath(token) || !exploreCodeShapedToken(token) {
-			continue
-		}
-		add(token)
-		if len(out) == exploreSyntacticAnchorMaxTerms {
-			break
+	for lane, laneTokens := range [2][]string{tokens, exploreFencedCodeTokens(task)} {
+		for _, token := range laneTokens {
+			if strings.HasPrefix(token, "--") {
+				continue
+			}
+			if exploreSyntacticAnchorRuntimeDataPath(token) || !exploreCodeShapedToken(token) {
+				continue
+			}
+			add(token, lane > 0)
+			if len(out) == exploreSyntacticAnchorMaxTerms {
+				return out
+			}
 		}
 	}
 	return out
@@ -1153,12 +1164,23 @@ func exploreSyntacticAnchorMatchesTargetSource(anchor exploreSyntacticAnchor, ta
 
 // exploreSyntacticAnchorEvidenceReady prevents a broad semantic neighbor from
 // terminating localization while a distinctive implementation clue is absent.
-// Every retained anchor needs one production declaration with hydrated source;
-// fields, tests, abstract declarations, and metadata-only hits cannot prove it.
+// Every retained anchor the requester spelled needs one production declaration
+// with hydrated source; fields, tests, abstract declarations, and metadata-only
+// hits cannot prove it.
 func exploreSyntacticAnchorEvidenceReady(task string, targets []exploreTarget) bool {
 	anchors := exploreSyntacticAnchors(task)
 	covered := make([]bool, len(anchors))
-	remaining := len(anchors)
+	remaining := 0
+	for index, anchor := range anchors {
+		if anchor.mined {
+			covered[index] = true
+			continue
+		}
+		remaining++
+	}
+	if remaining == 0 {
+		return true
+	}
 	for _, target := range targets {
 		if !exploreSyntacticAnchorEligibleNode(target.node) || strings.TrimSpace(target.source) == "" {
 			continue
@@ -1180,6 +1202,18 @@ func exploreSyntacticAnchorEvidenceReady(task string, targets []exploreTarget) b
 		}
 	}
 	return remaining == 0
+}
+
+// exploreAuthoredSyntacticAnchorCount counts the anchors the requester spelled.
+// Gates that withhold an answer read this count, never the mined total.
+func exploreAuthoredSyntacticAnchorCount(anchors []exploreSyntacticAnchor) int {
+	authored := 0
+	for _, anchor := range anchors {
+		if !anchor.mined {
+			authored++
+		}
+	}
+	return authored
 }
 
 func exploreSyntacticAnchorTargetMatchesAnchors(anchors []exploreSyntacticAnchor, target exploreTarget) int {

--- a/internal/mcp/localization_answer_grounding_test.go
+++ b/internal/mcp/localization_answer_grounding_test.go
@@ -1,0 +1,124 @@
+package mcp
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func firstLocalizationPrimaryLine(t *testing.T, page string) string {
+	t.Helper()
+	for _, line := range strings.Split(page, "\n") {
+		if strings.HasPrefix(line, "- PRIMARY — ") {
+			return line
+		}
+	}
+	t.Fatalf("page carries no primary row:\n%s", page)
+	return ""
+}
+
+// A name and a file locate a declaration; they do not show it. The excerpt is
+// the cheapest proof that the row names the declaration the caller wants.
+func TestPrimaryRowsCarryTheirDeclarationExcerpt(t *testing.T) {
+	rows := []localizationDigestRow{
+		{
+			ID: "repo/storage/disk.go::DiskStorage.Load", Name: "Load", Kind: "method",
+			File: "repo/storage/disk.go", Line: 42,
+			Signature: "func (s *DiskStorage) Load(key string) ([]byte, error)",
+		},
+		{
+			ID: "repo/storage/cache.go::Cache.Warm", Name: "Warm", Kind: "method",
+			File: "repo/storage/cache.go", Line: 8,
+			Signature: "func (c *Cache) Warm(ctx context.Context) error",
+		},
+		{
+			ID: "repo/storage/index.go::Index.Rebuild", Name: "Rebuild", Kind: "method",
+			File: "repo/storage/index.go", Line: 3,
+			Signature: "func (i *Index) Rebuild() error",
+		},
+		{
+			ID: "repo/storage/meta.go::Meta.Stamp", Name: "Stamp", Kind: "method",
+			File: "repo/storage/meta.go", Line: 90,
+			Signature: "func (m *Meta) Stamp(at time.Time)",
+		},
+	}
+	page := renderLocalizationFinalResponse(rows)
+
+	require.Contains(t, page,
+		"- PRIMARY — repo/storage/disk.go:42 — repo/storage/disk.go::DiskStorage.Load\n"+
+			"  func (s *DiskStorage) Load(key string) ([]byte, error)\n")
+	require.NotContains(t, page, "func (m *Meta) Stamp(at time.Time)",
+		"a supporting row is a pointer, not a declaration the answer rests on")
+	require.LessOrEqual(t, len(page), localizationFinalResponseMaxBytes)
+}
+
+// An excerpt proves which declaration a row names; a row is the answer itself.
+// Under the byte cap the proof goes before the identity it proves.
+func TestDeclarationExcerptsShedBeforeLocatedRows(t *testing.T) {
+	var envelope localizationExploreEnvelope
+	for index := 0; index < 4; index++ {
+		envelope.Evidence = append(envelope.Evidence, localizationEvidence{
+			Rank: index + 1,
+			ID:   fmt.Sprintf("repo/pkg/file%d.go::Handler%d.Run", index, index),
+			Name: fmt.Sprintf("Handler%d.Run", index), Kind: "method",
+			File: fmt.Sprintf("pkg/file%d.go", index), Line: index + 1,
+			Signature: "func (h *Handler) Run(" + strings.Repeat("option string, ", 260) + ") error",
+		})
+	}
+	digest := newLocalizationEvidenceDigestForTask("run the handler", envelope)
+
+	require.Len(t, digest.Evidence, len(envelope.Evidence))
+	for _, row := range envelope.Evidence {
+		require.Contains(t, digest.finalResponse, row.ID)
+	}
+	require.NotContains(t, digest.finalResponse, "option string")
+	require.LessOrEqual(t, len(digest.finalResponse), localizationFinalResponseMaxBytes)
+}
+
+// Two declarations sharing a bare name are the one case where naming the right
+// symbol is not enough. The provenance chain already knows which file the
+// answer is about; the leading row has to agree with it.
+func TestHomonymAnswerLeadsWithTheProvenanceLinkedFile(t *testing.T) {
+	rows := []localizationDigestRow{
+		{ID: "repo/storage/disk.go::DiskStorage.Load", Name: "Load", Kind: "method", File: "repo/storage/disk.go", Line: 42},
+		{ID: "repo/storage/cloud.go::CloudStorage.Load", Name: "Load", Kind: "method", File: "repo/storage/cloud.go", Line: 17},
+		{
+			ID: "repo/storage/cloud.go::CloudStorage", Name: "CloudStorage", Kind: "type",
+			File: "repo/storage/cloud.go", Line: 5, Provenance: localizationProvenanceDivergentDefaultType,
+		},
+	}
+	page := renderLocalizationFinalResponse(rows)
+	require.Contains(t, firstLocalizationPrimaryLine(t, page), "repo/storage/cloud.go::CloudStorage.Load")
+
+	// With no provenance flag the top-ranked row's file is the only thing the
+	// page knows, so the homonym in that file leads instead.
+	unanchored := renderLocalizationFinalResponse(rows[:2])
+	require.Contains(t, firstLocalizationPrimaryLine(t, unanchored), "repo/storage/disk.go::DiskStorage.Load")
+}
+
+func TestSameNamedRowsRenderFileQualified(t *testing.T) {
+	page := renderLocalizationFinalResponse([]localizationDigestRow{
+		{ID: "DiskStorage.Load", Name: "Load", Kind: "method", File: "repo/storage/disk.go", Line: 42},
+		{ID: "CloudStorage.Load", Name: "Load", Kind: "method", File: "repo/storage/cloud.go", Line: 17},
+	})
+	require.Contains(t, page, "- PRIMARY — repo/storage/disk.go:42 — repo/storage/disk.go::DiskStorage.Load")
+	require.Contains(t, page, "- PRIMARY — repo/storage/cloud.go:17 — repo/storage/cloud.go::CloudStorage.Load")
+
+	distinct := renderLocalizationFinalResponse([]localizationDigestRow{
+		{ID: "DiskStorage.Load", Name: "Load", Kind: "method", File: "repo/storage/disk.go", Line: 42},
+		{ID: "Cache.Warm", Name: "Warm", Kind: "method", File: "repo/storage/cache.go", Line: 8},
+	})
+	require.Contains(t, distinct, "- PRIMARY — repo/storage/disk.go:42 — DiskStorage.Load")
+}
+
+// The claim rule belongs on the page that ends the session. An unconfirmed
+// page prescribes a next step instead, and must not carry it.
+func TestTerminalDirectiveBindsClaimsToTheEvidence(t *testing.T) {
+	digest := provisionalTestDigest(t, provisionalTestRow())
+	require.Contains(t, localizationAnswerReadyDirective, localizationAnswerClaimDiscipline)
+	require.Contains(t, digest.finalResponse, localizationAnswerClaimDiscipline)
+	require.NotContains(t, digest.provisionalResponse, localizationAnswerClaimDiscipline)
+	require.LessOrEqual(t, len(digest.finalResponse), localizationFinalResponseMaxBytes)
+}

--- a/internal/mcp/localization_digest.go
+++ b/internal/mcp/localization_digest.go
@@ -565,6 +565,112 @@ func localizationFinalResponseBetterTaskScore(left, right localizationFinalRespo
 	return left.longest > right.longest
 }
 
+// localizationFinalResponseBareName is the identifier an answer is most likely
+// to reuse: the last segment of the row's name, stripped of its owner and file.
+// Two rows agreeing on it are the pair a caller can confuse.
+func localizationFinalResponseBareName(row localizationDigestRow) string {
+	name := strings.TrimSpace(row.Name)
+	if name == "" {
+		name = strings.TrimSpace(row.QualName)
+	}
+	if name == "" {
+		name = strings.TrimSpace(row.ID)
+	}
+	if cut := strings.LastIndex(name, "::"); cut >= 0 {
+		name = name[cut+2:]
+	}
+	if cut := strings.LastIndex(name, "."); cut >= 0 {
+		name = name[cut+1:]
+	}
+	return name
+}
+
+// localizationFinalResponseAnchorRank orders the provenance flags that can name
+// the file the page is actually about. A divergent default owner is the
+// strongest such claim, a causal literal callee next, then a proven
+// implementation target and a typed anchor projection.
+func localizationFinalResponseAnchorRank(provenance string) int {
+	switch provenance {
+	case localizationProvenanceDivergentDefault:
+		return 6
+	case localizationProvenanceSourceLiteralCallee:
+		return 5
+	case localizationProvenanceImplementationTarget:
+		return 4
+	case localizationProvenanceTypedAnchorProjection:
+		return 3
+	case localizationProvenanceDivergentDefaultType:
+		return 2
+	case localizationProvenancePermittedReadSource:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func localizationFinalResponseAnchorFile(rows []localizationDigestRow) string {
+	anchor, rank := "", 0
+	for _, row := range rows {
+		file := strings.TrimSpace(row.File)
+		if file == "" {
+			continue
+		}
+		if candidate := localizationFinalResponseAnchorRank(row.Provenance); candidate > rank {
+			anchor, rank = file, candidate
+		}
+		if anchor == "" {
+			// No provenance flag has spoken yet: the top-ranked row's file is the
+			// only thing the page knows about where the answer lives.
+			anchor = file
+		}
+	}
+	return anchor
+}
+
+// localizationFinalResponseHomonymOrder gives the first slot of each same-name
+// group to the row whose file the provenance chain points at. It reorders a
+// presentation copy only; retained evidence and its positional arrays are
+// untouched.
+func localizationFinalResponseHomonymOrder(rows []localizationDigestRow) []localizationDigestRow {
+	if len(rows) < 2 {
+		return rows
+	}
+	anchor := localizationFinalResponseAnchorFile(rows)
+	if anchor == "" {
+		return rows
+	}
+	counts := make(map[string]int, len(rows))
+	preferred := make(map[string]int, len(rows))
+	for index, row := range rows {
+		name := localizationFinalResponseBareName(row)
+		if name == "" {
+			continue
+		}
+		counts[name]++
+		if _, exists := preferred[name]; !exists && strings.TrimSpace(row.File) == anchor {
+			preferred[name] = index
+		}
+	}
+	ordered := make([]localizationDigestRow, 0, len(rows))
+	emitted := make([]bool, len(rows))
+	for index, row := range rows {
+		if emitted[index] {
+			continue
+		}
+		name := localizationFinalResponseBareName(row)
+		if target, exists := preferred[name]; exists && counts[name] > 1 && !emitted[target] {
+			ordered = append(ordered, rows[target])
+			emitted[target] = true
+		}
+		if emitted[index] {
+			continue
+		}
+		ordered = append(ordered, row)
+		emitted[index] = true
+	}
+	return ordered
+}
+
 func localizationFinalResponseNeighborContains(ids []string, id string) bool {
 	for _, candidate := range ids {
 		if strings.TrimSpace(candidate) == id {
@@ -597,6 +703,7 @@ func localizationFinalResponseRows(task string, current, rows []localizationDige
 	if len(rows) == 0 {
 		return nil
 	}
+	rows = localizationFinalResponseHomonymOrder(rows)
 	primaries := make([]localizationDigestRow, 0, localizationFinalResponsePrimaryLimit)
 	supporting := make([]localizationDigestRow, 0, localizationFinalResponseSupportingLimit)
 	selected := make(map[string]struct{}, localizationFinalResponsePrimaryLimit+localizationFinalResponseSupportingLimit)
@@ -709,7 +816,7 @@ func renderLocalizationFinalResponse(rows []localizationDigestRow) string {
 func renderLocalizationFinalResponseForTask(task string, current, rows []localizationDigestRow) string {
 	presented := localizationFinalResponseRows(task, current, rows)
 	return renderLocalizationAnswerPage(presented, localizationAnswerHeading,
-		"No bounded localization evidence was found.", localizationAnswerReadyDirective)
+		"No bounded localization evidence was found.", localizationAnswerReadyDirective, true)
 }
 
 // renderLocalizationProvisionalResponseForTask renders the same rows for a
@@ -724,22 +831,55 @@ func renderLocalizationProvisionalResponseForTask(task string, current, rows []l
 	if len(presented) > localizationProvisionalRowLimit {
 		presented = presented[:localizationProvisionalRowLimit]
 	}
+	excerpts := true
 	for {
 		page := renderLocalizationAnswerPage(presented, localizationProvisionalHeading,
 			"No localization evidence has been retained for this request yet.",
-			localizationProvisionalDirective)
+			localizationProvisionalDirective, excerpts)
 		if len(page) <= localizationFinalResponseMaxBytes || len(presented) == 0 {
 			return page
+		}
+		if excerpts {
+			// An excerpt proves which declaration a row names; a row is the answer
+			// itself. Drop every excerpt before the first located identity.
+			excerpts = false
+			continue
 		}
 		presented = presented[:len(presented)-1]
 	}
 }
 
+// localizationFinalResponseExcerptMaxRunes bounds one declaration excerpt. The
+// excerpt exists to show which declaration a row names, not to reproduce it.
+const localizationFinalResponseExcerptMaxRunes = 200
+
+func localizationFinalResponseExcerpt(row localizationDigestRow) string {
+	return compactLocalizationField(
+		localizationFinalResponseField(row.Signature), localizationFinalResponseExcerptMaxRunes,
+	)
+}
+
+// localizationFinalResponseSymbolLabel keeps same-named rows distinguishable by
+// the identity string alone. Graph identities already embed their file, so this
+// only qualifies the bare identities a caller could otherwise not tell apart.
+func localizationFinalResponseSymbolLabel(row localizationDigestRow, qualify bool) string {
+	id := localizationFinalResponseField(row.ID)
+	file := localizationFinalResponseField(row.File)
+	if !qualify || id == "" || file == "" || strings.Contains(id, file) {
+		return id
+	}
+	return file + "::" + id
+}
+
 func renderLocalizationAnswerPage(
-	presented []localizationFinalResponseRow, heading, empty, directive string,
+	presented []localizationFinalResponseRow, heading, empty, directive string, excerpts bool,
 ) string {
 	if len(presented) == 0 {
 		return heading + "\n" + empty + "\n\n" + directive
+	}
+	homonyms := make(map[string]int, len(presented))
+	for _, item := range presented {
+		homonyms[localizationFinalResponseBareName(item.row)]++
 	}
 	var response strings.Builder
 	response.WriteString(heading)
@@ -750,12 +890,23 @@ func renderLocalizationAnswerPage(
 			role = "PRIMARY"
 		}
 		file := localizationFinalResponseField(item.row.File)
-		id := localizationFinalResponseField(item.row.ID)
+		id := localizationFinalResponseSymbolLabel(item.row,
+			homonyms[localizationFinalResponseBareName(item.row)] > 1)
 		if item.row.Line > 0 {
 			fmt.Fprintf(&response, "- %s — %s:%d — %s\n", role, file, item.row.Line, id)
+		} else {
+			fmt.Fprintf(&response, "- %s — %s — %s\n", role, file, id)
+		}
+		// The excerpt rides its own line so the role/file/symbol tuple stays one
+		// aligned, parseable row.
+		if !excerpts || !item.primary {
 			continue
 		}
-		fmt.Fprintf(&response, "- %s — %s — %s\n", role, file, id)
+		if excerpt := localizationFinalResponseExcerpt(item.row); excerpt != "" {
+			response.WriteString("  ")
+			response.WriteString(excerpt)
+			response.WriteString("\n")
+		}
 	}
 	response.WriteString("\n")
 	response.WriteString(directive)
@@ -774,6 +925,12 @@ func refreshLocalizationDigestResponses(digest *localizationEvidenceDigest, task
 	digest.provisionalResponse = renderLocalizationProvisionalResponseForTask(task, current, digest.Evidence)
 }
 
+// localizationAnswerClaimDiscipline closes the remaining gap between a page
+// that names the right symbol and an answer that does. It rides the terminal
+// directive only: a page still prescribing a step must keep asking for that
+// step, and the refinement contract it carries is byte-budgeted.
+const localizationAnswerClaimDiscipline = "Name only symbols this page lists or a permitted call already returned."
+
 // The directive is the only instruction the caller sees on a terminal page, so
 // it names the one failure mode measurement keeps finding: an answer that
 // paraphrases the located identifier into a neighbouring one it inferred from
@@ -788,7 +945,7 @@ func refreshLocalizationDigestResponses(digest *localizationEvidenceDigest, task
 // caller's own statements against 2% on pages without it. Ask for the answer,
 // name what the answer should carry, and leave the caller free to disagree —
 // its disagreement is right more often than not.
-const localizationAnswerReadyDirective = "Localization for this task is complete. Answer now from this evidence, naming the files and symbols you rely on. If it does not fit the request, say so and name what does — your judgement about the code is welcome, another navigation call is not."
+const localizationAnswerReadyDirective = "Localization for this task is complete. Answer now from this evidence, naming the files and symbols you rely on. If it does not fit the request, say so and name what does — your judgement about the code is welcome, another navigation call is not. " + localizationAnswerClaimDiscipline
 
 const (
 	localizationAnswerHeading      = "LOCALIZATION:"

--- a/internal/mcp/localization_file_outline.go
+++ b/internal/mcp/localization_file_outline.go
@@ -1,0 +1,190 @@
+package mcp
+
+import (
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/search/rerank"
+)
+
+// Leading-file outline.
+//
+// A bounded localization page shows ten signature rows, and per-file
+// diversification spends most of those slots on distinct files. When the answer
+// is a declaration in the file the page already leads with, but not one of the
+// rows that file won, nothing on the page says the file declares it at all —
+// so the caller searches again for something it is already looking at. The
+// outline is that leading file's declaration index: name and line, no
+// signatures and no bodies. Only a page that still asks the caller to choose
+// carries one; a terminal page's caller is answering, not choosing.
+
+const (
+	// localizationOutlineRowCap bounds the rows one outline may serialize.
+	localizationOutlineRowCap = 40
+	// localizationOutlineHeadRows splits an elided outline between the file's
+	// opening declarations and its closing ones.
+	localizationOutlineHeadRows = localizationOutlineRowCap / 2
+)
+
+type localizationOutlineRow struct {
+	Name string `json:"name"`
+	Line int    `json:"line"`
+	// Kind is a one-rune hint. The row is a locator, so a coarse hint costs a
+	// byte and the name still decides.
+	Kind string `json:"kind,omitempty"`
+}
+
+// localizationFileOutline is the bounded declaration index of a page's leading
+// file. Declared counts what the file declares; Elided counts the rows the cap
+// dropped from the middle.
+type localizationFileOutline struct {
+	File     string                   `json:"file"`
+	Declared int                      `json:"declared"`
+	Elided   int                      `json:"elided,omitempty"`
+	Rows     []localizationOutlineRow `json:"rows"`
+}
+
+// localizationPageAcceptsOutline admits the outline on the states whose caller
+// still has to choose where to look.
+func localizationPageAcceptsOutline(state string) bool {
+	switch state {
+	case localizationStateNeedsRefinement, localizationStateNeedsRecovery,
+		localizationStateNeedsExactRead:
+		return true
+	}
+	return false
+}
+
+// localizationLeadingFileOutlineProvider defers the file enumeration until a
+// page is known to still be refining, and performs it at most once per page.
+// A nil enumerator disables the outline entirely.
+func localizationLeadingFileOutlineProvider(
+	pool []*rerank.Candidate,
+	targets []exploreTarget,
+	enumerate func(string) []*graph.Node,
+) func() *localizationFileOutline {
+	if enumerate == nil {
+		return nil
+	}
+	var (
+		outline *localizationFileOutline
+		built   bool
+	)
+	return func() *localizationFileOutline {
+		if built {
+			return outline
+		}
+		built = true
+		file := localizationOutlineLeadingFile(pool, targets)
+		if file == "" {
+			return nil
+		}
+		nodes := enumerate(file)
+		if len(nodes) == 0 {
+			// Nothing to enumerate leaves the nodes this page already fetched,
+			// which is the whole of what it knows about that file.
+			nodes = localizationOutlineFetchedNodes(pool, targets)
+		}
+		outline = newLocalizationFileOutline(file, nodes)
+		return outline
+	}
+}
+
+// localizationOutlineLeadingFile reuses the ranked leading-file notion depth
+// allocation settled on, falling back to the page's own order for the query
+// classes that never diversify by file and so retain no pre-diversification
+// pool.
+func localizationOutlineLeadingFile(pool []*rerank.Candidate, targets []exploreTarget) string {
+	if file := exploreLeadingRankedFile(pool); file != "" {
+		return file
+	}
+	ranked := make([]*rerank.Candidate, 0, len(targets))
+	for _, target := range targets {
+		if target.node == nil {
+			continue
+		}
+		ranked = append(ranked, &rerank.Candidate{Node: target.node})
+	}
+	return exploreLeadingRankedFile(ranked)
+}
+
+func localizationOutlineFetchedNodes(pool []*rerank.Candidate, targets []exploreTarget) []*graph.Node {
+	nodes := make([]*graph.Node, 0, len(pool)+len(targets))
+	for _, candidate := range pool {
+		if candidate != nil && candidate.Node != nil {
+			nodes = append(nodes, candidate.Node)
+		}
+	}
+	for _, target := range targets {
+		if target.node != nil {
+			nodes = append(nodes, target.node)
+		}
+	}
+	return nodes
+}
+
+// newLocalizationFileOutline projects one file's declarations into file order.
+// Nodes from another file are dropped, so a candidate pool is as valid an input
+// as a file enumeration.
+func newLocalizationFileOutline(file string, nodes []*graph.Node) *localizationFileOutline {
+	file = strings.TrimSpace(file)
+	if file == "" {
+		return nil
+	}
+	rows := make([]localizationOutlineRow, 0, len(nodes))
+	seen := make(map[string]struct{}, len(nodes))
+	for _, node := range nodes {
+		if node == nil || nodeDisplayPath(node) != file || isNonDefinitionNode(node.Kind) {
+			continue
+		}
+		name := strings.TrimSpace(node.QualName)
+		if name == "" {
+			name = strings.TrimSpace(node.Name)
+		}
+		if name == "" {
+			continue
+		}
+		key := node.ID
+		if key == "" {
+			key = name
+		}
+		if _, duplicate := seen[key]; duplicate {
+			continue
+		}
+		seen[key] = struct{}{}
+		rows = append(rows, localizationOutlineRow{
+			Name: compactLocalizationField(name, localizationMaxNameRunes),
+			Line: node.StartLine,
+			Kind: localizationOutlineKindLetter(node.Kind),
+		})
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	sort.SliceStable(rows, func(first, second int) bool {
+		if rows[first].Line != rows[second].Line {
+			return rows[first].Line < rows[second].Line
+		}
+		return rows[first].Name < rows[second].Name
+	})
+	outline := &localizationFileOutline{File: file, Declared: len(rows), Rows: rows}
+	if len(rows) > localizationOutlineRowCap {
+		// Both ends of a file carry declarations a caller may want; the middle
+		// is what a bounded index can give back.
+		kept := make([]localizationOutlineRow, 0, localizationOutlineRowCap)
+		kept = append(kept, rows[:localizationOutlineHeadRows]...)
+		kept = append(kept, rows[len(rows)-(localizationOutlineRowCap-localizationOutlineHeadRows):]...)
+		outline.Elided = len(rows) - localizationOutlineRowCap
+		outline.Rows = kept
+	}
+	return outline
+}
+
+func localizationOutlineKindLetter(kind graph.NodeKind) string {
+	for _, letter := range string(kind) {
+		return string(unicode.ToLower(letter))
+	}
+	return ""
+}

--- a/internal/mcp/localization_file_outline_test.go
+++ b/internal/mcp/localization_file_outline_test.go
@@ -1,0 +1,360 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/search/rerank"
+)
+
+const outlineLeadingFile = "repo/lead.go"
+
+func outlineDeclaration(name string, line int) *graph.Node {
+	return &graph.Node{
+		ID:        outlineLeadingFile + "::" + name,
+		Name:      name,
+		QualName:  name,
+		Kind:      graph.KindFunction,
+		FilePath:  outlineLeadingFile,
+		StartLine: line,
+		EndLine:   line + 4,
+		Meta:      map[string]any{"signature": "func " + name + "()"},
+	}
+}
+
+func outlineDeclaredFile(count int) []*graph.Node {
+	nodes := make([]*graph.Node, 0, count)
+	for index := 0; index < count; index++ {
+		nodes = append(nodes, outlineDeclaration(fmt.Sprintf("Declared%02d", index), index+1))
+	}
+	return nodes
+}
+
+func outlinePool(nodes ...*graph.Node) []*rerank.Candidate {
+	pool := make([]*rerank.Candidate, 0, len(nodes))
+	for index, node := range nodes {
+		pool = append(pool, &rerank.Candidate{Node: node, TextRank: index, VectorRank: -1})
+	}
+	return pool
+}
+
+func outlineEnvelope(t *testing.T, result *mcpgo.CallToolResult) localizationExploreEnvelope {
+	t.Helper()
+	if result == nil || result.IsError {
+		t.Fatalf("localization result = %#v", result)
+	}
+	text, ok := singleTextContent(result)
+	if !ok {
+		t.Fatalf("localization result content = %#v", result.Content)
+	}
+	var envelope localizationExploreEnvelope
+	if err := json.Unmarshal([]byte(text), &envelope); err != nil {
+		t.Fatalf("decode localization envelope: %v", err)
+	}
+	return envelope
+}
+
+func outlineEnvelopeBytes(t *testing.T, result *mcpgo.CallToolResult) int {
+	t.Helper()
+	text, ok := singleTextContent(result)
+	if !ok {
+		t.Fatalf("localization result content = %#v", result.Content)
+	}
+	return len(text)
+}
+
+func TestRefiningPageCarriesTheLeadingFileOutline(t *testing.T) {
+	declared := outlineDeclaredFile(6)
+	preferred, alternate := declared[0], declared[1]
+	targets := []exploreTarget{
+		{node: preferred, source: "func Declared00() { executeAll() }"},
+		{node: alternate, source: "func Declared01() { executeOne() }"},
+	}
+	enumerated := 0
+	outline := localizationLeadingFileOutlineProvider(
+		outlinePool(preferred, alternate), targets,
+		func(file string) []*graph.Node {
+			if file != outlineLeadingFile {
+				t.Fatalf("enumerated file = %q, want %q", file, outlineLeadingFile)
+			}
+			enumerated++
+			return declared
+		},
+	)
+	result, completion, _, _ := buildLocalizationRefinementResultForTaskWithOutline(
+		preferred.ID, "find the declared implementation", targets,
+		localizationDefaultBudgetTokens, exploreLocalizationRefinementRoutes(targets), outline,
+	)
+	if completion.State != localizationStateNeedsRefinement {
+		t.Fatalf("completion state = %q, want %q", completion.State, localizationStateNeedsRefinement)
+	}
+	envelope := outlineEnvelope(t, result)
+	if envelope.Outline == nil {
+		t.Fatal("refining page carries no leading-file outline")
+	}
+	if enumerated != 1 {
+		t.Fatalf("graph enumerations = %d, want exactly one per page", enumerated)
+	}
+	if envelope.Outline.File != outlineLeadingFile || envelope.Outline.Declared != len(declared) {
+		t.Fatalf("outline = %#v, want %d declarations in %q",
+			envelope.Outline, len(declared), outlineLeadingFile)
+	}
+	ranked := make(map[string]bool, len(envelope.Evidence))
+	for _, row := range envelope.Evidence {
+		ranked[row.Name] = true
+	}
+	unranked := 0
+	for _, row := range envelope.Outline.Rows {
+		if row.Name == "" || row.Line <= 0 {
+			t.Fatalf("outline row is not a locator: %#v", row)
+		}
+		if !ranked[row.Name] {
+			unranked++
+		}
+	}
+	if unranked == 0 {
+		t.Fatal("outline names only the symbols the ranked page already carries")
+	}
+	encoded, err := json.Marshal(envelope.Outline)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "func ") {
+		t.Fatalf("outline carries signatures or bodies: %s", encoded)
+	}
+}
+
+func TestTerminalPageCarriesNoOutlineAndPaysNoEnumeration(t *testing.T) {
+	declared := outlineDeclaredFile(6)
+	targets := []exploreTarget{{
+		node: declared[0], source: "func Declared00() { executeAll() }",
+		sourceLiteral: true, sourceLiteralCallee: true, exactContent: true,
+	}}
+	enumerated := 0
+	outline := localizationLeadingFileOutlineProvider(
+		outlinePool(declared[0]), targets,
+		func(string) []*graph.Node {
+			enumerated++
+			return declared
+		},
+	)
+	result, _, _, packed := buildLocalizationExploreResultForTaskFinalizedWithOutline(
+		newLocalizationCompletion(true, ""), "Declared00 executeAll", targets,
+		localizationDefaultBudgetTokens, outline,
+	)
+	if packed.State != localizationStateAnswerReady {
+		t.Fatalf("packed state = %q, want %q", packed.State, localizationStateAnswerReady)
+	}
+	if envelope := outlineEnvelope(t, result); envelope.Outline != nil {
+		t.Fatalf("terminal page carries an outline: %#v", envelope.Outline)
+	}
+	if enumerated != 0 {
+		t.Fatalf("terminal page paid %d graph enumerations, want none", enumerated)
+	}
+}
+
+func TestOutlineShedsBeforeEvidenceRowsUnderATightBudget(t *testing.T) {
+	declared := outlineDeclaredFile(40)
+	long := strings.Repeat("quoted-\"-slash-\\-metadata-", 24)
+	neighbors := make([]*graph.Node, 0, 12)
+	for index := 0; index < 12; index++ {
+		neighbors = append(neighbors, &graph.Node{ID: fmt.Sprintf("repo/neighbor-%02d-%s", index, long)})
+	}
+	targets := []exploreTarget{
+		{node: declared[0], source: "func Declared00() { executeAll() }", callers: neighbors, callees: neighbors},
+		{node: declared[1], source: "func Declared01() { executeOne() }", callers: neighbors, callees: neighbors},
+	}
+	for index := 0; index < 8; index++ {
+		targets = append(targets, exploreTarget{node: &graph.Node{
+			ID:       fmt.Sprintf("repo/optional-%02d.go::%s", index, long),
+			Name:     long,
+			Kind:     graph.KindFunction,
+			FilePath: fmt.Sprintf("repo/optional/%02d/%s.go", index, long),
+			QualName: long,
+			Meta:     map[string]any{"signature": long},
+		}})
+	}
+	routes := exploreLocalizationRefinementRoutes(targets)
+	build := func(budget int, withOutline bool) (localizationExploreEnvelope, int) {
+		var outline func() *localizationFileOutline
+		if withOutline {
+			outline = localizationLeadingFileOutlineProvider(
+				outlinePool(declared[0], declared[1]), targets,
+				func(string) []*graph.Node { return declared },
+			)
+		}
+		result, completion, _, _ := buildLocalizationRefinementResultForTaskWithOutline(
+			declared[0].ID, "find the declared implementation", targets, budget, routes, outline,
+		)
+		if completion.State != localizationStateNeedsRefinement {
+			t.Fatalf("completion state = %q, want %q", completion.State, localizationStateNeedsRefinement)
+		}
+		return outlineEnvelope(t, result), outlineEnvelopeBytes(t, result)
+	}
+
+	tight, tightBytes := build(exploreMinBudgetTokens, true)
+	if tight.Outline != nil {
+		t.Fatalf("tight page kept the outline: %#v", tight.Outline)
+	}
+	if tightBytes > exploreMinBudgetTokens*localizationEnvelopeBytesPerToken {
+		t.Fatalf("tight envelope = %d bytes, budget = %d",
+			tightBytes, exploreMinBudgetTokens*localizationEnvelopeBytesPerToken)
+	}
+	bare, bareBytes := build(exploreMinBudgetTokens, false)
+	if !reflect.DeepEqual(tight.Evidence, bare.Evidence) || !reflect.DeepEqual(tight.Symbols, bare.Symbols) {
+		t.Fatalf("outline cost evidence rows: %d/%d rows, %d/%d bytes",
+			len(tight.Evidence), len(bare.Evidence), tightBytes, bareBytes)
+	}
+	// The same rows and the same outline, with room for both: only the budget
+	// decided which one gave way.
+	wide, _ := build(exploreMaxBudgetTokens, true)
+	if wide.Outline == nil {
+		t.Fatal("a page with room to spare shed the outline anyway")
+	}
+}
+
+func TestOutlineElidesTheMiddleOfALargeFile(t *testing.T) {
+	declared := outlineDeclaredFile(100)
+	outline := newLocalizationFileOutline(outlineLeadingFile, declared)
+	if outline == nil {
+		t.Fatal("large file produced no outline")
+	}
+	if len(outline.Rows) != localizationOutlineRowCap {
+		t.Fatalf("outline rows = %d, want cap %d", len(outline.Rows), localizationOutlineRowCap)
+	}
+	if outline.Declared != len(declared) || outline.Elided != len(declared)-localizationOutlineRowCap {
+		t.Fatalf("outline = declared %d elided %d, want %d/%d",
+			outline.Declared, outline.Elided, len(declared), len(declared)-localizationOutlineRowCap)
+	}
+	head := outline.Rows[:localizationOutlineHeadRows]
+	tail := outline.Rows[localizationOutlineHeadRows:]
+	if head[0].Line != 1 || head[len(head)-1].Line != localizationOutlineHeadRows {
+		t.Fatalf("outline head = lines %d..%d", head[0].Line, head[len(head)-1].Line)
+	}
+	if tail[len(tail)-1].Line != len(declared) {
+		t.Fatalf("outline tail ends at line %d, want %d", tail[len(tail)-1].Line, len(declared))
+	}
+	if tail[0].Line <= head[len(head)-1].Line+1 {
+		t.Fatalf("outline elided nothing between lines %d and %d", head[len(head)-1].Line, tail[0].Line)
+	}
+	for _, row := range outline.Rows {
+		if row.Kind != "f" {
+			t.Fatalf("outline row kind = %q, want the function letter", row.Kind)
+		}
+	}
+}
+
+func TestLocalizationBudgetLeavesRoomForOutlineBesideEvidence(t *testing.T) {
+	if exploreDefaultBudgetTokens != 1600 {
+		t.Fatalf("explore default budget = %d, want 1600 for non-localization paths", exploreDefaultBudgetTokens)
+	}
+	if localizationDefaultBudgetTokens != 2400 {
+		t.Fatalf("localization default budget = %d, want 2400", localizationDefaultBudgetTokens)
+	}
+	declared := outlineDeclaredFile(60)
+	targets := []exploreTarget{
+		{node: declared[0], source: "func Declared00() { executeAll() }"},
+		{node: declared[1], source: "func Declared01() { executeOne() }"},
+	}
+	for index := 0; index < 8; index++ {
+		name := fmt.Sprintf("Breadth%02d", index)
+		targets = append(targets, exploreTarget{node: &graph.Node{
+			ID:        fmt.Sprintf("repo/breadth_%02d.go::%s", index, name),
+			Name:      name,
+			QualName:  "breadth." + name,
+			Kind:      graph.KindFunction,
+			FilePath:  fmt.Sprintf("repo/breadth_%02d.go", index),
+			StartLine: 12,
+			EndLine:   40,
+			Meta:      map[string]any{"signature": "func " + name + "(ctx context.Context) error"},
+		}})
+	}
+	outline := localizationLeadingFileOutlineProvider(
+		outlinePool(declared[0], declared[1]), targets,
+		func(string) []*graph.Node { return declared },
+	)
+	result, completion, _, _ := buildLocalizationRefinementResultForTaskWithOutline(
+		declared[0].ID, "find the declared implementation", targets,
+		localizationDefaultBudgetTokens, exploreLocalizationRefinementRoutes(targets), outline,
+	)
+	if completion.State != localizationStateNeedsRefinement {
+		t.Fatalf("completion state = %q", completion.State)
+	}
+	envelope := outlineEnvelope(t, result)
+	if bytes := outlineEnvelopeBytes(t, result); bytes > localizationDefaultBudgetTokens*localizationEnvelopeBytesPerToken {
+		t.Fatalf("envelope = %d bytes, budget = %d",
+			bytes, localizationDefaultBudgetTokens*localizationEnvelopeBytesPerToken)
+	}
+	if envelope.Outline == nil || len(envelope.Outline.Rows) != localizationOutlineRowCap {
+		t.Fatalf("outline = %#v, want %d rows beside the evidence", envelope.Outline, localizationOutlineRowCap)
+	}
+	if len(envelope.Evidence) != len(targets) {
+		t.Fatalf("evidence rows = %d, want all %d ranked rows beside the outline",
+			len(envelope.Evidence), len(targets))
+	}
+}
+
+func TestLeadingFileOutlineEnumeratesOncePerPage(t *testing.T) {
+	declared := outlineDeclaredFile(4)
+	targets := []exploreTarget{{node: declared[0]}, {node: declared[1]}}
+	enumerated := 0
+	outline := localizationLeadingFileOutlineProvider(
+		outlinePool(declared[0], declared[1]), targets,
+		func(string) []*graph.Node {
+			enumerated++
+			return declared
+		},
+	)
+	first, second := outline(), outline()
+	if first == nil || first != second {
+		t.Fatalf("outline provider = (%#v, %#v), want one retained result", first, second)
+	}
+	if enumerated != 1 {
+		t.Fatalf("graph enumerations = %d, want exactly one", enumerated)
+	}
+}
+
+func TestLeadingFileOutlineFallsBackToAlreadyFetchedNodes(t *testing.T) {
+	declared := outlineDeclaredFile(3)
+	targets := []exploreTarget{{node: declared[0]}, {node: declared[1]}}
+	outline := localizationLeadingFileOutlineProvider(
+		outlinePool(declared...), targets,
+		func(string) []*graph.Node { return nil },
+	)()
+	if outline == nil || outline.Declared != len(declared) {
+		t.Fatalf("outline = %#v, want the %d pool nodes of %q", outline, len(declared), outlineLeadingFile)
+	}
+}
+
+func TestScatteredRankingCarriesNoOutline(t *testing.T) {
+	var pool []*rerank.Candidate
+	var targets []exploreTarget
+	for index := 0; index < 6; index++ {
+		node := &graph.Node{
+			ID:        fmt.Sprintf("repo/scatter_%d.go::Scatter%d", index, index),
+			Name:      fmt.Sprintf("Scatter%d", index),
+			Kind:      graph.KindFunction,
+			FilePath:  fmt.Sprintf("repo/scatter_%d.go", index),
+			StartLine: 3,
+		}
+		pool = append(pool, &rerank.Candidate{Node: node, TextRank: index, VectorRank: -1})
+		targets = append(targets, exploreTarget{node: node})
+	}
+	enumerated := 0
+	outline := localizationLeadingFileOutlineProvider(pool, targets, func(string) []*graph.Node {
+		enumerated++
+		return nil
+	})
+	if page := outline(); page != nil {
+		t.Fatalf("scattered ranking produced an outline: %#v", page)
+	}
+	if enumerated != 0 {
+		t.Fatalf("scattered ranking paid %d graph enumerations", enumerated)
+	}
+}

--- a/internal/mcp/search_symbols_content_fallback.go
+++ b/internal/mcp/search_symbols_content_fallback.go
@@ -1,0 +1,123 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/zzet/gortex/internal/query"
+	"github.com/zzet/gortex/internal/search/trigram"
+)
+
+const (
+	// searchSymbolsContentFallbackMaxMatches bounds the whole recovery: at
+	// most this many trigram hits are grepped, scope-filtered, and mapped to
+	// an enclosing declaration, so the file-node lookups the mapping performs
+	// are bounded by the same number.
+	searchSymbolsContentFallbackMaxMatches = 8
+	searchSymbolsContentFallbackMinRunes   = 3
+
+	searchSymbolsContentFallbackReason = "symbol_lookup_empty"
+	searchSymbolsContentFallbackNote   = "No symbol node carries this name. These are raw content matches from the text index — file:line evidence plus the smallest declaration enclosing each line, not graph symbols. Nothing here can be passed to a symbol-id argument."
+)
+
+// searchSymbolsContentFallbackSection is the clearly separated, non-symbol
+// half of a search_symbols response. It rides its own field so every existing
+// consumer of `results` / `total` — including the localization recovery
+// contract, which reads the captured graph page rather than the wire body —
+// still sees the exact empty page an unresolved identifier produced.
+type searchSymbolsContentFallbackSection struct {
+	Reason  string              `json:"reason"`
+	Query   string              `json:"query"`
+	Note    string              `json:"note"`
+	Count   int                 `json:"count"`
+	Matches []enrichedTextMatch `json:"matches"`
+}
+
+// searchSymbolsContentFallbackTerm reports the exact identifier an empty
+// symbol lookup may re-run as a content search, and whether the query is
+// identifier-shaped at all. Prose, paths, calls, and dotted qualifiers are
+// refused: they either never occur verbatim in source or already have their
+// own decomposition path, so grepping them is pure cost.
+func searchSymbolsContentFallbackTerm(q string) (string, bool) {
+	term := strings.Trim(strings.TrimSpace(q), "`'\"")
+	if utf8.RuneCountInString(term) < searchSymbolsContentFallbackMinRunes {
+		return "", false
+	}
+	first, _ := utf8.DecodeRuneInString(term)
+	if !unicode.IsLetter(first) && first != '_' && first != '$' {
+		return "", false
+	}
+	hasLetter := false
+	for _, r := range term {
+		switch {
+		case unicode.IsLetter(r):
+			hasLetter = true
+		case unicode.IsDigit(r), r == '_', r == '$':
+		default:
+			return "", false
+		}
+	}
+	if !hasLetter {
+		return "", false
+	}
+	return term, true
+}
+
+// searchSymbolsContentFallback runs one bounded literal search for term and
+// returns the surviving hits mapped to their enclosing declarations, or nil
+// when the text backend is unavailable, refuses the scope, or finds nothing.
+// The wall-clock slice is the same bounded budget the source-literal recall
+// spends, so an empty symbol lookup can never turn into an open-ended scan.
+func (s *Server) searchSymbolsContentFallback(
+	ctx context.Context,
+	term string,
+	resolved ResolvedScope,
+	scope query.QueryOptions,
+) *searchSymbolsContentFallbackSection {
+	if s == nil || term == "" || ctx.Err() != nil {
+		return nil
+	}
+	if s.indexer == nil && s.multiIndexer == nil {
+		return nil
+	}
+
+	boundedCtx, cancel := context.WithTimeout(ctx, s.sourceLiteralRecallBudget())
+	defer cancel()
+	search := s.searchExploreSourceLiteral(
+		boundedCtx, term, "", scope, searchSymbolsContentFallbackMaxMatches,
+	)
+	if len(search.matches) == 0 {
+		return nil
+	}
+
+	// GrepLiteralBounded already rejects substring-only occurrences, but the
+	// same word-boundary test the explore path uses keeps the two recalls
+	// reporting the same notion of "exact".
+	exact := make([]trigram.Match, 0, len(search.matches))
+	for _, match := range search.matches {
+		if exploreTextHasExactLiteral(match.Text, term) {
+			exact = append(exact, match)
+		}
+	}
+	exact = s.filterTextMatchesByResolvedScope(exact, resolved)
+	if len(exact) > searchSymbolsContentFallbackMaxMatches {
+		exact = exact[:searchSymbolsContentFallbackMaxMatches]
+	}
+	if len(exact) == 0 {
+		return nil
+	}
+
+	enriched := s.enrichTextMatches(exact)
+	if len(enriched) == 0 {
+		return nil
+	}
+	return &searchSymbolsContentFallbackSection{
+		Reason:  searchSymbolsContentFallbackReason,
+		Query:   term,
+		Note:    searchSymbolsContentFallbackNote,
+		Count:   len(enriched),
+		Matches: enriched,
+	}
+}

--- a/internal/mcp/search_symbols_content_fallback_test.go
+++ b/internal/mcp/search_symbols_content_fallback_test.go
@@ -1,0 +1,193 @@
+package mcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/query"
+)
+
+type searchSymbolsFallbackResponse struct {
+	Results        []map[string]any `json:"results"`
+	Total          int              `json:"total"`
+	Decomposed     bool             `json:"decomposed"`
+	ContentMatches *struct {
+		Reason  string `json:"reason"`
+		Query   string `json:"query"`
+		Note    string `json:"note"`
+		Count   int    `json:"count"`
+		Matches []struct {
+			Path       string `json:"path"`
+			Line       int    `json:"line"`
+			Text       string `json:"text"`
+			SymbolID   string `json:"symbol_id"`
+			SymbolName string `json:"symbol_name"`
+		} `json:"matches"`
+	} `json:"content_matches"`
+}
+
+// setupContentFallbackServer indexes a repo whose only occurrences of
+// GORTEX_GENERATED_HANDLER and gortexnoseparatorhandler sit inside a function
+// body, so both identifiers exist verbatim in file content but neither becomes
+// a symbol node. The first carries separators and so reaches the caller through
+// the leaf-decomposition rescue; the second has none and returns a literally
+// empty page. The comment on line 3 is the prose control: it too occurs
+// verbatim in content, and its words name no symbol in the fixture.
+func setupContentFallbackServer(t *testing.T) *Server {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "dispatch.go"), []byte(
+		"package app\n\n"+
+			"// wiring table for generated handlers\n"+
+			"func Register() {\n"+
+			"\troute(\"GORTEX_GENERATED_HANDLER\")\n"+
+			"\troute(\"gortexnoseparatorhandler\")\n"+
+			"}\n\n"+
+			"func route(name string) {}\n"),
+		0o644))
+
+	g := graph.New()
+	reg := testRegistry()
+	cfg := config.Default()
+	idx := indexer.New(g, reg, cfg.Index, zap.NewNop())
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+	eng := query.NewEngine(g)
+	return NewServer(eng, g, idx, nil, zap.NewNop(), nil)
+}
+
+func decodeSearchSymbolsFallback(t *testing.T, res *mcplib.CallToolResult) searchSymbolsFallbackResponse {
+	t.Helper()
+	require.False(t, res.IsError)
+	var out searchSymbolsFallbackResponse
+	require.NoError(t, json.Unmarshal([]byte(res.Content[0].(mcplib.TextContent).Text), &out))
+	return out
+}
+
+func requireNoSymbolRowNamed(t *testing.T, out searchSymbolsFallbackResponse, name string) {
+	t.Helper()
+	for _, row := range out.Results {
+		require.NotEqual(t, name, row["name"], "fixture invariant: the identifier must have no symbol node")
+	}
+}
+
+// TestSearchSymbols_ContentFallbackOnDecomposedMiss pins the recovery path for
+// a separator-carrying identifier: the exact lookup matches no symbol, the
+// decomposition rescue answers with leaf-token neighbours, and the identifier
+// itself comes back as clearly-labelled content evidence.
+func TestSearchSymbols_ContentFallbackOnDecomposedMiss(t *testing.T) {
+	srv := setupContentFallbackServer(t)
+
+	out := decodeSearchSymbolsFallback(t, callTool(t, srv, "search_symbols",
+		map[string]any{"query": "GORTEX_GENERATED_HANDLER"}))
+	require.True(t, out.Decomposed, "fixture invariant: the exact identifier resolves to no symbol node")
+	requireNoSymbolRowNamed(t, out, "GORTEX_GENERATED_HANDLER")
+
+	require.NotNil(t, out.ContentMatches, "an exact identifier miss with content presence must fall back to text search")
+	require.Equal(t, "symbol_lookup_empty", out.ContentMatches.Reason)
+	require.Equal(t, "GORTEX_GENERATED_HANDLER", out.ContentMatches.Query)
+	require.NotEmpty(t, out.ContentMatches.Note, "the section must say these are content matches, not symbol nodes")
+	require.GreaterOrEqual(t, out.ContentMatches.Count, 1)
+	require.LessOrEqual(t, out.ContentMatches.Count, searchSymbolsContentFallbackMaxMatches)
+	require.Len(t, out.ContentMatches.Matches, out.ContentMatches.Count)
+
+	hit := out.ContentMatches.Matches[0]
+	require.Equal(t, "dispatch.go", hit.Path)
+	require.Equal(t, 5, hit.Line)
+	require.Contains(t, hit.Text, "GORTEX_GENERATED_HANDLER")
+	require.Equal(t, "Register", hit.SymbolName,
+		"a content match must be mapped to its smallest enclosing declaration")
+	require.NotEmpty(t, hit.SymbolID)
+}
+
+// TestSearchSymbols_ContentFallbackOnEmptyPage covers the other half of the
+// same miss: an identifier with no separator to decompose returns a literally
+// empty symbol page, and still recovers its content evidence.
+func TestSearchSymbols_ContentFallbackOnEmptyPage(t *testing.T) {
+	srv := setupContentFallbackServer(t)
+
+	out := decodeSearchSymbolsFallback(t, callTool(t, srv, "search_symbols",
+		map[string]any{"query": "gortexnoseparatorhandler"}))
+	require.Equal(t, 0, out.Total, "fixture invariant: the identifier must have no symbol node")
+	require.Empty(t, out.Results, "the fallback must not leak into the symbol result rows")
+
+	require.NotNil(t, out.ContentMatches)
+	require.Equal(t, "symbol_lookup_empty", out.ContentMatches.Reason)
+	require.Equal(t, "gortexnoseparatorhandler", out.ContentMatches.Query)
+	require.Equal(t, 1, out.ContentMatches.Count)
+
+	hit := out.ContentMatches.Matches[0]
+	require.Equal(t, "dispatch.go", hit.Path)
+	require.Equal(t, 6, hit.Line)
+	require.Equal(t, "Register", hit.SymbolName)
+}
+
+// TestSearchSymbols_NoContentFallbackWhenSymbolsFound keeps the fallback off
+// the common path: a query that resolves to graph symbols pays no trigram
+// search and the response shape is unchanged.
+func TestSearchSymbols_NoContentFallbackWhenSymbolsFound(t *testing.T) {
+	srv := setupContentFallbackServer(t)
+
+	out := decodeSearchSymbolsFallback(t, callTool(t, srv, "search_symbols",
+		map[string]any{"query": "Register"}))
+	require.Greater(t, out.Total, 0)
+	require.False(t, out.Decomposed)
+	require.Nil(t, out.ContentMatches, "non-empty symbol results must not trigger the content fallback")
+}
+
+// TestSearchSymbols_NoContentFallbackForNonIdentifierQuery keeps the fallback
+// anchored to exact-identifier lookups. The prose query below occurs verbatim
+// in the fixture's content, so only the shape gate can suppress the section.
+func TestSearchSymbols_NoContentFallbackForNonIdentifierQuery(t *testing.T) {
+	srv := setupContentFallbackServer(t)
+
+	out := decodeSearchSymbolsFallback(t, callTool(t, srv, "search_symbols",
+		map[string]any{"query": "wiring table for generated handlers"}))
+	require.Nil(t, out.ContentMatches, "a multi-word prose query is not identifier-shaped")
+}
+
+// TestSearchSymbols_NoContentFallbackUnderKindFilter keeps the fallback out of
+// a narrowed lookup: a raw content line carries no node kind, so it can never
+// satisfy the constraint the caller asked for.
+func TestSearchSymbols_NoContentFallbackUnderKindFilter(t *testing.T) {
+	srv := setupContentFallbackServer(t)
+
+	out := decodeSearchSymbolsFallback(t, callTool(t, srv, "search_symbols",
+		map[string]any{"query": "GORTEX_GENERATED_HANDLER", "kind": "function"}))
+	requireNoSymbolRowNamed(t, out, "GORTEX_GENERATED_HANDLER")
+	require.Nil(t, out.ContentMatches, "a kind-filtered lookup must not receive kindless content rows")
+}
+
+func TestSearchSymbolsContentFallbackTerm(t *testing.T) {
+	for _, tc := range []struct {
+		query string
+		term  string
+		ok    bool
+	}{
+		{"GORTEX_GENERATED_HANDLER", "GORTEX_GENERATED_HANDLER", true},
+		{"  parseToken  ", "parseToken", true},
+		{"`wrapped_ident`", "wrapped_ident", true},
+		{"handler$impl", "handler$impl", true},
+		{"", "", false},
+		{"ab", "", false},
+		{"decode bson body", "", false},
+		{"internal/mcp/tools_core.go", "", false},
+		{"Parse(ctx)", "", false},
+		{"UserService.FindUser", "", false},
+		{"____", "", false},
+		{"9lives", "", false},
+	} {
+		term, ok := searchSymbolsContentFallbackTerm(tc.query)
+		require.Equal(t, tc.ok, ok, "query %q", tc.query)
+		require.Equal(t, tc.term, term, "query %q", tc.query)
+	}
+}

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -1972,6 +1972,31 @@ func (s *Server) handleSearchSymbols(ctx context.Context, req mcp.CallToolReques
 	if nextCursor != "" {
 		resp["next_cursor"] = nextCursor
 	}
+	// Exact-identifier miss recovery. An identifier that no extractor turned
+	// into a symbol (macro-generated, string-embedded, or simply missed) still
+	// occurs verbatim in indexed content, and a page the caller learns nothing
+	// from is the only thing the symbol channel can offer. Run one bounded
+	// literal search and return the hits in a separate, explicitly non-symbol
+	// section.
+	//
+	// A decomposition rescue counts as the same miss: it runs only after every
+	// earlier tier returned nothing for the exact query, so its rows are
+	// leaf-token neighbours of the identifier rather than the identifier. Most
+	// real identifiers carry a separator or a camelCase boundary, so gating on
+	// a literally empty page alone would leave the recovery unreachable.
+	//
+	// A kind / flavor narrowing forbids it — a raw content line has no node
+	// kind to satisfy. The section rides its own field: `results`, `total`,
+	// and the graph page captured for the localization recovery contract above
+	// are all untouched, so an empty typed page still reads as empty to every
+	// contract check.
+	if (total == 0 || decomposed) && kindArg == "" && flavorArg == "" {
+		if term, identifier := searchSymbolsContentFallbackTerm(q); identifier {
+			if section := s.searchSymbolsContentFallback(ctx, term, resolved, scope); section != nil {
+				resp["content_matches"] = section
+			}
+		}
+	}
 	// A repo-narrowed zero is indistinguishable from "not indexed" in
 	// clients that never render _meta. Say it in the body — and since the
 	// result is empty anyway, pay one extra BM25 fetch to report whether

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -833,6 +833,21 @@ func stripNonDefinitionNodes(sg *query.SubGraph) *query.SubGraph {
 	}
 }
 
+// fileDefinitionNodes enumerates one file's declared symbols through the same
+// graph query and definition filter get_file_summary answers from, without the
+// tool layer's freshness, encoding, and accounting passes. The path must
+// already be in the graph's stored form.
+func fileDefinitionNodes(eng *query.Engine, filePath string) []*graph.Node {
+	if eng == nil || strings.TrimSpace(filePath) == "" {
+		return nil
+	}
+	sg := stripNonDefinitionNodes(eng.GetFileSymbols(filePath))
+	if sg == nil {
+		return nil
+	}
+	return sg.Nodes
+}
+
 // compactSubGraph formats a SubGraph as compact text.
 func compactSubGraph(sg *query.SubGraph) string {
 	var b strings.Builder

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -2652,9 +2652,16 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 	// intentionally optimized for source symbols and may discard the exact
 	// paths, keys, flags, and environment names needed by config/CI searches.
 	artifactIntent := classifyExploreArtifactIntent(task)
+	localize := req.GetBool("localize", false)
+	// The same ranked spans, derived once, applied to source candidate paths.
+	// Ordinary exploration keeps the zero value and so corroborates nothing.
+	var pathProbes explorePathProbes
+	if localize {
+		pathProbes = newExplorePathProbes(task)
+	}
 	maxSymbols := clampInt(req.GetInt("max_symbols", exploreDefaultMaxSymbols), 1, exploreMaxMaxSymbols)
 	defaultBudget := exploreDefaultBudgetTokens
-	if req.GetBool("localize", false) {
+	if localize {
 		defaultBudget = localizationDefaultBudgetTokens
 	}
 	budget := clampInt(req.GetInt("token_budget", defaultBudget), exploreMinBudgetTokens, exploreMaxBudgetTokens)
@@ -2806,6 +2813,9 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 			prod = append(prod, c)
 		}
 	}
+	// One bounded string pass over the ranked prefix, so the selection cut and
+	// the leading-file election both read a score computed once.
+	stampExplorePathProbeScores(prod, pathProbes)
 	// Natural-language localization can retrieve large exact-name collision
 	// sets (`client` fields, `Validate` methods, generated accessors). BM25 is
 	// right that each item matches, but a useful neighborhood needs distinct
@@ -2827,13 +2837,19 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 	// ranking left it.
 	var localizationRankedPool []*rerank.Candidate
 	if exploreShouldDiversifyByFile(queryClass) {
-		if req.GetBool("localize", false) {
+		if localize {
 			localizationRankedPool = append([]*rerank.Candidate(nil), prod...)
 		}
 		_, prod = diversifyByFile(prodNodes, prod, defaultMaxPerFile)
 	}
 	prod, protectedImplementationID := reserveExploreConceptImplementation(searchQuery, queryClass, prod, maxSymbols)
 	prod = reserveExploreComponentConjunction(searchQuery, queryClass, prod, maxSymbols)
+	// Path corroboration decides only what the cut was about to drop: one better
+	// corroborated row below it replaces the weakest row no lane reserved.
+	prod = liftExplorePathProbeCandidates(
+		prod, maxSymbols,
+		exploreFinalReservedCandidateIDs(prod, protectedSyntacticAnchors, protectedImplementationID),
+	)
 	cands := selectFinalExploreCandidates(prod, test, maxSymbols)
 	if len(protectedSyntacticAnchors) > 0 {
 		// Source-literal selection owns its own final-slot guarantees. Re-union
@@ -2862,7 +2878,7 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 		cands, protectedSyntacticAnchors, protectedImplementationID,
 	)
 	if len(cands) == 0 && len(artifactLane.targets) == 0 {
-		if req.GetBool("localize", false) {
+		if localize {
 			return s.completeEmptyLocalization(ctx, task, budget), nil
 		}
 		return mcp.NewToolResultText(fmt.Sprintf(
@@ -2994,7 +3010,7 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 	// structured responses can reserve a source body without a broad read.
 	targets = s.materializeExploreStructuralSource(ctx, task, targets, opts)
 
-	if !req.GetBool("localize", false) {
+	if !localize {
 		return mcp.NewToolResultText(s.renderExplore(task, targets, budget)), nil
 	}
 	symbolTargets = targets[len(artifactTargets):]

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -101,6 +101,7 @@ type exploreTarget struct {
 	sourceLiteralAligned  bool   // source-literal callee that instantiates the task's value; strongest literal owner
 	typedAnchorProjection bool   // bounded field-owner-call proof promoted from a task-aligned typed field
 	foldedOwner           bool   // synthetic owner inserted by concept member folding
+	leadingFileDepth      bool   // sibling of the ranked leading file, admitted into the expendable breadth tail
 	localizationRelation  string // direct_caller/direct_callee row promoted only into the bounded terminal projection
 }
 
@@ -2813,7 +2814,14 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 	for i, c := range prod {
 		prodNodes[i] = c.Node
 	}
+	// Retain the pre-diversification order for the localization page: the
+	// leading file's demoted siblings are only recoverable from the pool as
+	// ranking left it.
+	var localizationRankedPool []*rerank.Candidate
 	if exploreShouldDiversifyByFile(queryClass) {
+		if req.GetBool("localize", false) {
+			localizationRankedPool = append([]*rerank.Candidate(nil), prod...)
+		}
 		_, prod = diversifyByFile(prodNodes, prod, defaultMaxPerFile)
 	}
 	prod, protectedImplementationID := reserveExploreConceptImplementation(searchQuery, queryClass, prod, maxSymbols)
@@ -3015,6 +3023,17 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 			answerReady = false
 		}
 	}
+	// Once ranking has settled on one file, re-spend the page's expendable
+	// breadth tail on that file's demoted siblings. This is an evidence-page
+	// allocation only: terminality and the contract selections below continue
+	// to read the diversified set.
+	pageTargets := reserveExploreLeadingFileDepthTargets(
+		localizationRankedPool, symbolTargets, maxSymbols, protectedFinalCandidateIDs,
+		func(node *graph.Node) exploreTarget {
+			return s.hydrateExploreLeadingFileDepthTarget(ctx, eng, node, ringOpts)
+		},
+	)
+	targets = append(targets[:len(artifactTargets):len(artifactTargets)], pageTargets...)
 	// File evidence can make localization answer-ready, but it never becomes a
 	// synthetic exact-symbol read. Exact reads remain declaration-only.
 	exactSymbol := exploreLocalizationExplicitTarget(task, symbolTargets)
@@ -3713,7 +3732,10 @@ func interleaveLocalizationDirectRelationsWithRoutes(
 		if index < localizationDirectEvidenceReserve || target.node.ID == requiredID ||
 			target.causalChangeBridge || target.causalChangeLeaf || target.causalChangeOwner ||
 			target.divergentDefaultOwner || target.divergentDefaultType || target.conceptImplementation || target.conceptComplement ||
-			target.exactContent || target.sourceLiteral || target.typedAnchorProjection {
+			target.exactContent || target.sourceLiteral || target.typedAnchorProjection ||
+			// Depth rows already paid for the tail they occupy; a relationship
+			// row must not reclaim the same slot a second time.
+			target.leadingFileDepth {
 			protected[target.node.ID] = struct{}{}
 		}
 		if target.node.ID == requiredID || target.causalChangeBridge || target.causalChangeLeaf || target.causalChangeOwner ||

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -39,7 +39,11 @@ const exploreToolDescription = "Start here for any task, bug report, or " +
 // corpus, query vocabulary, or benchmark. The verb takes arbitrary free
 // text; nothing here is derived from a fixed task set.
 const (
-	exploreDefaultBudgetTokens             = 1600
+	exploreDefaultBudgetTokens = 1600
+	// localizationDefaultBudgetTokens is the localize-path default. Its
+	// envelope pays for ranked rows and the leading file's outline out of one
+	// budget, where explore(task) prose pays for rows alone.
+	localizationDefaultBudgetTokens        = 2400
 	exploreMinBudgetTokens                 = 1000
 	exploreMaxBudgetTokens                 = 24000
 	exploreDefaultMaxSymbols               = 10
@@ -2649,7 +2653,11 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 	// paths, keys, flags, and environment names needed by config/CI searches.
 	artifactIntent := classifyExploreArtifactIntent(task)
 	maxSymbols := clampInt(req.GetInt("max_symbols", exploreDefaultMaxSymbols), 1, exploreMaxMaxSymbols)
-	budget := clampInt(req.GetInt("token_budget", exploreDefaultBudgetTokens), exploreMinBudgetTokens, exploreMaxBudgetTokens)
+	defaultBudget := exploreDefaultBudgetTokens
+	if req.GetBool("localize", false) {
+		defaultBudget = localizationDefaultBudgetTokens
+	}
+	budget := clampInt(req.GetInt("token_budget", defaultBudget), exploreMinBudgetTokens, exploreMaxBudgetTokens)
 
 	resolved, errResult := s.resolveScope(ctx, req, IntentLocate)
 	if errResult != nil {
@@ -3034,6 +3042,13 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 		},
 	)
 	targets = append(targets[:len(artifactTargets):len(artifactTargets)], pageTargets...)
+	// The same leading file, indexed rather than ranked. The enumeration is
+	// deferred: only a page that stays non-terminal pays for it, and it pays
+	// once however many envelopes this request packs.
+	pageOutline := localizationLeadingFileOutlineProvider(
+		localizationRankedPool, pageTargets,
+		func(file string) []*graph.Node { return fileDefinitionNodes(eng, file) },
+	)
 	// File evidence can make localization answer-ready, but it never becomes a
 	// synthetic exact-symbol read. Exact reads remain declaration-only.
 	exactSymbol := exploreLocalizationExplicitTarget(task, symbolTargets)
@@ -3066,8 +3081,8 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 		preferredSymbol := explorePreferredRoutedRefinementSymbol(
 			preferred, symbolTargets, routes,
 		)
-		result, refinement, boundedRoutes, digest := buildLocalizationRefinementResultForTask(
-			preferredSymbol, task, targets, budget, routes,
+		result, refinement, boundedRoutes, digest := buildLocalizationRefinementResultForTaskWithOutline(
+			preferredSymbol, task, targets, budget, routes, pageOutline,
 		)
 		if refinement.State != localizationStateNeedsRefinement {
 			refinement.digest = digest
@@ -3089,7 +3104,9 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 	// and is retained for post-terminal replay — for the exact-read contract
 	// too, whose success promotes to answer_ready with the evidence already
 	// stashed.
-	result, _, digest, completion := buildLocalizationExploreResultForTaskFinalized(completion, task, targets, budget)
+	result, _, digest, completion := buildLocalizationExploreResultForTaskFinalizedWithOutline(
+		completion, task, targets, budget, pageOutline,
+	)
 	// Literal-driven terminality must show its evidence: when the verdict
 	// rests on a quoted-literal match but the budgeted envelope shed the
 	// literal, downgrade to the bounded refinement read instead of telling
@@ -3101,8 +3118,8 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 		preferredSymbol := explorePreferredRoutedRefinementSymbol(
 			explorePreferredRefinementSymbol(task, symbolTargets), symbolTargets, routes,
 		)
-		refined, refinement, boundedRoutes, refinedDigest := buildLocalizationRefinementResultForTask(
-			preferredSymbol, task, targets, budget, routes,
+		refined, refinement, boundedRoutes, refinedDigest := buildLocalizationRefinementResultForTaskWithOutline(
+			preferredSymbol, task, targets, budget, routes, pageOutline,
 		)
 		if refinement.State != localizationStateNeedsRefinement {
 			refinement.digest = refinedDigest
@@ -3130,11 +3147,12 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 // explicit localization-only request. Ordinary explore(task) retains the
 // human-oriented legacy rendering; localize does not duplicate it.
 type localizationExploreEnvelope struct {
-	Completion localizationCompletion `json:"completion"`
-	Terminal   bool                   `json:"terminal"`
-	Files      []string               `json:"files"`
-	Symbols    []string               `json:"symbols"`
-	Evidence   []localizationEvidence `json:"evidence"`
+	Completion localizationCompletion   `json:"completion"`
+	Terminal   bool                     `json:"terminal"`
+	Files      []string                 `json:"files"`
+	Symbols    []string                 `json:"symbols"`
+	Evidence   []localizationEvidence   `json:"evidence"`
+	Outline    *localizationFileOutline `json:"outline,omitempty"`
 }
 
 type localizationEvidence struct {
@@ -3990,6 +4008,20 @@ func buildLocalizationRefinementResultForTask(
 	budget int,
 	routes map[string]localizationRefinementRoute,
 ) (*mcp.CallToolResult, localizationCompletion, map[string]localizationRefinementRoute, *localizationEvidenceDigest) {
+	return buildLocalizationRefinementResultForTaskWithOutline(
+		preferredSymbol, task, targets, budget, routes, nil,
+	)
+}
+
+// The outline variant additionally offers the leading file's declaration index
+// to whichever page this build settles on; see localization_file_outline.go.
+func buildLocalizationRefinementResultForTaskWithOutline(
+	preferredSymbol, task string,
+	targets []exploreTarget,
+	budget int,
+	routes map[string]localizationRefinementRoute,
+	outline func() *localizationFileOutline,
+) (*mcp.CallToolResult, localizationCompletion, map[string]localizationRefinementRoute, *localizationEvidenceDigest) {
 	choosePreferred := func(symbols []string, requested string) (string, []string, map[string]localizationRefinementRoute) {
 		authorized, bounded := boundedLocalizationRefinementRoutes(symbols, routes, requested)
 		if requested != "" {
@@ -4012,7 +4044,9 @@ func buildLocalizationRefinementResultForTask(
 	preferredSymbol, preauthorized, prebounded := choosePreferred(candidateSymbols, preferredSymbol)
 	if preferredSymbol == "" {
 		advisory := newLocalizationCompletion(true, "")
-		result, _, digest, packedCompletion := buildLocalizationExploreResultForTaskFinalized(advisory, task, targets, budget)
+		result, _, digest, packedCompletion := buildLocalizationExploreResultForTaskFinalizedWithOutline(
+			advisory, task, targets, budget, outline,
+		)
 		return result, packedCompletion, nil, digest
 	}
 
@@ -4022,8 +4056,8 @@ func buildLocalizationRefinementResultForTask(
 	budgetCompletion := newLocalizationRefinementCompletionForSymbols(preferredSymbol, preauthorized)
 	budgetCompletion.refinementRoutes = prebounded
 	var finalRoutes map[string]localizationRefinementRoute
-	result, _, digest, packedCompletion := buildLocalizationExploreResultForTaskFinalized(
-		budgetCompletion, task, targets, budget,
+	result, _, digest, packedCompletion := buildLocalizationExploreResultForTaskFinalizedWithOutline(
+		budgetCompletion, task, targets, budget, outline,
 		func(packed localizationExploreEnvelope) localizationCompletion {
 			packedPreferred, allowedSymbols, bounded := choosePreferred(packed.Symbols, preferredSymbol)
 			if packedPreferred == "" {
@@ -4046,6 +4080,19 @@ func buildLocalizationExploreResultForTaskFinalized(
 	task string,
 	targets []exploreTarget,
 	budget int,
+	finalize ...localizationCompletionFinalizer,
+) (*mcp.CallToolResult, []string, *localizationEvidenceDigest, localizationCompletion) {
+	return buildLocalizationExploreResultForTaskFinalizedWithOutline(
+		completion, task, targets, budget, nil, finalize...,
+	)
+}
+
+func buildLocalizationExploreResultForTaskFinalizedWithOutline(
+	completion localizationCompletion,
+	task string,
+	targets []exploreTarget,
+	budget int,
+	outline func() *localizationFileOutline,
 	finalize ...localizationCompletionFinalizer,
 ) (*mcp.CallToolResult, []string, *localizationEvidenceDigest, localizationCompletion) {
 	var draft []exploreDraftEntry
@@ -4307,6 +4354,14 @@ func buildLocalizationExploreResultForTaskFinalized(
 	contract = localizationContractReconciledWithDigest(envelope.Completion, digest)
 	envelope.Completion = contract.Completion
 	envelope.Terminal = contract.Terminal
+	// A page that still asks the caller to choose gets the leading file's
+	// declaration index. The rows above name at most one symbol per file, so a
+	// caller looking at the right file and the wrong row has nothing to correct
+	// with; the outline is that file's remaining declarations, and it is the
+	// first thing given back when the budget cannot hold everything.
+	if outline != nil && localizationPageAcceptsOutline(envelope.Completion.State) {
+		envelope.Outline = outline()
+	}
 	// The ready-to-emit answer is derived from the retained rows, so it lands
 	// after the fit checks above and can push the envelope past its budget.
 	// Give back the weakest presented row first — the caller is asked to
@@ -4319,6 +4374,13 @@ func buildLocalizationExploreResultForTaskFinalized(
 		shedBudget = maxBytes + localizationRetiredReadAllowance(maxBytes)
 	}
 	for !localizationEnvelopeFits(envelope, shedBudget) {
+		if envelope.Outline != nil {
+			// The outline is a convenience over rows the caller can still reach
+			// by other means; every other payload here is evidence this
+			// response is answering with.
+			envelope.Outline = nil
+			continue
+		}
 		if digest != nil && len(digest.Evidence) > localizationFinalResponsePrimaryLimit {
 			digest.Evidence = digest.Evidence[:len(digest.Evidence)-1]
 			rebuildLocalizationDigestSkeleton(digest)

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -1215,7 +1215,7 @@ func exploreSingleQualifiedImplementation(task string, targets []exploreTarget) 
 	// bounded result must contain exactly one hydrated production callable;
 	// supporting graph relations may still be rendered later, but a selected
 	// alternate can never be described as absent merely because it ranked lower.
-	if len(targets) != 1 || len(exploreQuotedRecallTerms(task)) > 0 ||
+	if len(targets) != 1 || len(exploreQuotedRecallClaimTerms(task)) > 0 ||
 		!exploreHydratedProductionCallable(targets[0]) {
 		return false
 	}
@@ -1340,7 +1340,7 @@ func exploreAnswerReady(task string, targets []exploreTarget) bool {
 	// no verified exact literal evidence, ordinary concept alignment must not
 	// turn that claim into a terminal answer. Explicit path/symbol/signature
 	// anchors and the unique/ambiguous exact paths above retain their behavior.
-	if len(exploreQuotedRecallTerms(task)) > 0 {
+	if len(exploreQuotedRecallClaimTerms(task)) > 0 {
 		return false
 	}
 
@@ -1349,7 +1349,7 @@ func exploreAnswerReady(task string, targets []exploreTarget) bool {
 	// declarations remain useful evidence, but cannot terminate navigation.
 	var implementation *exploreTarget
 	if class == rerank.QueryClassConcept {
-		hasSyntacticAnchors := len(exploreSyntacticAnchors(task)) > 0
+		hasSyntacticAnchors := exploreAuthoredSyntacticAnchorCount(exploreSyntacticAnchors(task)) > 0
 		for i := range targets {
 			target := &targets[i]
 			callable := target.node != nil &&
@@ -5121,18 +5121,48 @@ const (
 	exploreSourceLiteralTaskAlignSignal = "explore_source_literal_task_alignment"
 	exploreSourceLiteralReservationMax  = 2
 	exploreQuotedRecallMaxTerms         = 3
-	exploreQuotedRecallMaxPerTerm       = 12
-	exploreQuotedRecallRetryMaxRows     = 24
+	// Literals mined from code blocks may only take the slots prose left
+	// unclaimed, up to this total, so a task with no code block searches
+	// exactly as many terms as before.
+	exploreQuotedRecallMaxMinedTerms = 5
+	exploreQuotedRecallMaxPerTerm    = 12
+	exploreQuotedRecallRetryMaxRows  = 24
 )
 
 // exploreQuotedRecallTerms extracts only explicit, high-signal literal anchors
-// from prose. The ordinary symbol corpus intentionally excludes function bodies;
-// these literals are the bounded bridge to the existing source-content FTS for
-// errors, configuration values, protocol names, and other evidence that exists
-// only inside an implementation. Regex/pattern literals remain in the shaped
-// symbol query but are not sent to content recall because their punctuation
-// decomposes into noisy one-character terms.
+// from prose, then the literals mined from the task's code blocks. The ordinary
+// symbol corpus intentionally excludes function bodies; these literals are the
+// bounded bridge to the existing source-content FTS for errors, configuration
+// values, protocol names, and other evidence that exists only inside an
+// implementation. Regex/pattern literals remain in the shaped symbol query but
+// are not sent to content recall because their punctuation decomposes into
+// noisy one-character terms.
 func exploreQuotedRecallTerms(task string) []string {
+	seen := make(map[string]struct{}, exploreQuotedRecallMaxMinedTerms)
+	out := make([]string, 0, exploreQuotedRecallMaxMinedTerms)
+	out = admitExploreQuotedRecallTerms(task, exploreProseQuotedLiterals(task), out, seen, exploreQuotedRecallMaxTerms)
+	return admitExploreQuotedRecallTerms(
+		task, exploreFencedRecallLiterals(task), out, seen, exploreQuotedRecallMaxMinedTerms,
+	)
+}
+
+// exploreQuotedRecallClaimTerms returns only the literals the requester wrote
+// as prose. Terminality gates key on the requester's factual claim about the
+// source, never on a literal mined out of a pasted code block: mining is our
+// own inference, and an inference that retrieves nothing must not cost the
+// session a turn. Retrieval keeps using the full list.
+func exploreQuotedRecallClaimTerms(task string) []string {
+	return admitExploreQuotedRecallTerms(
+		task, exploreProseQuotedLiterals(task),
+		make([]string, 0, exploreQuotedRecallMaxTerms),
+		make(map[string]struct{}, exploreQuotedRecallMaxTerms),
+		exploreQuotedRecallMaxTerms,
+	)
+}
+
+// exploreProseQuotedLiterals returns every quoted span of the raw task, in
+// document order.
+func exploreProseQuotedLiterals(task string) []string {
 	literals := make([]string, 0, exploreQuotedRecallMaxTerms)
 	for _, match := range reInlineQuoted.FindAllString(task, -1) {
 		if len(match) >= 2 {
@@ -5155,12 +5185,30 @@ func exploreQuotedRecallTerms(task string) []string {
 		literals = append(literals, rest[:end])
 		rest = rest[end+1:]
 	}
+	return literals
+}
 
-	seen := make(map[string]struct{}, len(literals))
-	out := make([]string, 0, min(len(literals), exploreQuotedRecallMaxTerms))
+// admitExploreQuotedRecallTerms applies the shared acceptance policy — length,
+// noise, short-anchor intent, and case-folded deduplication — to one lane of
+// literal candidates and stops at the lane's cumulative limit.
+func admitExploreQuotedRecallTerms(
+	task string,
+	literals, out []string,
+	seen map[string]struct{},
+	limit int,
+) []string {
 	for _, literal := range literals {
+		if len(out) >= limit {
+			break
+		}
 		literal = strings.TrimSpace(literal)
 		if len(literal) < 2 || len(literal) > 128 || quotedLiteralIsNoise(literal) {
+			continue
+		}
+		// A span the opening delimiter never closed on its line is not a source
+		// literal: content FTS cannot match text that crosses a line break, and
+		// admitting it would spend a term slot the mined lines can use.
+		if strings.ContainsAny(literal, "\r\n") {
 			continue
 		}
 		if exploreTwoLetterQuotedAnchor(literal) && !exploreAllowsTwoLetterQuotedAnchor(task) {
@@ -5172,9 +5220,6 @@ func exploreQuotedRecallTerms(task string) []string {
 		}
 		seen[key] = struct{}{}
 		out = append(out, literal)
-		if len(out) >= exploreQuotedRecallMaxTerms {
-			break
-		}
 	}
 	return out
 }

--- a/internal/parser/detect_content.go
+++ b/internal/parser/detect_content.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"bytes"
 	"path"
+	"path/filepath"
 	"strings"
 )
 
@@ -103,6 +104,28 @@ func trimInterpVersion(interp string) string {
 	return interp[:end]
 }
 
+// ambiguousExtensions is the set of extensions whose default language
+// mapping is a guess that sniffAmbiguous may overturn from content. It
+// gates sniffAmbiguous, so no extension can be refined without being
+// listed here, and ExtensionNeedsContentProbe reports the same set to
+// callers that detected a language before reading the file.
+var ambiguousExtensions = map[string]bool{
+	".json": true,
+	".h":    true,
+	".inc":  true,
+	".m":    true,
+	".xml":  true,
+}
+
+// ExtensionNeedsContentProbe reports whether a file's extension maps to
+// more than one plausible language. A language detected for such a file
+// without its bytes in hand is provisional — the extension's default,
+// never a content-backed answer — so a caller that later reads the file
+// must re-detect with the content before choosing an extractor.
+func ExtensionNeedsContentProbe(filePath string) bool {
+	return ambiguousExtensions[strings.ToLower(filepath.Ext(filePath))]
+}
+
 // sniffAmbiguous refines the language of a file whose extension maps
 // to more than one plausible language. ext is the file extension
 // (with leading dot). It returns (lang, true) when the content
@@ -110,7 +133,7 @@ func trimInterpVersion(interp string) string {
 // extension is not ambiguous or the probe is inconclusive — the
 // caller then keeps the extension's default mapping.
 func sniffAmbiguous(filePath, ext string, content []byte) (string, bool) {
-	if len(content) == 0 {
+	if len(content) == 0 || !ambiguousExtensions[strings.ToLower(ext)] {
 		return "", false
 	}
 	probe := content

--- a/internal/parser/detect_content_test.go
+++ b/internal/parser/detect_content_test.go
@@ -117,6 +117,29 @@ func TestDetectLanguageContent_AmbiguousHeader(t *testing.T) {
 	assert.Equal(t, "objc", lang)
 }
 
+// TestExtensionNeedsContentProbe pins the set a name-only detection cannot
+// decide. An indexer that resolves a language before reading the file relies
+// on this to know its answer is provisional: for a contested extension the
+// name yields the default mapping, not a content-backed language.
+func TestExtensionNeedsContentProbe(t *testing.T) {
+	for _, p := range []string{"inc/list.h", "src/View.H", "vendor/table.inc", "a/b.m", "conf/beans.xml", "templates/product.json"} {
+		assert.Truef(t, ExtensionNeedsContentProbe(p), "%s is decided by content", p)
+	}
+	for _, p := range []string{"main.go", "app.cpp", "lib.c", "index.ts", "Makefile"} {
+		assert.Falsef(t, ExtensionNeedsContentProbe(p), "%s is decided by its extension", p)
+	}
+}
+
+// TestDetectLanguageContent_UncontestedExtensionIgnoresProbe guards the gate
+// sniffAmbiguous now applies: only a listed extension may be re-typed from
+// content, so a `.c` file full of C++ markers still goes to the C extractor.
+func TestDetectLanguageContent_UncontestedExtensionIgnoresProbe(t *testing.T) {
+	r := ambiguityRegistry()
+	lang, ok := r.DetectLanguageContent("src/main.c", []byte("namespace ui {\nclass Widget {};\n}\n"))
+	assert.True(t, ok)
+	assert.Equal(t, "c", lang)
+}
+
 func TestDetectLanguageContent_CFragments(t *testing.T) {
 	r := NewRegistry()
 	r.Register(&mockExtractor{lang: "c", exts: []string{".c", ".h", ".def"}})

--- a/internal/parser/languages/cpp.go
+++ b/internal/parser/languages/cpp.go
@@ -56,6 +56,9 @@ const qCppAll = `
       (function_declarator
         declarator: (identifier) @func.name))) @func.def
 
+  (template_declaration
+    (function_definition) @tmplfn.inner) @tmplfn.def
+
   (preproc_include
     path: (_) @include.path) @include.def
 
@@ -143,6 +146,9 @@ func (e *CppExtractor) Extract(filePath string, src []byte) (*parser.ExtractionR
 
 			case m.Captures["enum.def"] != nil:
 				e.emitEnum(m, filePath, fileID, result, seen)
+
+			case m.Captures["tmplfn.def"] != nil:
+				e.emitTemplateFunction(m, filePath, fileID, src, result, seen)
 
 			case m.Captures["func.def"] != nil:
 				e.emitFunction(m, filePath, fileID, src, result, seen)
@@ -455,11 +461,38 @@ func (e *CppExtractor) emitEnum(m parser.QueryResult, filePath, fileID string, r
 // class method with a bare identifier declarator that was emitted
 // through addMethodFromNode — skip the duplicate.
 func (e *CppExtractor) emitFunction(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen map[string]bool) {
-	name := m.Captures["func.name"].Text
 	def := m.Captures["func.def"]
 	startLine := def.StartLine + 1
 	lineKey := filePath + "::_method_L" + fmt.Sprint(startLine)
 	if seen[lineKey] {
+		return
+	}
+	if cppTemplateOwnsDefinition(def.Node) {
+		return
+	}
+	e.emitFreeFunction(m.Captures["func.name"].Text, def.Node, startLine, def.EndLine+1,
+		filePath, fileID, src, result, seen)
+}
+
+// emitTemplateFunction emits a free template function definition —
+// `template <typename Char> void vprintf(buffer<Char>&, …) {…}` at file or
+// namespace scope. Two things need the template_declaration rather than the
+// function_definition it wraps: the symbol's span has to cover the
+// `template <…>` header, and an explicit specialization declares itself with a
+// `render<char>` declarator, a form the plain function_definition patterns
+// never reach. A template member declared inside a class or struct body is not
+// a free function and keeps its existing emission path.
+func (e *CppExtractor) emitTemplateFunction(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen map[string]bool) {
+	def, inner := m.Captures["tmplfn.def"], m.Captures["tmplfn.inner"]
+	if def == nil || inner == nil || inner.Node == nil || cppInsideTypeBody(inner.Node) {
+		return
+	}
+	e.emitFreeFunction(cppFreeTemplateFuncName(inner.Node, src), inner.Node,
+		def.StartLine+1, def.EndLine+1, filePath, fileID, src, result, seen)
+}
+
+func (e *CppExtractor) emitFreeFunction(name string, fnNode *sitter.Node, startLine, endLine int, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen map[string]bool) {
+	if name == "" {
 		return
 	}
 	id := filePath + "::" + name
@@ -471,24 +504,80 @@ func (e *CppExtractor) emitFunction(m parser.QueryResult, filePath, fileID strin
 	}
 	seen[id] = true
 	meta := map[string]any{}
-	if ns := enclosingCppNamespace(def.Node, src); ns != "" {
+	if ns := enclosingCppNamespace(fnNode, src); ns != "" {
 		meta["scope_ns"] = ns
 	}
 	// Free-function return type (smart-pointer-unwrapped) seeds chained-factory
 	// receiver inference for a bare factory call (`make_widget()->draw()`), the
 	// same way addMethodFromNode seeds `Foo::make().x()`.
-	if rt := cppReturnType(def.Node, src); rt != "" {
+	if rt := cppReturnType(fnNode, src); rt != "" {
 		meta["return_type"] = rt
 	}
-	stampCppSignature(meta, def.Node, src)
+	stampCppSignature(meta, fnNode, src)
 	result.Nodes = append(result.Nodes, &graph.Node{
 		ID: id, Kind: graph.KindFunction, Name: name,
-		FilePath: filePath, StartLine: startLine, EndLine: def.EndLine + 1,
+		FilePath: filePath, StartLine: startLine, EndLine: endLine,
 		Language: "cpp", Meta: meta,
 	})
 	result.Edges = append(result.Edges, &graph.Edge{
 		From: fileID, To: id, Kind: graph.EdgeDefines, FilePath: filePath, Line: startLine,
 	})
+}
+
+// cppTemplateOwnsDefinition reports whether a function_definition is emitted by
+// the template dispatch instead of the free-function one — true only for a free
+// template function, so members inside a class or struct body still come
+// through emitFunction.
+func cppTemplateOwnsDefinition(fn *sitter.Node) bool {
+	if fn == nil {
+		return false
+	}
+	p := fn.Parent()
+	return p != nil && p.Type() == "template_declaration" && !cppInsideTypeBody(fn)
+}
+
+// cppInsideTypeBody reports whether a node sits in a class / struct body, where
+// a definition is a member rather than a free function. The walk stops at the
+// first enclosing body-shaped ancestor so a member of a class nested in a
+// namespace is not mistaken for a namespace-scope definition.
+func cppInsideTypeBody(n *sitter.Node) bool {
+	if n == nil {
+		return false
+	}
+	for p := n.Parent(); p != nil; p = p.Parent() {
+		switch p.Type() {
+		case "field_declaration_list":
+			return true
+		case "translation_unit", "namespace_definition", "declaration_list":
+			return false
+		}
+	}
+	return false
+}
+
+// cppFreeTemplateFuncName resolves the declarator name of a template function
+// definition. Beyond the declarator forms extractFuncName walks, an explicit
+// specialization names itself with a template_function declarator
+// (`render<char>`). A qualified declarator (`Holder<T>::put`) is an out-of-line
+// member, not a free function, so it yields no name here.
+func cppFreeTemplateFuncName(fn *sitter.Node, src []byte) string {
+	fd := cppFunctionDeclarator(fn.ChildByFieldName("declarator"))
+	if fd == nil {
+		return ""
+	}
+	for i, _nc := 0, int(fd.NamedChildCount()); i < _nc; i++ {
+		c := fd.NamedChild(i)
+		switch c.Type() {
+		case "identifier", "operator_name":
+			return c.Content(src)
+		case "template_function":
+			if n := c.ChildByFieldName("name"); n != nil {
+				return n.Content(src)
+			}
+			return ""
+		}
+	}
+	return ""
 }
 
 func (e *CppExtractor) emitInclude(m parser.QueryResult, filePath, fileID string, result *parser.ExtractionResult) {

--- a/internal/parser/languages/cpp_test.go
+++ b/internal/parser/languages/cpp_test.go
@@ -307,3 +307,50 @@ func TestCppExtractor_TemplateClassMemberUnchanged(t *testing.T) {
 	assert.Equal(t, 4, puts[0].StartLine, "still spans from the member's own definition")
 	assert.Equal(t, 6, puts[0].EndLine)
 }
+
+// A header-only library opens and closes its namespace through macros the
+// preprocessor would expand (`FMT_BEGIN_NAMESPACE`), which tree-sitter cannot
+// resolve — it reads the marker as a declaration and recovers around it. The
+// free template function further down must still be extracted, carrying the
+// inner `namespace detail` it sits in as its scope. This is the shape a real
+// header-only formatting library ships, include guard and all.
+func TestCppExtractor_TemplateFunctionUnderMacroNamespaceMarkers(t *testing.T) {
+	src := []byte(`#ifndef LIB_PRINTF_H_
+#define LIB_PRINTF_H_
+
+#include "format.h"
+
+FMT_BEGIN_NAMESPACE
+FMT_BEGIN_EXPORT
+
+template <typename Char> class basic_printf_context {
+ public:
+  auto out() -> basic_appender<Char> { return out_; }
+
+ private:
+  basic_appender<Char> out_;
+};
+
+namespace detail {
+
+template <typename Char, typename Context>
+void vprintf(buffer<Char>& buf, basic_string_view<Char> format,
+             basic_format_args<Context> args) {
+  write(buf, format);
+}
+
+}  // namespace detail
+
+FMT_END_EXPORT
+FMT_END_NAMESPACE
+
+#endif  // LIB_PRINTF_H_
+`)
+	result, err := NewCppExtractor().Extract("printf.hpp", src)
+	require.NoError(t, err)
+
+	fn := nodeNamed(t, result.Nodes, graph.KindFunction, "vprintf")
+	assert.Equal(t, 19, fn.StartLine, "span covers the template header")
+	assert.Equal(t, 23, fn.EndLine)
+	assert.Equal(t, "detail", fn.Meta["scope_ns"])
+}

--- a/internal/parser/languages/cpp_test.go
+++ b/internal/parser/languages/cpp_test.go
@@ -204,3 +204,106 @@ func TestCppExtractor_FactoryChainReceiver(t *testing.T) {
 		t.Errorf("receiver_expr = %q, want builder().withX()", got)
 	}
 }
+
+// A free template function definition lives under a template_declaration,
+// so its symbol must cover the `template <…>` header and must survive
+// declarator forms the plain function_definition patterns never reach
+// (an explicit specialization's `name<Args>` declarator). Template
+// members declared inside a class body are not free functions and stay
+// on the class-body path.
+func TestCppExtractor_FreeTemplateFunction(t *testing.T) {
+	cases := []struct {
+		name      string
+		src       string
+		fn        string
+		startLine int
+		endLine   int
+		scopeNS   string
+	}{
+		{
+			name:      "file scope",
+			src:       "template <typename Char>\nvoid vprintf(buffer<Char>& buf, basic_string_view<Char> format) {\n  use(buf);\n}\n",
+			fn:        "vprintf",
+			startLine: 1,
+			endLine:   4,
+		},
+		{
+			name:      "inside namespace",
+			src:       "namespace detail {\ntemplate <typename Char>\nvoid vprintf(buffer<Char>& buf) {\n  use(buf);\n}\n}\n",
+			fn:        "vprintf",
+			startLine: 2,
+			endLine:   5,
+			scopeNS:   "detail",
+		},
+		{
+			name:      "multiple template params",
+			src:       "template <typename T, typename U, int N>\nauto combine(T t, U u) -> U {\n  return u;\n}\n",
+			fn:        "combine",
+			startLine: 1,
+			endLine:   4,
+		},
+		{
+			name:      "explicit specialization",
+			src:       "template <>\nvoid render<char>(char v) {\n  use(v);\n}\n",
+			fn:        "render",
+			startLine: 1,
+			endLine:   4,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := NewCppExtractor().Extract("tpl.hpp", []byte(tc.src))
+			require.NoError(t, err)
+
+			fn := nodeNamed(t, result.Nodes, graph.KindFunction, tc.fn)
+			assert.Equal(t, tc.startLine, fn.StartLine, "span covers the template header")
+			assert.Equal(t, tc.endLine, fn.EndLine)
+			assert.Equal(t, "tpl.hpp::"+tc.fn, fn.ID)
+			if tc.scopeNS != "" {
+				assert.Equal(t, tc.scopeNS, fn.Meta["scope_ns"])
+			}
+
+			var defined bool
+			for _, ed := range edgesOfKind(result.Edges, graph.EdgeDefines) {
+				if ed.From == "tpl.hpp" && ed.To == fn.ID {
+					defined = true
+				}
+			}
+			assert.True(t, defined, "file must define %s", fn.ID)
+		})
+	}
+}
+
+// A primary template and its explicit specialization are two definitions
+// of the same name; both keep a node.
+func TestCppExtractor_TemplateSpecializationDoesNotOverwritePrimary(t *testing.T) {
+	src := []byte("template <typename T>\nvoid render(T v) {\n  use(v);\n}\n\ntemplate <>\nvoid render<char>(char v) {\n  use(v);\n}\n")
+	result, err := NewCppExtractor().Extract("tpl.hpp", []byte(src))
+	require.NoError(t, err)
+
+	starts := map[int]bool{}
+	for _, n := range nodesOfKind(result.Nodes, graph.KindFunction) {
+		if n.Name == "render" {
+			starts[n.StartLine] = true
+		}
+	}
+	assert.Equal(t, map[int]bool{1: true, 6: true}, starts)
+}
+
+// Negative case: a template member declared inside a class body is not a
+// free function — its emission is untouched by the template dispatch.
+func TestCppExtractor_TemplateClassMemberUnchanged(t *testing.T) {
+	src := []byte("class Holder {\n public:\n  template <typename T>\n  void put(T v) {\n    store(v);\n  }\n};\n")
+	result, err := NewCppExtractor().Extract("holder.hpp", src)
+	require.NoError(t, err)
+
+	var puts []*graph.Node
+	for _, n := range result.Nodes {
+		if n.Name == "put" {
+			puts = append(puts, n)
+		}
+	}
+	require.Len(t, puts, 1, "no duplicate node for an in-class template member")
+	assert.Equal(t, 4, puts[0].StartLine, "still spans from the member's own definition")
+	assert.Equal(t, 6, puts[0].EndLine)
+}

--- a/internal/parser/languages/dart.go
+++ b/internal/parser/languages/dart.go
@@ -671,15 +671,27 @@ func (e *DartExtractor) extractCalls(
 		}
 
 		target := "unresolved::*." + callName
+		aliased := false
 		if leadingReceiver != "" {
 			if uri, ok := imports[leadingReceiver]; ok {
 				target = "unresolved::extern::" + uri + "::" + callName
+				aliased = true
 			}
 		}
-		result.Edges = append(result.Edges, &graph.Edge{
+		edge := &graph.Edge{
 			From: callerID, To: target,
 			Kind: graph.EdgeCalls, FilePath: filePath, Line: line,
-		})
+		}
+		// `TiledAtlas.fromTiledMap(1)` — a Capitalized chain head names the type
+		// the callee lives on, so the resolver binds the call to that type's
+		// member instead of any same-named symbol. Only a two-segment chain
+		// qualifies: in `Foo.bar.baz()` the head types `bar`, not `baz`. An
+		// import alias is excluded — it is a library prefix, not a type, and its
+		// attribution already rides the extern target.
+		if !aliased && len(methodChain) == 2 && isDartTypeNameCapitalized(leadingReceiver) {
+			edge.Meta = map[string]any{"receiver_type": leadingReceiver}
+		}
+		result.Edges = append(result.Edges, edge)
 	})
 }
 

--- a/internal/parser/languages/dart.go
+++ b/internal/parser/languages/dart.go
@@ -238,6 +238,9 @@ func (e *DartExtractor) emitDartMixinEdges(classNode *sitter.Node, src []byte, c
 }
 
 // extractMethods finds method_signature nodes inside class_body, extension_body, enum_body.
+// A constructor with no body (named, const, redirecting factory) is not wrapped
+// in method_signature at all — the grammar hangs its signature off a plain
+// `declaration`, so both wrappers are visited in the one walk.
 func (e *DartExtractor) extractMethods(
 	root *sitter.Node, src []byte, filePath string, fileNode *graph.Node,
 	result *parser.ExtractionResult, seen map[string]bool,
@@ -246,7 +249,8 @@ func (e *DartExtractor) extractMethods(
 	typeBodyRanges := e.collectTypeBodyRanges(root, src)
 
 	walkNodes(root, func(node *sitter.Node) {
-		if node.Type() != "method_signature" {
+		nodeType := node.Type()
+		if nodeType != "method_signature" && nodeType != "declaration" {
 			return
 		}
 
@@ -260,7 +264,14 @@ func (e *DartExtractor) extractMethods(
 			return
 		}
 
-		name := e.extractMethodName(node, src)
+		var name string
+		if nodeType == "method_signature" {
+			name = e.extractMethodName(node, src)
+		} else {
+			// Fields and static finals also ride `declaration`; only a
+			// constructor signature child yields a name.
+			name = dartDeclarationCtorName(node, src)
+		}
 		if name == "" {
 			return
 		}
@@ -731,13 +742,9 @@ func (e *DartExtractor) extractMethodName(node *sitter.Node, src []byte) string 
 			if nameNode != nil {
 				return "set " + nameNode.Content(src)
 			}
-		case "constructor_signature":
-			nameNode := child.ChildByFieldName("name")
-			if nameNode != nil {
-				return nameNode.Content(src)
-			}
-		case "factory_constructor_signature":
-			return e.findChildIdentifier(child, src)
+		case "constructor_signature", "constant_constructor_signature",
+			"factory_constructor_signature", "redirecting_factory_constructor_signature":
+			return dartCtorName(child, src)
 		case "operator_signature":
 			// operator + binary_operator child
 			for j, _nc := 0, int(child.ChildCount()); j < _nc; j++ {
@@ -749,6 +756,51 @@ func (e *DartExtractor) extractMethodName(node *sitter.Node, src []byte) string 
 		}
 	}
 	return ""
+}
+
+// dartDeclarationCtorName returns the constructor name carried by a class-body
+// `declaration` wrapper — the shape the grammar gives a body-less constructor
+// (named, const, redirecting factory). Returns "" for every other declaration
+// (fields, static finals).
+func dartDeclarationCtorName(decl *sitter.Node, src []byte) string {
+	for i, _nc := 0, int(decl.ChildCount()); i < _nc; i++ {
+		child := decl.Child(i)
+		switch child.Type() {
+		case "constructor_signature", "constant_constructor_signature",
+			"factory_constructor_signature", "redirecting_factory_constructor_signature":
+			return dartCtorName(child, src)
+		}
+	}
+	return ""
+}
+
+// dartCtorName returns a constructor signature's declared name. Dart spells a
+// named constructor `Type.name(...)`, and the grammar's `name` field points at
+// the leading TYPE identifier, so the constructor's own name is the identifier
+// that follows the dot. An unnamed constructor has no dot — the type identifier
+// is returned so the caller's unnamed-constructor guard recognises and drops it.
+func dartCtorName(sig *sitter.Node, src []byte) string {
+	typeName := ""
+	afterDot := false
+	for i, _nc := 0, int(sig.ChildCount()); i < _nc; i++ {
+		child := sig.Child(i)
+		switch child.Type() {
+		case ".":
+			afterDot = true
+		case "identifier":
+			if afterDot {
+				return child.Content(src)
+			}
+			if typeName == "" {
+				typeName = child.Content(src)
+			}
+		case "formal_parameter_list":
+			// The parameter list closes the name; a dot inside it
+			// (`Foo(this.n)`) is not a name separator.
+			return typeName
+		}
+	}
+	return typeName
 }
 
 type dartTypeRange struct {

--- a/internal/parser/languages/dart_test.go
+++ b/internal/parser/languages/dart_test.go
@@ -547,6 +547,44 @@ class Cache {
 	assert.Nil(t, byID["status.dart::Cache.Cache"])
 }
 
+// A Capitalized call-chain head names a type, so the call edge carries it as
+// receiver_type. Lowercase heads, bare calls, deeper chains, and import-alias
+// heads stay unstamped.
+func TestDartExtractor_CapitalizedChainReceiverType(t *testing.T) {
+	src := []byte(`import 'package:http/http.dart' as http;
+
+class TiledAtlas {
+  factory TiledAtlas.fromTiledMap(int m) => TiledAtlas.fromKey('x');
+  TiledAtlas.fromKey(String k);
+}
+
+void main() {
+  TiledAtlas.fromTiledMap(1);
+  http.get('u');
+  helper.run();
+  bare();
+  Config.opts.apply();
+}
+`)
+	res, err := NewDartExtractor().Extract("main.dart", src)
+	require.NoError(t, err)
+
+	recvType := map[string]any{}
+	for _, ed := range res.Edges {
+		if ed.Kind == graph.EdgeCalls && ed.From == "main.dart::main" {
+			recvType[ed.To] = ed.Meta["receiver_type"]
+		}
+	}
+
+	assert.Equal(t, "TiledAtlas", recvType["unresolved::*.fromTiledMap"],
+		"a Capitalized chain head must be stamped as the receiver type")
+	assert.Nil(t, recvType["unresolved::*.run"], "a lowercase head is a local, not a type")
+	assert.Nil(t, recvType["unresolved::*.bare"], "a bare call has no receiver")
+	assert.Nil(t, recvType["unresolved::*.apply"], "only a two-segment chain types the callee")
+	assert.Nil(t, recvType["unresolved::extern::package:http/http.dart::get"],
+		"an import alias is a library prefix, not a type")
+}
+
 func TestDartExtractor_FactoryChainReceiver(t *testing.T) {
 	src := []byte("Widget builder() { return Widget(); }\n" +
 		"void run() {\n" +

--- a/internal/parser/languages/dart_test.go
+++ b/internal/parser/languages/dart_test.go
@@ -429,6 +429,124 @@ class App {
 	assert.True(t, sawBuild, "the real method build should still be emitted")
 }
 
+// Every dotted Dart constructor — named, factory, const-named, and redirecting
+// factory — is a first-class member symbol: a KindMethod whose Name is the bare
+// constructor name (not the class name), owned by the enclosing type through an
+// EdgeMemberOf, and spanning at least its signature.
+func TestDartExtractor_ConstructorVariants(t *testing.T) {
+	src := []byte(`class TiledAtlas {
+  final int n;
+
+  TiledAtlas(this.n);
+
+  /// Builds from a cache key.
+  TiledAtlas.fromKey(String key) : n = 1;
+
+  const TiledAtlas.empty() : n = 0;
+
+  TiledAtlas.withBody(int x) : n = x {
+    print(x);
+  }
+
+  factory TiledAtlas.fromTiledMap(int m) {
+    return TiledAtlas.fromKey('x');
+  }
+
+  factory TiledAtlas.redirect() = TiledAtlas.empty;
+}
+`)
+	res, err := NewDartExtractor().Extract("atlas.dart", src)
+	require.NoError(t, err)
+
+	byID := map[string]*graph.Node{}
+	for _, n := range res.Nodes {
+		byID[n.ID] = n
+	}
+
+	cases := []struct {
+		id        string
+		name      string
+		startLine int
+		endLine   int
+	}{
+		{"atlas.dart::TiledAtlas.fromKey", "fromKey", 7, 7},
+		{"atlas.dart::TiledAtlas.empty", "empty", 9, 9},
+		{"atlas.dart::TiledAtlas.withBody", "withBody", 11, 13},
+		{"atlas.dart::TiledAtlas.fromTiledMap", "fromTiledMap", 15, 17},
+		{"atlas.dart::TiledAtlas.redirect", "redirect", 19, 19},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			n := byID[tc.id]
+			require.NotNil(t, n, "constructor %s not emitted; nodes=%v", tc.id, byID)
+			assert.Equal(t, graph.KindMethod, n.Kind)
+			assert.Equal(t, tc.name, n.Name, "constructor name must be the bare name, not the class name")
+			assert.Equal(t, "TiledAtlas", n.Meta["receiver"])
+			assert.Equal(t, tc.startLine, n.StartLine, "start line")
+			assert.Equal(t, tc.endLine, n.EndLine, "end line")
+
+			var owned bool
+			for _, ed := range res.Edges {
+				if ed.Kind == graph.EdgeMemberOf && ed.From == tc.id && ed.To == "atlas.dart::TiledAtlas" {
+					owned = true
+				}
+			}
+			assert.True(t, owned, "constructor %s must be a member of its type", tc.id)
+		})
+	}
+
+	// The doc comment above a named constructor rides the node.
+	assert.Equal(t, "Builds from a cache key.", byID["atlas.dart::TiledAtlas.fromKey"].Meta["doc"])
+
+	// The unnamed constructor stays out of the graph — `TiledAtlas(...)`
+	// constructs the class and must not be hijacked by a phantom member.
+	assert.Nil(t, byID["atlas.dart::TiledAtlas.TiledAtlas"],
+		"the unnamed constructor must not be emitted as a member")
+
+	// Constructor IDs are unique — a duplicate would collide in the store.
+	ids := map[string]bool{}
+	for _, n := range res.Nodes {
+		require.False(t, ids[n.ID], "duplicate node id %s", n.ID)
+		ids[n.ID] = true
+	}
+}
+
+// A const constructor on an enum and a private named constructor are ordinary
+// members too; a plain field declaration next to them stays a non-symbol.
+func TestDartExtractor_ConstructorsInEnumAndPrivate(t *testing.T) {
+	src := []byte(`enum Status {
+  active,
+  inactive;
+
+  const Status.raw();
+}
+
+class Cache {
+  final int size;
+  Cache._internal(this.size);
+}
+`)
+	res, err := NewDartExtractor().Extract("status.dart", src)
+	require.NoError(t, err)
+
+	byID := map[string]*graph.Node{}
+	for _, n := range res.Nodes {
+		byID[n.ID] = n
+	}
+
+	raw := byID["status.dart::Status.raw"]
+	require.NotNil(t, raw, "enum const constructor must be emitted")
+	assert.Equal(t, "raw", raw.Name)
+
+	internal := byID["status.dart::Cache._internal"]
+	require.NotNil(t, internal, "private named constructor must be emitted")
+	assert.Equal(t, "private", internal.Meta["visibility"])
+
+	// `final int size;` is a field declaration, not a constructor.
+	assert.Nil(t, byID["status.dart::Cache.size"])
+	assert.Nil(t, byID["status.dart::Cache.Cache"])
+}
+
 func TestDartExtractor_FactoryChainReceiver(t *testing.T) {
 	src := []byte("Widget builder() { return Widget(); }\n" +
 		"void run() {\n" +

--- a/internal/parser/languages/javascript.go
+++ b/internal/parser/languages/javascript.go
@@ -23,6 +23,9 @@ const qJSAll = `
   (function_declaration
     name: (identifier) @func.name) @func.def
 
+  (function_expression
+    name: (identifier) @fnexpr.name) @fnexpr.def
+
   (lexical_declaration
     (variable_declarator
       name: (identifier) @arrow.name
@@ -171,6 +174,9 @@ func (e *JavaScriptExtractor) Extract(filePath string, src []byte) (*parser.Extr
 
 		case m.Captures["func.def"] != nil:
 			e.emitFunction(m, filePath, fileID, src, result, seenIDs)
+
+		case m.Captures["fnexpr.def"] != nil:
+			e.emitFunctionExpression(m, filePath, fileID, src, result, seenIDs)
 
 		case m.Captures["arrow.def"] != nil:
 			e.emitArrow(m, filePath, fileID, src, result, arrowNames, seenIDs)
@@ -467,8 +473,25 @@ func (e *JavaScriptExtractor) Extract(filePath string, src []byte) (*parser.Extr
 // --- Per-match emit helpers -----------------------------------------
 
 func (e *JavaScriptExtractor) emitFunction(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seenIDs map[string]bool) {
-	name := m.Captures["func.name"].Text
-	def := m.Captures["func.def"]
+	e.emitNamedFunction(m.Captures["func.name"], m.Captures["func.def"], filePath, fileID, src, result, seenIDs)
+}
+
+// emitFunctionExpression emits a *named* function expression — the
+// binding-independent name in `const x = function foo() {…}`,
+// `module.exports = function foo() {…}`, `{ key: function foo() {…} }`
+// or `export default flag && function foo() {…}`. The grammar gives a
+// named expression the same name/parameters/body shape as a
+// declaration, so it emits through the same path. Anonymous function
+// expressions carry no name field and never match the query pattern.
+func (e *JavaScriptExtractor) emitFunctionExpression(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seenIDs map[string]bool) {
+	e.emitNamedFunction(m.Captures["fnexpr.name"], m.Captures["fnexpr.def"], filePath, fileID, src, result, seenIDs)
+}
+
+func (e *JavaScriptExtractor) emitNamedFunction(nameCap, def *parser.CapturedNode, filePath, fileID string, src []byte, result *parser.ExtractionResult, seenIDs map[string]bool) {
+	if nameCap == nil || def == nil {
+		return
+	}
+	name := nameCap.Text
 	id, ok := disambiguateID(seenIDs, filePath+"::"+name, def.StartLine+1)
 	if !ok {
 		return

--- a/internal/parser/languages/javascript_test.go
+++ b/internal/parser/languages/javascript_test.go
@@ -99,6 +99,81 @@ func TestJSExtractor_MethodMemberOf(t *testing.T) {
 	assert.GreaterOrEqual(t, len(memberEdges), 1)
 }
 
+func TestJSExtractor_NamedFunctionExpression(t *testing.T) {
+	cases := []struct {
+		name    string
+		src     string
+		want    string
+		wantSig string
+	}{
+		{
+			name:    "default export logical operand",
+			src:     "export default isHttpAdapterSupported && function httpAdapter(config) {\n  return config;\n};\n",
+			want:    "httpAdapter",
+			wantSig: "function httpAdapter()",
+		},
+		{
+			name:    "const initializer",
+			src:     "const wrapped = function inner(a) {\n  return a;\n};\n",
+			want:    "inner",
+			wantSig: "function inner()",
+		},
+		{
+			name:    "var initializer",
+			src:     "var legacy = function legacyImpl() {\n  return 1;\n};\n",
+			want:    "legacyImpl",
+			wantSig: "function legacyImpl()",
+		},
+		{
+			name:    "object property value",
+			src:     "const api = {\n  run: function runTask() {\n    return 1;\n  },\n};\n",
+			want:    "runTask",
+			wantSig: "function runTask()",
+		},
+		{
+			name:    "module.exports assignment",
+			src:     "module.exports = function createServer(opts) {\n  return opts;\n};\n",
+			want:    "createServer",
+			wantSig: "function createServer()",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := NewJavaScriptExtractor()
+			result, err := e.Extract("mod.js", []byte(tc.src))
+			require.NoError(t, err)
+
+			fn := nodeNamed(t, result.Nodes, graph.KindFunction, tc.want)
+			assert.Equal(t, "mod.js", fn.FilePath)
+			assert.Equal(t, "javascript", fn.Language)
+			assert.Greater(t, fn.EndLine, fn.StartLine)
+			assert.Equal(t, tc.wantSig, fn.Meta["signature"])
+
+			var defined bool
+			for _, ed := range edgesOfKind(result.Edges, graph.EdgeDefines) {
+				if ed.From == "mod.js" && ed.To == fn.ID {
+					defined = true
+				}
+			}
+			assert.True(t, defined, "file must define %s", fn.ID)
+		})
+	}
+}
+
+func TestJSExtractor_AnonymousFunctionExpressionUnemitted(t *testing.T) {
+	src := []byte(`const anon = function () {
+  return 1;
+};
+module.exports = function () {
+  return 2;
+};
+`)
+	e := NewJavaScriptExtractor()
+	result, err := e.Extract("anon.js", src)
+	require.NoError(t, err)
+	assert.Empty(t, nodesOfKind(result.Nodes, graph.KindFunction))
+}
+
 func TestJSExtractor_Extensions(t *testing.T) {
 	e := NewJavaScriptExtractor()
 	exts := e.Extensions()

--- a/internal/parser/languages/typescript.go
+++ b/internal/parser/languages/typescript.go
@@ -25,6 +25,9 @@ const tsQAll = `
   (function_declaration
     name: (identifier) @func.name) @func.def
 
+  (function_expression
+    name: (identifier) @fnexpr.name) @fnexpr.def
+
   (lexical_declaration
     (variable_declarator
       name: (identifier) @arrow.name
@@ -243,6 +246,9 @@ func (e *TypeScriptExtractor) Extract(filePath string, src []byte) (*parser.Extr
 		switch {
 		case m.Captures["func.def"] != nil:
 			e.emitFunction(m, filePath, fileID, src, result, seenIDs)
+
+		case m.Captures["fnexpr.def"] != nil:
+			e.emitFunctionExpression(m, filePath, fileID, src, result, seenIDs)
 
 		case m.Captures["arrow.def"] != nil:
 			if name := e.emitArrow(m, filePath, fileID, src, result, seenIDs); name != "" {
@@ -670,8 +676,26 @@ func (e *TypeScriptExtractor) Extract(filePath string, src []byte) (*parser.Extr
 // --- per-match emit helpers ------------------------------------------
 
 func (e *TypeScriptExtractor) emitFunction(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seenIDs map[string]bool) {
-	name := m.Captures["func.name"].Text
-	def := m.Captures["func.def"]
+	e.emitNamedFunction(m.Captures["func.name"], m.Captures["func.def"], filePath, fileID, src, result, seenIDs)
+}
+
+// emitFunctionExpression emits a *named* function expression — the
+// binding-independent name in `const x = function foo() {…}`,
+// `module.exports = function foo() {…}`, `{ key: function foo() {…} }`
+// or `export default flag && function foo() {…}`. The grammar gives a
+// named expression the same name/type-parameters/parameters/body shape
+// as a declaration, so it emits through the same path. Anonymous
+// function expressions carry no name field and never match the query
+// pattern.
+func (e *TypeScriptExtractor) emitFunctionExpression(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seenIDs map[string]bool) {
+	e.emitNamedFunction(m.Captures["fnexpr.name"], m.Captures["fnexpr.def"], filePath, fileID, src, result, seenIDs)
+}
+
+func (e *TypeScriptExtractor) emitNamedFunction(nameCap, def *parser.CapturedNode, filePath, fileID string, src []byte, result *parser.ExtractionResult, seenIDs map[string]bool) {
+	if nameCap == nil || def == nil {
+		return
+	}
+	name := nameCap.Text
 	id, ok := disambiguateID(seenIDs, filePath+"::"+name, def.StartLine+1)
 	if !ok {
 		return

--- a/internal/parser/languages/typescript_test.go
+++ b/internal/parser/languages/typescript_test.go
@@ -1091,13 +1091,101 @@ const middlewareImpl: MiddlewareImpl =
 		ids[n.ID] = string(n.Kind)
 	}
 	for id, kind := range map[string]string{
-		"mw/middleware.ts::StoreSetStateWithAction":              "type",
-		"mw/middleware.ts::middlewareImpl":                       "function",
+		"mw/middleware.ts::StoreSetStateWithAction":                  "type",
+		"mw/middleware.ts::middlewareImpl":                           "function",
 		"mw/middleware.ts::middlewareImpl#param:middlewareOptions@1": "param",
-		"mw/middleware.ts::setStateTracked":                      "function",
+		"mw/middleware.ts::setStateTracked":                          "function",
 	} {
 		if ids[id] != kind {
 			t.Fatalf("%s = %q, want %q (all: %v)", id, ids[id], kind, ids)
 		}
 	}
+}
+
+func TestTSExtractor_NamedFunctionExpression(t *testing.T) {
+	cases := []struct {
+		name    string
+		file    string
+		src     string
+		want    string
+		wantSig string
+	}{
+		{
+			name:    "default export logical operand",
+			file:    "adapter.ts",
+			src:     "export default isHttpAdapterSupported && function httpAdapter(config: Config) {\n  return config;\n};\n",
+			want:    "httpAdapter",
+			wantSig: "function httpAdapter()",
+		},
+		{
+			name:    "const initializer",
+			file:    "wrap.ts",
+			src:     "const wrapped = function inner(a: number) {\n  return a;\n};\n",
+			want:    "inner",
+			wantSig: "function inner()",
+		},
+		{
+			name:    "var initializer",
+			file:    "legacy.ts",
+			src:     "var legacy = function legacyImpl() {\n  return 1;\n};\n",
+			want:    "legacyImpl",
+			wantSig: "function legacyImpl()",
+		},
+		{
+			name:    "object property value",
+			file:    "api.ts",
+			src:     "const api = {\n  run: function runTask() {\n    return 1;\n  },\n};\n",
+			want:    "runTask",
+			wantSig: "function runTask()",
+		},
+		{
+			name:    "module.exports assignment",
+			file:    "cjs.ts",
+			src:     "module.exports = function createServer(opts: Options) {\n  return opts;\n};\n",
+			want:    "createServer",
+			wantSig: "function createServer()",
+		},
+		{
+			name:    "tsx grammar",
+			file:    "view.tsx",
+			src:     "const view = function renderView() {\n  return null;\n};\n",
+			want:    "renderView",
+			wantSig: "function renderView()",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := NewTypeScriptExtractor()
+			result, err := e.Extract(tc.file, []byte(tc.src))
+			require.NoError(t, err)
+
+			fn := nodeNamed(t, result.Nodes, graph.KindFunction, tc.want)
+			assert.Equal(t, tc.file, fn.FilePath)
+			assert.Equal(t, "typescript", fn.Language)
+			assert.Greater(t, fn.EndLine, fn.StartLine)
+			assert.Equal(t, tc.wantSig, fn.Meta["signature"])
+
+			var defined bool
+			for _, ed := range edgesOfKind(result.Edges, graph.EdgeDefines) {
+				if ed.From == tc.file && ed.To == fn.ID {
+					defined = true
+				}
+			}
+			assert.True(t, defined, "file must define %s", fn.ID)
+		})
+	}
+}
+
+func TestTSExtractor_AnonymousFunctionExpressionUnemitted(t *testing.T) {
+	src := []byte(`const anon = function () {
+  return 1;
+};
+module.exports = function () {
+  return 2;
+};
+`)
+	e := NewTypeScriptExtractor()
+	result, err := e.Extract("anon.ts", src)
+	require.NoError(t, err)
+	assert.Empty(t, nodesOfKind(result.Nodes, graph.KindFunction))
 }

--- a/internal/resolver/dart_ctor_receiver_test.go
+++ b/internal/resolver/dart_ctor_receiver_test.go
@@ -1,0 +1,61 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+// A `TiledAtlas.fromTiledMap(...)` call binds to the named factory constructor
+// on TiledAtlas — not to the same-named constructor on a decoy class. The
+// Capitalized chain head is the only evidence that separates them, so the bind
+// proves both halves: the constructor is a real member symbol, and the call
+// carries the receiver type the resolver matches it against.
+func TestDartConstructorCall_BindsViaCapitalizedReceiver(t *testing.T) {
+	src := `class Decoy {
+  Decoy.fromTiledMap(int m);
+}
+
+class TiledAtlas {
+  factory TiledAtlas.fromTiledMap(int m) {
+    return TiledAtlas.fromKey('x');
+  }
+
+  TiledAtlas.fromKey(String k);
+}
+
+void load() {
+  var a = TiledAtlas.fromTiledMap(1);
+}
+`
+	res, err := languages.NewDartExtractor().Extract("atlas.dart", []byte(src))
+	require.NoError(t, err)
+
+	g := graph.New()
+	loadExtract(t, g, res)
+	New(g).ResolveAll()
+
+	assert.Equal(t, "atlas.dart::TiledAtlas.fromTiledMap", dartCallTarget(g, "atlas.dart::load"),
+		"the call must land on TiledAtlas' factory constructor, not the decoy's")
+
+	// The factory body's own `TiledAtlas.fromKey(...)` binds too — a
+	// constructor is now an enclosing owner, so the calls it makes are
+	// attributed instead of dropped.
+	assert.Equal(t, "atlas.dart::TiledAtlas.fromKey",
+		dartCallTarget(g, "atlas.dart::TiledAtlas.fromTiledMap"),
+		"a call made inside a factory constructor must attribute to that constructor")
+}
+
+// dartCallTarget returns the single outgoing call target of a symbol.
+func dartCallTarget(g graph.Store, from string) string {
+	for _, e := range g.GetOutEdges(from) {
+		if e.Kind == graph.EdgeCalls {
+			return e.To
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary

Builds on #472 (based on `feat/localization-causal-and-anchor-targets`). Thirteen commits in three independent groups.

### Symbol extraction fidelity

- **Dart constructors become first-class symbols.** No constructor variant — named, factory, const, or redirecting — previously emitted a node, so constructor lookups, file outlines, and usage queries were blind to them. Unnamed constructors stay unemitted (existing pinned behavior). Capitalized call chains (`Type.member(...)`) now stamp `receiver_type`, so same-named members resolve to the right owner instead of binding by bare name.
- **JS/TS named function expressions** (`const x = function foo() {}`, default-export operands, object property values, `module.exports = function foo() {}`) now emit function symbols; anonymous expressions stay unemitted. Applied to both walkers (JS and TS are separate extractors).
- **C++ free template functions** emit nodes with their declarator names, including explicit specializations, with spans starting at the `template <...>` header so header-line lookups resolve.
- **Ambiguous `.h` headers detect their language from content at parse time** instead of inheriting the walk's extension default — C++ headers stop being parsed by the C extractor.

### Localization evidence pages

- **Leading-file depth**: when ranking produces a clear leading file, the evidence page reserves up to 3 of its slots for that file's next-ranked symbols instead of spreading strictly one row per file. Protected rows (anchors, divergent-default, causal) are never evicted.
- **Bounded file outline**: refining pages attach a name+line outline of the leading file (≤40 rows, elided beyond, shed first under budget pressure); the localize path's default budget rises to 2400 tokens. Terminal pages carry no outline.
- **Grounded primaries**: each PRIMARY answer row carries its declaration line; same-named candidates render file-qualified and the final response prefers the provenance-linked file; the terminal directive asks the agent to claim only symbols present in evidence or confirmed by an accepted call.

### Query signals and hooks

- Task tokens that exactly match indexed symbol names anchor candidates regardless of casing shape (bounded to 16 lookups, ambiguity-guarded); dotted `Owner.member` mentions resolve like `::`-qualified ones.
- Fenced code blocks are mined for anchors and literals instead of being discarded by query shaping.
- Candidate source files score against task-derived path probes, reusing the artifact-lane probe machinery; boosts can lift a candidate into the cut but never displace protected rows.
- An identifier-shaped symbols search that finds no node returns clearly-labeled content matches with their enclosing declarations in the same response.
- Hook deny responses carry results: Grep denies append the top hits the daemon probe already computed (≤600 bytes, no extra calls); Read denies append a bounded file outline (≤250 ms, degrades silently to today's exact message).

## Validation

- Full plain suite green (142 packages, 0 failures); `-race` green on `internal/mcp`, `internal/parser/...`, `internal/hooks`, `internal/resolver`, `internal/query`; `golangci-lint` clean on the touched trees; `gofmt` clean; no stray files.
- Every feature commit landed with its touched packages' tests green; new behaviors are covered by table-driven extractor tests, builder-level page tests, and hook tests with exact-message fallback assertions.
- Indexing performance on a 1.6k-file polyglot tree (interleaved A/B, median of 3): cold index +0.2 % wall (within noise), warm restart unchanged, peak daemon RSS unchanged within run variance; node count +1.3 % from the newly extracted constructor symbols.
