### PR TITLE
csharp: gate the lone-member guard keep on namespace visibility

### DIFF
--- a/internal/resolver/cross_pkg_guard.go
+++ b/internal/resolver/cross_pkg_guard.go
@@ -121,7 +121,7 @@ func (r *Resolver) guardCrossPackageCallEdges(jobs []reindexJob, closure map[str
 		// receivers (owner.foo() → BaseType.foo two packages up) never name the
 		// declaring package, so the import closure structurally misses them.
 		// Keep the resolution.
-		if r.loneMemberDefnKeep(target, j.edge, j.oldTo) {
+		if r.loneMemberDefnKeep(target, j.edge, j.oldTo, callerFile) {
 			continue
 		}
 		// A C# extension-method bind is corroborated by namespace
@@ -298,8 +298,10 @@ func sameScopePackage(a, b *graph.Node) bool {
 // languages listed in loneMemberLang, and gated on the receiver, when known,
 // naming an in-repo type so an external-typed receiver (a logging facade's
 // `logger.info`) still reverts rather than latching onto an unrelated
-// same-named local method.
-func (r *Resolver) loneMemberDefnKeep(target *graph.Node, e *graph.Edge, oldTo string) bool {
+// same-named local method. C# demands one more corroboration: the
+// candidate's namespace must be visible from the calling file — see the
+// BCL-shadowing note in the body.
+func (r *Resolver) loneMemberDefnKeep(target *graph.Node, e *graph.Edge, oldTo, callerFile string) bool {
 	if target == nil || !loneMemberLang(target.Language) {
 		return false
 	}
@@ -320,6 +322,29 @@ func (r *Resolver) loneMemberDefnKeep(target *graph.Node, e *graph.Edge, oldTo s
 	repo := r.callerRepoPrefix(e)
 	if rt := edgeReceiverType(e); rt != "" && !r.hasInRepoType(rt, repo) {
 		return false
+	}
+	// C#: a lone definition is no corroboration when the name shadows a
+	// BCL member (`Where`, `Select`, `Parse`) — the true target is
+	// external, so the sole indexed homonym is a decoy for every call the
+	// tenv could not type. Demand the candidate's namespace be visible
+	// from the calling file. Narrowing-only, like the extension-
+	// visibility policy: a file with NO recorded usings is stale or
+	// partial data, not evidence of absence — the keep is lost only when
+	// using evidence exists and the namespace is not in it (nor an
+	// enclosing one). For the member shapes that can bind cross-namespace
+	// without the file naming the type — extensions and class-qualified
+	// statics — visibility is the language rule, not a heuristic; for
+	// var-typed instance receivers it trades a rare silent miss for an
+	// honest unresolved.
+	if target.Language == "csharp" {
+		if ns, _ := target.Meta["scope_ns"].(string); ns != "" {
+			visible := r.csharpFileNamespaceSet(callerFile)
+			_, enc := visible.enclosing[ns]
+			_, imp := visible.imported[ns]
+			if len(visible.imported) > 0 && !enc && !imp {
+				return false
+			}
+		}
 	}
 	n := 0
 	for _, c := range r.cachedFindNodesByNameInRepo(name, repo) {

--- a/internal/resolver/csharp_lone_member_ns_gate_test.go
+++ b/internal/resolver/csharp_lone_member_ns_gate_test.go
@@ -1,0 +1,91 @@
+package resolver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// The BCL-shadowing decoy from the field report: every unresolvable LINQ
+// `.Where(...)` in the repo latched onto the one indexed method named
+// Where — a static helper in a namespace the calling file never imports.
+// The locality fallback's lone-member lift binds it at 0.7 ast_inferred,
+// and the cross-package guard's lone-definition keep waves it through:
+// with no receiver evidence, "only definition in the repo" is the entire
+// case for the bind. For C# the keep must also demand the candidate's
+// namespace be visible from the calling file — the true target
+// (System.Linq's Where) is external and can never out-argue an indexed
+// homonym, so an out-of-scope candidate is noise, not signal.
+func TestCSharpLoneMember_UnimportedNamespaceReverts(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Decoys/SpanQueries.cs": `namespace Probe.Decoys {
+    public static class SpanQueries {
+        public static int[] Where(int[] source, int min) {
+            return source;
+        }
+    }
+}`,
+		"Services/ReportService.cs": `using System.Linq;
+
+namespace App.Services {
+    public class ReportService {
+        public int CountBig() {
+            var rows = Externals.FetchRows();
+            var kept = rows.Where(v => v > 1);
+            return 0;
+        }
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	from := "Services/ReportService.cs::ReportService.CountBig"
+	decoy := "Decoys/SpanQueries.cs::SpanQueries.Where"
+	matched := 0
+	for _, e := range g.GetOutEdges(from) {
+		if e.Kind != graph.EdgeCalls || !strings.HasSuffix(e.To, "Where") {
+			continue
+		}
+		matched++
+		require.NotEqual(t, decoy, e.To,
+			"an unresolvable .Where() must not bind the lone same-named method in a namespace the file cannot see (conf=%v origin=%q)",
+			e.Confidence, e.Origin)
+	}
+	// Zero matches would pass vacuously on an ID-scheme drift — the
+	// reverted placeholder (`unresolved::*.Where`) still counts.
+	require.NotZero(t, matched, "no Where call edge found — fixture or ID scheme broke")
+}
+
+// Control: the lone-definition keep itself must survive. A file that DOES
+// import the candidate's namespace has the corroboration the gate asks
+// for, and the grounded 0.7 ast_inferred bind stays.
+func TestCSharpLoneMember_ImportedNamespaceKeeps(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Decoys/SpanQueries.cs": `namespace Probe.Decoys {
+    public static class SpanQueries {
+        public static int[] Where(int[] source, int min) {
+            return source;
+        }
+    }
+}`,
+		"Services/ReportService.cs": `using Probe.Decoys;
+
+namespace App.Services {
+    public class ReportService {
+        public int CountBig() {
+            var rows = Externals.FetchRows();
+            var kept = rows.Where(v => v > 1);
+            return 0;
+        }
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	edge := findCallEdge(g, "Services/ReportService.cs::ReportService.CountBig", "Decoys/SpanQueries.cs::SpanQueries.Where")
+	require.NotNil(t, edge, "with the namespace imported the lone-member bind must survive the guard")
+	require.Equal(t, graph.OriginASTInferred, edge.Origin)
+}


### PR DESCRIPTION
## Problem

Field-testing on my production C# codebase: every LINQ `.Where(...)` the
type environment cannot type gets bound to the one indexed method named
`Where` — a static helper in an internal tooling namespace no caller
imports — at 0.7 `ast_inferred`. The forward edges are wrong, and the
reverse side is worse: `callers` on that helper returns every LINQ-using
method in the repo, which makes a niche utility look load-bearing.

`.Where` is not special. Any name that shadows a BCL or library member
and has exactly one indexed homonym fails the same way. Measured on my
repo after the fix, the affected population was ~7,000 call edges across
50 names — `Join`, `Where`, `Any`, `StartsWith`, `Round`, plus library
shapes like FluentValidation's `WithMessage`/`NotEmpty` and Newtonsoft's
`SerializeObject`. The true targets are all external (`System.Linq`,
`string.Join`, vendor packages), so they are not in the graph and can
never out-argue the indexed decoy.

## Root cause

Two mechanisms, designed as a pair:

1. The locality fallback's lone-member lift (`resolveMethodCall`): a
   member call with exactly one same-name method candidate is treated as
   a grounded inference and stamped `ast_inferred`/0.7 — the comment
   explicitly counts on the guard's lone-definition exception to keep it.
2. `loneMemberDefnKeep` (cross_pkg_guard.go) then does exactly that: the
   bind fails import-reachability, but a member call with an unknown
   receiver type and a lone in-repo definition of the name is kept —
   "there is nowhere else the call could bind."

That last premise is what breaks: for BCL-shadowing names there IS
somewhere else the call binds — outside the graph. The lone indexed
homonym is not the only candidate, just the only *visible* one.

## Fix

For C# targets, `loneMemberDefnKeep` now demands one more piece of
corroboration before keeping: the candidate's namespace (`scope_ns`)
must be visible from the calling file — its own namespace chain or a
using directive, project-scoped globals included, reusing the same
namespace-set evidence the extension-visibility machinery already
maintains.

The gate is narrowing-only, matching the existing extension-visibility
policy: a file with **no** recorded usings is stale or partial data, not
evidence of absence, so the keep is lost only when using evidence exists
and the namespace is not in it. (The suite's
`TestResolveCSharpExtension_NothingVisibleFallsBackToUnique` pins that
policy and caught my first, stricter cut — the shipped version keeps it
green.)

The rationale mirrors the language where it can: for the member shapes
that can bind cross-namespace without the file naming the type —
extension methods and class-qualified statics — namespace visibility is
the language rule, not a heuristic. For instance calls through
`var`-typed receivers it is a heuristic, and the trade is deliberate: a
rare silent miss (healed by csharp-types enrichment whenever the
receiver becomes typeable) instead of a systematic false family.

Scoped by `target.Language == "csharp"`; no other language's keep
changes. Reverted sites take the guard's normal path — back to the
unresolved placeholder with the `guard_reverted` stamp, honest instead
of wrong.

## Behavior notes

- A lone in-repo method in a never-imported namespace, called through an
  untypeable receiver that really is that type, now sits unresolved
  until enrichment can type the receiver. With using evidence absent the
  old keep still applies.
- Existing stores heal at each file's next resolve pass (the guard runs
  on both the batch and incremental paths), fully on a rebuild —
  enrichment alone cannot retarget these, since the receivers are
  precisely the ones it cannot type.
- Extension-method binds are untouched — they carry the
  `extension_method` resolution and are kept (or not) by their own
  visibility rule, which this gate deliberately parallels.

## Tests

TDD, red watched first on the exact field shape:

- `TestCSharpLoneMember_UnimportedNamespaceReverts` — real extractor +
  `ResolveAll`; an unresolvable `.Where(...)` with the lone `Where` in a
  never-imported namespace failed red bound at 0.7 `ast_inferred`, green
  now reverts to the unresolved placeholder (with a non-vacuity counter
  so an ID-scheme drift can't green it silently).
- `TestCSharpLoneMember_ImportedNamespaceKeeps` — control: the same
  shape with the namespace imported keeps the grounded 0.7 bind.
- `TestResolveCSharpExtension_NothingVisibleFallsBackToUnique` — the
  pre-existing pin that shaped the final design, still green.

Suites: resolver failure name-set byte-identical to clean main on my
Windows box (pre-existing platform failures only, worktree-verified);
tstypes and languages fully green.

## Validation

Deployed on a rebuilt binary with a from-scratch index:

- My counted C# fixture repo's decoy cell flipped from the pinned false
  bind to zero — the declared fix signal — with every other pinned cell
  stable, including the facade-fix cells from #516 (their heal path
  routes through import-reachable targets and never consults this keep).
- On the production repo: the four pinned `.Where` false edges from the
  original report are gone, the decoy's caller list dropped from
  repo-wide to its three real same-subsystem callers, the ~7,000-edge
  lone-homonym population across 50 names is honest-unresolved, and the
  1,000+ extension-method binds are unchanged.
