### PR TITLE
daemon: stop the cheap probe path waiting out a reindex

### DIFF
--- a/cmd/gortex/daemon_controller.go
+++ b/cmd/gortex/daemon_controller.go
@@ -37,8 +37,19 @@ import (
 // Methods are serialized via a mutex — track/reload can race with status
 // otherwise. The mutex is coarse; finer locking is a later optimization.
 type realController struct {
-	mu            sync.Mutex
-	graph         graph.Store
+	mu sync.Mutex
+	// graph is assigned once when the controller is constructed and never
+	// reassigned, so reading it requires no synchronisation — and must not
+	// take mu. Taking mu for a handle that cannot change bought nothing and
+	// cost everything: mu is held for the entire duration of a track /
+	// reload / enrichment, so the "cheap probe path" the hooks depend on
+	// (SearchSymbols) queued behind minutes of indexing. Measured, the
+	// UserPromptSubmit probe exceeded its 800ms budget on 82.6% of turns.
+	//
+	// Mutating operations still take mu; they serialise indexer work, not
+	// this pointer. If this field ever becomes reassignable, it needs an
+	// atomic — not mu — for the same reason multiWatcher already uses one.
+	graph graph.Store
 	indexer       *indexer.Indexer
 	multiIndexer  *indexer.MultiIndexer
 	configManager *config.ConfigManager
@@ -770,9 +781,7 @@ func (c *realController) Status(ctx context.Context) (daemon.StatusResponse, err
 	// advisory counts and byte estimates intentionally remain zero. Once
 	// enriched, snapshot the graph handle under a brief lock and run the
 	// exact (store-memoised) estimates without holding the controller mutex.
-	c.mu.Lock()
-	g := c.graph
-	c.mu.Unlock()
+	g := c.graph // write-once at construction; see the field comment
 	enriched := c.enriched.Load()
 	var memEstimates map[string]graph.RepoMemoryEstimate
 	var wholeStoreNodes, wholeStoreEdges int
@@ -1269,9 +1278,10 @@ const (
 // shard writers and blew past the hook's 200ms budget. The hook then logged
 // probed_miss / timed_out and never once produced a hit.
 func (c *realController) SearchSymbols(_ context.Context, p daemon.SearchSymbolsParams) (daemon.SearchSymbolsResult, error) {
-	c.mu.Lock()
+	// No mu: graph is write-once at construction (see the field comment), and
+	// this is the probe path a hook calls on a sub-second budget. Taking mu
+	// here is what made it wait out an in-flight reindex.
 	g := c.graph
-	c.mu.Unlock()
 
 	if g == nil || p.Query == "" {
 		return daemon.SearchSymbolsResult{}, nil

--- a/cmd/gortex/daemon_controller_search_mutation_test.go
+++ b/cmd/gortex/daemon_controller_search_mutation_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/daemon"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// SearchSymbols is documented on the Controller interface as "the cheap probe
+// path used by external clients (Claude Code's Grep-redirect hook) that need a
+// single short answer without setting up a full MCP session".
+//
+// It was not cheap. It took c.mu to read a handle that is assigned once at
+// construction and never reassigned, and c.mu is held for the entire duration
+// of a track / reload / enrichment. So the cheapest call in the tree waited
+// out the most expensive operation in the daemon: measured, the
+// UserPromptSubmit probe that depends on it exceeded its 800ms budget on
+// 82.6% of turns, which reads downstream as "no hits" rather than "ask later".
+func TestSearchSymbolsAnswersDuringLongMutation(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID: "pkg/a.go::Widget", Kind: graph.KindType, Name: "Widget",
+		FilePath: "pkg/a.go", Language: "go",
+	})
+	c := &realController{graph: g}
+
+	c.mu.Lock() // stand in for a track / reload / enrichment in flight
+	defer c.mu.Unlock()
+
+	type searchResult struct {
+		res daemon.SearchSymbolsResult
+		err error
+	}
+	done := make(chan searchResult, 1)
+	go func() {
+		res, err := c.SearchSymbols(context.Background(), daemon.SearchSymbolsParams{Query: "Widget"})
+		done <- searchResult{res: res, err: err}
+	}()
+
+	select {
+	case got := <-done:
+		require.NoError(t, got.err)
+		assert.NotEmpty(t, got.res.Hits,
+			"the probe must still answer from the graph while the indexer is busy")
+	case <-time.After(2 * time.Second):
+		t.Fatal("SearchSymbols blocked behind the controller mutex — the hook probe path " +
+			"must not take c.mu, or it waits out every reindex")
+	}
+}


### PR DESCRIPTION
Stacked on #487 → #485. Review those first.

## The finding

`SearchSymbols` is documented on the `Controller` interface as:

> the cheap probe path used by external clients (Claude Code's Grep-redirect hook) that need a single short answer **without setting up a full MCP session**

It was not cheap. It opened with:

```go
c.mu.Lock()
g := c.graph
c.mu.Unlock()
```

`c.graph` is assigned once when the controller is constructed and **never reassigned** — there is no `c.graph = ` anywhere in the package. So the lock protected an immutable field, while `c.mu` is held for the entire duration of a track / reload / enrichment. The cheapest call in the tree waited out the most expensive operation in the daemon.

## Why this matters beyond latency

You asked me to verify whether UserPromptSubmit earns its place, given **3 emits in 311 fires (1.0%)** and 82.6% dying at its 800 ms budget.

It doesn't earn removal on that evidence, because that evidence was produced by this bug. UserPromptSubmit's probe goes through `SearchSymbols`, so its budget was being consumed by an unnecessary mutex, and a starved probe returns *no hits* — which reads downstream as "the graph had nothing to offer" rather than "the daemon was busy". That's the same wrong conclusion the session briefing was drawing from its own timeout.

**The feature has never had a fair trial.** I'd fix this first and re-measure its emit rate before deciding — deleting it now would be removing something that was starved, not tested. If it's still ~1% on a healthy daemon, removal is well-founded and I'll do it.

## The change

The handle is read without the mutex, and the invariant is stated on the field — including what to do if it ever becomes reassignable (an atomic, not `mu`, matching `multiWatcher`, which is already documented as atomic for exactly this reason). `Status` takes the same snapshot and is fixed alongside. Mutating operations still take `mu`; they serialise indexer work, not this pointer.

## Tests

`TestSearchSymbolsAnswersDuringLongMutation` — answers from the graph while `c.mu` is held, under `-race`. Full `cmd/gortex` suite green under `-race`; `golangci-lint` clean.

## Cluster status

This is the third and last daemon-side fix for the starvation root cause:

| | |
|---|---|
| #485 | `ControlProbe` — liveness/scope without the aggregate pass or `c.mu` |
| #487 | SessionStart stops reporting a busy daemon as broken (81.5% of sessions) |
| **this** | the probe path itself no longer queues behind indexing |

Still open, each needing its own decision: **PreCompact** (13/13 fires emit nothing; starves 5 s then falls through to a dead HTTP fallback), **PostToolUse** (matcher/handler disagreement makes its enrichment path unreachable), and **re-measuring UserPromptSubmit** once this lands.
