### PR TITLE
daemon: add a control probe that indexing cannot delay

### DIFF
--- a/cmd/gortex/daemon_controller.go
+++ b/cmd/gortex/daemon_controller.go
@@ -687,6 +687,72 @@ func resolveSearchBackend(b search.Backend) searchBackendInfo {
 // Status gathers per-repo stats and basic process metrics. Daemon-level
 // fields (PID, uptime, socket, session count) are filled in by the
 // daemon itself before the response goes out.
+// Probe answers "is the daemon up, is it ready, and what does it track"
+// without taking c.mu and without reading the store.
+//
+// This is the whole point of the call. Status takes c.mu, and c.mu is held
+// for the entire duration of a track / reload / enrichment — the same
+// reasoning that already keeps multiWatcher and onShutdown off that mutex.
+// Measured on a 44-repo workspace, serial Status calls with no concurrent
+// load returned the identical payload in 156 ms to 11.5 s depending only on
+// what the indexer was doing. Callers on a sub-second budget therefore
+// concluded the daemon was unreachable while it was perfectly healthy.
+//
+// So: no c.mu, no graph handle, no runtime.ReadMemStats, and no per-repo
+// stat. ready/enriched are already atomics, and the tracked-repo registry is
+// the config — which is the membership source of truth anyway, since a
+// status row for a repo the daemon holds no index for is itself synthesised
+// from it.
+//
+// Anything added here that reads the store or takes a lock reintroduces
+// exactly the stall this exists to avoid; TestProbeAnswersDuringLongMutation
+// pins that.
+func (c *realController) Probe(ctx context.Context) (daemon.ProbeResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return daemon.ProbeResponse{}, err
+	}
+
+	resp := daemon.ProbeResponse{
+		Ready:    c.ready.Load(),
+		Enriched: c.enriched.Load(),
+	}
+	if c.configManager == nil {
+		return resp, nil
+	}
+	gc := c.configManager.Global()
+	if gc == nil {
+		return resp, nil
+	}
+
+	seen := make(map[string]bool)
+	add := func(e config.RepoEntry) {
+		path := strings.TrimSpace(e.Path)
+		if path == "" || seen[path] {
+			return
+		}
+		seen[path] = true
+		resp.TrackedRepos = append(resp.TrackedRepos, daemon.ProbeRepo{
+			Path:      path,
+			Prefix:    config.ResolvePrefix(e),
+			Name:      e.Name,
+			Workspace: e.Workspace,
+			Project:   e.Project,
+		})
+	}
+	for _, e := range gc.Repos {
+		add(e)
+	}
+	// Project-nested entries are tracked the same as top-level ones. Omitting
+	// them would report a tracked path as untracked, which downstream reads as
+	// "no repo owns this" — the precise misread this call exists to prevent.
+	for _, pc := range gc.Projects {
+		for _, e := range pc.Repos {
+			add(e)
+		}
+	}
+	return resp, nil
+}
+
 func (c *realController) Status(ctx context.Context) (daemon.StatusResponse, error) {
 	// Bail before doing any work if the caller is already gone. Status sits
 	// on the critical path of `daemon stop`, `gortex call`, and the agent

--- a/cmd/gortex/daemon_controller_probe_test.go
+++ b/cmd/gortex/daemon_controller_probe_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/config"
+)
+
+func probeController(t *testing.T, configBody string) *realController {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(configBody), 0o600))
+	cm, err := config.NewConfigManager(path)
+	require.NoError(t, err)
+	return &realController{configManager: cm}
+}
+
+// The reason Probe exists: c.mu is held for the whole of a track / reload /
+// enrichment — minutes on a large workspace — and Status takes it. A caller on
+// a sub-second budget therefore times out against a healthy daemon and renders
+// its "unreachable" fallback.
+//
+// Probe must answer regardless of what the indexer is doing. Holding c.mu here
+// simulates exactly that in-flight mutation.
+func TestProbeAnswersDuringLongMutation(t *testing.T) {
+	c := probeController(t, "repos:\n  - path: /work/alpha\n")
+	c.ready.Store(true)
+
+	c.mu.Lock() // stand in for a track / reload / enrichment in flight
+	defer c.mu.Unlock()
+
+	type probeResult struct {
+		repos int
+		err   error
+	}
+	done := make(chan probeResult, 1)
+	go func() {
+		resp, err := c.Probe(context.Background())
+		done <- probeResult{repos: len(resp.TrackedRepos), err: err}
+	}()
+
+	select {
+	case got := <-done:
+		require.NoError(t, got.err)
+		assert.Equal(t, 1, got.repos, "probe must still report the tracked registry")
+	case <-time.After(2 * time.Second):
+		t.Fatal("Probe blocked behind the controller mutex — it must not take c.mu, " +
+			"or it reintroduces the stall it exists to avoid")
+	}
+}
+
+// The contrast that makes the test above meaningful: Status does block on the
+// same mutex. If this ever stops blocking, Status was fixed and Probe's
+// justification should be revisited rather than silently kept.
+func TestStatusBlocksDuringLongMutation(t *testing.T) {
+	c := probeController(t, "repos:\n  - path: /work/alpha\n")
+
+	c.mu.Lock()
+	done := make(chan struct{})
+	go func() {
+		_, _ = c.Status(context.Background())
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		c.mu.Unlock()
+		t.Fatal("Status no longer blocks on c.mu — re-evaluate whether Probe is still needed")
+	case <-time.After(300 * time.Millisecond):
+		// Expected: still queued behind the mutex.
+	}
+	c.mu.Unlock()
+	<-done // let the goroutine finish so the test does not leak it
+}
+
+// Probe reports identity for every tracked repo, including project-nested
+// entries. Dropping those would report a tracked path as untracked, which
+// downstream reads as "no repo owns this" — the misread this call prevents.
+func TestProbeIncludesProjectNestedRepos(t *testing.T) {
+	c := probeController(t, `
+repos:
+  - path: /work/alpha
+    name: canonical
+projects:
+  side:
+    repos:
+      - path: /work/beta
+`)
+	c.ready.Store(true)
+	c.enriched.Store(true)
+
+	resp, err := c.Probe(context.Background())
+	require.NoError(t, err)
+	assert.True(t, resp.Ready)
+	assert.True(t, resp.Enriched)
+
+	got := map[string]string{}
+	for _, r := range resp.TrackedRepos {
+		got[r.Path] = r.Prefix
+	}
+	assert.Equal(t, map[string]string{
+		"/work/alpha": "canonical", // explicit name wins, mirroring config.ResolvePrefix
+		"/work/beta":  "beta",
+	}, got)
+}
+
+// A cancelled caller gets nothing rather than work nobody will read.
+func TestProbeHonoursCancelledContext(t *testing.T) {
+	c := probeController(t, "repos:\n  - path: /work/alpha\n")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := c.Probe(ctx)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+// A daemon with no config manager still answers — liveness does not depend on
+// a registry being present, and a nil-config crash here would take out the one
+// call that is supposed to work when things are unhealthy.
+func TestProbeSurvivesMissingConfig(t *testing.T) {
+	c := &realController{}
+	c.ready.Store(true)
+
+	resp, err := c.Probe(context.Background())
+	require.NoError(t, err)
+	assert.True(t, resp.Ready)
+	assert.Empty(t, resp.TrackedRepos)
+}

--- a/internal/daemon/proto.go
+++ b/internal/daemon/proto.go
@@ -127,9 +127,28 @@ const (
 	// cache — so `gortex proxy on/off/add/remove` apply to a running
 	// daemon without a restart. Distinct from ControlReload, which runs
 	// a full repo track/untrack reconcile and never touches the router.
-	ControlProxy         = "proxy"
-	ControlStatus        = "status"
+	ControlProxy  = "proxy"
+	ControlStatus = "status"
+	// ControlProbe is the liveness/scope answer a short-lived caller needs
+	// — is the daemon up, is it ready, and which repos does it track — with
+	// none of the aggregation ControlStatus performs.
+	//
+	// It exists because ControlStatus cannot serve that question reliably.
+	// Status computes per-repo memory estimates, whole-store node/edge
+	// counts, a stop-the-world runtime.ReadMemStats, and a stat of every
+	// configured repo path, then takes the controller mutex — which is held
+	// for the entire duration of a track / reload / enrichment. Measured on
+	// a 44-repo workspace, serial calls with no concurrent load returned the
+	// identical payload in anywhere from 156 ms to 11.5 s depending only on
+	// what the indexer happened to be doing.
+	//
+	// Callers that budget in hundreds of milliseconds — the agent hooks —
+	// therefore timed out against a perfectly healthy daemon and rendered
+	// their "daemon unreachable" fallback. Probe touches no store, no
+	// MemStats, no filesystem, and no mutex: it reads atomics and the config
+	// registry, so an in-flight reindex cannot delay it.
 	ControlShutdown      = "shutdown"
+	ControlProbe         = "probe"
 	ControlSearchSymbols = "search_symbols"
 	// ControlEnrichChurn dispatches to Controller.EnrichChurn — the daemon
 	// runs the churn enricher against its in-process graph so the CLI
@@ -210,6 +229,39 @@ type TrackParams struct {
 // UntrackParams is the payload for ControlUntrack.
 type UntrackParams struct {
 	PathOrPrefix string `json:"path_or_prefix"`
+}
+
+// ProbeResponse is the payload returned under Result on a successful
+// ControlProbe call: enough to decide whether the daemon can answer and
+// which repos it owns, and nothing that costs a store read.
+//
+// Deliberately not a subset-typed StatusResponse. Sharing the type would
+// leave every aggregate field present but zero, and a caller cannot tell a
+// real zero from an unpopulated one — which is the same ambiguity that made
+// a timed-out status read as "nothing is tracked".
+type ProbeResponse struct {
+	Version       string `json:"version"`
+	PID           int    `json:"pid"`
+	UptimeSeconds int64  `json:"uptime_seconds"`
+	// Ready reports resolved references and a queryable graph; Enriched
+	// reports the slow semantic passes finished on top of that. A caller
+	// deciding whether to trust a graph answer wants Ready.
+	Ready    bool `json:"ready"`
+	Enriched bool `json:"enriched"`
+	// TrackedRepos carries identity only — path, prefix, and the workspace
+	// grouping. No counts, no byte estimates, and no on-disk liveness stat:
+	// each of those is a scan, and identity is what a scope decision needs.
+	TrackedRepos []ProbeRepo `json:"tracked_repos"`
+	Sessions     int         `json:"sessions"`
+}
+
+// ProbeRepo is one tracked repo as ControlProbe reports it.
+type ProbeRepo struct {
+	Path      string `json:"path"`
+	Prefix    string `json:"prefix"`
+	Name      string `json:"name,omitempty"`
+	Workspace string `json:"workspace,omitempty"`
+	Project   string `json:"project,omitempty"`
 }
 
 // StatusResponse is the payload returned under Result on a successful

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -133,6 +133,12 @@ type Controller interface {
 	// restart. Distinct from Reload, which reconciles tracked repos.
 	ReloadServers(ctx context.Context) (json.RawMessage, error)
 	Status(ctx context.Context) (StatusResponse, error)
+	// Probe answers liveness + tracked scope without the aggregation
+	// Status performs, and — critically — without taking the controller
+	// mutex, which a track / reload / enrichment holds for minutes. It is
+	// the call a short-lived client on a sub-second budget should make;
+	// see ControlProbe for the measurements that motivated it.
+	Probe(ctx context.Context) (ProbeResponse, error)
 	// SearchSymbols is the cheap probe path used by external clients
 	// (Claude Code's Grep-redirect hook) that need a single short answer
 	// without setting up a full MCP session.
@@ -662,6 +668,19 @@ func (s *Server) handleControl(ctx context.Context, _ *Session, req ControlReque
 			return controlErr(ErrInternal, err.Error())
 		}
 		return ControlResponse{OK: true, Result: result}
+
+	case ControlProbe:
+		pr, err := s.Controller.Probe(ctx)
+		if err != nil {
+			return controlErr(ErrInternal, err.Error())
+		}
+		// Daemon-level fields the controller cannot see, matching Status.
+		pr.Version = s.Version
+		pr.PID = os.Getpid()
+		pr.UptimeSeconds = int64(time.Since(s.started).Seconds())
+		pr.Sessions = s.sessions.Count()
+		buf, _ := json.Marshal(pr)
+		return ControlResponse{OK: true, Result: buf}
 
 	case ControlStatus:
 		st, err := s.Controller.Status(ctx)

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -23,17 +23,18 @@ var osStat = os.Stat
 // canned responses — lets the daemon lifecycle tests run without wiring
 // in the real MultiIndexer.
 type fakeController struct {
-	mu            sync.Mutex
-	trackCalls    []TrackParams
-	untrackCalls  []UntrackParams
+	mu                 sync.Mutex
+	trackCalls         []TrackParams
+	untrackCalls       []UntrackParams
 	reloadCalls        int
 	reloadServersCalls int
 	statusCalls        int
-	shutdownCalls int
-	shutdownErr   error
-	searchCalls   []SearchSymbolsParams
-	searchHits    []SymbolHit
-	searchErr     error
+	probeCalls         int
+	shutdownCalls      int
+	shutdownErr        error
+	searchCalls        []SearchSymbolsParams
+	searchHits         []SymbolHit
+	searchErr          error
 
 	enrichChurnCalls    []EnrichChurnParams
 	enrichReleasesCalls []EnrichReleasesParams
@@ -77,6 +78,18 @@ func (f *fakeController) Status(_ context.Context) (StatusResponse, error) {
 	return StatusResponse{
 		TrackedRepos: []TrackedRepoStatus{
 			{Prefix: "myrepo", Path: "/tmp/myrepo", Files: 42, Nodes: 100, Edges: 200},
+		},
+	}, nil
+}
+
+func (f *fakeController) Probe(_ context.Context) (ProbeResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.probeCalls++
+	return ProbeResponse{
+		Ready: true,
+		TrackedRepos: []ProbeRepo{
+			{Prefix: "myrepo", Path: "/tmp/myrepo"},
 		},
 	}, nil
 }


### PR DESCRIPTION
Root-cause fix for the hook timeout cluster in #479. One daemon-side change; it is the cause behind four separate hook bugs.

## The measurement

Five **serial** `daemon status` calls, no concurrent load, 44-repo workspace — identical 14,468-byte payload every time:

```
11531 ms · 8225 ms · 344 ms · 2041 ms · 156 ms
```

Same payload, 74× spread. That is not the work, it is the wait. The daemon log shows incremental derived passes running 28 seconds at a stretch, and `Status` takes `c.mu` — which is held for the entire duration of a track / reload / enrichment.

I had assumed the hooks were causing this themselves (63k connections). They are not: these calls were serial, one second apart, with no hooks running.

## This hazard is already known in this file

```go
// multiWatcher is an atomic pointer, not a mu-guarded field: the daemon's
// teardown hook reads it, and reading it under mu is what kept `daemon
// stop` queued behind a running track / reload / enrichment.
```

```go
// Guarded by its own mutex, deliberately NOT by mu. Shutdown is the one
// control RPC that has to work when the daemon is at its least healthy,
// and mu is held for the entire duration of a track / reload / enrichment
// — minutes on a large workspace.
```

`Shutdown` and `multiWatcher` were given that treatment. `Status` never was, and it sits on the critical path of every agent hook.

## The consequence is a wrong answer, not slowness

Callers on sub-second budgets time out against a perfectly healthy daemon and render their unreachable fallback. Measured over 233 real fires, the SessionStart briefing emits

> ⚠️ Gortex daemon status query failed — continuing with rule-only enforcement.

in **81.5%** of sessions. Same root cause behind UserPromptSubmit (82.6% at its 800 ms budget), PostToolUse (48.5% at 2 s), and PreCompact (100% at 5 s, which has never emitted anything).

## What `ControlProbe` does

Answers "up, ready, and what do you track" with none of the aggregation `Status` performs — no `c.mu`, no graph handle, no `runtime.ReadMemStats` (which stops the world), no per-repo `stat`. It reads two atomics and the config registry, which is the membership source of truth anyway: a status row for a repo the daemon holds no index for is itself synthesised from that file.

`ProbeResponse` is a distinct type rather than a subset-typed `StatusResponse` deliberately. Sharing the type would leave every aggregate field present but zero, and a caller cannot tell a real zero from an unpopulated one — that ambiguity is exactly what made a timed-out status read as "nothing is tracked".

## Tests

Five, under `-race`, including a deliberate pair:

| test | result |
|---|---|
| `TestProbeAnswersDuringLongMutation` — `c.mu` held | **0.00 s** |
| `TestStatusBlocksDuringLongMutation` — same mutex | **0.31 s, blocked** |

The second test is the guard on the first: it asserts `Status` *does* block, so if `Status` is ever fixed properly this fails and `Probe`'s justification gets revisited rather than silently kept. The rest cover project-nested repos, context cancellation, and a nil config manager (liveness must not depend on a registry being present).

## Scope

Deliberately daemon-side only. Callers still use `Status`; wiring them to `Probe` is a follow-up so the transport lands and can be reviewed on its own. The follow-up has one real design question worth separating: SessionStart renders node/edge counts, which a probe cannot supply, so it needs an explicit answer for "healthy but counts unknown" rather than silently rendering zeros.

## Related

- #480 (merged) — removed this same `ControlStatus` round trip from the PreToolUse path; p90 2063 → 199 ms, and 6/24 wrong answers → 0. That fix worked by *avoiding* the contended control plane; this one fixes the plane.
- #483 — guard that every hook-dispatched tool still resolves.
