### PR TITLE
csharp: emit member-access read/write edges

### DIFF
--- a/internal/indexer/extractor_version.go
+++ b/internal/indexer/extractor_version.go
@@ -32,7 +32,7 @@ var extractorVersions = map[string]int{
 	//   "go": 2,
 	"c":      generatedParserProjectionPolicyVersion, // generated parser projection covers all strictly detected table sizes
 	"php":    2,                                      // class/interface inheritance now emits typed structural edges
-	"csharp": 5,                                      // awaited-receiver Task<T> unwrap + return_shape (was: this./base.-qualified call edges)
+	"csharp": 6,                                      // member-access reads/writes edges (was: awaited-receiver Task<T> unwrap + return_shape). NOTE: #478 also claims 6 — whichever lands second bumps to 7.
 }
 
 // extractorSaltExtLang maps a lower-case file extension to the language

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -112,6 +112,13 @@ const qCSharpAll = `
       type: (_) @lvar.type
       (variable_declarator
         (identifier) @lvar.name))) @lvar.def
+
+  (member_access_expression
+    name: (identifier) @maccess.name) @maccess.expr
+
+  (conditional_access_expression
+    (member_binding_expression
+      name: (identifier) @maccess.condname)) @maccess.condexpr
 ]
 `
 
@@ -258,6 +265,7 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 	var calls []csharpDeferredCall
 	var locals []csharpDeferredLocal
 	var typeUses []csharpTypeUse
+	var accesses []csharpDeferredAccess
 
 	parser.EachMatch(e.qAll, root, src, func(m parser.QueryResult) {
 		switch {
@@ -336,6 +344,21 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 				name:        m.Captures["call.name"].Text,
 				line:        expr.StartLine + 1,
 				returnUsage: classifyReturnUsage(expr.Node, src, csharpReturnUsageSpec),
+			})
+
+		case m.Captures["maccess.expr"] != nil:
+			accesses = append(accesses, csharpDeferredAccess{
+				name: m.Captures["maccess.name"].Text,
+				node: m.Captures["maccess.expr"].Node,
+				line: m.Captures["maccess.expr"].StartLine + 1,
+			})
+
+		case m.Captures["maccess.condexpr"] != nil:
+			accesses = append(accesses, csharpDeferredAccess{
+				name:        m.Captures["maccess.condname"].Text,
+				node:        m.Captures["maccess.condexpr"].Node,
+				line:        m.Captures["maccess.condexpr"].StartLine + 1,
+				conditional: true,
 			})
 
 		case m.Captures["lvar.def"] != nil:
@@ -612,6 +635,11 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 		stampReturnUsage(edge, c.returnUsage)
 		result.Edges = append(result.Edges, edge)
 	}
+
+	// Member accesses ride the same deferred machinery as calls — the
+	// receiver-typing ladder needs the finished tenv.
+	emitCSharpMemberAccesses(accesses, src, filePath, funcRanges,
+		tenvByOwner, builtinsByOwner, result)
 
 	// .NET surfaces a symbol walk misses: DI registrations + COM
 	// interop. Stamped onto the file node.

--- a/internal/parser/languages/csharp_member_access.go
+++ b/internal/parser/languages/csharp_member_access.go
@@ -153,12 +153,64 @@ func csharpAccessReceiverType(a csharpDeferredAccess, src []byte, owner string,
 	return resolveChainType(text, tenv, result)
 }
 
+// csharpParamNamesByOwner indexes declared parameter names per owning
+// function/method from the KindParam nodes the shape emitter produced
+// (ID form `<ownerID>#param:<name>@<pos>`). An untyped receiver that
+// names a parameter is still a VALUE — the namespace-noise rule must
+// not swallow its chained reads.
+func csharpParamNamesByOwner(result *parser.ExtractionResult) map[string]map[string]bool {
+	out := map[string]map[string]bool{}
+	for _, n := range result.Nodes {
+		if n == nil || n.Kind != graph.KindParam {
+			continue
+		}
+		idx := strings.LastIndex(n.ID, "#param:")
+		if idx < 0 {
+			continue
+		}
+		owner := n.ID[:idx]
+		name := n.ID[idx+len("#param:"):]
+		if at := strings.LastIndex(name, "@"); at >= 0 {
+			name = name[:at]
+		}
+		m := out[owner]
+		if m == nil {
+			m = map[string]bool{}
+			out[owner] = m
+		}
+		m[name] = true
+	}
+	return out
+}
+
+// csharpAccessNamesValue reports whether the access's receiver is a
+// bare identifier naming a declared value (parameter, tenv local, or
+// builtin-typed local) of the enclosing function — value-ness evidence
+// even when the TYPE is unknown.
+func csharpAccessNamesValue(a csharpDeferredAccess, src []byte,
+	params map[string]bool, tenv typeEnv, builtins map[string]string) bool {
+	recv := a.node.ChildByFieldName("expression")
+	if a.conditional {
+		recv = a.node.ChildByFieldName("condition")
+	}
+	if recv == nil || recv.Type() != "identifier" {
+		return false
+	}
+	name := recv.Content(src)
+	if params[name] || builtins[name] != "" {
+		return true
+	}
+	_, ok := tenv[name]
+	return ok
+}
+
 // emitCSharpMemberAccesses turns the buffered access sites into
 // EdgeReads/EdgeWrites once the type environments exist.
 func emitCSharpMemberAccesses(accesses []csharpDeferredAccess, src []byte,
 	filePath string, funcRanges *csharpFuncLookup,
 	tenvByOwner map[string]typeEnv, builtinsByOwner map[string]map[string]string,
 	result *parser.ExtractionResult) {
+	paramsByOwner := csharpParamNamesByOwner(result)
 	for _, a := range accesses {
 		if a.node == nil || csharpAccessInCallPosition(a.node) {
 			continue
@@ -169,10 +221,14 @@ func emitCSharpMemberAccesses(accesses []csharpDeferredAccess, src []byte,
 		}
 		recvType := csharpAccessReceiverType(a, src, callerID,
 			tenvByOwner[callerID], builtinsByOwner[callerID], result)
-		if recvType == "" && !a.conditional && csharpAccessIsInnerLink(a.node) {
+		if recvType == "" && !a.conditional && csharpAccessIsInnerLink(a.node) &&
+			!csharpAccessNamesValue(a, src, paramsByOwner[callerID],
+				tenvByOwner[callerID], builtinsByOwner[callerID]) {
 			// Evidence-less inner link — almost always a namespace or
 			// static-qualification prefix; emitting it would shower the
-			// graph with reads of `Threading`/`Tasks`.
+			// graph with reads of `Threading`/`Tasks`. A receiver that
+			// names a declared param/local is a value, not a namespace,
+			// so its chained reads survive even untyped.
 			continue
 		}
 		kind := graph.EdgeReads

--- a/internal/parser/languages/csharp_member_access.go
+++ b/internal/parser/languages/csharp_member_access.go
@@ -1,0 +1,191 @@
+package languages
+
+import (
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	sitter "github.com/zzet/gortex/internal/parser/tsitter"
+)
+
+// C# property / field / constant usage edges.
+//
+// The extractor recorded calls but never accesses: `p.Title`,
+// `this.Note`, `Plaque.Cap` and `p?.Title` produced no edge of any
+// kind, so find_usages on a C# property or field returned its
+// declaration and nothing else — the member looked unused no matter how
+// often the code read or wrote it. Mirrors the PHP property-access
+// emission: each access is an EdgeReads (EdgeWrites in assignment
+// position) to `unresolved::*.<member>`, the shape resolveFieldRef
+// already consumes.
+//
+// One rule PHP does not need: dotted namespace qualification parses as
+// nested member_access_expression here (`System.Threading.Tasks.Task`),
+// so an access with NO receiver evidence emits only at the outermost
+// link of its chain — a typed inner link (`p.Title` in `p.Title.Length`)
+// still emits, while the namespace-prefix links stay silent.
+
+// csharpDeferredAccess buffers one member-access site until the
+// type-env build has run, mirroring csharpDeferredCall — receiver
+// typing needs the same tenv the call path uses.
+type csharpDeferredAccess struct {
+	name        string
+	node        *sitter.Node
+	line        int
+	conditional bool
+}
+
+// csharpAccessInCallPosition reports whether the access node is the
+// function of an invocation — `p.Chime()` belongs to the call query,
+// never to the access emitter.
+func csharpAccessInCallPosition(node *sitter.Node) bool {
+	parent := node.Parent()
+	if parent == nil || parent.Type() != "invocation_expression" {
+		return false
+	}
+	fn := parent.ChildByFieldName("function")
+	return fn != nil && fn.Equal(node)
+}
+
+// csharpAccessIsInnerLink reports whether the access is the receiver of
+// an enclosing member access (`p.Title` inside `p.Title.Length`).
+func csharpAccessIsInnerLink(node *sitter.Node) bool {
+	parent := node.Parent()
+	if parent == nil || parent.Type() != "member_access_expression" {
+		return false
+	}
+	expr := parent.ChildByFieldName("expression")
+	return expr != nil && expr.Equal(node)
+}
+
+// csharpAccessIsWrite reports whether an access sits in a position that
+// stores into the member: an assignment (simple or compound)
+// left-hand side, or the operand of `++` / `--`. Element accesses are
+// climbed first: `p.Items[0] = v` mutates Items, so it counts as a
+// write of Items; an access used as the index is a read.
+func csharpAccessIsWrite(node *sitter.Node) bool {
+	for {
+		parent := node.Parent()
+		if parent == nil || parent.Type() != "element_access_expression" {
+			break
+		}
+		expr := parent.ChildByFieldName("expression")
+		if expr == nil || !expr.Equal(node) {
+			return false
+		}
+		node = parent
+	}
+	parent := node.Parent()
+	if parent == nil {
+		return false
+	}
+	switch parent.Type() {
+	case "assignment_expression":
+		left := parent.ChildByFieldName("left")
+		return left != nil && left.Equal(node)
+	case "prefix_unary_expression", "postfix_unary_expression":
+		op := parent.Child(0)
+		if parent.Type() == "postfix_unary_expression" {
+			op = parent.Child(int(parent.ChildCount()) - 1)
+		}
+		if op == nil {
+			return false
+		}
+		t := op.Type()
+		return t == "++" || t == "--"
+	}
+	return false
+}
+
+// csharpAccessKeyword returns "this"/"base" when the access is
+// qualified by one of the anonymous keyword tokens (which no named
+// field capture ever sees — the same grammar wrinkle the call patterns
+// handle with literal-token alternations), "" otherwise.
+func csharpAccessKeyword(node *sitter.Node) string {
+	if node == nil || node.ChildCount() == 0 {
+		return ""
+	}
+	switch node.Child(0).Type() {
+	case "this":
+		return "this"
+	case "base":
+		return "base"
+	}
+	return ""
+}
+
+// csharpAccessReceiverType resolves the receiver type evidence for one
+// access, through the same ladder the deferred-call path uses: keyword
+// qualifiers from the enclosing declaration, identifiers from the
+// method's tenv (builtins stay unstamped, matching call policy), bare
+// known types for static accesses, and chains through resolveChainType.
+func csharpAccessReceiverType(a csharpDeferredAccess, src []byte, owner string,
+	tenv typeEnv, builtins map[string]string, result *parser.ExtractionResult) string {
+	if kw := csharpAccessKeyword(a.node); kw != "" {
+		return csharpQualifiedReceiverType(a.node, src, kw)
+	}
+	var recv *sitter.Node
+	if a.conditional {
+		recv = a.node.ChildByFieldName("condition")
+	} else {
+		recv = a.node.ChildByFieldName("expression")
+	}
+	if recv == nil {
+		return ""
+	}
+	if recv.Type() == "identifier" {
+		name := recv.Content(src)
+		if builtins[name] != "" {
+			return ""
+		}
+		if t, ok := tenv[name]; ok {
+			return t
+		}
+		if isKnownType(name, result) {
+			return name
+		}
+		return ""
+	}
+	text := strings.TrimSpace(recv.Content(src))
+	if text == "" {
+		return ""
+	}
+	return resolveChainType(text, tenv, result)
+}
+
+// emitCSharpMemberAccesses turns the buffered access sites into
+// EdgeReads/EdgeWrites once the type environments exist.
+func emitCSharpMemberAccesses(accesses []csharpDeferredAccess, src []byte,
+	filePath string, funcRanges *csharpFuncLookup,
+	tenvByOwner map[string]typeEnv, builtinsByOwner map[string]map[string]string,
+	result *parser.ExtractionResult) {
+	for _, a := range accesses {
+		if a.node == nil || csharpAccessInCallPosition(a.node) {
+			continue
+		}
+		callerID := funcRanges.enclosing(a.line)
+		if callerID == "" {
+			continue
+		}
+		recvType := csharpAccessReceiverType(a, src, callerID,
+			tenvByOwner[callerID], builtinsByOwner[callerID], result)
+		if recvType == "" && !a.conditional && csharpAccessIsInnerLink(a.node) {
+			// Evidence-less inner link — almost always a namespace or
+			// static-qualification prefix; emitting it would shower the
+			// graph with reads of `Threading`/`Tasks`.
+			continue
+		}
+		kind := graph.EdgeReads
+		if !a.conditional && csharpAccessIsWrite(a.node) {
+			kind = graph.EdgeWrites
+		}
+		edge := &graph.Edge{
+			From: callerID, To: "unresolved::*." + a.name,
+			Kind: kind, FilePath: filePath, Line: a.line,
+		}
+		if recvType != "" {
+			edge.Meta = map[string]any{"receiver_type": recvType}
+		}
+		result.Edges = append(result.Edges, edge)
+	}
+}

--- a/internal/parser/languages/csharp_member_access_test.go
+++ b/internal/parser/languages/csharp_member_access_test.go
@@ -1,0 +1,128 @@
+package languages
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// accessEdges returns the EdgeReads/EdgeWrites edges out of fromID whose
+// unresolved target names member.
+func accessEdges(result_edges []*graph.Edge, fromID, member string) []*graph.Edge {
+	var out []*graph.Edge
+	for _, ed := range result_edges {
+		if ed.From != fromID || (ed.Kind != graph.EdgeReads && ed.Kind != graph.EdgeWrites) {
+			continue
+		}
+		if strings.HasSuffix(ed.To, "."+member) {
+			out = append(out, ed)
+		}
+	}
+	return out
+}
+
+// C# property / field / const accesses must emit EdgeReads (EdgeWrites in
+// assignment position) like PHP and Go already do — previously they
+// produced no edge of any kind, so every C# property answered
+// find_usages with its declaration and nothing else.
+func TestCSharpExtractor_MemberAccessEdges(t *testing.T) {
+	src := []byte(`namespace App {
+    public class Plaque {
+        public string Title { get; set; }
+        public const int Cap = 5;
+        public int Chime() { return 1; }
+    }
+    public class Reader {
+        public string Note { get; set; }
+
+        public string Get() { Plaque p = new Plaque(); return p.Title; }
+        public void Set() { Plaque p = new Plaque(); p.Title = "x"; }
+        public void Bump() { Plaque p = new Plaque(); p.Title += "!"; }
+        public string Self() { return this.Note; }
+        public int Fixed() { return Plaque.Cap; }
+        public string Cond() { Plaque p = new Plaque(); return p?.Title; }
+        public int Chained() { Plaque p = new Plaque(); return p.Title.Length; }
+        public int Call() { Plaque p = new Plaque(); return p.Chime(); }
+        public string FromParam(Plaque q) { return q.Title; }
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("Plaque.cs", src)
+	require.NoError(t, err)
+
+	get := accessEdges(result.Edges, "Plaque.cs::Reader.Get", "Title")
+	require.Len(t, get, 1, "p.Title in return position is one read")
+	assert.Equal(t, graph.EdgeReads, get[0].Kind)
+	require.NotNil(t, get[0].Meta)
+	assert.Equal(t, "Plaque", get[0].Meta["receiver_type"])
+
+	set := accessEdges(result.Edges, "Plaque.cs::Reader.Set", "Title")
+	require.Len(t, set, 1, "assignment lhs is one write")
+	assert.Equal(t, graph.EdgeWrites, set[0].Kind)
+	assert.Equal(t, "Plaque", set[0].Meta["receiver_type"])
+
+	bump := accessEdges(result.Edges, "Plaque.cs::Reader.Bump", "Title")
+	require.Len(t, bump, 1, "compound assignment lhs is one write")
+	assert.Equal(t, graph.EdgeWrites, bump[0].Kind)
+
+	self := accessEdges(result.Edges, "Plaque.cs::Reader.Self", "Note")
+	require.Len(t, self, 1, "this.Note is one read")
+	assert.Equal(t, graph.EdgeReads, self[0].Kind)
+	assert.Equal(t, "Reader", self[0].Meta["receiver_type"],
+		"this-receiver is the enclosing type")
+
+	fixed := accessEdges(result.Edges, "Plaque.cs::Reader.Fixed", "Cap")
+	require.Len(t, fixed, 1, "Plaque.Cap static const access is one read")
+	assert.Equal(t, graph.EdgeReads, fixed[0].Kind)
+	assert.Equal(t, "Plaque", fixed[0].Meta["receiver_type"],
+		"a known-type receiver types the static access")
+
+	cond := accessEdges(result.Edges, "Plaque.cs::Reader.Cond", "Title")
+	require.Len(t, cond, 1, "p?.Title conditional access is one read")
+	assert.Equal(t, graph.EdgeReads, cond[0].Kind)
+	assert.Equal(t, "Plaque", cond[0].Meta["receiver_type"])
+
+	chained := accessEdges(result.Edges, "Plaque.cs::Reader.Chained", "Title")
+	require.Len(t, chained, 1, "the typed inner link of p.Title.Length is a read of Title")
+	assert.Equal(t, graph.EdgeReads, chained[0].Kind)
+
+	call := accessEdges(result.Edges, "Plaque.cs::Reader.Call", "Chime")
+	assert.Empty(t, call, "p.Chime() is a call - the call query owns it, no read edge")
+
+	// Parameter receivers are not in the extraction tenv (same contract
+	// as calls): the edge still emits, untyped, and receiver binding is
+	// the resolver cascade's job.
+	param := accessEdges(result.Edges, "Plaque.cs::Reader.FromParam", "Title")
+	require.Len(t, param, 1, "a param-receiver access still emits its read edge")
+	assert.Equal(t, graph.EdgeReads, param[0].Kind)
+}
+
+// Dotted namespace qualification parses as nested member accesses in this
+// grammar - `System.Threading.Tasks.Task.CompletedTask` must not shower
+// the graph with reads of Threading/Tasks. The rule: an access with NO
+// receiver evidence emits only at the outermost link of its chain.
+func TestCSharpExtractor_MemberAccessNamespaceNoise(t *testing.T) {
+	src := []byte(`using System.Threading.Tasks;
+namespace App {
+    public class Runner {
+        public Task Idle() { return System.Threading.Tasks.Task.CompletedTask; }
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("Runner.cs", src)
+	require.NoError(t, err)
+
+	for _, member := range []string{"Threading", "Tasks", "Task"} {
+		assert.Empty(t, accessEdges(result.Edges, "Runner.cs::Runner.Idle", member),
+			"namespace-prefix link %q must not emit an access edge", member)
+	}
+	// The outermost link (CompletedTask) may emit an untyped read - that
+	// is the same degraded-but-useful shape PHP emits for unknown
+	// receivers, and the resolver's locality cascade handles it.
+}

--- a/internal/parser/languages/csharp_member_access_test.go
+++ b/internal/parser/languages/csharp_member_access_test.go
@@ -48,6 +48,7 @@ func TestCSharpExtractor_MemberAccessEdges(t *testing.T) {
         public int Chained() { Plaque p = new Plaque(); return p.Title.Length; }
         public int Call() { Plaque p = new Plaque(); return p.Chime(); }
         public string FromParam(Plaque q) { return q.Title; }
+        public int ParamChain(Plaque q) { return q.Title.Length; }
     }
 }
 `)
@@ -100,6 +101,14 @@ func TestCSharpExtractor_MemberAccessEdges(t *testing.T) {
 	param := accessEdges(result.Edges, "Plaque.cs::Reader.FromParam", "Title")
 	require.Len(t, param, 1, "a param-receiver access still emits its read edge")
 	assert.Equal(t, graph.EdgeReads, param[0].Kind)
+
+	// A chained access on a param receiver is a REAL read even though the
+	// receiver is untyped: `q` names a declared parameter, which is
+	// value-ness evidence the namespace-noise rule must respect —
+	// `System` in `System.Threading.Tasks` names no param or local.
+	pchain := accessEdges(result.Edges, "Plaque.cs::Reader.ParamChain", "Title")
+	require.Len(t, pchain, 1, "q.Title inside q.Title.Length is a read of Title")
+	assert.Equal(t, graph.EdgeReads, pchain[0].Kind)
 }
 
 // Dotted namespace qualification parses as nested member accesses in this

--- a/internal/resolver/csharp_member_access_spec_test.go
+++ b/internal/resolver/csharp_member_access_spec_test.go
@@ -1,0 +1,63 @@
+package resolver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// accessEdge returns the first EdgeReads/EdgeWrites out of fromID whose
+// target (resolved or unresolved) names member.
+func accessEdge(g graph.Store, fromID, member string) *graph.Edge {
+	for _, e := range g.GetOutEdges(fromID) {
+		if e.Kind != graph.EdgeReads && e.Kind != graph.EdgeWrites {
+			continue
+		}
+		if graph.IsUnresolvedTarget(e.To) {
+			if name := graph.UnresolvedName(e.To); name == "*."+member || name == member {
+				return e
+			}
+			continue
+		}
+		if n := g.GetNode(e.To); n != nil && n.Name == member {
+			return e
+		}
+	}
+	return nil
+}
+
+// A typed C# property read must bind the receiver type's own property —
+// not a same-named property on an unrelated class — through the existing
+// resolveFieldRef cascade.
+func TestResolveCSharp_MemberAccessBindsReceiverField(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Lib.cs": `namespace App {
+    public class StencilDecoy { public string Title { get; set; } }
+    public class Plaque { public string Title { get; set; } }
+    public class Reader {
+        public string Get() { Plaque p = new Plaque(); return p.Title; }
+        public void Set() { Plaque p = new Plaque(); p.Title = "x"; }
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	read := accessEdge(g, "Lib.cs::Reader.Get", "Title")
+	require.NotNil(t, read, "p.Title must produce a read edge")
+	assert.True(t, strings.Contains(read.To, "Plaque.Title"),
+		"typed receiver binds the receiver type's property, got %q", read.To)
+	assert.False(t, strings.Contains(read.To, "StencilDecoy"),
+		"decoy must not win, got %q", read.To)
+	assert.GreaterOrEqual(t, read.Confidence, 0.9,
+		"exact receiver-type field match binds confidently")
+
+	write := accessEdge(g, "Lib.cs::Reader.Set", "Title")
+	require.NotNil(t, write, "p.Title = ... must produce a write edge")
+	assert.Equal(t, graph.EdgeWrites, write.Kind)
+	assert.True(t, strings.Contains(write.To, "Plaque.Title"),
+		"write binds the same way, got %q", write.To)
+}


### PR DESCRIPTION
C# property, field, and constant accesses emitted no edges of any kind — `find_usages` on any C# property answered with its declaration and nothing else. On a production C# codebase, 6 of 28,773 field nodes had any non-structural in-edge; every property looked unused no matter how often the code read or wrote it.

This brings C# to parity with the PHP and Go extractors through the existing pipeline: each access emits `EdgeReads` (`EdgeWrites` in assignment position — simple and compound assignment, `++`/`--`, with element accesses climbed so `p.Items[0] = v` writes `Items`) to `unresolved::*.<member>`, the shape `resolveFieldRef` already consumes. Receiver typing rides the same ladder as calls: `this`/`base` from the enclosing declaration, locals from the tenv, known types for static accesses, chains through the chain typer. The resolver needed zero changes.

One rule PHP does not need: dotted namespace qualification parses as nested member accesses in this grammar, so `System.Threading.Tasks.Task.CompletedTask` would shower the graph with reads of `Threading`/`Tasks`. An access with no receiver evidence emits only at the outermost link of its chain — with one refinement: a receiver that names a declared parameter or local is a value, not a namespace, so its chained reads survive even untyped.

Documented v1 boundaries: parameter and field receivers emit untyped edges (binding falls to the resolver cascade, same contract as calls); conditional accesses are read-only; object-initializer assignments and attribute-argument reads don't emit.

Tests: extractor spec covering read/write/compound/`this`/static-const/conditional/chained shapes plus the call-position exclusion and the namespace-noise rule; resolver spec binding a typed read and write to the receiver type's property at ≥0.9 over a same-named decoy. Written first, watched fail. All suites at their pre-existing Windows baselines.

Validated live on a production C# codebase: 108,696 read + 9,978 write edges where there were none. On the counted fixture repo, an authored ledger (exactly 3 reads + 1 write of one property) pins as counted battery cells, green twice.

Stacked on #481 (which takes `csharp` extractor version 7); this PR bumps 7→8.
