### PR TITLE
fix(parser): emit call edges for generic calls in Scala, Go, C++ and Swift

### DIFF
--- a/internal/indexer/extractor_version.go
+++ b/internal/indexer/extractor_version.go
@@ -34,6 +34,7 @@ var extractorVersions = map[string]int{
 	"php":    2,                                      // class/interface inheritance now emits typed structural edges
 	"csharp": 8,                                      // interface base lists emit extends edges (was: record positional property nodes)
 	"scala":  2,                                      // explicitly instantiated generic calls emit call edges
+	"go":     2,                                      // explicitly instantiated generic calls emit call edges
 }
 
 // extractorSaltExtLang maps a lower-case file extension to the language

--- a/internal/indexer/extractor_version.go
+++ b/internal/indexer/extractor_version.go
@@ -35,6 +35,7 @@ var extractorVersions = map[string]int{
 	"csharp": 8,                                      // interface base lists emit extends edges (was: record positional property nodes)
 	"scala":  2,                                      // explicitly instantiated generic calls emit call edges
 	"go":     2,                                      // explicitly instantiated generic calls emit call edges
+	"cpp":    2,                                      // templated and namespace-qualified calls emit call edges
 }
 
 // extractorSaltExtLang maps a lower-case file extension to the language

--- a/internal/indexer/extractor_version.go
+++ b/internal/indexer/extractor_version.go
@@ -33,6 +33,7 @@ var extractorVersions = map[string]int{
 	"c":      generatedParserProjectionPolicyVersion, // generated parser projection covers all strictly detected table sizes
 	"php":    2,                                      // class/interface inheritance now emits typed structural edges
 	"csharp": 8,                                      // interface base lists emit extends edges (was: record positional property nodes)
+	"scala":  2,                                      // explicitly instantiated generic calls emit call edges
 }
 
 // extractorSaltExtLang maps a lower-case file extension to the language

--- a/internal/indexer/extractor_version.go
+++ b/internal/indexer/extractor_version.go
@@ -36,6 +36,7 @@ var extractorVersions = map[string]int{
 	"scala":  2,                                      // explicitly instantiated generic calls emit call edges
 	"go":     2,                                      // explicitly instantiated generic calls emit call edges
 	"cpp":    2,                                      // templated and namespace-qualified calls emit call edges
+	"swift":  2,                                      // generic calls and ordinary member calls emit call edges
 }
 
 // extractorSaltExtLang maps a lower-case file extension to the language

--- a/internal/indexer/extractor_version_test.go
+++ b/internal/indexer/extractor_version_test.go
@@ -40,12 +40,21 @@ func TestStaleLangsDetection(t *testing.T) {
 			t.Errorf("bad json = %v, want nil", got)
 		}
 		// Against the live extractor versions, an unchanged baseline language
-		// is not stale.
-		if got := ExtractorVersionStaleLangs(`{"go":1}`); len(got) != 0 {
+		// is not stale. Java is the exemplar because its extractor has never
+		// been bumped — a language whose version this suite also asserts
+		// would make the check tautological.
+		if got := ExtractorVersionStaleLangs(`{"java":1}`); len(got) != 0 {
 			t.Errorf("stored at current = %v, want empty", got)
 		}
-		if got := ExtractorVersionStaleLangs(`{"go":1,"php":1}`); !reflect.DeepEqual(got, []string{"php"}) {
+		if got := ExtractorVersionStaleLangs(`{"java":1,"php":1}`); !reflect.DeepEqual(got, []string{"php"}) {
 			t.Errorf("stored PHP structural-edge version = %v, want [php]", got)
+		}
+		// A store extracted before the generic-call fix must re-extract:
+		// until then, every call spelling explicit type arguments is missing
+		// from its graph entirely, and no content change will trigger it.
+		if got := ExtractorVersionStaleLangs(`{"go":1,"scala":1,"cpp":1,"swift":1}`); !reflect.DeepEqual(
+			got, []string{"cpp", "go", "scala", "swift"}) {
+			t.Errorf("stored pre-generic-call version = %v, want all four", got)
 		}
 		// A store extracted before the C# usings-scope/builtin-receiver
 		// stamps must re-extract its .cs files on upgrade — the stamps

--- a/internal/parser/languages/cpp.go
+++ b/internal/parser/languages/cpp.go
@@ -74,6 +74,33 @@ const qCppAll = `
   (call_expression
     function: (field_expression
       field: (field_identifier) @callm.method)) @callm.expr
+
+  ; Explicitly instantiated template calls. foo<T>() wraps its callee in
+  ; a template_function, and obj.foo<T>() / ptr->foo<T>() wrap the member
+  ; in a template_method, so neither pattern above could match and every
+  ; templated call site emitted no edge at all.
+  (call_expression
+    function: (template_function
+      name: (identifier) @call.name)) @call.expr
+
+  (call_expression
+    function: (field_expression
+      field: (template_method
+        name: (field_identifier) @callm.method))) @callm.expr
+
+  ; Namespace-qualified free calls. std::move(x), ns::helper() and their
+  ; templated forms parse the callee as a qualified_identifier, which the
+  ; bare-identifier pattern cannot match — so every :: call was dropped
+  ; too, generics or not. Rust already carries the equivalent
+  ; scoped_identifier pattern; the trailing name is what the call names.
+  (call_expression
+    function: (qualified_identifier
+      name: (identifier) @call.name)) @call.expr
+
+  (call_expression
+    function: (qualified_identifier
+      name: (template_function
+        name: (identifier) @call.name))) @call.expr
 ]
 `
 

--- a/internal/parser/languages/cpp_generic_call_test.go
+++ b/internal/parser/languages/cpp_generic_call_test.go
@@ -1,0 +1,50 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCppExtractor_TemplateCallEmitsEdge(t *testing.T) {
+	src := []byte(`void run(Obj obj, Obj* ptr) {
+  plain();
+  generic<int>();
+  obj.method();
+  obj.methodT<int>();
+  ptr->methodT<int>();
+}
+`)
+	res, err := NewCppExtractor().Extract("demo.cpp", src)
+	require.NoError(t, err)
+	byLine := genericCallTargets(res)
+
+	assert.Contains(t, byLine[2], "unresolved::plain", "control")
+	assert.Contains(t, byLine[3], "unresolved::generic",
+		"a template_function callee must not cost the edge")
+	assert.Contains(t, byLine[4], "unresolved::*.method", "control")
+	assert.Contains(t, byLine[5], "unresolved::*.methodT",
+		"a template_method through . must not cost the edge")
+	assert.Contains(t, byLine[6], "unresolved::*.methodT",
+		"a template_method through -> must not cost the edge")
+}
+
+// C++ namespace-qualified calls are a second, non-generic blind spot in the
+// same query: the callee is a qualified_identifier, which the bare-identifier
+// pattern cannot match, so every std:: / ns:: free call was dropped.
+func TestCppExtractor_QualifiedCallEmitsEdge(t *testing.T) {
+	src := []byte(`void run() {
+  ns::helper();
+  ns::templated<int>();
+}
+`)
+	res, err := NewCppExtractor().Extract("demo.cpp", src)
+	require.NoError(t, err)
+	byLine := genericCallTargets(res)
+
+	assert.Contains(t, byLine[2], "unresolved::helper",
+		"the trailing name is what a qualified call names")
+	assert.Contains(t, byLine[3], "unresolved::templated",
+		"a templated qualified call names the same trailing identifier")
+}

--- a/internal/parser/languages/golang.go
+++ b/internal/parser/languages/golang.go
@@ -54,6 +54,40 @@ const qGoAll = `
       operand: (_) @callm.receiver
       field: (field_identifier) @callm.method)) @callm.expr
 
+  ; Explicitly instantiated generic calls. With ONE type argument the
+  ; grammar cannot tell Zero[int]() from indexing a func-valued map, so
+  ; it parses the callee as an index_expression and the patterns above
+  ; match nothing — every such call vanished, edge and stub alike. Go
+  ; forbids a func and a var sharing a package-scope name, so binding the
+  ; operand name is safe: a genuine handlers[k]() finds no function of
+  ; that name and stays an unresolved stub. Two or more type arguments
+  ; already parse as a plain callee with a sibling type_arguments field
+  ; and were never affected.
+  (call_expression
+    function: (index_expression
+      operand: (identifier) @call.name)) @call.expr
+
+  (call_expression
+    function: (index_expression
+      operand: (selector_expression
+        operand: (_) @callm.receiver
+        field: (field_identifier) @callm.method))) @callm.expr
+
+  ; ...and with exactly one VALUE argument the same call is not even a
+  ; call_expression: One[int](1) is indistinguishable from a conversion
+  ; to the generic type One[int], and the grammar picks the conversion.
+  ; Same reasoning applies — a real conversion names a type, and a type
+  ; cannot share a package-scope name with a function.
+  (type_conversion_expression
+    type: (generic_type
+      type: (type_identifier) @call.name)) @call.expr
+
+  (type_conversion_expression
+    type: (generic_type
+      type: (qualified_type
+        package: (_) @callm.receiver
+        name: (type_identifier) @callm.method))) @callm.expr
+
   (var_declaration
     (var_spec
       name: (identifier) @var.name

--- a/internal/parser/languages/golang_generic_call_test.go
+++ b/internal/parser/languages/golang_generic_call_test.go
@@ -1,0 +1,40 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGoExtractor_GenericCallEmitsEdge(t *testing.T) {
+	src := []byte(`package demo
+
+type Box struct{}
+
+func run(obj Box) {
+	Plain(1)
+	Zero[int]()
+	OneArg[int](1)
+	TwoArgs[int](1, 2)
+	MultiT[string, int](1, 2)
+	obj.Method[int]()
+	obj.Single[int](1)
+}
+`)
+	res, err := NewGoExtractor().Extract("demo.go", src)
+	require.NoError(t, err)
+	byLine := genericCallTargets(res)
+
+	assert.Contains(t, byLine[6], "unresolved::Plain", "control")
+	assert.Contains(t, byLine[7], "unresolved::Zero",
+		"one type argument and no value argument parses as an index_expression")
+	assert.Contains(t, byLine[8], "unresolved::OneArg",
+		"one type argument and exactly one value argument parses as a type conversion")
+	assert.Contains(t, byLine[9], "unresolved::TwoArgs")
+	assert.Contains(t, byLine[10], "unresolved::MultiT",
+		"control: two type arguments always parsed as an ordinary call")
+	assert.Contains(t, byLine[11], "unresolved::*.Method")
+	assert.Contains(t, byLine[12], "unresolved::*.Single",
+		"the qualified-type conversion form is still a member call")
+}

--- a/internal/parser/languages/scala.go
+++ b/internal/parser/languages/scala.go
@@ -613,6 +613,21 @@ func (e *ScalaExtractor) extractCall(
 		return
 	}
 	callee := node.Child(0)
+	// A call spelling explicit type arguments — `f[T]()`, `obj.m[T](x)`,
+	// `Future[Int] { … }` — wraps its callee in a generic_function node, so
+	// the switch below saw neither an identifier nor a field_expression and
+	// returned without emitting anything: no edge, not even an unresolved
+	// stub. Unwrap to the real callee and the ordinary cases apply.
+	if callee != nil && callee.Type() == "generic_function" {
+		if inner := callee.ChildByFieldName("function"); inner != nil {
+			callee = inner
+		} else if inner := callee.NamedChild(0); inner != nil {
+			callee = inner
+		}
+	}
+	if callee == nil {
+		return
+	}
 	var callName string
 	var receiver string
 	switch callee.Type() {

--- a/internal/parser/languages/scala_generic_call_test.go
+++ b/internal/parser/languages/scala_generic_call_test.go
@@ -1,0 +1,58 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+)
+
+// A call query that pins the callee to a plain identifier node drops every
+// call spelling explicit type arguments, because those grammars wrap the
+// callee in a different node. The call then emits NO edge — not an
+// unresolved stub, nothing — so `query callers` answers total_edges: 0 with
+// the likely_unused caveat and a resolution failure is indistinguishable
+// from dead code.
+//
+// Each test below pairs the plain and generic spellings of one call shape.
+// The pair is the assertion: adding type arguments must not cost the edge.
+
+// genericCallTargets returns the unresolved targets of every EdgeCalls in
+// the result, keyed by source line.
+func genericCallTargets(res *parser.ExtractionResult) map[int][]string {
+	byLine := map[int][]string{}
+	for _, e := range res.Edges {
+		if e.Kind == graph.EdgeCalls {
+			byLine[e.Line] = append(byLine[e.Line], e.To)
+		}
+	}
+	return byLine
+}
+
+func TestScalaExtractor_GenericCallEmitsEdge(t *testing.T) {
+	src := []byte(`package demo
+object Runner {
+  def run(obj: Helper): Unit = {
+    plainCall()
+    genericCall[String]()
+    genericTwo[String, Int](1)
+    obj.methodPlain()
+    obj.methodGeneric[String](1)
+  }
+}
+`)
+	res, err := NewScalaExtractor().Extract("Runner.scala", src)
+	require.NoError(t, err)
+	byLine := genericCallTargets(res)
+
+	assert.Contains(t, byLine[4], "unresolved::*.plainCall", "control")
+	assert.Contains(t, byLine[5], "unresolved::*.genericCall",
+		"a generic_function callee must not cost the edge")
+	assert.Contains(t, byLine[6], "unresolved::*.genericTwo")
+	assert.Contains(t, byLine[7], "unresolved::*.methodPlain", "control")
+	assert.Contains(t, byLine[8], "unresolved::*.methodGeneric",
+		"a generic member call is still a member call")
+}

--- a/internal/parser/languages/swift.go
+++ b/internal/parser/languages/swift.go
@@ -49,6 +49,15 @@ const qSwiftAll = `
   (call_expression
     (navigation_expression
       (navigation_suffix (simple_identifier) @callm.name)) @callm.nav) @callm.expr
+
+  ; A call spelling explicit type arguments is not a call_expression at
+  ; all: lowerGeneric<Int>(), obj.doThing<Int>() and MyType<Int>(x:) all
+  ; parse as a constructor_expression whose constructed type carries the
+  ; whole dotted path. Nothing in this query matched one, so adding type
+  ; arguments to any call — free function, member, or initializer —
+  ; silently deleted its edge.
+  (constructor_expression
+    (user_type) @ctor.type) @ctor.expr
 ]
 `
 
@@ -170,17 +179,32 @@ func (e *SwiftExtractor) Extract(filePath string, src []byte) (*parser.Extractio
 			if nav := m.Captures["callm.nav"]; nav != nil && nav.Node != nil && nav.Node.NamedChildCount() > 0 {
 				recv = strings.TrimSpace(nav.Node.NamedChild(0).Content(src))
 			}
-			// Only chained-factory member calls (the receiver is itself a call)
-			// are captured here, so the bare-identifier query stays authoritative
-			// for ordinary obj.method() and the graph is not flooded.
-			if strings.Contains(recv, "(") {
-				calls = append(calls, swiftDeferredCall{
-					name:     m.Captures["callm.name"].Text,
-					line:     expr.StartLine + 1,
-					isMember: true,
-					receiver: recv,
-				})
+			calls = append(calls, swiftDeferredCall{
+				name:     m.Captures["callm.name"].Text,
+				line:     expr.StartLine + 1,
+				isMember: true,
+				receiver: recv,
+			})
+
+		case m.Captures["ctor.expr"] != nil:
+			expr := m.Captures["ctor.expr"]
+			path := swiftUserTypePath(m.Captures["ctor.type"].Node, src)
+			if len(path) == 0 {
+				break
 			}
+			call := swiftDeferredCall{
+				name: path[len(path)-1],
+				line: expr.StartLine + 1,
+			}
+			// A dotted constructed type is a member call whose receiver
+			// the grammar folded into the type path; a bare one is a free
+			// function or an initializer, which the non-generic spelling
+			// already records the same way.
+			if len(path) > 1 {
+				call.isMember = true
+				call.receiver = strings.Join(path[:len(path)-1], ".")
+			}
+			calls = append(calls, call)
 		}
 	})
 
@@ -903,4 +927,23 @@ func findEnclosingSwiftContainer(n *sitter.Node, t string) *sitter.Node {
 		}
 	}
 	return nil
+}
+
+// swiftUserTypePath returns the dotted path spelled by a constructed
+// type, outermost segment first: `MyType<Int>` yields ["MyType"] and
+// `obj.doThing<Int>` yields ["obj", "doThing"]. Only the node's own
+// type_identifier children count — the ones nested inside a
+// type_arguments list are the type ARGUMENTS, not part of the path.
+func swiftUserTypePath(userType *sitter.Node, src []byte) []string {
+	if userType == nil {
+		return nil
+	}
+	var path []string
+	for i, nc := 0, int(userType.NamedChildCount()); i < nc; i++ {
+		c := userType.NamedChild(i)
+		if c != nil && c.Type() == "type_identifier" {
+			path = append(path, c.Content(src))
+		}
+	}
+	return path
 }

--- a/internal/parser/languages/swift_generic_call_test.go
+++ b/internal/parser/languages/swift_generic_call_test.go
@@ -1,0 +1,59 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSwiftExtractor_GenericCallEmitsEdge(t *testing.T) {
+	src := []byte(`class Runner {
+  func run(obj: Runner) {
+    upperPlain()
+    lowerGeneric<Int>()
+    obj.doThing()
+    obj.doThing<Int>()
+    let _ = MyType<Int>(x: 1)
+  }
+}
+`)
+	res, err := NewSwiftExtractor().Extract("demo.swift", src)
+	require.NoError(t, err)
+	byLine := genericCallTargets(res)
+
+	assert.Contains(t, byLine[3], "unresolved::upperPlain", "control")
+	assert.Contains(t, byLine[4], "unresolved::lowerGeneric",
+		"a generic free call reroutes to constructor_expression but is still a call")
+	assert.Contains(t, byLine[5], "unresolved::*.doThing", "control")
+	assert.Contains(t, byLine[6], "unresolved::*.doThing",
+		"the grammar folds the receiver into the constructed type path")
+	assert.Contains(t, byLine[7], "unresolved::MyType",
+		"a generic initializer is recorded like its non-generic spelling")
+}
+
+// Swift's member-call branch was gated to factory chains on the belief that
+// the bare-identifier pattern covered ordinary obj.method(). It does not:
+// that pattern needs a simple_identifier as a DIRECT child of the call, and
+// a member call nests it under a navigation_expression. So every plain
+// obj.method() and self.method() emitted nothing.
+func TestSwiftExtractor_PlainMemberCallEmitsEdge(t *testing.T) {
+	src := []byte(`class Runner {
+  func free() {}
+  func run(h: Helper) {
+    free()
+    h.work()
+    self.free()
+  }
+}
+`)
+	res, err := NewSwiftExtractor().Extract("demo.swift", src)
+	require.NoError(t, err)
+	byLine := genericCallTargets(res)
+
+	assert.Contains(t, byLine[4], "unresolved::free", "control: a free call always worked")
+	assert.Contains(t, byLine[5], "unresolved::*.work",
+		"an ordinary member call is a call")
+	assert.Contains(t, byLine[6], "unresolved::*.free",
+		"a self-qualified call is a call")
+}

--- a/internal/resolver/go_generic_call_ambiguity_test.go
+++ b/internal/resolver/go_generic_call_ambiguity_test.go
@@ -1,0 +1,88 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Go's grammar cannot distinguish an explicitly instantiated generic call
+// from two other constructs that share its spelling:
+//
+//	Zero[int]()     vs  handlers[key]()   — both an index_expression
+//	OneArg[int](1)  vs  MyList[int](x)    — both a type_conversion_expression
+//
+// The extractor widened its patterns to catch the call forms, so it now also
+// emits an unresolved stub for the other two. That is only acceptable if the
+// stub cannot BIND to something wrong. It cannot, and the reason is a Go rule
+// rather than luck: a package-scope name is a func, a var or a type — never
+// two of them — so a stub named after a variable or a type finds no function
+// candidate and stays unresolved. An unresolved target is a placeholder that
+// reverse walks ignore, so nothing downstream sees a phantom call.
+func TestResolveGo_IndexAndConversionDoNotBindWrongly(t *testing.T) {
+	g := buildMultiLangGraph(t, map[string]string{
+		"app/handlers.go": `package app
+
+type MyList[T any] struct{}
+
+var handlers = map[string]func(){}
+
+func Dispatch(key string) {
+	handlers[key]()
+}
+
+func Convert(xs []int) {
+	_ = MyList[int](xs)
+}
+`,
+	})
+	New(g).ResolveAll()
+
+	for _, caller := range []string{"app/handlers.go::Dispatch", "app/handlers.go::Convert"} {
+		for _, e := range g.GetOutEdges(caller) {
+			if e.Kind != graph.EdgeCalls || graph.IsUnresolvedTarget(e.To) {
+				continue
+			}
+			n := g.GetNode(e.To)
+			if n == nil {
+				continue
+			}
+			assert.Contains(t, []graph.NodeKind{graph.KindFunction, graph.KindMethod}, n.Kind,
+				"%s bound a call to a %s node (%s) — indexing a func-valued map and "+
+					"converting to a generic type must never resolve as calls",
+				caller, n.Kind, e.To)
+		}
+	}
+}
+
+// The other half of the same trade-off: a real generic call still resolves.
+func TestResolveGo_GenericCallResolvesAcrossFiles(t *testing.T) {
+	g := buildMultiLangGraph(t, map[string]string{
+		"app/lib.go": `package app
+
+func Zero[T any]() T { var z T; return z }
+func OneArg[T any](a T) T { return a }
+`,
+		"app/use.go": `package app
+
+func Run() {
+	_ = Zero[int]()
+	_ = OneArg[int](1)
+}
+`,
+	})
+	New(g).ResolveAll()
+
+	var targets []string
+	for _, e := range g.GetOutEdges("app/use.go::Run") {
+		if e.Kind == graph.EdgeCalls {
+			targets = append(targets, e.To)
+		}
+	}
+	assert.Contains(t, targets, "app/lib.go::Zero",
+		"a generic call with no value argument resolves to its declaration")
+	assert.Contains(t, targets, "app/lib.go::OneArg",
+		"a generic call with exactly one value argument resolves to its declaration")
+}


### PR DESCRIPTION
Fixes #537.

Four more extractors share the blind spot found in #534: a call query that pins the callee to a plain identifier node drops **every call spelling explicit type arguments**, because those grammars wrap the callee in a different node. The call emits *no edge at all* — not an unresolved stub — so `query callers` answers `total_edges: 0` with the `likely_unused` caveat, and a resolution failure is indistinguishable from dead code.

This is a recurring class here: `rust.go` carries a note that the turbofish version of it cost **5,301 unrecorded call sites**.

Every shape below was pinned by dumping the real parse tree and confirmed by running the real extractor before and after — no query was fixed on inference. One commit per language, each with its own `extractorVersions` bump so already-indexed files re-extract instead of keeping the edge-less graph.

## Scala — `generic_function`

`extractCall` switched on the callee and handled only `identifier` / `field_expression`, falling through to `default: return`. Any callee with type arguments is wrapped:

```
(call_expression function: (generic_function function: (identifier) type_arguments: (…)) arguments: (…))
```

`f[T]()`, `obj.m[T](x)` and `Future[Int] { … }` all emitted nothing. Unwrapping to the real callee lets the two existing cases apply unchanged.

## Go — two mechanisms, not one

The patterns pinned `function:` to `(identifier)` / `(selector_expression)`. A Go call with **one** type argument matches neither, via two different routes — fixing only the obvious one leaves half the calls missing:

| Written | Parses as |
|---|---|
| `Zero[int]()`, `obj.M[int]()` | `function: (index_expression …)` |
| `OneArg[int](1)`, `obj.N[int](1)` | `type_conversion_expression` — **not a call at all** |

Two or more type arguments were never affected (`F[string, int](a, b)` keeps a plain callee with a sibling `type_arguments` field), which is why the gap looked like it didn't exist.

**Both shapes are genuinely ambiguous in the grammar.** An `index_expression` callee is also how `handlers[key]()` parses, and a conversion to a generic type is spelled exactly like a one-argument generic call. Widening therefore emits an unresolved stub for those too.

That is safe for a reason specific to Go rather than luck: **a package-scope name is a func, a var or a type — never two of them.** A stub named after a variable or a type finds no function candidate and stays unresolved, and an unresolved target is a placeholder reverse walks ignore. `TestResolveGo_IndexAndConversionDoNotBindWrongly` asserts no call edge in that fixture ever lands on a non-callable node, and its sibling asserts a real cross-file generic call still resolves.

## C++ — three of five callee shapes were missing

The query matched a bare `identifier` and a `field_expression` with a `field_identifier`. C++ has five:

- `generic<int>()` → `function: (template_function …)`
- `obj.m<int>()` / `ptr->m<int>()` → `field: (template_method …)`
- `ns::helper()` / `std::move(x)` → `function: (qualified_identifier …)`

The last is **not about templates and is the larger loss**: every namespace-qualified free call in the language was dropped, so a codebase that qualifies consistently recorded almost no free calls at all. `rust.go` already carries the equivalent `scoped_identifier` pattern; C++ now matches it.

## Swift — two losses, the second much larger

Adding type arguments reroutes *any* Swift call away from `call_expression` entirely:

```
constructor_expression
  user_type "obj.doThing<Int>"
    type_identifier "obj"
    type_identifier "doThing"
    type_arguments "<Int>"
  constructor_suffix "()"
```

`lowerGeneric<Int>()`, `obj.doThing<Int>()` and `MyType<Int>(x: 1)` all became `constructor_expression`, which nothing in the query matched. The constructed type's own `type_identifier` children give the dotted path back; the ones nested inside `type_arguments` are the arguments and are excluded.

**The second loss was not in the issue.** The member branch was gated to factory chains only, on the stated belief that the bare-identifier pattern stayed *"authoritative for ordinary `obj.method()`"*. It never was — that pattern needs a `simple_identifier` as a **direct** child of the call, and a member call nests it under a `navigation_expression`. So every plain `obj.method()` and `self.method()` emitted no edge either:

```
  calls Runner.run -> unresolved::free        line=8   ✓ free call
  (nothing)                                   line=9   ✗ h.work()
  (nothing)                                   line=10  ✗ self.free()
  calls Runner.run -> unresolved::*.work      line=11  ✓ Helper().work()  (factory chain)
```

Swift was recording free calls and factory chains and nothing in between. Removing the gate restores what every other language already does, and the generic fix would have been incoherent without it — `o.doThing<Int>()` resolving while `o.doThing()` did not.

## Verified clean, and why

Probed the same way and left alone: **typescript** (.ts + .tsx), **java**, **kotlin**, **rust**, **dart**, **c**, **php**. In TS and Java the type arguments are a *sibling field* of the callee; in Kotlin they live inside `call_suffix`; Dart's sit inside `argument_part`; C and PHP have no generic call syntax.

## Verification

`go test ./internal/...` passes in full; `golangci-lint` reports 0 issues. Each language's test pairs the plain and generic spellings of every call shape and asserts they behave identically — the property that was actually violated, and the one that makes the regression hard to reintroduce quietly.

## Note for merging

Touches the same `extractorVersions` map as #536, so whichever merges second will want a one-line conflict resolution. The two PRs are otherwise independent.
