### PR TITLE
daemon: resolve workspace-root cwds to their contained repos' workspace

### DIFF
--- a/cmd/gortex/daemon_integration_test.go
+++ b/cmd/gortex/daemon_integration_test.go
@@ -223,6 +223,17 @@ func TestDaemon_EndToEnd_WorkspaceRootCWDServed(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(reply, &resp))
 	require.NotNil(t, resp.Result, "workspace-root cwd must get a tool result: %s", string(reply))
+
+	// Scope-sensitive twin: graph_stats never consults the session
+	// scope, so a binding that admits the session but blanks its scope
+	// would pass the assertion above. A symbol search runs through the
+	// scoped engine — the tracked repo's own symbol must come back.
+	frame = []byte(`{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"search_symbols","arguments":{"query":"main"}}}`)
+	require.NoError(t, client.WriteMCPFrame(frame))
+	reply, err = client.ReadMCPFrame()
+	require.NoError(t, err)
+	require.Contains(t, string(reply), "main.go",
+		"workspace-root session's scope must reach the contained repo's symbols: %s", string(reply))
 }
 
 // TestDaemon_EndToEnd_TrackAddsRepoLive proves track-while-running is

--- a/cmd/gortex/daemon_integration_test.go
+++ b/cmd/gortex/daemon_integration_test.go
@@ -163,8 +163,12 @@ func TestDaemon_EndToEnd_GraphStatsOverMCPProxy(t *testing.T) {
 // dispatcher. An agent opening in an untracked directory must see a
 // usable error on every tool call, not a silent zero result.
 func TestDaemon_EndToEnd_UntrackedCWDRejectedViaProxy(t *testing.T) {
-	socket, trackedRoot := spinUpDaemon(t)
-	untracked := filepath.Dir(trackedRoot) // parent of tracked root is NOT tracked
+	socket, _ := spinUpDaemon(t)
+	// A directory unrelated to the tracked root in either containment
+	// direction. (The tracked root's PARENT no longer qualifies — a
+	// workspace-root cwd above tracked repos is served, see
+	// TestDaemon_EndToEnd_WorkspaceRootCWDServed.)
+	untracked := t.TempDir()
 
 	client, err := daemon.DialTo(socket, daemon.Handshake{
 		Mode: daemon.ModeMCP,
@@ -190,6 +194,35 @@ func TestDaemon_EndToEnd_UntrackedCWDRejectedViaProxy(t *testing.T) {
 	assert.Equal(t, "repo_not_tracked", resp.Error.Data["error_code"],
 		"untracked cwd must produce structured error: %s", string(reply))
 	assert.Equal(t, untracked, resp.Error.Data["path"])
+}
+
+// TestDaemon_EndToEnd_WorkspaceRootCWDServed pins the flip side: a cwd
+// that is the PARENT of the tracked root (an agent opened at the
+// workspace root above its repo) binds to the contained repo's
+// workspace and gets real answers, not repo_not_tracked.
+func TestDaemon_EndToEnd_WorkspaceRootCWDServed(t *testing.T) {
+	socket, trackedRoot := spinUpDaemon(t)
+	wsRoot := filepath.Dir(trackedRoot)
+
+	client, err := daemon.DialTo(socket, daemon.Handshake{
+		Mode: daemon.ModeMCP,
+		CWD:  wsRoot,
+	})
+	require.NoError(t, err)
+	defer client.Close()
+
+	frame := []byte(`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"graph_stats","arguments":{}}}`)
+	require.NoError(t, client.WriteMCPFrame(frame))
+	reply, err := client.ReadMCPFrame()
+	require.NoError(t, err)
+
+	require.NotContains(t, string(reply), "repo_not_tracked",
+		"workspace-root cwd must be served, got: %s", string(reply))
+	var resp struct {
+		Result map[string]any `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(reply, &resp))
+	require.NotNil(t, resp.Result, "workspace-root cwd must get a tool result: %s", string(reply))
 }
 
 // TestDaemon_EndToEnd_TrackAddsRepoLive proves track-while-running is

--- a/cmd/gortex/daemon_mcp.go
+++ b/cmd/gortex/daemon_mcp.go
@@ -313,6 +313,16 @@ func (d *mcpDispatcher) cwdReachable(cwd string) bool {
 	if d.isCWDTracked(cwd) {
 		return true
 	}
+	// Workspace-root fallback: a cwd that CONTAINS tracked repos (agent
+	// opened at the root above its repos) is reachable exactly when
+	// ScopeForCWD can bind it to one workspace — the same resolution
+	// sessionScope applies later, so the gate can never admit a session
+	// the scope would blank out, or refuse one it could serve.
+	if d.multiIndexer != nil {
+		if _, _, _, ok := d.multiIndexer.ScopeForCWD(cwd); ok {
+			return true
+		}
+	}
 	rtr := d.router.Load()
 	if rtr == nil {
 		return false

--- a/cmd/gortex/daemon_mcp_test.go
+++ b/cmd/gortex/daemon_mcp_test.go
@@ -346,6 +346,51 @@ func TestDispatcher_UnreachableCWD_StillRejected(t *testing.T) {
 	assert.Equal(t, "repo_not_tracked", data["error_code"])
 }
 
+// TestDispatcher_WorkspaceRootCWD_Passes covers the reverse-containment
+// case: the session cwd is not inside any tracked repo but is a PARENT
+// of one (an agent opened at the workspace root above its repos, e.g.
+// `<root>` over `<root>/projects/<repo>`). The guard must let the frame
+// through — ScopeForCWD binds such a session to the contained repo's
+// workspace, so refusing here contradicts the scope the session would
+// actually get. A parent whose repos span different workspaces stays
+// rejected: sessionScope cannot express that union, and passing the
+// gate would trade the actionable error for silently empty results.
+func TestDispatcher_WorkspaceRootCWD_Passes(t *testing.T) {
+	parent := t.TempDir()
+	app := filepath.Join(parent, "projects", "app")
+	require.NoError(t, os.MkdirAll(app, 0o755))
+
+	d, mi := trackedPathMCPSetup(t, app)
+
+	assert.True(t, d.cwdReachable(parent),
+		"workspace root above one tracked repo must be reachable")
+
+	sess := &daemon.Session{ID: "sess_wsroot", CWD: parent}
+	frame := []byte(`{"jsonrpc":"2.0","id":11,"method":"tools/call","params":{"name":"graph_stats","arguments":{}}}`)
+	reply, err := d.Dispatch(context.Background(), sess, frame)
+	require.NoError(t, err)
+	require.NotNil(t, reply)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(reply, &parsed))
+	if errObj, ok := parsed["error"].(map[string]any); ok {
+		if data, ok := errObj["data"].(map[string]any); ok {
+			assert.NotEqual(t, "repo_not_tracked", data["error_code"],
+				"workspace-root cwd wrongly rejected by guard: %v", parsed)
+		}
+	}
+
+	// Track a second repo under the same parent: each repo is its own
+	// singleton workspace, so the parent now spans two workspaces and
+	// must fail closed again.
+	other := filepath.Join(parent, "projects", "other")
+	require.NoError(t, os.MkdirAll(other, 0o755))
+	_, err = mi.TrackRepoCtx(context.Background(), config.RepoEntry{Path: other})
+	require.NoError(t, err)
+	assert.False(t, d.cwdReachable(parent),
+		"parent spanning two singleton workspaces must stay unreachable")
+}
+
 // TestDispatcher_UntrackedHandshake_SurvivesWithInactiveVariant proves the
 // F4 contract: an MCP session opened in a cwd that no tracked repo covers must
 // still complete its handshake. initialize flows through and the response

--- a/internal/indexer/multi_case_identity_test.go
+++ b/internal/indexer/multi_case_identity_test.go
@@ -82,6 +82,19 @@ func TestScopeForCWD_CaseMismatchedCwd(t *testing.T) {
 	assert.Equal(t, "myrepo", prefix)
 }
 
+// The reverse direction folds too: a case-variant of the PARENT above
+// the tracked repo (a workspace-root cwd) still resolves to the
+// contained repo. The #277 scenario one level up.
+func TestScopeForCWD_CaseMismatchedWorkspaceRoot(t *testing.T) {
+	forceCaseInsensitive(t, true)
+	mi, dir := indexSingleRepoForTest(t)
+
+	parent := caseVariantOf(filepath.Dir(dir))
+	_, _, prefix, ok := mi.ScopeForCWD(parent)
+	require.True(t, ok, "case-variant workspace root must resolve to the contained repo")
+	assert.Equal(t, "myrepo", prefix)
+}
+
 // ScopeForCWD must NOT resolve a genuinely unrelated cwd.
 func TestScopeForCWD_UnrelatedCwdMisses(t *testing.T) {
 	forceCaseInsensitive(t, true)

--- a/internal/indexer/multi_case_identity_test.go
+++ b/internal/indexer/multi_case_identity_test.go
@@ -8,9 +8,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/pathkey"
+	"github.com/zzet/gortex/internal/search"
 )
 
 // forceCaseInsensitive flips the process-global pathkey.CaseInsensitivePaths
@@ -84,12 +87,29 @@ func TestScopeForCWD_CaseMismatchedCwd(t *testing.T) {
 
 // The reverse direction folds too: a case-variant of the PARENT above
 // the tracked repo (a workspace-root cwd) still resolves to the
-// contained repo. The #277 scenario one level up.
+// contained repo. The #277 scenario one level up. The repo sits under a
+// LETTERED intermediate directory on purpose: t.TempDir's own basename
+// is digits-only, which swapCaseASCII leaves unchanged — toggling it
+// would exercise nothing.
 func TestScopeForCWD_CaseMismatchedWorkspaceRoot(t *testing.T) {
 	forceCaseInsensitive(t, true)
-	mi, dir := indexSingleRepoForTest(t)
+	dir := setupRepoDir(t, filepath.Join("Work", "myrepo"))
+
+	tmpCfg := filepath.Join(t.TempDir(), "config.yaml")
+	gc := &config.GlobalConfig{
+		Repos: []config.RepoEntry{{Path: dir, Name: "myrepo"}},
+	}
+	gc.SetConfigPath(tmpCfg)
+	require.NoError(t, gc.Save())
+	cm, err := config.NewConfigManager(tmpCfg)
+	require.NoError(t, err)
+	mi := NewMultiIndexer(graph.New(), newTestRegistry(), search.NewBM25(), cm, zap.NewNop())
+	_, err = mi.IndexAll()
+	require.NoError(t, err)
 
 	parent := caseVariantOf(filepath.Dir(dir))
+	require.NotEqual(t, filepath.Dir(dir), parent,
+		"the case variant must differ byte-wise or the test is vacuous")
 	_, _, prefix, ok := mi.ScopeForCWD(parent)
 	require.True(t, ok, "case-variant workspace root must resolve to the contained repo")
 	assert.Equal(t, "myrepo", prefix)

--- a/internal/indexer/scope_for_cwd_test.go
+++ b/internal/indexer/scope_for_cwd_test.go
@@ -93,3 +93,88 @@ func TestScopeForCWD_And_ReposInWorkspace(t *testing.T) {
 	// An unknown workspace resolves to the empty set.
 	assert.Empty(t, mi.ReposInWorkspace("does-not-exist"))
 }
+
+// TestScopeForCWD_WorkspaceRoot covers the reverse containment: a cwd
+// that is not inside any tracked repo but CONTAINS tracked repos (an
+// agent session started at a workspace root above its repos). Such a
+// cwd binds to the contained repos' workspace when that workspace is
+// unambiguous; repos spanning different workspaces keep failing closed
+// — a single-workspace session scope cannot express the union.
+func TestScopeForCWD_WorkspaceRoot(t *testing.T) {
+	mkRepo := func(parent, name string) string {
+		t.Helper()
+		dir := filepath.Join(parent, name)
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"),
+			[]byte("package main\n\nfunc Hello() {}\n"), 0o644))
+		return dir
+	}
+
+	// Layout 1: one repo nested two levels under the workspace root.
+	parentSingle := t.TempDir()
+	app := mkRepo(filepath.Join(parentSingle, "projects"), "app")
+
+	// Layout 2: two repos under one root, sharing workspace "shared".
+	parentShared := t.TempDir()
+	r1 := mkRepo(parentShared, "r1")
+	r2 := mkRepo(parentShared, "r2")
+	require.NoError(t, os.WriteFile(filepath.Join(r1, ".gortex.yaml"),
+		[]byte("workspace: shared\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(r2, ".gortex.yaml"),
+		[]byte("workspace: shared\n"), 0o644))
+
+	// Layout 3: two repos under one root, each its own singleton workspace.
+	parentMixed := t.TempDir()
+	x := mkRepo(parentMixed, "x")
+	y := mkRepo(parentMixed, "y")
+
+	tmpCfg := filepath.Join(t.TempDir(), "config.yaml")
+	gc := &config.GlobalConfig{
+		Repos: []config.RepoEntry{
+			{Path: app, Name: "app"},
+			{Path: r1, Name: "r1"},
+			{Path: r2, Name: "r2"},
+			{Path: x, Name: "x"},
+			{Path: y, Name: "y"},
+		},
+	}
+	gc.SetConfigPath(tmpCfg)
+	require.NoError(t, gc.Save())
+
+	cm, err := config.NewConfigManager(tmpCfg)
+	require.NoError(t, err)
+
+	g := graph.New()
+	mi := NewMultiIndexer(g, newTestRegistry(), search.NewBM25(), cm, zap.NewNop())
+	_, err = mi.IndexScoped("", "")
+	require.NoError(t, err)
+
+	// Workspace root above exactly one tracked repo: binds with the
+	// full scope of that repo — the session behaves as if started
+	// inside it (home repo included, so locality ranking still works).
+	ws, proj, prefix, ok := mi.ScopeForCWD(parentSingle)
+	require.True(t, ok, "workspace root containing one tracked repo must resolve")
+	assert.Equal(t, "app", ws)
+	assert.Equal(t, "app", proj)
+	assert.Equal(t, "app", prefix)
+
+	// Workspace root above two repos that share one workspace slug:
+	// binds to the workspace, with no home repo (the session has no
+	// single locality anchor).
+	ws, proj, prefix, ok = mi.ScopeForCWD(parentShared)
+	require.True(t, ok, "workspace root over a single shared workspace must resolve")
+	assert.Equal(t, "shared", ws)
+	assert.Empty(t, proj, "ambiguous project must stay empty")
+	assert.Empty(t, prefix, "no home repo above multiple repos")
+
+	// Workspace root above repos in DIFFERENT workspaces: fail closed —
+	// one session scope cannot span two workspace boundaries.
+	_, _, _, ok = mi.ScopeForCWD(parentMixed)
+	assert.False(t, ok, "mixed-workspace parent must not resolve")
+
+	// The forward direction is untouched: inside a repo still wins.
+	ws, _, prefix, ok = mi.ScopeForCWD(filepath.Join(app, "internal"))
+	require.True(t, ok)
+	assert.Equal(t, "app", ws)
+	assert.Equal(t, "app", prefix)
+}

--- a/internal/indexer/workspace_resolve.go
+++ b/internal/indexer/workspace_resolve.go
@@ -75,9 +75,19 @@ func resolveProjectID(entry *config.RepoEntry, cfg *config.Config, fallbackPrefi
 // matching repo root wins so a repo nested inside another resolves to
 // the inner one.
 //
-// ok is false when cwd lies outside every tracked repo — callers MUST
-// fail closed (return no cross-workspace data) rather than widening to
-// the global graph.
+// When cwd is inside no tracked repo but is a PARENT of tracked repos
+// (a session started at a workspace root above its repos), it binds to
+// the contained repos' workspace — provided they all share one
+// effective workspace slug. A single contained repo keeps its full
+// scope (home repo included, so locality ranking works); several repos
+// in one workspace bind with no home repo. Contained repos spanning
+// DIFFERENT workspaces fail closed: a single-workspace session scope
+// cannot express the union, and widening silently would cross the
+// isolation boundary.
+//
+// ok is false when neither direction matches — callers MUST fail
+// closed (return no cross-workspace data) rather than widening to the
+// global graph.
 //
 // A repo whose effective WorkspaceID is empty (no `.gortex.yaml::
 // workspace:` and no global-config override) is treated as its own
@@ -109,7 +119,7 @@ func (mi *MultiIndexer) ScopeForCWD(cwd string) (workspaceID, projectID, repoPre
 		}
 	}
 	if bestPrefix == "" {
-		return "", "", "", false
+		return mi.scopeForWorkspaceRootLocked(cwd)
 	}
 
 	ws, proj := bestPrefix, bestPrefix
@@ -122,6 +132,52 @@ func (mi *MultiIndexer) ScopeForCWD(cwd string) (workspaceID, projectID, repoPre
 		}
 	}
 	return ws, proj, bestPrefix, true
+}
+
+// scopeForWorkspaceRootLocked is ScopeForCWD's reverse-containment
+// fallback: cwd contains tracked repos instead of living inside one.
+// Caller holds mi.mu (read).
+func (mi *MultiIndexer) scopeForWorkspaceRootLocked(cwd string) (workspaceID, projectID, repoPrefix string, ok bool) {
+	var (
+		contained []string // repo prefixes rooted under cwd
+		sharedWS  string
+	)
+	for prefix, meta := range mi.repos {
+		if meta == nil {
+			continue
+		}
+		root := filepath.Clean(meta.RootPath)
+		if root == "" || root == "." || !pathkey.HasPathPrefix(root, cwd) {
+			continue
+		}
+		ws := prefix // singleton fallback, same rule as ReposInWorkspace
+		if idx := mi.indexers[prefix]; idx != nil {
+			if v := idx.WorkspaceID(); v != "" {
+				ws = v
+			}
+		}
+		if len(contained) > 0 && ws != sharedWS {
+			return "", "", "", false // spans workspaces — fail closed
+		}
+		sharedWS = ws
+		contained = append(contained, prefix)
+	}
+	switch len(contained) {
+	case 0:
+		return "", "", "", false
+	case 1:
+		prefix := contained[0]
+		proj := prefix
+		if idx := mi.indexers[prefix]; idx != nil {
+			if v := idx.ProjectID(); v != "" {
+				proj = v
+			}
+		}
+		return sharedWS, proj, prefix, true
+	default:
+		// Several repos, one workspace: no single home repo or project.
+		return sharedWS, "", "", true
+	}
 }
 
 // ReposInWorkspace returns the set of repo prefixes whose effective

--- a/internal/mcp/search_corpus.go
+++ b/internal/mcp/search_corpus.go
@@ -160,6 +160,24 @@ func (s *Server) mergeContentChannel(ctx context.Context, query string, nodes []
 		limit = fetchLimit
 	}
 	repoPrefix, _ := s.sessionLocality(ctx)
+	// A workspace-root binding has no home repo, so the prefix above is
+	// empty and SearchContent would span every repo in every workspace —
+	// the one channel the session's workspace boundary doesn't reach
+	// (the merged hits are materialised by raw GetNode below). Clamp the
+	// hits to the bound workspace's repo set; a bound session whose
+	// workspace enumerates no repos fails closed and merges nothing.
+	var allow map[string]bool
+	if repoPrefix == "" {
+		if ws, _, bound := s.sessionScope(ctx); bound {
+			if s.multiIndexer == nil {
+				return nodes
+			}
+			allow = s.multiIndexer.ReposInWorkspace(ws)
+			if len(allow) == 0 {
+				return nodes
+			}
+		}
+	}
 	hits, err := cs.SearchContent(query, repoPrefix, limit)
 	if err != nil || len(hits) == 0 {
 		return nodes
@@ -178,6 +196,9 @@ func (s *Server) mergeContentChannel(ctx context.Context, query string, nodes []
 		}
 		n := s.graph.GetNode(h.NodeID)
 		if n == nil {
+			continue
+		}
+		if allow != nil && !allow[n.RepoPrefix] {
 			continue
 		}
 		seen[h.NodeID] = struct{}{}

--- a/internal/mcp/search_corpus_scope_test.go
+++ b/internal/mcp/search_corpus_scope_test.go
@@ -1,0 +1,137 @@
+package mcp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+	"github.com/zzet/gortex/internal/search"
+)
+
+// newWorkspaceRootBoundServer builds the shared-workspace-root shape zzet's
+// PR-484 review calls out: r1 + r2 share a workspace via slug under one
+// parent root, z lives elsewhere in its own workspace with a content
+// body in the content index. Returns a server whose session, when dialed
+// from root, binds to the shared workspace with an empty home repo.
+func newWorkspaceRootBoundServer(t *testing.T) (s *Server, root string) {
+	t.Helper()
+	writeRepo := func(dir string) {
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, "main.go"),
+			[]byte("package main\n\nfunc Hello() {}\n"), 0o644))
+	}
+	root = t.TempDir()
+	r1 := filepath.Join(root, "r1")
+	r2 := filepath.Join(root, "r2")
+	writeRepo(r1)
+	writeRepo(r2)
+	z := setupMiniRepo(t, "z")
+
+	tmpCfg := filepath.Join(t.TempDir(), "config.yaml")
+	gc := &config.GlobalConfig{
+		Repos: []config.RepoEntry{
+			{Path: r1, Name: "r1", Workspace: "shared"},
+			{Path: r2, Name: "r2", Workspace: "shared"},
+			{Path: z, Name: "z"},
+		},
+	}
+	gc.SetConfigPath(tmpCfg)
+	require.NoError(t, gc.Save())
+	cm, err := config.NewConfigManager(tmpCfg)
+	require.NoError(t, err)
+
+	store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "s.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	reg := parser.NewRegistry()
+	reg.Register(languages.NewGoExtractor())
+	mi := indexer.NewMultiIndexer(store, reg, search.NewBM25(), cm, zap.NewNop())
+	_, err = mi.IndexAll()
+	require.NoError(t, err)
+
+	// A content node owned by z, with its body in the content index.
+	store.AddNode(&graph.Node{
+		ID:         "z/doc.txt::doc:section-0",
+		Kind:       graph.KindDoc,
+		FilePath:   "z/doc.txt",
+		RepoPrefix: "z",
+		Meta:       map[string]any{"data_class": "content", "section_text": "snippet"},
+	})
+	require.NoError(t, store.AppendContent("z", []graph.ContentFTSItem{
+		{NodeID: "z/doc.txt::doc:section-0", FilePath: "z/doc.txt", Body: "the zzleakterm appears only here"},
+	}))
+	require.NoError(t, store.BuildContentIndex())
+
+	return &Server{
+		graph:        store,
+		multiIndexer: mi,
+		session:      newSessionState(),
+		tokenStats:   &tokenStats{},
+		symHistory:   &symbolHistory{entries: make(map[string][]SymbolModification)},
+		sessions:     newSessionMap(),
+		toolScopes:   newScopeRegistry(),
+	}, root
+}
+
+// TestMergeContentChannel_WorkspaceRootSessionStaysInWorkspace: a session
+// bound to a shared workspace by its ROOT cwd carries an empty repo
+// prefix — the content channel must not let that empty prefix widen the
+// content search across every workspace. A content body indexed under a
+// repo in ANOTHER workspace must stay invisible to the bound session.
+func TestMergeContentChannel_WorkspaceRootSessionStaysInWorkspace(t *testing.T) {
+	s, root := newWorkspaceRootBoundServer(t)
+	ctx := WithSessionCWD(context.Background(), root)
+
+	// Precondition: the root cwd binds to the shared workspace with an
+	// empty home repo — the exact state the leak needs.
+	ws, _, bound := s.sessionScope(ctx)
+	require.True(t, bound, "workspace-root session must bind")
+	repoPrefix, _ := s.sessionLocality(ctx)
+	require.Empty(t, repoPrefix, "multi-repo workspace-root binding has no home repo")
+	require.NotContains(t, ws, unresolvedWorkspacePrefix)
+
+	merged := s.mergeContentChannel(ctx, "zzleakterm", nil, 10)
+	for _, n := range merged {
+		require.NotEqual(t, "z/doc.txt::doc:section-0", n.ID,
+			"content from another workspace must not leak into a bound workspace-root session")
+	}
+
+	// Control: an unbound session (no cwd) keeps the pre-existing
+	// whole-graph behavior. Fresh server: session scope caches on the
+	// default session state, so reusing s would replay the bound scope.
+	s2, _ := newWorkspaceRootBoundServer(t)
+	unbound := s2.mergeContentChannel(context.Background(), "zzleakterm", nil, 10)
+	var ids []string
+	for _, n := range unbound {
+		ids = append(ids, n.ID)
+	}
+	require.Contains(t, ids, "z/doc.txt::doc:section-0",
+		"unbound sessions keep the server-default whole-graph content channel")
+}
+
+// TestActiveProjectName_WorkspaceRootBindingHidesServerDefault: a cwd
+// that binds to a shared workspace resolves with an EMPTY project — the
+// initialize instructions must not fall through to the server-wide
+// active project, which may live outside the session's bound workspace.
+func TestActiveProjectName_WorkspaceRootBindingHidesServerDefault(t *testing.T) {
+	s, root := newWorkspaceRootBoundServer(t)
+	s.activeProject = "elsewhere"
+
+	require.Empty(t, s.activeProjectName(root),
+		"a bound-empty project must not advertise the server-wide default")
+
+	// An uncovered cwd keeps the pre-existing fallback.
+	require.Equal(t, "elsewhere", s.activeProjectName(filepath.Join(t.TempDir(), "nowhere")))
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1442,7 +1442,11 @@ func (s *Server) activeProjectName(cwd string) string {
 		return ""
 	}
 	if strings.TrimSpace(cwd) != "" {
-		if _, proj, _, ok := s.multiIndexer.ScopeForCWD(cwd); ok && proj != "" {
+		if _, proj, _, ok := s.multiIndexer.ScopeForCWD(cwd); ok {
+			// A resolved cwd owns the answer either way: a multi-repo
+			// workspace-root binding resolves with an empty project, and
+			// falling through to the server-wide default would advertise
+			// a project the session's bound scope may not even see.
 			return proj
 		}
 	}


### PR DESCRIPTION
Fixes the fallback loop root-caused in https://github.com/zzet/gortex/pull/480#issuecomment-5214702976: a session whose cwd *contains* tracked repos (a workspace root like `<root>` over `<root>/projects/<repo>`) was classified untracked by both gates — `isCWDTracked` and `ScopeForCWD` only tested one direction of containment — so every `tools/call` got `-32000 repo_not_tracked` while the hook layer kept steering the agent to MCP.

Two coordinated changes:

- **`ScopeForCWD` gains a reverse-containment fallback.** When cwd is inside no tracked repo, repos rooted *under* it are collected: exactly one repo → its full scope (home repo included, locality ranking intact); several repos sharing one effective workspace → workspace-bound session with no home repo; repos spanning different workspaces → still fail closed, since a single-workspace session scope can't express the union and widening silently would cross the isolation boundary.
- **`cwdReachable` delegates to `ScopeForCWD`** instead of duplicating containment logic, so the dispatcher gate and the session scope can never disagree again: the gate admits a session exactly when the scope can bind it. `isCWDTracked` keeps its strict "inside a repo" meaning (its parent-must-not-count pin still passes).

Tests: three-layout scope test (single nested repo / shared-workspace pair / mixed-workspace pair), a case-variant workspace-root pin (the #277 folding scenario one level up), and a dispatcher test covering both the pass and the mixed-workspace refusal. Full indexer/mcp/cmd suites show failure sets identical to main on Windows.

Validated live on my box in both shapes — a root above a single repo and a root above two repos sharing a config-assigned workspace slug — with cross-workspace isolation confirmed intact and my C# fixture battery unchanged.

Judgment calls I want to flag rather than hide:

1. With a single tracked repo, *any* ancestor cwd (even a drive root) now binds to it. Consistent with single-repo mode's allow-everything, but say the word if you'd rather see a depth bound.
2. A parent spanning multiple workspaces still gets `repo_not_tracked` while the hook orientation advertises fan-out for it — narrower inconsistency than before, not zero. Multi-workspace sessions would be the real fix and felt out of scope here.
3. Multi-repo binding leaves `projectID` empty even when the repos share a project.
