### PR TITLE
Stop the repo-ownership audit from flagging projected rationale nodes

### DIFF
--- a/internal/graph/prefix_diagnostics.go
+++ b/internal/graph/prefix_diagnostics.go
@@ -18,9 +18,10 @@ import (
 // The audit applies only to repository source nodes. Some synthetic nodes
 // retain a FilePath as attribution rather than as an on-disk source path:
 // semantic externals use `external::…`, synthesized external calls use
-// `external-call::…`, and contracts plus topics use identity namespaces that
-// deliberately do not mirror their source path. Those populations are outside
-// the ownership invariant even when FilePath is non-empty.
+// `external-call::…`, and contracts, topics plus projected rationale use
+// identity namespaces that deliberately do not mirror their source path.
+// Those populations are outside the ownership invariant even when FilePath is
+// non-empty.
 //
 // Every other file-backed node with an empty prefix is an UNOWNED CODE NODE:
 // a real symbol, extracted from a real file, that no repository claims.
@@ -130,13 +131,17 @@ func IsAuditableRepoSourcePath(filePath string) bool {
 // IsAuditableRepoSourceNode reports whether n participates in the repository
 // ownership invariant. Contract and topic identities intentionally live in
 // global namespaces rather than below their source repository prefix; contract
-// bridge nodes likewise use the virtual contracts://bridges path.
+// bridge nodes likewise use the virtual contracts://bridges path. Rationale
+// nodes are the same shape: the memory projection mints them as
+// `rationale::<memory-id>` over the virtual .gortex/rationale path while still
+// stamping the repo the memory belongs to, so their identity can never carry
+// the prefix and auditing them reports a defect on every healthy graph.
 func IsAuditableRepoSourceNode(n *Node) bool {
 	if n == nil || !IsAuditableRepoSourcePath(n.FilePath) {
 		return false
 	}
 	switch n.Kind {
-	case KindContract, KindContractBridge, KindTopic:
+	case KindContract, KindContractBridge, KindTopic, KindRationale:
 		return false
 	default:
 		return true

--- a/internal/graph/prefix_diagnostics_test.go
+++ b/internal/graph/prefix_diagnostics_test.go
@@ -63,6 +63,15 @@ func TestClassifyNodePrefix(t *testing.T) {
 		node: &Node{ID: "topic::nats::go", Kind: KindTopic, FilePath: "gortex/main.go", RepoPrefix: "gortex"},
 		want: "",
 	}, {
+		// A repo-scoped development memory projects to a repo-stamped node
+		// whose identity is `rationale::<memory-id>` over a virtual path. It
+		// can never carry the prefix, so auditing it reported a misprefixed
+		// node — and downgraded the whole audit to Error — on every graph that
+		// had one.
+		name: "projected rationale identity is not audited",
+		node: &Node{ID: "rationale::mem3539475d73f80040", Kind: KindRationale, FilePath: ".gortex/rationale", RepoPrefix: "gortex"},
+		want: "",
+	}, {
 		name: "repo-scoped stub carries no file and is not audited",
 		node: &Node{ID: "gortex::builtin::go::make", Kind: KindBuiltin, RepoPrefix: "gortex"},
 		want: "",

--- a/internal/graph/store_sqlite/prefix_diagnostics.go
+++ b/internal/graph/store_sqlite/prefix_diagnostics.go
@@ -11,8 +11,8 @@ import (
 // The predicates below are the SQL transcription of
 // graph.IsAuditableRepoSourceNode and graph.ClassifyNodePrefix, and the two
 // must be changed together. The auditable predicate admits repository source
-// while excluding exact virtual external paths and the contract/topic identity
-// namespaces whose IDs deliberately are not path-prefixed.
+// while excluding exact virtual external paths and the contract/topic/rationale
+// identity namespaces whose IDs deliberately are not path-prefixed.
 //
 // Each population is answered by one aggregate plus one bounded sample
 // query rather than a node pull: on a warm multi-repo store the node table
@@ -24,7 +24,7 @@ const (
 	// of a broad punctuation/URI heuristic so real parser nodes cannot escape
 	// the audit merely because their path contains punctuation.
 	auditableRepoSourceNodePredicate = `file_path <> '' AND ` +
-		`kind NOT IN ('contract', 'contract_bridge', 'topic') AND ` +
+		`kind NOT IN ('contract', 'contract_bridge', 'topic', 'rationale') AND ` +
 		`instr(file_path, 'external::') <> 1 AND ` +
 		`instr(file_path, 'external-call::') <> 1`
 

--- a/internal/graph/storetest/storetest.go
+++ b/internal/graph/storetest/storetest.go
@@ -139,6 +139,11 @@ func testPrefixDiagnostics(t *testing.T, factory Factory) {
 	s.AddNode(mkRepoNode("contract::http::GET::/health", "GET /health", "r1/api.go", "r1", graph.KindContract))
 	s.AddNode(mkRepoNode("contract-bridge::request::response", "request → response", "contracts://bridges", "r1", graph.KindContractBridge))
 	s.AddNode(mkRepoNode("topic::nats::go", "go", "r1/main.go", "r1", graph.KindTopic))
+	// The memory projection stamps the owning repo but mints the identity as
+	// `rationale::<memory-id>` over a virtual path, so a rationale node can
+	// never carry its prefix. Auditing it reported a misprefixed node on every
+	// healthy graph that had a repo-scoped memory.
+	s.AddNode(mkRepoNode("rationale::mem3539475d73f80040", "why the resolver stubs res://", ".gortex/rationale", "r1", graph.KindRationale))
 
 	d, ok := graph.ReadPrefixDiagnostics(s, 5)
 	if !ok {


### PR DESCRIPTION
## What

Exempt `KindRationale` from the repo-prefix ownership audit, in both the in-memory classifier and the SQLite predicate that transcribes it.

## Why

Every daemon start on a workspace holding repo-scoped development memories logged this at **Error**:

```
daemon: repo ownership is inconsistent — repo-scoped reads will silently return a subset
of the graph; the store holds both prefixed and unprefixed copies of the same code, or a
node's stamped repo differs from its id
  owned_code_nodes: 644746
  unowned_code_nodes: 0
  misprefixed_nodes: 9
  misprefixed_samples: ["rationale::mem3539475d73f80040", "rationale::mem4209e14e240d8045", …]
```

The graph was healthy. `owned=644746 / unowned=0` means not mixed — no ghost population, which is the failure the detector exists for. Only `misprefixed` was non-zero, and every node in it was a false positive.

`ClassifyNodePrefix` already exempts the identity namespaces whose IDs deliberately do not mirror a source path: contracts, contract bridges, topics. `projectMemories` mints nodes of exactly that shape:

```go
id := "rationale::" + e.ID
… FilePath: rationaleVirtualFile,   // ".gortex/rationale"
   RepoPrefix: e.RepoPrefix,        // stamped from the memory entry
```

A repo is stamped, but the identity is namespaced and the path is virtual, so `strings.HasPrefix(n.ID, repoPrefix+"/")` can never hold. `KindRationale` was simply never added to the exempt switch — so one repo-scoped memory was enough to drive `Clean()` false and escalate the whole audit to Error, with copy describing a data-loss bug that was not occurring.

`index_health` reported the same false positive, via `repo_ownership.consistent: false` plus the "Graph holds inconsistent repository ownership … untrack and re-track the repo" remediation.

## Changes

- `internal/graph/prefix_diagnostics.go` — add `KindRationale` to the exempt switch in `IsAuditableRepoSourceNode`; explain why in the doc comment.
- `internal/graph/store_sqlite/prefix_diagnostics.go` — mirror it in `auditableRepoSourceNodePredicate` (`kind NOT IN (…, 'rationale')`). The file's contract is that the SQL is a transcription of the Go classifier and the two change together.
- `internal/graph/prefix_diagnostics_test.go` — classifier case for a projected rationale identity.
- `internal/graph/storetest/storetest.go` — projected rationale node in the cross-backend conformance fixture.

Only the ownership audit is affected. `buildIndexHealthPayloadCtx`'s path-liveness probe also calls `IsAuditableRepoSourcePath`, but it walks `NodesByKind(KindFile)` only, so rationale nodes never reach it.

## Verification

Both fences fail without their corresponding fix — confirmed by reverting each and re-running:

```
--- FAIL: TestClassifyNodePrefix/projected_rationale_identity_is_not_audited
        ClassifyNodePrefix() = "misprefixed_identity", want ""
--- FAIL: TestSQLiteStoreConformance/PrefixDiagnostics
        MisprefixedNodes = 2, want 1 (owned=1 unowned=1 misprefixed=2)
```

With the fix:

- `go test -race ./internal/graph/ ./internal/graph/storetest/` — ok
- `go test -race ./internal/graph/store_sqlite/` — ok (full suite, 1438s)
- `golangci-lint run ./internal/graph/...` — 0 issues
