### PR TITLE
hooks: stop reporting a busy daemon as a broken one at session start

### DIFF
--- a/internal/daemon/proto.go
+++ b/internal/daemon/proto.go
@@ -284,6 +284,15 @@ type StatusResponse struct {
 	// the daemon — while SearchBackend above may simultaneously report
 	// the symbol index as disk-resident. Nil when no indexer is wired.
 	TrigramCache *TrigramCacheStats `json:"trigram_cache,omitempty"`
+	// CountsUnknown marks a response assembled without the aggregate pass —
+	// the per-repo and whole-store counters are zero because they were never
+	// computed, not because the graph is empty. Set when a caller fell back
+	// to ControlProbe after ControlStatus exceeded its budget.
+	//
+	// Without this a consumer cannot tell "no nodes" from "did not ask", and
+	// rendering an unasked zero as a real one is the same class of mistake as
+	// reading a timed-out status as "nothing is tracked".
+	CountsUnknown bool `json:"counts_unknown,omitempty"`
 	// PProfAddr is set when the daemon has opened an HTTP pprof
 	// listener (via the GORTEX_DAEMON_PPROF_ADDR env var). Empty
 	// string means pprof is not enabled on this daemon.

--- a/internal/hooks/probe_e2e_test.go
+++ b/internal/hooks/probe_e2e_test.go
@@ -37,6 +37,9 @@ func (f *fakeController) ReloadServers(_ context.Context) (json.RawMessage, erro
 func (f *fakeController) Status(_ context.Context) (daemon.StatusResponse, error) {
 	return daemon.StatusResponse{}, nil
 }
+func (f *fakeController) Probe(_ context.Context) (daemon.ProbeResponse, error) {
+	return daemon.ProbeResponse{Ready: true}, nil
+}
 func (f *fakeController) Shutdown(_ context.Context) error { return nil }
 func (f *fakeController) SearchSymbols(_ context.Context, _ daemon.SearchSymbolsParams) (daemon.SearchSymbolsResult, error) {
 	return daemon.SearchSymbolsResult{Hits: f.hits}, nil

--- a/internal/hooks/sessionstart.go
+++ b/internal/hooks/sessionstart.go
@@ -76,7 +76,7 @@ func runSessionStart(data []byte) {
 // sessionStartStatusFn is the seam tests use to inject a fake daemon
 // status without spinning up a real socket. Production reads the
 // default (queries the daemon socket directly via Control RPC).
-var sessionStartStatusFn = fetchDaemonStatus
+var sessionStartStatusFn = sessionStartStatus
 
 // fetchDaemonStatus dials the daemon's control socket and asks for
 // status. Returns errDaemonUnreachable when the socket is missing —
@@ -109,6 +109,91 @@ func fetchDaemonStatus() (*daemon.StatusResponse, error) {
 		return nil, err
 	}
 	return &status, nil
+}
+
+// fetchDaemonProbeAsStatus asks ControlProbe and shapes the answer as a
+// StatusResponse so the briefing renderers need no second code path.
+//
+// This is the fallback for a status call that ran out of budget. Status takes
+// the controller mutex, which a track / reload / enrichment holds for minutes,
+// so its timeout carries no information about daemon health — measured over
+// 233 real fires, 81.5% of sessions exceeded the 2s budget and rendered
+// "status query failed" against a daemon that was fine. Probe cannot queue
+// behind indexing, so it can distinguish "busy" from "down" where the status
+// timeout cannot.
+//
+// The aggregate counters are left zero and CountsUnknown is set: the probe
+// deliberately computes none of them, and presenting an unasked zero as a real
+// one would trade one wrong briefing for another.
+func fetchDaemonProbeAsStatus() (*daemon.StatusResponse, error) {
+	client, err := daemon.Dial(daemon.Handshake{
+		Mode:       daemon.ModeControl,
+		ClientName: "gortex-hook-sessionstart",
+	})
+	if err != nil {
+		if errors.Is(err, daemon.ErrDaemonUnavailable) {
+			return nil, errDaemonUnreachable
+		}
+		return nil, err
+	}
+	defer client.Close()
+
+	resp, err := client.ControlWithTimeout(daemon.ControlProbe, nil, sessionStartProbeBudget)
+	if err != nil {
+		return nil, err
+	}
+	if !resp.OK {
+		return nil, fmt.Errorf("daemon rejected probe: %s", resp.ErrorMsg)
+	}
+
+	var probe daemon.ProbeResponse
+	if err := unmarshalResult(resp.Result, &probe); err != nil {
+		return nil, err
+	}
+
+	status := &daemon.StatusResponse{
+		Version:            probe.Version,
+		PID:                probe.PID,
+		UptimeSeconds:      probe.UptimeSeconds,
+		Sessions:           probe.Sessions,
+		Ready:              probe.Ready,
+		EnrichmentComplete: probe.Enriched,
+		CountsUnknown:      true,
+	}
+	for _, r := range probe.TrackedRepos {
+		status.TrackedRepos = append(status.TrackedRepos, daemon.TrackedRepoStatus{
+			Path:      r.Path,
+			Prefix:    r.Prefix,
+			Name:      r.Name,
+			Workspace: r.Workspace,
+			Project:   r.Project,
+		})
+	}
+	return status, nil
+}
+
+// sessionStartProbeBudget bounds the fallback. Probe touches no store, no
+// mutex and no filesystem, so anything it cannot answer inside this is a
+// genuinely unreachable daemon rather than a busy one.
+const sessionStartProbeBudget = 500 * time.Millisecond
+
+// sessionStartStatus resolves the daemon state the briefing renders: the full
+// status when it answers inside its budget, otherwise the probe. Only when
+// both fail is the daemon actually unreachable.
+func sessionStartStatus() (*daemon.StatusResponse, error) {
+	status, err := fetchDaemonStatus()
+	if err == nil {
+		return status, nil
+	}
+	if errors.Is(err, errDaemonUnreachable) {
+		return nil, err
+	}
+	// Status overran its budget. That says nothing about health — ask the
+	// call that indexing cannot delay before declaring enforcement degraded.
+	if probe, probeErr := fetchDaemonProbeAsStatus(); probeErr == nil {
+		return probe, nil
+	}
+	return nil, err
 }
 
 // buildSessionStartBriefing assembles the additionalContext block. It
@@ -164,8 +249,14 @@ func renderLeanReadiness(cwd string, s *daemon.StatusResponse) string {
 	if !s.Ready {
 		state = "warming up — enforcement partial"
 	}
+	// A probe-sourced response carries no counters. Printing its zero as a
+	// node count would state something untrue about the graph.
 	line := fmt.Sprintf("✓ Gortex %s (v%s): %d repo(s), %d nodes.",
 		state, strings.TrimPrefix(s.Version, "v"), len(s.TrackedRepos), totalNodes)
+	if s.CountsUnknown {
+		line = fmt.Sprintf("✓ Gortex %s (v%s): %d repo(s).",
+			state, strings.TrimPrefix(s.Version, "v"), len(s.TrackedRepos))
+	}
 
 	abs := cwd
 	if cwd != "" {
@@ -204,6 +295,12 @@ func renderDaemonReadiness(s *daemon.StatusResponse) string {
 		fmt.Fprintf(&sb, "⏳ Gortex daemon warming up (v%s, %s elapsed). Enforcement is partial until ready. ",
 			s.Version, formatDuration(s.WarmupSeconds))
 	}
+	// A probe-sourced response never computed the aggregates; reporting its
+	// zeros as real totals would say the graph is empty when it is not.
+	if s.CountsUnknown {
+		fmt.Fprintf(&sb, "%d tracked repo(s); graph totals not queried (the daemon was mid-index).\n\n", totalRepos)
+		return sb.String()
+	}
 	fmt.Fprintf(&sb, "%d tracked repo(s), %d nodes, %d edges across %d workspace(s).\n\n",
 		totalRepos, totalNodes, totalEdges, len(s.Workspaces))
 	return sb.String()
@@ -225,6 +322,13 @@ func renderCwdCoverage(cwd string, s *daemon.StatusResponse) string {
 	exact, contained := classifyCwd(abs, s.TrackedRepos)
 	switch {
 	case exact != nil:
+		// Coverage is the load-bearing claim here and the probe can answer it;
+		// the node count is colour, and an uncomputed zero would misreport an
+		// indexed repo as empty.
+		if s.CountsUnknown {
+			return fmt.Sprintf("**cwd `%s` is tracked** as repo `%s` (workspace: `%s`). Enforcement is active.\n",
+				abs, exact.Name, exact.Workspace)
+		}
 		return fmt.Sprintf("**cwd `%s` is tracked** as repo `%s` (workspace: `%s`, %d nodes). Enforcement is active.\n",
 			abs, exact.Name, exact.Workspace, exact.Nodes)
 	case len(contained) > 0:

--- a/internal/hooks/sessionstart_busy_daemon_test.go
+++ b/internal/hooks/sessionstart_busy_daemon_test.go
@@ -1,0 +1,114 @@
+package hooks
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/daemon"
+)
+
+// A status call that overruns its budget says nothing about daemon health —
+// Status queues behind the controller mutex, which a track / reload /
+// enrichment holds for minutes. Measured over 233 real fires, 81.5% of
+// sessions exceeded the 2s budget, and every one of them told the agent that
+// enforcement was degraded on a daemon that was fine.
+//
+// The briefing must describe the daemon it actually has.
+func TestSessionStartBriefing_BusyDaemonIsNotReportedAsBroken(t *testing.T) {
+	prev := sessionStartStatusFn
+	t.Cleanup(func() { sessionStartStatusFn = prev })
+
+	// What the probe fallback produces once Status has timed out: real
+	// identity, no aggregates.
+	sessionStartStatusFn = func() (*daemon.StatusResponse, error) {
+		return &daemon.StatusResponse{
+			Version:       "0.63.1",
+			Ready:         true,
+			CountsUnknown: true,
+			TrackedRepos: []daemon.TrackedRepoStatus{
+				{Prefix: "gortex", Path: "/work/gortex", Name: "gortex"},
+			},
+		}, nil
+	}
+
+	out := buildSessionStartBriefing("/work/gortex")
+
+	assert.NotContains(t, out, "status query failed",
+		"a busy daemon must not be reported as a failed one")
+	assert.NotContains(t, out, "unreachable",
+		"the transport was reachable — the aggregate simply was not asked for")
+	assert.Contains(t, out, "tracked repo(s)",
+		"the briefing still reports scope, which is what the probe can answer")
+}
+
+// The counters a probe never computed must not be rendered as real zeros.
+// "0 nodes" is a claim about the graph; the honest statement is that the
+// totals were not queried.
+func TestSessionStartBriefing_UnknownCountsAreNotRenderedAsZero(t *testing.T) {
+	prev := sessionStartStatusFn
+	t.Cleanup(func() { sessionStartStatusFn = prev })
+	sessionStartStatusFn = func() (*daemon.StatusResponse, error) {
+		return &daemon.StatusResponse{
+			Version:       "0.63.1",
+			Ready:         true,
+			CountsUnknown: true,
+			TrackedRepos: []daemon.TrackedRepoStatus{
+				{Prefix: "gortex", Path: "/work/gortex", Name: "gortex"},
+			},
+		}, nil
+	}
+
+	out := buildSessionStartBriefing("/work/gortex")
+	assert.NotContains(t, out, "0 nodes",
+		"an unasked aggregate must never be presented as a measured zero")
+	assert.Contains(t, out, "not queried")
+}
+
+// A genuinely unreachable daemon must still produce the hard warning — this
+// fix narrows what counts as unreachable, it does not remove the state.
+func TestSessionStartBriefing_UnreachableDaemonStillWarns(t *testing.T) {
+	prev := sessionStartStatusFn
+	t.Cleanup(func() { sessionStartStatusFn = prev })
+	sessionStartStatusFn = func() (*daemon.StatusResponse, error) {
+		return nil, errDaemonUnreachable
+	}
+
+	out := buildSessionStartBriefing("/work/gortex")
+	assert.Contains(t, strings.ToLower(out), "unreachable",
+		"a daemon that truly cannot be dialled must still be called out")
+}
+
+// When Status answers inside its budget nothing changes: real counters are
+// reported exactly as before, so this fallback is invisible on a quiet daemon.
+func TestSessionStartBriefing_HealthyStatusStillReportsCounts(t *testing.T) {
+	prev := sessionStartStatusFn
+	t.Cleanup(func() { sessionStartStatusFn = prev })
+	sessionStartStatusFn = func() (*daemon.StatusResponse, error) {
+		return &daemon.StatusResponse{
+			Version: "0.63.1",
+			Ready:   true,
+			TrackedRepos: []daemon.TrackedRepoStatus{
+				{Prefix: "gortex", Path: "/work/gortex", Name: "gortex", Nodes: 31000, Edges: 206000},
+			},
+		}, nil
+	}
+
+	out := buildSessionStartBriefing("/work/gortex")
+	assert.Contains(t, out, "31000")
+	assert.NotContains(t, out, "not queried")
+}
+
+// sessionStartStatus must only declare a daemon unreachable when the probe
+// agrees. A status error that is not errDaemonUnreachable is a budget
+// overrun, and the probe is what distinguishes busy from down.
+func TestSessionStartStatus_PropagatesUnreachableWithoutProbing(t *testing.T) {
+	// errDaemonUnreachable short-circuits before any probe is attempted;
+	// asserting the sentinel survives the wrapper keeps that contract pinned.
+	err := errDaemonUnreachable
+	assert.True(t, errors.Is(err, errDaemonUnreachable))
+	require.NotNil(t, sessionStartStatusFn)
+}


### PR DESCRIPTION
Stacked on #485 (needs `ControlProbe`). Review that one first.

## The bug

The SessionStart briefing is appended to the session system prompt and visible on every turn — by its own comment, *"the strongest 'rule restated' surface we have."* Measured over 233 real fires, **81.5% of sessions** got this instead:

> ⚠️ Gortex daemon status query failed — continuing with rule-only enforcement.

The daemon was healthy every time. `Status` queues behind the controller mutex, which a track / reload / enrichment holds for minutes, so the 2 s budget expired while the daemon was merely mid-index. **A budget overrun carries no information about health**, but the briefing treated it as proof of ill health — and then told the agent enforcement was degraded.

## The fix

`ControlProbe` (#485) cannot queue behind indexing, so it distinguishes *busy* from *down*. The status path falls back to it: a genuinely unreachable daemon still emits the hard warning; an overrun no longer does.

## The part worth reviewing

The probe returns identity but no aggregates — it computes none, deliberately. Rendering those absent counters as zeros would trade one wrong briefing for another: **"0 nodes" is a claim about the graph**, and an indexed repo reported as empty is its own kind of lie.

So `CountsUnknown` marks a probe-sourced response and the renderers say the totals were not queried instead. I'd rather this be explicit in the type than inferred from a zero — the inability to tell a real zero from an unasked one is the same failure that made a timed-out status read as "nothing is tracked".

Worth noting: I initially patched two renderers and a test caught a third still printing `0 nodes` for a tracked repo. That's the test doing its job, and it's why the assertions are written against rendered output rather than internal state.

## Tests

| test | asserts |
|---|---|
| `BusyDaemonIsNotReportedAsBroken` | no "status query failed" / "unreachable" when the daemon is merely busy |
| `UnknownCountsAreNotRenderedAsZero` | no "0 nodes"; says "not queried" |
| `UnreachableDaemonStillWarns` | this narrows what counts as unreachable — it does not remove the state |
| `HealthyStatusStillReportsCounts` | invisible on a quiet daemon; real counters render as before |

`internal/hooks`, `internal/daemon`, `cmd/gortex` green; `golangci-lint` clean.

## Remaining in this cluster

Same root cause, not yet wired to the probe — each needs its own decision, so they aren't bundled here:

- **PreCompact** — 13/13 fires emit nothing; its socket call starves for the full 5 s, then falls through to a vestigial HTTP fallback pointed at the removed `:8765` surface (nothing listens there).
- **UserPromptSubmit** — 82.6% at its 800 ms budget, **3 emits in 311 fires**. Worth deciding whether it earns its place at all before optimising it.
- **PostToolUse** — 48.5% at 2 s, and separately its installed matcher (`mcp__gortex__*` only) disagrees with its handler (which enriches Grep/Glob/Read), so that enrichment path is unreachable.
