### PR TITLE
mcp: guard that every hook-dispatched tool still resolves

### DIFF
--- a/internal/mcp/hook_tool_reachability_test.go
+++ b/internal/mcp/hook_tool_reachability_test.go
@@ -1,0 +1,110 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A hook dispatches a tool by name over the daemon socket and treats every
+// failure — "tool not found" included — as an unreachable bridge, rendering
+// nothing. A name the server no longer registers therefore produces silence,
+// not an error: it survives review, it survives CI, and it is found by accident
+// much later. That is how the Stop briefing's contracts section and the
+// PreCompact churn section went dead (#356), and how the PreCompact bridge kept
+// posting to an HTTP surface that had been removed (#241).
+//
+// internal/hooks owns a companion guard (TestHookToolSurfaceCoversEveryCalledTool)
+// which asks whether a called tool sits inside the declared preset. That guard
+// short-circuits whenever the surface is unrestricted, which it is today
+// ("full"), and an unrestricted surface is not the same claim as "this name is
+// still registered" — a retired tool passes it either way.
+//
+// This is the missing half: does the name resolve against the registry at all.
+// It lives here rather than in internal/hooks because that package deliberately
+// does not link the server (a hook talks over a socket; keeping it free of
+// internal/mcp is what allows a slim hook client). Reading the hook sources as
+// text introduces no such dependency in either direction.
+
+// hookToolCallSite matches the two shapes a hook uses to name a tool: the
+// shared dispatcher — callServerTool(port, "name", args) — and the raw
+// tools/call frame's "name" member.
+var hookToolCallSite = regexp.MustCompile(
+	`callServerTool[A-Za-z]*\([^,]+,\s*"([a-z][a-z0-9_]*)"|"name":\s*"([a-z][a-z0-9_]*)"`,
+)
+
+// hookDispatchedToolNames reads the non-test sources of internal/hooks and
+// returns every tool name a hook asks the daemon to run, mapped to the files
+// that call it. Derived from source rather than a hand-kept list so a new call
+// site is covered the moment it is written.
+func hookDispatchedToolNames(t *testing.T) map[string][]string {
+	t.Helper()
+	dir := filepath.Join("..", "hooks")
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err, "read internal/hooks")
+
+	out := map[string][]string{}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		src, readErr := os.ReadFile(filepath.Clean(filepath.Join(dir, name)))
+		require.NoError(t, readErr)
+		for _, m := range hookToolCallSite.FindAllStringSubmatch(string(src), -1) {
+			tool := m[1]
+			if tool == "" {
+				tool = m[2]
+			}
+			if tool != "" {
+				out[tool] = append(out[tool], name)
+			}
+		}
+	}
+	return out
+}
+
+// Every tool a hook dispatches must still resolve against this package's
+// registry — as a facade tool in its own right, or as an implementation-era
+// name the facade registry still maps to a public operation. A name that is
+// neither is one the daemon will not answer, and the hook calling it goes
+// quiet instead of failing.
+func TestHookDispatchedToolsResolve(t *testing.T) {
+	called := hookDispatchedToolNames(t)
+	require.NotEmpty(t, called,
+		"no tool names found in internal/hooks — the call-site pattern drifted and this guard is now vacuous")
+
+	var unreachable []string
+	for tool, files := range called {
+		if isFacadeToolName(tool) {
+			continue
+		}
+		if _, _, ok := PublicOperationForLegacy(tool); ok {
+			continue
+		}
+		unreachable = append(unreachable, tool+" (called from "+strings.Join(files, ", ")+")")
+	}
+	sort.Strings(unreachable)
+
+	assert.Empty(t, unreachable,
+		"these hook-dispatched tools resolve to nothing this package registers, so the hooks calling them\n"+
+			"render silence rather than an error:\n  %s", strings.Join(unreachable, "\n  "))
+}
+
+// The scan is this guard's foundation: if the pattern stops matching real call
+// sites, the test above passes with an empty set and the protection disappears
+// without a signal. Pin names that are dispatched today so a change to the
+// dispatcher's shape fails here instead of quietly blinding the guard.
+func TestHookToolScanStillSeesKnownCallSites(t *testing.T) {
+	called := hookDispatchedToolNames(t)
+	for _, expect := range []string{"detect_changes", "get_file_summary", "contracts"} {
+		assert.Contains(t, called, expect,
+			"the call-site scan no longer sees %q — the guard has gone blind", expect)
+	}
+}


### PR DESCRIPTION
Closes the gap that let #241 and #356 ship: a hook calling a tool the server no longer registers goes *silent* rather than failing.

## The failure mode

A hook dispatches by name over the daemon socket and treats every failure — including "tool not found" — as an unreachable bridge, so it renders nothing. No error, no log, no test failure. Both prior incidents were found by accident, long after they shipped:

- **#356** — the Stop briefing's contracts section and the PreCompact churn section went dead under a restricted preset
- **#241** — the PreCompact bridge kept posting to an HTTP surface that had been removed

## Why the existing guard doesn't cover it

`internal/hooks` has `TestHookToolSurfaceCoversEveryCalledTool`, and it's a good test — but it asks whether a called tool is inside the declared *preset*, and it opens with:

```go
unrestricted := map[string]bool{"": true, "full": true, "all": true}
if unrestricted[hookInternalToolSurface] { return }
```

`hookInternalToolSurface` is `"full"`, so **it returns before checking anything today**. It is currently vacuous, and only wakes up if someone narrows the surface.

Even when it does run, "no preset restriction" is a weaker claim than it appears — it is not the same as "this name is registered". A retired tool passes either way.

## What this adds

The missing half: *does the name resolve against the registry at all* — as a facade tool, or as an implementation-era name the facade registry still maps to a public operation.

All twelve names the hooks dispatch today resolve, so this lands green and stays green until something is retired out from under them.

Two details worth flagging for review:

- **It lives in `internal/mcp`, not `internal/hooks`.** That package deliberately does not link the server — `daemon_tool_test.go` says so explicitly, and duplicates a preset list rather than import `internal/mcp` for exactly this reason. That boundary is load-bearing for any future slim hook client, so I read the hook sources as *text*, which adds no dependency in either direction.
- **It derives names from source, not a hand-kept list**, so a new call site is covered the moment it's written. Because a scanner that stops matching would make the guard silently vacuous — the same trap the existing guard fell into — a second test pins names dispatched today so a dispatcher-shape change fails loudly instead of blinding the scan.

## Verification

Mutation-tested rather than assumed. Pointing one existing call at a retired name:

```
--- FAIL: TestHookDispatchedToolsResolve
    Should be empty, but was [get_repo_briefing_v0 (called from precompact.go)]
    render silence rather than an error:
      get_repo_briefing_v0 (called from precompact.go)
```

Restoring it returns to green. `internal/mcp` and `internal/hooks` suites pass; `golangci-lint` clean.

## Context

This is the first of several fixes from a hook latency/correctness investigation. It's deliberately first because it's independent of the others and prevents recurrence of the class while the rest land. Related follow-ups, in order of value:

1. **Daemon control-plane starvation** — `daemon status` measured 155 ms → 11.5 s on *serial* calls with no hook load, same payload each time, while the log showed 28-second incremental derived passes. Control calls queue behind indexing. This single root cause explains the PreCompact, SessionStart, UserPromptSubmit and PostToolUse timeout bugs.
2. **PreCompact** emits nothing 100% of the time (13/13 fires) — its socket call starves for the full 5 s, then falls through to the dead HTTP fallback.
3. **Facade unification** — the hooks' emitted guidance is facade-clean, but all twelve tools they *call* are implementation-era names. Exactly four (`contracts`, `explain_change_impact`, `get_symbol_history`, `feedback`) are why `Tools: "full"` is forced.
