### PR TITLE
tstypes: partition the streamed-apply fact spool by class

### DIFF
--- a/internal/semantic/tstypes/apply_golden_test.go
+++ b/internal/semantic/tstypes/apply_golden_test.go
@@ -1,0 +1,168 @@
+package tstypes
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/semantic"
+)
+
+var updateGolden = flag.Bool("update", false, "rewrite golden snapshots")
+
+type snapEdge struct {
+	From, To, Kind, Origin string
+	Line                   int
+}
+
+type snapMeta struct {
+	NodeID, Key, Value string
+}
+
+type applySnapshot struct {
+	Edges           []snapEdge
+	MetaStamps      []snapMeta
+	EdgesConfirmed  int
+	EdgesAdded      int
+	SymbolsCovered  int
+	SymbolsTotal    int
+	CoveragePercent float64
+}
+
+// goldenFixtureFiles is a miniature C# repo shaped like the cases the
+// spool must not disturb: a partial type whose base clause lives in one
+// part while the calls live in another (the Razor-codebehind shape), a
+// local-variable receiver, and a parameter-typed receiver.
+func goldenFixtureFiles() map[string]string {
+	return map[string]string{
+		"widgets/Base.cs": `namespace Widgets
+{
+    public class WidgetBase
+    {
+        public void Render() { }
+    }
+}
+`,
+		"widgets/Alpha.Part1.cs": `namespace Widgets
+{
+    public partial class Alpha : WidgetBase
+    {
+        public Helper Sidekick { get; set; }
+    }
+}
+`,
+		"widgets/Alpha.Part2.cs": `namespace Widgets
+{
+    public partial class Alpha
+    {
+        public void Draw()
+        {
+            this.Render();
+            var helper = new Helper();
+            helper.Assist(null);
+        }
+    }
+}
+`,
+		"widgets/Helper.cs": `namespace Widgets
+{
+    public class Helper
+    {
+        public void Assist(WidgetBase w)
+        {
+            w.Render();
+        }
+    }
+}
+`,
+	}
+}
+
+func snapshotFrom(g *graph.Graph, res *semantic.EnrichResult) applySnapshot {
+	snap := applySnapshot{
+		EdgesConfirmed: res.EdgesConfirmed, EdgesAdded: res.EdgesAdded,
+		SymbolsCovered: res.SymbolsCovered, SymbolsTotal: res.SymbolsTotal,
+		CoveragePercent: res.CoveragePercent,
+	}
+	for _, e := range g.AllEdges() {
+		snap.Edges = append(snap.Edges, snapEdge{From: e.From, To: e.To, Kind: string(e.Kind), Origin: e.Origin, Line: e.Line})
+	}
+	for _, n := range g.AllNodes() {
+		for key, val := range n.Meta {
+			if s, ok := val.(string); ok {
+				snap.MetaStamps = append(snap.MetaStamps, snapMeta{NodeID: n.ID, Key: key, Value: s})
+			}
+		}
+	}
+	sort.Slice(snap.Edges, func(i, j int) bool {
+		a, b := snap.Edges[i], snap.Edges[j]
+		if a.From != b.From {
+			return a.From < b.From
+		}
+		if a.To != b.To {
+			return a.To < b.To
+		}
+		if a.Kind != b.Kind {
+			return a.Kind < b.Kind
+		}
+		return a.Line < b.Line
+	})
+	sort.Slice(snap.MetaStamps, func(i, j int) bool {
+		a, b := snap.MetaStamps[i], snap.MetaStamps[j]
+		if a.NodeID != b.NodeID {
+			return a.NodeID < b.NodeID
+		}
+		if a.Key != b.Key {
+			return a.Key < b.Key
+		}
+		return a.Value < b.Value
+	})
+	return snap
+}
+
+// TestApplyGoldenSnapshot pins the full streamed pipeline — parse
+// fan-out, fact spool, four-phase apply, coverage accounting — against a
+// committed snapshot. Any spool or paging change must reproduce this
+// byte-for-byte; regenerate deliberately with -update.
+func TestApplyGoldenSnapshot(t *testing.T) {
+	g, dir := buildFixture(t, goldenFixtureFiles())
+	p := NewProvider(CSharpSpec(), zap.NewNop())
+	res, err := p.EnrichRepo(g, "", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := snapshotFrom(g, res)
+
+	goldenPath := filepath.Join("testdata", "golden", "apply_snapshot.json")
+	if *updateGolden {
+		blob, err := json.MarshalIndent(got, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Dir(goldenPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(goldenPath, blob, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	blob, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("read golden (run with -update first): %v", err)
+	}
+	var want applySnapshot
+	if err := json.Unmarshal(blob, &want); err != nil {
+		t.Fatal(err)
+	}
+	gotBlob, _ := json.Marshal(got)
+	wantBlob, _ := json.Marshal(want)
+	if string(gotBlob) != string(wantBlob) {
+		t.Fatalf("apply snapshot drifted from golden\ngot:  %s\nwant: %s", gotBlob, wantBlob)
+	}
+}

--- a/internal/semantic/tstypes/apply_hot_cache.go
+++ b/internal/semantic/tstypes/apply_hot_cache.go
@@ -283,6 +283,28 @@ func (c *applyHotCache) putIn(id string, edges []*graph.Edge) {
 	c.cur.bytes += int64(len(id)) + applyHotEdgesBytes(edges)
 }
 
+// applyHotCacheStats reports the funnel counters for the pass-end log line —
+// they were previously write-only, which left this cache invisible to the
+// completion log the resolver-side caches already have.
+type applyHotCacheStats struct {
+	NodeHits, NodeMisses int64
+	NameHits, NameMisses int64
+	AdjHits, AdjMisses   int64
+	FileHits, FileMisses int64
+}
+
+func (c *applyHotCache) statsSnapshot() applyHotCacheStats {
+	if c == nil {
+		return applyHotCacheStats{}
+	}
+	return applyHotCacheStats{
+		NodeHits: c.nodeHits, NodeMisses: c.nodeMisses,
+		NameHits: c.nameHits, NameMisses: c.nameMisses,
+		AdjHits: c.adjHits, AdjMisses: c.adjMisses,
+		FileHits: c.fileHits, FileMisses: c.fileMisses,
+	}
+}
+
 // flushAdjacency drops every cached adjacency entry in both generations. The
 // driver calls it at phase boundaries: the supers phase synthesizes
 // inheritance edges, and every later phase's frontier walk must observe them

--- a/internal/semantic/tstypes/engine_pages.go
+++ b/internal/semantic/tstypes/engine_pages.go
@@ -276,6 +276,32 @@ func factCallChainDepth(facts *fileFacts) int {
 	return maxDepth
 }
 
+// coverFiles hydrates the page's per-file node groups (through the pass hot
+// cache — warming them for every later phase) and counts covered symbols.
+// It replaces the coverage side effect the supers phase carried when every
+// file appeared in its walk; the walk itself decodes no facts.
+func (a *applier) coverFiles(page []*fileFacts) int {
+	files := make([]string, 0, len(page))
+	fileSet := make(map[string]struct{}, len(page))
+	repoNames := make(map[string]map[string]struct{})
+	for _, facts := range page {
+		if facts == nil || facts.file == "" {
+			continue
+		}
+		if _, duplicate := fileSet[facts.file]; duplicate {
+			continue
+		}
+		fileSet[facts.file] = struct{}{}
+		files = append(files, facts.file)
+		if _, ok := repoNames[facts.repoPrefix]; !ok {
+			repoNames[facts.repoPrefix] = make(map[string]struct{})
+		}
+	}
+	sort.Strings(files)
+	a.loadPageFileNodes(files, fileSet, repoNames)
+	return a.coveredSymbols(page)
+}
+
 func (a *applier) preparePage(all []*fileFacts) []*fileIndex {
 	sort.Slice(all, func(i, j int) bool { return all[i].file < all[j].file })
 	a.preload(all)

--- a/internal/semantic/tstypes/fact_spool.go
+++ b/internal/semantic/tstypes/fact_spool.go
@@ -333,58 +333,6 @@ ON CONFLICT(class,file_path) DO UPDATE SET repo_prefix=excluded.repo_prefix,payl
 	return tx.Commit()
 }
 
-// page reads a deterministic keyset page over the staged files, hydrating
-// every class — transitional full-fat shape; per-class paging lands with the
-// phase-loop change.
-func (s *factSpool) page(ctx context.Context, after string) ([]*fileFacts, string, factPageStats, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT file_path,repo_prefix FROM files
-WHERE file_path > ? ORDER BY file_path LIMIT ?`, after, tstypesFactPageFiles)
-	if err != nil {
-		return nil, after, factPageStats{}, err
-	}
-	page := make([]*fileFacts, 0, tstypesFactPageFiles)
-	stats := factPageStats{}
-	last := after
-	for rows.Next() {
-		var filePath, repoPrefix string
-		if err := rows.Scan(&filePath, &repoPrefix); err != nil {
-			_ = rows.Close()
-			return nil, last, stats, err
-		}
-		page = append(page, &fileFacts{file: filePath, repoPrefix: repoPrefix})
-		last = filePath
-		stats.Files++
-	}
-	if err := rows.Close(); err != nil {
-		return nil, last, stats, err
-	}
-	for _, facts := range page {
-		classRows, err := s.db.QueryContext(ctx, `SELECT class,payload FROM file_facts
-WHERE file_path = ? ORDER BY class`, facts.file)
-		if err != nil {
-			return nil, last, stats, err
-		}
-		for classRows.Next() {
-			var class int
-			var payload []byte
-			if err := classRows.Scan(&class, &payload); err != nil {
-				_ = classRows.Close()
-				return nil, last, stats, err
-			}
-			if err := unmarshalClassPayload(facts, factClass(class), payload); err != nil {
-				_ = classRows.Close()
-				return nil, last, stats, fmt.Errorf("decode facts for %s: %w", facts.file, err)
-			}
-			stats.Bytes += len(payload)
-		}
-		if err := classRows.Close(); err != nil {
-			return nil, last, stats, err
-		}
-		stats.Facts += len(facts.imports) + len(facts.calls) + len(facts.supers) + len(facts.metas) + len(facts.aliases)
-	}
-	return page, last, stats, nil
-}
-
 // pageClass reads a deterministic keyset page of one fact class. Every
 // returned fileFacts carries that class plus the file's imports — buildIndex
 // needs the import map in every phase. Files without facts of the class have

--- a/internal/semantic/tstypes/fact_spool.go
+++ b/internal/semantic/tstypes/fact_spool.go
@@ -62,10 +62,16 @@ func newFactSpool() (*factSpool, error) {
 	if _, err := db.Exec(`PRAGMA journal_mode=OFF;
 PRAGMA synchronous=OFF;
 PRAGMA cache_size=-4096;
-CREATE TABLE file_facts (
+CREATE TABLE files (
   file_path TEXT PRIMARY KEY,
+  repo_prefix TEXT NOT NULL
+) WITHOUT ROWID;
+CREATE TABLE file_facts (
+  class INTEGER NOT NULL,
+  file_path TEXT NOT NULL,
   repo_prefix TEXT NOT NULL,
-  payload BLOB NOT NULL
+  payload BLOB NOT NULL,
+  PRIMARY KEY (class, file_path)
 ) WITHOUT ROWID;
 CREATE TABLE resolved_aliases (
   seq INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -93,14 +99,6 @@ func (s *factSpool) close() {
 	_ = os.Remove(s.path + "-journal")
 	_ = os.Remove(s.path + "-wal")
 	_ = os.Remove(s.path + "-shm")
-}
-
-type encodedFileFacts struct {
-	Imports []Import       `json:"imports,omitempty"`
-	Calls   []encodedCall  `json:"calls,omitempty"`
-	Supers  []encodedSuper `json:"supers,omitempty"`
-	Metas   []encodedMeta  `json:"metas,omitempty"`
-	Aliases []encodedAlias `json:"aliases,omitempty"`
 }
 
 type encodedCall struct {
@@ -161,44 +159,6 @@ func decodeCallFact(in *encodedCall) *callFact {
 		recvIdent: in.RecvIdent, recvChain: decodeCallFact(in.RecvChain),
 		inferred: in.Inferred, argCount: in.ArgCount, argKnown: in.ArgKnown,
 	}
-}
-
-func marshalFileFacts(facts *fileFacts) ([]byte, error) {
-	wire := encodedFileFacts{Imports: facts.imports}
-	for i := range facts.calls {
-		wire.Calls = append(wire.Calls, *encodeCallFact(&facts.calls[i]))
-	}
-	for _, fact := range facts.supers {
-		wire.Supers = append(wire.Supers, encodedSuper{fact.typeName, fact.superName, fact.kind, fact.line})
-	}
-	for _, fact := range facts.metas {
-		wire.Metas = append(wire.Metas, encodedMeta{fact.key, fact.value, fact.owner, fact.name, fact.line})
-	}
-	for _, fact := range facts.aliases {
-		wire.Aliases = append(wire.Aliases, encodedAlias{fact.typeName, fact.alias, fact.trait, fact.method, fact.line})
-	}
-	return json.Marshal(&wire)
-}
-
-func unmarshalFileFacts(filePath, repoPrefix string, payload []byte) (*fileFacts, error) {
-	var wire encodedFileFacts
-	if err := json.Unmarshal(payload, &wire); err != nil {
-		return nil, err
-	}
-	facts := &fileFacts{file: filePath, repoPrefix: repoPrefix, imports: wire.Imports}
-	for i := range wire.Calls {
-		facts.calls = append(facts.calls, *decodeCallFact(&wire.Calls[i]))
-	}
-	for _, fact := range wire.Supers {
-		facts.supers = append(facts.supers, superFact{fact.TypeName, fact.SuperName, fact.Kind, fact.Line})
-	}
-	for _, fact := range wire.Metas {
-		facts.metas = append(facts.metas, metaFact{fact.Key, fact.Value, fact.Owner, fact.Name, fact.Line})
-	}
-	for _, fact := range wire.Aliases {
-		facts.aliases = append(facts.aliases, aliasFact{fact.TypeName, fact.Alias, fact.Trait, fact.Method, fact.Line})
-	}
-	return facts, nil
 }
 
 // factClass partitions one file's facts by the phase that applies them.
@@ -308,17 +268,26 @@ func unmarshalClassPayload(facts *fileFacts, class factClass, payload []byte) er
 }
 
 type stagedFileFacts struct {
-	facts   *fileFacts
-	payload []byte
+	facts    *fileFacts
+	payloads map[factClass][]byte
+	bytes    int
 }
 
 func stageFileFacts(facts *fileFacts) (stagedFileFacts, error) {
-	payload, err := marshalFileFacts(facts)
-	return stagedFileFacts{facts: facts, payload: payload}, err
+	payloads, err := marshalClassPayloads(facts)
+	if err != nil {
+		return stagedFileFacts{}, err
+	}
+	total := 0
+	for _, payload := range payloads {
+		total += len(payload)
+	}
+	return stagedFileFacts{facts: facts, payloads: payloads, bytes: total}, nil
 }
 
 // appendFiles performs one bounded transaction for a writer page; it is never
-// called once per parser worker or source file.
+// called once per parser worker or source file. Each record lands as one
+// files row plus a file_facts row per non-empty class.
 func (s *factSpool) appendFiles(records []stagedFileFacts) error {
 	if len(records) == 0 {
 		return nil
@@ -328,65 +297,90 @@ func (s *factSpool) appendFiles(records []stagedFileFacts) error {
 		return err
 	}
 	for start := 0; start < len(records); start += tstypesSQLChunkRows {
-		end := start + tstypesSQLChunkRows
-		if end > len(records) {
-			end = len(records)
-		}
-		values := make([]string, 0, end-start)
-		args := make([]any, 0, (end-start)*3)
+		end := min(start+tstypesSQLChunkRows, len(records))
+		fileValues := make([]string, 0, end-start)
+		fileArgs := make([]any, 0, (end-start)*2)
+		classValues := make([]string, 0, (end-start)*4)
+		classArgs := make([]any, 0, (end-start)*4*4)
 		for _, record := range records[start:end] {
 			if record.facts == nil {
 				continue
 			}
-			values = append(values, "(?,?,?)")
-			args = append(args, record.facts.file, record.facts.repoPrefix, record.payload)
+			fileValues = append(fileValues, "(?,?)")
+			fileArgs = append(fileArgs, record.facts.file, record.facts.repoPrefix)
+			for class, payload := range record.payloads {
+				classValues = append(classValues, "(?,?,?,?)")
+				classArgs = append(classArgs, int(class), record.facts.file, record.facts.repoPrefix, payload)
+			}
 		}
-		if len(values) == 0 {
-			continue
+		if len(fileValues) > 0 {
+			query := `INSERT INTO files(file_path,repo_prefix) VALUES ` + strings.Join(fileValues, ",") + `
+ON CONFLICT(file_path) DO UPDATE SET repo_prefix=excluded.repo_prefix`
+			if _, err := tx.Exec(query, fileArgs...); err != nil {
+				_ = tx.Rollback()
+				return err
+			}
 		}
-		query := `INSERT INTO file_facts(file_path,repo_prefix,payload) VALUES ` + strings.Join(values, ",") + `
-ON CONFLICT(file_path) DO UPDATE SET repo_prefix=excluded.repo_prefix,payload=excluded.payload`
-		if _, err := tx.Exec(query, args...); err != nil {
-			_ = tx.Rollback()
-			return err
+		if len(classValues) > 0 {
+			query := `INSERT INTO file_facts(class,file_path,repo_prefix,payload) VALUES ` + strings.Join(classValues, ",") + `
+ON CONFLICT(class,file_path) DO UPDATE SET repo_prefix=excluded.repo_prefix,payload=excluded.payload`
+			if _, err := tx.Exec(query, classArgs...); err != nil {
+				_ = tx.Rollback()
+				return err
+			}
 		}
 	}
 	return tx.Commit()
 }
 
-// page reads a deterministic keyset page. Rows are streamed and the byte cap
-// stops decoding before a second large row can inflate retained memory.
+// page reads a deterministic keyset page over the staged files, hydrating
+// every class — transitional full-fat shape; per-class paging lands with the
+// phase-loop change.
 func (s *factSpool) page(ctx context.Context, after string) ([]*fileFacts, string, factPageStats, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT file_path,repo_prefix,payload FROM file_facts
+	rows, err := s.db.QueryContext(ctx, `SELECT file_path,repo_prefix FROM files
 WHERE file_path > ? ORDER BY file_path LIMIT ?`, after, tstypesFactPageFiles)
 	if err != nil {
 		return nil, after, factPageStats{}, err
 	}
-	defer rows.Close()
 	page := make([]*fileFacts, 0, tstypesFactPageFiles)
 	stats := factPageStats{}
 	last := after
 	for rows.Next() {
 		var filePath, repoPrefix string
-		var payload []byte
-		if err := rows.Scan(&filePath, &repoPrefix, &payload); err != nil {
+		if err := rows.Scan(&filePath, &repoPrefix); err != nil {
+			_ = rows.Close()
 			return nil, last, stats, err
 		}
-		if len(page) > 0 && stats.Bytes+len(payload) > tstypesFactPageBytes {
-			break
-		}
-		facts, err := unmarshalFileFacts(filePath, repoPrefix, payload)
-		if err != nil {
-			return nil, last, stats, fmt.Errorf("decode facts for %s: %w", filePath, err)
-		}
-		page = append(page, facts)
+		page = append(page, &fileFacts{file: filePath, repoPrefix: repoPrefix})
 		last = filePath
 		stats.Files++
-		stats.Bytes += len(payload)
-		stats.Facts += len(facts.imports) + len(facts.calls) + len(facts.supers) + len(facts.metas) + len(facts.aliases)
 	}
-	if err := rows.Err(); err != nil {
+	if err := rows.Close(); err != nil {
 		return nil, last, stats, err
+	}
+	for _, facts := range page {
+		classRows, err := s.db.QueryContext(ctx, `SELECT class,payload FROM file_facts
+WHERE file_path = ? ORDER BY class`, facts.file)
+		if err != nil {
+			return nil, last, stats, err
+		}
+		for classRows.Next() {
+			var class int
+			var payload []byte
+			if err := classRows.Scan(&class, &payload); err != nil {
+				_ = classRows.Close()
+				return nil, last, stats, err
+			}
+			if err := unmarshalClassPayload(facts, factClass(class), payload); err != nil {
+				_ = classRows.Close()
+				return nil, last, stats, fmt.Errorf("decode facts for %s: %w", facts.file, err)
+			}
+			stats.Bytes += len(payload)
+		}
+		if err := classRows.Close(); err != nil {
+			return nil, last, stats, err
+		}
+		stats.Facts += len(facts.imports) + len(facts.calls) + len(facts.supers) + len(facts.metas) + len(facts.aliases)
 	}
 	return page, last, stats, nil
 }

--- a/internal/semantic/tstypes/fact_spool.go
+++ b/internal/semantic/tstypes/fact_spool.go
@@ -201,6 +201,112 @@ func unmarshalFileFacts(filePath, repoPrefix string, payload []byte) (*fileFacts
 	return facts, nil
 }
 
+// factClass partitions one file's facts by the phase that applies them.
+// Values are stable spool row keys — the temp spool never outlives a pass,
+// so renumbering is safe across builds but pointless.
+type factClass int
+
+const (
+	classImports factClass = iota
+	classSupers
+	classMetas
+	classAliases
+	classCalls
+)
+
+// marshalClassPayloads encodes one file's facts as per-class JSON arrays,
+// omitting empty classes entirely — a file with no aliases contributes no
+// aliases row, which is what lets a phase skip files wholesale.
+func marshalClassPayloads(facts *fileFacts) (map[factClass][]byte, error) {
+	out := make(map[factClass][]byte, 5)
+	put := func(class factClass, v any, n int) error {
+		if n == 0 {
+			return nil
+		}
+		blob, err := json.Marshal(v)
+		if err != nil {
+			return err
+		}
+		out[class] = blob
+		return nil
+	}
+	if err := put(classImports, facts.imports, len(facts.imports)); err != nil {
+		return nil, err
+	}
+	wireSupers := make([]encodedSuper, 0, len(facts.supers))
+	for _, fact := range facts.supers {
+		wireSupers = append(wireSupers, encodedSuper{fact.typeName, fact.superName, fact.kind, fact.line})
+	}
+	if err := put(classSupers, wireSupers, len(wireSupers)); err != nil {
+		return nil, err
+	}
+	wireMetas := make([]encodedMeta, 0, len(facts.metas))
+	for _, fact := range facts.metas {
+		wireMetas = append(wireMetas, encodedMeta{fact.key, fact.value, fact.owner, fact.name, fact.line})
+	}
+	if err := put(classMetas, wireMetas, len(wireMetas)); err != nil {
+		return nil, err
+	}
+	wireAliases := make([]encodedAlias, 0, len(facts.aliases))
+	for _, fact := range facts.aliases {
+		wireAliases = append(wireAliases, encodedAlias{fact.typeName, fact.alias, fact.trait, fact.method, fact.line})
+	}
+	if err := put(classAliases, wireAliases, len(wireAliases)); err != nil {
+		return nil, err
+	}
+	wireCalls := make([]encodedCall, 0, len(facts.calls))
+	for i := range facts.calls {
+		wireCalls = append(wireCalls, *encodeCallFact(&facts.calls[i]))
+	}
+	if err := put(classCalls, wireCalls, len(wireCalls)); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// unmarshalClassPayload appends one class's decoded facts onto facts.
+func unmarshalClassPayload(facts *fileFacts, class factClass, payload []byte) error {
+	switch class {
+	case classImports:
+		return json.Unmarshal(payload, &facts.imports)
+	case classSupers:
+		var wire []encodedSuper
+		if err := json.Unmarshal(payload, &wire); err != nil {
+			return err
+		}
+		for _, fact := range wire {
+			facts.supers = append(facts.supers, superFact{fact.TypeName, fact.SuperName, fact.Kind, fact.Line})
+		}
+	case classMetas:
+		var wire []encodedMeta
+		if err := json.Unmarshal(payload, &wire); err != nil {
+			return err
+		}
+		for _, fact := range wire {
+			facts.metas = append(facts.metas, metaFact{fact.Key, fact.Value, fact.Owner, fact.Name, fact.Line})
+		}
+	case classAliases:
+		var wire []encodedAlias
+		if err := json.Unmarshal(payload, &wire); err != nil {
+			return err
+		}
+		for _, fact := range wire {
+			facts.aliases = append(facts.aliases, aliasFact{fact.TypeName, fact.Alias, fact.Trait, fact.Method, fact.Line})
+		}
+	case classCalls:
+		var wire []encodedCall
+		if err := json.Unmarshal(payload, &wire); err != nil {
+			return err
+		}
+		for i := range wire {
+			facts.calls = append(facts.calls, *decodeCallFact(&wire[i]))
+		}
+	default:
+		return fmt.Errorf("unknown fact class %d", class)
+	}
+	return nil
+}
+
 type stagedFileFacts struct {
 	facts   *fileFacts
 	payload []byte

--- a/internal/semantic/tstypes/fact_spool.go
+++ b/internal/semantic/tstypes/fact_spool.go
@@ -28,6 +28,7 @@ type factSpool struct {
 }
 
 type factPageStats struct {
+	Class      factClass
 	Files      int
 	Facts      int
 	Bytes      int
@@ -344,7 +345,7 @@ WHERE class = ? AND file_path > ? ORDER BY file_path LIMIT ?`, int(class), after
 		return nil, after, factPageStats{}, err
 	}
 	page := make([]*fileFacts, 0, tstypesFactPageFiles)
-	stats := factPageStats{}
+	stats := factPageStats{Class: class}
 	last := after
 	for rows.Next() {
 		var filePath, repoPrefix string

--- a/internal/semantic/tstypes/fact_spool.go
+++ b/internal/semantic/tstypes/fact_spool.go
@@ -385,6 +385,106 @@ WHERE file_path = ? ORDER BY class`, facts.file)
 	return page, last, stats, nil
 }
 
+// pageClass reads a deterministic keyset page of one fact class. Every
+// returned fileFacts carries that class plus the file's imports — buildIndex
+// needs the import map in every phase. Files without facts of the class have
+// no row and are skipped wholesale.
+func (s *factSpool) pageClass(ctx context.Context, class factClass, after string) ([]*fileFacts, string, factPageStats, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT file_path,repo_prefix,payload FROM file_facts
+WHERE class = ? AND file_path > ? ORDER BY file_path LIMIT ?`, int(class), after, tstypesFactPageFiles)
+	if err != nil {
+		return nil, after, factPageStats{}, err
+	}
+	page := make([]*fileFacts, 0, tstypesFactPageFiles)
+	stats := factPageStats{}
+	last := after
+	for rows.Next() {
+		var filePath, repoPrefix string
+		var payload []byte
+		if err := rows.Scan(&filePath, &repoPrefix, &payload); err != nil {
+			_ = rows.Close()
+			return nil, last, stats, err
+		}
+		if len(page) > 0 && stats.Bytes+len(payload) > tstypesFactPageBytes {
+			break
+		}
+		facts := &fileFacts{file: filePath, repoPrefix: repoPrefix}
+		if err := unmarshalClassPayload(facts, class, payload); err != nil {
+			_ = rows.Close()
+			return nil, last, stats, fmt.Errorf("decode facts for %s: %w", filePath, err)
+		}
+		page = append(page, facts)
+		last = filePath
+		stats.Files++
+		stats.Bytes += len(payload)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, last, stats, err
+	}
+	if class != classImports && len(page) > 0 {
+		if err := s.attachImports(ctx, page); err != nil {
+			return nil, last, stats, err
+		}
+	}
+	for _, facts := range page {
+		stats.Facts += len(facts.imports) + len(facts.calls) + len(facts.supers) + len(facts.metas) + len(facts.aliases)
+	}
+	return page, last, stats, nil
+}
+
+// attachImports hydrates the page files' imports rows in one bounded IN query.
+func (s *factSpool) attachImports(ctx context.Context, page []*fileFacts) error {
+	byFile := make(map[string]*fileFacts, len(page))
+	args := make([]any, 0, len(page)+1)
+	args = append(args, int(classImports))
+	for _, facts := range page {
+		byFile[facts.file] = facts
+		args = append(args, facts.file)
+	}
+	placeholders := strings.Repeat(",?", len(page))[1:]
+	rows, err := s.db.QueryContext(ctx, `SELECT file_path,payload FROM file_facts
+WHERE class = ? AND file_path IN (`+placeholders+`)`, args...)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var filePath string
+		var payload []byte
+		if err := rows.Scan(&filePath, &payload); err != nil {
+			return err
+		}
+		if facts := byFile[filePath]; facts != nil {
+			if err := unmarshalClassPayload(facts, classImports, payload); err != nil {
+				return fmt.Errorf("decode imports for %s: %w", filePath, err)
+			}
+		}
+	}
+	return rows.Err()
+}
+
+// pageFiles lists staged files as bare stubs for the coverage walk — no
+// payload touched anywhere.
+func (s *factSpool) pageFiles(ctx context.Context, after string) ([]*fileFacts, string, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT file_path,repo_prefix FROM files
+WHERE file_path > ? ORDER BY file_path LIMIT ?`, after, tstypesFactPageFiles)
+	if err != nil {
+		return nil, after, err
+	}
+	defer rows.Close()
+	page := make([]*fileFacts, 0, tstypesFactPageFiles)
+	last := after
+	for rows.Next() {
+		var filePath, repoPrefix string
+		if err := rows.Scan(&filePath, &repoPrefix); err != nil {
+			return nil, last, err
+		}
+		page = append(page, &fileFacts{file: filePath, repoPrefix: repoPrefix})
+		last = filePath
+	}
+	return page, last, rows.Err()
+}
+
 func (s *factSpool) appendAliases(records []stagedResolvedAlias) error {
 	if len(records) == 0 {
 		return nil

--- a/internal/semantic/tstypes/fact_spool_bench_test.go
+++ b/internal/semantic/tstypes/fact_spool_bench_test.go
@@ -1,0 +1,127 @@
+package tstypes
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// benchCorpus stages a spool shaped like a large production C# repo:
+// calls dominate every file, a third of files declare inheritance, aliases
+// are absent entirely — the class-skew the partitioned walk exploits.
+func benchCorpus(b *testing.B, files int) *factSpool {
+	b.Helper()
+	spool, err := newFactSpool()
+	if err != nil {
+		b.Fatal(err)
+	}
+	staged := make([]stagedFileFacts, 0, files)
+	for i := 0; i < files; i++ {
+		facts := &fileFacts{
+			file: fmt.Sprintf("src/dir%02d/File%04d.cs", i%16, i), repoPrefix: "bench",
+			imports: []Import{{Local: "Sys"}, {Local: "Col"}},
+		}
+		if i%3 == 0 {
+			facts.supers = []superFact{{typeName: "T", superName: "Base", kind: graph.EdgeExtends, line: 1}}
+		}
+		for m := 0; m < 5; m++ {
+			facts.metas = append(facts.metas, metaFact{key: "return_type", value: "T", owner: "T", name: fmt.Sprintf("M%d", m), line: m})
+		}
+		for c := 0; c < 40; c++ {
+			facts.calls = append(facts.calls, callFact{
+				line: c, method: fmt.Sprintf("Call%d", c), recvType: "T",
+				recvChain: &callFact{line: c, method: "Inner", recvIdent: "x"},
+			})
+		}
+		record, err := stageFileFacts(facts)
+		if err != nil {
+			b.Fatal(err)
+		}
+		staged = append(staged, record)
+	}
+	if err := spool.appendFiles(staged); err != nil {
+		b.Fatal(err)
+	}
+	return spool
+}
+
+// legacyFourPhaseWalk models the pre-partition read pattern: four full
+// walks, each decoding every class of every file. Query granularity is
+// per file rather than the old per-32-file page scan, so treat the gap
+// as decode volume (~4x) plus point-query overhead, not decode alone.
+func legacyFourPhaseWalk(b *testing.B, spool *factSpool) int {
+	total := 0
+	for phase := 0; phase < 4; phase++ {
+		after := ""
+		for {
+			page, last, err := spool.pageFiles(context.Background(), after)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if len(page) == 0 {
+				break
+			}
+			for _, stub := range page {
+				rows, err := spool.db.Query(`SELECT class,payload FROM file_facts WHERE file_path = ?`, stub.file)
+				if err != nil {
+					b.Fatal(err)
+				}
+				for rows.Next() {
+					var class int
+					var payload []byte
+					if err := rows.Scan(&class, &payload); err != nil {
+						b.Fatal(err)
+					}
+					if err := unmarshalClassPayload(stub, factClass(class), payload); err != nil {
+						b.Fatal(err)
+					}
+				}
+				_ = rows.Close()
+				total += len(stub.calls) + len(stub.supers) + len(stub.metas) + len(stub.aliases)
+			}
+			after = last
+		}
+	}
+	return total
+}
+
+func partitionedFourPhaseWalk(b *testing.B, spool *factSpool) int {
+	total := 0
+	for _, class := range []factClass{classSupers, classMetas, classAliases, classCalls} {
+		after := ""
+		for {
+			page, last, _, err := spool.pageClass(context.Background(), class, after)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if len(page) == 0 {
+				break
+			}
+			for _, facts := range page {
+				total += len(facts.calls) + len(facts.supers) + len(facts.metas) + len(facts.aliases)
+			}
+			after = last
+		}
+	}
+	return total
+}
+
+func BenchmarkFourPhaseWalkLegacyShape(b *testing.B) {
+	spool := benchCorpus(b, 512)
+	defer spool.close()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		legacyFourPhaseWalk(b, spool)
+	}
+}
+
+func BenchmarkFourPhaseWalkPartitioned(b *testing.B) {
+	spool := benchCorpus(b, 512)
+	defer spool.close()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		partitionedFourPhaseWalk(b, spool)
+	}
+}

--- a/internal/semantic/tstypes/fact_spool_partition_test.go
+++ b/internal/semantic/tstypes/fact_spool_partition_test.go
@@ -54,3 +54,34 @@ func TestMarshalClassPayloadsRoundTrip(t *testing.T) {
 		t.Fatalf("aliases should stay empty: %+v", dst.aliases)
 	}
 }
+
+func TestAppendFilesWritesClassRows(t *testing.T) {
+	spool, err := newFactSpool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer spool.close()
+	record, err := stageFileFacts(sampleFacts())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.bytes <= 0 {
+		t.Fatal("staged bytes must sum class payloads")
+	}
+	if err := spool.appendFiles([]stagedFileFacts{record}); err != nil {
+		t.Fatal(err)
+	}
+	var fileRows, classRows, aliasClassRows int
+	if err := spool.db.QueryRow(`SELECT COUNT(*) FROM files`).Scan(&fileRows); err != nil {
+		t.Fatal(err)
+	}
+	if err := spool.db.QueryRow(`SELECT COUNT(*) FROM file_facts`).Scan(&classRows); err != nil {
+		t.Fatal(err)
+	}
+	if err := spool.db.QueryRow(`SELECT COUNT(*) FROM file_facts WHERE class=3`).Scan(&aliasClassRows); err != nil {
+		t.Fatal(err)
+	}
+	if fileRows != 1 || classRows != 4 || aliasClassRows != 0 {
+		t.Fatalf("rows: files=%d classes=%d aliases=%d (want 1/4/0)", fileRows, classRows, aliasClassRows)
+	}
+}

--- a/internal/semantic/tstypes/fact_spool_partition_test.go
+++ b/internal/semantic/tstypes/fact_spool_partition_test.go
@@ -1,6 +1,8 @@
 package tstypes
 
 import (
+	"context"
+	"strings"
 	"testing"
 
 	"github.com/zzet/gortex/internal/graph"
@@ -83,5 +85,91 @@ func TestAppendFilesWritesClassRows(t *testing.T) {
 	}
 	if fileRows != 1 || classRows != 4 || aliasClassRows != 0 {
 		t.Fatalf("rows: files=%d classes=%d aliases=%d (want 1/4/0)", fileRows, classRows, aliasClassRows)
+	}
+}
+
+func TestPageClassReturnsOnlyOwnClassPlusImports(t *testing.T) {
+	spool, err := newFactSpool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer spool.close()
+	full, err := stageFileFacts(sampleFacts())
+	if err != nil {
+		t.Fatal(err)
+	}
+	callsOnly, err := stageFileFacts(&fileFacts{
+		file: "z/calls_only.cs", repoPrefix: "repo",
+		calls: []callFact{{line: 1, method: "Only"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := spool.appendFiles([]stagedFileFacts{full, callsOnly}); err != nil {
+		t.Fatal(err)
+	}
+
+	supersPage, last, _, err := spool.pageClass(context.Background(), classSupers, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(supersPage) != 1 || supersPage[0].file != "a/b.cs" {
+		t.Fatalf("supers walk must skip files without supers: %+v", supersPage)
+	}
+	got := supersPage[0]
+	if len(got.supers) != 1 || len(got.imports) != 1 {
+		t.Fatalf("supers page must carry supers+imports: %+v", got)
+	}
+	if len(got.calls) != 0 || len(got.metas) != 0 || len(got.aliases) != 0 {
+		t.Fatalf("other classes must stay empty: %+v", got)
+	}
+	if next, _, _, err := spool.pageClass(context.Background(), classSupers, last); err != nil || len(next) != 0 {
+		t.Fatalf("keyset must terminate: %v %d", err, len(next))
+	}
+
+	callsPage, _, _, err := spool.pageClass(context.Background(), classCalls, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(callsPage) != 2 {
+		t.Fatalf("calls walk must see both files: %d", len(callsPage))
+	}
+
+	filesPage, _, err := spool.pageFiles(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(filesPage) != 2 || filesPage[0].file != "a/b.cs" || filesPage[1].file != "z/calls_only.cs" {
+		t.Fatalf("files walk must list every staged file in order: %+v", filesPage)
+	}
+}
+
+func TestPageClassRespectsByteCap(t *testing.T) {
+	spool, err := newFactSpool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer spool.close()
+	big := strings.Repeat("x", 3<<20) // two ~3 MiB call payloads exceed the 4 MiB page cap
+	staged := make([]stagedFileFacts, 0, 2)
+	for _, name := range []string{"a/one.cs", "a/two.cs"} {
+		record, err := stageFileFacts(&fileFacts{
+			file: name, repoPrefix: "repo",
+			calls: []callFact{{line: 1, method: big}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		staged = append(staged, record)
+	}
+	if err := spool.appendFiles(staged); err != nil {
+		t.Fatal(err)
+	}
+	page, last, _, err := spool.pageClass(context.Background(), classCalls, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page) != 1 || last != "a/one.cs" {
+		t.Fatalf("byte cap must stop after the first oversized row: %d files, last=%q", len(page), last)
 	}
 }

--- a/internal/semantic/tstypes/fact_spool_partition_test.go
+++ b/internal/semantic/tstypes/fact_spool_partition_test.go
@@ -1,0 +1,56 @@
+package tstypes
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func sampleFacts() *fileFacts {
+	return &fileFacts{
+		file: "a/b.cs", repoPrefix: "repo",
+		imports: []Import{{Local: "Sys"}},
+		supers:  []superFact{{typeName: "A", superName: "B", kind: graph.EdgeExtends, line: 1}},
+		metas:   []metaFact{{key: "return_type", value: "C", owner: "A", name: "M", line: 2}},
+		calls: []callFact{{line: 3, method: "M", recvType: "C",
+			recvChain: &callFact{line: 3, method: "N"}, argCount: 2, argKnown: true}},
+		// aliases deliberately empty — must be absent from the payload map
+	}
+}
+
+func TestMarshalClassPayloadsRoundTrip(t *testing.T) {
+	src := sampleFacts()
+	payloads, err := marshalClassPayloads(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := payloads[classAliases]; ok {
+		t.Fatal("empty aliases class must be omitted")
+	}
+	for _, class := range []factClass{classImports, classSupers, classMetas, classCalls} {
+		if len(payloads[class]) == 0 {
+			t.Fatalf("class %d missing payload", class)
+		}
+	}
+	dst := &fileFacts{file: src.file, repoPrefix: src.repoPrefix}
+	for class, payload := range payloads {
+		if err := unmarshalClassPayload(dst, class, payload); err != nil {
+			t.Fatalf("class %d: %v", class, err)
+		}
+	}
+	if len(dst.imports) != 1 || dst.imports[0].Local != "Sys" {
+		t.Fatalf("imports lost: %+v", dst.imports)
+	}
+	if len(dst.supers) != 1 || dst.supers[0].superName != "B" {
+		t.Fatalf("supers lost: %+v", dst.supers)
+	}
+	if len(dst.metas) != 1 || dst.metas[0].value != "C" {
+		t.Fatalf("metas lost: %+v", dst.metas)
+	}
+	if len(dst.calls) != 1 || dst.calls[0].recvChain == nil || dst.calls[0].recvChain.method != "N" {
+		t.Fatalf("calls (incl. chain) lost: %+v", dst.calls)
+	}
+	if len(dst.aliases) != 0 {
+		t.Fatalf("aliases should stay empty: %+v", dst.aliases)
+	}
+}

--- a/internal/semantic/tstypes/provider_stream.go
+++ b/internal/semantic/tstypes/provider_stream.go
@@ -234,6 +234,14 @@ func (p *Provider) applyStagedFacts(ctx context.Context, g graph.Store, repoPref
 			after = last
 		}
 	}
+	stats := hot.statsSnapshot()
+	p.logger.Info("tstypes: apply hot cache",
+		zap.String("provider", p.Name()),
+		zap.String("repo_prefix", repoPrefix),
+		zap.Int64("node_hits", stats.NodeHits), zap.Int64("node_misses", stats.NodeMisses),
+		zap.Int64("name_hits", stats.NameHits), zap.Int64("name_misses", stats.NameMisses),
+		zap.Int64("adj_hits", stats.AdjHits), zap.Int64("adj_misses", stats.AdjMisses),
+		zap.Int64("file_hits", stats.FileHits), zap.Int64("file_misses", stats.FileMisses))
 	if res.SymbolsTotal > 0 {
 		res.CoveragePercent = float64(res.SymbolsCovered) / float64(res.SymbolsTotal) * 100
 	}

--- a/internal/semantic/tstypes/provider_stream.go
+++ b/internal/semantic/tstypes/provider_stream.go
@@ -152,6 +152,34 @@ func (p *Provider) applyStagedFacts(ctx context.Context, g graph.Store, repoPref
 	// process CPU (48–62% measured) because each of the 4 phases re-fetched
 	// near-identical name groups and inheritance frontiers per 32-file page.
 	hot := newApplyHotCache(applyHotCacheBudget())
+
+	// Coverage walk: every staged file, no payload decode. The supers phase
+	// no longer sees files without inheritance facts, so coverage counting
+	// cannot ride on it; this walk also pre-warms the per-file node groups
+	// for all four phases.
+	after := ""
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		page, last, err := spool.pageFiles(ctx, after)
+		if err != nil {
+			return err
+		}
+		if len(page) == 0 {
+			break
+		}
+		ap := newApplier(g, p.spec, p.Name()).withHotCache(hot)
+		res.SymbolsCovered += ap.coverFiles(page)
+		after = last
+	}
+
+	classForPhase := map[stagedFactPhase]factClass{
+		stagedSupers:  classSupers,
+		stagedMetas:   classMetas,
+		stagedAliases: classAliases,
+		stagedCalls:   classCalls,
+	}
 	for phase := stagedSupers; phase <= stagedCalls; phase++ {
 		// Adjacency is only valid within one phase: the supers phase
 		// synthesizes inheritance edges that later phases' frontier walks
@@ -164,7 +192,7 @@ func (p *Provider) applyStagedFacts(ctx context.Context, g graph.Store, repoPref
 			if err := ctx.Err(); err != nil {
 				return err
 			}
-			page, last, stats, err := spool.page(ctx, after)
+			page, last, stats, err := spool.pageClass(ctx, classForPhase[phase], after)
 			if err != nil {
 				return err
 			}
@@ -175,7 +203,6 @@ func (p *Provider) applyStagedFacts(ctx context.Context, g graph.Store, repoPref
 			switch phase {
 			case stagedSupers:
 				err = ap.applySupersPage(ctx, page, res)
-				res.SymbolsCovered += ap.coveredSymbols(page)
 			case stagedMetas:
 				err = ap.applyMetasPage(ctx, page, res)
 				ap.flush()

--- a/internal/semantic/tstypes/provider_stream.go
+++ b/internal/semantic/tstypes/provider_stream.go
@@ -104,12 +104,12 @@ func (p *Provider) stageRepoFacts(ctx context.Context, files []fileRef, spool *f
 			continue
 		}
 		if len(batch) > 0 && (len(batch) >= tstypesFactPageFiles ||
-			batchBytes+len(record.payload) > tstypesFactPageBytes) {
+			batchBytes+record.bytes > tstypesFactPageBytes) {
 			flush()
 		}
 		if stageErr == nil {
 			batch = append(batch, record)
-			batchBytes += len(record.payload)
+			batchBytes += record.bytes
 		}
 	}
 	if stageErr == nil && ctx.Err() == nil {

--- a/internal/semantic/tstypes/provider_stream_test.go
+++ b/internal/semantic/tstypes/provider_stream_test.go
@@ -55,7 +55,7 @@ func TestFactSpoolThousandsStayInBoundedDeterministicPages(t *testing.T) {
 	seen := 0
 	lastSeen := ""
 	for {
-		page, last, stats, pageErr := spool.page(context.Background(), after)
+		page, last, stats, pageErr := spool.pageClass(context.Background(), classCalls, after)
 		require.NoError(t, pageErr)
 		if len(page) == 0 {
 			break
@@ -68,6 +68,8 @@ func TestFactSpoolThousandsStayInBoundedDeterministicPages(t *testing.T) {
 			require.Len(t, facts.calls, 1)
 			require.NotNil(t, facts.calls[0].recvChain)
 			assert.Equal(t, "step", facts.calls[0].recvChain.method)
+			require.Len(t, facts.imports, 1, "imports side-fetch must ride every class page")
+			assert.Empty(t, facts.supers, "a calls page must not decode other classes")
 			seen++
 		}
 		after = last

--- a/internal/semantic/tstypes/testdata/golden/apply_snapshot.json
+++ b/internal/semantic/tstypes/testdata/golden/apply_snapshot.json
@@ -1,0 +1,349 @@
+{
+  "Edges": [
+    {
+      "From": "widgets/Alpha.Part1.cs",
+      "To": "widgets/Alpha.Part1.cs::Alpha",
+      "Kind": "defines",
+      "Origin": "",
+      "Line": 3
+    },
+    {
+      "From": "widgets/Alpha.Part1.cs",
+      "To": "widgets/Alpha.Part1.cs::Alpha.Sidekick",
+      "Kind": "defines",
+      "Origin": "",
+      "Line": 5
+    },
+    {
+      "From": "widgets/Alpha.Part1.cs",
+      "To": "widgets/Alpha.Part1.cs::Widgets",
+      "Kind": "defines",
+      "Origin": "",
+      "Line": 1
+    },
+    {
+      "From": "widgets/Alpha.Part1.cs::Alpha",
+      "To": "widgets/Base.cs::WidgetBase",
+      "Kind": "extends",
+      "Origin": "ast_resolved",
+      "Line": 3
+    },
+    {
+      "From": "widgets/Alpha.Part1.cs::Alpha.Sidekick",
+      "To": "unresolved::Helper",
+      "Kind": "typed_as",
+      "Origin": "ast_inferred",
+      "Line": 5
+    },
+    {
+      "From": "widgets/Alpha.Part1.cs::Alpha.Sidekick",
+      "To": "widgets/Alpha.Part1.cs::Alpha",
+      "Kind": "member_of",
+      "Origin": "",
+      "Line": 5
+    },
+    {
+      "From": "widgets/Alpha.Part2.cs",
+      "To": "widgets/Alpha.Part2.cs::Alpha",
+      "Kind": "defines",
+      "Origin": "",
+      "Line": 3
+    },
+    {
+      "From": "widgets/Alpha.Part2.cs",
+      "To": "widgets/Alpha.Part2.cs::Alpha.Draw",
+      "Kind": "defines",
+      "Origin": "",
+      "Line": 5
+    },
+    {
+      "From": "widgets/Alpha.Part2.cs",
+      "To": "widgets/Alpha.Part2.cs::Widgets",
+      "Kind": "defines",
+      "Origin": "",
+      "Line": 1
+    },
+    {
+      "From": "widgets/Alpha.Part2.cs::Alpha.Draw",
+      "To": "unresolved::*.Render",
+      "Kind": "calls",
+      "Origin": "",
+      "Line": 7
+    },
+    {
+      "From": "widgets/Alpha.Part2.cs::Alpha.Draw",
+      "To": "unresolved::Helper",
+      "Kind": "instantiates",
+      "Origin": "ast_resolved",
+      "Line": 8
+    },
+    {
+      "From": "widgets/Alpha.Part2.cs::Alpha.Draw",
+      "To": "widgets/Alpha.Part2.cs::Alpha",
+      "Kind": "member_of",
+      "Origin": "",
+      "Line": 5
+    },
+    {
+      "From": "widgets/Alpha.Part2.cs::Alpha.Draw",
+      "To": "widgets/Helper.cs::Helper.Assist",
+      "Kind": "calls",
+      "Origin": "ast_resolved",
+      "Line": 9
+    },
+    {
+      "From": "widgets/Base.cs",
+      "To": "widgets/Base.cs::WidgetBase",
+      "Kind": "defines",
+      "Origin": "",
+      "Line": 3
+    },
+    {
+      "From": "widgets/Base.cs",
+      "To": "widgets/Base.cs::WidgetBase.Render",
+      "Kind": "defines",
+      "Origin": "",
+      "Line": 5
+    },
+    {
+      "From": "widgets/Base.cs",
+      "To": "widgets/Base.cs::Widgets",
+      "Kind": "defines",
+      "Origin": "",
+      "Line": 1
+    },
+    {
+      "From": "widgets/Base.cs::WidgetBase.Render",
+      "To": "widgets/Base.cs::WidgetBase",
+      "Kind": "member_of",
+      "Origin": "",
+      "Line": 5
+    },
+    {
+      "From": "widgets/Helper.cs",
+      "To": "widgets/Helper.cs::Helper",
+      "Kind": "defines",
+      "Origin": "",
+      "Line": 3
+    },
+    {
+      "From": "widgets/Helper.cs",
+      "To": "widgets/Helper.cs::Helper.Assist",
+      "Kind": "defines",
+      "Origin": "",
+      "Line": 5
+    },
+    {
+      "From": "widgets/Helper.cs",
+      "To": "widgets/Helper.cs::Widgets",
+      "Kind": "defines",
+      "Origin": "",
+      "Line": 1
+    },
+    {
+      "From": "widgets/Helper.cs::Helper.Assist",
+      "To": "widgets/Base.cs::WidgetBase.Render",
+      "Kind": "calls",
+      "Origin": "ast_resolved",
+      "Line": 7
+    },
+    {
+      "From": "widgets/Helper.cs::Helper.Assist",
+      "To": "widgets/Helper.cs::Helper",
+      "Kind": "member_of",
+      "Origin": "",
+      "Line": 5
+    },
+    {
+      "From": "widgets/Helper.cs::Helper.Assist#param:w@0",
+      "To": "unresolved::WidgetBase",
+      "Kind": "typed_as",
+      "Origin": "ast_inferred",
+      "Line": 5
+    },
+    {
+      "From": "widgets/Helper.cs::Helper.Assist#param:w@0",
+      "To": "widgets/Helper.cs::Helper.Assist",
+      "Kind": "param_of",
+      "Origin": "ast_resolved",
+      "Line": 5
+    }
+  ],
+  "MetaStamps": [
+    {
+      "NodeID": "widgets/Alpha.Part1.cs::Alpha",
+      "Key": "scope_ns",
+      "Value": "Widgets"
+    },
+    {
+      "NodeID": "widgets/Alpha.Part1.cs::Alpha",
+      "Key": "type_flavor",
+      "Value": "class"
+    },
+    {
+      "NodeID": "widgets/Alpha.Part1.cs::Alpha",
+      "Key": "visibility",
+      "Value": "public"
+    },
+    {
+      "NodeID": "widgets/Alpha.Part1.cs::Alpha.Sidekick",
+      "Key": "field_type",
+      "Value": "Helper"
+    },
+    {
+      "NodeID": "widgets/Alpha.Part1.cs::Alpha.Sidekick",
+      "Key": "kind",
+      "Value": "property"
+    },
+    {
+      "NodeID": "widgets/Alpha.Part1.cs::Alpha.Sidekick",
+      "Key": "receiver",
+      "Value": "Alpha"
+    },
+    {
+      "NodeID": "widgets/Alpha.Part1.cs::Alpha.Sidekick",
+      "Key": "semantic_source",
+      "Value": "csharp-types"
+    },
+    {
+      "NodeID": "widgets/Alpha.Part1.cs::Alpha.Sidekick",
+      "Key": "semantic_type",
+      "Value": "Helper"
+    },
+    {
+      "NodeID": "widgets/Alpha.Part1.cs::Alpha.Sidekick",
+      "Key": "visibility",
+      "Value": "public"
+    },
+    {
+      "NodeID": "widgets/Alpha.Part2.cs::Alpha",
+      "Key": "scope_ns",
+      "Value": "Widgets"
+    },
+    {
+      "NodeID": "widgets/Alpha.Part2.cs::Alpha",
+      "Key": "type_flavor",
+      "Value": "class"
+    },
+    {
+      "NodeID": "widgets/Alpha.Part2.cs::Alpha",
+      "Key": "visibility",
+      "Value": "public"
+    },
+    {
+      "NodeID": "widgets/Alpha.Part2.cs::Alpha.Draw",
+      "Key": "receiver",
+      "Value": "Alpha"
+    },
+    {
+      "NodeID": "widgets/Alpha.Part2.cs::Alpha.Draw",
+      "Key": "return_type",
+      "Value": "void"
+    },
+    {
+      "NodeID": "widgets/Alpha.Part2.cs::Alpha.Draw",
+      "Key": "scope_ns",
+      "Value": "Widgets"
+    },
+    {
+      "NodeID": "widgets/Alpha.Part2.cs::Alpha.Draw",
+      "Key": "semantic_source",
+      "Value": "csharp-types"
+    },
+    {
+      "NodeID": "widgets/Alpha.Part2.cs::Alpha.Draw",
+      "Key": "visibility",
+      "Value": "public"
+    },
+    {
+      "NodeID": "widgets/Base.cs::WidgetBase",
+      "Key": "scope_ns",
+      "Value": "Widgets"
+    },
+    {
+      "NodeID": "widgets/Base.cs::WidgetBase",
+      "Key": "type_flavor",
+      "Value": "class"
+    },
+    {
+      "NodeID": "widgets/Base.cs::WidgetBase",
+      "Key": "visibility",
+      "Value": "public"
+    },
+    {
+      "NodeID": "widgets/Base.cs::WidgetBase.Render",
+      "Key": "receiver",
+      "Value": "WidgetBase"
+    },
+    {
+      "NodeID": "widgets/Base.cs::WidgetBase.Render",
+      "Key": "return_type",
+      "Value": "void"
+    },
+    {
+      "NodeID": "widgets/Base.cs::WidgetBase.Render",
+      "Key": "scope_ns",
+      "Value": "Widgets"
+    },
+    {
+      "NodeID": "widgets/Base.cs::WidgetBase.Render",
+      "Key": "semantic_source",
+      "Value": "csharp-types"
+    },
+    {
+      "NodeID": "widgets/Base.cs::WidgetBase.Render",
+      "Key": "visibility",
+      "Value": "public"
+    },
+    {
+      "NodeID": "widgets/Helper.cs::Helper",
+      "Key": "scope_ns",
+      "Value": "Widgets"
+    },
+    {
+      "NodeID": "widgets/Helper.cs::Helper",
+      "Key": "type_flavor",
+      "Value": "class"
+    },
+    {
+      "NodeID": "widgets/Helper.cs::Helper",
+      "Key": "visibility",
+      "Value": "public"
+    },
+    {
+      "NodeID": "widgets/Helper.cs::Helper.Assist",
+      "Key": "receiver",
+      "Value": "Helper"
+    },
+    {
+      "NodeID": "widgets/Helper.cs::Helper.Assist",
+      "Key": "return_type",
+      "Value": "void"
+    },
+    {
+      "NodeID": "widgets/Helper.cs::Helper.Assist",
+      "Key": "scope_ns",
+      "Value": "Widgets"
+    },
+    {
+      "NodeID": "widgets/Helper.cs::Helper.Assist",
+      "Key": "semantic_source",
+      "Value": "csharp-types"
+    },
+    {
+      "NodeID": "widgets/Helper.cs::Helper.Assist",
+      "Key": "visibility",
+      "Value": "public"
+    },
+    {
+      "NodeID": "widgets/Helper.cs::Helper.Assist#param:w@0",
+      "Key": "type",
+      "Value": "WidgetBase"
+    }
+  ],
+  "EdgesConfirmed": 3,
+  "EdgesAdded": 0,
+  "SymbolsCovered": 13,
+  "SymbolsTotal": 13,
+  "CoveragePercent": 100
+}


### PR DESCRIPTION
## Problem

On a cold index of my production C# repo (≈117k graph nodes), the csharp-types provider dominated the enrichment phase: 527.7 s of a 532.3 s phase. The streamed apply walks its fact spool four times — once per phase (supers, calls, aliases, coverage) — and each walk decoded **every** file's **full** fact payload, regardless of which facts the phase actually consumes. Fact classes are heavily skewed (calls dominate every file, inheritance facts exist in a fraction of files, aliases are absent entirely in C#), so most of that decode volume was thrown away.

## Change

Partition the per-pass temp spool by fact class:

- Staging writes one `files` row per file plus one `file_facts` row per **non-empty** class — a file with no aliases contributes no aliases row at all, which is what lets a phase skip files wholesale rather than decode-and-discard.
- Each apply phase pages over its own class only, with a bounded side-fetch of the page's imports rows (`buildIndex` needs the import map in every phase).
- Coverage counting no longer rides on the supers phase (which now legitimately doesn't see inheritance-less files); it moved to a decode-free walk over file stubs that also pre-warms the per-file node groups for all four phases.
- The apply hot cache's funnel counters — previously write-only — are logged at pass end (`tstypes: apply hot cache`), so the cache's behavior is visible in production runs, not just tests.

The spool is per-pass and never outlives it; class ids are stable row keys, nothing persisted.

## Numbers

Microbench (committed, `fact_spool_bench_test.go`, class-skew shaped like the production repo): four-phase walk **296 → 32 ms**, allocations **131 → 33 MB**. Caveat honored in the bench comment: the legacy model queries per file where the old code scanned 32-file pages, so read the gap as decode volume (~4×) plus point-query overhead, not decode alone.

Production A/B (idle machine, from-scratch index, same repo):

| | before | after |
|---|---|---|
| csharp-types provider | 527.7 s | **154.1 s (3.4×)** |
| enrichment phase | 532.3 s | 160.2 s |

Outcome counters digit-identical across runs: confirmed 9798 / added 114 / nodes enriched 41234 / coverage identical to 14 decimal places. Apply hot cache at pass end: 87% node / 86% adjacency hit.

## Disclosures

- **Synthesis delta ±4:** repo-wide synthesized edges moved 44,597 → 44,600 — two order-sensitive Go-side synthesizers (fn-value-callback −1, value-ref +4); csharp-iface-dispatch identical at 32,912. The order-sensitivity pre-exists; the partitioned walk changes apply order within phases.
- **Golden snapshot:** `apply_golden_test.go` pins the full streamed pipeline (real extractors, partial-type fixture in the Razor-codebehind shape) against a committed snapshot; regenerate only deliberately with `-update`. It deliberately pins a pre-existing partial-class cross-part resolution gap as-is — that's a separate correctness item, not something this PR touches.
- The coverage walk is a behavior-preserving relocation, guarded by the golden plus a streamed-vs-whole parity oracle.

## Tests

Full tstypes suite green, including the new golden and the streamed-vs-whole parity oracle — re-verified after rebasing onto the sqlite-only backend transition (#473), since the storage substrate changed underneath. Repo-wide failure set vs clean main is identical on my Windows box (pre-existing platform bucket only, zero new). Five consecutive production cold runs with this code produced digit-identical outcome counters.
