### PR TITLE
fix(test): isolate the real user home on every platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,15 @@ jobs:
       - name: Test sidecar handle release
         run: go test -timeout=5m -count=1 -run TestCloseSidecar ./internal/persistence
 
+      # os.UserHomeDir reads %USERPROFILE% here and $HOME everywhere else, so
+      # a test that isolates itself with HOME alone keeps resolving the real
+      # profile on Windows — and writes to it. That is invisible to the
+      # linux/macos matrix by construction, so the isolation helper and the
+      # path resolver it protects have to be verified on this runner or not
+      # at all.
+      - name: Test user-state isolation
+        run: go test -timeout=5m -count=1 ./internal/testenv ./internal/platform
+
   build-linux-static:
     # The linux release ships a statically linked binary so it runs on any
     # distro (see .goreleaser.yml). That only holds while the code stays

--- a/cmd/gortex/daemon_supervisor_test.go
+++ b/cmd/gortex/daemon_supervisor_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/zzet/gortex/internal/daemon"
+	"github.com/zzet/gortex/internal/testenv"
 )
 
 func restoreServiceSeams() {
@@ -59,9 +60,7 @@ func TestRunDaemonRestart_SupervisedRoutesToServiceRestart(t *testing.T) {
 func TestDefaultServiceActive_NoUnitFileIsInactive(t *testing.T) {
 	// Point HOME (and cache) at an empty dir so no unit file exists; detection
 	// must short-circuit to false without shelling out to the supervisor.
-	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
-	t.Setenv("XDG_CACHE_HOME", tmp)
+	testenv.Sandbox(t)
 	if defaultServiceActive() {
 		t.Fatal("no installed unit file => service must be reported inactive")
 	}

--- a/cmd/gortex/init_integration_test.go
+++ b/cmd/gortex/init_integration_test.go
@@ -11,6 +11,7 @@ import (
 	toml "github.com/pelletier/go-toml/v2"
 
 	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/testenv"
 )
 
 func TestInitSummaryDoesNotRequireManualMCPEnablement(t *testing.T) {
@@ -48,7 +49,7 @@ func TestInitDryRunJSONReportShape(t *testing.T) {
 
 	repo := t.TempDir()
 	home := t.TempDir()
-	isolateInitTestEnv(t, home)
+	testenv.SandboxAt(t, home)
 
 	initYes = true
 	initDryRun = true
@@ -119,7 +120,7 @@ func TestInitAgentsFilterRejectsUnknownName(t *testing.T) {
 	})
 
 	repo := t.TempDir()
-	isolateInitTestEnv(t, t.TempDir())
+	testenv.SandboxAt(t, t.TempDir())
 
 	initYes = true
 	initDryRun = true
@@ -169,7 +170,7 @@ func TestInitCreatesProjectMarker(t *testing.T) {
 	t.Setenv("GORTEX_DAEMON_SNAPSHOT", filepath.Join(inheritedDaemon, "daemon.gob.gz"))
 
 	repo := t.TempDir()
-	isolateInitTestEnv(t, t.TempDir())
+	testenv.SandboxAt(t, t.TempDir())
 
 	initYes = true
 	initDryRun = false
@@ -227,7 +228,7 @@ func TestInitDryRunSkipsProjectMarker(t *testing.T) {
 	})
 
 	repo := t.TempDir()
-	isolateInitTestEnv(t, t.TempDir())
+	testenv.SandboxAt(t, t.TempDir())
 
 	initYes = true
 	initDryRun = true
@@ -266,7 +267,7 @@ func TestInitRefusesHomeDirectory(t *testing.T) {
 	})
 
 	home := t.TempDir()
-	isolateInitTestEnv(t, home)
+	testenv.SandboxAt(t, home)
 
 	initYes = true
 	initDryRun = false
@@ -308,7 +309,7 @@ func TestInitForceBypassesHomeDirectoryGuard(t *testing.T) {
 	})
 
 	home := t.TempDir()
-	isolateInitTestEnv(t, home)
+	testenv.SandboxAt(t, home)
 
 	initYes = true
 	initDryRun = true // planning-only: keeps the forced run from writing into $HOME during the test
@@ -335,7 +336,7 @@ func TestInitHooksOnlyRefreshesClaudeAndCodexHooks(t *testing.T) {
 
 	repo := t.TempDir()
 	home := t.TempDir()
-	isolateInitTestEnv(t, home)
+	testenv.SandboxAt(t, home)
 
 	codexDir := filepath.Join(home, ".codex")
 	if err := os.MkdirAll(codexDir, 0o755); err != nil {
@@ -411,7 +412,7 @@ func TestInitHooksOnlyRespectsAgentsAllowlist(t *testing.T) {
 
 	repo := t.TempDir()
 	home := t.TempDir()
-	isolateInitTestEnv(t, home)
+	testenv.SandboxAt(t, home)
 	if err := os.MkdirAll(filepath.Join(home, ".codex"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -448,7 +449,7 @@ func TestInitHooksOnlyRespectsAgentsSkip(t *testing.T) {
 
 	repo := t.TempDir()
 	home := t.TempDir()
-	isolateInitTestEnv(t, home)
+	testenv.SandboxAt(t, home)
 	codexDir := filepath.Join(home, ".codex")
 	if err := os.MkdirAll(codexDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -499,7 +500,7 @@ func TestInitHooksOnlyDryRunDoesNotWriteHooks(t *testing.T) {
 
 	repo := t.TempDir()
 	home := t.TempDir()
-	isolateInitTestEnv(t, home)
+	testenv.SandboxAt(t, home)
 	if err := os.MkdirAll(filepath.Join(home, ".codex"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -545,7 +546,7 @@ func TestInitDryRunIntakeJSONDoesNotWrite(t *testing.T) {
 	})
 
 	repo := t.TempDir()
-	isolateInitTestEnv(t, t.TempDir())
+	testenv.SandboxAt(t, t.TempDir())
 	if err := os.WriteFile(filepath.Join(repo, "main.go"), []byte("package main\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -584,22 +585,6 @@ func TestInitDryRunIntakeJSONDoesNotWrite(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(repo, ".gortex")); err == nil {
 		t.Fatal("dry-run-intake wrote .gortex/ — must be inspection-only")
 	}
-}
-
-// isolateInitTestEnv prevents inherited machine state from escaping the test sandbox.
-func isolateInitTestEnv(t *testing.T, home string) {
-	t.Helper()
-
-	root := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(root, "config"))
-	t.Setenv("XDG_DATA_HOME", filepath.Join(root, "data"))
-	t.Setenv("XDG_CACHE_HOME", filepath.Join(root, "cache"))
-	t.Setenv("XDG_RUNTIME_DIR", filepath.Join(root, "runtime"))
-	t.Setenv("GORTEX_DAEMON_SOCKET", filepath.Join(root, "daemon.sock"))
-	t.Setenv("GORTEX_DAEMON_PIDFILE", filepath.Join(root, "daemon.pid"))
-	t.Setenv("GORTEX_DAEMON_LOGFILE", filepath.Join(root, "daemon.log"))
-	t.Setenv("GORTEX_DAEMON_SNAPSHOT", filepath.Join(root, "daemon.gob.gz"))
 }
 
 func saveInitGlobals(t *testing.T) func() {

--- a/cmd/gortex/instructions_test.go
+++ b/cmd/gortex/instructions_test.go
@@ -10,19 +10,21 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/zzet/gortex/internal/profiles"
+	"github.com/zzet/gortex/internal/testenv"
 )
 
 // sandboxInstructionsEnv points the profile dir (XDG_DATA_HOME) and the
-// home dir (skills sync, pointer nudge) at temp dirs, and neutralises
-// the profile env override so on-disk state decides.
+// home dir at temp dirs, and neutralises the profile env override so
+// on-disk state decides. The home has to be isolated the cross-platform
+// way: runInstructionsSwitch hands os.UserHomeDir() to SyncGlobalSkills,
+// which prunes shipped skills out of <home>/.claude/skills — against the
+// developer's real profile on Windows, where a HOME-only override is a
+// no-op.
 func sandboxInstructionsEnv(t *testing.T) (home, dataDir string) {
 	t.Helper()
-	home = t.TempDir()
-	dataDir = t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_DATA_HOME", dataDir)
+	d := testenv.Sandbox(t)
 	t.Setenv(profiles.ActiveEnv, "")
-	return home, dataDir
+	return d.Home, d.Data
 }
 
 func captureCmd() (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {

--- a/cmd/gortex/main_test.go
+++ b/cmd/gortex/main_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/platform"
+	"github.com/zzet/gortex/internal/testenv"
+)
+
+// TestMain gives the whole package a sandboxed per-user environment, and
+// then proves the developer's real one came through the run untouched.
+//
+// Both halves earn their keep. Individual tests do isolate themselves,
+// but the isolation was easy to get wrong in a way no CI job could see:
+// t.Setenv("HOME", dir) does not move os.UserHomeDir on Windows, so
+// tests that looked isolated on the linux and macos matrix were
+// appending their temp directories to the real config.yaml as tracked
+// repos, merging hooks into the real ~/.codex/config.toml, and pruning
+// shipped skills out of the real ~/.claude/skills. The package-wide
+// sandbox makes forgetting harmless; the fingerprint check catches
+// anything that reaches the real home by a route the sandbox misses.
+func TestMain(m *testing.M) {
+	before := map[string]string{}
+	for _, p := range realUserStatePaths() {
+		before[p] = fingerprint(p)
+	}
+
+	restore, err := testenv.SandboxProcess()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cmd/gortex: cannot sandbox the test environment: %v\n", err)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+	restore()
+
+	if report := diffUserState(before); report != "" {
+		fmt.Fprint(os.Stderr, report)
+		if code == 0 {
+			code = 1
+		}
+	}
+	os.Exit(code)
+}
+
+// realUserStatePaths lists the per-user files this package has been
+// caught writing through to, resolved against the ambient environment
+// before the sandbox is installed. The paths are captured rather than
+// re-resolved afterwards, so the check does not depend on the
+// environment having been restored correctly.
+func realUserStatePaths() []string {
+	paths := []string{
+		config.DefaultGlobalConfigPath(),
+		filepath.Join(platform.ConfigDir(), "servers.toml"),
+		filepath.Join(platform.CacheDir(), "query-log.jsonl"),
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		paths = append(paths,
+			filepath.Join(home, ".codex", "config.toml"),
+			filepath.Join(home, ".codex", "AGENTS.md"),
+			filepath.Join(home, ".claude", "settings.json"),
+			filepath.Join(home, ".claude", "CLAUDE.md"),
+			filepath.Join(home, ".claude", "skills"),
+		)
+	}
+	return paths
+}
+
+// diffUserState re-fingerprints every captured path and describes what
+// moved, or returns "" when the real state is intact.
+func diffUserState(before map[string]string) string {
+	var changed []string
+	for p, was := range before {
+		if now := fingerprint(p); now != was {
+			changed = append(changed, fmt.Sprintf("  %s (%s -> %s)", p, was, now))
+		}
+	}
+	if len(changed) == 0 {
+		return ""
+	}
+	sort.Strings(changed)
+	return fmt.Sprintf(
+		"\ncmd/gortex: a test wrote through to the developer's real per-user state:\n%s\n\n"+
+			"Isolate the test with internal/testenv (Sandbox / SandboxAt / UnifiedHome / SetHome)\n"+
+			"instead of t.Setenv(\"HOME\", ...), which does not move os.UserHomeDir on Windows.\n"+
+			"If a gortex daemon was running and tracked a repository during this run, that is a\n"+
+			"false positive — re-run with the daemon stopped to confirm.\n",
+		strings.Join(changed, "\n"))
+}
+
+// fingerprint reduces a path to a value that changes whenever its
+// contents do. A directory is fingerprinted by its entry names, which is
+// enough to catch a prune of ~/.claude/skills without walking a tree of
+// unknown size.
+func fingerprint(path string) string {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "absent"
+	}
+	if info.IsDir() {
+		entries, err := os.ReadDir(path)
+		if err != nil {
+			return "unreadable"
+		}
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		sort.Strings(names)
+		return shortHash([]byte(strings.Join(names, "\n")))
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "unreadable"
+	}
+	return shortHash(data)
+}
+
+func shortHash(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:8])
+}

--- a/cmd/gortex/proxy_test.go
+++ b/cmd/gortex/proxy_test.go
@@ -8,6 +8,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/zzet/gortex/internal/testenv"
 )
 
 // TestResolveLaunchCWDFallsBackFromHome exercises the gortexhq/gortex#19
@@ -29,7 +31,7 @@ func TestResolveLaunchCWDFallsBackFromHome(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Setenv("HOME", fakeHome)
+	testenv.SetHome(t, fakeHome)
 	t.Setenv("PWD", "") // clear so we exercise the editor-env path
 	t.Setenv("CURSOR_WORKSPACE", project)
 	t.Setenv("CLAUDE_CODE_WORKSPACE", "")

--- a/cmd/gortex/uninstall_purge_test.go
+++ b/cmd/gortex/uninstall_purge_test.go
@@ -8,18 +8,16 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/testenv"
 )
 
 // TestComputePurgePlanCollectsExistingDataDirs proves --purge targets the
 // unified ~/.gortex tree when it exists, de-duplicated across the
 // config/data/cache/home categories that collapse to it.
 func TestComputePurgePlanCollectsExistingDataDirs(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	// Neutralise XDG overrides so the categories collapse into ~/.gortex.
-	t.Setenv("XDG_CONFIG_HOME", "")
-	t.Setenv("XDG_DATA_HOME", "")
-	t.Setenv("XDG_CACHE_HOME", "")
+	// UnifiedHome clears the XDG overrides so the categories collapse into ~/.gortex.
+	home := testenv.UnifiedHome(t)
 
 	gortexHome := filepath.Join(home, ".gortex")
 	require.NoError(t, os.MkdirAll(filepath.Join(gortexHome, "cache"), 0o755))
@@ -37,11 +35,7 @@ func TestComputePurgePlanCollectsExistingDataDirs(t *testing.T) {
 // TestComputePurgePlanEmptyWhenNothingInstalled asserts a clean host yields no
 // data dirs to remove.
 func TestComputePurgePlanEmptyWhenNothingInstalled(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", "")
-	t.Setenv("XDG_DATA_HOME", "")
-	t.Setenv("XDG_CACHE_HOME", "")
+	testenv.UnifiedHome(t)
 
 	p := computePurgePlan()
 	assert.Empty(t, p.dirs)

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 	"pgregory.net/rapid"
+
+	"github.com/zzet/gortex/internal/testenv"
 )
 
 // TestDefaultGlobalConfigPath_HonorsHomeChange guards the regression
@@ -26,7 +28,7 @@ func TestDefaultGlobalConfigPath_HonorsHomeChange(t *testing.T) {
 	// this test asserts.
 	t.Setenv("XDG_CONFIG_HOME", "")
 	homeA := t.TempDir()
-	t.Setenv("HOME", homeA)
+	testenv.SetHome(t, homeA)
 	gotA := DefaultGlobalConfigPath()
 	wantA := filepath.Join(homeA, ".gortex", "config.yaml")
 	if gotA != wantA {
@@ -34,7 +36,7 @@ func TestDefaultGlobalConfigPath_HonorsHomeChange(t *testing.T) {
 	}
 
 	homeB := t.TempDir()
-	t.Setenv("HOME", homeB)
+	testenv.SetHome(t, homeB)
 	gotB := DefaultGlobalConfigPath()
 	wantB := filepath.Join(homeB, ".gortex", "config.yaml")
 	if gotB != wantB {
@@ -48,7 +50,7 @@ func TestDefaultGlobalConfigPath_HonorsHomeChange(t *testing.T) {
 // unified $HOME/.gortex location.
 func TestDefaultGlobalConfigPath_HonorsXDGConfigHome(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	testenv.SetHome(t, home)
 
 	// Unset: historical default.
 	t.Setenv("XDG_CONFIG_HOME", "")

--- a/internal/hooks/localization_terminal_test.go
+++ b/internal/hooks/localization_terminal_test.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/zzet/gortex/internal/testenv"
 )
 
 func TestObserveLocalizationTerminalAcceptsDirectAndPluginNavigationFacades(t *testing.T) {
@@ -1007,9 +1009,7 @@ func mustJSON(t *testing.T, value any) []byte {
 
 func configureLocalizationTerminalTestHome(t *testing.T) {
 	t.Helper()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_CACHE_HOME", home)
+	testenv.Sandbox(t)
 }
 
 func captureHookStdout(t *testing.T, fn func()) string {

--- a/internal/platform/migrate_test.go
+++ b/internal/platform/migrate_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/zzet/gortex/internal/testenv"
 )
 
 func seed(t *testing.T, path, content string) {
@@ -20,9 +22,7 @@ func seed(t *testing.T, path, content string) {
 // unified ~/.gortex tree, the stale socket is left behind, and a second
 // run is a no-op that doesn't clobber.
 func TestMigrateToUnifiedHome(t *testing.T) {
-	clearXDG(t)
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testenv.UnifiedHome(t)
 
 	seed(t, filepath.Join(home, ".config", "gortex", "config.yaml"), "cfg")
 	seed(t, filepath.Join(home, ".cache", "gortex", "daemon-sqlite.gob.gz"), "snap")
@@ -72,9 +72,7 @@ func TestMigrateToUnifiedHome(t *testing.T) {
 // TestMigrateToUnifiedHome_SkipsUnderXDG verifies an explicit XDG opt-in
 // makes migration a no-op — the user chose the XDG layout.
 func TestMigrateToUnifiedHome_SkipsUnderXDG(t *testing.T) {
-	clearXDG(t)
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testenv.UnifiedHome(t)
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
 	old := filepath.Join(home, ".config", "gortex", "config.yaml")

--- a/internal/platform/xdg_test.go
+++ b/internal/platform/xdg_test.go
@@ -3,23 +3,13 @@ package platform
 import (
 	"path/filepath"
 	"testing"
-)
 
-// clearXDG unsets every XDG base-directory variable so a test starts
-// from a known clean slate; t.Setenv restores the prior value at the
-// end of the test.
-func clearXDG(t *testing.T) {
-	t.Helper()
-	for _, v := range []string{"XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_CACHE_HOME"} {
-		t.Setenv(v, "")
-	}
-}
+	"github.com/zzet/gortex/internal/testenv"
+)
 
 // TestHome verifies the unified per-user directory is $HOME/.gortex.
 func TestHome(t *testing.T) {
-	clearXDG(t)
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testenv.UnifiedHome(t)
 
 	if got, want := Home(), filepath.Join(home, ".gortex"); got != want {
 		t.Errorf("Home() = %s, want %s", got, want)
@@ -29,7 +19,7 @@ func TestHome(t *testing.T) {
 // TestConfigDir_HonorsXDGConfigHome verifies an absolute $XDG_CONFIG_HOME
 // relocates config to the standard XDG location.
 func TestConfigDir_HonorsXDGConfigHome(t *testing.T) {
-	clearXDG(t)
+	testenv.UnifiedHome(t)
 	xdg := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", xdg)
 
@@ -42,9 +32,7 @@ func TestConfigDir_HonorsXDGConfigHome(t *testing.T) {
 // TestConfigDir_UnsetFallback verifies the env-unset default is the
 // unified $HOME/.gortex directory.
 func TestConfigDir_UnsetFallback(t *testing.T) {
-	clearXDG(t)
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testenv.UnifiedHome(t)
 
 	want := filepath.Join(home, ".gortex")
 	if got := ConfigDir(); got != want {
@@ -55,7 +43,7 @@ func TestConfigDir_UnsetFallback(t *testing.T) {
 // TestDataDir_HonorsXDGDataHome verifies an absolute $XDG_DATA_HOME
 // relocates data to the standard XDG location.
 func TestDataDir_HonorsXDGDataHome(t *testing.T) {
-	clearXDG(t)
+	testenv.UnifiedHome(t)
 	xdg := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", xdg)
 
@@ -68,9 +56,7 @@ func TestDataDir_HonorsXDGDataHome(t *testing.T) {
 // TestDataDir_UnsetFallback verifies the env-unset default collapses
 // into the unified $HOME/.gortex directory.
 func TestDataDir_UnsetFallback(t *testing.T) {
-	clearXDG(t)
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testenv.UnifiedHome(t)
 
 	want := filepath.Join(home, ".gortex")
 	if got := DataDir(); got != want {
@@ -81,9 +67,7 @@ func TestDataDir_UnsetFallback(t *testing.T) {
 // TestTelemetryDir verifies the telemetry buffer lives under DataDir, both for
 // the unified default and an absolute $XDG_DATA_HOME relocation.
 func TestTelemetryDir(t *testing.T) {
-	clearXDG(t)
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testenv.UnifiedHome(t)
 	if got, want := TelemetryDir(), filepath.Join(home, ".gortex", "telemetry"); got != want {
 		t.Errorf("TelemetryDir() = %s, want %s (unified default)", got, want)
 	}
@@ -98,7 +82,7 @@ func TestTelemetryDir(t *testing.T) {
 // TestCacheDir_HonorsXDGCacheHome verifies an absolute $XDG_CACHE_HOME
 // relocates cache to the standard XDG location.
 func TestCacheDir_HonorsXDGCacheHome(t *testing.T) {
-	clearXDG(t)
+	testenv.UnifiedHome(t)
 	xdg := t.TempDir()
 	t.Setenv("XDG_CACHE_HOME", xdg)
 
@@ -111,9 +95,7 @@ func TestCacheDir_HonorsXDGCacheHome(t *testing.T) {
 // TestCacheDir_UnsetFallback verifies the env-unset default is the
 // cache/ sub-directory inside the unified ~/.gortex tree.
 func TestCacheDir_UnsetFallback(t *testing.T) {
-	clearXDG(t)
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testenv.UnifiedHome(t)
 
 	want := filepath.Join(home, ".gortex", "cache")
 	if got := CacheDir(); got != want {
@@ -125,9 +107,7 @@ func TestCacheDir_UnsetFallback(t *testing.T) {
 // to the same place as CacheDir under both an XDG override and the
 // unified default.
 func TestOSCacheDir_ConvergesWithCacheDir(t *testing.T) {
-	clearXDG(t)
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testenv.UnifiedHome(t)
 	if got, want := OSCacheDir(), CacheDir(); got != want {
 		t.Errorf("OSCacheDir() = %s, want %s (must converge with CacheDir)", got, want)
 	}
@@ -145,9 +125,7 @@ func TestOSCacheDir_ConvergesWithCacheDir(t *testing.T) {
 // TestPurposeDirs_UnsetFallback verifies the store / models / memories
 // sub-directories hang off the unified ~/.gortex tree by default.
 func TestPurposeDirs_UnsetFallback(t *testing.T) {
-	clearXDG(t)
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testenv.UnifiedHome(t)
 
 	cases := []struct {
 		name string
@@ -168,7 +146,7 @@ func TestPurposeDirs_UnsetFallback(t *testing.T) {
 // TestPurposeDirs_HonorXDGDataHome verifies the purpose sub-directories
 // follow an absolute $XDG_DATA_HOME into the standard XDG layout.
 func TestPurposeDirs_HonorXDGDataHome(t *testing.T) {
-	clearXDG(t)
+	testenv.UnifiedHome(t)
 	xdg := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", xdg)
 
@@ -192,9 +170,7 @@ func TestPurposeDirs_HonorXDGDataHome(t *testing.T) {
 // ignored, as the XDG Base Directory specification mandates — the
 // resolver falls back to the unified $HOME/.gortex default instead.
 func TestNonAbsoluteXDGIgnored(t *testing.T) {
-	clearXDG(t)
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testenv.UnifiedHome(t)
 
 	cases := []struct {
 		name   string

--- a/internal/testenv/testenv.go
+++ b/internal/testenv/testenv.go
@@ -1,0 +1,177 @@
+// Package testenv redirects the per-user state a test can reach — the
+// user home, the XDG base directories, and the daemon's runtime files —
+// into temporary directories, so no test reads or writes the developer's
+// real Gortex configuration.
+//
+// It exists because t.Setenv("HOME", dir) does not isolate a test on
+// every platform. os.UserHomeDir reads $HOME on Unix but %USERPROFILE%
+// on Windows, so a HOME-only override is a silent no-op there: the code
+// under test keeps resolving the developer's real home and writes
+// straight through to it. That asymmetry is invisible on the linux and
+// macos CI matrix, which is exactly why it survived — on Windows the
+// cmd/gortex suite was appending its temp directories to the real
+// config.yaml as tracked repos, merging hooks into the real
+// ~/.codex/config.toml, and deleting shipped skills out of the real
+// ~/.claude/skills tree.
+//
+// Every helper here sets both variables, plus the AppData pair that
+// os.UserConfigDir and os.UserCacheDir read on Windows, so whatever the
+// current platform considers "the user's home" lands inside the sandbox.
+package testenv
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// xdgVars is every XDG base-directory variable that can relocate Gortex
+// state. platform.unifiedDir honours an absolute value over the home
+// directory, so a test that wants the unified <home>/.gortex layout has
+// to clear all of them, not just the one it happens to care about.
+var xdgVars = []string{
+	"XDG_CONFIG_HOME",
+	"XDG_DATA_HOME",
+	"XDG_CACHE_HOME",
+	"XDG_STATE_HOME",
+	"XDG_RUNTIME_DIR",
+}
+
+// Dirs are the sandbox roots handed to a test by Sandbox and SandboxAt.
+type Dirs struct {
+	Home    string // $HOME and %USERPROFILE%
+	Config  string // $XDG_CONFIG_HOME
+	Data    string // $XDG_DATA_HOME
+	Cache   string // $XDG_CACHE_HOME
+	Runtime string // $XDG_RUNTIME_DIR
+}
+
+// homeEnv is every variable that has to move for the current platform to
+// stop resolving the developer's real home directory.
+func homeEnv(home string) map[string]string {
+	return map[string]string{
+		"HOME":        home, // Unix: os.UserHomeDir
+		"USERPROFILE": home, // Windows: os.UserHomeDir
+		// os.UserConfigDir and os.UserCacheDir read these two on
+		// Windows, where the XDG variables are ignored entirely.
+		"AppData":      filepath.Join(home, "AppData", "Roaming"),
+		"LocalAppData": filepath.Join(home, "AppData", "Local"),
+	}
+}
+
+// sandboxEnv is homeEnv plus every base directory and daemon runtime
+// path Gortex resolves, rooted at a scratch directory. Keeping the one
+// list here is the point of the package: a second copy is how a variable
+// gets forgotten and a suite starts writing through again.
+func sandboxEnv(d Dirs, root string) map[string]string {
+	env := homeEnv(d.Home)
+	env["XDG_CONFIG_HOME"] = d.Config
+	env["XDG_DATA_HOME"] = d.Data
+	env["XDG_CACHE_HOME"] = d.Cache
+	env["XDG_STATE_HOME"] = filepath.Join(root, "state")
+	env["XDG_RUNTIME_DIR"] = d.Runtime
+	// The daemon resolves each of these before falling back to the XDG
+	// cache directory, so redirecting the cache root is not enough.
+	env["GORTEX_DAEMON_SOCKET"] = filepath.Join(root, "daemon.sock")
+	env["GORTEX_DAEMON_PIDFILE"] = filepath.Join(root, "daemon.pid")
+	env["GORTEX_DAEMON_LOGFILE"] = filepath.Join(root, "daemon.log")
+	env["GORTEX_DAEMON_SNAPSHOT"] = filepath.Join(root, "daemon.gob.gz")
+	return env
+}
+
+// dirsUnder lays the sandbox roots out beneath a scratch directory.
+func dirsUnder(home, root string) Dirs {
+	return Dirs{
+		Home:    home,
+		Config:  filepath.Join(root, "config"),
+		Data:    filepath.Join(root, "data"),
+		Cache:   filepath.Join(root, "cache"),
+		Runtime: filepath.Join(root, "runtime"),
+	}
+}
+
+// SetHome points the current platform's user-home lookup at dir, so
+// os.UserHomeDir resolves there on Unix and on Windows alike. Use it
+// directly only when a test needs to move the home mid-run; otherwise
+// prefer UnifiedHome or Sandbox, which also handle the XDG variables.
+func SetHome(tb testing.TB, dir string) {
+	tb.Helper()
+	for k, v := range homeEnv(dir) {
+		tb.Setenv(k, v)
+	}
+}
+
+// UnifiedHome isolates the user home and clears every XDG override, so
+// path resolution collapses into the unified <home>/.gortex layout. Use
+// it for tests that assert that default layout; use Sandbox when the
+// test only needs the state to go somewhere harmless.
+func UnifiedHome(tb testing.TB) string {
+	tb.Helper()
+	home := tb.TempDir()
+	SetHome(tb, home)
+	for _, v := range xdgVars {
+		tb.Setenv(v, "")
+	}
+	return home
+}
+
+// Sandbox isolates the user home and points every XDG base directory
+// and daemon runtime file at a fresh temporary tree.
+func Sandbox(tb testing.TB) Dirs {
+	tb.Helper()
+	return SandboxAt(tb, tb.TempDir())
+}
+
+// SandboxAt is Sandbox with a caller-supplied home directory, for tests
+// that seed files into the home before running the code under test.
+func SandboxAt(tb testing.TB, home string) Dirs {
+	tb.Helper()
+	root := tb.TempDir()
+	d := dirsUnder(home, root)
+	for k, v := range sandboxEnv(d, root) {
+		tb.Setenv(k, v)
+	}
+	return d
+}
+
+// SandboxProcess isolates the whole process's per-user environment and
+// returns a function that restores it and removes the scratch tree. It
+// is the TestMain-time counterpart to Sandbox, for a package that wants
+// every one of its tests sandboxed by default rather than trusting each
+// to remember. A test that needs its own home can still override with
+// t.Setenv, which unwinds to this sandbox rather than to the real home.
+func SandboxProcess() (restore func(), err error) {
+	root, err := os.MkdirTemp("", "gortex-testenv")
+	if err != nil {
+		return nil, fmt.Errorf("create sandbox root: %w", err)
+	}
+	home := filepath.Join(root, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		_ = os.RemoveAll(root)
+		return nil, fmt.Errorf("create sandbox home: %w", err)
+	}
+
+	saved := map[string]*string{}
+	for k, v := range sandboxEnv(dirsUnder(home, root), root) {
+		if prev, ok := os.LookupEnv(k); ok {
+			saved[k] = &prev
+		} else {
+			saved[k] = nil
+		}
+		if err := os.Setenv(k, v); err != nil {
+			return nil, fmt.Errorf("set %s: %w", k, err)
+		}
+	}
+
+	return func() {
+		for k, prev := range saved {
+			if prev == nil {
+				_ = os.Unsetenv(k)
+				continue
+			}
+			_ = os.Setenv(k, *prev)
+		}
+		_ = os.RemoveAll(root)
+	}, nil
+}

--- a/internal/testenv/testenv_test.go
+++ b/internal/testenv/testenv_test.go
@@ -1,0 +1,133 @@
+package testenv
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestSetHomeRedirectsUserHomeDir is the regression guard for the bug
+// this package exists to prevent: t.Setenv("HOME", dir) alone leaves
+// os.UserHomeDir resolving the developer's real profile on Windows.
+// Asserting against os.UserHomeDir rather than against $HOME is what
+// makes this test meaningful on every platform — it checks the lookup
+// the production code actually performs, not the variable we happened
+// to set.
+func TestSetHomeRedirectsUserHomeDir(t *testing.T) {
+	dir := t.TempDir()
+	SetHome(t, dir)
+
+	got, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("os.UserHomeDir() after SetHome: %v", err)
+	}
+	if got != dir {
+		t.Fatalf("os.UserHomeDir() = %s, want %s — the sandbox does not cover %s", got, dir, runtime.GOOS)
+	}
+}
+
+// TestSandboxRedirectsEveryUserDirLookup pins all three stdlib user-dir
+// lookups, because Gortex resolves cache and config paths through
+// os.UserCacheDir in several packages as a fallback. On Windows those
+// two read %AppData% / %LocalAppData% and ignore the XDG variables, so
+// covering only XDG would leave them pointed at the real profile.
+//
+// It deliberately asserts exact sandbox paths instead of "not under the
+// real home": on GitHub's Windows runner TEMP itself lives under the
+// user profile, so a prefix check would be both wrong and green.
+func TestSandboxRedirectsEveryUserDirLookup(t *testing.T) {
+	d := Sandbox(t)
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("os.UserHomeDir(): %v", err)
+	}
+	if home != d.Home {
+		t.Errorf("os.UserHomeDir() = %s, want %s", home, d.Home)
+	}
+
+	// Each platform derives these two differently, and only the generic
+	// Unix branch consults XDG. Spelling the matrix out is the point of
+	// the test: it proves the sandbox covers the lookup this platform
+	// really performs, whichever root that turns out to be.
+	var wantConfig, wantCache string
+	switch runtime.GOOS {
+	case "windows":
+		wantConfig = filepath.Join(d.Home, "AppData", "Roaming")
+		wantCache = filepath.Join(d.Home, "AppData", "Local")
+	case "darwin", "ios":
+		wantConfig = filepath.Join(d.Home, "Library", "Application Support")
+		wantCache = filepath.Join(d.Home, "Library", "Caches")
+	default:
+		wantConfig = d.Config
+		wantCache = d.Cache
+	}
+
+	gotConfig, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatalf("os.UserConfigDir(): %v", err)
+	}
+	if gotConfig != wantConfig {
+		t.Errorf("os.UserConfigDir() = %s, want %s", gotConfig, wantConfig)
+	}
+
+	gotCache, err := os.UserCacheDir()
+	if err != nil {
+		t.Fatalf("os.UserCacheDir(): %v", err)
+	}
+	if gotCache != wantCache {
+		t.Errorf("os.UserCacheDir() = %s, want %s", gotCache, wantCache)
+	}
+}
+
+// TestUnifiedHomeCollapsesToHomeLayout proves the variant used by tests
+// that assert the default ~/.gortex layout both moves the home and
+// clears every XDG override — an inherited XDG_CONFIG_HOME on the
+// developer's machine would otherwise win over the temporary home.
+func TestUnifiedHomeCollapsesToHomeLayout(t *testing.T) {
+	for _, v := range xdgVars {
+		t.Setenv(v, filepath.Join(t.TempDir(), "inherited"))
+	}
+
+	home := UnifiedHome(t)
+
+	got, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("os.UserHomeDir(): %v", err)
+	}
+	if got != home {
+		t.Errorf("os.UserHomeDir() = %s, want %s", got, home)
+	}
+	for _, v := range xdgVars {
+		if val := os.Getenv(v); val != "" {
+			t.Errorf("%s = %q, want empty — an inherited override still wins", v, val)
+		}
+	}
+}
+
+// TestSandboxRestoresAmbientEnvironment proves the sandbox is scoped to
+// the test that asked for it. t.Setenv unwinds at test end, so a helper
+// that isolated one test must not silently isolate — or corrupt — the
+// next one.
+func TestSandboxRestoresAmbientEnvironment(t *testing.T) {
+	before, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no resolvable home directory in this environment")
+	}
+
+	t.Run("sandboxed", func(t *testing.T) {
+		d := Sandbox(t)
+		if d.Home == before {
+			t.Fatalf("sandbox home %s equals the ambient home — nothing was isolated", d.Home)
+		}
+	})
+
+	after, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("os.UserHomeDir() after the sandboxed subtest: %v", err)
+	}
+	if after != before {
+		t.Fatalf("ambient home leaked: was %s, now %s", before, after)
+	}
+}


### PR DESCRIPTION
## Summary

`#499` closed the symptom reported in #503 — temp directories regrowing as `repos:`
entries in the real `config.yaml` — but it closed it by accident, and the cause it
named is untouched.

The write it stopped goes `ensureGlobalConfig` → `config.DefaultGlobalConfigPath()` →
`platform.ConfigDir()`, and `unifiedDir` short-circuits on an absolute `XDG_CONFIG_HOME`
*before* `os.UserHomeDir()` is consulted. `filepath.IsAbs("D:\\…")` is true, so pointing
the XDG variables at temp dirs isolated that one path on Windows too. The reporter's
cited lines — `init.go:235` and `:374` — feed `agents.Env.Home` and were never on the
`config.yaml` path at all.

So the root cause is still live: `t.Setenv("HOME", dir)` does not move `os.UserHomeDir`
on Windows, `USERPROFILE` appears nowhere in the tree, and everything that resolves the
home *without* an XDG hop still lands in the developer's real profile.

Three of those survive today, reachable from a plain `go test ./cmd/gortex/`:

| Test | Writes to the real profile |
|---|---|
| `TestInitHooksOnlyRefreshesClaudeAndCodexHooks` | merges hooks into `%USERPROFILE%\.codex\config.toml` (`init.go:392`) |
| `TestInstructionsSwitchListShowRegen` | hands the real home to `SyncGlobalSkills`, which `os.RemoveAll`s `%USERPROFILE%\.claude\skills` |
| every `TestDispatcher_*` | appends to the real `~/.gortex/cache/query-log.jsonl` — **on every platform**, not just Windows |

The skills prune is a bigger blast radius than the bug it replaced: two stray `repos:`
lines are a one-line undo, a deleted skills tree needs a reinstall.

`internal/platform` and `internal/config` are worse than leaky — they assert `Home()`
resolves to `<temp>/.gortex`, which cannot hold while the home lookup ignores `HOME`.
Those tests **fail** on Windows today; nothing runs them there.

## Changes

- **`internal/testenv`** — one cross-platform helper, replacing nine hand-rolled copies.
  Sets `HOME` *and* `USERPROFILE`, plus the `AppData` pair `os.UserConfigDir` /
  `os.UserCacheDir` read on Windows. `SetHome` moves just the home, `UnifiedHome` also
  clears the XDG overrides, `Sandbox` redirects the base directories and daemon runtime
  files, `SandboxProcess` does it for a whole test binary from `TestMain`.
- **Nine test files** routed through it; local `clearXDG` and `isolateInitTestEnv` removed.
- **`cmd/gortex` `TestMain`** — sandboxes the package by default, then fingerprints the
  real `config.yaml`, `servers.toml`, query log, `~/.codex` and `~/.claude` entries and
  fails the package if any changed. This is the belt-and-braces tripwire the issue asked
  for; the sandbox makes forgetting harmless, the tripwire catches what it misses.
- **CI** — the Windows job now runs `./internal/testenv ./internal/platform`.

## Testing

- [x] `go test -race ./internal/testenv ./internal/platform ./internal/config ./internal/hooks ./cmd/gortex` — all pass.
- [x] `go build ./...`, `go vet`, `golangci-lint run` on the touched packages — 0 issues.
- [x] **The guard is not vacuous.** Added a probe test writing a watched path: tests
      report `PASS`, the package exits non-zero with the diagnostic. Reverted.
- [x] **The query-log leak is real and is closed.** Real `query-log.jsonl` measured
      across three runs: `29876159` → without `TestMain` `29876502` (+343 bytes) →
      with `TestMain` `29876502` (unchanged).
- [x] Full `go test -race ./...` not run.

## Risk

`./internal/platform` has never run on the Windows job, despite already shipping
`background_command_windows_test.go`. Its first CI run here is also its first Windows
verification — I cannot execute Windows locally, so if that package holds an unrelated
latent failure, this PR is where it surfaces. Drop that path from the step if you would
rather land the isolation first.

Fixes #503
