### PR TITLE
docs: refresh the contributing guide and invite newcomers to Discord

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,29 @@
 # Contributing to Gortex
 
-Thank you for considering contributing to Gortex! This guide will help you get started.
+Thank you for considering contributing to Gortex! This guide will help you get
+started.
+
+## Come say hello
+
+Most day-to-day discussion happens on Discord:
+
+**[discord.gg/39MFHu3J5d](https://discord.gg/39MFHu3J5d)**
+
+If you're new, join and introduce yourself — what you work on, which languages
+or ecosystems you care about, and what brought you to Gortex. It's the fastest
+way to:
+
+- find out whether someone is already working on the thing you want to build,
+- sanity-check a design before you write the code,
+- get unstuck on a build, a tree-sitter grammar, or a failing test,
+- coordinate on larger changes that touch several subsystems.
+
+Issues and pull requests are still the source of truth for anything that ships.
+Discord is where the coordination happens so PRs don't collide.
+
+Please also read the [Code of Conduct](CODE_OF_CONDUCT.md); it applies to
+Discord, issues, and pull requests alike. Security issues go through
+[SECURITY.md](SECURITY.md), **not** a public issue.
 
 ## Licensing of contributions
 
@@ -12,14 +35,16 @@ contribution; the project retains a perpetual, worldwide, royalty-free
 license to use, modify, and redistribute it as part of Gortex.
 
 Contributors are listed in [CONTRIBUTORS.md](CONTRIBUTORS.md). Add yourself
-to that file in the dedicated PR, linking previous contributions if you'd like to be credited.
+to that file in a dedicated PR, linking your previous contributions, if you'd
+like to be credited.
 
 ## Getting Started
 
 ### Prerequisites
 
-- Go 1.25+
-- CGO enabled (required for tree-sitter C bindings)
+- Go 1.26+ (the toolchain version is pinned in `go.mod`; CI builds with it)
+- CGO enabled and a working C/C++ compiler — tree-sitter grammars are C.
+  On Windows the mingw-w64 toolchain works; that's what CI uses.
 - Git
 
 ### Building
@@ -30,19 +55,75 @@ cd gortex
 go build -o gortex ./cmd/gortex/
 ```
 
+A cold build compiles several hundred vendored tree-sitter grammars, so expect
+minutes rather than seconds the first time. Later builds hit the Go build cache
+and are fast.
+
+`make build` does the same thing but adds `-tags llama` for the in-process
+llama.cpp LLM provider. The plain `go build` above is the configuration CI
+checks and is the right default for most work. Other optional build tags:
+
+| Tag | Enables |
+|-----|---------|
+| `llama` | In-process llama.cpp provider (`llm.provider: local`) |
+| `embeddings_onnx` | ONNX Runtime embedding backend |
+| `embeddings_gomlx` (+ `XLA`) | GoMLX embedding backend |
+| `netgo,osusergo,static_link` | The fully static Linux release build |
+
 ### Running Tests
 
 ```bash
 go test -race ./...
 ```
 
+CI runs the suite with `-timeout=20m` on Linux and macOS. A few packages —
+`internal/persistence` in particular — are slow under `-race`, so if you hit the
+default 10-minute panic, raise the timeout rather than assuming a hang.
+
+### Linting
+
+```bash
+make lint      # golangci-lint run --timeout=5m
+```
+
+**A green test run is not the full CI gate.** CI pins golangci-lint to
+**v2.11.4** and fails the build on any finding. Run it locally before opening a
+PR — config lives in [`.golangci.yaml`](.golangci.yaml).
+
+```bash
+make fmt       # gofmt -s -w .
+```
+
 ### Running Benchmarks
+
+```bash
+make bench
+```
+
+Or target a single package:
 
 ```bash
 go test -bench=. -benchmem ./internal/parser/languages/
 go test -bench=. -benchmem ./internal/query/
-go test -bench=. -benchmem ./internal/indexer/
+go test -bench=. -benchmem ./internal/graph/
 ```
+
+### What CI checks
+
+Your PR has to get past all of these
+([`.github/workflows/ci.yml`](.github/workflows/ci.yml)):
+
+- `go build` + `go test -race` on `ubuntu-latest` and `macos-latest`
+- a native Windows CGO build, plus focused tests for the agent, path-guard, and
+  sidecar code paths whose behaviour differs there
+- a static Linux build (`netgo,osusergo,static_link`) verified to be
+  self-contained and smoke-tested inside `debian:11` and `alpine:3`
+- golangci-lint
+- builds with the ONNX and GoMLX embedding tags
+- benchmarks for the parser, query, and graph packages
+
+Additional workflows cover security scanning, the install script, init smoke
+tests, and skill drift.
 
 ## How to Contribute
 
@@ -55,7 +136,8 @@ go test -bench=. -benchmem ./internal/indexer/
 ### Suggesting Features
 
 - Open an issue describing the feature and its use case
-- For language support requests, mention if the tree-sitter grammar is available in `github.com/smacker/go-tree-sitter`
+- For language support requests, say whether an upstream tree-sitter grammar
+  exists — see [Adding a Language](#adding-a-language) for the tiers
 
 ### Submitting Code
 
@@ -63,20 +145,46 @@ go test -bench=. -benchmem ./internal/indexer/
 2. Create a feature branch (`git checkout -b feature/my-feature`)
 3. Write tests for your changes
 4. Ensure all tests pass (`go test -race ./...`)
-5. Commit with a clear message
-6. Open a pull request
+5. Ensure the linter is clean (`make lint`)
+6. Commit with a clear message
+7. Open a pull request and fill in the template
 
-### Adding a New Language Extractor
+Small, focused PRs get reviewed fastest. If a change is large or crosses
+subsystem boundaries, raise it on Discord or in an issue first — it's much
+cheaper to redirect a design than a finished branch.
 
-This is one of the most impactful contributions. Follow these steps:
+## Adding a Language
 
-1. Check if the tree-sitter grammar exists in `github.com/smacker/go-tree-sitter`
-2. Create `internal/parser/languages/<language>.go` implementing the `parser.Extractor` interface
-3. Create `internal/parser/languages/<language>_test.go` with at least 3 tests
-4. Register it in `internal/parser/languages/register.go`
-5. Debug the AST first — tree-sitter node types vary between grammars
+This is one of the most impactful contributions. Gortex indexes languages
+through three engine tiers, in order of decreasing extraction depth and
+increasing ease:
+
+1. **Bespoke tree-sitter** — a vendored grammar under
+   [`internal/parser/tsitter/`](internal/parser/tsitter/) plus a hand-tuned
+   extractor in [`internal/parser/languages/`](internal/parser/languages/) with
+   per-language S-expression queries. Worth it when you need ORM, contract,
+   dataflow, or scope-aware call resolution.
+2. **Regex** — pattern-matched line scanning for languages with no upstream
+   grammar. Shared block helpers live in `helpers_indent.go`.
+3. **Forest signature-only** — if
+   [`alexaandru/go-sitter-forest`](https://github.com/alexaandru/go-sitter-forest)
+   already ships a grammar, add the module and append one row to
+   `forestLanguages` in
+   [`forest_registrations.go`](internal/parser/languages/forest_registrations.go).
+   Cheapest path, broadest coverage, no deep extraction.
+
+[**docs/languages.md**](docs/languages.md) documents each tier, the current
+language matrix, and the exact steps — read it before you start.
+
+Hand-written extractors implement the `parser.Extractor` interface
+([`internal/parser/extractor.go`](internal/parser/extractor.go)) and are
+registered in `RegisterAll` in
+[`register.go`](internal/parser/languages/register.go). Registration order
+matters: extractors registered before `registerForestLanguages` claim their
+extensions ahead of the generic forest grammars.
 
 **What to extract (in priority order):**
+
 - Functions/methods with `EdgeMemberOf` to their class/type
 - Classes/types/interfaces
 - Interface method specs in `Meta["methods"]` (enables IMPLEMENTS inference)
@@ -85,37 +193,69 @@ This is one of the most impactful contributions. Follow these steps:
 - Variables/constants
 
 **Reference implementations:**
+
 - `golang.go` — the most complete extractor
 - `python.go` — simple OOP language
 - `rust.go` — systems language with impl blocks
+- `nim.go` / `abap.go` — regex-tier templates
 - `yaml.go` — simple config extractor
 
-### Code Style
+Every extractor ships a `_test.go` with at least a happy-path and an
+empty-input case. Debug the AST first — tree-sitter node types vary between
+grammars.
 
-- Follow standard Go conventions (`gofmt`, `go vet`)
-- No unnecessary abstractions — three similar lines is better than a premature helper
+## Code Style
+
+- Follow standard Go conventions (`gofmt -s`, `go vet`, golangci-lint)
+- No unnecessary abstractions — three similar lines is better than a premature
+  helper
+- Comments explain *why*, not *what*; match the density of the surrounding code
 - Tests should be self-contained with inline source snippets
-- Extractor test helpers (`nodesOfKind`, `edgesOfKind`) are shared across test files
+- Extractor test helpers (`nodesOfKind`, `edgesOfKind`) are shared across test
+  files
 
 ## Project Structure
 
 ```
-cmd/gortex/          CLI entry point and commands
+cmd/gortex/          CLI entry point and subcommands
+pkg/gortex/          Public API for embedding Gortex in another Go program
+docs/                Reference documentation (see below)
 internal/
-  analysis/          Community detection, process discovery, impact analysis
-  claudemd/          CLAUDE.md generator
-  config/            Configuration loading
-  graph/             Core graph data structure (Node, Edge, Graph)
-  indexer/           Directory walker, file watcher
+  analysis/          Communities, processes, hotspots, architecture rollups
+  contracts/         Contract definitions and checking
+  daemon/            Long-running daemon: lifecycle, watchers, federation
+  graph/             Core graph data structures (Node, Edge, Graph)
+  indexer/           Directory walker, file watcher, incremental reindex
+  llm/               LLM providers and the `ask` agent
   mcp/               MCP server and tool handlers
-  parser/            Extractor interface, tree-sitter helpers
+  parser/            Extractor interface, tree-sitter plumbing, registry
     languages/       Per-language extractors (one file each)
+    forest/          Generic signature-only extractor over go-sitter-forest
+    tsitter/         Vendored grammar wrappers for the bespoke tier
+  persistence/       SQLite graph store and sidecars
   query/             Query engine (BFS traversal, SubGraph)
   resolver/          Cross-file reference resolution, IMPLEMENTS inference
-  web/               Web visualization server (Sigma.js)
-pkg/gortex/          Public API for embedding
+  review/            PR review and diff analysis pipeline
+  search/            BM25, trigram, and semantic search
+  server/            HTTP transports and the web dashboard
 ```
+
+`internal/` holds many more focused packages than the ones above; those are the
+load-bearing ones to know first.
+
+## Where to Read Next
+
+| Doc | Covers |
+|-----|--------|
+| [docs/architecture.md](docs/architecture.md) | How the pieces fit together |
+| [docs/languages.md](docs/languages.md) | Language matrix and adding a language |
+| [docs/mcp.md](docs/mcp.md) | MCP server, tool presets, transports |
+| [docs/cli.md](docs/cli.md) | CLI verb reference |
+| [docs/llm.md](docs/llm.md) | LLM provider configuration |
+| [docs/features.md](docs/features.md) | Capability tour |
+| [CLAUDE.md](CLAUDE.md) | Repo conventions for coding agents |
 
 ## Questions?
 
-Open an issue or start a discussion. We're happy to help!
+Ask on [Discord](https://discord.gg/39MFHu3J5d), open an issue, or start a
+discussion. We're happy to help!

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 [![MCP Toplist](https://mcptoplist.com/badge/glama%2Fzzet%2Fgortex.svg)](https://mcptoplist.com/server/glama%2Fzzet%2Fgortex)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/zzet/gortex/badge)](https://scorecard.dev/viewer/?uri=github.com/zzet/gortex)
 [![Go Reference](https://pkg.go.dev/badge/github.com/zzet/gortex.svg)](https://pkg.go.dev/github.com/zzet/gortex)
+[![Discord](https://img.shields.io/badge/Discord-join%20the%20community-5865F2?logo=discord&logoColor=white)](https://discord.gg/39MFHu3J5d)
   <br />
   <a href="https://trendshift.io/repositories/36832" target="_blank"><img src="https://trendshift.io/api/badge/repositories/36832" alt="zzet%2Fgortex | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 </div>
@@ -187,3 +188,5 @@ Apache License 2.0. See [LICENSE.md](LICENSE.md). Copyright 2024-2026 Andrey Kum
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on adding features, language extractors, and submitting PRs.
+
+New contributors are very welcome — join us on [Discord](https://discord.gg/39MFHu3J5d) and introduce yourself. It's the easiest place to ask questions, check whether someone is already working on something, and get feedback on a design before you write the code.


### PR DESCRIPTION
## Summary

`CONTRIBUTING.md` had drifted from the repo it describes, and there was nowhere in the docs pointing new contributors at the community. This rewrites the guide against what the build and CI actually enforce today, and adds the Discord invite so newcomers have a place to introduce themselves.

## What was stale

| Claim in the old guide | Reality |
|---|---|
| Go 1.21+ | `go.mod` pins `go 1.26.5`; CI builds from `go-version-file` |
| Grammars come from `smacker/go-tree-sitter` | Now `tree-sitter/go-tree-sitter` v0.25, `alexaandru/go-sitter-forest`, and several `gortexhq/*` forks |
| One path to add a language (write extractor → `register.go`) | Three tiers — bespoke tree-sitter, regex, forest signature-only — already documented in `docs/languages.md`; registration order decides which extractor claims an extension |
| No mention of linting | CI pins golangci-lint **v2.11.4** and fails on any finding. A green `go test` is not the gate |
| Project layout listing ~10 `internal/` dirs incl. `web/` (Sigma.js) | 70+ packages, and no `internal/web` — it's `internal/server` plus the standalone Next.js UI |
| Benchmarks target `internal/indexer/` | `make bench` covers the real set; CI benches parser / query / graph |

## Changes

- **Prerequisites / build** — correct Go floor, the C toolchain note (mingw-w64 on Windows, matching CI), the cold-build cost from vendored grammars, and a table of the optional build tags (`llama`, `embeddings_onnx`, `embeddings_gomlx`, `netgo,osusergo,static_link`).
- **Testing** — notes that CI runs `-timeout=20m`, and that `internal/persistence` under `-race` exceeds the default 10m and reads as a hang rather than a slow package.
- **Linting** — new section; `make lint`, the pinned version, and a pointer to `.golangci.yaml`.
- **What CI checks** — the six jobs a PR has to clear, including the Windows CGO build, the static Linux build smoke-tested in `debian:11` / `alpine:3`, and the ONNX / GoMLX tag builds.
- **Adding a Language** — describes the three tiers and defers detail to `docs/languages.md` instead of keeping a stale second copy. Keeps the extraction-priority list, adds the regex-tier templates, and explains why registration order matters.
- **Project structure** — refreshed to the load-bearing packages, with `forest/` and `tsitter/` called out.
- **Where to read next** — table linking `docs/architecture.md`, `languages.md`, `mcp.md`, `cli.md`, `llm.md`, `features.md`, and `CLAUDE.md`.
- Links the Code of Conduct and routes security reports through `SECURITY.md` rather than a public issue.
- Carries over the newer `origin/main` wording for adding yourself to `CONTRIBUTORS.md` in a dedicated PR.

## Discord

`https://discord.gg/39MFHu3J5d` now appears in three places:

- a **Come say hello** section at the top of `CONTRIBUTING.md` — introduce yourself, find out whether someone is already working on the thing, sanity-check a design before writing the code, get unstuck on a build or grammar;
- the closing **Questions?** section;
- the README, as a badge and a line in its Contributing section.

No channel names are referenced, so the text stays valid if the server is reorganised.

## Testing

- [x] Docs-only change — no code touched
- [x] Every referenced path verified to exist (`internal/parser/{extractor.go,tsitter/,forest/}`, `register.go`, `forest_registrations.go`, the named extractor files, all `docs/*.md` targets, `.golangci.yaml`, `.github/workflows/ci.yml`)
- [x] Every factual claim checked against `go.mod`, `Makefile`, and `.github/workflows/ci.yml`