### PR TITLE
hooks: read the tracked-repo registry from config, not a daemon round trip

### DIFF
--- a/internal/hooks/session_paths.go
+++ b/internal/hooks/session_paths.go
@@ -17,10 +17,15 @@ type sessionScope struct {
 	CWD       string
 }
 
-// hookTrackedReposFn is the daemon's tracked-repo list, injectable so tests
+// hookTrackedReposFn is the tracked-repo list, injectable so tests
 // never dial a real daemon.
-var hookTrackedReposFn = cachedTrackedRepos
+// Reads the local registry (see tracked_repos_config.go) and only falls back
+// to a daemon round trip when that file cannot be established.
+var hookTrackedReposFn = configTrackedRepos
 
+// cachedTrackedRepos is the daemon-backed registry: the fallback for
+// configTrackedRepos, and still the direct source for callers that need the
+// live per-repo counters the config cannot supply.
 func cachedTrackedRepos() []daemon.TrackedRepoStatus {
 	status, err := cachedDaemonStatus()
 	if err != nil || status == nil {

--- a/internal/hooks/tracked_repos_config.go
+++ b/internal/hooks/tracked_repos_config.go
@@ -1,0 +1,121 @@
+package hooks
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/daemon"
+)
+
+// The tracked-repo registry is `~/.gortex/config.yaml` — a daemon status row
+// for a repo the daemon holds no index for is itself synthesised from that
+// file, so the config is the membership source of truth and the status call
+// only adds live counters on top.
+//
+// Reading it directly is what the hot path wants. Asking the daemon instead
+// cost a full ControlStatus round trip per hook fire — every tracked repo
+// marshalled with its file/node/edge counts and memory breakdown — measured at
+// ~76 ms warm, over a second under load, and often enough hitting its 2 s
+// deadline that the hook then answered from an empty list. An empty list reads
+// as "no repo owns this path" downstream, so a timeout did not merely make the
+// hook slow: it silently downgraded an indexed-file decision to generic
+// guidance.
+//
+// Membership is all the hot path needs — repoRootForFile and the scope gate
+// read Path, hookRepoScope reads Path and Prefix. The live counters stay zero
+// here; SessionStart is the only consumer that reads them and it keeps its own
+// status call, firing once per session rather than once per tool call.
+
+var (
+	configReposOnce sync.Once
+	configReposVal  []daemon.TrackedRepoStatus
+	configReposOK   bool
+)
+
+// configTrackedRepos returns the tracked-repo registry read from the user's
+// global config, falling back to the daemon only when that file is absent or
+// unparseable. The result is memoised for the process: a hook invocation is
+// short-lived and the registry cannot change underneath it.
+func configTrackedRepos() []daemon.TrackedRepoStatus {
+	configReposOnce.Do(func() {
+		configReposVal, configReposOK = loadConfigTrackedRepos()
+	})
+	if configReposOK {
+		return configReposVal
+	}
+	// Unreadable config: fall back to the daemon rather than report an empty
+	// registry, which downstream cannot distinguish from "nothing is tracked".
+	return cachedTrackedRepos()
+}
+
+// loadConfigTrackedRepos flattens the global config's repo entries — both the
+// top-level list and every named project's — into status rows. ok is false
+// only when the registry could not be established at all (missing or invalid
+// config file); a config that parses but declares no repos is authoritative
+// and returns (nil, true), because that genuinely means nothing is tracked.
+func loadConfigTrackedRepos() ([]daemon.TrackedRepoStatus, bool) {
+	return loadTrackedReposFromPath(config.DefaultGlobalConfigPath())
+}
+
+// loadTrackedReposFromPath is loadConfigTrackedRepos with an explicit config
+// path, so tests exercise the registry without a real ~/.gortex/config.yaml.
+func loadTrackedReposFromPath(path string) ([]daemon.TrackedRepoStatus, bool) {
+	if path == "" {
+		return nil, false
+	}
+	if _, err := os.Stat(path); err != nil {
+		return nil, false // absent → let the daemon answer
+	}
+	gc, err := config.LoadGlobal(path)
+	if err != nil || gc == nil {
+		return nil, false
+	}
+
+	var out []daemon.TrackedRepoStatus
+	seen := make(map[string]bool)
+	add := func(e config.RepoEntry) {
+		p := strings.TrimSpace(e.Path)
+		if p == "" {
+			return
+		}
+		// Deliberately symlink-naive, matching repoRootForFile and
+		// hookRepoScope: a symlinked worktree resolves to no repo and
+		// degrades to the labeled fallback rather than a guessed attribution.
+		if !filepath.IsAbs(p) {
+			abs, absErr := filepath.Abs(p)
+			if absErr != nil {
+				return
+			}
+			p = abs
+		}
+		p = filepath.Clean(p)
+		if seen[p] {
+			return
+		}
+		seen[p] = true
+		out = append(out, daemon.TrackedRepoStatus{
+			Path:      p,
+			Prefix:    config.ResolvePrefix(e),
+			Name:      e.Name,
+			Ref:       e.Ref,
+			Workspace: e.Workspace,
+			Project:   e.Project,
+		})
+	}
+
+	for _, e := range gc.Repos {
+		add(e)
+	}
+	// Project-nested entries are tracked the same as top-level ones; a
+	// registry that dropped them would report a tracked path as untracked,
+	// which is the exact failure this file exists to remove.
+	for _, pc := range gc.Projects {
+		for _, e := range pc.Repos {
+			add(e)
+		}
+	}
+	return out, true
+}

--- a/internal/hooks/tracked_repos_config_test.go
+++ b/internal/hooks/tracked_repos_config_test.go
@@ -1,0 +1,148 @@
+package hooks
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/daemon"
+)
+
+func writeGlobalConfig(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+	return path
+}
+
+// The registry must carry every tracked repo, from both the top-level list and
+// each named project. A project-nested repo dropped here reports a tracked path
+// as untracked, which is exactly the misread this registry exists to prevent:
+// downstream, "no repo owns this path" downgrades an indexed-file decision to
+// generic guidance.
+func TestLoadTrackedRepos_IncludesProjectNestedRepos(t *testing.T) {
+	path := writeGlobalConfig(t, `
+repos:
+  - path: /work/alpha
+projects:
+  side:
+    repos:
+      - path: /work/beta
+      - path: /work/gamma
+`)
+	repos, ok := loadTrackedReposFromPath(path)
+	require.True(t, ok)
+
+	got := map[string]string{}
+	for _, r := range repos {
+		got[r.Path] = r.Prefix
+	}
+	assert.Equal(t, map[string]string{
+		"/work/alpha": "alpha",
+		"/work/beta":  "beta",
+		"/work/gamma": "gamma",
+	}, got, "top-level and project-nested repos are both tracked")
+}
+
+// Prefix mirrors config.ResolvePrefix: an explicit name wins, otherwise the
+// path's base. hookRepoScope hands this value out as the graph repo prefix, so
+// a wrong one mis-attributes a Stop-time diff.
+func TestLoadTrackedRepos_PrefixPrefersExplicitName(t *testing.T) {
+	path := writeGlobalConfig(t, `
+repos:
+  - path: /work/checkout
+    name: canonical
+  - path: /work/plain
+`)
+	repos, ok := loadTrackedReposFromPath(path)
+	require.True(t, ok)
+	require.Len(t, repos, 2)
+	assert.Equal(t, "canonical", repos[0].Prefix)
+	assert.Equal(t, "plain", repos[1].Prefix)
+}
+
+// The same path reachable twice (top-level and under a project) is one repo.
+func TestLoadTrackedRepos_DedupesRepeatedPath(t *testing.T) {
+	path := writeGlobalConfig(t, `
+repos:
+  - path: /work/alpha
+projects:
+  dup:
+    repos:
+      - path: /work/alpha
+`)
+	repos, ok := loadTrackedReposFromPath(path)
+	require.True(t, ok)
+	assert.Len(t, repos, 1)
+}
+
+// A config that parses but declares no repos is authoritative — nothing is
+// tracked — and must NOT fall back to the daemon. Reporting "unknown" here
+// would reintroduce the per-call status round trip for exactly the untracked
+// sessions that should cost nothing.
+func TestLoadTrackedRepos_EmptyConfigIsAuthoritative(t *testing.T) {
+	path := writeGlobalConfig(t, "active_project: none\n")
+	repos, ok := loadTrackedReposFromPath(path)
+	assert.True(t, ok, "a parsed config with no repos is a known-empty registry")
+	assert.Empty(t, repos)
+}
+
+// An absent or unparseable config is NOT a known-empty registry: the caller
+// must fall back to the daemon rather than answer from an empty list, which
+// downstream cannot tell apart from "nothing is tracked".
+func TestLoadTrackedRepos_UnestablishedRegistryFallsBack(t *testing.T) {
+	_, ok := loadTrackedReposFromPath(filepath.Join(t.TempDir(), "absent.yaml"))
+	assert.False(t, ok, "absent config must not be reported as known-empty")
+
+	_, ok = loadTrackedReposFromPath(writeGlobalConfig(t, "repos: [oops\n"))
+	assert.False(t, ok, "unparseable config must not be reported as known-empty")
+
+	_, ok = loadTrackedReposFromPath("")
+	assert.False(t, ok, "empty path must not be reported as known-empty")
+}
+
+// A blank path entry cannot own any file and must not become a row — an empty
+// Path would prefix-match nothing but still pad the registry.
+func TestLoadTrackedRepos_SkipsBlankPaths(t *testing.T) {
+	path := writeGlobalConfig(t, `
+repos:
+  - path: ""
+  - path: /work/real
+`)
+	repos, ok := loadTrackedReposFromPath(path)
+	require.True(t, ok)
+	require.Len(t, repos, 1)
+	assert.Equal(t, "/work/real", repos[0].Path)
+}
+
+// The registry feeds trackedRepoForPath, whose longest-match rule resolves
+// nested checkouts. Proving it here pins the end-to-end contract the PreToolUse
+// probe depends on, not just the parse.
+func TestLoadTrackedRepos_FeedsLongestMatchLookup(t *testing.T) {
+	path := writeGlobalConfig(t, `
+repos:
+  - path: /work/outer
+  - path: /work/outer/inner
+`)
+	repos, ok := loadTrackedReposFromPath(path)
+	require.True(t, ok)
+
+	prev := hookTrackedReposFn
+	hookTrackedReposFn = func() []daemon.TrackedRepoStatus { return repos }
+	t.Cleanup(func() { hookTrackedReposFn = prev })
+
+	got, found := trackedRepoForPath(filepath.Join("/work/outer/inner", "pkg", "f.go"))
+	require.True(t, found)
+	assert.Equal(t, "/work/outer/inner", got.Path,
+		"the nested checkout owns its own files, not the outer one")
+
+	got, found = trackedRepoForPath(filepath.Join("/work/outer", "pkg", "f.go"))
+	require.True(t, found)
+	assert.Equal(t, "/work/outer", got.Path)
+
+	_, found = trackedRepoForPath("/elsewhere/pkg/f.go")
+	assert.False(t, found, "a path outside every tracked repo owns no repo")
+}


### PR DESCRIPTION
Addresses the measured cause of #479's per-call hook latency — though not the one the issue proposes to fix.

## What I measured

Tracing the real `PreToolUse` path (macOS 15 / Apple Silicon, warm daemon, 44-repo registry) gives this per-call anatomy:

| phase | cost |
|---|---|
| exec + Go runtime init (400 packages) | ~30 ms |
| stdin read + parse + model hint | ~0.1 ms |
| **`ControlStatus` RPC — only to learn tracked roots** | **76 ms → 1210 ms → 2000 ms timeout** |
| dial + handshake for the tool call | **0.3 ms** |
| `get_file_summary` tools/call | 38–48 ms |

The handshake #479 proposes to make lightweight is **0.3 ms**. The issue's PoC saw a fresh client's first dial cost ~1 s and attributed it to per-session handshake bookkeeping; that second is this status call sitting in front of it.

## The bug behind the latency

`runPreToolUse` → `repoRootForFile` → `trackedRepoForPath` → `cachedTrackedRepos` → a full `daemon status` RPC, on every fire, to answer a membership test. There is a cache, but its TTL is process-scoped and every hook fire is a fresh process, so it only ever helps a `postGlob` loop inside one invocation.

On timeout the registry comes back empty, and an empty registry reads downstream as "no repo owns this path" — so the hook silently downgrades an indexed-file decision to generic guidance. Same payload, same file, back to back:

```
slow → 2016 ms → "[Gortex] Use explore first..."               (generic)
fast →  118 ms → "[Gortex] BLOCKED: ... (96 symbols indexed)"  (correct)
```

The hook gets slower and wronger under exactly the load that makes it slow.

## The change

`~/.gortex/config.yaml` is already the membership source of truth — a status row for a repo the daemon holds no index for is itself synthesised from that file. The hot path reads it directly: `repoRootForFile` and the scope gate need `Path`, `hookRepoScope` needs `Path` and `Prefix`, and `config.ResolvePrefix` is a pure function of the entry.

Live counters stay with the daemon. Their only consumer is `SessionStart`, which keeps its own status call and fires once per session rather than once per tool call.

Fallback is deliberate in both directions: an absent or unparseable config falls back to the daemon, so an unestablished registry degrades to today's behaviour rather than to a confident empty one. A config that parses with no repos is authoritative — that genuinely means nothing is tracked, and re-dialling there would put the round trip back on exactly the untracked sessions that should cost nothing.

## Result

24 interleaved paired runs (alternating binaries so daemon load drift hits both equally), tracked file, warm daemon:

| | before | after |
|---|---|---|
| median | 181.8 ms | **91.6 ms** |
| p90 | 2063.0 ms | **199.3 ms** |
| max | 2090.5 ms | **497.5 ms** |
| answers | 6/24 generic, 18/24 correct | **24/24 correct** |

The tail is what reads as "laggy", and it drops ~10×. The wrong-answer path is gone.

`internal/hooks`, `internal/config`, `cmd/gortex` green; `golangci-lint` clean on the changed package.

## What I did not change

I tested the obvious follow-on — narrowing the hook's `full` tool surface to `core` for the per-call probe — and it made no measurable difference (still 36–38 ms), so I dropped it rather than carry a change that only risks re-opening the #356 regression where a restricted preset silently emptied the Stop/PreCompact briefings.

That leaves `get_file_summary` at ~40 ms as the next target, and it wants a real answer rather than a guess: the hook uses a general-purpose file summariser to obtain a single symbol count. A narrow probe RPC returning `{tracked, indexed, symbol_count}` is the shape worth measuring next.

Two notes for #479's remaining phases, both now cheaper to judge with the status call gone:

- **Phase 1/2 as specified** target a 0.3 ms handshake. They may still be worth doing for structure, but not for latency.
- **Phase 3** (the thin binary) is worth ~30 ms here and ~250 ms on the Windows 11 numbers in the issue — a much easier sell there than on Apple Silicon, and now measurable against a baseline that is not dominated by this round trip.
