### PR TITLE
fix(analyze): let the handler decide repo visibility for a route row

### DIFF
--- a/internal/mcp/tools_analyze_framework.go
+++ b/internal/mcp/tools_analyze_framework.go
@@ -67,17 +67,29 @@ func (s *Server) handleAnalyzeRoutes(ctx context.Context, req mcp.CallToolReques
 		})
 	}
 	// routes reads EdgeHandlesRoute directly off s.graph; narrow each row to
-	// the session workspace + optional repo allow-set. Keep a row only when
-	// BOTH endpoints — the handler (e.From) and the route contract (e.To) —
-	// are visible. Unbound sessions see every row (analyzeNodeVisible passes),
-	// so this is a strict no-op there. total recomputes after this block.
+	// the session workspace + optional repo allow-set. Unbound sessions see
+	// every row, so this is a strict no-op there. total recomputes after this
+	// block.
+	//
+	// The repo decision comes from the handler alone. A route contract is keyed
+	// by method+path with no repo prefix, so a single node is shared by every
+	// repo that handles the same route and carries exactly one repo's prefix.
+	// Requiring that shared node to satisfy the repo allow-set dropped every row
+	// for all but its owning repo — a scoped query returned 0 while the same
+	// rows were plainly present unscoped, and analyze contracts accepted the
+	// identical repo value. The handler endpoint is unambiguously attributed, so
+	// it decides. The contract is still held to the session workspace ceiling.
 	if s.scopeFiltersActive(ctx) {
 		kept := make([]*routeRow, 0, len(rows))
 		for _, r := range rows {
-			if s.analyzeNodeVisible(ctx, s.graph.GetNode(r.Handler)) &&
-				s.analyzeNodeVisible(ctx, s.graph.GetNode(r.Route)) {
-				kept = append(kept, r)
+			if !s.analyzeNodeVisible(ctx, s.graph.GetNode(r.Handler)) {
+				continue
 			}
+			route := s.graph.GetNode(r.Route)
+			if route == nil || !s.nodeInSessionScope(ctx, route) {
+				continue
+			}
+			kept = append(kept, r)
 		}
 		rows = kept
 	}

--- a/internal/mcp/tools_analyze_framework_test.go
+++ b/internal/mcp/tools_analyze_framework_test.go
@@ -307,3 +307,50 @@ func TestAnalyzeDbtModels_FilterByType(t *testing.T) {
 		t.Fatalf("expected 1 source row, got %d", len(rows))
 	}
 }
+
+// A route contract node is keyed by method+path with no repo prefix, so one
+// node is shared by every repo that handles the same route. Narrowing to a repo
+// that is not the shared node's owner must still return that repo's rows: the
+// repo decision belongs to the handler, which is unambiguously attributed.
+func TestAnalyzeRoutes_RepoNarrowKeepsRowsWhenContractNodeIsSharedAcrossRepos(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	// The shared contract node carries exactly one repo prefix.
+	srv.graph.AddNode(&graph.Node{
+		ID: "http::GET::/alpha", Kind: graph.KindContract, Name: "http::GET::/alpha",
+		Language: "contract", RepoPrefix: "repo-b",
+		Meta: map[string]any{"type": "http", "role": "provider", "method": "GET", "path": "/alpha"},
+	})
+	for _, repo := range []string{"repo-a", "repo-b"} {
+		srv.graph.AddNode(&graph.Node{
+			ID: repo + "/main.go::alphaHandler", Kind: graph.KindFunction,
+			Name: "alphaHandler", Language: "go", RepoPrefix: repo,
+		})
+		addHandlesRouteEdge(srv.graph, repo+"/main.go::alphaHandler", "http::GET::/alpha", repo+"/main.go", 7)
+	}
+
+	for _, repo := range []string{"repo-a", "repo-b"} {
+		t.Run(repo, func(t *testing.T) {
+			ctx := withRepoAllow(context.Background(), map[string]bool{repo: true})
+			req := mcplib.CallToolRequest{}
+			req.Params.Name = "analyze"
+			req.Params.Arguments = map[string]any{"kind": "routes"}
+			res, err := srv.handleAnalyzeRoutes(ctx, req)
+			if err != nil {
+				t.Fatalf("handleAnalyzeRoutes: %v", err)
+			}
+			var out map[string]any
+			if err := json.Unmarshal([]byte(res.Content[0].(mcplib.TextContent).Text), &out); err != nil {
+				t.Fatalf("json: %v", err)
+			}
+			rows, _ := out["routes"].([]any)
+			if len(rows) != 1 {
+				t.Fatalf("repo %q: got %d rows, want 1 — the shared contract node must not decide repo visibility; out=%v", repo, len(rows), out)
+			}
+			got := rows[0].(map[string]any)["handler"].(string)
+			if want := repo + "/main.go::alphaHandler"; got != want {
+				t.Fatalf("repo %q: handler = %q, want %q", repo, got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #506.

## What was broken

`analyze(kind:"routes", options:{repo:X})` returned **0 rows** for a repo whose routes were plainly present in the unscoped result — while the same filter worked for its sibling repo, and while `analyze(kind:"contracts")` accepted the **identical** repo value and returned rows.

## Cause

A route contract is keyed by method+path with **no repo prefix**, so one node is shared by every repo handling the same route and carries exactly one repo's prefix:

```
handler=repo-a/main.go::alphaHandler          route=http::GET::/alpha
handler=repo-a-suffix/main.go::alphaHandler   route=http::GET::/alpha   <- same node
```

`handleAnalyzeRoutes` kept a row only when **both** endpoints passed `analyzeNodeVisible`, so that shared node's single prefix decided visibility for every repo pointing at it. Narrowing to any repo other than the node's owner dropped all of that repo's rows.

That is also why `contracts` was unaffected — it never asks a shared node to answer a repo question.

## Fix

The handler endpoint is unambiguously attributed, so it decides the repo question alone. The contract endpoint is still held to the session workspace ceiling via `nodeInSessionScope`, so the **workspace** boundary is unchanged — only the repo allow-set stops being applied to a node that cannot express repo identity.

Unscoped calls are untouched: `scopeFiltersActive` still gates the whole block.

## Repro

A repo plus a linked worktree sharing one workspace, three routes each:

| call | before | after |
|---|---|---|
| `routes` unscoped | 6 rows (both repos) | 6 |
| `routes repo=repo-a` | **0** | **3** |
| `routes repo=repo-a-suffix` | 3 | 3 |

Also confirmed on a real 2-repo / ~250k-node workspace, where the scoped call returned 0 against 152 rows present unscoped.

## Test

`TestAnalyzeRoutes_RepoNarrowKeepsRowsWhenContractNodeIsSharedAcrossRepos` builds two repo-prefixed handlers pointing at one shared contract node owned by one of them, then narrows to **each** repo in turn. Before the change it fails for the non-owning repo and passes for the owner — the asymmetry is the bug, so asserting both directions is what pins it.

## Test run

`go test ./internal/mcp` is clean apart from `TestWriteFile_InRepoSymlinkEscapeRefused`, which fails identically on an unmodified tree in this environment (Windows symlink privilege, `A required privilege is not held by the client`). I verified that by stashing the change and re-running that test alone.