### PR TITLE
Harden the daemon's write sinks and network surfaces

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,6 +26,65 @@ agent to invoke tools with attacker-influenced arguments. The boundaries
 described below — file-path confinement, opt-in network egress, and explicit
 process execution — are the security boundary, not the agent's good behavior.
 
+## Two channels, two levels of trust
+
+Gortex's enforcement rests on one distinction, and understanding it explains
+every exemption in this document:
+
+- The **operator channel** — the `gortex` CLI and the daemon's control surface —
+  is you, typing a command. It is deliberately **not** confined: `gortex export
+  --out /any/path` writes where you say, and `gortex init --force` will index a
+  root the safety check otherwise refuses. You asked in your own name, on your
+  own machine.
+- The **agent channel** — MCP tool calls — is confined, because its arguments
+  can be steered by content Gortex indexed. Path arguments are checked against
+  the tracked roots, and the operations that would widen those roots are refused.
+
+When something below says "operator only" or "you opted in", it means exactly
+this: Gortex stopped enforcing at that point because you made the decision, not
+because the operation is safe. Those decisions are enumerated next so you can
+see which ones you have actually made.
+
+## Decisions that grant authority
+
+Each of these hands out capability. None is a vulnerability; all of them are
+choices, and the risk is yours once made.
+
+| You do this | It grants | Note |
+|---|---|---|
+| Run the daemon | Any process that can open its socket gets **full authority over every tracked repository** — reads, writes, and the control surface | There is no per-connection authentication beyond the socket's `0600` mode. A second local *account* cannot reach it; another process running as *you* can |
+| `gortex track <path>` | Every agent session on the machine can read **and write** that tree by absolute path, in any workspace | Persisted to your global config. Tracking is the act that grants file access — treat it as such |
+| Use the CLI / control channel | Unconfined file writes (`gortex export --out <anywhere>`) and indexing of a root the safety check refuses (`gortex init --force`) | Intentional. The equivalent operations are refused on the agent channel |
+| Give several repos the same `workspace:` slug | A session opened *above* your repos binds to the whole slug — including repos that share it from **elsewhere on disk**, outside the directory you opened | A slug is an explicit grouping you declared, so it is honoured over the narrower "what this folder contains" inference |
+| `gortex mcp --index <path>` | A repo-local `.gortex/` notebook store is created in that tree | Only for a path you named. An inferred working directory never gets one |
+| `--http-addr` (even `127.0.0.1`) | **Every local process, and any page your browser loads**, can reach the MCP surface | The unix socket's permissions do not cover a TCP port. Prefer the socket |
+| Omit `--http-auth-token` on a loopback bind | Unauthenticated access to that port | Permitted by design; a non-loopback bind refuses to start without a token |
+| `--http-allowed-origin <origin>` | That website can drive the full tool surface **with your privileges** | Off by default: cross-origin browser requests to `/mcp` are refused |
+| `--cors-origin '*'` (current default) | Any origin may read `/v1` responses when it can reach the port | Narrow it if you enable `--http-addr` |
+| `gortex eval-server` | An HTTP tool surface for benchmarking | Loopback-only unless you pass a token |
+| `GORTEX_DAEMON_PPROF_ADDR` | Unauthenticated heap dumps (**containing indexed source**) and `/debug/pprof/cmdline` (**containing your auth token**) | Loopback-only; opt-in |
+| Configure a hosted or subprocess **LLM provider** | Prompts derived from your source leave the machine | No provider is configured by default |
+| Enable **federation / proxy** | Graph queries go to the daemons you configure | Off unless configured; read-only by default |
+| Index a repository you do not trust | Its content reaches the agent's context, widening the prompt-injection surface | This is the threat the confinement boundaries exist for |
+
+## What Gortex does not protect you from
+
+Stated plainly, because the absence of a boundary is easy to mistake for the
+presence of one:
+
+- **Agent sessions are not isolated from each other on the filesystem.** Workspace
+  and project scoping bound *graph queries*. A session working in one tracked
+  repository can read and write another tracked repository by absolute path.
+- **A repository you track is a repository you have shared** with every agent
+  session on the machine, for the lifetime of that config entry.
+- **Editing is a first-class feature**, so an agent that can write source can
+  influence what runs the next time you build, test, or open the project. Review
+  agent-authored changes the way you would review a pull request.
+- **Anything reachable at a local TCP port is reachable by your browser.** A
+  loopback bind is a convenience, not an isolation mechanism.
+- **Nothing here defends against a local attacker already running as you.** Such
+  a process can read your files without involving Gortex at all.
+
 ## Scope
 
 ### File system access
@@ -58,23 +117,19 @@ process execution — are the security boundary, not the agent's good behavior.
 ### The daemon socket is the trust boundary
 
 The daemon runs as **you**, never with elevated privileges, and its unix socket
-is created `0600` inside a `0700` directory. It performs no per-connection
-authorization beyond those filesystem permissions: any process that can open
-the socket has the daemon's full authority over every tracked repository —
-reads, writes, and the control surface (track / untrack / shutdown).
+is created `0600` inside a `0700` directory. Access control is those filesystem
+permissions and nothing else — there is no per-connection authentication, and
+one connection grants both the tool surface and the control surface (track /
+untrack / shutdown).
 
-This means Gortex never grants access to a directory you could not already read
-yourself. It also means a second local account cannot reach your daemon. What it
-does *not* mean is that separate sessions are isolated from one another; they are
-not, by design.
+The useful consequence: **Gortex never grants access to a directory you could
+not already read yourself.** It cannot be used to reach another user's files,
+because a daemon that can read them is running as someone who can read them, and
+only that someone can open its socket.
 
-Optional HTTP surfaces (`gortex daemon start --http-addr`, `gortex mcp
---server`, `gortex eval-server`) change this: a loopback TCP port is reachable
-by **every local process and by any page the user's browser loads**, which the
-unix socket's permissions do not cover. `/mcp` therefore refuses cross-origin
-browser requests unless you name the origin with `--http-allowed-origin`, and a
-non-loopback bind requires an auth token. Prefer the unix socket unless you
-specifically need HTTP.
+See [Decisions that grant authority](#decisions-that-grant-authority) for what
+the HTTP surfaces change, and [What Gortex does not protect you
+from](#what-gortex-does-not-protect-you-from) for what this boundary is not.
 
 ### Network access
 
@@ -129,16 +184,23 @@ specifically need HTTP.
 
 ## Hardening checklist
 
-The following configuration choices increase Gortex's exposure; review them for
-your environment:
+[Decisions that grant authority](#decisions-that-grant-authority) lists what each
+choice hands out. This is the short actionable form:
 
-- Configuring a **hosted or subprocess LLM provider** sends code-derived prompts
-  off the machine.
-- Enabling **federation / proxy** sends graph queries to the remote daemons you
-  configure.
-- Binding the HTTP endpoint to a **non-localhost address** exposes the MCP
-  surface to the network — always set `--http-auth-token`, and prefer a
-  localhost bind or an SSH tunnel.
-- Driving the MCP tools with an agent that ingests **untrusted repository
-  content** widens the prompt-injection surface; keep Gortex pointed at
-  repositories you trust.
+- **Track only what you would share.** Every tracked repository is readable and
+  writable by every agent session on the machine. Prune the list with
+  `gortex untrack`; it is a standing grant, not a per-session one.
+- **Prefer the unix socket.** Only pass `--http-addr` if you need HTTP. If you
+  do: set `--http-auth-token` even on loopback, narrow `--cors-origin` from its
+  `*` default, and add `--http-allowed-origin` only for a web front end you run.
+- **Never bind a non-loopback address without a token.** Gortex refuses to start
+  that way; do not work around it. Use an SSH tunnel instead.
+- **Leave `GORTEX_DAEMON_PPROF_ADDR` unset** outside a debugging session — it
+  serves your argv (including auth tokens) and heap unauthenticated.
+- **Treat a configured LLM provider as data egress**: prompts derived from your
+  source go to that endpoint or subprocess. None is configured by default.
+- **Review agent-authored edits.** Write tools are first-class, and changed
+  source runs the next time you build or test.
+- **Point Gortex at repositories you trust.** Indexed content reaches the agent's
+  context, which is the prompt-injection surface the confinement boundaries
+  exist to contain.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,6 +41,40 @@ process execution — are the security boundary, not the agent's good behavior.
   resolved before the check so a link cannot be used to escape a root.
 - Gortex does not require, and does not request, access to files outside the
   repositories you index.
+- The confinement boundary is the **union of every tracked repository root**,
+  not the workspace of the session making the call. A session working in one
+  tracked repository can read and write files in another tracked repository by
+  absolute path. Workspace and project scoping narrow *graph queries*; they are
+  a relevance and context boundary, not a filesystem one. Do not track a
+  repository you would not let every agent session on this machine read and
+  modify.
+- Because the tracked-root set defines that boundary, the tools that extend it
+  (`track_repository` / `workspace_admin(operation:"track")`) are part of the
+  boundary. Tracking a new root widens file access for every tool and persists
+  to your global config; the `force` option, which would allow tracking `/` or
+  your home directory, is refused for agent sessions and available only from
+  the CLI you run yourself.
+
+### The daemon socket is the trust boundary
+
+The daemon runs as **you**, never with elevated privileges, and its unix socket
+is created `0600` inside a `0700` directory. It performs no per-connection
+authorization beyond those filesystem permissions: any process that can open
+the socket has the daemon's full authority over every tracked repository —
+reads, writes, and the control surface (track / untrack / shutdown).
+
+This means Gortex never grants access to a directory you could not already read
+yourself. It also means a second local account cannot reach your daemon. What it
+does *not* mean is that separate sessions are isolated from one another; they are
+not, by design.
+
+Optional HTTP surfaces (`gortex daemon start --http-addr`, `gortex mcp
+--server`, `gortex eval-server`) change this: a loopback TCP port is reachable
+by **every local process and by any page the user's browser loads**, which the
+unix socket's permissions do not cover. `/mcp` therefore refuses cross-origin
+browser requests unless you name the origin with `--http-allowed-origin`, and a
+non-loopback bind requires an auth token. Prefer the unix socket unless you
+specifically need HTTP.
 
 ### Network access
 

--- a/cmd/gortex/browser_origin_guard_test.go
+++ b/cmd/gortex/browser_origin_guard_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestBrowserOriginGuard covers the DNS-rebinding / cross-origin path into
+// the daemon's Streamable HTTP surface.
+//
+// A loopback bind is not private: any page the user opens can reach
+// 127.0.0.1, and this surface defaults to no auth token on a loopback bind.
+// The transport's own AllowedOrigins mechanism existed but was never wired,
+// so every origin was admitted.
+func TestBrowserOriginGuard(t *testing.T) {
+	reached := false
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	call := func(guard http.Handler, origin string) int {
+		reached = false
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		if origin != "" {
+			req.Header.Set("Origin", origin)
+		}
+		rec := httptest.NewRecorder()
+		guard.ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	t.Run("no Origin header is allowed", func(t *testing.T) {
+		// Ordinary MCP clients are not browsers and never send Origin.
+		// Refusing here would break every legitimate caller.
+		code := call(browserOriginGuard(inner, nil), "")
+		assert.Equal(t, http.StatusOK, code)
+		assert.True(t, reached)
+	})
+
+	t.Run("a browser origin is refused when none is allowed", func(t *testing.T) {
+		code := call(browserOriginGuard(inner, nil), "https://evil.example")
+		assert.Equal(t, http.StatusForbidden, code)
+		assert.False(t, reached, "the request must not reach the tool surface")
+	})
+
+	t.Run("an explicitly allowed origin passes", func(t *testing.T) {
+		guard := browserOriginGuard(inner, []string{"https://ui.example"})
+		assert.Equal(t, http.StatusOK, call(guard, "https://ui.example"))
+		assert.True(t, reached)
+	})
+
+	t.Run("the allowlist is exact, and case-insensitive on the origin", func(t *testing.T) {
+		guard := browserOriginGuard(inner, []string{"https://ui.example"})
+		assert.Equal(t, http.StatusOK, call(guard, "HTTPS://UI.EXAMPLE"))
+		assert.Equal(t, http.StatusForbidden, call(guard, "https://ui.example.evil.com"),
+			"a suffix match must not be treated as the allowed origin")
+		assert.Equal(t, http.StatusForbidden, call(guard, "http://ui.example"),
+			"scheme is part of the origin")
+	})
+
+	t.Run("blank entries in the allowlist do not admit a missing origin check", func(t *testing.T) {
+		guard := browserOriginGuard(inner, []string{"", "   "})
+		assert.Equal(t, http.StatusForbidden, call(guard, "https://evil.example"))
+	})
+}
+
+// TestIsLocalhostBind_RejectsWildcards pins the predicate the eval-server and
+// pprof binds now rely on: a wildcard bind is externally reachable and must
+// not be treated as loopback.
+func TestIsLocalhostBind_RejectsWildcards(t *testing.T) {
+	for _, addr := range []string{"127.0.0.1:4747", "localhost:4747", "[::1]:4747", "127.0.0.1"} {
+		assert.True(t, isLocalhostBind(addr), "%q is loopback", addr)
+	}
+	for _, addr := range []string{"0.0.0.0:4747", ":4747", "[::]:4747", "192.168.1.5:4747", "example.com:4747"} {
+		assert.False(t, isLocalhostBind(addr), "%q is externally reachable", addr)
+	}
+}

--- a/cmd/gortex/daemon.go
+++ b/cmd/gortex/daemon.go
@@ -51,6 +51,7 @@ var (
 	daemonStatusInterval        time.Duration
 	daemonHTTPAddr              string
 	daemonHTTPAuthToken         string
+	daemonHTTPAllowedOrigins    []string
 	daemonHTTPCORSOrigin        string
 	daemonHTTPConversationAllow []string
 	daemonBackend               string
@@ -124,6 +125,8 @@ func init() {
 		"also expose the MCP 2026 Streamable HTTP transport on this TCP address (e.g. 127.0.0.1:7411); empty disables")
 	daemonStartCmd.Flags().StringVar(&daemonHTTPAuthToken, "http-auth-token", "",
 		"bearer token required on every Streamable HTTP request (default: read $GORTEX_DAEMON_HTTP_TOKEN; empty allows unauthenticated localhost binds)")
+	daemonStartCmd.Flags().StringSliceVar(&daemonHTTPAllowedOrigins, "http-allowed-origin", nil,
+		"web origin permitted to call /mcp cross-origin (e.g. https://ui.example); repeatable. Empty refuses every browser origin — a loopback bind is reachable from any page the user visits")
 	daemonStartCmd.Flags().StringVar(&daemonHTTPCORSOrigin, "cors-origin", "*",
 		"allowed CORS origin for the HTTP surface (use '*' for any); applies to both /mcp and /v1 when --http-addr is set")
 	daemonStartCmd.Flags().StringSliceVar(&daemonHTTPConversationAllow, "conversation-host", nil,

--- a/cmd/gortex/daemon_pprof.go
+++ b/cmd/gortex/daemon_pprof.go
@@ -39,6 +39,16 @@ func startPProfIfEnabled(logger *zap.Logger) {
 	if addr == "" {
 		return
 	}
+	// pprof serves the DefaultServeMux with no auth, and /debug/pprof/cmdline
+	// echoes the daemon's argv — which carries --http-auth-token. The heap it
+	// dumps holds indexed source from every tracked repository. Keep it on
+	// loopback: an operator who wants it reachable can port-forward.
+	if !isLocalhostBind(addr) {
+		logger.Warn("daemon: refusing non-loopback pprof bind",
+			zap.String("addr", addr),
+			zap.String("hint", "pprof is unauthenticated and exposes argv + heap; bind 127.0.0.1 and port-forward"))
+		return
+	}
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		logger.Warn("daemon: pprof listener failed",

--- a/cmd/gortex/daemon_streamable.go
+++ b/cmd/gortex/daemon_streamable.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/zzet/gortex/internal/daemon"
@@ -216,7 +217,45 @@ func buildDaemonStreamableHandler(disp daemon.MCPDispatcher, reg *daemon.Session
 	// Always wrap: the middleware resolves the token per request, so a
 	// request with no configured token is served unauthenticated and the
 	// token can be rotated (added/changed/removed) without a restart.
-	return bearerAuthMiddleware(mux, tokenFn)
+	// The origin guard sits outside it, because the request it refuses is
+	// one a browser makes with the user's own credentials — an unauthenticated
+	// loopback bind is reachable from any page the user visits.
+	return browserOriginGuard(bearerAuthMiddleware(mux, tokenFn), daemonHTTPAllowedOrigins)
+}
+
+// browserOriginGuard refuses a request carrying a cross-origin Origin header.
+//
+// A loopback HTTP bind is not private: every page in the user's browser can
+// reach 127.0.0.1, and the transport's own Origin allowlist
+// (streamable.Config.AllowedOrigins) was never wired to anything, so it
+// admitted every origin. With the surface's default of no auth token on a
+// localhost bind, that made the full MCP tool catalogue — file reads and
+// writes included — reachable from any site the user happened to open.
+//
+// A request with NO Origin header is allowed: browsers always set it
+// cross-origin, and ordinary MCP clients (which are not browsers) never send
+// it. So the guard costs nothing for real clients and closes the browser path.
+// Operators serving a genuine web front end name its origin explicitly.
+func browserOriginGuard(next http.Handler, allowed []string) http.Handler {
+	allowSet := make(map[string]struct{}, len(allowed))
+	for _, o := range allowed {
+		if o = strings.ToLower(strings.TrimSpace(o)); o != "" {
+			allowSet[o] = struct{}{}
+		}
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		origin := strings.ToLower(strings.TrimSpace(r.Header.Get("Origin")))
+		if origin == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		if _, ok := allowSet[origin]; ok {
+			next.ServeHTTP(w, r)
+			return
+		}
+		http.Error(w, "forbidden: cross-origin requests are not accepted; "+
+			"pass --http-allowed-origin to permit a specific web origin", http.StatusForbidden)
+	})
 }
 
 // bearerAuthMiddleware gates every request behind a bearer token resolved

--- a/cmd/gortex/eval_server.go
+++ b/cmd/gortex/eval_server.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 
 	"github.com/spf13/cobra"
 
@@ -18,6 +20,7 @@ import (
 	"github.com/zzet/gortex/internal/parser/languages"
 	"github.com/zzet/gortex/internal/platform"
 	"github.com/zzet/gortex/internal/query"
+	"github.com/zzet/gortex/internal/server"
 )
 
 var (
@@ -33,8 +36,15 @@ var evalServerCmd = &cobra.Command{
 	RunE:  runEvalServer,
 }
 
+var (
+	evalBind      string
+	evalAuthToken string
+)
+
 func init() {
 	evalServerCmd.Flags().IntVar(&evalPort, "port", 4747, "HTTP port to listen on")
+	evalServerCmd.Flags().StringVar(&evalBind, "bind", "127.0.0.1", "bind address; a non-loopback bind requires --auth-token")
+	evalServerCmd.Flags().StringVar(&evalAuthToken, "auth-token", "", "bearer token required for every request (fallback: $GORTEX_EVAL_TOKEN)")
 	evalServerCmd.Flags().StringVar(&evalIndex, "index", "", "repository path to index on startup")
 	evalServerCmd.Flags().StringVar(&evalCacheDir, "cache-dir", "", "index cache directory (default ~/.gortex-eval-cache)")
 	rootCmd.AddCommand(evalServerCmd)
@@ -114,13 +124,28 @@ func runEvalServer(cmd *cobra.Command, args []string) error {
 	// Wire the MCP server's tool dispatch into an HTTP handler.
 	handler := eval.NewHandler(srv.MCPServer(), g, version, logger)
 
-	addr := fmt.Sprintf(":%d", evalPort)
+	// Bind loopback by default and refuse a wider bind without a token.
+	// This surface publishes the daemon's whole tool catalogue — including
+	// file reads and writes — so binding every interface unauthenticated
+	// handed the machine's indexed repositories to anyone who could route
+	// to the port.
+	authToken := evalAuthToken
+	if authToken == "" {
+		authToken = os.Getenv("GORTEX_EVAL_TOKEN")
+	}
+	addr := net.JoinHostPort(evalBind, strconv.Itoa(evalPort))
+	if err := httpTokenRequirementError(addr, authToken); err != nil {
+		return err
+	}
+	if authToken == "" {
+		fmt.Fprintln(os.Stderr, "[gortex] eval-server: unauthenticated mode; localhost only")
+	}
 	httpServer := &http.Server{
 		Addr:    addr,
-		Handler: handler,
+		Handler: server.WithAuth(handler, authToken),
 	}
 
-	fmt.Fprintf(os.Stderr, "[gortex] eval-server listening on http://localhost:%d\n", evalPort)
+	fmt.Fprintf(os.Stderr, "[gortex] eval-server listening on http://%s\n", addr)
 
 	// Start HTTP server in a goroutine.
 	errCh := make(chan error, 1)

--- a/docs/multi-repo.md
+++ b/docs/multi-repo.md
@@ -4,7 +4,9 @@ Gortex can index multiple repositories into a single shared graph, enabling cros
 
 ## Workspace boundary
 
-Every node and contract is keyed on a **workspace slug**, which is the hard graph boundary for cross-repo work. Two repos that should pair their contracts (an HTTP server and the client that calls it, a Kafka producer and its consumer, etc.) must declare the same `workspace:` in their `.gortex.yaml` — otherwise contract matching stops at the boundary and they look like orphans.
+Every node and contract is keyed on a **workspace slug**, which is the hard graph boundary for cross-repo work.
+
+> **Scope of this boundary.** It bounds *graph queries* — what symbols, callers and analysis a session can observe. It does **not** bound filesystem access: `read_file`, `edit_file` and the other path-argument tools are confined to the union of every tracked repository root, not to the session's workspace. See [SECURITY.md](../SECURITY.md#file-system-access). Two repos that should pair their contracts (an HTTP server and the client that calls it, a Kafka producer and its consumer, etc.) must declare the same `workspace:` in their `.gortex.yaml` — otherwise contract matching stops at the boundary and they look like orphans.
 
 Slug resolution precedence (first match wins):
 
@@ -144,7 +146,7 @@ Agents can manage repos at runtime without CLI access:
 | `set_active_project` | Switch project scope for all subsequent queries |
 | `get_active_project` | Return current project name and repo list |
 
-Locate, reach, and analyze query tools uniformly accept `repo`, `project`, `workspace`, and `scope` parameters for scoping (plus `ref` where reference tags apply). All are clamped to the session workspace — the hard isolation boundary. Default breadth now follows **tool intent** when `scope.intent_defaults` is enabled (the default); see [Tool scoping by intent](#tool-scoping-by-intent) below.
+Locate, reach, and analyze query tools uniformly accept `repo`, `project`, `workspace`, and `scope` parameters for scoping (plus `ref` where reference tags apply). All are clamped to the session workspace — the hard boundary for graph queries. Default breadth now follows **tool intent** when `scope.intent_defaults` is enabled (the default); see [Tool scoping by intent](#tool-scoping-by-intent) below.
 
 For `analyze`, the overrides genuinely narrow its **graph-node** kinds — `dead_code`, `hotspots`, `cycles`, `health_score`, `todos`, `stale_code`, `ownership`, `coverage_gaps`, `coverage_summary`, `impact`, `bottlenecks`, `role`, `k8s_resources`, `images`, `kustomize`, `dbt_models`, `external_calls`, and the like — and, since v1, its **edge-walk / graph-algorithm / framework / file-AST-scan** kinds too (`channel_ops`, `pubsub`, `routes`, `models`, `pagerank`, `kcore`, `edge_audit`, `tests_as_edges`, `sast`, `review`, …), which prune their rows / re-tally their counts against the same workspace + repo allow-set. The narrowing also resolves the two kind-specific collisions: `kind=cross_repo` keeps `repo` as its boundary filter and `kind=cycles` keeps `scope` as a file-path / package prefix (both are stripped from the uniform scope-resolution view). **v1 caveat:** the remaining long-tail kinds — community detection (`clusters`, `concepts`, `suggest_boundaries`), git/disk-mining (`blame`, `coverage`, `fixes_history`, `retrieval_log`, `temporal_verify`), per-id (`would_create_cycle`, `def_use`), `synthesizers` / `resolution_outcomes`, and `sql_rebuild` — remain workspace-bound but are **not** repo-narrowed — passing a narrowing arg on such a kind stamps a `scope_note` on the response disclosing the no-op.
 
@@ -171,7 +173,7 @@ Other query tools (`get_symbol`, `get_file_summary`, `smart_context`, etc.) keep
 
 - Controls the intent-based default scoping described above
 - **Defaults ON** (enabled out of the box — this is the new behavior after upgrade)
-- **Narrow-only invariant:** the intent defaults only ever *narrow* within the session workspace (the hard isolation boundary); they never widen past it, and an explicit `repo` / `project` / `workspace` / `scope` arg always overrides the default
+- **Narrow-only invariant:** the intent defaults only ever *narrow* within the session workspace (the hard boundary for graph queries); they never widen past it, and an explicit `repo` / `project` / `workspace` / `scope` arg always overrides the default
 - Opt out: set `scope.intent_defaults: false` in `.gortex.yaml`, or set env var `GORTEX_SCOPE_INTENT_DEFAULTS=0`
 
 **⚠ Upgrade note (behavior change):** When upgrading to this version:
@@ -190,7 +192,7 @@ When intent defaults are on, you can still widen or narrow explicitly:
 
 ### Uniform parameter set
 
-Every locate/reach/analyze tool now uniformly accepts `repo`, `project`, `workspace`, and `scope` parameters — including the legacy tools the `analyze` facade forwards to (`audit_health`, `find_clones`, `run_inspections`, `get_communities`, `get_processes`, `get_recent_changes`). All are clamped to the session workspace (the hard isolation boundary). For `analyze` this narrows the graph-node, edge-walk, graph-algorithm, framework, and file/AST-scan kinds; the remaining community / git-mining / per-id / synthesizer kinds are workspace-bound but not repo-narrowed in v1 (see the [MCP tools](#mcp-tools) caveat above).
+Every locate/reach/analyze tool now uniformly accepts `repo`, `project`, `workspace`, and `scope` parameters — including the legacy tools the `analyze` facade forwards to (`audit_health`, `find_clones`, `run_inspections`, `get_communities`, `get_processes`, `get_recent_changes`). All are clamped to the session workspace (the hard boundary for graph queries). For `analyze` this narrows the graph-node, edge-walk, graph-algorithm, framework, and file/AST-scan kinds; the remaining community / git-mining / per-id / synthesizer kinds are workspace-bound but not repo-narrowed in v1 (see the [MCP tools](#mcp-tools) caveat above).
 
 ### Response metadata
 

--- a/internal/analysis/diffmap.go
+++ b/internal/analysis/diffmap.go
@@ -45,6 +45,9 @@ type DiffResult struct {
 // repo-relative paths; empty only for the standalone Indexer, which
 // mints unprefixed paths.
 func MapGitDiff(g graph.Store, repoRoot, repoPrefix, scope, baseRef string) (*DiffResult, error) {
+	if err := gitcmd.ValidateRef(baseRef); err != nil {
+		return nil, err
+	}
 	args := buildDiffArgs(scope, baseRef)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -156,6 +159,13 @@ func GitDiffArgs(scope, baseRef string, unified int) []string {
 	case "all":
 		args = append(args, "HEAD")
 	case "compare":
+		// A hostile base degrades to the documented default rather than
+		// reaching argv: the token is baseRef+"...HEAD", so a value
+		// starting with "-" is still an option to git, and GitDiffArgs
+		// has no error return to surface it through. MapGitDiff rejects
+		// it loudly before calling here; this is the backstop for the
+		// other callers that build args directly.
+		baseRef = gitcmd.SafeRef(baseRef)
 		if baseRef == "" {
 			baseRef = "main"
 		}
@@ -300,6 +310,9 @@ func parseNewStart(line string) (int, bool) {
 // the diff's context width differs), so symbol overlap is unaffected.
 // repoPrefix anchors the node join exactly as in MapGitDiff.
 func MapGitDiffWithLines(g graph.Store, repoRoot, repoPrefix, scope, baseRef string) (*DiffResult, map[string][]HunkLine, error) {
+	if err := gitcmd.ValidateRef(baseRef); err != nil {
+		return nil, nil, err
+	}
 	args := buildDiffArgsWithContext(scope, baseRef)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/internal/blame/blame.go
+++ b/internal/blame/blame.go
@@ -64,6 +64,9 @@ func Run(repoRoot, relPath string) (map[int]Author, error) {
 // pinning to `origin/main` so feature-branch work-in-progress doesn't
 // pollute the persisted data.
 func RunAt(repoRoot, rev, relPath string) (map[int]Author, error) {
+	if err := gitcmd.ValidateRef(rev); err != nil {
+		return nil, err
+	}
 	args := []string{"blame", "-p"}
 	if rev != "" {
 		args = append(args, rev)

--- a/internal/churn/churn.go
+++ b/internal/churn/churn.go
@@ -206,6 +206,9 @@ type commitRecord struct {
 // Ordered newest → oldest. Empty slice when the file has no history
 // on that branch (untracked, or the rev predates the file).
 func fileCommits(repoRoot, branch, relPath string) ([]commitRecord, error) {
+	if err := gitcmd.ValidateRef(branch); err != nil {
+		return nil, err
+	}
 	out, err := gitcmd.Run(context.Background(), repoRoot, "log", branch,
 		"--no-merges", "--follow", "--format=%H|%ct|%ae", "--", relPath)
 	if err != nil {

--- a/internal/gitcmd/ref.go
+++ b/internal/gitcmd/ref.go
@@ -1,0 +1,72 @@
+package gitcmd
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ValidateRef rejects a caller-supplied git revision that git would read as
+// an OPTION rather than as a ref.
+//
+// Every git subcommand this codebase runs takes the revision as a positional
+// argv element — `git log <rev>`, `git blame -p <rev>`, `git diff
+// <base>...HEAD`. argv carries no quoting, so a value beginning with "-" is
+// not a ref at all: git parses it as a flag. The diff family — diff, log,
+// blame, show — accepts `--output=<path>`, which redirects the command's
+// output into a file of the caller's choosing. Refs reach these call sites
+// from MCP tool arguments (`base`, `base_ref`, `branch`, `rev`), so they are
+// attacker-controlled whenever the agent driving the session is.
+//
+// Measured reach, so this comment does not overstate it. The diff path builds
+// `<ref>...HEAD` as ONE argv token, so the file git writes carries a literal
+// "...HEAD" suffix: an existing file is created beside, not truncated. That
+// is arbitrary file CREATION, in a directory that already exists, carrying
+// the real diff output — not arbitrary overwrite. The bare-token sites
+// (`git log <ref>`, `git blame -p <ref>`) have no such suffix and do
+// truncate. Git-level options like --git-dir and --work-tree are NOT
+// reachable from here: git accepts those only before the subcommand, and
+// every call site places the caller's token after it.
+//
+// The rule is a denylist, not an allowlist, on purpose: legitimate revision
+// expressions are far broader than ref names — `HEAD~3`, `origin/main`,
+// `a...b`, `v1.2^{commit}`, `HEAD:path/to/file` are all valid — and an
+// allowlist tight enough to be safe would reject real input. What actually
+// carries the vulnerability is the leading "-", so that is what is refused.
+// Whitespace and control characters are refused alongside it: no legal
+// revision contains them, and they corrupt the error strings and logs the
+// argv is echoed into.
+//
+// An empty ref is valid. Every call site treats "" as "omit this argument"
+// and never places it in argv; rejecting it here would turn the documented
+// default (HEAD, or the configured default branch) into an error.
+//
+// Deliberately NOT solved with `--end-of-options`: it is git >= 2.24 only,
+// its accepted position differs per subcommand (git refuses it after a
+// positional argument), and it would leave the same value flowing into the
+// forge and blame paths that build argv differently. Rejecting the input is
+// one rule that holds everywhere.
+func ValidateRef(ref string) error {
+	if ref == "" {
+		return nil
+	}
+	if strings.HasPrefix(ref, "-") {
+		return fmt.Errorf("invalid git revision %q: must not begin with '-' (git would read it as an option, not a ref)", ref)
+	}
+	for _, r := range ref {
+		if r < 0x20 || r == 0x7f || r == ' ' || r == '\t' {
+			return fmt.Errorf("invalid git revision %q: contains whitespace or a control character", ref)
+		}
+	}
+	return nil
+}
+
+// SafeRef returns ref when ValidateRef accepts it and "" otherwise. For the
+// call sites that cannot surface an error and already treat "" as "use the
+// default" — dropping a hostile ref there degrades to the documented
+// default instead of running it.
+func SafeRef(ref string) string {
+	if ValidateRef(ref) != nil {
+		return ""
+	}
+	return ref
+}

--- a/internal/gitcmd/ref_test.go
+++ b/internal/gitcmd/ref_test.go
@@ -1,0 +1,117 @@
+package gitcmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestValidateRef pins the rule that closes the option-injection class:
+// argv carries no quoting, so a revision beginning with "-" is parsed by git
+// as a flag rather than a ref.
+func TestValidateRef(t *testing.T) {
+	valid := []string{
+		"", // omitted — call sites never place it in argv
+		"main",
+		"HEAD",
+		"HEAD~3",
+		"HEAD^{commit}",
+		"origin/main",
+		"refs/heads/feature",
+		"v1.2.3",
+		"a1b2c3d4",
+		"main...HEAD",
+		"HEAD:path/to/file.go",
+		"release/2026-08",
+		"fix/some-branch", // an interior "-" is fine; only a leading one is not
+	}
+	for _, ref := range valid {
+		if err := ValidateRef(ref); err != nil {
+			t.Errorf("ValidateRef(%q) = %v, want nil — this is a legitimate revision", ref, err)
+		}
+	}
+
+	invalid := []string{
+		"--output=/tmp/pwned", // writes an arbitrary file
+		"--git-dir=/etc",      // repoints git at another repository
+		"--work-tree=/",
+		"--upload-pack=/bin/sh",
+		"-c",
+		"-",
+		"--output=/tmp/x...HEAD", // the shape GitDiffArgs builds
+		"main branch",            // whitespace
+		"main\nlog",              // newline: corrupts logs and error strings
+		"main\ttab",
+		"main\x00null",
+	}
+	for _, ref := range invalid {
+		if err := ValidateRef(ref); err == nil {
+			t.Errorf("ValidateRef(%q) = nil, want an error", ref)
+		}
+	}
+}
+
+// TestSafeRef checks the degrade-to-default helper used where the call site
+// has no error return.
+func TestSafeRef(t *testing.T) {
+	if got := SafeRef("main"); got != "main" {
+		t.Errorf("SafeRef(main) = %q, want main", got)
+	}
+	if got := SafeRef("--output=/tmp/pwned"); got != "" {
+		t.Errorf("SafeRef of a hostile ref = %q, want \"\" so the caller falls back to its default", got)
+	}
+}
+
+// TestValidateRef_BlocksRealGitFileWrite is the end-to-end proof. It runs the
+// exact argv shape the churn enricher builds and confirms two things: that git
+// really does honour an option-shaped revision by writing a file (so the
+// validator is guarding a live behaviour, not a theoretical one), and that
+// ValidateRef refuses that input before it can be built.
+//
+// Skipped when git is unavailable, or when this git is old enough not to
+// support `log --output` — in which case there is nothing to demonstrate.
+func TestValidateRef_BlocksRealGitFileWrite(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	repo := t.TempDir()
+	run := func(args ...string) error {
+		cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
+		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+		return cmd.Run()
+	}
+	if err := run("init", "-q"); err != nil {
+		t.Skipf("git init failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("hi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := run("add", "-A"); err != nil {
+		t.Fatal(err)
+	}
+	if err := run("-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "init"); err != nil {
+		t.Skipf("git commit failed: %v", err)
+	}
+
+	target := filepath.Join(t.TempDir(), "written-by-git.txt")
+	hostileRef := "--output=" + target
+
+	// The validator must refuse it. This is the assertion that matters.
+	if err := ValidateRef(hostileRef); err == nil {
+		t.Fatalf("ValidateRef(%q) accepted an option-shaped revision", hostileRef)
+	} else if !strings.Contains(err.Error(), "option") {
+		t.Errorf("error should explain WHY it is refused, got: %v", err)
+	}
+
+	// Demonstrate the behaviour being guarded: the same token, placed where
+	// fileCommits places it, makes git write the file.
+	_ = run("log", hostileRef, "--no-merges", "--format=%H", "--", "README.md")
+	if _, err := os.Stat(target); err != nil {
+		t.Skipf("this git does not honour `log --output` (%v) — nothing to demonstrate, "+
+			"but ValidateRef still refuses the input", err)
+	}
+	t.Logf("confirmed: git wrote %s when handed an option-shaped revision; ValidateRef refuses it", target)
+}

--- a/internal/mcp/tools_multi.go
+++ b/internal/mcp/tools_multi.go
@@ -30,7 +30,7 @@ func (s *Server) registerMultiRepoTools() {
 			mcp.WithString("path", mcp.Required(), mcp.Description("Absolute path to repository")),
 			mcp.WithString("name", mcp.Description("Optional repo prefix override")),
 			mcp.WithBoolean("as_worktree", mcp.Description("Track a linked git worktree as an independent instance (derived `<base>@<workspace>` prefix) even when its repo is already tracked elsewhere. Auto-detected when the worktree's .gortex.yaml declares a different workspace; set this to force it.")),
-			mcp.WithBoolean("force", mcp.Description("Track even when the path is the home directory or filesystem root (refused by default to avoid an unbounded crawl).")),
+			mcp.WithBoolean("force", mcp.Description("Track even when the path is the home directory or filesystem root (refused by default to avoid an unbounded crawl). Operator/CLI channel only — refused for agent sessions, since the tracked-root set is the file-access boundary.")),
 		),
 		s.handleTrackRepository,
 	)
@@ -103,8 +103,20 @@ func (s *Server) handleTrackRepository(ctx context.Context, req mcp.CallToolRequ
 	if asWT, ok := req.GetArguments()["as_worktree"].(bool); ok {
 		entry.AsWorktree = asWT
 	}
-	if force, ok := req.GetArguments()["force"].(bool); ok {
-		entry.Force = force
+	if force, ok := req.GetArguments()["force"].(bool); ok && force {
+		// force skips unsafeRootBlocked, the guard that refuses `/`, a
+		// Windows drive root and $HOME. That guard is not only a crawl
+		// bound: the tracked-root set IS the confinement boundary for
+		// every file-path tool (guardRepoRoots), so tracking `/` would
+		// widen read and write access to the whole filesystem — and the
+		// change persists to the global config. An agent session must not
+		// be able to do that to itself; the operator CLI still can.
+		if s.confineCallerPaths(ctx) {
+			return mcp.NewToolResultError(
+				"force is not available to an agent session: it would track a root that " +
+					"widens file access for every tool. Run `gortex track` yourself if that is intended."), nil
+		}
+		entry.Force = true
 	}
 
 	// A fresh repo's first index routinely outruns the MCP request deadline,

--- a/internal/mcp/tools_multi.go
+++ b/internal/mcp/tools_multi.go
@@ -113,8 +113,9 @@ func (s *Server) handleTrackRepository(ctx context.Context, req mcp.CallToolRequ
 		// be able to do that to itself; the operator CLI still can.
 		if s.confineCallerPaths(ctx) {
 			return mcp.NewToolResultError(
-				"force is not available to an agent session: it would track a root that " +
-					"widens file access for every tool. Run `gortex track` yourself if that is intended."), nil
+				"force is not available to an agent session: it would track a root such as / or " +
+					"your home directory, widening file access for every tool and persisting that to " +
+					"your global config. Track the specific repository you need instead."), nil
 		}
 		entry.Force = true
 	}

--- a/internal/mcp/tools_wiki.go
+++ b/internal/mcp/tools_wiki.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -67,6 +68,16 @@ func (s *Server) handleGenerateWiki(ctx context.Context, req mcp.CallToolRequest
 		NoContracts:    boolArgValue(args, "no_contracts"),
 		NoDocs:         boolArgValue(args, "no_docs"),
 		Force:          boolArgValue(args, "force"),
+	}
+
+	// output_dir becomes the writer root and `repo` becomes a path segment
+	// under it, so both steer where files land. Confine them the same way
+	// export_graph confines its own output arguments.
+	if err := s.guardGeneratedOutputPath(ctx, opts.OutputDir); err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	if err := s.guardGeneratedOutputPath(ctx, filepath.Join(opts.OutputDir, opts.Repo)); err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
 	}
 
 	g := s.graph
@@ -171,6 +182,9 @@ func (s *Server) handleGenerateDocs(ctx context.Context, req mcp.CallToolRequest
 
 	outputPath := stringArg(args, "output_path")
 	if outputPath != "" {
+		if err := s.guardGeneratedOutputPath(ctx, outputPath); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
 		if err := writeWikiFile(outputPath, []byte(output)); err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("write %q: %v", outputPath, err)), nil
 		}

--- a/internal/mcp/tools_wiki_confine_test.go
+++ b/internal/mcp/tools_wiki_confine_test.go
@@ -1,0 +1,86 @@
+package mcp
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func wikiTool(t *testing.T, srv *Server, ctx context.Context, name string,
+	h func(context.Context, mcplib.CallToolRequest) (*mcplib.CallToolResult, error),
+	args map[string]any,
+) *mcplib.CallToolResult {
+	t.Helper()
+	req := mcplib.CallToolRequest{}
+	req.Params.Name = name
+	req.Params.Arguments = args
+	res, err := h(ctx, req)
+	require.NoError(t, err)
+	return res
+}
+
+// TestGenerateDocs_ConfinesAgentOutputPath closes an arbitrary-file write.
+//
+// generate_docs took output_path straight to os.MkdirAll + os.WriteFile with
+// no confinement of any kind, while the structurally identical export_graph
+// argument two files away was guarded. A prompt-injected agent could
+// therefore drive the daemon into truncating any file the daemon user can
+// write — the boundary SECURITY.md says is enforced.
+func TestGenerateDocs_ConfinesAgentOutputPath(t *testing.T) {
+	srv, _, repoRoot := newSingleRepoServer(t)
+	realRoot, err := filepath.EvalSymlinks(repoRoot)
+	require.NoError(t, err)
+	outside := t.TempDir()
+
+	escape := filepath.Join(outside, "escape.md")
+	agentCtx := WithSessionCWD(context.Background(), realRoot)
+
+	res := wikiTool(t, srv, agentCtx, "generate_docs", srv.handleGenerateDocs,
+		map[string]any{"output_path": escape})
+	require.True(t, res.IsError, "an agent write outside every repo root must be refused")
+	txt, _ := singleTextContent(res)
+	require.Contains(t, txt, "outside every indexed repository")
+	require.NoFileExists(t, escape, "the guard must run before os.WriteFile")
+
+	// No false positive: writing inside the repo is still allowed.
+	inside := filepath.Join(realRoot, "docs-out.md")
+	res = wikiTool(t, srv, agentCtx, "generate_docs", srv.handleGenerateDocs,
+		map[string]any{"output_path": inside})
+	require.False(t, res.IsError, "an in-repo write must still succeed: %v", res)
+	require.FileExists(t, inside)
+
+	// The operator-driven CLI / control channel carries no session cwd and
+	// stays free to write where the user names — same rule as export_graph.
+	cliEscape := filepath.Join(outside, "cli.md")
+	res = wikiTool(t, srv, context.Background(), "generate_docs", srv.handleGenerateDocs,
+		map[string]any{"output_path": cliEscape})
+	require.False(t, res.IsError, "the CLI channel must stay unconfined: %v", res)
+	require.FileExists(t, cliEscape)
+}
+
+// TestGenerateWiki_ConfinesAgentOutputDir is the directory-creating sibling:
+// output_dir becomes the writer root, so it steers where the whole generated
+// tree lands.
+func TestGenerateWiki_ConfinesAgentOutputDir(t *testing.T) {
+	srv, _, repoRoot := newSingleRepoServer(t)
+	realRoot, err := filepath.EvalSymlinks(repoRoot)
+	require.NoError(t, err)
+	outside := t.TempDir()
+
+	escapeDir := filepath.Join(outside, "escape-wiki")
+	agentCtx := WithSessionCWD(context.Background(), realRoot)
+
+	res := wikiTool(t, srv, agentCtx, "generate_wiki", srv.handleGenerateWiki,
+		map[string]any{"output_dir": escapeDir})
+	require.True(t, res.IsError, "an agent out-dir outside every repo root must be refused")
+	require.NoDirExists(t, escapeDir, "the guard must run before MkdirAll")
+
+	// `repo` is joined under output_dir, so it is a second route to the same
+	// primitive and must be confined too.
+	res = wikiTool(t, srv, agentCtx, "generate_wiki", srv.handleGenerateWiki,
+		map[string]any{"output_dir": realRoot, "repo": "../../../escape-via-repo"})
+	require.True(t, res.IsError, "a traversing repo segment must be refused")
+}

--- a/internal/mcp/tools_wiki_helpers.go
+++ b/internal/mcp/tools_wiki_helpers.go
@@ -1,6 +1,8 @@
 package mcp
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -113,4 +115,27 @@ func (a *watcherHistoryAdapter) HistorySince(since time.Time) []docs.HistoryEven
 		})
 	}
 	return out
+}
+
+// guardGeneratedOutputPath confines a caller-named output path for the
+// generator tools (generate_wiki, generate_docs) to the indexed repository
+// roots, on the same terms export_graph already applies to its own output
+// arguments.
+//
+// Those two tools wrote wherever the argument pointed: generate_docs took
+// output_path straight to os.MkdirAll + os.WriteFile, and generate_wiki's
+// output_dir became the writer root. A prompt-injected agent could therefore
+// drive the daemon into creating a tree — or truncating a file — anywhere the
+// daemon user can write, which is exactly what the export path was hardened
+// against. The guard is skipped for the operator-driven CLI / control channel
+// (confineCallerPaths), which asks for the write in the user's own name.
+func (s *Server) guardGeneratedOutputPath(ctx context.Context, path string) error {
+	if path == "" || !s.confineCallerPaths(ctx) {
+		return nil
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("resolve output path %q: %w", path, err)
+	}
+	return s.guardSymlinkWithinRepo(abs)
 }

--- a/internal/releases/releases.go
+++ b/internal/releases/releases.go
@@ -53,8 +53,8 @@ func ListTags(repoRoot string) []string {
 func ListTagsOnBranch(repoRoot, branch string) []string {
 	args := []string{"for-each-ref",
 		"--sort=creatordate", "--format=%(refname:short)"}
-	if strings.TrimSpace(branch) != "" {
-		args = append(args, "--merged="+branch)
+	if b := gitcmd.SafeRef(strings.TrimSpace(branch)); b != "" {
+		args = append(args, "--merged="+b)
 	}
 	args = append(args, "refs/tags/")
 	out, err := gitcmd.Run(context.Background(), repoRoot, args...)


### PR DESCRIPTION
Follow-up to the trust-boundary review in #510. These are pre-existing issues, independent of that PR and based on `main` so they can merge on their own.

Every finding below was traced end to end and, where the behaviour was testable, reproduced against real tools. Findings that did not survive that check are listed at the bottom rather than fixed.

## The model this is defending

The daemon runs as the invoking user (no `Setuid`/`Credential` anywhere; LaunchAgent / systemd `--user` / `schtasks /RL LIMITED`) and its socket is `0600` in a `0700` directory. **It never holds filesystem authority its caller lacks, so it cannot be used to reach another OS user's files.** That part is sound and unchanged.

What these commits address is the other half of `SECURITY.md`: the agent driving the tools is treated as potentially adversarial, and file-path confinement is named as the boundary. Several paths did not enforce it.

## 1. A git revision that git reads as an option

Revisions reach git as positional argv elements. argv has no quoting, so a value starting with `-` is a flag — and the diff family accepts `--output=<path>`.

Reachable from `base` / `base_ref` on twelve review/diff/contract tools and `branch` on the enrichers. Nothing validated them.

**Measured rather than assumed**, because my first read of this overstated it. The diff path builds `<ref>...HEAD` as one token, so git writes a file with a literal `...HEAD` suffix — arbitrary file *creation* in an existing directory carrying the real diff output, not truncation of an arbitrary file. The bare-token sites (`log`, `blame`) do truncate. `--git-dir` / `--work-tree` are **not** reachable: git accepts those only before the subcommand. And `enrich_churn`, which I originally named as the one-call path, turns out to be shielded by an unrelated `rev-parse --verify` pre-gate on the same value.

`gitcmd.ValidateRef` refuses a leading `-`, plus whitespace and control characters. Denylist by design: legitimate revisions (`HEAD~3`, `a...b`, `v1.2^{commit}`, `HEAD:path`) are far broader than ref names, and an allowlist tight enough to be safe would reject real input. `--end-of-options` was considered and rejected — git ≥2.24 only, position differs per subcommand, and it wouldn't cover the sites that build argv differently.

## 2. Write sinks with no confinement, and a boundary that could be moved

`generate_docs` passed `output_path` straight to `os.MkdirAll` + `os.WriteFile`; `generate_wiki`'s `output_dir` became the writer root with `repo` joined under it. The structurally identical `export_graph` arguments are guarded two files away — an omission, not a decision. All three now use that guard, with the same CLI/control-channel exemption.

Subtler: the boundary was **caller-extensible**. `guardRepoRoots` builds its allow-list from the tracked-root set, and `track_repository`'s `force` skips the guard refusing `/`, a drive root, and `$HOME`. Tracking `/` widened read *and* write access to the whole filesystem for every path tool, and persisted to global config.

`force` is now refused for agent sessions. Note the commit message for that change says it is "left to the operator" — that is wrong, and the later docs commit corrects it: `RepoEntry.Force` is settable **only** through the MCP tool, so this removes the field's only caller. The operator's route to indexing an otherwise-refused root is `gortex init --force`, a separate check that is unaffected.

## 3. Network surfaces reachable by anyone who can route to them

- **`gortex eval-server` bound `:4747`** — every interface, full tool catalogue, zero auth code in the handler. Now loopback by default, with `--bind` / `--auth-token` and the same non-loopback-requires-a-token rule the daemon uses.
- **`/mcp`'s Origin allowlist was never wired**, and the surface deliberately permits an unauthenticated loopback bind. A loopback port is reachable by any page the user visits, so any site could drive the tool surface. Cross-origin browser requests are now refused unless an operator names the origin via `--http-allowed-origin`. Requests with no `Origin` header are untouched — browsers always send it cross-origin, and MCP clients aren't browsers, so real callers are unaffected.
- **pprof** took its address from the environment with no bind check and served `DefaultServeMux` unauthenticated. `/debug/pprof/cmdline` echoes argv including `--http-auth-token`, and the heap holds indexed source. Now loopback-only.

## 4. Documentation: what is enforced, and where the risk becomes yours

`docs/multi-repo.md` called the session workspace "the hard isolation boundary" three times. It bounds *graph queries*; it is not a filesystem boundary — a session in one tracked repo can read and write another by absolute path, which I verified live. Corrected, with a pointer to `SECURITY.md`.

`SECURITY.md` gains the part that was missing. Several boundaries in this codebase stop at "the operator asked for it" — the CLI writes wherever you point it, a declared `workspace:` slug is honoured over the narrower directory-containment inference, an explicit `--index` gets a repo-local notebook. Those are defensible calls, but the reasoning lived in code comments, so a user could not tell which risks they had accepted. The policy now states the rule once (operator channel trusted, agent channel confined) and then enumerates **every decision that grants authority** with what it hands out — plus a **"what Gortex does not protect you from"** section, because an absent boundary is easy to mistake for a present one.

The load-bearing line: *tracking a repository is a standing grant of read and write access to every agent session on the machine*, and it reads like a convenience command.

## Verified not to be issues

Reported by analysis but refuted on inspection, and deliberately not "fixed":

- **`get_diagnostics` reading an unconfined path** — the bytes go to a language server the daemon spawns as the same uid, never to the caller, who receives only diagnostics. An existence oracle, not exfiltration.
- **`homeDirReason` not resolving symlinks** — a documented crawl-safety guard, and `track_repository("/etc")` needs no symlink anyway. Not a security control.
- **`query_project` bypassing the session clamp** — documented, intentional, and every tracked repo is already readable by the same user.
- **Non-constant-time bearer compare** — real inconsistency, but remote timing against a high-entropy operator-chosen secret isn't a practical attack.
- **Socket bind→chmod window** — the inode is `0755` at the default umask, which `connect(2)` cannot use. Exploitation needs `umask 002` with a shared primary group, plus winning a microsecond race.

One finding I chose **not** to fix here: `repoNarrowAdmits` treats an empty-but-non-nil allow-set as "no narrow" (fail open) while `buildASTTargets` treats the identical value as "admit nothing". That contradiction is real and worth resolving, but it changes semantics across ~18 call sites and deserves its own PR rather than riding along with security fixes.

## Verification

`go test ./...` — 143 packages, 0 failures. `go vet` clean. `golangci-lint run` — 0 issues. New tests cover the ref validator (including a live demonstration that git honours the option, so the test fails if that ever changes), the wiki/docs confinement (both the refusal and the no-false-positive case), and the origin guard.