### PR TITLE
fix(csharp): resolve calls with explicit type arguments and same-name extension overloads

### DIFF
--- a/internal/indexer/extractor_version.go
+++ b/internal/indexer/extractor_version.go
@@ -32,7 +32,7 @@ var extractorVersions = map[string]int{
 	//   "go": 2,
 	"c":      generatedParserProjectionPolicyVersion, // generated parser projection covers all strictly detected table sizes
 	"php":    2,                                      // class/interface inheritance now emits typed structural edges
-	"csharp": 8,                                      // interface base lists emit extends edges (was: record positional property nodes)
+	"csharp": 9,                                      // generic invocations emit call edges (was: interface base lists emit extends edges)
 }
 
 // extractorSaltExtLang maps a lower-case file extension to the language
@@ -41,41 +41,47 @@ var extractorVersions = map[string]int{
 // staleness, the pre-existing behaviour). Extensions are grouped to the
 // extractor that owns them.
 var extractorSaltExtLang = map[string]string{
-	".go":    "go",
-	".py":    "python",
-	".pyi":   "python",
-	".js":    "javascript",
-	".jsx":   "javascript",
-	".mjs":   "javascript",
-	".cjs":   "javascript",
-	".ts":    "typescript",
-	".tsx":   "typescript",
-	".mts":   "typescript",
-	".cts":   "typescript",
-	".java":  "java",
-	".rb":    "ruby",
-	".rs":    "rust",
-	".c":     "c",
-	".h":     "c",
-	".cc":    "cpp",
-	".cpp":   "cpp",
-	".cxx":   "cpp",
-	".hpp":   "cpp",
-	".hh":    "cpp",
-	".cs":    "csharp",
-	".php":   "php",
-	".swift": "swift",
-	".kt":    "kotlin",
-	".kts":   "kotlin",
-	".scala": "scala",
-	".m":     "objc",
-	".mm":    "objcpp",
-	".lua":   "lua",
-	".dart":  "dart",
-	".ex":    "elixir",
-	".exs":   "elixir",
-	".sh":    "bash",
-	".bash":  "bash",
+	".go":   "go",
+	".py":   "python",
+	".pyi":  "python",
+	".js":   "javascript",
+	".jsx":  "javascript",
+	".mjs":  "javascript",
+	".cjs":  "javascript",
+	".ts":   "typescript",
+	".tsx":  "typescript",
+	".mts":  "typescript",
+	".cts":  "typescript",
+	".java": "java",
+	".rb":   "ruby",
+	".rs":   "rust",
+	".c":    "c",
+	".h":    "c",
+	".cc":   "cpp",
+	".cpp":  "cpp",
+	".cxx":  "cpp",
+	".hpp":  "cpp",
+	".hh":   "cpp",
+	".cs":   "csharp",
+	// Razor templates are extracted by the C# extractor over their
+	// embedded code blocks, so a C# extraction fix has to re-flag them
+	// too — otherwise the same stale extraction survives on exactly the
+	// files whose C# is hardest to re-trigger by hand.
+	".razor":  "csharp",
+	".cshtml": "csharp",
+	".php":    "php",
+	".swift":  "swift",
+	".kt":     "kotlin",
+	".kts":    "kotlin",
+	".scala":  "scala",
+	".m":      "objc",
+	".mm":     "objcpp",
+	".lua":    "lua",
+	".dart":   "dart",
+	".ex":     "elixir",
+	".exs":    "elixir",
+	".sh":     "bash",
+	".bash":   "bash",
 }
 
 // ExtractorLangForFile returns the extractor-staleness language key for a

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -670,6 +670,16 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 				}
 			} else if strings.Contains(c.receiver, ".") || strings.Contains(c.receiver, "(") {
 				stampFactoryChainReceiver(edge, c.receiver, resolveChainType(c.receiver, tenvByOwner[callerID], result))
+			} else if c.receiver != "" {
+				// A bare receiver nothing above could type. Its spelling
+				// is still evidence: reaching here means no local, param
+				// or builtin in scope carries that name, so a receiver
+				// that names a static class is the STATIC form of an
+				// extension call (`BagExt.Add(bag)`) — where the `this`
+				// slot is filled by the first argument, not the
+				// receiver. The extension binder needs that distinction
+				// before it can compare argument counts.
+				edge.Meta = map[string]any{"receiver_name": c.receiver}
 			}
 			// Eviction restubs a member call to a bare unresolved name; the
 			// marker is what lets the resolver still route the rebind through

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -71,41 +71,69 @@ const qCSharpAll = `
 
   (using_directive (_) @using.path) @using.def
 
+  ; An invocation that spells explicit type arguments parses its callee
+  ; name as a generic_name, never a bare identifier — so pinning the name
+  ; to (identifier) dropped every generic call site outright, with no edge
+  ; and no unresolved stub. That is the dominant .NET call shape
+  ; (GetRequiredService<T>(), AddSingleton<TI, TImpl>()), and it left
+  ; heavily-called methods looking like dead code. Each alternation
+  ; captures the inner identifier, so the callee name stays bare.
   (invocation_expression
-    function: (identifier) @call.name) @call.expr
+    function: [
+      (identifier) @call.name
+      (generic_name (identifier) @call.name)
+    ]) @call.expr
 
   (invocation_expression
     function: (member_access_expression
       expression: (_) @callm.receiver
-      name: (identifier) @callm.method)) @callm.expr
+      name: [
+        (identifier) @callm.method
+        (generic_name (identifier) @callm.method)
+      ])) @callm.expr
 
   (invocation_expression
     function: (conditional_access_expression
       condition: (_) @callm.receiver
       (member_binding_expression
-        name: (identifier) @callm.method))) @callm.expr
+        name: [
+          (identifier) @callm.method
+          (generic_name (identifier) @callm.method)
+        ]))) @callm.expr
 
   (invocation_expression
     function: (conditional_access_expression
       "this"
       (member_binding_expression
-        name: (identifier) @callself.method))) @callself.expr
+        name: [
+          (identifier) @callself.method
+          (generic_name (identifier) @callself.method)
+        ]))) @callself.expr
 
   (invocation_expression
     function: (conditional_access_expression
       "base"
       (member_binding_expression
-        name: (identifier) @callbase.method))) @callbase.expr
+        name: [
+          (identifier) @callbase.method
+          (generic_name (identifier) @callbase.method)
+        ]))) @callbase.expr
 
   (invocation_expression
     function: (member_access_expression
       "this"
-      name: (identifier) @callself.method)) @callself.expr
+      name: [
+        (identifier) @callself.method
+        (generic_name (identifier) @callself.method)
+      ])) @callself.expr
 
   (invocation_expression
     function: (member_access_expression
       "base"
-      name: (identifier) @callbase.method)) @callbase.expr
+      name: [
+        (identifier) @callbase.method
+        (generic_name (identifier) @callbase.method)
+      ])) @callbase.expr
 
   (local_declaration_statement
     (variable_declaration
@@ -114,11 +142,17 @@ const qCSharpAll = `
         (identifier) @lvar.name))) @lvar.def
 
   (member_access_expression
-    name: (identifier) @maccess.name) @maccess.expr
+    name: [
+      (identifier) @maccess.name
+      (generic_name (identifier) @maccess.name)
+    ]) @maccess.expr
 
   (conditional_access_expression
     (member_binding_expression
-      name: (identifier) @maccess.condname)) @maccess.condexpr
+      name: [
+        (identifier) @maccess.condname
+        (generic_name (identifier) @maccess.condname)
+      ])) @maccess.condexpr
 ]
 `
 

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -188,6 +188,23 @@ type csharpDeferredCall struct {
 	// (graph.ReturnUsage* label), classified at capture time and
 	// stamped as edge Meta on the EdgeCalls emitted for this site.
 	returnUsage string
+	// argCount / typeArgCount are the call's applicability evidence:
+	// how many arguments it passes and how many type arguments it
+	// spells explicitly. Their *Known flags keep "no evidence"
+	// distinguishable from a genuine zero — narrowing an overload set
+	// on a count we never measured would be a guess, not a rule.
+	argCount     int
+	argKnown     bool
+	typeArgCount int
+	typeArgKnown bool
+}
+
+// withCSharpCallArity records the applicability counts an invocation
+// node carries, so every capture site stamps the same evidence.
+func withCSharpCallArity(c csharpDeferredCall, inv *sitter.Node) csharpDeferredCall {
+	c.argCount, c.argKnown = csharpCallArgCount(inv)
+	c.typeArgCount, c.typeArgKnown = csharpCallTypeArgCount(inv)
+	return c
 }
 
 // csharpDeferredLocal buffers a local variable declaration for the
@@ -342,36 +359,39 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 
 		case m.Captures["callm.expr"] != nil:
 			expr := m.Captures["callm.expr"]
-			calls = append(calls, csharpDeferredCall{
+			calls = append(calls, withCSharpCallArity(csharpDeferredCall{
 				name:        m.Captures["callm.method"].Text,
 				receiver:    m.Captures["callm.receiver"].Text,
 				line:        expr.StartLine + 1,
 				isMember:    true,
 				returnUsage: classifyReturnUsage(expr.Node, src, csharpReturnUsageSpec),
-			})
+			}, expr.Node))
 
 		case m.Captures["callself.expr"] != nil:
 			expr := m.Captures["callself.expr"]
-			calls = append(calls, csharpDeferredCall{
+			calls = append(calls, withCSharpCallArity(csharpDeferredCall{
 				name:        m.Captures["callself.method"].Text,
 				receiver:    "this",
 				recvType:    csharpQualifiedReceiverType(expr.Node, src, "this"),
 				line:        expr.StartLine + 1,
 				isMember:    true,
 				returnUsage: classifyReturnUsage(expr.Node, src, csharpReturnUsageSpec),
-			})
+			}, expr.Node))
 
 		case m.Captures["callbase.expr"] != nil:
 			expr := m.Captures["callbase.expr"]
-			calls = append(calls, csharpDeferredCall{
+			calls = append(calls, withCSharpCallArity(csharpDeferredCall{
 				name:        m.Captures["callbase.method"].Text,
 				receiver:    "base",
 				recvType:    csharpQualifiedReceiverType(expr.Node, src, "base"),
 				line:        expr.StartLine + 1,
 				isMember:    true,
 				returnUsage: classifyReturnUsage(expr.Node, src, csharpReturnUsageSpec),
-			})
+			}, expr.Node))
 
+		// A receiverless call carries no applicability stamps: nothing
+		// resolves it through the extension binder, and the scope rules
+		// that do bind it never consult arity.
 		case m.Captures["call.expr"] != nil:
 			expr := m.Captures["call.expr"]
 			calls = append(calls, csharpDeferredCall{
@@ -658,6 +678,16 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 				edge.Meta = map[string]any{}
 			}
 			edge.Meta["member_call"] = true
+			// Applicability evidence for the overload set behind this
+			// name. Member calls carry it because they are the shape
+			// the extension binder resolves; a plain `Foo()` is already
+			// bound by scope rules that never consult arity.
+			if c.argKnown {
+				edge.Meta["arg_count"] = c.argCount
+			}
+			if c.typeArgKnown {
+				edge.Meta["type_arg_count"] = c.typeArgCount
+			}
 			stampReturnUsage(edge, c.returnUsage)
 			result.Edges = append(result.Edges, edge)
 			continue
@@ -1231,6 +1261,20 @@ func (e *CSharpExtractor) emitMethod(m parser.QueryResult, filePath, fileID stri
 			}
 			sort.Strings(names)
 			meta["method_type_params"] = strings.Join(names, ",")
+		}
+	}
+	// Parameter arity — the evidence that splits a same-name overload set
+	// the receiver type alone cannot. Stamped on the node rather than read
+	// back off the KindParam nodes because those carry no default-value
+	// marker (and a discard parameter emits none at all), so they cannot
+	// answer "how many arguments MUST a caller supply".
+	if count, required, variadic, ok := csharpParamArity(def.Node, src); ok {
+		meta["param_count"] = count
+		if required != count {
+			meta["param_required"] = required
+		}
+		if variadic {
+			meta["param_variadic"] = true
 		}
 	}
 	if ns := csharpEnclosingNamespace(def.Node, src); ns != "" {

--- a/internal/parser/languages/csharp_arity.go
+++ b/internal/parser/languages/csharp_arity.go
@@ -1,0 +1,164 @@
+package languages
+
+import (
+	"strings"
+
+	sitter "github.com/zzet/gortex/internal/parser/tsitter"
+)
+
+// C# overload evidence — the shape facts that let the resolver pick one
+// member out of a same-name set without guessing.
+//
+// A same-name C# method set is split by APPLICABILITY before anything
+// else: how many arguments the call passes, and how many type arguments
+// it spells. Receiver type alone cannot separate overloads that all
+// extend the same type (`AddFoo(this IServiceCollection)` vs
+// `AddFoo(this IServiceCollection, Action<Options>)`), which is the
+// dominant shape in .NET DI registration code. Without these stamps the
+// resolver's ambiguity refusal drops the call edge entirely.
+//
+// Both sides of the comparison are recorded here: the call site's
+// argument / type-argument counts (stamped on the EdgeCalls) and the
+// declaration's parameter arity (stamped on the method node).
+
+// csharpCallArgCount counts the argument expressions of an invocation.
+// ok=false when the node carries no argument list at all, so an unknown
+// arity is never mistaken for a zero-argument call.
+func csharpCallArgCount(inv *sitter.Node) (int, bool) {
+	if inv == nil {
+		return 0, false
+	}
+	args := inv.ChildByFieldName("arguments")
+	if args == nil {
+		return 0, false
+	}
+	n := 0
+	for i, nc := 0, int(args.NamedChildCount()); i < nc; i++ {
+		// Named children include comments; only `argument` nodes count.
+		if c := args.NamedChild(i); c != nil && c.Type() == "argument" {
+			n++
+		}
+	}
+	return n, true
+}
+
+// csharpCallTypeArgCount counts the EXPLICIT type arguments an
+// invocation spells (`Foo<A, B>()` → 2). ok=false when the invoked name
+// carries no type-argument list — C# infers them there, so the count is
+// no evidence about the callee's arity.
+func csharpCallTypeArgCount(inv *sitter.Node) (int, bool) {
+	if inv == nil {
+		return 0, false
+	}
+	fn := inv.ChildByFieldName("function")
+	if fn == nil {
+		return 0, false
+	}
+	// `Foo<T>()` invokes a generic_name directly; `x.Foo<T>()` and
+	// `x?.Foo<T>()` wrap it in the member access / binding's name field.
+	switch fn.Type() {
+	case "member_access_expression", "member_binding_expression":
+		fn = fn.ChildByFieldName("name")
+	case "conditional_access_expression":
+		fn = csharpFirstChildOfType(fn, "member_binding_expression")
+		if fn != nil {
+			fn = fn.ChildByFieldName("name")
+		}
+	}
+	if fn == nil || fn.Type() != "generic_name" {
+		return 0, false
+	}
+	list := csharpFirstChildOfType(fn, "type_argument_list")
+	if list == nil {
+		return 0, false
+	}
+	n := 0
+	for i, nc := 0, int(list.NamedChildCount()); i < nc; i++ {
+		if c := list.NamedChild(i); c != nil && c.Type() != "comment" {
+			n++
+		}
+	}
+	return n, n > 0
+}
+
+// csharpParamArity summarises a declaration's parameter list: the total
+// declared count, how many a caller MUST supply, and whether a `params`
+// array lifts the upper bound. The `this` parameter of an extension
+// method is counted like any other — the consumer knows whether the call
+// site writes extension form or static form and adjusts.
+//
+// ok=false when the list is absent OR when the grammar did not resolve
+// every entry into a `parameter` node. The vendored C# grammar flattens
+// a `params object[] rest` entry into loose `array_type` + `identifier`
+// siblings instead of a parameter, so a naive count would report one
+// parameter for a two-parameter method — and an overload narrowed on
+// that count would be excluded for argument counts it actually accepts.
+// A list we cannot read in full yields no evidence at all, which leaves
+// the method universally applicable rather than wrongly excluded.
+func csharpParamArity(decl *sitter.Node, src []byte) (count, required int, variadic bool, ok bool) {
+	if decl == nil {
+		return 0, 0, false, false
+	}
+	params := decl.ChildByFieldName("parameters")
+	if params == nil {
+		return 0, 0, false, false
+	}
+	for i, nc := 0, int(params.NamedChildCount()); i < nc; i++ {
+		p := params.NamedChild(i)
+		if p == nil || p.Type() == "comment" {
+			continue
+		}
+		if p.Type() != "parameter" {
+			return 0, 0, false, false
+		}
+		count++
+		isVariadic := csharpParamIsVariadic(p, src)
+		if isVariadic {
+			variadic = true
+		}
+		// A defaulted parameter (`int retries = 3`) and a `params`
+		// array are both omissible at the call site.
+		if isVariadic || csharpParamHasDefault(p) {
+			continue
+		}
+		required++
+	}
+	return count, required, variadic, true
+}
+
+// csharpParamHasDefault reports whether a parameter declares a default
+// value. The grammar spells it as a bare `=` token followed by the value
+// expression — there is no equals-value wrapper node to look for.
+func csharpParamHasDefault(p *sitter.Node) bool {
+	if p == nil {
+		return false
+	}
+	for i, nc := 0, int(p.ChildCount()); i < nc; i++ {
+		if c := p.Child(i); c != nil && c.Type() == "=" {
+			return true
+		}
+	}
+	return false
+}
+
+// csharpParamIsVariadic reports whether a parameter carries the `params`
+// modifier — C#'s variadic marker. Both modifier spellings the grammar
+// has used are accepted so the check survives a grammar bump.
+func csharpParamIsVariadic(p *sitter.Node, src []byte) bool {
+	if p == nil {
+		return false
+	}
+	for i, nc := 0, int(p.NamedChildCount()); i < nc; i++ {
+		c := p.NamedChild(i)
+		if c == nil {
+			continue
+		}
+		if c.Type() != "modifier" && c.Type() != "parameter_modifier" {
+			continue
+		}
+		if strings.Contains(c.Content(src), "params") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/parser/languages/csharp_function_shape.go
+++ b/internal/parser/languages/csharp_function_shape.go
@@ -29,7 +29,7 @@ func emitCSharpFunctionShape(ownerID string, methodNode *sitter.Node, src []byte
 }
 
 func emitCSharpParamNodes(ownerID string, params *sitter.Node, src []byte, filePath string, declLine int, result *parser.ExtractionResult) {
-	pos := 0
+	declaredPos := 0
 	for i, _nc := 0, int(params.NamedChildCount()); i < _nc; i++ {
 		decl := params.NamedChild(i)
 		if decl == nil {
@@ -38,22 +38,20 @@ func emitCSharpParamNodes(ownerID string, params *sitter.Node, src []byte, fileP
 		if decl.Type() != "parameter" {
 			continue
 		}
+		// Every `parameter` child holds a position, whether or not it
+		// gets a node below: a discard (`void Foo(int _, string name)`)
+		// still occupies slot 0, so skipping it silently would shift
+		// every later parameter's recorded position down by one.
+		pos := declaredPos
+		declaredPos++
 		var name, typeRaw string
-		variadic := false
 		if n := decl.ChildByFieldName("name"); n != nil {
 			name = n.Content(src)
 		}
 		if t := decl.ChildByFieldName("type"); t != nil {
 			typeRaw = strings.TrimSpace(t.Content(src))
 		}
-		// Look for `params` modifier — variadic in C#.
-		for j, _nc := 0, int(decl.NamedChildCount()); j < _nc; j++ {
-			c := decl.NamedChild(j)
-			if c != nil && c.Type() == "parameter_modifier" && strings.Contains(c.Content(src), "params") {
-				variadic = true
-				break
-			}
-		}
+		variadic := csharpParamIsVariadic(decl, src)
 		if name == "" || name == "_" {
 			continue
 		}
@@ -97,7 +95,6 @@ func emitCSharpParamNodes(ownerID string, params *sitter.Node, src []byte, fileP
 				Origin:   graph.OriginASTInferred,
 			})
 		}
-		pos++
 	}
 }
 

--- a/internal/parser/languages/csharp_generic_call_test.go
+++ b/internal/parser/languages/csharp_generic_call_test.go
@@ -1,0 +1,100 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// callEdgesFrom returns the EdgeCalls out of fromID whose unresolved
+// target names method (member form `unresolved::*.Name` or plain
+// `unresolved::Name`).
+func callEdgesFrom(edges []*graph.Edge, fromID, method string) []*graph.Edge {
+	var out []*graph.Edge
+	for _, ed := range edges {
+		if ed.From != fromID || ed.Kind != graph.EdgeCalls {
+			continue
+		}
+		if ed.To == "unresolved::*."+method || ed.To == "unresolved::"+method {
+			out = append(out, ed)
+		}
+	}
+	return out
+}
+
+// A call that spells explicit type arguments parses its invoked name as a
+// `generic_name`, not an `identifier`. The call-site query used to require
+// an identifier in every position, so EVERY generic invocation — the
+// dominant shape in .NET (`GetRequiredService<T>()`,
+// `AddSingleton<TI, TImpl>()`, `Deserialize<T>()`) — matched no pattern and
+// produced no call edge at all. Not an unresolved stub: nothing. That made
+// a heavily-called generic method indistinguishable from dead code.
+//
+// Each row pairs a call shape written WITHOUT type arguments against the
+// same shape written with them. The pair — not an absolute expectation —
+// is the assertion: whatever a shape earns plainly, it must still earn
+// when the invoked name is generic. That keeps the test honest about
+// shapes the extractor types weakly for unrelated reasons, while still
+// failing loudly if type arguments cost an edge or a stamp.
+func TestCSharpExtractor_GenericInvocationEmitsCallEdge(t *testing.T) {
+	src := []byte(`namespace App {
+    public interface IBox { }
+
+    public class Registry {
+        public T Resolve<T>() { return default(T); }
+        public void Resolve() { }
+    }
+
+    public class Base {
+        public virtual T Make<T>() { return default(T); }
+        public virtual void Make() { }
+    }
+
+    public class Runner : Base {
+        public void LocalPlain() { Registry r = new Registry(); r.Resolve(); }
+        public void LocalGeneric() { Registry r = new Registry(); r.Resolve<IBox>(); }
+
+        public void CondPlain(Registry r) { r?.Resolve(); }
+        public void CondGeneric(Registry r) { r?.Resolve<IBox>(); }
+
+        public void SelfPlain() { this.Helper(); }
+        public void SelfGeneric() { this.Helper<IBox>(); }
+
+        public void BasePlain() { base.Make(); }
+        public void BaseGeneric() { base.Make<IBox>(); }
+
+        public void BarePlain() { Helper(); }
+        public void BareGeneric() { Helper<IBox>(); }
+
+        public void Helper() { }
+        public T Helper<T>() { return default(T); }
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("App.cs", src)
+	require.NoError(t, err)
+
+	for _, row := range []struct{ shape, plain, generic, method string }{
+		{"typed local receiver", "LocalPlain", "LocalGeneric", "Resolve"},
+		{"null-conditional receiver", "CondPlain", "CondGeneric", "Resolve"},
+		{"this-qualified", "SelfPlain", "SelfGeneric", "Helper"},
+		{"base-qualified", "BasePlain", "BaseGeneric", "Make"},
+		{"receiverless", "BarePlain", "BareGeneric", "Helper"},
+	} {
+		t.Run(row.shape, func(t *testing.T) {
+			plain := callEdgesFrom(result.Edges, "App.cs::Runner."+row.plain, row.method)
+			generic := callEdgesFrom(result.Edges, "App.cs::Runner."+row.generic, row.method)
+			require.Len(t, plain, 1, "control: the non-generic call emits one edge")
+			require.Len(t, generic, 1,
+				"explicit type arguments must not cost the call edge")
+			assert.Equal(t, plain[0].To, generic[0].To,
+				"both spellings name the same callee")
+			assert.Equal(t, plain[0].Meta["receiver_type"], generic[0].Meta["receiver_type"],
+				"explicit type arguments must not cost the receiver stamp")
+		})
+	}
+}

--- a/internal/parser/languages/csharp_generic_decl_fnvalue_test.go
+++ b/internal/parser/languages/csharp_generic_decl_fnvalue_test.go
@@ -1,0 +1,82 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Issue #534, second symptom: the reporter saw an edge into the extension
+// set anchored at an overload's DECLARATION line rather than any call
+// site.
+//
+// Same root cause as the dropped call edges — an identifier followed by
+// `<`. The function-as-value capture treats a following `(` as proof that
+// an identifier is a callee rather than a value use, and relies on that
+// to skip a declaration's own name. A generic declaration
+// (`AddFooDecorator<TInterface, TImpl>(`) puts `<` there instead, so the
+// method's own name was captured as a function reference and landed a
+// placeholder edge stamped at the declaration line.
+//
+// The `(` heuristic cannot be widened to `<` — in JavaScript and
+// TypeScript `f < g` is a comparison — so the fix reads the tree: an
+// identifier that IS a callable declaration's name field is a
+// declaration, whatever byte follows it.
+func TestCSharpExtractor_GenericDeclNameIsNotFnValue(t *testing.T) {
+	src := []byte(`using System;
+
+namespace Lib.Extensions
+{
+    public interface IServiceCollection { }
+    public class DecoratorOptions { }
+
+    public static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection AddFooDecorator<TInterface, TImpl>(
+            this IServiceCollection services)
+            where TInterface : class
+            where TImpl : class, TInterface
+        {
+            return services;
+        }
+
+        public static IServiceCollection AddFooDecorator<TInterface, TImpl>(
+            this IServiceCollection services,
+            Action<DecoratorOptions> configure)
+            where TInterface : class
+            where TImpl : class, TInterface
+        {
+            return services;
+        }
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("Ext.cs", src)
+	require.NoError(t, err)
+
+	// Declaration lines, 1-based: overload A at 10, overload B at 18.
+	declLines := map[int]bool{10: true, 18: true}
+	for _, ed := range result.Edges {
+		if ed.Kind != graph.EdgeReferences {
+			continue
+		}
+		assert.False(t, declLines[ed.Line],
+			"a generic method's own declaration is not a reference to it: %s -> %s at line %d",
+			ed.From, ed.To, ed.Line)
+	}
+
+	// The non-generic control has always been excluded by the `(` rule;
+	// assert the generic spelling now matches it exactly.
+	fnValue := 0
+	for _, ed := range result.Edges {
+		if ed.Kind == graph.EdgeReferences && ed.Meta != nil && ed.Meta["via"] != nil {
+			fnValue++
+		}
+	}
+	assert.Zero(t, fnValue,
+		"no function-as-value candidate exists in a file that only declares methods")
+}

--- a/internal/parser/languages/csharp_overload_evidence_test.go
+++ b/internal/parser/languages/csharp_overload_evidence_test.go
@@ -1,0 +1,173 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Overload evidence: the counts a call site spells and the arity a
+// declaration accepts. Together they are what lets the resolver pick one
+// member out of a same-name set instead of refusing the whole set.
+
+// The counts that let the resolver split an overload set ride the call
+// edge: how many arguments it passes and how many type arguments it
+// spells. A call with no explicit type arguments must stamp none — C#
+// infers them there, so a count would be an invention.
+func TestCSharpExtractor_CallStampsApplicabilityCounts(t *testing.T) {
+	src := []byte(`namespace App {
+    public class Registry {
+        public T Resolve<T>() { return default(T); }
+    }
+    public class Runner {
+        public void Explicit(Registry r) { r.Resolve<string>(); }
+        public void TwoArgs(Registry r) { r.Save("a", 1); }
+        public void Inferred(Registry r) { r.Save(1); }
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("App.cs", src)
+	require.NoError(t, err)
+
+	explicit := callEdgesFrom(result.Edges, "App.cs::Runner.Explicit", "Resolve")
+	require.Len(t, explicit, 1)
+	assert.Equal(t, 0, explicit[0].Meta["arg_count"])
+	assert.Equal(t, 1, explicit[0].Meta["type_arg_count"])
+
+	two := callEdgesFrom(result.Edges, "App.cs::Runner.TwoArgs", "Save")
+	require.Len(t, two, 1)
+	assert.Equal(t, 2, two[0].Meta["arg_count"])
+	assert.NotContains(t, two[0].Meta, "type_arg_count",
+		"no explicit type arguments means no type-arity evidence")
+
+	inferred := callEdgesFrom(result.Edges, "App.cs::Runner.Inferred", "Save")
+	require.Len(t, inferred, 1)
+	assert.Equal(t, 1, inferred[0].Meta["arg_count"])
+}
+
+// The type-argument count is recorded for every MEMBER call shape, not
+// just the simplest one — receiver-qualified, null-conditional, this-
+// and base-qualified generic calls are all equally narrowable.
+//
+// A receiverless call is deliberately excluded: no consumer resolves one
+// through the extension binder, and the scope rules that do bind it never
+// consult arity, so stamping it would be dead weight on every C# call
+// edge in the graph.
+func TestCSharpExtractor_TypeArgCountAcrossCallShapes(t *testing.T) {
+	src := []byte(`namespace App {
+    public interface IBox { }
+    public class Registry { public T Resolve<T>() { return default(T); } }
+    public class Base { public virtual T Make<T>() { return default(T); } }
+
+    public class Runner : Base {
+        public void ViaLocal() { Registry r = new Registry(); r.Resolve<IBox>(); }
+        public void ViaConditional(Registry r) { r?.Resolve<IBox>(); }
+        public void ViaThis() { this.Helper<IBox>(); }
+        public override T Make<T>() { return base.Make<T>(); }
+        public void Bare() { Helper<IBox>(); }
+        public T Helper<T>() { return default(T); }
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("App.cs", src)
+	require.NoError(t, err)
+
+	for _, row := range []struct{ caller, method string }{
+		{"ViaLocal", "Resolve"},
+		{"ViaConditional", "Resolve"},
+		{"ViaThis", "Helper"},
+		{"Make", "Make"},
+	} {
+		edges := callEdgesFrom(result.Edges, "App.cs::Runner."+row.caller, row.method)
+		require.Len(t, edges, 1, "%s emits one %s call", row.caller, row.method)
+		assert.Equal(t, 1, edges[0].Meta["type_arg_count"],
+			"%s spells one type argument", row.caller)
+	}
+
+	bare := callEdgesFrom(result.Edges, "App.cs::Runner.Bare", "Helper")
+	require.Len(t, bare, 1, "the receiverless call still emits its edge")
+	assert.NotContains(t, bare[0].Meta, "type_arg_count",
+		"a receiverless call has no extension binder to narrow, so it carries no stamp")
+	assert.NotContains(t, bare[0].Meta, "arg_count")
+}
+
+// The declaration side of the same evidence. `param_required` is stamped
+// only when it differs from the total, and `param_variadic` only when a
+// trailing `params` array lifts the upper bound.
+func TestCSharpExtractor_MethodStampsParamArity(t *testing.T) {
+	src := []byte(`namespace App {
+    public class Opts { }
+    public static class Ext {
+        public static void Fixed(this string s, int a, int b) { }
+        public static void Optional(this string s, int a, int b = 2) { }
+        public static void Variadic(this string s, params object[] rest) { }
+        public static void Nullary() { }
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("Ext.cs", src)
+	require.NoError(t, err)
+
+	byID := map[string]*graph.Node{}
+	for _, n := range result.Nodes {
+		byID[n.ID] = n
+	}
+
+	fixed := byID["Ext.cs::Ext.Fixed"]
+	require.NotNil(t, fixed)
+	assert.Equal(t, 3, fixed.Meta["param_count"])
+	assert.NotContains(t, fixed.Meta, "param_required",
+		"every parameter is required — the count already says so")
+
+	opt := byID["Ext.cs::Ext.Optional"]
+	require.NotNil(t, opt)
+	assert.Equal(t, 3, opt.Meta["param_count"])
+	assert.Equal(t, 2, opt.Meta["param_required"], "a defaulted parameter is omissible")
+
+	// The vendored grammar does not resolve a `params` entry into a
+	// parameter node — it flattens the type and name into loose siblings
+	// of the list. Counting what survives would claim one parameter for a
+	// two-parameter method, so an unreadable list must yield NO stamp:
+	// the resolver then treats the method as universally applicable
+	// instead of excluding it from argument counts it really accepts.
+	vari := byID["Ext.cs::Ext.Variadic"]
+	require.NotNil(t, vari)
+	assert.NotContains(t, vari.Meta, "param_count",
+		"a parameter list the grammar cannot fully structure yields no arity evidence")
+
+	nullary := byID["Ext.cs::Ext.Nullary"]
+	require.NotNil(t, nullary)
+	assert.Equal(t, 0, nullary.Meta["param_count"])
+}
+
+// A discard parameter is a real positional slot. Skipping its node while
+// also skipping its position renumbered every parameter after it, so
+// `name` in `Foo(int _, string name)` reported position 0 — the slot the
+// discard occupies.
+func TestCSharpExtractor_DiscardParamKeepsPositions(t *testing.T) {
+	src := []byte(`namespace App {
+    public class Handler {
+        public void Handle(int _, string name, int count) { }
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("Handler.cs", src)
+	require.NoError(t, err)
+
+	pos := map[string]any{}
+	for _, n := range result.Nodes {
+		if n.Kind == graph.KindParam {
+			pos[n.Name] = n.Meta["position"]
+		}
+	}
+	assert.Equal(t, 1, pos["name"], "name follows the discard in slot 1")
+	assert.Equal(t, 2, pos["count"])
+	assert.NotContains(t, pos, "_", "a discard names no value, so it emits no node")
+}

--- a/internal/parser/languages/fn_ref_spec.go
+++ b/internal/parser/languages/fn_ref_spec.go
@@ -224,6 +224,33 @@ func fnRefStartsCall(spec fnRefSpec, n *sitter.Node, src []byte) bool {
 	return byteAfterIdentStartsCall(src, int(n.EndByte()))
 }
 
+// fnRefIsCallableDeclName reports whether n is the NAME of a callable
+// declaration rather than a use of one.
+//
+// The byte heuristic leans on the `(` that follows a declaration's name to
+// exclude the declaration itself, and that holds only while nothing sits
+// between them. A generic declaration puts the type parameters there —
+// `AddFooDecorator<TInterface, TImpl>(` — so the method's own name read as a
+// function-as-value and landed a placeholder reference edge stamped at its
+// declaration line, which the gate then bound to a sibling overload.
+//
+// Widening the byte rule to `<` is not available: `f < g` is a comparison in
+// JavaScript, TypeScript and every C-family language the capture serves. The
+// tree answers exactly, and for every language at once — a node that fills its
+// parent's `name` field where that parent also declares `parameters` is a
+// declaration however it is spelled.
+func fnRefIsCallableDeclName(n *sitter.Node) bool {
+	p := n.Parent()
+	if p == nil {
+		return false
+	}
+	name := p.ChildByFieldName("name")
+	if name == nil || name.StartByte() != n.StartByte() || name.EndByte() != n.EndByte() {
+		return false
+	}
+	return p.ChildByFieldName("parameters") != nil
+}
+
 // fnRefForm reports the wrapper form (address_of / eta) a captured node sits in
 // per the spec's unwrapForms, or "" for a plain value position.
 func (s fnRefSpec) fnRefForm(n *sitter.Node) string {

--- a/internal/parser/languages/fn_value_capture.go
+++ b/internal/parser/languages/fn_value_capture.go
@@ -177,6 +177,9 @@ func captureFnValueCandidates(result *parser.ExtractionResult, root *sitter.Node
 		if fnRefStartsCall(spec, n, src) {
 			return // callee of a call (incl. tagged template), not a value use
 		}
+		if fnRefIsCallableDeclName(n) {
+			return // the declaration of the function, not a use of it
+		}
 		line := int(n.StartPoint().Row) + 1
 		fromID := findEnclosingFunc(funcRanges, line)
 		if fromID == "" {

--- a/internal/resolver/csharp_applicability.go
+++ b/internal/resolver/csharp_applicability.go
@@ -97,13 +97,18 @@ func csharpMethodTypeParamCount(c *graph.Node) int {
 }
 
 // csharpExtensionAcceptsArgCount reports whether a candidate extension
-// method can accept the call's argument count written in EXTENSION FORM
-// (`x.Foo(a)`), where the receiver supplies the `this` parameter.
+// method can accept the call's argument count.
 //
 // The window is [required, count], widened to [required, +inf) by a
-// trailing `params` array. A candidate with no parameter stamp — an
-// older graph, or a declaration whose parameter list the grammar did not
-// expose — accepts anything.
+// trailing `params` array. In EXTENSION form (`x.Foo(a)`) the receiver
+// fills the `this` slot, so both ends drop by one; in STATIC form
+// (`Ext.Foo(x, a)`) the argument list covers every parameter and the
+// window is used as declared. Reading the wrong form would exclude an
+// overload for the very count it accepts, and — worse — could leave a
+// sibling as the sole survivor.
+//
+// A candidate with no parameter stamp — an older graph, or a declaration
+// whose parameter list the grammar did not expose — accepts anything.
 func csharpExtensionAcceptsArgCount(e *graph.Edge, c *graph.Node) bool {
 	argc, ok := metaIntValue(e.Meta["arg_count"])
 	if !ok || c == nil || c.Meta == nil {
@@ -120,15 +125,33 @@ func csharpExtensionAcceptsArgCount(e *graph.Edge, c *graph.Node) bool {
 	if r, rok := metaIntValue(c.Meta["param_required"]); rok {
 		required = r
 	}
-	// The receiver fills the `this` slot; the remaining parameters are
-	// what the argument list has to cover.
-	count--
-	required--
-	if required < 0 {
-		required = 0
+	if !csharpCallIsStaticForm(e, c) {
+		count--
+		required--
+		if required < 0 {
+			required = 0
+		}
 	}
 	if variadic, _ := c.Meta["param_variadic"].(bool); variadic {
 		return argc >= required
 	}
 	return argc >= required && argc <= count
+}
+
+// csharpCallIsStaticForm reports whether the call invokes the extension
+// through its declaring class (`BagExt.Add(bag)`) rather than on a
+// receiver value (`bag.Add()`).
+//
+// The extractor stamps receiver_name only for a bare receiver that no
+// local, parameter or builtin in scope explains — so a receiver_name
+// equal to the candidate's own declaring class is a type reference, not
+// a shadowing variable. Any receiver the extractor DID type is a value
+// by construction, and carries no receiver_name at all.
+func csharpCallIsStaticForm(e *graph.Edge, c *graph.Node) bool {
+	recv, _ := e.Meta["receiver_name"].(string)
+	if recv == "" {
+		return false
+	}
+	owner, _ := c.Meta["receiver"].(string)
+	return owner != "" && recv == owner
 }

--- a/internal/resolver/csharp_applicability.go
+++ b/internal/resolver/csharp_applicability.go
@@ -1,0 +1,134 @@
+package resolver
+
+import (
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// C# applicability narrowing — the arity half of overload resolution.
+//
+// Receiver-type evidence separates extensions that extend DIFFERENT
+// types. It says nothing about a set that extends the SAME type, which
+// is the dominant .NET shape: `AddFoo(this IServiceCollection)` beside
+// `AddFoo(this IServiceCollection, Action<Options>)`. Namespace
+// visibility cannot break that tie either — sibling overloads almost
+// always share a namespace — so the binder's ambiguity refusal used to
+// drop every such call, leaving the declaration looking uncalled.
+//
+// C# resolves those by APPLICABILITY: a candidate is in the running only
+// if the call's argument count fits its parameter list and its type-
+// parameter count matches any explicitly spelled type arguments. Both
+// are exact, spec-grounded rules — not heuristics — so applying them
+// before the visibility tie-break both matches §12.8.10.3 (each scope
+// considers only APPLICABLE candidates) and turns the common overload
+// pair into a single answer.
+//
+// Every function here narrows only. Missing evidence, an unparseable
+// stamp, or a filter that would empty the set all return the input
+// untouched: this can turn a refusal into a bind, never a bind into a
+// different bind.
+//
+// The arity window matches ResolveCppOverload's cppArityCompatible — the
+// same [required, declared] range widened by a variadic tail. The two
+// stay separate because C++ ranks on parameter TYPES as well, and C#
+// alone has to discount the receiver's `this` slot.
+
+// csharpNarrowByApplicability filters a same-name C# candidate set to the
+// members the call site could actually invoke.
+func csharpNarrowByApplicability(e *graph.Edge, cands []*graph.Node) []*graph.Node {
+	if len(cands) < 2 || e == nil || e.Meta == nil {
+		return cands
+	}
+	out := csharpKeepIf(cands, func(c *graph.Node) bool {
+		return csharpAcceptsTypeArgCount(e, c)
+	})
+	return csharpKeepIf(out, func(c *graph.Node) bool {
+		return csharpExtensionAcceptsArgCount(e, c)
+	})
+}
+
+// csharpKeepIf applies one narrowing predicate. An empty result is
+// discarded — a rule that excludes everything is evidence the rule
+// misread the code, not evidence the call is unresolvable.
+func csharpKeepIf(cands []*graph.Node, keep func(*graph.Node) bool) []*graph.Node {
+	if len(cands) < 2 {
+		return cands
+	}
+	out := make([]*graph.Node, 0, len(cands))
+	for _, c := range cands {
+		if c != nil && keep(c) {
+			out = append(out, c)
+		}
+	}
+	if len(out) == 0 || len(out) == len(cands) {
+		return cands
+	}
+	return out
+}
+
+// csharpAcceptsTypeArgCount reports whether a candidate's own generic
+// arity matches the type arguments the call spells explicitly. A call
+// with no explicit type arguments proves nothing (C# infers them), and a
+// candidate with no type-parameter stamp is treated as non-generic.
+func csharpAcceptsTypeArgCount(e *graph.Edge, c *graph.Node) bool {
+	want, ok := metaIntValue(e.Meta["type_arg_count"])
+	if !ok {
+		return true
+	}
+	return csharpMethodTypeParamCount(c) == want
+}
+
+// csharpMethodTypeParamCount counts a method's own type parameters from
+// the extractor's comma-joined stamp.
+func csharpMethodTypeParamCount(c *graph.Node) int {
+	if c == nil || c.Meta == nil {
+		return 0
+	}
+	s, _ := c.Meta["method_type_params"].(string)
+	if s == "" {
+		return 0
+	}
+	n := 1
+	for _, r := range s {
+		if r == ',' {
+			n++
+		}
+	}
+	return n
+}
+
+// csharpExtensionAcceptsArgCount reports whether a candidate extension
+// method can accept the call's argument count written in EXTENSION FORM
+// (`x.Foo(a)`), where the receiver supplies the `this` parameter.
+//
+// The window is [required, count], widened to [required, +inf) by a
+// trailing `params` array. A candidate with no parameter stamp — an
+// older graph, or a declaration whose parameter list the grammar did not
+// expose — accepts anything.
+func csharpExtensionAcceptsArgCount(e *graph.Edge, c *graph.Node) bool {
+	argc, ok := metaIntValue(e.Meta["arg_count"])
+	if !ok || c == nil || c.Meta == nil {
+		return true
+	}
+	count, ok := metaIntValue(c.Meta["param_count"])
+	if !ok || count == 0 {
+		// An extension method always declares at least the `this`
+		// parameter, so a zero here means "no evidence", not "takes
+		// nothing".
+		return true
+	}
+	required := count
+	if r, rok := metaIntValue(c.Meta["param_required"]); rok {
+		required = r
+	}
+	// The receiver fills the `this` slot; the remaining parameters are
+	// what the argument list has to cover.
+	count--
+	required--
+	if required < 0 {
+		required = 0
+	}
+	if variadic, _ := c.Meta["param_variadic"].(bool); variadic {
+		return argc >= required
+	}
+	return argc >= required && argc <= count
+}

--- a/internal/resolver/csharp_extension.go
+++ b/internal/resolver/csharp_extension.go
@@ -195,6 +195,11 @@ func (r *Resolver) tryBindCSharpExtension(e *graph.Edge, methodName, receiverTyp
 				return false
 			}
 		}
+		// Applicability before visibility: C# considers only the
+		// candidates a call site could actually invoke at each scope
+		// level, and sibling overloads of one method group share a
+		// namespace, so visibility alone can never split them.
+		typed = csharpNarrowByApplicability(e, typed)
 		if len(typed) == 1 {
 			if !r.csharpExtensionVisible(e, e.FilePath, typed[0]) {
 				// An extension the call site can neither enclose nor
@@ -261,14 +266,28 @@ func (r *Resolver) bindCSharpExtensionUntyped(e *graph.Edge, pool []*graph.Node,
 	if len(pool) == 0 {
 		return false
 	}
+	// Applicability is a hard rule, so it runs ahead of the visibility
+	// tier — but it must not SMUGGLE a candidate past it. The
+	// pool-unique rule below deliberately waives visibility (partial
+	// using data is common, and a name with exactly one extension in the
+	// whole repo has nothing to confuse it with); a pool applicability
+	// just narrowed is a different thing entirely — visibility is
+	// precisely what would have ranked the candidates it removed, so its
+	// veto still has to hold.
+	applicable := csharpNarrowByApplicability(e, pool)
+	narrowed := len(applicable) < len(pool)
+	pool = applicable
 	if vis := r.narrowCSharpExtensionsByVisibility(e, pool); len(vis) == 1 {
 		pool = vis
 	}
-	if len(pool) == 1 && !csharpHasCompetingMethod(candidates) {
-		r.bindCSharpExtension(e, pool[0], 0.75, stats)
-		return true
+	if len(pool) != 1 || csharpHasCompetingMethod(candidates) {
+		return false
 	}
-	return false
+	if narrowed && !r.csharpExtensionVisible(e, e.FilePath, pool[0]) {
+		return false
+	}
+	r.bindCSharpExtension(e, pool[0], 0.75, stats)
+	return true
 }
 
 // csharpExtensionReachableMatches walks the receiver type's declared

--- a/internal/resolver/csharp_extension_overload_test.go
+++ b/internal/resolver/csharp_extension_overload_test.go
@@ -1,0 +1,307 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// namedCallTarget returns the target of the single EdgeCalls out of
+// fromID whose callee is named method — resolved node or unresolved stub.
+func namedCallTarget(t *testing.T, g graph.Store, fromID, method string) string {
+	t.Helper()
+	var hits []string
+	for _, e := range g.GetOutEdges(fromID) {
+		if e.Kind != graph.EdgeCalls {
+			continue
+		}
+		if graph.IsUnresolvedTarget(e.To) {
+			if n := graph.UnresolvedName(e.To); n == method || n == "*."+method {
+				hits = append(hits, e.To)
+			}
+			continue
+		}
+		if n := g.GetNode(e.To); n != nil && n.Name == method {
+			hits = append(hits, e.To)
+		}
+	}
+	require.Len(t, hits, 1, "expected exactly one %s call out of %s", method, fromID)
+	return hits[0]
+}
+
+// Issue #534. The reporter's fixture, verbatim in shape: one static class
+// declares two `AddFooDecorator` overloads over `IServiceCollection`, and
+// three call sites invoke the no-argument one — from a different project,
+// from the same namespace in a different file, and from a different
+// namespace in the same project.
+//
+// Two independent defects made every one of them vanish. The call-site
+// query required an `identifier`, so `services.AddFooDecorator<I, T>()`
+// (a `generic_name`) emitted no edge at all; and once it did, the two
+// same-receiver overloads shared a namespace, so neither type evidence
+// nor visibility could split them and the binder refused. `query callers`
+// on the extension answered `total_edges: 0` with the `likely_unused`
+// caveat — a resolution failure wearing dead code's clothes.
+func TestResolveCSharpExtension_CrossFileGenericOverload(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Lib/Extensions/ServiceCollectionExtensions.cs": `using System;
+
+namespace Lib.Extensions
+{
+    public interface IServiceCollection { }
+
+    public class DecoratorOptions { public int RetryCount { get; set; } }
+
+    public static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection AddFooDecorator<TInterface, TImpl>(
+            this IServiceCollection services)
+            where TInterface : class
+            where TImpl : class, TInterface
+        {
+            services.AddFooDecoratorInfrastructure();
+            return services;
+        }
+
+        public static IServiceCollection AddFooDecorator<TInterface, TImpl>(
+            this IServiceCollection services,
+            Action<DecoratorOptions> configure)
+            where TInterface : class
+            where TImpl : class, TInterface
+        {
+            services.AddFooDecoratorInfrastructure();
+            return services;
+        }
+
+        public static IServiceCollection AddFooDecoratorInfrastructure(
+            this IServiceCollection services) => services;
+    }
+}`,
+		// Case 1 — different project, different namespace, `using` import.
+		"Consumer/Extensions/ConsumerRegistration.cs": `using Lib.Extensions;
+
+namespace Consumer.Extensions
+{
+    public interface IAlpha { }
+    public class Alpha : IAlpha { }
+
+    public static class ConsumerRegistration
+    {
+        public static IServiceCollection AddConsumerServices(this IServiceCollection services)
+        {
+            services.AddFooDecorator<IAlpha, Alpha>();
+            return services;
+        }
+    }
+}`,
+		// Case 2 — same project, SAME namespace, different file: no import
+		// indirection at all, so nothing but the overload tie can explain
+		// a miss.
+		"Lib/Extensions/SameNamespaceCaller.cs": `namespace Lib.Extensions
+{
+    public interface IDelta { }
+    public class Delta : IDelta { }
+
+    public static class SameNamespaceCaller
+    {
+        public static IServiceCollection Register(this IServiceCollection services)
+        {
+            services.AddFooDecorator<IDelta, Delta>();
+            return services;
+        }
+    }
+}`,
+		// Case 3 — same project, different namespace, `using` import.
+		"Lib/Other/DifferentNamespaceCaller.cs": `using Lib.Extensions;
+
+namespace Lib.Other
+{
+    public interface IEcho { }
+    public class Echo : IEcho { }
+
+    public static class DifferentNamespaceCaller
+    {
+        public static IServiceCollection Register(this IServiceCollection services)
+        {
+            services.AddFooDecorator<IEcho, Echo>();
+            return services;
+        }
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	const decl = "Lib/Extensions/ServiceCollectionExtensions.cs::ServiceCollectionExtensions.AddFooDecorator"
+	for _, caller := range []string{
+		"Consumer/Extensions/ConsumerRegistration.cs::ConsumerRegistration.AddConsumerServices",
+		"Lib/Extensions/SameNamespaceCaller.cs::SameNamespaceCaller.Register",
+		"Lib/Other/DifferentNamespaceCaller.cs::DifferentNamespaceCaller.Register",
+	} {
+		assert.Equal(t, decl, namedCallTarget(t, g, caller, "AddFooDecorator"),
+			"%s passes no argument, so the one-parameter overload is the only applicable one", caller)
+	}
+
+	// The intra-file control the reporter used still binds, and the
+	// extension is no longer reported as uncalled.
+	callers := 0
+	for _, e := range g.GetInEdges(decl) {
+		if e.Kind == graph.EdgeCalls {
+			callers++
+		}
+	}
+	assert.Equal(t, 3, callers, "all three call sites are incoming edges on the declaration")
+}
+
+// Argument count is decisive both ways: the same call name with one
+// argument must land on the two-parameter overload.
+func TestResolveCSharpExtension_ArgCountPicksOverload(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Ext.cs": `using System;
+namespace Lib {
+    public interface IBag { }
+    public class Opts { }
+    public static class BagExt {
+        public static IBag Add(this IBag bag) { return bag; }
+        public static IBag Add(this IBag bag, Action<Opts> configure) { return bag; }
+    }
+}`,
+		"Caller.cs": `using Lib;
+namespace App {
+    public class Runner {
+        public void Bare(IBag bag) { bag.Add(); }
+        public void Configured(IBag bag) { bag.Add(x => { }); }
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	assert.Equal(t, "Ext.cs::BagExt.Add",
+		namedCallTarget(t, g, "Caller.cs::Runner.Bare", "Add"),
+		"no arguments fits only the one-parameter overload")
+	assert.Equal(t, "Ext.cs::BagExt.Add_L7",
+		namedCallTarget(t, g, "Caller.cs::Runner.Configured", "Add"),
+		"one argument fits only the two-parameter overload")
+}
+
+// A defaulted parameter widens an overload's acceptable arity, so a
+// zero-argument call fits BOTH members here. Narrowing must not
+// manufacture a winner — the refusal is the correct answer, and a
+// missing edge beats a wrong one.
+func TestResolveCSharpExtension_OptionalParamKeepsAmbiguity(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Ext.cs": `namespace Lib {
+    public interface IBag { }
+    public static class BagExt {
+        public static IBag Tag(this IBag bag) { return bag; }
+        public static IBag Tag(this IBag bag, int depth = 0) { return bag; }
+    }
+}`,
+		"Caller.cs": `using Lib;
+namespace App {
+    public class Runner {
+        public void Run(IBag bag) { bag.Tag(); }
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	target := namedCallTarget(t, g, "Caller.cs::Runner.Run", "Tag")
+	assert.True(t, graph.IsUnresolvedTarget(target),
+		"both overloads accept zero arguments — refusing beats guessing, got %q", target)
+}
+
+// A trailing `params` array lifts the upper bound: `Log(this IBag, params object[])`
+// accepts any argument count, while the fixed sibling accepts exactly one.
+func TestResolveCSharpExtension_VariadicWidensArity(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Ext.cs": `namespace Lib {
+    public interface IBag { }
+    public static class BagExt {
+        public static IBag Log(this IBag bag, string only) { return bag; }
+        public static IBag Log(this IBag bag, params object[] rest) { return bag; }
+    }
+}`,
+		"Caller.cs": `using Lib;
+namespace App {
+    public class Runner {
+        public void Many(IBag bag) { bag.Log("a", "b", "c"); }
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	assert.Equal(t, "Ext.cs::BagExt.Log_L5",
+		namedCallTarget(t, g, "Caller.cs::Runner.Many", "Log"),
+		"three arguments overflow the fixed overload and only the params one accepts them")
+}
+
+// Explicit type arguments are their own applicability rule: a call
+// spelling two type arguments cannot invoke a one-type-parameter
+// overload, even when both accept the same argument count.
+func TestResolveCSharpExtension_TypeArgCountPicksOverload(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Ext.cs": `namespace Lib {
+    public interface IBag { }
+    public static class BagExt {
+        public static IBag Map<TOut>(this IBag bag) { return bag; }
+        public static IBag Map<TIn, TOut>(this IBag bag) { return bag; }
+    }
+}`,
+		"Caller.cs": `using Lib;
+namespace App {
+    public class Runner {
+        public void One(IBag bag) { bag.Map<string>(); }
+        public void Two(IBag bag) { bag.Map<int, string>(); }
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	assert.Equal(t, "Ext.cs::BagExt.Map",
+		namedCallTarget(t, g, "Caller.cs::Runner.One", "Map"),
+		"one type argument fits only the one-type-parameter overload")
+	assert.Equal(t, "Ext.cs::BagExt.Map_L5",
+		namedCallTarget(t, g, "Caller.cs::Runner.Two", "Map"),
+		"two type arguments fit only the two-type-parameter overload")
+}
+
+// Applicability narrows; it never overrides. Here arity is decisive and
+// points at a namespace the call site can neither enclose nor import: the
+// one-argument call fits only the overload in `Vendor.Internal`. Binding
+// it would be exactly the misattribution the visibility veto exists to
+// stop, so the narrowed-to-one set must still be refused. Applicability
+// running FIRST must not turn the veto into a tiebreak that never runs.
+func TestResolveCSharpExtension_ArityNeverBeatsVisibility(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Lib.cs": `namespace Lib {
+    public interface IBag { }
+}`,
+		"Visible.cs": `using Lib;
+namespace Lib.Ext {
+    public static class VisibleExt {
+        public static void Ping(this IBag bag) { }
+    }
+}`,
+		"Hidden.cs": `using Lib;
+namespace Vendor.Internal {
+    public static class HiddenExt {
+        public static void Ping(this IBag bag, int depth) { }
+    }
+}`,
+		"Caller.cs": `using Lib;
+using Lib.Ext;
+namespace App {
+    public class Runner {
+        public void Run(IBag bag) { bag.Ping(7); }
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	target := namedCallTarget(t, g, "Caller.cs::Runner.Run", "Ping")
+	assert.True(t, graph.IsUnresolvedTarget(target),
+		"the only arity-applicable overload lives in an unimported namespace, got %q", target)
+}

--- a/internal/resolver/csharp_extension_overload_test.go
+++ b/internal/resolver/csharp_extension_overload_test.go
@@ -305,3 +305,47 @@ namespace App {
 	assert.True(t, graph.IsUnresolvedTarget(target),
 		"the only arity-applicable overload lives in an unimported namespace, got %q", target)
 }
+
+// An extension method can also be invoked through its declaring class,
+// where the argument list covers EVERY parameter because the first
+// argument is what fills the `this` slot. Reading such a call as
+// extension form shifts the whole arity window by one, which does not
+// merely lose the bind — it can leave the wrong sibling as the sole
+// survivor and bind that instead.
+//
+// The extractor stamps a bare receiver's spelling only when no local,
+// parameter or builtin in scope explains it, so a receiver naming the
+// candidate's own declaring class is a type reference rather than a
+// shadowing variable.
+func TestResolveCSharpExtension_StaticFormCountsTheReceiverArgument(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Ext.cs": `using System;
+namespace Lib {
+    public interface IBag { }
+    public class Opts { }
+    public static class BagExt {
+        public static IBag Add(this IBag bag) { return bag; }
+        public static IBag Add(this IBag bag, Action<Opts> configure) { return bag; }
+    }
+}`,
+		"Caller.cs": `using Lib;
+namespace App {
+    public class Runner {
+        public void Extension(IBag bag) { bag.Add(); }
+        public void StaticForm(IBag bag) { BagExt.Add(bag); }
+        public void StaticFormTwo(IBag bag) { BagExt.Add(bag, x => { }); }
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	assert.Equal(t, "Ext.cs::BagExt.Add",
+		namedCallTarget(t, g, "Caller.cs::Runner.Extension", "Add"),
+		"extension form: the receiver fills the this slot, so zero arguments is the one-parameter overload")
+	assert.Equal(t, "Ext.cs::BagExt.Add",
+		namedCallTarget(t, g, "Caller.cs::Runner.StaticForm", "Add"),
+		"static form: the single argument IS the receiver, so this is still the one-parameter overload")
+	assert.Equal(t, "Ext.cs::BagExt.Add_L7",
+		namedCallTarget(t, g, "Caller.cs::Runner.StaticFormTwo", "Add"),
+		"static form with a real second argument is the two-parameter overload")
+}


### PR DESCRIPTION
Fixes #534.

## What the report got right, and what it turned out to be

The reporter's observation is exact — every cross-file call to their extension method produced `total_edges: 0` — but the cause is not cross-file resolution. Running their fixture through the real extractor shows the three failing call sites never reach the resolver at all:

```
=== EDGES BEFORE RESOLVE ===
ServiceCollectionExtensions.AddFooDecorator_L20 -> unresolved::*.AddFooDecoratorInfrastructure  line=26
ServiceCollectionExtensions.AddFooDecorator     -> unresolved::*.AddFooDecoratorInfrastructure  line=16
                                              (nothing from the three callers)
```

The variable is not the file. It is the **type arguments**. Their intra-file control calls `services.AddFooDecoratorInfrastructure()`; all three failing sites call `services.AddFooDecorator<I, T>()`. Two independent defects sit behind that, and both had to be fixed to close the issue.

## 1. Generic invocations emitted no call edge at all

The C# call-site query pinned every invoked name to `(identifier)`. A call spelling explicit type arguments parses that name as a `generic_name`, so it matched **no pattern** — no edge, not even an unresolved stub. The member-access patterns carried the same constraint, so the call earned no reference edge either, which is why `query usages` also reported zero.

This is not a corner case. `GetRequiredService<T>()`, `AddSingleton<TI, TImpl>()`, `Deserialize<T>()`, `Map<TDest>()` — generic invocation is the dominant call shape in .NET, so a large fraction of every indexed C# repo was invisible. It is also a recurring class here: `rust.go` carries a note that the turbofish version cost **5,301 unrecorded call sites**.

Each affected pattern now accepts either spelling and captures the inner identifier, so the callee name stays bare and every downstream tier is unchanged.

## 2. Same-name extension overloads could never be bound

With edges flowing, the fixture still resolved to nothing. Both `AddFooDecorator` overloads extend `IServiceCollection` and both live in `Lib.Extensions`, so neither the receiver-type tiers nor the namespace-visibility tie-break could separate them, and the binder's ambiguity refusal dropped all three sites. Overloaded extension methods over one interface is the standard .NET DI registration shape.

C# separates such a set by **applicability**, which is exact rather than heuristic: an overload is a candidate only if the call's argument count fits its parameter list and its type-parameter count matches any explicitly spelled type arguments. Neither fact was in the graph. Both are now recorded — argument and type-argument counts on the member-call edge, `param_count` / `param_required` / `param_variadic` on the method node — and the binder narrows on them before the visibility tie-break, matching §12.8.10.3, where each scope level considers only applicable candidates.

All three of the reporter's cases now bind to the one-parameter overload, and the intra-file control still binds.

### Static-form calls, and why they mattered

An extension can also be invoked through its declaring class — `BagExt.Add(bag)` — where the receiver is passed as the *first argument*, so the argument list has to cover every parameter. Comparing such a call against the extension-form window shifts it by one, and with a sibling overload present that does not merely lose the bind: it leaves the **wrong** candidate as the sole survivor, and narrowing then binds it. I hit this while reviewing my own patch, on a probe rather than a test.

The resolver had no way to tell the forms apart, so the extractor now stamps a bare receiver's spelling — but only in the one case nothing else explains it, after the local, parameter and builtin lookups have all missed. That restriction is what makes the signal trustworthy: reaching it means no value in scope carries the name, so a receiver equal to a candidate's declaring class is a type reference rather than a variable shadowing it. Beyond removing the misbinding, this also resolves static-form calls correctly, which previously stayed unresolved on any overloaded set.

### Narrowing only, and never past the visibility veto

Missing evidence, an unreadable stamp, or a filter that would empty the set all leave the candidates untouched, so this can turn a refusal into a bind but never a bind into a different one. Where it *does* narrow, the winner must still clear the visibility veto: the pool-unique rule waives visibility deliberately, but that waiver is scoped to sets applicability never touched, so an overload the call site cannot see is refused rather than promoted by arity. `ArityNeverBeatsVisibility` pins exactly this — I hit it as a real regression in an earlier draft of the patch.

## 3. The reporter's second note, same root cause

Their Note about an edge anchored at a *declaration* line rather than a call site is real, and it is the same `<` blind spot. The function-as-value capture treats a `(` after an identifier as proof the identifier is a callee, and relies on that to skip a declaration's own name. `AddFooDecorator<TInterface, TImpl>(` puts the type parameters where the `(` is looked for, so the method's own name was captured as a function reference at its declaration line, and the gate then bound it to the first same-name sibling — an edge between two overloads at a line where no call exists.

The byte rule cannot simply learn `<`: in JavaScript, TypeScript and every C-family language the capture serves, `f < g` is a comparison. The tree answers exactly and for all of them at once — a node filling its parent's `name` field where that parent also declares `parameters` is a declaration however it is spelled.

## Also fixed along the way

- **Existing indexes**: `extractorVersions["csharp"]` is bumped, so already-indexed `.cs` files re-extract instead of silently keeping the edge-less graph. Razor templates are salted with C# too, since they are extracted by the C# extractor.
- **Parameter positions**: a discard (`Foo(int _, string name)`) emits no param node but still occupies its slot; skipping the slot along with the node renumbered every later parameter, so `name` reported position 0.

## Two grammar traps the tests pin

- The vendored grammar does **not** resolve a `params object[] rest` entry into a `parameter` node — it flattens it into loose siblings. A naive count claims one parameter for a two-parameter method, which would exclude that overload from argument counts it really accepts. A parameter list that cannot be read in full now yields no evidence at all, leaving the method universally applicable.
- A defaulted parameter has no equals-value wrapper node, only a bare `=` token, so optional parameters were invisible to the obvious check.

## Verification

`go test ./internal/...` passes in full; `go test -race` on the three touched packages passes; `golangci-lint` reports 0 issues.

New coverage, all failing before the change:
- the reporter's four-file fixture, asserting all three cases bind and the declaration reports three incoming callers;
- each call shape (typed local, null-conditional, `this`-, `base`-qualified, receiverless) paired with and without type arguments, asserting identical behaviour — the property that was actually violated;
- argument count picking each overload in turn, an optional parameter correctly *keeping* the ambiguity, a `params` list widening it, type-argument count splitting `Map<T>` from `Map<TIn, TOut>`, and arity not overriding visibility;
- extension form and both static forms of an overloaded extension each landing on the right overload;
- a generic declaration minting no function-value reference at its own line.

## Not in this PR

The same class of blind spot is present in **`scala.go`, `golang.go`, `cpp.go` and `swift.go`** — verified by running each real extractor and comparing the plain and generic spellings of the same call, not by reading queries. Go has two distinct mechanisms behind it (`index_expression`, and `type_conversion_expression` when a single type argument meets exactly one value argument), and C++ additionally drops every `ns::`-qualified call. Filed separately rather than bundled here, since each needs its own grammar handling, version bump and fixtures.
