### PR TITLE
Fix gortex call --arg splitting and --format json output

### DIFF
--- a/cmd/gortex/call.go
+++ b/cmd/gortex/call.go
@@ -61,7 +61,9 @@ The walrus is recognised only when ":=" opens the token, so a value that quotes
 
 Use --dry to print the lowered argument object and the target tool without
 calling the daemon (works with no daemon running). Use --format to pick the
-wire format the tool renders (json|gcx|toon|text).
+wire format the tool renders (json|gcx|toon|text). --format json always prints
+parseable JSON: a tool that answers in prose is wrapped as
+{"tool":…,"format":"text","text":…}.
 
 When <tool> is one of the compact public tool names, this command automatically
 selects the compact surface for that connection and accepts the exact MCP
@@ -160,9 +162,32 @@ func runCall(cmd *cobra.Command, args []string) error {
 		// corrupt them.
 		fmt.Fprintln(cmd.OutOrStdout(), strings.TrimRight(string(raw), "\n"))
 		return nil
-	default: // json | text
+	case "json":
+		return emitCallJSON(cmd, tool, raw)
+	default: // text
 		return emitDaemonJSON(cmd, raw)
 	}
+}
+
+// emitCallJSON keeps the --format json promise for every tool on the surface,
+// including the ones that answer in prose. A JSON payload is re-indented and
+// printed unchanged. A payload the tool rendered as text is wrapped in a
+// minimal envelope so a JSON client parses a response instead of failing on the
+// first markdown character. explore(operation:"task") is the case in the core
+// surface: it returns the human-oriented localization page and has no
+// structured response upstream to surface instead, unlike operation:"localize",
+// whose envelope passes straight through.
+func emitCallJSON(cmd *cobra.Command, tool string, raw json.RawMessage) error {
+	if json.Valid(raw) {
+		return emitDaemonJSON(cmd, raw)
+	}
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(map[string]any{
+		"tool":   tool,
+		"format": "text",
+		"text":   string(raw),
+	})
 }
 
 func describeToolEffects(effect daemon.ToolEffect) string {

--- a/cmd/gortex/call.go
+++ b/cmd/gortex/call.go
@@ -56,7 +56,8 @@ from three layers (last wins per key):
 number, null -> null, a value starting with [ or { -> parsed JSON, key:=<raw>
 forces raw-JSON parse of the right-hand side (so version:="1.0" stays the
 string "1.0"), key= -> the empty string, and anything else stays a string.
-Repeating a key replaces the earlier value.
+The walrus is recognised only when ":=" opens the token, so a value that quotes
+":=" is passed through verbatim. Repeating a key replaces the earlier value.
 
 Use --dry to print the lowered argument object and the target tool without
 calling the daemon (works with no daemon running). Use --format to pick the
@@ -281,15 +282,25 @@ func mergeJSONObject(dst map[string]any, data []byte, source string) error {
 // type coercion. The grammar:
 //
 //	key:=<raw>  walrus — the right-hand side is parsed as raw JSON (so
-//	            version:="1.0" stays the string "1.0", not a number)
+//	            version:="1.0" stays the string "1.0", not a number). Applies
+//	            only when ":=" opens the token; a ":=" inside the value is
+//	            ordinary text.
 //	key=value   value is coerced: true/false -> bool, int/float -> number,
 //	            null -> null, a value starting with [ or { -> parsed JSON,
 //	            key= -> empty string, everything else -> string
 func coerceArg(token string) (string, any, error) {
-	// Walrus first: a "key:=rhs" forces raw-JSON parse of the RHS. Detect the
-	// ":=" boundary before the plain "=" so version:="1.0" is not mistaken for
-	// a key of "version:" with an "=" value.
-	if i := strings.Index(token, ":="); i >= 0 {
+	// The separator is decided on the KEY position alone. Whichever of ":=" and
+	// "=" opens the token ends the key; everything after it is the value, and a
+	// ":=" that occurs later belongs to the value. Scanning the whole token for
+	// the walrus would split a pasted snippet (task=Dim x := 5) mid-value and
+	// then reject the remainder as invalid JSON.
+	eq := strings.Index(token, "=")
+	if eq < 0 {
+		return "", nil, fmt.Errorf("--arg %q: expected key=value or key:=<json>", token)
+	}
+	// Walrus: a "key:=rhs" forces raw-JSON parse of the RHS, so version:="1.0"
+	// stays the string "1.0" and is not mistaken for a key of "version:".
+	if i := strings.Index(token, ":="); i >= 0 && i < eq {
 		key := token[:i]
 		if key == "" {
 			return "", nil, fmt.Errorf("--arg %q: empty key", token)
@@ -302,10 +313,6 @@ func coerceArg(token string) (string, any, error) {
 		return key, v, nil
 	}
 
-	eq := strings.Index(token, "=")
-	if eq < 0 {
-		return "", nil, fmt.Errorf("--arg %q: expected key=value or key:=<json>", token)
-	}
 	key := token[:eq]
 	if key == "" {
 		return "", nil, fmt.Errorf("--arg %q: empty key", token)

--- a/cmd/gortex/call_test.go
+++ b/cmd/gortex/call_test.go
@@ -306,6 +306,78 @@ func TestCall_CompactDefaultPreservesRequestOutputFormat(t *testing.T) {
 	require.Equal(t, "TOON|results|...\n", buf.String())
 }
 
+// exploreTaskMarkdown is the shape explore(operation:"task") returns: the
+// human-oriented localization page, which the tool renders as markdown and
+// which carries no structured payload of its own.
+const exploreTaskMarkdown = "# Task: retry backoff\n\n## Candidates\n\n1. `Client.do` — internal/http/client.go:42\n"
+
+// TestCall_JSONFormatAlwaysEmitsJSON pins the --format json contract at the
+// only layer that promises it: whatever the tool rendered, stdout parses as
+// JSON. explore(operation:"task") is the case in the core surface that renders
+// markdown, so a JSON client used to get a parse error instead of a response.
+func TestCall_JSONFormatAlwaysEmitsJSON(t *testing.T) {
+	origLegacy, origFacade := callDaemonTool, callFacadeDaemonTool
+	t.Cleanup(func() { callDaemonTool, callFacadeDaemonTool = origLegacy, origFacade })
+
+	t.Run("explore task markdown is wrapped in an envelope", func(t *testing.T) {
+		callFacadeDaemonTool = func(_ string, _ string, _ map[string]any) (json.RawMessage, error) {
+			return json.RawMessage(exploreTaskMarkdown), nil
+		}
+		cmd, buf := newCallTestCmd(t)
+		callArgs = []string{"operation=task", "task=why does the retry backoff never fire"}
+		require.NoError(t, runCall(cmd, []string{"explore"}))
+
+		var envelope map[string]any
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &envelope),
+			"--format json must emit parseable JSON, got: %s", buf.String())
+		require.Equal(t, "explore", envelope["tool"])
+		require.Equal(t, "text", envelope["format"])
+		require.Equal(t, exploreTaskMarkdown, envelope["text"])
+	})
+
+	t.Run("structured payloads pass through unwrapped", func(t *testing.T) {
+		callFacadeDaemonTool = func(_ string, _ string, _ map[string]any) (json.RawMessage, error) {
+			return json.RawMessage(`{"completion":{"state":"localized"},"symbols":["a"]}`), nil
+		}
+		cmd, buf := newCallTestCmd(t)
+		callArgs = []string{"operation=localize", "task=where is the retry backoff"}
+		require.NoError(t, runCall(cmd, []string{"explore"}))
+
+		var payload map[string]any
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &payload))
+		require.Contains(t, payload, "completion", "a JSON tool response must not be re-wrapped")
+		require.NotContains(t, payload, "text")
+	})
+
+	t.Run("legacy relay text is wrapped too", func(t *testing.T) {
+		callDaemonTool = func(_ string, tool string, _ map[string]any) (json.RawMessage, error) {
+			if tool == "tool_profile" {
+				return json.RawMessage(cannedToolProfileJSON), nil
+			}
+			return json.RawMessage("plain prose, not JSON\n"), nil
+		}
+		cmd, buf := newCallTestCmd(t)
+		require.NoError(t, runCall(cmd, []string{"search_symbols"}))
+
+		var envelope map[string]any
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &envelope),
+			"--format json must emit parseable JSON, got: %s", buf.String())
+		require.Equal(t, "search_symbols", envelope["tool"])
+		require.Equal(t, "plain prose, not JSON\n", envelope["text"])
+	})
+
+	t.Run("format text keeps the rendered page verbatim", func(t *testing.T) {
+		callFacadeDaemonTool = func(_ string, _ string, _ map[string]any) (json.RawMessage, error) {
+			return json.RawMessage(exploreTaskMarkdown), nil
+		}
+		cmd, buf := newCallTestCmd(t)
+		callFormat = "text"
+		callArgs = []string{"operation=task", "task=why does the retry backoff never fire"}
+		require.NoError(t, runCall(cmd, []string{"explore"}))
+		require.Equal(t, exploreTaskMarkdown+"\n", buf.String())
+	})
+}
+
 func TestCall_CompactDryRunShowsFinalExplicitFormat(t *testing.T) {
 	cmd, buf := newCallTestCmd(t)
 	callDry = true

--- a/cmd/gortex/call_test.go
+++ b/cmd/gortex/call_test.go
@@ -114,6 +114,46 @@ func TestCoerceArg(t *testing.T) {
 	})
 }
 
+// TestCoerceArg_SeparatorChosenByKeyPosition pins the rule that decides which
+// separator splits a token: the walrus applies only when ":=" opens the token's
+// key, so a VALUE that quotes ":=" (a pasted VB/Go snippet, a Pascal
+// assignment) is carried through verbatim instead of being split mid-value and
+// rejected as invalid JSON.
+func TestCoerceArg_SeparatorChosenByKeyPosition(t *testing.T) {
+	t.Run("value containing walrus stays a string", func(t *testing.T) {
+		k, v, err := coerceArg("key=a:=b")
+		require.NoError(t, err)
+		require.Equal(t, "key", k)
+		require.Equal(t, "a:=b", v)
+	})
+	t.Run("walrus in key position parses JSON", func(t *testing.T) {
+		k, v, err := coerceArg(`key:={"x":1}`)
+		require.NoError(t, err)
+		require.Equal(t, "key", k)
+		require.Equal(t, map[string]any{"x": float64(1)}, v)
+	})
+	t.Run("plain key=value is unchanged", func(t *testing.T) {
+		k, v, err := coerceArg("key=val")
+		require.NoError(t, err)
+		require.Equal(t, "key", k)
+		require.Equal(t, "val", v)
+	})
+	t.Run("value containing both separators is verbatim", func(t *testing.T) {
+		// A pasted issue body: the first "=" ends the key, everything after it
+		// — further "=" signs and the ":=" walrus alike — is the value.
+		k, v, err := coerceArg("task=Dim x := 5 : y = x + 1")
+		require.NoError(t, err)
+		require.Equal(t, "task", k)
+		require.Equal(t, "Dim x := 5 : y = x + 1", v)
+	})
+	t.Run("walrus still wins when it opens the token", func(t *testing.T) {
+		k, v, err := coerceArg(`note:="a=b:=c"`)
+		require.NoError(t, err)
+		require.Equal(t, "note", k)
+		require.Equal(t, "a=b:=c", v)
+	})
+}
+
 // TestLowerCallArgs_Precedence asserts the three precedence layers: base JSON,
 // inline JSON merged over it, and --arg merged on top (last wins per key).
 func TestLowerCallArgs_Precedence(t *testing.T) {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -160,6 +160,8 @@ The bytes are validated as well-formed JSON before the call. The same `inline / 
 | `key=` | the empty string |
 | anything else | string |
 
+The separator is chosen by the **key** position: `:=` opens a raw-JSON token only when it comes before the first `=`. A `:=` inside the value is ordinary text, so `--arg task=Dim x := 5` passes the snippet through verbatim.
+
 Repeating a key replaces the earlier value. For `call`, a base object can also come from `--json '<obj>'`, `--json-file <path>`, or `--json -` (stdin); precedence is **file < `--json` < `--arg`** (last wins per key).
 
 ### `gortex call <tool>` — invoke any tool by name
@@ -171,7 +173,7 @@ The generic relay: invoke any tool the daemon's MCP surface registers, even one 
 | `--arg key=value` | one argument, repeatable; coercion table above |
 | `--json '<obj>'` / `--json -` | base object inline or from stdin |
 | `--json-file <path>` | base object from a file |
-| `--format json\|gcx\|toon\|text` | wire format forwarded to the tool (default `json`) |
+| `--format json\|gcx\|toon\|text` | wire format forwarded to the tool (default `json`). `json` always prints parseable JSON: a tool that answers in prose — `explore` with `operation: "task"`, which renders a markdown page — is wrapped as `{"tool":…,"format":"text","text":…}`. Use `--format text` for the page itself. |
 | `--dry` | print the lowered argument object + target tool **without** calling the daemon (works offline) |
 | `--quiet` | suppress the mutating-tool stderr note |
 | `--legacy` | use the historical handler contract for a name shared by the compact and legacy surfaces (`analyze`, `explore`, `review`, `ask`) |


### PR DESCRIPTION
Two defects in the `gortex call` door, both found while replaying recorded benchmark sessions through the CLI.

## `--arg` split at the wrong separator

`coerceArg` scanned the **whole** `--arg` token for the `:=` walrus, so a value that quoted `:=` was split mid-value and the remainder rejected as invalid JSON. A pasted issue body containing a VB assignment (`precision:=3`) was enough to fail the call.

The separator is now decided on the **key** position alone: the walrus applies only when `:=` occurs before the first `=`; otherwise the token splits at the first `=` and the whole remainder is the value, verbatim. Every previously accepted form is unchanged — `version:="1.0"` still yields the string `"1.0"`, `key:={"a":1}` still parses as JSON, and the empty-key / missing-`=` errors are untouched. `gortex analyze --arg` shares the function and gets the same fix.

## `--format json` printed markdown

`explore` with `operation: "task"` renders a human-oriented markdown localization page, so `gortex call explore --format json` put markdown on stdout and a JSON client failed on the first character. `operation: "localize"` was unaffected — it builds a structured envelope.

There is no structured response to surface instead: `explore` deliberately keeps the task page free of the localization completion contract, so `handleExplore` returns a text-only result on that path. The fix is therefore at the layer that makes the promise. The json output path now prints a JSON payload unchanged (re-indented, as before) and wraps a text payload as `{"tool":…,"format":"text","text":…}`. `--format text` still prints the rendered page verbatim, and `gcx` / `toon` are untouched.

## Tests

- `TestCoerceArg_SeparatorChosenByKeyPosition` — value containing `:=`, walrus in key position, plain `key=value`, a value carrying both separators, and a walrus RHS that itself quotes both.
- `TestCall_JSONFormatAlwaysEmitsJSON` — markdown wrapped into a parseable envelope on the compact relay and the legacy relay, a structured payload passing through unwrapped, and `--format text` keeping the page verbatim.

Both test functions fail on the parent commit for exactly the reported reasons.

## Gates

- `go test ./cmd/gortex/ -count=1` — ok
- `golangci-lint run ./cmd/gortex/` — 0 issues
- `gofmt -l` clean on touched files
- `go build -buildvcs=false ./cmd/gortex/` — ok
