### PR TITLE
csharp: stop member calls from binding to the calling method itself

### DIFF
--- a/internal/resolver/cross_repo.go
+++ b/internal/resolver/cross_repo.go
@@ -1474,7 +1474,10 @@ func (cr *CrossRepoResolver) resolveMethodCall(e *graph.Edge, methodName string,
 	receiverType := edgeReceiverType(e)
 	reachable := cr.reachabilityChecker(e)
 
-	// If we have a type hint, try exact type match first.
+	// If we have a type hint, try exact type match first. Both exact-type
+	// tiers stamp OriginASTResolved like the main resolver's Passes 1/2 —
+	// unstamped, their receiver-typed evidence would be indistinguishable
+	// from the name-tier binds semantic enrichment is allowed to reclaim.
 	if receiverType != "" {
 		// Same-repo + exact type.
 		for _, c := range candidates {
@@ -1483,6 +1486,7 @@ func (cr *CrossRepoResolver) resolveMethodCall(e *graph.Edge, methodName string,
 				nodeReceiverType(c) == receiverType {
 				e.To = c.ID
 				e.Confidence = 0.95
+				e.Origin = graph.OriginASTResolved
 				stats.Resolved++
 				return
 			}
@@ -1501,6 +1505,7 @@ func (cr *CrossRepoResolver) resolveMethodCall(e *graph.Edge, methodName string,
 			}
 			e.To = c.ID
 			e.Confidence = 0.85
+			e.Origin = graph.OriginASTResolved
 			stats.Resolved++
 			if isCrossRepoHop(callerRepo, c.RepoPrefix) {
 				e.CrossRepo = true

--- a/internal/resolver/csharp_facade_self_steal_test.go
+++ b/internal/resolver/csharp_facade_self_steal_test.go
@@ -57,10 +57,12 @@ namespace App.Services {
 	New(g).ResolveAll()
 
 	from := "FolioService.cs::FolioService.FetchSealedFolios"
+	matched := 0
 	for _, e := range g.GetOutEdges(from) {
 		if e.Kind != graph.EdgeCalls || !strings.HasSuffix(e.To, "FetchSealedFolios") {
 			continue
 		}
+		matched++
 		require.NotEqual(t, from, e.To,
 			"member call on the injected field must not bind to the calling method itself (got conf=%v origin=%q)",
 			e.Confidence, e.Origin)
@@ -73,6 +75,10 @@ namespace App.Services {
 				"an origin-unstamped name-tier bind at >=0.9 masquerades as AST-grade (to=%s)", e.To)
 		}
 	}
+	// The loop's assertions are only meaningful if the extractor emitted
+	// the call at all — zero matches would pass vacuously on an ID-scheme
+	// drift.
+	require.NotZero(t, matched, "no FetchSealedFolios call edges found — fixture or ID scheme broke")
 }
 
 // Control: the gate must not disturb same-class binds that carry real

--- a/internal/resolver/csharp_facade_self_steal_test.go
+++ b/internal/resolver/csharp_facade_self_steal_test.go
@@ -1,0 +1,98 @@
+package resolver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// The facade shape: a service wraps a repository method under the SAME
+// name, calling through an interface-typed field the extractor cannot
+// type (fields never reach the tenv). The caller-receiver fallback used
+// to answer "does the caller's own class declare this name?" — yes — and
+// bind `_archive.FetchSealedFolios(...)` to the calling method ITSELF, a
+// 0.9 self-loop with no Origin stamp. The PHP shield above that fallback
+// documents the identical failure for `$this->handler->setFormatter()`;
+// this pins the C# side.
+func TestCSharpFacade_MemberCallDoesNotStealToSelf(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"IFolioArchive.cs": `using System.Collections.Generic;
+
+namespace App.Contracts {
+    public interface IFolioArchive {
+        IReadOnlyList<int> FetchSealedFolios(int year);
+    }
+}`,
+		"FolioArchive.cs": `using System.Collections.Generic;
+using App.Contracts;
+
+namespace App.Data {
+    public class FolioArchive : IFolioArchive {
+        public IReadOnlyList<int> FetchSealedFolios(int year) {
+            return new List<int> { year };
+        }
+    }
+}`,
+		"FolioService.cs": `using System.Collections.Generic;
+using App.Contracts;
+
+namespace App.Services {
+    public class FolioService {
+        private readonly IFolioArchive _archive;
+
+        public FolioService(IFolioArchive archive) {
+            _archive = archive;
+        }
+
+        public IReadOnlyList<int> FetchSealedFolios(int year) {
+            var folios = _archive.FetchSealedFolios(year);
+            return folios;
+        }
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	from := "FolioService.cs::FolioService.FetchSealedFolios"
+	for _, e := range g.GetOutEdges(from) {
+		if e.Kind != graph.EdgeCalls || !strings.HasSuffix(e.To, "FetchSealedFolios") {
+			continue
+		}
+		require.NotEqual(t, from, e.To,
+			"member call on the injected field must not bind to the calling method itself (got conf=%v origin=%q)",
+			e.Confidence, e.Origin)
+		// Whatever tier picked a target, the bind must stay below the AST
+		// ceiling so semantic enrichment can still claim the site — the
+		// old fallback's unstamped 0.9 backfills to ast_resolved and
+		// blocks the retarget.
+		if e.Origin == "" {
+			require.Less(t, e.Confidence, 0.9,
+				"an origin-unstamped name-tier bind at >=0.9 masquerades as AST-grade (to=%s)", e.To)
+		}
+	}
+}
+
+// Control: the gate must not disturb same-class binds that carry real
+// receiver evidence — `this.Helper()` states the receiver type and binds
+// at the exact-type tier.
+func TestCSharpFacade_ThisCallStillBindsOwnClass(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Tower.cs": `namespace App {
+    public class Tower {
+        public int Height() {
+            return this.Helper();
+        }
+
+        public int Helper() { return 3; }
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	edge := findCallEdge(g, "Tower.cs::Tower.Height", "Tower.cs::Tower.Helper")
+	require.NotNil(t, edge, "this.Helper() must still bind to the own-class member")
+	require.GreaterOrEqual(t, edge.Confidence, 0.9)
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -4104,12 +4104,13 @@ func (r *Resolver) resolveMethodCall(e *graph.Edge, methodName string, stats *Re
 	//
 	// C# member calls are exempt: a member_call edge still untyped here has
 	// an explicit receiver that is NOT this/base (those carry receiver_type
-	// from extraction) — a field, parameter, or untyped local. Whether the
-	// CALLER's class declares a same-named method says nothing about such a
-	// receiver, and on facade classes that wrap a same-named repository
-	// method this fallback bound the call to the calling method ITSELF (the
-	// PHP shield above exists for the identical failure). Leave the site for
-	// the extension/locality tiers and semantic enrichment.
+	// from extraction) — a field, parameter, or an expression the tenv
+	// couldn't type. Whether the CALLER's class declares a same-named method
+	// says nothing about such a receiver, and on facade classes that wrap a
+	// same-named repository method this fallback bound the call to the
+	// calling method ITSELF (the PHP shield above exists for the identical
+	// failure). Leave the site for the extension/locality tiers and
+	// semantic enrichment.
 	memberCall, _ := e.Meta["member_call"].(bool)
 	callerNode := r.cachedGetNode(e.From)
 	if callerNode != nil && callerNode.Kind == graph.KindMethod && !memberCall {
@@ -4174,7 +4175,8 @@ func (r *Resolver) resolveMethodCall(e *graph.Edge, methodName string, stats *Re
 		}
 		// A member call never locality-binds to the calling method itself:
 		// `x.Foo()` inside Foo is the facade shape wrapping a same-named
-		// member on x, not recursion — recursion is an unqualified call.
+		// member on x, not recursion — self-recursion through `this`
+		// carries receiver_type and resolves in the typed passes above.
 		if memberCall && c.ID == e.From {
 			continue
 		}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -4101,8 +4101,18 @@ func (r *Resolver) resolveMethodCall(e *graph.Edge, methodName string, stats *Re
 	// If the caller is a method on type X and there's a candidate method on
 	// type X with the same name, prefer it.  This handles e.extractFunctions()
 	// where the type env doesn't have a hint for parameter-bound receivers.
+	//
+	// C# member calls are exempt: a member_call edge still untyped here has
+	// an explicit receiver that is NOT this/base (those carry receiver_type
+	// from extraction) — a field, parameter, or untyped local. Whether the
+	// CALLER's class declares a same-named method says nothing about such a
+	// receiver, and on facade classes that wrap a same-named repository
+	// method this fallback bound the call to the calling method ITSELF (the
+	// PHP shield above exists for the identical failure). Leave the site for
+	// the extension/locality tiers and semantic enrichment.
+	memberCall, _ := e.Meta["member_call"].(bool)
 	callerNode := r.cachedGetNode(e.From)
-	if callerNode != nil && callerNode.Kind == graph.KindMethod {
+	if callerNode != nil && callerNode.Kind == graph.KindMethod && !memberCall {
 		callerRecv := nodeReceiverType(callerNode)
 		if callerRecv != "" {
 			// Same receiver type + same directory = very high confidence.
@@ -4160,6 +4170,12 @@ func (r *Resolver) resolveMethodCall(e *graph.Edge, methodName string, stats *Re
 		// rule above; a locality guess must never pick one, which would
 		// misattribute `x.Foo()` to an unrelated extension named Foo.
 		if isCSharpExtension(c) {
+			continue
+		}
+		// A member call never locality-binds to the calling method itself:
+		// `x.Foo()` inside Foo is the facade shape wrapping a same-named
+		// member on x, not recursion — recursion is an unqualified call.
+		if memberCall && c.ID == e.From {
 			continue
 		}
 		switch c.Kind {

--- a/internal/semantic/tstypes/csharp_facade_test.go
+++ b/internal/semantic/tstypes/csharp_facade_test.go
@@ -1,0 +1,144 @@
+package tstypes
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// The facade shape from the field report: a service wraps a repository
+// method under the SAME name, calling through an interface-typed field.
+// The resolver's caller-receiver fallback used to steal that call for
+// the calling method itself — a 0.9 self-loop with no Origin stamp —
+// and claimable() then graded the guess at the AST ceiling (the
+// DefaultOriginFor backfill maps conf>=0.9 to ast_resolved), so the
+// engine computed the right target and threw it away. Field-typed
+// evidence must be able to reclaim the site.
+func TestCSharp_FacadeSelfLoopIsClaimable(t *testing.T) {
+	g, dir := buildFixture(t, map[string]string{
+		"A/IFolioArchive.cs": `using System.Collections.Generic;
+
+namespace App.Contracts {
+    public interface IFolioArchive {
+        IReadOnlyList<int> FetchSealedFolios(int year);
+    }
+}
+`,
+		"A/FolioArchive.cs": `using System.Collections.Generic;
+using App.Contracts;
+
+namespace App.Data {
+    public class FolioArchive : IFolioArchive {
+        public IReadOnlyList<int> FetchSealedFolios(int year) {
+            return new List<int> { year };
+        }
+    }
+}
+`,
+		"B/FolioService.cs": `using System.Collections.Generic;
+using App.Contracts;
+
+namespace App.Services {
+    public class FolioService {
+        private readonly IFolioArchive _archive;
+
+        public FolioService(IFolioArchive archive) {
+            _archive = archive;
+        }
+
+        public IReadOnlyList<int> FetchSealedFolios(int year) {
+            var folios = _archive.FetchSealedFolios(year);
+            return folios;
+        }
+    }
+}
+`,
+	})
+
+	callerID := "B/FolioService.cs::FolioService.FetchSealedFolios"
+	edges := callEdgesNamed(g, callerID, "FetchSealedFolios")
+	if len(edges) != 1 {
+		t.Fatalf("expected the one extracted member-call stub, got %v", edges)
+	}
+	// Simulate the resolver damage exactly as minted by the
+	// caller-receiver fallback: bound to the calling method itself,
+	// confidence 0.9, Origin never stamped.
+	self := edges[0]
+	oldTo := self.To
+	self.To = callerID
+	self.Confidence = 0.9
+	self.Origin = ""
+	g.ReindexEdge(self, oldTo)
+
+	p := NewProvider(CSharpSpec(), zap.NewNop())
+	if _, err := p.Enrich(g, dir); err != nil {
+		t.Fatal(err)
+	}
+
+	ifaceID := "A/IFolioArchive.cs::IFolioArchive.FetchSealedFolios"
+	e := callEdgeTo(g, callerID, ifaceID)
+	if e == nil {
+		t.Fatalf("field-typed evidence must reclaim the self-stolen site; edges: %v", g.GetOutEdges(callerID))
+	}
+	assertASTProvenance(t, e, "csharp-types")
+	if callEdgeTo(g, callerID, callerID) != nil {
+		t.Errorf("the self-loop must be retargeted, not kept alongside the fix")
+	}
+}
+
+// Guard rail: a bind that carries an explicit ast_resolved stamp — real
+// structural evidence, not a backfilled guess — must stay unclaimable
+// even when it disagrees with the engine's pick.
+func TestCSharp_ExplicitASTResolvedBindStaysUnclaimed(t *testing.T) {
+	g, dir := buildFixture(t, map[string]string{
+		"A/IFolioArchive.cs": `using System.Collections.Generic;
+
+namespace App.Contracts {
+    public interface IFolioArchive {
+        IReadOnlyList<int> FetchSealedFolios(int year);
+    }
+}
+`,
+		"B/FolioService.cs": `using System.Collections.Generic;
+using App.Contracts;
+
+namespace App.Services {
+    public class FolioService {
+        private readonly IFolioArchive _archive;
+
+        public FolioService(IFolioArchive archive) {
+            _archive = archive;
+        }
+
+        public IReadOnlyList<int> FetchSealedFolios(int year) {
+            var folios = _archive.FetchSealedFolios(year);
+            return folios;
+        }
+    }
+}
+`,
+	})
+
+	callerID := "B/FolioService.cs::FolioService.FetchSealedFolios"
+	edges := callEdgesNamed(g, callerID, "FetchSealedFolios")
+	if len(edges) != 1 {
+		t.Fatalf("expected the one extracted member-call stub, got %v", edges)
+	}
+	self := edges[0]
+	oldTo := self.To
+	self.To = callerID
+	self.Confidence = 0.9
+	self.Origin = graph.OriginASTResolved
+	g.ReindexEdge(self, oldTo)
+
+	p := NewProvider(CSharpSpec(), zap.NewNop())
+	if _, err := p.Enrich(g, dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if e := callEdgeTo(g, callerID, callerID); e == nil {
+		t.Fatalf("an explicitly ast_resolved bind must not be retargeted; edges: %v", g.GetOutEdges(callerID))
+	}
+}

--- a/internal/semantic/tstypes/csharp_facade_test.go
+++ b/internal/semantic/tstypes/csharp_facade_test.go
@@ -142,3 +142,50 @@ namespace App.Services {
 		t.Fatalf("an explicitly ast_resolved bind must not be retargeted; edges: %v", g.GetOutEdges(callerID))
 	}
 }
+
+// Recursion through a SELF-typed field (linked list, chain of
+// responsibility): `next.Print()` inside Print, where `next` is a field
+// of the enclosing class. The resolver's facade gate leaves this site
+// as a stub on purpose — so the engine must be able to claim it when
+// its field-type evidence names the calling method itself. Only
+// claiming: a fresh self-edge is still never minted (that stays the
+// self-guard's job).
+func TestCSharp_SelfTypedFieldRecursionClaimsStub(t *testing.T) {
+	g, dir := buildFixture(t, map[string]string{
+		"A/Node.cs": `namespace App {
+    public class Node {
+        private Node next;
+
+        public void Print() {
+            if (next != null) {
+                next.Print();
+            }
+        }
+    }
+}
+`,
+	})
+
+	callerID := "A/Node.cs::Node.Print"
+	edges := callEdgesNamed(g, callerID, "Print")
+	if len(edges) != 1 {
+		t.Fatalf("expected the one extracted member-call stub, got %v", edges)
+	}
+	if !isStubTarget(edges[0].To) {
+		t.Fatalf("precondition: the call must be an unresolved stub, got %q", edges[0].To)
+	}
+
+	p := NewProvider(CSharpSpec(), zap.NewNop())
+	if _, err := p.Enrich(g, dir); err != nil {
+		t.Fatal(err)
+	}
+
+	e := callEdgeTo(g, callerID, callerID)
+	if e == nil {
+		t.Fatalf("typed-field recursion must claim the stub back to the caller; edges: %v", g.GetOutEdges(callerID))
+	}
+	assertASTProvenance(t, e, "csharp-types")
+	if got := len(callEdgesNamed(g, callerID, "Print")); got != 1 {
+		t.Errorf("the stub must be claimed in place, not duplicated: %d edges", got)
+	}
+}

--- a/internal/semantic/tstypes/engine.go
+++ b/internal/semantic/tstypes/engine.go
@@ -1710,6 +1710,23 @@ func (a *applier) claimable(e *graph.Edge) bool {
 	if isStubTarget(e.To) {
 		return true
 	}
+	// A member-call bind that never got an Origin stamp came from the
+	// resolver's name-locality tiers (the caller-receiver and locality
+	// fallbacks stamp none) — name evidence no matter its confidence.
+	// Without this, the DefaultOriginFor backfill grades a 0.9 guess at
+	// the AST ceiling and blocks the retarget: the facade shape (a
+	// service wrapping a same-named repository method) stays bound to
+	// the calling method itself forever. Explicitly stamped tiers, DI
+	// binds (resolution marker), and provider edges (semantic_source)
+	// keep their rank.
+	if e.Origin == "" && e.Meta != nil {
+		mc, _ := e.Meta["member_call"].(bool)
+		_, hasResolution := e.Meta["resolution"]
+		_, hasSemantic := e.Meta["semantic_source"]
+		if mc && !hasResolution && !hasSemantic {
+			return true
+		}
+	}
 	return graph.OriginRank(effectiveOrigin(e)) < graph.OriginRank(graph.OriginASTResolved)
 }
 

--- a/internal/semantic/tstypes/engine.go
+++ b/internal/semantic/tstypes/engine.go
@@ -1065,7 +1065,7 @@ func (a *applier) applyCall(idx *fileIndex, cf callFact, res *semantic.EnrichRes
 		return
 	}
 	caller := idx.enclosingCallable(cf.line)
-	if caller == nil || caller.ID == target.ID {
+	if caller == nil {
 		return
 	}
 	strategy, confidence := strategyDirect, astConfidence
@@ -1073,6 +1073,15 @@ func (a *applier) applyCall(idx *fileIndex, cf callFact, res *semantic.EnrichRes
 		// The receiver type was derived through a chained return-type
 		// rewrite rather than a direct binding — grade the edge honestly.
 		strategy, confidence = strategyInferred, inferredConfidence
+	}
+	if caller.ID == target.ID {
+		// A SELF-typed receiver — a field of the enclosing class calling
+		// the same method (linked list, chain of responsibility) — makes
+		// the calling method its own genuine target. Claim the extracted
+		// stub in place; minting a fresh self-edge stays forbidden, which
+		// is what this guard has always been for.
+		a.upgradeExistingCall(caller, target, cf, res, strategy, confidence)
+		return
 	}
 	a.upgradeOrCreateCall(caller, target, cf, idx.facts.file, res, strategy, confidence)
 }
@@ -1338,13 +1347,26 @@ func (a *applier) buildExtensionIndex() {
 // a fresh edge. Edges that already carry compiler/AST-grade provenance
 // pointing elsewhere are never overridden.
 func (a *applier) upgradeOrCreateCall(caller, target *graph.Node, cf callFact, file string, res *semantic.EnrichResult, strategy resolutionStrategy, confidence float64) {
+	if a.upgradeExistingCall(caller, target, cf, res, strategy, confidence) {
+		return
+	}
+	a.addASTEdge(caller.ID, target.ID, graph.EdgeCalls, file, cf.line, strategy, confidence)
+	res.EdgesAdded++
+}
+
+// upgradeExistingCall confirms or retargets an edge already present at
+// the call site and reports whether the site is handled — false means
+// no edge matched and the caller may mint a fresh one. Split out so the
+// self-target path (a SELF-typed receiver field, where target == caller)
+// can claim the extracted stub without ever being allowed to create.
+func (a *applier) upgradeExistingCall(caller, target *graph.Node, cf callFact, res *semantic.EnrichResult, strategy resolutionStrategy, confidence float64) bool {
 	outs := a.outEdges(caller.ID)
 	for _, e := range outs {
 		if e.Kind == graph.EdgeCalls && e.To == target.ID {
 			if a.confirmCall(e, strategy, confidence) {
 				res.EdgesConfirmed++
 			}
-			return
+			return true
 		}
 	}
 	for _, e := range outs {
@@ -1358,17 +1380,16 @@ func (a *applier) upgradeOrCreateCall(caller, target *graph.Node, cf callFact, f
 			// A same-line edge for this name already carries
 			// equal-or-stronger evidence for a different target —
 			// leave it alone and don't double the call site.
-			return
+			return true
 		}
 		oldTo := e.To
 		e.To = target.ID
 		a.reindexEdge(e, oldTo)
 		a.confirmCall(e, strategy, confidence)
 		res.EdgesConfirmed++
-		return
+		return true
 	}
-	a.addASTEdge(caller.ID, target.ID, graph.EdgeCalls, file, cf.line, strategy, confidence)
-	res.EdgesAdded++
+	return false
 }
 
 // confirmCall lands the provenance of a resolved call edge at the band
@@ -1711,8 +1732,8 @@ func (a *applier) claimable(e *graph.Edge) bool {
 		return true
 	}
 	// A member-call bind that never got an Origin stamp came from the
-	// resolver's name-locality tiers (the caller-receiver and locality
-	// fallbacks stamp none) — name evidence no matter its confidence.
+	// resolver's caller-receiver fallback (which stamps no Origin) or a
+	// pre-stamping vintage — name evidence no matter its confidence.
 	// Without this, the DefaultOriginFor backfill grades a 0.9 guess at
 	// the AST ceiling and blocks the retarget: the facade shape (a
 	// service wrapping a same-named repository method) stays bound to


### PR DESCRIPTION
Title: csharp: stop member calls from binding to the calling method itself

## Problem

Field-testing on my production C# codebase: `callers` on a repository
interface method never returns the service that calls it through a
ctor-injected field — the dominant DI/delegation pattern there. The graph
shows why: the service's call is bound to **the calling method itself** as a
0.9-confidence self-loop, and no edge into the interface exists at all.

The trigger is the facade shape — a service wrapping a repository method
under the same name:

```csharp
public class FolioService {
    private readonly IFolioArchive _archive;

    public IReadOnlyList<int> FetchSealedFolios(int year) {
        return _archive.FetchSealedFolios(year);   // → bound to FolioService.FetchSealedFolios (itself)
    }
}
```

Sibling methods whose names differ from the wrapped method (e.g. an `Async`
suffix) bind correctly at 0.95 via csharp-types — which is what hid this for
so long.

## Root cause (two layers)

1. **The caller-receiver fallback is receiver-blind.** When
   `resolveMethodCall` reaches the fallback with no `receiver_type` (fields
   never reach the extraction tenv), it asks only "does the caller's own
   class declare this name?" — and for a facade the answer is yes, so the
   call binds to the enclosing method at 0.9 with no Origin stamp. The PHP
   shield directly above the fallback documents this exact self-bind failure
   for `$this->handler->setFormatter()`; C# had no equivalent.
2. **The unstamped 0.9 masquerades as AST-grade.** `DefaultOriginFor` maps
   `confidence >= 0.9` to `ast_resolved`, so the tstypes applier's
   `claimable()` ranks the guess at the AST ceiling. Enrichment then computes
   the correct interface target, hits the same-line self edge in
   `upgradeOrCreateCall`, and honours don't-double-the-call-site — the right
   edge is silently dropped, permanently.

A `member_call` edge that reaches the fallback untyped necessarily has an
explicit receiver that is *not* `this`/`base` (those carry `receiver_type`
from extraction), so the caller's own member set is no evidence about it.

## Fix

- `resolveMethodCall`: exempt `member_call` edges from the caller-receiver
  fallback, mirroring the PHP shield; and never let the locality fallback
  bind a member call to its own caller (`x.Foo()` inside `Foo` is the facade
  shape, not recursion — recursion is an unqualified call).
- tstypes `claimable`: an origin-unstamped `member_call` bind with no
  `resolution`/`semantic_source` marker came from the name-locality tiers by
  construction — treat it as claimable regardless of the backfilled
  confidence. This half also heals **existing** stores on their next
  enrichment pass: already-resolved edges never re-enter the resolver, so
  without it every deployed index keeps its self-loops until a full rebuild.

The `member_call` marker is stamped only by the C# extractor, so both gates
are C#-scoped by construction; no other language's fallback behavior
changes. No extractor changes, no version bump.

## Behavior changes worth knowing (reviewed for blast radius)

- **Member calls on fields typed as the enclosing class** lose the old
  type-filtered 0.9 bind. Wrapped targets heal to a true 0.95 via
  csharp-types enrichment (fields are exactly what it types); in the window
  before enrichment — or with the C# provider disabled — these sites sit at
  `text_matched`/unresolved instead. Recursion through a self-typed field
  (`next.Print()` inside `Print` — linked lists, chains of responsibility)
  is covered: the applier's self-guard now *claims the extracted stub* when
  typed-field evidence names the calling method itself, while minting fresh
  self-edges stays forbidden.
- **Scoring/tier consumers**: the affected population previously backfilled
  to `ast_resolved` (the conf>=0.9 rule); as explicit `text_matched` it now
  weighs honestly in path confidence, provenance weighting, and `min_tier`
  filtering until enrichment lands the real bind at 0.95.
- **Suppression/dispatch precision**: the old unstamped 0.9 binds escaped
  `SuppressRedundantTextMatches` and could seed interface-dispatch fan-out
  from wrong callers; as stamped `text_matched` they suppress and fan
  correctly.
- **Existing stores**: persisted self-loops are reused as-is by incremental
  indexing and heal at each file's next enrichment pass (the claimable
  half), not at reuse time.

## Tests

TDD, both layers watched red first:

- `TestCSharpFacade_MemberCallDoesNotStealToSelf` — the facade fixture
  through the real extractor + `ResolveAll`; red on the self-loop at
  0.9/no-origin, green with the target off-self and any unstamped bind below
  0.9. Control: `this.Helper()` still binds its own class at ≥0.9.
- `TestCSharp_FacadeSelfLoopIsClaimable` — reproduces the resolver damage on
  an extracted fixture (self-target, 0.9, `Origin=""`), runs `Enrich`, and
  requires the site retargeted to the interface method at AST provenance
  with the self-loop gone. Guard rail:
  `TestCSharp_ExplicitASTResolvedBindStaysUnclaimed` pins that an edge
  explicitly stamped `ast_resolved` is still never retargeted.
- `TestCSharp_SelfTypedFieldRecursionClaimsStub` — the population an
  adversarial review round caught the first cut orphaning: recursion
  through a field typed as the enclosing class. The resolver gate leaves it
  a stub by design, and the applier's self-guard used to refuse the claim
  too, stranding the site. `upgradeOrCreateCall` is split so the
  self-target path claims an existing stub without ever being allowed to
  create; watched red before the split.

Same review round: cross_repo's exact-type tiers now stamp
`OriginASTResolved` like the main resolver's typed passes — unstamped,
their receiver-typed binds were indistinguishable from the name-tier family
`claimable()` may reclaim.

Suites: resolver/indexer failure name-sets byte-identical to clean main on
my Windows box (pre-existing platform failures only, worktree-verified);
tstypes and languages fully green.

## Validation

Deployed on a rebuilt binary with a from-scratch index:

- My counted C# fixture repo's facade cell flipped from the pinned
  self-loop to the wrapped interface method at 0.95 (csharp-types) plus the
  concrete impl at 0.85 — and a second, older pinned cell (the original
  sighting of this steal: a controller's `_repository.Read` grabbed by its
  own `Read`) flipped green with it. No other pinned cell drifted.
- On the production repo, the acceptance pair now exists in the graph: the
  service's call binds the repository interface method at 0.95 with the
  impl fan-out at 0.85; the self-loop and the spurious service-interface
  mirror are gone. Re-running my acceptance probe closed the loop — a
  single `callers` query on the interface method now walks the full
  production chain, including a second interface-dispatch hop to the
  consumer the original investigation started from.
