### PR TITLE
Announce a point patch whose graph mutation already landed

### DIFF
--- a/internal/indexer/watcher.go
+++ b/internal/indexer/watcher.go
@@ -2117,9 +2117,17 @@ func (w *Watcher) patchGraphWithReceiptStateRawModern(
 	if err != nil {
 		return err
 	}
-	if !w.generationCurrent(path, generation) {
-		return errMutationSuperseded
-	}
+	// A newer generation can be scheduled while the reindex runs — FSEvents
+	// reports a single save as several notifications, and the wider the patch
+	// window (a loaded machine, a repository lane held by a sibling repo) the
+	// likelier one lands right here. The graph mutation above has already
+	// landed, so this pass still owes the announcement for it: returning now
+	// drops the change from Events(), from History(), and from the
+	// symbol-change callback, and the newer generation cannot make up for it
+	// because it finds the persisted receipt already matching and correctly
+	// patches nothing. Finish the announcement and report the supersession to
+	// the caller, which owns waiter attachment.
+	superseded := !w.generationCurrent(path, generation)
 	if result == nil {
 		return errors.New("watcher: exact-path reindex returned no result")
 	}
@@ -2200,6 +2208,9 @@ func (w *Watcher) patchGraphWithReceiptStateRawModern(
 			zap.String("kind", string(kind)),
 			zap.String("delta_class", classification),
 			zap.Int64("ms", ev.DurationMs))
+	}
+	if superseded {
+		return errMutationSuperseded
 	}
 	return nil
 }

--- a/internal/indexer/watcher_duplicate_notification_test.go
+++ b/internal/indexer/watcher_duplicate_notification_test.go
@@ -1,0 +1,94 @@
+package indexer
+
+import (
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+// TestWatcher_DuplicateNotificationDuringPatchStillAnnounces pins the
+// announcement contract for a patch that raced a duplicate native
+// notification.
+//
+// FSEvents reports one save as several notifications, so a second one for the
+// same path routinely lands while the first debounced patch is still running.
+// The reindex that pass already applied is real graph state, so dropping its
+// GraphChangeEvent loses the change from Events(), from History(), and from
+// the symbol-change callback — the newer generation cannot make up for it,
+// because it finds the persisted receipt already matching and correctly does
+// nothing.
+//
+// The duplicate is injected from inside the reindex rather than timed, so the
+// window is exercised on every run instead of only on a loaded machine.
+func TestWatcher_DuplicateNotificationDuringPatchStillAnnounces(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.go")
+	writeTestFile(t, path, `package main
+
+func Original() {}
+`)
+
+	g := graph.New()
+	reg := parser.NewRegistry()
+	reg.Register(languages.NewGoExtractor())
+	cfg := config.Default()
+	cfg.Index.Workers = 1
+
+	idx := New(g, reg, cfg.Index, zap.NewNop())
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+
+	w, err := NewWatcher(idx, config.WatchConfig{
+		Enabled:    true,
+		Paths:      []string{dir},
+		DebounceMs: 50,
+		Exclude:    []string{"**/*.tmp", "**/.git/**"},
+	}, zap.NewNop())
+	require.NoError(t, err)
+
+	// Armed only once the watcher is live, so the Darwin startup barrier
+	// never sees an injected mutation. Installed before Start so the field
+	// is never written while a patch goroutine reads it.
+	var armed atomic.Bool
+	var once sync.Once
+	w.pointReindexRaw = func(p string) (*IndexResult, error) {
+		result, err := idx.incrementalPointWatcherPath(idx.rootPath, p)
+		if armed.Load() {
+			// The window between "graph mutated" and "is my generation
+			// still current" is exactly where a repeated FSEvents
+			// notification for the same save lands.
+			once.Do(func() { w.scheduleFileMutation(p, ChangeModified) })
+		}
+		return result, err
+	}
+
+	require.NoError(t, w.Start([]string{dir}))
+	t.Cleanup(func() { _ = w.Stop() })
+
+	armed.Store(true)
+	writeTestFile(t, path, `package main
+
+func Duplicated() {}
+`)
+
+	ev := waitForEvent(t, w, 5*time.Second)
+	assert.Equal(t, ChangeModified, ev.Kind)
+	assert.Equal(t, path, ev.FilePath)
+
+	require.Eventually(t, func() bool {
+		return len(g.FindNodesByName("Duplicated")) > 0
+	}, 5*time.Second, 20*time.Millisecond, "the applied reindex must be in the graph")
+
+	require.NotEmpty(t, w.History(), "an applied patch must leave a history row")
+}


### PR DESCRIPTION
## The defect

A debounced watcher patch that finished its reindex — the graph mutation **has landed** — then discovered a newer generation was scheduled mid-flight, and returned `errMutationSuperseded` before announcing anything. The newer generation then correctly did nothing: the content receipt the first pass persisted already matched, so its identity gate short-circuited.

Net effect: the change is in the graph but never reaches `Events()`, `History()`, or the symbol-change callback. That is not only test flake — `get_recent_changes` and `get_symbol_history` silently lose a save whenever a duplicate native notification lands in that window.

FSEvents reports one save as several notifications, so the duplicate is routine. The wider the patch window, the likelier one lands in it — which is why this surfaced on macOS CI as `MultiWatcher` timeouts waiting for the **second** repository's merged event, whose patch overlaps the first repository's tail on the shared graph store.

Observed on main in [this run](https://github.com/zzet/gortex/actions/runs/31262833523/job/93116183326) (`TestMultiWatcher_Events_MergedFromMultipleRepos`, `multi_watcher_test.go:187`) and in run 31220658442 (`TestMultiWatcher_OnSymbolChangeFanout`, `multi_watcher_test.go:384`). Both are the second repo's wait.

## The fix

Keep the supersession signal — the caller owns waiter attachment — but finish the announcement for work that actually landed.

## Verification

- **Deterministic regression test**, injecting the duplicate from inside the reindex so the window is exercised on every run rather than only on a loaded machine: fails 3/3 before, passes 5/5 after.
- **CI symptom reproduced locally** at `GOMAXPROCS=2` over the whole `TestMultiWatcher` suite: 2 failures in 40 iterations, on the exact CI lines. Narrower configurations (the two tests alone, `GOMAXPROCS=1`, default parallelism) do not reproduce — the sibling contention is what widens the window.
- **After the fix:** 960 runs of that suite, 0 failures.
- `go test -race ./internal/indexer/` green (1496 tests) on this base; `golangci-lint run ./internal/indexer/...` clean.

0/960 against a ~2/640 baseline is consistent with elimination but is not proof on its own; the deterministic test is what pins the mechanism.

## Not addressed here

- Storm-drain batches (`drainStorm`) announce nothing at all — no event, no history row. Pre-existing and arguably intentional for burst handling, but it leaves `get_recent_changes` blind across a branch checkout.
- `TestRunAnalysis_FeedsBundleFingerprintsToSQLiteBackend` in `internal/mcp` is a separate macOS flake seen on main.