### PR TITLE
testpath: match directory markers case-insensitively

### DIFF
--- a/internal/testpath/testpath.go
+++ b/internal/testpath/testpath.go
@@ -51,16 +51,22 @@ var dirMarkers = []string{"__tests__", "tests", "test", "spec"}
 //	*Tests.swift                       (Swift)
 //	*Test.php / *test.php              (PHPUnit / Pest)
 //	files under __tests__/, tests/,
-//	  test/, spec/                     (any language using these dirs)
+//	  test/, spec/                     (any language using these dirs;
+//	                                    matched case-insensitively)
 func IsTestFile(path string) bool {
 	if path == "" {
 		return false
 	}
 	// Directory-based hints first — covers projects that don't follow
-	// the per-file naming convention.
+	// the per-file naming convention. Markers match case-insensitively:
+	// .NET solutions capitalize their test directories (Test/, Tests/)
+	// and often name the files beneath them without a Test suffix, so a
+	// case-sensitive scan left every symbol in them stamped as
+	// production code.
 	slashed := strings.ReplaceAll(path, `\`, "/")
+	folded := strings.ToLower(slashed)
 	for _, marker := range dirMarkers {
-		if strings.Contains(slashed, "/"+marker+"/") || strings.HasPrefix(slashed, marker+"/") {
+		if strings.Contains(folded, "/"+marker+"/") || strings.HasPrefix(folded, marker+"/") {
 			return true
 		}
 	}

--- a/internal/testpath/testpath_test.go
+++ b/internal/testpath/testpath_test.go
@@ -54,6 +54,18 @@ func TestIsTestFile(t *testing.T) {
 		// Directory markers must be whole path segments.
 		{"src/testing/helper.go", false},
 		{"src/spectrum/color.ts", false},
+
+		// Directory markers match case-insensitively. .NET solutions
+		// capitalize test directories (Test/, Tests/), and the files
+		// beneath them frequently don't carry a Test/Tests filename
+		// suffix — the marker is the only signal.
+		{"App/Test/Unit/CalculatorProbe.cs", true},
+		{`App\Tests\Support\Builder.cs`, true},
+		{"Test/main.cs", true},
+
+		// The whole-segment rule holds case-insensitively too.
+		{"src/Testing/helper.go", false},
+		{"src/Spectrum/color.ts", false},
 	}
 	for _, c := range cases {
 		if got := IsTestFile(c.path); got != c.want {


### PR DESCRIPTION
In .NET solutions, test directories are capitalized (`Test/`, `Tests/`) and the files beneath them often carry no `Test`/`Tests` filename suffix — the directory is the only signal. `testpath.IsTestFile` folds backslashes but compares its directory markers case-sensitively, so every symbol under such directories is stamped as production code: `is_test=false`, empty `test_role`/`test_runner`, and `find_usages` reporting `n_test_refs=0` on a production C# codebase where ~20 of 25 consumer files were MSTest/xUnit projects.

Fix: fold the slash-normalized path to lower case for the marker scan only. Filename conventions keep their case-sensitive suffix rules (`*Test.java` vs `*test.php` distinctions are untouched), and the whole-segment discipline holds case-insensitively (`Testing/`, `Spectrum/` still don't match).

Since indexer stamping, resolver dispatch exclusion, impact attribution, and review ranking all funnel through this one predicate, the single change fixes `is_test`, `test_role`, `test_runner`, and `n_test_refs` together.

Suites: failure name sets identical to main across testpath / analysis / indexer / resolver / mcp / review / cmd on Windows. Also verified end-to-end against a live store with capital-`Test/` MSTest and xUnit fixture files in my counted C# fixture repo: pre-fix they classify as production (only a `*Tests.cs`-suffixed control file gets stamped), which is exactly the bug this fixes.
