### PR TITLE
Resume deferred enrichment from a durable per-file ledger

### DIFF
--- a/cmd/gortex/daemon_state.go
+++ b/cmd/gortex/daemon_state.go
@@ -823,10 +823,12 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 	resolveScope := warmupResolveScope(changed, len(repos), anyChanged,
 		scopeUnknown.Load(), state.snapshotPartial, needsRebuild)
 
-	// Resume enrichment for any repo a prior process left partial / abandoned.
+	// Resume enrichment for any repo a prior process left partial / abandoned,
+	// or that indexed files under a deferred-enrichment window it never closed.
 	// Seeded BEFORE the resolve phase so the overlapped enrichment pool below
 	// covers those repos too. Cheap for a fully-enriched workspace: each
-	// already-complete repo pays only a git rev-parse plus one marker lookup.
+	// already-complete repo pays a git rev-parse, one marker lookup, and one
+	// repo-scoped file-node projection — bounded by file count, not symbols.
 	enrichPending := state.multiIndexer.SeedPendingEnrichAll()
 	if enrichPending > 0 && !anyChanged {
 		logger.Info("daemon: warmup resuming incomplete enrichment on an otherwise-unchanged restart",

--- a/internal/indexer/deferred_enrich_gate_test.go
+++ b/internal/indexer/deferred_enrich_gate_test.go
@@ -24,6 +24,7 @@ import (
 type spyEnrichProvider struct {
 	mu      sync.Mutex
 	repos   []string
+	files   []string
 	partial bool
 }
 
@@ -42,8 +43,15 @@ func (s *spyEnrichProvider) Enrich(g graph.Store, repoRoot string) (*semantic.En
 	return s.EnrichRepo(g, "", repoRoot)
 }
 
-func (s *spyEnrichProvider) EnrichFile(_ graph.Store, _, _ string) (*semantic.EnrichResult, error) {
-	return nil, nil
+// EnrichFile records the single-file dispatch a one-file frontier takes
+// (EnrichFilesContext calls it directly rather than a repo-wide pass), and
+// reports the same Partial disposition as the repo entry point so the
+// deferral-ledger tests can drive both outcomes.
+func (s *spyEnrichProvider) EnrichFile(_ graph.Store, _, filePath string) (*semantic.EnrichResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.files = append(s.files, filePath)
+	return &semantic.EnrichResult{Provider: "spy", Language: "go", Partial: s.partial}, nil
 }
 
 func (s *spyEnrichProvider) Close() error { return nil }
@@ -52,6 +60,14 @@ func (s *spyEnrichProvider) invoked() []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return append([]string(nil), s.repos...)
+}
+
+// enrichedFiles returns the file-scoped dispatches, the frontier equivalent of
+// invoked().
+func (s *spyEnrichProvider) enrichedFiles() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.files...)
 }
 
 func newSpyManager(spy *spyEnrichProvider) *semantic.Manager {

--- a/internal/indexer/deferred_enrich_ledger_test.go
+++ b/internal/indexer/deferred_enrich_ledger_test.go
@@ -1,0 +1,303 @@
+package indexer
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/semantic"
+)
+
+// seedWatchIndexedFile writes the KindFile node a live re-parse leaves behind
+// when semantic enrichment was deferred: present in the graph, stamped with the
+// durable graph.MetaReparsePendingEnrichment ledger marker. Returns the graph
+// path.
+func seedWatchIndexedFile(t *testing.T, g graph.Store, repoPrefix, relPath string) string {
+	t.Helper()
+	graphPath := filepath.Join(repoPrefix, relPath)
+	g.AddBatch([]*graph.Node{{
+		ID:         graphPath,
+		Kind:       graph.KindFile,
+		Name:       filepath.Base(relPath),
+		FilePath:   graphPath,
+		Language:   "go",
+		RepoPrefix: repoPrefix,
+		Meta:       map[string]any{graph.MetaReparsePendingEnrichment: true},
+	}}, nil)
+	return graphPath
+}
+
+// pendingLedger reports the repo's durable per-file deferral ledger, read back
+// through the graph so the assertion covers persistence rather than the
+// indexer's in-memory scope set.
+func pendingLedger(t *testing.T, idx *Indexer) []string {
+	t.Helper()
+	return idx.pendingEnrichFrontier()
+}
+
+// TestMaybeSeedPendingEnrich_NonGitRepoResumesFromLedger is the headline
+// regression. A tracked directory that is not a git repository can never have a
+// whole-repo completion marker — recordEnrichMarker no-ops on an empty sha — so
+// the marker gate declined forever and files the watcher indexed under
+// enrich_on_watch=false stayed at their heuristic tier across every restart.
+// The durable per-file ledger needs no git state, so it re-arms the pass.
+func TestMaybeSeedPendingEnrich_NonGitRepoResumesFromLedger(t *testing.T) {
+	repo := t.TempDir() // deliberately NOT a git repository
+	store := openTestSqlite(t)
+
+	spy := &spyEnrichProvider{}
+	idx := New(store, newTestRegistry(), config.Default().Index, zap.NewNop())
+	idx.SetRepoPrefix("r")
+	idx.SetRootPath(repo)
+	idx.SetSemanticManager(newSpyManager(spy))
+
+	require.Empty(t, repoHead(repo), "the fixture must not be a git repository")
+	assert.False(t, idx.MaybeSeedPendingEnrich(),
+		"a non-git repo with an empty ledger has nothing to resume")
+
+	// The watcher indexes a file while enrichment is deferred.
+	seedWatchIndexedFile(t, store, "r", "watched.go")
+
+	assert.True(t, idx.MaybeSeedPendingEnrich(),
+		"a non-git repo whose ledger names outstanding files must be re-armed")
+	assert.True(t, idx.pendingEnrich.Load())
+
+	// The resume is file-scoped, not a whole-repo re-enrich.
+	files, full, _ := idx.deferredEnrichScope()
+	assert.False(t, full, "the ledger names an exact frontier — no full pass")
+	assert.Equal(t, []string{filepath.Join("r", "watched.go")}, files)
+}
+
+// TestMaybeSeedPendingEnrich_LedgerResumeConverges: the resumed pass must
+// discharge the ledger it consumed, or every restart re-arms the same files
+// forever. Nothing but a watch-time enrichment cleared the marker before, and
+// watch-time enrichment is off by construction on the deferral path.
+func TestMaybeSeedPendingEnrich_LedgerResumeConverges(t *testing.T) {
+	repo := t.TempDir()
+	store := openTestSqlite(t)
+
+	spy := &spyEnrichProvider{}
+	idx := New(store, newTestRegistry(), config.Default().Index, zap.NewNop())
+	idx.SetRepoPrefix("r")
+	idx.SetRootPath(repo)
+	idx.SetSemanticManager(newSpyManager(spy))
+
+	seedWatchIndexedFile(t, store, "r", "watched.go")
+	require.True(t, idx.MaybeSeedPendingEnrich())
+
+	idx.runDeferredEnrich()
+	assert.Equal(t, []string{filepath.Join("r", "watched.go")}, spy.enrichedFiles(),
+		"the resumed pass must dispatch enrichment for exactly the ledger's files")
+	assert.False(t, idx.pendingEnrich.Load())
+	assert.Empty(t, pendingLedger(t, idx),
+		"a completed file-scoped pass must discharge the ledger entries it covered")
+
+	// A later restart sees an empty ledger and declines — the resume is one-shot.
+	assert.False(t, idx.MaybeSeedPendingEnrich(),
+		"a discharged ledger must not re-arm the pass on the next restart")
+}
+
+// TestMaybeSeedPendingEnrich_DischargesFilesNoProviderCovers: the discharge
+// covers the whole dispatched frontier, not only the paths a provider claimed.
+// A file whose language no provider handles still had its deferred pass run;
+// leaving it marked would re-arm the repo on every restart in perpetuity.
+func TestMaybeSeedPendingEnrich_DischargesFilesNoProviderCovers(t *testing.T) {
+	repo := t.TempDir()
+	store := openTestSqlite(t)
+
+	spy := &spyEnrichProvider{} // Languages() == ["go"]
+	idx := New(store, newTestRegistry(), config.Default().Index, zap.NewNop())
+	idx.SetRepoPrefix("r")
+	idx.SetRootPath(repo)
+	idx.SetSemanticManager(newSpyManager(spy))
+
+	// A Ruby file: stamped by the incremental path (providersPresent is
+	// repo-global, not per-language) but dispatched to no provider.
+	graphPath := filepath.Join("r", "script.rb")
+	store.AddBatch([]*graph.Node{{
+		ID: graphPath, Kind: graph.KindFile, Name: "script.rb",
+		FilePath: graphPath, Language: "ruby", RepoPrefix: "r",
+		Meta: map[string]any{graph.MetaReparsePendingEnrichment: true},
+	}}, nil)
+
+	require.True(t, idx.MaybeSeedPendingEnrich())
+	idx.runDeferredEnrich()
+
+	assert.Empty(t, pendingLedger(t, idx),
+		"an uncovered language must still be discharged by the pass that ran for it")
+	assert.False(t, idx.MaybeSeedPendingEnrich(),
+		"an uncovered language must not re-arm the repo forever")
+}
+
+// TestMaybeSeedPendingEnrich_DirtyTreeResumesFromLedger covers the second half
+// of the hole: a real git repo whose completion marker is current for HEAD, but
+// whose watch-indexed edits are still uncommitted. The marker gate saw "current"
+// and declined; the warmup parse saw the watcher's own persisted results and
+// reported nothing changed. Only the ledger knows those files skipped enrichment.
+func TestMaybeSeedPendingEnrich_DirtyTreeResumesFromLedger(t *testing.T) {
+	repo := commitGitRepo(t)
+	store := openTestSqlite(t)
+
+	spy := &spyEnrichProvider{}
+	mgr := newSpyManager(spy)
+	idx := New(store, newTestRegistry(), config.Default().Index, zap.NewNop())
+	idx.SetRepoPrefix("r")
+	idx.SetRootPath(repo)
+	idx.SetSemanticManager(mgr)
+
+	// A prior process completed enrichment at this HEAD on a clean tree.
+	sha := repoHead(repo)
+	require.NotEmpty(t, sha)
+	mgr.RecordRepoEnrichmentComplete(store, "r", sha, false)
+	require.False(t, idx.MaybeSeedPendingEnrich(),
+		"a current marker on a clean tree with an empty ledger declines")
+
+	// Then the watcher indexed an uncommitted file with enrichment deferred.
+	writeFile(t, filepath.Join(repo, "extra.go"), "package main\n\nvar Extra = 1\n")
+	seedWatchIndexedFile(t, store, "r", "extra.go")
+
+	assert.True(t, idx.MaybeSeedPendingEnrich(),
+		"uncommitted watch-indexed files must resume even though the marker names HEAD")
+	files, full, _ := idx.deferredEnrichScope()
+	assert.False(t, full)
+	assert.Equal(t, []string{filepath.Join("r", "extra.go")}, files)
+}
+
+// TestMaybeSeedPendingEnrich_StaleMarkerStillWinsOverLedger: an absent or stale
+// completion marker on a CLEAN tree means the last whole-repo pass never
+// finished, so files outside the ledger are unenriched too. That signal must
+// keep dominating — a file-scoped resume would silently narrow the recovery.
+func TestMaybeSeedPendingEnrich_StaleMarkerStillWinsOverLedger(t *testing.T) {
+	repo := commitGitRepo(t)
+	store := openTestSqlite(t)
+
+	spy := &spyEnrichProvider{}
+	idx := New(store, newTestRegistry(), config.Default().Index, zap.NewNop())
+	idx.SetRepoPrefix("r")
+	idx.SetRootPath(repo)
+	idx.SetSemanticManager(newSpyManager(spy))
+
+	// No completion marker (a partial pass writes none) AND a ledger entry.
+	seedWatchIndexedFile(t, store, "r", "watched.go")
+
+	require.True(t, idx.MaybeSeedPendingEnrich())
+	_, full, _ := idx.deferredEnrichScope()
+	assert.True(t, full,
+		"a known-incomplete whole-repo pass must re-arm full scope, not the file frontier")
+}
+
+// TestRunDeferredEnrich_FullPassDischargesLedger: a whole-repo pass covers every
+// file, so it retires the durable ledger outright. Without this the markers
+// accumulate for the life of the graph and find_usages keeps riding every one of
+// those files' suppressions with a re-verification-pending flag that no
+// completed enrichment could ever retire.
+func TestRunDeferredEnrich_FullPassDischargesLedger(t *testing.T) {
+	// The whole-repo entry point applies the language admission floor; these
+	// fixtures carry a handful of nodes, so disable it to exercise dispatch.
+	t.Setenv("GORTEX_ENRICH_MIN_NODES", "0")
+	repo := commitGitRepo(t)
+	store := openTestSqlite(t)
+
+	spy := &spyEnrichProvider{}
+	idx := New(store, newTestRegistry(), config.Default().Index, zap.NewNop())
+	idx.SetRepoPrefix("r")
+	idx.SetRootPath(repo)
+	idx.SetSemanticManager(newSpyManager(spy))
+
+	seedWatchIndexedFile(t, store, "r", "a.go")
+	seedWatchIndexedFile(t, store, "r", "b.go")
+	require.Len(t, pendingLedger(t, idx), 2)
+
+	idx.markPendingEnrichFull()
+	idx.runDeferredEnrich()
+
+	assert.Equal(t, []string{"r"}, spy.invoked())
+	assert.Empty(t, pendingLedger(t, idx),
+		"a completed whole-repo pass must discharge the durable ledger")
+}
+
+// TestRunDeferredEnrich_PartialPassKeepsLedger: a partial / abandoned pass must
+// not discharge anything, or the outstanding work becomes invisible to the next
+// restart — the exact failure mode this ledger exists to prevent.
+func TestRunDeferredEnrich_PartialPassKeepsLedger(t *testing.T) {
+	repo := t.TempDir()
+	store := openTestSqlite(t)
+
+	spy := &spyEnrichProvider{partial: true}
+	idx := New(store, newTestRegistry(), config.Default().Index, zap.NewNop())
+	idx.SetRepoPrefix("r")
+	idx.SetRootPath(repo)
+	idx.SetSemanticManager(newSpyManager(spy))
+
+	seedWatchIndexedFile(t, store, "r", "watched.go")
+	require.True(t, idx.MaybeSeedPendingEnrich())
+
+	idx.runDeferredEnrich()
+
+	assert.True(t, idx.pendingEnrich.Load(), "a partial pass keeps the in-memory gate armed")
+	assert.Equal(t, []string{filepath.Join("r", "watched.go")}, pendingLedger(t, idx),
+		"a partial pass must leave the durable ledger intact for the next restart")
+}
+
+// TestSeedPendingEnrichAll_ResumesNonGitRepo drives the warmup entry point over
+// a mixed workspace: the non-git repo with outstanding ledger entries is
+// resumed, the fully-enriched git repo is left alone.
+func TestSeedPendingEnrichAll_ResumesNonGitRepo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available in PATH")
+	}
+	store := openTestSqlite(t)
+	spy := &spyEnrichProvider{}
+	mgr := newSpyManager(spy)
+
+	gitRepo := commitGitRepo(t)
+	complete := New(store, newTestRegistry(), config.Default().Index, zap.NewNop())
+	complete.SetRepoPrefix("complete")
+	complete.SetRootPath(gitRepo)
+	complete.SetSemanticManager(mgr)
+	mgr.RecordRepoEnrichmentComplete(store, "complete", repoHead(gitRepo), false)
+
+	plain := New(store, newTestRegistry(), config.Default().Index, zap.NewNop())
+	plain.SetRepoPrefix("plain")
+	plain.SetRootPath(t.TempDir()) // not a git repository
+	plain.SetSemanticManager(mgr)
+	seedWatchIndexedFile(t, store, "plain", "watched.go")
+
+	mi := newEmptyMultiIndexer(t, store)
+	mi.indexers["complete"] = complete
+	mi.indexers["plain"] = plain
+
+	assert.Equal(t, 1, mi.SeedPendingEnrichAll(),
+		"only the repo with outstanding ledger entries is re-armed")
+	assert.True(t, plain.pendingEnrich.Load())
+	assert.False(t, complete.pendingEnrich.Load())
+
+	mi.runDeferredEnrichParallel([]*Indexer{complete, plain})
+	assert.Equal(t, []string{filepath.Join("plain", "watched.go")}, spy.enrichedFiles(),
+		"only the resumed repo should have its enrichment dispatched")
+	assert.Empty(t, spy.invoked(),
+		"a ledger resume is file-scoped — it must not trigger a whole-repo pass")
+}
+
+// TestMaybeSeedPendingEnrich_NoLedgerNoProvidersNoop keeps the cheapest decline
+// free of graph work: without providers there is nothing to resume, ledger or
+// not, so the projection is never issued.
+func TestMaybeSeedPendingEnrich_NoLedgerNoProvidersNoop(t *testing.T) {
+	store := openTestSqlite(t)
+	idx := New(store, newTestRegistry(), config.Default().Index, zap.NewNop())
+	idx.SetRepoPrefix("r")
+	idx.SetRootPath(t.TempDir())
+	idx.SetSemanticManager(semantic.NewManager(semantic.Config{Enabled: true}, zap.NewNop()))
+
+	seedWatchIndexedFile(t, store, "r", "watched.go")
+
+	assert.False(t, idx.MaybeSeedPendingEnrich(),
+		"a repo with no semantic providers has nothing to resume")
+	assert.False(t, idx.pendingEnrich.Load())
+}

--- a/internal/indexer/deferred_enrich_scope.go
+++ b/internal/indexer/deferred_enrich_scope.go
@@ -153,6 +153,59 @@ func (idx *Indexer) semanticDependencyFrontierForDeletedFiles(relPaths []string)
 	return appendUniqueSorted(nil, frontier...)
 }
 
+// pendingEnrichFrontier reads the DURABLE per-file deferral ledger: the graph
+// paths whose KindFile node still carries graph.MetaReparsePendingEnrichment,
+// which the incremental / watch paths stamp on a file they re-parsed while
+// semantic enrichment was deferred (semantic.enrich_on_watch=false, or a
+// deferred global-pass window). Unlike the in-memory deferredEnrichFiles set it
+// lives on the node itself, so it survives a daemon restart — and unlike the
+// whole-repo completion marker it needs neither a git sha nor a clean tree, so
+// it is the ONLY evidence of outstanding enrichment for a repo that is not a
+// git checkout or whose watch-indexed edits are still uncommitted.
+//
+// One repo-scoped, kind-filtered projection per call; the marker is a binary
+// meta blob, so the key test is decoded backend-side rather than pushed into
+// the query. Bounded by the repo's file count, not its symbol count.
+func (idx *Indexer) pendingEnrichFrontier() []string {
+	nodes := graph.ReadRepoNodesByKindsWithMetaKey(
+		idx.graph, idx.repoPrefix, idx.workspaceID,
+		[]graph.NodeKind{graph.KindFile}, graph.MetaReparsePendingEnrichment,
+	)
+	var frontier []string
+	for _, node := range nodes {
+		if node == nil || node.FilePath == "" {
+			continue
+		}
+		// Mirror suppressionMayBeStale: only a truthy marker is pending. The
+		// writer deletes the key when it clears, so a false value is unreachable
+		// today — reading it defensively keeps the two consumers in agreement.
+		if pending, _ := node.Meta[graph.MetaReparsePendingEnrichment].(bool); pending {
+			frontier = append(frontier, node.FilePath)
+		}
+	}
+	return appendUniqueSorted(nil, frontier...)
+}
+
+// dischargePendingEnrichFrontier clears the durable per-file deferral for the
+// graph paths a deferred pass just covered. Without it the ledger only ever
+// grows: nothing but a watch-time enrichment (which is off by construction on
+// the deferral path) cleared the marker, so a resumed pass would re-arm the
+// same files on every restart, and find_usages would keep riding every one of
+// those files' suppressions with a re-verification-pending flag that no
+// completed enrichment could ever retire.
+func (idx *Indexer) dischargePendingEnrichFrontier(graphPaths []string) {
+	if len(graphPaths) == 0 {
+		return
+	}
+	discharged := make(map[string]bool, len(graphPaths))
+	for _, graphPath := range graphPaths {
+		if graphPath != "" {
+			discharged[graphPath] = false
+		}
+	}
+	idx.setReparsePendingEnrichments(discharged)
+}
+
 // clearPendingEnrich clears only the work represented by generation. If a
 // watcher queued another change during enrichment, that newer work remains.
 func (idx *Indexer) clearPendingEnrich(generation uint64) bool {

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -1278,7 +1278,15 @@ func (idx *Indexer) runDeferredEnrich() {
 		// A file frontier proves only that the affected language/file batches
 		// were refreshed. It must never publish the whole-repository completion
 		// marker: files and packages outside this exact frontier did not run.
-		idx.clearPendingEnrich(pendingGeneration)
+		if idx.clearPendingEnrich(pendingGeneration) {
+			// The whole dispatched frontier is discharged, not just the paths a
+			// provider claimed: a file whose language no provider covers still
+			// had its deferred pass run, and leaving it marked would re-arm it
+			// on every restart forever. A newer generation (the watcher queued
+			// work mid-pass) keeps its own markers — clearPendingEnrich already
+			// declined, so this does not run.
+			idx.dischargePendingEnrichFrontier(pendingFiles)
+		}
 		return
 	}
 	// A re-parse this run evicted the persisted hover edges of the re-parsed
@@ -1315,6 +1323,12 @@ func (idx *Indexer) runDeferredEnrich() {
 	// so a later deferred pass (or the next restart, once the repo changes
 	// again) retries the enrichment rather than trusting an incomplete graph.
 	if !partialRepos[idx.repoPrefix] && idx.clearPendingEnrich(pendingGeneration) {
+		// A whole-repo pass covers every file, so it discharges the durable
+		// per-file ledger outright. This is the only place a non-git or dirty
+		// repo can ever retire those markers — RecordRepoEnrichmentComplete
+		// below no-ops for it — and it is what keeps find_usages from riding a
+		// re-verification-pending flag on files whose enrichment did complete.
+		idx.dischargePendingEnrichFrontier(idx.pendingEnrichFrontier())
 		// Persist a whole-repo completion marker at this HEAD so the next warm
 		// restart can tell, with one lookup, that this repo's enrichment finished
 		// and MaybeSeedPendingEnrich need not resume it. A partial / abandoned
@@ -1335,13 +1349,31 @@ func (idx *Indexer) runDeferredEnrich() {
 // file changed to raise the flag. The daemon warmup calls this after the parse
 // phase, before draining the deferred passes.
 //
+// Two independent signals arm it, in dominance order:
+//
+//	Whole-repo completion marker — absent or stale at a clean HEAD means the
+//	last pass never finished, so the WHOLE repo is re-armed. This signal needs
+//	a git sha it can key on and a clean tree it can trust, and is skipped on a
+//	backend that does not persist enrichment state (such a backend re-indexes
+//	from scratch each restart anyway).
+//
+//	Durable per-file ledger — the graph.MetaReparsePendingEnrichment markers
+//	the watch / incremental paths stamp on files they re-parsed without
+//	running enrichment. This signal needs no git state at all, so it is what
+//	closes the window for (a) a tracked directory that is not a git repository
+//	and (b) a git repo whose watch-indexed changes stay uncommitted across
+//	restarts. Both used to decline here, silently and permanently: the marker
+//	could never be keyed (recordEnrichMarker no-ops on an empty sha) or was
+//	current for a HEAD the uncommitted files had moved past, the warmup parse
+//	saw the watcher's own persisted results and reported nothing changed, and
+//	so the "until the next full enrichment" window that EnrichesOnWatch
+//	documents never closed. The ledger names exactly the outstanding files, so
+//	the resumed pass is file-scoped rather than a whole-repo re-enrich.
+//
 // Returns whether this repo will enrich (already pending, or newly seeded). A
-// no-op — false — for a repo without semantic providers, on a non-git tree (no
-// reliable freshness signal), on a backend that does not persist enrichment
-// state (it re-indexes from scratch each restart anyway), when the completion
-// marker already records the current HEAD, or on a dirty tree (the marker is
-// never written or trusted against uncommitted content, and resuming every
-// restart while the tree stays dirty would defeat the warm-restart fast path).
+// no-op — false — for a repo without semantic providers, and for one whose
+// completion marker is current with an empty ledger; that decline is logged at
+// debug with the reason, since it is the ordinary warm-restart outcome.
 func (idx *Indexer) MaybeSeedPendingEnrich() bool {
 	if idx.semanticMgr == nil || !idx.semanticMgr.Enabled() || !idx.semanticMgr.HasProviders() {
 		return false
@@ -1353,22 +1385,42 @@ func (idx *Indexer) MaybeSeedPendingEnrich() bool {
 	// Cheap probe first: only the sha is needed to tell a repo whose marker is
 	// already current (the common warm-restart case) from one that must resume,
 	// so the slower git status shell-out is deferred to the resume path below.
-	sha := repoHead(idx.rootPath)
-	if sha == "" {
-		return false
+	reason := "no git head"
+	if sha := repoHead(idx.rootPath); sha != "" {
+		current, persisted := idx.semanticMgr.RepoEnrichmentMarkerState(idx.graph, idx.repoPrefix, sha)
+		switch {
+		case !persisted:
+			reason = "enrichment state not persisted"
+		case current:
+			reason = "completion marker current"
+		default:
+			// Known-incomplete. The marker is only trustworthy against
+			// committed content, so a dirty tree falls through to the ledger
+			// rather than re-enriching the whole repo on every restart.
+			if _, dirty := repoHeadAndDirty(idx.rootPath); !dirty {
+				idx.logger.Info("deferred enrichment re-armed: persisted enrichment incomplete",
+					zap.String("repo", idx.repoPrefix),
+					zap.String("sha", sha))
+				idx.markPendingEnrichFull()
+				return true
+			}
+			reason = "completion marker stale on a dirty tree"
+		}
 	}
-	current, persisted := idx.semanticMgr.RepoEnrichmentMarkerState(idx.graph, idx.repoPrefix, sha)
-	if !persisted || current {
-		return false
+	// The whole-repo marker could not settle it. Resume from the durable
+	// per-file ledger, which is independent of git state.
+	if frontier := idx.pendingEnrichFrontier(); len(frontier) > 0 {
+		idx.logger.Info("deferred enrichment re-armed: files indexed without semantic enrichment",
+			zap.String("repo", idx.repoPrefix),
+			zap.Int("files", len(frontier)),
+			zap.String("marker", reason))
+		idx.markPendingEnrichFiles(frontier)
+		return true
 	}
-	if _, dirty := repoHeadAndDirty(idx.rootPath); dirty {
-		return false
-	}
-	idx.logger.Info("deferred enrichment re-armed: persisted enrichment incomplete",
+	idx.logger.Debug("deferred enrichment not re-armed",
 		zap.String("repo", idx.repoPrefix),
-		zap.String("sha", sha))
-	idx.markPendingEnrichFull()
-	return true
+		zap.String("reason", reason))
+	return false
 }
 
 // runDeferredContracts extracts and commits this repo's contract nodes and


### PR DESCRIPTION
Fixes #493.

## The hole

Files the watcher indexed while semantic enrichment was deferred could stay at their heuristic tier **permanently**, across any number of daemon restarts. Three gates composed with no exit:

1. **Watch-time** — the incremental path skips `EnrichFile` when `semantic.enrich_on_watch` is off. By design; `EnrichesOnWatch`'s doc calls the resulting window "until the next full enrichment".
2. **Restart-time resume** — `MaybeSeedPendingEnrich` re-armed that pass *only* from the whole-repo completion marker, which needs a git sha to key on and a clean tree to be trusted. A non-git directory never has a marker at all (`recordEnrichMarker` no-ops on an empty sha); a repo whose watch-indexed edits are uncommitted has one that names a HEAD those files have moved past.
3. **Restart-time parse** — the watcher already persisted the new files' parse, so warmup saw the repo as unchanged and did not arm it either.

Net: for a tracked directory that is not a git repository, **and** for any repo carrying uncommitted watch-indexed changes across a restart, the next full enrichment never came. `GORTEX_WARMUP_FORCE_ENRICH=1` was the only lever, and it re-enriches every tracked repo.

## The fix

**Resume from the durable per-file ledger that already existed.** `graph.MetaReparsePendingEnrichment` is stamped on the `KindFile` node of every file the incremental/watch paths re-parse without enriching. It lives on the node, so it survives a restart — and it needs no git state, which is exactly what the completion marker cannot offer these repos. It also names the outstanding files, so the resumed pass is **file-scoped** rather than the whole-repo re-enrich issue #493's option 2 proposed.

The completion marker still dominates: absent or stale at a **clean** HEAD means the last whole-repo pass never finished, so files outside the ledger are unenriched too and a file-scoped resume would silently narrow the recovery.

**Discharge the ledger when a pass covers it.** Nothing retired these markers before — only a watch-time enrichment cleared them, and watch-time enrichment is off by construction on the deferral path. Without a discharge the ledger only grows, the resume becomes a restart loop, and `find_usages` keeps riding every one of those files' suppressions with a re-verification-pending flag (`suppressionMayBeStale`) that no completed enrichment could ever retire. A file-scoped pass discharges its frontier; a whole-repo pass discharges the repo.

The previously silent decline is now logged with its reason (`no git head`, `enrichment state not persisted`, `completion marker current`, `completion marker stale on a dirty tree`).

## Cost

`SeedPendingEnrichAll` now adds one repo-scoped `kind=file` projection per repo at warmup, on top of the existing `git rev-parse` + marker lookup. Bounded by file count, not symbol count — the largest repo in the workspace above is 14k file nodes. The marker is a binary meta blob (not JSON text in the `nodes` column), so the key test is decoded backend-side rather than pushed into SQL; `graph.ReadRepoNodesByKindsWithMetaKey` is the existing sanctioned projection for exactly this. The `git status` shell-out is still confined to the stale-marker branch.

First restart after this lands does one bounded catch-up pass per affected repo — the work that was being skipped.

## Tests

`internal/indexer/deferred_enrich_ledger_test.go`, 9 cases:

- non-git repo resumes from the ledger, file-scoped
- git repo with a **current** marker + uncommitted watch-indexed files resumes
- resume converges — a completed pass discharges the ledger and the next restart declines (not a restart loop)
- a language no provider covers is still discharged
- a stale marker on a clean tree still wins over the ledger (full scope, not narrowed)
- a whole-repo pass discharges the ledger
- a **partial** pass leaves the ledger intact for the next restart
- `SeedPendingEnrichAll` over a mixed workspace resumes only the repo with outstanding entries
- no providers → no graph work

The shared `spyEnrichProvider.EnrichFile` returned `(nil, nil)` and recorded nothing, so single-file frontier dispatch (`EnrichFilesContext` calls `EnrichFile` directly for a one-file frontier) was invisible to tests. It now records the path and propagates the same `Partial` disposition as the repo entry point.

## Verification

- `go build ./...`, `go vet` clean
- `golangci-lint run` clean on the touched packages
- `go test -race ./...` green
