### PR TITLE
csharp: emit interface base-list extends edges

### DIFF
--- a/internal/indexer/extractor_version.go
+++ b/internal/indexer/extractor_version.go
@@ -32,7 +32,7 @@ var extractorVersions = map[string]int{
 	//   "go": 2,
 	"c":      generatedParserProjectionPolicyVersion, // generated parser projection covers all strictly detected table sizes
 	"php":    2,                                      // class/interface inheritance now emits typed structural edges
-	"csharp": 7,                                      // record positional parameters emit property nodes (was: record members extracted)
+	"csharp": 8,                                      // interface base lists emit extends edges (was: record positional property nodes)
 }
 
 // extractorSaltExtLang maps a lower-case file extension to the language

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -723,12 +723,12 @@ func (e *CSharpExtractor) emitContainer(m parser.QueryResult, kind string, nodeK
 	})
 	emitCSharpAnnotationEdges(csharpCollectAttributes(def.Node, src), id, filePath, result, annotationSeen)
 	emitCSharpGenericParamNodes(id, def.Node, src, filePath, def.StartLine+1, result)
-	// Only classes, structs, and records carry a base class / interface
-	// list that splits into EdgeExtends + EdgeImplements. Structs and
-	// `record struct` declarations have no base class — every base is an
-	// interface — which emitCSharpBaseList infers from the declaration.
+	// Classes, structs, records, and interfaces carry a base list;
+	// emitCSharpBaseList derives each entry's edge kind from the
+	// declaration (base class vs interface for classes, all-interface
+	// for structs and records, inheritance for interfaces).
 	switch kind {
-	case "class", "struct", "record":
+	case "class", "struct", "record", "iface":
 		emitCSharpBaseList(id, def.Node, src, filePath, localInterfaces, result)
 	case "enum":
 		e.emitCSharpEnumMembers(def.Node, src, filePath, id, name, result, seen)
@@ -1599,6 +1599,8 @@ func collectCSharpInterfaceNames(root *sitter.Node, src []byte) map[string]bool 
 
 // emitCSharpBaseList splits a class/struct/record base list into
 // EdgeExtends (the superclass) and EdgeImplements (the interfaces).
+// An interface's base list bypasses that split entirely — see the
+// short-circuit below.
 //
 // C# lists the optional base class and any implemented interfaces in a
 // single comma-separated base_list, and — unlike Go or Java — the
@@ -1644,6 +1646,10 @@ func emitCSharpBaseList(typeID string, decl *sitter.Node, src []byte, filePath s
 	// Structs and `record struct` cannot derive from a base class — the
 	// CLR forbids it — so every entry in their base list is an interface
 	// and the "first non-interface is the superclass" branch never runs.
+	// An interface's bases can only be interfaces, and the relation is
+	// inheritance — every entry rides EdgeExtends (the same convention
+	// the semantic engine applies), bypassing the discrimination below.
+	ifaceDecl := decl.Type() == "interface_declaration"
 	allowsBaseClass := csharpDeclAllowsBaseClass(decl)
 	extendsTaken := false
 	for i, _nc := 0, int(baseList.NamedChildCount()); i < _nc; i++ {
@@ -1662,7 +1668,10 @@ func emitCSharpBaseList(typeID string, decl *sitter.Node, src []byte, filePath s
 		isInterface := !isCtorBase &&
 			(localInterfaces[name] || csharpInterfaceNamePattern.MatchString(name))
 		kind := graph.EdgeImplements
-		if !isInterface && allowsBaseClass && !extendsTaken {
+		switch {
+		case ifaceDecl:
+			kind = graph.EdgeExtends
+		case !isInterface && allowsBaseClass && !extendsTaken:
 			kind = graph.EdgeExtends
 			extendsTaken = true
 		}

--- a/internal/parser/languages/csharp_test.go
+++ b/internal/parser/languages/csharp_test.go
@@ -737,6 +737,77 @@ class Panel : Widget {}`)
 	})
 }
 
+// TestCSharpExtractor_InterfaceBaseList: an interface declaration's
+// base list is interface inheritance — every entry must emit
+// EdgeExtends at the same inferred tier as the class path. Without
+// these edges a derived interface has no hierarchy in the base graph.
+func TestCSharpExtractor_InterfaceBaseList(t *testing.T) {
+	e := NewCSharpExtractor()
+
+	t.Run("single base interface", func(t *testing.T) {
+		src := []byte(`interface IDerived : IBase {}`)
+		result, err := e.Extract("D.cs", src)
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{"IBase"},
+			edgeTargetNames(result.Edges, "D.cs::IDerived", graph.EdgeExtends))
+		assert.Empty(t, edgeTargetNames(result.Edges, "D.cs::IDerived", graph.EdgeImplements))
+	})
+
+	t.Run("generic base strips type arguments", func(t *testing.T) {
+		// Type params on the declaring interface and a where-clause
+		// (a base_list sibling in the grammar) must not disturb the
+		// entry walk.
+		src := []byte(`interface ILedger<T> : IReadRepository<T> where T : class {}`)
+		result, err := e.Extract("L.cs", src)
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{"IReadRepository"},
+			edgeTargetNames(result.Edges, "L.cs::ILedger", graph.EdgeExtends))
+	})
+
+	t.Run("qualified base keeps target_fqn for namespace narrowing", func(t *testing.T) {
+		src := []byte(`interface IHandle : System.IDisposable {}`)
+		result, err := e.Extract("H.cs", src)
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{"IDisposable"},
+			edgeTargetNames(result.Edges, "H.cs::IHandle", graph.EdgeExtends))
+		for _, ed := range result.Edges {
+			if ed.From == "H.cs::IHandle" && ed.Kind == graph.EdgeExtends {
+				assert.Equal(t, "System.IDisposable", ed.Meta["target_fqn"])
+			}
+		}
+	})
+
+	t.Run("multiple bases all extend", func(t *testing.T) {
+		src := []byte(`interface IBoth : IReader, IWriter {}`)
+		result, err := e.Extract("B.cs", src)
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{"IReader", "IWriter"},
+			edgeTargetNames(result.Edges, "B.cs::IBoth", graph.EdgeExtends))
+	})
+
+	t.Run("inferred tier and no edges without a base list", func(t *testing.T) {
+		src := []byte(`interface IDerived : IBase {}
+interface IPlain {}`)
+		result, err := e.Extract("T.cs", src)
+		require.NoError(t, err)
+
+		found := false
+		for _, ed := range result.Edges {
+			if ed.From == "T.cs::IDerived" && ed.Kind == graph.EdgeExtends {
+				found = true
+				assert.Equal(t, graph.OriginASTInferred, ed.Origin)
+			}
+		}
+		assert.True(t, found, "IDerived must emit an extends edge")
+		assert.Empty(t, edgeTargetNames(result.Edges, "T.cs::IPlain", graph.EdgeExtends))
+		assert.Empty(t, edgeTargetNames(result.Edges, "T.cs::IPlain", graph.EdgeImplements))
+	})
+}
+
 // TestCSharpEnumMembersConstsAndFlags is the C8 test: enum members extract as
 // navigable nodes (with values), `const` fields classify as constants,
 // async/static/readonly/value-type flags are stamped, and types/methods carry


### PR DESCRIPTION
# csharp: emit interface base-list extends edges

## What

`emitCSharpBaseList` only ran for `class` / `struct` / `record` declarations, so an interface's base list produced no edges at all: `interface IDerivedRepository : IReadRepository<Widget>` left `IDerivedRepository` with **no hierarchy edge in the graph**.

This PR adds `iface` to the base-list switch. For an interface declaration every base-list entry is an interface and the relation is inheritance, so each entry emits `EdgeExtends` — bypassing the class-path extends/implements discrimination (which exists only because a class base list doesn't syntactically tag which entry is the base class). This matches the semantic engine's convention (`csharpSupertypes`: "An interface's bases can only be interfaces" → `EdgeExtends`), so `applySuper` confirms/retargets the extractor edge in-kind instead of adding a parallel one. Generic bases already reduce through `csharpBaseTypeName` (`IReadRepository<Widget>` → `IReadRepository`), and qualified spellings keep their `target_fqn` stamp for namespace narrowing, same as the class path.

## Why it matters

Without the edge, interface inheritance is invisible to everything that walks declared hierarchy before (or without) semantic enrichment:

- The interface-dispatch family builder (`ResolveCSharpInterfaceDispatch`) builds its subtype adjacency from declared `implements`/`extends` edges and deliberately skips method-set-inference edges — so a dispatch family could never span interface inheritance for C#.
- Inherited-member resolution through a receiver typed as the derived interface has no path to the base interface's members.
- `find_implementations` / hierarchy walks stop at the derived interface; base interfaces show up as unused (no inbound extends).

The tree-sitter types engine can backfill the edge from the AST (`applySuper`), but that only helps files a semantic enrichment pass has actually covered; the base extraction should carry the declared hierarchy on its own.

Found while investigating unresolved member calls through constructor-injected fields typed as a derived repository interface on a production C# codebase, reproduced in a counted C# fixture repo.

## Change

- `internal/parser/languages/csharp.go`: `iface` added to the base-list switch in `emitContainer`; `emitCSharpBaseList` emits `EdgeExtends` for every entry when the declaration is an `interface_declaration`. Same `unresolved::` targets, same `OriginASTInferred` tier as the class path — the resolver binds them like every other C# reference.
- `internal/indexer/extractor_version.go`: `csharp` 7 → 8 — a new edge kind for already-indexed files is exactly the registry's bump trigger; without it, persisted stores would re-extract only edited files and carry a mixed graph.

## Interactions reviewed

- **Dispatch-family cap**: interface-inheritance closure grows `csharp-iface-dispatch` families. Measured on a production C# codebase (~6k files, 334 declared interface-inheritance links): largest of 2,923 families is 59 members — well under the 128 cap, none dropped.
- **`applySuper` dedup**: the extractor edge is claimable and `trailingNameMatches` strips the `unresolved::` prefix, so enrichment retargets + confirms in place; no duplicate edges (visible only as `EdgesAdded` shifting to `EdgesConfirmed` in enrich metrics).
- **Cross-package guard**: extends edges are not call-like; out of scope, never reverted.
- Two small pre-existing/adjacent items surfaced during review, kept out of this PR deliberately: method-set inference can mint an inferred `implements` parallel to a declared interface `extends` (its dedup set only checks `implements` pairs), and the entry-point controller-base scan would accept an interface extending a repo-local type literally named `Controller`. Happy to follow up on either.

## Tests

- New `TestCSharpExtractor_InterfaceBaseList` (5 subtests): single base, generic base with declaring-interface type params + where-clause, qualified base with `target_fqn` assertion (first pin of that stamp), multiple bases, tier + no-base-list control. Watched fail before the fix (nil edges), green after.
- Existing `TestCSharpExtractor_BaseListDiscrimination` unchanged and green — class/struct/record behavior is untouched.
- Full parser / resolver / semantic / contracts / mcp / query / graph / indexer suites: failure name-sets identical to a clean checkout on this Windows box (pre-existing platform failures only, stash-verified).
