### PR TITLE
fix(init): isolate integration-test XDG paths

### DIFF
--- a/cmd/gortex/init_integration_test.go
+++ b/cmd/gortex/init_integration_test.go
@@ -48,7 +48,7 @@ func TestInitDryRunJSONReportShape(t *testing.T) {
 
 	repo := t.TempDir()
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	isolateInitTestEnv(t, home)
 
 	initYes = true
 	initDryRun = true
@@ -119,7 +119,7 @@ func TestInitAgentsFilterRejectsUnknownName(t *testing.T) {
 	})
 
 	repo := t.TempDir()
-	t.Setenv("HOME", t.TempDir())
+	isolateInitTestEnv(t, t.TempDir())
 
 	initYes = true
 	initDryRun = true
@@ -156,8 +156,20 @@ func TestInitCreatesProjectMarker(t *testing.T) {
 		initAgents = saved.agents
 	})
 
+	inheritedConfig := t.TempDir()
+	inheritedData := t.TempDir()
+	inheritedCache := t.TempDir()
+	inheritedDaemon := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", inheritedConfig)
+	t.Setenv("XDG_DATA_HOME", inheritedData)
+	t.Setenv("XDG_CACHE_HOME", inheritedCache)
+	t.Setenv("GORTEX_DAEMON_SOCKET", filepath.Join(inheritedDaemon, "daemon.sock"))
+	t.Setenv("GORTEX_DAEMON_PIDFILE", filepath.Join(inheritedDaemon, "daemon.pid"))
+	t.Setenv("GORTEX_DAEMON_LOGFILE", filepath.Join(inheritedDaemon, "daemon.log"))
+	t.Setenv("GORTEX_DAEMON_SNAPSHOT", filepath.Join(inheritedDaemon, "daemon.gob.gz"))
+
 	repo := t.TempDir()
-	t.Setenv("HOME", t.TempDir())
+	isolateInitTestEnv(t, t.TempDir())
 
 	initYes = true
 	initDryRun = false
@@ -189,6 +201,16 @@ func TestInitCreatesProjectMarker(t *testing.T) {
 	if err := runInit(initCmd, []string{repo}); err != nil {
 		t.Fatalf("second runInit: %v", err)
 	}
+
+	for _, root := range []string{inheritedConfig, inheritedData, inheritedCache, inheritedDaemon} {
+		entries, err := os.ReadDir(root)
+		if err != nil {
+			t.Fatalf("read inherited state root %s: %v", root, err)
+		}
+		if len(entries) != 0 {
+			t.Fatalf("runInit wrote through inherited state root %s: %v", root, entries)
+		}
+	}
 }
 
 // TestInitDryRunSkipsProjectMarker pins the inverse: dry-run is a
@@ -205,7 +227,7 @@ func TestInitDryRunSkipsProjectMarker(t *testing.T) {
 	})
 
 	repo := t.TempDir()
-	t.Setenv("HOME", t.TempDir())
+	isolateInitTestEnv(t, t.TempDir())
 
 	initYes = true
 	initDryRun = true
@@ -244,7 +266,7 @@ func TestInitRefusesHomeDirectory(t *testing.T) {
 	})
 
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	isolateInitTestEnv(t, home)
 
 	initYes = true
 	initDryRun = false
@@ -286,7 +308,7 @@ func TestInitForceBypassesHomeDirectoryGuard(t *testing.T) {
 	})
 
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	isolateInitTestEnv(t, home)
 
 	initYes = true
 	initDryRun = true // planning-only: keeps the forced run from writing into $HOME during the test
@@ -313,7 +335,7 @@ func TestInitHooksOnlyRefreshesClaudeAndCodexHooks(t *testing.T) {
 
 	repo := t.TempDir()
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	isolateInitTestEnv(t, home)
 
 	codexDir := filepath.Join(home, ".codex")
 	if err := os.MkdirAll(codexDir, 0o755); err != nil {
@@ -389,7 +411,7 @@ func TestInitHooksOnlyRespectsAgentsAllowlist(t *testing.T) {
 
 	repo := t.TempDir()
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	isolateInitTestEnv(t, home)
 	if err := os.MkdirAll(filepath.Join(home, ".codex"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -426,7 +448,7 @@ func TestInitHooksOnlyRespectsAgentsSkip(t *testing.T) {
 
 	repo := t.TempDir()
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	isolateInitTestEnv(t, home)
 	codexDir := filepath.Join(home, ".codex")
 	if err := os.MkdirAll(codexDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -477,7 +499,7 @@ func TestInitHooksOnlyDryRunDoesNotWriteHooks(t *testing.T) {
 
 	repo := t.TempDir()
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	isolateInitTestEnv(t, home)
 	if err := os.MkdirAll(filepath.Join(home, ".codex"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -523,7 +545,7 @@ func TestInitDryRunIntakeJSONDoesNotWrite(t *testing.T) {
 	})
 
 	repo := t.TempDir()
-	t.Setenv("HOME", t.TempDir())
+	isolateInitTestEnv(t, t.TempDir())
 	if err := os.WriteFile(filepath.Join(repo, "main.go"), []byte("package main\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -562,6 +584,22 @@ func TestInitDryRunIntakeJSONDoesNotWrite(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(repo, ".gortex")); err == nil {
 		t.Fatal("dry-run-intake wrote .gortex/ — must be inspection-only")
 	}
+}
+
+// isolateInitTestEnv prevents inherited machine state from escaping the test sandbox.
+func isolateInitTestEnv(t *testing.T, home string) {
+	t.Helper()
+
+	root := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(root, "config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(root, "data"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(root, "cache"))
+	t.Setenv("XDG_RUNTIME_DIR", filepath.Join(root, "runtime"))
+	t.Setenv("GORTEX_DAEMON_SOCKET", filepath.Join(root, "daemon.sock"))
+	t.Setenv("GORTEX_DAEMON_PIDFILE", filepath.Join(root, "daemon.pid"))
+	t.Setenv("GORTEX_DAEMON_LOGFILE", filepath.Join(root, "daemon.log"))
+	t.Setenv("GORTEX_DAEMON_SNAPSHOT", filepath.Join(root, "daemon.gob.gz"))
 }
 
 func saveInitGlobals(t *testing.T) func() {


### PR DESCRIPTION
<!-- agx-pr:auto-start -->

## Summary

Init tests could inherit real config paths from the developer's machine. A test
could then write temporary repositories into the user's Gortex config.

This change sends all test config, state, runtime, and daemon files to temporary
directories. A regression test proves the inherited paths remain untouched.

```text
Before: init test -> inherited user paths
After:  init test -> temporary test paths
```

## Changes

- Add one helper that isolates all init test paths.
- Use it in every `runInit` integration test.
- Verify repeated init stays isolated and does not modify inherited paths.

## Testing

- [ ] All tests pass (`go test -race ./...`) - the full race suite was not run.
- [x] `go test -race ./cmd/gortex -run '^TestInit' -count=1` - 22 tests passed.
- [x] `go test ./cmd/gortex -run '^TestInitCreatesProjectMarker$' -count=1` - passed.
- [x] `go test ./...` - 12,077 tests passed across 158 packages.
- [x] New tests added for new functionality.
- [x] Benchmarks not run because the change is test isolation only.
- [x] The production config SHA-256 was unchanged after the qualified full suite.

## Checklist

- [x] Code follows existing patterns in the codebase.
- [x] No unnecessary abstractions added.
- [x] Language extractor metadata is not applicable.
- [x] Member-edge behavior is not applicable.

<!-- agx-pr:auto-end -->
