### PR TITLE
csharp: emit property nodes for record positional parameters

### DIFF
--- a/internal/indexer/extractor_version.go
+++ b/internal/indexer/extractor_version.go
@@ -32,7 +32,7 @@ var extractorVersions = map[string]int{
 	//   "go": 2,
 	"c":      generatedParserProjectionPolicyVersion, // generated parser projection covers all strictly detected table sizes
 	"php":    2,                                      // class/interface inheritance now emits typed structural edges
-	"csharp": 6,                                      // record members extracted (was: awaited-receiver Task<T> unwrap + return_shape)
+	"csharp": 7,                                      // record positional parameters emit property nodes (was: record members extracted)
 }
 
 // extractorSaltExtLang maps a lower-case file extension to the language

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -705,6 +705,68 @@ func (e *CSharpExtractor) emitContainer(m parser.QueryResult, kind string, nodeK
 	case "enum":
 		e.emitCSharpEnumMembers(def.Node, src, filePath, id, name, result, seen)
 	}
+	if kind == "record" {
+		e.emitCSharpRecordPositionalProps(id, name, def.Node, src, filePath, fileID, result, seen)
+	}
+}
+
+// emitCSharpRecordPositionalProps fabricates property member nodes for a
+// record's positional parameters — `record Medal(int Id, string Motto)`
+// synthesizes public properties Id and Motto with no declaration node
+// for the member walk to find, so the parameter list is the only source.
+// Runs at container emission, which precedes the body's member matches
+// in tree order: an explicit redeclaration of a positional property
+// (legal C# — it replaces the synthesized one) hits the seen guard and
+// stays a single node for the same logical member.
+func (e *CSharpExtractor) emitCSharpRecordPositionalProps(ownerID, ownerName string, decl *sitter.Node, src []byte, filePath, fileID string, result *parser.ExtractionResult, seen map[string]bool) {
+	// The record's parameter_list is an unnamed child in this grammar —
+	// unlike method parameters, ChildByFieldName("parameters") finds
+	// nothing, so scan the direct children by type.
+	var params *sitter.Node
+	for i, _nc := 0, int(decl.NamedChildCount()); i < _nc; i++ {
+		if c := decl.NamedChild(i); c != nil && c.Type() == "parameter_list" {
+			params = c
+			break
+		}
+	}
+	if params == nil {
+		return
+	}
+	for i, _nc := 0, int(params.NamedChildCount()); i < _nc; i++ {
+		p := params.NamedChild(i)
+		if p == nil || p.Type() != "parameter" {
+			continue
+		}
+		nameNode := p.ChildByFieldName("name")
+		if nameNode == nil {
+			continue
+		}
+		pname := nameNode.Content(src)
+		id := filePath + "::" + ownerName + "." + pname
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		line := int(p.StartPoint().Row) + 1
+		meta := map[string]any{
+			"receiver":   ownerName,
+			"visibility": VisibilityPublic,
+			"kind":       "property",
+			"positional": true,
+		}
+		if t := p.ChildByFieldName("type"); t != nil {
+			meta["field_type"] = strings.TrimSpace(t.Content(src))
+		}
+		result.Nodes = append(result.Nodes, &graph.Node{
+			ID: id, Kind: graph.KindField, Name: pname,
+			FilePath: filePath, StartLine: line, EndLine: line,
+			Language: "csharp",
+			Meta:     meta,
+		})
+		result.Edges = append(result.Edges,
+			&graph.Edge{From: fileID, To: id, Kind: graph.EdgeDefines, FilePath: filePath, Line: line},
+			&graph.Edge{From: id, To: ownerID, Kind: graph.EdgeMemberOf, FilePath: filePath, Line: line})
+	}
 }
 
 // emitCSharpEnumMembers emits one KindEnumMember per `enum_member_declaration`

--- a/internal/parser/languages/csharp_record_positional_test.go
+++ b/internal/parser/languages/csharp_record_positional_test.go
@@ -1,0 +1,81 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Positional record parameters synthesize public properties — the
+// defining feature of records and their most-used members. They have no
+// declaration node for the member walk, so the extractor fabricates the
+// property nodes from the record's parameter list.
+func TestCSharpExtractor_RecordPositionalProperties(t *testing.T) {
+	src := []byte(`namespace App {
+    public record Medal(int Id, string Motto) {
+        public int Rank { get { return Id * 10; } }
+    }
+    public readonly record struct RibbonClip(int Width);
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("Medal.cs", src)
+	require.NoError(t, err)
+
+	byID := map[string]*graph.Node{}
+	for _, n := range result.Nodes {
+		byID[n.ID] = n
+	}
+
+	id := byID["Medal.cs::Medal.Id"]
+	require.NotNil(t, id, "positional parameter Id must emit a property node")
+	assert.Equal(t, graph.KindField, id.Kind)
+	require.NotNil(t, id.Meta)
+	assert.Equal(t, "Medal", id.Meta["receiver"])
+	assert.Equal(t, "property", id.Meta["kind"])
+	assert.Equal(t, "int", id.Meta["field_type"],
+		"the declared parameter type rides the node")
+	assert.Equal(t, VisibilityPublic, id.Meta["visibility"],
+		"synthesized positional properties are public")
+
+	require.NotNil(t, byID["Medal.cs::Medal.Motto"], "second positional emits too")
+	assert.NotNil(t, byID["Medal.cs::Medal.Rank"], "explicit body member still emits")
+
+	clip := byID["Medal.cs::RibbonClip.Width"]
+	require.NotNil(t, clip, "record STRUCT positional emits a property node")
+	assert.Equal(t, "string", byID["Medal.cs::Medal.Motto"].Meta["field_type"])
+
+	var memberOf bool
+	for _, ed := range result.Edges {
+		if ed.Kind == graph.EdgeMemberOf && ed.From == "Medal.cs::Medal.Id" && ed.To == "Medal.cs::Medal" {
+			memberOf = true
+		}
+	}
+	assert.True(t, memberOf, "positional property carries a member_of edge to its record")
+}
+
+// An explicit redeclaration of a positional property (legal C#: the
+// explicit member replaces the synthesized one) must not produce a
+// duplicate node.
+func TestCSharpExtractor_RecordPositionalRedeclaration(t *testing.T) {
+	src := []byte(`namespace App {
+    public record Badge(int Code) {
+        public int Code { get; init; }
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("Badge.cs", src)
+	require.NoError(t, err)
+
+	count := 0
+	for _, n := range result.Nodes {
+		if n.ID == "Badge.cs::Badge.Code" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "one node for Code, not two")
+}


### PR DESCRIPTION
Follow-up to the #478 review comment: positional record parameters — the synthesized public properties that are a record's defining members — emitted nothing. `public record Medal(int Id, string Motto)` produced the `Medal` type node with no `Medal.Id` or `Medal.Motto`.

Unlike the #478 gap, there is no declaration node for the member walk to find: the properties exist only in the compiler's synthesis. So the record's container emission now fabricates one property node per positional parameter, with the declared parameter type riding as `field_type`, public visibility, a `positional: true` provenance marker, and the usual defines/member_of edges. One grammar wrinkle handled along the way: a record's `parameter_list` carries no field name (unlike method parameters), so it is found by child-type scan.

Container emission precedes the body's member matches in tree order, so an explicit redeclaration of a positional property (legal C# — it replaces the synthesized one) deduplicates to a single node for the same logical member. Covers `record` and `record struct`.

Tests: property nodes for both positional parameters plus the record-struct case (kind, receiver, declared type, visibility, member_of edge), coexistence with explicit body members, and the redeclaration dedupe. Written first, watched fail. `internal/parser/languages` fully green; resolver and indexer at their pre-existing Windows baselines.

Validated live on a counted C# fixture repo: all six authored positional properties emit (across `record`, `record struct`, and a record with mixed positional + explicit members), pinned as counted battery cells, green twice.

Bumps the `csharp` extractor version 6→7 to restage `.cs` files.
