### PR TITLE
Exclude repo-local toolchain caches and stop the shed-patch log flood

### DIFF
--- a/internal/excludes/builtin.go
+++ b/internal/excludes/builtin.go
@@ -48,6 +48,23 @@ var Builtin = []string{
 	".bundle/",    // Ruby Bundler cache
 	".dart_tool/", // Dart/Flutter build cache
 	".pub-cache/", // Dart global pub cache, occasionally vendored
+	// Dependency caches a repo-local toolchain home materializes inside the
+	// working tree. A harness that pins M2_HOME / store-dir at the repo
+	// (CI images, benchmark runners, reproducible-build setups) lands tens
+	// of thousands of upstream artifacts under these names. They hold
+	// third-party jars and tarballs, never first-party source, and a repo
+	// that redirects a toolchain home this way rarely thinks to .gitignore
+	// the result — which is the case this list exists to cover.
+	".m2/",         // Maven local repository
+	".ivy2/",       // Ivy / sbt resolution cache
+	".sbt/",        // sbt launcher + plugin cache
+	".pnpm-store/", // pnpm content-addressable store
+	".stack-work/", // Haskell Stack build tree
+	// IDE workspace state: per-machine indexes, launch configs, and scratch
+	// metadata. `.eclipse/` and `.metadata/` are unambiguous — no project
+	// keeps its own source under either.
+	".eclipse/",
+	".metadata/",
 	// Visual Studio / MSBuild artifacts.
 	".vs/",         // Visual Studio per-solution cache
 	"TestResults/", // Visual Studio / `dotnet test` output

--- a/internal/excludes/builtin_test.go
+++ b/internal/excludes/builtin_test.go
@@ -64,6 +64,48 @@ func TestBuiltinExcludesVisualStudioArtifacts(t *testing.T) {
 	}
 }
 
+// A harness that pins a toolchain home at the repo (CI images, benchmark
+// runners) materializes these caches inside the working tree, where they
+// hold upstream artifacts the walker would otherwise index.
+func TestBuiltinExcludesRepoLocalToolchainCaches(t *testing.T) {
+	t.Parallel()
+
+	matcher := New(Builtin)
+	for _, path := range []string{
+		".m2/repository/org/slf4j/slf4j-api/2.0.9/slf4j-api-2.0.9.jar",
+		".ivy2/cache/org.scala-lang/scala-library/ivy.xml",
+		".sbt/1.0/plugins/target/config-classes/cached.class",
+		".pnpm-store/v3/files/00/abcdef",
+		".stack-work/dist/x86_64-linux/build/Main.hi",
+		".eclipse/org.eclipse.platform_4.30/configuration/config.ini",
+		".metadata/.plugins/org.eclipse.core.resources/.projects/p/.location",
+		"nested/.m2/repository/junit/junit/4.13.2/junit-4.13.2.jar",
+	} {
+		if !matcher.MatchRel(path) {
+			t.Errorf("Builtin should exclude toolchain cache path %q", path)
+		}
+	}
+}
+
+// The cache entries are directory-anchored, so a first-party package or file
+// that merely shares the stem stays indexed.
+func TestBuiltinDoesNotExcludeSimilarToolchainNames(t *testing.T) {
+	t.Parallel()
+
+	matcher := New(Builtin)
+	for _, path := range []string{
+		"m2/decoder.go",
+		"internal/sbt/parser.go",
+		"pkg/metadata/loader.go",
+		"src/eclipse/render.ts",
+		"tools/pnpm-store-inspector/main.go",
+	} {
+		if matcher.MatchRel(path) {
+			t.Errorf("Builtin unexpectedly excludes first-party path %q", path)
+		}
+	}
+}
+
 // The MSBuild entries name what MSBuild writes rather than blanket-dropping
 // `obj/` or `bin/`, both of which are committed source in other ecosystems.
 func TestBuiltinDoesNotExcludeFirstPartyObjOrBin(t *testing.T) {

--- a/internal/indexer/watcher.go
+++ b/internal/indexer/watcher.go
@@ -1731,7 +1731,7 @@ func (w *Watcher) scheduleFileMutation(path string, kind ChangeKind) *MutationTi
 		// mutation lane. Giving up here rather than queueing forever is
 		// what lets a jammed lane shed work instead of accumulating
 		// goroutines against it.
-		release, admitted := w.admitMutationWork()
+		release, admitted := w.admitMutationWork(path)
 		if !admitted {
 			w.completeMutationWaiters(path, generation, errMutationPatchAborted)
 			return

--- a/internal/indexer/watcher_mutation_admission.go
+++ b/internal/indexer/watcher_mutation_admission.go
@@ -31,6 +31,14 @@ const (
 	// large repo has been measured in the tens of seconds — so it only
 	// fires for a lane that is genuinely stuck.
 	mutationLaneTimeout = 10 * time.Minute
+	// mutationShedLogInterval throttles the shed warning. A jammed lane
+	// sheds one patch per queued callback, so logging each one unthrottled
+	// emits a line per shed — thousands per minute on a repo with a large
+	// generated tree, which buries the storm-drain and reconcile records
+	// that explain why the lane is jammed in the first place. One line per
+	// interval carrying the suppressed count and a sample path is what a
+	// diagnosis actually needs.
+	mutationShedLogInterval = 30 * time.Second
 )
 
 // mutationWorkSlots sizes the cohort semaphore. Patching is CPU- and
@@ -47,8 +55,10 @@ func mutationWorkSlots() int {
 // admitMutationWork takes a slot in the watcher's cohort semaphore. The
 // returned release must be called when the work is done. admitted is
 // false when the wait timed out or the watcher is stopping, in which case
-// release is a no-op and the caller must not proceed.
-func (w *Watcher) admitMutationWork() (release func(), admitted bool) {
+// release is a no-op and the caller must not proceed. path names the file
+// whose patch is at stake; it is only used to give the shed warning a
+// sample worth acting on.
+func (w *Watcher) admitMutationWork(path string) (release func(), admitted bool) {
 	if w == nil {
 		return func() {}, false
 	}
@@ -64,12 +74,46 @@ func (w *Watcher) admitMutationWork() (release func(), admitted bool) {
 	case <-w.done:
 		return func() {}, false
 	case <-timer.C:
-		if w.logger != nil {
-			w.logger.Warn("watcher: mutation admission timed out; shedding patch",
-				zap.Duration("waited", mutationAdmissionWaitTimeout))
-		}
+		w.noteShedPatch(path)
 		return func() {}, false
 	}
+}
+
+// noteShedPatch records one shed patch and writes at most one warning per
+// mutationShedLogInterval. The first shed of a burst logs immediately so the
+// condition is never silent; the rest accumulate into that line's count.
+func (w *Watcher) noteShedPatch(path string) {
+	if w == nil || w.logger == nil {
+		return
+	}
+	w.shedMu.Lock()
+	w.shedCount++
+	if w.shedSample == "" {
+		w.shedSample = path
+	}
+	now := time.Now()
+	first := w.shedWindowStart.IsZero()
+	if !first && now.Sub(w.shedWindowStart) < mutationShedLogInterval {
+		w.shedMu.Unlock()
+		return
+	}
+	count := w.shedCount
+	sample := w.shedSample
+	window := now.Sub(w.shedWindowStart)
+	w.shedWindowStart = now
+	w.shedCount = 0
+	w.shedSample = ""
+	w.shedMu.Unlock()
+
+	fields := []zap.Field{
+		zap.Int("shed", count),
+		zap.Duration("waited", mutationAdmissionWaitTimeout),
+		zap.String("sample_path", sample),
+	}
+	if !first {
+		fields = append(fields, zap.Duration("window", window))
+	}
+	w.logger.Warn("watcher: mutation admission timed out; shedding patches", fields...)
 }
 
 // mutationSlots returns the cohort semaphore, creating it on first use so
@@ -85,6 +129,13 @@ func (w *Watcher) mutationSlots() chan struct{} {
 type watcherMutationAdmission struct {
 	mutationSlotsOnce sync.Once
 	mutationSlotsCh   chan struct{}
+
+	// shed* throttle the admission-timeout warning. Guarded by shedMu
+	// because every debounce callback that gives up races here.
+	shedMu          sync.Mutex
+	shedWindowStart time.Time
+	shedCount       int
+	shedSample      string
 }
 
 // mutationLaneContext returns the context a watcher-driven patch uses to

--- a/internal/indexer/watcher_test.go
+++ b/internal/indexer/watcher_test.go
@@ -1,6 +1,7 @@
 package indexer
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/zzet/gortex/internal/config"
 	"github.com/zzet/gortex/internal/graph"
@@ -453,7 +455,7 @@ func TestMutationAdmissionBoundsConcurrency(t *testing.T) {
 
 	releases := make([]func(), 0, slots)
 	for i := 0; i < slots; i++ {
-		release, ok := w.admitMutationWork()
+		release, ok := w.admitMutationWork("held.go")
 		require.True(t, ok, "the first %d admissions must succeed", slots)
 		releases = append(releases, release)
 	}
@@ -461,7 +463,7 @@ func TestMutationAdmissionBoundsConcurrency(t *testing.T) {
 	// The semaphore is full: a further admission blocks until a slot frees.
 	admitted := make(chan bool, 1)
 	go func() {
-		release, ok := w.admitMutationWork()
+		release, ok := w.admitMutationWork("queued.go")
 		if ok {
 			release()
 		}
@@ -484,14 +486,14 @@ func TestMutationAdmissionReleasedOnStop(t *testing.T) {
 	w := &Watcher{logger: zap.NewNop(), done: make(chan struct{})}
 	held := make([]func(), 0, cap(w.mutationSlots()))
 	for i := 0; i < cap(w.mutationSlots()); i++ {
-		release, ok := w.admitMutationWork()
+		release, ok := w.admitMutationWork("held.go")
 		require.True(t, ok)
 		held = append(held, release)
 	}
 
 	admitted := make(chan bool, 1)
 	go func() {
-		_, ok := w.admitMutationWork()
+		_, ok := w.admitMutationWork("stopping.go")
 		admitted <- ok
 	}()
 	close(w.done)
@@ -499,6 +501,49 @@ func TestMutationAdmissionReleasedOnStop(t *testing.T) {
 	for _, release := range held {
 		release()
 	}
+}
+
+// TestShedPatchLoggingIsThrottled pins that a jammed lane reports itself
+// once per window rather than once per shed patch. A repo with a large
+// generated tree sheds thousands of patches a minute; logging each one
+// buries the storm-drain and reconcile records that explain the jam.
+func TestShedPatchLoggingIsThrottled(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
+	w := &Watcher{logger: zap.New(core), done: make(chan struct{})}
+
+	w.noteShedPatch("first.go")
+	require.Equal(t, 1, logs.Len(), "the first shed must report immediately")
+
+	for i := range 500 {
+		w.noteShedPatch(fmt.Sprintf("burst-%d.go", i))
+	}
+	require.Equal(t, 1, logs.Len(), "sheds inside the window must not each log")
+
+	// Reopening the window publishes the suppressed count and a sample.
+	w.shedMu.Lock()
+	w.shedWindowStart = time.Now().Add(-2 * mutationShedLogInterval)
+	w.shedMu.Unlock()
+	w.noteShedPatch("last.go")
+
+	require.Equal(t, 2, logs.Len())
+	entry := logs.All()[1]
+	fields := entry.ContextMap()
+	require.Equal(t, int64(501), fields["shed"],
+		"the throttled line must account for every suppressed shed")
+	require.Equal(t, "burst-0.go", fields["sample_path"],
+		"the sample must name a real shed path")
+	require.Contains(t, fields, "window")
+
+	// The first line carries no window — there is no prior one to measure.
+	require.NotContains(t, logs.All()[0].ContextMap(), "window")
+	require.Equal(t, int64(1), logs.All()[0].ContextMap()["shed"])
+}
+
+// TestShedPatchLoggingSurvivesNilLogger keeps the accounting path inert for
+// a watcher built without a logger rather than panicking on a shed.
+func TestShedPatchLoggingSurvivesNilLogger(t *testing.T) {
+	require.NotPanics(t, func() { (&Watcher{}).noteShedPatch("x.go") })
+	require.NotPanics(t, func() { (*Watcher)(nil).noteShedPatch("x.go") })
 }
 
 // TestMutationLaneContextCarriesDeadline pins the escape hatch: a patch


### PR DESCRIPTION
Two independent fixes for the same failure, found while diagnosing a daemon that emitted 8,787 `watcher: mutation admission timed out; shedding patch` warnings in twelve minutes for one repo.

## What was happening

The repo had a 20 GB working tree: benchmark output, per-language toolchain caches, and a stray copy of a Gortex store. A run writing into it burst enough filesystem events that the watcher's storm drains held the repository mutation lane continuously — one drain took 371 s to conclude that zero files needed indexing. Every per-file debounce callback queued behind that lane expired at the 2-minute admission timeout and shed its patch, and each shed
wrote its own warning line.

## Exclude repo-local toolchain caches

A harness that pins a toolchain home inside the working tree — CI images, benchmark runners, reproducible-build setups — materializes Maven, Ivy, sbt, pnpm, Stack, and Eclipse caches under the repo root. They hold upstream jars
and tarballs, never first-party source, and a repo that redirects a toolchain home this way rarely thinks to `.gitignore` the result.

Unexcluded they are indexed on the initial walk and, worse, watched: writes into them saturate the mutation lane, which then sheds live patches for real source. `.gradle/` was already covered; this adds its peers. Entries are
directory-anchored, so a first-party package sharing the stem stays indexed — pinned by a companion negative test.

## Report shed patches once per window

Logging one warning per shed produced thousands of identical lines a minute, carrying neither a path nor a count, burying the storm-drain and reconcile records that explain the jam. Sheds now accumulate and warn at most once per
30 s. The first shed of a burst still logs immediately, so the condition is never silent. The line carries the suppressed count, a sample path, and the window it covers — enough to identify the offending tree without reconstructing it from timestamps.

## Scope

This reduces how often the condition is reached and makes it legible when it is. It does not change the admission timeout, the storm-drain design, or the full-tree reconcile loop, all of which behave as documented. A repo with a
large *project-specific* generated tree still needs a per-repo `exclude`.

## Verification

- `go build ./...`
- `go test -race -timeout 20m ./internal/indexer/` — 253 s, pass
- `go test ./internal/excludes/... ./internal/config/...` — pass
- `golangci-lint run ./internal/excludes/... ./internal/indexer/...` — 0 issues