### PR TITLE
Index the files a refining localization page names, and keep the index under budget

### DIFF
--- a/internal/mcp/localization_file_outline.go
+++ b/internal/mcp/localization_file_outline.go
@@ -117,10 +117,6 @@ func localizationPageOutlineProvider(
 			return page
 		}
 		built = true
-		leading := localizationOutlineLeadingFile(pool, targets)
-		if leading == "" {
-			return nil
-		}
 		index := func(file string, rank int) *localizationFileOutline {
 			nodes := enumerate(file)
 			if len(nodes) == 0 {
@@ -130,13 +126,24 @@ func localizationPageOutlineProvider(
 			}
 			return newLocalizationFileOutlineForTerms(file, nodes, terms, localizationOutlineFileRowCap(rank))
 		}
-		outline := index(leading, 0)
-		if outline == nil {
-			return nil
+		// A page whose ranking never settled on one file has no leading slice to
+		// give — but its rows still name files, and every one of them declares
+		// siblings the rows could not show. Those files are indexed at the
+		// shallower depths instead, so scattered ranking costs the caller an
+		// index only where there is nothing to index.
+		leading := localizationOutlineLeadingFile(pool, targets)
+		following := localizationOutlineFileCap
+		page = &localizationPageOutline{}
+		if leading != "" {
+			if outline := index(leading, 0); outline != nil {
+				page.Leading = outline
+				following--
+			} else {
+				leading = ""
+			}
 		}
-		page = &localizationPageOutline{Leading: outline}
 		ranked := localizationOutlinePageRowCounts(targets)
-		for _, file := range localizationOutlineFollowingFiles(targets, leading, localizationOutlineFileCap-1) {
+		for _, file := range localizationOutlineFollowingFiles(targets, leading, following) {
 			other := index(file, len(page.Others)+1)
 			if other == nil || other.Declared <= ranked[file] {
 				// A file whose every declaration is already a row on this page
@@ -145,6 +152,9 @@ func localizationPageOutlineProvider(
 				continue
 			}
 			page.Others = append(page.Others, other)
+		}
+		if page.empty() {
+			page = nil
 		}
 		return page
 	}

--- a/internal/mcp/localization_file_outline.go
+++ b/internal/mcp/localization_file_outline.go
@@ -433,17 +433,18 @@ func (p *localizationPageOutline) relieve() {
 	if p == nil {
 		return
 	}
-	deepest, rows := (*localizationFileOutline)(nil), localizationOutlineFloorRows
+	floor := p.leadingFloor()
+	deepest, rows := (*localizationFileOutline)(nil), floor
 	if p.Leading != nil && len(p.Leading.Rows) > rows {
 		deepest, rows = p.Leading, len(p.Leading.Rows)
 	}
 	for _, other := range p.Others {
 		if other != nil && len(other.Rows) >= rows && len(other.Rows) > localizationOutlineFloorRows {
-			deepest, rows = other, len(other.Rows)
+			deepest, rows, floor = other, len(other.Rows), localizationOutlineFloorRows
 		}
 	}
 	if deepest != nil {
-		deepest.elide(localizationOutlineNextRowCap(rows))
+		deepest.elide(max(localizationOutlineNextRowCap(rows), floor))
 		return
 	}
 	if last := len(p.Others); last > 0 {
@@ -451,6 +452,18 @@ func (p *localizationPageOutline) relieve() {
 		return
 	}
 	p.Leading = nil
+}
+
+// leadingFloor is where the leading file's index stops shrinking. While the page
+// still indexes further files, they are what a tight page gives back — measured,
+// spending the leading file's depth on a neighbour's first twelve rows loses the
+// answer more often than it finds one. Once no further file is left, the leading
+// index may shrink to the same floor as any other.
+func (p *localizationPageOutline) leadingFloor() int {
+	if len(p.Others) > 0 {
+		return localizationOutlineSecondFileRowCap
+	}
+	return localizationOutlineFloorRows
 }
 
 // empty reports a block with nothing left to give.
@@ -464,7 +477,7 @@ func (p *localizationPageOutline) atFloor() bool {
 	if p == nil {
 		return true
 	}
-	if p.Leading != nil && len(p.Leading.Rows) > localizationOutlineFloorRows {
+	if p.Leading != nil && len(p.Leading.Rows) > p.leadingFloor() {
 		return false
 	}
 	for _, other := range p.Others {

--- a/internal/mcp/localization_file_outline.go
+++ b/internal/mcp/localization_file_outline.go
@@ -26,6 +26,9 @@ const (
 	// localizationOutlineHeadRows splits an elided outline between the file's
 	// opening declarations and its closing ones.
 	localizationOutlineHeadRows = localizationOutlineRowCap / 2
+	// localizationOutlineFloorRows is the smallest index still worth its bytes.
+	// Budget pressure shrinks an outline to this floor before it may drop one.
+	localizationOutlineFloorRows = 8
 )
 
 type localizationOutlineRow struct {
@@ -302,6 +305,43 @@ func (o *localizationFileOutline) elide(rowCap int) {
 	}
 	o.Rows = rows
 	o.Elided = len(o.all) - len(rows)
+}
+
+// clone detaches an outline from the provider's cache. One request can pack
+// several envelopes from the same provider, and each envelope shrinks its own
+// copy under its own budget; the retained declarations are read-only and stay
+// shared.
+func (o *localizationFileOutline) clone() *localizationFileOutline {
+	if o == nil {
+		return nil
+	}
+	copied := *o
+	copied.Rows = append([]localizationOutlineRow(nil), o.Rows...)
+	return &copied
+}
+
+// localizationOutlineRelief gives back one increment of outline payload, and
+// reports whether anything was given. An outline that no longer fits shrinks
+// toward its floor before it is dropped: a shorter index still names the file
+// and still carries the declarations the task asked about, where no index at
+// all sends the caller back to search for what it is already looking at.
+func localizationOutlineRelief(outline *localizationFileOutline) (*localizationFileOutline, bool) {
+	if outline == nil {
+		return nil, false
+	}
+	if rows := len(outline.Rows); rows > localizationOutlineFloorRows {
+		outline.elide(localizationOutlineNextRowCap(rows))
+		return outline, true
+	}
+	return nil, true
+}
+
+// localizationOutlineNextRowCap steps a bounded index down in proportion to its
+// size, so a wide outline converges on a fitting one in a few steps and a narrow
+// one gives back only what it must.
+func localizationOutlineNextRowCap(rows int) int {
+	step := max(rows/4, 4)
+	return max(rows-step, localizationOutlineFloorRows)
 }
 
 func localizationOutlineKindLetter(kind graph.NodeKind) string {

--- a/internal/mcp/localization_file_outline.go
+++ b/internal/mcp/localization_file_outline.go
@@ -378,9 +378,14 @@ func (o *localizationFileOutline) elide(rowCap int) {
 		o.Elided = 0
 		return
 	}
+	// The task's own matches lead, but never take the whole index: a task whose
+	// words happen to name half a file would otherwise turn that file's index
+	// into a list of the query, and the declaration a caller cannot name is
+	// exactly the one it came here to find.
+	reserve := max(rowCap/2, 1)
 	kept := make(map[int]struct{}, rowCap)
 	for _, index := range o.priority {
-		if len(kept) >= rowCap {
+		if len(kept) >= reserve {
 			break
 		}
 		kept[index] = struct{}{}

--- a/internal/mcp/localization_file_outline.go
+++ b/internal/mcp/localization_file_outline.go
@@ -458,6 +458,23 @@ func (p *localizationPageOutline) empty() bool {
 	return p == nil || (p.Leading == nil && len(p.Others) == 0)
 }
 
+// atFloor reports a block that has given back every row it can and would next
+// have to give back a whole file.
+func (p *localizationPageOutline) atFloor() bool {
+	if p == nil {
+		return true
+	}
+	if p.Leading != nil && len(p.Leading.Rows) > localizationOutlineFloorRows {
+		return false
+	}
+	for _, other := range p.Others {
+		if other != nil && len(other.Rows) > localizationOutlineFloorRows {
+			return false
+		}
+	}
+	return true
+}
+
 // localizationOutlineNextRowCap steps a bounded index down in proportion to its
 // size, so a wide outline converges on a fitting one in a few steps and a narrow
 // one gives back only what it must.

--- a/internal/mcp/localization_file_outline.go
+++ b/internal/mcp/localization_file_outline.go
@@ -36,14 +36,21 @@ type localizationOutlineRow struct {
 	Kind string `json:"kind,omitempty"`
 }
 
-// localizationFileOutline is the bounded declaration index of a page's leading
-// file. Declared counts what the file declares; Elided counts the rows the cap
+// localizationFileOutline is the bounded declaration index of a page file.
+// Declared counts what the file declares; Elided counts the rows the cap
 // dropped from the middle.
+//
+// The unexported fields are the whole file in line order plus the task-term
+// priority over it, retained so the same outline can be re-elided at a smaller
+// cap without re-reading the graph. They are never serialized.
 type localizationFileOutline struct {
 	File     string                   `json:"file"`
 	Declared int                      `json:"declared"`
 	Elided   int                      `json:"elided,omitempty"`
 	Rows     []localizationOutlineRow `json:"rows"`
+
+	all      []localizationOutlineRow
+	priority []int
 }
 
 // localizationPageAcceptsOutline admits the outline on the states whose caller
@@ -63,6 +70,7 @@ func localizationPageAcceptsOutline(state string) bool {
 func localizationLeadingFileOutlineProvider(
 	pool []*rerank.Candidate,
 	targets []exploreTarget,
+	terms map[string]struct{},
 	enumerate func(string) []*graph.Node,
 ) func() *localizationFileOutline {
 	if enumerate == nil {
@@ -87,7 +95,7 @@ func localizationLeadingFileOutlineProvider(
 			// which is the whole of what it knows about that file.
 			nodes = localizationOutlineFetchedNodes(pool, targets)
 		}
-		outline = newLocalizationFileOutline(file, nodes)
+		outline = newLocalizationFileOutlineForTerms(file, nodes, terms, localizationOutlineRowCap)
 		return outline
 	}
 }
@@ -125,10 +133,22 @@ func localizationOutlineFetchedNodes(pool []*rerank.Candidate, targets []explore
 	return nodes
 }
 
-// newLocalizationFileOutline projects one file's declarations into file order.
-// Nodes from another file are dropped, so a candidate pool is as valid an input
-// as a file enumeration.
+// newLocalizationFileOutline projects one file's declarations into file order
+// at the default cap, with no task to prioritize by.
 func newLocalizationFileOutline(file string, nodes []*graph.Node) *localizationFileOutline {
+	return newLocalizationFileOutlineForTerms(file, nodes, nil, localizationOutlineRowCap)
+}
+
+// newLocalizationFileOutlineForTerms projects one file's declarations into file
+// order. Nodes from another file are dropped, so a candidate pool is as valid an
+// input as a file enumeration. Rows whose name carries a task term are ranked
+// ahead of the file's own head and tail for whatever the cap can hold.
+func newLocalizationFileOutlineForTerms(
+	file string,
+	nodes []*graph.Node,
+	terms map[string]struct{},
+	rowCap int,
+) *localizationFileOutline {
 	file = strings.TrimSpace(file)
 	if file == "" {
 		return nil
@@ -169,17 +189,119 @@ func newLocalizationFileOutline(file string, nodes []*graph.Node) *localizationF
 		}
 		return rows[first].Name < rows[second].Name
 	})
-	outline := &localizationFileOutline{File: file, Declared: len(rows), Rows: rows}
-	if len(rows) > localizationOutlineRowCap {
-		// Both ends of a file carry declarations a caller may want; the middle
-		// is what a bounded index can give back.
-		kept := make([]localizationOutlineRow, 0, localizationOutlineRowCap)
-		kept = append(kept, rows[:localizationOutlineHeadRows]...)
-		kept = append(kept, rows[len(rows)-(localizationOutlineRowCap-localizationOutlineHeadRows):]...)
-		outline.Elided = len(rows) - localizationOutlineRowCap
-		outline.Rows = kept
+	outline := &localizationFileOutline{
+		File:     file,
+		Declared: len(rows),
+		all:      rows,
+		priority: localizationOutlinePriority(rows, terms),
 	}
+	outline.elide(rowCap)
 	return outline
+}
+
+// localizationOutlinePriority ranks the declarations a task names: more distinct
+// task terms first, then the longer match, then file order. A row that names
+// nothing the task said is not in the result at all.
+func localizationOutlinePriority(rows []localizationOutlineRow, terms map[string]struct{}) []int {
+	if len(terms) == 0 {
+		return nil
+	}
+	type match struct{ index, matched, longest int }
+	matches := make([]match, 0, len(rows))
+	for index, row := range rows {
+		matched, longest := localizationOutlineRowTermMatch(row.Name, terms)
+		if matched == 0 {
+			continue
+		}
+		matches = append(matches, match{index: index, matched: matched, longest: longest})
+	}
+	sort.SliceStable(matches, func(first, second int) bool {
+		if matches[first].matched != matches[second].matched {
+			return matches[first].matched > matches[second].matched
+		}
+		if matches[first].longest != matches[second].longest {
+			return matches[first].longest > matches[second].longest
+		}
+		return matches[first].index < matches[second].index
+	})
+	priority := make([]int, 0, len(matches))
+	for _, ranked := range matches {
+		priority = append(priority, ranked.index)
+	}
+	return priority
+}
+
+// localizationOutlineRowTermMatch counts the distinct task terms a declaration
+// name carries, over the same camel/snake tokenization and the same root form
+// the task's own terms were built with.
+func localizationOutlineRowTermMatch(name string, terms map[string]struct{}) (matched, longest int) {
+	if len(terms) == 0 {
+		return 0, 0
+	}
+	seen := make(map[string]struct{}, len(terms))
+	for _, raw := range rerank.Tokenize(name) {
+		token := exploreTerminalTermRoot(strings.ToLower(strings.TrimSpace(raw)))
+		if token == "" {
+			continue
+		}
+		if _, ok := terms[token]; !ok {
+			continue
+		}
+		if _, duplicate := seen[token]; duplicate {
+			continue
+		}
+		seen[token] = struct{}{}
+		matched++
+		if len(token) > longest {
+			longest = len(token)
+		}
+	}
+	return matched, longest
+}
+
+// elide re-projects the retained rows at rowCap. The declarations the task names
+// are kept first; the file's head and tail then fill whatever the cap has left,
+// so an index the caller cannot navigate by eye still shows both of its ends.
+func (o *localizationFileOutline) elide(rowCap int) {
+	if o == nil {
+		return
+	}
+	if rowCap < 0 {
+		rowCap = 0
+	}
+	if len(o.all) <= rowCap {
+		o.Rows = o.all
+		o.Elided = 0
+		return
+	}
+	kept := make(map[int]struct{}, rowCap)
+	for _, index := range o.priority {
+		if len(kept) >= rowCap {
+			break
+		}
+		kept[index] = struct{}{}
+	}
+	// Both ends of a file carry declarations a caller may want; the middle is
+	// what a bounded index gives back once the task's own matches are held.
+	headQuota := (rowCap - len(kept)) / 2
+	for index := 0; index < len(o.all) && headQuota > 0 && len(kept) < rowCap; index++ {
+		if _, duplicate := kept[index]; duplicate {
+			continue
+		}
+		kept[index] = struct{}{}
+		headQuota--
+	}
+	for index := len(o.all) - 1; index >= 0 && len(kept) < rowCap; index-- {
+		kept[index] = struct{}{}
+	}
+	rows := make([]localizationOutlineRow, 0, len(kept))
+	for index, row := range o.all {
+		if _, keep := kept[index]; keep {
+			rows = append(rows, row)
+		}
+	}
+	o.Rows = rows
+	o.Elided = len(o.all) - len(rows)
 }
 
 func localizationOutlineKindLetter(kind graph.NodeKind) string {

--- a/internal/mcp/localization_file_outline.go
+++ b/internal/mcp/localization_file_outline.go
@@ -9,19 +9,22 @@ import (
 	"github.com/zzet/gortex/internal/search/rerank"
 )
 
-// Leading-file outline.
+// Page-file outlines.
 //
 // A bounded localization page shows ten signature rows, and per-file
 // diversification spends most of those slots on distinct files. When the answer
-// is a declaration in the file the page already leads with, but not one of the
-// rows that file won, nothing on the page says the file declares it at all —
-// so the caller searches again for something it is already looking at. The
-// outline is that leading file's declaration index: name and line, no
-// signatures and no bodies. Only a page that still asks the caller to choose
-// carries one; a terminal page's caller is answering, not choosing.
+// is a declaration in a file the page already names, but not one of the rows
+// that file won, nothing on the page says the file declares it at all — so the
+// caller searches again for something it is already looking at. The outline is
+// that file's declaration index: name and line, no signatures and no bodies.
+// The page's leading file gets the deepest index and each further page file a
+// shallower one, because a row that lost its file's only slot is as invisible
+// at rank nine as at rank one. Only a page that still asks the caller to choose
+// carries outlines; a terminal page's caller is answering, not choosing.
 
 const (
-	// localizationOutlineRowCap bounds the rows one outline may serialize.
+	// localizationOutlineRowCap bounds the rows the leading file's outline may
+	// serialize.
 	localizationOutlineRowCap = 40
 	// localizationOutlineHeadRows splits an elided outline between the file's
 	// opening declarations and its closing ones.
@@ -29,7 +32,33 @@ const (
 	// localizationOutlineFloorRows is the smallest index still worth its bytes.
 	// Budget pressure shrinks an outline to this floor before it may drop one.
 	localizationOutlineFloorRows = 8
+	// localizationOutlineSecondFileRowCap is the depth the file ranked directly
+	// after the leading one gets. Every file after that starts at the floor.
+	localizationOutlineSecondFileRowCap = 12
+	// localizationOutlineFileCap bounds how many of the page's distinct files
+	// are indexed at all, leading file included.
+	localizationOutlineFileCap = 6
 )
+
+// localizationOutlineFileRowCap is the depth ladder over a page's files: the
+// leading file keeps the whole index, the next one a third of it, and the rest
+// start where shrinking would stop anyway.
+func localizationOutlineFileRowCap(rank int) int {
+	switch rank {
+	case 0:
+		return localizationOutlineRowCap
+	case 1:
+		return localizationOutlineSecondFileRowCap
+	}
+	return localizationOutlineFloorRows
+}
+
+// localizationPageOutline is the page's declaration index: the leading file's
+// outline and the outlines of the further page files, deepest first.
+type localizationPageOutline struct {
+	Leading *localizationFileOutline
+	Others  []*localizationFileOutline
+}
 
 type localizationOutlineRow struct {
 	Name string `json:"name"`
@@ -67,40 +96,87 @@ func localizationPageAcceptsOutline(state string) bool {
 	return false
 }
 
-// localizationLeadingFileOutlineProvider defers the file enumeration until a
+// localizationPageOutlineProvider defers the file enumeration until a
 // page is known to still be refining, and performs it at most once per page.
-// A nil enumerator disables the outline entirely.
-func localizationLeadingFileOutlineProvider(
+// A nil enumerator disables the outlines entirely.
+func localizationPageOutlineProvider(
 	pool []*rerank.Candidate,
 	targets []exploreTarget,
 	terms map[string]struct{},
 	enumerate func(string) []*graph.Node,
-) func() *localizationFileOutline {
+) func() *localizationPageOutline {
 	if enumerate == nil {
 		return nil
 	}
 	var (
-		outline *localizationFileOutline
-		built   bool
+		page  *localizationPageOutline
+		built bool
 	)
-	return func() *localizationFileOutline {
+	return func() *localizationPageOutline {
 		if built {
-			return outline
+			return page
 		}
 		built = true
-		file := localizationOutlineLeadingFile(pool, targets)
-		if file == "" {
+		leading := localizationOutlineLeadingFile(pool, targets)
+		if leading == "" {
 			return nil
 		}
-		nodes := enumerate(file)
-		if len(nodes) == 0 {
-			// Nothing to enumerate leaves the nodes this page already fetched,
-			// which is the whole of what it knows about that file.
-			nodes = localizationOutlineFetchedNodes(pool, targets)
+		index := func(file string, rank int) *localizationFileOutline {
+			nodes := enumerate(file)
+			if len(nodes) == 0 {
+				// Nothing to enumerate leaves the nodes this page already
+				// fetched, which is the whole of what it knows about that file.
+				nodes = localizationOutlineFetchedNodes(pool, targets)
+			}
+			return newLocalizationFileOutlineForTerms(file, nodes, terms, localizationOutlineFileRowCap(rank))
 		}
-		outline = newLocalizationFileOutlineForTerms(file, nodes, terms, localizationOutlineRowCap)
-		return outline
+		outline := index(leading, 0)
+		if outline == nil {
+			return nil
+		}
+		page = &localizationPageOutline{Leading: outline}
+		ranked := localizationOutlinePageRowCounts(targets)
+		for _, file := range localizationOutlineFollowingFiles(targets, leading, localizationOutlineFileCap-1) {
+			other := index(file, len(page.Others)+1)
+			if other == nil || other.Declared <= ranked[file] {
+				// A file whose every declaration is already a row on this page
+				// is a file the caller can already see. Indexing it costs bytes
+				// the deeper files would rather have.
+				continue
+			}
+			page.Others = append(page.Others, other)
+		}
+		return page
 	}
+}
+
+// localizationOutlineFollowingFiles names the page's other distinct files in
+// page order. The rows are already ranked, so their file order is the page's own
+// judgement of which neighbourhood the caller should look at next.
+func localizationOutlineFollowingFiles(targets []exploreTarget, leading string, limit int) []string {
+	if limit <= 0 {
+		return nil
+	}
+	files := make([]string, 0, limit)
+	seen := map[string]struct{}{leading: {}}
+	for _, target := range targets {
+		if len(files) >= limit {
+			break
+		}
+		if target.node == nil {
+			continue
+		}
+		file := nodeDisplayPath(target.node)
+		if file == "" {
+			continue
+		}
+		if _, duplicate := seen[file]; duplicate {
+			continue
+		}
+		seen[file] = struct{}{}
+		files = append(files, file)
+	}
+	return files
 }
 
 // localizationOutlineLeadingFile reuses the ranked leading-file notion depth
@@ -119,6 +195,21 @@ func localizationOutlineLeadingFile(pool []*rerank.Candidate, targets []exploreT
 		ranked = append(ranked, &rerank.Candidate{Node: target.node})
 	}
 	return exploreLeadingRankedFile(ranked)
+}
+
+// localizationOutlinePageRowCounts counts how many of a file's declarations the
+// page already names as ranked rows.
+func localizationOutlinePageRowCounts(targets []exploreTarget) map[string]int {
+	counts := make(map[string]int, len(targets))
+	for _, target := range targets {
+		if target.node == nil {
+			continue
+		}
+		if file := nodeDisplayPath(target.node); file != "" {
+			counts[file]++
+		}
+	}
+	return counts
 }
 
 func localizationOutlineFetchedNodes(pool []*rerank.Candidate, targets []exploreTarget) []*graph.Node {
@@ -320,20 +411,51 @@ func (o *localizationFileOutline) clone() *localizationFileOutline {
 	return &copied
 }
 
-// localizationOutlineRelief gives back one increment of outline payload, and
-// reports whether anything was given. An outline that no longer fits shrinks
-// toward its floor before it is dropped: a shorter index still names the file
-// and still carries the declarations the task asked about, where no index at
-// all sends the caller back to search for what it is already looking at.
-func localizationOutlineRelief(outline *localizationFileOutline) (*localizationFileOutline, bool) {
-	if outline == nil {
-		return nil, false
+// clone detaches a page's outlines from the provider's cache.
+func (p *localizationPageOutline) clone() *localizationPageOutline {
+	if p == nil {
+		return nil
 	}
-	if rows := len(outline.Rows); rows > localizationOutlineFloorRows {
-		outline.elide(localizationOutlineNextRowCap(rows))
-		return outline, true
+	copied := &localizationPageOutline{Leading: p.Leading.clone()}
+	for _, other := range p.Others {
+		copied.Others = append(copied.Others, other.clone())
 	}
-	return nil, true
+	return copied
+}
+
+// relieve gives back one increment of outline payload. An index that no longer
+// fits shrinks toward its floor before it is dropped: a shorter index still
+// names the file and still carries the declarations the task asked about, where
+// no index at all sends the caller back to search for what it is already
+// looking at. Depth goes before breadth — the deepest index gives back first,
+// and only once every file is at its floor does a file go, shallowest first.
+func (p *localizationPageOutline) relieve() {
+	if p == nil {
+		return
+	}
+	deepest, rows := (*localizationFileOutline)(nil), localizationOutlineFloorRows
+	if p.Leading != nil && len(p.Leading.Rows) > rows {
+		deepest, rows = p.Leading, len(p.Leading.Rows)
+	}
+	for _, other := range p.Others {
+		if other != nil && len(other.Rows) >= rows && len(other.Rows) > localizationOutlineFloorRows {
+			deepest, rows = other, len(other.Rows)
+		}
+	}
+	if deepest != nil {
+		deepest.elide(localizationOutlineNextRowCap(rows))
+		return
+	}
+	if last := len(p.Others); last > 0 {
+		p.Others = p.Others[:last-1]
+		return
+	}
+	p.Leading = nil
+}
+
+// empty reports a block with nothing left to give.
+func (p *localizationPageOutline) empty() bool {
+	return p == nil || (p.Leading == nil && len(p.Others) == 0)
 }
 
 // localizationOutlineNextRowCap steps a bounded index down in proportion to its

--- a/internal/mcp/localization_file_outline_test.go
+++ b/internal/mcp/localization_file_outline_test.go
@@ -906,6 +906,39 @@ func TestLeadingFileOutlineProviderCarriesTheTaskTerms(t *testing.T) {
 	}
 }
 
+func TestOutlineElisionLeavesHalfTheIndexToTheFileItself(t *testing.T) {
+	// A task whose words happen to name half a file must not turn that file's
+	// index into a list of its own query. The declaration a caller is looking
+	// for is often the one the task could not name.
+	declared := outlineDeclaredFile(25)
+	for _, index := range []int{2, 3, 4, 5, 10, 11, 17, 18} {
+		declared[index] = outlineDeclaration(fmt.Sprintf("retryBackoff%02d", index), index+1)
+	}
+	const named = "send"
+	declared[22] = outlineDeclaration(named, 23)
+	terms := exploreTerminalTerms("the retry backoff never fires")
+	outline := newLocalizationFileOutlineForTerms(outlineLeadingFile, declared, terms, 12)
+	if outline == nil || len(outline.Rows) != 12 {
+		t.Fatalf("outline = %#v, want 12 rows", outline)
+	}
+	matched := 0
+	for _, row := range outline.Rows {
+		if strings.HasPrefix(row.Name, "retryBackoff") {
+			matched++
+		}
+	}
+	if matched > 6 {
+		t.Fatalf("task-term matches took %d of 12 rows, want at most half", matched)
+	}
+	if outline.Rows[0].Line != 1 || outline.Rows[len(outline.Rows)-1].Line != len(declared) {
+		t.Fatalf("outline spans lines %d..%d, want the file's own ends",
+			outline.Rows[0].Line, outline.Rows[len(outline.Rows)-1].Line)
+	}
+	if !outlineRowNamed(outline, named) {
+		t.Fatalf("the file's own tail lost a declaration the task could not name: %#v", outline.Rows)
+	}
+}
+
 func TestOutlineElisionRanksStrongerTaskTermMatchesFirst(t *testing.T) {
 	declared := outlineDeclaredFile(120)
 	// More task-term matches than the cap can hold: the strongest match must

--- a/internal/mcp/localization_file_outline_test.go
+++ b/internal/mcp/localization_file_outline_test.go
@@ -78,7 +78,7 @@ func TestRefiningPageCarriesTheLeadingFileOutline(t *testing.T) {
 	}
 	enumerated := 0
 	outline := localizationLeadingFileOutlineProvider(
-		outlinePool(preferred, alternate), targets,
+		outlinePool(preferred, alternate), targets, nil,
 		func(file string) []*graph.Node {
 			if file != outlineLeadingFile {
 				t.Fatalf("enumerated file = %q, want %q", file, outlineLeadingFile)
@@ -138,7 +138,7 @@ func TestTerminalPageCarriesNoOutlineAndPaysNoEnumeration(t *testing.T) {
 	}}
 	enumerated := 0
 	outline := localizationLeadingFileOutlineProvider(
-		outlinePool(declared[0]), targets,
+		outlinePool(declared[0]), targets, nil,
 		func(string) []*graph.Node {
 			enumerated++
 			return declared
@@ -185,7 +185,7 @@ func TestOutlineShedsBeforeEvidenceRowsUnderATightBudget(t *testing.T) {
 		var outline func() *localizationFileOutline
 		if withOutline {
 			outline = localizationLeadingFileOutlineProvider(
-				outlinePool(declared[0], declared[1]), targets,
+				outlinePool(declared[0], declared[1]), targets, nil,
 				func(string) []*graph.Node { return declared },
 			)
 		}
@@ -276,7 +276,7 @@ func TestLocalizationBudgetLeavesRoomForOutlineBesideEvidence(t *testing.T) {
 		}})
 	}
 	outline := localizationLeadingFileOutlineProvider(
-		outlinePool(declared[0], declared[1]), targets,
+		outlinePool(declared[0], declared[1]), targets, nil,
 		func(string) []*graph.Node { return declared },
 	)
 	result, completion, _, _ := buildLocalizationRefinementResultForTaskWithOutline(
@@ -305,7 +305,7 @@ func TestLeadingFileOutlineEnumeratesOncePerPage(t *testing.T) {
 	targets := []exploreTarget{{node: declared[0]}, {node: declared[1]}}
 	enumerated := 0
 	outline := localizationLeadingFileOutlineProvider(
-		outlinePool(declared[0], declared[1]), targets,
+		outlinePool(declared[0], declared[1]), targets, nil,
 		func(string) []*graph.Node {
 			enumerated++
 			return declared
@@ -324,11 +324,98 @@ func TestLeadingFileOutlineFallsBackToAlreadyFetchedNodes(t *testing.T) {
 	declared := outlineDeclaredFile(3)
 	targets := []exploreTarget{{node: declared[0]}, {node: declared[1]}}
 	outline := localizationLeadingFileOutlineProvider(
-		outlinePool(declared...), targets,
+		outlinePool(declared...), targets, nil,
 		func(string) []*graph.Node { return nil },
 	)()
 	if outline == nil || outline.Declared != len(declared) {
 		t.Fatalf("outline = %#v, want the %d pool nodes of %q", outline, len(declared), outlineLeadingFile)
+	}
+}
+
+func outlineRowNamed(outline *localizationFileOutline, name string) bool {
+	if outline == nil {
+		return false
+	}
+	for _, row := range outline.Rows {
+		if row.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func TestOutlineElisionKeepsTaskTermMatchingDeclarations(t *testing.T) {
+	const named = "dispatchHttpRequest"
+	declared := outlineDeclaredFile(60)
+	// The declaration the task names sits in the middle of the file — exactly
+	// where a blind head/tail elision drops it.
+	middle := len(declared) / 2
+	declared[middle] = outlineDeclaration(named, middle+1)
+
+	blind := newLocalizationFileOutline(outlineLeadingFile, declared)
+	if blind == nil || len(blind.Rows) != localizationOutlineRowCap {
+		t.Fatalf("blind outline = %#v, want %d rows", blind, localizationOutlineRowCap)
+	}
+	if outlineRowNamed(blind, named) {
+		t.Fatalf("fixture does not reproduce a mid-file elision: %q survived a blind cap", named)
+	}
+
+	terms := exploreTerminalTerms("the http request dispatch never retries")
+	outline := newLocalizationFileOutlineForTerms(outlineLeadingFile, declared, terms, localizationOutlineRowCap)
+	if outline == nil {
+		t.Fatal("task-term outline is absent")
+	}
+	if len(outline.Rows) != localizationOutlineRowCap {
+		t.Fatalf("outline rows = %d, want cap %d", len(outline.Rows), localizationOutlineRowCap)
+	}
+	if outline.Declared != len(declared) || outline.Elided != len(declared)-localizationOutlineRowCap {
+		t.Fatalf("outline = declared %d elided %d, want %d/%d",
+			outline.Declared, outline.Elided, len(declared), len(declared)-localizationOutlineRowCap)
+	}
+	if !outlineRowNamed(outline, named) {
+		t.Fatalf("outline elided the declaration the task names: %#v", outline.Rows)
+	}
+	// The retained rows stay a file index: still in line order, still anchored
+	// at the file's own head and tail.
+	for index := 1; index < len(outline.Rows); index++ {
+		if outline.Rows[index-1].Line > outline.Rows[index].Line {
+			t.Fatalf("outline rows are out of file order at %d: %#v", index, outline.Rows)
+		}
+	}
+	if outline.Rows[0].Line != 1 || outline.Rows[len(outline.Rows)-1].Line != len(declared) {
+		t.Fatalf("outline spans lines %d..%d, want the whole file's ends",
+			outline.Rows[0].Line, outline.Rows[len(outline.Rows)-1].Line)
+	}
+}
+
+func TestLeadingFileOutlineProviderCarriesTheTaskTerms(t *testing.T) {
+	const named = "dispatchHttpRequest"
+	declared := outlineDeclaredFile(60)
+	middle := len(declared) / 2
+	declared[middle] = outlineDeclaration(named, middle+1)
+	targets := []exploreTarget{{node: declared[0]}, {node: declared[1]}}
+	outline := localizationLeadingFileOutlineProvider(
+		outlinePool(declared[0], declared[1]), targets,
+		exploreTerminalTerms("the http request dispatch never retries"),
+		func(string) []*graph.Node { return declared },
+	)()
+	if !outlineRowNamed(outline, named) {
+		t.Fatalf("provider built an outline blind to the task: %#v", outline)
+	}
+}
+
+func TestOutlineElisionRanksStrongerTaskTermMatchesFirst(t *testing.T) {
+	declared := outlineDeclaredFile(120)
+	// More task-term matches than the cap can hold: the strongest match must
+	// still survive, ahead of the rows matching a single term.
+	for index := 20; index < 100; index++ {
+		declared[index] = outlineDeclaration(fmt.Sprintf("retryOnce%02d", index), index+1)
+	}
+	declared[60] = outlineDeclaration("retryBackoffSchedule", 61)
+	terms := exploreTerminalTerms("the retry backoff schedule never fires")
+	outline := newLocalizationFileOutlineForTerms(outlineLeadingFile, declared, terms, localizationOutlineRowCap)
+	if !outlineRowNamed(outline, "retryBackoffSchedule") {
+		t.Fatalf("outline dropped the strongest task-term match: %#v", outline)
 	}
 }
 
@@ -347,7 +434,7 @@ func TestScatteredRankingCarriesNoOutline(t *testing.T) {
 		targets = append(targets, exploreTarget{node: node})
 	}
 	enumerated := 0
-	outline := localizationLeadingFileOutlineProvider(pool, targets, func(string) []*graph.Node {
+	outline := localizationLeadingFileOutlineProvider(pool, targets, nil, func(string) []*graph.Node {
 		enumerated++
 		return nil
 	})

--- a/internal/mcp/localization_file_outline_test.go
+++ b/internal/mcp/localization_file_outline_test.go
@@ -77,7 +77,7 @@ func TestRefiningPageCarriesTheLeadingFileOutline(t *testing.T) {
 		{node: alternate, source: "func Declared01() { executeOne() }"},
 	}
 	enumerated := 0
-	outline := localizationLeadingFileOutlineProvider(
+	outline := localizationPageOutlineProvider(
 		outlinePool(preferred, alternate), targets, nil,
 		func(file string) []*graph.Node {
 			if file != outlineLeadingFile {
@@ -137,7 +137,7 @@ func TestTerminalPageCarriesNoOutlineAndPaysNoEnumeration(t *testing.T) {
 		sourceLiteral: true, sourceLiteralCallee: true, exactContent: true,
 	}}
 	enumerated := 0
-	outline := localizationLeadingFileOutlineProvider(
+	outline := localizationPageOutlineProvider(
 		outlinePool(declared[0]), targets, nil,
 		func(string) []*graph.Node {
 			enumerated++
@@ -182,9 +182,9 @@ func TestOutlineGivesWayBeforeEvidenceRowsUnderATightBudget(t *testing.T) {
 	}
 	routes := exploreLocalizationRefinementRoutes(targets)
 	build := func(budget int, withOutline bool) (localizationExploreEnvelope, int) {
-		var outline func() *localizationFileOutline
+		var outline func() *localizationPageOutline
 		if withOutline {
-			outline = localizationLeadingFileOutlineProvider(
+			outline = localizationPageOutlineProvider(
 				outlinePool(declared[0], declared[1]), targets, nil,
 				func(string) []*graph.Node { return declared },
 			)
@@ -284,7 +284,7 @@ func TestLocalizationBudgetLeavesRoomForOutlineBesideEvidence(t *testing.T) {
 			Meta:      map[string]any{"signature": "func " + name + "(ctx context.Context) error"},
 		}})
 	}
-	outline := localizationLeadingFileOutlineProvider(
+	outline := localizationPageOutlineProvider(
 		outlinePool(declared[0], declared[1]), targets, nil,
 		func(string) []*graph.Node { return declared },
 	)
@@ -313,7 +313,7 @@ func TestLeadingFileOutlineEnumeratesOncePerPage(t *testing.T) {
 	declared := outlineDeclaredFile(4)
 	targets := []exploreTarget{{node: declared[0]}, {node: declared[1]}}
 	enumerated := 0
-	outline := localizationLeadingFileOutlineProvider(
+	outline := localizationPageOutlineProvider(
 		outlinePool(declared[0], declared[1]), targets, nil,
 		func(string) []*graph.Node {
 			enumerated++
@@ -332,11 +332,11 @@ func TestLeadingFileOutlineEnumeratesOncePerPage(t *testing.T) {
 func TestLeadingFileOutlineFallsBackToAlreadyFetchedNodes(t *testing.T) {
 	declared := outlineDeclaredFile(3)
 	targets := []exploreTarget{{node: declared[0]}, {node: declared[1]}}
-	outline := localizationLeadingFileOutlineProvider(
+	outline := localizationPageOutlineProvider(
 		outlinePool(declared...), targets, nil,
 		func(string) []*graph.Node { return nil },
 	)()
-	if outline == nil || outline.Declared != len(declared) {
+	if outline == nil || outline.Leading == nil || outline.Leading.Declared != len(declared) {
 		t.Fatalf("outline = %#v, want the %d pool nodes of %q", outline, len(declared), outlineLeadingFile)
 	}
 }
@@ -432,6 +432,159 @@ func outlineBreadthTargets(count int) []exploreTarget {
 	return targets
 }
 
+// outlineFileDeclaration mirrors outlineDeclaration for a file other than the
+// page's leading one.
+func outlineFileDeclaration(file, name string, line int) *graph.Node {
+	return &graph.Node{
+		ID:        file + "::" + name,
+		Name:      name,
+		QualName:  name,
+		Kind:      graph.KindMethod,
+		FilePath:  file,
+		StartLine: line,
+		EndLine:   line + 4,
+		Meta:      map[string]any{"signature": "func " + name + "()"},
+	}
+}
+
+func TestOutlineCoversTheOtherFilesTheRowsCameFrom(t *testing.T) {
+	// The ranked page leads with one file and names another only in its last
+	// rows. The rows of that second file are one member each; the declaration
+	// that answers the task is a sibling the rows never reach.
+	const otherFile = "repo/other.go"
+	const answer = "onCollisionRemoved"
+	declared := outlineDeclaredFile(12)
+	other := []*graph.Node{
+		outlineFileDeclaration(otherFile, "OtherType", 4),
+		outlineFileDeclaration(otherFile, "renderTree", 20),
+		outlineFileDeclaration(otherFile, answer, 41),
+		outlineFileDeclaration(otherFile, "attachChild", 60),
+	}
+	targets := []exploreTarget{
+		{node: declared[0], source: "func Declared00() { executeAll() }"},
+		{node: declared[1], source: "func Declared01() { executeOne() }"},
+	}
+	targets = append(targets, outlineBreadthTargets(4)...)
+	targets = append(targets, exploreTarget{node: other[0]}, exploreTarget{node: other[1]})
+
+	enumerated := make([]string, 0, 4)
+	outline := localizationPageOutlineProvider(
+		outlinePool(declared[0], declared[1]), targets, nil,
+		func(file string) []*graph.Node {
+			enumerated = append(enumerated, file)
+			switch file {
+			case outlineLeadingFile:
+				return declared
+			case otherFile:
+				return other
+			}
+			return nil
+		},
+	)
+	result, completion, _, _ := buildLocalizationRefinementResultForTaskWithOutline(
+		declared[0].ID, "find the declared implementation", targets,
+		exploreMaxBudgetTokens, exploreLocalizationRefinementRoutes(targets), outline,
+	)
+	if completion.State != localizationStateNeedsRefinement {
+		t.Fatalf("completion state = %q, want %q", completion.State, localizationStateNeedsRefinement)
+	}
+	envelope := outlineEnvelope(t, result)
+	if envelope.Outline == nil || envelope.Outline.File != outlineLeadingFile {
+		t.Fatalf("leading outline = %#v, want %q", envelope.Outline, outlineLeadingFile)
+	}
+	var second *localizationFileOutline
+	for _, extra := range envelope.Outlines {
+		if extra != nil && extra.File == otherFile {
+			second = extra
+		}
+	}
+	if second == nil {
+		t.Fatalf("outlines = %#v, want the page's other file %q", envelope.Outlines, otherFile)
+	}
+	if !outlineRowNamed(second, answer) {
+		t.Fatalf("the other file's outline never names its unranked declaration: %#v", second.Rows)
+	}
+	// The leading file keeps the deepest index; the files after it are shallower.
+	if len(envelope.Outlines) == 0 {
+		t.Fatal("no further page files were indexed")
+	}
+	for _, extra := range envelope.Outlines {
+		if extra.File == outlineLeadingFile {
+			t.Fatalf("the leading file is indexed twice: %#v", envelope.Outlines)
+		}
+	}
+	for _, file := range enumerated {
+		if file == "" {
+			t.Fatalf("enumerated an empty file: %#v", enumerated)
+		}
+	}
+	if len(enumerated) > localizationOutlineFileCap {
+		t.Fatalf("enumerated %d files, cap %d", len(enumerated), localizationOutlineFileCap)
+	}
+}
+
+func TestPageOutlinesGiveBackDepthBeforeTheyGiveBackAFile(t *testing.T) {
+	const otherFile = "repo/other.go"
+	declared := outlineDeclaredFile(40)
+	other := make([]*graph.Node, 0, 20)
+	for index := 0; index < 20; index++ {
+		other = append(other, outlineFileDeclaration(otherFile, fmt.Sprintf("Other%02d", index), index*3+1))
+	}
+	targets := []exploreTarget{
+		{node: declared[0], source: "func Declared00() { executeAll() }"},
+		{node: declared[1], source: "func Declared01() { executeOne() }"},
+	}
+	targets = append(targets, outlineBreadthTargets(4)...)
+	targets = append(targets, exploreTarget{node: other[0]}, exploreTarget{node: other[1]})
+	routes := exploreLocalizationRefinementRoutes(targets)
+
+	build := func(budget int) localizationExploreEnvelope {
+		outline := localizationPageOutlineProvider(
+			outlinePool(declared[0], declared[1]), targets, nil,
+			func(file string) []*graph.Node {
+				switch file {
+				case outlineLeadingFile:
+					return declared
+				case otherFile:
+					return other
+				}
+				return nil
+			},
+		)
+		result, _, _, _ := buildLocalizationRefinementResultForTaskWithOutline(
+			declared[0].ID, "find the declared implementation", targets, budget, routes, outline,
+		)
+		if bytes := outlineEnvelopeBytes(t, result); bytes > budget*localizationEnvelopeBytesPerToken {
+			t.Fatalf("envelope = %d bytes, budget = %d", bytes, budget*localizationEnvelopeBytesPerToken)
+		}
+		return outlineEnvelope(t, result)
+	}
+
+	roomy := build(exploreMaxBudgetTokens)
+	if roomy.Outline == nil || len(roomy.Outlines) == 0 {
+		t.Fatalf("roomy page = %#v / %#v, want both files indexed", roomy.Outline, roomy.Outlines)
+	}
+	tight := build(exploreMinBudgetTokens)
+	tightRows := 0
+	if tight.Outline != nil {
+		tightRows += len(tight.Outline.Rows)
+	}
+	for _, extra := range tight.Outlines {
+		tightRows += len(extra.Rows)
+	}
+	roomyRows := len(roomy.Outline.Rows)
+	for _, extra := range roomy.Outlines {
+		roomyRows += len(extra.Rows)
+	}
+	if tightRows >= roomyRows {
+		t.Fatalf("tight page indexed %d rows against the roomy page's %d", tightRows, roomyRows)
+	}
+	// Whatever is left of the block still leads with the file the page led with.
+	if len(tight.Outlines) > 0 && tight.Outline == nil {
+		t.Fatalf("the leading file's index went before a later file's: %#v", tight.Outlines)
+	}
+}
+
 func TestOutlineShrinksRatherThanVanishingWhenTheBudgetBinds(t *testing.T) {
 	const named = "computeRetryBackoff"
 	declared := outlineDeclaredFile(40)
@@ -448,7 +601,7 @@ func TestOutlineShrinksRatherThanVanishingWhenTheBudgetBinds(t *testing.T) {
 	routes := exploreLocalizationRefinementRoutes(targets)
 
 	build := func(budget int) localizationExploreEnvelope {
-		outline := localizationLeadingFileOutlineProvider(
+		outline := localizationPageOutlineProvider(
 			outlinePool(declared[0], declared[1]), targets, exploreTerminalTerms(task),
 			func(string) []*graph.Node { return declared },
 		)
@@ -497,7 +650,7 @@ func TestOutlineShrinkingNeverEscapesTheProviderCache(t *testing.T) {
 	declared := outlineDeclaredFile(40)
 	targets := []exploreTarget{{node: declared[0]}, {node: declared[1]}}
 	targets = append(targets, outlineBreadthTargets(8)...)
-	outline := localizationLeadingFileOutlineProvider(
+	outline := localizationPageOutlineProvider(
 		outlinePool(declared[0], declared[1]), targets, nil,
 		func(string) []*graph.Node { return declared },
 	)
@@ -531,12 +684,12 @@ func TestLeadingFileOutlineProviderCarriesTheTaskTerms(t *testing.T) {
 	middle := len(declared) / 2
 	declared[middle] = outlineDeclaration(named, middle+1)
 	targets := []exploreTarget{{node: declared[0]}, {node: declared[1]}}
-	outline := localizationLeadingFileOutlineProvider(
+	outline := localizationPageOutlineProvider(
 		outlinePool(declared[0], declared[1]), targets,
 		exploreTerminalTerms("the http request dispatch never retries"),
 		func(string) []*graph.Node { return declared },
 	)()
-	if !outlineRowNamed(outline, named) {
+	if outline == nil || !outlineRowNamed(outline.Leading, named) {
 		t.Fatalf("provider built an outline blind to the task: %#v", outline)
 	}
 }
@@ -571,7 +724,7 @@ func TestScatteredRankingCarriesNoOutline(t *testing.T) {
 		targets = append(targets, exploreTarget{node: node})
 	}
 	enumerated := 0
-	outline := localizationLeadingFileOutlineProvider(pool, targets, nil, func(string) []*graph.Node {
+	outline := localizationPageOutlineProvider(pool, targets, nil, func(string) []*graph.Node {
 		enumerated++
 		return nil
 	})

--- a/internal/mcp/localization_file_outline_test.go
+++ b/internal/mcp/localization_file_outline_test.go
@@ -762,6 +762,57 @@ func TestOutlineFloorOutranksTheTrailingRowsExpansionDetail(t *testing.T) {
 	}
 }
 
+func TestFurtherFilesGiveWayBeforeTheLeadingFilesDepth(t *testing.T) {
+	leading := &localizationFileOutline{File: "repo/lead.go"}
+	leading.all = make([]localizationOutlineRow, 0, 30)
+	for index := 0; index < 30; index++ {
+		leading.all = append(leading.all, localizationOutlineRow{
+			Name: fmt.Sprintf("Declared%02d", index), Line: index + 1, Kind: "f",
+		})
+	}
+	leading.Declared = len(leading.all)
+	leading.elide(localizationOutlineRowCap)
+	page := &localizationPageOutline{Leading: leading}
+	for _, file := range []string{"repo/second.go", "repo/third.go"} {
+		other := &localizationFileOutline{File: file}
+		for index := 0; index < 20; index++ {
+			other.all = append(other.all, localizationOutlineRow{
+				Name: fmt.Sprintf("Other%02d", index), Line: index + 1, Kind: "f",
+			})
+		}
+		other.Declared = len(other.all)
+		other.elide(localizationOutlineSecondFileRowCap)
+		page.Others = append(page.Others, other)
+	}
+
+	// Pressure until nothing is left, recording the leading file's depth at the
+	// moment each further file went.
+	depthWhenAFileWent := []int{}
+	for guard := 0; !page.empty(); guard++ {
+		if guard > 200 {
+			t.Fatal("relief never converged")
+		}
+		before := len(page.Others)
+		leadingRows := 0
+		if page.Leading != nil {
+			leadingRows = len(page.Leading.Rows)
+		}
+		page.relieve()
+		if len(page.Others) < before {
+			depthWhenAFileWent = append(depthWhenAFileWent, leadingRows)
+		}
+	}
+	if len(depthWhenAFileWent) != 2 {
+		t.Fatalf("further files dropped %d times, want 2", len(depthWhenAFileWent))
+	}
+	for _, depth := range depthWhenAFileWent {
+		if depth < localizationOutlineSecondFileRowCap {
+			t.Fatalf("a further file survived the leading file's depth falling to %d, floor %d",
+				depth, localizationOutlineSecondFileRowCap)
+		}
+	}
+}
+
 func TestATradeThatCannotSaveTheOutlineIsGivenBack(t *testing.T) {
 	const named = "computeRetryBackoff"
 	declared := outlineDeclaredFile(20)

--- a/internal/mcp/localization_file_outline_test.go
+++ b/internal/mcp/localization_file_outline_test.go
@@ -650,11 +650,14 @@ func TestOutlineShrinksRatherThanVanishingWhenTheBudgetBinds(t *testing.T) {
 // default budget on their own — the shape that left no room for any index at
 // all. Each row carries the qualified name, signature, and neighbour
 // identifiers a real evidence row serializes.
-func outlineBudgetFillingTargets(count int) []exploreTarget {
+func outlineBudgetFillingTargets(count int, deep bool) []exploreTarget {
 	targets := make([]exploreTarget, 0, count)
 	for index := 0; index < count; index++ {
 		name := fmt.Sprintf("BreadthCandidate%02d", index)
 		dir := fmt.Sprintf("repo/breadth/service/%02d", index)
+		if deep {
+			dir += "/subsystem/internal"
+		}
 		qual := dir + "/handler." + name + ".ExecuteWithRetriesAndBackoff"
 		neighbors := make([]*graph.Node, 0, 3)
 		for neighbor := 0; neighbor < 3; neighbor++ {
@@ -693,7 +696,7 @@ func TestOutlineFloorOutranksTheTrailingRowsExpansionDetail(t *testing.T) {
 		{node: declared[0], source: "func Declared00() { executeAll() }"},
 		{node: declared[1], source: "func Declared01() { executeOne() }"},
 	}
-	targets = append(targets, outlineBudgetFillingTargets(8)...)
+	targets = append(targets, outlineBudgetFillingTargets(8, false)...)
 	routes := exploreLocalizationRefinementRoutes(targets)
 
 	build := func(withOutline bool) localizationExploreEnvelope {
@@ -756,6 +759,51 @@ func TestOutlineFloorOutranksTheTrailingRowsExpansionDetail(t *testing.T) {
 			t.Fatalf("row %d inside the direct-evidence reserve gave up detail: %#v against %#v",
 				index, page.Evidence[index], bare.Evidence[index])
 		}
+	}
+}
+
+func TestATradeThatCannotSaveTheOutlineIsGivenBack(t *testing.T) {
+	const named = "computeRetryBackoff"
+	declared := outlineDeclaredFile(20)
+	middle := len(declared) / 2
+	declared[middle] = outlineDeclaration(named, middle+1)
+	task := "the retry backoff never fires after a throttled response"
+	targets := []exploreTarget{
+		{node: declared[0], source: "func Declared00() { executeAll() }"},
+		{node: declared[1], source: "func Declared01() { executeOne() }"},
+	}
+	// One expendable row on a page too tight for even a floor-sized index:
+	// whatever that row gives up cannot buy the index, so it keeps it.
+	targets = append(targets, outlineBudgetFillingTargets(7, true)...)
+	routes := exploreLocalizationRefinementRoutes(targets)
+
+	build := func(withOutline bool) localizationExploreEnvelope {
+		var outline func() *localizationPageOutline
+		if withOutline {
+			outline = localizationPageOutlineProvider(
+				outlinePool(declared[0], declared[1]), targets, exploreTerminalTerms(task),
+				func(file string) []*graph.Node {
+					if file == outlineLeadingFile {
+						return declared
+					}
+					return nil
+				},
+			)
+		}
+		result, _, _, _ := buildLocalizationRefinementResultForTaskWithOutline(
+			declared[0].ID, task, targets, localizationDefaultBudgetTokens, routes, outline,
+		)
+		return outlineEnvelope(t, result)
+	}
+
+	bare := build(false)
+	page := build(true)
+	if page.Outline != nil {
+		t.Skip("the fixture is no longer tight enough to drop the index")
+	}
+	if !reflect.DeepEqual(page.Evidence, bare.Evidence) {
+		t.Fatalf("a page that dropped its index still paid for it:\n%#v\nagainst\n%#v",
+			page.Evidence, bare.Evidence)
 	}
 }
 

--- a/internal/mcp/localization_file_outline_test.go
+++ b/internal/mcp/localization_file_outline_test.go
@@ -159,7 +159,7 @@ func TestTerminalPageCarriesNoOutlineAndPaysNoEnumeration(t *testing.T) {
 	}
 }
 
-func TestOutlineShedsBeforeEvidenceRowsUnderATightBudget(t *testing.T) {
+func TestOutlineGivesWayBeforeEvidenceRowsUnderATightBudget(t *testing.T) {
 	declared := outlineDeclaredFile(40)
 	long := strings.Repeat("quoted-\"-slash-\\-metadata-", 24)
 	neighbors := make([]*graph.Node, 0, 12)
@@ -199,8 +199,13 @@ func TestOutlineShedsBeforeEvidenceRowsUnderATightBudget(t *testing.T) {
 	}
 
 	tight, tightBytes := build(exploreMinBudgetTokens, true)
+	// The outline is what a tight page gives back, and it gives it back by
+	// degrees: fewer rows down to the floor, then nothing.
 	if tight.Outline != nil {
-		t.Fatalf("tight page kept the outline: %#v", tight.Outline)
+		if rows := len(tight.Outline.Rows); rows >= len(declared) || rows < localizationOutlineFloorRows {
+			t.Fatalf("tight page kept %d outline rows of %d declared, floor %d",
+				rows, len(declared), localizationOutlineFloorRows)
+		}
 	}
 	if tightBytes > exploreMinBudgetTokens*localizationEnvelopeBytesPerToken {
 		t.Fatalf("tight envelope = %d bytes, budget = %d",
@@ -214,8 +219,12 @@ func TestOutlineShedsBeforeEvidenceRowsUnderATightBudget(t *testing.T) {
 	// The same rows and the same outline, with room for both: only the budget
 	// decided which one gave way.
 	wide, _ := build(exploreMaxBudgetTokens, true)
-	if wide.Outline == nil {
-		t.Fatal("a page with room to spare shed the outline anyway")
+	if wide.Outline == nil || len(wide.Outline.Rows) != len(declared) {
+		t.Fatalf("a page with room to spare shortened its outline: %#v", wide.Outline)
+	}
+	if tight.Outline != nil && len(tight.Outline.Rows) >= len(wide.Outline.Rows) {
+		t.Fatalf("the tight page gave nothing back: %d rows against %d",
+			len(tight.Outline.Rows), len(wide.Outline.Rows))
 	}
 }
 
@@ -385,6 +394,134 @@ func TestOutlineElisionKeepsTaskTermMatchingDeclarations(t *testing.T) {
 	if outline.Rows[0].Line != 1 || outline.Rows[len(outline.Rows)-1].Line != len(declared) {
 		t.Fatalf("outline spans lines %d..%d, want the whole file's ends",
 			outline.Rows[0].Line, outline.Rows[len(outline.Rows)-1].Line)
+	}
+}
+
+// outlineBreadthTargets is the ranked breadth a real localization page carries
+// beside its leading file: distinct files, each with the qualified name,
+// signature, and neighbor identifiers an evidence row serializes.
+func outlineBreadthTargets(count int) []exploreTarget {
+	targets := make([]exploreTarget, 0, count)
+	for index := 0; index < count; index++ {
+		name := fmt.Sprintf("BreadthCandidate%02d", index)
+		qual := fmt.Sprintf("repo/breadth/service/%02d/handler.BreadthCandidate%02d.Execute", index, index)
+		neighbors := make([]*graph.Node, 0, 3)
+		for neighbor := 0; neighbor < 3; neighbor++ {
+			neighbors = append(neighbors, &graph.Node{
+				ID: fmt.Sprintf("repo/breadth/service/%02d/neighbor_%d.go::Neighbor%02d%d", index, neighbor, index, neighbor),
+			})
+		}
+		targets = append(targets, exploreTarget{
+			node: &graph.Node{
+				ID:        fmt.Sprintf("repo/breadth/service/%02d/handler.go::%s", index, name),
+				Name:      name,
+				QualName:  qual,
+				Kind:      graph.KindFunction,
+				FilePath:  fmt.Sprintf("repo/breadth/service/%02d/handler.go", index),
+				StartLine: 24,
+				EndLine:   96,
+				Meta: map[string]any{
+					"signature": "func (" + name + ") Execute(ctx context.Context, request *BreadthRequest, options ...BreadthOption) (*BreadthResponse, error)",
+					"qualname":  qual,
+				},
+			},
+			callers: neighbors,
+			callees: neighbors,
+		})
+	}
+	return targets
+}
+
+func TestOutlineShrinksRatherThanVanishingWhenTheBudgetBinds(t *testing.T) {
+	const named = "computeRetryBackoff"
+	declared := outlineDeclaredFile(40)
+	// The answer is a declaration of the file the page already leads with, in
+	// the middle of it — the shape the outline exists to catch.
+	middle := len(declared) / 2
+	declared[middle] = outlineDeclaration(named, middle+1)
+	task := "the retry backoff never fires after a throttled response"
+	targets := []exploreTarget{
+		{node: declared[0], source: "func Declared00() { executeAll() }"},
+		{node: declared[1], source: "func Declared01() { executeOne() }"},
+	}
+	targets = append(targets, outlineBreadthTargets(8)...)
+	routes := exploreLocalizationRefinementRoutes(targets)
+
+	build := func(budget int) localizationExploreEnvelope {
+		outline := localizationLeadingFileOutlineProvider(
+			outlinePool(declared[0], declared[1]), targets, exploreTerminalTerms(task),
+			func(string) []*graph.Node { return declared },
+		)
+		result, completion, _, _ := buildLocalizationRefinementResultForTaskWithOutline(
+			declared[0].ID, task, targets, budget, routes, outline,
+		)
+		if completion.State != localizationStateNeedsRefinement {
+			t.Fatalf("completion state = %q, want %q", completion.State, localizationStateNeedsRefinement)
+		}
+		if bytes := outlineEnvelopeBytes(t, result); bytes > budget*localizationEnvelopeBytesPerToken {
+			t.Fatalf("envelope = %d bytes, budget = %d", bytes, budget*localizationEnvelopeBytesPerToken)
+		}
+		return outlineEnvelope(t, result)
+	}
+
+	roomy := build(exploreMaxBudgetTokens)
+	if roomy.Outline == nil || len(roomy.Outline.Rows) != localizationOutlineRowCap {
+		t.Fatalf("roomy page outline = %#v, want the full %d rows", roomy.Outline, localizationOutlineRowCap)
+	}
+
+	page := build(localizationDefaultBudgetTokens)
+	if page.Outline == nil {
+		t.Fatal("the default budget shed the leading-file outline entirely")
+	}
+	if len(page.Outline.Rows) >= localizationOutlineRowCap {
+		t.Fatalf("fixture is not under budget pressure: %d rows survived at the default budget",
+			len(page.Outline.Rows))
+	}
+	if len(page.Outline.Rows) < localizationOutlineFloorRows {
+		t.Fatalf("outline shrank past its floor: %d rows, floor %d",
+			len(page.Outline.Rows), localizationOutlineFloorRows)
+	}
+	if page.Outline.Declared != len(declared) {
+		t.Fatalf("outline declared = %d, want the file's %d", page.Outline.Declared, len(declared))
+	}
+	if !outlineRowNamed(page.Outline, named) {
+		t.Fatalf("shrinking dropped the declaration the task names: %#v", page.Outline.Rows)
+	}
+	if len(page.Evidence) != len(roomy.Evidence) {
+		t.Fatalf("evidence rows = %d, want the %d the same page carries with room to spare",
+			len(page.Evidence), len(roomy.Evidence))
+	}
+}
+
+func TestOutlineShrinkingNeverEscapesTheProviderCache(t *testing.T) {
+	declared := outlineDeclaredFile(40)
+	targets := []exploreTarget{{node: declared[0]}, {node: declared[1]}}
+	targets = append(targets, outlineBreadthTargets(8)...)
+	outline := localizationLeadingFileOutlineProvider(
+		outlinePool(declared[0], declared[1]), targets, nil,
+		func(string) []*graph.Node { return declared },
+	)
+	routes := exploreLocalizationRefinementRoutes(targets)
+	// The same provider serves every envelope one request packs. A page that
+	// shrank its outline must not hand the next page a shrunken one.
+	tight, _, _, _ := buildLocalizationRefinementResultForTaskWithOutline(
+		declared[0].ID, "find the declared implementation", targets,
+		localizationDefaultBudgetTokens, routes, outline,
+	)
+	roomy, _, _, _ := buildLocalizationRefinementResultForTaskWithOutline(
+		declared[0].ID, "find the declared implementation", targets,
+		exploreMaxBudgetTokens, routes, outline,
+	)
+	tightPage, roomyPage := outlineEnvelope(t, tight), outlineEnvelope(t, roomy)
+	if tightPage.Outline == nil || roomyPage.Outline == nil {
+		t.Fatalf("outlines = %#v tight, %#v roomy; want both pages indexed",
+			tightPage.Outline, roomyPage.Outline)
+	}
+	tightRows := len(tightPage.Outline.Rows)
+	roomyRows := len(roomyPage.Outline.Rows)
+	if roomyRows != localizationOutlineRowCap || roomyRows <= tightRows {
+		t.Fatalf("outline rows = %d tight, %d roomy; want the cached outline unshrunk at %d",
+			tightRows, roomyRows, localizationOutlineRowCap)
 	}
 }
 

--- a/internal/mcp/localization_file_outline_test.go
+++ b/internal/mcp/localization_file_outline_test.go
@@ -646,6 +646,119 @@ func TestOutlineShrinksRatherThanVanishingWhenTheBudgetBinds(t *testing.T) {
 	}
 }
 
+// outlineBudgetFillingTargets is a page whose ranked rows fill the localize
+// default budget on their own — the shape that left no room for any index at
+// all. Each row carries the qualified name, signature, and neighbour
+// identifiers a real evidence row serializes.
+func outlineBudgetFillingTargets(count int) []exploreTarget {
+	targets := make([]exploreTarget, 0, count)
+	for index := 0; index < count; index++ {
+		name := fmt.Sprintf("BreadthCandidate%02d", index)
+		dir := fmt.Sprintf("repo/breadth/service/%02d", index)
+		qual := dir + "/handler." + name + ".ExecuteWithRetriesAndBackoff"
+		neighbors := make([]*graph.Node, 0, 3)
+		for neighbor := 0; neighbor < 3; neighbor++ {
+			neighbors = append(neighbors, &graph.Node{
+				ID: fmt.Sprintf("%s/neighbor_%d.go::NeighbouringCandidate%02d%d.Execute", dir, neighbor, index, neighbor),
+			})
+		}
+		targets = append(targets, exploreTarget{
+			node: &graph.Node{
+				ID:        dir + "/handler.go::" + name,
+				Name:      name,
+				QualName:  qual,
+				Kind:      graph.KindFunction,
+				FilePath:  dir + "/handler.go",
+				StartLine: 24,
+				EndLine:   96,
+				Meta: map[string]any{
+					"signature": "func (" + name + ") ExecuteWithRetriesAndBackoff(ctx context.Context, request *BreadthRequest, options ...BreadthOption) (*BreadthResponse, error)",
+					"qualname":  qual,
+				},
+			},
+			callers: neighbors,
+			callees: neighbors,
+		})
+	}
+	return targets
+}
+
+func TestOutlineFloorOutranksTheTrailingRowsExpansionDetail(t *testing.T) {
+	const named = "computeRetryBackoff"
+	declared := outlineDeclaredFile(20)
+	middle := len(declared) / 2
+	declared[middle] = outlineDeclaration(named, middle+1)
+	task := "the retry backoff never fires after a throttled response"
+	targets := []exploreTarget{
+		{node: declared[0], source: "func Declared00() { executeAll() }"},
+		{node: declared[1], source: "func Declared01() { executeOne() }"},
+	}
+	targets = append(targets, outlineBudgetFillingTargets(8)...)
+	routes := exploreLocalizationRefinementRoutes(targets)
+
+	build := func(withOutline bool) localizationExploreEnvelope {
+		var outline func() *localizationPageOutline
+		if withOutline {
+			outline = localizationPageOutlineProvider(
+				outlinePool(declared[0], declared[1]), targets, exploreTerminalTerms(task),
+				func(file string) []*graph.Node {
+					if file == outlineLeadingFile {
+						return declared
+					}
+					return nil
+				},
+			)
+		}
+		result, completion, _, _ := buildLocalizationRefinementResultForTaskWithOutline(
+			declared[0].ID, task, targets, localizationDefaultBudgetTokens, routes, outline,
+		)
+		if completion.State != localizationStateNeedsRefinement {
+			t.Fatalf("completion state = %q, want %q", completion.State, localizationStateNeedsRefinement)
+		}
+		budget := localizationDefaultBudgetTokens * localizationEnvelopeBytesPerToken
+		if bytes := outlineEnvelopeBytes(t, result); bytes > budget {
+			t.Fatalf("envelope = %d bytes, budget = %d", bytes, budget)
+		}
+		return outlineEnvelope(t, result)
+	}
+
+	bare := build(false)
+	if bare.Outline != nil {
+		t.Fatalf("the no-outline build produced one: %#v", bare.Outline)
+	}
+	// The fixture only proves anything if the rows really did fill the budget:
+	// a page with room to spare never has to trade anything for its index.
+	if len(bare.Evidence) != len(targets) {
+		t.Fatalf("bare evidence rows = %d, want all %d ranked rows", len(bare.Evidence), len(targets))
+	}
+	page := build(true)
+	if page.Outline == nil || len(page.Outline.Rows) < localizationOutlineFloorRows {
+		t.Fatalf("a page whose rows filled the budget carries no index: %#v", page.Outline)
+	}
+	if !outlineRowNamed(page.Outline, named) {
+		t.Fatalf("the retained index misses the declaration the task names: %#v", page.Outline.Rows)
+	}
+	// Not one ranked row was given up for it, and none lost its identity.
+	if !reflect.DeepEqual(page.Symbols, bare.Symbols) || !reflect.DeepEqual(page.Files, bare.Files) {
+		t.Fatalf("the index cost ranked rows: %d/%d symbols, %d/%d files",
+			len(page.Symbols), len(bare.Symbols), len(page.Files), len(bare.Files))
+	}
+	for index, row := range page.Evidence {
+		if row.ID != bare.Evidence[index].ID || row.Line != bare.Evidence[index].Line ||
+			row.File != bare.Evidence[index].File || row.Name != bare.Evidence[index].Name {
+			t.Fatalf("row %d lost its identity: %#v against %#v", index, row, bare.Evidence[index])
+		}
+	}
+	// The detail it traded came off the expendable tail, never the rows the
+	// refinement contract is allowed to name.
+	for index := 0; index < min(localizationDirectEvidenceReserve, len(page.Evidence)); index++ {
+		if !reflect.DeepEqual(page.Evidence[index], bare.Evidence[index]) {
+			t.Fatalf("row %d inside the direct-evidence reserve gave up detail: %#v against %#v",
+				index, page.Evidence[index], bare.Evidence[index])
+		}
+	}
+}
+
 func TestOutlineShrinkingNeverEscapesTheProviderCache(t *testing.T) {
 	declared := outlineDeclaredFile(40)
 	targets := []exploreTarget{{node: declared[0]}, {node: declared[1]}}

--- a/internal/mcp/localization_file_outline_test.go
+++ b/internal/mcp/localization_file_outline_test.go
@@ -921,29 +921,57 @@ func TestOutlineElisionRanksStrongerTaskTermMatchesFirst(t *testing.T) {
 	}
 }
 
-func TestScatteredRankingCarriesNoOutline(t *testing.T) {
+func TestScatteredRankingIndexesThePageFilesWithoutALeadingOne(t *testing.T) {
 	var pool []*rerank.Candidate
 	var targets []exploreTarget
+	declared := map[string][]*graph.Node{}
 	for index := 0; index < 6; index++ {
+		file := fmt.Sprintf("repo/scatter_%d.go", index)
 		node := &graph.Node{
-			ID:        fmt.Sprintf("repo/scatter_%d.go::Scatter%d", index, index),
+			ID:        file + fmt.Sprintf("::Scatter%d", index),
 			Name:      fmt.Sprintf("Scatter%d", index),
 			Kind:      graph.KindFunction,
-			FilePath:  fmt.Sprintf("repo/scatter_%d.go", index),
+			FilePath:  file,
 			StartLine: 3,
 		}
 		pool = append(pool, &rerank.Candidate{Node: node, TextRank: index, VectorRank: -1})
 		targets = append(targets, exploreTarget{node: node})
+		for sibling := 0; sibling < 4; sibling++ {
+			declared[file] = append(declared[file], &graph.Node{
+				ID:        file + fmt.Sprintf("::Sibling%d%d", index, sibling),
+				Name:      fmt.Sprintf("Sibling%d%d", index, sibling),
+				Kind:      graph.KindFunction,
+				FilePath:  file,
+				StartLine: 10 + sibling*5,
+			})
+		}
 	}
 	enumerated := 0
-	outline := localizationPageOutlineProvider(pool, targets, nil, func(string) []*graph.Node {
+	page := localizationPageOutlineProvider(pool, targets, nil, func(file string) []*graph.Node {
 		enumerated++
-		return nil
-	})
-	if page := outline(); page != nil {
-		t.Fatalf("scattered ranking produced an outline: %#v", page)
+		return declared[file]
+	})()
+	if page == nil {
+		t.Fatal("a scattered page carries no index at all")
 	}
-	if enumerated != 0 {
-		t.Fatalf("scattered ranking paid %d graph enumerations", enumerated)
+	// Ranking never settled, so no file earns the leading slot — but the rows
+	// still name files, and each of them declares siblings the rows never show.
+	if page.Leading != nil {
+		t.Fatalf("a scattered page elected a leading file: %#v", page.Leading)
+	}
+	if len(page.Others) == 0 {
+		t.Fatal("a scattered page indexed none of the files its rows named")
+	}
+	if len(page.Others) > localizationOutlineFileCap {
+		t.Fatalf("indexed %d files, cap %d", len(page.Others), localizationOutlineFileCap)
+	}
+	if enumerated > localizationOutlineFileCap {
+		t.Fatalf("scattered ranking paid %d graph enumerations, cap %d",
+			enumerated, localizationOutlineFileCap)
+	}
+	for _, other := range page.Others {
+		if len(other.Rows) > localizationOutlineSecondFileRowCap {
+			t.Fatalf("a file on a page with no leading one took the deepest slice: %#v", other)
+		}
 	}
 }

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -4403,6 +4403,17 @@ func buildLocalizationExploreResultForTaskFinalizedWithOutline(
 			// reach by other means, so they give way before every other payload
 			// here — but they give way by degrees. A shorter index is worth far
 			// more than none, and only pressure past the floor drops one.
+			if block.atFloor() &&
+				localizationShedTrailingEvidenceDetail(&envelope, mandatoryCount) {
+				// The index has given back everything it can and the page still
+				// does not fit. A ranked page fills its budget with rows, so
+				// without this the floor is unreachable exactly on the pages
+				// that need an index most. The expendable breadth tail pays,
+				// in the detail a caller can re-derive from the identity that
+				// stays — never in a row, and never inside the reserve the
+				// refinement contract may name.
+				continue
+			}
 			block.relieve()
 			envelope.Outline, envelope.Outlines = block.Leading, block.Others
 			continue
@@ -4449,6 +4460,27 @@ func buildLocalizationExploreResultForTaskFinalizedWithOutline(
 	}
 	result := attachLocalizationHostEnvelope(mcp.NewToolResultText(string(body)), envelope.Completion, digest)
 	return result, append([]string(nil), envelope.Symbols...), digest, envelope.Completion
+}
+
+// localizationShedTrailingEvidenceDetail gives back one trailing row's
+// expansion detail — the qualified name, signature, and neighbour identifiers a
+// caller can re-derive from the identity that stays. Only the breadth tail past
+// the direct-evidence reserve is eligible, and the row's ID, kind, file, line,
+// and provenance are untouched, so nothing the completion contract or the
+// evidence policy reads can move. This is the same trade the packing loop
+// already makes for a mandatory row that will not fit whole.
+func localizationShedTrailingEvidenceDetail(envelope *localizationExploreEnvelope, mandatory int) bool {
+	protected := max(mandatory, localizationDirectEvidenceReserve)
+	for index := len(envelope.Evidence) - 1; index >= protected; index-- {
+		row := &envelope.Evidence[index]
+		if row.QualName == "" && row.Signature == "" && len(row.Callers) == 0 && len(row.Callees) == 0 {
+			continue
+		}
+		row.QualName, row.Signature = "", ""
+		row.Callers, row.Callees = nil, nil
+		return true
+	}
+	return false
 }
 
 func boundedLocalizationNeighborIDs(nodes []*graph.Node, limit int) []string {

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -3062,7 +3062,7 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 	// deferred: only a page that stays non-terminal pays for it, and it pays
 	// once however many envelopes this request packs. The task's own terms ride
 	// along so a bounded index keeps the declarations the task named.
-	pageOutline := localizationLeadingFileOutlineProvider(
+	pageOutline := localizationPageOutlineProvider(
 		localizationRankedPool, pageTargets, exploreTerminalTerms(task),
 		func(file string) []*graph.Node { return fileDefinitionNodes(eng, file) },
 	)
@@ -3164,12 +3164,16 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 // explicit localization-only request. Ordinary explore(task) retains the
 // human-oriented legacy rendering; localize does not duplicate it.
 type localizationExploreEnvelope struct {
-	Completion localizationCompletion   `json:"completion"`
-	Terminal   bool                     `json:"terminal"`
-	Files      []string                 `json:"files"`
-	Symbols    []string                 `json:"symbols"`
-	Evidence   []localizationEvidence   `json:"evidence"`
-	Outline    *localizationFileOutline `json:"outline,omitempty"`
+	Completion localizationCompletion `json:"completion"`
+	Terminal   bool                   `json:"terminal"`
+	Files      []string               `json:"files"`
+	Symbols    []string               `json:"symbols"`
+	Evidence   []localizationEvidence `json:"evidence"`
+	// Outline indexes the page's leading file; Outlines indexes the page's
+	// further files, deepest first. The split keeps the leading file where
+	// consumers already read it.
+	Outline  *localizationFileOutline   `json:"outline,omitempty"`
+	Outlines []*localizationFileOutline `json:"outlines,omitempty"`
 }
 
 type localizationEvidence struct {
@@ -4037,7 +4041,7 @@ func buildLocalizationRefinementResultForTaskWithOutline(
 	targets []exploreTarget,
 	budget int,
 	routes map[string]localizationRefinementRoute,
-	outline func() *localizationFileOutline,
+	outline func() *localizationPageOutline,
 ) (*mcp.CallToolResult, localizationCompletion, map[string]localizationRefinementRoute, *localizationEvidenceDigest) {
 	choosePreferred := func(symbols []string, requested string) (string, []string, map[string]localizationRefinementRoute) {
 		authorized, bounded := boundedLocalizationRefinementRoutes(symbols, routes, requested)
@@ -4109,7 +4113,7 @@ func buildLocalizationExploreResultForTaskFinalizedWithOutline(
 	task string,
 	targets []exploreTarget,
 	budget int,
-	outline func() *localizationFileOutline,
+	outline func() *localizationPageOutline,
 	finalize ...localizationCompletionFinalizer,
 ) (*mcp.CallToolResult, []string, *localizationEvidenceDigest, localizationCompletion) {
 	var draft []exploreDraftEntry
@@ -4371,13 +4375,15 @@ func buildLocalizationExploreResultForTaskFinalizedWithOutline(
 	contract = localizationContractReconciledWithDigest(envelope.Completion, digest)
 	envelope.Completion = contract.Completion
 	envelope.Terminal = contract.Terminal
-	// A page that still asks the caller to choose gets the leading file's
-	// declaration index. The rows above name at most one symbol per file, so a
-	// caller looking at the right file and the wrong row has nothing to correct
-	// with; the outline is that file's remaining declarations, and it is the
-	// first thing given back when the budget cannot hold everything.
+	// A page that still asks the caller to choose gets its files' declaration
+	// indexes. The rows above name at most one symbol per file, so a caller
+	// looking at the right file and the wrong row has nothing to correct with;
+	// the outlines are those files' remaining declarations, and they are the
+	// first payload given back when the budget cannot hold everything.
 	if outline != nil && localizationPageAcceptsOutline(envelope.Completion.State) {
-		envelope.Outline = outline().clone()
+		if page := outline().clone(); page != nil {
+			envelope.Outline, envelope.Outlines = page.Leading, page.Others
+		}
 	}
 	// The ready-to-emit answer is derived from the retained rows, so it lands
 	// after the fit checks above and can push the envelope past its budget.
@@ -4391,12 +4397,14 @@ func buildLocalizationExploreResultForTaskFinalizedWithOutline(
 		shedBudget = maxBytes + localizationRetiredReadAllowance(maxBytes)
 	}
 	for !localizationEnvelopeFits(envelope, shedBudget) {
-		if envelope.Outline != nil {
-			// The outline is a convenience over rows the caller can still reach
-			// by other means, so it gives way before every other payload here —
-			// but it gives way by degrees. A shorter index is worth far more
-			// than none, and only pressure past its floor drops it outright.
-			envelope.Outline, _ = localizationOutlineRelief(envelope.Outline)
+		block := &localizationPageOutline{Leading: envelope.Outline, Others: envelope.Outlines}
+		if !block.empty() {
+			// The outlines are a convenience over rows the caller can still
+			// reach by other means, so they give way before every other payload
+			// here — but they give way by degrees. A shorter index is worth far
+			// more than none, and only pressure past the floor drops one.
+			block.relieve()
+			envelope.Outline, envelope.Outlines = block.Leading, block.Others
 			continue
 		}
 		if digest != nil && len(digest.Evidence) > localizationFinalResponsePrimaryLimit {

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -4396,6 +4396,9 @@ func buildLocalizationExploreResultForTaskFinalizedWithOutline(
 	if satisfiedSymbol != "" {
 		shedBudget = maxBytes + localizationRetiredReadAllowance(maxBytes)
 	}
+	// The rows as they stood before the breadth tail was asked to pay for an
+	// index. A trade that ends with no index bought nothing, so it is undone.
+	var untraded []localizationEvidence
 	for !localizationEnvelopeFits(envelope, shedBudget) {
 		block := &localizationPageOutline{Leading: envelope.Outline, Others: envelope.Outlines}
 		if !block.empty() {
@@ -4403,8 +4406,7 @@ func buildLocalizationExploreResultForTaskFinalizedWithOutline(
 			// reach by other means, so they give way before every other payload
 			// here — but they give way by degrees. A shorter index is worth far
 			// more than none, and only pressure past the floor drops one.
-			if block.atFloor() &&
-				localizationShedTrailingEvidenceDetail(&envelope, mandatoryCount) {
+			if block.atFloor() {
 				// The index has given back everything it can and the page still
 				// does not fit. A ranked page fills its budget with rows, so
 				// without this the floor is unreachable exactly on the pages
@@ -4412,10 +4414,21 @@ func buildLocalizationExploreResultForTaskFinalizedWithOutline(
 				// in the detail a caller can re-derive from the identity that
 				// stays — never in a row, and never inside the reserve the
 				// refinement contract may name.
-				continue
+				if untraded == nil {
+					untraded = append([]localizationEvidence(nil), envelope.Evidence...)
+				}
+				if localizationShedTrailingEvidenceDetail(&envelope, mandatoryCount) {
+					continue
+				}
 			}
 			block.relieve()
 			envelope.Outline, envelope.Outlines = block.Leading, block.Others
+			if block.empty() && untraded != nil {
+				// Nothing was bought. Give the tail its detail back rather than
+				// return a page that is both shorter and unindexed.
+				envelope.Evidence = untraded
+				untraded = nil
+			}
 			continue
 		}
 		if digest != nil && len(digest.Evidence) > localizationFinalResponsePrimaryLimit {

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -4377,7 +4377,7 @@ func buildLocalizationExploreResultForTaskFinalizedWithOutline(
 	// with; the outline is that file's remaining declarations, and it is the
 	// first thing given back when the budget cannot hold everything.
 	if outline != nil && localizationPageAcceptsOutline(envelope.Completion.State) {
-		envelope.Outline = outline()
+		envelope.Outline = outline().clone()
 	}
 	// The ready-to-emit answer is derived from the retained rows, so it lands
 	// after the fit checks above and can push the envelope past its budget.
@@ -4393,9 +4393,10 @@ func buildLocalizationExploreResultForTaskFinalizedWithOutline(
 	for !localizationEnvelopeFits(envelope, shedBudget) {
 		if envelope.Outline != nil {
 			// The outline is a convenience over rows the caller can still reach
-			// by other means; every other payload here is evidence this
-			// response is answering with.
-			envelope.Outline = nil
+			// by other means, so it gives way before every other payload here —
+			// but it gives way by degrees. A shorter index is worth far more
+			// than none, and only pressure past its floor drops it outright.
+			envelope.Outline, _ = localizationOutlineRelief(envelope.Outline)
 			continue
 		}
 		if digest != nil && len(digest.Evidence) > localizationFinalResponsePrimaryLimit {

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -3060,9 +3060,10 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 	targets = append(targets[:len(artifactTargets):len(artifactTargets)], pageTargets...)
 	// The same leading file, indexed rather than ranked. The enumeration is
 	// deferred: only a page that stays non-terminal pays for it, and it pays
-	// once however many envelopes this request packs.
+	// once however many envelopes this request packs. The task's own terms ride
+	// along so a bounded index keeps the declarations the task named.
 	pageOutline := localizationLeadingFileOutlineProvider(
-		localizationRankedPool, pageTargets,
+		localizationRankedPool, pageTargets, exploreTerminalTerms(task),
 		func(file string) []*graph.Node { return fileDefinitionNodes(eng, file) },
 	)
 	// File evidence can make localization answer-ready, but it never becomes a


### PR DESCRIPTION
A refining localization page now carries a declaration index of the files it names, and that index survives the byte budget instead of being the first thing silently dropped.

## Why

The page shows ten ranked rows and diversifies them across files, so a file usually wins exactly one slot. When the answer is a sibling declaration in a file the page already names, nothing on the page says that file declares it —
the caller searches again for something it is already looking at. The leading-file index existed to close that, but measured on a corpus of first calls it was absent more often than present, covered only one file, and elided
its middle blindly.

## What changes

One commit per behaviour, each pinned by a test written before it.

1. **The index keeps the declarations the task named.** Elision kept a file's head and tail and dropped the middle, so on a file large enough to need eliding — the only kind a caller cannot navigate by eye — the declaration the task actually named was the one lost. The task's terms now reach outline construction and rows whose name carries one are retained first, ranked by how many distinct terms they carry.
2. **The index shrinks instead of vanishing.** It was the first payload an over-budget envelope gave back, and it gave back all of it. It now steps down in proportion to its size, and only pressure past an eight-row floor drops it.
3. **The index covers the other files the rows came from.** It covered one file: the one the page led with. A page whose ninth and tenth rows are methods of the answering file got an index of a neighbour. The leading file keeps the full index under the same `outline` field; further page files ride in a new sibling `outlines` list at shallower depths. Additive wire change — no existing field moves, and a file whose every declaration is already a row is skipped.
4. **The floor is reachable.** Evidence packing fills the budget with rows, so the index was offered a remainder that on most refining pages is a few dozen bytes; the floor was unreachable exactly where an index is worth most. Once every index is at its floor, the breadth tail past the direct-evidence reserve gives back its expansion detail — qualified name, signature, neighbour ids, all re-derivable and all still carried by the host digest — before any index is dropped. No ranked row is lost, and no row's id, kind, file, line, or provenance changes, so the symbol list, the file list, the completion contract, and the evidence policy read exactly what they read before.
5. **A trade that buys nothing is undone.** A page that paid for an index and dropped it anyway is the worst of the three outcomes; the rows are snapshotted before the first trade and restored the moment the last index goes.
6. **Further files never starve the leading file's depth.** Relief shrank whichever index was deepest, so the leading file paid for its neighbours. While the page still indexes further files, they are what a tight page gives back; the leading index stops shrinking at the depth a further file may hold.
7. **Scattered ranking still gets an index.** The index was gated on one file winning the ranked window. When ranking stays scattered no file wins and the page returned nothing — measured, on pages with two thousand spare bytes and the answering file at row two. Those pages now index the files their rows named, at the shallower depths, with no file taking the leading slice.
8. **Half of an index belongs to the file.** Ranking the task's terms first turned an index into a list of the query when the task's words happened to name half the file, and the declaration the caller wanted — a short generic name the task never said — was elided. The task's matches now take at most half the rows.

Terminality is untouched: `localizationPageAcceptsOutline` still gates every index, so a terminal page carries none and pays no enumeration. The indexes ride only in the text envelope — the host digest has no outline field and structuredContent is attached only to answer_ready pages, which never carry one.

## Measured

Offline replay of the first `explore` call for the 53 tasks a localization benchmark run missed, re-issued at the exact recorded arguments against a freshly indexed, isolated daemon. Zero model calls, $0. 49 of the 53 completed —
the four outstanding are three netty tasks and one that queued behind them, and netty's index alone runs 7–13 minutes per task. The table is like-for-like over the 49 both arms have.

| metric | before | after |
|---|---:|---:|
| gold_in_outline | 7 | **13** |
| gold_anywhere_on_page | 24 | **28** |
| gold_file_on_page | 39 | 40 |
| gold_as_evidence_row | 19 | 16 |
| required_action_names_gold | 7 | 7 |

Four tasks moved not-on-page → on-page and none moved the other way. Three of the four are carried by the further-file indexes alone — the answering file was on the page but not the one it led with.

Two caveats stated rather than buried:

- **Scoring.** The replay harness reads only the `outline` field, so the further files were invisible to it. The numbers above apply the harness's own credit rule — a row credits gold only when its block's file is the gold file — to every block on the page. Under the harness's unextended rule, the same run scores `gold_in_outline` 9 and `gold_anywhere_on_page` 23.
- **`gold_as_evidence_row` fell by three.** All three are on the `explore(operation:"task")` markdown door, which this change never reaches — its response is built and returned before any index is constructed. They are ranking differences between the build the baseline was measured on and this branch's base, eleven commits apart. Nothing here can reorder or reselect a ranked row.

## Cost

Mean serialized envelope over the 41 pages that carry one: 9007 → 9373 bytes (+4%), inside the same budget. Checked across the replayed pages: no page exceeded its byte budget, no page carried fewer ranked rows than before, and no terminal page carried an index.
