### PR TITLE
hooks: stand down per-call enforcement while the daemon is unreachable

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -206,6 +206,18 @@ Hooks installed today: **PreToolUse**, **PreCompact**, **Stop**,
 prime the first turn with graph orientation; PreCompact fires on
 summary boundaries.
 
+> **Daemon outage = per-call enforcement stands down.** Every per-call
+> surface (PreToolUse denies and graph advisories, PostToolUse follow-ups,
+> and the Codex / Kimi / Pi / Hermes mirrors) checks daemon reachability
+> first and stays quiet while the daemon socket cannot be dialed — guidance
+> that mandates Gortex MCP tools is untrue the moment the daemon cannot
+> serve them. The SessionStart briefing announces rule-only enforcement to a
+> session that starts mid-outage; a session the outage begins in gets one
+> PreToolUse notice (once per session) carrying the same stance. The
+> localization terminal deny is daemon-independent and deliberately stays
+> live. Enforcement resumes automatically on the next tool call once the
+> daemon is back.
+
 ### aider
 
 Aider has no native MCP client today. We install an `.aiderignore`

--- a/internal/hooks/codex.go
+++ b/internal/hooks/codex.go
@@ -138,10 +138,18 @@ func runCodexBashHardDeny(data []byte, port int) {
 	if err := json.Unmarshal(data, &input); err != nil || input.HookEventName != "PreToolUse" || input.ToolName != "Bash" {
 		return
 	}
+	daemonUp := daemonReachableFn()
 	emitted := false
 	defer func() {
-		logHookEffectiveness("PreToolUse", emitted, daemonReachableFn(), hookAlternationSegmentCount(input), time.Since(started))
+		logHookEffectiveness("PreToolUse", emitted, daemonUp, hookAlternationSegmentCount(input), time.Since(started))
 	}()
+
+	// Daemon outage: the deny posture stands down entirely (#486) — both the
+	// deny escalation and its advisory fallback mandate MCP operations the
+	// daemon cannot currently serve.
+	if !daemonUp {
+		return
+	}
 
 	result := enrich(input, port)
 	classification := classifyBashCommand(fmt.Sprint(input.ToolInput["command"]))
@@ -152,7 +160,7 @@ func runCodexBashHardDeny(data []byte, port int) {
 		// indexed. Keep the reminder but never block that command.
 		result = enrichResult{context: defaultGrepGuidance()}
 	}
-	if !result.deny && daemonReachableFn() && workspaceScoped &&
+	if !result.deny && workspaceScoped &&
 		classification.Action == BashActionGrepLike && result.context != "" &&
 		codexTextSearchHitFn(port, classification.Pattern) {
 		result.deny = true
@@ -290,10 +298,19 @@ func runCodexMCPReadPreToolUse(data []byte, mode CodexMode) {
 	if input.HookEventName != "PreToolUse" || !codexMCPReadPreToolUseTool(input.ToolName) {
 		return
 	}
+	daemonUp := daemonReachableFn()
 	emitted := false
 	defer func() {
-		logHookEffectiveness("PreToolUse", emitted, daemonReachableFn(), 0, time.Since(started))
+		logHookEffectiveness("PreToolUse", emitted, daemonUp, 0, time.Since(started))
 	}()
+
+	// Daemon outage: nudging, rewriting, or (in deny mode) blocking a Gortex
+	// read is moot when the daemon cannot serve it — the call is about to
+	// fail on transport, and a compress-bodies deny on top of that failure
+	// would read as enforcement of a tool that does not answer (#486).
+	if !daemonUp {
+		return
+	}
 
 	ctx := gortexReadNudge(input.ToolName, input.ToolInput)
 	if ctx == "" {
@@ -341,10 +358,18 @@ func runCodexBashRewrite(data []byte, port int) {
 	if err := json.Unmarshal(data, &input); err != nil || input.HookEventName != "PreToolUse" || input.ToolName != "Bash" {
 		return
 	}
+	daemonUp := daemonReachableFn()
 	emitted := false
 	defer func() {
-		logHookEffectiveness("PreToolUse", emitted, daemonReachableFn(), hookAlternationSegmentCount(input), time.Since(started))
+		logHookEffectiveness("PreToolUse", emitted, daemonUp, hookAlternationSegmentCount(input), time.Since(started))
 	}()
+
+	// Daemon outage: stand down (#486). Rewriting a working `cat` into a
+	// `gortex call read` that cannot be served would break the command
+	// outright, and the advisory fallback mandates the same unusable tools.
+	if !daemonUp {
+		return
+	}
 
 	if updated, message, ok := rewrittenCodexBashInput(input); ok {
 		emitted = true
@@ -405,12 +430,19 @@ func runCodexPostToolUse(data []byte, port int, mode CodexMode) {
 		return
 	}
 	if input.ToolName == "apply_patch" {
-		ctx := buildMutationBriefing(port, sessionScope{
-			SessionID: input.SessionID,
-			CWD:       firstNonEmpty(input.CWD, loadHookCWD()),
-		})
+		daemonUp := daemonReachableFn()
+		ctx := ""
+		// Daemon outage: the mutation briefing is built from daemon answers
+		// only, so skip its round-trips instead of paying them just to
+		// render nothing (#486).
+		if daemonUp {
+			ctx = buildMutationBriefing(port, sessionScope{
+				SessionID: input.SessionID,
+				CWD:       firstNonEmpty(input.CWD, loadHookCWD()),
+			})
+		}
 		emitted := ctx != ""
-		logHookEffectiveness("PostToolUse", emitted, daemonReachableFn(), 0, time.Since(started))
+		logHookEffectiveness("PostToolUse", emitted, daemonUp, 0, time.Since(started))
 		if !emitted {
 			return
 		}
@@ -452,9 +484,15 @@ func runCodexPostToolUse(data []byte, port int, mode CodexMode) {
 		runPostToolUse(normalized)
 		return
 	}
-	ctx := postToolContext(input)
+	daemonUp := daemonReachableFn()
+	ctx := ""
+	// Same stand-down as runPostToolUse's own gate (#486): the follow-ups
+	// need daemon answers and point at tools an outage cannot serve.
+	if daemonUp {
+		ctx = postToolContext(input)
+	}
 	emitted := ctx != ""
-	logHookEffectiveness("PostToolUse", emitted, daemonReachableFn(), 0, time.Since(started))
+	logHookEffectiveness("PostToolUse", emitted, daemonUp, 0, time.Since(started))
 	if emitted {
 		emitPostToolContext(ctx, true)
 	}

--- a/internal/hooks/daemon_degraded.go
+++ b/internal/hooks/daemon_degraded.go
@@ -1,0 +1,50 @@
+package hooks
+
+// Daemon-outage degradation (#486). When the daemon socket is unreachable,
+// every per-call enforcement surface stands down: the PreToolUse denies and
+// graph advisories, the PostToolUse follow-ups, and the Codex / Kimi / Pi /
+// Hermes adapter mirrors. Guidance that mandates Gortex MCP tools is untrue
+// the moment the daemon cannot serve them — an agent that follows it is
+// instructed to use tools that cannot answer while being flagged for using
+// the tools that can. The SessionStart briefing already announces rule-only
+// enforcement to a session that starts mid-outage; the once-per-session
+// notice below is the same signal for a session the outage begins in.
+//
+// Deliberately exempt: the localization terminal marker (it is local state
+// that carries its own answer and mandates nothing the daemon serves), the
+// consult-unlock / write-target markers (local bookkeeping), and the
+// Stop / PreCompact / UserPromptSubmit briefings (their content is built
+// entirely from daemon answers, so they already degrade to silence).
+
+// daemonUnreachableStance is the one instruction both the SessionStart
+// briefing and the per-call degradation notice give for an outage. Shared so
+// the session-level and per-call layers cannot drift into contradicting each
+// other about what an agent should do while the daemon is down.
+const daemonUnreachableStance = "Treat this as an MCP integration failure: stop indexed code operations and report it; do not start a daemon manually or switch to a CLI fallback."
+
+// daemonDownNotice is the once-per-session PreToolUse notice for an outage
+// that begins mid-session — the SessionStart briefing has already promised
+// active enforcement, so going quiet without a word would read as a hook
+// failure rather than a deliberate stand-down.
+const daemonDownNotice = "[Gortex] Gortex daemon unreachable — per-call graph enforcement is standing down to rule-only guidance until the daemon is back. " +
+	daemonUnreachableStance +
+	" This notice fires once per session."
+
+// daemonDownNoticeOnce returns the degradation notice the first time it is
+// called for a session and "" on every later call, keyed through the same
+// per-session state store the consult-unlock marker uses. Sessions without a
+// usable state path (no session_id, no cache dir) stay quiet — without
+// deduplication the notice would repeat on every call, and the SessionStart
+// briefing already covers the outage once.
+func daemonDownNoticeOnce(sessionID string) string {
+	if sessionStatePath(sessionID) == "" {
+		return ""
+	}
+	st := loadSessionState(sessionID)
+	if st.DaemonDownNotified {
+		return ""
+	}
+	st.DaemonDownNotified = true
+	saveSessionState(sessionID, st)
+	return daemonDownNotice
+}

--- a/internal/hooks/daemon_degraded_test.go
+++ b/internal/hooks/daemon_degraded_test.go
@@ -1,0 +1,308 @@
+package hooks
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/daemon"
+)
+
+// The tests below pin the #486 contract: while the daemon is unreachable,
+// every per-call enforcement surface stands down — no denies, no
+// MCP-mandating advisories, no "do not re-Read / re-Grep" follow-ups —
+// because that guidance points at tools the daemon cannot serve. Each test
+// first proves the enforcement fires with the daemon up (so the outage
+// assertion tests the gate, not a broken fixture), then flips reachability.
+
+func preToolReadPayload(t *testing.T, sessionID string) []byte {
+	t.Helper()
+	return mustJSON(t, map[string]any{
+		"hook_event_name": "PreToolUse",
+		"tool_name":       "Read",
+		"tool_input":      map[string]any{"file_path": "/repo/internal/server.go"},
+		"cwd":             "/repo",
+		"session_id":      sessionID,
+	})
+}
+
+func TestPreToolUseDaemonDownStandsDownWithOneNotice(t *testing.T) {
+	t.Setenv(hookSessionDirEnvVar, t.TempDir())
+	stubIndexedFile(t, true, 9) // would hard-deny if enforcement were live
+	withDaemonReachable(t, true)
+
+	control := captureHookStdout(t, func() { runPreToolUse(preToolReadPayload(t, "sess-outage"), 0, ModeDeny) })
+	if !strings.Contains(control, "deny") {
+		t.Fatalf("control: indexed Read should deny while the daemon is up: %q", control)
+	}
+
+	daemonReachableFn = func() bool { return false }
+	first := captureHookStdout(t, func() { runPreToolUse(preToolReadPayload(t, "sess-outage"), 0, ModeDeny) })
+	if strings.Contains(first, "deny") || strings.Contains(first, "BLOCKED") {
+		t.Fatalf("daemon down must not deny: %q", first)
+	}
+	if !strings.Contains(first, "standing down to rule-only guidance") {
+		t.Fatalf("first degraded call should carry the once-per-session notice: %q", first)
+	}
+	if !strings.Contains(first, "MCP integration failure") {
+		t.Fatalf("notice must state the briefing's outage stance: %q", first)
+	}
+
+	second := captureHookStdout(t, func() { runPreToolUse(preToolReadPayload(t, "sess-outage"), 0, ModeDeny) })
+	if second != "" {
+		t.Fatalf("degraded PreToolUse must go quiet after the one notice: %q", second)
+	}
+}
+
+func TestPreToolUseDaemonDownWithoutSessionStaysSilent(t *testing.T) {
+	t.Setenv(hookSessionDirEnvVar, t.TempDir())
+	stubIndexedFile(t, true, 3)
+	withDaemonReachable(t, false)
+
+	out := captureHookStdout(t, func() { runPreToolUse(preToolReadPayload(t, ""), 0, ModeDeny) })
+	if out != "" {
+		t.Fatalf("no session id means no dedupe, so the degraded call must stay silent: %q", out)
+	}
+}
+
+func TestPreToolUseDaemonDownGatesForceCompressDeny(t *testing.T) {
+	t.Setenv(hookSessionDirEnvVar, t.TempDir())
+	t.Setenv(gortexForceCompressEnvVar, "1")
+	payload := mustJSON(t, map[string]any{
+		"hook_event_name": "PreToolUse",
+		"tool_name":       gortexCompactReadTool,
+		"tool_input": map[string]any{
+			"operation": "file",
+			"target":    map[string]any{"file": "/repo/internal/server.go"},
+		},
+		"cwd": "/repo",
+	})
+
+	withDaemonReachable(t, true)
+	control := captureHookStdout(t, func() { runPreToolUse(payload, 0, ModeDeny) })
+	if !strings.Contains(control, "deny") {
+		t.Fatalf("control: force-compress should deny a whole-file read while the daemon is up: %q", control)
+	}
+
+	daemonReachableFn = func() bool { return false }
+	out := captureHookStdout(t, func() { runPreToolUse(payload, 0, ModeDeny) })
+	if out != "" {
+		t.Fatalf("the force-compress deny is local, but enforcing it during an outage blocks a call that already fails on transport: %q", out)
+	}
+}
+
+func TestPreToolUseTerminalDenyStaysLiveDuringOutage(t *testing.T) {
+	configureLocalizationTerminalTestHome(t)
+	withDaemonReachable(t, false)
+	cwd := t.TempDir()
+	identity := beginTestLocalizationSubagentTurn(t, "sess-terminal-outage", "agent-1", cwd)
+	if !markLocalizationTerminal(identity, localizationTerminalContractV2) {
+		t.Fatal("markLocalizationTerminal failed")
+	}
+
+	payload := mustJSON(t, map[string]any{
+		"hook_event_name": "PreToolUse",
+		"tool_name":       "Read",
+		"tool_input":      map[string]any{"file_path": "/repo/internal/server.go"},
+		"cwd":             cwd,
+		"session_id":      "sess-terminal-outage",
+		"agent_id":        "agent-1",
+	})
+	out := captureHookStdout(t, func() { runPreToolUse(payload, 0, ModeDeny) })
+	if !strings.Contains(out, "Localization for this task is complete") {
+		t.Fatalf("terminal enforcement is daemon-independent and must survive an outage: %q", out)
+	}
+}
+
+func TestPostToolUseDaemonDownSuppressesFollowUps(t *testing.T) {
+	oldSummary := fileSummaryFn
+	fileSummaryFn = func(_, _ string) (*hookFileSummary, bool) {
+		return &hookFileSummary{
+			Symbols:    []summaryNode{{Name: "Foo", Kind: "function", StartLine: 1, EndLine: 20}},
+			Dependents: 2,
+		}, true
+	}
+	t.Cleanup(func() { fileSummaryFn = oldSummary })
+
+	payload := mustJSON(t, map[string]any{
+		"hook_event_name": "PostToolUse",
+		"tool_name":       "Read",
+		"tool_input":      map[string]any{"file_path": "/repo/internal/server.go"},
+		"tool_response":   "package server",
+		"cwd":             "/repo",
+	})
+
+	withDaemonReachable(t, true)
+	control := captureHookStdout(t, func() { runPostToolUse(payload) })
+	if !strings.Contains(control, "Do not re-Read") {
+		t.Fatalf("control: expected the follow-up while the daemon is up: %q", control)
+	}
+
+	daemonReachableFn = func() bool { return false }
+	out := captureHookStdout(t, func() { runPostToolUse(payload) })
+	if out != "" {
+		t.Fatalf("PostToolUse follow-ups must not land during an outage: %q", out)
+	}
+}
+
+func TestCodexBashHardDenyDaemonDownStandsDown(t *testing.T) {
+	stubIndexedFile(t, true, 4)
+
+	withDaemonReachable(t, true)
+	control := captureHookStdout(t, func() { runCodexBashHardDeny(codexBashPayload("cat internal/server.go"), 0) })
+	if !strings.Contains(control, "deny") {
+		t.Fatalf("control: indexed cat should deny while the daemon is up: %q", control)
+	}
+
+	daemonReachableFn = func() bool { return false }
+	out := captureHookStdout(t, func() { runCodexBashHardDeny(codexBashPayload("cat internal/server.go"), 0) })
+	if out != "" {
+		t.Fatalf("Codex deny posture must stand down during an outage: %q", out)
+	}
+}
+
+func TestCodexBashRewriteDaemonDownStandsDown(t *testing.T) {
+	stubIndexedFile(t, true, 4)
+
+	withDaemonReachable(t, true)
+	control := captureHookStdout(t, func() { runCodexBashRewrite(codexBashPayload("cat internal/server.go"), 0) })
+	if !strings.Contains(control, "gortex call read") {
+		t.Fatalf("control: indexed cat should be rewritten while the daemon is up: %q", control)
+	}
+
+	daemonReachableFn = func() bool { return false }
+	out := captureHookStdout(t, func() { runCodexBashRewrite(codexBashPayload("cat internal/server.go"), 0) })
+	if out != "" {
+		t.Fatalf("rewriting a working cat into an unserveable gortex call would break the command: %q", out)
+	}
+}
+
+func TestCodexMCPReadDaemonDownStaysSilent(t *testing.T) {
+	payload := mustJSON(t, map[string]any{
+		"hook_event_name": "PreToolUse",
+		"tool_name":       gortexCompactReadTool,
+		"tool_input": map[string]any{
+			"operation": "file",
+			"target":    map[string]any{"file": "/repo/internal/server.go"},
+		},
+		"cwd": "/repo",
+	})
+
+	withDaemonReachable(t, true)
+	control := captureHookStdout(t, func() { runCodexMCPReadPreToolUse(payload, CodexModeDeny) })
+	if !strings.Contains(control, "deny") {
+		t.Fatalf("control: expected the compress-bodies deny while the daemon is up: %q", control)
+	}
+
+	daemonReachableFn = func() bool { return false }
+	out := captureHookStdout(t, func() { runCodexMCPReadPreToolUse(payload, CodexModeDeny) })
+	if out != "" {
+		t.Fatalf("a Gortex read the daemon cannot serve must not be blocked on a nudge: %q", out)
+	}
+}
+
+func TestKimiPreToolUseDaemonDownStaysSilent(t *testing.T) {
+	stubIndexedFile(t, true, 4)
+	input := map[string]any{"file_path": "/repo/internal/server.go"}
+
+	withDaemonReachable(t, true)
+	control := captureHookStdout(t, func() { runKimiPreToolUse("Read", input, "sess", 0, ModeDeny) })
+	if !strings.Contains(control, "deny") {
+		t.Fatalf("control: indexed Read should deny while the daemon is up: %q", control)
+	}
+
+	daemonReachableFn = func() bool { return false }
+	out := captureHookStdout(t, func() { runKimiPreToolUse("Read", input, "sess", 0, ModeDeny) })
+	if out != "" {
+		t.Fatalf("Kimi's documented contract is a silent no-op when the daemon is unreachable: %q", out)
+	}
+}
+
+func TestKimiSubagentStartDaemonDownStaysSilent(t *testing.T) {
+	payload := mustJSON(t, map[string]any{"hook_event_name": "SubagentStart"})
+
+	withDaemonReachable(t, true)
+	control := captureHookStdout(t, func() { runKimiSubagentStart(payload, 0) })
+	if !strings.Contains(control, "MUST use Gortex MCP tools") {
+		t.Fatalf("control: expected the fallback briefing while the daemon is up: %q", control)
+	}
+
+	daemonReachableFn = func() bool { return false }
+	out := captureHookStdout(t, func() { runKimiSubagentStart(payload, 0) })
+	if out != "" {
+		t.Fatalf("a subagent must not be told MCP is mandatory while the daemon cannot serve it: %q", out)
+	}
+}
+
+func TestPiToolCallDaemonDownEmptyDecision(t *testing.T) {
+	stubIndexedFile(t, true, 4)
+	ev := PiEvent{
+		Event:     "tool_call",
+		ToolName:  "Read",
+		ToolInput: map[string]any{"file_path": "/repo/internal/server.go"},
+		CWD:       "/repo",
+		SessionID: "sess",
+	}
+
+	withDaemonReachable(t, true)
+	if control := piToolCall(ev, 0, ModeDeny); !control.Block {
+		t.Fatalf("control: indexed Read should block while the daemon is up: %#v", control)
+	}
+
+	daemonReachableFn = func() bool { return false }
+	if d := piToolCall(ev, 0, ModeDeny); d.Block || d.Reason != "" || d.AdditionalContext != "" {
+		t.Fatalf("Pi must return an empty decision during an outage: %#v", d)
+	}
+}
+
+func TestHermesPreToolCallDaemonDownNeverBlocks(t *testing.T) {
+	stubIndexedFile(t, true, 4)
+	payload := mustJSON(t, map[string]any{
+		"hook_event_name": hermesEventPreToolCall,
+		"tool_name":       hermesReadFileTool,
+		"tool_input":      map[string]any{"path": "/repo/internal/server.go"},
+		"cwd":             "/repo",
+		"session_id":      "sess",
+	})
+
+	withDaemonReachable(t, true)
+	control := captureHookStdout(t, func() { runHermesPreToolCall(payload, 0, ModeDeny) })
+	if !strings.Contains(control, "block") {
+		t.Fatalf("control: indexed read_file should block while the daemon is up: %q", control)
+	}
+
+	daemonReachableFn = func() bool { return false }
+	out := captureHookStdout(t, func() { runHermesPreToolCall(payload, 0, ModeDeny) })
+	if out != "" {
+		t.Fatalf("Hermes' only channel is a block, which must never fire during an outage: %q", out)
+	}
+}
+
+func TestDaemonDownNoticeSharesBriefingStance(t *testing.T) {
+	if !strings.Contains(daemonDownNotice, daemonUnreachableStance) {
+		t.Fatal("the per-call notice must carry the same stance sentence as the SessionStart briefing")
+	}
+
+	old := sessionStartStatusFn
+	sessionStartStatusFn = func() (*daemon.StatusResponse, error) { return nil, errDaemonUnreachable }
+	t.Cleanup(func() { sessionStartStatusFn = old })
+	briefing := buildSessionStartBriefing("")
+	if !strings.Contains(briefing, daemonUnreachableStance) {
+		t.Fatalf("the unreachable briefing must carry the shared stance sentence: %q", briefing)
+	}
+}
+
+func TestDaemonDownNoticeOnceDeduplicatesPerSession(t *testing.T) {
+	t.Setenv(hookSessionDirEnvVar, t.TempDir())
+	if got := daemonDownNoticeOnce("sess-a"); got != daemonDownNotice {
+		t.Fatalf("first call should return the notice, got %q", got)
+	}
+	if got := daemonDownNoticeOnce("sess-a"); got != "" {
+		t.Fatalf("second call for the same session must be silent, got %q", got)
+	}
+	if got := daemonDownNoticeOnce("sess-b"); got != daemonDownNotice {
+		t.Fatalf("a different session gets its own notice, got %q", got)
+	}
+	if got := daemonDownNoticeOnce(""); got != "" {
+		t.Fatalf("a session without a state path must stay silent, got %q", got)
+	}
+}

--- a/internal/hooks/daemon_degraded_test.go
+++ b/internal/hooks/daemon_degraded_test.go
@@ -1,10 +1,12 @@
 package hooks
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/zzet/gortex/internal/daemon"
+	"github.com/zzet/gortex/internal/localizationauth"
 )
 
 // The tests below pin the #486 contract: while the daemon is unreachable,
@@ -288,6 +290,156 @@ func TestDaemonDownNoticeSharesBriefingStance(t *testing.T) {
 	briefing := buildSessionStartBriefing("")
 	if !strings.Contains(briefing, daemonUnreachableStance) {
 		t.Fatalf("the unreachable briefing must carry the shared stance sentence: %q", briefing)
+	}
+}
+
+func TestPreToolUseDaemonDownPreservesLocalizationPassthrough(t *testing.T) {
+	configureLocalizationTerminalTestHome(t)
+	withDaemonReachable(t, false)
+	problemStatement := "Title: Neutral storage failure\n\nDiskStorage.load returns an empty value."
+	identity, ok := beginLocalizationTurnWithProblem(t.Name(), "prompt", "", t.TempDir(), problemStatement)
+	if !ok {
+		t.Fatal("beginLocalizationTurnWithProblem failed")
+	}
+	payload := mustJSON(t, map[string]any{
+		"hook_event_name": "PreToolUse",
+		"tool_name":       gortexMCPToolPrefix + "explore",
+		"tool_use_id":     "tool-use",
+		"tool_input": map[string]any{
+			"operation": "localize",
+			"task":      "literal symptom",
+			"options":   map[string]any{"new_user_task": true},
+		},
+		"session_id": identity.SessionID,
+		"prompt_id":  identity.PromptID,
+		"cwd":        identity.CWD,
+	})
+
+	output := captureHookStdout(t, func() { runPreToolUse(payload, 0, ModeDeny) })
+	var decoded HookOutput
+	if err := json.Unmarshal([]byte(output), &decoded); err != nil || decoded.HookSpecificOutput == nil {
+		t.Fatalf("invalid degraded PreToolUse output: %v\n%s", err, output)
+	}
+	hso := decoded.HookSpecificOutput
+	if hso.PermissionDecision == "deny" {
+		t.Fatalf("degraded branch must not deny: %#v", hso)
+	}
+	// The auth nonce and the problem-statement rewrite are what correlate a
+	// still-live MCP transport's answer_ready receipt with this turn; the
+	// stand-down must not strip them.
+	if _, ok := hso.UpdatedInput[localizationauth.ArgumentKey].(string); !ok {
+		t.Fatalf("degraded branch lost the terminal auth passthrough: %#v", hso)
+	}
+	if got := hso.UpdatedInput["task"]; got != problemStatement {
+		t.Fatalf("degraded branch lost the problem-statement rewrite: %#v", got)
+	}
+}
+
+func TestDaemonDownNoticeScopedToTrackedRepos(t *testing.T) {
+	t.Setenv(hookSessionDirEnvVar, t.TempDir())
+	withDaemonReachable(t, false)
+	oldRepos := hookTrackedReposFn
+	hookTrackedReposFn = func() []daemon.TrackedRepoStatus {
+		return []daemon.TrackedRepoStatus{{Path: "/repo", Name: "repo"}}
+	}
+	t.Cleanup(func() { hookTrackedReposFn = oldRepos })
+
+	untracked := mustJSON(t, map[string]any{
+		"hook_event_name": "PreToolUse",
+		"tool_name":       "Read",
+		"tool_input":      map[string]any{"file_path": "/elsewhere/scratch.go"},
+		"cwd":             "/elsewhere",
+		"session_id":      "sess-scoped",
+	})
+	if out := captureHookStdout(t, func() { runPreToolUse(untracked, 0, ModeDeny) }); out != "" {
+		t.Fatalf("enforcement never applied outside tracked repos, so the notice must not fire there: %q", out)
+	}
+
+	// The untracked call must not have burned the session's single notice.
+	tracked := preToolReadPayload(t, "sess-scoped")
+	out := captureHookStdout(t, func() { runPreToolUse(tracked, 0, ModeDeny) })
+	if !strings.Contains(out, "standing down to rule-only guidance") {
+		t.Fatalf("first tracked-repo call should still carry the notice: %q", out)
+	}
+}
+
+func TestPreToolUseDaemonDownSkipsNudgeUnderAutoApprove(t *testing.T) {
+	payload := mustJSON(t, map[string]any{
+		"hook_event_name": "PreToolUse",
+		"tool_name":       gortexCompactReadTool,
+		"tool_input": map[string]any{
+			"operation": "file",
+			"target":    map[string]any{"file": "/repo/internal/server.go"},
+		},
+		"cwd":             "/repo",
+		"permission_mode": "acceptEdits",
+	})
+
+	withDaemonReachable(t, true)
+	control := captureHookStdout(t, func() { runPreToolUse(payload, 0, ModeDeny) })
+	if !strings.Contains(control, "auto-approved") || !strings.Contains(control, "compress_bodies") {
+		t.Fatalf("control: auto-approve should carry the read nudge while the daemon is up: %q", control)
+	}
+
+	daemonReachableFn = func() bool { return false }
+	out := captureHookStdout(t, func() { runPreToolUse(payload, 0, ModeDeny) })
+	if !strings.Contains(out, "auto-approved") {
+		t.Fatalf("auto-approve itself must survive the outage: %q", out)
+	}
+	if strings.Contains(out, "compress_bodies") {
+		t.Fatalf("coaching the shape of a call about to fail on transport must be skipped: %q", out)
+	}
+}
+
+func TestCodexPostToolUseSuppressDaemonDownStaysSilent(t *testing.T) {
+	oldSummary := fileSummaryFn
+	fileSummaryFn = func(_, _ string) (*hookFileSummary, bool) {
+		return &hookFileSummary{
+			Symbols: []summaryNode{{Name: "Foo", Kind: "function", StartLine: 1, EndLine: 20}},
+		}, true
+	}
+	t.Cleanup(func() { fileSummaryFn = oldSummary })
+	payload := codexPostBashPayload("grep -rn Foo internal/", "internal/server.go:3:Foo()")
+
+	withDaemonReachable(t, true)
+	control := captureHookStdout(t, func() { runCodexPostToolUse(payload, 0, CodexModeSuppress) })
+	if !strings.Contains(control, "Do not re-Grep") {
+		t.Fatalf("control: expected the graph follow-up while the daemon is up: %q", control)
+	}
+
+	daemonReachableFn = func() bool { return false }
+	out := captureHookStdout(t, func() { runCodexPostToolUse(payload, 0, CodexModeSuppress) })
+	if out != "" {
+		t.Fatalf("Codex suppress-mode follow-ups must not land during an outage: %q", out)
+	}
+}
+
+func TestPiAdaptiveNudgeStreakFrozenDuringOutage(t *testing.T) {
+	t.Setenv(hookSessionDirEnvVar, t.TempDir())
+	const session = "sess-pi-streak"
+	saveSessionState(session, sessionState{NonSymbolicStreak: 2})
+	ev := PiEvent{
+		Event:        "tool_call",
+		ToolName:     "search_symbols",
+		CWD:          "/repo",
+		SessionID:    session,
+		IsGortexTool: true,
+	}
+
+	withDaemonReachable(t, false)
+	if d := piToolCall(ev, 0, ModeAdaptiveNudge); d.Block || d.AdditionalContext != "" {
+		t.Fatalf("gortex call must pass through untouched: %#v", d)
+	}
+	if got := loadSessionState(session).NonSymbolicStreak; got != 2 {
+		t.Fatalf("outage must freeze the streak like every other adapter, got %d", got)
+	}
+
+	daemonReachableFn = func() bool { return true }
+	if d := piToolCall(ev, 0, ModeAdaptiveNudge); d.Block || d.AdditionalContext != "" {
+		t.Fatalf("gortex call must pass through untouched: %#v", d)
+	}
+	if got := loadSessionState(session).NonSymbolicStreak; got != 0 {
+		t.Fatalf("a symbolic call with the daemon up should reset the streak, got %d", got)
 	}
 }
 

--- a/internal/hooks/hermes.go
+++ b/internal/hooks/hermes.go
@@ -155,6 +155,14 @@ func runHermesPreToolCall(data []byte, port int, mode Mode) {
 		return
 	}
 
+	// Daemon outage: never block (#486). pre_tool_call's only channel is a
+	// block, and a block that redirects to graph tools the daemon cannot
+	// serve deadlocks the agent. The consult-unlock marker above is local
+	// state and deliberately stays live.
+	if !daemonReachableFn() {
+		return
+	}
+
 	result := hermesEnrich(input, port)
 
 	switch mode {

--- a/internal/hooks/kimi.go
+++ b/internal/hooks/kimi.go
@@ -109,6 +109,13 @@ func runKimiPreToolUseEvent(data []byte, port int, mode Mode) {
 //     whole-file read becomes a Kimi permission-decision block; soft guidance
 //     is appended as plain-stdout context so the call still proceeds.
 func runKimiPreToolUse(toolName string, toolInput map[string]any, sessionID string, port int, mode Mode) {
+	// Daemon outage: stand down (#486). Both the compress-bodies nudge and
+	// the enrich redirects mandate Gortex tools; while the daemon cannot
+	// serve them, silence is the only honest posture — and the one this
+	// file's contract has always documented.
+	if !daemonReachableFn() {
+		return
+	}
 	if kimiGortexReadPreToolUseTool(toolName) {
 		if ctx := gortexReadNudge(toolName, toolInput); ctx != "" {
 			fmt.Print(ctx)
@@ -160,6 +167,13 @@ func runKimiStop(data []byte, port int) {
 // symbols + the tool-swap table) as plain stdout, so it reaches for the graph
 // tools instead of defaulting to raw Read/Grep on indexed source.
 func runKimiSubagentStart(data []byte, port int) {
+	// Daemon outage: don't hand a fresh subagent a "MUST use Gortex MCP"
+	// briefing while the daemon cannot serve a single call (#486). The
+	// static fallback below exists for a missing task text, not for an
+	// outage.
+	if !daemonReachableFn() {
+		return
+	}
 	briefing := buildKimiSubagentBriefing(port, kimiSubagentTask(data))
 	if briefing == "" {
 		return

--- a/internal/hooks/main_test.go
+++ b/internal/hooks/main_test.go
@@ -23,6 +23,11 @@ func TestMain(m *testing.M) {
 		_ = os.Setenv("GORTEX_HOOK_EFFECTIVENESS_LOG", filepath.Join(dir, "hook-effectiveness.jsonl"))
 		defer func() { _ = os.RemoveAll(dir) }()
 	}
+	// Per-call enforcement is gated on daemon reachability (#486). Default
+	// it to "reachable" so enforcement tests stay deterministic on machines
+	// without a daemon (and never dial a real socket); daemon-outage tests
+	// stub it false via withDaemonReachable.
+	daemonReachableFn = func() bool { return true }
 	// Default the file-indexed / file-summary probes to "not indexed" so no
 	// test dials a real daemon. Tests needing an indexed verdict stub
 	// fileIndexedFn / fileSummaryFn (fakeIndexedBridge / newIndexedBridge /

--- a/internal/hooks/pi.go
+++ b/internal/hooks/pi.go
@@ -122,16 +122,21 @@ func piToolCall(ev PiEvent, port int, mode Mode) PiDecision {
 		if mode == ModeConsultUnlock {
 			markGraphConsulted(ev.SessionID)
 		}
-		// Still let adaptive-nudge reset its streak on a symbolic call.
-		if mode == ModeAdaptiveNudge {
+		// Still let adaptive-nudge reset its streak on a symbolic call —
+		// but only while the daemon is up. During an outage every adapter
+		// freezes the streak entirely (Claude's and Hermes' gates sit above
+		// their streak bookkeeping), so post-outage nudge behavior resumes
+		// exactly where it left off; resetting here would make Pi the one
+		// adapter whose streak drifts mid-outage (#486).
+		if mode == ModeAdaptiveNudge && daemonReachableFn() {
 			_ = applyMode(input, true, mode, enrichResult{})
 		}
 		return PiDecision{}
 	}
 
 	// Daemon outage: stand down (#486) — a block or advisory here would
-	// point at graph tools the daemon cannot serve. The consult-unlock /
-	// streak bookkeeping above is local state and deliberately stays live.
+	// point at graph tools the daemon cannot serve. The consult-unlock
+	// marker above is local state and deliberately stays live.
 	if !daemonReachableFn() {
 		return PiDecision{}
 	}

--- a/internal/hooks/pi.go
+++ b/internal/hooks/pi.go
@@ -129,6 +129,13 @@ func piToolCall(ev PiEvent, port int, mode Mode) PiDecision {
 		return PiDecision{}
 	}
 
+	// Daemon outage: stand down (#486) — a block or advisory here would
+	// point at graph tools the daemon cannot serve. The consult-unlock /
+	// streak bookkeeping above is local state and deliberately stays live.
+	if !daemonReachableFn() {
+		return PiDecision{}
+	}
+
 	result := applyMode(input, isGortexTool, mode, enrich(input, port))
 	if result.deny {
 		return PiDecision{Block: true, Reason: result.reason}

--- a/internal/hooks/posttooluse.go
+++ b/internal/hooks/posttooluse.go
@@ -57,6 +57,7 @@ func runPostToolUse(data []byte) {
 	if input.HookEventName != "PostToolUse" {
 		return
 	}
+	daemonUp := daemonReachableFn()
 	emitted := false
 	terminalObserved := false
 	defer func() {
@@ -64,12 +65,23 @@ func runPostToolUse(data []byte) {
 			localizationTerminalTelemetry("observed", emitted, started)
 			return
 		}
-		logHookEffectiveness("PostToolUse", emitted, daemonReachableFn(), 0, time.Since(started))
+		logHookEffectiveness("PostToolUse", emitted, daemonUp, 0, time.Since(started))
 	}()
 
 	if terminal, observed := observeLocalizationTerminal(data); observed {
 		terminalObserved = true
 		emitted = emitLocalizationTerminalContext(terminal)
+		return
+	}
+
+	// Daemon outage: the follow-ups below both need daemon answers and
+	// instruct "Do not re-Read / re-Grep" — guidance that must not land
+	// while the daemon cannot serve the tools it points at (#486). The
+	// per-file probes would fail individually anyway; returning here keeps
+	// a flapping daemon from emitting follow-ups mid-outage and skips up to
+	// one failed dial per matched file. Terminal-receipt handling above is
+	// local state and deliberately stays ahead of this gate.
+	if !daemonUp {
 		return
 	}
 

--- a/internal/hooks/pretooluse.go
+++ b/internal/hooks/pretooluse.go
@@ -168,9 +168,10 @@ func runPreToolUse(data []byte, gortexPort int, mode Mode) {
 		return
 	}
 
+	daemonUp := daemonReachableFn()
 	emitted := false
 	defer func() {
-		logHookEffectiveness("PreToolUse", emitted, daemonReachableFn(), hookAlternationSegmentCount(input), time.Since(started))
+		logHookEffectiveness("PreToolUse", emitted, daemonUp, hookAlternationSegmentCount(input), time.Since(started))
 	}()
 
 	isGortexMCP := isGortexMCPToolName(input.ToolName)
@@ -191,8 +192,12 @@ func runPreToolUse(data []byte, gortexPort int, mode Mode) {
 		// a permissive permission mode means low friction, not "stop
 		// reminding me my full-body read is expensive". Never a hard
 		// deny here: auto-approve has already promised to allow the call.
-		if adv := gortexReadNudge(input.ToolName, input.ToolInput); adv != "" {
-			hso.AdditionalContext = adv
+		// Skipped during a daemon outage: coaching the shape of a call
+		// that is about to fail on transport is noise (#486).
+		if daemonUp {
+			if adv := gortexReadNudge(input.ToolName, input.ToolInput); adv != "" {
+				hso.AdditionalContext = adv
+			}
 		}
 		if updatedInput != nil {
 			hso.UpdatedInput = updatedInput
@@ -214,6 +219,31 @@ func runPreToolUse(data []byte, gortexPort int, mode Mode) {
 				UpdatedInput:  updatedInput,
 			}})
 		}
+		return
+	}
+
+	// Daemon outage: per-call enforcement stands down (#486). Every deny and
+	// advisory the enrichment below can produce mandates Gortex MCP tools;
+	// while the daemon cannot serve them that guidance deadlocks the agent —
+	// instructed to use tools that cannot answer and flagged for using the
+	// tools that can. Degrade the way the SessionStart briefing does
+	// (rule-only enforcement): stay quiet per call, surface one notice per
+	// session so a mid-session outage is explained, and keep the
+	// localization input passthrough intact. The terminal deny above stays
+	// live on purpose — it is daemon-independent and carries its own answer.
+	if !daemonUp {
+		hso := &HookSpecificOutput{HookEventName: "PreToolUse"}
+		if updatedInput != nil {
+			hso.UpdatedInput = updatedInput
+		}
+		if hookCallTargetsTrackedRepo(input.ToolName, input.ToolInput, input.CWD) {
+			hso.AdditionalContext = daemonDownNoticeOnce(input.SessionID)
+		}
+		if hso.AdditionalContext == "" && hso.UpdatedInput == nil {
+			return
+		}
+		emitted = hso.AdditionalContext != ""
+		emitPreToolUse(HookOutput{HookSpecificOutput: hso})
 		return
 	}
 

--- a/internal/hooks/session_state.go
+++ b/internal/hooks/session_state.go
@@ -27,6 +27,11 @@ type sessionState struct {
 	// calls (Read / Grep / Glob) since the last symbolic call or nudge.
 	// ModeAdaptiveNudge fires a soft-deny when it crosses the threshold.
 	NonSymbolicStreak int `json:"non_symbolic_streak,omitempty"`
+	// DaemonDownNotified records that this session was already told the
+	// daemon is unreachable and per-call enforcement is standing down, so
+	// the degradation notice fires once per session rather than once per
+	// tool call (see daemonDownNoticeOnce).
+	DaemonDownNotified bool `json:"daemon_down_notified,omitempty"`
 	// WrittenPaths is the set of file paths (and graph symbol IDs, whose
 	// path part is extracted at match time) this session's tool calls were
 	// about to rewrite. It is what lets a Stop-hook briefing tell this

--- a/internal/hooks/sessionstart.go
+++ b/internal/hooks/sessionstart.go
@@ -206,7 +206,7 @@ func buildSessionStartBriefing(cwd string) string {
 	status, err := sessionStartStatusFn()
 	switch {
 	case errors.Is(err, errDaemonUnreachable):
-		sb.WriteString("⚠️  **Gortex graph transport is unreachable.** Required native MCP tools and code-operation enforcement cannot be assumed healthy. Treat this as an MCP integration failure: stop indexed code operations and report it; do not start a daemon manually or switch to a CLI fallback.\n\n")
+		sb.WriteString("⚠️  **Gortex graph transport is unreachable.** Required native MCP tools and code-operation enforcement cannot be assumed healthy. " + daemonUnreachableStance + "\n\n")
 		sb.WriteString(rulePreamble())
 		return sb.String()
 	case err != nil:


### PR DESCRIPTION
Fixes #486.

## What the issue reported, and what validation found

The issue is confirmed, with one refinement. `daemonReachableFn()` was indeed computed in `runPreToolUse` / `runPostToolUse` and fed only `logHookEffectiveness` — the hook measured "daemon unreachable", logged it, and emitted mandatory-tool guidance anyway. The refinement: most *hard denies* already failed closed during a full outage, because they hinge on daemon probes (`queryFileIndexed`, `scopeTrackedFn`, the symbol probe) that return "no signal" when the socket is dead. What kept firing on every call was the **advisory layer** — the not-indexed Read guidance, `defaultGrepGuidance`, `defaultGlobGuidance`, the Bash read redirect — each ending with the "native Gortex MCP is mandatory … report an integration failure and stop" line. That per-call text is exactly the deadlock the issue describes: instructed to use tools that cannot answer, flagged for using the tools that can. And because the tracked-repo registry is read from `~/.gortex/config.yaml` rather than the daemon, the policy machinery stayed fully in-scope during the outage.

Beyond the advisories, validation turned up per-call surfaces that were **not** protected by probe fail-closed behavior:

- `GORTEX_HOOK_FORCE_COMPRESS` hard-denies a Gortex whole-file read from purely local classification — it could block calls mid-outage.
- Codex `rewrite` mode turns an indexed `cat` into `gortex call read`; on a flapping daemon that converts a working command into a failing one.
- Kimi's SubagentStart fallback briefing hands a fresh subagent "MUST use Gortex MCP tools … Never Read/Grep indexed source" with zero daemon dependence — while the daemon can't serve a single call.
- The Kimi/Pi/Hermes mirrors of the enrich pipeline leaked the same advisories/blocks (Kimi's own doc comment has always promised "a silent no-op when … the daemon is unreachable"; it now tells the truth).

## The fix

Every per-call emitter now checks `daemonReachableFn()` first (hoisted so each handler dials at most once, where previously the deferred telemetry dialed anyway) and stands down while the socket is unreachable:

- **`runPreToolUse`** skips enrichment entirely, preserves the localization `updatedInput` passthrough (the auth nonce / problem-statement rewrite that a still-live MCP transport needs for `answer_ready` correlation), and emits a **once-per-session degradation notice** — deduped through the session state store, scoped to calls that target a tracked repo. The notice carries the same stance sentence as the SessionStart briefing via a shared const (`daemonUnreachableStance`), so the session-level and per-call layers cannot drift into contradicting each other — the issue's "related consistency point".
- **`runPostToolUse`** suppresses the "Do not re-Read/re-Grep" follow-ups (and skips up to one failed dial per matched file on a wide Glob).
- **Codex**: hard-deny, rewrite, and MCP-read nudge/deny postures stand down (the escalation's inline reachability check folds into the gate); `apply_patch` and suppress-mode PostToolUse skip their daemon round-trips.
- **Kimi**: PreToolUse and SubagentStart go silent.
- **Pi** returns an empty decision; **Hermes** never blocks. In both, the consult-unlock marker deliberately stays live (a failed graph attempt still shows intent), and the adaptive-nudge streak is now **frozen identically on every adapter** during an outage — Pi previously kept resetting it above the gate.

**Deliberately unchanged:** the localization terminal deny (local state that carries its own final answer — a test pins that it survives an outage), the consult-unlock / write-target markers (local bookkeeping), and the Stop / PreCompact / UserPromptSubmit briefings (built entirely from daemon answers, so they already degrade to silence).

**Known limit, matching the issue's scope:** the gate is `daemon.IsRunning` (a 200 ms socket dial). A daemon that accepts connections but cannot answer (the wedged case) still passes the gate; there the probes' individual fail-closed behavior remains the backstop. That mirror case is the #483 series' territory.

## Tests

- `internal/hooks` TestMain now pins `daemonReachableFn = true`, which also removes the suite's latent dependence on whether the developer machine happens to run a live daemon (previously the seam defaulted to a real socket dial in ~45 tests).
- 18 new tests in `daemon_degraded_test.go`, each with an up/down control pair so the outage assertion proves the gate rather than a broken fixture: per-adapter stand-down (Claude Pre/PostToolUse, Codex deny/rewrite/nudge/suppress, Kimi PreToolUse + SubagentStart, Pi, Hermes), notice dedupe + tracked-repo scoping (an untracked call neither notifies nor burns the session's notice), the force-compress deny gated, the localization passthrough preserved, the terminal deny surviving an outage, the auto-approve nudge dropped while the allow survives, the Pi streak freeze, and the notice/briefing stance shared-const invariant.
- The branch was additionally reviewed by a 15-agent adversarial pass (4 lenses → per-finding refutation, several verified by mutation testing); the surviving findings are fixed in the second commit.

`go build ./...`, `go test -race ./internal/hooks/`, `go test ./cmd/gortex/ ./internal/agents/...` (1114 tests / 23 packages), and `golangci-lint run ./internal/hooks/...` are green.