### PR TITLE
daemon: keep the control plane answerable while indexing runs

### DIFF
--- a/cmd/gortex/daemon_controller.go
+++ b/cmd/gortex/daemon_controller.go
@@ -37,8 +37,19 @@ import (
 // Methods are serialized via a mutex — track/reload can race with status
 // otherwise. The mutex is coarse; finer locking is a later optimization.
 type realController struct {
-	mu            sync.Mutex
-	graph         graph.Store
+	mu sync.Mutex
+	// graph is assigned once when the controller is constructed and never
+	// reassigned, so reading it requires no synchronisation — and must not
+	// take mu. Taking mu for a handle that cannot change bought nothing and
+	// cost everything: mu is held for the entire duration of a track /
+	// reload / enrichment, so the "cheap probe path" the hooks depend on
+	// (SearchSymbols) queued behind minutes of indexing. Measured, the
+	// UserPromptSubmit probe exceeded its 800ms budget on 82.6% of turns.
+	//
+	// Mutating operations still take mu; they serialise indexer work, not
+	// this pointer. If this field ever becomes reassignable, it needs an
+	// atomic — not mu — for the same reason multiWatcher already uses one.
+	graph graph.Store
 	indexer       *indexer.Indexer
 	multiIndexer  *indexer.MultiIndexer
 	configManager *config.ConfigManager
@@ -687,6 +698,72 @@ func resolveSearchBackend(b search.Backend) searchBackendInfo {
 // Status gathers per-repo stats and basic process metrics. Daemon-level
 // fields (PID, uptime, socket, session count) are filled in by the
 // daemon itself before the response goes out.
+// Probe answers "is the daemon up, is it ready, and what does it track"
+// without taking c.mu and without reading the store.
+//
+// This is the whole point of the call. Status takes c.mu, and c.mu is held
+// for the entire duration of a track / reload / enrichment — the same
+// reasoning that already keeps multiWatcher and onShutdown off that mutex.
+// Measured on a 44-repo workspace, serial Status calls with no concurrent
+// load returned the identical payload in 156 ms to 11.5 s depending only on
+// what the indexer was doing. Callers on a sub-second budget therefore
+// concluded the daemon was unreachable while it was perfectly healthy.
+//
+// So: no c.mu, no graph handle, no runtime.ReadMemStats, and no per-repo
+// stat. ready/enriched are already atomics, and the tracked-repo registry is
+// the config — which is the membership source of truth anyway, since a
+// status row for a repo the daemon holds no index for is itself synthesised
+// from it.
+//
+// Anything added here that reads the store or takes a lock reintroduces
+// exactly the stall this exists to avoid; TestProbeAnswersDuringLongMutation
+// pins that.
+func (c *realController) Probe(ctx context.Context) (daemon.ProbeResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return daemon.ProbeResponse{}, err
+	}
+
+	resp := daemon.ProbeResponse{
+		Ready:    c.ready.Load(),
+		Enriched: c.enriched.Load(),
+	}
+	if c.configManager == nil {
+		return resp, nil
+	}
+	gc := c.configManager.Global()
+	if gc == nil {
+		return resp, nil
+	}
+
+	seen := make(map[string]bool)
+	add := func(e config.RepoEntry) {
+		path := strings.TrimSpace(e.Path)
+		if path == "" || seen[path] {
+			return
+		}
+		seen[path] = true
+		resp.TrackedRepos = append(resp.TrackedRepos, daemon.ProbeRepo{
+			Path:      path,
+			Prefix:    config.ResolvePrefix(e),
+			Name:      e.Name,
+			Workspace: e.Workspace,
+			Project:   e.Project,
+		})
+	}
+	for _, e := range gc.Repos {
+		add(e)
+	}
+	// Project-nested entries are tracked the same as top-level ones. Omitting
+	// them would report a tracked path as untracked, which downstream reads as
+	// "no repo owns this" — the precise misread this call exists to prevent.
+	for _, pc := range gc.Projects {
+		for _, e := range pc.Repos {
+			add(e)
+		}
+	}
+	return resp, nil
+}
+
 func (c *realController) Status(ctx context.Context) (daemon.StatusResponse, error) {
 	// Bail before doing any work if the caller is already gone. Status sits
 	// on the critical path of `daemon stop`, `gortex call`, and the agent
@@ -704,9 +781,7 @@ func (c *realController) Status(ctx context.Context) (daemon.StatusResponse, err
 	// advisory counts and byte estimates intentionally remain zero. Once
 	// enriched, snapshot the graph handle under a brief lock and run the
 	// exact (store-memoised) estimates without holding the controller mutex.
-	c.mu.Lock()
-	g := c.graph
-	c.mu.Unlock()
+	g := c.graph // write-once at construction; see the field comment
 	enriched := c.enriched.Load()
 	var memEstimates map[string]graph.RepoMemoryEstimate
 	var wholeStoreNodes, wholeStoreEdges int
@@ -1203,9 +1278,10 @@ const (
 // shard writers and blew past the hook's 200ms budget. The hook then logged
 // probed_miss / timed_out and never once produced a hit.
 func (c *realController) SearchSymbols(_ context.Context, p daemon.SearchSymbolsParams) (daemon.SearchSymbolsResult, error) {
-	c.mu.Lock()
+	// No mu: graph is write-once at construction (see the field comment), and
+	// this is the probe path a hook calls on a sub-second budget. Taking mu
+	// here is what made it wait out an in-flight reindex.
 	g := c.graph
-	c.mu.Unlock()
 
 	if g == nil || p.Query == "" {
 		return daemon.SearchSymbolsResult{}, nil

--- a/cmd/gortex/daemon_controller_probe_test.go
+++ b/cmd/gortex/daemon_controller_probe_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/config"
+)
+
+func probeController(t *testing.T, configBody string) *realController {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(configBody), 0o600))
+	cm, err := config.NewConfigManager(path)
+	require.NoError(t, err)
+	return &realController{configManager: cm}
+}
+
+// The reason Probe exists: c.mu is held for the whole of a track / reload /
+// enrichment — minutes on a large workspace — and Status takes it. A caller on
+// a sub-second budget therefore times out against a healthy daemon and renders
+// its "unreachable" fallback.
+//
+// Probe must answer regardless of what the indexer is doing. Holding c.mu here
+// simulates exactly that in-flight mutation.
+func TestProbeAnswersDuringLongMutation(t *testing.T) {
+	c := probeController(t, "repos:\n  - path: /work/alpha\n")
+	c.ready.Store(true)
+
+	c.mu.Lock() // stand in for a track / reload / enrichment in flight
+	defer c.mu.Unlock()
+
+	type probeResult struct {
+		repos int
+		err   error
+	}
+	done := make(chan probeResult, 1)
+	go func() {
+		resp, err := c.Probe(context.Background())
+		done <- probeResult{repos: len(resp.TrackedRepos), err: err}
+	}()
+
+	select {
+	case got := <-done:
+		require.NoError(t, got.err)
+		assert.Equal(t, 1, got.repos, "probe must still report the tracked registry")
+	case <-time.After(2 * time.Second):
+		t.Fatal("Probe blocked behind the controller mutex — it must not take c.mu, " +
+			"or it reintroduces the stall it exists to avoid")
+	}
+}
+
+// The contrast that makes the test above meaningful: Status does block on the
+// same mutex. If this ever stops blocking, Status was fixed and Probe's
+// justification should be revisited rather than silently kept.
+func TestStatusBlocksDuringLongMutation(t *testing.T) {
+	c := probeController(t, "repos:\n  - path: /work/alpha\n")
+
+	c.mu.Lock()
+	done := make(chan struct{})
+	go func() {
+		_, _ = c.Status(context.Background())
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		c.mu.Unlock()
+		t.Fatal("Status no longer blocks on c.mu — re-evaluate whether Probe is still needed")
+	case <-time.After(300 * time.Millisecond):
+		// Expected: still queued behind the mutex.
+	}
+	c.mu.Unlock()
+	<-done // let the goroutine finish so the test does not leak it
+}
+
+// Probe reports identity for every tracked repo, including project-nested
+// entries. Dropping those would report a tracked path as untracked, which
+// downstream reads as "no repo owns this" — the misread this call prevents.
+func TestProbeIncludesProjectNestedRepos(t *testing.T) {
+	c := probeController(t, `
+repos:
+  - path: /work/alpha
+    name: canonical
+projects:
+  side:
+    repos:
+      - path: /work/beta
+`)
+	c.ready.Store(true)
+	c.enriched.Store(true)
+
+	resp, err := c.Probe(context.Background())
+	require.NoError(t, err)
+	assert.True(t, resp.Ready)
+	assert.True(t, resp.Enriched)
+
+	got := map[string]string{}
+	for _, r := range resp.TrackedRepos {
+		got[r.Path] = r.Prefix
+	}
+	assert.Equal(t, map[string]string{
+		"/work/alpha": "canonical", // explicit name wins, mirroring config.ResolvePrefix
+		"/work/beta":  "beta",
+	}, got)
+}
+
+// A cancelled caller gets nothing rather than work nobody will read.
+func TestProbeHonoursCancelledContext(t *testing.T) {
+	c := probeController(t, "repos:\n  - path: /work/alpha\n")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := c.Probe(ctx)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+// A daemon with no config manager still answers — liveness does not depend on
+// a registry being present, and a nil-config crash here would take out the one
+// call that is supposed to work when things are unhealthy.
+func TestProbeSurvivesMissingConfig(t *testing.T) {
+	c := &realController{}
+	c.ready.Store(true)
+
+	resp, err := c.Probe(context.Background())
+	require.NoError(t, err)
+	assert.True(t, resp.Ready)
+	assert.Empty(t, resp.TrackedRepos)
+}

--- a/cmd/gortex/daemon_controller_search_mutation_test.go
+++ b/cmd/gortex/daemon_controller_search_mutation_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/daemon"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// SearchSymbols is documented on the Controller interface as "the cheap probe
+// path used by external clients (Claude Code's Grep-redirect hook) that need a
+// single short answer without setting up a full MCP session".
+//
+// It was not cheap. It took c.mu to read a handle that is assigned once at
+// construction and never reassigned, and c.mu is held for the entire duration
+// of a track / reload / enrichment. So the cheapest call in the tree waited
+// out the most expensive operation in the daemon: measured, the
+// UserPromptSubmit probe that depends on it exceeded its 800ms budget on
+// 82.6% of turns, which reads downstream as "no hits" rather than "ask later".
+func TestSearchSymbolsAnswersDuringLongMutation(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID: "pkg/a.go::Widget", Kind: graph.KindType, Name: "Widget",
+		FilePath: "pkg/a.go", Language: "go",
+	})
+	c := &realController{graph: g}
+
+	c.mu.Lock() // stand in for a track / reload / enrichment in flight
+	defer c.mu.Unlock()
+
+	type searchResult struct {
+		res daemon.SearchSymbolsResult
+		err error
+	}
+	done := make(chan searchResult, 1)
+	go func() {
+		res, err := c.SearchSymbols(context.Background(), daemon.SearchSymbolsParams{Query: "Widget"})
+		done <- searchResult{res: res, err: err}
+	}()
+
+	select {
+	case got := <-done:
+		require.NoError(t, got.err)
+		assert.NotEmpty(t, got.res.Hits,
+			"the probe must still answer from the graph while the indexer is busy")
+	case <-time.After(2 * time.Second):
+		t.Fatal("SearchSymbols blocked behind the controller mutex — the hook probe path " +
+			"must not take c.mu, or it waits out every reindex")
+	}
+}

--- a/internal/daemon/proto.go
+++ b/internal/daemon/proto.go
@@ -127,9 +127,28 @@ const (
 	// cache — so `gortex proxy on/off/add/remove` apply to a running
 	// daemon without a restart. Distinct from ControlReload, which runs
 	// a full repo track/untrack reconcile and never touches the router.
-	ControlProxy         = "proxy"
-	ControlStatus        = "status"
+	ControlProxy  = "proxy"
+	ControlStatus = "status"
+	// ControlProbe is the liveness/scope answer a short-lived caller needs
+	// — is the daemon up, is it ready, and which repos does it track — with
+	// none of the aggregation ControlStatus performs.
+	//
+	// It exists because ControlStatus cannot serve that question reliably.
+	// Status computes per-repo memory estimates, whole-store node/edge
+	// counts, a stop-the-world runtime.ReadMemStats, and a stat of every
+	// configured repo path, then takes the controller mutex — which is held
+	// for the entire duration of a track / reload / enrichment. Measured on
+	// a 44-repo workspace, serial calls with no concurrent load returned the
+	// identical payload in anywhere from 156 ms to 11.5 s depending only on
+	// what the indexer happened to be doing.
+	//
+	// Callers that budget in hundreds of milliseconds — the agent hooks —
+	// therefore timed out against a perfectly healthy daemon and rendered
+	// their "daemon unreachable" fallback. Probe touches no store, no
+	// MemStats, no filesystem, and no mutex: it reads atomics and the config
+	// registry, so an in-flight reindex cannot delay it.
 	ControlShutdown      = "shutdown"
+	ControlProbe         = "probe"
 	ControlSearchSymbols = "search_symbols"
 	// ControlEnrichChurn dispatches to Controller.EnrichChurn — the daemon
 	// runs the churn enricher against its in-process graph so the CLI
@@ -212,6 +231,39 @@ type UntrackParams struct {
 	PathOrPrefix string `json:"path_or_prefix"`
 }
 
+// ProbeResponse is the payload returned under Result on a successful
+// ControlProbe call: enough to decide whether the daemon can answer and
+// which repos it owns, and nothing that costs a store read.
+//
+// Deliberately not a subset-typed StatusResponse. Sharing the type would
+// leave every aggregate field present but zero, and a caller cannot tell a
+// real zero from an unpopulated one — which is the same ambiguity that made
+// a timed-out status read as "nothing is tracked".
+type ProbeResponse struct {
+	Version       string `json:"version"`
+	PID           int    `json:"pid"`
+	UptimeSeconds int64  `json:"uptime_seconds"`
+	// Ready reports resolved references and a queryable graph; Enriched
+	// reports the slow semantic passes finished on top of that. A caller
+	// deciding whether to trust a graph answer wants Ready.
+	Ready    bool `json:"ready"`
+	Enriched bool `json:"enriched"`
+	// TrackedRepos carries identity only — path, prefix, and the workspace
+	// grouping. No counts, no byte estimates, and no on-disk liveness stat:
+	// each of those is a scan, and identity is what a scope decision needs.
+	TrackedRepos []ProbeRepo `json:"tracked_repos"`
+	Sessions     int         `json:"sessions"`
+}
+
+// ProbeRepo is one tracked repo as ControlProbe reports it.
+type ProbeRepo struct {
+	Path      string `json:"path"`
+	Prefix    string `json:"prefix"`
+	Name      string `json:"name,omitempty"`
+	Workspace string `json:"workspace,omitempty"`
+	Project   string `json:"project,omitempty"`
+}
+
 // StatusResponse is the payload returned under Result on a successful
 // ControlStatus call.
 type StatusResponse struct {
@@ -232,6 +284,15 @@ type StatusResponse struct {
 	// the daemon — while SearchBackend above may simultaneously report
 	// the symbol index as disk-resident. Nil when no indexer is wired.
 	TrigramCache *TrigramCacheStats `json:"trigram_cache,omitempty"`
+	// CountsUnknown marks a response assembled without the aggregate pass —
+	// the per-repo and whole-store counters are zero because they were never
+	// computed, not because the graph is empty. Set when a caller fell back
+	// to ControlProbe after ControlStatus exceeded its budget.
+	//
+	// Without this a consumer cannot tell "no nodes" from "did not ask", and
+	// rendering an unasked zero as a real one is the same class of mistake as
+	// reading a timed-out status as "nothing is tracked".
+	CountsUnknown bool `json:"counts_unknown,omitempty"`
 	// PProfAddr is set when the daemon has opened an HTTP pprof
 	// listener (via the GORTEX_DAEMON_PPROF_ADDR env var). Empty
 	// string means pprof is not enabled on this daemon.

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -133,6 +133,12 @@ type Controller interface {
 	// restart. Distinct from Reload, which reconciles tracked repos.
 	ReloadServers(ctx context.Context) (json.RawMessage, error)
 	Status(ctx context.Context) (StatusResponse, error)
+	// Probe answers liveness + tracked scope without the aggregation
+	// Status performs, and — critically — without taking the controller
+	// mutex, which a track / reload / enrichment holds for minutes. It is
+	// the call a short-lived client on a sub-second budget should make;
+	// see ControlProbe for the measurements that motivated it.
+	Probe(ctx context.Context) (ProbeResponse, error)
 	// SearchSymbols is the cheap probe path used by external clients
 	// (Claude Code's Grep-redirect hook) that need a single short answer
 	// without setting up a full MCP session.
@@ -662,6 +668,19 @@ func (s *Server) handleControl(ctx context.Context, _ *Session, req ControlReque
 			return controlErr(ErrInternal, err.Error())
 		}
 		return ControlResponse{OK: true, Result: result}
+
+	case ControlProbe:
+		pr, err := s.Controller.Probe(ctx)
+		if err != nil {
+			return controlErr(ErrInternal, err.Error())
+		}
+		// Daemon-level fields the controller cannot see, matching Status.
+		pr.Version = s.Version
+		pr.PID = os.Getpid()
+		pr.UptimeSeconds = int64(time.Since(s.started).Seconds())
+		pr.Sessions = s.sessions.Count()
+		buf, _ := json.Marshal(pr)
+		return ControlResponse{OK: true, Result: buf}
 
 	case ControlStatus:
 		st, err := s.Controller.Status(ctx)

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -23,17 +23,18 @@ var osStat = os.Stat
 // canned responses — lets the daemon lifecycle tests run without wiring
 // in the real MultiIndexer.
 type fakeController struct {
-	mu            sync.Mutex
-	trackCalls    []TrackParams
-	untrackCalls  []UntrackParams
+	mu                 sync.Mutex
+	trackCalls         []TrackParams
+	untrackCalls       []UntrackParams
 	reloadCalls        int
 	reloadServersCalls int
 	statusCalls        int
-	shutdownCalls int
-	shutdownErr   error
-	searchCalls   []SearchSymbolsParams
-	searchHits    []SymbolHit
-	searchErr     error
+	probeCalls         int
+	shutdownCalls      int
+	shutdownErr        error
+	searchCalls        []SearchSymbolsParams
+	searchHits         []SymbolHit
+	searchErr          error
 
 	enrichChurnCalls    []EnrichChurnParams
 	enrichReleasesCalls []EnrichReleasesParams
@@ -77,6 +78,18 @@ func (f *fakeController) Status(_ context.Context) (StatusResponse, error) {
 	return StatusResponse{
 		TrackedRepos: []TrackedRepoStatus{
 			{Prefix: "myrepo", Path: "/tmp/myrepo", Files: 42, Nodes: 100, Edges: 200},
+		},
+	}, nil
+}
+
+func (f *fakeController) Probe(_ context.Context) (ProbeResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.probeCalls++
+	return ProbeResponse{
+		Ready: true,
+		TrackedRepos: []ProbeRepo{
+			{Prefix: "myrepo", Path: "/tmp/myrepo"},
 		},
 	}, nil
 }

--- a/internal/hooks/probe_e2e_test.go
+++ b/internal/hooks/probe_e2e_test.go
@@ -37,6 +37,9 @@ func (f *fakeController) ReloadServers(_ context.Context) (json.RawMessage, erro
 func (f *fakeController) Status(_ context.Context) (daemon.StatusResponse, error) {
 	return daemon.StatusResponse{}, nil
 }
+func (f *fakeController) Probe(_ context.Context) (daemon.ProbeResponse, error) {
+	return daemon.ProbeResponse{Ready: true}, nil
+}
 func (f *fakeController) Shutdown(_ context.Context) error { return nil }
 func (f *fakeController) SearchSymbols(_ context.Context, _ daemon.SearchSymbolsParams) (daemon.SearchSymbolsResult, error) {
 	return daemon.SearchSymbolsResult{Hits: f.hits}, nil

--- a/internal/hooks/sessionstart.go
+++ b/internal/hooks/sessionstart.go
@@ -76,7 +76,7 @@ func runSessionStart(data []byte) {
 // sessionStartStatusFn is the seam tests use to inject a fake daemon
 // status without spinning up a real socket. Production reads the
 // default (queries the daemon socket directly via Control RPC).
-var sessionStartStatusFn = fetchDaemonStatus
+var sessionStartStatusFn = sessionStartStatus
 
 // fetchDaemonStatus dials the daemon's control socket and asks for
 // status. Returns errDaemonUnreachable when the socket is missing —
@@ -109,6 +109,91 @@ func fetchDaemonStatus() (*daemon.StatusResponse, error) {
 		return nil, err
 	}
 	return &status, nil
+}
+
+// fetchDaemonProbeAsStatus asks ControlProbe and shapes the answer as a
+// StatusResponse so the briefing renderers need no second code path.
+//
+// This is the fallback for a status call that ran out of budget. Status takes
+// the controller mutex, which a track / reload / enrichment holds for minutes,
+// so its timeout carries no information about daemon health — measured over
+// 233 real fires, 81.5% of sessions exceeded the 2s budget and rendered
+// "status query failed" against a daemon that was fine. Probe cannot queue
+// behind indexing, so it can distinguish "busy" from "down" where the status
+// timeout cannot.
+//
+// The aggregate counters are left zero and CountsUnknown is set: the probe
+// deliberately computes none of them, and presenting an unasked zero as a real
+// one would trade one wrong briefing for another.
+func fetchDaemonProbeAsStatus() (*daemon.StatusResponse, error) {
+	client, err := daemon.Dial(daemon.Handshake{
+		Mode:       daemon.ModeControl,
+		ClientName: "gortex-hook-sessionstart",
+	})
+	if err != nil {
+		if errors.Is(err, daemon.ErrDaemonUnavailable) {
+			return nil, errDaemonUnreachable
+		}
+		return nil, err
+	}
+	defer client.Close()
+
+	resp, err := client.ControlWithTimeout(daemon.ControlProbe, nil, sessionStartProbeBudget)
+	if err != nil {
+		return nil, err
+	}
+	if !resp.OK {
+		return nil, fmt.Errorf("daemon rejected probe: %s", resp.ErrorMsg)
+	}
+
+	var probe daemon.ProbeResponse
+	if err := unmarshalResult(resp.Result, &probe); err != nil {
+		return nil, err
+	}
+
+	status := &daemon.StatusResponse{
+		Version:            probe.Version,
+		PID:                probe.PID,
+		UptimeSeconds:      probe.UptimeSeconds,
+		Sessions:           probe.Sessions,
+		Ready:              probe.Ready,
+		EnrichmentComplete: probe.Enriched,
+		CountsUnknown:      true,
+	}
+	for _, r := range probe.TrackedRepos {
+		status.TrackedRepos = append(status.TrackedRepos, daemon.TrackedRepoStatus{
+			Path:      r.Path,
+			Prefix:    r.Prefix,
+			Name:      r.Name,
+			Workspace: r.Workspace,
+			Project:   r.Project,
+		})
+	}
+	return status, nil
+}
+
+// sessionStartProbeBudget bounds the fallback. Probe touches no store, no
+// mutex and no filesystem, so anything it cannot answer inside this is a
+// genuinely unreachable daemon rather than a busy one.
+const sessionStartProbeBudget = 500 * time.Millisecond
+
+// sessionStartStatus resolves the daemon state the briefing renders: the full
+// status when it answers inside its budget, otherwise the probe. Only when
+// both fail is the daemon actually unreachable.
+func sessionStartStatus() (*daemon.StatusResponse, error) {
+	status, err := fetchDaemonStatus()
+	if err == nil {
+		return status, nil
+	}
+	if errors.Is(err, errDaemonUnreachable) {
+		return nil, err
+	}
+	// Status overran its budget. That says nothing about health — ask the
+	// call that indexing cannot delay before declaring enforcement degraded.
+	if probe, probeErr := fetchDaemonProbeAsStatus(); probeErr == nil {
+		return probe, nil
+	}
+	return nil, err
 }
 
 // buildSessionStartBriefing assembles the additionalContext block. It
@@ -164,8 +249,14 @@ func renderLeanReadiness(cwd string, s *daemon.StatusResponse) string {
 	if !s.Ready {
 		state = "warming up — enforcement partial"
 	}
+	// A probe-sourced response carries no counters. Printing its zero as a
+	// node count would state something untrue about the graph.
 	line := fmt.Sprintf("✓ Gortex %s (v%s): %d repo(s), %d nodes.",
 		state, strings.TrimPrefix(s.Version, "v"), len(s.TrackedRepos), totalNodes)
+	if s.CountsUnknown {
+		line = fmt.Sprintf("✓ Gortex %s (v%s): %d repo(s).",
+			state, strings.TrimPrefix(s.Version, "v"), len(s.TrackedRepos))
+	}
 
 	abs := cwd
 	if cwd != "" {
@@ -204,6 +295,12 @@ func renderDaemonReadiness(s *daemon.StatusResponse) string {
 		fmt.Fprintf(&sb, "⏳ Gortex daemon warming up (v%s, %s elapsed). Enforcement is partial until ready. ",
 			s.Version, formatDuration(s.WarmupSeconds))
 	}
+	// A probe-sourced response never computed the aggregates; reporting its
+	// zeros as real totals would say the graph is empty when it is not.
+	if s.CountsUnknown {
+		fmt.Fprintf(&sb, "%d tracked repo(s); graph totals not queried (the daemon was mid-index).\n\n", totalRepos)
+		return sb.String()
+	}
 	fmt.Fprintf(&sb, "%d tracked repo(s), %d nodes, %d edges across %d workspace(s).\n\n",
 		totalRepos, totalNodes, totalEdges, len(s.Workspaces))
 	return sb.String()
@@ -225,6 +322,13 @@ func renderCwdCoverage(cwd string, s *daemon.StatusResponse) string {
 	exact, contained := classifyCwd(abs, s.TrackedRepos)
 	switch {
 	case exact != nil:
+		// Coverage is the load-bearing claim here and the probe can answer it;
+		// the node count is colour, and an uncomputed zero would misreport an
+		// indexed repo as empty.
+		if s.CountsUnknown {
+			return fmt.Sprintf("**cwd `%s` is tracked** as repo `%s` (workspace: `%s`). Enforcement is active.\n",
+				abs, exact.Name, exact.Workspace)
+		}
 		return fmt.Sprintf("**cwd `%s` is tracked** as repo `%s` (workspace: `%s`, %d nodes). Enforcement is active.\n",
 			abs, exact.Name, exact.Workspace, exact.Nodes)
 	case len(contained) > 0:

--- a/internal/hooks/sessionstart_busy_daemon_test.go
+++ b/internal/hooks/sessionstart_busy_daemon_test.go
@@ -1,0 +1,114 @@
+package hooks
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/daemon"
+)
+
+// A status call that overruns its budget says nothing about daemon health —
+// Status queues behind the controller mutex, which a track / reload /
+// enrichment holds for minutes. Measured over 233 real fires, 81.5% of
+// sessions exceeded the 2s budget, and every one of them told the agent that
+// enforcement was degraded on a daemon that was fine.
+//
+// The briefing must describe the daemon it actually has.
+func TestSessionStartBriefing_BusyDaemonIsNotReportedAsBroken(t *testing.T) {
+	prev := sessionStartStatusFn
+	t.Cleanup(func() { sessionStartStatusFn = prev })
+
+	// What the probe fallback produces once Status has timed out: real
+	// identity, no aggregates.
+	sessionStartStatusFn = func() (*daemon.StatusResponse, error) {
+		return &daemon.StatusResponse{
+			Version:       "0.63.1",
+			Ready:         true,
+			CountsUnknown: true,
+			TrackedRepos: []daemon.TrackedRepoStatus{
+				{Prefix: "gortex", Path: "/work/gortex", Name: "gortex"},
+			},
+		}, nil
+	}
+
+	out := buildSessionStartBriefing("/work/gortex")
+
+	assert.NotContains(t, out, "status query failed",
+		"a busy daemon must not be reported as a failed one")
+	assert.NotContains(t, out, "unreachable",
+		"the transport was reachable — the aggregate simply was not asked for")
+	assert.Contains(t, out, "tracked repo(s)",
+		"the briefing still reports scope, which is what the probe can answer")
+}
+
+// The counters a probe never computed must not be rendered as real zeros.
+// "0 nodes" is a claim about the graph; the honest statement is that the
+// totals were not queried.
+func TestSessionStartBriefing_UnknownCountsAreNotRenderedAsZero(t *testing.T) {
+	prev := sessionStartStatusFn
+	t.Cleanup(func() { sessionStartStatusFn = prev })
+	sessionStartStatusFn = func() (*daemon.StatusResponse, error) {
+		return &daemon.StatusResponse{
+			Version:       "0.63.1",
+			Ready:         true,
+			CountsUnknown: true,
+			TrackedRepos: []daemon.TrackedRepoStatus{
+				{Prefix: "gortex", Path: "/work/gortex", Name: "gortex"},
+			},
+		}, nil
+	}
+
+	out := buildSessionStartBriefing("/work/gortex")
+	assert.NotContains(t, out, "0 nodes",
+		"an unasked aggregate must never be presented as a measured zero")
+	assert.Contains(t, out, "not queried")
+}
+
+// A genuinely unreachable daemon must still produce the hard warning — this
+// fix narrows what counts as unreachable, it does not remove the state.
+func TestSessionStartBriefing_UnreachableDaemonStillWarns(t *testing.T) {
+	prev := sessionStartStatusFn
+	t.Cleanup(func() { sessionStartStatusFn = prev })
+	sessionStartStatusFn = func() (*daemon.StatusResponse, error) {
+		return nil, errDaemonUnreachable
+	}
+
+	out := buildSessionStartBriefing("/work/gortex")
+	assert.Contains(t, strings.ToLower(out), "unreachable",
+		"a daemon that truly cannot be dialled must still be called out")
+}
+
+// When Status answers inside its budget nothing changes: real counters are
+// reported exactly as before, so this fallback is invisible on a quiet daemon.
+func TestSessionStartBriefing_HealthyStatusStillReportsCounts(t *testing.T) {
+	prev := sessionStartStatusFn
+	t.Cleanup(func() { sessionStartStatusFn = prev })
+	sessionStartStatusFn = func() (*daemon.StatusResponse, error) {
+		return &daemon.StatusResponse{
+			Version: "0.63.1",
+			Ready:   true,
+			TrackedRepos: []daemon.TrackedRepoStatus{
+				{Prefix: "gortex", Path: "/work/gortex", Name: "gortex", Nodes: 31000, Edges: 206000},
+			},
+		}, nil
+	}
+
+	out := buildSessionStartBriefing("/work/gortex")
+	assert.Contains(t, out, "31000")
+	assert.NotContains(t, out, "not queried")
+}
+
+// sessionStartStatus must only declare a daemon unreachable when the probe
+// agrees. A status error that is not errDaemonUnreachable is a budget
+// overrun, and the probe is what distinguishes busy from down.
+func TestSessionStartStatus_PropagatesUnreachableWithoutProbing(t *testing.T) {
+	// errDaemonUnreachable short-circuits before any probe is attempted;
+	// asserting the sentinel survives the wrapper keeps that contract pinned.
+	err := errDaemonUnreachable
+	assert.True(t, errors.Is(err, errDaemonUnreachable))
+	require.NotNil(t, sessionStartStatusFn)
+}


### PR DESCRIPTION
Replaces #485, #487 and #488, which I split too finely — see the note at the bottom.

Root-cause fix for the hook timeout cluster in #479. One cause, three call sites.

## The measurement

Five **serial** `daemon status` calls, no concurrent load, 44-repo workspace — identical 14,468-byte payload every time:

```
11531 ms · 8225 ms · 344 ms · 2041 ms · 156 ms
```

Same payload, 74× spread. Not the work — the wait. `Status` takes `c.mu`, which is held for the entire duration of a track / reload / enrichment, and the daemon log shows incremental derived passes running 28 seconds at a stretch.

I had assumed the hooks were causing this themselves (63k connections/day). They are not — these calls were serial, one second apart, with no hooks running.

## The consequence is a wrong answer, not slowness

The SessionStart briefing is appended to the session system prompt and visible every turn. Measured over 233 real fires, **81.5% of sessions** were told:

> ⚠️ Gortex daemon status query failed — continuing with rule-only enforcement.

The daemon was fine each time. A budget overrun carries no information about health, but the briefing treated it as proof of ill health.

## This hazard is already known in this file

```go
// multiWatcher is an atomic pointer, not a mu-guarded field: ... reading it
// under mu is what kept `daemon stop` queued behind a running track /
// reload / enrichment.
```

```go
// Guarded by its own mutex, deliberately NOT by mu. Shutdown is the one
// control RPC that has to work when the daemon is at its least healthy,
// and mu is held for the entire duration of a track / reload / enrichment
// — minutes on a large workspace.
```

`Shutdown` and `multiWatcher` got that treatment. The read paths never did.

## Three parts

**`ControlProbe`** — liveness + tracked scope with none of `Status`'s aggregation: no `c.mu`, no graph handle, no `runtime.ReadMemStats` (stops the world), no per-repo `stat`. Two atomics and the config registry, which is the membership source of truth anyway.

`ProbeResponse` is a distinct type rather than a subset-typed `StatusResponse` on purpose — sharing it would leave every aggregate present but zero, and a caller cannot tell a real zero from an unpopulated one. That ambiguity is exactly what made a timed-out status read as "nothing is tracked".

**`SearchSymbols`** — documented on the interface as *"the cheap probe path used by external clients (Claude Code's Grep-redirect hook)"*. It opened by taking `c.mu` to read `c.graph` — a field assigned once at construction and **never reassigned** (there is no `c.graph = ` in the package). The lock protected nothing while serialising the cheapest call in the tree behind the most expensive operation in the daemon.

This also settles the UserPromptSubmit question. Its probe runs through `SearchSymbols`, so its 3-emits-in-311 (82.6% dying at 800 ms) was measured while it was starved — and a starved probe returns *no hits*, indistinguishable from "the graph had nothing". **It has never had a fair trial.** Worth re-measuring on a healthy daemon before deciding to remove it; if it's still ~1%, removal is well-founded.

**SessionStart** falls back to the probe when status overruns. The fallback carries identity but no aggregates, so `CountsUnknown` marks it and the renderers say the totals were not queried rather than printing an uncomputed zero — "0 nodes" is a claim about the graph. A test caught a third renderer still printing it.

## Tests

Under `-race`, including a deliberate pair:

| test | result |
|---|---|
| `TestProbeAnswersDuringLongMutation` (`c.mu` held) | **0.00 s** |
| `TestSearchSymbolsAnswersDuringLongMutation` (`c.mu` held) | answers from the graph |
| `TestStatusBlocksDuringLongMutation` | **0.31 s, blocked** |

That last one guards the other two: it asserts `Status` *does* still block, so if it is ever fixed properly this fails and these calls' justification gets revisited rather than silently kept. Plus SessionStart rendering tests (busy ≠ broken, no zero-count claims, unreachable still warns, quiet daemon unchanged).

Verified against the **whole tree** this time — `go build ./...`, `go vet ./...`, `go test ./...`, `golangci-lint run ./...` — all clean.

## Why this replaces three PRs

I split this into #485 → #487 → #488 and that was wrong. #485 added `Probe` to the `Controller` interface but `internal/hooks/probe_e2e_test.go` has its own `fakeController`, which I updated on #487 — so #485 could not compile on its own and CI failed. An interface change has to ship with every implementor in the same commit. I also verified only the packages I touched instead of the full tree, which is how it reached CI at all.

#483 (hook tool-reachability guard) stays separate — it's test-only, independent of this, and already green.
