### PR TITLE
Resolve GDScript static, autoload and signal-wiring references by receiver

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -255,8 +255,8 @@ What is **not** covered:
 | ActionScript | `.as` | `package`, classes, interfaces, `function`, `import X.Y.*;` |
 | Dart | `.dart` | Full (see core matrix) |
 | Swift | `.swift` | Full (see core matrix) |
-| GDScript | `.gd`, `project.godot` | `func`, `class`, signals; receiver-typed calls — a script's funcs are methods of its `class_name`, and `Notify.event()` / typed locals / params / `self` bind by receiver, so a project-global class resolves across directories. `[autoload]` singletons in `project.godot` bind to their declared script. `preload("res://…")` binds to the file. |
-| Godot resources | `.tscn`, `.tres` | Scene tree nodes keyed by NodePath, `[ext_resource]` → script / sub-scene / asset, per-node `script =` / `instance=ExtResource(…)` |
+| GDScript | `.gd`, `project.godot` | `func`, `class`, signals; receiver-typed calls — a script's funcs are methods of its `class_name`, and `Notify.event()` / typed locals / params / `self` bind by receiver, so a project-global class resolves across directories. A call whose bind contradicts its stated receiver is demoted to the speculative tier, so a caller list holds only calls that class can receive. `[autoload]` singletons in `project.godot` and `const X = preload("res://…")` aliases both bind to the script they name, including one with no `class_name`. Class-body initialiser calls (`@onready var ui = Hud.build()`) are attributed to the file. A method referenced without parentheses — `connect(_on_x)`, `Callable(self, "_on_x")` — is a usage, so `rename` rewrites the signal wiring instead of silently breaking it. `preload("res://…")` binds to the file. |
+| Godot resources | `.tscn`, `.tres` | Scene tree nodes keyed by NodePath, `[ext_resource]` → script / sub-scene / asset, per-node `script =` / `instance=ExtResource(…)`, `[connection … method="…"]` → the handler on the target node's script |
 | Verse (UEFN) | `.verse` | `class` / `struct` / `enum` / `interface`, functions with specifier blocks, `using { /Path }` |
 | Nix | `.nix` | Attribute sets, functions, `import` / `<nixpkgs>` |
 | AL (Business Central) | `.al` | Tables, pages, codeunits, procedures |

--- a/internal/indexer/gdscript_resolution_e2e_test.go
+++ b/internal/indexer/gdscript_resolution_e2e_test.go
@@ -1,0 +1,322 @@
+package indexer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+// The four GDScript attribution gaps that survived receiver-aware call
+// extraction, each asserted through the real pipeline:
+//
+//  1. a static method's call sites resolve like an instance method's,
+//     including through the `const X = preload(…)` alias that reaches a
+//     script with no `class_name`;
+//  2. calls originating in an autoload script are attributed to it —
+//     including the class-body initialisers that run before any func and
+//     the `self.`-qualified calls a script with no `class_name` makes;
+//  3. a caller list contains only calls whose receiver resolves to that
+//     class, so a same-named method elsewhere cannot inflate it;
+//  4. a method referenced without parentheses — `connect(_on_x)`,
+//     `Callable(self, "_on_x")`, a scene `[connection]` block — counts as
+//     a usage, so rename rewrites it instead of silently unwiring a signal.
+func gdIndexResolutionProject(t *testing.T) *graph.Graph {
+	t.Helper()
+	dir := t.TempDir()
+	files := map[string]string{
+		"project.godot": `config_version=5
+
+[autoload]
+
+Game="*res://src/core/Game.gd"
+`,
+		// A static method on a global class, in a directory of its own.
+		"src/save/Persist.gd": `class_name Persist
+extends RefCounted
+
+static func snapshot(c) -> Dictionary:
+    return {}
+`,
+		"src/combat/Combat.gd": `class_name Combat
+extends Node
+
+func save() -> Dictionary:
+    return Persist.snapshot(self)
+`,
+		// A static-utility script with NO class_name, reached only through
+		// the preload alias each caller declares for it.
+		"src/util/Maths.gd": `extends RefCounted
+
+static func clampf(v):
+    return v
+`,
+		"src/ui/Hud.gd": `class_name Hud
+extends Control
+
+const M = preload("res://src/util/Maths.gd")
+
+var initial = Persist.snapshot(self)
+
+func draw() -> void:
+    M.clampf(1.0)
+`,
+		// The autoload entry point: no class_name, so its funcs belong to
+		// no nameable class.
+		"src/core/Game.gd": `extends Node
+
+func start_mission() -> void:
+    Carry.apply(1, 2, 3)
+    self.tick()
+
+func tick() -> void:
+    pass
+`,
+		// Three unrelated classes declaring `apply`. Carry sits in the
+		// caller's own directory — the phantom's usual source.
+		"src/ui/Carry.gd": `class_name Carry
+extends RefCounted
+
+static func apply(world, state, payload) -> void:
+    pass
+`,
+		"src/data/Items.gd": `class_name Items
+extends RefCounted
+
+static func give(state, av, item_id) -> void:
+    pass
+`,
+		"src/ui/Caller.gd": `class_name Caller
+extends Control
+
+func run() -> void:
+    Items.apply(1, 2, 3)
+    Input.apply(1, 2, 3)
+`,
+		// Inherited dispatch: a call on the subclass must keep binding to
+		// the base's method. The gate must not read this as a mismatch.
+		"src/base/Base.gd": `class_name Base
+extends Node
+
+func shared() -> void:
+    pass
+`,
+		"src/base/Derived.gd": `class_name Derived
+extends Base
+`,
+		"src/base/UseDerived.gd": `class_name UseDerived
+extends Node
+
+var d: Derived
+
+func go() -> void:
+    d.shared()
+`,
+		// Signal wiring: by method value, by Callable string, and from the
+		// scene file.
+		"src/ui/Panel.gd": `class_name Panel
+extends Control
+
+func _ready() -> void:
+    button.pressed.connect(_on_random)
+    other.thing.connect(Callable(self, "_on_named"))
+
+func _on_random() -> void:
+    pass
+
+func _on_named() -> void:
+    pass
+
+func _on_scene() -> void:
+    pass
+`,
+		"src/ui/Panel.tscn": `[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://src/ui/Panel.gd" id="1_abc"]
+
+[node name="Panel" type="Control"]
+script = ExtResource("1_abc")
+
+[node name="Button" type="Button" parent="."]
+
+[connection signal="pressed" from="Button" to="." method="_on_scene"]
+`,
+	}
+	for name, src := range files {
+		path := filepath.Join(dir, filepath.FromSlash(name))
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(src), 0o644))
+	}
+
+	g := graph.New()
+	reg := parser.NewRegistry()
+	languages.RegisterAll(reg)
+	idx := New(g, reg, config.Default().Index, zap.NewNop())
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+	idx.ResolveAll()
+	return g
+}
+
+// gdEdgesInto returns the sources of every edge of kind k landing on id
+// that a default query would show — a demoted edge is excluded, which is
+// the whole point of the receiver gate.
+func gdEdgesInto(g *graph.Graph, id string, k graph.EdgeKind) []string {
+	var out []string
+	for _, e := range g.GetInEdges(id) {
+		if e.Kind != k {
+			continue
+		}
+		if speculative, _ := e.Meta[graph.MetaSpeculative].(bool); speculative {
+			continue
+		}
+		out = append(out, e.From)
+	}
+	return out
+}
+
+func gdOutTargets(g *graph.Graph, from string, k graph.EdgeKind) []string {
+	var out []string
+	for _, e := range g.GetOutEdges(from) {
+		if e.Kind == k && !graph.IsUnresolvedTarget(e.To) {
+			out = append(out, e.To)
+		}
+	}
+	return out
+}
+
+func TestGDScriptResolution_StaticAndPreloadAlias(t *testing.T) {
+	g := gdIndexResolutionProject(t)
+
+	t.Run("a static method resolves across directories", func(t *testing.T) {
+		assert.Contains(t, gdOutTargets(g, "src/combat/Combat.gd::save", graph.EdgeCalls),
+			"src/save/Persist.gd::snapshot",
+			"static is not a different kind of receiver")
+	})
+
+	t.Run("a preload alias names a script with no class_name", func(t *testing.T) {
+		assert.Contains(t, gdOutTargets(g, "src/ui/Hud.gd::draw", graph.EdgeCalls),
+			"src/util/Maths.gd::clampf",
+			"`const M = preload(…)` is how a static-utility script is reached")
+	})
+
+	t.Run("preload binds to the indexed script, not an external stub", func(t *testing.T) {
+		assert.Contains(t, gdOutTargets(g, "src/ui/Hud.gd", graph.EdgeImports),
+			"src/util/Maths.gd",
+			"a res:// path is rooted at the project, so it always names an indexed file")
+	})
+
+	t.Run("a scene's ext_resource script reference binds", func(t *testing.T) {
+		assert.Contains(t, gdOutTargets(g, "src/ui/Panel.tscn", graph.EdgeReferences),
+			"src/ui/Panel.gd",
+			"in Godot a script's blast radius runs through the scene that mounts it")
+	})
+}
+
+func TestGDScriptResolution_AutoloadScriptAsCaller(t *testing.T) {
+	g := gdIndexResolutionProject(t)
+
+	t.Run("a call from an autoload script is attributed to it", func(t *testing.T) {
+		assert.Contains(t, gdEdgesInto(g, "src/ui/Carry.gd::apply", graph.EdgeCalls),
+			"src/core/Game.gd::start_mission",
+			"the autoload entry point is usually the game's most load-bearing file")
+	})
+
+	t.Run("a self call in a class_name-less script is not a weak-tier guess", func(t *testing.T) {
+		var found *graph.Edge
+		for _, e := range g.GetInEdges("src/core/Game.gd::tick") {
+			if e.Kind == graph.EdgeCalls && e.From == "src/core/Game.gd::start_mission" {
+				found = e
+			}
+		}
+		require.NotNil(t, found, "self.tick() is a call to this script's own method")
+		assert.Equal(t, graph.OriginASTResolved, found.EffectiveOrigin(),
+			"a script with no class_name still owns its own methods; "+
+				"the name-only tier is suppressed by default and hides the call")
+	})
+
+	t.Run("a class-body initialiser call is attributed to the file", func(t *testing.T) {
+		assert.Contains(t, gdEdgesInto(g, "src/save/Persist.gd::snapshot", graph.EdgeCalls),
+			"src/ui/Hud.gd",
+			"`var initial = Persist.snapshot(self)` runs, so it is a call site")
+	})
+}
+
+func TestGDScriptResolution_ReceiverGate(t *testing.T) {
+	g := gdIndexResolutionProject(t)
+
+	t.Run("a caller list holds only calls whose receiver names that class", func(t *testing.T) {
+		callers := gdEdgesInto(g, "src/ui/Carry.gd::apply", graph.EdgeCalls)
+		assert.NotContains(t, callers, "src/ui/Caller.gd::run",
+			"Items.apply() and Input.apply() belong to other receivers; "+
+				"counting them makes a blast radius look reassuring while pointing at the wrong code")
+		assert.Contains(t, callers, "src/core/Game.gd::start_mission",
+			"the real Carry.apply() call site must survive the gate")
+	})
+
+	t.Run("a mismatched bind is demoted, not deleted", func(t *testing.T) {
+		var demoted int
+		for _, e := range g.GetOutEdges("src/ui/Caller.gd::run") {
+			if e.Kind != graph.EdgeCalls {
+				continue
+			}
+			if reason, _ := e.Meta["demoted"].(string); reason == "receiver_type_mismatch" {
+				demoted++
+			}
+		}
+		assert.Equal(t, 2, demoted,
+			"the evidence stays inspectable at the speculative tier")
+	})
+
+	t.Run("inherited dispatch is not a mismatch", func(t *testing.T) {
+		assert.Contains(t, gdEdgesInto(g, "src/base/Base.gd::shared", graph.EdgeCalls),
+			"src/base/UseDerived.gd::go",
+			"a Derived receiver landing on Base.shared is dispatch, not a phantom")
+	})
+}
+
+func TestGDScriptResolution_MethodReferencesAreUsages(t *testing.T) {
+	g := gdIndexResolutionProject(t)
+
+	t.Run("connect(_on_x) is a usage", func(t *testing.T) {
+		assert.Contains(t, gdEdgesInto(g, "src/ui/Panel.gd::_on_random", graph.EdgeReferences),
+			"src/ui/Panel.gd::_ready",
+			"renaming past this leaves a button that silently stops working")
+	})
+
+	t.Run("Callable(self, \"_on_x\") is a usage", func(t *testing.T) {
+		assert.Contains(t, gdEdgesInto(g, "src/ui/Panel.gd::_on_named", graph.EdgeReferences),
+			"src/ui/Panel.gd::_ready")
+	})
+
+	t.Run("a scene [connection] is a usage of the script's method", func(t *testing.T) {
+		refs := gdEdgesInto(g, "src/ui/Panel.gd::_on_scene", graph.EdgeReferences)
+		assert.Contains(t, refs, "src/ui/Panel.tscn::Panel",
+			"the connection names the method as a bare string in a third file")
+	})
+
+	t.Run("the connection binds through the node's script, not by name", func(t *testing.T) {
+		var conn *graph.Edge
+		for _, e := range g.GetInEdges("src/ui/Panel.gd::_on_scene") {
+			if e.Kind == graph.EdgeReferences && e.FilePath == "src/ui/Panel.tscn" {
+				conn = e
+			}
+		}
+		require.NotNil(t, conn)
+		assert.Equal(t, "godot-connection", conn.Meta["synthesized_by"],
+			"binding by name alone is right only while the handler name is unique")
+	})
+
+	t.Run("an ordinary call is still a call, not a reference", func(t *testing.T) {
+		assert.NotContains(t, gdEdgesInto(g, "src/core/Game.gd::tick", graph.EdgeReferences),
+			"src/core/Game.gd::start_mission")
+	})
+}

--- a/internal/mcp/rename_gdscript_signal_test.go
+++ b/internal/mcp/rename_gdscript_signal_test.go
@@ -1,0 +1,85 @@
+package mcp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/query"
+)
+
+// Renaming a Godot signal handler must rewrite the wiring too.
+//
+// Godot connects a signal by passing the method itself, without
+// parentheses — `pressed.connect(_on_random)` — or by naming it in a
+// string, either in `Callable(self, "…")` or in the scene's own
+// `[connection]` block. None of those is a call, so a rename that only
+// followed call edges rewrote the definition and the ordinary call sites
+// and left the wiring pointing at a name that no longer exists. The
+// project still parses, nothing raises an error anywhere, and the button
+// simply stops working — the most expensive failure shape in the report,
+// because it is silent.
+func TestRenameSymbol_GDScriptSignalWiring(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]string{
+		"Panel.gd": `class_name Panel
+extends Control
+
+func _ready() -> void:
+    button.pressed.connect(_on_random)
+    timer.timeout.connect(Callable(self, "_on_random"))
+    _on_random()
+
+func _on_random() -> void:
+    pass
+`,
+		"Panel.tscn": `[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://Panel.gd" id="1_abc"]
+
+[node name="Panel" type="Control"]
+script = ExtResource("1_abc")
+
+[connection signal="pressed" from="Panel" to="." method="_on_random"]
+`,
+	}
+	for name, src := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(src), 0o644))
+	}
+
+	g := graph.New()
+	idx := indexer.New(g, testRegistry(), config.Default().Index, zap.NewNop())
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+	idx.ResolveAll()
+	srv := NewServer(query.NewEngine(g), g, idx, nil, zap.NewNop(), nil)
+	srv.RunAnalysis()
+
+	res := callToolByName(t, srv, context.Background(), "rename_symbol", map[string]any{
+		"id":       "Panel.gd::_on_random",
+		"new_name": "_on_shuffle",
+	})
+	resp := decodeRenameResp(t, res)
+	assert.Equal(t, "applied", resp["status"])
+
+	script, err := os.ReadFile(filepath.Join(dir, "Panel.gd"))
+	require.NoError(t, err)
+	assert.Contains(t, string(script), "func _on_shuffle() -> void:", "the definition")
+	assert.Contains(t, string(script), "connect(_on_shuffle)", "the bare method value")
+	assert.Contains(t, string(script), `Callable(self, "_on_shuffle")`, "the Callable string")
+	assert.NotContains(t, string(script), "_on_random",
+		"a surviving mention is a signal wired to a method that no longer exists")
+
+	scene, err := os.ReadFile(filepath.Join(dir, "Panel.tscn"))
+	require.NoError(t, err)
+	assert.Contains(t, string(scene), `method="_on_shuffle"`,
+		"the scene's own connection block wires the handler too")
+}

--- a/internal/parser/languages/gdscript.go
+++ b/internal/parser/languages/gdscript.go
@@ -2,6 +2,7 @@ package languages
 
 import (
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/zzet/gortex/internal/graph"
@@ -38,11 +39,23 @@ var (
 	gdClassNameRe = regexp.MustCompile(`(?m)^\s*class_name\s+(\w+)`)
 	gdInnerClass  = regexp.MustCompile(`(?m)^[ \t]*class\s+(\w+)`)
 	gdExtendsRe   = regexp.MustCompile(`(?m)^\s*extends\s+([\w.]+)`)
-	gdVarRe       = regexp.MustCompile(`(?m)^[ \t]*(?:@\w+(?:\([^)]*\))?\s+)*(?:static\s+)?var\s+(\w+)`)
-	gdConstRe     = regexp.MustCompile(`(?m)^[ \t]*const\s+(\w+)`)
-	gdEnumRe      = regexp.MustCompile(`(?m)^[ \t]*enum\s+(\w+)`)
-	gdSignalRe    = regexp.MustCompile(`(?m)^[ \t]*signal\s+(\w+)`)
-	gdPreloadRe   = regexp.MustCompile(`\b(?:preload|load)\s*\(\s*["']([^"']+)["']\s*\)`)
+	// gdScriptExtendsRe matches the script-level `extends` clause — always
+	// unindented, and naming a single class. Anything else (a `res://`
+	// path, a dotted inner-class path) is an opaque base the receiver gate
+	// must not read as "this class inherits nothing in this repo".
+	gdScriptExtendsRe    = regexp.MustCompile(`(?m)^extends[ \t]+([A-Za-z_]\w*)[ \t]*(?:#.*)?$`)
+	gdScriptExtendsAnyRe = regexp.MustCompile(`(?m)^extends[ \t]+\S`)
+	gdVarRe              = regexp.MustCompile(`(?m)^[ \t]*(?:@\w+(?:\([^)]*\))?\s+)*(?:static\s+)?var\s+(\w+)`)
+	gdConstRe            = regexp.MustCompile(`(?m)^[ \t]*const\s+(\w+)`)
+	gdEnumRe             = regexp.MustCompile(`(?m)^[ \t]*enum\s+(\w+)`)
+	gdSignalRe           = regexp.MustCompile(`(?m)^[ \t]*signal\s+(\w+)`)
+	gdPreloadRe          = regexp.MustCompile(`\b(?:preload|load)\s*\(\s*["']([^"']+)["']\s*\)`)
+	// gdPreloadAliasRe matches the idiom that gives a script a name
+	// without a `class_name`: `const Persist = preload("res://…")`. The
+	// alias is then used exactly like a global — `Persist.snapshot(…)` —
+	// so the name has to be tied back to the script it loads.
+	gdPreloadAliasRe = regexp.MustCompile(
+		`(?m)^[ \t]*(?:@\w+(?:\([^)]*\))?\s+)*(?:static\s+)?(?:const|var)\s+(\w+)\s*(?::\s*\w+\s*)?:?=\s*(?:preload|load)\s*\(\s*["']([^"']+)["']\s*\)`)
 
 	// gdCallRe captures an optional dotted receiver chain ahead of the
 	// callee. `Notify.event(` yields ("Notify", "event"); `a.b.c(`
@@ -55,6 +68,23 @@ var (
 	gdNewVarRe   = regexp.MustCompile(`(?m)^[ \t]*(?:@\w+(?:\([^)]*\))?\s+)*(?:static\s+)?var\s+(\w+)\s*:?=\s*([A-Za-z_]\w*)\s*\.\s*new\s*\(`)
 	gdFuncSigRe  = regexp.MustCompile(`(?m)^[ \t]*(?:static\s+)?func\s+\w+\s*\(([^)]*)\)`)
 	gdParamRe    = regexp.MustCompile(`(\w+)\s*:\s*([A-Za-z_]\w*)`)
+
+	// gdIdentRe matches every bare identifier, for the method-value scan
+	// below: a method mentioned WITHOUT parentheses is a reference to the
+	// method itself, which is how Godot wires every signal.
+	gdIdentRe = regexp.MustCompile(`[A-Za-z_]\w*`)
+
+	// gdMethodNameAPIRe matches the engine APIs that take a method name as
+	// a STRING. Each is a reference to that method, and each is invisible
+	// to any scan that only looks at call syntax. The argument tail is
+	// matched non-greedily to the first `)`; a nested `Callable(...)` is
+	// picked up by this same regex on its own match, so nesting needs no
+	// balanced-paren scan.
+	gdMethodNameAPIRe = regexp.MustCompile(
+		`\b(?:connect|disconnect|is_connected|has_method|call|call_deferred|callv|` +
+			`rpc|rpc_id|Callable|tween_callback|tween_method|set_script_method)\s*\(([^()]*)\)`)
+	// gdQuotedRe matches one quoted string inside such an argument list.
+	gdQuotedRe = regexp.MustCompile(`["']([A-Za-z_]\w*)["']`)
 )
 
 // GDScriptExtractor extracts Godot GDScript source using regex.
@@ -86,6 +116,10 @@ func (e *GDScriptExtractor) Extract(filePath string, src []byte) (*parser.Extrac
 	result.Nodes = append(result.Nodes, fileNode)
 
 	seen := make(map[string]bool)
+	// callables are the names this script declares as funcs or signals.
+	// A bare mention of one of them is a reference to the method itself
+	// (`pressed.connect(_on_x)`), which the call scan below cannot see.
+	callables := make(map[string]bool)
 	add := func(name string, kind graph.NodeKind, start, end int, meta map[string]any) {
 		if name == "" || isGDKeyword(name) {
 			return
@@ -95,6 +129,9 @@ func (e *GDScriptExtractor) Extract(filePath string, src []byte) (*parser.Extrac
 			return
 		}
 		seen[id] = true
+		if kind == graph.KindMethod || kind == graph.KindFunction {
+			callables[name] = true
+		}
 		result.Nodes = append(result.Nodes, &graph.Node{
 			ID: id, Kind: kind, Name: name,
 			FilePath: filePath, StartLine: start, EndLine: end,
@@ -107,13 +144,30 @@ func (e *GDScriptExtractor) Extract(filePath string, src []byte) (*parser.Extrac
 		})
 	}
 
+	// The script's base class, carried on the `class_name` node so the
+	// receiver gate can walk an inheritance chain: a call on a `Child`
+	// receiver that lands on `Parent.method` is dispatch, not a phantom.
+	// An `extends` the gate cannot read as one in-repo class name is
+	// recorded as opaque so it declines to judge rather than guessing.
+	// A fresh map per node: enrichment writes back into Node.Meta, so two
+	// nodes must never share one.
+	classMeta := func() map[string]any {
+		m := map[string]any{"gd_kind": "class_name"}
+		if base := gdScriptExtendsRe.FindSubmatch(src); base != nil && !isGDKeyword(string(base[1])) {
+			m["gd_extends"] = string(base[1])
+		} else if gdScriptExtendsAnyRe.Match(src) {
+			m["gd_extends_opaque"] = true
+		}
+		return m
+	}
+
 	// The script's own global class name, if it declares one. Godot
 	// allows at most one `class_name` per script.
 	selfClass := ""
 	for _, m := range gdClassNameRe.FindAllSubmatchIndex(src, -1) {
 		name := string(src[m[2]:m[3]])
 		line := lineAt(src, m[0])
-		add(name, graph.KindType, line, line, map[string]any{"gd_kind": "class_name"})
+		add(name, graph.KindType, line, line, classMeta())
 		if selfClass == "" {
 			selfClass = name
 		}
@@ -124,7 +178,12 @@ func (e *GDScriptExtractor) Extract(filePath string, src []byte) (*parser.Extrac
 		name := string(src[m[2]:m[3]])
 		line := lineAt(src, m[0])
 		end := findIndentedBlockEnd(lines, line)
-		add(name, graph.KindType, line, end, map[string]any{"gd_kind": "inner_class"})
+		// An inner class's own `extends` is not parsed, so its base is
+		// unknown rather than absent — opaque, so the receiver gate
+		// declines to call a mismatch it cannot prove.
+		add(name, graph.KindType, line, end, map[string]any{
+			"gd_kind": "inner_class", "gd_extends_opaque": true,
+		})
 		owners = append(owners, gdOwner{name: name, start: line, end: end})
 	}
 	ownerAt := func(line int) string {
@@ -153,15 +212,32 @@ func (e *GDScriptExtractor) Extract(filePath string, src []byte) (*parser.Extrac
 			add(name, graph.KindFunction, line, end, nil)
 		}
 	}
+	// Script aliases: `const Persist = preload("res://…")`. The name is
+	// used like a global class, so the resolver needs the script it names.
+	preloadOf := map[string]string{}
+	for _, m := range gdPreloadAliasRe.FindAllSubmatchIndex(src, -1) {
+		preloadOf[string(src[m[2]:m[3]])] = string(src[m[4]:m[5]])
+	}
+	varMeta := func(name string, base map[string]any) map[string]any {
+		path, ok := preloadOf[name]
+		if !ok {
+			return base
+		}
+		if base == nil {
+			base = map[string]any{}
+		}
+		base["gd_preload"] = path
+		return base
+	}
 	for _, m := range gdVarRe.FindAllSubmatchIndex(src, -1) {
 		name := string(src[m[2]:m[3]])
 		line := lineAt(src, m[0])
-		add(name, graph.KindVariable, line, line, nil)
+		add(name, graph.KindVariable, line, line, varMeta(name, nil))
 	}
 	for _, m := range gdConstRe.FindAllSubmatchIndex(src, -1) {
 		name := string(src[m[2]:m[3]])
 		line := lineAt(src, m[0])
-		add(name, graph.KindVariable, line, line, map[string]any{"const": true})
+		add(name, graph.KindVariable, line, line, varMeta(name, map[string]any{"const": true}))
 	}
 	for _, m := range gdEnumRe.FindAllSubmatchIndex(src, -1) {
 		name := string(src[m[2]:m[3]])
@@ -201,15 +277,24 @@ func (e *GDScriptExtractor) Extract(filePath string, src []byte) (*parser.Extrac
 	// `#` note or a `"res://..."` path cannot mint a call edge. Masking
 	// preserves length, so every offset below still indexes src alike.
 	masked := gdMaskLiterals(src)
+	// callOffsets marks every identifier that IS a callee, so the
+	// method-value scan below can tell `_on_x()` from `connect(_on_x)`.
+	callOffsets := make(map[int]bool)
 	for _, m := range gdCallRe.FindAllSubmatchIndex(masked, -1) {
 		name := string(masked[m[4]:m[5]])
+		callOffsets[m[4]] = true
 		if isGDKeyword(name) || declOffsets[m[4]] {
 			continue
 		}
 		line := lineAt(masked, m[0])
+		// A call outside every func — a `var hp = Stats.roll()` or an
+		// `@onready var ui = Hud.build()` in the class body — still calls
+		// something. Attributing it to the file keeps the script's whole
+		// initialisation layer in the callee's caller list instead of
+		// dropping it, the same rule Python applies to module-level calls.
 		callerID := findEnclosingFunc(funcRanges, line)
 		if callerID == "" {
-			continue
+			callerID = fileNode.ID
 		}
 		recv := ""
 		if m[2] >= 0 {
@@ -231,11 +316,29 @@ func (e *GDScriptExtractor) Extract(filePath string, src []byte) (*parser.Extrac
 				member, recvType = true, owner
 			}
 		case "self":
-			member, recvType = true, ownerAt(line)
+			if owner := ownerAt(line); owner != "" {
+				member, recvType = true, owner
+			} else if seen[filePath+"::"+name] {
+				// A script with no `class_name` — every autoload entry
+				// point is one — has no nameable receiver, so the member
+				// shape would carry no receiver evidence and the call
+				// would settle on the name-only tier that find_usages
+				// suppresses by default. The file declares the callee, so
+				// the free-function shape binds it same-file instead.
+				member = false
+			} else {
+				member = true
+			}
 		default:
 			member = true
 			if t := types.lookup(callerID, recv); t != "" {
 				recvType = t
+			} else if _, aliased := preloadOf[recv]; aliased {
+				// A `const X = preload(…)` alias names a script directly,
+				// whatever its casing — `PERSIST.snapshot()` is as much a
+				// receiver as `Persist.snapshot()`. The preload pass binds
+				// it from the const's own declared path.
+				recvType = recv
 			} else if gdLooksGlobalName(recv) {
 				// GDScript style reserves PascalCase for `class_name`
 				// globals, autoload singletons and engine singletons,
@@ -271,7 +374,179 @@ func (e *GDScriptExtractor) Extract(filePath string, src []byte) (*parser.Extrac
 		})
 	}
 
+	e.addMethodValueRefs(result, gdRefScan{
+		filePath:    filePath,
+		fileID:      fileNode.ID,
+		src:         src,
+		masked:      masked,
+		callables:   callables,
+		shadowed:    gdLocalNames(src, funcRanges),
+		callOffsets: callOffsets,
+		declOffsets: declOffsets,
+		funcRanges:  funcRanges,
+	})
+
 	return result, nil
+}
+
+// gdRefScan carries the per-file state the method-value scan reads.
+type gdRefScan struct {
+	filePath    string
+	fileID      string
+	src         []byte
+	masked      []byte
+	callables   map[string]bool
+	shadowed    map[string]map[string]bool
+	callOffsets map[int]bool
+	declOffsets map[int]bool
+	funcRanges  []funcRange
+}
+
+// addMethodValueRefs emits an EdgeReferences for every mention of one of
+// this script's own methods that is NOT a call.
+//
+// Godot wires signals by passing the method itself — `pressed.connect(
+// _on_random)`, `Callable(self, "_on_random")`, and the Godot 3
+// `connect("pressed", self, "_on_random")`. None of those is a call, so
+// a scan that only reads call syntax sees nothing, and `rename` rewrites
+// the definition and the ordinary call sites while leaving the wiring
+// pointing at a name that no longer exists. The project still parses,
+// nothing errors, and the button silently stops working.
+//
+// Two shapes are recognised, and both target the same-file definition
+// directly — the script that declares the method is the script that
+// mentions it, so there is nothing for the resolver to guess:
+//
+//   - a bare identifier (or `self.<identifier>`) that names a func or
+//     signal this file declares and is not followed by `(`;
+//   - a quoted name inside one of the engine APIs that takes a method
+//     name as a string.
+//
+// A name shadowed by a local or a parameter in the enclosing func is
+// skipped: there the identifier is that local, not the method.
+func (e *GDScriptExtractor) addMethodValueRefs(result *parser.ExtractionResult, s gdRefScan) {
+	if len(s.callables) == 0 {
+		return
+	}
+	emitted := make(map[string]bool)
+	emit := func(name string, off int) {
+		line := lineAt(s.masked, off)
+		owner := findEnclosingFunc(s.funcRanges, line)
+		if owner == "" {
+			owner = s.fileID
+		}
+		target := s.filePath + "::" + name
+		if owner == target {
+			// A method mentioning its own name is the definition line or a
+			// self-reference; neither adds anything to the caller list.
+			return
+		}
+		key := owner + "\x00" + target + "\x00" + strconv.Itoa(line)
+		if emitted[key] {
+			return
+		}
+		emitted[key] = true
+		result.Edges = append(result.Edges, &graph.Edge{
+			From: owner, To: target,
+			Kind: graph.EdgeReferences, FilePath: s.filePath, Line: line,
+			// The target is named exactly and declared in this same file:
+			// structural, not a name guess.
+			Origin: graph.OriginASTResolved, Confidence: 0.9,
+			Meta: map[string]any{"gd_method_value": true},
+		})
+	}
+
+	// Bare (and `self.`-qualified) method values, over the masked source so
+	// a comment or an unrelated string cannot mint one.
+	for _, m := range gdIdentRe.FindAllIndex(s.masked, -1) {
+		off := m[0]
+		name := string(s.masked[off:m[1]])
+		if !s.callables[name] || s.callOffsets[off] || s.declOffsets[off] {
+			continue
+		}
+		if recv, dotted := gdRefReceiver(s.masked, off); dotted && recv != "self" {
+			// `other.foo` names a method of a different object; only this
+			// script's own definition can be claimed from here.
+			continue
+		}
+		line := lineAt(s.masked, off)
+		if fn := findEnclosingFunc(s.funcRanges, line); fn != "" && s.shadowed[fn][name] {
+			continue
+		}
+		emit(name, off)
+	}
+
+	// Method names passed as strings. Read from the ORIGINAL source —
+	// masking blanks exactly the literals this shape lives in.
+	for _, m := range gdMethodNameAPIRe.FindAllSubmatchIndex(s.src, -1) {
+		for _, q := range gdQuotedRe.FindAllSubmatchIndex(s.src[m[2]:m[3]], -1) {
+			name := string(s.src[m[2]+q[2] : m[2]+q[3]])
+			if s.callables[name] {
+				emit(name, m[2]+q[2])
+			}
+		}
+	}
+}
+
+// gdRefReceiver reports the receiver an identifier at off is reached
+// through, and whether there was one at all. `self.foo` yields
+// ("self", true), `a.b.foo` yields ("b", true), a bare `foo` ("", false).
+func gdRefReceiver(masked []byte, off int) (string, bool) {
+	i := off - 1
+	for i >= 0 && (masked[i] == ' ' || masked[i] == '\t') {
+		i--
+	}
+	if i < 0 || masked[i] != '.' {
+		return "", false
+	}
+	end := i
+	i--
+	for i >= 0 && (masked[i] == ' ' || masked[i] == '\t') {
+		i--
+	}
+	start := i
+	for start >= 0 && (isIdentByte(masked[start]) || masked[start] == '.') {
+		start--
+	}
+	recv := strings.TrimSpace(string(masked[start+1 : end]))
+	if j := strings.LastIndexByte(recv, '.'); j >= 0 {
+		recv = recv[j+1:]
+	}
+	return recv, true
+}
+
+func isIdentByte(b byte) bool {
+	return b == '_' || (b >= '0' && b <= '9') ||
+		(b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}
+
+// gdLocalNames collects the names each func declares locally — its
+// parameters and its `var`s. A bare identifier matching one of them is
+// that local, not the same-named method, so the method-value scan skips
+// it.
+func gdLocalNames(src []byte, ranges []funcRange) map[string]map[string]bool {
+	out := map[string]map[string]bool{}
+	bind := func(fnID, name string) {
+		if fnID == "" || name == "" {
+			return
+		}
+		if out[fnID] == nil {
+			out[fnID] = map[string]bool{}
+		}
+		out[fnID][name] = true
+	}
+	for _, m := range gdVarRe.FindAllSubmatchIndex(src, -1) {
+		bind(findEnclosingFunc(ranges, lineAt(src, m[0])), string(src[m[2]:m[3]]))
+	}
+	for _, m := range gdFuncSigRe.FindAllSubmatchIndex(src, -1) {
+		fnID := findEnclosingFunc(ranges, lineAt(src, m[0]))
+		for _, p := range strings.Split(string(src[m[2]:m[3]]), ",") {
+			if n := gdIdentRe.FindString(strings.TrimSpace(p)); n != "" {
+				bind(fnID, n)
+			}
+		}
+	}
+	return out
 }
 
 // gdTypeEnv maps a receiver expression to its declared type, scoped to

--- a/internal/parser/languages/gdscript_method_value_test.go
+++ b/internal/parser/languages/gdscript_method_value_test.go
@@ -1,0 +1,186 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+)
+
+// gdRefsTo collects the sources of every reference edge landing on a
+// target, one entry per line so a duplicate is visible.
+func gdRefsTo(res *parser.ExtractionResult, to string) []int {
+	var lines []int
+	for _, e := range res.Edges {
+		if e.Kind == graph.EdgeReferences && e.To == to {
+			lines = append(lines, e.Line)
+		}
+	}
+	return lines
+}
+
+func gdExtract(t *testing.T, path, src string) *parser.ExtractionResult {
+	t.Helper()
+	res, err := NewGDScriptExtractor().Extract(path, []byte(src))
+	require.NoError(t, err)
+	return res
+}
+
+// A method mentioned without parentheses is a reference to the method.
+// That is how Godot wires every signal, and it is invisible to a scan
+// that only reads call syntax.
+func TestGDScriptExtractor_MethodValueReferences(t *testing.T) {
+	res := gdExtract(t, "Panel.gd", `class_name Panel
+extends Control
+
+func _ready() -> void:
+    button.pressed.connect(_on_random)
+    area.entered.connect(self._on_random)
+    timer.timeout.connect(Callable(self, "_on_random"))
+    legacy.connect("pressed", self, "_on_random")
+    var f = _on_random
+
+func _on_random() -> void:
+    pass
+`)
+
+	assert.ElementsMatch(t, []int{5, 6, 7, 8, 9}, gdRefsTo(res, "Panel.gd::_on_random"),
+		"every wiring shape is a usage of the handler")
+}
+
+// The scan must not turn ordinary source into references. Each of these
+// would be a false rename target, and rename writes to disk.
+func TestGDScriptExtractor_MethodValueReferencePrecision(t *testing.T) {
+	res := gdExtract(t, "Panel.gd", `class_name Panel
+extends Control
+
+# handler is mentioned in this comment
+var note = "handler"
+
+func run(handler) -> void:
+    print(handler)
+    other.handler
+    var handler2 = 1
+
+func handler() -> void:
+    pass
+`)
+
+	assert.Empty(t, gdRefsTo(res, "Panel.gd::handler"),
+		"a comment, a plain string, a shadowing parameter and another "+
+			"object's member are none of them this script's method")
+}
+
+func TestGDScriptExtractor_MethodValueSkipsOrdinaryCalls(t *testing.T) {
+	res := gdExtract(t, "Panel.gd", `class_name Panel
+extends Control
+
+func run() -> void:
+    handler()
+    self.handler()
+
+func handler() -> void:
+    pass
+`)
+
+	assert.Empty(t, gdRefsTo(res, "Panel.gd::handler"),
+		"a call is a call edge; duplicating it as a reference double-counts it")
+	calls := gdCalls(res)
+	assert.Contains(t, calls, "unresolved::*.handler")
+}
+
+// A call outside every func still calls something. Dropping it loses a
+// script's whole initialisation layer from the callee's caller list.
+func TestGDScriptExtractor_ClassBodyCallsAttributeToFile(t *testing.T) {
+	res := gdExtract(t, "Hud.gd", `class_name Hud
+extends Control
+
+var hp = Stats.roll()
+
+@onready var ui = Hud.build()
+
+func draw() -> void:
+    Paint.line()
+`)
+
+	byTarget := map[string]*graph.Edge{}
+	for _, e := range res.Edges {
+		if e.Kind == graph.EdgeCalls {
+			byTarget[e.To+"@"+e.Meta["receiver_type"].(string)] = e
+		}
+	}
+	require.Contains(t, byTarget, "unresolved::*.roll@Stats")
+	assert.Equal(t, "Hud.gd", byTarget["unresolved::*.roll@Stats"].From)
+	require.Contains(t, byTarget, "unresolved::*.build@Hud")
+	assert.Equal(t, "Hud.gd", byTarget["unresolved::*.build@Hud"].From)
+	require.Contains(t, byTarget, "unresolved::*.line@Paint")
+	assert.Equal(t, "Hud.gd::draw", byTarget["unresolved::*.line@Paint"].From,
+		"a call inside a func still belongs to that func")
+}
+
+// A script with no `class_name` — every autoload entry point is one —
+// has no nameable receiver, so a member-shaped self call would carry no
+// evidence and settle on the tier find_usages suppresses by default.
+func TestGDScriptExtractor_SelfCallWithoutClassName(t *testing.T) {
+	res := gdExtract(t, "Game.gd", `extends Node
+
+func start() -> void:
+    self.tick()
+    self.free()
+
+func tick() -> void:
+    pass
+`)
+
+	calls := gdCalls(res)
+	require.Contains(t, calls, "unresolved::tick",
+		"the file declares tick, so the same-file tier can bind it exactly")
+	assert.Contains(t, calls, "unresolved::*.free",
+		"an inherited engine method is not this file's to claim")
+}
+
+func TestGDScriptExtractor_PreloadAliasAndExtends(t *testing.T) {
+	res := gdExtract(t, "Hud.gd", `class_name Hud
+extends BasePanel
+
+const M = preload("res://src/util/Maths.gd")
+var Late = load("res://src/util/Late.gd")
+
+func draw() -> void:
+    M.clampf(1.0)
+`)
+
+	byID := map[string]*graph.Node{}
+	for _, n := range res.Nodes {
+		byID[n.ID] = n
+	}
+	require.Contains(t, byID, "Hud.gd::M")
+	assert.Equal(t, "res://src/util/Maths.gd", byID["Hud.gd::M"].Meta["gd_preload"])
+	require.Contains(t, byID, "Hud.gd::Late")
+	assert.Equal(t, "res://src/util/Late.gd", byID["Hud.gd::Late"].Meta["gd_preload"])
+
+	require.Contains(t, byID, "Hud.gd::Hud")
+	assert.Equal(t, "BasePanel", byID["Hud.gd::Hud"].Meta["gd_extends"],
+		"the receiver gate walks this chain before calling a mismatch")
+
+	assert.Equal(t, "M", gdCalls(res)["unresolved::*.clampf"].Meta["receiver_type"],
+		"an alias is a receiver whatever its casing")
+}
+
+func TestGDScriptExtractor_OpaqueExtendsIsRecorded(t *testing.T) {
+	res := gdExtract(t, "Hud.gd", `class_name Hud
+extends "res://src/base/Panel.gd"
+`)
+	for _, n := range res.Nodes {
+		if n.ID == "Hud.gd::Hud" {
+			assert.Equal(t, true, n.Meta["gd_extends_opaque"],
+				"a base named by path is unknown, not absent")
+			assert.NotContains(t, n.Meta, "gd_extends")
+			return
+		}
+	}
+	t.Fatal("class_name node missing")
+}

--- a/internal/parser/languages/godot_scene.go
+++ b/internal/parser/languages/godot_scene.go
@@ -146,6 +146,35 @@ func (e *GodotSceneExtractor) Extract(filePath string, src []byte) (*parser.Extr
 				})
 				// `instance=ExtResource("id")` rides the header itself.
 				e.addExtResourceRef(result, extResources, id, line, filePath, lineNo)
+			case "connection":
+				// `[connection signal="pressed" from="Button" to="."
+				// method="_on_random"]` wires a signal to a method of the
+				// script attached to the `to` node. The method is named as
+				// a bare string, so nothing in the scripts themselves
+				// records the link: without this edge a rename rewrites the
+				// method and leaves the scene calling a name that no longer
+				// exists, with nothing raising an error.
+				method := attrs["method"]
+				if method == "" {
+					continue
+				}
+				owner := godotScenePathNodeID(filePath, rootName, attrs["to"])
+				if owner == "" {
+					owner = fileNode.ID
+				}
+				// The method name rides in Meta as well as in the
+				// placeholder: once a weaker pass binds the placeholder to
+				// some same-named method, the name is the only way back to
+				// what the scene actually wrote.
+				meta := map[string]any{"godot_connection": true, "godot_method": method}
+				if sig := attrs["signal"]; sig != "" {
+					meta["godot_signal"] = sig
+				}
+				result.Edges = append(result.Edges, &graph.Edge{
+					From: owner, To: "unresolved::*." + method,
+					Kind: graph.EdgeReferences, FilePath: filePath, Line: lineNo,
+					Meta: meta,
+				})
 			}
 			continue
 		}
@@ -204,6 +233,21 @@ func parseGodotAttrs(header string) map[string]string {
 // to the root (`parent="Panel/VBox"`). Prefixing root reproduces the
 // NodePath Godot itself uses, so the ID is stable and collision-free
 // within the scene — including a child that shares the root's name.
+// godotScenePathNodeID resolves a NodePath as written in a `[connection]`
+// header (`to="."`, `to="Panel/VBox"`) to the scene node's graph ID. The
+// path is relative to the scene root, which `godotSceneNodeID` also
+// prefixes, so the two agree on every node in the scene.
+func godotScenePathNodeID(filePath, root, nodePath string) string {
+	if root == "" {
+		return ""
+	}
+	p := strings.Trim(strings.TrimSpace(nodePath), "/")
+	if p == "" || p == "." {
+		return filePath + "::" + root
+	}
+	return filePath + "::" + root + "/" + p
+}
+
 func godotSceneNodeID(filePath, root, parent, name string) string {
 	if name == "" {
 		return ""

--- a/internal/parser/languages/godot_scene_connection_test.go
+++ b/internal/parser/languages/godot_scene_connection_test.go
@@ -1,0 +1,58 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// A scene's `[connection]` block names a handler as a bare string. It is
+// the third place a signal wiring lives — alongside the bare method value
+// and the `Callable(self, "…")` string in the script itself — and the one
+// no script mentions at all.
+func TestGodotSceneExtractor_ConnectionReferencesHandler(t *testing.T) {
+	res, err := NewGodotSceneExtractor().Extract("ui/Panel.tscn", []byte(
+		`[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://ui/Panel.gd" id="1_abc"]
+
+[node name="Panel" type="Control"]
+script = ExtResource("1_abc")
+
+[node name="Button" type="Button" parent="."]
+
+[node name="Inner" type="Control" parent="Panel/Box"]
+
+[connection signal="pressed" from="Button" to="." method="_on_pressed"]
+
+[connection signal="hovered" from="Button" to="Panel/Box/Inner" method="_on_hover"]
+
+[connection signal="broken" from="Button" to="."]
+`))
+	require.NoError(t, err)
+
+	byMethod := map[string]*graph.Edge{}
+	for _, e := range res.Edges {
+		if e.Kind != graph.EdgeReferences || e.Meta == nil {
+			continue
+		}
+		if conn, _ := e.Meta["godot_connection"].(bool); conn {
+			byMethod[e.Meta["godot_method"].(string)] = e
+		}
+	}
+
+	require.Contains(t, byMethod, "_on_pressed")
+	assert.Equal(t, "ui/Panel.tscn::Panel", byMethod["_on_pressed"].From,
+		`to="." is the scene root, which is where the script usually hangs`)
+	assert.Equal(t, "unresolved::*._on_pressed", byMethod["_on_pressed"].To)
+	assert.Equal(t, "pressed", byMethod["_on_pressed"].Meta["godot_signal"])
+
+	require.Contains(t, byMethod, "_on_hover")
+	assert.Equal(t, "ui/Panel.tscn::Panel/Panel/Box/Inner", byMethod["_on_hover"].From,
+		"a deeper NodePath is relative to the root, exactly as node IDs are built")
+
+	assert.Len(t, byMethod, 2, "a connection with no method names no handler")
+}

--- a/internal/resolver/framework_synth.go
+++ b/internal/resolver/framework_synth.go
@@ -125,6 +125,8 @@ const (
 	SynthUIKitResolve        = "uikit-resolve"
 	SynthVaporResolve        = "vapor-resolve"
 	SynthGodotAutoload       = "godot-autoload"
+	SynthGodotPreloadAlias   = "godot-preload-alias"
+	SynthGodotConnection     = "godot-connection"
 	SynthGinMiddleware       = "gin-middleware"
 	SynthSvelteKitLoad       = "sveltekit-load"
 	SynthSpeculative         = "speculative-dispatch"
@@ -587,6 +589,7 @@ const (
 	frameworkMarkerSvelteKitServer    = "sveltekit-load:server"
 	frameworkMarkerPascalSource       = "pascal-form:source"
 	frameworkMarkerPascalForm         = "pascal-form:form"
+	frameworkMarkerGDScript           = "gdscript:node"
 	frameworkMarkerStrictFamilyPrefix = "family-strict:"
 
 	frameworkObserverRegistrarRole  uint8 = 1
@@ -690,6 +693,13 @@ func recordFrameworkNodeCandidates(markers map[string]int, n *graph.Node, family
 		if (n.Kind == graph.KindMethod || n.Kind == graph.KindFunction) && n.Name == "handle" {
 			markers[SynthLaravelEvent]++
 		}
+	case "gdscript":
+		// The receiver gate reads only GDScript nodes, so a corpus with
+		// none provably yields no demotion — and on a scoped run, a
+		// resolve that touched no GDScript file cannot have changed any
+		// verdict, since both the call edges and the class index it
+		// judges against come from `.gd` files.
+		markers[frameworkMarkerGDScript]++
 	case "csharp":
 		if n.Kind == graph.KindInterface {
 			markers[SynthCSharpIfaceDispatch]++
@@ -970,6 +980,16 @@ func defaultFrameworkSynthesizers() []FrameworkSynthesizer {
 		// the script `project.godot` declares the singleton `Game` to
 		// be — the only place that mapping exists.
 		synthFunc{name: SynthGodotAutoload, fn: ResolveGDScriptAutoloads},
+		// Godot preload aliases: a `const Persist = preload("res://…")`
+		// names a script file-locally, and `Persist.snapshot()` is then
+		// used exactly like a global — the standard way to reach a
+		// static-utility script that declares no `class_name`.
+		synthFunc{name: SynthGodotPreloadAlias, fn: ResolveGDScriptPreloadAliases},
+		// Godot scene connections: a `.tscn` `[connection … method="…"]`
+		// block wires a signal to a method of the script attached to the
+		// target node. The method is named as a bare string, so nothing in
+		// the scripts records the link.
+		synthFunc{name: SynthGodotConnection, fn: ResolveGodotSceneConnections},
 		// SwiftUI directory-convention fallback: a residual `*View` /
 		// `*ViewModel` / `*Store` / `*Manager` / PascalCase-model reference
 		// binds to its /Views/ /ViewModels/ /Stores/ /Models/ definition.
@@ -1043,6 +1063,10 @@ type FrameworkSynthReport struct {
 	// tier because they attach to a same-named member of a type unrelated to
 	// the edge's receiver_type.
 	ReceiverGated int `json:"receiver_type_gated,omitempty"`
+	// GDScriptReceiverGated counts the same demotion for GDScript, where the
+	// receiver is stated at every call site and a same-named method in the
+	// caller's own directory is the standing phantom.
+	GDScriptReceiverGated int `json:"gdscript_receiver_type_gated,omitempty"`
 	// GateMillis/ClaimMillis/DemoteMillis time the three tail passes that
 	// run once (not per-synthesizer) after the main loop, so a slow one
 	// doesn't hide behind the loop's aggregate elapsed.
@@ -1265,6 +1289,13 @@ func runFrameworkSynthesizersScoped(
 			g, executionScope, filePaths, csharpHierarchyChanged,
 		)
 	}
+	// The GDScript gate runs in the same slot and for the same reason: it
+	// corrects already-bound member calls, so it must see the settled call
+	// graph — after the Godot autoload / preload-alias binders above have
+	// had their chance to claim an edge the gate would otherwise judge.
+	if frameworkGDScriptGateNeeded(candidates) {
+		rep.GDScriptReceiverGated = DemoteGDScriptReceiverMismatches(g)
+	}
 	rep.DemoteMillis = time.Since(demoteStart).Milliseconds()
 	return rep
 }
@@ -1304,6 +1335,20 @@ func frameworkFamilyGateNeeded(_ map[string]bool, summary frameworkCandidateSumm
 // type/interface names proves the gate returns zero on any graph. Scoped
 // runs always run the gate — the gate's name index is whole-graph while a
 // scoped census is not.
+// frameworkGDScriptGateNeeded reports whether the GDScript receiver gate
+// can change anything. Unlike the family/receiver tails, a scoped census
+// is enough here: the gate reads only GDScript nodes and edges, so a
+// resolve whose candidate set contains no GDScript node cannot have moved
+// a verdict. The gate runs whole-graph when it runs, so keeping it off a
+// resolve that touched no `.gd` file is what keeps a warm restart on a
+// polyglot workspace from paying for it.
+func frameworkGDScriptGateNeeded(summary frameworkCandidateSummary) bool {
+	if summary.fullCensus {
+		return summary.allMarkers[frameworkMarkerGDScript] > 0
+	}
+	return summary.scopedMarkers[frameworkMarkerGDScript] > 0
+}
+
 func frameworkReceiverGateNeeded(_ map[string]bool, summary frameworkCandidateSummary) bool {
 	if !summary.fullCensus {
 		return true

--- a/internal/resolver/gdscript_autoload.go
+++ b/internal/resolver/gdscript_autoload.go
@@ -34,7 +34,11 @@ func ResolveGDScriptAutoloads(g graph.Store) int {
 	if len(scripts) == 0 {
 		return 0
 	}
-	members := gdMembersByFile(g, scripts)
+	want := make(map[string]bool, len(scripts))
+	for _, fileID := range scripts {
+		want[fileID] = true
+	}
+	members := gdMembersByFileSet(g, want)
 	resolved := 0
 	var reindex []graph.EdgeReindex
 	for e := range g.EdgesByKind(graph.EdgeCalls) {
@@ -141,13 +145,12 @@ func gdPathMatches(filePath, script string) bool {
 	return strings.HasSuffix(p, "/"+script)
 }
 
-// gdMembersByFile indexes the callable members declared by each autoload
-// script, by name. Signals are included: `Game.started.emit()` and a
-// direct connect both reference the signal as a member.
-func gdMembersByFile(g graph.Store, scripts map[string]string) map[string]map[string]string {
-	want := make(map[string]bool, len(scripts))
-	for _, fileID := range scripts {
-		want[fileID] = true
+// gdMembersByFileSet indexes the callable members declared by each of the
+// named script files, by name. Signals are included: `Game.started.emit()`
+// and a direct connect both reference the signal as a member.
+func gdMembersByFileSet(g graph.Store, want map[string]bool) map[string]map[string]string {
+	if len(want) == 0 {
+		return nil
 	}
 	out := make(map[string]map[string]string, len(want))
 	for _, kind := range []graph.NodeKind{graph.KindMethod, graph.KindFunction} {

--- a/internal/resolver/gdscript_preload_alias.go
+++ b/internal/resolver/gdscript_preload_alias.go
@@ -1,0 +1,173 @@
+package resolver
+
+import (
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// GDScript preload-alias resolution. A script with no `class_name` is
+// still reachable by name — every file that wants it declares its own
+// alias:
+//
+//	const Persist = preload("res://src/save/Persist.gd")
+//	...
+//	Persist.snapshot(self)
+//
+// This is the standard way to reach a static-utility script, and it is
+// the shape that survives when a project deliberately keeps a script out
+// of the global class table. The extractor stamps the alias as the
+// call's receiver_type and records the loaded path on the const itself;
+// nothing else in the graph connects the two, because the alias is
+// file-local — the same name means a different script one directory over.
+//
+// This pass supplies that link, per file: it reads the alias consts each
+// script declares, maps each to the file it preloads, and binds residual
+// `unresolved::*.method` calls in THAT file whose receiver_type names one
+// of its own aliases. A name the loaded script does not declare is left
+// alone rather than bound to the file.
+func ResolveGDScriptPreloadAliases(g graph.Store) int {
+	if g == nil {
+		return 0
+	}
+	// aliases[fileID][aliasName] = target script file ID.
+	aliases := gdPreloadAliases(g)
+	if len(aliases) == 0 {
+		return 0
+	}
+	targets := make(map[string]bool)
+	for _, byName := range aliases {
+		for _, fileID := range byName {
+			targets[fileID] = true
+		}
+	}
+	members := gdMembersByFileSet(g, targets)
+
+	resolved := 0
+	var reindex []graph.EdgeReindex
+	for e := range g.EdgesByKind(graph.EdgeCalls) {
+		if e == nil || e.Meta == nil || !graph.IsUnresolvedTarget(e.To) {
+			continue
+		}
+		recv, _ := e.Meta["receiver_type"].(string)
+		if recv == "" {
+			continue
+		}
+		byName := aliases[gdEdgeSourceFile(e)]
+		if byName == nil {
+			continue
+		}
+		target := members[byName[recv]][strings.TrimPrefix(graph.UnresolvedName(e.To), "*.")]
+		if target == "" {
+			continue
+		}
+		oldTo := e.To
+		e.To = target
+		// The alias states its own path in the source line that declares
+		// it, and the loaded script declares the member. Same grade of
+		// evidence as the autoload binding this mirrors.
+		e.Origin = graph.OriginASTResolved
+		e.Confidence = 0.9
+		e.ConfidenceLabel = graph.ConfidenceLabelFor(graph.EdgeCalls, 0.9)
+		StampSynthesized(e, SynthGodotPreloadAlias)
+		reindex = append(reindex, graph.EdgeReindex{Edge: e, OldTo: oldTo})
+		resolved++
+	}
+	if len(reindex) > 0 {
+		g.ReindexEdges(reindex)
+	}
+	return resolved
+}
+
+// gdEdgeSourceFile returns the graph file ID an edge is sourced from.
+// A call attributed to the file node IS the file ID; one attributed to a
+// symbol carries it ahead of the `::` separator.
+func gdEdgeSourceFile(e *graph.Edge) string {
+	if i := strings.Index(e.From, "::"); i >= 0 {
+		return e.From[:i]
+	}
+	return e.From
+}
+
+// gdPreloadAliases maps, per GDScript file, each preload-alias name to
+// the graph file ID of the script it loads. An alias whose path is not
+// indexed, or is ambiguous across two indexed scripts, is dropped.
+func gdPreloadAliases(g graph.Store) map[string]map[string]string {
+	// decls[fileID][alias] = declared res:// path (project-relative).
+	var decls map[string]map[string]string
+	for n := range g.NodesByKind(graph.KindVariable) {
+		if n == nil || n.Meta == nil || n.Language != "gdscript" {
+			continue
+		}
+		path, _ := n.Meta["gd_preload"].(string)
+		path = gdProjectRelPath(path)
+		if path == "" || !strings.HasSuffix(path, ".gd") {
+			continue
+		}
+		fileID, _, ok := strings.Cut(n.ID, "::")
+		if !ok {
+			continue
+		}
+		if decls == nil {
+			decls = map[string]map[string]string{}
+		}
+		if decls[fileID] == nil {
+			decls[fileID] = map[string]string{}
+		}
+		decls[fileID][n.Name] = path
+	}
+	if len(decls) == 0 {
+		return nil
+	}
+
+	// One pass over the script file nodes serves every alias — a scan per
+	// alias would multiply a full-store walk by the project's alias count.
+	byPath := make(map[string]string)
+	ambiguous := make(map[string]bool)
+	wanted := make(map[string]bool)
+	for _, byName := range decls {
+		for _, path := range byName {
+			wanted[path] = true
+		}
+	}
+	for f := range g.NodesByKind(graph.KindFile) {
+		if f == nil || f.Language != "gdscript" {
+			continue
+		}
+		for path := range wanted {
+			if ambiguous[path] || !gdPathMatches(f.FilePath, path) {
+				continue
+			}
+			if prev, seen := byPath[path]; seen && prev != f.ID {
+				delete(byPath, path)
+				ambiguous[path] = true
+				continue
+			}
+			byPath[path] = f.ID
+		}
+	}
+
+	out := make(map[string]map[string]string, len(decls))
+	for fileID, byName := range decls {
+		for alias, path := range byName {
+			target := byPath[path]
+			if target == "" || target == fileID {
+				continue
+			}
+			if out[fileID] == nil {
+				out[fileID] = map[string]string{}
+			}
+			out[fileID][alias] = target
+		}
+	}
+	return out
+}
+
+// gdProjectRelPath strips the `res://` scheme and any leading separator,
+// leaving the project-relative path the file index is matched against.
+func gdProjectRelPath(p string) string {
+	if !strings.HasPrefix(p, godotResScheme) {
+		return ""
+	}
+	return strings.Trim(strings.TrimPrefix(p, godotResScheme), "/")
+}

--- a/internal/resolver/gdscript_preload_alias_test.go
+++ b/internal/resolver/gdscript_preload_alias_test.go
@@ -1,0 +1,79 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// gdAliasConst declares `const <alias> = preload("<path>")` in a script.
+func gdAliasConst(g *graph.Graph, file, alias, path string) {
+	g.AddNode(&graph.Node{
+		ID: file + "::" + alias, Kind: graph.KindVariable, Name: alias,
+		FilePath: file, Language: "gdscript",
+		Meta: map[string]any{"const": true, "gd_preload": path},
+	})
+}
+
+func gdPreloadGraph(t *testing.T) *graph.Graph {
+	t.Helper()
+	g := graph.New()
+	gdScriptFile(g, "src/util/Maths.gd", "clampf")
+	gdScriptFile(g, "src/ui/Hud.gd", "draw")
+	gdAliasConst(g, "src/ui/Hud.gd", "M", "res://src/util/Maths.gd")
+	return g
+}
+
+// A script with no `class_name` is reached by the alias its callers
+// declare for it. The alias is file-local — the same name one directory
+// over means a different script — so nothing but the const's own declared
+// path connects the two.
+func TestResolveGDScriptPreloadAliases_BindsAliasedMember(t *testing.T) {
+	g := gdPreloadGraph(t)
+	gdRecvCall(g, "src/ui/Hud.gd::draw", "src/ui/Hud.gd", "clampf", "M")
+
+	require.Equal(t, 1, ResolveGDScriptPreloadAliases(g))
+	e := gdCallEdge(g, "src/ui/Hud.gd::draw", "src/util/Maths.gd::clampf")
+	require.NotNil(t, e)
+	assert.Equal(t, graph.OriginASTResolved, e.Origin)
+	assert.Equal(t, SynthGodotPreloadAlias, e.Meta[MetaSynthesizedBy])
+}
+
+// The alias belongs to the file that declares it. Another script using
+// the same name for something else must not ride it.
+func TestResolveGDScriptPreloadAliases_IsFileLocal(t *testing.T) {
+	g := gdPreloadGraph(t)
+	gdScriptFile(g, "src/ui/Other.gd", "paint")
+	gdRecvCall(g, "src/ui/Other.gd::paint", "src/ui/Other.gd", "clampf", "M")
+
+	assert.Zero(t, ResolveGDScriptPreloadAliases(g))
+	assert.Nil(t, gdCallEdge(g, "src/ui/Other.gd::paint", "src/util/Maths.gd::clampf"))
+}
+
+// A member the loaded script does not declare is left unresolved rather
+// than bound to the file — the alias proves which script, not which name.
+func TestResolveGDScriptPreloadAliases_UnknownMemberStaysUnresolved(t *testing.T) {
+	g := gdPreloadGraph(t)
+	gdRecvCall(g, "src/ui/Hud.gd::draw", "src/ui/Hud.gd", "missing", "M")
+
+	assert.Zero(t, ResolveGDScriptPreloadAliases(g))
+	assert.NotNil(t, gdCallEdge(g, "src/ui/Hud.gd::draw", "unresolved::*.missing"))
+}
+
+// A path matching two indexed scripts names neither.
+func TestResolveGDScriptPreloadAliases_AmbiguousPathRefuses(t *testing.T) {
+	g := gdPreloadGraph(t)
+	gdScriptFile(g, "vendor/src/util/Maths.gd", "clampf")
+	gdRecvCall(g, "src/ui/Hud.gd::draw", "src/ui/Hud.gd", "clampf", "M")
+
+	assert.Zero(t, ResolveGDScriptPreloadAliases(g))
+}
+
+func TestResolveGDScriptPreloadAliases_NoAliasesIsANoOp(t *testing.T) {
+	g := graph.New()
+	gdScriptFile(g, "src/ui/Hud.gd", "draw")
+	assert.Zero(t, ResolveGDScriptPreloadAliases(g))
+}

--- a/internal/resolver/gdscript_receiver_gate.go
+++ b/internal/resolver/gdscript_receiver_gate.go
@@ -1,0 +1,213 @@
+package resolver
+
+import (
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Receiver-type gating for GDScript member-call attribution.
+//
+// A GDScript call states its receiver — `Items.apply(...)` — and the
+// extractor stamps that name on the edge. When no member of that receiver
+// can be found, a weak resolver tier still answers with whatever
+// same-named method sits nearest the caller, and the receiver evidence is
+// silently discarded. With `apply` declared in several unrelated classes,
+// the caller list of any one of them then contains calls that belong to
+// the others:
+//
+//	# reported as callers of Carry.apply, but the source lines read:
+//	Items.apply(state, av, item_id)
+//	Effects.apply(world, state, reward)
+//
+// For blast radius this is the dangerous direction: the count looks
+// reassuring while pointing at the wrong code. This pass demotes such
+// edges to the speculative tier so they drop out of every default query
+// and min_tier filter, mirroring the C# receiver gate.
+//
+// A demotion is only taken when the mismatch is PROVABLE. Inherited
+// dispatch (`Child.method()` landing on `Parent.method`) is a legitimate
+// bind and is preserved by walking the receiver's `extends` chain; a
+// chain the extractor could not read as one in-repo class name is opaque
+// and declines to judge. Autoload and preload-alias receivers are checked
+// against the script they actually name.
+func DemoteGDScriptReceiverMismatches(g graph.Store) int {
+	if g == nil {
+		return 0
+	}
+	classes := gdClassIndex(g)
+	if len(classes) == 0 {
+		return 0
+	}
+	autoloads := gdAutoloadScripts(g)
+	aliases := gdPreloadAliases(g)
+
+	var reindex []graph.EdgeReindex
+	for _, kind := range []graph.EdgeKind{graph.EdgeCalls, graph.EdgeReferences} {
+		for e := range g.EdgesByKind(kind) {
+			if !gdReceiverMismatch(g, e, classes, autoloads, aliases) {
+				continue
+			}
+			e.Origin = graph.OriginSpeculative
+			if e.Meta == nil {
+				e.Meta = map[string]any{}
+			}
+			e.Meta[graph.MetaSpeculative] = true
+			e.Meta["demoted"] = "receiver_type_mismatch"
+			reindex = append(reindex, graph.EdgeReindex{
+				Edge: e, OldFrom: e.From, OldTo: e.To,
+				OldFilePath: e.FilePath, OldLine: e.Line, RefreshIdentity: true,
+			})
+		}
+	}
+	if len(reindex) > 0 {
+		g.ReindexEdges(reindex)
+	}
+	return len(reindex)
+}
+
+// gdClass is one GDScript class the gate can reason about: the file that
+// declares it, its declared base, and whether that base is readable.
+type gdClass struct {
+	fileID string
+	parent string
+	// opaque marks a class whose base the extractor could not reduce to a
+	// single in-repo class name — an `extends "res://…"`, a dotted inner
+	// class, or an inner class whose own base was never parsed. Its
+	// ancestry is unknown, so no mismatch against it is provable.
+	opaque bool
+}
+
+// gdClassIndex maps each GDScript class name to its declaration. A name
+// declared by two different files is ambiguous — the gate cannot tell
+// which one a receiver means, so it is marked opaque rather than dropped,
+// which keeps it from being read as "no such class exists".
+func gdClassIndex(g graph.Store) map[string]*gdClass {
+	out := map[string]*gdClass{}
+	for n := range g.NodesByKind(graph.KindType) {
+		if n == nil || n.Language != "gdscript" || n.Meta == nil {
+			continue
+		}
+		switch kind, _ := n.Meta["gd_kind"].(string); kind {
+		case "class_name", "inner_class":
+		default:
+			continue
+		}
+		fileID, _, _ := strings.Cut(n.ID, "::")
+		parent, _ := n.Meta["gd_extends"].(string)
+		opaque, _ := n.Meta["gd_extends_opaque"].(bool)
+		if prev, dup := out[n.Name]; dup {
+			if prev.fileID != fileID {
+				prev.opaque = true
+			}
+			continue
+		}
+		out[n.Name] = &gdClass{fileID: fileID, parent: parent, opaque: opaque}
+	}
+	return out
+}
+
+// gdReceiverMismatch reports whether a resolved GDScript edge binds to a
+// member that its stated receiver provably does not own.
+func gdReceiverMismatch(
+	g graph.Store,
+	e *graph.Edge,
+	classes map[string]*gdClass,
+	autoloads map[string]string,
+	aliases map[string]map[string]string,
+) bool {
+	if e == nil || e.Meta == nil || e.To == "" || graph.IsUnresolvedTarget(e.To) {
+		return false
+	}
+	if _, already := e.Meta["demoted"]; already {
+		return false
+	}
+	recv, _ := e.Meta["receiver_type"].(string)
+	if recv == "" {
+		return false
+	}
+	target := g.GetNode(e.To)
+	if target == nil || target.Language != "gdscript" {
+		return false
+	}
+	targetFile, _, _ := strings.Cut(target.ID, "::")
+	// A binding inside the caller's own file needs no receiver evidence:
+	// the definition is right there, and `self`-shaped receivers on a
+	// script with no `class_name` legitimately land on it.
+	if targetFile == gdEdgeSourceFile(e) {
+		return false
+	}
+
+	// The receiver names a script directly — an autoload singleton or a
+	// file-local preload alias. Whether that is the script the edge landed
+	// on is a fact, not a guess, either way.
+	if fileID, ok := autoloads[recv]; ok && fileID != "" {
+		return fileID != targetFile
+	}
+	if fileID := aliases[gdEdgeSourceFile(e)][recv]; fileID != "" {
+		return fileID != targetFile
+	}
+
+	owner := ""
+	if target.Meta != nil {
+		owner, _ = target.Meta["receiver"].(string)
+	}
+	if owner == recv {
+		return false
+	}
+
+	recvClass, known := classes[recv]
+	if known && recvClass.opaque {
+		return false
+	}
+	if !known {
+		// No in-repo class, autoload or alias carries this name — it is an
+		// engine type (`Input`, `OS`) or a global this index never saw. No
+		// in-repo method can be its member, so any bind here is a phantom.
+		// The one exception is a receiver the caller's own file declares as
+		// a plain variable: that is a local alias whose target the graph
+		// does not track, and a mismatch is not provable.
+		return !gdReceiverLocallyDeclared(g, e, recv)
+	}
+	if owner == "" {
+		// A plain function in a script with no `class_name`, reached from
+		// another file by a receiver naming a class. The autoload and alias
+		// routes above are the only legitimate ways to name such a script,
+		// and neither claimed this edge.
+		return true
+	}
+	// Inherited dispatch: walk the receiver's declared base chain. Any
+	// unreadable link makes the ancestry unknown and the verdict unsafe.
+	for seen, cur := map[string]bool{recv: true}, recvClass; cur != nil; {
+		if cur.opaque {
+			return false
+		}
+		if cur.parent == "" {
+			return true
+		}
+		if cur.parent == owner {
+			return false
+		}
+		next, ok := classes[cur.parent]
+		if !ok {
+			// The base is an engine class (`Node`, `Resource`); the chain
+			// leaves the repo, so no in-repo owner can be above it.
+			return true
+		}
+		if seen[cur.parent] {
+			return false // a cycle in declared bases proves nothing
+		}
+		seen[cur.parent] = true
+		cur = next
+	}
+	return true
+}
+
+// gdReceiverLocallyDeclared reports whether the calling file declares the
+// receiver name itself — a `var`/`const` holding a value whose type the
+// graph does not track. Such a receiver is a local alias, not a claim
+// about a class, so no mismatch can be proven from it.
+func gdReceiverLocallyDeclared(g graph.Store, e *graph.Edge, recv string) bool {
+	n := g.GetNode(gdEdgeSourceFile(e) + "::" + recv)
+	return n != nil && n.Language == "gdscript" && n.Kind == graph.KindVariable
+}

--- a/internal/resolver/gdscript_receiver_gate_test.go
+++ b/internal/resolver/gdscript_receiver_gate_test.go
@@ -1,0 +1,190 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// gdClassScript declares a `class_name` script: the file, its class node
+// (with an optional base), and the methods that class owns.
+func gdClassScript(g *graph.Graph, path, class, extends string, methods ...string) {
+	g.AddNode(&graph.Node{
+		ID: path, Kind: graph.KindFile, Name: path,
+		FilePath: path, Language: "gdscript",
+	})
+	meta := map[string]any{"gd_kind": "class_name"}
+	if extends != "" {
+		meta["gd_extends"] = extends
+	}
+	g.AddNode(&graph.Node{
+		ID: path + "::" + class, Kind: graph.KindType, Name: class,
+		FilePath: path, Language: "gdscript", Meta: meta,
+	})
+	for _, m := range methods {
+		g.AddNode(&graph.Node{
+			ID: path + "::" + m, Kind: graph.KindMethod, Name: m,
+			FilePath: path, Language: "gdscript",
+			Meta: map[string]any{"receiver": class},
+		})
+	}
+}
+
+// gdBoundCall is a call already resolved onto a target by a weak tier,
+// carrying the receiver its source stated.
+func gdBoundCall(g *graph.Graph, from, file, to, recv string) *graph.Edge {
+	gdBoundCallLine++
+	e := &graph.Edge{
+		From: from, To: to, Kind: graph.EdgeCalls, FilePath: file,
+		// Distinct lines: two call sites in one func onto one target
+		// differ only by line, and the store keys edges by identity.
+		Line:   gdBoundCallLine,
+		Origin: graph.OriginASTInferred, Confidence: 0.7,
+		Meta: map[string]any{"receiver_type": recv},
+	}
+	g.AddEdge(e)
+	return e
+}
+
+var gdBoundCallLine int
+
+func gdDemoted(e *graph.Edge) bool {
+	reason, _ := e.Meta["demoted"].(string)
+	return reason == "receiver_type_mismatch"
+}
+
+// A call states its receiver. When the bind contradicts it, the caller
+// list of the target is wrong in the direction that matters: the count
+// looks reassuring while pointing at code the change cannot reach.
+func TestDemoteGDScriptReceiverMismatches_UnrelatedClass(t *testing.T) {
+	g := graph.New()
+	gdClassScript(g, "src/ui/Carry.gd", "Carry", "RefCounted", "apply")
+	gdClassScript(g, "src/data/Items.gd", "Items", "RefCounted", "give")
+	gdClassScript(g, "src/ui/Caller.gd", "Caller", "Control", "run")
+	mismatch := gdBoundCall(g, "src/ui/Caller.gd::run", "src/ui/Caller.gd",
+		"src/ui/Carry.gd::apply", "Items")
+	right := gdBoundCall(g, "src/ui/Caller.gd::run", "src/ui/Caller.gd",
+		"src/ui/Carry.gd::apply", "Carry")
+
+	require.Equal(t, 1, DemoteGDScriptReceiverMismatches(g))
+	assert.True(t, gdDemoted(mismatch))
+	assert.Equal(t, graph.OriginSpeculative, mismatch.Origin,
+		"the evidence stays inspectable rather than being deleted")
+	assert.False(t, gdDemoted(right))
+}
+
+// An engine singleton (`Input`, `OS`) names no in-repo class, so no
+// in-repo method can be its member.
+func TestDemoteGDScriptReceiverMismatches_UnknownReceiver(t *testing.T) {
+	g := graph.New()
+	gdClassScript(g, "src/ui/Carry.gd", "Carry", "RefCounted", "apply")
+	gdClassScript(g, "src/ui/Caller.gd", "Caller", "Control", "run")
+	e := gdBoundCall(g, "src/ui/Caller.gd::run", "src/ui/Caller.gd",
+		"src/ui/Carry.gd::apply", "Input")
+
+	require.Equal(t, 1, DemoteGDScriptReceiverMismatches(g))
+	assert.True(t, gdDemoted(e))
+}
+
+// A receiver the calling file declares itself is a local alias whose
+// target the graph does not track — a mismatch is not provable.
+func TestDemoteGDScriptReceiverMismatches_LocalAliasIsNotProvable(t *testing.T) {
+	g := graph.New()
+	gdClassScript(g, "src/ui/Carry.gd", "Carry", "RefCounted", "apply")
+	gdClassScript(g, "src/ui/Caller.gd", "Caller", "Control", "run")
+	g.AddNode(&graph.Node{
+		ID: "src/ui/Caller.gd::Helper", Kind: graph.KindVariable, Name: "Helper",
+		FilePath: "src/ui/Caller.gd", Language: "gdscript",
+		Meta: map[string]any{"const": true},
+	})
+	e := gdBoundCall(g, "src/ui/Caller.gd::run", "src/ui/Caller.gd",
+		"src/ui/Carry.gd::apply", "Helper")
+
+	assert.Zero(t, DemoteGDScriptReceiverMismatches(g))
+	assert.False(t, gdDemoted(e))
+}
+
+// Calling an inherited method is dispatch, not a phantom. Over-demoting
+// here would trade one wrong answer for another.
+func TestDemoteGDScriptReceiverMismatches_InheritedDispatchSurvives(t *testing.T) {
+	g := graph.New()
+	gdClassScript(g, "src/base/Base.gd", "Base", "Node", "shared")
+	gdClassScript(g, "src/base/Mid.gd", "Mid", "Base")
+	gdClassScript(g, "src/base/Derived.gd", "Derived", "Mid")
+	gdClassScript(g, "src/ui/Caller.gd", "Caller", "Control", "run")
+	e := gdBoundCall(g, "src/ui/Caller.gd::run", "src/ui/Caller.gd",
+		"src/base/Base.gd::shared", "Derived")
+
+	assert.Zero(t, DemoteGDScriptReceiverMismatches(g))
+	assert.False(t, gdDemoted(e))
+}
+
+// A base the extractor could not read as one in-repo class name leaves
+// the ancestry unknown, so no mismatch against it is provable.
+func TestDemoteGDScriptReceiverMismatches_OpaqueBaseDeclines(t *testing.T) {
+	g := graph.New()
+	gdClassScript(g, "src/base/Base.gd", "Base", "Node", "shared")
+	gdClassScript(g, "src/ui/Caller.gd", "Caller", "Control", "run")
+	g.AddNode(&graph.Node{
+		ID: "src/ui/Odd.gd", Kind: graph.KindFile, Name: "src/ui/Odd.gd",
+		FilePath: "src/ui/Odd.gd", Language: "gdscript",
+	})
+	g.AddNode(&graph.Node{
+		ID: "src/ui/Odd.gd::Odd", Kind: graph.KindType, Name: "Odd",
+		FilePath: "src/ui/Odd.gd", Language: "gdscript",
+		Meta: map[string]any{"gd_kind": "class_name", "gd_extends_opaque": true},
+	})
+	e := gdBoundCall(g, "src/ui/Caller.gd::run", "src/ui/Caller.gd",
+		"src/base/Base.gd::shared", "Odd")
+
+	assert.Zero(t, DemoteGDScriptReceiverMismatches(g))
+	assert.False(t, gdDemoted(e))
+}
+
+// The autoload and preload-alias binders name a script directly; the gate
+// must recognise their work rather than judge it against a class name.
+func TestDemoteGDScriptReceiverMismatches_AutoloadReceiverKeeps(t *testing.T) {
+	g := graph.New()
+	gdAutoloadNode(g, "Game", "src/core/Game.gd")
+	gdScriptFile(g, "src/core/Game.gd", "set_speed")
+	gdClassScript(g, "src/ui/Caller.gd", "Caller", "Control", "run")
+	keep := gdBoundCall(g, "src/ui/Caller.gd::run", "src/ui/Caller.gd",
+		"src/core/Game.gd::set_speed", "Game")
+
+	assert.Zero(t, DemoteGDScriptReceiverMismatches(g))
+	assert.False(t, gdDemoted(keep))
+}
+
+func TestDemoteGDScriptReceiverMismatches_AutoloadReceiverOnWrongScript(t *testing.T) {
+	g := graph.New()
+	gdAutoloadNode(g, "Game", "src/core/Game.gd")
+	gdScriptFile(g, "src/core/Game.gd", "set_speed")
+	gdClassScript(g, "src/ui/Other.gd", "Other", "Node", "set_speed")
+	gdClassScript(g, "src/ui/Caller.gd", "Caller", "Control", "run")
+	e := gdBoundCall(g, "src/ui/Caller.gd::run", "src/ui/Caller.gd",
+		"src/ui/Other.gd::set_speed", "Game")
+
+	require.Equal(t, 1, DemoteGDScriptReceiverMismatches(g))
+	assert.True(t, gdDemoted(e))
+}
+
+// A same-file bind needs no receiver evidence — the definition is right
+// there, and a `self` receiver on a script with no class_name lands on it.
+func TestDemoteGDScriptReceiverMismatches_SameFileKeeps(t *testing.T) {
+	g := graph.New()
+	gdClassScript(g, "src/ui/Panel.gd", "Panel", "Control", "run", "tick")
+	e := gdBoundCall(g, "src/ui/Panel.gd::run", "src/ui/Panel.gd",
+		"src/ui/Panel.gd::tick", "Something")
+
+	assert.Zero(t, DemoteGDScriptReceiverMismatches(g))
+	assert.False(t, gdDemoted(e))
+}
+
+func TestDemoteGDScriptReceiverMismatches_NoGDScriptIsANoOp(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "a.go", Kind: graph.KindFile, Name: "a.go", Language: "go"})
+	assert.Zero(t, DemoteGDScriptReceiverMismatches(g))
+}

--- a/internal/resolver/godot_res_paths.go
+++ b/internal/resolver/godot_res_paths.go
@@ -16,6 +16,25 @@ const godotResScheme = "res://"
 // until this pass lands it on the indexed file.
 const godotResPlaceholderPrefix = "unresolved::import::" + godotResScheme
 
+// isGodotResPlaceholder reports whether a target is a parked `res://`
+// reference that resolveGodotResPaths owns.
+//
+// The generic resolvers must leave it alone. A `res://` path is rooted at
+// the Godot project, never at a package registry, so the `external::`
+// stub they fall back to is always wrong — and it is also unrecoverable:
+// once the scheme is buried inside a bookkeeping string, the later Godot
+// pass cannot tell it from any other unresolved import, and every scene →
+// script edge is lost. That is what used to happen on every real index:
+// this pass ran, found no placeholder left to bind, and did nothing.
+//
+// Holding them back costs nothing — the pass that owns them runs in the
+// same resolve — and a path this pass cannot bind stays unresolved rather
+// than becoming an `external::` stub, which is the honest answer for an
+// asset outside the corpus and the one the pass's own tests pin.
+func isGodotResPlaceholder(to string) bool {
+	return strings.HasPrefix(to, godotResPlaceholderPrefix)
+}
+
 // resolveGodotResPaths binds `res://` references onto the file they name.
 //
 // Two extractors mint these placeholders and neither could resolve them:
@@ -32,7 +51,11 @@ const godotResPlaceholderPrefix = "unresolved::import::" + godotResScheme
 // refuses rather than guesses — see uniqueFileSuffixMatch.
 //
 // Runs serially in ResolveAll's relative-import settle window, alongside
-// the Lua require binding it mirrors.
+// the Lua require binding it mirrors. Reaching that window at all takes
+// isGodotResPlaceholder holding the generic resolvers off: they run
+// first, and each of them stubs an unrecognised import out to
+// `external::<path>` — which this pass can no longer recognise, so
+// nothing here ever fired through the real pipeline.
 func (r *Resolver) resolveGodotResPaths() {
 	if !r.graphHasLanguage("godot_resource") && !r.graphHasLanguage("gdscript") {
 		return

--- a/internal/resolver/godot_scene_connections.go
+++ b/internal/resolver/godot_scene_connections.go
@@ -1,0 +1,150 @@
+package resolver
+
+import (
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Godot scene-connection resolution. A `.tscn` wires a signal to a
+// handler in a block that names the method as a bare string:
+//
+//	[connection signal="pressed" from="Button" to="." method="_on_random"]
+//
+// The method belongs to the script attached to the `to` node — a
+// relationship spread across three places (the connection block, the
+// node's `script = ExtResource(…)` assignment, and the `[ext_resource]`
+// header that gives the path) and recorded in none of the scripts. Left
+// unresolved, a rename rewrites the method and leaves the scene calling a
+// name that no longer exists; the project still loads, nothing errors,
+// and the button silently stops working.
+//
+// This pass joins the three: for each connection edge, it follows the
+// owning scene node's script reference to the `.gd` file and binds the
+// named member. A node with no script, a script that is not indexed, and
+// a method the script does not declare are each left alone rather than
+// guessed at.
+//
+// It is authoritative, not a fallback. The generic reference resolver
+// reaches these placeholders first and binds them by name at a weak
+// tier — which happens to be right when the handler name is unique in
+// the project and silently wrong when it is not, and `_on_pressed` is
+// never unique. The scene states which script owns the node, so this
+// pass overrides that guess wherever it can compute the answer.
+func ResolveGodotSceneConnections(g graph.Store) int {
+	if g == nil {
+		return 0
+	}
+	pending := gdConnectionEdges(g)
+	if len(pending) == 0 {
+		return 0
+	}
+
+	// The scene node that owns the connection carries the script binding as
+	// an outgoing reference; a scene whose root holds the script covers the
+	// common `to="."` case directly.
+	scripts := make(map[string]string, len(pending))
+	scriptFiles := make(map[string]bool)
+	for _, e := range pending {
+		if _, done := scripts[e.From]; done {
+			continue
+		}
+		fileID := gdScriptOfSceneNode(g, e.From)
+		scripts[e.From] = fileID
+		if fileID != "" {
+			scriptFiles[fileID] = true
+		}
+	}
+	members := gdMembersByFileSet(g, scriptFiles)
+
+	resolved := 0
+	var reindex []graph.EdgeReindex
+	for _, e := range pending {
+		fileID := scripts[e.From]
+		if fileID == "" {
+			continue
+		}
+		method, ok := e.Meta["godot_method"].(string)
+		if !ok || method == "" {
+			continue
+		}
+		target := members[fileID][method]
+		if target == "" {
+			continue
+		}
+		oldTo := e.To
+		e.To = target
+		// Every hop is written out in the scene file and matched exactly.
+		e.Origin = graph.OriginASTResolved
+		e.Confidence = 0.9
+		e.ConfidenceLabel = graph.ConfidenceLabelFor(graph.EdgeReferences, 0.9)
+		StampSynthesized(e, SynthGodotConnection)
+		if oldTo == target {
+			// Already on the right node by a weaker route; only the tier
+			// and provenance change, so the identity has to be refreshed
+			// in place rather than re-keyed.
+			reindex = append(reindex, graph.EdgeReindex{
+				Edge: e, OldFrom: e.From, OldTo: oldTo,
+				OldFilePath: e.FilePath, OldLine: e.Line, RefreshIdentity: true,
+			})
+			continue
+		}
+		reindex = append(reindex, graph.EdgeReindex{Edge: e, OldTo: oldTo})
+		resolved++
+	}
+	if len(reindex) > 0 {
+		g.ReindexEdges(reindex)
+	}
+	return resolved
+}
+
+// gdConnectionEdges collects the `[connection]` edges the scene extractor
+// emitted, whether or not a weaker pass has already bound them.
+func gdConnectionEdges(g graph.Store) []*graph.Edge {
+	var out []*graph.Edge
+	for e := range g.EdgesByKind(graph.EdgeReferences) {
+		if e == nil || e.Meta == nil {
+			continue
+		}
+		if conn, _ := e.Meta["godot_connection"].(bool); conn {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// gdScriptOfSceneNode returns the graph file ID of the GDScript attached
+// to a scene node, or to the scene's own file when the node itself
+// carries none — Godot resolves a connection's target against the scene
+// it is declared in, whose root script is the usual holder.
+func gdScriptOfSceneNode(g graph.Store, nodeID string) string {
+	if id := gdScriptRefTarget(g, nodeID); id != "" {
+		return id
+	}
+	sceneFile, _, ok := strings.Cut(nodeID, "::")
+	if !ok {
+		return ""
+	}
+	return gdScriptRefTarget(g, sceneFile)
+}
+
+// gdScriptRefTarget returns the single GDScript file a node references,
+// or "" when it references none or several — two scripts on one node is
+// malformed, and guessing between them is worse than declining.
+func gdScriptRefTarget(g graph.Store, id string) string {
+	found := ""
+	for _, e := range g.GetOutEdges(id) {
+		if e == nil || e.Kind != graph.EdgeReferences || graph.IsUnresolvedTarget(e.To) {
+			continue
+		}
+		n := g.GetNode(e.To)
+		if n == nil || n.Kind != graph.KindFile || n.Language != "gdscript" {
+			continue
+		}
+		if found != "" && found != n.ID {
+			return ""
+		}
+		found = n.ID
+	}
+	return found
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -3267,6 +3267,11 @@ func pendingShapeSummary(pending []*graph.Edge) string {
 }
 
 func (r *Resolver) resolveImport(e *graph.Edge, importPath string, stats *ResolveStats) {
+	if isGodotResPlaceholder(e.To) {
+		// resolveGodotResPaths owns this one; see the note on the helper.
+		stats.Unresolved++
+		return
+	}
 	callerRepo := r.callerRepoPrefix(e)
 	callerWorkspace := r.callerWorkspaceID(e)
 	ambiguousQualName := false


### PR DESCRIPTION
Fixes #491.

## Validation

Reproduced all four at the source, through the real pipeline. Two of them did **not** reproduce from the report's own snippets — the minimal `Persist.snapshot()` and `Game.gd → Carry.apply()` cases already resolve on v0.63.1 — so I built a matrix of realistic GDScript call shapes to find what the 17.5% is actually made of. That changed the fix.

## 1 & 2 — static methods, autoload callers

Neither is a defect in its own right. Three shapes underneath them are:

**Class-body calls were dropped entirely.** `findEnclosingFunc` returned "" and the edge was skipped, so `var hp = Stats.roll()` and `@onready var ui = Hud.build()` produced nothing. That is a script's whole initialisation layer, and Godot puts a lot there. They now attribute to the file node — the rule Python already applies to module-level calls, and the same unit the report measures in ("misses at least one calling file").

**`self.x()` in a script with no `class_name` degraded to the suppressed tier.** Every autoload entry point is such a script, so it has no nameable receiver; the member shape carried no `receiver_type` and the call settled at `text_matched`, which `find_usages` hides by default. It measured as "calls from autoload code are invisible". The file declares the callee, so the call is now emitted in the free-function shape and the same-file tier binds it at `ast_resolved`.

**`const Persist = preload("res://…")` was not a receiver.** This is how a static-utility script that declares no `class_name` gets reached, and the alias is file-local — the same name one directory over means a different script, so nothing in the graph connected the two. The loaded path is now recorded on the const and a `godot-preload-alias` pass binds through it.

## 3 — same-named methods cross-linking

Reproduced exactly, and it is the dangerous one. With `apply` declared in several classes and one of them in the caller's own directory:

```
src/ui/Caller.gd::run -> src/ui/Carry.gd::apply  ast_inferred 0.70  receiver_type:Items
src/ui/Caller.gd::run -> src/ui/Carry.gd::apply  ast_inferred 0.70  receiver_type:Effects
src/ui/Caller.gd::run -> src/ui/Carry.gd::apply  ast_inferred 0.70  receiver_type:Unknown
```

The receiver was stamped on the edge and then ignored: a weak tier answered with the nearest same-named method. A receiver gate now demotes a provable mismatch to the speculative tier, so it drops out of every default query and `min_tier` filter — the same treatment and the same rationale as the existing C# receiver gate.

Only a **provable** mismatch, because over-demoting trades one wrong answer for another. Inherited dispatch survives by walking the receiver's declared `extends` chain; an `extends` that cannot be read as one in-repo class name (a `res://` path, a dotted inner class, an inner class whose base is never parsed) is recorded as opaque and the gate declines; an autoload or preload-alias receiver is checked against the script it actually names; a same-file bind and a receiver the calling file declares itself are both left alone.

## 4 — `connect(_on_x)` is now a usage

All three wiring shapes, plus the Godot 3 form:

- a bare method value — `pressed.connect(_on_random)`, `self._on_random`, `var f = _on_random`
- a method name as a string — `Callable(self, "_on_random")`, `connect("pressed", self, "_on_random")`, `call_deferred`, `has_method`, `rpc`, …
- the scene's own `[connection signal="…" to="…" method="…"]`

`rename_symbol` rewrites all of them, `.tscn` included — asserted end-to-end in `TestRenameSymbol_GDScriptSignalWiring`.

Precision matters here because rename writes to disk, so the bare-identifier scan reads masked source (no comments, no strings), skips callees, skips a name shadowed by a local or parameter in the enclosing func, and refuses `other.foo` — only bare and `self.`-qualified mentions of a name **this file declares** are claimed. The string form is gated on the engine APIs that take a method name.

The scene connection binds through the target node's `script = ExtResource(…)` rather than by name. The generic resolver reaches it first and binds by name, which is right only while the handler name is unique in the project — and `_on_pressed` never is — so the pass is authoritative and overrides that guess wherever it can compute the answer.

## Also fixed — `res://` references never bound

Found while wiring case 4, in its own commit. `resolveGodotResPaths` never fired through the real pipeline: the generic import resolver reaches the same `unresolved::import::res://…` placeholder first and rewrites it to `external::res://…`, after which nothing can tell a Godot project path from a third-party package. Every scene → script and `preload` edge was lost — which in Godot is most of a script's blast radius, since a script is reached through the scene that mounts it rather than through a call. The pass's own tests passed throughout because they call it directly on a graph nothing else has touched.

Holding the generic resolver off the placeholder is enough; a path the pass cannot bind stays unresolved rather than becoming an `external::` stub, which is the behaviour those tests already pin.

## Verification

`internal/indexer/gdscript_resolution_e2e_test.go` indexes a project shaped like the reported one and asserts each case through the real pipeline, including the two negative directions that a fix like this gets wrong: inherited dispatch must survive the gate, and an ordinary call must not also become a reference.

Unit coverage for the receiver gate's decline paths (opaque base, local alias, autoload receiver, same-file), the preload-alias pass (file-locality, unknown member, ambiguous path), the method-value scan's false-positive guards, and the scene `[connection]` NodePath shapes.

Full suite green, `-race` green on the four touched packages, `golangci-lint` clean, `gortex review` approve.

## Not addressed

`X.new()` still parks on `unresolved::*.new` — the constructor is reachable as the class's `_init`, but binding it is a separate change from receiver resolution. A receiver reached through a property chain (`Game.state.apply()`) or a cast (`($Button as Carry).apply()`) still carries no receiver type; both now stay honestly unresolved rather than binding to a neighbour, which is the safe half.

Happy to take the comparison script from the report as a regression fixture if you want to share it — the shapes it found are exactly the ones the minimal repros missed.
