### PR TITLE
Join the analysis-generation prune before the backend store closes

### DIFF
--- a/internal/mcp/analysis_generation.go
+++ b/internal/mcp/analysis_generation.go
@@ -335,7 +335,20 @@ func (s *Server) scheduleAnalysisGenerationPrune(writer graph.AnalysisGeneration
 	if writer == nil || !s.analysisPruneScheduled.CompareAndSwap(false, true) {
 		return
 	}
+	// Add under the gate so it cannot start at counter zero concurrently
+	// with DrainBackground's Wait (a WaitGroup misuse panic), and so a
+	// prune requested after the drain is refused instead of escaping it
+	// to write through a store that is about to close.
+	s.backgroundMaintenanceMu.Lock()
+	if s.backgroundMaintenanceDrained {
+		s.backgroundMaintenanceMu.Unlock()
+		s.analysisPruneScheduled.Store(false)
+		return
+	}
+	s.backgroundMaintenance.Add(1)
+	s.backgroundMaintenanceMu.Unlock()
 	go func() {
+		defer s.backgroundMaintenance.Done()
 		defer s.analysisPruneScheduled.Store(false)
 		runtimeactivity.Begin("analysis_generation_gc")
 		defer runtimeactivity.End("analysis_generation_gc")
@@ -345,6 +358,23 @@ func (s *Server) scheduleAnalysisGenerationPrune(writer graph.AnalysisGeneration
 			s.logger.Warn("mcp: analysis generation prune failed", zap.Error(err))
 		}
 	}()
+}
+
+// DrainBackground waits for any in-flight analysis-generation prune and
+// permanently refuses to schedule new ones. Call it before closing the backend
+// store: the prune keeps writing on its already-acquired connection after
+// sql.DB.Close, and a commit there recreates WAL files under a directory being
+// torn down (a test TempDir, an uninstall). The wait ends once the prune's
+// 30s context expires between chunks, though an in-flight chunk can first
+// queue behind the store's writer gate. It does not quiesce RunAnalysis
+// itself: a pass still running on a detached caller (on-demand ensureAnalysis,
+// the track_repository worker) keeps writing generations through the store,
+// and stopping those is the caller's lifecycle problem, not this drain's.
+func (s *Server) DrainBackground() {
+	s.backgroundMaintenanceMu.Lock()
+	s.backgroundMaintenanceDrained = true
+	s.backgroundMaintenanceMu.Unlock()
+	s.backgroundMaintenance.Wait()
 }
 
 func restoreAdjacencyBlob(payload []byte) (*analysis.AdjacencySnapshot, error) {

--- a/internal/mcp/bundle_cache_wiring_test.go
+++ b/internal/mcp/bundle_cache_wiring_test.go
@@ -40,6 +40,11 @@ func TestRunAnalysis_FeedsBundleFingerprintsToSQLiteBackend(t *testing.T) {
 
 	eng := query.NewEngine(s)
 	srv := NewServer(eng, s, nil, nil, zap.NewNop(), nil)
+	// Registered after the store's Close cleanup so it runs first: the
+	// analysis-generation prune RunAnalysis spawns must finish before the
+	// store closes and the TempDir is removed, or its WAL commit recreates
+	// files under the directory mid-RemoveAll.
+	t.Cleanup(srv.DrainBackground)
 
 	// RunAnalysis must reach backendStore() == the sqlite store and feed
 	// it fingerprints. After it, a query populates the cache; a graph

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -230,8 +230,18 @@ type Server struct {
 	analysisGeneration      graph.AnalysisGenerationHeader
 	analysisGenerationReady bool
 	analysisPruneScheduled  atomic.Bool
-	analysisMaterializeMu   sync.Mutex
-	analysisMu              sync.RWMutex
+	// backgroundMaintenance joins the detached analysis-generation prune
+	// goroutine. Anyone closing the backend store must DrainBackground
+	// first: an in-flight prune batch survives sql.DB.Close on its pinned
+	// connection and its next WAL commit recreates store files
+	// mid-teardown. Add is gated by the mutex + drained flag so it never
+	// races DrainBackground's Wait, and a prune requested after the drain
+	// is dropped rather than run against a closing store.
+	backgroundMaintenance        sync.WaitGroup
+	backgroundMaintenanceMu      sync.Mutex
+	backgroundMaintenanceDrained bool
+	analysisMaterializeMu        sync.Mutex
+	analysisMu                   sync.RWMutex
 
 	// cochange caches the git-history co-change graph. cochangeByFile
 	// maps a file path to its co-changing file paths and association

--- a/internal/serverstack/shared_server.go
+++ b/internal/serverstack/shared_server.go
@@ -589,6 +589,10 @@ func NewSharedServer(cfg SharedServerConfig) (*SharedServer, error) {
 
 	gortexmcp.Version = cfg.Version
 	srv := gortexmcp.NewServer(eng, g, idx, nil, logger, conf.Guards.Rules, multiOpts...)
+	// Appended after backendCleanup so LIFO teardown drains the server's
+	// detached store-writing goroutines (analysis-generation prune) before
+	// the backend store closes underneath them.
+	s.cleanup = append(s.cleanup, srv.DrainBackground)
 	srv.SetArchitecture(conf.Architecture)
 	srv.SetEventRules(conf.Events.Rules)
 	srv.SetArtifacts(conf.Artifacts)


### PR DESCRIPTION
## Problem

`test (macos-latest, 1.26)` on main failed in `internal/mcp`:

```
--- FAIL: TestRunAnalysis_FeedsBundleFingerprintsToSQLiteBackend (0.83s)
    testing.go:1464: TempDir RemoveAll cleanup: unlinkat .../001: directory not empty
```

The test's assertions all passed — the failure is the temp-dir teardown. `RunAnalysis` defers `scheduleAnalysisGenerationPrune`, which detaches a goroutine running `PruneAnalysisGenerations` (batched DELETEs) against the backend sqlite store. Nothing joins that goroutine. `sql.DB.Close` does not wait for in-use connections, so after the test's `s.Close()` cleanup the prune's already-acquired connection kept committing, recreating `-wal`/`-shm` files inside the `t.TempDir()` while the harness was deleting it. A flake: any run of this test can hit it, macOS runners just have the timing.

## Fix

- Track the prune goroutine on a `Server` WaitGroup and add `Server.DrainBackground()`, which waits for an in-flight prune and permanently refuses new ones. The `Add` is gated by a mutex + drained flag, so it can never start at counter zero concurrently with the drain's `Wait` (a WaitGroup-misuse panic), and a prune requested after the drain is dropped instead of escaping into a closing store.
- The wiring test registers `t.Cleanup(srv.DrainBackground)` after `NewServer`, so LIFO cleanup runs drain → store close → TempDir removal.
- `SharedServer` appends the drain to its cleanup chain right after server construction, so daemon teardown also drains before the backend close.

## Known remaining class (intentionally out of scope)

Detached `RunAnalysis` callers (the on-demand pass in `analysis_ondemand.go`, the `track_repository` worker in `tools_multi.go`) and the co-change miner still write through the store with nothing joining them at teardown, and supervisor/signal shutdown paths never run the cleanup chain at all. Closing that needs a real lifecycle (context cancellation + join) for those callers; recorded as a development memory anchored to `Server.DrainBackground`.

## Verification

- `go test -race -run TestRunAnalysis_FeedsBundleFingerprintsToSQLiteBackend -count=100 ./internal/mcp/` — ok (and ×30 after the gate hardening)
- `go test -race ./internal/mcp/ ./internal/serverstack/` — ok
- `golangci-lint run internal/mcp/... internal/serverstack/...` — no issues