### PR TITLE
fix(store_sqlite): bound the repo memory estimate and never cache a truncated count

### DIFF
--- a/internal/graph/store_sqlite/export_memest_test.go
+++ b/internal/graph/store_sqlite/export_memest_test.go
@@ -1,0 +1,13 @@
+package store_sqlite
+
+import "time"
+
+// SetMemEstBudgetForTest shrinks the per-recompute budget that
+// AllRepoMemoryEstimates gives its COUNT scans, so a test can force the
+// truncated path deterministically instead of waiting for a slow store.
+// It returns a restore func.
+func SetMemEstBudgetForTest(d time.Duration) func() {
+	prev := memEstBudget
+	memEstBudget = d
+	return func() { memEstBudget = prev }
+}

--- a/internal/graph/store_sqlite/store.go
+++ b/internal/graph/store_sqlite/store.go
@@ -144,6 +144,12 @@ type Store struct {
 	memEstMu  sync.Mutex
 	memEstVal map[string]graph.RepoMemoryEstimate
 	memEstAt  time.Time
+	// memEstCost is what the last *complete* recompute actually took; the
+	// TTL scales with it so a scan that costs seconds is not repeated every
+	// few seconds. memEstRetryAt suppresses retries after a recompute ran
+	// out of budget.
+	memEstCost    time.Duration
+	memEstRetryAt time.Time
 
 	// Bulk-load fast path (graph.BulkLoader). Non-nil only between
 	// BeginBulkLoad and FlushBulk, and only on a first/empty cold index.
@@ -2212,6 +2218,24 @@ func (s *Store) RepoMemoryEstimate(repoPrefix string) graph.RepoMemoryEstimate {
 // status polls from each triggering a full COUNT … GROUP BY scan.
 const memEstTTL = 3 * time.Second
 
+// memEstTTLScale keeps a recompute that cost T from being repeated for
+// roughly T*scale, capped by memEstMaxTTL. A fixed TTL is only correct while
+// the scan is cheap: on a large store the COUNT scan grew past the TTL, so
+// every poll recomputed and the memoisation stopped doing anything.
+const memEstTTLScale = 10
+
+// memEstMaxTTL caps the adaptive TTL so the estimate cannot go stale forever.
+const memEstMaxTTL = 5 * time.Minute
+
+// memEstBackoff suppresses recomputes after one ran out of budget, so a burst
+// of status polls does not walk into the same wall every time.
+const memEstBackoff = 30 * time.Second
+
+// memEstBudget bounds a single recompute. The estimate is advisory (status
+// display), so it must never be able to spend the caller's whole control
+// budget. A var, not a const, so tests can force the truncated path.
+var memEstBudget = 2 * time.Second
+
 func cloneRepoMemEstimates(m map[string]graph.RepoMemoryEstimate) map[string]graph.RepoMemoryEstimate {
 	out := make(map[string]graph.RepoMemoryEstimate, len(m))
 	for k, v := range m {
@@ -2223,59 +2247,134 @@ func cloneRepoMemEstimates(m map[string]graph.RepoMemoryEstimate) map[string]gra
 func (s *Store) AllRepoMemoryEstimates() map[string]graph.RepoMemoryEstimate {
 	// Hold memEstMu across the recompute so a burst of concurrent status
 	// polls collapses onto one scan: the first caller computes and
-	// caches, the rest block briefly and then hit the fresh cache.
+	// caches, the rest block briefly and then hit the fresh cache. The
+	// hold is bounded by memEstBudget, so "briefly" stays true.
 	s.memEstMu.Lock()
 	defer s.memEstMu.Unlock()
-	if s.memEstVal != nil && time.Since(s.memEstAt) < memEstTTL {
+	if s.memEstVal != nil && time.Since(s.memEstAt) < s.memEstFreshFor() {
 		return cloneRepoMemEstimates(s.memEstVal)
 	}
+	if !s.memEstRetryAt.IsZero() && time.Now().Before(s.memEstRetryAt) {
+		// A recent recompute ran out of budget. Serve what we have rather
+		// than spending the caller's budget on the same scan again.
+		if s.memEstVal != nil {
+			return cloneRepoMemEstimates(s.memEstVal)
+		}
+		return map[string]graph.RepoMemoryEstimate{}
+	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), memEstBudget)
+	defer cancel()
+
+	started := time.Now()
+	out, complete := s.scanRepoMemEstimates(ctx)
+	if !complete {
+		// Never cache a truncated count. A partial estimate is not stale,
+		// it is wrong, and the TTL would then serve that wrong number as
+		// though it had been measured.
+		//
+		// Back off only when there is already an answer worth protecting.
+		// With nothing cached there is nothing to serve, so keep trying —
+		// each attempt is bounded by memEstBudget anyway, and a cold start
+		// that hit one slow moment should not blank the column for a
+		// whole backoff window.
+		if s.memEstVal != nil {
+			s.memEstRetryAt = time.Now().Add(memEstBackoff)
+			return cloneRepoMemEstimates(s.memEstVal)
+		}
+		return map[string]graph.RepoMemoryEstimate{}
+	}
+
+	s.memEstVal = out
+	s.memEstAt = time.Now()
+	s.memEstCost = time.Since(started)
+	s.memEstRetryAt = time.Time{}
+	return cloneRepoMemEstimates(out)
+}
+
+// memEstFreshFor scales the memoisation window with what the last complete
+// recompute cost, so the TTL stays useful as the store grows. Callers hold
+// memEstMu.
+func (s *Store) memEstFreshFor() time.Duration {
+	ttl := time.Duration(memEstTTLScale) * s.memEstCost
+	if ttl < memEstTTL {
+		ttl = memEstTTL
+	}
+	if ttl > memEstMaxTTL {
+		ttl = memEstMaxTTL
+	}
+	return ttl
+}
+
+// scanRepoMemEstimates runs the two COUNT … GROUP BY scans under ctx. The
+// bool reports whether both completed; a false means the caller must not
+// cache what came back. Callers hold memEstMu.
+func (s *Store) scanRepoMemEstimates(ctx context.Context) (map[string]graph.RepoMemoryEstimate, bool) {
 	out := map[string]graph.RepoMemoryEstimate{}
-	rows, err := s.stmtAllRepoCountsNodes.Query()
+
+	rows, err := s.stmtAllRepoCountsNodes.QueryContext(ctx)
 	if err != nil {
-		panicOnFatal(err)
-		return out
+		if ctx.Err() == nil {
+			panicOnFatal(err)
+		}
+		return out, false
 	}
 	for rows.Next() {
 		var repo string
 		var n int
 		if err := rows.Scan(&repo, &n); err != nil {
 			_ = rows.Close()
-			panicOnFatal(err)
-			return out
+			if ctx.Err() == nil {
+				panicOnFatal(err)
+			}
+			return out, false
 		}
 		est := out[repo]
 		est.NodeCount = n
 		est.NodeBytes = uint64(n) * perNodeByteEstimate
 		out[repo] = est
 	}
+	err = rows.Err()
 	_ = rows.Close()
-
-	rows, err = s.stmtAllRepoCountsEdges.Query()
 	if err != nil {
-		panicOnFatal(err)
-		return out
+		if ctx.Err() == nil {
+			panicOnFatal(err)
+		}
+		return out, false
+	}
+
+	rows, err = s.stmtAllRepoCountsEdges.QueryContext(ctx)
+	if err != nil {
+		if ctx.Err() == nil {
+			panicOnFatal(err)
+		}
+		return out, false
 	}
 	for rows.Next() {
 		var repo string
 		var n int
 		if err := rows.Scan(&repo, &n); err != nil {
 			_ = rows.Close()
-			panicOnFatal(err)
-			return out
+			if ctx.Err() == nil {
+				panicOnFatal(err)
+			}
+			return out, false
 		}
 		est := out[repo]
 		est.EdgeCount = n
 		est.EdgeBytes = uint64(n) * perEdgeByteEstimate
 		out[repo] = est
 	}
+	err = rows.Err()
 	_ = rows.Close()
+	if err != nil {
+		if ctx.Err() == nil {
+			panicOnFatal(err)
+		}
+		return out, false
+	}
 
-	// Cache only on the full-success path — the early error returns above
-	// leave a partial `out` and must not poison the cache.
-	s.memEstVal = out
-	s.memEstAt = time.Now()
-	return cloneRepoMemEstimates(out)
+	return out, true
 }
 
 // -- helpers --------------------------------------------------------------

--- a/internal/graph/store_sqlite/store_memest_truncation_test.go
+++ b/internal/graph/store_sqlite/store_memest_truncation_test.go
@@ -1,0 +1,58 @@
+package store_sqlite_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+)
+
+// A COUNT scan that runs out of budget must not be cached. The estimate is
+// advisory, but a *truncated* count is not stale — it is wrong, and the TTL
+// would then serve that wrong number as if it were a measurement.
+func TestAllRepoMemoryEstimates_TruncatedScanIsNotCached(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "g.sqlite")
+	s, err := store_sqlite.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	const want = 20000
+	batch := make([]*graph.Node, 0, want)
+	for i := 0; i < want; i++ {
+		id := fmt.Sprintf("a.go::F%d", i)
+		batch = append(batch, &graph.Node{
+			ID: id, Kind: graph.KindFunction, Name: fmt.Sprintf("F%d", i),
+			FilePath: "a.go", RepoPrefix: fmt.Sprintf("r%d", i%4),
+		})
+	}
+	s.AddBatch(batch, nil)
+
+	totalNodes := func(m map[string]graph.RepoMemoryEstimate) int {
+		n := 0
+		for _, e := range m {
+			n += e.NodeCount
+		}
+		return n
+	}
+
+	// Force the scan to run out of budget mid-flight.
+	restore := store_sqlite.SetMemEstBudgetForTest(time.Millisecond)
+	truncated := s.AllRepoMemoryEstimates()
+	restore()
+
+	if totalNodes(truncated) == want {
+		t.Skip("scan completed inside the shrunken budget; nothing to assert")
+	}
+
+	// With a normal budget the very next call must report the true count.
+	// Before the fix the truncated map was cached and served here for the
+	// whole TTL, so this reads a plausible-looking wrong number.
+	full := s.AllRepoMemoryEstimates()
+	require.Equal(t, want, totalNodes(full),
+		"a truncated COUNT was cached and served as if it were a real measurement")
+}


### PR DESCRIPTION
Fixes #539.

## What the dump showed

Captured live while `gortex daemon status` was timing out, before any restart:

```
goroutine 1252 [syscall]:
  modernc.org/sqlite/lib._winRead
  store_sqlite.(*Store).AllRepoMemoryEstimates   store.go:2223
  daemon.(*Server).handleControl                 server.go:686
```

`status` was not blocked by a track/reload/enrichment. It **was** the slow work. CPU delta measured 36.2 s over 10 s wall — genuinely busy, zero goroutines in `semacquire`.

## Measured, same driver, read-only, on a 9.4 GB store

```
nodes  ->  6.9s   SCAN nodes USING COVERING INDEX nodes_by_repo
edges  -> 27.8s   SCAN n USING COVERING INDEX nodes_by_repo
                  SEARCH e USING COVERING INDEX edges_by_from_line (from_id=?)
          -----
           34.7s  > the 30s control budget
```

**No index is missing** — both plans are already covering. The cost is that `COUNT(*) … GROUP BY` must touch every node and every edge.

And the existing mitigation could not help: `memEstTTL` is **3 s in front of a ~35 s scan**, so the cache expired about ten times over before it was ever read. Every poll recomputed, holding `memEstMu` throughout.

## Three changes, no schema

1. **Bound it.** Both scans run under a `memEstBudget` (2 s) context, so an advisory display column can no longer spend the caller's whole budget. I verified the driver honours the deadline mid-scan before relying on it.
2. **Never cache a truncated count.** The scans now report completion. A partial count is not *stale*, it is *wrong*, and the TTL would serve it as if measured. The old loop never checked `rows.Err()`, so a cut-short iteration fell straight through to the cache write — adding a deadline without this would have promoted a latent bug to a routine one.
3. **Scale the TTL with measured cost** (`T*10`, floored at the old 3 s, capped at 5 min), so memoisation keeps working as the store grows instead of silently degrading.

Backoff after a truncated recompute applies **only when a cached answer already exists**. With nothing cached there is nothing to protect, so it keeps trying — each attempt is bounded anyway.

## Conventions followed, not invented

`QueryContext` and the `rows.Err() … ctx.Err() == nil` pattern are already used elsewhere in this file (1784, 1826, 1851). `AllRepoMemoryEstimates` was the one place doing neither.

## Test, and an honest note on what it does not cover

`TestAllRepoMemoryEstimates_TruncatedScanIsNotCached` builds a 20k-node fixture, shrinks the budget through an `export_test` hook so the scan is cut mid-flight, then asserts the next call reports the true count.

Sabotage-checked:

| Sabotage | Result |
|---|---|
| remove the `complete` guard | **red**, as intended |
| remove `rows.Err()` on the *nodes* query | **green** |

The second stays green because the expired context makes the following edges query fail at `QueryContext`, so truncation is caught downstream. That per-query check is convention-conformance for real I/O errors, **not** something this test covers — saying so rather than letting the table imply otherwise.

The test also caught a flaw in my own first draft: it backed off unconditionally and returned an empty map where the true count was available.

## Test run

`go test ./internal/graph/store_sqlite/` has five pre-existing failures on this tree (`TestSweepPlanLocks`, `TestAdjacencyPlanLocksDuringBulkLoad`, `TestSweepPlanLockReceiverRebindBatch`, `TestPreparedStatementPlansNeverScanBigTables`, `TestSweepWarnPlanLocks`). I verified they fail identically on unmodified `main` by stashing the change and re-running, so they are not from this PR.

## Not addressed here

Denormalising `repo_prefix` onto `edges` so the second query becomes a single-table `GROUP BY`. That removes the join entirely and is the real long-term fix — but it is a schema change plus migration, and that is your call.