### PR TITLE
mcp: fill find_implementations' GCX edges section

### DIFF
--- a/internal/mcp/find_implementations_edges_test.go
+++ b/internal/mcp/find_implementations_edges_test.go
@@ -1,0 +1,56 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/query"
+)
+
+// find_implementations' GCX payload promises a `.nodes` AND a `.edges`
+// section (wire-format.md). The handler used to wrap the node list in
+// an edge-less SubGraph, so the two halves disagreed: an implementation
+// in `.nodes` with `edges count=0` right underneath. The edges carry
+// the evidence (origin/confidence) — they must survive to the client.
+func TestFindImplementations_GCXCarriesImplementsEdges(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "pkg/i.go::Storer", Kind: graph.KindInterface, Name: "Storer", FilePath: "pkg/i.go", Language: "go"})
+	g.AddNode(&graph.Node{ID: "pkg/s.go::DiskStore", Kind: graph.KindType, Name: "DiskStore", FilePath: "pkg/s.go", Language: "go"})
+	g.AddEdge(&graph.Edge{
+		From: "pkg/s.go::DiskStore", To: "pkg/i.go::Storer",
+		Kind: graph.EdgeImplements, Confidence: 0.95, Origin: "ast_resolved",
+	})
+
+	idx := indexer.New(g, testRegistry(), config.Default().Index, zap.NewNop())
+	srv := NewServer(query.NewEngine(g), g, idx, nil, zap.NewNop(), nil)
+
+	req := mcplib.CallToolRequest{}
+	req.Params.Name = "find_implementations"
+	req.Params.Arguments = map[string]any{"id": "pkg/i.go::Storer", "format": "gcx"}
+
+	result, err := srv.handleFindImplementations(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	text := result.Content[0].(mcplib.TextContent).Text
+
+	assert.Contains(t, text, "DiskStore", "implementation node must be present")
+	assert.Contains(t, text, "implements", "edges section must carry the implements edge: %s", text)
+	assert.False(t, strings.Contains(text, "count=0"),
+		"edges section must not be empty when implementations exist: %s", text)
+
+	// The enrich pass fills display fields on the payload copies — the
+	// edge stored in the graph must stay untouched (Origin empty until a
+	// resolver stamps it), or a read would mutate shared state.
+	stored := g.GetInEdges("pkg/i.go::Storer")
+	require.Len(t, stored, 1)
+	assert.Empty(t, stored[0].Tier, "read path must not write display fields onto the stored edge")
+}

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -2569,7 +2569,7 @@ func (s *Server) handleFindImplementations(ctx context.Context, req mcp.CallTool
 	if errResult != nil {
 		return errResult, nil
 	}
-	impls := s.engineFor(ctx).FindImplementationsMinTier(id, minTier)
+	impls, implEdges := s.engineFor(ctx).FindImplementationsWithEdgesMinTier(id, minTier)
 	// Confine results to the session's workspace — FindImplementations
 	// doesn't take QueryOptions, so the boundary is enforced here.
 	impls = s.scopedNodeSlice(ctx, impls)
@@ -2577,7 +2577,25 @@ func (s *Server) handleFindImplementations(ctx context.Context, req mcp.CallTool
 	impls = s.withAbsPaths(impls)
 
 	if s.isGCX(ctx, req) {
-		sg := &query.SubGraph{Nodes: impls, TotalNodes: len(impls)}
+		// Keep only the implements-edges whose implementation survived
+		// the scope filters, so the `.edges` section always agrees with
+		// `.nodes` — an edge to a node the session can't see would leak
+		// the boundary the filters just enforced. Copies, not the live
+		// graph edges: enrichSubGraphEdges writes display fields, and a
+		// read path must never mutate shared graph state.
+		keep := make(map[string]bool, len(impls))
+		for _, n := range impls {
+			keep[n.ID] = true
+		}
+		var edges []*graph.Edge
+		for _, edge := range implEdges {
+			if keep[edge.From] {
+				c := *edge
+				edges = append(edges, &c)
+			}
+		}
+		sg := &query.SubGraph{Nodes: impls, Edges: edges, TotalNodes: len(impls), TotalEdges: len(edges)}
+		enrichSubGraphEdges(sg)
 		return s.returnScopedSubGraph(ctx, req, sg, resolved)
 	}
 

--- a/internal/query/engine.go
+++ b/internal/query/engine.go
@@ -343,8 +343,19 @@ func (e *Engine) FindOverridden(methodID string) []*graph.Node {
 // graph.OriginLSPDispatch (or higher) to restrict to compiler-verified
 // interface dispatches.
 func (e *Engine) FindImplementationsMinTier(interfaceID, minTier string) []*graph.Node {
+	impls, _ := e.FindImplementationsWithEdgesMinTier(interfaceID, minTier)
+	return impls
+}
+
+// FindImplementationsWithEdgesMinTier additionally returns the
+// implements-edges the node list was derived from, index-aligned by
+// construction (edges[i].From == impls[i].ID). Callers rendering a
+// subgraph need them — the wire format's `.edges` section carries the
+// evidence tier (origin/confidence) that the bare node list drops.
+func (e *Engine) FindImplementationsWithEdgesMinTier(interfaceID, minTier string) ([]*graph.Node, []*graph.Edge) {
 	edges := e.g.GetInEdges(interfaceID)
 	var impls []*graph.Node
+	var kept []*graph.Edge
 	for _, edge := range edges {
 		if edge.Kind != graph.EdgeImplements {
 			continue
@@ -361,9 +372,10 @@ func (e *Engine) FindImplementationsMinTier(interfaceID, minTier string) []*grap
 		}
 		if n := e.g.GetNode(edge.From); n != nil {
 			impls = append(impls, n)
+			kept = append(kept, edge)
 		}
 	}
-	return impls
+	return impls, kept
 }
 
 // FindUsages returns all nodes that reference a symbol.

--- a/internal/query/engine_test.go
+++ b/internal/query/engine_test.go
@@ -156,6 +156,22 @@ func TestFindImplementations(t *testing.T) {
 	assert.Equal(t, "DBImpl", impls[0].Name)
 }
 
+// The implements-edges behind the node list must be retrievable too —
+// find_implementations' wire format promises a `.edges` section
+// (from/to/kind/origin/confidence), and the handler can only fill it
+// if the engine hands the edges over instead of dropping them after
+// the walk.
+func TestFindImplementationsWithEdges(t *testing.T) {
+	e := NewEngine(buildTestGraph())
+
+	impls, edges := e.FindImplementationsWithEdgesMinTier("pkg/db.go::DB", "")
+	require.Len(t, impls, 1)
+	require.Len(t, edges, 1, "one implements edge backs the one implementation")
+	assert.Equal(t, impls[0].ID, edges[0].From)
+	assert.Equal(t, "pkg/db.go::DB", edges[0].To)
+	assert.Equal(t, graph.EdgeImplements, edges[0].Kind)
+}
+
 func TestFindUsages(t *testing.T) {
 	e := NewEngine(buildTestGraph())
 


### PR DESCRIPTION
Field testing `relations(operation:"implementations")` on a production C# codebase returned the correct implementation in `.nodes` with `edges count=0` directly underneath — the two halves of the payload disagreed. Per `docs/wire-format.md`, `find_implementations` emits two sections, `.nodes` then `.edges` (`from,to,kind,origin,confidence,label`), so the empty section is a spec violation, and it drops exactly the evidence (`origin`/`confidence`) that distinguishes a compiler-verified implementation from an inferred one.

Cause: `handleFindImplementations` wraps the engine's node list in an edge-less `SubGraph` for the GCX path. The engine walks the `implements` edges to build that list and then discards them.

Fix: `FindImplementationsWithEdgesMinTier` returns the edges alongside the nodes (the existing method delegates to it, so the five node-only callers are untouched), and the handler attaches only the edges whose implementation survived the session's workspace-scope filters — `.edges` now agrees with `.nodes` by construction in both directions (no missing edges, no boundary leaks). Same `enrichSubGraphEdges` pass the class-hierarchy handler uses.

The attached edges are copies, not the live graph edges: `enrichSubGraphEdges` fills display fields (`Origin`/`Tier`/`ConfidenceLabel`/`Via`), and a read path must never write into shared graph state — matching the node-side "copied, never mutated" contract in `returnSubGraph`. A test pins the stored edge staying untouched, and I mutation-verified the pin (passing the live pointer instead makes it fail).

Tests: an engine-level pair test, plus a handler-level GCX test that reproduces the exact `count=0` symptom against the old code. `-race` clean on both packages. JSON/TOON output shapes are untouched. This also fixes `gortex query implementations`, which routes through the same handler.
