### PR TITLE
test: sandbox mcp query logs

### DIFF
--- a/internal/mcp/instruction_profile_policy_test.go
+++ b/internal/mcp/instruction_profile_policy_test.go
@@ -1,13 +1,14 @@
 package mcp
 
 import (
+	"fmt"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/zzet/gortex/internal/profiles"
+	"github.com/zzet/gortex/internal/testenv"
 )
 
 // TestMain pins the instruction-profile env override to the default
@@ -18,30 +19,21 @@ import (
 func TestMain(m *testing.M) {
 	os.Setenv(profiles.ActiveEnv, profiles.DefaultName)
 
-	// NewServer constructs the query logger eagerly. Keep its default path in
-	// a disposable package-local cache so concurrent package tests cannot write
-	// through to the developer's real ~/.gortex/cache/query-log.jsonl.
-	testCache, err := os.MkdirTemp("", "gortex-mcp-test-cache-")
+	// NewServer constructs the query logger and mounts the global memory store
+	// eagerly. Sandbox the whole process so both XDG_CACHE_HOME and the
+	// XDG_DATA_HOME-backed ~/.gortex/memories path stay out of the developer's
+	// real home.
+	restore, err := testenv.SandboxProcess()
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "internal/mcp: cannot sandbox the test environment: %v\n", err)
 		os.Exit(1)
 	}
-	previousCache, hadCache := os.LookupEnv("XDG_CACHE_HOME")
-	previousQueryLog, hadQueryLog := os.LookupEnv("GORTEX_QUERY_LOG")
-	_ = os.Setenv("XDG_CACHE_HOME", testCache)
-	_ = os.Setenv("GORTEX_QUERY_LOG", filepath.Join(testCache, "query-log.jsonl"))
+	// query_log.go lets an ambient GORTEX_QUERY_LOG override CacheDir, so clear
+	// it and let the logger resolve the sandboxed cache directory.
+	_ = os.Unsetenv("GORTEX_QUERY_LOG")
 
 	code := m.Run()
-	if hadCache {
-		_ = os.Setenv("XDG_CACHE_HOME", previousCache)
-	} else {
-		_ = os.Unsetenv("XDG_CACHE_HOME")
-	}
-	if hadQueryLog {
-		_ = os.Setenv("GORTEX_QUERY_LOG", previousQueryLog)
-	} else {
-		_ = os.Unsetenv("GORTEX_QUERY_LOG")
-	}
-	_ = os.RemoveAll(testCache)
+	restore()
 	os.Exit(code)
 }
 

--- a/internal/mcp/instruction_profile_policy_test.go
+++ b/internal/mcp/instruction_profile_policy_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -16,7 +17,32 @@ import (
 // stub activeInstructionPreset directly.
 func TestMain(m *testing.M) {
 	os.Setenv(profiles.ActiveEnv, profiles.DefaultName)
-	os.Exit(m.Run())
+
+	// NewServer constructs the query logger eagerly. Keep its default path in
+	// a disposable package-local cache so concurrent package tests cannot write
+	// through to the developer's real ~/.gortex/cache/query-log.jsonl.
+	testCache, err := os.MkdirTemp("", "gortex-mcp-test-cache-")
+	if err != nil {
+		os.Exit(1)
+	}
+	previousCache, hadCache := os.LookupEnv("XDG_CACHE_HOME")
+	previousQueryLog, hadQueryLog := os.LookupEnv("GORTEX_QUERY_LOG")
+	_ = os.Setenv("XDG_CACHE_HOME", testCache)
+	_ = os.Setenv("GORTEX_QUERY_LOG", filepath.Join(testCache, "query-log.jsonl"))
+
+	code := m.Run()
+	if hadCache {
+		_ = os.Setenv("XDG_CACHE_HOME", previousCache)
+	} else {
+		_ = os.Unsetenv("XDG_CACHE_HOME")
+	}
+	if hadQueryLog {
+		_ = os.Setenv("GORTEX_QUERY_LOG", previousQueryLog)
+	} else {
+		_ = os.Unsetenv("GORTEX_QUERY_LOG")
+	}
+	_ = os.RemoveAll(testCache)
+	os.Exit(code)
 }
 
 // stubActiveProfilePreset swaps the machine-state reader for the test.


### PR DESCRIPTION
## Summary

- Put the internal/mcp package's default query-log path under a disposable
  test cache.
- Preserve and restore existing XDG cache and explicit query-log environment
  values around the package test run.

This prevents concurrent package tests from writing to a developer's real
`~/.gortex/cache/query-log.jsonl` while keeping individual tests free to
override the logger path with `t.Setenv`.

## Validation

- `gofmt` passed.
- `git diff --check` passed.
- `go test ./internal/mcp -run 'Test(QueryLogger|CountFromResultText|FirstStringArg)' -count=1` passed.
- `go test ./internal/mcp` passed (the first dependency build took about 17
  minutes; the cached test run completed in about 102 seconds).

Closes #518
