### PR TITLE
store_sqlite: accept separator-normalized paths in import adjacency projection

### DIFF
--- a/internal/graph/store_sqlite/import_adjacency_projection.go
+++ b/internal/graph/store_sqlite/import_adjacency_projection.go
@@ -49,7 +49,16 @@ func (s *Store) ProjectImportAdjacency(filePaths []string) (map[string][]string,
 	seen := make(map[string]struct{}, len(filePaths))
 	paths := make([]string, 0, len(filePaths))
 	for _, path := range filePaths {
-		if path == "" || path == "." || filepath.Clean(path) != path {
+		if path == "" || path == "." {
+			return nil, false
+		}
+		// Indexed paths keep '/' after the repo prefix with the rest
+		// OS-native, so on Windows filepath.Clean rewrites separators on
+		// every stored path. A separator-only difference is not a
+		// canonicality violation — only a structural one (traversal,
+		// duplicate separators, trailing dots) rejects the request.
+		if cleaned := filepath.Clean(path); cleaned != path &&
+			filepath.ToSlash(cleaned) != filepath.ToSlash(path) {
 			return nil, false
 		}
 		if _, duplicate := seen[path]; duplicate {

--- a/internal/graph/store_sqlite/import_adjacency_projection_test.go
+++ b/internal/graph/store_sqlite/import_adjacency_projection_test.go
@@ -81,6 +81,31 @@ func TestImportAdjacencyProjectionSkipsUnrelatedOutgoingRows(t *testing.T) {
 	}
 }
 
+func TestImportAdjacencyProjectionAcceptsMixedSeparatorPaths(t *testing.T) {
+	// Windows stores index paths with the repo prefix joined by '/' and the
+	// rest OS-native ("repo/dir\file.cs"). filepath.Clean normalizes the
+	// separators, so a separator-only difference is not a canonicality
+	// violation — treating it as one silently disabled the projection (and
+	// every consumer above it) on Windows.
+	store := openImportProjectionTestStore(t)
+	const callerPath = `pkg/sub\caller.go`
+	const callerID = callerPath + "::Caller"
+	const targetPath = "dep/target.go"
+	store.AddBatch([]*graph.Node{
+		{ID: callerID, Kind: graph.KindFunction, Name: "Caller", FilePath: callerPath},
+		{ID: targetPath, Kind: graph.KindFile, Name: "target.go", FilePath: targetPath},
+	}, []*graph.Edge{{
+		From: callerID, To: targetPath, Kind: graph.EdgeImports, FilePath: callerPath,
+	}})
+	got, complete := store.ProjectImportAdjacency([]string{callerPath})
+	if !complete {
+		t.Fatal("mixed-separator canonical path reported incomplete")
+	}
+	if targets := got[callerPath]; len(targets) != 1 || targets[0] != targetPath {
+		t.Fatalf("projected targets = %v, want [%s]", targets, targetPath)
+	}
+}
+
 func TestImportAdjacencyProjectionRejectsMalformedProvenance(t *testing.T) {
 	t.Run("noncanonical request", func(t *testing.T) {
 		store := openImportProjectionTestStore(t)


### PR DESCRIPTION
## Problem

`ProjectImportAdjacency` returns `complete=false` for every request on Windows, so the projection fast-path has never run there — every consumer silently takes the legacy per-file fallback.

The canonicality guard rejects any path that `filepath.Clean` changes:

```go
if path == "" || path == "." || filepath.Clean(path) != path {
```

On Windows, `Clean` rewrites `/` to `\`. Indexed paths keep `/` after the repo prefix with the rest OS-native (`repo/dir\file.cs`), so `Clean` changes **every** stored path — even pure-slash ones — and the guard reads that as a canonicality violation. On separator-stable platforms the same comparison is fine, which is why this never showed up outside Windows.

Measured on a cold index of my production C# repo: all 93 resolve pages fell back, every run — roughly 142 s of a ~342 s resolve phase spent in the legacy reads the projection exists to replace. The guard also fails `TestImportAdjacencyProjectionSkipsUnrelatedOutgoingRows` on Windows (its fixture paths get rejected before the query logic under test is ever reached), which is how it hid inside the known Windows failure bucket.

## Fix

Make the canonicality check separator-insensitive: reject only when `Clean` changes the path in `ToSlash` form.

```go
if cleaned := filepath.Clean(path); cleaned != path &&
    filepath.ToSlash(cleaned) != filepath.ToSlash(path) {
```

Structural violations — traversal segments, `.`/`..`, duplicate separators, trailing dots — all still produce a ToSlash-divergent form and still reject. A separator-only difference no longer does. Non-Windows behavior is provably unchanged: `Clean` never rewrites separators there, so the new clause only fires where the old one misfired.

## Tests

- New `TestImportAdjacencyProjectionAcceptsMixedSeparatorPaths` — the stored-path shape; fails on Windows without the fix (verified red).
- Repairs `TestImportAdjacencyProjectionSkipsUnrelatedOutgoingRows` on Windows — pre-existing failure, verified red-on-main / green-here.
- `TestImportAdjacencyProjectionRejectsMalformedProvenance` (traversal, blank, mismatched provenance) unchanged and green.

Windows failure count for the package's neighborhood drops by exactly one, zero new failures.

## Validation

With the guard fixed, five consecutive cold indexes of my production repo ran the fast-path on 93+ of 96 pages (the remaining fallbacks are genuinely malformed batches — the conservative path working as designed) with outcome counters digit-identical to the fallback path throughout. Follow-up PR builds on this to retain projections across pages; this fix is independently valuable either way.

## Aside: Windows CI

This one was hard to see even from a Windows machine — the failing test blended into the ambient Windows failure set, and the silent fallback hid the perf cost. If a small `windows-latest` job would be useful (even just `internal/graph/store_sqlite` and `internal/resolver`), I'd be glad to put one together in a separate PR — no worries if that's already on the radar or not a priority.
