### PR TITLE
fix(graph): exclude topics from repo-prefix diagnostics

### DIFF
--- a/internal/graph/prefix_diagnostics.go
+++ b/internal/graph/prefix_diagnostics.go
@@ -18,9 +18,9 @@ import (
 // The audit applies only to repository source nodes. Some synthetic nodes
 // retain a FilePath as attribution rather than as an on-disk source path:
 // semantic externals use `external::…`, synthesized external calls use
-// `external-call::…`, and contracts use identity namespaces that deliberately
-// do not mirror their source path. Those populations are outside the ownership
-// invariant even when FilePath is non-empty.
+// `external-call::…`, and contracts plus topics use identity namespaces that
+// deliberately do not mirror their source path. Those populations are outside
+// the ownership invariant even when FilePath is non-empty.
 //
 // Every other file-backed node with an empty prefix is an UNOWNED CODE NODE:
 // a real symbol, extracted from a real file, that no repository claims.
@@ -128,15 +128,15 @@ func IsAuditableRepoSourcePath(filePath string) bool {
 }
 
 // IsAuditableRepoSourceNode reports whether n participates in the repository
-// ownership invariant. Contract identities intentionally live in contract
-// namespaces rather than below their source repository prefix; contract bridge
-// nodes likewise use the virtual contracts://bridges path.
+// ownership invariant. Contract and topic identities intentionally live in
+// global namespaces rather than below their source repository prefix; contract
+// bridge nodes likewise use the virtual contracts://bridges path.
 func IsAuditableRepoSourceNode(n *Node) bool {
 	if n == nil || !IsAuditableRepoSourcePath(n.FilePath) {
 		return false
 	}
 	switch n.Kind {
-	case KindContract, KindContractBridge:
+	case KindContract, KindContractBridge, KindTopic:
 		return false
 	default:
 		return true

--- a/internal/graph/prefix_diagnostics_test.go
+++ b/internal/graph/prefix_diagnostics_test.go
@@ -59,6 +59,10 @@ func TestClassifyNodePrefix(t *testing.T) {
 		node: &Node{ID: "contract-bridge::request::response", Kind: KindContractBridge, FilePath: "contracts://bridges", RepoPrefix: "gortex"},
 		want: "",
 	}, {
+		name: "topic identity namespace is not audited",
+		node: &Node{ID: "topic::nats::go", Kind: KindTopic, FilePath: "gortex/main.go", RepoPrefix: "gortex"},
+		want: "",
+	}, {
 		name: "repo-scoped stub carries no file and is not audited",
 		node: &Node{ID: "gortex::builtin::go::make", Kind: KindBuiltin, RepoPrefix: "gortex"},
 		want: "",

--- a/internal/graph/store_sqlite/prefix_diagnostics.go
+++ b/internal/graph/store_sqlite/prefix_diagnostics.go
@@ -11,7 +11,7 @@ import (
 // The predicates below are the SQL transcription of
 // graph.IsAuditableRepoSourceNode and graph.ClassifyNodePrefix, and the two
 // must be changed together. The auditable predicate admits repository source
-// while excluding exact virtual external paths and the contract identity
+// while excluding exact virtual external paths and the contract/topic identity
 // namespaces whose IDs deliberately are not path-prefixed.
 //
 // Each population is answered by one aggregate plus one bounded sample
@@ -24,7 +24,7 @@ const (
 	// of a broad punctuation/URI heuristic so real parser nodes cannot escape
 	// the audit merely because their path contains punctuation.
 	auditableRepoSourceNodePredicate = `file_path <> '' AND ` +
-		`kind NOT IN ('contract', 'contract_bridge') AND ` +
+		`kind NOT IN ('contract', 'contract_bridge', 'topic') AND ` +
 		`instr(file_path, 'external::') <> 1 AND ` +
 		`instr(file_path, 'external-call::') <> 1`
 

--- a/internal/graph/storetest/storetest.go
+++ b/internal/graph/storetest/storetest.go
@@ -138,6 +138,7 @@ func testPrefixDiagnostics(t *testing.T, factory Factory) {
 	s.AddNode(mkNode("external-call::npm:lodash", "lodash", "external-call::npm:lodash", graph.KindModule))
 	s.AddNode(mkRepoNode("contract::http::GET::/health", "GET /health", "r1/api.go", "r1", graph.KindContract))
 	s.AddNode(mkRepoNode("contract-bridge::request::response", "request → response", "contracts://bridges", "r1", graph.KindContractBridge))
+	s.AddNode(mkRepoNode("topic::nats::go", "go", "r1/main.go", "r1", graph.KindTopic))
 
 	d, ok := graph.ReadPrefixDiagnostics(s, 5)
 	if !ok {


### PR DESCRIPTION
<!-- agx-pr:auto-start -->

## Summary

Valid topic nodes were incorrectly reported as repository-prefix errors. Topics
use global names, so they should not be checked like repository-owned nodes.

This change skips that check for topics in both the in-memory and SQLite stores.
Regression tests keep both implementations consistent.

```text
Repository node -> check repository prefix
Topic node      -> skip this check
```

## Changes

- Exclude topics from repository-prefix checks.
- Apply the same rule in the in-memory and SQLite stores.
- Add shared regression coverage for topic nodes.

## Testing

- [ ] All tests pass (`go test -race ./...`) - the full race suite was not run.
- [x] `go test ./internal/graph/...` - 989 tests passed.
- [x] `go test -race ./internal/graph ./internal/graph/store_sqlite` - 908 tests passed.
- [x] `go vet ./internal/graph/...` - passed.
- [x] Isolated `go test ./...` - 11,962 tests passed across 180 packages.
- [x] New tests added for new functionality.
- [x] Benchmarks not run because the predicate adds one constant kind exclusion.

## Checklist

- [x] Code follows existing patterns in the codebase.
- [x] No unnecessary abstractions added.
- [x] Language extractor metadata is not applicable.
- [x] Member-edge behavior is not applicable.

<!-- agx-pr:auto-end -->
