### PR TITLE
csharp: extract record members

### DIFF
--- a/internal/indexer/extractor_version.go
+++ b/internal/indexer/extractor_version.go
@@ -32,7 +32,7 @@ var extractorVersions = map[string]int{
 	//   "go": 2,
 	"c":      generatedParserProjectionPolicyVersion, // generated parser projection covers all strictly detected table sizes
 	"php":    2,                                      // class/interface inheritance now emits typed structural edges
-	"csharp": 5,                                      // awaited-receiver Task<T> unwrap + return_shape (was: this./base.-qualified call edges)
+	"csharp": 6,                                      // record members extracted (was: awaited-receiver Task<T> unwrap + return_shape)
 }
 
 // extractorSaltExtLang maps a lower-case file extension to the language

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -1018,7 +1018,7 @@ func (e *CSharpExtractor) emitMethod(m parser.QueryResult, filePath, fileID stri
 	def := m.Captures["method.def"]
 	startLine1 := def.StartLine + 1
 
-	owner := csharpDirectMemberOwner(def.Node, src, "class_declaration", "struct_declaration", "interface_declaration")
+	owner := csharpDirectMemberOwner(def.Node, src, "class_declaration", "struct_declaration", "interface_declaration", "record_declaration")
 	if owner.kind == "" {
 		// Method outside a recognised container — legacy didn't emit
 		// these (its nested queries required class/struct/interface
@@ -1138,7 +1138,7 @@ func (e *CSharpExtractor) emitMethod(m parser.QueryResult, filePath, fileID stri
 func (e *CSharpExtractor) emitConstructor(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen map[string]bool) {
 	def := m.Captures["ctor.def"]
 	startLine1 := def.StartLine + 1
-	owner := csharpDirectMemberOwner(def.Node, src, "class_declaration", "struct_declaration")
+	owner := csharpDirectMemberOwner(def.Node, src, "class_declaration", "struct_declaration", "record_declaration")
 	if owner.kind == "" {
 		return
 	}
@@ -1180,7 +1180,7 @@ func (e *CSharpExtractor) emitConstructor(m parser.QueryResult, filePath, fileID
 
 func (e *CSharpExtractor) emitField(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen map[string]bool) {
 	def := m.Captures["field.def"]
-	owner := csharpDirectMemberOwner(def.Node, src, "class_declaration", "struct_declaration", "interface_declaration")
+	owner := csharpDirectMemberOwner(def.Node, src, "class_declaration", "struct_declaration", "interface_declaration", "record_declaration")
 	if owner.kind == "" {
 		return
 	}
@@ -1247,7 +1247,7 @@ func (e *CSharpExtractor) emitField(m parser.QueryResult, filePath, fileID strin
 
 func (e *CSharpExtractor) emitProperty(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen map[string]bool) {
 	def := m.Captures["prop.def"]
-	owner := csharpDirectMemberOwner(def.Node, src, "class_declaration", "struct_declaration", "interface_declaration")
+	owner := csharpDirectMemberOwner(def.Node, src, "class_declaration", "struct_declaration", "interface_declaration", "record_declaration")
 	if owner.kind == "" {
 		return
 	}

--- a/internal/parser/languages/csharp_record_members_test.go
+++ b/internal/parser/languages/csharp_record_members_test.go
@@ -1,0 +1,65 @@
+package languages
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Record bodies must extract like class bodies: methods, properties,
+// fields, and ctors declared inside a record (or record struct) get
+// member nodes, and calls out of record methods emit edges. Previously
+// every member emitter's owner walk recognised class/struct/interface
+// only, so a record's declaration_list members vanished entirely — no
+// nodes, no call edges, and calls INTO record members mis-bound to
+// same-named members of unrelated classes.
+func TestCSharpExtractor_RecordMembers(t *testing.T) {
+	src := []byte(`namespace App {
+    public class Engraver {
+        public string Etch(string text) { return text; }
+    }
+    public record Medal(int Id, string Motto) {
+        private int _polish;
+        public Medal(int id) : this(id, "none") { _polish = 1; }
+        public string Inscribe(Engraver engraver) { return engraver.Etch(Motto); }
+        public int Rank { get { return Id * 10; } }
+    }
+    public readonly record struct RibbonClip(int Width) {
+        public int Span() { return Width * 2; }
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("Medal.cs", src)
+	require.NoError(t, err)
+
+	byID := map[string]*graph.Node{}
+	for _, n := range result.Nodes {
+		byID[n.ID] = n
+	}
+
+	method := byID["Medal.cs::Medal.Inscribe"]
+	require.NotNil(t, method, "record method must emit a node")
+	assert.Equal(t, graph.KindMethod, method.Kind)
+	require.NotNil(t, method.Meta)
+	assert.Equal(t, "Medal", method.Meta["receiver"])
+
+	assert.NotNil(t, byID["Medal.cs::Medal.Rank"], "record property must emit a node")
+	assert.NotNil(t, byID["Medal.cs::Medal._polish"], "record field must emit a node")
+	assert.NotNil(t, byID["Medal.cs::Medal.<init>"], "record ctor must emit a node")
+	assert.NotNil(t, byID["Medal.cs::RibbonClip.Span"], "record STRUCT method must emit a node")
+
+	var etchCall *graph.Edge
+	for _, ed := range result.Edges {
+		if ed.Kind == graph.EdgeCalls && ed.From == "Medal.cs::Medal.Inscribe" && strings.Contains(ed.To, "Etch") {
+			etchCall = ed
+		}
+	}
+	require.NotNil(t, etchCall, "call out of a record method must emit an edge")
+	require.NotNil(t, etchCall.Meta)
+	assert.Equal(t, true, etchCall.Meta["member_call"])
+}

--- a/internal/resolver/csharp_record_members_spec_test.go
+++ b/internal/resolver/csharp_record_members_spec_test.go
@@ -1,0 +1,40 @@
+package resolver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Calls into a record's members must bind the record's member, not a
+// same-named member of an unrelated class. Before record bodies were
+// extracted there was no Medal.Foo node at all, so the fallback
+// confidently picked the decoy — a wrong answer, not a missing one.
+func TestResolveCSharp_RecordMemberCalls(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Lib.cs": `namespace App {
+    public class StencilDecoy { public int Foo(int id) { return 0; } }
+    public record Medal(int Id) {
+        public int Foo(int id) { return Id + id; }
+    }
+    public class MedalCase {
+        public int Show(int id) {
+            Medal medal = new Medal(id);
+            return medal.Foo(id);
+        }
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	call := fooCallEdge(g, "Lib.cs::MedalCase.Show")
+	require.NotNil(t, call, "medal.Foo() must produce a call edge")
+	assert.True(t, strings.Contains(call.To, "Medal.Foo"),
+		"record-typed receiver binds the record's member, got %q", call.To)
+	assert.False(t, strings.Contains(call.To, "StencilDecoy"),
+		"decoy must not win, got %q", call.To)
+	assert.GreaterOrEqual(t, call.Confidence, 0.9,
+		"declared receiver type must bind confidently, not by fallback luck")
+}


### PR DESCRIPTION

Follow-up to the #466 review's second finding: members declared inside a `record` body were not extracted at all. The cause is one gate — the member emitters resolve ownership through a parent walk whose allowed-container list is `class_declaration` / `struct_declaration` / `interface_declaration`, so every method, constructor, field, and property inside a `record_declaration` hit the "unrecognised container" skip. The record's type node existed; its body was invisible.

The damage is worse than a missing edge. With no member node to bind, a call into a record member falls through to the fallback tiers and lands on a same-named member of an unrelated class — reproduced live at confidence 0.7 with `receiver_type` evidence present. A confident wrong answer, where the rest of the pipeline had done everything right.

**Fix**: add `record_declaration` to the four owner lists. `record struct` is the same node type in the grammar (the `struct` keyword is a child, as `csharpDeclAllowsBaseClass` already handles), so both flavors ride the same change. Everything downstream comes along for free — the function-range lookup is built from emitted nodes, so tenv typing, awaited-receiver unwrapping, and async spawn edges now work inside record methods with no further changes.

**Tests**: an extractor spec pinning member nodes for all four member kinds (method with `receiver` meta, property, field, `<init>`) plus a record-struct method and the call edge out of a record method; and a resolver spec asserting a record-typed receiver binds the record's member over a same-named decoy on an unrelated class at ≥ 0.9 — pre-fix that spec reproduces the 0.7 decoy mis-bind exactly. All tests were written first and failed against the old behaviour before the fix landed. `internal/parser/languages` fully green; `internal/resolver` and `internal/indexer` at their pre-existing Windows baselines with zero new failures.

The commit bumps the `csharp` extractor version 5→6 so existing stores restage `.cs` files. Validated live on a counted C# fixture repo after a cold rebuild: a record method's call edge out, a call into a record method, and a call into a record-struct method all bind their compiler-correct targets at 0.95 with the decoy excluded — three cells that were pinned as known-gap flipped on the first settled run.
