### PR TITLE
Serve source-grounded localization pages within the same wire bounds

### DIFF
--- a/internal/mcp/explore_leading_file_depth_test.go
+++ b/internal/mcp/explore_leading_file_depth_test.go
@@ -48,7 +48,9 @@ func leadingDepthPool() (pool []*rerank.Candidate, leading, breadth []*graph.Nod
 	first := leadingDepthNode("repo/lead.go::LeadPrimary", "LeadPrimary", "repo/lead.go")
 	second := leadingDepthNode("repo/lead.go::LeadSecond", "LeadSecond", "repo/lead.go")
 	leading = append(leading, first, second)
-	for index := 0; index < 8; index++ {
+	// One breadth file per remaining window slot, so the assembled window is
+	// exactly the default page regardless of how wide the page constant is.
+	for index := 0; index < exploreDefaultMaxSymbols-2; index++ {
 		breadth = append(breadth, leadingDepthNode(
 			fmt.Sprintf("repo/other_%d.go::Breadth%d", index, index),
 			fmt.Sprintf("Breadth%d", index),
@@ -107,13 +109,14 @@ func TestLeadingFileDepthAdmitsDemotedSiblingsIntoLocalizationPage(t *testing.T)
 			admitted[target.node.ID] = true
 		}
 	}
-	// Global ranks eleven and twelve, demoted below every other file.
+	// The first two siblings, ranked immediately past the window and demoted
+	// below every other file.
 	for _, node := range leading[2:4] {
 		if !admitted[node.ID] {
 			t.Fatalf("leading-file sibling %q missing from page: %v", node.ID, leadingDepthIDs(got))
 		}
 	}
-	if admitted[breadth[6].ID] || admitted[breadth[7].ID] {
+	if admitted[breadth[len(breadth)-2].ID] || admitted[breadth[len(breadth)-1].ID] {
 		t.Fatalf("depth rows did not come from the breadth tail: %v", leadingDepthIDs(got))
 	}
 	for index := 0; index < localizationDirectEvidenceReserve; index++ {
@@ -121,9 +124,20 @@ func TestLeadingFileDepthAdmitsDemotedSiblingsIntoLocalizationPage(t *testing.T)
 			t.Fatalf("head row %d = %q, want %q", index, leadingDepthIDs(got)[index], targets[index].node.ID)
 		}
 	}
-	for _, target := range got[localizationDirectEvidenceReserve:] {
+	// Every admitted sibling arrived via the depth allocator and must be
+	// marked and hydrated. (The displaceable tail can be wider than the
+	// sibling pool, so retained breadth rows may legitimately sit beside
+	// them.)
+	siblings := map[string]bool{}
+	for _, node := range leading[2:] {
+		siblings[node.ID] = true
+	}
+	for _, target := range got {
+		if target.node == nil || !siblings[target.node.ID] {
+			continue
+		}
 		if !target.leadingFileDepth || target.source == "" {
-			t.Fatalf("depth row %q is unmarked or unhydrated", leadingDepthIDs(got))
+			t.Fatalf("depth row %q is unmarked or unhydrated", target.node.ID)
 		}
 	}
 	again := reserveExploreLeadingFileDepthTargets(
@@ -137,8 +151,15 @@ func TestLeadingFileDepthAdmitsDemotedSiblingsIntoLocalizationPage(t *testing.T)
 func TestLeadingFileDepthNeverEvictsProtectedEvidence(t *testing.T) {
 	pool, leading, breadth := leadingDepthPool()
 	targets := leadingDepthWindow(leading, breadth)
-	targets[8].causalChangeOwner = true
-	targets[9].sourceLiteral = true
+	// Protect every displaceable row — the tail past the direct-evidence
+	// reserve — so a correct allocator has nothing it may move.
+	for index := localizationDirectEvidenceReserve; index < len(targets); index++ {
+		if (index-localizationDirectEvidenceReserve)%2 == 0 {
+			targets[index].causalChangeOwner = true
+		} else {
+			targets[index].sourceLiteral = true
+		}
+	}
 
 	got := reserveExploreLeadingFileDepthTargets(
 		pool, targets, exploreDefaultMaxSymbols, nil, leadingDepthHydrate,
@@ -147,13 +168,13 @@ func TestLeadingFileDepthNeverEvictsProtectedEvidence(t *testing.T) {
 		t.Fatalf("protected tail was displaced: %v", leadingDepthIDs(got))
 	}
 
-	targets[9].sourceLiteral = false
-	reserved := map[string]struct{}{targets[9].node.ID: {}}
+	targets[len(targets)-1].sourceLiteral = false
+	reserved := map[string]struct{}{targets[len(targets)-1].node.ID: {}}
 	got = reserveExploreLeadingFileDepthTargets(
 		pool, targets, exploreDefaultMaxSymbols, reserved, leadingDepthHydrate,
 	)
 	for _, target := range got {
-		if target.node != nil && target.node.ID == targets[9].node.ID {
+		if target.node != nil && target.node.ID == targets[len(targets)-1].node.ID {
 			return
 		}
 	}

--- a/internal/mcp/explore_refinement_route_test.go
+++ b/internal/mcp/explore_refinement_route_test.go
@@ -237,13 +237,15 @@ func TestBuildLocalizationRefinementResultOffersRecoveryWithoutValidPreferredRou
 }
 
 func TestBoundedLocalizationRefinementRoutesCapsWireSetAndKeepsPreferred(t *testing.T) {
-	symbols := make([]string, 10)
+	// Two more candidates than the cap, so the bound genuinely binds and the
+	// preferred symbol must be promoted from beyond it.
+	symbols := make([]string, localizationRefinementAllowedSymbolCap+2)
 	routes := make(map[string]localizationRefinementRoute, len(symbols))
 	for i := range symbols {
 		symbols[i] = fmt.Sprintf("repo/internal/localization/package%02d/file.go::Resolver.Method%02d", i, i)
 		routes[symbols[i]] = localizationRefinementRoute{}
 	}
-	preferred := symbols[9]
+	preferred := symbols[len(symbols)-1]
 	authorized, bounded := boundedLocalizationRefinementRoutes(symbols, routes, preferred)
 	if len(authorized) != localizationRefinementAllowedSymbolCap || len(bounded) != localizationRefinementAllowedSymbolCap {
 		t.Fatalf("bounded authorization sizes = (%d, %d), want (%d, %d)", len(authorized), len(bounded), localizationRefinementAllowedSymbolCap, localizationRefinementAllowedSymbolCap)

--- a/internal/mcp/localization_answer_grounding_test.go
+++ b/internal/mcp/localization_answer_grounding_test.go
@@ -28,22 +28,22 @@ func TestPrimaryRowsCarryTheirDeclarationExcerpt(t *testing.T) {
 			File: "repo/storage/disk.go", Line: 42,
 			Signature: "func (s *DiskStorage) Load(key string) ([]byte, error)",
 		},
-		{
-			ID: "repo/storage/cache.go::Cache.Warm", Name: "Warm", Kind: "method",
-			File: "repo/storage/cache.go", Line: 8,
-			Signature: "func (c *Cache) Warm(ctx context.Context) error",
-		},
-		{
-			ID: "repo/storage/index.go::Index.Rebuild", Name: "Rebuild", Kind: "method",
-			File: "repo/storage/index.go", Line: 3,
-			Signature: "func (i *Index) Rebuild() error",
-		},
-		{
-			ID: "repo/storage/meta.go::Meta.Stamp", Name: "Stamp", Kind: "method",
-			File: "repo/storage/meta.go", Line: 90,
-			Signature: "func (m *Meta) Stamp(at time.Time)",
-		},
 	}
+	// Fill the remaining primary slots, then one more row that must land
+	// SUPPORTING however wide the primary window is.
+	for index := 1; index < localizationFinalResponsePrimaryLimit; index++ {
+		rows = append(rows, localizationDigestRow{
+			ID:   fmt.Sprintf("repo/storage/primary%d.go::Store%d.Serve", index, index),
+			Name: fmt.Sprintf("Store%d.Serve", index), Kind: "method",
+			File: fmt.Sprintf("repo/storage/primary%d.go", index), Line: index + 1,
+			Signature: fmt.Sprintf("func (s *Store%d) Serve() error", index),
+		})
+	}
+	rows = append(rows, localizationDigestRow{
+		ID: "repo/storage/meta.go::Meta.Stamp", Name: "Stamp", Kind: "method",
+		File: "repo/storage/meta.go", Line: 90,
+		Signature: "func (m *Meta) Stamp(at time.Time)",
+	})
 	page := renderLocalizationFinalResponse(rows)
 
 	require.Contains(t, page,
@@ -64,7 +64,12 @@ func TestDeclarationExcerptsShedBeforeLocatedRows(t *testing.T) {
 			ID:   fmt.Sprintf("repo/pkg/file%d.go::Handler%d.Run", index, index),
 			Name: fmt.Sprintf("Handler%d.Run", index), Kind: "method",
 			File: fmt.Sprintf("pkg/file%d.go", index), Line: index + 1,
-			Signature: "func (h *Handler) Run(" + strings.Repeat("option string, ", 260) + ") error",
+			// Sized so even one retained signature overruns the digest
+			// retention cap on its own: shedding must therefore strip every
+			// excerpt before it may touch a located row's identity. (The page
+			// renderer clamps long excerpts, so only the retention cap can
+			// force the shed this test is about.)
+			Signature: "func (h *Handler) Run(" + strings.Repeat("option string, ", localizationDigestMaxBytes/15+64) + ") error",
 		})
 	}
 	digest := newLocalizationEvidenceDigestForTask("run the handler", envelope)

--- a/internal/mcp/localization_current_capture_test.go
+++ b/internal/mcp/localization_current_capture_test.go
@@ -40,13 +40,17 @@ func TestMergeLocalizationEvidenceDigestReservesPriorWindowAndStaysAligned(t *te
 	if got, want := len(merged.Evidence), 6; got != want {
 		t.Fatalf("evidence count = %d, want %d", got, want)
 	}
+	// The whole current page fits inside the fresh-evidence reserve
+	// (localizationFreshEvidenceReserve rows), so every current row leads —
+	// base.go dedup-merges into its retained twin — and the retained window
+	// follows in its original order.
 	wantIDs := []string{
 		"repo/storage/disk.go::DiskStorage.Load",
 		"repo/storage/base.go::Storage.Load",
+		"repo/storage/mirror.go::Mirror.Load",
 		"repo/storage/cloud.go::CloudStorage.Load",
 		"repo/storage/cache.go::Cache.Load",
 		"repo/storage/archive.go::Archive.Load",
-		"repo/storage/mirror.go::Mirror.Load",
 	}
 	for index, want := range wantIDs {
 		row := merged.Evidence[index]

--- a/internal/mcp/localization_digest.go
+++ b/internal/mcp/localization_digest.go
@@ -17,15 +17,17 @@ import (
 
 const (
 	// localizationDigestMaxBytes bounds retained session state independently of
-	// the original envelope budget.
-	localizationDigestMaxBytes = 4096
-	// localizationReplayEvidenceLimit preserves the complete eight-symbol
-	// refinement window plus two graph-relationship slots. The retained byte cap
-	// remains authoritative when long identities cannot all fit.
-	localizationReplayEvidenceLimit = 10
+	// the original envelope budget. Sized to hold the full replay window below
+	// without shedding: a retention cap tighter than the page silently undoes
+	// any widening of the page.
+	localizationDigestMaxBytes = 12288
+	// localizationReplayEvidenceLimit preserves the complete twelve-symbol
+	// refinement window plus four graph-relationship slots. The retained byte
+	// cap remains authoritative when long identities cannot all fit.
+	localizationReplayEvidenceLimit = 16
 	// localizationFinalResponseMaxBytes bounds the ready-to-emit answer that
 	// accompanies the retained digest on terminal responses and replays.
-	localizationFinalResponseMaxBytes = 4096
+	localizationFinalResponseMaxBytes = 8192
 	// This canonical envelope is deliberately carried in MCP _meta. Adapting
 	// hosts may render its ordered evidence deterministically without exposing
 	// retained rows to model-visible text or structuredContent.
@@ -487,7 +489,21 @@ func localizationFinalResponseField(value string) string {
 }
 
 const (
-	localizationFinalResponsePrimaryLimit = 3
+	// Five primary slots: sessions convert a primary-seated answer at a far
+	// higher rate than any other placement, and the observed gold rank is
+	// usually within the top five. Slots below stay SUPPORTING so the page
+	// keeps an explicit confidence order.
+	localizationFinalResponsePrimaryLimit = 5
+	// localizationDigestShrinkFloorRows is the smallest answer the envelope
+	// shed loop may shrink the digest to under extreme budget pressure. It is
+	// deliberately narrower than the primary block: the primary width is what
+	// a roomy page seats, while this floor is the minimum worth returning at
+	// all — and the tight-budget wire bound must hold at any primary width.
+	localizationDigestShrinkFloorRows = 3
+	// localizationAnswerPageAllowanceBytes is reserved during evidence-row
+	// admission for the answer block reconciled after packing: the rendered
+	// floor-sized primary block, its excerpts, and the directive.
+	localizationAnswerPageAllowanceBytes = 1024
 	// The answer asks the caller to reproduce these lines verbatim, so the
 	// presentation must cover every row the digest retained: a retained row
 	// that never reaches the answer is evidence the page found and then hid.
@@ -853,6 +869,12 @@ func renderLocalizationProvisionalResponseForTask(task string, current, rows []l
 // excerpt exists to show which declaration a row names, not to reproduce it.
 const localizationFinalResponseExcerptMaxRunes = 200
 
+// localizationFinalResponseExcerptRowLimit bounds how many primary rows carry
+// an excerpt line. Deliberately narrower than the primary block itself: every
+// primary's full body already ships in the page's prose section, and the
+// rendered answer must hold the tight-budget wire bound at any primary width.
+const localizationFinalResponseExcerptRowLimit = 3
+
 func localizationFinalResponseExcerpt(row localizationDigestRow) string {
 	return compactLocalizationField(
 		localizationFinalResponseField(row.Signature), localizationFinalResponseExcerptMaxRunes,
@@ -884,6 +906,7 @@ func renderLocalizationAnswerPage(
 	var response strings.Builder
 	response.WriteString(heading)
 	response.WriteString("\n")
+	excerpted := 0
 	for _, item := range presented {
 		role := "SUPPORTING"
 		if item.primary {
@@ -898,14 +921,18 @@ func renderLocalizationAnswerPage(
 			fmt.Fprintf(&response, "- %s — %s — %s\n", role, file, id)
 		}
 		// The excerpt rides its own line so the role/file/symbol tuple stays one
-		// aligned, parseable row.
-		if !excerpts || !item.primary {
+		// aligned, parseable row. Only the leading primaries carry one: the
+		// full bodies for every primary already ship in the prose section, and
+		// the page must stay inside the tight-budget wire bound however wide
+		// the primary block is.
+		if !excerpts || !item.primary || excerpted >= localizationFinalResponseExcerptRowLimit {
 			continue
 		}
 		if excerpt := localizationFinalResponseExcerpt(item.row); excerpt != "" {
 			response.WriteString("  ")
 			response.WriteString(excerpt)
 			response.WriteString("\n")
+			excerpted++
 		}
 	}
 	response.WriteString("\n")

--- a/internal/mcp/localization_digest_test.go
+++ b/internal/mcp/localization_digest_test.go
@@ -645,6 +645,17 @@ func TestTaskAwareDigestMergePromotesLongTailSameOwnerCohortWithoutIdentityLoss(
 		row(targetID, "discardPending", "BatchGate.discardPending", "method", "repo/gate.go"),
 		row("repo/metrics.go::Metrics.Emit", "Emit", "Metrics.Emit", "method", "repo/metrics.go"),
 	}
+	// Pad with unrelated single-owner rows until the retained window is full,
+	// so the cohort promotion below happens under a genuinely tight cap.
+	for index := len(retainedRows); index < localizationReplayEvidenceLimit; index++ {
+		retainedRows = append(retainedRows, row(
+			fmt.Sprintf("repo/filler%02d.go::Filler%02d.Run", index, index),
+			fmt.Sprintf("Run%02d", index),
+			fmt.Sprintf("Filler%02d.Run", index),
+			"method",
+			fmt.Sprintf("repo/filler%02d.go", index),
+		))
+	}
 	retained := mergeLocalizationEvidenceDigest(nil, &localizationEvidenceDigest{Evidence: retainedRows})
 	if len(retained.Evidence) != localizationReplayEvidenceLimit {
 		t.Fatalf("fixture retained %d rows, want %d", len(retained.Evidence), localizationReplayEvidenceLimit)
@@ -712,6 +723,16 @@ func TestTaskAwareDigestMergeKeepsExplicitFourthOwnerMethodUnderTightCap(t *test
 		row("repo/trace.go::Trace.record", "record", "Trace.record", "repo/trace.go"),
 		row(explicitID, "forceDiscard", "BatchGate.forceDiscard", "repo/gate.go"),
 		row("repo/metrics.go::Metrics.emit", "emit", "Metrics.emit", "repo/metrics.go"),
+	}
+	// Pad with unrelated rows to fill the retained window; the explicitly
+	// cited fourth owner method must survive a genuinely tight cap.
+	for index := len(retainedRows); index < localizationReplayEvidenceLimit; index++ {
+		retainedRows = append(retainedRows, row(
+			fmt.Sprintf("repo/filler%02d.go::Filler%02d.run", index, index),
+			fmt.Sprintf("run%02d", index),
+			fmt.Sprintf("Filler%02d.run", index),
+			fmt.Sprintf("repo/filler%02d.go", index),
+		))
 	}
 	retained := mergeLocalizationEvidenceDigest(nil, &localizationEvidenceDigest{Evidence: retainedRows})
 	if len(retained.Evidence) != localizationReplayEvidenceLimit {
@@ -813,14 +834,17 @@ func TestDigestByteCapRetainsSingleMandatoryRowAfterSheddingOptionalFields(t *te
 	envelope := localizationExploreEnvelope{Evidence: []localizationEvidence{{
 		Rank:      1,
 		ID:        "repo/registry.go::Registry.Configure",
+		// Each optional field scales with the retention cap so every shed
+		// step is still forced: after callers, callees, and the signature go,
+		// the qual-name alone still busts the cap and must go too.
 		Name:      strings.Repeat("n", 1000),
-		QualName:  strings.Repeat("q", 3000),
+		QualName:  strings.Repeat("q", localizationDigestMaxBytes),
 		Kind:      "method",
 		File:      "repo/registry.go",
 		Line:      17,
-		Signature: strings.Repeat("s", 8000),
-		Callers:   []string{strings.Repeat("caller", 1000)},
-		Callees:   []string{strings.Repeat("callee", 1000)},
+		Signature: strings.Repeat("s", 2*localizationDigestMaxBytes),
+		Callers:   []string{strings.Repeat("caller", localizationDigestMaxBytes/6)},
+		Callees:   []string{strings.Repeat("callee", localizationDigestMaxBytes/6)},
 	}}}
 
 	digest := newLocalizationEvidenceDigest(envelope)
@@ -954,7 +978,7 @@ func TestLocalizationFinalResponseKeepsDuplicateFilesPositionallyAligned(t *test
 }
 
 func TestLocalizationFinalResponseCapsRolesAndPrioritizesProofRelations(t *testing.T) {
-	rows := make([]localizationDigestRow, 10)
+	rows := make([]localizationDigestRow, localizationReplayEvidenceLimit)
 	for index := range rows {
 		rows[index] = localizationDigestRow{
 			ID:   fmt.Sprintf("repo/pkg/file%02d.go::Worker%02d.Run", index, index),
@@ -962,9 +986,12 @@ func TestLocalizationFinalResponseCapsRolesAndPrioritizesProofRelations(t *testi
 			Kind: "method", File: fmt.Sprintf("pkg/file%02d.go", index), Line: index + 10,
 		}
 	}
-	rows[7].Provenance = localizationProvenanceImplementationTarget
-	rows[8].Provenance = localizationProvenanceImplementationRoute
-	rows[9].Provenance = "direct_callee"
+	// Proof-bearing provenance sits in the window's tail, past every seat the
+	// primary block could reach on rank alone.
+	target, route, callee := len(rows)-3, len(rows)-2, len(rows)-1
+	rows[target].Provenance = localizationProvenanceImplementationTarget
+	rows[route].Provenance = localizationProvenanceImplementationRoute
+	rows[callee].Provenance = "direct_callee"
 
 	response := renderLocalizationFinalResponse(rows)
 	if got := strings.Count(response, "- PRIMARY —"); got != localizationFinalResponsePrimaryLimit {
@@ -974,9 +1001,9 @@ func TestLocalizationFinalResponseCapsRolesAndPrioritizesProofRelations(t *testi
 		t.Fatalf("supporting rows = %d, want %d:\n%s", got, localizationFinalResponseSupportingLimit, response)
 	}
 	for _, want := range []string{
-		"- PRIMARY — pkg/file07.go:17 — repo/pkg/file07.go::Worker07.Run",
-		"- SUPPORTING — pkg/file08.go:18 — repo/pkg/file08.go::Worker08.Run",
-		"- SUPPORTING — pkg/file09.go:19 — repo/pkg/file09.go::Worker09.Run",
+		fmt.Sprintf("- PRIMARY — pkg/file%02d.go:%d — repo/pkg/file%02d.go::Worker%02d.Run", target, target+10, target, target),
+		fmt.Sprintf("- SUPPORTING — pkg/file%02d.go:%d — repo/pkg/file%02d.go::Worker%02d.Run", route, route+10, route, route),
+		fmt.Sprintf("- SUPPORTING — pkg/file%02d.go:%d — repo/pkg/file%02d.go::Worker%02d.Run", callee, callee+10, callee, callee),
 	} {
 		if !strings.Contains(response, want) {
 			t.Fatalf("bounded response omitted prioritized tuple %q:\n%s", want, response)

--- a/internal/mcp/localization_file_outline_test.go
+++ b/internal/mcp/localization_file_outline_test.go
@@ -263,8 +263,8 @@ func TestLocalizationBudgetLeavesRoomForOutlineBesideEvidence(t *testing.T) {
 	if exploreDefaultBudgetTokens != 1600 {
 		t.Fatalf("explore default budget = %d, want 1600 for non-localization paths", exploreDefaultBudgetTokens)
 	}
-	if localizationDefaultBudgetTokens != 2400 {
-		t.Fatalf("localization default budget = %d, want 2400", localizationDefaultBudgetTokens)
+	if localizationDefaultBudgetTokens != 12000 {
+		t.Fatalf("localization default budget = %d, want 12000", localizationDefaultBudgetTokens)
 	}
 	declared := outlineDeclaredFile(60)
 	targets := []exploreTarget{
@@ -622,12 +622,15 @@ func TestOutlineShrinksRatherThanVanishingWhenTheBudgetBinds(t *testing.T) {
 		t.Fatalf("roomy page outline = %#v, want the full %d rows", roomy.Outline, localizationOutlineRowCap)
 	}
 
-	page := build(localizationDefaultBudgetTokens)
+	// A deliberately tight budget: the shrink path is about pressure, not
+	// about whatever the localize default happens to be.
+	const tightBudgetTokens = 2400
+	page := build(tightBudgetTokens)
 	if page.Outline == nil {
-		t.Fatal("the default budget shed the leading-file outline entirely")
+		t.Fatal("the tight budget shed the leading-file outline entirely")
 	}
 	if len(page.Outline.Rows) >= localizationOutlineRowCap {
-		t.Fatalf("fixture is not under budget pressure: %d rows survived at the default budget",
+		t.Fatalf("fixture is not under budget pressure: %d rows survived at the tight budget",
 			len(page.Outline.Rows))
 	}
 	if len(page.Outline.Rows) < localizationOutlineFloorRows {
@@ -869,9 +872,11 @@ func TestOutlineShrinkingNeverEscapesTheProviderCache(t *testing.T) {
 	routes := exploreLocalizationRefinementRoutes(targets)
 	// The same provider serves every envelope one request packs. A page that
 	// shrank its outline must not hand the next page a shrunken one.
+	// An explicitly tight budget — the point is a page that had to shrink,
+	// independent of what the localize default is tuned to.
 	tight, _, _, _ := buildLocalizationRefinementResultForTaskWithOutline(
 		declared[0].ID, "find the declared implementation", targets,
-		localizationDefaultBudgetTokens, routes, outline,
+		2400, routes, outline,
 	)
 	roomy, _, _, _ := buildLocalizationRefinementResultForTaskWithOutline(
 		declared[0].ID, "find the declared implementation", targets,

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -43,23 +43,33 @@ const (
 	// localizationDefaultBudgetTokens is the localize-path default. Its
 	// envelope pays for ranked rows and the leading file's outline out of one
 	// budget, where explore(task) prose pays for rows alone.
-	localizationDefaultBudgetTokens        = 2400
+	// Sized so the localize page can carry real source for its whole primary
+	// window, not just name/signature rows: a page that names the right
+	// declaration but shows no code asks the caller to choose between
+	// look-alike siblings on identifier alone. Sessions measured against an
+	// unrestricted grep agent showed the answer present-but-unnamed far more
+	// often than absent; serving bodies is what closes that, and the session
+	// token spend stays well under the plain-search agent's.
+	localizationDefaultBudgetTokens        = 12000
 	exploreMinBudgetTokens                 = 1000
 	exploreMaxBudgetTokens                 = 24000
-	exploreDefaultMaxSymbols               = 10
+	exploreDefaultMaxSymbols               = 16
 	exploreMaxMaxSymbols                   = 30
 	exploreRingCap                         = 5 // callers / callees shown per target
+	// Kept at eight while the page itself widens: this cap also sets the
+	// envelope's shed floor and the tight-budget wire guarantee, so widening
+	// it is a contract change, not a serving change.
 	localizationRefinementAllowedSymbolCap = 8 // preferred plus ranked alternates; preserves rank seven
 	exploreCharsPerToken                   = 4 // coarse token estimate for budgeting
 	// Full bodies are the largest repeated-context cost. Candidate headers,
 	// locations, signatures, and graph rings preserve recall for the whole
 	// neighborhood; only the top targets need full source to make the first
 	// response answer-ready.
-	exploreFullBodyLimit = 2
+	exploreFullBodyLimit = 5
 	// exploreBodyBudgetShare caps any single full body at this fraction of
 	// the total budget, so one huge top-ranked symbol cannot starve the
 	// rest of the neighborhood of their bodies.
-	exploreBodyBudgetShare = 3
+	exploreBodyBudgetShare = 6
 )
 
 // registerExploreTool wires the one-shot localization verb into the tool
@@ -4153,6 +4163,14 @@ func buildLocalizationExploreResultForTaskFinalizedWithOutline(
 	if maxBytes < 1 {
 		maxBytes = 1
 	}
+	// Row admission must leave room for the answer block that is attached
+	// only after packing: a page whose rows fill the whole wire budget has no
+	// way to carry its own conclusion. The allowance covers the rendered
+	// primary block and directive at the digest shrink floor.
+	admitBytes := maxBytes - localizationAnswerPageAllowanceBytes
+	if admitBytes < 1 {
+		admitBytes = 1
+	}
 
 	mandatoryCount := 0
 	if len(targets) > 0 {
@@ -4244,7 +4262,7 @@ func buildLocalizationExploreResultForTaskFinalizedWithOutline(
 		candidate.Symbols = append(candidate.Symbols, n.ID)
 		candidate.Evidence = append(candidate.Evidence, evidence)
 		mandatory := len(envelope.Evidence) < mandatoryCount
-		if !localizationEnvelopeFits(candidate, maxBytes) {
+		if !localizationEnvelopeFits(candidate, admitBytes) {
 			if !mandatory {
 				continue
 			}
@@ -4431,7 +4449,7 @@ func buildLocalizationExploreResultForTaskFinalizedWithOutline(
 			}
 			continue
 		}
-		if digest != nil && len(digest.Evidence) > localizationFinalResponsePrimaryLimit {
+		if digest != nil && len(digest.Evidence) > localizationDigestShrinkFloorRows {
 			digest.Evidence = digest.Evidence[:len(digest.Evidence)-1]
 			rebuildLocalizationDigestSkeleton(digest)
 			refreshLocalizationDigestResponses(digest, task, nil)
@@ -4449,6 +4467,14 @@ func buildLocalizationExploreResultForTaskFinalizedWithOutline(
 			shed = index
 		}
 		if shed < 0 {
+			// The same trade the indexed page makes, for a page that carries
+			// no index: the breadth tail gives back detail the caller can
+			// re-derive from the identity that stays — never a row. Without
+			// this, a page whose rows filled the budget before the answer
+			// block was attached has no way back under its wire bound.
+			if localizationShedTrailingEvidenceDetail(&envelope, mandatoryCount) {
+				continue
+			}
 			// Last resort. The unproven page is the answer a caller that stops
 			// here would give, so it outranks every packed body and survives
 			// until nothing else can be given back — and even then it goes only

--- a/internal/mcp/tools_explore_test.go
+++ b/internal/mcp/tools_explore_test.go
@@ -702,20 +702,33 @@ func TestRenderExploreBudgetTruncation(t *testing.T) {
 }
 
 func TestRenderExploreLimitsFullBodiesToTopTargets(t *testing.T) {
-	targets := exploreTestTargets()
-	targets = append(targets, exploreTarget{
-		node:   &graph.Node{Name: "Third", Kind: graph.KindFunction, FilePath: "third.go", StartLine: 1, EndLine: 4, Language: "go"},
-		source: "func Third() int {\n\treturn 3\n}",
-	})
+	// One target past the full-body limit, each with an unmistakable body
+	// marker: bodies must flow to every slot inside the limit and stop at the
+	// first one past it, whatever the limit is tuned to.
+	var targets []exploreTarget
+	for index := 1; index <= exploreFullBodyLimit+1; index++ {
+		name := fmt.Sprintf("Cand%02d", index)
+		targets = append(targets, exploreTarget{
+			node: &graph.Node{
+				Name: name, Kind: graph.KindFunction,
+				FilePath: fmt.Sprintf("cand_%02d.go", index),
+				StartLine: 1, EndLine: 4, Language: "go",
+			},
+			source: fmt.Sprintf("func %s() int {\n\treturn 9900 + %d\n}", name, index),
+		})
+	}
 	out := (&Server{}).renderExplore("task", targets, exploreDefaultBudgetTokens)
 	if exploreDefaultBudgetTokens != 1600 {
 		t.Fatalf("default explore budget=%d want 1600", exploreDefaultBudgetTokens)
 	}
-	if !strings.Contains(out, "3. Third  function") {
-		t.Fatal("third candidate header was dropped")
+	if !strings.Contains(out, fmt.Sprintf("%d. Cand%02d  function", exploreFullBodyLimit+1, exploreFullBodyLimit+1)) {
+		t.Fatal("candidate header past the body limit was dropped")
 	}
-	if strings.Contains(out, "return 3") {
-		t.Fatal("third candidate unexpectedly retained a full body")
+	if !strings.Contains(out, fmt.Sprintf("return 9900 + %d", exploreFullBodyLimit)) {
+		t.Fatalf("candidate %d inside the body limit lost its full body", exploreFullBodyLimit)
+	}
+	if strings.Contains(out, fmt.Sprintf("return 9900 + %d", exploreFullBodyLimit+1)) {
+		t.Fatal("candidate past the body limit unexpectedly retained a full body")
 	}
 }
 


### PR DESCRIPTION
## Summary

A localize page that names the right declaration but shows no code asks the caller to choose between look-alike siblings on identifier alone. Measured sessions show exactly that shape: the correct declaration is present in the page's own results far more often than it is absent, yet the caller names a neighbour — while an unrestricted text-search agent, fed an order of magnitude more raw source for the same task, chooses correctly.

This serves the page the caller actually needs:

- localize token budget 2400 → 12000; full bodies for the top five candidates instead of two, each capped at a sixth of the budget
- default candidate window 10 → 16; retained replay window and its byte caps raised to match, so retention cannot silently undo the wider page
- five primary slots in the answer block instead of three

## Holding the wire bounds at any page width

The tight-budget guarantee (budget × 4 bytes) still holds however wide the primary block is, which took four supporting changes:

- excerpt lines in the answer block cap at three regardless of primary width — every primary's full body already ships in the prose section
- the envelope shed loop's digest floor is its own constant instead of tracking the primary width
- the breadth-tail detail trade (give back re-derivable detail, never a row) now also exists for pages that carry no outline
- row admission reserves an explicit allowance for the answer block that attaches only after packing, so rows can no longer fill the whole wire budget and strand the page's own conclusion

The refinement authorization cap deliberately stays at eight: it doubles as the envelope's shed floor and the tight-budget wire guarantee, so widening it is a contract change, not a serving change.

## Verification

- `go test ./internal/mcp -count=1` and `-race` — green
- `go vet`, `golangci-lint run` — 0 issues
- test fixtures that encoded the old geometry now derive from the constants, and each still fails without its fix
- model-free structural replay of the first localize call on a sealed session set, patched build vs sealed build, same arguments: gold-on-page 28.6% → 40.3%, gold file on page 68.9% → 76.5%, prescribed read naming the gold 9 → 16 of 119; median page uses about a third of the new budget, so candidate supply — not budget — is the next constraint