### PR TITLE
resolver: retain import-adjacency projections within a resolve pass

### DIFF
--- a/internal/resolver/attribution_reindex_batch.go
+++ b/internal/resolver/attribution_reindex_batch.go
@@ -144,6 +144,9 @@ func (r *Resolver) reindexAttributionTargetsBatched(
 		fallback = append(fallback, candidate.old)
 	}
 	if len(direct) > 0 {
+		if targetBatchWritesImportEdges(direct) {
+			r.noteImportEdgeWrite()
+		}
 		targeter.ReindexUnresolvedEdgeTargets(direct)
 	}
 	if len(fallback) > 0 {

--- a/internal/resolver/attribution_reindex_batch.go
+++ b/internal/resolver/attribution_reindex_batch.go
@@ -144,9 +144,7 @@ func (r *Resolver) reindexAttributionTargetsBatched(
 		fallback = append(fallback, candidate.old)
 	}
 	if len(direct) > 0 {
-		if targetBatchWritesImportEdges(direct) {
-			r.noteImportEdgeWrite()
-		}
+		r.noteImportTargetReindexes(direct)
 		targeter.ReindexUnresolvedEdgeTargets(direct)
 	}
 	if len(fallback) > 0 {

--- a/internal/resolver/go_builtins_attribution.go
+++ b/internal/resolver/go_builtins_attribution.go
@@ -178,9 +178,7 @@ func (r *Resolver) attributeGoBuiltinCandidates(candidates []*graph.Edge) {
 	if len(batch) == 0 {
 		return
 	}
-	if batchWritesImportEdges(batch) {
-		r.noteImportEdgeWrite()
-	}
+	r.noteImportEdgeReindexes(batch)
 	targeter, ok := r.graph.(graph.UnresolvedEdgeTargetBatchReindexer)
 	if !ok {
 		r.graph.ReindexEdges(batch)
@@ -274,9 +272,7 @@ func (r *Resolver) attributeGoBuiltinIdentityCandidates(
 		r.graph.AddBatch(nodes, nil)
 	}
 	if len(direct) > 0 {
-		if targetBatchWritesImportEdges(direct) {
-			r.noteImportEdgeWrite()
-		}
+		r.noteImportTargetReindexes(direct)
 		targeter.ReindexUnresolvedEdgeTargets(direct)
 	}
 	return true

--- a/internal/resolver/go_builtins_attribution.go
+++ b/internal/resolver/go_builtins_attribution.go
@@ -178,6 +178,9 @@ func (r *Resolver) attributeGoBuiltinCandidates(candidates []*graph.Edge) {
 	if len(batch) == 0 {
 		return
 	}
+	if batchWritesImportEdges(batch) {
+		r.noteImportEdgeWrite()
+	}
 	targeter, ok := r.graph.(graph.UnresolvedEdgeTargetBatchReindexer)
 	if !ok {
 		r.graph.ReindexEdges(batch)
@@ -271,6 +274,9 @@ func (r *Resolver) attributeGoBuiltinIdentityCandidates(
 		r.graph.AddBatch(nodes, nil)
 	}
 	if len(direct) > 0 {
+		if targetBatchWritesImportEdges(direct) {
+			r.noteImportEdgeWrite()
+		}
 		targeter.ReindexUnresolvedEdgeTargets(direct)
 	}
 	return true

--- a/internal/resolver/godot_res_paths.go
+++ b/internal/resolver/godot_res_paths.go
@@ -104,9 +104,7 @@ func (r *Resolver) resolveGodotResPaths() {
 		}
 	}
 	if len(reindexBatch) > 0 {
-		if batchWritesImportEdges(reindexBatch) {
-			r.noteImportEdgeWrite()
-		}
+		r.noteImportEdgeReindexes(reindexBatch)
 		r.graph.ReindexEdges(reindexBatch)
 	}
 }

--- a/internal/resolver/godot_res_paths.go
+++ b/internal/resolver/godot_res_paths.go
@@ -104,6 +104,9 @@ func (r *Resolver) resolveGodotResPaths() {
 		}
 	}
 	if len(reindexBatch) > 0 {
+		if batchWritesImportEdges(reindexBatch) {
+			r.noteImportEdgeWrite()
+		}
 		r.graph.ReindexEdges(reindexBatch)
 	}
 }

--- a/internal/resolver/incremental_attribution_cache.go
+++ b/internal/resolver/incremental_attribution_cache.go
@@ -93,9 +93,7 @@ func (r *Resolver) flushIncrementalAttributionReindexes() {
 	// Release the resolver-owned backing array before entering the store. Every
 	// emitted chunk is still referenced by batch until its write completes.
 	r.incrementalAttributionReindex = nil
-	if batchWritesImportEdges(batch) {
-		r.noteImportEdgeWrite()
-	}
+	r.noteImportEdgeReindexes(batch)
 	for len(batch) > 0 {
 		n := attributionReindexBatchSize
 		if len(batch) < n {
@@ -116,9 +114,7 @@ func (r *Resolver) persistAttributionReindexes(batch []graph.EdgeReindex) {
 	if len(batch) == 0 {
 		return
 	}
-	if batchWritesImportEdges(batch) {
-		r.noteImportEdgeWrite()
-	}
+	r.noteImportEdgeReindexes(batch)
 	if r.incrementalNodesByFile == nil {
 		for len(batch) > 0 {
 			n := attributionReindexBatchSize

--- a/internal/resolver/incremental_attribution_cache.go
+++ b/internal/resolver/incremental_attribution_cache.go
@@ -93,6 +93,9 @@ func (r *Resolver) flushIncrementalAttributionReindexes() {
 	// Release the resolver-owned backing array before entering the store. Every
 	// emitted chunk is still referenced by batch until its write completes.
 	r.incrementalAttributionReindex = nil
+	if batchWritesImportEdges(batch) {
+		r.noteImportEdgeWrite()
+	}
 	for len(batch) > 0 {
 		n := attributionReindexBatchSize
 		if len(batch) < n {
@@ -112,6 +115,9 @@ func (r *Resolver) clearIncrementalAttributionCache() {
 func (r *Resolver) persistAttributionReindexes(batch []graph.EdgeReindex) {
 	if len(batch) == 0 {
 		return
+	}
+	if batchWritesImportEdges(batch) {
+		r.noteImportEdgeWrite()
 	}
 	if r.incrementalNodesByFile == nil {
 		for len(batch) > 0 {

--- a/internal/resolver/lsp_resolve.go
+++ b/internal/resolver/lsp_resolve.go
@@ -480,6 +480,9 @@ func (r *Resolver) resolveDeferredLSPWithPassBudget(
 		r.lspDeferredCursorSet = false
 	}
 	if len(reindexBatch) > 0 {
+		if batchWritesImportEdges(reindexBatch) {
+			r.noteImportEdgeWrite()
+		}
 		r.graph.ReindexEdges(reindexBatch)
 		reconcilePlaceholderSources(r.graph, &r.placeholderSrcIdx, reindexBatch)
 	}

--- a/internal/resolver/lsp_resolve.go
+++ b/internal/resolver/lsp_resolve.go
@@ -480,9 +480,7 @@ func (r *Resolver) resolveDeferredLSPWithPassBudget(
 		r.lspDeferredCursorSet = false
 	}
 	if len(reindexBatch) > 0 {
-		if batchWritesImportEdges(reindexBatch) {
-			r.noteImportEdgeWrite()
-		}
+		r.noteImportEdgeReindexes(reindexBatch)
 		r.graph.ReindexEdges(reindexBatch)
 		reconcilePlaceholderSources(r.graph, &r.placeholderSrcIdx, reindexBatch)
 	}

--- a/internal/resolver/lua_imports.go
+++ b/internal/resolver/lua_imports.go
@@ -75,9 +75,7 @@ func (r *Resolver) resolveLuaRequires() {
 		reindexBatch = append(reindexBatch, graph.EdgeReindex{Edge: e, OldTo: oldTo})
 	}
 	if len(reindexBatch) > 0 {
-		if batchWritesImportEdges(reindexBatch) {
-			r.noteImportEdgeWrite()
-		}
+		r.noteImportEdgeReindexes(reindexBatch)
 		r.graph.ReindexEdges(reindexBatch)
 	}
 }

--- a/internal/resolver/lua_imports.go
+++ b/internal/resolver/lua_imports.go
@@ -75,6 +75,9 @@ func (r *Resolver) resolveLuaRequires() {
 		reindexBatch = append(reindexBatch, graph.EdgeReindex{Edge: e, OldTo: oldTo})
 	}
 	if len(reindexBatch) > 0 {
+		if batchWritesImportEdges(reindexBatch) {
+			r.noteImportEdgeWrite()
+		}
 		r.graph.ReindexEdges(reindexBatch)
 	}
 }

--- a/internal/resolver/module_attribution.go
+++ b/internal/resolver/module_attribution.go
@@ -185,9 +185,7 @@ func (r *Resolver) attributeNonGoModuleImports() {
 		r.graph.AddBatch(nil, dependsBatch)
 	}
 	if len(reindexBatch) > 0 {
-		if batchWritesImportEdges(reindexBatch) {
-			r.noteImportEdgeWrite()
-		}
+		r.noteImportEdgeReindexes(reindexBatch)
 		r.graph.ReindexEdges(reindexBatch)
 	}
 }

--- a/internal/resolver/module_attribution.go
+++ b/internal/resolver/module_attribution.go
@@ -185,6 +185,9 @@ func (r *Resolver) attributeNonGoModuleImports() {
 		r.graph.AddBatch(nil, dependsBatch)
 	}
 	if len(reindexBatch) > 0 {
+		if batchWritesImportEdges(reindexBatch) {
+			r.noteImportEdgeWrite()
+		}
 		r.graph.ReindexEdges(reindexBatch)
 	}
 }

--- a/internal/resolver/razor_using.go
+++ b/internal/resolver/razor_using.go
@@ -151,9 +151,7 @@ func (r *Resolver) resolveRazorUsings() {
 		reindexBatch = append(reindexBatch, graph.EdgeReindex{Edge: e, OldTo: oldTo})
 	}
 	if len(reindexBatch) > 0 {
-		if batchWritesImportEdges(reindexBatch) {
-			r.noteImportEdgeWrite()
-		}
+		r.noteImportEdgeReindexes(reindexBatch)
 		r.graph.ReindexEdges(reindexBatch)
 	}
 	// The marker edges were scaffolding for this pass — remove them so they do

--- a/internal/resolver/razor_using.go
+++ b/internal/resolver/razor_using.go
@@ -151,6 +151,9 @@ func (r *Resolver) resolveRazorUsings() {
 		reindexBatch = append(reindexBatch, graph.EdgeReindex{Edge: e, OldTo: oldTo})
 	}
 	if len(reindexBatch) > 0 {
+		if batchWritesImportEdges(reindexBatch) {
+			r.noteImportEdgeWrite()
+		}
 		r.graph.ReindexEdges(reindexBatch)
 	}
 	// The marker edges were scaffolding for this pass — remove them so they do

--- a/internal/resolver/reachability_projection_test.go
+++ b/internal/resolver/reachability_projection_test.go
@@ -92,7 +92,7 @@ func TestReachabilityProjectionCapClearsPathologicalCache(t *testing.T) {
 	for i := 0; i <= reachabilityStableFileCap; i++ {
 		indexes.reachabilityFiles[fmt.Sprintf("bulk/file%06d.go", i)] = map[string]struct{}{"bulk": {}}
 	}
-	if !r.buildReachabilityIndexForPendingCached(pending, nil, indexes.reachabilityFiles) {
+	if ok, _ := r.buildReachabilityIndexForPendingCached(pending, nil, indexes.reachabilityFiles); !ok {
 		t.Fatal("reachability build failed")
 	}
 	defer r.clearReachabilityIndex()
@@ -116,7 +116,7 @@ func TestReachabilityProjectionFallsBackForMalformedProvenance(t *testing.T) {
 		From: "repo/caller.go::Caller", To: graph.UnresolvedMarker + "Work",
 		Kind: graph.EdgeCalls, FilePath: "repo/caller.go",
 	}}
-	if !r.buildReachabilityIndexForPendingCached(pending, nil, make(map[string]map[string]struct{})) {
+	if ok, _ := r.buildReachabilityIndexForPendingCached(pending, nil, make(map[string]map[string]struct{})); !ok {
 		t.Fatal("reachability was not built through compatibility fallback")
 	}
 	defer r.clearReachabilityIndex()

--- a/internal/resolver/reachability_projection_test.go
+++ b/internal/resolver/reachability_projection_test.go
@@ -244,6 +244,36 @@ func TestReachabilityAdjacencyRetentionCapClearsWholesale(t *testing.T) {
 	}
 }
 
+func TestBatchWritesImportEdgesDetectsKind(t *testing.T) {
+	calls := []graph.EdgeReindex{{Edge: &graph.Edge{Kind: graph.EdgeCalls}}}
+	if batchWritesImportEdges(calls) {
+		t.Fatal("calls-only batch must not flag import writes")
+	}
+	mixed := append(calls, graph.EdgeReindex{Edge: &graph.Edge{Kind: graph.EdgeImports}})
+	if !batchWritesImportEdges(mixed) {
+		t.Fatal("batch containing an imports edge must flag")
+	}
+	// A kind migration away from imports still rewrites an imports row.
+	migrated := []graph.EdgeReindex{{Edge: &graph.Edge{Kind: graph.EdgeCalls}, OldKind: graph.EdgeImports}}
+	if !batchWritesImportEdges(migrated) {
+		t.Fatal("batch migrating an edge off the imports kind must flag")
+	}
+	if batchWritesImportEdges([]graph.EdgeReindex{{Edge: nil}}) {
+		t.Fatal("nil edge must not flag")
+	}
+}
+
+func TestTargetBatchWritesImportEdgesDetectsKind(t *testing.T) {
+	calls := []graph.UnresolvedEdgeTargetReindex{{Old: graph.EdgeIdentity{Kind: graph.EdgeCalls}}}
+	if targetBatchWritesImportEdges(calls) {
+		t.Fatal("calls-only batch must not flag import writes")
+	}
+	mixed := append(calls, graph.UnresolvedEdgeTargetReindex{Old: graph.EdgeIdentity{Kind: graph.EdgeImports}})
+	if !targetBatchWritesImportEdges(mixed) {
+		t.Fatal("batch containing an imports identity must flag")
+	}
+}
+
 // Renegotiated from TestReachabilityProjectionDoesNotCacheUnresolvedImports:
 // adjacency for an unresolved-import caller MAY now be retained across pages —
 // the pinned invariant is freshness, not absence. An imports-kind edge write

--- a/internal/resolver/reachability_projection_test.go
+++ b/internal/resolver/reachability_projection_test.go
@@ -155,6 +155,9 @@ func TestReachabilityProjectionRefreshInvalidatesPassCache(t *testing.T) {
 	if indexes.reachabilityFiles != nil {
 		t.Fatal("close retained the pass-local reachability cache")
 	}
+	if indexes.importAdjacency != nil {
+		t.Fatal("close retained the pass-local adjacency retention")
+	}
 }
 
 func TestReachabilityAdjacencyRetentionServesUnstableAcrossPages(t *testing.T) {
@@ -241,19 +244,35 @@ func TestReachabilityAdjacencyRetentionCapClearsWholesale(t *testing.T) {
 	}
 }
 
-func TestReachabilityProjectionDoesNotCacheUnresolvedImports(t *testing.T) {
-	_, store, _, indexes, pending := newReachabilityProjectionFixture(t)
+// Renegotiated from TestReachabilityProjectionDoesNotCacheUnresolvedImports:
+// adjacency for an unresolved-import caller MAY now be retained across pages —
+// the pinned invariant is freshness, not absence. An imports-kind edge write
+// (noted via the resolver generation) clears the retention, and the next page
+// re-projects and sees the newly resolved target.
+func TestReachabilityProjectionUnresolvedImportsStayFresh(t *testing.T) {
+	_, store, r, indexes, pending := newReachabilityProjectionFixture(t)
 	defer indexes.close()
 	store.projected["repo/caller.go"] = []string{graph.UnresolvedMarker + "import::dep"}
 
 	for page := 0; page < 2; page++ {
 		indexes.prepare(pending)
 		if len(indexes.reachabilityFiles) != 0 {
-			t.Fatalf("page %d cached an unresolved import", page)
+			t.Fatalf("page %d cached an unresolved import in the stable set", page)
 		}
 		indexes.clearPage()
 	}
+	if store.projectionCalls != 1 {
+		t.Fatalf("projection calls = %d, want 1: unstable adjacency is retained across pages", store.projectionCalls)
+	}
+
+	store.projected["repo/caller.go"] = []string{"dep2/two.go"}
+	r.noteImportEdgeWrite()
+	indexes.prepare(pending)
+	defer indexes.clearPage()
 	if store.projectionCalls != 2 {
-		t.Fatalf("unresolved projection calls = %d, want 2", store.projectionCalls)
+		t.Fatalf("projection calls = %d, want 2 after an imports-kind write", store.projectionCalls)
+	}
+	if _, ok := r.reachableDirsByFile["repo/caller.go"]["dep2"]; !ok {
+		t.Fatal("post-write projection missing the newly resolved dep2 directory")
 	}
 }

--- a/internal/resolver/reachability_projection_test.go
+++ b/internal/resolver/reachability_projection_test.go
@@ -92,7 +92,7 @@ func TestReachabilityProjectionCapClearsPathologicalCache(t *testing.T) {
 	for i := 0; i <= reachabilityStableFileCap; i++ {
 		indexes.reachabilityFiles[fmt.Sprintf("bulk/file%06d.go", i)] = map[string]struct{}{"bulk": {}}
 	}
-	if ok, _ := r.buildReachabilityIndexForPendingCached(pending, nil, indexes.reachabilityFiles); !ok {
+	if ok, _ := r.buildReachabilityIndexForPendingCached(pending, nil, indexes.reachabilityFiles, nil); !ok {
 		t.Fatal("reachability build failed")
 	}
 	defer r.clearReachabilityIndex()
@@ -116,7 +116,7 @@ func TestReachabilityProjectionFallsBackForMalformedProvenance(t *testing.T) {
 		From: "repo/caller.go::Caller", To: graph.UnresolvedMarker + "Work",
 		Kind: graph.EdgeCalls, FilePath: "repo/caller.go",
 	}}
-	if ok, _ := r.buildReachabilityIndexForPendingCached(pending, nil, make(map[string]map[string]struct{})); !ok {
+	if ok, _ := r.buildReachabilityIndexForPendingCached(pending, nil, make(map[string]map[string]struct{}), nil); !ok {
 		t.Fatal("reachability was not built through compatibility fallback")
 	}
 	defer r.clearReachabilityIndex()
@@ -154,6 +154,90 @@ func TestReachabilityProjectionRefreshInvalidatesPassCache(t *testing.T) {
 	indexes.close()
 	if indexes.reachabilityFiles != nil {
 		t.Fatal("close retained the pass-local reachability cache")
+	}
+}
+
+func TestReachabilityAdjacencyRetentionServesUnstableAcrossPages(t *testing.T) {
+	_, store, r, indexes, pending := newReachabilityProjectionFixture(t)
+	defer indexes.close()
+	// An unresolved import keeps the caller out of the stable set — before
+	// retention this file re-projected on every page it appeared on.
+	store.projected["repo/caller.go"] = []string{graph.UnresolvedMarker + "import::dep"}
+	adjacency := make(map[string][]string)
+	for page := 0; page < 3; page++ {
+		if ok, _ := r.buildReachabilityIndexForPendingCached(pending, nil, indexes.reachabilityFiles, adjacency); !ok {
+			t.Fatalf("page %d build failed", page)
+		}
+		r.clearReachabilityIndex()
+	}
+	if store.projectionCalls != 1 {
+		t.Fatalf("projection calls = %d, want 1: retained adjacency must serve later pages", store.projectionCalls)
+	}
+	if len(indexes.reachabilityFiles) != 0 {
+		t.Fatal("unresolved import must still keep the file out of the stable set")
+	}
+	if _, ok := adjacency["repo/caller.go"]; !ok {
+		t.Fatal("adjacency retention missing the projected caller")
+	}
+}
+
+func TestReachabilityAdjacencyRetentionStatsCountHits(t *testing.T) {
+	_, store, r, indexes, pending := newReachabilityProjectionFixture(t)
+	defer indexes.close()
+	store.projected["repo/caller.go"] = []string{graph.UnresolvedMarker + "import::dep"}
+	adjacency := make(map[string][]string)
+	if _, stats := r.buildReachabilityIndexForPendingCached(pending, nil, indexes.reachabilityFiles, adjacency); stats.adjCached != 0 {
+		t.Fatalf("first page adjCached = %d, want 0", stats.adjCached)
+	}
+	r.clearReachabilityIndex()
+	_, stats := r.buildReachabilityIndexForPendingCached(pending, nil, indexes.reachabilityFiles, adjacency)
+	defer r.clearReachabilityIndex()
+	if stats.adjCached != 1 || stats.missing != 1 {
+		t.Fatalf("second page adjCached=%d missing=%d, want 1/1", stats.adjCached, stats.missing)
+	}
+}
+
+func TestReachabilityAdjacencyRetentionSkipsFallback(t *testing.T) {
+	// complete=false is a store-canonicality signal — legacy answers are
+	// never retained.
+	g := graph.New()
+	g.AddBatch([]*graph.Node{
+		{ID: "repo/caller.go::Caller", Kind: graph.KindFunction, Name: "Caller", FilePath: "repo/caller.go"},
+		{ID: "dep/target.go", Kind: graph.KindFile, Name: "target.go", FilePath: "dep/target.go"},
+	}, []*graph.Edge{{
+		From: "repo/caller.go::Caller", To: "dep/target.go", Kind: graph.EdgeImports, FilePath: "",
+	}})
+	counting := &resolverBatchCountingStore{Store: g}
+	store := &scriptedImportProjectionStore{resolverBatchCountingStore: counting, complete: false}
+	r := New(store)
+	pending := []*graph.Edge{{
+		From: "repo/caller.go::Caller", To: graph.UnresolvedMarker + "Work",
+		Kind: graph.EdgeCalls, FilePath: "repo/caller.go",
+	}}
+	adjacency := make(map[string][]string)
+	if ok, _ := r.buildReachabilityIndexForPendingCached(pending, nil, make(map[string]map[string]struct{}), adjacency); !ok {
+		t.Fatal("fallback build failed")
+	}
+	defer r.clearReachabilityIndex()
+	if len(adjacency) != 0 {
+		t.Fatalf("fallback results retained: %v", adjacency)
+	}
+}
+
+func TestReachabilityAdjacencyRetentionCapClearsWholesale(t *testing.T) {
+	_, store, r, indexes, pending := newReachabilityProjectionFixture(t)
+	defer indexes.close()
+	store.projected["repo/caller.go"] = []string{graph.UnresolvedMarker + "import::dep"}
+	adjacency := make(map[string][]string, reachabilityStableFileCap+2)
+	for i := 0; i <= reachabilityStableFileCap; i++ {
+		adjacency[fmt.Sprintf("bulk/file%06d.go", i)] = nil
+	}
+	if ok, _ := r.buildReachabilityIndexForPendingCached(pending, nil, indexes.reachabilityFiles, adjacency); !ok {
+		t.Fatal("build failed")
+	}
+	defer r.clearReachabilityIndex()
+	if len(adjacency) > 1 {
+		t.Fatalf("cap overflow retained %d entries, want wholesale clear + this page's entry", len(adjacency))
 	}
 }
 

--- a/internal/resolver/reachability_projection_test.go
+++ b/internal/resolver/reachability_projection_test.go
@@ -247,8 +247,8 @@ func TestReachabilityAdjacencyRetentionCapClearsWholesale(t *testing.T) {
 func TestNoteImportEdgeReindexesRecordsDirtyFiles(t *testing.T) {
 	r := New(graph.New())
 	r.noteImportEdgeReindexes([]graph.EdgeReindex{
-		{Edge: &graph.Edge{Kind: graph.EdgeCalls, FilePath: "a.go"}},
-		{Edge: &graph.Edge{Kind: graph.EdgeImports, FilePath: "b.go"}},
+		{Edge: &graph.Edge{Kind: graph.EdgeCalls, FilePath: "a.go", To: "x"}, OldTo: "y"},
+		{Edge: &graph.Edge{Kind: graph.EdgeImports, FilePath: "b.go", To: "dep/one.go"}, OldTo: "unresolved::import::dep"},
 		{Edge: nil},
 	})
 	if _, ok := r.importDirtyFiles["b.go"]; !ok || len(r.importDirtyFiles) != 1 {
@@ -260,15 +260,34 @@ func TestNoteImportEdgeReindexesRecordsDirtyFiles(t *testing.T) {
 	// A kind migration away from imports still rewrites an imports row; the
 	// pre-mutation provenance names the file.
 	r.noteImportEdgeReindexes([]graph.EdgeReindex{
-		{Edge: &graph.Edge{Kind: graph.EdgeCalls}, OldKind: graph.EdgeImports, OldFilePath: "c.go"},
+		{Edge: &graph.Edge{Kind: graph.EdgeCalls, To: "x"}, OldTo: "x", OldKind: graph.EdgeImports, OldFilePath: "c.go"},
 	})
 	if _, ok := r.importDirtyFiles["c.go"]; !ok {
 		t.Fatalf("dirty files = %v, want c.go from OldFilePath", r.importDirtyFiles)
 	}
 	// No file provenance at all → conservative wholesale clear.
-	r.noteImportEdgeReindexes([]graph.EdgeReindex{{Edge: &graph.Edge{Kind: graph.EdgeImports}}})
+	r.noteImportEdgeReindexes([]graph.EdgeReindex{
+		{Edge: &graph.Edge{Kind: graph.EdgeImports, To: "dep/one.go"}, OldTo: "unresolved::import::dep"},
+	})
 	if r.importEdgeGen != 1 {
 		t.Fatal("provenance-less imports write must fall back to the wholesale generation")
+	}
+}
+
+// The second cold-run regression: the pass rewrites still-unresolved import
+// edges for bookkeeping (meta, confidence, terminality) on every frontier
+// revisit. A rewrite that changes neither target, kind, nor file cannot
+// change stored adjacency — it must NOT dirty the file, or the retention
+// evicts exactly the unstable files it exists to serve.
+func TestNoteImportEdgeReindexesIgnoresIdentityPreservingRewrites(t *testing.T) {
+	r := New(graph.New())
+	r.noteImportEdgeReindexes([]graph.EdgeReindex{
+		{Edge: &graph.Edge{Kind: graph.EdgeImports, FilePath: "a.go", To: "unresolved::import::dep"},
+			OldTo: "unresolved::import::dep"},
+	})
+	if len(r.importDirtyFiles) != 0 || r.importEdgeGen != 0 {
+		t.Fatalf("identity-preserving rewrite dirtied files=%v gen=%d, want none",
+			r.importDirtyFiles, r.importEdgeGen)
 	}
 }
 
@@ -304,7 +323,8 @@ func TestReachabilityAdjacencyRetentionSurvivesUnrelatedImportWrites(t *testing.
 	indexes.clearPage()
 	for page := 0; page < 3; page++ {
 		r.noteImportEdgeReindexes([]graph.EdgeReindex{
-			{Edge: &graph.Edge{Kind: graph.EdgeImports, FilePath: "other/unrelated.go"}},
+			{Edge: &graph.Edge{Kind: graph.EdgeImports, FilePath: "other/unrelated.go", To: "dep/one.go"},
+				OldTo: graph.UnresolvedMarker + "import::other"},
 		})
 		indexes.prepare(pending)
 		indexes.clearPage()
@@ -337,7 +357,8 @@ func TestReachabilityProjectionUnresolvedImportsStayFresh(t *testing.T) {
 
 	store.projected["repo/caller.go"] = []string{"dep2/two.go"}
 	r.noteImportEdgeReindexes([]graph.EdgeReindex{
-		{Edge: &graph.Edge{Kind: graph.EdgeImports, FilePath: "repo/caller.go"}},
+		{Edge: &graph.Edge{Kind: graph.EdgeImports, FilePath: "repo/caller.go", To: "dep2/two.go"},
+			OldTo: graph.UnresolvedMarker + "import::dep"},
 	})
 	indexes.prepare(pending)
 	defer indexes.clearPage()

--- a/internal/resolver/reachability_projection_test.go
+++ b/internal/resolver/reachability_projection_test.go
@@ -244,33 +244,73 @@ func TestReachabilityAdjacencyRetentionCapClearsWholesale(t *testing.T) {
 	}
 }
 
-func TestBatchWritesImportEdgesDetectsKind(t *testing.T) {
-	calls := []graph.EdgeReindex{{Edge: &graph.Edge{Kind: graph.EdgeCalls}}}
-	if batchWritesImportEdges(calls) {
-		t.Fatal("calls-only batch must not flag import writes")
+func TestNoteImportEdgeReindexesRecordsDirtyFiles(t *testing.T) {
+	r := New(graph.New())
+	r.noteImportEdgeReindexes([]graph.EdgeReindex{
+		{Edge: &graph.Edge{Kind: graph.EdgeCalls, FilePath: "a.go"}},
+		{Edge: &graph.Edge{Kind: graph.EdgeImports, FilePath: "b.go"}},
+		{Edge: nil},
+	})
+	if _, ok := r.importDirtyFiles["b.go"]; !ok || len(r.importDirtyFiles) != 1 {
+		t.Fatalf("dirty files = %v, want exactly b.go", r.importDirtyFiles)
 	}
-	mixed := append(calls, graph.EdgeReindex{Edge: &graph.Edge{Kind: graph.EdgeImports}})
-	if !batchWritesImportEdges(mixed) {
-		t.Fatal("batch containing an imports edge must flag")
+	if r.importEdgeGen != 0 {
+		t.Fatal("known-file invalidation must not bump the wholesale generation")
 	}
-	// A kind migration away from imports still rewrites an imports row.
-	migrated := []graph.EdgeReindex{{Edge: &graph.Edge{Kind: graph.EdgeCalls}, OldKind: graph.EdgeImports}}
-	if !batchWritesImportEdges(migrated) {
-		t.Fatal("batch migrating an edge off the imports kind must flag")
+	// A kind migration away from imports still rewrites an imports row; the
+	// pre-mutation provenance names the file.
+	r.noteImportEdgeReindexes([]graph.EdgeReindex{
+		{Edge: &graph.Edge{Kind: graph.EdgeCalls}, OldKind: graph.EdgeImports, OldFilePath: "c.go"},
+	})
+	if _, ok := r.importDirtyFiles["c.go"]; !ok {
+		t.Fatalf("dirty files = %v, want c.go from OldFilePath", r.importDirtyFiles)
 	}
-	if batchWritesImportEdges([]graph.EdgeReindex{{Edge: nil}}) {
-		t.Fatal("nil edge must not flag")
+	// No file provenance at all → conservative wholesale clear.
+	r.noteImportEdgeReindexes([]graph.EdgeReindex{{Edge: &graph.Edge{Kind: graph.EdgeImports}}})
+	if r.importEdgeGen != 1 {
+		t.Fatal("provenance-less imports write must fall back to the wholesale generation")
 	}
 }
 
-func TestTargetBatchWritesImportEdgesDetectsKind(t *testing.T) {
-	calls := []graph.UnresolvedEdgeTargetReindex{{Old: graph.EdgeIdentity{Kind: graph.EdgeCalls}}}
-	if targetBatchWritesImportEdges(calls) {
-		t.Fatal("calls-only batch must not flag import writes")
+func TestNoteImportTargetReindexesRecordsDirtyFiles(t *testing.T) {
+	r := New(graph.New())
+	r.noteImportTargetReindexes([]graph.UnresolvedEdgeTargetReindex{
+		{Old: graph.EdgeIdentity{Kind: graph.EdgeCalls, FilePath: "a.go"}},
+		{Old: graph.EdgeIdentity{Kind: graph.EdgeImports, FilePath: "b.go"}},
+	})
+	if _, ok := r.importDirtyFiles["b.go"]; !ok || len(r.importDirtyFiles) != 1 {
+		t.Fatalf("dirty files = %v, want exactly b.go", r.importDirtyFiles)
 	}
-	mixed := append(calls, graph.UnresolvedEdgeTargetReindex{Old: graph.EdgeIdentity{Kind: graph.EdgeImports}})
-	if !targetBatchWritesImportEdges(mixed) {
-		t.Fatal("batch containing an imports identity must flag")
+	if r.importEdgeGen != 0 {
+		t.Fatal("known-file invalidation must not bump the wholesale generation")
+	}
+	r.noteImportTargetReindexes([]graph.UnresolvedEdgeTargetReindex{
+		{Old: graph.EdgeIdentity{Kind: graph.EdgeImports}},
+	})
+	if r.importEdgeGen != 1 {
+		t.Fatal("provenance-less imports identity must fall back to the wholesale generation")
+	}
+}
+
+// The cold-run regression this amendment fixes: import edges resolve in a
+// steady stream throughout a pass, so invalidation must be per-file — a write
+// against an UNRELATED file must not evict the whole retention.
+func TestReachabilityAdjacencyRetentionSurvivesUnrelatedImportWrites(t *testing.T) {
+	_, store, r, indexes, pending := newReachabilityProjectionFixture(t)
+	defer indexes.close()
+	store.projected["repo/caller.go"] = []string{graph.UnresolvedMarker + "import::dep"}
+
+	indexes.prepare(pending)
+	indexes.clearPage()
+	for page := 0; page < 3; page++ {
+		r.noteImportEdgeReindexes([]graph.EdgeReindex{
+			{Edge: &graph.Edge{Kind: graph.EdgeImports, FilePath: "other/unrelated.go"}},
+		})
+		indexes.prepare(pending)
+		indexes.clearPage()
+	}
+	if store.projectionCalls != 1 {
+		t.Fatalf("projection calls = %d, want 1: unrelated import writes must not evict the retention", store.projectionCalls)
 	}
 }
 
@@ -296,7 +336,9 @@ func TestReachabilityProjectionUnresolvedImportsStayFresh(t *testing.T) {
 	}
 
 	store.projected["repo/caller.go"] = []string{"dep2/two.go"}
-	r.noteImportEdgeWrite()
+	r.noteImportEdgeReindexes([]graph.EdgeReindex{
+		{Edge: &graph.Edge{Kind: graph.EdgeImports, FilePath: "repo/caller.go"}},
+	})
 	indexes.prepare(pending)
 	defer indexes.clearPage()
 	if store.projectionCalls != 2 {

--- a/internal/resolver/reachability_projection_test.go
+++ b/internal/resolver/reachability_projection_test.go
@@ -274,11 +274,11 @@ func TestNoteImportEdgeReindexesRecordsDirtyFiles(t *testing.T) {
 	}
 }
 
-// The second cold-run regression: the pass rewrites still-unresolved import
-// edges for bookkeeping (meta, confidence, terminality) on every frontier
-// revisit. A rewrite that changes neither target, kind, nor file cannot
-// change stored adjacency — it must NOT dirty the file, or the retention
-// evicts exactly the unstable files it exists to serve.
+// The pass rewrites still-unresolved import edges for bookkeeping (meta,
+// confidence, terminality) on every frontier revisit. A rewrite that changes
+// neither target, kind, nor file cannot change stored adjacency — it must
+// NOT dirty the file, or the retention evicts exactly the unstable files it
+// exists to serve.
 func TestNoteImportEdgeReindexesIgnoresIdentityPreservingRewrites(t *testing.T) {
 	r := New(graph.New())
 	r.noteImportEdgeReindexes([]graph.EdgeReindex{
@@ -311,9 +311,9 @@ func TestNoteImportTargetReindexesRecordsDirtyFiles(t *testing.T) {
 	}
 }
 
-// The cold-run regression this amendment fixes: import edges resolve in a
-// steady stream throughout a pass, so invalidation must be per-file — a write
-// against an UNRELATED file must not evict the whole retention.
+// Import edges resolve in a steady stream throughout a cold pass, so
+// invalidation must be per-file — a write against an UNRELATED file must not
+// evict the whole retention.
 func TestReachabilityAdjacencyRetentionSurvivesUnrelatedImportWrites(t *testing.T) {
 	_, store, r, indexes, pending := newReachabilityProjectionFixture(t)
 	defer indexes.close()

--- a/internal/resolver/relative_imports.go
+++ b/internal/resolver/relative_imports.go
@@ -267,9 +267,7 @@ func (r *Resolver) resolveRelativeImports() {
 		reindexBatch = append(reindexBatch, graph.EdgeReindex{Edge: e, OldTo: oldTo})
 	}
 	if len(reindexBatch) > 0 {
-		if batchWritesImportEdges(reindexBatch) {
-			r.noteImportEdgeWrite()
-		}
+		r.noteImportEdgeReindexes(reindexBatch)
 		r.graph.ReindexEdges(reindexBatch)
 	}
 }

--- a/internal/resolver/relative_imports.go
+++ b/internal/resolver/relative_imports.go
@@ -267,6 +267,9 @@ func (r *Resolver) resolveRelativeImports() {
 		reindexBatch = append(reindexBatch, graph.EdgeReindex{Edge: e, OldTo: oldTo})
 	}
 	if len(reindexBatch) > 0 {
+		if batchWritesImportEdges(reindexBatch) {
+			r.noteImportEdgeWrite()
+		}
 		r.graph.ReindexEdges(reindexBatch)
 	}
 }

--- a/internal/resolver/resolve_all_pending.go
+++ b/internal/resolver/resolve_all_pending.go
@@ -228,6 +228,7 @@ func (p *resolveAllPassIndexes) prepare(pending []*graph.Edge) map[string]*graph
 		zap.Int("reach_cached", reachStats.cached),
 		zap.Int("reach_missing", reachStats.missing),
 		zap.Int("reach_unstable", reachStats.unstable),
+		zap.Int("reach_adj_cached", reachStats.adjCached),
 		zap.Duration("reach_project", reachStats.project),
 		zap.Duration("reach_place", reachStats.place),
 		zap.Duration("reach_match", reachStats.match),

--- a/internal/resolver/resolve_all_pending.go
+++ b/internal/resolver/resolve_all_pending.go
@@ -196,7 +196,7 @@ func (p *resolveAllPassIndexes) prepare(pending []*graph.Edge) map[string]*graph
 		providesElapsed = time.Since(start)
 	}
 	reachabilityStart := time.Now()
-	_, reachStats := p.resolver.buildReachabilityIndexForPendingCached(pending, sources, p.reachabilityFiles)
+	_, reachStats := p.resolver.buildReachabilityIndexForPendingCached(pending, sources, p.reachabilityFiles, nil)
 	reachabilityElapsed := time.Since(reachabilityStart)
 	p.generation = p.resolver.scratchGeneration
 	p.resolver.logger.Info("resolver: prepare page indexes",

--- a/internal/resolver/resolve_all_pending.go
+++ b/internal/resolver/resolve_all_pending.go
@@ -206,12 +206,19 @@ func (p *resolveAllPassIndexes) prepare(pending []*graph.Edge) map[string]*graph
 		providesElapsed = time.Since(start)
 	}
 	if p.importAdjacencyGen != p.resolver.importEdgeGen {
-		// An imports-kind edge write landed since this retention was built —
-		// stored adjacency rows may have changed under it. Clear wholesale;
-		// the next projection repopulates at first-touch cost.
+		// A provenance-less imports-kind write landed since this retention
+		// was built — adjacency rows may have changed anywhere. Clear
+		// wholesale; the next projection repopulates at first-touch cost.
 		clear(p.importAdjacency)
 		p.importAdjacencyGen = p.resolver.importEdgeGen
+	} else {
+		// The common path: the pass resolved import edges with known
+		// provenance. Drop exactly those files' retained projections.
+		for filePath := range p.resolver.importDirtyFiles {
+			delete(p.importAdjacency, filePath)
+		}
 	}
+	clear(p.resolver.importDirtyFiles)
 	reachabilityStart := time.Now()
 	_, reachStats := p.resolver.buildReachabilityIndexForPendingCached(pending, sources, p.reachabilityFiles, p.importAdjacency)
 	reachabilityElapsed := time.Since(reachabilityStart)

--- a/internal/resolver/resolve_all_pending.go
+++ b/internal/resolver/resolve_all_pending.go
@@ -196,7 +196,7 @@ func (p *resolveAllPassIndexes) prepare(pending []*graph.Edge) map[string]*graph
 		providesElapsed = time.Since(start)
 	}
 	reachabilityStart := time.Now()
-	p.resolver.buildReachabilityIndexForPendingCached(pending, sources, p.reachabilityFiles)
+	_, reachStats := p.resolver.buildReachabilityIndexForPendingCached(pending, sources, p.reachabilityFiles)
 	reachabilityElapsed := time.Since(reachabilityStart)
 	p.generation = p.resolver.scratchGeneration
 	p.resolver.logger.Info("resolver: prepare page indexes",
@@ -207,6 +207,13 @@ func (p *resolveAllPassIndexes) prepare(pending []*graph.Edge) map[string]*graph
 		zap.Duration("ensure_dep", depElapsed),
 		zap.Duration("ensure_provides", providesElapsed),
 		zap.Duration("reachability", reachabilityElapsed),
+		zap.Int("reach_files", reachStats.files),
+		zap.Int("reach_cached", reachStats.cached),
+		zap.Int("reach_missing", reachStats.missing),
+		zap.Int("reach_unstable", reachStats.unstable),
+		zap.Duration("reach_project", reachStats.project),
+		zap.Duration("reach_place", reachStats.place),
+		zap.Duration("reach_match", reachStats.match),
 		zap.Duration("elapsed", time.Since(prepareStart)))
 	return sources
 }

--- a/internal/resolver/resolve_all_pending.go
+++ b/internal/resolver/resolve_all_pending.go
@@ -205,6 +205,7 @@ func (p *resolveAllPassIndexes) prepare(pending []*graph.Edge) map[string]*graph
 		p.ensureProvides(prefixes)
 		providesElapsed = time.Since(start)
 	}
+	reachDirty := len(p.resolver.importDirtyFiles)
 	if p.importAdjacencyGen != p.resolver.importEdgeGen {
 		// A provenance-less imports-kind write landed since this retention
 		// was built — adjacency rows may have changed anywhere. Clear
@@ -236,6 +237,8 @@ func (p *resolveAllPassIndexes) prepare(pending []*graph.Edge) map[string]*graph
 		zap.Int("reach_missing", reachStats.missing),
 		zap.Int("reach_unstable", reachStats.unstable),
 		zap.Int("reach_adj_cached", reachStats.adjCached),
+		zap.Int("reach_dirty", reachDirty),
+		zap.Uint64("reach_gen", p.resolver.importEdgeGen),
 		zap.Duration("reach_project", reachStats.project),
 		zap.Duration("reach_place", reachStats.place),
 		zap.Duration("reach_match", reachStats.match),

--- a/internal/resolver/resolve_all_pending.go
+++ b/internal/resolver/resolve_all_pending.go
@@ -239,6 +239,8 @@ func (p *resolveAllPassIndexes) prepare(pending []*graph.Edge) map[string]*graph
 		zap.Int("reach_adj_cached", reachStats.adjCached),
 		zap.Int("reach_dirty", reachDirty),
 		zap.Uint64("reach_gen", p.resolver.importEdgeGen),
+		zap.Int("reach_fallback", reachStats.fallback),
+		zap.Int("reach_retained", reachStats.retained),
 		zap.Duration("reach_project", reachStats.project),
 		zap.Duration("reach_place", reachStats.place),
 		zap.Duration("reach_match", reachStats.match),

--- a/internal/resolver/resolve_all_pending.go
+++ b/internal/resolver/resolve_all_pending.go
@@ -28,6 +28,14 @@ type resolveAllPassIndexes struct {
 	// caller files already seen in this pass. Page-local active maps remain on
 	// Resolver and are cleared after every page.
 	reachabilityFiles map[string]map[string]struct{}
+
+	// importAdjacency retains raw ProjectImportAdjacency results for caller
+	// files already seen in this pass — stable or not. Only the store read is
+	// retained; the per-page derivation still reruns, so reachable dirs track
+	// targets resolved later in the pass. Cleared wholesale on interleave and
+	// on importAdjacencyGen drift (an imports-kind edge write landed).
+	importAdjacency    map[string][]string
+	importAdjacencyGen uint64
 }
 
 func newResolveAllPassIndexes(r *Resolver) *resolveAllPassIndexes {
@@ -38,6 +46,7 @@ func newResolveAllPassIndexes(r *Resolver) *resolveAllPassIndexes {
 		depRepos:          make(map[string]struct{}),
 		provideRepos:      make(map[string]struct{}),
 		reachabilityFiles: make(map[string]map[string]struct{}),
+		importAdjacency:   make(map[string][]string),
 	}
 }
 
@@ -48,6 +57,7 @@ func newPendingFrontierPassIndexes(r *Resolver) *resolveAllPassIndexes {
 		depRepos:          make(map[string]struct{}),
 		provideRepos:      make(map[string]struct{}),
 		reachabilityFiles: make(map[string]map[string]struct{}),
+		importAdjacency:   make(map[string][]string),
 	}
 }
 
@@ -195,8 +205,15 @@ func (p *resolveAllPassIndexes) prepare(pending []*graph.Edge) map[string]*graph
 		p.ensureProvides(prefixes)
 		providesElapsed = time.Since(start)
 	}
+	if p.importAdjacencyGen != p.resolver.importEdgeGen {
+		// An imports-kind edge write landed since this retention was built —
+		// stored adjacency rows may have changed under it. Clear wholesale;
+		// the next projection repopulates at first-touch cost.
+		clear(p.importAdjacency)
+		p.importAdjacencyGen = p.resolver.importEdgeGen
+	}
 	reachabilityStart := time.Now()
-	_, reachStats := p.resolver.buildReachabilityIndexForPendingCached(pending, sources, p.reachabilityFiles, nil)
+	_, reachStats := p.resolver.buildReachabilityIndexForPendingCached(pending, sources, p.reachabilityFiles, p.importAdjacency)
 	reachabilityElapsed := time.Since(reachabilityStart)
 	p.generation = p.resolver.scratchGeneration
 	p.resolver.logger.Info("resolver: prepare page indexes",
@@ -226,6 +243,7 @@ func (p *resolveAllPassIndexes) resetAfterInterleave() {
 	p.depRepos = make(map[string]struct{})
 	p.provideRepos = make(map[string]struct{})
 	p.reachabilityFiles = make(map[string]map[string]struct{})
+	p.importAdjacency = make(map[string][]string)
 }
 
 // refreshAfterInterleave restores only scratch actually invalidated while
@@ -264,6 +282,7 @@ func (p *resolveAllPassIndexes) prepareTail() {
 
 func (p *resolveAllPassIndexes) close() {
 	p.reachabilityFiles = nil
+	p.importAdjacency = nil
 	p.resolver.clearPassIndexes()
 }
 

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -4510,7 +4510,7 @@ func (r *Resolver) buildReachabilityIndex() {
 // concrete From node when possible, otherwise leave that edge unfiltered. The
 // reachability filter is explicitly fail-open for an unknown caller path.
 func (r *Resolver) buildReachabilityIndexForPending(pending []*graph.Edge, sources map[string]*graph.Node) bool {
-	ok, _ := r.buildReachabilityIndexForPendingCached(pending, sources, nil)
+	ok, _ := r.buildReachabilityIndexForPendingCached(pending, sources, nil, nil)
 	return ok
 }
 
@@ -4531,21 +4531,28 @@ const reachabilityStableFileCap = 1 << 16
 // went. Purely observational — prepare logs it so a cold run can show whether
 // unstable caller files dominate the per-page rebuild cost.
 type reachabilityPageStats struct {
-	files    int
-	cached   int
-	missing  int
-	unstable int
-	project  time.Duration
-	place    time.Duration
-	match    time.Duration
+	files     int
+	cached    int
+	missing   int
+	unstable  int
+	adjCached int
+	project   time.Duration
+	place     time.Duration
+	match     time.Duration
 }
 
 func (r *Resolver) buildReachabilityIndexForPendingCached(
 	pending []*graph.Edge,
 	sources map[string]*graph.Node,
 	stableByFile map[string]map[string]struct{},
+	adjacency map[string][]string,
 ) (bool, reachabilityPageStats) {
 	var stats reachabilityPageStats
+	if len(adjacency) > reachabilityStableFileCap {
+		// Same overflow contract as the stable retention below: a wholesale
+		// clear beats piecemeal eviction, which would recreate per-page churn.
+		clear(adjacency)
+	}
 	callerPaths := make(map[string]struct{})
 	missingCallerSet := make(map[string]struct{})
 	for _, edge := range pending {
@@ -4619,17 +4626,40 @@ func (r *Resolver) buildReachabilityIndexForPendingCached(
 	stats.files = len(filePaths)
 	stats.missing = len(missingFiles)
 
-	importsByFile := make(map[string][]string)
-	projectStart := time.Now()
-	if len(missingFiles) > 0 {
-		if projector, ok := r.graph.(graph.ImportAdjacencyProjector); ok {
-			if projected, complete := projector.ProjectImportAdjacency(missingFiles); complete {
-				importsByFile = projected
-			} else {
-				importsByFile = r.legacyImportTargetsByFile(missingFiles)
+	importsByFile := make(map[string][]string, len(missingFiles))
+	projectFiles := missingFiles
+	if adjacency != nil {
+		projectFiles = make([]string, 0, len(missingFiles))
+		for _, filePath := range missingFiles {
+			if cached, ok := adjacency[filePath]; ok {
+				importsByFile[filePath] = cached
+				stats.adjCached++
+				continue
 			}
-		} else {
-			importsByFile = r.legacyImportTargetsByFile(missingFiles)
+			projectFiles = append(projectFiles, filePath)
+		}
+	}
+	projectStart := time.Now()
+	if len(projectFiles) > 0 {
+		var projected map[string][]string
+		complete := false
+		if projector, ok := r.graph.(graph.ImportAdjacencyProjector); ok {
+			projected, complete = projector.ProjectImportAdjacency(projectFiles)
+		}
+		if !complete {
+			// complete=false is a canonicality signal, not a cacheable
+			// answer — fallback results are never retained.
+			projected = r.legacyImportTargetsByFile(projectFiles)
+		} else if adjacency != nil {
+			// Retain raw projections for every projected file, including
+			// ones absent from the result map — known-empty is knowledge
+			// too, else importless files re-project forever.
+			for _, filePath := range projectFiles {
+				adjacency[filePath] = projected[filePath]
+			}
+		}
+		for filePath, targets := range projected {
+			importsByFile[filePath] = targets
 		}
 	}
 	stats.project = time.Since(projectStart)

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -1003,6 +1003,9 @@ func (r *Resolver) ResolveAllContext(ctx context.Context) (*ResolveStats, error)
 				perWorkerJobs[i] = kept
 			}
 			if len(reindexBatch) > 0 {
+				if batchWritesImportEdges(reindexBatch) {
+					r.noteImportEdgeWrite()
+				}
 				r.graph.ReindexEdges(reindexBatch)
 				reconcilePlaceholderSources(r.graph, &r.placeholderSrcIdx, reindexBatch)
 				reindexTotal += len(reindexBatch)
@@ -1349,6 +1352,9 @@ func (r *Resolver) ResolveAllContext(ctx context.Context) (*ResolveStats, error)
 				terminalClears = append(terminalClears, graph.EdgeReindex{Edge: edge.edge, OldTo: oldTo})
 			}
 			if len(terminalClears) > 0 {
+				if batchWritesImportEdges(terminalClears) {
+					r.noteImportEdgeWrite()
+				}
 				r.graph.ReindexEdges(terminalClears)
 			}
 
@@ -2666,6 +2672,9 @@ func (r *Resolver) applyIncrementalReindexesLocked(
 	stats *ResolveStats,
 ) {
 	if len(reindexBatch) > 0 {
+		if batchWritesImportEdges(reindexBatch) {
+			r.noteImportEdgeWrite()
+		}
 		r.graph.ReindexEdges(reindexBatch)
 		// nil index: incremental batches are file-sized, direct probes
 		// stay under the single-save latency budget.
@@ -4762,8 +4771,55 @@ func (r *Resolver) clearReachabilityIndex() {
 // pass-scoped import-adjacency retention compares generations at page start
 // and clears wholesale on drift — invalidation precision is traded for
 // audit-proof simplicity, and measured import writes are rare mid-pass.
+//
+// Write-site audit (every ReindexEdges / ReindexUnresolvedEdgeTargets /
+// AddBatch call in this package):
+//   - guarded bump: main page commit + incremental commit (resolver.go),
+//     deferred-LSP terminal clears and page reindexes (resolver.go,
+//     lsp_resolve.go), attribution batches (attribution_reindex_batch.go,
+//     go_builtins_attribution.go, incremental_attribution_cache.go),
+//     import-flavored retargets (relative_imports.go, lua_imports.go,
+//     razor_using.go, godot_res_paths.go), module attribution reindexes
+//     (module_attribution.go).
+//   - no bump, kind-bounded: generic_param_bind.go (EdgesByKind over
+//     non-import kinds), cross_pkg_guard.go (call-edge guard reverts).
+//   - no bump, outside any live pass retention: exported framework/registry
+//     synthesis passes (celery/mediatr/express/fastapi/django/rails/vapor/
+//     grpc/rtk/redux/vuex/ngrx/react/swiftui/uikit/sidekiq/spring/sql/
+//     store_factory/temporal/goframe/mybatis/laravel/gdscript/godot-scene/
+//     rust/kmp/iface-dispatch/fn-pointer/fn-value/chain-factory/
+//     speculative/external_calls/object_registry/value_refs and peers),
+//     cross-repo resolver (own lifecycle), framework store wrappers
+//     (their callers decide), node-only AddBatch sites, and indexer-side
+//     writers (interleave refresh already clears retention wholesale).
 func (r *Resolver) noteImportEdgeWrite() {
 	r.importEdgeGen++
+}
+
+// batchWritesImportEdges reports whether an edge-reindex batch can change a
+// file's stored import adjacency. Kind migrations count in both directions:
+// either the new or the persisted pre-mutation kind being imports rewrites an
+// imports row. Sites whose batches are provably calls-only skip the bump —
+// the verdict table lives at noteImportEdgeWrite's callers.
+func batchWritesImportEdges(batch []graph.EdgeReindex) bool {
+	for _, reindex := range batch {
+		if reindex.OldKind == graph.EdgeImports {
+			return true
+		}
+		if reindex.Edge != nil && reindex.Edge.Kind == graph.EdgeImports {
+			return true
+		}
+	}
+	return false
+}
+
+func targetBatchWritesImportEdges(batch []graph.UnresolvedEdgeTargetReindex) bool {
+	for _, reindex := range batch {
+		if reindex.Old.Kind == graph.EdgeImports {
+			return true
+		}
+	}
+	return false
 }
 
 // importedDirForSpec returns the directory that an unresolved

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -4510,7 +4510,8 @@ func (r *Resolver) buildReachabilityIndex() {
 // concrete From node when possible, otherwise leave that edge unfiltered. The
 // reachability filter is explicitly fail-open for an unknown caller path.
 func (r *Resolver) buildReachabilityIndexForPending(pending []*graph.Edge, sources map[string]*graph.Node) bool {
-	return r.buildReachabilityIndexForPendingCached(pending, sources, nil)
+	ok, _ := r.buildReachabilityIndexForPendingCached(pending, sources, nil)
+	return ok
 }
 
 // buildReachabilityIndexForPendingCached materialises direct-import
@@ -4525,11 +4526,26 @@ func (r *Resolver) buildReachabilityIndexForPending(pending []*graph.Edge, sourc
 // pathological inputs.
 const reachabilityStableFileCap = 1 << 16
 
+// reachabilityPageStats reports how much of one page's reachability build was
+// served from the pass-scoped stable retention and where the recompute time
+// went. Purely observational — prepare logs it so a cold run can show whether
+// unstable caller files dominate the per-page rebuild cost.
+type reachabilityPageStats struct {
+	files    int
+	cached   int
+	missing  int
+	unstable int
+	project  time.Duration
+	place    time.Duration
+	match    time.Duration
+}
+
 func (r *Resolver) buildReachabilityIndexForPendingCached(
 	pending []*graph.Edge,
 	sources map[string]*graph.Node,
 	stableByFile map[string]map[string]struct{},
-) bool {
+) (bool, reachabilityPageStats) {
+	var stats reachabilityPageStats
 	callerPaths := make(map[string]struct{})
 	missingCallerSet := make(map[string]struct{})
 	for _, edge := range pending {
@@ -4593,13 +4609,18 @@ func (r *Resolver) buildReachabilityIndexForPendingCached(
 		dirs[filePath] = dir
 		if cached, ok := stableByFile[filePath]; ok {
 			reachable[filePath] = cached
+			stats.cached++
 			continue
 		}
 		reachable[filePath] = map[string]struct{}{dir: {}}
 		missingFiles = append(missingFiles, filePath)
 	}
 
+	stats.files = len(filePaths)
+	stats.missing = len(missingFiles)
+
 	importsByFile := make(map[string][]string)
+	projectStart := time.Now()
 	if len(missingFiles) > 0 {
 		if projector, ok := r.graph.(graph.ImportAdjacencyProjector); ok {
 			if projected, complete := projector.ProjectImportAdjacency(missingFiles); complete {
@@ -4611,6 +4632,7 @@ func (r *Resolver) buildReachabilityIndexForPendingCached(
 			importsByFile = r.legacyImportTargetsByFile(missingFiles)
 		}
 	}
+	stats.project = time.Since(projectStart)
 
 	targetSet := make(map[string]struct{})
 	for _, filePath := range missingFiles {
@@ -4624,8 +4646,11 @@ func (r *Resolver) buildReachabilityIndexForPendingCached(
 	for id := range targetSet {
 		targetIDs = append(targetIDs, id)
 	}
+	placeStart := time.Now()
 	targets := graph.NodePlacementsByIDs(r.graph, targetIDs)
+	stats.place = time.Since(placeStart)
 
+	matchStart := time.Now()
 	for _, filePath := range missingFiles {
 		stable := true
 		for _, targetID := range importsByFile[filePath] {
@@ -4653,11 +4678,14 @@ func (r *Resolver) buildReachabilityIndexForPendingCached(
 		}
 		if stable {
 			stableByFile[filePath] = reachable[filePath]
+		} else {
+			stats.unstable++
 		}
 	}
+	stats.match = time.Since(matchStart)
 	r.reachableDirsByFile = reachable
 	r.dirByFilePath = dirs
-	return true
+	return true, stats
 }
 
 // legacyImportTargetsByFile preserves the ordinary Store path for in-memory

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -218,6 +218,10 @@ type Resolver struct {
 	// (filepathlite.Dir/Clean dominate). Read-only after build, so the
 	// workers share it lock-free.
 	dirByFilePath map[string]string
+	// importEdgeGen counts imports-kind edge writes noted while a resolve
+	// pass may hold pass-scoped import-adjacency retention. Write-site
+	// verdicts live at noteImportEdgeWrite's callers.
+	importEdgeGen uint64
 	// depModuleIndex bridges Go imports to dep::<module> contract
 	// nodes emitted from go.mod. Keyed by RepoPrefix (the dep node's
 	// owning repo) so we never link an import in repo A to a dep
@@ -4752,6 +4756,14 @@ func (r *Resolver) legacyImportTargetsByFile(filePaths []string) map[string][]st
 func (r *Resolver) clearReachabilityIndex() {
 	r.reachableDirsByFile = nil
 	r.dirByFilePath = nil
+}
+
+// noteImportEdgeWrite records that an imports-kind edge row was written. The
+// pass-scoped import-adjacency retention compares generations at page start
+// and clears wholesale on drift — invalidation precision is traded for
+// audit-proof simplicity, and measured import writes are rare mid-pass.
+func (r *Resolver) noteImportEdgeWrite() {
+	r.importEdgeGen++
 }
 
 // importedDirForSpec returns the directory that an unresolved

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -222,6 +222,10 @@ type Resolver struct {
 	// pass may hold pass-scoped import-adjacency retention. Write-site
 	// verdicts live at noteImportEdgeWrite's callers.
 	importEdgeGen uint64
+	// importDirtyFiles names caller files whose stored import adjacency was
+	// rewritten with known provenance; prepare deletes exactly these keys
+	// from the pass-scoped retention instead of clearing it wholesale.
+	importDirtyFiles map[string]struct{}
 	// depModuleIndex bridges Go imports to dep::<module> contract
 	// nodes emitted from go.mod. Keyed by RepoPrefix (the dep node's
 	// owning repo) so we never link an import in repo A to a dep
@@ -1003,9 +1007,7 @@ func (r *Resolver) ResolveAllContext(ctx context.Context) (*ResolveStats, error)
 				perWorkerJobs[i] = kept
 			}
 			if len(reindexBatch) > 0 {
-				if batchWritesImportEdges(reindexBatch) {
-					r.noteImportEdgeWrite()
-				}
+				r.noteImportEdgeReindexes(reindexBatch)
 				r.graph.ReindexEdges(reindexBatch)
 				reconcilePlaceholderSources(r.graph, &r.placeholderSrcIdx, reindexBatch)
 				reindexTotal += len(reindexBatch)
@@ -1352,9 +1354,7 @@ func (r *Resolver) ResolveAllContext(ctx context.Context) (*ResolveStats, error)
 				terminalClears = append(terminalClears, graph.EdgeReindex{Edge: edge.edge, OldTo: oldTo})
 			}
 			if len(terminalClears) > 0 {
-				if batchWritesImportEdges(terminalClears) {
-					r.noteImportEdgeWrite()
-				}
+				r.noteImportEdgeReindexes(terminalClears)
 				r.graph.ReindexEdges(terminalClears)
 			}
 
@@ -2672,9 +2672,7 @@ func (r *Resolver) applyIncrementalReindexesLocked(
 	stats *ResolveStats,
 ) {
 	if len(reindexBatch) > 0 {
-		if batchWritesImportEdges(reindexBatch) {
-			r.noteImportEdgeWrite()
-		}
+		r.noteImportEdgeReindexes(reindexBatch)
 		r.graph.ReindexEdges(reindexBatch)
 		// nil index: incremental batches are file-sized, direct probes
 		// stay under the single-save latency budget.
@@ -4774,7 +4772,8 @@ func (r *Resolver) clearReachabilityIndex() {
 //
 // Write-site audit (every ReindexEdges / ReindexUnresolvedEdgeTargets /
 // AddBatch call in this package):
-//   - guarded bump: main page commit + incremental commit (resolver.go),
+//   - precise invalidation via noteImportEdgeReindexes/noteImportTargetReindexes:
+//     main page commit + incremental commit (resolver.go),
 //     deferred-LSP terminal clears and page reindexes (resolver.go,
 //     lsp_resolve.go), attribution batches (attribution_reindex_batch.go,
 //     go_builtins_attribution.go, incremental_attribution_cache.go),
@@ -4796,30 +4795,53 @@ func (r *Resolver) noteImportEdgeWrite() {
 	r.importEdgeGen++
 }
 
-// batchWritesImportEdges reports whether an edge-reindex batch can change a
-// file's stored import adjacency. Kind migrations count in both directions:
-// either the new or the persisted pre-mutation kind being imports rewrites an
-// imports row. Sites whose batches are provably calls-only skip the bump —
-// the verdict table lives at noteImportEdgeWrite's callers.
-func batchWritesImportEdges(batch []graph.EdgeReindex) bool {
-	for _, reindex := range batch {
-		if reindex.OldKind == graph.EdgeImports {
-			return true
-		}
-		if reindex.Edge != nil && reindex.Edge.Kind == graph.EdgeImports {
-			return true
-		}
+func (r *Resolver) markImportDirty(filePath string) {
+	if r.importDirtyFiles == nil {
+		r.importDirtyFiles = make(map[string]struct{})
 	}
-	return false
+	r.importDirtyFiles[filePath] = struct{}{}
 }
 
-func targetBatchWritesImportEdges(batch []graph.UnresolvedEdgeTargetReindex) bool {
+// noteImportEdgeReindexes records which caller files' stored import adjacency
+// an edge-reindex batch rewrites. Kind migrations count in both directions:
+// either the new or the persisted pre-mutation kind being imports rewrites an
+// imports row. Known files invalidate precisely — import edges resolve in a
+// steady stream throughout a cold pass, so clearing wholesale here would
+// evict the retention before it ever serves. Entries without file provenance
+// fall back to the wholesale generation.
+func (r *Resolver) noteImportEdgeReindexes(batch []graph.EdgeReindex) {
 	for _, reindex := range batch {
-		if reindex.Old.Kind == graph.EdgeImports {
-			return true
+		importsRow := reindex.OldKind == graph.EdgeImports ||
+			(reindex.Edge != nil && reindex.Edge.Kind == graph.EdgeImports)
+		if !importsRow {
+			continue
+		}
+		marked := false
+		if reindex.Edge != nil && reindex.Edge.FilePath != "" {
+			r.markImportDirty(reindex.Edge.FilePath)
+			marked = true
+		}
+		if reindex.OldFilePath != "" {
+			r.markImportDirty(reindex.OldFilePath)
+			marked = true
+		}
+		if !marked {
+			r.noteImportEdgeWrite()
 		}
 	}
-	return false
+}
+
+func (r *Resolver) noteImportTargetReindexes(batch []graph.UnresolvedEdgeTargetReindex) {
+	for _, reindex := range batch {
+		if reindex.Old.Kind != graph.EdgeImports {
+			continue
+		}
+		if reindex.Old.FilePath == "" {
+			r.noteImportEdgeWrite()
+			continue
+		}
+		r.markImportDirty(reindex.Old.FilePath)
+	}
 }
 
 // importedDirForSpec returns the directory that an unresolved

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -4816,6 +4816,14 @@ func (r *Resolver) noteImportEdgeReindexes(batch []graph.EdgeReindex) {
 		if !importsRow {
 			continue
 		}
+		// Frontier revisits rewrite still-unresolved import edges for pure
+		// bookkeeping (meta, confidence, terminality). A rewrite that keeps
+		// target, kind, and file cannot change stored adjacency — dirtying
+		// it would evict exactly the unstable files the retention serves.
+		if reindex.Edge != nil && reindex.OldTo == reindex.Edge.To &&
+			reindex.OldKind == "" && reindex.OldFilePath == "" {
+			continue
+		}
 		marked := false
 		if reindex.Edge != nil && reindex.Edge.FilePath != "" {
 			r.markImportDirty(reindex.Edge.FilePath)

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -4769,10 +4769,11 @@ func (r *Resolver) clearReachabilityIndex() {
 	r.dirByFilePath = nil
 }
 
-// noteImportEdgeWrite records that an imports-kind edge row was written. The
-// pass-scoped import-adjacency retention compares generations at page start
-// and clears wholesale on drift — invalidation precision is traded for
-// audit-proof simplicity, and measured import writes are rare mid-pass.
+// noteImportEdgeWrite records an imports-kind edge write with no file
+// provenance. The pass-scoped import-adjacency retention compares generations
+// at page start and clears wholesale on drift — the conservative fallback
+// behind the per-file invalidation in noteImportEdgeReindexes, which covers
+// the common provenance-carrying writes.
 //
 // Write-site audit (every ReindexEdges / ReindexUnresolvedEdgeTargets /
 // AddBatch call in this package):

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -4547,6 +4547,8 @@ type reachabilityPageStats struct {
 	missing   int
 	unstable  int
 	adjCached int
+	fallback  int
+	retained  int
 	project   time.Duration
 	place     time.Duration
 	match     time.Duration
@@ -4660,6 +4662,7 @@ func (r *Resolver) buildReachabilityIndexForPendingCached(
 		if !complete {
 			// complete=false is a canonicality signal, not a cacheable
 			// answer — fallback results are never retained.
+			stats.fallback = 1
 			projected = r.legacyImportTargetsByFile(projectFiles)
 		} else if adjacency != nil {
 			// Retain raw projections for every projected file, including
@@ -4724,6 +4727,7 @@ func (r *Resolver) buildReachabilityIndexForPendingCached(
 		}
 	}
 	stats.match = time.Since(matchStart)
+	stats.retained = len(adjacency)
 	r.reachableDirsByFile = reachable
 	r.dirByFilePath = dirs
 	return true, stats


### PR DESCRIPTION
## Problem

Cold-run telemetry on my production C# repo: the resolve phase spent **142.1 s of 341.9 s** building per-page reachability, and 99.9% of that was `ProjectImportAdjacency` store reads. Caller files recur across resolve pages (~9× on average — 75,843 page-file appearances), but the existing pass-scoped retention only keeps a file whose imports are **all** resolved. Mid-pass, unresolved imports are the norm — that's what the pass is resolving — so 87.5% of recomputes were files the cache had already refused once. Worst page: 4.33 s.

## Change

First commit is instrumentation only: the existing `resolver: prepare page indexes` log line gains per-page `reach_*` fields (files, cached, missing, unstable, adjacency hits, dirty count, generation, fallback, retained size, and the project/place/match timing split). Everything after is driven by what those counters showed.

The retention itself:

- Retain raw `ProjectImportAdjacency` results per caller file for the life of the pass — **stable or not**. Only the store read is retained; the per-page derivation still reruns, so reachable dirs pick up targets resolved later in the same pass.
- Invalidation is per-file: an imports-kind edge write with file provenance drops exactly that file's retained projection (kind migrations count in both directions — either the new or the pre-mutation kind being imports rewrites an imports row). A provenance-less imports write falls back to a wholesale generation bump.
- Identity-preserving rewrites don't invalidate: the pass rewrites still-unresolved import edges for bookkeeping (meta, confidence, terminality) on every frontier revisit, and a rewrite that changes neither target, kind, nor file cannot change stored adjacency — dirtying it would evict exactly the unstable files the retention exists to serve.
- `complete=false` projections are never retained (canonicality signal, not a cacheable answer); known-empty projections are (else importless files re-project forever). Same overflow contract as the stable retention: past the entry cap, clear wholesale rather than evict piecemeal.
- Every edge write site in the package carries an audit verdict — precise invalidation, or no-bump with the reason — in a table at `noteImportEdgeWrite`.

One pinned test renegotiated, called out explicitly: `TestReachabilityProjectionDoesNotCacheUnresolvedImports` pinned "unstable files are never retained". Its replacement `TestReachabilityProjectionUnresolvedImportsStayFresh` pins what actually matters — **freshness, not absence**: a mid-pass import write still invalidates, and the next page sees the newly resolved target.

## Numbers

Idle machine, from-scratch index, same instrumentation on both sides of the A/B:

| | before | after |
|---|---|---|
| reachability build per pass | 142.1 s | **6.7 s (21×)** |
| worst page | 4.33 s | 1.03 s |
| resolve phase | 341.9 s | 193.6 s |
| total cold index | 646.6 s | 494.9 s |

The reachability sub-metric is the honest primary — it comes from the same per-page instrumentation on both sides. Phase totals are secondary: resolve varies by ~±25 s day-to-day on this machine for identical code. Retention served 34,225 page-file appearances across 5,988 unique files; the legacy fallback ran on 3 of 96 pages (genuinely malformed batches — the conservative path doing its job). Outcome counters were digit-identical across five consecutive cold runs.

## Relationship to #529

On Windows, these numbers require #529: the projection fast-path was disabled there by the path canonicality guard, so this retention had nothing to retain (fallback results are never cached — by design). The diffs are independent and touch different packages; on separator-stable platforms the retention stands alone.

## How it was validated

The diagnostics commits exist because the first deployment served zero hits, and each iteration was eliminated by a counter rather than a theory: `adj_cached=0` → generation counter showed no wholesale clears (`gen=0` all run) → dirty-set counter showed per-file invalidation was small (~75/page vs ~47k recomputes) → the fallback counter showed `complete=false` on 93 of 93 pages → the Windows path guard (#529). Outcomes stayed digit-identical through every inert run, so the retention path was provably harmless while it was being debugged.

Those `reach_*` fields aren't scaffolding to strip afterwards — they're the operational proof the retention serves. If a future write site misses its audit verdict or provenance changes shape, it shows up as `adj_cached=0` in the daemon log instead of needing a bisect.

## Tests

Retention across pages, cap-overflow wholesale clear, per-file invalidation surviving unrelated import writes, identity-preserving rewrites not invalidating, provenance-less writes falling back to the generation, the freshness pin, and fallback-never-retained are each pinned individually. Full graph+resolver failure set vs clean main is identical on my Windows box (pre-existing platform bucket only, zero new).
